### PR TITLE
remove-terminal-work-public-messages-re-export

### DIFF
--- a/ui/src/features/terminal-work/public/index.ts
+++ b/ui/src/features/terminal-work/public/index.ts
@@ -1,4 +1,3 @@
 export * from "../components/terminal-work-card";
 export * from "../components/terminal-work-widget";
 export * from "../lib/types";
-export * from "../messages";


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/remove-terminal-work-public-messages-re-export",
  "description": "Remove the unused terminal-work messages re-export from the terminal-work public barrel so the feature public surface only exposes the component and type exports that current consumers actually use, while preserving existing website behavior.",
  "context": {
    "customerAsk": "Delete `export * from \"../messages\";` from `ui/src/features/terminal-work/public/index.ts`, keep the cleanup behavior-preserving, avoid widening the change into terminal-work component, story, or i18n import retargeting, and leave `ui/src/features/terminal-work/messages/index.ts` untouched for follow-up work.",
    "problem": "`ui/src/features/terminal-work/public/index.ts` currently re-exports terminal-work message helpers and message-related types even though no verified consumer of `ui/src/features/terminal-work/public` uses those message exports. That redundant re-export expands the public surface, creates avoidable coupling to the message module, and suggests a broader supported boundary than current usage requires.",
    "solution": "Remove the messages re-export from `ui/src/features/terminal-work/public/index.ts`, confirm that repo-local imports of `ui/src/features/terminal-work/public` still resolve only component and type consumers, and run the smallest targeted frontend verification needed to prove the narrowed public barrel still compiles after the export removal."
  },
  "acceptanceCriteria": [
    "`ui/src/features/terminal-work/public/index.ts` no longer re-exports `../messages`.",
    "Verified imports of `ui/src/features/terminal-work/public` in `ui/src` continue to resolve only terminal-work component and type consumers after the cleanup.",
    "Observable terminal-work consumer behavior remains unchanged after the export cleanup, with targeted runtime tests still proving localized copy and selection behavior through the existing terminal-work component seam.",
    "No terminal-work component behavior, public component exports, or public type exports change as part of this slice.",
    "`ui/src/features/terminal-work/messages/index.ts` remains in the repository unchanged for follow-up work.",
    "The implementation stays limited to the terminal-work public barrel seam and does not expand into terminal-work component, story, or i18n import retargeting.",
    "Quality gate: frontend typecheck, lint, and targeted tests pass."
  ],
  "userStories": [
    {
      "id": "remove-terminal-work-public-messages-re-export-001",
      "title": "Retire the unused terminal-work messages public re-export",
      "description": "As a frontend maintainer, I want the terminal-work public barrel to stop re-exporting terminal-work messages so that the feature public surface reflects actual supported component and type usage without changing runtime behavior.",
      "acceptanceCriteria": [
        "`ui/src/features/terminal-work/public/index.ts` deletes `export * from \"../messages\";`.",
        "Repo-local verification with `rg -n \"features/terminal-work/public\" ui/src` continues to show only component and type consumers, not terminal-work message helper or message-type consumers.",
        "The cleanup does not retarget terminal-work component, story, or i18n imports and does not delete `ui/src/features/terminal-work/messages/index.ts`.",
        "Observable runtime behavior remains unchanged for existing terminal-work consumers, with targeted tests continuing to prove localized copy and selection behavior through the component seam after the export removal.",
        "The narrowed public barrel continues to compile for existing consumers after the export removal.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    }
  ]
}
