### PR TITLE
work-outcome-chart-zoom

### DIFF
--- a/ui/src/components/ui/chart.tsx
+++ b/ui/src/components/ui/chart.tsx
@@ -1,13 +1,19 @@
+import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
 import { createContext, useContext } from "react";
-import type { CSSProperties, ReactNode } from "react";
 import {
   Legend as RechartsLegend,
-  ResponsiveContainer,
   Tooltip as RechartsTooltip,
+  ResponsiveContainer,
   type TooltipContentProps,
 } from "recharts";
-import type { Props as RechartsLegendContentProps, LegendPayload } from "recharts/types/component/DefaultLegendContent";
-import type { NameType, ValueType } from "recharts/types/component/DefaultTooltipContent";
+import type {
+  LegendPayload,
+  Props as RechartsLegendContentProps,
+} from "recharts/types/component/DefaultLegendContent";
+import type {
+  NameType,
+  ValueType,
+} from "recharts/types/component/DefaultTooltipContent";
 
 import { cn } from "../../lib/cn";
 
@@ -34,15 +40,19 @@ export function ChartContainer({
   children,
   className,
   config,
+  interactionAttributes,
   overlay,
   rootAttributes,
+  style,
   title,
 }: {
   children: ReactNode;
   className?: string;
   config: ChartConfig;
+  interactionAttributes?: HTMLAttributes<HTMLDivElement>;
   overlay?: ReactNode;
   rootAttributes?: Record<string, string>;
+  style?: CSSProperties;
   title: string;
 }) {
   return (
@@ -55,15 +65,29 @@ export function ChartContainer({
         )}
         data-chart-container=""
         role="img"
+        {...interactionAttributes}
         {...rootAttributes}
         style={
-          Object.fromEntries(
-            Object.entries(config).map(([key, value]) => [`--color-${key}`, value.color]),
-          ) as CSSProperties
+          {
+            ...Object.fromEntries(
+              Object.entries(config).map(([key, value]) => [
+                `--color-${key}`,
+                value.color,
+              ]),
+            ),
+            ...style,
+          } as CSSProperties
         }
       >
-        {overlay ? <div className="pointer-events-none absolute inset-0">{overlay}</div> : null}
-        <ResponsiveContainer height="100%" minHeight={0} minWidth={0} width="100%">
+        {overlay ? (
+          <div className="pointer-events-none absolute inset-0">{overlay}</div>
+        ) : null}
+        <ResponsiveContainer
+          height="100%"
+          minHeight={0}
+          minWidth={0}
+          width="100%"
+        >
           {children}
         </ResponsiveContainer>
       </div>
@@ -100,11 +124,17 @@ export function ChartTooltipContent({
           const item = config[key];
 
           return (
-            <div className="flex items-center justify-between gap-3 text-af-ink/78" key={key}>
+            <div
+              className="flex items-center justify-between gap-3 text-af-ink/78"
+              key={key}
+            >
               <div className="flex items-center gap-2">
                 <span
                   className="h-2.5 w-2.5 rounded-full"
-                  style={{ backgroundColor: item?.color ?? entry.color ?? "currentColor" }}
+                  style={{
+                    backgroundColor:
+                      item?.color ?? entry.color ?? "currentColor",
+                  }}
                 />
                 <span>{item?.label ?? key}</span>
               </div>
@@ -128,7 +158,12 @@ export function ChartLegendContent({
   }
 
   return (
-    <div className={cn("flex flex-wrap items-center gap-4 pt-3 text-xs text-af-ink/66", className)}>
+    <div
+      className={cn(
+        "flex flex-wrap items-center gap-4 pt-3 text-xs text-af-ink/66",
+        className,
+      )}
+    >
       {payload.map((entry: LegendPayload) => {
         const key = entry.dataKey?.toString() ?? "";
         const item = config[key];
@@ -137,7 +172,9 @@ export function ChartLegendContent({
           <div className="flex items-center gap-2" key={key}>
             <span
               className="h-2.5 w-2.5 rounded-full"
-              style={{ backgroundColor: item?.color ?? entry.color ?? "currentColor" }}
+              style={{
+                backgroundColor: item?.color ?? entry.color ?? "currentColor",
+              }}
             />
             <span>{item?.label ?? key}</span>
           </div>

--- a/ui/src/features/work-outcome/work-chart-data.ts
+++ b/ui/src/features/work-outcome/work-chart-data.ts
@@ -1,0 +1,183 @@
+import type { WorkChartModel, WorkChartSeriesKey } from "./trends";
+
+export interface WorkChartSeriesDefinition {
+  key: WorkChartSeriesKey;
+  label: string;
+  lineColor: string;
+  lineClassName: string;
+  pointClassName?: string;
+  pointRadius?: number;
+}
+
+export interface WorkChartBuiltSeries {
+  key: string;
+  label: string;
+  lineColor: string;
+  lineClassName: string;
+  pointClassName?: string;
+  pointRadius?: number;
+  strokeDasharray?: string;
+}
+
+export interface WorkChartData {
+  config: Record<string, { color: string; label: string }>;
+  rows: WorkChartRow[];
+  series: WorkChartBuiltSeries[];
+}
+
+export interface WorkChartRow {
+  label: string;
+  tick: number;
+  [seriesKey: string]: number | string | undefined;
+}
+
+export type WorkChartDataResult =
+  | { data: WorkChartData; status: "ready" }
+  | { status: "empty" }
+  | { status: "invalid" };
+
+export function buildWorkChartData(
+  model: WorkChartModel | undefined,
+  series: readonly WorkChartSeriesDefinition[],
+): WorkChartDataResult {
+  if (!isWorkChartModel(model) || !isWorkChartSeriesDefinitionArray(series)) {
+    return { status: "invalid" };
+  }
+
+  if (model.points.length === 0 || series.length === 0) {
+    return { status: "empty" };
+  }
+
+  const seriesByKey = new Map(
+    model.series.map((definition) => [definition.key, definition.points]),
+  );
+  const rows = model.points.map((point, index) => {
+    const row: WorkChartRow = {
+      label: point.label,
+      tick: point.tick,
+    };
+
+    for (const definition of series) {
+      const value = seriesByKey
+        .get(definition.key)
+        ?.find((seriesPoint) => seriesPoint.order === index)?.value;
+      if (value !== undefined) {
+        row[definition.key] = value;
+      }
+    }
+
+    return row;
+  });
+
+  const builtSeries = series
+    .filter((definition) =>
+      rows.some((row) => hasSeriesValue(row, definition.key)),
+    )
+    .map((definition) => ({
+      key: definition.key,
+      label: definition.label,
+      lineClassName: definition.lineClassName,
+      lineColor: definition.lineColor,
+      pointClassName: definition.pointClassName,
+      pointRadius: definition.pointRadius,
+      strokeDasharray: extractStrokeDasharray(definition.lineClassName),
+    }));
+
+  return {
+    data: {
+      config: Object.fromEntries(
+        builtSeries.map((seriesEntry) => [
+          seriesEntry.key,
+          { color: seriesEntry.lineColor, label: seriesEntry.label },
+        ]),
+      ),
+      rows,
+      series: builtSeries,
+    },
+    status: "ready",
+  };
+}
+
+function hasSeriesValue(row: WorkChartRow, key: string): boolean {
+  return Object.hasOwn(row, key) && typeof row[key] === "number";
+}
+
+function extractStrokeDasharray(className: string): string | undefined {
+  const dashArrayMatch = className.match(/\[stroke-dasharray:([^\]]+)\]/);
+  return dashArrayMatch?.[1]?.replaceAll("_", " ");
+}
+
+function isWorkChartSeriesDefinitionArray(
+  value: unknown,
+): value is readonly WorkChartSeriesDefinition[] {
+  return Array.isArray(value) && value.every(isWorkChartSeriesDefinition);
+}
+
+function isWorkChartSeriesDefinition(
+  value: unknown,
+): value is WorkChartSeriesDefinition {
+  return (
+    isRecord(value) &&
+    typeof value.key === "string" &&
+    typeof value.label === "string" &&
+    typeof value.lineColor === "string" &&
+    typeof value.lineClassName === "string" &&
+    (value.pointClassName === undefined ||
+      typeof value.pointClassName === "string") &&
+    (value.pointRadius === undefined || isFiniteNumber(value.pointRadius))
+  );
+}
+
+function isWorkChartModel(value: unknown): value is WorkChartModel {
+  return (
+    isRecord(value) &&
+    Array.isArray(value.points) &&
+    Array.isArray(value.series) &&
+    value.points.every(isWorkChartSample) &&
+    value.series.every(isWorkChartSeries)
+  );
+}
+
+function isWorkChartSample(
+  value: unknown,
+): value is WorkChartModel["points"][number] {
+  return (
+    isRecord(value) &&
+    typeof value.label === "string" &&
+    isFiniteNumber(value.observedAt) &&
+    isFiniteNumber(value.order) &&
+    isFiniteNumber(value.tick)
+  );
+}
+
+function isWorkChartSeries(
+  value: unknown,
+): value is WorkChartModel["series"][number] {
+  return (
+    isRecord(value) &&
+    typeof value.key === "string" &&
+    typeof value.label === "string" &&
+    Array.isArray(value.points) &&
+    value.points.every(isWorkChartSeriesPoint)
+  );
+}
+
+function isWorkChartSeriesPoint(
+  value: unknown,
+): value is WorkChartModel["series"][number]["points"][number] {
+  return (
+    isRecord(value) &&
+    typeof value.label === "string" &&
+    isFiniteNumber(value.observedAt) &&
+    isFiniteNumber(value.order) &&
+    isFiniteNumber(value.value)
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}

--- a/ui/src/features/work-outcome/work-chart.stories.tsx
+++ b/ui/src/features/work-outcome/work-chart.stories.tsx
@@ -1,9 +1,9 @@
 import type { ComponentProps } from "react";
-import { expect, within } from "storybook/test";
+import { expect, fireEvent, userEvent, within } from "storybook/test";
 
 import { getDashboardWorkChartSeriesStyle } from "./chart-contract";
-import { WorkChart, type WorkChartSeriesDefinition } from "./work-chart";
 import type { WorkChartModel } from "./trends";
+import { WorkChart, type WorkChartSeriesDefinition } from "./work-chart";
 
 const populatedModel = {
   delta: {
@@ -146,7 +146,9 @@ function expectWorkChartPaddingContract(chart: HTMLElement): void {
   expect(chart.className).toContain("sm:pb-6");
   expect(chart.className).toContain("sm:pt-5");
 
-  const overlay = chart.querySelector<HTMLElement>("[data-work-chart-overlay='true']");
+  const overlay = chart.querySelector<HTMLElement>(
+    "[data-work-chart-overlay='true']",
+  );
 
   expect(overlay).not.toBeNull();
   expect(overlay?.className).toContain("px-5");
@@ -172,10 +174,28 @@ function renderWorkChartStoryShell(
   maxWidth: string,
 ) {
   return (
-    <div data-story-shell="work-chart" style={{ maxWidth, padding: "1rem", width: "100%" }}>
+    <div
+      data-story-shell="work-chart"
+      style={{ maxWidth, padding: "1rem", width: "100%" }}
+    >
       <WorkChart {...args} />
     </div>
   );
+}
+
+async function dragWorkChart(
+  chart: HTMLElement,
+  startFraction: number,
+  endFraction: number,
+) {
+  const rect = chart.getBoundingClientRect();
+  const startX = rect.left + rect.width * startFraction;
+  const endX = rect.left + rect.width * endFraction;
+  const y = rect.top + rect.height * 0.7;
+
+  fireEvent.mouseDown(chart, { clientX: startX, clientY: y });
+  fireEvent.mouseMove(chart, { clientX: endX, clientY: y });
+  fireEvent.mouseUp(chart, { clientX: endX, clientY: y });
 }
 
 export default {
@@ -196,10 +216,48 @@ export const Populated = {
   },
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
-    const chart = await canvas.findByRole("img", { name: "Work outcome chart" });
+    const chart = await canvas.findByRole("img", {
+      name: "Work outcome chart",
+    });
 
     expectWorkChartOverlayContract(chart);
     expectWorkChartPaddingContract(chart);
+  },
+};
+
+export const ZoomInteraction = {
+  render: (args: ComponentProps<typeof WorkChart>) =>
+    renderWorkChartStoryShell(args, "640px"),
+  args: {
+    model: populatedModel,
+    series: WORK_CHART_SERIES,
+  },
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const chart = await canvas.findByRole("img", {
+      name: "Work outcome chart",
+    });
+
+    expect(chart.getAttribute("data-work-chart-visible-ticks")).toBe(
+      "10,20,40",
+    );
+
+    await dragWorkChart(chart, 0.1, 0.5);
+
+    expect(chart.getAttribute("data-work-chart-visible-ticks")).toBe("10,20");
+    await expect(canvas.getByText("Zoomed to ticks 10-20")).toBeVisible();
+
+    const reset = canvas.getByRole("button", {
+      name: "Reset work outcome chart zoom",
+    });
+    await expect(reset).toBeVisible();
+
+    await userEvent.click(reset);
+
+    expect(chart.getAttribute("data-work-chart-visible-ticks")).toBe(
+      "10,20,40",
+    );
+    expect(canvas.queryByText("Zoomed to ticks 10-20")).toBeNull();
   },
 };
 
@@ -236,7 +294,9 @@ export const ConstrainedWidth = {
   },
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
-    const chart = await canvas.findByRole("img", { name: "Work outcome chart" });
+    const chart = await canvas.findByRole("img", {
+      name: "Work outcome chart",
+    });
 
     expectWorkChartOverlayContract(chart);
     expectWorkChartPaddingContract(chart);

--- a/ui/src/features/work-outcome/work-chart.test.tsx
+++ b/ui/src/features/work-outcome/work-chart.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { installDashboardBrowserTestShims } from "../../components/dashboard/test-browser-shims";
 import { getDashboardWorkChartSeriesStyle } from "./chart-contract";
@@ -226,6 +227,100 @@ describe("WorkChart", () => {
     );
   });
 
+  it("shows active zoom context and resets the chart range when reset is clicked", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <WorkChart
+        ariaLabel="Resettable work chart"
+        model={sparseWorkChartModel}
+        series={OUTCOME_SERIES}
+      />,
+    );
+
+    const chart = screen.getByRole("img", { name: "Resettable work chart" });
+    expect(
+      screen.queryByRole("button", {
+        name: "Reset work outcome chart zoom",
+      }),
+    ).toBeNull();
+
+    dragWorkChart(chart, { endX: 650, startX: 60 });
+
+    expect(chart.getAttribute("data-work-chart-visible-ticks")).toBe("10,20");
+    expect(screen.getByText("Zoomed to ticks 10-20")).toBeTruthy();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Reset work outcome chart zoom",
+      }),
+    );
+
+    expect(chart.getAttribute("data-work-chart-visible-ticks")).toBe(
+      "10,20,40",
+    );
+    expect(screen.queryByText("Zoomed to ticks 10-20")).toBeNull();
+    expect(
+      screen.queryByRole("button", {
+        name: "Reset work outcome chart zoom",
+      }),
+    ).toBeNull();
+  });
+
+  it("lets keyboard users focus and activate reset zoom with Enter and Space", async () => {
+    const user = userEvent.setup();
+
+    const { rerender } = render(
+      <WorkChart
+        ariaLabel="Keyboard reset work chart"
+        model={sparseWorkChartModel}
+        series={OUTCOME_SERIES}
+      />,
+    );
+
+    let chart = screen.getByRole("img", { name: "Keyboard reset work chart" });
+    dragWorkChart(chart, { endX: 650, startX: 60 });
+
+    await user.tab();
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", {
+        name: "Reset work outcome chart zoom",
+      }),
+    );
+
+    await user.keyboard("{Enter}");
+    expect(chart.getAttribute("data-work-chart-visible-ticks")).toBe(
+      "10,20,40",
+    );
+    expect(
+      screen.queryByRole("button", {
+        name: "Reset work outcome chart zoom",
+      }),
+    ).toBeNull();
+
+    rerender(
+      <WorkChart
+        ariaLabel="Keyboard reset work chart"
+        model={sparseWorkChartModel}
+        series={OUTCOME_SERIES}
+      />,
+    );
+
+    chart = screen.getByRole("img", { name: "Keyboard reset work chart" });
+    dragWorkChart(chart, { endX: 650, startX: 60 });
+    await user.tab();
+    await user.keyboard(" ");
+
+    expect(chart.getAttribute("data-work-chart-visible-ticks")).toBe(
+      "10,20,40",
+    );
+    expect(
+      screen.queryByRole("button", {
+        name: "Reset work outcome chart zoom",
+      }),
+    ).toBeNull();
+  });
+
   it("keeps missing series points absent instead of fabricating zero-valued rows", () => {
     render(
       <WorkChart
@@ -268,6 +363,11 @@ describe("WorkChart", () => {
       ),
     ).toBeTruthy();
     expect(screen.queryByRole("img", { name: "Work chart empty" })).toBeNull();
+    expect(
+      screen.queryByRole("button", {
+        name: "Reset work outcome chart zoom",
+      }),
+    ).toBeNull();
   });
 
   it("renders explicit no-data state when series definitions are unavailable", () => {
@@ -305,6 +405,11 @@ describe("WorkChart", () => {
     expect(
       screen.queryByRole("img", { name: "Work chart loading" }),
     ).toBeNull();
+    expect(
+      screen.queryByRole("button", {
+        name: "Reset work outcome chart zoom",
+      }),
+    ).toBeNull();
   });
 
   it("renders an error-safe fallback when the chart model shape is incomplete", () => {
@@ -332,6 +437,11 @@ describe("WorkChart", () => {
     ).toBeTruthy();
     expect(
       screen.queryByRole("img", { name: "Work chart malformed" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", {
+        name: "Reset work outcome chart zoom",
+      }),
     ).toBeNull();
   });
 });

--- a/ui/src/features/work-outcome/work-chart.test.tsx
+++ b/ui/src/features/work-outcome/work-chart.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 
 import { installDashboardBrowserTestShims } from "../../components/dashboard/test-browser-shims";
-import { WorkChart, type WorkChartSeriesDefinition } from "./work-chart";
-import type { WorkChartModel } from "./trends";
 import { getDashboardWorkChartSeriesStyle } from "./chart-contract";
+import type { WorkChartModel } from "./trends";
+import { WorkChart, type WorkChartSeriesDefinition } from "./work-chart";
 
 const sparseWorkChartModel: WorkChartModel = {
   delta: {
@@ -108,7 +108,9 @@ const zeroValuedFailedSeriesModel: WorkChartModel = {
     seriesEntry.key === "failed"
       ? {
           ...seriesEntry,
-          points: [{ label: "Failed: 0", observedAt: 2000, order: 1, value: 0 }],
+          points: [
+            { label: "Failed: 0", observedAt: 2000, order: 1, value: 0 },
+          ],
         }
       : seriesEntry,
   ),
@@ -164,6 +166,66 @@ describe("WorkChart", () => {
     expect(within(chart).getByText("Work count")).toBeTruthy();
   });
 
+  it("zooms the ready chart to the selected tick range after a horizontal drag", () => {
+    render(
+      <WorkChart
+        ariaLabel="Zoomable work chart"
+        model={sparseWorkChartModel}
+        series={OUTCOME_SERIES}
+      />,
+    );
+
+    const chart = screen.getByRole("img", { name: "Zoomable work chart" });
+    expect(chart.getAttribute("data-work-chart-visible-ticks")).toBe(
+      "10,20,40",
+    );
+
+    dragWorkChart(chart, { endX: 650, startX: 60 });
+
+    expect(chart.getAttribute("data-work-chart-visible-ticks")).toBe("10,20");
+    expect(within(chart).getByText("Queued")).toBeTruthy();
+    expect(within(chart).getByText("In-flight")).toBeTruthy();
+    expect(within(chart).getByText("Completed")).toBeTruthy();
+    expect(within(chart).getByText("Ticks")).toBeTruthy();
+    expect(within(chart).getByText("Work count")).toBeTruthy();
+  });
+
+  it("applies the same selected tick range when dragged from right to left", () => {
+    render(
+      <WorkChart
+        ariaLabel="Reverse zoomable work chart"
+        model={sparseWorkChartModel}
+        series={OUTCOME_SERIES}
+      />,
+    );
+
+    const chart = screen.getByRole("img", {
+      name: "Reverse zoomable work chart",
+    });
+
+    dragWorkChart(chart, { endX: 60, startX: 650 });
+
+    expect(chart.getAttribute("data-work-chart-visible-ticks")).toBe("10,20");
+  });
+
+  it("leaves the current domain unchanged for click-only selections", () => {
+    render(
+      <WorkChart
+        ariaLabel="Click-only work chart"
+        model={sparseWorkChartModel}
+        series={OUTCOME_SERIES}
+      />,
+    );
+
+    const chart = screen.getByRole("img", { name: "Click-only work chart" });
+
+    dragWorkChart(chart, { endX: 60, startX: 60 });
+
+    expect(chart.getAttribute("data-work-chart-visible-ticks")).toBe(
+      "10,20,40",
+    );
+  });
+
   it("keeps missing series points absent instead of fabricating zero-valued rows", () => {
     render(
       <WorkChart
@@ -185,7 +247,9 @@ describe("WorkChart", () => {
       />,
     );
 
-    expect(screen.getByRole("img", { name: "Zero work chart" }).textContent).toContain("Failed");
+    expect(
+      screen.getByRole("img", { name: "Zero work chart" }).textContent,
+    ).toContain("Failed");
   });
 
   it("renders explicit no-data state when timeline points are unavailable", () => {
@@ -199,7 +263,9 @@ describe("WorkChart", () => {
 
     expect(screen.getByText("No work outcome samples")).toBeTruthy();
     expect(
-      screen.getByText("Work outcome data appears after the event stream receives work history."),
+      screen.getByText(
+        "Work outcome data appears after the event stream receives work history.",
+      ),
     ).toBeTruthy();
     expect(screen.queryByRole("img", { name: "Work chart empty" })).toBeNull();
   });
@@ -215,7 +281,9 @@ describe("WorkChart", () => {
 
     expect(screen.getByRole("status")).toBeTruthy();
     expect(screen.getByText("No work outcome samples")).toBeTruthy();
-    expect(screen.queryByRole("img", { name: "Work chart zero series" })).toBeNull();
+    expect(
+      screen.queryByRole("img", { name: "Work chart zero series" }),
+    ).toBeNull();
   });
 
   it("renders an accessible loading placeholder before chart data is ready", () => {
@@ -230,9 +298,13 @@ describe("WorkChart", () => {
     const loadingState = screen.getByRole("status");
     expect(loadingState.getAttribute("aria-busy")).toBe("true");
     expect(screen.getByText("Loading work outcome samples")).toBeTruthy();
-    expect(screen.getByText("Waiting for dashboard timeline data.")).toBeTruthy();
+    expect(
+      screen.getByText("Waiting for dashboard timeline data."),
+    ).toBeTruthy();
     expect(loadingState.querySelector(".animate-pulse")).toBeTruthy();
-    expect(screen.queryByRole("img", { name: "Work chart loading" })).toBeNull();
+    expect(
+      screen.queryByRole("img", { name: "Work chart loading" }),
+    ).toBeNull();
   });
 
   it("renders an error-safe fallback when the chart model shape is incomplete", () => {
@@ -258,6 +330,20 @@ describe("WorkChart", () => {
         "Chart data is incomplete, so the dashboard cannot draw this work outcome view yet.",
       ),
     ).toBeTruthy();
-    expect(screen.queryByRole("img", { name: "Work chart malformed" })).toBeNull();
+    expect(
+      screen.queryByRole("img", { name: "Work chart malformed" }),
+    ).toBeNull();
   });
 });
+
+function dragWorkChart(
+  chart: HTMLElement,
+  { endX, startX }: { endX: number; startX: number },
+): void {
+  const surface = chart.querySelector(".recharts-surface");
+  expect(surface).toBeTruthy();
+
+  fireEvent.mouseDown(surface as Element, { clientX: startX, clientY: 280 });
+  fireEvent.mouseMove(surface as Element, { clientX: endX, clientY: 280 });
+  fireEvent.mouseUp(surface as Element, { clientX: endX, clientY: 280 });
+}

--- a/ui/src/features/work-outcome/work-chart.test.tsx
+++ b/ui/src/features/work-outcome/work-chart.test.tsx
@@ -187,6 +187,7 @@ describe("WorkChart", () => {
     expect(within(chart).getByText("Queued")).toBeTruthy();
     expect(within(chart).getByText("In-flight")).toBeTruthy();
     expect(within(chart).getByText("Completed")).toBeTruthy();
+    expect(within(chart).queryByText("Failed")).toBeNull();
     expect(within(chart).getByText("Ticks")).toBeTruthy();
     expect(within(chart).getByText("Work count")).toBeTruthy();
   });

--- a/ui/src/features/work-outcome/work-chart.tsx
+++ b/ui/src/features/work-outcome/work-chart.tsx
@@ -12,6 +12,7 @@ import {
   EMPTY_STATE_CLASS,
   EMPTY_STATE_COMPACT_CLASS,
 } from "../../components/dashboard/widget-board";
+import { Button } from "../../components/ui/button";
 import {
   ChartContainer,
   ChartLegend,
@@ -47,8 +48,11 @@ const WORK_CHART_MARGIN = { bottom: 40, left: 18, right: 28, top: 28 };
 const WORK_CHART_READY_CLASS =
   "h-64 min-h-56 px-5 pb-5 pt-4 sm:h-72 sm:px-6 sm:pb-6 sm:pt-5";
 const WORK_CHART_OVERLAY_CLASS =
-  "flex items-start justify-between gap-3 px-5 pb-4 pt-4 sm:px-6 sm:pb-5 sm:pt-5";
-const WORK_CHART_X_AXIS_OVERLAY_CLASS = "self-end";
+  "grid h-full grid-rows-[auto_1fr_auto] gap-2 px-5 pb-4 pt-4 sm:px-6 sm:pb-5 sm:pt-5";
+const WORK_CHART_TOP_OVERLAY_CLASS = "flex items-start justify-between gap-3";
+const WORK_CHART_ZOOM_CONTEXT_CLASS =
+  "pointer-events-auto flex max-w-[70%] flex-wrap items-center justify-end gap-2 text-right sm:max-w-none";
+const WORK_CHART_X_AXIS_OVERLAY_CLASS = "justify-self-end";
 const WORK_CHART_Y_AXIS_WIDTH = 52;
 
 export type WorkChartState =
@@ -179,6 +183,10 @@ function ReadyWorkChart({
     selectionStartTick,
     selectionEndTick,
   );
+  const zoomContext =
+    zoomRange === null
+      ? null
+      : `Zoomed to ticks ${formatAxisNumber(zoomRange.startTick)}-${formatAxisNumber(zoomRange.endTick)}`;
 
   const beginSelection = (event: ReactMouseEvent<HTMLDivElement>) => {
     const tick = readPointerTick(event, visibleRows);
@@ -224,7 +232,27 @@ function ReadyWorkChart({
           className={WORK_CHART_OVERLAY_CLASS}
           data-work-chart-overlay="true"
         >
-          <p className={cn("m-0", WORK_CHART_AXIS_LABEL_CLASS)}>{yAxisLabel}</p>
+          <div className={WORK_CHART_TOP_OVERLAY_CLASS}>
+            <p className={cn("m-0", WORK_CHART_AXIS_LABEL_CLASS)}>
+              {yAxisLabel}
+            </p>
+            {zoomContext === null ? null : (
+              <div className={WORK_CHART_ZOOM_CONTEXT_CLASS}>
+                <p className={cn("m-0", WORK_CHART_AXIS_LABEL_CLASS)}>
+                  {zoomContext}
+                </p>
+                <Button
+                  aria-label="Reset work outcome chart zoom"
+                  className="min-h-8 rounded-lg px-2.5 py-1.5 text-xs"
+                  onClick={() => setZoomRange(null)}
+                  size="sm"
+                  tone="outline"
+                >
+                  Reset zoom
+                </Button>
+              </div>
+            )}
+          </div>
           <p
             className={cn(
               "m-0",

--- a/ui/src/features/work-outcome/work-chart.tsx
+++ b/ui/src/features/work-outcome/work-chart.tsx
@@ -1,15 +1,17 @@
-import { useMemo } from "react";
+import type { MouseEvent as ReactMouseEvent } from "react";
+import { useMemo, useState } from "react";
 import {
   CartesianGrid,
   Line,
   LineChart,
+  ReferenceArea,
   XAxis,
   YAxis,
 } from "recharts";
-
 import {
-  DASHBOARD_CHART_AXIS_LABEL_CLASS,
-} from "./chart-contract";
+  EMPTY_STATE_CLASS,
+  EMPTY_STATE_COMPACT_CLASS,
+} from "../../components/dashboard/widget-board";
 import {
   ChartContainer,
   ChartLegend,
@@ -19,37 +21,35 @@ import {
 } from "../../components/ui/chart";
 import { Skeleton } from "../../components/ui/skeleton";
 import { cn } from "../../lib/cn";
+import { DASHBOARD_CHART_AXIS_LABEL_CLASS } from "./chart-contract";
+import type { WorkChartModel } from "./trends";
 import {
-  EMPTY_STATE_CLASS,
-  EMPTY_STATE_COMPACT_CLASS,
-} from "../../components/dashboard/widget-board";
-import type { WorkChartModel, WorkChartSeriesKey } from "./trends";
+  buildWorkChartData,
+  type WorkChartBuiltSeries,
+  type WorkChartData,
+  type WorkChartRow,
+  type WorkChartSeriesDefinition,
+} from "./work-chart-data";
+
+export type { WorkChartSeriesDefinition } from "./work-chart-data";
 
 export const WORK_CHART_AXIS_LABEL_CLASS = DASHBOARD_CHART_AXIS_LABEL_CLASS;
 export const WORK_CHART_EMPTY_TITLE = "No work outcome samples";
 export const WORK_CHART_EMPTY_MESSAGE =
   "Work outcome data appears after the event stream receives work history.";
 export const WORK_CHART_LOADING_TITLE = "Loading work outcome samples";
-export const WORK_CHART_LOADING_MESSAGE = "Waiting for dashboard timeline data.";
+export const WORK_CHART_LOADING_MESSAGE =
+  "Waiting for dashboard timeline data.";
 export const WORK_CHART_ERROR_TITLE = "Work outcome chart unavailable";
 export const WORK_CHART_ERROR_MESSAGE =
   "Chart data is incomplete, so the dashboard cannot draw this work outcome view yet.";
 const WORK_CHART_MARGIN = { bottom: 40, left: 18, right: 28, top: 28 };
 const WORK_CHART_READY_CLASS =
-  "h-[16rem] min-h-[14rem] px-5 pb-5 pt-4 sm:h-[18rem] sm:px-6 sm:pb-6 sm:pt-5";
+  "h-64 min-h-56 px-5 pb-5 pt-4 sm:h-72 sm:px-6 sm:pb-6 sm:pt-5";
 const WORK_CHART_OVERLAY_CLASS =
   "flex items-start justify-between gap-3 px-5 pb-4 pt-4 sm:px-6 sm:pb-5 sm:pt-5";
 const WORK_CHART_X_AXIS_OVERLAY_CLASS = "self-end";
 const WORK_CHART_Y_AXIS_WIDTH = 52;
-
-export interface WorkChartSeriesDefinition {
-  key: WorkChartSeriesKey;
-  label: string;
-  lineColor: string;
-  lineClassName: string;
-  pointClassName?: string;
-  pointRadius?: number;
-}
 
 export type WorkChartState =
   | { status: "ready" }
@@ -139,13 +139,15 @@ export function WorkChart({
     );
   }
 
-  return renderReadyWorkChart({
-    ariaLabel,
-    chartData: chartData.data,
-    className,
-    xAxisLabel,
-    yAxisLabel,
-  });
+  return (
+    <ReadyWorkChart
+      ariaLabel={ariaLabel}
+      chartData={chartData.data}
+      className={className}
+      xAxisLabel={xAxisLabel}
+      yAxisLabel={yAxisLabel}
+    />
+  );
 }
 
 interface ReadyWorkChartProps {
@@ -156,31 +158,96 @@ interface ReadyWorkChartProps {
   yAxisLabel: string;
 }
 
-function renderReadyWorkChart({
+function ReadyWorkChart({
   ariaLabel,
   chartData,
   className,
   xAxisLabel,
   yAxisLabel,
 }: ReadyWorkChartProps) {
+  const [zoomRange, setZoomRange] = useState<WorkChartZoomRange | null>(null);
+  const [selectionStartTick, setSelectionStartTick] = useState<number | null>(
+    null,
+  );
+  const [selectionEndTick, setSelectionEndTick] = useState<number | null>(null);
+
+  const visibleRows = useMemo(
+    () => filterRowsForZoomRange(chartData.rows, zoomRange),
+    [chartData.rows, zoomRange],
+  );
+  const selectionRange = buildSelectionRange(
+    selectionStartTick,
+    selectionEndTick,
+  );
+
+  const beginSelection = (event: ReactMouseEvent<HTMLDivElement>) => {
+    const tick = readPointerTick(event, visibleRows);
+    setSelectionStartTick(tick);
+    setSelectionEndTick(tick);
+  };
+
+  const updateSelection = (event: ReactMouseEvent<HTMLDivElement>) => {
+    if (selectionStartTick === null) {
+      return;
+    }
+
+    const tick = readPointerTick(event, visibleRows);
+    if (tick !== null) {
+      setSelectionEndTick(tick);
+    }
+  };
+
+  const commitSelection = (event: ReactMouseEvent<HTMLDivElement>) => {
+    const endTick = readPointerTick(event, visibleRows) ?? selectionEndTick;
+    const nextRange = buildSelectionRange(selectionStartTick, endTick);
+    setSelectionStartTick(null);
+    setSelectionEndTick(null);
+
+    if (nextRange === null || nextRange.startTick === nextRange.endTick) {
+      return;
+    }
+
+    setZoomRange(nextRange);
+  };
+
   return (
     <ChartContainer
       className={cn(WORK_CHART_READY_CLASS, className)}
       config={chartData.config}
+      interactionAttributes={{
+        onMouseDown: beginSelection,
+        onMouseMove: updateSelection,
+        onMouseUp: commitSelection,
+      }}
       overlay={
-        <div className={WORK_CHART_OVERLAY_CLASS} data-work-chart-overlay="true">
+        <div
+          className={WORK_CHART_OVERLAY_CLASS}
+          data-work-chart-overlay="true"
+        >
           <p className={cn("m-0", WORK_CHART_AXIS_LABEL_CLASS)}>{yAxisLabel}</p>
-          <p className={cn("m-0", WORK_CHART_AXIS_LABEL_CLASS, WORK_CHART_X_AXIS_OVERLAY_CLASS)}>
+          <p
+            className={cn(
+              "m-0",
+              WORK_CHART_AXIS_LABEL_CLASS,
+              WORK_CHART_X_AXIS_OVERLAY_CLASS,
+            )}
+          >
             {xAxisLabel}
           </p>
         </div>
       }
-      rootAttributes={{ "data-work-chart-ready": "true" }}
+      rootAttributes={{
+        "data-work-chart-ready": "true",
+        "data-work-chart-visible-ticks": visibleRows
+          .map((row) => row.tick)
+          .join(","),
+      }}
+      style={{ height: "16rem", minHeight: "14rem" }}
       title={ariaLabel}
     >
       <LineChart
         accessibilityLayer
-        data={chartData.rows}
+        data={visibleRows}
         margin={WORK_CHART_MARGIN}
       >
         <CartesianGrid vertical={false} />
@@ -209,32 +276,68 @@ function renderReadyWorkChart({
           cursor={{ stroke: "rgb(from var(--color-af-overlay) r g b / 0.16)" }}
         />
         <ChartLegend content={<ChartLegendContent />} />
-        {chartData.series.map((seriesData) => (
-          <Line
-            key={seriesData.key}
-            activeDot={{
-              className: seriesData.pointClassName,
-              fill: seriesData.lineColor,
-              r: seriesData.pointRadius,
-              stroke: "rgb(from var(--color-af-canvas) r g b / 0.88)",
-              strokeWidth: 1.5,
-            }}
-            className={seriesData.lineClassName}
-            data-chart-series={seriesData.key}
-            data-chart-series-color={seriesData.lineColor}
-            dataKey={seriesData.key}
-            dot={false}
-            isAnimationActive={false}
-            name={seriesData.label}
-            stroke={seriesData.lineColor}
-            strokeDasharray={seriesData.strokeDasharray}
-            strokeWidth={2.25}
-            type="linear"
-          />
-        ))}
+        <WorkChartSelectionArea selectionRange={selectionRange} />
+        <WorkChartLines series={chartData.series} />
       </LineChart>
     </ChartContainer>
   );
+}
+
+function WorkChartSelectionArea({
+  selectionRange,
+}: {
+  selectionRange: WorkChartZoomRange | null;
+}) {
+  if (
+    selectionRange === null ||
+    selectionRange.startTick === selectionRange.endTick
+  ) {
+    return null;
+  }
+
+  return (
+    <ReferenceArea
+      fill="rgb(from var(--color-af-accent) r g b / 0.12)"
+      stroke="rgb(from var(--color-af-accent) r g b / 0.42)"
+      x1={selectionRange.startTick}
+      x2={selectionRange.endTick}
+    />
+  );
+}
+
+function WorkChartLines({
+  series,
+}: {
+  series: readonly WorkChartBuiltSeries[];
+}) {
+  return series.map((seriesData) => (
+    <Line
+      key={seriesData.key}
+      activeDot={{
+        className: seriesData.pointClassName,
+        fill: seriesData.lineColor,
+        r: seriesData.pointRadius,
+        stroke: "rgb(from var(--color-af-canvas) r g b / 0.88)",
+        strokeWidth: 1.5,
+      }}
+      className={seriesData.lineClassName}
+      data-chart-series={seriesData.key}
+      data-chart-series-color={seriesData.lineColor}
+      dataKey={seriesData.key}
+      dot={false}
+      isAnimationActive={false}
+      name={seriesData.label}
+      stroke={seriesData.lineColor}
+      strokeDasharray={seriesData.strokeDasharray}
+      strokeWidth={2.25}
+      type="linear"
+    />
+  ));
+}
+
+interface WorkChartZoomRange {
+  endTick: number;
+  startTick: number;
 }
 
 interface WorkChartStatusPanelProps {
@@ -271,95 +374,53 @@ function WorkChartStatusPanel({
   );
 }
 
-interface WorkChartBuiltSeries {
-  key: string;
-  label: string;
-  lineColor: string;
-  lineClassName: string;
-  pointClassName?: string;
-  pointRadius?: number;
-  strokeDasharray?: string;
-}
-
-interface WorkChartData {
-  config: Record<string, { color: string; label: string }>;
-  rows: WorkChartRow[];
-  series: WorkChartBuiltSeries[];
-}
-
-interface WorkChartRow {
-  label: string;
-  tick: number;
-  [seriesKey: string]: number | string | undefined;
-}
-
-type WorkChartDataResult =
-  | { data: WorkChartData; status: "ready" }
-  | { status: "empty" }
-  | { status: "invalid" };
-
-function buildWorkChartData(
-  model: WorkChartModel | undefined,
-  series: readonly WorkChartSeriesDefinition[],
-): WorkChartDataResult {
-  if (!isWorkChartModel(model) || !isWorkChartSeriesDefinitionArray(series)) {
-    return { status: "invalid" };
+function filterRowsForZoomRange(
+  rows: readonly WorkChartRow[],
+  zoomRange: WorkChartZoomRange | null,
+): WorkChartRow[] {
+  if (zoomRange === null) {
+    return [...rows];
   }
 
-  if (model.points.length === 0 || series.length === 0) {
-    return { status: "empty" };
-  }
-
-  const seriesByKey = new Map(
-    model.series.map((definition) => [definition.key, definition.points]),
+  const filteredRows = rows.filter(
+    (row) => row.tick >= zoomRange.startTick && row.tick <= zoomRange.endTick,
   );
-  const rows = model.points.map((point, index) => {
-    const row: WorkChartRow = {
-      label: point.label,
-      tick: point.tick,
-    };
+  return filteredRows.length >= 2 ? filteredRows : [...rows];
+}
 
-    for (const definition of series) {
-      const value = seriesByKey
-        .get(definition.key)
-        ?.find((seriesPoint) => seriesPoint.order === index)?.value;
-      if (value !== undefined) {
-        row[definition.key] = value;
-      }
-    }
-
-    return row;
-  });
-
-  const builtSeries = series
-    .filter((definition) => rows.some((row) => hasSeriesValue(row, definition.key)))
-    .map((definition) => ({
-      key: definition.key,
-      label: definition.label,
-      lineClassName: definition.lineClassName,
-      lineColor: definition.lineColor,
-      pointClassName: definition.pointClassName,
-      pointRadius: definition.pointRadius,
-      strokeDasharray: extractStrokeDasharray(definition.lineClassName),
-    }));
+function buildSelectionRange(
+  startTick: number | null,
+  endTick: number | null,
+): WorkChartZoomRange | null {
+  if (startTick === null || endTick === null) {
+    return null;
+  }
 
   return {
-    data: {
-      config: Object.fromEntries(
-        builtSeries.map((seriesEntry) => [
-          seriesEntry.key,
-          { color: seriesEntry.lineColor, label: seriesEntry.label },
-        ]),
-      ),
-      rows,
-      series: builtSeries,
-    },
-    status: "ready",
+    endTick: Math.max(startTick, endTick),
+    startTick: Math.min(startTick, endTick),
   };
 }
 
-function hasSeriesValue(row: WorkChartRow, key: string): boolean {
-  return  Object.hasOwn(row, key) && typeof row[key] === "number";
+function readPointerTick(
+  event: ReactMouseEvent<HTMLDivElement>,
+  rows: readonly WorkChartRow[],
+): number | null {
+  if (rows.length === 0) {
+    return null;
+  }
+
+  const rect = event.currentTarget.getBoundingClientRect();
+  if (!Number.isFinite(rect.width) || rect.width <= 0) {
+    return null;
+  }
+
+  const relativeX = Math.min(
+    Math.max(event.clientX - rect.left, 0),
+    rect.width,
+  );
+  const rowIndex = Math.round((relativeX / rect.width) * (rows.length - 1));
+  return rows[rowIndex]?.tick ?? null;
 }
 
 function formatAxisNumber(value: number): string {
@@ -367,77 +428,4 @@ function formatAxisNumber(value: number): string {
     return String(value);
   }
   return value.toFixed(1);
-}
-
-function extractStrokeDasharray(className: string): string | undefined {
-  const dashArrayMatch = className.match(/\[stroke-dasharray:([^\]]+)\]/);
-  return dashArrayMatch?.[1]?.replaceAll("_", " ");
-}
-
-function isWorkChartSeriesDefinitionArray(
-  value: unknown,
-): value is readonly WorkChartSeriesDefinition[] {
-  return Array.isArray(value) && value.every(isWorkChartSeriesDefinition);
-}
-
-function isWorkChartSeriesDefinition(value: unknown): value is WorkChartSeriesDefinition {
-  return (
-    isRecord(value) &&
-    typeof value.key === "string" &&
-    typeof value.label === "string" &&
-    typeof value.lineColor === "string" &&
-    typeof value.lineClassName === "string" &&
-    (value.pointClassName === undefined || typeof value.pointClassName === "string") &&
-    (value.pointRadius === undefined || isFiniteNumber(value.pointRadius))
-  );
-}
-
-function isWorkChartModel(value: unknown): value is WorkChartModel {
-  return (
-    isRecord(value) &&
-    Array.isArray(value.points) &&
-    Array.isArray(value.series) &&
-    value.points.every(isWorkChartSample) &&
-    value.series.every(isWorkChartSeries)
-  );
-}
-
-function isWorkChartSample(value: unknown): value is WorkChartModel["points"][number] {
-  return (
-    isRecord(value) &&
-    typeof value.label === "string" &&
-    isFiniteNumber(value.observedAt) &&
-    isFiniteNumber(value.order) &&
-    isFiniteNumber(value.tick)
-  );
-}
-
-function isWorkChartSeries(value: unknown): value is WorkChartModel["series"][number] {
-  return (
-    isRecord(value) &&
-    typeof value.key === "string" &&
-    typeof value.label === "string" &&
-    Array.isArray(value.points) &&
-    value.points.every(isWorkChartSeriesPoint)
-  );
-}
-
-function isWorkChartSeriesPoint(
-  value: unknown,
-): value is WorkChartModel["series"][number]["points"][number] {
-  return (
-    isRecord(value) &&
-    typeof value.label === "string" &&
-    isFiniteNumber(value.observedAt) &&
-    isFiniteNumber(value.order) &&
-    isFiniteNumber(value.value)
-  );
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function isFiniteNumber(value: unknown): value is number {
-  return typeof value === "number" && Number.isFinite(value);
 }


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/work-outcome-chart-zoom",
  "description": "Add zoom support to the dashboard work outcome chart so customers can drag across the chart to focus on a selected tick range, see active zoom context, and reset back to the full range.",
  "context": {
    "customerAsk": "The current work outcome charts do not support zoom. Update the component to allow zooming and add corresponding tests. Reference interaction: https://recharts.github.io/en-US/examples/HighlightAndZoomLineChart/",
    "problem": "Customers can only inspect the full selected work outcome time range. Dense or spiky outcome series are harder to diagnose because the chart cannot focus on a smaller interval without changing broader dashboard state.",
    "solution": "Add chart-local Recharts zoom behavior to the existing work outcome chart: drag to select a tick range, render only rows inside the active range, show accessible zoom context and a reset control, and cover the behavior with focused component and browser-visible tests."
  },
  "acceptanceCriteria": [
    "A customer can drag across the ready work outcome chart to zoom into the selected tick range.",
    "The zoomed chart renders only samples inside the selected range while preserving labels, legend, tooltips, and series colors.",
    "A visible and keyboard-accessible reset control appears when the chart is zoomed and restores the full chart range.",
    "Invalid selections, single-point selections, clicks without drag, and reversed drag direction do not crash or leave the chart in a broken state.",
    "Loading, empty, and error states do not expose inactive zoom controls and continue to render the same user-facing state messages.",
    "The chart remains usable without horizontal page scrolling on mobile and desktop dashboard layouts.",
    "Typecheck, lint, and tests pass."
  ],
  "userStories": [
    {
      "id": "work-outcome-chart-zoom-001",
      "title": "Zoom work outcome chart by drag selection",
      "description": "As a dashboard customer, I want to drag across the work outcome chart to focus on a smaller tick range so that I can inspect spikes and transitions in work outcomes.",
      "acceptanceCriteria": [
        "In the ready chart state, dragging horizontally across two or more tick positions applies a zoomed domain bounded by the selected start and end ticks.",
        "Dragging from right to left applies the same zoomed domain as selecting the same ticks from left to right.",
        "The zoomed chart renders only rows within the selected tick range and keeps the existing series legend, axis labels, tooltip content, and color mapping.",
        "Clicks without a valid drag and selections that resolve to fewer than two distinct ticks leave the chart at its current domain.",
        "The implementation does not change the chart's loading, empty, or error state behavior.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "work-outcome-chart-zoom-002",
      "title": "Show and operate chart zoom reset controls",
      "description": "As a dashboard customer, I want a clear way to see and clear the active zoom so that I can return to the full work outcome range without refreshing the page.",
      "acceptanceCriteria": [
        "A reset zoom control is visible only when a zoomed range is active.",
        "Activating the reset control restores the full chart range and hides the reset control.",
        "The reset control is a semantic button with an accessible name and visible focus styling.",
        "Keyboard users can tab to the reset control and activate it with Enter or Space.",
        "The chart exposes user-visible zoom context, such as the active tick range, without relying only on color or pointer position.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "work-outcome-chart-zoom-003",
      "title": "Preserve chart states, layout, and verification coverage",
      "description": "As a reviewer, I want focused behavioral coverage for chart zoom states so that zoom support does not regress existing work outcome chart behavior.",
      "acceptanceCriteria": [
        "Component tests cover successful drag-to-zoom, reversed drag direction, invalid click-only selection, reset zoom, and sparse-series rendering after zoom.",
        "Component tests confirm loading, empty, and error states render without active zoom affordances.",
        "Storybook or browser verification demonstrates the ready chart zoom interaction at a desktop viewport.",
        "Browser verification confirms the work outcome chart remains readable and does not introduce horizontal page scrolling at a mobile viewport.",
        "No backend, OpenAPI, event-stream, or persisted user preference behavior is introduced for this feature.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}
