### PR TITLE
graph-phantom-worker-node-fix

### DIFF
--- a/ui/integration/maintainer-phantom-worker-graph.integration.test.mjs
+++ b/ui/integration/maintainer-phantom-worker-graph.integration.test.mjs
@@ -1,0 +1,189 @@
+// @vitest-environment node
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  buildTimeoutMs,
+  browserScenarioTimeoutMs,
+  expectNoBrowserErrors,
+  openBrowserPage,
+  startBrowserPreview,
+  startFactoryApiServer,
+  uiInteractionTimeoutMs,
+} from "./browser-test-harness.mjs";
+
+const SYSTEM_TIME_WORK_TYPE_ID = "__system_time";
+const SYSTEM_TIME_EXPIRY_TRANSITION_ID = "__system_time:expire";
+
+const maintainerRuntimeShapedFactory = {
+  name: "maintainer-runtime-factory",
+  resources: [{ capacity: 10, name: "executor-slot" }],
+  workers: [{ name: "processor" }, { name: "workspace-setup" }],
+  workTypes: [
+    {
+      name: "task",
+      states: [
+        { name: "init", type: "INITIAL" },
+        { name: "done", type: "TERMINAL" },
+      ],
+    },
+    {
+      name: SYSTEM_TIME_WORK_TYPE_ID,
+      states: [{ name: "pending", type: "PROCESSING" }],
+    },
+  ],
+  workstations: [
+    {
+      inputs: [{ state: "init", workType: "task" }],
+      name: "process",
+      outputs: [{ state: "done", workType: "task" }],
+      resources: [{ capacity: 1, name: "executor-slot" }],
+      worker: "processor",
+    },
+    {
+      inputs: [{ state: "init", workType: "task" }],
+      name: "setup-workspace",
+      outputs: [{ state: "done", workType: "task" }],
+      worker: "workspace-setup",
+    },
+    {
+      inputs: [{ state: "pending", workType: SYSTEM_TIME_WORK_TYPE_ID }],
+      name: SYSTEM_TIME_EXPIRY_TRANSITION_ID,
+      outputs: [],
+      worker: "",
+    },
+  ],
+};
+
+const maintainerRuntimeShapedEventLines = [
+  JSON.stringify({
+    context: {
+      eventTime: "2026-05-31T20:00:00Z",
+      sequence: 1,
+      tick: 1,
+    },
+    id: "maintainer-phantom-worker-smoke-1",
+    payload: {
+      factory: maintainerRuntimeShapedFactory,
+    },
+    type: "INITIAL_STRUCTURE_REQUEST",
+  }),
+  JSON.stringify({
+    context: {
+      eventTime: "2026-05-31T20:00:01Z",
+      sequence: 2,
+      tick: 2,
+    },
+    id: "maintainer-phantom-worker-smoke-2",
+    payload: {
+      previousState: "RUNNING",
+      reason: "maintainer phantom worker smoke complete",
+      state: "FINISHED",
+    },
+    type: "FACTORY_STATE_RESPONSE",
+  }),
+];
+
+describe.sequential("maintainer phantom worker graph browser integration", () => {
+  let preview = null;
+
+  beforeAll(async () => {
+    preview = await startBrowserPreview();
+  }, buildTimeoutMs);
+
+  afterAll(async () => {
+    await preview?.stop();
+    preview = null;
+  }, buildTimeoutMs);
+
+  it(
+    "renders defined worker labels without a bare worker: node and supports worker selection",
+    async () => {
+      const replayServer = await startFactoryApiServer({
+        apiPort: preview.apiPort,
+        currentFactory: maintainerRuntimeShapedFactory,
+        eventLines: maintainerRuntimeShapedEventLines,
+      });
+      const browserPage = await openBrowserPage({
+        artifactLabel: "maintainer-phantom-worker-graph",
+      });
+
+      try {
+        await browserPage.page.goto(preview.previewURL, {
+          waitUntil: "domcontentloaded",
+        });
+        await replayServer.replayCompleted;
+
+        const graphViewport = browserPage.page.getByRole("region", {
+          name: "Work graph viewport",
+        });
+        await graphViewport.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
+
+        const processorWorkerButton = graphViewport.getByRole("button", {
+          name: "Select processor worker",
+        });
+        const workspaceSetupWorkerButton = graphViewport.getByRole("button", {
+          name: "Select workspace-setup worker",
+        });
+
+        await processorWorkerButton.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
+        await workspaceSetupWorkerButton.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
+
+        const workerNodeLabels = await graphViewport
+          .locator("[data-worker-label-zone]")
+          .evaluateAll((elements) =>
+            elements
+              .map((element) => element.getAttribute("aria-label")?.trim() ?? "")
+              .filter((label) => label.length > 0),
+          );
+        expect(workerNodeLabels).toEqual(
+          expect.arrayContaining(["worker:processor", "worker:workspace-setup"]),
+        );
+        expect(workerNodeLabels).not.toContain("worker:");
+        expect(
+          await graphViewport
+            .getByRole("img", { name: "worker:", exact: true })
+            .count(),
+        ).toBe(0);
+
+        await processorWorkerButton.click({ force: true });
+        await expect
+          .poll(async () => processorWorkerButton.getAttribute("aria-pressed"), {
+            timeout: uiInteractionTimeoutMs,
+          })
+          .toBe("true");
+
+        await workspaceSetupWorkerButton.click({ force: true });
+        await expect
+          .poll(async () => workspaceSetupWorkerButton.getAttribute("aria-pressed"), {
+            timeout: uiInteractionTimeoutMs,
+          })
+          .toBe("true");
+        await expect
+          .poll(async () => processorWorkerButton.getAttribute("aria-pressed"), {
+            timeout: uiInteractionTimeoutMs,
+          })
+          .toBe("false");
+
+        expectNoBrowserErrors(
+          browserPage.pageErrors,
+          browserPage.consoleErrors,
+          expect,
+        );
+      } finally {
+        await replayServer.stop();
+        await browserPage.close();
+      }
+    },
+    browserScenarioTimeoutMs,
+  );
+});

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-customer-display.test.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-customer-display.test.ts
@@ -5,6 +5,7 @@ import {
   systemTimeGraphNodeId,
 } from "./factory-graph-customer-display";
 import { buildFactoryGraphTopologyFromDefinition } from "./factory-graph-draft-graph";
+import { buildNode } from "./factory-graph-draft-types";
 import type { CanonicalFactoryDefinition } from "./factory-graph-draft-types";
 import { maintainerRuntimeShapedFactory } from "./maintainer-runtime-shaped-factory.fixture";
 
@@ -235,5 +236,36 @@ describe("filterFactoryGraphTopologyForCustomerDisplay", () => {
     expect(
       edgeIds(filtered).some((edgeId) => edgeId.startsWith("worker-assignment:")),
     ).toBe(true);
+  });
+
+  it("drops stale empty-name worker nodes during customer-display filtering", () => {
+    const filteredTopology = filterFactoryGraphTopologyForCustomerDisplay(
+      buildFactoryGraphTopologyFromDefinition(maintainerRuntimeShapedFactory),
+    );
+    const withStalePhantomWorker = {
+      ...filteredTopology,
+      nodes: [
+        ...filteredTopology.nodes,
+        buildNode({ kind: "worker", name: "" }),
+      ],
+      edges: [
+        ...filteredTopology.edges,
+        {
+          id: "worker-assignment:worker:->workstation:process",
+          kind: "worker-assignment" as const,
+          sourceId: "worker:",
+          targetId: "workstation:process",
+        },
+      ],
+    };
+
+    const filtered = filterFactoryGraphTopologyForCustomerDisplay(
+      withStalePhantomWorker,
+    );
+
+    expect(nodeIds(filtered)).not.toContain("worker:");
+    expect(edgeIds(filtered)).not.toContain(
+      "worker-assignment:worker:->workstation:process",
+    );
   });
 });

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-customer-display.test.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-customer-display.test.ts
@@ -6,6 +6,7 @@ import {
 } from "./factory-graph-customer-display";
 import { buildFactoryGraphTopologyFromDefinition } from "./factory-graph-draft-graph";
 import type { CanonicalFactoryDefinition } from "./factory-graph-draft-types";
+import { maintainerRuntimeShapedFactory } from "./maintainer-runtime-shaped-factory.fixture";
 
 const pureSystemTimeFactory = {
   name: "system-time-only",
@@ -114,6 +115,7 @@ function edgeIds(
   return topology.edges.map((edge) => edge.id);
 }
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: customer-display regression fixtures stay grouped around the filter they protect.
 describe("filterFactoryGraphTopologyForCustomerDisplay", () => {
   it("removes pure system-time graph nodes and incident edges", () => {
     const rawTopology = buildFactoryGraphTopologyFromDefinition(
@@ -219,5 +221,19 @@ describe("filterFactoryGraphTopologyForCustomerDisplay", () => {
         nodeId.includes(SYSTEM_TIME_WORK_TYPE_ID),
       ),
     ).toBe(false);
+  });
+
+  it("omits phantom worker nodes from maintainer runtime-shaped factories", () => {
+    const filtered = filterFactoryGraphTopologyForCustomerDisplay(
+      buildFactoryGraphTopologyFromDefinition(maintainerRuntimeShapedFactory),
+    );
+
+    expect(nodeIds(filtered)).not.toContain("worker:");
+    expect(nodeIds(filtered)).toEqual(
+      expect.arrayContaining(["worker:processor", "worker:workspace-setup"]),
+    );
+    expect(
+      edgeIds(filtered).some((edgeId) => edgeId.startsWith("worker-assignment:")),
+    ).toBe(true);
   });
 });

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-customer-display.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-customer-display.ts
@@ -44,6 +44,18 @@ export function isHiddenSystemTimeGraphNode(node: FactoryGraphNode): boolean {
   );
 }
 
+function isEmptyWorkerGraphNode(node: FactoryGraphNode): boolean {
+  return (
+    node.key.kind === "worker" && (node.key.name ?? "").trim().length === 0
+  );
+}
+
+export function isHiddenCustomerDisplayGraphNode(
+  node: FactoryGraphNode,
+): boolean {
+  return isHiddenSystemTimeGraphNode(node) || isEmptyWorkerGraphNode(node);
+}
+
 export function systemTimeGraphNodeId(
   kind: "work-type" | "work-state" | "workstation",
   ...parts: string[]
@@ -66,7 +78,9 @@ export function filterFactoryGraphTopologyForCustomerDisplay(
   topology: FactoryGraphTopology,
 ): FactoryGraphTopology {
   const hiddenNodeIds = new Set(
-    topology.nodes.filter(isHiddenSystemTimeGraphNode).map((node) => node.id),
+    topology.nodes
+      .filter(isHiddenCustomerDisplayGraphNode)
+      .map((node) => node.id),
   );
 
   return {

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-draft-graph.test.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-draft-graph.test.ts
@@ -1,0 +1,91 @@
+import { buildFactoryGraphTopologyFromDefinition } from "./factory-graph-draft-graph";
+import type { CanonicalFactoryDefinition } from "./factory-graph-draft-types";
+
+const runtimeShapedFactory: CanonicalFactoryDefinition = {
+  name: "runtime-shaped-factory",
+  workTypes: [
+    {
+      name: "story",
+      states: [
+        { name: "new", type: "INITIAL" },
+        { name: "done", type: "TERMINAL" },
+      ],
+    },
+    {
+      name: "__system_time",
+      states: [{ name: "pending", type: "PROCESSING" }],
+    },
+  ],
+  workers: [
+    {
+      model: "gpt-5",
+      name: "router",
+      type: "MODEL_WORKER",
+    },
+  ],
+  workstations: [
+    {
+      inputs: [{ state: "new", workType: "story" }],
+      name: "route-story",
+      outputs: [
+        { state: "done", workType: "story" },
+        { state: "pending", workType: "__system_time" },
+      ],
+      type: "MODEL_WORKSTATION",
+      worker: "router",
+    },
+    {
+      inputs: [{ state: "pending", workType: "__system_time" }],
+      name: "__system_time:expire",
+      outputs: [],
+      type: "MODEL_WORKSTATION",
+      worker: "",
+    },
+  ],
+};
+
+it("does not synthesize worker nodes or assignment edges for empty workstation worker names", () => {
+  const topology = buildFactoryGraphTopologyFromDefinition(runtimeShapedFactory);
+
+  expect(topology.nodes.map((node) => node.id)).toEqual(
+    expect.arrayContaining([
+      "worker:router",
+      "workstation:route-story",
+      "workstation:__system_time:expire",
+    ]),
+  );
+  expect(topology.nodes.map((node) => node.id)).not.toContain("worker:");
+  expect(topology.edges.map((edge) => edge.id)).toEqual(
+    expect.arrayContaining([
+      "worker-assignment:worker:router->workstation:route-story",
+    ]),
+  );
+  expect(
+    topology.edges.some((edge) => edge.kind === "worker-assignment"),
+  ).toBe(true);
+  expect(
+    topology.edges.filter((edge) => edge.kind === "worker-assignment"),
+  ).toHaveLength(1);
+});
+
+it("treats whitespace-only workstation worker names as unassigned", () => {
+  const topology = buildFactoryGraphTopologyFromDefinition({
+    ...runtimeShapedFactory,
+    workstations: [
+      {
+        inputs: [{ state: "new", workType: "story" }],
+        name: "unassigned",
+        outputs: [],
+        type: "MODEL_WORKSTATION",
+        worker: "   ",
+      },
+    ],
+  });
+
+  expect(topology.nodes.map((node) => node.id)).not.toContain("worker:");
+  expect(topology.edges.map((edge) => edge.id)).not.toEqual(
+    expect.arrayContaining([
+      expect.stringMatching(/^worker-assignment:/),
+    ]),
+  );
+});

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-draft-graph.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-draft-graph.ts
@@ -165,7 +165,7 @@ function appendWorkstationWorkerEdge(
 
   const workerKey: FactoryGraphNodeReference = {
     kind: "worker",
-    name: workstation.worker,
+    name: workerName,
   };
   nodes.set(nodeKeyId(workerKey), buildNode(workerKey));
   const workerEdge = buildEdge("worker-assignment", workerKey, workstationKey);

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-draft-graph.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-draft-graph.ts
@@ -158,15 +158,16 @@ function appendWorkstationWorkerEdge(
   nodes: NodeMap,
   edges: EdgeMap,
 ) {
+  const workerName = (workstation.worker ?? "").trim();
+  if (workerName.length === 0) {
+    return;
+  }
+
   const workerKey: FactoryGraphNodeReference = {
     kind: "worker",
     name: workstation.worker,
   };
   nodes.set(nodeKeyId(workerKey), buildNode(workerKey));
-  if (workstation.worker.trim().length === 0) {
-    return;
-  }
-
   const workerEdge = buildEdge("worker-assignment", workerKey, workstationKey);
   edges.set(workerEdge.id, workerEdge);
 }

--- a/ui/src/features/factory-graph-editor/lib/maintainer-runtime-shaped-factory.fixture.ts
+++ b/ui/src/features/factory-graph-editor/lib/maintainer-runtime-shaped-factory.fixture.ts
@@ -1,0 +1,46 @@
+import type { CanonicalFactoryDefinition } from "./factory-graph-draft-types";
+import {
+  SYSTEM_TIME_EXPIRY_TRANSITION_ID,
+  SYSTEM_TIME_WORK_TYPE_ID,
+} from "./factory-graph-customer-display";
+
+/** Minimal maintainer-shaped factory with runtime-injected system-time routes. */
+export const maintainerRuntimeShapedFactory = {
+  name: "maintainer-runtime-factory",
+  resources: [{ capacity: 10, name: "executor-slot" }],
+  workers: [{ name: "processor" }, { name: "workspace-setup" }],
+  workTypes: [
+    {
+      name: "task",
+      states: [
+        { name: "init", type: "INITIAL" as const },
+        { name: "done", type: "TERMINAL" as const },
+      ],
+    },
+    {
+      name: SYSTEM_TIME_WORK_TYPE_ID,
+      states: [{ name: "pending", type: "PROCESSING" as const }],
+    },
+  ],
+  workstations: [
+    {
+      inputs: [{ state: "init", workType: "task" }],
+      name: "process",
+      outputs: [{ state: "done", workType: "task" }],
+      resources: [{ capacity: 1, name: "executor-slot" }],
+      worker: "processor",
+    },
+    {
+      inputs: [{ state: "init", workType: "task" }],
+      name: "setup-workspace",
+      outputs: [{ state: "done", workType: "task" }],
+      worker: "workspace-setup",
+    },
+    {
+      inputs: [{ state: "pending", workType: SYSTEM_TIME_WORK_TYPE_ID }],
+      name: SYSTEM_TIME_EXPIRY_TRANSITION_ID,
+      outputs: [],
+      worker: "",
+    },
+  ],
+} satisfies CanonicalFactoryDefinition;

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card.test.tsx
@@ -44,6 +44,7 @@ import {
   SYSTEM_TIME_WORK_TYPE_ID,
   systemTimeGraphNodeId,
 } from "../../factory-graph-editor/lib/factory-graph-customer-display";
+import { maintainerRuntimeShapedFactory } from "../../factory-graph-editor/lib/maintainer-runtime-shaped-factory.fixture";
 import { removeFactoryGraphNode } from "../../factory-graph-editor/lib/factory-graph-operations";
 import { useFactoryGraphDraftState } from "../../factory-graph-editor/hooks/factory-graph-draft-hook";
 import { useEditableFactoryGraph } from "../../factory-graph-editor/hooks/use-editable-factory-graph";
@@ -2412,6 +2413,42 @@ describe("ReactFlowCurrentActivityCard graph semantics", () => {
     );
 
     expect(onSelectWorker).toHaveBeenCalledWith("writer");
+  });
+
+  it("renders maintainer runtime-shaped factory workers without a bare worker: node", async () => {
+    const factoryDocument = {
+      ...maintainerRuntimeShapedFactory,
+      version: { logical: "1", physical: "2026-05-31T20:00:00Z" },
+    };
+    vi.mocked(useCurrentFactoryDocument).mockReturnValue({
+      data: factoryDocument,
+      error: null,
+      status: "success",
+    } as never);
+    vi.mocked(useFactoryGraphDraftState).mockReturnValue({
+      ...defaultDraftState,
+      latestDocument: factoryDocument,
+      pendingFactoryDefinition: factoryDocument,
+    } as never);
+    const snapshot = structuredClone(semanticWorkflowDashboardSnapshot);
+    snapshot.factory = maintainerRuntimeShapedFactory;
+
+    const { onSelectWorker } = renderCurrentActivity({ snapshot });
+
+    expect(
+      await screen.findByRole("button", { name: "Select processor worker" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Select workspace-setup worker" }),
+    ).toBeTruthy();
+    expect(screen.getByLabelText("worker:processor")).toBeTruthy();
+    expect(screen.getByLabelText("worker:workspace-setup")).toBeTruthy();
+    expect(screen.queryByLabelText("worker:")).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Select processor worker" }),
+    );
+    expect(onSelectWorker).toHaveBeenCalledWith("processor");
   });
 
   it("shows selected styling for the active worker selection", async () => {

--- a/ui/src/features/workflow-activity/lib/current-activity-factory-graph-layout-legacy.test.ts
+++ b/ui/src/features/workflow-activity/lib/current-activity-factory-graph-layout-legacy.test.ts
@@ -1,5 +1,6 @@
 // biome-ignore-all lint/complexity/noExcessiveLinesPerFunction: legacy graph regression fixtures stay grouped around the projection they protect.
 import { semanticWorkflowDashboardSnapshot } from "../../../components/dashboard/test-fixtures";
+import { maintainerRuntimeShapedFactory } from "../../factory-graph-editor/lib/maintainer-runtime-shaped-factory.fixture";
 import { buildCurrentActivityGraphLayoutFromFactory } from "./current-activity-factory-graph-layout";
 import { buildGraphEdges } from "./react-flow-current-activity-card-edges";
 import {
@@ -12,6 +13,19 @@ import {
 } from "./react-flow-current-activity-card-graph";
 
 describe("current activity factory graph legacy replay layout", () => {
+  it("omits phantom worker nodes from maintainer runtime-shaped factories", async () => {
+    const graphLayout = await buildCurrentActivityGraphLayoutFromFactory(
+      maintainerRuntimeShapedFactory,
+    );
+
+    expect(graphLayout.nodes.map((node) => node.nodeId)).not.toContain(
+      "worker:",
+    );
+    expect(graphLayout.nodes.map((node) => node.nodeId)).toEqual(
+      expect.arrayContaining(["worker:processor", "worker:workspace-setup"]),
+    );
+  });
+
   it("collapses resource availability work states into the canonical resource node", async () => {
     const graphLayout = await buildCurrentActivityGraphLayoutFromFactory({
       name: "Legacy resource availability factory",


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/graph-phantom-worker-node-fix",
  "description": "Remove the spurious worker: node from the factory graph by not synthesizing empty-name worker nodes from workstations (including runtime-injected system-time workstations), with regression tests and visual verification on the maintainer factory.",
  "context": {
    "customerAsk": "Fix the bug that causes a random worker: node when running the current factory.json. The graph should only show workers that exist in the factory definition.",
    "problem": "The graph topology builder creates a worker: node (empty worker name) for workstations with blank worker fields. Runtime session factories include the injected __system_time:expire workstation with worker: \"\". Customer-display filtering hides that workstation but leaves the orphan worker: node visible.",
    "solution": "Trace factory document through buildFactoryGraphTopologyFromDefinition and customer-display filtering; skip worker node and assignment synthesis when the trimmed worker name is empty; add regression tests for runtime-shaped factories; verify the maintainer factory graph shows only defined workers."
  },
  "acceptanceCriteria": [
    "Visible graph for the maintainer factory session shows worker:processor and worker:workspace-setup only—no bare worker: node.",
    "Topology build plus customer-display filter never emits a worker: node id when workstation worker fields are empty.",
    "Non-empty workstation worker assignments still render worker nodes and assignment edges.",
    "Automated regression tests cover runtime-shaped factories with __system_time:expire and worker: \"\".",
    "No graph layout, coloring, or unrelated editor behavior changes.",
    "Typecheck, lint, and tests pass for touched UI packages."
  ],
  "userStories": [
    {
      "id": "graph-phantom-worker-node-fix-001",
      "title": "Do not synthesize empty-name worker graph nodes",
      "description": "As a maintainer, I need the factory graph topology builder to skip worker nodes when a workstation has no assigned worker name so internal or unassigned workstations cannot leak placeholder entities into the graph model.",
      "acceptanceCriteria": [
        "appendWorkstationWorkerEdge (or equivalent) does not insert a worker: node when (workstation.worker ?? \"\").trim() is empty.",
        "No worker-assignment edge is created when the worker name is empty.",
        "Non-empty worker names still produce worker:{name} nodes and assignment edges unchanged.",
        "Unit tests on buildFactoryGraphTopologyFromDefinition cover system-time expiry with worker: \"\" and a real worker assignment—only the latter creates a worker node.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "graph-phantom-worker-node-fix-002",
      "title": "Runtime-shaped factory renders without phantom worker in activity graph",
      "description": "As an operator viewing the dashboard graph after starting the maintainer factory, I want the rendered activity graph to match defined workers only so the topology I see is trustworthy.",
      "acceptanceCriteria": [
        "filterFactoryGraphTopologyForCustomerDisplay(buildFactoryGraphTopologyFromDefinition(factory)) has no node id worker: for a fixture with maintainer workstations plus injected __system_time and __system_time:expire with worker: \"\".",
        "buildCurrentActivityGraphLayoutFromFactory omits worker: from rendered node ids for that fixture.",
        "Rendered graph still includes legitimate worker nodes such as worker:processor and worker:workspace-setup from the fixture.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "graph-phantom-worker-node-fix-003",
      "title": "Visual confirmation on maintainer factory graph",
      "description": "As an operator, I want to visually confirm that running the maintainer factory and opening the graph never shows a bare worker: node.",
      "acceptanceCriteria": [
        "With the maintainer factory running and the graph visible, labels show worker:processor and worker:workspace-setup but not a standalone worker: node.",
        "Selecting workers from the graph targets real configured workers only.",
        "Typecheck passes",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)