### PR TITLE
retire-legacy-inference-payload-identity-fallback

### DIFF
--- a/ui/src/features/timeline/state/factoryTimelineStore.test.ts
+++ b/ui/src/features/timeline/state/factoryTimelineStore.test.ts
@@ -3365,9 +3365,9 @@ describe("factory timeline reconstruction dispatch projection", () => {
     });
   });
 
-  it("backfills completed trace dispatch snapshots when inference responses arrive after dispatch completion", () => {
-    const legacyWorkRequest = event(
-      "event-legacy-backfill-work-request",
+  it("backfills completed trace dispatch snapshots from canonical late inference responses", () => {
+    const lateWorkRequest = event(
+      "event-late-inference-work-request",
       2,
       FACTORY_EVENT_TYPES.workRequest,
       {
@@ -3375,85 +3375,85 @@ describe("factory timeline reconstruction dispatch projection", () => {
         type: "FACTORY_REQUEST_BATCH",
         works: [
           {
-            name: "Legacy Timeline Story",
-            trace_id: "trace-legacy-backfill",
-            work_id: "work-legacy-backfill",
+            name: "Late Inference Story",
+            trace_id: "trace-late-inference",
+            work_id: "work-late-inference",
             work_type_id: "story",
           },
         ],
       },
     );
-    legacyWorkRequest.context.requestId = "request-legacy-backfill";
-    legacyWorkRequest.context.traceIds = ["trace-legacy-backfill"];
-    legacyWorkRequest.context.workIds = ["work-legacy-backfill"];
+    lateWorkRequest.context.requestId = "request-late-inference";
+    lateWorkRequest.context.traceIds = ["trace-late-inference"];
+    lateWorkRequest.context.workIds = ["work-late-inference"];
 
-    const legacyDispatchRequest = event(
-      "event-legacy-backfill-dispatch-request",
+    const lateDispatchRequest = event(
+      "event-late-inference-dispatch-request",
       3,
       FACTORY_EVENT_TYPES.dispatchRequest,
       {
-        current_chaining_trace_id: "chain-legacy-backfill-current",
-        dispatchId: "dispatch-legacy-backfill",
+        current_chaining_trace_id: "chain-late-inference-current",
+        dispatchId: "dispatch-late-inference",
         inputs: [
           {
-            name: "Legacy Timeline Story",
-            trace_id: "trace-legacy-backfill",
-            work_id: "work-legacy-backfill",
+            name: "Late Inference Story",
+            trace_id: "trace-late-inference",
+            work_id: "work-late-inference",
             work_type_id: "story",
           },
         ],
         previous_chaining_trace_ids: [
-          "chain-legacy-backfill-a",
-          "chain-legacy-backfill-b",
+          "chain-late-inference-a",
+          "chain-late-inference-b",
         ],
         transitionId: "review",
         workstation: {
-          name: "Legacy Review",
+          name: "Late Inference Review",
         },
       },
     );
-    legacyDispatchRequest.context.traceIds = ["trace-legacy-backfill"];
-    legacyDispatchRequest.context.workIds = ["work-legacy-backfill"];
+    lateDispatchRequest.context.traceIds = ["trace-late-inference"];
+    lateDispatchRequest.context.workIds = ["work-late-inference"];
 
-    const legacyDispatchResponse = event(
-      "event-legacy-backfill-dispatch-response",
+    const lateDispatchResponse = event(
+      "event-late-inference-dispatch-response",
       4,
       FACTORY_EVENT_TYPES.dispatchResponse,
       {
-        current_chaining_trace_id: "chain-legacy-backfill-current",
-        dispatchId: "dispatch-legacy-backfill",
+        current_chaining_trace_id: "chain-late-inference-current",
+        dispatchId: "dispatch-late-inference",
         durationMillis: 640,
         outcome: "ACCEPTED",
-        output: "Legacy replay output",
+        output: "Late inference replay output",
         outputWork: [
           {
-            name: "Legacy Timeline Story",
+            name: "Late Inference Story",
             previous_chaining_trace_ids: [
-              "chain-legacy-backfill-a",
-              "chain-legacy-backfill-b",
+              "chain-late-inference-a",
+              "chain-late-inference-b",
             ],
             state: "done",
-            trace_id: "trace-legacy-backfill",
-            work_id: "work-legacy-backfill",
+            trace_id: "trace-late-inference",
+            work_id: "work-late-inference",
             work_type_id: "story",
           },
         ],
         previous_chaining_trace_ids: [
-          "chain-legacy-backfill-a",
-          "chain-legacy-backfill-b",
+          "chain-late-inference-a",
+          "chain-late-inference-b",
         ],
         transitionId: "review",
         workstation: {
-          name: "Legacy Review",
+          name: "Late Inference Review",
         },
       },
     );
-    legacyDispatchResponse.context.traceIds = ["trace-legacy-backfill"];
-    legacyDispatchResponse.context.workIds = ["work-legacy-backfill"];
-    legacyDispatchResponse.context.eventTime = "2026-04-16T12:00:04Z";
+    lateDispatchResponse.context.traceIds = ["trace-late-inference"];
+    lateDispatchResponse.context.workIds = ["work-late-inference"];
+    lateDispatchResponse.context.eventTime = "2026-04-16T12:00:04Z";
 
-    const legacyInferenceResponse = event(
-      "event-legacy-backfill-inference-response",
+    const lateInferenceResponse = event(
+      "event-late-inference-response",
       5,
       FACTORY_EVENT_TYPES.inferenceResponse,
       {
@@ -3463,70 +3463,68 @@ describe("factory timeline reconstruction dispatch projection", () => {
             model: "gpt-5.4-mini",
             provider: "openai",
             requestMetadata: {
-              prompt_source: "legacy-review-backfill",
+              prompt_source: "late-inference-review",
             },
             responseMetadata: {
-              provider_session_id: "legacy-session-2",
+              provider_session_id: "late-session-2",
             },
           },
         },
-        dispatchId: "dispatch-legacy-backfill",
         durationMillis: 700,
-        inferenceRequestId: "dispatch-legacy-backfill/inference-request/1",
+        inferenceRequestId: "dispatch-late-inference/inference-request/1",
         outcome: "SUCCEEDED",
         providerSession: {
-          id: "legacy-session-2",
+          id: "late-session-2",
           kind: "session_id",
           provider: "openai",
         },
-        response: "Legacy backfilled replay output",
-        transitionId: "legacy-payload-review",
+        response: "Late inference backfilled replay output",
       },
     );
-    legacyInferenceResponse.context.traceIds = ["trace-legacy-backfill"];
-    legacyInferenceResponse.context.workIds = ["work-legacy-backfill"];
-    legacyInferenceResponse.context.dispatchId = "dispatch-legacy-backfill";
-    legacyInferenceResponse.context.eventTime = "2026-04-16T12:00:05Z";
+    lateInferenceResponse.context.traceIds = ["trace-late-inference"];
+    lateInferenceResponse.context.workIds = ["work-late-inference"];
+    lateInferenceResponse.context.dispatchId = "dispatch-late-inference";
+    lateInferenceResponse.context.eventTime = "2026-04-16T12:00:05Z";
 
     const projected = buildFactoryTimelineSnapshot(
       [
         initialStructureRequest,
-        legacyWorkRequest,
-        legacyDispatchRequest,
-        legacyDispatchResponse,
-        legacyInferenceResponse,
+        lateWorkRequest,
+        lateDispatchRequest,
+        lateDispatchResponse,
+        lateInferenceResponse,
       ],
       5,
     );
 
     expect(
-      projected.tracesByWorkID["work-legacy-backfill"]?.dispatches[0],
+      projected.tracesByWorkID["work-late-inference"]?.dispatches[0],
     ).toMatchObject({
-      current_chaining_trace_id: "chain-legacy-backfill-current",
+      current_chaining_trace_id: "chain-late-inference-current",
       diagnostics: {
         provider: {
           model: "gpt-5.4-mini",
           provider: "openai",
           request_metadata: {
-            prompt_source: "legacy-review-backfill",
+            prompt_source: "late-inference-review",
           },
           response_metadata: {
-            provider_session_id: "legacy-session-2",
+            provider_session_id: "late-session-2",
           },
         },
       },
-      dispatch_id: "dispatch-legacy-backfill",
+      dispatch_id: "dispatch-late-inference",
       previous_chaining_trace_ids: [
-        "chain-legacy-backfill-a",
-        "chain-legacy-backfill-b",
+        "chain-late-inference-a",
+        "chain-late-inference-b",
       ],
       provider_session: {
-        id: "legacy-session-2",
+        id: "late-session-2",
         provider: "openai",
       },
-      token_names: ["Legacy Timeline Story"],
+      token_names: ["Late Inference Story"],
       work_types: ["story"],
-      workstation_name: "Legacy Review",
+      workstation_name: "Late Inference Review",
     });
     expect(projected.runtime.session.provider_sessions?.[0]).toMatchObject({
       diagnostics: {
@@ -3535,20 +3533,20 @@ describe("factory timeline reconstruction dispatch projection", () => {
           provider: "openai",
         },
       },
-      dispatch_id: "dispatch-legacy-backfill",
+      dispatch_id: "dispatch-late-inference",
       provider_session: {
-        id: "legacy-session-2",
+        id: "late-session-2",
         provider: "openai",
       },
-      workstation_name: "Legacy Review",
+      workstation_name: "Late Inference Review",
     });
     expect(
       projected.runtime.inference_attempts_by_dispatch_id?.[
-        "dispatch-legacy-backfill"
-      ]?.["dispatch-legacy-backfill/inference-request/1"],
+        "dispatch-late-inference"
+      ]?.["dispatch-late-inference/inference-request/1"],
     ).toMatchObject({
-      dispatch_id: "dispatch-legacy-backfill",
-      inference_request_id: "dispatch-legacy-backfill/inference-request/1",
+      dispatch_id: "dispatch-late-inference",
+      inference_request_id: "dispatch-late-inference/inference-request/1",
       transition_id: "review",
     });
   });

--- a/ui/src/features/timeline/state/factoryTimelineStore.test.ts
+++ b/ui/src/features/timeline/state/factoryTimelineStore.test.ts
@@ -2531,6 +2531,62 @@ describe("factory timeline reconstruction request state", () => {
     ).toBeUndefined();
   });
 
+  it("resolves inference transition IDs from dispatch replay state instead of payload aliases", () => {
+    const payloadAliasInferenceRequest = event(
+      "event-payload-transition-inference-request",
+      4,
+      FACTORY_EVENT_TYPES.inferenceRequest,
+      {
+        attempt: 1,
+        inferenceRequestId: "dispatch-1/inference-request/payload-transition",
+        prompt: "This payload transition alias should not be used.",
+        transitionId: "payload-transition",
+      },
+    );
+    payloadAliasInferenceRequest.context.dispatchId = "dispatch-1";
+    payloadAliasInferenceRequest.context.traceIds = ["trace-1"];
+    payloadAliasInferenceRequest.context.workIds = ["work-1"];
+
+    const payloadAliasInferenceResponse = event(
+      "event-payload-transition-inference-response",
+      5,
+      FACTORY_EVENT_TYPES.inferenceResponse,
+      {
+        attempt: 1,
+        durationMillis: 10,
+        inferenceRequestId: "dispatch-1/inference-request/payload-transition",
+        outcome: "SUCCEEDED",
+        response: "Payload transition alias ignored.",
+        transitionId: "payload-response-transition",
+      },
+    );
+    payloadAliasInferenceResponse.context.dispatchId = "dispatch-1";
+    payloadAliasInferenceResponse.context.traceIds = ["trace-1"];
+    payloadAliasInferenceResponse.context.workIds = ["work-1"];
+
+    const projected = buildFactoryTimelineSnapshot(
+      [
+        initialStructureRequest,
+        workInput,
+        request,
+        payloadAliasInferenceRequest,
+        payloadAliasInferenceResponse,
+      ],
+      5,
+    );
+
+    expect(
+      projected.runtime.inference_attempts_by_dispatch_id?.["dispatch-1"]?.[
+        "dispatch-1/inference-request/payload-transition"
+      ],
+    ).toMatchObject({
+      dispatch_id: "dispatch-1",
+      inference_request_id: "dispatch-1/inference-request/payload-transition",
+      outcome: "SUCCEEDED",
+      transition_id: "review",
+    });
+  });
+
   it("reduces script request and response events into script-aware workstation state", () => {
     const events = [
       initialStructureRequest,
@@ -3424,7 +3480,7 @@ describe("factory timeline reconstruction dispatch projection", () => {
           provider: "openai",
         },
         response: "Legacy backfilled replay output",
-        transitionId: "review",
+        transitionId: "legacy-payload-review",
       },
     );
     legacyInferenceResponse.context.traceIds = ["trace-legacy-backfill"];
@@ -3485,6 +3541,15 @@ describe("factory timeline reconstruction dispatch projection", () => {
         provider: "openai",
       },
       workstation_name: "Legacy Review",
+    });
+    expect(
+      projected.runtime.inference_attempts_by_dispatch_id?.[
+        "dispatch-legacy-backfill"
+      ]?.["dispatch-legacy-backfill/inference-request/1"],
+    ).toMatchObject({
+      dispatch_id: "dispatch-legacy-backfill",
+      inference_request_id: "dispatch-legacy-backfill/inference-request/1",
+      transition_id: "review",
     });
   });
 });

--- a/ui/src/features/timeline/state/factoryTimelineStore.test.ts
+++ b/ui/src/features/timeline/state/factoryTimelineStore.test.ts
@@ -2485,6 +2485,52 @@ describe("factory timeline reconstruction request state", () => {
     });
   });
 
+  it("ignores inference payload dispatch IDs without canonical dispatch context", () => {
+    const payloadOnlyInferenceRequest = event(
+      "event-payload-only-inference-request",
+      4,
+      FACTORY_EVENT_TYPES.inferenceRequest,
+      {
+        attempt: 1,
+        dispatchId: "dispatch-1",
+        inferenceRequestId: "dispatch-1/inference-request/payload-only",
+        prompt: "This payload alias should not attach.",
+        transitionId: "review",
+      },
+    );
+    const payloadOnlyInferenceResponse = event(
+      "event-payload-only-inference-response",
+      5,
+      FACTORY_EVENT_TYPES.inferenceResponse,
+      {
+        attempt: 1,
+        dispatchId: "dispatch-1",
+        durationMillis: 10,
+        inferenceRequestId: "dispatch-1/inference-request/payload-only",
+        outcome: "SUCCEEDED",
+        response: "Payload alias ignored.",
+        transitionId: "review",
+      },
+    );
+
+    const projected = buildFactoryTimelineSnapshot(
+      [
+        initialStructureRequest,
+        workInput,
+        request,
+        payloadOnlyInferenceRequest,
+        payloadOnlyInferenceResponse,
+      ],
+      5,
+    );
+
+    expect(
+      projected.runtime.inference_attempts_by_dispatch_id?.["dispatch-1"]?.[
+        "dispatch-1/inference-request/payload-only"
+      ],
+    ).toBeUndefined();
+  });
+
   it("reduces script request and response events into script-aware workstation state", () => {
     const events = [
       initialStructureRequest,
@@ -3383,6 +3429,7 @@ describe("factory timeline reconstruction dispatch projection", () => {
     );
     legacyInferenceResponse.context.traceIds = ["trace-legacy-backfill"];
     legacyInferenceResponse.context.workIds = ["work-legacy-backfill"];
+    legacyInferenceResponse.context.dispatchId = "dispatch-legacy-backfill";
     legacyInferenceResponse.context.eventTime = "2026-04-16T12:00:05Z";
 
     const projected = buildFactoryTimelineSnapshot(

--- a/ui/src/features/timeline/state/timeline/replayWorldState.ts
+++ b/ui/src/features/timeline/state/timeline/replayWorldState.ts
@@ -36,7 +36,6 @@ import {
   applyScriptRequest,
   applyScriptResponse,
   inferenceAttemptsForDispatch,
-  legacyInferencePayloadTransitionID,
   resolveDispatchTransitionID,
   syncCompletedDispatchAttempt,
 } from "./replayWorldStateSupport";
@@ -301,7 +300,6 @@ function applyInferenceRequest(
   const attempts = inferenceAttemptsForDispatch(state, dispatchID);
   const current = attempts[payload.inferenceRequestId];
   const transitionID =
-    legacyInferencePayloadTransitionID(payload) ??
     current?.transition_id ??
     resolveDispatchTransitionID(state, dispatchID);
   if (!transitionID) {
@@ -332,7 +330,6 @@ function applyInferenceResponse(
   const attempts = inferenceAttemptsForDispatch(state, dispatchID);
   const current = attempts[payload.inferenceRequestId];
   const transitionID =
-    legacyInferencePayloadTransitionID(payload) ??
     current?.transition_id ??
     resolveDispatchTransitionID(state, dispatchID);
   if (!transitionID) {

--- a/ui/src/features/timeline/state/timeline/replayWorldState.ts
+++ b/ui/src/features/timeline/state/timeline/replayWorldState.ts
@@ -36,7 +36,6 @@ import {
   applyScriptRequest,
   applyScriptResponse,
   inferenceAttemptsForDispatch,
-  legacyInferencePayloadDispatchID,
   legacyInferencePayloadTransitionID,
   resolveDispatchTransitionID,
   syncCompletedDispatchAttempt,
@@ -295,8 +294,7 @@ function applyInferenceRequest(
   event: InferenceRequestEvent,
 ): void {
   const { payload } = event;
-  const dispatchID =
-    event.context.dispatchId ?? legacyInferencePayloadDispatchID(payload);
+  const dispatchID = event.context.dispatchId;
   if (!dispatchID || !payload.inferenceRequestId) {
     return;
   }
@@ -327,8 +325,7 @@ function applyInferenceResponse(
   event: InferenceResponseEvent,
 ): void {
   const { payload } = event;
-  const dispatchID =
-    event.context.dispatchId ?? legacyInferencePayloadDispatchID(payload);
+  const dispatchID = event.context.dispatchId;
   if (!dispatchID || !payload.inferenceRequestId) {
     return;
   }

--- a/ui/src/features/timeline/state/timeline/replayWorldStateSupport.ts
+++ b/ui/src/features/timeline/state/timeline/replayWorldStateSupport.ts
@@ -83,15 +83,6 @@ export function syncCompletedDispatchAttempt(
   }
 }
 
-export function legacyInferencePayloadTransitionID(
-  payload: unknown,
-): string | undefined {
-  const transitionID = (payload as { transitionId?: unknown }).transitionId;
-  return typeof transitionID === "string" && transitionID.length > 0
-    ? transitionID
-    : undefined;
-}
-
 export function scriptRequestsForDispatch(
   state: ReplayWorldState,
   dispatchID: string,

--- a/ui/src/features/timeline/state/timeline/replayWorldStateSupport.ts
+++ b/ui/src/features/timeline/state/timeline/replayWorldStateSupport.ts
@@ -1,7 +1,4 @@
-import type {
-  DashboardInferenceAttempt,
-} from "../../../../api/dashboard";
-import type { InferenceRequestPayload, InferenceResponsePayload } from "../../../../api/events";
+import type { DashboardInferenceAttempt } from "../../../../api/dashboard";
 import {
   completionToProviderSession,
   completionToTraceDispatch,
@@ -86,15 +83,8 @@ export function syncCompletedDispatchAttempt(
   }
 }
 
-export function legacyInferencePayloadDispatchID(
-  payload: InferenceRequestPayload | InferenceResponsePayload,
-): string | undefined {
-  const dispatchID = (payload as { dispatchId?: unknown }).dispatchId;
-  return typeof dispatchID === "string" && dispatchID.length > 0 ? dispatchID : undefined;
-}
-
 export function legacyInferencePayloadTransitionID(
-  payload: InferenceRequestPayload | InferenceResponsePayload,
+  payload: unknown,
 ): string | undefined {
   const transitionID = (payload as { transitionId?: unknown }).transitionId;
   return typeof transitionID === "string" && transitionID.length > 0


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/retire-legacy-inference-payload-identity-fallback",
  "description": "Retire the legacy inference payload identity fallback from UI timeline replay so inference request and response events use FactoryEvent.context.dispatchId for dispatch identity and dispatch lifecycle replay state for transition identity.",
  "context": {
    "customerAsk": "Remove legacyInferencePayloadDispatchID(...) and legacyInferencePayloadTransitionID(...) from replayWorldStateSupport.ts, update applyInferenceRequest(...) and applyInferenceResponse(...) so inference replay uses FactoryEvent.context.dispatchId plus stored attempt or resolveDispatchTransitionID(...) for transition identity, avoid adding a replacement compatibility layer, and rewrite or remove the legacy inference backfill fixture in factoryTimelineStore.test.ts so tests prove canonical context-driven replay.",
    "problem": "Timeline replay still supports retired inference request and response payload aliases for dispatchId and transitionId, which keeps old dashboard projection behavior alive and makes inference replay harder to reason about now that the canonical factory event contract owns dispatch identity on FactoryEvent.context.dispatchId.",
    "solution": "Delete the inference payload legacy identity helpers, make inference request and response replay attach attempts through event.context.dispatchId only, derive transition identity from the current stored attempt or dispatch lifecycle state through resolveDispatchTransitionID(...), and replace legacy alias tests with replay-visible assertions for canonical event streams."
  },
  "acceptanceCriteria": [
    "Timeline inference replay no longer reads dispatchId or transitionId from inference request or response payload objects.",
    "replayWorldStateSupport.ts no longer exports legacy inference payload dispatch or transition identity helpers.",
    "Inference request and response events still attach attempts to the correct dispatch when FactoryEvent.context.dispatchId is present.",
    "Inference attempts still resolve transition identity from an existing stored attempt or from dispatch lifecycle state projected into replay.",
    "Tests no longer preserve legacy inference payload identity aliases as supported dashboard replay behavior.",
    "Typecheck, lint, and focused frontend tests pass as the final quality gate, including npm --prefix ui test -- src/features/timeline/state/factoryTimelineStore.test.ts src/api/events/types.test.ts."
  ],
  "userStories": [
    {
      "id": "retire-legacy-inference-payload-identity-fallback-001",
      "title": "Attach inference replay by canonical dispatch context",
      "description": "As a dashboard maintainer, I want inference request and response replay to use FactoryEvent.context.dispatchId as the only dispatch identifier so current event streams have one canonical dispatch identity source.",
      "acceptanceCriteria": [
        "Inference request replay attaches the attempt to the dispatch identified by FactoryEvent.context.dispatchId.",
        "Inference response replay updates the attempt for the dispatch identified by FactoryEvent.context.dispatchId.",
        "Inference request and response replay do not recover dispatch identity from payload-level dispatchId.",
        "Current event streams with context.dispatchId preserve the same timeline attempt attachment behavior after the cleanup.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "retire-legacy-inference-payload-identity-fallback-002",
      "title": "Resolve inference transition identity from replay state",
      "description": "As a dashboard maintainer, I want inference transition identity to come from the stored attempt or dispatch lifecycle state so replay no longer depends on retired payload-level transitionId fields.",
      "acceptanceCriteria": [
        "Inference request replay assigns transition identity from resolveDispatchTransitionID(...) for the current dispatch lifecycle state when creating or updating an attempt.",
        "Inference response replay preserves transition identity from the current stored attempt when present.",
        "Inference response replay falls back to resolveDispatchTransitionID(...) for the current dispatch lifecycle state when the stored attempt does not already provide transition identity.",
        "Inference request and response replay do not recover transition identity from payload-level transitionId.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "retire-legacy-inference-payload-identity-fallback-003",
      "title": "Replace legacy payload-alias replay tests with canonical replay proof",
      "description": "As a reviewer, I want timeline replay tests to prove canonical context-driven inference behavior so the test suite no longer documents retired payload aliases as supported dashboard behavior.",
      "acceptanceCriteria": [
        "The legacy inference backfill fixture in factoryTimelineStore.test.ts is removed or rewritten so it no longer relies on payload-level dispatchId or transitionId.",
        "Focused replay coverage proves inference attempts attach to the correct dispatch through FactoryEvent.context.dispatchId.",
        "Focused replay coverage proves inference attempts resolve transition identity from stored attempt or dispatch lifecycle state.",
        "Tests avoid helper-presence, source-layout, route-inventory, or asset-bundle assertions and verify replay-visible behavior instead.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}
