### PR TITLE
remove-submit-work-card-public-re-export

### DIFF
--- a/ui/src/features/current-selection/components/detail-card-types.ts
+++ b/ui/src/features/current-selection/components/detail-card-types.ts
@@ -229,6 +229,7 @@ export interface WorkstationActiveWorkListProps {
   now: number;
   onSelectWorkID?: (workID: string) => void;
   onSelectWorkstationRequest?: (request: DashboardWorkstationRequest) => void;
+  selectedNode: DashboardWorkstationNode;
   selectedRequest?: DashboardWorkstationRequest | null;
   selectedWorkID?: string | null;
   workstationRequestsByDispatchID?: Record<string, DashboardWorkstationRequest>;

--- a/ui/src/features/current-selection/components/workstation-detail-card.tsx
+++ b/ui/src/features/current-selection/components/workstation-detail-card.tsx
@@ -95,6 +95,7 @@ export function WorkstationDetailCard({
         now={now}
         onSelectWorkID={onSelectWorkID}
         onSelectWorkstationRequest={onSelectWorkstationRequest}
+        selectedNode={selectedNode}
         selectedRequest={selectedRequest}
         selectedWorkID={selectedWorkID}
         workstationRequestsByDispatchID={workstationRequestsByDispatchID}
@@ -402,6 +403,7 @@ function WorkstationActiveWorkList({
   now,
   onSelectWorkID,
   onSelectWorkstationRequest,
+  selectedNode,
   selectedRequest,
   selectedWorkID,
   workstationRequestsByDispatchID,

--- a/ui/src/features/submit-work/public/index.test.tsx
+++ b/ui/src/features/submit-work/public/index.test.tsx
@@ -1,0 +1,60 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, within } from "@testing-library/react";
+
+import { DEFAULT_FACTORY_SESSION_ID } from "../../../api/session-routing";
+import {
+  resetDashboardSessionStore,
+  useDashboardSessionStore,
+} from "../../dashboard/state/dashboardSessionStore";
+import { SubmitWorkWidget } from "./index";
+
+describe("submit-work public barrel", () => {
+  beforeEach(() => {
+    resetDashboardSessionStore();
+    useDashboardSessionStore.setState({
+      selectedSessionID: DEFAULT_FACTORY_SESSION_ID,
+    });
+  });
+
+  it("keeps SubmitWorkWidget rendering the submit form through the public export", () => {
+    renderSubmitWorkWidget(
+      <SubmitWorkWidget submitWorkTypes={[{ work_type_name: "story" }]} />,
+    );
+
+    const card = screen.getByRole("article", { name: "Submit work" });
+
+    expect(
+      within(card).getByRole("combobox", { name: "Work type" }),
+    ).toBeTruthy();
+    expect(
+      within(card).getByRole("textbox", { name: "Request name" }),
+    ).toBeTruthy();
+    expect(
+      within(card).getByRole("list", { name: "Submission items" }),
+    ).toBeTruthy();
+    expect(
+      within(card).getByRole("textbox", { name: "Text item 1" }),
+    ).toBeTruthy();
+    expect(
+      within(card).getByRole("button", { name: "Submit work" }),
+    ).toBeTruthy();
+  });
+});
+
+function renderSubmitWorkWidget(element: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: {
+        retry: false,
+      },
+      queries: {
+        gcTime: Infinity,
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>{element}</QueryClientProvider>,
+  );
+}

--- a/ui/src/features/submit-work/public/index.ts
+++ b/ui/src/features/submit-work/public/index.ts
@@ -1,2 +1,1 @@
-export * from "../components/submit-work-card";
 export * from "../components/submit-work-widget";


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/remove-submit-work-card-public-re-export",
  "description": "Remove the unused SubmitWorkCard re-export from the submit-work public barrel while keeping SubmitWorkWidget publicly exported, preserving existing direct internal imports, and proving the cleanup does not change website behavior.",
  "context": {
    "customerAsk": "Remove the unused SubmitWorkCard re-export from ui/src/features/submit-work/public/index.ts, keep the SubmitWorkWidget re-export intact, do not change direct internal imports that already target ./submit-work-card, keep the change limited to this one-file seam, confirm that no repo-local imports still pull SubmitWorkCard through the submit-work public barrel, and run the smallest targeted frontend verification appropriate for the touched public barrel.",
    "problem": "The submit-work public barrel currently exposes both SubmitWorkCard and SubmitWorkWidget, but the verified public-barrel usage only consumes SubmitWorkWidget. Keeping SubmitWorkCard in the barrel advertises a broader public surface than the repo actively uses, adds unnecessary re-export indirection, and works against the customer's direction to remove unnecessary re-exports and move toward direct imports where appropriate.",
    "solution": "Trim ui/src/features/submit-work/public/index.ts so it re-exports only SubmitWorkWidget, leave direct component-path imports of SubmitWorkCard unchanged, verify that no repo-local import still requests SubmitWorkCard from the submit-work public barrel, and use focused frontend quality checks to prove the cleanup preserves existing behavior."
  },
  "acceptanceCriteria": [
    "ui/src/features/submit-work/public/index.ts no longer re-exports SubmitWorkCard.",
    "ui/src/features/submit-work/public/index.ts continues to re-export SubmitWorkWidget.",
    "Direct internal imports that already reference ./submit-work-card remain unchanged.",
    "Repo-local verification shows no remaining imports of SubmitWorkCard through ui/src/features/submit-work/public.",
    "The submit-work implementation change remains limited to the touched public barrel seam and does not broaden into a larger submit-work barrel or import-surface reorganization; the focused public-seam test and the minimal current-head mergeability repair needed for UI typecheck are allowed follow-up work on this PR head.",
    "Focused automated coverage proves a SubmitWorkWidget consumer still renders the submit-work form through the public barrel after the cleanup.",
    "Quality gate: the smallest relevant frontend typecheck, lint, and automated test coverage for the touched barrel seam pass."
  ],
  "userStories": [
    {
      "id": "remove-submit-work-card-public-re-export-001",
      "title": "Trim the submit-work public barrel to the live public export",
      "description": "As a frontend maintainer, I want the submit-work public barrel to expose only SubmitWorkWidget so that the feature's public surface matches the repo's actual public usage without changing submit-work behavior.",
      "acceptanceCriteria": [
        "ui/src/features/submit-work/public/index.ts removes the SubmitWorkCard re-export and keeps the SubmitWorkWidget re-export intact.",
        "Existing direct internal imports of SubmitWorkCard, including component-path imports such as ./submit-work-card, remain unchanged.",
        "Repo-local verification confirms there are no remaining imports of SubmitWorkCard through ui/src/features/submit-work/public.",
        "The cleanup stays limited to the touched public barrel file and does not introduce replacement barrels, aliases, or broader import rewrites; the focused public-seam test and the minimal current-head mergeability repair needed for UI typecheck are allowed follow-up work on this PR head.",
        "Focused automated coverage proves a SubmitWorkWidget consumer still renders the submit-work form through the public barrel after the cleanup.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    }
  ]
}
