### PR TITLE
remove-work-outcome-internal-public-re-exports

### DIFF
--- a/ui/src/features/work-outcome/public/index.ts
+++ b/ui/src/features/work-outcome/public/index.ts
@@ -1,7 +1,2 @@
-export * from "../components/d3-information-card";
-export * from "../components/trend-cards";
-export * from "../components/work-chart";
 export * from "../components/work-outcome-widget";
 export * from "../hooks/useWorkOutcomeChart";
-export * from "../lib/chart-contract";
-export * from "../lib/trends";


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/remove-work-outcome-internal-public-re-exports",
  "description": "Remove internal work-outcome component and library re-exports from the work-outcome public barrel while keeping only WorkOutcomeWidget and useWorkOutcomeChart as the intentional cross-feature public surface.",
  "context": {
    "customerAsk": "Remove internal work-outcome component and library re-exports from ui/src/features/work-outcome/public/index.ts. Remove re-exports for ../components/d3-information-card, ../components/trend-cards, ../components/work-chart, ../lib/chart-contract, and ../lib/trends. Keep only ../components/work-outcome-widget and ../hooks/useWorkOutcomeChart. Confirm no cross-feature imports rely on the removed work-outcome exports and run the smallest relevant frontend verification for the public barrel and bento consumers.",
    "problem": "The work-outcome public barrel exposes internal chart components and library helpers that cross-feature runtime consumers do not need. This broadens the apparent public API, keeps unnecessary re-export indirection alive, and conflicts with the customer direction to remove unnecessary website public re-exports and move toward direct imports where appropriate.",
    "solution": "Trim ui/src/features/work-outcome/public/index.ts to expose only WorkOutcomeWidget and useWorkOutcomeChart, leave internal work-outcome component and library files untouched, avoid compatibility aliases or replacement barrels, verify public-barrel consumers use only the intended symbols, and run focused frontend verification for the bento/work-outcome surfaces."
  },
  "acceptanceCriteria": [
    "ui/src/features/work-outcome/public/index.ts no longer re-exports ../components/d3-information-card, ../components/trend-cards, ../components/work-chart, ../lib/chart-contract, or ../lib/trends.",
    "ui/src/features/work-outcome/public/index.ts continues to export WorkOutcomeWidget and useWorkOutcomeChart.",
    "Existing bento consumers that import from ../../work-outcome/public continue to use only WorkOutcomeWidget and useWorkOutcomeChart.",
    "No compatibility alias, replacement barrel, or broad work-outcome import reorganization is introduced.",
    "WorkOutcomeWidget and useWorkOutcomeChart runtime behavior remain unchanged.",
    "Repo-local verification with rg \"from ['\\\\\\\"].*work-outcome/public|work-outcome/public\" ui/src -n confirms public-barrel consumers only rely on WorkOutcomeWidget and useWorkOutcomeChart.",
    "Quality gate: typecheck, lint, and relevant targeted frontend tests pass."
  ],
  "userStories": [
    {
      "id": "remove-work-outcome-internal-public-re-exports-001",
      "title": "Trim the work-outcome public barrel to the intentional exports",
      "description": "As a frontend maintainer, I want the work-outcome public barrel to expose only the widget and chart hook used by cross-feature consumers so that internal chart components and helpers do not define the feature's public API.",
      "acceptanceCriteria": [
        "ui/src/features/work-outcome/public/index.ts removes the re-exports for ../components/d3-information-card, ../components/trend-cards, ../components/work-chart, ../lib/chart-contract, and ../lib/trends.",
        "ui/src/features/work-outcome/public/index.ts keeps the exports for ../components/work-outcome-widget and ../hooks/useWorkOutcomeChart.",
        "Bento imports from ../../work-outcome/public continue to resolve WorkOutcomeWidget and useWorkOutcomeChart.",
        "No compatibility alias, replacement barrel, or unrelated work-outcome file reorganization is added.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "remove-work-outcome-internal-public-re-exports-002",
      "title": "Prove cross-feature consumers do not rely on removed exports",
      "description": "As a maintainer, I want direct verification that cross-feature consumers rely only on the intended work-outcome public exports so that removing internal re-exports does not create hidden dashboard regressions.",
      "acceptanceCriteria": [
        "Running rg \"from ['\\\\\\\"].*work-outcome/public|work-outcome/public\" ui/src -n shows public-barrel consumers only importing or mocking WorkOutcomeWidget and useWorkOutcomeChart.",
        "ui/src/features/bento/components/dashboard-bento-cards.tsx, ui/src/features/bento/components/dashboard-bento.tsx, and ui/src/features/bento/components/dashboard-bento.test.tsx continue to compile with their existing ../../work-outcome/public imports or mocks.",
        "Focused frontend verification runs the relevant bento/work-outcome Vitest files when cheap, or the normal local frontend typecheck/lint gate when that is the smallest reliable verification path.",
        "The cleanup remains behavior-preserving and does not change WorkOutcomeWidget rendering, useWorkOutcomeChart data behavior, dashboard layout, loading state, empty state, error state, accessibility behavior, or responsive behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
