### PR TITLE
factory-overview-agent-submit-policy

### DIFF
--- a/factory/docs/overview.md
+++ b/factory/docs/overview.md
@@ -134,6 +134,38 @@ Authoring guidance:
   `PARENT_CHILD`, or multiple work types in one batch (see `you docs
   relationships`).
 
+## Operator loop (maintainer factory)
+
+Short loop for submitting and verifying maintainer work against a **running**
+factory (see `you docs agents` § Is the factory running?):
+
+1. **`you session list`** — confirm the service is listening and a session is
+   open. Connection refused means start `you run --dir ./factory` (or
+   `you run --continuously`) before submitting.
+2. **Submit an idea** — default path for new work: CLI or inbox markdown under
+   `factory/inputs/idea/default/` (see **Submission recipes** above).
+3. **Verify acceptance** — use one or more of:
+   - **`GET /factory-sessions/{session_id}/status`** — `factoryState` and
+     `runtimeStatus` show whether the runtime accepted work and is processing
+     (session id is often `~default` on single-session hosts).
+   - **Dashboard** — `http://localhost:7437/dashboard/ui` on the same host/port
+     as the API (adjust for `--server` / `--port`).
+   - **`you work list`** — when the listing is populated, locate the submitted
+     item by name or `workId` from the submit response.
+
+Example CLI submit:
+
+```bash
+you submit --name my-idea --work-type-name idea --payload path/to.md
+```
+
+**Post-submit timing:** `you work show <work-id>` may not find the item
+immediately while dispatch is still in flight. An empty `you work list` right
+after submit does **not** by itself mean the submit failed — prefer session
+status and the dashboard until work appears in the list, then use
+`you work show` or `you work list --name <name>` for detail (see `you docs work`
+§ Verify after submit).
+
 ## Maintainer notes
 
 - Maintainer control surface: `factory/internal/{asks,view,progress,meta}.md`

--- a/factory/docs/overview.md
+++ b/factory/docs/overview.md
@@ -99,6 +99,17 @@ pipeline and work-type tables above; the inbox table below lists paths.
   in one `FACTORY_REQUEST_BATCH` (see `you docs batch-inputs` and
   `you docs relationships`).
 
+## Submission recipes (this factory)
+
+Pick a row by goal; do not route greenfield features or docs to **`task`**.
+
+| Goal | Work type | Ingress |
+|------|-----------|---------|
+| New feature or documentation | `idea` | `you submit --work-type-name idea` (with `--name` and `--payload` as needed) or markdown under `factory/inputs/idea/default/` |
+| Large, ambiguous multi-area customer ask | `thoughts` | Markdown under `factory/inputs/thoughts/default/` |
+| Unstick failed or looped implementation | `task` | Markdown under `factory/inputs/task/default/` or `you submit --work-type-name task` (with `--name` and `--payload` as needed) |
+| Ordered multi-item or mixed-type request | Batch (`FACTORY_REQUEST_BATCH`) | `factory/inputs/BATCH/default/{requestId}.json` |
+
 ## Input layout
 
 Seed checked-in repository work under:

--- a/factory/docs/overview.md
+++ b/factory/docs/overview.md
@@ -78,6 +78,27 @@ Planner workstations enqueue work; executor workstations run inference or
 scripts at bound workers. See `you docs agents` § Planner vs Executor and
 `docs/reference/authoring-agents-md.md` for prompt file shape.
 
+## Agent submission policy
+
+Use this policy when choosing `workTypeName` and ingress. It matches the
+pipeline and work-type tables above; the inbox table below lists paths.
+
+- **Default — `idea`:** Submit new maintainer work as **`idea`**: standalone
+  markdown under `factory/inputs/idea/default/` or
+  `you submit --work-type-name idea` (with `--name` and `--payload` as needed).
+- **`thoughts`:** Only for large, ambiguous customer asks that need **ideafy**
+  breakdown into multiple ideas — not routine features or docs.
+- **`task`:** Only to **unstick** stuck or failed work: failed tokens, review
+  loops that are not progressing, or recovery after **`executor-loop-breaker`**
+  or **`review-loop-breaker`** routes work to `task:failed`. Do **not** use
+  `task` for greenfield features, documentation, or normal pipeline progression.
+- **`plan`:** Rarely submit standalone plans; the pipeline normally spawns
+  **`plan`** work from accepted ideas.
+- **Batch JSON:** Use `factory/inputs/BATCH/default/{requestId}.json` only when
+  the request needs **`DEPENDS_ON`**, **`PARENT_CHILD`**, or multiple work types
+  in one `FACTORY_REQUEST_BATCH` (see `you docs batch-inputs` and
+  `you docs relationships`).
+
 ## Input layout
 
 Seed checked-in repository work under:

--- a/factory/docs/overview.md
+++ b/factory/docs/overview.md
@@ -69,8 +69,9 @@ backends live under `factory/workers/<name>/AGENTS.md`.
 1. Run `you docs agents` for the end-to-end agent playbook.
 2. Open `factory.json` in this directory.
 3. Read this overview and the workstation `AGENTS.md` for the step you will run.
-4. Confirm the target `workTypeName` and inbox path from the tables below — do
-   not infer names from other repositories or examples.
+4. Confirm the target `workTypeName` and inbox path from **Agent submission
+   policy** and the tables below — do not infer names from other repositories or
+   examples.
 5. For batch JSON, follow `you docs batch-inputs` (`you docs batch-work` is a
    byte-identical alias).
 
@@ -129,7 +130,9 @@ repository-local working state, not generated starter payloads from
 
 Authoring guidance:
 
-- Default to **one standalone markdown idea file** under `factory/inputs/idea/default/`.
+- Default to **one standalone markdown idea file** under
+  `factory/inputs/idea/default/` (see **Agent submission policy** — new work is
+  **`idea`**, not **`task`**).
 - Use `factory/inputs/BATCH/default/` only when the request needs `DEPENDS_ON`,
   `PARENT_CHILD`, or multiple work types in one batch (see `you docs
   relationships`).
@@ -181,6 +184,7 @@ status and the dashboard until work appears in the list, then use
 |------|---------|
 | Agent orientation | `you docs agents` |
 | `factory.json` topology and portability | `you docs config` |
+| Factory sessions and liveness | `you session list` (`you docs sessions` not packaged yet — see **Operator loop** and `you docs agents`) |
 | Submitted work and `POST /work` | `you docs work` |
 | Batch ingress and inboxes | `you docs batch-inputs` |
 | Relations in batch JSON | `you docs relationships` |

--- a/pkg/config/layout_script_copy_test.go
+++ b/pkg/config/layout_script_copy_test.go
@@ -285,10 +285,22 @@ func TestFlattenFactoryConfig_CheckedInFactoryBundlesOverviewDoc(t *testing.T) {
 		"thoughts:init",
 		"factory/inputs/BATCH/default/",
 		"you docs agents",
+		"## Agent submission policy",
+		"## Submission recipes (this factory)",
+		"## Operator loop (maintainer factory)",
 	} {
 		if !strings.Contains(overview.Content.Inline, want) {
 			t.Fatalf("overview inline missing %q:\n%s", want, overview.Content.Inline)
 		}
+	}
+
+	overviewPath := testpath.MustRepoPathFromCaller(t, 0, "factory", "docs", "overview.md")
+	onDisk, err := os.ReadFile(overviewPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", overviewPath, err)
+	}
+	if overview.Content.Inline != string(onDisk) {
+		t.Fatalf("bundled overview inline does not match on-disk %s", overviewPath)
 	}
 }
 


### PR DESCRIPTION
{
  "project": "Factory Overview — Agent Submission Policy",
  "branchName": "ralph/factory-overview-agent-submit-policy",
  "description": "Document explicit agent submission policy in the repository maintainer factory overview: default new work to idea, reserve task for stuck/failed recovery, add submission recipes and operator verify loop, extend Related you docs topics, and regression-test portable bundled overview content.",
  "context": {
    "customerAsk": "Update the repository maintainer factory overview so autonomous agents default to submitting ideas for new work and reserve tasks for unsticking failed or stuck execution.",
    "problem": "factory/docs/overview.md documents inboxes and pipeline stages but not a clear agent policy for which work type and ingress to use. Agents guess between thoughts, idea, task, and CLI vs inbox paths.",
    "solution": "Extend factory/docs/overview.md with Agent submission policy, Submission recipes (this factory), and Operator loop (maintainer factory) sections; add you docs sessions to Related topics when available; note post-submit verify behavior when you work show is empty during dispatch; keep portable bundled overview aligned via existing flatten auto-bundle and extend layout_script_copy_test markers."
  },
  "acceptanceCriteria": [
    "factory/docs/overview.md contains Agent submission policy and Submission recipes sections with idea default and task-for-recovery-only rules",
    "Operator loop documents you session list, idea submit, verify via session status API dashboard or you work list, and includes you submit --work-type-name idea example",
    "Post-submit guidance explains you work show or list may be empty during dispatch and prefers session status plus dashboard",
    "Related you docs topics table includes you docs sessions or interim equivalent until the topic is packaged",
    "TestFlattenFactoryConfig_CheckedInFactoryBundlesOverviewDoc asserts new section headings in bundled overview inline content",
    "Portable bundled overview matches on-disk factory/docs/overview.md for changed sections after config flatten",
    "Typecheck, lint, and tests pass for touched paths"
  ],
  "userStories": [
    {
      "id": "factory-overview-agent-submit-policy-001",
      "title": "Document agent submission policy in factory overview",
      "description": "As an autonomous agent or maintainer, I want an explicit Agent submission policy in factory/docs/overview.md so I choose the correct work type without guessing from repository layout.",
      "acceptanceCriteria": [
        "New ## Agent submission policy section in factory/docs/overview.md states default new work is idea (factory/inputs/idea/default/ or you submit --work-type-name idea)",
        "Section states thoughts only for large ambiguous customer asks needing ideafy breakdown",
        "Section states task only for stuck work (failed tokens, review loops, executor-loop-breaker or review-loop-breaker recovery) not greenfield features or docs",
        "Section states plan rarely because pipeline normally spawns plan from ideas",
        "Section states batch JSON only for DEPENDS_ON, PARENT_CHILD, or mixed work types in one request",
        "Section placement does not contradict existing pipeline and work-type tables",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "factory-overview-agent-submit-policy-002",
      "title": "Add submission recipes table to factory overview",
      "description": "As an agent submitting work to this factory, I want a goal to work type to ingress table so I can pick the right submission path in one glance.",
      "acceptanceCriteria": [
        "New ## Submission recipes (this factory) section contains a table with rows for new feature or docs to idea via you submit or factory/inputs/idea/default",
        "Table includes thoughts for ambiguous multi-area asks via factory/inputs/thoughts/default",
        "Table includes task for unstick failed or looped implementation via factory/inputs/task/default or you submit --work-type-name task",
        "Table includes batch for ordered multi-item requests via factory/inputs/BATCH/default/{requestId}.json",
        "No table row directs greenfield work to task",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "factory-overview-agent-submit-policy-003",
      "title": "Document operator loop and post-submit verification",
      "description": "As a maintainer operating this factory, I want a short operator loop and realistic verify steps so I do not treat an empty you work list as a failed submit during dispatch.",
      "acceptanceCriteria": [
        "New ## Operator loop (maintainer factory) section lists you session list then submit idea then verify via session status API dashboard or you work list when populated",
        "Section includes example: you submit --name my-idea --work-type-name idea --payload path/to.md",
        "Section notes you work show may not find work immediately during dispatch and prefers session status and dashboard when you work list is empty",
        "Typecheck passes"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "factory-overview-agent-submit-policy-004",
      "title": "Extend Related you docs topics and cross-links",
      "description": "As a reader of the factory overview, I want the Related you docs table to include sessions and tightened cross-links from read-before-submit and input layout to the new policy.",
      "acceptanceCriteria": [
        "Related you docs topics table adds a row for you docs sessions when packaged or interim guidance via you session list and agents guide until packaged",
        "Existing agents work and batch-inputs rows remain without removal",
        "Read before you submit or Input layout bullets cross-reference ## Agent submission policy without contradicting default idea guidance",
        "Typecheck passes"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "factory-overview-agent-submit-policy-005",
      "title": "Regression-test bundled overview policy sections",
      "description": "As a maintainer, I want the portable flatten bundle for factory/docs/overview.md to include new policy headings so bundled content cannot drift from disk unnoticed.",
      "acceptanceCriteria": [
        "TestFlattenFactoryConfig_CheckedInFactoryBundlesOverviewDoc asserts bundled inline overview contains ## Agent submission policy, ## Submission recipes, and ## Operator loop",
        "After config flatten on checked-in factory, bundled overview inline matches on-disk factory/docs/overview.md for those sections",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)