### PR TITLE
inline-work-chart-region-class

### DIFF
--- a/ui/scripts/inline-component-class-usage-allowlist.mjs
+++ b/ui/scripts/inline-component-class-usage-allowlist.mjs
@@ -59,7 +59,6 @@ export const allowlistedInlineComponentClassUsage = [
   "src/features/trace-drilldown/components/trace-grid-card.tsx#TRACE_WORK_ITEM_BUTTON_CLASS",
   "src/features/trace-drilldown/components/trace-relation-flow.tsx#GRAPH_SHELL_CLASS",
   "src/features/trace-drilldown/components/trace-workstation-path.tsx#GRAPH_SHELL_CLASS",
-  "src/features/work-outcome/components/d3-information-card.tsx#WORK_CHART_REGION_CLASS",
   "src/features/work-outcome/components/trend-cards.tsx#TREND_TOOLBAR_CLASS",
   "src/features/work-outcome/components/trend-cards.tsx#TREND_RANGE_LABEL_CLASS",
   "src/features/work-outcome/components/trend-cards.tsx#TREND_RANGE_TEXT_CLASS",

--- a/ui/src/features/work-outcome/components/d3-information-card.tsx
+++ b/ui/src/features/work-outcome/components/d3-information-card.tsx
@@ -20,7 +20,6 @@ export interface WorkChartCardProps {
 
 const WORK_CHART_BODY_CLASS =
   "!flex !min-h-0 !flex-col !gap-0 !overflow-hidden px-0 pb-5";
-const WORK_CHART_REGION_CLASS = "flex min-h-0 flex-1 px-4 sm:px-5";
 
 export function WorkChartCard({
   chartState,
@@ -67,7 +66,7 @@ export function WorkChartCard({
     >
       <section
         aria-label={chartMessages.cardRegionLabel}
-        className={WORK_CHART_REGION_CLASS}
+        className="flex min-h-0 flex-1 px-4 sm:px-5"
         id={chartRegionID}
       >
         <WorkChart


### PR DESCRIPTION
{
  "project": "Inline Work Chart Region Class",
  "branchName": "ralph/inline-work-chart-region-class",
  "description": "Inline WORK_CHART_REGION_CLASS directly into the chart region section JSX in d3-information-card.tsx, remove the matching inline-component-class allowlist entry, and prove chart region layout and accessibility behavior are unchanged through work-outcome component tests and the inline-class usage checker.",
  "context": {
    "customerAsk": "Customer ask 1.5 is to stop declaring component classes separately from JSX and shrink the inline-class allowlist through exact component-level follow-ups. Inline WORK_CHART_REGION_CLASS on the chart region section in d3-information-card.tsx and remove its allowlist entry.",
    "problem": "WorkChartCard still uses a local WORK_CHART_REGION_CLASS constant solely for one chart region className, keeping an unnecessary allowlist exception and separating styling from JSX without any reuse benefit.",
    "solution": "Remove WORK_CHART_REGION_CLASS, set className=\"flex min-h-0 flex-1 px-4 sm:px-5\" on the chart region section, delete the matching allowlist entry, leave WORK_CHART_BODY_CLASS unchanged unless the checker requires otherwise, and verify behavior with existing d3-information-card tests plus npm run check:inline-component-class-usage from ui/."
  },
  "acceptanceCriteria": [
    "WORK_CHART_REGION_CLASS no longer exists in ui/src/features/work-outcome/components/d3-information-card.tsx.",
    "The chart region section renders with className=\"flex min-h-0 flex-1 px-4 sm:px-5\" and unchanged aria-label and id behavior.",
    "WORK_CHART_BODY_CLASS remains unchanged in this slice unless the inline-class checker requires inlining it in the same pass.",
    "The allowlist entry src/features/work-outcome/components/d3-information-card.tsx#WORK_CHART_REGION_CLASS is removed from ui/scripts/inline-component-class-usage-allowlist.mjs.",
    "npm run check:inline-component-class-usage from ui/ passes with no violations for d3-information-card.tsx.",
    "Focused work-outcome component tests for WorkChartCard and D3CompletionInformationCard continue to pass and assert chart region layout classes and accessibility label.",
    "Repository quality gate passes: frontend typecheck, lint, and relevant tests are green."
  ],
  "userStories": [
    {
      "id": "inline-work-chart-region-class-001",
      "title": "Inline chart region class in WorkChartCard",
      "description": "As a dashboard user, I want the work outcome chart card region to keep the same layout and accessibility semantics so resizing and chart rendering behave exactly as before while maintainers colocate styling with JSX.",
      "acceptanceCriteria": [
        "Remove the WORK_CHART_REGION_CLASS constant from ui/src/features/work-outcome/components/d3-information-card.tsx",
        "Set the chart region section to className=\"flex min-h-0 flex-1 px-4 sm:px-5\"",
        "Leave WORK_CHART_BODY_CLASS unchanged unless the inline-class checker fails without inlining it in the same pass",
        "The chart region section keeps its existing aria-label={chartMessages.cardRegionLabel} and id={chartRegionID} wiring",
        "Focused tests in ui/src/features/work-outcome/components/d3-information-card.test.tsx that render D3CompletionInformationCard or WorkChartCard find the chart region by accessibility label and assert the inlined layout classes flex, flex-1, min-h-0, px-4, and sm:px-5",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "inline-work-chart-region-class-002",
      "title": "Remove allowlist entry and confirm inline-class governance",
      "description": "As a maintainer, I want the inline-component-class allowlist to shrink for d3-information-card.tsx so new separate-class constants cannot reappear without an explicit exception.",
      "acceptanceCriteria": [
        "Remove src/features/work-outcome/components/d3-information-card.tsx#WORK_CHART_REGION_CLASS from ui/scripts/inline-component-class-usage-allowlist.mjs and no other entries in this slice",
        "Running npm run check:inline-component-class-usage from ui/ exits successfully with no violations reported for d3-information-card.tsx",
        "No changes are made to work-chart.tsx allowlist entries, queued notifications cleanups, or work-outcome public re-export cleanups",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)