### PR TITLE
trim-starter-input-readme-contract

### DIFF
--- a/pkg/cli/init/init_test.go
+++ b/pkg/cli/init/init_test.go
@@ -601,6 +601,30 @@ func assertInitScaffoldFilesCanonical(t *testing.T, base, wantModel, wantProvide
 		}
 	}
 
+	inputsReadmePath := filepath.Join(base, "inputs", "README.md")
+	inputsReadmeBytes, err := os.ReadFile(inputsReadmePath)
+	if err != nil {
+		t.Fatalf("read generated inputs README.md: %v", err)
+	}
+	inputsReadme := string(inputsReadmeBytes)
+	for _, expected := range []string{
+		"inputs/task/default/",
+		"Seed your starter work by adding files to this inbox",
+	} {
+		if !strings.Contains(inputsReadme, expected) {
+			t.Fatalf("generated inputs README.md should contain %q:\n%s", expected, inputsReadme)
+		}
+	}
+	for _, retired := range []string{
+		"inputs/<work-type>/default/",
+		"inputs/<work-type>/<execution-id>/",
+		"Multi-channel input directory for work submissions.",
+	} {
+		if strings.Contains(inputsReadme, retired) {
+			t.Fatalf("generated inputs README.md should not contain retired starter prose %q:\n%s", retired, inputsReadme)
+		}
+	}
+
 	workerAgentsPath := filepath.Join(base, "workers", "processor", "AGENTS.md")
 	workerAgentsBytes, err := os.ReadFile(workerAgentsPath)
 	if err != nil {

--- a/pkg/cli/init/scaffolds.go
+++ b/pkg/cli/init/scaffolds.go
@@ -102,15 +102,10 @@ Each subdirectory contains an AGENTS.md defining the workstation prompt template
 `,
 			factoryInputsDirName + "/README.md": `# Inputs
 
-Multi-channel input directory for work submissions.
-
-Default local task path:
+Use the default starter inbox for local task submissions:
   inputs/task/default/                 - Markdown or JSON task submissions
 
-General layout:
-  inputs/<work-type>/default/          - manual submissions
-  inputs/<work-type>/<execution-id>/   - executor-generated work
-
+Seed your starter work by adding files to this inbox, then run the starter to process them.
 The file watcher monitors this directory tree and automatically watches new subdirectories.
 `,
 			factoryWorkersDirName + "/processor/" + factoryAgentsFileName: `---

--- a/tests/functional/bootstrap_portability/cli_init_factory_test.go
+++ b/tests/functional/bootstrap_portability/cli_init_factory_test.go
@@ -15,6 +15,11 @@ import (
 
 var retiredInitFactoryContractFields = []string{`"work_types"`, `"work_type"`, `"on_failure"`}
 var retiredInitWorkerContractFields = []string{"model_provider:", "provider:", "stop_token:", "skip_permissions:", "concurrency:", "sessionId:"}
+var retiredStarterReadmeFragments = []string{
+	"inputs/<work-type>/default/",
+	"inputs/<work-type>/<execution-id>/",
+	"Multi-channel input directory for work submissions.",
+}
 
 // TestInitFactory_StructureIsValid verifies that the init command creates the
 // correct directory structure with all required files:
@@ -290,6 +295,25 @@ func assertGeneratedInitScaffoldCanonical(t *testing.T, dir, wantModel, wantProv
 	for _, retired := range retiredInitFactoryContractFields {
 		if strings.Contains(factoryJSON, retired) {
 			t.Fatalf("generated factory.json should not contain retired %q:\n%s", retired, factoryJSON)
+		}
+	}
+
+	inputsReadmeBytes, err := os.ReadFile(filepath.Join(dir, "inputs", "README.md"))
+	if err != nil {
+		t.Fatalf("read generated inputs README.md: %v", err)
+	}
+	inputsReadme := string(inputsReadmeBytes)
+	for _, expected := range []string{
+		"inputs/task/default/",
+		"Seed your starter work by adding files to this inbox",
+	} {
+		if !strings.Contains(inputsReadme, expected) {
+			t.Fatalf("generated inputs README.md should contain %q:\n%s", expected, inputsReadme)
+		}
+	}
+	for _, retired := range retiredStarterReadmeFragments {
+		if strings.Contains(inputsReadme, retired) {
+			t.Fatalf("generated inputs README.md should not contain retired starter prose %q:\n%s", retired, inputsReadme)
 		}
 	}
 


### PR DESCRIPTION
{
  "project": "Infinite You",
  "branchName": "ralph/trim-starter-input-readme-contract",
  "description": "Infinite You is an AI agent factory for scheduling and orchestrating many AI workers concurrently. This change trims the generated default starter `factory/inputs/README.md` down to the one canonical starter inbox contract by teaching `inputs/task/default/` as the out-of-the-box path, removing stale starter-facing generic multi-channel prose, and keeping scaffold plus bootstrap coverage aligned with the unchanged runtime behavior.",
  "context": {
    "customerAsk": "Trim the generated starter `factory/inputs/README.md` down to the one canonical starter inbox contract instead of continuing to teach the older generic multi-channel prose.",
    "problem": "PR `#80` already aligned the default starter flow around `inputs/task/default/`, but the generated starter scaffold still writes `factory/inputs/README.md` with generic `inputs/<work-type>/default/` and `inputs/<work-type>/<execution-id>/` guidance. That leaves the default starter teaching surface slightly out of sync with the docs, CLI help, and tests that now point at the canonical starter inbox path.",
    "solution": "Rewrite the default scaffold's generated `factory/inputs/README.md` so it centers `inputs/task/default/` as the one canonical starter inbox, remove stale starter-facing mentions of the older generic multi-channel layout, and update scaffold plus bootstrap-portability coverage so the generated README stays aligned with the unchanged starter runtime behavior."
  },
  "acceptanceCriteria": [
    "AC-1: A freshly generated starter scaffold writes `factory/inputs/README.md` that clearly names `inputs/task/default/` as the default starter inbox.",
    "AC-2: The generated starter README no longer teaches `inputs/<work-type>/<execution-id>/` as part of default starter onboarding.",
    "AC-3: The generated starter README keeps the default starter instructions focused on how to seed task work into the canonical inbox and run the starter successfully.",
    "AC-4: Init-scaffold coverage asserts the generated starter README matches the canonical starter inbox contract and omits the stale multi-channel starter prose.",
    "AC-5: Bootstrap-portability coverage still proves a fresh starter can seed work in `inputs/task/default/` and complete it successfully without changing routing or watcher behavior.",
    "AC-6: The implementation stays scoped to the default starter teaching surface and its verification, without widening into broader input-routing or multi-scaffold contract changes.",
    "AC-7: Quality checks pass (typecheck, lint, tests)."
  ],
  "userStories": [
    {
      "id": "US-001",
      "title": "Generate a starter inputs README that teaches only the canonical inbox",
      "description": "As a new Infinite You starter user, I want the generated `factory/inputs/README.md` to point me directly at `inputs/task/default/` so I can seed starter work without learning older generic path variants that are not needed for the default scaffold.",
      "acceptanceCriteria": [
        "A fresh default scaffold generates `factory/inputs/README.md` with `inputs/task/default/` identified as the default starter inbox.",
        "The generated README explains that starter task submissions belong in the canonical inbox and keeps the instructions sufficient to use the default scaffold successfully.",
        "The generated README does not teach `inputs/<work-type>/<execution-id>/` as part of the default starter onboarding text.",
        "The generated README does not reintroduce broad multi-channel wording that conflicts with the simplified starter contract.",
        "The starter scaffold's generated runtime behavior remains unchanged by the README rewrite.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "US-002",
      "title": "Keep scaffold and bootstrap coverage aligned with the canonical starter README",
      "description": "As a maintainer, I want init and bootstrap coverage to assert the simplified starter README contract while still proving seeded task work runs through the canonical inbox so that future starter copy drift is caught without changing watcher behavior.",
      "acceptanceCriteria": [
        "Init-focused coverage asserts that a freshly generated starter README contains `inputs/task/default/` and omits the retired generic starter prose.",
        "Bootstrap-portability coverage continues to seed a work item in `inputs/task/default/` and proves the starter completes it successfully.",
        "Coverage verifies the default starter contract through observable scaffold output and seeded-run behavior rather than meta assertions about unrelated source structure.",
        "Tests do not add or require a new routing, watcher, or execution-id contract for the default starter flow.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
