### PR TITLE
stabilize-root-factory-starter-contract

### DIFF
--- a/docs/development/root-factory-artifact-contract-inventory.md
+++ b/docs/development/root-factory-artifact-contract-inventory.md
@@ -34,6 +34,9 @@ matter to the targeted contract tests in `pkg/api`, `pkg/config`, `pkg/replay`,
 | `factory/inputs/thoughts/default/.gitkeep` | `checked_in` | Tracked sentinel that keeps the canonical thought inbox present in clean checkouts. |
 | `factory/logs/agent-fails.json` | `checked_in` | Event-stream sample for replay artifact conversion coverage. |
 | `factory/logs/agent-fails.replay.json` | `checked_in` | Replay artifact sample paired with `agent-fails.json`. |
+| `factory/logs/meta/asks.md` | `checked_in` | Checked-in meta ask surface for the repository-maintainer cleanup loop. |
+| `factory/logs/meta/progress.tsx` | `checked_in` | Checked-in meta progress surface used by the repository-maintainer cleanup loop. |
+| `factory/logs/meta/view.md` | `checked_in` | Checked-in meta world-view surface used by the repository-maintainer cleanup loop. |
 | `tests/adhoc/factory-recording-04-11-02.json` | `checked_in` | Canonical replay fixture used by adhoc and replay package tests. |
 | `tests/adhoc/factory/README.md` | `checked_in` | Checked-in adhoc fixture doc. |
 | `tests/adhoc/factory/factory.json` | `checked_in` | Checked-in adhoc fixture config. |

--- a/docs/processes/factory-workstation-relevant-files.md
+++ b/docs/processes/factory-workstation-relevant-files.md
@@ -20,3 +20,4 @@ work inputs.
 
 - Treat `factory/inputs/idea/default/` as the live standalone idea inbox, not as a checked-in template catalog; clean checkouts may only contain `.gitkeep`.
 - When prompt instructions need ordered or multi-item follow-up work, point them to `docs/guides/batch-inputs.md` and `factory/inputs/BATCH/default/` instead of overloading the markdown idea inbox.
+- Keep workstation prompts repository-local and public-surface neutral: cite checked-in docs or `factory/` paths in this repo, never absolute paths to a different checkout or merge-conflict marker text.

--- a/factory/workstations/cleaner/AGENTS.md
+++ b/factory/workstations/cleaner/AGENTS.md
@@ -1,12 +1,12 @@
 ---
 type: MODEL_WORKSTATION
 ---
-You are the meta software agent. 
+You are the meta software agent.
 
-Your job is to basically run every few minutes or so, and have a role of: 
+Your job is to periodically inspect the repository and:
 1. requesting agents to do work for you to clean up the code
 2. constructing your own theory of mind on how the system works and updating that theory of mind as you explore how things change over time. 
-3. handling customer asks at factoy/logs/meta/asks.md
+3. handling customer asks at `factory/logs/meta/asks.md`
 
 # Steps
 ## step 0 - update the repo
@@ -14,10 +14,9 @@ run git pull and make the workspace be up to date to remote
 
 ## Step 1 - read
 0. read your own at factory/logs/meta/view.md and factory/logs/meta/progress.tsx and the customer's asks factory/logs/meta/asks.md
-1. read the C:\Users\andre\work\portos\portos-backend\docs\operations\postmortem\agent-factory-quality-defects.md file. 
-2. Read up the code under the ./, and read recent prs that are associated with your previous requests. 
-3. For now, read up the current files the factory/inputs directory to see any previous clean up attempts that have already been done. 
-4. read `factory/README.md`, `docs/development/root-factory-artifact-contract-inventory.md`, and inspect the checked-in workflow inputs under `factory/inputs/`.
+1. read `factory/README.md`, `docs/development/root-factory-artifact-contract-inventory.md`, `docs/processes/factory-workstation-relevant-files.md`, and `docs/guides/batch-inputs.md` before deciding where follow-up work should land.
+2. read up the code under `./`, and read recent PRs that are associated with your previous requests.
+3. inspect the current files under `factory/inputs/` to see any previous cleanup attempts that have already been made.
 
 ## Step 2 - based on the above results decide on one of the following: 
 1. update your meta view of the world
@@ -51,10 +50,6 @@ figure out a way to clean the code (in priority order)
 5. consolidate duplicative structures or fucntionality across the code base. 
 6. for the agentfactory websites we look to remove unused code, reduce the amount of duplicative components, reduce functionality down to small components, shared styles, such that the overall complexity of teh system is reduced. 
 
-<<<<<<< HEAD
-
-=======
 ## Step 3 - write a file
 1. for one standalone cleanup idea, write one markdown file to `{project-git-root-directory}/factory/inputs/idea/default/{your-idea}.md`; that inbox is the checked-in surface and is kept present by `factory/inputs/idea/default/.gitkeep`.
 2. if the follow-up needs ordered or mixed-work-type submission instead of one standalone idea file, follow `docs/guides/batch-inputs.md` and write the canonical `FACTORY_REQUEST_BATCH` JSON to `{project-git-root-directory}/factory/inputs/BATCH/default/{request_id}.json`
->>>>>>> 2896cc65792feb0bf419c4942f08e1993935e577

--- a/internal/testpath/artifact_contract.go
+++ b/internal/testpath/artifact_contract.go
@@ -106,6 +106,21 @@ var artifactContractEntries = []ArtifactContractEntry{
 		Reason:         "Checked-in replay artifact sample paired with the event-stream conversion smoke.",
 	},
 	{
+		Path:           "factory/logs/meta/asks.md",
+		Classification: ArtifactCheckedIn,
+		Reason:         "Checked-in meta ask surface used by the repository-maintainer cleanup loop.",
+	},
+	{
+		Path:           "factory/logs/meta/progress.tsx",
+		Classification: ArtifactCheckedIn,
+		Reason:         "Checked-in meta progress surface used by the repository-maintainer cleanup loop.",
+	},
+	{
+		Path:           "factory/logs/meta/view.md",
+		Classification: ArtifactCheckedIn,
+		Reason:         "Checked-in meta world-view surface used by the repository-maintainer cleanup loop.",
+	},
+	{
 		Path:           "tests/adhoc/factory-recording-04-11-02.json",
 		Classification: ArtifactCheckedIn,
 		Reason:         "Canonical replay fixture used by targeted adhoc and replay tests.",


### PR DESCRIPTION
## Summary
- remove external Port OS coupling and merge-conflict drift from the checked-in cleaner workstation prompt
- classify the live actory/logs/meta/* prompt dependencies in the root artifact contract inventory
- document the repository-local prompt guidance rule in the workstation relevant-files guide

## Verification
- make lint
- go test ./pkg/api ./pkg/config ./pkg/replay ./tests/adhoc ./tests/functional_test
