### PR TITLE
issues2-graph-state-node-colors

### DIFF
--- a/ui/scripts/inline-component-class-usage-allowlist.mjs
+++ b/ui/scripts/inline-component-class-usage-allowlist.mjs
@@ -74,7 +74,6 @@ export const allowlistedInlineComponentClassUsage = [
   "src/features/workflow-activity/components/dashboard-flow-axis-legend.tsx#PANEL_HEADER_CLASS",
   "src/features/workflow-activity/components/dashboard-flow-axis-legend.tsx#PANEL_TITLE_CLASS",
   "src/features/workflow-activity/components/dashboard-flow-axis-legend.tsx#COLLAPSE_BUTTON_CLASS",
-  "src/features/workflow-activity/components/dashboard-flow-axis-legend.tsx#ITEMS_LIST_CLASS",
   "src/features/workflow-activity/components/mutation-dialog.tsx#DIALOG_PANEL_CLASS",
   "src/features/workflow-activity/components/mutation-dialog.tsx#DIALOG_HEADER_CLASS",
   "src/features/workflow-activity/components/mutation-dialog.tsx#DIALOG_TITLE_CLASS",

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-work-state-phase-styling.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-work-state-phase-styling.ts
@@ -6,8 +6,8 @@
  * - TERMINAL → af-success (green)
  * - FAILED → af-danger (red)
  *
- * Observer current-activity graphs use different icon tones in
- * `current-activity-place-node.tsx`; keep editor lifecycle styling here.
+ * Dashboard workflow graph work-state nodes reuse these helpers from
+ * `current-activity-place-node.tsx` via `place.state_category`.
  */
 import type { GraphSemanticIconKind } from "../../flowchart/components/graph-semantic-icon";
 import type { FactoryGraphWorkStateType } from "./factory-graph-work-state-type";
@@ -22,10 +22,7 @@ export const WORK_STATE_PHASE_LEGEND_ORDER = [
 const NEUTRAL_WORK_STATE_SURFACE =
   "border-af-border-strong bg-af-surface-raised";
 
-const WORK_STATE_PHASE_SURFACE: Record<
-  FactoryGraphWorkStateType,
-  string
-> = {
+const WORK_STATE_PHASE_SURFACE: Record<FactoryGraphWorkStateType, string> = {
   INITIAL: "border-af-info-border bg-af-info-surface",
   PROCESSING: "border-af-warning-border bg-af-warning-surface",
   TERMINAL: "border-af-success-border bg-af-success-surface",
@@ -42,13 +39,12 @@ const WORK_STATE_PHASE_ICON_KIND: Record<
   FAILED: "failed",
 };
 
-const WORK_STATE_PHASE_ICON_CLASS: Record<FactoryGraphWorkStateType, string> =
-  {
-    INITIAL: "text-af-info",
-    PROCESSING: "text-af-warning",
-    TERMINAL: "text-af-success",
-    FAILED: "text-af-danger",
-  };
+const WORK_STATE_PHASE_ICON_CLASS: Record<FactoryGraphWorkStateType, string> = {
+  INITIAL: "text-af-info",
+  PROCESSING: "text-af-warning",
+  TERMINAL: "text-af-success",
+  FAILED: "text-af-danger",
+};
 
 export function workStatePhaseSwatchClassName(
   workStateType: FactoryGraphWorkStateType,

--- a/ui/src/features/flowchart/components/current-activity-place-node.test.tsx
+++ b/ui/src/features/flowchart/components/current-activity-place-node.test.tsx
@@ -1,0 +1,177 @@
+import { cleanup, render } from "@testing-library/react";
+import type { NodeProps } from "@xyflow/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { DashboardPlaceRef } from "../../../api/dashboard/types";
+import {
+  workStatePhaseSemanticIconClassName,
+  workStatePhaseSurfaceClassName,
+} from "../../factory-graph-editor/lib/factory-graph-work-state-phase-styling";
+import type { StatePositionNodeData } from "./current-activity-place-node";
+import { StatePositionNodeView } from "./current-activity-place-node";
+
+vi.mock("@xyflow/react", () => ({
+  Handle: ({ id }: { id: string }) => <div data-testid={`handle-${id}`} />,
+  Position: { Left: "left", Right: "right" },
+}));
+
+function statePositionNodeProps(
+  place: DashboardPlaceRef,
+  overrides: Partial<StatePositionNodeData> = {},
+): NodeProps<{
+  data: StatePositionNodeData;
+  id: string;
+  type: "statePosition";
+}> {
+  return {
+    data: {
+      activeFlow: false,
+      activeItemLabels: [],
+      handles: [],
+      muted: false,
+      place,
+      selectedStateNode: false,
+      tokenCount: 0,
+      ...overrides,
+    },
+    dragging: false,
+    id: place.place_id,
+    isConnectable: false,
+    selected: false,
+    type: "statePosition",
+    zIndex: 0,
+  };
+}
+
+function nodeShell(container: HTMLElement): HTMLElement | null {
+  return container.querySelector(
+    "[data-current-activity-node-type='statePosition']",
+  );
+}
+
+describe("CurrentActivity place node work-state phase styling", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it.each([
+    ["INITIAL", "INITIAL"],
+    ["PROCESSING", "PROCESSING"],
+    ["TERMINAL", "TERMINAL"],
+    ["FAILED", "FAILED"],
+  ] as const)("applies lifecycle surface classes for work_state with state_category %s", (stateCategory) => {
+    const place: DashboardPlaceRef = {
+      kind: "work_state",
+      place_id: `story:${stateCategory.toLowerCase()}`,
+      state_category: stateCategory,
+      state_value: stateCategory.toLowerCase(),
+      type_id: "story",
+    };
+    const { container } = render(
+      <StatePositionNodeView {...statePositionNodeProps(place)} />,
+    );
+    const shell = nodeShell(container);
+
+    expect(shell?.className).toContain(
+      workStatePhaseSurfaceClassName(stateCategory),
+    );
+  });
+
+  it("uses neutral surface styling when work_state has no state_category", () => {
+    const place: DashboardPlaceRef = {
+      kind: "work_state",
+      place_id: "story:unknown",
+      state_value: "unknown",
+      type_id: "story",
+    };
+    const { container } = render(
+      <StatePositionNodeView {...statePositionNodeProps(place)} />,
+    );
+    const shell = nodeShell(container);
+
+    expect(shell?.className).toContain(
+      workStatePhaseSurfaceClassName(undefined),
+    );
+  });
+
+  it("keeps resource node styling unchanged", () => {
+    const place: DashboardPlaceRef = {
+      kind: "resource",
+      place_id: "resource:cpu",
+      state_value: "cpu",
+      type_id: "resource",
+    };
+    const { container } = render(
+      <StatePositionNodeView {...statePositionNodeProps(place)} />,
+    );
+    const shell = container.querySelector(
+      "[data-current-activity-node-type='resource']",
+    );
+
+    expect(shell?.className).toContain("bg-af-surface");
+    expect(shell?.className).not.toContain("bg-af-info-surface");
+  });
+
+  it("applies lifecycle icon tone from shared phase styling", () => {
+    const place: DashboardPlaceRef = {
+      kind: "work_state",
+      place_id: "story:processing",
+      state_category: "PROCESSING",
+      state_value: "processing",
+      type_id: "story",
+    };
+    const { container } = render(
+      <StatePositionNodeView {...statePositionNodeProps(place)} />,
+    );
+    const icon = container.querySelector("[data-place-semantic-icon] svg");
+
+    expect(icon?.getAttribute("class")).toContain(
+      workStatePhaseSemanticIconClassName("PROCESSING"),
+    );
+  });
+
+  it("keeps selection ring visible on lifecycle-colored work-state nodes", () => {
+    const place: DashboardPlaceRef = {
+      kind: "work_state",
+      place_id: "story:ready",
+      state_category: "INITIAL",
+      state_value: "ready",
+      type_id: "story",
+    };
+    const { container } = render(
+      <StatePositionNodeView
+        {...statePositionNodeProps(place, { selectedStateNode: true })}
+      />,
+    );
+    const shell = nodeShell(container);
+
+    expect(shell?.className).toContain("border-af-accent-border");
+    expect(shell?.className).toContain(
+      workStatePhaseSurfaceClassName("INITIAL"),
+    );
+  });
+
+  it("keeps validation error ring visible on lifecycle-colored work-state nodes", () => {
+    const place: DashboardPlaceRef = {
+      kind: "work_state",
+      place_id: "story:failed",
+      state_category: "FAILED",
+      state_value: "failed",
+      type_id: "story",
+    };
+    const { container } = render(
+      <StatePositionNodeView
+        {...statePositionNodeProps(place, {
+          onSelectStateNode: () => undefined,
+          validationError: true,
+        })}
+      />,
+    );
+    const shell = nodeShell(container);
+
+    expect(shell?.className).toContain("ring-af-danger-border");
+    expect(shell?.className).toContain(
+      workStatePhaseSurfaceClassName("FAILED"),
+    );
+  });
+});

--- a/ui/src/features/flowchart/components/current-activity-place-node.tsx
+++ b/ui/src/features/flowchart/components/current-activity-place-node.tsx
@@ -9,6 +9,11 @@ import {
 } from "../../../components/ui/place-labels";
 import { cn } from "../../../lib/cn";
 import type { FactoryGraphNodeKind } from "../../factory-graph-editor/lib/factory-graph-draft-types";
+import {
+  workStatePhaseSemanticIconClassName,
+  workStatePhaseSemanticIconKind,
+  workStatePhaseSurfaceClassName,
+} from "../../factory-graph-editor/lib/factory-graph-work-state-phase-styling";
 import { getWorkflowActivityShellMessages } from "../../workflow-activity/messages/activity-shell";
 import { getActivityGraphMessages } from "../messages/activity-graph";
 import { ActivityGraphNodeBadge } from "./current-activity-node-chrome";
@@ -145,41 +150,24 @@ function PlaceNodeView({ data }: NodeProps<CurrentActivityPlaceNode>) {
 }
 
 function placeNodeClassName(place: DashboardPlaceRef): string {
-  const kindClassName = (() => {
-    if (place.kind === "work_state") {
-      return "border-af-border-strong";
-    }
-    if (place.kind === "resource") {
-      // hardcoded-ui-copy-exception: non-product-diagnostic
-      return "border-af-border-strong bg-af-surface text-af-text";
-    }
-    // hardcoded-ui-copy-exception: non-product-diagnostic
-    return "border-dashed border-af-info-border bg-af-surface-subtle text-af-text";
-  })();
-  const stateClassName =
-    place.state_category === "TERMINAL"
-      ? "border-af-border-strong"
-      : place.state_category === "FAILED"
-        ? "border-af-danger-border"
-        : "";
+  if (place.kind === "work_state") {
+    return workStatePhaseSurfaceClassName(place.state_category);
+  }
 
-  return cn(kindClassName, stateClassName);
+  if (place.kind === "resource") {
+    // hardcoded-ui-copy-exception: non-product-diagnostic
+    return "border-af-border-strong bg-af-surface text-af-text";
+  }
+
+  // hardcoded-ui-copy-exception: non-product-diagnostic
+  return "border-dashed border-af-info-border bg-af-surface-subtle text-af-text";
 }
 
 function placeSemanticIconKind(
   place: DashboardPlaceRef,
 ): GraphSemanticIconKind {
   if (place.kind === "work_state") {
-    if (place.state_category === "TERMINAL") {
-      return "terminal";
-    }
-    if (place.state_category === "FAILED") {
-      return "failed";
-    }
-    if (place.state_category === "PROCESSING") {
-      return "processing";
-    }
-    return "queue";
+    return workStatePhaseSemanticIconKind(place.state_category);
   }
 
   if (place.kind === "resource") {
@@ -198,16 +186,7 @@ function placeSemanticIconLabel(
 
 function placeSemanticIconClassName(place: DashboardPlaceRef): string {
   if (place.kind === "work_state") {
-    if (place.state_category === "TERMINAL") {
-      return "text-af-success";
-    }
-    if (place.state_category === "FAILED") {
-      return "text-af-danger";
-    }
-    if (place.state_category === "PROCESSING") {
-      return "text-af-info";
-    }
-    return "text-af-text-subtle";
+    return workStatePhaseSemanticIconClassName(place.state_category);
   }
 
   if (place.kind === "resource") {

--- a/ui/src/features/workflow-activity/components/dashboard-flow-axis-legend.stories.tsx
+++ b/ui/src/features/workflow-activity/components/dashboard-flow-axis-legend.stories.tsx
@@ -2,12 +2,14 @@ import type { ReactNode } from "react";
 import { expect, userEvent, within } from "storybook/test";
 
 import "../../../styles.css";
+import { getFactoryGraphEditorMessages } from "../../factory-graph-editor/messages/editor";
+import { getDashboardFlowAxisLegendMessages } from "../messages/dashboard-flow-axis-legend";
 import {
   DashboardFlowAxisLegend,
   getDefaultDashboardFlowAxisLegendEdgeItems,
   getDefaultDashboardFlowAxisLegendIconItems,
+  getDefaultDashboardFlowAxisLegendPhaseItems,
 } from "./dashboard-flow-axis-legend";
-import { getDashboardFlowAxisLegendMessages } from "../messages/dashboard-flow-axis-legend";
 
 export default {
   title: "Agent Factory/Dashboard/Dashboard Flow Axis Legend",
@@ -36,6 +38,7 @@ export const Interactive = {
         className="relative left-0 top-0"
         edgeItems={getDefaultDashboardFlowAxisLegendEdgeItems("en")}
         iconItems={getDefaultDashboardFlowAxisLegendIconItems("en")}
+        phaseItems={getDefaultDashboardFlowAxisLegendPhaseItems("en")}
       />
     </LegendStoryFrame>
   ),
@@ -66,6 +69,14 @@ export const Interactive = {
     await expect(
       legendScope.getByText(messages.edgeLabels.failurePath),
     ).toBeVisible();
+    const editorMessages = getFactoryGraphEditorMessages("en");
+    const phaseLegend = legendScope.getByLabelText(
+      editorMessages.workStatePhaseLegendAriaLabel,
+    );
+    await expect(within(phaseLegend).getByText("Initial")).toBeVisible();
+    await expect(within(phaseLegend).getByText("Processing")).toBeVisible();
+    await expect(within(phaseLegend).getByText("Completed")).toBeVisible();
+    await expect(within(phaseLegend).getByText("Failed")).toBeVisible();
     for (const [label, kind] of [
       [messages.iconLabels.queue, "queue"],
       [messages.iconLabels.processing, "processing"],
@@ -80,10 +91,14 @@ export const Interactive = {
       [messages.iconLabels["active-work"], "active-work"],
       [messages.iconLabels.exhaustion, "exhaustion"],
     ]) {
+      const iconEntry = legend.querySelector(`[data-legend-icon='${kind}']`);
       await expect(
         legendScope.getByRole("img", { name: messages.iconLabel(label) }),
       ).toHaveAttribute("data-graph-semantic-icon", kind);
-      await expect(legendScope.getByText(label)).toBeVisible();
+      await expect(iconEntry).toBeTruthy();
+      await expect(
+        within(iconEntry as HTMLElement).getByText(label),
+      ).toBeVisible();
     }
 
     await userEvent.click(collapseButton);
@@ -105,6 +120,7 @@ export const Expanded = {
         defaultExpanded={true}
         edgeItems={getDefaultDashboardFlowAxisLegendEdgeItems("en")}
         iconItems={getDefaultDashboardFlowAxisLegendIconItems("en")}
+        phaseItems={getDefaultDashboardFlowAxisLegendPhaseItems("en")}
       />
     </LegendStoryFrame>
   ),
@@ -124,6 +140,7 @@ export const Narrow = {
         className="relative left-0 top-0"
         edgeItems={getDefaultDashboardFlowAxisLegendEdgeItems("en")}
         iconItems={getDefaultDashboardFlowAxisLegendIconItems("en")}
+        phaseItems={getDefaultDashboardFlowAxisLegendPhaseItems("en")}
       />
     </LegendStoryFrame>
   ),
@@ -165,6 +182,7 @@ export const Japanese = {
         className="relative left-0 top-0"
         edgeItems={getDefaultDashboardFlowAxisLegendEdgeItems("ja")}
         iconItems={getDefaultDashboardFlowAxisLegendIconItems("ja")}
+        phaseItems={getDefaultDashboardFlowAxisLegendPhaseItems("ja")}
         locale="ja"
       />
     </LegendStoryFrame>

--- a/ui/src/features/workflow-activity/components/dashboard-flow-axis-legend.test.tsx
+++ b/ui/src/features/workflow-activity/components/dashboard-flow-axis-legend.test.tsx
@@ -1,11 +1,12 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
-
+import { getFactoryGraphEditorMessages } from "../../factory-graph-editor/messages/editor";
+import { getDashboardFlowAxisLegendMessages } from "../messages/dashboard-flow-axis-legend";
 import {
   DashboardFlowAxisLegend,
   getDefaultDashboardFlowAxisLegendEdgeItems,
   getDefaultDashboardFlowAxisLegendIconItems,
+  getDefaultDashboardFlowAxisLegendPhaseItems,
 } from "./dashboard-flow-axis-legend";
-import { getDashboardFlowAxisLegendMessages } from "../messages/dashboard-flow-axis-legend";
 
 describe("DashboardFlowAxisLegend", () => {
   it("starts minimized and reveals the dashboard flow semantic vocabulary when expanded", () => {
@@ -15,6 +16,7 @@ describe("DashboardFlowAxisLegend", () => {
       <DashboardFlowAxisLegend
         edgeItems={getDefaultDashboardFlowAxisLegendEdgeItems("en")}
         iconItems={getDefaultDashboardFlowAxisLegendIconItems("en")}
+        phaseItems={getDefaultDashboardFlowAxisLegendPhaseItems("en")}
       />,
     );
 
@@ -68,13 +70,14 @@ describe("DashboardFlowAxisLegend", () => {
       [messages.iconLabels["active-work"], "active-work"],
       [messages.iconLabels.exhaustion, "exhaustion"],
     ]) {
+      const iconEntry = legend.querySelector(`[data-legend-icon='${kind}']`);
       const icon = legendScope.getByRole("img", {
         name: messages.iconLabel(label),
       });
 
+      expect(iconEntry).toBeTruthy();
       expect(icon.getAttribute("data-graph-semantic-icon")).toBe(kind);
-      expect(legendScope.getByText(label)).toBeTruthy();
-      expect(legend.querySelector(`[data-legend-icon='${kind}']`)).toBeTruthy();
+      expect(within(iconEntry as HTMLElement).getByText(label)).toBeTruthy();
     }
 
     fireEvent.click(collapseButton);
@@ -97,6 +100,7 @@ describe("DashboardFlowAxisLegend", () => {
         className="relative top-0"
         edgeItems={getDefaultDashboardFlowAxisLegendEdgeItems("en").slice(0, 1)}
         iconItems={getDefaultDashboardFlowAxisLegendIconItems("en").slice(0, 2)}
+        phaseItems={[]}
       />,
     );
 
@@ -130,6 +134,7 @@ describe("DashboardFlowAxisLegend", () => {
       <DashboardFlowAxisLegend
         edgeItems={getDefaultDashboardFlowAxisLegendEdgeItems("ja")}
         iconItems={getDefaultDashboardFlowAxisLegendIconItems("ja")}
+        phaseItems={getDefaultDashboardFlowAxisLegendPhaseItems("ja")}
         locale="ja"
       />,
     );
@@ -161,6 +166,7 @@ describe("DashboardFlowAxisLegend", () => {
       <DashboardFlowAxisLegend
         edgeItems={getDefaultDashboardFlowAxisLegendEdgeItems("fr-CA")}
         iconItems={getDefaultDashboardFlowAxisLegendIconItems("fr-CA")}
+        phaseItems={getDefaultDashboardFlowAxisLegendPhaseItems("fr-CA")}
         locale="fr-CA"
       />,
     );
@@ -183,5 +189,71 @@ describe("DashboardFlowAxisLegend", () => {
         name: messages.iconLabel(messages.iconLabels.workstation),
       }),
     ).toBeTruthy();
+  });
+
+  it("renders work-state lifecycle swatches with localized labels when expanded", () => {
+    const editorMessages = getFactoryGraphEditorMessages("en");
+    const messages = getDashboardFlowAxisLegendMessages("en");
+
+    render(
+      <DashboardFlowAxisLegend
+        edgeItems={[]}
+        iconItems={[]}
+        phaseItems={getDefaultDashboardFlowAxisLegendPhaseItems("en")}
+      />,
+    );
+
+    expect(
+      screen.queryByLabelText(editorMessages.workStatePhaseLegendAriaLabel),
+    ).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: messages.expandToggleLabel("graph legend"),
+      }),
+    );
+
+    const phaseLegend = screen.getByLabelText(
+      editorMessages.workStatePhaseLegendAriaLabel,
+    );
+
+    expect(phaseLegend.getAttribute("aria-label")).toBe(
+      editorMessages.workStatePhaseLegendAriaLabel,
+    );
+    expect(screen.getByText("Initial")).toBeTruthy();
+    expect(screen.getByText("Processing")).toBeTruthy();
+    expect(screen.getByText("Completed")).toBeTruthy();
+    expect(screen.getByText("Failed")).toBeTruthy();
+
+    const swatches = phaseLegend.querySelectorAll("[aria-hidden='true']");
+    expect(swatches.length).toBe(4);
+    expect(swatches[0]?.getAttribute("class")).toContain(
+      "border-af-info-border",
+    );
+    expect(swatches[0]?.getAttribute("class")).toContain("bg-af-info-surface");
+    expect(swatches[1]?.getAttribute("class")).toContain(
+      "border-af-warning-border",
+    );
+    expect(swatches[1]?.getAttribute("class")).toContain(
+      "bg-af-warning-surface",
+    );
+    expect(swatches[2]?.getAttribute("class")).toContain(
+      "border-af-success-border",
+    );
+    expect(swatches[2]?.getAttribute("class")).toContain(
+      "bg-af-success-surface",
+    );
+    expect(swatches[3]?.getAttribute("class")).toContain(
+      "border-af-danger-border",
+    );
+    expect(swatches[3]?.getAttribute("class")).toContain(
+      "bg-af-danger-surface",
+    );
+
+    for (const phase of ["INITIAL", "PROCESSING", "TERMINAL", "FAILED"]) {
+      expect(
+        phaseLegend.querySelector(`[data-legend-phase='${phase}']`),
+      ).toBeTruthy();
+    }
   });
 });

--- a/ui/src/features/workflow-activity/components/dashboard-flow-axis-legend.tsx
+++ b/ui/src/features/workflow-activity/components/dashboard-flow-axis-legend.tsx
@@ -3,6 +3,12 @@ import { DisclosureButton } from "../../../components/ui/disclosure-button";
 import { ExpandablePanelIcon } from "../../../components/ui/expandable-panel-icon";
 import { cn } from "../../../lib/cn";
 import {
+  WORK_STATE_PHASE_LEGEND_ORDER,
+  workStatePhaseSwatchClassName,
+} from "../../factory-graph-editor/lib/factory-graph-work-state-phase-styling";
+import type { FactoryGraphWorkStateType } from "../../factory-graph-editor/lib/factory-graph-work-state-type";
+import { getFactoryGraphEditorMessages } from "../../factory-graph-editor/messages/editor";
+import {
   EXHAUSTION_WORKSTATION_ICON_METADATA,
   SUPPORTED_WORKSTATION_ICON_METADATA,
 } from "../../flowchart/lib/workstation-icon-metadata";
@@ -22,12 +28,19 @@ export interface DashboardFlowAxisLegendIconItem {
   label: string;
 }
 
+export interface DashboardFlowAxisLegendPhaseItem {
+  id: FactoryGraphWorkStateType;
+  label: string;
+  swatchClassName: string;
+}
+
 export interface DashboardFlowAxisLegendProps {
   ariaLabel?: string;
   className?: string;
   defaultExpanded?: boolean;
   edgeItems: readonly DashboardFlowAxisLegendEdgeItem[];
   iconItems: readonly DashboardFlowAxisLegendIconItem[];
+  phaseItems: readonly DashboardFlowAxisLegendPhaseItem[];
   locale?: string;
 }
 
@@ -109,6 +122,18 @@ export function getDefaultDashboardFlowAxisLegendIconItems(
   ];
 }
 
+export function getDefaultDashboardFlowAxisLegendPhaseItems(
+  locale?: string,
+): readonly DashboardFlowAxisLegendPhaseItem[] {
+  const messages = getFactoryGraphEditorMessages(locale);
+
+  return WORK_STATE_PHASE_LEGEND_ORDER.map((phase) => ({
+    id: phase,
+    label: messages.workStatePhaseLegendLabel(phase),
+    swatchClassName: workStatePhaseSwatchClassName(phase),
+  }));
+}
+
 const DEFAULT_CONTAINER_CLASS =
   "pointer-events-none z-10 flex flex-col items-stretch gap-2 md:items-start";
 const TOGGLE_BUTTON_CLASS =
@@ -121,6 +146,8 @@ const COLLAPSE_BUTTON_CLASS =
   "dashboard-eyebrow shrink-0 cursor-pointer rounded-full border border-af-border bg-af-surface-subtle px-3 py-2 text-af-text-muted transition hover:border-af-border-strong hover:bg-af-overlay hover:text-af-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-af-focus-ring";
 const ITEMS_LIST_CLASS =
   "m-0 grid list-none grid-cols-1 gap-x-3 gap-y-2 p-0 sm:grid-cols-2";
+const LEGEND_SECTIONS_CLASS = "flex flex-col gap-3";
+const PHASE_SWATCH_CLASS = "h-3 w-3 shrink-0 rounded-sm border";
 
 function normalizeLabelForAction(ariaLabel: string): string {
   return ariaLabel.charAt(0).toLowerCase() + ariaLabel.slice(1);
@@ -162,46 +189,80 @@ function DashboardFlowAxisLegendItems({
   edgeItems,
   iconItems,
   locale,
-}: Pick<DashboardFlowAxisLegendProps, "edgeItems" | "iconItems" | "locale">) {
+  phaseItems,
+}: Pick<
+  DashboardFlowAxisLegendProps,
+  "edgeItems" | "iconItems" | "locale" | "phaseItems"
+>) {
   const messages = getDashboardFlowAxisLegendMessages(locale);
+  const editorMessages = getFactoryGraphEditorMessages(locale);
 
   return (
-    <ul className={ITEMS_LIST_CLASS}>
-      {edgeItems.map((item) => (
-        <li
-          className="flex items-center gap-2"
-          data-legend-edge={item.id}
-          key={item.id}
-        >
-          <span
-            className={cn(
-              "h-1 w-7 rounded-full",
-              edgeSwatchClassName(item.tone),
-            )}
-            data-legend-flow={item.tone === "active" ? "" : undefined}
-          />
-          <span className="dashboard-body-sm min-w-0 text-af-text-muted [overflow-wrap:anywhere]">
-            {item.label}
-          </span>
-        </li>
-      ))}
-      {iconItems.map((item) => (
-        <li
-          className="flex min-w-0 items-center gap-2"
-          data-legend-icon={item.kind}
-          key={item.kind}
-        >
-          <GraphSemanticIcon
-            className={cn("h-4 w-4", item.iconClassName)}
-            kind={item.kind}
-            label={messages.iconLabel(item.label)}
-          />
-          <span className="dashboard-body-sm min-w-0 text-af-text-muted [overflow-wrap:anywhere]">
-            {item.label}
-          </span>
-        </li>
-      ))}
-    </ul>
+    <div className={LEGEND_SECTIONS_CLASS}>
+      {edgeItems.length > 0 ? (
+        <ul className={ITEMS_LIST_CLASS}>
+          {edgeItems.map((item) => (
+            <li
+              className="flex items-center gap-2"
+              data-legend-edge={item.id}
+              key={item.id}
+            >
+              <span
+                className={cn(
+                  "h-1 w-7 rounded-full",
+                  edgeSwatchClassName(item.tone),
+                )}
+                data-legend-flow={item.tone === "active" ? "" : undefined}
+              />
+              <span className="dashboard-body-sm min-w-0 text-af-text-muted [overflow-wrap:anywhere]">
+                {item.label}
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {phaseItems.length > 0 ? (
+        <section aria-label={editorMessages.workStatePhaseLegendAriaLabel}>
+          <ul className={ITEMS_LIST_CLASS}>
+            {phaseItems.map((item) => (
+              <li
+                className="flex items-center gap-2"
+                data-legend-phase={item.id}
+                key={item.id}
+              >
+                <span
+                  aria-hidden="true"
+                  className={cn(PHASE_SWATCH_CLASS, item.swatchClassName)}
+                />
+                <span className="dashboard-body-sm min-w-0 text-af-text-muted [overflow-wrap:anywhere]">
+                  {item.label}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+      {iconItems.length > 0 ? (
+        <ul className={ITEMS_LIST_CLASS}>
+          {iconItems.map((item) => (
+            <li
+              className="flex min-w-0 items-center gap-2"
+              data-legend-icon={item.kind}
+              key={item.kind}
+            >
+              <GraphSemanticIcon
+                className={cn("h-4 w-4", item.iconClassName)}
+                kind={item.kind}
+                label={messages.iconLabel(item.label)}
+              />
+              <span className="dashboard-body-sm min-w-0 text-af-text-muted [overflow-wrap:anywhere]">
+                {item.label}
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
   );
 }
 
@@ -211,6 +272,7 @@ export function DashboardFlowAxisLegend({
   defaultExpanded = false,
   edgeItems,
   iconItems,
+  phaseItems,
   locale,
 }: DashboardFlowAxisLegendProps) {
   const messages = getDashboardFlowAxisLegendMessages(locale);
@@ -254,6 +316,7 @@ export function DashboardFlowAxisLegend({
             edgeItems={edgeItems}
             iconItems={iconItems}
             locale={locale}
+            phaseItems={phaseItems}
           />
         </aside>
       ) : (

--- a/ui/src/features/workflow-activity/components/dashboard-flow-axis-legend.tsx
+++ b/ui/src/features/workflow-activity/components/dashboard-flow-axis-legend.tsx
@@ -146,7 +146,6 @@ const COLLAPSE_BUTTON_CLASS =
   "dashboard-eyebrow shrink-0 cursor-pointer rounded-full border border-af-border bg-af-surface-subtle px-3 py-2 text-af-text-muted transition hover:border-af-border-strong hover:bg-af-overlay hover:text-af-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-af-focus-ring";
 const ITEMS_LIST_CLASS =
   "m-0 grid list-none grid-cols-1 gap-x-3 gap-y-2 p-0 sm:grid-cols-2";
-const LEGEND_SECTIONS_CLASS = "flex flex-col gap-3";
 const PHASE_SWATCH_CLASS = "h-3 w-3 shrink-0 rounded-sm border";
 
 function normalizeLabelForAction(ariaLabel: string): string {
@@ -198,7 +197,7 @@ function DashboardFlowAxisLegendItems({
   const editorMessages = getFactoryGraphEditorMessages(locale);
 
   return (
-    <div className={LEGEND_SECTIONS_CLASS}>
+    <div className="flex flex-col gap-3">
       {edgeItems.length > 0 ? (
         <ul className={ITEMS_LIST_CLASS}>
           {edgeItems.map((item) => (

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.test.tsx
@@ -66,6 +66,19 @@ const importController: CurrentActivityImportController = {
 
 // biome-ignore lint/complexity/noExcessiveLinesPerFunction: viewport coverage keeps related mocked React Flow click paths together.
 describe("CurrentActivityGraphViewport", () => {
+  it.each([{ editorMode: false }, { editorMode: true }])(
+    "does not render the top-right work-state phase legend when editorMode is $editorMode",
+    ({ editorMode }) => {
+      const { container } = renderViewport({ editorMode });
+
+      expect(
+        container.querySelector(
+          "[data-factory-graph-work-state-phase-legend]",
+        ),
+      ).toBeNull();
+    },
+  );
+
   it.each([
     {
       expectedNodeId: "work-type:story",

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
@@ -32,6 +32,7 @@ import {
   DashboardFlowAxisLegend,
   getDefaultDashboardFlowAxisLegendEdgeItems,
   getDefaultDashboardFlowAxisLegendIconItems,
+  getDefaultDashboardFlowAxisLegendPhaseItems,
 } from "./dashboard-flow-axis-legend";
 import {
   GraphDropOverlay,
@@ -251,6 +252,7 @@ export function CurrentActivityGraphViewport({
         defaultExpanded={false}
         edgeItems={getDefaultDashboardFlowAxisLegendEdgeItems(locale)}
         iconItems={getDefaultDashboardFlowAxisLegendIconItems(locale)}
+        phaseItems={getDefaultDashboardFlowAxisLegendPhaseItems(locale)}
         locale={locale}
       />
       <section

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
@@ -21,7 +21,6 @@ import type { WorkstationProgressOutcomeRouteContext } from "../../current-facto
 import {
   type FactoryGraphEditorMenuAction,
   FactoryGraphEditorToolbar,
-  FactoryGraphEditorWorkStatePhaseLegend,
 } from "../../factory-graph-editor/components/factory-graph-editor-controls";
 import type { FactoryGraphNodeKind } from "../../factory-graph-editor/lib/factory-graph-draft-types";
 import { isValidFactoryGraphConnection } from "../../factory-graph-editor/lib/factory-graph-editor-connections";
@@ -57,30 +56,24 @@ function CurrentActivityGraphEditorChrome(props: {
   saveDisabledReason?: string;
 }) {
   return (
-    <>
-      <FactoryGraphEditorWorkStatePhaseLegend
-        locale={props.locale}
-        visible={props.editorMode}
-      />
-      <FactoryGraphEditorToolbar
-        activeTool={props.activeTool}
-        addMenuActions={props.addMenuActions}
-        canDiscard={props.hasPendingChanges}
-        canInteract={props.canInteractWithEditor}
-        canSave={props.canSaveDraft}
-        hasPendingChanges={props.hasPendingChanges}
-        isSaving={props.isSavingDraft}
-        locale={props.locale}
-        onAddAction={props.onAddAction}
-        onAddMenuOpenChange={props.onAddMenuOpenChange}
-        onDiscard={props.handleDiscardPendingChanges}
-        onSave={props.handleSaveDraft}
-        onSelectTool={props.onSelectTool}
-        openAddMenu={props.openAddMenu}
-        saveDisabledReason={props.saveDisabledReason}
-        visible={props.editorMode}
-      />
-    </>
+    <FactoryGraphEditorToolbar
+      activeTool={props.activeTool}
+      addMenuActions={props.addMenuActions}
+      canDiscard={props.hasPendingChanges}
+      canInteract={props.canInteractWithEditor}
+      canSave={props.canSaveDraft}
+      hasPendingChanges={props.hasPendingChanges}
+      isSaving={props.isSavingDraft}
+      locale={props.locale}
+      onAddAction={props.onAddAction}
+      onAddMenuOpenChange={props.onAddMenuOpenChange}
+      onDiscard={props.handleDiscardPendingChanges}
+      onSave={props.handleSaveDraft}
+      onSelectTool={props.onSelectTool}
+      openAddMenu={props.openAddMenu}
+      saveDisabledReason={props.saveDisabledReason}
+      visible={props.editorMode}
+    />
   );
 }
 

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card.coverage.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card.coverage.test.tsx
@@ -1,5 +1,4 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { DashboardSessionTestProvider } from "../../../testing/dashboard-session-test-provider";
 import {
   act,
   fireEvent,
@@ -9,11 +8,11 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
-
 import {
   semanticWorkflowDashboardSnapshot,
   singleNodeDashboardSnapshot,
 } from "../../../components/dashboard/test-fixtures";
+import { DashboardSessionTestProvider } from "../../../testing/dashboard-session-test-provider";
 import { useCurrentFactoryDocument } from "../../current-factory-definition/hooks/useCurrentFactoryDefinition";
 import { useFactoryDocumentSave } from "../../current-factory-definition/hooks/useFactoryDocumentSave";
 import { useFactoryGraphDraftState } from "../../factory-graph-editor/hooks/factory-graph-draft-hook";
@@ -194,6 +193,7 @@ vi.mock("./dashboard-flow-axis-legend", () => ({
   ),
   getDefaultDashboardFlowAxisLegendEdgeItems: () => [],
   getDefaultDashboardFlowAxisLegendIconItems: () => [],
+  getDefaultDashboardFlowAxisLegendPhaseItems: () => [],
 }));
 
 vi.mock("./react-flow-current-activity-card-import", () => ({
@@ -202,31 +202,40 @@ vi.mock("./react-flow-current-activity-card-import", () => ({
   graphDropStateAttribute: () => "idle",
 }));
 
-vi.mock("../../current-factory-definition/hooks/useCurrentFactoryDefinition", async () => {
-  const actual = await vi.importActual(
-    "../../current-factory-definition/hooks/useCurrentFactoryDefinition",
-  );
+vi.mock(
+  "../../current-factory-definition/hooks/useCurrentFactoryDefinition",
+  async () => {
+    const actual = await vi.importActual(
+      "../../current-factory-definition/hooks/useCurrentFactoryDefinition",
+    );
 
-  return {
-    ...actual,
-    useCurrentFactoryDocument: vi.fn(),
-  };
-});
+    return {
+      ...actual,
+      useCurrentFactoryDocument: vi.fn(),
+    };
+  },
+);
 
-vi.mock("../../current-factory-definition/hooks/useFactoryDocumentSave", () => ({
-  useFactoryDocumentSave: vi.fn(),
-}));
+vi.mock(
+  "../../current-factory-definition/hooks/useFactoryDocumentSave",
+  () => ({
+    useFactoryDocumentSave: vi.fn(),
+  }),
+);
 
-vi.mock("../../factory-graph-editor/hooks/factory-graph-draft-hook", async () => {
-  const actual = await vi.importActual(
-    "../../factory-graph-editor/hooks/factory-graph-draft-hook",
-  );
+vi.mock(
+  "../../factory-graph-editor/hooks/factory-graph-draft-hook",
+  async () => {
+    const actual = await vi.importActual(
+      "../../factory-graph-editor/hooks/factory-graph-draft-hook",
+    );
 
-  return {
-    ...actual,
-    useFactoryGraphDraftState: vi.fn(),
-  };
-});
+    return {
+      ...actual,
+      useFactoryGraphDraftState: vi.fn(),
+    };
+  },
+);
 
 vi.mock("../../factory-graph-editor/hooks/use-factory-validation", () => ({
   useFactoryValidation: () => ({

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card.test.tsx
@@ -3078,13 +3078,14 @@ describe("ReactFlowCurrentActivityCard graph semantics", () => {
     expect(legend.querySelector("[data-legend-flow]")).toBeTruthy();
     expect(collapseButton.getAttribute("aria-expanded")).toBe("true");
     for (const [label, kind] of LEGEND_ICON_EXPECTATIONS) {
+      const iconEntry = legend.querySelector(`[data-legend-icon='${kind}']`);
       const icon = legendScope.getByRole("img", {
         name: `${label} legend icon`,
       });
 
+      expect(iconEntry).toBeTruthy();
       expect(icon.getAttribute("data-graph-semantic-icon")).toBe(kind);
-      expect(legendScope.getByText(label)).toBeTruthy();
-      expect(legend.querySelector(`[data-legend-icon='${kind}']`)).toBeTruthy();
+      expect(within(iconEntry as HTMLElement).getByText(label)).toBeTruthy();
     }
     expect(
       legend.querySelector("[data-legend-icon='queue'] span.h-3"),


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/issues2-graph-state-node-colors",
  "description": "Color dashboard workflow graph work-state nodes by lifecycle phase from state_category metadata (init blue, processing yellow, completed green, failed red), document those colors in the left graph legend, and remove the duplicate top-right phase legend.",
  "context": {
    "customerAsk": "Color work-state nodes by state type; merge legend. State nodes styled by state category metadata. Single left legend documents state colors. Top-right duplicate legend removed. Init blue, processing yellow, completed green, failed red.",
    "problem": "Dashboard workflow graph work-state nodes use mostly neutral surfaces while a separate top-right phase legend (editor mode) duplicates lifecycle semantics partially covered by the left graph legend, forcing operators to cross-reference two legend regions.",
    "solution": "Reuse factory-graph-work-state-phase-styling to apply lifecycle surface and icon colors from place.state_category on work-state nodes, add swatch-based Initial/Processing/Completed/Failed entries to DashboardFlowAxisLegend, and remove FactoryGraphEditorWorkStatePhaseLegend from the workflow graph viewport."
  },
  "acceptanceCriteria": [
    "Work-state nodes on the dashboard workflow graph render lifecycle surface colors from state_category: INITIAL blue, PROCESSING yellow, TERMINAL green, FAILED red",
    "Work-state nodes without state_category use neutral fallback styling; non-work-state nodes are unchanged",
    "Expanded left graph legend documents work-state lifecycle colors with swatches and localized Initial, Processing, Completed, and Failed labels",
    "Top-right FactoryGraphEditorWorkStatePhaseLegend is not rendered on the workflow graph viewport in observer or editor mode",
    "Selection, active-flow, validation-error, and editor draft treatments remain visible on lifecycle-colored work-state nodes",
    "Automated tests cover node surface class mapping and consolidated legend behavior",
    "UI typecheck, lint, and affected tests pass"
  ],
  "userStories": [
    {
      "id": "issues2-graph-state-node-colors-001",
      "title": "Style dashboard work-state nodes from state category metadata",
      "description": "As a factory operator viewing the workflow graph, I want work-state nodes colored by lifecycle phase so I can identify init, processing, completed, and failed states without reading every label.",
      "acceptanceCriteria": [
        "Work-state nodes apply lifecycle surface classes from shared phase styling: INITIAL info/blue, PROCESSING warning/yellow, TERMINAL success/green, FAILED danger/red",
        "Surface colors are driven by place.state_category via factory-graph-work-state-phase-styling without duplicating token maps",
        "Work-state semantic icon tones align with the same lifecycle mapping",
        "Non-work-state nodes and missing state_category keep existing or neutral styling unchanged",
        "Selection, active-flow, and validation-error treatments remain visually distinct on colored nodes",
        "Unit tests assert surface classes for each state_category and neutral fallback",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues2-graph-state-node-colors-002",
      "title": "Document work-state lifecycle colors in the left graph legend",
      "description": "As a factory operator, I want the left graph legend to explain work-state node fill colors so I do not need a second legend to decode node backgrounds.",
      "acceptanceCriteria": [
        "Expanded DashboardFlowAxisLegend includes swatch entries for Initial, Processing, Completed, and Failed using workStatePhaseSwatchClassName tokens",
        "Swatch labels use localized factory graph editor lifecycle legend copy for supported locales",
        "Lifecycle swatch group has an accessible label distinct from edge-flow and icon sections",
        "Minimized legend toggle behavior is unchanged; swatches appear only when the panel is expanded",
        "Unit tests assert all four lifecycle labels and swatch classes render in the expanded legend",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill: expand left graph legend and confirm Initial, Processing, Completed, and Failed swatches with matching colors"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues2-graph-state-node-colors-003",
      "title": "Remove duplicate top-right phase legend from workflow graph",
      "description": "As a factory operator editing topology, I want a single legend on the graph so lifecycle colors are documented once without overlapping UI chrome.",
      "acceptanceCriteria": [
        "FactoryGraphEditorWorkStatePhaseLegend is not mounted in react-flow-current-activity-card-viewport in observer or editor mode",
        "Entering editor mode does not render data-factory-graph-work-state-phase-legend on the workflow graph surface",
        "Left legend remains the sole documentation for work-state lifecycle colors on this surface",
        "Tests and stories that asserted the top-right legend are updated for consolidated left-legend behavior",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill: enter graph editor mode and confirm no top-right phase legend while left legend documents lifecycle colors"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)