### PR TITLE
docs: refresh meta world state

### DIFF
--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -159,19 +159,29 @@
   `origin/main` directly; a plain branch-local `git pull` can leave the branch
   current with its own remote tracking ref while still missing newer mainline
   merges that change PR ownership or the next cleanup seam.
+- When only one productive non-meta feature PR remains open, queue two fresh
+  non-overlapping idea files so the active cleanup lanes still total three;
+  stacked meta-refresh PRs do not count toward the customer ask.
 - After a localized dashboard dialog merges, re-read the adjacent header
   controls and status accessibility labels next; concentrated English-only
   residue often remains there rather than in another dialog.
 - When a helper still carries an explicitly backwards-compatible variadic
   parameter but the live production caller already passes one concrete explicit
   value, prefer deleting the shim over preserving two call shapes.
+- When a dashboard feature already has focused tests but no feature-local
+  `messages/` owner, that is usually the next safe localization seam after an
+  adjacent UI lane merges.
+- When a runtime config package exposes the same lookup behavior through an
+  alias type, an internal map holder, and a private bounce method, prefer
+  collapsing the package-local indirection while preserving the public
+  interface contract and behavior tests.
 
 ## Current Summary
 
-- As of `2026-05-07T12:06:28.9599999-07:00`, `HEAD` points to `cb24fe4` on
+- As of `2026-05-07T12:36:57.0000000-07:00`, `HEAD` points to `df7db2a` on
   branch `meta-refresh-world-state-20260507-110000`, rebased onto live
-  `origin/main` through merged PR `#162`
-  (`localize-dashboard-flow-axis-legend-copy`).
+  `origin/main` through merged PR `#165`
+  (`localize-workflow-activity-graph-import-copy`).
 - The canonical ask surface remains `factory/logs/meta/asks.md`.
 - The checked-in maintainer workflow is `thoughts -> idea -> plan -> task`
   with `idea/task:to-complete`, same-name `consume`, `.claude/worktrees`
@@ -183,10 +193,9 @@
   user-owned tracked edit and the maintainer meta refresh updates the tracked
   view/progress docs; ignored workflow files under `factory/inputs/**` remain
   operating state rather than canonical queue truth.
-- Recent merged PRs now include `#162`, `#161`, and `#160`; open PR `#141`
-  owns the checklist-audit lane and open PR `#164` owns terminal-work
-  localization, while the older meta refresh PRs remain stacked beside this
-  branch.
+- Recent merged PRs now include `#165`, `#164`, `#162`, `#161`, and `#160`;
+  open PR `#141` now stands as the only productive non-meta feature lane while
+  the older meta refresh PRs remain stacked beside this branch.
 - The canonical ask surface remains the quality-oriented rewrite in
   `factory/logs/meta/asks.md`; the active asks are external checklist
   alignment, stronger backend and website testing, ongoing simplification, and
@@ -197,12 +206,14 @@
 - The external website and backend checklist URLs remain readable on
   `2026-05-07`, but the linked external `asks.md` URL still does not produce a
   readable checklist document and must be treated as a source-evidence gap.
-- The previously queued ignored idea
-  `localize-terminal-work-card-copy.md` is stale because that lane has now
-  advanced into open PR `#164`.
-- The next maintainer-owned operating queue slot should now be
-  `localize-workflow-activity-graph-import-copy.md`, which keeps three
-  non-overlapping active lanes alongside open PR `#141` and open PR `#164`.
+- The previously queued ignored ideas
+  `localize-terminal-work-card-copy.md` and
+  `localize-workflow-activity-graph-import-copy.md` are stale because merged
+  PRs `#164` and `#165` already landed those exact lanes on `main`.
+- The next maintainer-owned operating queue slots should now be
+  `localize-work-outcome-trend-cards-copy.md` and
+  `simplify-loaded-runtime-definition-lookups.md`, which restore three
+  productive non-overlapping lanes alongside open PR `#141`.
 
 ## 2026-05-07T12:06:28.9599999-07:00 - meta state refresh
 
@@ -2162,3 +2173,47 @@
   `factory/inputs/idea/default/localize-terminal-work-card-copy.md` so the
   active maintainers' work returns to three non-overlapping lanes alongside
   open PR `#141` and open PR `#162`.
+
+## 2026-05-07T12:36:57.0000000-07:00 - meta state refresh
+
+- Ran `git pull --ff-only`, confirmed the branch was still one merge behind
+  live `origin/main` because merged PR `#165` had landed after the prior meta
+  refresh commit, then ran `git pull --rebase --autostash origin main` to
+  rebase this branch onto live `main` through merged PRs `#164` and `#165`
+  while preserving the user-owned tracked edit in `factory/logs/meta/asks.md`.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`, current PR
+  state, the tracked-versus-ignored `factory/inputs/**` surface, and the live
+  candidate UI and backend seams.
+- Re-validated tracked queue truth with `git ls-files factory/inputs` and
+  `Get-ChildItem -Recurse -Force factory/inputs`, confirming the checked-in
+  inboxes remain sentinel-only while the visible idea file was ignored local
+  operating residue.
+- Confirmed the previously visible ignored idea
+  `factory/inputs/idea/default/localize-workflow-activity-graph-import-copy.md`
+  is stale because merged PR `#165` already landed that exact cleanup on
+  `main`, and observed that open PR `#141` is now the only productive
+  non-meta feature lane still active.
+- Used delegated explorer passes, graph-backed discovery, direct reads of
+  `ui/src/features/work-outcome/trend-cards.tsx`,
+  `ui/src/features/work-outcome/trends.ts`, and
+  `pkg/config/runtime_config.go`, plus focused test inventory reads, to choose
+  two replacement lanes that restore three productive non-overlapping asks in
+  flight:
+  `localize-work-outcome-trend-cards-copy.md` and
+  `simplify-loaded-runtime-definition-lookups.md`.
+- Verified the work-outcome lane is implementation-ready because
+  `trend-cards.tsx` still hardcodes user-facing and accessible copy for the
+  failure, rework, and timing cards, `trends.ts` still hardcodes shared
+  throughput labels such as `Queued`, `In-flight`, `Completed`,
+  `Failed/retried`, and `Session`, and focused coverage already exists in
+  `ui/src/features/work-outcome/trend-cards.test.tsx`.
+- Verified the runtime-config lane is implementation-ready because
+  `pkg/config/runtime_config.go` still carries one redundant package-local
+  lookup layer through `lookup`, `runtimeDefinitionLookup()`,
+  `runtimeDefinitionLookupMaps`, the `runtimeDefinitionConfig` alias, and
+  `newRuntimeDefinitionConfig()`, while focused behavior coverage already
+  exists in `pkg/config/runtime_config_test.go`,
+  `pkg/factory/projections/topology_projection_test.go`,
+  `pkg/factory/event_history_test.go`, and `pkg/service/factory_test.go`.

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -155,6 +155,10 @@
 - When the customer-linked external checklist repository omits one of the
   requested documents, record that missing source as an evidence gap and avoid
   inferring checklist content that is not actually retrievable on that date.
+- When refreshing from a long-lived meta branch, compare `HEAD` against
+  `origin/main` directly; a plain branch-local `git pull` can leave the branch
+  current with its own remote tracking ref while still missing newer mainline
+  merges that change PR ownership or the next cleanup seam.
 - After a localized dashboard dialog merges, re-read the adjacent header
   controls and status accessibility labels next; concentrated English-only
   residue often remains there rather than in another dialog.
@@ -164,10 +168,10 @@
 
 ## Current Summary
 
-- As of `2026-05-07T05:03:44.1967849-07:00`, `HEAD` points to `3d0c461` on
-  branch `main`, is ahead of `origin/main` by three local meta commits, and
-  already contains merged PR `#147` (`localize-export-dialog-and-trigger`) from
-  `origin/main`.
+- As of `2026-05-07T12:06:28.9599999-07:00`, `HEAD` points to `cb24fe4` on
+  branch `meta-refresh-world-state-20260507-110000`, rebased onto live
+  `origin/main` through merged PR `#162`
+  (`localize-dashboard-flow-axis-legend-copy`).
 - The canonical ask surface remains `factory/logs/meta/asks.md`.
 - The checked-in maintainer workflow is `thoughts -> idea -> plan -> task`
   with `idea/task:to-complete`, same-name `consume`, `.claude/worktrees`
@@ -179,9 +183,10 @@
   user-owned tracked edit and the maintainer meta refresh updates the tracked
   view/progress docs; ignored workflow files under `factory/inputs/**` remain
   operating state rather than canonical queue truth.
-- Recent merged PRs now include `#146` and `#147`; open PR `#141` owns the
-  active checklist-audit lane, while `#145`, `#143`, `#139`, `#123`, and
-  `#120` remain meta refresh branches.
+- Recent merged PRs now include `#162`, `#161`, and `#160`; open PR `#141`
+  owns the checklist-audit lane and open PR `#164` owns terminal-work
+  localization, while the older meta refresh PRs remain stacked beside this
+  branch.
 - The canonical ask surface remains the quality-oriented rewrite in
   `factory/logs/meta/asks.md`; the active asks are external checklist
   alignment, stronger backend and website testing, ongoing simplification, and
@@ -192,13 +197,51 @@
 - The external website and backend checklist URLs remain readable on
   `2026-05-07`, but the linked external `asks.md` URL still does not produce a
   readable checklist document and must be treated as a source-evidence gap.
-- The previously queued ignored ideas `localize-export-dialog-and-trigger` and
-  `narrow-cron-watcher-runtime-lookup-contract` are stale because merged PRs
-  `#147` and `#146` landed those exact lanes on `main`.
-- The next maintainer-owned operating queue should hold three non-overlapping
-  ideas together: repo-wide checklist audit evidence,
-  `retire-template-fields-variadic-worktree-shim`, and
-  `localize-dashboard-header-timeline-and-stream-status`.
+- The previously queued ignored idea
+  `localize-terminal-work-card-copy.md` is stale because that lane has now
+  advanced into open PR `#164`.
+- The next maintainer-owned operating queue slot should now be
+  `localize-workflow-activity-graph-import-copy.md`, which keeps three
+  non-overlapping active lanes alongside open PR `#141` and open PR `#164`.
+
+## 2026-05-07T12:06:28.9599999-07:00 - meta state refresh
+
+- Ran `git pull --ff-only`, then confirmed the branch was still seven commits
+  behind live `origin/main` despite being current with its own remote tracking
+  ref, so ran `git pull --rebase --autostash origin main` to rebase the meta
+  branch onto live `main` and pull in merged PR `#162`
+  (`localize-dashboard-flow-axis-legend-copy`) while preserving the user-owned
+  tracked edit in `factory/logs/meta/asks.md`.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`, the backend and
+  website standards, current PR state, the tracked-versus-ignored
+  `factory/inputs/**` surface, and the live external checklist sources.
+- Re-validated tracked queue truth with `git ls-files factory/inputs` and
+  `Get-ChildItem -Recurse -Force factory/inputs`, confirming the checked-in
+  inboxes remain sentinel-only while the visible idea file is ignored local
+  operating residue.
+- Confirmed the previously visible ignored idea
+  `factory/inputs/idea/default/localize-terminal-work-card-copy.md` is now
+  stale because that lane has advanced into open PR `#164`, so pruned that
+  residue locally instead of counting it as a third active lane beside the PR.
+- Re-checked open PR ownership with `gh pr list --state open --limit 20` and
+  `gh pr view 164`, confirming open PR `#141` still owns the repo-wide
+  checklist audit and open PR `#164` now owns the terminal-work localization
+  seam while merged PR `#162` closed the workflow-activity legend lane on
+  `main`.
+- Used delegated explorer passes, graph-backed discovery, direct reads of
+  `ui/src/features/workflow-activity/react-flow-current-activity-card-import.tsx`
+  and `ui/src/features/workflow-activity/mutation-dialog.tsx`, plus focused
+  test inventory reads, to choose the next replacement lane:
+  `localize-workflow-activity-graph-import-copy.md`.
+- Verified that the replacement seam stays implementation-ready and
+  non-overlapping because the graph-import overlay still hardcodes PNG import
+  guidance, loading, error, and dismiss copy, `mutation-dialog.tsx` still owns
+  the shared shell copy `Close dialog` and `Mutation flow`, and focused
+  coverage already exists in
+  `ui/src/features/workflow-activity/react-flow-current-activity-card-import.test.tsx`
+  and `ui/src/features/workflow-activity/mutation-dialog.test.tsx`.
 
 ## 2026-05-07T05:03:44.1967849-07:00 - meta state refresh
 

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -30,6 +30,10 @@
 - Prune ignored local idea files once their owning PR has merged; otherwise the
   canonical inbox can retain stale residue that no longer represents an
   actionable backlog item.
+- When a queued idea has already advanced into an open PR, prune the ignored
+  inbox residue and treat the PR as the active lane; refill only genuinely
+  vacant task slots instead of counting duplicate idea files and PRs as
+  separate work.
 - Import/export contract cleanup crosses more than one layer: confirm
   `api/openapi.yaml`, generated API artifacts, `pkg/config` mapping logic, and
   runtime/functional tests together before assuming a field has really been
@@ -2073,3 +2077,45 @@
   `factory/inputs/idea/default/cover-releasesmoke-command-owner-parse-and-json-error-branches.md`
   so the operating backlog returns to three narrow active lanes without
   overlapping PR `#141` or `#142`.
+
+## 2026-05-07T11:03:26.5424733-07:00 - meta state refresh
+
+- Switched to a fresh branch from live `origin/main` because the older
+  meta-refresh branch had become a stack of stale worldview commits that no
+  longer rebased cleanly after merged PRs `#160` and `#161`.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`, the backend and
+  website standards, current PR state, the tracked-versus-ignored
+  `factory/inputs/**` surface, and live terminal-work, current-selection,
+  workflow-activity, workers, cmd, and `pkg/cli` candidate seams.
+- Re-validated tracked queue truth with `git ls-files factory/inputs` and
+  `Get-ChildItem -Recurse -Force factory/inputs`, confirming the checked-in
+  inboxes remain sentinel-only while the visible idea files were ignored local
+  operating residue.
+- Confirmed the previously visible ignored ideas
+  `audit-repository-against-2026-website-and-backend-checklists.md`,
+  `cover-cli-docs-command-surface.md`, and
+  `localize-current-selection-workstation-detail-card-copy.md` were stale for
+  active-queue purposes because the audit lane already advanced into open
+  PR `#141` and merged PRs `#161` and `#160` already landed the latter two
+  lanes on `main`; pruned that residue locally.
+- Re-checked open PR ownership and found a new live owner:
+  open PR `#162` now covers the workflow-activity dashboard flow-axis legend
+  localization lane, so fresh backlog work needs to stay outside that surface.
+- Verified by direct reads of
+  `ui/src/features/terminal-work/terminal-work-card.tsx`,
+  `ui/src/features/terminal-work/terminal-work-card.test.tsx`, and
+  `ui/src/features/terminal-work/terminal-work-card.stories.tsx` that the next
+  concentrated non-overlapping localization seam is the terminal-work card,
+  which still hardcodes visible and accessible copy, empty states, and
+  session-summary fallback text while already having focused test seams.
+- Re-ran live coverage on `pkg/cli` and confirmed the prior docs-command lane
+  is materially closed on `main`; `go test -cover ./pkg/cli` now reports
+  `95.7%`, and the remaining uncovered `newDocsTopicCommand` branch is the
+  `docscli.Markdown(topic)` error return rather than the previously suspected
+  writer-failure or `Execute()` wrapper paths.
+- Queued one fresh ignored idea under
+  `factory/inputs/idea/default/localize-terminal-work-card-copy.md` so the
+  active maintainers' work returns to three non-overlapping lanes alongside
+  open PR `#141` and open PR `#162`.

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,12 +2,12 @@
 
 ## world state
 
-- as of `2026-05-07T12:06:28.9599999-07:00`, this meta refresh branch
+- as of `2026-05-07T12:36:57.0000000-07:00`, this meta refresh branch
   `meta-refresh-world-state-20260507-110000` has been rebased onto live
-  `origin/main`, which now includes merged PR `#162`
-  (`localize-dashboard-flow-axis-legend-copy`) at `2026-05-07T17:24:30Z`
-  and keeps open PR `#164`
-  (`localize-terminal-work-card-copy`) active at `2026-05-07T18:23:49Z`
+  `origin/main`, which now includes merged PR `#164`
+  (`localize-terminal-work-card-copy`) at `2026-05-07T19:10:30Z` and
+  merged PR `#165` (`localize-workflow-activity-graph-import-copy`) at
+  `2026-05-07T19:40:24Z`
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - the only tracked local dirtiness outside this meta refresh remains the
   user-maintained canonical ask file `factory/logs/meta/asks.md`
@@ -41,16 +41,19 @@
 - the previously ignored idea files
   `audit-repository-against-2026-website-and-backend-checklists.md`,
   `cover-cli-docs-command-surface.md`,
-  `localize-current-selection-workstation-detail-card-copy.md`, and
-  `localize-terminal-work-card-copy.md` were stale for active-queue purposes
-  because the audit lane already advanced into open PR `#141`, merged
-  PRs `#161` and `#160` already landed the earlier queue slots on `main`, and
-  the terminal-work lane has now advanced into open PR `#164`
-- after pruning that residue, the maintainer-owned ignored queue now carries
-  one fresh non-overlapping replacement idea:
-  - `localize-workflow-activity-graph-import-copy.md`
-- combined with open PR `#141` and open PR `#164`, the active maintainers'
-  work now again spans three non-overlapping lanes
+  `localize-current-selection-workstation-detail-card-copy.md`,
+  `localize-terminal-work-card-copy.md`, and
+  `localize-workflow-activity-graph-import-copy.md` are now stale for
+  active-queue purposes because the audit lane already advanced into open
+  PR `#141` and merged PRs `#161`, `#160`, `#164`, and `#165` already landed
+  the other queue slots on `main`
+- after pruning that residue, the maintainer-owned ignored queue should carry
+  two fresh non-overlapping replacement ideas:
+  - `localize-work-outcome-trend-cards-copy.md`
+  - `simplify-loaded-runtime-definition-lookups.md`
+- combined with open PR `#141`, those two replacement ideas restore three
+  productive non-overlapping maintainer lanes without counting stacked
+  meta-refresh PRs as cleanup throughput
 
 ## customer-ask truth
 
@@ -79,19 +82,23 @@
 - there is still no checked-in repo-owned daily QA schedule or canonical QA
   work item on live `main`; that remains an acknowledged ask gap rather than a
   completed capability
-- the UI localization foothold now reaches both current-selection workstation
-  detail and workflow-activity legend, while the repo-owned CLI docs package
+- the UI localization foothold now reaches terminal-work and the
+  workflow-activity graph import flow, while the repo-owned CLI docs package
   lane is materially closed:
   - merged PR `#160` localized
     `ui/src/features/current-selection/workstation-detail-card.tsx`
   - merged PR `#162` localized
     `ui/src/features/workflow-activity/dashboard-flow-axis-legend.tsx`
+  - merged PR `#164` localized
+    `ui/src/features/terminal-work/terminal-work-card.tsx`
+  - merged PR `#165` localized the workflow-activity graph-import overlay,
+    import dialog shell, and import-preview touch points
   - merged PR `#161` raised `pkg/cli` coverage to `95.7%` on
     `2026-05-07`; the previously suspected `Execute()` wrapper and docs-topic
     writer-failure gaps are already covered
-  - open PR `#164` now owns the terminal-work localization lane
-  - the next concentrated non-overlapping English-only dashboard surface now
-    sits in the workflow-activity graph import overlay and dialog shell
+  - with `#164` and `#165` merged, the next concentrated non-overlapping
+    English-only dashboard surface now sits in the work-outcome trend cards
+    and shared throughput labels
 
 ## replay truth
 
@@ -106,6 +113,10 @@
 ## recent repo movement
 
 - recent merged PRs on `main` now include:
+  - `#165` `localize-workflow-activity-graph-import-copy`, merged on
+    `2026-05-07T19:40:24Z`
+  - `#164` `localize-terminal-work-card-copy`, merged on
+    `2026-05-07T19:10:30Z`
   - `#162` `localize-dashboard-flow-axis-legend-copy`, merged on
     `2026-05-07T17:24:30Z`
   - `#161` `cover-cli-docs-command-surface`, merged on
@@ -117,7 +128,6 @@
   - `#158` `localize-selected-work-dispatch-history-card-copy`, merged on
     `2026-05-07T15:22:57Z`
 - `gh pr list --state open` now reports:
-  - `#164` `localize-terminal-work-card-copy`
   - `#163` `docs: refresh meta world state`
   - `#152` `docs: refresh meta world state`
   - `#145` `docs: refresh meta world state`
@@ -126,34 +136,43 @@
   - `#139` `docs: refresh meta world state`
   - `#123` `docs: refresh meta world state`
   - `#120` `docs: refresh meta world state`
-- open PR `#141` owns the current checklist-audit lane and open PR `#164`
-  owns the current terminal-work lane, so fresh backlog work must stay
-  outside both surfaces
+- open PR `#141` is now the only productive non-meta feature lane still open,
+  so the queue needs two fresh non-overlapping replacements to satisfy the
+  standing three-task ask
 
 ## next cleanup candidates
 
 - the repo-wide standards audit remains the highest-priority checklist ask on
   live `main`, but PR `#141` already owns that documentation lane
-- the terminal-work seam is already owned by open PR `#164`
-- the next replacement backlog slot on live `main` is now the workflow-
-  activity graph-import copy surface:
-  - `ui/src/features/workflow-activity/react-flow-current-activity-card-import.tsx`
-    still hardcodes user-facing and accessible copy such as
-    `Drop an Infinite You PNG onto this graph to start import.`,
-    `Import factory PNG`, `Validating factory PNG`, `Factory import failed`,
-    `Dismiss`, and the PNG import error-copy mapping
-  - `ui/src/features/workflow-activity/mutation-dialog.tsx` still hardcodes
-    the shared dialog-shell copy `Close dialog` and `Mutation flow`
+- the next UI replacement backlog slot on live `main` is now the work-outcome
+  trend-card copy surface:
+  - `ui/src/features/work-outcome/trend-cards.tsx` still hardcodes titles,
+    subtitles, summary labels, empty states, and chart/list accessibility copy
+    for the failure, rework, and timing cards
+  - `ui/src/features/work-outcome/trends.ts` still hardcodes shared
+    user-facing labels such as `Queued`, `In-flight`, `Completed`,
+    `Failed/retried`, and `Session`
   - focused coverage already exists in
-    `ui/src/features/workflow-activity/react-flow-current-activity-card-import.test.tsx`
-    and `ui/src/features/workflow-activity/mutation-dialog.test.tsx`
+    `ui/src/features/work-outcome/trend-cards.test.tsx`
   - the lane is feature-local, implementation-ready, and does not overlap the
-    open checklist-audit or terminal-work branches
-- the `pkg/cli` docs lane is no longer the next candidate:
-  - `go test -cover ./pkg/cli` now reports `95.7%` on `2026-05-07`
-  - the remaining uncovered `newDocsTopicCommand` branch is the
-    `docscli.Markdown(topic)` error path, not the previously suspected writer
-    failure or `Execute()` wrapper path
+    open checklist-audit branch or the freshly merged terminal-work and
+    workflow-activity lanes
+- the next backend replacement backlog slot on live `main` is now the loaded
+  runtime-definition lookup simplification seam:
+  - `pkg/config/runtime_config.go` still carries one redundant internal lookup
+    layer through `lookup`, `runtimeDefinitionLookup()`,
+    `runtimeDefinitionLookupMaps`, the `runtimeDefinitionConfig` alias, and
+    `newRuntimeDefinitionConfig()`
+  - the public `interfaces.RuntimeDefinitionLookup` and
+    `interfaces.RuntimeConfigLookup` behavior can stay unchanged while that
+    package-local indirection is collapsed
+  - focused behavior coverage already exists in
+    `pkg/config/runtime_config_test.go`,
+    `pkg/factory/projections/topology_projection_test.go`,
+    `pkg/factory/event_history_test.go`, and
+    `pkg/service/factory_test.go`
+  - the lane is backend-local, implementation-ready, and does not overlap the
+    open checklist-audit branch
 
 ## theory of mind
 
@@ -168,6 +187,9 @@
 - when the customer ask requires at least three tasks in flight, open PRs can
   satisfy part of that count, so refill only the truly vacant backlog slots
   instead of keeping three ignored idea files regardless of PR state
+- when only one productive non-meta feature PR remains open, refill the queue
+  with two fresh non-overlapping ideas rather than counting stacked
+  meta-refresh branches as satisfying the three-task ask
 - when a current-selection localization seam merges and the workflow-activity
   legend is already owned by an open PR, move the next localization follow-up
   to another dashboard-adjacent feature such as terminal-work rather than
@@ -180,10 +202,18 @@
   open PR, the least-overlap localization follow-up is the graph-import overlay
   and mutation-dialog shell inside `workflow-activity`, not another header or
   current-selection lane
+- after a queued localization lane merges, prefer the next dashboard-adjacent
+  feature that still lacks a `messages/` owner and already has focused tests;
+  the work-outcome trend cards now fit that pattern better than revisiting
+  recently localized workflow-activity files
 - when a repo-owned coverage package has just merged a focused branch-coverage
   PR, re-run live coverage and inspect exact uncovered lines before re-queueing
   the same seam; stale summaries can miss that the remaining gap moved to a
   different branch entirely
+- when a runtime config owner exposes the same lookup behavior through an alias
+  type, an internal map holder, and a private bounce method, treat that
+  package-local indirection as a valid simplification seam once behavior tests
+  already pin the public contract
 - when the linked external checklist repo omits one requested source such as
   `asks.md`, record that as an evidence gap and continue from the sources that
   are actually retrievable instead of inventing missing checklist content

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,10 +2,12 @@
 
 ## world state
 
-- as of `2026-05-07T05:03:44.1967849-07:00`, local `HEAD` on `main` points to
-  `3d0c461` (`docs: refresh meta world state`), is ahead of `origin/main` by
-  three local meta commits, and already contains upstream `origin/main` through
-  merged PR `#147` (`localize-export-dialog-and-trigger`) at `6451e25`
+- as of `2026-05-07T11:03:26.5424733-07:00`, this meta refresh runs from
+  branch `meta-refresh-world-state-20260507-110000` created directly from live
+  `origin/main`, which now includes merged PR `#160`
+  (`localize-current-selection-workstation-detail-card-copy`) at
+  `2026-05-07T17:53:59Z` and merged PR `#161`
+  (`cover-cli-docs-command-surface`) at `2026-05-07T17:25:09Z`
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - the only tracked local dirtiness outside this meta refresh remains the
   user-maintained canonical ask file `factory/logs/meta/asks.md`
@@ -36,18 +38,18 @@
   - `factory/inputs/thoughts/default/.gitkeep`
 - `.gitignore` still keeps live workflow submissions under `factory/inputs/**`
   out of normal commits except for those sentinel paths
-- the ignored idea files
-  `factory/inputs/idea/default/localize-export-dialog-and-trigger.md` and
-  `factory/inputs/idea/default/narrow-cron-watcher-runtime-lookup-contract.md`
-  were stale on live `main` because merged PR `#147` landed on
-  `2026-05-07T11:46:43Z` and merged PR `#146` landed on
-  `2026-05-07T11:39:54Z`
-- after pruning those stale residues, the maintainer-owned ignored queue now
-  carries three fresh non-overlapping idea files so the autonomous lane still
-  matches the standing ask to keep at least three tasks running:
-  - `audit-repository-against-2026-website-and-backend-checklists.md`
-  - `retire-template-fields-variadic-worktree-shim.md`
-  - `localize-dashboard-header-timeline-and-stream-status.md`
+- the previously ignored idea files
+  `audit-repository-against-2026-website-and-backend-checklists.md`,
+  `cover-cli-docs-command-surface.md`, and
+  `localize-current-selection-workstation-detail-card-copy.md` were stale for
+  active-queue purposes because the audit lane already advanced into open
+  PR `#141` and merged PRs `#161` and `#160` already landed the latter two
+  lanes on `main`
+- after pruning that residue, the maintainer-owned ignored queue now carries
+  one fresh non-overlapping replacement idea:
+  - `localize-terminal-work-card-copy.md`
+- combined with open PR `#141` and open PR `#162`, the active maintainers'
+  work now again spans three non-overlapping lanes
 
 ## customer-ask truth
 
@@ -60,29 +62,32 @@
   - keep simplifying backend and website ownership where duplicate or stale
     logic remains
   - keep at least three non-overlapping tasks running at a time
+  - establish a daily QA run lane focused on whether major features still work
 - the external checklist links in `factory/logs/meta/asks.md` still point at
   the live `portpowered/checklists` repository, and the explicit linked docs
   remain the current `2026` checklist revisions:
   - `website-development-checklist.md`
   - `backend-development-checklist.md`
 - the linked external `asks.md` source still has an evidence gap on
-  `2026-05-07`: `https://raw.githubusercontent.com/portpowered/checklists/main/asks.md`
-  does not resolve to a readable checklist document, so that ask reference
-  still needs to be treated as unavailable evidence rather than assumed input
+  `2026-05-07`: both the raw URL and the live repo listing still fail to
+  surface a readable `asks.md`, so that reference remains unavailable evidence
+  rather than assumed requirements
 - there is still no merged checked-in repo-wide review record mapping this
   repository against those external checklist documents on live `main`; open
   PR `#141` currently owns that audit lane
-- the UI localization foothold now reaches both import and export surfaces on
-  live `main`:
-  - `ui/src/i18n/index.ts`, `ui/src/i18n/locales.ts`, and
-    `ui/src/i18n/messages.ts` exist on `main`
-  - merged PR `#142` localized and accessibility-hardened the import preview
-    dialog
-  - merged PR `#147` localized the export dialog and export trigger
-  - `ui/src/features/header/tick-slider-control.tsx` and
-    `ui/src/features/header/dashboard-header.tsx` still keep concentrated
-    hardcoded English timeline and stream-status accessibility text, which is
-    now the next narrow header-local follow-up
+- there is still no checked-in repo-owned daily QA schedule or canonical QA
+  work item on live `main`; that remains an acknowledged ask gap rather than a
+  completed capability
+- the UI localization foothold now reaches both current-selection workstation
+  detail and the repo-owned CLI docs package lane is materially closed:
+  - merged PR `#160` localized
+    `ui/src/features/current-selection/workstation-detail-card.tsx`
+  - merged PR `#161` raised `pkg/cli` coverage to `95.7%` on
+    `2026-05-07`; the previously suspected `Execute()` wrapper and docs-topic
+    writer-failure gaps are already covered
+  - open PR `#162` now owns the workflow-activity legend localization lane
+  - `ui/src/features/terminal-work/terminal-work-card.tsx` is now the next
+    concentrated non-overlapping English-only dashboard surface
 
 ## replay truth
 
@@ -97,63 +102,50 @@
 ## recent repo movement
 
 - recent merged PRs on `main` now include:
-  - `#147` `localize-export-dialog-and-trigger`, merged on
-    `2026-05-07T11:46:43Z`
-  - `#146` `narrow-cron-watcher-runtime-lookup-contract`, merged on
-    `2026-05-07T11:39:54Z`
-  - `#144` `cover-releasesmoke-command-owner-parse-and-json-error-branches`,
-    merged on `2026-05-07T10:13:02Z`
-  - `#142` `localize-and-accessibility-harden-import-preview-dialog`, merged
-    on `2026-05-07T09:34:50Z`
-  - `#140` `retire-deadcodecheck-gotypesalias-compat-shim`, merged on
-    `2026-05-07T09:25:03Z`
+  - `#160` `localize-current-selection-workstation-detail-card-copy`, merged
+    on `2026-05-07T17:53:59Z`
+  - `#161` `cover-cli-docs-command-surface`, merged on
+    `2026-05-07T17:25:09Z`
+  - `#159` `cover-gocoveragecheck-malformed-percentage-parser-branches`,
+    merged on `2026-05-07T16:18:02Z`
+  - `#158` `localize-selected-work-dispatch-history-card-copy`, merged on
+    `2026-05-07T15:22:57Z`
+  - `#157` `cover-releasetagcheck-command-owner-parse-failure-branch`, merged
+    on `2026-05-07T15:12:40Z`
 - `gh pr list --state open` now reports:
+  - `#162` `localize-dashboard-flow-axis-legend-copy`
+  - `#152` `docs: refresh meta world state`
   - `#145` `docs: refresh meta world state`
   - `#143` `docs: refresh meta world state`
   - `#141` `audit-repository-against-2026-website-and-backend-checklists`
   - `#139` `docs: refresh meta world state`
   - `#123` `docs: refresh meta world state`
   - `#120` `docs: refresh meta world state`
-- open PR `#141` already owns the current checklist-audit lane, so new backlog
-  replacements must avoid its doc surface while still acting on live code gaps
+- open PR `#141` owns the current checklist-audit lane and open PR `#162`
+  owns the current workflow-activity legend lane, so fresh backlog work must
+  stay outside both surfaces
 
 ## next cleanup candidates
 
 - the repo-wide standards audit remains the highest-priority checklist ask on
   live `main`, but PR `#141` already owns that documentation lane
-- the next narrow backend simplification seam is the workers template-field
-  helper:
-  - `pkg/workers/template_fields.go` still exposes `ResolveTemplateFields`
-    with an explicitly backwards-compat variadic `worktreeTemplate ...string`
-    parameter
-  - the production caller in `pkg/workers/workstation_executor.go` already
-    passes one concrete `workstationDef.Worktree` value, so the legacy
-    compatibility shape is no longer needed on the live path
-  - the direct fallout is localized to `pkg/workers/template_fields_test.go`
-    plus the one production caller, making this a small implementation-ready
-    shim retirement
-- the next narrow UI checklist-alignment seam is the dashboard header control
-  surface:
-  - `ui/src/features/header/tick-slider-control.tsx` still hardcodes the slider
-    label, slider `aria-label`, waiting-state text, tick status text, and
-    "Return to current tick" button name
-  - `ui/src/features/header/dashboard-header.tsx` still hardcodes the region
-    label and stream-status accessible names for `live`, `offline`, and
-    `connecting`
-  - the import/export dialog localization pattern already exists on live
-    `main`, so this is now a small feature-local follow-up rather than a new
-    i18n foundation project
-- the next backup backend seam after that is `cmd/releaseprep`:
-  - `go test -cover ./cmd/...` now reports `94.1%` for `cmd/releaseprep`
-  - `cmd/releaseprep/main.go` still leaves the explicit `flag.ErrHelp` success
-    branch and direct parse-failure routing as a small command-owner coverage
-    closeout
-- the next backup backend testing seam after that is still `cmd/gocoveragecheck`:
-  - `go test -cover ./cmd/...` now reports `75.0%` for
-    `cmd/gocoveragecheck`
-  - remaining coverage is concentrated in command-owner execution, package-list,
-    and coverage-evaluation error branches rather than in backend application
-    packages
+- the current workflow-activity legend seam is already owned by open PR `#162`
+- the next replacement backlog slot on live `main` is now the terminal-work
+  detail card:
+  - `ui/src/features/terminal-work/terminal-work-card.tsx` still hardcodes
+    user-facing and accessible copy such as `Completed and failed work`,
+    `Terminal work outcomes`, `Completed`, `Failed`, `Expand`, `Collapse`,
+    `Completed work`, `Failed work`, and the empty and fallback summary text
+  - focused coverage already exists in
+    `ui/src/features/terminal-work/terminal-work-card.test.tsx` and
+    `ui/src/features/terminal-work/terminal-work-card.stories.tsx`
+  - the lane is feature-local, implementation-ready, and does not overlap the
+    open checklist-audit or workflow-activity legend branches
+- the `pkg/cli` docs lane is no longer the next candidate:
+  - `go test -cover ./pkg/cli` now reports `95.7%` on `2026-05-07`
+  - the remaining uncovered `newDocsTopicCommand` branch is the
+    `docscli.Markdown(topic)` error path, not the previously suspected writer
+    failure or `Execute()` wrapper path
 
 ## theory of mind
 
@@ -162,26 +154,20 @@
   checklist docs together
 - `factory/inputs/**` must still be reasoned about in two layers:
   checked-in contract versus ignored operating residue
-- when a previously queued idea lands on `main`, prune the ignored residue and
-  refresh the next seam from live code and PR state before queuing anything
-  else; merged PRs `#146` and `#147` invalidated two of the three active
-  backlog slots within the same cycle
-- when the customer ask requires at least three tasks in flight, satisfy that
-  ask with three narrow non-overlapping idea files rather than one broad batch
-  unless dependency ordering is actually required
-- when checklist conformance is still undocumented, queue one audit lane plus
-  smaller implementation-ready follow-ups instead of claiming alignment from
-  standards intent alone
-- when a localization follow-up merges on one dashboard dialog, re-read the
-  adjacent header controls and accessibility labels next; the concentrated
-  English-only residue often lives there rather than in a second dialog
-- when a helper still advertises an explicitly backwards-compatible variadic or
-  optional parameter but the live production caller already passes the
-  canonical explicit shape, retire the shim before widening into larger runtime
-  refactors
-- when a repo-owned command package is already above 90% coverage, prefer the
-  remaining help, parse, or exit-routing branches in that thin command owner
-  before widening into the underlying internal package
+- when a queued idea has advanced into an open PR, prune the ignored local idea
+  residue as well as merged residues; otherwise the canonical inbox keeps
+  duplicating already-owned work
+- when the customer ask requires at least three tasks in flight, open PRs can
+  satisfy part of that count, so refill only the truly vacant backlog slots
+  instead of keeping three ignored idea files regardless of PR state
+- when a current-selection localization seam merges and the workflow-activity
+  legend is already owned by an open PR, move the next localization follow-up
+  to another dashboard-adjacent feature such as terminal-work rather than
+  stacking siblings onto the same owned surfaces
+- when a repo-owned coverage package has just merged a focused branch-coverage
+  PR, re-run live coverage and inspect exact uncovered lines before re-queueing
+  the same seam; stale summaries can miss that the remaining gap moved to a
+  different branch entirely
 - when the linked external checklist repo omits one requested source such as
   `asks.md`, record that as an evidence gap and continue from the sources that
   are actually retrievable instead of inventing missing checklist content

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,12 +2,12 @@
 
 ## world state
 
-- as of `2026-05-07T11:03:26.5424733-07:00`, this meta refresh runs from
-  branch `meta-refresh-world-state-20260507-110000` created directly from live
-  `origin/main`, which now includes merged PR `#160`
-  (`localize-current-selection-workstation-detail-card-copy`) at
-  `2026-05-07T17:53:59Z` and merged PR `#161`
-  (`cover-cli-docs-command-surface`) at `2026-05-07T17:25:09Z`
+- as of `2026-05-07T12:06:28.9599999-07:00`, this meta refresh branch
+  `meta-refresh-world-state-20260507-110000` has been rebased onto live
+  `origin/main`, which now includes merged PR `#162`
+  (`localize-dashboard-flow-axis-legend-copy`) at `2026-05-07T17:24:30Z`
+  and keeps open PR `#164`
+  (`localize-terminal-work-card-copy`) active at `2026-05-07T18:23:49Z`
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - the only tracked local dirtiness outside this meta refresh remains the
   user-maintained canonical ask file `factory/logs/meta/asks.md`
@@ -40,15 +40,16 @@
   out of normal commits except for those sentinel paths
 - the previously ignored idea files
   `audit-repository-against-2026-website-and-backend-checklists.md`,
-  `cover-cli-docs-command-surface.md`, and
-  `localize-current-selection-workstation-detail-card-copy.md` were stale for
-  active-queue purposes because the audit lane already advanced into open
-  PR `#141` and merged PRs `#161` and `#160` already landed the latter two
-  lanes on `main`
+  `cover-cli-docs-command-surface.md`,
+  `localize-current-selection-workstation-detail-card-copy.md`, and
+  `localize-terminal-work-card-copy.md` were stale for active-queue purposes
+  because the audit lane already advanced into open PR `#141`, merged
+  PRs `#161` and `#160` already landed the earlier queue slots on `main`, and
+  the terminal-work lane has now advanced into open PR `#164`
 - after pruning that residue, the maintainer-owned ignored queue now carries
   one fresh non-overlapping replacement idea:
-  - `localize-terminal-work-card-copy.md`
-- combined with open PR `#141` and open PR `#162`, the active maintainers'
+  - `localize-workflow-activity-graph-import-copy.md`
+- combined with open PR `#141` and open PR `#164`, the active maintainers'
   work now again spans three non-overlapping lanes
 
 ## customer-ask truth
@@ -79,15 +80,18 @@
   work item on live `main`; that remains an acknowledged ask gap rather than a
   completed capability
 - the UI localization foothold now reaches both current-selection workstation
-  detail and the repo-owned CLI docs package lane is materially closed:
+  detail and workflow-activity legend, while the repo-owned CLI docs package
+  lane is materially closed:
   - merged PR `#160` localized
     `ui/src/features/current-selection/workstation-detail-card.tsx`
+  - merged PR `#162` localized
+    `ui/src/features/workflow-activity/dashboard-flow-axis-legend.tsx`
   - merged PR `#161` raised `pkg/cli` coverage to `95.7%` on
     `2026-05-07`; the previously suspected `Execute()` wrapper and docs-topic
     writer-failure gaps are already covered
-  - open PR `#162` now owns the workflow-activity legend localization lane
-  - `ui/src/features/terminal-work/terminal-work-card.tsx` is now the next
-    concentrated non-overlapping English-only dashboard surface
+  - open PR `#164` now owns the terminal-work localization lane
+  - the next concentrated non-overlapping English-only dashboard surface now
+    sits in the workflow-activity graph import overlay and dialog shell
 
 ## replay truth
 
@@ -102,18 +106,19 @@
 ## recent repo movement
 
 - recent merged PRs on `main` now include:
-  - `#160` `localize-current-selection-workstation-detail-card-copy`, merged
-    on `2026-05-07T17:53:59Z`
+  - `#162` `localize-dashboard-flow-axis-legend-copy`, merged on
+    `2026-05-07T17:24:30Z`
   - `#161` `cover-cli-docs-command-surface`, merged on
-    `2026-05-07T17:25:09Z`
+    `2026-05-07T17:12:20Z`
+  - `#160` `localize-current-selection-workstation-detail-card-copy`, merged
+    on `2026-05-07T16:32:50Z`
   - `#159` `cover-gocoveragecheck-malformed-percentage-parser-branches`,
     merged on `2026-05-07T16:18:02Z`
   - `#158` `localize-selected-work-dispatch-history-card-copy`, merged on
     `2026-05-07T15:22:57Z`
-  - `#157` `cover-releasetagcheck-command-owner-parse-failure-branch`, merged
-    on `2026-05-07T15:12:40Z`
 - `gh pr list --state open` now reports:
-  - `#162` `localize-dashboard-flow-axis-legend-copy`
+  - `#164` `localize-terminal-work-card-copy`
+  - `#163` `docs: refresh meta world state`
   - `#152` `docs: refresh meta world state`
   - `#145` `docs: refresh meta world state`
   - `#143` `docs: refresh meta world state`
@@ -121,26 +126,29 @@
   - `#139` `docs: refresh meta world state`
   - `#123` `docs: refresh meta world state`
   - `#120` `docs: refresh meta world state`
-- open PR `#141` owns the current checklist-audit lane and open PR `#162`
-  owns the current workflow-activity legend lane, so fresh backlog work must
-  stay outside both surfaces
+- open PR `#141` owns the current checklist-audit lane and open PR `#164`
+  owns the current terminal-work lane, so fresh backlog work must stay
+  outside both surfaces
 
 ## next cleanup candidates
 
 - the repo-wide standards audit remains the highest-priority checklist ask on
   live `main`, but PR `#141` already owns that documentation lane
-- the current workflow-activity legend seam is already owned by open PR `#162`
-- the next replacement backlog slot on live `main` is now the terminal-work
-  detail card:
-  - `ui/src/features/terminal-work/terminal-work-card.tsx` still hardcodes
-    user-facing and accessible copy such as `Completed and failed work`,
-    `Terminal work outcomes`, `Completed`, `Failed`, `Expand`, `Collapse`,
-    `Completed work`, `Failed work`, and the empty and fallback summary text
+- the terminal-work seam is already owned by open PR `#164`
+- the next replacement backlog slot on live `main` is now the workflow-
+  activity graph-import copy surface:
+  - `ui/src/features/workflow-activity/react-flow-current-activity-card-import.tsx`
+    still hardcodes user-facing and accessible copy such as
+    `Drop an Infinite You PNG onto this graph to start import.`,
+    `Import factory PNG`, `Validating factory PNG`, `Factory import failed`,
+    `Dismiss`, and the PNG import error-copy mapping
+  - `ui/src/features/workflow-activity/mutation-dialog.tsx` still hardcodes
+    the shared dialog-shell copy `Close dialog` and `Mutation flow`
   - focused coverage already exists in
-    `ui/src/features/terminal-work/terminal-work-card.test.tsx` and
-    `ui/src/features/terminal-work/terminal-work-card.stories.tsx`
+    `ui/src/features/workflow-activity/react-flow-current-activity-card-import.test.tsx`
+    and `ui/src/features/workflow-activity/mutation-dialog.test.tsx`
   - the lane is feature-local, implementation-ready, and does not overlap the
-    open checklist-audit or workflow-activity legend branches
+    open checklist-audit or terminal-work branches
 - the `pkg/cli` docs lane is no longer the next candidate:
   - `go test -cover ./pkg/cli` now reports `95.7%` on `2026-05-07`
   - the remaining uncovered `newDocsTopicCommand` branch is the
@@ -164,6 +172,14 @@
   legend is already owned by an open PR, move the next localization follow-up
   to another dashboard-adjacent feature such as terminal-work rather than
   stacking siblings onto the same owned surfaces
+- when a queued ignored idea advances into an open PR, replace that queue slot
+  from the next adjacent but non-identical feature seam instead of leaving the
+  same idea file in place or hopping back into already-localized header or
+  current-selection surfaces
+- after the workflow-activity legend merges and terminal-work advances into an
+  open PR, the least-overlap localization follow-up is the graph-import overlay
+  and mutation-dialog shell inside `workflow-activity`, not another header or
+  current-selection lane
 - when a repo-owned coverage package has just merged a focused branch-coverage
   PR, re-run live coverage and inspect exact uncovered lines before re-queueing
   the same seam; stale summaries can miss that the remaining gap moved to a


### PR DESCRIPTION
## Summary
- refresh the checked-in meta worldview against live main after merged PRs #160 and #161
- prune stale ignored inbox residue and queue one fresh non-overlapping terminal-work localization idea
- record that open PRs #141 and #162 already satisfy two of the three required active lanes

## Notes
- direct push to main was blocked by repository rules requiring status checks
- left the user-owned tracked edit in factory/logs/meta/asks.md untouched
