### PR TITLE
docs: refresh meta world state

### DIFF
--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -102,66 +102,31 @@
 
 ## Current Summary
 
-- As of `2026-05-05T15:03:51.1883314-07:00`, `HEAD` on `main` points to
-  `53c8c0d` and matches `origin/main`; the worktree is clean apart from ignored
-  workflow inputs.
+- As of `2026-05-06T01:04:51.9722496-07:00`, `HEAD` on `main` points to
+  `6b95577` and matches `origin/main`.
 - The canonical ask surface remains `factory/logs/meta/asks.md`.
 - The checked-in maintainer workflow is `thoughts -> idea -> plan -> task`
   with `idea/task:to-complete`, same-name `consume`, `.claude/worktrees`
   execution for `process` and `review`, `executor-slot` capacity `10`, an
   hourly cleaner, and loop breakers.
-- The tracked input surface remains sentinel-only; visible files under
-  `factory/inputs/**` are ignored local residue rather than checked-in repo
-  truth.
-- Merged PR `#69` closed the array-valued workstation non-success route ask on
-  `main`.
-- Merged PR `#83` closed the broad dashboard-header verbosity copy ask on
-  `main`.
-- Merged PR `#84` closed the work-outcome chart axis-label and margin ask on
-  `main`.
-- Merged PR `#85` closed the remaining dashboard branding and header
-  iconography ask on `main`.
-- Merged PR `#86` closed the header button-convergence seam on `main`.
-- Merged PR `#87` closed the submit-work button-tone seam on `main`.
-- Merged PR `#88` closed the broader replay legacy-compat duplication lane on
-  `main`.
-- Merged PR `#89` closed the remaining replay trace-dispatch projection
-  duplication lane on `main`.
-- Merged PR `#93` closed the supported portable bundled-file portability lane
-  on `main`.
-- Merged PR `#94` closed the replay dispatch payload cast-wrapper cleanup on
-  `main`.
-- Merged PR `#95` closed the submit-request shaping dedupe lane on `main`.
-- Merged PR `#92` closed the stale OpenAPI cron post-processing compatibility
-  seam on `main`.
-- Merged PR `#91` closed the hidden singular non-success route compatibility
-  seam on `main`.
-- Merged PR `#97` closed the last stale iconography branch residue on `main`.
-- Merged PR `#98` closed the remaining work-outcome chart padding follow-up on
-  `main`.
-- Merged PR `#100` closed the replay event-stream file-wrapper seam on `main`.
-- Merged PR `#101` closed the backend coverage lane on `main`.
-- The selected-work current-selection ask is now materially satisfied on
-  `main` through PR `#74` plus PR `#77`.
-- The submit-work copy ask remains satisfied on `main` through merged PR `#75`.
-- `gh pr list --state open` now reports three open PRs: `#99`
-  (`workstation-current-selection-cleanup`), `#102`
-  (`work-chaininig-trace-ids`), and `#103` (`code-coverage-frontend`).
-- The tracked local ask diff now explicitly writes the array-valued
-  non-success output-interface request, but that lane is already materially
-  closed on `main` through merged PR `#69`.
-- Merged PR `#96` has already removed the dead submission forwarder package on
-  `main`, and merged PR `#100` has already removed the replay event-stream file
-  wrapper seam that the prior worldview still had queued locally.
-- The local ignored idea
-  `factory/inputs/idea/default/retire-replay-event-stream-file-wrapper-cluster.md`
-  was stale after PR `#100` and needed pruning before any new dispatch.
-- The next non-overlapping cleanup seam is trimming replay-only exported helper
-  surface from `pkg/testutil` and `internal/testpath`, where direct reads and
-  graph traces show helpers such as `WithReplayHarnessDir`,
-  `WithReplayHarnessServiceOptions`, `AssertReplayDiverges`, and
-  `MustClassifiedArtifactPath` are now only consumed by the replay contract
-  tests.
+- The tracked input surface remains sentinel-only; there is no checked-in
+  cleanup request currently queued under `factory/inputs/**`.
+- The local worktree is not clean, but the visible residue is unrelated
+  untracked root and `factory/` files rather than canonical queue state.
+- Recent merged PRs now include `#106`, `#107`, `#108`, `#109`, `#110`, and
+  `#111`; the current open PR set is down to one branch, `#112`
+  (`website-export`).
+- The import/export P0, current-selection, submit-work copy, and dashboard UI
+  asks remain materially closed on `main`; the remaining ask surface is broader
+  program work in standards migration, website coverage, docs audit, manual
+  QA, and systems-quality documentation.
+- The replay fixtures remain historical samples rather than current workflow
+  truth, and one rejection payload is still quoted anomalously in the replay
+  sample.
+- The next non-overlapping cleanup seam is functional test helper duplication:
+  `tests/functional/internal/support/events.go` already owns
+  `LastFactoryEventTick`, while replay-contract and runtime-API suites still
+  carry local `lastFactoryEventTick` copies.
 
 ## 2026-05-05T15:03:51.1883314-07:00 - meta state refresh
 
@@ -1299,3 +1264,37 @@
 - Added a standards-alignment checklist here so the meta loop now carries a
   checked-in running summary of the highest-signal open website and backend
   standards gaps instead of only recording them in prose refresh notes.
+
+## 2026-05-06T01:04:51.9722496-07:00 - meta state refresh
+
+- Switched back to `main`, then ran `git pull --ff-only origin main`; `main`
+  was already current at `6b95577`
+  (`Merge pull request #111 from portpowered/remove-init-default-models`).
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, and `factory/README.md`.
+- Re-validated tracked versus live workflow inputs with `git ls-files` and
+  `Get-ChildItem -Recurse factory/inputs`, confirming the canonical checked-in
+  input surface is still sentinel-only and had no pre-existing ignored idea
+  residue at the start of this refresh.
+- Re-checked repo movement with `git log --oneline --decorate -12`,
+  `gh pr list --state merged --limit 12`, and `gh pr list --state open --limit 20`,
+  confirming merged PRs `#106` through `#111` are now on `main` and the only
+  open PR is `#112` (`website-export`).
+- Used delegated explorer reads, the code graph, and direct file reads to
+  reject a false deadcode lead in `tests/functional/providers/helpers_test.go`:
+  the baseline entry is not enough by itself because those helpers still serve
+  `functionallong` tests.
+- Confirmed one new non-overlapping cleanup seam in live code instead:
+  `tests/functional/internal/support/events.go` already owns
+  `LastFactoryEventTick`, while
+  `tests/functional/replay_contracts/short_helpers_test.go`,
+  `tests/functional/replay_contracts/replay_record_end_to_end_long_test.go`,
+  and `tests/functional/runtime_api/api_inference_events_test.go` still carry
+  local `lastFactoryEventTick` copies.
+- Queued one fresh ignored idea under
+  `factory/inputs/idea/default/consolidate-functional-factory-event-tick-helpers.md`
+  so the next worker can collapse those suites onto the shared helper without
+  reopening the export lane owned by PR `#112`.
+- Updated the checked-in worldview and summary so they no longer claim stale
+  PR state, stale inbox residue, or a clean worktree.

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,12 +2,17 @@
 
 ## world state
 
-- as of `2026-05-05T16:33:00-07:00`, local `HEAD` on `main` points to
-  `a73fb01`
-  (`Merge pull request #105 from portpowered/ralph/dedupe-functional-dispatch-history-test-helpers`)
-  and matches `origin/main`
-- the local worktree is clean apart from ignored workflow inputs
+- as of `2026-05-06T01:04:51.9722496-07:00`, local `HEAD` on `main` points to
+  `6b95577`
+  (`Merge pull request #111 from portpowered/remove-init-default-models`) and
+  matches `origin/main`
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
+- the local worktree is not clean:
+  - canonical `factory/inputs/**` remains tracked-sentinel-only
+  - there is no checked-in cleanup request currently queued under
+    `factory/inputs/**`
+  - unrelated untracked local residue exists at the repo root and under
+    `factory/` and should not be treated as canonical queue state
 
 ## workflow truth
 
@@ -42,178 +47,27 @@
   contract and no longer accepts direct
   `factory/inputs/<work-type>/<file>` submissions as an implicit `default`
   channel fallback
-- the visible canonical inboxes now contain the tracked `.gitkeep` sentinels
-  plus one ignored local idea residue:
-  `factory/inputs/idea/default/dedupe-functional-agent-config-and-arg-sequence-test-helpers.md`
+- there is no pre-existing ignored idea residue in the canonical inboxes at the
+  start of this refresh; any new idea file written this turn is fresh local
+  operating state rather than stale carry-over
 
 ## customer-ask truth
 
-- the import/export P0 lane is now materially closed on `main`:
-  - merged PRs `#67`, `#68`, `#69`, `#70`, `#71`, `#72`, and `#93` now cover
-    the prompt template, split-layout, non-success-route, dialog, and
-    supported portable bundled-file portions of that ask
-  - canonical export now omits inline bundled-file content for supported
-    portable `factory/scripts/**` and `factory/docs/**` entries while keeping
-    the transport records needed for portability
-  - runtime loading and validation now accept the supported disk-backed
-    portable bundled-file path without rehydrating supported inline ownership
-  - package, integration, service, and functional coverage now protect the
-    supported bundled-file round-trip behavior through export, import, and
-    runtime loading
+- the import/export P0 lane remains materially closed on `main` through merged
+  PRs `#67`, `#68`, `#69`, `#70`, `#71`, `#72`, `#93`, and `#109`
 - the selected-work current-selection ask is materially satisfied on `main`
-  through merged PRs `#74` and `#77`
+  through merged PRs `#74`, `#77`, and `#110`
 - the submit-work copy ask is satisfied on `main` through merged PR `#75`
-- merged PR `#83` satisfied the header-verbosity copy reduction ask on `main`:
-  visible `Factory state`, `Stream`, `Export PNG`, and `Current` toolbar text
-  labels are gone
-- merged PR `#84` satisfied the work-outcome chart ask on `main`:
-  the chart no longer teaches detached axis labels and now carries increased
-  axis spacing through rendered chart behavior
-- merged PR `#85` satisfied the remaining dashboard branding and header
-  iconography lane on `main`:
-  - `ui/index.html`, `ui/fallback_dist/index.html`, and
-    `ui/fallback_dist/assets/index.js` no longer ship the old
-    `Agent Factory` / triangle shell contract
-  - `ui/src/features/header/dashboard-header.tsx`,
-    `ui/src/features/header/dashboard-status-panel.tsx`,
-    `ui/src/features/bento/agent-bento.tsx`,
-    `ui/src/features/workflow-activity/react-flow-current-activity-card-import.tsx`,
-    `ui/src/features/header/dashboard-export-dialog.tsx`, and
-    `ui/src/features/export/build-factory-export-filename.ts` now align with
-    the Infinite You rename
-  - the header stream/export/current controls now use the requested
-    pulsating-dot, share-style, and play-style semantics
-- merged PR `#86` satisfied the remaining header button-convergence seam on
-  `main`:
-  - `ui/src/features/header/dashboard-header.tsx` and
-    `ui/src/features/header/tick-slider-control.tsx` now route the export and
-    return-to-current actions through
-    `ui/src/features/header/dashboard-header-action-button.tsx`
-  - `ui/src/features/header/dashboard-header.test.tsx` and
-    `ui/src/App.stories.tsx` now protect the converged neutral header-action
-    treatment through rendered behavior
-- merged PR `#87` satisfied the remaining submit-work button-tone seam on
-  `main`:
-  - `ui/src/features/submit-work/submit-work-card.tsx` now renders the
-    `Submit work` CTA through the shared neutral `outline` tone instead of the
-    accent-filled default treatment
-  - `ui/src/features/submit-work/submit-work-widget.test.tsx` and
-    `ui/src/App.stories.tsx` now protect that neutral rendered treatment
-- the tracked local ask diff now explicitly includes the array-valued
-  non-success output-interface request, but that ask is already materially
-  satisfied on `main` through merged PR `#69`
-- there is no remaining unowned customer-visible dashboard ask on `main`; the
-  next narrow cleanup candidate now comes from the broader backend quality
-  lane:
-- merged PR `#88` retired the duplicated legacy dispatch compat payload
-  aliases from `ui/src/features/timeline/state/timeline/replayWorldStateTypes.ts`
-  and merged PR `#89` centralized the remaining replay
-  `completionToTraceDispatch` projection duplication without reopening the
-  broader legacy compat lane
-- merged PR `#90` closed the authored-throttle transition-ID fallback lane on
-  `main`:
-  - `pkg/petri/inference_throttle_guard.go` no longer carries
-    `WatchedTransitionIDs`
-  - `pkg/config/config_mapper.go` no longer lowers authored throttle guards
-    through transition-ID watch sets
-  - throttle tests now assert runtime-observable lane behavior instead of the
-    retired fallback shape
-- merged PR `#91` closed the last hidden non-success route compatibility seam
-  on `main`:
-  - `pkg/config/openapi_factory.go` no longer carries the singular
-    `onContinue` / `onRejection` / `onFailure` coercion helper
-  - `pkg/api/factory_config_smoke_test.go` now rejects singular non-success
-    route objects at the generated boundary
-  - checked-in factory fixtures across `factory/`, `examples/`, and
-    `tests/functional_test/testdata/` now author canonical array-valued
-    non-success routes
-- merged PR `#92` closed the stale OpenAPI cron post-processing compatibility
-  seam on `main`:
-  - `pkg/config/factory_config_mapping.go` no longer calls
-    `applyOpenAPICronCompatibility`
-  - `pkg/config/openapi_factory.go` no longer reparses normalized authored JSON
-    through `buildRawOpenAPIWorkstationCronIndex`
-  - `pkg/config/openapi_factory_test.go` and
-    `tests/functional/runtime_api/api_runtime_config_alignment_smoke_test.go`
-    now cover canonical cron loading through the generated boundary and runtime
-    config path
-- merged PR `#93` closed the supported portable bundled-file portability seam
-  on `main`:
-  - `pkg/config/factory_config_mapping.go` now strips supported portable inline
-    bundled-file content from canonical export while preserving the portable
-    transport entries
-  - `pkg/config/runtime_config.go`, `pkg/config/layout.go`, and
-    `pkg/config/config_validator.go` now treat supported portable bundled files
-    as disk-backed during runtime loading, expansion, and validation
-  - `pkg/config/portable_bundled_files*.go`, `pkg/service/factory_test.go`,
-    and functional portability smoke coverage now protect the supported
-    export/import/runtime round-trip behavior
-- merged PR `#94` closed the remaining replay-wrapper cleanup seam on `main`:
-  - `ui/src/features/timeline/state/timeline/replayCompletion.ts` and
-    `ui/src/features/timeline/state/timeline/replayWorldState.ts` no longer
-    carry the cast-wrapper-only replay payload helpers
-  - replay timeline tests remain the proof path for the live replay behavior
-- merged PR `#95` closed the duplicated submit-request shaping drift on `main`:
-  - `pkg/factory/work_request.go` now owns the canonical
-    `[]interfaces.SubmitRequest -> interfaces.WorkRequest` shaping path
-  - `pkg/internal/submission/work_request.go` is now only a pass-through alias
-    onto `factory.WorkRequestFromSubmitRequests`
-  - functional runtime smoke coverage now protects trace and request-shaping
-    parity through the runtime-visible submission path
-- merged PR `#96` closed the dead submission-forwarder lane on `main`:
-  - `pkg/internal/submission` is gone
-  - live callers now import `pkg/factory.WorkRequestFromSubmitRequests`
-    directly
-  - the old meta note naming that package as the next cleanup candidate is now
-    stale
-- merged PR `#97` closed the last stale iconography branch residue without
-  reopening the broader dashboard ask on `main`
-- merged PR `#98` closed the remaining work-outcome chart padding follow-up on
-  `main`
-- merged PR `#100` closed the replay event-stream file-wrapper seam on `main`:
-  - `pkg/replay/event_stream_artifact.go` is gone from production ownership
-  - replay conversion behavior now lives in the replay contract smoke lane
-- merged PR `#101` closed the backend `80%` coverage lane on `main`:
-  - `Makefile` and `cmd/gocoveragecheck/main.go` now enforce the backend gate
-  - backend runtime, replay, worker, and projection tests now cover the raised
-    floor through observable behavior
-- merged PR `#104` closed the replay-only shared-helper lane on `main`:
-  - replay-only helper ownership no longer inflates the shared exported surface
-    of `pkg/testutil` and `internal/testpath`
-  - replay artifact smoke and replay regression coverage still protect copied
-    factory replay success plus expected divergence behavior through observable
-    runtime outcomes
-- merged PR `#105` closed the duplicate functional dispatch-history helper
-  lane on `main`:
-  - `tests/functional/runtime_api/api_cron_workstations_smoke_test.go` now
-    routes dispatch-input reconstruction through
-    `tests/functional/internal/support/events.go`
-  - `tests/functional/internal/support/events.go` no longer carries the extra
-    local helper breadth that only existed to support the cron smoke's private
-    copy
-  - guards-batch and cron runtime assertions still prove the same observable
-    history behavior through live factory events
-- there is still no remaining narrow unowned customer-visible ask gap on
-  `main`; the next non-overlapping cleanup candidate now comes from the
-  broader backend quality lane:
-  - `tests/functional/internal/support/fixtures.go` already owns
-    `WriteAgentConfig`
-  - `tests/functional/internal/support/fixtures.go` already owns
-    `AssertArgsContainSequence`
-  - `tests/functional/guards_batch/helpers_test.go`,
-    `tests/functional/runtime_api/runtime_support_test.go`, and
-    `tests/functional/smoke/service_config_override_alignment_test.go` still
-    carry suite-local copies of those same helper behaviors
-  - the next cleanup should consolidate those tests onto the shared helper
-    ownership without changing observable provider-command, runtime-config, or
-    guards-batch behavior
-- the remaining ask surface beyond that is broader program work:
-  - the general standards-migration checklist ask is still open in
-    `factory/logs/meta/asks.md`
-  - the website `90%` coverage target is still open in
-    `factory/logs/meta/asks.md`
-  - the manual QA and systems-quality documentation asks are still open in
-    `factory/logs/meta/asks.md`
+- the header verbosity, chart layout, branding/iconography, and button-tone
+  asks are materially satisfied on `main` through merged PRs `#83`, `#84`,
+  `#85`, `#86`, `#87`, and `#98`
+- the remaining open asks in `factory/logs/meta/asks.md` are broader program
+  work rather than narrow customer-visible regressions:
+  - standards-migration checklist tracking
+  - website `90%` coverage target
+  - docs audit
+  - manual QA
+  - systems-quality documentation
 
 ## replay truth
 
@@ -226,127 +80,55 @@
 - replay outcome counts remain unchanged in the sample:
   - `process`: `9 ACCEPTED <COMPLETE>`, `27 CONTINUE <CONTINUE>`
   - `review`: `5 ACCEPTED <COMPLETE>`, `4 REJECTED <REJECTED>`
+- one replay rejection payload is still oddly quoted as `"\"<REJECTED>\"\n"`;
+  treat that as a fixture quirk rather than current workflow truth
 
 ## recent repo movement
 
 - recent merged PRs on `main` now include:
+  - `#111` `remove-init-default-models`, merged on `2026-05-06T07:09:23Z`
+  - `#110` `workstation-request-current-selection-cleanup`, merged on
+    `2026-05-06T03:28:00Z`
+  - `#109` `inline-supporting-file-content-on-export-and-thin-factory-import`,
+    merged on `2026-05-06T03:23:17Z`
+  - `#108` `remove-deadcode-2026-may`, merged on `2026-05-06T03:05:09Z`
+  - `#107` `Branch check`, merged on `2026-05-06T02:56:30Z`
+  - `#106` `dedupe-functional-agent-config-and-arg-sequence-test-helpers`,
+    merged on `2026-05-06T00:15:17Z`
   - `#105` `dedupe-functional-dispatch-history-test-helpers`, merged on
     `2026-05-05T23:16:03Z`
-  - `#104` `trim-replay-only-testutil-helper-surface`, merged on
-    `2026-05-05T22:23:43Z`
-  - `#102` `work-chaininig-trace-ids`, merged on `2026-05-05T21:39:26Z`
-  - `#99` `workstation-current-selection-cleanup`, merged on
-    `2026-05-05T21:20:11Z`
-  - `#101` `code-coverage-backend`, merged on `2026-05-05T21:29:09Z`
-  - `#100` `retire-replay-event-stream-file-wrapper-cluster`, merged on
-    `2026-05-05T21:22:34Z`
-  - `#98` `work-outcome-chart-padding`, merged on `2026-05-05T21:02:23Z`
-  - `#97` `website-icon-removal`, merged on `2026-05-05T20:59:43Z`
-  - `#96` `remove-dead-submission-work-request-forwarder-package`, merged on
-    `2026-05-04T18:22:54Z`
-  - `#95` `dedupe-submit-request-shaping-between-production-and-functional-runtime-tests`,
-    merged on `2026-05-04T17:34:28Z`
-  - `#94` `retire-replay-dispatch-payload-cast-wrappers`, merged on
-    `2026-05-04T17:21:31Z`
-  - `#93` `canonicalize-portable-bundled-files-without-inline-content`,
-    merged on `2026-05-04T15:53:47Z`
-  - `#92` `retire-openapi-cron-compatibility-patch`, merged on
-    `2026-05-04T14:33:28Z`
-  - `#91` `retire-singular-workstation-route-compatibility`, merged on
-    `2026-05-04T13:28:02Z`
-  - `#90` `retire-authored-throttle-transition-id-fallback`, merged on
-    `2026-05-04T12:32:50Z`
-  - `#89` `centralize-replay-trace-dispatch-projection`, merged on
-    `2026-05-04T11:25:59Z`
-  - `#88` `retire-replay-timeline-legacy-compat-duplication`, merged on
-    `2026-05-04T10:20:32Z`
-  - `#87` `normalize-submit-work-button-treatment`, merged on
-    `2026-05-04T09:17:47Z`
-  - `#86` `normalize-dashboard-header-button-treatment`, merged on
-    `2026-05-04T08:36:11Z`
-  - `#85` `align-dashboard-branding-and-header-iconography`, merged on
-    `2026-05-04T08:00:00Z`
-  - `#69` `workstation-non-success-route-arrays`, merged into `main` before the
-    current refresh and now represented by `HEAD`
-  - `#84` `align-work-outcome-chart-axis-labels-and-margins`, merged on
-    `2026-05-04T06:31:54Z`
-  - `#83` `simplify-dashboard-header-toolbar-verbosity`, merged on
-    `2026-05-04T05:53:10Z`
-  - `#82` `trim-ralph-starter-input-readme-contract`, merged on
-    `2026-05-04T04:20:52Z`
-  - `#81` `trim-starter-input-readme-contract`, merged on
-    `2026-05-04T03:18:53Z`
-  - `#80` `align-default-starter-task-input-contract`, merged on
-    `2026-05-04T02:36:26Z`
-  - `#79` `retire-filewatcher-default-channel-fallback`, merged on
-    `2026-05-04T01:27:11Z`
-  - `#78` `remove-list-work-legacy-pagination-shim`, merged on
-    `2026-05-04T00:28:40Z`
 - `gh pr list --state open` currently reports one open PR:
-  - `#103` `code-coverage-frontend`, opened on `2026-05-05T21:45:42Z`
+  - `#112` `website-export`, opened on `2026-05-06T07:45:59Z`
+- PR `#112` owns the current export/bundled-file work on its branch, so new
+  cleanup dispatches should avoid portability/export overlap until that lane
+  merges or closes
+
+## next cleanup candidate
+
+- there is no remaining narrow unowned customer-visible ask gap on `main`
+- the next non-overlapping cleanup seam is in functional test helper
+  duplication:
+  - `tests/functional/internal/support/events.go` already owns
+    `LastFactoryEventTick`
+  - `tests/functional/replay_contracts/short_helpers_test.go`
+  - `tests/functional/replay_contracts/replay_record_end_to_end_long_test.go`
+  - `tests/functional/runtime_api/api_inference_events_test.go`
+    still carry local `lastFactoryEventTick` copies
+- the next dispatch should consolidate those suites onto the shared support
+  helper without changing replay, runtime API, or projection behavior
 
 ## theory of mind
 
-- the authoritative world model still comes from live git state plus the
-  checked-in workflow contract, not from replay fixtures alone
+- the authoritative world model comes from live `main`, the checked-in workflow
+  contract, and current PR state together; stale checked-in summaries are only
+  safe after revalidation
 - `factory/inputs/**` must always be reasoned about in two layers:
   checked-in contract versus ignored operating residue
-- ignored queue residue can become stale within a single merge cycle, so the
-  meta loop has to reconcile local inbox files against the newest merged PRs
-  before dispatching anything new
-- merged PR state can flip between the start of a refresh and the end of it;
-  open-PR assumptions need to be revalidated after `git pull` and before queue
-  writes
-- once a customer-visible ask lands, the right follow-up is usually not another
-  broad lane but the smallest remaining seam that preserves the ask's public
-  intent without reopening merged work
-- once a portability lane looks closed, re-check export mapping, runtime load,
-  validation, and service/functional tests together before retiring the idea;
-  PR `#93` only became safe to close after all four layers moved to the same
-  supported disk-backed ownership model
-- once a narrow cleanup merges, the next best seam can still hide in boundary
-  normalizers and fixtures rather than in the obvious runtime path; after
-  PR `#90`, the stale throttle note was gone on `main` but the array-route ask
-  still had a hidden compatibility layer in the OpenAPI factory boundary
-- when a public JSON shape moves from singular objects to arrays, re-check
-  import/load normalization helpers and checked-in factory fixtures; type and
-  schema updates alone do not prove the old authored shape is actually rejected
-- after a boundary migration lands, re-check for follow-on post-processing
-  patches that still reparse the authored JSON out-of-band; once the generated
-  model and mapper both carry the canonical field directly, those patches are
-  often the next dead compatibility seam
-- for import/export asks, verify both canonical `factory.json` flattening and
-  expanded authored layout writes before declaring the lane closed; stripping a
-  field during `WriteExpandedFactoryLayout` does not mean `FlattenFactoryConfig`
-  and runtime loading have stopped rehydrating it back into the exported JSON
-- after broad replay legacy-compat cleanups merge, scan for any remaining
-  one-line cast wrappers or alias-only helpers on the live replay path before
-  inventing a larger follow-up; those seams are often the next lowest-risk
-  simplifications
-- when production request-shaping and functional-test request-shaping both
-  exist, compare chaining-trace propagation and batch metadata field-by-field
-  before assuming the duplicate helper is harmless; this repo already allowed a
-  test-only copy to drift away from the live submit path
-- once a dedupe PR lands, re-scan the old owner package for alias-only
-  wrappers; this repo now shows that a merged centralization can leave a whole
-  package behind as dead forwarding surface even after the behavioral drift is
-  fixed
-- once a cleanup seam is recorded in the checked-in worldview, re-validate it
-  against live `main` before dispatching; merged PR `#96` proved the meta view
-  can go stale within a single refresh cycle
-- when an open PR touches a surface already marked closed in the worldview,
-  compare the PR diff against the canonical ask text before dispatching any
-  sibling work; PR `#97` is a good example of overlap hiding behind a new
-  branch name
-- deadcode-baseline entries that are only reachable from one long functional
-  smoke are strong candidates for the next narrow cleanup idea, especially when
-  the live runtime, API, and CLI paths have no direct callers
-- when a deadcode-baseline entry still has live callers, compare it against
-  suite-local helper copies before queueing deletion; duplicated functional
-  helper ownership can be the real simplification seam
-- when a helper file is split by build tags, validate usage in both the short
-  and `functionallong` lanes before treating it as dead; replay-contract helper
-  files can look unused in one lane while still serving the other
-- graph and explorer results can lag behind a fast-forwarded `main`; verify any
-  suggested cleanup seam against live `git log`, `rg`, and direct file reads
-  before writing a new queue item
+- when the current branch is not `main`, refresh the worldview from live
+  `main` before queueing cleanup work; branch-local open PRs can otherwise hide
+  overlap
+- deadcode-baseline output is only a candidate generator:
+  build-tagged functional helpers must be checked in both default and
+  `functionallong` lanes before treating them as dead
+- when a shared functional support helper already exists, prefer collapsing
+  local suite copies onto it instead of inventing another abstraction layer


### PR DESCRIPTION
## Summary
- refresh the checked-in meta world view against live main and current PR state
- update the progress summary and append the latest meta refresh entry
- queue one ignored cleanup idea for consolidating duplicate functional factory-event tick helpers

## Notes
- the cleanup idea lives under the ignored factory inbox and is intentionally not part of the git commit
- direct pushes to main are blocked by repository rules, so this PR carries the checked-in meta updates