### PR TITLE
docs: refresh meta world state

### DIFF
--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -197,6 +197,39 @@
   higher aggregate threshold, package-by-package test authoring, or another
   command-entrypoint lane.
 
+## 2026-05-06T13:04:11.9967894-07:00 - meta state refresh
+
+- Ran `git pull --ff-only`, saw remote movement on `origin/main`, then ran
+  `git pull --rebase --autostash origin main`; Git rebased the meta branch
+  onto live `origin/main`, pulling in merged PR `#131`
+  (`close-backend-coverage-coverpkg-summary-tail-gap`) while preserving the
+  user-owned tracked edit in `factory/logs/meta/asks.md`.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`,
+  `factory/factory.json`, `.gitignore`, current `factory/inputs/**` state, and
+  recent PR state.
+- Re-validated tracked queue truth with `git ls-files factory/inputs` and
+  `Get-ChildItem factory/inputs/idea/default -Force`, confirming the
+  checked-in inboxes remain sentinel-only while the visible idea file is
+  ignored local operating residue.
+- Confirmed the previously queued ignored idea
+  `factory/inputs/idea/default/close-backend-coverage-coverpkg-summary-tail-gap.md`
+  is stale because merged PR `#131` already landed that exact cleanup on
+  `main`, so it should be replaced rather than re-queued.
+- Verified with direct reads, delegated explorer inspection, and live
+  `go test -cover` runs that the next narrow command-owner quality seam is now
+  `cmd/deadcodecheck`: `Makefile` still routes the maintainer deadcode gate
+  through it, `main.go` still owns the baseline-drift and failure behavior,
+  `main_test.go` still covers only `ensureGoTypesAliasEnabled`, and
+  `go test -cover ./cmd/deadcodecheck` currently reports `23.4%` statement
+  coverage.
+- Queued one replacement ignored idea under
+  `factory/inputs/idea/default/cover-deadcodecheck-command-owner-branches.md`
+  so the next worker can tighten that repo-owned deadcode command boundary
+  without broadening into baseline churn, repo-wide deadcode deletion, or a
+  new package-by-package test campaign.
+
 ## 2026-05-06T11:02:38.5905896-07:00 - meta state refresh
 
 - Ran `git pull --rebase --autostash origin main`; Git rebased the meta branch

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -130,6 +130,9 @@
   repo-owned `cmd/` entrypoint and the underlying internal package already has
   behavioral tests, treat the missing command-local seam as the next narrow
   coverage cleanup before changing release orchestration itself.
+- After a command-entrypoint coverage PR merges, inspect the same package for
+  any remaining `0.0%` repo-owned subprocess wrapper before widening scope
+  into a different command or a repo-wide coverage campaign.
 
 ## Current Summary
 
@@ -1727,3 +1730,44 @@
   command-runner lanes.
 - Updated the checked-in worldview and summary so they no longer claim stale
   PR ownership, stale queue residue, or the old tick-helper next seam.
+
+## 2026-05-06T14:03:39.1137712-07:00 - meta state refresh
+
+- Ran `git pull --ff-only`, saw remote movement on `origin/main` without
+  advancing the branch-local tracking ref, then ran
+  `git pull --rebase --autostash origin main`; Git rebased the meta branch
+  onto live `origin/main`, pulling in merged PR `#132`
+  (`cover-deadcodecheck-command-owner-branches`) while preserving the
+  user-owned tracked edit in `factory/logs/meta/asks.md`.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`, current PR
+  state, the tracked-versus-ignored `factory/inputs/**` surface, and the live
+  `cmd/` maintainer-gate packages.
+- Re-validated tracked queue truth with `git ls-files factory/inputs` and
+  `Get-ChildItem -Recurse -Force factory/inputs`, confirming the checked-in
+  inboxes remain sentinel-only while the visible idea file is ignored local
+  operating residue.
+- Confirmed the previously queued ignored idea
+  `factory/inputs/idea/default/cover-deadcodecheck-command-owner-branches.md`
+  is stale because merged PR `#132` already landed that exact cleanup on
+  `main`, so it should be replaced rather than re-queued.
+- Verified with `gh pr list`, `gh pr view 132`, direct reads,
+  delegated explorer inspection, and fresh `go test -cover ./cmd/...` runs
+  that `cmd/deadcodecheck` is no longer the next gap on live `main`;
+  `go test -cover ./cmd/deadcodecheck` now reports `83.3%` statement coverage.
+- Used graph-backed discovery, direct reads of `cmd/releasetagcheck/main.go`
+  and `cmd/releasetagcheck/main_test.go`, and workflow search over
+  `.github/workflows/release.yml` plus
+  `.github/workflows/release-candidate.yml` to identify the next narrower
+  command-owner seam: merged PR `#127` already covered the entrypoint and
+  argument-routing behavior, but the same package still owns an untested
+  `git tag --points-at` subprocess wrapper in `gitTagsPointingAt`, and
+  `go test -cover ./cmd/releasetagcheck` still reports `71.4%` statement
+  coverage with that function at `0.0%`.
+- Queued one replacement ignored idea under
+  `factory/inputs/idea/default/cover-releasetagcheck-git-tag-wrapper-branches.md`
+  so the next worker can add focused success and failure coverage for the
+  repo-owned git-tag wrapper without changing release-tag policy, moving git
+  lookup ownership out of the command, or reopening the broader entrypoint
+  lane from PR `#127`.

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -119,12 +119,16 @@
   the workflow contract centralized there and add command-local tests for flag
   routing and emitted output instead of relying only on lower-level helper
   package tests.
+- When a root maintainer command such as `make release` still shells through a
+  repo-owned `cmd/` entrypoint and the underlying internal package already has
+  behavioral tests, treat the missing command-local seam as the next narrow
+  coverage cleanup before changing release orchestration itself.
 
 ## Current Summary
 
-- As of `2026-05-06T09:04:02.6782977-07:00`, `HEAD` points to `337fdb2` on
+- As of `2026-05-06T10:02:07.1841958-07:00`, `HEAD` points to `93f0b6d` on
   branch `meta-refresh-world-state-20260506-050415`; local `main` also points
-  to `7ee70eb` and contains `origin/main` through merged PR `#127`.
+  to `2c21b00` and contains `origin/main` through merged PR `#128`.
 - The canonical ask surface remains `factory/logs/meta/asks.md`.
 - The checked-in maintainer workflow is `thoughts -> idea -> plan -> task`
   with `idea/task:to-complete`, same-name `consume`, `.claude/worktrees`
@@ -136,8 +140,8 @@
   user-owned tracked edit; ignored workflow files under `factory/inputs/**`
   remain operating state rather than canonical queue truth.
 - Recent merged PRs now include `#112`, `#113`, `#114`, `#115`, `#117`,
-  `#118`, `#119`, `#121`, `#122`, `#124`, `#125`, `#126`, and `#127`; open
-  PRs `#120` and `#123` are only
+  `#118`, `#119`, `#121`, `#122`, `#124`, `#125`, `#126`, `#127`, and `#128`;
+  open PRs `#120` and `#123` are only
   meta refresh branches and do not own the next code cleanup lane.
 - The import/export P0, current-selection, submit-work copy, and dashboard UI
   asks remain materially closed on `main`; the remaining ask surface is broader
@@ -146,11 +150,47 @@
 - The replay fixtures remain historical samples rather than current workflow
   truth, and one rejection payload is still quoted anomalously in the replay
   sample.
-- The next non-overlapping dispatch is the release-smoke command-entrypoint
-  lane: release smoke wrappers call `cmd/releasesmoke` directly, harness tests
-  already cover the behavior beneath it, and the script-owned command surface
-  still lacks package-local coverage for flag routing, JSON stdout/stderr, and
-  exit behavior.
+- The next non-overlapping dispatch is the release-prep command-entrypoint
+  lane: `make release` shells through `cmd/releaseprep`, internal
+  `releaseprep` tests already cover the policy beneath it, and the
+  maintainer-facing command surface still lacks package-local coverage for flag
+  routing, stdout or stderr wiring, and exit behavior.
+
+## 2026-05-06T10:02:07.1841958-07:00 - meta state refresh
+
+- Ran `git pull --rebase --autostash origin main`; Git rebased the meta branch
+  onto live `origin/main`, pulling in merged PR `#128`
+  (`cover-releasesmoke-command-entrypoint`) while preserving the user-owned
+  tracked edit in `factory/logs/meta/asks.md`.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`, recent PR
+  state, the tracked-versus-ignored `factory/inputs/**` surface, and the live
+  release command boundaries.
+- Re-validated tracked queue truth with `git ls-files factory/inputs`,
+  `rg --files -uu factory/inputs`, delegated explorer inspection, and direct
+  reads, confirming the checked-in inboxes remain sentinel-only while the
+  visible idea file is ignored local operating state.
+- Confirmed the previously queued ignored idea
+  `factory/inputs/idea/default/cover-releasesmoke-command-entrypoint.md` is
+  stale because merged PR `#128` already landed that exact cleanup on `main`,
+  so it should be replaced rather than re-queued.
+- Verified with `git log`, `gh pr list`, `gh pr view 128`, direct reads, and
+  delegated explorer output that `main` now closes the recorded releasesmoke
+  gap and that open PRs `#120` and `#123` remain meta-only.
+- Used direct inspection of `Makefile`, `cmd/releaseprep/main.go`,
+  `internal/releaseprep/releaseprep.go`,
+  `internal/releaseprep/releaseprep_test.go`, and
+  `docs/processes/development-guide-relevant-files.md` to identify the next
+  narrower sibling seam in the same quality lane: `make release` still shells
+  through the repo-owned `cmd/releaseprep` boundary, internal release policy is
+  already covered beneath it, but there is still no checked-in
+  `cmd/releaseprep/main_test.go`.
+- Queued one replacement ignored idea under
+  `factory/inputs/idea/default/cover-releaseprep-command-entrypoint.md` so the
+  next worker can make that maintainer-facing command directly testable without
+  changing release policy sequencing, broadening into workflow or packaging
+  work, or moving those assertions down into `internal/releaseprep`.
 
 ## 2026-05-06T09:04:02.6782977-07:00 - meta state refresh
 

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -122,9 +122,9 @@
 
 ## Current Summary
 
-- As of `2026-05-06T08:03:56.8600066-07:00`, `HEAD` points to `527c286` on
+- As of `2026-05-06T09:04:02.6782977-07:00`, `HEAD` points to `337fdb2` on
   branch `meta-refresh-world-state-20260506-050415`; local `main` also points
-  to `b0ae97a` and contains `origin/main` through merged PR `#126`.
+  to `7ee70eb` and contains `origin/main` through merged PR `#127`.
 - The canonical ask surface remains `factory/logs/meta/asks.md`.
 - The checked-in maintainer workflow is `thoughts -> idea -> plan -> task`
   with `idea/task:to-complete`, same-name `consume`, `.claude/worktrees`
@@ -136,8 +136,8 @@
   user-owned tracked edit; ignored workflow files under `factory/inputs/**`
   remain operating state rather than canonical queue truth.
 - Recent merged PRs now include `#112`, `#113`, `#114`, `#115`, `#117`,
-  `#118`, `#119`, `#121`, `#122`, `#124`, `#125`, and `#126`; open PRs `#120`
-  and `#123` are only
+  `#118`, `#119`, `#121`, `#122`, `#124`, `#125`, `#126`, and `#127`; open
+  PRs `#120` and `#123` are only
   meta refresh branches and do not own the next code cleanup lane.
 - The import/export P0, current-selection, submit-work copy, and dashboard UI
   asks remain materially closed on `main`; the remaining ask surface is broader
@@ -146,11 +146,48 @@
 - The replay fixtures remain historical samples rather than current workflow
   truth, and one rejection payload is still quoted anomalously in the replay
   sample.
-- The next non-overlapping dispatch is the release-tag command-entrypoint lane:
-  release workflows call `cmd/releasetagcheck` directly, helper tests only
-  cover semver parsing today, and the workflow-owned command surface still
-  lacks package-local coverage for flag routing, git lookup, and emitted
-  `release_tag=...` output.
+- The next non-overlapping dispatch is the release-smoke command-entrypoint
+  lane: release smoke wrappers call `cmd/releasesmoke` directly, harness tests
+  already cover the behavior beneath it, and the script-owned command surface
+  still lacks package-local coverage for flag routing, JSON stdout/stderr, and
+  exit behavior.
+
+## 2026-05-06T09:04:02.6782977-07:00 - meta state refresh
+
+- Ran `git pull --rebase --autostash origin main`; Git rebased the meta branch
+  onto live `origin/main`, pulling in merged PR `#127`
+  (`cover-releasetagcheck-command-entrypoint`) while preserving the user-owned
+  tracked edit in `factory/logs/meta/asks.md`.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`, recent PR
+  state, the tracked-versus-ignored `factory/inputs/**` surface, and the live
+  release smoke command boundaries.
+- Re-validated tracked queue truth with `git ls-files factory/inputs`,
+  `Get-ChildItem -Recurse factory/inputs`, delegated explorer inspection, and
+  direct reads, confirming the checked-in inboxes remain sentinel-only while
+  the visible idea file is ignored local operating state.
+- Confirmed the previously queued ignored idea
+  `factory/inputs/idea/default/cover-releasetagcheck-command-entrypoint.md` is
+  stale because merged PR `#127` already landed that exact cleanup on `main`,
+  so it should be replaced rather than re-queued.
+- Verified with `git log`, `gh pr list`, `git show origin/main:cmd/releasetagcheck/main_test.go`,
+  direct reads, and delegated explorer output that `main` now closes the
+  recorded releasetagcheck gap and that open PRs `#120` and `#123` remain
+  meta-only.
+- Used direct inspection of `scripts/release/smoke-artifact.sh`,
+  `scripts/release/smoke-artifact.ps1`, `cmd/releasesmoke/main.go`,
+  `tests/release/release_smoke_test.go`, `internal/releasesmoke/harness.go`,
+  and `docs/processes/development-guide-relevant-files.md` to identify the
+  next narrower sibling seam in the same quality lane: release smoke wrappers
+  still shell through the repo-owned `cmd/releasesmoke` boundary, harness
+  behavior is already covered beneath it, but there is still no checked-in
+  `cmd/releasesmoke/main_test.go`.
+- Queued one replacement ignored idea under
+  `factory/inputs/idea/default/cover-releasesmoke-command-entrypoint.md` so
+  the next worker can make that script-facing command directly testable
+  without changing release smoke behavior, moving verification logic into
+  shell wrappers, or broadening into workflow or artifact-packaging work.
 
 ## 2026-05-06T05:07:16.1578424-07:00 - meta state refresh
 

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -114,9 +114,9 @@
 
 ## Current Summary
 
-- As of `2026-05-06T05:04:15.1266160-07:00`, `HEAD` on `main` points to
-  `d17acf1`, a local docs refresh commit that contains `origin/main` through
-  merged PR `#122`.
+- As of `2026-05-06T05:07:16.1578424-07:00`, `HEAD` points to `e47cbe3` on
+  branch `meta-refresh-world-state-20260506-050415`; local `main` also points
+  to `e47cbe3` and contains `origin/main` through merged PR `#122`.
 - The canonical ask surface remains `factory/logs/meta/asks.md`.
 - The checked-in maintainer workflow is `thoughts -> idea -> plan -> task`
   with `idea/task:to-complete`, same-name `consume`, `.claude/worktrees`
@@ -128,8 +128,8 @@
   user-owned tracked edit; ignored workflow files under `factory/inputs/**`
   remain operating state rather than canonical queue truth.
 - Recent merged PRs now include `#112`, `#113`, `#114`, `#115`, `#117`,
-  `#118`, `#119`, `#121`, and `#122`; open PR `#120` is only the meta refresh
-  branch and does not own the next code cleanup lane.
+  `#118`, `#119`, `#121`, and `#122`; open PRs `#120` and `#123` are only
+  meta refresh branches and do not own the next code cleanup lane.
 - The import/export P0, current-selection, submit-work copy, and dashboard UI
   asks remain materially closed on `main`; the remaining ask surface is broader
   program work in standards migration, website coverage, docs audit, manual
@@ -142,7 +142,7 @@
   and `cmd/gocoveragecheck`, but the current aggregate threshold can still
   hide backend-owned packages with `0%` statement coverage.
 
-## 2026-05-06T05:04:15.1266160-07:00 - meta state refresh
+## 2026-05-06T05:07:16.1578424-07:00 - meta state refresh
 
 - Ran `git pull --rebase --autostash origin main`; Git rebased the local docs
   refresh commits onto `origin/main`, bringing in merged PR `#122`
@@ -178,6 +178,11 @@
   `factory/inputs/idea/default/add-backend-zero-coverage-package-gate.md`
   so the next worker can tighten the backend testing gate without broadening
   into a multi-package coverage campaign or a frontend quality lane.
+- Committed the tracked worldview/progress refresh as
+  `e47cbe3` (`docs: refresh meta world state`), attempted `git push origin main`
+  but GitHub rejected the direct push because required status checks gate
+  `main`, then pushed branch `meta-refresh-world-state-20260506-050415` and
+  opened PR `#123` for the latest refresh.
 
 ## 2026-05-06T04:04:39.6158725-07:00 - meta state refresh
 

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -118,6 +118,10 @@
 - When `go test -coverpkg` appends `in <package list>` after
   `coverage: ... of statements`, verify the parser against the full live line
   shape; simplified test fixtures can falsely suggest the gate is complete.
+- When a repo-owned functional-lane command already has the thin entrypoint
+  seam covered, inspect the same package next for untested `main` error paths,
+  `failf` exit behavior, and wrapped discovery or execution failures before
+  widening scope into functional test rewrites or a broader coverage program.
 - When a repo-owned `Makefile` target shells through a thin command under
   `cmd/`, prefer adding a local callable seam plus package-local entrypoint
   tests in that command owner before pushing coverage assertions down into
@@ -140,9 +144,9 @@
 
 ## Current Summary
 
-- As of `2026-05-06T15:03:24.7591584-07:00`, `HEAD` points to `3e82419` on
+- As of `2026-05-06T16:03:38.4962364-07:00`, `HEAD` points to `a25885a` on
   branch `meta-refresh-world-state-20260506-050415`; live `origin/main` points
-  to `24fa5f8` through merged PR `#133`.
+  to `4f21b7b` through merged PR `#134`.
 - The canonical ask surface remains `factory/logs/meta/asks.md`.
 - The checked-in maintainer workflow is `thoughts -> idea -> plan -> task`
   with `idea/task:to-complete`, same-name `consume`, `.claude/worktrees`
@@ -155,7 +159,7 @@
   remain operating state rather than canonical queue truth.
 - Recent merged PRs now include `#112`, `#113`, `#114`, `#115`, `#117`,
   `#118`, `#119`, `#121`, `#122`, `#124`, `#125`, `#126`, `#127`, `#128`,
-  `#129`, `#130`, `#132`, and `#133`; open PRs `#120` and `#123` are only
+  `#129`, `#130`, `#132`, `#133`, and `#134`; open PRs `#120` and `#123` are only
   meta refresh branches and do not own the next code cleanup lane.
 - The canonical ask surface is now the user-owned quality-only rewrite in
   `factory/logs/meta/asks.md`; the active asks are external checklist
@@ -164,11 +168,54 @@
 - The replay fixtures remain historical samples rather than current workflow
   truth, and one rejection payload is still quoted anomalously in the replay
   sample.
-- The next non-overlapping dispatch is the `cmd/gocoveragecheck`
-  command-owner threshold and entrypoint lane: the parser and zero-coverage
-  seams are now closed on `main`, but the repo-owned coverage gate still lacks
-  direct success-path, aggregate-threshold, and exit-behavior coverage while
-  package coverage sits at `77.4%`.
+- The next non-overlapping dispatch is the `cmd/functionallane`
+  command-owner error and entrypoint lane: PR `#126` already covered the thin
+  command-entrypoint routing seam on `main`, but the repo-owned functional
+  lane still lacks direct coverage for `main` failure routing, `failf` exit
+  behavior, `run()` success, and wrapped discovery or execution failures while
+  package coverage sits at `82.0%`.
+
+## 2026-05-06T16:03:38.4962364-07:00 - meta state refresh
+
+- Ran `git pull --ff-only`, saw remote movement on `origin/main`, then ran
+  `git pull --rebase --autostash origin main`; Git rebased the meta branch
+  onto live `origin/main`, pulling in merged PR `#134`
+  (`cover-gocoveragecheck-command-owner-threshold-and-entrypoint-branches`)
+  while preserving the user-owned tracked edit in `factory/logs/meta/asks.md`.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`, current PR
+  state, the tracked-versus-ignored `factory/inputs/**` surface, and the live
+  repo-owned `cmd/` maintainer-gate packages.
+- Re-validated tracked queue truth with `git ls-files factory/inputs`,
+  `Get-ChildItem -Recurse -Force factory/inputs`, and `.gitignore`,
+  confirming the checked-in inboxes remain sentinel-only while the visible
+  idea file is ignored local operating residue.
+- Confirmed the previously queued ignored idea
+  `factory/inputs/idea/default/cover-gocoveragecheck-command-owner-threshold-and-entrypoint-branches.md`
+  is stale because merged PR `#134` already landed that exact cleanup on
+  `main`, so it should be replaced rather than re-queued.
+- Verified with `gh pr list`, `gh pr view 134`, direct reads of
+  `cmd/gocoveragecheck/main_test.go`, delegated explorer inspection, and fresh
+  `go test -cover ./cmd/...` runs that the gocoveragecheck seam is now closed
+  on live `main`; `go test -cover ./cmd/gocoveragecheck` reports `78.5%`
+  statement coverage and PR `#134` owns the remaining rise from the stale
+  pre-merge `77.4%` local result.
+- Used graph-backed discovery, direct reads of `cmd/functionallane/main.go`
+  and `cmd/functionallane/main_test.go`, workflow search over `Makefile` plus
+  `docs/processes/development-guide-relevant-files.md`, and a delegated
+  explorer pass to identify the next narrower command-owner seam: merged PR
+  `#126` already covered the thin entrypoint routing behavior, but the same
+  package still owns untested `main` failure routing, `failf` exit behavior,
+  `run()` success behavior, and wrapped discovery or test-execution failures,
+  and `go test -cover ./cmd/functionallane` still reports `82.0%` statement
+  coverage.
+- Queued one replacement ignored idea under
+  `factory/inputs/idea/default/cover-functionallane-command-owner-error-and-entrypoint-branches.md`
+  so the next worker can raise package-local command coverage for the
+  maintainer-owned default functional lane without changing package discovery
+  policy, widening the functional lane scope, or broadening into package-by-
+  package functional test authoring.
 
 ## 2026-05-06T12:04:09.0951770-07:00 - meta state refresh
 

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -111,6 +111,10 @@
 - An aggregate backend coverage floor can still hide `0%` packages; the first
   useful ratchet is to fail the existing coverage lane on zero-coverage
   backend packages and print the offenders explicitly.
+- When a repo-owned `Makefile` target shells through a thin command under
+  `cmd/`, prefer adding a local callable seam plus package-local entrypoint
+  tests in that command owner before pushing coverage assertions down into
+  unrelated CLI or runtime packages.
 
 ## Current Summary
 
@@ -220,6 +224,41 @@
   `factory/inputs/idea/default/close-backend-coverage-profile-gap.md` so the
   next worker can close that profile-gap loophole without broadening into a
   higher aggregate threshold or a multi-package test-authoring effort.
+
+## 2026-05-06T07:04:44.5861978-07:00 - meta state refresh
+
+- Ran `git pull --rebase --autostash origin main`; Git rebased the meta branch
+  onto live `origin/main`, pulling in merged PR `#125`
+  (`close-backend-coverage-profile-gap`) while preserving the user-owned
+  tracked edit in `factory/logs/meta/asks.md`.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`, recent PR
+  state, the tracked-versus-ignored `factory/inputs/**` surface, and the live
+  repo-owned backend quality lane after the `#125` merge.
+- Re-validated tracked queue truth with `git ls-files factory/inputs`,
+  `rg --files -uu factory/inputs`, and `Get-ChildItem -Recurse factory/inputs`,
+  confirming the checked-in inboxes remain sentinel-only while the visible idea
+  file is ignored local operating state.
+- Confirmed the previously queued ignored idea
+  `factory/inputs/idea/default/close-backend-coverage-profile-gap.md` is stale
+  because merged PR `#125` already landed that exact cleanup on `main`, so it
+  should be replaced rather than re-queued.
+- Verified with `gh pr diff 125`, delegated explorer inspection, and direct
+  reads of `cmd/gocoveragecheck/main.go`, `cmd/gocoveragecheck/main_test.go`,
+  and `cmd/factory/main_test.go` that `main` now closes the recorded
+  report-versus-profile gap and also covers the thin `cmd/factory` entrypoint
+  through a command-local callable seam.
+- Used direct reads of `Makefile` and `cmd/functionallane/main.go` to identify
+  the next narrower sibling seam in the same ask lane: `make test-functional`
+  still shells through the repo-owned `cmd/functionallane` command, which owns
+  functional package discovery and invocation behavior, but it still has no
+  checked-in `cmd/functionallane/main_test.go`.
+- Queued one replacement ignored idea under
+  `factory/inputs/idea/default/cover-functionallane-command-entrypoint.md` so
+  the next worker can make that repo-owned functional-lane command directly
+  testable without broadening into new functional scenarios, coverage-threshold
+  changes, or a wider package-by-package campaign.
 
 ## 2026-05-06T04:04:39.6158725-07:00 - meta state refresh
 

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -111,6 +111,10 @@
 - An aggregate backend coverage floor can still hide `0%` packages; the first
   useful ratchet is to fail the existing coverage lane on zero-coverage
   backend packages and print the offenders explicitly.
+- When `cmd/gocoveragecheck` parses `go test` package summaries, treat both
+  bare `pkg/path  coverage: ...` lines and `ok pkg/path ... coverage: ...`
+  lines as canonical input shapes; backend-owned packages can still report
+  `0.0%` through either format.
 - When a repo-owned `Makefile` target shells through a thin command under
   `cmd/`, prefer adding a local callable seam plus package-local entrypoint
   tests in that command owner before pushing coverage assertions down into
@@ -126,9 +130,9 @@
 
 ## Current Summary
 
-- As of `2026-05-06T10:02:07.1841958-07:00`, `HEAD` points to `93f0b6d` on
+- As of `2026-05-06T11:02:38.5905896-07:00`, `HEAD` points to `1813e37` on
   branch `meta-refresh-world-state-20260506-050415`; local `main` also points
-  to `2c21b00` and contains `origin/main` through merged PR `#128`.
+  to `0e82c26` and contains `origin/main` through merged PR `#129`.
 - The canonical ask surface remains `factory/logs/meta/asks.md`.
 - The checked-in maintainer workflow is `thoughts -> idea -> plan -> task`
   with `idea/task:to-complete`, same-name `consume`, `.claude/worktrees`
@@ -140,21 +144,54 @@
   user-owned tracked edit; ignored workflow files under `factory/inputs/**`
   remain operating state rather than canonical queue truth.
 - Recent merged PRs now include `#112`, `#113`, `#114`, `#115`, `#117`,
-  `#118`, `#119`, `#121`, `#122`, `#124`, `#125`, `#126`, `#127`, and `#128`;
-  open PRs `#120` and `#123` are only
+  `#118`, `#119`, `#121`, `#122`, `#124`, `#125`, `#126`, `#127`, `#128`, and
+  `#129`; open PRs `#120` and `#123` are only
   meta refresh branches and do not own the next code cleanup lane.
-- The import/export P0, current-selection, submit-work copy, and dashboard UI
-  asks remain materially closed on `main`; the remaining ask surface is broader
-  program work in standards migration, website coverage, docs audit, manual
-  QA, and systems-quality documentation.
+- The canonical ask surface is now the user-owned quality-only rewrite in
+  `factory/logs/meta/asks.md`; the active asks are external checklist
+  alignment plus stronger backend and website testing toward a declared
+  `100%` minimum.
 - The replay fixtures remain historical samples rather than current workflow
   truth, and one rejection payload is still quoted anomalously in the replay
   sample.
-- The next non-overlapping dispatch is the release-prep command-entrypoint
-  lane: `make release` shells through `cmd/releaseprep`, internal
-  `releaseprep` tests already cover the policy beneath it, and the
-  maintainer-facing command surface still lacks package-local coverage for flag
-  routing, stdout or stderr wiring, and exit behavior.
+- The next non-overlapping dispatch is the backend coverage summary-parser
+  lane: `cmd/gocoveragecheck` still lets `ok ... coverage: 0.0%` backend
+  package summaries evade failure even though the command is the repo-owned
+  backend coverage gate.
+
+## 2026-05-06T11:02:38.5905896-07:00 - meta state refresh
+
+- Ran `git pull --rebase --autostash origin main`; Git rebased the meta branch
+  onto live `origin/main`, pulling in merged PR `#129`
+  (`cover-releaseprep-command-entrypoint`) while preserving the user-owned
+  tracked edit in `factory/logs/meta/asks.md`.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`, recent PR
+  state, the tracked-versus-ignored `factory/inputs/**` surface, and the live
+  backend coverage gate.
+- Re-validated tracked queue truth with `git ls-files factory/inputs` and
+  `rg --files -uu factory/inputs`, confirming the checked-in inboxes remain
+  sentinel-only while the visible idea file is ignored local operating state.
+- Confirmed the previously queued ignored idea
+  `factory/inputs/idea/default/cover-releaseprep-command-entrypoint.md` is
+  stale because merged PR `#129` already landed that exact cleanup on `main`,
+  so it should be replaced rather than re-queued.
+- Verified with `git log`, `gh pr list`, `gh pr view 129`, direct reads, and a
+  live `cmd/releaseprep/main_test.go` read that `main` now closes the recorded
+  releaseprep command-entrypoint gap and that open PRs `#120` and `#123`
+  remain meta-only.
+- Used direct inspection of `Makefile`, `cmd/gocoveragecheck/main.go`, and
+  `cmd/gocoveragecheck/main_test.go`, plus a live
+  `go run ./cmd/gocoveragecheck -min 0` run, to identify the next narrower
+  quality seam: the repo-owned backend coverage gate still exits successfully
+  even when backend packages such as `pkg/cli/docs` report
+  `0.0% of statements` through an `ok ... coverage:` package-summary line.
+- Queued one replacement ignored idea under
+  `factory/inputs/idea/default/close-backend-coverage-ok-summary-gap.md` so
+  the next worker can close that parser gap without broadening into a higher
+  aggregate threshold, a package-by-package coverage campaign, or another
+  command-entrypoint lane.
 
 ## 2026-05-06T10:02:07.1841958-07:00 - meta state refresh
 

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -184,6 +184,43 @@
   `main`, then pushed branch `meta-refresh-world-state-20260506-050415` and
   opened PR `#123` for the latest refresh.
 
+## 2026-05-06T06:04:20.9377891-07:00 - meta state refresh
+
+- Ran `git pull --rebase --autostash origin main`; Git rebased the meta branch
+  onto live `origin/main`, pulling in merged PR `#124`
+  (`add-backend-zero-coverage-package-gate`) while preserving the user-owned
+  tracked edit in `factory/logs/meta/asks.md`.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`, recent PR
+  state, the tracked-versus-ignored `factory/inputs/**` surface, and the live
+  backend coverage gate after the `#124` merge.
+- Re-validated tracked queue truth with `git ls-files factory/inputs` and
+  `Get-ChildItem -Recurse factory/inputs`, confirming the checked-in inboxes
+  remain sentinel-only while the visible idea file is ignored local operating
+  state.
+- Confirmed the previously queued ignored idea
+  `factory/inputs/idea/default/add-backend-zero-coverage-package-gate.md` is
+  stale because merged PR `#124` already landed that exact cleanup on `main`,
+  so it should be replaced rather than re-queued.
+- Used direct reads, a delegated explorer pass, and a live
+  `go run ./cmd/gocoveragecheck -min 80.0` run to identify the next narrower
+  gap in the same lane: backend packages can still print
+  `coverage: 0.0% of statements` and evade failure when they never appear in
+  the parsed coverage-profile map.
+- Verified the live evidence for that gap on `main`: `pkg/apisurface`,
+  `pkg/buffers`, and `pkg/cli/default` still report `0.0%` coverage while
+  `cmd/gocoveragecheck` exits successfully at `86.4%` total coverage.
+- Confirmed the exact code seam in `cmd/gocoveragecheck/main.go`:
+  `findZeroCoveragePackages` currently skips `!ok` profile-map misses instead
+  of treating them as backend zero-coverage failures, and
+  `cmd/gocoveragecheck/main_test.go` does not yet cover that absent-package
+  case.
+- Queued one replacement ignored idea under
+  `factory/inputs/idea/default/close-backend-coverage-profile-gap.md` so the
+  next worker can close that profile-gap loophole without broadening into a
+  higher aggregate threshold or a multi-package test-authoring effort.
+
 ## 2026-05-06T04:04:39.6158725-07:00 - meta state refresh
 
 - Ran `git pull --no-rebase --autostash origin main`; Git merged `origin/main`

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -133,12 +133,16 @@
 - After a command-entrypoint coverage PR merges, inspect the same package for
   any remaining `0.0%` repo-owned subprocess wrapper before widening scope
   into a different command or a repo-wide coverage campaign.
+- When a repo-owned coverage gate already has parser and zero-coverage
+  regression tests but still trails sibling maintainer commands on package
+  coverage, prefer adding command-owner success and threshold-branch coverage
+  there before widening scope into low-coverage application packages.
 
 ## Current Summary
 
-- As of `2026-05-06T12:04:09.0951770-07:00`, `HEAD` points to `3c36fe7` on
+- As of `2026-05-06T15:03:24.7591584-07:00`, `HEAD` points to `3e82419` on
   branch `meta-refresh-world-state-20260506-050415`; live `origin/main` points
-  to `52aa4e1` through merged PR `#130`.
+  to `24fa5f8` through merged PR `#133`.
 - The canonical ask surface remains `factory/logs/meta/asks.md`.
 - The checked-in maintainer workflow is `thoughts -> idea -> plan -> task`
   with `idea/task:to-complete`, same-name `consume`, `.claude/worktrees`
@@ -151,7 +155,7 @@
   remain operating state rather than canonical queue truth.
 - Recent merged PRs now include `#112`, `#113`, `#114`, `#115`, `#117`,
   `#118`, `#119`, `#121`, `#122`, `#124`, `#125`, `#126`, `#127`, `#128`,
-  `#129`, and `#130`; open PRs `#120` and `#123` are only
+  `#129`, `#130`, `#132`, and `#133`; open PRs `#120` and `#123` are only
   meta refresh branches and do not own the next code cleanup lane.
 - The canonical ask surface is now the user-owned quality-only rewrite in
   `factory/logs/meta/asks.md`; the active asks are external checklist
@@ -160,10 +164,11 @@
 - The replay fixtures remain historical samples rather than current workflow
   truth, and one rejection payload is still quoted anomalously in the replay
   sample.
-- The next non-overlapping dispatch is the backend coverage coverpkg-summary
-  lane: `cmd/gocoveragecheck` still lets live
-  `ok ... coverage: 0.0% of statements in ...` backend package summaries evade
-  failure even though the command is the repo-owned backend coverage gate.
+- The next non-overlapping dispatch is the `cmd/gocoveragecheck`
+  command-owner threshold and entrypoint lane: the parser and zero-coverage
+  seams are now closed on `main`, but the repo-owned coverage gate still lacks
+  direct success-path, aggregate-threshold, and exit-behavior coverage while
+  package coverage sits at `77.4%`.
 
 ## 2026-05-06T12:04:09.0951770-07:00 - meta state refresh
 
@@ -1771,3 +1776,42 @@
   repo-owned git-tag wrapper without changing release-tag policy, moving git
   lookup ownership out of the command, or reopening the broader entrypoint
   lane from PR `#127`.
+
+## 2026-05-06T15:03:24.7591584-07:00 - meta state refresh
+
+- Ran `git pull --ff-only`, saw remote movement on `origin/main`, then ran
+  `git pull --rebase --autostash origin main`; Git rebased the meta branch
+  onto live `origin/main`, pulling in merged PR `#133`
+  (`cover-releasetagcheck-git-tag-wrapper-branches`) while preserving the
+  user-owned tracked edit in `factory/logs/meta/asks.md`.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`, current PR
+  state, the tracked-versus-ignored `factory/inputs/**` surface, and the live
+  maintainer-gate command packages.
+- Re-validated tracked queue truth with `git ls-files factory/inputs` and
+  `Get-ChildItem -Recurse -Force factory/inputs`, confirming the checked-in
+  inboxes remain sentinel-only while the visible idea file was ignored local
+  operating residue.
+- Confirmed the previously queued ignored idea
+  `factory/inputs/idea/default/cover-releasetagcheck-git-tag-wrapper-branches.md`
+  is stale because merged PR `#133` already landed that exact cleanup on
+  `main`, so it should be replaced rather than re-queued.
+- Verified with `gh pr list`, `gh pr view 133`, direct reads of
+  `cmd/releasetagcheck/main_test.go`, delegated explorer inspection, and fresh
+  `go test -cover ./cmd/...` runs that the releasetagcheck wrapper seam is now
+  closed on live `main`; `go test -cover ./cmd/releasetagcheck` reports
+  `92.9%` statement coverage.
+- Used graph-backed discovery, direct reads of `cmd/gocoveragecheck/main.go`
+  and `cmd/gocoveragecheck/main_test.go`, plus a live
+  `go run ./cmd/gocoveragecheck -min 80.0` run, to identify the next narrower
+  command-owner seam: the repo-owned backend coverage gate still lacks direct
+  coverage for successful command completion, aggregate-threshold failure
+  messaging, and `main`/`failf` exit behavior even though parsing and
+  zero-coverage backend-package enforcement were already tightened by the
+  earlier `gocoveragecheck` PRs.
+- Queued one replacement ignored idea under
+  `factory/inputs/idea/default/cover-gocoveragecheck-command-owner-threshold-and-entrypoint-branches.md`
+  so the next worker can raise package-local command coverage for the
+  maintainer-owned backend coverage gate without changing coverage policy,
+  widening the lane scope, or broadening into package-by-package test authoring.

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -115,12 +115,16 @@
   `cmd/`, prefer adding a local callable seam plus package-local entrypoint
   tests in that command owner before pushing coverage assertions down into
   unrelated CLI or runtime packages.
+- When a GitHub workflow shells through a repo-owned `cmd/` entrypoint, keep
+  the workflow contract centralized there and add command-local tests for flag
+  routing and emitted output instead of relying only on lower-level helper
+  package tests.
 
 ## Current Summary
 
-- As of `2026-05-06T05:07:16.1578424-07:00`, `HEAD` points to `e47cbe3` on
+- As of `2026-05-06T08:03:56.8600066-07:00`, `HEAD` points to `527c286` on
   branch `meta-refresh-world-state-20260506-050415`; local `main` also points
-  to `e47cbe3` and contains `origin/main` through merged PR `#122`.
+  to `b0ae97a` and contains `origin/main` through merged PR `#126`.
 - The canonical ask surface remains `factory/logs/meta/asks.md`.
 - The checked-in maintainer workflow is `thoughts -> idea -> plan -> task`
   with `idea/task:to-complete`, same-name `consume`, `.claude/worktrees`
@@ -132,7 +136,8 @@
   user-owned tracked edit; ignored workflow files under `factory/inputs/**`
   remain operating state rather than canonical queue truth.
 - Recent merged PRs now include `#112`, `#113`, `#114`, `#115`, `#117`,
-  `#118`, `#119`, `#121`, and `#122`; open PRs `#120` and `#123` are only
+  `#118`, `#119`, `#121`, `#122`, `#124`, `#125`, and `#126`; open PRs `#120`
+  and `#123` are only
   meta refresh branches and do not own the next code cleanup lane.
 - The import/export P0, current-selection, submit-work copy, and dashboard UI
   asks remain materially closed on `main`; the remaining ask surface is broader
@@ -141,10 +146,11 @@
 - The replay fixtures remain historical samples rather than current workflow
   truth, and one rejection payload is still quoted anomalously in the replay
   sample.
-- The next non-overlapping dispatch is the backend zero-coverage-package gate:
-  the repo already enforces backend coverage through `make test-coverage-go`
-  and `cmd/gocoveragecheck`, but the current aggregate threshold can still
-  hide backend-owned packages with `0%` statement coverage.
+- The next non-overlapping dispatch is the release-tag command-entrypoint lane:
+  release workflows call `cmd/releasetagcheck` directly, helper tests only
+  cover semver parsing today, and the workflow-owned command surface still
+  lacks package-local coverage for flag routing, git lookup, and emitted
+  `release_tag=...` output.
 
 ## 2026-05-06T05:07:16.1578424-07:00 - meta state refresh
 
@@ -259,6 +265,41 @@
   the next worker can make that repo-owned functional-lane command directly
   testable without broadening into new functional scenarios, coverage-threshold
   changes, or a wider package-by-package campaign.
+
+## 2026-05-06T08:03:56.8600066-07:00 - meta state refresh
+
+- Ran `git pull --rebase --autostash origin main`; Git rebased the meta branch
+  onto live `origin/main`, pulling in merged PR `#126`
+  (`cover-functionallane-command-entrypoint`) while preserving the user-owned
+  tracked edit in `factory/logs/meta/asks.md`.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`, recent PR
+  state, the tracked-versus-ignored `factory/inputs/**` surface, and the live
+  release-workflow command boundaries.
+- Re-validated tracked queue truth with `git ls-files factory/inputs`,
+  `Get-ChildItem -Recurse factory/inputs`, delegated explorer summaries, and
+  direct reads, confirming the checked-in inboxes remain sentinel-only while
+  the visible idea file is ignored local operating state.
+- Confirmed the previously queued ignored idea
+  `factory/inputs/idea/default/cover-functionallane-command-entrypoint.md` is
+  stale because merged PR `#126` already landed that exact cleanup on `main`,
+  so it should be replaced rather than re-queued.
+- Verified with `git log`, `gh pr list`, direct reads of
+  `cmd/functionallane/main_test.go`, and the rebased branch state that `main`
+  now closes the recorded functionallane gap and that open PRs `#120` and
+  `#123` remain meta-only.
+- Used code-graph reads plus direct inspection of `Makefile`,
+  `.github/workflows/release-candidate.yml`, `.github/workflows/release.yml`,
+  `cmd/releasetagcheck/main.go`, and `internal/releasetag/releasetag_test.go`
+  to identify the next narrower sibling seam in the same quality lane:
+  release workflows shell through the repo-owned `cmd/releasetagcheck`
+  boundary, but there is still no checked-in `cmd/releasetagcheck/main_test.go`.
+- Queued one replacement ignored idea under
+  `factory/inputs/idea/default/cover-releasetagcheck-command-entrypoint.md` so
+  the next worker can make that workflow-facing command directly testable
+  without changing release behavior, adding a new command surface, or
+  broadening into artifact publication work.
 
 ## 2026-05-06T04:04:39.6158725-07:00 - meta state refresh
 

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -115,6 +115,9 @@
   bare `pkg/path  coverage: ...` lines and `ok pkg/path ... coverage: ...`
   lines as canonical input shapes; backend-owned packages can still report
   `0.0%` through either format.
+- When `go test -coverpkg` appends `in <package list>` after
+  `coverage: ... of statements`, verify the parser against the full live line
+  shape; simplified test fixtures can falsely suggest the gate is complete.
 - When a repo-owned `Makefile` target shells through a thin command under
   `cmd/`, prefer adding a local callable seam plus package-local entrypoint
   tests in that command owner before pushing coverage assertions down into
@@ -130,9 +133,9 @@
 
 ## Current Summary
 
-- As of `2026-05-06T11:02:38.5905896-07:00`, `HEAD` points to `1813e37` on
-  branch `meta-refresh-world-state-20260506-050415`; local `main` also points
-  to `0e82c26` and contains `origin/main` through merged PR `#129`.
+- As of `2026-05-06T12:04:09.0951770-07:00`, `HEAD` points to `3c36fe7` on
+  branch `meta-refresh-world-state-20260506-050415`; live `origin/main` points
+  to `52aa4e1` through merged PR `#130`.
 - The canonical ask surface remains `factory/logs/meta/asks.md`.
 - The checked-in maintainer workflow is `thoughts -> idea -> plan -> task`
   with `idea/task:to-complete`, same-name `consume`, `.claude/worktrees`
@@ -144,8 +147,8 @@
   user-owned tracked edit; ignored workflow files under `factory/inputs/**`
   remain operating state rather than canonical queue truth.
 - Recent merged PRs now include `#112`, `#113`, `#114`, `#115`, `#117`,
-  `#118`, `#119`, `#121`, `#122`, `#124`, `#125`, `#126`, `#127`, `#128`, and
-  `#129`; open PRs `#120` and `#123` are only
+  `#118`, `#119`, `#121`, `#122`, `#124`, `#125`, `#126`, `#127`, `#128`,
+  `#129`, and `#130`; open PRs `#120` and `#123` are only
   meta refresh branches and do not own the next code cleanup lane.
 - The canonical ask surface is now the user-owned quality-only rewrite in
   `factory/logs/meta/asks.md`; the active asks are external checklist
@@ -154,10 +157,45 @@
 - The replay fixtures remain historical samples rather than current workflow
   truth, and one rejection payload is still quoted anomalously in the replay
   sample.
-- The next non-overlapping dispatch is the backend coverage summary-parser
-  lane: `cmd/gocoveragecheck` still lets `ok ... coverage: 0.0%` backend
-  package summaries evade failure even though the command is the repo-owned
-  backend coverage gate.
+- The next non-overlapping dispatch is the backend coverage coverpkg-summary
+  lane: `cmd/gocoveragecheck` still lets live
+  `ok ... coverage: 0.0% of statements in ...` backend package summaries evade
+  failure even though the command is the repo-owned backend coverage gate.
+
+## 2026-05-06T12:04:09.0951770-07:00 - meta state refresh
+
+- Ran `git pull --rebase --autostash origin main`; Git rebased the meta branch
+  onto live `origin/main`, pulling in merged PR `#130`
+  (`close-backend-coverage-ok-summary-gap`) while preserving the user-owned
+  tracked edit in `factory/logs/meta/asks.md`.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`, current PR
+  state, the tracked-versus-ignored `factory/inputs/**` surface, and the live
+  backend and website coverage lanes.
+- Re-validated tracked queue truth with `git ls-files factory/inputs` and
+  `rg --files -uu factory/inputs`, confirming the checked-in inboxes remain
+  sentinel-only while the visible idea file is ignored local operating state.
+- Confirmed the previously queued ignored idea
+  `factory/inputs/idea/default/close-backend-coverage-ok-summary-gap.md` is
+  stale because merged PR `#130` already landed that exact cleanup on `main`,
+  so it should be replaced rather than re-queued.
+- Verified with `gh pr list`, `gh pr view 130`, direct reads, and live
+  `make ui-test-coverage` / `make test-coverage-go` runs that both quality
+  lanes still pass on `main`, with UI coverage holding at `93.42%` statements
+  and backend aggregate coverage holding at `86.5%`.
+- Used direct inspection of `Makefile`, `.github/workflows/ci.yml`,
+  `cmd/gocoveragecheck/main.go`, and `cmd/gocoveragecheck/main_test.go`, plus
+  the live `make test-coverage-go` output, to identify the narrower remaining
+  backend gate seam: the parser now covers bare and simplified `ok ...`
+  package summaries, but it still misses the real `go test -coverpkg` success
+  summary tail when the line ends with
+  `coverage: 0.0% of statements in github.com/portpowered/infinite-you/...`.
+- Queued one replacement ignored idea under
+  `factory/inputs/idea/default/close-backend-coverage-coverpkg-summary-tail-gap.md`
+  so the next worker can close that live parser gap without broadening into a
+  higher aggregate threshold, package-by-package test authoring, or another
+  command-entrypoint lane.
 
 ## 2026-05-06T11:02:38.5905896-07:00 - meta state refresh
 

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,11 +2,11 @@
 
 ## world state
 
-- as of `2026-05-06T07:04:44.5861978-07:00`, local `HEAD` on
-  `meta-refresh-world-state-20260506-050415` points to `87324ab`
+- as of `2026-05-06T08:03:56.8600066-07:00`, local `HEAD` on
+  `meta-refresh-world-state-20260506-050415` points to `527c286`
   (`docs: refresh meta world state`) and has been rebased onto live
-  `origin/main` through `d3785b4`
-  (`Merge pull request #125 from portpowered/ralph/close-backend-coverage-profile-gap`)
+  `origin/main` through `b0ae97a`
+  (`Merge pull request #126 from portpowered/ralph/cover-functionallane-command-entrypoint`)
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - the local worktree is not clean:
   - canonical `factory/inputs/**` remains tracked-sentinel-only
@@ -15,7 +15,7 @@
   - `factory/logs/meta/asks.md` carries a local tracked edit and should be
     treated as user-owned state for this refresh
   - tracked meta-log updates are required because the last checked-in summary
-    predates merged PR `#125`
+    predates merged PR `#126`
   - ignored local workflow residue under `factory/inputs/**` must still be
     treated as operating state rather than checked-in queue truth
 
@@ -53,13 +53,13 @@
   `factory/inputs/<work-type>/<file>` submissions as an implicit `default`
   channel fallback
 - the visible ignored local idea residue at the start of this refresh was:
-  - `factory/inputs/idea/default/close-backend-coverage-profile-gap.md`
+  - `factory/inputs/idea/default/cover-functionallane-command-entrypoint.md`
 - that ignored idea was stale queue residue rather than checked-in queue truth
-  because merged PR `#125` already landed that backend coverage profile-gap
+  because merged PR `#126` already landed that functionallane command-entrypoint
   cleanup on `main`
 - it has been replaced during this refresh with one narrower customer-ask
   follow-up idea:
-  - `factory/inputs/idea/default/cover-functionallane-command-entrypoint.md`
+  - `factory/inputs/idea/default/cover-releasetagcheck-command-entrypoint.md`
 
 ## customer-ask truth
 
@@ -96,6 +96,8 @@
 ## recent repo movement
 
 - recent merged PRs on `main` now include:
+  - `#126` `cover-functionallane-command-entrypoint`, merged on
+    `2026-05-06T14:18:07Z`
   - `#125` `close-backend-coverage-profile-gap`, merged on
     `2026-05-06T13:46:50Z`
   - `#124` `add-backend-zero-coverage-package-gate`, merged on
@@ -127,31 +129,31 @@
 ## next cleanup candidate
 
 - there is no remaining narrow unowned customer-visible ask gap on `main`
-- merged PR `#125` materially closes the previously recorded backend
-  coverage-profile loophole on `main`:
-  - `cmd/gocoveragecheck/main.go` now reads package-level `0.0%` coverage from
-    real `go test` summary output in addition to the parsed coverage profile
-  - `cmd/gocoveragecheck/main_test.go` now covers both present-in-profile and
-    missing-from-profile backend zero-coverage cases plus excluded packages
-  - `cmd/factory/main.go` and `cmd/factory/main_test.go` now keep the thin CLI
-    entrypoint directly testable so that repo-owned backend coverage can count
-    the command owner instead of pushing entrypoint assertions into unrelated
-    package tests
+- merged PR `#126` materially closes the previously recorded functionallane
+  command-entrypoint gap on `main`:
+  - `cmd/functionallane/main.go` now exposes a thin callable seam so the
+    repo-owned command boundary is directly testable
+  - `cmd/functionallane/main_test.go` now covers `main` execution, functional
+    package discovery, `internal/support` filtering, empty-lane failure, and
+    final `go test` invocation wiring
+  - `Makefile` still keeps `test-functional` routed through the same
+    repo-owned command surface rather than moving coverage assertions into
+    unrelated packages
 - the next non-overlapping dispatch should keep advancing the broad P0 testing
-  ask through adjacent repo-owned command surfaces instead of broadening into a
-  package-by-package coverage campaign:
-  - `Makefile` still routes `test-functional` through
-    `go run ./cmd/functionallane`
-  - `cmd/functionallane/main.go` owns functional package discovery,
-    `internal/support` filtering, config parsing, and the final `go test`
-    command invocation for that repo-owned lane
-  - there is still no checked-in `cmd/functionallane/main_test.go`
-  - the repo just established the narrower command-entrypoint pattern in
-    `cmd/factory`, so `cmd/functionallane` is the nearest sibling seam in the
-    same quality lane
-- the next idea should make `cmd/functionallane` directly testable with focused
-  command-owner coverage, without replacing `make test-functional`, changing
-  package selection semantics, or broadening into new functional scenarios
+  ask through adjacent repo-owned command surfaces and workflow boundaries
+  instead of broadening into a package-by-package coverage campaign:
+  - `.github/workflows/release-candidate.yml` calls
+    `go run ./cmd/releasetagcheck -tag "$RELEASE_TAG"`
+  - `.github/workflows/release.yml` calls
+    `go run ./cmd/releasetagcheck -points-at HEAD`
+  - `cmd/releasetagcheck/main.go` owns the workflow-visible behavior for flag
+    exclusivity, semver validation, git tag resolution, and emitted
+    `release_tag=...` output
+  - `internal/releasetag/releasetag_test.go` covers semver parsing helpers, but
+    there is still no checked-in `cmd/releasetagcheck/main_test.go`
+- the next idea should make `cmd/releasetagcheck` directly testable with
+  focused command-owner coverage, without changing release workflow behavior,
+  adding a new release surface, or broadening into artifact-publish logic
 
 ## theory of mind
 
@@ -180,3 +182,6 @@
 - when one repo-owned command entrypoint gains a thin test seam to satisfy a
   coverage ask, inspect sibling repo-owned lane commands next before pushing
   equivalent coverage assertions down into unrelated downstream packages
+- when a GitHub workflow shells through a repo-owned `cmd/` entrypoint, treat
+  its output format and flag-routing behavior as command-owner seams even if
+  helper packages beneath it already have unit tests

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,11 +2,11 @@
 
 ## world state
 
-- as of `2026-05-06T13:04:11.9967894-07:00`, local `HEAD` on
-  `meta-refresh-world-state-20260506-050415` points to `2d1f89b`
+- as of `2026-05-06T14:03:39.1137712-07:00`, local `HEAD` on
+  `meta-refresh-world-state-20260506-050415` points to `86a9d60`
   (`docs: refresh meta world state`) and has been rebased onto live
-  `origin/main` through `a2f82d7`
-  (`Merge pull request #131 from portpowered/ralph/close-backend-coverage-coverpkg-summary-tail-gap`)
+  `origin/main` through `ed8b6b5`
+  (`cover-deadcodecheck-command-owner-branches (#132)`)
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - the local worktree is not clean:
   - canonical `factory/inputs/**` remains tracked-sentinel-only
@@ -15,7 +15,7 @@
   - `factory/logs/meta/asks.md` carries a local tracked edit and should be
     treated as user-owned state for this refresh
   - tracked meta-log updates are required because the last checked-in summary
-    predates merged PR `#131`
+    predates merged PR `#132`
   - ignored local workflow residue under `factory/inputs/**` must still be
     treated as operating state rather than checked-in queue truth
 
@@ -52,13 +52,13 @@
   contract and no longer accepts direct
   `factory/inputs/<work-type>/<file>` submissions as an implicit `default`
   channel fallback
-- the visible ignored local idea residue at the start of this refresh was:
-  - `factory/inputs/idea/default/close-backend-coverage-coverpkg-summary-tail-gap.md`
+- the visible ignored local idea residue after rebasing onto live `main` was:
+  - `factory/inputs/idea/default/cover-deadcodecheck-command-owner-branches.md`
 - that ignored idea is now stale queue residue rather than checked-in queue
-  truth because merged PR `#131` already landed that exact cleanup on `main`
+  truth because merged PR `#132` already landed that exact cleanup on `main`
 - it has been replaced during this refresh with one narrower customer-ask
   follow-up idea:
-  - `factory/inputs/idea/default/cover-deadcodecheck-command-owner-branches.md`
+  - `factory/inputs/idea/default/cover-releasetagcheck-git-tag-wrapper-branches.md`
 
 ## customer-ask truth
 
@@ -88,6 +88,8 @@
 ## recent repo movement
 
 - recent merged PRs on `main` now include:
+  - `#132` `cover-deadcodecheck-command-owner-branches`, merged on
+    `2026-05-06T20:27:02Z`
   - `#131` `close-backend-coverage-coverpkg-summary-tail-gap`, merged on
     `2026-05-06T19:11:57Z`
   - `#130` `close-backend-coverage-ok-summary-gap`, merged on
@@ -131,23 +133,24 @@
 
 ## next cleanup candidate
 
-- merged PR `#131` closes the previously recorded `gocoveragecheck`
-  trailing-summary parser seam on live `main`
+- merged PR `#132` closes the previously recorded `cmd/deadcodecheck`
+  command-owner branch seam on live `main`
 - the next non-overlapping dispatch should keep advancing the broad quality ask
   by tightening another existing repo-owned maintainer gate instead of
   broadening into a package-by-package test campaign:
-  - `Makefile` still routes the deadcode gate through
-    `go run ./cmd/deadcodecheck`
-  - `cmd/deadcodecheck/main.go` owns the command-local baseline-drift contract,
-    `bin/deadcode-current.txt` write path, deadcode tool invocation, stderr
-    forwarding, and exit behavior
-  - `cmd/deadcodecheck/main_test.go` currently covers only
-    `ensureGoTypesAliasEnabled`
-  - `go test -cover ./cmd/deadcodecheck` currently reports `23.4%` statement
-    coverage
-- the next idea should add command-owner tests for `cmd/deadcodecheck`
-  failure and drift branches without changing deadcode policy, editing the
-  baseline as scope creep, or reopening the just-closed coverage parser lane
+  - `.github/workflows/release.yml` still resolves the release tag through
+    `go run ./cmd/releasetagcheck -points-at HEAD`
+  - `.github/workflows/release-candidate.yml` still validates explicit release
+    tags through `go run ./cmd/releasetagcheck -tag "$RELEASE_TAG"`
+  - merged PR `#127` covered the command entrypoint and argument-routing
+    behavior, but `cmd/releasetagcheck/main.go` still owns the live
+    `git tag --points-at` subprocess wrapper in `gitTagsPointingAt`
+  - `go test -cover ./cmd/releasetagcheck` still reports `71.4%` statement
+    coverage because `gitTagsPointingAt` remains at `0.0%`
+- the next idea should add focused package-local tests for
+  `cmd/releasetagcheck`'s repo-owned git-tag wrapper success and failure
+  branches without changing release-tag policy, moving git lookup ownership
+  out of the command, or reopening the broader entrypoint lane from PR `#127`
 
 ## theory of mind
 
@@ -193,3 +196,6 @@
   repo-owned `cmd/` entrypoint and the command test file only covers helper
   functions, treat the missing baseline-drift and failure-path coverage as the
   next narrow quality seam before inventing new repo-wide deadcode work
+- when a repo-owned command-entrypoint PR closes the main routing seam, inspect
+  the same package for any remaining `0.0%` subprocess-wrapper function before
+  widening scope into a different command or a repo-wide coverage campaign

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,11 +2,11 @@
 
 ## world state
 
-- as of `2026-05-06T10:02:07.1841958-07:00`, local `HEAD` on
-  `meta-refresh-world-state-20260506-050415` points to `93f0b6d`
+- as of `2026-05-06T11:02:38.5905896-07:00`, local `HEAD` on
+  `meta-refresh-world-state-20260506-050415` points to `1813e37`
   (`docs: refresh meta world state`) and has been rebased onto live
-  `origin/main` through `2c21b00`
-  (`Merge pull request #128 from portpowered/ralph/cover-releasesmoke-command-entrypoint`)
+  `origin/main` through `0e82c26`
+  (`Merge pull request #129 from portpowered/ralph/cover-releaseprep-command-entrypoint`)
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - the local worktree is not clean:
   - canonical `factory/inputs/**` remains tracked-sentinel-only
@@ -15,7 +15,7 @@
   - `factory/logs/meta/asks.md` carries a local tracked edit and should be
     treated as user-owned state for this refresh
   - tracked meta-log updates are required because the last checked-in summary
-    predates merged PR `#128`
+    predates merged PR `#129`
   - ignored local workflow residue under `factory/inputs/**` must still be
     treated as operating state rather than checked-in queue truth
 
@@ -53,31 +53,24 @@
   `factory/inputs/<work-type>/<file>` submissions as an implicit `default`
   channel fallback
 - the visible ignored local idea residue at the start of this refresh was:
-  - `factory/inputs/idea/default/cover-releasesmoke-command-entrypoint.md`
+  - `factory/inputs/idea/default/cover-releaseprep-command-entrypoint.md`
 - that ignored idea was stale queue residue rather than checked-in queue truth
-  because merged PR `#128` already landed that releasesmoke command-entrypoint
+  because merged PR `#129` already landed that releaseprep command-entrypoint
   cleanup on `main`
 - it has been replaced during this refresh with one narrower customer-ask
   follow-up idea:
-  - `factory/inputs/idea/default/cover-releaseprep-command-entrypoint.md`
+  - `factory/inputs/idea/default/close-backend-coverage-ok-summary-gap.md`
 
 ## customer-ask truth
 
-- the import/export P0 lane remains materially closed on `main` through merged
-  PRs `#67`, `#68`, `#69`, `#70`, `#71`, `#72`, `#93`, and `#109`
-- the selected-work current-selection ask is materially satisfied on `main`
-  through merged PRs `#74`, `#77`, and `#110`
-- the submit-work copy ask is satisfied on `main` through merged PR `#75`
-- the header verbosity, chart layout, branding/iconography, and button-tone
-  asks are materially satisfied on `main` through merged PRs `#83`, `#84`,
-  `#85`, `#86`, `#87`, and `#98`
-- the remaining open asks in `factory/logs/meta/asks.md` are broader program
-  work rather than narrow customer-visible regressions:
-  - standards-migration checklist tracking
-  - backend and website `100%` coverage target plus stronger test enforcement
-  - docs audit
-  - manual QA
-  - systems-quality documentation
+- the canonical ask surface is now narrower than the last checked-in summary
+  because the user-owned tracked edit in `factory/logs/meta/asks.md` has
+  collapsed it to one active quality lane plus an autonomy notice
+- the remaining active asks are broader program work rather than narrow
+  customer-visible regressions:
+  - follow the external website/backend checklist set and create alignment
+    tasks
+  - raise backend and website testing toward a declared `100%` minimum
 
 ## replay truth
 
@@ -96,6 +89,8 @@
 ## recent repo movement
 
 - recent merged PRs on `main` now include:
+  - `#129` `cover-releaseprep-command-entrypoint`, merged on
+    `2026-05-06T17:26:30Z`
   - `#128` `cover-releasesmoke-command-entrypoint`, merged on
     `2026-05-06T16:25:12Z`
   - `#127` `cover-releasetagcheck-command-entrypoint`, merged on
@@ -132,32 +127,29 @@
 
 ## next cleanup candidate
 
-- there is no remaining narrow unowned customer-visible ask gap on `main`
-- merged PR `#128` materially closes the previously recorded releasesmoke
-  command-entrypoint gap on `main`:
-  - `cmd/releasesmoke/main.go` now exposes a thin callable seam so the
-    script-facing command boundary is directly testable
-  - `cmd/releasesmoke/main_test.go` now covers `main` execution, flag routing,
-    structured JSON stdout, structured JSON stderr, and non-zero exit behavior
-  - `scripts/release/smoke-artifact.sh` and
-    `scripts/release/smoke-artifact.ps1` still keep release smoke verification
-    routed through the same repo-owned command surface rather than moving those
-    assertions into wrapper-only coverage
-- the next non-overlapping dispatch should keep advancing the broad P0 testing
-  ask through adjacent repo-owned command surfaces and workflow boundaries
-  instead of broadening into a package-by-package coverage campaign:
-  - `Makefile` still exposes the maintainer release surface as
-    `go run ./cmd/releaseprep -version $(VERSION)`
-  - `cmd/releaseprep/main.go` still owns command-visible `-version` flag
-    parsing, stdout or stderr wiring, and exit behavior for the release-prep
-    lane
-  - `internal/releaseprep/releaseprep_test.go` already covers the policy
-    behavior beneath that boundary, but there is still no checked-in
-    `cmd/releaseprep/main_test.go`
-- the next idea should make `cmd/releaseprep` directly testable with focused
-  command-owner coverage, without changing release policy sequencing,
-  broadening into GitHub release workflow changes, or moving those assertions
-  down into `internal/releaseprep`
+- there is no remaining narrow unowned repo-owned `cmd/` entrypoint coverage
+  gap on live `main`; merged PR `#129` closes the previously recorded
+  releaseprep command-owner seam
+- the next non-overlapping dispatch should keep advancing the broad quality ask
+  by tightening an existing enforcement seam instead of broadening into a
+  package-by-package coverage campaign:
+  - `Makefile` still routes backend coverage through
+    `go run ./cmd/gocoveragecheck -min $(GO_COVERAGE_MIN)`
+  - `cmd/gocoveragecheck/main.go` now catches backend packages that are absent
+    from the parsed coverage-profile map when their package-summary lines are
+    bare `pkg/path  coverage: 0.0%` entries
+  - but the live command still misses backend packages reported as
+    `ok pkg/path ... coverage: 0.0% of statements`
+- the gap is currently observable on live `main`:
+  - `go run ./cmd/gocoveragecheck -min 0` exits successfully and reports
+    `Go coverage 86.5% meets minimum 0.0%.`
+  - the same run prints `ok   github.com/portpowered/infinite-you/pkg/cli/docs`
+    with `coverage: 0.0% of statements`
+  - `cmd/gocoveragecheck/main_test.go` covers bare zero-coverage package
+    summaries, but not the `ok ... coverage:` summary shape
+- the next idea should close that parser gap without changing the aggregate
+  threshold, broadening into package-by-package test authoring, or reopening
+  the already-closed command-entrypoint lane
 
 ## theory of mind
 
@@ -183,6 +175,9 @@
 - when a broad quality or coverage ask is open, prefer tightening an existing
   repo-owned enforcement seam before queueing a repo-wide test-authoring
   program
+- when a repo-owned coverage gate parses `go test` package summaries, account
+  for both bare `pkg/path  coverage: ...` lines and `ok pkg/path ... coverage:
+  ...` lines; backend packages can surface `0.0%` through either shape
 - when one repo-owned command entrypoint gains a thin test seam to satisfy a
   coverage ask, inspect sibling repo-owned lane commands next before pushing
   equivalent coverage assertions down into unrelated downstream packages

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,10 +2,10 @@
 
 ## world state
 
-- as of `2026-05-06T05:04:15.1266160-07:00`, local `HEAD` on `main` points to
-  `d17acf1`
-  (`docs: refresh meta world state`) and contains the merged `origin/main`
-  baseline through `cee2465`
+- as of `2026-05-06T05:07:16.1578424-07:00`, local `HEAD` on
+  `meta-refresh-world-state-20260506-050415` points to `e47cbe3`
+  (`docs: refresh meta world state`); local `main` also points to `e47cbe3`
+  and contains the merged `origin/main` baseline through `cee2465`
   (`Merge pull request #122 from portpowered/ralph/collapse-runtime-api-functional-server-lifecycle-owner`)
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - the local worktree is not clean:
@@ -114,10 +114,11 @@
   - `#112` `updated website export to support exporting bundled files`, merged
     on `2026-05-06T07:45:59Z`
   - `#111` `remove-init-default-models`, merged on `2026-05-06T07:09:23Z`
-- `gh pr list --state open` currently reports one open PR:
+- `gh pr list --state open` currently reports two open PRs:
+  - `#123` `docs: refresh meta world state`
   - `#120` `docs: refresh meta world state`
-- PR `#120` is a meta-log refresh branch and does not own the next code cleanup
-  lane
+- PRs `#120` and `#123` are meta-log refresh branches and do not own the next
+  code cleanup lane; `#123` is the latest pushed refresh branch for this turn
 
 ## next cleanup candidate
 

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,11 +2,11 @@
 
 ## world state
 
-- as of `2026-05-06T08:03:56.8600066-07:00`, local `HEAD` on
-  `meta-refresh-world-state-20260506-050415` points to `527c286`
+- as of `2026-05-06T09:04:02.6782977-07:00`, local `HEAD` on
+  `meta-refresh-world-state-20260506-050415` points to `337fdb2`
   (`docs: refresh meta world state`) and has been rebased onto live
-  `origin/main` through `b0ae97a`
-  (`Merge pull request #126 from portpowered/ralph/cover-functionallane-command-entrypoint`)
+  `origin/main` through `7ee70eb`
+  (`Merge pull request #127 from portpowered/ralph/cover-releasetagcheck-command-entrypoint`)
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - the local worktree is not clean:
   - canonical `factory/inputs/**` remains tracked-sentinel-only
@@ -15,7 +15,7 @@
   - `factory/logs/meta/asks.md` carries a local tracked edit and should be
     treated as user-owned state for this refresh
   - tracked meta-log updates are required because the last checked-in summary
-    predates merged PR `#126`
+    predates merged PR `#127`
   - ignored local workflow residue under `factory/inputs/**` must still be
     treated as operating state rather than checked-in queue truth
 
@@ -53,13 +53,13 @@
   `factory/inputs/<work-type>/<file>` submissions as an implicit `default`
   channel fallback
 - the visible ignored local idea residue at the start of this refresh was:
-  - `factory/inputs/idea/default/cover-functionallane-command-entrypoint.md`
+  - `factory/inputs/idea/default/cover-releasetagcheck-command-entrypoint.md`
 - that ignored idea was stale queue residue rather than checked-in queue truth
-  because merged PR `#126` already landed that functionallane command-entrypoint
+  because merged PR `#127` already landed that releasetagcheck command-entrypoint
   cleanup on `main`
 - it has been replaced during this refresh with one narrower customer-ask
   follow-up idea:
-  - `factory/inputs/idea/default/cover-releasetagcheck-command-entrypoint.md`
+  - `factory/inputs/idea/default/cover-releasesmoke-command-entrypoint.md`
 
 ## customer-ask truth
 
@@ -96,6 +96,8 @@
 ## recent repo movement
 
 - recent merged PRs on `main` now include:
+  - `#127` `cover-releasetagcheck-command-entrypoint`, merged on
+    `2026-05-06T15:17:38Z`
   - `#126` `cover-functionallane-command-entrypoint`, merged on
     `2026-05-06T14:18:07Z`
   - `#125` `close-backend-coverage-profile-gap`, merged on
@@ -129,31 +131,34 @@
 ## next cleanup candidate
 
 - there is no remaining narrow unowned customer-visible ask gap on `main`
-- merged PR `#126` materially closes the previously recorded functionallane
+- merged PR `#127` materially closes the previously recorded releasetagcheck
   command-entrypoint gap on `main`:
-  - `cmd/functionallane/main.go` now exposes a thin callable seam so the
-    repo-owned command boundary is directly testable
-  - `cmd/functionallane/main_test.go` now covers `main` execution, functional
-    package discovery, `internal/support` filtering, empty-lane failure, and
-    final `go test` invocation wiring
-  - `Makefile` still keeps `test-functional` routed through the same
-    repo-owned command surface rather than moving coverage assertions into
-    unrelated packages
+  - `cmd/releasetagcheck/main.go` now exposes a thin callable seam so the
+    workflow-facing command boundary is directly testable
+  - `cmd/releasetagcheck/main_test.go` now covers `main` execution, explicit
+    `-tag` validation, `-points-at` lookup behavior, mutual exclusivity
+    failures, surfaced git failures, and exact `release_tag=...` output
+  - `.github/workflows/release-candidate.yml` and `.github/workflows/release.yml`
+    still keep release-tag resolution routed through the same repo-owned
+    command surface rather than moving those assertions into workflow-only
+    coverage
 - the next non-overlapping dispatch should keep advancing the broad P0 testing
   ask through adjacent repo-owned command surfaces and workflow boundaries
   instead of broadening into a package-by-package coverage campaign:
-  - `.github/workflows/release-candidate.yml` calls
-    `go run ./cmd/releasetagcheck -tag "$RELEASE_TAG"`
-  - `.github/workflows/release.yml` calls
-    `go run ./cmd/releasetagcheck -points-at HEAD`
-  - `cmd/releasetagcheck/main.go` owns the workflow-visible behavior for flag
-    exclusivity, semver validation, git tag resolution, and emitted
-    `release_tag=...` output
-  - `internal/releasetag/releasetag_test.go` covers semver parsing helpers, but
-    there is still no checked-in `cmd/releasetagcheck/main_test.go`
-- the next idea should make `cmd/releasetagcheck` directly testable with
-  focused command-owner coverage, without changing release workflow behavior,
-  adding a new release surface, or broadening into artifact-publish logic
+  - `scripts/release/smoke-artifact.sh` calls
+    `go run ./cmd/releasesmoke -binary "$1" -fixture "$2" -timeout "$TIMEOUT"`
+  - `scripts/release/smoke-artifact.ps1` calls
+    `go run ./cmd/releasesmoke -binary $BinaryPath -fixture $FixturePath -timeout $Timeout`
+  - `cmd/releasesmoke/main.go` owns the script-visible behavior for flag
+    parsing, harness invocation wiring, structured JSON success output, and
+    structured JSON failure output
+  - `tests/release/release_smoke_test.go` and `internal/releasesmoke` already
+    cover the harness behavior beneath that boundary, but there is still no
+    checked-in `cmd/releasesmoke/main_test.go`
+- the next idea should make `cmd/releasesmoke` directly testable with focused
+  command-owner coverage, without changing release smoke behavior, moving
+  verification logic into shell wrappers, or broadening into workflow or
+  artifact-packaging changes
 
 ## theory of mind
 

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,11 +2,11 @@
 
 ## world state
 
-- as of `2026-05-06T14:03:39.1137712-07:00`, local `HEAD` on
-  `meta-refresh-world-state-20260506-050415` points to `86a9d60`
+- as of `2026-05-06T15:03:24.7591584-07:00`, local `HEAD` on
+  `meta-refresh-world-state-20260506-050415` points to `3e82419`
   (`docs: refresh meta world state`) and has been rebased onto live
-  `origin/main` through `ed8b6b5`
-  (`cover-deadcodecheck-command-owner-branches (#132)`)
+  `origin/main` through `24fa5f8`
+  (`cover-releasetagcheck-git-tag-wrapper-branches (#133)`)
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - the local worktree is not clean:
   - canonical `factory/inputs/**` remains tracked-sentinel-only
@@ -15,7 +15,7 @@
   - `factory/logs/meta/asks.md` carries a local tracked edit and should be
     treated as user-owned state for this refresh
   - tracked meta-log updates are required because the last checked-in summary
-    predates merged PR `#132`
+    predates merged PR `#133`
   - ignored local workflow residue under `factory/inputs/**` must still be
     treated as operating state rather than checked-in queue truth
 
@@ -53,12 +53,12 @@
   `factory/inputs/<work-type>/<file>` submissions as an implicit `default`
   channel fallback
 - the visible ignored local idea residue after rebasing onto live `main` was:
-  - `factory/inputs/idea/default/cover-deadcodecheck-command-owner-branches.md`
+  - `factory/inputs/idea/default/cover-releasetagcheck-git-tag-wrapper-branches.md`
 - that ignored idea is now stale queue residue rather than checked-in queue
-  truth because merged PR `#132` already landed that exact cleanup on `main`
+  truth because merged PR `#133` already landed that exact cleanup on `main`
 - it has been replaced during this refresh with one narrower customer-ask
   follow-up idea:
-  - `factory/inputs/idea/default/cover-releasetagcheck-git-tag-wrapper-branches.md`
+  - `factory/inputs/idea/default/cover-gocoveragecheck-command-owner-threshold-and-entrypoint-branches.md`
 
 ## customer-ask truth
 
@@ -88,6 +88,8 @@
 ## recent repo movement
 
 - recent merged PRs on `main` now include:
+  - `#133` `cover-releasetagcheck-git-tag-wrapper-branches`, merged on
+    `2026-05-06T21:11:35Z`
   - `#132` `cover-deadcodecheck-command-owner-branches`, merged on
     `2026-05-06T20:27:02Z`
   - `#131` `close-backend-coverage-coverpkg-summary-tail-gap`, merged on
@@ -133,24 +135,26 @@
 
 ## next cleanup candidate
 
-- merged PR `#132` closes the previously recorded `cmd/deadcodecheck`
-  command-owner branch seam on live `main`
+- merged PR `#133` closes the previously recorded `cmd/releasetagcheck`
+  git-wrapper seam on live `main`
 - the next non-overlapping dispatch should keep advancing the broad quality ask
   by tightening another existing repo-owned maintainer gate instead of
   broadening into a package-by-package test campaign:
-  - `.github/workflows/release.yml` still resolves the release tag through
-    `go run ./cmd/releasetagcheck -points-at HEAD`
-  - `.github/workflows/release-candidate.yml` still validates explicit release
-    tags through `go run ./cmd/releasetagcheck -tag "$RELEASE_TAG"`
-  - merged PR `#127` covered the command entrypoint and argument-routing
-    behavior, but `cmd/releasetagcheck/main.go` still owns the live
-    `git tag --points-at` subprocess wrapper in `gitTagsPointingAt`
-  - `go test -cover ./cmd/releasetagcheck` still reports `71.4%` statement
-    coverage because `gitTagsPointingAt` remains at `0.0%`
+  - `Makefile` still routes the backend coverage lane through
+    `go run ./cmd/gocoveragecheck -min $(GO_COVERAGE_MIN)`
+  - `docs/processes/development-guide-relevant-files.md` still names
+    `cmd/gocoveragecheck/` as the repo-owned backend coverage policy owner
+  - merged PRs `#124`, `#130`, and `#131` already covered zero-coverage
+    backend-package enforcement and real `go test` package-summary parsing
+  - `cmd/gocoveragecheck/main_test.go` still does not cover the command-owner
+    success-path emission, aggregate-threshold failure branch, or direct
+    `main` and `failf` exit behavior
+  - `go test -cover ./cmd/gocoveragecheck` still reports `77.4%` statement
+    coverage, materially below the sibling maintainer-gate command packages
 - the next idea should add focused package-local tests for
-  `cmd/releasetagcheck`'s repo-owned git-tag wrapper success and failure
-  branches without changing release-tag policy, moving git lookup ownership
-  out of the command, or reopening the broader entrypoint lane from PR `#127`
+  `cmd/gocoveragecheck`'s command-owner threshold and entrypoint branches
+  without changing coverage policy, widening the coverage lane scope, or
+  pushing these assertions down into unrelated backend packages
 
 ## theory of mind
 
@@ -199,3 +203,7 @@
 - when a repo-owned command-entrypoint PR closes the main routing seam, inspect
   the same package for any remaining `0.0%` subprocess-wrapper function before
   widening scope into a different command or a repo-wide coverage campaign
+- when a repo-owned coverage gate already has parser and zero-coverage
+  regression tests but still trails sibling maintainer commands on package
+  coverage, prefer adding command-owner success and threshold-branch coverage
+  there before widening scope into low-coverage application packages

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,11 +2,11 @@
 
 ## world state
 
-- as of `2026-05-06T11:02:38.5905896-07:00`, local `HEAD` on
-  `meta-refresh-world-state-20260506-050415` points to `1813e37`
+- as of `2026-05-06T12:04:09.0951770-07:00`, local `HEAD` on
+  `meta-refresh-world-state-20260506-050415` points to `3c36fe7`
   (`docs: refresh meta world state`) and has been rebased onto live
-  `origin/main` through `0e82c26`
-  (`Merge pull request #129 from portpowered/ralph/cover-releaseprep-command-entrypoint`)
+  `origin/main` through `52aa4e1`
+  (`Merge pull request #130 from portpowered/ralph/close-backend-coverage-ok-summary-gap`)
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - the local worktree is not clean:
   - canonical `factory/inputs/**` remains tracked-sentinel-only
@@ -15,7 +15,7 @@
   - `factory/logs/meta/asks.md` carries a local tracked edit and should be
     treated as user-owned state for this refresh
   - tracked meta-log updates are required because the last checked-in summary
-    predates merged PR `#129`
+    predates merged PR `#130`
   - ignored local workflow residue under `factory/inputs/**` must still be
     treated as operating state rather than checked-in queue truth
 
@@ -53,13 +53,12 @@
   `factory/inputs/<work-type>/<file>` submissions as an implicit `default`
   channel fallback
 - the visible ignored local idea residue at the start of this refresh was:
-  - `factory/inputs/idea/default/cover-releaseprep-command-entrypoint.md`
-- that ignored idea was stale queue residue rather than checked-in queue truth
-  because merged PR `#129` already landed that releaseprep command-entrypoint
-  cleanup on `main`
+  - `factory/inputs/idea/default/close-backend-coverage-ok-summary-gap.md`
+- that ignored idea is now stale queue residue rather than checked-in queue
+  truth because merged PR `#130` already landed that exact cleanup on `main`
 - it has been replaced during this refresh with one narrower customer-ask
   follow-up idea:
-  - `factory/inputs/idea/default/close-backend-coverage-ok-summary-gap.md`
+  - `factory/inputs/idea/default/close-backend-coverage-coverpkg-summary-tail-gap.md`
 
 ## customer-ask truth
 
@@ -89,6 +88,8 @@
 ## recent repo movement
 
 - recent merged PRs on `main` now include:
+  - `#130` `close-backend-coverage-ok-summary-gap`, merged on
+    `2026-05-06T18:20:24Z`
   - `#129` `cover-releaseprep-command-entrypoint`, merged on
     `2026-05-06T17:26:30Z`
   - `#128` `cover-releasesmoke-command-entrypoint`, merged on
@@ -123,7 +124,8 @@
   - `#123` `docs: refresh meta world state`
   - `#120` `docs: refresh meta world state`
 - PRs `#120` and `#123` are meta-log refresh branches and do not own the next
-  code cleanup lane; `#123` is the latest pushed refresh branch for this turn
+  code cleanup lane; `#123` remains the latest pushed refresh branch for this
+  turn
 
 ## next cleanup candidate
 
@@ -137,19 +139,23 @@
     `go run ./cmd/gocoveragecheck -min $(GO_COVERAGE_MIN)`
   - `cmd/gocoveragecheck/main.go` now catches backend packages that are absent
     from the parsed coverage-profile map when their package-summary lines are
-    bare `pkg/path  coverage: 0.0%` entries
-  - but the live command still misses backend packages reported as
-    `ok pkg/path ... coverage: 0.0% of statements`
+    either bare `pkg/path  coverage: 0.0% of statements` entries or simplified
+    `ok pkg/path ... coverage: 0.0% of statements` entries
+  - but the live command still misses the real `go test -coverpkg` success
+    summary shape when it appends `in <coverpkg list>` after
+    `coverage: 0.0% of statements`
 - the gap is currently observable on live `main`:
-  - `go run ./cmd/gocoveragecheck -min 0` exits successfully and reports
-    `Go coverage 86.5% meets minimum 0.0%.`
-  - the same run prints `ok   github.com/portpowered/infinite-you/pkg/cli/docs`
-    with `coverage: 0.0% of statements`
-  - `cmd/gocoveragecheck/main_test.go` covers bare zero-coverage package
-    summaries, but not the `ok ... coverage:` summary shape
-- the next idea should close that parser gap without changing the aggregate
-  threshold, broadening into package-by-package test authoring, or reopening
-  the already-closed command-entrypoint lane
+  - `make test-coverage-go` exits successfully and reports
+    `Go coverage 86.5% meets minimum 80.0%.`
+  - the same run prints bare `0.0%` backend summaries such as
+    `github.com/portpowered/infinite-you/pkg/apisurface`
+  - the same run also prints
+    `ok   github.com/portpowered/infinite-you/pkg/cli/docs ... coverage: 0.0% of statements in github.com/portpowered/infinite-you/...`
+  - `cmd/gocoveragecheck/main_test.go` covers simplified `ok ... coverage:`
+    summaries, but not the live trailing `in ...` coverpkg summary tail
+- the next idea should close that trailing-summary parser gap without changing
+  the aggregate threshold, broadening into package-by-package test authoring,
+  or reopening the already-closed command-entrypoint lane
 
 ## theory of mind
 
@@ -178,6 +184,9 @@
 - when a repo-owned coverage gate parses `go test` package summaries, account
   for both bare `pkg/path  coverage: ...` lines and `ok pkg/path ... coverage:
   ...` lines; backend packages can surface `0.0%` through either shape
+- when `go test -coverpkg` appends `in <package list>` after
+  `coverage: ... of statements`, treat that as the same package-summary shape
+  rather than assuming simplified fixture lines match the live output exactly
 - when one repo-owned command entrypoint gains a thin test seam to satisfy a
   coverage ask, inspect sibling repo-owned lane commands next before pushing
   equivalent coverage assertions down into unrelated downstream packages

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,11 +2,11 @@
 
 ## world state
 
-- as of `2026-05-06T15:03:24.7591584-07:00`, local `HEAD` on
-  `meta-refresh-world-state-20260506-050415` points to `3e82419`
+- as of `2026-05-06T16:03:38.4962364-07:00`, local `HEAD` on
+  `meta-refresh-world-state-20260506-050415` points to `a25885a`
   (`docs: refresh meta world state`) and has been rebased onto live
-  `origin/main` through `24fa5f8`
-  (`cover-releasetagcheck-git-tag-wrapper-branches (#133)`)
+  `origin/main` through `4f21b7b`
+  (`cover-gocoveragecheck-command-owner-threshold-and-entrypoint-branches (#134)`)
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - the local worktree is not clean:
   - canonical `factory/inputs/**` remains tracked-sentinel-only
@@ -15,7 +15,7 @@
   - `factory/logs/meta/asks.md` carries a local tracked edit and should be
     treated as user-owned state for this refresh
   - tracked meta-log updates are required because the last checked-in summary
-    predates merged PR `#133`
+    predates merged PR `#134`
   - ignored local workflow residue under `factory/inputs/**` must still be
     treated as operating state rather than checked-in queue truth
 
@@ -53,12 +53,12 @@
   `factory/inputs/<work-type>/<file>` submissions as an implicit `default`
   channel fallback
 - the visible ignored local idea residue after rebasing onto live `main` was:
-  - `factory/inputs/idea/default/cover-releasetagcheck-git-tag-wrapper-branches.md`
+  - `factory/inputs/idea/default/cover-gocoveragecheck-command-owner-threshold-and-entrypoint-branches.md`
 - that ignored idea is now stale queue residue rather than checked-in queue
-  truth because merged PR `#133` already landed that exact cleanup on `main`
+  truth because merged PR `#134` already landed that exact cleanup on `main`
 - it has been replaced during this refresh with one narrower customer-ask
   follow-up idea:
-  - `factory/inputs/idea/default/cover-gocoveragecheck-command-owner-threshold-and-entrypoint-branches.md`
+  - `factory/inputs/idea/default/cover-functionallane-command-owner-error-and-entrypoint-branches.md`
 
 ## customer-ask truth
 
@@ -88,6 +88,8 @@
 ## recent repo movement
 
 - recent merged PRs on `main` now include:
+  - `#134` `cover-gocoveragecheck-command-owner-threshold-and-entrypoint-branches`, merged on
+    `2026-05-06T22:26:56Z`
   - `#133` `cover-releasetagcheck-git-tag-wrapper-branches`, merged on
     `2026-05-06T21:11:35Z`
   - `#132` `cover-deadcodecheck-command-owner-branches`, merged on
@@ -135,26 +137,25 @@
 
 ## next cleanup candidate
 
-- merged PR `#133` closes the previously recorded `cmd/releasetagcheck`
-  git-wrapper seam on live `main`
+- merged PR `#134` closes the previously recorded `cmd/gocoveragecheck`
+  command-owner threshold and entrypoint seam on live `main`
 - the next non-overlapping dispatch should keep advancing the broad quality ask
   by tightening another existing repo-owned maintainer gate instead of
   broadening into a package-by-package test campaign:
-  - `Makefile` still routes the backend coverage lane through
-    `go run ./cmd/gocoveragecheck -min $(GO_COVERAGE_MIN)`
+  - `Makefile` still routes the default functional lane through
+    `go run ./cmd/functionallane -jobs $(FUNCTIONAL_DEFAULT_JOBS) -count=1 -timeout $(GO_TEST_TIMEOUT)`
   - `docs/processes/development-guide-relevant-files.md` still names
-    `cmd/gocoveragecheck/` as the repo-owned backend coverage policy owner
-  - merged PRs `#124`, `#130`, and `#131` already covered zero-coverage
-    backend-package enforcement and real `go test` package-summary parsing
-  - `cmd/gocoveragecheck/main_test.go` still does not cover the command-owner
-    success-path emission, aggregate-threshold failure branch, or direct
-    `main` and `failf` exit behavior
-  - `go test -cover ./cmd/gocoveragecheck` still reports `77.4%` statement
+    `cmd/functionallane/` as the repo-owned default functional-lane owner
+  - merged PR `#126` already covered the thin command-entrypoint routing seam
+    for this package, but the same package still lacks direct coverage for the
+    `main` error path, `failf` exit behavior, `run()` success path, and the
+    discovery and test-execution failure wrappers
+  - `go test -cover ./cmd/functionallane` now reports `82.0%` statement
     coverage, materially below the sibling maintainer-gate command packages
 - the next idea should add focused package-local tests for
-  `cmd/gocoveragecheck`'s command-owner threshold and entrypoint branches
-  without changing coverage policy, widening the coverage lane scope, or
-  pushing these assertions down into unrelated backend packages
+  `cmd/functionallane`'s remaining command-owner error and entrypoint branches
+  without changing functional-lane package discovery policy, widening the lane
+  scope, or pushing these assertions down into unrelated functional suites
 
 ## theory of mind
 
@@ -207,3 +208,7 @@
   regression tests but still trails sibling maintainer commands on package
   coverage, prefer adding command-owner success and threshold-branch coverage
   there before widening scope into low-coverage application packages
+- when a repo-owned functional-lane command already has its thin entrypoint
+  seam covered, inspect the same package next for untested `main` error paths,
+  `failf` exit behavior, and wrapped discovery or execution failures before
+  widening scope into functional test rewrites or broader coverage programs

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,11 +2,11 @@
 
 ## world state
 
-- as of `2026-05-06T12:04:09.0951770-07:00`, local `HEAD` on
-  `meta-refresh-world-state-20260506-050415` points to `3c36fe7`
+- as of `2026-05-06T13:04:11.9967894-07:00`, local `HEAD` on
+  `meta-refresh-world-state-20260506-050415` points to `2d1f89b`
   (`docs: refresh meta world state`) and has been rebased onto live
-  `origin/main` through `52aa4e1`
-  (`Merge pull request #130 from portpowered/ralph/close-backend-coverage-ok-summary-gap`)
+  `origin/main` through `a2f82d7`
+  (`Merge pull request #131 from portpowered/ralph/close-backend-coverage-coverpkg-summary-tail-gap`)
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - the local worktree is not clean:
   - canonical `factory/inputs/**` remains tracked-sentinel-only
@@ -15,7 +15,7 @@
   - `factory/logs/meta/asks.md` carries a local tracked edit and should be
     treated as user-owned state for this refresh
   - tracked meta-log updates are required because the last checked-in summary
-    predates merged PR `#130`
+    predates merged PR `#131`
   - ignored local workflow residue under `factory/inputs/**` must still be
     treated as operating state rather than checked-in queue truth
 
@@ -53,12 +53,12 @@
   `factory/inputs/<work-type>/<file>` submissions as an implicit `default`
   channel fallback
 - the visible ignored local idea residue at the start of this refresh was:
-  - `factory/inputs/idea/default/close-backend-coverage-ok-summary-gap.md`
+  - `factory/inputs/idea/default/close-backend-coverage-coverpkg-summary-tail-gap.md`
 - that ignored idea is now stale queue residue rather than checked-in queue
-  truth because merged PR `#130` already landed that exact cleanup on `main`
+  truth because merged PR `#131` already landed that exact cleanup on `main`
 - it has been replaced during this refresh with one narrower customer-ask
   follow-up idea:
-  - `factory/inputs/idea/default/close-backend-coverage-coverpkg-summary-tail-gap.md`
+  - `factory/inputs/idea/default/cover-deadcodecheck-command-owner-branches.md`
 
 ## customer-ask truth
 
@@ -88,8 +88,10 @@
 ## recent repo movement
 
 - recent merged PRs on `main` now include:
+  - `#131` `close-backend-coverage-coverpkg-summary-tail-gap`, merged on
+    `2026-05-06T19:11:57Z`
   - `#130` `close-backend-coverage-ok-summary-gap`, merged on
-    `2026-05-06T18:20:24Z`
+    `2026-05-06T18:10:41Z`
   - `#129` `cover-releaseprep-command-entrypoint`, merged on
     `2026-05-06T17:26:30Z`
   - `#128` `cover-releasesmoke-command-entrypoint`, merged on
@@ -129,33 +131,23 @@
 
 ## next cleanup candidate
 
-- there is no remaining narrow unowned repo-owned `cmd/` entrypoint coverage
-  gap on live `main`; merged PR `#129` closes the previously recorded
-  releaseprep command-owner seam
+- merged PR `#131` closes the previously recorded `gocoveragecheck`
+  trailing-summary parser seam on live `main`
 - the next non-overlapping dispatch should keep advancing the broad quality ask
-  by tightening an existing enforcement seam instead of broadening into a
-  package-by-package coverage campaign:
-  - `Makefile` still routes backend coverage through
-    `go run ./cmd/gocoveragecheck -min $(GO_COVERAGE_MIN)`
-  - `cmd/gocoveragecheck/main.go` now catches backend packages that are absent
-    from the parsed coverage-profile map when their package-summary lines are
-    either bare `pkg/path  coverage: 0.0% of statements` entries or simplified
-    `ok pkg/path ... coverage: 0.0% of statements` entries
-  - but the live command still misses the real `go test -coverpkg` success
-    summary shape when it appends `in <coverpkg list>` after
-    `coverage: 0.0% of statements`
-- the gap is currently observable on live `main`:
-  - `make test-coverage-go` exits successfully and reports
-    `Go coverage 86.5% meets minimum 80.0%.`
-  - the same run prints bare `0.0%` backend summaries such as
-    `github.com/portpowered/infinite-you/pkg/apisurface`
-  - the same run also prints
-    `ok   github.com/portpowered/infinite-you/pkg/cli/docs ... coverage: 0.0% of statements in github.com/portpowered/infinite-you/...`
-  - `cmd/gocoveragecheck/main_test.go` covers simplified `ok ... coverage:`
-    summaries, but not the live trailing `in ...` coverpkg summary tail
-- the next idea should close that trailing-summary parser gap without changing
-  the aggregate threshold, broadening into package-by-package test authoring,
-  or reopening the already-closed command-entrypoint lane
+  by tightening another existing repo-owned maintainer gate instead of
+  broadening into a package-by-package test campaign:
+  - `Makefile` still routes the deadcode gate through
+    `go run ./cmd/deadcodecheck`
+  - `cmd/deadcodecheck/main.go` owns the command-local baseline-drift contract,
+    `bin/deadcode-current.txt` write path, deadcode tool invocation, stderr
+    forwarding, and exit behavior
+  - `cmd/deadcodecheck/main_test.go` currently covers only
+    `ensureGoTypesAliasEnabled`
+  - `go test -cover ./cmd/deadcodecheck` currently reports `23.4%` statement
+    coverage
+- the next idea should add command-owner tests for `cmd/deadcodecheck`
+  failure and drift branches without changing deadcode policy, editing the
+  baseline as scope creep, or reopening the just-closed coverage parser lane
 
 ## theory of mind
 
@@ -197,3 +189,7 @@
   `cmd/` entrypoint and the internal policy package already has behavioral
   tests, prefer adding command-local seam coverage there before widening the
   scope into release-process refactors
+- when a root maintainer gate such as `make deadcode` still shells through a
+  repo-owned `cmd/` entrypoint and the command test file only covers helper
+  functions, treat the missing baseline-drift and failure-path coverage as the
+  next narrow quality seam before inventing new repo-wide deadcode work

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,11 +2,11 @@
 
 ## world state
 
-- as of `2026-05-06T09:04:02.6782977-07:00`, local `HEAD` on
-  `meta-refresh-world-state-20260506-050415` points to `337fdb2`
+- as of `2026-05-06T10:02:07.1841958-07:00`, local `HEAD` on
+  `meta-refresh-world-state-20260506-050415` points to `93f0b6d`
   (`docs: refresh meta world state`) and has been rebased onto live
-  `origin/main` through `7ee70eb`
-  (`Merge pull request #127 from portpowered/ralph/cover-releasetagcheck-command-entrypoint`)
+  `origin/main` through `2c21b00`
+  (`Merge pull request #128 from portpowered/ralph/cover-releasesmoke-command-entrypoint`)
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - the local worktree is not clean:
   - canonical `factory/inputs/**` remains tracked-sentinel-only
@@ -15,7 +15,7 @@
   - `factory/logs/meta/asks.md` carries a local tracked edit and should be
     treated as user-owned state for this refresh
   - tracked meta-log updates are required because the last checked-in summary
-    predates merged PR `#127`
+    predates merged PR `#128`
   - ignored local workflow residue under `factory/inputs/**` must still be
     treated as operating state rather than checked-in queue truth
 
@@ -53,13 +53,13 @@
   `factory/inputs/<work-type>/<file>` submissions as an implicit `default`
   channel fallback
 - the visible ignored local idea residue at the start of this refresh was:
-  - `factory/inputs/idea/default/cover-releasetagcheck-command-entrypoint.md`
+  - `factory/inputs/idea/default/cover-releasesmoke-command-entrypoint.md`
 - that ignored idea was stale queue residue rather than checked-in queue truth
-  because merged PR `#127` already landed that releasetagcheck command-entrypoint
+  because merged PR `#128` already landed that releasesmoke command-entrypoint
   cleanup on `main`
 - it has been replaced during this refresh with one narrower customer-ask
   follow-up idea:
-  - `factory/inputs/idea/default/cover-releasesmoke-command-entrypoint.md`
+  - `factory/inputs/idea/default/cover-releaseprep-command-entrypoint.md`
 
 ## customer-ask truth
 
@@ -96,6 +96,8 @@
 ## recent repo movement
 
 - recent merged PRs on `main` now include:
+  - `#128` `cover-releasesmoke-command-entrypoint`, merged on
+    `2026-05-06T16:25:12Z`
   - `#127` `cover-releasetagcheck-command-entrypoint`, merged on
     `2026-05-06T15:17:38Z`
   - `#126` `cover-functionallane-command-entrypoint`, merged on
@@ -131,34 +133,31 @@
 ## next cleanup candidate
 
 - there is no remaining narrow unowned customer-visible ask gap on `main`
-- merged PR `#127` materially closes the previously recorded releasetagcheck
+- merged PR `#128` materially closes the previously recorded releasesmoke
   command-entrypoint gap on `main`:
-  - `cmd/releasetagcheck/main.go` now exposes a thin callable seam so the
-    workflow-facing command boundary is directly testable
-  - `cmd/releasetagcheck/main_test.go` now covers `main` execution, explicit
-    `-tag` validation, `-points-at` lookup behavior, mutual exclusivity
-    failures, surfaced git failures, and exact `release_tag=...` output
-  - `.github/workflows/release-candidate.yml` and `.github/workflows/release.yml`
-    still keep release-tag resolution routed through the same repo-owned
-    command surface rather than moving those assertions into workflow-only
-    coverage
+  - `cmd/releasesmoke/main.go` now exposes a thin callable seam so the
+    script-facing command boundary is directly testable
+  - `cmd/releasesmoke/main_test.go` now covers `main` execution, flag routing,
+    structured JSON stdout, structured JSON stderr, and non-zero exit behavior
+  - `scripts/release/smoke-artifact.sh` and
+    `scripts/release/smoke-artifact.ps1` still keep release smoke verification
+    routed through the same repo-owned command surface rather than moving those
+    assertions into wrapper-only coverage
 - the next non-overlapping dispatch should keep advancing the broad P0 testing
   ask through adjacent repo-owned command surfaces and workflow boundaries
   instead of broadening into a package-by-package coverage campaign:
-  - `scripts/release/smoke-artifact.sh` calls
-    `go run ./cmd/releasesmoke -binary "$1" -fixture "$2" -timeout "$TIMEOUT"`
-  - `scripts/release/smoke-artifact.ps1` calls
-    `go run ./cmd/releasesmoke -binary $BinaryPath -fixture $FixturePath -timeout $Timeout`
-  - `cmd/releasesmoke/main.go` owns the script-visible behavior for flag
-    parsing, harness invocation wiring, structured JSON success output, and
-    structured JSON failure output
-  - `tests/release/release_smoke_test.go` and `internal/releasesmoke` already
-    cover the harness behavior beneath that boundary, but there is still no
-    checked-in `cmd/releasesmoke/main_test.go`
-- the next idea should make `cmd/releasesmoke` directly testable with focused
-  command-owner coverage, without changing release smoke behavior, moving
-  verification logic into shell wrappers, or broadening into workflow or
-  artifact-packaging changes
+  - `Makefile` still exposes the maintainer release surface as
+    `go run ./cmd/releaseprep -version $(VERSION)`
+  - `cmd/releaseprep/main.go` still owns command-visible `-version` flag
+    parsing, stdout or stderr wiring, and exit behavior for the release-prep
+    lane
+  - `internal/releaseprep/releaseprep_test.go` already covers the policy
+    behavior beneath that boundary, but there is still no checked-in
+    `cmd/releaseprep/main_test.go`
+- the next idea should make `cmd/releaseprep` directly testable with focused
+  command-owner coverage, without changing release policy sequencing,
+  broadening into GitHub release workflow changes, or moving those assertions
+  down into `internal/releaseprep`
 
 ## theory of mind
 
@@ -190,3 +189,7 @@
 - when a GitHub workflow shells through a repo-owned `cmd/` entrypoint, treat
   its output format and flag-routing behavior as command-owner seams even if
   helper packages beneath it already have unit tests
+- when a root `Makefile` maintainer command still shells through a repo-owned
+  `cmd/` entrypoint and the internal policy package already has behavioral
+  tests, prefer adding command-local seam coverage there before widening the
+  scope into release-process refactors

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,11 +2,11 @@
 
 ## world state
 
-- as of `2026-05-06T06:04:20.9377891-07:00`, local `HEAD` on
-  `meta-refresh-world-state-20260506-050415` points to `fd5c0a0`
+- as of `2026-05-06T07:04:44.5861978-07:00`, local `HEAD` on
+  `meta-refresh-world-state-20260506-050415` points to `87324ab`
   (`docs: refresh meta world state`) and has been rebased onto live
-  `origin/main` through `2d79be4`
-  (`Merge pull request #124 from portpowered/ralph/add-backend-zero-coverage-package-gate`)
+  `origin/main` through `d3785b4`
+  (`Merge pull request #125 from portpowered/ralph/close-backend-coverage-profile-gap`)
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - the local worktree is not clean:
   - canonical `factory/inputs/**` remains tracked-sentinel-only
@@ -15,7 +15,7 @@
   - `factory/logs/meta/asks.md` carries a local tracked edit and should be
     treated as user-owned state for this refresh
   - tracked meta-log updates are required because the last checked-in summary
-    predates merged PR `#124`
+    predates merged PR `#125`
   - ignored local workflow residue under `factory/inputs/**` must still be
     treated as operating state rather than checked-in queue truth
 
@@ -53,13 +53,13 @@
   `factory/inputs/<work-type>/<file>` submissions as an implicit `default`
   channel fallback
 - the visible ignored local idea residue at the start of this refresh was:
-  - `factory/inputs/idea/default/add-backend-zero-coverage-package-gate.md`
+  - `factory/inputs/idea/default/close-backend-coverage-profile-gap.md`
 - that ignored idea was stale queue residue rather than checked-in queue truth
-  because merged PR `#124` already landed that backend zero-coverage gate on
-  `main`
+  because merged PR `#125` already landed that backend coverage profile-gap
+  cleanup on `main`
 - it has been replaced during this refresh with one narrower customer-ask
   follow-up idea:
-  - `factory/inputs/idea/default/close-backend-coverage-profile-gap.md`
+  - `factory/inputs/idea/default/cover-functionallane-command-entrypoint.md`
 
 ## customer-ask truth
 
@@ -96,6 +96,8 @@
 ## recent repo movement
 
 - recent merged PRs on `main` now include:
+  - `#125` `close-backend-coverage-profile-gap`, merged on
+    `2026-05-06T13:46:50Z`
   - `#124` `add-backend-zero-coverage-package-gate`, merged on
     `2026-05-06T12:39:23Z`
   - `#122` `collapse-runtime-api-functional-server-lifecycle-owner`, merged on
@@ -125,25 +127,31 @@
 ## next cleanup candidate
 
 - there is no remaining narrow unowned customer-visible ask gap on `main`
-- the next non-overlapping dispatch should advance the broad P0 testing ask
-  through the existing backend coverage gate instead of inventing a new lane:
-  - `Makefile` already exposes `test-coverage-go` with
-    `GO_COVERAGE_MIN ?= 80.0`
-  - `.github/workflows/ci.yml` already enforces that repo-owned command in CI
-  - merged PR `#124` already rejects backend packages that appear in the
-    coverage profile with `0%` covered statements
-  - the live command still prints `coverage: 0.0% of statements` for backend
-    packages such as `pkg/apisurface`, `pkg/buffers`, and `pkg/cli/default`
-    while exiting successfully at `86.4%` total coverage
-  - `cmd/gocoveragecheck/main.go` currently skips packages missing from the
-    parsed profile map in `findZeroCoveragePackages`, so absent packages evade
-    the zero-coverage failure entirely
-  - `cmd/gocoveragecheck/main_test.go` covers present zero-coverage packages
-    and exclusions but not the missing-from-profile case
-- the next idea should tighten `cmd/gocoveragecheck` so the backend coverage
-  lane also rejects backend-owned packages that report `0.0%` coverage while
-  never appearing in the coverage profile, without changing the existing
-  aggregate threshold, package exclusions, or CI entrypoint
+- merged PR `#125` materially closes the previously recorded backend
+  coverage-profile loophole on `main`:
+  - `cmd/gocoveragecheck/main.go` now reads package-level `0.0%` coverage from
+    real `go test` summary output in addition to the parsed coverage profile
+  - `cmd/gocoveragecheck/main_test.go` now covers both present-in-profile and
+    missing-from-profile backend zero-coverage cases plus excluded packages
+  - `cmd/factory/main.go` and `cmd/factory/main_test.go` now keep the thin CLI
+    entrypoint directly testable so that repo-owned backend coverage can count
+    the command owner instead of pushing entrypoint assertions into unrelated
+    package tests
+- the next non-overlapping dispatch should keep advancing the broad P0 testing
+  ask through adjacent repo-owned command surfaces instead of broadening into a
+  package-by-package coverage campaign:
+  - `Makefile` still routes `test-functional` through
+    `go run ./cmd/functionallane`
+  - `cmd/functionallane/main.go` owns functional package discovery,
+    `internal/support` filtering, config parsing, and the final `go test`
+    command invocation for that repo-owned lane
+  - there is still no checked-in `cmd/functionallane/main_test.go`
+  - the repo just established the narrower command-entrypoint pattern in
+    `cmd/factory`, so `cmd/functionallane` is the nearest sibling seam in the
+    same quality lane
+- the next idea should make `cmd/functionallane` directly testable with focused
+  command-owner coverage, without replacing `make test-functional`, changing
+  package selection semantics, or broadening into new functional scenarios
 
 ## theory of mind
 
@@ -169,9 +177,6 @@
 - when a broad quality or coverage ask is open, prefer tightening an existing
   repo-owned enforcement seam before queueing a repo-wide test-authoring
   program
-- aggregate coverage floors can hide `0%` backend packages; the first useful
-  ratchet is per-package zero-coverage rejection inside the existing coverage
-  lane, not a broad threshold jump
-- a zero-coverage gate that only consults the coverage profile is still
-  incomplete because untouched backend packages can show `0.0%` in `go test`
-  output yet never materialize in the profile map
+- when one repo-owned command entrypoint gains a thin test seam to satisfy a
+  coverage ask, inspect sibling repo-owned lane commands next before pushing
+  equivalent coverage assertions down into unrelated downstream packages

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,11 +2,11 @@
 
 ## world state
 
-- as of `2026-05-06T05:07:16.1578424-07:00`, local `HEAD` on
-  `meta-refresh-world-state-20260506-050415` points to `e47cbe3`
-  (`docs: refresh meta world state`); local `main` also points to `e47cbe3`
-  and contains the merged `origin/main` baseline through `cee2465`
-  (`Merge pull request #122 from portpowered/ralph/collapse-runtime-api-functional-server-lifecycle-owner`)
+- as of `2026-05-06T06:04:20.9377891-07:00`, local `HEAD` on
+  `meta-refresh-world-state-20260506-050415` points to `fd5c0a0`
+  (`docs: refresh meta world state`) and has been rebased onto live
+  `origin/main` through `2d79be4`
+  (`Merge pull request #124 from portpowered/ralph/add-backend-zero-coverage-package-gate`)
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - the local worktree is not clean:
   - canonical `factory/inputs/**` remains tracked-sentinel-only
@@ -15,7 +15,7 @@
   - `factory/logs/meta/asks.md` carries a local tracked edit and should be
     treated as user-owned state for this refresh
   - tracked meta-log updates are required because the last checked-in summary
-    predates merged PR `#122`
+    predates merged PR `#124`
   - ignored local workflow residue under `factory/inputs/**` must still be
     treated as operating state rather than checked-in queue truth
 
@@ -53,13 +53,13 @@
   `factory/inputs/<work-type>/<file>` submissions as an implicit `default`
   channel fallback
 - the visible ignored local idea residue at the start of this refresh was:
-  - `factory/inputs/idea/default/collapse-runtime-api-functional-server-lifecycle-owner.md`
+  - `factory/inputs/idea/default/add-backend-zero-coverage-package-gate.md`
 - that ignored idea was stale queue residue rather than checked-in queue truth
-  because merged PR `#122` already landed that runtime API lifecycle cleanup
-  on `main`
+  because merged PR `#124` already landed that backend zero-coverage gate on
+  `main`
 - it has been replaced during this refresh with one narrower customer-ask
   follow-up idea:
-  - `factory/inputs/idea/default/add-backend-zero-coverage-package-gate.md`
+  - `factory/inputs/idea/default/close-backend-coverage-profile-gap.md`
 
 ## customer-ask truth
 
@@ -96,6 +96,8 @@
 ## recent repo movement
 
 - recent merged PRs on `main` now include:
+  - `#124` `add-backend-zero-coverage-package-gate`, merged on
+    `2026-05-06T12:39:23Z`
   - `#122` `collapse-runtime-api-functional-server-lifecycle-owner`, merged on
     `2026-05-06T11:29:08Z`
   - `#121` `consolidate-runtime-api-functional-support-helpers`, merged on
@@ -128,13 +130,20 @@
   - `Makefile` already exposes `test-coverage-go` with
     `GO_COVERAGE_MIN ?= 80.0`
   - `.github/workflows/ci.yml` already enforces that repo-owned command in CI
-  - `cmd/gocoveragecheck/main.go` currently fails only on total statement
-    coverage, which can still hide backend packages at `0%`
-  - `cmd/gocoveragecheck/main_test.go` already owns focused unit coverage for
-    the lane-selection logic
-- the next idea should extend `cmd/gocoveragecheck` so the backend coverage
-  lane fails when an included backend package lands at `0%` statement coverage
-  while preserving the current package exclusions and repo-owned CI entrypoint
+  - merged PR `#124` already rejects backend packages that appear in the
+    coverage profile with `0%` covered statements
+  - the live command still prints `coverage: 0.0% of statements` for backend
+    packages such as `pkg/apisurface`, `pkg/buffers`, and `pkg/cli/default`
+    while exiting successfully at `86.4%` total coverage
+  - `cmd/gocoveragecheck/main.go` currently skips packages missing from the
+    parsed profile map in `findZeroCoveragePackages`, so absent packages evade
+    the zero-coverage failure entirely
+  - `cmd/gocoveragecheck/main_test.go` covers present zero-coverage packages
+    and exclusions but not the missing-from-profile case
+- the next idea should tighten `cmd/gocoveragecheck` so the backend coverage
+  lane also rejects backend-owned packages that report `0.0%` coverage while
+  never appearing in the coverage profile, without changing the existing
+  aggregate threshold, package exclusions, or CI entrypoint
 
 ## theory of mind
 
@@ -163,3 +172,6 @@
 - aggregate coverage floors can hide `0%` backend packages; the first useful
   ratchet is per-package zero-coverage rejection inside the existing coverage
   lane, not a broad threshold jump
+- a zero-coverage gate that only consults the coverage profile is still
+  incomplete because untouched backend packages can show `0.0%` in `go test`
+  output yet never materialize in the profile map


### PR DESCRIPTION
## Summary\n- refresh the checked-in meta world view and progress log to match live main after merged PR #122\n- prune the stale ignored runtime-api lifecycle idea and replace it with a narrower backend coverage enforcement follow-up in local workflow inputs\n- leave the user-owned tracked edit in factory/logs/meta/asks.md untouched\n\n## Notes\n- direct push to main is blocked by repository rules requiring status checks, so this change is queued through a PR instead\n- the next dispatch is the backend zero-coverage-package gate in the existing repo-owned coverage lane