### PR TITLE
Clean up submit work card controls

### DIFF
--- a/ui/scripts/inline-component-class-usage-allowlist.mjs
+++ b/ui/scripts/inline-component-class-usage-allowlist.mjs
@@ -52,7 +52,6 @@ export const allowlistedInlineComponentClassUsage = [
   "src/features/submit-work/components/submit-work-card.tsx#FORM_CLASS",
   "src/features/submit-work/components/submit-work-card.tsx#FORM_FIELDS_CLASS",
   "src/features/submit-work/components/submit-work-card.tsx#ACTION_ROW_CLASS",
-  "src/features/submit-work/components/submit-work-card.tsx#ITEM_SHELL_CLASS",
   "src/features/terminal-work/components/terminal-work-card.tsx#TERMINAL_ROWS_CLASS",
   "src/features/terminal-work/components/terminal-work-card.tsx#TERMINAL_ROW_HEADER_CLASS",
   "src/features/terminal-work/components/terminal-work-card.tsx#TERMINAL_ROW_TITLE_CLASS",

--- a/ui/src/App.follow-up-submit.test.tsx
+++ b/ui/src/App.follow-up-submit.test.tsx
@@ -123,10 +123,10 @@ describe("App follow-up submit request flows", () => {
     );
     expect(submitButton.disabled).toBe(true);
     expect(
-      submitWorkScope.getByText(
+      submitWorkScope.queryByText(
         "Choose a work type and enter a request name to continue.",
       ),
-    ).toBeTruthy();
+    ).toBeNull();
 
     fireEvent.change(workType, { target: { value: "story" } });
     fireEvent.change(requestName, {
@@ -156,13 +156,20 @@ describe("App follow-up submit request flows", () => {
     fireEvent.change(requestName, {
       target: { value: "Dashboard empty payload request" },
     });
+    const requestsBeforeEmptyPayloadSubmit =
+      nonPromptTemplateFetchPaths(fetchMock).length;
     fireEvent.click(submitButton);
 
-    expect(
-      await submitWorkScope.findAllByText(
-        "Add at least one non-empty text item or one staged file before submitting.",
-      ),
-    ).toHaveLength(2);
+    await waitFor(() => {
+      expect(nonPromptTemplateFetchPaths(fetchMock)).toHaveLength(
+        requestsBeforeEmptyPayloadSubmit + 1,
+      );
+    });
+    expect(JSON.parse(String(fetchMock.mock.calls.at(-1)?.[1]?.body))).toEqual({
+      items: [],
+      name: "Dashboard empty payload request",
+      workTypeName: "story",
+    });
 
     fireEvent.change(requestName, {
       target: { value: "Retry dashboard request" },
@@ -178,6 +185,7 @@ describe("App follow-up submit request flows", () => {
       await submitWorkScope.findByText("work_type_name is required"),
     ).toBeTruthy();
     expect(nonPromptTemplateFetchPaths(fetchMock)).toEqual([
+      `/factory-sessions/${DEFAULT_FACTORY_SESSION_ID}/work`,
       `/factory-sessions/${DEFAULT_FACTORY_SESSION_ID}/work`,
       `/factory-sessions/${DEFAULT_FACTORY_SESSION_ID}/work`,
     ]);

--- a/ui/src/features/submit-work/components/submit-work-card.tsx
+++ b/ui/src/features/submit-work/components/submit-work-card.tsx
@@ -1,4 +1,5 @@
 import { useState, type ReactNode } from "react";
+import { Plus } from "lucide-react";
 
 import {
   Button,
@@ -9,7 +10,6 @@ import {
   PopoverContent,
   PopoverTrigger,
   Select,
-  Textarea,
 } from "../../../components/ui";
 import {
   DASHBOARD_BODY_TEXT_CLASS,
@@ -18,7 +18,7 @@ import {
 } from "../../../components/ui/dashboard-typography";
 import { cn } from "../../../lib/cn";
 import { getSubmitWorkMessages } from "../messages/submit-work";
-import { FileSubmissionItemEditor } from "./submit-work-file-input";
+import { SubmissionItemsList } from "./submit-work-items-list";
 
 export interface SubmitWorkDraft {
   items: SubmitWorkDraftItem[];
@@ -74,11 +74,10 @@ export interface SubmitWorkCardProps {
   widgetId?: string;
 }
 
-const FORM_CLASS = "grid h-full min-h-0 grid-rows-[minmax(0,1fr)_auto] gap-3";
-const FORM_FIELDS_CLASS = "grid min-h-0 content-start gap-4 overflow-y-auto pb-2 pr-1";
+const FORM_CLASS = "grid h-full min-h-0 content-start gap-3";
+const FORM_FIELDS_CLASS = "grid min-h-0 content-start gap-4 overflow-y-auto pr-1";
 const FIELD_GROUP_CLASS = "grid gap-2";
-const FIELD_LABEL_CLASS = DASHBOARD_SUPPORTING_LABEL_CLASS;
-const ACTION_ROW_CLASS = "mt-auto grid gap-3";
+const ACTION_ROW_CLASS = "grid gap-3";
 const HELP_TEXT_CLASS = cn(
   "max-w-xl leading-relaxed text-af-text-muted",
   DASHBOARD_SUPPORTING_TEXT_CLASS,
@@ -87,8 +86,6 @@ const VALIDATION_TEXT_CLASS = cn(
   "text-af-danger-text",
   DASHBOARD_SUPPORTING_TEXT_CLASS,
 );
-const ITEM_SHELL_CLASS =
-  "grid gap-3 rounded-lg border-af-border border bg-af-panel p-3";
 const STATUS_TONE_CLASS_BY_KIND: Record<SubmitWorkStatus["kind"], string> = {
   error: "text-af-danger-text",
   guidance: "text-af-text-subtle",
@@ -142,10 +139,30 @@ export function SubmitWorkCard({
   const workTypeID = `${widgetId}-work-type`;
   const workTypeErrorID = `${widgetId}-work-type-error`;
   const statusID = `${widgetId}-status`;
+  const shouldRenderStatus =
+    status.kind !== "guidance" ||
+    (status.message !== messages.statusMessages.emptyGuidance &&
+      status.message !== messages.statusMessages.ready);
 
   return (
     <DashboardWidgetFrame
-      headerAction={headerAction}
+      headerAction={
+        <SubmitWorkHeaderControls
+          controlsDisabled={controlsDisabled}
+          headerAction={headerAction}
+          isAddItemMenuOpen={isAddItemMenuOpen}
+          messages={messages}
+          onAddItem={onAddItem}
+          onAddItemMenuOpenChange={setIsAddItemMenuOpen}
+          onWorkTypeNameChange={onWorkTypeNameChange}
+          submitWorkTypeNames={submitWorkTypeNames}
+          validationErrors={validationErrors}
+          widgetId={widgetId}
+          workTypeID={workTypeID}
+          workTypeName={draft.workTypeName}
+          workTypeErrorID={workTypeErrorID}
+        />
+      }
       title={messages.cardTitle}
       widgetId={widgetId}
     >
@@ -158,36 +175,10 @@ export function SubmitWorkCard({
       >
         <div className={FORM_FIELDS_CLASS}>
           <div className={FIELD_GROUP_CLASS}>
-            <label className={FIELD_LABEL_CLASS} htmlFor={workTypeID}>
-              {messages.workTypeLabel}
-            </label>
-            <Select
-              aria-describedby={
-                validationErrors?.workTypeName ? workTypeErrorID : undefined
-              }
-              aria-invalid={validationErrors?.workTypeName ? "true" : undefined}
-              className={DASHBOARD_BODY_TEXT_CLASS}
-              disabled={controlsDisabled}
-              id={workTypeID}
-              onChange={(event) => onWorkTypeNameChange(event.target.value)}
-              value={draft.workTypeName}
+            <label
+              className={DASHBOARD_SUPPORTING_LABEL_CLASS}
+              htmlFor={requestNameID}
             >
-              <option value="">{messages.selectWorkTypePlaceholder}</option>
-              {submitWorkTypeNames.map((workTypeName) => (
-                <option key={workTypeName} value={workTypeName}>
-                  {workTypeName}
-                </option>
-              ))}
-            </Select>
-            {validationErrors?.workTypeName ? (
-              <p className={VALIDATION_TEXT_CLASS} id={workTypeErrorID}>
-                {validationErrors.workTypeName}
-              </p>
-            ) : null}
-          </div>
-
-          <div className={FIELD_GROUP_CLASS}>
-            <label className={FIELD_LABEL_CLASS} htmlFor={requestNameID}>
               {messages.requestNameLabel}
             </label>
             <Input
@@ -211,16 +202,9 @@ export function SubmitWorkCard({
           </div>
 
           <div className={FIELD_GROUP_CLASS}>
-            <div className={FIELD_LABEL_CLASS} id={submissionItemsID}>
+            <div className="sr-only" id={submissionItemsID}>
               {messages.submissionItemsLabel}
             </div>
-            <AddSubmissionItemMenu
-              controlsDisabled={controlsDisabled}
-              isOpen={isAddItemMenuOpen}
-              messages={messages}
-              onAddItem={onAddItem}
-              onOpenChange={setIsAddItemMenuOpen}
-            />
             <SubmissionItemsList
               controlsDisabled={controlsDisabled}
               draft={draft}
@@ -240,21 +224,23 @@ export function SubmitWorkCard({
         </div>
 
         <div className={ACTION_ROW_CLASS}>
-          <p
-            className={cn(
-              "min-w-0 flex-1",
-              HELP_TEXT_CLASS,
-              STATUS_TONE_CLASS_BY_KIND[status.kind],
-            )}
-            id={statusID}
-            role={
-              status.kind === "error" || status.kind === "validation-error"
-                ? "alert"
-                : "status"
-            }
-          >
-            {status.message}
-          </p>
+          {shouldRenderStatus ? (
+            <p
+              className={cn(
+                "min-w-0 flex-1",
+                HELP_TEXT_CLASS,
+                STATUS_TONE_CLASS_BY_KIND[status.kind],
+              )}
+              id={statusID}
+              role={
+                status.kind === "error" || status.kind === "validation-error"
+                  ? "alert"
+                  : "status"
+              }
+            >
+              {status.message}
+            </p>
+          ) : null}
           <Button
             aria-busy={isSubmitting ? "true" : undefined}
             className="w-full justify-center self-start"
@@ -270,240 +256,143 @@ export function SubmitWorkCard({
   );
 }
 
+function SubmitWorkHeaderControls({
+  controlsDisabled,
+  headerAction,
+  isAddItemMenuOpen,
+  messages,
+  onAddItem,
+  onAddItemMenuOpenChange,
+  onWorkTypeNameChange,
+  submitWorkTypeNames,
+  validationErrors,
+  widgetId,
+  workTypeErrorID,
+  workTypeID,
+  workTypeName,
+}: {
+  controlsDisabled: boolean;
+  headerAction?: ReactNode;
+  isAddItemMenuOpen: boolean;
+  messages: ReturnType<typeof getSubmitWorkMessages>;
+  onAddItem: (type: SubmitWorkDraftItemType) => void;
+  onAddItemMenuOpenChange: (open: boolean) => void;
+  onWorkTypeNameChange: (value: string) => void;
+  submitWorkTypeNames: string[];
+  validationErrors?: SubmitWorkValidationErrors;
+  widgetId: string;
+  workTypeErrorID: string;
+  workTypeID: string;
+  workTypeName: string;
+}) {
+  return (
+    <div className="flex min-w-0 flex-wrap items-center justify-end gap-2">
+      <div className="grid min-w-36 gap-1">
+        <label className="sr-only" htmlFor={workTypeID}>
+          {messages.workTypeLabel}
+        </label>
+        <Select
+          aria-describedby={
+            validationErrors?.workTypeName ? workTypeErrorID : undefined
+          }
+          aria-invalid={validationErrors?.workTypeName ? "true" : undefined}
+          className={cn("min-h-9 py-2 text-xs", DASHBOARD_BODY_TEXT_CLASS)}
+          disabled={controlsDisabled}
+          id={workTypeID}
+          onChange={(event) => onWorkTypeNameChange(event.target.value)}
+          value={workTypeName}
+        >
+          <option value="">{messages.selectWorkTypePlaceholder}</option>
+          {submitWorkTypeNames.map((submitWorkTypeName) => (
+            <option key={submitWorkTypeName} value={submitWorkTypeName}>
+              {submitWorkTypeName}
+            </option>
+          ))}
+        </Select>
+        {validationErrors?.workTypeName ? (
+          <p className="sr-only" id={workTypeErrorID}>
+            {validationErrors.workTypeName}
+          </p>
+        ) : null}
+      </div>
+      <AddSubmissionItemMenu
+        controlsDisabled={controlsDisabled}
+        isOpen={isAddItemMenuOpen}
+        messages={messages}
+        onAddItem={onAddItem}
+        onOpenChange={onAddItemMenuOpenChange}
+        widgetId={widgetId}
+      />
+      {headerAction}
+    </div>
+  );
+}
+
 function AddSubmissionItemMenu({
   controlsDisabled,
   isOpen,
   messages,
   onAddItem,
   onOpenChange,
+  widgetId,
 }: {
   controlsDisabled: boolean;
   isOpen: boolean;
   messages: ReturnType<typeof getSubmitWorkMessages>;
   onAddItem: (type: SubmitWorkDraftItemType) => void;
   onOpenChange: (open: boolean) => void;
-}) {
-  return (
-    <div className="flex justify-start">
-      <Popover onOpenChange={onOpenChange} open={isOpen}>
-        <PopoverTrigger asChild>
-          <Button
-            aria-label={messages.addItemAction}
-            disabled={controlsDisabled}
-            size="sm"
-            tone="outline"
-            type="button"
-          >
-            {messages.addItemAction}
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent
-          align="start"
-          aria-label={messages.addItemMenuLabel}
-          className="grid gap-3"
-        >
-          <p className={HELP_TEXT_CLASS}>{messages.addItemMenuDescription}</p>
-          <div className="grid gap-2">
-            {ADDABLE_ITEM_TYPES.map((itemType) => {
-              const typeLabel = itemTypeLabel(messages, itemType);
-              return (
-                <Button
-                  aria-label={typeLabel}
-                  className="justify-start border-af-border text-left font-medium"
-                  key={itemType}
-                  onClick={() => {
-                    onAddItem(itemType);
-                    onOpenChange(false);
-                  }}
-                  tone="outline"
-                  type="button"
-                >
-                  {typeLabel}
-                </Button>
-              );
-            })}
-          </div>
-        </PopoverContent>
-      </Popover>
-    </div>
-  );
-}
-
-function SubmissionItemsList({
-  controlsDisabled,
-  draft,
-  messages,
-  onItemTextChange,
-  onRemoveItem,
-  onStageFileItems,
-  submissionItemsID,
-  widgetId,
-}: {
-  controlsDisabled: boolean;
-  draft: SubmitWorkDraft;
-  messages: ReturnType<typeof getSubmitWorkMessages>;
-  onItemTextChange: (itemId: string, value: string) => void;
-  onRemoveItem: (itemId: string) => void;
-  onStageFileItems: (itemId: string, files: File[]) => void;
-  submissionItemsID: string;
   widgetId: string;
 }) {
-  return (
-    <ol aria-labelledby={submissionItemsID} className="grid gap-3">
-      {draft.items.map((item, index) => {
-        const requestItemLabel = messages.requestItemLabel(index + 1);
-        const typeLabel = itemTypeLabel(messages, item.type);
+  const menuDescriptionID = `${widgetId}-add-item-menu-description`;
 
-        return (
-          <SubmitWorkItemShell
-            disabled={controlsDisabled}
-            itemTypeLabel={typeLabel}
-            key={item.id}
-            onRemove={() => onRemoveItem(item.id)}
-            removeLabel={messages.removeItemLabel(typeLabel, index + 1)}
-          >
-            {item.type === "text" ? (
-              <TextSubmissionItemEditor
-                disabled={controlsDisabled}
-                item={item}
-                itemLabel={requestItemLabel}
-                messages={messages}
-                onChange={onItemTextChange}
-                widgetId={widgetId}
-              />
-            ) : (
-              <FileSubmissionItemEditorShell
-                disabled={controlsDisabled}
-                item={item}
-                messages={messages}
-                onStageFileItems={onStageFileItems}
-                widgetId={widgetId}
-              />
-            )}
-          </SubmitWorkItemShell>
-        );
-      })}
-    </ol>
-  );
-}
-
-function SubmitWorkItemShell({
-  children,
-  disabled = false,
-  itemTypeLabel,
-  onRemove,
-  removeLabel,
-}: {
-  children: ReactNode;
-  disabled?: boolean;
-  itemTypeLabel: string;
-  onRemove: () => void;
-  removeLabel: string;
-}) {
   return (
-    <li className={ITEM_SHELL_CLASS}>
-      <div className="flex items-start justify-between gap-3">
-        <div className="grid gap-1">
-          <span className={FIELD_LABEL_CLASS}>{itemTypeLabel}</span>
-        </div>
+    <Popover onOpenChange={onOpenChange} open={isOpen}>
+      <PopoverTrigger asChild>
         <DashboardIconButtonShell
-          aria-label={removeLabel}
-          className="text-af-text-subtle hover:border-af-danger-border hover:bg-af-danger-surface hover:text-af-danger-text"
-          disabled={disabled}
-          onClick={() => {
-            if (disabled) {
-              return;
-            }
-            onRemove();
-          }}
+          aria-label={messages.addItemAction}
+          disabled={controlsDisabled}
+          tone="outline"
+          type="button"
         >
-          <svg
+          <Plus
             aria-hidden="true"
-            fill="none"
-            height="16"
-            viewBox="0 0 16 16"
-            width="16"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="m4 4 8 8M12 4 4 12"
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="1.7"
-            />
-          </svg>
+            className="size-4"
+            focusable="false"
+            strokeWidth={1.8}
+          />
         </DashboardIconButtonShell>
-      </div>
-      {children}
-    </li>
-  );
-}
-
-function TextSubmissionItemEditor({
-  disabled,
-  item,
-  itemLabel,
-  messages,
-  onChange,
-  widgetId,
-}: {
-  disabled: boolean;
-  item: SubmitWorkDraftTextItem;
-  itemLabel: string;
-  messages: ReturnType<typeof getSubmitWorkMessages>;
-  onChange: (itemId: string, value: string) => void;
-  widgetId: string;
-}) {
-  const requestTextID = `${widgetId}-${item.id}-text`;
-  const requestTextHintID = `${widgetId}-${item.id}-text-hint`;
-  const requestHint = messages.requestHint?.trim();
-
-  return (
-    <>
-      <Textarea
-        aria-label={itemLabel}
-        aria-describedby={requestHint ? requestTextHintID : undefined}
-        className={DASHBOARD_BODY_TEXT_CLASS}
-        disabled={disabled}
-        id={requestTextID}
-        onChange={(event) => onChange(item.id, event.target.value)}
-        placeholder={messages.requestPlaceholder}
-        value={item.text}
-      />
-      {requestHint ? (
-        <p className={HELP_TEXT_CLASS} id={requestTextHintID}>
-          {requestHint}
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        aria-describedby={menuDescriptionID}
+        aria-label={messages.addItemMenuLabel}
+        className="grid gap-3"
+      >
+        <p className={HELP_TEXT_CLASS} id={menuDescriptionID}>
+          {messages.addItemMenuDescription}
         </p>
-      ) : null}
-    </>
-  );
-}
-
-function FileSubmissionItemEditorShell({
-  disabled,
-  item,
-  messages,
-  onStageFileItems,
-  widgetId,
-}: {
-  disabled: boolean;
-  item: SubmitWorkDraftFileItem;
-  messages: ReturnType<typeof getSubmitWorkMessages>;
-  onStageFileItems: (itemId: string, files: File[]) => void;
-  widgetId: string;
-}) {
-  return (
-    <FileSubmissionItemEditor
-      disabled={disabled}
-      fieldLabelClassName={FIELD_LABEL_CLASS}
-      helpTextClassName={HELP_TEXT_CLASS}
-      inputID={`${widgetId}-${item.id}-file`}
-      item={item}
-      messages={messages}
-      onStageFileItems={(files: File[]) => onStageFileItems(item.id, files)}
-      validationTextClassName={VALIDATION_TEXT_CLASS}
-    />
+        <div className="grid gap-2">
+          {ADDABLE_ITEM_TYPES.map((itemType) => {
+            const typeLabel = itemTypeLabel(messages, itemType);
+            return (
+              <Button
+                aria-label={typeLabel}
+                className="justify-start border-af-border text-left font-medium"
+                key={itemType}
+                onClick={() => {
+                  onAddItem(itemType);
+                  onOpenChange(false);
+                }}
+                tone="outline"
+                type="button"
+              >
+                {typeLabel}
+              </Button>
+            );
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }
 

--- a/ui/src/features/submit-work/components/submit-work-items-list.tsx
+++ b/ui/src/features/submit-work/components/submit-work-items-list.tsx
@@ -1,0 +1,214 @@
+import type { ReactNode } from "react";
+
+import {
+  DashboardIconButtonShell,
+  Textarea,
+} from "../../../components/ui";
+import {
+  DASHBOARD_BODY_TEXT_CLASS,
+  DASHBOARD_SUPPORTING_LABEL_CLASS,
+  DASHBOARD_SUPPORTING_TEXT_CLASS,
+} from "../../../components/ui/dashboard-typography";
+import { cn } from "../../../lib/cn";
+import type { getSubmitWorkMessages } from "../messages/submit-work";
+import type {
+  SubmitWorkDraft,
+  SubmitWorkDraftFileItem,
+  SubmitWorkDraftItemType,
+  SubmitWorkDraftTextItem,
+} from "./submit-work-card";
+import { FileSubmissionItemEditor } from "./submit-work-file-input";
+
+const FIELD_LABEL_CLASS = DASHBOARD_SUPPORTING_LABEL_CLASS;
+const HELP_TEXT_CLASS = cn(
+  "max-w-xl leading-relaxed text-af-text-muted",
+  DASHBOARD_SUPPORTING_TEXT_CLASS,
+);
+const VALIDATION_TEXT_CLASS = cn(
+  "text-af-danger-text",
+  DASHBOARD_SUPPORTING_TEXT_CLASS,
+);
+export function SubmissionItemsList({
+  controlsDisabled,
+  draft,
+  messages,
+  onItemTextChange,
+  onRemoveItem,
+  onStageFileItems,
+  submissionItemsID,
+  widgetId,
+}: {
+  controlsDisabled: boolean;
+  draft: SubmitWorkDraft;
+  messages: ReturnType<typeof getSubmitWorkMessages>;
+  onItemTextChange: (itemId: string, value: string) => void;
+  onRemoveItem: (itemId: string) => void;
+  onStageFileItems: (itemId: string, files: File[]) => void;
+  submissionItemsID: string;
+  widgetId: string;
+}) {
+  return (
+    <ol aria-labelledby={submissionItemsID} className="grid gap-3">
+      {draft.items.map((item, index) => {
+        const requestItemLabel = messages.requestItemLabel(index + 1);
+        const typeLabel = itemTypeLabel(messages, item.type);
+
+        return (
+          <SubmitWorkItemShell
+            disabled={controlsDisabled}
+            itemTypeLabel={typeLabel}
+            key={item.id}
+            onRemove={() => onRemoveItem(item.id)}
+            removeLabel={messages.removeItemLabel(typeLabel, index + 1)}
+          >
+            {item.type === "text" ? (
+              <TextSubmissionItemEditor
+                disabled={controlsDisabled}
+                item={item}
+                itemLabel={requestItemLabel}
+                messages={messages}
+                onChange={onItemTextChange}
+                widgetId={widgetId}
+              />
+            ) : (
+              <FileSubmissionItemEditorShell
+                disabled={controlsDisabled}
+                item={item}
+                messages={messages}
+                onStageFileItems={onStageFileItems}
+                widgetId={widgetId}
+              />
+            )}
+          </SubmitWorkItemShell>
+        );
+      })}
+    </ol>
+  );
+}
+
+function SubmitWorkItemShell({
+  children,
+  disabled = false,
+  itemTypeLabel,
+  onRemove,
+  removeLabel,
+}: {
+  children: ReactNode;
+  disabled?: boolean;
+  itemTypeLabel: string;
+  onRemove: () => void;
+  removeLabel: string;
+}) {
+  return (
+    <li className="grid gap-3 rounded-lg border-af-border border bg-af-panel p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="grid gap-1">
+          <span className={FIELD_LABEL_CLASS}>{itemTypeLabel}</span>
+        </div>
+        <DashboardIconButtonShell
+          aria-label={removeLabel}
+          className="text-af-text-subtle hover:border-af-danger-border hover:bg-af-danger-surface hover:text-af-danger-text"
+          disabled={disabled}
+          onClick={() => {
+            if (disabled) {
+              return;
+            }
+            onRemove();
+          }}
+        >
+          <svg
+            aria-hidden="true"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="m4 4 8 8M12 4 4 12"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="1.7"
+            />
+          </svg>
+        </DashboardIconButtonShell>
+      </div>
+      {children}
+    </li>
+  );
+}
+
+function TextSubmissionItemEditor({
+  disabled,
+  item,
+  itemLabel,
+  messages,
+  onChange,
+  widgetId,
+}: {
+  disabled: boolean;
+  item: SubmitWorkDraftTextItem;
+  itemLabel: string;
+  messages: ReturnType<typeof getSubmitWorkMessages>;
+  onChange: (itemId: string, value: string) => void;
+  widgetId: string;
+}) {
+  const requestTextID = `${widgetId}-${item.id}-text`;
+  const requestTextHintID = `${widgetId}-${item.id}-text-hint`;
+  const requestHint = messages.requestHint?.trim();
+
+  return (
+    <>
+      <Textarea
+        aria-label={itemLabel}
+        aria-describedby={requestHint ? requestTextHintID : undefined}
+        className={DASHBOARD_BODY_TEXT_CLASS}
+        disabled={disabled}
+        id={requestTextID}
+        onChange={(event) => onChange(item.id, event.target.value)}
+        placeholder={messages.requestPlaceholder}
+        value={item.text}
+      />
+      {requestHint ? (
+        <p className={HELP_TEXT_CLASS} id={requestTextHintID}>
+          {requestHint}
+        </p>
+      ) : null}
+    </>
+  );
+}
+
+function FileSubmissionItemEditorShell({
+  disabled,
+  item,
+  messages,
+  onStageFileItems,
+  widgetId,
+}: {
+  disabled: boolean;
+  item: SubmitWorkDraftFileItem;
+  messages: ReturnType<typeof getSubmitWorkMessages>;
+  onStageFileItems: (itemId: string, files: File[]) => void;
+  widgetId: string;
+}) {
+  return (
+    <FileSubmissionItemEditor
+      disabled={disabled}
+      fieldLabelClassName={FIELD_LABEL_CLASS}
+      helpTextClassName={HELP_TEXT_CLASS}
+      inputID={`${widgetId}-${item.id}-file`}
+      item={item}
+      messages={messages}
+      onStageFileItems={(files: File[]) => onStageFileItems(item.id, files)}
+      validationTextClassName={VALIDATION_TEXT_CLASS}
+    />
+  );
+}
+
+function itemTypeLabel(
+  messages: ReturnType<typeof getSubmitWorkMessages>,
+  itemType: SubmitWorkDraftItemType,
+): string {
+  return messages.addItemOptionLabel(itemType);
+}

--- a/ui/src/features/submit-work/components/submit-work-widget.test.tsx
+++ b/ui/src/features/submit-work/components/submit-work-widget.test.tsx
@@ -57,10 +57,10 @@ describe("SubmitWorkWidget form behavior", () => {
       within(card).getByRole("textbox", { name: "Text item 1" }),
     ).toBeTruthy();
     expect(
-      within(card).getByText(
+      within(card).queryByText(
         "Choose a work type and enter a request name to continue.",
       ),
-    ).toBeTruthy();
+    ).toBeNull();
     expect(
       within(card).queryByText(
         "Optional: describe what you want this request to accomplish.",
@@ -76,6 +76,50 @@ describe("SubmitWorkWidget form behavior", () => {
     expect(form?.className).toContain("gap-3");
     expect(submitButton.className).toContain("w-full");
     expect(submitButton.className).toContain("justify-center");
+  });
+
+  it("orders submit-work header tools before the dashboard move control", () => {
+    render(
+      <SubmitWorkCard
+        draft={{
+          items: [{ id: "submission-item-1", text: "", type: "text" }],
+          requestName: "",
+          workTypeName: "",
+        }}
+        headerAction={
+          <button type="button">Remove Submit work widget from dashboard</button>
+        }
+        onAddItem={() => {}}
+        onItemTextChange={() => {}}
+        onRemoveItem={() => {}}
+        onRequestNameChange={() => {}}
+        onStageFileItems={() => {}}
+        onSubmit={() => {}}
+        onWorkTypeNameChange={() => {}}
+        status={{
+          kind: "guidance",
+          message: getSubmitWorkMessages().statusMessages.emptyGuidance,
+        }}
+        submitWorkTypeNames={["story", "task"]}
+      />,
+    );
+
+    const workType = screen.getByRole("combobox", { name: "Work type" });
+    const addInput = screen.getByRole("button", { name: "Add input" });
+    const remove = screen.getByRole("button", {
+      name: "Remove Submit work widget from dashboard",
+    });
+    const move = screen.getByRole("button", { name: "Move Submit work" });
+
+    expect(workType.compareDocumentPosition(addInput)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(addInput.compareDocumentPosition(remove)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(remove.compareDocumentPosition(move)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
   });
 
   it("enables submission only after a configured work type and non-blank request name are present", () => {
@@ -103,10 +147,10 @@ describe("SubmitWorkWidget form behavior", () => {
 
     expect(submitButton.disabled).toBe(true);
     expect(
-      screen.getByText(
+      screen.queryByText(
         "Choose a work type and enter a request name to continue.",
       ),
-    ).toBeTruthy();
+    ).toBeNull();
 
     fireEvent.change(workType, { target: { value: "story" } });
     expect(submitButton.disabled).toBe(true);
@@ -123,7 +167,7 @@ describe("SubmitWorkWidget form behavior", () => {
     });
 
     expect(submitButton.disabled).toBe(false);
-    expect(screen.getByText("Ready to submit.")).toBeTruthy();
+    expect(screen.queryByText("Ready to submit.")).toBeNull();
     expect(
       screen.queryByText("Ready to submit. Request details are optional."),
     ).toBeNull();
@@ -188,7 +232,7 @@ describe("SubmitWorkWidget form behavior", () => {
       screen.getByRole("button", {
         name: "Add input",
       }).className,
-    ).toContain("min-h-9");
+    ).toContain("h-10");
   });
 
   it("adds typed items from the shared add-input control and renders their type cues", () => {
@@ -1171,8 +1215,15 @@ describe("SubmitWorkWidget submission behavior", () => {
     expect(requestName.getAttribute("aria-invalid")).toBe("true");
   });
 
-  it("blocks obviously empty submissions before the network request", async () => {
-    const fetchMock = vi.fn();
+  it("submits a request-name-only draft with an empty items payload", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ traceId: "trace-submit-story" }), {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        status: 201,
+      }),
+    );
     vi.stubGlobal("fetch", fetchMock);
     renderSubmitWorkWidget(
       <SubmitWorkWidget submitWorkTypes={[{ work_type_name: "story" }]} />,
@@ -1191,12 +1242,14 @@ describe("SubmitWorkWidget submission behavior", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: "Submit work" }));
 
-    expect(
-      await screen.findAllByText(
-        "Add at least one non-empty text item or one staged file before submitting.",
-      ),
-    ).toHaveLength(2);
-    expect(fetchMock).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
+      items: [],
+      name: "Empty payload request",
+      workTypeName: "story",
+    });
   });
 
   it("preserves authored text-item order in the structured submit request", async () => {
@@ -1409,8 +1462,8 @@ describe("SubmitWorkWidget submission behavior", () => {
     expect(within(card).getByRole("list", { name: "提交项" })).toBeTruthy();
     expect(within(card).getByRole("textbox", { name: "文本项 1" })).toBeTruthy();
     expect(
-      within(card).getByText("先选择工作类型并填写请求名称，然后即可继续。"),
-    ).toBeTruthy();
+      within(card).queryByText("先选择工作类型并填写请求名称，然后即可继续。"),
+    ).toBeNull();
     expect(within(card).getByRole("button", { name: "提交工作" })).toBeTruthy();
   });
 });

--- a/ui/src/features/submit-work/hooks/use-submit-work-widget-helpers.ts
+++ b/ui/src/features/submit-work/hooks/use-submit-work-widget-helpers.ts
@@ -211,11 +211,6 @@ export function validateDraft(
     validationErrors.requestName =
       messages.validationMessages.requestRequired;
   }
-  if (!hasMeaningfulSubmissionItems(draft)) {
-    validationErrors.submissionItems =
-      messages.validationMessages.submissionItemsRequired;
-    return validationErrors;
-  }
   if (hasStagingFileItems(draft)) {
     validationErrors.submissionItems =
       messages.validationMessages.fileItemStillStaging;
@@ -295,15 +290,6 @@ export async function fileToBase64(file: File): Promise<string> {
   }
 
   throw new Error("Base64 encoding is unavailable in this environment.");
-}
-
-function hasMeaningfulSubmissionItems(draft: SubmitWorkDraft): boolean {
-  return draft.items.some((item) => {
-    if (item.type === "text") {
-      return item.text.trim().length > 0;
-    }
-    return item.stagingStatus === "ready" && (item.stagedFileRef ?? "").length > 0;
-  });
 }
 
 function hasIncompleteFileItems(draft: SubmitWorkDraft): boolean {


### PR DESCRIPTION
## Summary
- Move the work type selector and add-input action into the submit-work card header
- Replace the add-input label with a shared icon-button plus control
- Remove redundant submission item/ready guidance and allow request-name-only submissions

## Verification
- bunx biome check ui/src/features/submit-work/components/submit-work-card.tsx ui/src/features/submit-work/components/submit-work-widget.test.tsx ui/src/features/submit-work/hooks/use-submit-work-widget-helpers.ts
- bunx vitest run src/features/submit-work/components/submit-work-widget.test.tsx src/features/submit-work/public/index.test.tsx
- bunx tsc -b --noEmit --pretty false