### PR TITLE
remove-current-selection-provider-session-hook-relay-from-public

### DIFF
--- a/ui/src/features/bento/components/dashboard-bento-card-catalog.stories.tsx
+++ b/ui/src/features/bento/components/dashboard-bento-card-catalog.stories.tsx
@@ -15,8 +15,8 @@ import {
   CurrentSelectionWidget,
   useCurrentSelection,
   useCurrentSelectionDetails,
-  useSelectedProviderSessionState,
 } from "../../current-selection/public";
+import { useSelectedProviderSessionState } from "../../current-selection/work-selection/public";
 import { InlineAddWidgetCard } from "../../dashboard-add-card/components/inline-add-widget-card";
 import { ProviderSessionWidget } from "../../provider-session-detail/public";
 import {

--- a/ui/src/features/bento/components/dashboard-bento-cards.tsx
+++ b/ui/src/features/bento/components/dashboard-bento-cards.tsx
@@ -6,8 +6,8 @@ import {
   CurrentSelectionWidget,
   type useCurrentSelection,
   type useCurrentSelectionDetails,
-  type useSelectedProviderSessionState,
 } from "../../current-selection/public";
+import type { useSelectedProviderSessionState } from "../../current-selection/work-selection/public";
 import { InlineAddWidgetCard } from "../../dashboard-add-card/components/inline-add-widget-card";
 import { getProviderSessionWidgetMessages } from "../../provider-session-detail/messages/provider-session-widget";
 import { ProviderSessionWidget } from "../../provider-session-detail/public";

--- a/ui/src/features/bento/components/dashboard-bento.test.tsx
+++ b/ui/src/features/bento/components/dashboard-bento.test.tsx
@@ -49,33 +49,36 @@ const SHARED_SELECTED_SESSION: LoadableProviderSessionRef = {
   provider: "codex",
 };
 
-vi.mock("../../current-selection/public", async () => {
+vi.mock("../../current-selection/public", () => ({
+  CurrentSelectionWidget: ({
+    headerAction,
+    onSelectProviderSession,
+  }: {
+    headerAction?: React.ReactNode;
+    onSelectProviderSession?: (session: LoadableProviderSessionRef) => void;
+  }) => (
+    <section>
+      {headerAction}
+      <p>Current selection card</p>
+      <button
+        onClick={() => onSelectProviderSession?.(SHARED_SELECTED_SESSION)}
+        type="button"
+      >
+        Select shared provider session
+      </button>
+    </section>
+  ),
+  useCurrentSelection: () => currentSelectionState,
+  useCurrentSelectionDetails: () => ({
+    selectedWorkExecutionDetails: null,
+    selectedWorkRelationshipGraph: { status: "loading" as const },
+  }),
+}));
+
+vi.mock("../../current-selection/work-selection/public", async () => {
   const React = await vi.importActual<typeof import("react")>("react");
 
   return {
-    CurrentSelectionWidget: ({
-      headerAction,
-      onSelectProviderSession,
-    }: {
-      headerAction?: React.ReactNode;
-      onSelectProviderSession?: (session: LoadableProviderSessionRef) => void;
-    }) => (
-      <section>
-        {headerAction}
-        <p>Current selection card</p>
-        <button
-          onClick={() => onSelectProviderSession?.(SHARED_SELECTED_SESSION)}
-          type="button"
-        >
-          Select shared provider session
-        </button>
-      </section>
-    ),
-    useCurrentSelection: () => currentSelectionState,
-    useCurrentSelectionDetails: () => ({
-      selectedWorkExecutionDetails: null,
-      selectedWorkRelationshipGraph: { status: "loading" as const },
-    }),
     useSelectedProviderSessionState: () => {
       const [selectedProviderSession, setSelectedProviderSession] =
         React.useState<LoadableProviderSessionRef | null>(null);

--- a/ui/src/features/bento/components/dashboard-bento.tsx
+++ b/ui/src/features/bento/components/dashboard-bento.tsx
@@ -6,8 +6,8 @@ import { useAppLocale } from "../../../i18n";
 import {
   useCurrentSelection,
   useCurrentSelectionDetails,
-  useSelectedProviderSessionState,
 } from "../../current-selection/public";
+import { useSelectedProviderSessionState } from "../../current-selection/work-selection/public";
 import { useDashboardSessionStore } from "../../dashboard/state/dashboardSessionStore";
 import type { FactoryPngImportValue } from "../../import/lib/factory-png-import";
 import { DashboardImportPreviewDialog } from "../../import/public";

--- a/ui/src/features/current-selection/public/index.test.ts
+++ b/ui/src/features/current-selection/public/index.test.ts
@@ -14,7 +14,6 @@ describe("current-selection public barrel", () => {
       "CurrentSelectionWidget",
       "useCurrentSelection",
       "useCurrentSelectionDetails",
-      "useSelectedProviderSessionState",
     ]);
     expect("TerminalWorkDetail" in currentSelectionPublic).toBe(false);
   });

--- a/ui/src/features/current-selection/public/index.ts
+++ b/ui/src/features/current-selection/public/index.ts
@@ -1,8 +1,6 @@
 export * from "../components/current-selection-widget";
 export * from "../hooks/useCurrentSelection";
 export * from "../hooks/useCurrentSelectionDetails";
-export { useSelectedProviderSessionState } from "../work-selection/public";
-export type { SelectedProviderSessionState } from "../work-selection/public";
 export type {
   DashboardSelection,
   DashboardWorkItemSelection,


### PR DESCRIPTION
{
  "project": "Remove Current Selection Provider Session Hook Relay From Public",
  "branchName": "ralph/remove-current-selection-provider-session-hook-relay-from-public",
  "description": "Remove the unnecessary useSelectedProviderSessionState relay from current-selection/public, retarget bento consumers to work-selection/public, and keep dashboard provider-session selection behavior unchanged while preserving widget and core selection hook exports on the top-level barrel.",
  "context": {
    "customerAsk": "Keep removing unnecessary website re-exports and move toward direct imports where the public workflow allows. After PR #428, stop relaying useSelectedProviderSessionState through current-selection/public because work-selection/public already owns that hook.",
    "problem": "The top-level current-selection/public barrel still re-exports useSelectedProviderSessionState and SelectedProviderSessionState from work-selection/public, which duplicates ownership and leads bento dashboard code to depend on a grab-bag barrel instead of the owning module.",
    "solution": "Delete the hook-only relay from current-selection/public, retarget the three bento files to import from work-selection/public, update the public barrel contract test, and prove unchanged provider-session and dashboard composition with focused tests and a Storybook or dashboard spot check."
  },
  "acceptanceCriteria": [
    "current-selection/public no longer exports useSelectedProviderSessionState or SelectedProviderSessionState.",
    "dashboard-bento.tsx, dashboard-bento-cards.tsx, and dashboard-bento-card-catalog.stories.tsx import the provider-session hook and type from work-selection/public, not from current-selection/public.",
    "current-selection/public still exports CurrentSelectionWidget, useCurrentSelection, useCurrentSelectionDetails, and base/public selection contract types.",
    "Dashboard provider-session cross-card sharing and catalog story behavior match pre-change expectations in focused automated tests.",
    "current-selection/public/index.test.ts documents the narrowed runtime contract without the relayed hook.",
    "No compatibility shims or new barrel indirection are introduced.",
    "Typecheck, lint, and tests pass for all affected UI packages."
  ],
  "userStories": [
    {
      "id": "remove-current-selection-provider-session-hook-relay-from-public-001",
      "title": "Retarget bento to owning work-selection public surface",
      "description": "As a dashboard user, I want provider-session-dependent bento cards to keep sharing the same selected session state when I change selection, so cross-card behavior stays consistent after import cleanup.",
      "acceptanceCriteria": [
        "dashboard-bento.tsx, dashboard-bento-cards.tsx, and dashboard-bento-card-catalog.stories.tsx import useSelectedProviderSessionState and SelectedProviderSessionState (where used) from current-selection/work-selection/public, not from current-selection/public.",
        "No bento file imports the provider-session hook or type from current-selection/public.",
        "dashboard-bento.test.tsx still proves cross-card provider-session state sharing; mocks are updated only as needed for the new import paths.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "remove-current-selection-provider-session-hook-relay-from-public-002",
      "title": "Narrow current-selection public barrel contract",
      "description": "As a maintainer, I want the top-level current-selection/public barrel to expose only widget, core hooks, and selection contracts so module ownership stays obvious.",
      "acceptanceCriteria": [
        "ui/src/features/current-selection/public/index.ts removes re-exports of useSelectedProviderSessionState and SelectedProviderSessionState.",
        "The barrel still exports CurrentSelectionWidget, useCurrentSelection, useCurrentSelectionDetails, and selection contract types from base/public.",
        "ui/src/features/current-selection/public/index.test.ts expects runtime keys CurrentSelectionWidget, useCurrentSelection, and useCurrentSelectionDetails only.",
        "Contract type samples in index.test.ts still compile and validate selection shapes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "remove-current-selection-provider-session-hook-relay-from-public-003",
      "title": "Confirm dashboard provider-session behavior unchanged",
      "description": "As a maintainer, I need confidence that narrowing the public barrel did not regress dashboard provider-session composition or Storybook catalog scenarios.",
      "acceptanceCriteria": [
        "Focused Vitest runs pass for dashboard-bento.test.tsx, current-selection/public/index.test.ts, and work-selection/public/index.test.ts.",
        "No external feature imports useSelectedProviderSessionState from current-selection/public.",
        "Dashboard bento Storybook catalog stories that use provider-session state still render provider-session cards with selection-driven content unchanged from before this slice.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill (dashboard bento with provider-session cards and relevant Storybook catalog story)"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Verified 2026-05-29 UTC: focused Vitest (9 tests), tsc, build-storybook; no external useSelectedProviderSessionState imports from current-selection/public; dev-browser skill unavailable—Storybook static build used per website-component-cleanup-closeout pattern."
    }
  ]
}

Made with [Cursor](https://cursor.com)