### PR TITLE
docs: refresh meta world state

### DIFF
--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -1,5 +1,11 @@
 ## Codebase Patterns
 
+- Treat live `origin/main` plus the canonical ask file as the source of truth
+  over older local worldview notes; if upstream reintroduces asks, invalidate
+  stale “no asks” summaries immediately.
+- Do not trust a passing `cmd/gocoveragecheck` result on aggregate percentage
+  alone; compare the same live run for printed `0.0%` backend package lines
+  because the zero-coverage gate can still miss packages and overstate quality.
 - When the canonical local ask file is reduced to `for now no asks exists.`,
   treat earlier broad backlog notes as withdrawn for the current cycle instead
   of continuing to satisfy them by inertia.
@@ -174,10 +180,9 @@
 
 ## Current Summary
 
-- As of `2026-05-09T15:05:05+09:00`, live upstream `origin/main` points to
-  merged `PR #176` commit `37c7c61`, and local `main` has been rebased onto
-  that head while still carrying stacked local meta-refresh commits awaiting
-  push.
+- As of `2026-05-09T16:03:49+09:00`, live upstream `origin/main` points to
+  merged `PR #177` commit `ca69cbc`, and local `main` has been rebased onto
+  that head while carrying only the local meta-refresh commit stack.
 - The canonical ask surface remains `factory/logs/meta/asks.md`.
 - The checked-in maintainer workflow is `thoughts -> idea -> plan -> task`
   with `idea/task:to-complete`, same-name `consume`, `.claude/worktrees`
@@ -185,27 +190,59 @@
   hourly cleaner, and loop breakers.
 - The tracked input surface remains sentinel-only; there is no checked-in
   cleanup request currently queued under `factory/inputs/**`.
-- The local worktree is not clean because `factory/logs/meta/asks.md` and
-  `factory/workers/workspace-setup/AGENTS.md` already carry tracked local edits
-  and this refresh updates the tracked meta docs; ignored workflow files under
-  `factory/inputs/**` remain operating state rather than canonical queue truth.
+- The visible local queue state under `factory/inputs/**` is ignored operating
+  residue rather than checked-in queue truth.
 - Open PR ownership now includes `#141` for checklist audit, `#167` for
   work-outcome localization, `#171` for workflow-graph spacing, and `#172` for
   the same-trace guard, while `#175` is the freshest open meta-refresh lane.
-- The canonical ask surface currently says `for now no asks exists.`, so the
-  earlier checklist, coverage, simplification, and queue-count backlog is
-  withdrawn for this cycle.
+- `#141` also touches the meta-doc pair, so meta-refresh work is not isolated
+  to the `#175` stack.
+- The canonical ask surface on live `main` is active again and currently asks
+  for external-checklist conformance, stronger backend and website coverage,
+  and ongoing simplification.
 - The replay fixtures remain historical samples rather than current workflow
   truth, and one rejection payload is still quoted anomalously in the replay
   sample.
-- The previously queued ignored bootstrap-portability idea was stale because
-  merged PR `#176` already landed that exact lane on `main`, and the stale
-  ignored residue has been pruned locally.
-- The older smoke-suite helper-dedupe seam previously recorded here is also
-  closed on live `main`; the shared owner now lives in
-  `tests/functional/smoke/service_pipeline_config_helpers_test.go`.
+- The replay-helper dedupe lane previously recorded here is now closed on live
+  `main` through merged `PR #177`, so its ignored idea residue is stale.
 - The fresh maintainer-owned ignored cleanup slot for this cycle is
-  `factory/inputs/idea/default/dedupe-replay-contract-tagged-helpers.md`.
+  `factory/inputs/idea/default/fix-gocoveragecheck-zero-coverage-report-gap.md`.
+
+## 2026-05-09T16:03:49+09:00 - meta state refresh
+
+- Reconciled the branch onto current upstream with
+  `git pull --rebase origin main` after stashing local tracked edits out of the
+  way; live `origin/main` now resolves to merged `PR #177` commit `ca69cbc`.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`,
+  `factory/factory.json`, the backend standard, the tracked-versus-ignored
+  `factory/inputs/**` surface, recent merged/open PR movement, and direct code
+  in the candidate cleanup areas.
+- Corrected the stale worldview assumptions from the previous cycle:
+  the canonical ask file on live `main` is active again,
+  `PR #177` is merged, and the older replay-helper cleanup request is already
+  closed on upstream.
+- Re-validated that the tracked factory inboxes remain sentinel-only while the
+  visible local idea files are ignored operating residue.
+- Verified with `gh pr list --state open` that active product-code ownership is
+  still concentrated in `#141`, `#167`, `#171`, and `#172`, leaving
+  `cmd/gocoveragecheck` outside current open-lane overlap.
+- Ran the live backend coverage lane with
+  `go run ./cmd/gocoveragecheck -min 80 -timeout 300s` and confirmed the
+  command still exits successfully at `86.6%` total coverage while the same
+  output prints `0.0%` backend package lines for
+  `pkg/apisurface`, `pkg/buffers`, and `pkg/cli/default`.
+- Re-read `cmd/gocoveragecheck/main.go` and its tests, confirming the next
+  high-value narrow seam is the zero-coverage detection path in
+  `findZeroCoveragePackages` and its regression coverage, not a broader
+  package-by-package test-authoring campaign.
+- Used delegated explorer passes to reject already-owned or already-merged
+  seams and to keep one smaller fallback helper-dedupe seam on hand, but chose
+  the coverage-gate bug as the stronger customer-facing cleanup lane.
+- Pruned the stale ignored replay-helper idea and replaced it with one fresh
+  standalone cleanup idea:
+  `factory/inputs/idea/default/fix-gocoveragecheck-zero-coverage-report-gap.md`.
 
 ## 2026-05-09T15:05:05+09:00 - meta state refresh
 

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -164,6 +164,9 @@
 - When a standards audit PR or a checklist follow-up PR is already open, treat
   its branch and changed-file surface as owned; replace only merged or stale
   backlog slots instead of queueing a second idea over the same files.
+- When many open PRs all stack on `factory/logs/meta/*`, treat those files as
+  a conflict-prone reporting surface and prefer dispatching cleanup work in
+  non-meta code paths so queue throughput does not collapse into doc overlap.
 - When the customer-linked external checklist repository omits one of the
   requested documents, record that missing source as an evidence gap and avoid
   inferring checklist content that is not actually retrievable on that date.
@@ -2476,4 +2479,59 @@
   - When the external checklist ask is already owned by an audit PR, re-verify
     only enough of the source repository to keep the world model current and
     avoid spawning an overlapping second audit lane.
+---
+
+## 2026-05-09T18:03:23+09:00 - meta state refresh
+
+- Re-ran `git pull --ff-only` and confirmed the repository was still current
+  with live `origin/main` at merged `PR #177` commit `ca69cbc`.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`,
+  `factory/factory.json`, and the backend plus website standards before making
+  a new dispatch decision.
+- Revalidated the canonical queue surface with `git ls-files 'factory/inputs/**'`
+  and `find factory/inputs -maxdepth 3 -type f`, confirming the tracked inboxes
+  remain sentinel-only while live idea files stay ignored operating state.
+- Used delegated explorers plus direct `gh pr view` reads to confirm the main
+  overlap risk is self-stacked branch ownership on `factory/logs/meta/*`,
+  while `factory/inputs/*` and the service cron-watcher seam are not currently
+  claimed by any open PR.
+- Verified that the current visible ignored idea files are
+  `fix-gocoveragecheck-zero-coverage-report-gap.md`,
+  `website-edit-running-factory-workstations.md`, and the new
+  `simplify-cron-watcher-runtime-lookup-width.md`; only the first is already
+  advanced into an open worker lane (`PR #179`).
+- Read `pkg/service/cron_watcher.go`, `pkg/service/factory.go`,
+  `pkg/service/factory_test.go`, and
+  `docs/internal/processes/factory-workstation-relevant-files.md` and
+  confirmed a narrow simplification seam: `startCronWatchersForRuntime`
+  still accepts `interfaces.RuntimeConfigLookup` even though watcher-start
+  already derives workflow identity from `factoryDir` and passes only
+  workstation lookup needs downstream.
+- Queued one ignored standalone idea at
+  `factory/inputs/idea/default/simplify-cron-watcher-runtime-lookup-width.md`
+  so a worker can narrow that service-layer dependency without touching the
+  open `cmd/gocoveragecheck`, workflow-graph, work-outcome, same-trace, or
+  audit lanes.
+- Ran `go test ./pkg/service -run TestFactoryService_StartCronWatchersForRuntime_DisablesInvalidSchedulesWithoutAffectingValidCronJobs -count=1`
+  and confirmed the existing service watcher coverage that already exercises
+  the seam passes on live `main`.
+- Files changed:
+  - `factory/logs/meta/view.md`
+  - `factory/logs/meta/progress.txt`
+  - added ignored idea
+    `factory/inputs/idea/default/simplify-cron-watcher-runtime-lookup-width.md`
+- **Learnings for future iterations:**
+  - When open PR ownership is concentrated on `factory/logs/meta/*`, treat the
+    meta-doc pair as a reporting hotspot and avoid inventing new cleanup work
+    there unless the world model itself actually changed.
+  - If watcher-start already derives workflow identity from `factoryDir`, keep
+    the remaining cron helper dependency narrowed to
+    `interfaces.RuntimeWorkstationLookup` instead of preserving a wider
+    path-aware runtime interface.
+  - `factory/inputs/*` can be safely used for new ignored operating-state
+    requests even when the tracked meta docs are conflict-heavy, because the
+    active PR overlap right now is in the docs and command/test lanes, not the
+    inbox paths.
 ---

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -167,9 +167,9 @@
 
 ## Current Summary
 
-- As of `2026-05-09T12:03:55+09:00`, live upstream `origin/main` points to
-  `bc1e149` after merged PRs `#169` and `#170`, while the local branch is being
-  reconciled with that upstream head plus existing local tracked edits.
+- As of `2026-05-09T12:06:06+09:00`, local `HEAD` and live upstream
+  `origin/main` both point to `e3162f4` after this cycle's merge-and-refresh
+  push to `main`.
 - The canonical ask surface remains `factory/logs/meta/asks.md`.
 - The checked-in maintainer workflow is `thoughts -> idea -> plan -> task`
   with `idea/task:to-complete`, same-name `consume`, `.claude/worktrees`
@@ -2164,6 +2164,23 @@
   - Open PR ownership can remain useful context even after the canonical ask
     surface goes empty, but those PRs should no longer be described as
     customer-required lanes unless the ask file says so.
+---
+
+## 2026-05-09T12:06:06+09:00 - meta push closeout
+
+- Pushed `main` successfully after the merge resolution, moving live upstream
+  from `bc1e149` to `e3162f4`.
+- Rechecked `git rev-parse HEAD origin/main` and confirmed the local branch and
+  remote `main` now match exactly.
+- Left the pre-existing local edits in `factory/logs/meta/asks.md` and
+  `factory/workers/workspace-setup/AGENTS.md` untouched after the push.
+- Files changed:
+  - `factory/logs/meta/view.md`
+  - `factory/logs/meta/progress.txt`
+- **Learnings for future iterations:**
+  - If the meta refresh itself lands on `main`, do one final post-push
+    worldview adjustment so the checked-in state describes the new upstream
+    head rather than the pre-push merge base.
 ---
 
 ## 2026-05-09T12:03:55+09:00 - meta state refresh

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -2166,6 +2166,55 @@
     customer-required lanes unless the ask file says so.
 ---
 
+## 2026-05-09T13:05:17+09:00 - meta state refresh
+
+- Ran `git pull --rebase --autostash origin main`; Git rebased local `main`
+  onto live `origin/main`, pulling in merged PR `#174`
+  (`dedupe-service-smoke-pipeline-config-builders`) while preserving the
+  tracked local edits in `factory/logs/meta/asks.md` and
+  `factory/workers/workspace-setup/AGENTS.md`.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`, the code-review,
+  backend, and website standards, current PR state, the tracked-versus-ignored
+  `factory/inputs/**` surface, and the live candidate seams in `pkg/api`,
+  `pkg/listeners`, `pkg/replay`, and `tests/functional/smoke`.
+- Revalidated queue truth with `git ls-files factory/inputs` and
+  `find factory/inputs -maxdepth 3 -type f`, confirming the checked-in inboxes
+  remain sentinel-only and that the visible ignored smoke-dedupe idea was
+  stale local operating residue rather than a pending checked-in request.
+- Confirmed the previously queued ignored idea
+  `factory/inputs/idea/default/dedupe-service-smoke-pipeline-config-builders.md`
+  is stale because merged PR `#174` already landed that exact cleanup lane on
+  `main`, then pruned that ignored residue locally.
+- Used one delegated explorer pass to propose replacement seams, then
+  invalidated the first two suggestions with direct code reads:
+  `pkg/listeners/filewatcher.go` already rejects direct
+  `inputs/<work-type>/<file>` drops and
+  `pkg/api/server.go` already relies on generated query binding for `/work`
+  pagination parameters.
+- Rechecked `pkg/replay/event_stream_artifact.go` and its callers, confirming
+  the file-wrapper helpers are still covered by in-repo package and functional
+  tests, so that seam is not dead code.
+- Chose not to queue a fresh cleanup request this cycle because the validated
+  world state no longer supports the stale candidate and the replacement seams
+  were not real on live `main`.
+- Files changed:
+  - `factory/logs/meta/view.md`
+  - `factory/logs/meta/progress.txt`
+  - deleted ignored residue
+    `factory/inputs/idea/default/dedupe-service-smoke-pipeline-config-builders.md`
+- **Learnings for future iterations:**
+  - Treat delegated explorer suggestions as hypotheses; re-read the cited files
+    on live `main` before dispatching a new cleanup request.
+  - A merged cleanup PR can leave an ignored idea file behind locally even when
+    the checked-in inboxes are clean, so queue truth must be reconciled at both
+    the git-tracked and ignored-operating-state layers.
+  - When the canonical ask surface is empty, it is better to leave no queued
+    cleanup than to dispatch a request supported only by stale branch-local
+    evidence.
+---
+
 ## 2026-05-09T12:06:06+09:00 - meta push closeout
 
 - Pushed `main` successfully after the merge resolution, moving live upstream

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -167,12 +167,17 @@
 - When deadcode flags an untagged test helper as unreachable, check whether its
   only callers live behind `//go:build functionallong`; if so, move the helper
   behind the same build tag instead of accepting permanent baseline noise.
+- When the same replay-contract helper logic is defined once in a default-tag
+  helper file and again in a `functionallong` test file, prefer one shared
+  helper owner that both build modes compile instead of carrying duplicate
+  assertion helpers plus build-mode deadcode noise.
 
 ## Current Summary
 
-- As of `2026-05-09T12:06:06+09:00`, local `HEAD` and live upstream
-  `origin/main` both point to `e3162f4` after this cycle's merge-and-refresh
-  push to `main`.
+- As of `2026-05-09T15:05:05+09:00`, live upstream `origin/main` points to
+  merged `PR #176` commit `37c7c61`, and local `main` has been rebased onto
+  that head while still carrying stacked local meta-refresh commits awaiting
+  push.
 - The canonical ask surface remains `factory/logs/meta/asks.md`.
 - The checked-in maintainer workflow is `thoughts -> idea -> plan -> task`
   with `idea/task:to-complete`, same-name `consume`, `.claude/worktrees`
@@ -186,19 +191,57 @@
   `factory/inputs/**` remain operating state rather than canonical queue truth.
 - Open PR ownership now includes `#141` for checklist audit, `#167` for
   work-outcome localization, `#171` for workflow-graph spacing, and `#172` for
-  the same-trace guard, while `#168` remains the older open meta-refresh lane.
+  the same-trace guard, while `#175` is the freshest open meta-refresh lane.
 - The canonical ask surface currently says `for now no asks exists.`, so the
   earlier checklist, coverage, simplification, and queue-count backlog is
   withdrawn for this cycle.
 - The replay fixtures remain historical samples rather than current workflow
   truth, and one rejection payload is still quoted anomalously in the replay
   sample.
-- The previously queued ignored replay idea
-  `collapse-replay-safe-diagnostics-rehydration` is stale because merged PR
-  `#169` landed that exact lane on `main`.
-- The next maintainer-owned ignored queue slot should be the narrow smoke-suite
-  helper dedupe between `tests/functional/smoke/short_helpers_test.go` and
-  `tests/functional/smoke/service_lifecycle_smoke_long_test.go`.
+- The previously queued ignored bootstrap-portability idea was stale because
+  merged PR `#176` already landed that exact lane on `main`, and the stale
+  ignored residue has been pruned locally.
+- The older smoke-suite helper-dedupe seam previously recorded here is also
+  closed on live `main`; the shared owner now lives in
+  `tests/functional/smoke/service_pipeline_config_helpers_test.go`.
+- The fresh maintainer-owned ignored cleanup slot for this cycle is
+  `factory/inputs/idea/default/dedupe-replay-contract-tagged-helpers.md`.
+
+## 2026-05-09T15:05:05+09:00 - meta state refresh
+
+- `git pull --ff-only` failed immediately because local `main` was ahead `3`
+  and behind `3`; deferred branch reconciliation until after the repository
+  state and queue truth were re-validated.
+- Finished the branch reconciliation later in the same cycle with
+  `git pull --rebase --autostash origin main`, which replayed the local
+  meta-refresh stack cleanly onto `37c7c61` while preserving existing tracked
+  local edits.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`,
+  `factory/factory.json`, the backend and website standards, the tracked versus
+  ignored `factory/inputs/**` surface, and recent merged/open PR movement.
+- Confirmed the canonical ask surface still says `for now no asks exists.`, so
+  this cycle stays focused on worldview accuracy plus one narrow cleanup lane.
+- Re-validated that the tracked factory inboxes remain sentinel-only while the
+  visible local queue state is ignored operating residue rather than checked-in
+  contract.
+- Confirmed live upstream already merged `PR #176`
+  (`split-bootstrap-portability-functionallong-helpers`), so the local ignored
+  idea file for that lane had become stale and was pruned.
+- Re-checked the older smoke-helper seam recorded in the prior summary and
+  found it was also stale on live code: the shared helper owner already exists
+  in `tests/functional/smoke/service_pipeline_config_helpers_test.go`, so that
+  lane must not be re-queued.
+- Used a delegated explorer plus direct code reads to choose the next narrow
+  non-overlapping cleanup seam in `tests/functional/replay_contracts/`:
+  `short_helpers_test.go` and
+  `replay_record_end_to_end_long_test.go` duplicate the same helper logic
+  across default and `functionallong` build-tag lanes.
+- Wrote one fresh standalone cleanup idea to
+  `factory/inputs/idea/default/dedupe-replay-contract-tagged-helpers.md`
+  asking for one shared replay-contract helper owner plus deadcode-baseline
+  cleanup.
 
 ## 2026-05-07T05:03:44.1967849-07:00 - meta state refresh
 

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -164,6 +164,9 @@
 - When a helper still carries an explicitly backwards-compatible variadic
   parameter but the live production caller already passes one concrete explicit
   value, prefer deleting the shim over preserving two call shapes.
+- When deadcode flags an untagged test helper as unreachable, check whether its
+  only callers live behind `//go:build functionallong`; if so, move the helper
+  behind the same build tag instead of accepting permanent baseline noise.
 
 ## Current Summary
 
@@ -2286,4 +2289,65 @@
   - When short and `functionallong` test lanes define the same factory-config
     builder, prefer one shared helper owner so fixture drift cannot hide behind
     build tags.
+---
+
+## 2026-05-09T14:02:51+09:00 - meta state refresh
+
+- Re-ran `git pull --ff-only` and confirmed the repository was already current
+  with live `origin/main`, while local `main` still sat ahead with stacked
+  meta-only refresh commits and an open replacement meta PR `#175`.
+- Re-read `factory/logs/meta/view.md`, `factory/logs/meta/progress.txt`,
+  `factory/logs/meta/asks.md`, `factory/logs/agent-fails.json`,
+  `factory/logs/agent-fails.replay.json`, `factory/README.md`,
+  `factory/factory.json`, the code-review standard, the backend and website
+  standards, the tracked-versus-ignored `factory/inputs/**` surface, open PR
+  ownership, recent git history, and live code under `tests/functional/` and
+  `pkg/`.
+- Confirmed the canonical ask surface still says `for now no asks exists.`, so
+  no customer lane displaced the cleanup decision this cycle.
+- Revalidated queue truth with `git ls-files factory/inputs` and
+  `find factory/inputs -maxdepth 3 -type f`, confirming the checked-in inboxes
+  remain sentinel-only and that the new cleanup request belongs only in the
+  ignored operating queue.
+- Used one delegated explorer to reconcile PR ownership and confirmed `PR #175`
+  supersedes `PR #173` plus the older still-open meta-refresh stack on the same
+  two tracked files, while active non-meta ownership remains isolated to
+  `PR #141`, `PR #167`, `PR #171`, and `PR #172`.
+- Validated one broader delegated duplication seam in
+  `pkg/factory/projections/world_view_work_item_refs.go` versus
+  `pkg/api/workstation_request_projection.go`, but left it unqueued because it
+  is materially wider than the best deadcode cleanup available right now.
+- Chose one narrower cleanup lane from direct code reads plus the deadcode
+  baseline: bootstrap-portability helper functions are reported unreachable
+  only because long-only callers live behind `//go:build functionallong` while
+  the helpers themselves still compile in the default lane.
+- Queued one ignored standalone idea at
+  `factory/inputs/idea/default/split-bootstrap-portability-functionallong-helpers.md`
+  to move those helpers behind matching build tags and prune the resulting
+  deadcode-baseline noise.
+- Ran `go test ./cmd/deadcodecheck` and confirmed the command-owner coverage
+  seam recorded earlier is now obsolete on live `main` (`97.7%` statements),
+  so it should not be treated as an active next cleanup lane anymore.
+- Ran `go test ./tests/functional/bootstrap_portability/...` successfully.
+- Ran `go test -tags functionallong ./tests/functional/bootstrap_portability/...`
+  and confirmed the full tagged suite already fails on unrelated existing
+  fixture/config drift (`promptTemplate` rejection in current-factory
+  portability fixtures and missing AGENTS frontmatter in the expand/flatten
+  portability sweep), so the queued cleanup keeps full long-lane repair out of
+  scope.
+- Files changed:
+  - `factory/logs/meta/view.md`
+  - `factory/logs/meta/progress.txt`
+  - added ignored idea
+    `factory/inputs/idea/default/split-bootstrap-portability-functionallong-helpers.md`
+- **Learnings for future iterations:**
+  - When the same two meta-doc files are already owned by multiple open
+    meta-refresh PRs, treat only the freshest worldview branch as current lane
+    ownership and treat the older stack as superseded residue.
+  - If long-only functional helpers live in untagged `_test.go` files, the
+    right cleanup is to align helper build tags with their callers rather than
+    preserving deadcode-baseline entries forever.
+  - Re-check old coverage-driven backlog notes against live commands before
+    dispatching them; the repo-owned gate may already have been raised by a
+    later merge.
 ---

--- a/factory/logs/meta/progress.txt
+++ b/factory/logs/meta/progress.txt
@@ -135,6 +135,9 @@
 - When `go test -coverpkg` appends `in <package list>` after
   `coverage: ... of statements`, verify the parser against the full live line
   shape; simplified test fixtures can falsely suggest the gate is complete.
+- When `go test -coverpkg` reports a backend-owned package at `0.0%` in the
+  package summary, treat that as package-local zero coverage even if the
+  aggregate coverage profile shows transitive hits from other packages' tests.
 - When a repo-owned functional-lane command already has the thin entrypoint
   seam covered, inspect the same package next for untested `main` error paths,
   `failf` exit behavior, and wrapped discovery or execution failures before
@@ -194,9 +197,10 @@
   residue rather than checked-in queue truth.
 - Open PR ownership now includes `#141` for checklist audit, `#167` for
   work-outcome localization, `#171` for workflow-graph spacing, and `#172` for
-  the same-trace guard, while `#175` is the freshest open meta-refresh lane.
+  the same-trace guard, while `#178` is the freshest open meta-refresh lane
+  and `#179` owns the live `gocoveragecheck` zero-coverage fix.
 - `#141` also touches the meta-doc pair, so meta-refresh work is not isolated
-  to the `#175` stack.
+  to the open meta-refresh stack.
 - The canonical ask surface on live `main` is active again and currently asks
   for external-checklist conformance, stronger backend and website coverage,
   and ongoing simplification.
@@ -2430,4 +2434,46 @@
   - Re-check old coverage-driven backlog notes against live commands before
     dispatching them; the repo-owned gate may already have been raised by a
     later merge.
+---
+
+## 2026-05-09T17:04:00+09:00 - meta state refresh
+
+- Re-ran `git pull --ff-only` and confirmed the repo was already current with
+  `origin/main` at merged `PR #177` commit `ca69cbc`.
+- Re-read the canonical maintainer state files, `factory/README.md`,
+  `factory/factory.json`, the backend standard, current `factory/inputs/**`
+  state, and live `cmd/gocoveragecheck` code and tests.
+- Verified the external checklist repo still exposes the same checked-in
+  top-level checklist files referenced by the ask:
+  `backend-development-checklist.md` and
+  `website-development-checklist.md`.
+- Used delegated repo inspection to verify the highest-value narrow seam
+  remains the backend coverage gate in `cmd/gocoveragecheck`, but also to
+  confirm that seam is already staged locally in the ignored idea inbox and is
+  already owned by open `PR #179`.
+- Ran `go run ./cmd/gocoveragecheck -min 80 -timeout 300s` and confirmed the
+  live false-pass still exists: the command exits successfully at `86.6%`
+  total coverage while printing `0.0%` package-summary lines for
+  `pkg/apisurface`, `pkg/buffers`, and `pkg/cli/default`.
+- Read the open `ralph/fix-gocoveragecheck-zero-coverage-report-gap` branch
+  diff against `origin/main` and confirmed `PR #179` is the exact non-
+  overlapping worker lane needed here; it stays local to
+  `cmd/gocoveragecheck/main.go` and `cmd/gocoveragecheck/main_test.go`.
+- Chose not to dispatch a second cleanup idea this cycle because doing so
+  would duplicate the already-open `PR #179` lane instead of increasing
+  throughput.
+- Updated the world model so `PR #178` is the freshest open meta-refresh lane
+  and `PR #179` is the active backend coverage-fix owner.
+- Files changed:
+  - `factory/logs/meta/view.md`
+  - `factory/logs/meta/progress.txt`
+- **Learnings for future iterations:**
+  - Before queueing a cleanup from ignored `factory/inputs/**` residue, check
+    whether the exact idea has already advanced into an open worker PR.
+  - In this repo's backend coverage lane, package-summary `0.0%` under
+    `go test -coverpkg` is stronger evidence of package-local ownership gaps
+    than aggregate profile hits from other packages' tests.
+  - When the external checklist ask is already owned by an audit PR, re-verify
+    only enough of the source repository to keep the world model current and
+    avoid spawning an overlapping second audit lane.
 ---

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,9 +2,9 @@
 
 ## world state
 
-- as of `2026-05-09T12:03:55+09:00`, live upstream `origin/main` points to
-  `bc1e149` after merged PR `#170` (`weird-work-names`) and merged PR `#169`
-  (`collapse-replay-safe-diagnostics-rehydration`)
+- as of `2026-05-09T12:06:06+09:00`, local `HEAD` on `main` and live upstream
+  `origin/main` both point to `e3162f4` after the meta merge-and-refresh push
+  for this cycle
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - the current canonical local ask file says there are no active customer asks:
   `for now no asks exists.`
@@ -84,8 +84,8 @@
 - `PR #171` owns the dashboard-shell and workflow-graph padding lane
 - `PR #172` owns the same-trace guard lane across config, petri, API, and
   functional coverage
-- `PR #168` still owns the previously opened meta-refresh branch for the older
-  worldview
+- the previously opened meta-refresh branches such as `PR #168` now reflect an
+  older worldview than live `main`
 - the replay diagnostics dedupe lane is closed on live `main` through merged
   `PR #169`, so it should not remain in the ignored inbox
 

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,11 +2,12 @@
 
 ## world state
 
-- as of `2026-05-09T16:03:49+09:00`, live `origin/main` points at merged
+- as of `2026-05-09T17:04:00+09:00`, live `origin/main` points at merged
   `PR #177` commit `ca69cbc`, which closed the replay-contract tagged-helper
   cleanup after merged `PR #176` and merged `PR #174`
-- local `main` has been rebased onto `origin/main` during this cycle and is
-  now ahead only by the local meta-refresh commit stack
+- local `main`, `meta-refresh-world-state-20260509-160349`, and
+  `fix-gocoveragecheck-zero-coverage-report-gap` currently point at the same
+  local meta-refresh stack, while `origin/main` remains at `ca69cbc`
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - the canonical ask file on live `main` is active again; it currently asks for
   external-checklist conformance work, stronger backend and website coverage,
@@ -45,8 +46,8 @@
 - the visible local ignored idea surface still contains one unrelated PRD-style
   residue:
   `factory/inputs/idea/default/website-edit-running-factory-workstations.md`
-- this cycle replaces the stale replay-helper residue with one fresh
-  maintainer-owned standalone cleanup idea:
+- the visible local ignored idea surface also includes one active
+  maintainer-owned cleanup request already advanced into an open worker lane:
   `factory/inputs/idea/default/fix-gocoveragecheck-zero-coverage-report-gap.md`
 
 ## customer-ask truth
@@ -69,7 +70,9 @@
   - `#170` `weird-work-names`
   - `#169` `collapse-replay-safe-diagnostics-rehydration`
   - `#166` `simplify-loaded-runtime-definition-lookups`
-- `gh pr list --state open` on `2026-05-09` still reports:
+- `gh pr list --state open` on `2026-05-09` now reports:
+  - `#179` `fix-gocoveragecheck-zero-coverage-report-gap`
+  - `#178` `docs: refresh meta world state`
   - `#175` `docs: refresh meta world state`
   - `#173` `docs: refresh meta world state`
   - `#172` `same-trace`
@@ -83,11 +86,12 @@
 
 - `PR #141` owns the repository-wide external checklist audit lane and also
   touches the meta-doc pair, so it is not isolated from worldview updates
+- `PR #179` owns the live `cmd/gocoveragecheck` zero-coverage-gap lane
 - `PR #167` owns the current `ui/src/features/work-outcome/*` localization lane
 - `PR #171` owns the dashboard-shell and workflow-graph padding lane
 - `PR #172` owns the same-trace guard lane across config, petri, API, and
   functional coverage
-- `PR #175` is still the freshest open meta-refresh branch; the older open
+- `PR #178` is now the freshest open meta-refresh branch; the older open
   meta-refresh PRs are stale duplicates on the same file pair
 - the replay-helper lane is closed on live `main` through merged `PR #177`
 - the bootstrap-portability helper split lane is closed on live `main` through
@@ -107,8 +111,7 @@
 
 ## current maintainer decision
 
-- this cycle queues one new cleanup request:
-  `fix-gocoveragecheck-zero-coverage-report-gap`
+- this cycle does not queue a new cleanup request
 - reason:
   - the active customer asks explicitly prioritize stronger backend coverage
     evidence and code quality simplification
@@ -119,11 +122,11 @@
   - that means the repo-owned backend coverage gate is currently overstating
     quality and can let zero-coverage backend packages pass the customer-facing
     lane
-  - the exact seam is narrow and local to `cmd/gocoveragecheck` plus its tests,
-    with no overlap with open PR ownership in `#141`, `#167`, `#171`, or
-    `#172`
-  - fixing the gate is higher leverage than a small test-helper dedupe because
-    it improves the truthfulness of the repository's existing quality signal
+  - the exact seam is narrow and local to `cmd/gocoveragecheck` plus its tests
+  - that seam is already owned by open `PR #179`, which changes only
+    `cmd/gocoveragecheck/main.go` and `cmd/gocoveragecheck/main_test.go`
+  - creating another idea over the same lane would duplicate in-flight work
+    instead of improving the queue
 
 ## theory of mind
 
@@ -143,3 +146,6 @@
 - when the repo-owned coverage command prints backend packages at `0.0%` while
   still exiting successfully, prefer tightening that gate before queueing a
   broader package-by-package test-authoring campaign
+- when `go test -coverpkg` summary output says a backend-owned package is at
+  `0.0%`, treat that as package-local zero coverage even if the aggregate
+  profile shows transitive hits from other packages' tests

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,12 +2,12 @@
 
 ## world state
 
-- as of `2026-05-09T17:04:00+09:00`, live `origin/main` points at merged
+- as of `2026-05-09T18:03:23+09:00`, live `origin/main` points at merged
   `PR #177` commit `ca69cbc`, which closed the replay-contract tagged-helper
   cleanup after merged `PR #176` and merged `PR #174`
-- local `main`, `meta-refresh-world-state-20260509-160349`, and
-  `fix-gocoveragecheck-zero-coverage-report-gap` currently point at the same
-  local meta-refresh stack, while `origin/main` remains at `ca69cbc`
+- local `main` remains on the older local meta-refresh stack at `71796ff`
+  while the current branch `meta-refresh-world-state-20260509-160349` is at
+  `ef7f189`; both are still ahead of `origin/main`
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - the canonical ask file on live `main` is active again; it currently asks for
   external-checklist conformance work, stronger backend and website coverage,
@@ -40,15 +40,15 @@
   - `factory/inputs/thoughts/default/.gitkeep`
 - `.gitignore` still keeps live workflow submissions under `factory/inputs/**`
   out of normal commits except for those sentinel paths
-- the ignored replay-helper idea
-  `factory/inputs/idea/default/dedupe-replay-contract-tagged-helpers.md` is
-  stale because merged `PR #177` landed that exact lane on `main`
 - the visible local ignored idea surface still contains one unrelated PRD-style
   residue:
   `factory/inputs/idea/default/website-edit-running-factory-workstations.md`
 - the visible local ignored idea surface also includes one active
   maintainer-owned cleanup request already advanced into an open worker lane:
   `factory/inputs/idea/default/fix-gocoveragecheck-zero-coverage-report-gap.md`
+- the visible local ignored idea surface now also includes one new
+  maintainer-owned simplification request not claimed by an open PR:
+  `factory/inputs/idea/default/simplify-cron-watcher-runtime-lookup-width.md`
 
 ## customer-ask truth
 
@@ -93,6 +93,8 @@
   functional coverage
 - `PR #178` is now the freshest open meta-refresh branch; the older open
   meta-refresh PRs are stale duplicates on the same file pair
+- no open PR currently owns `pkg/service/cron_watcher.go` or the adjacent
+  cron-watcher simplification seam
 - the replay-helper lane is closed on live `main` through merged `PR #177`
 - the bootstrap-portability helper split lane is closed on live `main` through
   merged `PR #176`
@@ -111,22 +113,23 @@
 
 ## current maintainer decision
 
-- this cycle does not queue a new cleanup request
+- this cycle queues one new cleanup request
 - reason:
-  - the active customer asks explicitly prioritize stronger backend coverage
-    evidence and code quality simplification
-  - a live `go run ./cmd/gocoveragecheck -min 80 -timeout 300s` run on
-    `2026-05-09` printed `0.0%` coverage for
-    `pkg/apisurface`, `pkg/buffers`, and `pkg/cli/default`
-    but still exited successfully with `Go coverage 86.6% meets minimum 80.0%`
-  - that means the repo-owned backend coverage gate is currently overstating
-    quality and can let zero-coverage backend packages pass the customer-facing
-    lane
-  - the exact seam is narrow and local to `cmd/gocoveragecheck` plus its tests
-  - that seam is already owned by open `PR #179`, which changes only
-    `cmd/gocoveragecheck/main.go` and `cmd/gocoveragecheck/main_test.go`
-  - creating another idea over the same lane would duplicate in-flight work
-    instead of improving the queue
+  - the active customer asks still prioritize simplification and reduction of
+    redundant structures alongside coverage work
+  - the backend coverage-gate seam in `cmd/gocoveragecheck` remains important
+    but is already owned by open `PR #179`, so re-queueing it would duplicate
+    in-flight work
+  - direct code reads in `pkg/service/cron_watcher.go` and
+    `pkg/service/factory.go` show that `startCronWatchersForRuntime` still
+    depends on the wider `interfaces.RuntimeConfigLookup` even though
+    watcher-start already derives workflow identity from `factoryDir` and the
+    downstream helpers only need workstation lookup behavior
+  - the seam is narrow, implementation-ready, aligned with the checked-in
+    workstation guidance, and already covered by service-layer watcher tests
+  - the queued request is
+    `factory/inputs/idea/default/simplify-cron-watcher-runtime-lookup-width.md`
+    and it does not overlap any currently open PR file ownership
 
 ## theory of mind
 
@@ -143,6 +146,9 @@
 - treat delegated explorer suggestions as hypotheses; re-verify them against
   live `main` before dispatching new cleanup work because recent merges can
   invalidate an otherwise plausible seam within the same cycle
+- when many open PRs all touch `factory/logs/meta/*`, treat meta-doc edits as
+  a self-overlap hotspot and keep new cleanup dispatches off those tracked
+  files whenever possible
 - when the repo-owned coverage command prints backend packages at `0.0%` while
   still exiting successfully, prefer tightening that gate before queueing a
   broader package-by-package test-authoring campaign

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,26 +2,22 @@
 
 ## world state
 
-- as of `2026-05-09T15:05:05+09:00`, live `origin/main` points at merged
-  `PR #176` commit `37c7c61`, which pulled in
-  `split-bootstrap-portability-functionallong-helpers` after the earlier
-  merged `PR #174` service-smoke helper cleanup
-- after this cycle's `git pull --rebase --autostash origin main`, local
-  `main` is rebased onto `origin/main` and still carries stacked local
-  meta-refresh commits waiting to be pushed
+- as of `2026-05-09T16:03:49+09:00`, live `origin/main` points at merged
+  `PR #177` commit `ca69cbc`, which closed the replay-contract tagged-helper
+  cleanup after merged `PR #176` and merged `PR #174`
+- local `main` has been rebased onto `origin/main` during this cycle and is
+  now ahead only by the local meta-refresh commit stack
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
-- the current canonical local ask file still says there are no active customer
-  asks: `for now no asks exists.`
+- the canonical ask file on live `main` is active again; it currently asks for
+  external-checklist conformance work, stronger backend and website coverage,
+  and ongoing code simplification
 - the tracked maintainer workflow inputs remain sentinel-only under
   `factory/inputs/**`; live work items there are ignored operating state
-- the local worktree is still dirty from tracked local edits in
-  `factory/logs/meta/asks.md` and `factory/workers/workspace-setup/AGENTS.md`;
-  treat those as existing local state, not as noise to revert
 
 ## workflow truth
 
-- `factory/factory.json` still defines five work types: `thoughts`, `idea`,
-  `plan`, `task`, and `cron-triggers`
+- `factory/factory.json` defines five work types: `thoughts`, `idea`, `plan`,
+  `task`, and `cron-triggers`
 - the checked-in maintainer loop on live `main` is:
   `thoughts:init -> ideafy -> thoughts:complete`
   `idea:init -> plan -> idea:to-complete + plan:init`
@@ -43,64 +39,61 @@
   - `factory/inputs/thoughts/default/.gitkeep`
 - `.gitignore` still keeps live workflow submissions under `factory/inputs/**`
   out of normal commits except for those sentinel paths
-- the previously queued ignored idea
-  `factory/inputs/idea/default/split-bootstrap-portability-functionallong-helpers.md`
-  is now stale because merged `PR #176` landed that exact lane on `main`
-- that stale ignored idea residue has now been pruned locally
+- the ignored replay-helper idea
+  `factory/inputs/idea/default/dedupe-replay-contract-tagged-helpers.md` is
+  stale because merged `PR #177` landed that exact lane on `main`
 - the visible local ignored idea surface still contains one unrelated PRD-style
   residue:
   `factory/inputs/idea/default/website-edit-running-factory-workstations.md`
-- this cycle adds one fresh maintainer-owned standalone cleanup idea:
-  `factory/inputs/idea/default/dedupe-replay-contract-tagged-helpers.md`
+- this cycle replaces the stale replay-helper residue with one fresh
+  maintainer-owned standalone cleanup idea:
+  `factory/inputs/idea/default/fix-gocoveragecheck-zero-coverage-report-gap.md`
 
 ## customer-ask truth
 
-- the local canonical ask file continues to withdraw the earlier checklist,
-  coverage, simplification, and minimum-concurrency backlog for this cycle
-- there is therefore no active customer-directed requirement right now to keep
-  a minimum number of simultaneous lanes in flight
-- open PRs can still inform overlap checks, but they do not become asks unless
-  `factory/logs/meta/asks.md` reintroduces them
+- the active canonical ask backlog currently includes:
+  - repository conformance work against the linked website and backend
+    checklists
+  - backend functional coverage toward `90%` of non-generated `pkg/**`
+  - website test coverage toward `90%` of non-generated `ui/src/**`
+  - ongoing simplification, dead-code removal, and duplication cleanup
+- there is no current instruction in the live ask file to keep a minimum
+  number of simultaneous cleanup lanes in flight
 
 ## recent repo movement
 
 - recent merged PRs on `main` now include:
+  - `#177` `dedupe-replay-contract-tagged-helpers`
   - `#176` `split-bootstrap-portability-functionallong-helpers`
   - `#174` `dedupe-service-smoke-pipeline-config-builders`
   - `#170` `weird-work-names`
   - `#169` `collapse-replay-safe-diagnostics-rehydration`
   - `#166` `simplify-loaded-runtime-definition-lookups`
-  - `#165` `localize-workflow-activity-graph-import-copy`
-- `gh pr list --state open` on `2026-05-09` reports:
+- `gh pr list --state open` on `2026-05-09` still reports:
   - `#175` `docs: refresh meta world state`
   - `#173` `docs: refresh meta world state`
   - `#172` `same-trace`
   - `#171` `workflow-graph-padding`
   - `#167` `localize-work-outcome-trend-cards-copy`
-  - `#163` `docs: refresh meta world state`
-  - `#152` `docs: refresh meta world state`
-  - `#145` `docs: refresh meta world state`
-  - `#143` `docs: refresh meta world state`
+  - `#163`, `#152`, `#145`, `#143`, `#139`, `#123`, `#120`
+    `docs: refresh meta world state`
   - `#141` `audit-repository-against-2026-website-and-backend-checklists`
-  - `#139` `docs: refresh meta world state`
-  - `#123` `docs: refresh meta world state`
-  - `#120` `docs: refresh meta world state`
 
 ## open-lane truth
 
-- `PR #141` still owns the repository-wide external checklist audit lane
+- `PR #141` owns the repository-wide external checklist audit lane and also
+  touches the meta-doc pair, so it is not isolated from worldview updates
 - `PR #167` owns the current `ui/src/features/work-outcome/*` localization lane
 - `PR #171` owns the dashboard-shell and workflow-graph padding lane
 - `PR #172` owns the same-trace guard lane across config, petri, API, and
   functional coverage
-- `PR #175` is the freshest open meta-refresh branch and supersedes `PR #173`
-  plus the older still-open meta-refresh PR stack on the same file pair
+- `PR #175` is still the freshest open meta-refresh branch; the older open
+  meta-refresh PRs are stale duplicates on the same file pair
+- the replay-helper lane is closed on live `main` through merged `PR #177`
 - the bootstrap-portability helper split lane is closed on live `main` through
-  merged `PR #176`, so it must not be re-queued
-- the older smoke-helper dedupe lane is also closed on live `main` through
-  merged `PR #174`; the prior meta note that still treated it as the next seam
-  was stale because the shared helper owner now lives in
-  `tests/functional/smoke/service_pipeline_config_helpers_test.go`
+  merged `PR #176`
+- the smoke-helper dedupe lane is closed on live `main` through merged
+  `PR #174`
 
 ## replay truth
 
@@ -115,30 +108,31 @@
 ## current maintainer decision
 
 - this cycle queues one new cleanup request:
-  `dedupe-replay-contract-tagged-helpers`
+  `fix-gocoveragecheck-zero-coverage-report-gap`
 - reason:
-  - the canonical ask surface is still empty, so cleanup choice must be
-    justified only by live repo state and non-overlap with active PR ownership
-  - direct reads show `tests/functional/replay_contracts/short_helpers_test.go`
-    and `tests/functional/replay_contracts/replay_record_end_to_end_long_test.go`
-    still duplicate the same replay helper logic across default and
-    `functionallong` lanes
-  - `docs/internal/development/deadcode-baseline.txt` still flags the
-    short-only helper owner as unreachable in one build mode, which is now
-    noise caused by split helper ownership rather than by real dead code
-  - the affected files are narrow and local to one functional test package, so
-    the cleanup does not overlap active ownership in `PR #141`, `PR #167`,
-    `PR #171`, or `PR #172`
-  - consolidating the helpers into one shared owner removes duplication and
-    deadcode-baseline noise without changing backend, API, CLI, or UI behavior
+  - the active customer asks explicitly prioritize stronger backend coverage
+    evidence and code quality simplification
+  - a live `go run ./cmd/gocoveragecheck -min 80 -timeout 300s` run on
+    `2026-05-09` printed `0.0%` coverage for
+    `pkg/apisurface`, `pkg/buffers`, and `pkg/cli/default`
+    but still exited successfully with `Go coverage 86.6% meets minimum 80.0%`
+  - that means the repo-owned backend coverage gate is currently overstating
+    quality and can let zero-coverage backend packages pass the customer-facing
+    lane
+  - the exact seam is narrow and local to `cmd/gocoveragecheck` plus its tests,
+    with no overlap with open PR ownership in `#141`, `#167`, `#171`, or
+    `#172`
+  - fixing the gate is higher leverage than a small test-helper dedupe because
+    it improves the truthfulness of the repository's existing quality signal
 
 ## theory of mind
 
 - the authoritative world model comes from live upstream git state, the
   checked-in workflow contract, the canonical ask file, current PR ownership,
-  ignored queue residue, and direct code reads together
-- when `factory/logs/meta/asks.md` changes locally, treat that edit as the
-  immediate routing truth even if it withdraws a previously active backlog
+  ignored queue residue, and direct command/code reads together
+- stale local summaries do not override live `main`; when the canonical ask
+  file on upstream reintroduces backlog work, treat older “no asks” notes as
+  invalid immediately
 - reason about `factory/inputs/**` in two layers:
   checked-in contract versus ignored operating state
 - prune ignored local idea files once their owning PR merges; otherwise the
@@ -146,13 +140,6 @@
 - treat delegated explorer suggestions as hypotheses; re-verify them against
   live `main` before dispatching new cleanup work because recent merges can
   invalidate an otherwise plausible seam within the same cycle
-- when an untagged test helper is only called from `functionallong` suites,
-  treat the build-tag mismatch as the real deadcode seam and move the helper
-  behind matching tags instead of normalizing the noise into the baseline
-- when the same helper logic exists in both default-tag and `functionallong`
-  replay-contract files, prefer one shared helper owner that both build modes
-  compile instead of preserving duplicated assertions across the tag split
-- when multiple open meta-refresh PRs touch only
-  `factory/logs/meta/view.md` and `factory/logs/meta/progress.txt`, the newest
-  live worldview supersedes the older stack rather than creating parallel lane
-  ownership
+- when the repo-owned coverage command prints backend packages at `0.0%` while
+  still exiting successfully, prefer tightening that gate before queueing a
+  broader package-by-package test-authoring campaign

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,22 +2,22 @@
 
 ## world state
 
-- as of `2026-05-09T12:06:06+09:00`, local `HEAD` on `main` and live upstream
-  `origin/main` both point to `e3162f4` after the meta merge-and-refresh push
-  for this cycle
+- as of `2026-05-09T13:05:17+09:00`, local `main` has been rebased onto live
+  `origin/main` at `74b874a` and then carries one local meta-refresh commit
+  `57076b3`
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
-- the current canonical local ask file says there are no active customer asks:
-  `for now no asks exists.`
+- the current canonical local ask file still says there are no active customer
+  asks: `for now no asks exists.`
 - the tracked maintainer workflow inputs remain sentinel-only under
   `factory/inputs/**`; live work items there are ignored operating state
-- the local worktree is dirty before this refresh from tracked local edits in
+- the local worktree is still dirty from tracked local edits in
   `factory/logs/meta/asks.md` and `factory/workers/workspace-setup/AGENTS.md`;
   treat those as existing local state, not as noise to revert
 
 ## workflow truth
 
-- `factory/factory.json` defines five work types: `thoughts`, `idea`, `plan`,
-  `task`, and `cron-triggers`
+- `factory/factory.json` still defines five work types: `thoughts`, `idea`,
+  `plan`, `task`, and `cron-triggers`
 - the checked-in maintainer loop on live `main` is:
   `thoughts:init -> ideafy -> thoughts:complete`
   `idea:init -> plan -> idea:to-complete + plan:init`
@@ -40,33 +40,32 @@
 - `.gitignore` still keeps live workflow submissions under `factory/inputs/**`
   out of normal commits except for those sentinel paths
 - the previously queued ignored idea
-  `factory/inputs/idea/default/collapse-replay-safe-diagnostics-rehydration.md`
-  is stale because its owning work merged through PR `#169`
-- after pruning that stale residue, the next maintainer-owned ignored backlog
-  slot should be a fresh standalone idea rather than a duplicate replay request
+  `factory/inputs/idea/default/dedupe-service-smoke-pipeline-config-builders.md`
+  was stale because merged PR `#174` landed that exact lane on `main`
+- that stale ignored idea residue has now been pruned locally so the operating
+  queue no longer points at already-merged work
 
 ## customer-ask truth
 
-- the local canonical ask file now withdraws the earlier checklist, coverage,
-  simplification, and minimum-concurrency backlog for this cycle
+- the local canonical ask file continues to withdraw the earlier checklist,
+  coverage, simplification, and minimum-concurrency backlog for this cycle
 - there is therefore no active customer-directed requirement right now to keep
   a minimum number of simultaneous lanes in flight
-- open PRs can still inform overlap checks, but they no longer count as
-  customer-required work unless the canonical ask file reintroduces them
+- open PRs can still inform overlap checks, but they do not become asks unless
+  `factory/logs/meta/asks.md` reintroduces them
 
 ## recent repo movement
 
 - recent merged PRs on `main` now include:
+  - `#174` `dedupe-service-smoke-pipeline-config-builders`
   - `#170` `weird-work-names`
   - `#169` `collapse-replay-safe-diagnostics-rehydration`
   - `#166` `simplify-loaded-runtime-definition-lookups`
   - `#165` `localize-workflow-activity-graph-import-copy`
-  - `#164` `localize-terminal-work-card-copy`
-  - `#162` `localize-dashboard-flow-axis-legend-copy`
 - `gh pr list --state open` on `2026-05-09` reports:
+  - `#173` `docs: refresh meta world state`
   - `#172` `same-trace`
   - `#171` `workflow-graph-padding`
-  - `#168` `docs: refresh meta world state`
   - `#167` `localize-work-outcome-trend-cards-copy`
   - `#163` `docs: refresh meta world state`
   - `#152` `docs: refresh meta world state`
@@ -84,10 +83,10 @@
 - `PR #171` owns the dashboard-shell and workflow-graph padding lane
 - `PR #172` owns the same-trace guard lane across config, petri, API, and
   functional coverage
-- the previously opened meta-refresh branches such as `PR #168` now reflect an
-  older worldview than live `main`
-- the replay diagnostics dedupe lane is closed on live `main` through merged
-  `PR #169`, so it should not remain in the ignored inbox
+- `PR #173` is the current open meta-refresh branch and is now older than the
+  live rebased local worldview again
+- the smoke helper dedupe lane is closed on live `main` through merged
+  `PR #174`, so it must not be re-queued
 
 ## replay truth
 
@@ -99,36 +98,32 @@
 - one replay rejection payload is still quoted oddly as `"\"<REJECTED>\"\n"`;
   treat that as fixture history rather than live workflow behavior
 
-## next cleanup candidate
+## current maintainer decision
 
-- the next maintainer-owned non-overlapping cleanup seam is service-smoke test
-  helper dedupe:
-  - `tests/functional/smoke/short_helpers_test.go` defines
-    `simpleServicePipelineConfig` and `twoStageServicePipelineConfig`
-  - `tests/functional/smoke/service_lifecycle_smoke_long_test.go` defines the
-    same two helpers again for the `functionallong` lane
-  - `tests/functional/smoke/service_config_override_alignment_test.go` already
-    consumes the short-lane shared helper, so the duplicate long-lane owner is
-    now the drift risk
-  - this is a narrow simplification lane that removes duplicated fixture
-    builders while preserving the observable service smoke behavior in both the
-    default and `functionallong` test lanes
-- that seam is not covered by open PRs `#141`, `#167`, `#168`, `#171`, or
-  `#172`
+- this cycle does not queue a new cleanup request
+- reason:
+  - the previously selected next cleanup seam already merged through `PR #174`
+  - the delegated explorer's replacement suggestions did not survive direct
+    code validation on live `main`
+  - `pkg/listeners/filewatcher.go` already rejects direct two-segment
+    `inputs/<work-type>/<file>` drops and tests cover the canonical
+    `default/`-channel-only contract
+  - `pkg/api/server.go` no longer carries a handwritten `/work` pagination shim
+    and the generated binding path already owns invalid `maxResults` rejection
+  - `pkg/replay/event_stream_artifact.go` still has in-repo test and
+    functional callers for the file-wrapper helpers, so that seam is not dead
 
 ## theory of mind
 
 - the authoritative world model comes from live upstream git state, the
   checked-in workflow contract, the canonical ask file, current PR ownership,
-  and direct code reads together
+  ignored queue residue, and direct code reads together
 - when `factory/logs/meta/asks.md` changes locally, treat that edit as the
   immediate routing truth even if it withdraws a previously active backlog
 - reason about `factory/inputs/**` in two layers:
   checked-in contract versus ignored operating state
 - prune ignored local idea files once their owning PR merges; otherwise the
-  local queue can preserve stale work that the live repo already finished
-- treat delegated explorer suggestions as provisional after a fast-forward or
-  merge; confirm the seam still exists on live `main` before re-queuing it
-- when one functional test lane already exposes shared fixture builders, prefer
-  reusing that owner across build-tag variants instead of keeping duplicated
-  config definitions in long and short suites
+  canonical inbox can preserve stale work that the live repo already finished
+- treat delegated explorer suggestions as hypotheses; re-verify them against
+  live `main` before dispatching new cleanup work because recent merges can
+  invalidate an otherwise plausible seam within the same cycle

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,9 +2,9 @@
 
 ## world state
 
-- as of `2026-05-09T13:05:17+09:00`, local `main` has been rebased onto live
-  `origin/main` at `74b874a` and then carries one local meta-refresh commit
-  `57076b3`
+- as of `2026-05-09T14:02:51+09:00`, live `origin/main` still points at
+  merged `PR #174` commit `74b874a`, while local `main` also carries stacked
+  meta-only refresh commits, including `c1b5823` on open `PR #175`
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - the current canonical local ask file still says there are no active customer
   asks: `for now no asks exists.`
@@ -44,6 +44,8 @@
   was stale because merged PR `#174` landed that exact lane on `main`
 - that stale ignored idea residue has now been pruned locally so the operating
   queue no longer points at already-merged work
+- the local ignored operating queue now contains one fresh standalone idea:
+  `factory/inputs/idea/default/split-bootstrap-portability-functionallong-helpers.md`
 
 ## customer-ask truth
 
@@ -63,6 +65,7 @@
   - `#166` `simplify-loaded-runtime-definition-lookups`
   - `#165` `localize-workflow-activity-graph-import-copy`
 - `gh pr list --state open` on `2026-05-09` reports:
+  - `#175` `docs: refresh meta world state`
   - `#173` `docs: refresh meta world state`
   - `#172` `same-trace`
   - `#171` `workflow-graph-padding`
@@ -83,8 +86,8 @@
 - `PR #171` owns the dashboard-shell and workflow-graph padding lane
 - `PR #172` owns the same-trace guard lane across config, petri, API, and
   functional coverage
-- `PR #173` is the current open meta-refresh branch and is now older than the
-  live rebased local worldview again
+- `PR #175` is the freshest open meta-refresh branch and supersedes `PR #173`
+  plus the older still-open meta-refresh PR stack on the same file pair
 - the smoke helper dedupe lane is closed on live `main` through merged
   `PR #174`, so it must not be re-queued
 
@@ -100,18 +103,23 @@
 
 ## current maintainer decision
 
-- this cycle does not queue a new cleanup request
+- this cycle queues one new cleanup request:
+  `split-bootstrap-portability-functionallong-helpers`
 - reason:
-  - the previously selected next cleanup seam already merged through `PR #174`
-  - the delegated explorer's replacement suggestions did not survive direct
-    code validation on live `main`
-  - `pkg/listeners/filewatcher.go` already rejects direct two-segment
-    `inputs/<work-type>/<file>` drops and tests cover the canonical
-    `default/`-channel-only contract
-  - `pkg/api/server.go` no longer carries a handwritten `/work` pagination shim
-    and the generated binding path already owns invalid `maxResults` rejection
-  - `pkg/replay/event_stream_artifact.go` still has in-repo test and
-    functional callers for the file-wrapper helpers, so that seam is not dead
+  - the canonical ask surface is still empty, so cleanup choice must be
+    justified only by live repo state and non-overlap with active PR ownership
+  - direct reads plus `docs/internal/development/deadcode-baseline.txt` show
+    bootstrap-portability helper functions reported as unreachable solely
+    because they live in always-built `_test.go` files while their only callers
+    sit behind `//go:build functionallong`
+  - the affected helpers are narrow and isolated to
+    `tests/functional/bootstrap_portability/*`, so the cleanup does not overlap
+    active ownership in `PR #141`, `PR #167`, `PR #171`, or `PR #172`
+  - moving those helpers behind matching build tags removes deadcode-baseline
+    noise without changing backend, API, CLI, or UI behavior
+  - the alternative duplicated projection seams found by a delegated explorer
+    remain real but broader, so they are lower priority than this tighter
+    deadcode cleanup
 
 ## theory of mind
 
@@ -127,3 +135,10 @@
 - treat delegated explorer suggestions as hypotheses; re-verify them against
   live `main` before dispatching new cleanup work because recent merges can
   invalidate an otherwise plausible seam within the same cycle
+- when an untagged test helper is only called from `functionallong` suites,
+  treat the build-tag mismatch as the real deadcode seam and move the helper
+  behind matching tags instead of normalizing the noise into the baseline
+- when multiple open meta-refresh PRs touch only
+  `factory/logs/meta/view.md` and `factory/logs/meta/progress.txt`, the newest
+  live worldview supersedes the older stack rather than creating parallel lane
+  ownership

--- a/factory/logs/meta/view.md
+++ b/factory/logs/meta/view.md
@@ -2,9 +2,13 @@
 
 ## world state
 
-- as of `2026-05-09T14:02:51+09:00`, live `origin/main` still points at
-  merged `PR #174` commit `74b874a`, while local `main` also carries stacked
-  meta-only refresh commits, including `c1b5823` on open `PR #175`
+- as of `2026-05-09T15:05:05+09:00`, live `origin/main` points at merged
+  `PR #176` commit `37c7c61`, which pulled in
+  `split-bootstrap-portability-functionallong-helpers` after the earlier
+  merged `PR #174` service-smoke helper cleanup
+- after this cycle's `git pull --rebase --autostash origin main`, local
+  `main` is rebased onto `origin/main` and still carries stacked local
+  meta-refresh commits waiting to be pushed
 - the canonical maintainer ask surface remains `factory/logs/meta/asks.md`
 - the current canonical local ask file still says there are no active customer
   asks: `for now no asks exists.`
@@ -40,12 +44,14 @@
 - `.gitignore` still keeps live workflow submissions under `factory/inputs/**`
   out of normal commits except for those sentinel paths
 - the previously queued ignored idea
-  `factory/inputs/idea/default/dedupe-service-smoke-pipeline-config-builders.md`
-  was stale because merged PR `#174` landed that exact lane on `main`
-- that stale ignored idea residue has now been pruned locally so the operating
-  queue no longer points at already-merged work
-- the local ignored operating queue now contains one fresh standalone idea:
   `factory/inputs/idea/default/split-bootstrap-portability-functionallong-helpers.md`
+  is now stale because merged `PR #176` landed that exact lane on `main`
+- that stale ignored idea residue has now been pruned locally
+- the visible local ignored idea surface still contains one unrelated PRD-style
+  residue:
+  `factory/inputs/idea/default/website-edit-running-factory-workstations.md`
+- this cycle adds one fresh maintainer-owned standalone cleanup idea:
+  `factory/inputs/idea/default/dedupe-replay-contract-tagged-helpers.md`
 
 ## customer-ask truth
 
@@ -59,6 +65,7 @@
 ## recent repo movement
 
 - recent merged PRs on `main` now include:
+  - `#176` `split-bootstrap-portability-functionallong-helpers`
   - `#174` `dedupe-service-smoke-pipeline-config-builders`
   - `#170` `weird-work-names`
   - `#169` `collapse-replay-safe-diagnostics-rehydration`
@@ -88,8 +95,12 @@
   functional coverage
 - `PR #175` is the freshest open meta-refresh branch and supersedes `PR #173`
   plus the older still-open meta-refresh PR stack on the same file pair
-- the smoke helper dedupe lane is closed on live `main` through merged
-  `PR #174`, so it must not be re-queued
+- the bootstrap-portability helper split lane is closed on live `main` through
+  merged `PR #176`, so it must not be re-queued
+- the older smoke-helper dedupe lane is also closed on live `main` through
+  merged `PR #174`; the prior meta note that still treated it as the next seam
+  was stale because the shared helper owner now lives in
+  `tests/functional/smoke/service_pipeline_config_helpers_test.go`
 
 ## replay truth
 
@@ -104,22 +115,22 @@
 ## current maintainer decision
 
 - this cycle queues one new cleanup request:
-  `split-bootstrap-portability-functionallong-helpers`
+  `dedupe-replay-contract-tagged-helpers`
 - reason:
   - the canonical ask surface is still empty, so cleanup choice must be
     justified only by live repo state and non-overlap with active PR ownership
-  - direct reads plus `docs/internal/development/deadcode-baseline.txt` show
-    bootstrap-portability helper functions reported as unreachable solely
-    because they live in always-built `_test.go` files while their only callers
-    sit behind `//go:build functionallong`
-  - the affected helpers are narrow and isolated to
-    `tests/functional/bootstrap_portability/*`, so the cleanup does not overlap
-    active ownership in `PR #141`, `PR #167`, `PR #171`, or `PR #172`
-  - moving those helpers behind matching build tags removes deadcode-baseline
-    noise without changing backend, API, CLI, or UI behavior
-  - the alternative duplicated projection seams found by a delegated explorer
-    remain real but broader, so they are lower priority than this tighter
-    deadcode cleanup
+  - direct reads show `tests/functional/replay_contracts/short_helpers_test.go`
+    and `tests/functional/replay_contracts/replay_record_end_to_end_long_test.go`
+    still duplicate the same replay helper logic across default and
+    `functionallong` lanes
+  - `docs/internal/development/deadcode-baseline.txt` still flags the
+    short-only helper owner as unreachable in one build mode, which is now
+    noise caused by split helper ownership rather than by real dead code
+  - the affected files are narrow and local to one functional test package, so
+    the cleanup does not overlap active ownership in `PR #141`, `PR #167`,
+    `PR #171`, or `PR #172`
+  - consolidating the helpers into one shared owner removes duplication and
+    deadcode-baseline noise without changing backend, API, CLI, or UI behavior
 
 ## theory of mind
 
@@ -138,6 +149,9 @@
 - when an untagged test helper is only called from `functionallong` suites,
   treat the build-tag mismatch as the real deadcode seam and move the helper
   behind matching tags instead of normalizing the noise into the baseline
+- when the same helper logic exists in both default-tag and `functionallong`
+  replay-contract files, prefer one shared helper owner that both build modes
+  compile instead of preserving duplicated assertions across the tag split
 - when multiple open meta-refresh PRs touch only
   `factory/logs/meta/view.md` and `factory/logs/meta/progress.txt`, the newest
   live worldview supersedes the older stack rather than creating parallel lane


### PR DESCRIPTION
## Summary
- refresh the meta worldview to match live upstream state and the active canonical ask file
- record the current  zero-coverage gate gap and queue a fresh ignored cleanup idea for it
- prune the stale replay-helper idea residue from the local maintainer inbox

## Verification
- gh pr list / gh pr list --state merged
- go run ./cmd/gocoveragecheck -min 80 -timeout 300s
- git ls-files 'factory/inputs/**'
