### PR TITLE
remove-bento-hook-reexports-from-public

### DIFF
--- a/ui/src/features/bento/public/index.ts
+++ b/ui/src/features/bento/public/index.ts
@@ -1,4 +1,2 @@
 export * from "../components/agent-bento";
 export * from "../components/dashboard-bento";
-export * from "../hooks/useDashboardLayout";
-export * from "../hooks/useDashboardNow";

--- a/ui/src/testing/app-shell-test-utils.tsx
+++ b/ui/src/testing/app-shell-test-utils.tsx
@@ -17,7 +17,7 @@ import {
 } from "../components/dashboard/fixtures";
 import { installDashboardBrowserTestShims } from "../components/dashboard/test-browser-shims";
 import { semanticWorkflowDashboardSnapshot } from "../components/dashboard/test-fixtures";
-import { reloadDashboardLayoutFromStorage } from "../features/bento/public";
+import { reloadDashboardLayoutFromStorage } from "../features/bento/hooks/useDashboardLayout";
 import { useDashboardBentoStore } from "../features/bento/state/dashboardBentoStore";
 import { useCurrentFactoryDocument } from "../features/current-factory-definition/public";
 import { resetSelectionHistoryStore } from "../features/current-selection/state/selectionHistoryStore";


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/remove-bento-hook-reexports-from-public",
  "description": "Remove the bento hook re-exports from the bento public barrel, retarget exact hook-owned consumers to the owning bento hook modules, and preserve the intentional `AgentBentoCard` and `DashboardBento` public component boundary without changing dashboard behavior.",
  "context": {
    "customerAsk": "Remove the `useDashboardLayout` and `useDashboardNow` hook re-exports from `ui/src/features/bento/public/index.ts`, retarget any affected consumers to the owning `ui/src/features/bento/hooks/*` modules, keep the intended public component boundary for `AgentBentoCard` and `DashboardBento`, preserve dashboard layout persistence and time behavior, and prove the cleanup with focused frontend checks including `bun run check:inline-component-class-usage`, the existing `useDashboardLayout` hook tests, and at least one app-shell path that uses `ui/src/testing/app-shell-test-utils.tsx`.",
    "problem": "The bento feature public barrel currently exposes both intentional component exports and lower-level hook re-exports that do not represent a maintained broad runtime contract. The maintained cross-feature consumer is the shared test harness importing `reloadDashboardLayoutFromStorage`, while the owning feature already imports `useDashboardNow` directly from its hook module. Keeping those hook relays in `bento/public` widens the apparent supported surface, obscures true ownership of dashboard layout helpers, and works against the customer direction to reduce unnecessary public re-exports in favor of direct imports.",
    "solution": "Retarget the shared harness and any other exact consumers of `reloadDashboardLayoutFromStorage` or related hook-owned exports to the owning `ui/src/features/bento/hooks/useDashboardLayout` module, remove the `useDashboardLayout` and `useDashboardNow` re-export lines from `ui/src/features/bento/public/index.ts`, and keep `AgentBentoCard` and `DashboardBento` available through the bento public boundary. Preserve runtime behavior and prove the cleanup through focused compile and regression checks rather than broader bento cleanup."
  },
  "acceptanceCriteria": [
    "`ui/src/features/bento/public/index.ts` no longer re-exports `../hooks/useDashboardLayout` or `../hooks/useDashboardNow`.",
    "The shared harness in `ui/src/testing/app-shell-test-utils.tsx` imports `reloadDashboardLayoutFromStorage` directly from `ui/src/features/bento/hooks/useDashboardLayout` instead of `ui/src/features/bento/public`.",
    "The intended bento public boundary continues to expose `AgentBentoCard` and `DashboardBento` for current runtime consumers without prop, naming, or rendering changes.",
    "Dashboard layout persistence behavior, stored-layout reload behavior, and dashboard time-driven rendering behavior remain unchanged after the import-path cleanup.",
    "The implementation stays limited to the bento public barrel and the exact consumers that depended on the hook relay; it does not widen into widget, layout model, or dashboard runtime cleanup.",
    "Quality gate: frontend typecheck, `bun run check:inline-component-class-usage`, `ui/src/features/bento/hooks/useDashboardLayout.test.tsx`, `ui/src/features/bento/hooks/useDashboardLayout.inline-add-widget.test.tsx`, and at least one existing app-shell path that uses `ui/src/testing/app-shell-test-utils.tsx` pass."
  ],
  "userStories": [
    {
      "id": "remove-bento-hook-reexports-from-public-001",
      "title": "Retarget hook-owned bento consumers to direct modules",
      "description": "As a frontend maintainer, I want shared harness code to import dashboard layout helpers from the owning bento hook module so that internal consumers depend directly on the real hook owner instead of the broader bento public barrel.",
      "acceptanceCriteria": [
        "`ui/src/testing/app-shell-test-utils.tsx` imports `reloadDashboardLayoutFromStorage` from `ui/src/features/bento/hooks/useDashboardLayout`.",
        "Any other maintained consumer that breaks because it depended on the bento public hook relay is retargeted to the owning `ui/src/features/bento/hooks/*` module and preserves type-only import intent where applicable.",
        "App-shell test setup still reloads stored dashboard layout state the same way before rendering app-shell flows that depend on the harness.",
        "The retargeting stays limited to exact hook-owned consumers and does not move hook implementations or alter dashboard layout persistence semantics.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "remove-bento-hook-reexports-from-public-002",
      "title": "Narrow the bento public boundary to the intended component exports",
      "description": "As a reviewer, I want the bento public barrel to expose only the intended bento components so that the feature boundary stays minimal while dashboard layout and time behavior remain unchanged.",
      "acceptanceCriteria": [
        "`ui/src/features/bento/public/index.ts` removes the `useDashboardLayout` and `useDashboardNow` re-export lines while keeping the component exports needed for `AgentBentoCard` and `DashboardBento`.",
        "Existing runtime consumers continue to resolve `AgentBentoCard` and `DashboardBento` from `ui/src/features/bento/public` without import-path changes or behavior changes.",
        "`useDashboardNow` is no longer part of the bento public barrel and no maintained external consumer relies on it through that public boundary.",
        "Focused verification proves dashboard layout persistence, inline widget layout behavior, and at least one app-shell flow using `ui/src/testing/app-shell-test-utils.tsx` still match the pre-cleanup behavior.",
        "Verification includes `bun run check:inline-component-class-usage`, `ui/src/features/bento/hooks/useDashboardLayout.test.tsx`, and `ui/src/features/bento/hooks/useDashboardLayout.inline-add-widget.test.tsx`.",
        "The cleanup does not broaden into other bento public-boundary changes, widget layout model changes, or dashboard runtime refactors.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": false,
      "notes": ""
    }
  ]
}
