### PR TITLE
issues2-flat-blue-background

### DIFF
--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -39,6 +39,7 @@
         "@vitest/browser": "4.1.3",
         "@vitest/browser-playwright": "4.1.3",
         "@vitest/coverage-v8": "4.1.3",
+        "happy-dom": "^20.9.0",
         "http-server": "^14.1.1",
         "jest-axe": "^10.0.0",
         "jsdom": "^27.0.1",
@@ -616,6 +617,8 @@
 
     "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
 
+    "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
+
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
@@ -625,6 +628,10 @@
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
+
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@vitejs/plugin-react-swc": ["@vitejs/plugin-react-swc@4.3.0", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7", "@swc/core": "^1.15.11" }, "peerDependencies": { "vite": "^4 || ^5 || ^6 || ^7 || ^8" } }, "sha512-mOkXCII839dHyAt/gpoSlm28JIVDwhZ6tnG6wJxUy2bmOx7UaPjvOyIDf3SFv5s7Eo7HVaq6kRcu6YMEzt5Z7w=="],
 
@@ -848,7 +855,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
 
-    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -909,6 +916,8 @@
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -1264,6 +1273,8 @@
 
     "unbash": ["unbash@3.0.0", "", {}, "sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA=="],
 
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
     "union": ["union@0.5.0", "", { "dependencies": { "qs": "^6.4.0" } }, "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA=="],
 
     "unplugin": ["unplugin@2.3.11", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww=="],
@@ -1300,7 +1311,7 @@
 
     "whatwg-encoding": ["whatwg-encoding@2.0.0", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg=="],
 
-    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "whatwg-url": ["whatwg-url@15.1.0", "", { "dependencies": { "tr46": "^6.0.0", "webidl-conversions": "^8.0.0" } }, "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g=="],
 
@@ -1380,7 +1391,11 @@
 
     "jsdom/html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 
+    "jsdom/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
     "loose-envify/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 

--- a/ui/integration/page-shell-background.integration.test.mjs
+++ b/ui/integration/page-shell-background.integration.test.mjs
@@ -1,0 +1,60 @@
+// @vitest-environment node
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  buildTimeoutMs,
+  browserScenarioTimeoutMs,
+  expectNoBrowserErrors,
+  openBrowserPage,
+  startBrowserPreview,
+} from "./browser-test-harness.mjs";
+
+describe.sequential("page-shell background browser integration", () => {
+  let preview = null;
+
+  beforeAll(async () => {
+    preview = await startBrowserPreview();
+  }, buildTimeoutMs);
+
+  afterAll(async () => {
+    await preview?.stop();
+    preview = null;
+  }, buildTimeoutMs);
+
+  it(
+    "applies a flat foundation blue page shell on the document root",
+    async () => {
+      const browserPage = await openBrowserPage({
+        artifactLabel: "page-shell-background",
+      });
+
+      try {
+        await browserPage.page.goto(preview.previewURL, {
+          waitUntil: "domcontentloaded",
+        });
+
+        const shell = await browserPage.page.evaluate(() => {
+          const root = getComputedStyle(document.documentElement);
+          return {
+            backgroundColor: root.backgroundColor,
+            backgroundImage: root.backgroundImage,
+          };
+        });
+
+        expect(shell.backgroundImage === "none" || shell.backgroundImage === "").toBe(
+          true,
+        );
+        expect(shell.backgroundColor).toBe("rgb(10, 17, 23)");
+        expectNoBrowserErrors(
+          browserPage.pageErrors,
+          browserPage.consoleErrors,
+          expect,
+        );
+      } finally {
+        await browserPage.close();
+      }
+    },
+    browserScenarioTimeoutMs,
+  );
+});

--- a/ui/integration/page-shell-background.integration.test.mjs
+++ b/ui/integration/page-shell-background.integration.test.mjs
@@ -8,7 +8,12 @@ import {
   expectNoBrowserErrors,
   openBrowserPage,
   startBrowserPreview,
+  startFactoryApiServer,
 } from "./browser-test-harness.mjs";
+
+const pageShellFactoryDefinition = {
+  name: "Page Shell Harness",
+};
 
 describe.sequential("page-shell background browser integration", () => {
   let preview = null;
@@ -25,6 +30,10 @@ describe.sequential("page-shell background browser integration", () => {
   it(
     "applies a flat foundation blue page shell on the document root",
     async () => {
+      const server = await startFactoryApiServer({
+        apiPort: preview.apiPort,
+        currentFactory: pageShellFactoryDefinition,
+      });
       const browserPage = await openBrowserPage({
         artifactLabel: "page-shell-background",
       });
@@ -53,6 +62,7 @@ describe.sequential("page-shell background browser integration", () => {
         );
       } finally {
         await browserPage.close();
+        await server.stop();
       }
     },
     browserScenarioTimeoutMs,

--- a/ui/package.json
+++ b/ui/package.json
@@ -71,6 +71,7 @@
     "@vitest/browser": "4.1.3",
     "@vitest/browser-playwright": "4.1.3",
     "@vitest/coverage-v8": "4.1.3",
+    "happy-dom": "^20.9.0",
     "http-server": "^14.1.1",
     "jest-axe": "^10.0.0",
     "jsdom": "^27.0.1",

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -136,10 +136,8 @@
 @layer base {
   :root {
     @apply bg-af-background text-af-text font-sans leading-normal;
-    background:
-      radial-gradient(circle at top left, rgb(from var(--color-af-accent-glow) r g b / 0.18), transparent 34%),
-      radial-gradient(circle at bottom right, rgb(from var(--color-af-info-glow) r g b / 0.14), transparent 28%),
-      linear-gradient(145deg, var(--color-af-bg-start) 0%, var(--color-af-bg-mid) 44%, var(--color-af-bg) 100%);
+    background-color: var(--color-af-bg);
+    background-image: none;
   }
 
   * {

--- a/ui/src/styles.page-shell-background.test.ts
+++ b/ui/src/styles.page-shell-background.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { compile } from "@tailwindcss/node";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const stylesSourcePath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "styles.css",
+);
+
+function extractPageShellRootBlock(css: string): string {
+  const blocks = css.match(/:root\s*\{[^}]*\}/g) ?? [];
+  return (
+    blocks.find((block) => block.includes("background-color: var(--color-af-bg)")) ?? ""
+  );
+}
+
+describe("page-shell background", () => {
+  let compiledStyles = "";
+
+  beforeAll(async () => {
+    const source = readFileSync(stylesSourcePath, "utf8");
+    const compiled = await compile(source, {
+      base: path.dirname(stylesSourcePath),
+      from: stylesSourcePath,
+      onDependency: () => {},
+    });
+    compiledStyles = compiled.build([]);
+  });
+
+  it("keeps :root on a flat --color-af-bg fill without gradient layers", () => {
+    const source = readFileSync(stylesSourcePath, "utf8");
+    const rootBlock = extractPageShellRootBlock(compiledStyles);
+
+    expect(source).toContain("background-color: var(--color-af-bg);");
+    expect(source).toContain("background-image: none;");
+    expect(source).not.toMatch(
+      /@layer base\s*\{[^}]*:root\s*\{[^}]*(?:linear-gradient|radial-gradient)/s,
+    );
+
+    expect(rootBlock).toContain("background-color: var(--color-af-bg)");
+    expect(rootBlock).toContain("background-image: none");
+    expect(rootBlock).not.toMatch(/gradient/i);
+    expect(rootBlock).not.toContain("linear-gradient");
+    expect(rootBlock).not.toContain("radial-gradient");
+  });
+});

--- a/ui/src/styles.page-shell-background.test.ts
+++ b/ui/src/styles.page-shell-background.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -9,16 +11,17 @@ const stylesSourcePath = path.join(
   "styles.css",
 );
 
-function extractPageShellRootBlock(css: string): string {
-  const blocks = css.match(/:root\s*\{[^}]*\}/g) ?? [];
-  return (
-    blocks.find((block) => block.includes("background-color: var(--color-af-bg)")) ?? ""
-  );
+/** Canonical foundation blue from @theme (--color-af-foundation-background). */
+const FOUNDATION_BACKGROUND = "#0a1117";
+
+function injectCompiledRootRules(compiledCss: string): void {
+  const rootBlocks = compiledCss.match(/:root[^{]*\{[^}]*\}/g) ?? [];
+  const style = document.createElement("style");
+  style.textContent = rootBlocks.join("\n");
+  document.head.appendChild(style);
 }
 
 describe("page-shell background", () => {
-  let compiledStyles = "";
-
   beforeAll(async () => {
     const source = readFileSync(stylesSourcePath, "utf8");
     const compiled = await compile(source, {
@@ -26,23 +29,14 @@ describe("page-shell background", () => {
       from: stylesSourcePath,
       onDependency: () => {},
     });
-    compiledStyles = compiled.build([]);
+    injectCompiledRootRules(compiled.build([]));
   });
 
-  it("keeps :root on a flat --color-af-bg fill without gradient layers", () => {
-    const source = readFileSync(stylesSourcePath, "utf8");
-    const rootBlock = extractPageShellRootBlock(compiledStyles);
-
-    expect(source).toContain("background-color: var(--color-af-bg);");
-    expect(source).toContain("background-image: none;");
-    expect(source).not.toMatch(
-      /@layer base\s*\{[^}]*:root\s*\{[^}]*(?:linear-gradient|radial-gradient)/s,
+  it("renders a flat token-backed fill on the document root", () => {
+    const root = getComputedStyle(document.documentElement);
+    expect(root.backgroundImage === "none" || root.backgroundImage === "").toBe(
+      true,
     );
-
-    expect(rootBlock).toContain("background-color: var(--color-af-bg)");
-    expect(rootBlock).toContain("background-image: none");
-    expect(rootBlock).not.toMatch(/gradient/i);
-    expect(rootBlock).not.toContain("linear-gradient");
-    expect(rootBlock).not.toContain("radial-gradient");
+    expect(root.backgroundColor.toLowerCase()).toBe(FOUNDATION_BACKGROUND);
   });
 });


### PR DESCRIPTION
{
  "project": "Infinite You Dashboard UI",
  "branchName": "ralph/issues2-flat-blue-background",
  "description": "Replace the dashboard page-shell multi-layer gradient background with a single flat blue semantic token (--color-af-bg) while preserving dark-theme contrast for text, surfaces, and charts.",
  "context": {
    "customerAsk": "Replace gradient background with a flat blue surface color. Dashboard background must be a flat blue token, not a gradient. Contrast and theme tokens remain consistent with dark UI.",
    "problem": "The global :root background stacks radial accent/info glows and a diagonal linear gradient across bg-start, bg-mid, and bg tokens, causing visible banding and corner glow behind all dashboard views.",
    "solution": "Use the existing --color-af-bg foundation blue as the sole page-shell fill, remove gradient layers from :root, keep other theme tokens unchanged, and add a Vitest regression plus browser verification."
  },
  "acceptanceCriteria": [
    "Dashboard routes show a uniform flat blue page shell with no diagonal banding or corner radial glows from :root",
    "Page shell background resolves to solid var(--color-af-bg) with no linear-gradient or radial-gradient on :root for the main canvas",
    "Text, surface, border, and chart semantic tokens remain unchanged unless a contrast defect requires a minimal token fix",
    "Vitest asserts document root computed background is solid (no gradient background-image on page shell)",
    "Typecheck passes",
    "Lint passes",
    "Existing and new UI tests pass"
  ],
  "userStories": [
    {
      "id": "issues2-flat-blue-background-001",
      "title": "Flat blue page-shell background",
      "description": "As a dashboard user, I want the app background to be a flat blue surface so the UI feels calmer and consistent with dark surface cards.",
      "acceptanceCriteria": [
        ":root page-shell background uses only var(--color-af-bg) as a solid fill with no stacked gradient layers",
        "No radial-gradient or linear-gradient remains on :root background used for the dashboard page shell",
        "--color-af-bg remains the canonical flat blue token with no ad-hoc hex in component code",
        "Typecheck passes",
        "Verify in browser using dev-browser skill: load a dashboard route and confirm uniform flat blue with no gradient banding or corner glows"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues2-flat-blue-background-002",
      "title": "Regression test for solid page-shell background",
      "description": "As a maintainer, I want an automated check that the page shell stays a flat token-backed color so gradient backgrounds cannot return unnoticed.",
      "acceptanceCriteria": [
        "Vitest test under ui/ loads global styles and asserts document root computed background-image is none and background-color matches --color-af-bg",
        "Test fails if :root reintroduces gradient background layers for the page shell",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)