### PR TITLE
Remove init scaffold default models

### DIFF
--- a/pkg/cli/init/init.go
+++ b/pkg/cli/init/init.go
@@ -66,16 +66,13 @@ func parseStarterExecutor(raw string) (starterExecutor, error) {
 }
 
 func defaultModelWorkerAgentsMD(executor starterExecutor) string {
-	model := "gpt-5-codex"
 	modelProvider := "CODEX"
 	if executor == StarterExecutorClaude {
-		model = "claude-sonnet-4-20250514"
 		modelProvider = "CLAUDE"
 	}
 
 	return fmt.Sprintf(`---
 type: MODEL_WORKER
-model: %s
 modelProvider: %s
 executorProvider: SCRIPT_WRAP
 resources:
@@ -84,7 +81,7 @@ resources:
 timeout: 1h
 skipPermissions: true
 ---
-%s`, model, modelProvider, defaultProcessorSystemBody)
+%s`, modelProvider, defaultProcessorSystemBody)
 }
 
 // Init creates the factory directory structure.

--- a/pkg/cli/init/init_test.go
+++ b/pkg/cli/init/init_test.go
@@ -127,11 +127,11 @@ func TestInit_CreatesDirectoryStructure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read generated worker AGENTS.md: %v", err)
 	}
-	if !strings.Contains(string(workerAgents), "model: gpt-5-codex") {
-		t.Fatalf("generated worker AGENTS.md = %q, want model: gpt-5-codex", string(workerAgents))
-	}
 	if !strings.Contains(string(workerAgents), "modelProvider: CODEX") {
 		t.Fatalf("generated worker AGENTS.md = %q, want modelProvider: CODEX", string(workerAgents))
+	}
+	if strings.Contains(string(workerAgents), "model:") {
+		t.Fatalf("generated worker AGENTS.md = %q, should not contain a default model", string(workerAgents))
 	}
 	if !strings.Contains(string(workerAgents), "executorProvider: SCRIPT_WRAP") {
 		t.Fatalf("generated worker AGENTS.md = %q, want executorProvider: SCRIPT_WRAP", string(workerAgents))
@@ -160,7 +160,7 @@ func TestInit_CreatesDirectoryStructure(t *testing.T) {
 	if strings.Contains(string(workerAgents), "timeout: 2h") {
 		t.Fatal("generated worker AGENTS.md should not use the subprocess fallback as the emitted default")
 	}
-	assertInitScaffoldFilesCanonical(t, base, "gpt-5-codex", "codex")
+	assertInitScaffoldFilesCanonical(t, base, "codex")
 
 	workstationAgentsPath := filepath.Join(base, "workstations", "process", "AGENTS.md")
 	if _, err := os.Stat(workstationAgentsPath); os.IsNotExist(err) {
@@ -188,11 +188,11 @@ func TestInit_ClaudeExecutorCreatesClaudeWorkerScaffold(t *testing.T) {
 	}
 
 	contents := string(workerAgents)
-	if !strings.Contains(contents, "model: claude-sonnet-4-20250514") {
-		t.Fatalf("generated worker AGENTS.md = %q, want Claude model scaffold", contents)
-	}
 	if !strings.Contains(contents, "modelProvider: CLAUDE") {
 		t.Fatalf("generated worker AGENTS.md = %q, want modelProvider: CLAUDE", contents)
+	}
+	if strings.Contains(contents, "model:") {
+		t.Fatalf("generated worker AGENTS.md = %q, should not contain a default model", contents)
 	}
 	if !strings.Contains(contents, "executorProvider: SCRIPT_WRAP") {
 		t.Fatalf("generated worker AGENTS.md = %q, want executorProvider: SCRIPT_WRAP", contents)
@@ -200,10 +200,7 @@ func TestInit_ClaudeExecutorCreatesClaudeWorkerScaffold(t *testing.T) {
 	if !strings.Contains(contents, defaultProcessorSystemBody) {
 		t.Fatalf("generated worker AGENTS.md = %q, want default processor system prompt", contents)
 	}
-	if strings.Contains(contents, "model: gpt-5-codex") {
-		t.Fatalf("generated worker AGENTS.md = %q, should not include default codex model", contents)
-	}
-	assertInitScaffoldFilesCanonical(t, base, "claude-sonnet-4-20250514", "claude")
+	assertInitScaffoldFilesCanonical(t, base, "claude")
 }
 
 func TestInit_LoadRuntimeConfigForDefaultScaffold(t *testing.T) {
@@ -214,7 +211,7 @@ func TestInit_LoadRuntimeConfigForDefaultScaffold(t *testing.T) {
 		t.Fatalf("Init: %v", err)
 	}
 
-	assertInitRuntimeConfig(t, base, "gpt-5-codex", "codex")
+	assertInitRuntimeConfig(t, base, "", "codex")
 }
 
 func TestInit_LoadRuntimeConfigForClaudeScaffold(t *testing.T) {
@@ -225,7 +222,7 @@ func TestInit_LoadRuntimeConfigForClaudeScaffold(t *testing.T) {
 		t.Fatalf("Init: %v", err)
 	}
 
-	assertInitRuntimeConfig(t, base, "claude-sonnet-4-20250514", "claude")
+	assertInitRuntimeConfig(t, base, "", "claude")
 }
 
 func TestInit_Idempotent(t *testing.T) {
@@ -398,6 +395,7 @@ func TestInit_RalphScaffoldTemplatesUsePublicContractAndArtifactFlow(t *testing.
 			"skipPermissions: true",
 		})
 		requireOmitsAll(t, workerPath, workerBody, []string{
+			"model:",
 			"model_provider:",
 			"provider:",
 			"stop_token:",
@@ -595,7 +593,7 @@ func assertInitRuntimeConfig(t *testing.T, base, wantModel, wantProvider string)
 	}
 }
 
-func assertInitScaffoldFilesCanonical(t *testing.T, base, wantModel, wantProvider string) {
+func assertInitScaffoldFilesCanonical(t *testing.T, base, wantProvider string) {
 	t.Helper()
 
 	factoryConfigPath := filepath.Join(base, "factory.json")
@@ -650,7 +648,6 @@ func assertInitScaffoldFilesCanonical(t *testing.T, base, wantModel, wantProvide
 	}
 	workerAgents := string(workerAgentsBytes)
 	for _, expected := range []string{
-		"model: " + wantModel,
 		"modelProvider: " + strings.ToUpper(wantProvider),
 		"executorProvider: SCRIPT_WRAP",
 		"timeout: 1h",
@@ -665,5 +662,8 @@ func assertInitScaffoldFilesCanonical(t *testing.T, base, wantModel, wantProvide
 		if strings.Contains(workerAgents, retired) {
 			t.Fatalf("generated worker AGENTS.md should not contain retired %q:\n%s", retired, workerAgents)
 		}
+	}
+	if strings.Contains(workerAgents, "model:") {
+		t.Fatalf("generated worker AGENTS.md should not contain a default model:\n%s", workerAgents)
 	}
 }

--- a/pkg/cli/init/scaffolds.go
+++ b/pkg/cli/init/scaffolds.go
@@ -110,7 +110,6 @@ The file watcher monitors this directory tree and automatically watches new subd
 `,
 			factoryWorkersDirName + "/processor/" + factoryAgentsFileName: `---
 type: MODEL_WORKER
-model: gpt-5-codex
 modelProvider: CODEX
 executorProvider: SCRIPT_WRAP
 resources: ["agent-slot"]
@@ -272,7 +271,6 @@ Keep the plan product-neutral unless the customer request names a specific produ
 `,
 			factoryWorkersDirName + "/planner/" + factoryAgentsFileName: `---
 type: MODEL_WORKER
-model: gpt-5-codex
 modelProvider: CODEX
 executorProvider: SCRIPT_WRAP
 stopToken: "<COMPLETE>"
@@ -286,7 +284,6 @@ Produce clear, product-neutral planning artifacts that the executor can apply di
 `,
 			factoryWorkersDirName + "/executor/" + factoryAgentsFileName: `---
 type: MODEL_WORKER
-model: gpt-5-codex
 modelProvider: CODEX
 executorProvider: SCRIPT_WRAP
 stopToken: "<COMPLETE>"

--- a/tests/functional/bootstrap_portability/cli_init_factory_test.go
+++ b/tests/functional/bootstrap_portability/cli_init_factory_test.go
@@ -91,7 +91,7 @@ func TestInitFactory_EndToEnd(t *testing.T) {
 	if err := initcmd.Init(initcmd.InitConfig{Dir: dir}); err != nil {
 		t.Fatalf("Init failed: %v", err)
 	}
-	assertGeneratedInitScaffoldCanonical(t, dir, "gpt-5-codex", "codex")
+	assertGeneratedInitScaffoldCanonical(t, dir, "codex")
 
 	// Step 2: Write a seed file into the generated preseed directory.
 	testutil.WriteSeedFile(t, dir, initcmd.DefaultFactoryInputType, []byte(`{"title": "init factory e2e test"}`))
@@ -135,7 +135,7 @@ func TestInitFactory_EndToEnd(t *testing.T) {
 	if calls[0].UserMessage == "" {
 		t.Error("expected non-empty user message from rendered workstations/process/AGENTS.md template")
 	}
-	assertInitProviderRequest(t, calls[0], "gpt-5-codex", "codex")
+	assertInitProviderRequest(t, calls[0], "", "codex")
 }
 
 func TestInitFactory_ClaudeEndToEndUsesClaudeStarterWorker(t *testing.T) {
@@ -144,7 +144,7 @@ func TestInitFactory_ClaudeEndToEndUsesClaudeStarterWorker(t *testing.T) {
 	if err := initcmd.Init(initcmd.InitConfig{Dir: dir, Executor: "claude"}); err != nil {
 		t.Fatalf("Init failed: %v", err)
 	}
-	assertGeneratedInitScaffoldCanonical(t, dir, "claude-sonnet-4-20250514", "claude")
+	assertGeneratedInitScaffoldCanonical(t, dir, "claude")
 
 	testutil.WriteSeedFile(t, dir, initcmd.DefaultFactoryInputType, []byte(`{"title": "claude init factory e2e test"}`))
 	assertCanonicalStarterInboxState(t, dir)
@@ -177,7 +177,7 @@ func TestInitFactory_ClaudeEndToEndUsesClaudeStarterWorker(t *testing.T) {
 	if len(calls) == 0 {
 		t.Fatal("expected at least 1 provider call")
 	}
-	assertInitProviderRequest(t, calls[0], "claude-sonnet-4-20250514", "claude")
+	assertInitProviderRequest(t, calls[0], "", "claude")
 }
 
 // TestInitFactory_FailureRouting verifies that the init-generated factory
@@ -279,7 +279,7 @@ func assertCanonicalStarterInboxState(t *testing.T, dir string) {
 	}
 }
 
-func assertGeneratedInitScaffoldCanonical(t *testing.T, dir, wantModel, wantProvider string) {
+func assertGeneratedInitScaffoldCanonical(t *testing.T, dir, wantProvider string) {
 	t.Helper()
 
 	factoryJSONBytes, err := os.ReadFile(filepath.Join(dir, "factory.json"))
@@ -323,7 +323,6 @@ func assertGeneratedInitScaffoldCanonical(t *testing.T, dir, wantModel, wantProv
 	}
 	workerAgents := string(workerAgentsBytes)
 	for _, expected := range []string{
-		"model: " + wantModel,
 		"modelProvider: " + strings.ToUpper(wantProvider),
 		"executorProvider: SCRIPT_WRAP",
 		"skipPermissions: true",
@@ -338,5 +337,8 @@ func assertGeneratedInitScaffoldCanonical(t *testing.T, dir, wantModel, wantProv
 		if strings.Contains(workerAgents, retired) {
 			t.Fatalf("generated worker AGENTS.md should not contain retired %q:\n%s", retired, workerAgents)
 		}
+	}
+	if strings.Contains(workerAgents, "model:") {
+		t.Fatalf("generated worker AGENTS.md should not contain a default model:\n%s", workerAgents)
 	}
 }


### PR DESCRIPTION
## Summary
- stop scaffolding default model values in init-generated worker AGENTS files
- keep executor and model provider defaults intact for codex and claude starters
- update init and bootstrap portability tests to expect provider-only starter configs

## Testing
- go test ./pkg/cli/init ./tests/functional/bootstrap_portability
- go build ./cmd/factory
- make lint
- make api-smoke

## Notes
- make build on this Windows workspace hit a locked in/infinite-you.exe, so go build ./cmd/factory was used to verify compilation without writing that filename
