### PR TITLE
docs-extensions-mock-workers-and-record

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -11,8 +11,10 @@ complete customer-facing contract.
 
 | Topic | Packaged scope | Canonical or broader customer guide |
 |-------|----------------|--------------------------------------|
-| `authoring-factories` | Practical factory authoring workflow, runnable examples, mock workers, and replay | [Author factories](authoring-factories.md) |
+| `authoring-factories` | Practical factory authoring workflow, runnable examples, and cross-links to run-mode guides | [Author factories](authoring-factories.md) |
 | `config` | Split layout and `factory.json` placement | [Factory JSON and work configuration](work.md) and [Author factories](authoring-factories.md) |
+| `mock-workers` | `--with-mock-workers` and the `mockWorkers` JSON contract | [Mock workers](mock-workers.md) |
+| `record-replay` | Default recording, `--record`, `--replay`, and `--no-record` | [Record and replay](record-replay.md) |
 | `work` | Work types, states, routing, resources, and portability fields | [Factory JSON and work configuration](work.md) |
 | `workstations` | Workstation kinds, routes, runtime fields, and scoped execution settings | [Workstations](workstations.md) |
 | `workers` | Worker quick reference | [Workers](workers.md) |
@@ -76,9 +78,14 @@ Use these canonical concept owners when you need the current contract.
   shape, watched-file placement, and supported relation types.
 - [Templates](templates.md) explains the supported Go-template surfaces, the
   full variable inventory, and the JSON-versus-Markdown quoting rules.
-- [Author factories](authoring-factories.md) keeps factory sequencing,
-  mock-worker checks, replay recording guidance, reusable
-  [`docs/examples/`](../examples/README.md) inputs, and run commands.
+- [Mock workers](mock-workers.md) owns `--with-mock-workers`, the
+  `mockWorkers` JSON contract, selection fields, and `runType` outcomes.
+- [Record and replay](record-replay.md) owns default recording, generated
+  artifact paths, `--record`, `--replay`, `--no-record`, and incompatible flag
+  combinations.
+- [Author factories](authoring-factories.md) keeps factory sequencing, quick-start
+  run commands, reusable [`docs/examples/`](../examples/README.md) inputs, and
+  links to the dedicated mock-worker and record/replay guides.
 - [Author AGENTS.md](authoring-agents-md.md) keeps split-file shape, prompt
   placement, and prompt-authoring examples.
 

--- a/docs/reference/authoring-factories.md
+++ b/docs/reference/authoring-factories.md
@@ -230,65 +230,14 @@ you run --dir ./factory --with-mock-workers
 The command loads `factory.json`, resolves the split `AGENTS.md` files, starts
 continuous mode, and exposes the dashboard and API on the configured port.
 
-Normal live `you run` invocations record a replay-compatible artifact by
-default when you do not pass `--record` or `--replay`. The generated artifact
-root is:
+Live runs record a replay-compatible artifact by default. Use `--no-record`,
+`--record <path>`, or `--replay <path>` when you need to override capture or
+playback. Run `you docs record-replay` for generated paths, incompatible flag
+combinations, sensitivity warnings, and copy-pasteable record and replay
+examples.
 
-```text
-~/.you-agent-factory/recordings/YYYY-MM/YYYY-MM-DD/
-```
-
-The top-level session for a normal run writes a filename shaped like:
-
-```text
-factory-session-~default-HHMMSS-<unique-id>.json
-```
-
-Independent factory sessions opened later in the same service lifetime keep the
-same directory contract but replace `~default` with the owning session ID so
-their histories stay isolated in separate replay artifacts.
-
-Use these controls when you need to override the default behavior:
-
-- Pass `--no-record` to skip the default recording for one invocation.
-- Pass `--record <path>` to write the replay artifact to an explicit path you
-  own instead of the generated recordings directory.
-- Pass `--replay <path>` to replay an existing artifact instead of starting a
-  live run.
-
-For an explicit recording path, run:
-
-```bash
-you run --dir ./factory --record ./docs/examples/sample-run.replay.json
-```
-
-To replay that artifact later, run:
-
-```bash
-you run --dir ./factory --replay ./docs/examples/sample-run.replay.json
-```
-
-To run without writing the default recording, run:
-
-```bash
-you run --dir ./factory --no-record
-```
-
-Record mode starts a live run and writes the observed runtime history to a
-replay artifact. Replay mode reads an existing artifact and uses the recorded
-runtime history instead of dispatching live workers again. `--record` and
-`--replay` cannot be used together for the same invocation.
-
-The CLI reports the resolved generated path during shutdown with
-`Recording saved: ...` so the artifact is easy to find after a failure or an
-unexpected run. Replay artifacts are sensitive because they can contain
-prompts, payloads, stdout, stderr, and diagnostic metadata. The first version
-does not delete old artifacts automatically, so manage retention in your own
-home directory or CI workspace.
-
-Maintainers who need the internal event-log and fixture workflow can use
-[`docs/internal/development/record-replay.md`](../internal/development/record-replay.md);
-customer runs only need the CLI flags above.
+Run `you docs mock-workers` for the `--with-mock-workers` JSON contract,
+selection fields, and deterministic outcome examples beyond this quick start.
 
 ### 4. Submit work
 
@@ -660,68 +609,26 @@ V1 non-goals for poller authoring:
 Use mock workers when you want to verify routing, rejection loops, failure
 paths, and script side effects without making live provider calls.
 
-For the simplest validation run, omit the config path:
+Run `you docs mock-workers` for the full JSON contract, selection fields,
+`runType` values, and examples. For this review-loop walkthrough, start with:
 
 ```bash
 you run --dir ./factory --with-mock-workers
 ```
 
-That is equivalent to this config:
-
-```json
-{
-  "mockWorkers": []
-}
-```
-
-To target specific dispatches, pass a config path:
+To exercise the checked-in rejection example:
 
 ```bash
 you run --dir ./factory --with-mock-workers ./docs/examples/mock-workers.json
 ```
 
-The reusable example in
-[`docs/examples/mock-workers.json`](../examples/mock-workers.json) matches a
-review dispatch and returns a deterministic rejection:
-
-```json
-{
-  "mockWorkers": [
-    {
-      "id": "reviewer-rejects-first-pass",
-      "workerName": "reviewer",
-      "workstationName": "review-story",
-      "workInputs": [
-        {
-          "workType": "story",
-          "state": "in-review",
-          "inputName": "work"
-        }
-      ],
-      "runType": "reject",
-      "rejectConfig": {
-        "stdout": "needs changes",
-        "stderr": "missing acceptance criteria",
-        "exitCode": 42
-      }
-    }
-  ]
-}
-```
-
-Selection fields combine as filters:
-
-| Field | Matches |
-|-------|---------|
-| `workerName` | Worker identity from `workers[].name` |
-| `workstationName` | Workstation currently executing |
-| `workInputs` | Consumed token fields such as `workType`, `state`, `inputName`, `traceId`, or `payloadHash` |
-
-Use `workerName` for the worker declared in `workers[].name`,
-`workstationName` for the workstation currently executing, `workInputs` for
-the consumed work filters, `runType` for the outcome, and the matching
-run-type config such as `rejectConfig` or `scriptConfig` for outcome details.
-If no entry matches, mock-worker mode returns the default accepted result.
+Reusable inputs live under [`docs/examples/`](../examples/README.md), including
+[`docs/examples/mock-workers.json`](../examples/mock-workers.json) and
+[`docs/examples/startup-work.json`](../examples/startup-work.json). The
+companion [`docs/examples/README.md`](../examples/README.md) shows how to combine
+startup work, mock-worker config, and record/replay commands with the checked-in
+[`examples/write-code-review`](../../examples/write-code-review/factory.json)
+factory.
 
 The checked-in
 [`examples/write-code-review/factory.json`](../../examples/write-code-review/factory.json)
@@ -746,6 +653,8 @@ review-loop workflow.
 
 ## Related
 
+- [Mock workers](mock-workers.md)
+- [Record and replay](record-replay.md)
 - [Factory JSON And Work Configuration](work.md)
 - [Workstations](workstations.md)
 - [Workers](workers.md)

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -140,8 +140,21 @@ and `LoadRuntimeConfig(...)` without redefining the manifest shape.
 This bundle slice is intentionally narrow. `config flatten` does not recurse
 through arbitrary project files outside the documented allowlist.
 
+## Run Controls
+
+`you run` supports optional mock-worker and record/replay flags:
+
+- `--with-mock-workers` — deterministic worker outcomes without live provider calls
+- `--record`, `--replay`, `--no-record` — control replay artifact capture and playback
+
+Canonical guides: [Mock workers](mock-workers.md) and
+[Record and replay](record-replay.md). For an end-to-end authoring walkthrough,
+see [Author factories](authoring-factories.md).
+
 ## Related
 
+- [Mock workers](mock-workers.md)
+- [Record and replay](record-replay.md)
 - [CLI reference landing page](README.md)
 - [Package docs index](../README.md)
 - [Author factories](authoring-factories.md)

--- a/docs/reference/mock-workers.md
+++ b/docs/reference/mock-workers.md
@@ -1,0 +1,160 @@
+# Mock Workers
+
+Use mock workers when you want to verify routing, rejection loops, failure
+paths, and script side effects without making live provider calls.
+
+`you docs mock-workers` is the canonical guide for `--with-mock-workers` and
+the mock-workers JSON contract. See [Authoring Factories](authoring-factories.md)
+for the full factory setup workflow.
+
+## Enable Mock-Worker Mode
+
+Pass `--with-mock-workers` on `you run` to replace live worker dispatch with
+deterministic mock outcomes:
+
+```bash
+you run --dir <factory> --with-mock-workers
+```
+
+The optional path argument selects a JSON config file:
+
+```bash
+you run --dir <factory> --with-mock-workers ./path/to/mock-workers.json
+```
+
+When you omit the path, the CLI enables mock mode with an empty config. That
+is equivalent to:
+
+```json
+{
+  "mockWorkers": []
+}
+```
+
+With no matching entries, every dispatch returns the default accepted result.
+
+## JSON Contract
+
+The config file is a single JSON object with a top-level `mockWorkers` array.
+Each array element selects a worker dispatch and declares the outcome to apply
+when it matches.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | No | Stable label for diagnostics and test fixtures. |
+| `workerName` | No | Matches `workers[].name` from `factory.json`. |
+| `workstationName` | No | Matches the workstation currently executing. |
+| `workInputs` | No | Filters on consumed work input fields (see below). |
+| `runType` | Yes | One of `accept`, `reject`, or `script`. |
+| `scriptConfig` | When `runType` is `script` | Command, args, env, and related script fields. |
+| `rejectConfig` | When `runType` is `reject` | Observable stdout, stderr, and exit code. |
+
+Unknown JSON fields are rejected at load time.
+
+### Work Input Selectors
+
+Each `workInputs` entry narrows the match using any combination of:
+
+| Field | Matches |
+|-------|---------|
+| `workId` | Work item identifier |
+| `workType` | Work type name such as `story` |
+| `state` | Current work state such as `in-review` |
+| `inputName` | Consumed input token name such as `work` |
+| `traceId` | Trace identifier when present |
+| `channel` | Input channel when present |
+| `payloadHash` | Payload hash when present |
+
+All specified selector fields on an entry must match for that entry to apply.
+Omit a selector field to leave it unconstrained.
+
+### Run Types
+
+**`accept`** — Return a successful accepted result with no extra config.
+
+**`reject`** — Return a rejected result. Optional `rejectConfig` fields:
+
+| Field | Description |
+|-------|-------------|
+| `stdout` | Text surfaced as command stdout |
+| `stderr` | Text surfaced as command stderr |
+| `exitCode` | Integer exit code between 1 and 255 when set |
+
+**`script`** — Execute a local command through the shared command-runner
+boundary. Requires `scriptConfig` with at least `command`. Optional fields:
+
+| Field | Description |
+|-------|-------------|
+| `args` | Argument list |
+| `env` | Environment map |
+| `workingDirectory` | Working directory for the command |
+| `stdin` | Stdin payload |
+| `timeout` | Duration string such as `30s` |
+
+### Default When Nothing Matches
+
+If no `mockWorkers` entry matches a dispatch, mock-worker mode returns the
+default accepted result. An empty `mockWorkers` array therefore accepts every
+dispatch.
+
+## Example Commands
+
+Simple validation run without a config file:
+
+```bash
+you run --dir ./factory --with-mock-workers
+```
+
+Targeted rejection using the checked-in example config:
+
+```bash
+you run --dir ./factory --with-mock-workers ./docs/examples/mock-workers.json
+```
+
+The reusable example in
+[`docs/examples/mock-workers.json`](../examples/mock-workers.json) matches a
+review dispatch and returns a deterministic rejection:
+
+```json
+{
+  "mockWorkers": [
+    {
+      "id": "reviewer-rejects-first-pass",
+      "workerName": "reviewer",
+      "workstationName": "review-story",
+      "workInputs": [
+        {
+          "workType": "story",
+          "state": "in-review",
+          "inputName": "work"
+        }
+      ],
+      "runType": "reject",
+      "rejectConfig": {
+        "stdout": "needs changes",
+        "stderr": "missing acceptance criteria",
+        "exitCode": 42
+      }
+    }
+  ]
+}
+```
+
+Combine mock workers with startup work for an end-to-end review-loop exercise:
+
+```bash
+you run --dir ./examples/write-code-review \
+  --with-mock-workers ./docs/examples/mock-workers.json \
+  --work ./docs/examples/startup-work.json
+```
+
+[`docs/examples/README.md`](../examples/README.md) documents how the example
+files fit together. The checked-in
+[`examples/write-code-review/factory.json`](../../examples/write-code-review/factory.json)
+factory is a concrete starting point for adapting these commands.
+
+## Related
+
+- [Config](config.md) — brief run-flag summary with pointers to this topic
+- [Authoring Factories](authoring-factories.md) — full factory authoring workflow
+- [Workers](workers.md) — worker types and configuration

--- a/docs/reference/record-replay.md
+++ b/docs/reference/record-replay.md
@@ -1,0 +1,121 @@
+# Record and Replay
+
+Use record and replay when you want to capture a live factory run as a
+replay-compatible artifact, locate the saved file after shutdown, or re-run
+from a saved history without dispatching live workers again.
+
+`you docs record-replay` is the canonical guide for `--record`, `--replay`, and
+`--no-record`. See [Authoring Factories](authoring-factories.md) for the full
+factory setup workflow.
+
+## Default Recording On Live Runs
+
+Normal live `you run` invocations record a replay-compatible artifact by default
+when you do not pass `--record` or `--replay`.
+
+The generated artifact root is:
+
+```text
+~/.you-agent-factory/recordings/YYYY-MM/YYYY-MM-DD/
+```
+
+The top-level session for a normal run writes a filename shaped like:
+
+```text
+factory-session-~default-HHMMSS-<unique-id>.json
+```
+
+Independent factory sessions opened later in the same service lifetime keep the
+same directory contract but replace `~default` with the owning session ID so
+their histories stay isolated in separate replay artifacts.
+
+On shutdown, the CLI reports the resolved generated path with:
+
+```text
+Recording saved: <path>
+```
+
+That message makes the artifact easy to find after a failure or an unexpected
+run.
+
+## Record Mode vs Replay Mode
+
+**Record mode** starts a live run and writes the observed runtime history to a
+replay artifact. Use the default generated path, `--record <path>`, or rely on
+default recording without extra flags.
+
+**Replay mode** reads an existing artifact and uses the recorded runtime history
+instead of dispatching live workers again. Pass `--replay <path>`.
+
+## Run Controls
+
+| Flag | Effect |
+|------|--------|
+| *(none on a live run)* | Record to the generated path under `~/.you-agent-factory/recordings/` |
+| `--no-record` | Skip the default recording for one invocation |
+| `--record <path>` | Write the replay artifact to an explicit path you own |
+| `--replay <path>` | Replay an existing artifact instead of starting a live run |
+
+### Incompatible Combinations
+
+These flag pairs are rejected for the same invocation:
+
+- `--record` with `--replay`
+- `--no-record` with `--record`
+
+## Example Commands
+
+Record to an explicit path you control:
+
+```bash
+you run --dir ./factory --record ./docs/examples/sample-run.replay.json
+```
+
+Replay that artifact later:
+
+```bash
+you run --dir ./factory --replay ./docs/examples/sample-run.replay.json
+```
+
+Run live without writing the default recording:
+
+```bash
+you run --dir ./factory --no-record
+```
+
+Combine recording with mock workers and startup work using the checked-in
+examples:
+
+```bash
+you run --dir ./examples/write-code-review \
+  --with-mock-workers ./docs/examples/mock-workers.json \
+  --work ./docs/examples/startup-work.json \
+  --record ./docs/examples/sample-run.replay.json
+```
+
+```bash
+you run --dir ./examples/write-code-review \
+  --replay ./docs/examples/sample-run.replay.json
+```
+
+[`docs/examples/README.md`](../examples/README.md) documents how the example
+files fit together.
+
+## Sensitivity and Retention
+
+Replay artifacts are sensitive because they can contain prompts, payloads,
+stdout, stderr, and diagnostic metadata.
+
+The first version does not delete old artifacts automatically. Manage retention
+in your own home directory or CI workspace. Do not commit generated replay
+artifacts from real customer runs.
+
+Maintainers who need the internal event-log and fixture workflow can use
+[`docs/internal/development/record-replay.md`](../internal/development/record-replay.md);
+customer runs only need the CLI flags above.
+
+## Related
+
+- [Config](config.md) — brief run-flag summary with pointers to this topic
+- [Authoring Factories](authoring-factories.md) — full factory authoring workflow
+- [Mock Workers](mock-workers.md) — deterministic runs without live provider calls

--- a/pkg/cli/docs/docs.go
+++ b/pkg/cli/docs/docs.go
@@ -17,6 +17,7 @@ const (
 	TopicAuthoringFactories Topic = "authoring-factories"
 	TopicConfig             Topic = "config"
 	TopicMockWorkers        Topic = "mock-workers"
+	TopicRecordReplay       Topic = "record-replay"
 	TopicWork               Topic = "work"
 	TopicWorkstations       Topic = "workstations"
 	TopicWorkers            Topic = "workers"
@@ -35,6 +36,7 @@ const (
 	referenceAuthoringFactoriesPath = "reference/authoring-factories.md"
 	referenceConfigPath             = "reference/config.md"
 	referenceMockWorkersPath        = "reference/mock-workers.md"
+	referenceRecordReplayPath       = "reference/record-replay.md"
 	referenceWorkPath               = "reference/work.md"
 	referenceWorkstationsPath       = "reference/workstations.md"
 	referenceWorkersPath            = "reference/workers.md"
@@ -56,6 +58,7 @@ var topicDocuments = []topicDocument{
 	{topic: TopicAuthoringFactories, description: "Practical factory authoring workflow, runnable examples, mock workers, and replay.", path: referenceAuthoringFactoriesPath, displayOrder: 10},
 	{topic: TopicConfig, description: "Factory configuration, work types, workers, resources, and local run options.", path: referenceConfigPath, displayOrder: 20},
 	{topic: TopicMockWorkers, description: "Mock-worker runs, JSON selection contract, and deterministic accept, reject, and script outcomes.", path: referenceMockWorkersPath, displayOrder: 25},
+	{topic: TopicRecordReplay, description: "Record and replay run modes, artifact paths, sensitivity, and incompatible flag combinations.", path: referenceRecordReplayPath, displayOrder: 26},
 	{topic: TopicWork, description: "Work types, states, routing, resources, and portable factory fields.", path: referenceWorkPath, displayOrder: 30},
 	{topic: TopicWorkstations, description: "Workstation kinds, route fields, runtime step behavior, and scoped execution settings.", path: referenceWorkstationsPath, displayOrder: 40, aliases: []Topic{TopicWorkstationAlias}},
 	{topic: TopicWorkers, description: "Worker types, model providers, script workers, and worker configuration.", path: referenceWorkersPath, displayOrder: 50},

--- a/pkg/cli/docs/docs.go
+++ b/pkg/cli/docs/docs.go
@@ -16,6 +16,7 @@ type Topic string
 const (
 	TopicAuthoringFactories Topic = "authoring-factories"
 	TopicConfig             Topic = "config"
+	TopicMockWorkers        Topic = "mock-workers"
 	TopicWork               Topic = "work"
 	TopicWorkstations       Topic = "workstations"
 	TopicWorkers            Topic = "workers"
@@ -33,6 +34,7 @@ const (
 const (
 	referenceAuthoringFactoriesPath = "reference/authoring-factories.md"
 	referenceConfigPath             = "reference/config.md"
+	referenceMockWorkersPath        = "reference/mock-workers.md"
 	referenceWorkPath               = "reference/work.md"
 	referenceWorkstationsPath       = "reference/workstations.md"
 	referenceWorkersPath            = "reference/workers.md"
@@ -53,6 +55,7 @@ type topicDocument struct {
 var topicDocuments = []topicDocument{
 	{topic: TopicAuthoringFactories, description: "Practical factory authoring workflow, runnable examples, mock workers, and replay.", path: referenceAuthoringFactoriesPath, displayOrder: 10},
 	{topic: TopicConfig, description: "Factory configuration, work types, workers, resources, and local run options.", path: referenceConfigPath, displayOrder: 20},
+	{topic: TopicMockWorkers, description: "Mock-worker runs, JSON selection contract, and deterministic accept, reject, and script outcomes.", path: referenceMockWorkersPath, displayOrder: 25},
 	{topic: TopicWork, description: "Work types, states, routing, resources, and portable factory fields.", path: referenceWorkPath, displayOrder: 30},
 	{topic: TopicWorkstations, description: "Workstation kinds, route fields, runtime step behavior, and scoped execution settings.", path: referenceWorkstationsPath, displayOrder: 40, aliases: []Topic{TopicWorkstationAlias}},
 	{topic: TopicWorkers, description: "Worker types, model providers, script workers, and worker configuration.", path: referenceWorkersPath, displayOrder: 50},

--- a/pkg/cli/docs/docs_test.go
+++ b/pkg/cli/docs/docs_test.go
@@ -53,6 +53,7 @@ func TestSupportedTopics_ReturnsFixedTopicOrder(t *testing.T) {
 		"authoring-factories",
 		"config",
 		"mock-workers",
+		"record-replay",
 		"work",
 		"workstations",
 		"workers",
@@ -80,6 +81,7 @@ func TestSupportedTopicCommands_ReturnsCanonicalTopicsAndAliases(t *testing.T) {
 		"authoring-factories",
 		"config",
 		"mock-workers",
+		"record-replay",
 		"work",
 		"workstations",
 		"workstation",
@@ -144,6 +146,7 @@ func TestIndexMarkdown_ListsSupportedTopicsWithCommands(t *testing.T) {
 		"`authoring-factories` - Practical factory authoring workflow",
 		"`config` - Factory configuration",
 		"`mock-workers` - Mock-worker runs",
+		"`record-replay` - Record and replay run modes",
 		"`work` - Work types",
 		"`workstations` - Workstation kinds",
 		"`workers` - Worker types",
@@ -154,6 +157,7 @@ func TestIndexMarkdown_ListsSupportedTopicsWithCommands(t *testing.T) {
 		"`you docs authoring-factories`",
 		"`you docs config`",
 		"`you docs mock-workers`",
+		"`you docs record-replay`",
 		"`you docs work`",
 		"`you docs workstations`",
 		"`you docs batch-inputs`",
@@ -326,6 +330,40 @@ func TestMarkdown_WorkstationsAndCompatibilityAliasReturnRawAuthoredMarkdown(t *
 	}
 }
 
+func TestMarkdown_RecordReplayReturnsRawAuthoredMarkdown(t *testing.T) {
+	t.Parallel()
+
+	got, err := Markdown("record-replay")
+	if err != nil {
+		t.Fatalf("Markdown(record-replay) error = %v", err)
+	}
+
+	for _, want := range []string{
+		"# Record and Replay",
+		"~/.you-agent-factory/recordings/",
+		"factory-session-~default-HHMMSS-<unique-id>.json",
+		"Recording saved:",
+		"you run --dir ./factory --record ./docs/examples/sample-run.replay.json",
+		"you run --dir ./factory --replay ./docs/examples/sample-run.replay.json",
+		"you run --dir ./factory --no-record",
+		"`--record` with `--replay`",
+		"`--no-record` with `--record`",
+		"does not delete old artifacts automatically",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Markdown(record-replay) missing %q:\n%s", want, got)
+		}
+	}
+	for _, wrapper := range []string{
+		"# Docs",
+		"Run `you docs record-replay`.",
+	} {
+		if strings.Contains(got, wrapper) {
+			t.Fatalf("Markdown(record-replay) included wrapper text %q:\n%s", wrapper, got)
+		}
+	}
+}
+
 func TestMarkdown_RejectsUnsupportedTopics(t *testing.T) {
 	t.Parallel()
 
@@ -333,7 +371,7 @@ func TestMarkdown_RejectsUnsupportedTopics(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected unsupported docs topic to fail")
 	}
-	if got := err.Error(); got != `unsupported docs topic "unknown" (supported: authoring-factories, config, mock-workers, work, workstations, workers, resources, models, batch-inputs, templates)` {
+	if got := err.Error(); got != `unsupported docs topic "unknown" (supported: authoring-factories, config, mock-workers, record-replay, work, workstations, workers, resources, models, batch-inputs, templates)` {
 		t.Fatalf("unsupported topic error = %q", got)
 	}
 }

--- a/pkg/cli/docs/docs_test.go
+++ b/pkg/cli/docs/docs_test.go
@@ -212,8 +212,9 @@ func TestMarkdown_AuthoringFactoriesReturnsRawAuthoredMarkdown(t *testing.T) {
 	for _, want := range []string{
 		"# Authoring Factories",
 		"you run --dir ./factory --with-mock-workers",
-		"you run --dir ./factory --record ./docs/examples/sample-run.replay.json",
-		"you run --dir ./factory --replay ./docs/examples/sample-run.replay.json",
+		"you docs mock-workers",
+		"you docs record-replay",
+		"docs/examples/mock-workers.json",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("Markdown(authoring-factories) missing %q:\n%s", want, got)

--- a/pkg/cli/docs/docs_test.go
+++ b/pkg/cli/docs/docs_test.go
@@ -331,6 +331,43 @@ func TestMarkdown_WorkstationsAndCompatibilityAliasReturnRawAuthoredMarkdown(t *
 	}
 }
 
+func TestMarkdown_MockWorkersReturnsRawAuthoredMarkdown(t *testing.T) {
+	t.Parallel()
+
+	got, err := Markdown("mock-workers")
+	if err != nil {
+		t.Fatalf("Markdown(mock-workers) error = %v", err)
+	}
+
+	for _, want := range []string{
+		"# Mock Workers",
+		"mockWorkers",
+		"you run --dir <factory> --with-mock-workers",
+		"you run --dir ./factory --with-mock-workers ./docs/examples/mock-workers.json",
+		"runType",
+		"accept",
+		"reject",
+		"script",
+		"scriptConfig",
+		"rejectConfig",
+		"default accepted",
+		"docs/examples/mock-workers.json",
+		"docs/examples/startup-work.json",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Markdown(mock-workers) missing %q:\n%s", want, got)
+		}
+	}
+	for _, wrapper := range []string{
+		"# Docs",
+		"Run `you docs mock-workers`.",
+	} {
+		if strings.Contains(got, wrapper) {
+			t.Fatalf("Markdown(mock-workers) included wrapper text %q:\n%s", wrapper, got)
+		}
+	}
+}
+
 func TestMarkdown_RecordReplayReturnsRawAuthoredMarkdown(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cli/docs/docs_test.go
+++ b/pkg/cli/docs/docs_test.go
@@ -52,6 +52,7 @@ func TestSupportedTopics_ReturnsFixedTopicOrder(t *testing.T) {
 	want := []string{
 		"authoring-factories",
 		"config",
+		"mock-workers",
 		"work",
 		"workstations",
 		"workers",
@@ -78,6 +79,7 @@ func TestSupportedTopicCommands_ReturnsCanonicalTopicsAndAliases(t *testing.T) {
 	want := []string{
 		"authoring-factories",
 		"config",
+		"mock-workers",
 		"work",
 		"workstations",
 		"workstation",
@@ -141,6 +143,7 @@ func TestIndexMarkdown_ListsSupportedTopicsWithCommands(t *testing.T) {
 		"# Docs",
 		"`authoring-factories` - Practical factory authoring workflow",
 		"`config` - Factory configuration",
+		"`mock-workers` - Mock-worker runs",
 		"`work` - Work types",
 		"`workstations` - Workstation kinds",
 		"`workers` - Worker types",
@@ -150,6 +153,7 @@ func TestIndexMarkdown_ListsSupportedTopicsWithCommands(t *testing.T) {
 		"`templates` - Prompt template variables",
 		"`you docs authoring-factories`",
 		"`you docs config`",
+		"`you docs mock-workers`",
 		"`you docs work`",
 		"`you docs workstations`",
 		"`you docs batch-inputs`",
@@ -329,7 +333,7 @@ func TestMarkdown_RejectsUnsupportedTopics(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected unsupported docs topic to fail")
 	}
-	if got := err.Error(); got != `unsupported docs topic "unknown" (supported: authoring-factories, config, work, workstations, workers, resources, models, batch-inputs, templates)` {
+	if got := err.Error(); got != `unsupported docs topic "unknown" (supported: authoring-factories, config, mock-workers, work, workstations, workers, resources, models, batch-inputs, templates)` {
 		t.Fatalf("unsupported topic error = %q", got)
 	}
 }

--- a/pkg/cli/docs/reference/authoring-factories.md
+++ b/pkg/cli/docs/reference/authoring-factories.md
@@ -230,65 +230,14 @@ you run --dir ./factory --with-mock-workers
 The command loads `factory.json`, resolves the split `AGENTS.md` files, starts
 continuous mode, and exposes the dashboard and API on the configured port.
 
-Normal live `you run` invocations record a replay-compatible artifact by
-default when you do not pass `--record` or `--replay`. The generated artifact
-root is:
+Live runs record a replay-compatible artifact by default. Use `--no-record`,
+`--record <path>`, or `--replay <path>` when you need to override capture or
+playback. Run `you docs record-replay` for generated paths, incompatible flag
+combinations, sensitivity warnings, and copy-pasteable record and replay
+examples.
 
-```text
-~/.you-agent-factory/recordings/YYYY-MM/YYYY-MM-DD/
-```
-
-The top-level session for a normal run writes a filename shaped like:
-
-```text
-factory-session-~default-HHMMSS-<unique-id>.json
-```
-
-Independent factory sessions opened later in the same service lifetime keep the
-same directory contract but replace `~default` with the owning session ID so
-their histories stay isolated in separate replay artifacts.
-
-Use these controls when you need to override the default behavior:
-
-- Pass `--no-record` to skip the default recording for one invocation.
-- Pass `--record <path>` to write the replay artifact to an explicit path you
-  own instead of the generated recordings directory.
-- Pass `--replay <path>` to replay an existing artifact instead of starting a
-  live run.
-
-For an explicit recording path, run:
-
-```bash
-you run --dir ./factory --record ./docs/examples/sample-run.replay.json
-```
-
-To replay that artifact later, run:
-
-```bash
-you run --dir ./factory --replay ./docs/examples/sample-run.replay.json
-```
-
-To run without writing the default recording, run:
-
-```bash
-you run --dir ./factory --no-record
-```
-
-Record mode starts a live run and writes the observed runtime history to a
-replay artifact. Replay mode reads an existing artifact and uses the recorded
-runtime history instead of dispatching live workers again. `--record` and
-`--replay` cannot be used together for the same invocation.
-
-The CLI reports the resolved generated path during shutdown with
-`Recording saved: ...` so the artifact is easy to find after a failure or an
-unexpected run. Replay artifacts are sensitive because they can contain
-prompts, payloads, stdout, stderr, and diagnostic metadata. The first version
-does not delete old artifacts automatically, so manage retention in your own
-home directory or CI workspace.
-
-Maintainers who need the internal event-log and fixture workflow can use
-[`docs/internal/development/record-replay.md`](../internal/development/record-replay.md);
-customer runs only need the CLI flags above.
+Run `you docs mock-workers` for the `--with-mock-workers` JSON contract,
+selection fields, and deterministic outcome examples beyond this quick start.
 
 ### 4. Submit work
 
@@ -660,68 +609,26 @@ V1 non-goals for poller authoring:
 Use mock workers when you want to verify routing, rejection loops, failure
 paths, and script side effects without making live provider calls.
 
-For the simplest validation run, omit the config path:
+Run `you docs mock-workers` for the full JSON contract, selection fields,
+`runType` values, and examples. For this review-loop walkthrough, start with:
 
 ```bash
 you run --dir ./factory --with-mock-workers
 ```
 
-That is equivalent to this config:
-
-```json
-{
-  "mockWorkers": []
-}
-```
-
-To target specific dispatches, pass a config path:
+To exercise the checked-in rejection example:
 
 ```bash
 you run --dir ./factory --with-mock-workers ./docs/examples/mock-workers.json
 ```
 
-The reusable example in
-[`docs/examples/mock-workers.json`](../examples/mock-workers.json) matches a
-review dispatch and returns a deterministic rejection:
-
-```json
-{
-  "mockWorkers": [
-    {
-      "id": "reviewer-rejects-first-pass",
-      "workerName": "reviewer",
-      "workstationName": "review-story",
-      "workInputs": [
-        {
-          "workType": "story",
-          "state": "in-review",
-          "inputName": "work"
-        }
-      ],
-      "runType": "reject",
-      "rejectConfig": {
-        "stdout": "needs changes",
-        "stderr": "missing acceptance criteria",
-        "exitCode": 42
-      }
-    }
-  ]
-}
-```
-
-Selection fields combine as filters:
-
-| Field | Matches |
-|-------|---------|
-| `workerName` | Worker identity from `workers[].name` |
-| `workstationName` | Workstation currently executing |
-| `workInputs` | Consumed token fields such as `workType`, `state`, `inputName`, `traceId`, or `payloadHash` |
-
-Use `workerName` for the worker declared in `workers[].name`,
-`workstationName` for the workstation currently executing, `workInputs` for
-the consumed work filters, `runType` for the outcome, and the matching
-run-type config such as `rejectConfig` or `scriptConfig` for outcome details.
-If no entry matches, mock-worker mode returns the default accepted result.
+Reusable inputs live under [`docs/examples/`](../examples/README.md), including
+[`docs/examples/mock-workers.json`](../examples/mock-workers.json) and
+[`docs/examples/startup-work.json`](../examples/startup-work.json). The
+companion [`docs/examples/README.md`](../examples/README.md) shows how to combine
+startup work, mock-worker config, and record/replay commands with the checked-in
+[`examples/write-code-review`](../../examples/write-code-review/factory.json)
+factory.
 
 The checked-in
 [`examples/write-code-review/factory.json`](../../examples/write-code-review/factory.json)
@@ -746,6 +653,8 @@ review-loop workflow.
 
 ## Related
 
+- [Mock workers](mock-workers.md)
+- [Record and replay](record-replay.md)
 - [Factory JSON And Work Configuration](work.md)
 - [Workstations](workstations.md)
 - [Workers](workers.md)

--- a/pkg/cli/docs/reference/config.md
+++ b/pkg/cli/docs/reference/config.md
@@ -62,10 +62,16 @@ factory/
 workstation runtime content such as system prompts, prompt templates, timeout
 limits, and executor settings.
 
-For an end-to-end run walkthrough, including `--with-mock-workers`,
-`--record`, `--replay`, `--no-record`, and reusable files under
-`docs/examples/`, use
-[`docs/reference/authoring-factories.md`](../../../docs/reference/authoring-factories.md).
+## Run Controls
+
+`you run` supports optional mock-worker and record/replay flags:
+
+- `--with-mock-workers` — deterministic worker outcomes without live provider calls
+- `--record`, `--replay`, `--no-record` — control replay artifact capture and playback
+
+Canonical guides: `you docs mock-workers` and `you docs record-replay`. For an
+end-to-end authoring walkthrough and reusable files under `docs/examples/`, use
+`you docs authoring-factories`.
 
 ## Core Fields
 
@@ -113,6 +119,9 @@ For an end-to-end run walkthrough, including `--with-mock-workers`,
 
 ## Related
 
+- `you docs mock-workers`
+- `you docs record-replay`
+- `you docs authoring-factories`
 - `you docs workstations`
 - `you docs workers`
 - `you docs resources`

--- a/pkg/cli/docs/reference/mock-workers.md
+++ b/pkg/cli/docs/reference/mock-workers.md
@@ -1,0 +1,160 @@
+# Mock Workers
+
+Use mock workers when you want to verify routing, rejection loops, failure
+paths, and script side effects without making live provider calls.
+
+`you docs mock-workers` is the canonical guide for `--with-mock-workers` and
+the mock-workers JSON contract. See [Authoring Factories](authoring-factories.md)
+for the full factory setup workflow.
+
+## Enable Mock-Worker Mode
+
+Pass `--with-mock-workers` on `you run` to replace live worker dispatch with
+deterministic mock outcomes:
+
+```bash
+you run --dir <factory> --with-mock-workers
+```
+
+The optional path argument selects a JSON config file:
+
+```bash
+you run --dir <factory> --with-mock-workers ./path/to/mock-workers.json
+```
+
+When you omit the path, the CLI enables mock mode with an empty config. That
+is equivalent to:
+
+```json
+{
+  "mockWorkers": []
+}
+```
+
+With no matching entries, every dispatch returns the default accepted result.
+
+## JSON Contract
+
+The config file is a single JSON object with a top-level `mockWorkers` array.
+Each array entry selects a worker dispatch and declares the outcome to apply
+when it matches.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | No | Stable label for diagnostics and test fixtures. |
+| `workerName` | No | Matches `workers[].name` from `factory.json`. |
+| `workstationName` | No | Matches the workstation currently executing. |
+| `workInputs` | No | Filters on consumed work input fields (see below). |
+| `runType` | Yes | One of `accept`, `reject`, or `script`. |
+| `scriptConfig` | When `runType` is `script` | Command, args, env, and related script fields. |
+| `rejectConfig` | When `runType` is `reject` | Observable stdout, stderr, and exit code. |
+
+Unknown JSON fields are rejected at load time.
+
+### Work Input Selectors
+
+Each `workInputs` entry narrows the match using any combination of:
+
+| Field | Matches |
+|-------|---------|
+| `workId` | Work item identifier |
+| `workType` | Work type name such as `story` |
+| `state` | Current work state such as `in-review` |
+| `inputName` | Consumed input token name such as `work` |
+| `traceId` | Trace identifier when present |
+| `channel` | Input channel when present |
+| `payloadHash` | Payload hash when present |
+
+All specified selector fields on an entry must match for that entry to apply.
+Omit a selector field to leave it unconstrained.
+
+### Run Types
+
+**`accept`** — Return a successful accepted result with no extra config.
+
+**`reject`** — Return a rejected result. Optional `rejectConfig` fields:
+
+| Field | Description |
+|-------|-------------|
+| `stdout` | Text surfaced as command stdout |
+| `stderr` | Text surfaced as command stderr |
+| `exitCode` | Integer exit code between 1 and 255 when set |
+
+**`script`** — Execute a local command through the shared command-runner
+boundary. Requires `scriptConfig` with at least `command`. Optional fields:
+
+| Field | Description |
+|-------|-------------|
+| `args` | Argument list |
+| `env` | Environment map |
+| `workingDirectory` | Working directory for the command |
+| `stdin` | Stdin payload |
+| `timeout` | Duration string such as `30s` |
+
+### Default When Nothing Matches
+
+If no `mockWorkers` entry matches a dispatch, mock-worker mode returns the
+default accepted result. An empty `mockWorkers` array therefore accepts every
+dispatch.
+
+## Example Commands
+
+Simple validation run without a config file:
+
+```bash
+you run --dir ./factory --with-mock-workers
+```
+
+Targeted rejection using the checked-in example config:
+
+```bash
+you run --dir ./factory --with-mock-workers ./docs/examples/mock-workers.json
+```
+
+The reusable example in
+[`docs/examples/mock-workers.json`](../examples/mock-workers.json) matches a
+review dispatch and returns a deterministic rejection:
+
+```json
+{
+  "mockWorkers": [
+    {
+      "id": "reviewer-rejects-first-pass",
+      "workerName": "reviewer",
+      "workstationName": "review-story",
+      "workInputs": [
+        {
+          "workType": "story",
+          "state": "in-review",
+          "inputName": "work"
+        }
+      ],
+      "runType": "reject",
+      "rejectConfig": {
+        "stdout": "needs changes",
+        "stderr": "missing acceptance criteria",
+        "exitCode": 42
+      }
+    }
+  ]
+}
+```
+
+Combine mock workers with startup work for an end-to-end review-loop exercise:
+
+```bash
+you run --dir ./examples/write-code-review \
+  --with-mock-workers ./docs/examples/mock-workers.json \
+  --work ./docs/examples/startup-work.json
+```
+
+[`docs/examples/README.md`](../examples/README.md) documents how the example
+files fit together. The checked-in
+[`examples/write-code-review/factory.json`](../../examples/write-code-review/factory.json)
+factory is a concrete starting point for adapting these commands.
+
+## Related
+
+- [Config](config.md) — brief run-flag summary with pointers to this topic
+- [Authoring Factories](authoring-factories.md) — full factory authoring workflow
+- [Workers](workers.md) — worker types and configuration

--- a/pkg/cli/docs/reference/record-replay.md
+++ b/pkg/cli/docs/reference/record-replay.md
@@ -1,0 +1,121 @@
+# Record and Replay
+
+Use record and replay when you want to capture a live factory run as a
+replay-compatible artifact, locate the saved file after shutdown, or re-run
+from a saved history without dispatching live workers again.
+
+`you docs record-replay` is the canonical guide for `--record`, `--replay`, and
+`--no-record`. See [Authoring Factories](authoring-factories.md) for the full
+factory setup workflow.
+
+## Default Recording On Live Runs
+
+Normal live `you run` invocations record a replay-compatible artifact by default
+when you do not pass `--record` or `--replay`.
+
+The generated artifact root is:
+
+```text
+~/.you-agent-factory/recordings/YYYY-MM/YYYY-MM-DD/
+```
+
+The top-level session for a normal run writes a filename shaped like:
+
+```text
+factory-session-~default-HHMMSS-<unique-id>.json
+```
+
+Independent factory sessions opened later in the same service lifetime keep the
+same directory contract but replace `~default` with the owning session ID so
+their histories stay isolated in separate replay artifacts.
+
+On shutdown, the CLI reports the resolved generated path with:
+
+```text
+Recording saved: <path>
+```
+
+That message makes the artifact easy to find after a failure or an unexpected
+run.
+
+## Record Mode vs Replay Mode
+
+**Record mode** starts a live run and writes the observed runtime history to a
+replay artifact. Use the default generated path, `--record <path>`, or rely on
+default recording without extra flags.
+
+**Replay mode** reads an existing artifact and uses the recorded runtime history
+instead of dispatching live workers again. Pass `--replay <path>`.
+
+## Run Controls
+
+| Flag | Effect |
+|------|--------|
+| *(none on a live run)* | Record to the generated path under `~/.you-agent-factory/recordings/` |
+| `--no-record` | Skip the default recording for one invocation |
+| `--record <path>` | Write the replay artifact to an explicit path you own |
+| `--replay <path>` | Replay an existing artifact instead of starting a live run |
+
+### Incompatible Combinations
+
+These flag pairs are rejected for the same invocation:
+
+- `--record` with `--replay`
+- `--no-record` with `--record`
+
+## Example Commands
+
+Record to an explicit path you control:
+
+```bash
+you run --dir ./factory --record ./docs/examples/sample-run.replay.json
+```
+
+Replay that artifact later:
+
+```bash
+you run --dir ./factory --replay ./docs/examples/sample-run.replay.json
+```
+
+Run live without writing the default recording:
+
+```bash
+you run --dir ./factory --no-record
+```
+
+Combine recording with mock workers and startup work using the checked-in
+examples:
+
+```bash
+you run --dir ./examples/write-code-review \
+  --with-mock-workers ./docs/examples/mock-workers.json \
+  --work ./docs/examples/startup-work.json \
+  --record ./docs/examples/sample-run.replay.json
+```
+
+```bash
+you run --dir ./examples/write-code-review \
+  --replay ./docs/examples/sample-run.replay.json
+```
+
+[`docs/examples/README.md`](../examples/README.md) documents how the example
+files fit together.
+
+## Sensitivity and Retention
+
+Replay artifacts are sensitive because they can contain prompts, payloads,
+stdout, stderr, and diagnostic metadata.
+
+The first version does not delete old artifacts automatically. Manage retention
+in your own home directory or CI workspace. Do not commit generated replay
+artifacts from real customer runs.
+
+Maintainers who need the internal event-log and fixture workflow can use
+[`docs/internal/development/record-replay.md`](../internal/development/record-replay.md);
+customer runs only need the CLI flags above.
+
+## Related
+
+- [Config](config.md) — brief run-flag summary with pointers to this topic
+- [Authoring Factories](authoring-factories.md) — full factory authoring workflow
+- [Mock Workers](mock-workers.md) — deterministic runs without live provider calls

--- a/pkg/cli/root_docs_test.go
+++ b/pkg/cli/root_docs_test.go
@@ -26,6 +26,7 @@ func TestDocsCommand_NoTopicPrintsDocsIndex(t *testing.T) {
 		"`authoring-factories` - Practical factory authoring workflow",
 		"`config` - Factory configuration",
 		"`mock-workers` - Mock-worker runs",
+		"`record-replay` - Record and replay run modes",
 		"`work` - Work types",
 		"`workstations` - Workstation kinds",
 		"`workers` - Worker types",
@@ -33,6 +34,7 @@ func TestDocsCommand_NoTopicPrintsDocsIndex(t *testing.T) {
 		"`you docs authoring-factories`",
 		"`you docs config`",
 		"`you docs mock-workers`",
+		"`you docs record-replay`",
 		"`you docs work`",
 		"`you docs workstations`",
 		"`you docs workers`",
@@ -88,7 +90,7 @@ func TestDocsCommand_UnsupportedTopicReturnsCanonicalTopicError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected unsupported docs topic to fail")
 	}
-	if got := err.Error(); got != `unsupported docs topic "unknown" (supported: authoring-factories, config, mock-workers, work, workstations, workers, resources, models, batch-inputs, templates)` {
+	if got := err.Error(); got != `unsupported docs topic "unknown" (supported: authoring-factories, config, mock-workers, record-replay, work, workstations, workers, resources, models, batch-inputs, templates)` {
 		t.Fatalf("unexpected docs error %q", got)
 	}
 	if got := stdout.String(); got != "" {

--- a/pkg/cli/root_docs_test.go
+++ b/pkg/cli/root_docs_test.go
@@ -25,12 +25,14 @@ func TestDocsCommand_NoTopicPrintsDocsIndex(t *testing.T) {
 		"# Docs",
 		"`authoring-factories` - Practical factory authoring workflow",
 		"`config` - Factory configuration",
+		"`mock-workers` - Mock-worker runs",
 		"`work` - Work types",
 		"`workstations` - Workstation kinds",
 		"`workers` - Worker types",
 		"`batch-inputs` - Batch input files",
 		"`you docs authoring-factories`",
 		"`you docs config`",
+		"`you docs mock-workers`",
 		"`you docs work`",
 		"`you docs workstations`",
 		"`you docs workers`",
@@ -86,7 +88,7 @@ func TestDocsCommand_UnsupportedTopicReturnsCanonicalTopicError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected unsupported docs topic to fail")
 	}
-	if got := err.Error(); got != `unsupported docs topic "unknown" (supported: authoring-factories, config, work, workstations, workers, resources, models, batch-inputs, templates)` {
+	if got := err.Error(); got != `unsupported docs topic "unknown" (supported: authoring-factories, config, mock-workers, work, workstations, workers, resources, models, batch-inputs, templates)` {
 		t.Fatalf("unexpected docs error %q", got)
 	}
 	if got := stdout.String(); got != "" {

--- a/prd.json
+++ b/prd.json
@@ -61,7 +61,7 @@
         "Tests pass"
       ],
       "priority": 3,
-      "passes": false,
+      "passes": true,
       "notes": ""
     },
     {

--- a/prd.json
+++ b/prd.json
@@ -1,0 +1,84 @@
+{
+  "project": "Packaged CLI Docs for Mock Workers and Record/Replay",
+  "branchName": "ralph/docs-extensions-mock-workers-and-record",
+  "description": "Add dedicated you docs mock-workers and record-replay packaged topics so customers can discover how to use --with-mock-workers, mock-workers JSON, and the --record / --replay / --no-record run controls from the installed binary, with cross-links from existing topics and CLI smoke coverage.",
+  "context": {
+    "customerAsk": "The current ./bin/you docs does not document how customers are supposed to use mock-workers or record/replay commands. Please add support for this.",
+    "problem": "Mock-worker and record/replay guidance is buried inside the long authoring-factories topic and only summarized in config. you docs has no dedicated mock-workers or record-replay topics, so customers cannot discover complete command and JSON contract documentation from the installed CLI index.",
+    "solution": "Introduce two new canonical packaged docs topics (mock-workers and record-replay) with synchronized docs/reference and pkg/cli/docs/reference markdown, register them in pkg/cli/docs/docs.go, cross-link from authoring-factories and config, and extend focused CLI and functional smoke tests so the topics are listed and render stable command guidance outside the repository docs tree."
+  },
+  "acceptanceCriteria": [
+    "you docs lists mock-workers and record-replay with descriptions and you docs <topic> commands in the index.",
+    "you docs mock-workers returns a complete customer guide for --with-mock-workers, optional config paths, the mockWorkers JSON contract, selection fields, runType values, and example commands referencing docs/examples/mock-workers.json.",
+    "you docs record-replay returns a complete customer guide for default recording, generated artifact paths, --record, --replay, --no-record, sensitivity warnings, and incompatible flag combinations.",
+    "authoring-factories and config cross-link to the new topics without contradicting you run --help; docs/reference and pkg/cli/docs/reference copies stay synchronized.",
+    "Focused docs unit tests and functional cli_docs smoke tests prove index output and topic rendering from a working directory without a local docs tree.",
+    "Typecheck, lint, and tests pass for all changed packages."
+  ],
+  "userStories": [
+    {
+      "id": "docs-extensions-mock-workers-and-record-001",
+      "title": "Add mock-workers packaged docs topic",
+      "description": "As a factory author, I want you docs mock-workers to print a complete mock-worker guide so I can test routing and outcomes without live provider calls.",
+      "acceptanceCriteria": [
+        "docs/reference/mock-workers.md and pkg/cli/docs/reference/mock-workers.md match and document enabling with you run --dir <factory> --with-mock-workers (optional path), empty-config default accept behavior, the mockWorkers JSON array, selection fields, runType values accept/reject/script with their config objects, and default accept when no entry matches.",
+        "The page includes copy-pasteable you run commands and references docs/examples/mock-workers.json with a runnable example that uses docs/examples/startup-work.json when startup work is relevant.",
+        "pkg/cli/docs/docs.go registers canonical topic mock-workers with display order, packaged path, and index description; SupportedTopics() and unsupported-topic errors include it in deterministic order.",
+        "Running you docs lists mock-workers without listing compatibility aliases for it.",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 1,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "docs-extensions-mock-workers-and-record-002",
+      "title": "Add record-replay packaged docs topic",
+      "description": "As a factory operator, I want you docs record-replay to explain record and replay run modes so I can capture, locate, and replay sensitive run artifacts safely.",
+      "acceptanceCriteria": [
+        "docs/reference/record-replay.md and pkg/cli/docs/reference/record-replay.md match and document default-on recording, generated paths under ~/.you-agent-factory/recordings/, session filename pattern, explicit --record, --replay, --no-record, Recording saved shutdown messaging, sensitivity warnings, no automatic retention cleanup in v1, and rejection of --record with --replay or --no-record with --record.",
+        "The page distinguishes record mode (live run writes history) from replay mode (reads artifact instead of live worker dispatch) without requiring maintainer event-log detail.",
+        "Includes copy-pasteable you run examples using docs/examples/sample-run.replay.json for explicit record and replay paths.",
+        "pkg/cli/docs/docs.go registers canonical topic record-replay with display order, packaged path, and index description.",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "docs-extensions-mock-workers-and-record-003",
+      "title": "Cross-link existing packaged topics to new owners",
+      "description": "As a customer reading you docs config or you docs authoring-factories, I want clear pointers to the dedicated mock-worker and record/replay guides so I do not have to search a long workflow page.",
+      "acceptanceCriteria": [
+        "config retains brief mentions of --with-mock-workers, --record, --replay, and --no-record but links to you docs mock-workers and you docs record-replay as canonical owners.",
+        "authoring-factories keeps workflow sequencing but replaces duplicated deep mock-worker and record/replay sections with short summaries plus links to the new topics; quick-start commands for the review example remain.",
+        "authoring-factories still links to docs/examples/README.md and example JSON files with repository-relative paths that work from the docs tree.",
+        "docs/reference/README.md packaged-topic table includes mock-workers and record-replay with accurate scope descriptions.",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 3,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "docs-extensions-mock-workers-and-record-004",
+      "title": "Prove packaged CLI docs behavior for new topics",
+      "description": "As a maintainer, I need automated checks that the installed docs command exposes the new topics reliably so regressions are caught before release.",
+      "acceptanceCriteria": [
+        "pkg/cli/docs/docs_test.go expects mock-workers and record-replay in supported-topic order, index markdown, and raw markdown markers for each new topic.",
+        "pkg/cli/root_docs_test.go and other root-command docs tests list the new topics in help or unsupported-topic error text where applicable.",
+        "tests/functional/smoke/cli_docs_smoke_test.go runs you docs mock-workers and you docs record-replay from a temp working directory without a local docs tree and asserts stable headings and command markers including --with-mock-workers, --record, --replay, --no-record, and example artifact paths.",
+        "Unsupported-topic errors list all canonical topics including mock-workers and record-replay in deterministic order.",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 4,
+      "passes": false,
+      "notes": ""
+    }
+  ]
+}

--- a/prd.md
+++ b/prd.md
@@ -1,0 +1,159 @@
+# PRD: Packaged CLI Docs for Mock Workers and Record/Replay
+
+## Introduction
+
+Customers run factories locally with `you run` and need deterministic workflow checks without live model or script provider calls, plus the ability to capture and replay runs for debugging and support. The installed `you docs` surface is the primary way customers read reference material from `./bin/you` without cloning the repository.
+
+Today, mock-worker and record/replay guidance is scattered inside the long `authoring-factories` topic and only summarized in `config`. A customer running `you docs` does not get dedicated topics for `--with-mock-workers`, mock-workers JSON, or the `--record` / `--replay` / `--no-record` controls. The content that exists is hard to discover and mixes workflow sequencing with CLI run-mode reference.
+
+Add two focused packaged docs topics—`mock-workers` and `record-replay`—that explain how to use those commands from the installed binary, keep `docs/reference/` and `pkg/cli/docs/reference/` synchronized, and cross-link from existing topics without duplicating maintainer-only internals.
+
+## Context
+
+### Customer ask
+
+The current `./bin/you docs` output does not document how customers are supposed to use `mock-workers` or `record/replay` commands. Add support for this.
+
+### Problem
+
+- `you docs` lists nine topics; none are named for mock workers or record/replay.
+- Runnable command examples and JSON contracts for `--with-mock-workers` live deep inside `authoring-factories`, mixed with factory layout and batch-input guidance.
+- Record/replay behavior (default-on recording, generated artifact paths, explicit `--record`, `--replay`, `--no-record`, sensitivity warnings, and mutual exclusion) is similarly buried; `config` only points readers elsewhere.
+- Customers who know the feature names cannot run `you docs mock-workers` or `you docs record-replay` and get a complete answer.
+
+### High-level solution
+
+Introduce two new canonical packaged topics registered in `pkg/cli/docs/docs.go`, backed by customer-authored markdown in `docs/reference/mock-workers.md` and `docs/reference/record-replay.md` with synchronized packaged copies. Trim `authoring-factories` and `config` to short summaries plus links to the new owners. Extend CLI and functional smoke tests so the new topics are discoverable from `you docs` and return stable, copy-pasteable command guidance outside the repository docs tree.
+
+## Goals
+
+- Customers can discover mock-worker and record/replay documentation from `you docs` without reading the full authoring workflow guide.
+- `you docs mock-workers` explains when to use `--with-mock-workers`, optional config paths, the JSON contract, selection fields, supported `runType` values, default accept behavior, and links to checked-in examples.
+- `you docs record-replay` explains default recording, generated artifact locations, explicit `--record` / `--replay` / `--no-record`, sensitivity and retention expectations, and flag combinations the CLI rejects.
+- Existing topics remain accurate entry points via cross-links; maintainer internals stay in `docs/internal/development/record-replay.md`.
+- Packaged topics work when the repository `docs/` tree is absent (installed-binary behavior).
+
+## Project-Level Acceptance Criteria
+
+- [ ] Running `you docs` lists `mock-workers` and `record-replay` with customer-facing descriptions and `you docs <topic>` commands.
+- [ ] Running `you docs mock-workers` prints a dedicated guide that includes `you run --with-mock-workers` usage, optional config path behavior, the `mockWorkers` JSON shape, selection-field semantics, supported `runType` values, and links to `docs/examples/mock-workers.json`.
+- [ ] Running `you docs record-replay` prints a dedicated guide that includes default-on recording, generated artifact path contract, `--record`, `--replay`, `--no-record`, sensitivity guidance, and the rule that `--record` and `--replay` cannot be combined.
+- [ ] `authoring-factories` and `config` cross-link to the new topics without contradicting `you run --help` or root-command flag text.
+- [ ] Canonical `docs/reference/` pages and packaged `pkg/cli/docs/reference/` copies stay synchronized for every touched topic.
+- [ ] Focused tests prove index output, topic rendering, and installed-binary smoke behavior for the new topics.
+- [ ] Typecheck, lint, and tests pass for the changed packages.
+
+## User Stories
+
+### docs-extensions-mock-workers-and-record-001: Add mock-workers packaged docs topic
+
+**Description:** As a factory author, I want `you docs mock-workers` to print a complete mock-worker guide so I can test routing and outcomes without live provider calls.
+
+**Acceptance Criteria:**
+
+- [ ] `docs/reference/mock-workers.md` and `pkg/cli/docs/reference/mock-workers.md` match and document: enabling with `you run --dir <factory> --with-mock-workers` (optional path), empty-config default accept behavior, JSON top-level `mockWorkers` array, selection fields (`workerName`, `workstationName`, `workInputs`, etc.), `runType` values `accept`, `reject`, and `script` with their config objects, and unmatched-dispatch default accept behavior.
+- [ ] The page includes copy-pasteable commands using the `you` binary name and references the checked-in example at `docs/examples/mock-workers.json` with a runnable combined example that also uses `docs/examples/startup-work.json` when startup work is relevant.
+- [ ] `pkg/cli/docs/docs.go` registers canonical topic `mock-workers` with explicit display order, packaged path, and index description; `SupportedTopics()` and unsupported-topic errors include it in deterministic order.
+- [ ] `you docs` index lists `mock-workers` and does not list compatibility aliases for it.
+- [ ] Typecheck passes
+- [ ] Tests pass
+
+### docs-extensions-mock-workers-and-record-002: Add record-replay packaged docs topic
+
+**Description:** As a factory operator, I want `you docs record-replay` to explain record and replay run modes so I can capture, locate, and replay sensitive run artifacts safely.
+
+**Acceptance Criteria:**
+
+- [ ] `docs/reference/record-replay.md` and `pkg/cli/docs/reference/record-replay.md` match and document: default-on recording when neither `--record` nor `--replay` is passed, generated artifact directory `~/.you-agent-factory/recordings/YYYY-MM/YYYY-MM-DD/`, session-based filename pattern, explicit `--record <path>`, `--replay <path>`, `--no-record`, shutdown `Recording saved: ...` messaging, sensitivity warnings, no automatic retention cleanup in v1, and rejection of `--record` with `--replay` or `--no-record` with `--record`.
+- [ ] The page distinguishes record mode (live run writes history) from replay mode (reads artifact instead of dispatching live workers) in customer language without requiring maintainer event-log detail.
+- [ ] Includes copy-pasteable `you run` examples using `docs/examples/sample-run.replay.json` for explicit record and replay paths.
+- [ ] `pkg/cli/docs/docs.go` registers canonical topic `record-replay` with explicit display order, packaged path, and index description.
+- [ ] Typecheck passes
+- [ ] Tests pass
+
+### docs-extensions-mock-workers-and-record-003: Cross-link existing packaged topics to the new owners
+
+**Description:** As a customer reading `you docs config` or `you docs authoring-factories`, I want clear pointers to the dedicated mock-worker and record/replay guides so I do not have to search a long workflow page.
+
+**Acceptance Criteria:**
+
+- [ ] `config` retains a brief mention of `--with-mock-workers`, `--record`, `--replay`, and `--no-record` but links to `you docs mock-workers` and `you docs record-replay` as the canonical owners instead of being the only detailed reference.
+- [ ] `authoring-factories` keeps workflow sequencing but replaces duplicated deep mock-worker and record/replay sections with short summaries plus links to the new topics; runnable quick-start commands for the review example remain present.
+- [ ] `authoring-factories` still links to `docs/examples/README.md` and example JSON files using paths that work from the repository docs tree.
+- [ ] `docs/reference/README.md` packaged-topic table includes `mock-workers` and `record-replay` with accurate scope descriptions.
+- [ ] Typecheck passes
+- [ ] Tests pass
+
+### docs-extensions-mock-workers-and-record-004: Prove packaged CLI docs behavior for new topics
+
+**Description:** As a maintainer, I need automated checks that the installed docs command exposes the new topics reliably so regressions are caught before release.
+
+**Acceptance Criteria:**
+
+- [ ] `pkg/cli/docs/docs_test.go` expects `mock-workers` and `record-replay` in supported-topic order, index markdown, and raw markdown markers for each new topic.
+- [ ] `pkg/cli/root_docs_test.go` and other root-command docs tests list the new topics in help or unsupported-topic error text where applicable.
+- [ ] `tests/functional/smoke/cli_docs_smoke_test.go` runs `you docs mock-workers` and `you docs record-replay` from a temp working directory without a local `docs/` tree and asserts stable headings and command markers (for example `--with-mock-workers`, `--record`, `--replay`, `--no-record`, and example artifact paths).
+- [ ] Unsupported-topic errors list all canonical topics including the two new ones in deterministic order.
+- [ ] Typecheck passes
+- [ ] Tests pass
+
+## Functional Requirements
+
+- FR-1: Register `mock-workers` and `record-replay` as canonical packaged docs topics with positive display order after existing run-adjacent topics and before or after `templates` per a stable ordering documented in the registration table.
+- FR-2: `you docs mock-workers` returns raw markdown with no CLI wrapper prose, matching the authored reference page.
+- FR-3: `you docs record-replay` returns raw markdown with no CLI wrapper prose, matching the authored reference page.
+- FR-4: Mock-workers documentation must reflect the runtime JSON contract validated by `LoadMockWorkersConfig` / `ParseMockWorkersConfig` (including `mockWorkers`, `runType`, `rejectConfig`, `scriptConfig`, and work-input selectors).
+- FR-5: Record-replay documentation must align with `you run` flag behavior and long help in `pkg/cli/root.go` for default recording, sensitivity, and conflicting flag rejection.
+- FR-6: All customer-facing command examples in new pages use the installed binary name `you`, not legacy `agent-factory` or `infinite-you` invocations.
+- FR-7: Maintainer-only event-log, fixture promotion, and divergence interpretation remain in `docs/internal/development/record-replay.md`; the customer topic links to it only as optional further reading for contributors.
+
+## Non-Goals
+
+- No new CLI flags or changes to mock-worker or replay runtime behavior beyond documentation.
+- No website or OpenAPI contract changes.
+- No automatic pruning or encryption of replay artifacts.
+- No meta-tests that only walk `docs/reference` link graphs or assert file inventories without checking CLI output.
+- No removal of `authoring-factories` as the workflow-oriented entry point.
+
+## Technical Design
+
+### Packaged docs ownership
+
+Follow `docs/internal/development/packaged-cli-docs-surface.md`:
+
+1. Author canonical markdown under `docs/reference/`.
+2. Copy to `pkg/cli/docs/reference/`.
+3. Register in `topicDocuments` in `pkg/cli/docs/docs.go`.
+4. Update `pkg/cli/docs/docs_test.go`, root docs tests, and `cli_docs_smoke_test.go`.
+
+### Content extraction strategy
+
+- **mock-workers.md:** Customer guide focused on `--with-mock-workers`, optional path sentinel behavior (flag present without path uses empty config), JSON schema, matching semantics, run types, and example commands. Pull accurate field tables from existing `authoring-factories` section `## Test Workflows With Mock Workers` and `pkg/config` validation rules.
+- **record-replay.md:** Customer guide focused on CLI controls and artifact handling. Pull from existing `authoring-factories` step 3 record/replay bullets and customer-safe portions of `docs/internal/development/record-replay.md` (record paths, flags, sensitivity); omit maintainer test-promotion workflows.
+- **authoring-factories.md:** Keep the numbered workflow; replace long duplicated sections with 2–4 sentence summaries and links `you docs mock-workers` / `you docs record-replay`.
+
+### Display order
+
+Place new topics after `config` (display order ~25 and ~26) so run-mode references sit near configuration and before work-type reference material, or immediately after `authoring-factories` if that keeps workflow-adjacent topics grouped—implementers should pick one order, apply it consistently in `docs.go` and tests, and document the choice in the registration table comment if non-obvious.
+
+### Examples and paths
+
+Continue using repository-owned examples under `docs/examples/` (`mock-workers.json`, `startup-work.json`, `sample-run.replay.json`). Docs pages should show paths relative to a cloned repository for copy-paste and mention that installed-binary users can pass any local path for `--with-mock-workers` and replay artifacts.
+
+## Supporting Considerations
+
+- Keep `docs/examples/README.md` aligned if command examples change.
+- Update `docs/internal/processes/development-guide-relevant-files.md` only if the packaged-docs inventory row needs the new topic names (optional, same PR if touched).
+- `you run --help` remains the concise flag reference; packaged docs provide narrative and examples.
+- Replay artifacts are sensitive; both new topic and `record-replay` must warn customers not to commit real recordings.
+
+## Success Metrics
+
+- A customer can answer “how do I run with mock workers?” using only `you docs mock-workers` in under one minute.
+- A customer can answer “where did my recording go?” and “how do I replay it?” using only `you docs record-replay`.
+- Functional docs smoke tests pass from a clean temp directory without the repo `docs/` tree.
+- No increase in unsupported-topic confusion: canonical topic list in errors matches index.
+
+## Open Questions
+
+None. Scope, ownership split, and verification surfaces are defined by existing packaged-docs standards and current CLI behavior.

--- a/progress.txt
+++ b/progress.txt
@@ -2,6 +2,7 @@
 - Register new packaged `you docs` topics in the single `topicDocuments` table in `pkg/cli/docs/docs.go` with canonical name, description, `displayOrder`, path, and optional aliases together so `SupportedTopics()`, index output, and unsupported-topic errors stay aligned.
 - Keep `docs/reference/*.md` and `pkg/cli/docs/reference/*.md` synchronized when adding customer-facing packaged topics; embedded markdown is loaded from `pkg/cli/docs/reference/` via `//go:embed`.
 - When a new canonical topic is added, update hardcoded topic-order assertions in `pkg/cli/docs/docs_test.go`, `pkg/cli/root_docs_test.go`, and `tests/functional/smoke/cli_docs_smoke_test.go` unsupported-topic error expectations.
+- When trimming `authoring-factories` after new topics land, point readers at `you docs mock-workers` and `you docs record-replay` and update `TestMarkdown_AuthoringFactoriesReturnsRawAuthoredMarkdown` markers away from removed deep-dive strings.
 
 ## 2026-05-29T14:50:44Z - docs-extensions-mock-workers-and-record-001
 - What was implemented: Added canonical `mock-workers` packaged docs topic with synchronized reference markdown, `docs.go` registration at display order 25, and test expectation updates for topic order and unsupported-topic errors.
@@ -19,4 +20,13 @@
   - Patterns discovered: Record/replay customer content mirrors `authoring-factories.md` § Start the factory recording subsection; use `displayOrder` 26 immediately after `mock-workers` (25) before `work` (30).
   - Gotchas encountered: Incompatible-flag bullets use markdown backticks (`--record` with `--replay`); test markers must include those backticks when asserting exact phrases.
   - Useful context: `sample-run.replay.json` is referenced as an example path in docs but is not checked in; story 003 will add cross-links from config and trim authoring-factories duplication.
+---
+
+## 2026-05-29T16:05:00Z - docs-extensions-mock-workers-and-record-003
+- What was implemented: Trimmed duplicated mock-worker and record/replay depth from `authoring-factories`, added `Run Controls` brief mentions with canonical links in `config`, updated `docs/reference/README.md` packaged-topic table, and aligned `docs_test` authoring-factories markers with cross-links.
+- Files changed: `docs/reference/README.md`, `docs/reference/authoring-factories.md`, `docs/reference/config.md`, `pkg/cli/docs/reference/authoring-factories.md`, `pkg/cli/docs/reference/config.md`, `pkg/cli/docs/docs_test.go`
+- **Learnings for future iterations:**
+  - Patterns discovered: After extracting topics, replace deep sections with `you docs <topic>` pointers and keep only quick-start `you run` commands needed for the walkthrough; sync `docs/reference/authoring-factories.md` to `pkg/cli/docs/reference/` with `cp` when they must stay identical.
+  - Gotchas encountered: `TestMarkdown_AuthoringFactoriesReturnsRawAuthoredMarkdown` still asserted record/replay example commands removed from authoring-factories; update markers to `you docs mock-workers` / `you docs record-replay` when trimming.
+  - Useful context: Packaged `config` (`pkg/cli/docs/reference/config.md`) and layout `docs/reference/config.md` differ; both need run-control cross-links for story 003.
 ---

--- a/progress.txt
+++ b/progress.txt
@@ -1,0 +1,22 @@
+## Codebase Patterns
+- Register new packaged `you docs` topics in the single `topicDocuments` table in `pkg/cli/docs/docs.go` with canonical name, description, `displayOrder`, path, and optional aliases together so `SupportedTopics()`, index output, and unsupported-topic errors stay aligned.
+- Keep `docs/reference/*.md` and `pkg/cli/docs/reference/*.md` synchronized when adding customer-facing packaged topics; embedded markdown is loaded from `pkg/cli/docs/reference/` via `//go:embed`.
+- When a new canonical topic is added, update hardcoded topic-order assertions in `pkg/cli/docs/docs_test.go`, `pkg/cli/root_docs_test.go`, and `tests/functional/smoke/cli_docs_smoke_test.go` unsupported-topic error expectations.
+
+## 2026-05-29T14:50:44Z - docs-extensions-mock-workers-and-record-001
+- What was implemented: Added canonical `mock-workers` packaged docs topic with synchronized reference markdown, `docs.go` registration at display order 25, and test expectation updates for topic order and unsupported-topic errors.
+- Files changed: `docs/reference/mock-workers.md`, `pkg/cli/docs/reference/mock-workers.md`, `pkg/cli/docs/docs.go`, `pkg/cli/docs/docs_test.go`, `pkg/cli/root_docs_test.go`, `tests/functional/smoke/cli_docs_smoke_test.go`
+- **Learnings for future iterations:**
+  - Patterns discovered: New topics slot between existing `displayOrder` values (used 25 between config 20 and work 30); `TestMarkdown_ReturnsRawPackagedMarkdownForEachSupportedTopic` automatically covers new topics via `topicRegistry.ordered`.
+  - Gotchas encountered: `TestSupportedTopicCommands` and smoke unsupported-topic strings must include new canonical topics in deterministic order.
+  - Useful context: Mock-worker JSON contract and examples are consolidated from `authoring-factories.md` § Test Workflows With Mock Workers; story 003 will trim duplication there.
+---
+
+## 2026-05-29T15:12:00Z - docs-extensions-mock-workers-and-record-002
+- What was implemented: Added canonical `record-replay` packaged docs topic with synchronized reference markdown, `docs.go` registration at display order 26, focused `TestMarkdown_RecordReplayReturnsRawAuthoredMarkdown`, and topic-order expectation updates across docs and smoke tests.
+- Files changed: `docs/reference/record-replay.md`, `pkg/cli/docs/reference/record-replay.md`, `pkg/cli/docs/docs.go`, `pkg/cli/docs/docs_test.go`, `pkg/cli/root_docs_test.go`, `tests/functional/smoke/cli_docs_smoke_test.go`
+- **Learnings for future iterations:**
+  - Patterns discovered: Record/replay customer content mirrors `authoring-factories.md` § Start the factory recording subsection; use `displayOrder` 26 immediately after `mock-workers` (25) before `work` (30).
+  - Gotchas encountered: Incompatible-flag bullets use markdown backticks (`--record` with `--replay`); test markers must include those backticks when asserting exact phrases.
+  - Useful context: `sample-run.replay.json` is referenced as an example path in docs but is not checked in; story 003 will add cross-links from config and trim authoring-factories duplication.
+---

--- a/tests/functional/smoke/cli_docs_smoke_test.go
+++ b/tests/functional/smoke/cli_docs_smoke_test.go
@@ -22,8 +22,10 @@ type docsSmokeTopic struct {
 }
 
 var docsSmokeTopics = []docsSmokeTopic{
-	{name: "authoring-factories", heading: "# Authoring Factories", markers: []string{"factory.json", "workers/<name>/AGENTS.md", "workstations/<name>/AGENTS.md", "you run --dir ./factory --with-mock-workers", "--record ./docs/examples/sample-run.replay.json", "--replay ./docs/examples/sample-run.replay.json"}},
-	{name: "config", heading: "# Config", markers: []string{"factory.json", "workTypes", "supportingFiles", "bundledFiles", "share-time starter-work snapshots", "docs/reference/config.md", "docs/reference/work.md", "docs/reference/authoring-factories.md", "--with-mock-workers", "--record", "--replay", "--no-record", "you-agent-factory run"}, absent: []string{"Agent Factory run"}},
+	{name: "authoring-factories", heading: "# Authoring Factories", markers: []string{"factory.json", "workers/<name>/AGENTS.md", "workstations/<name>/AGENTS.md", "you run --dir ./factory --with-mock-workers", "you docs mock-workers", "you docs record-replay", "--no-record"}},
+	{name: "config", heading: "# Config", markers: []string{"factory.json", "workTypes", "supportingFiles", "bundledFiles", "share-time starter-work snapshots", "docs/reference/config.md", "docs/reference/work.md", "you docs mock-workers", "you docs record-replay", "you docs authoring-factories", "--with-mock-workers", "--record", "--replay", "--no-record", "you-agent-factory run"}, absent: []string{"Agent Factory run"}},
+	{name: "mock-workers", heading: "# Mock Workers", markers: []string{"--with-mock-workers", "mockWorkers", "runType", "accept", "reject", "script", "docs/examples/mock-workers.json", "docs/examples/startup-work.json"}},
+	{name: "record-replay", heading: "# Record and Replay", markers: []string{"--record", "--replay", "--no-record", "~/.you-agent-factory/recordings/", "docs/examples/sample-run.replay.json", "Recording saved:", "`--record` with `--replay`", "`--no-record` with `--record`"}},
 	{name: "work", heading: "# Factory JSON And Work Configuration", markers: []string{"work types, states, workers, workstations, resources, and routing", "supportingFiles", "## Work Types", "## Resources", "[Workstations](workstations.md)", "batch-inputs.md"}},
 	{name: "workstations", heading: "# Workstations Reference", markers: []string{"workstation authoring contract", "MODEL_WORKSTATION", "CLASSIFIER_WORKSTATION", "LOGICAL_MOVE"}},
 	{name: "workstation", heading: "# Workstations Reference", markers: []string{"workstation authoring contract", "MODEL_WORKSTATION", "CLASSIFIER_WORKSTATION", "LOGICAL_MOVE"}, absent: []string{"docs/reference/workstations-and-workers.md"}},
@@ -50,10 +52,10 @@ func TestAuthoringFactoriesDocs_LinkMockWorkerReplayExamplesFromCustomerPath(t *
 		"../examples/mock-workers.json",
 		"../examples/startup-work.json",
 		"../examples/README.md",
-		"--record ./docs/examples/sample-run.replay.json",
-		"--replay ./docs/examples/sample-run.replay.json",
+		"you docs mock-workers",
+		"you docs record-replay",
 		"--no-record",
-		"docs/internal/development/record-replay.md",
+		"record-replay.md",
 	} {
 		if !strings.Contains(doc, marker) {
 			t.Fatalf("authoring factories docs missing marker %q", marker)
@@ -75,7 +77,7 @@ func TestCLIDocsSmoke_PackagedTopicsRemainAvailableOutsideRepositoryDocsTree(t *
 	}
 
 	index := executeDocsSmokeCommand(t, workingDir, "docs")
-	for _, want := range []string{"# Docs", "`authoring-factories` - Practical factory authoring workflow", "`config` - Factory configuration", "`work` - Work types", "`batch-inputs` - Batch input files", "`workstations` - Workstation kinds", "`you docs authoring-factories`", "`you docs config`", "`you docs work`", "`you docs batch-inputs`", "`you docs workstations`"} {
+	for _, want := range []string{"# Docs", "`authoring-factories` - Practical factory authoring workflow", "`config` - Factory configuration", "`mock-workers` - Mock-worker runs", "`record-replay` - Record and replay run modes", "`work` - Work types", "`batch-inputs` - Batch input files", "`workstations` - Workstation kinds", "`you docs authoring-factories`", "`you docs config`", "`you docs mock-workers`", "`you docs record-replay`", "`you docs work`", "`you docs batch-inputs`", "`you docs workstations`"} {
 		if !strings.Contains(index, want) {
 			t.Fatalf("docs index missing %q:\n%s", want, index)
 		}

--- a/tests/functional/smoke/cli_docs_smoke_test.go
+++ b/tests/functional/smoke/cli_docs_smoke_test.go
@@ -97,7 +97,7 @@ func TestCLIDocsSmoke_PackagedTopicsRemainAvailableOutsideRepositoryDocsTree(t *
 		if err == nil {
 			t.Fatal("expected unsupported docs topic to fail")
 		}
-		if got := err.Error(); got != `unsupported docs topic "unknown" (supported: authoring-factories, config, mock-workers, work, workstations, workers, resources, models, batch-inputs, templates)` {
+		if got := err.Error(); got != `unsupported docs topic "unknown" (supported: authoring-factories, config, mock-workers, record-replay, work, workstations, workers, resources, models, batch-inputs, templates)` {
 			t.Fatalf("unexpected unsupported topic error %q", got)
 		}
 	})

--- a/tests/functional/smoke/cli_docs_smoke_test.go
+++ b/tests/functional/smoke/cli_docs_smoke_test.go
@@ -97,7 +97,7 @@ func TestCLIDocsSmoke_PackagedTopicsRemainAvailableOutsideRepositoryDocsTree(t *
 		if err == nil {
 			t.Fatal("expected unsupported docs topic to fail")
 		}
-		if got := err.Error(); got != `unsupported docs topic "unknown" (supported: authoring-factories, config, work, workstations, workers, resources, models, batch-inputs, templates)` {
+		if got := err.Error(); got != `unsupported docs topic "unknown" (supported: authoring-factories, config, mock-workers, work, workstations, workers, resources, models, batch-inputs, templates)` {
 			t.Fatalf("unexpected unsupported topic error %q", got)
 		}
 	})


### PR DESCRIPTION
{
  "project": "Packaged CLI Docs for Mock Workers and Record/Replay",
  "branchName": "ralph/docs-extensions-mock-workers-and-record",
  "description": "Add dedicated you docs mock-workers and record-replay packaged topics so customers can discover how to use --with-mock-workers, mock-workers JSON, and the --record / --replay / --no-record run controls from the installed binary, with cross-links from existing topics and CLI smoke coverage.",
  "context": {
    "customerAsk": "The current ./bin/you docs does not document how customers are supposed to use mock-workers or record/replay commands. Please add support for this.",
    "problem": "Mock-worker and record/replay guidance is buried inside the long authoring-factories topic and only summarized in config. you docs has no dedicated mock-workers or record-replay topics, so customers cannot discover complete command and JSON contract documentation from the installed CLI index.",
    "solution": "Introduce two new canonical packaged docs topics (mock-workers and record-replay) with synchronized docs/reference and pkg/cli/docs/reference markdown, register them in pkg/cli/docs/docs.go, cross-link from authoring-factories and config, and extend focused CLI and functional smoke tests so the topics are listed and render stable command guidance outside the repository docs tree."
  },
  "acceptanceCriteria": [
    "you docs lists mock-workers and record-replay with descriptions and you docs <topic> commands in the index.",
    "you docs mock-workers returns a complete customer guide for --with-mock-workers, optional config paths, the mockWorkers JSON contract, selection fields, runType values, and example commands referencing docs/examples/mock-workers.json.",
    "you docs record-replay returns a complete customer guide for default recording, generated artifact paths, --record, --replay, --no-record, sensitivity warnings, and incompatible flag combinations.",
    "authoring-factories and config cross-link to the new topics without contradicting you run --help; docs/reference and pkg/cli/docs/reference copies stay synchronized.",
    "Focused docs unit tests and functional cli_docs smoke tests prove index output and topic rendering from a working directory without a local docs tree.",
    "Typecheck, lint, and tests pass for all changed packages."
  ],
  "userStories": [
    {
      "id": "docs-extensions-mock-workers-and-record-001",
      "title": "Add mock-workers packaged docs topic",
      "description": "As a factory author, I want you docs mock-workers to print a complete mock-worker guide so I can test routing and outcomes without live provider calls.",
      "acceptanceCriteria": [
        "docs/reference/mock-workers.md and pkg/cli/docs/reference/mock-workers.md match and document enabling with you run --dir <factory> --with-mock-workers (optional path), empty-config default accept behavior, the mockWorkers JSON array, selection fields, runType values accept/reject/script with their config objects, and default accept when no entry matches.",
        "The page includes copy-pasteable you run commands and references docs/examples/mock-workers.json with a runnable example that uses docs/examples/startup-work.json when startup work is relevant.",
        "pkg/cli/docs/docs.go registers canonical topic mock-workers with display order, packaged path, and index description; SupportedTopics() and unsupported-topic errors include it in deterministic order.",
        "Running you docs lists mock-workers without listing compatibility aliases for it.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "docs-extensions-mock-workers-and-record-002",
      "title": "Add record-replay packaged docs topic",
      "description": "As a factory operator, I want you docs record-replay to explain record and replay run modes so I can capture, locate, and replay sensitive run artifacts safely.",
      "acceptanceCriteria": [
        "docs/reference/record-replay.md and pkg/cli/docs/reference/record-replay.md match and document default-on recording, generated paths under ~/.you-agent-factory/recordings/, session filename pattern, explicit --record, --replay, --no-record, Recording saved shutdown messaging, sensitivity warnings, no automatic retention cleanup in v1, and rejection of --record with --replay or --no-record with --record.",
        "The page distinguishes record mode (live run writes history) from replay mode (reads artifact instead of live worker dispatch) without requiring maintainer event-log detail.",
        "Includes copy-pasteable you run examples using docs/examples/sample-run.replay.json for explicit record and replay paths.",
        "pkg/cli/docs/docs.go registers canonical topic record-replay with display order, packaged path, and index description.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "docs-extensions-mock-workers-and-record-003",
      "title": "Cross-link existing packaged topics to new owners",
      "description": "As a customer reading you docs config or you docs authoring-factories, I want clear pointers to the dedicated mock-worker and record/replay guides so I do not have to search a long workflow page.",
      "acceptanceCriteria": [
        "config retains brief mentions of --with-mock-workers, --record, --replay, and --no-record but links to you docs mock-workers and you docs record-replay as canonical owners.",
        "authoring-factories keeps workflow sequencing but replaces duplicated deep mock-worker and record/replay sections with short summaries plus links to the new topics; quick-start commands for the review example remain.",
        "authoring-factories still links to docs/examples/README.md and example JSON files with repository-relative paths that work from the docs tree.",
        "docs/reference/README.md packaged-topic table includes mock-workers and record-replay with accurate scope descriptions.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "docs-extensions-mock-workers-and-record-004",
      "title": "Prove packaged CLI docs behavior for new topics",
      "description": "As a maintainer, I need automated checks that the installed docs command exposes the new topics reliably so regressions are caught before release.",
      "acceptanceCriteria": [
        "pkg/cli/docs/docs_test.go expects mock-workers and record-replay in supported-topic order, index markdown, and raw markdown markers for each new topic.",
        "pkg/cli/root_docs_test.go and other root-command docs tests list the new topics in help or unsupported-topic error text where applicable.",
        "tests/functional/smoke/cli_docs_smoke_test.go runs you docs mock-workers and you docs record-replay from a temp working directory without a local docs tree and asserts stable headings and command markers including --with-mock-workers, --record, --replay, --no-record, and example artifact paths.",
        "Unsupported-topic errors list all canonical topics including mock-workers and record-replay in deterministic order.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)