### PR TITLE
cover-releasetagcheck-command-owner-parse-failure-branch

### DIFF
--- a/cmd/releasetagcheck/main_test.go
+++ b/cmd/releasetagcheck/main_test.go
@@ -131,6 +131,23 @@ func TestRunRequiresOneTagInput(t *testing.T) {
 	}
 }
 
+func TestRunInvalidFlagPreservesParseFailureContract(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := run([]string{"-unknown"}, &stdout, &stderr)
+
+	if exitCode != 1 {
+		t.Fatalf("run() exit code = %d, want 1", exitCode)
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("run() stdout = %q, want empty", got)
+	}
+	if got := stderr.String(); got != "flag provided but not defined: -unknown\n" {
+		t.Fatalf("run() stderr = %q", got)
+	}
+}
+
 func TestRunPointsAtSuccess(t *testing.T) {
 	originalListGitTagsPointingAt := listGitTagsPointingAt
 	t.Cleanup(func() {


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/cover-releasetagcheck-command-owner-parse-failure-branch",
  "description": "Add one focused package-local regression test in `cmd/releasetagcheck` that proves invalid-flag parse failure preserves the command's existing exit-code and stderr contract without widening into release-policy or git-wrapper changes.",
  "context": {
    "customerAsk": "The canonical customer ask in `factory/logs/meta/asks.md` requires stronger backend testing evidence and continued narrow cleanup work that improves repository-owned quality gates without widening into broad application rewrites.",
    "problem": "Merged PR `#155` (`cover-deadcodecheck-write-read-and-stderr-branches`) closed the remaining small `deadcodecheck` seam on live `main`, so the next thinnest repo-owned command-owner test gap is now `cmd/releasetagcheck`. On `2026-05-07`, `go test -cover ./cmd/releasetagcheck` reports `92.9%` statement coverage, and the only uncovered branches stay local to `cmd/releasetagcheck/main.go`: `run()`'s parse-error return path and `parseArgs()` when `flag.Parse` fails. The package already covers explicit tag validation, `-points-at` behavior, and the real git wrapper, but it still does not prove the invalid-flag path that maintains the command's public error contract.",
    "solution": "Keep the follow-up local to `cmd/releasetagcheck` and add one focused package-local test that exercises `run([]string{\"-unknown\"}, ...)`, asserts the emitted stderr and exit code, and preserves the existing command contract without widening into broader release or git-policy changes."
  },
  "acceptanceCriteria": [
    "AC-1: `cmd/releasetagcheck` gains focused package-local coverage for the invalid-flag parse-failure path in `main.go`.",
    "AC-2: Invalid flag input remains an observable command-owner failure, with the existing non-zero exit result preserved for parse errors.",
    "AC-3: The new regression evidence asserts stderr output and exit code behavior instead of only executing lines for coverage.",
    "AC-4: Existing explicit-tag validation, `-points-at` behavior, and git-wrapper behavior remain unchanged.",
    "AC-5: The work stays localized to the repo-owned `releasetagcheck` command and its direct tests without broadening into release workflow or policy changes.",
    "AC-6: Quality checks pass (typecheck, lint, tests)."
  ],
  "userStories": [
    {
      "id": "cover-releasetagcheck-command-owner-parse-failure-branch-001",
      "title": "Prove invalid-flag handling keeps the releasetagcheck command contract",
      "description": "As a maintainer, I want the releasetagcheck command owner to prove its invalid-flag parse-failure path so CI and local command usage keep a trusted regression check for the command's public error behavior.",
      "acceptanceCriteria": [
        "A package-local test directly exercises `run([]string{\"-unknown\"}, ...)` and proves the existing parse-failure exit result.",
        "The test asserts the invalid-flag path emits stderr output from argument parsing so the command's observable error contract stays covered behaviorally.",
        "The test keeps execution scoped to parse failure and does not require changes to tag validation rules, `-points-at` handling, or the git wrapper.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    }
  ]
}
