### PR TITLE
inline-workflow-activity-bento-card-class

### DIFF
--- a/prd.json
+++ b/prd.json
@@ -1,30 +1,30 @@
 {
-  "project": "OpenCode Agent Support",
-  "branchName": "ralph/opencode-agent-support",
-  "description": "Let factory authors select OpenCode agent profiles via openCodeAgent on workers and workstations, forward the resolved name through ProviderInferenceRequest, pass opencode run --agent during OpenCode dispatch, surface the value in inference diagnostics, align factory OpenAPI shapes, document the field, and prove the behavior with backend tests.",
+  "project": "Inline Workflow Activity Bento Card Graph Panel Shell Class",
+  "branchName": "ralph/inline-workflow-activity-bento-card-class",
+  "description": "Inline the single-use GRAPH_PANEL_SHELL_CLASS constant directly on the workflow-activity bento card graph panel shell section, remove the matching inline-class allowlist exception, and prove layout and card behavior are unchanged through focused component tests and the inline-class guard.",
   "context": {
-    "customerAsk": "Add agent support for OpenCode using the OpenCode CLI documentation (https://opencode.ai/docs/cli/), including corresponding backend tests.",
-    "problem": "The opencode runner invokes opencode run without the --agent flag, factory config has no openCodeAgent field, and inference diagnostics do not record which OpenCode agent profile was requested even though the CLI supports named agents.",
-    "solution": "Add openCodeAgent to worker and workstation configuration with workstation override precedence, validate it against resolved runner opencode, populate ProviderInferenceRequest.OpenCodeAgent, append --agent to opencode run in openCodeProviderBehavior, record opencode_agent in request metadata, extend OpenAPI factory schemas, update reference docs, and add backend tests for command construction, dispatch wiring, and misconfiguration errors."
+    "customerAsk": "Inline GRAPH_PANEL_SHELL_CLASS directly on the JSX className and remove the matching allowlist entry while preserving workflow-activity bento card layout.",
+    "problem": "workflow-activity-bento-card.tsx still declares GRAPH_PANEL_SHELL_CLASS as a module constant used only once on the graph panel shell section, which keeps an unnecessary inline-component-class allowlist exception alive without improving reuse or readability.",
+    "solution": "Move the relative h-full min-h-0 min-w-0 class string onto the graph panel shell section className, delete the constant, remove the allowlist entry, and verify unchanged card behavior with focused WorkflowActivityBentoCard tests plus bun run check:inline-component-class-usage."
   },
   "acceptanceCriteria": [
-    "Worker or workstation openCodeAgent with resolved runner opencode dispatches opencode run with --agent <name> before the user prompt.",
-    "Omitting openCodeAgent leaves existing OpenCode dispatch behavior unchanged.",
-    "Setting openCodeAgent when the resolved runner is not opencode fails before subprocess start with a clear configuration error.",
-    "Inference request diagnostics include opencode_agent when an agent was configured.",
-    "OpenAPI worker and workstation schemas accept openCodeAgent and round-trip through config load and projection.",
-    "Reference docs describe openCodeAgent, precedence, and opencode agent list discovery.",
-    "Repository quality gate passes: typecheck, lint, and affected backend and UI test suites are green."
+    "GRAPH_PANEL_SHELL_CLASS no longer exists in ui/src/features/workflow-activity/components/workflow-activity-bento-card.tsx.",
+    "The graph panel shell section renders with relative h-full min-h-0 min-w-0 in the DOM.",
+    "The allowlist entry src/features/workflow-activity/components/workflow-activity-bento-card.tsx#GRAPH_PANEL_SHELL_CLASS is removed from ui/scripts/inline-component-class-usage-allowlist.mjs.",
+    "bun run check:inline-component-class-usage --cwd ui passes with no stale allowlist entries.",
+    "Focused WorkflowActivityBentoCard tests pass with no changes to graph editor wiring, selection behavior, or card composition.",
+    "Repository quality gate passes: UI typecheck, lint, and affected tests are green."
   ],
   "userStories": [
     {
-      "id": "opencode-agent-support-001",
-      "title": "Author OpenCode agent names in factory config",
-      "description": "As a factory author, I want to declare which OpenCode agent profile a worker or workstation should use so I can reuse agents I created with opencode agent create without duplicating prompts in infinite-you.",
+      "id": "inline-workflow-activity-bento-card-class-001",
+      "title": "Inline graph panel shell classes on WorkflowActivityBentoCard",
+      "description": "As a dashboard user, I want the workflow-activity bento card graph panel shell to keep the same flex-safe layout classes so the embedded React Flow graph still fills the card without overflow regressions.",
       "acceptanceCriteria": [
-        "Worker AGENTS.md frontmatter accepts optional openCodeAgent as a non-empty string.",
-        "Workstation AGENTS.md frontmatter accepts optional openCodeAgent that overrides the worker default when both are set.",
-        "Loaded runtime worker and workstation config retain the resolved openCodeAgent value through factory build.",
+        "Remove the GRAPH_PANEL_SHELL_CLASS module constant from workflow-activity-bento-card.tsx.",
+        "Set the graph panel shell section className directly to \"relative h-full min-h-0 min-w-0\".",
+        "Do not change graph editor wiring, selection handlers, header actions, or ReactFlowCurrentActivityCardView props.",
+        "Add or extend a WorkflowActivityBentoCard rendering test that asserts the graph panel shell section wrapping the viewport region has a className containing relative, h-full, min-h-0, and min-w-0.",
         "Typecheck passes",
         "Tests pass"
       ],
@@ -33,90 +33,19 @@
       "notes": ""
     },
     {
-      "id": "opencode-agent-support-002",
-      "title": "Reject OpenCode agent config on non-OpenCode runners",
-      "description": "As an operator, I want a clear configuration error when openCodeAgent is set but the dispatch will not use the OpenCode runner, so misconfigured factories fail fast instead of silently ignoring the field.",
+      "id": "inline-workflow-activity-bento-card-class-002",
+      "title": "Remove the graph panel shell allowlist exception",
+      "description": "As a frontend maintainer, I want the inline-class guard to stop carrying an exception for a constant that no longer exists so policy checks stay honest and the allowlist keeps shrinking.",
       "acceptanceCriteria": [
-        "When openCodeAgent is non-empty and the resolved runner for a model dispatch is not opencode, the factory reports a validation or dispatch-time error that references openCodeAgent and the resolved runner ID.",
-        "When openCodeAgent is empty or unset, non-OpenCode runners behave exactly as before.",
+        "Remove src/features/workflow-activity/components/workflow-activity-bento-card.tsx#GRAPH_PANEL_SHELL_CLASS from ui/scripts/inline-component-class-usage-allowlist.mjs.",
+        "Do not modify other allowlisted entries or unrelated workflow-activity files in this slice.",
+        "bun run check:inline-component-class-usage --cwd ui exits successfully with no stale allowlist entries reported.",
+        "Focused workflow-activity-bento-card tests still pass after the allowlist cleanup.",
         "Typecheck passes",
         "Tests pass"
       ],
       "priority": 2,
       "passes": true,
-      "notes": ""
-    },
-    {
-      "id": "opencode-agent-support-003",
-      "title": "Forward OpenCode agent into provider inference requests",
-      "description": "As a backend maintainer, I want the resolved OpenCode agent name on ProviderInferenceRequest so provider behavior can build CLI arguments without re-reading frontmatter.",
-      "acceptanceCriteria": [
-        "ProviderInferenceRequest carries an OpenCodeAgent field populated from workstation override else worker default when the resolved runner is opencode.",
-        "The shared inference-request builder sets OpenCodeAgent only for OpenCode dispatches and leaves it empty for other runners.",
-        "Cloning and diagnostic helpers preserve OpenCodeAgent without mutating shared maps.",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 3,
-      "passes": true,
-      "notes": ""
-    },
-    {
-      "id": "opencode-agent-support-004",
-      "title": "Pass --agent to opencode run",
-      "description": "As a factory operator, I want OpenCode dispatches to invoke my configured agent profile so tool permissions and system prompts defined in OpenCode take effect.",
-      "acceptanceCriteria": [
-        "For model provider opencode with non-empty OpenCodeAgent, built CLI args include opencode run --agent <name> with existing --model, --session, --dir, and --dangerously-skip-permissions flags unchanged when those fields are set.",
-        "For empty OpenCodeAgent, built args match today's opencode run shape with no --agent flag.",
-        "Existing OpenCode unsupported capability guards still apply unchanged.",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 4,
-      "passes": true,
-      "notes": ""
-    },
-    {
-      "id": "opencode-agent-support-005",
-      "title": "Surface OpenCode agent in inference diagnostics",
-      "description": "As an operator reviewing inference events, I want to see which OpenCode agent was requested so I can correlate factory behavior with OpenCode session logs.",
-      "acceptanceCriteria": [
-        "Provider request metadata for OpenCode dispatches includes opencode_agent with the resolved agent name when configured.",
-        "OpenCode dispatches without a configured agent omit opencode_agent from request metadata.",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 5,
-      "passes": true,
-      "notes": ""
-    },
-    {
-      "id": "opencode-agent-support-006",
-      "title": "Extend factory OpenAPI shapes for openCodeAgent",
-      "description": "As an API consumer editing factory definitions through the API or UI, I want openCodeAgent on worker and workstation schemas so saved factories preserve the setting.",
-      "acceptanceCriteria": [
-        "OpenAPI Worker and Workstation components include optional openCodeAgent string fields with descriptions referencing OpenCode CLI agent selection.",
-        "Regenerated Go and TypeScript clients expose openCodeAgent; factory-definition validation accepts non-empty strings.",
-        "A contract or config round-trip test proves openCodeAgent survives OpenAPI decode and public projection for worker and workstation fixtures.",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 6,
-      "passes": false,
-      "notes": ""
-    },
-    {
-      "id": "opencode-agent-support-007",
-      "title": "Document OpenCode agent configuration for factory authors",
-      "description": "As a factory author reading reference docs, I want clear guidance on openCodeAgent and how it maps to the OpenCode CLI so I can configure agents without reading backend source.",
-      "acceptanceCriteria": [
-        "docs/reference/workers.md documents openCodeAgent for model workers used with runner or modelProvider OpenCode.",
-        "docs/reference/workstations.md documents workstation-level override and precedence over the worker default.",
-        "Docs reference opencode agent list per https://opencode.ai/docs/cli/ for discovering agent names.",
-        "Typecheck passes"
-      ],
-      "priority": 7,
-      "passes": false,
       "notes": ""
     }
   ]

--- a/prd.md
+++ b/prd.md
@@ -1,163 +1,109 @@
-# PRD: OpenCode Agent Support
+# PRD: Inline Workflow Activity Bento Card Graph Panel Shell Class
 
 ## Introduction
 
-infinite-you already routes OpenCode-backed model work through the built-in `opencode` runner (`opencode run` with `--model`, `--session`, `--dir`, and optional `--dangerously-skip-permissions`). The [OpenCode CLI](https://opencode.ai/docs/cli/) also supports selecting a named OpenCode agent profile via `opencode run --agent <name>` (and the same flag on the TUI entrypoint). Factories cannot express that choice today, so every OpenCode dispatch uses the CLI default agent even when authors maintain custom agents under `.opencode/agent` or global agent directories.
+Customer ask `1.5` continues shrinking the inline-component-class allowlist by inlining single-use class constants directly on nearby JSX. The workflow-activity bento card still declares `GRAPH_PANEL_SHELL_CLASS` as a module constant and references it once on the graph panel shell `<section>`. That pattern keeps an unnecessary allowlist exception alive without improving reuse or readability.
 
-This project adds first-class OpenCode agent selection to factory configuration and backend dispatch, wires it through the existing provider execution path, records it in inference diagnostics, and proves the behavior with targeted backend tests.
+This change inlines the graph panel shell layout classes on the `<section>` element, removes the module constant, and deletes the matching allowlist entry. Graph editor wiring, selection behavior, and bento card composition stay unchanged.
 
 ## Context
 
 ### Customer ask
 
-Add agent support for OpenCode using the OpenCode CLI documentation, including corresponding backend tests.
+Inline `GRAPH_PANEL_SHELL_CLASS` directly on the JSX `className` and remove the matching allowlist entry while preserving workflow-activity bento card layout.
 
 ### Problem
 
-- `pkg/workers/provider` builds `opencode run` without `--agent`, so custom OpenCode agent profiles never participate in factory execution.
-- Worker and workstation `AGENTS.md` frontmatter, OpenAPI factory schemas, and `ProviderInferenceRequest` have no field for an OpenCode agent name.
-- Operators cannot tell from inference diagnostics which OpenCode agent profile was requested for a dispatch.
-- Existing OpenCode tests cover model, session, directory, and permission flags only.
+- `GRAPH_PANEL_SHELL_CLASS` is declared separately from JSX even though it is used only once.
+- The inline-class guard still carries a stale-exception entry for this constant.
+- The extra indirection adds maintenance noise without enabling reuse or conditional styling.
 
 ### Solution
 
-Introduce an `openCodeAgent` configuration field (worker-owned default with optional workstation override), map it into `ProviderInferenceRequest` when the resolved runner is `opencode`, append `--agent <name>` to `opencode run` invocations per the CLI contract, surface the resolved agent in provider request metadata, extend factory/OpenAPI shapes where worker and workstation settings are serialized, document the field for factory authors, and add backend tests that lock command construction and dispatch wiring.
+Move `"relative h-full min-h-0 min-w-0"` onto the graph panel shell `<section className="...">`, delete the constant, remove the allowlist entry, and prove layout behavior is unchanged through focused component tests and the inline-class guard.
 
 ## Goals
 
-- Let factory authors pin a named OpenCode agent profile on OpenCode-backed workers and workstations.
-- Pass the resolved agent to `opencode run --agent` during model dispatch.
-- Ignore or reject misconfiguration when `openCodeAgent` is set but the resolved runner is not OpenCode, with a clear operator-visible outcome.
-- Record the requested OpenCode agent in inference request metadata for debugging.
-- Prove behavior with backend unit and dispatch-level tests (no UI-only verification stories).
+- Remove `GRAPH_PANEL_SHELL_CLASS` from `workflow-activity-bento-card.tsx`.
+- Keep the graph panel shell layout classes identical in rendered output.
+- Remove the corresponding allowlist exception and keep the inline-class guard green.
+- Preserve existing workflow-activity bento card behavior and composition.
 
 ## Project-Level Acceptance Criteria
 
-- [ ] A worker or workstation with `openCodeAgent: "<name>"` and resolved runner `opencode` dispatches successfully and invokes `opencode run` with `--agent <name>` before the user prompt argument.
-- [ ] When `openCodeAgent` is omitted, OpenCode dispatch behavior is unchanged (no `--agent` flag).
-- [ ] When `openCodeAgent` is set but the resolved runner is not `opencode`, dispatch fails before subprocess start with a field-scoped error that names the configured agent and the resolved runner.
-- [ ] Inference request diagnostics include the resolved OpenCode agent name when one was configured.
-- [ ] Factory/OpenAPI worker and workstation shapes accept `openCodeAgent` and round-trip through config load and public projection where those entities are already serialized.
-- [ ] Reference documentation describes `openCodeAgent`, runner precedence, and the link to OpenCode's `opencode agent list` workflow.
-- [ ] Repository quality gate passes: backend and UI typecheck, lint, and affected test suites are green.
+- [ ] `GRAPH_PANEL_SHELL_CLASS` no longer exists in `ui/src/features/workflow-activity/components/workflow-activity-bento-card.tsx`.
+- [ ] The graph panel shell `<section>` renders with `relative h-full min-h-0 min-w-0` in the DOM.
+- [ ] The allowlist entry `src/features/workflow-activity/components/workflow-activity-bento-card.tsx#GRAPH_PANEL_SHELL_CLASS` is removed from `ui/scripts/inline-component-class-usage-allowlist.mjs`.
+- [ ] `bun run check:inline-component-class-usage --cwd ui` passes with no stale allowlist entries.
+- [ ] Focused `WorkflowActivityBentoCard` tests pass with no changes to graph editor wiring, selection behavior, or card composition.
+- [ ] Repository quality gate passes: UI typecheck, lint, and affected tests are green.
 
 ## User Stories
 
-### opencode-agent-support-001: Author OpenCode agent names in factory config
+### inline-workflow-activity-bento-card-class-001: Inline graph panel shell classes on WorkflowActivityBentoCard
 
-**Description:** As a factory author, I want to declare which OpenCode agent profile a worker or workstation should use so I can reuse agents I created with `opencode agent create` without duplicating prompts in infinite-you.
+**Description:** As a dashboard user, I want the workflow-activity bento card graph panel shell to keep the same flex-safe layout classes so the embedded React Flow graph still fills the card without overflow regressions.
 
 **Acceptance Criteria:**
-- [ ] Worker `AGENTS.md` frontmatter accepts optional `openCodeAgent` (non-empty string).
-- [ ] Workstation `AGENTS.md` frontmatter accepts optional `openCodeAgent` that overrides the worker default for that step when both are set.
-- [ ] Loaded runtime worker and workstation config retain the resolved `openCodeAgent` value through factory build.
+
+- [ ] Remove the `GRAPH_PANEL_SHELL_CLASS` module constant from `workflow-activity-bento-card.tsx`.
+- [ ] Set the graph panel shell `<section>` `className` directly to `"relative h-full min-h-0 min-w-0"`.
+- [ ] Do not change graph editor wiring, selection handlers, header actions, or `ReactFlowCurrentActivityCardView` props.
+- [ ] Add or extend a `WorkflowActivityBentoCard` rendering test that asserts the graph panel shell `<section>` wrapping the viewport region has a `className` containing `relative`, `h-full`, `min-h-0`, and `min-w-0`.
 - [ ] Typecheck passes
 - [ ] Tests pass
 
-### opencode-agent-support-002: Reject OpenCode agent config on non-OpenCode runners
+### inline-workflow-activity-bento-card-class-002: Remove the graph panel shell allowlist exception
 
-**Description:** As an operator, I want a clear configuration error when `openCodeAgent` is set but the dispatch will not use the OpenCode runner, so misconfigured factories fail fast instead of silently ignoring the field.
+**Description:** As a frontend maintainer, I want the inline-class guard to stop carrying an exception for a constant that no longer exists so policy checks stay honest and the allowlist keeps shrinking.
 
 **Acceptance Criteria:**
-- [ ] When `openCodeAgent` is non-empty and the resolved runner for a model dispatch is not `opencode`, the factory reports a validation or dispatch-time error that references `openCodeAgent` and the resolved runner ID.
-- [ ] When `openCodeAgent` is empty or unset, non-OpenCode runners behave exactly as before.
+
+- [ ] Remove `src/features/workflow-activity/components/workflow-activity-bento-card.tsx#GRAPH_PANEL_SHELL_CLASS` from `ui/scripts/inline-component-class-usage-allowlist.mjs`.
+- [ ] Do not modify other allowlisted entries or unrelated workflow-activity files in this slice.
+- [ ] `bun run check:inline-component-class-usage --cwd ui` exits successfully with no stale allowlist entries reported.
+- [ ] Focused `workflow-activity-bento-card` tests still pass after the allowlist cleanup.
 - [ ] Typecheck passes
 - [ ] Tests pass
-
-### opencode-agent-support-003: Forward OpenCode agent into provider inference requests
-
-**Description:** As a backend maintainer, I want the resolved OpenCode agent name on `ProviderInferenceRequest` so provider behavior can build CLI arguments without re-reading frontmatter.
-
-**Acceptance Criteria:**
-- [x] `ProviderInferenceRequest` carries an `OpenCodeAgent` field populated from workstation override, else worker default, when the resolved runner is `opencode`.
-- [x] `AgentExecutor` (or the shared inference-request builder) sets `OpenCodeAgent` only for OpenCode dispatches; the field stays empty for other runners.
-- [x] Cloning and diagnostic helpers preserve `OpenCodeAgent` without mutating shared maps.
-- [x] Typecheck passes
-- [x] Tests pass
-
-### opencode-agent-support-004: Pass `--agent` to `opencode run`
-
-**Description:** As a factory operator, I want OpenCode dispatches to invoke my configured agent profile so tool permissions and system prompts defined in OpenCode take effect.
-
-**Acceptance Criteria:**
-- [ ] For `ModelProvider` `opencode` with non-empty `OpenCodeAgent`, built CLI args are `opencode run --agent <name> ...` with `--model`, `--session`, `--dir`, and `--dangerously-skip-permissions` unchanged relative to today's ordering when those fields are set.
-- [ ] For empty `OpenCodeAgent`, built args match today's `opencode run` shape (no `--agent`).
-- [ ] Existing OpenCode capability guards (unsupported structured output, image input, worktree) still apply unchanged.
-- [ ] Typecheck passes
-- [ ] Tests pass
-
-### opencode-agent-support-005: Surface OpenCode agent in inference diagnostics
-
-**Description:** As an operator reviewing inference events, I want to see which OpenCode agent was requested so I can correlate factory behavior with OpenCode session logs.
-
-**Acceptance Criteria:**
-- [ ] Provider request metadata for OpenCode dispatches includes `opencode_agent` with the resolved agent name when configured.
-- [ ] OpenCode dispatches without a configured agent omit `opencode_agent` from request metadata.
-- [ ] Typecheck passes
-- [ ] Tests pass
-
-### opencode-agent-support-006: Extend factory OpenAPI shapes for `openCodeAgent`
-
-**Description:** As an API consumer editing factory definitions through the API or UI, I want `openCodeAgent` on worker and workstation schemas so saved factories preserve the setting.
-
-**Acceptance Criteria:**
-- [ ] OpenAPI `Worker` and `Workstation` (or equivalent factory-definition components) include optional `openCodeAgent` string fields with descriptions referencing OpenCode CLI agent selection.
-- [ ] Regenerated Go and TypeScript clients expose the new fields; factory-definition validation accepts non-empty strings and rejects invalid types.
-- [ ] A contract or config round-trip test proves `openCodeAgent` survives OpenAPI decode and public projection for at least one worker and one workstation fixture.
-- [ ] Typecheck passes
-- [ ] Tests pass
-
-### opencode-agent-support-007: Document OpenCode agent configuration for factory authors
-
-**Description:** As a factory author reading reference docs, I want clear guidance on `openCodeAgent` and how it maps to the OpenCode CLI so I can configure agents without reading backend source.
-
-**Acceptance Criteria:**
-- [ ] `docs/reference/workers.md` documents `openCodeAgent` on model workers used with runner or `modelProvider` OpenCode.
-- [ ] `docs/reference/workstations.md` documents workstation-level override and precedence over the worker default.
-- [ ] Docs mention that agent names correspond to OpenCode agents discoverable via `opencode agent list` per https://opencode.ai/docs/cli/.
-- [ ] Typecheck passes
 
 ## Functional Requirements
 
-- FR-1: Factory config **MUST** accept optional `openCodeAgent` on worker and workstation definitions.
-- FR-2: Workstation `openCodeAgent` **MUST** override worker `openCodeAgent` when both are set for the same dispatch.
-- FR-3: When the resolved runner is `opencode` and `openCodeAgent` is non-empty, subprocess invocation **MUST** include `opencode run --agent <openCodeAgent>`.
-- FR-4: When `openCodeAgent` is set and the resolved runner is not `opencode`, dispatch **MUST** fail with an explicit configuration error before starting the provider subprocess.
-- FR-5: Inference diagnostics **MUST** record the resolved OpenCode agent under request metadata key `opencode_agent` when configured.
-- FR-6: OpenAPI factory worker and workstation schemas **MUST** include `openCodeAgent` when those entities are already part of the public contract.
+- FR-1: The graph panel shell `<section>` in `WorkflowActivityBentoCard` must use the exact class string `relative h-full min-h-0 min-w-0` inline on JSX.
+- FR-2: No module-level class constant may remain for the graph panel shell in `workflow-activity-bento-card.tsx`.
+- FR-3: The inline-component-class allowlist must no longer reference `GRAPH_PANEL_SHELL_CLASS` for this file.
+- FR-4: Existing workflow-activity bento card rendering, editor entry, duplicate-instance accessibility, and header-action ordering behavior must remain unchanged.
 
 ## Non-Goals
 
-- Managing OpenCode agents from infinite-you (`opencode agent create`, `list`, or interactive setup).
-- UI pickers or live discovery of OpenCode agents in the dashboard (documentation points authors to `opencode agent list`).
-- Supporting OpenCode `--agent` on non-`run` entrypoints such as `opencode serve`, `web`, or `acp`.
-- Adding new OpenCode optional capabilities (structured output, image input, worktree) in this lane.
-- Changing runner prerequisite checks beyond ensuring the existing `opencode` binary lookup still applies.
+- Do not inline or modify other allowlisted class constants in this slice.
+- Do not change notifications, work-outcome, or current-factory-definition public barrels.
+- Do not refactor graph editor hooks, React Flow wiring, or bento card composition beyond the class inlining.
+- Do not add structural, route-inventory, or source-registration meta tests.
 
 ## High-Level Technical Design
 
-1. **Configuration surface:** Add `OpenCodeAgent string` to `interfaces.WorkerConfig` and workstation runtime config (frontmatter key `openCodeAgent`). Parse via existing `agents_config.go` paths with camelCase canonical naming.
-2. **Precedence:** Resolve agent name as `workstation.openCodeAgent` if non-empty, else `worker.openCodeAgent`.
-3. **Validation:** During factory build or dispatch preparation, if resolved agent is non-empty and `ResolveRunnerSelection` does not yield `opencode`, return a configuration error.
-4. **Inference contract:** Extend `interfaces.ProviderInferenceRequest` with `OpenCodeAgent string`; populate in `inferenceRequestForExecutionRequest` when the effective model provider is `opencode`.
-5. **CLI mapping:** In `openCodeProviderBehavior.BuildArgs`, after `run` and before model/session flags, append `--agent`, `<name>` when `req.OpenCodeAgent != ""`, matching OpenCode CLI flag order from https://opencode.ai/docs/cli/ (`--model`, `--agent`, `--session`, etc. are all documented on `opencode run`; place `--agent` after `--model` and before `--session` for stable tests).
-6. **Diagnostics:** Extend `workDiagnosticsForInferenceRequest` request metadata with `opencode_agent` when non-empty.
-7. **Contracts:** Add `openCodeAgent` to `api/components/schemas/data-models/Worker.yaml` and the workstation schema, regenerate clients, align `ui/src/api/factory-definition` validation if present.
-8. **Tests:** Extend `provider_behavior_test.go` and `inference_provider_test.go` table cases; add config/dispatch test showing rejection when `openCodeAgent` is set with `runner: codex`.
+This is a localized JSX cleanup with no API, state, or routing changes.
+
+1. **Component edit:** Replace `<section className={GRAPH_PANEL_SHELL_CLASS}>` with a literal `className` on the same element and delete the constant declaration.
+2. **Behavioral proof:** Extend the existing Vitest suite in `workflow-activity-bento-card.test.tsx` to assert the shell section's rendered classes rather than scanning source structure.
+3. **Policy cleanup:** Remove the single stale `file#CONSTANT` allowlist entry in the same follow-up story so `check-inline-component-class-usage.mjs` reports zero stale exceptions.
+
+No new components, hooks, or shared utilities are required.
 
 ## Supporting Technical and UX Considerations
 
-- OpenCode agent names are opaque strings managed outside infinite-you; do not validate against a local registry in v1.
-- Keep `openCodeAgent` separate from infinite-you worker `name` and from `model`/`modelProvider` fields to avoid conflating factory topology with OpenCode's agent subsystem.
-- `skipPermissions` continues to map to `--dangerously-skip-permissions` independently of agent selection.
-- Session resume (`--session`) and working directory (`--dir`) behavior remains unchanged when an agent is configured.
+- The class string controls flex containment for the embedded graph viewport; changing token order or dropping a class can cause overflow or collapsed layout inside the bento card.
+- The inline-class guard treats removed constants as stale allowlist entries; the allowlist change must land after the constant is deleted.
+- Prefer reusing the existing `WorkflowActivityBentoCard` test harness and semantic dashboard snapshot fixtures rather than adding new Storybook or browser-only coverage for this refactor.
+- Visible UI behavior should remain identical; no browser-only verification is required beyond the rendering test assertion on the shell section classes.
 
 ## Success Metrics
 
-- A factory can run two workstations with different `openCodeAgent` values against the same OpenCode runner without prompt duplication.
-- Inference event streams show `opencode_agent` metadata for configured dispatches.
-- No regression in existing OpenCode provider tests when `openCodeAgent` is unset.
+- One fewer entry in `inline-component-class-usage-allowlist.mjs`.
+- Zero regressions in focused workflow-activity bento card tests.
+- Inline-class guard passes on the first run after allowlist cleanup.
+- No user-visible layout or interaction change on the dashboard workflow-activity card.
 
 ## Open Questions
 
-None for v1; agent name validation against `opencode agent list` output is intentionally deferred.
+None. Scope, target files, verification commands, and out-of-scope boundaries are fully specified by the customer ask.

--- a/progress.txt
+++ b/progress.txt
@@ -1,4 +1,5 @@
 ## Codebase Patterns
+- Inline single-use workflow-activity layout class strings directly on JSX in `workflow-activity-bento-card.tsx`; assert the graph panel shell via the viewport region’s `section[aria-labelledby]` parent in `workflow-activity-bento-card.test.tsx` (contains `relative`, `h-full`, `min-h-0`, `min-w-0`).
 - Parse worker/workstation `openCodeAgent` through `pkg/config/agents_config.go` with `validateOpenCodeAgentInFrontmatter` (rejects explicit empty or whitespace-only values), merge via `applyWorkerRuntimeExecution` / `applyWorkstationRuntimeIdentity`, and resolve dispatch precedence with `interfaces.ResolveOpenCodeAgent(workstation, worker)`.
 - Forward resolved OpenCode agent on `interfaces.ProviderInferenceRequest.OpenCodeAgent` from `pkg/workers/executor/agent.go` `inferenceRequestForExecutionRequest` only when `ModelProvider` is `opencode`; lookup workstation via `runtimeConfig.Workstation(inferenceWorkstationType(request))` and leave the field empty for other providers.
 - Append `opencode run --agent <name>` in `openCodeProviderBehavior.BuildArgs` when `req.OpenCodeAgent` is non-empty, placing `--agent` after `--model` and before `--session`; empty agent leaves today's `opencode run` arg shape unchanged.
@@ -146,4 +147,22 @@
   - Patterns discovered: Omit `opencode_agent` from request metadata entirely when unset rather than emitting an empty string; mirror the conditional in both `pkg/workers/executor/diagnostics.go` and `pkg/workers/provider/helpers.go`.
   - Gotchas encountered: Safe projection drops unknown metadata keys—add new provider request metadata keys to `isSafeProviderMetadataKey` or inference events will lose them downstream.
   - Useful context: Story 006 extends OpenAPI factory schemas; story 007 documents `openCodeAgent` for factory authors.
+---
+
+## 2026-05-30T08:57:00Z - inline-workflow-activity-bento-card-class-001
+- What was implemented: Removed `GRAPH_PANEL_SHELL_CLASS` from `workflow-activity-bento-card.tsx`, inlined `relative h-full min-h-0 min-w-0` on the graph panel shell `<section>`, and added a rendering test that asserts those classes on the shell wrapping the viewport region.
+- Files changed: `ui/src/features/workflow-activity/components/workflow-activity-bento-card.tsx`, `ui/src/features/workflow-activity/components/workflow-activity-bento-card.test.tsx`
+- **Learnings for future iterations:**
+  - Patterns discovered: Graph panel shell is the parent of the workflow graph `section[aria-labelledby]`; locate it from `screen.getByRole("region", { name: messages.viewportLabel })` via `closest("section[aria-labelledby]")?.parentElement`.
+  - Gotchas encountered: Story 002 must remove the stale `GRAPH_PANEL_SHELL_CLASS` allowlist entry; inline-class guard will fail until then.
+  - Useful context: `ReactFlowCurrentActivityCardView` keeps its own `CURRENT_ACTIVITY_CARD_CLASS` on the inner workflow section—do not conflate with the bento card outer shell.
+---
+
+## 2026-05-30T02:16:00Z - inline-workflow-activity-bento-card-class-002
+- What was implemented: Removed stale `workflow-activity-bento-card.tsx#GRAPH_PANEL_SHELL_CLASS` entry from `inline-component-class-usage-allowlist.mjs` after story 001 inlined the shell classes; verified `bun run check:inline-component-class-usage`, allowlist guard tests, and `workflow-activity-bento-card.test.tsx`.
+- Files changed: `ui/scripts/inline-component-class-usage-allowlist.mjs`
+- **Learnings for future iterations:**
+  - Patterns discovered: After inlining a single-use class constant, remove the matching `file#CONSTANT` allowlist entry in the follow-up story so `check:inline-component-class-usage` reports no stale exceptions.
+  - Gotchas encountered: The allowlist guard test file is `ui/scripts/check-inline-component-class-usage.test.mjs`, not `.ts`.
+  - Useful context: No PR conversation feedback existed this iteration; PR creation follows when all PRD stories pass.
 ---

--- a/ui/scripts/inline-component-class-usage-allowlist.mjs
+++ b/ui/scripts/inline-component-class-usage-allowlist.mjs
@@ -88,5 +88,4 @@ export const allowlistedInlineComponentClassUsage = [
   "src/features/workflow-activity/components/react-flow-current-activity-card.tsx#CURRENT_ACTIVITY_CARD_CLASS",
   "src/features/workflow-activity/components/react-flow-current-activity-card.tsx#CURRENT_ACTIVITY_HEADER_CLASS",
   "src/features/workflow-activity/components/react-flow-current-activity-card.tsx#CURRENT_ACTIVITY_TITLE_CLASS",
-  "src/features/workflow-activity/components/workflow-activity-bento-card.tsx#GRAPH_PANEL_SHELL_CLASS",
 ];

--- a/ui/src/features/workflow-activity/components/workflow-activity-bento-card.test.tsx
+++ b/ui/src/features/workflow-activity/components/workflow-activity-bento-card.test.tsx
@@ -210,6 +210,26 @@ function registerWorkflowActivityBentoCardTestSetup() {
 describe("WorkflowActivityBentoCard", () => {
   registerWorkflowActivityBentoCardTestSetup();
 
+  it("keeps flex-safe layout classes on the graph panel shell around the viewport", async () => {
+    const locale = "zh-CN";
+    const messages = getWorkflowActivityShellMessages(locale);
+    renderWorkflowActivityBentoCard({ locale });
+
+    const viewport = await screen.findByRole("region", {
+      name: messages.viewportLabel,
+    });
+    const workflowSection = viewport.closest<HTMLElement>(
+      "section[aria-labelledby]",
+    );
+    const graphPanelShell = workflowSection?.parentElement;
+
+    expect(graphPanelShell?.tagName).toBe("SECTION");
+    expect(graphPanelShell?.className).toContain("relative");
+    expect(graphPanelShell?.className).toContain("h-full");
+    expect(graphPanelShell?.className).toContain("min-h-0");
+    expect(graphPanelShell?.className).toContain("min-w-0");
+  });
+
   it("wraps the React Flow graph without a floating inspector", async () => {
     const locale = "zh-CN";
     const messages = getWorkflowActivityShellMessages(locale);

--- a/ui/src/features/workflow-activity/components/workflow-activity-bento-card.tsx
+++ b/ui/src/features/workflow-activity/components/workflow-activity-bento-card.tsx
@@ -29,8 +29,6 @@ interface WorkflowActivityBentoCardProps {
   widgetInstanceID?: string;
 }
 
-const GRAPH_PANEL_SHELL_CLASS = "relative h-full min-h-0 min-w-0";
-
 export function WorkflowActivityBentoCard({
   headerAction,
   importController,
@@ -69,7 +67,7 @@ export function WorkflowActivityBentoCard({
       }
       title={messages.widgetTitle}
     >
-      <section className={GRAPH_PANEL_SHELL_CLASS}>
+      <section className="relative h-full min-h-0 min-w-0">
         <ReactFlowCurrentActivityCardView
           editor={editor}
           importController={importController}


### PR DESCRIPTION
{
  "project": "Inline Workflow Activity Bento Card Graph Panel Shell Class",
  "branchName": "ralph/inline-workflow-activity-bento-card-class",
  "description": "Inline the single-use GRAPH_PANEL_SHELL_CLASS constant directly on the workflow-activity bento card graph panel shell section, remove the matching inline-class allowlist exception, and prove layout and card behavior are unchanged through focused component tests and the inline-class guard.",
  "context": {
    "customerAsk": "Inline GRAPH_PANEL_SHELL_CLASS directly on the JSX className and remove the matching allowlist entry while preserving workflow-activity bento card layout.",
    "problem": "workflow-activity-bento-card.tsx still declares GRAPH_PANEL_SHELL_CLASS as a module constant used only once on the graph panel shell section, which keeps an unnecessary inline-component-class allowlist exception alive without improving reuse or readability.",
    "solution": "Move the relative h-full min-h-0 min-w-0 class string onto the graph panel shell section className, delete the constant, remove the allowlist entry, and verify unchanged card behavior with focused WorkflowActivityBentoCard tests plus bun run check:inline-component-class-usage."
  },
  "acceptanceCriteria": [
    "GRAPH_PANEL_SHELL_CLASS no longer exists in ui/src/features/workflow-activity/components/workflow-activity-bento-card.tsx.",
    "The graph panel shell section renders with relative h-full min-h-0 min-w-0 in the DOM.",
    "The allowlist entry src/features/workflow-activity/components/workflow-activity-bento-card.tsx#GRAPH_PANEL_SHELL_CLASS is removed from ui/scripts/inline-component-class-usage-allowlist.mjs.",
    "bun run check:inline-component-class-usage --cwd ui passes with no stale allowlist entries.",
    "Focused WorkflowActivityBentoCard tests pass with no changes to graph editor wiring, selection behavior, or card composition.",
    "Repository quality gate passes: UI typecheck, lint, and affected tests are green."
  ],
  "userStories": [
    {
      "id": "inline-workflow-activity-bento-card-class-001",
      "title": "Inline graph panel shell classes on WorkflowActivityBentoCard",
      "description": "As a dashboard user, I want the workflow-activity bento card graph panel shell to keep the same flex-safe layout classes so the embedded React Flow graph still fills the card without overflow regressions.",
      "acceptanceCriteria": [
        "Remove the GRAPH_PANEL_SHELL_CLASS module constant from workflow-activity-bento-card.tsx.",
        "Set the graph panel shell section className directly to \"relative h-full min-h-0 min-w-0\".",
        "Do not change graph editor wiring, selection handlers, header actions, or ReactFlowCurrentActivityCardView props.",
        "Add or extend a WorkflowActivityBentoCard rendering test that asserts the graph panel shell section wrapping the viewport region has a className containing relative, h-full, min-h-0, and min-w-0.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "inline-workflow-activity-bento-card-class-002",
      "title": "Remove the graph panel shell allowlist exception",
      "description": "As a frontend maintainer, I want the inline-class guard to stop carrying an exception for a constant that no longer exists so policy checks stay honest and the allowlist keeps shrinking.",
      "acceptanceCriteria": [
        "Remove src/features/workflow-activity/components/workflow-activity-bento-card.tsx#GRAPH_PANEL_SHELL_CLASS from ui/scripts/inline-component-class-usage-allowlist.mjs.",
        "Do not modify other allowlisted entries or unrelated workflow-activity files in this slice.",
        "bun run check:inline-component-class-usage --cwd ui exits successfully with no stale allowlist entries reported.",
        "Focused workflow-activity-bento-card tests still pass after the allowlist cleanup.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)