### PR TITLE
dashboard-notification-dedup-persistence

### DIFF
--- a/ui/src/features/notifications/components/app-notification-toaster.test.tsx
+++ b/ui/src/features/notifications/components/app-notification-toaster.test.tsx
@@ -3,6 +3,8 @@ import { render, screen } from "@testing-library/react";
 import {
   AppNotificationToaster,
   GLOBAL_TOAST_DURATION_MS,
+  PERSISTENT_TOAST_DURATION_MS,
+  resolveAppNotificationToastDuration,
 } from "./app-notification-toaster";
 
 vi.mock("sonner", () => ({
@@ -25,12 +27,22 @@ vi.mock("sonner", () => ({
 }));
 
 describe("AppNotificationToaster", () => {
-  it("configures global sonner notifications as closeable top-right toasts that dismiss after three seconds", () => {
+  it("configures closeable top-right toasts with the global success/info TTL default", () => {
     render(<AppNotificationToaster />);
 
     const toaster = screen.getByTestId("app-notification-toaster");
     expect(toaster.dataset.closeable).toBe("true");
     expect(toaster.dataset.duration).toBe(String(GLOBAL_TOAST_DURATION_MS));
     expect(toaster.dataset.position).toBe("top-right");
+  });
+
+  it("documents persistent error duration separate from the global toaster default", () => {
+    expect(resolveAppNotificationToastDuration("error")).toBe(
+      PERSISTENT_TOAST_DURATION_MS,
+    );
+    expect(resolveAppNotificationToastDuration("success")).toBe(
+      GLOBAL_TOAST_DURATION_MS,
+    );
+    expect(PERSISTENT_TOAST_DURATION_MS).not.toBe(GLOBAL_TOAST_DURATION_MS);
   });
 });

--- a/ui/src/features/notifications/components/app-notification-toaster.tsx
+++ b/ui/src/features/notifications/components/app-notification-toaster.tsx
@@ -1,16 +1,18 @@
 import { Toaster } from "sonner";
 
-import { GLOBAL_TOAST_DURATION_MS } from "../lib/notification-toast-duration";
+import {
+  GLOBAL_TOAST_DURATION_MS,
+  getAppNotificationToasterProps,
+  PERSISTENT_TOAST_DURATION_MS,
+  resolveAppNotificationToastDuration,
+} from "../lib/notification-toaster-config";
 
-export { GLOBAL_TOAST_DURATION_MS };
+export {
+  GLOBAL_TOAST_DURATION_MS,
+  PERSISTENT_TOAST_DURATION_MS,
+  resolveAppNotificationToastDuration,
+};
 
 export function AppNotificationToaster() {
-  return (
-    <Toaster
-      closeButton
-      duration={GLOBAL_TOAST_DURATION_MS}
-      position="top-right"
-      richColors
-    />
-  );
+  return <Toaster {...getAppNotificationToasterProps()} />;
 }

--- a/ui/src/features/notifications/components/app-notification-toaster.tsx
+++ b/ui/src/features/notifications/components/app-notification-toaster.tsx
@@ -1,6 +1,8 @@
 import { Toaster } from "sonner";
 
-export const GLOBAL_TOAST_DURATION_MS = 3000;
+import { GLOBAL_TOAST_DURATION_MS } from "../lib/notification-toast-duration";
+
+export { GLOBAL_TOAST_DURATION_MS };
 
 export function AppNotificationToaster() {
   return (

--- a/ui/src/features/notifications/lib/notification-toast-duration.ts
+++ b/ui/src/features/notifications/lib/notification-toast-duration.ts
@@ -1,0 +1,5 @@
+/** Default auto-dismiss duration for success and info save toasts. */
+export const GLOBAL_TOAST_DURATION_MS = 3000;
+
+/** Error toasts stay visible until the operator dismisses them. */
+export const PERSISTENT_TOAST_DURATION_MS = Number.POSITIVE_INFINITY;

--- a/ui/src/features/notifications/lib/notification-toaster-config.test.ts
+++ b/ui/src/features/notifications/lib/notification-toaster-config.test.ts
@@ -1,0 +1,30 @@
+import {
+  GLOBAL_TOAST_DURATION_MS,
+  getAppNotificationToasterProps,
+  PERSISTENT_TOAST_DURATION_MS,
+  resolveAppNotificationToastDuration,
+} from "./notification-toaster-config";
+
+describe("notification toaster config", () => {
+  it("uses persistent duration for errors and global TTL for success and info", () => {
+    expect(resolveAppNotificationToastDuration("error")).toBe(
+      PERSISTENT_TOAST_DURATION_MS,
+    );
+    expect(resolveAppNotificationToastDuration("success")).toBe(
+      GLOBAL_TOAST_DURATION_MS,
+    );
+    expect(resolveAppNotificationToastDuration("info")).toBe(
+      GLOBAL_TOAST_DURATION_MS,
+    );
+    expect(PERSISTENT_TOAST_DURATION_MS).not.toBe(GLOBAL_TOAST_DURATION_MS);
+  });
+
+  it("configures the global toaster with closeable top-right success/info defaults", () => {
+    expect(getAppNotificationToasterProps()).toEqual({
+      closeButton: true,
+      duration: GLOBAL_TOAST_DURATION_MS,
+      position: "top-right",
+      richColors: true,
+    });
+  });
+});

--- a/ui/src/features/notifications/lib/notification-toaster-config.ts
+++ b/ui/src/features/notifications/lib/notification-toaster-config.ts
@@ -1,0 +1,38 @@
+import type { ToasterProps } from "sonner";
+
+import {
+  GLOBAL_TOAST_DURATION_MS,
+  PERSISTENT_TOAST_DURATION_MS,
+} from "./notification-toast-duration";
+
+export type AppNotificationToastKind = "error" | "success" | "info";
+
+/**
+ * Per-outcome toast duration for dashboard notifications.
+ * Errors persist until dismissed; success and info use the global TTL.
+ */
+export function resolveAppNotificationToastDuration(
+  kind: AppNotificationToastKind,
+): number {
+  return kind === "error"
+    ? PERSISTENT_TOAST_DURATION_MS
+    : GLOBAL_TOAST_DURATION_MS;
+}
+
+/** Shared Sonner Toaster props for the dashboard shell. */
+export function getAppNotificationToasterProps(): Pick<
+  ToasterProps,
+  "closeButton" | "duration" | "position" | "richColors"
+> {
+  return {
+    closeButton: true,
+    duration: GLOBAL_TOAST_DURATION_MS,
+    position: "top-right",
+    richColors: true,
+  };
+}
+
+export {
+  GLOBAL_TOAST_DURATION_MS,
+  PERSISTENT_TOAST_DURATION_MS,
+} from "./notification-toast-duration";

--- a/ui/src/features/notifications/lib/save-notification-delivery-policy.test.ts
+++ b/ui/src/features/notifications/lib/save-notification-delivery-policy.test.ts
@@ -1,0 +1,79 @@
+import {
+  buildSaveErrorStableIdentity,
+  buildSaveErrorToastOptions,
+  buildSaveNotificationDeliveryKey,
+  buildSaveSuccessStableIdentity,
+  buildSaveSuccessToastOptions,
+  GLOBAL_TOAST_DURATION_MS,
+  PERSISTENT_TOAST_DURATION_MS,
+  shouldDeliverSaveNotification,
+} from "./save-notification-delivery-policy";
+
+describe("save notification delivery policy", () => {
+  const errorIdentity = buildSaveErrorStableIdentity({
+    message: "The graph is invalid.",
+    code: "VALIDATION_FAILED",
+  });
+
+  it("builds stable error identity from kind, message, and code", () => {
+    expect(errorIdentity).toEqual({
+      kind: "error",
+      stableId: "VALIDATION_FAILED:The graph is invalid.",
+    });
+  });
+
+  it("builds delivery keys that include save-attempt revision", () => {
+    expect(buildSaveNotificationDeliveryKey(errorIdentity, 1)).toBe(
+      "error:VALIDATION_FAILED:The graph is invalid.#1",
+    );
+    expect(buildSaveNotificationDeliveryKey(errorIdentity, 2)).toBe(
+      "error:VALIDATION_FAILED:The graph is invalid.#2",
+    );
+  });
+
+  it("suppresses duplicate delivery for the same revision and stable identity", () => {
+    const deliveryKey = buildSaveNotificationDeliveryKey(errorIdentity, 3);
+
+    expect(shouldDeliverSaveNotification(deliveryKey, deliveryKey)).toBe(false);
+  });
+
+  it("delivers again when save-attempt revision increments with the same stable identity", () => {
+    const firstAttemptKey = buildSaveNotificationDeliveryKey(errorIdentity, 1);
+    const secondAttemptKey = buildSaveNotificationDeliveryKey(errorIdentity, 2);
+
+    expect(
+      shouldDeliverSaveNotification(secondAttemptKey, firstAttemptKey),
+    ).toBe(true);
+  });
+
+  it("always delivers when stable identity differs", () => {
+    const firstIdentity = buildSaveErrorStableIdentity({
+      message: "First error",
+    });
+    const secondIdentity = buildSaveErrorStableIdentity({
+      message: "Second error",
+    });
+    const firstKey = buildSaveNotificationDeliveryKey(firstIdentity, 1);
+    const secondKey = buildSaveNotificationDeliveryKey(secondIdentity, 1);
+
+    expect(shouldDeliverSaveNotification(secondKey, firstKey)).toBe(true);
+  });
+
+  it("uses persistent duration for errors and global TTL for success", () => {
+    expect(buildSaveErrorToastOptions("details")).toEqual({
+      description: "details",
+      duration: PERSISTENT_TOAST_DURATION_MS,
+    });
+    expect(buildSaveSuccessToastOptions("saved")).toEqual({
+      description: "saved",
+      duration: GLOBAL_TOAST_DURATION_MS,
+    });
+  });
+
+  it("builds a fixed stable identity for graph save success", () => {
+    expect(buildSaveSuccessStableIdentity()).toEqual({
+      kind: "success",
+      stableId: "graph-save-success",
+    });
+  });
+});

--- a/ui/src/features/notifications/lib/save-notification-delivery-policy.ts
+++ b/ui/src/features/notifications/lib/save-notification-delivery-policy.ts
@@ -1,0 +1,114 @@
+import {
+  GLOBAL_TOAST_DURATION_MS,
+  PERSISTENT_TOAST_DURATION_MS,
+} from "./notification-toast-duration";
+
+export type SaveNotificationKind = "error" | "success" | "info";
+
+export type SaveNotificationStableIdentity = {
+  kind: SaveNotificationKind;
+  stableId: string;
+};
+
+export type SaveNotificationDeliveryKey = string;
+
+function normalizeSaveNotificationMessage(message: string): string {
+  return message.trim();
+}
+
+/**
+ * Stable identity for save errors: kind plus normalized message and optional code.
+ * Cross-attempt retries with the same message share identity; delivery keys still
+ * differ when save-attempt revision increments.
+ */
+export function buildSaveErrorStableIdentity(input: {
+  message: string;
+  code?: string | null;
+}): SaveNotificationStableIdentity {
+  const normalizedMessage = normalizeSaveNotificationMessage(input.message);
+  const normalizedCode =
+    typeof input.code === "string" && input.code.trim().length > 0
+      ? input.code.trim()
+      : null;
+
+  const stableId =
+    normalizedCode === null
+      ? normalizedMessage
+      : `${normalizedCode}:${normalizedMessage}`;
+
+  return {
+    kind: "error",
+    stableId,
+  };
+}
+
+/** Stable identity for a graph save success toast (one per save surface). */
+export function buildSaveSuccessStableIdentity(): SaveNotificationStableIdentity {
+  return {
+    kind: "success",
+    stableId: "graph-save-success",
+  };
+}
+
+/**
+ * Attempt-scoped delivery key. Includes save-attempt revision so operator retries
+ * always qualify as new delivery even when stable identity is unchanged.
+ */
+export function buildSaveNotificationDeliveryKey(
+  identity: SaveNotificationStableIdentity,
+  saveAttemptRevision: number,
+): SaveNotificationDeliveryKey {
+  return `${identity.kind}:${identity.stableId}#${saveAttemptRevision}`;
+}
+
+/**
+ * Burst-only dedupe: suppress when the same delivery key was already shown for
+ * this attempt outcome (e.g. React strict-mode or prop rerenders). Does not
+ * suppress across attempts because revision is part of the delivery key.
+ */
+export function shouldDeliverSaveNotification(
+  deliveryKey: SaveNotificationDeliveryKey,
+  lastDeliveredDeliveryKey: SaveNotificationDeliveryKey | null,
+): boolean {
+  return deliveryKey !== lastDeliveredDeliveryKey;
+}
+
+export type SaveNotificationToastOptions = {
+  description: string;
+  duration: number;
+};
+
+/** Sonner options for save error toasts (persistent until dismissed). */
+export function buildSaveErrorToastOptions(
+  description: string,
+): SaveNotificationToastOptions {
+  return {
+    description,
+    duration: PERSISTENT_TOAST_DURATION_MS,
+  };
+}
+
+/** Sonner options for save success toasts (existing global TTL). */
+export function buildSaveSuccessToastOptions(
+  description: string,
+): SaveNotificationToastOptions {
+  return {
+    description,
+    duration: GLOBAL_TOAST_DURATION_MS,
+  };
+}
+
+/** Sonner options for save info toasts (existing global TTL). */
+export function buildSaveInfoToastOptions(
+  description: string,
+): SaveNotificationToastOptions {
+  return {
+    description,
+    duration: GLOBAL_TOAST_DURATION_MS,
+  };
+}
+
+export {
+  GLOBAL_TOAST_DURATION_MS,
+  PERSISTENT_TOAST_DURATION_MS,
+} from "./notification-toast-duration";

--- a/ui/src/features/notifications/lib/save-notification-delivery-policy.ts
+++ b/ui/src/features/notifications/lib/save-notification-delivery-policy.ts
@@ -98,16 +98,6 @@ export function buildSaveSuccessToastOptions(
   };
 }
 
-/** Sonner options for save info toasts (existing global TTL). */
-export function buildSaveInfoToastOptions(
-  description: string,
-): SaveNotificationToastOptions {
-  return {
-    description,
-    duration: GLOBAL_TOAST_DURATION_MS,
-  };
-}
-
 export {
   GLOBAL_TOAST_DURATION_MS,
   PERSISTENT_TOAST_DURATION_MS,

--- a/ui/src/features/notifications/public/index.ts
+++ b/ui/src/features/notifications/public/index.ts
@@ -1,5 +1,10 @@
 export { AppNotificationToaster } from "../components/app-notification-toaster";
 export {
+  type AppNotificationToastKind,
+  getAppNotificationToasterProps,
+  resolveAppNotificationToastDuration,
+} from "../lib/notification-toaster-config";
+export {
   buildSaveErrorStableIdentity,
   buildSaveErrorToastOptions,
   buildSaveInfoToastOptions,

--- a/ui/src/features/notifications/public/index.ts
+++ b/ui/src/features/notifications/public/index.ts
@@ -1,1 +1,16 @@
 export { AppNotificationToaster } from "../components/app-notification-toaster";
+export {
+  buildSaveErrorStableIdentity,
+  buildSaveErrorToastOptions,
+  buildSaveInfoToastOptions,
+  buildSaveNotificationDeliveryKey,
+  buildSaveSuccessStableIdentity,
+  buildSaveSuccessToastOptions,
+  GLOBAL_TOAST_DURATION_MS,
+  PERSISTENT_TOAST_DURATION_MS,
+  type SaveNotificationDeliveryKey,
+  type SaveNotificationKind,
+  type SaveNotificationStableIdentity,
+  type SaveNotificationToastOptions,
+  shouldDeliverSaveNotification,
+} from "../lib/save-notification-delivery-policy";

--- a/ui/src/features/notifications/public/index.ts
+++ b/ui/src/features/notifications/public/index.ts
@@ -7,7 +7,6 @@ export {
 export {
   buildSaveErrorStableIdentity,
   buildSaveErrorToastOptions,
-  buildSaveInfoToastOptions,
   buildSaveNotificationDeliveryKey,
   buildSaveSuccessStableIdentity,
   buildSaveSuccessToastOptions,

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-save-notifications.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-save-notifications.test.tsx
@@ -1,7 +1,10 @@
 import { render } from "@testing-library/react";
 import { toast } from "sonner";
 
-import { GLOBAL_TOAST_DURATION_MS } from "../../notifications/components/app-notification-toaster";
+import {
+  GLOBAL_TOAST_DURATION_MS,
+  PERSISTENT_TOAST_DURATION_MS,
+} from "../../notifications/public";
 import { CurrentActivityGraphSaveNotifications } from "./react-flow-current-activity-card-save-notifications";
 
 vi.mock("sonner", () => ({
@@ -15,6 +18,7 @@ function createEditorStub(overrides: Record<string, unknown> = {}) {
   return {
     draftState: { hasChanges: false },
     graphDraftSaveSucceeded: false,
+    saveAttemptRevision: 0,
     saveEditableDefinition: {
       error: null,
     },
@@ -33,6 +37,7 @@ describe("CurrentActivityGraphSaveNotifications", () => {
         editor={
           createEditorStub({
             graphDraftSaveSucceeded: true,
+            saveAttemptRevision: 1,
           }) as never
         }
       />,
@@ -51,6 +56,7 @@ describe("CurrentActivityGraphSaveNotifications", () => {
       <CurrentActivityGraphSaveNotifications
         editor={
           createEditorStub({
+            saveAttemptRevision: 1,
             saveEditableDefinition: {
               error: new Error("The graph is invalid."),
             },
@@ -61,14 +67,15 @@ describe("CurrentActivityGraphSaveNotifications", () => {
 
     expect(toast.error).toHaveBeenCalledWith("Topology save failed", {
       description: "The graph is invalid.",
-      duration: GLOBAL_TOAST_DURATION_MS,
+      duration: PERSISTENT_TOAST_DURATION_MS,
     });
     expect(toast.success).not.toHaveBeenCalled();
   });
 
-  it("does not repeat the same save notification across rerenders", () => {
+  it("does not repeat the same save notification across rerenders with the same attempt revision", () => {
     const editor = createEditorStub({
       graphDraftSaveSucceeded: true,
+      saveAttemptRevision: 1,
     });
     const { rerender } = render(
       <CurrentActivityGraphSaveNotifications editor={editor as never} />,
@@ -79,5 +86,37 @@ describe("CurrentActivityGraphSaveNotifications", () => {
     );
 
     expect(toast.success).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls toast.error twice for the same message on distinct save attempts", () => {
+    const { rerender } = render(
+      <CurrentActivityGraphSaveNotifications
+        editor={
+          createEditorStub({
+            saveAttemptRevision: 1,
+            saveEditableDefinition: {
+              error: new Error("The graph is invalid."),
+            },
+          }) as never
+        }
+      />,
+    );
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <CurrentActivityGraphSaveNotifications
+        editor={
+          createEditorStub({
+            saveAttemptRevision: 2,
+            saveEditableDefinition: {
+              error: new Error("The graph is invalid."),
+            },
+          }) as never
+        }
+      />,
+    );
+
+    expect(toast.error).toHaveBeenCalledTimes(2);
   });
 });

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-save-notifications.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-save-notifications.tsx
@@ -2,8 +2,28 @@ import { useEffect, useRef } from "react";
 import { toast } from "sonner";
 
 import { getFactoryGraphEditorMessages } from "../../factory-graph-editor/messages/editor";
-import { GLOBAL_TOAST_DURATION_MS } from "../../notifications/components/app-notification-toaster";
+import {
+  buildSaveErrorStableIdentity,
+  buildSaveErrorToastOptions,
+  buildSaveNotificationDeliveryKey,
+  buildSaveSuccessStableIdentity,
+  buildSaveSuccessToastOptions,
+  type SaveNotificationDeliveryKey,
+  shouldDeliverSaveNotification,
+} from "../../notifications/public";
 import type { useCurrentActivityGraphEditor } from "../hooks/react-flow-current-activity-card-editor";
+
+function readSaveErrorCode(error: unknown): string | null {
+  if (
+    error !== null &&
+    typeof error === "object" &&
+    "code" in error &&
+    typeof (error as { code: unknown }).code === "string"
+  ) {
+    return (error as { code: string }).code;
+  }
+  return null;
+}
 
 export function CurrentActivityGraphSaveNotifications({
   editor,
@@ -13,42 +33,69 @@ export function CurrentActivityGraphSaveNotifications({
   locale?: string;
 }) {
   const messages = getFactoryGraphEditorMessages(locale);
-  const lastToastKeyRef = useRef<string | null>(null);
-  const saveErrorMessage = editor.saveEditableDefinition.error?.message ?? null;
+  const lastDeliveredDeliveryKeyRef =
+    useRef<SaveNotificationDeliveryKey | null>(null);
+  const saveError = editor.saveEditableDefinition.error ?? null;
+  const saveErrorMessage = saveError?.message ?? null;
+  const saveAttemptRevision = editor.saveAttemptRevision;
   const hasDraftChanges = editor.draftState.hasChanges;
   const showSaveSuccessToast =
     editor.graphDraftSaveSucceeded && !hasDraftChanges;
 
   useEffect(() => {
-    const toastKey =
-      saveErrorMessage !== null
-        ? `error:${saveErrorMessage}`
-        : showSaveSuccessToast
-          ? "success"
-          : null;
+    let deliveryKey: SaveNotificationDeliveryKey | null = null;
+    let emitError = false;
+    let emitSuccess = false;
 
-    if (toastKey === null || toastKey === lastToastKeyRef.current) {
+    if (saveErrorMessage !== null) {
+      const identity = buildSaveErrorStableIdentity({
+        message: saveErrorMessage,
+        code: readSaveErrorCode(saveError),
+      });
+      deliveryKey = buildSaveNotificationDeliveryKey(
+        identity,
+        saveAttemptRevision,
+      );
+      emitError = true;
+    } else if (showSaveSuccessToast) {
+      const identity = buildSaveSuccessStableIdentity();
+      deliveryKey = buildSaveNotificationDeliveryKey(
+        identity,
+        saveAttemptRevision,
+      );
+      emitSuccess = true;
+    }
+
+    if (
+      deliveryKey === null ||
+      !shouldDeliverSaveNotification(
+        deliveryKey,
+        lastDeliveredDeliveryKeyRef.current,
+      )
+    ) {
       return;
     }
 
-    lastToastKeyRef.current = toastKey;
+    lastDeliveredDeliveryKeyRef.current = deliveryKey;
 
-    if (saveErrorMessage !== null) {
+    if (emitError && saveErrorMessage !== null) {
       toast.error(messages.noticeSaveFailedTitle, {
-        description: saveErrorMessage,
-        duration: GLOBAL_TOAST_DURATION_MS,
+        ...buildSaveErrorToastOptions(saveErrorMessage),
       });
       return;
     }
 
-    toast.success(messages.noticeSaveSuccessTitle, {
-      description: messages.noticeSaveSuccessDescription,
-      duration: GLOBAL_TOAST_DURATION_MS,
-    });
+    if (emitSuccess) {
+      toast.success(messages.noticeSaveSuccessTitle, {
+        ...buildSaveSuccessToastOptions(messages.noticeSaveSuccessDescription),
+      });
+    }
   }, [
     messages.noticeSaveFailedTitle,
     messages.noticeSaveSuccessDescription,
     messages.noticeSaveSuccessTitle,
+    saveAttemptRevision,
+    saveError,
     saveErrorMessage,
     showSaveSuccessToast,
   ]);

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor-value.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor-value.ts
@@ -50,6 +50,7 @@ export function buildCurrentActivityGraphEditorValue(args: {
   pendingRemovalIntent: ReturnType<
     typeof useFactoryGraphRemovalController
   >["pendingRemovalIntent"];
+  saveAttemptRevision: number;
   saveBlockedReason?: string;
   saveEditableDefinition: ReturnType<typeof useFactoryDocumentSave>;
   saveSummary: ReturnType<typeof buildFactoryGraphSaveSummary>;
@@ -100,6 +101,7 @@ export function buildCurrentActivityGraphEditorValue(args: {
     leaveDialogOpen: args.isConfirmingLeaveEditor,
     pendingConnectionSource: args.pendingConnectionSource,
     pendingRemovalIntent: args.pendingRemovalIntent,
+    saveAttemptRevision: args.saveAttemptRevision,
     saveBlockedReason: args.saveBlockedReason,
     saveEditableDefinition: args.saveEditableDefinition,
     saveSummary: args.saveSummary,

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor.tsx
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor.tsx
@@ -111,6 +111,7 @@ export function useCurrentActivityGraphEditor(
     isStaleDraft: saveFlow.isStaleDraft,
     pendingConnectionSource: controllers.pendingConnectionSource,
     pendingRemovalIntent: controllers.pendingRemovalIntent,
+    saveAttemptRevision: saveFlow.saveAttemptRevision,
     saveBlockedReason: saveFlow.saveBlockedReason,
     saveEditableDefinition,
     saveSummary: saveFlow.saveSummary,

--- a/ui/src/features/workflow-activity/hooks/use-graph-editor-save-flow.test.ts
+++ b/ui/src/features/workflow-activity/hooks/use-graph-editor-save-flow.test.ts
@@ -120,30 +120,32 @@ function renderSaveFlow(activeWorkCount = 0) {
   };
 }
 
+function resetSaveFlowFixture() {
+  fixtureState.addEntityController.reset.mockReset();
+  fixtureState.saveStateIsStale = false;
+  fixtureState.draftState = {
+    baseDocument: fixtureState.baseDocument,
+    draft: fixtureState.emptyDraft,
+    hasChanges: false,
+    latestDocument: fixtureState.baseDocument,
+    pendingFactoryDefinition: fixtureState.baseDocument,
+    replaceDraft: vi.fn(),
+    resetDraft: vi.fn(),
+    validationErrors: [],
+  };
+  fixtureState.saveEditableDefinition = {
+    error: null,
+    isPending: false,
+    reset: vi.fn(),
+    saveAsync: vi.fn(async () => undefined),
+  };
+  fixtureState.transientControllerReset.setConnectionNotice.mockReset();
+  fixtureState.transientControllerReset.setPendingRemovalEdgeId.mockReset();
+  fixtureState.transientControllerReset.setPendingRemovalNodeId.mockReset();
+}
+
 describe("useGraphEditorSaveFlow", () => {
-  beforeEach(() => {
-    fixtureState.addEntityController.reset.mockReset();
-    fixtureState.saveStateIsStale = false;
-    fixtureState.draftState = {
-      baseDocument: fixtureState.baseDocument,
-      draft: fixtureState.emptyDraft,
-      hasChanges: false,
-      latestDocument: fixtureState.baseDocument,
-      pendingFactoryDefinition: fixtureState.baseDocument,
-      replaceDraft: vi.fn(),
-      resetDraft: vi.fn(),
-      validationErrors: [],
-    };
-    fixtureState.saveEditableDefinition = {
-      error: null,
-      isPending: false,
-      reset: vi.fn(),
-      saveAsync: vi.fn(async () => undefined),
-    };
-    fixtureState.transientControllerReset.setConnectionNotice.mockReset();
-    fixtureState.transientControllerReset.setPendingRemovalEdgeId.mockReset();
-    fixtureState.transientControllerReset.setPendingRemovalNodeId.mockReset();
-  });
+  beforeEach(resetSaveFlowFixture);
 
   it("blocks saving while active work is in flight", () => {
     fixtureState.draftState.hasChanges = true;
@@ -207,50 +209,6 @@ describe("useGraphEditorSaveFlow", () => {
     expect(result.current.isConfirmingSave).toBe(false);
   });
 
-  it("starts saveAttemptRevision at zero", () => {
-    const { result } = renderSaveFlow(0);
-
-    expect(result.current.saveAttemptRevision).toBe(0);
-  });
-
-  it("increments saveAttemptRevision when each save starts", async () => {
-    fixtureState.draftState.hasChanges = true;
-    const { result } = renderSaveFlow(0);
-
-    await act(async () => {
-      await result.current.handleSaveDraft();
-    });
-    expect(result.current.saveAttemptRevision).toBe(1);
-
-    fixtureState.draftState.hasChanges = true;
-    await act(async () => {
-      await result.current.handleSaveBeforeLeavingEditor();
-    });
-    expect(result.current.saveAttemptRevision).toBe(2);
-  });
-
-  it("does not increment saveAttemptRevision on rerender alone", () => {
-    fixtureState.draftState.hasChanges = true;
-    const { result, rerender } = renderSaveFlow(0);
-
-    expect(result.current.saveAttemptRevision).toBe(0);
-
-    rerender();
-
-    expect(result.current.saveAttemptRevision).toBe(0);
-  });
-
-  it("does not increment saveAttemptRevision when save is blocked", async () => {
-    fixtureState.draftState.hasChanges = true;
-    const { result } = renderSaveFlow(2);
-
-    await act(async () => {
-      await result.current.handleSaveDraft();
-    });
-
-    expect(result.current.saveAttemptRevision).toBe(0);
-  });
-
   it("saves and leaves editor mode when asked to save before leaving", async () => {
     fixtureState.draftState.hasChanges = true;
     const { result, setActiveTool, setEditorMode } = renderSaveFlow(0);
@@ -274,5 +232,53 @@ describe("useGraphEditorSaveFlow", () => {
     expect(setActiveTool).toHaveBeenCalledWith(null);
     expect(result.current.isConfirmingSave).toBe(false);
     expect(result.current.isConfirmingLeaveEditor).toBe(false);
+  });
+});
+
+describe("useGraphEditorSaveFlow saveAttemptRevision", () => {
+  beforeEach(resetSaveFlowFixture);
+
+  it("starts at zero", () => {
+    const { result } = renderSaveFlow(0);
+
+    expect(result.current.saveAttemptRevision).toBe(0);
+  });
+
+  it("increments when each save starts", async () => {
+    fixtureState.draftState.hasChanges = true;
+    const { result } = renderSaveFlow(0);
+
+    await act(async () => {
+      await result.current.handleSaveDraft();
+    });
+    expect(result.current.saveAttemptRevision).toBe(1);
+
+    fixtureState.draftState.hasChanges = true;
+    await act(async () => {
+      await result.current.handleSaveBeforeLeavingEditor();
+    });
+    expect(result.current.saveAttemptRevision).toBe(2);
+  });
+
+  it("does not increment on rerender alone", () => {
+    fixtureState.draftState.hasChanges = true;
+    const { result, rerender } = renderSaveFlow(0);
+
+    expect(result.current.saveAttemptRevision).toBe(0);
+
+    rerender();
+
+    expect(result.current.saveAttemptRevision).toBe(0);
+  });
+
+  it("does not increment when save is blocked", async () => {
+    fixtureState.draftState.hasChanges = true;
+    const { result } = renderSaveFlow(2);
+
+    await act(async () => {
+      await result.current.handleSaveDraft();
+    });
+
+    expect(result.current.saveAttemptRevision).toBe(0);
   });
 });

--- a/ui/src/features/workflow-activity/hooks/use-graph-editor-save-flow.test.ts
+++ b/ui/src/features/workflow-activity/hooks/use-graph-editor-save-flow.test.ts
@@ -207,6 +207,50 @@ describe("useGraphEditorSaveFlow", () => {
     expect(result.current.isConfirmingSave).toBe(false);
   });
 
+  it("starts saveAttemptRevision at zero", () => {
+    const { result } = renderSaveFlow(0);
+
+    expect(result.current.saveAttemptRevision).toBe(0);
+  });
+
+  it("increments saveAttemptRevision when each save starts", async () => {
+    fixtureState.draftState.hasChanges = true;
+    const { result } = renderSaveFlow(0);
+
+    await act(async () => {
+      await result.current.handleSaveDraft();
+    });
+    expect(result.current.saveAttemptRevision).toBe(1);
+
+    fixtureState.draftState.hasChanges = true;
+    await act(async () => {
+      await result.current.handleSaveBeforeLeavingEditor();
+    });
+    expect(result.current.saveAttemptRevision).toBe(2);
+  });
+
+  it("does not increment saveAttemptRevision on rerender alone", () => {
+    fixtureState.draftState.hasChanges = true;
+    const { result, rerender } = renderSaveFlow(0);
+
+    expect(result.current.saveAttemptRevision).toBe(0);
+
+    rerender();
+
+    expect(result.current.saveAttemptRevision).toBe(0);
+  });
+
+  it("does not increment saveAttemptRevision when save is blocked", async () => {
+    fixtureState.draftState.hasChanges = true;
+    const { result } = renderSaveFlow(2);
+
+    await act(async () => {
+      await result.current.handleSaveDraft();
+    });
+
+    expect(result.current.saveAttemptRevision).toBe(0);
+  });
+
   it("saves and leaves editor mode when asked to save before leaving", async () => {
     fixtureState.draftState.hasChanges = true;
     const { result, setActiveTool, setEditorMode } = renderSaveFlow(0);

--- a/ui/src/features/workflow-activity/hooks/use-graph-editor-save-flow.ts
+++ b/ui/src/features/workflow-activity/hooks/use-graph-editor-save-flow.ts
@@ -41,6 +41,7 @@ export function useGraphEditorSaveFlow({
 }) {
   const [isConfirmingLeaveEditor, setIsConfirmingLeaveEditor] = useState(false);
   const [isConfirmingSave, setIsConfirmingSave] = useState(false);
+  const [saveAttemptRevision, setSaveAttemptRevision] = useState(0);
   const hasActiveWork = activeWorkCount > 0;
   const isStaleDraft = editableGraph.saveState.isStale;
   const canSaveDraft =
@@ -91,6 +92,8 @@ export function useGraphEditorSaveFlow({
         return false;
       }
 
+      setSaveAttemptRevision((revision) => revision + 1);
+
       try {
         const didSave = await editableGraph.actions.save();
         if (!didSave) {
@@ -131,6 +134,7 @@ export function useGraphEditorSaveFlow({
     isConfirmingSave,
     isStaleDraft,
     leaveEditor,
+    saveAttemptRevision,
     saveBlockedReason,
     saveSummary,
     setIsConfirmingLeaveEditor,


### PR DESCRIPTION
{
  "project": "Dashboard Notification Dedup and Persistence",
  "branchName": "ralph/dashboard-notification-dedup-persistence",
  "description": "Fix dashboard save toasts so each operator save attempt produces feedback, error notifications persist until dismissed, and duplicate suppression applies only within a single save-attempt burst—not across retries with the same error message.",
  "context": {
    "customerAsk": "Introduce per-notification nonce or stable id plus monotonic revision so repeated identical errors still notify on retry. Stop auto-expiring error toasts; require explicit dismiss. Deduplicate only within a single save-attempt burst, not across operator retries. Success/info may keep existing TTL.",
    "problem": "Graph save notifications key toasts by error message or a static success key and suppress repeats via a ref, so a second save with the same validation error shows no new toast. Global Sonner duration is 3000 ms, so errors disappear before operators dismiss them.",
    "solution": "Add a notifications delivery policy (stable identity, attempt-scoped delivery key, burst-only dedupe, persistent error duration). Expose monotonic saveAttemptRevision from the graph save flow. Wire CurrentActivityGraphSaveNotifications and toaster defaults to the policy so each save attempt toasts once, errors persist, and success keeps TTL."
  },
  "acceptanceCriteria": [
    "Two consecutive graph save attempts failing with the same error message each produce a visible error toast",
    "Error toasts remain until explicitly dismissed (no three-second auto-expire)",
    "Re-renders within the same save attempt and outcome do not emit duplicate toasts",
    "Success save toasts retain the existing GLOBAL_TOAST_DURATION_MS TTL with documented policy",
    "Shared delivery policy lives under ui/src/features/notifications with direct unit and component tests",
    "No notification center redesign, email, or webhook alerting",
    "Typecheck, lint, and tests pass for touched UI packages"
  ],
  "userStories": [
    {
      "id": "dashboard-notification-dedup-persistence-001",
      "title": "Notification delivery policy for save outcomes",
      "description": "As a maintainer, I want a pure notification delivery policy so save surfaces share stable identity, attempt-scoped keys, burst dedupe, and error vs success duration rules.",
      "acceptanceCriteria": [
        "ui/src/features/notifications/lib exports stable error identity, delivery key including save-attempt revision, burst-only suppression, and toast option builders",
        "Policy sets persistent duration for errors and GLOBAL_TOAST_DURATION_MS for success/info",
        "Unit tests prove same revision suppresses duplicate delivery, incremented revision does not, and different identity always delivers",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "dashboard-notification-dedup-persistence-002",
      "title": "Monotonic save-attempt revision on graph save",
      "description": "As an operator, I want each save click to count as a new notification attempt so retries are never swallowed by prior dedupe state.",
      "acceptanceCriteria": [
        "Graph editor save flow exposes saveAttemptRevision on the editor view model used by save notifications",
        "Revision increments when a save starts across two sequential save invocations",
        "Hook or controller tests prove revision does not increment on unrelated rerenders alone",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "dashboard-notification-dedup-persistence-003",
      "title": "Persistent error toasts in global toaster defaults",
      "description": "As an operator, I want error toasts to stay visible until I dismiss them so I do not miss failures while editing.",
      "acceptanceCriteria": [
        "AppNotificationToaster or scoped error toast calls ensure errors do not auto-dismiss after three seconds",
        "Success and info toasts retain close button, top-right position, and existing TTL behavior",
        "app-notification-toaster tests assert error persistence policy and unchanged success duration constant",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "dashboard-notification-dedup-persistence-004",
      "title": "Graph save notifications honor attempt-scoped delivery",
      "description": "As an operator editing factory topology, I want each save attempt to produce feedback once, with errors staying until dismissed.",
      "acceptanceCriteria": [
        "CurrentActivityGraphSaveNotifications uses shared policy and saveAttemptRevision instead of message-only toast keys",
        "Component tests: same revision rerender calls toast once; two failures with same message and different revisions call toast.error twice",
        "Component tests: error uses persistent duration; success uses GLOBAL_TOAST_DURATION_MS",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill: two saves with same validation error show two error toasts; error remains after 3+ seconds until dismissed"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}
