### PR TITLE
selection-work-state-rename

### DIFF
--- a/ui/src/features/current-factory-definition/lib/work-state-editable-values.test.ts
+++ b/ui/src/features/current-factory-definition/lib/work-state-editable-values.test.ts
@@ -1,0 +1,135 @@
+import type { CanonicalFactoryDefinition } from "../../../api/current-factory-definition";
+import {
+  applyEditableWorkStateDraft,
+  editableWorkStateDraftFromValues,
+  resolveEditableWorkStateValues,
+} from "./work-state-editable-values";
+
+const factoryWithWorkStateRoutes: CanonicalFactoryDefinition = {
+  name: "Current Factory",
+  workers: [
+    { modelProvider: "CURSOR", name: "reviewer", type: "MODEL_WORKER" },
+  ],
+  workTypes: [
+    {
+      name: "story",
+      states: [
+        { name: "queued", type: "INITIAL" },
+        { name: "done", type: "TERMINAL" },
+      ],
+    },
+  ],
+  workstations: [
+    {
+      id: "plan",
+      inputs: [{ state: "queued", workType: "story" }],
+      name: "Plan",
+      onContinue: [{ state: "queued", workType: "story" }],
+      onFailure: [{ state: "queued", workType: "story" }],
+      onRejection: [{ state: "queued", workType: "story" }],
+      outputs: [{ state: "done", workType: "story" }],
+      worker: "reviewer",
+    },
+    {
+      classificationRoutes: [
+        {
+          label: "ship",
+          outputs: [{ state: "queued", workType: "story" }],
+        },
+      ],
+      id: "classify",
+      inputs: [{ state: "queued", workType: "story" }],
+      name: "Classify",
+      worker: "reviewer",
+    },
+    {
+      id: "other",
+      inputs: [{ state: "queued", workType: "task" }],
+      name: "Other",
+      worker: "reviewer",
+    },
+  ],
+};
+
+describe("resolveEditableWorkStateValues", () => {
+  it("returns work state values for a factory-backed place id", () => {
+    expect(
+      resolveEditableWorkStateValues(
+        factoryWithWorkStateRoutes,
+        "story:queued",
+      ),
+    ).toEqual({
+      stateName: "queued",
+      stateNamesInWorkType: ["queued", "done"],
+      stateType: "INITIAL",
+      workTypeName: "story",
+    });
+  });
+
+  it("returns null when the place id does not resolve to a factory work state", () => {
+    expect(
+      resolveEditableWorkStateValues(
+        factoryWithWorkStateRoutes,
+        "story:missing",
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("applyEditableWorkStateDraft", () => {
+  it("renames the work state and propagates workstation route references", () => {
+    const updatedFactory = applyEditableWorkStateDraft(
+      factoryWithWorkStateRoutes,
+      "story:queued",
+      {
+        name: "ready",
+        type: "INITIAL",
+      },
+    );
+
+    expect(updatedFactory?.workTypes?.[0]?.states).toEqual([
+      { name: "ready", type: "INITIAL" },
+      { name: "done", type: "TERMINAL" },
+    ]);
+    expect(updatedFactory?.workstations?.[0]).toMatchObject({
+      inputs: [{ state: "ready", workType: "story" }],
+      onContinue: [{ state: "ready", workType: "story" }],
+      onFailure: [{ state: "ready", workType: "story" }],
+      onRejection: [{ state: "ready", workType: "story" }],
+      outputs: [{ state: "done", workType: "story" }],
+    });
+    expect(
+      updatedFactory?.workstations?.[1]?.classificationRoutes?.[0]?.outputs,
+    ).toEqual([{ state: "ready", workType: "story" }]);
+    expect(updatedFactory?.workstations?.[2]?.inputs).toEqual([
+      { state: "queued", workType: "task" },
+    ]);
+  });
+
+  it("preserves lifecycle type when only the name changes", () => {
+    const updatedFactory = applyEditableWorkStateDraft(
+      factoryWithWorkStateRoutes,
+      "story:done",
+      editableWorkStateDraftFromValues({
+        stateName: "done",
+        stateNamesInWorkType: ["queued", "done"],
+        stateType: "TERMINAL",
+        workTypeName: "story",
+      }),
+    );
+
+    expect(updatedFactory?.workTypes?.[0]?.states[1]).toEqual({
+      name: "done",
+      type: "TERMINAL",
+    });
+  });
+
+  it("returns null when the place id does not resolve", () => {
+    expect(
+      applyEditableWorkStateDraft(factoryWithWorkStateRoutes, "story:missing", {
+        name: "ready",
+        type: "INITIAL",
+      }),
+    ).toBeNull();
+  });
+});

--- a/ui/src/features/current-factory-definition/lib/work-state-editable-values.ts
+++ b/ui/src/features/current-factory-definition/lib/work-state-editable-values.ts
@@ -1,0 +1,216 @@
+import type { CanonicalFactoryDefinition } from "../../../api/current-factory-definition";
+
+type CanonicalWorkType = NonNullable<
+  CanonicalFactoryDefinition["workTypes"]
+>[number];
+type CanonicalWorkState = CanonicalWorkType["states"][number];
+type CanonicalWorkstation = NonNullable<
+  CanonicalFactoryDefinition["workstations"]
+>[number];
+type CanonicalWorkstationIO = CanonicalWorkstation["inputs"][number];
+type WorkStateType = CanonicalWorkState["type"];
+
+export interface EditableWorkStateValues {
+  stateName: string;
+  stateNamesInWorkType: string[];
+  stateType: WorkStateType;
+  workTypeName: string;
+}
+
+export interface EditableWorkStateDraft {
+  name: string;
+  type: WorkStateType;
+}
+
+export function resolveEditableWorkStateValues(
+  factory: CanonicalFactoryDefinition,
+  placeId: string,
+): EditableWorkStateValues | null {
+  const resolution = resolveWorkStateFromPlaceId(factory, placeId);
+  if (!resolution) {
+    return null;
+  }
+
+  const { workType, state } = resolution;
+
+  return {
+    stateName: state.name,
+    stateNamesInWorkType: workType.states.map((entry) => entry.name),
+    stateType: state.type,
+    workTypeName: workType.name,
+  };
+}
+
+export function editableWorkStateDraftFromValues(
+  values: EditableWorkStateValues,
+): EditableWorkStateDraft {
+  return {
+    name: values.stateName,
+    type: values.stateType,
+  };
+}
+
+export function applyEditableWorkStateDraft(
+  factory: CanonicalFactoryDefinition,
+  placeId: string,
+  draft: EditableWorkStateDraft,
+): CanonicalFactoryDefinition | null {
+  const resolution = resolveWorkStateFromPlaceId(factory, placeId);
+  if (!resolution) {
+    return null;
+  }
+
+  const trimmedName = draft.name.trim();
+  const originalStateName = resolution.state.name;
+  const { workType, workTypeIndex, stateIndex } = resolution;
+
+  const nextWorkTypes = (factory.workTypes ?? []).map(
+    (workTypeEntry, index) => {
+      if (index !== workTypeIndex) {
+        return workTypeEntry;
+      }
+
+      return {
+        ...workTypeEntry,
+        states: workTypeEntry.states.map((state, stateEntryIndex) =>
+          stateEntryIndex === stateIndex
+            ? {
+                ...state,
+                name: trimmedName,
+                type: draft.type,
+              }
+            : state,
+        ),
+      };
+    },
+  );
+
+  const nextWorkstations = (factory.workstations ?? []).map((workstation) =>
+    rewriteWorkstationStateReferences(
+      workstation,
+      workType.name,
+      originalStateName,
+      trimmedName,
+    ),
+  );
+
+  return {
+    ...factory,
+    workTypes: nextWorkTypes,
+    workstations: nextWorkstations,
+  };
+}
+
+function resolveWorkStateFromPlaceId(
+  factory: CanonicalFactoryDefinition,
+  placeId: string,
+): {
+  state: CanonicalWorkState;
+  stateIndex: number;
+  workType: CanonicalWorkType;
+  workTypeIndex: number;
+} | null {
+  const workTypes = factory.workTypes ?? [];
+
+  for (const [workTypeIndex, workType] of workTypes.entries()) {
+    for (const [stateIndex, state] of workType.states.entries()) {
+      if (workStatePlaceId(workType.name, state.name) !== placeId) {
+        continue;
+      }
+
+      return {
+        state,
+        stateIndex,
+        workType,
+        workTypeIndex,
+      };
+    }
+  }
+
+  return null;
+}
+
+function workStatePlaceId(workTypeName: string, stateName: string): string {
+  return `${workTypeName}:${stateName}`;
+}
+
+function rewriteWorkstationStateReferences(
+  workstation: CanonicalWorkstation,
+  workTypeName: string,
+  originalStateName: string,
+  nextStateName: string,
+): CanonicalWorkstation {
+  return {
+    ...workstation,
+    classificationRoutes: workstation.classificationRoutes?.map((route) => ({
+      ...route,
+      outputs: rewriteRequiredWorkstationIORoutes(
+        route.outputs,
+        workTypeName,
+        originalStateName,
+        nextStateName,
+      ),
+    })),
+    inputs: rewriteRequiredWorkstationIORoutes(
+      workstation.inputs,
+      workTypeName,
+      originalStateName,
+      nextStateName,
+    ),
+    onContinue: rewriteOptionalWorkstationIORoutes(
+      workstation.onContinue,
+      workTypeName,
+      originalStateName,
+      nextStateName,
+    ),
+    onFailure: rewriteOptionalWorkstationIORoutes(
+      workstation.onFailure,
+      workTypeName,
+      originalStateName,
+      nextStateName,
+    ),
+    onRejection: rewriteOptionalWorkstationIORoutes(
+      workstation.onRejection,
+      workTypeName,
+      originalStateName,
+      nextStateName,
+    ),
+    outputs: rewriteOptionalWorkstationIORoutes(
+      workstation.outputs,
+      workTypeName,
+      originalStateName,
+      nextStateName,
+    ),
+  };
+}
+
+function rewriteRequiredWorkstationIORoutes(
+  routes: CanonicalWorkstationIO[],
+  workTypeName: string,
+  originalStateName: string,
+  nextStateName: string,
+): CanonicalWorkstationIO[] {
+  return routes.map((route) =>
+    route.workType === workTypeName && route.state === originalStateName
+      ? { ...route, state: nextStateName }
+      : route,
+  );
+}
+
+function rewriteOptionalWorkstationIORoutes(
+  routes: CanonicalWorkstationIO[] | undefined,
+  workTypeName: string,
+  originalStateName: string,
+  nextStateName: string,
+): CanonicalWorkstationIO[] | undefined {
+  if (!routes) {
+    return routes;
+  }
+
+  return rewriteRequiredWorkstationIORoutes(
+    routes,
+    workTypeName,
+    originalStateName,
+    nextStateName,
+  );
+}

--- a/ui/src/features/current-selection/base/components/detail-card-save-test-helpers.ts
+++ b/ui/src/features/current-selection/base/components/detail-card-save-test-helpers.ts
@@ -241,6 +241,28 @@ export function buildDetailCardCurrentSelection(
   };
 }
 
+export function buildDetailCardWorkStateFactoryDocument(
+  overrides?: Partial<CurrentFactoryDocument>,
+): CurrentFactoryDocument {
+  return {
+    name: "Current Factory",
+    version: { ...DETAIL_CARD_SAVE_FACTORY_VERSION },
+    workers: [],
+    workstations: [],
+    workTypes: [
+      {
+        name: "story",
+        states: [
+          { name: "implemented", type: "PROCESSING" },
+          { name: "complete", type: "TERMINAL" },
+          { name: "blocked", type: "FAILED" },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
 export function buildDetailCardWorkstationNodeSelection(
   nodeId = semanticWorkflowDashboardSnapshot.topology.workstation_nodes_by_id
     .review.node_id,

--- a/ui/src/features/current-selection/base/components/detail-card-test-helpers.tsx
+++ b/ui/src/features/current-selection/base/components/detail-card-test-helpers.tsx
@@ -82,6 +82,7 @@ export {
   buildDetailCardFactoryDocumentSaveHookReturn,
   buildDetailCardMultiWorkstationFactoryDocument,
   buildDetailCardSharedWorkerFactoryDocument,
+  buildDetailCardWorkStateFactoryDocument,
   buildDetailCardWorkstationNodeSelection,
   createDetailCardDeferredFactoryDocumentSave,
   DETAIL_CARD_SAVE_FACTORY_VERSION,

--- a/ui/src/features/current-selection/components/current-selection-widget.save.test.tsx
+++ b/ui/src/features/current-selection/components/current-selection-widget.save.test.tsx
@@ -15,6 +15,7 @@ import {
   buildDetailCardFactoryDocumentSaveHookReturn,
   buildDetailCardMultiWorkstationFactoryDocument,
   buildDetailCardSharedWorkerFactoryDocument,
+  buildDetailCardWorkStateFactoryDocument,
   createDetailCardDeferredFactoryDocumentSave,
   DETAIL_CARD_NOW,
   DETAIL_CARD_SAVE_FACTORY_VERSION,
@@ -1145,6 +1146,128 @@ describe("CurrentSelectionWidget workstation save flow", () => {
   });
 });
 
+describe("CurrentSelectionWidget work state save flow", () => {
+  beforeEach(() => {
+    resetSelectionHistoryStore();
+    saveCurrentFactoryMutation.mockReset();
+    vi.mocked(useCurrentFactoryDocument).mockReturnValue(
+      buildDetailCardFactoryDocumentQueryResult(
+        buildDetailCardWorkStateFactoryDocument(),
+      ),
+    );
+    vi.mocked(useFactoryDocumentSave).mockReturnValue(
+      buildDetailCardFactoryDocumentSaveHookReturn(
+        saveCurrentFactoryMutation,
+      ) as never,
+    );
+  });
+
+  afterEach(() => {
+    resetSelectionHistoryStore();
+  });
+
+  it("wires header save for editable work state rename and blocks duplicate names", async () => {
+    const snapshot = semanticWorkflowDashboardSnapshot;
+    const selectedStatePlace =
+      snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
+        (place) => place.place_id === "story:implemented",
+      );
+
+    if (!selectedStatePlace) {
+      throw new Error("expected implemented state fixture");
+    }
+
+    renderWorkStateSelection(selectedStatePlace);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("State name")).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByLabelText("State name"), {
+      target: { value: "complete" },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen
+          .getByRole("button", { name: "Save work state" })
+          .getAttribute("disabled"),
+      ).not.toBeNull();
+    });
+    expect(
+      screen.getByText(
+        'A work state named "complete" already exists for this work type.',
+      ),
+    ).toBeTruthy();
+  });
+
+  it("persists work state rename inline and updates selection to the new place id", async () => {
+    const snapshot = semanticWorkflowDashboardSnapshot;
+    const selectedStatePlace =
+      snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
+        (place) => place.place_id === "story:implemented",
+      );
+    const selectStateNode = vi.fn();
+    const savedFactory = buildDetailCardWorkStateFactoryDocument({
+      workTypes: [
+        {
+          name: "story",
+          states: [
+            { name: "ready", type: "PROCESSING" },
+            { name: "complete", type: "TERMINAL" },
+            { name: "blocked", type: "FAILED" },
+          ],
+        },
+      ],
+    });
+
+    if (!selectedStatePlace) {
+      throw new Error("expected implemented state fixture");
+    }
+
+    saveCurrentFactoryMutation.mockResolvedValue(savedFactory);
+
+    renderWorkStateSelection(selectedStatePlace, selectStateNode);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("State name")).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByLabelText("State name"), {
+      target: { value: "ready" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save work state" }));
+
+    await waitFor(() => {
+      expect(saveCurrentFactoryMutation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseVersion: DETAIL_CARD_SAVE_FACTORY_VERSION,
+          factory: expect.objectContaining({
+            workTypes: [
+              expect.objectContaining({
+                name: "story",
+                states: expect.arrayContaining([
+                  expect.objectContaining({ name: "ready", type: "PROCESSING" }),
+                ]),
+              }),
+            ],
+          }),
+        }),
+      );
+    });
+    await waitFor(() => {
+      expect(selectStateNode).toHaveBeenCalledWith("story:ready");
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Running factory saved. ready was updated in the running factory definition.",
+        ),
+      ).toBeTruthy();
+    });
+  });
+});
+
 describe("CurrentSelectionWidget worker save flow", () => {
   beforeEach(() => {
     resetSelectionHistoryStore();
@@ -1238,6 +1361,28 @@ function renderWorkerSelection() {
       currentSelection={buildDetailCardCurrentSelection({
         selectedWorkerName: "reviewer",
         selection: { kind: "worker", workerName: "reviewer" },
+      })}
+      now={DETAIL_CARD_NOW}
+      selectedWorkExecutionDetails={null}
+    />,
+  );
+}
+
+function renderWorkStateSelection(
+  selectedStatePlace: NonNullable<
+    ReturnType<typeof buildDetailCardCurrentSelection>["selectedStatePlace"]
+  >,
+  selectStateNode: ReturnType<typeof vi.fn> = vi.fn(),
+) {
+  return renderWithQueryClient(
+    <CurrentSelectionWidget
+      currentSelection={buildDetailCardCurrentSelection({
+        selectStateNode,
+        selectedStatePlace,
+        selection: {
+          kind: "state-node",
+          placeId: selectedStatePlace.place_id,
+        },
       })}
       now={DETAIL_CARD_NOW}
       selectedWorkExecutionDetails={null}

--- a/ui/src/features/current-selection/components/current-selection-widget.tsx
+++ b/ui/src/features/current-selection/components/current-selection-widget.tsx
@@ -238,6 +238,7 @@ function renderCurrentSelectionDetailCard({
   return <NoSelectionDetailCard widgetId={widgetId} />;
 }
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: widget wires editable workstation, worker, and work-state save hooks into one selection detail surface.
 export function CurrentSelectionWidget({
   activeTraceID,
   currentSelection,

--- a/ui/src/features/current-selection/components/current-selection-widget.tsx
+++ b/ui/src/features/current-selection/components/current-selection-widget.tsx
@@ -27,6 +27,9 @@ import {
   EditableWorkstationSaveHeaderAction,
   WorkstationDetailCard,
 } from "../workstation-selection/public";
+import { useEditableWorkStateConfigurationState } from "../work-state-selection/hooks/use-editable-work-state-configuration-state";
+import { useSaveEditableWorkStateConfiguration } from "../work-state-selection/hooks/use-save-editable-work-state-configuration";
+import { EditableWorkStateSaveHeaderAction } from "../work-state-selection/public";
 import {
   NoSelectionDetailCard,
   StateNodeDetailCard,
@@ -56,6 +59,7 @@ function renderCurrentSelectionDetailCard({
   activeTraceID,
   currentSelection,
   editableConfigurationState,
+  editableWorkStateConfigurationState,
   editableWorkerConfigurationState,
   failedWorkDetailsByWorkID,
   headerAction,
@@ -63,6 +67,8 @@ function renderCurrentSelectionDetailCard({
   now,
   onSelectTraceID,
   saveState,
+  workStateHeaderAction,
+  workStateSaveState,
   workerHeaderAction,
   workerSaveState,
   selectedProviderSessionKey,
@@ -77,6 +83,9 @@ function renderCurrentSelectionDetailCard({
   editableConfigurationState: ReturnType<
     typeof useEditableWorkstationConfigurationState
   >;
+  editableWorkStateConfigurationState: ReturnType<
+    typeof useEditableWorkStateConfigurationState
+  >;
   editableWorkerConfigurationState: ReturnType<
     typeof useEditableWorkerConfigurationState
   >;
@@ -85,6 +94,10 @@ function renderCurrentSelectionDetailCard({
   locale?: string;
   now: number;
   onSelectTraceID?: (traceID: string) => void;
+  workStateHeaderAction: ReactNode;
+  workStateSaveState: ReturnType<
+    typeof useSaveEditableWorkStateConfiguration
+  >["saveState"];
   workerHeaderAction: ReactNode;
   saveState: ReturnType<
     typeof useSaveEditableWorkstationConfiguration
@@ -156,12 +169,15 @@ function renderCurrentSelectionDetailCard({
     return (
       <StateNodeDetailCard
         currentWorkItems={selectedStateCurrentWorkItems}
+        editableConfigurationState={editableWorkStateConfigurationState}
         failedWorkDetailsByWorkID={failedWorkDetailsByWorkID}
+        headerAction={workStateHeaderAction}
         locale={locale}
         onSelectWorkItem={(workItem) =>
           selectStateWorkItem(selectedStatePlace, workItem)
         }
         place={selectedStatePlace}
+        saveState={workStateSaveState}
         terminalHistoryWorkItems={selectedStateTerminalHistoryWorkItems}
         tokenCount={selectedStateTokenCount}
         widgetId={widgetId}
@@ -250,6 +266,10 @@ export function CurrentSelectionWidget({
     selectedNode,
     locale,
   );
+  const workStatePlaceId =
+    selection?.kind === "state-node" ? selection.placeId : null;
+  const editableWorkStateConfigurationState =
+    useEditableWorkStateConfigurationState(selection, workStatePlaceId, locale);
   const editableWorkerConfigurationState = useEditableWorkerConfigurationState(
     selection,
     selectedWorkerName,
@@ -268,6 +288,12 @@ export function CurrentSelectionWidget({
     selection?.kind === "worker" && selectedWorkerName
       ? selectedWorkerName
       : null;
+  const workStateSave = useSaveEditableWorkStateConfiguration({
+    editableConfigurationState: editableWorkStateConfigurationState,
+    locale,
+    onWorkStateRenamed: currentSelection.selectStateNode,
+    scopeKey: workStatePlaceId,
+  });
   const workerSave = useSaveEditableWorkerConfiguration({
     editableConfigurationState: editableWorkerConfigurationState,
     locale,
@@ -294,6 +320,14 @@ export function CurrentSelectionWidget({
       saveState={workstationSave.saveState}
     />
   );
+  const workStateHeaderAction = (
+    <EditableWorkStateSaveHeaderAction
+      canSave={workStateSave.canSave}
+      locale={locale ?? undefined}
+      onClick={() => void workStateSave.save()}
+      saveState={workStateSave.saveState}
+    />
+  );
   const workerHeaderAction = (
     <EditableWorkerSaveHeaderAction
       canSave={workerSave.canSave}
@@ -306,12 +340,15 @@ export function CurrentSelectionWidget({
     activeTraceID,
     currentSelection,
     editableConfigurationState,
+    editableWorkStateConfigurationState,
     editableWorkerConfigurationState,
     failedWorkDetailsByWorkID,
     headerAction: workstationHeaderAction,
     locale: locale ?? undefined,
     now,
     onSelectTraceID,
+    workStateHeaderAction,
+    workStateSaveState: workStateSave.saveState,
     workerHeaderAction,
     saveState: workstationSave.saveState,
     selectedProviderSessionKey,

--- a/ui/src/features/current-selection/work-state-selection/components/state-node-detail.test.tsx
+++ b/ui/src/features/current-selection/work-state-selection/components/state-node-detail.test.tsx
@@ -1,9 +1,16 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
+import type { CurrentFactoryDocument } from "../../../../api/current-factory-definition";
 import { semanticWorkflowDashboardSnapshot } from "../../../../components/dashboard/test-fixtures";
 import { WIDGET_SUBTITLE_CLASS } from "../../../../components/ui/widget-frame";
 import { formatLocalDateTime } from "../../../../components/ui/formatters";
 import { describe, expect, it, vi } from "vitest";
 import { CurrentSelectionLocaleProvider } from "../../base/components/current-selection-locale";
+import type {
+  EditableWorkStateConfigurationState,
+  EditableWorkStateSaveState,
+} from "../lib/detail-card-types";
+import { getWorkStateDetailMessages } from "../messages/work-state-detail";
+import { EditableWorkStateSaveHeaderAction } from "./work-state-save-controls";
 import { StateNodeDetailCard } from "./state-node-detail";
 
 function requireValue<T>(value: T | null | undefined, message: string): T {
@@ -339,5 +346,198 @@ describe("StateNodeDetailCard", () => {
         `开始时间 ${formatLocalDateTime(activeStoryStartedAt, "不可用", "zh-CN")}`,
       ),
     ).toBeTruthy();
+  });
+});
+
+function buildFactoryDocument(
+  overrides?: Partial<CurrentFactoryDocument>,
+): CurrentFactoryDocument {
+  return {
+    name: "Current Factory",
+    version: {
+      logical: "7",
+      physical: "2026-05-23T16:22:24Z",
+    },
+    workers: [],
+    workstations: [],
+    workTypes: [
+      {
+        name: "story",
+        states: [
+          { name: "implemented", type: "PROCESSING" },
+          { name: "complete", type: "TERMINAL" },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function buildWorkStateHeaderSaveAction({
+  canSave,
+  onClick = vi.fn(),
+  saveState = { status: "idle" },
+}: {
+  canSave: boolean;
+  onClick?: () => void;
+  saveState?: EditableWorkStateSaveState;
+}) {
+  return (
+    <EditableWorkStateSaveHeaderAction
+      canSave={canSave}
+      onClick={onClick}
+      saveState={saveState}
+    />
+  );
+}
+
+describe("StateNodeDetailCard editable work state configuration", () => {
+  const messages = getWorkStateDetailMessages();
+
+  it("renders editable name and read-only lifecycle type when configuration state is ready", () => {
+    const snapshot = semanticWorkflowDashboardSnapshot;
+    const selectedState = snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
+      (place) => place.place_id === "story:implemented",
+    );
+    const resolvedSelectedState = requireValue(selectedState, "expected implemented state fixture");
+    const editableConfigurationState: EditableWorkStateConfigurationState = {
+      baseVersion: buildFactoryDocument().version,
+      canSave: false,
+      draft: {
+        name: "implemented",
+        type: "PROCESSING",
+      },
+      hasValidationErrors: false,
+      initialValues: {
+        stateName: "implemented",
+        stateNamesInWorkType: ["implemented", "complete"],
+        stateType: "PROCESSING",
+        workTypeName: "story",
+      },
+      isDirty: false,
+      markChangesSaved: vi.fn(),
+      onNameChange: vi.fn(),
+      onResetToLatest: vi.fn(),
+      originalStateName: "implemented",
+      pendingFactoryDefinition: buildFactoryDocument(),
+      status: "ready",
+      validationErrors: {},
+      workTypeName: "story",
+    };
+
+    render(
+      <StateNodeDetailCard
+        currentWorkItems={[]}
+        editableConfigurationState={editableConfigurationState}
+        headerAction={buildWorkStateHeaderSaveAction({ canSave: false })}
+        place={resolvedSelectedState}
+        tokenCount={0}
+      />,
+    );
+
+    expect(screen.getByLabelText(messages.nameFieldLabel)).toBeTruthy();
+    expect(screen.getByText(messages.localizeWorkStateType("PROCESSING"))).toBeTruthy();
+    expect(screen.queryByText("story: implemented")).toBeNull();
+    expect(screen.getByText(messages.editableConfigurationHeading)).toBeTruthy();
+  });
+
+  it("shows duplicate-name validation with aria-invalid and role alert", () => {
+    const snapshot = semanticWorkflowDashboardSnapshot;
+    const selectedState = snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
+      (place) => place.place_id === "story:implemented",
+    );
+    const resolvedSelectedState = requireValue(selectedState, "expected implemented state fixture");
+    const duplicateMessage = messages.editableConfigurationNameDuplicate("complete");
+
+    render(
+      <StateNodeDetailCard
+        currentWorkItems={[]}
+        editableConfigurationState={{
+          baseVersion: buildFactoryDocument().version,
+          canSave: false,
+          draft: {
+            name: "complete",
+            type: "PROCESSING",
+          },
+          hasValidationErrors: true,
+          initialValues: {
+            stateName: "implemented",
+            stateNamesInWorkType: ["implemented", "complete"],
+            stateType: "PROCESSING",
+            workTypeName: "story",
+          },
+          isDirty: true,
+          markChangesSaved: vi.fn(),
+          onNameChange: vi.fn(),
+          onResetToLatest: vi.fn(),
+          originalStateName: "implemented",
+          pendingFactoryDefinition: buildFactoryDocument(),
+          status: "ready",
+          validationErrors: {
+            name: duplicateMessage,
+          },
+          workTypeName: "story",
+        }}
+        headerAction={buildWorkStateHeaderSaveAction({ canSave: false })}
+        place={resolvedSelectedState}
+        tokenCount={0}
+      />,
+    );
+
+    const nameInput = screen.getByLabelText(messages.nameFieldLabel);
+    expect(nameInput.getAttribute("aria-invalid")).toBe("true");
+    expect(screen.getByText(duplicateMessage)).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: messages.editableConfigurationSaveAction })
+        .getAttribute("disabled"),
+    ).not.toBeNull();
+  });
+
+  it("keeps runtime work list content when editable configuration is ready", () => {
+    const snapshot = semanticWorkflowDashboardSnapshot;
+    const selectedState = snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
+      (place) => place.place_id === "story:implemented",
+    );
+    const resolvedSelectedState = requireValue(selectedState, "expected implemented state fixture");
+
+    render(
+      <StateNodeDetailCard
+        currentWorkItems={[
+          {
+            display_name: "Active Story",
+            work_id: "work-active-story",
+          },
+        ]}
+        editableConfigurationState={{
+          baseVersion: buildFactoryDocument().version,
+          canSave: false,
+          draft: {
+            name: "implemented",
+            type: "PROCESSING",
+          },
+          hasValidationErrors: false,
+          initialValues: {
+            stateName: "implemented",
+            stateNamesInWorkType: ["implemented", "complete"],
+            stateType: "PROCESSING",
+            workTypeName: "story",
+          },
+          isDirty: false,
+          markChangesSaved: vi.fn(),
+          onNameChange: vi.fn(),
+          onResetToLatest: vi.fn(),
+          originalStateName: "implemented",
+          pendingFactoryDefinition: buildFactoryDocument(),
+          status: "ready",
+          validationErrors: {},
+          workTypeName: "story",
+        }}
+        place={resolvedSelectedState}
+        tokenCount={1}
+      />,
+    );
+
+    expect(screen.getByText("Current work")).toBeTruthy();
+    expect(screen.getByText("Active Story")).toBeTruthy();
   });
 });

--- a/ui/src/features/current-selection/work-state-selection/components/state-node-detail.tsx
+++ b/ui/src/features/current-selection/work-state-selection/components/state-node-detail.tsx
@@ -22,20 +22,24 @@ import {
   useCurrentSelectionDetailMessages,
   useCurrentSelectionLocale,
 } from "../../base/components/current-selection-locale";
-import { getWorkStateDetailMessages } from "../messages/work-state-detail";
 import type {
   StateNodeDetailCardProps,
   StatePositionWorkListItemProps,
   StatePositionWorkListProps,
 } from "../lib/detail-card-types";
+import { getWorkStateDetailMessages } from "../messages/work-state-detail";
+import { WorkStateEditableConfigurationSection } from "./work-state-editable-configuration-section";
 import { WorkStateTopologyDeleteSection } from "./work-state-topology-delete-section";
 
 export function StateNodeDetailCard({
   currentWorkItems,
+  editableConfigurationState,
   failedWorkDetailsByWorkID,
+  headerAction,
   locale,
   onSelectWorkItem,
   place,
+  saveState,
   terminalHistoryWorkItems = [],
   tokenCount,
   widgetId = "current-selection",
@@ -46,22 +50,32 @@ export function StateNodeDetailCard({
     ? terminalHistoryWorkItems
     : currentWorkItems;
   const messages = useCurrentSelectionDetailMessages();
-  const topologyMessages = getWorkStateDetailMessages(locale);
+  const workStateMessages = getWorkStateDetailMessages(locale);
   const workTypeName = place.type_id?.trim() ?? "";
   const stateName = place.state_value?.trim() ?? "";
   const summaryLabel = formatStateSelectionSummary(
     place.type_id,
     place.state_value,
   );
+  const showRuntimeSummary = editableConfigurationState?.status !== "ready";
 
   return (
-    <SelectionDetailLayout widgetId={widgetId}>
-      <div className="mt-0 grid gap-1" title={placeLabel}>
-        <p className={WIDGET_SUBTITLE_CLASS}>{summaryLabel || placeLabel}</p>
-      </div>
+    <SelectionDetailLayout headerAction={headerAction} widgetId={widgetId}>
+      {showRuntimeSummary ? (
+        <div className="mt-0 grid gap-1" title={placeLabel}>
+          <p className={WIDGET_SUBTITLE_CLASS}>{summaryLabel || placeLabel}</p>
+        </div>
+      ) : null}
+      {editableConfigurationState ? (
+        <WorkStateEditableConfigurationSection
+          messages={workStateMessages}
+          saveState={saveState}
+          state={editableConfigurationState}
+        />
+      ) : null}
       {workTypeName && stateName ? (
         <WorkStateTopologyDeleteSection
-          messages={topologyMessages}
+          messages={workStateMessages}
           placeId={place.place_id}
           stateName={stateName}
           workTypeName={workTypeName}

--- a/ui/src/features/current-selection/work-state-selection/components/work-state-editable-configuration-section.tsx
+++ b/ui/src/features/current-selection/work-state-selection/components/work-state-editable-configuration-section.tsx
@@ -1,0 +1,235 @@
+import type { ReactNode } from "react";
+
+import { DashboardActionButton, DashboardActionRow } from "../../../../components/ui";
+import {
+  DASHBOARD_BODY_TEXT_CLASS,
+  DASHBOARD_SUPPORTING_LABEL_CLASS,
+  DASHBOARD_SUPPORTING_TEXT_CLASS,
+} from "../../../../components/ui/dashboard-typography";
+import { cn } from "../../../../lib/cn";
+import {
+  DetailCardFactorySaveFeedback,
+  mergeDetailCardSaveFieldErrors,
+} from "../../base/components/detail-card-factory-save-feedback";
+import {
+  CURRENT_SELECTION_FIELD_PANEL_CLASS,
+  CurrentSelectionSectionHeader,
+} from "../../base/components/detail-card-shared";
+import type {
+  EditableWorkStateConfigurationState,
+  EditableWorkStateSaveState,
+  EditableWorkStateSaveValidationErrors,
+} from "../lib/detail-card-types";
+import type { EditableWorkStateValidationErrors } from "../lib/work-state-editable-validation";
+import type { getWorkStateDetailMessages } from "../messages/work-state-detail";
+
+export function WorkStateEditableConfigurationSection({
+  messages,
+  saveState,
+  state,
+}: {
+  messages: ReturnType<typeof getWorkStateDetailMessages>;
+  saveState?: EditableWorkStateSaveState;
+  state?: EditableWorkStateConfigurationState;
+}) {
+  const headingId = "editable-work-state-configuration-heading";
+
+  return (
+    <section aria-labelledby={headingId} className="mt-0 grid gap-2.5 [&_h4]:m-0">
+      <CurrentSelectionSectionHeader
+        headingId={headingId}
+        title={messages.editableConfigurationHeading}
+      />
+      <div className="grid gap-2.5">
+        {state?.status === "loading" ? (
+          <p className={cn("m-0 text-af-text-muted", DASHBOARD_BODY_TEXT_CLASS)}>
+            {messages.editableConfigurationLoading}
+          </p>
+        ) : null}
+        {state?.status === "error" ? (
+          <p
+            className={cn("m-0 text-af-danger-text", DASHBOARD_BODY_TEXT_CLASS)}
+            role="alert"
+          >
+            {messages.editableConfigurationErrorPrefix} {state.errorMessage}
+          </p>
+        ) : null}
+        {state?.status === "empty" ? (
+          <p className={cn("m-0 text-af-text-muted", DASHBOARD_BODY_TEXT_CLASS)}>
+            {state.message || messages.editableConfigurationEmpty}
+          </p>
+        ) : null}
+        {state?.status === "ready" ? (
+          <WorkStateEditableConfigurationReadyForm
+            messages={messages}
+            saveState={saveState}
+            state={state}
+          />
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function WorkStateEditableConfigurationReadyForm({
+  messages,
+  saveState,
+  state,
+}: {
+  messages: ReturnType<typeof getWorkStateDetailMessages>;
+  saveState?: EditableWorkStateSaveState;
+  state: Extract<EditableWorkStateConfigurationState, { status: "ready" }>;
+}) {
+  const validationErrors = mergeDetailCardSaveFieldErrors<
+    EditableWorkStateValidationErrors & Record<string, string | undefined>,
+    EditableWorkStateSaveValidationErrors
+  >(state.validationErrors, saveState);
+  const isSaving = saveState?.status === "submitting";
+  const displayStateName = state.draft.name.trim() || state.originalStateName;
+
+  return (
+    <form className="grid gap-3" onSubmit={(event) => event.preventDefault()}>
+      <DetailCardFactorySaveFeedback<EditableWorkStateSaveValidationErrors>
+        messages={{
+          errorPrefix: messages.editableConfigurationSaveErrorPrefix,
+          staleVersionDetail: messages.editableConfigurationSaveStaleVersionDetail,
+          successMessage: messages.editableConfigurationSaveSuccess(displayStateName),
+        }}
+        saveState={saveState}
+      />
+      {validationErrors.contract ? (
+        <p
+          className={cn("m-0 text-af-danger-text", DASHBOARD_BODY_TEXT_CLASS)}
+          role="alert"
+        >
+          {validationErrors.contract}
+        </p>
+      ) : null}
+      <WorkStateEditableConfigurationDraftStatus messages={messages} state={state} />
+      <WorkStateEditableConfigurationField
+        errorMessage={validationErrors.name}
+        fieldId="editable-work-state-name"
+        input={
+          <input
+            aria-describedby={
+              validationErrors.name ? "editable-work-state-name-error" : undefined
+            }
+            aria-invalid={validationErrors.name ? "true" : undefined}
+            className="w-full rounded-lg border border-af-border bg-af-surface px-3 py-2 text-sm text-af-text"
+            id="editable-work-state-name"
+            onChange={(event) => state.onNameChange(event.target.value)}
+            type="text"
+            value={state.draft.name}
+          />
+        }
+        label={messages.nameFieldLabel}
+      />
+      <WorkStateEditableConfigurationField
+        fieldId="editable-work-state-type"
+        input={
+          <output
+            className="block w-full rounded-lg border border-af-border bg-af-surface-subtle px-3 py-2 text-sm text-af-text-muted"
+            id="editable-work-state-type"
+          >
+            {messages.localizeWorkStateType(state.draft.type)}
+          </output>
+        }
+        label={messages.typeFieldLabel}
+      />
+      {state.isDirty ? (
+        <DashboardActionRow
+          actions={
+            <DashboardActionButton
+              disabled={isSaving}
+              onClick={state.onResetToLatest}
+              type="button"
+            >
+              {messages.discardDraftAction}
+            </DashboardActionButton>
+          }
+        />
+      ) : null}
+    </form>
+  );
+}
+
+function WorkStateEditableConfigurationDraftStatus({
+  messages,
+  state,
+}: {
+  messages: ReturnType<typeof getWorkStateDetailMessages>;
+  state: Extract<EditableWorkStateConfigurationState, { status: "ready" }>;
+}) {
+  return (
+    <div className={CURRENT_SELECTION_FIELD_PANEL_CLASS}>
+      <p
+        className={cn(
+          "m-0",
+          state.hasValidationErrors
+            ? "text-af-danger-text"
+            : "text-af-text-muted",
+          DASHBOARD_BODY_TEXT_CLASS,
+        )}
+        role={state.hasValidationErrors ? "alert" : "status"}
+      >
+        {state.hasValidationErrors
+          ? messages.editableConfigurationValidationStatus
+          : state.isDirty
+            ? messages.editableConfigurationDirtyStatus
+            : messages.editableConfigurationDraftNote}
+      </p>
+      {state.hasValidationErrors ? (
+        <p
+          className={cn(
+            "m-0 text-af-text-subtle",
+            DASHBOARD_SUPPORTING_TEXT_CLASS,
+          )}
+        >
+          {messages.editableConfigurationSaveDisabledValidationDetail}
+        </p>
+      ) : (
+        <p
+          className={cn(
+            "m-0 text-af-text-subtle",
+            DASHBOARD_SUPPORTING_TEXT_CLASS,
+          )}
+        >
+          {messages.editableConfigurationDraftNote}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function WorkStateEditableConfigurationField({
+  errorMessage,
+  fieldId,
+  input,
+  label,
+}: {
+  errorMessage?: string;
+  fieldId: string;
+  input: ReactNode;
+  label: string;
+}) {
+  return (
+    <div className={CURRENT_SELECTION_FIELD_PANEL_CLASS}>
+      <label className={DASHBOARD_SUPPORTING_LABEL_CLASS} htmlFor={fieldId}>
+        {label}
+      </label>
+      {input}
+      {errorMessage ? (
+        <p
+          className={cn(
+            "m-0 text-af-danger-text",
+            DASHBOARD_SUPPORTING_TEXT_CLASS,
+          )}
+          id={`${fieldId}-error`}
+          role="alert"
+        >
+          {errorMessage}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/src/features/current-selection/work-state-selection/components/work-state-save-controls.test.tsx
+++ b/ui/src/features/current-selection/work-state-selection/components/work-state-save-controls.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+
+import { EditableWorkStateSaveHeaderAction } from "./work-state-save-controls";
+
+describe("EditableWorkStateSaveHeaderAction", () => {
+  it("uses warning styling when save is available and not submitting", () => {
+    const { rerender } = render(
+      <EditableWorkStateSaveHeaderAction
+        canSave
+        onClick={() => undefined}
+        saveState={{ status: "idle" }}
+      />,
+    );
+
+    const saveButton = screen.getByRole("button", { name: "Save work state" });
+    expect(saveButton.className).toContain("border-af-warning-border");
+    expect(saveButton.className).toContain("bg-af-warning-surface");
+    expect(saveButton.className).toContain("text-af-warning-text");
+
+    rerender(
+      <EditableWorkStateSaveHeaderAction
+        canSave={false}
+        onClick={() => undefined}
+        saveState={{ status: "idle" }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Save work state" }).className,
+    ).not.toContain("border-af-warning-border");
+  });
+
+  it("does not use warning styling while save is submitting", () => {
+    render(
+      <EditableWorkStateSaveHeaderAction
+        canSave
+        onClick={() => undefined}
+        saveState={{ status: "submitting" }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Saving work state..." }).className,
+    ).not.toContain("border-af-warning-border");
+  });
+});

--- a/ui/src/features/current-selection/work-state-selection/components/work-state-save-controls.tsx
+++ b/ui/src/features/current-selection/work-state-selection/components/work-state-save-controls.tsx
@@ -1,0 +1,46 @@
+import { Save } from "lucide-react";
+
+import { DashboardActionButton } from "../../../../components/ui";
+import { cn } from "../../../../lib/cn";
+import type { EditableWorkStateSaveState } from "../lib/detail-card-types";
+import { getWorkStateDetailMessages } from "../messages/work-state-detail";
+
+export function EditableWorkStateSaveHeaderAction({
+  canSave,
+  locale,
+  onClick,
+  saveState,
+}: {
+  canSave: boolean;
+  locale?: string;
+  onClick: () => void;
+  saveState: EditableWorkStateSaveState;
+}) {
+  const messages = getWorkStateDetailMessages(locale);
+  const emphasizeSave = canSave && saveState.status !== "submitting";
+
+  return (
+    <DashboardActionButton
+      aria-label={
+        saveState.status === "submitting"
+          ? messages.editableConfigurationSaveBusyAction
+          : messages.editableConfigurationSaveAction
+      }
+      className={
+        emphasizeSave
+          ? cn(
+              "border-af-warning-border bg-af-warning-surface text-af-warning-text",
+              "hover:border-af-warning-border hover:bg-af-warning-surface hover:text-af-warning-text",
+            )
+          : undefined
+      }
+      disabled={!canSave}
+      executing={saveState.status === "submitting"}
+      iconOnly
+      onClick={onClick}
+      type="button"
+    >
+      <Save aria-hidden="true" className="size-4" />
+    </DashboardActionButton>
+  );
+}

--- a/ui/src/features/current-selection/work-state-selection/hooks/use-editable-work-state-configuration-state.test.tsx
+++ b/ui/src/features/current-selection/work-state-selection/hooks/use-editable-work-state-configuration-state.test.tsx
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/nursery/noExcessiveLinesPerFile lint/complexity/noExcessiveLinesPerFunction: editable work-state hook regressions share one mocked factory-document seam.
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { CurrentFactoryDocument } from "../../../../api/current-factory-definition";
 import { useCurrentFactoryDocument } from "../../../current-factory-definition/hooks/useCurrentFactoryDefinition";

--- a/ui/src/features/current-selection/work-state-selection/hooks/use-editable-work-state-configuration-state.test.tsx
+++ b/ui/src/features/current-selection/work-state-selection/hooks/use-editable-work-state-configuration-state.test.tsx
@@ -1,0 +1,260 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { CurrentFactoryDocument } from "../../../../api/current-factory-definition";
+import { useCurrentFactoryDocument } from "../../../current-factory-definition/hooks/useCurrentFactoryDefinition";
+import type { DashboardSelection } from "../../base/state/selection-types";
+import { useEditableWorkStateConfigurationState } from "./use-editable-work-state-configuration-state";
+
+vi.mock(
+  "../../../current-factory-definition/hooks/useCurrentFactoryDefinition",
+  async () => {
+    const actual = await vi.importActual(
+      "../../../current-factory-definition/hooks/useCurrentFactoryDefinition",
+    );
+
+    return {
+      ...actual,
+      useCurrentFactoryDocument: vi.fn(),
+    };
+  },
+);
+
+function buildFactoryDocument(
+  overrides?: Partial<CurrentFactoryDocument>,
+): CurrentFactoryDocument {
+  return {
+    name: "Current Factory",
+    version: {
+      logical: "7",
+      physical: "2026-05-23T16:22:24Z",
+    },
+    workers: [
+      {
+        modelProvider: "CURSOR",
+        name: "reviewer",
+        type: "MODEL_WORKER",
+      },
+    ],
+    workstations: [],
+    workTypes: [
+      {
+        name: "story",
+        states: [
+          { name: "queued", type: "INITIAL" },
+          { name: "done", type: "TERMINAL" },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("useEditableWorkStateConfigurationState", () => {
+  const queuedSelection: DashboardSelection = {
+    kind: "state-node",
+    placeId: "story:queued",
+  };
+
+  beforeEach(() => {
+    vi.mocked(useCurrentFactoryDocument).mockReturnValue({
+      data: buildFactoryDocument(),
+      error: null,
+      isError: false,
+      isPending: false,
+      status: "success",
+    } as never);
+  });
+
+  it("initializes editable work state draft values from the current factory document", () => {
+    const { result } = renderHook(() =>
+      useEditableWorkStateConfigurationState(queuedSelection, "story:queued"),
+    );
+
+    expect(result.current).toMatchObject({
+      status: "ready",
+      canSave: false,
+      draft: {
+        name: "queued",
+        type: "INITIAL",
+      },
+      hasValidationErrors: false,
+      isDirty: false,
+      originalStateName: "queued",
+      validationErrors: {},
+      workTypeName: "story",
+    });
+  });
+
+  it("detects dirty state when the work state name changes", () => {
+    const { result } = renderHook(() =>
+      useEditableWorkStateConfigurationState(queuedSelection, "story:queued"),
+    );
+
+    act(() => {
+      if (result.current?.status !== "ready") {
+        throw new Error("Expected ready editable work state");
+      }
+      result.current.onNameChange("ready");
+    });
+
+    expect(result.current).toMatchObject({
+      status: "ready",
+      canSave: true,
+      draft: {
+        name: "ready",
+        type: "INITIAL",
+      },
+      isDirty: true,
+    });
+  });
+
+  it("blocks save when the work state name duplicates another state in the work type", () => {
+    const { result } = renderHook(() =>
+      useEditableWorkStateConfigurationState(queuedSelection, "story:queued"),
+    );
+
+    act(() => {
+      if (result.current?.status !== "ready") {
+        throw new Error("Expected ready editable work state");
+      }
+      result.current.onNameChange("done");
+    });
+
+    expect(result.current).toMatchObject({
+      status: "ready",
+      canSave: false,
+      hasValidationErrors: true,
+      isDirty: true,
+      validationErrors: {
+        name: expect.stringContaining("done"),
+      },
+    });
+  });
+
+  it("builds a pending factory definition that renames the selected work state", () => {
+    const { result } = renderHook(() =>
+      useEditableWorkStateConfigurationState(queuedSelection, "story:queued"),
+    );
+
+    act(() => {
+      if (result.current?.status !== "ready") {
+        throw new Error("Expected ready editable work state");
+      }
+      result.current.onNameChange("ready");
+    });
+
+    expect(result.current?.status).toBe("ready");
+    if (result.current?.status !== "ready") {
+      return;
+    }
+
+    expect(
+      result.current.pendingFactoryDefinition?.workTypes?.[0]?.states,
+    ).toEqual([
+      { name: "ready", type: "INITIAL" },
+      { name: "done", type: "TERMINAL" },
+    ]);
+  });
+
+  it("markChangesSaved clears dirty state for the current draft", async () => {
+    const { result } = renderHook(() =>
+      useEditableWorkStateConfigurationState(queuedSelection, "story:queued"),
+    );
+
+    await waitFor(() => {
+      expect(result.current?.status).toBe("ready");
+    });
+
+    act(() => {
+      if (result.current?.status !== "ready") {
+        throw new Error("Expected ready editable work state");
+      }
+      result.current.onNameChange("ready");
+      result.current.markChangesSaved();
+    });
+
+    expect(result.current).toMatchObject({
+      status: "ready",
+      draft: {
+        name: "ready",
+        type: "INITIAL",
+      },
+      isDirty: false,
+    });
+  });
+
+  it("resets the editable work state draft when the selected place changes", async () => {
+    const doneSelection: DashboardSelection = {
+      kind: "state-node",
+      placeId: "story:done",
+    };
+
+    const { rerender, result } = renderHook(
+      ({
+        currentSelection,
+        currentPlaceId,
+      }: {
+        currentSelection: DashboardSelection;
+        currentPlaceId: string;
+      }) =>
+        useEditableWorkStateConfigurationState(
+          currentSelection,
+          currentPlaceId,
+        ),
+      {
+        initialProps: {
+          currentPlaceId: "story:queued",
+          currentSelection: queuedSelection,
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current?.status).toBe("ready");
+    });
+
+    act(() => {
+      if (result.current?.status !== "ready") {
+        throw new Error("Expected ready editable work state");
+      }
+      result.current.onNameChange("Keep this local queued draft.");
+    });
+
+    expect(result.current).toMatchObject({
+      draft: {
+        name: "Keep this local queued draft.",
+        type: "INITIAL",
+      },
+      isDirty: true,
+      status: "ready",
+    });
+
+    rerender({
+      currentPlaceId: "story:done",
+      currentSelection: doneSelection,
+    });
+
+    await waitFor(() => {
+      expect(result.current).toMatchObject({
+        draft: {
+          name: "done",
+          type: "TERMINAL",
+        },
+        isDirty: false,
+        originalStateName: "done",
+        status: "ready",
+        workTypeName: "story",
+      });
+    });
+  });
+
+  it("returns undefined when the selection is not a state node", () => {
+    const { result } = renderHook(() =>
+      useEditableWorkStateConfigurationState(
+        { kind: "worker", workerName: "reviewer" },
+        "story:queued",
+      ),
+    );
+
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/ui/src/features/current-selection/work-state-selection/hooks/use-editable-work-state-configuration-state.ts
+++ b/ui/src/features/current-selection/work-state-selection/hooks/use-editable-work-state-configuration-state.ts
@@ -1,0 +1,256 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { useCurrentFactoryDocument } from "../../../current-factory-definition/hooks/useCurrentFactoryDefinition";
+import {
+  applyEditableWorkStateDraft,
+  type EditableWorkStateDraft,
+  editableWorkStateDraftFromValues,
+  resolveEditableWorkStateValues,
+} from "../../../current-factory-definition/lib/work-state-editable-values";
+import type { DashboardSelection } from "../../base/state/selection-types";
+import type { EditableWorkStateConfigurationState } from "../lib/detail-card-types";
+import {
+  hasEditableWorkStateValidationErrors,
+  mergeEditableWorkStateContractValidationErrors,
+  validateEditableWorkStateDraft,
+} from "../lib/work-state-editable-validation";
+import { getWorkStateDetailMessages } from "../messages/work-state-detail";
+
+interface EditableWorkStateSessionState {
+  draft: EditableWorkStateDraft;
+  latestDefinitionDraft: EditableWorkStateDraft;
+  selectionKey: string;
+  sessionStartDraft: EditableWorkStateDraft;
+}
+
+export function useEditableWorkStateConfigurationState(
+  selection: DashboardSelection | null,
+  placeId: string | null,
+  locale?: string | null,
+): EditableWorkStateConfigurationState | undefined {
+  const isStateNodeSelection =
+    selection?.kind === "state-node" && placeId != null;
+  const messages = getWorkStateDetailMessages(locale);
+  const editableDefinition = useCurrentFactoryDocument(isStateNodeSelection);
+  const { selectedEditableValues, sessionState, setSessionState } =
+    useEditableWorkStateSession(
+      editableDefinition.data,
+      placeId,
+      isStateNodeSelection,
+    );
+
+  if (!isStateNodeSelection || !placeId) {
+    return undefined;
+  }
+
+  if (editableDefinition.isPending) {
+    return { status: "loading" };
+  }
+
+  if (editableDefinition.isError) {
+    return {
+      errorMessage: editableDefinition.error.message,
+      status: "error",
+    };
+  }
+
+  if (!editableDefinition.data || !selectedEditableValues || !sessionState) {
+    return {
+      message: messages.configurationEmpty,
+      status: "empty",
+    };
+  }
+
+  return buildReadyEditableWorkStateConfigurationState({
+    editableDefinition: editableDefinition.data,
+    placeId,
+    selectedEditableValues,
+    sessionState,
+    setSessionState,
+  });
+}
+
+function useEditableWorkStateSession(
+  editableDefinition: ReturnType<typeof useCurrentFactoryDocument>["data"],
+  placeId: string | null,
+  isStateNodeSelection: boolean,
+) {
+  const selectedEditableValues = useMemo(() => {
+    if (!isStateNodeSelection || !placeId || !editableDefinition) {
+      return null;
+    }
+
+    return resolveEditableWorkStateValues(editableDefinition, placeId);
+  }, [editableDefinition, isStateNodeSelection, placeId]);
+  const selectionKey = isStateNodeSelection && placeId ? placeId : null;
+  const [sessionState, setSessionState] =
+    useState<EditableWorkStateSessionState | null>(null);
+
+  useEffect(() => {
+    setSessionState((currentState) =>
+      syncEditableWorkStateSession(
+        currentState,
+        selectedEditableValues,
+        selectionKey,
+      ),
+    );
+  }, [selectedEditableValues, selectionKey]);
+
+  return {
+    selectedEditableValues,
+    sessionState,
+    setSessionState,
+  };
+}
+
+function buildReadyEditableWorkStateConfigurationState({
+  editableDefinition,
+  placeId,
+  selectedEditableValues,
+  sessionState,
+  setSessionState,
+}: {
+  editableDefinition: NonNullable<
+    ReturnType<typeof useCurrentFactoryDocument>["data"]
+  >;
+  placeId: string;
+  selectedEditableValues: NonNullable<
+    ReturnType<typeof resolveEditableWorkStateValues>
+  >;
+  sessionState: EditableWorkStateSessionState;
+  setSessionState: (
+    updater: (
+      currentState: EditableWorkStateSessionState | null,
+    ) => EditableWorkStateSessionState | null,
+  ) => void;
+}): Extract<EditableWorkStateConfigurationState, { status: "ready" }> {
+  const messages = getWorkStateDetailMessages();
+  const pendingFactoryDefinition = applyEditableWorkStateDraft(
+    editableDefinition,
+    placeId,
+    sessionState.draft,
+  );
+  const validationErrors = mergeEditableWorkStateContractValidationErrors(
+    validateEditableWorkStateDraft(sessionState.draft, messages, {
+      originalStateName: selectedEditableValues.stateName,
+      stateNamesInWorkType: selectedEditableValues.stateNamesInWorkType,
+    }),
+    pendingFactoryDefinition,
+    messages,
+  );
+  const hasValidationErrors =
+    hasEditableWorkStateValidationErrors(validationErrors);
+  const isDirty = !areEditableWorkStateDraftsEqual(
+    sessionState.draft,
+    sessionState.sessionStartDraft,
+  );
+
+  return {
+    baseVersion: editableDefinition.version,
+    canSave:
+      isDirty && !hasValidationErrors && pendingFactoryDefinition != null,
+    draft: sessionState.draft,
+    hasValidationErrors,
+    initialValues: selectedEditableValues,
+    isDirty,
+    markChangesSaved: () => {
+      setSessionState((currentState) =>
+        currentState
+          ? {
+              ...currentState,
+              latestDefinitionDraft: currentState.draft,
+              sessionStartDraft: currentState.draft,
+            }
+          : currentState,
+      );
+    },
+    onNameChange: (value) => {
+      updateDraft(setSessionState, (draft) => ({ ...draft, name: value }));
+    },
+    onResetToLatest: () => {
+      setSessionState((currentState) =>
+        currentState
+          ? {
+              ...currentState,
+              draft: currentState.latestDefinitionDraft,
+              sessionStartDraft: currentState.latestDefinitionDraft,
+            }
+          : currentState,
+      );
+    },
+    originalStateName: selectedEditableValues.stateName,
+    pendingFactoryDefinition,
+    status: "ready",
+    validationErrors,
+    workTypeName: selectedEditableValues.workTypeName,
+  };
+}
+
+function updateDraft(
+  setSessionState: (
+    updater: (
+      currentState: EditableWorkStateSessionState | null,
+    ) => EditableWorkStateSessionState | null,
+  ) => void,
+  updater: (draft: EditableWorkStateDraft) => EditableWorkStateDraft,
+) {
+  setSessionState((currentState) =>
+    currentState
+      ? {
+          ...currentState,
+          draft: updater(currentState.draft),
+        }
+      : currentState,
+  );
+}
+
+function areEditableWorkStateDraftsEqual(
+  left: EditableWorkStateDraft,
+  right: EditableWorkStateDraft,
+): boolean {
+  return left.name === right.name && left.type === right.type;
+}
+
+function syncEditableWorkStateSession(
+  currentState: EditableWorkStateSessionState | null,
+  selectedEditableValues: ReturnType<typeof resolveEditableWorkStateValues>,
+  selectionKey: string | null,
+): EditableWorkStateSessionState | null {
+  if (!selectionKey || !selectedEditableValues) {
+    return null;
+  }
+
+  const initialDraft = editableWorkStateDraftFromValues(selectedEditableValues);
+  if (!currentState || currentState.selectionKey !== selectionKey) {
+    return {
+      draft: initialDraft,
+      latestDefinitionDraft: initialDraft,
+      selectionKey,
+      sessionStartDraft: initialDraft,
+    };
+  }
+
+  if (
+    areEditableWorkStateDraftsEqual(
+      currentState.draft,
+      currentState.sessionStartDraft,
+    )
+  ) {
+    return {
+      draft: initialDraft,
+      latestDefinitionDraft: initialDraft,
+      selectionKey,
+      sessionStartDraft: initialDraft,
+    };
+  }
+
+  return areEditableWorkStateDraftsEqual(
+    currentState.latestDefinitionDraft,
+    initialDraft,
+  )
+    ? currentState
+    : {
+        ...currentState,
+        latestDefinitionDraft: initialDraft,
+      };
+}

--- a/ui/src/features/current-selection/work-state-selection/hooks/use-save-editable-work-state-configuration.test.tsx
+++ b/ui/src/features/current-selection/work-state-selection/hooks/use-save-editable-work-state-configuration.test.tsx
@@ -11,6 +11,7 @@ import {
 import { workStateFieldValidationTarget } from "../../../../testing/factory-validation-target-fixtures";
 import * as factoryDocumentSaveHooks from "../../../current-factory-definition/hooks/useFactoryDocumentSave";
 import { useDashboardSessionStore } from "../../../dashboard/state/dashboardSessionStore";
+import { useCurrentActivityGraphStore } from "../../../workflow-activity/state/currentActivityGraphStore";
 import type { EditableWorkStateConfigurationState } from "../lib/detail-card-types";
 import { useSaveEditableWorkStateConfiguration } from "./use-save-editable-work-state-configuration";
 
@@ -166,6 +167,8 @@ describe("useSaveEditableWorkStateConfiguration", () => {
   it("updates work state selection after a successful rename save", async () => {
     const markChangesSaved = vi.fn();
     const onWorkStateRenamed = vi.fn();
+    const migrateWorkStateNodePositions = vi.fn();
+    useCurrentActivityGraphStore.setState({ migrateWorkStateNodePositions });
     const saveMutation = mockFactoryDocumentSave({ mode: "success" });
     vi.spyOn(
       factoryDocumentSaveHooks,
@@ -217,6 +220,11 @@ describe("useSaveEditableWorkStateConfiguration", () => {
     });
 
     expect(markChangesSaved).toHaveBeenCalledTimes(1);
+    expect(migrateWorkStateNodePositions).toHaveBeenCalledWith({
+      nextStateName: "ready",
+      previousStateName: "queued",
+      workTypeName: "story",
+    });
     expect(onWorkStateRenamed).toHaveBeenCalledWith("story:ready");
   });
 

--- a/ui/src/features/current-selection/work-state-selection/hooks/use-save-editable-work-state-configuration.test.tsx
+++ b/ui/src/features/current-selection/work-state-selection/hooks/use-save-editable-work-state-configuration.test.tsx
@@ -1,0 +1,411 @@
+// biome-ignore-all lint/nursery/noExcessiveLinesPerFile lint/complexity/noExcessiveLinesPerFunction: focused save-hook regressions share one mocked mutation seam.
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import { CurrentFactoryDefinitionError } from "../../../../api/current-factory-definition";
+import {
+  mockFactoryDocumentSave,
+  mockPendingFactoryDocumentSave,
+} from "../../../../testing/factory-document-save-mocks";
+import { workStateFieldValidationTarget } from "../../../../testing/factory-validation-target-fixtures";
+import * as factoryDocumentSaveHooks from "../../../current-factory-definition/hooks/useFactoryDocumentSave";
+import { useDashboardSessionStore } from "../../../dashboard/state/dashboardSessionStore";
+import type { EditableWorkStateConfigurationState } from "../lib/detail-card-types";
+import { useSaveEditableWorkStateConfiguration } from "./use-save-editable-work-state-configuration";
+
+describe("useSaveEditableWorkStateConfiguration", () => {
+  beforeEach(() => {
+    useDashboardSessionStore.setState({ selectedSessionID: "~default" });
+    vi.restoreAllMocks();
+  });
+
+  it("uses localized fallback copy for unknown save errors", async () => {
+    const saveMutation = mockFactoryDocumentSave({
+      mode: "error",
+      rejectedError: "network unavailable",
+    });
+    vi.spyOn(
+      factoryDocumentSaveHooks,
+      "useFactoryDocumentSave",
+    ).mockReturnValue(saveMutation as never);
+    const saveAsync = saveMutation.saveAsync;
+
+    const { result } = renderHook(
+      () =>
+        useSaveEditableWorkStateConfiguration({
+          editableConfigurationState: buildReadyEditableConfigurationState(),
+          locale: "zh-CN",
+          scopeKey: "story:queued",
+        }),
+      { wrapper: createQueryClientWrapper() },
+    );
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    await waitFor(() => {
+      expect(result.current.saveState).toEqual({
+        errorMessage: "无法保存运行中的工厂。",
+        status: "error",
+      });
+    });
+    expect(saveAsync).toHaveBeenCalledWith({
+      baseVersion: {
+        logical: "7",
+        physical: "2026-05-23T15:52:00Z",
+      },
+      factory: {
+        name: "Current Factory",
+        workers: [
+          {
+            modelProvider: "CURSOR",
+            name: "reviewer",
+            type: "MODEL_WORKER",
+          },
+        ],
+        workTypes: [
+          {
+            name: "story",
+            states: [
+              { name: "queued", type: "INITIAL" },
+              { name: "done", type: "TERMINAL" },
+            ],
+          },
+        ],
+        workstations: [],
+      },
+    });
+  });
+
+  it("saves work state edits through the scoped factory document route", async () => {
+    useDashboardSessionStore.setState({ selectedSessionID: "session-beta" });
+    const markChangesSaved = vi.fn();
+    const saveMutation = mockFactoryDocumentSave({
+      mode: "success",
+      resolvedDocument: {
+        name: "Current Factory",
+        version: {
+          logical: "8",
+          physical: "2026-05-23T15:52:00.001Z",
+        },
+        workers: [
+          {
+            modelProvider: "CURSOR",
+            name: "reviewer",
+            type: "MODEL_WORKER",
+          },
+        ],
+        workstations: [],
+        workTypes: [
+          {
+            name: "story",
+            states: [
+              { name: "queued", type: "INITIAL" },
+              { name: "done", type: "TERMINAL" },
+            ],
+          },
+        ],
+      },
+    });
+    vi.spyOn(
+      factoryDocumentSaveHooks,
+      "useFactoryDocumentSave",
+    ).mockReturnValue(saveMutation as never);
+    const saveAsync = saveMutation.saveAsync;
+
+    const { result } = renderHook(
+      () =>
+        useSaveEditableWorkStateConfiguration({
+          editableConfigurationState: buildReadyEditableConfigurationState({
+            isDirty: false,
+            markChangesSaved,
+          }),
+          scopeKey: "story:queued",
+        }),
+      { wrapper: createQueryClientWrapper() },
+    );
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    await waitFor(() => {
+      expect(result.current.saveState).toEqual({ status: "success" });
+    });
+    expect(markChangesSaved).toHaveBeenCalledTimes(1);
+    expect(saveAsync).toHaveBeenCalledWith({
+      baseVersion: {
+        logical: "7",
+        physical: "2026-05-23T15:52:00Z",
+      },
+      factory: {
+        name: "Current Factory",
+        workers: [
+          {
+            modelProvider: "CURSOR",
+            name: "reviewer",
+            type: "MODEL_WORKER",
+          },
+        ],
+        workTypes: [
+          {
+            name: "story",
+            states: [
+              { name: "queued", type: "INITIAL" },
+              { name: "done", type: "TERMINAL" },
+            ],
+          },
+        ],
+        workstations: [],
+      },
+    });
+  });
+
+  it("updates work state selection after a successful rename save", async () => {
+    const markChangesSaved = vi.fn();
+    const onWorkStateRenamed = vi.fn();
+    const saveMutation = mockFactoryDocumentSave({ mode: "success" });
+    vi.spyOn(
+      factoryDocumentSaveHooks,
+      "useFactoryDocumentSave",
+    ).mockReturnValue(saveMutation as never);
+
+    const renamedState = buildReadyEditableConfigurationState({
+      markChangesSaved,
+    });
+    if (renamedState.status === "ready") {
+      renamedState.draft = {
+        name: "ready",
+        type: "INITIAL",
+      };
+      renamedState.pendingFactoryDefinition = {
+        name: "Current Factory",
+        workers: [
+          {
+            modelProvider: "CURSOR",
+            name: "reviewer",
+            type: "MODEL_WORKER",
+          },
+        ],
+        workTypes: [
+          {
+            name: "story",
+            states: [
+              { name: "ready", type: "INITIAL" },
+              { name: "done", type: "TERMINAL" },
+            ],
+          },
+        ],
+        workstations: [],
+      };
+    }
+
+    const { result } = renderHook(
+      () =>
+        useSaveEditableWorkStateConfiguration({
+          editableConfigurationState: renamedState,
+          onWorkStateRenamed,
+          scopeKey: "story:queued",
+        }),
+      { wrapper: createQueryClientWrapper() },
+    );
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(markChangesSaved).toHaveBeenCalledTimes(1);
+    expect(onWorkStateRenamed).toHaveBeenCalledWith("story:ready");
+  });
+
+  it("does not call save when client validation blocks canSave", async () => {
+    const saveMutation = mockFactoryDocumentSave({ mode: "success" });
+    vi.spyOn(
+      factoryDocumentSaveHooks,
+      "useFactoryDocumentSave",
+    ).mockReturnValue(saveMutation as never);
+    const saveAsync = saveMutation.saveAsync;
+
+    const { result } = renderHook(
+      () =>
+        useSaveEditableWorkStateConfiguration({
+          editableConfigurationState: buildReadyEditableConfigurationState({
+            canSave: false,
+            validationErrors: {
+              name: 'A work state named "done" already exists for this work type.',
+            },
+          }),
+          scopeKey: "story:queued",
+        }),
+      { wrapper: createQueryClientWrapper() },
+    );
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(saveAsync).not.toHaveBeenCalled();
+    expect(result.current.canSave).toBe(false);
+  });
+
+  it("ignores repeated save requests while the current save is still in flight", async () => {
+    const pendingSave = mockPendingFactoryDocumentSave();
+    vi.spyOn(
+      factoryDocumentSaveHooks,
+      "useFactoryDocumentSave",
+    ).mockReturnValue(pendingSave.saveMutation as never);
+    const saveAsync = pendingSave.saveAsync;
+    const deferredSave = pendingSave.deferred;
+
+    const { result } = renderHook(
+      () =>
+        useSaveEditableWorkStateConfiguration({
+          editableConfigurationState: buildReadyEditableConfigurationState(),
+          scopeKey: "story:queued",
+        }),
+      { wrapper: createQueryClientWrapper() },
+    );
+
+    let firstSave: Promise<void> | undefined;
+    await act(async () => {
+      firstSave = result.current.save();
+      await Promise.resolve();
+      await result.current.save();
+    });
+
+    expect(saveAsync).toHaveBeenCalledTimes(1);
+    expect(result.current.saveState).toEqual({ status: "submitting" });
+
+    deferredSave.resolve({
+      name: "Current Factory",
+      version: {
+        logical: "7",
+        physical: "2026-05-23T15:52:00Z",
+      },
+      workers: [],
+      workstations: [],
+      workTypes: [],
+    });
+
+    await act(async () => {
+      await firstSave;
+    });
+
+    await waitFor(() => {
+      expect(result.current.saveState).not.toEqual({ status: "submitting" });
+    });
+  });
+
+  it("maps targeted save validation failures onto the work state name field", async () => {
+    const message = "Work state name is invalid.";
+    const saveAsync = vi.fn().mockRejectedValue(
+      new CurrentFactoryDefinitionError(message, {
+        code: "BAD_REQUEST",
+        status: 400,
+        targets: [workStateFieldValidationTarget("name", message)],
+      }),
+    );
+    vi.spyOn(
+      factoryDocumentSaveHooks,
+      "useFactoryDocumentSave",
+    ).mockReturnValue({
+      isPending: false,
+      saveAsync,
+    } as never);
+
+    const { result } = renderHook(
+      () =>
+        useSaveEditableWorkStateConfiguration({
+          editableConfigurationState: buildReadyEditableConfigurationState(),
+          scopeKey: "story:queued",
+        }),
+      { wrapper: createQueryClientWrapper() },
+    );
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    await waitFor(() => {
+      expect(result.current.saveState).toEqual({
+        errorMessage: message,
+        fieldErrors: {
+          name: message,
+        },
+        status: "error",
+      });
+    });
+  });
+});
+
+function createQueryClientWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+
+  return function QueryClientWrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function buildReadyEditableConfigurationState(overrides?: {
+  canSave?: boolean;
+  isDirty?: boolean;
+  markChangesSaved?: () => void;
+  validationErrors?: EditableWorkStateConfigurationState extends {
+    status: "ready";
+  }
+    ? EditableWorkStateConfigurationState["validationErrors"]
+    : never;
+}): EditableWorkStateConfigurationState {
+  return {
+    baseVersion: {
+      logical: "7",
+      physical: "2026-05-23T15:52:00Z",
+    },
+    canSave: overrides?.canSave ?? true,
+    draft: {
+      name: "queued",
+      type: "INITIAL",
+    },
+    hasValidationErrors: overrides?.canSave === false,
+    initialValues: {
+      stateName: "queued",
+      stateNamesInWorkType: ["queued", "done"],
+      stateType: "INITIAL",
+      workTypeName: "story",
+    },
+    isDirty: overrides?.isDirty ?? true,
+    markChangesSaved: overrides?.markChangesSaved ?? vi.fn(),
+    onNameChange: vi.fn(),
+    onResetToLatest: vi.fn(),
+    originalStateName: "queued",
+    pendingFactoryDefinition: {
+      name: "Current Factory",
+      workers: [
+        {
+          modelProvider: "CURSOR",
+          name: "reviewer",
+          type: "MODEL_WORKER",
+        },
+      ],
+      workTypes: [
+        {
+          name: "story",
+          states: [
+            { name: "queued", type: "INITIAL" },
+            { name: "done", type: "TERMINAL" },
+          ],
+        },
+      ],
+      workstations: [],
+    },
+    status: "ready",
+    validationErrors: overrides?.validationErrors ?? {},
+    workTypeName: "story",
+  };
+}

--- a/ui/src/features/current-selection/work-state-selection/hooks/use-save-editable-work-state-configuration.ts
+++ b/ui/src/features/current-selection/work-state-selection/hooks/use-save-editable-work-state-configuration.ts
@@ -1,0 +1,128 @@
+import { useCallback, useMemo } from "react";
+
+import type { CurrentFactoryDefinitionError } from "../../../../api/current-factory-definition";
+import { useScopedFactoryDocumentSave } from "../../base/hooks/useScopedFactoryDocumentSave";
+import type {
+  EditableWorkStateConfigurationState,
+  EditableWorkStateSaveState,
+  EditableWorkStateSaveValidationErrors,
+} from "../lib/detail-card-types";
+import { getWorkStateDetailMessages } from "../messages/work-state-detail";
+
+interface UseSaveEditableWorkStateConfigurationOptions {
+  editableConfigurationState?: EditableWorkStateConfigurationState;
+  locale?: string | null;
+  onWorkStateRenamed?: (placeId: string) => void;
+  scopeKey: string | null;
+}
+
+interface UseSaveEditableWorkStateConfigurationResult {
+  canSave: boolean;
+  save: () => Promise<void>;
+  saveState: EditableWorkStateSaveState;
+}
+
+export function useSaveEditableWorkStateConfiguration({
+  editableConfigurationState,
+  locale,
+  onWorkStateRenamed,
+  scopeKey,
+}: UseSaveEditableWorkStateConfigurationOptions): UseSaveEditableWorkStateConfigurationResult {
+  const messages = getWorkStateDetailMessages(locale);
+  const isDirty =
+    editableConfigurationState?.status === "ready" &&
+    editableConfigurationState.isDirty;
+
+  const { isPending, saveNow, saveState } =
+    useScopedFactoryDocumentSave<EditableWorkStateSaveValidationErrors>({
+      fallbackErrorMessage: messages.editableConfigurationSaveFallbackError,
+      isDirty,
+      mapSaveErrorToFieldErrors: resolveSaveFieldErrors,
+      scopeKey,
+    });
+
+  const canSave =
+    editableConfigurationState?.status === "ready" &&
+    editableConfigurationState.canSave &&
+    editableConfigurationState.pendingFactoryDefinition != null &&
+    !isPending;
+
+  const save = useCallback(async () => {
+    if (
+      editableConfigurationState?.status !== "ready" ||
+      editableConfigurationState.pendingFactoryDefinition == null ||
+      scopeKey == null ||
+      !editableConfigurationState.canSave
+    ) {
+      return;
+    }
+
+    const { originalStateName, workTypeName } = editableConfigurationState;
+
+    await saveNow({
+      baseVersion: editableConfigurationState.baseVersion,
+      factory: editableConfigurationState.pendingFactoryDefinition,
+      onSaved: () => {
+        editableConfigurationState.markChangesSaved();
+        const savedStateName =
+          editableConfigurationState.draft.name.trim();
+        if (
+          savedStateName.length > 0 &&
+          savedStateName !== originalStateName
+        ) {
+          onWorkStateRenamed?.(`${workTypeName}:${savedStateName}`);
+        }
+      },
+      scopeKey,
+    });
+  }, [editableConfigurationState, onWorkStateRenamed, saveNow, scopeKey]);
+
+  return useMemo(
+    () => ({
+      canSave,
+      save,
+      saveState,
+    }),
+    [canSave, save, saveState],
+  );
+}
+
+function resolveSaveFieldErrors(
+  error: Pick<CurrentFactoryDefinitionError, "message" | "targets">,
+): EditableWorkStateSaveValidationErrors | undefined {
+  const fieldErrors: EditableWorkStateSaveValidationErrors = {};
+
+  for (const target of error.targets ?? []) {
+    const fieldName = resolveTargetFieldName(target);
+    if (fieldName === null) {
+      continue;
+    }
+    fieldErrors[fieldName] ??= error.message;
+  }
+
+  return Object.keys(fieldErrors).length > 0 ? fieldErrors : undefined;
+}
+
+function resolveTargetFieldName(
+  target: NonNullable<CurrentFactoryDefinitionError["targets"]>[number],
+): keyof EditableWorkStateSaveValidationErrors | null {
+  const subjectID = target.subject.id.trim().toLowerCase();
+  const subjectType = target.subject.type;
+
+  if (subjectType === "WORK_STATE" && subjectID === "name") {
+    return "name";
+  }
+
+  if (subjectType === "WORK_TYPE" && subjectID === "name") {
+    return "name";
+  }
+
+  if (
+    /factory\.workTypes\[\d+\]\.states\[\d+\]\.name/.test(target.code) ||
+    /factory\.workTypes\[\d+\]\.name/.test(target.code)
+  ) {
+    return "name";
+  }
+
+  return null;
+}

--- a/ui/src/features/current-selection/work-state-selection/hooks/use-save-editable-work-state-configuration.ts
+++ b/ui/src/features/current-selection/work-state-selection/hooks/use-save-editable-work-state-configuration.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from "react";
 
 import type { CurrentFactoryDefinitionError } from "../../../../api/current-factory-definition";
+import { useCurrentActivityGraphStore } from "../../../workflow-activity/state/currentActivityGraphStore";
 import { useScopedFactoryDocumentSave } from "../../base/hooks/useScopedFactoryDocumentSave";
 import type {
   EditableWorkStateConfigurationState,
@@ -64,12 +65,15 @@ export function useSaveEditableWorkStateConfiguration({
       factory: editableConfigurationState.pendingFactoryDefinition,
       onSaved: () => {
         editableConfigurationState.markChangesSaved();
-        const savedStateName =
-          editableConfigurationState.draft.name.trim();
-        if (
-          savedStateName.length > 0 &&
-          savedStateName !== originalStateName
-        ) {
+        const savedStateName = editableConfigurationState.draft.name.trim();
+        if (savedStateName.length > 0 && savedStateName !== originalStateName) {
+          useCurrentActivityGraphStore
+            .getState()
+            .migrateWorkStateNodePositions({
+              nextStateName: savedStateName,
+              previousStateName: originalStateName,
+              workTypeName,
+            });
           onWorkStateRenamed?.(`${workTypeName}:${savedStateName}`);
         }
       },

--- a/ui/src/features/current-selection/work-state-selection/lib/detail-card-types.ts
+++ b/ui/src/features/current-selection/work-state-selection/lib/detail-card-types.ts
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 import type { DashboardFailedWorkDetail, DashboardPlaceRef } from "../../../../api/dashboard/types";
 import type {
   CanonicalFactoryDefinition,
@@ -66,10 +68,13 @@ export interface StatePositionWorkListItemProps {
 
 export interface StateNodeDetailCardProps {
   currentWorkItems: StatePositionWorkItem[];
+  editableConfigurationState?: EditableWorkStateConfigurationState;
   failedWorkDetailsByWorkID?: Record<string, DashboardFailedWorkDetail>;
+  headerAction?: ReactNode;
   locale?: string | null;
   onSelectWorkItem?: (workItem: StatePositionWorkItem) => void;
   place: DashboardPlaceRef;
+  saveState?: EditableWorkStateSaveState;
   terminalHistoryWorkItems?: StatePositionWorkItem[];
   tokenCount: number;
   widgetId?: string;

--- a/ui/src/features/current-selection/work-state-selection/lib/detail-card-types.ts
+++ b/ui/src/features/current-selection/work-state-selection/lib/detail-card-types.ts
@@ -1,6 +1,38 @@
 import type { DashboardFailedWorkDetail, DashboardPlaceRef } from "../../../../api/dashboard/types";
+import type {
+  CanonicalFactoryDefinition,
+  CurrentFactoryVersion,
+} from "../../../../api/current-factory-definition";
+import type {
+  EditableWorkStateDraft,
+  EditableWorkStateValues,
+} from "../../../current-factory-definition/lib/work-state-editable-values";
 import type { CurrentSelectionDetailMessages } from "../../base/messages/current-selection-detail";
 import type { StatePositionWorkItem } from "../../base/state/selection-types";
+import type { EditableWorkStateValidationErrors } from "./work-state-editable-validation";
+
+export type EditableWorkStateConfigurationState =
+  | { status: "loading" }
+  | { status: "error"; errorMessage: string }
+  | { status: "empty"; message?: string }
+  | {
+      baseVersion: CurrentFactoryVersion;
+      canSave: boolean;
+      draft: EditableWorkStateDraft;
+      hasValidationErrors: boolean;
+      initialValues: EditableWorkStateValues;
+      isDirty: boolean;
+      markChangesSaved: () => void;
+      onNameChange: (value: string) => void;
+      onResetToLatest: () => void;
+      originalStateName: string;
+      pendingFactoryDefinition: CanonicalFactoryDefinition | null;
+      status: "ready";
+      validationErrors: EditableWorkStateValidationErrors;
+      workTypeName: string;
+    };
+
+export type { EditableWorkStateValidationErrors } from "./work-state-editable-validation";
 
 export interface StatePositionWorkListProps {
   failedWorkDetailsByWorkID?: Record<string, DashboardFailedWorkDetail>;

--- a/ui/src/features/current-selection/work-state-selection/lib/detail-card-types.ts
+++ b/ui/src/features/current-selection/work-state-selection/lib/detail-card-types.ts
@@ -9,7 +9,16 @@ import type {
 } from "../../../current-factory-definition/lib/work-state-editable-values";
 import type { CurrentSelectionDetailMessages } from "../../base/messages/current-selection-detail";
 import type { StatePositionWorkItem } from "../../base/state/selection-types";
+import type { DetailCardSaveState } from "../../base/hooks/detail-card-save-types";
 import type { EditableWorkStateValidationErrors } from "./work-state-editable-validation";
+
+export type EditableWorkStateSaveValidationErrors = {
+  contract?: string;
+  name?: string;
+} & Record<string, string>;
+
+export type EditableWorkStateSaveState =
+  DetailCardSaveState<EditableWorkStateSaveValidationErrors>;
 
 export type EditableWorkStateConfigurationState =
   | { status: "loading" }

--- a/ui/src/features/current-selection/work-state-selection/lib/work-state-editable-validation.test.ts
+++ b/ui/src/features/current-selection/work-state-selection/lib/work-state-editable-validation.test.ts
@@ -1,0 +1,134 @@
+import type { EditableWorkStateDraft } from "../../../current-factory-definition/lib/work-state-editable-values";
+import {
+  hasEditableWorkStateValidationErrors,
+  mergeEditableWorkStateContractValidationErrors,
+  validateEditableWorkStateDraft,
+} from "./work-state-editable-validation";
+
+const messages = {
+  editableConfigurationContractInvalidPrefix:
+    "Factory configuration is invalid.",
+  editableConfigurationNameDuplicate: (name: string) =>
+    `A work state named "${name}" already exists for this work type.`,
+  editableConfigurationNameRequired: "Work state name is required.",
+};
+
+function buildDraft(
+  overrides: Partial<EditableWorkStateDraft> = {},
+): EditableWorkStateDraft {
+  return {
+    name: "queued",
+    type: "INITIAL",
+    ...overrides,
+  };
+}
+
+const validationContext = {
+  originalStateName: "queued",
+  stateNamesInWorkType: ["queued", "done"],
+};
+
+describe("validateEditableWorkStateDraft", () => {
+  it("requires a non-empty trimmed work state name", () => {
+    expect(
+      validateEditableWorkStateDraft(
+        buildDraft({ name: "   " }),
+        messages,
+        validationContext,
+      ),
+    ).toEqual({
+      name: messages.editableConfigurationNameRequired,
+    });
+  });
+
+  it("rejects duplicate work state names within the same work type", () => {
+    expect(
+      validateEditableWorkStateDraft(
+        buildDraft({ name: "done" }),
+        messages,
+        validationContext,
+      ),
+    ).toEqual({
+      name: messages.editableConfigurationNameDuplicate("done"),
+    });
+  });
+
+  it("allows keeping the current work state name", () => {
+    expect(
+      validateEditableWorkStateDraft(buildDraft(), messages, validationContext),
+    ).toEqual({});
+  });
+});
+
+describe("mergeEditableWorkStateContractValidationErrors", () => {
+  it("surfaces normalizeFactoryDefinition failures on the name field when applicable", () => {
+    const pendingFactoryDefinition = {
+      name: "Current Factory",
+      workTypes: [
+        {
+          name: "story",
+          states: [{ type: "INITIAL" }],
+        },
+      ],
+      workers: [
+        { modelProvider: "CURSOR", name: "reviewer", type: "MODEL_WORKER" },
+      ],
+    };
+
+    expect(
+      mergeEditableWorkStateContractValidationErrors(
+        {},
+        pendingFactoryDefinition,
+        messages,
+      ).name,
+    ).toContain(messages.editableConfigurationContractInvalidPrefix);
+  });
+
+  it("falls back to a scoped contract banner when the error is not field-specific", () => {
+    const pendingFactoryDefinition = {
+      name: "Current Factory",
+      workTypes: [
+        {
+          name: "story",
+          states: [{ name: "queued", type: "INVALID" }],
+        },
+      ],
+      workers: [
+        { modelProvider: "CURSOR", name: "reviewer", type: "MODEL_WORKER" },
+      ],
+      workstations: [
+        {
+          id: "plan",
+          inputs: [{ state: "queued", workType: "story" }],
+          name: "Plan",
+          worker: "reviewer",
+        },
+      ],
+    };
+
+    const errors = mergeEditableWorkStateContractValidationErrors(
+      {},
+      pendingFactoryDefinition,
+      messages,
+    );
+
+    expect(errors.contract).toContain(
+      messages.editableConfigurationContractInvalidPrefix,
+    );
+    expect(hasEditableWorkStateValidationErrors(errors)).toBe(true);
+  });
+});
+
+describe("hasEditableWorkStateValidationErrors", () => {
+  it("returns false for an empty error map", () => {
+    expect(hasEditableWorkStateValidationErrors({})).toBe(false);
+  });
+
+  it("returns true when any field error is present", () => {
+    expect(
+      hasEditableWorkStateValidationErrors({
+        name: messages.editableConfigurationNameRequired,
+      }),
+    ).toBe(true);
+  });
+});

--- a/ui/src/features/current-selection/work-state-selection/lib/work-state-editable-validation.ts
+++ b/ui/src/features/current-selection/work-state-selection/lib/work-state-editable-validation.ts
@@ -1,0 +1,126 @@
+import type { CanonicalFactoryDefinition } from "../../../../api/current-factory-definition";
+import {
+  FactoryDefinitionAPIError,
+  normalizeFactoryDefinition,
+} from "../../../../api/factory-definition";
+import type { EditableWorkStateDraft } from "../../../current-factory-definition/lib/work-state-editable-values";
+
+export type EditableWorkStateValidationField = "contract" | "name";
+
+export type EditableWorkStateValidationErrors = Partial<
+  Record<EditableWorkStateValidationField, string>
+>;
+
+export interface ValidateEditableWorkStateDraftContext {
+  originalStateName: string;
+  stateNamesInWorkType: string[];
+}
+
+export interface EditableWorkStateValidationMessages {
+  editableConfigurationContractInvalidPrefix: string;
+  editableConfigurationNameDuplicate: (name: string) => string;
+  editableConfigurationNameRequired: string;
+}
+
+export function validateEditableWorkStateDraft(
+  draft: EditableWorkStateDraft,
+  messages: EditableWorkStateValidationMessages,
+  context?: ValidateEditableWorkStateDraftContext,
+): EditableWorkStateValidationErrors {
+  const validationErrors: EditableWorkStateValidationErrors = {};
+  const trimmedName = draft.name.trim();
+
+  if (trimmedName.length === 0) {
+    validationErrors.name = messages.editableConfigurationNameRequired;
+  } else if (context) {
+    const duplicateNames = context.stateNamesInWorkType.filter(
+      (stateName) =>
+        stateName !== context.originalStateName && stateName === trimmedName,
+    );
+    if (duplicateNames.length > 0) {
+      validationErrors.name =
+        messages.editableConfigurationNameDuplicate(trimmedName);
+    }
+  }
+
+  return validationErrors;
+}
+
+export function mergeEditableWorkStateContractValidationErrors(
+  validationErrors: EditableWorkStateValidationErrors,
+  pendingFactoryDefinition: CanonicalFactoryDefinition | null,
+  messages: Pick<
+    EditableWorkStateValidationMessages,
+    "editableConfigurationContractInvalidPrefix"
+  >,
+): EditableWorkStateValidationErrors {
+  if (!pendingFactoryDefinition) {
+    return validationErrors;
+  }
+
+  try {
+    normalizeFactoryDefinition(pendingFactoryDefinition);
+    return validationErrors;
+  } catch (error) {
+    const contractMessage = resolveEditableWorkStateContractErrorMessage(
+      error,
+      messages,
+    );
+    const contractField = resolveEditableWorkStateContractField(error);
+
+    if (contractField && !validationErrors[contractField]) {
+      return {
+        ...validationErrors,
+        [contractField]: contractMessage,
+      };
+    }
+
+    if (validationErrors.contract) {
+      return validationErrors;
+    }
+
+    return {
+      ...validationErrors,
+      contract: contractMessage,
+    };
+  }
+}
+
+export function hasEditableWorkStateValidationErrors(
+  validationErrors: EditableWorkStateValidationErrors,
+): boolean {
+  return Object.values(validationErrors).some(
+    (message) => typeof message === "string" && message.length > 0,
+  );
+}
+
+function resolveEditableWorkStateContractErrorMessage(
+  error: unknown,
+  messages: Pick<
+    EditableWorkStateValidationMessages,
+    "editableConfigurationContractInvalidPrefix"
+  >,
+): string {
+  if (error instanceof FactoryDefinitionAPIError) {
+    return `${messages.editableConfigurationContractInvalidPrefix} ${error.message}`;
+  }
+
+  return messages.editableConfigurationContractInvalidPrefix;
+}
+
+function resolveEditableWorkStateContractField(
+  error: unknown,
+): EditableWorkStateValidationField | null {
+  if (!(error instanceof FactoryDefinitionAPIError)) {
+    return null;
+  }
+
+  if (
+    /factory\.workTypes\[\d+\]\.states\[\d+\]\.name/.test(error.message) ||
+    /factory\.workTypes\[\d+\]\.name/.test(error.message)
+  ) {
+    return "name";
+  }
+
+  return null;
+}

--- a/ui/src/features/current-selection/work-state-selection/messages/work-state-detail-enums.test.ts
+++ b/ui/src/features/current-selection/work-state-selection/messages/work-state-detail-enums.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { localizeWorkStateType } from "./work-state-detail-enums";
+
+describe("localizeWorkStateType", () => {
+  it("localizes work state lifecycle types for supported locales", () => {
+    expect(localizeWorkStateType("INITIAL", "en")).toBe("Initial");
+    expect(localizeWorkStateType("PROCESSING", "ja")).toBe("処理中");
+    expect(localizeWorkStateType("TERMINAL", "ko")).toBe("완료");
+    expect(localizeWorkStateType("FAILED", "zh-CN")).toBe("失败");
+  });
+});

--- a/ui/src/features/current-selection/work-state-selection/messages/work-state-detail-enums.ts
+++ b/ui/src/features/current-selection/work-state-selection/messages/work-state-detail-enums.ts
@@ -1,0 +1,42 @@
+import type { EditableWorkStateDraft } from "../../../current-factory-definition/lib/work-state-editable-values";
+import {
+  type LocalizedMessages,
+  resolveLocalizedMessages,
+} from "../../../../i18n";
+
+type WorkStateType = EditableWorkStateDraft["type"];
+
+const workStateTypeLabelsByLocale = {
+  en: {
+    FAILED: "Failed",
+    INITIAL: "Initial",
+    PROCESSING: "Processing",
+    TERMINAL: "Completed",
+  },
+  ja: {
+    FAILED: "失敗",
+    INITIAL: "初期",
+    PROCESSING: "処理中",
+    TERMINAL: "完了",
+  },
+  ko: {
+    FAILED: "실패",
+    INITIAL: "초기",
+    PROCESSING: "처리 중",
+    TERMINAL: "완료",
+  },
+  "zh-CN": {
+    FAILED: "失败",
+    INITIAL: "初始",
+    PROCESSING: "处理中",
+    TERMINAL: "终止",
+  },
+} satisfies LocalizedMessages<Record<WorkStateType, string>>;
+
+export function localizeWorkStateType(
+  stateType: WorkStateType,
+  locale?: string | null,
+): string {
+  const labels = resolveLocalizedMessages(workStateTypeLabelsByLocale, locale);
+  return labels[stateType] ?? stateType;
+}

--- a/ui/src/features/current-selection/work-state-selection/messages/work-state-detail-types.ts
+++ b/ui/src/features/current-selection/work-state-selection/messages/work-state-detail-types.ts
@@ -1,3 +1,5 @@
+import type { EditableWorkStateDraft } from "../../../current-factory-definition/lib/work-state-editable-values";
+
 export interface WorkStateDetailMessages {
   topologyDeleteAction: (workTypeName: string, stateName: string) => string;
   topologyDeleteBlockedPrefix: string;
@@ -5,12 +7,25 @@ export interface WorkStateDetailMessages {
   configurationEmpty: string;
   configurationErrorPrefix: string;
   configurationLoading: string;
+  discardDraftAction: string;
   editableConfigurationContractInvalidPrefix: string;
+  editableConfigurationDirtyStatus: string;
+  editableConfigurationDraftNote: string;
   editableConfigurationEmpty: string;
   editableConfigurationErrorPrefix: string;
+  editableConfigurationHeading: string;
+  editableConfigurationLoading: string;
   editableConfigurationNameDuplicate: (stateName: string) => string;
   editableConfigurationNameRequired: string;
   editableConfigurationSaveAction: string;
   editableConfigurationSaveBusyAction: string;
+  editableConfigurationSaveDisabledValidationDetail: string;
+  editableConfigurationSaveErrorPrefix: string;
   editableConfigurationSaveFallbackError: string;
+  editableConfigurationSaveStaleVersionDetail: string;
+  editableConfigurationSaveSuccess: (stateName: string) => string;
+  editableConfigurationValidationStatus: string;
+  localizeWorkStateType: (stateType: EditableWorkStateDraft["type"]) => string;
+  nameFieldLabel: string;
+  typeFieldLabel: string;
 }

--- a/ui/src/features/current-selection/work-state-selection/messages/work-state-detail-types.ts
+++ b/ui/src/features/current-selection/work-state-selection/messages/work-state-detail-types.ts
@@ -2,4 +2,12 @@ export interface WorkStateDetailMessages {
   topologyDeleteAction: (workTypeName: string, stateName: string) => string;
   topologyDeleteBlockedPrefix: string;
   topologyDeleteHeading: string;
+  configurationEmpty: string;
+  configurationErrorPrefix: string;
+  configurationLoading: string;
+  editableConfigurationContractInvalidPrefix: string;
+  editableConfigurationEmpty: string;
+  editableConfigurationErrorPrefix: string;
+  editableConfigurationNameDuplicate: (stateName: string) => string;
+  editableConfigurationNameRequired: string;
 }

--- a/ui/src/features/current-selection/work-state-selection/messages/work-state-detail-types.ts
+++ b/ui/src/features/current-selection/work-state-selection/messages/work-state-detail-types.ts
@@ -10,4 +10,7 @@ export interface WorkStateDetailMessages {
   editableConfigurationErrorPrefix: string;
   editableConfigurationNameDuplicate: (stateName: string) => string;
   editableConfigurationNameRequired: string;
+  editableConfigurationSaveAction: string;
+  editableConfigurationSaveBusyAction: string;
+  editableConfigurationSaveFallbackError: string;
 }

--- a/ui/src/features/current-selection/work-state-selection/messages/work-state-detail.messages.test.ts
+++ b/ui/src/features/current-selection/work-state-selection/messages/work-state-detail.messages.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { getWorkStateDetailMessages } from "./work-state-detail";
+
+const locales = ["en", "ja", "ko", "zh-CN"] as const;
+
+describe("getWorkStateDetailMessages", () => {
+  it.each(locales)("returns non-empty editable field copy for $locale", (locale) => {
+    const messages = getWorkStateDetailMessages(locale);
+
+    expect(messages.nameFieldLabel.length).toBeGreaterThan(0);
+    expect(messages.typeFieldLabel.length).toBeGreaterThan(0);
+    expect(messages.editableConfigurationSaveAction.length).toBeGreaterThan(0);
+    expect(messages.editableConfigurationNameRequired.length).toBeGreaterThan(0);
+    expect(messages.localizeWorkStateType("PROCESSING").length).toBeGreaterThan(0);
+    expect(messages.editableConfigurationNameDuplicate("queued").length).toBeGreaterThan(
+      0,
+    );
+  });
+});

--- a/ui/src/features/current-selection/work-state-selection/messages/work-state-detail.ts
+++ b/ui/src/features/current-selection/work-state-selection/messages/work-state-detail.ts
@@ -24,6 +24,10 @@ const workStateDetailMessagesByLocale = {
       `A work state named "${stateName}" already exists for this work type.`,
     editableConfigurationNameRequired:
       "Enter a work state name before saving this work state.",
+    editableConfigurationSaveAction: "Save work state",
+    editableConfigurationSaveBusyAction: "Saving work state...",
+    editableConfigurationSaveFallbackError:
+      "The running factory could not be saved.",
   },
   ja: {
     topologyDeleteAction: (workTypeName, stateName) =>
@@ -44,6 +48,10 @@ const workStateDetailMessagesByLocale = {
       `このワークタイプには、すでに「${stateName}」というワーク状態があります。`,
     editableConfigurationNameRequired:
       "保存する前にワーク状態名を入力してください。",
+    editableConfigurationSaveAction: "ワーク状態を保存",
+    editableConfigurationSaveBusyAction: "ワーク状態を保存しています...",
+    editableConfigurationSaveFallbackError:
+      "実行中のファクトリーを保存できませんでした。",
   },
   ko: {
     topologyDeleteAction: (workTypeName, stateName) =>
@@ -64,6 +72,10 @@ const workStateDetailMessagesByLocale = {
       `이 작업 유형에 이미 "${stateName}" 작업 상태가 있습니다.`,
     editableConfigurationNameRequired:
       "이 작업 상태를 저장하기 전에 작업 상태 이름을 입력하세요.",
+    editableConfigurationSaveAction: "작업 상태 저장",
+    editableConfigurationSaveBusyAction: "작업 상태 저장 중...",
+    editableConfigurationSaveFallbackError:
+      "실행 중인 팩토리를 저장할 수 없습니다.",
   },
   "zh-CN": {
     topologyDeleteAction: (workTypeName, stateName) =>
@@ -80,6 +92,9 @@ const workStateDetailMessagesByLocale = {
     editableConfigurationNameDuplicate: (stateName) =>
       `此工作类型已存在名为“${stateName}”的工作状态。`,
     editableConfigurationNameRequired: "保存此工作状态前请输入工作状态名称。",
+    editableConfigurationSaveAction: "保存工作状态",
+    editableConfigurationSaveBusyAction: "正在保存工作状态...",
+    editableConfigurationSaveFallbackError: "无法保存运行中的工厂。",
   },
 } satisfies LocalizedMessages<WorkStateDetailMessages>;
 

--- a/ui/src/features/current-selection/work-state-selection/messages/work-state-detail.ts
+++ b/ui/src/features/current-selection/work-state-selection/messages/work-state-detail.ts
@@ -2,7 +2,13 @@ import {
   type LocalizedMessages,
   resolveLocalizedMessages,
 } from "../../../../i18n";
+import { localizeWorkStateType } from "./work-state-detail-enums";
 import type { WorkStateDetailMessages } from "./work-state-detail-types";
+
+type WorkStateDetailCatalogMessages = Omit<
+  WorkStateDetailMessages,
+  "localizeWorkStateType"
+>;
 
 const workStateDetailMessagesByLocale = {
   en: {
@@ -15,19 +21,37 @@ const workStateDetailMessagesByLocale = {
     configurationErrorPrefix: "Work state definition unavailable.",
     configurationLoading:
       "Loading the current factory definition for this work state.",
+    discardDraftAction: "Discard local changes",
     editableConfigurationContractInvalidPrefix:
       "Work state configuration is invalid.",
+    editableConfigurationDirtyStatus:
+      "You have unsaved changes for this work state.",
+    editableConfigurationDraftNote:
+      "Changes stay local to this edit session until you save the running factory.",
     editableConfigurationEmpty:
       "This running factory definition does not expose editable work state values.",
     editableConfigurationErrorPrefix: "Work state configuration unavailable.",
+    editableConfigurationHeading: "Work state configuration",
+    editableConfigurationLoading: "Loading editable work state configuration.",
     editableConfigurationNameDuplicate: (stateName) =>
       `A work state named "${stateName}" already exists for this work type.`,
     editableConfigurationNameRequired:
       "Enter a work state name before saving this work state.",
     editableConfigurationSaveAction: "Save work state",
     editableConfigurationSaveBusyAction: "Saving work state...",
+    editableConfigurationSaveDisabledValidationDetail:
+      "Save stays disabled until the highlighted work state fields are valid.",
+    editableConfigurationSaveErrorPrefix: "Saving failed.",
     editableConfigurationSaveFallbackError:
       "The running factory could not be saved.",
+    editableConfigurationSaveStaleVersionDetail:
+      "Reload the latest running-factory values or keep this draft and retry after the editor refreshes.",
+    editableConfigurationSaveSuccess: (stateName) =>
+      `Running factory saved. ${stateName} was updated in the running factory definition.`,
+    editableConfigurationValidationStatus:
+      "Fix the highlighted work state fields before saving.",
+    nameFieldLabel: "State name",
+    typeFieldLabel: "Lifecycle type",
   },
   ja: {
     topologyDeleteAction: (workTypeName, stateName) =>
@@ -39,19 +63,37 @@ const workStateDetailMessagesByLocale = {
     configurationErrorPrefix: "ワーク状態定義を利用できません。",
     configurationLoading:
       "このワーク状態の現在のファクトリー定義を読み込んでいます。",
+    discardDraftAction: "ローカルの変更を破棄",
     editableConfigurationContractInvalidPrefix:
       "ワーク状態の構成が無効です。",
+    editableConfigurationDirtyStatus:
+      "このワーク状態に未保存の変更があります。",
+    editableConfigurationDraftNote:
+      "実行中のファクトリーを保存するまで、変更はこの編集セッション内に留まります。",
     editableConfigurationEmpty:
       "実行中のファクトリー定義に、編集可能なワーク状態の値がありません。",
     editableConfigurationErrorPrefix: "ワーク状態の構成を利用できません。",
+    editableConfigurationHeading: "ワーク状態の構成",
+    editableConfigurationLoading: "編集可能なワーク状態の構成を読み込んでいます。",
     editableConfigurationNameDuplicate: (stateName) =>
       `このワークタイプには、すでに「${stateName}」というワーク状態があります。`,
     editableConfigurationNameRequired:
       "保存する前にワーク状態名を入力してください。",
     editableConfigurationSaveAction: "ワーク状態を保存",
     editableConfigurationSaveBusyAction: "ワーク状態を保存しています...",
+    editableConfigurationSaveDisabledValidationDetail:
+      "強調表示されたワーク状態フィールドが有効になるまで保存は無効のままです。",
+    editableConfigurationSaveErrorPrefix: "保存に失敗しました。",
     editableConfigurationSaveFallbackError:
       "実行中のファクトリーを保存できませんでした。",
+    editableConfigurationSaveStaleVersionDetail:
+      "最新の実行中ファクトリー値を再読み込みするか、この下書きを保持してエディター更新後に再試行してください。",
+    editableConfigurationSaveSuccess: (stateName) =>
+      `実行中のファクトリーを保存しました。${stateName} を実行中のファクトリー定義で更新しました。`,
+    editableConfigurationValidationStatus:
+      "保存する前に強調表示されたワーク状態フィールドを修正してください。",
+    nameFieldLabel: "状態名",
+    typeFieldLabel: "ライフサイクル種別",
   },
   ko: {
     topologyDeleteAction: (workTypeName, stateName) =>
@@ -63,19 +105,37 @@ const workStateDetailMessagesByLocale = {
     configurationErrorPrefix: "작업 상태 정의를 사용할 수 없습니다.",
     configurationLoading:
       "이 작업 상태의 현재 팩토리 정의를 불러오는 중입니다.",
+    discardDraftAction: "로컬 변경 사항 취소",
     editableConfigurationContractInvalidPrefix:
       "작업 상태 구성이 유효하지 않습니다.",
+    editableConfigurationDirtyStatus:
+      "이 작업 상태에 저장되지 않은 변경 사항이 있습니다.",
+    editableConfigurationDraftNote:
+      "실행 중인 팩토리를 저장할 때까지 변경 사항은 이 편집 세션에만 유지됩니다.",
     editableConfigurationEmpty:
       "실행 중인 팩토리 정의에 편집 가능한 작업 상태 값이 없습니다.",
     editableConfigurationErrorPrefix: "작업 상태 구성을 사용할 수 없습니다.",
+    editableConfigurationHeading: "작업 상태 구성",
+    editableConfigurationLoading: "편집 가능한 작업 상태 구성을 불러오는 중입니다.",
     editableConfigurationNameDuplicate: (stateName) =>
       `이 작업 유형에 이미 "${stateName}" 작업 상태가 있습니다.`,
     editableConfigurationNameRequired:
       "이 작업 상태를 저장하기 전에 작업 상태 이름을 입력하세요.",
     editableConfigurationSaveAction: "작업 상태 저장",
     editableConfigurationSaveBusyAction: "작업 상태 저장 중...",
+    editableConfigurationSaveDisabledValidationDetail:
+      "강조 표시된 작업 상태 필드가 유효해질 때까지 저장이 비활성화됩니다.",
+    editableConfigurationSaveErrorPrefix: "저장에 실패했습니다.",
     editableConfigurationSaveFallbackError:
       "실행 중인 팩토리를 저장할 수 없습니다.",
+    editableConfigurationSaveStaleVersionDetail:
+      "최신 실행 중 팩토리 값을 다시 불러오거나 이 초안을 유지한 뒤 편집기가 새로고침된 후 다시 시도하세요.",
+    editableConfigurationSaveSuccess: (stateName) =>
+      `실행 중인 팩토리를 저장했습니다. ${stateName}이(가) 실행 중 팩토리 정의에서 업데이트되었습니다.`,
+    editableConfigurationValidationStatus:
+      "저장하기 전에 강조 표시된 작업 상태 필드를 수정하세요.",
+    nameFieldLabel: "상태 이름",
+    typeFieldLabel: "수명 주기 유형",
   },
   "zh-CN": {
     topologyDeleteAction: (workTypeName, stateName) =>
@@ -85,21 +145,47 @@ const workStateDetailMessagesByLocale = {
     configurationEmpty: "运行中的工厂定义不包含所选工作状态。",
     configurationErrorPrefix: "工作状态定义不可用。",
     configurationLoading: "正在加载此工作状态的当前工厂定义。",
+    discardDraftAction: "放弃本地更改",
     editableConfigurationContractInvalidPrefix: "工作状态配置无效。",
+    editableConfigurationDirtyStatus: "此工作状态有未保存的更改。",
+    editableConfigurationDraftNote:
+      "在保存运行中的工厂之前，更改仅保留在此编辑会话中。",
     editableConfigurationEmpty:
       "运行中的工厂定义未提供可编辑的工作状态值。",
     editableConfigurationErrorPrefix: "工作状态配置不可用。",
+    editableConfigurationHeading: "工作状态配置",
+    editableConfigurationLoading: "正在加载可编辑的工作状态配置。",
     editableConfigurationNameDuplicate: (stateName) =>
       `此工作类型已存在名为“${stateName}”的工作状态。`,
     editableConfigurationNameRequired: "保存此工作状态前请输入工作状态名称。",
     editableConfigurationSaveAction: "保存工作状态",
     editableConfigurationSaveBusyAction: "正在保存工作状态...",
+    editableConfigurationSaveDisabledValidationDetail:
+      "在突出显示的工作状态字段有效之前，保存将保持禁用。",
+    editableConfigurationSaveErrorPrefix: "保存失败。",
     editableConfigurationSaveFallbackError: "无法保存运行中的工厂。",
+    editableConfigurationSaveStaleVersionDetail:
+      "重新加载最新的运行中工厂值，或保留此草稿并在编辑器刷新后重试。",
+    editableConfigurationSaveSuccess: (stateName) =>
+      `已保存运行中的工厂。${stateName} 已在运行中的工厂定义中更新。`,
+    editableConfigurationValidationStatus:
+      "保存前请修复突出显示的工作状态字段。",
+    nameFieldLabel: "状态名称",
+    typeFieldLabel: "生命周期类型",
   },
-} satisfies LocalizedMessages<WorkStateDetailMessages>;
+} satisfies LocalizedMessages<WorkStateDetailCatalogMessages>;
 
 export function getWorkStateDetailMessages(
   locale?: string | null,
 ): WorkStateDetailMessages {
-  return resolveLocalizedMessages(workStateDetailMessagesByLocale, locale);
+  const messages = resolveLocalizedMessages(
+    workStateDetailMessagesByLocale,
+    locale,
+  );
+
+  return {
+    ...messages,
+    localizeWorkStateType: (stateType) =>
+      localizeWorkStateType(stateType, locale),
+  };
 }

--- a/ui/src/features/current-selection/work-state-selection/messages/work-state-detail.ts
+++ b/ui/src/features/current-selection/work-state-selection/messages/work-state-detail.ts
@@ -1,49 +1,90 @@
+import {
+  type LocalizedMessages,
+  resolveLocalizedMessages,
+} from "../../../../i18n";
 import type { WorkStateDetailMessages } from "./work-state-detail-types";
 
-const WORK_STATE_DETAIL_MESSAGES: Record<string, WorkStateDetailMessages> = {
+const workStateDetailMessagesByLocale = {
   en: {
     topologyDeleteAction: (workTypeName, stateName) =>
       `Delete ${workTypeName} ${stateName} work state`,
     topologyDeleteBlockedPrefix: "Work state cannot be deleted:",
     topologyDeleteHeading: "Factory graph",
+    configurationEmpty:
+      "This running factory definition does not include the selected work state.",
+    configurationErrorPrefix: "Work state definition unavailable.",
+    configurationLoading:
+      "Loading the current factory definition for this work state.",
+    editableConfigurationContractInvalidPrefix:
+      "Work state configuration is invalid.",
+    editableConfigurationEmpty:
+      "This running factory definition does not expose editable work state values.",
+    editableConfigurationErrorPrefix: "Work state configuration unavailable.",
+    editableConfigurationNameDuplicate: (stateName) =>
+      `A work state named "${stateName}" already exists for this work type.`,
+    editableConfigurationNameRequired:
+      "Enter a work state name before saving this work state.",
   },
   ja: {
     topologyDeleteAction: (workTypeName, stateName) =>
       `ワーク状態 ${workTypeName} ${stateName} を削除`,
     topologyDeleteBlockedPrefix: "ワーク状態を削除できません:",
     topologyDeleteHeading: "ファクトリグラフ",
+    configurationEmpty:
+      "実行中のファクトリー定義に、選択したワーク状態が含まれていません。",
+    configurationErrorPrefix: "ワーク状態定義を利用できません。",
+    configurationLoading:
+      "このワーク状態の現在のファクトリー定義を読み込んでいます。",
+    editableConfigurationContractInvalidPrefix:
+      "ワーク状態の構成が無効です。",
+    editableConfigurationEmpty:
+      "実行中のファクトリー定義に、編集可能なワーク状態の値がありません。",
+    editableConfigurationErrorPrefix: "ワーク状態の構成を利用できません。",
+    editableConfigurationNameDuplicate: (stateName) =>
+      `このワークタイプには、すでに「${stateName}」というワーク状態があります。`,
+    editableConfigurationNameRequired:
+      "保存する前にワーク状態名を入力してください。",
   },
   ko: {
     topologyDeleteAction: (workTypeName, stateName) =>
       `작업 상태 ${workTypeName} ${stateName} 삭제`,
     topologyDeleteBlockedPrefix: "작업 상태를 삭제할 수 없습니다:",
     topologyDeleteHeading: "팩토리 그래프",
+    configurationEmpty:
+      "실행 중인 팩토리 정의에 선택한 작업 상태가 포함되어 있지 않습니다.",
+    configurationErrorPrefix: "작업 상태 정의를 사용할 수 없습니다.",
+    configurationLoading:
+      "이 작업 상태의 현재 팩토리 정의를 불러오는 중입니다.",
+    editableConfigurationContractInvalidPrefix:
+      "작업 상태 구성이 유효하지 않습니다.",
+    editableConfigurationEmpty:
+      "실행 중인 팩토리 정의에 편집 가능한 작업 상태 값이 없습니다.",
+    editableConfigurationErrorPrefix: "작업 상태 구성을 사용할 수 없습니다.",
+    editableConfigurationNameDuplicate: (stateName) =>
+      `이 작업 유형에 이미 "${stateName}" 작업 상태가 있습니다.`,
+    editableConfigurationNameRequired:
+      "이 작업 상태를 저장하기 전에 작업 상태 이름을 입력하세요.",
   },
-  zh: {
+  "zh-CN": {
     topologyDeleteAction: (workTypeName, stateName) =>
       `删除工作状态 ${workTypeName} ${stateName}`,
     topologyDeleteBlockedPrefix: "无法删除工作状态:",
     topologyDeleteHeading: "工厂图",
+    configurationEmpty: "运行中的工厂定义不包含所选工作状态。",
+    configurationErrorPrefix: "工作状态定义不可用。",
+    configurationLoading: "正在加载此工作状态的当前工厂定义。",
+    editableConfigurationContractInvalidPrefix: "工作状态配置无效。",
+    editableConfigurationEmpty:
+      "运行中的工厂定义未提供可编辑的工作状态值。",
+    editableConfigurationErrorPrefix: "工作状态配置不可用。",
+    editableConfigurationNameDuplicate: (stateName) =>
+      `此工作类型已存在名为“${stateName}”的工作状态。`,
+    editableConfigurationNameRequired: "保存此工作状态前请输入工作状态名称。",
   },
-};
+} satisfies LocalizedMessages<WorkStateDetailMessages>;
 
 export function getWorkStateDetailMessages(
   locale?: string | null,
 ): WorkStateDetailMessages {
-  if (!locale) {
-    return WORK_STATE_DETAIL_MESSAGES.en;
-  }
-
-  const normalizedLocale = locale.toLowerCase();
-  if (normalizedLocale.startsWith("ja")) {
-    return WORK_STATE_DETAIL_MESSAGES.ja;
-  }
-  if (normalizedLocale.startsWith("ko")) {
-    return WORK_STATE_DETAIL_MESSAGES.ko;
-  }
-  if (normalizedLocale.startsWith("zh")) {
-    return WORK_STATE_DETAIL_MESSAGES.zh;
-  }
-
-  return WORK_STATE_DETAIL_MESSAGES.en;
+  return resolveLocalizedMessages(workStateDetailMessagesByLocale, locale);
 }

--- a/ui/src/features/current-selection/work-state-selection/public/index.test.ts
+++ b/ui/src/features/current-selection/work-state-selection/public/index.test.ts
@@ -4,6 +4,9 @@ import * as workStateSelectionPublic from "./index";
 
 describe("work-state-selection/public", () => {
   it("exports state node detail card, editable state types, and message helpers", () => {
+    expect(workStateSelectionPublic.EditableWorkStateSaveHeaderAction).toBeTypeOf(
+      "function",
+    );
     expect(workStateSelectionPublic.StateNodeDetailCard).toBeTypeOf("function");
     expect(workStateSelectionPublic.getWorkStateDetailMessages).toBeTypeOf(
       "function",
@@ -13,6 +16,9 @@ describe("work-state-selection/public", () => {
   it("does not export work state editing hooks", () => {
     expect(workStateSelectionPublic).not.toHaveProperty(
       "useEditableWorkStateConfigurationState",
+    );
+    expect(workStateSelectionPublic).not.toHaveProperty(
+      "useSaveEditableWorkStateConfiguration",
     );
   });
 });

--- a/ui/src/features/current-selection/work-state-selection/public/index.test.ts
+++ b/ui/src/features/current-selection/work-state-selection/public/index.test.ts
@@ -3,7 +3,16 @@ import { describe, expect, it } from "vitest";
 import * as workStateSelectionPublic from "./index";
 
 describe("work-state-selection/public", () => {
-  it("exports state node detail card and prop types", () => {
+  it("exports state node detail card, editable state types, and message helpers", () => {
     expect(workStateSelectionPublic.StateNodeDetailCard).toBeTypeOf("function");
+    expect(workStateSelectionPublic.getWorkStateDetailMessages).toBeTypeOf(
+      "function",
+    );
+  });
+
+  it("does not export work state editing hooks", () => {
+    expect(workStateSelectionPublic).not.toHaveProperty(
+      "useEditableWorkStateConfigurationState",
+    );
   });
 });

--- a/ui/src/features/current-selection/work-state-selection/public/index.ts
+++ b/ui/src/features/current-selection/work-state-selection/public/index.ts
@@ -1,7 +1,12 @@
 export { StateNodeDetailCard } from "../components/state-node-detail";
 
 export type {
+  EditableWorkStateConfigurationState,
   StateNodeDetailCardProps,
   StatePositionWorkListItemProps,
   StatePositionWorkListProps,
 } from "../lib/detail-card-types";
+export {
+  getWorkStateDetailMessages,
+} from "../messages/work-state-detail";
+export type { WorkStateDetailMessages } from "../messages/work-state-detail-types";

--- a/ui/src/features/current-selection/work-state-selection/public/index.ts
+++ b/ui/src/features/current-selection/work-state-selection/public/index.ts
@@ -1,7 +1,9 @@
+export { EditableWorkStateSaveHeaderAction } from "../components/work-state-save-controls";
 export { StateNodeDetailCard } from "../components/state-node-detail";
 
 export type {
   EditableWorkStateConfigurationState,
+  EditableWorkStateSaveState,
   StateNodeDetailCardProps,
   StatePositionWorkListItemProps,
   StatePositionWorkListProps,

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-react-flow-projection.test.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-react-flow-projection.test.ts
@@ -58,6 +58,57 @@ describe("factory graph React Flow projection", () => {
     );
   });
 
+  it("projects renamed work-state node ids and labels from an updated factory definition", () => {
+    const renamedFactoryDefinition = {
+      ...baseFactoryDefinition,
+      workTypes: [
+        {
+          name: "story",
+          states: [
+            { name: "ready", type: "INITIAL" },
+            { name: "done", type: "TERMINAL" },
+          ],
+        },
+      ],
+      workstations: [
+        {
+          ...baseFactoryDefinition.workstations?.[0],
+          inputs: [{ state: "ready", workType: "story" }],
+          name: "draft",
+          outputs: [{ state: "done", workType: "story" }],
+        },
+      ],
+    } satisfies CanonicalFactoryDefinition;
+    const topology = buildFactoryGraphTopologyFromDefinition(
+      renamedFactoryDefinition,
+    );
+
+    const projection = projectFactoryGraphToReactFlow({
+      factoryDefinition: renamedFactoryDefinition,
+      topology,
+    });
+
+    expect(
+      projection.nodes.find((node) => node.id === "work-state:story:ready"),
+    ).toMatchObject({
+      data: {
+        kind: "work-state",
+        label: "story:ready",
+      },
+      id: "work-state:story:ready",
+    });
+    expect(
+      projection.nodes.some((node) => node.id === "work-state:story:queued"),
+    ).toBe(false);
+    expect(projection.edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "workstation-input:work-state:story:ready->workstation:draft",
+        }),
+      ]),
+    );
+  });
+
   it("projects workStateType from factory definition for all lifecycle phases", () => {
     const lifecycleFactoryDefinition = {
       ...baseFactoryDefinition,

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-edit-integration.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-edit-integration.test.tsx
@@ -525,8 +525,11 @@ describe("ReactFlowCurrentActivityCard edit integration", () => {
       ).toBeNull();
     });
     expect(
-      within(toolbar).getByText("No draft changes", { exact: true }),
-    ).toBeTruthy();
+      within(toolbar).queryByRole("button", { name: "Save changes" }),
+    ).toBeNull();
+    expect(
+      within(toolbar).queryByRole("button", { name: "Discard changes" }),
+    ).toBeNull();
   });
 
   it("opens save confirmation from the activity card host portaled to document.body", async () => {

--- a/ui/src/features/workflow-activity/lib/migrate-work-state-graph-layout-positions.test.ts
+++ b/ui/src/features/workflow-activity/lib/migrate-work-state-graph-layout-positions.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { baseFactoryDefinition } from "../../factory-graph-editor/lib/factory-graph-draft.test-helpers";
+import { buildCurrentActivityGraphLayoutFromFactory } from "./current-activity-factory-graph-layout";
+import {
+  migrateWorkStateGraphLayoutPositions,
+  workStateFactoryGraphNodeId,
+} from "./migrate-work-state-graph-layout-positions";
+import { currentActivityGraphKey } from "./react-flow-current-activity-card-keys";
+
+describe("migrateWorkStateGraphLayoutPositions", () => {
+  it("copies stored positions from the previous work-state node id to the renamed id", () => {
+    const previousNodeId = workStateFactoryGraphNodeId("story", "queued");
+    const nextNodeId = workStateFactoryGraphNodeId("story", "ready");
+    const graphKey = `resource:gpu|${previousNodeId}|workstation:draft::edge-a`;
+
+    const migrated = migrateWorkStateGraphLayoutPositions({
+      nextStateName: "ready",
+      positionsByGraphKey: {
+        [graphKey]: {
+          [previousNodeId]: { x: 120, y: 240 },
+        },
+      },
+      previousStateName: "queued",
+      workTypeName: "story",
+    });
+
+    const migratedGraphKey = graphKey.replaceAll(previousNodeId, nextNodeId);
+    expect(migrated[migratedGraphKey]).toEqual({
+      [nextNodeId]: { x: 120, y: 240 },
+    });
+    expect(migrated[graphKey]).toBeUndefined();
+    expect(migrated[migratedGraphKey]?.[previousNodeId]).toBeUndefined();
+  });
+
+  it("rewrites graph keys that embed the previous work-state node id in edge ids", async () => {
+    const renamedFactoryDefinition = {
+      ...baseFactoryDefinition,
+      workTypes: [
+        {
+          name: "story",
+          states: [
+            { name: "ready", type: "INITIAL" },
+            { name: "done", type: "TERMINAL" },
+          ],
+        },
+      ],
+      workstations: [
+        {
+          ...baseFactoryDefinition.workstations?.[0],
+          inputs: [{ state: "ready", workType: "story" }],
+          name: "draft",
+          outputs: [{ state: "done", workType: "story" }],
+        },
+      ],
+    };
+    const graphLayout = await buildCurrentActivityGraphLayoutFromFactory(
+      renamedFactoryDefinition,
+    );
+    const graphKey = currentActivityGraphKey(graphLayout);
+    const previousNodeId = workStateFactoryGraphNodeId("story", "queued");
+    const nextNodeId = workStateFactoryGraphNodeId("story", "ready");
+
+    const migrated = migrateWorkStateGraphLayoutPositions({
+      nextStateName: "ready",
+      positionsByGraphKey: {
+        [graphKey.replaceAll(nextNodeId, previousNodeId)]: {
+          [previousNodeId]: { x: 44, y: 88 },
+        },
+      },
+      previousStateName: "queued",
+      workTypeName: "story",
+    });
+
+    expect(migrated[graphKey]?.[nextNodeId]).toEqual({ x: 44, y: 88 });
+    expect(
+      migrated[graphKey.replaceAll(nextNodeId, previousNodeId)],
+    ).toBeUndefined();
+  });
+
+  it("leaves unrelated graph keys unchanged when they do not reference the renamed node", () => {
+    const unrelated = {
+      "worker:writer::workstation:draft": {
+        "worker:writer": { x: 1, y: 2 },
+      },
+    };
+
+    expect(
+      migrateWorkStateGraphLayoutPositions({
+        nextStateName: "ready",
+        positionsByGraphKey: unrelated,
+        previousStateName: "queued",
+        workTypeName: "story",
+      }),
+    ).toEqual(unrelated);
+  });
+});

--- a/ui/src/features/workflow-activity/lib/migrate-work-state-graph-layout-positions.ts
+++ b/ui/src/features/workflow-activity/lib/migrate-work-state-graph-layout-positions.ts
@@ -1,0 +1,82 @@
+import type { FactoryGraphWorkStateReference } from "../../factory-graph-editor/lib/factory-graph-draft-types";
+import { nodeKeyId } from "../../factory-graph-editor/lib/factory-graph-draft-types";
+import type { GraphNodePositions } from "../state/currentActivityGraphStore";
+
+export interface MigrateWorkStateGraphLayoutPositionsInput {
+  nextStateName: string;
+  positionsByGraphKey: Record<string, GraphNodePositions>;
+  previousStateName: string;
+  workTypeName: string;
+}
+
+export function workStateFactoryGraphNodeId(
+  workTypeName: string,
+  stateName: string,
+): string {
+  const key: FactoryGraphWorkStateReference = {
+    kind: "work-state",
+    stateName,
+    workTypeName,
+  };
+  return nodeKeyId(key);
+}
+
+export function migrateWorkStateGraphLayoutPositions({
+  nextStateName,
+  positionsByGraphKey,
+  previousStateName,
+  workTypeName,
+}: MigrateWorkStateGraphLayoutPositionsInput): Record<
+  string,
+  GraphNodePositions
+> {
+  const previousNodeId = workStateFactoryGraphNodeId(
+    workTypeName,
+    previousStateName,
+  );
+  const nextNodeId = workStateFactoryGraphNodeId(workTypeName, nextStateName);
+  if (previousNodeId === nextNodeId) {
+    return positionsByGraphKey;
+  }
+
+  const migratedPositionsByGraphKey: Record<string, GraphNodePositions> = {};
+
+  for (const [graphKey, positions] of Object.entries(positionsByGraphKey)) {
+    const hasStoredPreviousPosition = positions[previousNodeId] !== undefined;
+    const graphKeyReferencesPreviousNode = graphKey.includes(previousNodeId);
+    if (!hasStoredPreviousPosition && !graphKeyReferencesPreviousNode) {
+      migratedPositionsByGraphKey[graphKey] = positions;
+      continue;
+    }
+
+    const migratedGraphKey = graphKeyReferencesPreviousNode
+      ? graphKey.replaceAll(previousNodeId, nextNodeId)
+      : graphKey;
+    const migratedPositions = migrateWorkStateNodePositionEntry(
+      positions,
+      previousNodeId,
+      nextNodeId,
+    );
+    const existingPositions = migratedPositionsByGraphKey[migratedGraphKey];
+    migratedPositionsByGraphKey[migratedGraphKey] = existingPositions
+      ? { ...existingPositions, ...migratedPositions }
+      : migratedPositions;
+  }
+
+  return migratedPositionsByGraphKey;
+}
+
+function migrateWorkStateNodePositionEntry(
+  positions: GraphNodePositions,
+  previousNodeId: string,
+  nextNodeId: string,
+): GraphNodePositions {
+  const previousPosition = positions[previousNodeId];
+  if (previousPosition === undefined) {
+    return positions;
+  }
+
+  const migratedPositions = { ...positions, [nextNodeId]: previousPosition };
+  delete migratedPositions[previousNodeId];
+  return migratedPositions;
+}

--- a/ui/src/features/workflow-activity/state/currentActivityGraphStore.ts
+++ b/ui/src/features/workflow-activity/state/currentActivityGraphStore.ts
@@ -1,6 +1,8 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
+import { migrateWorkStateGraphLayoutPositions } from "../lib/migrate-work-state-graph-layout-positions";
+
 export interface GraphNodePosition {
   x: number;
   y: number;
@@ -8,9 +10,22 @@ export interface GraphNodePosition {
 
 export type GraphNodePositions = Record<string, GraphNodePosition>;
 
+export interface MigrateWorkStateNodePositionsInput {
+  nextStateName: string;
+  previousStateName: string;
+  workTypeName: string;
+}
+
 interface CurrentActivityGraphState {
+  migrateWorkStateNodePositions: (
+    input: MigrateWorkStateNodePositionsInput,
+  ) => void;
   positionsByGraphKey: Record<string, GraphNodePositions>;
-  setNodePosition: (graphKey: string, nodeId: string, position: GraphNodePosition) => void;
+  setNodePosition: (
+    graphKey: string,
+    nodeId: string,
+    position: GraphNodePosition,
+  ) => void;
 }
 
 export const CURRENT_ACTIVITY_GRAPH_STORAGE_KEY =
@@ -19,6 +34,14 @@ export const CURRENT_ACTIVITY_GRAPH_STORAGE_KEY =
 export const useCurrentActivityGraphStore = create<CurrentActivityGraphState>()(
   persist(
     (set) => ({
+      migrateWorkStateNodePositions: (input) => {
+        set((state) => ({
+          positionsByGraphKey: migrateWorkStateGraphLayoutPositions({
+            ...input,
+            positionsByGraphKey: state.positionsByGraphKey,
+          }),
+        }));
+      },
       positionsByGraphKey: {},
       setNodePosition: (graphKey, nodeId, position) => {
         set((state) => ({
@@ -34,9 +57,10 @@ export const useCurrentActivityGraphStore = create<CurrentActivityGraphState>()(
     }),
     {
       name: CURRENT_ACTIVITY_GRAPH_STORAGE_KEY,
-      partialize: (state) => ({ positionsByGraphKey: state.positionsByGraphKey }),
+      partialize: (state) => ({
+        positionsByGraphKey: state.positionsByGraphKey,
+      }),
       storage: createJSONStorage(() => window.localStorage),
     },
   ),
 );
-

--- a/ui/src/testing/factory-validation-target-fixtures.ts
+++ b/ui/src/testing/factory-validation-target-fixtures.ts
@@ -1,5 +1,21 @@
 import type { FactoryValidationTarget } from "../api/factory-validation";
 
+export function workStateFieldValidationTarget(
+  fieldName: string,
+  message = `Invalid ${fieldName}.`,
+): FactoryValidationTarget {
+  return {
+    code: `factory.workTypes[0].states[0].${fieldName}`,
+    message,
+    severity: "error",
+    subject: {
+      id: fieldName,
+      location: "DEFINITION",
+      type: "WORK_STATE",
+    },
+  };
+}
+
 export function workerFieldValidationTarget(
   fieldName: string,
   message = `Invalid ${fieldName}.`,


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/selection-work-state-rename",
  "description": "Let operators rename a factory work state from the dashboard current-selection panel with validation, scoped factory document save, and immediate factory-graph label updates without a full page reload.",
  "context": {
    "customerAsk": "Add an editable work state name field in current selection with validation (unique per work type, non-empty), persist through factory document save, and update graph labels after save.",
    "problem": "The work state current-selection panel shows runtime place context only; workTypes[].states[].name cannot be edited from the UI, so operators must hand-edit factory.json to rename states.",
    "solution": "Add work-state editable draft helpers with workstation route propagation, configuration and save hooks mirroring worker selection, an editable name field with header save in StateNodeDetailCard, and post-save selection/graph/layout coherence for renamed work-state node ids."
  },
  "acceptanceCriteria": [
    "Factory-graph editor mode shows an editable work state name field in current selection with read-only lifecycle type",
    "Valid renames save via scoped factory document REPLACE_CURRENT and clear dirty state on success",
    "Duplicate names within the same work type and empty names are rejected with clear field-level errors before save",
    "Rename updates workTypes state names and all workstation route state references for that work type",
    "After save, graph node label and selection reflect the new name without a full page reload",
    "Work state type changes and work state deletion remain out of scope",
    "Typecheck, lint, and tests pass for touched UI packages"
  ],
  "userStories": [
    {
      "id": "selection-work-state-rename-001",
      "title": "Work state rename helpers and validation",
      "description": "As a developer, I need pure factory-document helpers and client validation for work state renames so save logic stays testable and consistent with worker and workstation editors.",
      "acceptanceCriteria": [
        "resolveEditableWorkStateValues, editableWorkStateDraftFromValues, and applyEditableWorkStateDraft update workTypes state names and propagate renames across workstation route state fields for the same work type",
        "validateEditableWorkStateDraft requires non-empty trimmed name, rejects duplicate names within the work type, and surfaces normalizeFactoryDefinition failures",
        "Unit tests cover rename with workstation input and output routes, duplicate-name rejection, and unchanged lifecycle type after rename",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "selection-work-state-rename-002",
      "title": "Editable work state configuration state hook",
      "description": "As a developer, I need session draft state for the selected work state so the detail panel can track dirty fields and a pending factory document.",
      "acceptanceCriteria": [
        "useEditableWorkStateConfigurationState loads when selection.kind is state-node and placeId resolves to a factory work state",
        "Ready state exposes draft, isDirty, canSave, validationErrors, pendingFactoryDefinition, workTypeName, originalStateName, and markChangesSaved",
        "Hook resets when placeId or factory document identity changes",
        "Hook tests cover dirty detection, duplicate-name validation block, and reset on selection switch",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "selection-work-state-rename-003",
      "title": "Persist work state rename via scoped factory save",
      "description": "As an operator, I want to save a renamed work state through the factory document API with the same outcomes and error handling as other current-selection editors.",
      "acceptanceCriteria": [
        "useSaveEditableWorkStateConfiguration saves via useScopedFactoryDocumentSave REPLACE_CURRENT using pendingFactoryDefinition",
        "EditableWorkStateSaveHeaderAction mirrors worker header save affordances and disabled states",
        "Successful rename save updates selection from workType:oldName to workType:newName",
        "API validation errors map to the name field when applicable",
        "Save-hook tests cover successful save, validation block, and selection follow after rename",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "selection-work-state-rename-004",
      "title": "Editable name field in work state current selection",
      "description": "As an operator, I want to edit a work state name in the current-selection panel when I select it on the factory graph.",
      "acceptanceCriteria": [
        "StateNodeDetailCard renders an editable name input and read-only lifecycle type when editable configuration state is ready",
        "Name field validation uses aria-invalid and role alert; save is disabled when canSave is false",
        "CurrentSelectionWidget wires work-state editable state and header save for factory-backed work state selection",
        "Runtime work list content still renders without regression when a session is active",
        "Localized messages exist for en, ja, ko, and zh covering name label, validation, and save feedback",
        "state-node-detail and current-selection-widget tests cover editable name, duplicate error, and header save wiring",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill: select work-state node, rename, save from header; panel shows new name"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "selection-work-state-rename-005",
      "title": "Graph and layout coherence after rename save",
      "description": "As an operator, I want the factory graph to show the new work state name immediately after save without reloading the dashboard.",
      "acceptanceCriteria": [
        "After save, work-state graph node id and label use the new state name without a full page reload",
        "Graph selection highlight follows the renamed work-state node id",
        "Persisted graph layout positions migrate from the old work-state node id to the new id",
        "Workstation edges remain connected to the renamed work-state node after save",
        "Tests cover layout position migration and graph projection label update from updated factory definition",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill: rename connected work state, save, confirm graph label updates without refresh"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)