### PR TITLE
split-functionallong-guards-batch-helpers-from-default-support

### DIFF
--- a/docs/internal/development/deadcode-baseline.txt
+++ b/docs/internal/development/deadcode-baseline.txt
@@ -1,4 +1,3 @@
-tests/functional/guards_batch/helpers_test.go:93:29: unreachable func: panickingExecutor.Execute
 tests/functional/internal/support/events.go:23:6: unreachable func: FactoryRelationsValue
 tests/functional/internal/support/fixtures.go:160:6: unreachable func: UpdateFactoryConfig
 tests/functional/providers/helpers_test.go:127:6: unreachable func: buildModelWorkerConfig

--- a/docs/internal/development/deadcode-baseline.txt
+++ b/docs/internal/development/deadcode-baseline.txt
@@ -1,5 +1,4 @@
-tests/functional/guards_batch/helpers_test.go:14:6: unreachable func: providerErrorCorpusEntryForTest
-tests/functional/guards_batch/helpers_test.go:99:29: unreachable func: panickingExecutor.Execute
+tests/functional/guards_batch/helpers_test.go:93:29: unreachable func: panickingExecutor.Execute
 tests/functional/internal/support/events.go:23:6: unreachable func: FactoryRelationsValue
 tests/functional/internal/support/fixtures.go:160:6: unreachable func: UpdateFactoryConfig
 tests/functional/providers/helpers_test.go:127:6: unreachable func: buildModelWorkerConfig

--- a/tests/functional/guards_batch/helpers_long_test.go
+++ b/tests/functional/guards_batch/helpers_long_test.go
@@ -5,10 +5,18 @@ package guards_batch
 import (
 	"context"
 	"sync"
+	"testing"
 
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/petri"
+	"github.com/portpowered/infinite-you/pkg/workers"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
+
+func providerErrorCorpusEntryForTest(t *testing.T, name string) workers.ProviderErrorCorpusEntry {
+	t.Helper()
+	return support.ProviderErrorCorpusEntry(t, name)
+}
 
 type failOnNthPageExecutor struct {
 	mu     sync.Mutex

--- a/tests/functional/guards_batch/helpers_long_test.go
+++ b/tests/functional/guards_batch/helpers_long_test.go
@@ -18,6 +18,14 @@ func providerErrorCorpusEntryForTest(t *testing.T, name string) workers.Provider
 	return support.ProviderErrorCorpusEntry(t, name)
 }
 
+type panickingExecutor struct{}
+
+func (e *panickingExecutor) Execute(_ context.Context, _ interfaces.WorkDispatch) (interfaces.WorkResult, error) {
+	panic("intentional executor panic for testing")
+}
+
+var _ workers.WorkerExecutor = (*panickingExecutor)(nil)
+
 type failOnNthPageExecutor struct {
 	mu     sync.Mutex
 	calls  int

--- a/tests/functional/guards_batch/helpers_test.go
+++ b/tests/functional/guards_batch/helpers_test.go
@@ -4,17 +4,11 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"testing"
 
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/workers"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
-
-func providerErrorCorpusEntryForTest(t *testing.T, name string) workers.ProviderErrorCorpusEntry {
-	t.Helper()
-	return support.ProviderErrorCorpusEntry(t, name)
-}
 
 type fanoutParserExecutor struct {
 	mu         sync.Mutex

--- a/tests/functional/guards_batch/helpers_test.go
+++ b/tests/functional/guards_batch/helpers_test.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"github.com/portpowered/infinite-you/pkg/interfaces"
-	"github.com/portpowered/infinite-you/pkg/workers"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
 
@@ -87,11 +86,3 @@ func (e *multiChapterParserExecutor) Execute(_ context.Context, dispatch interfa
 		SpawnedWork:  spawned,
 	}, nil
 }
-
-type panickingExecutor struct{}
-
-func (e *panickingExecutor) Execute(_ context.Context, _ interfaces.WorkDispatch) (interfaces.WorkResult, error) {
-	panic("intentional executor panic for testing")
-}
-
-var _ workers.WorkerExecutor = (*panickingExecutor)(nil)


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/split-functionallong-guards-batch-helpers-from-default-support",
  "description": "Move guards-batch helpers that are only live in functionallong partial-batch and concurrency-limit tests into explicit functionallong ownership while preserving the same observable failure-routing, retry, and resource-release behavior.",
  "context": {
    "customerAsk": "Split the guards-batch functional-test helper surface so providerErrorCorpusEntryForTest and panickingExecutor no longer live in the default helper owner, keep default-lane helpers limited to callers that still exist in the default lane, and preserve the current long-lane behavioral assertions instead of replacing them with meta tests about file placement.",
    "problem": "tests/functional/guards_batch/helpers_test.go currently mixes default-lane parser helpers with long-only support used only by partial_batch_long_test.go and concurrency_limit_long_test.go. Because those helper definitions compile in the default lane, the package exposes a wider helper surface than the default tests actually need and makes lane ownership harder to reason about.",
    "solution": "Move providerErrorCorpusEntryForTest, panickingExecutor, and the panickingExecutor interface assertion into an explicit //go:build functionallong helper owner for guards-batch, keep parser helpers in the default helper file only when they still serve default-lane callers, and preserve the same observable long-lane partial-batch and concurrency-limit behavior through the existing functional tests."
  },
  "acceptanceCriteria": [
    "The default guards-batch functional-test lane compiles and runs without depending on providerErrorCorpusEntryForTest or panickingExecutor.",
    "The long-lane partial-batch tests still prove the same observable behavior after the split: retryable provider failures retry through the script-wrap path, non-retryable provider failures route tokens to task:failed, and provider invocation shape remains intact for the covered cases.",
    "The long-lane concurrency-limit tests still prove the same observable behavior after the split: both inline and async executor panics route work to failure and release the expected resource tokens back to the available place.",
    "Default-lane guards-batch helper support does not gain any new long-only helpers as part of this cleanup, and shared parser helpers remain in the default lane only when they still serve default-lane callers.",
    "Verification stays at the functional-test boundary through the relevant go test commands for tests/functional/guards_batch instead of adding meta assertions about helper file placement.",
    "Typecheck, lint, and the relevant functional test commands pass for the touched guards-batch package."
  ],
  "userStories": [
    {
      "id": "split-functionallong-guards-batch-helpers-from-default-support-001",
      "title": "Keep partial-batch provider failure behavior intact while long-only provider helpers move to the long lane",
      "description": "As a maintainer, I want the long-lane partial-batch provider failure tests to keep the same observable routing and retry behavior after helper ownership is aligned so the cleanup does not weaken confidence in script-wrap failure handling.",
      "acceptanceCriteria": [
        "providerErrorCorpusEntryForTest is owned by a //go:build functionallong helper file for guards-batch rather than the default helper owner.",
        "The long-lane partial-batch coverage still proves that retryable provider failures retry through the script-wrap path before succeeding.",
        "The long-lane partial-batch coverage still proves that non-retryable provider exit failures route the token to task:failed and preserve the provider invocation shape asserted by the current tests.",
        "No new default-lane helper support is introduced for long-only provider failure scenarios as part of this story.",
        "go test -tags functionallong ./tests/functional/guards_batch succeeds for the touched scenarios.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "split-functionallong-guards-batch-helpers-from-default-support-002",
      "title": "Keep concurrency-limit panic recovery intact while panic helpers move to the long lane",
      "description": "As a maintainer, I want the long-lane concurrency-limit panic tests to keep the same observable failure routing and resource-release behavior after helper ownership is aligned so panic recovery remains proven in both inline and async execution modes.",
      "acceptanceCriteria": [
        "panickingExecutor and its workers.WorkerExecutor interface assertion are owned by a //go:build functionallong helper file for guards-batch rather than the default helper owner.",
        "The long-lane concurrency-limit coverage still proves that an inline executor panic routes the token to task:failed, preserves a panic-derived failure message, and returns the expected resource token to the available place.",
        "The long-lane concurrency-limit coverage still proves that an async executor panic routes the token to task:failed and returns the expected resource token to the available place.",
        "The cleanup does not change non-panic concurrency-limit behavior outside the existing long-lane assertions.",
        "go test -tags functionallong ./tests/functional/guards_batch succeeds for the touched scenarios.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "split-functionallong-guards-batch-helpers-from-default-support-003",
      "title": "Keep default-lane guards-batch helper support limited to default-lane callers",
      "description": "As a reviewer, I want the default guards-batch helper surface to stay limited to helpers that default-lane tests actually use so default builds do not silently compile long-only support.",
      "acceptanceCriteria": [
        "tests/functional/guards_batch/helpers_test.go keeps fanoutParserExecutor and multiChapterParserExecutor only if they still have direct default-lane callers after the split.",
        "The default guards-batch test lane continues to compile and run without depending on long-only provider failure or panic helpers.",
        "The implementation stays local to tests/functional/guards_batch/* unless a narrowly related stale test-only finding is directly exposed by the split.",
        "go test ./tests/functional/guards_batch succeeds.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}
