### PR TITLE
retire-legacy-interfaces-state-shim

### DIFF
--- a/pkg/cli/run/run.go
+++ b/pkg/cli/run/run.go
@@ -79,6 +79,11 @@ var buildFactoryService = func(
 	return service.BuildFactoryService(ctx, cfg)
 }
 
+const (
+	completedPlaceIDSuffix = "completed"
+	failedPlaceIDSuffix    = "failed"
+)
+
 var bootstrapFactory = func(dir string) error {
 	resolvedDir, err := factoryconfig.ResolveCurrentFactoryDir(dir)
 	if err != nil {
@@ -444,11 +449,11 @@ func CountTokenStates(snap *petri.MarkingSnapshot) (wip, completed, failed int) 
 }
 
 func isTerminalState(state string) bool {
-	return state == string(interfaces.StateCompleted)
+	return state == completedPlaceIDSuffix
 }
 
 func isFailedState(state string) bool {
-	return state == string(interfaces.StateFailed)
+	return state == failedPlaceIDSuffix
 }
 
 // FormatDuration formats a duration as "Xm" or "Xh Ym".

--- a/pkg/cli/run/run_test.go
+++ b/pkg/cli/run/run_test.go
@@ -98,6 +98,17 @@ func TestCountTokenStates(t *testing.T) {
 			},
 			wantFail: 3,
 		},
+		{
+			name: "work type prefix stays local to suffix classification",
+			tokens: map[string]*interfaces.Token{
+				"t1": {ID: "t1", PlaceID: "story:phase:completed"},
+				"t2": {ID: "t2", PlaceID: "story:phase:failed"},
+				"t3": {ID: "t3", PlaceID: "story:phase:queued"},
+			},
+			wantWIP:  1,
+			wantDone: 1,
+			wantFail: 1,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/interfaces/constants.go
+++ b/pkg/interfaces/constants.go
@@ -1,14 +1,5 @@
 package interfaces
 
-// State classifies a work-type state at the compatibility edges that still
-// read terminal or failed values as strings.
-type State string
-
-const (
-	StateCompleted State = "completed"
-	StateFailed    State = "failed"
-)
-
 // File directories
 
 const (


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/retire-legacy-interfaces-state-shim",
  "description": "Remove the legacy exported lowercase State compatibility shim from pkg/interfaces and keep the CLI token place-suffix classification logic local to pkg/cli/run without changing observable CountTokenStates behavior.",
  "context": {
    "customerAsk": "Remove the legacy exported State compatibility shim from pkg/interfaces/constants.go, keep terminal-place suffix detection local to the CLI package, preserve the {work_type_id}:{state_value} place ID convention, and rely on existing CLI tests to prove token-state counting behavior stays the same.",
    "problem": "pkg/interfaces still exports a lowercase State shim even though the canonical factory lifecycle enum already exists separately in pkg/interfaces/factory_runtime.go, and the shim's only remaining runtime consumer is the CLI token-state counting path in pkg/cli/run.",
    "solution": "Move completed and failed place-suffix detection fully into pkg/cli/run using explicit local lowercase suffix ownership, keep the CLI counting behavior unchanged for completed and failed token places, then remove the retired State exports from pkg/interfaces/constants.go without altering FactoryState values or runtime lifecycle behavior."
  },
  "acceptanceCriteria": [
    "pkg/cli/run classifies terminal and failed token place suffixes without depending on interfaces.State, StateCompleted, or StateFailed.",
    "CountTokenStates continues to treat place IDs ending in lowercase completed as completed and lowercase failed as failed, with all other suffixes remaining work-in-progress.",
    "The {work_type_id}:{state_value} place ID convention remains unchanged for CLI token-state counting behavior.",
    "pkg/interfaces/constants.go no longer exports the legacy State type or the StateCompleted and StateFailed constants.",
    "FactoryStateCompleted, FactoryStateFailed, and factory runtime lifecycle behavior remain unchanged.",
    "Typecheck, lint, and the relevant CLI tests pass as the final quality gate."
  ],
  "userStories": [
    {
      "id": "retire-legacy-interfaces-state-shim-001",
      "title": "Localize CLI terminal and failed suffix classification",
      "description": "As a CLI maintainer, I want the token-state counting path to own its lowercase place-suffix rules locally so the CLI behavior no longer depends on a broad exported compatibility shim.",
      "acceptanceCriteria": [
        "pkg/cli/run/run.go classifies terminal and failed place suffixes using CLI-local logic instead of converting through interfaces.State.",
        "The CLI continues to treat a place ID suffix of completed as completed and a suffix of failed as failed.",
        "Place IDs with any other suffix continue to count as work-in-progress.",
        "TestCountTokenStates or equivalent focused CLI tests explicitly prove the mixed, completed-only, and failed-only counting paths still behave the same.",
        "No CLI behavior is changed to use uppercase FactoryState lifecycle values for place-suffix detection.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "retire-legacy-interfaces-state-shim-002",
      "title": "Remove the retired exported state shim from interfaces",
      "description": "As a backend maintainer, I want the obsolete exported lowercase State shim removed from pkg/interfaces once the CLI no longer needs it so the shared interfaces package only exposes actively owned runtime surfaces.",
      "acceptanceCriteria": [
        "pkg/interfaces/constants.go no longer exports State, StateCompleted, or StateFailed.",
        "The cleanup does not rename or alter FactoryStateCompleted, FactoryStateFailed, or other factory runtime lifecycle values.",
        "The CLI token-state counting path continues to compile and use the same lowercase place-suffix behavior after the shim removal.",
        "Existing CLI tests continue to prove terminal and failed helper behavior and the token-state counting path after the retired exports are removed.",
        "No unrelated enum cleanup, public API contract edits, or place ID convention changes are included in this task.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
