### PR TITLE
retire-replay-timeline-legacy-compat-duplication

### DIFF
--- a/ui/src/features/timeline/state/factoryTimelineStore.test.ts
+++ b/ui/src/features/timeline/state/factoryTimelineStore.test.ts
@@ -3106,6 +3106,192 @@ describe("factory timeline reconstruction", () => {
     });
   });
 
+  it("replays legacy dispatch payload fallbacks through active and completed workstation projections", () => {
+    const legacyWorkRequest = event(
+      "event-legacy-dispatch-work-request",
+      2,
+      FACTORY_EVENT_TYPES.workRequest,
+      {
+        source: "api",
+        type: "FACTORY_REQUEST_BATCH",
+        works: [
+          {
+            name: "Legacy Timeline Story",
+            trace_id: "trace-legacy",
+            work_id: "work-legacy",
+            work_type_id: "story",
+          },
+        ],
+      },
+    );
+    legacyWorkRequest.context.requestId = "request-legacy";
+    legacyWorkRequest.context.traceIds = ["trace-legacy"];
+    legacyWorkRequest.context.workIds = ["work-legacy"];
+
+    const legacyDispatchRequest = event(
+      "event-legacy-dispatch-request",
+      3,
+      FACTORY_EVENT_TYPES.dispatchRequest,
+      {
+        current_chaining_trace_id: "chain-legacy-current",
+        dispatchId: "dispatch-legacy",
+        inputs: [
+          {
+            name: "Legacy Timeline Story",
+            trace_id: "trace-legacy",
+            work_id: "work-legacy",
+            work_type_id: "story",
+          },
+        ],
+        previous_chaining_trace_ids: ["chain-legacy-a", "chain-legacy-b"],
+        transitionId: "review",
+        workstation: {
+          name: "Legacy Review",
+        },
+      },
+    );
+    legacyDispatchRequest.context.traceIds = ["trace-legacy"];
+    legacyDispatchRequest.context.workIds = ["work-legacy"];
+
+    const legacyDispatchResponse = event(
+      "event-legacy-dispatch-response",
+      4,
+      FACTORY_EVENT_TYPES.dispatchResponse,
+      {
+        current_chaining_trace_id: "chain-legacy-current",
+        diagnostics: {
+          provider: {
+            model: "gpt-5.4-mini",
+            provider: "openai",
+            requestMetadata: {
+              prompt_source: "legacy-review",
+            },
+            responseMetadata: {
+              provider_session_id: "legacy-session-1",
+            },
+          },
+        },
+        dispatchId: "dispatch-legacy",
+        durationMillis: 640,
+        outcome: "ACCEPTED",
+        output: "Legacy replay output",
+        outputWork: [
+          {
+            name: "Legacy Timeline Story",
+            previous_chaining_trace_ids: ["chain-legacy-a", "chain-legacy-b"],
+            state: "done",
+            trace_id: "trace-legacy",
+            work_id: "work-legacy",
+            work_type_id: "story",
+          },
+        ],
+        previous_chaining_trace_ids: ["chain-legacy-a", "chain-legacy-b"],
+        providerSession: {
+          id: "legacy-session-1",
+          kind: "session_id",
+          provider: "openai",
+        },
+        transitionId: "review",
+        workstation: {
+          name: "Legacy Review",
+        },
+      },
+    );
+    legacyDispatchResponse.context.traceIds = ["trace-legacy"];
+    legacyDispatchResponse.context.workIds = ["work-legacy"];
+    legacyDispatchResponse.context.eventTime = "2026-04-16T12:00:04Z";
+
+    const activeProjected = buildFactoryTimelineSnapshot(
+      [initialStructureRequest, legacyWorkRequest, legacyDispatchRequest],
+      3,
+    );
+    expect(
+      activeProjected.runtime.active_executions_by_dispatch_id?.["dispatch-legacy"],
+    ).toMatchObject({
+      workstation_name: "Legacy Review",
+    });
+    expect(
+      activeProjected.workstationRequestsByDispatchID["dispatch-legacy"],
+    ).toMatchObject({
+      dispatch_id: "dispatch-legacy",
+      request_view: {
+        current_chaining_trace_id: "chain-legacy-current",
+        input_work_items: [
+          {
+            display_name: "Legacy Timeline Story",
+            trace_id: "trace-legacy",
+            work_id: "work-legacy",
+            work_type_id: "story",
+          },
+        ],
+        previous_chaining_trace_ids: ["chain-legacy-a", "chain-legacy-b"],
+      },
+      workstation_name: "Legacy Review",
+    });
+
+    const completedProjected = buildFactoryTimelineSnapshot(
+      [
+        initialStructureRequest,
+        legacyWorkRequest,
+        legacyDispatchRequest,
+        legacyDispatchResponse,
+      ],
+      4,
+    );
+    expect(
+      completedProjected.workstationRequestsByDispatchID["dispatch-legacy"],
+    ).toMatchObject({
+      dispatch_id: "dispatch-legacy",
+      outcome: "ACCEPTED",
+      response: "Legacy replay output",
+      response_view: {
+        diagnostics: {
+          provider: {
+            model: "gpt-5.4-mini",
+            provider: "openai",
+            request_metadata: {
+              prompt_source: "legacy-review",
+            },
+            response_metadata: {
+              provider_session_id: "legacy-session-1",
+            },
+          },
+        },
+        output_work_items: [
+          {
+            display_name: "Legacy Timeline Story",
+            previous_chaining_trace_ids: ["chain-legacy-a", "chain-legacy-b"],
+            trace_id: "trace-legacy",
+            work_id: "work-legacy",
+            work_type_id: "story",
+          },
+        ],
+        provider_session: {
+          id: "legacy-session-1",
+          provider: "openai",
+        },
+      },
+      workstation_name: "Legacy Review",
+    });
+    expect(
+      completedProjected.tracesByWorkID["work-legacy"]?.dispatches[0],
+    ).toMatchObject({
+      current_chaining_trace_id: "chain-legacy-current",
+      previous_chaining_trace_ids: ["chain-legacy-a", "chain-legacy-b"],
+      workstation_name: "Legacy Review",
+    });
+    expect(
+      completedProjected.runtime.session.provider_sessions?.[0],
+    ).toMatchObject({
+      dispatch_id: "dispatch-legacy",
+      provider_session: {
+        id: "legacy-session-1",
+        provider: "openai",
+      },
+      workstation_name: "Legacy Review",
+    });
+  });
+
   it("projects script-aware workstation requests by dispatch id without inference-shaped fallbacks", () => {
     const projected = buildFactoryTimelineSnapshot(
       [

--- a/ui/src/features/timeline/state/timeline/replayWorldStateSupport.ts
+++ b/ui/src/features/timeline/state/timeline/replayWorldStateSupport.ts
@@ -3,12 +3,7 @@ import type {
   DashboardProviderSessionAttempt,
   DashboardTraceDispatch,
 } from "../../../../api/dashboard";
-import type {
-  DispatchResponsePayload,
-  InferenceRequestPayload,
-  InferenceResponsePayload,
-} from "../../../../api/events";
-import type { LegacyDispatchResponsePayloadCompat } from "./replayWorldStateTypes";
+import type { InferenceRequestPayload, InferenceResponsePayload } from "../../../../api/events";
 import type {
   ReplayWorldState,
   WorldCompletion,
@@ -172,12 +167,6 @@ export function scriptResponsesForDispatch(
   return responses;
 }
 
-export function legacyDispatchResponsePayload(
-  payload: DispatchResponsePayload,
-): LegacyDispatchResponsePayloadCompat {
-  return payload as DispatchResponsePayload & LegacyDispatchResponsePayloadCompat;
-}
-
 export function applyScriptRequest(
   state: ReplayWorldState,
   event: {
@@ -245,5 +234,3 @@ export function applyScriptResponse(
     transition_id: payload.transitionId,
   };
 }
-
-

--- a/ui/src/features/timeline/state/timeline/replayWorldStateTypes.ts
+++ b/ui/src/features/timeline/state/timeline/replayWorldStateTypes.ts
@@ -3,9 +3,6 @@ import type {
   DispatchResponsePayload,
   FactoryEvent,
   FactoryStateResponsePayload,
-  FactoryWork,
-  FactoryWorkDiagnostics,
-  FactoryWorker,
   InferenceRequestPayload,
   InferenceResponsePayload,
   InitialStructureRequestPayload,
@@ -15,7 +12,6 @@ import type {
   ScriptResponsePayload,
   WorkRequestPayload,
 } from "../../../../api/events";
-import type { WorldCompletion } from "./types";
 
 export type InitialStructureRequestEvent = FactoryEvent<InitialStructureRequestPayload>;
 export type RunRequestEvent = FactoryEvent<RunRequestPayload>;
@@ -28,23 +24,3 @@ export type ScriptRequestEvent = FactoryEvent<ScriptRequestPayload>;
 export type ScriptResponseEvent = FactoryEvent<ScriptResponsePayload>;
 export type DispatchResponseEvent = FactoryEvent<DispatchResponsePayload>;
 export type FactoryStateResponseEvent = FactoryEvent<FactoryStateResponsePayload>;
-
-export interface LegacyDispatchRequestPayloadCompat {
-  current_chaining_trace_id?: string;
-  dispatchId?: string;
-  inputs?: Array<FactoryWork | { workId: string }>;
-  previous_chaining_trace_ids?: string[];
-  worker?: FactoryWorker;
-  workstation?: { name?: string };
-}
-
-export interface LegacyDispatchResponsePayloadCompat {
-  current_chaining_trace_id?: string;
-  diagnostics?: FactoryWorkDiagnostics;
-  dispatchId?: string;
-  previous_chaining_trace_ids?: string[];
-  providerSession?: WorldCompletion["providerSession"];
-  workstation?: { name?: string };
-}
-
-


### PR DESCRIPTION
{
  "project": "Infinite You",
  "branchName": "ralph/retire-replay-timeline-legacy-compat-duplication",
  "description": "Infinite You is an AI agent factory for scheduling and orchestrating many AI workers concurrently. This change retires duplicated legacy replay-compat ownership in the timeline state layer by centralizing retired dispatch payload aliases and the legacy dispatch-response cast helper while preserving observable replay behavior for dispatch identity fallback, chaining lineage fallback, diagnostics or provider-session hydration, and workstation-name resolution.",
  "context": {
    "customerAsk": "Collapse the duplicated legacy replay-compat helpers in the timeline state layer so the replay path keeps one source of truth for retired dispatch payload fallbacks instead of scattering the same shim across multiple files.",
    "problem": "The timeline replay state layer still duplicates narrow legacy dispatch compatibility behavior across multiple files: `replayCompletion.ts` and `replayWorldStateTypes.ts` both define legacy dispatch compat payload aliases, `replayCompletion.ts` and `replayWorldStateSupport.ts` both define the same legacy dispatch-response cast helper, and `replayWorldState.ts` still depends on those shims on the live replay path. The behavior is correct today, but ownership is split, which makes replay parsing harder to audit and easier to drift the next time legacy event handling changes.",
    "solution": "Keep replay behavior unchanged, but reduce the legacy dispatch compatibility layer to one clear owner for payload aliases and one clear owner for the dispatch-response cast helper. Update replay consumers to use those single sources of truth and prove the cleanup through replay-derived runtime or rendered timeline outcomes covering dispatch ID fallback, chaining lineage fallback, diagnostics or provider-session hydration, and workstation-name resolution."
  },
  "acceptanceCriteria": [
    "AC-1: The replay timeline state layer has one clear owner for legacy dispatch compat payload aliases.",
    "AC-2: The replay timeline state layer has one clear owner for the legacy dispatch-response cast helper.",
    "AC-3: Replaying legacy dispatch request and response events still reconstructs the same dispatch identity and chaining lineage outcomes in active and completed timeline projections.",
    "AC-4: Replaying legacy dispatch responses still hydrates the same diagnostics or provider-session data and workstation labels visible through replay-derived state.",
    "AC-5: Verification for this cleanup asserts runtime or rendered replay outcomes rather than source-layout, helper-name, or file-topology checks.",
    "AC-6: Quality checks pass (typecheck, lint, tests)."
  ],
  "userStories": [
    {
      "id": "US-001",
      "title": "Centralize legacy dispatch replay compatibility ownership",
      "description": "As a maintainer, I want the replay timeline state layer to use one authoritative compat definition path for retired dispatch payload fallbacks so replay parsing changes only need to update one place.",
      "acceptanceCriteria": [
        "The replay timeline state layer uses one clear owner for legacy dispatch compat payload aliases instead of duplicating the request or response alias shapes across multiple files.",
        "The replay timeline state layer uses one clear owner for the legacy dispatch-response cast helper instead of keeping duplicate cast helpers in separate replay modules.",
        "`replayWorldState.ts` and related replay helpers continue resolving legacy dispatch IDs, current chaining trace IDs, previous chaining trace IDs, diagnostics or provider-session fields, and workstation-name fallback through the centralized compat ownership.",
        "The cleanup does not introduce a new exported compatibility abstraction, mutable shared state, or a second wrapper layer around replay dispatch parsing.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "US-002",
      "title": "Prove replayed legacy dispatch outcomes stay unchanged",
      "description": "As a maintainer, I want focused replay coverage for legacy dispatch events so I can verify the compatibility cleanup preserved observable timeline behavior.",
      "acceptanceCriteria": [
        "Add or update replay-focused tests that construct legacy dispatch request and response events and assert dispatch ID fallback still appears correctly in replay-derived active or completed dispatch state.",
        "Add or update replay-focused tests that assert legacy chaining lineage fallback still produces the same current and previous chaining trace values in replay-derived workstation requests, traces, or dispatch summaries.",
        "Add or update replay-focused tests that assert legacy dispatch responses still hydrate the same diagnostics or provider-session outcomes and workstation labels through replay-derived state.",
        "The verification checks runtime or rendered timeline outcomes and does not assert helper locations, duplicate removal mechanics, or internal function names.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
