### PR TITLE
cover-releasesmoke-command-owner-parse-and-json-error-branches

### DIFF
--- a/cmd/releasesmoke/main_test.go
+++ b/cmd/releasesmoke/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"strings"
@@ -12,6 +13,14 @@ import (
 
 	"github.com/portpowered/infinite-you/internal/releasesmoke"
 )
+
+type failingWriter struct {
+	err error
+}
+
+func (writer failingWriter) Write(_ []byte) (int, error) {
+	return 0, writer.err
+}
 
 func TestMainRoutesThroughCommandMain(t *testing.T) {
 	originalCommandMain := commandMain
@@ -245,5 +254,21 @@ func TestRunFailureWritesStructuredJSONToStderrAndReturnsNonZero(t *testing.T) {
 	}
 	if !bytes.Contains(stderr.Bytes(), []byte("\n  \"phase\": ")) {
 		t.Fatalf("run() stderr = %q, want indented JSON field", stderr.String())
+	}
+}
+
+func TestWriteJSONReportsEncodeFailuresToStderr(t *testing.T) {
+	originalStderr := stderr
+	t.Cleanup(func() {
+		stderr = originalStderr
+	})
+
+	var errOut bytes.Buffer
+	stderr = &errOut
+
+	writeJSON(failingWriter{err: errors.New("writer failed")}, map[string]string{"status": "ok"})
+
+	if got := strings.TrimSpace(errOut.String()); !strings.Contains(got, "encode JSON output: writer failed") {
+		t.Fatalf("writeJSON() stderr = %q, want encode failure diagnostic", got)
 	}
 }

--- a/cmd/releasesmoke/main_test.go
+++ b/cmd/releasesmoke/main_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -95,6 +96,33 @@ func TestRunForwardsParsedConfigToHarness(t *testing.T) {
 	}
 	if got := stderr.String(); got != "" {
 		t.Fatalf("run() stderr = %q, want empty", got)
+	}
+}
+
+func TestRunInvalidArgsWritesFlagParseErrorToStderrAndReturnsNonZero(t *testing.T) {
+	originalRunReleaseSmoke := runReleaseSmoke
+	t.Cleanup(func() {
+		runReleaseSmoke = originalRunReleaseSmoke
+	})
+
+	runReleaseSmoke = func(_ context.Context, cfg releasesmoke.Config) (releasesmoke.Result, error) {
+		t.Fatalf("runReleaseSmoke() should not be called for invalid args: %+v", cfg)
+		return releasesmoke.Result{}, nil
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := run([]string{"-bogus"}, &stdout, &stderr)
+
+	if exitCode == 0 {
+		t.Fatalf("run() exit code = %d, want non-zero", exitCode)
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("run() stdout = %q, want empty", got)
+	}
+	if got := strings.TrimSpace(stderr.String()); !strings.Contains(got, "flag provided but not defined: -bogus") {
+		t.Fatalf("run() stderr = %q, want raw flag parse error", got)
 	}
 }
 


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/cover-releasesmoke-command-owner-parse-and-json-error-branches",
  "description": "Close the remaining `cmd/releasesmoke` command-owner coverage gaps by adding focused package-local tests for invalid argument parsing and JSON encode-failure diagnostics while preserving the existing stdout/stderr JSON contract and keeping the lane scoped to the command package.",
  "context": {
    "customerAsk": "The canonical customer ask in `factory/logs/meta/asks.md` requires stronger backend testing evidence while keeping cleanup lanes narrow, reviewable, and non-overlapping. Live `main` already merged PR `#128` (`cover-releasesmoke-command-entrypoint`), so the thin `main()` routing seam in `cmd/releasesmoke` is closed. The package still owns uncovered command-boundary branches in `cmd/releasesmoke/main.go`: invalid flag parsing in `parseArgs()` and JSON encode-failure handling in `writeJSON()`. Fresh command coverage runs still report `83.3%` statement coverage for `cmd/releasesmoke`, so the repo still lacks direct proof for those observable error paths. Keep this lane inside `cmd/releasesmoke`: add focused package-local tests for invalid argument handling and JSON encode failures, preserve the existing stdout/stderr contract, and avoid widening into `internal/releasesmoke` behavior or release-fixture changes.",
    "problem": "`infinite-you` relies on `cmd/releasesmoke` as a repo-owned maintainer command boundary, but its current package-local tests do not exercise invalid CLI parsing or JSON encode-failure behavior in `cmd/releasesmoke/main.go`. That leaves the command below neighboring package coverage levels and weakens reviewer confidence in the observable stderr contract for parse failures and output-write failures.",
    "solution": "Add two narrow package-local test slices inside `cmd/releasesmoke`: one that drives `run()` with invalid CLI arguments and verifies non-zero exit plus parsed stderr diagnostics, and one that forces `writeJSON()` through its encode-failure path and verifies the existing `encode JSON output:` stderr diagnostic, without changing harness behavior or payload schemas."
  },
  "acceptanceCriteria": [
    "AC-1: Package-local tests prove invalid CLI arguments cause `cmd/releasesmoke` to return a non-zero exit code and surface the parsed flag error through stderr.",
    "AC-2: Package-local tests prove `writeJSON()` surfaces an `encode JSON output:` diagnostic when JSON encoding fails because the target writer returns an error.",
    "AC-3: Existing observable command behavior remains unchanged: successful runs still emit structured JSON on stdout, harness failures still emit structured JSON on stderr, and this lane does not change the release-smoke payload schema.",
    "AC-4: The implementation stays scoped to `cmd/releasesmoke` command-owner branches and does not broaden into `internal/releasesmoke`, release fixtures, wrapper scripts, or workflow changes.",
    "AC-5: Reviewer-verifiable test evidence covers the remaining parse and JSON encode error branches directly in the touched command package.",
    "AC-6: Quality checks pass (typecheck, lint, tests)."
  ],
  "userStories": [
    {
      "id": "cover-releasesmoke-command-owner-parse-and-json-error-branches-001",
      "title": "Prove invalid flag handling at the command boundary",
      "description": "As a maintainer, I want invalid CLI arguments in `cmd/releasesmoke` to be test-proven so the command boundary stays safe without relying on manual invocation.",
      "acceptanceCriteria": [
        "Add a package-local test that invokes `run()` with invalid CLI arguments and verifies the returned exit code is non-zero.",
        "The test verifies stderr surfaces the parsed flag error produced by `parseArgs()` rather than a generic wrapped failure message.",
        "The test keeps the assertion at the command boundary and does not broaden into subprocess `main()` harness coverage already owned by the entrypoint lane.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "cover-releasesmoke-command-owner-parse-and-json-error-branches-002",
      "title": "Prove JSON encode-failure diagnostics stay visible",
      "description": "As a maintainer, I want JSON encode failures to remain visible through the command-owned stderr path so output errors do not fail silently.",
      "acceptanceCriteria": [
        "Add a focused package-local test seam, such as a writer stub that fails on `Write`, to force `writeJSON()` through its encode-failure branch.",
        "The test verifies stderr emits the existing `encode JSON output:` diagnostic when encoding cannot be written successfully.",
        "The added coverage does not change the current JSON payload contract for normal success output or harness-failure output.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
