### PR TITLE
graph-editor-node-placement

### DIFF
--- a/ui/biome.jsonc
+++ b/ui/biome.jsonc
@@ -169,7 +169,8 @@
         "integration/browser-test-harness.mjs",
         "integration/event-stream-replay.integration.test.mjs",
         "integration/dashboard-session-tabs.integration.test.mjs",
-        "integration/factory-graph-editor.integration.test.mjs"
+        "integration/factory-graph-editor.integration.test.mjs",
+        "integration/factory-graph-editor-node-placement.integration.test.mjs"
       ],
       "linter": {
         "rules": {

--- a/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
+++ b/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
@@ -3,8 +3,8 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import {
-  buildTimeoutMs,
   browserScenarioTimeoutMs,
+  buildTimeoutMs,
   expectNoBrowserErrors,
   openBrowserPage,
   startBrowserPreview,
@@ -470,9 +470,9 @@ describe.sequential("factory graph editor node placement browser integration", (
           existingDraftCenter,
         );
 
-        expect(
-          isNearViewportCenter(addedWorkerCenter, viewportMetrics),
-        ).toBe(true);
+        expect(isNearViewportCenter(addedWorkerCenter, viewportMetrics)).toBe(
+          true,
+        );
         expect(distanceFromExistingDraft).toBeGreaterThan(80);
 
         const flowPosition = await readNodeFlowPosition(
@@ -600,32 +600,35 @@ describe.sequential("factory graph editor node placement browser integration", (
         );
 
         await expect
-          .poll(async () => {
-            const nextFlowPosition = await readNodeFlowPosition(
-              browserPage.page,
-              "rf__node-resource:extra-gpu",
-            );
-            const nextScreenPosition = await readNodeScreenPosition(
-              browserPage.page,
-              "rf__node-resource:extra-gpu",
-            );
-            if (!nextScreenPosition || !initialScreenPosition) {
-              return null;
-            }
+          .poll(
+            async () => {
+              const nextFlowPosition = await readNodeFlowPosition(
+                browserPage.page,
+                "rf__node-resource:extra-gpu",
+              );
+              const nextScreenPosition = await readNodeScreenPosition(
+                browserPage.page,
+                "rf__node-resource:extra-gpu",
+              );
+              if (!nextScreenPosition || !initialScreenPosition) {
+                return null;
+              }
 
-            const movedOnScreen =
-              Math.abs(nextScreenPosition.x - initialScreenPosition.x) > 8 ||
-              Math.abs(nextScreenPosition.y - initialScreenPosition.y) > 8;
-            const movedInFlow =
-              initialFlowPosition &&
-              nextFlowPosition &&
-              (Math.abs(nextFlowPosition.x - initialFlowPosition.x) > 8 ||
-                Math.abs(nextFlowPosition.y - initialFlowPosition.y) > 8);
+              const movedOnScreen =
+                Math.abs(nextScreenPosition.x - initialScreenPosition.x) > 8 ||
+                Math.abs(nextScreenPosition.y - initialScreenPosition.y) > 8;
+              const movedInFlow =
+                initialFlowPosition &&
+                nextFlowPosition &&
+                (Math.abs(nextFlowPosition.x - initialFlowPosition.x) > 8 ||
+                  Math.abs(nextFlowPosition.y - initialFlowPosition.y) > 8);
 
-            return movedOnScreen || movedInFlow
-              ? { flow: nextFlowPosition, screen: nextScreenPosition }
-              : null;
-          }, { timeout: uiInteractionTimeoutMs })
+              return movedOnScreen || movedInFlow
+                ? { flow: nextFlowPosition, screen: nextScreenPosition }
+                : null;
+            },
+            { timeout: uiInteractionTimeoutMs },
+          )
           .not.toBeNull();
 
         const draggedFlowPosition = await readNodeFlowPosition(

--- a/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
+++ b/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
@@ -6,6 +6,7 @@ import {
   browserScenarioTimeoutMs,
   buildTimeoutMs,
   expectNoBrowserErrors,
+  fillWorkstationPromptBody,
   openBrowserPage,
   startBrowserPreview,
   startFactoryApiServer,
@@ -294,7 +295,7 @@ async function addWorkstation(page, toolbar, { body, name }) {
     timeout: uiInteractionTimeoutMs,
   });
   await addDialog.getByLabel("Identifier").fill(name);
-  await addDialog.getByLabel("Prompt body").fill(body);
+  await fillWorkstationPromptBody(addDialog, body);
   await addDialog.getByRole("button", { name: "Add entity" }).click();
 }
 

--- a/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
+++ b/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
@@ -257,7 +257,11 @@ async function nodeBoundingBox(page, nodeTestId) {
   return box;
 }
 
-async function addWorker(page, toolbar, { model = "gpt-5", name }) {
+async function addWorker(
+  page,
+  toolbar,
+  { model = "gpt-5", modelProvider = "CURSOR", name },
+) {
   await toolbar.getByRole("button", { name: "Open add entity menu" }).click();
   await page
     .getByLabel("Add graph entity menu")
@@ -270,6 +274,9 @@ async function addWorker(page, toolbar, { model = "gpt-5", name }) {
     timeout: uiInteractionTimeoutMs,
   });
   await addDialog.getByLabel("Identifier").fill(name);
+  await addDialog
+    .getByRole("combobox", { name: "Model provider" })
+    .selectOption(modelProvider);
   await addDialog.getByRole("textbox", { name: "Model" }).fill(model);
   await addDialog.getByRole("button", { name: "Add entity" }).click();
 }

--- a/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
+++ b/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
@@ -1,0 +1,665 @@
+// @vitest-environment node
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  buildTimeoutMs,
+  browserScenarioTimeoutMs,
+  expectNoBrowserErrors,
+  openBrowserPage,
+  startBrowserPreview,
+  startFactoryApiServer,
+  uiInteractionTimeoutMs,
+} from "./browser-test-harness.mjs";
+
+const editableGraphFactoryDefinition = {
+  metadata: {
+    owner: "operations",
+  },
+  name: "Current Factory",
+  resources: [
+    {
+      capacity: 2,
+      name: "gpu",
+    },
+  ],
+  workers: [
+    {
+      model: "gpt-5",
+      name: "writer",
+      type: "MODEL_WORKER",
+    },
+  ],
+  workTypes: [
+    {
+      name: "story",
+      states: [
+        {
+          name: "queued",
+          type: "INITIAL",
+        },
+        {
+          name: "done",
+          type: "TERMINAL",
+        },
+      ],
+    },
+  ],
+  workstations: [
+    {
+      body: "Draft the story.",
+      inputs: [
+        {
+          state: "queued",
+          workType: "story",
+        },
+      ],
+      name: "draft",
+      outputs: [
+        {
+          state: "done",
+          workType: "story",
+        },
+      ],
+      resources: [
+        {
+          capacity: 2,
+          name: "gpu",
+        },
+      ],
+      type: "MODEL_WORKSTATION",
+      worker: "writer",
+    },
+  ],
+};
+
+const editableGraphFactoryReplayLines = [
+  JSON.stringify({
+    context: {
+      eventTime: "2026-05-19T15:00:00Z",
+      sequence: 1,
+      tick: 1,
+    },
+    id: "editable-graph-1",
+    payload: {
+      factory: {
+        resources: [
+          {
+            capacity: 2,
+            name: "gpu",
+          },
+        ],
+        workTypes: [
+          {
+            name: "story",
+            states: [
+              {
+                name: "queued",
+                type: "INITIAL",
+              },
+              {
+                name: "done",
+                type: "TERMINAL",
+              },
+            ],
+          },
+        ],
+        workers: [
+          {
+            model: "gpt-5",
+            name: "writer",
+            type: "MODEL_WORKER",
+          },
+        ],
+        workstations: [
+          {
+            inputs: [
+              {
+                state: "queued",
+                workType: "story",
+              },
+            ],
+            name: "draft",
+            outputs: [
+              {
+                state: "done",
+                workType: "story",
+              },
+            ],
+            resources: [
+              {
+                capacity: 2,
+                name: "gpu",
+              },
+            ],
+            worker: "writer",
+          },
+        ],
+      },
+    },
+    type: "INITIAL_STRUCTURE_REQUEST",
+  }),
+  JSON.stringify({
+    context: {
+      eventTime: "2026-05-19T15:00:01Z",
+      sequence: 2,
+      tick: 2,
+    },
+    id: "editable-graph-2",
+    payload: {
+      previousState: "RUNNING",
+      reason: "fixture ready",
+      state: "FINISHED",
+    },
+    type: "FACTORY_STATE_RESPONSE",
+  }),
+];
+
+const viewportCenterToleranceRatio = 0.35;
+
+function distanceBetweenPoints(left, right) {
+  const deltaX = left.x - right.x;
+  const deltaY = left.y - right.y;
+  return Math.hypot(deltaX, deltaY);
+}
+
+function boundingBoxesOverlap(left, right) {
+  return (
+    left.x < right.x + right.width &&
+    left.x + left.width > right.x &&
+    left.y < right.y + right.height &&
+    left.y + left.height > right.y
+  );
+}
+
+async function enterGraphEditor(page) {
+  await page
+    .getByRole("button", { name: "Enter factory graph editor" })
+    .click();
+  const toolbar = page.getByRole("region", {
+    name: "Factory graph editor tools",
+  });
+  await toolbar.waitFor({
+    state: "visible",
+    timeout: uiInteractionTimeoutMs,
+  });
+  return toolbar;
+}
+
+async function graphViewport(page) {
+  return page.getByRole("region", { name: "Work graph viewport" });
+}
+
+async function panGraphViewport(page, deltaX, deltaY) {
+  const viewport = await graphViewport(page);
+  const pane = viewport.locator(".react-flow__pane");
+  await pane.waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+  const box = await pane.boundingBox();
+  if (!box) {
+    throw new Error("Expected graph pane bounding box.");
+  }
+
+  const startX = box.x + box.width * 0.2;
+  const startY = box.y + box.height * 0.2;
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(startX + deltaX, startY + deltaY, { steps: 12 });
+  await page.mouse.up();
+}
+
+async function viewportScreenMetrics(page) {
+  const viewport = await graphViewport(page);
+  const box = await viewport.boundingBox();
+  if (!box) {
+    throw new Error("Expected graph viewport bounding box.");
+  }
+
+  return {
+    box,
+    center: {
+      x: box.x + box.width / 2,
+      y: box.y + box.height / 2,
+    },
+  };
+}
+
+function isNearViewportCenter(nodeCenter, viewportMetrics) {
+  const maxDeltaX = viewportMetrics.box.width * viewportCenterToleranceRatio;
+  const maxDeltaY = viewportMetrics.box.height * viewportCenterToleranceRatio;
+
+  return (
+    Math.abs(nodeCenter.x - viewportMetrics.center.x) <= maxDeltaX &&
+    Math.abs(nodeCenter.y - viewportMetrics.center.y) <= maxDeltaY
+  );
+}
+
+async function nodeScreenCenter(page, nodeTestId) {
+  const node = page.getByTestId(nodeTestId);
+  await node.waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+  const box = await node.boundingBox();
+  if (!box) {
+    throw new Error(`Expected bounding box for ${nodeTestId}.`);
+  }
+
+  return {
+    x: box.x + box.width / 2,
+    y: box.y + box.height / 2,
+  };
+}
+
+async function nodeBoundingBox(page, nodeTestId) {
+  const node = page.getByTestId(nodeTestId);
+  await node.waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+  const box = await node.boundingBox();
+  if (!box) {
+    throw new Error(`Expected bounding box for ${nodeTestId}.`);
+  }
+  return box;
+}
+
+async function addWorker(page, toolbar, { model = "gpt-5", name }) {
+  await toolbar.getByRole("button", { name: "Open add entity menu" }).click();
+  await page
+    .getByLabel("Add graph entity menu")
+    .getByRole("button", { name: "Worker" })
+    .click();
+
+  const addDialog = page.getByRole("dialog", { name: "Add worker" });
+  await addDialog.waitFor({
+    state: "visible",
+    timeout: uiInteractionTimeoutMs,
+  });
+  await addDialog.getByLabel("Identifier").fill(name);
+  await addDialog.getByRole("textbox", { name: "Model" }).fill(model);
+  await addDialog.getByRole("button", { name: "Add entity" }).click();
+}
+
+async function addWorkstation(page, toolbar, { body, name }) {
+  await toolbar.getByRole("button", { name: "Open add entity menu" }).click();
+  await page
+    .getByLabel("Add graph entity menu")
+    .getByRole("button", { name: "Workstation" })
+    .click();
+
+  const addDialog = page.getByRole("dialog", { name: "Add workstation" });
+  await addDialog.waitFor({
+    state: "visible",
+    timeout: uiInteractionTimeoutMs,
+  });
+  await addDialog.getByLabel("Identifier").fill(name);
+  await addDialog.getByLabel("Prompt body").fill(body);
+  await addDialog.getByRole("button", { name: "Add entity" }).click();
+}
+
+async function readNodeFlowPosition(page, nodeTestId) {
+  return page.evaluate((testId) => {
+    const element = document.querySelector(`[data-testid="${testId}"]`);
+    const reactFlowNode =
+      element?.classList.contains("react-flow__node") === true
+        ? element
+        : element?.closest(".react-flow__node");
+    if (!reactFlowNode) {
+      return null;
+    }
+
+    const transform =
+      reactFlowNode.style.transform ||
+      window.getComputedStyle(reactFlowNode).transform;
+    if (!transform || transform === "none") {
+      return null;
+    }
+
+    const translateMatch = /translate(?:3d)?\(([-\d.]+)px,\s*([-\d.]+)px/.exec(
+      transform,
+    );
+    if (translateMatch) {
+      return {
+        x: Number(translateMatch[1]),
+        y: Number(translateMatch[2]),
+      };
+    }
+
+    const matrixMatch = /matrix\(([^)]+)\)/.exec(transform);
+    if (matrixMatch) {
+      const values = matrixMatch[1]
+        .split(",")
+        .map((value) => Number.parseFloat(value.trim()));
+      if (values.length >= 6) {
+        return { x: values[4], y: values[5] };
+      }
+    }
+
+    return null;
+  }, nodeTestId);
+}
+
+async function readNodeScreenPosition(page, nodeTestId) {
+  const box = await page.getByTestId(nodeTestId).boundingBox();
+  if (!box) {
+    return null;
+  }
+
+  return { x: box.x, y: box.y };
+}
+
+async function addResource(page, toolbar, { capacity = "1", name }) {
+  await toolbar.getByRole("button", { name: "Open add entity menu" }).click();
+  await page
+    .getByLabel("Add graph entity menu")
+    .getByRole("button", { name: "Resource" })
+    .click();
+
+  const addDialog = page.getByRole("dialog", { name: "Add resource" });
+  await addDialog.waitFor({
+    state: "visible",
+    timeout: uiInteractionTimeoutMs,
+  });
+  await addDialog.getByLabel("Identifier").fill(name);
+  await addDialog.getByLabel("Capacity").fill(capacity);
+  await addDialog.getByRole("button", { name: "Add entity" }).click();
+}
+
+async function dragNodeByOffset(page, nodeTestId, deltaX, deltaY) {
+  const node = page.getByTestId(nodeTestId);
+  await node.waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+  const viewport = await graphViewport(page);
+  const nodeBox = await node.boundingBox();
+  const viewportBox = await viewport.boundingBox();
+  if (!nodeBox || !viewportBox) {
+    throw new Error(`Expected bounding boxes for ${nodeTestId} drag.`);
+  }
+
+  await node.dragTo(viewport, {
+    sourcePosition: { x: 20, y: 20 },
+    targetPosition: {
+      x: nodeBox.x - viewportBox.x + deltaX,
+      y: nodeBox.y - viewportBox.y + deltaY,
+    },
+  });
+}
+
+async function saveGraphDraft(page, toolbar) {
+  const saveChangesButton = toolbar.getByRole("button", {
+    name: "Save changes",
+  });
+  await expect
+    .poll(async () => await saveChangesButton.isEnabled(), {
+      timeout: uiInteractionTimeoutMs,
+    })
+    .toBe(true);
+
+  await saveChangesButton.click();
+  const saveDialog = page.getByRole("dialog", {
+    name: "Save factory graph changes?",
+  });
+  await saveDialog.waitFor({
+    state: "visible",
+    timeout: uiInteractionTimeoutMs,
+  });
+  await saveDialog.getByRole("button", { name: "Save topology" }).click();
+  await page
+    .getByText("Topology saved", { exact: true })
+    .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+}
+
+describe.sequential("factory graph editor node placement browser integration", () => {
+  let preview = null;
+
+  beforeAll(async () => {
+    preview = await startBrowserPreview();
+  }, buildTimeoutMs);
+
+  afterAll(async () => {
+    if (!preview) {
+      return;
+    }
+
+    await Promise.race([
+      preview.stop(),
+      new Promise((resolve) => {
+        setTimeout(resolve, 15_000);
+      }),
+    ]);
+    preview = null;
+  }, 120_000);
+
+  afterEach(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  });
+
+  it(
+    "places a newly added worker near the visible viewport center after panning",
+    async () => {
+      const server = await startFactoryApiServer({
+        apiPort: preview.apiPort,
+        currentFactory: editableGraphFactoryDefinition,
+        eventLines: editableGraphFactoryReplayLines,
+      });
+      const browserPage = await openBrowserPage();
+
+      try {
+        await browserPage.page.goto(preview.previewURL, {
+          waitUntil: "domcontentloaded",
+        });
+        await server.replayCompleted;
+
+        const toolbar = await enterGraphEditor(browserPage.page);
+        await panGraphViewport(browserPage.page, 240, 180);
+
+        const existingDraftCenter = await nodeScreenCenter(
+          browserPage.page,
+          "rf__node-workstation:draft",
+        );
+        await addWorker(browserPage.page, toolbar, { name: "assistant" });
+
+        const newWorkerNode = browserPage.page.getByTestId(
+          "rf__node-worker:assistant",
+        );
+        await newWorkerNode.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
+
+        const viewportMetrics = await viewportScreenMetrics(browserPage.page);
+        const addedWorkerCenter = await nodeScreenCenter(
+          browserPage.page,
+          "rf__node-worker:assistant",
+        );
+        const distanceFromExistingDraft = distanceBetweenPoints(
+          addedWorkerCenter,
+          existingDraftCenter,
+        );
+
+        expect(
+          isNearViewportCenter(addedWorkerCenter, viewportMetrics),
+        ).toBe(true);
+        expect(distanceFromExistingDraft).toBeGreaterThan(80);
+
+        const flowPosition = await readNodeFlowPosition(
+          browserPage.page,
+          "rf__node-worker:assistant",
+        );
+        expect(flowPosition).not.toBeNull();
+        expect(Number.isFinite(flowPosition.x)).toBe(true);
+        expect(Number.isFinite(flowPosition.y)).toBe(true);
+
+        expectNoBrowserErrors(
+          browserPage.pageErrors,
+          browserPage.consoleErrors,
+          expect,
+        );
+      } finally {
+        await server.stop();
+        await browserPage.close();
+      }
+    },
+    browserScenarioTimeoutMs,
+  );
+
+  it(
+    "nudges a newly added workstation away from an existing viewport-center worker",
+    async () => {
+      const server = await startFactoryApiServer({
+        apiPort: preview.apiPort,
+        currentFactory: editableGraphFactoryDefinition,
+        eventLines: editableGraphFactoryReplayLines,
+      });
+      const browserPage = await openBrowserPage();
+
+      try {
+        await browserPage.page.goto(preview.previewURL, {
+          waitUntil: "domcontentloaded",
+        });
+        await server.replayCompleted;
+
+        const toolbar = await enterGraphEditor(browserPage.page);
+        await addWorker(browserPage.page, toolbar, { name: "center-anchor" });
+
+        const anchorNode = browserPage.page.getByTestId(
+          "rf__node-worker:center-anchor",
+        );
+        await anchorNode.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
+
+        await addWorkstation(browserPage.page, toolbar, {
+          body: "Review the drafted story.",
+          name: "review",
+        });
+
+        const workstationNode = browserPage.page.getByTestId(
+          "rf__node-workstation:review",
+        );
+        await workstationNode.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
+
+        const anchorBox = await nodeBoundingBox(
+          browserPage.page,
+          "rf__node-worker:center-anchor",
+        );
+        const workstationBox = await nodeBoundingBox(
+          browserPage.page,
+          "rf__node-workstation:review",
+        );
+
+        expect(boundingBoxesOverlap(anchorBox, workstationBox)).toBe(false);
+
+        expectNoBrowserErrors(
+          browserPage.pageErrors,
+          browserPage.consoleErrors,
+          expect,
+        );
+      } finally {
+        await server.stop();
+        await browserPage.close();
+      }
+    },
+    browserScenarioTimeoutMs,
+  );
+
+  it(
+    "keeps a manually dragged node position after reload",
+    async () => {
+      const server = await startFactoryApiServer({
+        apiPort: preview.apiPort,
+        currentFactory: editableGraphFactoryDefinition,
+        eventLines: editableGraphFactoryReplayLines,
+      });
+      const browserPage = await openBrowserPage();
+
+      try {
+        await browserPage.page.goto(preview.previewURL, {
+          waitUntil: "domcontentloaded",
+        });
+        await server.replayCompleted;
+
+        const toolbar = await enterGraphEditor(browserPage.page);
+        await addResource(browserPage.page, toolbar, { name: "extra-gpu" });
+        await browserPage.page
+          .getByTestId("rf__node-resource:extra-gpu")
+          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+
+        const initialFlowPosition = await readNodeFlowPosition(
+          browserPage.page,
+          "rf__node-resource:extra-gpu",
+        );
+        const initialScreenPosition = await readNodeScreenPosition(
+          browserPage.page,
+          "rf__node-resource:extra-gpu",
+        );
+        expect(initialFlowPosition ?? initialScreenPosition).not.toBeNull();
+
+        await dragNodeByOffset(
+          browserPage.page,
+          "rf__node-resource:extra-gpu",
+          160,
+          120,
+        );
+
+        await expect
+          .poll(async () => {
+            const nextFlowPosition = await readNodeFlowPosition(
+              browserPage.page,
+              "rf__node-resource:extra-gpu",
+            );
+            const nextScreenPosition = await readNodeScreenPosition(
+              browserPage.page,
+              "rf__node-resource:extra-gpu",
+            );
+            if (!nextScreenPosition || !initialScreenPosition) {
+              return null;
+            }
+
+            const movedOnScreen =
+              Math.abs(nextScreenPosition.x - initialScreenPosition.x) > 8 ||
+              Math.abs(nextScreenPosition.y - initialScreenPosition.y) > 8;
+            const movedInFlow =
+              initialFlowPosition &&
+              nextFlowPosition &&
+              (Math.abs(nextFlowPosition.x - initialFlowPosition.x) > 8 ||
+                Math.abs(nextFlowPosition.y - initialFlowPosition.y) > 8);
+
+            return movedOnScreen || movedInFlow
+              ? { flow: nextFlowPosition, screen: nextScreenPosition }
+              : null;
+          }, { timeout: uiInteractionTimeoutMs })
+          .not.toBeNull();
+
+        const draggedFlowPosition = await readNodeFlowPosition(
+          browserPage.page,
+          "rf__node-resource:extra-gpu",
+        );
+
+        await saveGraphDraft(browserPage.page, toolbar);
+
+        await browserPage.page.reload({ waitUntil: "domcontentloaded" });
+        await server.replayCompleted;
+        await enterGraphEditor(browserPage.page);
+        await browserPage.page
+          .getByTestId("rf__node-resource:extra-gpu")
+          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+
+        const reloadedFlowPosition = await readNodeFlowPosition(
+          browserPage.page,
+          "rf__node-resource:extra-gpu",
+        );
+
+        expect(reloadedFlowPosition).toEqual(draggedFlowPosition);
+        expect(draggedFlowPosition).not.toBeNull();
+
+        expectNoBrowserErrors(
+          browserPage.pageErrors,
+          browserPage.consoleErrors,
+          expect,
+        );
+      } finally {
+        await server.stop();
+        await browserPage.close();
+      }
+    },
+    browserScenarioTimeoutMs,
+  );
+});

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-editor-layout.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-editor-layout.ts
@@ -7,7 +7,8 @@ import type {
   FactoryGraphTopology,
 } from "./factory-graph-draft-types";
 
-const NODE_DIMENSIONS_BY_KIND: Record<
+/** Node bounds used by the factory graph editor layout and viewport placement resolver. */
+export const FACTORY_GRAPH_EDITOR_NODE_DIMENSIONS_BY_KIND: Record<
   FactoryGraphNodeKind,
   { height: number; width: number }
 > = {
@@ -41,7 +42,7 @@ export async function buildFactoryGraphEditorLayout(
       toNodeId: edge.targetId,
     })),
     nodes: topology.nodes.map((node) => ({
-      ...NODE_DIMENSIONS_BY_KIND[node.kind],
+      ...FACTORY_GRAPH_EDITOR_NODE_DIMENSIONS_BY_KIND[node.kind],
       id: node.id,
       nodeId: node.id,
       nodeKind: node.kind,

--- a/ui/src/features/workflow-activity/components/graph-editor-placement-context.tsx
+++ b/ui/src/features/workflow-activity/components/graph-editor-placement-context.tsx
@@ -1,0 +1,126 @@
+import type { ReactFlowInstance } from "@xyflow/react";
+import {
+  createContext,
+  type MutableRefObject,
+  useCallback,
+  useContext,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from "react";
+
+import type { FactoryGraphAddEntityDraft } from "../../factory-graph-editor/lib/factory-graph-editor-additions";
+import type { CurrentActivityNode } from "../../flowchart/public";
+import {
+  factoryGraphNodeIdForAddEntityDraft,
+  resolveInitialPlacementTopLeft,
+  viewportCenterInFlowCoordinates,
+} from "../lib/graph-editor-add-node-placement";
+import type { GraphNodePositions } from "../state/currentActivityGraphStore";
+
+export interface GraphEditorPlacementApi {
+  placeAddedNode: (draft: FactoryGraphAddEntityDraft) => void;
+}
+
+const GraphEditorPlacementContext =
+  createContext<MutableRefObject<GraphEditorPlacementApi> | null>(null);
+
+export function useGraphEditorPlaceAddedNode():
+  | ((draft: FactoryGraphAddEntityDraft) => void)
+  | undefined {
+  const apiRef = useContext(GraphEditorPlacementContext);
+  return useCallback(
+    (draft: FactoryGraphAddEntityDraft) => {
+      apiRef?.current.placeAddedNode(draft);
+    },
+    [apiRef],
+  );
+}
+
+export function GraphEditorPlacementProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const apiRef = useRef<GraphEditorPlacementApi>({
+    placeAddedNode: () => {},
+  });
+
+  return (
+    <GraphEditorPlacementContext.Provider value={apiRef}>
+      {children}
+    </GraphEditorPlacementContext.Provider>
+  );
+}
+
+export function GraphEditorPlacementRegistrar({
+  flowContainerRef,
+  flowInstanceRef,
+  graphKey,
+  nodes,
+  setStoredNodePosition,
+  storedNodePositions,
+}: {
+  flowContainerRef: MutableRefObject<HTMLElement | null>;
+  flowInstanceRef: MutableRefObject<ReactFlowInstance | null>;
+  graphKey: string;
+  nodes: readonly CurrentActivityNode[];
+  setStoredNodePosition: (
+    graphKey: string,
+    nodeId: string,
+    position: { x: number; y: number },
+  ) => void;
+  storedNodePositions: GraphNodePositions;
+}) {
+  const apiRef = useContext(GraphEditorPlacementContext);
+  const placementInput = useMemo(
+    () => ({
+      graphKey,
+      nodes,
+      setStoredNodePosition,
+      storedNodePositions,
+    }),
+    [graphKey, nodes, setStoredNodePosition, storedNodePositions],
+  );
+
+  useLayoutEffect(() => {
+    if (!apiRef) {
+      return;
+    }
+
+    apiRef.current = {
+      placeAddedNode: (draft) => {
+        if (!placementInput.graphKey) {
+          return;
+        }
+
+        const flowInstance = flowInstanceRef.current;
+        const flowContainer = flowContainerRef.current;
+        if (!flowInstance || !flowContainer) {
+          return;
+        }
+
+        const topLeft = resolveInitialPlacementTopLeft({
+          draft,
+          nodes: placementInput.nodes,
+          storedPositions: placementInput.storedNodePositions,
+          viewportCenter: viewportCenterInFlowCoordinates(
+            flowInstance,
+            flowContainer,
+          ),
+        });
+        if (!topLeft) {
+          return;
+        }
+
+        placementInput.setStoredNodePosition(
+          placementInput.graphKey,
+          factoryGraphNodeIdForAddEntityDraft(draft),
+          topLeft,
+        );
+      },
+    };
+  }, [apiRef, flowContainerRef, flowInstanceRef, placementInput]);
+
+  return null;
+}

--- a/ui/src/features/workflow-activity/components/graph-editor-placement-context.tsx
+++ b/ui/src/features/workflow-activity/components/graph-editor-placement-context.tsx
@@ -4,9 +4,11 @@ import {
   type MutableRefObject,
   useCallback,
   useContext,
+  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
+  useState,
 } from "react";
 
 import type { FactoryGraphAddEntityDraft } from "../../factory-graph-editor/lib/factory-graph-editor-additions";
@@ -16,6 +18,7 @@ import {
   resolveInitialPlacementTopLeft,
   viewportCenterInFlowCoordinates,
 } from "../lib/graph-editor-add-node-placement";
+import { graphKeyAfterAddingNode } from "../lib/react-flow-current-activity-card-keys";
 import type { GraphNodePositions } from "../state/currentActivityGraphStore";
 
 export interface GraphEditorPlacementApi {
@@ -73,6 +76,8 @@ export function GraphEditorPlacementRegistrar({
   storedNodePositions: GraphNodePositions;
 }) {
   const apiRef = useContext(GraphEditorPlacementContext);
+  const [pendingDraft, setPendingDraft] =
+    useState<FactoryGraphAddEntityDraft | null>(null);
   const placementInput = useMemo(
     () => ({
       graphKey,
@@ -90,37 +95,44 @@ export function GraphEditorPlacementRegistrar({
 
     apiRef.current = {
       placeAddedNode: (draft) => {
-        if (!placementInput.graphKey) {
-          return;
-        }
-
-        const flowInstance = flowInstanceRef.current;
-        const flowContainer = flowContainerRef.current;
-        if (!flowInstance || !flowContainer) {
-          return;
-        }
-
-        const topLeft = resolveInitialPlacementTopLeft({
-          draft,
-          nodes: placementInput.nodes,
-          storedPositions: placementInput.storedNodePositions,
-          viewportCenter: viewportCenterInFlowCoordinates(
-            flowInstance,
-            flowContainer,
-          ),
-        });
-        if (!topLeft) {
-          return;
-        }
-
-        placementInput.setStoredNodePosition(
-          placementInput.graphKey,
-          factoryGraphNodeIdForAddEntityDraft(draft),
-          topLeft,
-        );
+        setPendingDraft(draft);
       },
     };
-  }, [apiRef, flowContainerRef, flowInstanceRef, placementInput]);
+  }, [apiRef]);
+
+  useEffect(() => {
+    if (!pendingDraft || !placementInput.graphKey) {
+      return;
+    }
+
+    const flowInstance = flowInstanceRef.current;
+    const flowContainer = flowContainerRef.current;
+    if (!flowInstance || !flowContainer) {
+      return;
+    }
+
+    const topLeft = resolveInitialPlacementTopLeft({
+      draft: pendingDraft,
+      nodes: placementInput.nodes,
+      storedPositions: placementInput.storedNodePositions,
+      viewportCenter: viewportCenterInFlowCoordinates(
+        flowInstance,
+        flowContainer,
+      ),
+    });
+    if (!topLeft) {
+      setPendingDraft(null);
+      return;
+    }
+
+    const nodeId = factoryGraphNodeIdForAddEntityDraft(pendingDraft);
+    placementInput.setStoredNodePosition(
+      graphKeyAfterAddingNode(placementInput.graphKey, nodeId),
+      nodeId,
+      topLeft,
+    );
+    setPendingDraft(null);
+  }, [flowContainerRef, flowInstanceRef, pendingDraft, placementInput]);
 
   return null;
 }

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-editor-chrome.placement.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-editor-chrome.placement.test.tsx
@@ -55,6 +55,7 @@ describe("useFactoryGraphAddEntityController placement", () => {
       result.current.setAddEntityDraft({
         kind: "worker",
         model: "gpt",
+        modelProvider: "CURSOR",
         name: "reviewer",
       });
     });
@@ -67,6 +68,7 @@ describe("useFactoryGraphAddEntityController placement", () => {
     expect(placeAddedNode).toHaveBeenCalledWith({
       kind: "worker",
       model: "gpt",
+      modelProvider: "CURSOR",
       name: "reviewer",
     });
   });

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-editor-chrome.placement.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-editor-chrome.placement.test.tsx
@@ -1,0 +1,73 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { EditableFactoryGraphViewModel } from "../../factory-graph-editor/hooks/use-editable-factory-graph-types";
+import { GraphEditorPlacementProvider } from "./graph-editor-placement-context";
+import { useFactoryGraphAddEntityController } from "./react-flow-current-activity-card-editor-chrome";
+
+const placeAddedNode = vi.fn();
+
+vi.mock("./graph-editor-placement-context", async () => {
+  const actual = await vi.importActual("./graph-editor-placement-context");
+  return {
+    ...actual,
+    useGraphEditorPlaceAddedNode: () => placeAddedNode,
+  };
+});
+
+function buildEditableGraph(): EditableFactoryGraphViewModel {
+  return {
+    actions: {
+      addNode: vi.fn(() => ({ ok: true, value: {} })),
+      connectNodes: vi.fn(),
+      discard: vi.fn(),
+      disconnectEdge: vi.fn(),
+      removeNode: vi.fn(),
+      save: vi.fn(async () => true),
+      updateNodeField: vi.fn(),
+    },
+  } as unknown as EditableFactoryGraphViewModel;
+}
+
+describe("useFactoryGraphAddEntityController placement", () => {
+  it("places a newly added node after a successful add submit", () => {
+    placeAddedNode.mockReset();
+    const editableGraph = buildEditableGraph();
+    const setActiveTool = vi.fn();
+
+    const { result } = renderHook(
+      () =>
+        useFactoryGraphAddEntityController({
+          currentFactoryDefinition: {
+            name: "factory",
+            resources: [],
+            workers: [],
+            workTypes: [],
+            workstations: [],
+          },
+          editableGraph,
+          setActiveTool,
+        }),
+      { wrapper: GraphEditorPlacementProvider },
+    );
+
+    act(() => {
+      result.current.setAddEntityDraft({
+        kind: "worker",
+        model: "gpt",
+        name: "reviewer",
+      });
+    });
+
+    act(() => {
+      result.current.handleAddEntitySubmit();
+    });
+
+    expect(editableGraph.actions.addNode).toHaveBeenCalledTimes(1);
+    expect(placeAddedNode).toHaveBeenCalledWith({
+      kind: "worker",
+      model: "gpt",
+      name: "reviewer",
+    });
+  });
+});

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-editor-chrome.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-editor-chrome.tsx
@@ -7,8 +7,8 @@ import {
   FactoryGraphEditorStatus,
   type FactoryGraphEditorTool,
 } from "../../factory-graph-editor/components/factory-graph-editor-controls";
-import { getFactoryGraphEditorMessages } from "../../factory-graph-editor/messages/editor";
 import type { EditableFactoryGraphViewModel } from "../../factory-graph-editor/hooks/use-editable-factory-graph-types";
+import type { CanonicalFactoryDefinition } from "../../factory-graph-editor/lib/factory-graph-draft-types";
 import {
   createFactoryGraphAddEntityDraft,
   type FactoryGraphAddEntityDraft,
@@ -16,7 +16,8 @@ import {
   type FactoryGraphAddEntityKind,
   validateFactoryGraphAddEntityDraft,
 } from "../../factory-graph-editor/lib/factory-graph-editor-additions";
-import type { CanonicalFactoryDefinition } from "../../factory-graph-editor/lib/factory-graph-draft-types";
+import { getFactoryGraphEditorMessages } from "../../factory-graph-editor/messages/editor";
+import { useGraphEditorPlaceAddedNode } from "./graph-editor-placement-context";
 
 export function useFactoryGraphAddEntityController({
   currentFactoryDefinition,
@@ -32,6 +33,7 @@ export function useFactoryGraphAddEntityController({
     useState<FactoryGraphAddEntityDraft | null>(null);
   const [addEntityErrors, setAddEntityErrors] =
     useState<FactoryGraphAddEntityFieldErrors>({});
+  const placeAddedNode = useGraphEditorPlaceAddedNode();
 
   const handleAddEntityAction = useCallback(
     (actionID: string) => {
@@ -68,9 +70,15 @@ export function useFactoryGraphAddEntityController({
       return;
     }
 
+    placeAddedNode?.(addEntityDraft);
     setAddEntityDraft(null);
     setAddEntityErrors({});
-  }, [addEntityDraft, currentFactoryDefinition, editableGraph.actions]);
+  }, [
+    addEntityDraft,
+    currentFactoryDefinition,
+    editableGraph.actions,
+    placeAddedNode,
+  ]);
 
   const reset = useCallback(() => {
     setAddMenuOpen(false);

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-surface.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-surface.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from "react";
+import type { ReactFlowInstance } from "@xyflow/react";
+import { useMemo, useRef } from "react";
 
 import type { DashboardSnapshot } from "../../../api/dashboard/types";
 import { CurrentFactoryDefinitionError } from "../../../api/current-factory-definition";
@@ -7,13 +8,15 @@ import { getFactoryGraphEditorMessages } from "../../factory-graph-editor/messag
 import { CURRENT_ACTIVITY_NODE_TYPES } from "../../flowchart/public";
 import type { CurrentActivityImportController } from "../hooks/current-activity-import-controller";
 import type { useCurrentActivityGraphEditor } from "../hooks/react-flow-current-activity-card-editor";
+import type { useCurrentActivityGraphViewModel } from "../hooks/react-flow-current-activity-card-graph-view-model";
 import {
   mergeFactoryValidationTargets,
   saveErrorNoticeMessages,
   validationMessagesForGraphSelection,
 } from "../lib/react-flow-current-activity-card-validation";
+import { useCurrentActivityGraphStore } from "../state/currentActivityGraphStore";
+import { GraphEditorPlacementRegistrar } from "./graph-editor-placement-context";
 import type { CurrentActivitySelection } from "./react-flow-current-activity-card";
-import type { useCurrentActivityGraphViewModel } from "../hooks/react-flow-current-activity-card-graph-view-model";
 import { CurrentActivityGraphViewport } from "./react-flow-current-activity-card-viewport";
 
 // biome-ignore lint/complexity/noExcessiveLinesPerFunction: graph surface keeps editor notices, validation, and viewport wiring together.
@@ -35,6 +38,11 @@ export function CurrentActivityGraphSurface({
   snapshot: DashboardSnapshot;
 }) {
   const messages = getFactoryGraphEditorMessages(locale);
+  const flowContainerRef = useRef<HTMLElement | null>(null);
+  const flowInstanceRef = useRef<ReactFlowInstance | null>(null);
+  const storedNodePositions = useCurrentActivityGraphStore(
+    (state) => state.positionsByGraphKey[graph.graphKey] ?? {},
+  );
   const saveError = editor.saveEditableDefinition.error;
   const editorValidationProjection = useMemo(() => {
     if (!editor.editorMode) {
@@ -133,6 +141,14 @@ export function CurrentActivityGraphSurface({
           {messages.noticeStaleDescription}
         </FactoryGraphEditorNotice>
       ) : null}
+      <GraphEditorPlacementRegistrar
+        flowContainerRef={flowContainerRef}
+        flowInstanceRef={flowInstanceRef}
+        graphKey={graph.graphKey}
+        nodes={graph.nodes}
+        setStoredNodePosition={graph.setStoredNodePosition}
+        storedNodePositions={storedNodePositions}
+      />
       <CurrentActivityGraphViewport
         activeTool={editor.activeTool}
         addMenuActions={editor.addMenuActions}
@@ -140,6 +156,8 @@ export function CurrentActivityGraphSurface({
         canSaveDraft={editor.canSaveDraft}
         editorMode={editor.editorMode}
         edges={graph.edges}
+        flowContainerRef={flowContainerRef}
+        flowInstanceRef={flowInstanceRef}
         graphKey={graph.graphKey}
         handleDiscardPendingChanges={editor.handleDiscardPendingChanges}
         handleNodesChange={graph.handleNodesChange}

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
@@ -8,9 +8,10 @@ import {
   type NodeChange,
   type NodeTypes,
   ReactFlow,
+  type ReactFlowInstance,
   type XYPosition,
 } from "@xyflow/react";
-import { useCallback } from "react";
+import { type MutableRefObject, useCallback } from "react";
 import {
   DashboardGraphBackground,
   DashboardGraphControls,
@@ -152,6 +153,7 @@ function factoryGraphEdgeIdForRenderedEdge(nodes: Node[], edge: Edge) {
   )}->${factoryGraphNodeIdForRenderedNode(nodes, edge.target)}`;
 }
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: composes React Flow canvas wiring with editor toolbar overlays.
 export function CurrentActivityGraphViewport({
   activeTool,
   addMenuActions,
@@ -182,6 +184,8 @@ export function CurrentActivityGraphViewport({
   openAddMenu,
   saveDisabledReason,
   setStoredNodePosition,
+  flowContainerRef,
+  flowInstanceRef,
 }: {
   activeTool: "add" | "connect" | "delete" | null;
   addMenuActions?: FactoryGraphEditorMenuAction[];
@@ -216,6 +220,8 @@ export function CurrentActivityGraphViewport({
     nodeId: string,
     position: XYPosition,
   ) => void;
+  flowContainerRef?: MutableRefObject<HTMLElement | null>;
+  flowInstanceRef?: MutableRefObject<ReactFlowInstance | null>;
 }) {
   const editorMessages = getFactoryGraphEditorMessages(locale);
   const isValidConnection = buildCurrentActivityIsValidConnection({
@@ -248,6 +254,7 @@ export function CurrentActivityGraphViewport({
         locale={locale}
       />
       <section
+        ref={flowContainerRef}
         aria-describedby={headingID}
         aria-label={editorMessages.viewportLabel}
         className={cn(
@@ -286,6 +293,11 @@ export function CurrentActivityGraphViewport({
           edgesFocusable={editorMode}
           nodesConnectable={editorMode && activeTool === "connect"}
           onConnect={handleConnect}
+          onInit={(instance) => {
+            if (flowInstanceRef) {
+              flowInstanceRef.current = instance;
+            }
+          }}
           onError={handleCurrentActivityReactFlowError}
           onEdgeClick={(_, edge) => {
             if (editorMode) {

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card.tsx
@@ -22,6 +22,7 @@ import { getWorkflowActivityShellMessages } from "../messages/activity-shell";
 import { CurrentActivityGraphHeaderActions } from "./react-flow-current-activity-card-editor-chrome";
 import { CurrentActivityGraphEditorDialogs } from "./react-flow-current-activity-card-editor-dialogs";
 import { CurrentActivityGraphSaveNotifications } from "./react-flow-current-activity-card-save-notifications";
+import { GraphEditorPlacementProvider } from "./graph-editor-placement-context";
 import { CurrentActivityGraphSurface } from "./react-flow-current-activity-card-surface";
 
 export {
@@ -139,6 +140,7 @@ export function ReactFlowCurrentActivityCardView(
       : null;
 
   return (
+    <GraphEditorPlacementProvider>
     <section
       aria-labelledby={headingID}
       className={CURRENT_ACTIVITY_CARD_CLASS}
@@ -194,5 +196,6 @@ export function ReactFlowCurrentActivityCardView(
         shouldRenderImportPreviewDialog={shouldRenderImportPreviewDialog}
       />
     </section>
+    </GraphEditorPlacementProvider>
   );
 }

--- a/ui/src/features/workflow-activity/lib/graph-editor-add-node-placement.test.ts
+++ b/ui/src/features/workflow-activity/lib/graph-editor-add-node-placement.test.ts
@@ -1,0 +1,118 @@
+import type { Node } from "@xyflow/react";
+import { describe, expect, it } from "vitest";
+
+import type { FactoryGraphAddEntityDraft } from "../../factory-graph-editor/lib/factory-graph-editor-additions";
+import {
+  factoryGraphNodeIdForAddEntityDraft,
+  occupiedRectsFromRenderedNodes,
+  resolveInitialPlacementTopLeft,
+} from "./graph-editor-add-node-placement";
+
+function workerNode(
+  id: string,
+  position: { x: number; y: number },
+): Node {
+  return {
+    data: { kind: "worker" },
+    height: 86,
+    id,
+    position,
+    width: 164,
+  };
+}
+
+describe("factoryGraphNodeIdForAddEntityDraft", () => {
+  it("maps each add draft kind to the canonical factory graph node id", () => {
+    expect(
+      factoryGraphNodeIdForAddEntityDraft({
+        kind: "worker",
+        model: "gpt",
+        name: "reviewer",
+      }),
+    ).toBe("worker:reviewer");
+    expect(
+      factoryGraphNodeIdForAddEntityDraft({
+        behavior: "STANDARD",
+        body: "",
+        kind: "workstation",
+        name: "draft",
+        workerName: "writer",
+      }),
+    ).toBe("workstation:draft");
+    expect(
+      factoryGraphNodeIdForAddEntityDraft({
+        kind: "work-state",
+        name: "queued",
+        stateType: "INITIAL",
+        workTypeName: "story",
+      }),
+    ).toBe("work-state:story:queued");
+  });
+});
+
+describe("resolveInitialPlacementTopLeft", () => {
+  const workerDraft: FactoryGraphAddEntityDraft = {
+    kind: "worker",
+    model: "gpt",
+    name: "reviewer",
+  };
+
+  it("returns a viewport-centered top-left position when the canvas center is free", () => {
+    const topLeft = resolveInitialPlacementTopLeft({
+      draft: workerDraft,
+      nodes: [],
+      storedPositions: {},
+      viewportCenter: { x: 500, y: 300 },
+    });
+
+    expect(topLeft).toEqual({ x: 418, y: 257 });
+  });
+
+  it("skips placement when the new node already has a stored position", () => {
+    const topLeft = resolveInitialPlacementTopLeft({
+      draft: workerDraft,
+      nodes: [],
+      storedPositions: {
+        "worker:reviewer": { x: 12, y: 34 },
+      },
+      viewportCenter: { x: 500, y: 300 },
+    });
+
+    expect(topLeft).toBeNull();
+  });
+
+  it("nudges away from occupied nodes at the viewport center", () => {
+    const nodes = [workerNode("worker:writer", { x: 418, y: 257 })];
+    const topLeft = resolveInitialPlacementTopLeft({
+      draft: workerDraft,
+      nodes,
+      storedPositions: {},
+      viewportCenter: { x: 500, y: 300 },
+    });
+
+    expect(topLeft).not.toEqual({ x: 418, y: 257 });
+    expect(topLeft).not.toBeNull();
+  });
+
+  it("does not include the new node id in occupied bounds when it is already rendered", () => {
+    const nodes = [workerNode("worker:reviewer", { x: 418, y: 257 })];
+    const topLeft = resolveInitialPlacementTopLeft({
+      draft: workerDraft,
+      nodes,
+      storedPositions: {},
+      viewportCenter: { x: 500, y: 300 },
+    });
+
+    expect(topLeft).toEqual({ x: 418, y: 257 });
+  });
+});
+
+describe("occupiedRectsFromRenderedNodes", () => {
+  it("builds axis-aligned rects from rendered node positions and kind dimensions", () => {
+    const rects = occupiedRectsFromRenderedNodes([
+      workerNode("worker:writer", { x: 100, y: 200 }),
+    ]);
+
+    expect(rects).toEqual([{ height: 86, width: 164, x: 100, y: 200 }]);
+  });
+});

--- a/ui/src/features/workflow-activity/lib/graph-editor-add-node-placement.ts
+++ b/ui/src/features/workflow-activity/lib/graph-editor-add-node-placement.ts
@@ -1,0 +1,140 @@
+import type { Node, ReactFlowInstance } from "@xyflow/react";
+import {
+  type FactoryGraphNodeKind,
+  nodeKeyId,
+} from "../../factory-graph-editor/lib/factory-graph-draft-types";
+import type { FactoryGraphAddEntityDraft } from "../../factory-graph-editor/lib/factory-graph-editor-additions";
+import type { GraphNodePosition } from "../state/currentActivityGraphStore";
+import {
+  axisAlignedRectFromTopLeft,
+  type FlowPoint,
+  graphEditorNodeDimensionsForKind,
+  resolveViewportCenterNodePlacement,
+  topLeftFromAxisAlignedRectCenter,
+} from "./graph-editor-node-placement";
+
+export function factoryGraphNodeIdForAddEntityDraft(
+  draft: FactoryGraphAddEntityDraft,
+): string {
+  const name = draft.name.trim();
+  switch (draft.kind) {
+    case "resource":
+      return nodeKeyId({ kind: "resource", name });
+    case "worker":
+      return nodeKeyId({ kind: "worker", name });
+    case "work-type":
+      return nodeKeyId({ kind: "work-type", name });
+    case "work-state":
+      return nodeKeyId({
+        kind: "work-state",
+        stateName: name,
+        workTypeName: draft.workTypeName.trim(),
+      });
+    case "workstation":
+      return nodeKeyId({ kind: "workstation", name });
+  }
+}
+
+export function factoryGraphNodeKindForAddEntityDraft(
+  draft: FactoryGraphAddEntityDraft,
+): FactoryGraphNodeKind {
+  return draft.kind;
+}
+
+function finiteStoredPosition(
+  position: GraphNodePosition | undefined,
+): position is GraphNodePosition {
+  return (
+    position !== undefined &&
+    Number.isFinite(position.x) &&
+    Number.isFinite(position.y)
+  );
+}
+
+function nodeKindFromRenderedNode(node: Node): FactoryGraphNodeKind | null {
+  const kind = (node.data as { kind?: FactoryGraphNodeKind } | undefined)?.kind;
+  return kind ?? null;
+}
+
+function renderedNodeSize(
+  node: Node,
+): { height: number; width: number } | null {
+  const width = node.width ?? node.measured?.width;
+  const height = node.height ?? node.measured?.height;
+  if (
+    width === undefined ||
+    height === undefined ||
+    !Number.isFinite(width) ||
+    !Number.isFinite(height)
+  ) {
+    return null;
+  }
+
+  return { height, width };
+}
+
+export function occupiedRectsFromRenderedNodes(
+  nodes: readonly Node[],
+  excludeNodeId?: string,
+) {
+  const occupiedRects = [];
+
+  for (const node of nodes) {
+    if (excludeNodeId && node.id === excludeNodeId) {
+      continue;
+    }
+
+    const size = renderedNodeSize(node);
+    if (!size) {
+      continue;
+    }
+
+    const kind = nodeKindFromRenderedNode(node);
+    const dimensions = kind
+      ? graphEditorNodeDimensionsForKind(kind)
+      : { height: size.height, width: size.width };
+
+    occupiedRects.push(
+      axisAlignedRectFromTopLeft(node.position, {
+        height: dimensions.height,
+        width: dimensions.width,
+      }),
+    );
+  }
+
+  return occupiedRects;
+}
+
+export function viewportCenterInFlowCoordinates(
+  instance: ReactFlowInstance,
+  container: HTMLElement,
+): FlowPoint {
+  const bounds = container.getBoundingClientRect();
+  return instance.screenToFlowPosition({
+    x: bounds.left + bounds.width / 2,
+    y: bounds.top + bounds.height / 2,
+  });
+}
+
+export function resolveInitialPlacementTopLeft(input: {
+  draft: FactoryGraphAddEntityDraft;
+  nodes: readonly Node[];
+  storedPositions: Record<string, GraphNodePosition | undefined>;
+  viewportCenter: FlowPoint;
+}): GraphNodePosition | null {
+  const nodeId = factoryGraphNodeIdForAddEntityDraft(input.draft);
+  if (finiteStoredPosition(input.storedPositions[nodeId])) {
+    return null;
+  }
+
+  const candidateSize = graphEditorNodeDimensionsForKind(
+    factoryGraphNodeKindForAddEntityDraft(input.draft),
+  );
+  const placement = resolveViewportCenterNodePlacement({
+    candidateSize,
+    occupiedRects: occupiedRectsFromRenderedNodes(input.nodes, nodeId),
+    viewportCenter: input.viewportCenter,
+  });
+
+  return topLeftFromAxisAlignedRectCenter(placement.center, candidateSize);
+}

--- a/ui/src/features/workflow-activity/lib/graph-editor-node-placement.test.ts
+++ b/ui/src/features/workflow-activity/lib/graph-editor-node-placement.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { FACTORY_GRAPH_EDITOR_NODE_DIMENSIONS_BY_KIND } from "../../factory-graph-editor/lib/factory-graph-editor-layout";
+import {
+  axisAlignedRectFromTopLeft,
+  GRAPH_EDITOR_NODE_PLACEMENT_MAX_ATTEMPTS,
+  GRAPH_EDITOR_NODE_PLACEMENT_PADDING_GAP,
+  graphEditorNodeDimensionsForKind,
+  resolveViewportCenterNodePlacement,
+  topLeftFromAxisAlignedRectCenter,
+} from "./graph-editor-node-placement";
+
+const workerSize = graphEditorNodeDimensionsForKind("worker");
+
+describe("graphEditorNodeDimensionsForKind", () => {
+  it("matches factory graph editor layout dimensions", () => {
+    expect(graphEditorNodeDimensionsForKind("workstation")).toEqual(
+      FACTORY_GRAPH_EDITOR_NODE_DIMENSIONS_BY_KIND.workstation,
+    );
+    expect(graphEditorNodeDimensionsForKind("resource")).toEqual(
+      FACTORY_GRAPH_EDITOR_NODE_DIMENSIONS_BY_KIND.resource,
+    );
+  });
+});
+
+describe("resolveViewportCenterNodePlacement", () => {
+  it("returns the viewport center on an empty canvas", () => {
+    const viewportCenter = { x: 420, y: 280 };
+
+    const result = resolveViewportCenterNodePlacement({
+      candidateSize: workerSize,
+      occupiedRects: [],
+      viewportCenter,
+    });
+
+    expect(result).toEqual({
+      attemptsUsed: 1,
+      center: viewportCenter,
+      collidesAtCenter: false,
+      exhaustedSearch: false,
+    });
+  });
+
+  it("nudges away when the viewport center is blocked", () => {
+    const viewportCenter = { x: 200, y: 200 };
+    const blockerTopLeft = topLeftFromAxisAlignedRectCenter(
+      viewportCenter,
+      workerSize,
+    );
+
+    const result = resolveViewportCenterNodePlacement({
+      candidateSize: workerSize,
+      occupiedRects: [axisAlignedRectFromTopLeft(blockerTopLeft, workerSize)],
+      viewportCenter,
+    });
+
+    expect(result.collidesAtCenter).toBe(true);
+    expect(result.exhaustedSearch).toBe(false);
+    expect(result.center).not.toEqual(viewportCenter);
+    expect(result.attemptsUsed).toBeGreaterThan(1);
+  });
+
+  it("picks the nearest free slot when multiple blockers surround the center", () => {
+    const viewportCenter = { x: 0, y: 0 };
+    const blockerSize = { height: 120, width: 120 };
+    const occupiedRects = [
+      axisAlignedRectFromTopLeft({ x: -70, y: -70 }, blockerSize),
+      axisAlignedRectFromTopLeft({ x: -70, y: 40 }, blockerSize),
+      axisAlignedRectFromTopLeft({ x: 40, y: -70 }, blockerSize),
+      axisAlignedRectFromTopLeft({ x: 40, y: 40 }, blockerSize),
+    ];
+
+    const result = resolveViewportCenterNodePlacement({
+      candidateSize: workerSize,
+      occupiedRects,
+      viewportCenter,
+    });
+
+    expect(result.exhaustedSearch).toBe(false);
+    expect(result.center).not.toEqual(viewportCenter);
+    const distance = Math.hypot(
+      result.center.x - viewportCenter.x,
+      result.center.y - viewportCenter.y,
+    );
+    expect(distance).toBeGreaterThan(0);
+    expect(distance).toBeLessThan(
+      workerSize.width +
+        workerSize.height +
+        GRAPH_EDITOR_NODE_PLACEMENT_PADDING_GAP,
+    );
+  });
+
+  it("falls back to the viewport center when search is exhausted", () => {
+    const viewportCenter = { x: 100, y: 100 };
+    const blockerSize = { height: 400, width: 400 };
+    const occupiedRects = [
+      axisAlignedRectFromTopLeft({ x: -200, y: -200 }, blockerSize),
+    ];
+
+    const result = resolveViewportCenterNodePlacement({
+      candidateSize: workerSize,
+      maxAttempts: 4,
+      occupiedRects,
+      paddingGap: GRAPH_EDITOR_NODE_PLACEMENT_PADDING_GAP,
+      viewportCenter,
+    });
+
+    expect(result).toEqual({
+      attemptsUsed: 4,
+      center: viewportCenter,
+      collidesAtCenter: true,
+      exhaustedSearch: true,
+    });
+  });
+
+  it("documents the default max attempt budget", () => {
+    expect(GRAPH_EDITOR_NODE_PLACEMENT_MAX_ATTEMPTS).toBe(48);
+  });
+});

--- a/ui/src/features/workflow-activity/lib/graph-editor-node-placement.ts
+++ b/ui/src/features/workflow-activity/lib/graph-editor-node-placement.ts
@@ -1,0 +1,247 @@
+import type { FactoryGraphNodeKind } from "../../factory-graph-editor/lib/factory-graph-draft-types";
+import { FACTORY_GRAPH_EDITOR_NODE_DIMENSIONS_BY_KIND } from "../../factory-graph-editor/lib/factory-graph-editor-layout";
+
+export interface AxisAlignedRect {
+  height: number;
+  width: number;
+  x: number;
+  y: number;
+}
+
+export interface FlowPoint {
+  x: number;
+  y: number;
+}
+
+export interface NodePlacementSize {
+  height: number;
+  width: number;
+}
+
+export interface ViewportCenterPlacementInput {
+  candidateSize: NodePlacementSize;
+  maxAttempts?: number;
+  occupiedRects: readonly AxisAlignedRect[];
+  paddingGap?: number;
+  viewportCenter: FlowPoint;
+}
+
+export interface ViewportCenterPlacementResult {
+  attemptsUsed: number;
+  center: FlowPoint;
+  collidesAtCenter: boolean;
+  exhaustedSearch: boolean;
+}
+
+/** Default gap between candidate and occupied node bounds when testing overlap. */
+export const GRAPH_EDITOR_NODE_PLACEMENT_PADDING_GAP = 12;
+
+/**
+ * Maximum placement candidates tried after the viewport center, including the
+ * center itself (48 total attempts: center + 47 nudges).
+ */
+export const GRAPH_EDITOR_NODE_PLACEMENT_MAX_ATTEMPTS = 48;
+
+export function graphEditorNodeDimensionsForKind(
+  kind: FactoryGraphNodeKind,
+): NodePlacementSize {
+  return { ...FACTORY_GRAPH_EDITOR_NODE_DIMENSIONS_BY_KIND[kind] };
+}
+
+export function axisAlignedRectFromTopLeft(
+  topLeft: FlowPoint,
+  size: NodePlacementSize,
+): AxisAlignedRect {
+  return {
+    height: size.height,
+    width: size.width,
+    x: topLeft.x,
+    y: topLeft.y,
+  };
+}
+
+export function axisAlignedRectCenter(rect: AxisAlignedRect): FlowPoint {
+  return {
+    x: rect.x + rect.width / 2,
+    y: rect.y + rect.height / 2,
+  };
+}
+
+export function topLeftFromAxisAlignedRectCenter(
+  center: FlowPoint,
+  size: NodePlacementSize,
+): FlowPoint {
+  return {
+    x: center.x - size.width / 2,
+    y: center.y - size.height / 2,
+  };
+}
+
+function axisAlignedRectFromCenter(
+  center: FlowPoint,
+  size: NodePlacementSize,
+): AxisAlignedRect {
+  return axisAlignedRectFromTopLeft(
+    topLeftFromAxisAlignedRectCenter(center, size),
+    size,
+  );
+}
+
+function expandedRect(
+  rect: AxisAlignedRect,
+  paddingGap: number,
+): AxisAlignedRect {
+  return {
+    height: rect.height + paddingGap * 2,
+    width: rect.width + paddingGap * 2,
+    x: rect.x - paddingGap,
+    y: rect.y - paddingGap,
+  };
+}
+
+function rectsOverlap(
+  left: AxisAlignedRect,
+  right: AxisAlignedRect,
+  paddingGap: number,
+): boolean {
+  const expandedLeft = expandedRect(left, paddingGap);
+  const expandedRight = expandedRect(right, paddingGap);
+  const leftRight = expandedLeft.x + expandedLeft.width;
+  const leftBottom = expandedLeft.y + expandedLeft.height;
+  const rightRight = expandedRight.x + expandedRight.width;
+  const rightBottom = expandedRight.y + expandedRight.height;
+
+  return (
+    expandedLeft.x < rightRight &&
+    leftRight > expandedRight.x &&
+    expandedLeft.y < rightBottom &&
+    leftBottom > expandedRight.y
+  );
+}
+
+function collidesWithOccupied(
+  candidateRect: AxisAlignedRect,
+  occupiedRects: readonly AxisAlignedRect[],
+  paddingGap: number,
+): boolean {
+  return occupiedRects.some((occupiedRect) =>
+    rectsOverlap(candidateRect, occupiedRect, paddingGap),
+  );
+}
+
+function distanceSquared(from: FlowPoint, to: FlowPoint): number {
+  const deltaX = from.x - to.x;
+  const deltaY = from.y - to.y;
+  return deltaX * deltaX + deltaY * deltaY;
+}
+
+function* viewportCenterNudgeOffsets(
+  stepX: number,
+  stepY: number,
+): Generator<FlowPoint> {
+  yield { x: 0, y: 0 };
+
+  let offsetX = 0;
+  let offsetY = 0;
+  let stepsInSegment = 1;
+  const directions = [
+    { dx: 1, dy: 0 },
+    { dx: 0, dy: 1 },
+    { dx: -1, dy: 0 },
+    { dx: 0, dy: -1 },
+  ] as const;
+  let directionIndex = 0;
+
+  while (true) {
+    const direction = directions[directionIndex % directions.length];
+    for (let step = 0; step < stepsInSegment; step += 1) {
+      offsetX += direction.dx * stepX;
+      offsetY += direction.dy * stepY;
+      yield { x: offsetX, y: offsetY };
+    }
+    directionIndex += 1;
+    if (directionIndex % 2 === 0) {
+      stepsInSegment += 1;
+    }
+  }
+}
+
+export function resolveViewportCenterNodePlacement(
+  input: ViewportCenterPlacementInput,
+): ViewportCenterPlacementResult {
+  const paddingGap =
+    input.paddingGap ?? GRAPH_EDITOR_NODE_PLACEMENT_PADDING_GAP;
+  const maxAttempts =
+    input.maxAttempts ?? GRAPH_EDITOR_NODE_PLACEMENT_MAX_ATTEMPTS;
+  const stepX = input.candidateSize.width + paddingGap;
+  const stepY = input.candidateSize.height + paddingGap;
+  const centerRect = axisAlignedRectFromCenter(
+    input.viewportCenter,
+    input.candidateSize,
+  );
+  const collidesAtCenter = collidesWithOccupied(
+    centerRect,
+    input.occupiedRects,
+    paddingGap,
+  );
+
+  let attemptsUsed = 1;
+  if (!collidesAtCenter) {
+    return {
+      attemptsUsed,
+      center: input.viewportCenter,
+      collidesAtCenter: false,
+      exhaustedSearch: false,
+    };
+  }
+
+  let bestCenter: FlowPoint | undefined;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  const nudgeOffsets = viewportCenterNudgeOffsets(stepX, stepY);
+  nudgeOffsets.next();
+
+  while (attemptsUsed < maxAttempts) {
+    const nextOffset = nudgeOffsets.next();
+    if (nextOffset.done) {
+      break;
+    }
+
+    attemptsUsed += 1;
+    const candidateCenter = {
+      x: input.viewportCenter.x + nextOffset.value.x,
+      y: input.viewportCenter.y + nextOffset.value.y,
+    };
+    const candidateRect = axisAlignedRectFromCenter(
+      candidateCenter,
+      input.candidateSize,
+    );
+    if (collidesWithOccupied(candidateRect, input.occupiedRects, paddingGap)) {
+      continue;
+    }
+
+    const candidateDistance = distanceSquared(
+      input.viewportCenter,
+      candidateCenter,
+    );
+    if (candidateDistance < bestDistance) {
+      bestCenter = candidateCenter;
+      bestDistance = candidateDistance;
+    }
+  }
+
+  if (bestCenter) {
+    return {
+      attemptsUsed,
+      center: bestCenter,
+      collidesAtCenter: true,
+      exhaustedSearch: false,
+    };
+  }
+
+  return {
+    attemptsUsed,
+    center: input.viewportCenter,
+    collidesAtCenter: true,
+    exhaustedSearch: true,
+  };
+}

--- a/ui/src/features/workflow-activity/lib/graph-editor-node-placement.ts
+++ b/ui/src/features/workflow-activity/lib/graph-editor-node-placement.ts
@@ -60,13 +60,6 @@ export function axisAlignedRectFromTopLeft(
   };
 }
 
-export function axisAlignedRectCenter(rect: AxisAlignedRect): FlowPoint {
-  return {
-    x: rect.x + rect.width / 2,
-    y: rect.y + rect.height / 2,
-  };
-}
-
 export function topLeftFromAxisAlignedRectCenter(
   center: FlowPoint,
   size: NodePlacementSize,

--- a/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-keys.test.ts
+++ b/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-keys.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  currentActivityGraphKey,
+  graphKeyAfterAddingNode,
+} from "./react-flow-current-activity-card-keys";
+
+describe("graphKeyAfterAddingNode", () => {
+  it("adds the new node id to the sorted graph key node segment", () => {
+    const graphKey = currentActivityGraphKey({
+      edges: [{ edgeId: "edge-a", fromNodeId: "a", toNodeId: "b" }],
+      height: 100,
+      nodes: [
+        {
+          column: 0,
+          height: 86,
+          nodeId: "worker:writer",
+          nodeKind: "worker",
+          row: 0,
+          width: 164,
+          x: 0,
+          y: 0,
+        },
+        {
+          column: 1,
+          height: 196,
+          nodeId: "workstation:draft",
+          nodeKind: "workstation",
+          row: 0,
+          width: 156,
+          x: 200,
+          y: 0,
+        },
+      ],
+      width: 400,
+    });
+
+    expect(graphKeyAfterAddingNode(graphKey, "worker:assistant")).toBe(
+      "worker:assistant|worker:writer|workstation:draft::edge-a",
+    );
+  });
+});

--- a/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-keys.ts
+++ b/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-keys.ts
@@ -6,12 +6,41 @@ export function currentActivityGraphKey(graphLayout: GraphLayout): string {
     return "";
   }
 
-  const nodeIds = graphLayout.nodes.map((node) => node.nodeId).sort().join("|");
-  const edgeIds = graphLayout.edges.map((edge) => edge.edgeId).sort().join("|");
+  const nodeIds = graphLayout.nodes
+    .map((node) => node.nodeId)
+    .sort()
+    .join("|");
+  const edgeIds = graphLayout.edges
+    .map((edge) => edge.edgeId)
+    .sort()
+    .join("|");
   return `${nodeIds}::${edgeIds}`;
 }
 
-export function currentActivityTopologyKey(topology: DashboardTopology): string {
+export function graphKeyAfterAddingNode(
+  graphKey: string,
+  newNodeId: string,
+): string {
+  if (!graphKey) {
+    return newNodeId;
+  }
+
+  const separatorIndex = graphKey.indexOf("::");
+  const nodePart =
+    separatorIndex === -1 ? graphKey : graphKey.slice(0, separatorIndex);
+  const edgePart =
+    separatorIndex === -1 ? "" : graphKey.slice(separatorIndex + 2);
+  const nodeIds = nodePart.split("|").filter((nodeId) => nodeId.length > 0);
+
+  nodeIds.push(newNodeId);
+  nodeIds.sort();
+
+  return `${nodeIds.join("|")}::${edgePart}`;
+}
+
+export function currentActivityTopologyKey(
+  topology: DashboardTopology,
+): string {
   return JSON.stringify({
     edges: [...(topology.edges ?? [])]
       .map((edge) => ({
@@ -23,36 +52,35 @@ export function currentActivityTopologyKey(topology: DashboardTopology): string 
         via_place_id: edge.via_place_id,
         work_type_id: edge.work_type_id ?? "",
       }))
-      .sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right))),
-    workstations: [...topology.workstation_node_ids]
-      .sort()
-      .map((nodeId) => {
-        const workstation = topology.workstation_nodes_by_id[nodeId];
-        return {
-          input_places: [...(workstation?.input_places ?? [])]
-            .map((place) => ({
-              kind: place.kind,
-              place_id: place.place_id,
-              state_category: place.state_category ?? "",
-              state_value: place.state_value ?? "",
-              type_id: place.type_id ?? "",
-            }))
-            .sort((left, right) => left.place_id.localeCompare(right.place_id)),
-          node_id: workstation?.node_id ?? nodeId,
-          output_places: [...(workstation?.output_places ?? [])]
-            .map((place) => ({
-              kind: place.kind,
-              place_id: place.place_id,
-              state_category: place.state_category ?? "",
-              state_value: place.state_value ?? "",
-              type_id: place.type_id ?? "",
-            }))
-            .sort((left, right) => left.place_id.localeCompare(right.place_id)),
-          transition_id: workstation?.transition_id ?? "",
-          workstation_kind: workstation?.workstation_kind ?? "",
-          workstation_name: workstation?.workstation_name ?? "",
-        };
-      }),
+      .sort((left, right) =>
+        JSON.stringify(left).localeCompare(JSON.stringify(right)),
+      ),
+    workstations: [...topology.workstation_node_ids].sort().map((nodeId) => {
+      const workstation = topology.workstation_nodes_by_id[nodeId];
+      return {
+        input_places: [...(workstation?.input_places ?? [])]
+          .map((place) => ({
+            kind: place.kind,
+            place_id: place.place_id,
+            state_category: place.state_category ?? "",
+            state_value: place.state_value ?? "",
+            type_id: place.type_id ?? "",
+          }))
+          .sort((left, right) => left.place_id.localeCompare(right.place_id)),
+        node_id: workstation?.node_id ?? nodeId,
+        output_places: [...(workstation?.output_places ?? [])]
+          .map((place) => ({
+            kind: place.kind,
+            place_id: place.place_id,
+            state_category: place.state_category ?? "",
+            state_value: place.state_value ?? "",
+            type_id: place.type_id ?? "",
+          }))
+          .sort((left, right) => left.place_id.localeCompare(right.place_id)),
+        transition_id: workstation?.transition_id ?? "",
+        workstation_kind: workstation?.workstation_kind ?? "",
+        workstation_name: workstation?.workstation_name ?? "",
+      };
+    }),
   });
 }
-


### PR DESCRIPTION
```json
{
  "project": "infinite-you",
  "branchName": "ralph/graph-editor-node-placement",
  "description": "Place newly added factory graph editor nodes at the viewport center with collision-aware nudging, while preserving manual drag positions and existing saved layouts.",
  "context": {
    "customerAsk": "Place new graph nodes at viewport center without overlap. New worker/workstation (and other add flows) should appear near the center of the visible canvas, must not spawn directly under an existing node bounding box when avoidable, and existing saved positions must remain unchanged on load.",
    "problem": "When adding nodes in the factory graph editor, new entities inherit column/row layout fallbacks that may sit behind existing nodes or outside the panned viewport, so operators lose track of what was added.",
    "solution": "Add a testable placement resolver that maps the React Flow viewport center to flow coordinates, nudges away from occupied node bounds, and writes the result to the existing currentActivityGraphStore when an add succeeds—without rewriting stored positions for existing nodes or changing observer-mode layout."
  },
  "acceptanceCriteria": [
    "New nodes from all editor add flows (worker, workstation, resource, work type, work state) render near the visible viewport center, pan/zoom aware.",
    "When the center is occupied, new nodes are nudged to a nearby non-overlapping position when one exists within the search budget.",
    "Stored positions for existing nodes are unchanged on load and when adding unrelated nodes.",
    "Manual drag after placement continues to persist positions via onNodeDragStop.",
    "Observer (non-editor) graph behavior is unchanged.",
    "Typecheck, lint, and tests pass for touched UI packages."
  ],
  "userStories": [
    {
      "id": "graph-editor-node-placement-001",
      "title": "Viewport-center placement resolver",
      "passes": true
    },
    {
      "id": "graph-editor-node-placement-002",
      "title": "Apply placement when adding graph entities",
      "passes": true
    },
    {
      "id": "graph-editor-node-placement-003",
      "title": "End-to-end editor placement verification",
      "passes": true
    }
  ]
}
```

Made with [Cursor](https://cursor.com)