### PR TITLE
cli-work-inspection-v1

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -119,6 +119,7 @@ export default defineConfig({
       exclude: [
         ...coverageConfigDefaults.exclude,
         "**/*.jsonl",
+        "src/api/generated/**",
         "scripts/**",
         "src/testing/app-shell-test-graph-layout.ts",
         "src/testing/replay-harness.ts",


### PR DESCRIPTION
{
  "project": "CLI Work Inspection v1",
  "branchName": "ralph/cli-work-inspection-v1",
  "description": "Improve the submit → verify loop by adding work type to the default you work list table, server-backed list filters (name, work type, trace id, work id), and a new you work show command for single-item inspection.",
  "context": {
    "customerAsk": "After you submit, agents need to confirm work exists with the correct work type and state without paginating blindly. Extend you work list with a default work type column and filters (--name, --work-type-name, --trace-id), add you work show <work-id> for a single-token summary, and align with the submit response contract and agents verify playbook.",
    "problem": "you work list human output omits workTypeName even though the API returns it. There are no CLI filters for name, work type, or trace id, and the list API only supports state-based filters. There is no you work show command, forcing agents to paginate JSON or guess from incomplete submit output.",
    "solution": "Add WORK TYPE to the default list table, extend list-work OpenAPI and backend filtering for name/workTypeName/traceId/workId, wire matching CLI flags on you work list, and introduce you work show that fetches one Work via the workId list filter and prints state, trace, and relations in human or JSON form."
  },
  "acceptanceCriteria": [
    "you work list human table includes a WORK TYPE column populated from workTypeName",
    "you work list supports --name, --work-type-name, and --trace-id flags backed by server-side list-work query parameters",
    "you work show <work-id> prints workId, name, workTypeName, state.name, state.type, traceId, and relations summary; exits non-zero when the id is not found",
    "Global --json on list emits ListWorkResponse; --json on show emits a single Work object",
    "Commands honor default session targeting and stderr diagnostics consistent with existing you work list behavior",
    "Focused CLI and API tests prove table output, filter wiring, show success, and show not-found without command-registration inventory checks",
    "Typecheck, lint, and tests pass for all touched packages"
  ],
  "userStories": [
    {
      "id": "cli-work-inspection-v1-001",
      "title": "Work type column in default list table",
      "description": "As an agent verifying a submission, I want work type visible in the default you work list table so I can confirm I submitted to the correct type without parsing JSON.",
      "acceptanceCriteria": [
        "Human you work list output adds a WORK TYPE column sourced from each item's workTypeName (empty cell when absent)",
        "Existing columns WORK ID, NAME, STATE NAME, STATE TYPE, and RELATIONS remain present and tab-aligned",
        "--json output is unchanged and still includes workTypeName on each result object",
        "CLI unit test asserts the table header includes WORK TYPE and a row renders the expected work type value",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "cli-work-inspection-v1-002",
      "title": "List-work API filter query parameters",
      "description": "As a maintainer, I need the list-work API to filter by name, work type, trace id, and work id so CLI and scripts can verify submissions without client-side pagination hacks.",
      "acceptanceCriteria": [
        "OpenAPI GET /work and session-scoped list routes accept optional query parameters: name (case-sensitive substring on work name), workTypeName (exact), traceId (exact on legacy traceId or currentChainingTraceId), and workId (exact)",
        "Regenerated server bindings compile; ListWork and ListWorkBySessionId apply the new filters before pagination",
        "Empty filter values are ignored; invalid state.type and sortBy validation behavior is unchanged",
        "API tests cover filter by workTypeName, filter by name substring, filter by workId exact match, and combined filter with state.name",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "cli-work-inspection-v1-003",
      "title": "CLI list filters for name, work type, and trace",
      "description": "As an agent, I want you work list flags to find work by name, type, or trace after submit so I can verify the right item quickly.",
      "acceptanceCriteria": [
        "you work list accepts --name, --work-type-name, and --trace-id flags mapped to the corresponding list-work query parameters",
        "--help documents filter semantics (substring vs exact), interaction with --max-results and --next-token, and session scoping via --session",
        "Verbose diagnostics include the active filter summary without printing full response payloads",
        "CLI tests assert query string wiring for at least --work-type-name and --name, and human output reflects filtered results from a mocked server",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "cli-work-inspection-v1-004",
      "title": "you work show single work summary",
      "description": "As an agent, I want you work show <work-id> to print one work item's key fields so I can verify state and relations without paginating list JSON.",
      "acceptanceCriteria": [
        "you work show <work-id> requires exactly one positional argument",
        "Command calls list-work scoped to the selected session with workId filter and renders human output including workId, name, workTypeName, state.name, state.type, traceId (prefer currentChainingTraceId when present), and relations count or list-style relation summary",
        "When no matching work exists, exit non-zero with a clear error on stderr; stdout remains empty in human mode",
        "--json emits a single Work JSON object on success",
        "Command registers under you work show with shared --server, --session, and global --json wiring consistent with you work list",
        "CLI tests cover success output shape and not-found exit behavior with a mocked HTTP server",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)