### PR TITLE
remove-trace-grid-card-public-re-export

### DIFF
--- a/ui/src/features/trace-drilldown/public/index.ts
+++ b/ui/src/features/trace-drilldown/public/index.ts
@@ -1,3 +1,2 @@
-export * from "../components/trace-grid-card";
 export * from "../components/trace-drilldown-widget";
 export * from "../hooks/useTraceDrilldown";


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/remove-trace-grid-card-public-re-export",
  "description": "Remove the internal TraceGridBentoCard and TraceGridState re-export from the trace-drilldown public barrel, keep TraceDrilldownWidget and useTraceDrilldown publicly exported for runtime consumers, and prove the cleanup preserves website behavior.",
  "context": {
    "customerAsk": "Remove only the ../components/trace-grid-card export from ui/src/features/trace-drilldown/public/index.ts, keep TraceDrilldownWidget and useTraceDrilldown exported, do not change TraceDrilldownWidget, do not reorganize trace-drilldown components, hooks, tests, or stories, do not add compatibility aliases or new public barrel layers, confirm no cross-feature imports rely on TraceGridBentoCard or TraceGridState through ../../trace-drilldown/public, and run the smallest relevant frontend verification for the public barrel and trace drilldown widget/card.",
    "problem": "The trace-drilldown public barrel advertises internal grid card symbols that are not needed by runtime cross-feature consumers. Keeping TraceGridBentoCard and TraceGridState on the public surface makes the feature boundary broader than current behavior requires, adds unnecessary re-export indirection, and conflicts with the customer direction to remove unnecessary website public re-exports in favor of direct imports.",
    "solution": "Trim ui/src/features/trace-drilldown/public/index.ts so it continues to export TraceDrilldownWidget and useTraceDrilldown but no longer exports ../components/trace-grid-card, leave TraceDrilldownWidget unchanged with its direct ./trace-grid-card import, verify that no cross-feature public-barrel consumer imports TraceGridBentoCard or TraceGridState through ../../trace-drilldown/public, and run the smallest relevant frontend verification available for the trace-drilldown public barrel and widget/card surface."
  },
  "acceptanceCriteria": [
    "ui/src/features/trace-drilldown/public/index.ts no longer re-exports ../components/trace-grid-card.",
    "ui/src/features/trace-drilldown/public/index.ts continues to export TraceDrilldownWidget.",
    "ui/src/features/trace-drilldown/public/index.ts continues to export useTraceDrilldown.",
    "TraceDrilldownWidget runtime behavior remains unchanged because its direct ./trace-grid-card import is left intact.",
    "rg \"TraceGridBentoCard|TraceGridState\" ui/src/features -n confirms no cross-feature public-barrel consumer requires the removed export.",
    "No compatibility alias, replacement wrapper, new public barrel, component move, hook move, test reorganization, or story reorganization is introduced.",
    "Quality gate: typecheck, lint, and the smallest relevant frontend tests or equivalent targeted verification pass."
  ],
  "userStories": [
    {
      "id": "remove-trace-grid-card-public-re-export-001",
      "title": "Remove the internal trace grid card public export",
      "description": "As a frontend maintainer, I want the trace-drilldown public barrel to expose only the cross-feature widget and hook surface so that internal grid card symbols do not define the feature's public API.",
      "acceptanceCriteria": [
        "ui/src/features/trace-drilldown/public/index.ts removes the ../components/trace-grid-card export.",
        "ui/src/features/trace-drilldown/public/index.ts keeps the TraceDrilldownWidget export intact.",
        "ui/src/features/trace-drilldown/public/index.ts keeps the useTraceDrilldown export intact.",
        "TraceDrilldownWidget is not edited and continues to import TraceGridBentoCard and TraceGridState directly from ./trace-grid-card.",
        "rg \"TraceGridBentoCard|TraceGridState\" ui/src/features -n shows no cross-feature import of TraceGridBentoCard or TraceGridState from ../../trace-drilldown/public.",
        "No compatibility alias, wrapper, or new public barrel layer is added for TraceGridBentoCard or TraceGridState.",
        "The smallest relevant frontend verification for the trace-drilldown public barrel and widget/card runs successfully, such as targeted Vitest coverage if cheap or the normal frontend typecheck/lint gate.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    }
  ]
}
