### PR TITLE
remove-workstation-selection-hook-relays-from-public

### DIFF
--- a/ui/src/features/current-selection/components/current-selection-widget.tsx
+++ b/ui/src/features/current-selection/components/current-selection-widget.tsx
@@ -5,11 +5,11 @@ import type {
   DashboardTrace,
 } from "../../../api/dashboard/types";
 import type { LoadableProviderSessionRef } from "../../provider-session-detail/lib/provider-session-ref";
+import { useEditableWorkstationConfigurationState } from "../workstation-selection/hooks/use-editable-workstation-configuration-state";
+import { useSaveEditableWorkstationConfiguration } from "../workstation-selection/hooks/use-save-editable-workstation-configuration";
 import {
   EditableWorkstationSaveDialog,
   EditableWorkstationSaveHeaderAction,
-  useEditableWorkstationConfigurationState,
-  useSaveEditableWorkstationConfiguration,
   WorkstationDetailCard,
 } from "../workstation-selection/public";
 import type { CurrentSelectionState } from "../hooks/useCurrentSelection";

--- a/ui/src/features/current-selection/workstation-selection/public/index.test.ts
+++ b/ui/src/features/current-selection/workstation-selection/public/index.test.ts
@@ -3,31 +3,40 @@ import { describe, expect, it } from "vitest";
 import * as workstationSelectionPublic from "./index";
 
 describe("workstation-selection/public", () => {
-  it("exports workstation detail, save controls, hooks, and message helpers", () => {
-    expect(workstationSelectionPublic.WorkstationDetailCard).toBeTypeOf("function");
+  it("exports workstation detail, save controls, runner metadata, and message helpers", () => {
+    expect(workstationSelectionPublic.WorkstationDetailCard).toBeTypeOf(
+      "function",
+    );
     expect(workstationSelectionPublic.EditableWorkstationSaveDialog).toBeTypeOf(
       "function",
     );
-    expect(workstationSelectionPublic.EditableWorkstationSaveHeaderAction).toBeTypeOf(
-      "function",
-    );
-    expect(workstationSelectionPublic.useEditableWorkstationConfigurationState).toBeTypeOf(
-      "function",
-    );
-    expect(workstationSelectionPublic.useSaveEditableWorkstationConfiguration).toBeTypeOf(
-      "function",
-    );
+    expect(
+      workstationSelectionPublic.EditableWorkstationSaveHeaderAction,
+    ).toBeTypeOf("function");
     expect(workstationSelectionPublic.getWorkstationDetailMessages).toBeTypeOf(
       "function",
     );
-    expect(workstationSelectionPublic.ProviderSessionAttempts).toBeTypeOf("function");
-    expect(workstationSelectionPublic.CollapsibleProviderSessionAttempts).toBeTypeOf(
+    expect(workstationSelectionPublic.ProviderSessionAttempts).toBeTypeOf(
       "function",
     );
     expect(
-      workstationSelectionPublic.useCurrentWorkstationPromptTemplateValidation,
+      workstationSelectionPublic.CollapsibleProviderSessionAttempts,
     ).toBeTypeOf("function");
-    expect(workstationSelectionPublic.BUILT_IN_RUNNER_IDS.length).toBeGreaterThan(0);
+    expect(
+      workstationSelectionPublic.BUILT_IN_RUNNER_IDS.length,
+    ).toBeGreaterThan(0);
     expect(workstationSelectionPublic.getRunnerMetadata).toBeTypeOf("function");
+  });
+
+  it("does not export workstation editing hooks", () => {
+    expect(workstationSelectionPublic).not.toHaveProperty(
+      "useEditableWorkstationConfigurationState",
+    );
+    expect(workstationSelectionPublic).not.toHaveProperty(
+      "useSaveEditableWorkstationConfiguration",
+    );
+    expect(workstationSelectionPublic).not.toHaveProperty(
+      "useCurrentWorkstationPromptTemplateValidation",
+    );
   });
 });

--- a/ui/src/features/current-selection/workstation-selection/public/index.ts
+++ b/ui/src/features/current-selection/workstation-selection/public/index.ts
@@ -1,41 +1,31 @@
 export {
-  WorkstationDetailCard,
-} from "../components/workstation-detail-card";
-
+  CollapsibleProviderSessionAttempts,
+  ProviderSessionAttempts,
+} from "../components/provider-session-attempts";
+export { WorkstationDetailCard } from "../components/workstation-detail-card";
 export {
   EditableWorkstationSaveDialog,
   EditableWorkstationSaveHeaderAction,
 } from "../components/workstation-save-controls";
 
 export {
-  CollapsibleProviderSessionAttempts,
-  ProviderSessionAttempts,
-} from "../components/provider-session-attempts";
-
-export { useEditableWorkstationConfigurationState } from "../hooks/use-editable-workstation-configuration-state";
-export { useSaveEditableWorkstationConfiguration } from "../hooks/use-save-editable-workstation-configuration";
-export { useCurrentWorkstationPromptTemplateValidation } from "../hooks/useCurrentWorkstationPromptTemplateValidation";
-
-export {
   BUILT_IN_RUNNER_IDS,
   getRunnerMetadata,
-  type RunnerCapabilitySupport,
   type RunnerCapabilitiesMetadata,
+  type RunnerCapabilitySupport,
   type RunnerID,
   type RunnerMetadata,
   type RunnerOptionalCapability,
   type RunnerOptionalCapabilityStatus,
 } from "../editing/runner-metadata";
-
-export {
-  getWorkstationDetailMessages,
-  workstationDetailMessagesByLocale,
-} from "../messages/workstation-detail";
-export type { WorkstationDetailMessages } from "../messages/workstation-detail-types";
-
 export type {
   EditableWorkstationConfigurationState,
   EditableWorkstationOverwriteField,
   EditableWorkstationSaveState,
   WorkstationDetailCardProps,
 } from "../lib/detail-card-types";
+export {
+  getWorkstationDetailMessages,
+  workstationDetailMessagesByLocale,
+} from "../messages/workstation-detail";
+export type { WorkstationDetailMessages } from "../messages/workstation-detail-types";


### PR DESCRIPTION
```json
{
  "project": "infinite-you UI",
  "branchName": "ralph/remove-workstation-selection-hook-relays-from-public",
  "description": "Remove useEditableWorkstationConfigurationState, useSaveEditableWorkstationConfiguration, and useCurrentWorkstationPromptTemplateValidation from the workstation-selection public barrel; retarget CurrentSelectionWidget to the owning hook modules while preserving workstation editing and save behavior and keeping component, runner-metadata, and message exports on workstation-selection/public.",
  "context": {
    "customerAsk": "Continue removing unnecessary website re-exports: drop the three workstation editing hooks from workstation-selection/public, retarget current-selection-widget.tsx to workstation-selection/hooks/*, and leave component, runner-metadata, message, and detail-card type exports on the public boundary without changing workstation save or validation behavior.",
    "problem": "workstation-selection/public still relays three workstation editing hooks that only CurrentSelectionWidget consumes through the public barrel, while other current-selection tests already import those hooks from owning modules. The barrel widens the supported cross-feature API beyond presentation components and shared metadata helpers.",
    "solution": "Retarget CurrentSelectionWidget hook imports to workstation-selection/hooks/*, remove the three hook re-exports from workstation-selection/public, narrow workstation-selection/public/index.test.ts to assert the remaining public surface without hook export inventory checks, and verify unchanged behavior with focused hook and widget tests."
  },
  "acceptanceCriteria": [
    "workstation-selection/public/index.ts no longer re-exports useEditableWorkstationConfigurationState, useSaveEditableWorkstationConfiguration, or useCurrentWorkstationPromptTemplateValidation",
    "current-selection-widget.tsx imports the three hooks from workstation-selection/hooks/* owning modules",
    "workstation-selection/public still exports WorkstationDetailCard, save controls, ProviderSessionAttempts, runner metadata, message helpers, and detail-card types for existing consumers",
    "Workstation editing and save behavior in the current-selection widget is unchanged",
    "Focused tests pass: use-editable-workstation-configuration-state.test.tsx, use-save-editable-workstation-configuration.test.tsx, current-selection-widget.test.tsx, and workstation-selection/public/index.test.ts",
    "No production imports of the three workstation editing hooks from workstation-selection/public remain under ui/src",
    "Typecheck, lint, and relevant UI tests pass for touched areas"
  ],
  "userStories": [
    {
      "id": "remove-workstation-selection-hook-relays-from-public-001",
      "title": "Retarget current-selection widget hook imports",
      "passes": true
    },
    {
      "id": "remove-workstation-selection-hook-relays-from-public-002",
      "title": "Remove hook relays from workstation-selection public boundary",
      "passes": true
    },
    {
      "id": "remove-workstation-selection-hook-relays-from-public-003",
      "title": "Confirm hook and widget regression coverage",
      "passes": true
    }
  ]
}
```

## Test plan
- [x] `bunx vitest run` on hook, widget, and public barrel test files (42 tests)
- [x] `bun run tsc` typecheck
- [x] Grep confirms no production hook imports from `workstation-selection/public`

Made with [Cursor](https://cursor.com)