### PR TITLE
retire-workers-test-only-env-slice-parser

### DIFF
--- a/pkg/workers/diagnostics.go
+++ b/pkg/workers/diagnostics.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/portpowered/infinite-you/pkg/interfaces"
@@ -220,21 +219,6 @@ func cloneStringMap(in map[string]string) map[string]string {
 	out := make(map[string]string, len(in))
 	for k, v := range in {
 		out[k] = v
-	}
-	return out
-}
-
-func envSliceToMap(env []string) map[string]string {
-	if len(env) == 0 {
-		return nil
-	}
-	out := make(map[string]string, len(env))
-	for _, pair := range env {
-		name, value, ok := strings.Cut(pair, "=")
-		if !ok {
-			continue
-		}
-		out[name] = value
 	}
 	return out
 }

--- a/pkg/workers/env_slice_test.go
+++ b/pkg/workers/env_slice_test.go
@@ -1,0 +1,18 @@
+package workers
+
+import "strings"
+
+func envSliceToMap(env []string) map[string]string {
+	if len(env) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(env))
+	for _, pair := range env {
+		name, value, ok := strings.Cut(pair, "=")
+		if !ok {
+			continue
+		}
+		out[name] = value
+	}
+	return out
+}

--- a/pkg/workers/inference_provider_test.go
+++ b/pkg/workers/inference_provider_test.go
@@ -139,6 +139,38 @@ func TestBuildProviderEnv_UsesDeterministicPrecedenceForOverlappingKeys(t *testi
 	}
 }
 
+func TestModelWorkerCommandRequest_MergesEnvironmentWithDeterministicPrecedence(t *testing.T) {
+	t.Setenv("GIT_EDITOR", "vim")
+	t.Setenv("GIT_SEQUENCE_EDITOR", "vim")
+	t.Setenv("AGENT_FACTORY_PROVIDER_ENV_PRECEDENCE", "process")
+
+	behavior := providerBehaviorFor(string(ModelProviderClaude), nil)
+	req := behavior.BuildCommandRequest(interfaces.ProviderInferenceRequest{
+		ModelProvider: string(ModelProviderClaude),
+		UserMessage:   "fix it",
+		EnvVars: map[string]string{
+			"AGENT_FACTORY_PROVIDER_ENV_PRECEDENCE": "provider",
+			"AGENT_FACTORY_PROVIDER_ONLY":           "present",
+			"GIT_EDITOR":                            "nano",
+			"GIT_SEQUENCE_EDITOR":                   "nano",
+		},
+	}, []string{"-p", "fix it"})
+
+	assertEnvValue(t, req.Env, "GIT_EDITOR", "true")
+	assertEnvValue(t, req.Env, "GIT_SEQUENCE_EDITOR", "true")
+	assertEnvValue(t, req.Env, "AGENT_FACTORY_PROVIDER_ENV_PRECEDENCE", "provider")
+	assertEnvValue(t, req.Env, "AGENT_FACTORY_PROVIDER_ONLY", "present")
+
+	for _, name := range []string{
+		"AGENT_FACTORY_PROVIDER_ENV_PRECEDENCE",
+		"AGENT_FACTORY_PROVIDER_ONLY",
+		"GIT_EDITOR",
+		"GIT_SEQUENCE_EDITOR",
+	} {
+		assertEnvEntryCount(t, req.Env, name, 1)
+	}
+}
+
 func TestBuildProviderEnv_PreservesExplicitLegacyPortOSEnvKeys(t *testing.T) {
 	env := buildProviderEnv(map[string]string{
 		"PORTOS_BRANCH": "ralph/legacy-feature",


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/retire-workers-test-only-env-slice-parser",
  "description": "Move the workers envSliceToMap helper out of production diagnostics code and into the workers test surface while preserving the existing environment behavior verified by workers tests.",
  "context": {
    "customerAsk": "Move envSliceToMap out of pkg/workers/diagnostics.go because it is only used by workers package tests, keep one shared unexported test helper for the existing callers, and verify the focused workers tests.",
    "problem": "Production workers diagnostics code carries a test convenience parser and a strings import that are not used by runtime diagnostics behavior, unnecessarily widening the production source surface.",
    "solution": "Remove envSliceToMap and the now-unused strings import from production diagnostics code, add the same unexported package-local helper to a focused workers _test.go file, and run the existing workers tests that exercise the helper callers to confirm environment behavior is unchanged."
  },
  "acceptanceCriteria": [
    "Workers production diagnostics still compile and provide the same runtime diagnostics behavior without depending on the test-only environment slice parser.",
    "The existing script executor environment test continues to prove that direct command environments do not add provider automation defaults.",
    "The existing model worker command request test continues to prove deterministic environment merge precedence.",
    "The shared parser remains unexported and package-local to pkg/workers tests so the two test callers avoid duplicated parsing behavior.",
    "The cleanup does not introduce new abstractions, guard layers, env diagnostics behavior, or provider automation behavior.",
    "Typecheck, lint, and focused workers tests pass, with the full workers package test run when feasible."
  ],
  "userStories": [
    {
      "id": "retire-workers-test-only-env-slice-parser-001",
      "title": "Move the shared env slice parser to the workers test surface",
      "description": "As a maintainer, I want the workers environment slice parser to live only in the package test surface so production diagnostics do not carry test convenience code while existing environment behavior remains verified.",
      "acceptanceCriteria": [
        "pkg/workers/diagnostics.go no longer contains envSliceToMap and no longer imports strings solely for that helper.",
        "A focused workers _test.go helper provides an unexported package-local envSliceToMap implementation shared by the existing workers tests.",
        "TestScriptExecutor_DirectCommandEnvironmentDoesNotAddProviderAutomationDefaults continues to pass and proves the direct command environment behavior is unchanged.",
        "TestModelWorkerCommandRequest_MergesEnvironmentWithDeterministicPrecedence continues to pass and proves deterministic environment merge precedence is unchanged.",
        "No runtime diagnostics output, provider automation defaulting, or environment merge semantics are intentionally changed.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    }
  ]
}
