### PR TITLE
inline-dashboard-brand-lockup-class

### DIFF
--- a/ui/scripts/inline-component-class-usage-allowlist.mjs
+++ b/ui/scripts/inline-component-class-usage-allowlist.mjs
@@ -20,7 +20,6 @@ export const allowlistedInlineComponentClassUsage = [
   "src/features/factory-graph-editor/components/factory-graph-editor-controls.tsx#MENU_ACTION_DESCRIPTION_CLASS",
   "src/features/factory-graph-editor/components/factory-graph-editor-controls.tsx#VISIBILITY_PANEL_CLASS",
   "src/features/factory-graph-editor/components/factory-graph-editor-tooltip-button.tsx#INLINE_TOOLTIP_CLASS",
-  "src/features/header/components/dashboard-brand-lockup.tsx#BRAND_MARK_CLASS",
   "src/features/header/components/dashboard-header.tsx#DASHBOARD_TOOLBAR_CLASS",
   "src/features/header/components/dashboard-header.tsx#DASHBOARD_HEADER_ROWS_CLASS",
   "src/features/header/components/dashboard-header.tsx#DASHBOARD_PRIMARY_ROW_CLASS",

--- a/ui/src/features/header/components/dashboard-brand-lockup.tsx
+++ b/ui/src/features/header/components/dashboard-brand-lockup.tsx
@@ -6,9 +6,6 @@ interface DashboardBrandLockupProps {
   wordmarkClassName?: string;
 }
 
-const BRAND_MARK_CLASS =
-  "inline-flex h-12 items-center justify-center gap-1 rounded-sm mt-1 border border-af-accent-border bg-af-accent-surface px-3 text-sm font-black uppercase leading-none tracking-[0.18em] text-af-accent";
-
 export function DashboardBrandLockup({
   className = "",
   locale: _locale,
@@ -21,7 +18,7 @@ export function DashboardBrandLockup({
         className,
       )}
     >
-      <span className={BRAND_MARK_CLASS}>
+      <span className="inline-flex h-12 items-center justify-center gap-1 rounded-sm mt-1 border border-af-accent-border bg-af-accent-surface px-3 text-sm font-black uppercase leading-none tracking-[0.18em] text-af-accent">
         <span className="text-[1rem] leading-none">U</span>
       </span>
     </span>


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/inline-dashboard-brand-lockup-class",
  "description": "Inline the single-use dashboard brand mark Tailwind class string directly in JSX, remove the obsolete BRAND_MARK_CLASS constant, and shrink the inline component class usage allowlist while preserving the dashboard header brand lockup's current visual and behavioral treatment.",
  "context": {
    "customerAsk": "Inline BRAND_MARK_CLASS directly into the JSX in ui/src/features/header/components/dashboard-brand-lockup.tsx, delete the constant, and remove only src/features/header/components/dashboard-brand-lockup.tsx#BRAND_MARK_CLASS from ui/scripts/inline-component-class-usage-allowlist.mjs.",
    "problem": "The inline component class usage guard now treats local, unexported, single-use static class constants as legacy readability debt. BRAND_MARK_CLASS is still allowlisted even though it is used only as the direct className for the dashboard brand mark span, which weakens the guard's signal without providing a shared styling abstraction or behavior.",
    "solution": "Move the existing brand mark Tailwind class list directly onto the brand mark span, delete the now-unused BRAND_MARK_CLASS constant, remove only the matching allowlist entry, and run focused frontend verification to prove the brand lockup remains visually and behaviorally unchanged."
  },
  "acceptanceCriteria": [
    "BRAND_MARK_CLASS no longer exists in ui/src/features/header/components/dashboard-brand-lockup.tsx.",
    "The brand mark span in DashboardBrandLockup uses the same Tailwind class list inline in JSX and preserves the current rendered visual treatment.",
    "ui/scripts/inline-component-class-usage-allowlist.mjs no longer includes src/features/header/components/dashboard-brand-lockup.tsx#BRAND_MARK_CLASS.",
    "The implementation does not alter the component props contract, visible copy, localization plumbing, dashboard header layout, session tabs, import/export flows, design tokens, or unrelated allowlist entries.",
    "Focused frontend verification includes bun run check:inline-component-class-usage and an existing relevant header or app component test when one is available.",
    "Quality gate: frontend typecheck, lint, and relevant automated tests pass."
  ],
  "userStories": [
    {
      "id": "inline-dashboard-brand-lockup-class-001",
      "title": "Inline the dashboard brand mark class and retire its allowlist entry",
      "description": "As a frontend maintainer, I want the dashboard brand mark to use its static Tailwind class list directly in JSX so that the inline-class guard can enforce the current readability standard without changing the header experience.",
      "acceptanceCriteria": [
        "BRAND_MARK_CLASS is removed from ui/src/features/header/components/dashboard-brand-lockup.tsx.",
        "The brand mark span renders with the same class list it used before, now written directly in the className attribute.",
        "The dashboard brand lockup keeps the same accessible structure, visible copy, locale-derived text, layout placement, and visual treatment.",
        "ui/scripts/inline-component-class-usage-allowlist.mjs removes only src/features/header/components/dashboard-brand-lockup.tsx#BRAND_MARK_CLASS from the allowlist.",
        "Direct browser verification confirms the dashboard brand mark remains visually unchanged in the header.",
        "bun run check:inline-component-class-usage passes.",
        "An existing relevant header or app component test passes when one exists, such as the dashboard header or dashboard status panel component test.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    }
  ]
}
