### PR TITLE
consolidate-ui-classname-helper-ownership

### DIFF
--- a/ui/src/components/ui/classnames.ts
+++ b/ui/src/components/ui/classnames.ts
@@ -1,4 +1,0 @@
-export function cx(...classes: Array<false | null | string | undefined>): string {
-  return classes.filter(Boolean).join(" ");
-}
-

--- a/ui/src/components/ui/dashboard-shell.tsx
+++ b/ui/src/components/ui/dashboard-shell.tsx
@@ -1,6 +1,6 @@
 import type { HTMLAttributes, ReactNode } from "react";
 
-import { cx } from "./classnames";
+import { cn } from "../../lib/cn";
 
 export const DASHBOARD_PANEL_SHELL_CLASS =
   "rounded-lg border border-af-overlay/10 bg-af-surface/72 text-af-ink shadow-af-card";
@@ -22,7 +22,7 @@ export function DashboardPanelShell({
 }: DashboardPanelShellProps) {
   return (
     <Component
-      className={cx(DASHBOARD_PANEL_SHELL_CLASS, className)}
+      className={cn(DASHBOARD_PANEL_SHELL_CLASS, className)}
       data-dashboard-panel-shell={shellKind}
       {...props}
     >

--- a/ui/src/components/ui/index.ts
+++ b/ui/src/components/ui/index.ts
@@ -2,7 +2,6 @@ export * from "../../features/bento/agent-bento";
 export * from "./button";
 export * from "./calendar";
 export * from "./chart";
-export * from "./classnames";
 export * from "./collapsible";
 export * from "./dashboard-shell";
 export * from "./dashboard-typography";

--- a/ui/src/components/ui/widget-frame.tsx
+++ b/ui/src/components/ui/widget-frame.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 
 import { AgentBentoCard } from "../../features/bento/agent-bento";
-import { cx } from "./classnames";
+import { cn } from "../../lib/cn";
 import {
   DASHBOARD_BODY_TEXT_CLASS,
   DASHBOARD_SUPPORTING_LABELS_CLASS,
@@ -9,16 +9,16 @@ import {
 } from "./dashboard-typography";
 
 export const DASHBOARD_WIDGET_CLASS = "min-w-0";
-export const DETAIL_CARD_CLASS = cx(
+export const DETAIL_CARD_CLASS = cn(
   "[&_dd]:m-0 [&_dl]:m-0 [&_dl]:grid [&_dl]:gap-3 [&_dl_div:first-child]:border-t-0 [&_dl_div:first-child]:pt-0 [&_dl_div]:border-t [&_dl_div]:border-af-overlay/6 [&_dl_div]:pt-3 [&_dt]:mb-1 [&_h3]:mt-0",
   DASHBOARD_SUPPORTING_LABELS_CLASS,
 );
 export const DETAIL_CARD_WIDE_CLASS = "min-h-72";
-export const WIDGET_SUBTITLE_CLASS = cx(
+export const WIDGET_SUBTITLE_CLASS = cn(
   "mt-0",
   DASHBOARD_WIDGET_SUBTITLE_CLASS,
 );
-export const DETAIL_COPY_CLASS = cx("m-0", DASHBOARD_BODY_TEXT_CLASS);
+export const DETAIL_COPY_CLASS = cn("m-0", DASHBOARD_BODY_TEXT_CLASS);
 export const EMPTY_STATE_CLASS =
   "grid min-h-60 items-start gap-1.5 rounded-2xl border border-dashed border-af-overlay/15 bg-af-overlay/4 p-5 [&_h3]:m-0";
 export const EMPTY_STATE_COMPACT_CLASS = "min-h-0";
@@ -39,7 +39,7 @@ export function DashboardWidgetFrame({
 }: DashboardWidgetFrameProps) {
   return (
     <AgentBentoCard
-      className={cx(DASHBOARD_WIDGET_CLASS, DETAIL_CARD_CLASS, className)}
+      className={cn(DASHBOARD_WIDGET_CLASS, DETAIL_CARD_CLASS, className)}
       headerAction={headerAction}
       title={title}
     >

--- a/ui/src/features/bento/agent-bento.tsx
+++ b/ui/src/features/bento/agent-bento.tsx
@@ -5,7 +5,7 @@ import { GridLayout, useContainerWidth } from "react-grid-layout";
 import "react-grid-layout/css/styles.css";
 import "react-resizable/css/styles.css";
 
-import { cx } from "../../components/ui/classnames";
+import { cn } from "../../lib/cn";
 import { DashboardPanelShell } from "../../components/ui/dashboard-shell";
 import {
   DASHBOARD_BODY_TEXT_CLASS,
@@ -62,7 +62,7 @@ const BENTO_ITEM_CLASS = "min-w-0";
 const BENTO_CARD_CLASS = "flex h-full min-w-0 flex-col overflow-hidden";
 const BENTO_CARD_HEADER_CLASS =
   "flex min-h-13 cursor-move items-center justify-between gap-3 border-af-overlay/10 px-3.5 py-3";
-const BENTO_CARD_TITLE_CLASS = cx(
+const BENTO_CARD_TITLE_CLASS = cn(
   "m-0 [overflow-wrap:anywhere]",
   DASHBOARD_SECTION_HEADING_CLASS,
 );
@@ -70,7 +70,7 @@ const BENTO_CARD_HEADER_TOOLS_CLASS =
   "flex min-w-0 shrink-0 items-center gap-2";
 const BENTO_DRAG_HANDLE_CLASS =
   "inline-grid size-9 shrink-0 cursor-grab place-items-center rounded-lg border border-af-overlay/18 bg-af-overlay/8 text-af-ink/68 outline-af-ink/55 transition-colors hover:border-af-overlay/28 hover:bg-af-overlay/12 hover:text-af-ink focus-visible:outline-2 focus-visible:outline-offset-2 active:cursor-grabbing";
-const BENTO_CARD_BODY_CLASS = cx(
+const BENTO_CARD_BODY_CLASS = cn(
   "grid h-full min-h-0 flex-1 gap-2.5 overflow-auto p-3.5 [&_p]:m-0",
   DASHBOARD_BODY_TEXT_CLASS,
 );
@@ -156,7 +156,7 @@ export function AgentBentoLayout({
     onLayoutChange?.(toBentoLayout(nextLayout));
   };
 
-  const layoutClassName = cx(BENTO_LAYOUT_CLASS, className);
+  const layoutClassName = cn(BENTO_LAYOUT_CLASS, className);
   const renderedWidth = Math.max(width, 320);
 
   return (
@@ -209,8 +209,8 @@ export function AgentBentoCard({
   headerAction,
   title,
 }: AgentBentoCardProps) {
-  const cardClassName = cx(BENTO_CARD_CLASS, className);
-  const cardBodyClassName = cx(BENTO_CARD_BODY_CLASS, bodyClassName);
+  const cardClassName = cn(BENTO_CARD_CLASS, className);
+  const cardBodyClassName = cn(BENTO_CARD_BODY_CLASS, bodyClassName);
 
   return (
     <DashboardPanelShell

--- a/ui/src/features/bento/useDashboardLayout.ts
+++ b/ui/src/features/bento/useDashboardLayout.ts
@@ -230,4 +230,3 @@ function writeStoredDashboardLayout(layout: AgentBentoLayoutItem[]): void {
     // Layout persistence is a convenience; dashboard interaction should keep working without it.
   }
 }
-

--- a/ui/src/features/current-selection/current-selection-detail-layout.tsx
+++ b/ui/src/features/current-selection/current-selection-detail-layout.tsx
@@ -1,13 +1,13 @@
 import { DETAIL_CARD_WIDE_CLASS } from "../../components/dashboard/widget-board";
 import { DashboardWidgetFrame } from "../../components/ui";
 import { DASHBOARD_SUPPORTING_TEXT_CLASS } from "../../components/ui/dashboard-typography";
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import { useCurrentSelectionShellMessages } from "./current-selection-locale";
 import type { SelectionDetailLayoutProps } from "./detail-card-types";
 import { useSelectionHistoryStore } from "./state/selectionHistoryStore";
 
 const SELECTION_HISTORY_ACTIONS_CLASS = "flex items-center gap-2";
-const SELECTION_HISTORY_BUTTON_CLASS = cx(
+const SELECTION_HISTORY_BUTTON_CLASS = cn(
   "inline-flex h-9 items-center justify-center rounded-lg border border-af-overlay/12 bg-af-overlay/6 px-3 text-af-ink/78 transition hover:border-af-overlay/18 hover:bg-af-overlay/10 hover:text-af-ink focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-af-accent disabled:cursor-not-allowed disabled:border-af-overlay/8 disabled:bg-af-overlay/4 disabled:text-af-ink/35",
   DASHBOARD_SUPPORTING_TEXT_CLASS,
 );

--- a/ui/src/features/current-selection/detail-card-shared.tsx
+++ b/ui/src/features/current-selection/detail-card-shared.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from "react";
 import type { ReactNode } from "react";
 import type { DashboardPlaceRef } from "../../api/dashboard/types";
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import {
   DASHBOARD_BODY_CODE_CLASS,
   DASHBOARD_BODY_TEXT_CLASS,
@@ -19,7 +19,7 @@ import type {
 } from "./detail-card-types";
 import { useCurrentSelectionDetailMessages } from "./current-selection-locale";
 
-export const EXECUTION_PILL_CLASS = cx(
+export const EXECUTION_PILL_CLASS = cn(
   "inline-flex rounded-full bg-af-info/15 px-2 py-0.5 text-af-info-ink",
   DASHBOARD_SUPPORTING_CODE_CLASS,
 );
@@ -27,7 +27,7 @@ export const PROVIDER_SESSION_CARD_CLASS =
   "rounded-lg border border-af-overlay/8 bg-af-overlay/4 p-3.5";
 export const HISTORY_HEADER_CLASS =
   "flex items-center justify-between gap-3 rounded-lg border border-af-overlay/8 bg-af-overlay/4 px-3 py-2 [&_h4]:m-0";
-export const HISTORY_TOGGLE_CLASS = cx(
+export const HISTORY_TOGGLE_CLASS = cn(
   "shrink-0 cursor-pointer rounded-lg border border-af-overlay/12 bg-af-overlay/6 px-2.5 py-2 text-af-ink/78 transition hover:border-af-overlay/18 hover:bg-af-overlay/10 hover:text-af-ink focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-af-accent disabled:cursor-not-allowed disabled:border-af-overlay/8 disabled:bg-af-overlay/4 disabled:text-af-ink/35",
   DASHBOARD_SUPPORTING_TEXT_CLASS,
 );
@@ -35,38 +35,38 @@ export const WORKSTATION_SUMMARY_ITEM_CLASS =
   "grid min-w-0 gap-1 rounded-lg border border-af-overlay/8 bg-af-overlay/4 px-3 py-2";
 export const INFERENCE_ATTEMPT_CARD_CLASS =
   "grid min-w-0 gap-2.5 rounded-lg border border-af-overlay/8 p-3.5";
-export const INFERENCE_ATTEMPT_DETAIL_CLASS = cx(
+export const INFERENCE_ATTEMPT_DETAIL_CLASS = cn(
   "m-0 grid gap-1.5 [&_dd]:m-0 [&_div]:grid [&_div]:min-w-0 [&_div]:grid-cols-[8.5rem_minmax(0,1fr)] [&_div]:gap-2",
   DASHBOARD_BODY_TEXT_CLASS,
 );
 // tailwind-exception: intrinsic-sizing
-export const INFERENCE_ATTEMPT_TEXT_CLASS = cx(
+export const INFERENCE_ATTEMPT_TEXT_CLASS = cn(
   "min-h-[20rem] md:min-h-[26rem] lg:min-h-[min(70vh,36rem)]",
 );
-export const REQUEST_AUTHORED_TEXT_CLASS = cx(
+export const REQUEST_AUTHORED_TEXT_CLASS = cn(
   "grid gap-3 rounded-lg border border-af-overlay/8 bg-af-overlay/6 p-3 [overflow-wrap:anywhere] [&_code]:rounded-sm [&_code]:bg-af-overlay/12 [&_code]:px-1 [&_code]:py-0.5 [&_h1]:text-xl [&_h1]:font-semibold [&_h2]:text-lg [&_h2]:font-semibold [&_h3]:text-base [&_h3]:font-semibold [&_ol]:m-0 [&_ol]:list-decimal [&_ol]:pl-5 [&_pre]:m-0 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:border [&_pre]:border-af-overlay/8 [&_pre]:bg-af-overlay/12 [&_pre]:p-3 [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_ul]:m-0 [&_ul]:list-disc [&_ul]:pl-5",
   DASHBOARD_BODY_TEXT_CLASS,
 );
 export const RUNTIME_DETAILS_SECTION_CLASS =
   "mt-4 grid gap-3 border-t border-af-overlay/8 pt-4 [&_h4]:m-0";
 export const RUNTIME_DETAIL_VALUE_CLASS = "min-w-0 [overflow-wrap:anywhere]";
-export const RUNTIME_DETAIL_CODE_CLASS = cx(
+export const RUNTIME_DETAIL_CODE_CLASS = cn(
   DASHBOARD_BODY_CODE_CLASS,
   "[overflow-wrap:anywhere]",
 );
 export const TRACE_ACTION_LINK_CLASS =
   "inline-flex w-fit rounded-lg border border-on-foreground/35 bg-on-foreground/10 px-3 py-2 text-sm font-bold text-on-foreground outline-af-accent transition hover:bg-on-foreground/15 focus-visible:outline-2 focus-visible:outline-offset-2";
-export const REQUEST_SELECTION_STATUS_CLASS = cx(
+export const REQUEST_SELECTION_STATUS_CLASS = cn(
   "m-0 text-af-ink/68",
   DASHBOARD_SUPPORTING_TEXT_CLASS,
 );
-export const PROVIDER_SESSION_SELECTION_BUTTON_CLASS = cx(
+export const PROVIDER_SESSION_SELECTION_BUTTON_CLASS = cn(
   "grid w-full gap-1.5 rounded-lg border border-af-overlay/12 bg-af-overlay/6 px-3 py-2.5 text-left text-on-foreground/82 outline-af-accent transition hover:border-af-overlay/18 hover:bg-af-overlay/10 focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:border-af-overlay/8 disabled:bg-af-overlay/4 disabled:text-af-ink/35",
   DASHBOARD_BODY_TEXT_CLASS,
 );
 export const WORK_SELECTION_BUTTON_CLASS =
   "inline-flex w-fit rounded-lg border border-af-overlay/12 bg-af-overlay/6 px-2.5 py-2 text-xs font-bold text-on-foreground/78 outline-af-accent transition hover:border-af-overlay/18 hover:bg-af-overlay/10 hover:text-on-foreground focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:border-af-overlay/8 disabled:bg-af-overlay/4 disabled:text-af-ink/35";
-export const REQUEST_HISTORY_TEXT_CLASS = cx(
+export const REQUEST_HISTORY_TEXT_CLASS = cn(
   "m-0 whitespace-pre-wrap rounded-lg border border-af-overlay/8 bg-af-overlay/6 p-2 [overflow-wrap:anywhere]",
   DASHBOARD_BODY_CODE_CLASS,
 );
@@ -218,7 +218,7 @@ export function AuthoredBodyText({
   const blocks = parseRequestAuthoredBlocks(value);
 
   return (
-    <div className={cx(REQUEST_AUTHORED_TEXT_CLASS, className)}>
+    <div className={cn(REQUEST_AUTHORED_TEXT_CLASS, className)}>
       {blocks.map((block, index) => renderRequestAuthoredBlock(block, index))}
     </div>
   );

--- a/ui/src/features/current-selection/inference-attempt.tsx
+++ b/ui/src/features/current-selection/inference-attempt.tsx
@@ -3,7 +3,7 @@ import {
   formatProviderSession,
   getProviderSessionLogTarget,
 } from "../../components/ui/formatters";
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import {
   DASHBOARD_BODY_CODE_CLASS,
   DASHBOARD_SUPPORTING_TEXT_CLASS,
@@ -102,7 +102,7 @@ export function InferenceAttemptCard({
                 attempt.dispatch_id,
               )}
               aria-pressed={providerSessionSelected}
-              className={cx(
+              className={cn(
                 PROVIDER_SESSION_SELECTION_BUTTON_CLASS,
                 providerSessionSelected &&
                   "border-af-accent/35 bg-af-accent/10 text-af-accent",

--- a/ui/src/features/current-selection/provider-session-attempts.tsx
+++ b/ui/src/features/current-selection/provider-session-attempts.tsx
@@ -5,7 +5,7 @@ import {
   formatWorkstationRunOutcome,
   getProviderSessionLogTarget,
 } from "../../components/ui/formatters";
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import {
   DASHBOARD_BODY_CODE_CLASS,
   DASHBOARD_BODY_TEXT_CLASS,
@@ -77,7 +77,7 @@ export function CollapsibleProviderSessionAttempts({
           <h4 className={DASHBOARD_SECTION_HEADING_CLASS} id={`${historyID}-heading`}>
             {resolvedTitle}
           </h4>
-          <p className={cx("m-0 text-af-ink/62", DASHBOARD_SUPPORTING_TEXT_CLASS)}>
+          <p className={cn("m-0 text-af-ink/62", DASHBOARD_SUPPORTING_TEXT_CLASS)}>
             {itemCountLabel}
           </p>
         </div>
@@ -189,7 +189,7 @@ function ProviderSessionAttemptList({
 
         return (
           <article
-            className={cx(
+            className={cn(
               PROVIDER_SESSION_CARD_CLASS,
               isCurrentDispatch && "border-on-foreground/30 bg-on-foreground/6",
             )}
@@ -201,12 +201,12 @@ function ProviderSessionAttemptList({
             </div>
             <div className="mt-2 grid gap-1">
               <div className="flex flex-wrap items-center gap-2">
-                <p className={cx("m-0 text-af-ink/70", DASHBOARD_BODY_TEXT_CLASS)}>
+                <p className={cn("m-0 text-af-ink/70", DASHBOARD_BODY_TEXT_CLASS)}>
                   {outcome.label}
                 </p>
                 {isCurrentDispatch ? (
                   <span
-                    className={cx(
+                    className={cn(
                       "inline-flex rounded-full border border-on-foreground/35 bg-on-foreground/10 px-2 py-0.5 text-on-foreground",
                       DASHBOARD_SUPPORTING_TEXT_CLASS,
                     )}
@@ -216,7 +216,7 @@ function ProviderSessionAttemptList({
                 ) : null}
               </div>
               {outcome.rawOutcomeLabel ? (
-                <p className={cx("m-0 text-af-code-ink/72", DASHBOARD_SUPPORTING_CODE_CLASS)}>
+                <p className={cn("m-0 text-af-code-ink/72", DASHBOARD_SUPPORTING_CODE_CLASS)}>
                   {outcome.rawOutcomeLabel}
                 </p>
               ) : null}
@@ -228,7 +228,7 @@ function ProviderSessionAttemptList({
                   attempt.dispatch_id,
                 )}
                 aria-pressed={providerSessionSelected}
-                className={cx(
+                className={cn(
                   "mt-2",
                   PROVIDER_SESSION_SELECTION_BUTTON_CLASS,
                   providerSessionSelected &&
@@ -246,7 +246,7 @@ function ProviderSessionAttemptList({
               </button>
             ) : (
               <div className="mt-2 grid gap-1">
-                <code className={cx("text-af-code-ink/72", DASHBOARD_BODY_CODE_CLASS)}>
+                <code className={cn("text-af-code-ink/72", DASHBOARD_BODY_CODE_CLASS)}>
                   {providerSessionLabel}
                 </code>
                 <p className={REQUEST_SELECTION_STATUS_CLASS}>
@@ -330,7 +330,7 @@ function ProviderSessionLogAccess({
     <div className="mt-2 grid min-w-0 gap-1">
       {logTarget ? (
         <a
-          className={cx(
+          className={cn(
             "w-fit rounded-lg font-bold text-af-accent underline underline-offset-4 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-af-accent",
             DASHBOARD_BODY_TEXT_CLASS,
           )}
@@ -340,7 +340,7 @@ function ProviderSessionLogAccess({
           {messages.providerSessionLogAction}
         </a>
       ) : (
-        <span className={cx("font-bold text-af-ink/78", DASHBOARD_BODY_TEXT_CLASS)}>
+        <span className={cn("font-bold text-af-ink/78", DASHBOARD_BODY_TEXT_CLASS)}>
           {messages.providerSessionLogUnavailable}
         </span>
       )}

--- a/ui/src/features/current-selection/provider-session-detail-panel.tsx
+++ b/ui/src/features/current-selection/provider-session-detail-panel.tsx
@@ -6,7 +6,7 @@ import {
   DASHBOARD_SUPPORTING_TEXT_CLASS,
 } from "../../components/ui/dashboard-typography";
 import { DETAIL_COPY_CLASS } from "../../components/dashboard/widget-board";
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import type { ProviderSessionDetailResponse } from "../../api/provider-session-details";
 import { PROVIDER_SESSION_CARD_CLASS } from "./detail-card-shared";
 import { getProviderSessionDetailMessages } from "./messages/provider-session-detail";
@@ -60,7 +60,7 @@ function LoadedProviderSessionDetailPanel({
         <h4 className={DASHBOARD_SECTION_HEADING_CLASS}>
           {messages.selectedSessionHeading}
         </h4>
-        <p className={cx("m-0 text-af-ink/62", DASHBOARD_SUPPORTING_TEXT_CLASS)}>
+        <p className={cn("m-0 text-af-ink/62", DASHBOARD_SUPPORTING_TEXT_CLASS)}>
           <span className={DASHBOARD_SUPPORTING_LABEL_CLASS}>
             {messages.sessionLabel}
           </span>{" "}
@@ -261,7 +261,7 @@ function TurnsSection({
               <div className="grid gap-1">
                 <strong>{messages.turnLabel({ index: turn.index })}</strong>
                 <p
-                  className={cx(
+                  className={cn(
                     "m-0 text-af-ink/62",
                     DASHBOARD_SUPPORTING_TEXT_CLASS,
                   )}
@@ -319,7 +319,7 @@ function FunctionCallsSection({
                 <div className="grid gap-1">
                   <strong>{call.name ?? call.type}</strong>
                   <p
-                    className={cx(
+                    className={cn(
                       "m-0 text-af-ink/62",
                       DASHBOARD_SUPPORTING_TEXT_CLASS,
                     )}
@@ -332,7 +332,7 @@ function FunctionCallsSection({
                 </div>
                 {call.status ? (
                   <span
-                    className={cx(
+                    className={cn(
                       "inline-flex w-fit rounded-full border border-af-overlay/12 bg-af-overlay/6 px-2 py-0.5",
                       DASHBOARD_SUPPORTING_TEXT_CLASS,
                     )}
@@ -388,7 +388,7 @@ function ReasoningSection({
               <div className="grid gap-1">
                 <strong>{entry.sourceType}</strong>
                 <p
-                  className={cx(
+                  className={cn(
                     "m-0 text-af-ink/62",
                     DASHBOARD_SUPPORTING_TEXT_CLASS,
                   )}
@@ -400,13 +400,13 @@ function ReasoningSection({
                 </p>
               </div>
               {entry.summary ? (
-                <p className={cx("m-0 mt-2", DASHBOARD_BODY_TEXT_CLASS)}>
+                <p className={cn("m-0 mt-2", DASHBOARD_BODY_TEXT_CLASS)}>
                   {entry.summary}
                 </p>
               ) : null}
               {entry.text ? (
                 <pre
-                  className={cx(
+                  className={cn(
                     "m-0 mt-2 whitespace-pre-wrap rounded-lg border border-af-overlay/8 bg-af-overlay/6 p-3 [overflow-wrap:anywhere]",
                     DASHBOARD_BODY_CODE_CLASS,
                   )}
@@ -416,7 +416,7 @@ function ReasoningSection({
               ) : null}
               {entry.encrypted ? (
                 <p
-                  className={cx(
+                  className={cn(
                     "m-0 mt-2 text-af-ink/62",
                     DASHBOARD_SUPPORTING_TEXT_CLASS,
                   )}
@@ -462,7 +462,7 @@ function ParseDiagnosticsSection({
             key={`parse-error-${error.lineNumber}`}
           >
             <strong>{messages.lineLabel({ lineNumber: error.lineNumber })}</strong>
-            <p className={cx("m-0 mt-1.5", DASHBOARD_BODY_TEXT_CLASS)}>
+            <p className={cn("m-0 mt-1.5", DASHBOARD_BODY_TEXT_CLASS)}>
               {error.message}
             </p>
           </article>
@@ -476,7 +476,7 @@ function ParseDiagnosticsSection({
               {messages.unknownEventOnLineLabel({ lineNumber: event.lineNumber })}
             </strong>
             <p
-              className={cx(
+              className={cn(
                 "m-0 mt-1.5 text-af-ink/62",
                 DASHBOARD_SUPPORTING_TEXT_CLASS,
               )}
@@ -505,7 +505,7 @@ function DetailMetric({
   return (
     <div className={PROVIDER_SESSION_CARD_CLASS}>
       <span className={DASHBOARD_SUPPORTING_LABEL_CLASS}>{label}</span>
-      <p className={cx("m-0 mt-1", DASHBOARD_BODY_TEXT_CLASS)}>
+      <p className={cn("m-0 mt-1", DASHBOARD_BODY_TEXT_CLASS)}>
         {value}
       </p>
     </div>
@@ -523,7 +523,7 @@ function CodeBlockMetric({
     <div className="grid gap-1">
       <span className={DASHBOARD_SUPPORTING_LABEL_CLASS}>{label}</span>
       <pre
-        className={cx(
+        className={cn(
           "m-0 whitespace-pre-wrap rounded-lg border border-af-overlay/8 bg-af-overlay/6 p-3 [overflow-wrap:anywhere]",
           DASHBOARD_BODY_CODE_CLASS,
         )}

--- a/ui/src/features/current-selection/selected-work-dispatch-history-card.tsx
+++ b/ui/src/features/current-selection/selected-work-dispatch-history-card.tsx
@@ -1,4 +1,4 @@
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import {
   DASHBOARD_BODY_TEXT_CLASS,
   DASHBOARD_SUPPORTING_TEXT_CLASS,
@@ -75,7 +75,7 @@ export function DispatchHistoryCard({
 
   return (
     <article
-      className={cx(
+      className={cn(
         PROVIDER_SESSION_CARD_CLASS,
         isCurrentDispatch && "border-on-foreground/30 bg-on-foreground/6",
       )}
@@ -210,12 +210,12 @@ function DispatchHistoryHeader({
           {title || dispatchID || messages.unknownDispatchTitle}
         </strong>
         <div className="flex flex-wrap items-center gap-2">
-          <p className={cx("m-0 text-af-ink/70", DASHBOARD_BODY_TEXT_CLASS)}>
+          <p className={cn("m-0 text-af-ink/70", DASHBOARD_BODY_TEXT_CLASS)}>
             {outcome ?? messages.pendingOutcome}
           </p>
           {isCurrentDispatch ? (
             <span
-              className={cx(
+              className={cn(
                 "inline-flex rounded-full border border-on-foreground/35 bg-on-foreground/10 px-2 py-0.5 text-on-foreground",
                 DASHBOARD_SUPPORTING_TEXT_CLASS,
               )}
@@ -240,7 +240,7 @@ function DispatchSummaryDetails({
   view: DispatchHistoryView;
 }) {
   return (
-    <dl className={cx("mt-2.5", INFERENCE_ATTEMPT_DETAIL_CLASS)}>
+    <dl className={cn("mt-2.5", INFERENCE_ATTEMPT_DETAIL_CLASS)}>
       <InferenceAttemptDetail label={messages.workstationLabel} value={request.workstation_name} />
       <InferenceAttemptDetail label={messages.transitionIdLabel} code value={request.transition_id} />
       <InferenceAttemptDetail label={messages.startedAtLabel} value={requestStartedAt(request)} />

--- a/ui/src/features/current-selection/selected-work-dispatch-history.tsx
+++ b/ui/src/features/current-selection/selected-work-dispatch-history.tsx
@@ -1,4 +1,4 @@
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import {
   DASHBOARD_SECTION_HEADING_CLASS,
   DASHBOARD_SUPPORTING_TEXT_CLASS,
@@ -59,7 +59,7 @@ export function SelectedWorkDispatchHistorySection({
         >
           {messages.dispatchHistoryHeading}
         </h4>
-        <p className={cx("m-0 text-af-ink/62", DASHBOARD_SUPPORTING_TEXT_CLASS)}>
+        <p className={cn("m-0 text-af-ink/62", DASHBOARD_SUPPORTING_TEXT_CLASS)}>
           {messages.dispatchHistoryCountLabel(requests.length)}
         </p>
       </div>

--- a/ui/src/features/current-selection/workstation-detail-card.tsx
+++ b/ui/src/features/current-selection/workstation-detail-card.tsx
@@ -12,7 +12,7 @@ import {
   formatDurationFromISO,
   formatWorkItemLabel,
 } from "../../components/ui/formatters";
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import { SelectionDetailLayout } from "./current-selection-detail-layout";
 import {
   EXECUTION_PILL_CLASS,
@@ -171,7 +171,7 @@ function CollapsibleWorkstationRequests({
             {messages.requestHistoryHeading}
           </h4>
           <p
-            className={cx(
+            className={cn(
               "m-0 text-af-ink/62",
               DASHBOARD_SUPPORTING_TEXT_CLASS,
             )}
@@ -226,7 +226,7 @@ function CollapsibleWorkstationRequests({
                   </div>
                   <div className="mt-2 grid gap-1">
                     <p
-                      className={cx(
+                      className={cn(
                         "m-0 text-af-ink/70",
                         DASHBOARD_BODY_TEXT_CLASS,
                       )}
@@ -234,7 +234,7 @@ function CollapsibleWorkstationRequests({
                       {requestStatus}
                     </p>
                     <p
-                      className={cx(
+                      className={cn(
                         "m-0 text-af-ink/62",
                         DASHBOARD_SUPPORTING_TEXT_CLASS,
                       )}
@@ -243,7 +243,7 @@ function CollapsibleWorkstationRequests({
                     </p>
                     {request.started_at ? (
                       <p
-                        className={cx(
+                        className={cn(
                           "m-0 text-af-ink/62",
                           DASHBOARD_SUPPORTING_TEXT_CLASS,
                         )}
@@ -319,7 +319,7 @@ function WorkstationActiveWorkList({
 
               return (
                 <li
-                  className={cx(
+                  className={cn(
                     "grid min-w-0 gap-2 rounded-lg border border-af-overlay/8 bg-af-overlay/4 px-3 py-2",
                     DASHBOARD_BODY_TEXT_CLASS,
                   )}
@@ -329,7 +329,7 @@ function WorkstationActiveWorkList({
                     {workLabel}
                   </strong>
                   <dl
-                    className={cx(
+                    className={cn(
                       "m-0 grid gap-1.5 [&_dd]:m-0 [&_div]:grid [&_div]:min-w-0 [&_div]:grid-cols-[5.5rem_minmax(0,1fr)] [&_div]:gap-2",
                       DASHBOARD_BODY_TEXT_CLASS,
                     )}

--- a/ui/src/features/current-selection/workstation-editable-configuration-section.tsx
+++ b/ui/src/features/current-selection/workstation-editable-configuration-section.tsx
@@ -8,7 +8,7 @@ import {
   DASHBOARD_SUPPORTING_TEXT_CLASS,
 } from "../../components/ui/dashboard-typography";
 import { formatList } from "../../components/ui/formatters";
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import {
   HISTORY_HEADER_CLASS,
   HISTORY_TOGGLE_CLASS,
@@ -67,20 +67,20 @@ export function EditableConfigurationSection({
       {expanded ? (
         <div className="grid gap-2.5" id={contentId}>
           {state?.status === "loading" ? (
-            <p className={cx("m-0 text-af-ink/70", DASHBOARD_BODY_TEXT_CLASS)}>
+            <p className={cn("m-0 text-af-ink/70", DASHBOARD_BODY_TEXT_CLASS)}>
               {messages.editableConfigurationLoading}
             </p>
           ) : null}
           {state?.status === "error" ? (
             <p
-              className={cx("m-0 text-af-danger", DASHBOARD_BODY_TEXT_CLASS)}
+              className={cn("m-0 text-af-danger", DASHBOARD_BODY_TEXT_CLASS)}
               role="alert"
             >
               {messages.editableConfigurationErrorPrefix} {state.errorMessage}
             </p>
           ) : null}
           {state?.status === "empty" ? (
-            <p className={cx("m-0 text-af-ink/70", DASHBOARD_BODY_TEXT_CLASS)}>
+            <p className={cn("m-0 text-af-ink/70", DASHBOARD_BODY_TEXT_CLASS)}>
               {state.message || messages.editableConfigurationEmpty}
             </p>
           ) : null}
@@ -161,7 +161,7 @@ function EditableConfigurationSaveFeedback({
   if (saveState?.status === "success") {
     return (
       <p
-        className={cx("m-0 text-af-success-ink", DASHBOARD_BODY_TEXT_CLASS)}
+        className={cn("m-0 text-af-success-ink", DASHBOARD_BODY_TEXT_CLASS)}
         role="status"
       >
         {messages.editableConfigurationSaveSuccess}
@@ -172,7 +172,7 @@ function EditableConfigurationSaveFeedback({
   if (saveState?.status === "error") {
     return (
       <p
-        className={cx("m-0 text-af-danger-ink", DASHBOARD_BODY_TEXT_CLASS)}
+        className={cn("m-0 text-af-danger-ink", DASHBOARD_BODY_TEXT_CLASS)}
         role="alert"
       >
         {messages.editableConfigurationSaveErrorPrefix} {saveState.errorMessage}
@@ -196,7 +196,7 @@ function EditableConfigurationDraftStatus({
   return (
     <div className="grid gap-2 rounded-2xl border border-af-overlay/10 bg-af-overlay/4 p-3">
       <p
-        className={cx(
+        className={cn(
           "m-0",
           state.hasValidationErrors ? "text-af-danger-ink" : "text-af-ink/72",
           DASHBOARD_BODY_TEXT_CLASS,
@@ -209,7 +209,7 @@ function EditableConfigurationDraftStatus({
             ? messages.editableConfigurationDirtyStatus
             : messages.editableConfigurationDraftNote}
       </p>
-      <p className={cx("m-0 text-af-ink/58", DASHBOARD_SUPPORTING_TEXT_CLASS)}>
+      <p className={cn("m-0 text-af-ink/58", DASHBOARD_SUPPORTING_TEXT_CLASS)}>
         {messages.editableConfigurationDraftNote}
       </p>
     </div>
@@ -235,12 +235,12 @@ function EditableConfigurationOverwriteWarning({
   return (
     <div className="grid gap-2 rounded-2xl border border-af-warning/35 bg-af-warning/8 p-3">
       <p
-        className={cx("m-0 text-af-warning-ink", DASHBOARD_BODY_TEXT_CLASS)}
+        className={cn("m-0 text-af-warning-ink", DASHBOARD_BODY_TEXT_CLASS)}
         role="alert"
       >
         {messages.editableConfigurationOverwriteWarning(formattedFields)}
       </p>
-      <p className={cx("m-0 text-af-ink/62", DASHBOARD_SUPPORTING_TEXT_CLASS)}>
+      <p className={cn("m-0 text-af-ink/62", DASHBOARD_SUPPORTING_TEXT_CLASS)}>
         {messages.editableConfigurationOverwriteWarningDetail}
       </p>
     </div>
@@ -259,7 +259,7 @@ function EditableConfigurationWorkerInput({
 }) {
   if (state.workerOptionsState.status === "empty") {
     return (
-      <p className={cx("m-0 text-af-ink/70", DASHBOARD_BODY_TEXT_CLASS)}>
+      <p className={cn("m-0 text-af-ink/70", DASHBOARD_BODY_TEXT_CLASS)}>
         {state.workerOptionsState.message}
       </p>
     );
@@ -268,7 +268,7 @@ function EditableConfigurationWorkerInput({
   if (state.workerOptionsState.status === "error") {
     return (
       <p
-        className={cx("m-0 text-af-danger-ink", DASHBOARD_BODY_TEXT_CLASS)}
+        className={cn("m-0 text-af-danger-ink", DASHBOARD_BODY_TEXT_CLASS)}
         role="alert"
       >
         {messages.editableConfigurationWorkerUnavailablePrefix}{" "}
@@ -360,7 +360,7 @@ function EditableConfigurationField({
       {supportingContent}
       {errorMessage ? (
         <p
-          className={cx(
+          className={cn(
             "m-0 text-af-danger-ink",
             DASHBOARD_SUPPORTING_TEXT_CLASS,
           )}

--- a/ui/src/features/export/export-factory-dialog.tsx
+++ b/ui/src/features/export/export-factory-dialog.tsx
@@ -17,25 +17,25 @@ import {
   DASHBOARD_SUPPORTING_LABELS_CLASS,
   DASHBOARD_SUPPORTING_TEXT_CLASS,
 } from "../../components/ui/dashboard-typography";
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import { downloadBlobAsFile } from "./browser-download";
 import { buildFactoryExportFilename } from "./build-factory-export-filename";
 import { writeFactoryExportPng } from "./factory-png-export";
 import { getExportDialogMessages } from "./messages/export-dialog";
 import type { CurrentFactoryExportFailure } from "./use-current-factory-export";
 
-const DIALOG_TITLE_CLASS = cx("m-0", DASHBOARD_SECTION_HEADING_CLASS);
-const DIALOG_BODY_CLASS = cx("m-0 max-w-lg", DASHBOARD_BODY_TEXT_CLASS);
-const DIALOG_HINT_CLASS = cx("m-0", DASHBOARD_SUPPORTING_TEXT_CLASS);
+const DIALOG_TITLE_CLASS = cn("m-0", DASHBOARD_SECTION_HEADING_CLASS);
+const DIALOG_BODY_CLASS = cn("m-0 max-w-lg", DASHBOARD_BODY_TEXT_CLASS);
+const DIALOG_HINT_CLASS = cn("m-0", DASHBOARD_SUPPORTING_TEXT_CLASS);
 const DIALOG_FORM_CLASS = "space-y-5";
 const DIALOG_FIELD_GROUP_CLASS = "space-y-2";
-const DIALOG_FIELD_LABEL_CLASS = cx(
+const DIALOG_FIELD_LABEL_CLASS = cn(
   "block text-sm font-semibold text-af-ink",
   DASHBOARD_SUPPORTING_LABELS_CLASS,
 );
 const DIALOG_FILE_INPUT_CLASS =
   "block w-full rounded-xl border border-dashed border-af-overlay/18 bg-af-overlay/4 px-3 py-3 text-sm text-af-ink/80 file:mr-3 file:rounded-lg file:border-0 file:bg-af-accent/12 file:px-3 file:py-2 file:text-sm file:font-semibold file:text-af-accent hover:bg-af-overlay/6";
-const DIALOG_FIELD_DESCRIPTION_CLASS = cx(
+const DIALOG_FIELD_DESCRIPTION_CLASS = cn(
   "m-0",
   DASHBOARD_SUPPORTING_TEXT_CLASS,
 );

--- a/ui/src/features/factory-graph-editor/factory-graph-editor-controls.tsx
+++ b/ui/src/features/factory-graph-editor/factory-graph-editor-controls.tsx
@@ -8,7 +8,7 @@ import {
   PopoverTrigger,
   buttonVariants,
 } from "../../components/ui";
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import { getFactoryGraphEditorMessages } from "./messages/editor";
 import { FactoryGraphEditorTooltipButton } from "./factory-graph-editor-tooltip-button";
 
@@ -114,7 +114,7 @@ export function FactoryGraphEditorStatus({
   if (!editorMode) {
     return (
       <p
-        className={cx(
+        className={cn(
           STATUS_PILL_CLASS,
           "border-af-overlay/12 bg-af-overlay/6 text-af-ink/76",
         )}
@@ -128,7 +128,7 @@ export function FactoryGraphEditorStatus({
     return (
       <p
         aria-live="polite"
-        className={cx(
+        className={cn(
           STATUS_PILL_CLASS,
           "border-af-accent/24 bg-af-accent/10 text-af-accent",
         )}
@@ -142,7 +142,7 @@ export function FactoryGraphEditorStatus({
     return (
       <p
         aria-live="polite"
-        className={cx(
+        className={cn(
           STATUS_PILL_CLASS,
           "border-af-danger/30 bg-af-danger/8 text-af-danger-ink",
         )}
@@ -156,7 +156,7 @@ export function FactoryGraphEditorStatus({
   return (
     <p
       aria-live="polite"
-      className={cx(
+      className={cn(
         STATUS_PILL_CLASS,
         hasChanges
           ? "border-af-warning/30 bg-af-warning/10 text-af-warning-ink"
@@ -237,7 +237,7 @@ export function FactoryGraphEditorToolbar({
       />
       <p
         aria-live="polite"
-        className={cx(
+        className={cn(
           STATUS_PILL_CLASS,
           hasPendingChanges
             ? "border-af-warning/30 bg-af-warning/10 text-af-warning-ink"
@@ -284,7 +284,7 @@ export function FactoryGraphEditorVisibilityPanel({
               option.label,
             )}
             aria-pressed={option.visible}
-            className={cx(
+            className={cn(
               "flex items-center justify-between gap-3 rounded-2xl border px-3 py-2 text-left transition focus-visible:outline-2 focus-visible:outline-af-accent",
               option.visible
                 ? "border-af-accent/20 bg-af-accent/8 text-af-ink"
@@ -468,7 +468,7 @@ export function FactoryGraphEditorNotice({
 }) {
   return (
     <section
-      className={cx(
+      className={cn(
         "grid gap-1 rounded-2xl border p-4",
         NOTICE_TONE_CLASS[tone],
       )}

--- a/ui/src/features/factory-graph-editor/factory-graph-editor-flow.tsx
+++ b/ui/src/features/factory-graph-editor/factory-graph-editor-flow.tsx
@@ -5,7 +5,7 @@ import {
   type NodeProps,
 } from "@xyflow/react";
 
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import {
   ActivityGraphNodeShell,
   type ActivityGraphNodeHandle,
@@ -253,7 +253,7 @@ function FactoryGraphEditorNodeView({
 >) {
   return (
     <ActivityGraphNodeShell
-      className={cx(
+      className={cn(
         "min-w-0 w-full justify-start border text-left shadow-none",
         KIND_CLASS[data.kind],
         data.draftStatus === "addition" && "ring-2 ring-af-warning/34",
@@ -282,7 +282,7 @@ function FactoryGraphEditorNodeView({
           ) : null}
           {data.kind === "worker" && data.workerStatus ? (
             <span
-              className={cx(
+              className={cn(
                 "rounded-full border px-2 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.08em]",
                 WORKER_STATUS_CLASS[data.workerStatus],
               )}

--- a/ui/src/features/flowchart/current-activity-node-shell.tsx
+++ b/ui/src/features/flowchart/current-activity-node-shell.tsx
@@ -1,7 +1,7 @@
 import { Handle, Position } from "@xyflow/react";
 import type { ReactNode } from "react";
 
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 
 export type PlaceNodeType = "constraint" | "resource" | "statePosition";
 
@@ -43,7 +43,7 @@ export function ActivityGraphNodeShell({
 
   return (
     <article
-      className={cx(
+      className={cn(
         "flex h-full min-w-0 w-full flex-col gap-1 overflow-visible rounded-lg border border-af-overlay/9 bg-af-canvas p-3 text-af-ink",
         className,
       )}
@@ -114,7 +114,7 @@ function NodeHandleBadge({
     handle.side === "left"
       ? "-translate-x-1 flex-row"
       : "translate-x-1 flex-row-reverse";
-  const buttonClassName = cx(
+  const buttonClassName = cn(
     "nodrag nopan inline-flex min-h-6 items-center rounded-full border px-2 py-1 text-[0.625rem] font-semibold uppercase tracking-[0.08em] shadow-sm transition focus-visible:outline-2 focus-visible:outline-af-accent disabled:cursor-not-allowed",
     handle.variant === "selected" &&
       "border-af-accent/40 bg-af-accent/14 text-af-accent",
@@ -128,7 +128,7 @@ function NodeHandleBadge({
 
   return (
     <div
-      className={cx(
+      className={cn(
         "pointer-events-none absolute top-0 z-20 flex -translate-y-1/2 items-center gap-1.5",
         handle.side === "left" ? "left-0" : "right-0",
         wrapperClassName,
@@ -136,7 +136,7 @@ function NodeHandleBadge({
       style={{ top }}
     >
       <Handle
-        className={cx(
+        className={cn(
           "pointer-events-auto !h-3.5 !w-3.5 !border-2 !border-af-surface !bg-af-overlay/35 transition",
           handle.connectable && "!bg-af-accent/88",
           handle.variant === "selected" && "!bg-af-accent",
@@ -150,7 +150,7 @@ function NodeHandleBadge({
       <button
         aria-label={handle.buttonAriaLabel}
         aria-pressed={handle.buttonPressed}
-        className={cx("pointer-events-auto", buttonClassName)}
+        className={cn("pointer-events-auto", buttonClassName)}
         disabled={handle.buttonDisabled}
         onClick={handle.onButtonClick}
         title={handle.buttonTitle}

--- a/ui/src/features/flowchart/current-activity-place-node.tsx
+++ b/ui/src/features/flowchart/current-activity-place-node.tsx
@@ -6,7 +6,7 @@ import {
   formatDashboardPlaceLabel,
   getDashboardPlaceLabelParts,
 } from "../../components/ui/place-labels";
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import { getWorkflowActivityShellMessages } from "../workflow-activity/messages/activity-shell";
 import {
   ActivityGraphNodeShell,
@@ -90,7 +90,7 @@ function PlaceNodeView({ data }: NodeProps<CurrentActivityPlaceNode>) {
       : data.place.kind === "resource"
         ? "resource"
         : "constraint";
-  const nodeClassName = cx(
+  const nodeClassName = cn(
     placeNodeClassName(data.place),
     data.activeFlow &&
       !data.selectedStateNode &&
@@ -101,7 +101,7 @@ function PlaceNodeView({ data }: NodeProps<CurrentActivityPlaceNode>) {
 
   return (
     <ActivityGraphNodeShell
-      className={cx("justify-center text-left", nodeClassName)}
+      className={cn("justify-center text-left", nodeClassName)}
       incomingHandleCount={data.incomingHandleCount}
       nodeType={nodeType}
       outgoingHandleCount={data.outgoingHandleCount}
@@ -110,7 +110,7 @@ function PlaceNodeView({ data }: NodeProps<CurrentActivityPlaceNode>) {
         <button
           aria-label={messages.selectStateLabel(placeLabel)}
           aria-pressed={data.selectedStateNode}
-          className={cx(
+          className={cn(
             "nodrag nopan cursor-pointer border-0 bg-transparent p-0 text-left text-inherit",
             STATE_POSITION_CONTENT_CONTAINER_CLASSNAME,
           )}
@@ -158,7 +158,7 @@ function placeNodeClassName(place: DashboardPlaceRef): string {
         ? "border-af-edge-danger-muted"
         : "";
 
-  return cx(kindClassName, stateClassName);
+  return cn(kindClassName, stateClassName);
 }
 
 function placeKindLabel(place: DashboardPlaceRef): string {
@@ -308,7 +308,7 @@ function PlaceSemanticIcon({ place }: { place: DashboardPlaceRef }) {
       title={placeKindLabel(place)}
     >
       <GraphSemanticIcon
-        className={cx("h-3.5 w-3.5", placeSemanticIconClassName(place))}
+        className={cn("h-3.5 w-3.5", placeSemanticIconClassName(place))}
         kind={placeSemanticIconKind(place)}
         label={placeSemanticIconLabel(place)}
       />

--- a/ui/src/features/flowchart/current-activity-workstation-node.tsx
+++ b/ui/src/features/flowchart/current-activity-workstation-node.tsx
@@ -9,7 +9,7 @@ import {
   formatDurationFromISO,
   formatWorkItemLabel,
 } from "../../components/ui/formatters";
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import { getWorkflowActivityShellMessages } from "../workflow-activity/messages/activity-shell";
 import { ActivityGraphNodeShell } from "./current-activity-node-shell";
 import { GraphSemanticIcon } from "./graph-semantic-icon";
@@ -66,7 +66,7 @@ export function WorkstationNodeView({
     data.workstation.workstation_name ||
     data.workstation.transition_id ||
     data.workstation.node_id;
-  const nodeClassName = cx(
+  const nodeClassName = cn(
     "min-w-0 w-full justify-start overflow-hidden border-2 bg-af-surface/88",
     exhaustionRule ? "border-dashed border-af-danger/36" : "border-af-info/28",
     !exhaustionRule &&
@@ -143,7 +143,7 @@ function ExhaustionRuleNodeButton({
         title={semanticIconMetadata.label}
       >
         <GraphSemanticIcon
-          className={cx("h-4 w-4", semanticIconMetadata.className)}
+          className={cn("h-4 w-4", semanticIconMetadata.className)}
           kind={semanticIconMetadata.iconKind}
           label={semanticIconMetadata.label}
         />
@@ -203,7 +203,7 @@ function ActiveWorkstationNodeContent({
           title={semanticIconMetadata.label}
         >
           <GraphSemanticIcon
-            className={cx("h-4 w-4", semanticIconMetadata.className)}
+            className={cn("h-4 w-4", semanticIconMetadata.className)}
             kind={semanticIconMetadata.iconKind}
             label={semanticIconMetadata.label}
           />
@@ -242,7 +242,7 @@ function ActiveWorkstationNodeContent({
             <li key={`${execution.dispatch_id}:${workItem.work_id}`}>
               <button
                 aria-pressed={workItemSelected}
-                className={cx(
+                className={cn(
                   "nodrag nopan grid min-w-0 w-full cursor-pointer grid-cols-[minmax(0,1fr)_auto] items-center gap-2 overflow-hidden rounded-lg border border-af-overlay/8 bg-af-surface px-2 py-1.5 text-left text-[0.74rem] text-inherit",
                   workItemSelected &&
                     "border-af-info/60 bg-af-info/15 shadow-af-info-chip",
@@ -337,7 +337,7 @@ function workstationTitleClassName(label: string): string {
         ? "text-[0.88rem]"
         : "text-[1rem]";
 
-  return cx(
+  return cn(
     "block min-w-0 basis-0 flex-1 truncate whitespace-nowrap font-bold leading-tight",
     textSizeClassName,
   );
@@ -351,7 +351,7 @@ function workItemLabelClassName(label: string): string {
         ? "text-[0.68rem]"
         : "text-[0.74rem]";
 
-  return cx(
+  return cn(
     "block min-w-0 basis-0 flex-1 truncate whitespace-nowrap leading-tight",
     textSizeClassName,
   );

--- a/ui/src/features/flowchart/graph-semantic-icon.tsx
+++ b/ui/src/features/flowchart/graph-semantic-icon.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 
 export const GRAPH_SEMANTIC_ICON_KINDS = [
   "queue",
@@ -184,7 +184,7 @@ export function GraphSemanticIcon({
   return (
     <svg
       aria-label={accessibleLabel}
-      className={cx(DEFAULT_ICON_CLASS_NAME, className)}
+      className={cn(DEFAULT_ICON_CLASS_NAME, className)}
       data-graph-semantic-icon={definition ? kind : "unknown"}
       fill="none"
       focusable="false"

--- a/ui/src/features/header/dashboard-brand-lockup.tsx
+++ b/ui/src/features/header/dashboard-brand-lockup.tsx
@@ -1,4 +1,4 @@
-import { cx } from "../../components/ui";
+import { cn } from "../../lib/cn";
 import { getHeaderControlsMessages } from "./messages/header-controls";
 
 interface DashboardBrandLockupProps {
@@ -19,7 +19,7 @@ export function DashboardBrandLockup({
 
   return (
     <span
-      className={cx(
+      className={cn(
         "inline-flex min-w-0 items-center gap-4 align-middle leading-none",
         className,
       )}
@@ -28,7 +28,7 @@ export function DashboardBrandLockup({
         <span className="text-[1.65rem] leading-none">∞</span>
         <span className="text-[1.12rem] leading-none">U</span>
       </span>
-      <span className={cx("sr-only", wordmarkClassName)}>
+      <span className={cn("sr-only", wordmarkClassName)}>
         {messages.brandWordmark}
       </span>
     </span>

--- a/ui/src/features/header/dashboard-header.tsx
+++ b/ui/src/features/header/dashboard-header.tsx
@@ -9,7 +9,7 @@ import {
 
 import type { DashboardStreamState } from "../../api/dashboard/types";
 import { TickSliderControl } from "../../components/dashboard";
-import { cx } from "../../components/ui";
+import { cn } from "../../lib/cn";
 import { DASHBOARD_PANEL_SHELL_CLASS } from "../../components/ui/dashboard-shell";
 import {
   DASHBOARD_BODY_TEXT_CLASS,
@@ -30,27 +30,27 @@ import { DashboardBrandLockup } from "./dashboard-brand-lockup";
 import { DashboardHeaderActionButton } from "./dashboard-header-action-button";
 import { getHeaderControlsMessages } from "./messages/header-controls";
 
-const DASHBOARD_TOOLBAR_CLASS = cx(
+const DASHBOARD_TOOLBAR_CLASS = cn(
   DASHBOARD_PANEL_SHELL_CLASS,
   "mb-4 flex flex-wrap items-center gap-3 p-3 md:px-4 md:py-3",
 );
-const DASHBOARD_TITLE_CLASS = cx("m-0 shrink-0", DASHBOARD_PAGE_HEADING_CLASS);
-const DASHBOARD_CONTROLS_CLASS = cx(
+const DASHBOARD_TITLE_CLASS = cn("m-0 shrink-0", DASHBOARD_PAGE_HEADING_CLASS);
+const DASHBOARD_CONTROLS_CLASS = cn(
   "ml-auto flex min-w-0 flex-1 flex-wrap items-center justify-end gap-3",
   "max-md:ml-0 max-md:w-full max-md:justify-stretch",
 );
-const STREAM_STATUS_SHELL_CLASS = cx(
+const STREAM_STATUS_SHELL_CLASS = cn(
   "flex shrink-0 items-center justify-end",
   "max-md:justify-start",
 );
-const STREAM_STATUS_CLASS = cx(
+const STREAM_STATUS_CLASS = cn(
   "inline-flex h-10 w-10 items-center justify-center rounded-full border border-af-overlay/12 bg-af-overlay/4",
   DASHBOARD_BODY_TEXT_CLASS,
   DASHBOARD_SUPPORTING_LABELS_CLASS,
 );
 const LOCALE_MENU_PANEL_CLASS =
   "absolute right-0 top-full z-10 mt-2 min-w-44 overflow-hidden rounded-2xl border border-af-overlay/12 bg-af-surface/96 p-1 shadow-af-panel backdrop-blur-lg";
-const LOCALE_MENU_ITEM_CLASS = cx(
+const LOCALE_MENU_ITEM_CLASS = cn(
   "flex w-full items-center justify-between rounded-xl px-3 py-2 text-left text-sm text-af-ink/82 outline-none transition-colors",
   "focus-visible:bg-af-overlay/8 focus-visible:ring-2 focus-visible:ring-af-accent/25",
 );
@@ -270,7 +270,7 @@ function DashboardLocaleMenuList({
         return (
           <button
             aria-checked={isSelected}
-            className={cx(
+            className={cn(
               LOCALE_MENU_ITEM_CLASS,
               isSelected && "bg-af-accent/10 text-af-accent",
             )}
@@ -420,7 +420,7 @@ function moveLocaleMenuFocus(
 }
 
 function streamStatusClassName(status: DashboardStreamState["status"]): string {
-  return cx(
+  return cn(
     STREAM_STATUS_CLASS,
     status === "live" &&
       "border-af-success/30 bg-af-success/16 text-af-success-ink",

--- a/ui/src/features/header/dashboard-status-panel.tsx
+++ b/ui/src/features/header/dashboard-status-panel.tsx
@@ -1,4 +1,4 @@
-import { cx } from "../../components/ui";
+import { cn } from "../../lib/cn";
 import { DASHBOARD_PANEL_SHELL_CLASS } from "../../components/ui/dashboard-shell";
 import {
   DASHBOARD_BODY_TEXT_CLASS,
@@ -7,14 +7,14 @@ import {
 import { useAppLocale } from "../../i18n";
 import { DashboardBrandLockup } from "./dashboard-brand-lockup";
 
-const STATUS_PANEL_CLASS = cx(
+const STATUS_PANEL_CLASS = cn(
   DASHBOARD_PANEL_SHELL_CLASS,
   "mb-4 p-4 md:p-5 md:px-6",
 );
 const EYEBROW_CLASS =
   "mb-3 text-xs font-bold uppercase tracking-[0.16em] text-af-accent";
-const DASHBOARD_TITLE_CLASS = cx("m-0", DASHBOARD_PAGE_HEADING_CLASS);
-const DETAIL_COPY_CLASS = cx("m-0 max-w-80", DASHBOARD_BODY_TEXT_CLASS);
+const DASHBOARD_TITLE_CLASS = cn("m-0", DASHBOARD_PAGE_HEADING_CLASS);
+const DETAIL_COPY_CLASS = cn("m-0 max-w-80", DASHBOARD_BODY_TEXT_CLASS);
 
 interface DashboardStatusPanelProps {
   detail?: string;
@@ -32,7 +32,7 @@ export function DashboardStatusPanel({
   const { locale: resolvedLocale } = useAppLocale(locale);
   const detailClassName =
     tone === "error"
-      ? cx(DETAIL_COPY_CLASS, "text-af-danger-ink")
+      ? cn(DETAIL_COPY_CLASS, "text-af-danger-ink")
       : DETAIL_COPY_CLASS;
 
   return (

--- a/ui/src/features/header/tick-slider-control.tsx
+++ b/ui/src/features/header/tick-slider-control.tsx
@@ -1,5 +1,5 @@
 import { type ChangeEvent, useMemo } from "react";
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import { useFactoryTimelineStore } from "../timeline/state/factoryTimelineStore";
 import { DashboardHeaderActionButton } from "./dashboard-header-action-button";
 import {
@@ -8,7 +8,7 @@ import {
   HEADER_MAX_TICK_TOKEN,
 } from "./messages/header-controls";
 
-const TICK_SLIDER_SHELL_CLASS = cx(
+const TICK_SLIDER_SHELL_CLASS = cn(
   "flex min-w-0 w-full flex-wrap items-center gap-2 rounded-lg border border-af-overlay/10 bg-af-overlay/4 px-3 py-2",
   "md:w-auto md:min-w-80 md:max-w-xl",
 );
@@ -127,7 +127,7 @@ export function TickSliderControl({ locale }: TickSliderControlProps) {
       </span>
 
       <DashboardHeaderActionButton
-        className={cx(mode === "current" && "opacity-75")}
+        className={cn(mode === "current" && "opacity-75")}
         aria-label={messages.returnToCurrentTickLabel}
         compact
         disabled={isDisabled || mode === "current"}

--- a/ui/src/features/import/dashboard-import-preview-dialog.tsx
+++ b/ui/src/features/import/dashboard-import-preview-dialog.tsx
@@ -16,7 +16,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "../../components/ui";
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import type { FactoryPngImportValue } from "./factory-png-import";
 import {
   getImportPreviewDialogMessages,
@@ -27,10 +27,10 @@ import type { FactoryImportPreviewState } from "./use-factory-import-preview";
 
 const IMPORT_DIALOG_CONTENT_CLASS =
   "w-full max-w-5xl gap-6 p-4 md:grid-cols-[minmax(0,22rem)_minmax(0,1fr)] md:p-5";
-const IMPORT_DIALOG_TITLE_CLASS = cx("m-0", DASHBOARD_SECTION_HEADING_CLASS);
-const IMPORT_DIALOG_DESCRIPTION_CLASS = cx("m-0", DASHBOARD_BODY_TEXT_CLASS);
-const IMPORT_DIALOG_HINT_CLASS = cx("m-0", DASHBOARD_SUPPORTING_TEXT_CLASS);
-const IMPORT_DIALOG_LABEL_CLASS = cx(
+const IMPORT_DIALOG_TITLE_CLASS = cn("m-0", DASHBOARD_SECTION_HEADING_CLASS);
+const IMPORT_DIALOG_DESCRIPTION_CLASS = cn("m-0", DASHBOARD_BODY_TEXT_CLASS);
+const IMPORT_DIALOG_HINT_CLASS = cn("m-0", DASHBOARD_SUPPORTING_TEXT_CLASS);
+const IMPORT_DIALOG_LABEL_CLASS = cn(
   "text-[0.7rem] font-bold uppercase tracking-[0.14em] text-af-accent",
   DASHBOARD_SUPPORTING_LABELS_CLASS,
 );
@@ -107,12 +107,12 @@ function FactoryImportActivationErrorPanel({
   return (
     <div
       aria-live="assertive"
-      className={cx(EMPTY_STATE_CLASS, IMPORT_ERROR_PANEL_CLASS)}
+      className={cn(EMPTY_STATE_CLASS, IMPORT_ERROR_PANEL_CLASS)}
       role="alert"
     >
       <div className="grid gap-1">
         <h3>{messages.activationErrorTitle}</h3>
-        <p className={cx("m-0 text-sm", DASHBOARD_SUPPORTING_TEXT_CLASS)}>
+        <p className={cn("m-0 text-sm", DASHBOARD_SUPPORTING_TEXT_CLASS)}>
           {factoryImportActivationErrorCopy(error, locale)}
         </p>
       </div>

--- a/ui/src/features/submit-work/submit-work-card.tsx
+++ b/ui/src/features/submit-work/submit-work-card.tsx
@@ -10,7 +10,7 @@ import {
   DASHBOARD_SUPPORTING_LABEL_CLASS,
   DASHBOARD_SUPPORTING_TEXT_CLASS,
 } from "../../components/ui/dashboard-typography";
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import { getSubmitWorkMessages } from "./messages/submit-work";
 
 export interface SubmitWorkDraft {
@@ -47,11 +47,11 @@ const FORM_CLASS = "grid h-full min-h-0 gap-4";
 const FIELD_GROUP_CLASS = "grid gap-2";
 const FIELD_LABEL_CLASS = DASHBOARD_SUPPORTING_LABEL_CLASS;
 const ACTION_ROW_CLASS = "mt-auto flex items-start gap-3";
-const HELP_TEXT_CLASS = cx(
+const HELP_TEXT_CLASS = cn(
   "max-w-xl leading-relaxed text-af-ink/66",
   DASHBOARD_SUPPORTING_TEXT_CLASS,
 );
-const VALIDATION_TEXT_CLASS = cx(
+const VALIDATION_TEXT_CLASS = cn(
   "text-af-danger-ink",
   DASHBOARD_SUPPORTING_TEXT_CLASS,
 );
@@ -179,7 +179,7 @@ export function SubmitWorkCard({
 
         <div className={ACTION_ROW_CLASS}>
           <p
-            className={cx(
+            className={cn(
               "min-w-0 flex-1",
               HELP_TEXT_CLASS,
               STATUS_TONE_CLASS_BY_KIND[status.kind],

--- a/ui/src/features/terminal-work/terminal-work-card.tsx
+++ b/ui/src/features/terminal-work/terminal-work-card.tsx
@@ -20,7 +20,7 @@ import {
   DASHBOARD_SECTION_HEADING_CLASS,
   DASHBOARD_SUPPORTING_TEXT_CLASS,
 } from "../../components/ui/dashboard-typography";
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import type { GraphSemanticIconKind } from "../flowchart/graph-semantic-icon";
 import { GraphSemanticIcon } from "../flowchart/graph-semantic-icon";
 import { getTerminalWorkMessages } from "./messages";
@@ -78,7 +78,7 @@ const TERMINAL_ROW_TITLE_ICON_CLASS = "h-4 w-4 shrink-0";
 const TERMINAL_LIST_CLASS = "grid gap-2";
 const TERMINAL_TOGGLE_CLASS =
   "min-h-9 shrink-0 border-af-overlay/12 bg-af-overlay/6 px-2.5 py-2 text-xs text-af-ink/78 hover:border-af-overlay/18 hover:bg-af-overlay/10 hover:text-af-ink";
-const TERMINAL_BUTTON_CLASS = cx(
+const TERMINAL_BUTTON_CLASS = cn(
   "grid h-auto min-h-0 w-full justify-start gap-1 border-af-info/35 bg-af-info/10 px-3 py-2 text-left text-on-foreground [overflow-wrap:anywhere]",
   DASHBOARD_BODY_TEXT_CLASS,
 );
@@ -87,7 +87,7 @@ const TERMINAL_BUTTON_FAILED_CLASS =
 const TERMINAL_BUTTON_SELECTED_CLASS =
   "border-on-foreground/55 bg-on-foreground/14 text-on-foreground shadow-af-accent-chip";
 const TERMINAL_BUTTON_LABEL_CLASS = "font-bold";
-const TERMINAL_BUTTON_META_CLASS = cx(
+const TERMINAL_BUTTON_META_CLASS = cn(
   "leading-snug text-af-ink/66",
   DASHBOARD_SUPPORTING_TEXT_CLASS,
 );
@@ -115,7 +115,7 @@ export function CompletedFailedWorkstationCard({
 }: CompletedFailedWorkstationCardProps) {
   const [completedExpanded, setCompletedExpanded] = useState(true);
   const [failedExpanded, setFailedExpanded] = useState(true);
-  const cardClassName = cx(
+  const cardClassName = cn(
     DASHBOARD_WIDGET_CLASS,
     DETAIL_CARD_CLASS,
     className,
@@ -187,7 +187,7 @@ function TerminalWorkRow({
 
   return (
     <section
-      className={cx(
+      className={cn(
         TERMINAL_ROW_CLASS,
         status === "failed" && TERMINAL_FAILED_ROW_CLASS,
       )}
@@ -199,7 +199,7 @@ function TerminalWorkRow({
           <div>
             <div className={TERMINAL_ROW_TITLE_CLASS} data-terminal-work-title>
               <GraphSemanticIcon
-                className={cx(
+                className={cn(
                   TERMINAL_ROW_TITLE_ICON_CLASS,
                   terminalStatusIconClassName(status),
                 )}
@@ -233,7 +233,7 @@ function TerminalWorkRow({
             items.map((item) => (
               <Button
                 aria-label={item.label}
-                className={cx(
+                className={cn(
                   TERMINAL_BUTTON_CLASS,
                   status === "failed" && TERMINAL_BUTTON_FAILED_CLASS,
                   selectedLabel === item.label &&

--- a/ui/src/features/trace-drilldown/trace-grid-card.tsx
+++ b/ui/src/features/trace-drilldown/trace-grid-card.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import {
   formatDurationMillis,
   formatTraceOutcome,
@@ -50,7 +50,7 @@ const TRACE_EXPANDER_TOGGLE_CLASS = "min-h-9 shrink-0 px-2.5 py-2";
 const TRACE_LOADING_SKELETON_CLASS = "h-4 w-full max-w-48";
 // tailwind-exception: intrinsic-sizing
 const TRACE_GRID_TABLE_CLASS = "min-w-[860px]";
-const TRACE_WORK_ITEM_BUTTON_CLASS = cx(
+const TRACE_WORK_ITEM_BUTTON_CLASS = cn(
   "h-auto min-h-0 justify-start border-af-accent/35 bg-af-accent/10 px-2.5 py-1.5 text-left text-af-accent",
   DASHBOARD_SUPPORTING_CODE_CLASS,
 );
@@ -79,7 +79,7 @@ export function TraceGridBentoCard({
   title,
 }: TraceGridBentoCardProps) {
   const messages = getTraceDrilldownMessages(locale);
-  const cardClassName = cx(
+  const cardClassName = cn(
     DASHBOARD_WIDGET_CLASS,
     DETAIL_CARD_CLASS,
     DETAIL_CARD_WIDE_CLASS,
@@ -104,14 +104,14 @@ function renderTraceState(
   switch (state.status) {
     case "idle":
       return (
-        <div className={cx(EMPTY_STATE_CLASS, EMPTY_STATE_COMPACT_CLASS)}>
+        <div className={cn(EMPTY_STATE_CLASS, EMPTY_STATE_COMPACT_CLASS)}>
           <h3>{messages.idleTitle}</h3>
           <p>{messages.idleMessage}</p>
         </div>
       );
     case "loading":
       return (
-        <div className={cx(EMPTY_STATE_CLASS, EMPTY_STATE_COMPACT_CLASS)}>
+        <div className={cn(EMPTY_STATE_CLASS, EMPTY_STATE_COMPACT_CLASS)}>
           <h3>{messages.loadingTitle}</h3>
           <p>{messages.loadingMessage(state.workID)}</p>
           <div aria-hidden="true" className="grid gap-2 pt-2">
@@ -123,14 +123,14 @@ function renderTraceState(
       );
     case "empty":
       return (
-        <div className={cx(EMPTY_STATE_CLASS, EMPTY_STATE_COMPACT_CLASS)}>
+        <div className={cn(EMPTY_STATE_CLASS, EMPTY_STATE_COMPACT_CLASS)}>
           <h3>{messages.emptyTitle}</h3>
           <p>{messages.emptyMessage}</p>
         </div>
       );
     case "error":
       return (
-        <div className={cx(EMPTY_STATE_CLASS, EMPTY_STATE_COMPACT_CLASS)}>
+        <div className={cn(EMPTY_STATE_CLASS, EMPTY_STATE_COMPACT_CLASS)}>
           <h3>{messages.errorTitle}</h3>
           <p>{state.message}</p>
         </div>
@@ -159,7 +159,7 @@ function TraceGrid({ locale, onSelectWorkID, trace }: TraceGridProps) {
   return (
     <div className="grid min-w-0 w-full gap-3" style={{ overflowX: "hidden" }}>
       <dl
-        className={cx(
+        className={cn(
           "m-0 grid gap-3 [&_dd]:m-0 [&_div:first-child]:border-t-0 [&_div:first-child]:pt-0 [&_div]:border-t [&_div]:border-af-overlay/6 [&_div]:pt-3 [&_dt]:mb-1",
           DASHBOARD_SUPPORTING_LABELS_CLASS,
           DASHBOARD_BODY_TEXT_CLASS,
@@ -200,7 +200,7 @@ function TraceGrid({ locale, onSelectWorkID, trace }: TraceGridProps) {
                       <Button
                         aria-controls={workItemsID}
                         aria-expanded={workItemsExpanded}
-                        className={cx(
+                        className={cn(
                           TRACE_EXPANDER_TOGGLE_CLASS,
                           DASHBOARD_SUPPORTING_LABEL_CLASS,
                         )}
@@ -246,8 +246,8 @@ function TraceGrid({ locale, onSelectWorkID, trace }: TraceGridProps) {
 
       {trace.dispatches.length > 0 ? (
         <div className="min-w-0 overflow-x-auto">
-          <Table className={cx(TRACE_GRID_TABLE_CLASS, DASHBOARD_BODY_TEXT_CLASS)}>
-            <TableCaption className={cx("mb-2 text-left", DASHBOARD_SUPPORTING_LABEL_CLASS)}>
+          <Table className={cn(TRACE_GRID_TABLE_CLASS, DASHBOARD_BODY_TEXT_CLASS)}>
+            <TableCaption className={cn("mb-2 text-left", DASHBOARD_SUPPORTING_LABEL_CLASS)}>
               {messages.tableCaption}
             </TableCaption>
             <TableHeader>
@@ -274,7 +274,7 @@ function TraceGrid({ locale, onSelectWorkID, trace }: TraceGridProps) {
                 <TableRow key={dispatch.dispatch_id}>
                   <TableHead className="align-top" scope="row">
                     <span
-                      className={cx(
+                      className={cn(
                         "inline-flex rounded-full bg-af-info/15 px-2 py-0.5 text-af-info-ink",
                         DASHBOARD_SUPPORTING_CODE_CLASS,
                       )}
@@ -316,7 +316,7 @@ function TraceGrid({ locale, onSelectWorkID, trace }: TraceGridProps) {
           </Table>
         </div>
       ) : (
-        <div className={cx(EMPTY_STATE_CLASS, EMPTY_STATE_COMPACT_CLASS)}>
+        <div className={cn(EMPTY_STATE_CLASS, EMPTY_STATE_COMPACT_CLASS)}>
           <h3>{messages.noTraceHistoryTitle}</h3>
           <p>{messages.noTraceHistoryMessage}</p>
         </div>

--- a/ui/src/features/trace-drilldown/trace-relation-flow.tsx
+++ b/ui/src/features/trace-drilldown/trace-relation-flow.tsx
@@ -16,7 +16,7 @@ import {
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import {
   DASHBOARD_BODY_TEXT_CLASS,
   DASHBOARD_SUPPORTING_LABEL_CLASS,
@@ -232,7 +232,7 @@ function RelationWorkNode({
         {messages.workItemsLabel}
       </span>
       <strong
-        className={cx("text-sm text-af-ink [overflow-wrap:anywhere]", DASHBOARD_BODY_TEXT_CLASS)}
+        className={cn("text-sm text-af-ink [overflow-wrap:anywhere]", DASHBOARD_BODY_TEXT_CLASS)}
       >
         {data.label}
       </strong>
@@ -242,7 +242,7 @@ function RelationWorkNode({
   if (data.selectable && data.workID && data.onSelectWorkID) {
     return (
       <button
-        className={cx(RELATION_NODE_CLASS, RELATION_NODE_ACTIVE_CLASS)}
+        className={cn(RELATION_NODE_CLASS, RELATION_NODE_ACTIVE_CLASS)}
         onClick={handleSelectWork}
         title={data.workID}
         type="button"

--- a/ui/src/features/trace-drilldown/trace-workstation-path.tsx
+++ b/ui/src/features/trace-drilldown/trace-workstation-path.tsx
@@ -16,7 +16,7 @@ import {
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import {
   DASHBOARD_BODY_TEXT_CLASS,
   DASHBOARD_SUPPORTING_LABEL_CLASS,
@@ -216,12 +216,12 @@ function WorkstationPathGraphNode({
   const messages = getTraceDrilldownMessages(data.locale);
 
   return (
-    <article className={cx(PATH_NODE_CLASS, outcomeToneClassName(data.outcome))}>
+    <article className={cn(PATH_NODE_CLASS, outcomeToneClassName(data.outcome))}>
       <Handle className="opacity-0" position={Position.Left} type="target" />
       <Handle className="opacity-0" position={Position.Right} type="source" />
       <div className="flex items-center justify-between gap-3">
         <span
-          className={cx(
+          className={cn(
             "inline-flex rounded-full px-2 py-0.5 text-[0.68rem] font-semibold uppercase tracking-[0.12em]",
             DASHBOARD_SUPPORTING_LABEL_CLASS,
           )}
@@ -229,7 +229,7 @@ function WorkstationPathGraphNode({
           {messages.dispatchPathSectionLabel}
         </span>
         <span
-          className={cx(
+          className={cn(
             "inline-flex rounded-full px-2 py-0.5 text-[0.68rem] font-semibold uppercase tracking-[0.08em]",
             DASHBOARD_SUPPORTING_LABEL_CLASS,
           )}
@@ -240,7 +240,7 @@ function WorkstationPathGraphNode({
         </span>
       </div>
       <strong
-        className={cx("text-sm text-af-ink [overflow-wrap:anywhere]", DASHBOARD_BODY_TEXT_CLASS)}
+        className={cn("text-sm text-af-ink [overflow-wrap:anywhere]", DASHBOARD_BODY_TEXT_CLASS)}
       >
         {data.label}
       </strong>

--- a/ui/src/features/work-outcome/chart-contract.ts
+++ b/ui/src/features/work-outcome/chart-contract.ts
@@ -1,4 +1,4 @@
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import { DASHBOARD_SUPPORTING_LABEL_CLASS } from "../../components/ui/dashboard-typography";
 
 export type DashboardChartSemanticRole =
@@ -39,15 +39,15 @@ const DASHBOARD_CHART_POINT_WEIGHT_CLASS = "[stroke-width:1.5]";
 const DASHBOARD_CHART_DEFAULT_POINT_RADIUS = 3.25;
 
 export const DASHBOARD_CHART_AXIS_CLASS = "stroke-af-ink/18 [stroke-width:1]";
-export const DASHBOARD_CHART_AXIS_LABEL_CLASS = cx(
+export const DASHBOARD_CHART_AXIS_LABEL_CLASS = cn(
   "fill-af-ink/58 [letter-spacing:0.16em]",
   DASHBOARD_SUPPORTING_LABEL_CLASS,
 );
-export const DASHBOARD_CHART_LINE_CLASS = cx(
+export const DASHBOARD_CHART_LINE_CLASS = cn(
   "fill-none [stroke-linecap:round] [stroke-linejoin:round]",
   DASHBOARD_CHART_LINE_WEIGHT_CLASS,
 );
-export const DASHBOARD_CHART_POINT_CLASS = cx(
+export const DASHBOARD_CHART_POINT_CLASS = cn(
   "stroke-af-canvas/88",
   DASHBOARD_CHART_POINT_WEIGHT_CLASS,
 );
@@ -60,44 +60,44 @@ const DASHBOARD_CHART_SEMANTIC_STYLES: Record<
 > = {
   queued: {
     color: "var(--color-af-chart-queued)",
-    lineClassName: cx(DASHBOARD_CHART_LINE_CLASS, "[stroke-dasharray:5_4]"),
-    pointClassName: cx(DASHBOARD_CHART_POINT_CLASS, "fill-af-chart-queued"),
+    lineClassName: cn(DASHBOARD_CHART_LINE_CLASS, "[stroke-dasharray:5_4]"),
+    pointClassName: cn(DASHBOARD_CHART_POINT_CLASS, "fill-af-chart-queued"),
     pointRadius: DASHBOARD_CHART_DEFAULT_POINT_RADIUS,
   },
   inFlight: {
     color: "var(--color-af-chart-in-flight)",
-    lineClassName: cx(DASHBOARD_CHART_LINE_CLASS, "[stroke-dasharray:7_5]"),
-    pointClassName: cx(DASHBOARD_CHART_POINT_CLASS, "fill-af-chart-in-flight"),
+    lineClassName: cn(DASHBOARD_CHART_LINE_CLASS, "[stroke-dasharray:7_5]"),
+    pointClassName: cn(DASHBOARD_CHART_POINT_CLASS, "fill-af-chart-in-flight"),
     pointRadius: DASHBOARD_CHART_DEFAULT_POINT_RADIUS,
   },
   completed: {
     color: "var(--color-af-chart-completed)",
     lineClassName: DASHBOARD_CHART_LINE_CLASS,
-    pointClassName: cx(DASHBOARD_CHART_POINT_CLASS, "fill-af-chart-completed"),
+    pointClassName: cn(DASHBOARD_CHART_POINT_CLASS, "fill-af-chart-completed"),
     pointRadius: DASHBOARD_CHART_DEFAULT_POINT_RADIUS,
   },
   failed: {
     color: "var(--color-af-chart-failed)",
-    lineClassName: cx(DASHBOARD_CHART_LINE_CLASS, "[stroke-dasharray:2.5_4.5]"),
-    pointClassName: cx(DASHBOARD_CHART_POINT_CLASS, "fill-af-chart-failed"),
+    lineClassName: cn(DASHBOARD_CHART_LINE_CLASS, "[stroke-dasharray:2.5_4.5]"),
+    pointClassName: cn(DASHBOARD_CHART_POINT_CLASS, "fill-af-chart-failed"),
     pointRadius: DASHBOARD_CHART_DEFAULT_POINT_RADIUS,
   },
   failureTrend: {
     color: "var(--color-af-chart-failure-trend)",
     lineClassName: DASHBOARD_CHART_LINE_CLASS,
-    pointClassName: cx(DASHBOARD_CHART_POINT_CLASS, "fill-af-chart-failure-trend"),
+    pointClassName: cn(DASHBOARD_CHART_POINT_CLASS, "fill-af-chart-failure-trend"),
     pointRadius: DASHBOARD_CHART_DEFAULT_POINT_RADIUS,
   },
   reworkTrend: {
     color: "var(--color-af-chart-rework-trend)",
     lineClassName: DASHBOARD_CHART_LINE_CLASS,
-    pointClassName: cx(DASHBOARD_CHART_POINT_CLASS, "fill-af-chart-rework-trend"),
+    pointClassName: cn(DASHBOARD_CHART_POINT_CLASS, "fill-af-chart-rework-trend"),
     pointRadius: DASHBOARD_CHART_DEFAULT_POINT_RADIUS,
   },
   timingTrend: {
     color: "var(--color-af-chart-timing-trend)",
     lineClassName: DASHBOARD_CHART_LINE_CLASS,
-    pointClassName: cx(DASHBOARD_CHART_POINT_CLASS, "fill-af-chart-timing-trend"),
+    pointClassName: cn(DASHBOARD_CHART_POINT_CLASS, "fill-af-chart-timing-trend"),
     pointRadius: DASHBOARD_CHART_DEFAULT_POINT_RADIUS,
   },
 };

--- a/ui/src/features/work-outcome/d3-information-card.tsx
+++ b/ui/src/features/work-outcome/d3-information-card.tsx
@@ -1,5 +1,5 @@
 import { getDashboardWorkChartSeriesDefinitions } from "./chart-contract";
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import type { WorkChartModel } from "./trends";
 import { WorkChart } from "./work-chart";
 import type { WorkChartSeriesDefinition, WorkChartState } from "./work-chart";
@@ -30,7 +30,7 @@ export function WorkChartCard({
   const messages = getWorkOutcomeMessages(locale);
   const chartMessages = messages.chart;
   const chartRegionID = widgetId ? `${widgetId}-chart-region` : "work-outcome-chart-region";
-  const cardClassName = cx(DASHBOARD_WIDGET_CLASS, className);
+  const cardClassName = cn(DASHBOARD_WIDGET_CLASS, className);
   const resolvedTitle = title ?? chartMessages.cardTitle;
   const chartSeries: readonly WorkChartSeriesDefinition[] =
     getDashboardWorkChartSeriesDefinitions([

--- a/ui/src/features/work-outcome/trend-cards.tsx
+++ b/ui/src/features/work-outcome/trend-cards.tsx
@@ -3,7 +3,7 @@ import {
   DASHBOARD_CHART_SURFACE_CLASS,
   getDashboardChartSemanticStyle,
 } from "./chart-contract";
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import {
   formatDurationMillis,
   formatTraceOutcome,
@@ -58,24 +58,24 @@ const TREND_TOOLBAR_CLASS =
 const TREND_RANGE_LABEL_CLASS =
   "grid w-full gap-1 md:w-auto md:shrink-0 md:basis-36";
 const TREND_RANGE_TEXT_CLASS = DASHBOARD_SUPPORTING_LABEL_CLASS;
-const TREND_RANGE_SELECT_CLASS = cx(
+const TREND_RANGE_SELECT_CLASS = cn(
   "rounded-lg border border-af-accent/35 bg-af-canvas/82 px-2 py-2 text-af-ink",
   DASHBOARD_BODY_TEXT_CLASS,
 );
 const TREND_SUMMARY_CLASS =
-  cx(
+  cn(
     "mb-4 grid grid-cols-1 gap-3 [&_dd]:m-0 [&_div]:rounded-lg [&_div]:border [&_div]:border-af-overlay/8 [&_div]:bg-af-overlay/4 [&_div]:p-3 [&_dt]:mb-1 md:grid-cols-3",
     DASHBOARD_SUPPORTING_LABELS_CLASS,
   );
-const TREND_CHART_CLASS = cx(DASHBOARD_CHART_SURFACE_CLASS, "min-h-44 border border-af-overlay/8");
+const TREND_CHART_CLASS = cn(DASHBOARD_CHART_SURFACE_CLASS, "min-h-44 border border-af-overlay/8");
 const TREND_CAUSE_LIST_CLASS = "mt-4 grid list-none gap-2 p-0";
 const TREND_CAUSE_ITEM_CLASS =
   "flex items-center justify-between gap-3 rounded-lg border border-af-overlay/7 bg-af-overlay/4 px-3 py-2.5";
-const TREND_CAUSE_LABEL_CLASS = cx(
+const TREND_CAUSE_LABEL_CLASS = cn(
   "min-w-0 text-af-ink/78 [overflow-wrap:anywhere]",
   DASHBOARD_BODY_TEXT_CLASS,
 );
-const TIMING_RANGE_SUMMARY_CLASS = cx(TREND_SUMMARY_CLASS, "mt-3 md:grid-cols-2");
+const TIMING_RANGE_SUMMARY_CLASS = cn(TREND_SUMMARY_CLASS, "mt-3 md:grid-cols-2");
 const TREND_SUMMARY_TERM_CLASS = DASHBOARD_SUPPORTING_LABEL_CLASS;
 const TREND_SUMMARY_VALUE_CLASS = WIDGET_SUBTITLE_CLASS;
 const FAILURE_TREND_CHART_STYLE = getDashboardChartSemanticStyle("failureTrend");
@@ -99,7 +99,7 @@ export function FailureTrendCard({
 
   return (
     <DashboardWidgetFrame
-      className={cx(DETAIL_CARD_WIDE_CLASS, className)}
+      className={cn(DETAIL_CARD_WIDE_CLASS, className)}
       title={messages.failureTitle}
       widgetId={widgetId}
     >
@@ -167,7 +167,7 @@ export function FailureTrendCard({
           ))}
         </svg>
       ) : (
-        <div className={cx(EMPTY_STATE_CLASS, EMPTY_STATE_COMPACT_CLASS)}>
+        <div className={cn(EMPTY_STATE_CLASS, EMPTY_STATE_COMPACT_CLASS)}>
           <h3>{messages.failureEmptyTitle}</h3>
           <p>{messages.failureEmptyMessage}</p>
         </div>
@@ -202,7 +202,7 @@ export function ReworkTrendCard({
 
   return (
     <DashboardWidgetFrame
-      className={cx(DETAIL_CARD_WIDE_CLASS, className)}
+      className={cn(DETAIL_CARD_WIDE_CLASS, className)}
       title={messages.reworkTitle}
       widgetId={widgetId}
     >
@@ -257,7 +257,7 @@ export function ReworkTrendCard({
           ))}
         </svg>
       ) : (
-        <div className={cx(EMPTY_STATE_CLASS, EMPTY_STATE_COMPACT_CLASS)}>
+        <div className={cn(EMPTY_STATE_CLASS, EMPTY_STATE_COMPACT_CLASS)}>
           <h3>{messages.reworkEmptyTitle}</h3>
           <p>{messages.reworkEmptyMessage}</p>
         </div>
@@ -276,7 +276,7 @@ export function TimingTrendCard({
 
   return (
     <DashboardWidgetFrame
-      className={cx(DETAIL_CARD_WIDE_CLASS, className)}
+      className={cn(DETAIL_CARD_WIDE_CLASS, className)}
       title={messages.timingTitle}
       widgetId={widgetId}
     >
@@ -352,7 +352,7 @@ export function TimingTrendCard({
           </dl>
         </>
       ) : (
-        <div className={cx(EMPTY_STATE_CLASS, EMPTY_STATE_COMPACT_CLASS)}>
+        <div className={cn(EMPTY_STATE_CLASS, EMPTY_STATE_COMPACT_CLASS)}>
           <h3>{messages.reworkEmptyTitle}</h3>
           <p>{messages.timingEmptyMessage}</p>
         </div>

--- a/ui/src/features/work-totals/work-totals-card.tsx
+++ b/ui/src/features/work-totals/work-totals-card.tsx
@@ -1,5 +1,5 @@
 import { formatNumber } from "../../i18n";
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import { AgentBentoCard } from "../../components/ui";
 import { getWorkTotalsMessages } from "./messages/work-totals";
 
@@ -86,7 +86,7 @@ function StatCard({ label, locale, value, valueLabel, tone }: StatCardProps) {
   return (
     <article
       aria-label={valueLabel}
-      className={cx(
+      className={cn(
         STAT_CARD_CLASS,
         tone === "neutral" && "border-af-overlay/10",
         tone === "live" && "border-af-info/30",

--- a/ui/src/features/workflow-activity/dashboard-flow-axis-legend.tsx
+++ b/ui/src/features/workflow-activity/dashboard-flow-axis-legend.tsx
@@ -1,5 +1,5 @@
 import { useId, useState } from "react";
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import type { GraphSemanticIconKind } from "../flowchart/graph-semantic-icon";
 import { GraphSemanticIcon } from "../flowchart/graph-semantic-icon";
 import {
@@ -172,7 +172,7 @@ function DashboardFlowAxisLegendItems({
           key={item.id}
         >
           <span
-            className={cx(
+            className={cn(
               "h-1 w-7 rounded-full",
               edgeSwatchClassName(item.tone),
             )}
@@ -190,7 +190,7 @@ function DashboardFlowAxisLegendItems({
           key={item.kind}
         >
           <GraphSemanticIcon
-            className={cx("h-4 w-4", item.iconClassName)}
+            className={cn("h-4 w-4", item.iconClassName)}
             kind={item.kind}
             label={messages.iconLabel(item.label)}
           />
@@ -219,7 +219,7 @@ export function DashboardFlowAxisLegend({
 
   return (
     <div
-      className={cx(DEFAULT_CONTAINER_CLASS, className)}
+      className={cn(DEFAULT_CONTAINER_CLASS, className)}
       data-dashboard-flow-axis-legend=""
       data-legend-expanded={expanded ? "true" : "false"}
     >

--- a/ui/src/features/workflow-activity/mutation-dialog.tsx
+++ b/ui/src/features/workflow-activity/mutation-dialog.tsx
@@ -9,7 +9,7 @@ import {
   DASHBOARD_SUPPORTING_LABELS_CLASS,
   DASHBOARD_SUPPORTING_TEXT_CLASS,
 } from "../../components/ui/dashboard-typography";
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import { getWorkflowActivityGraphImportMessages } from "./messages/graph-import";
 
 const DIALOG_OVERLAY_CLASS =
@@ -17,9 +17,9 @@ const DIALOG_OVERLAY_CLASS =
 const DIALOG_PANEL_CLASS =
   "pointer-events-auto relative z-10 w-full overflow-hidden rounded-3xl border border-af-overlay/12 bg-af-surface/96 shadow-af-panel";
 const DIALOG_HEADER_CLASS = "flex items-start justify-between gap-4";
-const DIALOG_TITLE_CLASS = cx("m-0", DASHBOARD_SECTION_HEADING_CLASS);
-const DIALOG_DESCRIPTION_CLASS = cx("m-0", DASHBOARD_BODY_TEXT_CLASS);
-const DIALOG_EYEBROW_CLASS = cx(
+const DIALOG_TITLE_CLASS = cn("m-0", DASHBOARD_SECTION_HEADING_CLASS);
+const DIALOG_DESCRIPTION_CLASS = cn("m-0", DASHBOARD_BODY_TEXT_CLASS);
+const DIALOG_EYEBROW_CLASS = cn(
   "mb-0 text-xs font-bold uppercase tracking-[0.16em] text-af-accent",
   DASHBOARD_SUPPORTING_LABELS_CLASS,
 );
@@ -85,7 +85,7 @@ export function DashboardMutationDialog({
 
   return (
     <div
-      className={cx(
+      className={cn(
         DIALOG_OVERLAY_CLASS,
         "pointer-events-none relative",
         overlayClassName,
@@ -107,7 +107,7 @@ export function DashboardMutationDialog({
         role="dialog"
       >
         <div
-          className={cx(
+          className={cn(
             DIALOG_CONTENT_CLASS,
             media ? DIALOG_CONTENT_WITH_MEDIA_CLASS : undefined,
           )}
@@ -178,7 +178,7 @@ export function DashboardMessagePanel({
   return (
     <div
       aria-live={ariaLive}
-      className={cx(
+      className={cn(
         EMPTY_STATE_CLASS,
         compact && EMPTY_STATE_COMPACT_CLASS,
         MESSAGE_PANEL_TONE_CLASS[tone],
@@ -189,7 +189,7 @@ export function DashboardMessagePanel({
       <div className="flex items-start justify-between gap-4">
         <div className="grid gap-1">
           <h3>{title}</h3>
-          <div className={cx("m-0 text-sm", DASHBOARD_SUPPORTING_TEXT_CLASS)}>
+          <div className={cn("m-0 text-sm", DASHBOARD_SUPPORTING_TEXT_CLASS)}>
             {children}
           </div>
         </div>

--- a/ui/src/features/workflow-activity/react-flow-current-activity-card-viewport.tsx
+++ b/ui/src/features/workflow-activity/react-flow-current-activity-card-viewport.tsx
@@ -13,7 +13,7 @@ import {
 } from "@xyflow/react";
 import type { CSSProperties } from "react";
 
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import type { FactoryGraphNodeKind } from "../factory-graph-editor/factory-graph-draft-types";
 import { isValidFactoryGraphConnection } from "../factory-graph-editor/factory-graph-editor-connections";
 import {
@@ -153,7 +153,7 @@ export function CurrentActivityGraphViewport({
       <section
         aria-describedby="workflow-graph-heading"
         aria-label={editorMessages.viewportLabel}
-        className={cx(
+        className={cn(
           "relative h-full min-h-0 overflow-hidden rounded-3xl border transition-colors",
           (imports.dropState.status === "drag-active" ||
             imports.dropState.status === "reading") &&

--- a/ui/src/features/workflow-activity/react-flow-current-activity-card.tsx
+++ b/ui/src/features/workflow-activity/react-flow-current-activity-card.tsx
@@ -15,7 +15,7 @@ import type {
 import type { FactoryValue } from "../../api/named-factory";
 import { DASHBOARD_PANEL_SHELL_CLASS } from "../../components/ui/dashboard-shell";
 import { DASHBOARD_SECTION_HEADING_CLASS } from "../../components/ui/dashboard-typography";
-import { cx } from "../../lib/cx";
+import { cn } from "../../lib/cn";
 import { FactoryGraphEditorDraftActions } from "../factory-graph-editor/factory-graph-editor-draft-actions";
 import type { CurrentActivityNode } from "../flowchart/current-activity-nodes";
 import { buildGraphLayout, type GraphLayout } from "../flowchart/layout";
@@ -62,12 +62,12 @@ export {
 
 const GRAPH_LAYOUT_CACHE = new Map<string, GraphLayout>();
 const GRAPH_LAYOUT_PROMISE_CACHE = new Map<string, Promise<GraphLayout>>();
-const CURRENT_ACTIVITY_CARD_CLASS = cx(
+const CURRENT_ACTIVITY_CARD_CLASS = cn(
   DASHBOARD_PANEL_SHELL_CLASS,
   "relative flex h-full min-h-0 min-w-0 flex-col p-4 md:p-5",
 );
 const CURRENT_ACTIVITY_HEADER_CLASS = "mb-4";
-const CURRENT_ACTIVITY_TITLE_CLASS = cx("m-0", DASHBOARD_SECTION_HEADING_CLASS);
+const CURRENT_ACTIVITY_TITLE_CLASS = cn("m-0", DASHBOARD_SECTION_HEADING_CLASS);
 
 export type CurrentActivitySelection =
   | { kind: "node"; nodeId: string }

--- a/ui/src/lib/cn.test.ts
+++ b/ui/src/lib/cn.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { cn } from "./cn";
+
+describe("cn", () => {
+  it("joins only truthy class segments in order", () => {
+    expect(cn("alpha", undefined, false, "", null, "beta", "gamma")).toBe(
+      "alpha beta gamma",
+    );
+  });
+});

--- a/ui/src/lib/cx.ts
+++ b/ui/src/lib/cx.ts
@@ -1,4 +1,0 @@
-export function cx(...classes: Array<false | null | string | undefined>): string {
-  return classes.filter(Boolean).join(" ");
-}
-


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/consolidate-ui-classname-helper-ownership",
  "description": "Consolidate duplicate UI classname-composition helpers under ui/src/lib/cn.ts, route all current frontend consumers through that canonical helper path, delete the redundant helper files, and preserve existing frontend behavior, tests, typecheck, lint, and build outcomes.",
  "context": {
    "customerAsk": "Collapse the duplicate classname helpers into one canonical shared owner, keep ui/src/lib/cn.ts, delete ui/src/lib/cx.ts and ui/src/components/ui/classnames.ts, and update current consumers to import the canonical helper from one path without broadening the cleanup into styling rewrites, Tailwind refactors, component redesign, or compatibility aliases.",
    "problem": "The frontend currently keeps three owners for the same filter(Boolean).join(\" \") classname-composition behavior. Different UI surfaces import different names and paths for the same logic, which creates unnecessary maintenance overhead and drift risk in a shared primitive even though the intended runtime output should stay identical.",
    "solution": "Keep ui/src/lib/cn.ts as the single canonical classname helper, update all current cx and components/ui/classnames consumers to import that canonical helper, delete the duplicate helper files, align any touched shared export surfaces, and verify through frontend quality gates that rendered class behavior and overall UI behavior remain unchanged."
  },
  "acceptanceCriteria": [
    "There is exactly one shared classname-composition helper implementation in the UI source tree, with ui/src/lib/cn.ts as the canonical owner.",
    "ui/src/lib/cx.ts and ui/src/components/ui/classnames.ts are deleted rather than preserved as aliases or wrappers.",
    "Frontend code that previously imported cx or components/ui/classnames imports the canonical helper from one shared path instead of mixing multiple helper owners.",
    "Observable UI behavior remains unchanged across the touched surfaces, including conditional class application, responsive styling, disabled states, and layout behavior.",
    "Existing frontend tests and any targeted regression coverage continue to verify behavior rather than source-file inventories or helper-name trivia.",
    "No new duplicate classname-join helper implementation or compatibility layer is introduced during the cleanup.",
    "Typecheck, lint, build, and relevant frontend tests pass after the ownership consolidation."
  ],
  "userStories": [
    {
      "id": "consolidate-ui-classname-helper-ownership-001",
      "title": "Establish one canonical classname helper owner",
      "description": "As a frontend maintainer, I want one canonical classname-composition helper so future utility changes happen in one place instead of drifting across duplicate implementations.",
      "acceptanceCriteria": [
        "ui/src/lib/cn.ts remains the only shared classname-composition helper implementation in the UI source tree.",
        "ui/src/lib/cx.ts and ui/src/components/ui/classnames.ts are removed rather than converted into compatibility re-exports or wrappers.",
        "The canonical helper preserves the current runtime behavior of joining only truthy classname segments in order.",
        "Any touched shared export surface such as ui/src/components/ui/index.ts no longer exposes a duplicate classname-helper owner.",
        "Verification focuses on the canonical helper outcome and duplicate-owner removal, not on unrelated styling cleanup.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "consolidate-ui-classname-helper-ownership-002",
      "title": "Route frontend consumers through the canonical helper without visual change",
      "description": "As a customer using the dashboard UI, I want all touched surfaces to render exactly the same styling and interaction states after the cleanup so shared helper consolidation does not create UI regressions.",
      "acceptanceCriteria": [
        "All current consumers that imported cx or ui/src/components/ui/classnames import the canonical helper from ui/src/lib/cn.ts instead.",
        "Touched components preserve their current conditional class behavior for success, loading, empty, error, selection, disabled, and responsive states where those states already exist.",
        "No call site introduces a new local classname helper or duplicate class-join logic while migrating imports.",
        "Existing frontend tests covering touched surfaces continue to pass without changing the intended rendered behavior.",
        "Frontend build output remains unchanged in behavior, with no new import-resolution or shared-component export failures.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "consolidate-ui-classname-helper-ownership-003",
      "title": "Prove the cleanup through frontend verification gates",
      "description": "As a reviewer, I want direct verification evidence that the classname helper cleanup preserved observable UI behavior so I can approve it as duplication removal rather than visual change.",
      "acceptanceCriteria": [
        "Relevant frontend typecheck, lint, build, and test commands succeed after the helper consolidation.",
        "Verification evidence covers the touched frontend surfaces through existing behavioral tests or targeted regression checks rather than meta-tests that scan helper filenames or import inventories.",
        "Review evidence makes it clear that the change removed duplicate helper ownership without changing component semantics, accessibility behavior, keyboard behavior, or responsive behavior.",
        "The cleanup does not expand into Tailwind refactors, design-token changes, component redesign, or unrelated file cleanup.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}
