### PR TITLE
simplify-cron-watcher-runtime-lookup-width

### DIFF
--- a/pkg/service/cron_watcher.go
+++ b/pkg/service/cron_watcher.go
@@ -33,7 +33,7 @@ func (fs *FactoryService) startCronWatchersForRuntime(
 	sidecars *sync.WaitGroup,
 	factoryDir string,
 	factoryCfg *interfaces.FactoryConfig,
-	runtimeCfg interfaces.RuntimeConfigLookup,
+	runtimeCfg interfaces.RuntimeWorkstationLookup,
 	submitter workRequestSubmitter,
 ) {
 	if runtimeModeOrDefault(fs.cfg.RuntimeMode) != interfaces.RuntimeModeService || factoryCfg == nil || runtimeCfg == nil || submitter == nil {

--- a/pkg/service/factory_test.go
+++ b/pkg/service/factory_test.go
@@ -1936,20 +1936,17 @@ func TestFactoryService_StartCronWatchersForRuntime_DisablesInvalidSchedulesWith
 	})
 
 	startupRequest := waitForCronWorkRequest(t, observedRequests, time.Second)
-	assertCronWorkRequestNominalAt(t, startupRequest, start)
-	if got := startupRequest.Works[0].Tags[cronWorkstationTag]; got != "valid-cron" {
-		t.Fatalf("startup cron workstation tag = %q, want valid-cron", got)
-	}
+	assertCronWorkRequestForWorkstation(t, startupRequest, start, "valid-cron")
 
 	waitForFakeClockWaiters(t, fakeClock, 1)
 	assertNoCronWorkRequestQueued(t, observedRequests)
 	fakeClock.Advance(time.Minute)
 	scheduledRequest := waitForCronWorkRequest(t, observedRequests, time.Second)
-	assertCronWorkRequestNominalAt(t, scheduledRequest, start.Add(time.Minute))
-	if got := scheduledRequest.Works[0].Tags[cronWorkstationTag]; got != "valid-cron" {
-		t.Fatalf("scheduled cron workstation tag = %q, want valid-cron", got)
-	}
+	assertCronWorkRequestForWorkstation(t, scheduledRequest, start.Add(time.Minute), "valid-cron")
 	assertNoCronWorkRequestQueued(t, observedRequests)
+
+	cancelRun()
+	sidecars.Wait()
 
 	registered := observedLogs.FilterMessage("cron watcher registered").All()
 	if len(registered) != 1 {
@@ -1973,6 +1970,16 @@ func TestFactoryService_StartCronWatchersForRuntime_DisablesInvalidSchedulesWith
 	}
 	if got := started[0].ContextMap()["jobs"]; got != int64(1) {
 		t.Fatalf("cron scheduler started jobs = %#v, want 1", got)
+	}
+	if observedLogs.FilterMessage("cron watcher trigger retrying").Len() != 0 {
+		t.Fatalf("retry log count = %d, want 0", observedLogs.FilterMessage("cron watcher trigger retrying").Len())
+	}
+	if observedLogs.FilterMessage("cron watcher trigger exhausted").Len() != 0 {
+		t.Fatalf("exhausted log count = %d, want 0", observedLogs.FilterMessage("cron watcher trigger exhausted").Len())
+	}
+	stopped := observedLogs.FilterMessage("cron scheduler stopped").All()
+	if len(stopped) != 1 {
+		t.Fatalf("cron scheduler stopped log count = %d, want 1", len(stopped))
 	}
 }
 
@@ -2305,6 +2312,20 @@ func assertCronWorkRequestNominalAt(t *testing.T, request interfaces.WorkRequest
 	t.Helper()
 	if got := request.Works[0].Tags[interfaces.TimeWorkTagKeyNominalAt]; got != want.Format(time.RFC3339Nano) {
 		t.Fatalf("cron nominal_at tag = %q, want %q", got, want.Format(time.RFC3339Nano))
+	}
+}
+
+func assertCronWorkRequestForWorkstation(t *testing.T, request interfaces.WorkRequest, want time.Time, workstation string) {
+	t.Helper()
+	if request.Type != interfaces.WorkRequestTypeFactoryRequestBatch {
+		t.Fatalf("cron work request type = %q, want %q", request.Type, interfaces.WorkRequestTypeFactoryRequestBatch)
+	}
+	assertCronWorkRequestNominalAt(t, request, want)
+	if got := request.Works[0].Tags[cronWorkstationTag]; got != workstation {
+		t.Fatalf("cron workstation tag = %q, want %q", got, workstation)
+	}
+	if got := request.Works[0].Tags[cronSourceTag]; got != "cron" {
+		t.Fatalf("cron source tag = %q, want cron", got)
 	}
 }
 


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/simplify-cron-watcher-runtime-lookup-width",
  "description": "Narrow the cron watcher startup boundary so it depends only on runtime workstation lookup after workflow identity is derived from the entrypoint-owned factoryDir, while preserving existing cron watcher behavior and service-boundary verification.",
  "context": {
    "customerAsk": "Narrow startCronWatchersForRuntime from interfaces.RuntimeConfigLookup to interfaces.RuntimeWorkstationLookup, keep factoryDir as the entrypoint-owned source of workflow identity, preserve the current registerCronJobs, triggerCronAtStart, and submitCronTickForRuntime behavior, and update service tests or helper typing only where the narrower dependency requires it.",
    "problem": "The cron watcher startup path in pkg/service/cron_watcher.go still accepts a broader path-aware runtime lookup than it uses. Live code already passes factoryDir separately, and the downstream watcher helpers operate on workstation lookup plus already-derived workflow identity rather than on path-aware runtime methods, which leaves unnecessary interface-width coupling alive in a service path that should stay simple and local.",
    "solution": "Change the watcher-start boundary to accept interfaces.RuntimeWorkstationLookup, continue deriving workflow identity from the explicit factoryDir at the entrypoint, preserve existing cron registration and trigger behavior, and adjust only the affected service tests or helper typing needed to prove behavior remains unchanged at the watcher boundary."
  },
  "acceptanceCriteria": [
    "startCronWatchersForRuntime accepts interfaces.RuntimeWorkstationLookup rather than interfaces.RuntimeConfigLookup.",
    "The cron watcher startup path continues deriving workflow identity from the entrypoint-owned factoryDir input instead of reintroducing path-aware runtime lookup methods below that boundary.",
    "Valid cron workstations still register, trigger at startup when configured, and continue scheduled execution without any change to retry behavior, tags, or scheduler lifetime semantics.",
    "Invalid cron schedules are still disabled without preventing valid cron jobs from being registered and triggered in the same runtime.",
    "Verification remains behavioral at the service watcher boundary and does not broaden into cron schema, API, UI, or runtime-config normalization work.",
    "Typecheck, lint, and the required service test commands pass."
  ],
  "userStories": [
    {
      "id": "simplify-cron-watcher-runtime-lookup-width-001",
      "title": "Narrow the watcher-start runtime lookup boundary",
      "description": "As a maintainer, I want cron watcher startup to depend only on runtime workstation lookup so the service boundary reflects the behavior it actually needs after workflow identity is already derived.",
      "acceptanceCriteria": [
        "startCronWatchersForRuntime accepts interfaces.RuntimeWorkstationLookup and no longer requires interfaces.RuntimeConfigLookup.",
        "The watcher-start path continues receiving factoryDir explicitly and uses it as the source of workflow identity for cron submissions.",
        "registerCronJobs, triggerCronAtStart, and submitCronTickForRuntime continue operating with workstation lookup plus derived workflow identity rather than path-aware runtime methods.",
        "No new path-aware runtime lookup dependency is introduced below the watcher-start boundary once workflow identity is available.",
        "go test ./pkg/service -count=1 succeeds.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "simplify-cron-watcher-runtime-lookup-width-002",
      "title": "Preserve mixed valid and invalid cron watcher behavior at startup",
      "description": "As a reviewer, I want service-level verification that valid cron jobs still run while invalid schedules are disabled so the interface narrowing is proven at the same observable watcher boundary customers rely on.",
      "acceptanceCriteria": [
        "TestFactoryService_StartCronWatchersForRuntime_DisablesInvalidSchedulesWithoutAffectingValidCronJobs or an equivalent service-boundary test continues proving that a valid cron workstation registers, triggers at startup, and fires on schedule while an invalid cron workstation is disabled.",
        "Service verification proves the narrowed startup dependency does not change cron trigger behavior, retry behavior, workstation tags, or scheduler lifetime behavior for registered cron jobs.",
        "Any test helper typing changes stay limited to the service watcher boundary and do not require path-aware runtime lookup methods where workstation lookup is sufficient.",
        "go test ./pkg/service -run TestFactoryService_StartCronWatchersForRuntime_DisablesInvalidSchedulesWithoutAffectingValidCronJobs -count=1 succeeds.",
        "go test ./pkg/service -count=1 succeeds.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
