### PR TITLE
consolidate-config-string-map-clone-ownership

### DIFF
--- a/pkg/config/factory_config_mapping.go
+++ b/pkg/config/factory_config_mapping.go
@@ -748,7 +748,11 @@ func stringSlicePtr(values []string) *[]string {
 }
 
 func stringMapPtr(values map[string]string) *factoryapi.StringMap {
-	return optional.CopiedStringMapPtr(values)
+	if len(values) == 0 {
+		return nil
+	}
+	copied := factoryapi.StringMap(cloneStringMap(values))
+	return &copied
 }
 
 func intPtrIfNonZero(value int) *int {

--- a/pkg/config/openapi_factory_alias_test.go
+++ b/pkg/config/openapi_factory_alias_test.go
@@ -471,3 +471,82 @@ func TestFactoryConfigFromOpenAPI_ReportsNestedGeneratedFieldPathOnMappingError(
 		t.Fatalf("expected guard cardinality context in error, got %v", err)
 	}
 }
+
+func TestFactoryConfigToOpenAPI_PreservesAndDetachesWorkstationEnv(t *testing.T) {
+	cfg := &interfaces.FactoryConfig{
+		WorkTypes: []interfaces.WorkTypeConfig{{
+			Name: "story",
+			States: []interfaces.StateConfig{
+				{Name: "init", Type: interfaces.StateTypeInitial},
+				{Name: "complete", Type: interfaces.StateTypeTerminal},
+			},
+		}},
+		Workers: []interfaces.WorkerConfig{{Name: "executor"}},
+		Workstations: []interfaces.FactoryWorkstationConfig{{
+			Name:           "execute-story",
+			WorkerTypeName: "executor",
+			Inputs:         []interfaces.IOConfig{{WorkTypeName: "story", StateName: "init"}},
+			Outputs:        []interfaces.IOConfig{{WorkTypeName: "story", StateName: "complete"}},
+			Env:            map[string]string{"TEAM": `{{ index .Tags "team" }}`},
+		}},
+	}
+
+	generated := FactoryConfigToOpenAPI(cfg)
+	workstation := requireSingleGeneratedWorkstation(t, generated)
+	if workstation.Env == nil {
+		t.Fatal("expected generated workstation env")
+	}
+	if got := (*workstation.Env)["TEAM"]; got != `{{ index .Tags "team" }}` {
+		t.Fatalf("expected generated workstation env TEAM to be preserved, got %#v", workstation.Env)
+	}
+
+	cfg.Workstations[0].Env["TEAM"] = "mutated"
+	cfg.Workstations[0].Env["LATE_BOUND"] = "true"
+
+	if got := (*workstation.Env)["TEAM"]; got != `{{ index .Tags "team" }}` {
+		t.Fatalf("expected generated workstation env TEAM to stay detached, got %#v", workstation.Env)
+	}
+	if got := (*workstation.Env)["LATE_BOUND"]; got != "" {
+		t.Fatalf("expected generated workstation env to stay detached from later source mutations, got %#v", workstation.Env)
+	}
+}
+
+func TestFactoryConfigToOpenAPI_OmitsEmptyWorkstationEnv(t *testing.T) {
+	cfg := &interfaces.FactoryConfig{
+		WorkTypes: []interfaces.WorkTypeConfig{{
+			Name: "story",
+			States: []interfaces.StateConfig{
+				{Name: "init", Type: interfaces.StateTypeInitial},
+				{Name: "complete", Type: interfaces.StateTypeTerminal},
+			},
+		}},
+		Workers: []interfaces.WorkerConfig{{Name: "executor"}},
+		Workstations: []interfaces.FactoryWorkstationConfig{{
+			Name:           "execute-story",
+			WorkerTypeName: "executor",
+			Inputs:         []interfaces.IOConfig{{WorkTypeName: "story", StateName: "init"}},
+			Outputs:        []interfaces.IOConfig{{WorkTypeName: "story", StateName: "complete"}},
+			Env:            map[string]string{},
+		}},
+	}
+
+	generated := FactoryConfigToOpenAPI(cfg)
+	workstation := requireSingleGeneratedWorkstation(t, generated)
+	if workstation.Env != nil {
+		t.Fatalf("expected empty workstation env to be omitted from generated boundary, got %#v", workstation.Env)
+	}
+
+	generatedJSON, err := json.Marshal(generated)
+	if err != nil {
+		t.Fatalf("marshal generated factory boundary: %v", err)
+	}
+	var serialized struct {
+		Workstations []map[string]any `json:"workstations"`
+	}
+	if err := json.Unmarshal(generatedJSON, &serialized); err != nil {
+		t.Fatalf("unmarshal generated factory boundary JSON: %v", err)
+	}
+	if _, ok := serialized.Workstations[0]["env"]; ok {
+		t.Fatalf("expected generated workstation JSON to omit empty env, got %#v", serialized.Workstations[0])
+	}
+}


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/consolidate-config-string-map-clone-ownership",
  "description": "Consolidate string-map clone ownership inside pkg/config so OpenAPI workstation env mapping reuses one canonical package-local copy policy without changing emitted env behavior or detached map ownership.",
  "context": {
    "customerAsk": "Keep one package-local owner for string-map cloning inside pkg/config, make the OpenAPI mapping path reuse it, preserve current workstation Env behavior exactly, and verify behavior through emitted OpenAPI payload and detached ownership tests.",
    "problem": "pkg/config/runtime_config.go and pkg/config/factory_config_mapping.go currently own the same map[string]string copy policy through separate helpers even though both need the same nil-for-empty and detached-copy behavior for workstation Env data. That same-package duplication creates drift risk because future Env copy-policy changes would have to be made in two places.",
    "solution": "Keep cloneStringMap in pkg/config/runtime_config.go as the canonical package-local string-map clone helper, update the OpenAPI mapping path to reuse it when producing generated StringMap values, delete the duplicate copy loop, and verify preserved env content, omission behavior, and detached ownership through focused config tests."
  },
  "acceptanceCriteria": [
    "pkg/config has one clear package-local owner for map[string]string clone policy, and the OpenAPI workstation mapping path reuses it instead of maintaining a duplicate copy loop.",
    "FactoryConfigToOpenAPI continues to emit the same workstation env key/value pairs for non-empty authored Env maps.",
    "FactoryConfigToOpenAPI continues to omit workstation env from the generated OpenAPI payload when the authored Env map is empty or absent.",
    "The generated OpenAPI workstation Env map remains detached from the authored config map so later source-map mutation does not change the already-converted OpenAPI payload.",
    "The implementation stays narrowly scoped to same-package clone-owner consolidation in pkg/config without redesigning generated OpenAPI mapping helpers or broadening into cross-package helper consolidation.",
    "Regression coverage verifies emitted OpenAPI payloads and detached ownership behavior rather than helper names, helper counts, or source-file topology.",
    "Typecheck, lint, and tests pass for the touched backend packages."
  ],
  "userStories": [
    {
      "id": "consolidate-config-string-map-clone-ownership-001",
      "title": "Reuse one canonical string-map clone policy for OpenAPI workstation env mapping",
      "description": "As a backend maintainer, I want runtime config and OpenAPI workstation mapping to share one string-map clone helper so that the same package-local Env copy policy cannot drift across two config paths.",
      "acceptanceCriteria": [
        "pkg/config keeps exactly one package-local owner for map[string]string clone policy.",
        "The OpenAPI workstation mapping path reuses the canonical clone helper instead of maintaining its own duplicate map[string]string copy loop.",
        "FactoryConfigToOpenAPI still emits the same workstation env key/value pairs for non-empty authored Env maps.",
        "FactoryConfigToOpenAPI still omits workstation env when the authored Env map is empty or absent.",
        "The implementation remains narrowly scoped to same-package clone-owner consolidation and does not redesign generated OpenAPI mapping helpers or broaden into cross-package cleanup.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "consolidate-config-string-map-clone-ownership-002",
      "title": "Prove emitted OpenAPI env behavior and detached ownership with focused config tests",
      "description": "As a reviewer, I want focused behavioral tests around OpenAPI config conversion so that this cleanup proves workstation env payload content, omission behavior, and detached map ownership stayed stable.",
      "acceptanceCriteria": [
        "pkg/config/openapi_factory_alias_test.go or an equivalently focused generated-boundary test proves FactoryConfigToOpenAPI preserves workstation env key/value pairs for a representative non-empty authored Env map.",
        "pkg/config/openapi_factory_alias_test.go or an equivalently focused generated-boundary test proves mutating the source workstation Env map after FactoryConfigToOpenAPI does not change the generated OpenAPI workstation Env map.",
        "pkg/config/factory_config_mapping_roundtrip_test.go or an equivalently focused mapping test proves empty authored workstation Env maps remain omitted at the generated OpenAPI boundary rather than emitted as empty objects.",
        "Tests assert emitted OpenAPI payload behavior and detachment outcomes rather than helper names, helper placement, or source-file structure.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
