### PR TITLE
inline-current-activity-card-header-class

### DIFF
--- a/ui/scripts/inline-component-class-usage-allowlist.mjs
+++ b/ui/scripts/inline-component-class-usage-allowlist.mjs
@@ -85,6 +85,5 @@ export const allowlistedInlineComponentClassUsage = [
   "src/features/workflow-activity/components/mutation-dialog.tsx#DIALOG_CLOSE_BUTTON_CLASS",
   "src/features/workflow-activity/components/mutation-dialog.tsx#DIALOG_FOOTER_CLASS",
   "src/features/workflow-activity/components/react-flow-current-activity-card.tsx#CURRENT_ACTIVITY_CARD_CLASS",
-  "src/features/workflow-activity/components/react-flow-current-activity-card.tsx#CURRENT_ACTIVITY_HEADER_CLASS",
   "src/features/workflow-activity/components/react-flow-current-activity-card.tsx#CURRENT_ACTIVITY_TITLE_CLASS",
 ];

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card.tsx
@@ -59,7 +59,6 @@ const CURRENT_ACTIVITY_CARD_CLASS = cn(
   DASHBOARD_PANEL_SHELL_CLASS,
   "relative flex h-full min-h-0 min-w-0 flex-col",
 );
-const CURRENT_ACTIVITY_HEADER_CLASS = "mb-4";
 const CURRENT_ACTIVITY_TITLE_CLASS = cn("m-0", DASHBOARD_SECTION_HEADING_CLASS);
 
 export type CurrentActivitySelection =
@@ -439,7 +438,7 @@ export function ReactFlowCurrentActivityCardView(
       className={CURRENT_ACTIVITY_CARD_CLASS}
     >
       {showHeaderActions ? (
-        <div className={CURRENT_ACTIVITY_HEADER_CLASS}>
+        <div className="mb-4">
           <CurrentActivityGraphHeaderActions
             editorMode={editor.editorMode}
             editorUnavailableClassifierWorkstationName={


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/inline-current-activity-card-header-class",
  "description": "Inline the single-use current-activity card header wrapper margin class on the editor actions row, remove the stale inline-class allowlist entry, and preserve existing header spacing and factory graph editor chrome behavior.",
  "context": {
    "customerAsk": "As part of customer ask 1.5, inline `CURRENT_ACTIVITY_HEADER_CLASS` directly into the JSX `className` on the header wrapper `div` around `CurrentActivityGraphHeaderActions` in `ui/src/features/workflow-activity/components/react-flow-current-activity-card.tsx`, remove only `src/features/workflow-activity/components/react-flow-current-activity-card.tsx#CURRENT_ACTIVITY_HEADER_CLASS` from `ui/scripts/inline-component-class-usage-allowlist.mjs`, leave `CURRENT_ACTIVITY_CARD_CLASS` and `CURRENT_ACTIVITY_TITLE_CLASS` unchanged, and keep scope limited to those two files without changing card shell, title, graph viewport, or editor behavior.",
    "problem": "The current-activity card still defines a local class constant for a header wrapper margin cluster that is used only once on the `div` around `CurrentActivityGraphHeaderActions`, which conflicts with the repository guidance to keep single-use component class strings inline in JSX where allowed. The matching inline-class allowlist entry also remains, so the repository continues to track debt for an exception that should no longer exist after the cleanup.",
    "solution": "Set `className=\"mb-4\"` directly on the header wrapper `div`, delete the stale `CURRENT_ACTIVITY_HEADER_CLASS` constant and allowlist entry, and verify through focused `react-flow-current-activity-card` tests and `bun run check:inline-component-class-usage` that header spacing, editor toggle behavior, and card shell layout remain unchanged."
  },
  "acceptanceCriteria": [
    "`ui/src/features/workflow-activity/components/react-flow-current-activity-card.tsx` no longer defines `CURRENT_ACTIVITY_HEADER_CLASS`.",
    "The header wrapper `div` around `CurrentActivityGraphHeaderActions` uses `className=\"mb-4\"` inline in JSX with the same bottom margin spacing as before.",
    "`ReactFlowCurrentActivityCard` preserves unchanged editor header actions rendering, props, and spacing relative to the card heading and graph surface when `showHeaderActions` is true.",
    "`CURRENT_ACTIVITY_CARD_CLASS`, `CURRENT_ACTIVITY_TITLE_CLASS`, card shell structure, graph viewport wiring, and editor behavior remain unchanged in this slice.",
    "`ui/scripts/inline-component-class-usage-allowlist.mjs` no longer includes `src/features/workflow-activity/components/react-flow-current-activity-card.tsx#CURRENT_ACTIVITY_HEADER_CLASS`.",
    "The implementation stays limited to the card component and the single allowlist entry and does not touch notifications, work-outcome public barrels, or unrelated workflow-activity components.",
    "Quality gate: `bun run check:inline-component-class-usage`, focused `react-flow-current-activity-card` tests, frontend typecheck, and relevant lint pass."
  ],
  "userStories": [
    {
      "id": "inline-current-activity-card-header-class-001",
      "title": "Inline the header wrapper class on the editor actions row",
      "description": "As a frontend maintainer, I want the current-activity card header actions wrapper to keep its single-use margin class string inline on the header div so that the card component follows the shared styling standard without changing user-visible behavior.",
      "acceptanceCriteria": [
        "`ui/src/features/workflow-activity/components/react-flow-current-activity-card.tsx` no longer defines `CURRENT_ACTIVITY_HEADER_CLASS`.",
        "The wrapper `div` around `CurrentActivityGraphHeaderActions` uses `className=\"mb-4\"` directly in JSX.",
        "`CurrentActivityGraphHeaderActions` still receives the same `editorMode`, `hasChanges`, `isDefinitionLoading`, `loadErrorMessage`, `locale`, and `onToggle` props as before.",
        "`ReactFlowCurrentActivityCard` still passes `showHeaderActions` to `ReactFlowCurrentActivityCardView` so editor header actions render in the standalone card path.",
        "`CURRENT_ACTIVITY_CARD_CLASS` and `CURRENT_ACTIVITY_TITLE_CLASS` remain unchanged in this slice.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "inline-current-activity-card-header-class-002",
      "title": "Remove the stale allowlist entry and prove header layout is unchanged",
      "description": "As a reviewer, I want the inline component class usage allowlist to stop carrying the current-activity card header wrapper exception once the class is inlined so that repository debt tracking matches the real component state and header spacing remains verifiable.",
      "acceptanceCriteria": [
        "`ui/scripts/inline-component-class-usage-allowlist.mjs` no longer includes `src/features/workflow-activity/components/react-flow-current-activity-card.tsx#CURRENT_ACTIVITY_HEADER_CLASS`.",
        "`bun run check:inline-component-class-usage` passes without reintroducing an exception for `react-flow-current-activity-card.tsx` beyond the remaining `CURRENT_ACTIVITY_CARD_CLASS` and `CURRENT_ACTIVITY_TITLE_CLASS` entries.",
        "`bun test ui/src/features/workflow-activity/components/react-flow-current-activity-card.test.tsx` passes and continues to prove unchanged editor header actions behavior (for example enter/leave editor mode and toolbar availability).",
        "The cleanup remains limited to the single stale allowlist entry and does not remove unrelated allowlist debt or broaden into other files.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)