### PR TITLE
issues2-standard-list-selector

### DIFF
--- a/ui/scripts/button-usage-allowlist.mjs
+++ b/ui/scripts/button-usage-allowlist.mjs
@@ -39,12 +39,6 @@ export const approvedButtonUsageAllowlist = [
     relativeFilePath: "src/features/header/components/dashboard-session-tabs.tsx",
   },
   {
-    rawButtonFingerprints: ['SESSION_TARGET_BUTTON_CLASS'],
-    rawButtonReason:
-      "The open-session dialog trigger is a dedicated tab-strip affordance rather than an ordinary action button.",
-    relativeFilePath: "src/features/header/components/dashboard-session-tabs-open-dialog.tsx",
-  },
-  {
     rawButtonFingerprints: [
       'aria-label={workstationMessages.selectProviderSessionLabel(',
     ],

--- a/ui/scripts/inline-component-class-usage-allowlist.mjs
+++ b/ui/scripts/inline-component-class-usage-allowlist.mjs
@@ -32,7 +32,6 @@ export const allowlistedInlineComponentClassUsage = [
   "src/features/header/components/dashboard-header.tsx#DASHBOARD_TIMELINE_ACTIONS_CLASS",
   "src/features/header/components/dashboard-header.tsx#LOCALE_MENU_PANEL_CLASS",
   "src/features/header/components/dashboard-session-tabs-open-dialog.tsx#SESSION_SECTION_LABEL_CLASS",
-  "src/features/header/components/dashboard-session-tabs-open-dialog.tsx#SESSION_TARGET_LIST_CLASS",
   "src/features/header/components/dashboard-session-tabs.tsx#SESSION_TABS_SHELL_CLASS",
   "src/features/header/components/dashboard-session-tabs.tsx#SESSION_TABS_ROW_CLASS",
   "src/features/header/components/dashboard-session-tabs.tsx#SESSION_TAB_LIST_CLASS",

--- a/ui/src/App.current-selection.test.tsx
+++ b/ui/src/App.current-selection.test.tsx
@@ -1943,7 +1943,7 @@ describe("App current selection", () => {
       within(dashboardGrid)
         .getByRole("button", { name: "Done Story" })
         .getAttribute("data-selected"),
-    ).toBeNull();
+    ).toBe("false");
     expect(
       within(dashboardGrid)
         .getByRole("button", { name: "Failed Story" })

--- a/ui/src/components/ui/index.ts
+++ b/ui/src/components/ui/index.ts
@@ -22,6 +22,7 @@ export * from "./resizable";
 export * from "./select";
 export * from "./selectable-card-button";
 export * from "./skeleton";
+export * from "./standard-list-selection";
 export * from "./table";
 export * from "./textarea";
 export * from "./widget-frame";

--- a/ui/src/components/ui/standard-list-selection.stories.tsx
+++ b/ui/src/components/ui/standard-list-selection.stories.tsx
@@ -1,0 +1,174 @@
+import { expect, within } from "storybook/test";
+
+import {
+  STANDARD_LIST_SELECTION_ROW_DANGER_CLASS,
+  STANDARD_LIST_SELECTION_ROW_INFO_CLASS,
+  STANDARD_LIST_SELECTION_ROW_NEUTRAL_CLASS,
+  STANDARD_LIST_SELECTION_ROW_SELECTED_CLASS,
+  StandardListSelection,
+  StandardListSelectionItem,
+} from "./standard-list-selection";
+
+const ACCENT_SELECTED_TOKENS = [
+  "bg-af-accent",
+  "bg-af-accent-surface",
+  "border-af-accent",
+  "shadow-af-accent-selected",
+] as const;
+
+function expectNoAccentSelectedTreatment(className: string) {
+  for (const token of ACCENT_SELECTED_TOKENS) {
+    expect(className).not.toContain(token);
+  }
+}
+
+function StandardListSelectionShowcase() {
+  return (
+    <div className="grid max-w-md gap-6 p-6">
+      <section
+        aria-labelledby="standard-list-selection-states"
+        className="grid gap-3"
+      >
+        <h2
+          className="text-sm font-semibold text-af-text"
+          id="standard-list-selection-states"
+        >
+          Standard list selection states
+        </h2>
+        <StandardListSelection selectionAnnouncement="Alpha target selected">
+          <StandardListSelectionItem>
+            Neutral unselected
+          </StandardListSelectionItem>
+          <StandardListSelectionItem selected>
+            Neutral selected
+          </StandardListSelectionItem>
+          <StandardListSelectionItem disabled>
+            Disabled row
+          </StandardListSelectionItem>
+        </StandardListSelection>
+      </section>
+
+      <section
+        aria-labelledby="standard-list-selection-tones"
+        className="grid gap-3"
+      >
+        <h2
+          className="text-sm font-semibold text-af-text"
+          id="standard-list-selection-tones"
+        >
+          Outcome tone variants
+        </h2>
+        <StandardListSelection>
+          <StandardListSelectionItem tone="info">
+            Info unselected
+          </StandardListSelectionItem>
+          <StandardListSelectionItem selected tone="info">
+            Info selected
+          </StandardListSelectionItem>
+          <StandardListSelectionItem tone="danger">
+            Danger unselected
+          </StandardListSelectionItem>
+          <StandardListSelectionItem selected tone="danger">
+            Danger selected
+          </StandardListSelectionItem>
+        </StandardListSelection>
+      </section>
+
+      <section
+        aria-labelledby="standard-list-selection-pending"
+        className="grid gap-3"
+      >
+        <h2
+          className="text-sm font-semibold text-af-text"
+          id="standard-list-selection-pending"
+        >
+          Pending list
+        </h2>
+        <StandardListSelection disabled>
+          <StandardListSelectionItem selected>
+            Pending selected row
+          </StandardListSelectionItem>
+        </StandardListSelection>
+      </section>
+    </div>
+  );
+}
+
+export default {
+  title: "Agent Factory/UI/Standard List Selection",
+  tags: ["test"],
+};
+
+export const SharedStandardListSelection = {
+  render: () => <StandardListSelectionShowcase />,
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+
+    const neutralUnselected = canvas.getByRole("button", {
+      name: "Neutral unselected",
+    });
+    expect(neutralUnselected.className).toContain(
+      STANDARD_LIST_SELECTION_ROW_NEUTRAL_CLASS,
+    );
+    await expect(neutralUnselected).toHaveAttribute("aria-pressed", "false");
+    await expect(neutralUnselected).toHaveAttribute("data-selected", "false");
+    expectNoAccentSelectedTreatment(neutralUnselected.className);
+
+    const neutralSelected = canvas.getByRole("button", {
+      name: "Neutral selected",
+    });
+    expect(neutralSelected.className).toContain(
+      STANDARD_LIST_SELECTION_ROW_SELECTED_CLASS,
+    );
+    await expect(neutralSelected).toHaveAttribute("aria-pressed", "true");
+    await expect(neutralSelected).toHaveAttribute("data-selected", "true");
+    expectNoAccentSelectedTreatment(neutralSelected.className);
+
+    await expect(
+      canvas.getByRole("button", { name: "Disabled row" }),
+    ).toBeDisabled();
+
+    const infoUnselected = canvas.getByRole("button", {
+      name: "Info unselected",
+    });
+    expect(infoUnselected.className).toContain(
+      STANDARD_LIST_SELECTION_ROW_INFO_CLASS,
+    );
+    expectNoAccentSelectedTreatment(infoUnselected.className);
+
+    const infoSelected = canvas.getByRole("button", { name: "Info selected" });
+    expect(infoSelected.className).toContain(
+      STANDARD_LIST_SELECTION_ROW_SELECTED_CLASS,
+    );
+    expect(infoSelected.className).not.toContain(
+      STANDARD_LIST_SELECTION_ROW_INFO_CLASS,
+    );
+    await expect(infoSelected).toHaveAttribute("aria-pressed", "true");
+    expectNoAccentSelectedTreatment(infoSelected.className);
+
+    const dangerUnselected = canvas.getByRole("button", {
+      name: "Danger unselected",
+    });
+    expect(dangerUnselected.className).toContain(
+      STANDARD_LIST_SELECTION_ROW_DANGER_CLASS,
+    );
+    expectNoAccentSelectedTreatment(dangerUnselected.className);
+
+    const dangerSelected = canvas.getByRole("button", {
+      name: "Danger selected",
+    });
+    expect(dangerSelected.className).toContain(
+      STANDARD_LIST_SELECTION_ROW_SELECTED_CLASS,
+    );
+    expectNoAccentSelectedTreatment(dangerSelected.className);
+
+    const pendingList = canvas.getByRole("button", {
+      name: "Pending selected row",
+    });
+    await expect(pendingList).toBeDisabled();
+    await expect(pendingList).toHaveAttribute("aria-pressed", "true");
+    expectNoAccentSelectedTreatment(pendingList.className);
+
+    await expect(canvas.getByText("Alpha target selected")).toBeVisible();
+  },
+};

--- a/ui/src/components/ui/standard-list-selection.test.tsx
+++ b/ui/src/components/ui/standard-list-selection.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import {
+  STANDARD_LIST_SELECTION_ROW_DANGER_CLASS,
+  STANDARD_LIST_SELECTION_ROW_INFO_CLASS,
+  STANDARD_LIST_SELECTION_ROW_NEUTRAL_CLASS,
+  STANDARD_LIST_SELECTION_ROW_SELECTED_CLASS,
+  StandardListSelection,
+  StandardListSelectionItem,
+} from "./standard-list-selection";
+
+const ACCENT_SELECTED_TOKENS = [
+  "bg-af-accent",
+  "bg-af-accent-surface",
+  "border-af-accent",
+  "shadow-af-accent-selected",
+] as const;
+
+function expectNoAccentSelectedTreatment(className: string) {
+  for (const token of ACCENT_SELECTED_TOKENS) {
+    expect(className).not.toContain(token);
+  }
+}
+
+describe("StandardListSelection", () => {
+  it("renders a vertical list shell with optional selection announcement", () => {
+    const { container } = render(
+      <StandardListSelection selectionAnnouncement="Alpha target">
+        <StandardListSelectionItem selected>Alpha</StandardListSelectionItem>
+      </StandardListSelection>,
+    );
+
+    const list = container.firstElementChild;
+    expect(list?.className).toContain("grid");
+    expect(list?.className).toContain("gap-2");
+    expect(screen.getByText("Alpha target").getAttribute("aria-live")).toBe(
+      "polite",
+    );
+  });
+
+  it("marks the list busy and disables rows when pending", () => {
+    const onClick = vi.fn();
+
+    const { container } = render(
+      <StandardListSelection disabled>
+        <StandardListSelectionItem onClick={onClick}>
+          Alpha
+        </StandardListSelectionItem>
+      </StandardListSelection>,
+    );
+
+    const list = container.firstElementChild;
+    expect(list?.getAttribute("aria-busy")).toBe("true");
+
+    const row = screen.getByRole("button", { name: "Alpha" });
+    expect(row.disabled).toBe(true);
+    fireEvent.click(row);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});
+
+describe("StandardListSelectionItem", () => {
+  it("uses neutral dark gray surfaces when unselected", () => {
+    render(
+      <StandardListSelectionItem tone="neutral">
+        Neutral row
+      </StandardListSelectionItem>,
+    );
+
+    const row = screen.getByRole("button", { name: "Neutral row" });
+    expect(row.className).toContain(STANDARD_LIST_SELECTION_ROW_NEUTRAL_CLASS);
+    expect(row.getAttribute("aria-pressed")).toBe("false");
+    expect(row.getAttribute("data-selected")).toBe("false");
+    expectNoAccentSelectedTreatment(row.className);
+  });
+
+  it("uses neutral selected surfaces without accent fill when selected", () => {
+    render(
+      <StandardListSelectionItem selected tone="info">
+        Selected row
+      </StandardListSelectionItem>,
+    );
+
+    const row = screen.getByRole("button", { name: "Selected row" });
+    expect(row.className).toContain(STANDARD_LIST_SELECTION_ROW_SELECTED_CLASS);
+    expect(row.className).not.toContain(STANDARD_LIST_SELECTION_ROW_INFO_CLASS);
+    expect(row.getAttribute("aria-pressed")).toBe("true");
+    expect(row.getAttribute("data-selected")).toBe("true");
+    expectNoAccentSelectedTreatment(row.className);
+  });
+
+  it("applies info and danger tone variants only while unselected", () => {
+    const { rerender } = render(
+      <StandardListSelectionItem tone="info">
+        Info row
+      </StandardListSelectionItem>,
+    );
+
+    let row = screen.getByRole("button", { name: "Info row" });
+    expect(row.className).toContain(STANDARD_LIST_SELECTION_ROW_INFO_CLASS);
+    expectNoAccentSelectedTreatment(row.className);
+
+    rerender(
+      <StandardListSelectionItem tone="danger">
+        Danger row
+      </StandardListSelectionItem>,
+    );
+    row = screen.getByRole("button", { name: "Danger row" });
+    expect(row.className).toContain(STANDARD_LIST_SELECTION_ROW_DANGER_CLASS);
+    expectNoAccentSelectedTreatment(row.className);
+  });
+
+  it("honors per-row disabled state over list pending", () => {
+    render(
+      <StandardListSelection>
+        <StandardListSelectionItem disabled>
+          Disabled row
+        </StandardListSelectionItem>
+      </StandardListSelection>,
+    );
+
+    expect(screen.getByRole("button", { name: "Disabled row" }).disabled).toBe(
+      true,
+    );
+  });
+});

--- a/ui/src/components/ui/standard-list-selection.tsx
+++ b/ui/src/components/ui/standard-list-selection.tsx
@@ -1,0 +1,135 @@
+import {
+  createContext,
+  forwardRef,
+  type HTMLAttributes,
+  type ReactNode,
+  useContext,
+} from "react";
+
+import { cn } from "../../lib/cn";
+import {
+  SelectableCardButton,
+  type SelectableCardButtonProps,
+} from "./selectable-card-button";
+
+export type StandardListSelectionTone = "neutral" | "info" | "danger";
+
+const StandardListSelectionDisabledContext = createContext(false);
+
+export const STANDARD_LIST_SELECTION_LIST_CLASS = "grid gap-2";
+
+const STANDARD_LIST_SELECTION_ROW_BASE_CLASS =
+  "h-auto min-h-0 w-full justify-start gap-1 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-af-focus-ring";
+
+export const STANDARD_LIST_SELECTION_ROW_NEUTRAL_CLASS =
+  "border-af-border bg-af-surface-raised text-af-text hover:border-af-border-strong hover:bg-af-overlay";
+
+export const STANDARD_LIST_SELECTION_ROW_INFO_CLASS =
+  "border-af-info-border bg-af-info-surface text-af-on-info";
+
+export const STANDARD_LIST_SELECTION_ROW_DANGER_CLASS =
+  "border-af-danger-border bg-af-danger-surface text-af-on-danger";
+
+export const STANDARD_LIST_SELECTION_ROW_SELECTED_CLASS =
+  "border-af-border-strong bg-af-surface-subtle text-af-text";
+
+const STANDARD_LIST_SELECTION_TONE_CLASS: Record<
+  StandardListSelectionTone,
+  string
+> = {
+  neutral: STANDARD_LIST_SELECTION_ROW_NEUTRAL_CLASS,
+  info: STANDARD_LIST_SELECTION_ROW_INFO_CLASS,
+  danger: STANDARD_LIST_SELECTION_ROW_DANGER_CLASS,
+};
+
+export function standardListSelectionRowClassName({
+  className,
+  selected,
+  tone = "neutral",
+}: {
+  className?: string;
+  selected: boolean;
+  tone?: StandardListSelectionTone;
+}): string {
+  return cn(
+    STANDARD_LIST_SELECTION_ROW_BASE_CLASS,
+    selected
+      ? STANDARD_LIST_SELECTION_ROW_SELECTED_CLASS
+      : STANDARD_LIST_SELECTION_TONE_CLASS[tone],
+    className,
+  );
+}
+
+export interface StandardListSelectionProps
+  extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+  disabled?: boolean;
+  selectionAnnouncement?: string;
+}
+
+export function StandardListSelection({
+  children,
+  className,
+  disabled = false,
+  selectionAnnouncement,
+  ...props
+}: StandardListSelectionProps) {
+  return (
+    <StandardListSelectionDisabledContext.Provider value={disabled}>
+      <div
+        aria-busy={disabled ? true : undefined}
+        className={cn(STANDARD_LIST_SELECTION_LIST_CLASS, className)}
+        {...props}
+      >
+        {children}
+        {selectionAnnouncement ? (
+          <div aria-live="polite" className="sr-only">
+            {selectionAnnouncement}
+          </div>
+        ) : null}
+      </div>
+    </StandardListSelectionDisabledContext.Provider>
+  );
+}
+
+export interface StandardListSelectionItemProps
+  extends Omit<SelectableCardButtonProps, "selected" | "tone"> {
+  selected?: boolean;
+  tone?: StandardListSelectionTone;
+}
+
+export const StandardListSelectionItem = forwardRef<
+  HTMLButtonElement,
+  StandardListSelectionItemProps
+>(function StandardListSelectionItem(
+  {
+    children,
+    className,
+    disabled,
+    selected = false,
+    tone = "neutral",
+    ...props
+  },
+  ref,
+) {
+  const listDisabled = useContext(StandardListSelectionDisabledContext);
+
+  return (
+    <SelectableCardButton
+      className={standardListSelectionRowClassName({
+        className,
+        selected,
+        tone,
+      })}
+      data-selected={selected ? "true" : "false"}
+      disabled={disabled ?? listDisabled}
+      ref={ref}
+      selected={selected}
+      size="sm"
+      tone="outline"
+      {...props}
+    >
+      {children}
+    </SelectableCardButton>
+  );
+});

--- a/ui/src/features/header/components/dashboard-session-tabs-open-dialog.tsx
+++ b/ui/src/features/header/components/dashboard-session-tabs-open-dialog.tsx
@@ -1,11 +1,8 @@
-import {
-  type FormEvent,
-  useId,
-} from "react";
+import { type FormEvent, useId } from "react";
 
 import type {
-  FactorySessionTarget,
   FactorySessionsAPIError,
+  FactorySessionTarget,
 } from "../../../api/factory-sessions";
 import {
   Button,
@@ -13,12 +10,14 @@ import {
   DialogHeader,
   DialogTitle,
   Input,
+  StandardListSelection,
+  StandardListSelectionItem,
 } from "../../../components/ui";
 import { DASHBOARD_BODY_TEXT_CLASS } from "../../../components/ui/dashboard-typography";
 import { cn } from "../../../lib/cn";
 import {
-  factorySessionTargetOptionValue,
   type FolderValidationState,
+  factorySessionTargetOptionValue,
   folderValidationStatusMessage,
   selectedFactorySessionTarget,
 } from "../lib/dashboard-session-tabs-utils";
@@ -32,9 +31,6 @@ const SESSION_DIALOG_STATUS_CLASS =
   "rounded-xl border border-af-accent-border bg-af-accent-surface px-3 py-2 text-sm text-af-text";
 const SESSION_TARGET_PICKER_CLASS =
   "grid gap-3 rounded-2xl border border-af-border bg-af-surface-subtle p-4";
-const SESSION_TARGET_BUTTON_CLASS =
-  "flex min-h-16 w-full flex-col items-start justify-center rounded-xl border border-af-accent bg-af-accent px-4 py-3 text-left text-sm text-af-on-accent shadow-sm transition-colors hover:border-af-accent-hover hover:bg-af-accent-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-af-focus-ring";
-const SESSION_TARGET_LIST_CLASS = "grid gap-3";
 
 export function OpenSessionDialog({
   dialogError,
@@ -86,7 +82,10 @@ export function OpenSessionDialog({
       <DialogHeader>
         <DialogTitle>{messages.openSessionDialogTitle}</DialogTitle>
         <p
-          className={cn("text-sm leading-6 text-af-text-muted", DASHBOARD_BODY_TEXT_CLASS)}
+          className={cn(
+            "text-sm leading-6 text-af-text-muted",
+            DASHBOARD_BODY_TEXT_CLASS,
+          )}
           id={dialogDescriptionID}
         >
           {messages.openSessionDialogDescription}
@@ -94,7 +93,10 @@ export function OpenSessionDialog({
       </DialogHeader>
       <form className="grid gap-4" onSubmit={onInspectFolder}>
         <div className="grid gap-2">
-          <label className={SESSION_SECTION_LABEL_CLASS} htmlFor={folderFieldID}>
+          <label
+            className={SESSION_SECTION_LABEL_CLASS}
+            htmlFor={folderFieldID}
+          >
             {messages.sessionFolderFieldLabel}
           </label>
           <div className="flex flex-col gap-2 sm:flex-row">
@@ -112,7 +114,10 @@ export function OpenSessionDialog({
             />
           </div>
           <p
-            className={cn("text-sm text-af-text-muted", DASHBOARD_BODY_TEXT_CLASS)}
+            className={cn(
+              "text-sm text-af-text-muted",
+              DASHBOARD_BODY_TEXT_CLASS,
+            )}
             id={folderHelperTextID}
           >
             {messages.sessionFolderHelperText}
@@ -183,10 +188,11 @@ function InitNewFactoryConfirmation({
   onCancel: () => void;
   onConfirm: () => void;
 }) {
-  const description = messages.openSessionInitNewFactoryDescriptionTemplate.replace(
-    "{{folderPath}}",
-    folderPath,
-  );
+  const description =
+    messages.openSessionInitNewFactoryDescriptionTemplate.replace(
+      "{{folderPath}}",
+      folderPath,
+    );
 
   return (
     <section
@@ -194,7 +200,10 @@ function InitNewFactoryConfirmation({
       className={SESSION_TARGET_PICKER_CLASS}
     >
       <p
-        className={cn("text-sm leading-6 text-af-text", DASHBOARD_BODY_TEXT_CLASS)}
+        className={cn(
+          "text-sm leading-6 text-af-text",
+          DASHBOARD_BODY_TEXT_CLASS,
+        )}
         id="init-new-factory-confirmation-title"
       >
         {description}
@@ -242,12 +251,16 @@ function SessionTargetPicker({
   selectedTargetValue: string;
   targets: FactorySessionTarget[];
 }) {
-  const selectedTarget = selectedFactorySessionTarget(targets, selectedTargetValue)
-    ?? (targets.length === 1 ? targets[0] : null);
+  const selectedTarget =
+    selectedFactorySessionTarget(targets, selectedTargetValue) ??
+    (targets.length === 1 ? targets[0] : null);
 
   return (
     <section className={SESSION_TARGET_PICKER_CLASS}>
-      <div className={SESSION_TARGET_LIST_CLASS}>
+      <StandardListSelection
+        disabled={isPending}
+        selectionAnnouncement={selectedTarget?.label}
+      >
         {targets.map((target) => {
           const targetValue = factorySessionTargetOptionValue(target);
           const isSelected =
@@ -255,33 +268,25 @@ function SessionTargetPicker({
             factorySessionTargetOptionValue(selectedTarget) === targetValue;
 
           return (
-            <button
+            <StandardListSelectionItem
               key={`${target.ref.kind}:${target.ref.name ?? ""}:${target.factoryDir}`}
-              className={cn(
-                SESSION_TARGET_BUTTON_CLASS,
-                isSelected
-                  ? "ring-2 ring-af-focus-ring ring-offset-2 ring-offset-af-surface-subtle"
-                  : undefined,
-              )}
-              disabled={isPending}
               onClick={() => {
                 onOpenTarget(targetValue);
               }}
-              type="button"
+              selected={isSelected}
             >
-              <span className="font-semibold text-af-text">{target.label}</span>
-              <span className="truncate text-xs text-af-text-subtle">
-                {target.factoryDir}
+              <span className="flex min-h-16 w-full flex-col items-start justify-center px-1 py-1 text-sm">
+                <span className="font-semibold text-af-text">
+                  {target.label}
+                </span>
+                <span className="truncate text-xs text-af-text-subtle">
+                  {target.factoryDir}
+                </span>
               </span>
-            </button>
+            </StandardListSelectionItem>
           );
         })}
-      </div>
-      {selectedTarget ? (
-        <div className="sr-only" aria-live="polite">
-          {selectedTarget.label}
-        </div>
-      ) : null}
+      </StandardListSelection>
     </section>
   );
 }

--- a/ui/src/features/header/components/dashboard-session-tabs.launch-target-selection.test.tsx
+++ b/ui/src/features/header/components/dashboard-session-tabs.launch-target-selection.test.tsx
@@ -3,9 +3,13 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactElement } from "react";
 
 import { DEFAULT_FACTORY_SESSION_ID } from "../../../api/session-routing";
+import {
+  STANDARD_LIST_SELECTION_ROW_NEUTRAL_CLASS,
+  STANDARD_LIST_SELECTION_ROW_SELECTED_CLASS,
+} from "../../../components/ui/standard-list-selection";
 import { useDashboardSessionStore } from "../../dashboard/state/dashboardSessionStore";
-import { DashboardSessionTabs } from "./dashboard-session-tabs";
 import { getHeaderControlsMessages } from "../messages/header-controls";
+import { DashboardSessionTabs } from "./dashboard-session-tabs";
 
 const listFactorySessions = vi.fn();
 const openFactorySession = vi.fn();
@@ -31,6 +35,82 @@ vi.mock("../../../api/factory-sessions", () => ({
   openFactorySession: (...args: unknown[]) => openFactorySession(...args),
 }));
 
+function mockLaunchTargetSelectionSessionApis() {
+  listFactorySessions
+    .mockResolvedValueOnce([
+      {
+        factoryDir: "/workspace/root",
+        folderPath: "/workspace/root",
+        id: "~default",
+        isDefault: true,
+        project: "root",
+        target: {
+          kind: "default",
+        },
+      },
+    ])
+    .mockResolvedValueOnce([
+      {
+        factoryDir: "/workspace/root",
+        folderPath: "/workspace/root",
+        id: "~default",
+        isDefault: true,
+        project: "root",
+        target: {
+          kind: "default",
+        },
+      },
+      {
+        factoryDir: "/workspace/fleet/beta",
+        folderPath: "/workspace/fleet",
+        id: "session-beta",
+        isDefault: false,
+        project: "beta",
+        target: {
+          kind: "named",
+          name: "beta",
+        },
+      },
+    ]);
+  openFactorySession
+    .mockResolvedValueOnce({
+      targets: [
+        {
+          factoryDir: "/workspace/fleet",
+          folderPath: "/workspace/fleet",
+          label: "default",
+          project: "fleet",
+          ref: {
+            kind: "default",
+          },
+        },
+        {
+          factoryDir: "/workspace/fleet/beta",
+          folderPath: "/workspace/fleet",
+          label: "beta",
+          project: "beta",
+          ref: {
+            kind: "named",
+            name: "beta",
+          },
+        },
+      ],
+    })
+    .mockResolvedValueOnce({
+      session: {
+        factoryDir: "/workspace/fleet/beta",
+        folderPath: "/workspace/fleet",
+        id: "session-beta",
+        isDefault: false,
+        project: "beta",
+        target: {
+          kind: "named",
+          name: "beta",
+        },
+      },
+    });
+}
+
 describe("DashboardSessionTabs launch target selection", () => {
   beforeEach(() => {
     listFactorySessions.mockReset();
@@ -42,80 +122,7 @@ describe("DashboardSessionTabs launch target selection", () => {
   });
 
   it("launches the selected named factory instead of falling back to the default target", async () => {
-    listFactorySessions
-      .mockResolvedValueOnce([
-        {
-          factoryDir: "/workspace/root",
-          folderPath: "/workspace/root",
-          id: "~default",
-          isDefault: true,
-          project: "root",
-          target: {
-            kind: "default",
-          },
-        },
-      ])
-      .mockResolvedValueOnce([
-        {
-          factoryDir: "/workspace/root",
-          folderPath: "/workspace/root",
-          id: "~default",
-          isDefault: true,
-          project: "root",
-          target: {
-            kind: "default",
-          },
-        },
-        {
-          factoryDir: "/workspace/fleet/beta",
-          folderPath: "/workspace/fleet",
-          id: "session-beta",
-          isDefault: false,
-          project: "beta",
-          target: {
-            kind: "named",
-            name: "beta",
-          },
-        },
-      ]);
-    openFactorySession
-      .mockResolvedValueOnce({
-        targets: [
-          {
-            factoryDir: "/workspace/fleet",
-            folderPath: "/workspace/fleet",
-            label: "default",
-            project: "fleet",
-            ref: {
-              kind: "default",
-            },
-          },
-          {
-            factoryDir: "/workspace/fleet/beta",
-            folderPath: "/workspace/fleet",
-            label: "beta",
-            project: "beta",
-            ref: {
-              kind: "named",
-              name: "beta",
-            },
-          },
-        ],
-      })
-      .mockResolvedValueOnce({
-        session: {
-          factoryDir: "/workspace/fleet/beta",
-          folderPath: "/workspace/fleet",
-          id: "session-beta",
-          isDefault: false,
-          project: "beta",
-          target: {
-            kind: "named",
-            name: "beta",
-          },
-        },
-      });
-
+    mockLaunchTargetSelectionSessionApis();
     renderWithQueryClient(<DashboardSessionTabs locale="en" />);
     const messages = getHeaderControlsMessages("en");
 
@@ -149,7 +156,15 @@ describe("DashboardSessionTabs launch target selection", () => {
       });
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /beta/i }));
+    const defaultTargetButton = screen.getByRole("button", {
+      name: /default/i,
+    });
+    const betaTargetButton = screen.getByRole("button", { name: /beta/i });
+
+    expectStandardListTargetRow(defaultTargetButton, { selected: false });
+    expectStandardListTargetRow(betaTargetButton, { selected: false });
+
+    fireEvent.click(betaTargetButton);
 
     await waitFor(() => {
       expect(openFactorySession.mock.calls[1]?.[0]).toEqual({
@@ -160,11 +175,35 @@ describe("DashboardSessionTabs launch target selection", () => {
         },
       });
     });
+
     expect(useDashboardSessionStore.getState().selectedSessionID).toBe(
       "session-beta",
     );
   });
 });
+
+const ACCENT_SELECTED_TOKENS = [
+  "bg-af-accent",
+  "bg-af-accent-surface",
+  "border-af-accent",
+  "shadow-af-accent-selected",
+] as const;
+
+function expectStandardListTargetRow(
+  row: HTMLElement,
+  { selected }: { selected: boolean },
+) {
+  expect(row.getAttribute("aria-pressed")).toBe(selected ? "true" : "false");
+  expect(row.getAttribute("data-selected")).toBe(selected ? "true" : "false");
+  expect(row.className).toContain(
+    selected
+      ? STANDARD_LIST_SELECTION_ROW_SELECTED_CLASS
+      : STANDARD_LIST_SELECTION_ROW_NEUTRAL_CLASS,
+  );
+  for (const token of ACCENT_SELECTED_TOKENS) {
+    expect(row.className).not.toContain(token);
+  }
+}
 
 function renderWithQueryClient(view: ReactElement) {
   const queryClient = new QueryClient({

--- a/ui/src/features/terminal-work/components/terminal-work-card.stories.tsx
+++ b/ui/src/features/terminal-work/components/terminal-work-card.stories.tsx
@@ -1,7 +1,10 @@
 import { useState } from "react";
 import { expect, userEvent, within } from "storybook/test";
-
 import type { DashboardProviderSessionAttempt } from "../../../api/dashboard/types";
+import {
+  STANDARD_LIST_SELECTION_ROW_DANGER_CLASS,
+  STANDARD_LIST_SELECTION_ROW_SELECTED_CLASS,
+} from "../../../components/ui/standard-list-selection";
 import { getTerminalWorkMessages } from "../messages/terminal-work";
 import type {
   TerminalWorkItem,
@@ -52,6 +55,19 @@ const failedItems: TerminalWorkItem[] = [
   },
 ];
 
+const ACCENT_SELECTED_TOKENS = [
+  "bg-af-accent",
+  "bg-af-accent-surface",
+  "border-af-accent",
+  "shadow-af-accent-selected",
+] as const;
+
+function expectNoAccentSelectedTreatment(className: string) {
+  for (const token of ACCENT_SELECTED_TOKENS) {
+    expect(className).not.toContain(token);
+  }
+}
+
 function SelectableTerminalWorkStory() {
   const [selectedItem, setSelectedItem] = useState<{
     label: string;
@@ -92,6 +108,7 @@ export default {
 };
 
 export const MixedOutcomes = {
+  tags: ["test"],
   render: () => <SelectableTerminalWorkStory />,
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
@@ -121,6 +138,20 @@ export const MixedOutcomes = {
     await expect(doneStory).toBeVisible();
     await userEvent.click(doneStory);
     await expect(doneStory).toHaveAttribute("data-selected", "true");
+    await expect(doneStory).toHaveAttribute("aria-pressed", "true");
+    expect(doneStory.className).toContain(
+      STANDARD_LIST_SELECTION_ROW_SELECTED_CLASS,
+    );
+    expectNoAccentSelectedTreatment(doneStory.className);
+
+    const failedStory = await terminalScope.findByRole("button", {
+      name: "Failed Story",
+    });
+    expect(failedStory.className).toContain(
+      STANDARD_LIST_SELECTION_ROW_DANGER_CLASS,
+    );
+    await expect(failedStory).toHaveAttribute("aria-pressed", "false");
+    expectNoAccentSelectedTreatment(failedStory.className);
   },
 };
 

--- a/ui/src/features/terminal-work/components/terminal-work-card.test.tsx
+++ b/ui/src/features/terminal-work/components/terminal-work-card.test.tsx
@@ -5,6 +5,11 @@ import {
   DASHBOARD_SECTION_HEADING_CLASS,
   DASHBOARD_SUPPORTING_TEXT_CLASS,
 } from "../../../components/ui/dashboard-typography";
+import {
+  STANDARD_LIST_SELECTION_ROW_DANGER_CLASS,
+  STANDARD_LIST_SELECTION_ROW_INFO_CLASS,
+  STANDARD_LIST_SELECTION_ROW_SELECTED_CLASS,
+} from "../../../components/ui/standard-list-selection";
 import { getTerminalWorkMessages } from "../messages/terminal-work";
 import { CompletedFailedWorkstationCard } from "./terminal-work-card";
 
@@ -302,22 +307,14 @@ describe("CompletedFailedWorkstationCard", () => {
       />,
     );
 
-    expect(
-      screen
-        .getByRole("button", { name: /Failed Story/ })
-        .getAttribute("data-selected"),
-    ).toBe("true");
-    expect(
-      screen.getByRole("button", { name: /Failed Story/ }).className,
-    ).toContain("text-af-text");
-    expect(
-      screen.getByRole("button", { name: /Failed Story/ }).className,
-    ).toContain("border-af-accent-border");
-    expect(
-      screen
-        .getByRole("button", { name: /Done Story/ })
-        .getAttribute("data-selected"),
-    ).toBeNull();
+    expectStandardListTerminalRow(
+      screen.getByRole("button", { name: /Failed Story/ }),
+      { selected: true, tone: "danger" },
+    );
+    expectStandardListTerminalRow(
+      screen.getByRole("button", { name: /Done Story/ }),
+      { selected: false, tone: "info" },
+    );
   });
 
   it("keeps selection styling controlled by props across rerenders", () => {
@@ -353,16 +350,14 @@ describe("CompletedFailedWorkstationCard", () => {
       />,
     );
 
-    expect(
-      screen
-        .getByRole("button", { name: /Done Story/ })
-        .getAttribute("data-selected"),
-    ).toBeNull();
-    expect(
-      screen
-        .getByRole("button", { name: /Failed Story/ })
-        .getAttribute("data-selected"),
-    ).toBe("true");
+    expectStandardListTerminalRow(
+      screen.getByRole("button", { name: /Done Story/ }),
+      { selected: false, tone: "info" },
+    );
+    expectStandardListTerminalRow(
+      screen.getByRole("button", { name: /Failed Story/ }),
+      { selected: true, tone: "danger" },
+    );
   });
 
   it("renders explicit empty messages for each outcome row", () => {
@@ -483,3 +478,35 @@ describe("CompletedFailedWorkstationCard", () => {
     ).toBe("false");
   });
 });
+
+const ACCENT_SELECTED_TOKENS = [
+  "bg-af-accent",
+  "bg-af-accent-surface",
+  "border-af-accent",
+  "shadow-af-accent-selected",
+] as const;
+
+function expectStandardListTerminalRow(
+  row: HTMLElement,
+  {
+    selected,
+    tone,
+  }: {
+    selected: boolean;
+    tone: "info" | "danger";
+  },
+) {
+  const unselectedToneClass =
+    tone === "danger"
+      ? STANDARD_LIST_SELECTION_ROW_DANGER_CLASS
+      : STANDARD_LIST_SELECTION_ROW_INFO_CLASS;
+
+  expect(row.getAttribute("aria-pressed")).toBe(selected ? "true" : "false");
+  expect(row.getAttribute("data-selected")).toBe(selected ? "true" : "false");
+  expect(row.className).toContain(
+    selected ? STANDARD_LIST_SELECTION_ROW_SELECTED_CLASS : unselectedToneClass,
+  );
+  for (const token of ACCENT_SELECTED_TOKENS) {
+    expect(row.className).not.toContain(token);
+  }
+}

--- a/ui/src/features/terminal-work/components/terminal-work-card.tsx
+++ b/ui/src/features/terminal-work/components/terminal-work-card.tsx
@@ -69,10 +69,6 @@ const TERMINAL_ROW_HEADER_CLASS =
 const TERMINAL_ROW_TITLE_CLASS = "flex min-w-0 flex-1 items-center gap-2";
 const TERMINAL_ROW_TITLE_ICON_CLASS = "h-4 w-4 shrink-0";
 const TERMINAL_LIST_CLASS = "grid gap-2";
-const TERMINAL_ITEM_LAYOUT_CLASS = cn(
-  "px-2.5 py-2 [overflow-wrap:anywhere]",
-  DASHBOARD_BODY_TEXT_CLASS,
-);
 const TERMINAL_BUTTON_LABEL_CLASS = "font-bold";
 const TERMINAL_BUTTON_META_CLASS = cn(
   "leading-snug text-current",
@@ -225,7 +221,10 @@ function TerminalWorkRow({
               {items.map((item) => (
                 <StandardListSelectionItem
                   aria-label={item.label}
-                  className={TERMINAL_ITEM_LAYOUT_CLASS}
+                  className={cn(
+                    "px-2.5 py-2 [overflow-wrap:anywhere]",
+                    DASHBOARD_BODY_TEXT_CLASS,
+                  )}
                   key={`${status}-${item.label}`}
                   onClick={() => onSelectItem(item)}
                   selected={selectedLabel === item.label}

--- a/ui/src/features/terminal-work/components/terminal-work-card.tsx
+++ b/ui/src/features/terminal-work/components/terminal-work-card.tsx
@@ -11,7 +11,10 @@ import {
   DASHBOARD_SECTION_HEADING_CLASS,
   DASHBOARD_SUPPORTING_TEXT_CLASS,
 } from "../../../components/ui/dashboard-typography";
-import { SelectableCardButton } from "../../../components/ui/selectable-card-button";
+import {
+  StandardListSelection,
+  StandardListSelectionItem,
+} from "../../../components/ui/standard-list-selection";
 import {
   DASHBOARD_WIDGET_CLASS,
   DETAIL_CARD_CLASS,
@@ -66,14 +69,10 @@ const TERMINAL_ROW_HEADER_CLASS =
 const TERMINAL_ROW_TITLE_CLASS = "flex min-w-0 flex-1 items-center gap-2";
 const TERMINAL_ROW_TITLE_ICON_CLASS = "h-4 w-4 shrink-0";
 const TERMINAL_LIST_CLASS = "grid gap-2";
-const TERMINAL_BUTTON_CLASS = cn(
-  "grid h-auto min-h-0 w-full justify-start gap-1 border-af-info-border bg-af-info-surface px-2.5 py-2 text-left text-af-on-info [overflow-wrap:anywhere]",
+const TERMINAL_ITEM_LAYOUT_CLASS = cn(
+  "px-2.5 py-2 [overflow-wrap:anywhere]",
   DASHBOARD_BODY_TEXT_CLASS,
 );
-const TERMINAL_BUTTON_FAILED_CLASS =
-  "border-af-danger-border bg-af-danger-surface text-af-on-danger";
-const TERMINAL_BUTTON_SELECTED_CLASS =
-  "border-af-accent-border bg-af-accent-surface text-af-text shadow-af-accent-selected";
 const TERMINAL_BUTTON_LABEL_CLASS = "font-bold";
 const TERMINAL_BUTTON_META_CLASS = cn(
   "leading-snug text-current",
@@ -222,35 +221,28 @@ function TerminalWorkRow({
 
         <CollapsibleContent className={TERMINAL_LIST_CLASS} id={rowId}>
           {items.length > 0 ? (
-            items.map((item) => (
-              <SelectableCardButton
-                aria-label={item.label}
-                className={cn(
-                  TERMINAL_BUTTON_CLASS,
-                  status === "failed" && TERMINAL_BUTTON_FAILED_CLASS,
-                  selectedLabel === item.label &&
-                    TERMINAL_BUTTON_SELECTED_CLASS,
-                )}
-                data-selected={
-                  selectedLabel === item.label ? "true" : undefined
-                }
-                key={`${status}-${item.label}`}
-                onClick={() => onSelectItem(item)}
-                selected={selectedLabel === item.label}
-                size="sm"
-                tone="outline"
-              >
-                <span className={TERMINAL_BUTTON_LABEL_CLASS}>
-                  {item.label}
-                </span>
-                {renderTerminalWorkContext(
-                  item,
-                  fallbackMessage,
-                  summary,
-                  status,
-                )}
-              </SelectableCardButton>
-            ))
+            <StandardListSelection>
+              {items.map((item) => (
+                <StandardListSelectionItem
+                  aria-label={item.label}
+                  className={TERMINAL_ITEM_LAYOUT_CLASS}
+                  key={`${status}-${item.label}`}
+                  onClick={() => onSelectItem(item)}
+                  selected={selectedLabel === item.label}
+                  tone={status === "failed" ? "danger" : "info"}
+                >
+                  <span className={TERMINAL_BUTTON_LABEL_CLASS}>
+                    {item.label}
+                  </span>
+                  {renderTerminalWorkContext(
+                    item,
+                    fallbackMessage,
+                    summary,
+                    status,
+                  )}
+                </StandardListSelectionItem>
+              ))}
+            </StandardListSelection>
           ) : (
             <p className={DETAIL_COPY_CLASS}>{emptyMessage}</p>
           )}

--- a/ui/src/features/terminal-work/components/terminal-work-widget.test.tsx
+++ b/ui/src/features/terminal-work/components/terminal-work-widget.test.tsx
@@ -16,7 +16,9 @@ describe("TerminalWorkWidget", () => {
 
     render(
       <TerminalWorkWidget
-        completedItems={[{ label: "Done Story", traceWorkID: "work-done-story" }]}
+        completedItems={[
+          { label: "Done Story", traceWorkID: "work-done-story" },
+        ]}
         failedItems={[]}
         onSelectItem={vi.fn()}
         selectedItem={null}
@@ -35,7 +37,9 @@ describe("TerminalWorkWidget", () => {
 
     render(
       <TerminalWorkWidget
-        completedItems={[{ label: "Done Story", traceWorkID: "work-done-story" }]}
+        completedItems={[
+          { label: "Done Story", traceWorkID: "work-done-story" },
+        ]}
         failedItems={[]}
         locale="zh-CN"
         onSelectItem={vi.fn()}
@@ -55,8 +59,12 @@ describe("TerminalWorkWidget", () => {
 
     render(
       <TerminalWorkWidget
-        completedItems={[{ label: "Done Story", traceWorkID: "work-done-story" }]}
-        failedItems={[{ label: "Failed Story", traceWorkID: "work-failed-story" }]}
+        completedItems={[
+          { label: "Done Story", traceWorkID: "work-done-story" },
+        ]}
+        failedItems={[
+          { label: "Failed Story", traceWorkID: "work-failed-story" },
+        ]}
         onSelectItem={onSelectItem}
         selectedItem={{ label: "Done Story", status: "completed" }}
       />,
@@ -71,7 +79,7 @@ describe("TerminalWorkWidget", () => {
       screen
         .getByRole("button", { name: /Failed Story/ })
         .getAttribute("data-selected"),
-    ).toBeNull();
+    ).toBe("false");
 
     fireEvent.click(screen.getByRole("button", { name: /Failed Story/ }));
 


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/issues2-standard-list-selector",
  "description": "Converge the open-session factory target picker and the terminal work results list onto one shared list-selection component with standard dark gray surface styling for default and selected rows, replacing bespoke yellow accent list selectors while preserving selection behavior and accessibility.",
  "context": {
    "customerAsk": "Converge factory selector and work-results terminal list into one standard list-selection component using dark gray surface colors instead of accented yellow; preserve or improve keyboard and screen-reader behavior.",
    "problem": "The factory session target picker uses accent-filled yellow buttons while the terminal work results list uses a separate SelectableCardButton setup with accent selected styling. Two divergent implementations create inconsistent dashboard selection UX and duplicate styling logic.",
    "solution": "Add a shared list-selection primitive under ui/src/components/ui/ built on SelectableCardButton with neutral dark gray default and selected tokens, migrate SessionTargetPicker and terminal work item rows to it, and prove behavior with focused tests, Storybook, and browser verification."
  },
  "acceptanceCriteria": [
    "Shared list-selection component in ui/src/components/ui/ is used by the open-session factory target picker and the terminal work results list",
    "Selected rows on both surfaces use dark gray neutral surface tokens and do not use accent/yellow fill (bg-af-accent, bg-af-accent-surface, border-af-accent, shadow-af-accent-selected) as the primary selected-row treatment",
    "Factory target click still opens the correct runnable target; terminal work item click still invokes onSelectItem with the correct status and item payload",
    "Selected rows expose aria-pressed and accessible selection feedback; keyboard focus behavior is preserved or improved",
    "dashboard-session-tabs.launch-target-selection and terminal-work-card selection tests pass with updated neutral styling assertions",
    "Storybook demonstrates the shared list-selection component including selected, disabled, and tone variants without accent selection fill",
    "ui typecheck, lint, and affected tests pass"
  ],
  "userStories": [
    {
      "id": "issues2-standard-list-selector-001",
      "title": "Shared standard list selection primitive",
      "description": "As a maintainer, I need one reusable list-selection row and list shell so dashboard features do not reimplement selectable list markup, dark gray styling, and pressed-state semantics.",
      "acceptanceCriteria": [
        "Shared list-selection components live under ui/src/components/ui/ and are exported from the shared UI public surface",
        "Row items are built on SelectableCardButton with default dark gray surfaces (border-af-border, bg-af-surface-raised) and neutral selected styling (border-af-border-strong, bg-af-surface-subtle) without accent fill tokens as primary selected treatment",
        "Rows support optional tone variants (neutral, info, danger) for status context on unselected terminal work rows",
        "Selected rows set aria-pressed=\"true\" and data-selected=\"true\"; unselected rows set aria-pressed=\"false\"",
        "List shell supports vertical layout, disabled pending state, and optional aria-live selection announcement",
        "Unit tests cover default vs selected class tokens, aria-pressed, tone variants, and disabled behavior",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues2-standard-list-selector-002",
      "title": "Factory target picker uses standard list selection",
      "description": "As an operator opening a factory session from a folder with multiple runnable targets, I want target choices to look and behave like other dashboard list selections so the picker feels consistent and readable.",
      "acceptanceCriteria": [
        "SessionTargetPicker renders targets through the shared list-selection component instead of bespoke accent-filled buttons",
        "Target rows show primary label and secondary factoryDir path with neutral dark gray styling; selected target is distinguishable without yellow/accent row fill",
        "Clicking a target calls onOpenTarget with the correct factorySessionTargetOptionValue; dashboard-session-tabs.launch-target-selection.test.tsx passes",
        "Selected target exposes aria-pressed=\"true\" and selection is announced to screen readers",
        "Pending/disabled state disables row interaction without losing visible selection",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill: open-session dialog with multiple runnable targets—dark gray rows, neutral selected emphasis, target open works"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues2-standard-list-selector-003",
      "title": "Terminal work results list uses standard list selection",
      "description": "As an operator reviewing completed or failed work, I want work-item rows to use the same list-selection styling as the factory target picker so selected results are clear without yellow accent emphasis.",
      "acceptanceCriteria": [
        "Terminal work item rows in CompletedFailedWorkstationCard use the shared list-selection component instead of inline TERMINAL_BUTTON_SELECTED_CLASS accent styling",
        "Selected work item uses neutral dark gray selected styling, not border-af-accent-border, bg-af-accent-surface, or shadow-af-accent-selected",
        "Completed rows retain info-toned unselected styling; failed rows retain danger-toned unselected styling for outcome context",
        "onSelectItem, selectedItem prop wiring, collapsible rows, empty states, and data-terminal-work-status sections are unchanged",
        "terminal-work-card.test.tsx and terminal-work-widget.test.tsx selection tests pass with updated neutral styling assertions",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill: terminal-work widget—selecting completed and failed rows updates detail with neutral gray selected styling"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues2-standard-list-selector-004",
      "title": "Storybook catalog and cross-surface regression proof",
      "description": "As a maintainer, I need a catalog entry and focused regression tests so future UI work does not reintroduce bespoke accent list selectors on these surfaces.",
      "acceptanceCriteria": [
        "Storybook stories demonstrate the shared list-selection component with default, selected, disabled, and info/danger tone rows",
        "Storybook play or unit assertions confirm selected rows do not use accent-fill utility classes as primary styling",
        "terminal-work-card.stories.tsx selection plays are updated if they reference legacy accent selected classes",
        "Feature-local SESSION_TARGET_BUTTON_CLASS and TERMINAL_BUTTON_SELECTED_CLASS accent selection bundles are removed after migration",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)