### PR TITLE
remove-current-selection-terminal-work-type-public-reexport

### DIFF
--- a/ui/src/features/current-selection/public/index.test.ts
+++ b/ui/src/features/current-selection/public/index.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import * as currentSelectionPublic from "./index";
+import type {
+  DashboardSelection,
+  DashboardWorkItemSelection,
+  DashboardWorkstationRequestSelection,
+  StatePositionWorkItem,
+} from "./index";
+
+describe("current-selection public barrel", () => {
+  it("keeps the public runtime surface focused on the widget and hooks", () => {
+    expect(Object.keys(currentSelectionPublic).sort()).toEqual([
+      "CurrentSelectionWidget",
+      "useCurrentSelection",
+      "useCurrentSelectionDetails",
+      "useSelectedProviderSessionState",
+    ]);
+    expect("TerminalWorkDetail" in currentSelectionPublic).toBe(false);
+  });
+
+  it("keeps the current-selection contract types available", () => {
+    const workItem: StatePositionWorkItem = {
+      work_id: "work-1",
+    };
+    const workItemSelection: DashboardWorkItemSelection = {
+      kind: "work-item",
+      nodeId: "node-1",
+      workItem,
+    };
+    const workstationRequestSelection: DashboardWorkstationRequestSelection = {
+      dispatchId: "dispatch-1",
+      kind: "workstation-request",
+      nodeId: "node-1",
+      request: {
+        created_at: "2026-01-01T00:00:00Z",
+        dispatch_id: "dispatch-1",
+        request: {
+          name: "Request 1",
+          request_id: "request-1",
+          work_items: [],
+        },
+        workstation_name: "review",
+      },
+    };
+    const selection: DashboardSelection = workItemSelection;
+
+    expect(selection.kind).toBe("work-item");
+    expect(workstationRequestSelection.request.dispatch_id).toBe("dispatch-1");
+    expect(workItem.work_id).toBe("work-1");
+  });
+});

--- a/ui/src/features/current-selection/public/index.ts
+++ b/ui/src/features/current-selection/public/index.ts
@@ -1,5 +1,10 @@
 export * from "../components/current-selection-widget";
-export * from "../state/selection-types";
 export * from "../hooks/useCurrentSelection";
 export * from "../hooks/useCurrentSelectionDetails";
 export * from "../hooks/useSelectedProviderSessionState";
+export type {
+  DashboardSelection,
+  DashboardWorkItemSelection,
+  DashboardWorkstationRequestSelection,
+  StatePositionWorkItem,
+} from "../state/selection-types";


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/remove-current-selection-terminal-work-type-public-reexport",
  "description": "Replace the wildcard current-selection selection-types re-export with explicit selection contract exports so the feature keeps exposing its intended public hooks, widget, and selection types while no longer forwarding `TerminalWorkDetail` from terminal-work.",
  "context": {
    "customerAsk": "Replace the wildcard `selection-types` re-export in `ui/src/features/current-selection/public/index.ts` with explicit selection contract exports so the public barrel keeps exposing `CurrentSelectionWidget`, `useCurrentSelection`, `useCurrentSelectionDetails`, `useSelectedProviderSessionState`, and the true current-selection contract types, but stops forwarding `TerminalWorkDetail` from terminal-work. Update only the public export surface and any imports that break because they relied on that relay, preserve behavior, and prove the cleanup with focused frontend checks including `bun run check:inline-component-class-usage` plus relevant existing import-coverage tests.",
    "problem": "The current-selection public barrel currently re-exports `../state/selection-types` wholesale, and that state surface re-exports `TerminalWorkDetail` from `ui/src/features/terminal-work/lib/types`. This leaks a sibling terminal-work type through the current-selection public boundary, widens the apparent supported surface, and works against the customer direction to reduce unnecessary website re-exports and prefer direct ownership paths.",
    "solution": "Replace the module-wide `selection-types` re-export in `ui/src/features/current-selection/public/index.ts` with explicit exports of the intended current-selection contract types such as `DashboardSelection`, `DashboardWorkItemSelection`, `DashboardWorkstationRequestSelection`, and `StatePositionWorkItem`. Keep the existing public hooks and widget, retarget any broken `TerminalWorkDetail` consumers to the terminal-work owner path, and verify the boundary with focused frontend checks."
  },
  "acceptanceCriteria": [
    "`ui/src/features/current-selection/public/index.ts` no longer re-exports the entire `../state/selection-types` module.",
    "`TerminalWorkDetail` is no longer reachable through `ui/src/features/current-selection/public`.",
    "The intended current-selection public contract remains available through `ui/src/features/current-selection/public`, including `CurrentSelectionWidget`, `useCurrentSelection`, `useCurrentSelectionDetails`, `useSelectedProviderSessionState`, `DashboardSelection`, `DashboardWorkItemSelection`, `DashboardWorkstationRequestSelection`, and `StatePositionWorkItem`.",
    "Live cross-feature consumers in bento and workflow-activity continue to compile against the current-selection public boundary without behavior changes.",
    "The implementation stays limited to the current-selection public export surface and any import repairs required by that boundary change; it does not move runtime logic, change selection behavior, or broaden into hook or terminal-work UI cleanup.",
    "Quality gate: `bun run check:inline-component-class-usage`, frontend typecheck, and the relevant existing current-selection, bento, or workflow-activity tests covering the touched import surface pass."
  ],
  "userStories": [
    {
      "id": "remove-current-selection-terminal-work-type-public-reexport-001",
      "title": "Replace the wildcard current-selection type re-export with an explicit selection contract",
      "description": "As a frontend maintainer, I want the current-selection public barrel to expose only the selection-facing types it owns so that the feature boundary stays intentional and no longer relays a sibling terminal-work type.",
      "acceptanceCriteria": [
        "`ui/src/features/current-selection/public/index.ts` removes the wildcard `export * from \"../state/selection-types\";` line.",
        "`ui/src/features/current-selection/public/index.ts` explicitly exports the intended current-selection contract types needed by cross-feature consumers: `DashboardSelection`, `DashboardWorkItemSelection`, `DashboardWorkstationRequestSelection`, and `StatePositionWorkItem`.",
        "`ui/src/features/current-selection/public/index.ts` keeps exporting `CurrentSelectionWidget`, `useCurrentSelection`, `useCurrentSelectionDetails`, and `useSelectedProviderSessionState`.",
        "`TerminalWorkDetail` is no longer exported from the current-selection public barrel.",
        "The change does not alter current-selection runtime behavior, hook signatures, or widget behavior.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "remove-current-selection-terminal-work-type-public-reexport-002",
      "title": "Repair any broken imports and prove the narrowed boundary is safe for existing consumers",
      "description": "As a reviewer, I want any consumers that relied on the leaked type relay to use the correct direct owner so that the current-selection public cleanup remains behavior-preserving and easy to trust.",
      "acceptanceCriteria": [
        "Any import that breaks because it previously relied on `TerminalWorkDetail` through `ui/src/features/current-selection/public` is retargeted to the owning `ui/src/features/terminal-work/lib/types` path instead of restoring the relay.",
        "Existing bento and workflow-activity consumers continue importing selection hooks or `DashboardSelection` from `ui/src/features/current-selection/public` without behavior changes.",
        "Focused verification covers the narrowed public boundary with `bun run check:inline-component-class-usage` and the relevant existing current-selection, bento, or workflow-activity tests that already exercise these imports.",
        "The cleanup does not add topology-only tests, broaden into other public-barrel cleanup, or change terminal-work runtime code.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
