### PR TITLE
issues2-factory-graph-onrejection-edge-fix

### DIFF
--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-flow.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-flow.tsx
@@ -66,6 +66,7 @@ export function buildFactoryGraphEditorFlowModel(input: {
 } {
   const projection = projectFactoryGraphToReactFlow({
     factoryDefinition: input.factoryDefinition,
+    filterEdgesToRenderedHandles: true,
     editor: {
       canEditConnections: input.canEditConnections,
       onConnectionAnchorClick: input.onConnectionAnchorClick,

--- a/ui/src/features/factory-graph-editor/hooks/use-editable-factory-graph.ts
+++ b/ui/src/features/factory-graph-editor/hooks/use-editable-factory-graph.ts
@@ -43,6 +43,7 @@ export function useEditableFactoryGraph(
 
     return projectFactoryGraphToReactFlow({
       factoryDefinition,
+      filterEdgesToRenderedHandles: true,
       locale: options.locale ?? undefined,
       topology: draftState.graph,
       workstationResolver: factoryDefinition

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-draft-apply.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-draft-apply.ts
@@ -106,7 +106,7 @@ export function applyWorkstationEdgeChanges(
   const nextWorkstation = structuredClone(workstation);
 
   nextWorkstation.inputs = applyIOEdgeChanges(
-    nextWorkstation.inputs,
+    nextWorkstation.inputs ?? [],
     draft,
     workstationKey,
     "workstation-input",

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-react-flow-projection.test.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-react-flow-projection.test.ts
@@ -466,6 +466,7 @@ describe("factory graph React Flow projection", () => {
     };
 
     const projection = projectFactoryGraphToReactFlow({
+      filterEdgesToRenderedHandles: true,
       topology,
       workstationResolver,
     });
@@ -487,6 +488,50 @@ describe("factory graph React Flow projection", () => {
     expect(edgeKinds).not.toContain("workstation-on-rejection");
     expect(edgeKinds).toContain("workstation-on-failure");
     expect(edgeKinds).toContain("workstation-output");
+  });
+
+  it("keeps progress-outcome edges for observer projections when handle filtering is disabled", () => {
+    const factoryWithoutStopWords = {
+      ...baseFactoryDefinition,
+      workTypes: [
+        {
+          name: "story",
+          states: [
+            { name: "queued", type: "INITIAL" },
+            { name: "rejected", type: "FAILED" },
+            { name: "done", type: "TERMINAL" },
+          ],
+        },
+      ],
+      workstations: [
+        {
+          ...baseFactoryDefinition.workstations[0],
+          behavior: "STANDARD",
+          onContinue: [{ state: "queued", workType: "story" }],
+          onFailure: [{ state: "rejected", workType: "story" }],
+          onRejection: [{ state: "rejected", workType: "story" }],
+          stopWords: undefined,
+        },
+      ],
+    } satisfies CanonicalFactoryDefinition;
+    const topology = buildFactoryGraphTopologyFromDefinition(
+      factoryWithoutStopWords,
+    );
+
+    const projection = projectFactoryGraphToReactFlow({
+      mode: "observer",
+      topology,
+      workstationResolver: {
+        resolveWorkstation: (name) =>
+          factoryWithoutStopWords.workstations.find(
+            (workstation) => workstation.name === name,
+          ),
+      },
+    });
+    const edgeKinds = projection.edges.map((edge) => edge.data?.kind);
+
+    expect(edgeKinds).toContain("workstation-on-continue");
+    expect(edgeKinds).toContain("workstation-on-rejection");
   });
 
   it("omits worker-assignment handles on LOGICAL_MOVE workstations", () => {

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-react-flow-projection.test.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-react-flow-projection.test.ts
@@ -434,10 +434,23 @@ describe("factory graph React Flow projection", () => {
   it("omits continue and reject handles for a standard processor without stopWords", () => {
     const factoryWithoutStopWords = {
       ...baseFactoryDefinition,
+      workTypes: [
+        {
+          name: "story",
+          states: [
+            { name: "queued", type: "INITIAL" },
+            { name: "rejected", type: "FAILED" },
+            { name: "done", type: "TERMINAL" },
+          ],
+        },
+      ],
       workstations: [
         {
           ...baseFactoryDefinition.workstations[0],
           behavior: "STANDARD",
+          onContinue: [{ state: "queued", workType: "story" }],
+          onFailure: [{ state: "rejected", workType: "story" }],
+          onRejection: [{ state: "rejected", workType: "story" }],
           stopWords: undefined,
         },
       ],
@@ -460,6 +473,7 @@ describe("factory graph React Flow projection", () => {
       projection.nodes
         .find((node) => node.id === "workstation:draft")
         ?.data.connectionAnchors.map((anchor) => anchor.id) ?? [];
+    const edgeKinds = projection.edges.map((edge) => edge.data?.kind);
 
     expect(anchorIds).toEqual(
       expect.arrayContaining([
@@ -469,6 +483,10 @@ describe("factory graph React Flow projection", () => {
     );
     expect(anchorIds).not.toContain("workstation-on-continue-source");
     expect(anchorIds).not.toContain("workstation-on-rejection-source");
+    expect(edgeKinds).not.toContain("workstation-on-continue");
+    expect(edgeKinds).not.toContain("workstation-on-rejection");
+    expect(edgeKinds).toContain("workstation-on-failure");
+    expect(edgeKinds).toContain("workstation-output");
   });
 
   it("omits worker-assignment handles on LOGICAL_MOVE workstations", () => {
@@ -525,10 +543,23 @@ describe("factory graph React Flow projection", () => {
   it("exposes continue and reject handles when stopWords is configured", () => {
     const factoryWithStopWords = {
       ...baseFactoryDefinition,
+      workTypes: [
+        {
+          name: "story",
+          states: [
+            { name: "queued", type: "INITIAL" },
+            { name: "rejected", type: "FAILED" },
+            { name: "done", type: "TERMINAL" },
+          ],
+        },
+      ],
       workstations: [
         {
           ...baseFactoryDefinition.workstations[0],
           behavior: "STANDARD",
+          onContinue: [{ state: "queued", workType: "story" }],
+          onFailure: [{ state: "rejected", workType: "story" }],
+          onRejection: [{ state: "rejected", workType: "story" }],
           stopWords: ["DONE"],
         },
       ],
@@ -549,8 +580,11 @@ describe("factory graph React Flow projection", () => {
       projection.nodes
         .find((node) => node.id === "workstation:draft")
         ?.data.connectionAnchors.map((anchor) => anchor.id) ?? [];
+    const edgeKinds = projection.edges.map((edge) => edge.data?.kind);
 
     expect(anchorIds).toContain("workstation-on-continue-source");
     expect(anchorIds).toContain("workstation-on-rejection-source");
+    expect(edgeKinds).toContain("workstation-on-continue");
+    expect(edgeKinds).toContain("workstation-on-rejection");
   });
 });

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-react-flow-projection.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-react-flow-projection.ts
@@ -148,81 +148,87 @@ export function projectFactoryGraphToReactFlow(
     topology: displayTopology,
   };
 
-  return {
-    edges: displayTopology.edges.map((edge) =>
-      buildFactoryGraphReactFlowEdge(edge, projectionInput),
-    ),
-    nodes: [...displayTopology.nodes]
-      .sort(sortFactoryGraphNodes)
-      .map((node) => {
-        const column = COLUMN_BY_KIND[node.kind];
-        const row = rowCounts.get(column) ?? 0;
-        rowCounts.set(column, row + 1);
-        const workerStatus =
-          node.kind === "worker"
-            ? (input.runtime?.workerStatusByName?.get(node.label) ?? "idle")
-            : undefined;
-        const canEditConnections = input.editor?.canEditConnections ?? false;
-        const anchorContext = resolveFactoryGraphConnectionAnchorContext(
-          node,
-          input.workstationResolver,
-        );
-        const workStateType =
-          node.kind === "work-state" && node.key.kind === "work-state"
-            ? resolveWorkStateTypeForGraphNode(
-                input.factoryDefinition,
-                node.key,
-              )
-            : undefined;
+  const nodes = [...displayTopology.nodes]
+    .sort(sortFactoryGraphNodes)
+    .map((node) => {
+      const column = COLUMN_BY_KIND[node.kind];
+      const row = rowCounts.get(column) ?? 0;
+      rowCounts.set(column, row + 1);
+      const workerStatus =
+        node.kind === "worker"
+          ? (input.runtime?.workerStatusByName?.get(node.label) ?? "idle")
+          : undefined;
+      const canEditConnections = input.editor?.canEditConnections ?? false;
+      const anchorContext = resolveFactoryGraphConnectionAnchorContext(
+        node,
+        input.workstationResolver,
+      );
+      const workStateType =
+        node.kind === "work-state" && node.key.kind === "work-state"
+          ? resolveWorkStateTypeForGraphNode(input.factoryDefinition, node.key)
+          : undefined;
 
-        return {
-          className: nodeClassName(node.id, input),
-          data: {
-            active: input.runtime?.activeNodeIds?.has(node.id) ?? false,
-            activeFlow: input.runtime?.activeNodeIds?.has(node.id) ?? false,
-            activeTool: input.editor?.activeTool ?? null,
+      return {
+        className: nodeClassName(node.id, input),
+        data: {
+          active: input.runtime?.activeNodeIds?.has(node.id) ?? false,
+          activeFlow: input.runtime?.activeNodeIds?.has(node.id) ?? false,
+          activeTool: input.editor?.activeTool ?? null,
+          canEditConnections,
+          connectionAnchors: buildNodeHandles({
+            editor: input.editor,
+            locale: input.locale,
+            node,
+            topology: displayTopology,
+            workstationResolver: input.workstationResolver,
+          }),
+          connectionHint: messages.flowConnectionHint,
+          draftStatus: draftStatusForNode(node.id, input.editor),
+          focused: input.runtime?.focusedNodeIds?.has(node.id) ?? false,
+          kind: node.kind,
+          kindLabel: messages.kindLabel(node.kind),
+          label: node.label,
+          muted: input.runtime?.mutedNodeIds?.has(node.id) ?? false,
+          pendingLabel: messages.flowPendingLabel,
+          removingLabel: messages.flowRemovingLabel,
+          selectedWorkId: input.runtime?.selectedWorkId ?? null,
+          tokenCount:
+            input.runtime?.placeTokenCountsByNodeId?.get(node.id) ?? null,
+          validationMessage: validationMessages.get(node.id) ?? null,
+          ...(node.kind === "work-state" ? { workStateType } : {}),
+          workerStatus,
+          workerStatusLabel: workerStatus
+            ? messages.workerStatusLabel(workerStatus)
+            : undefined,
+          zAxisIncompleteHints: resolveFactoryGraphZAxisIncompleteHints({
+            anchorContext,
             canEditConnections,
-            connectionAnchors: buildNodeHandles({
-              editor: input.editor,
-              locale: input.locale,
-              node,
-              topology: displayTopology,
-              workstationResolver: input.workstationResolver,
-            }),
-            connectionHint: messages.flowConnectionHint,
-            draftStatus: draftStatusForNode(node.id, input.editor),
-            focused: input.runtime?.focusedNodeIds?.has(node.id) ?? false,
-            kind: node.kind,
-            kindLabel: messages.kindLabel(node.kind),
-            label: node.label,
-            muted: input.runtime?.mutedNodeIds?.has(node.id) ?? false,
-            pendingLabel: messages.flowPendingLabel,
-            removingLabel: messages.flowRemovingLabel,
-            selectedWorkId: input.runtime?.selectedWorkId ?? null,
-            tokenCount:
-              input.runtime?.placeTokenCountsByNodeId?.get(node.id) ?? null,
-            validationMessage: validationMessages.get(node.id) ?? null,
-            ...(node.kind === "work-state" ? { workStateType } : {}),
-            workerStatus,
-            workerStatusLabel: workerStatus
-              ? messages.workerStatusLabel(workerStatus)
-              : undefined,
-            zAxisIncompleteHints: resolveFactoryGraphZAxisIncompleteHints({
-              anchorContext,
-              canEditConnections,
-              locale: input.locale,
-              nodeKind: node.kind,
-            }),
-          },
-          draggable: true,
-          id: node.id,
-          position: input.layoutPositionsByNodeId?.get(node.id) ?? {
-            x: column * COLUMN_X,
-            y: row * ROW_Y,
-          },
-          type: "factoryEntity",
-        } satisfies FactoryGraphReactFlowNode;
-      }),
+            locale: input.locale,
+            nodeKind: node.kind,
+          }),
+        },
+        draggable: true,
+        id: node.id,
+        position: input.layoutPositionsByNodeId?.get(node.id) ?? {
+          x: column * COLUMN_X,
+          y: row * ROW_Y,
+        },
+        type: "factoryEntity",
+      } satisfies FactoryGraphReactFlowNode;
+    });
+  const nodesById = new Map(nodes.map((node) => [node.id, node]));
+
+  return {
+    edges: displayTopology.edges
+      .map((topologyEdge) => ({
+        edge: buildFactoryGraphReactFlowEdge(topologyEdge, projectionInput),
+        kind: topologyEdge.kind,
+      }))
+      .filter(({ edge, kind }) =>
+        shouldIncludeFactoryGraphReactFlowEdge(edge, kind, nodesById),
+      )
+      .map(({ edge }) => edge),
+    nodes,
   };
 }
 
@@ -248,6 +254,34 @@ function sortFactoryGraphNodes(
     return leftColumn - rightColumn;
   }
   return left.label.localeCompare(right.label);
+}
+
+function shouldIncludeFactoryGraphReactFlowEdge(
+  edge: FactoryGraphReactFlowEdge,
+  edgeKind: FactoryGraphEdge["kind"] | undefined,
+  nodesById: ReadonlyMap<string, FactoryGraphReactFlowNode>,
+): boolean {
+  if (edgeKind === "work-type-state") {
+    return true;
+  }
+
+  const sourceNode = nodesById.get(edge.source);
+  const targetNode = nodesById.get(edge.target);
+  if (!sourceNode || !targetNode || !edge.sourceHandle || !edge.targetHandle) {
+    return false;
+  }
+
+  const sourceAnchorIds = new Set(
+    sourceNode.data.connectionAnchors.map((anchor) => anchor.id),
+  );
+  const targetAnchorIds = new Set(
+    targetNode.data.connectionAnchors.map((anchor) => anchor.id),
+  );
+
+  return (
+    sourceAnchorIds.has(edge.sourceHandle) &&
+    targetAnchorIds.has(edge.targetHandle)
+  );
 }
 
 function buildFactoryGraphReactFlowEdge(
@@ -405,7 +439,9 @@ export function resolveFactoryGraphZAxisIncompleteHints(input: {
     input.nodeKind !== "workstation" ||
     !input.canEditConnections ||
     !input.anchorContext?.workstation ||
-    !workstationHasZAxisIncompleteForConnections(input.anchorContext.workstation)
+    !workstationHasZAxisIncompleteForConnections(
+      input.anchorContext.workstation,
+    )
   ) {
     return null;
   }

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-react-flow-projection.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-react-flow-projection.ts
@@ -98,6 +98,8 @@ export interface FactoryGraphReactFlowEditorOverlay {
 
 export interface ProjectFactoryGraphToReactFlowOptions {
   editor?: FactoryGraphReactFlowEditorOverlay;
+  /** When true, omit edges whose handles are absent from rendered connection anchors. */
+  filterEdgesToRenderedHandles?: boolean;
   factoryDefinition?: CanonicalFactoryDefinition | null;
   layoutPositionsByNodeId?: ReadonlyMap<string, { x: number; y: number }>;
   locale?: string;
@@ -218,16 +220,20 @@ export function projectFactoryGraphToReactFlow(
     });
   const nodesById = new Map(nodes.map((node) => [node.id, node]));
 
+  const projectedEdges = displayTopology.edges.map((topologyEdge) =>
+    buildFactoryGraphReactFlowEdge(topologyEdge, projectionInput),
+  );
+
   return {
-    edges: displayTopology.edges
-      .map((topologyEdge) => ({
-        edge: buildFactoryGraphReactFlowEdge(topologyEdge, projectionInput),
-        kind: topologyEdge.kind,
-      }))
-      .filter(({ edge, kind }) =>
-        shouldIncludeFactoryGraphReactFlowEdge(edge, kind, nodesById),
-      )
-      .map(({ edge }) => edge),
+    edges: input.filterEdgesToRenderedHandles
+      ? projectedEdges.filter((edge) =>
+          shouldIncludeFactoryGraphReactFlowEdge(
+            edge,
+            edge.data?.kind,
+            nodesById,
+          ),
+        )
+      : projectedEdges,
     nodes,
   };
 }

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-edit-mode-onrejection-edge.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-edit-mode-onrejection-edge.test.tsx
@@ -1,0 +1,340 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { Edge, Node } from "@xyflow/react";
+import type { ReactElement, ReactNode } from "react";
+
+import type { CurrentFactoryDocument } from "../../../api/current-factory-definition";
+import type { DashboardSnapshot } from "../../../api/dashboard/types";
+import { installDashboardBrowserTestShims } from "../../../components/dashboard/test-browser-shims";
+import { DashboardSessionTestProvider } from "../../../testing/dashboard-session-test-provider";
+import {
+  createHookTestGraphEditorDraftState,
+  wireMockEditableFactoryGraph,
+} from "../../../testing/graph-editor-harness";
+import { useCurrentFactoryDocument } from "../../current-factory-definition/hooks/useCurrentFactoryDefinition";
+import { useFactoryDocumentSave } from "../../current-factory-definition/hooks/useFactoryDocumentSave";
+import { useFactoryGraphDraftState } from "../../factory-graph-editor/hooks/factory-graph-draft-hook";
+import { useEditableFactoryGraph } from "../../factory-graph-editor/hooks/use-editable-factory-graph";
+import type { CurrentActivityImportController } from "../hooks/current-activity-import-controller";
+import { dashboardWorkstationFromFactory } from "../lib/current-activity-factory-graph-layout";
+import { loadFactoryGraphOnrejectionEdgeReproductionFactory } from "../lib/test-data/factory-graph-onrejection-edge-reproduction.fixture";
+import { useCurrentActivityGraphStore } from "../state/currentActivityGraphStore";
+import { ReactFlowCurrentActivityCard } from "./react-flow-current-activity-card";
+
+const reportedReactFlowErrors: Array<{ errorId: string; message: string }> = [];
+
+vi.mock("@xyflow/react", async () => {
+  const actual = await vi.importActual("@xyflow/react");
+
+  return {
+    ...actual,
+    Background: () => <div data-testid="graph-background" />,
+    Controls: () => <div data-testid="graph-controls" />,
+    ReactFlow: ({
+      children,
+      edges,
+      nodes,
+      onError,
+    }: {
+      children: ReactNode;
+      edges?: Edge[];
+      nodes?: Node[];
+      onError?: (errorId: string, message: string) => void;
+    }) => {
+      reportMissingEdgeHandles({
+        edges: edges ?? [],
+        nodes: nodes ?? [],
+        onError,
+      });
+
+      return (
+        <div data-testid="mock-react-flow">
+          <ul aria-label="Rendered graph edges">
+            {(edges ?? []).map((edge) => (
+              <li key={edge.id}>{edge.id}</li>
+            ))}
+          </ul>
+          {children}
+        </div>
+      );
+    },
+  };
+});
+
+function reportMissingEdgeHandles({
+  edges,
+  nodes,
+  onError,
+}: {
+  edges: Edge[];
+  nodes: Node[];
+  onError?: (errorId: string, message: string) => void;
+}) {
+  for (const edge of edges) {
+    const sourceNode = nodes.find((node) => node.id === edge.source);
+    const targetNode = nodes.find((node) => node.id === edge.target);
+    if (!sourceNode || !targetNode) {
+      const payload = {
+        errorId: "006",
+        message: `Couldn't create edge for missing node, edge id: ${edge.id}.`,
+      };
+      reportedReactFlowErrors.push(payload);
+      onError?.(payload.errorId, payload.message);
+      continue;
+    }
+
+    if (!nodeHasHandle(sourceNode, edge.sourceHandle)) {
+      const payload = {
+        errorId: "008",
+        message: `Couldn't create edge for source handle id: "${edge.sourceHandle}", edge id: ${edge.id}.`,
+      };
+      reportedReactFlowErrors.push(payload);
+      onError?.(payload.errorId, payload.message);
+      continue;
+    }
+
+    if (!nodeHasHandle(targetNode, edge.targetHandle)) {
+      const payload = {
+        errorId: "008",
+        message: `Couldn't create edge for target handle id: "${edge.targetHandle}", edge id: ${edge.id}.`,
+      };
+      reportedReactFlowErrors.push(payload);
+      onError?.(payload.errorId, payload.message);
+    }
+  }
+}
+
+function nodeHasHandle(node: Node, handleId: string | null | undefined) {
+  const handles = (node.data as { handles?: Array<{ id: string }> }).handles;
+  return Boolean(handleId && handles?.some((handle) => handle.id === handleId));
+}
+
+vi.mock(
+  "../../current-factory-definition/hooks/useCurrentFactoryDefinition",
+  async () => {
+    const actual = await vi.importActual(
+      "../../current-factory-definition/hooks/useCurrentFactoryDefinition",
+    );
+
+    return {
+      ...actual,
+      useCurrentFactoryDocument: vi.fn(),
+    };
+  },
+);
+
+vi.mock(
+  "../../current-factory-definition/hooks/useFactoryDocumentSave",
+  () => ({
+    useFactoryDocumentSave: vi.fn(),
+  }),
+);
+
+vi.mock(
+  "../../factory-graph-editor/hooks/use-editable-factory-graph",
+  async () => {
+    const actual = await vi.importActual(
+      "../../factory-graph-editor/hooks/use-editable-factory-graph",
+    );
+
+    return {
+      ...actual,
+      useEditableFactoryGraph: vi.fn(),
+    };
+  },
+);
+
+vi.mock(
+  "../../factory-graph-editor/hooks/factory-graph-draft-hook",
+  async () => {
+    const actual = await vi.importActual(
+      "../../factory-graph-editor/hooks/factory-graph-draft-hook",
+    );
+
+    return {
+      ...actual,
+      useFactoryGraphDraftState: vi.fn(),
+    };
+  },
+);
+
+const importController: CurrentActivityImportController = {
+  activateImport: vi.fn().mockResolvedValue(undefined),
+  activationState: { status: "idle" },
+  clearActivationError: vi.fn(),
+  clearError: vi.fn(),
+  closeImportPreview: vi.fn(),
+  dropState: { status: "idle" },
+  importPreviewState: { status: "idle" },
+  onDragEnter: vi.fn(),
+  onDragLeave: vi.fn(),
+  onDragOver: vi.fn(),
+  onDrop: vi.fn(),
+};
+
+function reproductionFactoryDocument(): CurrentFactoryDocument {
+  return {
+    ...loadFactoryGraphOnrejectionEdgeReproductionFactory(),
+    version: {
+      logical: "repro-onrejection-edge",
+      physical: "2026-05-31T00:00:00Z",
+    },
+  };
+}
+
+function buildReproductionSnapshot(
+  factoryDocument: CurrentFactoryDocument,
+): DashboardSnapshot {
+  const workstations = (factoryDocument.workstations ?? []).map(
+    dashboardWorkstationFromFactory,
+  );
+
+  return {
+    factory: factoryDocument,
+    factory_state: "IDLE",
+    runtime: {
+      active_executions_by_dispatch_id: {},
+      current_work_items_by_place_id: {},
+      place_occupancy_work_items_by_place_id: {},
+      place_token_counts: {},
+      session: {
+        completed_count: 0,
+        dispatched_count: 0,
+        failed_count: 0,
+        has_data: true,
+        provider_sessions: [],
+      },
+      workstation_requests_by_dispatch_id: {},
+    },
+    tick_count: 0,
+    topology: {
+      edges: [],
+      workstation_node_ids: workstations.map(
+        (workstation) => workstation.node_id,
+      ),
+      workstation_nodes_by_id: Object.fromEntries(
+        workstations.map((workstation) => [workstation.node_id, workstation]),
+      ),
+    },
+    uptime_seconds: 0,
+  };
+}
+
+let restoreBrowserTestShims: (() => void) | null = null;
+
+beforeEach(() => {
+  reportedReactFlowErrors.length = 0;
+  window.localStorage.clear();
+  useCurrentActivityGraphStore.setState({ positionsByGraphKey: {} });
+  restoreBrowserTestShims = installDashboardBrowserTestShims();
+
+  const factoryDocument = reproductionFactoryDocument();
+  vi.mocked(useCurrentFactoryDocument).mockReturnValue({
+    data: factoryDocument,
+    error: null,
+    status: "success",
+  } as never);
+  vi.mocked(useFactoryDocumentSave).mockReturnValue({
+    error: null,
+    isPending: false,
+    reset: vi.fn(),
+    save: vi.fn(),
+    saveAsync: vi.fn().mockResolvedValue(factoryDocument),
+  } as never);
+  wireMockEditableFactoryGraph(
+    {
+      useEditableFactoryGraph: vi.mocked(useEditableFactoryGraph),
+      useFactoryGraphDraftState: vi.mocked(useFactoryGraphDraftState),
+    },
+    createHookTestGraphEditorDraftState({
+      baseDocument: factoryDocument,
+      latestDocument: factoryDocument,
+      pendingFactoryDefinition: factoryDocument,
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  restoreBrowserTestShims?.();
+  restoreBrowserTestShims = null;
+  vi.clearAllMocks();
+});
+
+describe("ReactFlowCurrentActivityCard edit-mode onRejection edge regression", () => {
+  it("enters and leaves factory graph editor without React Flow endpoint error 008", async () => {
+    const factoryDocument = reproductionFactoryDocument();
+    renderCurrentActivity(buildReproductionSnapshot(factoryDocument));
+
+    await screen.findByRole("region", { name: "Work graph viewport" });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Enter factory graph editor" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Leave factory graph editor" }),
+      ).toBeTruthy();
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Leave factory graph editor" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Enter factory graph editor" }),
+      ).toBeTruthy();
+    });
+
+    expect(
+      reportedReactFlowErrors.filter((error) => error.errorId === "008"),
+    ).toEqual([]);
+    expect(
+      screen.queryByText(/React Flow factory graph endpoint error 008/),
+    ).toBeNull();
+  });
+});
+
+function renderCurrentActivity(snapshot: DashboardSnapshot) {
+  renderWithQueryClient(
+    <ReactFlowCurrentActivityCard
+      importController={importController}
+      now={Date.parse("2026-05-31T00:00:00Z")}
+      onSelectStateNode={vi.fn()}
+      onSelectWorkID={vi.fn()}
+      onSelectWorker={vi.fn()}
+      onSelectWorkType={vi.fn()}
+      onSelectWorkstation={vi.fn()}
+      selection={null}
+      snapshot={snapshot}
+    />,
+  );
+}
+
+function renderWithQueryClient(view: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: {
+        retry: false,
+      },
+      queries: {
+        gcTime: Infinity,
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <DashboardSessionTestProvider>{view}</DashboardSessionTestProvider>
+    </QueryClientProvider>,
+  );
+}

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport-errors.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport-errors.test.tsx
@@ -221,6 +221,7 @@ describe("CurrentActivityGraphViewport React Flow errors", () => {
       handleAssignments,
       new Set(),
       visibleGraphEdges,
+      nodes,
     );
 
     expect(edges).toEqual(

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
@@ -282,6 +282,16 @@ export function useCurrentActivityGraphViewModel({
         applyNodeChanges(changes, currentNodes) as CurrentActivityNode[],
     );
   }, []);
+  const displayNodes = useMemo(() => {
+    const positionOverrides = new Map(
+      nodes.map((node) => [node.id, node.position] as const),
+    );
+
+    return baseNodes.map((node) => ({
+      ...node,
+      position: positionOverrides.get(node.id) ?? node.position,
+    }));
+  }, [baseNodes, nodes]);
   const edges = useMemo(
     () =>
       buildGraphEdges(
@@ -289,11 +299,11 @@ export function useCurrentActivityGraphViewModel({
         handleAssignments,
         pendingAdditionEdgeIds,
         visibleGraphEdges,
-        baseNodes,
+        displayNodes,
       ),
     [
       activeGraphHighlights,
-      baseNodes,
+      displayNodes,
       handleAssignments,
       pendingAdditionEdgeIds,
       visibleGraphEdges,
@@ -317,7 +327,7 @@ export function useCurrentActivityGraphViewModel({
       initialFitViewOptions.nodes?.map((node) => node.id).join(":") ||
       "full-graph",
     initialFitViewOptions,
-    nodes,
+    nodes: displayNodes,
     setStoredNodePosition,
   };
 }

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
@@ -289,9 +289,11 @@ export function useCurrentActivityGraphViewModel({
         handleAssignments,
         pendingAdditionEdgeIds,
         visibleGraphEdges,
+        baseNodes,
       ),
     [
       activeGraphHighlights,
+      baseNodes,
       handleAssignments,
       pendingAdditionEdgeIds,
       visibleGraphEdges,

--- a/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-edges.ts
+++ b/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-edges.ts
@@ -6,7 +6,12 @@ import type {
   PositionedPlaceNode,
   PositionedWorkstationNode,
 } from "../../flowchart/lib/layout";
-import type { ActiveGraphHighlights, HandleAssignments } from "./react-flow-current-activity-card-graph";
+import type { CurrentActivityNode } from "../../flowchart/public";
+import {
+  type ActiveGraphHighlights,
+  type HandleAssignments,
+  filterGraphEdgesForRenderedHandles,
+} from "./react-flow-current-activity-card-graph";
 
 const EDGE_STROKE_MUTED = "var(--color-af-edge-muted)";
 const EDGE_STROKE_SOFT = "var(--color-af-edge-muted-soft)";
@@ -87,8 +92,18 @@ export function buildGraphEdges(
   handleAssignments: HandleAssignments,
   pendingAdditionEdgeIds: ReadonlySet<string>,
   visibleGraphEdges: PositionedEdge[],
+  renderedNodes?: ReadonlyArray<Pick<CurrentActivityNode, "data" | "id">>,
 ): Edge[] {
-  return visibleGraphEdges.map((edge) => {
+  const edgesToRender =
+    renderedNodes === undefined
+      ? visibleGraphEdges
+      : filterGraphEdgesForRenderedHandles(
+          visibleGraphEdges,
+          handleAssignments,
+          renderedNodes,
+        );
+
+  return edgesToRender.map((edge) => {
     const activeFlow = activeGraphHighlights.activeEdgeIds.has(edge.edgeId);
     const pendingAddition = pendingAdditionEdgeIds.has(edge.edgeId);
     const semantic = edgeSemantic(edge);

--- a/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-graph.test.ts
+++ b/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-graph.test.ts
@@ -1078,6 +1078,206 @@ describe("current activity graph editor handles", () => {
     expect(workstationNode?.data.zAxisIncompleteHints).toBeNull();
   });
 
+  it("omits progress-outcome edges when rendered workstation nodes omit those handles", async () => {
+    const factory = {
+      ...baseFactoryDefinition,
+      workTypes: [
+        {
+          name: "story",
+          states: [
+            { name: "queued", type: "INITIAL" },
+            { name: "rejected", type: "FAILED" },
+            { name: "done", type: "TERMINAL" },
+          ],
+        },
+      ],
+      workstations: [
+        {
+          ...baseFactoryDefinition.workstations?.[0],
+          behavior: "STANDARD",
+          onContinue: [{ state: "queued", workType: "story" }],
+          onFailure: [{ state: "rejected", workType: "story" }],
+          onRejection: [{ state: "rejected", workType: "story" }],
+          stopWords: undefined,
+        },
+      ],
+    } satisfies CanonicalFactoryDefinition;
+    const snapshot = buildSampleFactorySnapshot(factory);
+    const graphLayout =
+      await buildCurrentActivityGraphLayoutFromFactory(factory);
+    const visibleGraphEdges = buildVisibleGraphEdges(graphLayout);
+    const handleAssignments = buildHandleAssignments(
+      visibleGraphEdges,
+      graphLayout.nodes,
+    );
+    const observerNodes = buildCurrentActivityNodes({
+      activeExecutionsByWorkstationNodeID: {},
+      activeGraphHighlights: buildActiveGraphHighlights([], visibleGraphEdges),
+      activeItemLabelsByPlaceId: buildActiveItemLabelsByPlaceId([]),
+      factoryDefinition: factory,
+      graphLayout,
+      now: Date.parse("2026-05-24T00:00:00Z"),
+      onSelectStateNode: vi.fn(),
+      onSelectWorkID: vi.fn(),
+      onSelectWorker: vi.fn(),
+      onSelectWorkType: vi.fn(),
+      onSelectWorkstation: vi.fn(),
+      selection: null,
+      snapshot,
+      storedNodePositions: EMPTY_NODE_POSITIONS,
+    });
+    const editorNodes = buildCurrentActivityNodes({
+      activeExecutionsByWorkstationNodeID: {},
+      activeGraphHighlights: buildActiveGraphHighlights([], visibleGraphEdges),
+      activeItemLabelsByPlaceId: buildActiveItemLabelsByPlaceId([]),
+      editor: {
+        activeTool: "connect",
+        canInteractWithEditor: true,
+        editorMode: true,
+        onConnectionAnchorClick: vi.fn(),
+        pendingConnectionSource: null,
+      },
+      factoryDefinition: factory,
+      graphLayout,
+      now: Date.parse("2026-05-24T00:00:00Z"),
+      onSelectStateNode: vi.fn(),
+      onSelectWorkID: vi.fn(),
+      onSelectWorker: vi.fn(),
+      onSelectWorkType: vi.fn(),
+      onSelectWorkstation: vi.fn(),
+      selection: null,
+      snapshot,
+      storedNodePositions: EMPTY_NODE_POSITIONS,
+    });
+    expect(
+      visibleGraphEdges.some((edge) => edge.outcomeKind === "rejected"),
+    ).toBe(true);
+    expect(
+      visibleGraphEdges.some((edge) => edge.outcomeKind === "continue"),
+    ).toBe(true);
+
+    const observerEdges = buildGraphEdges(
+      buildActiveGraphHighlights([], visibleGraphEdges),
+      handleAssignments,
+      new Set(),
+      visibleGraphEdges,
+      observerNodes,
+    );
+    const editorEdges = buildGraphEdges(
+      buildActiveGraphHighlights([], visibleGraphEdges),
+      handleAssignments,
+      new Set(),
+      visibleGraphEdges,
+      editorNodes,
+    );
+
+    expect(
+      observerEdges.some(
+        (edge) => edge.sourceHandle === "workstation-on-rejection-source",
+      ),
+    ).toBe(false);
+    expect(
+      observerEdges.some(
+        (edge) => edge.sourceHandle === "workstation-on-continue-source",
+      ),
+    ).toBe(false);
+    expect(
+      editorEdges.some(
+        (edge) => edge.sourceHandle === "workstation-on-rejection-source",
+      ),
+    ).toBe(false);
+    expect(
+      editorEdges.some(
+        (edge) => edge.sourceHandle === "workstation-on-continue-source",
+      ),
+    ).toBe(false);
+    expect(
+      observerEdges.some(
+        (edge) => edge.sourceHandle === "workstation-on-failure-source",
+      ),
+    ).toBe(true);
+    expect(
+      observerEdges.some(
+        (edge) => edge.sourceHandle === "workstation-output-source",
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps progress-outcome edges when stopWords render continue and reject handles", async () => {
+    const factory = {
+      ...baseFactoryDefinition,
+      workTypes: [
+        {
+          name: "story",
+          states: [
+            { name: "queued", type: "INITIAL" },
+            { name: "rejected", type: "FAILED" },
+            { name: "done", type: "TERMINAL" },
+          ],
+        },
+      ],
+      workstations: [
+        {
+          ...baseFactoryDefinition.workstations?.[0],
+          behavior: "STANDARD",
+          onContinue: [{ state: "queued", workType: "story" }],
+          onFailure: [{ state: "rejected", workType: "story" }],
+          onRejection: [{ state: "rejected", workType: "story" }],
+          stopWords: ["DONE"],
+        },
+      ],
+    } satisfies CanonicalFactoryDefinition;
+    const snapshot = buildSampleFactorySnapshot(factory);
+    const graphLayout =
+      await buildCurrentActivityGraphLayoutFromFactory(factory);
+    const visibleGraphEdges = buildVisibleGraphEdges(graphLayout);
+    const handleAssignments = buildHandleAssignments(
+      visibleGraphEdges,
+      graphLayout.nodes,
+    );
+    const nodes = buildCurrentActivityNodes({
+      activeExecutionsByWorkstationNodeID: {},
+      activeGraphHighlights: buildActiveGraphHighlights([], visibleGraphEdges),
+      activeItemLabelsByPlaceId: buildActiveItemLabelsByPlaceId([]),
+      editor: {
+        activeTool: "connect",
+        canInteractWithEditor: true,
+        editorMode: false,
+        onConnectionAnchorClick: vi.fn(),
+        pendingConnectionSource: null,
+      },
+      factoryDefinition: factory,
+      graphLayout,
+      now: Date.parse("2026-05-24T00:00:00Z"),
+      onSelectStateNode: vi.fn(),
+      onSelectWorkID: vi.fn(),
+      onSelectWorker: vi.fn(),
+      onSelectWorkType: vi.fn(),
+      onSelectWorkstation: vi.fn(),
+      selection: null,
+      snapshot,
+      storedNodePositions: EMPTY_NODE_POSITIONS,
+    });
+    const edges = buildGraphEdges(
+      buildActiveGraphHighlights([], visibleGraphEdges),
+      handleAssignments,
+      new Set(),
+      visibleGraphEdges,
+      nodes,
+    );
+
+    expect(
+      edges.some(
+        (edge) => edge.sourceHandle === "workstation-on-rejection-source",
+      ),
+    ).toBe(true);
+    expect(
+      edges.some(
+        (edge) => edge.sourceHandle === "workstation-on-continue-source",
+      ),
+    ).toBe(true);
+  });
+
   it("wires shared handle click actions back through the editor anchor callback", () => {
     const onConnectionAnchorClick = vi.fn();
 

--- a/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-graph.ts
+++ b/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-graph.ts
@@ -5,6 +5,8 @@ import type {
 } from "../../../api/dashboard/types";
 import type { FactoryValidationTarget } from "../../../api/factory-validation";
 import type { WorkstationProgressOutcomeRouteContext } from "../../current-factory-definition/lib/workstation-progress-outcome-routes";
+import { workstationSupportsProgressOutcomeRoutes } from "../../current-factory-definition/lib/workstation-progress-outcome-routes";
+import { PROGRESS_OUTCOME_SOURCE_ANCHOR_IDS } from "../../factory-graph-editor/lib/factory-graph-editor-connections";
 import {
   type FactoryValidationGraphProjection,
   projectFactoryValidationTargets,
@@ -163,6 +165,86 @@ function workstationGraphNodeId(nodeId: string): string {
 function placeGraphNodeId(placeId: string): string {
   // hardcoded-ui-copy-exception: non-product-diagnostic
   return `place:${placeId}`;
+}
+
+export function renderedHandleIdsByNodeId(
+  nodes: ReadonlyArray<Pick<CurrentActivityNode, "data" | "id">>,
+): ReadonlyMap<string, ReadonlySet<string>> {
+  return new Map(
+    nodes.map((node) => [
+      node.id,
+      new Set((node.data.handles ?? []).map((handle) => handle.id)),
+    ]),
+  );
+}
+
+function workstationProgressOutcomeRoutesSupported(
+  node: Pick<CurrentActivityNode, "data" | "id">,
+): boolean | undefined {
+  if (node.data.kind !== "workstation") {
+    return undefined;
+  }
+
+  const workstation = (
+    node.data as {
+      progressOutcomeRouteWorkstation?: WorkstationProgressOutcomeRouteContext;
+    }
+  ).progressOutcomeRouteWorkstation;
+  if (!workstation) {
+    return undefined;
+  }
+
+  return workstationSupportsProgressOutcomeRoutes(workstation);
+}
+
+export function shouldIncludeCurrentActivityGraphEdge(
+  edge: PositionedEdge,
+  handleAssignments: HandleAssignments,
+  handleIdsByNodeId: ReadonlyMap<string, ReadonlySet<string>>,
+  nodesById: ReadonlyMap<string, Pick<CurrentActivityNode, "data" | "id">>,
+): boolean {
+  const sourceHandle = handleAssignments.sourceHandlesByEdgeId.get(edge.edgeId);
+  const targetHandle = handleAssignments.targetHandlesByEdgeId.get(edge.edgeId);
+  if (!sourceHandle || !targetHandle) {
+    return false;
+  }
+
+  if (PROGRESS_OUTCOME_SOURCE_ANCHOR_IDS.has(sourceHandle)) {
+    const sourceNode = nodesById.get(edge.fromNodeId);
+    if (
+      sourceNode &&
+      workstationProgressOutcomeRoutesSupported(sourceNode) === false
+    ) {
+      return false;
+    }
+  }
+
+  const sourceHandles = handleIdsByNodeId.get(edge.fromNodeId);
+  const targetHandles = handleIdsByNodeId.get(edge.toNodeId);
+  if (!sourceHandles || !targetHandles) {
+    return false;
+  }
+
+  return (
+    sourceHandles.has(sourceHandle) && targetHandles.has(targetHandle)
+  );
+}
+
+export function filterGraphEdgesForRenderedHandles(
+  edges: PositionedEdge[],
+  handleAssignments: HandleAssignments,
+  nodes: ReadonlyArray<Pick<CurrentActivityNode, "data" | "id">>,
+): PositionedEdge[] {
+  const handleIdsByNodeId = renderedHandleIdsByNodeId(nodes);
+  const nodesById = new Map(nodes.map((node) => [node.id, node]));
+  return edges.filter((edge) =>
+    shouldIncludeCurrentActivityGraphEdge(
+      edge,
+      handleAssignments,
+      handleIdsByNodeId,
+      nodesById,
+    ),
+  );
 }
 
 export function buildHandleAssignments(

--- a/ui/src/features/workflow-activity/lib/test-data/factory-graph-onrejection-edge-reproduction.factory.json
+++ b/ui/src/features/workflow-activity/lib/test-data/factory-graph-onrejection-edge-reproduction.factory.json
@@ -1,0 +1,384 @@
+{
+  "name": "factory",
+  "workTypes": [
+    {
+      "name": "thoughts",
+      "states": [
+        {
+          "name": "init",
+          "type": "INITIAL"
+        },
+        {
+          "name": "complete",
+          "type": "TERMINAL"
+        },
+        {
+          "name": "failed",
+          "type": "FAILED"
+        }
+      ]
+    },
+    {
+      "name": "task",
+      "states": [
+        {
+          "name": "init",
+          "type": "INITIAL"
+        },
+        {
+          "name": "in-review",
+          "type": "PROCESSING"
+        },
+        {
+          "name": "to-complete",
+          "type": "PROCESSING"
+        },
+        {
+          "name": "complete",
+          "type": "TERMINAL"
+        },
+        {
+          "name": "failed",
+          "type": "FAILED"
+        }
+      ]
+    },
+    {
+      "name": "idea",
+      "states": [
+        {
+          "name": "init",
+          "type": "INITIAL"
+        },
+        {
+          "name": "to-complete",
+          "type": "PROCESSING"
+        },
+        {
+          "name": "complete",
+          "type": "TERMINAL"
+        },
+        {
+          "name": "failed",
+          "type": "FAILED"
+        }
+      ]
+    },
+    {
+      "name": "plan",
+      "states": [
+        {
+          "name": "init",
+          "type": "INITIAL"
+        },
+        {
+          "name": "complete",
+          "type": "TERMINAL"
+        },
+        {
+          "name": "failed",
+          "type": "FAILED"
+        }
+      ]
+    },
+    {
+      "name": "cron-triggers",
+      "states": [
+        {
+          "name": "init",
+          "type": "INITIAL"
+        },
+        {
+          "name": "complete",
+          "type": "TERMINAL"
+        },
+        {
+          "name": "failed",
+          "type": "FAILED"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "name": "executor-slot",
+      "capacity": 10
+    }
+  ],
+  "workers": [
+    {
+      "name": "processor"
+    },
+    {
+      "name": "workspace-setup"
+    }
+  ],
+  "workstations": [
+    {
+      "name": "ideafy",
+      "worker": "processor",
+      "inputs": [
+        {
+          "workType": "thoughts",
+          "state": "init"
+        }
+      ],
+      "outputs": [
+        {
+          "workType": "thoughts",
+          "state": "complete"
+        }
+      ],
+      "onFailure": [
+        {
+          "workType": "thoughts",
+          "state": "failed"
+        }
+      ],
+      "resources": [
+        {
+          "name": "executor-slot",
+          "capacity": 1
+        }
+      ]
+    },
+    {
+      "name": "plan",
+      "worker": "processor",
+      "inputs": [
+        {
+          "workType": "idea",
+          "state": "init"
+        }
+      ],
+      "outputs": [
+        {
+          "workType": "idea",
+          "state": "to-complete"
+        },
+        {
+          "workType": "plan",
+          "state": "init"
+        }
+      ],
+      "resources": [
+        {
+          "name": "executor-slot",
+          "capacity": 1
+        }
+      ],
+      "onRejection": [
+        {
+          "workType": "idea",
+          "state": "failed"
+        }
+      ],
+      "onFailure": [
+        {
+          "workType": "idea",
+          "state": "failed"
+        }
+      ]
+    },
+    {
+      "name": "consume",
+      "type": "LOGICAL_MOVE",
+      "inputs": [
+        {
+          "workType": "idea",
+          "state": "to-complete",
+          "guards": [
+            {
+              "type": "SAME_NAME",
+              "matchInput": "task"
+            }
+          ]
+        },
+        {
+          "workType": "task",
+          "state": "to-complete"
+        }
+      ],
+      "outputs": [
+        {
+          "workType": "idea",
+          "state": "complete"
+        },
+        {
+          "workType": "task",
+          "state": "complete"
+        }
+      ]
+    },
+    {
+      "name": "setup-workspace",
+      "type": "MODEL_WORKSTATION",
+      "worker": "workspace-setup",
+      "inputs": [
+        {
+          "workType": "plan",
+          "state": "init"
+        }
+      ],
+      "outputs": [
+        {
+          "workType": "plan",
+          "state": "complete"
+        },
+        {
+          "workType": "task",
+          "state": "init"
+        }
+      ],
+      "onFailure": [
+        {
+          "workType": "plan",
+          "state": "failed"
+        }
+      ]
+    },
+    {
+      "name": "process",
+      "behavior": "REPEATER",
+      "worker": "processor",
+      "inputs": [
+        {
+          "workType": "task",
+          "state": "init"
+        }
+      ],
+      "outputs": [
+        {
+          "workType": "task",
+          "state": "in-review"
+        }
+      ],
+      "onContinue": [
+        {
+          "workType": "task",
+          "state": "init"
+        }
+      ],
+      "onRejection": [
+        {
+          "workType": "task",
+          "state": "init"
+        }
+      ],
+      "onFailure": [
+        {
+          "workType": "task",
+          "state": "failed"
+        }
+      ],
+      "resources": [
+        {
+          "name": "executor-slot",
+          "capacity": 1
+        }
+      ],
+      "workingDirectory": ".claude/worktrees/{{ (index .Inputs 0).Name }}"
+    },
+    {
+      "name": "review",
+      "worker": "processor",
+      "inputs": [
+        {
+          "workType": "task",
+          "state": "in-review"
+        }
+      ],
+      "outputs": [
+        {
+          "workType": "task",
+          "state": "to-complete"
+        }
+      ],
+      "onRejection": [
+        {
+          "workType": "task",
+          "state": "init"
+        }
+      ],
+      "onFailure": [
+        {
+          "workType": "task",
+          "state": "failed"
+        }
+      ],
+      "resources": [
+        {
+          "name": "executor-slot",
+          "capacity": 1
+        }
+      ],
+      "workingDirectory": ".claude/worktrees/{{ (index .Inputs 0).Name }}"
+    },
+    {
+      "name": "cleaner",
+      "behavior": "CRON",
+      "worker": "processor",
+      "resources": [
+        {
+          "name": "executor-slot",
+          "capacity": 1
+        }
+      ],
+      "outputs": [
+        {
+          "workType": "cron-triggers",
+          "state": "complete"
+        }
+      ],
+      "cron": {
+        "schedule": "0 */1 * * *"
+      }
+    },
+    {
+      "name": "executor-loop-breaker",
+      "type": "LOGICAL_MOVE",
+      "inputs": [
+        {
+          "workType": "task",
+          "state": "init"
+        }
+      ],
+      "outputs": [
+        {
+          "workType": "task",
+          "state": "failed"
+        }
+      ],
+      "guards": [
+        {
+          "type": "VISIT_COUNT",
+          "workstation": "process",
+          "maxVisits": 50
+        }
+      ]
+    },
+    {
+      "name": "review-loop-breaker",
+      "type": "LOGICAL_MOVE",
+      "inputs": [
+        {
+          "workType": "task",
+          "state": "in-review"
+        }
+      ],
+      "outputs": [
+        {
+          "workType": "task",
+          "state": "failed"
+        }
+      ],
+      "guards": [
+        {
+          "type": "VISIT_COUNT",
+          "workstation": "review",
+          "maxVisits": 10
+        }
+      ]
+    }
+  ]
+}

--- a/ui/src/features/workflow-activity/lib/test-data/factory-graph-onrejection-edge-reproduction.fixture.test.ts
+++ b/ui/src/features/workflow-activity/lib/test-data/factory-graph-onrejection-edge-reproduction.fixture.test.ts
@@ -1,0 +1,36 @@
+import { buildCurrentActivityGraphLayoutFromFactory } from "../current-activity-factory-graph-layout";
+import { loadFactoryGraphOnrejectionEdgeReproductionFactory } from "./factory-graph-onrejection-edge-reproduction.fixture";
+
+describe("factory-graph-onrejection-edge-reproduction fixture", () => {
+  it("loads a canonical factory with progress-outcome routes on standard processors", async () => {
+    const factory = loadFactoryGraphOnrejectionEdgeReproductionFactory();
+
+    expect(factory.name).toBe("factory");
+
+    const process = factory.workstations?.find(
+      (workstation) => workstation.name === "process",
+    );
+    const review = factory.workstations?.find(
+      (workstation) => workstation.name === "review",
+    );
+    const plan = factory.workstations?.find(
+      (workstation) => workstation.name === "plan",
+    );
+
+    expect(process?.onContinue?.length).toBeGreaterThan(0);
+    expect(process?.onRejection?.length).toBeGreaterThan(0);
+    expect(review?.onRejection?.length).toBeGreaterThan(0);
+    expect(plan?.onRejection?.length).toBeGreaterThan(0);
+    expect(process?.stopWords).toBeUndefined();
+    expect(review?.stopWords).toBeUndefined();
+    expect(plan?.stopWords).toBeUndefined();
+  });
+
+  it("builds current-activity graph layout from the committed fixture", async () => {
+    const factory = loadFactoryGraphOnrejectionEdgeReproductionFactory();
+    const layout = await buildCurrentActivityGraphLayoutFromFactory(factory);
+
+    expect(layout.nodes.length).toBeGreaterThan(0);
+    expect(layout.edges.length).toBeGreaterThan(0);
+  });
+});

--- a/ui/src/features/workflow-activity/lib/test-data/factory-graph-onrejection-edge-reproduction.fixture.ts
+++ b/ui/src/features/workflow-activity/lib/test-data/factory-graph-onrejection-edge-reproduction.fixture.ts
@@ -1,0 +1,7 @@
+import type { CanonicalFactoryDefinition } from "../../../../api/factory-definition";
+import factoryGraphOnrejectionEdgeReproductionFactory from "./factory-graph-onrejection-edge-reproduction.factory.json";
+
+/** Committed copy of repo `factory/factory.json` for graph edit-mode regression tests. */
+export function loadFactoryGraphOnrejectionEdgeReproductionFactory(): CanonicalFactoryDefinition {
+  return factoryGraphOnrejectionEdgeReproductionFactory as CanonicalFactoryDefinition;
+}


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/issues2-factory-graph-onrejection-edge-fix",
  "description": "Fix React Flow factory graph endpoint error 008 when leaving edit mode by omitting onRejection/onContinue edges whose progress-outcome handles are not rendered on standard processors, and lock the behavior with a Vitest regression that uses a committed copy of factory.json.",
  "context": {
    "customerAsk": "Entering and exiting graph edit mode must not throw React Flow handle errors. Edges for auto-generated onRejection/onContinue must be omitted when handles are hidden. Vitest must reproduce the failure on unfixed code and pass after the fix, using a copied factory.json fixture rather than the live factory/factory.json.",
    "problem": "The factory graph projects workstation-on-rejection and workstation-on-continue edges from topology while omitting those connection anchors on standard model processors without stopWords. Toggling factory graph edit mode causes React Flow endpoint error 008 because edges reference handles that are not on rendered nodes.",
    "solution": "Filter projected edges to match rendered node handles using the same workstation progress-outcome rules as anchor filtering, apply the rule in both factory-graph React Flow projection and Workflow Activity graph edge building, add a committed factory fixture copy under ui test data, and add Vitest coverage that enters and leaves edit mode without error 008."
  },
  "acceptanceCriteria": [
    "Entering and leaving factory graph edit mode on the reproduction factory fixture does not throw CurrentActivityGraphEndpointError 008",
    "workstation-on-rejection and workstation-on-continue edges are omitted when workstation-on-rejection-source and workstation-on-continue-source anchors are not rendered on the source workstation node",
    "Workstations with configured stopWords continue to show Continue/Reject edges and handles without regression",
    "Vitest regression loads only a committed ui test-data copy of factory.json and does not read factory/factory.json at runtime",
    "Regression test fails on unfixed projection behavior and passes after the edge-handle alignment fix",
    "Quality gate: ui typecheck, lint, and affected tests pass"
  ],
  "userStories": [
    {
      "id": "issues2-factory-graph-onrejection-edge-fix-001",
      "title": "Omit React Flow edges whose handles are not on rendered nodes",
      "description": "As a factory operator, I want the factory graph editor projection to drop edges that point at omitted progress-outcome handles so React Flow never receives invalid endpoint pairs.",
      "acceptanceCriteria": [
        "projectFactoryGraphToReactFlow excludes an edge when resolved sourceHandle or targetHandle is not present on the corresponding node's rendered connectionAnchors for that workstation context",
        "Standard model processors without stopWords omit workstation-on-rejection and workstation-on-continue edges when those source anchors are filtered; workstation-on-failure and other supported edge kinds still render",
        "Processors with stopWords configured still project Continue/Reject edges when anchors are present",
        "factory-graph-react-flow-projection.test.ts covers without-stopWords (edges omitted) and with-stopWords (edges kept) cases",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues2-factory-graph-onrejection-edge-fix-002",
      "title": "Keep Workflow Activity graph edges aligned when edit mode toggles",
      "description": "As a factory operator leaving edit mode on the Workflow Activity card, I want observe-mode edges to match rendered handles so exiting edit mode does not throw endpoint error 008.",
      "acceptanceCriteria": [
        "Current-activity graph edge building omits edges whose semantic handle ids are absent from the rendered workstation node handles list, using the same progress-outcome eligibility as connection anchor filtering",
        "Toggling editorMode from true to false with the reproduction factory fixture does not pass edges referencing workstation-on-rejection-source or workstation-on-continue-source on nodes that omit those handles",
        "Existing observer-mode hidden-handle tests for supported edges continue to pass",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues2-factory-graph-onrejection-edge-fix-003",
      "title": "Add committed factory fixture copy for regression",
      "description": "As a maintainer, I need a stable factory definition in ui test data so Vitest does not depend on the mutable factory/factory.json at the repo root.",
      "acceptanceCriteria": [
        "A committed JSON fixture under ui/ contains the factory graph shape that reproduces the edit-mode toggle failure, including progress-outcome routes and standard processors without stopWords",
        "The fixture is valid CanonicalFactoryDefinition JSON loadable by existing graph layout helpers",
        "No test reads factory/factory.json from the repository root at runtime",
        "Typecheck passes"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues2-factory-graph-onrejection-edge-fix-004",
      "title": "Vitest regression for edit-mode toggle without endpoint error 008",
      "description": "As a maintainer, I want an automated test that enters and leaves factory graph edit mode against the copied fixture so endpoint error 008 cannot return unnoticed.",
      "acceptanceCriteria": [
        "A Vitest test renders the Workflow Activity graph surface with the committed fixture and clicks Enter factory graph editor then Leave factory graph editor",
        "The test asserts no throw matching React Flow factory graph endpoint error 008 and no React Flow onError callback with error id 008 for progress-outcome handle mismatches",
        "The test fails on unfixed code and passes after issues2-factory-graph-onrejection-edge-fix-001 and -002",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill: Workflow Activity graph with reproduction factory enters and leaves edit mode without graph error overlay"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}
