### PR TITLE
Enable work chart legend toggles

### DIFF
--- a/ui/src/components/ui/chart.tsx
+++ b/ui/src/components/ui/chart.tsx
@@ -1,4 +1,9 @@
-import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
+import type {
+  CSSProperties,
+  HTMLAttributes,
+  MouseEvent as ReactMouseEvent,
+  ReactNode,
+} from "react";
 import { createContext, useContext } from "react";
 import {
   Legend as RechartsLegend,
@@ -14,8 +19,8 @@ import type {
   NameType,
   ValueType,
 } from "recharts/types/component/DefaultTooltipContent";
-
 import { cn } from "../../lib/cn";
+import { Button } from "./button";
 
 export interface ChartConfigEntry {
   color: string;
@@ -151,13 +156,25 @@ export function ChartTooltipContent({
 
 export function ChartLegendContent({
   className,
+  getToggleLabel,
+  hiddenSeries = new Set<string>(),
+  onToggleSeries,
   payload,
-}: RechartsLegendContentProps & { className?: string }) {
+}: RechartsLegendContentProps & {
+  className?: string;
+  getToggleLabel?: (label: string, hidden: boolean) => string;
+  hiddenSeries?: ReadonlySet<string>;
+  onToggleSeries?: (key: string) => void;
+}) {
   const config = useChartConfig();
 
   if (!payload?.length) {
     return null;
   }
+
+  const stopChartInteraction = (event: ReactMouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+  };
 
   return (
     <div
@@ -169,17 +186,55 @@ export function ChartLegendContent({
       {payload.map((entry: LegendPayload) => {
         const key = entry.dataKey?.toString() ?? "";
         const item = config[key];
-
-        return (
-          <div className="flex items-center gap-2" key={key}>
+        const label = item?.label ?? key;
+        const hidden = hiddenSeries.has(key);
+        const content = (
+          <>
             <span
-              className="h-2.5 w-2.5 rounded-full"
+              aria-hidden="true"
+              className={cn(
+                "h-2.5 w-2.5 rounded-full",
+                hidden ? "border border-af-border bg-af-surface-subtle" : "",
+              )}
               style={{
-                backgroundColor: item?.color ?? entry.color ?? "currentColor",
+                backgroundColor: hidden
+                  ? undefined
+                  : (item?.color ?? entry.color ?? "currentColor"),
               }}
             />
-            <span>{item?.label ?? key}</span>
-          </div>
+            <span>{label}</span>
+          </>
+        );
+
+        if (!onToggleSeries) {
+          return (
+            <div className="flex items-center gap-2" key={key}>
+              {content}
+            </div>
+          );
+        }
+
+        return (
+          <Button
+            aria-label={getToggleLabel?.(label, hidden) ?? label}
+            aria-pressed={!hidden}
+            className={cn(
+              "min-h-0 rounded-md border-transparent px-0 py-1 text-left font-normal focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-af-focus",
+              hidden ? "text-af-text-disabled" : "",
+            )}
+            data-chart-legend-series={key}
+            data-chart-legend-series-hidden={hidden ? "true" : "false"}
+            key={key}
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggleSeries(key);
+            }}
+            onMouseDown={stopChartInteraction}
+            size="sm"
+            tone="ghost"
+          >
+            {content}
+          </Button>
         );
       })}
     </div>

--- a/ui/src/features/work-outcome/components/d3-information-card.test.tsx
+++ b/ui/src/features/work-outcome/components/d3-information-card.test.tsx
@@ -1,8 +1,14 @@
-import { cleanup, render, screen, within } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 
 import { installDashboardBrowserTestShims } from "../../../components/dashboard/test-browser-shims";
-import { D3CompletionInformationCard } from "./d3-information-card";
 import type { WorkChartModel } from "../lib/trends";
+import { D3CompletionInformationCard } from "./d3-information-card";
 
 const populatedTrend: WorkChartModel = {
   delta: {
@@ -127,10 +133,16 @@ describe("D3CompletionInformationCard", () => {
     );
 
     const card = screen.getByRole("article", { name: "Work outcome chart" });
-    expect(within(card).queryByRole("combobox", { name: "Time range" })).toBeNull();
-    expect(within(card).queryByRole("list", { name: "Work outcome totals" })).toBeNull();
+    expect(
+      within(card).queryByRole("combobox", { name: "Time range" }),
+    ).toBeNull();
+    expect(
+      within(card).queryByRole("list", { name: "Work outcome totals" }),
+    ).toBeNull();
     expect(within(card).queryByText("Completed in range")).toBeNull();
-    const chart = within(card).getByRole("img", { name: "Work outcome chart for 15m" });
+    const chart = within(card).getByRole("img", {
+      name: "Work outcome chart for 15m",
+    });
     expect(chart).toBeTruthy();
     expect(card.querySelector(".recharts-wrapper")).toBeTruthy();
     expect(within(chart).getByText("Queued")).toBeTruthy();
@@ -140,7 +152,9 @@ describe("D3CompletionInformationCard", () => {
     expect(within(chart).getByText("Ticks")).toBeTruthy();
     expect(within(chart).getByText("Work count")).toBeTruthy();
     expect(chart.getAttribute("data-work-chart-ready")).toBe("true");
-    const chartRegion = within(card).getByLabelText("Work outcome chart region");
+    const chartRegion = within(card).getByLabelText(
+      "Work outcome chart region",
+    );
     expect(chartRegion.className).toContain("flex");
     expect(chartRegion.className).toContain("flex-1");
     expect(chartRegion.className).toContain("min-h-0");
@@ -158,7 +172,9 @@ describe("D3CompletionInformationCard", () => {
     expect(chart.className).toContain("sm:pt-5");
     expect(chart.style.height).toBe("");
     expect(chart.style.minHeight).toBe("14rem");
-    const overlay = chart.querySelector<HTMLElement>("[data-work-chart-overlay='true']");
+    const overlay = chart.querySelector<HTMLElement>(
+      "[data-work-chart-overlay='true']",
+    );
     expect(overlay).toBeTruthy();
     expect(overlay?.className).toContain("px-5");
     expect(overlay?.className).toContain("pb-4");
@@ -168,17 +184,60 @@ describe("D3CompletionInformationCard", () => {
     expect(overlay?.className).toContain("sm:pt-5");
   });
 
-  it("renders an explicit empty state without a chart when samples are unavailable", () => {
+  it("toggles chart lines when the legend controls are clicked", () => {
     render(
       <D3CompletionInformationCard
-        model={emptyTrend}
+        model={populatedTrend}
+        widgetId="work-outcome-chart"
       />,
     );
 
-    expect(screen.queryByRole("img", { name: "Work outcome chart for 15m" })).toBeNull();
+    const chart = screen.getByRole("img", {
+      name: "Work outcome chart for 15m",
+    });
+    const queuedLegendControl = within(chart).getByRole("button", {
+      name: "Hide Queued series",
+    });
+    expect(queuedLegendControl.getAttribute("aria-pressed")).toBe("true");
+    expect(chart.getAttribute("data-work-chart-hidden-series")).toBe("");
+    expect(chart.getAttribute("data-work-chart-visible-series")).toContain(
+      "queued",
+    );
+
+    fireEvent.click(queuedLegendControl);
+
+    expect(
+      within(chart).getByRole("button", { name: "Show Queued series" }),
+    ).toBeTruthy();
+    expect(chart.getAttribute("data-work-chart-hidden-series")).toBe("queued");
+    expect(chart.getAttribute("data-work-chart-visible-series")).not.toContain(
+      "queued",
+    );
+
+    fireEvent.click(
+      within(chart).getByRole("button", { name: "Show Queued series" }),
+    );
+
+    expect(
+      within(chart).getByRole("button", { name: "Hide Queued series" }),
+    ).toBeTruthy();
+    expect(chart.getAttribute("data-work-chart-hidden-series")).toBe("");
+    expect(chart.getAttribute("data-work-chart-visible-series")).toContain(
+      "queued",
+    );
+  });
+
+  it("renders an explicit empty state without a chart when samples are unavailable", () => {
+    render(<D3CompletionInformationCard model={emptyTrend} />);
+
+    expect(
+      screen.queryByRole("img", { name: "Work outcome chart for 15m" }),
+    ).toBeNull();
     expect(screen.getByText("No work outcome samples")).toBeTruthy();
     expect(
-      screen.getByText("Work outcome data appears after the event stream receives work history."),
+      screen.getByText(
+        "Work outcome data appears after the event stream receives work history.",
+      ),
     ).toBeTruthy();
     const emptyState = screen.getByRole("status");
     expect(emptyState.className).toContain("h-full");
@@ -198,7 +257,9 @@ describe("D3CompletionInformationCard", () => {
     );
 
     const card = screen.getByRole("article", { name: "Work outcome chart" });
-    expect(within(card).queryByRole("combobox", { name: "Time range" })).toBeNull();
+    expect(
+      within(card).queryByRole("combobox", { name: "Time range" }),
+    ).toBeNull();
     const loadingState = within(card).getByRole("status");
     expect(loadingState).toBeTruthy();
     expect(within(card).getByText("Loading work outcome samples")).toBeTruthy();
@@ -224,7 +285,9 @@ describe("D3CompletionInformationCard", () => {
     const card = screen.getByRole("article", { name: "Work outcome chart" });
     const alert = within(card).getByRole("alert");
     expect(alert).toBeTruthy();
-    expect(within(alert).getByText("Work outcome chart unavailable")).toBeTruthy();
+    expect(
+      within(alert).getByText("Work outcome chart unavailable"),
+    ).toBeTruthy();
     expect(
       within(alert).getByText(
         "Chart data is incomplete, so the dashboard cannot draw this work outcome view yet.",

--- a/ui/src/features/work-outcome/components/d3-information-card.tsx
+++ b/ui/src/features/work-outcome/components/d3-information-card.tsx
@@ -1,13 +1,12 @@
 import type { ReactNode } from "react";
-
-import { getDashboardWorkChartSeriesDefinitions } from "../lib/chart-contract";
-import { cn } from "../../../lib/cn";
-import type { WorkChartModel } from "../lib/trends";
-import { WorkChart } from "./work-chart";
-import type { WorkChartSeriesDefinition, WorkChartState } from "./work-chart";
 import { DASHBOARD_WIDGET_CLASS } from "../../../components/dashboard/widget-board";
 import { AgentBentoCard } from "../../../components/ui";
+import { cn } from "../../../lib/cn";
+import { getDashboardWorkChartSeriesDefinitions } from "../lib/chart-contract";
+import type { WorkChartModel } from "../lib/trends";
 import { getWorkOutcomeMessages } from "../messages/work-outcome";
+import type { WorkChartSeriesDefinition, WorkChartState } from "./work-chart";
+import { WorkChart } from "./work-chart";
 
 export interface WorkChartCardProps {
   chartState?: WorkChartState;
@@ -20,7 +19,7 @@ export interface WorkChartCardProps {
 }
 
 const WORK_CHART_BODY_CLASS =
-  "!flex !min-h-0 !flex-col !gap-0 !overflow-hidden !p-0";
+  "!flex !min-h-0 !flex-col !gap-0 !overflow-hidden px-0 pb-5";
 const WORK_CHART_REGION_CLASS = "flex min-h-0 flex-1 px-4 sm:px-5";
 
 export function WorkChartCard({
@@ -34,7 +33,9 @@ export function WorkChartCard({
 }: WorkChartCardProps) {
   const messages = getWorkOutcomeMessages(locale);
   const chartMessages = messages.chart;
-  const chartRegionID = widgetId ? `${widgetId}-chart-region` : "work-outcome-chart-region";
+  const chartRegionID = widgetId
+    ? `${widgetId}-chart-region`
+    : "work-outcome-chart-region";
   const cardClassName = cn(DASHBOARD_WIDGET_CLASS, className);
   const resolvedTitle = title ?? chartMessages.cardTitle;
   const chartSeries: readonly WorkChartSeriesDefinition[] =

--- a/ui/src/features/work-outcome/components/work-chart-interactions.ts
+++ b/ui/src/features/work-outcome/components/work-chart-interactions.ts
@@ -1,0 +1,139 @@
+import type { MouseEvent as ReactMouseEvent } from "react";
+import { useMemo, useState } from "react";
+
+import type { WorkChartData, WorkChartRow } from "../lib/work-chart-data";
+
+export interface WorkChartZoomRange {
+  endTick: number;
+  startTick: number;
+}
+
+export function useReadyWorkChartInteractions(chartData: WorkChartData) {
+  const [zoomRange, setZoomRange] = useState<WorkChartZoomRange | null>(null);
+  const [hiddenSeriesKeys, setHiddenSeriesKeys] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const [selectionStartTick, setSelectionStartTick] = useState<number | null>(
+    null,
+  );
+  const [selectionEndTick, setSelectionEndTick] = useState<number | null>(null);
+  const visibleRows = useMemo(
+    () => filterRowsForZoomRange(chartData.rows, zoomRange),
+    [chartData.rows, zoomRange],
+  );
+  const selectionRange = buildSelectionRange(
+    selectionStartTick,
+    selectionEndTick,
+  );
+  const visibleSeriesKeys = chartData.series
+    .filter((seriesEntry) => !hiddenSeriesKeys.has(seriesEntry.key))
+    .map((seriesEntry) => seriesEntry.key);
+
+  const resetZoom = () => {
+    setZoomRange(null);
+  };
+
+  const toggleSeries = (key: string) => {
+    setHiddenSeriesKeys((current) => {
+      const next = new Set(current);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
+
+  const beginSelection = (event: ReactMouseEvent<HTMLDivElement>) => {
+    const tick = readPointerTick(event, visibleRows);
+    setSelectionStartTick(tick);
+    setSelectionEndTick(tick);
+  };
+
+  const updateSelection = (event: ReactMouseEvent<HTMLDivElement>) => {
+    if (selectionStartTick === null) {
+      return;
+    }
+
+    const tick = readPointerTick(event, visibleRows);
+    if (tick !== null) {
+      setSelectionEndTick(tick);
+    }
+  };
+
+  const commitSelection = (event: ReactMouseEvent<HTMLDivElement>) => {
+    const endTick = readPointerTick(event, visibleRows) ?? selectionEndTick;
+    const nextRange = buildSelectionRange(selectionStartTick, endTick);
+    setSelectionStartTick(null);
+    setSelectionEndTick(null);
+
+    if (nextRange === null || nextRange.startTick === nextRange.endTick) {
+      return;
+    }
+
+    setZoomRange(nextRange);
+  };
+
+  return {
+    beginSelection,
+    commitSelection,
+    hiddenSeriesKeys,
+    resetZoom,
+    selectionRange,
+    toggleSeries,
+    updateSelection,
+    visibleRows,
+    visibleSeriesKeys,
+    zoomRange,
+  };
+}
+
+function filterRowsForZoomRange(
+  rows: readonly WorkChartRow[],
+  zoomRange: WorkChartZoomRange | null,
+): WorkChartRow[] {
+  if (zoomRange === null) {
+    return [...rows];
+  }
+
+  const filteredRows = rows.filter(
+    (row) => row.tick >= zoomRange.startTick && row.tick <= zoomRange.endTick,
+  );
+  return filteredRows.length >= 2 ? filteredRows : [...rows];
+}
+
+function buildSelectionRange(
+  startTick: number | null,
+  endTick: number | null,
+): WorkChartZoomRange | null {
+  if (startTick === null || endTick === null) {
+    return null;
+  }
+
+  return {
+    endTick: Math.max(startTick, endTick),
+    startTick: Math.min(startTick, endTick),
+  };
+}
+
+function readPointerTick(
+  event: ReactMouseEvent<HTMLDivElement>,
+  rows: readonly WorkChartRow[],
+): number | null {
+  if (rows.length === 0) {
+    return null;
+  }
+
+  const rect = event.currentTarget.getBoundingClientRect();
+  if (!Number.isFinite(rect.width) || rect.width <= 0) {
+    return null;
+  }
+
+  const relativeX = Math.min(
+    Math.max(event.clientX - rect.left, 0),
+    rect.width,
+  );
+  const rowIndex = Math.round((relativeX / rect.width) * (rows.length - 1));
+  return rows[rowIndex]?.tick ?? null;
+}

--- a/ui/src/features/work-outcome/components/work-chart.tsx
+++ b/ui/src/features/work-outcome/components/work-chart.tsx
@@ -1,17 +1,18 @@
-import type { MouseEvent as ReactMouseEvent } from "react";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import {
   CartesianGrid,
+  Label,
   Line,
   LineChart,
   ReferenceArea,
   XAxis,
   YAxis,
 } from "recharts";
-
 import {
-  DASHBOARD_CHART_AXIS_LABEL_CLASS,
-} from "../lib/chart-contract";
+  EMPTY_STATE_CLASS,
+  EMPTY_STATE_COMPACT_CLASS,
+} from "../../../components/dashboard/widget-board";
+import { Button } from "../../../components/ui/button";
 import {
   ChartContainer,
   ChartLegend,
@@ -19,22 +20,21 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "../../../components/ui/chart";
-import { Button } from "../../../components/ui/button";
 import { Skeleton } from "../../../components/ui/skeleton";
 import { cn } from "../../../lib/cn";
-import {
-  EMPTY_STATE_CLASS,
-  EMPTY_STATE_COMPACT_CLASS,
-} from "../../../components/dashboard/widget-board";
-import { getWorkOutcomeMessages } from "../messages/work-outcome";
+import { DASHBOARD_CHART_AXIS_LABEL_CLASS } from "../lib/chart-contract";
 import type { WorkChartModel } from "../lib/trends";
 import {
   buildWorkChartData,
   type WorkChartBuiltSeries,
   type WorkChartData,
-  type WorkChartRow,
   type WorkChartSeriesDefinition,
 } from "../lib/work-chart-data";
+import { getWorkOutcomeMessages } from "../messages/work-outcome";
+import {
+  useReadyWorkChartInteractions,
+  type WorkChartZoomRange,
+} from "./work-chart-interactions";
 
 export type { WorkChartSeriesDefinition } from "../lib/work-chart-data";
 
@@ -46,12 +46,12 @@ const WORK_CHART_READY_CLASS =
 // tailwind-exception: intrinsic-sizing
 const WORK_CHART_STATUS_PANEL_CLASS =
   "flex h-full min-h-[14rem] min-w-0 w-full flex-1 flex-col justify-center";
-const WORK_CHART_SHELL_CLASS = "flex h-full min-h-0 min-w-0 w-full flex-1 flex-col gap-3";
+const WORK_CHART_SHELL_CLASS =
+  "flex h-full min-h-0 min-w-0 w-full flex-1 flex-col gap-3";
 const WORK_CHART_TOOLBAR_CLASS =
   "flex flex-wrap items-center justify-end gap-2";
 const WORK_CHART_OVERLAY_CLASS =
   "flex h-full flex-col gap-2 px-5 pb-4 pt-4 sm:px-6 sm:pb-5 sm:pt-5";
-const WORK_CHART_X_AXIS_OVERLAY_CLASS = "mt-auto self-end";
 const WORK_CHART_Y_AXIS_WIDTH = 52;
 
 export type WorkChartState =
@@ -179,49 +179,18 @@ function ReadyWorkChart({
   yAxisLabel,
 }: ReadyWorkChartProps) {
   const chartMessages = getWorkOutcomeMessages(locale).chart;
-  const [zoomRange, setZoomRange] = useState<WorkChartZoomRange | null>(null);
-  const [selectionStartTick, setSelectionStartTick] = useState<number | null>(
-    null,
-  );
-  const [selectionEndTick, setSelectionEndTick] = useState<number | null>(null);
-  const visibleRows = useMemo(
-    () => filterRowsForZoomRange(chartData.rows, zoomRange),
-    [chartData.rows, zoomRange],
-  );
-  const selectionRange = buildSelectionRange(
-    selectionStartTick,
-    selectionEndTick,
-  );
-
-  const beginSelection = (event: ReactMouseEvent<HTMLDivElement>) => {
-    const tick = readPointerTick(event, visibleRows);
-    setSelectionStartTick(tick);
-    setSelectionEndTick(tick);
-  };
-
-  const updateSelection = (event: ReactMouseEvent<HTMLDivElement>) => {
-    if (selectionStartTick === null) {
-      return;
-    }
-
-    const tick = readPointerTick(event, visibleRows);
-    if (tick !== null) {
-      setSelectionEndTick(tick);
-    }
-  };
-
-  const commitSelection = (event: ReactMouseEvent<HTMLDivElement>) => {
-    const endTick = readPointerTick(event, visibleRows) ?? selectionEndTick;
-    const nextRange = buildSelectionRange(selectionStartTick, endTick);
-    setSelectionStartTick(null);
-    setSelectionEndTick(null);
-
-    if (nextRange === null || nextRange.startTick === nextRange.endTick) {
-      return;
-    }
-
-    setZoomRange(nextRange);
-  };
+  const {
+    beginSelection,
+    commitSelection,
+    hiddenSeriesKeys,
+    resetZoom,
+    selectionRange,
+    toggleSeries,
+    updateSelection,
+    visibleRows,
+    visibleSeriesKeys,
+    zoomRange,
+  } = useReadyWorkChartInteractions(chartData);
 
   return (
     <div className={cn(WORK_CHART_SHELL_CLASS, className)}>
@@ -233,7 +202,7 @@ function ReadyWorkChart({
           <Button
             aria-label={chartMessages.resetZoomLabel}
             className="min-h-8 rounded-lg px-2.5 py-1.5 text-xs"
-            onClick={() => setZoomRange(null)}
+            onClick={resetZoom}
             size="sm"
             tone="outline"
           >
@@ -249,28 +218,15 @@ function ReadyWorkChart({
           onMouseMove: updateSelection,
           onMouseUp: commitSelection,
         }}
-        overlay={
-          <div className={WORK_CHART_OVERLAY_CLASS} data-work-chart-overlay="true">
-            <p className={cn("m-0", WORK_CHART_AXIS_LABEL_CLASS)}>
-              {yAxisLabel}
-            </p>
-            <p
-              className={cn(
-                "m-0",
-                WORK_CHART_AXIS_LABEL_CLASS,
-                WORK_CHART_X_AXIS_OVERLAY_CLASS,
-              )}
-            >
-              {xAxisLabel}
-            </p>
-          </div>
-        }
         rootAttributes={{
           "data-work-chart-ready": "true",
+          "data-work-chart-hidden-series": [...hiddenSeriesKeys].join(","),
+          "data-work-chart-visible-series": visibleSeriesKeys.join(","),
           "data-work-chart-visible-ticks": visibleRows
             .map((row) => row.tick)
             .join(","),
         }}
+        overlay={<WorkChartAxisOverlay yAxisLabel={yAxisLabel} />}
         style={{ minHeight: "14rem" }}
         title={ariaLabel}
       >
@@ -287,7 +243,11 @@ function ReadyWorkChart({
             tick={{ className: WORK_CHART_AXIS_LABEL_CLASS }}
             tickFormatter={(value) => formatAxisNumber(value)}
             tickLine={false}
-          />
+          >
+            <Label value="insideBottom" offset={-10} position="insideBottom">
+              {xAxisLabel}
+            </Label>
+          </XAxis>
           <YAxis
             allowDecimals={false}
             axisLine={false}
@@ -296,7 +256,16 @@ function ReadyWorkChart({
             tickFormatter={(value) => formatAxisNumber(value)}
             tickLine={false}
             width={WORK_CHART_Y_AXIS_WIDTH}
-          />
+          >
+            <Label
+              angle={-90}
+              value={yAxisLabel}
+              position="insideLeft"
+              style={{ textAnchor: "middle" }}
+            />
+          </YAxis>
+
+          <CartesianGrid strokeDasharray="3 3" />
           <ChartTooltip
             content={(props) => {
               const tickValue = props.payload?.[0]?.payload?.tick;
@@ -308,11 +277,34 @@ function ReadyWorkChart({
             }}
             cursor={{ stroke: "var(--color-af-chart-cursor)" }}
           />
-          <ChartLegend content={<ChartLegendContent />} />
+          <ChartLegend
+            content={
+              <ChartLegendContent
+                getToggleLabel={(label, hidden) =>
+                  hidden
+                    ? chartMessages.showSeriesLabel(label)
+                    : chartMessages.hideSeriesLabel(label)
+                }
+                hiddenSeries={hiddenSeriesKeys}
+                onToggleSeries={toggleSeries}
+              />
+            }
+          />
           <WorkChartSelectionArea selectionRange={selectionRange} />
-          <WorkChartLines series={chartData.series} />
+          <WorkChartLines
+            hiddenSeriesKeys={hiddenSeriesKeys}
+            series={chartData.series}
+          />
         </LineChart>
       </ChartContainer>
+    </div>
+  );
+}
+
+function WorkChartAxisOverlay({ yAxisLabel }: { yAxisLabel: string }) {
+  return (
+    <div className={WORK_CHART_OVERLAY_CLASS} data-work-chart-overlay="true">
+      <span className={WORK_CHART_AXIS_LABEL_CLASS}>{yAxisLabel}</span>
     </div>
   );
 }
@@ -340,8 +332,10 @@ function WorkChartSelectionArea({
 }
 
 function WorkChartLines({
+  hiddenSeriesKeys,
   series,
 }: {
+  hiddenSeriesKeys: ReadonlySet<string>;
   series: readonly WorkChartBuiltSeries[];
 }) {
   return series.map((seriesData) => (
@@ -357,8 +351,12 @@ function WorkChartLines({
       className={seriesData.lineClassName}
       data-chart-series={seriesData.key}
       data-chart-series-color={seriesData.lineColor}
+      data-chart-series-hidden={
+        hiddenSeriesKeys.has(seriesData.key) ? "true" : "false"
+      }
       dataKey={seriesData.key}
       dot={false}
+      hide={hiddenSeriesKeys.has(seriesData.key)}
       isAnimationActive={false}
       name={seriesData.label}
       stroke={seriesData.lineColor}
@@ -367,11 +365,6 @@ function WorkChartLines({
       type="linear"
     />
   ));
-}
-
-interface WorkChartZoomRange {
-  endTick: number;
-  startTick: number;
 }
 
 interface WorkChartStatusPanelProps {
@@ -410,55 +403,6 @@ function WorkChartStatusPanel({
       <p>{message}</p>
     </div>
   );
-}
-
-function filterRowsForZoomRange(
-  rows: readonly WorkChartRow[],
-  zoomRange: WorkChartZoomRange | null,
-): WorkChartRow[] {
-  if (zoomRange === null) {
-    return [...rows];
-  }
-
-  const filteredRows = rows.filter(
-    (row) => row.tick >= zoomRange.startTick && row.tick <= zoomRange.endTick,
-  );
-  return filteredRows.length >= 2 ? filteredRows : [...rows];
-}
-
-function buildSelectionRange(
-  startTick: number | null,
-  endTick: number | null,
-): WorkChartZoomRange | null {
-  if (startTick === null || endTick === null) {
-    return null;
-  }
-
-  return {
-    endTick: Math.max(startTick, endTick),
-    startTick: Math.min(startTick, endTick),
-  };
-}
-
-function readPointerTick(
-  event: ReactMouseEvent<HTMLDivElement>,
-  rows: readonly WorkChartRow[],
-): number | null {
-  if (rows.length === 0) {
-    return null;
-  }
-
-  const rect = event.currentTarget.getBoundingClientRect();
-  if (!Number.isFinite(rect.width) || rect.width <= 0) {
-    return null;
-  }
-
-  const relativeX = Math.min(
-    Math.max(event.clientX - rect.left, 0),
-    rect.width,
-  );
-  const rowIndex = Math.round((relativeX / rect.width) * (rows.length - 1));
-  return rows[rowIndex]?.tick ?? null;
 }
 
 function formatAxisNumber(value: number): string {

--- a/ui/src/features/work-outcome/messages/work-outcome.ts
+++ b/ui/src/features/work-outcome/messages/work-outcome.ts
@@ -13,6 +13,7 @@ export interface WorkOutcomeMessages {
     emptyTitle: string;
     errorMessage: string;
     errorTitle: string;
+    hideSeriesLabel: (seriesLabel: string) => string;
     loadingMessage: string;
     loadingTitle: string;
     resetZoomAction: string;
@@ -25,6 +26,7 @@ export interface WorkOutcomeMessages {
     };
     seriesPointLabel: (seriesLabel: string, value: number) => string;
     sessionRangeLabel: string;
+    showSeriesLabel: (seriesLabel: string) => string;
     tickLabel: (tick: number) => string;
     workTypeFailureLabel: (workType: string) => string;
     xAxisLabel: string;
@@ -76,6 +78,7 @@ const workOutcomeMessagesByLocale = {
       errorMessage:
         "Chart data is incomplete, so the dashboard cannot draw this work outcome view yet.",
       errorTitle: "Work outcome chart unavailable",
+      hideSeriesLabel: (seriesLabel) => `Hide ${seriesLabel} series`,
       loadingMessage: "Waiting for dashboard timeline data.",
       loadingTitle: "Loading work outcome samples",
       resetZoomAction: "Reset zoom",
@@ -89,6 +92,7 @@ const workOutcomeMessagesByLocale = {
       seriesPointLabel: (seriesLabel, value) =>
         `${seriesLabel}: ${formatNumber(value, "en")}`,
       sessionRangeLabel: "Session",
+      showSeriesLabel: (seriesLabel) => `Show ${seriesLabel} series`,
       tickLabel: (tick) => `Tick ${formatNumber(tick, "en")}`,
       workTypeFailureLabel: (workType) => `Work type: ${workType}`,
       xAxisLabel: "Ticks",
@@ -100,11 +104,13 @@ const workOutcomeMessagesByLocale = {
       causeGroupsLabel: "Cause groups",
       causeGroupsRegionLabel: "Failure cause groups",
       failedInRangeLabel: "Failed in range",
-      failureChartAriaLabel: (rangeLabel) => `Failed work trend for ${rangeLabel}`,
+      failureChartAriaLabel: (rangeLabel) =>
+        `Failed work trend for ${rangeLabel}`,
       failureEmptyMessage:
         "Failure trend data appears after the event stream receives work history.",
       failureEmptyTitle: "No failure samples",
-      failureSummary: "Failed work and cause groups from the selected factory timeline.",
+      failureSummary:
+        "Failed work and cause groups from the selected factory timeline.",
       failureTitle: "Failure trend",
       fastestDurationLabel: "Fastest",
       latestDurationLabel: "Latest",
@@ -113,11 +119,13 @@ const workOutcomeMessagesByLocale = {
       rangeOptionLabel: (_rangeId, defaultLabel) => defaultLabel,
       reworkPointLabel: (dispatchLabel, reworkCount) =>
         `${dispatchLabel}: ${formatNumber(reworkCount, "en")} retry or rework events`,
-      reworkChartAriaLabel: (workLabel) => `Retry and rework trend for ${workLabel}`,
+      reworkChartAriaLabel: (workLabel) =>
+        `Retry and rework trend for ${workLabel}`,
       reworkEmptyMessage:
         "Select active work with retained trace history to see retry activity.",
       reworkEmptyTitle: "No selected trace",
-      reworkSummary: "Reject, retry, or rework activity from the selected work trace.",
+      reworkSummary:
+        "Reject, retry, or rework activity from the selected work trace.",
       reworkTitle: "Retry and rework trend",
       retryOrReworkLabel: "Retry or rework",
       slowestDurationLabel: "Slowest dispatch",
@@ -140,6 +148,7 @@ const workOutcomeMessagesByLocale = {
       emptyTitle: "暂无工作结果样本",
       errorMessage: "图表数据不完整，因此仪表板暂时无法绘制这个工作结果视图。",
       errorTitle: "工作结果图表不可用",
+      hideSeriesLabel: (seriesLabel) => `隐藏${seriesLabel}序列`,
       loadingMessage: "正在等待仪表板时间线数据。",
       loadingTitle: "正在加载工作结果样本",
       resetZoomAction: "重置缩放",
@@ -153,6 +162,7 @@ const workOutcomeMessagesByLocale = {
       seriesPointLabel: (seriesLabel, value) =>
         `${seriesLabel}：${formatNumber(value, "zh-CN")}`,
       sessionRangeLabel: "会话",
+      showSeriesLabel: (seriesLabel) => `显示${seriesLabel}序列`,
       tickLabel: (tick) => `刻度 ${formatNumber(tick, "zh-CN")}`,
       workTypeFailureLabel: (workType) => `工作类型：${workType}`,
       xAxisLabel: "刻度",
@@ -195,7 +205,9 @@ const workOutcomeMessagesByLocale = {
   },
 } satisfies LocalizedMessageCatalog<WorkOutcomeMessages>;
 
-export function getWorkOutcomeMessages(locale?: string | null): WorkOutcomeMessages {
+export function getWorkOutcomeMessages(
+  locale?: string | null,
+): WorkOutcomeMessages {
   return resolveLocalizedMessages(workOutcomeMessagesByLocale, locale);
 }
 


### PR DESCRIPTION
## Summary
- Make shared chart legend entries optionally interactive with accessible hide/show state
- Track hidden work outcome chart series and apply Recharts line visibility from legend clicks
- Add localized legend toggle labels and coverage for hiding/showing a series

## Tests
- bunx biome check src/components/ui/chart.tsx src/features/work-outcome/components/work-chart.tsx src/features/work-outcome/components/work-chart-interactions.ts src/features/work-outcome/components/d3-information-card.tsx src/features/work-outcome/components/d3-information-card.test.tsx src/features/work-outcome/messages/work-outcome.ts
- bunx tsc -b --noEmit --pretty false
- bunx vitest run src/features/work-outcome/messages/work-outcome.test.ts src/features/work-outcome/lib/work-chart-data.test.ts src/features/work-outcome/components/d3-information-card.test.tsx