### PR TITLE
Refine session tabs and provider transcripts

### DIFF
--- a/api/components/schemas/api/CodexSessionReasoningSummary.yaml
+++ b/api/components/schemas/api/CodexSessionReasoningSummary.yaml
@@ -24,3 +24,6 @@ properties:
   encrypted:
     type: boolean
     description: Whether the reasoning entry only exposed encrypted content.
+  encryptedContent:
+    type: string
+    description: Compact encrypted reasoning payload when the provider exposes it.

--- a/api/components/schemas/api/CodexSessionTranscriptEntry.yaml
+++ b/api/components/schemas/api/CodexSessionTranscriptEntry.yaml
@@ -49,3 +49,6 @@ properties:
   encrypted:
     type: boolean
     description: Whether the entry only exposed encrypted content instead of plaintext.
+  encryptedContent:
+    type: string
+    description: Compact encrypted reasoning payload when the provider exposes it.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1981,6 +1981,9 @@ components:
         encrypted:
           type: boolean
           description: Whether the reasoning entry only exposed encrypted content.
+        encryptedContent:
+          type: string
+          description: Compact encrypted reasoning payload when the provider exposes it.
     CodexSessionTokenUsage:
       type: object
       additionalProperties: false
@@ -4606,6 +4609,9 @@ components:
         encrypted:
           type: boolean
           description: Whether the entry only exposed encrypted content instead of plaintext.
+        encryptedContent:
+          type: string
+          description: Compact encrypted reasoning payload when the provider exposes it.
     HostedWorkerProvider:
       type: string
       description: Built-in repository-owned hosted worker providers supported by the public factory-config contract.

--- a/pkg/api/generated/server.gen.go
+++ b/pkg/api/generated/server.gen.go
@@ -498,6 +498,9 @@ type CodexSessionReasoningSummary struct {
 	// Encrypted Whether the reasoning entry only exposed encrypted content.
 	Encrypted *bool `json:"encrypted,omitempty"`
 
+	// EncryptedContent Compact encrypted reasoning payload when the provider exposes it.
+	EncryptedContent *string `json:"encryptedContent,omitempty"`
+
 	// Order Chronological order of the reasoning entry in the session stream.
 	Order int `json:"order"`
 
@@ -533,6 +536,9 @@ type CodexSessionTranscriptEntry struct {
 
 	// Encrypted Whether the entry only exposed encrypted content instead of plaintext.
 	Encrypted *bool `json:"encrypted,omitempty"`
+
+	// EncryptedContent Compact encrypted reasoning payload when the provider exposes it.
+	EncryptedContent *string `json:"encryptedContent,omitempty"`
 
 	// LineNumber One-based JSONL line number that produced this transcript entry when applicable.
 	LineNumber *int `json:"lineNumber,omitempty"`

--- a/pkg/api/provider_session_details.go
+++ b/pkg/api/provider_session_details.go
@@ -499,26 +499,29 @@ func (p *codexSessionParser) attachFunctionOutput(itemType string, payload map[s
 func (p *codexSessionParser) appendReasoning(sourceType string, payload map[string]any, timestamp *time.Time, lineNumber int, turn *factoryapi.CodexSessionTurnSummary) {
 	turn.ReasoningCount++
 	order := len(p.summary.Reasoning) + 1
-	encrypted := firstStringField(payload, "encrypted_content", "encryptedContent") != ""
+	encryptedContent := firstCompactField(payload, "encrypted_content", "encryptedContent")
+	encrypted := encryptedContent != ""
 	reasoning := factoryapi.CodexSessionReasoningSummary{
-		Order:      order,
-		TurnIndex:  intPtr(turn.Index),
-		SourceType: sourceType,
-		Text:       stringPtrIfNotEmpty(firstReasoningText(payload)),
-		Summary:    stringPtrIfNotEmpty(firstCompactField(payload, "summary")),
-		Encrypted:  &encrypted,
+		Order:            order,
+		TurnIndex:        intPtr(turn.Index),
+		SourceType:       sourceType,
+		Text:             stringPtrIfNotEmpty(firstReasoningText(payload)),
+		Summary:          stringPtrIfNotEmpty(firstCompactField(payload, "summary")),
+		Encrypted:        &encrypted,
+		EncryptedContent: stringPtrIfNotEmpty(encryptedContent),
 	}
 	p.summary.Reasoning = append(p.summary.Reasoning, reasoning)
 	p.transcript = append(p.transcript, factoryapi.CodexSessionTranscriptEntry{
-		Encrypted:  reasoning.Encrypted,
-		LineNumber: intPtr(lineNumber),
-		Order:      len(p.transcript) + 1,
-		SourceType: stringPtrIfNotEmpty(sourceType),
-		Summary:    reasoning.Summary,
-		Text:       reasoning.Text,
-		Timestamp:  timestamp,
-		TurnIndex:  reasoning.TurnIndex,
-		Type:       factoryapi.CodexSessionTranscriptEntryType("reasoning"),
+		Encrypted:        reasoning.Encrypted,
+		EncryptedContent: reasoning.EncryptedContent,
+		LineNumber:       intPtr(lineNumber),
+		Order:            len(p.transcript) + 1,
+		SourceType:       stringPtrIfNotEmpty(sourceType),
+		Summary:          reasoning.Summary,
+		Text:             reasoning.Text,
+		Timestamp:        timestamp,
+		TurnIndex:        reasoning.TurnIndex,
+		Type:             factoryapi.CodexSessionTranscriptEntryType("reasoning"),
 	})
 }
 

--- a/pkg/api/server_provider_session_test.go
+++ b/pkg/api/server_provider_session_test.go
@@ -192,8 +192,8 @@ func assertCodexSessionSummaryFunctionCalls(t *testing.T, summary factoryapi.Cod
 func assertCodexSessionSummaryReasoning(t *testing.T, summary factoryapi.CodexSessionParseSummary) {
 	t.Helper()
 
-	if len(summary.Reasoning) != 1 || stringValue(summary.Reasoning[0].Summary) != `["checked input"]` || summary.Reasoning[0].Encrypted == nil || !*summary.Reasoning[0].Encrypted {
-		t.Fatalf("reasoning = %#v, want summary and encrypted marker", summary.Reasoning)
+	if len(summary.Reasoning) != 1 || stringValue(summary.Reasoning[0].Summary) != `["checked input"]` || summary.Reasoning[0].Encrypted == nil || !*summary.Reasoning[0].Encrypted || stringValue(summary.Reasoning[0].EncryptedContent) != "sealed" {
+		t.Fatalf("reasoning = %#v, want summary, encrypted marker, and encrypted content", summary.Reasoning)
 	}
 }
 
@@ -298,8 +298,8 @@ func assertMixedCodexSessionTranscriptUserMessage(t *testing.T, parsed parsedCod
 func assertMixedCodexSessionTranscriptReasoning(t *testing.T, parsed parsedCodexSessionDetails) {
 	t.Helper()
 
-	if parsed.Transcript[1].Order != 2 || parsed.Transcript[1].Type != factoryapi.Reasoning || intValue(parsed.Transcript[1].LineNumber) != 3 || stringValue(parsed.Transcript[1].Summary) != `["Checking tool output"]` || parsed.Transcript[1].Encrypted == nil || !*parsed.Transcript[1].Encrypted {
-		t.Fatalf("transcript[1] = %#v, want encrypted reasoning summary on line 3", parsed.Transcript[1])
+	if parsed.Transcript[1].Order != 2 || parsed.Transcript[1].Type != factoryapi.Reasoning || intValue(parsed.Transcript[1].LineNumber) != 3 || stringValue(parsed.Transcript[1].Summary) != `["Checking tool output"]` || parsed.Transcript[1].Encrypted == nil || !*parsed.Transcript[1].Encrypted || stringValue(parsed.Transcript[1].EncryptedContent) != "sealed" {
+		t.Fatalf("transcript[1] = %#v, want encrypted reasoning summary and content on line 3", parsed.Transcript[1])
 	}
 
 	assertMixedCodexSessionTranscriptEntry(t, parsed, 6, factoryapi.Reasoning, 8, "Need one more validation step.")

--- a/ui/src/api/generated/openapi.ts
+++ b/ui/src/api/generated/openapi.ts
@@ -948,6 +948,8 @@ export interface components {
             summary?: string;
             /** @description Whether the reasoning entry only exposed encrypted content. */
             encrypted?: boolean;
+            /** @description Compact encrypted reasoning payload when the provider exposes it. */
+            encryptedContent?: string;
         };
         CodexSessionTokenUsage: {
             inputTokens?: number;
@@ -2251,6 +2253,8 @@ export interface components {
             output?: string;
             /** @description Whether the entry only exposed encrypted content instead of plaintext. */
             encrypted?: boolean;
+            /** @description Compact encrypted reasoning payload when the provider exposes it. */
+            encryptedContent?: string;
         };
         /**
          * @description Built-in repository-owned hosted worker providers supported by the public factory-config contract.

--- a/ui/src/features/header/components/dashboard-brand-lockup.tsx
+++ b/ui/src/features/header/components/dashboard-brand-lockup.tsx
@@ -7,7 +7,7 @@ interface DashboardBrandLockupProps {
 }
 
 const BRAND_MARK_CLASS =
-  "inline-flex h-12 items-center justify-center gap-1 rounded-full border border-af-accent-border bg-af-accent-surface px-3 text-sm font-black uppercase leading-none tracking-[0.18em] text-af-accent";
+  "inline-flex h-12 items-center justify-center gap-1 rounded-sm mt-1 border border-af-accent-border bg-af-accent-surface px-3 text-sm font-black uppercase leading-none tracking-[0.18em] text-af-accent";
 
 export function DashboardBrandLockup({
   className = "",

--- a/ui/src/features/header/components/dashboard-header.tsx
+++ b/ui/src/features/header/components/dashboard-header.tsx
@@ -31,12 +31,12 @@ import { TickSliderControl } from "./tick-slider-control";
 
 const DASHBOARD_TOOLBAR_CLASS = cn(
   DASHBOARD_PANEL_SHELL_CLASS,
-  "mb-3 grid gap-2 p-2 md:px-3 md:py-2",
+  "mb-3 grid gap-2 ",
 );
 const DASHBOARD_HEADER_ROWS_CLASS = "flex min-w-0 flex-col gap-0";
 const DASHBOARD_PRIMARY_ROW_CLASS = cn(
   "flex min-w-0 items-stretch gap-2",
-  "max-md:flex-col",
+  "max-md:flex-col px-2",
 );
 const DASHBOARD_SECONDARY_ROW_CLASS = "flex min-w-0";
 const DASHBOARD_BRAND_SLOT_CLASS = "min-w-0 self-end pb-2";
@@ -44,7 +44,7 @@ const DASHBOARD_TIMELINE_CLUSTER_CLASS = "flex min-w-0 w-full flex-1";
 const DASHBOARD_SESSION_STRIP_CLASS =
   "flex min-w-0 h-full w-full items-stretch px-2 pt-1";
 const DASHBOARD_TIMELINE_OPERATIONS_ROW_CLASS =
-  "relative flex min-w-0 w-full items-center gap-1.5 rounded-t-2xl bg-af-surface-subtle pb-2";
+  "relative flex min-w-0 w-full rounded-sm items-center gap-1.5 rounded-t-2xl bg-af-surface-subtle pb-2 px-2 pt-1";
 const DASHBOARD_TITLE_CLASS = cn("m-0 shrink-0", DASHBOARD_PAGE_HEADING_CLASS);
 const DASHBOARD_CONTROLS_CLASS = "shrink-0 self-end pb-2";
 const DASHBOARD_HEADER_ACTION_ROW_CLASS = "justify-end max-md:w-full";
@@ -339,7 +339,9 @@ function DashboardLocaleMenuList({
             aria-checked={isSelected}
             className={cn(
               LOCALE_MENU_ITEM_CLASS,
-              isSelected ? "border-af-accent-border bg-af-accent-surface text-af-text" : "text-af-text-muted",
+              isSelected
+                ? "border-af-accent-border bg-af-accent-surface text-af-text"
+                : "text-af-text-muted",
             )}
             onClick={() => {
               onChangeLocale(option.value);

--- a/ui/src/features/header/components/dashboard-session-tabs.test.tsx
+++ b/ui/src/features/header/components/dashboard-session-tabs.test.tsx
@@ -1,19 +1,14 @@
 // biome-ignore-all lint/nursery/noExcessiveLinesPerFile: existing dashboard-session-tabs coverage stayed intact during feature-root migration.
 // biome-ignore-all lint/complexity/noExcessiveLinesPerFunction: existing dashboard-session-tabs coverage stayed intact during feature-root migration.
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import {
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { FactorySessionsAPIError } from "../../../api/factory-sessions";
 import { DEFAULT_FACTORY_SESSION_ID } from "../../../api/session-routing";
 import { useDashboardSessionStore } from "../../dashboard/state/dashboardSessionStore";
-import { DashboardSessionTabs } from "./dashboard-session-tabs";
-import { getHeaderControlsMessages } from "../messages/header-controls";
 import { sessionCloseLabel } from "../lib/dashboard-session-tabs-utils";
+import { getHeaderControlsMessages } from "../messages/header-controls";
+import { DashboardSessionTabs } from "./dashboard-session-tabs";
 
 const listFactorySessions = vi.fn();
 const openFactorySession = vi.fn();
@@ -184,7 +179,9 @@ describe("DashboardSessionTabs", () => {
       expect(rootTab.getAttribute("aria-selected")).toBe("true");
     });
     expect(document.activeElement).toBe(rootTab);
-    expect(useDashboardSessionStore.getState().selectedSessionID).toBe("~default");
+    expect(useDashboardSessionStore.getState().selectedSessionID).toBe(
+      "~default",
+    );
   });
 
   it("shows the offline state and allows session refetch", async () => {
@@ -285,7 +282,9 @@ describe("DashboardSessionTabs", () => {
     fireEvent.click(
       screen.getByRole("button", { name: messages.openSessionButtonLabel }),
     );
-    expect(screen.getByText(messages.openSessionDialogDescription)).toBeTruthy();
+    expect(
+      screen.getByText(messages.openSessionDialogDescription),
+    ).toBeTruthy();
     const folderField = screen.getByRole("textbox", {
       name: messages.sessionFolderFieldLabel,
     });
@@ -303,9 +302,7 @@ describe("DashboardSessionTabs", () => {
       },
     );
     expect(inspectFolderButton.getAttribute("disabled")).toBeNull();
-    fireEvent.submit(
-      inspectFolderButton.closest("form") as HTMLFormElement,
-    );
+    fireEvent.submit(inspectFolderButton.closest("form") as HTMLFormElement);
 
     await waitFor(() => {
       expect(openFactorySession.mock.calls[0]?.[0]).toEqual({
@@ -313,7 +310,9 @@ describe("DashboardSessionTabs", () => {
         validateOnly: true,
       });
     });
-    expect(screen.queryByText(messages.openSessionLaunchReadySingleTarget)).toBeNull();
+    expect(
+      screen.queryByText(messages.openSessionLaunchReadySingleTarget),
+    ).toBeNull();
     expect(
       screen.queryByRole("button", { name: messages.openSessionSubmitLabel }),
     ).toBeNull();
@@ -507,9 +506,12 @@ describe("DashboardSessionTabs", () => {
     fireEvent.click(
       screen.getByRole("button", { name: messages.openSessionButtonLabel }),
     );
-    fireEvent.change(screen.getByPlaceholderText(messages.sessionFolderFieldPlaceholder), {
-      target: { value: "/workspace/fleet" },
-    });
+    fireEvent.change(
+      screen.getByPlaceholderText(messages.sessionFolderFieldPlaceholder),
+      {
+        target: { value: "/workspace/fleet" },
+      },
+    );
     fireEvent.submit(
       screen
         .getByRole("button", { name: messages.openSessionSubmitLabel })
@@ -522,7 +524,9 @@ describe("DashboardSessionTabs", () => {
         validateOnly: true,
       });
     });
-    expect(screen.queryByText(messages.openSessionLaunchReadyMultipleTargets)).toBeNull();
+    expect(
+      screen.queryByText(messages.openSessionLaunchReadyMultipleTargets),
+    ).toBeNull();
     expect(
       screen.queryByRole("button", { name: messages.openSessionSubmitLabel }),
     ).toBeNull();
@@ -665,7 +669,9 @@ describe("DashboardSessionTabs", () => {
       ).toBeTruthy();
     });
     expect(openFactorySession).toHaveBeenCalledTimes(4);
-    expect(screen.queryByRole("region", { name: messages.targetPickerTitle })).toBeNull();
+    expect(
+      screen.queryByRole("region", { name: messages.targetPickerTitle }),
+    ).toBeNull();
   });
 
   it("closes the active session tab and selects the remaining session deterministically", async () => {
@@ -725,9 +731,7 @@ describe("DashboardSessionTabs", () => {
     });
     await waitFor(() => {
       expect(
-        screen.getByRole("tab", { name: "beta" }).getAttribute(
-          "aria-selected",
-        ),
+        screen.getByRole("tab", { name: "beta" }).getAttribute("aria-selected"),
       ).toBe("true");
     });
     expect(useDashboardSessionStore.getState().selectedSessionID).toBe(
@@ -772,8 +776,12 @@ describe("DashboardSessionTabs", () => {
         screen.getByRole("button", { name: "Close root session" }),
       ),
     ).toBe(true);
-    expect(activeTab.parentElement?.contains(activeCluster as HTMLElement)).toBe(true);
-    expect(screen.getByRole("button", { name: "Close beta session" })).toBeTruthy();
+    expect(
+      activeTab.parentElement?.contains(activeCluster as HTMLElement),
+    ).toBe(true);
+    expect(
+      screen.getByRole("button", { name: "Close beta session" }),
+    ).toBeTruthy();
   });
 
   it("keeps inactive-tab close buttons quiet by default and directly operable", async () => {
@@ -844,8 +852,12 @@ describe("DashboardSessionTabs", () => {
     });
 
     expect(betaCloseButton.className).toContain("text-af-text-disabled");
-    expect(betaCloseButton.className).toContain("group-hover:text-af-text-muted");
-    expect(betaCloseButton.className).toContain("focus-visible:ring-af-focus-ring");
+    expect(betaCloseButton.className).toContain(
+      "group-hover:text-af-text-muted",
+    );
+    expect(betaCloseButton.className).toContain(
+      "focus-visible:ring-af-focus-ring",
+    );
 
     betaCloseButton.focus();
     expect(document.activeElement).toBe(betaCloseButton);
@@ -950,15 +962,16 @@ describe("DashboardSessionTabs", () => {
       name: sessionCloseLabel(rootSession, messages),
     });
 
-    expect(
-      (pendingCloseButton as HTMLButtonElement).disabled,
-    ).toBe(true);
+    expect((pendingCloseButton as HTMLButtonElement).disabled).toBe(true);
     expect(pendingCloseButton.textContent?.trim()).toBe(
       messages.closingSessionButtonLabel,
     );
   });
 
   it("uses short factory-first tab labels while preserving visible supporting context", async () => {
+    const longFolderPath =
+      "/workspace/customers/northwind/agent-factory/examples/catalog";
+
     listFactorySessions.mockResolvedValue([
       {
         factoryDir: "/workspace/root",
@@ -972,7 +985,7 @@ describe("DashboardSessionTabs", () => {
       },
       {
         factoryDir: "/workspace/catalog/review",
-        folderPath: "/workspace/catalog",
+        folderPath: longFolderPath,
         id: "session-review",
         isDefault: false,
         project: "catalog",
@@ -994,10 +1007,14 @@ describe("DashboardSessionTabs", () => {
 
     expect(rootTab.getAttribute("aria-label")).toBe("root");
     expect(reviewTab.getAttribute("aria-label")).toBe("review");
-    expect(rootTab.textContent).toBe("rootworkspace root");
-    expect(reviewTab.textContent).toBe("reviewcatalog");
-    expect(screen.getByText("workspace root")).toBeTruthy();
-    expect(screen.getByText("catalog")).toBeTruthy();
+    expect(rootTab.textContent).toBe("root/workspace/root");
+    expect(reviewTab.textContent).toBe(
+      "review...mers/northwind/agent-factory/examples/catalog",
+    );
+    expect(screen.getByText("/workspace/root")).toBeTruthy();
+    expect(screen.getByTitle(longFolderPath).textContent).toBe(
+      "...mers/northwind/agent-factory/examples/catalog",
+    );
   });
 });
 

--- a/ui/src/features/header/components/dashboard-session-tabs.tsx
+++ b/ui/src/features/header/components/dashboard-session-tabs.tsx
@@ -8,22 +8,23 @@ import type { DashboardStreamState } from "../../../api/dashboard/types";
 import type { FactorySessionSummary } from "../../../api/factory-sessions";
 import { DEFAULT_FACTORY_SESSION_ID } from "../../../api/session-routing";
 import { Button, Dialog } from "../../../components/ui";
-import { cn } from "../../../lib/cn";
 import { DASHBOARD_BODY_TEXT_CLASS } from "../../../components/ui/dashboard-typography";
+import { cn } from "../../../lib/cn";
 import { useDashboardStreamStore } from "../../dashboard/state/dashboardStreamStore";
-import { OpenSessionDialog } from "./dashboard-session-tabs-open-dialog";
+import {
+  type DashboardSessionTabsState,
+  useDashboardSessionTabsState,
+} from "../hooks/use-dashboard-session-tabs-state";
 import {
   normalizeFactorySessionsError,
   sessionCloseLabel,
   sessionPanelID,
   sessionTabID,
   sessionTabLabel,
+  sessionTabSecondaryPath,
 } from "../lib/dashboard-session-tabs-utils";
 import { getHeaderControlsMessages } from "../messages/header-controls";
-import {
-  type DashboardSessionTabsState,
-  useDashboardSessionTabsState,
-} from "../hooks/use-dashboard-session-tabs-state";
+import { OpenSessionDialog } from "./dashboard-session-tabs-open-dialog";
 
 const SESSION_TABS_SHELL_CLASS = "grid min-w-0 max-w-full flex-1 gap-2";
 const SESSION_TABS_ROW_CLASS =
@@ -47,7 +48,7 @@ const SESSION_TAB_ACTIVE_CLASS = cn(
   "after:pointer-events-none after:absolute after:-right-4 after:-bottom-0 after:h-4 after:w-4 after:bg-[radial-gradient(circle_at_top_right,transparent_1rem,var(--color-af-surface-subtle)_1rem)]",
 );
 const SESSION_TAB_INACTIVE_CLASS =
-  "rounded-t-xl rounded-b-none bg-af-surface-subtle-muted text-af-text-muted hover:bg-af-overlay hover:text-af-text";
+  "rounded-t-xl rounded-b-none text-af-text-muted hover:bg-af-overlay hover:text-af-text";
 const SESSION_TAB_ACTIVE_BUTTON_CLASS =
   "flex min-w-0 flex-1 flex-col items-start rounded-tl-xl px-3 py-2";
 const SESSION_TAB_INACTIVE_BUTTON_CLASS =
@@ -131,7 +132,9 @@ function DashboardSessionTabsView({
           <SessionTabsContent
             activeSession={activeSession}
             closingSessionID={
-              closeSessionMutation.isPending ? closeSessionMutation.variables : null
+              closeSessionMutation.isPending
+                ? closeSessionMutation.variables
+                : null
             }
             error={sessionsQuery.isError ? sessionsQuery.error : null}
             isPending={sessionsQuery.isPending}
@@ -197,11 +200,14 @@ function OpenSessionButton({
       onClick={onClick}
       type="button"
     >
-        <span aria-hidden="true" className="text-lg leading-none">+</span>
+      <span aria-hidden="true" className="text-lg leading-none">
+        +
+      </span>
     </button>
   );
 }
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: existing session tab orchestration stays intact; this change only adjusts the status indicator styling.
 function SessionTabsContent({
   activeSession,
   closingSessionID,
@@ -232,7 +238,9 @@ function SessionTabsContent({
 
   if (isPending) {
     return (
-      <p className={cn("text-sm text-af-text-muted", DASHBOARD_BODY_TEXT_CLASS)}>
+      <p
+        className={cn("text-sm text-af-text-muted", DASHBOARD_BODY_TEXT_CLASS)}
+      >
         {messages.loadingSessionsLabel}
       </p>
     );
@@ -270,7 +278,8 @@ function SessionTabsContent({
   }
 
   function moveSessionFocus(currentIndex: number, offset: number) {
-    const nextIndex = (currentIndex + offset + sessions.length) % sessions.length;
+    const nextIndex =
+      (currentIndex + offset + sessions.length) % sessions.length;
     const nextSession = sessions[nextIndex];
     if (!nextSession) {
       return;
@@ -281,7 +290,10 @@ function SessionTabsContent({
 
   return (
     <>
-      <nav aria-label={messages.sessionTabsLabel} className="min-w-0 overflow-visible">
+      <nav
+        aria-label={messages.sessionTabsLabel}
+        className="min-w-0 overflow-visible"
+      >
         <div
           aria-orientation="horizontal"
           className={SESSION_TAB_LIST_CLASS}
@@ -402,6 +414,7 @@ function SessionTabButton({
   tabID: string;
 }) {
   const label = sessionTabLabel(session);
+  const secondaryPath = sessionTabSecondaryPath(session.folderPath);
   return (
     <div
       className={cn(
@@ -416,7 +429,9 @@ function SessionTabButton({
         aria-selected={active}
         className={cn(
           SESSION_TAB_BUTTON_CLASS,
-          active ? SESSION_TAB_ACTIVE_BUTTON_CLASS : SESSION_TAB_INACTIVE_BUTTON_CLASS,
+          active
+            ? SESSION_TAB_ACTIVE_BUTTON_CLASS
+            : SESSION_TAB_INACTIVE_BUTTON_CLASS,
         )}
         id={tabID}
         onClick={onClick}
@@ -430,8 +445,11 @@ function SessionTabButton({
           <SessionTabStatusIndicator status={streamStatus} />
           <span className="truncate text-sm font-semibold">{label}</span>
         </span>
-        <span className="block truncate text-[11px] text-af-text-subtle">
-          {session.project || session.folderPath}
+        <span
+          className="block truncate text-[11px] text-af-text-subtle"
+          title={session.folderPath}
+        >
+          {secondaryPath}
         </span>
       </button>
       <button
@@ -458,18 +476,24 @@ function SessionTabStatusIndicator({
   status: DashboardStreamState["status"];
 }) {
   return (
-    <span
-      aria-hidden="true"
-      className={cn(
-        "relative inline-flex size-2.5 shrink-0 rounded-full",
-        status === "live" && "bg-af-success",
-        status === "connecting" && "bg-af-accent",
-        status === "offline" && "bg-af-danger",
-      )}
-    >
+    <span aria-hidden="true" className="relative inline-flex size-2.5 shrink-0">
       {status === "live" ? (
-        <span className="absolute inset-0 animate-ping rounded-full bg-af-success-surface" />
+        <span
+          className={cn(
+            "absolute -inset-1 animate-ping rounded-full",
+            "bg-[var(--color-af-session-live-ping)]",
+          )}
+          data-testid="dashboard-session-live-ping"
+        />
       ) : null}
+      <span
+        className={cn(
+          "absolute inset-0 rounded-full",
+          status === "live" && "bg-af-success",
+          status === "connecting" && "bg-af-accent",
+          status === "offline" && "bg-af-danger",
+        )}
+      />
     </span>
   );
 }

--- a/ui/src/features/header/lib/dashboard-session-tabs-utils.test.ts
+++ b/ui/src/features/header/lib/dashboard-session-tabs-utils.test.ts
@@ -10,6 +10,7 @@ import {
   sessionPanelID,
   sessionTabID,
   sessionTabLabel,
+  sessionTabSecondaryPath,
 } from "./dashboard-session-tabs-utils";
 
 const messages = getHeaderControlsMessages("en");
@@ -58,11 +59,31 @@ describe("dashboard session tabs utils", () => {
     );
   });
 
-  it("maps validation states and API errors to the visible folder-validation messages", () => {
-    expect(folderValidationStatusMessage({ status: "idle" }, messages)).toBeNull();
+  it("shrinks long session-tab secondary paths by hiding the prefix", () => {
+    expect(sessionTabSecondaryPath("/workspace/catalog")).toBe(
+      "/workspace/catalog",
+    );
     expect(
-      folderValidationStatusMessage({ status: "pending" }, messages),
-    ).toBe(messages.openSessionValidationPendingLabel);
+      sessionTabSecondaryPath(
+        "/workspace/customers/northwind/agent-factory/examples/support",
+        28,
+      ),
+    ).toBe("...-factory/examples/support");
+    expect(
+      sessionTabSecondaryPath(
+        "/workspace/customers/northwind/agent-factory/examples/support",
+        28,
+      ),
+    ).toHaveLength(28);
+  });
+
+  it("maps validation states and API errors to the visible folder-validation messages", () => {
+    expect(
+      folderValidationStatusMessage({ status: "idle" }, messages),
+    ).toBeNull();
+    expect(folderValidationStatusMessage({ status: "pending" }, messages)).toBe(
+      messages.openSessionValidationPendingLabel,
+    );
     expect(
       folderValidationStatusMessage(
         {
@@ -120,7 +141,9 @@ describe("dashboard session tabs utils", () => {
     expect(selectedFactorySessionTarget([...targets], "named:review")).toEqual(
       targets[1],
     );
-    expect(selectedFactorySessionTarget([...targets], "named:missing")).toBeNull();
+    expect(
+      selectedFactorySessionTarget([...targets], "named:missing"),
+    ).toBeNull();
 
     const wrappedError = normalizeFactorySessionsError("boom");
     expect(wrappedError).toBeInstanceOf(FactorySessionsAPIError);

--- a/ui/src/features/header/lib/dashboard-session-tabs-utils.ts
+++ b/ui/src/features/header/lib/dashboard-session-tabs-utils.ts
@@ -1,10 +1,12 @@
 import {
-  type FactorySessionTarget,
-  type FactorySessionsAPIErrorTarget,
   type FactorySessionSummary,
   FactorySessionsAPIError,
+  type FactorySessionsAPIErrorTarget,
+  type FactorySessionTarget,
 } from "../../../api/factory-sessions";
 import type { getHeaderControlsMessages } from "../messages/header-controls";
+
+export const SESSION_TAB_PATH_MAX_LENGTH = 48;
 
 export type FolderValidationState =
   | { status: "idle" }
@@ -22,7 +24,8 @@ export type FolderValidationErrorReason =
   | "unknown";
 
 export function sessionTabLabel(session: FactorySessionSummary): string {
-  const namedTarget = session.target.kind === "named" ? session.target.name : "";
+  const namedTarget =
+    session.target.kind === "named" ? session.target.name : "";
   return (
     normalizeSessionLabelPart(namedTarget) ||
     normalizeSessionLabelPart(basename(session.factoryDir)) ||
@@ -30,6 +33,24 @@ export function sessionTabLabel(session: FactorySessionSummary): string {
     normalizeSessionLabelPart(session.project) ||
     "factory"
   );
+}
+
+export function sessionTabSecondaryPath(
+  path: string,
+  maxLength = SESSION_TAB_PATH_MAX_LENGTH,
+): string {
+  const normalizedPath = path.trim();
+  if (normalizedPath.length <= maxLength) {
+    return normalizedPath;
+  }
+  if (maxLength <= 0) {
+    return "";
+  }
+  if (maxLength <= 3) {
+    return normalizedPath.slice(-maxLength);
+  }
+
+  return `...${normalizedPath.slice(-(maxLength - 3))}`;
 }
 
 export function sessionCloseLabel(
@@ -59,11 +80,16 @@ export function sessionTabID(sessionTabsID: string, sessionID: string): string {
   return `${sessionTabsID}-tab-${sessionDOMIDFragment(sessionID)}`;
 }
 
-export function sessionPanelID(sessionTabsID: string, sessionID: string): string {
+export function sessionPanelID(
+  sessionTabsID: string,
+  sessionID: string,
+): string {
   return `${sessionTabsID}-panel-${sessionDOMIDFragment(sessionID)}`;
 }
 
-export function normalizeFactorySessionsError(error: unknown): FactorySessionsAPIError {
+export function normalizeFactorySessionsError(
+  error: unknown,
+): FactorySessionsAPIError {
   if (error instanceof FactorySessionsAPIError) {
     return error;
   }
@@ -97,14 +123,19 @@ export function folderValidationStatusMessage(
 export function classifyFactorySessionFolderValidationError(
   error: FactorySessionsAPIError,
 ): FolderValidationErrorReason {
-  const targetedReason = classifyFactorySessionFolderValidationTarget(error.targets);
+  const targetedReason = classifyFactorySessionFolderValidationTarget(
+    error.targets,
+  );
   if (targetedReason !== null) {
     return targetedReason;
   }
 
   const message = error.message.trim();
 
-  if (message === "folderPath is required" || message === "factory session folder is required") {
+  if (
+    message === "folderPath is required" ||
+    message === "factory session folder is required"
+  ) {
     return "required";
   }
   if (
@@ -140,7 +171,9 @@ function classifyFactorySessionFolderValidationTarget(
   targets: FactorySessionsAPIErrorTarget[] | undefined,
 ): FolderValidationErrorReason | null {
   const validationTarget = targets?.find(
-    (target) => target.kind === "factory-session-validation" && typeof target.id === "string",
+    (target) =>
+      target.kind === "factory-session-validation" &&
+      typeof target.id === "string",
   );
   if (!validationTarget?.id) {
     return null;
@@ -176,7 +209,8 @@ export function selectedFactorySessionTarget(
 ): FactorySessionTarget | null {
   return (
     targets.find(
-      (target) => factorySessionTargetOptionValue(target) === selectedTargetValue,
+      (target) =>
+        factorySessionTargetOptionValue(target) === selectedTargetValue,
     ) ?? null
   );
 }

--- a/ui/src/features/provider-session-detail/components/exec-command-output.tsx
+++ b/ui/src/features/provider-session-detail/components/exec-command-output.tsx
@@ -1,8 +1,8 @@
+import { isAPIRecord } from "../../../api/transport";
 import {
   DASHBOARD_BODY_TEXT_CLASS,
   DASHBOARD_SUPPORTING_LABEL_CLASS,
 } from "../../../components/ui/dashboard-typography";
-import { isAPIRecord } from "../../../api/transport";
 import { formatNumber } from "../../../i18n/formatters";
 import { cn } from "../../../lib/cn";
 import { getProviderSessionDetailMessages } from "../messages/provider-session-detail";
@@ -27,7 +27,9 @@ export function FriendlyExecCommandOutput({
   if (friendlyOutput === null) {
     return (
       <div className="grid gap-3">
-        {text ? <p className={cn("m-0", DASHBOARD_BODY_TEXT_CLASS)}>{text}</p> : null}
+        {text ? (
+          <p className={cn("m-0", DASHBOARD_BODY_TEXT_CLASS)}>{text}</p>
+        ) : null}
         <ExpandableCodeBlock
           label={messages.outputLabel}
           locale={locale}
@@ -39,8 +41,10 @@ export function FriendlyExecCommandOutput({
 
   return (
     <div className="grid gap-3">
-      {text ? <p className={cn("m-0", DASHBOARD_BODY_TEXT_CLASS)}>{text}</p> : null}
-      <section className="grid gap-2 rounded-lg border border-af-success-border bg-af-success-surface p-3">
+      {text ? (
+        <p className={cn("m-0", DASHBOARD_BODY_TEXT_CLASS)}>{text}</p>
+      ) : null}
+      <section className="grid gap-2 rounded-lg border border-af-border bg-af-surface-subtle p-3">
         <span className={DASHBOARD_SUPPORTING_LABEL_CLASS}>
           {messages.execCommandResultHeading}
         </span>
@@ -58,14 +62,13 @@ export function FriendlyExecCommandOutput({
             />
           ) : null}
           {status ? (
-            <SummaryMetric
-              label={messages.sessionStatusLabel}
-              value={status}
-            />
+            <SummaryMetric label={messages.sessionStatusLabel} value={status} />
           ) : null}
           <SummaryMetric
             label={messages.execCommandOutputSummaryLabel}
-            value={friendlyOutput.summary ?? messages.execCommandNoOutputSummary}
+            value={
+              friendlyOutput.summary ?? messages.execCommandNoOutputSummary
+            }
           />
         </div>
       </section>
@@ -117,12 +120,20 @@ function parseExecCommandOutput(output: string): {
   }
 
   const wallTimeLine = lines.find((line) => line.startsWith("Wall time:"));
-  const exitCodeLine = lines.find((line) => /^Process exited with code -?\d+/.test(line));
-  const rawCommandOutput = lines.slice(outputStartIndex + 1).join("\n").trim();
+  const exitCodeLine = lines.find((line) =>
+    /^Process exited with code -?\d+/.test(line),
+  );
+  const rawCommandOutput = lines
+    .slice(outputStartIndex + 1)
+    .join("\n")
+    .trim();
 
   return {
     exitCode: exitCodeLine
-      ? Number.parseInt(exitCodeLine.replace(/^Process exited with code /, ""), 10)
+      ? Number.parseInt(
+          exitCodeLine.replace(/^Process exited with code /, ""),
+          10,
+        )
       : null,
     summary: summarizeExecCommandText(rawCommandOutput),
     wallTime: wallTimeLine ? wallTimeLine.replace(/^Wall time:\s*/, "") : null,
@@ -198,10 +209,7 @@ function summarizeExecCommandText(value: string | null): string | null {
     : firstMeaningfulLine;
 }
 
-function formatExecCommandWallTime(
-  value: string,
-  locale?: string,
-): string {
+function formatExecCommandWallTime(value: string, locale?: string): string {
   const secondsMatch = value.match(
     /^\s*(?<seconds>\d+(?:\.\d+)?)\s+seconds?\s*$/i,
   );
@@ -216,7 +224,7 @@ function formatExecCommandWallTime(
   }
 
   const fractionDigits = secondsText.includes(".")
-    ? secondsText.split(".")[1]?.length ?? 0
+    ? (secondsText.split(".")[1]?.length ?? 0)
     : 0;
 
   return formatNumber(secondsValue, locale, {

--- a/ui/src/features/provider-session-detail/components/provider-session-detail-panel.test.tsx
+++ b/ui/src/features/provider-session-detail/components/provider-session-detail-panel.test.tsx
@@ -259,7 +259,7 @@ describe("ProviderSessionDetailPanel", () => {
     expect(screen.getByText("Unknown event on line 2")).toBeTruthy();
   });
 
-  it("renders parsed source metadata, turns, function calls, reasoning, token usage, and diagnostics", async () => {
+  it("renders parsed source metadata, turns, token usage, and diagnostics", async () => {
     vi.mocked(globalThis.fetch).mockResolvedValue(
       jsonResponse(
         buildProviderSessionDetailResponse({
@@ -339,8 +339,8 @@ describe("ProviderSessionDetailPanel", () => {
       screen.getByRole("heading", { name: "Session analysis" }),
     ).toBeTruthy();
     expect(screen.getByText("Turn 1")).toBeTruthy();
-    expect(screen.getByText("list_dir")).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Reasoning" })).toBeTruthy();
+    expect(screen.queryByText("list_dir")).toBeNull();
+    expect(screen.queryByRole("heading", { name: "Reasoning" })).toBeNull();
     expect(
       screen.getByRole("heading", { name: "Maintainer diagnostics" }),
     ).toBeTruthy();
@@ -473,7 +473,7 @@ describe("ProviderSessionDetailPanel", () => {
         .getAllByTitle("2026-05-18T14:10:04Z")
         .some((element) => element.textContent === transcriptTimestamp),
     ).toBe(true);
-    expect(screen.getAllByText("Raw ISO timestamp").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Raw ISO timestamp")).toBeNull();
 
     const expandArguments = screen.getByRole("button", {
       name: "Expand Arguments",
@@ -547,7 +547,7 @@ describe("ProviderSessionDetailPanel", () => {
     expect(rawArguments.className).toContain("af-dashboard-body-code");
   });
 
-  it("formats source, transcript, and turn timestamps in the local timezone while preserving raw ISO access", async () => {
+  it("formats source, transcript, and turn timestamps in the local timezone while preserving raw source and turn ISO access", async () => {
     vi.mocked(globalThis.fetch).mockResolvedValue(
       jsonResponse(
         buildProviderSessionDetailResponse({
@@ -618,11 +618,15 @@ describe("ProviderSessionDetailPanel", () => {
         .some((element) => element.textContent === transcriptTimestamp),
     ).toBe(true);
 
-    fireEvent.click(screen.getAllByText("Raw ISO timestamp")[0]);
+    for (const rawTimestampControl of screen.getAllByText(
+      "Raw ISO timestamp",
+    )) {
+      fireEvent.click(rawTimestampControl);
+    }
 
     expect(screen.getByText("2026-05-18T14:09:59Z")).toBeTruthy();
     expect(screen.getByText("2026-05-18T14:10:00Z")).toBeTruthy();
-    expect(screen.getByText("2026-05-18T14:10:01Z")).toBeTruthy();
+    expect(screen.queryByText("2026-05-18T14:10:01Z")).toBeNull();
   });
 
   it("rerenders provider-session timestamps for zh-CN without changing raw values or payload text", async () => {
@@ -675,7 +679,9 @@ describe("ProviderSessionDetailPanel", () => {
     });
     const { rerender } = render(
       <QueryClientProvider client={queryClient}>
-        <ProviderSessionDetailPanel selectedProviderSession={SELECTED_SESSION} />
+        <ProviderSessionDetailPanel
+          selectedProviderSession={SELECTED_SESSION}
+        />
       </QueryClientProvider>,
     );
 
@@ -693,10 +699,13 @@ describe("ProviderSessionDetailPanel", () => {
         .getAllByTitle("2026-05-18T14:10:01Z")
         .some(
           (element) =>
-            element.textContent === formatDateTime("2026-05-18T14:10:01Z", "en"),
+            element.textContent ===
+            formatDateTime("2026-05-18T14:10:01Z", "en"),
         ),
     ).toBe(true);
-    expect(screen.getByText("Summarize the rollout state for this work item.")).toBeTruthy();
+    expect(
+      screen.getByText("Summarize the rollout state for this work item."),
+    ).toBeTruthy();
 
     rerender(
       <QueryClientProvider client={queryClient}>
@@ -721,16 +730,21 @@ describe("ProviderSessionDetailPanel", () => {
         .getAllByTitle("2026-05-18T14:10:01Z")
         .some(
           (element) =>
-            element.textContent === formatDateTime("2026-05-18T14:10:01Z", "zh-CN"),
+            element.textContent ===
+            formatDateTime("2026-05-18T14:10:01Z", "zh-CN"),
         ),
     ).toBe(true);
-    expect(screen.getByText("Summarize the rollout state for this work item.")).toBeTruthy();
+    expect(
+      screen.getByText("Summarize the rollout state for this work item."),
+    ).toBeTruthy();
 
-    fireEvent.click(screen.getAllByText("原始 ISO 时间戳")[0]);
+    for (const rawTimestampControl of screen.getAllByText("原始 ISO 时间戳")) {
+      fireEvent.click(rawTimestampControl);
+    }
 
     expect(screen.getByText("2026-05-18T14:09:59Z")).toBeTruthy();
     expect(screen.getByText("2026-05-18T14:10:00Z")).toBeTruthy();
-    expect(screen.getByText("2026-05-18T14:10:01Z")).toBeTruthy();
+    expect(screen.queryByText("2026-05-18T14:10:01Z")).toBeNull();
     expect(screen.getByText("sess_active")).toBeTruthy();
   });
 
@@ -879,8 +893,6 @@ describe("ProviderSessionDetailPanel", () => {
       "Session analysis",
       "Token usage",
       "Turns",
-      "Function calls",
-      "Reasoning",
       "Maintainer diagnostics",
     ];
 
@@ -998,14 +1010,14 @@ describe("ProviderSessionDetailPanel", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByRole("heading", { name: "Reasoning" })).toBeTruthy();
+      expect(screen.getByRole("heading", { name: "Transcript" })).toBeTruthy();
     });
 
     expect(screen.getAllByText(reasoningSummary)).toHaveLength(1);
     expect(screen.getAllByText(reasoningText)).toHaveLength(1);
     expect(screen.getAllByText(callArguments)).toHaveLength(1);
     expect(screen.getAllByText(callOutput)).toHaveLength(1);
-    expect(screen.getAllByText("read_file")).toHaveLength(2);
+    expect(screen.getAllByText("read_file")).toHaveLength(1);
     expect(screen.getAllByText("Order 4 / Turn 1").length).toBeGreaterThan(0);
   });
 
@@ -1122,20 +1134,20 @@ describe("ProviderSessionDetailPanel", () => {
     expect(screen.getByText("缓存输入")).toBeTruthy();
     expect(screen.getByText("轮次 2")).toBeTruthy();
     expect(screen.getByText("无时间戳")).toBeTruthy();
-    expect(screen.getAllByText("顺序 3 / 轮次 2").length).toBeGreaterThan(0);
-    expect(screen.getByText("调用 ID")).toBeTruthy();
+    expect(screen.queryByText("顺序 3 / 轮次 2")).toBeNull();
+    expect(screen.queryByText("调用 ID")).toBeNull();
     expect(screen.getAllByText("不可用").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("加密推理").length).toBeGreaterThan(0);
+    expect(screen.queryByText("加密推理")).toBeNull();
     expect(screen.getByText("命令结果")).toBeTruthy();
     expect(screen.getByText("退出代码")).toBeTruthy();
     expect(screen.getByText("耗时")).toBeTruthy();
     expect(screen.getByText("摘要")).toBeTruthy();
     expect(screen.getByText("命令执行成功")).toBeTruthy();
     expect(
-      screen.getByText(
+      screen.queryByText(
         "此步骤确实发生了推理，但明文内容会被有意隐藏，无法直接查看。",
       ),
-    ).toBeTruthy();
+    ).toBeNull();
     expect(screen.getByText("第 3 行")).toBeTruthy();
     expect(screen.getByText("第 2 行的未知事件")).toBeTruthy();
   });
@@ -1311,7 +1323,7 @@ describe("ProviderSessionDetailPanel", () => {
     expect(screen.getAllByText("类型").length).toBeGreaterThan(0);
     expect(screen.getAllByText("用户").length).toBeGreaterThan(0);
     expect(screen.getAllByText("助手").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("工具输出").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("call_exec_1").length).toBeGreaterThan(0);
     expect(screen.getAllByText("加密推理").length).toBeGreaterThan(0);
     expect(
       screen.getAllByText(
@@ -1334,10 +1346,12 @@ describe("ProviderSessionDetailPanel", () => {
         ),
     ).toBe(true);
 
-    fireEvent.click(screen.getAllByText("原始 ISO 时间戳")[0]);
+    for (const rawTimestampControl of screen.getAllByText("原始 ISO 时间戳")) {
+      fireEvent.click(rawTimestampControl);
+    }
 
     expect(screen.getByText("2026-05-18T14:09:59Z")).toBeTruthy();
-    expect(screen.getByText("2026-05-18T14:10:04Z")).toBeTruthy();
+    expect(screen.queryByText("2026-05-18T14:10:04Z")).toBeNull();
 
     const rawOutputButton = screen.getByRole("button", {
       name: "展开原始 exec_command 输出",

--- a/ui/src/features/provider-session-detail/components/provider-session-detail-panel.tsx
+++ b/ui/src/features/provider-session-detail/components/provider-session-detail-panel.tsx
@@ -1,4 +1,3 @@
-// biome-ignore lint/nursery/noExcessiveLinesPerFile: existing provider-session detail panel remains oversized while this story localizes enum-backed labels without a broader panel split.
 import type { ReactNode } from "react";
 import type { ProviderSessionDetailResponse } from "../../../api/provider-session-details";
 import { DETAIL_COPY_CLASS } from "../../../components/dashboard/widget-board";
@@ -16,10 +15,7 @@ import { PROVIDER_SESSION_CARD_CLASS } from "../../current-selection/components/
 import { useProviderSessionDetail } from "../hooks/use-provider-session-detail";
 import type { LoadableProviderSessionRef } from "../lib/provider-session-ref";
 import { getProviderSessionDetailMessages } from "../messages/provider-session-detail";
-import {
-  EncryptedReasoningNotice,
-  TranscriptSection,
-} from "./provider-session-transcript";
+import { TranscriptSection } from "./provider-session-transcript";
 
 export interface ProviderSessionDetailPanelProps {
   locale?: string;
@@ -86,7 +82,11 @@ function LoadedProviderSessionDetailPanel({
           {messages.localizedTimezoneContext}
         </LocalizedTimezoneNote>
         <div className="grid gap-3">
-          <DetailMetric label={messages.sessionLabel} value={sessionLabel} code />
+          <DetailMetric
+            label={messages.sessionLabel}
+            value={sessionLabel}
+            code
+          />
           <DetailMetric
             label={messages.sessionStatusLabel}
             value={getSessionStatusText(detailState.status, messages)}
@@ -164,8 +164,6 @@ function LoadedProviderSessionDetailPanel({
                 <ParseOverview detail={detail} locale={locale} />
                 <TokenUsageSection detail={detail} locale={locale} />
                 <TurnsSection detail={detail} locale={locale} />
-                <FunctionCallsSection detail={detail} locale={locale} />
-                <ReasoningSection detail={detail} locale={locale} />
               </SecondarySection>
               <ParseDiagnosticsSection detail={detail} locale={locale} />
             </>
@@ -187,7 +185,9 @@ function SourceFileSection({
 
   return (
     <section className="grid gap-2.5">
-      <h5 className={DASHBOARD_SECTION_HEADING_CLASS}>{messages.sourceHeading}</h5>
+      <h5 className={DASHBOARD_SECTION_HEADING_CLASS}>
+        {messages.sourceHeading}
+      </h5>
       <div className="grid gap-3">
         <DetailMetric
           label={messages.relativePathLabel}
@@ -270,7 +270,9 @@ function ParseOverview({
 
   return (
     <section className="grid gap-2.5">
-      <h5 className={DASHBOARD_SECTION_HEADING_CLASS}>{messages.parseSummaryHeading}</h5>
+      <h5 className={DASHBOARD_SECTION_HEADING_CLASS}>
+        {messages.parseSummaryHeading}
+      </h5>
       <div className="grid gap-3">
         <DetailMetric
           label={messages.eventCountLabel}
@@ -310,7 +312,10 @@ function TokenUsageSection({
       </h5>
       {tokenUsage ? (
         <div className="grid gap-3">
-          <DetailMetric label={messages.inputLabel} value={tokenUsage.inputTokens ?? 0} />
+          <DetailMetric
+            label={messages.inputLabel}
+            value={tokenUsage.inputTokens ?? 0}
+          />
           <DetailMetric
             label={messages.cachedInputLabel}
             value={tokenUsage.cachedInputTokens ?? 0}
@@ -369,7 +374,10 @@ function TurnsSection({
                 </div>
               </div>
               <div className="mt-2 grid gap-3">
-                <DetailMetric label={messages.eventsLabel} value={turn.eventCount} />
+                <DetailMetric
+                  label={messages.eventsLabel}
+                  value={turn.eventCount}
+                />
                 <DetailMetric
                   label={messages.responseItemsLabel}
                   value={turn.responseItemCount}
@@ -388,118 +396,6 @@ function TurnsSection({
         </div>
       ) : (
         <p className={DETAIL_COPY_CLASS}>{messages.turnsUnavailable}</p>
-      )}
-    </section>
-  );
-}
-
-function FunctionCallsSection({
-  detail,
-  locale,
-}: {
-  detail: SessionDetail;
-  locale?: string;
-}) {
-  const messages = getProviderSessionDetailMessages(locale);
-
-  return (
-    <section className="grid gap-2.5">
-      <h5 className={DASHBOARD_SECTION_HEADING_CLASS}>
-        {messages.functionCallsHeading}
-      </h5>
-      {detail.parse.functionCalls.length > 0 ? (
-        <div className="grid gap-3">
-          {detail.parse.functionCalls.map((call) => (
-            <article
-              className={PROVIDER_SESSION_CARD_CLASS}
-              key={`${call.order}-${call.callId ?? call.name ?? call.type}`}
-            >
-              <div className="grid gap-1">
-                <div className="grid gap-1">
-                  <strong>{call.name ?? call.type}</strong>
-                  <p
-                    className={cn(
-                      "m-0 text-af-text-subtle",
-                      DASHBOARD_SUPPORTING_TEXT_CLASS,
-                    )}
-                  >
-                    {messages.orderLabel({
-                      order: call.order,
-                      turnIndex: call.turnIndex,
-                    })}
-                  </p>
-                </div>
-                {call.status ? (
-                  <span
-                    className={cn(
-                      "inline-flex w-fit rounded-full border border-af-border bg-af-surface-raised px-2 py-0.5 text-af-text-subtle",
-                      DASHBOARD_SUPPORTING_TEXT_CLASS,
-                    )}
-                  >
-                    {call.status}
-                  </span>
-                ) : null}
-              </div>
-              <div className="mt-2 grid gap-3">
-                <DetailMetric label={messages.typeLabel} value={call.type} />
-                <DetailMetric
-                  label={messages.callIdLabel}
-                  value={call.callId ?? messages.unavailableValue}
-                />
-              </div>
-            </article>
-          ))}
-        </div>
-      ) : (
-        <p className={DETAIL_COPY_CLASS}>{messages.functionCallsUnavailable}</p>
-      )}
-    </section>
-  );
-}
-
-function ReasoningSection({
-  detail,
-  locale,
-}: {
-  detail: SessionDetail;
-  locale?: string;
-}) {
-  const messages = getProviderSessionDetailMessages(locale);
-
-  return (
-    <section className="grid gap-2.5">
-      <h5 className={DASHBOARD_SECTION_HEADING_CLASS}>
-        {messages.reasoningHeading}
-      </h5>
-      {detail.parse.reasoning.length > 0 ? (
-        <div className="grid gap-3">
-          {detail.parse.reasoning.map((entry) => (
-            <article
-              className={PROVIDER_SESSION_CARD_CLASS}
-              key={`${entry.order}-${entry.sourceType}`}
-            >
-              <div className="grid gap-1">
-                <strong>{entry.sourceType}</strong>
-                <p
-                  className={cn(
-                    "m-0 text-af-text-subtle",
-                    DASHBOARD_SUPPORTING_TEXT_CLASS,
-                  )}
-                >
-                  {messages.orderLabel({
-                    order: entry.order,
-                    turnIndex: entry.turnIndex,
-                  })}
-                </p>
-              </div>
-              {entry.encrypted ? (
-                <EncryptedReasoningNotice className="mt-2" locale={locale} />
-              ) : null}
-            </article>
-          ))}
-        </div>
-      ) : (
-        <p className={DETAIL_COPY_CLASS}>{messages.reasoningUnavailable}</p>
       )}
     </section>
   );
@@ -656,7 +552,9 @@ function TimestampMetricValue({
     return messages.unavailableValue;
   }
 
-  const formattedTimestamp = formatDateTime(normalizedTimestamp, locale, { fallback: messages.unavailableValue });
+  const formattedTimestamp = formatDateTime(normalizedTimestamp, locale, {
+    fallback: messages.unavailableValue,
+  });
 
   return (
     <span className="grid gap-1">
@@ -685,5 +583,7 @@ function TimestampMetricValue({
 
 function normalizeValidTimestamp(timestamp?: string | null): string | null {
   const normalizedTimestamp = timestamp?.trim();
-  return !normalizedTimestamp || Number.isNaN(Date.parse(normalizedTimestamp)) ? null : normalizedTimestamp;
+  return !normalizedTimestamp || Number.isNaN(Date.parse(normalizedTimestamp))
+    ? null
+    : normalizedTimestamp;
 }

--- a/ui/src/features/provider-session-detail/components/provider-session-transcript.test.tsx
+++ b/ui/src/features/provider-session-detail/components/provider-session-transcript.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+
+import type { ProviderSessionDetailResponse } from "../../../api/provider-session-details";
+import { TranscriptSection } from "./provider-session-transcript";
+
+describe("TranscriptSection", () => {
+  it("formats encrypted reasoning payloads as transcript code content", () => {
+    render(
+      <TranscriptSection
+        detail={buildProviderSessionDetailResponse({
+          transcript: [
+            {
+              encrypted: true,
+              encryptedContent: "sealed-chatgpt-reasoning-blob",
+              order: 1,
+              sourceType: "reasoning",
+              type: "reasoning",
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getAllByText("Encrypted reasoning").length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.getByText("sealed-chatgpt-reasoning-blob")).toBeTruthy();
+    expect(screen.queryByText("Encrypted reasoning content only.")).toBeNull();
+  });
+});
+
+function buildProviderSessionDetailResponse(
+  overrides: Partial<ProviderSessionDetailResponse>,
+): ProviderSessionDetailResponse {
+  return {
+    parse: {
+      eventCount: 1,
+      functionCalls: [],
+      lineCount: 1,
+      malformedLineCount: 0,
+      parseErrors: [],
+      reasoning: [],
+      turns: [],
+      unknownEventCount: 0,
+      unknownEvents: [],
+    },
+    providerSession: {
+      id: "sess_active",
+      kind: "session_id",
+      provider: "codex",
+    },
+    source: {
+      relativePath: "2026/05/18/rollout-sess_active.jsonl",
+      sizeBytes: 2048,
+    },
+    transcript: [],
+    ...overrides,
+  };
+}

--- a/ui/src/features/provider-session-detail/components/provider-session-transcript.tsx
+++ b/ui/src/features/provider-session-detail/components/provider-session-transcript.tsx
@@ -1,38 +1,29 @@
+import type { ProviderSessionDetailResponse } from "../../../api/provider-session-details";
 import {
-  DASHBOARD_BODY_CODE_CLASS,
   DASHBOARD_BODY_TEXT_CLASS,
   DASHBOARD_SECTION_HEADING_CLASS,
   DASHBOARD_SUPPORTING_TEXT_CLASS,
 } from "../../../components/ui/dashboard-typography";
-import type { ProviderSessionDetailResponse } from "../../../api/provider-session-details";
-import { cn } from "../../../lib/cn";
 import { formatDateTime } from "../../../i18n/formatters";
+import { cn } from "../../../lib/cn";
 import {
   AuthoredBodyText,
   PROVIDER_SESSION_CARD_CLASS,
 } from "../../current-selection/components/detail-card-shared";
+import { getProviderSessionDetailMessages } from "../messages/provider-session-detail";
 import { FriendlyExecCommandOutput } from "./exec-command-output";
 import { CodePanel, ExpandableCodeBlock } from "./transcript-code-block";
-import { getProviderSessionDetailMessages } from "../messages/provider-session-detail";
 
 type SessionDetail = ProviderSessionDetailResponse;
 type TranscriptEntry = SessionDetail["transcript"][number];
 
 const TRANSCRIPT_ENTRY_CLASS_NAMES: Record<TranscriptEntry["type"], string> = {
-  assistant_message: "border-af-border bg-af-surface-subtle",
-  reasoning: "border-af-info-border bg-af-info-surface",
-  system_event: "border-af-border bg-af-surface-raised",
-  tool_call: "border-af-warning-border bg-af-warning-surface",
-  tool_output: "border-af-success-border bg-af-success-surface",
-  user_message: "border-af-accent-border bg-af-accent-surface",
-};
-const TRANSCRIPT_BADGE_CLASS_NAMES: Record<TranscriptEntry["type"], string> = {
-  assistant_message: "border-af-border bg-af-surface-raised text-af-text-muted",
-  reasoning: "border-af-info-border bg-af-info-surface text-af-info-text",
-  system_event: "border-af-border bg-af-surface-raised text-af-text-subtle",
-  tool_call: "border-af-warning-border bg-af-warning-surface text-af-warning-text",
-  tool_output: "border-af-success-border bg-af-success-surface text-af-success-text",
-  user_message: "border-af-accent-border bg-af-accent-surface text-af-text",
+  assistant_message: "border-af-border",
+  reasoning: "border-af-border",
+  system_event: "border-af-border",
+  tool_call: "border-af-border",
+  tool_output: "border-af-border",
+  user_message: "border-af-border",
 };
 
 export function TranscriptSection({
@@ -47,16 +38,17 @@ export function TranscriptSection({
   const messages = getProviderSessionDetailMessages(locale);
 
   return (
-    <section
-      className={cn(
-        "grid gap-3 rounded-xl border border-af-accent-border bg-af-accent-surface p-4",
-        className,
-      )}
-    >
-      <h5 className={DASHBOARD_SECTION_HEADING_CLASS}>{messages.transcriptHeading}</h5>
+    <section className={cn("grid gap-3 rounded-xl border p-4", className)}>
+      <h5 className={DASHBOARD_SECTION_HEADING_CLASS}>
+        {messages.transcriptHeading}
+      </h5>
       <div className="grid gap-3">
         {detail.transcript.map((entry) => (
-          <TranscriptEntryCard entry={entry} key={entry.order} locale={locale} />
+          <TranscriptEntryCard
+            entry={entry}
+            key={entry.order}
+            locale={locale}
+          />
         ))}
       </div>
     </section>
@@ -123,15 +115,6 @@ function TranscriptEntryCard({
       )}
     >
       <div className="grid gap-2">
-        <span
-          className={cn(
-            "inline-flex w-fit rounded-full border px-2 py-0.5",
-            DASHBOARD_SUPPORTING_TEXT_CLASS,
-            getTranscriptBadgeClassName(entry.type),
-          )}
-        >
-          {entryLabel}
-        </span>
         <div className="grid gap-1">
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
             <strong>{getTranscriptEntryTitle(entry, entryLabel)}</strong>
@@ -163,13 +146,6 @@ function TranscriptEntryCard({
                   </span>
                 ) : null}
               </div>
-              {timestampState.rawTimestamp ? (
-                <TimestampDetails
-                  locale={locale}
-                  timestamp={timestampState.rawTimestamp}
-                  title={timestampState.label}
-                />
-              ) : null}
             </div>
           ) : null}
         </div>
@@ -179,7 +155,10 @@ function TranscriptEntryCard({
   );
 }
 
-function getTranscriptTimestampState(timestamp: string | undefined, locale?: string) {
+function getTranscriptTimestampState(
+  timestamp: string | undefined,
+  locale?: string,
+) {
   const messages = getProviderSessionDetailMessages(locale);
   const normalizedTimestamp = normalizeValidTimestamp(timestamp);
   if (!timestamp?.trim()) {
@@ -210,41 +189,9 @@ function normalizeValidTimestamp(timestamp: string | undefined): string | null {
     return null;
   }
 
-  return Number.isNaN(Date.parse(normalizedTimestamp)) ? null : normalizedTimestamp;
-}
-
-function TimestampDetails({
-  locale,
-  timestamp,
-  title,
-}: {
-  locale?: string;
-  timestamp: string;
-  title: string | null;
-}) {
-  const messages = getProviderSessionDetailMessages(locale);
-
-  return (
-    <details className="grid gap-1">
-      <summary
-        className={cn(
-          "w-fit cursor-pointer text-af-text-subtle underline decoration-dotted underline-offset-2",
-          DASHBOARD_SUPPORTING_TEXT_CLASS,
-        )}
-      >
-        <span title={timestamp}>{messages.rawTimestampDetailsLabel}</span>
-      </summary>
-      <code
-        className={cn(
-          "w-fit rounded-md border border-af-border bg-af-surface-subtle px-2 py-1",
-          DASHBOARD_BODY_CODE_CLASS,
-        )}
-        title={title ?? timestamp}
-      >
-        {timestamp}
-      </code>
-    </details>
-  );
+  return Number.isNaN(Date.parse(normalizedTimestamp))
+    ? null
+    : normalizedTimestamp;
 }
 
 function TranscriptEntryBody({
@@ -255,6 +202,8 @@ function TranscriptEntryBody({
   locale?: string;
 }) {
   const messages = getProviderSessionDetailMessages(locale);
+  const encryptedContent =
+    entry.type === "reasoning" ? entry.encryptedContent?.trim() : undefined;
 
   switch (entry.type) {
     case "user_message":
@@ -267,11 +216,25 @@ function TranscriptEntryBody({
             <EncryptedReasoningNotice locale={locale} />
           ) : null}
           {entry.summary ? (
-            <p className={cn("m-0", DASHBOARD_BODY_TEXT_CLASS)}>{entry.summary}</p>
+            <p className={cn("m-0", DASHBOARD_BODY_TEXT_CLASS)}>
+              {entry.summary}
+            </p>
           ) : null}
           {entry.text ? <CodePanel value={entry.text} /> : null}
-          {entry.encrypted && !entry.text ? (
-            <p className={cn("m-0 text-af-text-subtle", DASHBOARD_SUPPORTING_TEXT_CLASS)}>
+          {encryptedContent ? (
+            <ExpandableCodeBlock
+              label={messages.encryptedReasoningStateLabel}
+              locale={locale}
+              value={encryptedContent}
+            />
+          ) : null}
+          {entry.encrypted && !entry.text && !encryptedContent ? (
+            <p
+              className={cn(
+                "m-0 text-af-text-subtle",
+                DASHBOARD_SUPPORTING_TEXT_CLASS,
+              )}
+            >
               {messages.encryptedReasoningOnly}
             </p>
           ) : null}
@@ -280,7 +243,9 @@ function TranscriptEntryBody({
     case "tool_call":
       return (
         <div className="grid gap-3">
-          {entry.text ? <p className={cn("m-0", DASHBOARD_BODY_TEXT_CLASS)}>{entry.text}</p> : null}
+          {entry.text ? (
+            <p className={cn("m-0", DASHBOARD_BODY_TEXT_CLASS)}>{entry.text}</p>
+          ) : null}
           {entry.arguments ? (
             <ExpandableCodeBlock
               label={messages.argumentsLabel}
@@ -304,7 +269,9 @@ function TranscriptEntryBody({
 
       return (
         <div className="grid gap-3">
-          {entry.text ? <p className={cn("m-0", DASHBOARD_BODY_TEXT_CLASS)}>{entry.text}</p> : null}
+          {entry.text ? (
+            <p className={cn("m-0", DASHBOARD_BODY_TEXT_CLASS)}>{entry.text}</p>
+          ) : null}
           {entry.output ? (
             <ExpandableCodeBlock
               label={messages.outputLabel}
@@ -318,7 +285,9 @@ function TranscriptEntryBody({
       return (
         <div className="grid gap-2">
           {entry.summary ? (
-            <p className={cn("m-0", DASHBOARD_BODY_TEXT_CLASS)}>{entry.summary}</p>
+            <p className={cn("m-0", DASHBOARD_BODY_TEXT_CLASS)}>
+              {entry.summary}
+            </p>
           ) : null}
           {entry.text ? <CodePanel value={entry.text} /> : null}
         </div>
@@ -361,8 +330,4 @@ function getTranscriptEntryTitle(entry: TranscriptEntry, defaultLabel: string) {
 
 function getTranscriptEntryClassName(entryType: TranscriptEntry["type"]) {
   return TRANSCRIPT_ENTRY_CLASS_NAMES[entryType];
-}
-
-function getTranscriptBadgeClassName(entryType: TranscriptEntry["type"]) {
-  return TRANSCRIPT_BADGE_CLASS_NAMES[entryType];
 }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -53,6 +53,13 @@
   --color-af-success-surface: rgb(from var(--color-af-foundation-success) r g b / 0.12);
   --color-af-success-border: rgb(from var(--color-af-foundation-success) r g b / 0.28);
   --color-af-success-text: var(--color-af-foundation-success-ink);
+  --color-af-session-live-ping: radial-gradient(
+    circle,
+    rgb(from var(--color-af-foundation-success) r g b / 0.48) 0%,
+    rgb(from var(--color-af-foundation-success) r g b / 0.22) 36%,
+    rgb(from var(--color-af-foundation-success) r g b / 0.08) 56%,
+    transparent 76%
+  );
   --color-af-on-success: var(--color-af-text-inverse);
   --color-af-warning: var(--color-af-foundation-warning);
   --color-af-warning-surface: rgb(from var(--color-af-foundation-warning) r g b / 0.14);


### PR DESCRIPTION
## Summary
- shrink long session-tab folder paths while preserving the full path in the hover title
- streamline provider-session transcript display and remove duplicate function/reasoning summary sections
- preserve encrypted reasoning payloads in the API contract and render them as formatted transcript code blocks

## Verification
- bunx biome check src/features/header/components/dashboard-brand-lockup.tsx src/features/header/components/dashboard-header.tsx src/features/header/components/dashboard-session-tabs.tsx src/features/header/components/dashboard-session-tabs.test.tsx src/features/header/lib/dashboard-session-tabs-utils.ts src/features/header/lib/dashboard-session-tabs-utils.test.ts src/features/provider-session-detail/components/exec-command-output.tsx src/features/provider-session-detail/components/provider-session-detail-panel.tsx src/features/provider-session-detail/components/provider-session-detail-panel.test.tsx src/features/provider-session-detail/components/provider-session-transcript.tsx src/features/provider-session-detail/components/provider-session-transcript.test.tsx
- bunx vitest run src/features/header/lib/dashboard-session-tabs-utils.test.ts src/features/header/components/dashboard-session-tabs.test.tsx src/features/provider-session-detail/components/provider-session-detail-panel.test.tsx src/features/provider-session-detail/components/provider-session-transcript.test.tsx
- bunx tsc -b --noEmit --pretty false
- go test ./pkg/api -run 'TestParseCodexSessionSummary_ExtractsDiagnosticDetails|TestParseCodexSessionDetails_EmitsMixedTranscriptChronologically'
- make api-smoke