### PR TITLE
graph-editor-dialog-radix-migration

### DIFF
--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-add-dialog.test.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-add-dialog.test.tsx
@@ -63,6 +63,9 @@ describe("FactoryGraphEditorAddEntityDialog", () => {
       onSubmit,
     });
 
+    const dialog = screen.getByRole("dialog", { name: "Add resource" });
+    expect(document.body.contains(dialog)).toBe(true);
+
     fireEvent.change(screen.getByRole("textbox", { name: "Identifier" }), {
       target: { value: "cpu" },
     });

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-add-dialog.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-add-dialog.tsx
@@ -1,5 +1,15 @@
-import { Button, Input, Select, Textarea } from "../../../components/ui";
-import { DashboardMutationDialog } from "../../workflow-activity/components/mutation-dialog";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Select,
+  Textarea,
+} from "../../../components/ui";
 import type { CanonicalFactoryDefinition } from "../lib/factory-graph-draft-types";
 import type {
   FactoryGraphAddEntityDraft,
@@ -33,36 +43,44 @@ export function FactoryGraphEditorAddEntityDialog({
   onClose: () => void;
   onSubmit: () => void;
 }) {
-  if (!isOpen || draft === null) {
-    return null;
-  }
   const messages = getFactoryGraphEditorMessages(locale);
+  const isDialogOpen = isOpen && draft !== null;
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      onClose();
+    }
+  };
 
   return (
-    <DashboardMutationDialog
-      description={messages.addDialogDescription(draft.kind)}
-      onClose={onClose}
-      title={messages.addDialogTitle(draft.kind)}
-      footer={
-        <>
-          <Button onClick={onClose} tone="outline" type="button">
-            {messages.addDialogCancelAction}
-          </Button>
-          <Button onClick={onSubmit} type="button">
-            {messages.addDialogAddEntityAction}
-          </Button>
-        </>
-      }
-    >
-      <FactoryGraphEditorAddEntityFields
-        currentFactoryDefinition={currentFactoryDefinition}
-        draft={draft}
-        errors={errors}
-        locale={locale}
-        onChange={onChange}
-        onSubmit={onSubmit}
-      />
-    </DashboardMutationDialog>
+    <Dialog onOpenChange={handleOpenChange} open={isDialogOpen}>
+      {draft ? (
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{messages.addDialogTitle(draft.kind)}</DialogTitle>
+            <DialogDescription>
+              {messages.addDialogDescription(draft.kind)}
+            </DialogDescription>
+          </DialogHeader>
+          <FactoryGraphEditorAddEntityFields
+            currentFactoryDefinition={currentFactoryDefinition}
+            draft={draft}
+            errors={errors}
+            locale={locale}
+            onChange={onChange}
+            onSubmit={onSubmit}
+          />
+          <DialogFooter>
+            <Button onClick={onClose} tone="outline" type="button">
+              {messages.addDialogCancelAction}
+            </Button>
+            <Button onClick={onSubmit} type="button">
+              {messages.addDialogAddEntityAction}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      ) : null}
+    </Dialog>
   );
 }
 

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-controls.test.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-controls.test.tsx
@@ -122,7 +122,7 @@ describe("factory graph editor toolbar controls", () => {
     ).toBeTruthy();
   });
 
-  it("renders the confirmation dialog through the shared dialog pattern", async () => {
+  it("renders the confirmation dialog portaled to document.body", async () => {
     render(
       <FactoryGraphEditorConfirmationDialog
         cancelLabel="Cancel removal"
@@ -139,6 +139,7 @@ describe("factory graph editor toolbar controls", () => {
     const dialog = screen.getByRole("dialog", {
       name: "Remove review workstation?",
     });
+    expect(document.body.contains(dialog)).toBe(true);
     expect(
       within(dialog).getByRole("button", { name: "Cancel removal" }),
     ).toBeTruthy();

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-controls.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-controls.tsx
@@ -1,11 +1,16 @@
 import type { ReactNode } from "react";
 
-import { DashboardMutationDialog } from "../../workflow-activity/components/mutation-dialog";
 import {
   Button,
   DashboardActionRow,
   DashboardActionButton,
   DashboardStatusPill,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -482,18 +487,32 @@ export function FactoryGraphEditorConfirmationDialog({
   onConfirm: () => void;
   title: string;
 }) {
-  if (!isOpen) {
-    return null;
-  }
+  const handleOpenChange = (open: boolean) => {
+    if (!open && !isBusy) {
+      onCancel();
+    }
+  };
 
   return (
-    <DashboardMutationDialog
-      closeDisabled={isBusy}
-      description={description}
-      onClose={onCancel}
-      title={title}
-      footer={
-        <>
+    <Dialog onOpenChange={handleOpenChange} open={isOpen}>
+      <DialogContent
+        closeDisabled={isBusy}
+        onEscapeKeyDown={(event) => {
+          if (isBusy) {
+            event.preventDefault();
+          }
+        }}
+        onInteractOutside={(event) => {
+          if (isBusy) {
+            event.preventDefault();
+          }
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
           <Button
             disabled={isBusy}
             onClick={onCancel}
@@ -505,10 +524,8 @@ export function FactoryGraphEditorConfirmationDialog({
           <Button onClick={onConfirm} tone={confirmTone} type="button">
             {confirmLabel}
           </Button>
-        </>
-      }
-    >
-      <div />
-    </DashboardMutationDialog>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-leave-dialog.test.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-leave-dialog.test.tsx
@@ -22,6 +22,7 @@ describe("FactoryGraphEditorLeaveDialog", () => {
     const dialog = screen.getByRole("dialog", {
       name: "Leave graph editor with unsaved changes?",
     });
+    expect(document.body.contains(dialog)).toBe(true);
     expect(
       within(dialog).getByText(
         "This graph editor session still has local topology changes.",
@@ -67,6 +68,7 @@ describe("FactoryGraphEditorLeaveDialog", () => {
     const dialog = screen.getByRole("dialog", {
       name: "Leave graph editor with unsaved changes?",
     });
+    expect(document.body.contains(dialog)).toBe(true);
     expect(
       within(dialog)
         .getByRole("button", { name: "Keep editing" })

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-leave-dialog.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-leave-dialog.tsx
@@ -1,5 +1,12 @@
-import { DashboardMutationDialog } from "../../workflow-activity/components/mutation-dialog";
-import { Button } from "../../../components/ui";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../../../components/ui";
 import { getFactoryGraphEditorMessages } from "../messages/editor";
 
 export function FactoryGraphEditorLeaveDialog({
@@ -19,19 +26,35 @@ export function FactoryGraphEditorLeaveDialog({
   onDiscard: () => void;
   onSave: () => void;
 }) {
-  if (!isOpen) {
-    return null;
-  }
   const messages = getFactoryGraphEditorMessages(locale);
 
+  const handleOpenChange = (open: boolean) => {
+    if (!open && !isSaving) {
+      onCancel();
+    }
+  };
+
   return (
-    <DashboardMutationDialog
-      closeDisabled={isSaving}
-      description={messages.leaveDialogDescription}
-      onClose={onCancel}
-      title={messages.leaveDialogTitle}
-      footer={
-        <>
+    <Dialog onOpenChange={handleOpenChange} open={isOpen}>
+      <DialogContent
+        closeDisabled={isSaving}
+        onEscapeKeyDown={(event) => {
+          if (isSaving) {
+            event.preventDefault();
+          }
+        }}
+        onInteractOutside={(event) => {
+          if (isSaving) {
+            event.preventDefault();
+          }
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>{messages.leaveDialogTitle}</DialogTitle>
+          <DialogDescription>{messages.leaveDialogDescription}</DialogDescription>
+        </DialogHeader>
+        <p className="m-0 text-sm text-af-text-muted">{messages.leaveDialogBody}</p>
+        <DialogFooter>
           <Button
             disabled={isSaving}
             onClick={onCancel}
@@ -55,10 +78,8 @@ export function FactoryGraphEditorLeaveDialog({
           >
             {isSaving ? messages.draftActionsSaving : messages.draftActionsSave}
           </Button>
-        </>
-      }
-    >
-      <p className="m-0 text-sm text-af-text-muted">{messages.leaveDialogBody}</p>
-    </DashboardMutationDialog>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-edit-integration.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-edit-integration.test.tsx
@@ -459,6 +459,56 @@ describe("ReactFlowCurrentActivityCard edit integration", () => {
       }),
     ).toBeNull();
   });
+
+  it("opens save confirmation from the activity card host portaled to document.body", async () => {
+    renderCurrentActivity();
+    enterEditorMode();
+
+    await screen.findByRole("button", { name: "work-state:story:qa" });
+    fireEvent.click(await screen.findByRole("button", { name: "Connect" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Mock connect review to QA" }),
+    );
+
+    fireEvent.click(
+      within(
+        await screen.findByRole("region", {
+          name: "Factory graph editor tools",
+        }),
+      ).getByRole("button", { name: "Save changes" }),
+    );
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Save factory graph changes?",
+    });
+    expect(document.body.contains(dialog)).toBe(true);
+
+    fireEvent.click(
+      within(dialog).getByRole("button", { name: "Save topology" }),
+    );
+
+    await waitFor(() => {
+      expect(saveAsync).toHaveBeenCalledWith({
+        baseVersion: editableFactoryDocument.version,
+        factory: {
+          ...editableFactoryDocument,
+          resources: [],
+          workstations: [
+            {
+              ...editableFactoryDocument.workstations[0],
+              outputs: [
+                ...editableFactoryDocument.workstations[0].outputs,
+                {
+                  state: "qa",
+                  workType: "story",
+                },
+              ],
+            },
+          ],
+        },
+      });
+    });
+  });
 });
 
 describe("ReactFlowCurrentActivityCard distinct workstation ID editing", () => {


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/graph-editor-dialog-radix-migration",
  "description": "Migrate factory graph editor save, leave, and add-entity confirmation modals from in-card DashboardMutationDialog overlays to Radix Dialog primitives portaled to document.body, matching export/import behavior so operators always see centered, unclipped confirmations.",
  "context": {
    "customerAsk": "Migrate factory graph editor dialogs off DashboardMutationDialog so save, leave, and add-entity confirmations are viewport-centered and not clipped by the Workflow Activity bento card.",
    "problem": "FactoryGraphEditorConfirmationDialog, FactoryGraphEditorLeaveDialog, and FactoryGraphEditorAddEntityDialog mount inside the Workflow Activity card (overflow-hidden/auto, react-grid-layout transforms). DashboardMutationDialog uses a fixed overlay without DialogPortal, so dialogs can clip, pin to the card bottom, or appear missing on short or scrolled layouts even though unit tests pass.",
    "solution": "Replace DashboardMutationDialog with Radix Dialog/DialogContent in each graph-editor dialog component, preserve copy/actions/busy behavior and hook wiring through CurrentActivityGraphEditorDialogs, add portal-to-body test assertions, and verify in browser on a constrained bento layout."
  },
  "acceptanceCriteria": [
    "FactoryGraphEditorConfirmationDialog, FactoryGraphEditorLeaveDialog, and FactoryGraphEditorAddEntityDialog use Radix Dialog/DialogContent instead of DashboardMutationDialog",
    "Dialog open/close and save/leave/add business logic in hooks and CurrentActivityGraphEditorDialogs wiring is unchanged",
    "Save, leave, and add-entity modals are viewport-centered and fully visible when the Workflow Activity card is short or scrolled (browser verification)",
    "Graph-editor components no longer import DashboardMutationDialog; mutation-dialog.tsx is trimmed or removed only when no other production consumers remain",
    "Unit tests assert open dialogs render under document.body; integration save-confirm flow still passes",
    "ui typecheck, lint, and affected tests pass"
  ],
  "userStories": [
    {
      "id": "graph-editor-dialog-radix-migration-001",
      "title": "Migrate save topology confirmation dialog",
      "description": "As an operator editing the factory graph, I want the Save factory graph changes confirmation centered on screen so I can confirm or cancel without hunting for a clipped panel.",
      "acceptanceCriteria": [
        "FactoryGraphEditorConfirmationDialog uses Radix Dialog with open={isOpen} and DialogContent for title, description, and footer actions",
        "onOpenChange dismisses only when !isBusy; onEscapeKeyDown and onInteractOutside call preventDefault while isBusy",
        "Dialog accessible name remains Save factory graph changes? or locale equivalent",
        "factory-graph-editor-controls.test.tsx asserts the open dialog is under document.body",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill: trigger save from graph editor with a short activity card; dialog is centered and fully visible"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "graph-editor-dialog-radix-migration-002",
      "title": "Migrate leave editor dialog",
      "description": "As an operator leaving the graph editor with unsaved topology, I want the leave confirmation centered and readable with keep editing, discard, and save actions unchanged.",
      "acceptanceCriteria": [
        "FactoryGraphEditorLeaveDialog uses Radix Dialog and DialogContent",
        "While isSaving, overlay dismiss, escape, and actions behave as today (actions disabled; escape does not cancel)",
        "Dialog accessible name remains Leave graph editor with unsaved changes? or locale equivalent",
        "factory-graph-editor-leave-dialog.test.tsx asserts portal-to-body when open",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill: open leave dialog from editor exit flow; centered and not clipped"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "graph-editor-dialog-radix-migration-003",
      "title": "Migrate add-entity dialog",
      "description": "As an operator adding a workstation, worker, or work type from the graph editor, I want the add-entity form modal above the bento grid without overflow clipping.",
      "acceptanceCriteria": [
        "FactoryGraphEditorAddEntityDialog uses Radix Dialog and DialogContent",
        "Form fields, validation errors, and submit/close behavior are unchanged",
        "factory-graph-editor-add-dialog.test.tsx asserts portal-to-body when open",
        "Storybook story for add dialog still renders",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill: open add workstation from graph editor; dialog centered and scrollable if tall"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "graph-editor-dialog-radix-migration-004",
      "title": "Retire DashboardMutationDialog for graph editor",
      "description": "As a maintainer, I want graph-editor modals on the same Radix primitive as export/import so in-card clipping bugs are not reintroduced.",
      "acceptanceCriteria": [
        "No graph-editor component imports DashboardMutationDialog",
        "If no other production consumers remain, remove DashboardMutationDialog from mutation-dialog.tsx and keep DashboardMessagePanel; otherwise retain module for remaining consumers",
        "mutation-dialog.test.tsx is updated or removed consistent with exports",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "DashboardMutationDialog retained for EditableWorkstationSaveDialog (workstation-save-controls.tsx); graph-editor has no mutation-dialog imports."
    },
    {
      "id": "graph-editor-dialog-radix-migration-005",
      "title": "Regression coverage for editor dialog host",
      "description": "As a maintainer, I want integration confidence that graph editor dialogs still open from the activity card host after migration.",
      "acceptanceCriteria": [
        "react-flow-current-activity-card-edit-integration.test.tsx passes save-confirm flow (Save factory graph changes? to Save topology)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": "Added integration test asserting save dialog is portaled to document.body from activity card host."
    }
  ]
}

Made with [Cursor](https://cursor.com)