### PR TITLE
inline-factory-graph-editor-tooltip-button-class

### DIFF
--- a/ui/scripts/inline-component-class-usage-allowlist.mjs
+++ b/ui/scripts/inline-component-class-usage-allowlist.mjs
@@ -19,7 +19,6 @@ export const allowlistedInlineComponentClassUsage = [
   "src/features/factory-graph-editor/components/factory-graph-editor-controls.tsx#MENU_ACTION_LABEL_CLASS",
   "src/features/factory-graph-editor/components/factory-graph-editor-controls.tsx#MENU_ACTION_DESCRIPTION_CLASS",
   "src/features/factory-graph-editor/components/factory-graph-editor-controls.tsx#VISIBILITY_PANEL_CLASS",
-  "src/features/factory-graph-editor/components/factory-graph-editor-tooltip-button.tsx#INLINE_TOOLTIP_CLASS",
   "src/features/header/components/dashboard-header.tsx#DASHBOARD_TOOLBAR_CLASS",
   "src/features/header/components/dashboard-header.tsx#DASHBOARD_HEADER_ROWS_CLASS",
   "src/features/header/components/dashboard-header.tsx#DASHBOARD_PRIMARY_ROW_CLASS",

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-tooltip-button.test.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-tooltip-button.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { FactoryGraphEditorTooltipActionButton } from "./factory-graph-editor-tooltip-button";
+
+describe("FactoryGraphEditorTooltipActionButton", () => {
+  it("shows and hides the tooltip on hover without changing the copy or semantics", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <FactoryGraphEditorTooltipActionButton
+        aria-label="Delete"
+        tooltip="Remove nodes or edges from the draft"
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Delete" });
+    expect(button.getAttribute("aria-describedby")).toBeNull();
+    expect(screen.queryByRole("tooltip")).toBeNull();
+
+    await user.hover(button);
+
+    const tooltip = await screen.findByRole("tooltip", {
+      name: "Remove nodes or edges from the draft",
+    });
+    expect(button.getAttribute("aria-describedby")).toBe(tooltip.id);
+    expect(tooltip.className).toContain("pointer-events-none");
+    expect(tooltip.className).toContain("border-af-border-strong");
+    expect(tooltip.className).toContain("bg-af-surface-raised");
+    expect(tooltip.className).toContain("text-af-text");
+
+    await user.unhover(button);
+    expect(button.getAttribute("aria-describedby")).toBeNull();
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("shows and hides the tooltip on keyboard focus", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <FactoryGraphEditorTooltipActionButton
+        aria-label="Connect"
+        tooltip="Connect selected graph nodes"
+      />,
+    );
+
+    await user.tab();
+
+    const button = screen.getByRole("button", { name: "Connect" });
+    const tooltip = await screen.findByRole("tooltip", {
+      name: "Connect selected graph nodes",
+    });
+    expect(button.getAttribute("aria-describedby")).toBe(tooltip.id);
+
+    await user.tab();
+    expect(button.getAttribute("aria-describedby")).toBeNull();
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+});

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-tooltip-button.test.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-tooltip-button.test.tsx
@@ -1,26 +1,41 @@
-import { render, screen } from "@testing-library/react";
+import { JSDOM } from "jsdom";
+import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { FactoryGraphEditorTooltipActionButton } from "./factory-graph-editor-tooltip-button";
 
+if (typeof document === "undefined") {
+  const { window } = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: "http://localhost/",
+  });
+
+  Object.assign(globalThis, {
+    document: window.document,
+    HTMLElement: window.HTMLElement,
+    Node: window.Node,
+    navigator: window.navigator,
+    window,
+  });
+}
+
 describe("FactoryGraphEditorTooltipActionButton", () => {
   it("shows and hides the tooltip on hover without changing the copy or semantics", async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ document: globalThis.document });
 
-    render(
+    const view = render(
       <FactoryGraphEditorTooltipActionButton
         aria-label="Delete"
         tooltip="Remove nodes or edges from the draft"
       />,
     );
 
-    const button = screen.getByRole("button", { name: "Delete" });
+    const button = view.getByRole("button", { name: "Delete" });
     expect(button.getAttribute("aria-describedby")).toBeNull();
-    expect(screen.queryByRole("tooltip")).toBeNull();
+    expect(view.queryByRole("tooltip")).toBeNull();
 
     await user.hover(button);
 
-    const tooltip = await screen.findByRole("tooltip", {
+    const tooltip = await view.findByRole("tooltip", {
       name: "Remove nodes or edges from the draft",
     });
     expect(button.getAttribute("aria-describedby")).toBe(tooltip.id);
@@ -31,13 +46,13 @@ describe("FactoryGraphEditorTooltipActionButton", () => {
 
     await user.unhover(button);
     expect(button.getAttribute("aria-describedby")).toBeNull();
-    expect(screen.queryByRole("tooltip")).toBeNull();
+    expect(view.queryByRole("tooltip")).toBeNull();
   });
 
   it("shows and hides the tooltip on keyboard focus", async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ document: globalThis.document });
 
-    render(
+    const view = render(
       <FactoryGraphEditorTooltipActionButton
         aria-label="Connect"
         tooltip="Connect selected graph nodes"
@@ -46,14 +61,14 @@ describe("FactoryGraphEditorTooltipActionButton", () => {
 
     await user.tab();
 
-    const button = screen.getByRole("button", { name: "Connect" });
-    const tooltip = await screen.findByRole("tooltip", {
+    const button = view.getByRole("button", { name: "Connect" });
+    const tooltip = await view.findByRole("tooltip", {
       name: "Connect selected graph nodes",
     });
     expect(button.getAttribute("aria-describedby")).toBe(tooltip.id);
 
     await user.tab();
     expect(button.getAttribute("aria-describedby")).toBeNull();
-    expect(screen.queryByRole("tooltip")).toBeNull();
+    expect(view.queryByRole("tooltip")).toBeNull();
   });
 });

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-tooltip-button.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-tooltip-button.tsx
@@ -5,9 +5,6 @@ import {
   type DashboardActionButtonProps,
 } from "../../../components/ui";
 
-const INLINE_TOOLTIP_CLASS =
-  "pointer-events-none absolute left-1/2 top-full z-30 mt-2 -translate-x-1/2 rounded-xl border border-af-border-strong bg-af-surface-raised px-3 py-2 text-center text-xs font-medium text-af-text shadow-af-panel";
-
 export function FactoryGraphEditorTooltipActionButton({
   children,
   tooltip,
@@ -43,7 +40,11 @@ export function FactoryGraphEditorTooltipActionButton({
         {children}
       </DashboardActionButton>
       {tooltipVisible ? (
-        <span className={INLINE_TOOLTIP_CLASS} id={tooltipID} role="tooltip">
+        <span
+          className="pointer-events-none absolute left-1/2 top-full z-30 mt-2 -translate-x-1/2 rounded-xl border border-af-border-strong bg-af-surface-raised px-3 py-2 text-center text-xs font-medium text-af-text shadow-af-panel"
+          id={tooltipID}
+          role="tooltip"
+        >
           {tooltip}
         </span>
       ) : null}


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/inline-factory-graph-editor-tooltip-button-class",
  "description": "Inline the single-use tooltip class on the factory graph editor tooltip button element, remove the stale inline-class allowlist entry, and preserve existing tooltip hover, focus, semantics, and visual behavior.",
  "context": {
    "customerAsk": "Shrink the website inline-class allowlist by inlining the single-use `INLINE_TOOLTIP_CLASS` string directly on the local tooltip `<span role=\"tooltip\">` inside `ui/src/features/factory-graph-editor/components/factory-graph-editor-tooltip-button.tsx`, remove the matching allowlist entry from `ui/scripts/inline-component-class-usage-allowlist.mjs`, keep scope limited to those two files, and preserve tooltip visibility behavior, semantics, and graph editor copy.",
    "problem": "The factory graph editor tooltip button still defines a local class constant for a tooltip style cluster that is used only once, which conflicts with the repository guidance to keep single-use component class strings inline in JSX where allowed. The matching inline-class allowlist entry also remains, so the repository continues to track debt for an exception that should no longer exist after the cleanup.",
    "solution": "Move the existing tooltip class string directly onto the local `<span role=\"tooltip\">`, delete the stale `INLINE_TOOLTIP_CLASS` allowlist entry, and verify through focused frontend checks that tooltip positioning, pointer-event handling, copy, semantics, hover behavior, and keyboard focus behavior remain unchanged."
  },
  "acceptanceCriteria": [
    "`ui/src/features/factory-graph-editor/components/factory-graph-editor-tooltip-button.tsx` no longer defines `INLINE_TOOLTIP_CLASS`.",
    "The tooltip `<span role=\"tooltip\">` keeps the same styling inline on the JSX element, preserving current positioning, pointer-event behavior, and visual treatment.",
    "Tooltip hover and keyboard focus behavior remain unchanged for `FactoryGraphEditorTooltipActionButton`, including existing copy and accessibility semantics.",
    "`ui/scripts/inline-component-class-usage-allowlist.mjs` no longer includes `src/features/factory-graph-editor/components/factory-graph-editor-tooltip-button.tsx#INLINE_TOOLTIP_CLASS`.",
    "The implementation remains limited to the tooltip button component and the matching allowlist entry and does not widen into graph editor controls, action wiring, or unrelated allowlist cleanup.",
    "Quality gate: `bun run check:inline-component-class-usage`, `bun test ui/src/features/factory-graph-editor/components/factory-graph-editor-tooltip-button.test.tsx`, frontend typecheck, and relevant lint pass."
  ],
  "userStories": [
    {
      "id": "inline-factory-graph-editor-tooltip-button-class-001",
      "title": "Inline the tooltip class on the tooltip element",
      "description": "As a frontend maintainer, I want the factory graph editor tooltip button to keep its single-use tooltip class string inline on the tooltip element so that the component follows the shared styling standard without changing user-visible behavior.",
      "acceptanceCriteria": [
        "`ui/src/features/factory-graph-editor/components/factory-graph-editor-tooltip-button.tsx` no longer defines `INLINE_TOOLTIP_CLASS`.",
        "The local `<span role=\"tooltip\">` carries the same tooltip styling inline in JSX.",
        "Tooltip positioning, pointer-event behavior, visibility timing, tooltip copy, and accessibility semantics remain unchanged for hover and keyboard focus interactions.",
        "The change stays within the tooltip button component and does not alter `DashboardActionButton` contracts, graph editor action wiring, or other controls.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "inline-factory-graph-editor-tooltip-button-class-002",
      "title": "Remove the stale allowlist entry and prove the cleanup",
      "description": "As a reviewer, I want the inline component class usage allowlist to stop carrying the tooltip button exception once the class is inlined so that repository debt tracking matches the real component state.",
      "acceptanceCriteria": [
        "`ui/scripts/inline-component-class-usage-allowlist.mjs` no longer includes `src/features/factory-graph-editor/components/factory-graph-editor-tooltip-button.tsx#INLINE_TOOLTIP_CLASS`.",
        "`bun run check:inline-component-class-usage` passes without reintroducing an exception for the tooltip button component.",
        "`bun test ui/src/features/factory-graph-editor/components/factory-graph-editor-tooltip-button.test.tsx` passes and continues to prove unchanged tooltip hover and focus behavior.",
        "The cleanup remains limited to the single stale allowlist entry and does not remove unrelated allowlist debt.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
