### PR TITLE
retarget-dashboard-factory-query-key-imports

### DIFF
--- a/ui/src/features/dashboard/hooks/useDashboardSessionLifecycle.test.tsx
+++ b/ui/src/features/dashboard/hooks/useDashboardSessionLifecycle.test.tsx
@@ -10,7 +10,7 @@ import {
   CURRENT_FACTORY_DEFINITION_QUERY_KEY_PREFIX,
   currentFactoryDefinitionQueryKey,
   currentFactoryDocumentQueryKey,
-} from "../../current-factory-definition/public";
+} from "../../current-factory-definition/hooks/useCurrentFactoryDefinition";
 import {
   useFactoryTimelineStore,
   type WorldState,

--- a/ui/src/features/dashboard/hooks/useFactoryEventStream.test.tsx
+++ b/ui/src/features/dashboard/hooks/useFactoryEventStream.test.tsx
@@ -9,7 +9,7 @@ import { createReplayHarness } from "../../../testing/replay-harness";
 import {
   CURRENT_FACTORY_DOCUMENT_QUERY_KEY,
   CURRENT_FACTORY_DEFINITION_QUERY_KEY,
-} from "../../current-factory-definition/public";
+} from "../../current-factory-definition/hooks/useCurrentFactoryDefinition";
 import { useDashboardSessionStore } from "../state/dashboardSessionStore";
 import { DashboardSessionProvider } from "../session/dashboard-session-provider";
 import { useFactoryTimelineStore } from "../../timeline/state/factoryTimelineStore";

--- a/ui/src/features/dashboard/lib/dashboard-event-stream.test.ts
+++ b/ui/src/features/dashboard/lib/dashboard-event-stream.test.ts
@@ -5,7 +5,7 @@ import { FACTORY_EVENT_TYPES } from "../../../api/events";
 import {
   currentFactoryDocumentQueryKey,
   currentFactoryDefinitionQueryKey,
-} from "../../current-factory-definition/public";
+} from "../../current-factory-definition/hooks/useCurrentFactoryDefinition";
 import {
   clearQueuedFlush,
   pausedDashboardStreamState,

--- a/ui/src/features/dashboard/lib/dashboard-event-stream.ts
+++ b/ui/src/features/dashboard/lib/dashboard-event-stream.ts
@@ -9,7 +9,7 @@ import { normalizeFactoryDefinition } from "../../../api/factory-definition";
 import {
   currentFactoryDocumentQueryKey,
   currentFactoryDefinitionQueryKey,
-} from "../../current-factory-definition/public";
+} from "../../current-factory-definition/hooks/useCurrentFactoryDefinition";
 
 export function clearQueuedFlush(flushHandleRef: RefObject<number | null>): void {
   if (flushHandleRef.current === null) {

--- a/ui/src/features/dashboard/lib/dashboard-session-lifecycle.test.ts
+++ b/ui/src/features/dashboard/lib/dashboard-session-lifecycle.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { CURRENT_FACTORY_DEFINITION_QUERY_KEY_PREFIX } from "../../current-factory-definition/public";
+import { CURRENT_FACTORY_DEFINITION_QUERY_KEY_PREFIX } from "../../current-factory-definition/hooks/useCurrentFactoryDefinition";
 import {
   dashboardSessionKey,
   resetDashboardSessionScopedState,

--- a/ui/src/features/dashboard/lib/dashboard-session-lifecycle.ts
+++ b/ui/src/features/dashboard/lib/dashboard-session-lifecycle.ts
@@ -1,6 +1,6 @@
 import type { QueryClient } from "@tanstack/react-query";
 
-import { CURRENT_FACTORY_DEFINITION_QUERY_KEY_PREFIX } from "../../current-factory-definition/public";
+import { CURRENT_FACTORY_DEFINITION_QUERY_KEY_PREFIX } from "../../current-factory-definition/hooks/useCurrentFactoryDefinition";
 import { resetSelectionHistoryStore } from "../../current-selection/base/public";
 
 export function dashboardSessionKey(


### PR DESCRIPTION
{
  "project": "Retarget Dashboard Factory Query-Key Imports",
  "branchName": "ralph/retarget-dashboard-factory-query-key-imports",
  "description": "Retarget six dashboard production and test files to import current-factory-definition React Query cache-key constants from hooks/useCurrentFactoryDefinition instead of the public barrel, preserving session reset and event-stream invalidation behavior with no UI or query-semantics changes.",
  "context": {
    "customerAsk": "Retarget dashboard-owned modules and their tests to import factory query-key helpers directly from the owning hook module so dashboard code no longer depends on current-factory-definition/public for cache-key wiring.",
    "problem": "After PR #513 landed ui-api-module-cleanup-recovery-v2, six dashboard files still import CURRENT_FACTORY_DEFINITION_QUERY_KEY_PREFIX, CURRENT_FACTORY_DEFINITION_QUERY_KEY, currentFactoryDefinitionQueryKey, CURRENT_FACTORY_DOCUMENT_QUERY_KEY, and currentFactoryDocumentQueryKey from current-factory-definition/public even though those symbols are defined in hooks/useCurrentFactoryDefinition.ts, coupling dashboard cache wiring to an unnecessary public barrel.",
    "solution": "Replace public-barrel imports with direct imports from current-factory-definition/hooks/useCurrentFactoryDefinition in dashboard-session-lifecycle, dashboard-event-stream, and their four focused test files; run existing dashboard unit and hook tests to prove identical React Query key values and invalidation behavior."
  },
  "acceptanceCriteria": [
    "All six scoped dashboard files import query-key symbols from current-factory-definition/hooks/useCurrentFactoryDefinition, not from current-factory-definition/public.",
    "Session lifecycle still removes queries under CURRENT_FACTORY_DEFINITION_QUERY_KEY_PREFIX with exact: false on session reset.",
    "Event stream still sets definition cache entries and invalidates document queries using currentFactoryDefinitionQueryKey and currentFactoryDocumentQueryKey for the active session.",
    "Focused dashboard tests for session lifecycle, event stream, useDashboardSessionLifecycle, and useFactoryEventStream pass without behavioral assertion changes.",
    "No new public-barrel re-exports are added elsewhere; current-factory-definition/public/index.ts is not narrowed in this work item.",
    "No operator-visible dashboard UI behavior changes.",
    "Typecheck, lint, and project tests pass."
  ],
  "userStories": [
    {
      "id": "retarget-dashboard-factory-query-key-imports-001",
      "title": "Retarget session lifecycle query-key imports",
      "description": "As a maintainer, I want dashboard session lifecycle code to import CURRENT_FACTORY_DEFINITION_QUERY_KEY_PREFIX from the owning hook module so session switches still clear factory-definition cache entries without depending on the public barrel.",
      "acceptanceCriteria": [
        "dashboard-session-lifecycle.ts imports CURRENT_FACTORY_DEFINITION_QUERY_KEY_PREFIX from ../../current-factory-definition/hooks/useCurrentFactoryDefinition (not current-factory-definition/public)",
        "resetDashboardSessionScopedState still calls queryClient.removeQueries with queryKey: [CURRENT_FACTORY_DEFINITION_QUERY_KEY_PREFIX] and exact: false",
        "dashboard-session-lifecycle.test.ts imports the same symbol from the hook module and its reset test still expects removal of queries under that prefix",
        "bun test ui/src/features/dashboard/lib/dashboard-session-lifecycle.test.ts passes",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "retarget-dashboard-factory-query-key-imports-002",
      "title": "Retarget event stream query-key imports",
      "description": "As a maintainer, I want dashboard event-stream code to import currentFactoryDefinitionQueryKey and currentFactoryDocumentQueryKey from the owning hook module so factory events still invalidate the same React Query cache entries after the import retarget.",
      "acceptanceCriteria": [
        "dashboard-event-stream.ts imports currentFactoryDefinitionQueryKey and currentFactoryDocumentQueryKey from ../../current-factory-definition/hooks/useCurrentFactoryDefinition (not current-factory-definition/public)",
        "syncCurrentFactoryDefinition still sets definition data with currentFactoryDefinitionQueryKey(sessionID) and invalidates document queries with currentFactoryDocumentQueryKey(sessionID)",
        "dashboard-event-stream.test.ts imports the same helpers from the hook module; syncCurrentFactoryDefinition tests still assert cache data at those key tuples",
        "bun test ui/src/features/dashboard/lib/dashboard-event-stream.test.ts passes",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "retarget-dashboard-factory-query-key-imports-003",
      "title": "Retarget dashboard hook test query-key imports",
      "description": "As a maintainer, I want dashboard hook tests to import factory query-key constants from the owning hook module so test fixtures seed and assert the same cache keys production hooks use, without pulling the public barrel.",
      "acceptanceCriteria": [
        "useDashboardSessionLifecycle.test.tsx imports CURRENT_FACTORY_DEFINITION_QUERY_KEY and CURRENT_FACTORY_DEFINITION_QUERY_KEY_PREFIX from ../../current-factory-definition/hooks/useCurrentFactoryDefinition",
        "useFactoryEventStream.test.tsx imports CURRENT_FACTORY_DOCUMENT_QUERY_KEY and CURRENT_FACTORY_DEFINITION_QUERY_KEY from the same hook module",
        "Session-switch and event-stream hook tests still pass with the same seeded query data and invalidation expectations as before retargeting",
        "bun test ui/src/features/dashboard/hooks/useDashboardSessionLifecycle.test.tsx passes",
        "bun test ui/src/features/dashboard/hooks/useFactoryEventStream.test.tsx passes",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "retarget-dashboard-factory-query-key-imports-004",
      "title": "Confirm dashboard import boundary and quality gates",
      "description": "As a maintainer, I want confidence that dashboard code no longer depends on current-factory-definition/public for query keys and that UI quality gates remain green.",
      "acceptanceCriteria": [
        "None of the six scoped dashboard files import query-key symbols from current-factory-definition/public",
        "All four focused test commands pass: dashboard-session-lifecycle.test.ts, dashboard-event-stream.test.ts, useDashboardSessionLifecycle.test.tsx, useFactoryEventStream.test.tsx",
        "No new public-barrel re-exports were added in this change",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)