### PR TITLE
prune-solved-local-workflow-input-residue

### DIFF
--- a/docs/development/prune-solved-local-workflow-input-residue-verification.md
+++ b/docs/development/prune-solved-local-workflow-input-residue-verification.md
@@ -39,6 +39,19 @@ No approved archival surface was required because the solved request markdown is
 already absent from the live inboxes, and both canonical sentinels remain
 present and unchanged.
 
+## Scope Guard
+
+The review diff for this branch remains limited to:
+
+- this verification note, which records the landed-state proof and the
+  no-archival outcome for the cited inbox files
+- `docs/processes/factory-workstation-relevant-files.md`, which captures the
+  reusable inbox contract discovered during verification
+
+No product code, workflow execution logic, backlog content, or new cleanup
+lanes were added. The branch therefore stays within the stated inbox-hygiene
+scope and does not mix this cleanup lane with unrelated repository work.
+
 ## Validation
 
 Commands used during verification:
@@ -50,4 +63,5 @@ gh pr view 11 --json number,title,state,mergedAt,files,url
 gh pr view 4 --json number,title,state,headRefName,commits,files,url
 git log --oneline ralph/standardize-contract-guard-skip-policy..main
 Get-ChildItem factory/inputs/idea/default,factory/inputs/task/default -Force
+git diff --stat origin/main...HEAD
 ```

--- a/docs/development/prune-solved-local-workflow-input-residue-verification.md
+++ b/docs/development/prune-solved-local-workflow-input-residue-verification.md
@@ -1,0 +1,47 @@
+## Prune Solved Local Workflow Input Residue Verification
+
+Date: 2026-04-30
+Scope: landed-state verification for `prd.json` `US-001` on branch `ralph/prune-solved-local-workflow-input-residue`.
+
+## Summary
+
+This note verifies that the four workflow-input files named in the PRD do not
+represent active pending work on `main`. The live checked-in inbox directories
+already contain only their canonical `.gitkeep` sentinels, so this iteration is
+limited to recording why that empty state is correct.
+
+No approved archival surface for solved workflow-input markdown was found in the
+checked-in workflow docs. For these inboxes, the repository contract is direct
+live-inbox removal after the lane is landed while preserving the tracked
+directory sentinels.
+
+## Verification Record
+
+| Workflow input path | Landed-state evidence | Result |
+| --- | --- | --- |
+| `factory/inputs/idea/default/dedupe-root-factory-artifact-contract-entries.md` | PR `#14` (`canonicalize-meta-ask-surface`) is merged on `main` and records the artifact-contract closeout for that cleanup lane. | Solved; not an active inbox ask. |
+| `factory/inputs/task/default/inventory-remaining-contract-guard-walkers.md` | PR `#8` (`inventory-remaining-contract-guard-walkers`) is merged on `main` and lands the walker inventory plus its closeout artifact. | Solved; not an active inbox ask. |
+| `factory/inputs/task/default/stabilize-root-factory-starter-contract.md` | PR `#11` (`stabilize-root-factory-starter-contract`) is merged on `main` and lands the repository-local starter-contract cleanup. | Solved; not an active inbox ask. |
+| `factory/inputs/task/default/standardize-contract-guard-skip-policy.md` | `main` already contains the shared skip-policy outcome in commit `6b21fe0` (`feat: US-002 - Extract one canonical handwritten-source skip policy for guard scans`) and the follow-on exclusion alignment in commit `49cb38e`. The older PR `#4` remains open, but its head branch is stale relative to `main` and carries only an extra closeout-style commit (`a3a4fc6`) instead of an unmet production lane. | Solved on `main`; stale branch/PR state does not make this an active pending ask. |
+
+## Current Inbox State
+
+The live checked-in inbox directories were inspected directly:
+
+- `factory/inputs/idea/default/` contains only `.gitkeep`
+- `factory/inputs/task/default/` contains only `.gitkeep`
+
+That state matches the current landed repository truth for the four cited files.
+
+## Validation
+
+Commands used during verification:
+
+```powershell
+gh pr view 14 --json number,title,state,mergedAt,files,url
+gh pr view 8 --json number,title,state,mergedAt,files,url
+gh pr view 11 --json number,title,state,mergedAt,files,url
+gh pr view 4 --json number,title,state,headRefName,commits,files,url
+git log --oneline ralph/standardize-contract-guard-skip-policy..main
+Get-ChildItem factory/inputs/idea/default,factory/inputs/task/default -Force
+```

--- a/docs/development/prune-solved-local-workflow-input-residue-verification.md
+++ b/docs/development/prune-solved-local-workflow-input-residue-verification.md
@@ -1,14 +1,17 @@
 ## Prune Solved Local Workflow Input Residue Verification
 
 Date: 2026-04-30
-Scope: landed-state verification for `prd.json` `US-001` on branch `ralph/prune-solved-local-workflow-input-residue`.
+Scope: landed-state verification and live-inbox reconciliation for `prd.json`
+`US-001` and `US-002` on branch
+`ralph/prune-solved-local-workflow-input-residue`.
 
 ## Summary
 
 This note verifies that the four workflow-input files named in the PRD do not
 represent active pending work on `main`. The live checked-in inbox directories
 already contain only their canonical `.gitkeep` sentinels, so this iteration is
-limited to recording why that empty state is correct.
+limited to recording why that empty state is correct and why no additional
+archival handling is required.
 
 No approved archival surface for solved workflow-input markdown was found in the
 checked-in workflow docs. For these inboxes, the repository contract is direct
@@ -32,6 +35,9 @@ The live checked-in inbox directories were inspected directly:
 - `factory/inputs/task/default/` contains only `.gitkeep`
 
 That state matches the current landed repository truth for the four cited files.
+No approved archival surface was required because the solved request markdown is
+already absent from the live inboxes, and both canonical sentinels remain
+present and unchanged.
 
 ## Validation
 

--- a/docs/processes/factory-workstation-relevant-files.md
+++ b/docs/processes/factory-workstation-relevant-files.md
@@ -13,6 +13,7 @@ work inputs.
 | `docs/development/root-factory-artifact-contract-inventory.md` | Checked-in artifact inventory | Documents which root-level factory artifacts are checked in, generated, or obsolete. |
 | `docs/guides/batch-inputs.md` | Canonical batch request guide | Defines when to author `FACTORY_REQUEST_BATCH` JSON and where those files belong. |
 | `factory/inputs/idea/default/` | Standalone idea inbox | Checked-in inbox kept present by `.gitkeep`; standalone idea submissions land here as markdown files. |
+| `factory/inputs/task/default/` | Standalone task inbox | Checked-in inbox kept present by `.gitkeep`; standalone task submissions land here as markdown files. |
 | `factory/inputs/BATCH/default/` | Ordered or mixed-work-type request inbox | Canonical placement for `FACTORY_REQUEST_BATCH` JSON when operators need dependency ordering or mixed work types. |
 | `factory/workstations/cleaner/AGENTS.md` | Active cleanup workstation prompt | Should cite only checked-in workflow docs and the live idea or batch inboxes. |
 | `factory/workstations/ideafy/AGENTS.md` | Active ideation workstation prompt | Should default to one standalone idea markdown output and reserve batch JSON output for dependency-ordered or mixed-work-type follow-up. |
@@ -20,7 +21,9 @@ work inputs.
 ## Notes for future iterations
 
 - Treat `factory/inputs/idea/default/` as the live standalone idea inbox, not as a checked-in template catalog; clean checkouts may only contain `.gitkeep`.
+- Treat `factory/inputs/task/default/` as the live standalone task inbox, not as a checked-in template catalog; clean checkouts may only contain `.gitkeep`.
 - Treat `factory/logs/meta/asks.md` as the only checked-in customer-ask backlog; if another path mentions asks, use this file as the ownership source of truth.
+- Before redispatching a checked-in workflow-input markdown file, verify that the lane is not already landed on `main`; stale inbox residue should be treated as cleanup, not as a fresh request.
 - When a legacy maintainer path must remain for compatibility, reduce it to a redirect-only stub that names the canonical checked-in surface and carries no duplicated backlog content.
 - If a legacy checked-in path remains as a redirect-only stub, classify that stub explicitly in `docs/development/root-factory-artifact-contract-inventory.md` and `internal/testpath/artifact_contract.go` so the redirect contract stays test-enforced.
 - If a redirect-only stub protects a canonical maintainer surface, add a content-level regression test for the stub text in `pkg/testutil/artifact_contract_test.go`; inventory classification alone does not prevent drift back into a live duplicate surface.


### PR DESCRIPTION
## Summary
- record landed-state proof for the four cited solved workflow-input files
- document that the live idea/task inboxes are already correctly reduced to their .gitkeep sentinels
- capture the reusable inbox contract and scope guard so the branch stays limited to inbox hygiene

## Checks
- make test
- make lint