### PR TITLE
consolidate-stopword-merge-helper-ownership-in-config

### DIFF
--- a/pkg/config/factory_config_mapping.go
+++ b/pkg/config/factory_config_mapping.go
@@ -260,7 +260,7 @@ func workstationAPIFromInternal(workstation interfaces.FactoryWorkstationConfig)
 		Resources:             resourceRequirementsAPIFromInternal(normalized.Resources),
 		CopyReferencedScripts: boolPtrIfTrue(normalized.CopyReferencedScripts),
 		Guards:                workstationGuardsAPIFromInternal(normalized.Guards),
-		StopWords:             stringSlicePtr(mergeCanonicalStopWords(normalized.StopWords, normalized.RuntimeStopWords)),
+		StopWords:             stringSlicePtr(mergeStopWords(normalized.StopWords, normalized.RuntimeStopWords)),
 		Env:                   stringMapPtr(normalized.Env),
 		Body:                  stringPtrIfNotEmpty(promptBody),
 		Limits:                workstationLimitsAPIFromInternal(normalized.Limits),
@@ -516,28 +516,6 @@ func modelOperationContentTypesAPIFromInternal(contentTypes []string) []factorya
 		values[i] = publicFactoryModelOperationContentTypeFromInternal(contentType)
 	}
 	return values
-}
-
-func mergeCanonicalStopWords(base []string, extra []string) []string {
-	if len(base) == 0 {
-		return append([]string(nil), extra...)
-	}
-	if len(extra) == 0 {
-		return append([]string(nil), base...)
-	}
-	out := append([]string(nil), base...)
-	seen := make(map[string]struct{}, len(base)+len(extra))
-	for _, word := range base {
-		seen[word] = struct{}{}
-	}
-	for _, word := range extra {
-		if _, ok := seen[word]; ok {
-			continue
-		}
-		out = append(out, word)
-		seen[word] = struct{}{}
-	}
-	return out
 }
 
 func workstationLimitsAPIFromInternal(limits interfaces.WorkstationLimits) *factoryapi.WorkstationLimits {

--- a/pkg/config/factory_config_mapping_test.go
+++ b/pkg/config/factory_config_mapping_test.go
@@ -433,6 +433,54 @@ func TestFactoryConfigMapper_ExpandRejectsRetiredLegacyPayloadAliases(t *testing
 	}
 }
 
+func TestFactoryConfigMapper_FlattenMergesWorkstationStopWordsAndDetachesSlices(t *testing.T) {
+	mapper := NewFactoryConfigMapper()
+
+	cfg := &interfaces.FactoryConfig{
+		Workstations: []interfaces.FactoryWorkstationConfig{{
+			Name:             "execute-story",
+			StopWords:        []string{"CANONICAL", "SHARED"},
+			RuntimeStopWords: []string{"RUNTIME", "SHARED", "TAIL"},
+		}},
+	}
+
+	flattened, err := mapper.Flatten(cfg)
+	if err != nil {
+		t.Fatalf("mapper.Flatten: %v", err)
+	}
+
+	payload := mustDecodeFactoryPayload(t, flattened)
+	workstationPayload := payload["workstations"].([]any)[0].(map[string]any)
+	gotAny, ok := workstationPayload["stopWords"].([]any)
+	if !ok {
+		t.Fatalf("expected flattened stopWords array, got %#v", workstationPayload["stopWords"])
+	}
+	got := make([]string, len(gotAny))
+	for i, value := range gotAny {
+		got[i], ok = value.(string)
+		if !ok {
+			t.Fatalf("expected stopWords[%d] to be a string, got %#v", i, value)
+		}
+	}
+
+	want := []string{"CANONICAL", "SHARED", "RUNTIME", "TAIL"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("flattened stopWords mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+
+	cfg.Workstations[0].StopWords[0] = "CHANGED-CANONICAL"
+	cfg.Workstations[0].RuntimeStopWords[0] = "CHANGED-RUNTIME"
+
+	gotAny = workstationPayload["stopWords"].([]any)
+	got = make([]string, len(gotAny))
+	for i, value := range gotAny {
+		got[i] = value.(string)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("flattened stopWords should be detached from source slices\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
 func TestFactoryConfigMapper_ExpandReportsCanonicalRouteArrayFieldPath(t *testing.T) {
 	mapper := NewFactoryConfigMapper()
 

--- a/pkg/config/runtime_config_inline_merge_test.go
+++ b/pkg/config/runtime_config_inline_merge_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/interfaces"
 )
 
 func TestInlineRuntimeDefinitions_LoadsSplitDefinitionsIntoFactoryConfig(t *testing.T) {
@@ -146,5 +148,42 @@ Fallback body.
 
 	if !reflect.DeepEqual(inlined, merged) {
 		t.Fatalf("inline and lookup-merged factory configs differ\ninline: %#v\nlookup: %#v", inlined, merged)
+	}
+}
+
+func TestFactoryConfigWithRuntimeDefinitions_MergesWorkstationStopWordsAndDetachesSlices(t *testing.T) {
+	factoryCfg := &interfaces.FactoryConfig{
+		Workstations: []interfaces.FactoryWorkstationConfig{{
+			Name:      "execute-story",
+			StopWords: []string{"CANONICAL", "SHARED"},
+		}},
+	}
+	runtimeDefs := &runtimeDefinitionLookupMaps{
+		workstations: map[string]*interfaces.FactoryWorkstationConfig{
+			"execute-story": {
+				Name:             "execute-story",
+				StopWords:        []string{"RUNTIME", "SHARED"},
+				RuntimeStopWords: []string{"TAIL", "RUNTIME"},
+			},
+		},
+	}
+
+	merged, err := FactoryConfigWithRuntimeDefinitions(factoryCfg, runtimeDefs)
+	if err != nil {
+		t.Fatalf("FactoryConfigWithRuntimeDefinitions: %v", err)
+	}
+
+	got := merged.Workstations[0].StopWords
+	want := []string{"CANONICAL", "SHARED", "RUNTIME", "TAIL"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("merged stopWords mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+
+	factoryCfg.Workstations[0].StopWords[0] = "CHANGED-CANONICAL"
+	runtimeDefs.workstations["execute-story"].StopWords[0] = "CHANGED-RUNTIME"
+	runtimeDefs.workstations["execute-story"].RuntimeStopWords[0] = "CHANGED-TAIL"
+
+	if !reflect.DeepEqual(merged.Workstations[0].StopWords, want) {
+		t.Fatalf("merged stopWords should be detached from source slices\n got: %#v\nwant: %#v", merged.Workstations[0].StopWords, want)
 	}
 }


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/consolidate-stopword-merge-helper-ownership-in-config",
  "description": "Consolidate stop-word merge helper ownership inside pkg/config so runtime-config assembly and canonical workstation flattening reuse one package-local merge policy without changing observable stop-word behavior.",
  "context": {
    "customerAsk": "Delete duplicate stop-word merge policy inside pkg/config by keeping one canonical package-local helper, switching both runtime assembly and OpenAPI flattening to use it, deleting the duplicate helper, and preserving current runtime and canonical stop-word behavior with focused behavioral tests.",
    "problem": "pkg/config/runtime_config.go and pkg/config/factory_config_mapping.go currently own the same stop-word merge policy through separate helpers. Both paths preserve authored stop words first, append runtime stop words once, dedupe repeated values, and return detached slices, but keeping two owners for one package-local behavior creates drift risk in backend config assembly and canonical payload flattening.",
    "solution": "Keep one canonical package-local stop-word merge helper in pkg/config, make runtime-config assembly and canonical workstation flattening both call it, delete the duplicate helper, and add focused runtime and canonical behavioral coverage that proves ordering, dedupe, and detached-slice behavior stayed unchanged."
  },
  "acceptanceCriteria": [
    "pkg/config has one clear package-local owner for stop-word merge behavior used by both runtime-config assembly and canonical workstation flattening.",
    "Runtime-config assembly continues to preserve authored workstation stop words first, append runtime stop words once, dedupe repeats, and detach the merged result from later source-slice mutation.",
    "Canonical workstation flattening continues to emit the same merged stopWords order, dedupe behavior, and detached-slice semantics when both authored StopWords and RuntimeStopWords are present.",
    "The implementation stays same-package and implementation-light, without introducing a new abstraction layer outside pkg/config or broad unrelated cleanup.",
    "Regression coverage verifies runtime-visible and canonical-payload behavior rather than helper names, helper placement, or file topology.",
    "Typecheck, lint, and tests pass for the touched backend packages."
  ],
  "userStories": [
    {
      "id": "consolidate-stopword-merge-helper-ownership-in-config-001",
      "title": "Reuse one canonical stop-word merge policy across runtime assembly and canonical flattening",
      "description": "As a backend maintainer, I want runtime config assembly and canonical config flattening to share one stop-word merge implementation so that the same package-local policy cannot drift across two paths.",
      "acceptanceCriteria": [
        "pkg/config keeps exactly one package-local helper as the canonical owner of stop-word merge behavior.",
        "Runtime-config assembly still preserves authored workstation stop words first, appends runtime stop words only once, and removes duplicates when both sources are present.",
        "Canonical workstation flattening still emits merged stopWords with authored values first, runtime values appended once, and duplicates removed when both StopWords and RuntimeStopWords are present.",
        "Both runtime-config assembly and canonical flattening keep returning detached merged slices rather than aliasing caller-owned stop-word slices.",
        "The implementation remains narrowly scoped to same-package helper ownership consolidation and does not add a new abstraction layer outside pkg/config.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "consolidate-stopword-merge-helper-ownership-in-config-002",
      "title": "Prove behavior preservation with focused runtime and canonical merge coverage",
      "description": "As a reviewer, I want focused behavioral tests around runtime config assembly and canonical config flattening so that this cleanup proves observable stop-word behavior stayed stable and detached.",
      "acceptanceCriteria": [
        "pkg/config/runtime_config_inline_merge_test.go proves runtime config assembly keeps authored stop words first, appends runtime stop words once, and removes duplicates when both sources are present.",
        "pkg/config/runtime_config_inline_merge_test.go proves later mutation of the authored StopWords slice or RuntimeStopWords slice does not change the merged runtime-config stop words.",
        "pkg/config/factory_config_mapping_test.go proves canonical flattening emits the same merged stopWords order and dedupe behavior when both StopWords and RuntimeStopWords are present.",
        "pkg/config/factory_config_mapping_test.go proves later mutation of the source stop-word slices does not change the flattened canonical stopWords payload.",
        "Tests assert runtime-visible and canonical payload outcomes instead of helper names, helper placement, or source-file structure.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
