### PR TITLE
docs: refresh meta world state

### DIFF
--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -167,9 +167,9 @@
 
 ## Current Summary
 
-- As of `2026-05-09T12:03:55+09:00`, live upstream `origin/main` points to
-  `bc1e149` after merged PRs `#169` and `#170`, while the local branch is being
-  reconciled with that upstream head plus existing local tracked edits.
+- As of `2026-05-09T12:06:06+09:00`, local `HEAD` and live upstream
+  `origin/main` both point to `e3162f4` after this cycle's merge-and-refresh
+  push to `main`.
 - The canonical ask surface remains `factory/logs/meta/asks.md`.
 - The checked-in maintainer workflow is `thoughts -> idea -> plan -> task`
   with `idea/task:to-complete`, same-name `consume`, `.claude/worktrees`
@@ -2164,6 +2164,23 @@
   - Open PR ownership can remain useful context even after the canonical ask
     surface goes empty, but those PRs should no longer be described as
     customer-required lanes unless the ask file says so.
+---
+
+## 2026-05-09T12:06:06+09:00 - meta push closeout
+
+- Pushed `main` successfully after the merge resolution, moving live upstream
+  from `bc1e149` to `e3162f4`.
+- Rechecked `git rev-parse HEAD origin/main` and confirmed the local branch and
+  remote `main` now match exactly.
+- Left the pre-existing local edits in `factory/logs/meta/asks.md` and
+  `factory/workers/workspace-setup/AGENTS.md` untouched after the push.
+- Files changed:
+  - `factory/logs/meta/view.md`
+  - `factory/logs/meta/progress.txt`
+- **Learnings for future iterations:**
+  - If the meta refresh itself lands on `main`, do one final post-push
+    worldview adjustment so the checked-in state describes the new upstream
+    head rather than the pre-push merge base.
 ---
 
 ## 2026-05-09T12:03:55+09:00 - meta state refresh

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -2166,6 +2166,55 @@
     customer-required lanes unless the ask file says so.
 ---
 
+## 2026-05-09T13:05:17+09:00 - meta state refresh
+
+- Ran `git pull --rebase --autostash origin main`; Git rebased local `main`
+  onto live `origin/main`, pulling in merged PR `#174`
+  (`dedupe-service-smoke-pipeline-config-builders`) while preserving the
+  tracked local edits in `factory/logs/meta/asks.md` and
+  `factory/workers/workspace-setup/AGENTS.md`.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`, the code-review,
+  backend, and website standards, current PR state, the tracked-versus-ignored
+  `factory/inputs/**` surface, and the live candidate seams in `pkg/api`,
+  `pkg/listeners`, `pkg/replay`, and `tests/functional/smoke`.
+- Revalidated queue truth with `git ls-files factory/inputs` and
+  `find factory/inputs -maxdepth 3 -type f`, confirming the checked-in inboxes
+  remain sentinel-only and that the visible ignored smoke-dedupe idea was
+  stale local operating residue rather than a pending checked-in request.
+- Confirmed the previously queued ignored idea
+  `factory/inputs/idea/default/dedupe-service-smoke-pipeline-config-builders.md`
+  is stale because merged PR `#174` already landed that exact cleanup lane on
+  `main`, then pruned that ignored residue locally.
+- Used one delegated explorer pass to propose replacement seams, then
+  invalidated the first two suggestions with direct code reads:
+  `pkg/listeners/filewatcher.go` already rejects direct
+  `inputs/<work-type>/<file>` drops and
+  `pkg/api/server.go` already relies on generated query binding for `/work`
+  pagination parameters.
+- Rechecked `pkg/replay/event_stream_artifact.go` and its callers, confirming
+  the file-wrapper helpers are still covered by in-repo package and functional
+  tests, so that seam is not dead code.
+- Chose not to queue a fresh cleanup request this cycle because the validated
+  world state no longer supports the stale candidate and the replacement seams
+  were not real on live `main`.
+- Files changed:
+  - `factory/logs/meta/view.md`
+  - `factory/logs/meta/progress.txt`
+  - deleted ignored residue
+    `factory/inputs/idea/default/dedupe-service-smoke-pipeline-config-builders.md`
+- **Learnings for future iterations:**
+  - Treat delegated explorer suggestions as hypotheses; re-read the cited files
+    on live `main` before dispatching a new cleanup request.
+  - A merged cleanup PR can leave an ignored idea file behind locally even when
+    the checked-in inboxes are clean, so queue truth must be reconciled at both
+    the git-tracked and ignored-operating-state layers.
+  - When the canonical ask surface is empty, it is better to leave no queued
+    cleanup than to dispatch a request supported only by stale branch-local
+    evidence.
+---
+
 ## 2026-05-09T12:06:06+09:00 - meta push closeout
 
 - Pushed `main` successfully after the merge resolution, moving live upstream

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -164,6 +164,9 @@
 - When a helper still carries an explicitly backwards-compatible variadic
   parameter but the live production caller already passes one concrete explicit
   value, prefer deleting the shim over preserving two call shapes.
+- When deadcode flags an untagged test helper as unreachable, check whether its
+  only callers live behind `//go:build functionallong`; if so, move the helper
+  behind the same build tag instead of accepting permanent baseline noise.
 
 ## Current Summary
 
@@ -2286,4 +2289,65 @@
   - When short and `functionallong` test lanes define the same factory-config
     builder, prefer one shared helper owner so fixture drift cannot hide behind
     build tags.
+---
+
+## 2026-05-09T14:02:51+09:00 - meta state refresh
+
+- Re-ran `git pull --ff-only` and confirmed the repository was already current
+  with live `origin/main`, while local `main` still sat ahead with stacked
+  meta-only refresh commits and an open replacement meta PR `#175`.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`,
+  `factory/factory.json`, the code-review standard, the backend and website
+  standards, the tracked-versus-ignored `factory/inputs/**` surface, open PR
+  ownership, recent git history, and live code under `tests/functional/` and
+  `pkg/`.
+- Confirmed the canonical ask surface still says `for now no asks exists.`, so
+  no customer lane displaced the cleanup decision this cycle.
+- Revalidated queue truth with `git ls-files factory/inputs` and
+  `find factory/inputs -maxdepth 3 -type f`, confirming the checked-in inboxes
+  remain sentinel-only and that the new cleanup request belongs only in the
+  ignored operating queue.
+- Used one delegated explorer to reconcile PR ownership and confirmed `PR #175`
+  supersedes `PR #173` plus the older still-open meta-refresh stack on the same
+  two tracked files, while active non-meta ownership remains isolated to
+  `PR #141`, `PR #167`, `PR #171`, and `PR #172`.
+- Validated one broader delegated duplication seam in
+  `pkg/factory/projections/world_view_work_item_refs.go` versus
+  `pkg/api/workstation_request_projection.go`, but left it unqueued because it
+  is materially wider than the best deadcode cleanup available right now.
+- Chose one narrower cleanup lane from direct code reads plus the deadcode
+  baseline: bootstrap-portability helper functions are reported unreachable
+  only because long-only callers live behind `//go:build functionallong` while
+  the helpers themselves still compile in the default lane.
+- Queued one ignored standalone idea at
+  `factory/inputs/idea/default/split-bootstrap-portability-functionallong-helpers.md`
+  to move those helpers behind matching build tags and prune the resulting
+  deadcode-baseline noise.
+- Ran `go test ./cmd/deadcodecheck` and confirmed the command-owner coverage
+  seam recorded earlier is now obsolete on live `main` (`97.7%` statements),
+  so it should not be treated as an active next cleanup lane anymore.
+- Ran `go test ./tests/functional/bootstrap_portability/...` successfully.
+- Ran `go test -tags functionallong ./tests/functional/bootstrap_portability/...`
+  and confirmed the full tagged suite already fails on unrelated existing
+  fixture/config drift (`promptTemplate` rejection in current-factory
+  portability fixtures and missing AGENTS frontmatter in the expand/flatten
+  portability sweep), so the queued cleanup keeps full long-lane repair out of
+  scope.
+- Files changed:
+  - `factory/logs/meta/view.md`
+  - `factory/logs/meta/progress.txt`
+  - added ignored idea
+    `factory/inputs/idea/default/split-bootstrap-portability-functionallong-helpers.md`
+- **Learnings for future iterations:**
+  - When the same two meta-doc files are already owned by multiple open
+    meta-refresh PRs, treat only the freshest worldview branch as current lane
+    ownership and treat the older stack as superseded residue.
+  - If long-only functional helpers live in untagged `_test.go` files, the
+    right cleanup is to align helper build tags with their callers rather than
+    preserving deadcode-baseline entries forever.
+  - Re-check old coverage-driven backlog notes against live commands before
+    dispatching them; the repo-owned gate may already have been raised by a
+    later merge.
 ---

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,9 +2,9 @@
 
 ## world state
 
-- as of `2026-05-09T12:03:55+09:00`, live upstream `origin/main` points to
-  `bc1e149` after merged PR `#170` (`weird-work-names`) and merged PR `#169`
-  (`collapse-replay-safe-diagnostics-rehydration`)
+- as of `2026-05-09T12:06:06+09:00`, local `HEAD` on `main` and live upstream
+  `origin/main` both point to `e3162f4` after the meta merge-and-refresh push
+  for this cycle
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - the current canonical local ask file says there are no active customer asks:
   `for now no asks exists.`
@@ -84,8 +84,8 @@
 - `PR #171` owns the dashboard-shell and workflow-graph padding lane
 - `PR #172` owns the same-trace guard lane across config, petri, API, and
   functional coverage
-- `PR #168` still owns the previously opened meta-refresh branch for the older
-  worldview
+- the previously opened meta-refresh branches such as `PR #168` now reflect an
+  older worldview than live `main`
 - the replay diagnostics dedupe lane is closed on live `main` through merged
   `PR #169`, so it should not remain in the ignored inbox
 

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,22 +2,22 @@
 
 ## world state
 
-- as of `2026-05-09T12:06:06+09:00`, local `HEAD` on `main` and live upstream
-  `origin/main` both point to `e3162f4` after the meta merge-and-refresh push
-  for this cycle
+- as of `2026-05-09T13:05:17+09:00`, local `main` has been rebased onto live
+  `origin/main` at `74b874a` and then carries one local meta-refresh commit
+  `57076b3`
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
-- the current canonical local ask file says there are no active customer asks:
-  `for now no asks exists.`
+- the current canonical local ask file still says there are no active customer
+  asks: `for now no asks exists.`
 - the tracked maintainer workflow inputs remain sentinel-only under
   `factory/inputs/**`; live work items there are ignored operating state
-- the local worktree is dirty before this refresh from tracked local edits in
+- the local worktree is still dirty from tracked local edits in
   `factory/logs/meta/asks.md` and `factory/workers/workspace-setup/AGENTS.md`;
   treat those as existing local state, not as noise to revert
 
 ## workflow truth
 
-- `factory/factory.json` defines five work types: `thoughts`, `idea`, `plan`,
-  `task`, and `cron-triggers`
+- `factory/factory.json` still defines five work types: `thoughts`, `idea`,
+  `plan`, `task`, and `cron-triggers`
 - the checked-in maintainer loop on live `main` is:
   `thoughts:init -> ideafy -> thoughts:complete`
   `idea:init -> plan -> idea:to-complete + plan:init`
@@ -40,33 +40,32 @@
 - `.gitignore` still keeps live workflow submissions under `factory/inputs/**`
   out of normal commits except for those sentinel paths
 - the previously queued ignored idea
-  `factory/inputs/idea/default/collapse-replay-safe-diagnostics-rehydration.md`
-  is stale because its owning work merged through PR `#169`
-- after pruning that stale residue, the next maintainer-owned ignored backlog
-  slot should be a fresh standalone idea rather than a duplicate replay request
+  `factory/inputs/idea/default/dedupe-service-smoke-pipeline-config-builders.md`
+  was stale because merged PR `#174` landed that exact lane on `main`
+- that stale ignored idea residue has now been pruned locally so the operating
+  queue no longer points at already-merged work
 
 ## customer-ask truth
 
-- the local canonical ask file now withdraws the earlier checklist, coverage,
-  simplification, and minimum-concurrency backlog for this cycle
+- the local canonical ask file continues to withdraw the earlier checklist,
+  coverage, simplification, and minimum-concurrency backlog for this cycle
 - there is therefore no active customer-directed requirement right now to keep
   a minimum number of simultaneous lanes in flight
-- open PRs can still inform overlap checks, but they no longer count as
-  customer-required work unless the canonical ask file reintroduces them
+- open PRs can still inform overlap checks, but they do not become asks unless
+  `factory/logs/meta/asks.md` reintroduces them
 
 ## recent repo movement
 
 - recent merged PRs on `main` now include:
+  - `#174` `dedupe-service-smoke-pipeline-config-builders`
   - `#170` `weird-work-names`
   - `#169` `collapse-replay-safe-diagnostics-rehydration`
   - `#166` `simplify-loaded-runtime-definition-lookups`
   - `#165` `localize-workflow-activity-graph-import-copy`
-  - `#164` `localize-terminal-work-card-copy`
-  - `#162` `localize-dashboard-flow-axis-legend-copy`
 - `gh pr list --state open` on `2026-05-09` reports:
+  - `#173` `docs: refresh meta world state`
   - `#172` `same-trace`
   - `#171` `workflow-graph-padding`
-  - `#168` `docs: refresh meta world state`
   - `#167` `localize-work-outcome-trend-cards-copy`
   - `#163` `docs: refresh meta world state`
   - `#152` `docs: refresh meta world state`
@@ -84,10 +83,10 @@
 - `PR #171` owns the dashboard-shell and workflow-graph padding lane
 - `PR #172` owns the same-trace guard lane across config, petri, API, and
   functional coverage
-- the previously opened meta-refresh branches such as `PR #168` now reflect an
-  older worldview than live `main`
-- the replay diagnostics dedupe lane is closed on live `main` through merged
-  `PR #169`, so it should not remain in the ignored inbox
+- `PR #173` is the current open meta-refresh branch and is now older than the
+  live rebased local worldview again
+- the smoke helper dedupe lane is closed on live `main` through merged
+  `PR #174`, so it must not be re-queued
 
 ## replay truth
 
@@ -99,36 +98,32 @@
 - one replay rejection payload is still quoted oddly as `"\"<REJECTED>\"\n"`;
   treat that as fixture history rather than live workflow behavior
 
-## next cleanup candidate
+## current maintainer decision
 
-- the next maintainer-owned non-overlapping cleanup seam is service-smoke test
-  helper dedupe:
-  - `tests/functional/smoke/short_helpers_test.go` defines
-    `simpleServicePipelineConfig` and `twoStageServicePipelineConfig`
-  - `tests/functional/smoke/service_lifecycle_smoke_long_test.go` defines the
-    same two helpers again for the `functionallong` lane
-  - `tests/functional/smoke/service_config_override_alignment_test.go` already
-    consumes the short-lane shared helper, so the duplicate long-lane owner is
-    now the drift risk
-  - this is a narrow simplification lane that removes duplicated fixture
-    builders while preserving the observable service smoke behavior in both the
-    default and `functionallong` test lanes
-- that seam is not covered by open PRs `#141`, `#167`, `#168`, `#171`, or
-  `#172`
+- this cycle does not queue a new cleanup request
+- reason:
+  - the previously selected next cleanup seam already merged through `PR #174`
+  - the delegated explorer's replacement suggestions did not survive direct
+    code validation on live `main`
+  - `pkg/listeners/filewatcher.go` already rejects direct two-segment
+    `inputs/<work-type>/<file>` drops and tests cover the canonical
+    `default/`-channel-only contract
+  - `pkg/api/server.go` no longer carries a handwritten `/work` pagination shim
+    and the generated binding path already owns invalid `maxResults` rejection
+  - `pkg/replay/event_stream_artifact.go` still has in-repo test and
+    functional callers for the file-wrapper helpers, so that seam is not dead
 
 ## theory of mind
 
 - the authoritative world model comes from live upstream git state, the
   checked-in workflow contract, the canonical ask file, current PR ownership,
-  and direct code reads together
+  ignored queue residue, and direct code reads together
 - when `factory/logs/meta/asks.md` changes locally, treat that edit as the
   immediate routing truth even if it withdraws a previously active backlog
 - reason about `factory/inputs/**` in two layers:
   checked-in contract versus ignored operating state
 - prune ignored local idea files once their owning PR merges; otherwise the
-  local queue can preserve stale work that the live repo already finished
-- treat delegated explorer suggestions as provisional after a fast-forward or
-  merge; confirm the seam still exists on live `main` before re-queuing it
-- when one functional test lane already exposes shared fixture builders, prefer
-  reusing that owner across build-tag variants instead of keeping duplicated
-  config definitions in long and short suites
+  canonical inbox can preserve stale work that the live repo already finished
+- treat delegated explorer suggestions as hypotheses; re-verify them against
+  live `main` before dispatching new cleanup work because recent merges can
+  invalidate an otherwise plausible seam within the same cycle

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,9 +2,9 @@
 
 ## world state
 
-- as of `2026-05-09T13:05:17+09:00`, local `main` has been rebased onto live
-  `origin/main` at `74b874a` and then carries one local meta-refresh commit
-  `57076b3`
+- as of `2026-05-09T14:02:51+09:00`, live `origin/main` still points at
+  merged `PR #174` commit `74b874a`, while local `main` also carries stacked
+  meta-only refresh commits, including `c1b5823` on open `PR #175`
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - the current canonical local ask file still says there are no active customer
   asks: `for now no asks exists.`
@@ -44,6 +44,8 @@
   was stale because merged PR `#174` landed that exact lane on `main`
 - that stale ignored idea residue has now been pruned locally so the operating
   queue no longer points at already-merged work
+- the local ignored operating queue now contains one fresh standalone idea:
+  `factory/inputs/idea/default/split-bootstrap-portability-functionallong-helpers.md`
 
 ## customer-ask truth
 
@@ -63,6 +65,7 @@
   - `#166` `simplify-loaded-runtime-definition-lookups`
   - `#165` `localize-workflow-activity-graph-import-copy`
 - `gh pr list --state open` on `2026-05-09` reports:
+  - `#175` `docs: refresh meta world state`
   - `#173` `docs: refresh meta world state`
   - `#172` `same-trace`
   - `#171` `workflow-graph-padding`
@@ -83,8 +86,8 @@
 - `PR #171` owns the dashboard-shell and workflow-graph padding lane
 - `PR #172` owns the same-trace guard lane across config, petri, API, and
   functional coverage
-- `PR #173` is the current open meta-refresh branch and is now older than the
-  live rebased local worldview again
+- `PR #175` is the freshest open meta-refresh branch and supersedes `PR #173`
+  plus the older still-open meta-refresh PR stack on the same file pair
 - the smoke helper dedupe lane is closed on live `main` through merged
   `PR #174`, so it must not be re-queued
 
@@ -100,18 +103,23 @@
 
 ## current maintainer decision
 
-- this cycle does not queue a new cleanup request
+- this cycle queues one new cleanup request:
+  `split-bootstrap-portability-functionallong-helpers`
 - reason:
-  - the previously selected next cleanup seam already merged through `PR #174`
-  - the delegated explorer's replacement suggestions did not survive direct
-    code validation on live `main`
-  - `pkg/listeners/filewatcher.go` already rejects direct two-segment
-    `inputs/<work-type>/<file>` drops and tests cover the canonical
-    `default/`-channel-only contract
-  - `pkg/api/server.go` no longer carries a handwritten `/work` pagination shim
-    and the generated binding path already owns invalid `maxResults` rejection
-  - `pkg/replay/event_stream_artifact.go` still has in-repo test and
-    functional callers for the file-wrapper helpers, so that seam is not dead
+  - the canonical ask surface is still empty, so cleanup choice must be
+    justified only by live repo state and non-overlap with active PR ownership
+  - direct reads plus `docs/internal/development/deadcode-baseline.txt` show
+    bootstrap-portability helper functions reported as unreachable solely
+    because they live in always-built `_test.go` files while their only callers
+    sit behind `//go:build functionallong`
+  - the affected helpers are narrow and isolated to
+    `tests/functional/bootstrap_portability/*`, so the cleanup does not overlap
+    active ownership in `PR #141`, `PR #167`, `PR #171`, or `PR #172`
+  - moving those helpers behind matching build tags removes deadcode-baseline
+    noise without changing backend, API, CLI, or UI behavior
+  - the alternative duplicated projection seams found by a delegated explorer
+    remain real but broader, so they are lower priority than this tighter
+    deadcode cleanup
 
 ## theory of mind
 
@@ -127,3 +135,10 @@
 - treat delegated explorer suggestions as hypotheses; re-verify them against
   live `main` before dispatching new cleanup work because recent merges can
   invalidate an otherwise plausible seam within the same cycle
+- when an untagged test helper is only called from `functionallong` suites,
+  treat the build-tag mismatch as the real deadcode seam and move the helper
+  behind matching tags instead of normalizing the noise into the baseline
+- when multiple open meta-refresh PRs touch only
+  `factory/logs/meta/view.md` and `factory/logs/meta/progress.txt`, the newest
+  live worldview supersedes the older stack rather than creating parallel lane
+  ownership


### PR DESCRIPTION
## Summary
- refresh the meta world model after rebasing onto origin/main
- record that PR #174 merged the smoke config dedupe lane
- prune the stale ignored idea residue and document why no new cleanup request was queued this cycle

## Notes
- direct push to main was blocked by repository rules requiring status checks
- user-owned tracked edits in factory/logs/meta/asks.md and factory/workers/workspace-setup/AGENTS.md were left uncommitted