### PR TITLE
dedupe-replay-contract-tagged-helpers

### DIFF
--- a/docs/internal/development/deadcode-baseline.txt
+++ b/docs/internal/development/deadcode-baseline.txt
@@ -51,8 +51,6 @@ tests/functional/replay_contracts/replay_thin_event_dual_dispatch_smoke_test.go:
 tests/functional/replay_contracts/replay_thin_event_dual_dispatch_smoke_test.go:656:6: unreachable func: assertReplayProjectionOmitsInferenceFields
 tests/functional/replay_contracts/replay_thin_event_dual_dispatch_smoke_test.go:673:6: unreachable func: thinEventDispatchIDForWork
 tests/functional/replay_contracts/replay_thin_event_dual_dispatch_smoke_test.go:690:6: unreachable func: thinEventCompletedDispatchForID
-tests/functional/replay_contracts/short_helpers_test.go:26:6: unreachable func: replayEventCount
-tests/functional/replay_contracts/short_helpers_test.go:43:6: unreachable func: factoryRelationsValue
 tests/functional/runtime_api/api_batch_submission_boundary_smoke_test.go:39:6: unreachable func: runBoundaryBatchSmokeThroughWatchedFile
 tests/functional/runtime_api/api_batch_submission_boundary_smoke_test.go:55:6: unreachable func: runBoundaryBatchSmokeThroughHTTP
 tests/functional/runtime_api/api_batch_submission_boundary_smoke_test.go:98:6: unreachable func: loadBatchBoundarySummary

--- a/tests/functional/replay_contracts/replay_record_end_to_end_long_test.go
+++ b/tests/functional/replay_contracts/replay_record_end_to_end_long_test.go
@@ -479,18 +479,6 @@ func runRecordReplayCLIWithCapturedStdout(t *testing.T, cfg runcli.RunConfig) (s
 	return string(output), runErr
 }
 
-func assertReplayArtifactDoesNotContainRawValue(t *testing.T, artifactPath, rawValue string) {
-	t.Helper()
-
-	data, err := os.ReadFile(artifactPath)
-	if err != nil {
-		t.Fatalf("read replay artifact %s: %v", artifactPath, err)
-	}
-	if strings.Contains(string(data), rawValue) {
-		t.Fatalf("replay artifact %s leaked raw environment value %q", artifactPath, rawValue)
-	}
-}
-
 func assertReplayArtifactCommandEnvRedacted(t *testing.T, artifact *interfaces.ReplayArtifact, envKey string) {
 	t.Helper()
 
@@ -501,44 +489,6 @@ func assertReplayArtifactCommandEnvRedacted(t *testing.T, artifact *interfaces.R
 	if strings.Contains(string(data), envKey) || strings.Contains(string(data), workers.RedactedCommandEnvValue) {
 		t.Fatalf("replay artifact leaked command env metadata for %s", envKey)
 	}
-}
-
-func replayEventCount(artifact *interfaces.ReplayArtifact, eventType factoryapi.FactoryEventType) int {
-	count := 0
-	for _, event := range artifact.Events {
-		if event.Type == eventType {
-			count++
-		}
-	}
-	return count
-}
-
-func factoryWorksValue(value *[]factoryapi.Work) []factoryapi.Work {
-	if value == nil {
-		return nil
-	}
-	return *value
-}
-
-func factoryRelationsValue(value *[]factoryapi.Relation) []factoryapi.Relation {
-	if value == nil {
-		return nil
-	}
-	return *value
-}
-
-func stringPointerValue[T ~string](value *T) string {
-	if value == nil {
-		return ""
-	}
-	return string(*value)
-}
-
-func stringSlicePointerValue(value *[]string) []string {
-	if value == nil {
-		return nil
-	}
-	return *value
 }
 
 func commandEnvContains(env []string, want string) bool {

--- a/tests/functional/replay_contracts/short_helpers_contract_test.go
+++ b/tests/functional/replay_contracts/short_helpers_contract_test.go
@@ -1,0 +1,46 @@
+package replay_contracts
+
+import (
+	"testing"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+)
+
+func TestReplayEventCountCountsMatchingEventTypes(t *testing.T) {
+	artifact := &interfaces.ReplayArtifact{
+		Events: []factoryapi.FactoryEvent{
+			{Type: factoryapi.FactoryEventTypeDispatchRequest},
+			{Type: factoryapi.FactoryEventTypeDispatchResponse},
+			{Type: factoryapi.FactoryEventTypeDispatchRequest},
+		},
+	}
+
+	if got := replayEventCount(artifact, factoryapi.FactoryEventTypeDispatchRequest); got != 2 {
+		t.Fatalf("replayEventCount(dispatch request) = %d, want 2", got)
+	}
+	if got := replayEventCount(artifact, factoryapi.FactoryEventTypeWorkRequest); got != 0 {
+		t.Fatalf("replayEventCount(work request) = %d, want 0", got)
+	}
+}
+
+func TestFactoryRelationsValueReturnsUnderlyingSlice(t *testing.T) {
+	var nilRelations *[]factoryapi.Relation
+	if got := factoryRelationsValue(nilRelations); got != nil {
+		t.Fatalf("factoryRelationsValue(nil) = %#v, want nil", got)
+	}
+
+	relations := []factoryapi.Relation{{
+		Type:           factoryapi.RelationTypeDependsOn,
+		SourceWorkName: "generated-beta",
+		TargetWorkName: "generated-alpha",
+	}}
+
+	got := factoryRelationsValue(&relations)
+	if len(got) != 1 {
+		t.Fatalf("factoryRelationsValue(...) length = %d, want 1", len(got))
+	}
+	if got[0].SourceWorkName != relations[0].SourceWorkName || got[0].TargetWorkName != relations[0].TargetWorkName || got[0].Type != relations[0].Type {
+		t.Fatalf("factoryRelationsValue(...) = %#v, want %#v", got[0], relations[0])
+	}
+}

--- a/tests/functional/replay_contracts/short_helpers_test.go
+++ b/tests/functional/replay_contracts/short_helpers_test.go
@@ -1,5 +1,3 @@
-//go:build !functionallong
-
 package replay_contracts
 
 import (


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/dedupe-replay-contract-tagged-helpers",
  "description": "Create one canonical shared helper owner for replay-contract functional tests across the default and functionallong build-tag lanes, preserve the same observable replay assertions, and remove the resulting stale deadcode baseline entries.",
  "context": {
    "customerAsk": "Move the shared replay-contract helper set into a helper file that both the default and functionallong lanes compile, delete the duplicate helper definitions from the long-tagged end-to-end file, and remove the resulting stale deadcode baseline entries without changing replay runtime, API, CLI, or UI behavior.",
    "problem": "The replay-contract functional package currently duplicates the same helper logic across the default and functionallong build-tag lanes. That split ownership forces maintainers to keep helper behavior aligned in two places and causes deadcode analysis to report the default-lane helper definitions as unreachable in one build mode even though the overall replay-contract surface still relies on them.",
    "solution": "Introduce one canonical helper file under tests/functional/replay_contracts that both build-tag lanes compile, route both default-lane and functionallong callers through that shared helper owner, remove the duplicate long-lane helper block, and then delete only the deadcode baseline entries that disappear once helper ownership is shared cleanly."
  },
  "acceptanceCriteria": [
    "The replay-contract package exposes one canonical shared helper owner that compiles in both the default lane and the functionallong lane for the duplicated replay helper surface.",
    "Default-lane replay-contract tests and functionallong replay-contract tests continue to exercise the same observable replay assertions and helper-backed values after the deduplication.",
    "The duplicate helper definitions previously embedded in replay_record_end_to_end_long_test.go are no longer needed because long-tagged callers compile against the shared helper owner.",
    "docs/internal/development/deadcode-baseline.txt removes only the replay-contract helper entries that stop appearing once shared helper ownership is aligned across build-tag lanes.",
    "Verification proves the change through replay-contract test commands and deadcode checks rather than through source-topology assertions alone.",
    "Typecheck, lint, and tests pass for the touched replay-contract and deadcode verification paths."
  ],
  "userStories": [
    {
      "id": "dedupe-replay-contract-tagged-helpers-001",
      "title": "Share one replay-contract helper surface across both build-tag lanes",
      "description": "As a maintainer, I want replay-contract helpers that are used by both default and functionallong tests to live in one shared owner so both lanes keep the same observable assertions without duplicated helper definitions.",
      "acceptanceCriteria": [
        "One helper file under tests/functional/replay_contracts owns the shared replay-contract helper surface for assertReplayArtifactDoesNotContainRawValue, replayEventCount, factoryWorksValue, factoryRelationsValue, stringPointerValue, and stringSlicePointerValue.",
        "Both the default-lane callers and the functionallong callers compile against that shared helper owner without wrapper helpers or alias helpers.",
        "replay_record_end_to_end_long_test.go no longer carries duplicate definitions of the shared replay-contract helpers.",
        "The touched replay-contract tests continue to express the same observable replay artifact assertions, event counting behavior, and factory value setup after the helper move.",
        "go test ./tests/functional/replay_contracts/... succeeds.",
        "go test -run '^$' -tags functionallong ./tests/functional/replay_contracts/... succeeds.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "dedupe-replay-contract-tagged-helpers-002",
      "title": "Remove stale replay-contract deadcode baseline findings after helper deduplication",
      "description": "As a reviewer, I want the replay-contract deadcode findings to disappear once helper ownership is shared cleanly so the baseline reflects real deadcode instead of build-tag duplication noise.",
      "acceptanceCriteria": [
        "The default deadcode verification path no longer reports the replay-contract shared helper definitions as unreachable once both lanes compile from the canonical helper owner.",
        "docs/internal/development/deadcode-baseline.txt removes only the replay-contract helper entries that disappear from the deadcode diff after the helper move, leaving unrelated baseline items unchanged.",
        "go test ./cmd/deadcodecheck succeeds.",
        "The repository deadcode command, or the project-equivalent verification path, shows a baseline diff where the replay-contract helper findings are gone.",
        "Verification remains limited to helper placement, replay-contract compilation or behavior, and the corresponding deadcode baseline cleanup without broadening into replay redesign or unrelated functional-test rewrites.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
