### PR TITLE
editable-configuration-text

### DIFF
--- a/docs/internal/processes/factory-workstation-relevant-files.md
+++ b/docs/internal/processes/factory-workstation-relevant-files.md
@@ -28,6 +28,7 @@ work inputs.
 - Treat `factory/inputs/task/default/` as the live standalone task inbox, not as a checked-in template catalog; clean checkouts may only contain `.gitkeep`.
 - Treat `factory/internal/{asks,view,progress,meta}.md` as one control surface; if maintainer guidance mentions one of these files, keep the other three aligned in the same `factory/internal/` family.
 - The canonical `factory/internal/{asks,view,progress,meta}.md` control-surface files are gitignored by default, so intentional contract repairs there must be force-added to review commits; otherwise local test fixes can disappear from the PR diff and CI checkout.
+- Keep all four `factory/internal/{asks,view,progress,meta}.md` files tracked in clean checkouts whenever the artifact contract classifies them as `checked_in`; prompt and test guidance now relies on their physical presence, not just documentation references.
 - Before redispatching a checked-in workflow-input markdown file, verify that the lane is not already landed on `main`; stale inbox residue should be treated as cleanup, not as a fresh request.
 - Do not introduce a second checked-in maintainer backlog path or a redirect-only parallel surface; the canonical maintainer control plane lives only under `factory/internal/`.
 - When prompt instructions need ordered or multi-item follow-up work, point them to `docs/reference/batch-inputs.md` and `factory/inputs/BATCH/default/` instead of overloading the markdown idea inbox.

--- a/ui/src/App.stories.tsx
+++ b/ui/src/App.stories.tsx
@@ -300,7 +300,7 @@ function editableConfigurationSection(
   currentSelection: HTMLElement,
 ): HTMLElement {
   const section = within(currentSelection)
-    .getByRole("heading", { name: "Editable configuration" })
+    .getByRole("heading", { name: "Configuration" })
     .closest("section");
 
   if (!(section instanceof HTMLElement)) {

--- a/ui/src/features/current-selection/current-selection-widget.save.test.tsx
+++ b/ui/src/features/current-selection/current-selection-widget.save.test.tsx
@@ -341,7 +341,7 @@ describe("CurrentSelectionWidget workstation save flow", () => {
 
 function expandEditableConfiguration() {
   const section = screen
-    .getAllByRole("heading", { name: "Editable configuration" })
+    .getAllByRole("heading", { name: "Configuration" })
     .at(-1)
     ?.closest("section");
   if (!section) {

--- a/ui/src/features/current-selection/current-selection-widget.test.tsx
+++ b/ui/src/features/current-selection/current-selection-widget.test.tsx
@@ -1124,7 +1124,7 @@ function renderWithQueryClient(view: ReactNode) {
 
 function expandEditableConfiguration() {
   const section = screen
-    .getAllByRole("heading", { name: "Editable configuration" })
+    .getAllByRole("heading", { name: "Configuration" })
     .at(-1)
     ?.closest("section");
   if (!section) {

--- a/ui/src/features/current-selection/messages/workstation-detail-types.ts
+++ b/ui/src/features/current-selection/messages/workstation-detail-types.ts
@@ -25,7 +25,6 @@ export interface WorkstationDetailMessages {
   editableConfigurationSaveConfirmationTitle: string;
   editableConfigurationSaveErrorPrefix: string;
   editableConfigurationSaveSuccess: string;
-  editableConfigurationSummary: string;
   editableConfigurationValidationStatus: string;
   editableConfigurationPromptRequired: string;
   editableConfigurationSaveFallbackError: string;

--- a/ui/src/features/current-selection/messages/workstation-detail.ts
+++ b/ui/src/features/current-selection/messages/workstation-detail.ts
@@ -19,7 +19,7 @@ const workstationDetailMessagesByLocale = {
     editableConfigurationErrorPrefix: "Editable configuration unavailable.",
     editableConfigurationCollapseActionLabel: "Collapse editable configuration",
     editableConfigurationExpandActionLabel: "Expand editable configuration",
-    editableConfigurationHeading: "Editable configuration",
+    editableConfigurationHeading: "Configuration",
     editableConfigurationDirtyStatus:
       "You have unsaved changes for this workstation.",
     editableConfigurationDraftNote:
@@ -45,8 +45,6 @@ const workstationDetailMessagesByLocale = {
       "Running factory saved. The editable workstation values were refreshed to the saved definition.",
     editableConfigurationLoading:
       "Loading the current factory definition for this workstation.",
-    editableConfigurationSummary:
-      "Worker and prompt values are loaded from the latest editable current-factory definition.",
     editableConfigurationValidationStatus:
       "Resolve the highlighted fields before saving this workstation.",
     editableConfigurationPromptRequired:
@@ -136,7 +134,7 @@ const workstationDetailMessagesByLocale = {
     editableConfigurationErrorPrefix: "編集可能な構成は利用できません。",
     editableConfigurationCollapseActionLabel: "編集可能な構成を折りたたむ",
     editableConfigurationExpandActionLabel: "編集可能な構成を展開",
-    editableConfigurationHeading: "編集可能な構成",
+    editableConfigurationHeading: "構成",
     editableConfigurationDirtyStatus:
       "このワークステーションには未保存の変更があります。",
     editableConfigurationDraftNote:
@@ -162,8 +160,6 @@ const workstationDetailMessagesByLocale = {
       "実行中ファクトリーを保存しました。編集可能なワークステーション値は保存済み定義へ更新されました。",
     editableConfigurationLoading:
       "このワークステーション向けに現在のファクトリー定義を読み込んでいます。",
-    editableConfigurationSummary:
-      "Worker と prompt の値は最新の編集可能な current-factory 定義から読み込まれます。",
     editableConfigurationValidationStatus:
       "このワークステーションを保存する前に、強調表示された項目を修正してください。",
     editableConfigurationPromptRequired:
@@ -253,7 +249,7 @@ const workstationDetailMessagesByLocale = {
     editableConfigurationErrorPrefix: "편집 가능한 구성을 사용할 수 없습니다.",
     editableConfigurationCollapseActionLabel: "편집 가능한 구성 접기",
     editableConfigurationExpandActionLabel: "편집 가능한 구성 펼치기",
-    editableConfigurationHeading: "편집 가능한 구성",
+    editableConfigurationHeading: "구성",
     editableConfigurationDirtyStatus:
       "이 워크스테이션에 저장되지 않은 변경 사항이 있습니다.",
     editableConfigurationDraftNote:
@@ -279,8 +275,6 @@ const workstationDetailMessagesByLocale = {
       "실행 중인 팩토리를 저장했습니다. 편집 가능한 워크스테이션 값이 저장된 정의로 새로 고쳐졌습니다.",
     editableConfigurationLoading:
       "이 워크스테이션의 현재 팩토리 정의를 불러오는 중입니다.",
-    editableConfigurationSummary:
-      "Worker 및 prompt 값은 최신 편집 가능한 current-factory 정의에서 로드됩니다.",
     editableConfigurationValidationStatus:
       "이 워크스테이션을 저장하기 전에 강조 표시된 필드를 수정하세요.",
     editableConfigurationPromptRequired:
@@ -368,7 +362,7 @@ const workstationDetailMessagesByLocale = {
     editableConfigurationErrorPrefix: "无法提供可编辑配置。",
     editableConfigurationCollapseActionLabel: "收起可编辑配置",
     editableConfigurationExpandActionLabel: "展开可编辑配置",
-    editableConfigurationHeading: "可编辑配置",
+    editableConfigurationHeading: "配置",
     editableConfigurationDirtyStatus: "此工作站存在未保存的更改。",
     editableConfigurationDraftNote:
       "在保存运行中的工厂之前，更改只会保留在当前编辑会话中。",
@@ -391,8 +385,6 @@ const workstationDetailMessagesByLocale = {
     editableConfigurationSaveSuccess:
       "运行中的工厂已保存。可编辑的工作站值已刷新为保存后的定义。",
     editableConfigurationLoading: "正在加载此工作站的当前工厂定义。",
-    editableConfigurationSummary:
-      "Worker 和 prompt 值来自最新可编辑的 current-factory 定义。",
     editableConfigurationValidationStatus: "请先修正高亮字段，再保存此工作站。",
     editableConfigurationPromptRequired: "保存此工作站前请输入提示词。",
     editableConfigurationSaveFallbackError: "无法保存运行中的工厂。",

--- a/ui/src/features/current-selection/workstation-detail-card.editable-configuration.test.tsx
+++ b/ui/src/features/current-selection/workstation-detail-card.editable-configuration.test.tsx
@@ -7,7 +7,7 @@ const DETAIL_CARD_NOW = Date.parse("2026-04-08T12:00:04Z");
 
 function editableConfigurationSection() {
   const heading = screen
-    .getAllByRole("heading", { name: "Editable configuration" })
+    .getAllByRole("heading", { name: "Configuration" })
     .at(-1);
   const section = heading?.closest("section");
   if (!section) {

--- a/ui/src/features/current-selection/workstation-detail-card.test.tsx
+++ b/ui/src/features/current-selection/workstation-detail-card.test.tsx
@@ -177,7 +177,7 @@ describe("WorkstationDetailCard", () => {
 
     expect(screen.getByRole("heading", { name: "Active work" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Workstation summary" })).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Editable configuration" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Configuration" })).toBeTruthy();
     expect(screen.getByText("Worker type")).toBeTruthy();
     expect(screen.getByText("No active work is running on this workstation.")).toBeTruthy();
 

--- a/ui/src/features/current-selection/workstation-editable-configuration-section.tsx
+++ b/ui/src/features/current-selection/workstation-editable-configuration-section.tsx
@@ -44,18 +44,10 @@ export function EditableConfigurationSection({
       className="mt-4 grid gap-2.5 [&_h4]:m-0"
     >
       <div className={HISTORY_HEADER_CLASS}>
-        <div className="grid min-w-0 gap-1">
+        <div className="min-w-0">
           <h4 className={DASHBOARD_SECTION_HEADING_CLASS} id={headingId}>
             {messages.editableConfigurationHeading}
           </h4>
-          <p
-            className={cx(
-              "m-0 text-af-ink/62",
-              DASHBOARD_SUPPORTING_TEXT_CLASS,
-            )}
-          >
-            {messages.editableConfigurationSummary}
-          </p>
         </div>
         <button
           aria-label={


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/editable-configuration-text",
  "description": "Reduce bloated copy in the workstation current-selection editable configuration surface by renaming `editable configuration` to `configuration` and removing the redundant subtitle about worker and prompt values being loaded.",
  "context": {
    "customerAsk": "The editable configuration text is kind of bloated, we look to reduce. Change `editable configuration` to `configuration`, and remove the subtitle `worker and prompt values are loaded` completely.",
    "problem": "The current editable configuration section uses a longer-than-needed heading and includes helper copy that adds visual noise without providing meaningful guidance in the surrounding current-selection UI. This makes a dense operational panel harder to scan for a very small editing surface.",
    "solution": "Shorten the section heading from `editable configuration` to `configuration` and remove the redundant subtitle while preserving the existing editable configuration workflow, layout stability, and accessibility behavior."
  },
  "acceptanceCriteria": [
    "The workstation current-selection section that previously rendered `editable configuration` now renders `configuration`.",
    "The subtitle `worker and prompt values are loaded` is no longer rendered anywhere in the editable configuration surface.",
    "Removing the subtitle does not leave broken spacing, empty helper rows, or ambiguous unlabeled controls in the current-selection UI.",
    "The editable configuration section keeps its existing interaction behavior, keyboard accessibility, and responsive readability after the copy cleanup.",
    "Quality gate: frontend typecheck, lint, and relevant tests pass before merge."
  ],
  "userStories": [
    {
      "id": "editable-configuration-text-001",
      "title": "Simplify editable configuration heading and helper copy",
      "description": "As a customer editing the current workstation configuration, I want the section title and helper copy to be shorter so that the current-selection panel is easier to scan without changing how configuration editing works.",
      "acceptanceCriteria": [
        "The editable configuration section header renders `configuration` instead of `editable configuration`.",
        "The subtitle `worker and prompt values are loaded` is not rendered in the section.",
        "The copy cleanup does not remove or rename the underlying worker and prompt controls.",
        "The section remains readable and keyboard accessible on supported mobile and desktop layouts after the subtitle is removed.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    }
  ]
}
