### PR TITLE
remove-dashboard-feature-reexports-from-components-barrel

### DIFF
--- a/docs/internal/development/frontend-deadcode-baseline.json
+++ b/docs/internal/development/frontend-deadcode-baseline.json
@@ -1,5 +1,10 @@
 [
   {
+    "file": "src/components/dashboard/index.ts",
+    "kind": "file",
+    "name": "src/components/dashboard/index.ts"
+  },
+  {
     "file": "src/features/factory-graph-editor/lib/factory-graph-operations.ts",
     "kind": "export",
     "name": "validateFactoryGraphState"

--- a/ui/src/components/dashboard/index.ts
+++ b/ui/src/components/dashboard/index.ts
@@ -1,3 +1,2 @@
-export * from "../../features/workflow-activity/public";
 export * from "../../features/header/public";
 export * from "./widget-board";

--- a/ui/src/components/dashboard/index.ts
+++ b/ui/src/components/dashboard/index.ts
@@ -1,2 +1,1 @@
-export * from "../../features/header/public";
 export * from "./widget-board";

--- a/ui/src/features/current-selection/components/workstation-save-controls.test.tsx
+++ b/ui/src/features/current-selection/components/workstation-save-controls.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+
+import { EditableWorkstationSaveDialog } from "./workstation-save-controls";
+
+describe("EditableWorkstationSaveDialog", () => {
+  it("opens the overwrite confirmation and wires cancel and confirm actions", () => {
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn();
+
+    render(
+      <EditableWorkstationSaveDialog
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+        overwriteFieldNames={[]}
+        saveState={{ status: "confirming" }}
+      />,
+    );
+
+    const dialog = screen.getByRole("dialog", {
+      name: "Overwrite the running factory definition?",
+    });
+    expect(
+      within(dialog).getByText(
+        "Saving will overwrite the running factory definition with the kind, worker, and prompt values in this workstation draft.",
+      ),
+    ).toBeTruthy();
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    fireEvent.click(
+      within(dialog).getByRole("button", { name: "Overwrite factory" }),
+    );
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the save dialog locked while submitting", () => {
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn();
+
+    render(
+      <EditableWorkstationSaveDialog
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+        overwriteFieldNames={["prompt", "worker"]}
+        saveState={{ status: "submitting" }}
+      />,
+    );
+
+    const dialog = screen.getByRole("dialog", {
+      name: "Overwrite the running factory definition?",
+    });
+    expect(
+      within(dialog).getByText(
+        "Saving will overwrite newer server values for prompt, worker with the draft currently shown in the editor.",
+      ),
+    ).toBeTruthy();
+
+    const cancelButton = within(dialog).getByRole("button", { name: "Cancel" });
+    const submitButton = within(dialog).getByRole("button", {
+      name: "Saving...",
+    });
+    expect(cancelButton.getAttribute("disabled")).not.toBeNull();
+    expect(submitButton.getAttribute("disabled")).not.toBeNull();
+    expect(submitButton.getAttribute("aria-busy")).toBe("true");
+
+    fireEvent.keyDown(dialog, { key: "Escape" });
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/features/current-selection/components/workstation-save-controls.tsx
+++ b/ui/src/features/current-selection/components/workstation-save-controls.tsx
@@ -1,5 +1,5 @@
-import { DashboardMutationDialog } from "../../../components/dashboard";
 import { Button, DashboardActionButton } from "../../../components/ui";
+import { DashboardMutationDialog } from "../../workflow-activity/public";
 import { formatEditableOverwriteFieldLabels } from "../editing/editable-workstation-overwrite-fields";
 import { getWorkstationDetailMessages } from "../messages/workstation-detail";
 import type {

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-controls.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-controls.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 
-import { DashboardMutationDialog } from "../../../components/dashboard";
 import {
   Button,
   DashboardActionRow,
@@ -11,6 +10,7 @@ import {
   PopoverTrigger,
 } from "../../../components/ui";
 import { cn } from "../../../lib/cn";
+import { DashboardMutationDialog } from "../../workflow-activity/public";
 import { getFactoryGraphEditorMessages } from "../messages/editor";
 export {
   FactoryGraphEditorModeToggle,

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-leave-dialog.test.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-leave-dialog.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+
+import { FactoryGraphEditorLeaveDialog } from "./factory-graph-editor-leave-dialog";
+
+describe("FactoryGraphEditorLeaveDialog", () => {
+  it("opens with keep-editing, discard, and save actions", () => {
+    const onCancel = vi.fn();
+    const onDiscard = vi.fn();
+    const onSave = vi.fn();
+
+    render(
+      <FactoryGraphEditorLeaveDialog
+        canSave={true}
+        isOpen={true}
+        isSaving={false}
+        onCancel={onCancel}
+        onDiscard={onDiscard}
+        onSave={onSave}
+      />,
+    );
+
+    const dialog = screen.getByRole("dialog", {
+      name: "Leave graph editor with unsaved changes?",
+    });
+    expect(
+      within(dialog).getByText(
+        "This graph editor session still has local topology changes.",
+      ),
+    ).toBeTruthy();
+    expect(
+      within(dialog).getByText(
+        "Save to keep the pending factory topology, discard to revert to the latest server-backed graph, or keep editing.",
+      ),
+    ).toBeTruthy();
+
+    fireEvent.click(
+      within(dialog).getByRole("button", { name: "Keep editing" }),
+    );
+    fireEvent.click(
+      within(dialog).getByRole("button", { name: "Discard changes" }),
+    );
+    fireEvent.click(
+      within(dialog).getByRole("button", { name: "Save changes" }),
+    );
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("locks dismissal and mutation actions while saving", () => {
+    const onCancel = vi.fn();
+    const onDiscard = vi.fn();
+    const onSave = vi.fn();
+
+    render(
+      <FactoryGraphEditorLeaveDialog
+        canSave={true}
+        isOpen={true}
+        isSaving={true}
+        onCancel={onCancel}
+        onDiscard={onDiscard}
+        onSave={onSave}
+      />,
+    );
+
+    const dialog = screen.getByRole("dialog", {
+      name: "Leave graph editor with unsaved changes?",
+    });
+    expect(
+      within(dialog)
+        .getByRole("button", { name: "Keep editing" })
+        .getAttribute("disabled"),
+    ).not.toBeNull();
+    expect(
+      within(dialog)
+        .getByRole("button", { name: "Discard changes" })
+        .getAttribute("disabled"),
+    ).not.toBeNull();
+    expect(
+      within(dialog)
+        .getByRole("button", { name: "Saving..." })
+        .getAttribute("disabled"),
+    ).not.toBeNull();
+
+    fireEvent.keyDown(dialog, { key: "Escape" });
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(onDiscard).not.toHaveBeenCalled();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-leave-dialog.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-leave-dialog.tsx
@@ -1,5 +1,5 @@
-import { DashboardMutationDialog } from "../../../components/dashboard";
 import { Button } from "../../../components/ui";
+import { DashboardMutationDialog } from "../../workflow-activity/public";
 import { getFactoryGraphEditorMessages } from "../messages/editor";
 
 export function FactoryGraphEditorLeaveDialog({


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/remove-dashboard-feature-reexports-from-components-barrel",
  "description": "Remove workflow activity and header feature re-exports from the shared dashboard components barrel, retarget affected dashboard mutation dialog imports to the owning workflow activity module, and preserve workstation save and factory graph editor dialog behavior.",
  "context": {
    "customerAsk": "Remove export * from \"../../features/workflow-activity/public\" and export * from \"../../features/header/public\" from ui/src/components/dashboard/index.ts. Retarget current DashboardMutationDialog imports that resolve through components/dashboard in workstation save controls and factory graph editor controls/dialogs to the owning workflow activity path. If any header-owned symbol stops resolving from components/dashboard, import it from the header feature owner or direct owning component path. Keep intentional shared dashboard exports such as widget-board and preserve public behavior.",
    "problem": "The shared dashboard components barrel exposes feature-owned workflow activity and header symbols as if they were shared dashboard components. This blurs ownership, encourages dependency paths through the wrong module boundary, and conflicts with the cleanup direction toward direct imports and feature-owned public boundaries.",
    "solution": "Delete the workflow activity and header public re-exports from ui/src/components/dashboard/index.ts, retarget affected DashboardMutationDialog imports to the workflow activity owner or direct mutation dialog component path, retarget header-owned imports only if active consumers exist, and verify the touched workstation save and factory graph editor dialogs behave unchanged."
  },
  "acceptanceCriteria": [
    "ui/src/components/dashboard/index.ts no longer re-exports ../../features/workflow-activity/public.",
    "ui/src/components/dashboard/index.ts no longer re-exports ../../features/header/public.",
    "No DashboardMutationDialog import resolves through ui/src/components/dashboard.",
    "Any affected header-owned import resolves through the header feature owner or direct owning header component path; if no such consumer exists, no extra header code is changed.",
    "Intentional shared dashboard exports, including export * from \"./widget-board\";, keep their existing paths and behavior.",
    "Workstation save dialogs and factory graph editor mutation/leave dialogs render and behave the same after the import cleanup.",
    "Quality gate: bun run typecheck, lint, and focused tests for the touched workstation save controls and factory graph editor dialog surfaces pass."
  ],
  "userStories": [
    {
      "id": "remove-dashboard-feature-reexports-from-components-barrel-001",
      "title": "Route dashboard mutation dialogs through the workflow activity owner",
      "description": "As a frontend maintainer, I want dashboard mutation dialogs to be imported from the workflow activity owner so that shared dashboard component imports do not mask feature ownership.",
      "acceptanceCriteria": [
        "ui/src/components/dashboard/index.ts removes the workflow activity public re-export and keeps intentional shared dashboard exports such as export * from \"./widget-board\";.",
        "ui/src/features/current-selection/components/workstation-save-controls.tsx imports DashboardMutationDialog from the workflow activity owner or direct mutation dialog component path.",
        "ui/src/features/factory-graph-editor/components/factory-graph-editor-controls.tsx imports DashboardMutationDialog from the workflow activity owner or direct mutation dialog component path.",
        "ui/src/features/factory-graph-editor/components/factory-graph-editor-leave-dialog.tsx imports DashboardMutationDialog from the workflow activity owner or direct mutation dialog component path.",
        "The affected workstation save and factory graph editor dialog components keep the same dialog props, accessible labels, keyboard behavior, loading state, success behavior, and error behavior.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "remove-dashboard-feature-reexports-from-components-barrel-002",
      "title": "Remove the header re-export without changing header behavior",
      "description": "As a frontend maintainer, I want header-owned exports to stop flowing through the shared dashboard components barrel so that header behavior remains owned by the header feature.",
      "acceptanceCriteria": [
        "ui/src/components/dashboard/index.ts removes the header public re-export.",
        "If any header-owned symbol previously resolved through components/dashboard, its import is retargeted to ../../header/public or the direct owning header component path that matches nearby feature patterns.",
        "If no header-owned consumer uses the dashboard barrel, no unrelated header imports, components, styles, or tests are changed.",
        "Existing dashboard header rendering, navigation, responsive behavior, and keyboard behavior remain unchanged because this cleanup does not alter header component logic or markup.",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "remove-dashboard-feature-reexports-from-components-barrel-003",
      "title": "Prove dialog behavior remains unchanged after the import cleanup",
      "description": "As a reviewer, I want focused verification for the touched workstation save and factory graph editor dialogs so that the cleanup is proven behavior-preserving.",
      "acceptanceCriteria": [
        "Focused tests cover the current-selection workstation save controls touched by the DashboardMutationDialog import retargeting.",
        "Focused tests cover the factory graph editor mutation or leave dialog surfaces touched by the DashboardMutationDialog import retargeting.",
        "The verified dialog behavior includes the same render path and user-facing outcomes for opening, confirming, cancelling, loading, success, and error states covered by existing tests.",
        "Verification stays limited to the affected dialog surfaces and does not introduce broad route, command, source-topology, or fixture inventory tests.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}
