### PR TITLE
consolidate-local-model-worker-clone-ownership

### DIFF
--- a/pkg/service/local_model_runtime.go
+++ b/pkg/service/local_model_runtime.go
@@ -125,9 +125,10 @@ func (m *managedLocalModelManager) execute(
 	if err != nil {
 		return interfaces.InferenceResponse{}, true, err
 	}
+	loadWorker := factoryconfig.CloneWorkerConfig(*workerDef)
 	handle, err := m.loadHandle(ctx, resourceKey, localModelLoadRequest{
 		Resource:  resource,
-		Worker:    cloneWorkerForLocalModel(workerDef),
+		Worker:    &loadWorker,
 		ModelName: cacheLayout.ModelName,
 		CachePath: cacheLayout.CachePath,
 		Revision:  cacheLayout.Revision,
@@ -136,9 +137,10 @@ func (m *managedLocalModelManager) execute(
 	if err != nil {
 		return interfaces.InferenceResponse{}, true, err
 	}
+	invokeWorker := factoryconfig.CloneWorkerConfig(*workerDef)
 	response, err := handle.Invoke(ctx, localModelInvocationRequest{
 		Resource: resource,
-		Worker:   cloneWorkerForLocalModel(workerDef),
+		Worker:   &invokeWorker,
 		Request:  interfaces.CloneProviderInferenceRequest(request),
 	})
 	return response, true, err
@@ -211,17 +213,6 @@ func localModelRuntimeResource(factoryCfg *interfaces.FactoryConfig, workerDef *
 		return resource, key, true
 	}
 	return interfaces.ResourceConfig{}, "", false
-}
-
-func cloneWorkerForLocalModel(workerDef *interfaces.WorkerConfig) *interfaces.WorkerConfig {
-	if workerDef == nil {
-		return nil
-	}
-	clone := *workerDef
-	clone.Args = append([]string(nil), workerDef.Args...)
-	clone.Resources = append([]interfaces.ResourceConfig(nil), workerDef.Resources...)
-	clone.Operations = append([]interfaces.ModelOperation(nil), workerDef.Operations...)
-	return &clone
 }
 
 func canonicalBackendName(value string) string {

--- a/pkg/service/local_model_runtime_test.go
+++ b/pkg/service/local_model_runtime_test.go
@@ -245,6 +245,159 @@ func TestLoadWorkersFromConfig_LocalModelWorkerRecordsModelExecutionEvents(t *te
 	assertRecordedLocalModelExecutionEvents(t, history.Events(), audioPath)
 }
 
+func TestLoadWorkersFromConfig_LocalModelWorkerDetachesClonedWorkerRequestsFromLaterSourceMutation(t *testing.T) {
+	audioPath := filepath.Join(t.TempDir(), "speech.wav")
+	runtime := &fakeLocalModelRuntime{
+		response: interfaces.InferenceResponse{
+			Content: mustMarshalAudioContentResponse(t, audioPath),
+		},
+	}
+	factoryCfg := localModelFactoryConfig()
+	cache := localModelTestCacheLayout(t)
+	runtimeWorkers := localModelRuntimeWorkersWithCloneCoverage()
+	runtimeCfg := newLoadedFactoryConfigForServiceTest(t, "", factoryCfg, runtimeWorkers, map[string]*interfaces.FactoryWorkstationConfig{
+		"speak": {
+			Name:           "speak",
+			Type:           interfaces.WorkstationTypeInvoke,
+			WorkerTypeName: "tts-worker",
+			Operation:      "TTS",
+			OperationBindings: []interfaces.ModelOperationBinding{{
+				Slot: "text",
+				Selector: &interfaces.ModelOperationBindingSelector{
+					Label: "utterance",
+					Type:  interfaces.ModelOperationContentTypeText,
+				},
+			}},
+		},
+	})
+	opts, err := loadWorkersFromConfig(
+		"",
+		factoryCfg,
+		"",
+		runtimeCfg,
+		logging.NoopLogger{},
+		true,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		newLocalModelResourceLimiter(),
+		newManagedLocalModelManager(staticModelAssetPuller{cache: cache}, runtime),
+	)
+	if err != nil {
+		t.Fatalf("loadWorkersFromConfig: %v", err)
+	}
+
+	fc := &factory.FactoryConfig{}
+	for _, opt := range opts {
+		opt(fc)
+	}
+	exec, ok := fc.WorkerExecutors["tts-worker"]
+	if !ok {
+		t.Fatal("expected tts-worker executor to be registered")
+	}
+	wsExec, ok := exec.(*workers.WorkstationExecutor)
+	if !ok {
+		t.Fatalf("expected *workers.WorkstationExecutor, got %T", exec)
+	}
+
+	result, err := wsExec.Execute(context.Background(), localModelDispatch())
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result.Outcome != interfaces.OutcomeAccepted {
+		t.Fatalf("outcome = %s, want %s", result.Outcome, interfaces.OutcomeAccepted)
+	}
+	if runtime.loadCount() != 1 || runtime.invocationCount() != 1 {
+		t.Fatalf("runtime load/invoke counts = %d/%d, want 1/1", runtime.loadCount(), runtime.invocationCount())
+	}
+
+	mutateLocalModelWorkerCloneSource(runtimeWorkers["tts-worker"])
+
+	runtime.mu.Lock()
+	if len(runtime.loads) != 1 {
+		runtime.mu.Unlock()
+		t.Fatalf("load requests = %d, want 1", len(runtime.loads))
+	}
+	loadWorker := runtime.loads[0].Worker
+	if len(runtime.invocations) != 1 {
+		runtime.mu.Unlock()
+		t.Fatalf("invoke requests = %d, want 1", len(runtime.invocations))
+	}
+	invokeWorker := runtime.invocations[0].Worker
+	runtime.mu.Unlock()
+
+	assertLocalModelCloneCoverageWorker(t, loadWorker)
+	assertLocalModelCloneCoverageWorker(t, invokeWorker)
+}
+
+func TestNewRecordingModelRunner_LocalModelWorkerEventsStayDetachedFromLaterSourceMutation(t *testing.T) {
+	eventTime := time.Date(2026, time.May, 24, 8, 30, 0, 0, time.UTC)
+	workerDef := localModelRuntimeWorkersWithCloneCoverage()["tts-worker"]
+	var events []factoryapi.FactoryEvent
+	runner := newRecordingModelRunner(
+		recordingModelRunnerFunc(func(_ context.Context, _ interfaces.RunnerExecutionRequest) (interfaces.RunnerExecutionResult, error) {
+			return interfaces.RunnerExecutionResult{
+				Content: mustMarshalAudioContentResponse(t, filepath.Join(t.TempDir(), "speech.wav")),
+			}, nil
+		}),
+		localModelFactoryConfig(),
+		workerDef,
+		func(event factoryapi.FactoryEvent) {
+			events = append(events, event)
+		},
+		func() time.Time { return eventTime },
+	)
+
+	mutateLocalModelWorkerCloneSource(workerDef)
+
+	_, err := runner.Execute(context.Background(), interfaces.RunnerExecutionRequest{
+		Dispatch: interfaces.WorkDispatch{
+			DispatchID: "dispatch-tts",
+			Execution: interfaces.ExecutionMetadata{
+				CurrentTick: 2,
+				RequestID:   "request-tts",
+				TraceID:     "trace-tts",
+				WorkIDs:     []string{"work-tts"},
+			},
+		},
+		ModelOperation: "TTS",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if len(events) != 2 {
+		t.Fatalf("recorded events = %d, want 2", len(events))
+	}
+	requestPayload, err := events[0].Payload.AsModelRequestEventPayload()
+	if err != nil {
+		t.Fatalf("decode model request payload: %v", err)
+	}
+	if requestPayload.Worker != "tts-worker" {
+		t.Fatalf("request worker = %q, want tts-worker", requestPayload.Worker)
+	}
+	if requestPayload.Model != "OMNIVOICE_Q4_K_M" {
+		t.Fatalf("request model = %q, want OMNIVOICE_Q4_K_M", requestPayload.Model)
+	}
+	if requestPayload.ProviderLocality != interfaces.ModelLocalityLocal {
+		t.Fatalf("request locality = %q, want %q", requestPayload.ProviderLocality, interfaces.ModelLocalityLocal)
+	}
+	if requestPayload.Resources == nil || len(*requestPayload.Resources) != 1 || (*requestPayload.Resources)[0].Name != "omnivoice-cache" {
+		t.Fatalf("request resources = %#v, want omnivoice-cache", requestPayload.Resources)
+	}
+	responsePayload, err := events[1].Payload.AsModelResponseEventPayload()
+	if err != nil {
+		t.Fatalf("decode model response payload: %v", err)
+	}
+	if responsePayload.Resources == nil || len(*responsePayload.Resources) != 1 || (*responsePayload.Resources)[0].Name != "omnivoice-cache" {
+		t.Fatalf("response resources = %#v, want omnivoice-cache", responsePayload.Resources)
+	}
+}
+
 func localModelExecutionRecorderFixture(t *testing.T, eventTime time.Time) (*workers.WorkstationExecutor, *factory.FactoryEventHistory, string) {
 	t.Helper()
 	audioPath := filepath.Join(t.TempDir(), "speech.wav")
@@ -396,6 +549,46 @@ func localModelRuntimeWorkers() map[string]*interfaces.WorkerConfig {
 	}
 }
 
+func localModelRuntimeWorkersWithCloneCoverage() map[string]*interfaces.WorkerConfig {
+	return map[string]*interfaces.WorkerConfig{
+		"tts-worker": {
+			Name:          "tts-worker",
+			Type:          interfaces.WorkerTypeModel,
+			Model:         "OMNIVOICE_Q4_K_M",
+			ModelProvider: interfaces.RunnerIDCodex,
+			ModelLocality: interfaces.ModelLocalityLocal,
+			Args:          []string{"--voice", "alloy"},
+			Resources: []interfaces.ResourceConfig{{
+				Name:     "omnivoice-cache",
+				Capacity: 1,
+			}},
+			Operations: []interfaces.ModelOperation{{
+				Name: "TTS",
+				Inputs: []interfaces.ModelOperationSlot{{
+					Name:         "text",
+					ContentTypes: []string{interfaces.ModelOperationContentTypeText},
+					Required:     true,
+				}},
+				Outputs: []interfaces.ModelOperationSlot{{
+					Name:         "audio",
+					ContentTypes: []string{interfaces.ModelOperationContentTypeAudio},
+				}},
+			}},
+			Auth: &interfaces.HostedWorkerAuthConfig{
+				SecretRef: "secret/local-model",
+			},
+			Linear: &interfaces.HostedLinearWorkerConfig{
+				PollInterval: "30s",
+				TeamIDs:      []string{"team-a"},
+				StateIDs:     []string{"state-ready"},
+				Claim: &interfaces.HostedLinearWorkerClaimConfig{
+					AssigneeField: "owner",
+				},
+			},
+		},
+	}
+}
+
 func localModelTestCacheLayout(t *testing.T) localModelCacheLayout {
 	t.Helper()
 	return localModelCacheLayout{
@@ -421,4 +614,78 @@ func mustMarshalAudioContentResponse(t *testing.T, audioPath string) string {
 		t.Fatalf("marshal audio content response: %v", err)
 	}
 	return string(data)
+}
+
+func localModelDispatch() interfaces.WorkDispatch {
+	return interfaces.WorkDispatch{
+		DispatchID:      "dispatch-tts",
+		TransitionID:    "transition-tts",
+		WorkerType:      "tts-worker",
+		WorkstationName: "speak",
+		InputTokens: workers.InputTokens(interfaces.Token{
+			ID: "token-tts",
+			Color: interfaces.TokenColor{
+				WorkID: "work-tts",
+				Content: []interfaces.WorkContentPart{{
+					Type:  interfaces.WorkContentPartTypeText,
+					Label: "utterance",
+					Text:  "hello world",
+				}},
+			},
+		}),
+	}
+}
+
+func mutateLocalModelWorkerCloneSource(worker *interfaces.WorkerConfig) {
+	worker.Args[0] = "--mutated"
+	worker.Resources[0].Name = "mutated-cache"
+	worker.Resources[0].Capacity = 9
+	worker.Operations[0].Inputs[0].ContentTypes[0] = interfaces.ModelOperationContentTypeJSON
+	worker.Operations[0].Outputs[0].ContentTypes[0] = interfaces.ModelOperationContentTypeBinary
+	worker.Auth.SecretRef = "secret/mutated"
+	worker.Linear.TeamIDs[0] = "team-b"
+	worker.Linear.StateIDs[0] = "state-done"
+	worker.Linear.Claim.AssigneeField = "mutated-owner"
+	worker.Model = "mutated-model"
+	worker.ModelLocality = interfaces.ModelLocalityCloud
+}
+
+func assertLocalModelCloneCoverageWorker(t *testing.T, worker *interfaces.WorkerConfig) {
+	t.Helper()
+	if worker == nil {
+		t.Fatal("expected cloned worker, got nil")
+	}
+	if len(worker.Args) != 2 || worker.Args[0] != "--voice" || worker.Args[1] != "alloy" {
+		t.Fatalf("worker args = %#v, want [--voice alloy]", worker.Args)
+	}
+	if len(worker.Resources) != 1 || worker.Resources[0].Name != "omnivoice-cache" || worker.Resources[0].Capacity != 1 {
+		t.Fatalf("worker resources = %#v, want omnivoice-cache capacity 1", worker.Resources)
+	}
+	if len(worker.Operations) != 1 || len(worker.Operations[0].Inputs) != 1 || len(worker.Operations[0].Inputs[0].ContentTypes) != 1 || worker.Operations[0].Inputs[0].ContentTypes[0] != interfaces.ModelOperationContentTypeText {
+		t.Fatalf("worker input operations = %#v, want text input content type", worker.Operations)
+	}
+	if len(worker.Operations[0].Outputs) != 1 || len(worker.Operations[0].Outputs[0].ContentTypes) != 1 || worker.Operations[0].Outputs[0].ContentTypes[0] != interfaces.ModelOperationContentTypeAudio {
+		t.Fatalf("worker output operations = %#v, want audio output content type", worker.Operations)
+	}
+	if worker.Auth == nil || worker.Auth.SecretRef != "secret/local-model" {
+		t.Fatalf("worker auth = %#v, want secret/local-model", worker.Auth)
+	}
+	if worker.Linear == nil {
+		t.Fatal("worker linear config = nil, want values")
+	}
+	if len(worker.Linear.TeamIDs) != 1 || worker.Linear.TeamIDs[0] != "team-a" {
+		t.Fatalf("worker linear team IDs = %#v, want team-a", worker.Linear.TeamIDs)
+	}
+	if len(worker.Linear.StateIDs) != 1 || worker.Linear.StateIDs[0] != "state-ready" {
+		t.Fatalf("worker linear state IDs = %#v, want state-ready", worker.Linear.StateIDs)
+	}
+	if worker.Linear.Claim == nil || worker.Linear.Claim.AssigneeField != "owner" {
+		t.Fatalf("worker linear claim = %#v, want owner", worker.Linear.Claim)
+	}
+}
+
+type recordingModelRunnerFunc func(context.Context, interfaces.RunnerExecutionRequest) (interfaces.RunnerExecutionResult, error)
+
+func (fn recordingModelRunnerFunc) Execute(ctx context.Context, request interfaces.RunnerExecutionRequest) (interfaces.RunnerExecutionResult, error) {
+	return fn(ctx, request)
 }

--- a/pkg/service/local_model_runtime_test.go
+++ b/pkg/service/local_model_runtime_test.go
@@ -655,21 +655,46 @@ func assertLocalModelCloneCoverageWorker(t *testing.T, worker *interfaces.Worker
 	if worker == nil {
 		t.Fatal("expected cloned worker, got nil")
 	}
+	assertLocalModelCloneCoverageArgs(t, worker)
+	assertLocalModelCloneCoverageResources(t, worker)
+	assertLocalModelCloneCoverageOperations(t, worker)
+	assertLocalModelCloneCoverageAuth(t, worker)
+	assertLocalModelCloneCoverageLinear(t, worker)
+}
+
+func assertLocalModelCloneCoverageArgs(t *testing.T, worker *interfaces.WorkerConfig) {
+	t.Helper()
 	if len(worker.Args) != 2 || worker.Args[0] != "--voice" || worker.Args[1] != "alloy" {
 		t.Fatalf("worker args = %#v, want [--voice alloy]", worker.Args)
 	}
+}
+
+func assertLocalModelCloneCoverageResources(t *testing.T, worker *interfaces.WorkerConfig) {
+	t.Helper()
 	if len(worker.Resources) != 1 || worker.Resources[0].Name != "omnivoice-cache" || worker.Resources[0].Capacity != 1 {
 		t.Fatalf("worker resources = %#v, want omnivoice-cache capacity 1", worker.Resources)
 	}
+}
+
+func assertLocalModelCloneCoverageOperations(t *testing.T, worker *interfaces.WorkerConfig) {
+	t.Helper()
 	if len(worker.Operations) != 1 || len(worker.Operations[0].Inputs) != 1 || len(worker.Operations[0].Inputs[0].ContentTypes) != 1 || worker.Operations[0].Inputs[0].ContentTypes[0] != interfaces.ModelOperationContentTypeText {
 		t.Fatalf("worker input operations = %#v, want text input content type", worker.Operations)
 	}
 	if len(worker.Operations[0].Outputs) != 1 || len(worker.Operations[0].Outputs[0].ContentTypes) != 1 || worker.Operations[0].Outputs[0].ContentTypes[0] != interfaces.ModelOperationContentTypeAudio {
 		t.Fatalf("worker output operations = %#v, want audio output content type", worker.Operations)
 	}
+}
+
+func assertLocalModelCloneCoverageAuth(t *testing.T, worker *interfaces.WorkerConfig) {
+	t.Helper()
 	if worker.Auth == nil || worker.Auth.SecretRef != "secret/local-model" {
 		t.Fatalf("worker auth = %#v, want secret/local-model", worker.Auth)
 	}
+}
+
+func assertLocalModelCloneCoverageLinear(t *testing.T, worker *interfaces.WorkerConfig) {
+	t.Helper()
 	if worker.Linear == nil {
 		t.Fatal("worker linear config = nil, want values")
 	}

--- a/pkg/service/model_execution_events.go
+++ b/pkg/service/model_execution_events.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
+	factoryconfig "github.com/portpowered/infinite-you/pkg/config"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/workcontent"
 	"github.com/portpowered/infinite-you/pkg/workers"
@@ -65,10 +66,13 @@ func newRecordingModelRunner(
 	return &recordingModelRunner{
 		inner:      inner,
 		factoryCfg: factoryCfg,
-		workerDef:  cloneWorkerForLocalModel(workerDef),
-		recorder:   recorder,
-		now:        now,
-		attempts:   make(map[string]int),
+		workerDef: func() *interfaces.WorkerConfig {
+			cloned := factoryconfig.CloneWorkerConfig(*workerDef)
+			return &cloned
+		}(),
+		recorder: recorder,
+		now:      now,
+		attempts: make(map[string]int),
 	}
 }
 
@@ -145,11 +149,11 @@ func modelRequestEvent(
 	eventTime time.Time,
 ) factoryapi.FactoryEvent {
 	payload := factoryapi.ModelRequestEventPayload{
-		ModelRequestId:  modelRequestID,
-		Attempt:         attempt,
-		Operation:       strings.TrimSpace(request.ModelOperation),
-		Worker:          modelEventFirstNonEmpty(request.WorkerType, workerNameForModelEvents(workerDef)),
-		Model:           modelEventFirstNonEmpty(request.Model, modelNameForModelEvents(workerDef)),
+		ModelRequestId: modelRequestID,
+		Attempt:        attempt,
+		Operation:      strings.TrimSpace(request.ModelOperation),
+		Worker:         modelEventFirstNonEmpty(request.WorkerType, workerNameForModelEvents(workerDef)),
+		Model:          modelEventFirstNonEmpty(request.Model, modelNameForModelEvents(workerDef)),
 		ProviderLocality: modelEventFirstNonEmpty(
 			strings.TrimSpace(request.ModelLocality),
 			modelLocalityForModelEvents(workerDef),
@@ -186,11 +190,11 @@ func modelResponseEvent(
 	eventTime time.Time,
 ) factoryapi.FactoryEvent {
 	payload := factoryapi.ModelResponseEventPayload{
-		ModelRequestId:  modelRequestID,
-		Attempt:         attempt,
-		Operation:       strings.TrimSpace(request.ModelOperation),
-		Worker:          modelEventFirstNonEmpty(request.WorkerType, workerNameForModelEvents(workerDef)),
-		Model:           modelEventFirstNonEmpty(request.Model, modelNameForModelEvents(workerDef)),
+		ModelRequestId: modelRequestID,
+		Attempt:        attempt,
+		Operation:      strings.TrimSpace(request.ModelOperation),
+		Worker:         modelEventFirstNonEmpty(request.WorkerType, workerNameForModelEvents(workerDef)),
+		Model:          modelEventFirstNonEmpty(request.Model, modelNameForModelEvents(workerDef)),
 		ProviderLocality: modelEventFirstNonEmpty(
 			strings.TrimSpace(request.ModelLocality),
 			modelLocalityForModelEvents(workerDef),


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/consolidate-local-model-worker-clone-ownership",
  "description": "Consolidate local-model worker clone ownership by making local-model runtime execution and model-event recording reuse the canonical worker clone contract from pkg/config while preserving existing runtime behavior.",
  "context": {
    "customerAsk": "Replace local-model service call sites that use the private cloneWorkerForLocalModel helper with config.CloneWorkerConfig or a thin direct delegate, delete the duplicate partial clone helper from pkg/service/local_model_runtime.go, and keep local-model execution and model-event behavior unchanged with focused detachment tests.",
    "problem": "pkg/service/local_model_runtime.go currently owns a private cloneWorkerForLocalModel helper even though pkg/config/layout.go already defines the canonical worker clone contract in CloneWorkerConfig. The service helper only shallow-copies Args, Resources, and Operations, which creates a second weaker owner for worker clone behavior and leaves the local-model runtime and model-event recorder exposed to drift when nested worker fields change.",
    "solution": "Update local-model runtime load and invoke request construction plus model-event recorder worker capture to reuse config.CloneWorkerConfig, remove the duplicate partial clone helper from pkg/service, and add focused behavioral tests that prove detached worker args, resources, nested operations, hosted auth, and hosted linear config through runtime and event outcomes."
  },
  "acceptanceCriteria": [
    "pkg/service no longer owns a private partial worker clone helper for the local-model path.",
    "Local-model runtime load and invoke requests reuse the canonical worker clone contract from pkg/config.",
    "Model execution event recording for local-model workers reuses the same canonical worker clone contract from pkg/config.",
    "Local-model clone results continue to detach worker args, worker resources, nested operation content, hosted worker auth config, and hosted linear config from later source mutation.",
    "Observable local-model runtime behavior remains unchanged, including managed local-model loading, invocation, provider bypass, and model event payload behavior.",
    "Regression coverage verifies detached clone behavior through local-model runtime and model-event outcomes rather than helper placement, helper names, or file inventories.",
    "Typecheck, lint, and tests pass for the touched backend packages."
  ],
  "userStories": [
    {
      "id": "consolidate-local-model-worker-clone-ownership-001",
      "title": "Reuse the canonical worker clone contract in local-model service flows",
      "description": "As a backend maintainer, I want local-model runtime execution and model-event recording to use the canonical worker clone contract so that worker clone semantics cannot drift between config and service paths.",
      "acceptanceCriteria": [
        "Local-model runtime load requests clone the worker definition through config.CloneWorkerConfig or a same-behavior direct delegate instead of a service-owned partial clone helper.",
        "Local-model runtime invocation requests clone the worker definition through the same canonical worker clone contract.",
        "Model execution event recording stores its worker definition through the same canonical worker clone contract instead of a service-owned partial clone helper.",
        "The service package no longer defines a private partial clone helper for the local-model path once all local-model callers use the canonical contract.",
        "Existing local-model runtime behavior remains unchanged for managed runtime loading, cached handle reuse, provider bypass, and emitted model request/response event content.",
        "The implementation stays narrowly scoped to clone-ownership removal and does not broaden into unrelated service or config refactors.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "consolidate-local-model-worker-clone-ownership-002",
      "title": "Lock detached local-model worker clone behavior with focused runtime tests",
      "description": "As a reviewer, I want focused local-model regression tests so that the service path proves detached worker clone behavior and future cleanups cannot silently reintroduce shared nested state.",
      "acceptanceCriteria": [
        "Local-model runtime tests directly prove that mutating source worker args after local-model load or invoke setup does not change the cloned worker args used by the runtime path.",
        "Local-model runtime tests directly prove that mutating source worker resources after local-model load or invoke setup does not change the cloned worker resources used by the runtime path.",
        "Local-model runtime tests directly prove that mutating source nested operation content after local-model load or invoke setup does not change the cloned operations used by the runtime path, including nested slot content types.",
        "Local-model runtime tests directly prove that mutating source hosted worker auth config after local-model load or invoke setup does not change the cloned auth config used by the runtime path when auth is present.",
        "Local-model runtime tests directly prove that mutating source hosted linear config after local-model load or invoke setup does not change the cloned hosted linear values used by the runtime path when linear config is present, including TeamIDs, StateIDs, and Claim.",
        "Local-model event-recording tests prove the recorder retains detached worker details after later mutation of the source worker definition.",
        "Tests assert runtime-visible request, invocation, or event outcomes rather than asserting helper placement or implementation details.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
