### PR TITLE
remove-export-dialog-state-barrel-re-export

### DIFF
--- a/ui/src/App.timeline-regression.stories.tsx
+++ b/ui/src/App.timeline-regression.stories.tsx
@@ -6,7 +6,7 @@ import {
   resourceCountTimelineEvents,
 } from "./components/dashboard/fixtures";
 import { semanticWorkflowDashboardSnapshot } from "./components/dashboard/test-fixtures";
-import { useExportDialogStore } from "./features/export/state";
+import { useExportDialogStore } from "./features/export/state/exportDialogStore";
 import {
   activeStoryTrace,
   expectCompactedTopDashboardSection,

--- a/ui/src/features/export/state/index.ts
+++ b/ui/src/features/export/state/index.ts
@@ -1,1 +1,0 @@
-export * from "./exportDialogStore";

--- a/ui/src/testing/app-shell-test-utils.tsx
+++ b/ui/src/testing/app-shell-test-utils.tsx
@@ -26,7 +26,7 @@ import {
   useDashboardStreamStore,
 } from "../features/dashboard/state";
 import { useDashboardSessionStore } from "../features/dashboard/state/dashboardSessionStore";
-import { useExportDialogStore } from "../features/export/state";
+import { useExportDialogStore } from "../features/export/state/exportDialogStore";
 import type { FactoryPngImportValue } from "../features/import/public";
 import type { WorldState } from "../features/timeline/state";
 import { useFactoryTimelineStore } from "../features/timeline/state";


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/remove-export-dialog-state-barrel-re-export",
  "description": "Remove the redundant export dialog state barrel so the remaining story and app-shell helper consumers import useExportDialogStore directly from the canonical exportDialogStore module without changing visible website behavior.",
  "context": {
    "customerAsk": "Retarget ui/src/App.timeline-regression.stories.tsx and ui/src/testing/app-shell-test-utils.tsx to import useExportDialogStore directly from ui/src/features/export/state/exportDialogStore, delete ui/src/features/export/state/index.ts, keep the cleanup narrow, do not rename the store or change dialog behavior or state shape, and verify the affected frontend surfaces with the smallest relevant tests or typecheck coverage.",
    "problem": "ui/src/features/export/state/index.ts is a one-line barrel that only re-exports useExportDialogStore from exportDialogStore.ts. Direct imports from the canonical store module already exist elsewhere, and only two repository-local consumers still use the barrel path, so keeping both paths adds redundant import choices and obscures the true owner of the export dialog state without providing distinct behavior.",
    "solution": "Retarget the two remaining consumers to import useExportDialogStore directly from ui/src/features/export/state/exportDialogStore, delete the redundant state barrel, preserve the existing export dialog store contract and behavior, and prove the cleanup with focused frontend verification for the touched story and app-shell support surfaces."
  },
  "acceptanceCriteria": [
    "ui/src/App.timeline-regression.stories.tsx imports useExportDialogStore directly from ./features/export/state/exportDialogStore.",
    "ui/src/testing/app-shell-test-utils.tsx imports useExportDialogStore directly from ../features/export/state/exportDialogStore.",
    "ui/src/features/export/state/index.ts is deleted and no replacement export-dialog state barrel, shim, or alias path is introduced.",
    "Export dialog behavior, store shape, and the intent of the existing story and testing surfaces remain unchanged after the cleanup.",
    "No visible website behavior changes occur in the timeline regression story or app-shell-supported export dialog flows.",
    "Focused frontend verification covers the touched story and app-shell support surfaces with the smallest relevant typecheck or automated test evidence.",
    "Quality gate: typecheck, lint, and relevant automated tests pass."
  ],
  "userStories": [
    {
      "id": "remove-export-dialog-state-barrel-re-export-001",
      "title": "Retarget the remaining export dialog store consumers to the canonical state module",
      "description": "As a frontend maintainer, I want the remaining timeline-story and app-shell helper consumers to import useExportDialogStore directly from exportDialogStore.ts so that the export feature exposes one canonical store path without changing dialog behavior.",
      "acceptanceCriteria": [
        "ui/src/App.timeline-regression.stories.tsx imports useExportDialogStore from ./features/export/state/exportDialogStore.",
        "ui/src/testing/app-shell-test-utils.tsx imports useExportDialogStore from ../features/export/state/exportDialogStore.",
        "ui/src/features/export/state/index.ts is deleted.",
        "No new barrel, alias, compatibility shim, or renamed store is introduced for the export dialog state path.",
        "The export dialog continues to expose the same observable state behavior and state shape to the timeline story and app-shell test utilities.",
        "The change stays limited to this export dialog state cleanup and does not expand into other export-related barrels or feature reorganization.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "remove-export-dialog-state-barrel-re-export-002",
      "title": "Prove the direct-import cleanup preserves frontend behavior",
      "description": "As a reviewer, I want focused verification for the story and app-shell support surfaces touched by this cleanup so that deletion of the redundant barrel is supported by runtime-safe frontend evidence instead of source-topology assertions alone.",
      "acceptanceCriteria": [
        "Focused frontend verification covers the affected timeline regression story or app-shell-supported export dialog surface with the smallest relevant automated checks for the changed import paths.",
        "Verification confirms there is no visible website behavior change from the direct-import retargeting and barrel deletion.",
        "Verification remains behavioral and import-resolution focused rather than adding meta-tests for file inventories or barrel topology.",
        "The story and test-support surfaces continue to use the existing export dialog store contract without changing test intent.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
