### PR TITLE
remove-terminal-work-card-public-re-export

### DIFF
--- a/ui/src/features/terminal-work/public/index.ts
+++ b/ui/src/features/terminal-work/public/index.ts
@@ -1,3 +1,2 @@
-export * from "../components/terminal-work-card";
 export * from "../components/terminal-work-widget";
 export * from "../lib/types";


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/remove-terminal-work-card-public-re-export",
  "description": "Remove the unused terminal-work card re-export from the terminal-work public barrel so the feature's public website surface exposes only the live widget and type exports while preserving existing behavior.",
  "context": {
    "customerAsk": "Remove the unused terminal-work card re-export from ui/src/features/terminal-work/public/index.ts, keep the ../components/terminal-work-widget and ../lib/types re-exports intact, preserve direct internal imports that already point at ./terminal-work-card, confirm there are no remaining imports of CompletedFailedWorkstationCard through the terminal-work public barrel, and run only the smallest targeted frontend verification needed for the touched public barrel seam.",
    "problem": "ui/src/features/terminal-work/public/index.ts still re-exports ../components/terminal-work-card even though repository-local public-barrel consumers only use TerminalWorkWidget and terminal-work types. That redundant export widens the apparent public feature surface, adds maintenance noise, and works against the customer goal of moving the website toward direct imports.",
    "solution": "Delete only the ../components/terminal-work-card re-export from the terminal-work public barrel, leave the widget and type re-exports unchanged, keep direct internal terminal-work-card imports in place, and verify through repo-local import checks plus the smallest relevant frontend typecheck or lint lane that the live public surface remains intact."
  },
  "acceptanceCriteria": [
    "ui/src/features/terminal-work/public/index.ts no longer re-exports ../components/terminal-work-card.",
    "The terminal-work public barrel continues to re-export ../components/terminal-work-widget and ../lib/types unchanged.",
    "Repository-local consumers that use the terminal-work public barrel continue to resolve TerminalWorkWidget and terminal-work types without requiring import-path changes.",
    "CompletedFailedWorkstationCard remains available only through direct component-path imports, and no repo-local imports continue to reach it through ui/src/features/terminal-work/public.",
    "The implementation remains a one-file, behavior-preserving cleanup and does not expand into broader terminal-work barrel reorganization or internal component import rewrites.",
    "Focused frontend verification covers the touched public barrel seam with the smallest relevant static or automated check.",
    "Quality gate: typecheck, lint, and relevant automated tests pass."
  ],
  "userStories": [
    {
      "id": "remove-terminal-work-card-public-re-export-001",
      "title": "Remove the unused card export from the terminal-work public surface",
      "description": "As a frontend maintainer, I want the terminal-work public barrel to stop re-exporting the unused card component so that the feature's public surface matches the live import patterns the website actually supports.",
      "acceptanceCriteria": [
        "ui/src/features/terminal-work/public/index.ts removes only the export * from \"../components/terminal-work-card\" line.",
        "The barrel keeps the ../components/terminal-work-widget and ../lib/types re-exports intact.",
        "No direct internal imports that already target ./terminal-work-card are changed by this cleanup.",
        "The implementation does not introduce a replacement wrapper, alias, or alternate public export path for CompletedFailedWorkstationCard.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "remove-terminal-work-card-public-re-export-002",
      "title": "Prove the public barrel still supports only the live terminal-work surface",
      "description": "As a reviewer, I want focused verification that the terminal-work public barrel no longer exposes the card component while continuing to support the live widget and type imports so that this cleanup is clearly complete and behavior-preserving.",
      "acceptanceCriteria": [
        "Repo-local verification confirms there are no remaining imports of CompletedFailedWorkstationCard through ui/src/features/terminal-work/public.",
        "Repo-local verification confirms barrel consumers continue to import only TerminalWorkWidget and terminal-work types such as TerminalWorkItem, TerminalWorkStatus, and TerminalWorkDetail.",
        "Focused frontend verification runs the smallest relevant lint or typecheck lane for the touched public barrel seam.",
        "Verification stays behavioral and seam-focused rather than asserting broader barrel inventories or unrelated feature structure.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
