### PR TITLE
harden-filesystem-contract-guards

### DIFF
--- a/internal/handwrittensourceguard/policy.go
+++ b/internal/handwrittensourceguard/policy.go
@@ -26,133 +26,77 @@ type InventoryEntry struct {
 }
 
 func Inventory() []InventoryEntry {
+	return handwrittenSourceInventory()
+}
+
+func handwrittenSourceInventory() []InventoryEntry {
 	return []InventoryEntry{
-		{
-			GuardFile: "pkg/api/legacy_model_guard_test.go",
-			WalkRoot:  "repo-root",
-			Rules: []PathRule{
-				{
-					Path:  "repo-root/**/*.go",
-					Class: PathClassScanHandwritten,
-					Why:   "scan checked-in handwritten Go source across the repository",
-				},
-				{
-					Path:  "pkg/api/generated",
-					Class: PathClassExcludeGenerated,
-					Why:   "generated API output is not handwritten contract source",
-				},
-				{
-					Path:  "ui/dist",
-					Class: PathClassExcludeGenerated,
-					Why:   "compiled dashboard assets are generated artifacts",
-				},
-				{
-					Path:  "ui/node_modules",
-					Class: PathClassExcludeGenerated,
-					Why:   "dependency install output is not handwritten source",
-				},
-				{
-					Path:  "ui/storybook-static",
-					Class: PathClassExcludeGenerated,
-					Why:   "storybook build output is generated",
-				},
-				{
-					Path:  ".*/",
-					Class: PathClassExcludeHiddenRoot,
-					Why:   "hidden repository metadata such as .git, .claude, and nested worktree state must not count as handwritten source",
-				},
-			},
-		},
-		{
-			GuardFile: "pkg/petri/transition_contract_guard_test.go",
-			WalkRoot:  "repo-root",
-			Rules: []PathRule{
-				{
-					Path:  "repo-root/**/*.go",
-					Class: PathClassScanHandwritten,
-					Why:   "scan checked-in handwritten Go source across the repository",
-				},
-				{
-					Path:  "pkg/api/generated",
-					Class: PathClassExcludeGenerated,
-					Why:   "generated API output is not handwritten contract source",
-				},
-				{
-					Path:  "ui/dist",
-					Class: PathClassExcludeGenerated,
-					Why:   "compiled dashboard assets are generated artifacts",
-				},
-				{
-					Path:  "ui/node_modules",
-					Class: PathClassExcludeGenerated,
-					Why:   "dependency install output is not handwritten source",
-				},
-				{
-					Path:  "ui/storybook-static",
-					Class: PathClassExcludeGenerated,
-					Why:   "storybook build output is generated",
-				},
-				{
-					Path:  ".*/",
-					Class: PathClassExcludeHiddenRoot,
-					Why:   "hidden repository metadata such as .git, .claude, and nested worktree state must not count as handwritten source",
-				},
-			},
-		},
-		{
-			GuardFile: "pkg/interfaces/world_view_contract_guard_test.go#boundary",
-			WalkRoot:  "pkg/interfaces",
-			Rules: []PathRule{
-				{
-					Path:  "pkg/interfaces/*.go",
-					Class: PathClassScanHandwritten,
-					Why:   "boundary mirror names are only guarded inside the handwritten interfaces package",
-				},
-			},
-		},
-		{
-			GuardFile: "pkg/interfaces/world_view_contract_guard_test.go#canonical",
-			WalkRoot:  "pkg",
-			Rules: []PathRule{
-				{
-					Path:  "pkg/**/*.go",
-					Class: PathClassScanHandwritten,
-					Why:   "scan checked-in handwritten package Go source under pkg",
-				},
-				{
-					Path:  "pkg/api/generated",
-					Class: PathClassExcludeGenerated,
-					Why:   "generated API output is not handwritten pkg source",
-				},
-				{
-					Path:  ".*/",
-					Class: PathClassExcludeHiddenRoot,
-					Why:   "hidden package metadata and nested worker state must not count as handwritten pkg source",
-				},
-			},
-		},
-		{
-			GuardFile: "pkg/interfaces/runtime_lookup_contract_guard_test.go",
-			WalkRoot:  "pkg",
-			Rules: []PathRule{
-				{
-					Path:  "pkg/**/*.go",
-					Class: PathClassScanHandwritten,
-					Why:   "scan checked-in handwritten package Go source under pkg",
-				},
-				{
-					Path:  "pkg/api/generated",
-					Class: PathClassExcludeGenerated,
-					Why:   "generated API output is not handwritten pkg source",
-				},
-				{
-					Path:  ".*/",
-					Class: PathClassExcludeHiddenRoot,
-					Why:   "hidden package metadata and nested worker state must not count as handwritten pkg source",
-				},
-			},
+		repoRootInventoryEntry("pkg/api/legacy_model_guard_test.go"),
+		repoRootInventoryEntry("pkg/petri/transition_contract_guard_test.go"),
+		boundaryWorldViewInventoryEntry(),
+		pkgRootInventoryEntry("pkg/interfaces/world_view_contract_guard_test.go#canonical"),
+		pkgRootInventoryEntry("pkg/interfaces/runtime_lookup_contract_guard_test.go"),
+	}
+}
+
+func repoRootInventoryEntry(guardFile string) InventoryEntry {
+	return InventoryEntry{
+		GuardFile: guardFile,
+		WalkRoot:  "repo-root",
+		Rules:     repoRootRules(),
+	}
+}
+
+func boundaryWorldViewInventoryEntry() InventoryEntry {
+	return InventoryEntry{
+		GuardFile: "pkg/interfaces/world_view_contract_guard_test.go#boundary",
+		WalkRoot:  "pkg/interfaces",
+		Rules: []PathRule{
+			handwrittenScanRule(
+				"pkg/interfaces/*.go",
+				"boundary mirror names are only guarded inside the handwritten interfaces package",
+			),
 		},
 	}
+}
+
+func pkgRootInventoryEntry(guardFile string) InventoryEntry {
+	return InventoryEntry{
+		GuardFile: guardFile,
+		WalkRoot:  "pkg",
+		Rules:     pkgRootRules(),
+	}
+}
+
+func repoRootRules() []PathRule {
+	return []PathRule{
+		handwrittenScanRule("repo-root/**/*.go", "scan checked-in handwritten Go source across the repository"),
+		generatedRule("pkg/api/generated", "generated API output is not handwritten contract source"),
+		generatedRule("ui/dist", "compiled dashboard assets are generated artifacts"),
+		generatedRule("ui/node_modules", "dependency install output is not handwritten source"),
+		generatedRule("ui/storybook-static", "storybook build output is generated"),
+		hiddenRule("hidden repository metadata such as .git, .claude, and nested worktree state must not count as handwritten source"),
+	}
+}
+
+func pkgRootRules() []PathRule {
+	return []PathRule{
+		handwrittenScanRule("pkg/**/*.go", "scan checked-in handwritten package Go source under pkg"),
+		generatedRule("pkg/api/generated", "generated API output is not handwritten pkg source"),
+		hiddenRule("hidden package metadata and nested worker state must not count as handwritten pkg source"),
+	}
+}
+
+func handwrittenScanRule(path string, why string) PathRule {
+	return PathRule{Path: path, Class: PathClassScanHandwritten, Why: why}
+}
+
+func generatedRule(path string, why string) PathRule {
+	return PathRule{Path: path, Class: PathClassExcludeGenerated, Why: why}
+}
+
+func hiddenRule(why string) PathRule {
+	return PathRule{Path: ".*/", Class: PathClassExcludeHiddenRoot, Why: why}
 }
 
 func ShouldSkipDir(guardFile, walkRoot, path string) bool {

--- a/internal/handwrittensourceguard/policy.go
+++ b/internal/handwrittensourceguard/policy.go
@@ -1,0 +1,224 @@
+package handwrittensourceguard
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+type PathClass string
+
+const (
+	PathClassScanHandwritten   PathClass = "scan-handwritten"
+	PathClassExcludeGenerated  PathClass = "exclude-generated"
+	PathClassExcludeHiddenRoot PathClass = "exclude-hidden-root"
+)
+
+type PathRule struct {
+	Path  string
+	Class PathClass
+	Why   string
+}
+
+type InventoryEntry struct {
+	GuardFile string
+	WalkRoot  string
+	Rules     []PathRule
+}
+
+func Inventory() []InventoryEntry {
+	return []InventoryEntry{
+		{
+			GuardFile: "pkg/api/legacy_model_guard_test.go",
+			WalkRoot:  "repo-root",
+			Rules: []PathRule{
+				{
+					Path:  "repo-root/**/*.go",
+					Class: PathClassScanHandwritten,
+					Why:   "scan checked-in handwritten Go source across the repository",
+				},
+				{
+					Path:  "pkg/api/generated",
+					Class: PathClassExcludeGenerated,
+					Why:   "generated API output is not handwritten contract source",
+				},
+				{
+					Path:  "ui/dist",
+					Class: PathClassExcludeGenerated,
+					Why:   "compiled dashboard assets are generated artifacts",
+				},
+				{
+					Path:  "ui/node_modules",
+					Class: PathClassExcludeGenerated,
+					Why:   "dependency install output is not handwritten source",
+				},
+				{
+					Path:  "ui/storybook-static",
+					Class: PathClassExcludeGenerated,
+					Why:   "storybook build output is generated",
+				},
+				{
+					Path:  ".*/",
+					Class: PathClassExcludeHiddenRoot,
+					Why:   "hidden repository metadata such as .git, .claude, and nested worktree state must not count as handwritten source",
+				},
+			},
+		},
+		{
+			GuardFile: "pkg/petri/transition_contract_guard_test.go",
+			WalkRoot:  "repo-root",
+			Rules: []PathRule{
+				{
+					Path:  "repo-root/**/*.go",
+					Class: PathClassScanHandwritten,
+					Why:   "scan checked-in handwritten Go source across the repository",
+				},
+				{
+					Path:  "pkg/api/generated",
+					Class: PathClassExcludeGenerated,
+					Why:   "generated API output is not handwritten contract source",
+				},
+				{
+					Path:  "ui/dist",
+					Class: PathClassExcludeGenerated,
+					Why:   "compiled dashboard assets are generated artifacts",
+				},
+				{
+					Path:  "ui/node_modules",
+					Class: PathClassExcludeGenerated,
+					Why:   "dependency install output is not handwritten source",
+				},
+				{
+					Path:  "ui/storybook-static",
+					Class: PathClassExcludeGenerated,
+					Why:   "storybook build output is generated",
+				},
+				{
+					Path:  ".*/",
+					Class: PathClassExcludeHiddenRoot,
+					Why:   "hidden repository metadata such as .git, .claude, and nested worktree state must not count as handwritten source",
+				},
+			},
+		},
+		{
+			GuardFile: "pkg/interfaces/world_view_contract_guard_test.go#boundary",
+			WalkRoot:  "pkg/interfaces",
+			Rules: []PathRule{
+				{
+					Path:  "pkg/interfaces/*.go",
+					Class: PathClassScanHandwritten,
+					Why:   "boundary mirror names are only guarded inside the handwritten interfaces package",
+				},
+			},
+		},
+		{
+			GuardFile: "pkg/interfaces/world_view_contract_guard_test.go#canonical",
+			WalkRoot:  "pkg",
+			Rules: []PathRule{
+				{
+					Path:  "pkg/**/*.go",
+					Class: PathClassScanHandwritten,
+					Why:   "scan checked-in handwritten package Go source under pkg",
+				},
+				{
+					Path:  "pkg/api/generated",
+					Class: PathClassExcludeGenerated,
+					Why:   "generated API output is not handwritten pkg source",
+				},
+				{
+					Path:  ".*/",
+					Class: PathClassExcludeHiddenRoot,
+					Why:   "hidden package metadata and nested worker state must not count as handwritten pkg source",
+				},
+			},
+		},
+		{
+			GuardFile: "pkg/interfaces/runtime_lookup_contract_guard_test.go",
+			WalkRoot:  "pkg",
+			Rules: []PathRule{
+				{
+					Path:  "pkg/**/*.go",
+					Class: PathClassScanHandwritten,
+					Why:   "scan checked-in handwritten package Go source under pkg",
+				},
+				{
+					Path:  "pkg/api/generated",
+					Class: PathClassExcludeGenerated,
+					Why:   "generated API output is not handwritten pkg source",
+				},
+				{
+					Path:  ".*/",
+					Class: PathClassExcludeHiddenRoot,
+					Why:   "hidden package metadata and nested worker state must not count as handwritten pkg source",
+				},
+			},
+		},
+	}
+}
+
+func ShouldSkipDir(guardFile, walkRoot, path string) bool {
+	entry, ok := inventoryEntry(guardFile)
+	if !ok {
+		return false
+	}
+
+	rel, err := filepath.Rel(filepath.Clean(walkRoot), filepath.Clean(path))
+	if err != nil {
+		return false
+	}
+	rel = filepath.ToSlash(filepath.Clean(rel))
+	if rel == "." {
+		return false
+	}
+	if hasRule(entry, PathClassExcludeHiddenRoot) && containsHiddenSegment(rel) {
+		return true
+	}
+
+	for _, rule := range entry.Rules {
+		if rule.Class != PathClassExcludeGenerated {
+			continue
+		}
+		if matchesRule(entry.WalkRoot, rel, rule.Path) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func inventoryEntry(guardFile string) (InventoryEntry, bool) {
+	for _, entry := range Inventory() {
+		if entry.GuardFile == guardFile {
+			return entry, true
+		}
+	}
+	return InventoryEntry{}, false
+}
+
+func hasRule(entry InventoryEntry, class PathClass) bool {
+	for _, rule := range entry.Rules {
+		if rule.Class == class {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesRule(walkRoot, relPath, rulePath string) bool {
+	rulePath = strings.TrimSuffix(filepath.ToSlash(filepath.Clean(rulePath)), "/")
+	if walkRoot == "pkg" {
+		rulePath = strings.TrimPrefix(rulePath, "pkg/")
+	}
+	if walkRoot == "pkg/interfaces" {
+		rulePath = strings.TrimPrefix(rulePath, "pkg/interfaces/")
+	}
+	return relPath == rulePath || strings.HasPrefix(relPath, rulePath+"/")
+}
+
+func containsHiddenSegment(relPath string) bool {
+	for _, segment := range strings.Split(relPath, "/") {
+		if strings.HasPrefix(segment, ".") && segment != "." && segment != ".." {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/handwrittensourceguard/policy_test.go
+++ b/internal/handwrittensourceguard/policy_test.go
@@ -1,0 +1,50 @@
+package handwrittensourceguard
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestShouldSkipDir_BroadHandwrittenSourceGuardsShareCloseoutContract(t *testing.T) {
+	t.Parallel()
+
+	type expectation struct {
+		relativePath string
+		wantSkip     bool
+	}
+
+	rootExpectations := map[string][]expectation{
+		"repo-root": {
+			{relativePath: ".claude/worktrees/stale", wantSkip: true},
+			{relativePath: "pkg/api/generated", wantSkip: true},
+			{relativePath: "pkg/petri", wantSkip: false},
+		},
+		"pkg": {
+			{relativePath: ".cache", wantSkip: true},
+			{relativePath: "api/generated", wantSkip: true},
+			{relativePath: "interfaces", wantSkip: false},
+		},
+	}
+
+	repoRoot := filepath.Join("repo", "root")
+	pkgRoot := filepath.Join(repoRoot, "pkg")
+
+	for _, entry := range Inventory() {
+		expectations, ok := rootExpectations[entry.WalkRoot]
+		if !ok {
+			continue
+		}
+
+		walkRoot := repoRoot
+		if entry.WalkRoot == "pkg" {
+			walkRoot = pkgRoot
+		}
+
+		for _, tc := range expectations {
+			path := filepath.Join(walkRoot, filepath.FromSlash(tc.relativePath))
+			if got := ShouldSkipDir(entry.GuardFile, walkRoot, path); got != tc.wantSkip {
+				t.Fatalf("%s skip(%s) = %t, want %t", entry.GuardFile, tc.relativePath, got, tc.wantSkip)
+			}
+		}
+	}
+}

--- a/pkg/api/legacy_model_guard_test.go
+++ b/pkg/api/legacy_model_guard_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/portpowered/agent-factory/internal/contractguard"
+	"github.com/portpowered/agent-factory/internal/handwrittensourceguard"
 )
 
 func TestNoHandwrittenLegacyReplayModelsOrGeneratedAliases(t *testing.T) {
@@ -36,12 +36,7 @@ func TestNoHandwrittenLegacyReplayModelsOrGeneratedAliases(t *testing.T) {
 			return walkErr
 		}
 		if entry.IsDir() {
-			if contractguard.ShouldSkipDir(moduleRoot, path,
-				"pkg/api/generated",
-				"ui/dist",
-				"ui/node_modules",
-				"ui/storybook-static",
-			) {
+			if handwrittensourceguard.ShouldSkipDir("pkg/api/legacy_model_guard_test.go", moduleRoot, path) {
 				return filepath.SkipDir
 			}
 			return nil

--- a/pkg/interfaces/runtime_lookup_contract_guard_test.go
+++ b/pkg/interfaces/runtime_lookup_contract_guard_test.go
@@ -131,6 +131,35 @@ func runtimeBaseDir(v interface{ RuntimeBaseDir() string }) string {
 	)
 }
 
+func TestRuntimeLookupContractGuard_SkipsGeneratedApiOutputButScansHandwrittenPackages(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeRuntimeLookupGuardFixture(t, root, "api/generated/runtime_lookup.go", `package generated
+
+type GeneratedLookup interface {
+	RuntimeBaseDir() string
+}
+`)
+	writeRuntimeLookupGuardFixture(t, root, "workers/runtime_lookup.go", `package workers
+
+type RuntimeExecutionLookup interface {
+	RuntimeBaseDir() string
+}
+`)
+
+	violations, err := scanRuntimeLookupContractViolations(root)
+	if err != nil {
+		t.Fatalf("scan temp runtime lookup ownership: %v", err)
+	}
+
+	assertRuntimeLookupViolationKinds(
+		t,
+		violations,
+		[]string{"workers/runtime_lookup.go:unapproved RuntimeBaseDir interface owner"},
+	)
+}
+
 func scanRuntimeLookupContractViolations(root string) ([]runtimeLookupContractViolation, error) {
 	root = filepath.Clean(root)
 

--- a/pkg/interfaces/runtime_lookup_contract_guard_test.go
+++ b/pkg/interfaces/runtime_lookup_contract_guard_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/portpowered/agent-factory/internal/contractguard"
+	"github.com/portpowered/agent-factory/internal/handwrittensourceguard"
 )
 
 const approvedRuntimeLookupFactoryDirOwner = "interfaces/runtime_lookup.go"
@@ -141,7 +141,7 @@ func scanRuntimeLookupContractViolations(root string) ([]runtimeLookupContractVi
 			return walkErr
 		}
 		if d.IsDir() {
-			if contractguard.ShouldSkipDir(root, path) {
+			if handwrittensourceguard.ShouldSkipDir("pkg/interfaces/runtime_lookup_contract_guard_test.go", root, path) {
 				return filepath.SkipDir
 			}
 			return nil

--- a/pkg/interfaces/world_view_contract_guard_test.go
+++ b/pkg/interfaces/world_view_contract_guard_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/portpowered/agent-factory/internal/contractguard"
+	"github.com/portpowered/agent-factory/internal/handwrittensourceguard"
 )
 
 var retiredFactoryBoundaryMirrorNames = []string{
@@ -157,7 +158,7 @@ func TestFactoryWorldContractGuard_RetiredCanonicalMirrorNamesStayOutOfPkgGoFile
 			return err
 		}
 		if info.IsDir() {
-			if contractguard.ShouldSkipDir("..", path, "api/generated") {
+			if handwrittensourceguard.ShouldSkipDir("pkg/interfaces/world_view_contract_guard_test.go#canonical", "..", path) {
 				return filepath.SkipDir
 			}
 			return nil

--- a/pkg/interfaces/world_view_contract_guard_test.go
+++ b/pkg/interfaces/world_view_contract_guard_test.go
@@ -142,49 +142,34 @@ func TestFactoryWorldContractGuard_RetiredBoundaryMirrorNamesStayOutOfInterfaces
 func TestFactoryWorldContractGuard_RetiredCanonicalMirrorNamesStayOutOfPkgGoFiles(t *testing.T) {
 	t.Parallel()
 
-	names := append([]string(nil), retiredFactoryCanonicalMirrorNames...)
-	sort.Strings(names)
-	patterns := make([]string, 0, len(names))
-	for _, name := range names {
-		patterns = append(patterns, regexp.QuoteMeta(name))
-	}
-	matcher := regexp.MustCompile(`\b(?:` + strings.Join(patterns, "|") + `)\b`)
-	allowed := map[string]struct{}{
-		filepath.Clean("interfaces/world_view_contract_guard_test.go"): {},
-	}
-
-	err := filepath.Walk("..", func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if info.IsDir() {
-			if handwrittensourceguard.ShouldSkipDir("pkg/interfaces/world_view_contract_guard_test.go#canonical", "..", path) {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if filepath.Ext(path) != ".go" {
-			return nil
-		}
-		rel, relErr := filepath.Rel("..", path)
-		if relErr != nil {
-			return relErr
-		}
-		rel = filepath.Clean(rel)
-		if _, ok := allowed[rel]; ok {
-			return nil
-		}
-		data, readErr := os.ReadFile(path)
-		if readErr != nil {
-			return readErr
-		}
-		if match := matcher.FindString(string(data)); match != "" {
-			t.Fatalf("%s still contains retired mirror name %q; equivalent rg guard is `rg -n %q pkg -g \"*.go\"` from the repository root and should only hit approved guard notes", rel, match, strings.Join(names, "|"))
-		}
-		return nil
-	})
+	violations, err := scanWorldViewCanonicalMirrorViolations("..")
 	if err != nil {
 		t.Fatalf("scan pkg go files: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("%s still contains retired mirror name %q; equivalent rg guard is `rg -n %q pkg -g \"*.go\"` from the repository root and should only hit approved guard notes", violations[0].file, violations[0].name, strings.Join(retiredFactoryCanonicalMirrorNames, "|"))
+	}
+}
+
+func TestFactoryWorldContractGuard_CanonicalPkgScanSkipsGeneratedApiOutputButScansHandwrittenPackages(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeWorldViewGuardFixture(t, root, "api/generated/runtime_lookup.go", `package generated
+
+type FactoryProviderFailure struct{}
+`)
+	writeWorldViewGuardFixture(t, root, "workers/runtime_lookup.go", `package workers
+
+type FactoryProviderFailure struct{}
+`)
+
+	violations, err := scanWorldViewCanonicalMirrorViolations(root)
+	if err != nil {
+		t.Fatalf("scan temp pkg go files: %v", err)
+	}
+	if len(violations) != 1 || violations[0].file != filepath.Clean("workers/runtime_lookup.go") || violations[0].name != "FactoryProviderFailure" {
+		t.Fatalf("violations = %#v, want only handwritten worker violation", violations)
 	}
 }
 
@@ -295,4 +280,76 @@ func allRetiredFactoryMirrorNames() []string {
 	names = append(names, retiredFactoryBoundaryMirrorNames...)
 	names = append(names, retiredFactoryCanonicalMirrorNames...)
 	return names
+}
+
+type worldViewCanonicalMirrorViolation struct {
+	file string
+	name string
+}
+
+func scanWorldViewCanonicalMirrorViolations(root string) ([]worldViewCanonicalMirrorViolation, error) {
+	names := append([]string(nil), retiredFactoryCanonicalMirrorNames...)
+	sort.Strings(names)
+	patterns := make([]string, 0, len(names))
+	for _, name := range names {
+		patterns = append(patterns, regexp.QuoteMeta(name))
+	}
+	matcher := regexp.MustCompile(`\b(?:` + strings.Join(patterns, "|") + `)\b`)
+	allowed := map[string]struct{}{
+		filepath.Clean("interfaces/world_view_contract_guard_test.go"): {},
+	}
+
+	var violations []worldViewCanonicalMirrorViolation
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			if handwrittensourceguard.ShouldSkipDir("pkg/interfaces/world_view_contract_guard_test.go#canonical", root, path) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".go" {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		rel = filepath.Clean(rel)
+		if _, ok := allowed[rel]; ok {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		if match := matcher.FindString(string(data)); match != "" {
+			violations = append(violations, worldViewCanonicalMirrorViolation{file: rel, name: match})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(violations, func(i, j int) bool {
+		if violations[i].file == violations[j].file {
+			return violations[i].name < violations[j].name
+		}
+		return violations[i].file < violations[j].file
+	})
+	return violations, nil
+}
+
+func writeWorldViewGuardFixture(t *testing.T, root, relativePath, contents string) {
+	t.Helper()
+
+	path := filepath.Join(root, relativePath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
 }

--- a/pkg/petri/transition_contract_guard_test.go
+++ b/pkg/petri/transition_contract_guard_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -34,25 +35,7 @@ func TestTransitionContractGuard_ProductionTransitionLiteralsStayTopologyOnly(t 
 	t.Parallel()
 
 	moduleRoot := filepath.Clean(filepath.Join("..", ".."))
-	fset := token.NewFileSet()
-	err := filepath.WalkDir(moduleRoot, func(path string, entry os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if entry.IsDir() {
-			if handwrittensourceguard.ShouldSkipDir("pkg/petri/transition_contract_guard_test.go", moduleRoot, path) {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if filepath.Ext(path) != ".go" || strings.HasSuffix(path, "_test.go") || filepath.Base(path) == "transition_contract_guard_test.go" {
-			return nil
-		}
-
-		file, err := parser.ParseFile(fset, path, nil, 0)
-		if err != nil {
-			return err
-		}
+	err := walkTransitionGuardProductionFiles(moduleRoot, func(path string, file *ast.File) error {
 		petriAliases := transitionImportAliases(file)
 		ast.Inspect(file, func(node ast.Node) bool {
 			lit, ok := node.(*ast.CompositeLit)
@@ -79,6 +62,75 @@ func TestTransitionContractGuard_ProductionTransitionLiteralsStayTopologyOnly(t 
 	if err != nil {
 		t.Fatalf("scan production transition literals: %v", err)
 	}
+}
+
+func TestTransitionContractGuard_SkipsHiddenMetadataDirs(t *testing.T) {
+	t.Parallel()
+
+	moduleRoot := t.TempDir()
+	for path, contents := range map[string]string{
+		"pkg/feature/kept.go":                "package feature\n",
+		".claude/worktrees/stale/ignored.go": "package stale\n",
+		".git/hooks/ignored.go":              "package hooks\n",
+		".worktrees/nested/ignored.go":       "package nested\n",
+	} {
+		fullPath := filepath.Join(moduleRoot, filepath.FromSlash(path))
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+			t.Fatalf("create parent dir for %s: %v", path, err)
+		}
+		if err := os.WriteFile(fullPath, []byte(contents), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	var visited []string
+	if err := walkTransitionGuardProductionFiles(moduleRoot, func(path string, _ *ast.File) error {
+		rel, err := filepath.Rel(moduleRoot, path)
+		if err != nil {
+			return err
+		}
+		visited = append(visited, filepath.ToSlash(rel))
+		return nil
+	}); err != nil {
+		t.Fatalf("walk transition guard files: %v", err)
+	}
+
+	if !slices.Contains(visited, "pkg/feature/kept.go") {
+		t.Fatalf("expected handwritten source file to be visited, got %v", visited)
+	}
+	for _, skipped := range []string{
+		".claude/worktrees/stale/ignored.go",
+		".git/hooks/ignored.go",
+		".worktrees/nested/ignored.go",
+	} {
+		if slices.Contains(visited, skipped) {
+			t.Fatalf("expected hidden metadata path %s to be skipped, got %v", skipped, visited)
+		}
+	}
+}
+
+func walkTransitionGuardProductionFiles(moduleRoot string, visit func(path string, file *ast.File) error) error {
+	fset := token.NewFileSet()
+	return filepath.WalkDir(moduleRoot, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if handwrittensourceguard.ShouldSkipDir("pkg/petri/transition_contract_guard_test.go", moduleRoot, path) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".go" || strings.HasSuffix(path, "_test.go") || filepath.Base(path) == "transition_contract_guard_test.go" {
+			return nil
+		}
+
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return err
+		}
+		return visit(path, file)
+	})
 }
 
 func transitionImportAliases(file *ast.File) map[string]struct{} {

--- a/pkg/petri/transition_contract_guard_test.go
+++ b/pkg/petri/transition_contract_guard_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/portpowered/agent-factory/internal/contractguard"
+	"github.com/portpowered/agent-factory/internal/handwrittensourceguard"
 )
 
 var retiredTransitionRuntimeFields = map[string]struct{}{
@@ -40,7 +40,7 @@ func TestTransitionContractGuard_ProductionTransitionLiteralsStayTopologyOnly(t 
 			return walkErr
 		}
 		if entry.IsDir() {
-			if contractguard.ShouldSkipDir(moduleRoot, path, "pkg/api/generated", "ui/dist", "ui/node_modules", "ui/storybook-static") {
+			if handwrittensourceguard.ShouldSkipDir("pkg/petri/transition_contract_guard_test.go", moduleRoot, path) {
 				return filepath.SkipDir
 			}
 			return nil

--- a/pkg/testutil/handwritten_source_guard_inventory.go
+++ b/pkg/testutil/handwritten_source_guard_inventory.go
@@ -1,149 +1,21 @@
 package testutil
 
-// HandwrittenSourcePathClass classifies how a handwritten-source guard should
-// treat a filesystem path when scanning for checked-in source.
-type HandwrittenSourcePathClass string
+import "github.com/portpowered/agent-factory/internal/handwrittensourceguard"
+
+type HandwrittenSourcePathClass = handwrittensourceguard.PathClass
 
 const (
-	HandwrittenSourcePathClassScanHandwritten   HandwrittenSourcePathClass = "scan-handwritten"
-	HandwrittenSourcePathClassExcludeGenerated  HandwrittenSourcePathClass = "exclude-generated"
-	HandwrittenSourcePathClassExcludeHiddenRoot HandwrittenSourcePathClass = "exclude-hidden-root"
+	HandwrittenSourcePathClassScanHandwritten   = handwrittensourceguard.PathClassScanHandwritten
+	HandwrittenSourcePathClassExcludeGenerated  = handwrittensourceguard.PathClassExcludeGenerated
+	HandwrittenSourcePathClassExcludeHiddenRoot = handwrittensourceguard.PathClassExcludeHiddenRoot
 )
 
-// HandwrittenSourcePathRule captures one scanned root or excluded subtree for a
-// handwritten-source contract guard.
-type HandwrittenSourcePathRule struct {
-	Path  string
-	Class HandwrittenSourcePathClass
-	Why   string
-}
+type HandwrittenSourcePathRule = handwrittensourceguard.PathRule
 
-// HandwrittenSourceGuardInventoryEntry records the intended handwritten-source
-// contract for one guard that walks the filesystem.
-type HandwrittenSourceGuardInventoryEntry struct {
-	GuardFile string
-	WalkRoot  string
-	Rules     []HandwrittenSourcePathRule
-}
+type HandwrittenSourceGuardInventoryEntry = handwrittensourceguard.InventoryEntry
 
 // HandwrittenSourceGuardInventory is the source of truth for broad
 // filesystem-walking handwritten-source guards that need consistent skip policy.
 func HandwrittenSourceGuardInventory() []HandwrittenSourceGuardInventoryEntry {
-	return []HandwrittenSourceGuardInventoryEntry{
-		{
-			GuardFile: "pkg/api/legacy_model_guard_test.go",
-			WalkRoot:  "repo-root",
-			Rules: []HandwrittenSourcePathRule{
-				{
-					Path:  "repo-root/**/*.go",
-					Class: HandwrittenSourcePathClassScanHandwritten,
-					Why:   "scan checked-in handwritten Go source across the repository",
-				},
-				{
-					Path:  "pkg/api/generated",
-					Class: HandwrittenSourcePathClassExcludeGenerated,
-					Why:   "generated API output is not handwritten contract source",
-				},
-				{
-					Path:  "ui/dist",
-					Class: HandwrittenSourcePathClassExcludeGenerated,
-					Why:   "compiled dashboard assets are generated artifacts",
-				},
-				{
-					Path:  "ui/node_modules",
-					Class: HandwrittenSourcePathClassExcludeGenerated,
-					Why:   "dependency install output is not handwritten source",
-				},
-				{
-					Path:  "ui/storybook-static",
-					Class: HandwrittenSourcePathClassExcludeGenerated,
-					Why:   "storybook build output is generated",
-				},
-				{
-					Path:  ".*/",
-					Class: HandwrittenSourcePathClassExcludeHiddenRoot,
-					Why:   "hidden repository metadata such as .git, .claude, and nested worktree state must not count as handwritten source",
-				},
-			},
-		},
-		{
-			GuardFile: "pkg/petri/transition_contract_guard_test.go",
-			WalkRoot:  "repo-root",
-			Rules: []HandwrittenSourcePathRule{
-				{
-					Path:  "repo-root/**/*.go",
-					Class: HandwrittenSourcePathClassScanHandwritten,
-					Why:   "scan checked-in handwritten Go source across the repository",
-				},
-				{
-					Path:  "pkg/api/generated",
-					Class: HandwrittenSourcePathClassExcludeGenerated,
-					Why:   "generated API output is not handwritten contract source",
-				},
-				{
-					Path:  "ui/dist",
-					Class: HandwrittenSourcePathClassExcludeGenerated,
-					Why:   "compiled dashboard assets are generated artifacts",
-				},
-				{
-					Path:  "ui/node_modules",
-					Class: HandwrittenSourcePathClassExcludeGenerated,
-					Why:   "dependency install output is not handwritten source",
-				},
-				{
-					Path:  "ui/storybook-static",
-					Class: HandwrittenSourcePathClassExcludeGenerated,
-					Why:   "storybook build output is generated",
-				},
-				{
-					Path:  ".*/",
-					Class: HandwrittenSourcePathClassExcludeHiddenRoot,
-					Why:   "hidden repository metadata such as .git, .claude, and nested worktree state must not count as handwritten source",
-				},
-			},
-		},
-		{
-			GuardFile: "pkg/interfaces/world_view_contract_guard_test.go#boundary",
-			WalkRoot:  "pkg/interfaces",
-			Rules: []HandwrittenSourcePathRule{
-				{
-					Path:  "pkg/interfaces/*.go",
-					Class: HandwrittenSourcePathClassScanHandwritten,
-					Why:   "boundary mirror names are only guarded inside the handwritten interfaces package",
-				},
-			},
-		},
-		{
-			GuardFile: "pkg/interfaces/world_view_contract_guard_test.go#canonical",
-			WalkRoot:  "pkg",
-			Rules: []HandwrittenSourcePathRule{
-				{
-					Path:  "pkg/**/*.go",
-					Class: HandwrittenSourcePathClassScanHandwritten,
-					Why:   "scan checked-in handwritten package Go source under pkg",
-				},
-				{
-					Path:  "pkg/api/generated",
-					Class: HandwrittenSourcePathClassExcludeGenerated,
-					Why:   "generated API output is not handwritten pkg source",
-				},
-			},
-		},
-		{
-			GuardFile: "pkg/interfaces/runtime_lookup_contract_guard_test.go",
-			WalkRoot:  "pkg",
-			Rules: []HandwrittenSourcePathRule{
-				{
-					Path:  "pkg/**/*.go",
-					Class: HandwrittenSourcePathClassScanHandwritten,
-					Why:   "scan checked-in handwritten package Go source under pkg",
-				},
-				{
-					Path:  "pkg/api/generated",
-					Class: HandwrittenSourcePathClassExcludeGenerated,
-					Why:   "generated API output is not handwritten pkg source",
-				},
-			},
-		},
-	}
+	return handwrittensourceguard.Inventory()
 }

--- a/pkg/testutil/handwritten_source_guard_inventory.go
+++ b/pkg/testutil/handwritten_source_guard_inventory.go
@@ -1,0 +1,149 @@
+package testutil
+
+// HandwrittenSourcePathClass classifies how a handwritten-source guard should
+// treat a filesystem path when scanning for checked-in source.
+type HandwrittenSourcePathClass string
+
+const (
+	HandwrittenSourcePathClassScanHandwritten   HandwrittenSourcePathClass = "scan-handwritten"
+	HandwrittenSourcePathClassExcludeGenerated  HandwrittenSourcePathClass = "exclude-generated"
+	HandwrittenSourcePathClassExcludeHiddenRoot HandwrittenSourcePathClass = "exclude-hidden-root"
+)
+
+// HandwrittenSourcePathRule captures one scanned root or excluded subtree for a
+// handwritten-source contract guard.
+type HandwrittenSourcePathRule struct {
+	Path  string
+	Class HandwrittenSourcePathClass
+	Why   string
+}
+
+// HandwrittenSourceGuardInventoryEntry records the intended handwritten-source
+// contract for one guard that walks the filesystem.
+type HandwrittenSourceGuardInventoryEntry struct {
+	GuardFile string
+	WalkRoot  string
+	Rules     []HandwrittenSourcePathRule
+}
+
+// HandwrittenSourceGuardInventory is the source of truth for broad
+// filesystem-walking handwritten-source guards that need consistent skip policy.
+func HandwrittenSourceGuardInventory() []HandwrittenSourceGuardInventoryEntry {
+	return []HandwrittenSourceGuardInventoryEntry{
+		{
+			GuardFile: "pkg/api/legacy_model_guard_test.go",
+			WalkRoot:  "repo-root",
+			Rules: []HandwrittenSourcePathRule{
+				{
+					Path:  "repo-root/**/*.go",
+					Class: HandwrittenSourcePathClassScanHandwritten,
+					Why:   "scan checked-in handwritten Go source across the repository",
+				},
+				{
+					Path:  "pkg/api/generated",
+					Class: HandwrittenSourcePathClassExcludeGenerated,
+					Why:   "generated API output is not handwritten contract source",
+				},
+				{
+					Path:  "ui/dist",
+					Class: HandwrittenSourcePathClassExcludeGenerated,
+					Why:   "compiled dashboard assets are generated artifacts",
+				},
+				{
+					Path:  "ui/node_modules",
+					Class: HandwrittenSourcePathClassExcludeGenerated,
+					Why:   "dependency install output is not handwritten source",
+				},
+				{
+					Path:  "ui/storybook-static",
+					Class: HandwrittenSourcePathClassExcludeGenerated,
+					Why:   "storybook build output is generated",
+				},
+				{
+					Path:  ".*/",
+					Class: HandwrittenSourcePathClassExcludeHiddenRoot,
+					Why:   "hidden repository metadata such as .git, .claude, and nested worktree state must not count as handwritten source",
+				},
+			},
+		},
+		{
+			GuardFile: "pkg/petri/transition_contract_guard_test.go",
+			WalkRoot:  "repo-root",
+			Rules: []HandwrittenSourcePathRule{
+				{
+					Path:  "repo-root/**/*.go",
+					Class: HandwrittenSourcePathClassScanHandwritten,
+					Why:   "scan checked-in handwritten Go source across the repository",
+				},
+				{
+					Path:  "pkg/api/generated",
+					Class: HandwrittenSourcePathClassExcludeGenerated,
+					Why:   "generated API output is not handwritten contract source",
+				},
+				{
+					Path:  "ui/dist",
+					Class: HandwrittenSourcePathClassExcludeGenerated,
+					Why:   "compiled dashboard assets are generated artifacts",
+				},
+				{
+					Path:  "ui/node_modules",
+					Class: HandwrittenSourcePathClassExcludeGenerated,
+					Why:   "dependency install output is not handwritten source",
+				},
+				{
+					Path:  "ui/storybook-static",
+					Class: HandwrittenSourcePathClassExcludeGenerated,
+					Why:   "storybook build output is generated",
+				},
+				{
+					Path:  ".*/",
+					Class: HandwrittenSourcePathClassExcludeHiddenRoot,
+					Why:   "hidden repository metadata such as .git, .claude, and nested worktree state must not count as handwritten source",
+				},
+			},
+		},
+		{
+			GuardFile: "pkg/interfaces/world_view_contract_guard_test.go#boundary",
+			WalkRoot:  "pkg/interfaces",
+			Rules: []HandwrittenSourcePathRule{
+				{
+					Path:  "pkg/interfaces/*.go",
+					Class: HandwrittenSourcePathClassScanHandwritten,
+					Why:   "boundary mirror names are only guarded inside the handwritten interfaces package",
+				},
+			},
+		},
+		{
+			GuardFile: "pkg/interfaces/world_view_contract_guard_test.go#canonical",
+			WalkRoot:  "pkg",
+			Rules: []HandwrittenSourcePathRule{
+				{
+					Path:  "pkg/**/*.go",
+					Class: HandwrittenSourcePathClassScanHandwritten,
+					Why:   "scan checked-in handwritten package Go source under pkg",
+				},
+				{
+					Path:  "pkg/api/generated",
+					Class: HandwrittenSourcePathClassExcludeGenerated,
+					Why:   "generated API output is not handwritten pkg source",
+				},
+			},
+		},
+		{
+			GuardFile: "pkg/interfaces/runtime_lookup_contract_guard_test.go",
+			WalkRoot:  "pkg",
+			Rules: []HandwrittenSourcePathRule{
+				{
+					Path:  "pkg/**/*.go",
+					Class: HandwrittenSourcePathClassScanHandwritten,
+					Why:   "scan checked-in handwritten package Go source under pkg",
+				},
+				{
+					Path:  "pkg/api/generated",
+					Class: HandwrittenSourcePathClassExcludeGenerated,
+					Why:   "generated API output is not handwritten pkg source",
+				},
+			},
+		},
+	}
+}

--- a/pkg/testutil/handwritten_source_guard_inventory_test.go
+++ b/pkg/testutil/handwritten_source_guard_inventory_test.go
@@ -1,6 +1,9 @@
 package testutil
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
 func TestHandwrittenSourceGuardInventory_CoversTargetedGuardsAndClassifications(t *testing.T) {
 	t.Parallel()
@@ -69,5 +72,31 @@ func TestHandwrittenSourceGuardInventory_RecordsHiddenAndGeneratedExclusionsForB
 		if entry.GuardFile != "pkg/interfaces/world_view_contract_guard_test.go#boundary" && !hasGenerated && entry.WalkRoot != "pkg/interfaces" {
 			t.Fatalf("%s must record generated-output exclusions when scanning broad handwritten-source roots", entry.GuardFile)
 		}
+	}
+}
+
+func TestShouldSkipHandwrittenSourceDir_UsesInventoryGeneratedAndHiddenRules(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := filepath.Join("repo", "root")
+	if !ShouldSkipHandwrittenSourceDir("pkg/petri/transition_contract_guard_test.go", repoRoot, filepath.Join(repoRoot, ".claude", "worktrees")) {
+		t.Fatal("repo-root handwritten-source guard must skip hidden metadata directories")
+	}
+	if !ShouldSkipHandwrittenSourceDir("pkg/petri/transition_contract_guard_test.go", repoRoot, filepath.Join(repoRoot, "pkg", "api", "generated")) {
+		t.Fatal("repo-root handwritten-source guard must skip generated API output")
+	}
+	if ShouldSkipHandwrittenSourceDir("pkg/petri/transition_contract_guard_test.go", repoRoot, filepath.Join(repoRoot, "pkg", "petri")) {
+		t.Fatal("repo-root handwritten-source guard must keep handwritten source directories")
+	}
+
+	pkgRoot := filepath.Join("repo", "root", "pkg")
+	if !ShouldSkipHandwrittenSourceDir("pkg/interfaces/runtime_lookup_contract_guard_test.go", pkgRoot, filepath.Join(pkgRoot, "api", "generated")) {
+		t.Fatal("pkg-root handwritten-source guard must skip generated API output")
+	}
+	if !ShouldSkipHandwrittenSourceDir("pkg/interfaces/runtime_lookup_contract_guard_test.go", pkgRoot, filepath.Join(pkgRoot, ".cache")) {
+		t.Fatal("pkg-root handwritten-source guard must skip hidden directories")
+	}
+	if ShouldSkipHandwrittenSourceDir("pkg/interfaces/runtime_lookup_contract_guard_test.go", pkgRoot, filepath.Join(pkgRoot, "interfaces")) {
+		t.Fatal("pkg-root handwritten-source guard must keep handwritten package directories")
 	}
 }

--- a/pkg/testutil/handwritten_source_guard_inventory_test.go
+++ b/pkg/testutil/handwritten_source_guard_inventory_test.go
@@ -1,0 +1,73 @@
+package testutil
+
+import "testing"
+
+func TestHandwrittenSourceGuardInventory_CoversTargetedGuardsAndClassifications(t *testing.T) {
+	t.Parallel()
+
+	inventory := HandwrittenSourceGuardInventory()
+	if len(inventory) != 5 {
+		t.Fatalf("inventory entries = %d, want 5 targeted handwritten-source guards", len(inventory))
+	}
+
+	wantGuards := map[string]struct{}{
+		"pkg/api/legacy_model_guard_test.go":                         {},
+		"pkg/petri/transition_contract_guard_test.go":                {},
+		"pkg/interfaces/world_view_contract_guard_test.go#boundary":  {},
+		"pkg/interfaces/world_view_contract_guard_test.go#canonical": {},
+		"pkg/interfaces/runtime_lookup_contract_guard_test.go":       {},
+	}
+
+	for _, entry := range inventory {
+		if _, ok := wantGuards[entry.GuardFile]; !ok {
+			t.Fatalf("unexpected guard inventory entry %q", entry.GuardFile)
+		}
+		delete(wantGuards, entry.GuardFile)
+
+		var hasHandwritten bool
+		for _, rule := range entry.Rules {
+			if rule.Class == HandwrittenSourcePathClassScanHandwritten {
+				hasHandwritten = true
+			}
+			if rule.Path == "" || rule.Why == "" {
+				t.Fatalf("%s contains incomplete rule %#v", entry.GuardFile, rule)
+			}
+		}
+		if !hasHandwritten {
+			t.Fatalf("%s must declare at least one handwritten scan rule", entry.GuardFile)
+		}
+	}
+
+	if len(wantGuards) != 0 {
+		t.Fatalf("missing guard inventory entries: %#v", wantGuards)
+	}
+}
+
+func TestHandwrittenSourceGuardInventory_RecordsHiddenAndGeneratedExclusionsForBroadWalkers(t *testing.T) {
+	t.Parallel()
+
+	inventory := HandwrittenSourceGuardInventory()
+	for _, entry := range inventory {
+		if entry.WalkRoot != "repo-root" && entry.WalkRoot != "pkg" {
+			continue
+		}
+
+		var hasGenerated bool
+		var hasHidden bool
+		for _, rule := range entry.Rules {
+			switch rule.Class {
+			case HandwrittenSourcePathClassExcludeGenerated:
+				hasGenerated = true
+			case HandwrittenSourcePathClassExcludeHiddenRoot:
+				hasHidden = true
+			}
+		}
+
+		if entry.WalkRoot == "repo-root" && !hasHidden {
+			t.Fatalf("%s must record hidden-root exclusions for repo-root walks", entry.GuardFile)
+		}
+		if entry.GuardFile != "pkg/interfaces/world_view_contract_guard_test.go#boundary" && !hasGenerated && entry.WalkRoot != "pkg/interfaces" {
+			t.Fatalf("%s must record generated-output exclusions when scanning broad handwritten-source roots", entry.GuardFile)
+		}
+	}
+}

--- a/pkg/testutil/handwritten_source_guard_policy.go
+++ b/pkg/testutil/handwritten_source_guard_policy.go
@@ -1,0 +1,9 @@
+package testutil
+
+import "github.com/portpowered/agent-factory/internal/handwrittensourceguard"
+
+// ShouldSkipHandwrittenSourceDir reports whether a filesystem-walking
+// handwritten-source guard should skip the provided directory.
+func ShouldSkipHandwrittenSourceDir(guardFile, walkRoot, path string) bool {
+	return handwrittensourceguard.ShouldSkipDir(guardFile, walkRoot, path)
+}


### PR DESCRIPTION
## Summary
- add shared closeout coverage for the handwritten-source skip policy
- assert repo-root and pkg-root guard inventories skip hidden metadata and generated output
- keep handwritten source directories included in the shared regression contract

## Checks
- go test ./internal/handwrittensourceguard ./pkg/testutil ./pkg/api ./pkg/petri ./pkg/interfaces -count=1
- go vet ./...
- go run ./cmd/deadcodecheck
- go run ./cmd/publicsurfacecheck