### PR TITLE
consolidate-functional-factory-event-tick-helpers

### DIFF
--- a/docs/development/deadcode-baseline.txt
+++ b/docs/development/deadcode-baseline.txt
@@ -9,7 +9,6 @@ tests/functional/bootstrap_portability/portability_helpers_test.go:42:6: unreach
 tests/functional/bootstrap_portability/portability_helpers_test.go:49:6: unreachable func: writeFactoryTestFile
 tests/functional/guards_batch/helpers_test.go:14:6: unreachable func: providerErrorCorpusEntryForTest
 tests/functional/guards_batch/helpers_test.go:99:29: unreachable func: panickingExecutor.Execute
-tests/functional/internal/support/events.go:145:6: unreachable func: LastFactoryEventTick
 tests/functional/internal/support/fixtures.go:136:6: unreachable func: UpdateFactoryConfig
 tests/functional/providers/helpers_test.go:131:6: unreachable func: buildModelWorkerConfig
 tests/functional/providers/helpers_test.go:183:6: unreachable func: writeNamedWorkerAgents
@@ -64,7 +63,6 @@ tests/functional/replay_contracts/replay_thin_event_dual_dispatch_smoke_test.go:
 tests/functional/replay_contracts/replay_thin_event_dual_dispatch_smoke_test.go:690:6: unreachable func: thinEventCompletedDispatchForID
 tests/functional/replay_contracts/short_helpers_test.go:26:6: unreachable func: replayEventCount
 tests/functional/replay_contracts/short_helpers_test.go:43:6: unreachable func: factoryRelationsValue
-tests/functional/replay_contracts/short_helpers_test.go:64:6: unreachable func: lastFactoryEventTick
 tests/functional/runtime_api/api_batch_submission_boundary_smoke_test.go:40:6: unreachable func: runBoundaryBatchSmokeThroughWatchedFile
 tests/functional/runtime_api/api_batch_submission_boundary_smoke_test.go:56:6: unreachable func: runBoundaryBatchSmokeThroughHTTP
 tests/functional/runtime_api/api_batch_submission_boundary_smoke_test.go:99:6: unreachable func: loadBatchBoundarySummary

--- a/tests/functional/replay_contracts/replay_record_end_to_end_long_test.go
+++ b/tests/functional/replay_contracts/replay_record_end_to_end_long_test.go
@@ -298,7 +298,7 @@ func assertGeneratedReplayRequestMetadata(t *testing.T, events []factoryapi.Fact
 		t.Fatalf("generated relation metadata = %#v, want generated-beta depends on generated-alpha complete", relations)
 	}
 
-	world, err := projections.ReconstructFactoryWorldState(events, lastFactoryEventTick(events))
+	world, err := projections.ReconstructFactoryWorldState(events, support.LastFactoryEventTick(events))
 	if err != nil {
 		t.Fatalf("ReconstructFactoryWorldState: %v", err)
 	}
@@ -372,16 +372,6 @@ func replayWorkRequestEventsFromEvents(t *testing.T, events []factoryapi.Factory
 		})
 	}
 	return out
-}
-
-func lastFactoryEventTick(events []factoryapi.FactoryEvent) int {
-	tick := 0
-	for _, event := range events {
-		if event.Context.Tick > tick {
-			tick = event.Context.Tick
-		}
-	}
-	return tick
 }
 
 func snapshotContainsWorkID(snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], workID string) bool {

--- a/tests/functional/replay_contracts/replay_thin_event_dual_dispatch_smoke_long_test.go
+++ b/tests/functional/replay_contracts/replay_thin_event_dual_dispatch_smoke_long_test.go
@@ -23,7 +23,7 @@ func TestReplayThinEventDualDispatchSmoke_ReplayAndReadersReuseSharedArtifact(t 
 		HasNoTokenInPlace("task:failed").
 		HasNoTokenInPlace(dualDispatchSmokeScriptWorkType + ":failed")
 
-	finalTick := lastFactoryEventTick(smoke.artifact.Events)
+	finalTick := support.LastFactoryEventTick(smoke.artifact.Events)
 	worldState, err := projections.ReconstructFactoryWorldState(smoke.artifact.Events, finalTick)
 	if err != nil {
 		t.Fatalf("ReconstructFactoryWorldState: %v", err)

--- a/tests/functional/replay_contracts/short_helpers_test.go
+++ b/tests/functional/replay_contracts/short_helpers_test.go
@@ -60,13 +60,3 @@ func stringSlicePointerValue(value *[]string) []string {
 	}
 	return *value
 }
-
-func lastFactoryEventTick(events []factoryapi.FactoryEvent) int {
-	tick := 0
-	for _, event := range events {
-		if event.Context.Tick > tick {
-			tick = event.Context.Tick
-		}
-	}
-	return tick
-}

--- a/tests/functional/runtime_api/api_inference_events_test.go
+++ b/tests/functional/runtime_api/api_inference_events_test.go
@@ -303,7 +303,7 @@ func loadThinEventSmokeFinalSnapshot(
 	if err != nil {
 		t.Fatalf("decode final inference response payload: %v", err)
 	}
-	finalState, err := projections.ReconstructFactoryWorldState(artifact.Events, lastFactoryEventTick(artifact.Events))
+	finalState, err := projections.ReconstructFactoryWorldState(artifact.Events, support.LastFactoryEventTick(artifact.Events))
 	if err != nil {
 		t.Fatalf("ReconstructFactoryWorldState final tick: %v", err)
 	}
@@ -1009,16 +1009,6 @@ func mapValue[K comparable, V any](values *map[K]V) map[K]V {
 		return nil
 	}
 	return *values
-}
-
-func lastFactoryEventTick(events []factoryapi.FactoryEvent) int {
-	tick := 0
-	for _, event := range events {
-		if event.Context.Tick > tick {
-			tick = event.Context.Tick
-		}
-	}
-	return tick
 }
 
 func worldViewDispatchHistoryContainsTrace(view interfaces.FactoryWorldView, dispatchID, traceID string) bool {


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/consolidate-functional-factory-event-tick-helpers",
  "description": "Infinite You is an AI agent factory for scheduling and orchestrating many AI workers concurrently. This change consolidates duplicate functional-test final factory-event tick helpers onto the existing shared support owner so replay-contract and runtime-API suites keep proving the same replay reconstruction and runtime event-history behavior without carrying identical local helper bodies.",
  "context": {
    "customerAsk": "Cleanup Idea: Consolidate Functional Factory-Event Tick Helpers. The functional test support layer already owns `LastFactoryEventTick(events []factoryapi.FactoryEvent) int` in `tests/functional/internal/support/events.go`, but local copies still exist in `tests/functional/replay_contracts/short_helpers_test.go`, `tests/functional/replay_contracts/replay_record_end_to_end_long_test.go`, and `tests/functional/runtime_api/api_inference_events_test.go`. Keep this work limited to consolidating `lastFactoryEventTick` ownership, inspect the shared owner and each local copy, replace local copies with the shared support helper where the behavior is actually identical, keep the helper signature and call sites simple, preserve the existing observable replay and runtime API assertions, do not change production code, and do not add meta tests that only assert helper placement.",
    "problem": "Replay-contract and runtime-API functional tests currently repeat the same final factory-event tick calculation through multiple identical local helpers even though the functional support layer already owns that exact behavior. The duplication is narrow but still live in tests that reconstruct world state from recorded event history, which creates avoidable drift risk and review noise without changing any customer-visible outcome.",
    "solution": "Use `support.LastFactoryEventTick(...)` as the single shared owner for the final-event-tick calculation wherever the local helper body is behaviorally identical. Remove the duplicate local helpers from the affected replay-contract and runtime-API suites, keep call sites simple, and preserve the same replay reconstruction and runtime event-history assertions the suites already prove."
  },
  "acceptanceCriteria": [
    "AC-1: One shared owner remains for the factory-event tick calculation used by replay-contract and runtime-API functional suites.",
    "AC-2: Local `lastFactoryEventTick` helpers are removed from `tests/functional/replay_contracts/short_helpers_test.go`, `tests/functional/replay_contracts/replay_record_end_to_end_long_test.go`, and `tests/functional/runtime_api/api_inference_events_test.go` when their behavior matches the shared support helper exactly.",
    "AC-3: The affected replay-contract tests still reconstruct the same final replay world state and preserve the same replay-visible metadata and reader assertions after the cleanup.",
    "AC-4: The affected runtime-API tests still reconstruct the same final event-history snapshot and preserve the same runtime-visible inference-event and dispatch-history assertions after the cleanup.",
    "AC-5: No production code, replay payload helper ownership, work-request parsing helper ownership, or export-related behavior changes are introduced as part of this change.",
    "AC-6: Quality checks pass (typecheck, lint, tests)."
  ],
  "userStories": [
    {
      "id": "US-001",
      "title": "Preserve replay reconstruction behavior while consolidating final-tick calculation",
      "description": "As a replay maintainer, I want replay-contract tests to use the shared final-event-tick helper so that replay reconstruction behavior stays consistent without carrying duplicate local tick helpers.",
      "acceptanceCriteria": [
        "Replay-contract tests that reconstruct factory world state from replay artifact events use `support.LastFactoryEventTick(...)` instead of a local `lastFactoryEventTick` helper when the helper body is identical.",
        "`tests/functional/replay_contracts/short_helpers_test.go` no longer defines a local `lastFactoryEventTick` helper.",
        "`tests/functional/replay_contracts/replay_record_end_to_end_long_test.go` no longer defines a local `lastFactoryEventTick` helper.",
        "Replay reconstruction tests still prove the same final world-state outcomes after calling `projections.ReconstructFactoryWorldState(...)`, including the existing replay reader and request-metadata assertions.",
        "No new replay-only abstraction layer is introduced around final-tick calculation beyond the existing shared support helper.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "US-002",
      "title": "Preserve runtime API event-history reconstruction behavior while consolidating final-tick calculation",
      "description": "As a runtime API maintainer, I want the event-history functional tests to use the shared final-event-tick helper so that final snapshot reconstruction and event assertions stay aligned with the replay-contract lane.",
      "acceptanceCriteria": [
        "`tests/functional/runtime_api/api_inference_events_test.go` no longer defines a local `lastFactoryEventTick` helper when its behavior matches `support.LastFactoryEventTick(...)` exactly.",
        "Runtime API functional coverage still reconstructs the final factory world state from recorded events by passing the shared final tick into `projections.ReconstructFactoryWorldState(...)`.",
        "The affected runtime API tests still prove the same observable behavior for dispatch lifecycle history, reconstructed final snapshot contents, and script-worker no-inference-event outcomes.",
        "No meta tests are added that only assert helper names, helper placement, or shared-package topology.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
