### PR TITLE
consolidate-safe-diagnostics-string-map-clone-ownership

### DIFF
--- a/pkg/interfaces/safe_diagnostics.go
+++ b/pkg/interfaces/safe_diagnostics.go
@@ -309,7 +309,7 @@ func safeDiagnosticsStringMapPtr(values map[string]string) *factoryapi.StringMap
 	if len(values) == 0 {
 		return nil
 	}
-	converted := factoryapi.StringMap(cloneSafeDiagnosticsStringMap(values))
+	converted := factoryapi.StringMap(cloneStringMap(values))
 	return &converted
 }
 
@@ -336,15 +336,4 @@ func safeDiagnosticsStringValue(value *string) string {
 		return ""
 	}
 	return *value
-}
-
-func cloneSafeDiagnosticsStringMap(input map[string]string) map[string]string {
-	if input == nil {
-		return nil
-	}
-	clone := make(map[string]string, len(input))
-	for key, value := range input {
-		clone[key] = value
-	}
-	return clone
 }

--- a/pkg/interfaces/safe_diagnostics_test.go
+++ b/pkg/interfaces/safe_diagnostics_test.go
@@ -3,6 +3,8 @@ package interfaces
 import (
 	"reflect"
 	"testing"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
 )
 
 func TestWorkDiagnosticsFromSafeWorkDiagnostics_NilSafe(t *testing.T) {
@@ -110,5 +112,53 @@ func TestSafeWorkDiagnosticsRoundTrip_PreservesSafeFieldsOnly(t *testing.T) {
 	}
 	if rehydrated.Metadata != nil {
 		t.Fatalf("rehydrated metadata = %#v, want nil", rehydrated.Metadata)
+	}
+}
+
+func TestGeneratedSafeWorkDiagnostics_ClonesMapsAndPreservesNil(t *testing.T) {
+	diagnostics := &SafeWorkDiagnostics{
+		RenderedPrompt: &SafeRenderedPromptDiagnostic{
+			Variables: map[string]string{"prompt_source": "factory"},
+		},
+		Provider: &SafeProviderDiagnostic{
+			RequestMetadata:  map[string]string{"session_id": "req-1"},
+			ResponseMetadata: map[string]string{"retry_count": "0"},
+		},
+	}
+
+	generated := GeneratedSafeWorkDiagnostics(diagnostics)
+	(*generated.RenderedPrompt.Variables)["prompt_source"] = "mutated"
+	(*generated.Provider.RequestMetadata)["session_id"] = "mutated"
+	(*generated.Provider.ResponseMetadata)["retry_count"] = "1"
+
+	if diagnostics.RenderedPrompt.Variables["prompt_source"] != "factory" {
+		t.Fatalf("safe rendered prompt variables mutated = %#v", diagnostics.RenderedPrompt.Variables)
+	}
+	if diagnostics.Provider.RequestMetadata["session_id"] != "req-1" {
+		t.Fatalf("safe request metadata mutated = %#v", diagnostics.Provider.RequestMetadata)
+	}
+	if diagnostics.Provider.ResponseMetadata["retry_count"] != "0" {
+		t.Fatalf("safe response metadata mutated = %#v", diagnostics.Provider.ResponseMetadata)
+	}
+
+	if got := GeneratedSafeWorkDiagnostics(&SafeWorkDiagnostics{
+		RenderedPrompt: &SafeRenderedPromptDiagnostic{Variables: nil},
+		Provider: &SafeProviderDiagnostic{
+			RequestMetadata:  nil,
+			ResponseMetadata: map[string]string{},
+		},
+	}); got == nil {
+		t.Fatal("GeneratedSafeWorkDiagnostics returned nil, want non-nil diagnostics shell")
+	} else {
+		assertNilStringMapPtr(t, got.RenderedPrompt.Variables, "rendered prompt variables")
+		assertNilStringMapPtr(t, got.Provider.RequestMetadata, "request metadata")
+		assertNilStringMapPtr(t, got.Provider.ResponseMetadata, "response metadata")
+	}
+}
+
+func assertNilStringMapPtr(t *testing.T, got *factoryapi.StringMap, field string) {
+	t.Helper()
+	if got != nil {
+		t.Fatalf("%s = %#v, want nil", field, got)
 	}
 }


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/consolidate-safe-diagnostics-string-map-clone-ownership",
  "description": "Consolidate safe-diagnostics string-map clone ownership onto the existing pkg/interfaces cloneStringMap helper so generated safe-diagnostics conversion keeps the same nil-preserving detached-copy behavior without changing filtering rules or public contracts.",
  "context": {
    "customerAsk": "Remove the redundant private safe-diagnostics map clone helper, reuse the existing package-level cloneStringMap helper in the safe-diagnostics conversion path, keep the cleanup narrow, and preserve nil-in, nil-out detached map-copy semantics without changing filtering behavior or public contracts.",
    "problem": "pkg/interfaces/safe_diagnostics.go defines cloneSafeDiagnosticsStringMap even though pkg/interfaces/world_state_clones.go already defines the canonical package-level cloneStringMap for the same nil-preserving detached copy of map[string]string. safeDiagnosticsStringMapPtr is the only caller of the redundant helper, so the package currently keeps two ownership points for the same clone behavior without any observable product need.",
    "solution": "Route safeDiagnosticsStringMapPtr through the existing package-level cloneStringMap helper, delete the redundant cloneSafeDiagnosticsStringMap function, and preserve current behavior by relying on the existing pkg/interfaces tests that already prove safe-diagnostics round-trip behavior, detached map copies, and canonical safe-diagnostics clone assertions."
  },
  "acceptanceCriteria": [
    "pkg/interfaces/safe_diagnostics.go no longer defines a redundant private cloneSafeDiagnosticsStringMap helper.",
    "Safe-diagnostics generated-contract conversion reuses the existing package-level cloneStringMap owner for map[string]string detached copies.",
    "Nil-in, nil-out behavior remains unchanged for safe-diagnostics string-map conversion.",
    "Safe-diagnostics map conversion still returns detached copies so later mutation does not leak across safe and worker-facing diagnostic boundaries.",
    "Existing pkg/interfaces behavioral tests remain the proof points for safe-diagnostics round-trip, detached map-copy behavior, and canonical safe-diagnostics clone assertions without introducing public behavior changes.",
    "Typecheck, lint, and tests pass for the touched backend package."
  ],
  "userStories": [
    {
      "id": "consolidate-safe-diagnostics-string-map-clone-ownership-001",
      "title": "Reuse the canonical string-map clone owner in safe-diagnostics conversion",
      "description": "As a backend maintainer, I want safe-diagnostics string-map conversion to reuse the canonical pkg/interfaces clone helper so one package does not maintain parallel detached-copy implementations for the same map[string]string behavior.",
      "acceptanceCriteria": [
        "safeDiagnosticsStringMapPtr uses the existing package-level cloneStringMap helper when converting safe-diagnostics maps to the generated StringMap contract.",
        "pkg/interfaces/safe_diagnostics.go no longer defines the redundant private cloneSafeDiagnosticsStringMap helper.",
        "Safe-diagnostics generated conversion preserves nil-in, nil-out semantics for absent or empty input maps.",
        "Existing pkg/interfaces/safe_diagnostics_test.go and pkg/interfaces/world_state_clones_test.go continue to prove detached map-copy behavior and safe-diagnostics round-trip behavior without requiring public behavior changes.",
        "The cleanup does not change safe-diagnostics filtering rules, exported interfaces, or generated API contracts.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": false,
      "notes": ""
    }
  ]
}
