### PR TITLE
remove-work-selection-provider-session-hook-relay-from-public

### DIFF
--- a/ui/src/features/bento/components/dashboard-bento-card-catalog.stories.tsx
+++ b/ui/src/features/bento/components/dashboard-bento-card-catalog.stories.tsx
@@ -14,7 +14,7 @@ import { expectNoPageHorizontalOverflow } from "../../../stories/dashboardStoryS
 import { CurrentSelectionWidget } from "../../current-selection/public";
 import { useCurrentSelection } from "../../current-selection/hooks/useCurrentSelection";
 import { useCurrentSelectionDetails } from "../../current-selection/hooks/useCurrentSelectionDetails";
-import { useSelectedProviderSessionState } from "../../current-selection/work-selection/public";
+import { useSelectedProviderSessionState } from "../../current-selection/work-selection/hooks/useSelectedProviderSessionState";
 import { InlineAddWidgetCard } from "../../dashboard-add-card/components/inline-add-widget-card";
 import { ProviderSessionWidget } from "../../provider-session-detail/public";
 import {

--- a/ui/src/features/bento/components/dashboard-bento-cards.tsx
+++ b/ui/src/features/bento/components/dashboard-bento-cards.tsx
@@ -5,7 +5,7 @@ import { getCurrentSelectionShellMessages } from "../../current-selection/base/p
 import type { useCurrentSelection } from "../../current-selection/hooks/useCurrentSelection";
 import type { useCurrentSelectionDetails } from "../../current-selection/hooks/useCurrentSelectionDetails";
 import { CurrentSelectionWidget } from "../../current-selection/public";
-import type { useSelectedProviderSessionState } from "../../current-selection/work-selection/public";
+import type { useSelectedProviderSessionState } from "../../current-selection/work-selection/hooks/useSelectedProviderSessionState";
 import { InlineAddWidgetCard } from "../../dashboard-add-card/components/inline-add-widget-card";
 import { getProviderSessionWidgetMessages } from "../../provider-session-detail/messages/provider-session-widget";
 import { ProviderSessionWidget } from "../../provider-session-detail/public";

--- a/ui/src/features/bento/components/dashboard-bento.test.tsx
+++ b/ui/src/features/bento/components/dashboard-bento.test.tsx
@@ -81,7 +81,9 @@ vi.mock("../../current-selection/hooks/useCurrentSelectionDetails", () => ({
   }),
 }));
 
-vi.mock("../../current-selection/work-selection/public", async () => {
+vi.mock(
+  "../../current-selection/work-selection/hooks/useSelectedProviderSessionState",
+  async () => {
   const React = await vi.importActual<typeof import("react")>("react");
 
   return {

--- a/ui/src/features/bento/components/dashboard-bento.tsx
+++ b/ui/src/features/bento/components/dashboard-bento.tsx
@@ -5,7 +5,7 @@ import { DEFAULT_FACTORY_SESSION_ID } from "../../../api/session-routing";
 import { useAppLocale } from "../../../i18n";
 import { useCurrentSelection } from "../../current-selection/hooks/useCurrentSelection";
 import { useCurrentSelectionDetails } from "../../current-selection/hooks/useCurrentSelectionDetails";
-import { useSelectedProviderSessionState } from "../../current-selection/work-selection/public";
+import { useSelectedProviderSessionState } from "../../current-selection/work-selection/hooks/useSelectedProviderSessionState";
 import { useDashboardSessionStore } from "../../dashboard/state/dashboardSessionStore";
 import type { FactoryPngImportValue } from "../../import/lib/factory-png-import";
 import { DashboardImportPreviewDialog } from "../../import/public";

--- a/ui/src/features/current-selection/components/current-selection-widget.tsx
+++ b/ui/src/features/current-selection/components/current-selection-widget.tsx
@@ -13,10 +13,8 @@ import {
   WorkstationDetailCard,
 } from "../workstation-selection/public";
 import type { CurrentSelectionState } from "../hooks/useCurrentSelection";
-import {
-  useSelectedProviderSessionState,
-  WorkItemDetailCard,
-} from "../work-selection/public";
+import { useSelectedProviderSessionState } from "../work-selection/hooks/useSelectedProviderSessionState";
+import { WorkItemDetailCard } from "../work-selection/public";
 import type {
   SelectedWorkItemExecutionDetails,
   SelectedWorkRelationshipGraph,

--- a/ui/src/features/current-selection/work-selection/public/index.test.ts
+++ b/ui/src/features/current-selection/work-selection/public/index.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import * as workSelectionPublic from "./index";
 
 describe("work-selection/public", () => {
-  it("exports work detail, execution helpers, hooks, and relationship graph builders", () => {
+  it("exports work detail components, execution helpers, and relationship graph builders", () => {
     expect(workSelectionPublic.WorkItemDetailCard).toBeTypeOf("function");
     expect(workSelectionPublic.TerminalWorkSummaryCard).toBeTypeOf("function");
     expect(workSelectionPublic.ExecutionDetailsSection).toBeTypeOf("function");
@@ -11,14 +11,14 @@ describe("work-selection/public", () => {
     expect(workSelectionPublic.InferenceAttemptCard).toBeTypeOf("function");
     expect(workSelectionPublic.WorkItemPayloadList).toBeTypeOf("function");
     expect(workSelectionPublic.WorkRelationshipsSection).toBeTypeOf("function");
-    expect(workSelectionPublic.useSelectedProviderSessionState).toBeTypeOf(
-      "function",
-    );
     expect(workSelectionPublic.selectWorkItemExecutionDetails).toBeTypeOf(
       "function",
     );
     expect(workSelectionPublic.buildSelectedWorkRelationshipGraph).toBeTypeOf(
       "function",
+    );
+    expect(workSelectionPublic).not.toHaveProperty(
+      "useSelectedProviderSessionState",
     );
   });
 });

--- a/ui/src/features/current-selection/work-selection/public/index.ts
+++ b/ui/src/features/current-selection/work-selection/public/index.ts
@@ -8,9 +8,6 @@ export { InferenceAttemptCard } from "../components/inference-attempt";
 export { WorkItemPayloadList } from "../components/work-item-payload-details";
 export { WorkRelationshipsSection } from "../components/work-item-relationship-graph";
 
-export { useSelectedProviderSessionState } from "../hooks/useSelectedProviderSessionState";
-export type { SelectedProviderSessionState } from "../hooks/useSelectedProviderSessionState";
-
 export {
   selectWorkItemExecutionDetails,
 } from "../state/executionDetails";


### PR DESCRIPTION
{
  "project": "infinite-you UI",
  "branchName": "ralph/remove-work-selection-provider-session-hook-relay-from-public",
  "description": "Remove useSelectedProviderSessionState and SelectedProviderSessionState from the work-selection public barrel; retarget bento and current-selection consumers to the owning hook module while preserving provider-session selection behavior and keeping component/state exports on work-selection/public.",
  "context": {
    "customerAsk": "Keep removing unnecessary website re-exports: drop useSelectedProviderSessionState and SelectedProviderSessionState from work-selection/public, retarget bento and current-selection internals to work-selection/hooks/useSelectedProviderSessionState, and leave component and state-helper exports on the public boundary without changing selection behavior.",
    "problem": "work-selection/public still relays a provider-session hook that only bento and current-selection internals need, widening the public surface beyond components and state helpers and duplicating ownership that already lives under work-selection/hooks/.",
    "solution": "Remove the hook and type from work-selection/public, import them directly from the hook module in bento and CurrentSelectionWidget, update test mocks and narrow the public barrel test to component/state exports, and verify behavior with focused hook, bento, and widget tests."
  },
  "acceptanceCriteria": [
    "work-selection/public/index.ts does not export useSelectedProviderSessionState or SelectedProviderSessionState",
    "Bento files and current-selection-widget import the hook and type from work-selection/hooks/useSelectedProviderSessionState",
    "work-selection/public still exports work-detail components and execution/relationship state helpers used by dispatch and widgets",
    "Provider-session selection behavior in bento and current-selection widgets is unchanged",
    "Focused tests pass: useSelectedProviderSessionState.test.tsx, dashboard-bento.test.tsx, current-selection-widget.provider-session-selection.test.tsx, and work-selection/public/index.test.ts",
    "No production imports of useSelectedProviderSessionState from work-selection/public remain",
    "Typecheck, lint, and relevant UI tests pass for touched areas"
  ],
  "userStories": [
    {
      "id": "remove-work-selection-provider-session-hook-relay-from-public-001",
      "title": "Retarget current-selection widget hook import",
      "description": "As a maintainer, I want CurrentSelectionWidget to import useSelectedProviderSessionState from the owning hook module so internal feature code does not depend on a public hook relay.",
      "acceptanceCriteria": [
        "CurrentSelectionWidget imports useSelectedProviderSessionState from ../work-selection/hooks/useSelectedProviderSessionState, not work-selection/public",
        "With a work item selected and visible provider sessions, the widget still shows provider-session selection affordances and updates the selected session when the user picks a different session",
        "bun test ui/src/features/current-selection/components/current-selection-widget.provider-session-selection.test.tsx passes",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "remove-work-selection-provider-session-hook-relay-from-public-002",
      "title": "Retarget bento hook imports and mocks",
      "description": "As a dashboard user, I want bento cards to keep reflecting the selected provider session when selection context changes, without importing the hook through work-selection/public.",
      "acceptanceCriteria": [
        "dashboard-bento.tsx, dashboard-bento-cards.tsx, and dashboard-bento-card-catalog.stories.tsx import the hook and/or type from ../../current-selection/work-selection/hooks/useSelectedProviderSessionState",
        "dashboard-bento.test.tsx mocks the hook module path instead of work-selection/public when stubbing provider-session state",
        "Bento tests still render provider-session-aware card content when mocked selection includes provider sessions",
        "bun test ui/src/features/bento/components/dashboard-bento.test.tsx passes",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "remove-work-selection-provider-session-hook-relay-from-public-003",
      "title": "Remove hook relay from work-selection public boundary",
      "description": "As a feature-boundary maintainer, I want work-selection/public to expose only components and state helpers so new code cannot import the provider-session hook from the public barrel.",
      "acceptanceCriteria": [
        "work-selection/public/index.ts no longer re-exports useSelectedProviderSessionState or SelectedProviderSessionState",
        "work-selection/public/index.ts still exports work-detail components and selectWorkItemExecutionDetails, buildSelectedWorkRelationshipGraph, and related types",
        "work-selection/public/index.test.ts verifies remaining public exports without asserting the hook is exported",
        "Dispatch and widget files that import only components or state from work-selection/public compile without import changes",
        "bun test ui/src/features/current-selection/work-selection/public/index.test.ts passes",
        "Typecheck passes"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "remove-work-selection-provider-session-hook-relay-from-public-004",
      "title": "Confirm hook and integration regression coverage",
      "description": "As a reviewer, I want behavioral tests to show provider-session selection and dependent surfaces still work after the import boundary change.",
      "acceptanceCriteria": [
        "bun test ui/src/features/current-selection/work-selection/hooks/useSelectedProviderSessionState.test.tsx passes",
        "bun test ui/src/features/bento/components/dashboard-bento.test.tsx and bun test ui/src/features/current-selection/components/current-selection-widget.provider-session-selection.test.tsx pass with the public barrel test",
        "No remaining production imports of useSelectedProviderSessionState from work-selection/public",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)