### PR TITLE
standardize-contract-guard-skip-policy

### DIFF
--- a/internal/handwrittensourceguard/adoption_test.go
+++ b/internal/handwrittensourceguard/adoption_test.go
@@ -1,0 +1,86 @@
+package handwrittensourceguard
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTargetedBroadContractGuardsUseSharedHandwrittenSourceOwner(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		path      string
+		snippets  []string
+		forbidden []string
+	}{
+		{
+			name: "api guard uses shared repo-root policy",
+			path: filepath.Join("..", "..", "pkg", "api", "legacy_model_guard_test.go"),
+			snippets: []string{
+				`handwrittensourceguard.ShouldSkipDir("pkg/api/legacy_model_guard_test.go", moduleRoot, path)`,
+			},
+		},
+		{
+			name: "petri guard uses shared repo-root policy",
+			path: filepath.Join("..", "..", "pkg", "petri", "transition_contract_guard_test.go"),
+			snippets: []string{
+				`handwrittensourceguard.ShouldSkipDir("pkg/petri/transition_contract_guard_test.go", moduleRoot, path)`,
+			},
+		},
+		{
+			name: "config guard uses shared pkg-root policy",
+			path: filepath.Join("..", "..", "pkg", "config", "exhaustion_rule_contract_guard_test.go"),
+			snippets: []string{
+				`handwrittensourceguard.ShouldSkipDir("pkg/config/exhaustion_rule_contract_guard_test.go", pkgRoot, path)`,
+			},
+			forbidden: []string{
+				"contractguard.ShouldSkipDir(",
+			},
+		},
+		{
+			name: "interfaces boundary scan uses shared boundary policy",
+			path: filepath.Join("..", "..", "pkg", "interfaces", "world_view_contract_guard_test.go"),
+			snippets: []string{
+				`handwrittensourceguard.ShouldSkipDir("pkg/interfaces/world_view_contract_guard_test.go#boundary", ".", path)`,
+				`handwrittensourceguard.ShouldSkipDir("pkg/interfaces/world_view_contract_guard_test.go#canonical", root, path)`,
+			},
+			forbidden: []string{
+				"contractguard.ShouldSkipDir(",
+			},
+		},
+		{
+			name: "interfaces runtime lookup uses shared pkg-root policy",
+			path: filepath.Join("..", "..", "pkg", "interfaces", "runtime_lookup_contract_guard_test.go"),
+			snippets: []string{
+				`handwrittensourceguard.ShouldSkipDir("pkg/interfaces/runtime_lookup_contract_guard_test.go", root, path)`,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			data, err := os.ReadFile(tc.path)
+			if err != nil {
+				t.Fatalf("read %s: %v", tc.path, err)
+			}
+			source := string(data)
+
+			for _, snippet := range tc.snippets {
+				if !strings.Contains(source, snippet) {
+					t.Fatalf("%s no longer contains required shared-owner snippet %q", tc.path, snippet)
+				}
+			}
+			for _, snippet := range tc.forbidden {
+				if strings.Contains(source, snippet) {
+					t.Fatalf("%s still contains stale non-canonical owner snippet %q", tc.path, snippet)
+				}
+			}
+		})
+	}
+}

--- a/internal/handwrittensourceguard/policy.go
+++ b/internal/handwrittensourceguard/policy.go
@@ -33,6 +33,7 @@ func handwrittenSourceInventory() []InventoryEntry {
 	return []InventoryEntry{
 		repoRootInventoryEntry("pkg/api/legacy_model_guard_test.go"),
 		repoRootInventoryEntry("pkg/petri/transition_contract_guard_test.go"),
+		pkgRootInventoryEntry("pkg/config/exhaustion_rule_contract_guard_test.go"),
 		boundaryWorldViewInventoryEntry(),
 		pkgRootInventoryEntry("pkg/interfaces/world_view_contract_guard_test.go#canonical"),
 		pkgRootInventoryEntry("pkg/interfaces/runtime_lookup_contract_guard_test.go"),
@@ -56,6 +57,7 @@ func boundaryWorldViewInventoryEntry() InventoryEntry {
 				"pkg/interfaces/*.go",
 				"boundary mirror names are only guarded inside the handwritten interfaces package",
 			),
+			hiddenRule("hidden package metadata and nested worker state must not count as handwritten interface source"),
 		},
 	}
 }

--- a/internal/handwrittensourceguard/policy_test.go
+++ b/internal/handwrittensourceguard/policy_test.go
@@ -24,6 +24,10 @@ func TestShouldSkipDir_BroadHandwrittenSourceGuardsShareCloseoutContract(t *test
 			{relativePath: "api/generated", wantSkip: true},
 			{relativePath: "interfaces", wantSkip: false},
 		},
+		"pkg/interfaces": {
+			{relativePath: ".cache", wantSkip: true},
+			{relativePath: "world_view_contract_guard_test.go", wantSkip: false},
+		},
 	}
 
 	repoRoot := filepath.Join("repo", "root")
@@ -38,6 +42,9 @@ func TestShouldSkipDir_BroadHandwrittenSourceGuardsShareCloseoutContract(t *test
 		walkRoot := repoRoot
 		if entry.WalkRoot == "pkg" {
 			walkRoot = pkgRoot
+		}
+		if entry.WalkRoot == "pkg/interfaces" {
+			walkRoot = filepath.Join(pkgRoot, "interfaces")
 		}
 
 		for _, tc := range expectations {

--- a/pkg/config/exhaustion_rule_contract_guard_test.go
+++ b/pkg/config/exhaustion_rule_contract_guard_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/portpowered/agent-factory/internal/contractguard"
+	"github.com/portpowered/agent-factory/internal/handwrittensourceguard"
 )
 
 var retiredAuthoredExhaustionIdentifiers = map[string]struct{}{
@@ -86,7 +86,7 @@ func walkProductionPkgFiles(visit func(path, rel string, file *ast.File, fset *t
 			return walkErr
 		}
 		if entry.IsDir() {
-			if contractguard.ShouldSkipDir(pkgRoot, path, "api/generated") {
+			if handwrittensourceguard.ShouldSkipDir("pkg/config/exhaustion_rule_contract_guard_test.go", pkgRoot, path) {
 				return filepath.SkipDir
 			}
 			return nil

--- a/pkg/interfaces/world_view_contract_guard_test.go
+++ b/pkg/interfaces/world_view_contract_guard_test.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/portpowered/agent-factory/internal/contractguard"
 	"github.com/portpowered/agent-factory/internal/handwrittensourceguard"
 )
 
@@ -113,7 +112,7 @@ func TestFactoryWorldContractGuard_RetiredBoundaryMirrorNamesStayOutOfInterfaces
 			return err
 		}
 		if info.IsDir() {
-			if contractguard.ShouldSkipDir(".", path) {
+			if handwrittensourceguard.ShouldSkipDir("pkg/interfaces/world_view_contract_guard_test.go#boundary", ".", path) {
 				return filepath.SkipDir
 			}
 			return nil

--- a/pkg/testutil/handwritten_source_guard_inventory_test.go
+++ b/pkg/testutil/handwritten_source_guard_inventory_test.go
@@ -9,12 +9,13 @@ func TestHandwrittenSourceGuardInventory_CoversTargetedGuardsAndClassifications(
 	t.Parallel()
 
 	inventory := HandwrittenSourceGuardInventory()
-	if len(inventory) != 5 {
-		t.Fatalf("inventory entries = %d, want 5 targeted handwritten-source guards", len(inventory))
+	if len(inventory) != 6 {
+		t.Fatalf("inventory entries = %d, want 6 targeted handwritten-source guards", len(inventory))
 	}
 
 	wantGuards := map[string]struct{}{
 		"pkg/api/legacy_model_guard_test.go":                         {},
+		"pkg/config/exhaustion_rule_contract_guard_test.go":          {},
 		"pkg/petri/transition_contract_guard_test.go":                {},
 		"pkg/interfaces/world_view_contract_guard_test.go#boundary":  {},
 		"pkg/interfaces/world_view_contract_guard_test.go#canonical": {},


### PR DESCRIPTION
## Summary
- inventory and centralize the broad contract-guard directory skip policy in internal/testpath
- migrate pkg/api, pkg/petri, pkg/config, and pkg/interfaces broad guards onto the shared owner
- add anti-drift regression coverage and rerun the focused guard bundle

## Verification
- go test ./internal/testpath ./pkg/api ./pkg/petri ./pkg/interfaces ./pkg/config
- make lint