### PR TITLE
inline-current-selection-header-actions-class

### DIFF
--- a/ui/scripts/inline-component-class-usage-allowlist.mjs
+++ b/ui/scripts/inline-component-class-usage-allowlist.mjs
@@ -5,7 +5,6 @@ export const allowlistedInlineComponentClassUsage = [
   "src/features/bento/components/agent-bento.tsx#BENTO_ITEM_CLASS",
   "src/features/bento/components/agent-bento.tsx#BENTO_CARD_TITLE_CLASS",
   "src/features/bento/components/agent-bento.tsx#BENTO_DRAG_HANDLE_CLASS",
-  "src/features/current-selection/base/components/current-selection-header-actions.tsx#CURRENT_SELECTION_HEADER_ACTIONS_CLASS",
   "src/features/export/components/export-factory-dialog.tsx#DIALOG_TITLE_CLASS",
   "src/features/export/components/export-factory-dialog.tsx#DIALOG_BODY_CLASS",
   "src/features/export/components/export-factory-dialog.tsx#DIALOG_FORM_CLASS",

--- a/ui/src/features/current-selection/base/components/current-selection-header-actions.tsx
+++ b/ui/src/features/current-selection/base/components/current-selection-header-actions.tsx
@@ -5,7 +5,6 @@ import {
   DashboardActionRow,
 } from "../../../../components/ui";
 
-const CURRENT_SELECTION_HEADER_ACTIONS_CLASS = "w-full justify-end";
 const CURRENT_SELECTION_HEADER_ACTIONS_GROUP_CLASS = "w-full justify-end";
 const CURRENT_SELECTION_ICON_CLASS = "size-4";
 
@@ -52,7 +51,7 @@ export function CurrentSelectionHeaderActions({
         </>
       }
       actionsClassName={CURRENT_SELECTION_HEADER_ACTIONS_GROUP_CLASS}
-      className={CURRENT_SELECTION_HEADER_ACTIONS_CLASS}
+      className="w-full justify-end"
     />
   );
 }


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/inline-current-selection-header-actions-class",
  "description": "Inline the single-use current-selection header actions row class on DashboardActionRow, remove the stale inline-class allowlist entry, and preserve existing undo/redo layout, accessibility, and interaction behavior in the selection detail shell.",
  "context": {
    "customerAsk": "As part of customer ask 1.5, inline `CURRENT_SELECTION_HEADER_ACTIONS_CLASS` directly into the JSX `className` on `DashboardActionRow` in `ui/src/features/current-selection/base/components/current-selection-header-actions.tsx`, remove only `src/features/current-selection/base/components/current-selection-header-actions.tsx#CURRENT_SELECTION_HEADER_ACTIONS_CLASS` from `ui/scripts/inline-component-class-usage-allowlist.mjs`, leave `CURRENT_SELECTION_HEADER_ACTIONS_GROUP_CLASS` and `CURRENT_SELECTION_ICON_CLASS` unchanged unless the inline-class checker requires otherwise, and keep scope limited to those two files without refactoring undo/redo icons or current-selection public barrels.",
    "problem": "The current-selection header actions component still defines a local class constant for a layout cluster that is used only once on `DashboardActionRow`, which conflicts with the repository guidance to keep single-use component class strings inline in JSX where allowed. The matching inline-class allowlist entry also remains, so the repository continues to track debt for an exception that should no longer exist after the cleanup.",
    "solution": "Set `className=\"w-full justify-end\"` directly on `DashboardActionRow`, delete the stale `CURRENT_SELECTION_HEADER_ACTIONS_CLASS` constant and allowlist entry, and verify through focused current-selection layout tests and `bun run check:inline-component-class-usage` that undo/redo layout, labels, disabled behavior, and history interactions remain unchanged."
  },
  "acceptanceCriteria": [
    "`ui/src/features/current-selection/base/components/current-selection-header-actions.tsx` no longer defines `CURRENT_SELECTION_HEADER_ACTIONS_CLASS`.",
    "`DashboardActionRow` in `CurrentSelectionHeaderActions` uses `className=\"w-full justify-end\"` inline in JSX with the same right-aligned full-width layout as before.",
    "Undo and redo controls preserve existing aria labels, disabled states, handlers, icon markup, and action-row layout behavior.",
    "`CURRENT_SELECTION_HEADER_ACTIONS_GROUP_CLASS` and `CURRENT_SELECTION_ICON_CLASS` remain unchanged unless the inline-class checker requires inlining them in the same pass.",
    "`ui/scripts/inline-component-class-usage-allowlist.mjs` no longer includes `src/features/current-selection/base/components/current-selection-header-actions.tsx#CURRENT_SELECTION_HEADER_ACTIONS_CLASS`.",
    "The implementation stays limited to the header actions component and the single allowlist entry and does not refactor undo/redo icons, change current-selection public barrels, or touch unrelated allowlist debt.",
    "Quality gate: `bun run check:inline-component-class-usage`, `bun test ui/src/features/current-selection/base/components/current-selection-detail-layout.test.tsx`, frontend typecheck, and relevant lint pass."
  ],
  "userStories": [
    {
      "id": "inline-current-selection-header-actions-class-001",
      "title": "Inline the header actions row class on DashboardActionRow",
      "description": "As a frontend maintainer, I want the current-selection header actions row to keep its single-use layout class string inline on DashboardActionRow so that the component follows the shared styling standard without changing user-visible behavior.",
      "acceptanceCriteria": [
        "`ui/src/features/current-selection/base/components/current-selection-header-actions.tsx` no longer defines `CURRENT_SELECTION_HEADER_ACTIONS_CLASS`.",
        "`DashboardActionRow` uses `className=\"w-full justify-end\"` directly in JSX.",
        "Undo and redo buttons keep the same aria labels, disabled states, click handlers, and icon-only presentation.",
        "The action row keeps the same right-aligned full-width layout, including existing `actionsClassName` behavior from `CURRENT_SELECTION_HEADER_ACTIONS_GROUP_CLASS`.",
        "`CURRENT_SELECTION_HEADER_ACTIONS_GROUP_CLASS` and `CURRENT_SELECTION_ICON_CLASS` are left unchanged unless the inline-class checker requires inlining them in the same pass.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "inline-current-selection-header-actions-class-002",
      "title": "Remove the stale allowlist entry and prove the cleanup",
      "description": "As a reviewer, I want the inline component class usage allowlist to stop carrying the header actions row exception once the class is inlined so that repository debt tracking matches the real component state.",
      "acceptanceCriteria": [
        "`ui/scripts/inline-component-class-usage-allowlist.mjs` no longer includes `src/features/current-selection/base/components/current-selection-header-actions.tsx#CURRENT_SELECTION_HEADER_ACTIONS_CLASS`.",
        "`bun run check:inline-component-class-usage` passes without reintroducing an exception for `current-selection-header-actions.tsx`.",
        "`bun test ui/src/features/current-selection/base/components/current-selection-detail-layout.test.tsx` passes and continues to prove unchanged undo/redo rendering and history behavior in the selection detail shell.",
        "The cleanup remains limited to the single stale allowlist entry and does not remove unrelated allowlist debt or broaden into other files.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)