### PR TITLE
extract-shared-app-dashboard-test-harness

### DIFF
--- a/ui/src/App.current-selection.test.tsx
+++ b/ui/src/App.current-selection.test.tsx
@@ -1,93 +1,28 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   act,
-  cleanup,
   fireEvent,
-  render,
   screen,
   waitFor,
   within,
 } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { App } from "./App";
+import { describe, expect, it } from "vitest";
+import {
+  MockEventSource,
+  registerAppDashboardTestLifecycle,
+  removeTraceIDsFromSnapshot,
+  renderApp,
+  requireValue,
+} from "./App.dashboard-test-harness";
 import type {
   DashboardSnapshot,
   DashboardTrace,
-  DashboardWorkItemRef,
-  DashboardWorkstationRequest,
 } from "./api/dashboard";
 import {
   buildDashboardSnapshotFixture,
   dashboardWorkstationRequestFixtures,
   mediumBranchingDashboardTopology,
 } from "./components/dashboard/fixtures";
-import { installDashboardBrowserTestShims } from "./components/dashboard/test-browser-shims";
 import { semanticWorkflowDashboardSnapshot } from "./components/dashboard/test-fixtures";
-import { useDashboardBentoStore } from "./features/bento/state/dashboardBentoStore";
-import { reloadDashboardLayoutFromStorage } from "./features/bento/useDashboardLayout";
-import { useCurrentEditableFactoryDefinition } from "./features/current-factory-definition";
-import { resetSelectionHistoryStore } from "./features/current-selection/state/selectionHistoryStore";
-import {
-  createDefaultDashboardStreamState,
-  useDashboardStreamStore,
-} from "./features/dashboard/state/dashboardStreamStore";
-import { useExportDialogStore } from "./features/export/state/exportDialogStore";
-import type { WorldState } from "./features/timeline/state/factoryTimelineStore";
-import { useFactoryTimelineStore } from "./features/timeline/state/factoryTimelineStore";
-
-vi.mock("./features/current-factory-definition", async () => {
-  const actual = await vi.importActual("./features/current-factory-definition");
-
-  return {
-    ...actual,
-    useCurrentEditableFactoryDefinition: vi.fn(),
-  };
-});
-
-class MockEventSource {
-  public static instances: MockEventSource[] = [];
-
-  public onerror: ((event: Event) => void) | null = null;
-  public onopen: ((event: Event) => void) | null = null;
-
-  private readonly listeners = new Map<string, EventListener[]>();
-
-  constructor(public readonly url: string) {
-    MockEventSource.instances.push(this);
-  }
-
-  public addEventListener(type: string, listener: EventListener): void {
-    const existing = this.listeners.get(type) ?? [];
-    existing.push(listener);
-    this.listeners.set(type, existing);
-  }
-
-  public close(): void {}
-
-  public emit(type: string, data: unknown): void {
-    if (type === "snapshot") {
-      const state = useFactoryTimelineStore.getState();
-      const tracesByWorkID =
-        state.worldViewCache[state.selectedTick]?.tracesByWorkID ?? {};
-      seedTimelineSnapshot(data as DashboardSnapshot, tracesByWorkID);
-    }
-
-    const event = new MessageEvent(type, {
-      data: JSON.stringify(data),
-    });
-
-    for (const listener of this.listeners.get(type) ?? []) {
-      listener(event);
-    }
-  }
-}
-
-interface RenderAppOptions {
-  snapshot: DashboardSnapshot;
-  timelineSnapshots?: DashboardSnapshot[];
-  traceFixtures?: Record<string, DashboardTrace>;
-  workstationRequestsByDispatchID?: Record<string, DashboardWorkstationRequest>;
-}
 
 const activeWorkID = "work-active-story";
 const completedWorkID = "work-complete";
@@ -272,133 +207,6 @@ const failedTraceSnapshot: DashboardTrace = {
   ],
 };
 
-const queryClients: QueryClient[] = [];
-let restoreBrowserTestShims: (() => void) | null = null;
-
-function timelineSnapshot(
-  snapshot: DashboardSnapshot,
-  tracesByWorkID: Record<string, DashboardTrace> = {},
-  workstationRequestsByDispatchID: Record<
-    string,
-    DashboardWorkstationRequest
-  > = {},
-): WorldState {
-  return {
-    ...snapshot,
-    relationsByWorkID: {},
-    tracesByWorkID,
-    workstationRequestsByDispatchID,
-    workRequestsByID: {},
-  };
-}
-
-function seedTimelineSnapshot(
-  snapshot: DashboardSnapshot,
-  tracesByWorkID: Record<string, DashboardTrace> = {},
-  workstationRequestsByDispatchID: Record<
-    string,
-    DashboardWorkstationRequest
-  > = {},
-): void {
-  useFactoryTimelineStore.setState({
-    events: [],
-    latestTick: snapshot.tick_count,
-    mode: "current",
-    receivedEventIDs: [],
-    selectedTick: snapshot.tick_count,
-    worldViewCache: {
-      [snapshot.tick_count]: timelineSnapshot(
-        snapshot,
-        tracesByWorkID,
-        workstationRequestsByDispatchID,
-      ),
-    },
-  });
-}
-
-function seedTimelineSnapshots(snapshots: DashboardSnapshot[]): void {
-  const worldViewCache = Object.fromEntries(
-    snapshots.map(
-      (snapshot) =>
-        [
-          snapshot.tick_count,
-          timelineSnapshot(snapshot) satisfies WorldState,
-        ] as const,
-    ),
-  );
-  const latestTick = Math.max(
-    ...snapshots.map((snapshot) => snapshot.tick_count),
-  );
-
-  useFactoryTimelineStore.setState({
-    events: [],
-    latestTick,
-    mode: "current",
-    receivedEventIDs: [],
-    selectedTick: latestTick,
-    worldViewCache,
-  });
-}
-
-function renderApp({
-  snapshot,
-  timelineSnapshots,
-  traceFixtures = {},
-  workstationRequestsByDispatchID = {},
-}: RenderAppOptions) {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        gcTime: Infinity,
-        retry: false,
-      },
-    },
-  });
-  queryClients.push(queryClient);
-
-  const fetchMock = vi
-    .fn()
-    .mockImplementation(async (input: RequestInfo | URL) => {
-      const path =
-        typeof input === "string"
-          ? input
-          : input instanceof URL
-            ? `${input.pathname}${input.search}`
-            : input.url;
-
-      throw new Error(`unexpected fetch for ${path}`);
-    });
-
-  vi.stubGlobal("fetch", fetchMock);
-  vi.stubGlobal("EventSource", MockEventSource);
-  reloadDashboardLayoutFromStorage();
-  if (timelineSnapshots) {
-    seedTimelineSnapshots(timelineSnapshots);
-  } else {
-    seedTimelineSnapshot(
-      snapshot,
-      traceFixtures,
-      workstationRequestsByDispatchID,
-    );
-  }
-
-  const result = render(
-    <QueryClientProvider client={queryClient}>
-      <App />
-    </QueryClientProvider>,
-  );
-
-  return { ...result, fetchMock };
-}
-
-function requireValue<T>(value: T | null | undefined, message: string): T {
-  if (value === null || value === undefined) {
-    throw new Error(message);
-  }
-
-  return value;
-}
-
 function getDispatchHistoryCard(
   container: HTMLElement,
   dispatchId: string,
@@ -465,73 +273,6 @@ function getActiveStorySelectionButton(): HTMLElement {
   return activeStoryButton;
 }
 
-function removeTraceIDFromWorkItem(
-  workItem: DashboardWorkItemRef,
-): DashboardWorkItemRef {
-  const withoutTraceID: DashboardWorkItemRef = { work_id: workItem.work_id };
-  if (workItem.display_name) {
-    withoutTraceID.display_name = workItem.display_name;
-  }
-  if (workItem.work_type_id) {
-    withoutTraceID.work_type_id = workItem.work_type_id;
-  }
-  return withoutTraceID;
-}
-
-function removeTraceIDsFromSnapshot(
-  snapshot: DashboardSnapshot,
-): DashboardSnapshot {
-  return {
-    ...snapshot,
-    runtime: {
-      ...snapshot.runtime,
-      active_executions_by_dispatch_id: Object.fromEntries(
-        Object.entries(
-          snapshot.runtime.active_executions_by_dispatch_id ?? {},
-        ).map(([dispatchID, execution]) => [
-          dispatchID,
-          {
-            ...execution,
-            trace_ids: [],
-            work_items: execution.work_items?.map(removeTraceIDFromWorkItem),
-          },
-        ]),
-      ),
-      current_work_items_by_place_id: Object.fromEntries(
-        Object.entries(
-          snapshot.runtime.current_work_items_by_place_id ?? {},
-        ).map(([placeID, workItems]) => [
-          placeID,
-          workItems.map(removeTraceIDFromWorkItem),
-        ]),
-      ),
-      session: {
-        ...snapshot.runtime.session,
-        provider_sessions: snapshot.runtime.session.provider_sessions?.map(
-          (attempt) => ({
-            ...attempt,
-            work_items: attempt.work_items?.map(removeTraceIDFromWorkItem),
-          }),
-        ),
-      },
-      workstation_activity_by_node_id: Object.fromEntries(
-        Object.entries(
-          snapshot.runtime.workstation_activity_by_node_id ?? {},
-        ).map(([nodeID, activity]) => [
-          nodeID,
-          {
-            ...activity,
-            active_work_items: activity.active_work_items?.map(
-              removeTraceIDFromWorkItem,
-            ),
-            trace_ids: [],
-          },
-        ]),
-      ),
-    },
-  };
-}
-
 function resizeDashboardViewport(width: number): void {
   Object.defineProperty(window, "innerWidth", {
     configurable: true,
@@ -547,59 +288,7 @@ function resizeDashboardViewport(width: number): void {
 }
 
 describe("App current selection", () => {
-  beforeEach(() => {
-    window.localStorage.clear();
-    MockEventSource.instances = [];
-    restoreBrowserTestShims = installDashboardBrowserTestShims();
-    resetSelectionHistoryStore();
-    vi.mocked(useCurrentEditableFactoryDefinition).mockReturnValue({
-      data: undefined,
-      error: null,
-      failureCount: 0,
-      failureReason: null,
-      fetchStatus: "idle",
-      isError: false,
-      isFetched: false,
-      isFetchedAfterMount: false,
-      isFetching: false,
-      isInitialLoading: false,
-      isLoading: false,
-      isLoadingError: false,
-      isPaused: false,
-      isPending: true,
-      isPlaceholderData: false,
-      isRefetchError: false,
-      isRefetching: false,
-      isStale: true,
-      isSuccess: false,
-      promise: Promise.resolve(undefined),
-      refetch: vi.fn(),
-      status: "pending",
-    } as never);
-  });
-
-  afterEach(() => {
-    for (const queryClient of queryClients.splice(0)) {
-      queryClient.clear();
-    }
-    cleanup();
-    useDashboardBentoStore.setState({
-      refreshToken: 0,
-      selectedTraceID: null,
-    });
-    useExportDialogStore.setState({
-      isExportDialogOpen: false,
-    });
-    useDashboardStreamStore.setState({
-      streamState: createDefaultDashboardStreamState(),
-    });
-    useFactoryTimelineStore.getState().reset();
-    resetSelectionHistoryStore();
-    restoreBrowserTestShims?.();
-    restoreBrowserTestShims = null;
-    vi.restoreAllMocks();
-    vi.unstubAllGlobals();
-  });
+  registerAppDashboardTestLifecycle();
 
   it("renders a trace drill-down for a selected work item", async () => {
     renderApp({
@@ -1212,33 +901,7 @@ describe("App current selection", () => {
 });
 
 describe("App current selection layout", () => {
-  beforeEach(() => {
-    window.localStorage.clear();
-    MockEventSource.instances = [];
-    restoreBrowserTestShims = installDashboardBrowserTestShims();
-  });
-
-  afterEach(() => {
-    for (const queryClient of queryClients.splice(0)) {
-      queryClient.clear();
-    }
-    cleanup();
-    useDashboardBentoStore.setState({
-      refreshToken: 0,
-      selectedTraceID: null,
-    });
-    useExportDialogStore.setState({
-      isExportDialogOpen: false,
-    });
-    useDashboardStreamStore.setState({
-      streamState: createDefaultDashboardStreamState(),
-    });
-    useFactoryTimelineStore.getState().reset();
-    restoreBrowserTestShims?.();
-    restoreBrowserTestShims = null;
-    vi.restoreAllMocks();
-    vi.unstubAllGlobals();
-  });
+  registerAppDashboardTestLifecycle({ resetSelectionHistory: false });
 
   it("keeps selection detail out of the workflow graph inspector layer", async () => {
     renderApp({
@@ -1780,33 +1443,7 @@ describe("App current selection layout", () => {
 });
 
 describe("App current selection terminal states", () => {
-  beforeEach(() => {
-    window.localStorage.clear();
-    MockEventSource.instances = [];
-    restoreBrowserTestShims = installDashboardBrowserTestShims();
-  });
-
-  afterEach(() => {
-    for (const queryClient of queryClients.splice(0)) {
-      queryClient.clear();
-    }
-    cleanup();
-    useDashboardBentoStore.setState({
-      refreshToken: 0,
-      selectedTraceID: null,
-    });
-    useExportDialogStore.setState({
-      isExportDialogOpen: false,
-    });
-    useDashboardStreamStore.setState({
-      streamState: createDefaultDashboardStreamState(),
-    });
-    useFactoryTimelineStore.getState().reset();
-    restoreBrowserTestShims?.();
-    restoreBrowserTestShims = null;
-    vi.restoreAllMocks();
-    vi.unstubAllGlobals();
-  });
+  registerAppDashboardTestLifecycle({ resetSelectionHistory: false });
 
   it("opens completed and failed work summaries and updates the trace card", async () => {
     renderApp({

--- a/ui/src/App.dashboard-test-harness.tsx
+++ b/ui/src/App.dashboard-test-harness.tsx
@@ -1,0 +1,381 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { RenderResult } from "@testing-library/react";
+import { cleanup, render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { Mock } from "vitest";
+import { afterEach, beforeEach, vi } from "vitest";
+import { App } from "./App";
+import type {
+  DashboardSnapshot,
+  DashboardTrace,
+  DashboardWorkItemRef,
+  DashboardWorkstationRequest,
+} from "./api/dashboard";
+import type { FactoryEvent } from "./api/events";
+import { installDashboardBrowserTestShims } from "./components/dashboard/test-browser-shims";
+import { useDashboardBentoStore } from "./features/bento/state/dashboardBentoStore";
+import { reloadDashboardLayoutFromStorage } from "./features/bento/useDashboardLayout";
+import { useCurrentEditableFactoryDefinition } from "./features/current-factory-definition";
+import { resetSelectionHistoryStore } from "./features/current-selection/state/selectionHistoryStore";
+import {
+  createDefaultDashboardStreamState,
+  useDashboardStreamStore,
+} from "./features/dashboard/state/dashboardStreamStore";
+import { useExportDialogStore } from "./features/export/state/exportDialogStore";
+import type { WorldState } from "./features/timeline/state/factoryTimelineStore";
+import { useFactoryTimelineStore } from "./features/timeline/state/factoryTimelineStore";
+
+vi.mock("./features/current-factory-definition", async () => {
+  const actual = await vi.importActual("./features/current-factory-definition");
+
+  return {
+    ...actual,
+    useCurrentEditableFactoryDefinition: vi.fn(),
+  };
+});
+
+export class MockEventSource {
+  public static instances: MockEventSource[] = [];
+
+  public onerror: ((event: Event) => void) | null = null;
+  public onopen: ((event: Event) => void) | null = null;
+
+  private readonly listeners = new Map<string, EventListener[]>();
+
+  constructor(public readonly url: string) {
+    MockEventSource.instances.push(this);
+  }
+
+  public addEventListener(type: string, listener: EventListener): void {
+    const existing = this.listeners.get(type) ?? [];
+    existing.push(listener);
+    this.listeners.set(type, existing);
+  }
+
+  public close(): void {}
+
+  public emit(type: string, data: unknown): void {
+    if (type === "snapshot") {
+      const state = useFactoryTimelineStore.getState();
+      const tracesByWorkID =
+        state.worldViewCache[state.selectedTick]?.tracesByWorkID ?? {};
+      seedTimelineSnapshot(data as DashboardSnapshot, tracesByWorkID);
+    }
+
+    const event = new MessageEvent(type, {
+      data: JSON.stringify(data),
+    });
+
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+export interface RenderAppOptions {
+  browserLanguage?: string | null;
+  browserLanguages?: readonly string[] | null;
+  initialLocale?: string | null;
+  locationSearch?: string | null;
+  snapshot: DashboardSnapshot;
+  timelineEvents?: FactoryEvent[];
+  timelineSnapshots?: DashboardSnapshot[];
+  traceFixtures?: Record<string, DashboardTrace>;
+  workstationRequestsByDispatchID?: Record<string, DashboardWorkstationRequest>;
+}
+
+type AppDashboardFetchMock = Mock<
+  (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+>;
+type RenderAppResult = RenderResult & { fetchMock: AppDashboardFetchMock };
+
+const queryClients: QueryClient[] = [];
+let restoreBrowserTestShims: (() => void) | null = null;
+
+function timelineSnapshot(
+  snapshot: DashboardSnapshot,
+  tracesByWorkID: Record<string, DashboardTrace> = {},
+  workstationRequestsByDispatchID: Record<
+    string,
+    DashboardWorkstationRequest
+  > = {},
+): WorldState {
+  return {
+    ...snapshot,
+    relationsByWorkID: {},
+    tracesByWorkID,
+    workstationRequestsByDispatchID,
+    workRequestsByID: {},
+  };
+}
+
+export function seedTimelineSnapshot(
+  snapshot: DashboardSnapshot,
+  tracesByWorkID: Record<string, DashboardTrace> = {},
+  workstationRequestsByDispatchID: Record<
+    string,
+    DashboardWorkstationRequest
+  > = {},
+): void {
+  useFactoryTimelineStore.setState({
+    events: [],
+    latestTick: snapshot.tick_count,
+    mode: "current",
+    receivedEventIDs: [],
+    selectedTick: snapshot.tick_count,
+    worldViewCache: {
+      [snapshot.tick_count]: timelineSnapshot(
+        snapshot,
+        tracesByWorkID,
+        workstationRequestsByDispatchID,
+      ),
+    },
+  });
+}
+
+export function seedTimelineSnapshots(snapshots: DashboardSnapshot[]): void {
+  const worldViewCache = Object.fromEntries(
+    snapshots.map(
+      (snapshot) =>
+        [
+          snapshot.tick_count,
+          timelineSnapshot(snapshot) satisfies WorldState,
+        ] as const,
+    ),
+  );
+  const latestTick = Math.max(
+    ...snapshots.map((snapshot) => snapshot.tick_count),
+  );
+
+  useFactoryTimelineStore.setState({
+    events: [],
+    latestTick,
+    mode: "current",
+    receivedEventIDs: [],
+    selectedTick: latestTick,
+    worldViewCache,
+  });
+}
+
+export function renderApp({
+  browserLanguage,
+  browserLanguages,
+  initialLocale,
+  locationSearch,
+  snapshot,
+  timelineEvents,
+  timelineSnapshots,
+  traceFixtures = {},
+  workstationRequestsByDispatchID = {},
+}: RenderAppOptions): RenderAppResult {
+  const queryClient = createAppDashboardQueryClient();
+
+  const fetchMock = vi
+    .fn()
+    .mockImplementation(async (input: RequestInfo | URL) => {
+      const path =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? `${input.pathname}${input.search}`
+            : input.url;
+
+      throw new Error(`unexpected fetch for ${path}`);
+    });
+
+  vi.stubGlobal("fetch", fetchMock);
+  vi.stubGlobal("EventSource", MockEventSource);
+  reloadDashboardLayoutFromStorage();
+  if (timelineEvents) {
+    useFactoryTimelineStore.getState().replaceEvents(timelineEvents);
+  } else if (timelineSnapshots) {
+    seedTimelineSnapshots(timelineSnapshots);
+  } else {
+    seedTimelineSnapshot(
+      snapshot,
+      traceFixtures,
+      workstationRequestsByDispatchID,
+    );
+  }
+
+  const result = render(
+    <QueryClientProvider client={queryClient}>
+      <App
+        browserLanguage={browserLanguage}
+        browserLanguages={browserLanguages}
+        initialLocale={initialLocale}
+        locationSearch={locationSearch}
+      />
+    </QueryClientProvider>,
+  );
+
+  return { ...result, fetchMock };
+}
+
+export function renderWithAppDashboardQueryClient(children: ReactNode) {
+  return render(
+    <QueryClientProvider client={createAppDashboardQueryClient()}>
+      {children}
+    </QueryClientProvider>,
+  );
+}
+
+export function registerAppDashboardTestLifecycle({
+  resetSelectionHistory = true,
+}: {
+  resetSelectionHistory?: boolean;
+} = {}): void {
+  beforeEach(() => {
+    window.localStorage.clear();
+    MockEventSource.instances = [];
+    restoreBrowserTestShims = installDashboardBrowserTestShims();
+    if (resetSelectionHistory) {
+      resetSelectionHistoryStore();
+    }
+    vi.mocked(useCurrentEditableFactoryDefinition).mockReturnValue({
+      data: undefined,
+      error: null,
+      failureCount: 0,
+      failureReason: null,
+      fetchStatus: "idle",
+      isError: false,
+      isFetched: false,
+      isFetchedAfterMount: false,
+      isFetching: false,
+      isInitialLoading: false,
+      isLoading: false,
+      isLoadingError: false,
+      isPaused: false,
+      isPending: true,
+      isPlaceholderData: false,
+      isRefetchError: false,
+      isRefetching: false,
+      isStale: true,
+      isSuccess: false,
+      promise: Promise.resolve(undefined),
+      refetch: vi.fn(),
+      status: "pending",
+    } as never);
+  });
+
+  afterEach(() => {
+    clearAppDashboardQueryClients();
+    cleanup();
+    useDashboardBentoStore.setState({
+      refreshToken: 0,
+      selectedTraceID: null,
+    });
+    useExportDialogStore.setState({
+      isExportDialogOpen: false,
+    });
+    useDashboardStreamStore.setState({
+      streamState: createDefaultDashboardStreamState(),
+    });
+    useFactoryTimelineStore.getState().reset();
+    if (resetSelectionHistory) {
+      resetSelectionHistoryStore();
+    }
+    restoreBrowserTestShims?.();
+    restoreBrowserTestShims = null;
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+}
+
+export function requireValue<T>(
+  value: T | null | undefined,
+  message: string,
+): T {
+  if (value === null || value === undefined) {
+    throw new Error(message);
+  }
+
+  return value;
+}
+
+export function removeTraceIDsFromSnapshot(
+  snapshot: DashboardSnapshot,
+): DashboardSnapshot {
+  return {
+    ...snapshot,
+    runtime: {
+      ...snapshot.runtime,
+      active_executions_by_dispatch_id: Object.fromEntries(
+        Object.entries(
+          snapshot.runtime.active_executions_by_dispatch_id ?? {},
+        ).map(([dispatchID, execution]) => [
+          dispatchID,
+          {
+            ...execution,
+            trace_ids: [],
+            work_items: execution.work_items?.map(removeTraceIDFromWorkItem),
+          },
+        ]),
+      ),
+      current_work_items_by_place_id: Object.fromEntries(
+        Object.entries(
+          snapshot.runtime.current_work_items_by_place_id ?? {},
+        ).map(([placeID, workItems]) => [
+          placeID,
+          workItems.map(removeTraceIDFromWorkItem),
+        ]),
+      ),
+      session: {
+        ...snapshot.runtime.session,
+        provider_sessions: snapshot.runtime.session.provider_sessions?.map(
+          (attempt) => ({
+            ...attempt,
+            work_items: attempt.work_items?.map(removeTraceIDFromWorkItem),
+          }),
+        ),
+      },
+      workstation_activity_by_node_id: Object.fromEntries(
+        Object.entries(
+          snapshot.runtime.workstation_activity_by_node_id ?? {},
+        ).map(([nodeID, activity]) => [
+          nodeID,
+          {
+            ...activity,
+            active_work_items: activity.active_work_items?.map(
+              removeTraceIDFromWorkItem,
+            ),
+            trace_ids: [],
+          },
+        ]),
+      ),
+    },
+  };
+}
+
+function createAppDashboardQueryClient(): QueryClient {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        gcTime: Infinity,
+        retry: false,
+      },
+    },
+  });
+  queryClients.push(queryClient);
+
+  return queryClient;
+}
+
+function clearAppDashboardQueryClients(): void {
+  for (const queryClient of queryClients.splice(0)) {
+    queryClient.clear();
+  }
+}
+
+function removeTraceIDFromWorkItem(
+  workItem: DashboardWorkItemRef,
+): DashboardWorkItemRef {
+  const withoutTraceID: DashboardWorkItemRef = { work_id: workItem.work_id };
+  if (workItem.display_name) {
+    withoutTraceID.display_name = workItem.display_name;
+  }
+  if (workItem.work_type_id) {
+    withoutTraceID.work_type_id = workItem.work_type_id;
+  }
+  return withoutTraceID;
+}

--- a/ui/src/App.dashboard-test-harness.tsx
+++ b/ui/src/App.dashboard-test-harness.tsx
@@ -1,7 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { RenderResult } from "@testing-library/react";
 import { cleanup, render } from "@testing-library/react";
-import type { ReactNode } from "react";
 import type { Mock } from "vitest";
 import { afterEach, beforeEach, vi } from "vitest";
 import { App } from "./App";
@@ -109,7 +108,7 @@ function timelineSnapshot(
   };
 }
 
-export function seedTimelineSnapshot(
+function seedTimelineSnapshot(
   snapshot: DashboardSnapshot,
   tracesByWorkID: Record<string, DashboardTrace> = {},
   workstationRequestsByDispatchID: Record<
@@ -133,7 +132,7 @@ export function seedTimelineSnapshot(
   });
 }
 
-export function seedTimelineSnapshots(snapshots: DashboardSnapshot[]): void {
+function seedTimelineSnapshots(snapshots: DashboardSnapshot[]): void {
   const worldViewCache = Object.fromEntries(
     snapshots.map(
       (snapshot) =>
@@ -210,14 +209,6 @@ export function renderApp({
   );
 
   return { ...result, fetchMock };
-}
-
-export function renderWithAppDashboardQueryClient(children: ReactNode) {
-  return render(
-    <QueryClientProvider client={createAppDashboardQueryClient()}>
-      {children}
-    </QueryClientProvider>,
-  );
 }
 
 export function registerAppDashboardTestLifecycle({

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -1,21 +1,23 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   act,
-  cleanup,
   fireEvent,
-  render,
   screen,
   waitFor,
   within,
 } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { App } from "./App";
+import { describe, expect, it, vi } from "vitest";
+import {
+  MockEventSource,
+  registerAppDashboardTestLifecycle,
+  removeTraceIDsFromSnapshot,
+  renderApp,
+  renderWithAppDashboardQueryClient,
+  requireValue,
+} from "./App.dashboard-test-harness";
 import type {
   DashboardRuntimeWorkstationRequest,
   DashboardSnapshot,
   DashboardTrace,
-  DashboardWorkItemRef,
-  DashboardWorkstationRequest,
 } from "./api/dashboard";
 import type { FactoryEvent } from "./api/events";
 import { FACTORY_EVENT_TYPES } from "./api/events";
@@ -37,7 +39,6 @@ import {
   scriptDashboardIntegrationFixtureIDs,
   scriptDashboardIntegrationTimelineEvents,
 } from "./components/dashboard/fixtures";
-import { installDashboardBrowserTestShims } from "./components/dashboard/test-browser-shims";
 import {
   semanticWorkflowDashboardSnapshot,
   twentyNodeDashboardSnapshot,
@@ -48,83 +49,15 @@ import {
   DASHBOARD_SUPPORTING_LABELS_CLASS,
 } from "./components/ui/dashboard-typography";
 import { formatDurationMillis } from "./components/ui/formatters";
-import { useDashboardBentoStore } from "./features/bento/state/dashboardBentoStore";
-import { reloadDashboardLayoutFromStorage } from "./features/bento/useDashboardLayout";
-import { useCurrentEditableFactoryDefinition } from "./features/current-factory-definition";
-import { resetSelectionHistoryStore } from "./features/current-selection/state/selectionHistoryStore";
-import {
-  createDefaultDashboardStreamState,
-  useDashboardStreamStore,
-} from "./features/dashboard/state/dashboardStreamStore";
+import { useDashboardStreamStore } from "./features/dashboard/state/dashboardStreamStore";
 import * as factoryPngExportModule from "./features/export/factory-png-export";
-import { useExportDialogStore } from "./features/export/state/exportDialogStore";
 import type { FactoryPngImportValue } from "./features/import";
 import * as factoryPngImportModule from "./features/import/factory-png-import";
-import type { WorldState } from "./features/timeline/state/factoryTimelineStore";
 import { useFactoryTimelineStore } from "./features/timeline/state/factoryTimelineStore";
 import {
   TraceDrilldownWidget,
   useTraceDrilldown,
 } from "./features/trace-drilldown";
-
-vi.mock("./features/current-factory-definition", async () => {
-  const actual = await vi.importActual("./features/current-factory-definition");
-
-  return {
-    ...actual,
-    useCurrentEditableFactoryDefinition: vi.fn(),
-  };
-});
-
-class MockEventSource {
-  public static instances: MockEventSource[] = [];
-
-  public onerror: ((event: Event) => void) | null = null;
-  public onopen: ((event: Event) => void) | null = null;
-
-  private readonly listeners = new Map<string, EventListener[]>();
-
-  constructor(public readonly url: string) {
-    MockEventSource.instances.push(this);
-  }
-
-  public addEventListener(type: string, listener: EventListener): void {
-    const existing = this.listeners.get(type) ?? [];
-    existing.push(listener);
-    this.listeners.set(type, existing);
-  }
-
-  public close(): void {}
-
-  public emit(type: string, data: unknown): void {
-    if (type === "snapshot") {
-      const state = useFactoryTimelineStore.getState();
-      const tracesByWorkID =
-        state.worldViewCache[state.selectedTick]?.tracesByWorkID ?? {};
-      seedTimelineSnapshot(data as DashboardSnapshot, tracesByWorkID);
-    }
-
-    const event = new MessageEvent(type, {
-      data: JSON.stringify(data),
-    });
-
-    for (const listener of this.listeners.get(type) ?? []) {
-      listener(event);
-    }
-  }
-}
-
-interface RenderAppOptions {
-  browserLanguage?: string | null;
-  browserLanguages?: readonly string[] | null;
-  initialLocale?: string | null;
-  locationSearch?: string | null;
-  snapshot: DashboardSnapshot;
-  timelineEvents?: FactoryEvent[];
-  timelineSnapshots?: DashboardSnapshot[];
-  traceFixtures?: Record<string, DashboardTrace>;
-  workstationRequestsByDispatchID?: Record<string, DashboardWorkstationRequest>;
-}
 
 function TraceDrilldownTestHarness({
   selectedWorkID,
@@ -403,14 +336,6 @@ function getWorkstationNodeByLabel(label: string): HTMLElement {
   return node;
 }
 
-function requireValue<T>(value: T | null | undefined, message: string): T {
-  if (value === null || value === undefined) {
-    throw new Error(message);
-  }
-
-  return value;
-}
-
 function expectFixedReviewWorkstationDimensions(): void {
   const reviewNode = getWorkstationNodeByLabel("Review");
 
@@ -564,73 +489,6 @@ function _expectRenderedWorkstationRequest(
       "The workstation request has not produced a response yet.",
     ),
   ).toBeTruthy();
-}
-
-function removeTraceIDFromWorkItem(
-  workItem: DashboardWorkItemRef,
-): DashboardWorkItemRef {
-  const withoutTraceID: DashboardWorkItemRef = { work_id: workItem.work_id };
-  if (workItem.display_name) {
-    withoutTraceID.display_name = workItem.display_name;
-  }
-  if (workItem.work_type_id) {
-    withoutTraceID.work_type_id = workItem.work_type_id;
-  }
-  return withoutTraceID;
-}
-
-function removeTraceIDsFromSnapshot(
-  snapshot: DashboardSnapshot,
-): DashboardSnapshot {
-  return {
-    ...snapshot,
-    runtime: {
-      ...snapshot.runtime,
-      active_executions_by_dispatch_id: Object.fromEntries(
-        Object.entries(
-          snapshot.runtime.active_executions_by_dispatch_id ?? {},
-        ).map(([dispatchID, execution]) => [
-          dispatchID,
-          {
-            ...execution,
-            trace_ids: [],
-            work_items: execution.work_items?.map(removeTraceIDFromWorkItem),
-          },
-        ]),
-      ),
-      current_work_items_by_place_id: Object.fromEntries(
-        Object.entries(
-          snapshot.runtime.current_work_items_by_place_id ?? {},
-        ).map(([placeID, workItems]) => [
-          placeID,
-          workItems.map(removeTraceIDFromWorkItem),
-        ]),
-      ),
-      session: {
-        ...snapshot.runtime.session,
-        provider_sessions: snapshot.runtime.session.provider_sessions?.map(
-          (attempt) => ({
-            ...attempt,
-            work_items: attempt.work_items?.map(removeTraceIDFromWorkItem),
-          }),
-        ),
-      },
-      workstation_activity_by_node_id: Object.fromEntries(
-        Object.entries(
-          snapshot.runtime.workstation_activity_by_node_id ?? {},
-        ).map(([nodeID, activity]) => [
-          nodeID,
-          {
-            ...activity,
-            active_work_items: activity.active_work_items?.map(
-              removeTraceIDFromWorkItem,
-            ),
-            trace_ids: [],
-          },
-        ]),
-      ),
-    },
-  };
 }
 
 function expectSeparatedStateMarkerZones(label: string, count: number): void {
@@ -1190,137 +1048,6 @@ const currentNamedFactoryExportResponse = {
     },
   ],
 } satisfies FactoryValue;
-const queryClients: QueryClient[] = [];
-let restoreBrowserTestShims: (() => void) | null = null;
-
-function timelineSnapshot(
-  snapshot: DashboardSnapshot,
-  tracesByWorkID: Record<string, DashboardTrace> = {},
-  workstationRequestsByDispatchID: Record<
-    string,
-    DashboardWorkstationRequest
-  > = {},
-): WorldState {
-  return {
-    ...snapshot,
-    relationsByWorkID: {},
-    tracesByWorkID,
-    workstationRequestsByDispatchID,
-    workRequestsByID: {},
-  };
-}
-
-function seedTimelineSnapshot(
-  snapshot: DashboardSnapshot,
-  tracesByWorkID: Record<string, DashboardTrace> = {},
-  workstationRequestsByDispatchID: Record<
-    string,
-    DashboardWorkstationRequest
-  > = {},
-): void {
-  useFactoryTimelineStore.setState({
-    events: [],
-    latestTick: snapshot.tick_count,
-    mode: "current",
-    receivedEventIDs: [],
-    selectedTick: snapshot.tick_count,
-    worldViewCache: {
-      [snapshot.tick_count]: timelineSnapshot(
-        snapshot,
-        tracesByWorkID,
-        workstationRequestsByDispatchID,
-      ),
-    },
-  });
-}
-
-function seedTimelineSnapshots(snapshots: DashboardSnapshot[]): void {
-  const worldViewCache = Object.fromEntries(
-    snapshots.map(
-      (snapshot) =>
-        [
-          snapshot.tick_count,
-          timelineSnapshot(snapshot) satisfies WorldState,
-        ] as const,
-    ),
-  );
-  const latestTick = Math.max(
-    ...snapshots.map((snapshot) => snapshot.tick_count),
-  );
-
-  useFactoryTimelineStore.setState({
-    events: [],
-    latestTick,
-    mode: "current",
-    receivedEventIDs: [],
-    selectedTick: latestTick,
-    worldViewCache,
-  });
-}
-
-function renderApp({
-  browserLanguage,
-  browserLanguages,
-  initialLocale,
-  locationSearch,
-  snapshot,
-  timelineEvents,
-  timelineSnapshots,
-  traceFixtures = {},
-  workstationRequestsByDispatchID = {},
-}: RenderAppOptions) {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        gcTime: Infinity,
-        retry: false,
-      },
-    },
-  });
-  queryClients.push(queryClient);
-
-  const fetchMock = vi
-    .fn()
-    .mockImplementation(async (input: RequestInfo | URL) => {
-      const path =
-        typeof input === "string"
-          ? input
-          : input instanceof URL
-            ? `${input.pathname}${input.search}`
-            : input.url;
-
-      throw new Error(`unexpected fetch for ${path}`);
-    });
-
-  vi.stubGlobal("fetch", fetchMock);
-  vi.stubGlobal("EventSource", MockEventSource);
-  reloadDashboardLayoutFromStorage();
-  if (timelineEvents) {
-    useFactoryTimelineStore.getState().replaceEvents(timelineEvents);
-  } else if (timelineSnapshots) {
-    seedTimelineSnapshots(timelineSnapshots);
-  } else {
-    seedTimelineSnapshot(
-      snapshot,
-      traceFixtures,
-      workstationRequestsByDispatchID,
-    );
-  }
-
-  const result = render(
-    <QueryClientProvider client={queryClient}>
-      <App
-        browserLanguage={browserLanguage}
-        browserLanguages={browserLanguages}
-        initialLocale={initialLocale}
-        locationSearch={locationSearch}
-      />
-    </QueryClientProvider>,
-  );
-
-  return { ...result, fetchMock };
-}
-
 function submitWorkCardControls() {
   const dashboardGrid = screen.getByRole("region", {
     name: "Infinite You bento board",
@@ -1465,21 +1192,10 @@ function renderTraceDrilldownHarness({
   selectedWorkID: string;
   timelineEvents: FactoryEvent[];
 }) {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        gcTime: Infinity,
-        retry: false,
-      },
-    },
-  });
-  queryClients.push(queryClient);
   useFactoryTimelineStore.getState().replaceEvents(timelineEvents);
 
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <TraceDrilldownTestHarness selectedWorkID={selectedWorkID} />
-    </QueryClientProvider>,
+  return renderWithAppDashboardQueryClient(
+    <TraceDrilldownTestHarness selectedWorkID={selectedWorkID} />,
   );
 }
 
@@ -1569,92 +1285,6 @@ function _getDispatchHistoryCard(
   }
 
   return card;
-}
-
-function registerAppDashboardTestLifecycle(): void {
-  beforeEach(() => {
-    window.localStorage.clear();
-    MockEventSource.instances = [];
-    restoreBrowserTestShims = installDashboardBrowserTestShims();
-    resetSelectionHistoryStore();
-    vi.mocked(useCurrentEditableFactoryDefinition).mockReturnValue({
-      data: undefined,
-      error: null,
-      failureCount: 0,
-      failureReason: null,
-      fetchStatus: "idle",
-      isError: false,
-      isFetched: false,
-      isFetchedAfterMount: false,
-      isFetching: false,
-      isInitialLoading: false,
-      isLoading: false,
-      isLoadingError: false,
-      isPaused: false,
-      isPending: true,
-      isPlaceholderData: false,
-      isRefetchError: false,
-      isRefetching: false,
-      isStale: true,
-      isSuccess: false,
-      promise: Promise.resolve(undefined),
-      refetch: vi.fn(),
-      status: "pending",
-    } as never);
-  });
-
-  afterEach(() => {
-    for (const queryClient of queryClients.splice(0)) {
-      queryClient.clear();
-    }
-    cleanup();
-    useDashboardBentoStore.setState({
-      refreshToken: 0,
-      selectedTraceID: null,
-    });
-    useExportDialogStore.setState({
-      isExportDialogOpen: false,
-    });
-    useDashboardStreamStore.setState({
-      streamState: createDefaultDashboardStreamState(),
-    });
-    useFactoryTimelineStore.getState().reset();
-    resetSelectionHistoryStore();
-    restoreBrowserTestShims?.();
-    restoreBrowserTestShims = null;
-    vi.restoreAllMocks();
-    vi.unstubAllGlobals();
-  });
-}
-
-function registerAppFollowUpTestLifecycle(): void {
-  beforeEach(() => {
-    window.localStorage.clear();
-    MockEventSource.instances = [];
-    restoreBrowserTestShims = installDashboardBrowserTestShims();
-  });
-
-  afterEach(() => {
-    for (const queryClient of queryClients.splice(0)) {
-      queryClient.clear();
-    }
-    cleanup();
-    useDashboardBentoStore.setState({
-      refreshToken: 0,
-      selectedTraceID: null,
-    });
-    useExportDialogStore.setState({
-      isExportDialogOpen: false,
-    });
-    useDashboardStreamStore.setState({
-      streamState: createDefaultDashboardStreamState(),
-    });
-    useFactoryTimelineStore.getState().reset();
-    restoreBrowserTestShims?.();
-    restoreBrowserTestShims = null;
-    vi.restoreAllMocks();
-    vi.unstubAllGlobals();
-  });
 }
 
 describe("App shell import and export flows", () => {
@@ -3698,7 +3328,7 @@ describe("App dashboard layout and graph behavior", () => {
 });
 
 describe("App dashboard follow-up flows", () => {
-  registerAppFollowUpTestLifecycle();
+  registerAppDashboardTestLifecycle({ resetSelectionHistory: false });
 
   it("renders the submit-work card alongside the existing dashboard widgets", async () => {
     renderApp({ snapshot: terminalSnapshot });

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -1,6 +1,8 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   act,
   fireEvent,
+  render,
   screen,
   waitFor,
   within,
@@ -11,7 +13,6 @@ import {
   registerAppDashboardTestLifecycle,
   removeTraceIDsFromSnapshot,
   renderApp,
-  renderWithAppDashboardQueryClient,
   requireValue,
 } from "./App.dashboard-test-harness";
 import type {
@@ -1194,9 +1195,22 @@ function renderTraceDrilldownHarness({
 }) {
   useFactoryTimelineStore.getState().replaceEvents(timelineEvents);
 
-  return renderWithAppDashboardQueryClient(
-    <TraceDrilldownTestHarness selectedWorkID={selectedWorkID} />,
+  return render(
+    <QueryClientProvider client={createTraceDrilldownQueryClient()}>
+      <TraceDrilldownTestHarness selectedWorkID={selectedWorkID} />
+    </QueryClientProvider>,
   );
+}
+
+function createTraceDrilldownQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        gcTime: Infinity,
+        retry: false,
+      },
+    },
+  });
 }
 
 function createFactoryImportValue(): FactoryPngImportValue {


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/extract-shared-app-dashboard-test-harness",
  "description": "Extract the duplicated App-level dashboard test harness shared by App.test.tsx and App.current-selection.test.tsx into one narrowly scoped helper while preserving the same rendered dashboard and current-selection test behavior.",
  "context": {
    "customerAsk": "Extract the shared App dashboard test harness code currently duplicated across ui/src/App.test.tsx and ui/src/App.current-selection.test.tsx into one helper module, use it from both App-level test files, and keep the cleanup narrow without changing App runtime code, user-visible dashboard behavior, or the behaviors covered by the tests.",
    "problem": "The split between the general App suite and the current-selection App suite is useful, but both files duplicate browser-backed App setup for EventSource mocking, rendering, React Query cleanup, store resets, local storage cleanup, fetch stubbing, dashboard browser shims, timeline snapshot seeding, required-value assertions, and trace-ID stripping. Those duplicated setup details can drift and make future App-level dashboard regression tests harder to maintain.",
    "solution": "Create a narrowly scoped shared App dashboard test helper near the App tests, move only the harness pieces genuinely used by both suites into it, update both test files to consume the shared helper, and verify the same App-level dashboard and current-selection assertions continue to pass through focused UI tests."
  },
  "acceptanceCriteria": [
    "App.test.tsx and App.current-selection.test.tsx no longer maintain separate implementations of the shared App render helper, timeline seeding helpers, EventSource mock, and repeated cleanup setup.",
    "The shared helper exposes only the App-level harness behavior already needed by both suites and does not become a broad dashboard testing framework.",
    "Both App-level test files retain their existing behavior-focused rendered UI assertions for dashboard and current-selection behavior.",
    "Timeline seeding, EventSource stream delivery, React Query cleanup, store reset, local storage cleanup, fetch stubbing, and dashboard browser shim behavior remain equivalent from the tests' perspective.",
    "The focused UI test command for src/App.test.tsx and src/App.current-selection.test.tsx passes from ui/.",
    "Quality gate: typecheck, lint, and relevant UI tests pass."
  ],
  "userStories": [
    {
      "id": "extract-shared-app-dashboard-test-harness-001",
      "title": "Share the App dashboard harness setup",
      "description": "As a frontend maintainer, I want the duplicated App-level harness setup to live in one helper so that both App suites use the same render, stream, timeline, and cleanup semantics.",
      "acceptanceCriteria": [
        "A shared App dashboard test helper exists near the App tests and is imported by both App.test.tsx and App.current-selection.test.tsx.",
        "The shared helper provides the common App render helper, EventSource mock, React Query lifecycle support, store cleanup, local storage cleanup, fetch stubbing support, dashboard browser shim setup, and timeline snapshot seeding helpers used by both suites.",
        "The shared helper preserves the observable setup behavior currently expected by both suites, including seeded timeline world-view data and delivered stream events.",
        "The two App-level test files no longer contain independent implementations of the shared harness setup listed above.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "extract-shared-app-dashboard-test-harness-002",
      "title": "Preserve behavior-focused App and current-selection assertions",
      "description": "As a test reviewer, I want the App test files to keep their behavior-specific fixtures and rendered UI assertions so that the cleanup does not hide or weaken the dashboard regressions being protected.",
      "acceptanceCriteria": [
        "App.test.tsx keeps its existing dashboard behavior assertions in the test file rather than replacing them with helper-location or source-layout assertions.",
        "App.current-selection.test.tsx keeps current-selection-specific interactions, fixtures, and assertions in the test file unless a helper is already used by both suites.",
        "The cleanup does not merge the two App-level test files back together.",
        "The tests continue asserting rendered App behavior rather than asserting that commands, routes, registrations, assets, or helper internals exist.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "extract-shared-app-dashboard-test-harness-003",
      "title": "Verify equivalent App harness behavior through focused UI tests",
      "description": "As a maintainer, I want focused UI test evidence that the extracted harness behaves the same so that stream setup, timeline seeding, and cleanup semantics did not regress.",
      "acceptanceCriteria": [
        "Running the focused UI command from ui/, such as bun test src/App.test.tsx src/App.current-selection.test.tsx or the repository's current equivalent, passes.",
        "The passing test output covers both the general App suite and the current-selection suite using the shared helper.",
        "No App runtime code or user-visible dashboard behavior is changed to make the tests pass.",
        "Any test updates are limited to using the shared harness and preserving existing observable assertions.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}
