### PR TITLE
factory-session-selector-button-style

### DIFF
--- a/ui/integration/dashboard-session-tabs.integration.test.mjs
+++ b/ui/integration/dashboard-session-tabs.integration.test.mjs
@@ -21,6 +21,31 @@ const openedFactoryDefinition = {
   name: "Opened Review Factory",
 };
 
+const betaSessionID = "session-beta";
+
+const defaultSession = {
+  factoryDir: "/workspace/root",
+  folderPath: "/workspace/root",
+  id: "~default",
+  isDefault: true,
+  project: "root",
+  target: {
+    kind: "default",
+  },
+};
+
+const betaSession = {
+  factoryDir: "/workspace/root/beta",
+  folderPath: "/workspace/root",
+  id: betaSessionID,
+  isDefault: false,
+  project: "beta",
+  target: {
+    kind: "named",
+    name: "beta",
+  },
+};
+
 function renameReplayWorkstation(lines, workstationName) {
   return lines.map((line) => {
     const event = JSON.parse(line);
@@ -185,4 +210,103 @@ describe.sequential("dashboard session tabs browser integration", () => {
     },
     browserScenarioTimeoutMs,
   );
+
+  it(
+    "shows outline active session tab styling and moves selection across preloaded tabs",
+    async () => {
+      const replayLines = await loadReplayLines("graph-state-smoke-replay.jsonl");
+      const server = await startFactoryApiServer({
+        apiPort: preview.apiPort,
+        currentFactory: defaultFactoryDefinition,
+        eventLines: replayLines,
+        eventLinesBySessionID: {
+          [betaSessionID]: replayLines,
+        },
+        currentFactoryBySessionID: {
+          [betaSessionID]: defaultFactoryDefinition,
+        },
+        sessions: [defaultSession, betaSession],
+      });
+      const browserPage = await openBrowserPage();
+
+      try {
+        await browserPage.page.goto(preview.previewURL, {
+          waitUntil: "domcontentloaded",
+        });
+
+        const rootTab = browserPage.page.getByRole("tab", { name: "root" });
+        const betaTab = browserPage.page.getByRole("tab", { name: "beta" });
+        await rootTab.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
+        await betaTab.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
+        await expect
+          .poll(async () => rootTab.getAttribute("aria-selected"), {
+            timeout: uiInteractionTimeoutMs,
+          })
+          .toBe("true");
+
+        expectOutlineActiveSessionTabShell(
+          await readSessionTabShellClassName(rootTab),
+        );
+        expectMutedInactiveSessionTabShell(
+          await readSessionTabShellClassName(betaTab),
+        );
+
+        await betaTab.click();
+        await expect
+          .poll(async () => betaTab.getAttribute("aria-selected"), {
+            timeout: uiInteractionTimeoutMs,
+          })
+          .toBe("true");
+        await expect
+          .poll(async () => rootTab.getAttribute("aria-selected"), {
+            timeout: uiInteractionTimeoutMs,
+          })
+          .toBe("false");
+
+        expectOutlineActiveSessionTabShell(
+          await readSessionTabShellClassName(betaTab),
+        );
+        expectMutedInactiveSessionTabShell(
+          await readSessionTabShellClassName(rootTab),
+        );
+
+        expectNoBrowserErrors(
+          browserPage.pageErrors,
+          browserPage.consoleErrors,
+          expect,
+        );
+      } finally {
+        await server.stop();
+        await browserPage.close();
+      }
+    },
+    browserScenarioTimeoutMs,
+  );
 });
+
+async function readSessionTabShellClassName(tabLocator) {
+  return tabLocator.evaluate((tab) => {
+    const shell = tab.parentElement;
+    if (!shell) {
+      throw new Error("Expected session tab shell wrapper");
+    }
+    return shell.className;
+  });
+}
+
+function expectOutlineActiveSessionTabShell(className) {
+  expect(className).toContain("border-af-border-strong");
+  expect(className).toContain("bg-af-surface-raised");
+  expect(className).not.toContain("bg-af-accent");
+  expect(className).not.toContain("bg-af-accent-surface");
+}
+
+function expectMutedInactiveSessionTabShell(className) {
+  expect(className).toContain("text-af-text-muted");
+}

--- a/ui/src/features/header/components/dashboard-session-tabs.stories.tsx
+++ b/ui/src/features/header/components/dashboard-session-tabs.stories.tsx
@@ -9,9 +9,9 @@ import {
   liveWorkOutcomeSnapshot,
 } from "../../../stories/dashboardStorySupport";
 import { useDashboardSessionStore } from "../../dashboard/state/dashboardSessionStore";
-import { DashboardSessionTabs } from "./dashboard-session-tabs";
 import { SESSION_TAB_PATH_MAX_LENGTH } from "../lib/dashboard-session-tabs-utils";
 import { getHeaderControlsMessages } from "../messages/header-controls";
+import { DashboardSessionTabs } from "./dashboard-session-tabs";
 
 const defaultSession = {
   factoryDir: "/workspace/root",
@@ -96,11 +96,17 @@ export const OpenFlowVerification = {
     );
 
     await expect(tabsNavigation).toBeVisible();
-    await expect(canvas.getByRole("tab", { name: "root" })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
-    await expect(canvas.getByRole("tab", { name: "beta" })).toBeVisible();
+    const rootTab = canvas.getByRole("tab", { name: "root" });
+    const betaTab = canvas.getByRole("tab", { name: "beta" });
+    await expect(rootTab).toHaveAttribute("aria-selected", "true");
+    await expect(betaTab).toBeVisible();
+    const activeShellClassName = sessionTabShell(rootTab).className;
+    const inactiveShellClassName = sessionTabShell(betaTab).className;
+    expect(activeShellClassName).toContain("border-af-border-strong");
+    expect(activeShellClassName).toContain("bg-af-surface-raised");
+    expect(activeShellClassName).not.toContain("bg-af-accent");
+    expect(activeShellClassName).not.toContain("bg-af-accent-surface");
+    expect(inactiveShellClassName).toContain("text-af-text-muted");
     await expect(
       canvas.getByRole("button", { name: "Close beta session" }),
     ).toBeVisible();
@@ -117,7 +123,9 @@ export const OpenFlowVerification = {
     await userEvent.clear(folderField);
     await userEvent.type(folderField, "/workspace/catalog");
     await userEvent.click(
-      within(dialog).getByRole("button", { name: messages.openSessionSubmitLabel }),
+      within(dialog).getByRole("button", {
+        name: messages.openSessionSubmitLabel,
+      }),
     );
 
     await userEvent.click(
@@ -142,6 +150,14 @@ export const OpenFlowVerification = {
     await expect(canvas.queryByRole("tab", { name: "review" })).toBeNull();
   },
 };
+
+function sessionTabShell(tab: HTMLElement): HTMLElement {
+  const shell = tab.parentElement;
+  if (!shell) {
+    throw new Error("Expected session tab shell wrapper");
+  }
+  return shell;
+}
 
 function SessionTabsStory() {
   useEffect(() => {
@@ -281,7 +297,8 @@ function sessionTabsStoryParameters() {
             return {
               body: {
                 code: "BAD_REQUEST",
-                message: "Unsupported folder for the Storybook session-tabs flow.",
+                message:
+                  "Unsupported folder for the Storybook session-tabs flow.",
               },
               status: 400,
               statusText: "Bad Request",

--- a/ui/src/features/header/components/dashboard-session-tabs.test.tsx
+++ b/ui/src/features/header/components/dashboard-session-tabs.test.tsx
@@ -110,6 +110,58 @@ describe("DashboardSessionTabs", () => {
     expect(screen.getByRole("tabpanel")).toBeTruthy();
   });
 
+  it("uses outline-aligned styling on the active session tab shell without accent fill", async () => {
+    listFactorySessions.mockResolvedValue([
+      {
+        factoryDir: "/workspace/root",
+        folderPath: "/workspace/root",
+        id: "~default",
+        isDefault: true,
+        project: "root",
+        target: {
+          kind: "default",
+        },
+      },
+      {
+        factoryDir: "/workspace/root/beta",
+        folderPath: "/workspace/root",
+        id: "session-beta",
+        isDefault: false,
+        project: "beta",
+        target: {
+          kind: "named",
+          name: "beta",
+        },
+      },
+    ]);
+
+    renderWithQueryClient(<DashboardSessionTabs locale="en" />);
+    const messages = getHeaderControlsMessages("en");
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("navigation", { name: messages.sessionTabsLabel }),
+      ).toBeTruthy();
+    });
+
+    const rootTab = screen.getByRole("tab", { name: "root" });
+    const betaTab = screen.getByRole("tab", { name: "beta" });
+    const activeShell = sessionTabShell(rootTab);
+    const inactiveShell = sessionTabShell(betaTab);
+
+    expectOutlineActiveSessionTabShell(activeShell);
+    expectMutedInactiveSessionTabShell(inactiveShell);
+
+    fireEvent.click(betaTab);
+
+    await waitFor(() => {
+      expect(betaTab.getAttribute("aria-selected")).toBe("true");
+    });
+
+    expectOutlineActiveSessionTabShell(sessionTabShell(betaTab));
+    expectMutedInactiveSessionTabShell(sessionTabShell(rootTab));
+  });
+
   it("supports keyboard navigation across session tabs with roving tab focus", async () => {
     listFactorySessions.mockResolvedValue([
       {
@@ -1252,6 +1304,29 @@ describe("DashboardSessionTabs", () => {
     );
   });
 });
+
+function sessionTabShell(tab: HTMLElement): HTMLElement {
+  const shell = tab.parentElement;
+  if (!shell) {
+    throw new Error("Expected session tab shell wrapper");
+  }
+  return shell;
+}
+
+function expectOutlineActiveSessionTabShell(shell: HTMLElement) {
+  expect(shell.className).toContain("border-af-border-strong");
+  expect(shell.className).toContain("bg-af-surface-raised");
+  expect(shell.className).toContain("text-af-text");
+  expect(shell.className.includes("bg-af-accent")).toBe(false);
+  expect(shell.className.includes("bg-af-accent-surface")).toBe(false);
+}
+
+function expectMutedInactiveSessionTabShell(shell: HTMLElement) {
+  expect(shell.className).toContain("text-af-text-muted");
+  expect(shell.className.includes("bg-af-surface-raised")).toBe(false);
+  expect(shell.className.includes("bg-af-accent")).toBe(false);
+  expect(shell.className.includes("bg-af-accent-surface")).toBe(false);
+}
 
 function renderWithQueryClient(view: React.ReactElement) {
   const queryClient = new QueryClient({

--- a/ui/src/features/header/components/dashboard-session-tabs.tsx
+++ b/ui/src/features/header/components/dashboard-session-tabs.tsx
@@ -42,13 +42,17 @@ const OPEN_SESSION_TAB_BUTTON_CLASS = cn(
   "hover:bg-af-overlay-subtle hover:text-af-text",
   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-af-focus-ring",
 );
+/** Matches `BUTTON_TONE_CLASS.outline` on the tab shell (not the full button chrome). */
+const SESSION_TAB_OUTLINE_SURFACE_CLASS =
+  "border border-af-border-strong bg-af-surface-raised text-af-text";
 const SESSION_TAB_ACTIVE_CLASS = cn(
-  "z-10 -mb-0.5 overflow-visible rounded-t-2xl rounded-b-none bg-af-surface-subtle text-af-text",
-  "before:pointer-events-none before:absolute before:-left-4 before:-bottom-0 before:h-4 before:w-4 before:bg-[radial-gradient(circle_at_top_left,transparent_1rem,var(--color-af-surface-subtle)_1rem)]",
-  "after:pointer-events-none after:absolute after:-right-4 after:-bottom-0 after:h-4 after:w-4 after:bg-[radial-gradient(circle_at_top_right,transparent_1rem,var(--color-af-surface-subtle)_1rem)]",
+  SESSION_TAB_OUTLINE_SURFACE_CLASS,
+  "z-10 -mb-0.5 overflow-visible rounded-t-2xl rounded-b-none border-b-transparent",
+  "before:pointer-events-none before:absolute before:-left-4 before:-bottom-0 before:h-4 before:w-4 before:bg-[radial-gradient(circle_at_top_left,transparent_1rem,var(--color-af-surface-raised)_1rem)]",
+  "after:pointer-events-none after:absolute after:-right-4 after:-bottom-0 after:h-4 after:w-4 after:bg-[radial-gradient(circle_at_top_right,transparent_1rem,var(--color-af-surface-raised)_1rem)]",
 );
 const SESSION_TAB_INACTIVE_CLASS =
-  "rounded-t-xl rounded-b-none text-af-text-muted hover:bg-af-overlay hover:text-af-text";
+  "rounded-t-xl rounded-b-none border border-transparent text-af-text-muted hover:border-af-border hover:bg-af-overlay hover:text-af-text";
 const SESSION_TAB_ACTIVE_BUTTON_CLASS =
   "flex min-w-0 flex-1 flex-col items-start rounded-tl-xl px-3 py-2";
 const SESSION_TAB_INACTIVE_BUTTON_CLASS =


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/factory-session-selector-button-style",
  "description": "Restyle the dashboard header factory session selector so the active session tab uses outline button styling consistent with neighboring toolbar controls, preserves a clear selected state without accent/yellow fill, and is covered by unit tests and browser verification.",
  "context": {
    "customerAsk": "Change the factory session selector button from a yellow filled style to an outline button like other dashboard header controls, while keeping the selected session visually obvious.",
    "problem": "The active factory session click target in the dashboard header uses accent-filled styling that is inconsistent with outline toolbar buttons and draws excessive attention.",
    "solution": "Align SessionTabButton active-state classes in DashboardSessionTabs with shared outline button tokens, express selection via border and subtle neutral background instead of accent fill, and verify behavior with existing session-tab tests plus browser checks on the dashboard header."
  },
  "acceptanceCriteria": [
    "Active factory session tab in the dashboard header uses outline styling aligned with DashboardHeaderActionButton, not accent-filled primary background on the click target",
    "Inactive session tabs are visually quieter; operators can identify the selected session at a glance",
    "Session tab aria-selected, keyboard navigation, close controls, and stream status behavior are unchanged",
    "dashboard-session-tabs unit tests and Storybook plays pass with updated styling assertions where needed",
    "Browser verification on the dashboard header confirms outline active tab with multiple sessions open",
    "ui typecheck, lint, and affected tests pass"
  ],
  "userStories": [
    {
      "id": "factory-session-selector-button-style-001",
      "title": "Outline styling for active session tab",
      "description": "As a dashboard operator, I want the selected factory session tab to look like other outline header controls so the toolbar feels cohesive and the active session does not dominate visually.",
      "acceptanceCriteria": [
        "SESSION_TAB_ACTIVE_CLASS and SESSION_TAB_ACTIVE_BUTTON_CLASS in dashboard-session-tabs.tsx use outline-equivalent tokens instead of accent fill on the active tab click target",
        "Selected state uses stronger border and/or subtle neutral background; inactive tabs keep de-emphasized styling",
        "Stream status dot, secondary path, close control, and open-session (+) button remain functional and legible",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "factory-session-selector-button-style-002",
      "title": "Regression tests and Storybook for session tab chrome",
      "description": "As a maintainer, I need automated checks so future header changes do not reintroduce accent-filled session tabs.",
      "acceptanceCriteria": [
        "Focused tests assert the active session tab does not use bg-af-accent or bg-af-accent-surface as primary fill and does use outline-aligned border/surface classes",
        "Existing dashboard-session-tabs tests for aria-selected, keyboard navigation, session close, and stream labels still pass",
        "dashboard-session-tabs.stories.tsx plays still pass for multi-session scenarios",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "factory-session-selector-button-style-003",
      "title": "Browser verification on dashboard header",
      "description": "As a maintainer, I want visual confirmation that the dashboard header session strip matches outline toolbar styling with multiple sessions open.",
      "acceptanceCriteria": [
        "With at least two factory sessions loaded, the active tab shows outline styling without yellow/accent fill on the main click target and inactive tabs are muted",
        "Clicking an inactive tab moves aria-selected and active outline styling to that tab without header layout breakage",
        "Typecheck passes",
        "Verify in browser using dev-browser skill: dashboard header session tabs with multiple sessions—active tab outline, inactive tabs muted, selection switch works"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)