### PR TITLE
simplify-loaded-runtime-definition-lookups

### DIFF
--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -88,7 +88,7 @@ func LoadRuntimeConfig(factoryDir string, workstationLoader WorkstationLoader) (
 	if err := ApplySupportedPortableBundledFiles(resolvedFactoryDir, factoryCfg, false); err != nil {
 		return nil, fmt.Errorf("collect portable bundled files: %w", err)
 	}
-	runtimeDefs := newRuntimeDefinitionConfig(len(factoryCfg.Workers), len(factoryCfg.Workstations))
+	runtimeDefs := newRuntimeDefinitionLookupMaps(len(factoryCfg.Workers), len(factoryCfg.Workstations))
 
 	inlineDefinitionsRequired := hasInlineRuntimeDefinitions(factoryCfg)
 	for _, workstation := range factoryCfg.Workstations {
@@ -175,28 +175,26 @@ func (c *LoadedFactoryConfig) PortableBundledFileReplacements() []PortableBundle
 
 // WorkstationConfigs returns the effective workstation definitions by name.
 func (c *LoadedFactoryConfig) WorkstationConfigs() map[string]*interfaces.FactoryWorkstationConfig {
-	lookup := c.runtimeDefinitionLookup()
-	if lookup == nil {
+	if c == nil || c.lookup == nil {
 		return nil
 	}
-	return lookup.workstations
+	return c.lookup.workstations
 }
 
 // Worker returns the loaded worker definition for the given configured worker name.
 func (c *LoadedFactoryConfig) Worker(name string) (*interfaces.WorkerConfig, bool) {
-	return c.runtimeDefinitionLookup().Worker(name)
+	if c == nil {
+		return nil, false
+	}
+	return c.lookup.Worker(name)
 }
 
 // Workstation returns the canonical loaded workstation entry for the given configured workstation name.
 func (c *LoadedFactoryConfig) Workstation(name string) (*interfaces.FactoryWorkstationConfig, bool) {
-	return c.runtimeDefinitionLookup().Workstation(name)
-}
-
-func (c *LoadedFactoryConfig) runtimeDefinitionLookup() *runtimeDefinitionLookupMaps {
 	if c == nil {
-		return nil
+		return nil, false
 	}
-	return c.lookup
+	return c.lookup.Workstation(name)
 }
 
 type runtimeDefinitionLookupMaps struct {
@@ -220,13 +218,7 @@ func (c *runtimeDefinitionLookupMaps) Workstation(name string) (*interfaces.Fact
 	return def, ok
 }
 
-type runtimeDefinitionConfig = runtimeDefinitionLookupMaps
-
-var _ interfaces.RuntimeDefinitionLookup = (*runtimeDefinitionConfig)(nil)
-
-func newRuntimeDefinitionConfig(workerCount, workstationCount int) *runtimeDefinitionConfig {
-	return newRuntimeDefinitionLookupMaps(workerCount, workstationCount)
-}
+var _ interfaces.RuntimeDefinitionLookup = (*runtimeDefinitionLookupMaps)(nil)
 
 func newRuntimeDefinitionLookupMaps(workerCount, workstationCount int) *runtimeDefinitionLookupMaps {
 	return &runtimeDefinitionLookupMaps{

--- a/pkg/config/runtime_config_test.go
+++ b/pkg/config/runtime_config_test.go
@@ -1783,7 +1783,7 @@ func TestLoadRuntimeConfig_InlineAndSplitWorkstationsNormalizeToEquivalentCanoni
 }
 
 func TestNewLoadedFactoryConfig_MergesRuntimeDefinitionsOntoCanonicalConfig(t *testing.T) {
-	runtimeDefs := newRuntimeDefinitionConfig(1, 1)
+	runtimeDefs := newRuntimeDefinitionLookupMaps(1, 1)
 	runtimeDefs.workers["executor"] = &interfaces.WorkerConfig{
 		Type:        interfaces.WorkerTypeScript,
 		Command:     "go",
@@ -1813,7 +1813,7 @@ func TestNewLoadedFactoryConfig_MergesRuntimeDefinitionsOntoCanonicalConfig(t *t
 }
 
 func TestNewLoadedFactoryConfig_UsesCanonicalDefinitionsWhenRuntimeDefinitionsAreMissing(t *testing.T) {
-	loaded, err := NewLoadedFactoryConfig("factory-dir", canonicalMergeFactoryConfig(), newRuntimeDefinitionConfig(0, 0))
+	loaded, err := NewLoadedFactoryConfig("factory-dir", canonicalMergeFactoryConfig(), newRuntimeDefinitionLookupMaps(0, 0))
 	if err != nil {
 		t.Fatalf("NewLoadedFactoryConfig: %v", err)
 	}

--- a/pkg/config/runtime_config_test.go
+++ b/pkg/config/runtime_config_test.go
@@ -1818,14 +1818,16 @@ func TestNewLoadedFactoryConfig_UsesCanonicalDefinitionsWhenRuntimeDefinitionsAr
 		t.Fatalf("NewLoadedFactoryConfig: %v", err)
 	}
 
-	worker, ok := loaded.Worker("executor")
+	var lookup interfaces.RuntimeDefinitionLookup = loaded
+
+	worker, ok := lookup.Worker("executor")
 	if !ok {
 		t.Fatal("expected canonical worker")
 	}
 	if worker.Type != interfaces.WorkerTypeModel || worker.Model != "canonical-model" {
 		t.Fatalf("canonical worker fields were not preserved: %#v", worker)
 	}
-	assertCanonicalMergeWorkstation(t, loaded)
+	assertCanonicalMergeWorkstation(t, lookup)
 }
 
 func TestNewLoadedFactoryConfig_LoadsCanonicalConfigWithoutRuntimeConfig(t *testing.T) {
@@ -1834,11 +1836,13 @@ func TestNewLoadedFactoryConfig_LoadsCanonicalConfigWithoutRuntimeConfig(t *test
 		t.Fatalf("NewLoadedFactoryConfig: %v", err)
 	}
 
-	assertCanonicalRuntimeConfigLookupFactoryDir(t, loaded, "factory-dir")
-	assertCanonicalRuntimeConfigLookupRuntimeBaseDir(t, loaded, "factory-dir")
-	assertCanonicalRuntimeDefinitionLookupByName(t, loaded, "executor", "review")
-	assertRuntimeDefinitionLookupMissesByName(t, loaded, "missing-worker", "missing-workstation")
-	assertCanonicalMergeWorkstation(t, loaded)
+	var lookup interfaces.RuntimeConfigLookup = loaded
+
+	assertCanonicalRuntimeConfigLookupFactoryDir(t, lookup, "factory-dir")
+	assertCanonicalRuntimeConfigLookupRuntimeBaseDir(t, lookup, "factory-dir")
+	assertCanonicalRuntimeDefinitionLookupByName(t, lookup, "executor", "review")
+	assertRuntimeDefinitionLookupMissesByName(t, lookup, "missing-worker", "missing-workstation")
+	assertCanonicalMergeWorkstation(t, lookup)
 }
 
 func TestLoadedFactoryConfig_RuntimeBaseDirOverrideAndFallbackKeepsCanonicalLookupContract(t *testing.T) {
@@ -1847,33 +1851,37 @@ func TestLoadedFactoryConfig_RuntimeBaseDirOverrideAndFallbackKeepsCanonicalLook
 		t.Fatalf("NewLoadedFactoryConfig: %v", err)
 	}
 
-	assertCanonicalRuntimeConfigLookupFactoryDir(t, loaded, "factory-dir")
-	assertCanonicalRuntimeConfigLookupRuntimeBaseDir(t, loaded, "factory-dir")
+	var lookup interfaces.RuntimeConfigLookup = loaded
+
+	assertCanonicalRuntimeConfigLookupFactoryDir(t, lookup, "factory-dir")
+	assertCanonicalRuntimeConfigLookupRuntimeBaseDir(t, lookup, "factory-dir")
 
 	loaded.SetRuntimeBaseDir(" runtime-base/child/.. ")
 
-	assertCanonicalRuntimeConfigLookupFactoryDir(t, loaded, "factory-dir")
-	assertCanonicalRuntimeConfigLookupRuntimeBaseDir(t, loaded, "runtime-base")
+	assertCanonicalRuntimeConfigLookupFactoryDir(t, lookup, "factory-dir")
+	assertCanonicalRuntimeConfigLookupRuntimeBaseDir(t, lookup, "runtime-base")
 
 	loaded.SetRuntimeBaseDir(" \t ")
 
-	assertCanonicalRuntimeConfigLookupFactoryDir(t, loaded, "factory-dir")
-	assertCanonicalRuntimeConfigLookupRuntimeBaseDir(t, loaded, "factory-dir")
+	assertCanonicalRuntimeConfigLookupFactoryDir(t, lookup, "factory-dir")
+	assertCanonicalRuntimeConfigLookupRuntimeBaseDir(t, lookup, "factory-dir")
 }
 
 func TestLoadedFactoryConfig_SetRuntimeBaseDirNilReceiverNoops(t *testing.T) {
 	var loaded *LoadedFactoryConfig
+	var lookup interfaces.RuntimeConfigLookup = loaded
 
 	loaded.SetRuntimeBaseDir("runtime-base")
 
-	assertCanonicalRuntimeConfigLookupFactoryDir(t, loaded, "")
-	assertCanonicalRuntimeConfigLookupRuntimeBaseDir(t, loaded, "")
+	assertCanonicalRuntimeConfigLookupFactoryDir(t, lookup, "")
+	assertCanonicalRuntimeConfigLookupRuntimeBaseDir(t, lookup, "")
 }
 
 func TestLoadedFactoryConfig_RuntimeLookupNilReceiverReturnsMisses(t *testing.T) {
 	var loaded *LoadedFactoryConfig
+	var lookup interfaces.RuntimeDefinitionLookup = loaded
 
-	assertRuntimeDefinitionLookupMissesByName(t, loaded, "executor", "review")
+	assertRuntimeDefinitionLookupMissesByName(t, lookup, "executor", "review")
 }
 
 func TestLoadRuntimeConfig_ExposesEffectiveRuntimeDefinitionsThroughCanonicalLookup(t *testing.T) {
@@ -1918,7 +1926,12 @@ Runtime prompt.
 		t.Fatalf("LoadRuntimeConfig: %v", err)
 	}
 
-	worker, ok := loaded.Worker("executor")
+	var lookup interfaces.RuntimeConfigLookup = loaded
+
+	assertCanonicalRuntimeConfigLookupFactoryDir(t, lookup, factoryDir)
+	assertCanonicalRuntimeConfigLookupRuntimeBaseDir(t, lookup, factoryDir)
+
+	worker, ok := lookup.Worker("executor")
 	if !ok || worker == nil {
 		t.Fatalf("Worker(executor) = %#v ok=%v, want runtime worker hit", worker, ok)
 	}
@@ -1929,7 +1942,7 @@ Runtime prompt.
 		t.Fatalf("factory worker = %#v, want canonical lookup worker %#v", loaded.FactoryConfig().Workers[0], worker)
 	}
 
-	workstation, ok := loaded.Workstation("execute-story")
+	workstation, ok := lookup.Workstation("execute-story")
 	if !ok || workstation == nil {
 		t.Fatalf("Workstation(execute-story) = %#v ok=%v, want runtime workstation hit", workstation, ok)
 	}
@@ -1940,7 +1953,7 @@ Runtime prompt.
 		t.Fatalf("factory workstation = %#v, want canonical lookup workstation %#v", loaded.FactoryConfig().Workstations[0], workstation)
 	}
 
-	assertRuntimeDefinitionLookupMissesByName(t, loaded, "missing-worker", "missing-workstation")
+	assertRuntimeDefinitionLookupMissesByName(t, lookup, "missing-worker", "missing-workstation")
 }
 
 func assertCanonicalRuntimeConfigLookupFactoryDir(t *testing.T, lookup interfaces.RuntimeConfigLookup, want string) {
@@ -2061,9 +2074,9 @@ func assertMergedWorkstation(t *testing.T, loaded *LoadedFactoryConfig) {
 	}
 }
 
-func assertCanonicalMergeWorkstation(t *testing.T, loaded *LoadedFactoryConfig) {
+func assertCanonicalMergeWorkstation(t *testing.T, lookup interfaces.RuntimeDefinitionLookup) {
 	t.Helper()
-	workstation, ok := loaded.Workstation("review")
+	workstation, ok := lookup.Workstation("review")
 	if !ok {
 		t.Fatal("expected canonical workstation")
 	}


### PR DESCRIPTION
{
  "project": "Infinite You",
  "branchName": "ralph/simplify-loaded-runtime-definition-lookups",
  "description": "Infinite You is an AI agent factory for scheduling and orchestrating many AI workers concurrently. This change simplifies loaded runtime-definition lookup ownership in `pkg/config` by collapsing redundant internal lookup layers down to one package-local representation while preserving the public runtime lookup contracts, runtime-base-dir behavior, effective factory merge behavior, and existing downstream runtime config consumers.",
  "context": {
    "customerAsk": "The canonical customer ask in `factory/logs/meta/asks.md` requires ongoing backend simplification and keeping multiple narrow non-overlapping tasks in flight. For this lane, the requested change is to simplify loaded runtime-definition lookup ownership without changing customer-visible runtime behavior.",
    "problem": "On live `main`, `pkg/config/runtime_config.go` still expresses the same loaded runtime worker and workstation lookup behavior through several package-local layers: `LoadedFactoryConfig.lookup`, the private `runtimeDefinitionLookup()` bounce method, the `runtimeDefinitionLookupMaps` holder, the `runtimeDefinitionConfig` alias, and `newRuntimeDefinitionConfig()`. Those layers preserve the same public contract shape already exposed through `LoadedFactoryConfig`, `interfaces.RuntimeDefinitionLookup`, and `interfaces.RuntimeConfigLookup`, which increases cognitive load and maintenance surface without changing observable behavior for callers.",
    "solution": "Keep the work local to `pkg/config` and collapse the redundant package-local lookup alias and indirection down to one internal representation. Preserve the public runtime lookup contracts, preserve runtime-base-dir and effective factory merge behavior, and keep verification focused on observable lookup results through package tests and direct interface consumption."
  },
  "acceptanceCriteria": [
    "AC-1: `pkg/config/runtime_config.go` no longer relies on both a bounce-method path and a separate alias-plus-constructor path to expose the same runtime worker and workstation lookup behavior.",
    "AC-2: `LoadedFactoryConfig` continues satisfying `interfaces.RuntimeDefinitionLookup` and `interfaces.RuntimeConfigLookup` without caller-facing API changes.",
    "AC-3: Runtime config loading, runtime-base-dir fallback, worker lookup, workstation lookup, and effective factory merge behavior remain observably unchanged apart from the internal simplification.",
    "AC-4: Verification proves the simplified implementation through behavioral tests and interface-based consumption rather than assertions on private type names, field names, or helper layout.",
    "AC-5: The implementation stays localized to `pkg/config` and direct consumers touched only where required to preserve observable behavior.",
    "AC-6: Quality checks pass (typecheck, lint, tests)."
  ],
  "userStories": [
    {
      "id": "simplify-loaded-runtime-definition-lookups-001",
      "title": "Collapse redundant loaded runtime lookup ownership",
      "description": "As a maintainer, I want `LoadedFactoryConfig` to rely on one clear internal runtime-definition lookup owner so the config package is easier to understand and less likely to drift.",
      "acceptanceCriteria": [
        "The implementation no longer depends on both `runtimeDefinitionLookupMaps` and a separate `runtimeDefinitionConfig` alias-plus-constructor path to represent the same runtime worker and workstation lookup behavior.",
        "`LoadedFactoryConfig.Worker(...)` and `LoadedFactoryConfig.Workstation(...)` continue returning the same observable results for nil receivers, hits, and misses.",
        "Any touched effective runtime config accessors continue exposing the same worker and workstation definitions to callers after merge.",
        "The simplification does not introduce a new exported helper, interface, or cross-package abstraction.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "simplify-loaded-runtime-definition-lookups-002",
      "title": "Prove the canonical runtime lookup contract through focused behavior tests",
      "description": "As a maintainer, I want focused tests to prove that the simplified config owner still behaves correctly when consumed through the public runtime lookup interfaces.",
      "acceptanceCriteria": [
        "Existing or updated package tests prove runtime-base-dir fallback behavior still works after the simplification.",
        "Existing or updated package tests prove worker and workstation lookup hit, miss, and nil-receiver behavior through a `*LoadedFactoryConfig` consumed as `interfaces.RuntimeDefinitionLookup` or `interfaces.RuntimeConfigLookup`.",
        "Existing or updated tests prove effective runtime definitions exposed after merge still match prior observable behavior for direct consumers.",
        "Tests remain behavioral and contract-oriented and do not assert on private alias names, helper existence, or source-structure inventories.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
