### PR TITLE
docs: refresh meta world state

### DIFF
--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -167,9 +167,9 @@
 
 ## Current Summary
 
-- As of `2026-05-09T12:03:55+09:00`, live upstream `origin/main` points to
-  `bc1e149` after merged PRs `#169` and `#170`, while the local branch is being
-  reconciled with that upstream head plus existing local tracked edits.
+- As of `2026-05-09T12:06:06+09:00`, local `HEAD` and live upstream
+  `origin/main` both point to `e3162f4` after this cycle's merge-and-refresh
+  push to `main`.
 - The canonical ask surface remains `factory/logs/meta/asks.md`.
 - The checked-in maintainer workflow is `thoughts -> idea -> plan -> task`
   with `idea/task:to-complete`, same-name `consume`, `.claude/worktrees`
@@ -2164,6 +2164,23 @@
   - Open PR ownership can remain useful context even after the canonical ask
     surface goes empty, but those PRs should no longer be described as
     customer-required lanes unless the ask file says so.
+---
+
+## 2026-05-09T12:06:06+09:00 - meta push closeout
+
+- Pushed `main` successfully after the merge resolution, moving live upstream
+  from `bc1e149` to `e3162f4`.
+- Rechecked `git rev-parse HEAD origin/main` and confirmed the local branch and
+  remote `main` now match exactly.
+- Left the pre-existing local edits in `factory/logs/meta/asks.md` and
+  `factory/workers/workspace-setup/AGENTS.md` untouched after the push.
+- Files changed:
+  - `factory/logs/meta/view.md`
+  - `factory/logs/meta/progress.txt`
+- **Learnings for future iterations:**
+  - If the meta refresh itself lands on `main`, do one final post-push
+    worldview adjustment so the checked-in state describes the new upstream
+    head rather than the pre-push merge base.
 ---
 
 ## 2026-05-09T12:03:55+09:00 - meta state refresh

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,9 +2,9 @@
 
 ## world state
 
-- as of `2026-05-09T12:03:55+09:00`, live upstream `origin/main` points to
-  `bc1e149` after merged PR `#170` (`weird-work-names`) and merged PR `#169`
-  (`collapse-replay-safe-diagnostics-rehydration`)
+- as of `2026-05-09T12:06:06+09:00`, local `HEAD` on `main` and live upstream
+  `origin/main` both point to `e3162f4` after the meta merge-and-refresh push
+  for this cycle
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - the current canonical local ask file says there are no active customer asks:
   `for now no asks exists.`
@@ -84,8 +84,8 @@
 - `PR #171` owns the dashboard-shell and workflow-graph padding lane
 - `PR #172` owns the same-trace guard lane across config, petri, API, and
   functional coverage
-- `PR #168` still owns the previously opened meta-refresh branch for the older
-  worldview
+- the previously opened meta-refresh branches such as `PR #168` now reflect an
+  older worldview than live `main`
 - the replay diagnostics dedupe lane is closed on live `main` through merged
   `PR #169`, so it should not remain in the ignored inbox
 


### PR DESCRIPTION
## Summary
- refresh the checked-in meta world model after merging origin/main into the local meta branch
- record that the canonical ask surface currently says there are no active customer asks
- prune the stale replay cleanup idea and replace it with a fresh ignored smoke-helper dedupe request
- update the post-push worldview so the checked-in state points at the latest branch head

## Notes
- one merge-and-refresh commit (e3162f4) was pushed directly to main
- the final closeout commit (d42ff86) was blocked from direct push by required status checks, so it is routed through this PR instead
- the ignored idea file under factory/inputs remains operating state and is not part of this PR
