### PR TITLE
inline-workstation-runtime-lookup-key-fallback

### DIFF
--- a/pkg/factory/workstationconfig/runtime_lookup.go
+++ b/pkg/factory/workstationconfig/runtime_lookup.go
@@ -5,29 +5,27 @@ import (
 	"github.com/portpowered/infinite-you/pkg/petri"
 )
 
-// lookupKey returns the canonical authored workstation key for transition-owned
-// topology metadata, preferring Name and falling back to ID.
-func lookupKey(transition *petri.Transition) string {
-	if transition == nil {
-		return ""
-	}
-	if transition.Name != "" {
-		return transition.Name
-	}
-	return transition.ID
-}
-
 // Workstation returns the runtime workstation definition for a transition,
 // falling back from Name to ID in one place.
 func Workstation(transition *petri.Transition, runtimeConfig interfaces.RuntimeWorkstationLookup) (*interfaces.FactoryWorkstationConfig, bool) {
 	if transition == nil || runtimeConfig == nil {
 		return nil, false
 	}
-	for _, key := range lookupKeys(transition) {
-		workstation, ok := runtimeConfig.Workstation(key)
+
+	if transition.Name != "" {
+		workstation, ok := runtimeConfig.Workstation(transition.Name)
 		if ok && workstation != nil {
 			return workstation, true
 		}
+	}
+
+	if transition.ID == "" || transition.ID == transition.Name {
+		return nil, false
+	}
+
+	workstation, ok := runtimeConfig.Workstation(transition.ID)
+	if ok && workstation != nil {
+		return workstation, true
 	}
 	return nil, false
 }
@@ -48,18 +46,4 @@ func MaxRetries(transition *petri.Transition, runtimeConfig interfaces.RuntimeWo
 		return 0
 	}
 	return workstation.Limits.MaxRetries
-}
-
-func lookupKeys(transition *petri.Transition) []string {
-	if transition == nil {
-		return nil
-	}
-	key := lookupKey(transition)
-	if key == "" {
-		return nil
-	}
-	if transition.ID == "" || transition.ID == key {
-		return []string{key}
-	}
-	return []string{key, transition.ID}
 }

--- a/pkg/factory/workstationconfig/runtime_lookup_test.go
+++ b/pkg/factory/workstationconfig/runtime_lookup_test.go
@@ -1,0 +1,117 @@
+package workstationconfig
+
+import (
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/petri"
+	"github.com/portpowered/infinite-you/pkg/testutil/runtimefixtures"
+)
+
+func TestWorkstationReturnsFalseForNilInputs(t *testing.T) {
+	t.Parallel()
+
+	runtimeConfig := runtimefixtures.RuntimeWorkstationLookupFixture{
+		Workstations: map[string]*interfaces.FactoryWorkstationConfig{
+			"review": {Name: "Review", Kind: interfaces.WorkstationTypeLogical, Type: interfaces.WorkstationTypeLogical},
+		},
+	}
+
+	workstation, ok := Workstation(nil, runtimeConfig)
+	if ok || workstation != nil {
+		t.Fatalf("Workstation(nil, runtimeConfig) = (%#v, %t), want (nil, false)", workstation, ok)
+	}
+
+	workstation, ok = Workstation(&petri.Transition{Name: "review"}, nil)
+	if ok || workstation != nil {
+		t.Fatalf("Workstation(transition, nil) = (%#v, %t), want (nil, false)", workstation, ok)
+	}
+}
+
+func TestWorkstationPrefersTransitionName(t *testing.T) {
+	t.Parallel()
+
+	runtimeConfig := runtimefixtures.RuntimeWorkstationLookupFixture{
+		Workstations: map[string]*interfaces.FactoryWorkstationConfig{
+			"authored-name": {Name: "Authored Name", Kind: interfaces.WorkstationTypeLogical, Type: interfaces.WorkstationTypeLogical},
+			"transition-id": {Name: "Transition ID", Kind: interfaces.WorkstationTypeModel, Type: interfaces.WorkstationTypeModel},
+		},
+	}
+
+	workstation, ok := Workstation(&petri.Transition{Name: "authored-name", ID: "transition-id"}, runtimeConfig)
+	if !ok || workstation == nil {
+		t.Fatalf("Workstation(name-hit) = (%#v, %t), want configured workstation", workstation, ok)
+	}
+	if workstation.Name != "Authored Name" {
+		t.Fatalf("Workstation(name-hit).Name = %q, want %q", workstation.Name, "Authored Name")
+	}
+}
+
+func TestWorkstationFallsBackToIDWhenNameEmpty(t *testing.T) {
+	t.Parallel()
+
+	runtimeConfig := runtimefixtures.RuntimeWorkstationLookupFixture{
+		Workstations: map[string]*interfaces.FactoryWorkstationConfig{
+			"transition-id": {Name: "Transition ID", Kind: interfaces.WorkstationTypeModel, Type: interfaces.WorkstationTypeModel},
+		},
+	}
+
+	workstation, ok := Workstation(&petri.Transition{ID: "transition-id"}, runtimeConfig)
+	if !ok || workstation == nil {
+		t.Fatalf("Workstation(id-only) = (%#v, %t), want configured workstation", workstation, ok)
+	}
+	if workstation.Name != "Transition ID" {
+		t.Fatalf("Workstation(id-only).Name = %q, want %q", workstation.Name, "Transition ID")
+	}
+}
+
+func TestWorkstationFallsBackToDistinctIDAfterNameMiss(t *testing.T) {
+	t.Parallel()
+
+	runtimeConfig := runtimefixtures.RuntimeWorkstationLookupFixture{
+		Workstations: map[string]*interfaces.FactoryWorkstationConfig{
+			"transition-id": {
+				Name: "Transition ID",
+				Kind: interfaces.WorkstationTypeModel,
+				Type: interfaces.WorkstationTypeModel,
+				Limits: interfaces.WorkstationLimits{
+					MaxRetries: 4,
+				},
+			},
+		},
+	}
+
+	transition := &petri.Transition{Name: "missing-name", ID: "transition-id"}
+
+	workstation, ok := Workstation(transition, runtimeConfig)
+	if !ok || workstation == nil {
+		t.Fatalf("Workstation(name-miss-id-hit) = (%#v, %t), want configured workstation", workstation, ok)
+	}
+	if workstation.Name != "Transition ID" {
+		t.Fatalf("Workstation(name-miss-id-hit).Name = %q, want %q", workstation.Name, "Transition ID")
+	}
+	if got := Kind(transition, runtimeConfig); got != interfaces.WorkstationTypeModel {
+		t.Fatalf("Kind(name-miss-id-hit) = %q, want %q", got, interfaces.WorkstationTypeModel)
+	}
+	if got := MaxRetries(transition, runtimeConfig); got != 4 {
+		t.Fatalf("MaxRetries(name-miss-id-hit) = %d, want %d", got, 4)
+	}
+}
+
+func TestWorkstationKindAndMaxRetriesReturnZeroValuesWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	runtimeConfig := runtimefixtures.RuntimeWorkstationLookupFixture{}
+	transition := &petri.Transition{Name: "missing-name", ID: "missing-id"}
+
+	workstation, ok := Workstation(transition, runtimeConfig)
+	if ok || workstation != nil {
+		t.Fatalf("Workstation(missing) = (%#v, %t), want (nil, false)", workstation, ok)
+	}
+	if got := Kind(transition, runtimeConfig); got != "" {
+		t.Fatalf("Kind(missing) = %q, want empty kind", got)
+	}
+	if got := MaxRetries(transition, runtimeConfig); got != 0 {
+		t.Fatalf("MaxRetries(missing) = %d, want 0", got)
+	}
+}

--- a/pkg/factory/workstationconfig/runtime_lookup_test.go
+++ b/pkg/factory/workstationconfig/runtime_lookup_test.go
@@ -33,17 +33,32 @@ func TestWorkstationPrefersTransitionName(t *testing.T) {
 
 	runtimeConfig := runtimefixtures.RuntimeWorkstationLookupFixture{
 		Workstations: map[string]*interfaces.FactoryWorkstationConfig{
-			"authored-name": {Name: "Authored Name", Kind: interfaces.WorkstationTypeLogical, Type: interfaces.WorkstationTypeLogical},
+			"authored-name": {
+				Name: "Authored Name",
+				Kind: interfaces.WorkstationTypeLogical,
+				Type: interfaces.WorkstationTypeLogical,
+				Limits: interfaces.WorkstationLimits{
+					MaxRetries: 2,
+				},
+			},
 			"transition-id": {Name: "Transition ID", Kind: interfaces.WorkstationTypeModel, Type: interfaces.WorkstationTypeModel},
 		},
 	}
 
-	workstation, ok := Workstation(&petri.Transition{Name: "authored-name", ID: "transition-id"}, runtimeConfig)
+	transition := &petri.Transition{Name: "authored-name", ID: "transition-id"}
+
+	workstation, ok := Workstation(transition, runtimeConfig)
 	if !ok || workstation == nil {
 		t.Fatalf("Workstation(name-hit) = (%#v, %t), want configured workstation", workstation, ok)
 	}
 	if workstation.Name != "Authored Name" {
 		t.Fatalf("Workstation(name-hit).Name = %q, want %q", workstation.Name, "Authored Name")
+	}
+	if got := Kind(transition, runtimeConfig); got != interfaces.WorkstationTypeLogical {
+		t.Fatalf("Kind(name-hit) = %q, want %q", got, interfaces.WorkstationTypeLogical)
+	}
+	if got := MaxRetries(transition, runtimeConfig); got != 2 {
+		t.Fatalf("MaxRetries(name-hit) = %d, want %d", got, 2)
 	}
 }
 
@@ -52,16 +67,31 @@ func TestWorkstationFallsBackToIDWhenNameEmpty(t *testing.T) {
 
 	runtimeConfig := runtimefixtures.RuntimeWorkstationLookupFixture{
 		Workstations: map[string]*interfaces.FactoryWorkstationConfig{
-			"transition-id": {Name: "Transition ID", Kind: interfaces.WorkstationTypeModel, Type: interfaces.WorkstationTypeModel},
+			"transition-id": {
+				Name: "Transition ID",
+				Kind: interfaces.WorkstationTypeModel,
+				Type: interfaces.WorkstationTypeModel,
+				Limits: interfaces.WorkstationLimits{
+					MaxRetries: 3,
+				},
+			},
 		},
 	}
 
-	workstation, ok := Workstation(&petri.Transition{ID: "transition-id"}, runtimeConfig)
+	transition := &petri.Transition{ID: "transition-id"}
+
+	workstation, ok := Workstation(transition, runtimeConfig)
 	if !ok || workstation == nil {
 		t.Fatalf("Workstation(id-only) = (%#v, %t), want configured workstation", workstation, ok)
 	}
 	if workstation.Name != "Transition ID" {
 		t.Fatalf("Workstation(id-only).Name = %q, want %q", workstation.Name, "Transition ID")
+	}
+	if got := Kind(transition, runtimeConfig); got != interfaces.WorkstationTypeModel {
+		t.Fatalf("Kind(id-only) = %q, want %q", got, interfaces.WorkstationTypeModel)
+	}
+	if got := MaxRetries(transition, runtimeConfig); got != 3 {
+		t.Fatalf("MaxRetries(id-only) = %d, want %d", got, 3)
 	}
 }
 


### PR DESCRIPTION
## Summary
- inline runtime workstation name-to-id fallback ownership into Workstation(...)
- preserve derived Kind(...) and MaxRetries(...) behavior
- cover nil, name-hit, id-only, and name-miss/id-hit cases with focused package-local tests

## Verification
- go test ./pkg/factory/workstationconfig -count=1
- make lint
- make test
