### PR TITLE
backend-service-refactor

### DIFF
--- a/docs/internal/development/backend-service-refactor-service-package-closeout.md
+++ b/docs/internal/development/backend-service-refactor-service-package-closeout.md
@@ -70,3 +70,11 @@ For a full maintainer gate aligned with pull-request verification:
 ```text
 make lint
 ```
+
+## Verification Record (UTC)
+
+Validated on `ralph/backend-service-refactor` after extractions 001–004 (2026-05-30):
+
+- `make vet backend-size pkg-maint pkg-file-count` — passed
+- `go test ./pkg/factorysessions/... ./pkg/localmodels/... ./pkg/hostedworkers/...` — passed
+- `go test ./pkg/service/... ./pkg/api/...` — passed

--- a/pkg/factorysessions/api_test.go
+++ b/pkg/factorysessions/api_test.go
@@ -1,0 +1,55 @@
+package factorysessions
+
+import (
+	"testing"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
+)
+
+func TestListSummaries_OrdersDefaultSessionFirst(t *testing.T) {
+	registry := NewRegistry()
+	registry.Upsert(NewLiveSession(
+		"session-b",
+		"/factories/b",
+		"/workspace",
+		TargetRef{Kind: TargetKindNamed, Name: "b"},
+		nil,
+		false,
+		"b",
+	), true)
+	registry.Upsert(NewLiveSession(
+		DefaultSessionID,
+		"/factories/default",
+		"/workspace",
+		TargetRef{Kind: TargetKindDefault},
+		nil,
+		true,
+		"default",
+	), false)
+
+	summaries := ListSummaries(registry)
+	if len(summaries) != 2 {
+		t.Fatalf("len(summaries) = %d, want 2", len(summaries))
+	}
+	if !summaries[0].IsDefault || summaries[0].Id != DefaultSessionID {
+		t.Fatalf("first summary = %#v, want default session first", summaries[0])
+	}
+}
+
+func TestSummaryResponse_MapsLiveSessionFields(t *testing.T) {
+	name := "beta"
+	summary := SummaryResponse(&LiveSession{
+		ID:         "session-1",
+		FactoryDir: "/factories/beta",
+		FolderPath: "/workspace",
+		IsDefault:  false,
+		Project:    "beta-project",
+		Target:     TargetRef{Kind: TargetKindNamed, Name: name},
+	})
+	if summary.Id != "session-1" || summary.Project != "beta-project" {
+		t.Fatalf("summary = %#v, want mapped session fields", summary)
+	}
+	if summary.Target.Kind != factoryapi.FactorySessionTargetRefKindNamed || summary.Target.Name == nil || *summary.Target.Name != name {
+		t.Fatalf("summary target = %#v, want named beta target", summary.Target)
+	}
+}

--- a/pkg/factorysessions/discovery_test.go
+++ b/pkg/factorysessions/discovery_test.go
@@ -1,0 +1,92 @@
+package factorysessions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func alwaysRunnableProbe(folderPath, factoryDir string, ref TargetRef) (Target, bool) {
+	return BuildTargetFromConfig(folderPath, factoryDir, ref, filepath.Base(factoryDir)), true
+}
+
+func TestDiscoverTargets_ReturnsDefaultAndNamedTargets(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "beta"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	targets, err := DiscoverTargets(root, alwaysRunnableProbe)
+	if err != nil {
+		t.Fatalf("DiscoverTargets: %v", err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("len(targets) = %d, want 2", len(targets))
+	}
+	if targets[0].Ref.Kind != TargetKindDefault || targets[1].Ref != (TargetRef{Kind: TargetKindNamed, Name: "beta"}) {
+		t.Fatalf("targets = %#v, want default then named beta", targets)
+	}
+}
+
+func TestDiscoverTargets_RejectsFolderWithoutRunnableTargets(t *testing.T) {
+	root := t.TempDir()
+	_, err := DiscoverTargets(root, func(string, string, TargetRef) (Target, bool) {
+		return Target{}, false
+	})
+	if err == nil {
+		t.Fatal("DiscoverTargets(empty) error = nil, want not runnable")
+	}
+	reason, field, ok := ValidationReasonFromError(err)
+	if !ok || reason != ValidationReasonNotRunnable || field != "folderPath" {
+		t.Fatalf("validation = (%q, %q, %v), want not_runnable folderPath", reason, field, ok)
+	}
+}
+
+func TestSelectTarget_AutoSelectsSingleTarget(t *testing.T) {
+	targets := []Target{{
+		Ref:   TargetRef{Kind: TargetKindDefault},
+		Label: "default",
+	}}
+	selected, err := SelectTarget(targets, nil)
+	if err != nil {
+		t.Fatalf("SelectTarget: %v", err)
+	}
+	if selected == nil || selected.Ref.Kind != TargetKindDefault {
+		t.Fatalf("selected = %#v, want default target", selected)
+	}
+}
+
+func TestSelectTarget_ReturnsNilForAmbiguousFolder(t *testing.T) {
+	targets := []Target{
+		{Ref: TargetRef{Kind: TargetKindDefault}},
+		{Ref: TargetRef{Kind: TargetKindNamed, Name: "beta"}},
+	}
+	selected, err := SelectTarget(targets, nil)
+	if err != nil {
+		t.Fatalf("SelectTarget: %v", err)
+	}
+	if selected != nil {
+		t.Fatalf("selected = %#v, want nil for multi-target picker", selected)
+	}
+}
+
+func TestSelectTarget_RejectsMissingNamedTarget(t *testing.T) {
+	targets := []Target{{Ref: TargetRef{Kind: TargetKindDefault}}}
+	_, err := SelectTarget(targets, &TargetRef{Kind: TargetKindNamed, Name: "missing"})
+	if err == nil {
+		t.Fatal("SelectTarget(missing) error = nil, want target_not_found")
+	}
+	reason, field, ok := ValidationReasonFromError(err)
+	if !ok || reason != ValidationReasonTargetNotFound || field != "target.name" {
+		t.Fatalf("validation = (%q, %q, %v), want target_not_found target.name", reason, field, ok)
+	}
+}
+
+func TestCloneTargets_ReturnsDefensiveCopy(t *testing.T) {
+	original := []Target{{Ref: TargetRef{Kind: TargetKindDefault}, Label: "default"}}
+	cloned := CloneTargets(original)
+	original[0].Label = "mutated"
+	if cloned[0].Label != "default" {
+		t.Fatalf("cloned label = %q, want unchanged copy", cloned[0].Label)
+	}
+}

--- a/pkg/factorysessions/paths_test.go
+++ b/pkg/factorysessions/paths_test.go
@@ -1,0 +1,76 @@
+package factorysessions
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveSessionFolder_RequiresPath(t *testing.T) {
+	_, err := ResolveSessionFolder("   ")
+	if err == nil {
+		t.Fatal("ResolveSessionFolder(empty) error = nil, want validation failure")
+	}
+	reason, field, ok := ValidationReasonFromError(err)
+	if !ok || reason != ValidationReasonRequired || field != "folderPath" {
+		t.Fatalf("validation = (%q, %q, %v), want required folderPath", reason, field, ok)
+	}
+}
+
+func TestResolveSessionFolder_RejectsMissingDirectory(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing-session-folder")
+	_, err := ResolveSessionFolder(missing)
+	if err == nil {
+		t.Fatal("ResolveSessionFolder(missing) error = nil, want failure")
+	}
+	reason, field, ok := ValidationReasonFromError(err)
+	if !ok || reason != ValidationReasonMissing || field != "folderPath" {
+		t.Fatalf("validation = (%q, %q, %v), want missing folderPath", reason, field, ok)
+	}
+	if !strings.Contains(err.Error(), missing) {
+		t.Fatalf("error = %q, want resolved path %q", err, missing)
+	}
+}
+
+func TestExpandFolderHome_ExpandsTildePrefix(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got, err := ExpandFolderHome("~/sessions/workspace")
+	if err != nil {
+		t.Fatalf("ExpandFolderHome: %v", err)
+	}
+	want := filepath.Join(home, "sessions", "workspace")
+	if got != want {
+		t.Fatalf("ExpandFolderHome = %q, want %q", got, want)
+	}
+}
+
+func TestSameFactoryDir_NormalizesEquivalentPaths(t *testing.T) {
+	left := filepath.Join("/tmp", "factory", ".", "named")
+	right := filepath.Join("/tmp", "factory", "named")
+	if !SameFactoryDir(left, right) {
+		t.Fatal("SameFactoryDir did not treat equivalent paths as equal")
+	}
+	if SameFactoryDir("", right) {
+		t.Fatal("SameFactoryDir accepted empty left path")
+	}
+}
+
+func TestResolveSessionFolder_ExpandsTildeBeforeStat(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	sessionDir := filepath.Join(home, "session-root")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	got, err := ResolveSessionFolder("~/session-root")
+	if err != nil {
+		t.Fatalf("ResolveSessionFolder: %v", err)
+	}
+	if got != sessionDir {
+		t.Fatalf("ResolveSessionFolder = %q, want %q", got, sessionDir)
+	}
+}

--- a/pkg/factorysessions/registry_test.go
+++ b/pkg/factorysessions/registry_test.go
@@ -1,0 +1,56 @@
+package factorysessions
+
+import "testing"
+
+func TestRegistry_UpsertSelectAndRemove(t *testing.T) {
+	registry := NewRegistry()
+
+	defaultSession := NewLiveSession(DefaultSessionID, "/factories/alpha", "/workspace", TargetRef{Kind: TargetKindDefault}, "handle-default", true, "alpha")
+	betaSession := NewLiveSession("session-beta", "/factories/beta", "/workspace", TargetRef{Kind: TargetKindNamed, Name: "beta"}, "handle-beta", false, "beta")
+
+	registry.Upsert(defaultSession, true)
+	if got := registry.Current(); got != defaultSession {
+		t.Fatalf("Current() = %#v, want default session", got)
+	}
+	if registry.Count() != 1 {
+		t.Fatalf("Count() = %d, want 1", registry.Count())
+	}
+
+	registry.Upsert(betaSession, false)
+	if got := registry.Current(); got != defaultSession {
+		t.Fatalf("Current() after non-select upsert = %#v, want default session", got)
+	}
+	if registry.Count() != 2 {
+		t.Fatalf("Count() = %d, want 2", registry.Count())
+	}
+
+	if !registry.Select("session-beta") {
+		t.Fatal("Select(session-beta) = false, want true")
+	}
+	if got := registry.Current(); got != betaSession {
+		t.Fatalf("Current() after select = %#v, want beta session", got)
+	}
+
+	registry.Remove(DefaultSessionID)
+	if got := registry.Current(); got != betaSession {
+		t.Fatalf("Current() after removing default = %#v, want beta session", got)
+	}
+	if registry.Get(DefaultSessionID) != nil {
+		t.Fatal("removed default session is still registered")
+	}
+
+	registry.Remove("session-beta")
+	if registry.Current() != nil {
+		t.Fatalf("Current() after removing all = %#v, want nil", registry.Current())
+	}
+	if got := registry.IDs(); len(got) != 0 {
+		t.Fatalf("IDs() = %#v, want empty", got)
+	}
+}
+
+func TestRegistry_SelectUnknownReturnsFalse(t *testing.T) {
+	registry := NewRegistry()
+	if registry.Select("missing") {
+		t.Fatal("Select(missing) = true, want false")
+	}
+}

--- a/pkg/factorysessions/validation_test.go
+++ b/pkg/factorysessions/validation_test.go
@@ -1,0 +1,29 @@
+package factorysessions
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestValidationReasonFromError_RecognizesStructuredValidationErrors(t *testing.T) {
+	err := NewValidationError(ValidationReasonUnreadable, "folderPath", errors.New("permission denied"))
+	reason, field, ok := ValidationReasonFromError(err)
+	if !ok || reason != ValidationReasonUnreadable || field != "folderPath" {
+		t.Fatalf("ValidationReasonFromError = (%q, %q, %v)", reason, field, ok)
+	}
+
+	var ve *validationError
+	if !errors.As(err, &ve) {
+		t.Fatal("expected validationError type")
+	}
+	targets := ve.ErrorTargets()
+	if len(targets) != 1 || targets[0].Code == "" || targets[0].Subject.Id != "folderPath" {
+		t.Fatalf("ErrorTargets() = %#v, want folderPath validation target", targets)
+	}
+}
+
+func TestValidationReasonFromError_IgnoresUnrelatedErrors(t *testing.T) {
+	if _, _, ok := ValidationReasonFromError(errors.New("other")); ok {
+		t.Fatal("ValidationReasonFromError(other) = ok, want false")
+	}
+}

--- a/pkg/hostedworkers/supervisor_test.go
+++ b/pkg/hostedworkers/supervisor_test.go
@@ -6,10 +6,12 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/jonboulle/clockwork"
 	"github.com/portpowered/infinite-you/pkg/config"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"go.uber.org/zap"
@@ -184,6 +186,57 @@ func TestStartLinearPoller_StopsAndLogsLifecycle(t *testing.T) {
 	}
 }
 
+func TestStartLinearPoller_RestartsOnMissingAuthConfig(t *testing.T) {
+	fakeClock := clockwork.NewFakeClock()
+	logCore, observedLogs := observer.New(zap.InfoLevel)
+	poller := interfaces.FactoryWorkstationConfig{
+		Name:           "linear-ingress",
+		Kind:           interfaces.WorkstationKindPoller,
+		WorkerTypeName: "linear-poller",
+	}
+	worker := &interfaces.WorkerConfig{
+		Name:     "linear-poller",
+		Type:     interfaces.WorkerTypeHosted,
+		Provider: interfaces.HostedWorkerProviderLinear,
+		Linear: &interfaces.HostedLinearWorkerConfig{
+			PollInterval: "1h",
+			Mapping: interfaces.HostedLinearWorkerMappingConfig{
+				WorkType: "story",
+				State:    "init",
+			},
+		},
+	}
+	runtimeCfg, err := config.NewLoadedFactoryConfig(t.TempDir(), &interfaces.FactoryConfig{}, nil)
+	if err != nil {
+		t.Fatalf("NewLoadedFactoryConfig: %v", err)
+	}
+
+	pollerCfg := Config{
+		Logger: zap.New(logCore),
+		Clock:  fakeClock,
+	}
+
+	sidecarCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var sidecars sync.WaitGroup
+	StartLinearPoller(sidecarCtx, &sidecars, pollerCfg, runtimeCfg, poller, worker, func(context.Context, interfaces.WorkRequest) error {
+		return nil
+	})
+
+	waitForObservedLogMessage(t, observedLogs, "hosted linear poller restarting", time.Second)
+	restartEntry := observedLogs.FilterMessage("hosted linear poller restarting").All()[0]
+	if got := restartEntry.ContextMap()["error"]; got == nil || !strings.Contains(fieldString(got), "missing auth.secretRef") {
+		t.Fatalf("restart error = %#v, want missing auth.secretRef context", got)
+	}
+
+	waitForFakeClockWaiters(t, fakeClock, 1)
+	fakeClock.Advance(restartBackoffMin)
+	waitForObservedLogMessage(t, observedLogs, "hosted linear poller restarting", time.Second)
+	if observedLogs.FilterMessage("hosted linear poller restarting").Len() < 2 {
+		t.Fatalf("restart log count = %d, want at least 2 after backoff", observedLogs.FilterMessage("hosted linear poller restarting").Len())
+	}
+}
+
 func waitForSubmitCalls(t *testing.T, submitCalls *int, want int, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
@@ -206,4 +259,24 @@ func waitForObservedLogMessage(t *testing.T, logs *observer.ObservedLogs, messag
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("timed out waiting for log message %q", message)
+}
+
+func waitForFakeClockWaiters(t *testing.T, fakeClock *clockwork.FakeClock, waiters int) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := fakeClock.BlockUntilContext(ctx, waiters); err != nil {
+		t.Fatalf("timed out waiting for %d fake-clock waiter(s): %v", waiters, err)
+	}
+}
+
+func fieldString(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case error:
+		return typed.Error()
+	default:
+		return ""
+	}
 }

--- a/pkg/hostedworkers/supervisor_test.go
+++ b/pkg/hostedworkers/supervisor_test.go
@@ -231,10 +231,7 @@ func TestStartLinearPoller_RestartsOnMissingAuthConfig(t *testing.T) {
 
 	waitForFakeClockWaiters(t, fakeClock, 1)
 	fakeClock.Advance(restartBackoffMin)
-	waitForObservedLogMessage(t, observedLogs, "hosted linear poller restarting", time.Second)
-	if observedLogs.FilterMessage("hosted linear poller restarting").Len() < 2 {
-		t.Fatalf("restart log count = %d, want at least 2 after backoff", observedLogs.FilterMessage("hosted linear poller restarting").Len())
-	}
+	waitForObservedLogCount(t, observedLogs, "hosted linear poller restarting", 2, time.Second)
 }
 
 func waitForSubmitCalls(t *testing.T, submitCalls *int, want int, timeout time.Duration) {
@@ -251,14 +248,19 @@ func waitForSubmitCalls(t *testing.T, submitCalls *int, want int, timeout time.D
 
 func waitForObservedLogMessage(t *testing.T, logs *observer.ObservedLogs, message string, timeout time.Duration) {
 	t.Helper()
+	waitForObservedLogCount(t, logs, message, 1, timeout)
+}
+
+func waitForObservedLogCount(t *testing.T, logs *observer.ObservedLogs, message string, want int, timeout time.Duration) {
+	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		if logs.FilterMessage(message).Len() > 0 {
+		if logs.FilterMessage(message).Len() >= want {
 			return
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatalf("timed out waiting for log message %q", message)
+	t.Fatalf("timed out waiting for %d log message(s) %q; got %d", want, message, logs.FilterMessage(message).Len())
 }
 
 func waitForFakeClockWaiters(t *testing.T, fakeClock *clockwork.FakeClock, waiters int) {

--- a/pkg/localmodels/catalog_test.go
+++ b/pkg/localmodels/catalog_test.go
@@ -1,0 +1,118 @@
+package localmodels
+
+import (
+	"errors"
+	"testing"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
+	"github.com/portpowered/infinite-you/pkg/apisurface"
+	factoryconfig "github.com/portpowered/infinite-you/pkg/config"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+)
+
+func TestCanonicalModelName_NormalizesCaseAndWhitespace(t *testing.T) {
+	if got := CanonicalModelName("  omnivoice_q4_k_m  "); got != "OMNIVOICE_Q4_K_M" {
+		t.Fatalf("CanonicalModelName() = %q, want OMNIVOICE_Q4_K_M", got)
+	}
+	if CanonicalModelName("") != "" {
+		t.Fatal("CanonicalModelName(\"\") = non-empty, want empty")
+	}
+}
+
+func TestListModels_SummarizesConfiguredModelCapabilities(t *testing.T) {
+	loaded := mustLoadedCatalogConfig(t, catalogFactoryConfig(true))
+
+	models, err := ListModels(loaded)
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	if len(models.Results) != 1 {
+		t.Fatalf("models count = %d, want 1", len(models.Results))
+	}
+	model := models.Results[0]
+	if model.Name != "OMNIVOICE_Q4_K_M" || model.ProviderLocality != factoryapi.WorkerModelLocalityLocal {
+		t.Fatalf("model summary = %#v, want OMNIVOICE local model", model)
+	}
+	if model.Status != factoryapi.ModelStatusREADY || model.LoadState != factoryapi.UNLOADED {
+		t.Fatalf("model readiness = (%s, %s), want (READY, UNLOADED)", model.Status, model.LoadState)
+	}
+	if len(model.Operations) != 1 || model.Operations[0].Name != "TTS" {
+		t.Fatalf("operations = %#v, want one TTS operation", model.Operations)
+	}
+	if len(model.Modalities) != 2 {
+		t.Fatalf("modalities = %#v, want TEXT and AUDIO", model.Modalities)
+	}
+	if len(model.Resources) != 1 || model.Resources[0].Name != "omnivoice-cache" {
+		t.Fatalf("resources = %#v, want omnivoice-cache summary", model.Resources)
+	}
+}
+
+func TestGetModel_ReturnsUnavailableWithoutMatchingLocalModelResource(t *testing.T) {
+	loaded := mustLoadedCatalogConfig(t, catalogFactoryConfig(false))
+
+	model, err := GetModel(loaded, "OMNIVOICE_Q4_K_M")
+	if err != nil {
+		t.Fatalf("GetModel: %v", err)
+	}
+	if model.Status != factoryapi.ModelStatusUNAVAILABLE {
+		t.Fatalf("status = %s, want UNAVAILABLE", model.Status)
+	}
+	if model.Diagnostics["statusReason"] == "" {
+		t.Fatalf("diagnostics = %#v, want statusReason", model.Diagnostics)
+	}
+}
+
+func TestGetModel_ReturnsNotFoundForUnknownModel(t *testing.T) {
+	loaded := mustLoadedCatalogConfig(t, &interfaces.FactoryConfig{Name: "factory"})
+
+	_, err := GetModel(loaded, "missing")
+	if !errors.Is(err, apisurface.ErrModelNotFound) {
+		t.Fatalf("GetModel error = %v, want ErrModelNotFound", err)
+	}
+}
+
+func mustLoadedCatalogConfig(t *testing.T, factoryCfg *interfaces.FactoryConfig) *factoryconfig.LoadedFactoryConfig {
+	t.Helper()
+	loaded, err := factoryconfig.NewLoadedFactoryConfig(t.TempDir(), factoryCfg, nil)
+	if err != nil {
+		t.Fatalf("NewLoadedFactoryConfig: %v", err)
+	}
+	return loaded
+}
+
+func catalogFactoryConfig(includeResource bool) *interfaces.FactoryConfig {
+	worker := interfaces.WorkerConfig{
+		Name:          "voice-local",
+		Type:          interfaces.WorkerTypeModel,
+		Model:         "OMNIVOICE_Q4_K_M",
+		ModelLocality: interfaces.ModelLocalityLocal,
+		Operations: []interfaces.ModelOperation{{
+			Name: "TTS",
+			Inputs: []interfaces.ModelOperationSlot{{
+				Name:         "text",
+				ContentTypes: []string{interfaces.ModelOperationContentTypeText},
+				Required:     true,
+			}},
+			Outputs: []interfaces.ModelOperationSlot{{
+				Name:         "audio",
+				ContentTypes: []string{interfaces.ModelOperationContentTypeAudio},
+			}},
+		}},
+	}
+	cfg := &interfaces.FactoryConfig{
+		Name:    "factory",
+		Workers: []interfaces.WorkerConfig{worker},
+	}
+	if includeResource {
+		worker.Resources = []interfaces.ResourceConfig{{Name: "omnivoice-cache", Capacity: 1}}
+		cfg.Resources = []interfaces.ResourceConfig{{
+			Name:       "omnivoice-cache",
+			Type:       interfaces.ResourceTypeModel,
+			Capacity:   1,
+			Model:      "OMNIVOICE_Q4_K_M",
+			Backend:    "GGUF",
+			LoadPolicy: "ON_DEMAND",
+		}}
+	}
+	return cfg
+}

--- a/pkg/localmodels/manager_test.go
+++ b/pkg/localmodels/manager_test.go
@@ -1,0 +1,126 @@
+package localmodels
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/apisurface"
+	factoryconfig "github.com/portpowered/infinite-you/pkg/config"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+)
+
+type staticCatalogAssetPuller struct {
+	cache CacheLayout
+}
+
+func (s staticCatalogAssetPuller) PullModel(context.Context, *factoryconfig.LoadedFactoryConfig, string) (apisurface.ModelPullResult, error) {
+	return apisurface.ModelPullResult{}, nil
+}
+
+func (s staticCatalogAssetPuller) EnsureModelAvailable(context.Context, *factoryconfig.LoadedFactoryConfig, *interfaces.WorkerConfig) error {
+	return nil
+}
+
+func (s staticCatalogAssetPuller) ResolveModelCache(context.Context, *factoryconfig.LoadedFactoryConfig, *interfaces.WorkerConfig) (CacheLayout, error) {
+	return s.cache, nil
+}
+
+type countingLocalRuntime struct {
+	mu    sync.Mutex
+	loads int
+}
+
+func (r *countingLocalRuntime) Supports(resource interfaces.ResourceConfig, worker *interfaces.WorkerConfig) bool {
+	return CanonicalBackendName(resource.Backend) == "LLAMACPP" && CanonicalModelName(worker.Model) == CanonicalModelName("OMNIVOICE_Q4_K_M")
+}
+
+func (r *countingLocalRuntime) Load(context.Context, LoadRequest) (Handle, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.loads++
+	return stubHandle{}, nil
+}
+
+func (r *countingLocalRuntime) loadCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.loads
+}
+
+type stubHandle struct{}
+
+func (stubHandle) Invoke(context.Context, InvocationRequest) (interfaces.InferenceResponse, error) {
+	return interfaces.InferenceResponse{Content: "ok"}, nil
+}
+
+func TestManager_ReusesLoadedHandleForRepeatExecution(t *testing.T) {
+	runtime := &countingLocalRuntime{}
+	cache := CacheLayout{ModelName: "OMNIVOICE_Q4_K_M", CachePath: t.TempDir()}
+	manager := NewManager(staticCatalogAssetPuller{cache: cache}, runtime, Hooks{})
+	if manager == nil {
+		t.Fatal("NewManager returned nil")
+	}
+
+	factoryCfg := managerTestFactoryConfig()
+	loaded, err := factoryconfig.NewLoadedFactoryConfig(t.TempDir(), factoryCfg, nil)
+	if err != nil {
+		t.Fatalf("NewLoadedFactoryConfig: %v", err)
+	}
+	worker, ok := loaded.Worker("tts-worker")
+	if !ok || worker == nil {
+		t.Fatal("worker tts-worker not found in loaded config")
+	}
+
+	runner := manager.WrapRunner(stubRunner{}, loaded, factoryCfg, worker)
+	request := interfaces.RunnerExecutionRequest{
+		ModelOperation: "TTS",
+	}
+
+	if _, err := runner.Execute(context.Background(), request); err != nil {
+		t.Fatalf("first Execute: %v", err)
+	}
+	if _, err := runner.Execute(context.Background(), request); err != nil {
+		t.Fatalf("second Execute: %v", err)
+	}
+	if got := runtime.loadCount(); got != 1 {
+		t.Fatalf("load count = %d, want 1", got)
+	}
+}
+
+type stubRunner struct{}
+
+func (stubRunner) Execute(context.Context, interfaces.RunnerExecutionRequest) (interfaces.RunnerExecutionResult, error) {
+	return interfaces.RunnerExecutionResult{}, nil
+}
+
+func managerTestFactoryConfig() *interfaces.FactoryConfig {
+	return &interfaces.FactoryConfig{
+		Resources: []interfaces.ResourceConfig{{
+			Name:       "omnivoice-cache",
+			Type:       interfaces.ResourceTypeModel,
+			Capacity:   1,
+			Model:      "OMNIVOICE_Q4_K_M",
+			Backend:    "LLAMACPP",
+			LoadPolicy: "ON_DEMAND",
+		}},
+		Workers: []interfaces.WorkerConfig{{
+			Name:          "tts-worker",
+			Type:          interfaces.WorkerTypeModel,
+			Model:         "OMNIVOICE_Q4_K_M",
+			ModelLocality: interfaces.ModelLocalityLocal,
+			Resources: []interfaces.ResourceConfig{{
+				Name:     "omnivoice-cache",
+				Capacity: 1,
+			}},
+			Operations: []interfaces.ModelOperation{{
+				Name: "TTS",
+				Inputs: []interfaces.ModelOperationSlot{{
+					Name:         "text",
+					ContentTypes: []string{interfaces.ModelOperationContentTypeText},
+					Required:     true,
+				}},
+			}},
+		}},
+	}
+}

--- a/pkg/service/factory_runtime_mode_test.go
+++ b/pkg/service/factory_runtime_mode_test.go
@@ -618,6 +618,102 @@ func TestBuildReplacementFactoryRuntime_ServiceModeStaysRunningUntilCanceled(t *
 	}
 }
 
+func TestBuildReplacementFactoryRuntime_WiresLocalModelDelegationSeam(t *testing.T) {
+	rootDir := t.TempDir()
+	writeNamedFactoryFixture(t, rootDir, "alpha")
+	betaDir := writeNamedFactoryFixture(t, rootDir, "beta")
+	if err := config.WriteCurrentFactoryPointer(rootDir, "alpha"); err != nil {
+		t.Fatalf("WriteCurrentFactoryPointer(alpha): %v", err)
+	}
+
+	svc, err := BuildFactoryService(context.Background(), &FactoryServiceConfig{
+		Dir:               rootDir,
+		RuntimeMode:       interfaces.RuntimeModeService,
+		MockWorkersConfig: config.NewEmptyMockWorkersConfig(),
+		Logger:            zap.NewNop(),
+		LocalModelRuntimeOverride: &fakeLocalModelRuntime{
+			response: interfaces.InferenceResponse{Content: "ok"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildFactoryService: %v", err)
+	}
+
+	replacement, err := svc.buildReplacementFactoryRuntime(context.Background(), rootDir, betaDir, defaultFactorySessionID)
+	if err != nil {
+		t.Fatalf("buildReplacementFactoryRuntime: %v", err)
+	}
+	if replacement.localModels == nil {
+		t.Fatal("replacement runtime localModels = nil, want managed localmodels.Manager from buildRuntimeBundle seam")
+	}
+	if replacement.modelAssets == nil {
+		t.Fatal("replacement runtime modelAssets = nil, want localmodels.AssetPuller from buildRuntimeBundle seam")
+	}
+	if replacement.modelResources == nil {
+		t.Fatal("replacement runtime modelResources = nil, want localmodels.ResourceLimiter from buildRuntimeBundle seam")
+	}
+}
+
+func TestBuildFactoryService_PreservesSessionsRegistryAcrossRuntimeReplacement(t *testing.T) {
+	rootDir := t.TempDir()
+	alphaDir := writeNamedFactoryFixture(t, rootDir, "alpha")
+	betaDir := writeNamedFactoryFixture(t, rootDir, "beta")
+	if err := config.WriteCurrentFactoryPointer(rootDir, "alpha"); err != nil {
+		t.Fatalf("WriteCurrentFactoryPointer(alpha): %v", err)
+	}
+
+	svc, err := BuildFactoryService(context.Background(), &FactoryServiceConfig{
+		Dir:               rootDir,
+		RuntimeMode:       interfaces.RuntimeModeService,
+		MockWorkersConfig: config.NewEmptyMockWorkersConfig(),
+		Logger:            zap.NewNop(),
+	})
+	if err != nil {
+		t.Fatalf("BuildFactoryService: %v", err)
+	}
+	if svc.sessions == nil {
+		t.Fatal("expected factorysessions.Registry on FactoryService")
+	}
+	registryBefore := svc.sessions
+
+	if _, err := svc.buildReplacementFactoryRuntime(context.Background(), rootDir, betaDir, defaultFactorySessionID); err != nil {
+		t.Fatalf("buildReplacementFactoryRuntime: %v", err)
+	}
+	if svc.sessions != registryBefore {
+		t.Fatal("buildReplacementFactoryRuntime replaced sessions registry; session ownership should stay on FactoryService")
+	}
+	if svc.cfg.Dir != alphaDir {
+		t.Fatalf("service cfg.Dir = %q, want unchanged %q until activation", svc.cfg.Dir, alphaDir)
+	}
+}
+
+func TestBuildFactoryService_InitializesFactorySessionsRegistry(t *testing.T) {
+	rootDir := t.TempDir()
+	alphaDir := writeNamedFactoryFixture(t, rootDir, "alpha")
+	if err := config.WriteCurrentFactoryPointer(rootDir, "alpha"); err != nil {
+		t.Fatalf("WriteCurrentFactoryPointer(alpha): %v", err)
+	}
+
+	svc, err := BuildFactoryService(context.Background(), &FactoryServiceConfig{
+		Dir:               rootDir,
+		RuntimeMode:       interfaces.RuntimeModeService,
+		MockWorkersConfig: config.NewEmptyMockWorkersConfig(),
+		Logger:            zap.NewNop(),
+	})
+	if err != nil {
+		t.Fatalf("BuildFactoryService: %v", err)
+	}
+	if svc.sessions == nil {
+		t.Fatal("expected factorysessions.Registry on FactoryService")
+	}
+	if svc.cfg.Dir != alphaDir {
+		t.Fatalf("service cfg.Dir = %q, want %q", svc.cfg.Dir, alphaDir)
+	}
+	if svc.sessions.Count() != 0 {
+		t.Fatalf("sessions.Count() = %d before Run, want 0 until live sessions register", svc.sessions.Count())
+	}
+}
+
 func createReplacementWatchChannel(t *testing.T, factoryDir, workType, channel string) {
 	t.Helper()
 

--- a/pkg/service/poller_watcher_test.go
+++ b/pkg/service/poller_watcher_test.go
@@ -6,6 +6,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
 	"github.com/jonboulle/clockwork"
 	"github.com/portpowered/infinite-you/pkg/config"
 	"github.com/portpowered/infinite-you/pkg/factory"
@@ -15,12 +24,6 @@ import (
 	"github.com/portpowered/infinite-you/pkg/workers"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
-	"os"
-	"path/filepath"
-	"strings"
-	"sync"
-	"testing"
-	"time"
 )
 
 const (
@@ -246,6 +249,248 @@ func TestFactoryService_StartLiveRuntimeSidecars_BatchModeDoesNotStartScriptPoll
 	time.Sleep(50 * time.Millisecond)
 	if runner.callCount() != 0 {
 		t.Fatalf("poller runner calls = %d, want 0 in batch mode", runner.callCount())
+	}
+}
+
+func TestFactoryService_StartLiveRuntimeSidecars_StartsHostedLinearPoller(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"issues": {
+					"nodes": [
+						{
+							"id": "issue-new",
+							"identifier": "ENG-101",
+							"title": "Newest issue",
+							"description": "First",
+							"updatedAt": "2026-05-22T07:10:00Z",
+							"url": "https://linear.app/example/issue/ENG-101",
+							"team": {"id": "team-1", "key": "ENG", "name": "Engineering"},
+							"state": {"id": "state-1", "name": "Todo", "type": "unstarted"},
+							"assignee": null
+						}
+					],
+					"pageInfo": {"hasNextPage": false, "endCursor": ""}
+				}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	factoryDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(factoryDir, "secrets"), 0o755); err != nil {
+		t.Fatalf("mkdir secrets: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(factoryDir, "secrets", "linear-api-key"), []byte("runtime-linear-key\n"), 0o600); err != nil {
+		t.Fatalf("write secret file: %v", err)
+	}
+
+	submitted := &aggregateSnapshotFactory{}
+	svcCfg := &FactoryServiceConfig{
+		RuntimeMode:            interfaces.RuntimeModeService,
+		HostedPollerHTTPClient: server.Client(),
+		HostedLinearEndpoint:   server.URL,
+	}
+	svc := &FactoryService{
+		cfg:           svcCfg,
+		logger:        zap.NewNop(),
+		hostedWorkers: buildHostedWorkersConfig(svcCfg, zap.NewNop(), nil),
+	}
+	poller := interfaces.FactoryWorkstationConfig{
+		Name:           "linear-ingress",
+		Kind:           interfaces.WorkstationKindPoller,
+		WorkerTypeName: "linear-poller",
+	}
+	runtimeCfg := newLoadedFactoryConfigForServiceTest(
+		t,
+		factoryDir,
+		&interfaces.FactoryConfig{
+			Workers:      []interfaces.WorkerConfig{{Name: "linear-poller"}},
+			Workstations: []interfaces.FactoryWorkstationConfig{poller},
+		},
+		map[string]*interfaces.WorkerConfig{
+			"linear-poller": {
+				Name:     "linear-poller",
+				Type:     interfaces.WorkerTypeHosted,
+				Provider: interfaces.HostedWorkerProviderLinear,
+				Auth:     &interfaces.HostedWorkerAuthConfig{SecretRef: "secrets/linear-api-key"},
+				Linear: &interfaces.HostedLinearWorkerConfig{
+					PollInterval: "1h",
+					Mapping: interfaces.HostedLinearWorkerMappingConfig{
+						WorkType: "story",
+						State:    "init",
+					},
+				},
+			},
+		},
+		map[string]*interfaces.FactoryWorkstationConfig{poller.Name: &poller},
+	)
+	handle := &liveRuntimeHandle{
+		runtime: &replacementFactoryRuntime{
+			runtimeCfg: runtimeCfg,
+			factory:    submitted,
+		},
+	}
+	sidecarCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := svc.startLiveRuntimeSidecars(sidecarCtx, handle); err != nil {
+		t.Fatalf("startLiveRuntimeSidecars: %v", err)
+	}
+	defer svc.stopLiveRuntimeSidecars(handle)
+
+	waitForHostedPollerSubmission(t, submitted, 1, time.Second)
+	if submitted.submitCalls != 1 {
+		t.Fatalf("submit calls = %d, want 1", submitted.submitCalls)
+	}
+	if got := submitted.submissions[0].Works[0].WorkID; got != "linear:issue-new" {
+		t.Fatalf("submitted work id = %q, want linear:issue-new", got)
+	}
+}
+
+func TestFactoryService_StopLiveRuntimeSidecars_StopsHostedLinearPollerAndLogsLifecycle(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"issues": {
+					"nodes": [],
+					"pageInfo": {"hasNextPage": false, "endCursor": ""}
+				}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	factoryDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(factoryDir, "secrets"), 0o755); err != nil {
+		t.Fatalf("mkdir secrets: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(factoryDir, "secrets", "linear-api-key"), []byte("runtime-linear-key\n"), 0o600); err != nil {
+		t.Fatalf("write secret file: %v", err)
+	}
+
+	logCore, observedLogs := observer.New(zap.InfoLevel)
+	svcCfg := &FactoryServiceConfig{
+		RuntimeMode:            interfaces.RuntimeModeService,
+		HostedPollerHTTPClient: server.Client(),
+		HostedLinearEndpoint:   server.URL,
+	}
+	svc := &FactoryService{
+		cfg:           svcCfg,
+		logger:        zap.New(logCore),
+		hostedWorkers: buildHostedWorkersConfig(svcCfg, zap.New(logCore), nil),
+	}
+	poller := interfaces.FactoryWorkstationConfig{
+		Name:           "linear-ingress",
+		Kind:           interfaces.WorkstationKindPoller,
+		WorkerTypeName: "linear-poller",
+	}
+	runtimeCfg := newLoadedFactoryConfigForServiceTest(
+		t,
+		factoryDir,
+		&interfaces.FactoryConfig{
+			Workers:      []interfaces.WorkerConfig{{Name: "linear-poller"}},
+			Workstations: []interfaces.FactoryWorkstationConfig{poller},
+		},
+		map[string]*interfaces.WorkerConfig{
+			"linear-poller": {
+				Name:     "linear-poller",
+				Type:     interfaces.WorkerTypeHosted,
+				Provider: interfaces.HostedWorkerProviderLinear,
+				Auth:     &interfaces.HostedWorkerAuthConfig{SecretRef: "secrets/linear-api-key"},
+				Linear: &interfaces.HostedLinearWorkerConfig{
+					PollInterval: "1h",
+					Mapping: interfaces.HostedLinearWorkerMappingConfig{
+						WorkType: "story",
+						State:    "init",
+					},
+				},
+			},
+		},
+		map[string]*interfaces.FactoryWorkstationConfig{poller.Name: &poller},
+	)
+	handle := &liveRuntimeHandle{
+		runtime: &replacementFactoryRuntime{
+			runtimeCfg: runtimeCfg,
+			factory:    &aggregateSnapshotFactory{},
+		},
+	}
+
+	if err := svc.startLiveRuntimeSidecars(context.Background(), handle); err != nil {
+		t.Fatalf("startLiveRuntimeSidecars: %v", err)
+	}
+
+	waitForObservedLogMessage(t, observedLogs, "hosted linear poller started", time.Second)
+	svc.stopLiveRuntimeSidecars(handle)
+
+	stopped := observedLogs.FilterMessage("hosted linear poller stopped").All()
+	if len(stopped) != 1 {
+		t.Fatalf("hosted linear poller stopped log count = %d, want 1", len(stopped))
+	}
+	if got := fieldString(stopped[0].ContextMap()["reason"]); got != "context canceled" {
+		t.Fatalf("hosted linear poller stop reason = %q, want context canceled", got)
+	}
+}
+
+func TestFactoryService_StartLiveRuntimeSidecars_DisablesUnsupportedHostedProvider(t *testing.T) {
+	logCore, observedLogs := observer.New(zap.WarnLevel)
+	svcCfg := &FactoryServiceConfig{RuntimeMode: interfaces.RuntimeModeService}
+	svc := &FactoryService{
+		cfg:           svcCfg,
+		logger:        zap.New(logCore),
+		hostedWorkers: buildHostedWorkersConfig(svcCfg, zap.New(logCore), nil),
+	}
+	poller := interfaces.FactoryWorkstationConfig{
+		Name:           "custom-ingress",
+		Kind:           interfaces.WorkstationKindPoller,
+		WorkerTypeName: "custom-hosted",
+	}
+	runtimeCfg := newLoadedFactoryConfigForServiceTest(
+		t,
+		t.TempDir(),
+		&interfaces.FactoryConfig{
+			Workers:      []interfaces.WorkerConfig{{Name: "custom-hosted"}},
+			Workstations: []interfaces.FactoryWorkstationConfig{poller},
+		},
+		map[string]*interfaces.WorkerConfig{
+			"custom-hosted": {
+				Name:     "custom-hosted",
+				Type:     interfaces.WorkerTypeHosted,
+				Provider: "CUSTOM",
+			},
+		},
+		map[string]*interfaces.FactoryWorkstationConfig{poller.Name: &poller},
+	)
+	handle := &liveRuntimeHandle{
+		runtime: &replacementFactoryRuntime{
+			runtimeCfg: runtimeCfg,
+			factory:    &aggregateSnapshotFactory{},
+		},
+	}
+	sidecarCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := svc.startLiveRuntimeSidecars(sidecarCtx, handle); err != nil {
+		t.Fatalf("startLiveRuntimeSidecars: %v", err)
+	}
+	defer svc.stopLiveRuntimeSidecars(handle)
+
+	time.Sleep(50 * time.Millisecond)
+	disabled := observedLogs.FilterMessage("hosted poller disabled").All()
+	if len(disabled) != 1 {
+		t.Fatalf("hosted poller disabled log count = %d, want 1", len(disabled))
+	}
+	fields := disabled[0].ContextMap()
+	if fieldString(fields["workstation"]) != "custom-ingress" {
+		t.Fatalf("disabled workstation = %#v, want custom-ingress", fields["workstation"])
+	}
+	if fieldString(fields["reason"]) != "unsupported hosted provider" {
+		t.Fatalf("disabled reason = %#v, want unsupported hosted provider", fields["reason"])
+	}
+	if fieldString(fields["provider"]) != "CUSTOM" {
+		t.Fatalf("disabled provider = %#v, want CUSTOM", fields["provider"])
 	}
 }
 
@@ -658,6 +903,30 @@ func fieldString(value any) string {
 	default:
 		return ""
 	}
+}
+
+func waitForHostedPollerSubmission(t *testing.T, submitted *aggregateSnapshotFactory, want int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if submitted.submitCalls >= want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d hosted poller submission(s); got %d", want, submitted.submitCalls)
+}
+
+func waitForObservedLogMessage(t *testing.T, logs *observer.ObservedLogs, message string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if logs.FilterMessage(message).Len() > 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for log message %q", message)
 }
 
 func TestParseScriptPollerOutput_RejectsMalformedStdout(t *testing.T) {

--- a/pkg/service/testmain_test.go
+++ b/pkg/service/testmain_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/localmodels"
 	"github.com/portpowered/infinite-you/pkg/workers"
 	workerprovider "github.com/portpowered/infinite-you/pkg/workers/provider"
+	"github.com/portpowered/infinite-you/pkg/hostedworkers"
 	"go.uber.org/zap"
 	"net/http"
 	"net/http/httptest"
@@ -143,6 +144,31 @@ func TestBuildFactoryService_InitializesManagedLocalModelFields(t *testing.T) {
 	}
 	if svc.hostedWorkers.Logger == nil {
 		t.Fatal("expected BuildFactoryService to initialize hostedWorkers logger")
+	}
+}
+
+func TestBuildHostedWorkersConfig_DelegatesServiceConfigFields(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{}
+	resolver := hostedworkers.SecretResolver(func(context.Context, interfaces.RuntimeConfigLookup, string) (string, error) {
+		return "token", nil
+	})
+	cfg := &FactoryServiceConfig{
+		HostedPollerHTTPClient:     client,
+		HostedPollerSecretResolver: resolver,
+		HostedLinearEndpoint:       " https://linear.example/graphql ",
+	}
+
+	got := buildHostedWorkersConfig(cfg, zap.NewNop(), nil)
+	if got.HTTPClient != client {
+		t.Fatal("hosted workers HTTP client was not wired from FactoryServiceConfig")
+	}
+	if got.SecretResolver == nil {
+		t.Fatal("hosted workers secret resolver was not wired from FactoryServiceConfig")
+	}
+	if got.LinearEndpoint != "https://linear.example/graphql" {
+		t.Fatalf("LinearEndpoint = %q, want trimmed service config endpoint", got.LinearEndpoint)
 	}
 }
 


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/backend-service-refactor",
  "description": "Decompose the oversized pkg/service package by extracting factory session lifecycle, local model catalog/runtime/assets, and hosted-worker polling into dedicated top-level packages (factorysessions, localmodels, hostedworkers) while preserving all existing API, CLI, and service-mode runtime behavior.",
  "context": {
    "customerAsk": "The service package is too verbose. Break out factory_sessions, local_models (including model assets and model tests), and hosted_workers (including the poller and related logic) into separate top-level packages.",
    "problem": "pkg/service currently owns live factory-session lifecycle, managed local models, model assets, model catalog/invocation, and hosted-worker polling alongside unrelated factory build, replay, and ingest concerns. That blurs ownership, strains package-size gates, and makes safe refactors expensive.",
    "solution": "Introduce pkg/factorysessions, pkg/localmodels, and pkg/hostedworkers with explicit seams consumed by a slimmer FactoryService composition root. Move production code and co-located tests for each domain, keep script/cron pollers in pkg/service for this effort, and prove behavior preservation through existing session, model, and hosted-poller regression suites without OpenAPI or UI changes."
  },
  "acceptanceCriteria": [
    "Factory-session list, open, close, validate-only discovery, ~default routing, and session-not-found behavior match pre-refactor outcomes in pkg/api and pkg/service session regressions.",
    "Model list, detail, invoke, pull/availability, managed-runtime reuse, and HTTP model invocation semantics match pre-refactor outcomes covered by modeltests and local-model service tests.",
    "Hosted Linear poller startup, disable logging, restart/backoff, secret resolution, and work submission in service mode match pre-refactor hosted-poller regressions.",
    "pkg/service retains only thin orchestration for the extracted domains; root pkg/service stays within file-count and backend size policy without new broad waivers for moved code.",
    "docs/internal/processes/development-guide-relevant-files.md documents the three new package owners and dependency direction (extracted packages consumed by pkg/service, not the reverse).",
    "No intentional OpenAPI, generated client, UI route, or CLI semantic changes.",
    "Quality gate: typecheck, lint (including make pkg-maint and make backend-size), and required automated tests pass."
  ],
  "userStories": [
    {
      "id": "backend-service-refactor-001",
      "title": "Extract factory session lifecycle package",
      "description": "As a dashboard or API consumer, I want factory-session list/open/close behavior to remain identical after the refactor so that multi-session workspaces keep working without contract or routing changes.",
      "acceptanceCriteria": [
        "A new top-level package (pkg/factorysessions) owns live session registry, ~default alias behavior, folder-target discovery, session open/close orchestration, and per-session runtime registration previously in pkg/service/runtime_sessions.go.",
        "FactoryService delegates ListFactorySessions, OpenFactorySession, CloseFactorySession, and session-scoped runtime lookup through a narrow seam without changing handler routes or response shapes.",
        "Opening a session with validateOnly still returns discovered targets without starting a runtime; closing an unknown session still returns ErrFactorySessionNotFound.",
        "Canceled open-session requests do not leave behind newly registered live sessions.",
        "pkg/service/runtime_session_runtime_test.go, pkg/api/server_session_scoping_test.go, and other session-scoping regressions pass without weakening assertions.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "backend-service-refactor-002",
      "title": "Extract local models package",
      "description": "As an operator invoking models directly or through MODEL_INVOKE work, I want model catalog and invocation behavior to remain identical after the refactor so that local runtimes, asset caching, and error semantics do not change.",
      "acceptanceCriteria": [
        "A new top-level package (pkg/localmodels) owns managed local-model runtime, model asset pull/cache resolution, catalog projection, and invocation orchestration previously spread across pkg/service/localmodel, pkg/service/modelassets, and pkg/service/model_catalog.go.",
        "FactoryService still exposes ListModels, GetModel, and InvokeModel with the same success payloads, ErrModelNotFound, and model-not-available outcomes as before the move.",
        "A second InvokeModel call against the same loaded model reuses the managed handle.",
        "HTTP model invocation still routes through the same managed runtime path as factory-level model work.",
        "pkg/service/modeltests and local-model service tests pass without weakening assertions.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "backend-service-refactor-003",
      "title": "Extract hosted workers and hosted poller package",
      "description": "As a factory operator using a Linear hosted worker on a poller workstation, I want hosted ingress to keep submitting work and degrading safely when misconfigured so that service-mode automation does not regress.",
      "acceptanceCriteria": [
        "A new top-level package (pkg/hostedworkers) owns hosted-worker provider client logic (today hostedlinear), hosted poller run loops, restart/backoff supervision, secret resolution hooks, and hosted-specific disable logging.",
        "Service-mode startup still starts hosted Linear pollers only for HOSTED workers on poller workstations when runtime mode is service; unsupported hosted providers log a structured disable warning and do not crash the process.",
        "Missing worker binding, missing worker config, or missing/invalid auth still disable the hosted poller with the same log reason fields as today.",
        "When the Linear API reports new issues, the poller still submits a normalized work request through the existing submitter seam used by FactoryService.",
        "Hosted-poller regressions formerly in poller_watcher_test.go pass from their new package owner without changing expected submissions or disable behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "backend-service-refactor-004",
      "title": "Slim service orchestration to delegation seams",
      "description": "As a backend maintainer, I want pkg/service to compose runtimes through explicit dependencies so that future factory, replay, and ingest changes do not re-absorb session, model, or hosted-worker logic.",
      "acceptanceCriteria": [
        "pkg/service factory build/run paths wire factorysessions, localmodels, and hostedworkers through constructor or config fields rather than inlined copies of moved logic.",
        "Script poller and cron watcher behavior that is not hosted-worker-specific remains service-owned and continues to pass existing poller_watcher script/cron regressions.",
        "Root pkg/service counted production files remain at or below the repository file-count cap without new pkgmaintcheck file-scope waivers for the extracted concerns.",
        "go test ./pkg/service/... ./pkg/api/... passes for factory build, runtime replacement, named-factory, and dashboard render seams that previously imported moved symbols.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "backend-service-refactor-005",
      "title": "Document package ownership and run preservation closeout",
      "description": "As a reviewer, I want maintainer docs and a recorded verification bundle to name the new owners and prove behavior preservation so that later changes land in the correct package.",
      "acceptanceCriteria": [
        "docs/internal/processes/development-guide-relevant-files.md lists pkg/factorysessions, pkg/localmodels, and pkg/hostedworkers with the observable behaviors each owns and states that pkg/service composes them.",
        "A short closeout note under docs/internal/development/ records the canonical regression commands run after all three extractions.",
        "No new exported test-only symbols are introduced solely to satisfy package-size lint.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)