### PR TITLE
docs: refresh meta world state

### DIFF
--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -1,5 +1,12 @@
 ## Codebase Patterns
 
+- When the canonical local ask file is reduced to `for now no asks exists.`,
+  treat earlier broad backlog notes as withdrawn for the current cycle instead
+  of continuing to satisfy them by inertia.
+- Standalone markdown cleanup requests belong in
+  `factory/inputs/idea/default/`; the same markdown request under
+  `factory/inputs/plan/default/` is operating-state drift that should be
+  reconciled before counting queue truth.
 - When a customer ask points at an external checklist repository and this repo
   has no checked-in review record for it yet, treat conformance as unproven and
   queue either a narrow audit lane or a smaller repo-owned enforcement seam
@@ -2115,3 +2122,53 @@
   so the operating backlog returns to three non-overlapping active lanes
   without touching the open checklist audit branch or the open work-outcome
   localization branch.
+
+## 2026-05-09T11:02:43+09:00 - meta state refresh
+- Ran `git pull --ff-only`; Git reported `Already up to date.` while local
+  `main` remained ahead of `origin/main` by one previously opened meta-refresh
+  commit at `f0a6150`, which also matches open PR `#168`.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`,
+  `factory/factory.json`, the backend and website standards, current PR state,
+  the tracked-versus-ignored `factory/inputs/**` surface, and the replay
+  diagnostics seam in `pkg/interfaces/safe_diagnostics.go` plus
+  `pkg/replay/event_reducer.go`.
+- Confirmed the canonical local ask file was changed to `for now no asks
+  exists.`, so the previously recorded checklist, coverage, simplification, and
+  minimum-concurrency backlog is no longer the active customer-routing truth for
+  this cycle.
+- Re-validated tracked queue truth with `git ls-files factory/inputs` and live
+  operating residue with `find factory/inputs -maxdepth 3 -type f`, confirming
+  the checked-in inboxes remain sentinel-only while the only live ignored
+  maintainer request was a markdown cleanup item misplaced under
+  `factory/inputs/plan/default/`.
+- Reconciled that operating-state drift by moving
+  `collapse-replay-safe-diagnostics-rehydration.md` into the canonical
+  standalone idea inbox at `factory/inputs/idea/default/` so the queued replay
+  cleanup request matches the documented workflow contract.
+- Reconfirmed that the replay diagnostics dedupe seam is still narrow,
+  non-overlapping, and not yet implemented on live `main`: replay still rebuilds
+  `interfaces.WorkDiagnostics` locally after
+  `interfaces.SafeWorkDiagnosticsFromGenerated(...)`, even though the safe
+  diagnostics boundary is already centralized in `pkg/interfaces`.
+- Used an explorer to look for an alternate fallback seam and recorded one
+  future candidate that is not currently in flight: dedupe the duplicate smoke
+  test config builders `simpleServicePipelineConfig` and
+  `twoStageServicePipelineConfig` across `tests/functional/smoke/*`.
+- Files changed:
+  - `factory/logs/meta/view.md`
+  - `factory/logs/meta/progress.txt`
+  - `factory/inputs/idea/default/collapse-replay-safe-diagnostics-rehydration.md`
+  - deleted ignored residue `factory/inputs/plan/default/collapse-replay-safe-diagnostics-rehydration.md`
+- **Learnings for future iterations:**
+  - The local canonical ask file can withdraw a previously active backlog in one
+    edit, and the meta loop should stop enforcing the old queue-count target as
+    soon as that happens.
+  - The watched inbox contract for standalone markdown cleanup requests is
+    `factory/inputs/idea/default/`; a markdown file under `plan/default` is
+    stale operating residue rather than a valid queue shape.
+  - Open PR ownership can remain useful context even after the canonical ask
+    surface goes empty, but those PRs should no longer be described as
+    customer-required lanes unless the ask file says so.
+---

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -2073,3 +2073,45 @@
   `factory/inputs/idea/default/cover-releasesmoke-command-owner-parse-and-json-error-branches.md`
   so the operating backlog returns to three narrow active lanes without
   overlapping PR `#141` or `#142`.
+
+## 2026-05-09T10:03:07+09:00 - meta state refresh
+
+- Ran `git pull --ff-only`; local `main` fast-forwarded from `0616500` to
+  `3327a97`, bringing in merged PR `#162`, merged PR `#164`, merged PR `#165`,
+  and merged PR `#166` while leaving unrelated local worktree edits intact.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`,
+  `factory/factory.json`, `.gitignore`, the backend and website standards,
+  current PR state, and the tracked-versus-ignored `factory/inputs/**`
+  surface.
+- Re-validated tracked queue truth with `git ls-files factory/inputs` and
+  `find factory/inputs -maxdepth 3 -type f`, confirming the checked-in inboxes
+  remain sentinel-only and the canonical input surface had no live queued work
+  before this refresh.
+- Re-checked the external customer checklist repo on `2026-05-09` and
+  confirmed the top-level `portpowered/checklists` repository still exposes
+  `backend-development-checklist.md` and
+  `website-development-checklist.md`, while the linked `asks.md` page still
+  does not resolve to a readable checklist document and therefore remains an
+  evidence gap rather than usable input.
+- Reconciled earlier worldview notes against live `main` and current PR state:
+  the previously recorded `localize-dashboard-header-timeline-and-stream-status`
+  seam is already closed through merged `PR #151`, and the previously recorded
+  `retire-template-fields-variadic-worktree-shim` seam is already closed
+  through merged `PR #150`.
+- Verified the currently open non-meta work ownership is now split between
+  `PR #141` (`audit-repository-against-2026-website-and-backend-checklists`)
+  and `PR #167` (`localize-work-outcome-trend-cards-copy`), which together
+  cover the standing audit lane plus one active UI localization follow-up.
+- Used direct reads of `pkg/interfaces/safe_diagnostics.go` and
+  `pkg/replay/event_reducer.go`, plus explorer confirmation, to identify the
+  next narrow non-overlapping backend simplification seam: replay still
+  reconstructs `interfaces.WorkDiagnostics` through replay-local helper clones
+  even though the canonical safe-diagnostics boundary already lives in
+  `pkg/interfaces`.
+- Queued one fresh ignored idea under
+  `factory/inputs/idea/default/collapse-replay-safe-diagnostics-rehydration.md`
+  so the operating backlog returns to three non-overlapping active lanes
+  without touching the open checklist audit branch or the open work-outcome
+  localization branch.

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,28 +2,31 @@
 
 ## world state
 
-- as of `2026-05-07T05:03:44.1967849-07:00`, local `HEAD` on `main` points to
-  `3d0c461` (`docs: refresh meta world state`), is ahead of `origin/main` by
-  three local meta commits, and already contains upstream `origin/main` through
-  merged PR `#147` (`localize-export-dialog-and-trigger`) at `6451e25`
+- as of `2026-05-09T10:03:07+09:00`, local `HEAD` on `main` points to
+  `3327a97` (`Merge pull request #166 from
+  portpowered/ralph/simplify-loaded-runtime-definition-lookups`) and matches
+  `origin/main`
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
-- the only tracked local dirtiness outside this meta refresh remains the
-  user-maintained canonical ask file `factory/logs/meta/asks.md`
-- canonical `factory/inputs/**` remains tracked-sentinel-only in git, while
-  live maintainer submissions remain ignored operating state
+- the checked-in maintainer workflow inputs remain tracked-sentinel-only under
+  `factory/inputs/**`
+- the live worktree is already dirty outside this meta refresh from unrelated
+  local edits in OpenAPI, generated API artifacts, worker/provider code, plus
+  untracked local planning or script files; those are not maintainer-owned for
+  this cycle
 
 ## workflow truth
 
 - `factory/factory.json` still defines five work types: `thoughts`, `idea`,
   `plan`, `task`, and `cron-triggers`
-- the checked-in maintainer loop remains:
+- the checked-in maintainer loop on live `main` is:
   `thoughts:init -> ideafy -> thoughts:complete`
-  `idea:init -> plan -> idea:complete + plan:init`
+  `idea:init -> plan -> idea:to-complete + plan:init`
   `plan:init -> setup-workspace -> plan:complete + task:init`
-  `task:init -> process -> task:in-review -> review -> task:complete`
+  `task:init -> process -> task:in-review -> review -> task:to-complete`
+  `idea/task:to-complete -> consume -> idea/task:complete`
 - topology details that still matter:
-  - `process` and `review` run in `.claude/worktrees/{{name}}`
-  - shared `executor-slot` capacity is `10`
+  - `process` and `review` execute in `.claude/worktrees/{{name}}`
+  - shared `executor-slot` capacity remains `10`
   - loop breakers still guard repeated `process` and `review` retries
 
 ## input surface truth
@@ -36,18 +39,11 @@
   - `factory/inputs/thoughts/default/.gitkeep`
 - `.gitignore` still keeps live workflow submissions under `factory/inputs/**`
   out of normal commits except for those sentinel paths
-- the ignored idea files
-  `factory/inputs/idea/default/localize-export-dialog-and-trigger.md` and
-  `factory/inputs/idea/default/narrow-cron-watcher-runtime-lookup-contract.md`
-  were stale on live `main` because merged PR `#147` landed on
-  `2026-05-07T11:46:43Z` and merged PR `#146` landed on
-  `2026-05-07T11:39:54Z`
-- after pruning those stale residues, the maintainer-owned ignored queue now
-  carries three fresh non-overlapping idea files so the autonomous lane still
-  matches the standing ask to keep at least three tasks running:
-  - `audit-repository-against-2026-website-and-backend-checklists.md`
-  - `retire-template-fields-variadic-worktree-shim.md`
-  - `localize-dashboard-header-timeline-and-stream-status.md`
+- before this refresh, the checked-in inbox surface had no tracked or ignored
+  live work items beyond `.gitkeep`
+- after this refresh, one new ignored maintainer idea is queued locally under
+  `factory/inputs/idea/default/` for a non-overlapping backend cleanup seam:
+  `collapse-replay-safe-diagnostics-rehydration.md`
 
 ## customer-ask truth
 
@@ -60,29 +56,48 @@
   - keep simplifying backend and website ownership where duplicate or stale
     logic remains
   - keep at least three non-overlapping tasks running at a time
-- the external checklist links in `factory/logs/meta/asks.md` still point at
-  the live `portpowered/checklists` repository, and the explicit linked docs
-  remain the current `2026` checklist revisions:
-  - `website-development-checklist.md`
+- the linked external checklist repository still exposes the same top-level
+  checklist files on `main` on `2026-05-09`:
   - `backend-development-checklist.md`
+  - `website-development-checklist.md`
 - the linked external `asks.md` source still has an evidence gap on
-  `2026-05-07`: `https://raw.githubusercontent.com/portpowered/checklists/main/asks.md`
-  does not resolve to a readable checklist document, so that ask reference
-  still needs to be treated as unavailable evidence rather than assumed input
-- there is still no merged checked-in repo-wide review record mapping this
-  repository against those external checklist documents on live `main`; open
-  PR `#141` currently owns that audit lane
-- the UI localization foothold now reaches both import and export surfaces on
-  live `main`:
-  - `ui/src/i18n/index.ts`, `ui/src/i18n/locales.ts`, and
-    `ui/src/i18n/messages.ts` exist on `main`
-  - merged PR `#142` localized and accessibility-hardened the import preview
-    dialog
-  - merged PR `#147` localized the export dialog and export trigger
-  - `ui/src/features/header/tick-slider-control.tsx` and
-    `ui/src/features/header/dashboard-header.tsx` still keep concentrated
-    hardcoded English timeline and stream-status accessibility text, which is
-    now the next narrow header-local follow-up
+  `2026-05-09`: the GitHub `asks.md` page does not resolve to a readable
+  checklist document, so it remains unavailable evidence rather than usable
+  customer input
+
+## recent repo movement
+
+- recent merged PRs on `main` now include:
+  - `#166` `simplify-loaded-runtime-definition-lookups`
+  - `#165` `localize-workflow-activity-graph-import-copy`
+  - `#164` `localize-terminal-work-card-copy`
+  - `#162` `localize-dashboard-flow-axis-legend-copy`
+  - `#151` `localize-dashboard-header-timeline-and-stream-status`
+  - `#150` `retire-template-fields-variadic-worktree-shim`
+- `gh pr list --state open` on `2026-05-09` reports:
+  - `#167` `localize-work-outcome-trend-cards-copy`
+  - `#163` `docs: refresh meta world state`
+  - `#152` `docs: refresh meta world state`
+  - `#145` `docs: refresh meta world state`
+  - `#143` `docs: refresh meta world state`
+  - `#141` `audit-repository-against-2026-website-and-backend-checklists`
+  - `#139` `docs: refresh meta world state`
+  - `#123` `docs: refresh meta world state`
+  - `#120` `docs: refresh meta world state`
+
+## open-lane truth
+
+- `PR #141` still owns the repository-wide external checklist audit lane and
+  should be treated as the active umbrella evidence task rather than a product
+  code cleanup branch
+- `PR #167` owns the current downstream UI localization lane for
+  `ui/src/features/work-outcome/*`
+- the previously recorded dashboard-header localization seam is already closed
+  on live `main` through merged `PR #151`
+- the previously recorded template-field variadic worktree-shim seam is already
+  closed on live `main` through merged `PR #150`
+- with `#141` and `#167` still open, one additional non-overlapping queued idea
+  is enough to satisfy the standing ask to keep at least three tasks in flight
 
 ## replay truth
 
@@ -94,94 +109,39 @@
 - one replay rejection payload is still quoted oddly as `"\"<REJECTED>\"\n"`;
   treat that as fixture history rather than live workflow behavior
 
-## recent repo movement
+## next cleanup candidate
 
-- recent merged PRs on `main` now include:
-  - `#147` `localize-export-dialog-and-trigger`, merged on
-    `2026-05-07T11:46:43Z`
-  - `#146` `narrow-cron-watcher-runtime-lookup-contract`, merged on
-    `2026-05-07T11:39:54Z`
-  - `#144` `cover-releasesmoke-command-owner-parse-and-json-error-branches`,
-    merged on `2026-05-07T10:13:02Z`
-  - `#142` `localize-and-accessibility-harden-import-preview-dialog`, merged
-    on `2026-05-07T09:34:50Z`
-  - `#140` `retire-deadcodecheck-gotypesalias-compat-shim`, merged on
-    `2026-05-07T09:25:03Z`
-- `gh pr list --state open` now reports:
-  - `#145` `docs: refresh meta world state`
-  - `#143` `docs: refresh meta world state`
-  - `#141` `audit-repository-against-2026-website-and-backend-checklists`
-  - `#139` `docs: refresh meta world state`
-  - `#123` `docs: refresh meta world state`
-  - `#120` `docs: refresh meta world state`
-- open PR `#141` already owns the current checklist-audit lane, so new backlog
-  replacements must avoid its doc surface while still acting on live code gaps
-
-## next cleanup candidates
-
-- the repo-wide standards audit remains the highest-priority checklist ask on
-  live `main`, but PR `#141` already owns that documentation lane
-- the next narrow backend simplification seam is the workers template-field
-  helper:
-  - `pkg/workers/template_fields.go` still exposes `ResolveTemplateFields`
-    with an explicitly backwards-compat variadic `worktreeTemplate ...string`
-    parameter
-  - the production caller in `pkg/workers/workstation_executor.go` already
-    passes one concrete `workstationDef.Worktree` value, so the legacy
-    compatibility shape is no longer needed on the live path
-  - the direct fallout is localized to `pkg/workers/template_fields_test.go`
-    plus the one production caller, making this a small implementation-ready
-    shim retirement
-- the next narrow UI checklist-alignment seam is the dashboard header control
-  surface:
-  - `ui/src/features/header/tick-slider-control.tsx` still hardcodes the slider
-    label, slider `aria-label`, waiting-state text, tick status text, and
-    "Return to current tick" button name
-  - `ui/src/features/header/dashboard-header.tsx` still hardcodes the region
-    label and stream-status accessible names for `live`, `offline`, and
-    `connecting`
-  - the import/export dialog localization pattern already exists on live
-    `main`, so this is now a small feature-local follow-up rather than a new
-    i18n foundation project
-- the next backup backend seam after that is `cmd/releaseprep`:
-  - `go test -cover ./cmd/...` now reports `94.1%` for `cmd/releaseprep`
-  - `cmd/releaseprep/main.go` still leaves the explicit `flag.ErrHelp` success
-    branch and direct parse-failure routing as a small command-owner coverage
-    closeout
-- the next backup backend testing seam after that is still `cmd/gocoveragecheck`:
-  - `go test -cover ./cmd/...` now reports `75.0%` for
-    `cmd/gocoveragecheck`
-  - remaining coverage is concentrated in command-owner execution, package-list,
-    and coverage-evaluation error branches rather than in backend application
-    packages
+- the next maintainer-owned non-overlapping cleanup seam is replay diagnostics
+  dedupe:
+  - `pkg/interfaces/safe_diagnostics.go` already owns canonical conversions for
+    worker-internal diagnostics, generated safe diagnostics, provider-session
+    metadata, and provider-failure metadata
+  - `pkg/replay/event_reducer.go` still rebuilds
+    `interfaces.WorkDiagnostics` through replay-local helpers
+    `workDiagnosticsFromSafe`, `renderedPromptDiagnosticFromSafe`, and
+    `providerDiagnosticFromSafe` immediately after decoding the same safe
+    boundary through `interfaces.SafeWorkDiagnosticsFromGenerated(...)`
+  - the live replay consumer path still needs `interfaces.WorkDiagnostics`, but
+    it does not need those conversions to remain replay-local
+  - this is a narrow simplification lane that removes duplicate conversion
+    ownership without changing generated contracts, API behavior, or customer
+    visible runtime output
 
 ## theory of mind
 
-- the authoritative world model comes from live `main`, the checked-in workflow
-  contract, the canonical ask file, current PR state, and current external
-  checklist docs together
-- `factory/inputs/**` must still be reasoned about in two layers:
-  checked-in contract versus ignored operating residue
-- when a previously queued idea lands on `main`, prune the ignored residue and
-  refresh the next seam from live code and PR state before queuing anything
-  else; merged PRs `#146` and `#147` invalidated two of the three active
-  backlog slots within the same cycle
-- when the customer ask requires at least three tasks in flight, satisfy that
-  ask with three narrow non-overlapping idea files rather than one broad batch
-  unless dependency ordering is actually required
-- when checklist conformance is still undocumented, queue one audit lane plus
-  smaller implementation-ready follow-ups instead of claiming alignment from
-  standards intent alone
-- when a localization follow-up merges on one dashboard dialog, re-read the
-  adjacent header controls and accessibility labels next; the concentrated
-  English-only residue often lives there rather than in a second dialog
-- when a helper still advertises an explicitly backwards-compatible variadic or
-  optional parameter but the live production caller already passes the
-  canonical explicit shape, retire the shim before widening into larger runtime
-  refactors
-- when a repo-owned command package is already above 90% coverage, prefer the
-  remaining help, parse, or exit-routing branches in that thin command owner
-  before widening into the underlying internal package
-- when the linked external checklist repo omits one requested source such as
-  `asks.md`, record that as an evidence gap and continue from the sources that
-  are actually retrievable instead of inventing missing checklist content
+- the authoritative world model comes from live `main`, the checked-in
+  workflow contract, the canonical ask file, current PR state, and the
+  currently readable external checklist sources together
+- stale “next seam” notes can expire within hours once remote cleanup branches
+  merge; re-check the concrete code and PR state before re-queuing an old lane
+- reason about `factory/inputs/**` in two layers:
+  checked-in contract versus ignored operating state
+- when the standing ask requires at least three non-overlapping tasks, count
+  open product or audit PRs that still own active lanes, then queue only enough
+  new ignored ideas to restore the minimum
+- when a cleanup seam is already centralized in `pkg/interfaces` but one
+  downstream subsystem still duplicates the inverse conversion locally, prefer
+  collapsing that duplicate owner before inventing new abstractions
+- when the external checklist repo exposes only some of the requested files,
+  record the missing source as an evidence gap and continue from the verified
+  documents instead of inferring the absent content

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,17 +2,16 @@
 
 ## world state
 
-- as of `2026-05-09T10:03:07+09:00`, local `HEAD` on `main` points to
-  `3327a97` (`Merge pull request #166 from
-  portpowered/ralph/simplify-loaded-runtime-definition-lookups`) and matches
-  `origin/main`
+- as of `2026-05-09T11:02:43+09:00`, local `HEAD` on `main` points to
+  `f0a6150` (`docs: refresh meta world state`), is ahead of `origin/main` by
+  one local meta commit, and matches the head of open PR `#168`
+  (`meta-refresh-world-state-20260509-100307`)
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - the checked-in maintainer workflow inputs remain tracked-sentinel-only under
   `factory/inputs/**`
-- the live worktree is already dirty outside this meta refresh from unrelated
-  local edits in OpenAPI, generated API artifacts, worker/provider code, plus
-  untracked local planning or script files; those are not maintainer-owned for
-  this cycle
+- the live worktree is already dirty before this refresh from a user-owned
+  tracked edit in `factory/logs/meta/asks.md`; treat that ask-file edit as the
+  canonical local customer-routing truth for this cycle rather than as noise
 
 ## workflow truth
 
@@ -39,31 +38,25 @@
   - `factory/inputs/thoughts/default/.gitkeep`
 - `.gitignore` still keeps live workflow submissions under `factory/inputs/**`
   out of normal commits except for those sentinel paths
-- before this refresh, the checked-in inbox surface had no tracked or ignored
-  live work items beyond `.gitkeep`
-- after this refresh, one new ignored maintainer idea is queued locally under
-  `factory/inputs/idea/default/` for a non-overlapping backend cleanup seam:
+- before this refresh, the checked-in inbox surface had no tracked live work
+  items beyond `.gitkeep`, but ignored operating residue included one markdown
+  cleanup request misplaced under `factory/inputs/plan/default/`
+- after this refresh, that ignored cleanup request has been reconciled into the
+  canonical standalone idea inbox under `factory/inputs/idea/default/`:
   `collapse-replay-safe-diagnostics-rehydration.md`
 
 ## customer-ask truth
 
-- the canonical ask file still carries one broad active quality lane plus the
-  autonomy notice through `2026-05-25`
-- the active quality asks remain:
-  - follow the external website and backend checklists and create alignment
-    tasks
-  - keep backend and website testing moving toward declared high-coverage goals
-  - keep simplifying backend and website ownership where duplicate or stale
-    logic remains
-  - keep at least three non-overlapping tasks running at a time
-- the linked external checklist repository still exposes the same top-level
-  checklist files on `main` on `2026-05-09`:
-  - `backend-development-checklist.md`
-  - `website-development-checklist.md`
-- the linked external `asks.md` source still has an evidence gap on
-  `2026-05-09`: the GitHub `asks.md` page does not resolve to a readable
-  checklist document, so it remains unavailable evidence rather than usable
-  customer input
+- the current canonical local ask file now says there are no active customer
+  asks: `for now no asks exists.`
+- that local tracked ask-file edit supersedes the previously recorded quality,
+  checklist, coverage, simplification, and minimum-concurrency backlog for this
+  cycle
+- there is therefore no active customer-directed requirement right now to keep
+  three tasks in flight or to derive new checklist work from the external
+  repository
+- the earlier external-checklist lane remains historical context only until the
+  canonical ask file reintroduces it or a maintainer document redirects it
 
 ## recent repo movement
 
@@ -75,6 +68,7 @@
   - `#151` `localize-dashboard-header-timeline-and-stream-status`
   - `#150` `retire-template-fields-variadic-worktree-shim`
 - `gh pr list --state open` on `2026-05-09` reports:
+  - `#168` `docs: refresh meta world state`
   - `#167` `localize-work-outcome-trend-cards-copy`
   - `#163` `docs: refresh meta world state`
   - `#152` `docs: refresh meta world state`
@@ -87,17 +81,20 @@
 
 ## open-lane truth
 
-- `PR #141` still owns the repository-wide external checklist audit lane and
-  should be treated as the active umbrella evidence task rather than a product
-  code cleanup branch
+- `PR #141` still owns the repository-wide external checklist audit lane as an
+  in-flight repo task, but that lane is no longer backed by an active canonical
+  customer ask in the current local workspace
 - `PR #167` owns the current downstream UI localization lane for
   `ui/src/features/work-outcome/*`
+- `PR #168` owns the currently open meta-world refresh lane for the previous
+  checked-in worldview
 - the previously recorded dashboard-header localization seam is already closed
   on live `main` through merged `PR #151`
 - the previously recorded template-field variadic worktree-shim seam is already
   closed on live `main` through merged `PR #150`
-- with `#141` and `#167` still open, one additional non-overlapping queued idea
-  is enough to satisfy the standing ask to keep at least three tasks in flight
+- no active canonical ask currently requires a minimum number of simultaneous
+  lanes, so additional queueing should be driven by repo truth and cleanup
+  value rather than by the withdrawn concurrency target
 
 ## replay truth
 
@@ -126,19 +123,23 @@
   - this is a narrow simplification lane that removes duplicate conversion
     ownership without changing generated contracts, API behavior, or customer
     visible runtime output
+- that cleanup is already queued locally in the canonical ignored idea inbox,
+  so this refresh does not need to create another overlapping request
 
 ## theory of mind
 
 - the authoritative world model comes from live `main`, the checked-in
   workflow contract, the canonical ask file, current PR state, and the
   currently readable external checklist sources together
+- when `factory/logs/meta/asks.md` changes locally, treat that edit as the
+  immediate routing truth even if it withdraws a previously recorded backlog
 - stale “next seam” notes can expire within hours once remote cleanup branches
   merge; re-check the concrete code and PR state before re-queuing an old lane
 - reason about `factory/inputs/**` in two layers:
   checked-in contract versus ignored operating state
-- when the standing ask requires at least three non-overlapping tasks, count
-  open product or audit PRs that still own active lanes, then queue only enough
-  new ignored ideas to restore the minimum
+- when a standalone cleanup request exists as markdown, keep it in
+  `factory/inputs/idea/default/`; a markdown file under `plan/default` is
+  operating-state drift, not the canonical queue shape
 - when a cleanup seam is already centralized in `pkg/interfaces` but one
   downstream subsystem still duplicates the inverse conversion locally, prefer
   collapsing that duplicate owner before inventing new abstractions


### PR DESCRIPTION
## Summary
- refresh the checked-in meta world model against live main after PRs #150, #151, #162, #164, #165, and #166
- record the current open-lane truth around PR #141 and PR #167
- queue one new ignored maintainer idea for replay safe-diagnostics dedupe

## Notes
- direct push to main was blocked by repository rules, so this change is routed through the required PR path
- the queued idea file under factory/inputs remains ignored operating state and is not part of this PR