### PR TITLE
remove-work-totals-card-public-re-export

### DIFF
--- a/ui/src/features/bento/components/agent-bento.stories.tsx
+++ b/ui/src/features/bento/components/agent-bento.stories.tsx
@@ -1,7 +1,7 @@
 import { expect, userEvent, within } from "storybook/test";
 
 import { NoSelectionDetailCard } from "../../current-selection/components/no-selection-detail-card";
-import { WorkTotalsCard } from "../../work-totals/public";
+import { WorkTotalsCard } from "../../work-totals/components/work-totals-card";
 import "../../../styles.css";
 import {
   AgentBentoCard,

--- a/ui/src/features/bento/components/agent-bento.test.tsx
+++ b/ui/src/features/bento/components/agent-bento.test.tsx
@@ -9,7 +9,7 @@ import {
 import { DASHBOARD_PANEL_SHELL_CLASS } from "../../../components/ui/dashboard-shell";
 import { NoSelectionDetailCard } from "../../current-selection/components/no-selection-detail-card";
 import { InlineAddWidgetCard } from "../../dashboard-add-card/components/inline-add-widget-card";
-import { WorkTotalsCard } from "../../work-totals/public";
+import { WorkTotalsCard } from "../../work-totals/components/work-totals-card";
 import {
   AgentBentoCard,
   AgentBentoLayout,

--- a/ui/src/features/work-totals/public/index.ts
+++ b/ui/src/features/work-totals/public/index.ts
@@ -1,2 +1,1 @@
-export * from "../components/work-totals-card";
 export * from "../components/work-totals-widget";


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/remove-work-totals-card-public-re-export",
  "description": "Remove the fixture-only WorkTotalsCard re-export from the work-totals public barrel while preserving the runtime WorkTotalsWidget public boundary and retargeting bento fixture imports to the direct component path.",
  "context": {
    "customerAsk": "Remove the fixture-only WorkTotalsCard re-export from ui/src/features/work-totals/public/index.ts, keep the WorkTotalsWidget export intact, retarget the two bento fixture imports of WorkTotalsCard to ../../work-totals/components/work-totals-card, leave WorkTotalsWidget unchanged, preserve dashboard runtime imports that intentionally consume WorkTotalsWidget through the public boundary, confirm there are no remaining WorkTotalsCard imports through ../../work-totals/public, and run the smallest targeted frontend verification needed for the touched bento fixture and public-barrel surfaces.",
    "problem": "ui/src/features/work-totals/public/index.ts exposes WorkTotalsCard even though runtime public-barrel consumers only need WorkTotalsWidget and the only current public-barrel WorkTotalsCard consumers are bento fixture surfaces. The redundant export widens the apparent supported public surface, makes import ownership less clear, and works against the customer goal of removing unnecessary website re-exports.",
    "solution": "Delete only the WorkTotalsCard re-export from the work-totals public barrel, keep the WorkTotalsWidget export intact, update the two bento fixture surfaces to import WorkTotalsCard directly from ../../work-totals/components/work-totals-card, and verify through focused import checks plus the smallest relevant frontend test, typecheck, or lint lane."
  },
  "acceptanceCriteria": [
    "ui/src/features/work-totals/public/index.ts no longer re-exports WorkTotalsCard.",
    "The work-totals public barrel continues to export WorkTotalsWidget without requiring runtime dashboard import changes.",
    "Bento fixture surfaces that use WorkTotalsCard import it directly from ../../work-totals/components/work-totals-card.",
    "WorkTotalsWidget remains unchanged and continues to use its existing direct WorkTotalsCard component import.",
    "Repo-local verification confirms there are no remaining WorkTotalsCard imports through ../../work-totals/public.",
    "The implementation stays limited to the public-barrel trim and the two fixture import retargets, with no broader work-totals or dashboard reorganization.",
    "Quality gate: typecheck, lint, and relevant targeted frontend tests pass."
  ],
  "userStories": [
    {
      "id": "remove-work-totals-card-public-re-export-001",
      "title": "Retarget fixture card imports and trim the public barrel",
      "description": "As a frontend maintainer, I want fixture-only WorkTotalsCard usage to import the card directly while the work-totals public barrel exposes only the runtime widget so that the feature boundary reflects the supported runtime surface.",
      "acceptanceCriteria": [
        "ui/src/features/work-totals/public/index.ts removes the WorkTotalsCard re-export and keeps the WorkTotalsWidget export intact.",
        "ui/src/features/bento/components/agent-bento.test.tsx imports WorkTotalsCard from ../../work-totals/components/work-totals-card.",
        "ui/src/features/bento/components/agent-bento.stories.tsx imports WorkTotalsCard from ../../work-totals/components/work-totals-card.",
        "Dashboard runtime consumers continue to import WorkTotalsWidget through the work-totals public barrel without import-path changes.",
        "WorkTotalsWidget is not modified by this cleanup.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "remove-work-totals-card-public-re-export-002",
      "title": "Verify the work-totals public surface remains behavior-preserving",
      "description": "As a reviewer, I want focused verification that WorkTotalsCard is no longer consumed through the public barrel and that the touched bento fixture surfaces still compile so that the cleanup is complete without runtime behavior drift.",
      "acceptanceCriteria": [
        "Repo-local verification confirms there are no remaining WorkTotalsCard imports from ../../work-totals/public.",
        "Focused frontend verification covers the touched bento fixture or public-barrel seam, such as the relevant Vitest file or an existing cheap frontend typecheck or lint path.",
        "Verification does not require broad website public-barrel inventory checks or unrelated source topology assertions.",
        "The implementation does not introduce a replacement wrapper, alias, or alternate public export path for WorkTotalsCard.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
