### PR TITLE
retire-duplicate-selected-tick-boundary-allowlist

### DIFF
--- a/docs/internal/processes/contract-guard-relevant-files.md
+++ b/docs/internal/processes/contract-guard-relevant-files.md
@@ -15,3 +15,4 @@ This file inventories the broad contract guards that scan filesystem roots with 
 
 - Broad handwritten-source guards should keep package-specific generated-path exclusions explicit at each `contractguard.ShouldSkipDir(...)` call site even when hidden-directory handling is shared.
 - The inventory separates handwritten-source scans from generated-output exclusions so future guard cleanup can document ownership decisions in code and in this file together.
+- Keep structural `FactoryWorld*View` allowlists in `pkg/interfaces/world_view_contract_guard_test.go`; behavioral cross-boundary smokes in `pkg/api` should assert replayed runtime outputs instead of re-parsing source files for duplicate ownership.

--- a/pkg/api/selected_tick_cross_boundary_smoke_test.go
+++ b/pkg/api/selected_tick_cross_boundary_smoke_test.go
@@ -1,12 +1,7 @@
 package api
 
 import (
-	"go/ast"
-	"go/parser"
-	"go/token"
-	"path/filepath"
 	"reflect"
-	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -29,7 +24,6 @@ func TestSelectedTickCrossBoundarySmoke_ReconstructsCanonicalStateAcrossSupporte
 	}
 
 	assertSelectedTickCanonicalState(t, worldState)
-	assertSelectedTickBoundaryAllowlist(t)
 
 	worldView := projections.BuildFactoryWorldView(worldState)
 	assertSelectedTickWorldView(t, worldView)
@@ -142,59 +136,6 @@ func assertSelectedTickWorkstationRequests(
 	if failed.Response == nil || failed.Response.FailureReason == nil || *failed.Response.FailureReason != "provider_rate_limit" {
 		t.Fatalf("failed response = %#v, want provider_rate_limit", failed.Response)
 	}
-}
-
-func assertSelectedTickBoundaryAllowlist(t *testing.T) {
-	t.Helper()
-
-	paths, err := filepath.Glob("../interfaces/*.go")
-	if err != nil {
-		t.Fatalf("glob interfaces package: %v", err)
-	}
-
-	fset := token.NewFileSet()
-	liveViews := make([]string, 0, len(paths))
-	for _, path := range paths {
-		if strings.HasSuffix(path, "_test.go") {
-			continue
-		}
-		file, parseErr := parser.ParseFile(fset, path, nil, 0)
-		if parseErr != nil {
-			t.Fatalf("parse %s: %v", path, parseErr)
-		}
-		liveViews = append(liveViews, selectedTickBoundaryViews(file)...)
-	}
-	sort.Strings(liveViews)
-
-	want := []string{
-		"FactoryWorldRuntimeView",
-		"FactoryWorldTopologyView",
-		"FactoryWorldView",
-	}
-	if !reflect.DeepEqual(liveViews, want) {
-		t.Fatalf("live FactoryWorld*View allowlist = %#v, want %#v", liveViews, want)
-	}
-}
-
-func selectedTickBoundaryViews(file *ast.File) []string {
-	views := []string{}
-	for _, decl := range file.Decls {
-		gen, ok := decl.(*ast.GenDecl)
-		if !ok || gen.Tok != token.TYPE {
-			continue
-		}
-		for _, spec := range gen.Specs {
-			typeSpec, ok := spec.(*ast.TypeSpec)
-			if !ok {
-				continue
-			}
-			name := typeSpec.Name.Name
-			if strings.HasPrefix(name, "FactoryWorld") && strings.HasSuffix(name, "View") {
-				views = append(views, name)
-			}
-		}
-	}
-	return views
 }
 
 func crossBoundarySelectedTickEvents(t0 time.Time) []generated.FactoryEvent {


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/retire-duplicate-selected-tick-boundary-allowlist",
  "description": "Remove duplicated FactoryWorld*View allowlist ownership from the selected-tick cross-boundary API smoke so that the smoke stays focused on observable replayed runtime behavior while pkg/interfaces/world_view_contract_guard_test.go remains the sole structural owner.",
  "context": {
    "customerAsk": "Retire the duplicate FactoryWorld*View allowlist assertion from the selected-tick cross-boundary smoke, preserve the smoke's behavioral runtime/projection/dashboard coverage, and keep structural allowlist ownership only in pkg/interfaces/world_view_contract_guard_test.go.",
    "problem": "pkg/api/selected_tick_cross_boundary_smoke_test.go currently owns both behavioral selected-tick verification and a source-parsing allowlist over live FactoryWorld*View types in pkg/interfaces. That structural rule is already enforced by pkg/interfaces/world_view_contract_guard_test.go, so the policy lives in two places and turns the API smoke into a meta test about package topology instead of only observable behavior.",
    "solution": "Delete the duplicate FactoryWorld*View allowlist helpers and source parsing from the selected-tick smoke, preserve its reconstructed state/world-view/workstation-request/dashboard assertions, and keep any necessary structural protection only in the dedicated world-view contract guard."
  },
  "acceptanceCriteria": [
    "pkg/api/selected_tick_cross_boundary_smoke_test.go no longer parses pkg/interfaces source files and no longer owns a FactoryWorld*View allowlist assertion.",
    "The selected-tick smoke still verifies reconstructed canonical world state, world view, workstation-request projection, and rendered dashboard output from replayed events.",
    "pkg/interfaces/world_view_contract_guard_test.go remains the single clear owner of the live FactoryWorld*View structural allowlist in pkg/interfaces.",
    "If any guard tightening is needed to preserve the same protection, it happens inside the contract-guard test rather than by adding new source-layout assertions back into pkg/api.",
    "The diff stays narrowly scoped to duplicate test-ownership removal and direct regression protection, without redesigning selected-tick projections, world-view types, or broader contract-guard policy.",
    "Typecheck, lint, and tests pass for all touched packages."
  ],
  "userStories": [
    {
      "id": "retire-duplicate-selected-tick-boundary-allowlist-001",
      "title": "Keep selected-tick smoke behavioral-only",
      "description": "As a backend reviewer, I want the selected-tick cross-boundary smoke to verify only replayed runtime outcomes so that the smoke remains an observable behavior test instead of a source-topology guard.",
      "acceptanceCriteria": [
        "pkg/api/selected_tick_cross_boundary_smoke_test.go no longer parses pkg/interfaces Go files or defines helper logic that enumerates live FactoryWorld*View types.",
        "The selected-tick smoke still reconstructs replayed state and asserts canonical world-state outcomes for active dispatches, completed dispatches, provider sessions, inference attempts, and failure details.",
        "The selected-tick smoke still asserts canonical world-view outcomes, workstation-request projection outcomes, and dashboard output strings for the selected tick.",
        "The selected-tick smoke remains behavior-preserving: the observable selected-tick assertions continue to describe reconstructed runtime outputs rather than helper placement, file inventories, or allowed type names.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "retire-duplicate-selected-tick-boundary-allowlist-002",
      "title": "Keep one structural owner for FactoryWorld boundary views",
      "description": "As a maintainer, I want the world-view contract guard to remain the sole owner of the FactoryWorld*View allowlist so that structural boundary policy cannot drift across multiple tests.",
      "acceptanceCriteria": [
        "pkg/interfaces/world_view_contract_guard_test.go remains the only test that owns the approved live FactoryWorld*View allowlist for pkg/interfaces.",
        "If the selected-tick smoke removal exposes any protection gap, the fix is a focused contract-guard assertion change rather than a new pkg/api source scan.",
        "Contract-guard coverage still fails when an unapproved live FactoryWorld*View type is introduced in pkg/interfaces.",
        "Contract-guard coverage still allows the currently approved live FactoryWorldView, FactoryWorldTopologyView, and FactoryWorldRuntimeView types.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
