### PR TITLE
finish-contract-guard-hygiene-and-instruction-path-alignment

### DIFF
--- a/docs/development/contract-guard-walker-inventory.md
+++ b/docs/development/contract-guard-walker-inventory.md
@@ -20,21 +20,17 @@ hardening targets explicit before changing skip policy.
 
 | Guard file | Test or helper | Walk API | Scan root | Intended surface | Hidden metadata/worktree state | Generated output policy | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `pkg/config/exhaustion_rule_contract_guard_test.go` | `walkProductionPkgFiles` | `filepath.WalkDir` | `pkg/` via `filepath.Clean("..")` from `pkg/config` | `handwritten pkg subtree` | Not intended, but not yet skipped explicitly | Explicitly skips `pkg/api/generated` only | Remaining hardening target for hidden-dir policy and broader generated-output policy alignment. |
+| `pkg/config/exhaustion_rule_contract_guard_test.go` | `walkProductionPkgFiles` | `filepath.WalkDir` | `pkg/` via `filepath.Clean("..")` from `pkg/config` | `handwritten pkg subtree` | Explicitly skipped via shared hidden-dir policy | Explicitly skips `pkg/api/generated` | Broad handwritten `pkg/` scan hardened against hidden metadata and unrelated generated output. |
 | `pkg/interfaces/runtime_lookup_contract_guard_test.go` | `scanRuntimeLookupContractViolations` | `filepath.WalkDir` | package-local `pkg/interfaces` via `..` in production mode; temp fixture root in unit tests | `handwritten package source` | Not intentionally scanned in production because the root is package-local | No generated-output paths under the package-local scope | Production scan is package-local rather than repo-wide. |
 | `pkg/interfaces/world_view_contract_guard_test.go` | `TestFactoryWorldContractGuard_RetiredBoundaryMirrorNamesStayOutOfInterfacesGoFiles` | `filepath.Walk` | `.` from `pkg/interfaces` | `handwritten package source` | Not intentionally scanned in production because the root is package-local | No generated-output paths under the package-local scope | Package-local boundary-name guard for `pkg/interfaces` only. |
-| `pkg/interfaces/world_view_contract_guard_test.go` | `TestFactoryWorldContractGuard_RetiredCanonicalMirrorNamesStayOutOfPkgGoFiles` | `filepath.Walk` | `pkg/` via `..` from `pkg/interfaces` | `handwritten pkg subtree` | Not intended, and not yet skipped explicitly | No explicit generated-output skip; `pkg/api/generated` is in scope unless otherwise filtered by file contents | Broader pkg-tree scan that should stay visible to the hardening follow-up. |
-| `pkg/petri/transition_contract_guard_test.go` | `TestTransitionContractGuard_ProductionTransitionLiteralsStayTopologyOnly` | `filepath.WalkDir` | repository root via `filepath.Join("..", "..")` from `pkg/petri` | `handwritten repo source` | Not intended, but not yet skipped explicitly | Explicitly skips `pkg/api/generated`, `ui/dist`, `ui/node_modules`, and `ui/storybook-static` | Broadest active scan; already treats selected generated/build outputs as out of scope. |
+| `pkg/interfaces/world_view_contract_guard_test.go` | `TestFactoryWorldContractGuard_RetiredCanonicalMirrorNamesStayOutOfPkgGoFiles` | `filepath.Walk` | `pkg/` via `..` from `pkg/interfaces` | `handwritten pkg subtree` | Explicitly skipped via shared hidden-dir policy | Explicitly skips `pkg/api/generated` | Broader pkg-tree scan now matches the handwritten-source skip policy used by the other broad walkers. |
+| `pkg/petri/transition_contract_guard_test.go` | `TestTransitionContractGuard_ProductionTransitionLiteralsStayTopologyOnly` | `filepath.WalkDir` | repository root via `filepath.Join("..", "..")` from `pkg/petri` | `handwritten repo source` | Explicitly skips hidden metadata/worktree directories via shared hidden-dir policy | Explicitly skips `pkg/api/generated`, `ui/dist`, `ui/node_modules`, and `ui/storybook-static` | Broadest active scan; hardened so repository metadata stays out of scope while preserving the existing build-output exclusions. |
 
-## Hardening Targets
+## Hardening Status
 
-- `pkg/config/exhaustion_rule_contract_guard_test.go` is the clearest remaining
-  gap because it walks `pkg/` and only skips `pkg/api/generated`.
-- `pkg/interfaces/world_view_contract_guard_test.go` also contains a broad
-  `pkg/` walk whose skip policy is still implicit.
-- `pkg/petri/transition_contract_guard_test.go` already skips known generated
-  and build-output directories, but it still relies on the repository layout
-  rather than an explicit hidden-directory guard.
-
-Future hardening work should keep package-local scans simple and make broad
-walkers opt out of hidden metadata and unrelated generated output explicitly.
+- Every active handwritten-source broad walker in `pkg/*_contract_guard_test.go`
+  now opts out of hidden metadata/worktree directories explicitly.
+- `pkg/` subtree walkers skip `pkg/api/generated` unless a guard intentionally
+  targets generated output.
+- The repository-root `pkg/petri` walker preserves its existing UI build-output
+  skips while adding the same hidden-directory policy used by the `pkg/` scans.

--- a/docs/development/contract-guard-walker-inventory.md
+++ b/docs/development/contract-guard-walker-inventory.md
@@ -34,3 +34,16 @@ hardening targets explicit before changing skip policy.
   targets generated output.
 - The repository-root `pkg/petri` walker preserves its existing UI build-output
   skips while adding the same hidden-directory policy used by the `pkg/` scans.
+
+## Operator Contract
+
+- Treat repository-root paths as canonical for this checkout. Run guard
+  commands from the repository root and scope broad handwritten-source sweeps to
+  live surfaces such as `pkg/`, `docs/`, `factory/`, and
+  `tests/functional_test/`.
+- Use this inventory as the checked-in cleanup reference for active broad
+  walker scope, hidden-directory policy, and generated-output exclusions before
+  changing any `pkg/*_contract_guard_test.go` scan roots.
+- References to `libraries/agent-factory` in archival reports, replay
+  artifacts, or historical notes are preserved evidence from older layouts, not
+  the live operator contract for this repository.

--- a/docs/development/contract-guard-walker-inventory.md
+++ b/docs/development/contract-guard-walker-inventory.md
@@ -1,0 +1,40 @@
+# Contract Guard Walker Inventory
+
+This inventory records every active broad filesystem walk in
+`pkg/*_contract_guard_test.go`. It exists so cleanup work can distinguish
+package-local scans from broader repository walks and make remaining
+hardening targets explicit before changing skip policy.
+
+## Classification Rules
+
+- `handwritten package source`: scans maintained Go source in one package
+  directory.
+- `handwritten pkg subtree`: scans maintained Go source across `pkg/`.
+- `handwritten repo source`: scans maintained Go source across the repository
+  root.
+- `generated output`: intentionally scans generated artifacts.
+- `hidden metadata/worktree state`: intentionally scans hidden directories such
+  as `.git`, `.claude`, or nested worktree metadata.
+
+## Active Walker Inventory
+
+| Guard file | Test or helper | Walk API | Scan root | Intended surface | Hidden metadata/worktree state | Generated output policy | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `pkg/config/exhaustion_rule_contract_guard_test.go` | `walkProductionPkgFiles` | `filepath.WalkDir` | `pkg/` via `filepath.Clean("..")` from `pkg/config` | `handwritten pkg subtree` | Not intended, but not yet skipped explicitly | Explicitly skips `pkg/api/generated` only | Remaining hardening target for hidden-dir policy and broader generated-output policy alignment. |
+| `pkg/interfaces/runtime_lookup_contract_guard_test.go` | `scanRuntimeLookupContractViolations` | `filepath.WalkDir` | package-local `pkg/interfaces` via `..` in production mode; temp fixture root in unit tests | `handwritten package source` | Not intentionally scanned in production because the root is package-local | No generated-output paths under the package-local scope | Production scan is package-local rather than repo-wide. |
+| `pkg/interfaces/world_view_contract_guard_test.go` | `TestFactoryWorldContractGuard_RetiredBoundaryMirrorNamesStayOutOfInterfacesGoFiles` | `filepath.Walk` | `.` from `pkg/interfaces` | `handwritten package source` | Not intentionally scanned in production because the root is package-local | No generated-output paths under the package-local scope | Package-local boundary-name guard for `pkg/interfaces` only. |
+| `pkg/interfaces/world_view_contract_guard_test.go` | `TestFactoryWorldContractGuard_RetiredCanonicalMirrorNamesStayOutOfPkgGoFiles` | `filepath.Walk` | `pkg/` via `..` from `pkg/interfaces` | `handwritten pkg subtree` | Not intended, and not yet skipped explicitly | No explicit generated-output skip; `pkg/api/generated` is in scope unless otherwise filtered by file contents | Broader pkg-tree scan that should stay visible to the hardening follow-up. |
+| `pkg/petri/transition_contract_guard_test.go` | `TestTransitionContractGuard_ProductionTransitionLiteralsStayTopologyOnly` | `filepath.WalkDir` | repository root via `filepath.Join("..", "..")` from `pkg/petri` | `handwritten repo source` | Not intended, but not yet skipped explicitly | Explicitly skips `pkg/api/generated`, `ui/dist`, `ui/node_modules`, and `ui/storybook-static` | Broadest active scan; already treats selected generated/build outputs as out of scope. |
+
+## Hardening Targets
+
+- `pkg/config/exhaustion_rule_contract_guard_test.go` is the clearest remaining
+  gap because it walks `pkg/` and only skips `pkg/api/generated`.
+- `pkg/interfaces/world_view_contract_guard_test.go` also contains a broad
+  `pkg/` walk whose skip policy is still implicit.
+- `pkg/petri/transition_contract_guard_test.go` already skips known generated
+  and build-output directories, but it still relies on the repository layout
+  rather than an explicit hidden-directory guard.
+
+Future hardening work should keep package-local scans simple and make broad
+walkers opt out of hidden metadata and unrelated generated output explicitly.

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -262,6 +262,7 @@ The config validator checks workstation scheduling values against a known set of
 - [Internal Architecture](architecture.md)
 - [API Inventory](api-inventory.md)
 - [Dashboard UI Replay Testing](dashboard-ui-replay-testing.md)
+- [Contract Guard Walker Inventory](contract-guard-walker-inventory.md)
 - [Factory Config Schema Inventory And Enum Policy](factory-config-schema-inventory-and-enum-policy.md)
 - [Factory Config Generated-Schema Boundary Inventory](factory-config-generated-schema-boundary-inventory.md)
 - [Safe Diagnostics Contract Consolidation Data Model](safe-diagnostics-contract-consolidation-data-model.md)

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -53,6 +53,7 @@
   - this repository is rooted at the current checkout
   - `pkg/`, `tests/functional_test/`, `factory/`, and `docs/` are the live surfaces
   - `libraries/agent-factory` should be treated as stale historical wording, not the current path contract
+  - the checked-in broad-walker inventory in `docs/development/contract-guard-walker-inventory.md` is the live cleanup reference for scan roots, hidden-dir policy, and generated-output exclusions
 - the right cleanup rule now is:
   - do not reopen another broad audit
   - do not reopen the ownership design question unless the landing review finds a concrete issue

--- a/factory/workstations/plan/AGENTS.md
+++ b/factory/workstations/plan/AGENTS.md
@@ -9,14 +9,14 @@ Note that you are working in autonomous mode, do not ask any questions to the cu
 
 # steps
 ## step 1 
-Your work for prds in the final ralph file MUST be compliant to the standards outlined in \docs\standards\documentation\product-requirement-doc-standards.md. 
+Read `docs/standards/STANDARDS.md`, then follow the most relevant checked-in standard it points you to for PRD and planning work.
 
-read the file
+Read the standard before writing anything.
 
 ## step 2
 read the /prd and /ralph skills. 
 
-Please convert the file into the corresponding project-directory/tasks/todo/{{ (index .Inputs 0).Name }}.json, as well as corresponding project-directory/tasks/todo/{{ (index .Inputs 0).Name }}.md for the correpsonding prd.
+Please convert the file into the corresponding `tasks/todo/{{ (index .Inputs 0).Name }}.json`, as well as corresponding `tasks/todo/{{ (index .Inputs 0).Name }}.md`, relative to the repository root for the corresponding PRD.
 
 Please ensure that the prd.json contains an overall description of the project, and the changes that we are looking to make and the intent.
 

--- a/internal/contractguard/skip.go
+++ b/internal/contractguard/skip.go
@@ -1,0 +1,31 @@
+package contractguard
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// ShouldSkipDir reports whether a broad handwritten-source guard should skip
+// the provided directory because it is hidden metadata or an explicit
+// generated/build-output subtree outside the guard's intended surface.
+func ShouldSkipDir(scanRoot, path string, explicitSkips ...string) bool {
+	rel, err := filepath.Rel(scanRoot, path)
+	if err != nil {
+		return false
+	}
+	rel = filepath.ToSlash(filepath.Clean(rel))
+	if rel == "." {
+		return false
+	}
+	for _, part := range strings.Split(rel, "/") {
+		if strings.HasPrefix(part, ".") {
+			return true
+		}
+	}
+	for _, skip := range explicitSkips {
+		if rel == filepath.ToSlash(filepath.Clean(skip)) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/contractguard/skip_test.go
+++ b/internal/contractguard/skip_test.go
@@ -1,0 +1,60 @@
+package contractguard
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestShouldSkipDir(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Clean("pkg")
+	tests := []struct {
+		name   string
+		path   string
+		skips  []string
+		expect bool
+	}{
+		{
+			name:   "root stays visible",
+			path:   root,
+			skips:  []string{"api/generated"},
+			expect: false,
+		},
+		{
+			name:   "hidden root child is skipped",
+			path:   filepath.Join(root, ".claude"),
+			skips:  []string{"api/generated"},
+			expect: true,
+		},
+		{
+			name:   "nested hidden worktree metadata is skipped",
+			path:   filepath.Join(root, "interfaces", ".worktrees"),
+			skips:  []string{"api/generated"},
+			expect: true,
+		},
+		{
+			name:   "generated subtree is skipped",
+			path:   filepath.Join(root, "api", "generated"),
+			skips:  []string{"api/generated"},
+			expect: true,
+		},
+		{
+			name:   "normal package directory stays visible",
+			path:   filepath.Join(root, "config"),
+			skips:  []string{"api/generated"},
+			expect: false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := ShouldSkipDir(root, test.path, test.skips...); got != test.expect {
+				t.Fatalf("ShouldSkipDir(%q, %q) = %t, want %t", root, test.path, got, test.expect)
+			}
+		})
+	}
+}

--- a/pkg/config/exhaustion_rule_contract_guard_test.go
+++ b/pkg/config/exhaustion_rule_contract_guard_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"github.com/portpowered/agent-factory/internal/contractguard"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -84,11 +85,7 @@ func walkProductionPkgFiles(visit func(path, rel string, file *ast.File, fset *t
 			return walkErr
 		}
 		if entry.IsDir() {
-			rel, err := filepath.Rel(pkgRoot, path)
-			if err != nil {
-				return err
-			}
-			if filepath.Clean(rel) == filepath.Clean("api/generated") {
+			if contractguard.ShouldSkipDir(pkgRoot, path, "api/generated") {
 				return filepath.SkipDir
 			}
 			return nil

--- a/pkg/interfaces/world_view_contract_guard_test.go
+++ b/pkg/interfaces/world_view_contract_guard_test.go
@@ -1,6 +1,7 @@
 package interfaces
 
 import (
+	"github.com/portpowered/agent-factory/internal/contractguard"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -148,7 +149,13 @@ func TestFactoryWorldContractGuard_RetiredCanonicalMirrorNamesStayOutOfPkgGoFile
 		if err != nil {
 			return err
 		}
-		if info.IsDir() || filepath.Ext(path) != ".go" {
+		if info.IsDir() {
+			if contractguard.ShouldSkipDir("..", path, "api/generated") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".go" {
 			return nil
 		}
 		rel, relErr := filepath.Rel("..", path)

--- a/pkg/interfaces/world_view_contract_guard_test.go
+++ b/pkg/interfaces/world_view_contract_guard_test.go
@@ -171,7 +171,7 @@ func TestFactoryWorldContractGuard_RetiredCanonicalMirrorNamesStayOutOfPkgGoFile
 			return readErr
 		}
 		if match := matcher.FindString(string(data)); match != "" {
-			t.Fatalf("%s still contains retired mirror name %q; equivalent rg guard is `rg -n %q libraries/agent-factory/pkg -g \"*.go\"` and should only hit approved guard notes", rel, match, strings.Join(names, "|"))
+			t.Fatalf("%s still contains retired mirror name %q; equivalent rg guard is `rg -n %q pkg -g \"*.go\"` from the repository root and should only hit approved guard notes", rel, match, strings.Join(names, "|"))
 		}
 		return nil
 	})

--- a/pkg/petri/transition_contract_guard_test.go
+++ b/pkg/petri/transition_contract_guard_test.go
@@ -1,6 +1,7 @@
 package petri
 
 import (
+	"github.com/portpowered/agent-factory/internal/contractguard"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -38,7 +39,7 @@ func TestTransitionContractGuard_ProductionTransitionLiteralsStayTopologyOnly(t 
 			return walkErr
 		}
 		if entry.IsDir() {
-			if shouldSkipTransitionGuardDir(moduleRoot, path) {
+			if contractguard.ShouldSkipDir(moduleRoot, path, "pkg/api/generated", "ui/dist", "ui/node_modules", "ui/storybook-static") {
 				return filepath.SkipDir
 			}
 			return nil
@@ -77,18 +78,6 @@ func TestTransitionContractGuard_ProductionTransitionLiteralsStayTopologyOnly(t 
 	if err != nil {
 		t.Fatalf("scan production transition literals: %v", err)
 	}
-}
-
-func shouldSkipTransitionGuardDir(moduleRoot, path string) bool {
-	rel, err := filepath.Rel(moduleRoot, path)
-	if err != nil {
-		return false
-	}
-	rel = filepath.ToSlash(rel)
-	return rel == "pkg/api/generated" ||
-		rel == "ui/dist" ||
-		rel == "ui/node_modules" ||
-		rel == "ui/storybook-static"
 }
 
 func transitionImportAliases(file *ast.File) map[string]struct{} {

--- a/tests/adhoc/factory/workstations/cleaner/AGENTS.md
+++ b/tests/adhoc/factory/workstations/cleaner/AGENTS.md
@@ -1,8 +1,12 @@
 ---
 type: MODEL_WORKSTATION
 ---
-You are the cleaner. 
-Your job is to basically run every few minutes or so, and create tasks to clean up the agent-factory code under the libraries/agent-factory. 
+You are the meta software agent. 
+
+Your job is to basically run every few minutes or so, and have a role of: 
+1. cleaning up the code by dispatching workers
+2. constructing your own theory of mind on how the system works and updating that theory of mind as you explore how things change over time. 
+3. turning repeated repository cleanup gaps into checked-in ideas under `factory/inputs/idea/default/`
 
 
 # Steps
@@ -10,21 +14,36 @@ Your job is to basically run every few minutes or so, and create tasks to clean 
 run git pull and make the workspace be up to date to remote
 
 ## Step 1 - read
-Read up the code under the libraries/agent-factory/
-For now, read up the current files the factory/inputs/idea/default directory to see any previous clean up attempts that have already been done. 
+0. read `factory/README.md` and inspect the checked-in workflow inputs under `factory/inputs/`.
+1. read `docs/development/development.md` and the recent reports under `docs/development/cleanup-analyzer-reports/`.
+2. read the code in this repository and the recent PRs associated with your previous cleanup requests.
+3. read the current plan, task, thought, and idea files under `factory/inputs/` so you do not duplicate prior cleanup attempts.
 
-## Step 2 - figure out an idea 
+## Step 2 - based on the above results decide on one of the following: 
+1. update your repository-stability view using the checked-in workflow docs and inputs
+2. create a task to dispatch to make a change to the repository
+3. turn a repeated cleanup gap into a checked-in idea under `factory/inputs/idea/default/`
+
+you are responsible for deciding what is the best thing to do at any given time; if the code is not in a state where changes are progressing well, then focus on stability work before introducing new cleanup ideas.
+you should work on stability and cleanliness. That is, unless the customer asks the request as urgent, then that gets prioritized.
+
+Most important of all though is that your meta view of the world has to be right and updated. 
+You should always have a view of the world that is consistent with the world, that is to say, what does the world look like, what is the problems in the world, what is the best way to fix things overall.
+
+## Step 3 - completion
+
+after you are done, you MUST respond with <COMPLETE>.
+
+# dispatching a task
+
+## making  a change
 figure out a way to clean the code (in priority order)
 1. remove dead code
 2. look at overlapping interfaces in the pkg/interfaces and merge the interfaces together that are basically overlapping or are redundant
 3. remove redundant legacy handling code (we don't have customers so its okay to break things for now)
 4. simplify logic (we want to have as few edge case handlings as possible and defer to the primary abstractions like the petri-nets and the event history stream as much possible)
 5. consolidate duplicative structures or fucntionality across the code base. 
-
+6. for the agentfactory websites we look to remove unused code, reduce the amount of duplicative components, reduce functionality down to small components, shared styles, such that the overall complexity of teh system is reduced. 
 
 ## Step 3 - write a file
-1. after you're done, write a file to factory/inputs/idea/default directory as an .md file using the ideation-standards.md 
-
-## Step 4 - complete 
-
-After you have done your work, please respond with "<COMPLETE>".
+1. after you're done, write a file to `{project-git-root-directory}/factory/inputs/idea/default/{your-idea}.md` using the checked-in idea shape already present under `factory/inputs/idea/default/`

--- a/tests/adhoc/factory/workstations/ideafy/AGENTS.md
+++ b/tests/adhoc/factory/workstations/ideafy/AGENTS.md
@@ -7,15 +7,15 @@ The customer is asking a bunch of ambiguous things, but they are too large in sc
 
 Your job is to break down these items to standard idea files that are small enough to do within the scope of a day. 
 
-All idea files MUST be conformant to the standard in docs/templates/idea-templates.md
+All idea files MUST follow the checked-in idea shape already present under `factory/inputs/idea/default/`.
 
 # Steps
 ## Step 1 - read
 Read up on the relevant files in the documentation that would lead to the issue. 
-Read the idea-templates.md as well as the docs/standards-ideation-standards.md
+Read the existing files under `factory/inputs/idea/default/` to match the current idea shape.
 
-## Step 2 - write the file
-For each idea you should write the idea into factory/inputs/idea/default/{your-idea-name}.md. Note that you should only write after the idea is fully fleshed out, as each idea you write triggers out work to be deployed. 
+## Step 2 - write the files
+For each idea you should write the idea into `factory/inputs/idea/default/{your-idea-name}.md`. Note that you should only write after the idea is fully fleshed out, as each idea you write triggers out work to be deployed.
 
 ## Step 3 - complete
 

--- a/tests/adhoc/factory/workstations/plan/AGENTS.md
+++ b/tests/adhoc/factory/workstations/plan/AGENTS.md
@@ -9,14 +9,14 @@ Note that you are working in autonomous mode, do not ask any questions to the cu
 
 # steps
 ## step 1 
-Your work for prds in the final ralph file MUST be compliant to the standards outlined in \docs\standards\documentation\product-requirement-doc-standards.md. 
+Read `docs/standards/STANDARDS.md`, then follow the most relevant checked-in standard it points you to for PRD and planning work.
 
-read the file
+Read the standard before writing anything.
 
 ## step 2
 read the /prd and /ralph skills. 
 
-Please convert the file into the corresponding tasks/todo/{{ (index .Inputs 0).Name }}.json, as well as corresponding tasks/todo/{{ (index .Inputs 0).Name }}.md for the corresponding PRD.
+Please convert the file into the corresponding `tasks/todo/{{ (index .Inputs 0).Name }}.json`, as well as corresponding `tasks/todo/{{ (index .Inputs 0).Name }}.md`, relative to the repository root for the corresponding PRD.
 
 Please ensure that the prd.json contains an overall description of the project, and the changes that we are looking to make and the intent.
 

--- a/tests/functional_test/testdata/idea_plan_execute_review_with_limits/workstations/ideafy/AGENTS.md
+++ b/tests/functional_test/testdata/idea_plan_execute_review_with_limits/workstations/ideafy/AGENTS.md
@@ -8,15 +8,15 @@ The customer is asking a bunch of ambiguous things, but they are too large in sc
 
 Your job is to break down these items to standard idea files that are small enough to do within the scope of a day. 
 
-All idea files MUST be conformant to the standard in docs/templates/idea-templates.md
+All idea files MUST follow the checked-in idea shape already present under `factory/inputs/idea/default/`.
 
 # Steps
 ## Step 1 - read
 Read up on the relevant files in the documentation that would lead to the issue. 
-Read the idea-templates.md as well as the docs/standards-ideation-standards.md
+Read the existing files under `factory/inputs/idea/default/` to match the current idea shape.
 
-## Step 2 - write the file
-For each idea you should write the idea into factory/inputs/idea/default/{your-idea-name}.md. Note that you should only write after the idea is fully fleshed out, as each idea you write triggers out work to be deployed. 
+## Step 2 - write the files
+For each idea you should write the idea into `factory/inputs/idea/default/{your-idea-name}.md`. Note that you should only write after the idea is fully fleshed out, as each idea you write triggers out work to be deployed.
 
 ## Step 3 - complete
 

--- a/tests/functional_test/testdata/idea_plan_execute_review_with_limits/workstations/plan/AGENTS.md
+++ b/tests/functional_test/testdata/idea_plan_execute_review_with_limits/workstations/plan/AGENTS.md
@@ -10,14 +10,14 @@ Note that you are working in autonomous mode, do not ask any questions to the cu
 
 # steps
 ## step 1 
-Your work for prds in the final ralph file MUST be compliant to the standards outlined in \docs\standards\documentation\product-requirement-doc-standards.md. 
+Read `docs/standards/STANDARDS.md`, then follow the most relevant checked-in standard it points you to for PRD and planning work.
 
-read the file
+Read the standard before writing anything.
 
 ## step 2
 read the /prd and /ralph skills. 
 
-Please convert the file into the corresponding tasks/todo/{{ (index .Inputs 0).Name }}.json, as well as corresponding tasks/todo/{{ (index .Inputs 0).Name }}.md for the correpsonding prd.
+Please convert the file into the corresponding `tasks/todo/{{ (index .Inputs 0).Name }}.json`, as well as corresponding `tasks/todo/{{ (index .Inputs 0).Name }}.md`, relative to the repository root for the corresponding PRD.
 
 Please ensure that the prd.json contains an overall description of the project, and the changes that we are looking to make and the intent.
 


### PR DESCRIPTION
## Summary
- inventory active contract-guard filesystem walkers and link the inventory from development docs
- harden the remaining broad handwritten-source walkers with shared hidden-dir/generated-output skip policy coverage
- align active planning and cleanup guidance with repository-root paths and the live standards entrypoint, then rerun the focused guard closeout

## Verification
- go test ./pkg/api ./pkg/petri ./pkg/interfaces ./pkg/config -count=1
- make lint