### PR TITLE
remove-current-selection-hook-reexports-from-public

### DIFF
--- a/ui/src/features/bento/components/dashboard-bento-card-catalog.stories.tsx
+++ b/ui/src/features/bento/components/dashboard-bento-card-catalog.stories.tsx
@@ -11,11 +11,9 @@ import { DEFAULT_FACTORY_SESSION_ID } from "../../../api/session-routing";
 import { semanticWorkflowDashboardSnapshot } from "../../../components/dashboard/test-fixtures";
 import "../../../styles.css";
 import { expectNoPageHorizontalOverflow } from "../../../stories/dashboardStorySupport";
-import {
-  CurrentSelectionWidget,
-  useCurrentSelection,
-  useCurrentSelectionDetails,
-} from "../../current-selection/public";
+import { CurrentSelectionWidget } from "../../current-selection/public";
+import { useCurrentSelection } from "../../current-selection/hooks/useCurrentSelection";
+import { useCurrentSelectionDetails } from "../../current-selection/hooks/useCurrentSelectionDetails";
 import { useSelectedProviderSessionState } from "../../current-selection/work-selection/public";
 import { InlineAddWidgetCard } from "../../dashboard-add-card/components/inline-add-widget-card";
 import { ProviderSessionWidget } from "../../provider-session-detail/public";

--- a/ui/src/features/bento/components/dashboard-bento-cards.tsx
+++ b/ui/src/features/bento/components/dashboard-bento-cards.tsx
@@ -2,11 +2,9 @@ import type { ReactNode } from "react";
 
 import type { DashboardSnapshot } from "../../../api/dashboard/types";
 import { getCurrentSelectionShellMessages } from "../../current-selection/base/public";
-import {
-  CurrentSelectionWidget,
-  type useCurrentSelection,
-  type useCurrentSelectionDetails,
-} from "../../current-selection/public";
+import { CurrentSelectionWidget } from "../../current-selection/public";
+import type { useCurrentSelection } from "../../current-selection/hooks/useCurrentSelection";
+import type { useCurrentSelectionDetails } from "../../current-selection/hooks/useCurrentSelectionDetails";
 import type { useSelectedProviderSessionState } from "../../current-selection/work-selection/public";
 import { InlineAddWidgetCard } from "../../dashboard-add-card/components/inline-add-widget-card";
 import { getProviderSessionWidgetMessages } from "../../provider-session-detail/messages/provider-session-widget";

--- a/ui/src/features/bento/components/dashboard-bento.test.tsx
+++ b/ui/src/features/bento/components/dashboard-bento.test.tsx
@@ -68,7 +68,13 @@ vi.mock("../../current-selection/public", () => ({
       </button>
     </section>
   ),
+}));
+
+vi.mock("../../current-selection/hooks/useCurrentSelection", () => ({
   useCurrentSelection: () => currentSelectionState,
+}));
+
+vi.mock("../../current-selection/hooks/useCurrentSelectionDetails", () => ({
   useCurrentSelectionDetails: () => ({
     selectedWorkExecutionDetails: null,
     selectedWorkRelationshipGraph: { status: "loading" as const },

--- a/ui/src/features/bento/components/dashboard-bento.tsx
+++ b/ui/src/features/bento/components/dashboard-bento.tsx
@@ -3,10 +3,8 @@ import { useEffect } from "react";
 import type { DashboardSnapshot } from "../../../api/dashboard/types";
 import { DEFAULT_FACTORY_SESSION_ID } from "../../../api/session-routing";
 import { useAppLocale } from "../../../i18n";
-import {
-  useCurrentSelection,
-  useCurrentSelectionDetails,
-} from "../../current-selection/public";
+import { useCurrentSelection } from "../../current-selection/hooks/useCurrentSelection";
+import { useCurrentSelectionDetails } from "../../current-selection/hooks/useCurrentSelectionDetails";
 import { useSelectedProviderSessionState } from "../../current-selection/work-selection/public";
 import { useDashboardSessionStore } from "../../dashboard/state/dashboardSessionStore";
 import type { FactoryPngImportValue } from "../../import/lib/factory-png-import";

--- a/ui/src/features/current-selection/public/index.test.ts
+++ b/ui/src/features/current-selection/public/index.test.ts
@@ -9,11 +9,9 @@ import type {
 } from "./index";
 
 describe("current-selection public barrel", () => {
-  it("keeps the public runtime surface focused on the widget and hooks", () => {
+  it("keeps the public runtime surface focused on the widget", () => {
     expect(Object.keys(currentSelectionPublic).sort()).toEqual([
       "CurrentSelectionWidget",
-      "useCurrentSelection",
-      "useCurrentSelectionDetails",
     ]);
     expect("TerminalWorkDetail" in currentSelectionPublic).toBe(false);
   });

--- a/ui/src/features/current-selection/public/index.ts
+++ b/ui/src/features/current-selection/public/index.ts
@@ -1,6 +1,4 @@
 export * from "../components/current-selection-widget";
-export * from "../hooks/useCurrentSelection";
-export * from "../hooks/useCurrentSelectionDetails";
 export type {
   DashboardSelection,
   DashboardWorkItemSelection,


### PR DESCRIPTION
{
  "project": "Remove Current Selection Hook Re-Exports From Public",
  "branchName": "ralph/remove-current-selection-hook-reexports-from-public",
  "description": "Narrow the current-selection feature public barrel by removing useCurrentSelection and useCurrentSelectionDetails hook relays, retargeting bento to import those hooks from their owning modules, and keeping CurrentSelectionWidget plus explicit selection contract types on current-selection/public with unchanged dashboard selection behavior.",
  "context": {
    "customerAsk": "Continue removing unnecessary website re-exports and move toward direct imports where the public workflow allows it. For current-selection, stop forwarding useCurrentSelection and useCurrentSelectionDetails through the top-level public barrel while keeping the widget and selection contract exports.",
    "problem": "ui/src/features/current-selection/public/index.ts still re-exports useCurrentSelection and useCurrentSelectionDetails even though owning modules exist under hooks/. Bento is the only external runtime consumer and imports those hooks through the public barrel, which widens the supported cross-feature API beyond the intended widget and type boundary established by prior barrel cleanup (e.g. PR #429).",
    "solution": "Retarget bento components, stories, and tests to import selection hooks from ui/src/features/current-selection/hooks/*, remove the hook export lines from current-selection/public/index.ts, update the public barrel contract test to expect only CurrentSelectionWidget at runtime, and verify with focused bento and current-selection tests that selection-dependent dashboard behavior is unchanged."
  },
  "acceptanceCriteria": [
    "current-selection/public/index.ts no longer re-exports useCurrentSelection or useCurrentSelectionDetails and still exports CurrentSelectionWidget plus explicit selection contract types from base/public.",
    "Bento runtime and type imports for useCurrentSelection and useCurrentSelectionDetails resolve to ui/src/features/current-selection/hooks/*, not current-selection/public.",
    "current-selection/public/index.test.ts expects only CurrentSelectionWidget on the runtime public barrel and continues to prove selection contract types are importable.",
    "workflow-activity DashboardSelection type imports from current-selection/public remain unchanged.",
    "Focused bento and current-selection tests demonstrate unchanged selection-dependent dashboard composition after import retargeting.",
    "No compatibility shims, new barrel indirection, or unrelated current-selection submodule refactors are introduced.",
    "Typecheck, lint, and tests pass for all touched UI packages."
  ],
  "userStories": [
    {
      "id": "remove-current-selection-hook-reexports-from-public-001",
      "title": "Retarget bento selection hook imports to owning modules",
      "description": "As a dashboard user, I want the bento layout to keep reading current selection state the same way after imports move off the current-selection public barrel.",
      "acceptanceCriteria": [
        "dashboard-bento.tsx imports useCurrentSelection and useCurrentSelectionDetails from ../../current-selection/hooks/useCurrentSelection and ../../current-selection/hooks/useCurrentSelectionDetails (or equivalent established paths), not from current-selection/public.",
        "dashboard-bento-cards.tsx imports CurrentSelectionWidget from current-selection/public and imports hook symbols used for ReturnType typing from the owning hook modules.",
        "dashboard-bento-card-catalog.stories.tsx imports both hooks from the owning hook modules while keeping CurrentSelectionWidget from current-selection/public.",
        "dashboard-bento.test.tsx mocks the owning hook modules (or splits mocks so widget behavior still comes from current-selection/public) without weakening selection-state coverage.",
        "bun test ui/src/features/bento/components/dashboard-bento.test.tsx passes with the same selection-dependent assertions as before the import change.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "remove-current-selection-hook-reexports-from-public-002",
      "title": "Narrow the current-selection public runtime barrel",
      "description": "As a feature maintainer, I want current-selection/public to expose only the widget and shared selection contracts so cross-feature consumers do not treat internal hooks as a supported public API.",
      "acceptanceCriteria": [
        "ui/src/features/current-selection/public/index.ts removes export lines for useCurrentSelection and useCurrentSelectionDetails while keeping CurrentSelectionWidget and explicit type exports from ../base/public.",
        "ui/src/features/current-selection/public/index.test.ts expects Object.keys(currentSelectionPublic).sort() to equal [\"CurrentSelectionWidget\"] only.",
        "The contract-type test in index.test.ts still compiles and exercises DashboardSelection, DashboardWorkItemSelection, DashboardWorkstationRequestSelection, and StatePositionWorkItem from the public barrel.",
        "No workflow-activity import paths change for DashboardSelection types.",
        "bun test ui/src/features/current-selection/public/index.test.ts passes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "remove-current-selection-hook-reexports-from-public-003",
      "title": "Verify unchanged selection-dependent dashboard behavior",
      "description": "As a reviewer, I need direct test evidence that retargeting imports did not change how selection drives bento cards and related hook behavior.",
      "acceptanceCriteria": [
        "bun test ui/src/features/bento/components/dashboard-bento.test.tsx passes.",
        "bun test ui/src/features/current-selection/public/index.test.ts passes.",
        "bun test ui/src/features/current-selection/hooks/useCurrentSelection.test.tsx passes.",
        "No ui/src file imports useCurrentSelection or useCurrentSelectionDetails from current-selection/public except where the public barrel itself previously forwarded them (resolved: zero such consumer imports after retargeting).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)