### PR TITLE
retire-verbose-logger-export

### DIFF
--- a/docs/processes/development-guide-relevant-files.md
+++ b/docs/processes/development-guide-relevant-files.md
@@ -72,6 +72,7 @@ This inventory records the checked-in files and directories that the maintainer 
 - When maintainer docs describe command execution, anchor the instructions to the repository root that contains `go.mod` and `Makefile`.
 - If a workflow temporarily changes directories, state that it starts from the repository root and why the subdirectory hop is required.
 - When GitHub Actions or other automation is added, prefer repository-owned root commands or package scripts that the maintainer guide already documents instead of inventing CI-only command sequences.
+- When a backend cleanup narrows an exported seam without changing caller behavior, keep regression coverage at the owning package's public helper boundary and assert observable forwarding or no-op behavior instead of symbol-name, reflection, or source-inventory checks.
 - When the CLI docs command surface changes, update `README.md` in the same pass and keep its command examples aligned with the guard assertions in `pkg/cli/root_test.go`.
 - When contributor docs mention the repository CI workflow, mirror the exact root-level command sequence and its stated scope from `.github/workflows/ci.yml` so local reproduction and review expectations do not drift.
 - When the repository adds or changes release automation, keep the workflow trigger model and maintainer commands aligned with `docs/guides/cli-release-policy.md` so tags, documentation, and GitHub Actions do not describe conflicting release paths.

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -13,9 +13,9 @@ type Logger interface {
 	Error(msg string, keysAndValues ...any)
 }
 
-// VerboseLogger is an optional extension for loggers that can emit records
+// verboseLogger is an optional extension for loggers that can emit records
 // only when the caller explicitly enabled verbose runtime diagnostics.
-type VerboseLogger interface {
+type verboseLogger interface {
 	Logger
 	Verbose(msg string, keysAndValues ...any)
 }
@@ -42,7 +42,7 @@ func EnsureLogger(l Logger) Logger {
 // Verbose emits a verbose-only log record when the logger supports that
 // optional mode. Plain Logger implementations ignore verbose records.
 func Verbose(l Logger, msg string, keysAndValues ...any) {
-	if logger, ok := l.(VerboseLogger); ok {
+	if logger, ok := l.(verboseLogger); ok {
 		logger.Verbose(msg, keysAndValues...)
 	}
 }

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -19,6 +19,23 @@ func (s *spyLogger) Info(msg string, _ ...any)  { s.infoCalls = append(s.infoCal
 func (s *spyLogger) Warn(msg string, _ ...any)  { s.warnCalls = append(s.warnCalls, msg) }
 func (s *spyLogger) Error(msg string, _ ...any) { s.errorCalls = append(s.errorCalls, msg) }
 
+type verboseCall struct {
+	msg           string
+	keysAndValues []any
+}
+
+type verboseSpyLogger struct {
+	spyLogger
+	verboseCalls []verboseCall
+}
+
+func (s *verboseSpyLogger) Verbose(msg string, keysAndValues ...any) {
+	s.verboseCalls = append(s.verboseCalls, verboseCall{
+		msg:           msg,
+		keysAndValues: append([]any(nil), keysAndValues...),
+	})
+}
+
 func TestSpyLogger_ImplementsLogger(t *testing.T) {
 	var l Logger = &spyLogger{}
 	l.Debug("debug msg", "key", "value")
@@ -58,6 +75,38 @@ func TestEnsureLogger_NonNilReturnsSame(t *testing.T) {
 	l := EnsureLogger(spy)
 	if l != spy {
 		t.Error("expected EnsureLogger to return the same logger when non-nil")
+	}
+}
+
+func TestVerbose_ForwardsToVerboseCapableLogger(t *testing.T) {
+	logger := &verboseSpyLogger{}
+
+	Verbose(logger, "verbose message", "worker", "alpha", "attempt", 2)
+
+	if len(logger.verboseCalls) != 1 {
+		t.Fatalf("expected 1 verbose call, got %d", len(logger.verboseCalls))
+	}
+	if logger.verboseCalls[0].msg != "verbose message" {
+		t.Fatalf("expected verbose message to be forwarded, got %q", logger.verboseCalls[0].msg)
+	}
+	expectedFields := []any{"worker", "alpha", "attempt", 2}
+	if len(logger.verboseCalls[0].keysAndValues) != len(expectedFields) {
+		t.Fatalf("expected %d verbose fields, got %d", len(expectedFields), len(logger.verboseCalls[0].keysAndValues))
+	}
+	for i, field := range expectedFields {
+		if logger.verboseCalls[0].keysAndValues[i] != field {
+			t.Fatalf("expected verbose field %d to be %#v, got %#v", i, field, logger.verboseCalls[0].keysAndValues[i])
+		}
+	}
+}
+
+func TestVerbose_IgnoresPlainLogger(t *testing.T) {
+	logger := &spyLogger{}
+
+	Verbose(logger, "verbose message", "worker", "alpha")
+
+	if len(logger.debugCalls) != 0 || len(logger.infoCalls) != 0 || len(logger.warnCalls) != 0 || len(logger.errorCalls) != 0 {
+		t.Fatalf("expected plain logger to ignore verbose emission, got debug=%v info=%v warn=%v error=%v", logger.debugCalls, logger.infoCalls, logger.warnCalls, logger.errorCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary
- retire the exported verbose-capability interface from pkg/logging`n- keep logging.Verbose(...) as the only public verbose helper seam
- add focused helper regression coverage that proves verbose forwarding and plain-logger no-op behavior

## Verification
- make lint
- make test