### PR TITLE
remove-notifications-toast-duration-public-reexport

### DIFF
--- a/ui/src/features/notifications/public/index.ts
+++ b/ui/src/features/notifications/public/index.ts
@@ -1,4 +1,1 @@
-export {
-  AppNotificationToaster,
-  GLOBAL_TOAST_DURATION_MS,
-} from "../components/app-notification-toaster";
+export { AppNotificationToaster } from "../components/app-notification-toaster";

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-save-notifications.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-save-notifications.test.tsx
@@ -1,7 +1,7 @@
 import { render } from "@testing-library/react";
 import { toast } from "sonner";
 
-import { GLOBAL_TOAST_DURATION_MS } from "../../notifications/public";
+import { GLOBAL_TOAST_DURATION_MS } from "../../notifications/components/app-notification-toaster";
 import { CurrentActivityGraphSaveNotifications } from "./react-flow-current-activity-card-save-notifications";
 
 vi.mock("sonner", () => ({

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-save-notifications.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-save-notifications.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from "react";
 import { toast } from "sonner";
 
 import { getFactoryGraphEditorMessages } from "../../factory-graph-editor/messages/editor";
-import { GLOBAL_TOAST_DURATION_MS } from "../../notifications/public";
+import { GLOBAL_TOAST_DURATION_MS } from "../../notifications/components/app-notification-toaster";
 import type { useCurrentActivityGraphEditor } from "../hooks/react-flow-current-activity-card-editor";
 
 export function CurrentActivityGraphSaveNotifications({


### PR DESCRIPTION
{
  "project": "Remove Notifications Toast Duration Public Re-Export",
  "branchName": "ralph/remove-notifications-toast-duration-public-reexport",
  "description": "Narrow the notifications feature public barrel to app-composition only by removing the GLOBAL_TOAST_DURATION_MS re-export, retargeting the workflow-activity graph save-notification consumer to import the constant from the owning toaster module, and proving unchanged toast copy and duration through focused unit tests and repository quality gates.",
  "context": {
    "customerAsk": "Keep removing unnecessary website re-exports: stop forwarding GLOBAL_TOAST_DURATION_MS through notifications/public while keeping AppNotificationToaster on the public boundary for app entry.",
    "problem": "ui/src/features/notifications/public/index.ts re-exports both AppNotificationToaster and GLOBAL_TOAST_DURATION_MS, but only the toaster belongs on the public API; the duration constant is an implementation detail consumed by workflow-activity save notifications via an unnecessary public relay.",
    "solution": "Retarget react-flow-current-activity-card-save-notifications and its tests to import GLOBAL_TOAST_DURATION_MS from notifications/components/app-notification-toaster, then remove the constant from the notifications public barrel without changing toast timing, copy, or AppNotificationToaster app composition."
  },
  "acceptanceCriteria": [
    "ui/src/features/notifications/public/index.ts exports AppNotificationToaster only and no longer re-exports GLOBAL_TOAST_DURATION_MS.",
    "react-flow-current-activity-card-save-notifications.tsx imports GLOBAL_TOAST_DURATION_MS from ../../notifications/components/app-notification-toaster instead of notifications/public.",
    "No UI module imports GLOBAL_TOAST_DURATION_MS from notifications/public.",
    "ui/src/App.tsx continues to import AppNotificationToaster from ./features/notifications/public without app shell composition changes.",
    "Graph save success and error toasts keep the same titles, descriptions, and GLOBAL_TOAST_DURATION_MS duration behavior.",
    "Focused checks pass: bun run check:inline-component-class-usage (from ui/), bun test ui/src/features/workflow-activity/components/react-flow-current-activity-card-save-notifications.test.tsx, and bun test ui/src/features/notifications/components/app-notification-toaster.test.tsx.",
    "Repository quality gate passes: UI typecheck, lint, and affected tests are green."
  ],
  "userStories": [
    {
      "id": "remove-notifications-toast-duration-public-reexport-001",
      "title": "Retarget save-notification duration imports to owning module",
      "description": "As a user editing workflow topology, I want save success and error toasts to keep the same timing and messaging when a graph draft save completes or fails, so feedback stays consistent with the rest of the app.",
      "acceptanceCriteria": [
        "react-flow-current-activity-card-save-notifications.tsx imports GLOBAL_TOAST_DURATION_MS from ../../notifications/components/app-notification-toaster instead of ../../notifications/public.",
        "react-flow-current-activity-card-save-notifications.test.tsx imports GLOBAL_TOAST_DURATION_MS from the same owning toaster module path.",
        "Unit tests still assert success toast \"Topology saved\" with the existing description and duration GLOBAL_TOAST_DURATION_MS when save status is success.",
        "Unit tests still assert error toast \"Topology save failed\" with the error description and duration GLOBAL_TOAST_DURATION_MS when save status is error.",
        "Toast copy, toast position, and the numeric duration value remain unchanged (3000 ms via the shared constant).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "remove-notifications-toast-duration-public-reexport-002",
      "title": "Narrow notifications public barrel to app toaster only",
      "description": "As a frontend maintainer, I want the notifications public boundary to expose only the app-composition toaster so feature internals are not re-exported through public/.",
      "acceptanceCriteria": [
        "ui/src/features/notifications/public/index.ts exports AppNotificationToaster only and no longer re-exports GLOBAL_TOAST_DURATION_MS.",
        "ui/src/App.tsx continues to import AppNotificationToaster from ./features/notifications/public without import path changes.",
        "app-notification-toaster.test.tsx passes and still verifies the toaster uses GLOBAL_TOAST_DURATION_MS for its configured duration.",
        "bun run check:inline-component-class-usage passes from the ui/ directory.",
        "Focused save-notification and app-notification-toaster test files pass after the barrel change.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)