### PR TITLE
time-standardization

### DIFF
--- a/ui/src/App.stories.tsx
+++ b/ui/src/App.stories.tsx
@@ -7,7 +7,7 @@ import {
   singleNodeDashboardSnapshot,
   twentyNodeDashboardSnapshot,
 } from "./components/dashboard/test-fixtures";
-import { formatTimeOfDay } from "./components/ui/formatters";
+import { formatLocalDateTime } from "./components/ui/formatters";
 import {
   resetSelectionHistoryStore,
   useSelectionHistoryStore,
@@ -893,7 +893,7 @@ export const DashboardImprovementsSmoke = {
     await expect(currentSelection.getByText("Active Story")).toBeVisible();
     await expect(
       currentSelection.getByText(
-        `Started at ${formatTimeOfDay("2026-04-08T12:00:01Z")}`,
+        `Started at ${formatLocalDateTime("2026-04-08T12:00:01Z", "Unavailable")}`,
       ),
     ).toBeVisible();
     expect(summaryDetails).not.toBeNull();

--- a/ui/src/components/ui/formatters.test.ts
+++ b/ui/src/components/ui/formatters.test.ts
@@ -89,19 +89,19 @@ describe("formatRelativeTimeFromISO", () => {
 });
 
 describe("formatTimeOfDay", () => {
-  it("formats ISO timestamps as local clock times for detail cards", () => {
-    expect(formatTimeOfDay("2026-04-10T18:16:00.000Z")).toBe(
-      new Intl.DateTimeFormat(undefined, {
-        hour: "numeric",
-        minute: "2-digit",
-      })
-        .format(Date.parse("2026-04-10T18:16:00.000Z"))
-        .replace(/\s/g, ""),
+  it("delegates valid ISO timestamps to the canonical local date-time formatter", () => {
+    const timestamp = "2026-04-10T18:16:00.000Z";
+    expect(formatTimeOfDay(timestamp)).toBe(
+      formatLocalDateTime(timestamp, "Unavailable"),
+    );
+    expect(formatTimeOfDay(timestamp, "zh-CN", "不可用")).toBe(
+      formatLocalDateTime(timestamp, "不可用", "zh-CN"),
     );
   });
 
-  it("falls back to the raw value for invalid timestamps", () => {
-    expect(formatTimeOfDay("not-a-date")).toBe("not-a-date");
+  it("returns the supplied unavailable label for invalid timestamps", () => {
+    expect(formatTimeOfDay("not-a-date")).toBe("Unavailable");
+    expect(formatTimeOfDay("not-a-date", "zh-CN", "不可用")).toBe("不可用");
   });
 });
 
@@ -130,12 +130,23 @@ describe("formatList", () => {
 });
 
 describe("formatLocalDateTime", () => {
-  it("formats ISO timestamps as local date-time values for customer-visible details", () => {
-    expect(formatLocalDateTime("2026-04-10T18:16:00.000Z", "Unavailable")).toBe(
+  const sampleTimestamp = "2026-04-10T18:16:00.000Z";
+
+  it("formats ISO timestamps as medium date plus short local time for the default locale", () => {
+    expect(formatLocalDateTime(sampleTimestamp, "Unavailable")).toBe(
       new Intl.DateTimeFormat(undefined, {
         dateStyle: "medium",
         timeStyle: "short",
-      }).format(Date.parse("2026-04-10T18:16:00.000Z")),
+      }).format(Date.parse(sampleTimestamp)),
+    );
+  });
+
+  it("formats ISO timestamps as medium date plus short local time for zh-CN", () => {
+    expect(formatLocalDateTime(sampleTimestamp, "不可用", "zh-CN")).toBe(
+      new Intl.DateTimeFormat("zh-CN", {
+        dateStyle: "medium",
+        timeStyle: "short",
+      }).format(Date.parse(sampleTimestamp)),
     );
   });
 

--- a/ui/src/components/ui/formatters.ts
+++ b/ui/src/components/ui/formatters.ts
@@ -6,7 +6,6 @@ import {
   formatDateTime,
   formatDuration,
   formatRelativeTime,
-  formatTime,
 } from "../../i18n/formatters";
 import { getSharedPrimitiveMessages } from "./messages/shared-primitives";
 
@@ -105,13 +104,13 @@ export function formatRelativeTimeFromISO(
   );
 }
 
+/** @deprecated Use formatLocalDateTime for absolute operational timestamps. */
 export function formatTimeOfDay(
   isoTimestamp: string,
   locale?: string | null,
+  unavailableLabel = "Unavailable",
 ): string {
-  return formatTime(isoTimestamp, locale, {
-    fallback: isoTimestamp,
-  }).replace(/\s/g, "");
+  return formatLocalDateTime(isoTimestamp, unavailableLabel, locale);
 }
 
 export function formatLocalDateTime(

--- a/ui/src/features/current-selection/components/work-time-presentation.locale.test.tsx
+++ b/ui/src/features/current-selection/components/work-time-presentation.locale.test.tsx
@@ -1,18 +1,18 @@
 import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { dashboardWorkstationRequestFixtures } from "../../components/dashboard/fixtures";
-import { semanticWorkflowDashboardSnapshot } from "../../components/dashboard/test-fixtures";
-import { formatLocalDateTime } from "../../components/ui/formatters";
-import { formatTime } from "../../i18n/formatters";
+import { dashboardWorkstationRequestFixtures } from "../../../components/dashboard/fixtures";
+import { semanticWorkflowDashboardSnapshot } from "../../../components/dashboard/test-fixtures";
+import { formatLocalDateTime } from "../../../components/ui/formatters";
+import { formatTime } from "../../../i18n/formatters";
 import {
   DETAIL_CARD_NOW,
   getSelectedWorkItemFixture,
-} from "./base/components/detail-card-test-helpers";
-import { CurrentSelectionLocaleProvider } from "./base/components/current-selection-locale";
-import { StateNodeDetailCard } from "./work-state-selection/components/state-node-detail";
-import { selectWorkItemExecutionDetails } from "./work-selection/state/executionDetails";
-import { WorkItemDetailCard } from "./work-selection/components/work-item-card";
+} from "../base/components/detail-card-test-helpers";
+import { CurrentSelectionLocaleProvider } from "../base/components/current-selection-locale";
+import { StateNodeDetailCard } from "../work-state-selection/components/state-node-detail";
+import { selectWorkItemExecutionDetails } from "../work-selection/state/executionDetails";
+import { WorkItemDetailCard } from "../work-selection/components/work-item-card";
 
 const sharedStartedAt = "2026-04-08T12:00:01Z";
 

--- a/ui/src/features/current-selection/work-state-selection/components/state-node-detail.test.tsx
+++ b/ui/src/features/current-selection/work-state-selection/components/state-node-detail.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { semanticWorkflowDashboardSnapshot } from "../../../../components/dashboard/test-fixtures";
 import { WIDGET_SUBTITLE_CLASS } from "../../../../components/ui/widget-frame";
-import { formatTimeOfDay } from "../../../../components/ui/formatters";
+import { formatLocalDateTime } from "../../../../components/ui/formatters";
 import { describe, expect, it, vi } from "vitest";
 import { CurrentSelectionLocaleProvider } from "../../base/components/current-selection-locale";
 import { StateNodeDetailCard } from "./state-node-detail";
@@ -58,8 +58,16 @@ describe("StateNodeDetailCard", () => {
     expect(screen.getByText("Active Story")).toBeTruthy();
     expect(screen.getByText("work-active-story")).toBeTruthy();
     expect(
-      screen.getByText(`Started at ${formatTimeOfDay(activeStoryStartedAt)}`),
+      screen.getByText(
+        `Started at ${formatLocalDateTime(activeStoryStartedAt, "Unavailable")}`,
+      ),
     ).toBeTruthy();
+    const startedAtTime = requireValue(
+      screen.getByText(/^Started at /).closest("time"),
+      "expected started-at time element",
+    );
+    expect(startedAtTime.getAttribute("dateTime")).toBe(activeStoryStartedAt);
+    expect(startedAtTime.getAttribute("title")).toBe(activeStoryStartedAt);
     expect(screen.queryByText("trace-active-story")).toBeNull();
     expect(screen.queryByText("story")).toBeNull();
   });
@@ -161,7 +169,9 @@ describe("StateNodeDetailCard", () => {
     expect(screen.getByText("Done Story")).toBeTruthy();
     expect(screen.getByText("work-done-story")).toBeTruthy();
     expect(
-      screen.getByText(`Started at ${formatTimeOfDay(doneStoryStartedAt)}`),
+      screen.getByText(
+        `Started at ${formatLocalDateTime(doneStoryStartedAt, "Unavailable")}`,
+      ),
     ).toBeTruthy();
     expect(screen.queryByText("trace-done-story")).toBeNull();
     expect(screen.queryByText(/^story$/)).toBeNull();
@@ -214,7 +224,9 @@ describe("StateNodeDetailCard", () => {
     expect(screen.getByText("Failed Story")).toBeTruthy();
     expect(screen.getByText("work-failed-story")).toBeTruthy();
     expect(
-      screen.getByText(`Started at ${formatTimeOfDay(failedStoryStartedAt)}`),
+      screen.getByText(
+        `Started at ${formatLocalDateTime(failedStoryStartedAt, "Unavailable")}`,
+      ),
     ).toBeTruthy();
     expect(screen.getByText("Failure reason")).toBeTruthy();
     expect(screen.getByText("provider_rate_limit")).toBeTruthy();
@@ -296,5 +308,36 @@ describe("StateNodeDetailCard", () => {
     expect(screen.queryByText("状态节点 ID")).toBeNull();
     expect(screen.getByText("当前工作")).toBeTruthy();
     expect(screen.getByText("在所选时间刻度，这个位置暂时没有记录到工作。")).toBeTruthy();
+  });
+
+  it("renders Started at with the same canonical formatter output as dispatch history for zh-CN", () => {
+    const snapshot = semanticWorkflowDashboardSnapshot;
+    const selectedState = snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
+      (place) => place.place_id === "story:implemented",
+    );
+
+    const resolvedSelectedState = requireValue(selectedState, "expected implemented state fixture");
+
+    render(
+      <CurrentSelectionLocaleProvider locale="zh-CN">
+        <StateNodeDetailCard
+          currentWorkItems={[
+            {
+              display_name: "Active Story",
+              started_at: activeStoryStartedAt,
+              work_id: "work-active-story",
+            },
+          ]}
+          place={resolvedSelectedState}
+          tokenCount={1}
+        />
+      </CurrentSelectionLocaleProvider>,
+    );
+
+    expect(
+      screen.getByText(
+        `开始时间 ${formatLocalDateTime(activeStoryStartedAt, "不可用", "zh-CN")}`,
+      ),
+    ).toBeTruthy();
   });
 });

--- a/ui/src/features/current-selection/work-state-selection/components/state-node-detail.tsx
+++ b/ui/src/features/current-selection/work-state-selection/components/state-node-detail.tsx
@@ -1,5 +1,5 @@
 import {
-  formatTimeOfDay,
+  formatLocalDateTime,
   formatWorkItemLabel,
 } from "../../../../components/ui/formatters";
 import { formatDashboardPlaceLabel } from "../../../../components/ui/place-labels";
@@ -131,7 +131,8 @@ function StatePositionWorkListItem({
           dateTime={startedAt}
           title={startedAt}
         >
-          {messages.startedAtLabel} {formatTimeOfDay(startedAt, locale)}
+          {messages.startedAtLabel}{" "}
+          {formatLocalDateTime(startedAt, messages.timestampUnavailable, locale)}
         </time>
       ) : null}
       {hasFailureReason || hasFailureMessage ? (

--- a/ui/src/features/current-selection/work-state-selection/lib/detail-card-types.ts
+++ b/ui/src/features/current-selection/work-state-selection/lib/detail-card-types.ts
@@ -10,6 +10,7 @@ export interface StatePositionWorkListProps {
     | "failureReasonLabel"
     | "startedAtLabel"
     | "selectWorkItemLabel"
+    | "timestampUnavailable"
   >;
   onSelectWorkItem?: (workItem: StatePositionWorkItem) => void;
   workItems: StatePositionWorkItem[];

--- a/ui/src/features/current-selection/work-time-presentation.locale.test.tsx
+++ b/ui/src/features/current-selection/work-time-presentation.locale.test.tsx
@@ -1,0 +1,158 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { dashboardWorkstationRequestFixtures } from "../../components/dashboard/fixtures";
+import { semanticWorkflowDashboardSnapshot } from "../../components/dashboard/test-fixtures";
+import { formatLocalDateTime } from "../../components/ui/formatters";
+import { formatTime } from "../../i18n/formatters";
+import {
+  DETAIL_CARD_NOW,
+  getSelectedWorkItemFixture,
+} from "./base/components/detail-card-test-helpers";
+import { CurrentSelectionLocaleProvider } from "./base/components/current-selection-locale";
+import { StateNodeDetailCard } from "./work-state-selection/components/state-node-detail";
+import { selectWorkItemExecutionDetails } from "./work-selection/state/executionDetails";
+import { WorkItemDetailCard } from "./work-selection/components/work-item-card";
+
+const sharedStartedAt = "2026-04-08T12:00:01Z";
+
+const localeCases = [
+  {
+    locale: "en" as const,
+    unavailableLabel: "Unavailable",
+    startedAtLabel: "Started at",
+    dispatchHistoryRegion: "Workstation dispatches",
+  },
+  {
+    locale: "zh-CN" as const,
+    unavailableLabel: "不可用",
+    startedAtLabel: "开始时间",
+    dispatchHistoryRegion: "工作站分派",
+  },
+] as const;
+
+function getDetailRow(container: HTMLElement, label: string): HTMLElement {
+  const term = within(container).getByText(label, { selector: "dt" });
+  const row = term.closest("div");
+
+  if (!(row instanceof HTMLElement)) {
+    throw new Error(`expected detail row for ${label}`);
+  }
+
+  return row;
+}
+
+function requireValue<T>(value: T | null | undefined, message: string): T {
+  if (value === null || value === undefined) {
+    throw new Error(message);
+  }
+
+  return value;
+}
+
+function renderWorkStateStartedAt(locale: (typeof localeCases)[number]["locale"]): string {
+  const snapshot = semanticWorkflowDashboardSnapshot;
+  const selectedState = snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
+    (place) => place.place_id === "story:implemented",
+  );
+
+  render(
+    <CurrentSelectionLocaleProvider locale={locale}>
+      <StateNodeDetailCard
+        currentWorkItems={[
+          {
+            display_name: "Active Story",
+            started_at: sharedStartedAt,
+            work_id: "work-active-story",
+          },
+        ]}
+        place={requireValue(selectedState, "expected implemented state fixture")}
+        tokenCount={1}
+      />
+    </CurrentSelectionLocaleProvider>,
+  );
+
+  const unavailableLabel = locale === "zh-CN" ? "不可用" : "Unavailable";
+  const expected = formatLocalDateTime(sharedStartedAt, unavailableLabel, locale);
+  const startedAtPrefix = locale === "zh-CN" ? "开始时间 " : "Started at ";
+
+  expect(screen.getByText(`${startedAtPrefix}${expected}`)).toBeTruthy();
+
+  return expected;
+}
+
+function renderDispatchStartedAt(
+  locale: (typeof localeCases)[number]["locale"],
+  startedAtLabel: string,
+  dispatchHistoryRegion: string,
+): string {
+  const { dispatchID, execution, selectedNode, workItem } = getSelectedWorkItemFixture();
+  const unavailableLabel = locale === "zh-CN" ? "不可用" : "Unavailable";
+  const expected = formatLocalDateTime(sharedStartedAt, unavailableLabel, locale);
+
+  render(
+    <CurrentSelectionLocaleProvider locale={locale}>
+      <WorkItemDetailCard
+        dispatchAttempts={[]}
+        executionDetails={selectWorkItemExecutionDetails({
+          activeExecution: execution,
+          dispatchID,
+          selectedNode,
+          workItem,
+        })}
+        now={DETAIL_CARD_NOW}
+        selectedNode={selectedNode}
+        selection={{
+          dispatchId: dispatchID,
+          execution,
+          kind: "work-item",
+          nodeId: selectedNode.node_id,
+          workItem,
+        }}
+        workstationRequests={[dashboardWorkstationRequestFixtures.ready]}
+      />
+    </CurrentSelectionLocaleProvider>,
+  );
+
+  const dispatchCard = within(screen.getByRole("region", { name: dispatchHistoryRegion }))
+    .getByText("Active Story", { selector: "strong" })
+    .closest("article");
+
+  if (!(dispatchCard instanceof HTMLElement)) {
+    throw new Error("expected dispatch history card");
+  }
+
+  expect(
+    within(getDetailRow(dispatchCard, startedAtLabel)).getByText(expected),
+  ).toBeTruthy();
+
+  return expected;
+}
+
+describe("work time presentation locale regression", () => {
+  it.each(localeCases)(
+    "renders the same canonical Started at output on work-state and dispatch surfaces for $locale",
+    ({ locale, unavailableLabel, startedAtLabel, dispatchHistoryRegion }) => {
+      const expected = formatLocalDateTime(
+        sharedStartedAt,
+        unavailableLabel,
+        locale,
+      );
+      const hourOnly = formatTime(sharedStartedAt, locale);
+
+      expect(expected).not.toBe(hourOnly);
+
+      const workStateStartedAt = renderWorkStateStartedAt(locale);
+      const dispatchStartedAt = renderDispatchStartedAt(
+        locale,
+        startedAtLabel,
+        dispatchHistoryRegion,
+      );
+
+      expect(workStateStartedAt).toBe(expected);
+      expect(dispatchStartedAt).toBe(expected);
+      expect(workStateStartedAt).toBe(dispatchStartedAt);
+      expect(workStateStartedAt).not.toBe(hourOnly);
+    },
+  );
+});


### PR DESCRIPTION
{
  "project": "Current-Selection Work Time Standardization",
  "branchName": "ralph/time-standardization",
  "description": "Unify current-selection work timestamp presentation so work-state selection shows the same localized date-and-time as work-item and dispatch surfaces, using one shared formatter instead of hour-only display.",
  "context": {
    "customerAsk": "The current work-state selection representation shows times using only hour and minute, but we want day and month exposed the same way as work-item current selection. Apply the same treatment to all other work time representations and consolidate to a single localization function for time presentation.",
    "problem": "Work-state detail cards use formatTimeOfDay (clock time only) while work-item execution, dispatch history, and inference rows use formatLocalDateTime (medium date plus short time). Operators cannot compare timings across current-selection modes without guessing the calendar day, and two formatters diverge on invalid-input fallback behavior.",
    "solution": "Standardize covered current-selection absolute work timestamps on the existing formatLocalDateTime / getLocalDateTimeDisplay path backed by i18n formatDateTime, migrate work-state selection off formatTimeOfDay, align remaining call sites and stories, and prove consistency with formatter, component, and locale regression tests."
  },
  "acceptanceCriteria": [
    "Work-state selection Started at timestamps show the same localized date-and-time pattern as work-item and dispatch Started at values for the same ISO instant and locale.",
    "All covered current-selection absolute work timestamps render through the single canonical formatter entry point; no work surface uses formatTimeOfDay or ad hoc Intl/formatTime for absolute timestamps.",
    "Invalid or missing timestamps on covered surfaces use explicit unavailable copy or omit the row; raw ISO strings do not appear as the primary display value.",
    "Locale regression tests prove representative English and Chinese outputs for work-state and work-item/dispatch surfaces sharing the same underlying timestamp.",
    "Quality gate: frontend typecheck, lint, and relevant UI tests pass before merge."
  ],
  "userStories": [
    {
      "id": "time-standardization-001",
      "title": "Canonical work timestamp formatter",
      "description": "As a maintainer, I want one shared localization entry point for absolute work timestamps so presentation rules live in one place.",
      "acceptanceCriteria": [
        "ui/src/components/ui/formatters.ts exposes one canonical function for absolute operational timestamps (formatLocalDateTime) backed by formatDateTime with dateStyle medium and timeStyle short.",
        "formatTimeOfDay is removed or delegates to the canonical formatter; no new call sites use hour-only formatting for work timestamps.",
        "Formatter unit tests prove valid ISO input renders medium date plus short local time for default and zh-CN locales, and invalid or missing input returns the supplied unavailable label.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "time-standardization-002",
      "title": "Work-state selection shows full local date-time",
      "description": "As an operator reviewing work-state selection, I want Started at to include day and month so I can correlate state timing with dispatch and work-item details.",
      "acceptanceCriteria": [
        "StateNodeDetail renders Started at through the canonical work timestamp formatter with the active UI locale.",
        "For started_at 2026-04-08T12:00:01Z, the rendered label matches formatLocalDateTime output used by work-item dispatch history for the same locale, not clock-only text.",
        "The time element keeps dateTime and title set to the raw ISO value.",
        "StateNodeDetail component tests assert full date-time strings and no longer import formatTimeOfDay.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "time-standardization-003",
      "title": "Align remaining current-selection work timestamp call sites",
      "description": "As an operator, I want every work-related absolute timestamp in current selection to follow the same display rules so the panel feels cohesive.",
      "acceptanceCriteria": [
        "Covered surfaces use only the canonical formatter or getLocalDateTimeDisplay: execution-details, selected-work-dispatch-history-card, inference-attempt, and workstation request detail timestamp rows.",
        "App.stories.tsx and other current-selection fixtures that referenced formatTimeOfDay are updated to canonical formatter output.",
        "No formatTimeOfDay or direct formatTime( usage for absolute work timestamps remains under ui/src/features/current-selection.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "time-standardization-004",
      "title": "Locale regression for work time presentation",
      "description": "As a customer using localized UI, I want work-state and work-item timestamps to stay consistent when switching locale.",
      "acceptanceCriteria": [
        "Locale regression tests assert the same ISO instant produces matching canonical formatter output on work-state detail and work-item or dispatch Started at rows for en and zh-CN.",
        "Tests fail if work-state selection reverts to hour-only formatting while work-item selection shows full date-time.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)