### PR TITLE
flatten-dispatch-result-hook-wrapper-types

### DIFF
--- a/pkg/factory/engine/engine.go
+++ b/pkg/factory/engine/engine.go
@@ -654,16 +654,14 @@ func (e *FactoryEngine) invokeDispatchResultHook(ctx context.Context) (int, erro
 		return 0, nil
 	}
 
-	result, err := e.dispatchHook.OnTick(ctx, interfaces.DispatchResultHookContext[interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]]{
-		Snapshot: e.runtimeState.Snapshot(),
-	})
+	result, err := e.dispatchHook.OnTick(ctx, e.runtimeState.Snapshot())
 	if err != nil {
 		return 0, fmt.Errorf("dispatch/result hook: %w", err)
 	}
-	for _, workResult := range result.Results {
+	for _, workResult := range result {
 		e.appendObservedResult(workResult)
 	}
-	return len(result.Results), nil
+	return len(result), nil
 }
 
 func (e *FactoryEngine) invokeSubmissionHooks(ctx context.Context) (int, bool, error) {

--- a/pkg/factory/engine/engine_test_helpers_test.go
+++ b/pkg/factory/engine/engine_test_helpers_test.go
@@ -57,7 +57,7 @@ func (h *testSubmissionHook) OnTick(ctx context.Context, input interfaces.Submis
 type testDispatchResultHook struct {
 	waitCh   chan struct{}
 	submit   func(context.Context, interfaces.WorkDispatch) error
-	onTick   func(context.Context, interfaces.DispatchResultHookContext[interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]]) (interfaces.DispatchResultHookResult, error)
+	onTick   func(context.Context, interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) ([]interfaces.WorkResult, error)
 	submits  []interfaces.WorkDispatch
 	results  []interfaces.WorkResult
 	waitOnce bool
@@ -75,17 +75,17 @@ func (h *testDispatchResultHook) SubmitDispatch(ctx context.Context, dispatch in
 	return nil
 }
 
-func (h *testDispatchResultHook) OnTick(ctx context.Context, input interfaces.DispatchResultHookContext[interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]]) (interfaces.DispatchResultHookResult, error) {
+func (h *testDispatchResultHook) OnTick(ctx context.Context, input interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) ([]interfaces.WorkResult, error) {
 	if h.onTick != nil {
 		return h.onTick(ctx, input)
 	}
 	if len(h.results) == 0 {
-		return interfaces.DispatchResultHookResult{}, nil
+		return nil, nil
 	}
 	results := make([]interfaces.WorkResult, len(h.results))
 	copy(results, h.results)
 	h.results = nil
-	return interfaces.DispatchResultHookResult{Results: results}, nil
+	return results, nil
 }
 
 func (h *testDispatchResultHook) WaitCh() <-chan struct{} {

--- a/pkg/factory/options.go
+++ b/pkg/factory/options.go
@@ -75,7 +75,7 @@ type SubmissionHook interface {
 // execution and tick-owned result delivery.
 type DispatchResultHook interface {
 	SubmitDispatch(ctx context.Context, dispatch interfaces.WorkDispatch) error
-	OnTick(ctx context.Context, input interfaces.DispatchResultHookContext[interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]]) (interfaces.DispatchResultHookResult, error)
+	OnTick(ctx context.Context, snapshot interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) ([]interfaces.WorkResult, error)
 	WaitCh() <-chan struct{}
 }
 

--- a/pkg/factory/runtime/dispatch_result_hook.go
+++ b/pkg/factory/runtime/dispatch_result_hook.go
@@ -106,27 +106,27 @@ func (h *workerPoolDispatchResultHook) SubmitDispatch(ctx context.Context, dispa
 	return nil
 }
 
-func (h *workerPoolDispatchResultHook) OnTick(_ context.Context, input interfaces.DispatchResultHookContext[interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]]) (interfaces.DispatchResultHookResult, error) {
+func (h *workerPoolDispatchResultHook) OnTick(_ context.Context, snapshot interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) ([]interfaces.WorkResult, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if validator, ok := h.planner.(replayTickValidator); ok {
-		if err := validator.ValidateReplayTick(input.Snapshot.TickCount); err != nil {
-			return interfaces.DispatchResultHookResult{}, err
+		if err := validator.ValidateReplayTick(snapshot.TickCount); err != nil {
+			return nil, err
 		}
 	}
 	if len(h.results) == 0 {
-		return interfaces.DispatchResultHookResult{}, nil
+		return nil, nil
 	}
 
-	results := h.takeDueResults(input.Snapshot.TickCount)
+	results := h.takeDueResults(snapshot.TickCount)
 	if len(h.results) > 0 {
 		h.signalWaitLocked()
 	}
 	if len(results) == 0 {
-		return interfaces.DispatchResultHookResult{}, nil
+		return nil, nil
 	}
 
-	return interfaces.DispatchResultHookResult{Results: results}, nil
+	return results, nil
 }
 
 func (h *workerPoolDispatchResultHook) takeDueResults(currentTick int) []interfaces.WorkResult {

--- a/pkg/factory/runtime/dispatch_result_hook_test.go
+++ b/pkg/factory/runtime/dispatch_result_hook_test.go
@@ -110,19 +110,15 @@ func TestWorkerPoolDispatchResultHook_SubmitDispatchWithPlannerExecutesSynchrono
 		t.Fatalf("executor dispatch ID = %q, want %q", executor.calls[0].DispatchID, dispatch.DispatchID)
 	}
 
-	result, err := hook.OnTick(context.Background(), interfaces.DispatchResultHookContext[interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]]{
-		Snapshot: interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{
-			TickCount: 0,
-		},
-	})
+	result, err := hook.OnTick(context.Background(), interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{TickCount: 0})
 	if err != nil {
 		t.Fatalf("OnTick: %v", err)
 	}
-	if len(result.Results) != 1 {
-		t.Fatalf("hook result count = %d, want 1", len(result.Results))
+	if len(result) != 1 {
+		t.Fatalf("hook result count = %d, want 1", len(result))
 	}
-	if result.Results[0].Output != "executor-output" {
-		t.Fatalf("hook result output = %q, want executor-output", result.Results[0].Output)
+	if result[0].Output != "executor-output" {
+		t.Fatalf("hook result output = %q, want executor-output", result[0].Output)
 	}
 }
 
@@ -145,31 +141,23 @@ func TestWorkerPoolDispatchResultHook_SubmitDispatchWithPlannerDelaysDeliveryUnt
 		t.Fatalf("SubmitDispatch: %v", err)
 	}
 
-	result, err := hook.OnTick(context.Background(), interfaces.DispatchResultHookContext[interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]]{
-		Snapshot: interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{
-			TickCount: 2,
-		},
-	})
+	result, err := hook.OnTick(context.Background(), interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{TickCount: 2})
 	if err != nil {
 		t.Fatalf("OnTick before due tick: %v", err)
 	}
-	if len(result.Results) != 0 {
-		t.Fatalf("hook result count before due tick = %d, want 0", len(result.Results))
+	if len(result) != 0 {
+		t.Fatalf("hook result count before due tick = %d, want 0", len(result))
 	}
 
-	result, err = hook.OnTick(context.Background(), interfaces.DispatchResultHookContext[interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]]{
-		Snapshot: interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{
-			TickCount: 3,
-		},
-	})
+	result, err = hook.OnTick(context.Background(), interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{TickCount: 3})
 	if err != nil {
 		t.Fatalf("OnTick at due tick: %v", err)
 	}
-	if len(result.Results) != 1 {
-		t.Fatalf("hook result count at due tick = %d, want 1", len(result.Results))
+	if len(result) != 1 {
+		t.Fatalf("hook result count at due tick = %d, want 1", len(result))
 	}
-	if result.Results[0].Output != "executor-output" {
-		t.Fatalf("hook result output at due tick = %q, want executor-output", result.Results[0].Output)
+	if result[0].Output != "executor-output" {
+		t.Fatalf("hook result output at due tick = %q, want executor-output", result[0].Output)
 	}
 }
 
@@ -201,19 +189,15 @@ func TestWorkerPoolDispatchResultHook_SubmitDispatchWithPlannerUsesPlannedResult
 		t.Fatalf("executor call count = %d, want 1", len(executor.calls))
 	}
 
-	result, err := hook.OnTick(context.Background(), interfaces.DispatchResultHookContext[interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]]{
-		Snapshot: interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{
-			TickCount: 0,
-		},
-	})
+	result, err := hook.OnTick(context.Background(), interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{TickCount: 0})
 	if err != nil {
 		t.Fatalf("OnTick: %v", err)
 	}
-	if len(result.Results) != 1 {
-		t.Fatalf("hook result count = %d, want 1", len(result.Results))
+	if len(result) != 1 {
+		t.Fatalf("hook result count = %d, want 1", len(result))
 	}
-	if result.Results[0].Output != "planned-output" {
-		t.Fatalf("hook result output = %q, want planned-output", result.Results[0].Output)
+	if result[0].Output != "planned-output" {
+		t.Fatalf("hook result output = %q, want planned-output", result[0].Output)
 	}
 }
 
@@ -228,11 +212,7 @@ func TestWorkerPoolDispatchResultHook_OnTickValidatesReplayTick(t *testing.T) {
 		planner,
 	)
 
-	_, err := hook.OnTick(context.Background(), interfaces.DispatchResultHookContext[interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]]{
-		Snapshot: interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{
-			TickCount: 7,
-		},
-	})
+	_, err := hook.OnTick(context.Background(), interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{TickCount: 7})
 	if err != nil {
 		t.Fatalf("OnTick: %v", err)
 	}
@@ -242,11 +222,7 @@ func TestWorkerPoolDispatchResultHook_OnTickValidatesReplayTick(t *testing.T) {
 
 	expectedErr := errors.New("replay tick mismatch")
 	planner.validateErr = expectedErr
-	_, err = hook.OnTick(context.Background(), interfaces.DispatchResultHookContext[interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]]{
-		Snapshot: interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{
-			TickCount: 8,
-		},
-	})
+	_, err = hook.OnTick(context.Background(), interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{TickCount: 8})
 	if !errors.Is(err, expectedErr) {
 		t.Fatalf("OnTick error = %v, want %v", err, expectedErr)
 	}
@@ -295,16 +271,12 @@ func TestWorkerPoolDispatchResultHook_SubmitDispatchWithoutPlannerUsesWorkerPool
 		t.Fatal("timed out waiting for worker-pool executor to start")
 	}
 
-	result, err := hook.OnTick(context.Background(), interfaces.DispatchResultHookContext[interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]]{
-		Snapshot: interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{
-			TickCount: 0,
-		},
-	})
+	result, err := hook.OnTick(context.Background(), interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{TickCount: 0})
 	if err != nil {
 		t.Fatalf("OnTick before release: %v", err)
 	}
-	if len(result.Results) != 0 {
-		t.Fatalf("hook result count before worker completion = %d, want 0", len(result.Results))
+	if len(result) != 0 {
+		t.Fatalf("hook result count before worker completion = %d, want 0", len(result))
 	}
 
 	close(executor.release)
@@ -315,19 +287,15 @@ func TestWorkerPoolDispatchResultHook_SubmitDispatchWithoutPlannerUsesWorkerPool
 		t.Fatal("timed out waiting for async worker-pool completion signal")
 	}
 
-	result, err = hook.OnTick(context.Background(), interfaces.DispatchResultHookContext[interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]]{
-		Snapshot: interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{
-			TickCount: 0,
-		},
-	})
+	result, err = hook.OnTick(context.Background(), interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{TickCount: 0})
 	if err != nil {
 		t.Fatalf("OnTick after release: %v", err)
 	}
-	if len(result.Results) != 1 {
-		t.Fatalf("hook result count after worker completion = %d, want 1", len(result.Results))
+	if len(result) != 1 {
+		t.Fatalf("hook result count after worker completion = %d, want 1", len(result))
 	}
-	if result.Results[0].Output != "async-executor-output" {
-		t.Fatalf("hook result output = %q, want async-executor-output", result.Results[0].Output)
+	if result[0].Output != "async-executor-output" {
+		t.Fatalf("hook result output = %q, want async-executor-output", result[0].Output)
 	}
 }
 

--- a/pkg/interfaces/factory_hooks.go
+++ b/pkg/interfaces/factory_hooks.go
@@ -43,15 +43,3 @@ type SubmissionHookResult struct {
 	ContinuationState map[string]string
 	KeepAlive         bool
 }
-
-// DispatchResultHookContext is the input passed to dispatch/result hooks once
-// per logical tick.
-type DispatchResultHookContext[TSnapshot any] struct {
-	Snapshot TSnapshot
-}
-
-// DispatchResultHookResult contains worker completions made visible to the
-// engine at one logical tick.
-type DispatchResultHookResult struct {
-	Results []WorkResult
-}


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/flatten-dispatch-result-hook-wrapper-types",
  "description": "Flatten the dispatch-result hook surface so the hook accepts the live engine snapshot directly and returns due WorkResult values directly, removing shallow wrapper types while preserving worker-pool dispatch, replay validation, and delayed-result delivery behavior.",
  "context": {
    "customerAsk": "Flatten the dispatch-result hook surface by removing DispatchResultHookContext and DispatchResultHookResult, updating factory.DispatchResultHook to take the current engine snapshot directly and return []interfaces.WorkResult directly, updating the engine/runtime hook path and tests accordingly, and leaving the submission-hook wrapper types unchanged.",
    "problem": "The dispatch-result hook contract still uses DispatchResultHookContext and DispatchResultHookResult even though each wrapper now carries only one field. That adds boilerplate such as input.Snapshot and result.Results across the engine/runtime hook path without adding policy, while increasing type noise in a surface that is already local to the dispatch-result hook family.",
    "solution": "Remove the two shallow dispatch-result wrapper types, update the hook contract to use the concrete engine snapshot input and direct []interfaces.WorkResult output, simplify the engine call site to pass and append values directly, and update runtime/test helpers so replay-tick validation and delayed-result delivery behavior remain intact."
  },
  "acceptanceCriteria": [
    "pkg/interfaces/factory_hooks.go no longer defines DispatchResultHookContext or DispatchResultHookResult.",
    "factory.DispatchResultHook accepts the current interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net] directly and returns []interfaces.WorkResult directly.",
    "The engine dispatch-result hook call path passes e.runtimeState.Snapshot() directly and appends returned due results without introducing a replacement wrapper abstraction.",
    "Runtime dispatch-result behavior remains unchanged: replay-tick validation still rejects mismatched replay input and delayed results are still delivered only on their planned tick.",
    "SubmissionHookContext and SubmissionHookResult remain unchanged in this lane.",
    "The diff stays local to the dispatch-result hook family and directly affected tests, without unrelated worker, runner, or submission-hook cleanup.",
    "Typecheck, lint, and go test ./pkg/factory/engine ./pkg/factory/runtime ./pkg/interfaces pass for the final change."
  ],
  "userStories": [
    {
      "id": "flatten-dispatch-result-hook-wrapper-types-001",
      "title": "Flatten the dispatch-result hook contract",
      "description": "As a backend maintainer, I want the dispatch-result hook to accept the engine snapshot and return due results directly so that the hook contract is simpler without changing observable dispatch behavior.",
      "acceptanceCriteria": [
        "pkg/interfaces/factory_hooks.go removes DispatchResultHookContext and DispatchResultHookResult.",
        "factory.DispatchResultHook defines OnTick with a direct interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net] input and a direct []interfaces.WorkResult return value.",
        "The engine dispatch-result hook call site passes e.runtimeState.Snapshot() directly and appends returned due results directly rather than reading input.Snapshot or result.Results.",
        "No new wrapper or pass-through abstraction is introduced to replace the removed dispatch-result structs.",
        "SubmissionHookContext and SubmissionHookResult remain unchanged.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "flatten-dispatch-result-hook-wrapper-types-002",
      "title": "Preserve delayed delivery and replay validation behavior",
      "description": "As a maintainer, I want the runtime dispatch-result hook and its tests to keep the same due-result delivery and replay validation behavior after the signature flattening so that the cleanup remains behavior-preserving.",
      "acceptanceCriteria": [
        "pkg/factory/runtime/dispatch_result_hook.go uses the flattened dispatch-result hook signature while still validating replay ticks against the current runtime tick before accepting replayed results.",
        "Results scheduled for a future delivery tick are not returned before that tick and are returned as direct []interfaces.WorkResult values when the planned tick is reached.",
        "Engine and runtime tests covering the dispatch-result hook continue to assert observed due-result delivery and replay-tick validation outcomes rather than type names, file layout, or wrapper presence.",
        "The focused verification command go test ./pkg/factory/engine ./pkg/factory/runtime ./pkg/interfaces passes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
