### PR TITLE
remove-executor-provider-helper-shadow-ownership

### DIFF
--- a/pkg/workers/executor/agent.go
+++ b/pkg/workers/executor/agent.go
@@ -326,7 +326,7 @@ func RunnerFromProvider(provider Provider) Runner {
 
 func (a providerRunnerAdapter) Execute(ctx context.Context, request interfaces.RunnerExecutionRequest) (interfaces.RunnerExecutionResult, error) {
 	if a.inner == nil {
-		return interfaces.RunnerExecutionResult{}, NewProviderError(
+		return interfaces.RunnerExecutionResult{}, workerprovider.NewProviderError(
 			interfaces.ProviderErrorTypeMisconfigured,
 			"runner requires a provider implementation",
 			nil,
@@ -373,7 +373,7 @@ func (ae *AgentExecutor) evaluateOutcome(resp interfaces.InferenceResponse, work
 		ae.logger.Info("no stop token configured; defaulting to ACCEPTED outcome")
 		return interfaces.OutcomeAccepted
 	}
-	if ContainsStopToken(resp.Content, workerDef.StopToken) {
+	if workerprovider.ContainsStopToken(resp.Content, workerDef.StopToken) {
 		ae.logger.Info("stop token found in output; returning ACCEPTED outcome", "stop_token", workerDef.StopToken)
 		return interfaces.OutcomeAccepted
 	}

--- a/pkg/workers/executor/agent_test.go
+++ b/pkg/workers/executor/agent_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/testutil/runtimefixtures"
+	workerprovider "github.com/portpowered/infinite-you/pkg/workers/provider"
 )
 
 type agentMockProvider struct {
@@ -311,7 +312,7 @@ func TestAgentExecutor_ErrorDiagnosticsStayDetachedFromProviderMutation(t *testi
 		Metadata: map[string]string{"phase": "initial"},
 	}
 	provider := &agentMockProvider{
-		err: NewProviderError(interfaces.ProviderErrorTypeInternalServerError, "provider 500", nil),
+		err: workerprovider.NewProviderError(interfaces.ProviderErrorTypeInternalServerError, "provider 500", nil),
 	}
 	var providerErr *ProviderError
 	if !errors.As(provider.err, &providerErr) {
@@ -604,8 +605,8 @@ func TestAgentExecutor_SuccessfulResponse_PreservesProviderSession(t *testing.T)
 func TestAgentExecutor_RetryableProviderError_RetriesTwiceBeforeSuccess(t *testing.T) {
 	provider := &agentMockProvider{
 		errors: []error{
-			NewProviderError(interfaces.ProviderErrorTypeInternalServerError, "provider 500", nil),
-			NewProviderError(interfaces.ProviderErrorTypeTimeout, "provider timeout", nil),
+			workerprovider.NewProviderError(interfaces.ProviderErrorTypeInternalServerError, "provider 500", nil),
+			workerprovider.NewProviderError(interfaces.ProviderErrorTypeTimeout, "provider timeout", nil),
 			nil,
 		},
 		responses: []interfaces.InferenceResponse{
@@ -665,7 +666,7 @@ func TestAgentExecutor_RetryableProviderError_RetriesTwiceBeforeSuccess(t *testi
 
 func TestAgentExecutor_CodexWindowsExitCode4294967295_RetriesAndReturnsRetryableProviderMetadata(t *testing.T) {
 	provider := &agentMockProvider{
-		err: normalizeProviderExitFailure(
+		err: workerprovider.NormalizeProviderExitFailure(
 			string(ModelProviderCodex),
 			CommandResult{
 				ExitCode: codexWindowsProcessFailureExitCode,
@@ -724,7 +725,7 @@ func TestAgentExecutor_CodexWindowsExitCode4294967295_RetriesAndReturnsRetryable
 	if result.ProviderFailure.Family != interfaces.ProviderErrorFamilyRetryable {
 		t.Fatalf("provider failure family = %q, want %q", result.ProviderFailure.Family, interfaces.ProviderErrorFamilyRetryable)
 	}
-	decision := ProviderFailureDecisionFromMetadata(result.ProviderFailure)
+	decision := workerprovider.ProviderFailureDecisionFromMetadata(result.ProviderFailure)
 	if !decision.Retryable || decision.Terminal || decision.TriggersThrottlePause {
 		t.Fatalf("ProviderFailureDecisionFromMetadata(%#v) = %#v, want retryable non-terminal non-throttle", result.ProviderFailure, decision)
 	}
@@ -739,7 +740,7 @@ func TestAgentExecutor_CodexWindowsExitCode4294967295_RetriesAndReturnsRetryable
 func TestAgentExecutor_TerminalProviderError_DoesNotRetry(t *testing.T) {
 	provider := &agentMockProvider{
 		errors: []error{
-			NewProviderErrorWithSession(
+			workerprovider.NewProviderErrorWithSession(
 				interfaces.ProviderErrorTypeAuthFailure,
 				"auth failed",
 				nil,
@@ -801,7 +802,7 @@ func TestAgentExecutor_TerminalProviderError_DoesNotRetry(t *testing.T) {
 func TestAgentExecutor_ClaudeProviderError_PreservesConfiguredSessionID(t *testing.T) {
 	provider := &agentMockProvider{
 		errors: []error{
-			NewProviderErrorWithSession(
+			workerprovider.NewProviderErrorWithSession(
 				interfaces.ProviderErrorTypeAuthFailure,
 				"auth failed",
 				nil,

--- a/pkg/workers/executor/helpers.go
+++ b/pkg/workers/executor/helpers.go
@@ -29,7 +29,7 @@ const (
 	ModelProviderCursor   = workerprovider.ModelProviderCursor
 	ModelProviderOpenCode = workerprovider.ModelProviderOpenCode
 
-	providerSessionKindSessionID      = "session_id"
+	providerSessionKindSessionID       = "session_id"
 	codexWindowsProcessFailureExitCode = 4294967295
 
 	omitZeroWorkerEventExitCode    = false
@@ -45,26 +45,6 @@ const (
 	RedactedCommandEnvValue     = redactedCommandEnvValue
 	MetadataOnlyCommandEnvValue = metadataOnlyCommandEnvValue
 )
-
-func ContainsStopToken(output, stopToken string) bool {
-	return workerprovider.ContainsStopToken(output, stopToken)
-}
-
-func NewProviderError(errorType interfaces.ProviderErrorType, message string, cause error) *ProviderError {
-	return workerprovider.NewProviderError(errorType, message, cause)
-}
-
-func NewProviderErrorWithSession(errorType interfaces.ProviderErrorType, message string, cause error, session *interfaces.ProviderSessionMetadata) *ProviderError {
-	return workerprovider.NewProviderErrorWithSession(errorType, message, cause, session)
-}
-
-func ProviderFailureDecisionFromMetadata(metadata *interfaces.ProviderFailureMetadata) interfaces.ProviderFailureDecision {
-	return workerprovider.ProviderFailureDecisionFromMetadata(metadata)
-}
-
-func normalizeProviderExitFailure(provider string, result CommandResult, session *interfaces.ProviderSessionMetadata, diagnostics *interfaces.WorkDiagnostics) *ProviderError {
-	return workerprovider.NormalizeProviderExitFailure(provider, result, session, diagnostics)
-}
 
 func cloneInputTokens(rawTokens []any) []interfaces.Token {
 	if len(rawTokens) == 0 {


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/remove-executor-provider-helper-shadow-ownership",
  "description": "Remove executor-local shadow wrappers for provider stop-token checks and provider failure normalization so the executor package calls canonical workerprovider helpers directly while preserving existing backend behavior.",
  "context": {
    "customerAsk": "Retarget executor call sites to use the canonical workerprovider helpers directly, delete the redundant provider-behavior wrappers from pkg/workers/executor/helpers.go, keep the rest of the executor package structure unchanged, preserve current provider failure classification, session attachment, and stop-token behavior, avoid adding new compatibility helpers, and verify the cleanup with the smallest relevant backend executor or provider test lane.",
    "problem": "pkg/workers/executor still owns local wrappers for ContainsStopToken, NewProviderError, NewProviderErrorWithSession, ProviderFailureDecisionFromMetadata, and normalizeProviderExitFailure even though those behaviors are already canonically owned by pkg/workers/provider and are only consumed inside executor. That creates duplicate ownership for the same provider-specific behavior, increases drift risk, and makes the executor package harder to review.",
    "solution": "Update executor runtime and test call sites to invoke the canonical workerprovider helpers directly, delete the redundant wrapper names from pkg/workers/executor/helpers.go, and verify through focused executor or provider tests that stop-token handling, provider failure classification, session attachment, and provider exit normalization remain unchanged."
  },
  "acceptanceCriteria": [
    "Executor runtime and test call sites that currently depend on the shadow helper layer use the canonical workerprovider helpers directly for stop-token checks, provider error construction, provider failure decisions, and provider exit normalization.",
    "pkg/workers/executor no longer defines ContainsStopToken, NewProviderError, NewProviderErrorWithSession, ProviderFailureDecisionFromMetadata, or normalizeProviderExitFailure.",
    "Provider failure classification, attached session metadata, and stop-token detection remain observably unchanged for executor flows that surface provider-backed failures.",
    "The cleanup stays package-local to executor call sites and directly related tests and does not widen into root pkg/workers/*_compat.go seam removal, public import migration, or unrelated executor restructuring.",
    "Regression coverage in the touched executor/provider test lane asserts observable runtime outcomes rather than helper existence, helper placement, or refactor shape.",
    "Focused backend verification passes using the smallest relevant worker-package lane for the touched executor/provider behavior.",
    "Quality gate: typecheck, lint, and relevant automated tests pass."
  ],
  "userStories": [
    {
      "id": "remove-executor-provider-helper-shadow-ownership-001",
      "title": "Retarget executor behavior to the canonical provider helpers",
      "description": "As a backend maintainer, I want executor runtime paths to call the provider-owned helpers directly so that stop-token detection and provider-failure handling have one obvious owner inside the worker subsystem.",
      "acceptanceCriteria": [
        "Executor runtime call sites that currently use ContainsStopToken, NewProviderError, NewProviderErrorWithSession, ProviderFailureDecisionFromMetadata, or normalizeProviderExitFailure are updated to call the canonical workerprovider helpers directly.",
        "Executor-visible stop-token handling remains unchanged, including the same behavior when provider output includes an executor stop token.",
        "Executor-visible provider error construction remains unchanged, including the same error typing and attached session metadata for provider-backed failures.",
        "The change does not introduce a new executor-local compatibility wrapper, alias, or forwarding helper for provider-owned behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "remove-executor-provider-helper-shadow-ownership-002",
      "title": "Remove the shadow helper names and lock behavior with focused verification",
      "description": "As a reviewer, I want the executor-local shadow helper names removed and behavior preserved through focused tests so that the cleanup is obviously complete and safe.",
      "acceptanceCriteria": [
        "pkg/workers/executor no longer defines ContainsStopToken, NewProviderError, NewProviderErrorWithSession, ProviderFailureDecisionFromMetadata, or normalizeProviderExitFailure.",
        "Focused executor/provider tests prove that provider failure classification and normalized provider exit failures remain the same after executor call sites switch to workerprovider helpers.",
        "Focused executor/provider tests prove that provider session attachment on constructed provider errors remains the same after the helper removal.",
        "Verification uses the smallest relevant backend lane for the touched files, preferably targeted executor/provider tests or the normal worker-package test path used by the implementation lane.",
        "The implementation remains a narrow package-local cleanup and does not expand into root compatibility seam removal or broader worker import migration.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
