### PR TITLE
remove-import-hook-reexports-from-public

### DIFF
--- a/ui/src/features/import/components/dashboard-import-preview-dialog.test.tsx
+++ b/ui/src/features/import/components/dashboard-import-preview-dialog.test.tsx
@@ -5,8 +5,9 @@ import { axe } from "jest-axe";
 import { NamedFactoryAPIError } from "../../../api/named-factory";
 import {
   DashboardImportPreviewDialog,
+  FactoryImportPreviewDialog,
   type DashboardImportPreviewDialogProps,
-} from "./dashboard-import-preview-dialog";
+} from "../public";
 import { getImportPreviewDialogMessages } from "../messages/import-preview-dialog";
 
 function createReadyImportPreviewState(): DashboardImportPreviewDialogProps["importPreviewState"] {
@@ -47,6 +48,27 @@ function renderDialog(
 }
 
 describe("DashboardImportPreviewDialog", () => {
+  it("renders the factory preview dialog through the import public boundary", async () => {
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn();
+    const messages = getImportPreviewDialogMessages("en");
+
+    render(
+      <FactoryImportPreviewDialog
+        activationState={{ status: "idle" }}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+        previewState={createReadyImportPreviewState()}
+      />,
+    );
+
+    const previewDialog = await screen.findByRole("dialog", { name: messages.title });
+
+    fireEvent.click(within(previewDialog).getByRole("button", { name: messages.cancelAction }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
   it("renders the extracted dashboard-owned import preview", async () => {
     const { onCancel } = renderDialog();
     const messages = getImportPreviewDialogMessages("en");

--- a/ui/src/features/import/public/index.ts
+++ b/ui/src/features/import/public/index.ts
@@ -1,4 +1,1 @@
 export * from "../components/dashboard-import-preview-dialog";
-export * from "../hooks/use-factory-import-activation";
-export * from "../hooks/use-factory-import-preview";
-export * from "../hooks/use-factory-png-drop";

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-import.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-import.tsx
@@ -1,7 +1,7 @@
 import { Button } from "../../../components/ui";
 import type {
   FactoryPngDropState,
-} from "../../import/public";
+} from "../../import/hooks/use-factory-png-drop";
 import type { ReadFactoryImportPngError } from "../../import/lib/factory-png-import";
 import { getWorkflowActivityGraphImportMessages } from "../messages/graph-import";
 import { DashboardMessagePanel } from "./mutation-dialog";

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card.stories.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card.stories.tsx
@@ -19,8 +19,8 @@ import {
   EXHAUSTION_WORKSTATION_ICON_METADATA,
   SUPPORTED_WORKSTATION_ICON_METADATA,
 } from "../../flowchart/public";
+import type { ReadFactoryImportFile } from "../../import/hooks/use-factory-png-drop";
 import type { FactoryPngImportValue } from "../../import/lib/factory-png-import";
-import type { ReadFactoryImportFile } from "../../import/public";
 import type { CurrentActivitySelection } from "./react-flow-current-activity-card";
 import { ReactFlowCurrentActivityCard } from "./react-flow-current-activity-card";
 

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card.test.tsx
@@ -49,9 +49,9 @@ import {
   EXHAUSTION_WORKSTATION_ICON_METADATA,
   SUPPORTED_WORKSTATION_ICON_METADATA,
 } from "../../flowchart/public";
+import type { ReadFactoryImportFile } from "../../import/hooks/use-factory-png-drop";
 import type { FactoryPngImportValue } from "../../import/lib/factory-png-import";
 import { getImportPreviewDialogMessages } from "../../import/messages/import-preview-dialog";
-import type { ReadFactoryImportFile } from "../../import/public";
 import { buildCurrentActivityGraphLayoutFromFactory } from "../lib/current-activity-factory-graph-layout";
 import type { CurrentActivityImportController } from "../hooks/current-activity-import-controller";
 import { getDashboardFlowAxisLegendMessages } from "../messages/dashboard-flow-axis-legend";

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card.tsx
@@ -17,8 +17,8 @@ import { DASHBOARD_SECTION_HEADING_CLASS } from "../../../components/ui/dashboar
 import { cn } from "../../../lib/cn";
 import type { GraphLayout } from "../../flowchart/lib/layout";
 import type { CurrentActivityNode } from "../../flowchart/public";
+import type { ReadFactoryImportFile } from "../../import/hooks/use-factory-png-drop";
 import type { FactoryPngImportValue } from "../../import/lib/factory-png-import";
-import type { ReadFactoryImportFile } from "../../import/public";
 import {
   type CurrentActivityImportController,
   useCurrentActivityImportController,

--- a/ui/src/features/workflow-activity/hooks/current-activity-import-controller.ts
+++ b/ui/src/features/workflow-activity/hooks/current-activity-import-controller.ts
@@ -1,16 +1,20 @@
 import { useCallback } from "react";
 
 import type { FactoryValue } from "../../../api/named-factory";
+import type { FactoryPngImportValue } from "../../import/lib/factory-png-import";
 import {
   type FactoryImportActivationState,
+  useFactoryImportActivation,
+} from "../../import/hooks/use-factory-import-activation";
+import {
   type FactoryImportPreviewState,
+  useFactoryImportPreview,
+} from "../../import/hooks/use-factory-import-preview";
+import {
   type FactoryPngDropState,
   type ReadFactoryImportFile,
-  useFactoryImportActivation,
-  useFactoryImportPreview,
   useFactoryPngDrop,
-} from "../../import/public";
-import type { FactoryPngImportValue } from "../../import/lib/factory-png-import";
+} from "../../import/hooks/use-factory-png-drop";
 
 export interface CurrentActivityImportController {
   activateImport: (value: FactoryPngImportValue) => Promise<void>;


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/remove-import-hook-reexports-from-public",
  "description": "Remove the import hook re-exports from the import public barrel, retarget workflow-activity to the owning import hook modules, and preserve the intentional import preview dialog feature-public boundary without changing website behavior.",
  "context": {
    "customerAsk": "Retarget workflow-activity imports of `useFactoryImportActivation`, `useFactoryImportPreview`, `useFactoryPngDrop`, and `ReadFactoryImportFile` away from `../../import/public` and directly to their owning `ui/src/features/import/hooks/*` modules, keep the import preview dialog component exported through `ui/src/features/import/public/index.ts`, remove only the hook re-export lines from that public barrel, preserve current dashboard import, preview, activation, and PNG drop behavior, and prove the seam with focused frontend checks including `bun run check:inline-component-class-usage` plus the relevant existing workflow-activity or import tests.",
    "problem": "The import feature public barrel currently exposes both an intentional dialog component export and lower-level hook plus hook-owned type re-exports that are only consumed by workflow-activity internals. That mixes public and internal ownership, widens the apparent supported import feature surface, and hides the fact that those hook APIs and `ReadFactoryImportFile` are actually owned by specific `ui/src/features/import/hooks/*` modules.",
    "solution": "Retarget workflow-activity's internal dependencies to the owning import hook modules, then remove the hook re-export lines from `ui/src/features/import/public/index.ts` so the public boundary keeps only the import preview dialog component. Preserve runtime behavior and prove the cleanup with focused compile and regression checks."
  },
  "acceptanceCriteria": [
    "`ui/src/features/import/public/index.ts` exports the import preview dialog component only and no longer re-exports the import hook modules.",
    "Workflow-activity code that previously imported `useFactoryImportActivation`, `useFactoryImportPreview`, `useFactoryPngDrop`, or `ReadFactoryImportFile` through `../../import/public` imports them directly from the owning `ui/src/features/import/hooks/*` modules.",
    "Dashboard import preview, import activation, and PNG drop behavior remain unchanged after the import-path cleanup.",
    "Intentional dialog consumers continue to use `ui/src/features/import/public` for the import preview dialog component without prop, naming, or rendering changes.",
    "The implementation stays limited to the identified workflow-activity import sites and the public barrel cleanup; it does not rename hook APIs, move import logic, or refactor import preview state behavior.",
    "Quality gate: frontend typecheck, `bun run check:inline-component-class-usage`, and the relevant existing workflow-activity or import tests covering the affected behavior pass."
  ],
  "userStories": [
    {
      "id": "remove-import-hook-reexports-from-public-001",
      "title": "Retarget workflow-activity to the owning import hook modules",
      "description": "As a frontend maintainer, I want workflow-activity to import import hooks and hook-owned types from their owning modules so that internal consumers depend directly on the real import feature owners instead of the broader feature public barrel.",
      "acceptanceCriteria": [
        "Workflow-activity imports that previously read `useFactoryImportActivation`, `useFactoryImportPreview`, `useFactoryPngDrop`, or `ReadFactoryImportFile` through `../../import/public` now read them from the corresponding `../../import/hooks/*` modules.",
        "The retargeted imports preserve the current hook APIs, type-only import intent where applicable, and existing workflow-activity behavior in the current activity controller, card component, story, and test.",
        "Workflow-activity import preview state, activation flows, and PNG drop handling semantics remain unchanged after the import-path retargeting.",
        "The change stays limited to the identified live workflow-activity import sites and does not rewrite dialog consumers or move import hook implementations.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "remove-import-hook-reexports-from-public-002",
      "title": "Narrow the import public barrel to the dialog-only boundary",
      "description": "As a reviewer, I want the import feature public barrel to expose only the intentional dialog component so that the feature boundary stays minimal while import preview and drag-drop behavior remain unchanged.",
      "acceptanceCriteria": [
        "`ui/src/features/import/public/index.ts` removes only the hook re-export lines and keeps the import preview dialog component public export intact.",
        "Existing dialog consumers continue to resolve the import preview dialog component from `ui/src/features/import/public` without import-path changes or behavior changes.",
        "Focused verification proves dashboard import preview, import activation, and PNG drop behavior still match the pre-cleanup behavior.",
        "Verification includes `bun run check:inline-component-class-usage` and the relevant existing workflow-activity or import tests that already cover the affected behavior.",
        "The cleanup does not broaden into other import public-boundary changes, hook API renames, or workflow-activity behavior refactors.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
