### PR TITLE
docs: refresh meta world state

### DIFF
--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -151,12 +151,18 @@
 - When the customer-linked external checklist repository omits one of the
   requested documents, record that missing source as an evidence gap and avoid
   inferring checklist content that is not actually retrievable on that date.
+- After a localized dashboard dialog merges, re-read the adjacent header
+  controls and status accessibility labels next; concentrated English-only
+  residue often remains there rather than in another dialog.
+- When a helper still carries an explicitly backwards-compatible variadic
+  parameter but the live production caller already passes one concrete explicit
+  value, prefer deleting the shim over preserving two call shapes.
 
 ## Current Summary
 
-- As of `2026-05-07T04:04:43.0744927-07:00`, `HEAD` points to `b145e56` on
-  branch `main` and already contains merged PR `#144`
-  (`cover-releasesmoke-command-owner-parse-and-json-error-branches`) from
+- As of `2026-05-07T05:03:44.1967849-07:00`, `HEAD` points to `3d0c461` on
+  branch `main`, is ahead of `origin/main` by three local meta commits, and
+  already contains merged PR `#147` (`localize-export-dialog-and-trigger`) from
   `origin/main`.
 - The canonical ask surface remains `factory/logs/meta/asks.md`.
 - The checked-in maintainer workflow is `thoughts -> idea -> plan -> task`
@@ -169,9 +175,9 @@
   user-owned tracked edit and the maintainer meta refresh updates the tracked
   view/progress docs; ignored workflow files under `factory/inputs/**` remain
   operating state rather than canonical queue truth.
-- Recent merged PRs now include `#142` and `#144`; open PR `#141` owns the
-  active checklist-audit lane, while `#143`, `#139`, `#123`, and `#120` remain
-  older meta refresh branches.
+- Recent merged PRs now include `#146` and `#147`; open PR `#141` owns the
+  active checklist-audit lane, while `#145`, `#143`, `#139`, `#123`, and
+  `#120` remain meta refresh branches.
 - The canonical ask surface remains the quality-oriented rewrite in
   `factory/logs/meta/asks.md`; the active asks are external checklist
   alignment, stronger backend and website testing, ongoing simplification, and
@@ -182,13 +188,53 @@
 - The external website and backend checklist URLs remain readable on
   `2026-05-07`, but the linked external `asks.md` URL still does not produce a
   readable checklist document and must be treated as a source-evidence gap.
-- The previously queued ignored ideas
-  `localize-and-accessibility-harden-import-preview-dialog` and
-  `cover-releasesmoke-command-owner-parse-and-json-error-branches` are stale
-  because merged PRs `#142` and `#144` landed those exact lanes on `main`.
+- The previously queued ignored ideas `localize-export-dialog-and-trigger` and
+  `narrow-cron-watcher-runtime-lookup-contract` are stale because merged PRs
+  `#147` and `#146` landed those exact lanes on `main`.
 - The next maintainer-owned operating queue should hold three non-overlapping
-  ideas together: repo-wide checklist audit evidence, export-surface
-  localization, and cron runtime-lookup narrowing.
+  ideas together: repo-wide checklist audit evidence,
+  `retire-template-fields-variadic-worktree-shim`, and
+  `localize-dashboard-header-timeline-and-stream-status`.
+
+## 2026-05-07T05:03:44.1967849-07:00 - meta state refresh
+
+- Ran `git pull --rebase --autostash origin main`; Git rebased local `main`
+  onto live `origin/main`, pulling in merged PR `#146`
+  (`narrow-cron-watcher-runtime-lookup-contract`) and merged PR `#147`
+  (`localize-export-dialog-and-trigger`) while preserving the user-owned
+  tracked edit in `factory/logs/meta/asks.md`.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`, the backend and
+  website standards, current PR state, the tracked-versus-ignored
+  `factory/inputs/**` surface, and the live external checklist sources.
+- Re-validated tracked queue truth with `git ls-files factory/inputs` and
+  `Get-ChildItem -Recurse -Force factory/inputs`, confirming the checked-in
+  inboxes remain sentinel-only while the visible idea files are ignored local
+  operating residue.
+- Confirmed the previously queued ignored ideas
+  `factory/inputs/idea/default/localize-export-dialog-and-trigger.md` and
+  `factory/inputs/idea/default/narrow-cron-watcher-runtime-lookup-contract.md`
+  are stale because merged PR `#147` and merged PR `#146` already landed those
+  exact cleanup lanes on `main`, then pruned those ignored residues locally.
+- Re-checked the linked external checklist sources on `2026-05-07` and
+  confirmed the website and backend checklist documents remain readable, while
+  the linked `portpowered/checklists` `asks.md` source still does not resolve
+  to a readable document and must remain an evidence gap instead of an assumed
+  requirement source.
+- Used delegated explorer passes, graph-backed discovery, direct code reads,
+  and current `go test -cover ./cmd/...` output to choose two fresh
+  non-overlapping replacements for the merged queue slots:
+  `pkg/workers/template_fields.go` plus
+  `pkg/workers/workstation_executor.go` for the next small backend
+  simplification seam, and `ui/src/features/header/tick-slider-control.tsx`
+  plus `ui/src/features/header/dashboard-header.tsx` for the next narrow
+  dashboard-header localization seam.
+- Recorded one backup backend testing seam from direct command coverage checks
+  as well: `cmd/releaseprep/main.go` still leaves the explicit `flag.ErrHelp`
+  branch and direct parse-failure routing as a small command-owner coverage
+  closeout, but it is now a backup seam rather than one of the three active
+  backlog slots.
 
 ## 2026-05-07T04:04:43.0744927-07:00 - meta state refresh
 

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -148,12 +148,16 @@
 - When a standards audit PR or a checklist follow-up PR is already open, treat
   its branch and changed-file surface as owned; replace only merged or stale
   backlog slots instead of queueing a second idea over the same files.
+- When the customer-linked external checklist repository omits one of the
+  requested documents, record that missing source as an evidence gap and avoid
+  inferring checklist content that is not actually retrievable on that date.
 
 ## Current Summary
 
-- As of `2026-05-07T03:02:15.3916934-07:00`, `HEAD` points to `41ae281` on
-  branch `main` and already contains merged PR `#140`
-  (`retire-deadcodecheck-gotypesalias-compat-shim`) from `origin/main`.
+- As of `2026-05-07T04:04:43.0744927-07:00`, `HEAD` points to `b145e56` on
+  branch `main` and already contains merged PR `#144`
+  (`cover-releasesmoke-command-owner-parse-and-json-error-branches`) from
+  `origin/main`.
 - The canonical ask surface remains `factory/logs/meta/asks.md`.
 - The checked-in maintainer workflow is `thoughts -> idea -> plan -> task`
   with `idea/task:to-complete`, same-name `consume`, `.claude/worktrees`
@@ -165,9 +169,8 @@
   user-owned tracked edit and the maintainer meta refresh updates the tracked
   view/progress docs; ignored workflow files under `factory/inputs/**` remain
   operating state rather than canonical queue truth.
-- Recent merged PRs now include `#135`, `#136`, `#137`, `#138`, and `#140`;
-  open PRs `#141` and `#142` now own the active checklist-audit and
-  import-preview standards lanes, while `#139`, `#123`, and `#120` remain
+- Recent merged PRs now include `#142` and `#144`; open PR `#141` owns the
+  active checklist-audit lane, while `#143`, `#139`, `#123`, and `#120` remain
   older meta refresh branches.
 - The canonical ask surface remains the quality-oriented rewrite in
   `factory/logs/meta/asks.md`; the active asks are external checklist
@@ -176,14 +179,60 @@
 - The replay fixtures remain historical samples rather than current workflow
   truth, and one rejection payload is still quoted anomalously in the replay
   sample.
-- The previously queued ignored idea
-  `retire-deadcodecheck-gotypesalias-compat-shim` is stale because merged PR
-  `#140` landed that exact lane on `main`.
+- The external website and backend checklist URLs remain readable on
+  `2026-05-07`, but the linked external `asks.md` URL still does not produce a
+  readable checklist document and must be treated as a source-evidence gap.
+- The previously queued ignored ideas
+  `localize-and-accessibility-harden-import-preview-dialog` and
+  `cover-releasesmoke-command-owner-parse-and-json-error-branches` are stale
+  because merged PRs `#142` and `#144` landed those exact lanes on `main`.
 - The next maintainer-owned operating queue should hold three non-overlapping
-  ideas together:
-  repo-wide checklist audit evidence, import-preview localization plus
-  accessibility hardening, and releasesmoke command-owner parse/json branch
-  coverage.
+  ideas together: repo-wide checklist audit evidence, export-surface
+  localization, and cron runtime-lookup narrowing.
+
+## 2026-05-07T04:04:43.0744927-07:00 - meta state refresh
+
+- Ran `git pull --ff-only`, saw a divergent local branch because the checkout
+  was ahead by prior meta commits and behind by merged upstream work, then
+  stashed the user-owned tracked edit in `factory/logs/meta/asks.md`, merged
+  `origin/main` with `git pull --no-edit`, and restored the ask-file edit.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`, the backend and
+  website standards, current PR state, the tracked-versus-ignored
+  `factory/inputs/**` surface, the live external checklist sources, and the
+  live backend and UI candidate seams.
+- Re-validated tracked queue truth with `git ls-files factory/inputs` and
+  `Get-ChildItem -Recurse -Force factory/inputs`, confirming the checked-in
+  inboxes remain sentinel-only while the visible idea files are ignored local
+  operating residue.
+- Confirmed the previously queued ignored ideas
+  `factory/inputs/idea/default/localize-and-accessibility-harden-import-preview-dialog.md`
+  and
+  `factory/inputs/idea/default/cover-releasesmoke-command-owner-parse-and-json-error-branches.md`
+  are stale because merged PR `#142` and merged PR `#144` already landed those
+  exact cleanup lanes on `main`, so they should be pruned rather than left in
+  the active queue.
+- Re-checked repo movement with `gh pr list --state open --limit 20` and
+  `gh pr list --state merged --limit 10`, confirming `#142` and `#144` are now
+  merged while `#141` remains the only live checklist-audit implementation
+  lane.
+- Checked the linked external checklist sources again on `2026-05-07` and
+  confirmed the website and backend checklist documents remain readable, while
+  the linked `portpowered/checklists` `asks.md` source still does not resolve
+  to a readable document and must stay recorded as an evidence gap instead of a
+  silently assumed requirement source.
+- Used delegated explorer passes plus direct file reads to identify two fresh
+  non-overlapping replacements for the stale queue slots:
+  `ui/src/features/export/export-factory-dialog.tsx` plus
+  `ui/src/features/header/dashboard-header.tsx` for the next feature-local
+  localization seam, and `pkg/service/cron_watcher.go` plus
+  `pkg/interfaces/runtime_lookup.go` for the next narrow runtime-interface
+  simplification seam.
+- Recorded one backup backend testing seam from delegated inspection as well:
+  `cmd/releaseprep/main.go` still leaves the explicit `flag.ErrHelp` branch
+  without direct package-local coverage, but it is now a smaller next-up
+  candidate rather than one of the three active backlog slots.
 
 ## 2026-05-06T16:03:38.4962364-07:00 - meta state refresh
 

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -145,12 +145,15 @@
   regression tests but still trails sibling maintainer commands on package
   coverage, prefer adding command-owner success and threshold-branch coverage
   there before widening scope into low-coverage application packages.
+- When a standards audit PR or a checklist follow-up PR is already open, treat
+  its branch and changed-file surface as owned; replace only merged or stale
+  backlog slots instead of queueing a second idea over the same files.
 
 ## Current Summary
 
-- As of `2026-05-07T02:06:20.9186342-07:00`, `HEAD` points to `bf2ea7e` on
-  branch `main`; live `origin/main` is the same commit through merged PR
-  `#138`.
+- As of `2026-05-07T03:02:15.3916934-07:00`, `HEAD` points to `41ae281` on
+  branch `main` and already contains merged PR `#140`
+  (`retire-deadcodecheck-gotypesalias-compat-shim`) from `origin/main`.
 - The canonical ask surface remains `factory/logs/meta/asks.md`.
 - The checked-in maintainer workflow is `thoughts -> idea -> plan -> task`
   with `idea/task:to-complete`, same-name `consume`, `.claude/worktrees`
@@ -162,9 +165,10 @@
   user-owned tracked edit and the maintainer meta refresh updates the tracked
   view/progress docs; ignored workflow files under `factory/inputs/**` remain
   operating state rather than canonical queue truth.
-- Recent merged PRs now include `#134`, `#135`, `#136`, `#137`, and `#138`;
-  open PRs `#120` and `#123` are still only meta refresh branches and do not
-  own the next code cleanup lane.
+- Recent merged PRs now include `#135`, `#136`, `#137`, `#138`, and `#140`;
+  open PRs `#141` and `#142` now own the active checklist-audit and
+  import-preview standards lanes, while `#139`, `#123`, and `#120` remain
+  older meta refresh branches.
 - The canonical ask surface remains the quality-oriented rewrite in
   `factory/logs/meta/asks.md`; the active asks are external checklist
   alignment, stronger backend and website testing, ongoing simplification, and
@@ -173,12 +177,13 @@
   truth, and one rejection payload is still quoted anomalously in the replay
   sample.
 - The previously queued ignored idea
-  `cover-gocoveragecheck-helper-runtime-and-parser-branches` is stale because
-  merged PR `#137` landed that exact lane on `main`.
+  `retire-deadcodecheck-gotypesalias-compat-shim` is stale because merged PR
+  `#140` landed that exact lane on `main`.
 - The next maintainer-owned operating queue should hold three non-overlapping
   ideas together:
   repo-wide checklist audit evidence, import-preview localization plus
-  accessibility hardening, and deadcodecheck legacy-shim retirement.
+  accessibility hardening, and releasesmoke command-owner parse/json branch
+  coverage.
 
 ## 2026-05-06T16:03:38.4962364-07:00 - meta state refresh
 
@@ -1937,3 +1942,39 @@
   `audit-repository-against-2026-website-and-backend-checklists.md`,
   `localize-and-accessibility-harden-import-preview-dialog.md`, and
   `retire-deadcodecheck-gotypesalias-compat-shim.md`.
+
+## 2026-05-07T03:02:15.3916934-07:00 - meta state refresh
+
+- Ran `git pull` while local `main` was already one commit ahead of
+  `origin/main`; Git merged in upstream `08acc2f` so local `HEAD` advanced to
+  `41ae281` and now includes merged PR `#140`
+  (`retire-deadcodecheck-gotypesalias-compat-shim`) without disturbing the
+  user-owned tracked edit in `factory/logs/meta/asks.md`.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`, current PR
+  state, the tracked-versus-ignored `factory/inputs/**` surface, and the live
+  repo-owned `cmd/` candidate seams.
+- Re-validated tracked queue truth with `git ls-files factory/inputs` and
+  `Get-ChildItem -Recurse -Force factory/inputs`, confirming the checked-in
+  inboxes remain sentinel-only while the visible idea files are ignored local
+  operating residue.
+- Confirmed the previously queued ignored idea
+  `factory/inputs/idea/default/retire-deadcodecheck-gotypesalias-compat-shim.md`
+  is stale because merged PR `#140` already landed that exact cleanup on
+  `main`, so it should be pruned rather than left in the live queue.
+- Re-checked open PR ownership with `gh pr view 141` and `gh pr view 142`,
+  confirming those branches already own the repository-wide checklist audit and
+  the import-preview localization/accessibility lane; they should count toward
+  the standing three-task ask and block overlapping follow-up queue work.
+- Verified with direct reads of `cmd/releasesmoke/main.go` and
+  `cmd/releasesmoke/main_test.go`, `gh pr list --search "releasesmoke"`,
+  and fresh `go test -cover ./cmd/...` plus `go tool cover -func` output that
+  the next narrow non-overlapping backend testing seam is `cmd/releasesmoke`:
+  PR `#128` already closed the thin entrypoint routing, but the package still
+  leaves uncovered parse-error and `writeJSON` encode-failure branches and
+  reports `83.3%` statement coverage in the repo-owned command lane.
+- Replaced the stale deadcode slot with one fresh ignored idea under
+  `factory/inputs/idea/default/cover-releasesmoke-command-owner-parse-and-json-error-branches.md`
+  so the operating backlog returns to three narrow active lanes without
+  overlapping PR `#141` or `#142`.

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -148,9 +148,9 @@
 
 ## Current Summary
 
-- As of `2026-05-06T16:03:38.4962364-07:00`, `HEAD` points to `a25885a` on
-  branch `meta-refresh-world-state-20260506-050415`; live `origin/main` points
-  to `4f21b7b` through merged PR `#134`.
+- As of `2026-05-07T02:06:20.9186342-07:00`, `HEAD` points to `bf2ea7e` on
+  branch `main`; live `origin/main` is the same commit through merged PR
+  `#138`.
 - The canonical ask surface remains `factory/logs/meta/asks.md`.
 - The checked-in maintainer workflow is `thoughts -> idea -> plan -> task`
   with `idea/task:to-complete`, same-name `consume`, `.claude/worktrees`
@@ -159,25 +159,26 @@
 - The tracked input surface remains sentinel-only; there is no checked-in
   cleanup request currently queued under `factory/inputs/**`.
 - The local worktree is not clean because `factory/logs/meta/asks.md` carries a
-  user-owned tracked edit; ignored workflow files under `factory/inputs/**`
-  remain operating state rather than canonical queue truth.
-- Recent merged PRs now include `#112`, `#113`, `#114`, `#115`, `#117`,
-  `#118`, `#119`, `#121`, `#122`, `#124`, `#125`, `#126`, `#127`, `#128`,
-  `#129`, `#130`, `#132`, `#133`, and `#134`; open PRs `#120` and `#123` are only
-  meta refresh branches and do not own the next code cleanup lane.
-- The canonical ask surface is now the user-owned quality-only rewrite in
+  user-owned tracked edit and the maintainer meta refresh updates the tracked
+  view/progress docs; ignored workflow files under `factory/inputs/**` remain
+  operating state rather than canonical queue truth.
+- Recent merged PRs now include `#134`, `#135`, `#136`, `#137`, and `#138`;
+  open PRs `#120` and `#123` are still only meta refresh branches and do not
+  own the next code cleanup lane.
+- The canonical ask surface remains the quality-oriented rewrite in
   `factory/logs/meta/asks.md`; the active asks are external checklist
-  alignment plus stronger backend and website testing toward a declared
-  `100%` minimum.
+  alignment, stronger backend and website testing, ongoing simplification, and
+  maintaining at least three non-overlapping tasks in flight.
 - The replay fixtures remain historical samples rather than current workflow
   truth, and one rejection payload is still quoted anomalously in the replay
   sample.
-- The next non-overlapping dispatch is the `cmd/functionallane`
-  command-owner error and entrypoint lane: PR `#126` already covered the thin
-  command-entrypoint routing seam on `main`, but the repo-owned functional
-  lane still lacks direct coverage for `main` failure routing, `failf` exit
-  behavior, `run()` success, and wrapped discovery or execution failures while
-  package coverage sits at `82.0%`.
+- The previously queued ignored idea
+  `cover-gocoveragecheck-helper-runtime-and-parser-branches` is stale because
+  merged PR `#137` landed that exact lane on `main`.
+- The next maintainer-owned operating queue should hold three non-overlapping
+  ideas together:
+  repo-wide checklist audit evidence, import-preview localization plus
+  accessibility hardening, and deadcodecheck legacy-shim retirement.
 
 ## 2026-05-06T16:03:38.4962364-07:00 - meta state refresh
 
@@ -1897,3 +1898,42 @@
   `factory/inputs/idea/default/cover-gocoveragecheck-helper-runtime-and-parser-branches.md`
   so the next worker can tighten that backend coverage gate without changing
   thresholds, package-selection policy, or CI wiring.
+
+## 2026-05-07T02:06:20.9186342-07:00 - meta state refresh
+
+- Ran `git pull --rebase --autostash`; the checkout was already current on
+  `main` at `bf2ea7e` after merged PR `#138` (`Branchling`).
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`, the backend and
+  website standards, current PR state, the tracked-versus-ignored
+  `factory/inputs/**` surface, and the live repo-owned `cmd/` and `ui/`
+  candidate seams.
+- Re-validated tracked queue truth with `git ls-files factory/inputs` and
+  `Get-ChildItem -Recurse -Force factory/inputs`, confirming the checked-in
+  inboxes remain sentinel-only while the visible idea file was ignored local
+  operating residue.
+- Confirmed the previously queued ignored idea
+  `factory/inputs/idea/default/cover-gocoveragecheck-helper-runtime-and-parser-branches.md`
+  is stale because merged PR `#137` already landed that exact cleanup on
+  `main`, so it should be pruned rather than re-queued.
+- Re-checked the live `portpowered/checklists` customer references and
+  confirmed there is still no checked-in repo-wide audit record for the linked
+  `website-development-checklist.md`, `backend-development-checklist.md`, and
+  `asks.md` documents; only the narrower import/export checklist record exists.
+- Verified the next narrow UI checklist-alignment seam is
+  `ui/src/features/import/dashboard-import-preview-dialog.tsx`: the repo still
+  has no `ui/src/i18n` directory or automated accessibility test dependency in
+  `ui/package.json`, while that dialog keeps concentrated hardcoded copy and
+  already has focused test and Storybook seams for a small follow-up.
+- Verified the next narrow backend simplification seam is the
+  `cmd/deadcodecheck` `GODEBUG=gotypesalias=1` compatibility path: the shim is
+  still present in `runDeadcode()`, `deadcodeEnv()`, and
+  `ensureGoTypesAliasEnabled()`, but live deadcode runs on the supported Go
+  `1.24.x` toolchain succeed with or without the override, so the path now
+  appears to be redundant legacy handling rather than an active requirement.
+- Queued three replacement ignored idea files so the operating backlog matches
+  the standing ask to keep at least three non-overlapping tasks running:
+  `audit-repository-against-2026-website-and-backend-checklists.md`,
+  `localize-and-accessibility-harden-import-preview-dialog.md`, and
+  `retire-deadcodecheck-gotypesalias-compat-shim.md`.

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,9 +2,10 @@
 
 ## world state
 
-- as of `2026-05-07T02:06:20.9186342-07:00`, local `HEAD` on `main` points to
-  `bf2ea7e` (`Merge pull request #138 from portpowered/branchling`) and is
-  current with `origin/main`
+- as of `2026-05-07T03:02:15.3916934-07:00`, local `HEAD` on `main` points to
+  `41ae281` (`Merge branch 'main' of https://github.com/portpowered/infinite-you`)
+  and already contains upstream `origin/main` through merged PR `#140`
+  (`retire-deadcodecheck-gotypesalias-compat-shim`) at `08acc2f`
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - before this refresh, the only visible tracked local edit was the
   user-maintained canonical ask file `factory/logs/meta/asks.md`
@@ -36,15 +37,15 @@
 - `.gitignore` still keeps live workflow submissions under `factory/inputs/**`
   out of normal commits except for those sentinel paths
 - the previously queued ignored idea
-  `factory/inputs/idea/default/cover-gocoveragecheck-helper-runtime-and-parser-branches.md`
-  is stale on live `main` because merged PR `#137` landed that exact lane on
-  `2026-05-07T03:23:26Z`
+  `factory/inputs/idea/default/retire-deadcodecheck-gotypesalias-compat-shim.md`
+  is now stale on live `main` because merged PR `#140` landed that exact lane
+  on `2026-05-07T09:34:50Z`
 - after pruning that stale residue, the maintainer-owned ignored queue should
   carry three fresh non-overlapping idea files so the autonomous lane matches
   the standing ask to keep at least three tasks running:
   - `audit-repository-against-2026-website-and-backend-checklists.md`
   - `localize-and-accessibility-harden-import-preview-dialog.md`
-  - `retire-deadcodecheck-gotypesalias-compat-shim.md`
+  - `cover-releasesmoke-command-owner-parse-and-json-error-branches.md`
 
 ## customer-ask truth
 
@@ -64,13 +65,14 @@
   - `backend-development-checklist.md`
   - `asks.md`
 - there is still no checked-in repo-wide review record mapping this repository
-  against those external checklist documents; the only checked-in alignment
-  checklist found this turn is the narrower import/export lane record at
-  `docs/internal/development/import-export-standards-alignment-checklist.md`
-- the UI still lacks shared localization infrastructure:
-  - `ui/src/i18n` does not exist on live `main`
+  against those external checklist documents on live `main`; PR `#141`
+  currently owns that audit lane, but it is not merged yet
+- the UI still lacks shared localization infrastructure on live `main`:
+  - `ui/src/i18n` does not exist
   - `ui/package.json` does not currently carry an automated accessibility test
     dependency such as `axe-core` or a wrapper matcher
+  - PR `#142` owns the first narrow import-preview lane for those gaps, but it
+    is not merged yet
 
 ## replay truth
 
@@ -85,37 +87,40 @@
 ## recent repo movement
 
 - recent merged PRs on `main` now include:
-  - `#138` `Branchling`, merged on `2026-05-07T08:23:18Z`
+  - `#140` `retire-deadcodecheck-gotypesalias-compat-shim`, merged on
+    `2026-05-07T09:34:50Z`
+  - `#138` `Branchling`, merged on `2026-05-07T08:30:28Z`
   - `#137` `cover-gocoveragecheck-helper-runtime-and-parser-branches`, merged
-    on `2026-05-07T03:23:26Z`
-  - `#136` `Windows release`, merged on `2026-05-07T00:19:46Z`
+    on `2026-05-07T03:38:27Z`
+  - `#136` `Windows release`, merged on `2026-05-07T01:38:06Z`
   - `#135` `cover-functionallane-command-owner-error-and-entrypoint-branches`,
-    merged on `2026-05-06T23:18:17Z`
-  - `#134` `cover-gocoveragecheck-command-owner-threshold-and-entrypoint-branches`,
-    merged on `2026-05-06T22:18:52Z`
-- `gh pr list --state open` still reports only the two older meta-refresh PRs:
+    merged on `2026-05-06T23:28:08Z`
+- `gh pr list --state open` now reports:
+  - `#142` `localize-and-accessibility-harden-import-preview-dialog`
+  - `#141` `audit-repository-against-2026-website-and-backend-checklists`
+  - `#139` `docs: refresh meta world state`
   - `#123` `docs: refresh meta world state`
   - `#120` `docs: refresh meta world state`
-- those open PRs do not own the next code cleanup or checklist-alignment lane
+- PRs `#141` and `#142` already own the current checklist-audit and
+  import-preview standards lanes, so the next replacement task must avoid
+  those file and behavior surfaces
 
 ## next cleanup candidates
 
-- repo-wide standards evidence remains the highest-priority open ask because
-  there is still no checked-in audit mapping this repository to the current
-  external backend and website checklists
-- the narrowest current UI standards lane is the import preview dialog:
-  - `ui/src/features/import/dashboard-import-preview-dialog.tsx` still owns a
-    concentrated set of hardcoded user-visible strings
-  - `ui/src/features/import/dashboard-import-preview-dialog.test.tsx` and
-    `.stories.tsx` already provide focused verification seams
-  - the repo still lacks `ui/src/i18n` and automated accessibility assertions
-    for that feature surface
-- the narrowest current backend simplification lane is in `cmd/deadcodecheck`:
-  - `runDeadcode()` still injects a `GODEBUG=gotypesalias=1` compatibility shim
-    through `deadcodeEnv()` and `ensureGoTypesAliasEnabled()`
-  - live manual command checks on the supported Go `1.24.x` toolchain succeed
-    both with and without that override, so the shim now appears to be
-    redundant legacy handling rather than a live policy requirement
+- the repo-wide standards audit remains the highest-priority checklist ask on
+  live `main`, but PR `#141` already owns that documentation lane
+- the narrowest current UI standards lane remains the import preview dialog,
+  but PR `#142` already owns that feature-local localization and accessibility
+  work
+- the next non-overlapping repo-owned backend testing seam is now in
+  `cmd/releasesmoke`:
+  - merged PR `#128` already covered the thin `main()` entrypoint routing
+  - `go test -cover ./cmd/...` still reports `83.3%` statement coverage for
+    `cmd/releasesmoke`
+  - `cmd/releasesmoke/main.go` still carries uncovered parse-error and
+    `writeJSON` encode-failure branches in the command-owner boundary
+  - `cmd/releasesmoke/main_test.go` already provides a focused package-local
+    seam to add those assertions without widening into release harness changes
 
 ## theory of mind
 
@@ -126,11 +131,14 @@
   checked-in contract versus ignored operating residue
 - when a previously queued idea lands on `main`, prune the ignored residue and
   refresh the next seam from live code and PR state before queuing anything
-  else; merged PR `#137` invalidated the previously recorded next seam within
-  hours
+  else; merged PR `#140` invalidated one of the three active backlog slots
+  within the same cycle
 - when the customer ask requires at least three tasks in flight, satisfy that
   ask with three narrow non-overlapping idea files rather than one broad batch
   unless dependency ordering is actually required
 - when checklist conformance is still undocumented, queue one audit lane plus
   smaller implementation-ready follow-ups instead of claiming alignment from
   standards intent alone
+- when one queued lane merges while sibling PRs are still open, replace only
+  the merged slot with a new non-overlapping idea instead of re-queuing work
+  already owned by the open PRs

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,19 +2,14 @@
 
 ## world state
 
-- as of `2026-05-06T20:04:20.2572074-07:00`, local `HEAD` on `main` points to
-  `22e20d8` (`Merge pull request #136 from portpowered/windows-release`) and is
+- as of `2026-05-07T02:06:20.9186342-07:00`, local `HEAD` on `main` points to
+  `bf2ea7e` (`Merge pull request #138 from portpowered/branchling`) and is
   current with `origin/main`
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
-- the tracked worktree is not clean, but the visible tracked edits are outside
-  the canonical meta surfaces and should be treated as user-owned local state:
-  - `examples/idea-plan-code-review/scripts/setup-workspace.py`
-  - `examples/thought-idea--plan-work-review/scripts/setup-workspace.py`
-  - `factory/scripts/setup-workspace.py`
-  - `tests/adhoc/factory/scripts/setup-workspace.py`
-  - `tests/functional_test/testdata/idea_plan_execute_review_with_limits/scripts/setup-workspace.py`
-- canonical `factory/inputs/**` remains tracked-sentinel-only and there is no
-  checked-in cleanup request currently queued under `factory/inputs/**`
+- before this refresh, the only visible tracked local edit was the
+  user-maintained canonical ask file `factory/logs/meta/asks.md`
+- canonical `factory/inputs/**` remains tracked-sentinel-only in git, while
+  live maintainer submissions remain ignored operating state
 
 ## workflow truth
 
@@ -40,9 +35,16 @@
   - `factory/inputs/thoughts/default/.gitkeep`
 - `.gitignore` still keeps live workflow submissions under `factory/inputs/**`
   out of normal commits except for those sentinel paths
-- the visible canonical idea inbox is empty on this checkout aside from
-  `.gitkeep`, so the next dispatch must create fresh ignored operating state
-  rather than reconcile stale local residue
+- the previously queued ignored idea
+  `factory/inputs/idea/default/cover-gocoveragecheck-helper-runtime-and-parser-branches.md`
+  is stale on live `main` because merged PR `#137` landed that exact lane on
+  `2026-05-07T03:23:26Z`
+- after pruning that stale residue, the maintainer-owned ignored queue should
+  carry three fresh non-overlapping idea files so the autonomous lane matches
+  the standing ask to keep at least three tasks running:
+  - `audit-repository-against-2026-website-and-backend-checklists.md`
+  - `localize-and-accessibility-harden-import-preview-dialog.md`
+  - `retire-deadcodecheck-gotypesalias-compat-shim.md`
 
 ## customer-ask truth
 
@@ -54,15 +56,21 @@
   - keep backend and website testing moving toward declared high-coverage goals
   - keep simplifying backend and website ownership where duplicate or stale
     logic remains
+  - keep at least three non-overlapping tasks running at a time
 - the external checklist links in `factory/logs/meta/asks.md` still point at
-  the live `portpowered/checklists` repository, and both documents are current
-  `2026` checklist revisions:
+  the live `portpowered/checklists` repository, and the explicit linked docs
+  remain the current `2026` checklist revisions:
   - `website-development-checklist.md`
   - `backend-development-checklist.md`
+  - `asks.md`
 - there is still no checked-in repo-wide review record mapping this repository
   against those external checklist documents; the only checked-in alignment
   checklist found this turn is the narrower import/export lane record at
   `docs/internal/development/import-export-standards-alignment-checklist.md`
+- the UI still lacks shared localization infrastructure:
+  - `ui/src/i18n` does not exist on live `main`
+  - `ui/package.json` does not currently carry an automated accessibility test
+    dependency such as `axe-core` or a wrapper matcher
 
 ## replay truth
 
@@ -77,56 +85,52 @@
 ## recent repo movement
 
 - recent merged PRs on `main` now include:
-  - `#136` `Windows release`, merged on `2026-05-07T01:38:06Z`
+  - `#138` `Branchling`, merged on `2026-05-07T08:23:18Z`
+  - `#137` `cover-gocoveragecheck-helper-runtime-and-parser-branches`, merged
+    on `2026-05-07T03:23:26Z`
+  - `#136` `Windows release`, merged on `2026-05-07T00:19:46Z`
   - `#135` `cover-functionallane-command-owner-error-and-entrypoint-branches`,
-    merged on `2026-05-06T23:28:08Z`
+    merged on `2026-05-06T23:18:17Z`
   - `#134` `cover-gocoveragecheck-command-owner-threshold-and-entrypoint-branches`,
     merged on `2026-05-06T22:18:52Z`
-  - `#133` `cover-releasetagcheck-git-tag-wrapper-branches`, merged on
-    `2026-05-06T21:11:35Z`
-  - `#132` `cover-deadcodecheck-command-owner-branches`, merged on
-    `2026-05-06T20:17:42Z`
 - `gh pr list --state open` still reports only the two older meta-refresh PRs:
   - `#123` `docs: refresh meta world state`
   - `#120` `docs: refresh meta world state`
-- those open PRs do not own the next code cleanup lane
+- those open PRs do not own the next code cleanup or checklist-alignment lane
 
-## next cleanup candidate
+## next cleanup candidates
 
-- merged PR `#135` closes the previously recorded `cmd/functionallane`
-  command-owner seam on live `main`; `go test -cover ./cmd/functionallane` now
-  reports `100.0%` statement coverage
-- the next non-overlapping maintainer-owned quality seam is back in
-  `cmd/gocoveragecheck`:
-  - `make test-coverage-go` still routes through the repo-owned
-    `cmd/gocoveragecheck` entrypoint
-  - package coverage is still only `78.5%` on live `main`, materially below
-    adjacent maintainer-gate commands
-  - merged PR `#134` already covered the threshold and direct entrypoint
-    branches, but `run()`, `resolveCoverageLane()`, `listGoPackages()`,
-    `parseTotalCoverage()`, `evaluateCoverage()`, `parseCoverageProfile()`, and
-    `coverageImportPath()` still have uncovered helper and failure branches
-  - the remaining useful work is still narrow and package-local: add direct
-    tests for temp-profile lifecycle behavior, coverage-tool failure detail
-    selection, package-discovery and repo-root failure wrappers, and malformed
-    profile or path parsing cases without changing coverage policy, thresholds,
-    package selection, or CI wiring
+- repo-wide standards evidence remains the highest-priority open ask because
+  there is still no checked-in audit mapping this repository to the current
+  external backend and website checklists
+- the narrowest current UI standards lane is the import preview dialog:
+  - `ui/src/features/import/dashboard-import-preview-dialog.tsx` still owns a
+    concentrated set of hardcoded user-visible strings
+  - `ui/src/features/import/dashboard-import-preview-dialog.test.tsx` and
+    `.stories.tsx` already provide focused verification seams
+  - the repo still lacks `ui/src/i18n` and automated accessibility assertions
+    for that feature surface
+- the narrowest current backend simplification lane is in `cmd/deadcodecheck`:
+  - `runDeadcode()` still injects a `GODEBUG=gotypesalias=1` compatibility shim
+    through `deadcodeEnv()` and `ensureGoTypesAliasEnabled()`
+  - live manual command checks on the supported Go `1.24.x` toolchain succeed
+    both with and without that override, so the shim now appears to be
+    redundant legacy handling rather than a live policy requirement
 
 ## theory of mind
 
 - the authoritative world model comes from live `main`, the checked-in workflow
-  contract, the canonical ask file, and current PR state together
+  contract, the canonical ask file, current PR state, and current external
+  checklist docs together
 - `factory/inputs/**` must still be reasoned about in two layers:
   checked-in contract versus ignored operating residue
-- when a previously queued narrow coverage seam lands on `main`, refresh the
-  next seam from live coverage output before reusing the old theory; the
-  `functionallane` lane went from `82.0%` to `100.0%` within one refresh cycle
-- when the customer ask references external checklist repositories, re-check
-  the live linked documents before claiming conformance status; broad checklist
-  intent is not evidence
-- when no checked-in repo-wide checklist audit exists yet, treat checklist
-  conformance as still open and queue either a narrow audit task or a smaller
-  maintainer-owned enforcement seam instead of declaring the ask satisfied
-- when broad quality asks remain open, prefer the next narrow repo-owned gate
-  that improves reviewable evidence without overlapping unrelated user-owned
-  tracked edits
+- when a previously queued idea lands on `main`, prune the ignored residue and
+  refresh the next seam from live code and PR state before queuing anything
+  else; merged PR `#137` invalidated the previously recorded next seam within
+  hours
+- when the customer ask requires at least three tasks in flight, satisfy that
+  ask with three narrow non-overlapping idea files rather than one broad batch
+  unless dependency ordering is actually required
+- when checklist conformance is still undocumented, queue one audit lane plus
+  smaller implementation-ready follow-ups instead of claiming alignment from
+  standards intent alone

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,10 +2,11 @@
 
 ## world state
 
-- as of `2026-05-07T03:02:15.3916934-07:00`, local `HEAD` on `main` points to
-  `41ae281` (`Merge branch 'main' of https://github.com/portpowered/infinite-you`)
-  and already contains upstream `origin/main` through merged PR `#140`
-  (`retire-deadcodecheck-gotypesalias-compat-shim`) at `08acc2f`
+- as of `2026-05-07T04:04:43.0744927-07:00`, local `HEAD` on `main` points to
+  `b145e56` (`Merge branch 'main' of https://github.com/portpowered/infinite-you`)
+  and already contains upstream `origin/main` through merged PR `#144`
+  (`cover-releasesmoke-command-owner-parse-and-json-error-branches`) at
+  `8a7f0f9`
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - before this refresh, the only visible tracked local edit was the
   user-maintained canonical ask file `factory/logs/meta/asks.md`
@@ -36,16 +37,19 @@
   - `factory/inputs/thoughts/default/.gitkeep`
 - `.gitignore` still keeps live workflow submissions under `factory/inputs/**`
   out of normal commits except for those sentinel paths
-- the previously queued ignored idea
-  `factory/inputs/idea/default/retire-deadcodecheck-gotypesalias-compat-shim.md`
-  is now stale on live `main` because merged PR `#140` landed that exact lane
-  on `2026-05-07T09:34:50Z`
-- after pruning that stale residue, the maintainer-owned ignored queue should
+- the ignored idea files
+  `factory/inputs/idea/default/localize-and-accessibility-harden-import-preview-dialog.md`
+  and
+  `factory/inputs/idea/default/cover-releasesmoke-command-owner-parse-and-json-error-branches.md`
+  are now stale on live `main` because merged PR `#142` landed on
+  `2026-05-07T09:34:50Z` and merged PR `#144` landed on
+  `2026-05-07T10:13:02Z`
+- after pruning those stale residues, the maintainer-owned ignored queue should
   carry three fresh non-overlapping idea files so the autonomous lane matches
   the standing ask to keep at least three tasks running:
   - `audit-repository-against-2026-website-and-backend-checklists.md`
-  - `localize-and-accessibility-harden-import-preview-dialog.md`
-  - `cover-releasesmoke-command-owner-parse-and-json-error-branches.md`
+  - `localize-export-dialog-and-trigger.md`
+  - `narrow-cron-watcher-runtime-lookup-contract.md`
 
 ## customer-ask truth
 
@@ -63,16 +67,21 @@
   remain the current `2026` checklist revisions:
   - `website-development-checklist.md`
   - `backend-development-checklist.md`
-  - `asks.md`
-- there is still no checked-in repo-wide review record mapping this repository
-  against those external checklist documents on live `main`; PR `#141`
-  currently owns that audit lane, but it is not merged yet
-- the UI still lacks shared localization infrastructure on live `main`:
-  - `ui/src/i18n` does not exist
-  - `ui/package.json` does not currently carry an automated accessibility test
-    dependency such as `axe-core` or a wrapper matcher
-  - PR `#142` owns the first narrow import-preview lane for those gaps, but it
-    is not merged yet
+- the linked external `asks.md` source still has an evidence gap on
+  `2026-05-07`: `https://raw.githubusercontent.com/portpowered/checklists/main/asks.md`
+  does not resolve to a readable checklist document, so that ask reference
+  still needs to be treated as unavailable evidence rather than assumed input
+- there is still no merged checked-in repo-wide review record mapping this
+  repository against those external checklist documents on live `main`; open
+  PR `#141` currently owns that audit lane
+- the UI now has a shared localization foothold on live `main`:
+  - `ui/src/i18n/index.ts`, `ui/src/i18n/locales.ts`, and
+    `ui/src/i18n/messages.ts` now exist on `main`
+  - `ui/package.json` now carries `jest-axe`, but broad feature-local
+    accessibility automation is still not wired through the dashboard surface
+  - merged PR `#142` only localized and accessibility-hardened the import
+    preview dialog, so adjacent export-trigger and export-dialog copy remains
+    the next narrow i18n follow-up
 
 ## replay truth
 
@@ -87,40 +96,52 @@
 ## recent repo movement
 
 - recent merged PRs on `main` now include:
+  - `#144` `cover-releasesmoke-command-owner-parse-and-json-error-branches`,
+    merged on `2026-05-07T10:13:02Z`
+  - `#142` `localize-and-accessibility-harden-import-preview-dialog`, merged
+    on `2026-05-07T09:34:50Z`
   - `#140` `retire-deadcodecheck-gotypesalias-compat-shim`, merged on
-    `2026-05-07T09:34:50Z`
-  - `#138` `Branchling`, merged on `2026-05-07T08:30:28Z`
+    `2026-05-07T09:25:03Z`
+  - `#138` `Branchling`, merged on `2026-05-07T08:23:18Z`
   - `#137` `cover-gocoveragecheck-helper-runtime-and-parser-branches`, merged
-    on `2026-05-07T03:38:27Z`
-  - `#136` `Windows release`, merged on `2026-05-07T01:38:06Z`
-  - `#135` `cover-functionallane-command-owner-error-and-entrypoint-branches`,
-    merged on `2026-05-06T23:28:08Z`
+    on `2026-05-07T03:23:26Z`
 - `gh pr list --state open` now reports:
-  - `#142` `localize-and-accessibility-harden-import-preview-dialog`
+  - `#143` `docs: refresh meta world state`
   - `#141` `audit-repository-against-2026-website-and-backend-checklists`
   - `#139` `docs: refresh meta world state`
   - `#123` `docs: refresh meta world state`
   - `#120` `docs: refresh meta world state`
-- PRs `#141` and `#142` already own the current checklist-audit and
-  import-preview standards lanes, so the next replacement task must avoid
-  those file and behavior surfaces
+- open PR `#141` already owns the current checklist-audit lane, so new backlog
+  replacements must avoid its doc surface while still acting on live code gaps
 
 ## next cleanup candidates
 
 - the repo-wide standards audit remains the highest-priority checklist ask on
   live `main`, but PR `#141` already owns that documentation lane
-- the narrowest current UI standards lane remains the import preview dialog,
-  but PR `#142` already owns that feature-local localization and accessibility
-  work
-- the next non-overlapping repo-owned backend testing seam is now in
-  `cmd/releasesmoke`:
-  - merged PR `#128` already covered the thin `main()` entrypoint routing
-  - `go test -cover ./cmd/...` still reports `83.3%` statement coverage for
-    `cmd/releasesmoke`
-  - `cmd/releasesmoke/main.go` still carries uncovered parse-error and
-    `writeJSON` encode-failure branches in the command-owner boundary
-  - `cmd/releasesmoke/main_test.go` already provides a focused package-local
-    seam to add those assertions without widening into release harness changes
+- the next narrow UI checklist-alignment seam is the export path:
+  - `ui/src/features/export/export-factory-dialog.tsx` still hardcodes the
+    export dialog title, body copy, labels, validation text, success text, and
+    action labels
+  - `ui/src/features/header/dashboard-header.tsx` still hardcodes the export
+    trigger `aria-label`
+  - the shared dialog already supports `closeLabel`, but the export dialog does
+    not yet pass localized close-control copy
+- the next narrow backend simplification seam is the cron watcher runtime
+  contract:
+  - `pkg/interfaces/runtime_lookup.go` still exposes
+    `RuntimeConfigLookup` as a composite of definition lookups plus
+    path-aware methods
+  - `pkg/service/cron_watcher.go` currently accepts
+    `interfaces.RuntimeConfigLookup` across its top-level cron helpers even
+    though most of that file only needs workstation lookup plus a separately
+    provided workflow identity
+  - narrowing cron-side signatures to `RuntimeWorkstationLookup` is the
+    smallest non-overlapping interface cleanup now that the canonical lookup
+    owner is already centralized in `pkg/interfaces`
+- the next backup backend testing seam after that is `cmd/releaseprep`:
+  - `go test -cover ./cmd/...` now reports `94.1%` for `cmd/releaseprep`
+  - `cmd/releaseprep/main.go` still leaves the explicit `flag.ErrHelp` branch
+    in `run()` without direct package-local coverage
 
 ## theory of mind
 
@@ -142,3 +163,6 @@
 - when one queued lane merges while sibling PRs are still open, replace only
   the merged slot with a new non-overlapping idea instead of re-queuing work
   already owned by the open PRs
+- when the linked external checklist repo omits one requested source such as
+  `asks.md`, record that as an evidence gap and continue from the sources that
+  are actually retrievable instead of inventing missing checklist content

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,13 +2,12 @@
 
 ## world state
 
-- as of `2026-05-07T04:04:43.0744927-07:00`, local `HEAD` on `main` points to
-  `b145e56` (`Merge branch 'main' of https://github.com/portpowered/infinite-you`)
-  and already contains upstream `origin/main` through merged PR `#144`
-  (`cover-releasesmoke-command-owner-parse-and-json-error-branches`) at
-  `8a7f0f9`
+- as of `2026-05-07T05:03:44.1967849-07:00`, local `HEAD` on `main` points to
+  `3d0c461` (`docs: refresh meta world state`), is ahead of `origin/main` by
+  three local meta commits, and already contains upstream `origin/main` through
+  merged PR `#147` (`localize-export-dialog-and-trigger`) at `6451e25`
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
-- before this refresh, the only visible tracked local edit was the
+- the only tracked local dirtiness outside this meta refresh remains the
   user-maintained canonical ask file `factory/logs/meta/asks.md`
 - canonical `factory/inputs/**` remains tracked-sentinel-only in git, while
   live maintainer submissions remain ignored operating state
@@ -38,18 +37,17 @@
 - `.gitignore` still keeps live workflow submissions under `factory/inputs/**`
   out of normal commits except for those sentinel paths
 - the ignored idea files
-  `factory/inputs/idea/default/localize-and-accessibility-harden-import-preview-dialog.md`
-  and
-  `factory/inputs/idea/default/cover-releasesmoke-command-owner-parse-and-json-error-branches.md`
-  are now stale on live `main` because merged PR `#142` landed on
-  `2026-05-07T09:34:50Z` and merged PR `#144` landed on
-  `2026-05-07T10:13:02Z`
-- after pruning those stale residues, the maintainer-owned ignored queue should
-  carry three fresh non-overlapping idea files so the autonomous lane matches
-  the standing ask to keep at least three tasks running:
+  `factory/inputs/idea/default/localize-export-dialog-and-trigger.md` and
+  `factory/inputs/idea/default/narrow-cron-watcher-runtime-lookup-contract.md`
+  were stale on live `main` because merged PR `#147` landed on
+  `2026-05-07T11:46:43Z` and merged PR `#146` landed on
+  `2026-05-07T11:39:54Z`
+- after pruning those stale residues, the maintainer-owned ignored queue now
+  carries three fresh non-overlapping idea files so the autonomous lane still
+  matches the standing ask to keep at least three tasks running:
   - `audit-repository-against-2026-website-and-backend-checklists.md`
-  - `localize-export-dialog-and-trigger.md`
-  - `narrow-cron-watcher-runtime-lookup-contract.md`
+  - `retire-template-fields-variadic-worktree-shim.md`
+  - `localize-dashboard-header-timeline-and-stream-status.md`
 
 ## customer-ask truth
 
@@ -74,14 +72,17 @@
 - there is still no merged checked-in repo-wide review record mapping this
   repository against those external checklist documents on live `main`; open
   PR `#141` currently owns that audit lane
-- the UI now has a shared localization foothold on live `main`:
+- the UI localization foothold now reaches both import and export surfaces on
+  live `main`:
   - `ui/src/i18n/index.ts`, `ui/src/i18n/locales.ts`, and
-    `ui/src/i18n/messages.ts` now exist on `main`
-  - `ui/package.json` now carries `jest-axe`, but broad feature-local
-    accessibility automation is still not wired through the dashboard surface
-  - merged PR `#142` only localized and accessibility-hardened the import
-    preview dialog, so adjacent export-trigger and export-dialog copy remains
-    the next narrow i18n follow-up
+    `ui/src/i18n/messages.ts` exist on `main`
+  - merged PR `#142` localized and accessibility-hardened the import preview
+    dialog
+  - merged PR `#147` localized the export dialog and export trigger
+  - `ui/src/features/header/tick-slider-control.tsx` and
+    `ui/src/features/header/dashboard-header.tsx` still keep concentrated
+    hardcoded English timeline and stream-status accessibility text, which is
+    now the next narrow header-local follow-up
 
 ## replay truth
 
@@ -96,16 +97,18 @@
 ## recent repo movement
 
 - recent merged PRs on `main` now include:
+  - `#147` `localize-export-dialog-and-trigger`, merged on
+    `2026-05-07T11:46:43Z`
+  - `#146` `narrow-cron-watcher-runtime-lookup-contract`, merged on
+    `2026-05-07T11:39:54Z`
   - `#144` `cover-releasesmoke-command-owner-parse-and-json-error-branches`,
     merged on `2026-05-07T10:13:02Z`
   - `#142` `localize-and-accessibility-harden-import-preview-dialog`, merged
     on `2026-05-07T09:34:50Z`
   - `#140` `retire-deadcodecheck-gotypesalias-compat-shim`, merged on
     `2026-05-07T09:25:03Z`
-  - `#138` `Branchling`, merged on `2026-05-07T08:23:18Z`
-  - `#137` `cover-gocoveragecheck-helper-runtime-and-parser-branches`, merged
-    on `2026-05-07T03:23:26Z`
 - `gh pr list --state open` now reports:
+  - `#145` `docs: refresh meta world state`
   - `#143` `docs: refresh meta world state`
   - `#141` `audit-repository-against-2026-website-and-backend-checklists`
   - `#139` `docs: refresh meta world state`
@@ -118,30 +121,39 @@
 
 - the repo-wide standards audit remains the highest-priority checklist ask on
   live `main`, but PR `#141` already owns that documentation lane
-- the next narrow UI checklist-alignment seam is the export path:
-  - `ui/src/features/export/export-factory-dialog.tsx` still hardcodes the
-    export dialog title, body copy, labels, validation text, success text, and
-    action labels
-  - `ui/src/features/header/dashboard-header.tsx` still hardcodes the export
-    trigger `aria-label`
-  - the shared dialog already supports `closeLabel`, but the export dialog does
-    not yet pass localized close-control copy
-- the next narrow backend simplification seam is the cron watcher runtime
-  contract:
-  - `pkg/interfaces/runtime_lookup.go` still exposes
-    `RuntimeConfigLookup` as a composite of definition lookups plus
-    path-aware methods
-  - `pkg/service/cron_watcher.go` currently accepts
-    `interfaces.RuntimeConfigLookup` across its top-level cron helpers even
-    though most of that file only needs workstation lookup plus a separately
-    provided workflow identity
-  - narrowing cron-side signatures to `RuntimeWorkstationLookup` is the
-    smallest non-overlapping interface cleanup now that the canonical lookup
-    owner is already centralized in `pkg/interfaces`
-- the next backup backend testing seam after that is `cmd/releaseprep`:
+- the next narrow backend simplification seam is the workers template-field
+  helper:
+  - `pkg/workers/template_fields.go` still exposes `ResolveTemplateFields`
+    with an explicitly backwards-compat variadic `worktreeTemplate ...string`
+    parameter
+  - the production caller in `pkg/workers/workstation_executor.go` already
+    passes one concrete `workstationDef.Worktree` value, so the legacy
+    compatibility shape is no longer needed on the live path
+  - the direct fallout is localized to `pkg/workers/template_fields_test.go`
+    plus the one production caller, making this a small implementation-ready
+    shim retirement
+- the next narrow UI checklist-alignment seam is the dashboard header control
+  surface:
+  - `ui/src/features/header/tick-slider-control.tsx` still hardcodes the slider
+    label, slider `aria-label`, waiting-state text, tick status text, and
+    "Return to current tick" button name
+  - `ui/src/features/header/dashboard-header.tsx` still hardcodes the region
+    label and stream-status accessible names for `live`, `offline`, and
+    `connecting`
+  - the import/export dialog localization pattern already exists on live
+    `main`, so this is now a small feature-local follow-up rather than a new
+    i18n foundation project
+- the next backup backend seam after that is `cmd/releaseprep`:
   - `go test -cover ./cmd/...` now reports `94.1%` for `cmd/releaseprep`
-  - `cmd/releaseprep/main.go` still leaves the explicit `flag.ErrHelp` branch
-    in `run()` without direct package-local coverage
+  - `cmd/releaseprep/main.go` still leaves the explicit `flag.ErrHelp` success
+    branch and direct parse-failure routing as a small command-owner coverage
+    closeout
+- the next backup backend testing seam after that is still `cmd/gocoveragecheck`:
+  - `go test -cover ./cmd/...` now reports `75.0%` for
+    `cmd/gocoveragecheck`
+  - remaining coverage is concentrated in command-owner execution, package-list,
+    and coverage-evaluation error branches rather than in backend application
+    packages
 
 ## theory of mind
 
@@ -152,17 +164,24 @@
   checked-in contract versus ignored operating residue
 - when a previously queued idea lands on `main`, prune the ignored residue and
   refresh the next seam from live code and PR state before queuing anything
-  else; merged PR `#140` invalidated one of the three active backlog slots
-  within the same cycle
+  else; merged PRs `#146` and `#147` invalidated two of the three active
+  backlog slots within the same cycle
 - when the customer ask requires at least three tasks in flight, satisfy that
   ask with three narrow non-overlapping idea files rather than one broad batch
   unless dependency ordering is actually required
 - when checklist conformance is still undocumented, queue one audit lane plus
   smaller implementation-ready follow-ups instead of claiming alignment from
   standards intent alone
-- when one queued lane merges while sibling PRs are still open, replace only
-  the merged slot with a new non-overlapping idea instead of re-queuing work
-  already owned by the open PRs
+- when a localization follow-up merges on one dashboard dialog, re-read the
+  adjacent header controls and accessibility labels next; the concentrated
+  English-only residue often lives there rather than in a second dialog
+- when a helper still advertises an explicitly backwards-compatible variadic or
+  optional parameter but the live production caller already passes the
+  canonical explicit shape, retire the shim before widening into larger runtime
+  refactors
+- when a repo-owned command package is already above 90% coverage, prefer the
+  remaining help, parse, or exit-routing branches in that thin command owner
+  before widening into the underlying internal package
 - when the linked external checklist repo omits one requested source such as
   `asks.md`, record that as an evidence gap and continue from the sources that
   are actually retrievable instead of inventing missing checklist content


### PR DESCRIPTION
## Summary
- refresh the checked-in meta worldview to live main after merged PRs #146 and #147
- rotate the ignored operating queue to the checklist audit plus the new header-localization and template-field cleanup seams
- record the current external checklist evidence gap for checklists/asks.md

## Testing
- not run (meta docs and ignored workflow queue refresh only)