### PR TITLE
Refine dashboard header action controls

### DIFF
--- a/ui/integration/event-stream-replay.integration.test.mjs
+++ b/ui/integration/event-stream-replay.integration.test.mjs
@@ -263,11 +263,13 @@ async function assertReplayScenarioRenders(preview, replayFixture) {
       replayServer,
     });
     const dashboardSummary = browserPage.page.locator('[aria-label="dashboard summary"]');
-    await dashboardSummary
-      .getByRole("status", {
-        name: /Event stream (live|connecting|offline)/,
-      })
-      .waitFor();
+    expect(
+      await dashboardSummary
+        .getByRole("status", {
+          name: /Event stream (live|connecting|offline)/,
+        })
+        .count(),
+    ).toBe(0);
     expect(
       await dashboardSummary.getByText("RUNNING", { exact: true }).count(),
     ).toBe(0);

--- a/ui/src/App.follow-up-submit.test.tsx
+++ b/ui/src/App.follow-up-submit.test.tsx
@@ -391,10 +391,8 @@ describe("App follow-up workstation and live totals flows", () => {
             .closest("article") as HTMLElement,
         ).getByText("1"),
       ).toBeTruthy();
-      expect(
-        screen.getByRole("status", { name: "Event stream live" }),
-      ).toBeTruthy();
     });
+    expect(screen.queryByRole("status", { name: /Event stream/i })).toBeNull();
   });
 });
 

--- a/ui/src/App.stories.tsx
+++ b/ui/src/App.stories.tsx
@@ -2,8 +2,8 @@ import { expect, userEvent, waitFor, within } from "storybook/test";
 import { App } from "./App";
 import type { FactoryValue } from "./api/named-factory";
 import {
-  singleNodeDashboardSnapshot,
   semanticWorkflowDashboardSnapshot,
+  singleNodeDashboardSnapshot,
   twentyNodeDashboardSnapshot,
 } from "./components/dashboard/test-fixtures";
 import { formatTimeOfDay } from "./components/ui/formatters";
@@ -13,10 +13,10 @@ import {
   activeStoryTrace,
   buttonVisibleStyle,
   currentSelectionCard,
-  expectWorkOutcomeSeries,
   expectCurrentSelectionCardID,
   expectGraphWorkstation,
   expectNoPageHorizontalOverflow,
+  expectWorkOutcomeSeries,
   fillSubmitWorkCard,
   historicalWorkOutcomeSnapshot,
   liveWorkOutcomeSnapshot,
@@ -500,7 +500,9 @@ export const SemanticGraphComposition = {
       name: "Failed Story",
     });
     await expect(failedStoryButton).toBeVisible();
-    await expect(within(failedStoryButton).getByText("Failed at Repair")).toBeVisible();
+    await expect(
+      within(failedStoryButton).getByText("Failed at Repair"),
+    ).toBeVisible();
     expect(within(failedStoryButton).queryByText(/session_id/i)).toBeNull();
     expect(within(failedStoryButton).queryByText(/codex/i)).toBeNull();
   },
@@ -690,10 +692,10 @@ export const DashboardImprovementsSmoke = {
     );
     const currentSelection = within(currentSelectionCard(canvasElement));
     const summaryDetails = currentSelection.getByText("Count").closest("dl");
+    await expect(currentSelection.getByText("Current work")).toBeVisible();
     await expect(
-      currentSelection.getByText("Current work"),
+      currentSelection.getByText("story: implemented"),
     ).toBeVisible();
-    await expect(currentSelection.getByText("story: implemented")).toBeVisible();
     await expect(currentSelection.getByText("Active Story")).toBeVisible();
     await expect(
       currentSelection.getByText(
@@ -701,9 +703,15 @@ export const DashboardImprovementsSmoke = {
       ),
     ).toBeVisible();
     expect(summaryDetails).not.toBeNull();
-    expect(within(summaryDetails ?? canvasElement).queryByText("Work type")).toBeNull();
-    expect(within(summaryDetails ?? canvasElement).queryByText("State")).toBeNull();
-    expect(within(summaryDetails ?? canvasElement).queryByText("State node ID")).toBeNull();
+    expect(
+      within(summaryDetails ?? canvasElement).queryByText("Work type"),
+    ).toBeNull();
+    expect(
+      within(summaryDetails ?? canvasElement).queryByText("State"),
+    ).toBeNull();
+    expect(
+      within(summaryDetails ?? canvasElement).queryByText("State node ID"),
+    ).toBeNull();
     expect(currentSelection.queryByText("trace-active-story")).toBeNull();
     const traceDrilldownCard = await canvas.findByRole("article", {
       name: "Trace drill-down",
@@ -1070,10 +1078,8 @@ export const HeaderLocalizationVerification = {
     ).toBeVisible();
     await expect(await canvas.findByText("5/5")).toBeVisible();
     await expect(
-      within(localizedToolbar).getByRole("status", {
-        name: /事件流(正在连接|在线)/,
-      }),
-    ).toBeVisible();
+      within(localizedToolbar).queryByRole("status", { name: /事件流/ }),
+    ).toBeNull();
     await expect(
       within(localizedToolbar).queryByRole("button", { name: "返回当前刻度" }),
     ).toBeNull();
@@ -1084,9 +1090,12 @@ export const HeaderLocalizationVerification = {
     await userEvent.click(
       within(localizedToolbar).getByRole("button", { name: "导出 PNG" }),
     );
-    const dialog = await within(canvasElement.ownerDocument.body).findByRole("dialog", {
-      name: "导出工厂",
-    });
+    const dialog = await within(canvasElement.ownerDocument.body).findByRole(
+      "dialog",
+      {
+        name: "导出工厂",
+      },
+    );
     await expect(
       within(dialog).getByRole("button", { name: "取消" }),
     ).toBeVisible();
@@ -1094,9 +1103,12 @@ export const HeaderLocalizationVerification = {
       within(dialog).getByRole("button", { name: "导出 PNG" }),
     ).toBeVisible();
     await userEvent.click(within(dialog).getByRole("button", { name: "取消" }));
-    const localizedLanguageButton = within(localizedToolbar).getByRole("button", {
-      name: "切换语言",
-    });
+    const localizedLanguageButton = within(localizedToolbar).getByRole(
+      "button",
+      {
+        name: "切换语言",
+      },
+    );
     localizedLanguageButton.focus();
     await expect(localizedLanguageButton).toHaveFocus();
     await userEvent.click(localizedLanguageButton);
@@ -1105,7 +1117,9 @@ export const HeaderLocalizationVerification = {
         name: "English",
       }),
     );
-    const restoredToolbar = await canvas.findByRole("region", { name: "dashboard summary" });
+    const restoredToolbar = await canvas.findByRole("region", {
+      name: "dashboard summary",
+    });
     await expect(
       within(restoredToolbar).getByRole("button", { name: "Change language" }),
     ).toBeVisible();
@@ -1119,7 +1133,10 @@ export const LocalePropagationVerification = {
   tags: ["test"],
   parameters: {
     dashboardApi: {
-      timelineSnapshots: [historicalWorkOutcomeSnapshot, liveWorkOutcomeSnapshot],
+      timelineSnapshots: [
+        historicalWorkOutcomeSnapshot,
+        liveWorkOutcomeSnapshot,
+      ],
     },
   },
   render: () => <LocalePropagationStory />,

--- a/ui/src/App.timeline.test.tsx
+++ b/ui/src/App.timeline.test.tsx
@@ -124,25 +124,24 @@ describe("App timeline reconstruction flows", () => {
     const exportButton = within(toolbar).getByRole("button", {
       name: "Export PNG",
     });
-    const streamStatus = within(toolbar).getByRole("status", {
-      name: "Event stream connecting",
-    });
     const headerControls = Array.from(
       toolbar.querySelectorAll(
-        '[aria-label="Timeline tick"], [aria-label="Change language"], [aria-label="Export PNG"], [role="status"]',
+        '[aria-label="Timeline tick"], [aria-label="Change language"], [aria-label="Export PNG"]',
       ),
     );
 
-    expect(headerControls).toHaveLength(4);
-    expect(headerControls[0]).toBe(streamStatus);
-    expect(headerControls[1]).toBe(languageButton);
-    expect(headerControls[2]).toBe(slider);
-    expect(headerControls[3]).toBe(exportButton);
+    expect(headerControls).toHaveLength(3);
+    expect(headerControls[0]).toBe(languageButton);
+    expect(headerControls[1]).toBe(slider);
+    expect(headerControls[2]).toBe(exportButton);
     expect(within(toolbar).getByText("4/4")).toBeTruthy();
     expect(within(toolbar).queryByText(/Tick \d+ of \d+/)).toBeNull();
     expect(within(toolbar).getByText("Timeline tick").className).toContain(
       "sr-only",
     );
+    expect(
+      within(toolbar).queryByRole("status", { name: /Event stream/i }),
+    ).toBeNull();
   });
 
   it("renders totals and selection panels from the selected event tick", async () => {

--- a/ui/src/App.toolbar-locale.test.tsx
+++ b/ui/src/App.toolbar-locale.test.tsx
@@ -1,8 +1,15 @@
-import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { DASHBOARD_PAGE_HEADING_CLASS } from "./components/ui/dashboard-typography";
 import { useDashboardStreamStore } from "./features/dashboard/state";
 import * as factoryPngImportModule from "./features/import/lib/factory-png-import";
+import { currentNamedFactoryExportResponse } from "./testing/app-shell-export-test-utils";
 import {
   createFactoryImportValue,
   createFileDropTransfer,
@@ -11,7 +18,6 @@ import {
   renderApp,
   terminalSnapshot,
 } from "./testing/app-shell-test-utils";
-import { currentNamedFactoryExportResponse } from "./testing/app-shell-export-test-utils";
 
 describe("App shell locale and toolbar flows", () => {
   registerAppDashboardTestLifecycle();
@@ -158,16 +164,16 @@ describe("App shell locale and toolbar flows", () => {
 
     const heading = await screen.findByRole("heading", { name: "U" });
     const toolbar = screen.getByRole("region", { name: "dashboard summary" });
-    const streamStatus = screen.getByRole("status", {
-      name: "Event stream connecting",
-    });
     const exportButton = screen.getByRole("button", { name: "Export PNG" });
 
     expect(heading.className).toContain(DASHBOARD_PAGE_HEADING_CLASS);
-    expect(streamStatus.className).toContain("rounded-full");
-    expect(streamStatus.className).toContain("border");
+    expect(
+      within(toolbar).queryByRole("status", { name: /Event stream/i }),
+    ).toBeNull();
     expect(within(toolbar).queryByText("Factory state")).toBeNull();
-    expect(within(toolbar).queryByText(terminalSnapshot.factory_state)).toBeNull();
+    expect(
+      within(toolbar).queryByText(terminalSnapshot.factory_state),
+    ).toBeNull();
     expect(within(toolbar).queryByText("Loading factory events...")).toBeNull();
     expect(within(toolbar).queryByText("Export PNG")).toBeNull();
     expect(exportButton.getAttribute("aria-haspopup")).toBe("dialog");
@@ -181,10 +187,8 @@ describe("App shell locale and toolbar flows", () => {
     });
 
     expect(
-      within(toolbar).getByRole("status", {
-        name: "Event stream connecting",
-      }),
-    ).toBeTruthy();
+      within(toolbar).queryByRole("status", { name: /Event stream/i }),
+    ).toBeNull();
     expect(within(toolbar).queryByText("Factory state")).toBeNull();
     expect(within(toolbar).queryByText("Stream")).toBeNull();
     expect(within(toolbar).queryByText("Loading factory events...")).toBeNull();
@@ -201,10 +205,8 @@ describe("App shell locale and toolbar flows", () => {
 
     await waitFor(() => {
       expect(
-        within(toolbar).getByRole("status", {
-          name: "Event stream live",
-        }),
-      ).toBeTruthy();
+        within(toolbar).queryByRole("status", { name: /Event stream/i }),
+      ).toBeNull();
     });
     expect(
       within(toolbar).queryByText("Factory event stream connected."),
@@ -222,10 +224,8 @@ describe("App shell locale and toolbar flows", () => {
 
     await waitFor(() => {
       expect(
-        within(toolbar).getByRole("status", {
-          name: "Event stream offline",
-        }),
-      ).toBeTruthy();
+        within(toolbar).queryByRole("status", { name: /Event stream/i }),
+      ).toBeNull();
     });
     expect(
       within(toolbar).queryByText(

--- a/ui/src/components/ui/dashboard-action-button.tsx
+++ b/ui/src/components/ui/dashboard-action-button.tsx
@@ -2,11 +2,11 @@ import { forwardRef, type ReactNode } from "react";
 
 import { cn } from "../../lib/cn";
 import { Button, type ButtonProps } from "./button";
+import { DashboardIconButtonShell } from "./dashboard-icon-button-shell";
 
 const DASHBOARD_ACTION_BUTTON_BASE_CLASS =
   "relative shrink-0 rounded-lg border text-sm font-semibold";
 const DASHBOARD_ACTION_BUTTON_SIZE_CLASS = {
-  icon: "h-10 w-10 px-0 py-0",
   text: "min-h-10 px-3.5 py-2",
 };
 const DASHBOARD_ACTION_BUTTON_CONTENT_CLASS =
@@ -38,22 +38,8 @@ export const DashboardActionButton = forwardRef<
   },
   ref,
 ) {
-  return (
-    <Button
-      aria-busy={executing || undefined}
-      className={cn(
-        DASHBOARD_ACTION_BUTTON_BASE_CLASS,
-        iconOnly
-          ? DASHBOARD_ACTION_BUTTON_SIZE_CLASS.icon
-          : DASHBOARD_ACTION_BUTTON_SIZE_CLASS.text,
-        className,
-      )}
-      disabled={disabled || executing}
-      ref={ref}
-      size={iconOnly ? "icon" : "sm"}
-      tone={tone}
-      {...props}
-    >
+  const content = (
+    <>
       <span
         className={cn(
           DASHBOARD_ACTION_BUTTON_CONTENT_CLASS,
@@ -70,6 +56,39 @@ export const DashboardActionButton = forwardRef<
           <DashboardActionButtonSpinner />
         </span>
       ) : null}
+    </>
+  );
+
+  if (iconOnly) {
+    return (
+      <DashboardIconButtonShell
+        aria-busy={executing || undefined}
+        className={cn(DASHBOARD_ACTION_BUTTON_BASE_CLASS, className)}
+        disabled={disabled || executing}
+        ref={ref}
+        tone={tone}
+        {...props}
+      >
+        {content}
+      </DashboardIconButtonShell>
+    );
+  }
+
+  return (
+    <Button
+      aria-busy={executing || undefined}
+      className={cn(
+        DASHBOARD_ACTION_BUTTON_BASE_CLASS,
+        DASHBOARD_ACTION_BUTTON_SIZE_CLASS.text,
+        className,
+      )}
+      disabled={disabled || executing}
+      ref={ref}
+      size="sm"
+      tone={tone}
+      {...props}
+    >
+      {content}
     </Button>
   );
 });

--- a/ui/src/components/ui/dashboard-icon-button-shell.tsx
+++ b/ui/src/components/ui/dashboard-icon-button-shell.tsx
@@ -1,0 +1,31 @@
+import { forwardRef } from "react";
+
+import { cn } from "../../lib/cn";
+import { Button, type ButtonProps } from "./button";
+
+const DASHBOARD_ICON_BUTTON_SHELL_BASE_CLASS = "relative shrink-0";
+const DASHBOARD_ICON_BUTTON_SHELL_SIZE_CLASS = "h-10 w-10 rounded-lg";
+
+export interface DashboardIconButtonShellProps extends Omit<ButtonProps, "size"> {}
+
+export const DashboardIconButtonShell = forwardRef<
+  HTMLButtonElement,
+  DashboardIconButtonShellProps
+>(function DashboardIconButtonShell(
+  { className, tone = "outline", ...props },
+  ref,
+) {
+  return (
+    <Button
+      className={cn(
+        DASHBOARD_ICON_BUTTON_SHELL_BASE_CLASS,
+        DASHBOARD_ICON_BUTTON_SHELL_SIZE_CLASS,
+        className,
+      )}
+      ref={ref}
+      size="icon"
+      tone={tone}
+      {...props}
+    />
+  );
+});

--- a/ui/src/components/ui/index.ts
+++ b/ui/src/components/ui/index.ts
@@ -6,6 +6,7 @@ export * from "./chart";
 export * from "./collapsible";
 export * from "./dashboard-action-button";
 export * from "./dashboard-shell";
+export * from "./dashboard-icon-button-shell";
 export * from "./dashboard-status-pill";
 export * from "./dashboard-typography";
 export * from "./data-table";

--- a/ui/src/features/bento/components/agent-bento.test.tsx
+++ b/ui/src/features/bento/components/agent-bento.test.tsx
@@ -449,9 +449,12 @@ describe("AgentBentoLayout", () => {
 
     expect(header?.className).toContain("min-h-11");
     expect(header?.className).toContain("px-3");
-    expect(body?.className).toContain("p-3");
+    expect(body?.className).toContain("px-3");
+    expect(body?.className).toContain("pt-3");
+    expect(body?.className).toContain("pb-4");
     expect(body?.className).toContain("gap-2");
-    expect(handle.className).toContain("size-8");
-    expect(handle.className).toContain("bg-transparent");
+    expect(handle.className).toContain("h-10");
+    expect(handle.className).toContain("w-10");
+    expect(handle.className).toContain("bg-af-surface-raised");
   });
 });

--- a/ui/src/features/bento/components/agent-bento.tsx
+++ b/ui/src/features/bento/components/agent-bento.tsx
@@ -6,6 +6,7 @@ import "react-grid-layout/css/styles.css";
 import "react-resizable/css/styles.css";
 
 import { cn } from "../../../lib/cn";
+import { DashboardIconButtonShell } from "../../../components/ui/dashboard-icon-button-shell";
 import { DashboardPanelShell } from "../../../components/ui/dashboard-shell";
 import {
   DASHBOARD_BODY_TEXT_CLASS,
@@ -79,17 +80,14 @@ const BENTO_CARD_HEADER_TOOLS_CLASS =
   "flex min-w-0 shrink-0 items-center gap-2";
 const BENTO_CARD_HEADER_TOOLS_COMPACT_CLASS = "gap-1.5";
 const BENTO_DRAG_HANDLE_CLASS =
-  "inline-grid size-9 shrink-0 cursor-grab place-items-center rounded-lg border border-af-border bg-af-surface-raised text-af-text-muted outline-af-accent transition-colors hover:border-af-border-strong hover:bg-af-overlay hover:text-af-text focus-visible:outline-2 focus-visible:outline-offset-2 active:cursor-grabbing";
-const BENTO_DRAG_HANDLE_COMPACT_CLASS =
-  "size-8 rounded-md border-af-border bg-transparent text-af-text-subtle hover:border-af-border-strong hover:bg-af-overlay hover:text-af-text";
+  "cursor-grab text-af-text-muted hover:text-af-text active:cursor-grabbing";
 const BENTO_CARD_BODY_CLASS = cn(
-  "grid h-full min-h-0 flex-1 gap-2.5 overflow-auto p-3.5 [&_p]:m-0",
+  "grid h-full min-h-0 flex-1 gap-2.5 overflow-auto px-3.5 pt-3.5 pb-4 [&>*]:pb-1 [&_p]:m-0",
   DASHBOARD_BODY_TEXT_CLASS,
 );
-const BENTO_CARD_BODY_COMPACT_CLASS = "gap-2 p-3";
+const BENTO_CARD_BODY_COMPACT_CLASS = "gap-2 px-3 pt-3 pb-4 [&>*]:pb-1";
 
 interface AgentBentoDragHandleProps {
-  compact?: boolean;
   title: string;
 }
 
@@ -334,7 +332,7 @@ export function AgentBentoCard({
           )}
         >
           {headerAction}
-          <AgentBentoDragHandle compact={compactChrome} title={title} />
+          <AgentBentoDragHandle title={title} />
         </div>
       </header>
       <div className={cardBodyClassName}>{children}</div>
@@ -343,18 +341,14 @@ export function AgentBentoCard({
 }
 
 export function AgentBentoDragHandle({
-  compact = false,
   title,
 }: AgentBentoDragHandleProps) {
   return (
-    <button
+    <DashboardIconButtonShell
       aria-label={`Move ${title}`}
-      className={cn(
-        BENTO_DRAG_HANDLE_CLASS,
-        compact && BENTO_DRAG_HANDLE_COMPACT_CLASS,
-      )}
+      className={BENTO_DRAG_HANDLE_CLASS}
       data-bento-drag-handle="true"
-      type="button"
+      tone="outline"
     >
       <svg
         aria-hidden="true"
@@ -372,6 +366,6 @@ export function AgentBentoDragHandle({
           strokeWidth="1.7"
         />
       </svg>
-    </button>
+    </DashboardIconButtonShell>
   );
 }

--- a/ui/src/features/bento/components/dashboard-bento.test.tsx
+++ b/ui/src/features/bento/components/dashboard-bento.test.tsx
@@ -383,7 +383,8 @@ describe("DashboardBento", () => {
       name: "Remove Work totals widget from dashboard",
     });
 
-    expect(workTotalsRemoveButton.className).toContain("size-8");
+    expect(workTotalsRemoveButton.className).toContain("h-10");
+    expect(workTotalsRemoveButton.className).toContain("w-10");
     expect(workTotalsRemoveButton.className).toContain(
       "focus-visible:ring-2",
     );

--- a/ui/src/features/bento/components/dashboard-widget-remove-button.test.tsx
+++ b/ui/src/features/bento/components/dashboard-widget-remove-button.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { DashboardWidgetRemoveButton } from "./dashboard-widget-remove-button";
 
 describe("DashboardWidgetRemoveButton", () => {
-  it("renders a shared destructive compact control with a dashboard-specific label", () => {
+  it("renders a shared dashboard control with a dashboard-specific label", () => {
     const onClick = vi.fn();
     render(
       <DashboardWidgetRemoveButton
@@ -16,10 +16,11 @@ describe("DashboardWidgetRemoveButton", () => {
       name: "Remove Work totals widget from dashboard",
     });
 
-    expect(button.className).toContain("size-8");
+    expect(button.className).toContain("h-10");
+    expect(button.className).toContain("w-10");
     expect(button.className).toContain("focus-visible:ring-2");
-    expect(button.className).toContain("border-af-danger");
-    expect(button.className).toContain("bg-af-danger");
+    expect(button.className).toContain("border-af-border");
+    expect(button.className).toContain("bg-af-surface-raised");
 
     fireEvent.click(button);
 

--- a/ui/src/features/bento/components/dashboard-widget-remove-button.tsx
+++ b/ui/src/features/bento/components/dashboard-widget-remove-button.tsx
@@ -9,7 +9,7 @@ export interface DashboardWidgetRemoveButtonProps {
   widgetTitle: string;
 }
 
-export function DashboardWidgetRemoveButton({
+export function  DashboardWidgetRemoveButton({
   locale,
   onClick,
   widgetTitle,
@@ -19,10 +19,9 @@ export function DashboardWidgetRemoveButton({
   return (
     <DashboardActionButton
       aria-label={messages.removeWidgetLabel(widgetTitle)}
-      className="size-8 rounded-md"
       iconOnly
       onClick={onClick}
-      tone="destructive"
+      tone="outline"
     >
       <svg
         aria-hidden="true"

--- a/ui/src/features/bento/components/inline-add-widget-card.tsx
+++ b/ui/src/features/bento/components/inline-add-widget-card.tsx
@@ -108,7 +108,7 @@ export function InlineAddWidgetCard({
               </PopoverTrigger>
             </div>
             <div className={INLINE_ADD_WIDGET_DRAG_HANDLE_WRAP_CLASS}>
-              <AgentBentoDragHandle compact title={messages.title} />
+              <AgentBentoDragHandle title={messages.title} />
             </div>
           </div>
         </div>

--- a/ui/src/features/current-selection/components/current-selection-detail-layout.test.tsx
+++ b/ui/src/features/current-selection/components/current-selection-detail-layout.test.tsx
@@ -1,11 +1,13 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
-
-import { CurrentSelectionLocaleProvider } from "./current-selection-locale";
-import { SelectionDetailLayout } from "./current-selection-detail-layout";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import {
   resetSelectionHistoryStore,
   useSelectionHistoryStore,
 } from "../state/selectionHistoryStore";
+import {
+  CurrentSelectionHeaderActionProvider,
+  SelectionDetailLayout,
+} from "./current-selection-detail-layout";
+import { CurrentSelectionLocaleProvider } from "./current-selection-locale";
 
 describe("SelectionDetailLayout", () => {
   beforeEach(() => {
@@ -31,16 +33,19 @@ describe("SelectionDetailLayout", () => {
     ).toBeTruthy();
     expect(
       screen.getByRole("button", { name: "Undo selection" }).textContent,
-    ).toBe("Undo");
+    ).toBe("");
     expect(
       screen.getByRole("button", { name: "Redo selection" }).textContent,
-    ).toBe("Redo");
+    ).toBe("");
     expect(
       screen.getByRole("button", { name: "Undo selection" }).className,
     ).toContain("rounded-lg");
     expect(
       screen.getByRole("button", { name: "Undo selection" }).className,
-    ).toContain("min-h-10");
+    ).toContain("h-10");
+    expect(
+      screen.getByRole("button", { name: "Undo selection" }).className,
+    ).toContain("w-10");
   });
 
   it("renders localized history control labels and accessible names from the requested locale", () => {
@@ -56,10 +61,10 @@ describe("SelectionDetailLayout", () => {
     expect(screen.getByRole("heading", { name: "当前选择" })).toBeTruthy();
     expect(
       screen.getByRole("button", { name: "撤销所选内容" }).textContent,
-    ).toBe("撤销");
+    ).toBe("");
     expect(
       screen.getByRole("button", { name: "重做所选内容" }).textContent,
-    ).toBe("重做");
+    ).toBe("");
   });
 
   it("keeps undo and redo history behavior unchanged apart from the localized copy source", () => {
@@ -117,5 +122,37 @@ describe("SelectionDetailLayout", () => {
         .getByRole("button", { name: "重做所选内容" })
         .hasAttribute("disabled"),
     ).toBe(true);
+  });
+
+  it("orders undo, redo, detail actions, then shared header actions", () => {
+    render(
+      <CurrentSelectionHeaderActionProvider
+        headerAction={<button type="button">Remove card</button>}
+      >
+        <SelectionDetailLayout
+          headerAction={<button type="button">Save changes</button>}
+        >
+          <p>Body</p>
+        </SelectionDetailLayout>
+      </CurrentSelectionHeaderActionProvider>,
+    );
+
+    const actionSection = screen
+      .getByRole("button", { name: "Undo selection" })
+      .closest("[data-dashboard-action-row-section='actions']");
+
+    expect(actionSection).toBeTruthy();
+    const buttons = within(actionSection as HTMLElement).getAllByRole("button");
+
+    expect(
+      buttons.map(
+        (button) => button.getAttribute("aria-label") ?? button.textContent,
+      ),
+    ).toEqual([
+      "Undo selection",
+      "Redo selection",
+      "Save changes",
+      "Remove card",
+    ]);
   });
 });

--- a/ui/src/features/current-selection/components/current-selection-detail-layout.tsx
+++ b/ui/src/features/current-selection/components/current-selection-detail-layout.tsx
@@ -2,17 +2,12 @@ import type { ReactNode } from "react";
 import { createContext, useContext } from "react";
 
 import { DETAIL_CARD_WIDE_CLASS } from "../../../components/dashboard/widget-board";
-import {
-  DashboardActionButton,
-  DashboardActionRow,
-  DashboardWidgetFrame,
-} from "../../../components/ui";
+import { DashboardWidgetFrame } from "../../../components/ui";
+import { useSelectionHistoryStore } from "../state/selectionHistoryStore";
+import { CurrentSelectionHeaderActions } from "./current-selection-header-actions";
 import { useCurrentSelectionShellMessages } from "./current-selection-locale";
 import type { SelectionDetailLayoutProps } from "./detail-card-types";
-import { useSelectionHistoryStore } from "../state/selectionHistoryStore";
 
-const SELECTION_HISTORY_ACTIONS_CLASS = "justify-end";
-const SELECTION_HISTORY_ACTIONS_GROUP_CLASS = "justify-end";
 const CurrentSelectionHeaderActionContext = createContext<ReactNode>(null);
 
 export function CurrentSelectionHeaderActionProvider({
@@ -45,31 +40,19 @@ export function SelectionDetailLayout({
     <DashboardWidgetFrame
       className={DETAIL_CARD_WIDE_CLASS}
       headerAction={
-        <DashboardActionRow
-          actions={
+        <CurrentSelectionHeaderActions
+          canRedo={canRedo}
+          canUndo={canUndo}
+          headerActions={
             <>
-              {sharedHeaderAction}
               {headerAction}
-              <DashboardActionButton
-                aria-label={messages.undoAccessibleLabel}
-                disabled={!canUndo}
-                onClick={() => undoSelection()}
-                type="button"
-              >
-                {messages.undoLabel}
-              </DashboardActionButton>
-              <DashboardActionButton
-                aria-label={messages.redoAccessibleLabel}
-                disabled={!canRedo}
-                onClick={() => redoSelection()}
-                type="button"
-              >
-                {messages.redoLabel}
-              </DashboardActionButton>
+              {sharedHeaderAction}
             </>
           }
-          actionsClassName={SELECTION_HISTORY_ACTIONS_GROUP_CLASS}
-          className={SELECTION_HISTORY_ACTIONS_CLASS}
+          onRedo={() => redoSelection()}
+          onUndo={() => undoSelection()}
+          redoLabel={messages.redoAccessibleLabel}
+          undoLabel={messages.undoAccessibleLabel}
         />
       }
       title={messages.title}

--- a/ui/src/features/current-selection/components/current-selection-header-actions.tsx
+++ b/ui/src/features/current-selection/components/current-selection-header-actions.tsx
@@ -1,0 +1,110 @@
+import type { ReactNode } from "react";
+
+import {
+  DashboardActionButton,
+  DashboardActionRow,
+} from "../../../components/ui";
+
+const CURRENT_SELECTION_HEADER_ACTIONS_CLASS = "justify-end";
+const CURRENT_SELECTION_HEADER_ACTIONS_GROUP_CLASS = "justify-end";
+const CURRENT_SELECTION_ICON_CLASS = "size-4";
+
+export function CurrentSelectionHeaderActions({
+  canRedo,
+  canUndo,
+  headerActions,
+  onRedo,
+  onUndo,
+  redoLabel,
+  undoLabel,
+}: {
+  canRedo: boolean;
+  canUndo: boolean;
+  headerActions?: ReactNode;
+  onRedo: () => void;
+  onUndo: () => void;
+  redoLabel: string;
+  undoLabel: string;
+}) {
+  return (
+    <DashboardActionRow
+      actions={
+        <>
+          <DashboardActionButton
+            aria-label={undoLabel}
+            disabled={!canUndo}
+            iconOnly
+            onClick={onUndo}
+            type="button"
+          >
+            <UndoIcon />
+          </DashboardActionButton>
+          <DashboardActionButton
+            aria-label={redoLabel}
+            disabled={!canRedo}
+            iconOnly
+            onClick={onRedo}
+            type="button"
+          >
+            <RedoIcon />
+          </DashboardActionButton>
+          {headerActions}
+        </>
+      }
+      actionsClassName={CURRENT_SELECTION_HEADER_ACTIONS_GROUP_CLASS}
+      className={CURRENT_SELECTION_HEADER_ACTIONS_CLASS}
+    />
+  );
+}
+
+function UndoIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className={CURRENT_SELECTION_ICON_CLASS}
+      fill="none"
+      viewBox="0 0 16 16"
+    >
+      <path
+        d="M6.5 3 2.5 7l4 4"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.5"
+      />
+      <path
+        d="M3 7h6.25a3.75 3.75 0 1 1 0 7.5H7.5"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.5"
+      />
+    </svg>
+  );
+}
+
+function RedoIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className={CURRENT_SELECTION_ICON_CLASS}
+      fill="none"
+      viewBox="0 0 16 16"
+    >
+      <path
+        d="m9.5 3 4 4-4 4"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.5"
+      />
+      <path
+        d="M13 7H6.75a3.75 3.75 0 1 0 0 7.5H8.5"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.5"
+      />
+    </svg>
+  );
+}

--- a/ui/src/features/current-selection/components/workstation-save-controls.tsx
+++ b/ui/src/features/current-selection/components/workstation-save-controls.tsx
@@ -1,11 +1,11 @@
 import { DashboardMutationDialog } from "../../../components/dashboard";
-import { Button } from "../../../components/ui";
+import { Button, DashboardActionButton } from "../../../components/ui";
+import { formatEditableOverwriteFieldLabels } from "../editing/editable-workstation-overwrite-fields";
+import { getWorkstationDetailMessages } from "../messages";
 import type {
   EditableWorkstationOverwriteField,
   EditableWorkstationSaveState,
 } from "./detail-card-types";
-import { formatEditableOverwriteFieldLabels } from "../editing/editable-workstation-overwrite-fields";
-import { getWorkstationDetailMessages } from "../messages";
 
 export function EditableWorkstationSaveHeaderAction({
   canSave,
@@ -21,20 +21,24 @@ export function EditableWorkstationSaveHeaderAction({
   const messages = getWorkstationDetailMessages(locale);
 
   return (
-    <Button
+    <DashboardActionButton
+      aria-label={
+        saveState.status === "submitting"
+          ? messages.editableConfigurationSaveBusyAction
+          : messages.editableConfigurationSaveAction
+      }
       aria-expanded={
         saveState.status === "confirming" || saveState.status === "submitting"
       }
       aria-haspopup="dialog"
       disabled={!canSave}
+      executing={saveState.status === "submitting"}
+      iconOnly
       onClick={onClick}
-      size="sm"
       type="button"
     >
-      {saveState.status === "submitting"
-        ? messages.editableConfigurationSaveBusyAction
-        : messages.editableConfigurationSaveAction}
-    </Button>
+      <SaveIcon />
+    </DashboardActionButton>
   );
 }
 
@@ -90,5 +94,30 @@ export function EditableWorkstationSaveDialog({
     >
       <div />
     </DashboardMutationDialog>
+  );
+}
+
+function SaveIcon() {
+  return (
+    <svg aria-hidden="true" className="size-4" fill="none" viewBox="0 0 16 16">
+      <path
+        d="M3 2.75h8.5L13.25 4.5v8.75H3z"
+        stroke="currentColor"
+        strokeLinejoin="round"
+        strokeWidth="1.5"
+      />
+      <path
+        d="M5 2.75v3h5v-3"
+        stroke="currentColor"
+        strokeLinejoin="round"
+        strokeWidth="1.5"
+      />
+      <path
+        d="M5.25 13.25v-4h5.5v4"
+        stroke="currentColor"
+        strokeLinejoin="round"
+        strokeWidth="1.5"
+      />
+    </svg>
   );
 }

--- a/ui/src/features/header/components/dashboard-header.test.tsx
+++ b/ui/src/features/header/components/dashboard-header.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   act,
   fireEvent,
@@ -5,7 +6,6 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { FACTORY_EVENT_TYPES, type FactoryEvent } from "../../../api/events";
@@ -15,17 +15,19 @@ import { useDashboardStreamStore } from "../../dashboard/state/dashboardStreamSt
 import { getExportDialogMessages } from "../../export/messages/export-dialog";
 import { useExportDialogStore } from "../../export/state/exportDialogStore";
 import { useFactoryTimelineStore } from "../../timeline/state/factoryTimelineStore";
-import { DashboardHeader } from "./dashboard-header";
 import { getHeaderControlsMessages } from "../messages/header-controls";
+import { DashboardHeader } from "./dashboard-header";
 
 vi.mock("./dashboard-session-tabs", () => ({
   DashboardSessionTabs: ({ locale }: { locale: string }) => (
     <div data-testid={`dashboard-session-tabs-${locale}`}>
       <div>Dashboard session tabs {locale}</div>
-      <button aria-label={getHeaderControlsMessages(locale).openSessionButtonLabel} type="button">
+      <button
+        aria-label={getHeaderControlsMessages(locale).openSessionButtonLabel}
+        type="button"
+      >
         +
       </button>
-      <div role="status">{getHeaderControlsMessages(locale).streamStatusConnectingLabel}</div>
     </div>
   ),
 }));
@@ -132,10 +134,7 @@ describe("DashboardHeader", () => {
     const globalActions = screen.getByRole("group", {
       name: headerMessages.globalHeaderActionsLabel,
     });
-    const streamStatus = screen.getByRole("status", {
-      name: headerMessages.streamStatusConnectingLabel,
-    });
-    const actionRow = streamStatus.parentElement?.parentElement;
+    const actionRow = globalActions.parentElement?.parentElement;
     const actionRowSections = toolbar.querySelectorAll(
       "[data-dashboard-action-row-section]",
     );
@@ -156,26 +155,22 @@ describe("DashboardHeader", () => {
       "items-stretch",
     );
     expect(heading.textContent).toContain("U");
-    expect(toolbar.firstElementChild?.firstElementChild?.firstElementChild).toBe(
-      heading,
-    );
+    expect(
+      toolbar.firstElementChild?.firstElementChild?.firstElementChild,
+    ).toBe(heading);
     expect(heading.className).toContain("pb-2");
     expect(heading.firstElementChild?.className).toContain("items-center");
     expect(globalActions.className).toContain("self-end");
     expect(actionRow?.className).toContain("justify-end");
     expect(actionRow?.className).toContain("max-md:w-full");
-    expect(actionRowSections).toHaveLength(2);
+    expect(actionRowSections).toHaveLength(1);
     expect(
       actionRowSections[0]?.getAttribute("data-dashboard-action-row-section"),
-    ).toBe("statuses");
-    expect(
-      actionRowSections[1]?.getAttribute("data-dashboard-action-row-section"),
     ).toBe("actions");
-    expect(actionRowSections[0]?.contains(streamStatus)).toBe(true);
-    expect(actionRowSections[1]?.contains(languageButton)).toBe(true);
-    expect(
-      heading.firstElementChild?.firstElementChild?.className,
-    ).toContain("h-12");
+    expect(actionRowSections[0]?.contains(languageButton)).toBe(true);
+    expect(heading.firstElementChild?.firstElementChild?.className).toContain(
+      "h-12",
+    );
     expect(slider.closest("div")?.parentElement?.className).toContain(
       "rounded-t-2xl",
     );
@@ -195,15 +190,14 @@ describe("DashboardHeader", () => {
     expect(controls[1]).toBe(languageButton);
     expect(controls[2]).toBe(slider);
     expect(controls[3]).toBe(exportButton);
-    expect(streamStatus.textContent).toBe(
-      headerMessages.streamStatusConnectingLabel,
-    );
-    expect(streamStatus.className).toContain("rounded-full");
     expect(globalActions.contains(languageButton)).toBe(true);
     expect(globalActions.contains(openSessionButton)).toBe(false);
     expect(globalActions.contains(exportButton)).toBe(false);
-    expect(actionRowSections[1]?.contains(exportButton)).toBe(false);
-    expect(globalActions.compareDocumentPosition(slider) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(actionRowSections[0]?.contains(exportButton)).toBe(false);
+    expect(
+      globalActions.compareDocumentPosition(slider) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     expect(languageButton.dataset.dashboardHeaderAction).toBe("neutral");
     expect(languageButton.getAttribute("aria-haspopup")).toBe("menu");
     expect(languageButton.getAttribute("aria-expanded")).toBe("false");
@@ -264,9 +258,13 @@ describe("DashboardHeader", () => {
         name: headerMessages.languageMenuButtonLabel,
       }).textContent,
     ).toBe("");
-    expect(screen.queryByText(headerMessages.openSessionButtonLabel)).toBeNull();
+    expect(
+      screen.queryByText(headerMessages.openSessionButtonLabel),
+    ).toBeNull();
     expect(screen.queryByText(exportMessages.triggerLabel)).toBeNull();
-    expect(screen.queryByText(headerMessages.languageMenuButtonLabel)).toBeNull();
+    expect(
+      screen.queryByText(headerMessages.languageMenuButtonLabel),
+    ).toBeNull();
     expect(screen.queryByText(headerMessages.sliderLabel)?.className).toContain(
       "sr-only",
     );
@@ -290,9 +288,7 @@ describe("DashboardHeader", () => {
     expect(
       screen.getByRole("region", { name: messages.dashboardSummaryLabel }),
     ).toBeTruthy();
-    expect(
-      screen.getByRole("heading"),
-    ).toBeTruthy();
+    expect(screen.getByRole("heading")).toBeTruthy();
     expect(screen.getByText(messages.sliderLabel).className).toContain(
       "sr-only",
     );
@@ -304,8 +300,8 @@ describe("DashboardHeader", () => {
     ).toBeNull();
     expect(screen.getByText("Dashboard session tabs zh-CN")).toBeTruthy();
     expect(
-      screen.getByRole("status", { name: messages.streamStatusOfflineLabel }),
-    ).toBeTruthy();
+      screen.queryByRole("status", { name: messages.streamStatusOfflineLabel }),
+    ).toBeNull();
   });
 
   it("opens and closes the locale menu through keyboard and dismissal events", async () => {

--- a/ui/src/features/header/components/dashboard-header.tsx
+++ b/ui/src/features/header/components/dashboard-header.tsx
@@ -6,32 +6,25 @@ import {
   useRef,
   useState,
 } from "react";
-
-import { cn } from "../../../lib/cn";
+import { DashboardActionRow } from "../../../components/ui";
 import { DASHBOARD_PANEL_SHELL_CLASS } from "../../../components/ui/dashboard-shell";
-import {
-  DASHBOARD_PAGE_HEADING_CLASS,
-} from "../../../components/ui/dashboard-typography";
-import {
-  DashboardActionRow,
-  DashboardStatusPill,
-} from "../../../components/ui";
+import { DASHBOARD_PAGE_HEADING_CLASS } from "../../../components/ui/dashboard-typography";
 import {
   getNativeLanguageLabel,
   SUPPORTED_LOCALES,
   type SupportedLocale,
   useAppLocale,
 } from "../../../i18n";
-import { useDashboardStreamStore } from "../../dashboard/state/dashboardStreamStore";
+import { cn } from "../../../lib/cn";
 import { getExportDialogMessages } from "../../export/messages/export-dialog";
 import { useExportDialogStore } from "../../export/state/exportDialogStore";
+import { useDashboardSessionTabsState } from "../hooks/use-dashboard-session-tabs-state";
+import { sessionStreamToggleLabel } from "../lib/dashboard-session-tabs-utils";
+import { getHeaderControlsMessages } from "../messages/header-controls";
 import { DashboardBrandLockup } from "./dashboard-brand-lockup";
 import { DashboardHeaderActionButton } from "./dashboard-header-action-button";
 import { DashboardSessionTabs } from "./dashboard-session-tabs";
 import { TickSliderControl } from "./tick-slider-control";
-import { sessionStreamToggleLabel } from "../lib/dashboard-session-tabs-utils";
-import { getHeaderControlsMessages } from "../messages/header-controls";
-import { useDashboardSessionTabsState } from "../hooks/use-dashboard-session-tabs-state";
 
 const DASHBOARD_TOOLBAR_CLASS = cn(
   DASHBOARD_PANEL_SHELL_CLASS,
@@ -75,7 +68,6 @@ export interface DashboardHeaderProps {
 export function DashboardHeader({ locale }: DashboardHeaderProps) {
   const { locale: resolvedLocale, setLocale } = useAppLocale(locale);
   const sessionTabsState = useDashboardSessionTabsState();
-  const streamStatus = useDashboardStreamStore((state) => state.streamState.status);
   const isExportDialogOpen = useExportDialogStore(
     (state) => state.isExportDialogOpen,
   );
@@ -120,15 +112,6 @@ export function DashboardHeader({ locale }: DashboardHeaderProps) {
             }
             actionsClassName={DASHBOARD_HEADER_ACTION_ROW_ACTIONS_CLASS}
             className={DASHBOARD_HEADER_ACTION_ROW_CLASS}
-            statuses={
-              <DashboardStatusPill
-                aria-label={streamStatusLabel(streamStatus, headerMessages)}
-                role="status"
-                tone={streamStatusTone(streamStatus)}
-              >
-                {streamStatusLabel(streamStatus, headerMessages)}
-              </DashboardStatusPill>
-            }
           />
         </div>
         <div className={DASHBOARD_SECONDARY_ROW_CLASS}>
@@ -192,44 +175,13 @@ export function DashboardHeader({ locale }: DashboardHeaderProps) {
   );
 }
 
-function streamStatusLabel(
-  status: ReturnType<typeof useDashboardStreamStore.getState>["streamState"]["status"],
-  messages: ReturnType<typeof getHeaderControlsMessages>,
-) {
-  if (status === "live") {
-    return messages.streamStatusLiveLabel;
-  }
-  if (status === "offline") {
-    return messages.streamStatusOfflineLabel;
-  }
-
-  return messages.streamStatusConnectingLabel;
-}
-
-function streamStatusTone(
-  status: ReturnType<typeof useDashboardStreamStore.getState>["streamState"]["status"],
-) {
-  if (status === "live") {
-    return "active";
-  }
-  if (status === "offline") {
-    return "danger";
-  }
-
-  return "neutral";
-}
-
 function resolveLanguageSwitcherValue(locale: string): SupportedLocale {
   return SUPPORTED_LOCALES.includes(locale as SupportedLocale)
     ? (locale as SupportedLocale)
     : "en";
 }
 
-function SessionStreamToggleIcon({
-  paused,
-}: {
-  paused: boolean;
-}) {
+function SessionStreamToggleIcon({ paused }: { paused: boolean }) {
   return (
     <svg
       aria-hidden="true"
@@ -510,8 +462,9 @@ function moveLocaleMenuFocus(
   }
 
   const items = Array.from(
-    menuRef.current?.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]') ??
-      [],
+    menuRef.current?.querySelectorAll<HTMLButtonElement>(
+      '[role="menuitemradio"]',
+    ) ?? [],
   );
   if (items.length === 0) {
     return;

--- a/ui/src/features/header/components/dashboard-session-tabs.tsx
+++ b/ui/src/features/header/components/dashboard-session-tabs.tsx
@@ -25,10 +25,11 @@ import {
   useDashboardSessionTabsState,
 } from "../hooks/use-dashboard-session-tabs-state";
 
-const SESSION_TABS_SHELL_CLASS = "grid min-w-0 w-full flex-1 gap-2";
-const SESSION_TABS_ROW_CLASS = "flex min-w-0 w-full items-stretch overflow-visible";
+const SESSION_TABS_SHELL_CLASS = "grid min-w-0 max-w-full flex-1 gap-2";
+const SESSION_TABS_ROW_CLASS =
+  "flex min-w-0 max-w-full items-stretch gap-1 overflow-visible";
 const SESSION_TAB_LIST_CLASS =
-  "flex min-w-0 flex-1 items-end h-full gap-1 overflow-x-visible overflow-y-visible ";
+  "flex min-w-0 items-left h-full gap-1 overflow-x-visible overflow-y-visible";
 const SESSION_TAB_ITEM_CLASS =
   "group relative flex min-h-0 h-full min-w-0 shrink-0 items-stretch self-stretch transition-colors";
 const SESSION_TAB_BUTTON_CLASS =
@@ -280,7 +281,7 @@ function SessionTabsContent({
 
   return (
     <>
-      <nav aria-label={messages.sessionTabsLabel} className="min-w-0 flex-1 overflow-hidden">
+      <nav aria-label={messages.sessionTabsLabel} className="min-w-0 overflow-visible">
         <div
           aria-orientation="horizontal"
           className={SESSION_TAB_LIST_CLASS}

--- a/ui/src/features/submit-work/components/submit-work-card.tsx
+++ b/ui/src/features/submit-work/components/submit-work-card.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactNode } from "react";
 
 import {
   Button,
+  DashboardIconButtonShell,
   DashboardWidgetFrame,
   Input,
   Popover,
@@ -74,10 +75,11 @@ export interface SubmitWorkCardProps {
   widgetId?: string;
 }
 
-const FORM_CLASS = "grid h-full min-h-0 gap-4";
+const FORM_CLASS = "grid h-full min-h-0 grid-rows-[minmax(0,1fr)_auto] gap-4";
+const FORM_FIELDS_CLASS = "grid min-h-0 content-start gap-4 overflow-y-auto pb-2 pr-1";
 const FIELD_GROUP_CLASS = "grid gap-2";
 const FIELD_LABEL_CLASS = DASHBOARD_SUPPORTING_LABEL_CLASS;
-const ACTION_ROW_CLASS = "mt-auto flex items-start gap-3";
+const ACTION_ROW_CLASS = "flex items-start gap-3";
 const HELP_TEXT_CLASS = cn(
   "max-w-xl leading-relaxed text-af-text-muted",
   DASHBOARD_SUPPORTING_TEXT_CLASS,
@@ -87,7 +89,7 @@ const VALIDATION_TEXT_CLASS = cn(
   DASHBOARD_SUPPORTING_TEXT_CLASS,
 );
 const ITEM_SHELL_CLASS =
-  "grid gap-3 rounded-lg border border-af-border-subtle bg-af-panel p-3";
+  "grid gap-3 rounded-lg border-af-border border bg-af-panel p-3";
 const STATUS_TONE_CLASS_BY_KIND: Record<SubmitWorkStatus["kind"], string> = {
   error: "text-af-danger-text",
   guidance: "text-af-text-subtle",
@@ -155,85 +157,87 @@ export function SubmitWorkCard({
           onSubmit();
         }}
       >
-        <div className={FIELD_GROUP_CLASS}>
-          <label className={FIELD_LABEL_CLASS} htmlFor={workTypeID}>
-            {messages.workTypeLabel}
-          </label>
-          <Select
-            aria-describedby={
-              validationErrors?.workTypeName ? workTypeErrorID : undefined
-            }
-            aria-invalid={validationErrors?.workTypeName ? "true" : undefined}
-            className={DASHBOARD_BODY_TEXT_CLASS}
-            disabled={controlsDisabled}
-            id={workTypeID}
-            onChange={(event) => onWorkTypeNameChange(event.target.value)}
-            value={draft.workTypeName}
-          >
-            <option value="">{messages.selectWorkTypePlaceholder}</option>
-            {submitWorkTypeNames.map((workTypeName) => (
-              <option key={workTypeName} value={workTypeName}>
-                {workTypeName}
-              </option>
-            ))}
-          </Select>
-          {validationErrors?.workTypeName ? (
-            <p className={VALIDATION_TEXT_CLASS} id={workTypeErrorID}>
-              {validationErrors.workTypeName}
-            </p>
-          ) : null}
-        </div>
-
-        <div className={FIELD_GROUP_CLASS}>
-          <label className={FIELD_LABEL_CLASS} htmlFor={requestNameID}>
-            {messages.requestNameLabel}
-          </label>
-          <Input
-            aria-describedby={
-              validationErrors?.requestName ? requestNameErrorID : undefined
-            }
-            aria-invalid={validationErrors?.requestName ? "true" : undefined}
-            className={DASHBOARD_BODY_TEXT_CLASS}
-            disabled={controlsDisabled}
-            id={requestNameID}
-            onChange={(event) => onRequestNameChange(event.target.value)}
-            placeholder={messages.requestNamePlaceholder}
-            type="text"
-            value={draft.requestName}
-          />
-          {validationErrors?.requestName ? (
-            <p className={VALIDATION_TEXT_CLASS} id={requestNameErrorID}>
-              {validationErrors.requestName}
-            </p>
-          ) : null}
-        </div>
-
-        <div className={FIELD_GROUP_CLASS}>
-          <div className={FIELD_LABEL_CLASS} id={submissionItemsID}>
-            {messages.submissionItemsLabel}
+        <div className={FORM_FIELDS_CLASS}>
+          <div className={FIELD_GROUP_CLASS}>
+            <label className={FIELD_LABEL_CLASS} htmlFor={workTypeID}>
+              {messages.workTypeLabel}
+            </label>
+            <Select
+              aria-describedby={
+                validationErrors?.workTypeName ? workTypeErrorID : undefined
+              }
+              aria-invalid={validationErrors?.workTypeName ? "true" : undefined}
+              className={DASHBOARD_BODY_TEXT_CLASS}
+              disabled={controlsDisabled}
+              id={workTypeID}
+              onChange={(event) => onWorkTypeNameChange(event.target.value)}
+              value={draft.workTypeName}
+            >
+              <option value="">{messages.selectWorkTypePlaceholder}</option>
+              {submitWorkTypeNames.map((workTypeName) => (
+                <option key={workTypeName} value={workTypeName}>
+                  {workTypeName}
+                </option>
+              ))}
+            </Select>
+            {validationErrors?.workTypeName ? (
+              <p className={VALIDATION_TEXT_CLASS} id={workTypeErrorID}>
+                {validationErrors.workTypeName}
+              </p>
+            ) : null}
           </div>
-          <AddSubmissionItemMenu
-            controlsDisabled={controlsDisabled}
-            isOpen={isAddItemMenuOpen}
-            messages={messages}
-            onAddItem={onAddItem}
-            onOpenChange={setIsAddItemMenuOpen}
-          />
-          <SubmissionItemsList
-            controlsDisabled={controlsDisabled}
-            draft={draft}
-            messages={messages}
-            onItemTextChange={onItemTextChange}
-            onRemoveItem={onRemoveItem}
-            onStageFileItems={onStageFileItems}
-            submissionItemsID={submissionItemsID}
-            widgetId={widgetId}
-          />
-          {validationErrors?.submissionItems ? (
-            <p className={VALIDATION_TEXT_CLASS}>
-              {validationErrors.submissionItems}
-            </p>
-          ) : null}
+
+          <div className={FIELD_GROUP_CLASS}>
+            <label className={FIELD_LABEL_CLASS} htmlFor={requestNameID}>
+              {messages.requestNameLabel}
+            </label>
+            <Input
+              aria-describedby={
+                validationErrors?.requestName ? requestNameErrorID : undefined
+              }
+              aria-invalid={validationErrors?.requestName ? "true" : undefined}
+              className={DASHBOARD_BODY_TEXT_CLASS}
+              disabled={controlsDisabled}
+              id={requestNameID}
+              onChange={(event) => onRequestNameChange(event.target.value)}
+              placeholder={messages.requestNamePlaceholder}
+              type="text"
+              value={draft.requestName}
+            />
+            {validationErrors?.requestName ? (
+              <p className={VALIDATION_TEXT_CLASS} id={requestNameErrorID}>
+                {validationErrors.requestName}
+              </p>
+            ) : null}
+          </div>
+
+          <div className={FIELD_GROUP_CLASS}>
+            <div className={FIELD_LABEL_CLASS} id={submissionItemsID}>
+              {messages.submissionItemsLabel}
+            </div>
+            <AddSubmissionItemMenu
+              controlsDisabled={controlsDisabled}
+              isOpen={isAddItemMenuOpen}
+              messages={messages}
+              onAddItem={onAddItem}
+              onOpenChange={setIsAddItemMenuOpen}
+            />
+            <SubmissionItemsList
+              controlsDisabled={controlsDisabled}
+              draft={draft}
+              messages={messages}
+              onItemTextChange={onItemTextChange}
+              onRemoveItem={onRemoveItem}
+              onStageFileItems={onStageFileItems}
+              submissionItemsID={submissionItemsID}
+              widgetId={widgetId}
+            />
+            {validationErrors?.submissionItems ? (
+              <p className={VALIDATION_TEXT_CLASS}>
+                {validationErrors.submissionItems}
+              </p>
+            ) : null}
+          </div>
         </div>
 
         <div className={ACTION_ROW_CLASS}>
@@ -354,7 +358,6 @@ function SubmissionItemsList({
         return (
           <SubmitWorkItemShell
             disabled={controlsDisabled}
-            itemLabel={requestItemLabel}
             itemTypeLabel={typeLabel}
             key={item.id}
             onRemove={() => onRemoveItem(item.id)}
@@ -388,14 +391,12 @@ function SubmissionItemsList({
 function SubmitWorkItemShell({
   children,
   disabled = false,
-  itemLabel,
   itemTypeLabel,
   onRemove,
   removeLabel,
 }: {
   children: ReactNode;
   disabled?: boolean;
-  itemLabel: string;
   itemTypeLabel: string;
   onRemove: () => void;
   removeLabel: string;
@@ -405,11 +406,10 @@ function SubmitWorkItemShell({
       <div className="flex items-start justify-between gap-3">
         <div className="grid gap-1">
           <span className={FIELD_LABEL_CLASS}>{itemTypeLabel}</span>
-          <span className={HELP_TEXT_CLASS}>{itemLabel}</span>
         </div>
-        <button
+        <DashboardIconButtonShell
           aria-label={removeLabel}
-          className="inline-grid size-8 shrink-0 place-items-center rounded-md border border-af-border bg-transparent text-af-text-subtle transition-colors hover:border-af-danger-border hover:bg-af-danger-surface hover:text-af-danger-text focus-visible:ring-2 focus-visible:ring-af-focus-ring focus-visible:ring-offset-0"
+          className="text-af-text-subtle hover:border-af-danger-border hover:bg-af-danger-surface hover:text-af-danger-text"
           disabled={disabled}
           onClick={() => {
             if (disabled) {
@@ -417,7 +417,6 @@ function SubmitWorkItemShell({
             }
             onRemove();
           }}
-          type="button"
         >
           <svg
             aria-hidden="true"
@@ -435,7 +434,7 @@ function SubmitWorkItemShell({
               strokeWidth="1.7"
             />
           </svg>
-        </button>
+        </DashboardIconButtonShell>
       </div>
       {children}
     </li>
@@ -463,10 +462,8 @@ function TextSubmissionItemEditor({
 
   return (
     <>
-      <label className={FIELD_LABEL_CLASS} htmlFor={requestTextID}>
-        {itemLabel}
-      </label>
       <Textarea
+        aria-label={itemLabel}
         aria-describedby={requestHint ? requestTextHintID : undefined}
         className={DASHBOARD_BODY_TEXT_CLASS}
         disabled={disabled}

--- a/ui/src/features/work-totals/components/work-totals-card.test.tsx
+++ b/ui/src/features/work-totals/components/work-totals-card.test.tsx
@@ -33,7 +33,8 @@ describe("WorkTotalsCard", () => {
     expect(workTotals.className).toContain("md:grid-cols-4");
     expect(cardHeader?.className).toContain("min-h-11");
     expect(cardHeader?.className).toContain("px-3");
-    expect(moveHandle.className).toContain("size-8");
+    expect(moveHandle.className).toContain("h-10");
+    expect(moveHandle.className).toContain("w-10");
     expect(screen.getByLabelText("In progress: 2")).toBeTruthy();
     expect(screen.getByLabelText("Completed: 3")).toBeTruthy();
     expect(screen.getByLabelText("Failed: 1")).toBeTruthy();

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-editor-chrome.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-editor-chrome.test.tsx
@@ -25,7 +25,9 @@ describe("CurrentActivityGraphHeaderActions", () => {
     expect(sections[1]?.getAttribute("data-dashboard-action-row-section")).toBe(
       "actions",
     );
-    expect(within(sections[0] as HTMLElement).getByText("Observe mode")).toBeTruthy();
+    expect(
+      within(sections[0] as HTMLElement).getByText("Observe mode"),
+    ).toBeTruthy();
     expect(
       within(sections[1] as HTMLElement).getByRole("button", {
         name: "Enter factory graph editor",
@@ -57,5 +59,29 @@ describe("CurrentActivityGraphHeaderActions", () => {
       }),
     ).toBeTruthy();
     expect(screen.getByText("Unsaved graph changes")).toBeTruthy();
+  });
+
+  it("keeps custom header actions in the actions section after the mode toggle", () => {
+    const { container } = render(
+      <CurrentActivityGraphHeaderActions
+        editorMode={false}
+        hasChanges={false}
+        headerActions={<button type="button">Remove card</button>}
+        isDefinitionLoading={false}
+        onToggle={() => {}}
+      />,
+    );
+
+    const sections = container.querySelectorAll(
+      "[data-dashboard-action-row-section]",
+    );
+    const actionsSection = sections[1] as HTMLElement;
+    const actionButtons = within(actionsSection).getAllByRole("button");
+
+    expect(actionButtons).toHaveLength(2);
+    expect(actionButtons[0]?.getAttribute("aria-label")).toBe(
+      "Enter factory graph editor",
+    );
+    expect(actionButtons[1]?.textContent).toBe("Remove card");
   });
 });

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-editor-chrome.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-editor-chrome.tsx
@@ -1,23 +1,23 @@
-import { useCallback, useState } from "react";
+import { type ReactNode, useCallback, useState } from "react";
 
 import { DashboardActionRow } from "../../../components/ui";
 import { cn } from "../../../lib/cn";
-import {
-  applyFactoryGraphAddEntityDraft,
-  createFactoryGraphAddEntityDraft,
-  type CanonicalFactoryDefinition,
-  type FactoryGraphAddEntityDraft,
-  type FactoryGraphAddEntityFieldErrors,
-  type FactoryGraphAddEntityKind,
-  type useFactoryGraphDraftState,
-  validateFactoryGraphAddEntityDraft,
-} from "../../factory-graph-editor/public";
 import {
   FactoryGraphEditorModeToggle,
   FactoryGraphEditorStatus,
   type FactoryGraphEditorTool,
 } from "../../factory-graph-editor/components/factory-graph-editor-controls";
 import { getFactoryGraphEditorMessages } from "../../factory-graph-editor/messages/editor";
+import {
+  applyFactoryGraphAddEntityDraft,
+  type CanonicalFactoryDefinition,
+  createFactoryGraphAddEntityDraft,
+  type FactoryGraphAddEntityDraft,
+  type FactoryGraphAddEntityFieldErrors,
+  type FactoryGraphAddEntityKind,
+  type useFactoryGraphDraftState,
+  validateFactoryGraphAddEntityDraft,
+} from "../../factory-graph-editor/public";
 
 export function useFactoryGraphAddEntityController({
   currentFactoryDefinition,
@@ -89,8 +89,7 @@ export function useFactoryGraphAddEntityController({
   };
 }
 
-const FACTORY_GRAPH_HEADER_ACTIONS_CLASS =
-  "min-w-0 justify-end";
+const FACTORY_GRAPH_HEADER_ACTIONS_CLASS = "min-w-0 justify-end";
 const FACTORY_GRAPH_HEADER_ACTIONS_COMPACT_CLASS = "gap-1.5";
 const FACTORY_GRAPH_HEADER_ACTIONS_SECTIONS_COMPACT_CLASS = "gap-1.5";
 const STATUS_PILL_COMPACT_CLASS = "px-2.5 py-0.5 text-[0.7rem]";
@@ -101,6 +100,7 @@ export function CurrentActivityGraphHeaderActions({
   compact = false,
   editorMode,
   editorUnavailableClassifierWorkstationName,
+  headerActions,
   hasChanges,
   isDefinitionLoading,
   loadErrorMessage,
@@ -110,6 +110,7 @@ export function CurrentActivityGraphHeaderActions({
   compact?: boolean;
   editorMode: boolean;
   editorUnavailableClassifierWorkstationName?: string;
+  headerActions?: ReactNode;
   hasChanges: boolean;
   isDefinitionLoading: boolean;
   loadErrorMessage?: string;
@@ -127,32 +128,43 @@ export function CurrentActivityGraphHeaderActions({
   return (
     <DashboardActionRow
       actions={
-        <FactoryGraphEditorModeToggle
-          className={compact ? MODE_TOGGLE_COMPACT_CLASS : undefined}
-          disabled={!editorMode && editorUnavailableReason !== undefined}
-          editorMode={editorMode}
-          locale={locale}
-          onClick={onToggle}
-          tooltipOverride={editorUnavailableReason}
-        />
+        <>
+          <FactoryGraphEditorModeToggle
+            className={compact ? MODE_TOGGLE_COMPACT_CLASS : undefined}
+            disabled={!editorMode && editorUnavailableReason !== undefined}
+            editorMode={editorMode}
+            locale={locale}
+            onClick={onToggle}
+            tooltipOverride={editorUnavailableReason}
+          />
+          {headerActions}
+        </>
       }
-      actionsClassName={compact ? FACTORY_GRAPH_HEADER_ACTIONS_SECTIONS_COMPACT_CLASS : undefined}
+      actionsClassName={
+        compact
+          ? FACTORY_GRAPH_HEADER_ACTIONS_SECTIONS_COMPACT_CLASS
+          : undefined
+      }
       className={cn(
         FACTORY_GRAPH_HEADER_ACTIONS_CLASS,
         compact && FACTORY_GRAPH_HEADER_ACTIONS_COMPACT_CLASS,
       )}
       statuses={
         <FactoryGraphEditorStatus
-        className={compact ? STATUS_PILL_COMPACT_CLASS : undefined}
-        editorMode={editorMode}
-        editorUnavailableReason={editorUnavailableReason}
-        hasChanges={hasChanges}
-        isDefinitionLoading={isDefinitionLoading}
-        locale={locale}
-        loadErrorMessage={loadErrorMessage}
-      />
+          className={compact ? STATUS_PILL_COMPACT_CLASS : undefined}
+          editorMode={editorMode}
+          editorUnavailableReason={editorUnavailableReason}
+          hasChanges={hasChanges}
+          isDefinitionLoading={isDefinitionLoading}
+          locale={locale}
+          loadErrorMessage={loadErrorMessage}
+        />
       }
-      statusesClassName={compact ? FACTORY_GRAPH_HEADER_ACTIONS_SECTIONS_COMPACT_CLASS : undefined}
+      statusesClassName={
+        compact
+          ? FACTORY_GRAPH_HEADER_ACTIONS_SECTIONS_COMPACT_CLASS
+          : undefined
+      }
     />
   );
 }

--- a/ui/src/features/workflow-activity/components/workflow-activity-bento-card.test.tsx
+++ b/ui/src/features/workflow-activity/components/workflow-activity-bento-card.test.tsx
@@ -1,22 +1,25 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { semanticWorkflowDashboardSnapshot } from "../../../components/dashboard/test-fixtures";
-import { installDashboardBrowserTestShims } from "../../../components/dashboard/test-browser-shims";
+import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { installDashboardBrowserTestShims } from "../../../components/dashboard/test-browser-shims";
+import { semanticWorkflowDashboardSnapshot } from "../../../components/dashboard/test-fixtures";
 import {
   useCurrentFactoryDocument,
   useSaveCurrentFactory,
 } from "../../current-factory-definition/public";
-import { useFactoryGraphDraftState } from "../../factory-graph-editor/public";
-import { getFactoryGraphEditorMessages } from "../../factory-graph-editor/messages/editor";
 import type { DashboardSelection } from "../../current-selection/public";
+import { getFactoryGraphEditorMessages } from "../../factory-graph-editor/messages/editor";
+import { useFactoryGraphDraftState } from "../../factory-graph-editor/public";
 import type { CurrentActivityImportController } from "../hooks/current-activity-import-controller";
-import { WorkflowActivityBentoCard } from "./workflow-activity-bento-card";
 import { getWorkflowActivityShellMessages } from "../messages/activity-shell";
+import { WorkflowActivityBentoCard } from "./workflow-activity-bento-card";
 
 vi.mock("../../current-factory-definition/public", async () => {
-  const actual = await vi.importActual("../../current-factory-definition/public");
+  const actual = await vi.importActual(
+    "../../current-factory-definition/public",
+  );
 
   return {
     ...actual,
@@ -26,9 +29,7 @@ vi.mock("../../current-factory-definition/public", async () => {
 });
 
 vi.mock("../../factory-graph-editor/public", async () => {
-  const actual = await vi.importActual(
-    "../../factory-graph-editor/public",
-  );
+  const actual = await vi.importActual("../../factory-graph-editor/public");
 
   return {
     ...actual,
@@ -103,9 +104,11 @@ function createQueryClient(): QueryClient {
 }
 
 function renderWorkflowActivityBentoCard({
+  headerAction,
   locale = "zh-CN",
   widgetInstanceID,
 }: {
+  headerAction?: ReactNode;
   locale?: string;
   widgetInstanceID?: string;
 } = {}) {
@@ -120,6 +123,7 @@ function renderWorkflowActivityBentoCard({
   render(
     <QueryClientProvider client={queryClient}>
       <WorkflowActivityBentoCard
+        headerAction={headerAction}
         importController={createImportController()}
         locale={locale}
         now={Date.parse("2026-04-08T12:00:04Z")}
@@ -173,7 +177,7 @@ function renderDuplicateWorkflowActivityBentoCards(locale = "zh-CN") {
   );
 }
 
-describe("WorkflowActivityBentoCard", () => {
+function registerWorkflowActivityBentoCardTestSetup() {
   let restoreBrowserTestShims: (() => void) | null = null;
 
   beforeEach(() => {
@@ -198,6 +202,10 @@ describe("WorkflowActivityBentoCard", () => {
     restoreBrowserTestShims = null;
     vi.clearAllMocks();
   });
+}
+
+describe("WorkflowActivityBentoCard", () => {
+  registerWorkflowActivityBentoCardTestSetup();
 
   it("wraps the React Flow graph without a floating inspector", async () => {
     const locale = "zh-CN";
@@ -216,7 +224,7 @@ describe("WorkflowActivityBentoCard", () => {
     ).toBeTruthy();
     expect(
       within(graphCard).getByRole("button", { name: "Move 工厂图" }).className,
-    ).toContain("size-8");
+    ).toContain("h-10");
     expect(within(graphCard).getByText("观察模式")).toBeTruthy();
     expect(graphHeader?.textContent).toContain("观察模式");
     expect(
@@ -226,7 +234,9 @@ describe("WorkflowActivityBentoCard", () => {
       screen.getByRole("region", { name: messages.viewportLabel }),
     ).toBeTruthy();
     expect(screen.queryByRole("complementary")).toBeNull();
-    expect(screen.queryByRole("button", { name: /collapse inspector/i })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /collapse inspector/i }),
+    ).toBeNull();
   });
 
   it("keeps the header as the visible editor entry point in observe and loading editor states", async () => {
@@ -299,5 +309,40 @@ describe("WorkflowActivityBentoCard", () => {
         headingID ? container.ownerDocument.getElementById(headingID) : null,
       ).toBeTruthy();
     }
+  });
+});
+
+describe("WorkflowActivityBentoCard header actions", () => {
+  registerWorkflowActivityBentoCardTestSetup();
+
+  it("orders the remove action with the graph header controls instead of before the status pill", async () => {
+    const locale = "zh-CN";
+    const shellMessages = getWorkflowActivityShellMessages(locale);
+    renderWorkflowActivityBentoCard({
+      headerAction: <button type="button">Remove card</button>,
+      locale,
+    });
+
+    const graphCard = await screen.findByRole("article", {
+      name: shellMessages.widgetTitle,
+    });
+    const actionSections = graphCard.querySelectorAll(
+      "[data-dashboard-action-row-section]",
+    );
+
+    expect(actionSections).toHaveLength(2);
+    expect(
+      actionSections[0]?.getAttribute("data-dashboard-action-row-section"),
+    ).toBe("statuses");
+    expect(
+      actionSections[1]?.getAttribute("data-dashboard-action-row-section"),
+    ).toBe("actions");
+
+    const actions = within(actionSections[1] as HTMLElement).getAllByRole(
+      "button",
+    );
+
+    expect(actions[0]?.getAttribute("aria-label")).toBe("进入工厂图编辑器");
+    expect(actions[1]?.textContent).toBe("Remove card");
   });
 });

--- a/ui/src/features/workflow-activity/components/workflow-activity-bento-card.tsx
+++ b/ui/src/features/workflow-activity/components/workflow-activity-bento-card.tsx
@@ -4,13 +4,13 @@ import type { DashboardSnapshot } from "../../../api/dashboard/types";
 import { AgentBentoCard } from "../../../components/ui";
 import type { DashboardSelection } from "../../current-selection/public";
 import type { CurrentActivityImportController } from "../hooks/current-activity-import-controller";
+import { useCurrentActivityGraphEditor } from "../hooks/react-flow-current-activity-card-editor";
+import { getWorkflowActivityShellMessages } from "../messages/activity-shell";
 import {
   type CurrentActivitySelection,
   ReactFlowCurrentActivityCardView,
 } from "./react-flow-current-activity-card";
-import { useCurrentActivityGraphEditor } from "../hooks/react-flow-current-activity-card-editor";
 import { CurrentActivityGraphHeaderActions } from "./react-flow-current-activity-card-editor-chrome";
-import { getWorkflowActivityShellMessages } from "../messages/activity-shell";
 
 interface WorkflowActivityBentoCardProps {
   headerAction?: ReactNode;
@@ -49,23 +49,21 @@ export function WorkflowActivityBentoCard({
     <AgentBentoCard
       chromeDensity="compact"
       headerAction={
-        <>
-          {headerAction}
-          <CurrentActivityGraphHeaderActions
-            compact
-            editorMode={editor.editorMode}
-            editorUnavailableClassifierWorkstationName={
-              editor.editorUnavailableClassifierWorkstationName
-            }
-            hasChanges={editor.draftState.hasChanges}
-            isDefinitionLoading={
-              editor.editableDefinitionQuery.status === "pending"
-            }
-            loadErrorMessage={editor.editableDefinitionQuery.error?.message}
-            locale={locale}
-            onToggle={editor.handleEditorModeToggle}
-          />
-        </>
+        <CurrentActivityGraphHeaderActions
+          compact
+          editorMode={editor.editorMode}
+          editorUnavailableClassifierWorkstationName={
+            editor.editorUnavailableClassifierWorkstationName
+          }
+          hasChanges={editor.draftState.hasChanges}
+          headerActions={headerAction}
+          isDefinitionLoading={
+            editor.editableDefinitionQuery.status === "pending"
+          }
+          loadErrorMessage={editor.editableDefinitionQuery.error?.message}
+          locale={locale}
+          onToggle={editor.handleEditorModeToggle}
+        />
       }
       title={messages.widgetTitle}
     >

--- a/ui/src/stories/dashboardStoryTestUtils.ts
+++ b/ui/src/stories/dashboardStoryTestUtils.ts
@@ -4,16 +4,16 @@ import type { DashboardWorkstationRequest } from "../api/dashboard";
 import { dashboardWorkstationRequestFixtures } from "../components/dashboard/fixtures";
 import { semanticWorkflowDashboardSnapshot } from "../components/dashboard/test-fixtures";
 import {
-  findSubmitWorkCard,
-  getSubmitWorkCardControls,
-  submitWorkCardQueryContract,
-} from "../testing/submit-work-card-queries";
-import {
   DASHBOARD_BODY_TEXT_CLASS,
   DASHBOARD_PAGE_HEADING_CLASS,
   DASHBOARD_SECTION_HEADING_CLASS,
   DASHBOARD_SUPPORTING_TEXT_CLASS,
 } from "../components/ui/dashboard-typography";
+import {
+  findSubmitWorkCard,
+  getSubmitWorkCardControls,
+  submitWorkCardQueryContract,
+} from "../testing/submit-work-card-queries";
 import { activeStoryTrace } from "./dashboardStoryFixtures";
 
 export async function expectGraphWorkstation(
@@ -51,7 +51,10 @@ export function currentSelectionCard(canvasElement: HTMLElement): HTMLElement {
   });
 }
 
-export function requireValue<T>(value: T | null | undefined, message: string): T {
+export function requireValue<T>(
+  value: T | null | undefined,
+  message: string,
+): T {
   if (value === null || value === undefined) {
     throw new Error(message);
   }
@@ -59,7 +62,9 @@ export function requireValue<T>(value: T | null | undefined, message: string): T
   return value;
 }
 
-export function expectNoPageHorizontalOverflow(canvasElement: HTMLElement): void {
+export function expectNoPageHorizontalOverflow(
+  canvasElement: HTMLElement,
+): void {
   const documentElement = canvasElement.ownerDocument.documentElement;
   const overflowTolerance = 4;
 
@@ -87,7 +92,9 @@ export function buttonVisibleStyle(button: HTMLElement): {
   };
 }
 
-export async function submitWorkCardControls(canvasElement: HTMLElement): Promise<{
+export async function submitWorkCardControls(
+  canvasElement: HTMLElement,
+): Promise<{
   requestNameField: HTMLInputElement;
   requestField: HTMLTextAreaElement;
   scope: ReturnType<typeof within>;
@@ -147,15 +154,12 @@ export async function expectTypographyRegressionSurface(
   const canvas = within(canvasElement);
   const heading = await canvas.findByRole("heading", { name: "U" });
   const toolbar = canvas.getByRole("region", { name: "dashboard summary" });
-  const streamStatus = canvas.getByRole("status", {
-    name: /Event stream (connecting|live)/,
-  });
 
   expect(heading.className).toContain(DASHBOARD_PAGE_HEADING_CLASS);
   expect(heading.textContent).toBe("U");
-  expect(streamStatus.className).toContain("inline-flex");
-  expect(streamStatus.className).toContain("rounded-full");
-  expect(streamStatus.className).not.toContain("sr-only");
+  expect(
+    within(toolbar).queryByRole("status", { name: /Event stream/i }),
+  ).toBeNull();
   expect(within(toolbar).queryByText("Factory state")).toBeNull();
   expect(
     within(toolbar).queryByText(
@@ -203,9 +207,6 @@ export async function expectTimelineToolbarAlignment(
     name: "dashboard summary",
   });
   const heading = within(toolbar).getByRole("heading", { name: "U" });
-  const streamStatus = within(toolbar).getByRole("status", {
-    name: /Event stream (connecting|live)/,
-  });
   const activeTab = within(toolbar).getByRole("tab", { name: "root" });
   const slider = within(toolbar).getByRole<HTMLInputElement>("slider", {
     name: "Timeline tick",
@@ -217,7 +218,9 @@ export async function expectTimelineToolbarAlignment(
   const actionsGroup = within(toolbar).getByRole("group", {
     name: "Dashboard actions",
   });
-  const exportButton = within(toolbar).getByRole("button", { name: "Export PNG" });
+  const exportButton = within(toolbar).getByRole("button", {
+    name: "Export PNG",
+  });
   const sliderShell = requireValue(
     slider.closest<HTMLElement>("div"),
     "expected slider shell in dashboard toolbar",
@@ -243,28 +246,26 @@ export async function expectTimelineToolbarAlignment(
   const sliderInputRect = slider.getBoundingClientRect();
   const progressTextRect = progressText.getBoundingClientRect();
   const languageButtonRect = languageButton.getBoundingClientRect();
-  const streamStatusRect = streamStatus.getBoundingClientRect();
   const exportButtonRect = exportButton.getBoundingClientRect();
   const headerControls = Array.from(
     toolbar.querySelectorAll(
-      '[aria-label="Timeline tick"], [aria-label="Change language"], [aria-label="Export PNG"], [role="status"]',
+      '[aria-label="Timeline tick"], [aria-label="Change language"], [aria-label="Export PNG"]',
     ),
   );
 
   expect(sliderShell.className).toContain("gap-1.5");
-  expect(sliderShell.className).toContain("px-1");
-  expect(streamStatus.className).toContain("inline-flex");
-  expect(streamStatus.className).toContain("rounded-full");
-  expect(streamStatus.className).not.toContain("sr-only");
+  expect(sliderShell.className).toContain("px-2.5");
+  expect(
+    within(toolbar).queryByRole("status", { name: /Event stream/i }),
+  ).toBeNull();
   expect(sliderMetaGroup.contains(progressText)).toBe(true);
   expect(
     within(toolbar).queryByRole("button", { name: "Return to current tick" }),
   ).toBeNull();
-  expect(headerControls).toHaveLength(4);
-  expect(headerControls[0]).toBe(streamStatus);
-  expect(headerControls[1]).toBe(languageButton);
-  expect(headerControls[2]).toBe(slider);
-  expect(headerControls[3]).toBe(exportButton);
+  expect(headerControls).toHaveLength(3);
+  expect(headerControls[0]).toBe(languageButton);
+  expect(headerControls[1]).toBe(slider);
+  expect(headerControls[2]).toBe(exportButton);
   expect(primaryRowRect.top).toBeLessThan(secondaryRowRect.top);
   expect(sliderRect.top).toBeGreaterThanOrEqual(headingRect.bottom - 1);
   expect(sliderRect.top).toBeGreaterThanOrEqual(activeTabRect.bottom - 1);
@@ -272,11 +273,11 @@ export async function expectTimelineToolbarAlignment(
   expect(progressTextRect.width).toBeGreaterThan(0);
   expect(progressTextRect.height).toBeGreaterThan(0);
   expect(progressTextRect.top).toBeGreaterThanOrEqual(sliderInputRect.top - 1);
-  expect(exportButtonRect.left).toBeGreaterThanOrEqual(actionsGroupRect.left - 1);
+  expect(exportButtonRect.left).toBeGreaterThanOrEqual(
+    actionsGroupRect.left - 1,
+  );
   expect(languageButtonRect.width).toBeGreaterThan(0);
   expect(languageButtonRect.height).toBeGreaterThan(0);
-  expect(streamStatusRect.width).toBeGreaterThan(1);
-  expect(streamStatusRect.height).toBeGreaterThan(1);
 }
 
 export async function selectWorkstationRequest(

--- a/ui/src/stories/dashboardTopSectionStoryTestUtils.ts
+++ b/ui/src/stories/dashboardTopSectionStoryTestUtils.ts
@@ -28,9 +28,6 @@ export async function expectCompactedTopDashboardSection(
   const exportButton = within(toolbar).getByRole("button", {
     name: "Export PNG",
   });
-  const streamStatus = within(toolbar).getByRole("status", {
-    name: /Event stream (connecting|live)/,
-  });
 
   await expect(toolbar).toBeVisible();
   await expect(workTotals).toBeVisible();
@@ -47,7 +44,9 @@ export async function expectCompactedTopDashboardSection(
   ).toBeNull();
   expect(languageButton).toBeVisible();
   expect(exportButton).toBeVisible();
-  expect(streamStatus).toBeVisible();
+  expect(
+    within(toolbar).queryByRole("status", { name: /Event stream/i }),
+  ).toBeNull();
 
   languageButton.focus();
   expect(canvasElement.ownerDocument.activeElement).toBe(languageButton);


### PR DESCRIPTION
## Summary
- align the dashboard session add button with the active session tab strip
- consolidate icon-button chrome and restore submit-work accessibility coverage
- update replay integration coverage to match the compact dashboard header stream UI

## Verification
- make ui-test
- make ci