### PR TITLE
remove-dead-engine-state-runtime-snapshot-wrapper

### DIFF
--- a/pkg/factory/state/engine_state_test.go
+++ b/pkg/factory/state/engine_state_test.go
@@ -60,7 +60,7 @@ func TestEngineStateSnapshot_AllFieldsAccessible(t *testing.T) {
 		t.Fatalf("expected topology snapshot-topology, got %#v", snap.Topology)
 	}
 
-	runtime := snap.RuntimeStateSnapshot()
+	runtime := engineRuntimeSnapshotFixture()
 	if runtime.RuntimeStatus != snap.RuntimeStatus {
 		t.Fatalf("runtime status = %q, want %q", runtime.RuntimeStatus, snap.RuntimeStatus)
 	}
@@ -69,6 +69,9 @@ func TestEngineStateSnapshot_AllFieldsAccessible(t *testing.T) {
 	}
 	if len(runtime.ActiveThrottlePauses) != 1 {
 		t.Fatalf("runtime active throttle pause count = %d, want 1", len(runtime.ActiveThrottlePauses))
+	}
+	if runtime.Topology != nil {
+		t.Fatalf("runtime topology = %#v, want nil", runtime.Topology)
 	}
 	aggregate := NewEngineStateSnapshot(runtime, "RUNNING", time.Minute, snap.Topology)
 	if len(aggregate.ActiveThrottlePauses) != 1 {
@@ -139,4 +142,12 @@ func engineStateSnapshotFixture() interfaces.EngineStateSnapshot[petri.MarkingSn
 		Uptime:       10 * time.Minute,
 		Topology:     topology,
 	}
+}
+
+func engineRuntimeSnapshotFixture() interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *Net] {
+	runtime := engineStateSnapshotFixture()
+	runtime.FactoryState = ""
+	runtime.Uptime = 0
+	runtime.Topology = nil
+	return runtime
 }

--- a/pkg/interfaces/engine_state.go
+++ b/pkg/interfaces/engine_state.go
@@ -36,20 +36,3 @@ type EngineStateSnapshot[TMarking any, TTopology any] struct {
 	// records for service-facing observability read models.
 	Topology TTopology `json:"topology,omitempty"`
 }
-
-// RuntimeStateSnapshot returns the raw runtime portion of the aggregate
-// snapshot for reducers that intentionally operate on runtime records.
-func (s EngineStateSnapshot[TMarking, TTopology]) RuntimeStateSnapshot() EngineStateSnapshot[TMarking, TTopology] {
-	var topology TTopology
-	return EngineStateSnapshot[TMarking, TTopology]{
-		RuntimeStatus:        s.RuntimeStatus,
-		Marking:              s.Marking,
-		Dispatches:           s.Dispatches,
-		InFlightCount:        s.InFlightCount,
-		Results:              s.Results,
-		DispatchHistory:      s.DispatchHistory,
-		ActiveThrottlePauses: s.ActiveThrottlePauses,
-		TickCount:            s.TickCount,
-		Topology:             topology,
-	}
-}


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/remove-dead-engine-state-runtime-snapshot-wrapper",
  "description": "Remove the unused EngineStateSnapshot.RuntimeStateSnapshot() helper from the shared engine-state contract so the public snapshot surface reflects only live behavior while preserving runtime, API, CLI, and UI semantics.",
  "context": {
    "customerAsk": "Remove EngineStateSnapshot.RuntimeStateSnapshot() from pkg/interfaces/engine_state.go, update pkg/factory/state/engine_state_test.go so it still verifies the exported snapshot contract without the wrapper, clean up nearby comments only if needed, keep the scope local to the engine-state snapshot surface, and verify with go test ./pkg/interfaces ./pkg/factory/state ./pkg/factory/engine ./pkg/factory/runtime ./tests/functional/runtime_api.",
    "problem": "The shared engine-state contract still exports a runtime-only wrapper that no production runtime, API, CLI, or UI path uses. The helper only copies runtime fields that are already exposed on the aggregate snapshot and zeroes topology, so it adds a redundant exported name without carrying distinct runtime behavior.",
    "solution": "Delete the dead RuntimeStateSnapshot() method from EngineStateSnapshot, keep the aggregate snapshot structure and live GetRuntimeStateSnapshot() behavior intact, update the direct contract test to assert the remaining exported snapshot fields without the removed helper, and use focused backend verification to prove the cleanup did not change observable behavior."
  },
  "acceptanceCriteria": [
    "pkg/interfaces/engine_state.go no longer defines EngineStateSnapshot.RuntimeStateSnapshot().",
    "The remaining EngineStateSnapshot aggregate surface still exposes runtime fields, factory lifecycle state, uptime, and topology exactly as the live engine, runtime, and API readers depend on today.",
    "No replacement wrapper, compatibility shim, or alternate helper is introduced for the removed runtime snapshot method.",
    "pkg/factory/state/engine_state_test.go continues to verify the exported snapshot contract, including runtime fields and aggregate-only fields, without calling the removed wrapper.",
    "Runtime, API, CLI, and UI behavior remain unchanged because production consumers continue to rely on the existing snapshot structs and GetRuntimeStateSnapshot() flow rather than the deleted helper.",
    "The implementation stays local to the engine-state snapshot surface, directly affected comments, and the contract test lane named in the ask.",
    "Focused verification passes with go test ./pkg/interfaces ./pkg/factory/state ./pkg/factory/engine ./pkg/factory/runtime ./tests/functional/runtime_api.",
    "Quality gate: typecheck, lint, and relevant automated tests pass."
  ],
  "userStories": [
    {
      "id": "remove-dead-engine-state-runtime-snapshot-wrapper-001",
      "title": "Remove the dead runtime-only wrapper from the engine snapshot contract",
      "description": "As a backend maintainer, I want the shared engine snapshot contract to stop exporting an unused runtime-only wrapper so that the public interface surface reflects only the snapshot behaviors that production code actually depends on.",
      "acceptanceCriteria": [
        "pkg/interfaces/engine_state.go removes EngineStateSnapshot.RuntimeStateSnapshot().",
        "The remaining EngineStateSnapshot fields continue to represent the aggregate runtime snapshot contract without changing field names, field meanings, or JSON-facing structure.",
        "No replacement wrapper, compatibility shim, or duplicate runtime-only helper is added.",
        "Nearby comments are updated only as needed so the remaining engine-state contract reads coherently after the deletion.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "remove-dead-engine-state-runtime-snapshot-wrapper-002",
      "title": "Preserve contract evidence and observable behavior after the wrapper removal",
      "description": "As a maintainer, I want the engine-state contract tests and focused backend verification to prove that removing the dead wrapper did not change runtime-visible snapshot behavior or leave the snapshot surface under-specified.",
      "acceptanceCriteria": [
        "pkg/factory/state/engine_state_test.go verifies the exported snapshot contract without calling RuntimeStateSnapshot().",
        "The updated test still covers reviewer-verifiable runtime fields such as runtime status, dispatch state, dispatch history, active throttle pauses, and tick count, alongside aggregate-only fields such as factory state, uptime, and topology.",
        "The cleanup does not change observable engine runtime snapshot behavior exposed through existing production readers such as GetRuntimeStateSnapshot().",
        "Focused verification passes with go test ./pkg/interfaces ./pkg/factory/state ./pkg/factory/engine ./pkg/factory/runtime ./tests/functional/runtime_api.",
        "The implementation remains a narrow contract-and-test cleanup and does not expand into engine runtime redesign, topology modeling, or unrelated state refactors.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
