### PR TITLE
retire-functional-support-deadcode-baseline-entries

### DIFF
--- a/docs/internal/development/deadcode-baseline.txt
+++ b/docs/internal/development/deadcode-baseline.txt
@@ -1,2 +1,0 @@
-tests/functional/internal/support/events.go:23:6: unreachable func: FactoryRelationsValue
-tests/functional/internal/support/fixtures.go:159:6: unreachable func: UpdateFactoryConfig

--- a/tests/functional/internal/support/deadcode_contract_test.go
+++ b/tests/functional/internal/support/deadcode_contract_test.go
@@ -2,9 +2,13 @@ package support
 
 import (
 	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/testutil"
 	"github.com/portpowered/infinite-you/pkg/workers"
 )
@@ -59,6 +63,64 @@ func TestCountFactoryEvents_CountsMatchingEventTypes(t *testing.T) {
 	}
 	if got := CountFactoryEvents(events, factoryapi.FactoryEventTypeDispatchResponse); got != 1 {
 		t.Fatalf("CountFactoryEvents(dispatch response) = %d, want 1", got)
+	}
+}
+
+func TestFactoryRelationsValue_ReturnsNilAndPopulatedRelations(t *testing.T) {
+	var nilRelations *[]factoryapi.Relation
+	if got := FactoryRelationsValue(nilRelations); got != nil {
+		t.Fatalf("FactoryRelationsValue(nil) = %#v, want nil", got)
+	}
+
+	relations := []factoryapi.Relation{{
+		Type:           factoryapi.RelationTypeDependsOn,
+		SourceWorkName: "generated-beta",
+		TargetWorkName: "generated-alpha",
+	}}
+
+	got := FactoryRelationsValue(&relations)
+	if len(got) != 1 {
+		t.Fatalf("FactoryRelationsValue(...) length = %d, want 1", len(got))
+	}
+	if got[0] != relations[0] {
+		t.Fatalf("FactoryRelationsValue(...) = %#v, want %#v", got[0], relations[0])
+	}
+}
+
+func TestUpdateFactoryConfig_RewritesScaffoldedFactoryConfig(t *testing.T) {
+	dir := ScaffoldFactory(t, map[string]any{
+		"name": "original-factory",
+		"workstations": []map[string]any{{
+			"name": "writer",
+		}},
+	})
+
+	UpdateFactoryConfig(t, dir, func(cfg map[string]any) {
+		cfg["name"] = "updated-factory"
+		cfg["labels"] = map[string]any{
+			"team": "runtime",
+		}
+	})
+
+	data, err := os.ReadFile(filepath.Join(dir, interfaces.FactoryConfigFile))
+	if err != nil {
+		t.Fatalf("read updated factory config: %v", err)
+	}
+
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal updated factory config: %v", err)
+	}
+
+	if got := cfg["name"]; got != "updated-factory" {
+		t.Fatalf("factory name = %#v, want %q", got, "updated-factory")
+	}
+	labels, ok := cfg["labels"].(map[string]any)
+	if !ok {
+		t.Fatalf("factory labels type = %T, want map[string]any", cfg["labels"])
+	}
+	if got := labels["team"]; got != "runtime" {
+		t.Fatalf("factory labels.team = %#v, want %q", got, "runtime")
 	}
 }
 


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/retire-functional-support-deadcode-baseline-entries",
  "description": "Add default-build functional-support contract coverage for FactoryRelationsValue and UpdateFactoryConfig, then remove their stale accepted deadcode-baseline entries while preserving current helper behavior and long-test intent.",
  "context": {
    "customerAsk": "Add default-build coverage that directly proves FactoryRelationsValue(...) and UpdateFactoryConfig(...), remove their corresponding entries from docs/internal/development/deadcode-baseline.txt, keep the cleanup narrow, and verify with the focused support-package tests plus the repository deadcode lane.",
    "problem": "The checked-in Go deadcode baseline still accepts two unreachable-function findings in tests/functional/internal/support even though those helpers are live and still used by functional coverage behind the functionallong build tag. Because the default build does not prove those helper contracts, the repository carries stale accepted deadcode residue that weakens reviewer trust in the baseline.",
    "solution": "Add default-build support tests that directly exercise FactoryRelationsValue(...) for nil and populated relations and UpdateFactoryConfig(...) through a real scaffolded factory.json rewrite path, then remove the two matching deadcode-baseline entries and verify the result with the focused support-package tests and the repository deadcode command."
  },
  "acceptanceCriteria": [
    "Default-build support tests directly exercise FactoryRelationsValue(...) without the functionallong build tag and prove that FactoryRelationsValue(nil) remains nil-safe while populated relations are returned unchanged.",
    "Default-build support tests directly exercise UpdateFactoryConfig(...) against a real scaffolded factory.json and prove that the provided mutation callback rewrites the persisted config as expected.",
    "docs/internal/development/deadcode-baseline.txt no longer contains baseline entries for FactoryRelationsValue or UpdateFactoryConfig.",
    "Verification includes the focused support-package test target and the repository deadcode command, and neither relies on accepted baseline residue for these two helpers.",
    "The cleanup stays scoped to the two functional-support helper contracts and their baseline entries, without changing functionallong behavior, adding new exemptions, or redesigning functional-test structure.",
    "Typecheck, lint, and tests pass."
  ],
  "userStories": [
    {
      "id": "retire-functional-support-deadcode-baseline-entries-001",
      "title": "Prove the functional-support helper contracts in the default build",
      "description": "As a maintainer, I want default-build support tests for FactoryRelationsValue(...) and UpdateFactoryConfig(...) so the functional-support package proves those helper contracts even when functionallong callers are not compiled.",
      "acceptanceCriteria": [
        "A default-build support test exercises FactoryRelationsValue(nil) and confirms it returns safely without panicking and preserves the nil contract.",
        "A default-build support test exercises FactoryRelationsValue(...) with populated relations and confirms the returned value preserves the provided relations content unchanged.",
        "A default-build support test exercises UpdateFactoryConfig(...) against a real scaffolded factory.json, applies a mutation through the provided callback, and confirms the written config reflects that mutation.",
        "The added coverage does not depend on enabling the functionallong build tag and does not replace runtime-oriented assertions with source-layout or inventory meta tests.",
        "go test ./tests/functional/internal/support passes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "retire-functional-support-deadcode-baseline-entries-002",
      "title": "Retire the stale deadcode baseline allowances for the now-proven helpers",
      "description": "As a maintainer, I want the deadcode baseline to stop accepting FactoryRelationsValue and UpdateFactoryConfig as unreachable so the checked-in deadcode residue matches the real default-build coverage state of the functional-support package.",
      "acceptanceCriteria": [
        "docs/internal/development/deadcode-baseline.txt no longer contains the FactoryRelationsValue or UpdateFactoryConfig unreachable-function entries.",
        "The repository deadcode verification command no longer needs accepted baseline residue for those two helper findings.",
        "The cleanup leaves unrelated baseline entries, long-test helper ownership, and production runtime behavior unchanged.",
        "Verification includes both go test ./tests/functional/internal/support and the current repository deadcode target.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
