### PR TITLE
dedupe-root-factory-artifact-contract-entries

### DIFF
--- a/docs/development/root-factory-artifact-contract-inventory.md
+++ b/docs/development/root-factory-artifact-contract-inventory.md
@@ -34,7 +34,7 @@ matter to the targeted contract tests in `pkg/api`, `pkg/config`, `pkg/replay`,
 | `factory/inputs/thoughts/default/.gitkeep` | `checked_in` | Tracked sentinel that keeps the canonical thought inbox present in clean checkouts. |
 | `factory/logs/meta/asks.md` | `checked_in` | Canonical checked-in customer-ask backlog for the meta and cleaner workflow. |
 | `factory/logs/meta/view.md` | `checked_in` | Checked-in meta world-state view consumed by the cleaner workflow. |
-| `factory/logs/meta/progress.txt` | `checked_in` | Checked-in meta progress surface consumed by the cleaner workflow. |
+| `factory/logs/meta/progress.tsx` | `checked_in` | Checked-in meta progress surface consumed by the cleaner workflow. |
 | `factory/logs/agent-fails.json` | `checked_in` | Event-stream sample for replay artifact conversion coverage. |
 | `factory/logs/agent-fails.replay.json` | `checked_in` | Replay artifact sample paired with `agent-fails.json`. |
 | `factory/meta/asks.md` | `checked_in` | Redirect-only legacy stub that points maintainers back to `factory/logs/meta/asks.md` so a second live ask backlog cannot drift. |

--- a/docs/processes/contract-guard-relevant-files.md
+++ b/docs/processes/contract-guard-relevant-files.md
@@ -15,3 +15,4 @@ This file inventories the broad contract guards that scan filesystem roots with 
 
 - Broad handwritten-source guards should keep package-specific generated-path exclusions explicit at each `contractguard.ShouldSkipDir(...)` call site even when hidden-directory handling is shared.
 - The inventory separates handwritten-source scans from generated-output exclusions so future guard cleanup can document ownership decisions in code and in this file together.
+- Ordered contract inventories should assert normalized path uniqueness in the code-owned source before comparing mirrored docs, so duplicate entries fail at the mechanism instead of surfacing later as doc drift.

--- a/docs/processes/contract-guard-relevant-files.md
+++ b/docs/processes/contract-guard-relevant-files.md
@@ -15,4 +15,3 @@ This file inventories the broad contract guards that scan filesystem roots with 
 
 - Broad handwritten-source guards should keep package-specific generated-path exclusions explicit at each `contractguard.ShouldSkipDir(...)` call site even when hidden-directory handling is shared.
 - The inventory separates handwritten-source scans from generated-output exclusions so future guard cleanup can document ownership decisions in code and in this file together.
-- Ordered contract inventories should assert normalized path uniqueness in the code-owned source before comparing mirrored docs, so duplicate entries fail at the mechanism instead of surfacing later as doc drift.

--- a/factory/workstations/cleaner/AGENTS.md
+++ b/factory/workstations/cleaner/AGENTS.md
@@ -19,7 +19,7 @@ stub and do not read or edit it as a second backlog surface.
 run git pull and make the workspace be up to date to remote
 
 ## Step 1 - read
-0. read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`, `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`, and `factory/logs/agent-fails.replay.json` to understand the current repository-maintainer workflow state before proposing cleanup work
+0. read `factory/logs/meta/view.md`, `factory/logs/meta/progress.tsx`, `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`, and `factory/logs/agent-fails.replay.json` to understand the current repository-maintainer workflow state before proposing cleanup work
 1. read `docs/standards/STANDARDS.md`, `factory/README.md`, `docs/development/root-factory-artifact-contract-inventory.md`, `docs/processes/factory-workstation-relevant-files.md`, and `docs/guides/batch-inputs.md` so your cleanup ideas stay aligned with the repository's public workflow contract
 2. read the code under `./`, read recent PRs associated with your previous requests, and inspect the current checked-in workflow inputs under `factory/inputs/` to see any previous cleanup attempts that have already been made
 

--- a/internal/testpath/artifact_contract.go
+++ b/internal/testpath/artifact_contract.go
@@ -106,6 +106,11 @@ var artifactContractEntries = []ArtifactContractEntry{
 		Reason:         "Checked-in meta world-state view consumed by the cleaner workflow.",
 	},
 	{
+		Path:           "factory/logs/meta/progress.tsx",
+		Classification: ArtifactCheckedIn,
+		Reason:         "Checked-in meta progress surface consumed by the cleaner workflow.",
+	},
+	{
 		Path:           "factory/logs/agent-fails.json",
 		Classification: ArtifactCheckedIn,
 		Reason:         "Checked-in event-stream sample used for replay conversion coverage.",

--- a/pkg/testutil/artifact_contract_test.go
+++ b/pkg/testutil/artifact_contract_test.go
@@ -40,6 +40,7 @@ func TestArtifactContractInventory_ClassifiesTargetedRootArtifacts(t *testing.T)
 func TestArtifactContractInventory_DocumentationMatchesClassifications(t *testing.T) {
 	docEntries := parseArtifactContractInventoryDoc(t)
 	codeEntries := ArtifactContract()
+	assertUniqueNormalizedArtifactContractPaths(t, codeEntries)
 
 	if len(docEntries) != len(codeEntries) {
 		t.Fatalf("inventory doc entries = %d, want %d", len(docEntries), len(codeEntries))
@@ -128,6 +129,19 @@ func normalizeArtifactContractDocPath(path string) string {
 		return ""
 	}
 	return strings.TrimSuffix(normalized, "/")
+}
+
+func assertUniqueNormalizedArtifactContractPaths(t *testing.T, entries []ArtifactContractEntry) {
+	t.Helper()
+
+	seen := make(map[string]int, len(entries))
+	for i, entry := range entries {
+		normalized := normalizeArtifactContractDocPath(entry.Path)
+		if firstIndex, ok := seen[normalized]; ok {
+			t.Fatalf("artifact contract contains duplicate normalized path %q at entries[%d] and entries[%d]", normalized, firstIndex, i)
+		}
+		seen[normalized] = i
+	}
 }
 
 func assertCheckedInArtifactTracked(t *testing.T, repoRoot string, rel string) {


### PR DESCRIPTION
## Summary
- dedupe the checked-in root-factory meta artifact entries in the code-owned contract
- add a duplicate-normalized-path regression guard to the artifact-contract inventory test
- realign the checked-in inventory doc and related prompt/process references

## Verification
- make artifact-contract-closeout
- make lint