### PR TITLE
inline-current-activity-legend-class

### DIFF
--- a/ui/scripts/inline-component-class-usage-allowlist.mjs
+++ b/ui/scripts/inline-component-class-usage-allowlist.mjs
@@ -84,7 +84,6 @@ export const allowlistedInlineComponentClassUsage = [
   "src/features/workflow-activity/components/mutation-dialog.tsx#DIALOG_MAIN_CLASS",
   "src/features/workflow-activity/components/mutation-dialog.tsx#DIALOG_CLOSE_BUTTON_CLASS",
   "src/features/workflow-activity/components/mutation-dialog.tsx#DIALOG_FOOTER_CLASS",
-  "src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx#CURRENT_ACTIVITY_LEGEND_CLASS",
   "src/features/workflow-activity/components/react-flow-current-activity-card.tsx#CURRENT_ACTIVITY_CARD_CLASS",
   "src/features/workflow-activity/components/react-flow-current-activity-card.tsx#CURRENT_ACTIVITY_HEADER_CLASS",
   "src/features/workflow-activity/components/react-flow-current-activity-card.tsx#CURRENT_ACTIVITY_TITLE_CLASS",

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
@@ -35,8 +35,6 @@ import {
   graphDropStateAttribute,
 } from "./react-flow-current-activity-card-import";
 
-const CURRENT_ACTIVITY_LEGEND_CLASS = "absolute left-4 right-4 top-4 z-10";
-
 function CurrentActivityEditorToolbar(props: {
   activeTool: "add" | "connect" | "delete" | null;
   addMenuActions?: FactoryGraphEditorMenuAction[];
@@ -228,7 +226,7 @@ export function CurrentActivityGraphViewport({
   return (
     <div className="relative min-h-96 flex-1">
       <DashboardFlowAxisLegend
-        className={CURRENT_ACTIVITY_LEGEND_CLASS}
+        className="absolute left-4 right-4 top-4 z-10"
         defaultExpanded={false}
         edgeItems={getDefaultDashboardFlowAxisLegendEdgeItems(locale)}
         iconItems={getDefaultDashboardFlowAxisLegendIconItems(locale)}


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/inline-current-activity-legend-class",
  "description": "Inline the single-use current-activity graph legend wrapper class on DashboardFlowAxisLegend, remove the stale inline-class allowlist entry, and preserve existing legend overlay positioning and current-activity graph behavior.",
  "context": {
    "customerAsk": "As part of customer ask 1.5, inline `CURRENT_ACTIVITY_LEGEND_CLASS` directly into the JSX `className` on `DashboardFlowAxisLegend` in `ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx`, remove only `src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx#CURRENT_ACTIVITY_LEGEND_CLASS` from `ui/scripts/inline-component-class-usage-allowlist.mjs`, and keep scope limited to those two files without changing React Flow viewport wiring, editor toolbar behavior, or graph legend content.",
    "problem": "The current-activity graph viewport still defines a local class constant for a legend wrapper layout cluster that is used only once on `DashboardFlowAxisLegend`, which conflicts with the repository guidance to keep single-use component class strings inline in JSX where allowed. The matching inline-class allowlist entry also remains, so the repository continues to track debt for an exception that should no longer exist after the cleanup.",
    "solution": "Set `className=\"absolute left-4 right-4 top-4 z-10\"` directly on `DashboardFlowAxisLegend`, delete the stale `CURRENT_ACTIVITY_LEGEND_CLASS` constant and allowlist entry, and verify through focused current-activity graph tests and `bun run check:inline-component-class-usage` that legend overlay positioning, expand/collapse behavior, and React Flow viewport behavior remain unchanged."
  },
  "acceptanceCriteria": [
    "`ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx` no longer defines `CURRENT_ACTIVITY_LEGEND_CLASS`.",
    "`DashboardFlowAxisLegend` in `CurrentActivityGraphViewport` uses `className=\"absolute left-4 right-4 top-4 z-10\"` inline in JSX with the same overlay positioning as before.",
    "The current-activity graph legend keeps unchanged overlay layout, expand/collapse behavior, legend content, and drag/drop interaction boundaries relative to the graph viewport.",
    "React Flow viewport wiring and editor toolbar behavior in `CurrentActivityGraphViewport` remain unchanged.",
    "`ui/scripts/inline-component-class-usage-allowlist.mjs` no longer includes `src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx#CURRENT_ACTIVITY_LEGEND_CLASS`.",
    "The implementation stays limited to the viewport component and the single allowlist entry and does not touch other allowlisted files, notifications, work-outcome, or current-factory-definition public barrels.",
    "Quality gate: `bun run check:inline-component-class-usage`, focused current-activity graph/viewport tests, frontend typecheck, and relevant lint pass."
  ],
  "userStories": [
    {
      "id": "inline-current-activity-legend-class-001",
      "title": "Inline the legend wrapper class on DashboardFlowAxisLegend",
      "description": "As a frontend maintainer, I want the current-activity graph legend wrapper to keep its single-use layout class string inline on DashboardFlowAxisLegend so that the viewport component follows the shared styling standard without changing user-visible behavior.",
      "acceptanceCriteria": [
        "`ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx` no longer defines `CURRENT_ACTIVITY_LEGEND_CLASS`.",
        "`DashboardFlowAxisLegend` uses `className=\"absolute left-4 right-4 top-4 z-10\"` directly in JSX.",
        "`DashboardFlowAxisLegend` still receives the same `defaultExpanded`, `edgeItems`, `iconItems`, and `locale` props as before.",
        "React Flow viewport wiring, editor toolbar placement, and graph drop overlay behavior in `CurrentActivityGraphViewport` are unchanged.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "inline-current-activity-legend-class-002",
      "title": "Remove the stale allowlist entry and prove legend positioning is unchanged",
      "description": "As a reviewer, I want the inline component class usage allowlist to stop carrying the current-activity legend wrapper exception once the class is inlined so that repository debt tracking matches the real component state and legend overlay layout remains verifiable.",
      "acceptanceCriteria": [
        "`ui/scripts/inline-component-class-usage-allowlist.mjs` no longer includes `src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx#CURRENT_ACTIVITY_LEGEND_CLASS`.",
        "`bun run check:inline-component-class-usage` passes without reintroducing an exception for `react-flow-current-activity-card-viewport.tsx`.",
        "`bun test ui/src/features/workflow-activity/components/react-flow-current-activity-card.test.tsx` passes and continues to assert the legend wrapper renders with `absolute`, `left-4`, `right-4`, and `top-4` positioning classes.",
        "`bun test ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.test.tsx` passes when run as part of the focused verification set.",
        "The cleanup remains limited to the single stale allowlist entry and does not remove unrelated allowlist debt or broaden into other files.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)