### PR TITLE
trim-submit-work-card-intro-copy

### DIFF
--- a/ui/src/features/submit-work/submit-work-card.stories.tsx
+++ b/ui/src/features/submit-work/submit-work-card.stories.tsx
@@ -42,6 +42,9 @@ export const Configured = {
     const card = await canvas.findByRole("article", { name: "Submit work" });
     const scope = within(card);
 
+    await expect(
+      scope.queryByText("Send a new request to the current factory from the dashboard."),
+    ).toBeNull();
     const workType = scope.getByRole("combobox", { name: "Work type" });
     const requestName = scope.getByRole("textbox", { name: "Request name" });
     const requestText = scope.getByRole("textbox", { name: "Request" });
@@ -107,4 +110,3 @@ export const FailureRetry = {
     await expect(scope.getByRole("button", { name: "Submit work" })).toBeEnabled();
   },
 };
-

--- a/ui/src/features/submit-work/submit-work-card.tsx
+++ b/ui/src/features/submit-work/submit-work-card.tsx
@@ -5,7 +5,6 @@ import {
   DASHBOARD_SUPPORTING_TEXT_CLASS,
 } from "../../components/dashboard/typography";
 import { Button, DashboardWidgetFrame, Input, Select, Textarea } from "../../components/ui";
-import { WIDGET_SUBTITLE_CLASS } from "../../components/dashboard/widget-board";
 
 export interface SubmitWorkDraft {
   requestName: string;
@@ -84,12 +83,6 @@ export function SubmitWorkCard({
           onSubmit();
         }}
       >
-        <div className={FIELD_GROUP_CLASS}>
-          <p className={WIDGET_SUBTITLE_CLASS}>
-            Send a new request to the current factory from the dashboard.
-          </p>
-        </div>
-
         <div className={FIELD_GROUP_CLASS}>
           <label className={FIELD_LABEL_CLASS} htmlFor={workTypeID}>
             Work type
@@ -174,4 +167,3 @@ export function SubmitWorkCard({
     </DashboardWidgetFrame>
   );
 }
-

--- a/ui/src/features/submit-work/submit-work-widget.test.tsx
+++ b/ui/src/features/submit-work/submit-work-widget.test.tsx
@@ -1,11 +1,33 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 
 import { SubmitWorkWidget } from "./submit-work-widget";
 
 describe("SubmitWorkWidget", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+  });
+
+  it("keeps the submit-work card focused on the form without the redundant subtitle", () => {
+    renderSubmitWorkWidget(
+      <SubmitWorkWidget
+        submitWorkTypes={[
+          { work_type_name: "story" },
+          { work_type_name: "task" },
+        ]}
+      />,
+    );
+
+    const card = screen.getByRole("article", { name: "Submit work" });
+
+    expect(screen.queryByText("Send a new request to the current factory from the dashboard.")).toBeNull();
+    expect(within(card).getByRole("combobox", { name: "Work type" })).toBeTruthy();
+    expect(within(card).getByRole("textbox", { name: "Request name" })).toBeTruthy();
+    expect(within(card).getByRole("textbox", { name: "Request" })).toBeTruthy();
+    expect(
+      within(card).getByText("Choose a work type and describe what you need to get started."),
+    ).toBeTruthy();
+    expect(within(card).getByRole("button", { name: "Submit work" })).toBeTruthy();
   });
 
   it("disables submission until a configured work type and request text are present", () => {
@@ -218,4 +240,3 @@ function renderSubmitWorkWidget(element: React.ReactElement) {
 
   return render(<QueryClientProvider client={queryClient}>{element}</QueryClientProvider>);
 }
-


### PR DESCRIPTION
{
  "project": "Infinite You",
  "branchName": "ralph/trim-submit-work-card-intro-copy",
  "description": "Infinite You is an AI agent factory for scheduling and orchestrating many AI workers concurrently. This change trims redundant instructional copy from the dashboard submit-work card by removing the static subtitle, preserving the current form, validation, and submission behavior, and updating rendered UI coverage so the simplified card remains proven through observable behavior.",
  "context": {
    "customerAsk": "Simplify the submit-work dashboard card by removing redundant instructional copy that adds noise without improving the actual submission flow.",
    "problem": "The submit-work dashboard card still renders the sentence `Send a new request to the current factory from the dashboard.` even though the card title, field labels, placeholders, validation messages, and status guidance already explain the flow. The extra subtitle makes the card taller and noisier without adding new information.",
    "solution": "Remove the static subtitle from the submit-work card, keep the rest of the card content and submission flow unchanged, and update rendered UI coverage so tests prove the sentence is gone while the existing guidance, validation, and successful submission behavior remain intact."
  },
  "acceptanceCriteria": [
    "AC-1: The submit-work dashboard card no longer renders the sentence `Send a new request to the current factory from the dashboard.`.",
    "AC-2: The card still renders the `Submit work` title, form fields, status guidance, and submit action correctly after the subtitle removal.",
    "AC-3: Any wrapper markup or imports that exist only to support the removed subtitle are simplified without changing the card's remaining layout or semantics.",
    "AC-4: Component or story coverage proves the rendered card no longer shows the redundant subtitle while preserving validation, submission, and returned-status behavior.",
    "AC-5: The implementation remains scoped to the submit-work dashboard UI lane and does not widen into unrelated copy, contract, or workflow changes.",
    "AC-6: Quality checks pass (typecheck, lint, tests)."
  ],
  "userStories": [
    {
      "id": "US-001",
      "title": "Remove the redundant submit-work subtitle while preserving the card flow",
      "description": "As a dashboard user, I want the submit-work card to show only the copy that helps me complete the form so the card feels clearer without changing how I submit work.",
      "acceptanceCriteria": [
        "The rendered submit-work card no longer shows `Send a new request to the current factory from the dashboard.`.",
        "The card still renders the `Submit work` title, `Work type`, `Request name`, and `Request` fields, status guidance, and `Submit work` button.",
        "Removing the subtitle does not change the existing validation outcomes for incomplete drafts.",
        "Removing the subtitle does not change the successful submission flow, including the busy state, submitted payload shape, success message, and cleared draft.",
        "Any wrapper element or import used only for the removed subtitle is deleted or simplified without changing the remaining card semantics.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    }
  ]
}
