### PR TITLE
remove-current-selection-state-index-re-export

### DIFF
--- a/ui/src/features/current-selection/state/index.ts
+++ b/ui/src/features/current-selection/state/index.ts
@@ -1,3 +1,0 @@
-export * from "./dashboardSelection";
-export * from "./executionDetails";
-export * from "./selectionHistoryStore";

--- a/ui/src/testing/app-shell-test-utils.tsx
+++ b/ui/src/testing/app-shell-test-utils.tsx
@@ -20,7 +20,7 @@ import { semanticWorkflowDashboardSnapshot } from "../components/dashboard/test-
 import { reloadDashboardLayoutFromStorage } from "../features/bento/public";
 import { useDashboardBentoStore } from "../features/bento/state/dashboardBentoStore";
 import { useCurrentFactoryDocument } from "../features/current-factory-definition/public";
-import { resetSelectionHistoryStore } from "../features/current-selection/state";
+import { resetSelectionHistoryStore } from "../features/current-selection/state/selectionHistoryStore";
 import {
   createDefaultDashboardStreamState,
   useDashboardStreamStore,


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/remove-current-selection-state-index-re-export",
  "description": "Remove the redundant current-selection state barrel re-export so the remaining app-shell test helper imports resetSelectionHistoryStore from the canonical direct module while preserving existing website behavior.",
  "context": {
    "customerAsk": "Delete the feature-local barrel at ui/src/features/current-selection/state/index.ts, retarget its lone verified consumer in ui/src/testing/app-shell-test-utils.tsx to import resetSelectionHistoryStore directly from ../features/current-selection/state/selectionHistoryStore, keep the scope limited to that seam, and verify the existing frontend test surface still proves behavior is preserved.",
    "problem": "The website still carries a tiny feature-local barrel that only re-exports dashboardSelection, executionDetails, and selectionHistoryStore, but the currently verified repo-local consumer set has narrowed to one test helper that only needs resetSelectionHistoryStore. Keeping the barrel adds an unnecessary re-export layer, suggests a broader public state boundary than the repo still uses, and increases frontend surface-area noise without changing runtime behavior.",
    "solution": "Move the lone remaining test-helper import to the direct selectionHistoryStore module, delete the redundant state/index.ts barrel once nothing imports it, confirm that no repo-local imports still target ui/src/features/current-selection/state, and run focused frontend verification through the existing app-shell helper test surface to prove the cleanup preserves behavior."
  },
  "acceptanceCriteria": [
    "ui/src/testing/app-shell-test-utils.tsx imports resetSelectionHistoryStore directly from ../features/current-selection/state/selectionHistoryStore.",
    "ui/src/features/current-selection/state/index.ts is deleted.",
    "Repo-local verification shows no remaining imports that target ui/src/features/current-selection/state.",
    "Existing selection-history and app-shell helper behavior remain unchanged because this work only changes import ownership, not store logic or UI behavior.",
    "The implementation remains limited to the current-selection state barrel seam and does not broaden into a larger current-selection refactor.",
    "Quality gate: frontend typecheck, lint, and relevant automated tests pass."
  ],
  "userStories": [
    {
      "id": "remove-current-selection-state-index-re-export-001",
      "title": "Retarget the remaining selection-history consumer to the direct store module",
      "description": "As a frontend maintainer, I want the shared app-shell test helper to import resetSelectionHistoryStore from the direct selection history store module so that test code uses the canonical ownership path instead of a redundant barrel.",
      "acceptanceCriteria": [
        "ui/src/testing/app-shell-test-utils.tsx imports resetSelectionHistoryStore from ../features/current-selection/state/selectionHistoryStore.",
        "The updated test helper continues to compile and call the same reset behavior without changing selection-history runtime behavior, helper semantics, or browser-visible behavior.",
        "No replacement barrel, compatibility shim, or alternate re-export path is introduced for the current-selection state seam.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "remove-current-selection-state-index-re-export-002",
      "title": "Remove the redundant current-selection state barrel and prove the seam is retired",
      "description": "As a reviewer, I want direct proof that the redundant current-selection state barrel is gone and no repo-local imports still rely on it so that the cleanup is complete, behavior-preserving, and safely bounded.",
      "acceptanceCriteria": [
        "ui/src/features/current-selection/state/index.ts is deleted.",
        "Repo-local verification confirms there are no remaining imports of ui/src/features/current-selection/state.",
        "Focused frontend verification through the existing app-shell helper test surface shows the cleanup preserved current-selection behavior.",
        "The change remains limited to import ownership cleanup and does not expand into broader current-selection state or feature-surface reorganization.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
