### PR TITLE
remove-dashboard-state-index-re-export

### DIFF
--- a/ui/src/App.toolbar-locale.test.tsx
+++ b/ui/src/App.toolbar-locale.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { DASHBOARD_PAGE_HEADING_CLASS } from "./components/ui/dashboard-typography";
-import { useDashboardStreamStore } from "./features/dashboard/state";
+import { useDashboardStreamStore } from "./features/dashboard/state/dashboardStreamStore";
 import * as factoryPngImportModule from "./features/import/lib/factory-png-import";
 import {
   createFactoryImportValue,

--- a/ui/src/features/dashboard/state/index.ts
+++ b/ui/src/features/dashboard/state/index.ts
@@ -1,1 +1,0 @@
-export * from "./dashboardStreamStore";

--- a/ui/src/testing/app-shell-test-utils.tsx
+++ b/ui/src/testing/app-shell-test-utils.tsx
@@ -24,7 +24,7 @@ import { resetSelectionHistoryStore } from "../features/current-selection/state/
 import {
   createDefaultDashboardStreamState,
   useDashboardStreamStore,
-} from "../features/dashboard/state";
+} from "../features/dashboard/state/dashboardStreamStore";
 import { useDashboardSessionStore } from "../features/dashboard/state/dashboardSessionStore";
 import { useExportDialogStore } from "../features/export/state/exportDialogStore";
 import type { FactoryPngImportValue } from "../features/import/public";


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/remove-dashboard-state-index-re-export",
  "description": "Remove the redundant dashboard state barrel re-export so the remaining test consumers import dashboard stream store symbols from the canonical direct module while preserving existing website behavior.",
  "context": {
    "customerAsk": "Delete the feature-local barrel at ui/src/features/dashboard/state/index.ts, retarget its two remaining verified consumers in ui/src/testing/app-shell-test-utils.tsx and ui/src/App.toolbar-locale.test.tsx to import directly from dashboardStreamStore, keep the scope limited to that seam, and verify the existing frontend tests still prove behavior is preserved.",
    "problem": "The website still carries a tiny feature-local barrel that only re-exports ./dashboardStreamStore, and the currently verified consumer set has narrowed to two frontend test files. Keeping the barrel adds an unnecessary re-export layer, suggests a broader public state boundary than the repo actually uses, and creates extra import indirection without changing runtime behavior or improving maintainability.",
    "solution": "Move both verified test consumers to direct imports from ui/src/features/dashboard/state/dashboardStreamStore, delete the redundant state/index.ts barrel once nothing imports it, confirm that no repo-local imports still target ui/src/features/dashboard/state, and run focused frontend verification through the existing app-shell and toolbar locale test surfaces to prove the cleanup preserves behavior."
  },
  "acceptanceCriteria": [
    "ui/src/testing/app-shell-test-utils.tsx imports createDefaultDashboardStreamState and useDashboardStreamStore directly from ../features/dashboard/state/dashboardStreamStore.",
    "ui/src/App.toolbar-locale.test.tsx imports useDashboardStreamStore directly from ./features/dashboard/state/dashboardStreamStore.",
    "ui/src/features/dashboard/state/index.ts is deleted.",
    "Repo-local verification shows no remaining imports that target ui/src/features/dashboard/state.",
    "Existing dashboard stream store, app-shell helper, and toolbar locale test behavior remain unchanged because this work only changes import ownership, not store logic or UI behavior.",
    "The implementation remains limited to the dashboard state barrel seam and does not broaden into a larger dashboard state refactor.",
    "Quality gate: frontend typecheck, lint, and relevant automated tests pass."
  ],
  "userStories": [
    {
      "id": "remove-dashboard-state-index-re-export-001",
      "title": "Retarget the shared app-shell helper to the direct dashboard stream store module",
      "description": "As a frontend maintainer, I want the shared app-shell test helper to import dashboard stream store symbols from the direct store module so that test setup uses the canonical ownership path instead of a redundant barrel.",
      "acceptanceCriteria": [
        "ui/src/testing/app-shell-test-utils.tsx imports createDefaultDashboardStreamState and useDashboardStreamStore from ../features/dashboard/state/dashboardStreamStore.",
        "The updated helper continues to compile and provide the same dashboard stream setup behavior without changing store semantics, helper behavior, or browser-visible behavior.",
        "No replacement barrel, compatibility shim, or alternate re-export path is introduced for the dashboard state seam.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "remove-dashboard-state-index-re-export-002",
      "title": "Retarget the toolbar locale test to the direct dashboard stream store module",
      "description": "As a frontend maintainer, I want the toolbar locale test to import useDashboardStreamStore from the direct store module so that test coverage exercises the same canonical store ownership path as the rest of the codebase.",
      "acceptanceCriteria": [
        "ui/src/App.toolbar-locale.test.tsx imports useDashboardStreamStore from ./features/dashboard/state/dashboardStreamStore.",
        "The toolbar locale test continues to compile and exercise the same locale-related behavior without changing dashboard stream runtime behavior or test assertions.",
        "No replacement barrel, compatibility shim, or alternate re-export path is introduced for the dashboard state seam.",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "remove-dashboard-state-index-re-export-003",
      "title": "Remove the redundant dashboard state barrel and prove the seam is retired",
      "description": "As a reviewer, I want direct proof that the redundant dashboard state barrel is gone and no repo-local imports still rely on it so that the cleanup is complete, behavior-preserving, and safely bounded.",
      "acceptanceCriteria": [
        "ui/src/features/dashboard/state/index.ts is deleted.",
        "Repo-local verification confirms there are no remaining imports of ui/src/features/dashboard/state.",
        "Focused frontend verification through the existing app-shell and toolbar locale test surfaces shows the cleanup preserved dashboard stream behavior.",
        "The change remains limited to import ownership cleanup and does not expand into broader dashboard state or feature-surface reorganization.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}
