### PR TITLE
remove-trace-drilldown-hook-reexports-from-public

### DIFF
--- a/ui/src/features/bento/components/dashboard-bento-card-catalog.stories.tsx
+++ b/ui/src/features/bento/components/dashboard-bento-card-catalog.stories.tsx
@@ -26,10 +26,8 @@ import {
 } from "../../submit-work/components/submit-work-card";
 import { SubmitWorkWidget } from "../../submit-work/public";
 import { TerminalWorkWidget } from "../../terminal-work/public";
-import {
-  TraceDrilldownWidget,
-  type useTraceDrilldown,
-} from "../../trace-drilldown/public";
+import type { useTraceDrilldown } from "../../trace-drilldown/hooks/useTraceDrilldown";
+import { TraceDrilldownWidget } from "../../trace-drilldown/public";
 import type { WorkChartModel } from "../../work-outcome/lib/trends";
 import { WorkOutcomeWidget } from "../../work-outcome/public";
 import { WorkTotalsWidget } from "../../work-totals/public";

--- a/ui/src/features/bento/components/dashboard-bento-cards.tsx
+++ b/ui/src/features/bento/components/dashboard-bento-cards.tsx
@@ -16,10 +16,8 @@ import { SubmitWorkWidget } from "../../submit-work/public";
 import { getTerminalWorkMessages } from "../../terminal-work/messages/terminal-work";
 import { TerminalWorkWidget } from "../../terminal-work/public";
 import { getTraceDrilldownMessages } from "../../trace-drilldown/messages/trace-drilldown";
-import {
-  TraceDrilldownWidget,
-  type useTraceDrilldown,
-} from "../../trace-drilldown/public";
+import type { useTraceDrilldown } from "../../trace-drilldown/hooks/useTraceDrilldown";
+import { TraceDrilldownWidget } from "../../trace-drilldown/public";
 import { getWorkOutcomeMessages } from "../../work-outcome/messages/work-outcome";
 import {
   type useWorkOutcomeChart,

--- a/ui/src/features/bento/components/dashboard-bento.test.tsx
+++ b/ui/src/features/bento/components/dashboard-bento.test.tsx
@@ -167,16 +167,19 @@ vi.mock("../../timeline/state/factoryTimelineStore", () => ({
     }),
 }));
 
+vi.mock("../../trace-drilldown/hooks/useTraceDrilldown", () => ({
+  useTraceDrilldown: () => ({
+    selectedTrace: null,
+    traceGridState: { status: "empty" },
+  }),
+}));
+
 vi.mock("../../trace-drilldown/public", () => ({
   TraceDrilldownWidget: ({
     headerAction,
   }: {
     headerAction?: React.ReactNode;
   }) => <section>{headerAction}Trace card</section>,
-  useTraceDrilldown: () => ({
-    selectedTrace: null,
-    traceGridState: { status: "empty" },
-  }),
 }));
 
 vi.mock("../../work-outcome/public", () => ({

--- a/ui/src/features/bento/components/dashboard-bento.tsx
+++ b/ui/src/features/bento/components/dashboard-bento.tsx
@@ -12,7 +12,7 @@ import { useDashboardSessionStore } from "../../dashboard/state/dashboardSession
 import type { FactoryPngImportValue } from "../../import/lib/factory-png-import";
 import { DashboardImportPreviewDialog } from "../../import/public";
 import { useFactoryTimelineStore } from "../../timeline/state/factoryTimelineStore";
-import { useTraceDrilldown } from "../../trace-drilldown/public";
+import { useTraceDrilldown } from "../../trace-drilldown/hooks/useTraceDrilldown";
 import { useWorkOutcomeChart } from "../../work-outcome/public";
 import { useCurrentActivityImportController } from "../../workflow-activity/hooks/current-activity-import-controller";
 import {

--- a/ui/src/features/trace-drilldown/public/index.ts
+++ b/ui/src/features/trace-drilldown/public/index.ts
@@ -1,2 +1,1 @@
 export * from "../components/trace-drilldown-widget";
-export * from "../hooks/useTraceDrilldown";

--- a/ui/src/testing/app-shell-trace-follow-up-test-utils.tsx
+++ b/ui/src/testing/app-shell-trace-follow-up-test-utils.tsx
@@ -2,7 +2,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render } from "@testing-library/react";
 import type { FactoryEvent } from "../api/events";
 import { FACTORY_EVENT_TYPES } from "../api/events";
-import { TraceDrilldownWidget, useTraceDrilldown } from "../features/trace-drilldown/public";
+import { useTraceDrilldown } from "../features/trace-drilldown/hooks/useTraceDrilldown";
+import { TraceDrilldownWidget } from "../features/trace-drilldown/public";
 import { useFactoryTimelineStore } from "../features/timeline/state/factoryTimelineStore";
 
 export const activeWorkID = "work-active-story";


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/remove-trace-drilldown-hook-reexports-from-public",
  "description": "Remove useTraceDrilldown from the trace-drilldown public barrel and retarget bento, Storybook, and testing hook consumers to the owning hook module while keeping TraceDrilldownWidget as the public composition boundary. Dashboard trace card behavior must remain unchanged.",
  "context": {
    "customerAsk": "Continue removing unnecessary website re-exports. Stop forwarding useTraceDrilldown through ui/src/features/trace-drilldown/public/index.ts; retarget the exact bento, story, and testing consumers to the owning hook module; keep TraceDrilldownWidget on the public boundary for composition and trace follow-up tests.",
    "problem": "The trace-drilldown public barrel currently re-exports an internal hook that only bento internals, Storybook type fixtures, and testing helpers consume, blurring the intended widget-only public contract and encouraging cross-feature coupling through the wrong import surface.",
    "solution": "Retarget dashboard-bento.tsx, dashboard-bento-cards.tsx, dashboard-bento-card-catalog.stories.tsx, app-shell-trace-follow-up-test-utils.tsx, and dashboard-bento.test.tsx to import useTraceDrilldown (runtime and ReturnType typing) from ui/src/features/trace-drilldown/hooks/useTraceDrilldown; remove the hook re-export from trace-drilldown/public while preserving TraceDrilldownWidget exports and existing trace selection and grid behavior."
  },
  "acceptanceCriteria": [
    "ui/src/features/trace-drilldown/public/index.ts no longer re-exports useTraceDrilldown and still exports TraceDrilldownWidget",
    "ui/src/features/bento/components/dashboard-bento.tsx imports useTraceDrilldown from the owning hook module",
    "ui/src/features/bento/components/dashboard-bento-cards.tsx imports type useTraceDrilldown from the owning hook module and TraceDrilldownWidget from trace-drilldown/public",
    "ui/src/features/bento/components/dashboard-bento-card-catalog.stories.tsx retargets type useTraceDrilldown to the owning hook module while keeping TraceDrilldownWidget on the public boundary",
    "ui/src/testing/app-shell-trace-follow-up-test-utils.tsx imports useTraceDrilldown from the owning hook module and TraceDrilldownWidget from trace-drilldown/public",
    "dashboard-bento.test.tsx retargets hook mocks without weakening behavioral coverage; dashboard trace cards keep the same selection, expansion, and rendered trace behavior",
    "Typecheck, lint, bun run check:inline-component-class-usage, bun test ui/src/features/bento/components/dashboard-bento.test.tsx, and bun test ui/src/features/trace-drilldown/hooks/useTraceDrilldown.test.ts pass"
  ],
  "userStories": [
    {
      "id": "remove-trace-drilldown-hook-reexports-from-public-001",
      "title": "Retarget hook consumers to the owning module",
      "description": "As a dashboard maintainer, I want bento, Storybook, and testing code to import useTraceDrilldown from the trace-drilldown hook module so internal trace wiring does not depend on the public widget barrel.",
      "acceptanceCriteria": [
        "dashboard-bento.tsx imports useTraceDrilldown from ../../trace-drilldown/hooks/useTraceDrilldown instead of trace-drilldown/public",
        "dashboard-bento-cards.tsx imports type useTraceDrilldown from the owning hook module; TraceDrilldownWidget continues to import from trace-drilldown/public",
        "selectedTrace and traceGridState remain typed as ReturnType<typeof useTraceDrilldown> fields with no behavior change to card assembly",
        "dashboard-bento-card-catalog.stories.tsx imports type useTraceDrilldown from the owning hook module; TraceDrilldownWidget continues to import from trace-drilldown/public",
        "app-shell-trace-follow-up-test-utils.tsx imports useTraceDrilldown from the owning hook module and TraceDrilldownWidget from trace-drilldown/public",
        "dashboard-bento.test.tsx retargets its useTraceDrilldown mock to the owning hook module path while preserving the same empty-state trace grid model",
        "bun test ui/src/features/bento/components/dashboard-bento.test.tsx passes",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "remove-trace-drilldown-hook-reexports-from-public-002",
      "title": "Narrow the trace-drilldown public boundary to the widget only",
      "description": "As a feature maintainer, I want the trace-drilldown public barrel to expose only TraceDrilldownWidget so cross-feature consumers use the correct composition surface.",
      "acceptanceCriteria": [
        "ui/src/features/trace-drilldown/public/index.ts no longer re-exports useTraceDrilldown",
        "TraceDrilldownWidget remains exported and importable from dashboard-bento-cards.tsx, dashboard-bento-card-catalog.stories.tsx, and app-shell-trace-follow-up-test-utils.tsx",
        "No file under ui/src imports useTraceDrilldown from trace-drilldown/public",
        "bun test ui/src/features/trace-drilldown/hooks/useTraceDrilldown.test.ts passes",
        "bun run check:inline-component-class-usage passes",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)