### PR TITLE
issues2-editor-session-reset

### DIFF
--- a/ui/integration/factory-graph-editor-session-switch.integration.test.mjs
+++ b/ui/integration/factory-graph-editor-session-switch.integration.test.mjs
@@ -1,0 +1,441 @@
+// @vitest-environment node
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  browserScenarioTimeoutMs,
+  buildTimeoutMs,
+  expectNoBrowserErrors,
+  openBrowserPage,
+  startBrowserPreview,
+  startFactoryApiServer,
+  uiInteractionTimeoutMs,
+} from "./browser-test-harness.mjs";
+
+const betaSessionID = "session-beta";
+
+const defaultSession = {
+  factoryDir: "/workspace/root",
+  folderPath: "/workspace/root",
+  id: "~default",
+  isDefault: true,
+  project: "root",
+  target: {
+    kind: "default",
+  },
+};
+
+const betaSession = {
+  factoryDir: "/workspace/root/beta",
+  folderPath: "/workspace/root",
+  id: betaSessionID,
+  isDefault: false,
+  project: "beta",
+  target: {
+    kind: "named",
+    name: "beta",
+  },
+};
+
+const alphaGraphFactoryDefinition = {
+  name: "Alpha Graph Factory",
+  workers: [
+    {
+      model: "gpt-5",
+      name: "writer",
+      type: "MODEL_WORKER",
+    },
+  ],
+  workTypes: [
+    {
+      name: "story",
+      states: [
+        {
+          name: "queued",
+          type: "INITIAL",
+        },
+        {
+          name: "done",
+          type: "TERMINAL",
+        },
+      ],
+    },
+  ],
+  workstations: [
+    {
+      body: "Draft the story.",
+      inputs: [
+        {
+          state: "queued",
+          workType: "story",
+        },
+      ],
+      name: "draft",
+      outputs: [
+        {
+          state: "done",
+          workType: "story",
+        },
+      ],
+      type: "MODEL_WORKSTATION",
+      worker: "writer",
+    },
+  ],
+};
+
+const betaGraphFactoryDefinition = {
+  name: "Beta Graph Factory",
+  workers: [
+    {
+      model: "gpt-5",
+      name: "beta-writer",
+      type: "MODEL_WORKER",
+    },
+  ],
+  workTypes: [
+    {
+      name: "beta-story",
+      states: [
+        {
+          name: "queued",
+          type: "INITIAL",
+        },
+        {
+          name: "done",
+          type: "TERMINAL",
+        },
+      ],
+    },
+  ],
+  workstations: [
+    {
+      body: "Beta drafting.",
+      inputs: [
+        {
+          state: "queued",
+          workType: "beta-story",
+        },
+      ],
+      name: "beta-station",
+      outputs: [
+        {
+          state: "done",
+          workType: "beta-story",
+        },
+      ],
+      type: "MODEL_WORKSTATION",
+      worker: "beta-writer",
+    },
+  ],
+};
+
+function buildEditableGraphReplayLines(workstationName, workTypeName) {
+  return [
+    JSON.stringify({
+      context: {
+        eventTime: "2026-05-19T15:00:00Z",
+        sequence: 1,
+        tick: 1,
+      },
+      id: `editable-graph-${workstationName}`,
+      payload: {
+        factory: {
+          workTypes: [
+            {
+              name: workTypeName,
+              states: [
+                {
+                  name: "queued",
+                  type: "INITIAL",
+                },
+                {
+                  name: "done",
+                  type: "TERMINAL",
+                },
+              ],
+            },
+          ],
+          workers: [
+            {
+              model: "gpt-5",
+              name: "writer",
+              type: "MODEL_WORKER",
+            },
+          ],
+          workstations: [
+            {
+              inputs: [
+                {
+                  state: "queued",
+                  workType: workTypeName,
+                },
+              ],
+              name: workstationName,
+              outputs: [
+                {
+                  state: "done",
+                  workType: workTypeName,
+                },
+              ],
+              worker: "writer",
+            },
+          ],
+        },
+      },
+      type: "INITIAL_STRUCTURE_REQUEST",
+    }),
+    JSON.stringify({
+      context: {
+        eventTime: "2026-05-19T15:00:01Z",
+        sequence: 2,
+        tick: 2,
+      },
+      id: `editable-graph-ready-${workstationName}`,
+      payload: {
+        previousState: "RUNNING",
+        reason: "fixture ready",
+        state: "FINISHED",
+      },
+      type: "FACTORY_STATE_RESPONSE",
+    }),
+  ];
+}
+
+const alphaGraphReplayLines = buildEditableGraphReplayLines("draft", "story");
+const betaGraphReplayLines = buildEditableGraphReplayLines(
+  "beta-station",
+  "beta-story",
+);
+
+function factoryGraphCardScope(page) {
+  return page.getByRole("article", { name: "Factory graph" });
+}
+
+async function enterGraphEditor(page) {
+  const graphCard = factoryGraphCardScope(page);
+  await graphCard
+    .getByRole("button", { name: "Enter factory graph editor" })
+    .click();
+  await graphCard
+    .getByRole("region", { name: "Factory graph editor tools" })
+    .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+}
+
+async function addUnsavedWorkType(page, identifier) {
+  const graphCard = factoryGraphCardScope(page);
+  const toolbar = graphCard.getByRole("region", {
+    name: "Factory graph editor tools",
+  });
+  await toolbar.getByRole("button", { name: "Open add entity menu" }).click();
+  await page
+    .getByLabel("Add graph entity menu")
+    .getByRole("button", { name: "Work type" })
+    .click();
+
+  const addDialog = page.getByRole("dialog", {
+    name: "Add work type",
+  });
+  await addDialog.waitFor({
+    state: "visible",
+    timeout: uiInteractionTimeoutMs,
+  });
+  await addDialog.getByLabel("Identifier").fill(identifier);
+  await addDialog.getByLabel("First state").fill("queued");
+  await addDialog.getByRole("button", { name: "Add entity" }).click();
+
+  const discardChangesButton = toolbar.getByRole("button", {
+    name: "Discard changes",
+  });
+  await expect
+    .poll(async () => await discardChangesButton.isEnabled(), {
+      timeout: uiInteractionTimeoutMs,
+    })
+    .toBe(true);
+}
+
+async function expectEditorModeOff(page) {
+  const graphCard = factoryGraphCardScope(page);
+  await graphCard
+    .getByRole("button", { name: "Enter factory graph editor" })
+    .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+  expect(
+    await graphCard
+      .getByRole("region", { name: "Factory graph editor tools" })
+      .count(),
+  ).toBe(0);
+  expect(await graphCard.getByText("Unsaved changes").count()).toBe(0);
+}
+
+describe.sequential("factory graph editor session switch browser integration", () => {
+  let preview = null;
+
+  beforeAll(async () => {
+    preview = await startBrowserPreview();
+  }, buildTimeoutMs);
+
+  afterAll(async () => {
+    await preview?.stop();
+    preview = null;
+  });
+
+  it(
+    "clears unsaved graph editor chrome and session A topology when switching to session B",
+    async () => {
+      const server = await startFactoryApiServer({
+        apiPort: preview.apiPort,
+        currentFactory: alphaGraphFactoryDefinition,
+        currentFactoryBySessionID: {
+          [betaSessionID]: betaGraphFactoryDefinition,
+        },
+        eventLines: alphaGraphReplayLines,
+        eventLinesBySessionID: {
+          [betaSessionID]: betaGraphReplayLines,
+        },
+        sessions: [defaultSession, betaSession],
+      });
+      const browserPage = await openBrowserPage();
+
+      try {
+        await browserPage.page.goto(preview.previewURL, {
+          waitUntil: "domcontentloaded",
+        });
+        await server.replayCompleted;
+
+        const rootTab = browserPage.page.getByRole("tab", { name: "root" });
+        const betaTab = browserPage.page.getByRole("tab", { name: "beta" });
+        await rootTab.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
+        await betaTab.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
+
+        await enterGraphEditor(browserPage.page);
+        await addUnsavedWorkType(browserPage.page, "essay");
+        expect(
+          await browserPage.page
+            .getByTestId("rf__node-work-type:essay")
+            .count(),
+        ).toBe(1);
+
+        await betaTab.click();
+        await expect
+          .poll(async () => betaTab.getAttribute("aria-selected"), {
+            timeout: uiInteractionTimeoutMs,
+          })
+          .toBe("true");
+
+        await expectEditorModeOff(browserPage.page);
+        expect(
+          await browserPage.page
+            .getByTestId("rf__node-work-type:essay")
+            .count(),
+        ).toBe(0);
+        await browserPage.page
+          .getByTestId("rf__node-workstation:beta-station")
+          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+        expect(
+          await browserPage.page
+            .getByTestId("rf__node-workstation:draft")
+            .count(),
+        ).toBe(0);
+
+        await rootTab.click();
+        await expect
+          .poll(async () => rootTab.getAttribute("aria-selected"), {
+            timeout: uiInteractionTimeoutMs,
+          })
+          .toBe("true");
+
+        await expectEditorModeOff(browserPage.page);
+        await browserPage.page
+          .getByTestId("rf__node-workstation:draft")
+          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+        expect(
+          await browserPage.page
+            .getByTestId("rf__node-work-type:essay")
+            .count(),
+        ).toBe(0);
+
+        expectNoBrowserErrors(
+          browserPage.pageErrors,
+          browserPage.consoleErrors,
+          expect,
+        );
+      } finally {
+        await server.stop();
+        await browserPage.close();
+      }
+    },
+    browserScenarioTimeoutMs,
+  );
+
+  it(
+    "prompts before leaving graph editor with unsaved edits within one session",
+    async () => {
+      const server = await startFactoryApiServer({
+        apiPort: preview.apiPort,
+        currentFactory: alphaGraphFactoryDefinition,
+        eventLines: alphaGraphReplayLines,
+      });
+      const browserPage = await openBrowserPage();
+
+      try {
+        await browserPage.page.goto(preview.previewURL, {
+          waitUntil: "domcontentloaded",
+        });
+        await server.replayCompleted;
+
+        await enterGraphEditor(browserPage.page);
+        await addUnsavedWorkType(browserPage.page, "memo");
+
+        const graphCard = factoryGraphCardScope(browserPage.page);
+        await graphCard
+          .getByRole("button", { name: "Leave factory graph editor" })
+          .click();
+
+        const leaveDialog = browserPage.page.getByRole("dialog", {
+          name: "Leave graph editor with unsaved changes?",
+        });
+        await leaveDialog.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
+        await leaveDialog.getByRole("button", { name: "Keep editing" }).click();
+        await leaveDialog.waitFor({
+          state: "hidden",
+          timeout: uiInteractionTimeoutMs,
+        });
+        await graphCard
+          .getByRole("region", { name: "Factory graph editor tools" })
+          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+
+        await graphCard
+          .getByRole("button", { name: "Leave factory graph editor" })
+          .click();
+        await leaveDialog.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
+        await leaveDialog.getByRole("button", { name: "Discard changes" }).click();
+        await leaveDialog.waitFor({
+          state: "hidden",
+          timeout: uiInteractionTimeoutMs,
+        });
+        await expectEditorModeOff(browserPage.page);
+
+        expectNoBrowserErrors(
+          browserPage.pageErrors,
+          browserPage.consoleErrors,
+          expect,
+        );
+      } finally {
+        await server.stop();
+        await browserPage.close();
+      }
+    },
+    browserScenarioTimeoutMs,
+  );
+});

--- a/ui/integration/factory-graph-editor-session-switch.integration.test.mjs
+++ b/ui/integration/factory-graph-editor-session-switch.integration.test.mjs
@@ -266,6 +266,151 @@ async function expectEditorModeOff(page) {
   expect(await graphCard.getByText("Unsaved changes").count()).toBe(0);
 }
 
+async function runSessionSwitchClearsDirtyEditorScenario(preview) {
+  const server = await startFactoryApiServer({
+    apiPort: preview.apiPort,
+    currentFactory: alphaGraphFactoryDefinition,
+    currentFactoryBySessionID: {
+      [betaSessionID]: betaGraphFactoryDefinition,
+    },
+    eventLines: alphaGraphReplayLines,
+    eventLinesBySessionID: {
+      [betaSessionID]: betaGraphReplayLines,
+    },
+    sessions: [defaultSession, betaSession],
+  });
+  const browserPage = await openBrowserPage();
+
+  try {
+    await browserPage.page.goto(preview.previewURL, {
+      waitUntil: "domcontentloaded",
+    });
+    await server.replayCompleted;
+
+    const rootTab = browserPage.page.getByRole("tab", { name: "root" });
+    const betaTab = browserPage.page.getByRole("tab", { name: "beta" });
+    await rootTab.waitFor({
+      state: "visible",
+      timeout: uiInteractionTimeoutMs,
+    });
+    await betaTab.waitFor({
+      state: "visible",
+      timeout: uiInteractionTimeoutMs,
+    });
+
+    await enterGraphEditor(browserPage.page);
+    await addUnsavedWorkType(browserPage.page, "essay");
+    expect(
+      await browserPage.page.getByTestId("rf__node-work-type:essay").count(),
+    ).toBe(1);
+
+    await betaTab.click();
+    await expect
+      .poll(async () => betaTab.getAttribute("aria-selected"), {
+        timeout: uiInteractionTimeoutMs,
+      })
+      .toBe("true");
+
+    await expectEditorModeOff(browserPage.page);
+    expect(
+      await browserPage.page.getByTestId("rf__node-work-type:essay").count(),
+    ).toBe(0);
+    await browserPage.page
+      .getByTestId("rf__node-workstation:beta-station")
+      .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+    expect(
+      await browserPage.page.getByTestId("rf__node-workstation:draft").count(),
+    ).toBe(0);
+
+    await rootTab.click();
+    await expect
+      .poll(async () => rootTab.getAttribute("aria-selected"), {
+        timeout: uiInteractionTimeoutMs,
+      })
+      .toBe("true");
+
+    await expectEditorModeOff(browserPage.page);
+    await browserPage.page
+      .getByTestId("rf__node-workstation:draft")
+      .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+    expect(
+      await browserPage.page.getByTestId("rf__node-work-type:essay").count(),
+    ).toBe(0);
+
+    expectNoBrowserErrors(
+      browserPage.pageErrors,
+      browserPage.consoleErrors,
+      expect,
+    );
+  } finally {
+    await server.stop();
+    await browserPage.close();
+  }
+}
+
+async function runLeaveEditorUnsavedPromptScenario(preview) {
+  const server = await startFactoryApiServer({
+    apiPort: preview.apiPort,
+    currentFactory: alphaGraphFactoryDefinition,
+    eventLines: alphaGraphReplayLines,
+  });
+  const browserPage = await openBrowserPage();
+
+  try {
+    await browserPage.page.goto(preview.previewURL, {
+      waitUntil: "domcontentloaded",
+    });
+    await server.replayCompleted;
+
+    await enterGraphEditor(browserPage.page);
+    await addUnsavedWorkType(browserPage.page, "memo");
+
+    const graphCard = factoryGraphCardScope(browserPage.page);
+    await graphCard
+      .getByRole("button", { name: "Leave factory graph editor" })
+      .click();
+
+    const leaveDialog = browserPage.page.getByRole("dialog", {
+      name: "Leave graph editor with unsaved changes?",
+    });
+    await leaveDialog.waitFor({
+      state: "visible",
+      timeout: uiInteractionTimeoutMs,
+    });
+    await leaveDialog.getByRole("button", { name: "Keep editing" }).click();
+    await leaveDialog.waitFor({
+      state: "hidden",
+      timeout: uiInteractionTimeoutMs,
+    });
+    await graphCard
+      .getByRole("region", { name: "Factory graph editor tools" })
+      .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+
+    await graphCard
+      .getByRole("button", { name: "Leave factory graph editor" })
+      .click();
+    await leaveDialog.waitFor({
+      state: "visible",
+      timeout: uiInteractionTimeoutMs,
+    });
+    await leaveDialog.getByRole("button", { name: "Discard changes" }).click();
+    await leaveDialog.waitFor({
+      state: "hidden",
+      timeout: uiInteractionTimeoutMs,
+    });
+    await expectEditorModeOff(browserPage.page);
+
+    expectNoBrowserErrors(
+      browserPage.pageErrors,
+      browserPage.consoleErrors,
+      expect,
+    );
+  } finally {
+    await server.stop();
+    await browserPage.close();
+  }
+}
+
 describe.sequential("factory graph editor session switch browser integration", () => {
   let preview = null;
 
@@ -280,162 +425,13 @@ describe.sequential("factory graph editor session switch browser integration", (
 
   it(
     "clears unsaved graph editor chrome and session A topology when switching to session B",
-    async () => {
-      const server = await startFactoryApiServer({
-        apiPort: preview.apiPort,
-        currentFactory: alphaGraphFactoryDefinition,
-        currentFactoryBySessionID: {
-          [betaSessionID]: betaGraphFactoryDefinition,
-        },
-        eventLines: alphaGraphReplayLines,
-        eventLinesBySessionID: {
-          [betaSessionID]: betaGraphReplayLines,
-        },
-        sessions: [defaultSession, betaSession],
-      });
-      const browserPage = await openBrowserPage();
-
-      try {
-        await browserPage.page.goto(preview.previewURL, {
-          waitUntil: "domcontentloaded",
-        });
-        await server.replayCompleted;
-
-        const rootTab = browserPage.page.getByRole("tab", { name: "root" });
-        const betaTab = browserPage.page.getByRole("tab", { name: "beta" });
-        await rootTab.waitFor({
-          state: "visible",
-          timeout: uiInteractionTimeoutMs,
-        });
-        await betaTab.waitFor({
-          state: "visible",
-          timeout: uiInteractionTimeoutMs,
-        });
-
-        await enterGraphEditor(browserPage.page);
-        await addUnsavedWorkType(browserPage.page, "essay");
-        expect(
-          await browserPage.page
-            .getByTestId("rf__node-work-type:essay")
-            .count(),
-        ).toBe(1);
-
-        await betaTab.click();
-        await expect
-          .poll(async () => betaTab.getAttribute("aria-selected"), {
-            timeout: uiInteractionTimeoutMs,
-          })
-          .toBe("true");
-
-        await expectEditorModeOff(browserPage.page);
-        expect(
-          await browserPage.page
-            .getByTestId("rf__node-work-type:essay")
-            .count(),
-        ).toBe(0);
-        await browserPage.page
-          .getByTestId("rf__node-workstation:beta-station")
-          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
-        expect(
-          await browserPage.page
-            .getByTestId("rf__node-workstation:draft")
-            .count(),
-        ).toBe(0);
-
-        await rootTab.click();
-        await expect
-          .poll(async () => rootTab.getAttribute("aria-selected"), {
-            timeout: uiInteractionTimeoutMs,
-          })
-          .toBe("true");
-
-        await expectEditorModeOff(browserPage.page);
-        await browserPage.page
-          .getByTestId("rf__node-workstation:draft")
-          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
-        expect(
-          await browserPage.page
-            .getByTestId("rf__node-work-type:essay")
-            .count(),
-        ).toBe(0);
-
-        expectNoBrowserErrors(
-          browserPage.pageErrors,
-          browserPage.consoleErrors,
-          expect,
-        );
-      } finally {
-        await server.stop();
-        await browserPage.close();
-      }
-    },
+    async () => runSessionSwitchClearsDirtyEditorScenario(preview),
     browserScenarioTimeoutMs,
   );
 
   it(
     "prompts before leaving graph editor with unsaved edits within one session",
-    async () => {
-      const server = await startFactoryApiServer({
-        apiPort: preview.apiPort,
-        currentFactory: alphaGraphFactoryDefinition,
-        eventLines: alphaGraphReplayLines,
-      });
-      const browserPage = await openBrowserPage();
-
-      try {
-        await browserPage.page.goto(preview.previewURL, {
-          waitUntil: "domcontentloaded",
-        });
-        await server.replayCompleted;
-
-        await enterGraphEditor(browserPage.page);
-        await addUnsavedWorkType(browserPage.page, "memo");
-
-        const graphCard = factoryGraphCardScope(browserPage.page);
-        await graphCard
-          .getByRole("button", { name: "Leave factory graph editor" })
-          .click();
-
-        const leaveDialog = browserPage.page.getByRole("dialog", {
-          name: "Leave graph editor with unsaved changes?",
-        });
-        await leaveDialog.waitFor({
-          state: "visible",
-          timeout: uiInteractionTimeoutMs,
-        });
-        await leaveDialog.getByRole("button", { name: "Keep editing" }).click();
-        await leaveDialog.waitFor({
-          state: "hidden",
-          timeout: uiInteractionTimeoutMs,
-        });
-        await graphCard
-          .getByRole("region", { name: "Factory graph editor tools" })
-          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
-
-        await graphCard
-          .getByRole("button", { name: "Leave factory graph editor" })
-          .click();
-        await leaveDialog.waitFor({
-          state: "visible",
-          timeout: uiInteractionTimeoutMs,
-        });
-        await leaveDialog.getByRole("button", { name: "Discard changes" }).click();
-        await leaveDialog.waitFor({
-          state: "hidden",
-          timeout: uiInteractionTimeoutMs,
-        });
-        await expectEditorModeOff(browserPage.page);
-
-        expectNoBrowserErrors(
-          browserPage.pageErrors,
-          browserPage.consoleErrors,
-          expect,
-        );
-      } finally {
-        await server.stop();
-        await browserPage.close();
-      }
-    },
+    async () => runLeaveEditorUnsavedPromptScenario(preview),
     browserScenarioTimeoutMs,
   );
 });

--- a/ui/src/App.follow-up-submit.test.tsx
+++ b/ui/src/App.follow-up-submit.test.tsx
@@ -9,7 +9,9 @@ import {
 import {
   activeSnapshot,
   baselineSnapshot,
+  chainRenderAppFetchMock,
   jsonResponse,
+  lastFetchCallBody,
   MockEventSource,
   nonPromptTemplateFetchPaths,
   registerAppDashboardTestLifecycle,
@@ -18,6 +20,7 @@ import {
   terminalSnapshot,
   waitForDashboardShell,
 } from "./testing/app-shell-test-utils";
+import { isSessionFactoryRequest } from "./testing/session-factory-mocks";
 
 describe("App follow-up flows", () => {
   registerAppDashboardTestLifecycle();
@@ -48,18 +51,24 @@ describe("App follow-up flows", () => {
   });
 
   it("keeps the export toolbar action available alongside the submit-work card", async () => {
-    const { fetchMock } = renderApp({ snapshot: terminalSnapshot });
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse(
-        {
-          code: "NOT_FOUND",
-          family: "NOT_FOUND",
-          message: "Current named factory not found.",
-        },
-        404,
-        "Not Found",
-      ),
-    );
+    renderApp({
+      snapshot: terminalSnapshot,
+      fetchOverride: async (path, method) => {
+        if (method === "GET" && isSessionFactoryRequest(path, method)) {
+          return jsonResponse(
+            {
+              code: "NOT_FOUND",
+              family: "NOT_FOUND",
+              message: "Current named factory not found.",
+            },
+            404,
+            "Not Found",
+          );
+        }
+
+        return undefined;
+      },
+    });
 
     await screen.findByRole("button", { name: "Export PNG" });
     fireEvent.click(screen.getByRole("button", { name: "Export PNG" }));
@@ -81,29 +90,31 @@ describe("App follow-up flows", () => {
   describe("submit request flows", () => {
   it("submits configured and empty work requests, while preserving failed form state", async () => {
     const { fetchMock } = renderApp({ snapshot: activeSnapshot });
-    fetchMock.mockImplementation(
-      async (_input: RequestInfo | URL, init?: RequestInit) => {
-        const body = JSON.parse(String(init?.body ?? "{}"));
-        if (body.name === "Retry dashboard request") {
-          return new Response(
-            JSON.stringify({
-              code: "BAD_REQUEST",
-              message: "work_type_name is required",
-            }),
-            {
-              headers: { "Content-Type": "application/json" },
-              status: 400,
-              statusText: "Bad Request",
-            },
-          );
-        }
+    chainRenderAppFetchMock(fetchMock, async (path, method, _input, init) => {
+      if (method !== "POST" || !path.endsWith("/work")) {
+        return undefined;
+      }
 
-        return new Response(JSON.stringify({ traceId: "trace-submit-story" }), {
-          headers: { "Content-Type": "application/json" },
-          status: 201,
-        });
-      },
-    );
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      if (body.name === "Retry dashboard request") {
+        return new Response(
+          JSON.stringify({
+            code: "BAD_REQUEST",
+            message: "work_type_name is required",
+          }),
+          {
+            headers: { "Content-Type": "application/json" },
+            status: 400,
+            statusText: "Bad Request",
+          },
+        );
+      }
+
+      return new Response(JSON.stringify({ traceId: "trace-submit-story" }), {
+        headers: { "Content-Type": "application/json" },
+        status: 201,
+      });
+    });
 
     await waitForDashboardShell();
 
@@ -143,7 +154,12 @@ describe("App follow-up flows", () => {
         "Your request was submitted. Trace ID: trace-submit-story.",
       ),
     ).toBeTruthy();
-    expect(JSON.parse(String(fetchMock.mock.calls.at(-1)?.[1]?.body))).toEqual({
+    expect(
+      lastFetchCallBody(
+        fetchMock,
+        (path, method) => method === "POST" && path.endsWith("/work"),
+      ),
+    ).toEqual({
       items: [
         {
           text: "Review the failed dashboard submission smoke.",
@@ -166,7 +182,12 @@ describe("App follow-up flows", () => {
         requestsBeforeEmptyPayloadSubmit + 1,
       );
     });
-    expect(JSON.parse(String(fetchMock.mock.calls.at(-1)?.[1]?.body))).toEqual({
+    expect(
+      lastFetchCallBody(
+        fetchMock,
+        (path, method) => method === "POST" && path.endsWith("/work"),
+      ),
+    ).toEqual({
       items: [],
       name: "Dashboard empty payload request",
       workTypeName: "story",
@@ -211,23 +232,26 @@ describe("App follow-up flows", () => {
   describe("multimodal submit", () => {
   it("submits a light text-plus-image multimodal request through the dashboard shell", async () => {
     const { fetchMock } = renderApp({ snapshot: activeSnapshot });
-    fetchMock.mockImplementation(
-      async (input: RequestInfo | URL, _init?: RequestInit) => {
-        const url = String(input);
-        if (url.endsWith("/work/staged-files")) {
-          return new Response(
-            JSON.stringify({
-              fileName: "review.png",
-              mediaType: "image/png",
-              stagedFileRef: "/tmp/staged/review.png",
-            }),
-            {
-              headers: { "Content-Type": "application/json" },
-              status: 201,
-            },
-          );
-        }
+    chainRenderAppFetchMock(fetchMock, async (path, method) => {
+      if (method !== "POST") {
+        return undefined;
+      }
 
+      if (path.endsWith("/work/staged-files")) {
+        return new Response(
+          JSON.stringify({
+            fileName: "review.png",
+            mediaType: "image/png",
+            stagedFileRef: "/tmp/staged/review.png",
+          }),
+          {
+            headers: { "Content-Type": "application/json" },
+            status: 201,
+          },
+        );
+      }
+
+      if (path.endsWith("/work")) {
         return new Response(
           JSON.stringify({ traceId: "trace-submit-multimodal" }),
           {
@@ -235,8 +259,10 @@ describe("App follow-up flows", () => {
             status: 201,
           },
         );
-      },
-    );
+      }
+
+      return undefined;
+    });
 
     await waitForDashboardShell();
 
@@ -280,7 +306,12 @@ describe("App follow-up flows", () => {
         "Your request was submitted. Trace ID: trace-submit-multimodal.",
       ),
     ).toBeTruthy();
-    expect(JSON.parse(String(fetchMock.mock.calls.at(-1)?.[1]?.body))).toEqual({
+    expect(
+      lastFetchCallBody(
+        fetchMock,
+        (path, method) => method === "POST" && path.endsWith("/work"),
+      ),
+    ).toEqual({
       items: [
         {
           text: "Review the screenshot and summarize the issue.",

--- a/ui/src/App.layout-graph.test.tsx
+++ b/ui/src/App.layout-graph.test.tsx
@@ -203,6 +203,12 @@ describe("App layout and graph behavior", () => {
   it("renders distinct graph semantics for topology places, active work, and retry outcomes", async () => {
     await renderAppWithDashboardShell({ snapshot: activeSnapshot });
 
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole("button", { name: /Select .* workstation/ }).length,
+      ).toBeGreaterThan(0);
+    });
+
     fireEvent.click(screen.getByRole("button", { name: "Select work item Active Story" }));
     expect(screen.getAllByRole("button", { name: /Select .* workstation/ })).toHaveLength(5);
     expect(screen.getByLabelText("agent-slot")).toBeTruthy();

--- a/ui/src/App.replay-workstation-requests.test.tsx
+++ b/ui/src/App.replay-workstation-requests.test.tsx
@@ -31,12 +31,9 @@ function expectDefinitionValue(
 }
 
 async function selectReviewRequest(dispatchID: string): Promise<void> {
-  const reviewWorkstationButton = screen.queryByRole("button", {
-    name: "Select Review workstation",
-  });
-  if (reviewWorkstationButton) {
-    fireEvent.click(reviewWorkstationButton);
-  }
+  fireEvent.click(
+    await screen.findByRole("button", { name: "Select Review workstation" }),
+  );
 
   const workstationSelection = await screen.findByRole("article", {
     name: "Current selection",
@@ -176,7 +173,7 @@ describe("App replay workstation request flows", () => {
     ).toBeNull();
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Select Review workstation" }),
+      await screen.findByRole("button", { name: "Select Review workstation" }),
     );
     fireEvent.click(
       screen.getByRole("button", {

--- a/ui/src/features/factory-graph-editor/hooks/factory-graph-draft-hook.ts
+++ b/ui/src/features/factory-graph-editor/hooks/factory-graph-draft-hook.ts
@@ -33,9 +33,15 @@ export function useFactoryGraphDraftState(
   const currentFactoryDocument = options.currentFactoryDocument;
   const factoryDocumentScopeKey = options.factoryDocumentScopeKey ?? null;
   const lastFactoryDocumentScopeKeyRef = useRef<string | null>(null);
+  const lastSyncedFactoryDocumentRef = useRef<
+    CurrentFactoryDocument | undefined
+  >(undefined);
+  const staleDocumentBlockedForScopeChangeRef = useRef<
+    CurrentFactoryDocument | undefined
+  >(undefined);
   const emptyDraft = useMemo(() => createEmptyFactoryGraphDraft(), []);
   const emptyGraph = useMemo(
-    () => ({ edges: [], nodes: [] } as FactoryGraphDraftDerivedState["graph"]),
+    () => ({ edges: [], nodes: [] }) as FactoryGraphDraftDerivedState["graph"],
     [],
   );
   const [sessionState, setSessionState] =
@@ -113,25 +119,49 @@ export function useFactoryGraphDraftState(
   useEffect(() => {
     const previousScopeKey = lastFactoryDocumentScopeKeyRef.current;
     const scopeChanged =
-      previousScopeKey !== null &&
-      previousScopeKey !== factoryDocumentScopeKey;
+      previousScopeKey !== null && previousScopeKey !== factoryDocumentScopeKey;
     lastFactoryDocumentScopeKeyRef.current = factoryDocumentScopeKey;
 
+    if (scopeChanged) {
+      const staleDocument = lastSyncedFactoryDocumentRef.current;
+      lastSyncedFactoryDocumentRef.current = undefined;
+      setSessionState(null);
+
+      if (
+        !currentFactoryDocument ||
+        (staleDocument !== undefined &&
+          staleDocument === currentFactoryDocument)
+      ) {
+        staleDocumentBlockedForScopeChangeRef.current = staleDocument;
+        return;
+      }
+
+      staleDocumentBlockedForScopeChangeRef.current = undefined;
+      setSessionState(
+        syncFactoryGraphDraftSession(null, currentFactoryDocument),
+      );
+      lastSyncedFactoryDocumentRef.current = currentFactoryDocument;
+      return;
+    }
+
     if (!currentFactoryDocument) {
+      staleDocumentBlockedForScopeChangeRef.current = undefined;
       setSessionState(null);
       return;
     }
 
-    if (scopeChanged) {
-      setSessionState(
-        syncFactoryGraphDraftSession(null, currentFactoryDocument),
-      );
+    if (
+      staleDocumentBlockedForScopeChangeRef.current !== undefined &&
+      staleDocumentBlockedForScopeChangeRef.current === currentFactoryDocument
+    ) {
       return;
     }
+    staleDocumentBlockedForScopeChangeRef.current = undefined;
 
     setSessionState((currentState) =>
       syncFactoryGraphDraftSession(currentState, currentFactoryDocument),
     );
+    lastSyncedFactoryDocumentRef.current = currentFactoryDocument;
   }, [currentFactoryDocument, factoryDocumentScopeKey]);
 
   const currentFactoryState = useMemo<FactoryGraphDraftDerivedState | null>(

--- a/ui/src/features/factory-graph-editor/hooks/use-editable-factory-graph.document-plane.test.tsx
+++ b/ui/src/features/factory-graph-editor/hooks/use-editable-factory-graph.document-plane.test.tsx
@@ -1,12 +1,12 @@
 import { act, renderHook } from "@testing-library/react";
 
 import type { CurrentFactoryDocument } from "../../../api/current-factory-definition";
-import { mockFactoryDocumentSave } from "../../../testing/factory-document-save-mocks";
 import {
   createEditableFactoryGraphHookWrapper,
   renderEditableFactoryGraphHook,
   setupEditableFactoryGraphSaveTestEnvironment,
 } from "../../../testing/editable-factory-graph-hook-test-helpers";
+import { mockFactoryDocumentSave } from "../../../testing/factory-document-save-mocks";
 import { useEditableFactoryGraph } from "./use-editable-factory-graph";
 
 const sharedWorkType = {
@@ -75,9 +75,9 @@ describe("useEditableFactoryGraph document plane projection", () => {
     expect(result.current.projection.nodes.map((node) => node.id)).toContain(
       "workstation:document-only",
     );
-    expect(result.current.projection.nodes.map((node) => node.id)).not.toContain(
-      "workstation:snapshot-only",
-    );
+    expect(
+      result.current.projection.nodes.map((node) => node.id),
+    ).not.toContain("workstation:snapshot-only");
   });
 
   it("exposes an empty projection while the factory document is still unavailable", () => {
@@ -94,9 +94,82 @@ describe("useEditableFactoryGraph document plane projection", () => {
   });
 });
 
-describe("useEditableFactoryGraph document plane scope and persist", () => {
+describe("useEditableFactoryGraph document plane scope isolation", () => {
   beforeEach(() => {
     setupEditableFactoryGraphSaveTestEnvironment();
+  });
+
+  it("does not rehydrate from a stale document while the new scope document is pending", () => {
+    const betaFactory: CurrentFactoryDocument = {
+      ...documentFactory,
+      name: "Beta Factory Pending",
+      workstations: [
+        {
+          ...documentFactory.workstations[0],
+          name: "beta-pending-only",
+        },
+      ],
+    };
+    const { result, rerender } = renderHook(
+      ({
+        currentFactoryDocument,
+        factoryDocumentScopeKey,
+      }: {
+        currentFactoryDocument: CurrentFactoryDocument | undefined;
+        factoryDocumentScopeKey: string;
+      }) =>
+        useEditableFactoryGraph({
+          currentFactoryDocument,
+          factoryDocumentScopeKey,
+        }),
+      {
+        initialProps: {
+          currentFactoryDocument: documentFactory,
+          factoryDocumentScopeKey: "session-alpha",
+        },
+        wrapper:
+          createEditableFactoryGraphHookWrapper()
+            .EditableFactoryGraphHookWrapper,
+      },
+    );
+
+    act(() => {
+      result.current.actions.addNode({
+        kind: "worker",
+        model: "gpt-5",
+        modelProvider: "CURSOR",
+        name: "extra",
+      });
+    });
+
+    rerender({
+      currentFactoryDocument: documentFactory,
+      factoryDocumentScopeKey: "session-beta",
+    });
+
+    expect(result.current.pendingState.hasChanges).toBe(false);
+    expect(result.current.draftState.source).toBe("projection");
+    expect(result.current.draftState.latestDocument).toBeNull();
+    expect(result.current.projection).toEqual({
+      edges: [],
+      nodes: [],
+    });
+
+    rerender({
+      currentFactoryDocument: betaFactory,
+      factoryDocumentScopeKey: "session-beta",
+    });
+
+    expect(result.current.pendingState.hasChanges).toBe(false);
+    expect(result.current.draftState.latestDocument?.name).toBe(
+      "Beta Factory Pending",
+    );
+    expect(result.current.projection.nodes.map((node) => node.id)).toContain(
+      "workstation:beta-pending-only",
+    );
+    expect(
+      result.current.projection.nodes.map((node) => node.id),
+    ).not.toContain("workstation:document-only");
   });
 
   it("drops a dirty draft when the factory document scope key changes", () => {
@@ -117,8 +190,9 @@ describe("useEditableFactoryGraph document plane scope and persist", () => {
           currentFactoryDocument: documentFactory,
           factoryDocumentScopeKey: "session-alpha",
         },
-        wrapper: createEditableFactoryGraphHookWrapper()
-          .EditableFactoryGraphHookWrapper,
+        wrapper:
+          createEditableFactoryGraphHookWrapper()
+            .EditableFactoryGraphHookWrapper,
       },
     );
 
@@ -152,9 +226,15 @@ describe("useEditableFactoryGraph document plane scope and persist", () => {
     expect(result.current.projection.nodes.map((node) => node.id)).toContain(
       "workstation:beta-only",
     );
-    expect(result.current.projection.nodes.map((node) => node.id)).not.toContain(
-      "workstation:document-only",
-    );
+    expect(
+      result.current.projection.nodes.map((node) => node.id),
+    ).not.toContain("workstation:document-only");
+  });
+});
+
+describe("useEditableFactoryGraph document plane persist", () => {
+  beforeEach(() => {
+    setupEditableFactoryGraphSaveTestEnvironment();
   });
 
   it("clears pending edits after save and resyncs latestDocument when the document cache updates", async () => {
@@ -163,7 +243,11 @@ describe("useEditableFactoryGraph document plane scope and persist", () => {
     );
 
     const { result, rerender } = renderHook(
-      ({ currentFactoryDocument }: { currentFactoryDocument: CurrentFactoryDocument }) =>
+      ({
+        currentFactoryDocument,
+      }: {
+        currentFactoryDocument: CurrentFactoryDocument;
+      }) =>
         useEditableFactoryGraph({
           currentFactoryDocument,
           factoryDocumentScopeKey: "session-alpha",
@@ -172,8 +256,9 @@ describe("useEditableFactoryGraph document plane scope and persist", () => {
         initialProps: {
           currentFactoryDocument: documentFactory,
         },
-        wrapper: createEditableFactoryGraphHookWrapper()
-          .EditableFactoryGraphHookWrapper,
+        wrapper:
+          createEditableFactoryGraphHookWrapper()
+            .EditableFactoryGraphHookWrapper,
       },
     );
 

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-draft.state.test.tsx
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-draft.state.test.tsx
@@ -1,8 +1,4 @@
 import { act, renderHook } from "@testing-library/react";
-
-import { buildPendingFactoryDefinition } from "./factory-graph-draft-apply";
-import { createEmptyFactoryGraphDraft } from "./factory-graph-draft-types";
-import { validateFactoryGraphDraft } from "./factory-graph-draft-validation";
 import {
   syncFactoryGraphDraftSession,
   useFactoryGraphDraftState,
@@ -11,6 +7,9 @@ import {
   baseFactoryDefinition,
   currentFactoryDocument,
 } from "./factory-graph-draft.test-helpers";
+import { buildPendingFactoryDefinition } from "./factory-graph-draft-apply";
+import { createEmptyFactoryGraphDraft } from "./factory-graph-draft-types";
+import { validateFactoryGraphDraft } from "./factory-graph-draft-validation";
 
 it("replaces workstation worker assignments in the pending definition without introducing validation errors", () => {
   const draft = createEmptyFactoryGraphDraft();
@@ -196,14 +195,27 @@ it("keeps a dirty draft while newer editable-definition versions arrive", () => 
 });
 
 it("clears draft state when the factory document scope key changes", () => {
+  const betaFactoryDocument = {
+    ...currentFactoryDocument,
+    name: "Beta Session Factory",
+  };
   const { result, rerender } = renderHook(
-    ({ factoryDocumentScopeKey }: { factoryDocumentScopeKey: string }) =>
+    ({
+      currentFactoryDocument: scopedDocument,
+      factoryDocumentScopeKey,
+    }: {
+      currentFactoryDocument: typeof currentFactoryDocument;
+      factoryDocumentScopeKey: string;
+    }) =>
       useFactoryGraphDraftState({
-        currentFactoryDocument,
+        currentFactoryDocument: scopedDocument,
         factoryDocumentScopeKey,
       }),
     {
-      initialProps: { factoryDocumentScopeKey: "session-alpha" },
+      initialProps: {
+        currentFactoryDocument,
+        factoryDocumentScopeKey: "session-alpha",
+      },
     },
   );
 
@@ -228,12 +240,88 @@ it("clears draft state when the factory document scope key changes", () => {
 
   expect(result.current.hasChanges).toBe(true);
 
-  rerender({ factoryDocumentScopeKey: "session-beta" });
+  rerender({
+    currentFactoryDocument,
+    factoryDocumentScopeKey: "session-beta",
+  });
+
+  expect(result.current.hasChanges).toBe(false);
+  expect(result.current.source).toBe("projection");
+  expect(result.current.latestDocument).toBeNull();
+
+  rerender({
+    currentFactoryDocument: betaFactoryDocument,
+    factoryDocumentScopeKey: "session-beta",
+  });
 
   expect(result.current.hasChanges).toBe(false);
   expect(result.current.source).toBe("current-factory");
-  expect(result.current.latestDocument).toEqual(currentFactoryDocument);
-  expect(result.current.baseDocument).toEqual(currentFactoryDocument);
+  expect(result.current.latestDocument).toEqual(betaFactoryDocument);
+  expect(result.current.baseDocument).toEqual(betaFactoryDocument);
+});
+
+it("does not rehydrate from a stale document while the new scope document is pending", () => {
+  const betaFactoryDocument = {
+    ...currentFactoryDocument,
+    name: "Beta Session Factory",
+  };
+  const { result, rerender } = renderHook(
+    ({
+      currentFactoryDocument: scopedDocument,
+      factoryDocumentScopeKey,
+    }: {
+      currentFactoryDocument: typeof currentFactoryDocument | undefined;
+      factoryDocumentScopeKey: string;
+    }) =>
+      useFactoryGraphDraftState({
+        currentFactoryDocument: scopedDocument,
+        factoryDocumentScopeKey,
+      }),
+    {
+      initialProps: {
+        currentFactoryDocument,
+        factoryDocumentScopeKey: "session-alpha",
+      },
+    },
+  );
+
+  act(() => {
+    result.current.replaceDraft({
+      ...createEmptyFactoryGraphDraft(),
+      additions: {
+        resources: [],
+        workers: [
+          {
+            model: "gpt-5-mini",
+            name: "reviewer",
+            type: "MODEL_WORKER",
+          },
+        ],
+        workStates: [],
+        workTypes: [],
+        workstations: [],
+      },
+    });
+  });
+
+  rerender({
+    currentFactoryDocument,
+    factoryDocumentScopeKey: "session-beta",
+  });
+
+  expect(result.current.hasChanges).toBe(false);
+  expect(result.current.source).toBe("projection");
+  expect(result.current.latestDocument).toBeNull();
+  expect(result.current.graph.nodes.map((node) => node.id)).toEqual([]);
+
+  rerender({
+    currentFactoryDocument: betaFactoryDocument,
+    factoryDocumentScopeKey: "session-beta",
+  });
+
+  expect(result.current.source).toBe("current-factory");
+  expect(result.current.latestDocument?.name).toBe("Beta Session Factory");
+  expect(result.current.hasChanges).toBe(false);
 });
 
 it("resets draft state when the loaded factory document identity changes", () => {

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card.test.tsx
@@ -871,9 +871,9 @@ function registerCurrentActivityCardTestLifecycle(): void {
     useCurrentActivityGraphStore.setState({ positionsByGraphKey: {} });
     restoreBrowserTestShims = installDashboardBrowserTestShims();
     vi.mocked(useCurrentFactoryDocument).mockReturnValue({
-      data: undefined,
+      data: baseFactoryDefinitionDocument,
       error: null,
-      status: "pending",
+      status: "success",
     } as never);
     vi.mocked(useFactoryDocumentSave).mockReturnValue({
       error: null,
@@ -945,6 +945,11 @@ function registerCurrentActivityCardEditorChromeTests(): void {
   });
 
   it("keeps classifier workstations out of the editable graph flow", async () => {
+    vi.mocked(useCurrentFactoryDocument).mockReturnValue({
+      data: undefined,
+      error: null,
+      status: "pending",
+    } as never);
     const snapshot = dashboardSnapshotWithActiveWorkItemCount(0);
     snapshot.topology.workstation_nodes_by_id.review.workstation_kind =
       "CLASSIFIER_WORKSTATION";
@@ -1270,6 +1275,42 @@ function registerCurrentActivityCardEditorChromeTests(): void {
       expect(document.querySelector('[data-id="worker:stalled"]')).toBeTruthy();
       expect(document.querySelector('[data-id="resource:gpu"]')).toBeTruthy();
     });
+  });
+
+  it("does not render prior-session snapshot workstations in observe mode while the factory document is pending", async () => {
+    const snapshot = buildDivergentPlaneDashboardSnapshot();
+    vi.mocked(useCurrentFactoryDocument).mockReturnValue({
+      data: undefined,
+      error: null,
+      status: "pending",
+    } as never);
+    wireMockEditableFactoryGraph(
+      {
+        useEditableFactoryGraph: vi.mocked(useEditableFactoryGraph),
+        useFactoryGraphDraftState: vi.mocked(useFactoryGraphDraftState),
+      },
+      createMockGraphEditorDraftState({
+        baseDocument: null,
+        latestDocument: null,
+        pendingFactoryDefinition: null,
+      }),
+    );
+
+    renderCurrentActivity({ snapshot });
+
+    expect(
+      await screen.findByRole("region", { name: "Work graph viewport" }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", {
+        name: "Select Snapshot Only workstation",
+      }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", {
+        name: "Select Document Only workstation",
+      }),
+    ).toBeNull();
   });
 
   it("renders snapshot-only workstations in observe mode when the document plane diverges", async () => {
@@ -2477,7 +2518,14 @@ describe("ReactFlowCurrentActivityCard graph semantics", () => {
   registerCurrentActivityCardTestLifecycle();
 
   it("renders active observer graph state from the canonical snapshot factory without topology fallback", async () => {
-    renderCurrentActivity({ snapshot: canonicalObserverSnapshot() });
+    const snapshot = canonicalObserverSnapshot();
+    vi.mocked(useCurrentFactoryDocument).mockReturnValue({
+      data: currentFactoryDocumentFromSnapshot(snapshot),
+      error: null,
+      status: "success",
+    } as never);
+
+    renderCurrentActivity({ snapshot });
 
     expect(
       await screen.findByRole("region", { name: "Work graph viewport" }),

--- a/ui/src/features/workflow-activity/components/workflow-activity-bento-card.test.tsx
+++ b/ui/src/features/workflow-activity/components/workflow-activity-bento-card.test.tsx
@@ -198,9 +198,9 @@ function registerWorkflowActivityBentoCardTestSetup() {
   beforeEach(() => {
     restoreBrowserTestShims = installDashboardBrowserTestShims();
     vi.mocked(useCurrentFactoryDocument).mockReturnValue({
-      data: undefined,
+      data: baseFactoryDefinitionDocument,
       error: null,
-      status: "pending",
+      status: "success",
     } as never);
     vi.mocked(useFactoryDocumentSave).mockReturnValue({
       error: null,
@@ -302,6 +302,12 @@ describe("WorkflowActivityBentoCard", () => {
     expect(
       within(graphCard).queryByRole("heading", { name: shellMessages.title }),
     ).toBeNull();
+
+    vi.mocked(useCurrentFactoryDocument).mockReturnValue({
+      data: undefined,
+      error: null,
+      status: "pending",
+    } as never);
 
     await user.click(
       headerScope.getByRole("button", { name: editorMessages.modeEnterEditor }),

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor-editable-graph.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor-editable-graph.ts
@@ -13,7 +13,7 @@ export function useCurrentActivityEditableGraph({
   locale?: string | null;
   snapshot: DashboardSnapshot;
 }) {
-  const currentFactoryQuery = useCurrentFactoryDocument(editorMode);
+  const currentFactoryQuery = useCurrentFactoryDocument(true);
   const editableGraph = useEditableFactoryGraph({
     activeWorkCount: snapshot.runtime.in_flight_dispatch_count,
     currentFactoryDocument: currentFactoryQuery.data,

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor.test.tsx
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor.test.tsx
@@ -159,6 +159,7 @@ vi.mock("../../factory-graph-editor/hooks/use-editable-factory-graph", () => ({
         hookState.draftState.hasChanges &&
         hookState.draftState.pendingFactoryDefinition !== null &&
         hookState.draftState.latestDocument !== null &&
+        hookState.draftState.validationErrors.length === 0 &&
         !hookState.saveStateIsStale,
       documentSave: hookState.saveStateIsStale
         ? {
@@ -475,5 +476,135 @@ describe("useCurrentActivityGraphEditor", () => {
     );
     expect(result.current.editorMode).toBe(false);
     expect(result.current.activeTool).toBeNull();
+  });
+});
+
+const inSessionScopeKey = "session-in-session";
+
+function renderEditorWithConstantScope(
+  snapshot = semanticWorkflowDashboardSnapshot,
+) {
+  return renderHook(() =>
+    useCurrentActivityGraphEditor(snapshot, "en", inSessionScopeKey),
+  );
+}
+
+describe("useCurrentActivityGraphEditor in-session save and discard", () => {
+  beforeEach(() => {
+    useFactoryGraphTopologyEditorBridge.setState({ handlers: null });
+    hookState.addEntityController.reset.mockReset();
+    hookState.connectionController.setConnectionNotice.mockReset();
+    hookState.currentFactoryQuery = {
+      data: fixtureState.editableDocument,
+      status: "success",
+    };
+    hookState.draftState = {
+      baseDocument: fixtureState.editableDocument,
+      draft: fixtureState.emptyDraft(),
+      hasChanges: false,
+      latestDocument: fixtureState.editableDocument,
+      pendingFactoryDefinition: fixtureState.baseFactoryDefinition,
+      replaceDraft: vi.fn(),
+      resetDraft: vi.fn(),
+      validationErrors: [],
+    };
+    hookState.saveEditableDefinition = {
+      error: null,
+      isPending: false,
+      reset: vi.fn(),
+      saveAsync: vi.fn(async () => undefined),
+    };
+    hookState.documentSave = { status: "idle" };
+    hookState.saveStateIsStale = false;
+  });
+
+  it("keeps leave confirmation and editor mode when the draft is dirty within a constant scope", () => {
+    const { result } = renderEditorWithConstantScope();
+
+    act(() => {
+      result.current.handleEditorModeToggle();
+    });
+    hookState.draftState.hasChanges = true;
+
+    act(() => {
+      result.current.handleEditorModeToggle();
+    });
+
+    expect(result.current.editorMode).toBe(true);
+    expect(result.current.isConfirmingLeaveEditor).toBe(true);
+    expect(hookState.addEntityController.reset).not.toHaveBeenCalled();
+    expect(useFactoryGraphTopologyEditorBridge.getState().handlers).toBeNull();
+  });
+
+  it("discards pending changes without leaving editor mode within a constant scope", () => {
+    hookState.draftState.hasChanges = true;
+    const { result } = renderEditorWithConstantScope();
+
+    act(() => {
+      result.current.handleEditorModeToggle();
+      result.current.setActiveTool("connect");
+      result.current.handleDiscardPendingChanges();
+    });
+
+    expect(hookState.draftState.resetDraft).toHaveBeenCalledTimes(1);
+    expect(hookState.addEntityController.reset).toHaveBeenCalledTimes(1);
+    expect(result.current.editorMode).toBe(true);
+    expect(result.current.activeTool).toBe("connect");
+    expect(result.current.isConfirmingLeaveEditor).toBe(false);
+  });
+
+  it("saves pending edits and clears the draft within a constant scope", async () => {
+    hookState.draftState.hasChanges = true;
+    const snapshot = structuredClone(semanticWorkflowDashboardSnapshot);
+    snapshot.runtime.in_flight_dispatch_count = 0;
+
+    const { result } = renderEditorWithConstantScope(snapshot);
+
+    act(() => {
+      result.current.handleEditorModeToggle();
+    });
+
+    let didSave = false;
+    await act(async () => {
+      didSave = await result.current.handleSaveDraft();
+    });
+
+    expect(didSave).toBe(true);
+    expect(hookState.saveEditableDefinition.saveAsync).toHaveBeenCalledWith({
+      baseVersion: fixtureState.editableDocument.version,
+      factory: fixtureState.baseFactoryDefinition,
+    });
+    expect(hookState.draftState.replaceDraft).toHaveBeenCalledWith(
+      createEmptyFactoryGraphDraft(),
+    );
+    expect(result.current.editorMode).toBe(true);
+  });
+
+  it("blocks save when draft validation errors are present within a constant scope", async () => {
+    hookState.draftState.hasChanges = true;
+    hookState.draftState.validationErrors = [
+      {
+        code: "MISSING_REQUIRED_FIELD",
+        field: "worker",
+        message: "Workstation draft requires a worker assignment.",
+        target: {
+          id: "workstation:review",
+          kind: "node",
+        },
+      },
+    ];
+    const snapshot = structuredClone(semanticWorkflowDashboardSnapshot);
+    snapshot.runtime.in_flight_dispatch_count = 0;
+
+    const { result } = renderEditorWithConstantScope(snapshot);
+
+    let didSave = true;
+    await act(async () => {
+      didSave = await result.current.handleSaveDraft();
+    });
+
+    expect(didSave).toBe(false);
+    expect(result.current.canSaveDraft).toBe(false);
+    expect(hookState.saveEditableDefinition.saveAsync).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor.test.tsx
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor.test.tsx
@@ -4,6 +4,7 @@ import { act, renderHook } from "@testing-library/react";
 import { semanticWorkflowDashboardSnapshot } from "../../../components/dashboard/test-fixtures";
 import type { CanonicalFactoryDefinition } from "../../api/current-factory-definition";
 import { createEmptyFactoryGraphDraft } from "../../factory-graph-editor/lib/factory-graph-draft-types";
+import { useFactoryGraphTopologyEditorBridge } from "../state/factory-graph-topology-editor-bridge";
 import { useCurrentActivityGraphEditor } from "./react-flow-current-activity-card-editor";
 
 const fixtureState = vi.hoisted(() => {
@@ -226,6 +227,7 @@ vi.mock("./react-flow-current-activity-card-editor-value", () => ({
 
 describe("useCurrentActivityGraphEditor", () => {
   beforeEach(() => {
+    useFactoryGraphTopologyEditorBridge.setState({ handlers: null });
     hookState.addEntityController.reset.mockReset();
     hookState.connectionController.handleConnectionAnchorClick.mockReset();
     hookState.connectionController.handleEditorConnect.mockReset();
@@ -392,6 +394,55 @@ describe("useCurrentActivityGraphEditor", () => {
     expect(didSave).toBe(false);
     rerender();
     expect(result.current.isConfirmingSave).toBe(false);
+  });
+
+  it("resets editor chrome and topology bridge when factory document scope changes", () => {
+    const { result, rerender } = renderHook(
+      ({ factoryDocumentScopeKey }: { factoryDocumentScopeKey: string }) =>
+        useCurrentActivityGraphEditor(
+          semanticWorkflowDashboardSnapshot,
+          "en",
+          factoryDocumentScopeKey,
+        ),
+      {
+        initialProps: { factoryDocumentScopeKey: "session-alpha" },
+      },
+    );
+
+    act(() => {
+      result.current.handleEditorModeToggle();
+      result.current.setActiveTool("connect");
+      result.current.setIsConfirmingLeaveEditor(true);
+      result.current.setIsConfirmingSave(true);
+    });
+    hookState.draftState.hasChanges = true;
+    useFactoryGraphTopologyEditorBridge.setState({
+      handlers: {
+        blockedRemovalReason: null,
+        canInteractWithEditor: true,
+        editorMode: true,
+        requestNodeRemoval: vi.fn(),
+      },
+    });
+
+    rerender({ factoryDocumentScopeKey: "session-beta" });
+
+    expect(result.current.editorMode).toBe(false);
+    expect(result.current.activeTool).toBeNull();
+    expect(result.current.isConfirmingLeaveEditor).toBe(false);
+    expect(result.current.isConfirmingSave).toBe(false);
+    expect(hookState.addEntityController.reset).toHaveBeenCalled();
+    expect(hookState.saveEditableDefinition.reset).toHaveBeenCalled();
+    expect(
+      hookState.connectionController.setConnectionNotice,
+    ).toHaveBeenCalledWith(null);
+    expect(
+      hookState.removalController.setPendingRemovalEdgeId,
+    ).toHaveBeenCalledWith(null);
+    expect(
+      hookState.removalController.setPendingRemovalNodeId,
+    ).toHaveBeenCalledWith(null);
+    expect(useFactoryGraphTopologyEditorBridge.getState().handlers).toBeNull();
   });
 
   it("saves the draft and leaves editor mode when asked to save before leaving", async () => {

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor.test.tsx
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor.test.tsx
@@ -1,4 +1,4 @@
-// biome-ignore-all lint/complexity/noExcessiveLinesPerFunction: focused hook coverage keeps the mergeability-only save/leave branches in one seam.
+// biome-ignore-all lint/complexity/noExcessiveLinesPerFunction lint/nursery/noExcessiveLinesPerFile: focused hook coverage keeps session-reset and in-session save/leave branches on one harness seam.
 import { act, renderHook } from "@testing-library/react";
 
 import { semanticWorkflowDashboardSnapshot } from "../../../components/dashboard/test-fixtures";

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor.tsx
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import type { DashboardSnapshot } from "../../../api/dashboard/types";
 import type { FactoryGraphEditorTool } from "../../factory-graph-editor/components/factory-graph-editor-controls";
+import { useFactoryGraphTopologyEditorBridge } from "../state/factory-graph-topology-editor-bridge";
 import { useDraftAppliedFactoryValidation } from "./react-flow-current-activity-card-editor-draft-validation";
 import { useCurrentActivityEditableGraph } from "./react-flow-current-activity-card-editor-editable-graph";
 import { useGraphEditorLeaveEditorBridge } from "./react-flow-current-activity-card-editor-save-flow";
@@ -76,6 +77,23 @@ export function useCurrentActivityGraphEditor(
     },
   });
   leaveEditorBridge.bindSaveFlow(saveFlow);
+
+  const { resetEditorChromeForScopeChange } = saveFlow;
+  const lastFactoryDocumentScopeKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    const normalizedScopeKey = factoryDocumentScopeKey ?? null;
+    const previousScopeKey = lastFactoryDocumentScopeKeyRef.current;
+    const scopeChanged =
+      previousScopeKey !== null && previousScopeKey !== normalizedScopeKey;
+    lastFactoryDocumentScopeKeyRef.current = normalizedScopeKey;
+
+    if (!scopeChanged) {
+      return;
+    }
+
+    resetEditorChromeForScopeChange();
+    useFactoryGraphTopologyEditorBridge.getState().setHandlers(null);
+  }, [factoryDocumentScopeKey, resetEditorChromeForScopeChange]);
 
   return buildCurrentActivityGraphEditorValue({
     activeTool,

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.test.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import { singleNodeDashboardSnapshot } from "../../../components/dashboard/test-fixtures";
+import {
+  baseFactoryDefinitionDocument,
+  createMockGraphEditorDraftState,
+} from "../../../testing/graph-editor-harness";
+import { currentActivityCardFactoryDefinition } from "./react-flow-current-activity-card-graph-view-model";
+
+function createEditorStub(
+  overrides: {
+    draftState?: ReturnType<typeof createMockGraphEditorDraftState>;
+    editableDefinitionQuery?: {
+      status: "error" | "pending" | "success";
+    };
+    editorMode?: boolean;
+  } = {},
+) {
+  return {
+    draftState: overrides.draftState ?? createMockGraphEditorDraftState(),
+    editableDefinitionQuery: {
+      status: overrides.editableDefinitionQuery?.status ?? "success",
+    },
+    editorMode: overrides.editorMode ?? false,
+  } as Parameters<typeof currentActivityCardFactoryDefinition>[0];
+}
+
+describe("currentActivityCardFactoryDefinition", () => {
+  it("returns null in observe mode while the scoped factory document is pending", () => {
+    const snapshot = structuredClone(singleNodeDashboardSnapshot);
+
+    expect(
+      currentActivityCardFactoryDefinition(
+        createEditorStub({
+          editableDefinitionQuery: { status: "pending" },
+          editorMode: false,
+        }),
+        snapshot,
+      ),
+    ).toBeNull();
+  });
+
+  it("returns undefined in observe mode once the scoped factory document succeeds", () => {
+    const snapshot = structuredClone(singleNodeDashboardSnapshot);
+
+    expect(
+      currentActivityCardFactoryDefinition(
+        createEditorStub({
+          editableDefinitionQuery: { status: "success" },
+          editorMode: false,
+        }),
+        snapshot,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("returns null in editor mode while the scoped factory document is pending", () => {
+    const snapshot = structuredClone(singleNodeDashboardSnapshot);
+
+    expect(
+      currentActivityCardFactoryDefinition(
+        createEditorStub({
+          editableDefinitionQuery: { status: "pending" },
+          editorMode: true,
+        }),
+        snapshot,
+      ),
+    ).toBeNull();
+  });
+
+  it("returns the pending document definition in editor mode after the document succeeds", () => {
+    const snapshot = structuredClone(singleNodeDashboardSnapshot);
+    const draftState = createMockGraphEditorDraftState({
+      latestDocument: baseFactoryDefinitionDocument,
+      pendingFactoryDefinition: baseFactoryDefinitionDocument,
+    });
+
+    expect(
+      currentActivityCardFactoryDefinition(
+        createEditorStub({
+          draftState,
+          editableDefinitionQuery: { status: "success" },
+          editorMode: true,
+        }),
+        snapshot,
+      ),
+    ).toEqual(baseFactoryDefinitionDocument);
+  });
+});

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
@@ -159,7 +159,7 @@ function useActiveGraphHighlights({
 
 export function currentActivityCardFactoryDefinition(
   editor: ReturnType<typeof useCurrentActivityGraphEditor>,
-  snapshot: DashboardSnapshot,
+  _snapshot: DashboardSnapshot,
 ): DashboardSnapshot["factory"] | null | undefined {
   if (editor.editableDefinitionQuery.status !== "success") {
     return null;
@@ -193,7 +193,6 @@ function useEditorCurrentActivityGraphLayout(
   );
 }
 
-// biome-ignore lint/complexity/noExcessiveLinesPerFunction: coordinates graph layout, editor draft, and selection handler wiring in one hook.
 export function useCurrentActivityGraphViewModel({
   editor,
   locale,

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
@@ -161,12 +161,12 @@ export function currentActivityCardFactoryDefinition(
   editor: ReturnType<typeof useCurrentActivityGraphEditor>,
   snapshot: DashboardSnapshot,
 ): DashboardSnapshot["factory"] | null | undefined {
-  if (!editor.editorMode) {
-    return undefined;
-  }
-
   if (editor.editableDefinitionQuery.status !== "success") {
     return null;
+  }
+
+  if (!editor.editorMode) {
+    return undefined;
   }
 
   return editorModeFactoryDefinition(editor) ?? null;

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
@@ -161,7 +161,7 @@ export function currentActivityCardFactoryDefinition(
   editor: ReturnType<typeof useCurrentActivityGraphEditor>,
   _snapshot: DashboardSnapshot,
 ): DashboardSnapshot["factory"] | null | undefined {
-  if (editor.editableDefinitionQuery.status !== "success") {
+  if (editor.editableDefinitionQuery?.status !== "success") {
     return null;
   }
 

--- a/ui/src/features/workflow-activity/hooks/use-graph-editor-save-flow.ts
+++ b/ui/src/features/workflow-activity/hooks/use-graph-editor-save-flow.ts
@@ -1,13 +1,14 @@
 import { useCallback, useEffect, useState } from "react";
-
-import type { FactoryDocumentSaveState } from "../../current-selection/base/public";
 import { isFactoryDocumentSaveConfirming } from "../../current-selection/base/hooks/factory-document-save-types";
-import type { EditableFactoryGraphDocumentSaveControls } from "../../factory-graph-editor/hooks/use-editable-factory-graph-types";
-import type { EditableFactoryGraphSaveMutation } from "../../factory-graph-editor/hooks/use-editable-factory-graph-types";
+import type { FactoryDocumentSaveState } from "../../current-selection/base/public";
+import type { FactoryGraphEditorTool } from "../../factory-graph-editor/components/factory-graph-editor-controls";
+import type {
+  EditableFactoryGraphDocumentSaveControls,
+  EditableFactoryGraphSaveMutation,
+  EditableFactoryGraphViewModel,
+} from "../../factory-graph-editor/hooks/use-editable-factory-graph-types";
 import { buildFactoryGraphSaveSummary } from "../../factory-graph-editor/lib/factory-graph-editor-save-summary";
 import { getFactoryGraphEditorMessages } from "../../factory-graph-editor/messages/editor";
-import type { EditableFactoryGraphViewModel } from "../../factory-graph-editor/hooks/use-editable-factory-graph-types";
-import type { FactoryGraphEditorTool } from "../../factory-graph-editor/components/factory-graph-editor-controls";
 import type { useFactoryGraphAddEntityController } from "../components/react-flow-current-activity-card-editor-chrome";
 import type { useFactoryGraphConnectionController } from "./react-flow-current-activity-card-editor-connections";
 
@@ -19,6 +20,7 @@ export type GraphEditorTransientControllerReset = {
   setPendingRemovalNodeId: (nodeId: string | null) => void;
 };
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: save/leave confirmation and scope-reset chrome share one hook boundary.
 export function useGraphEditorSaveFlow({
   activeWorkCount,
   addEntityController,
@@ -104,6 +106,19 @@ export function useGraphEditorSaveFlow({
     resetTransientEditorState();
   }, [resetTransientEditorState, setActiveTool, setEditorMode]);
 
+  const resetEditorChromeForScopeChange = useCallback(() => {
+    setEditorMode(false);
+    setActiveTool(null);
+    setPendingSaveConfirmation(false);
+    documentSaveControls.cancelConfirmation();
+    resetTransientEditorState();
+  }, [
+    documentSaveControls,
+    resetTransientEditorState,
+    setActiveTool,
+    setEditorMode,
+  ]);
+
   const handleDiscardPendingChanges = useCallback(() => {
     editableGraph.actions.discard();
     resetTransientEditorState();
@@ -138,12 +153,7 @@ export function useGraphEditorSaveFlow({
         return false;
       }
     },
-    [
-      canSaveDraft,
-      documentSaveControls,
-      editableGraph.actions,
-      leaveEditor,
-    ],
+    [canSaveDraft, documentSaveControls, editableGraph.actions, leaveEditor],
   );
 
   const handleSaveDraft = useCallback(
@@ -168,6 +178,7 @@ export function useGraphEditorSaveFlow({
     isConfirmingSave,
     isStaleDraft,
     leaveEditor,
+    resetEditorChromeForScopeChange,
     saveAttemptRevision,
     saveBlockedReason,
     saveSummary,

--- a/ui/src/testing/app-shell-test-utils.tsx
+++ b/ui/src/testing/app-shell-test-utils.tsx
@@ -89,6 +89,7 @@ interface RenderAppOptions {
   browserLanguage?: string | null;
   browserLanguages?: readonly string[] | null;
   factorySessions?: FactorySessionSummary[];
+  fetchOverride?: RenderAppFetchOverride;
   initialLocale?: string | null;
   locationSearch?: string | null;
   sessionID?: string | null;
@@ -198,6 +199,7 @@ export function renderApp({
   browserLanguage,
   browserLanguages,
   factorySessions,
+  fetchOverride,
   initialLocale,
   locationSearch,
   seedTimelineFromSnapshot = true,
@@ -241,6 +243,10 @@ export function renderApp({
 
       throw new Error(`unexpected fetch for ${path}`);
     });
+
+  if (fetchOverride) {
+    chainRenderAppFetchMock(fetchMock, fetchOverride);
+  }
 
   vi.stubGlobal("fetch", fetchMock);
   vi.stubGlobal("EventSource", MockEventSource);
@@ -297,9 +303,56 @@ export function nonPromptTemplateFetchPaths(
   return fetchCallPaths(fetchMock).filter(
     (path) =>
       !path.includes("/prompt-template-contract") &&
+      !path.includes("/prompt-template-validation") &&
       path !== "/factory-sessions" &&
       !path.endsWith("/factory"),
   );
+}
+
+export type RenderAppFetchOverride = (
+  path: string,
+  method: string,
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response | undefined>;
+
+export function chainRenderAppFetchMock(
+  fetchMock: FetchMock,
+  override: RenderAppFetchOverride,
+): void {
+  const defaultHandler = fetchMock.getMockImplementation();
+  if (defaultHandler == null) {
+    throw new Error("fetchMock has no default implementation");
+  }
+
+  fetchMock.mockImplementation(async (input, init) => {
+    const path = fetchRequestPath(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+    const overridden = await override(path, method, input, init);
+    if (overridden !== undefined) {
+      return overridden;
+    }
+
+    return defaultHandler(input, init);
+  });
+}
+
+export function lastFetchCallBody(
+  fetchMock: FetchMock,
+  predicate: (path: string, method: string) => boolean,
+): unknown {
+  for (let index = fetchMock.mock.calls.length - 1; index >= 0; index -= 1) {
+    const [input, init] = fetchMock.mock.calls[index] ?? [];
+    const path = fetchRequestPath(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+    if (!predicate(path, method)) {
+      continue;
+    }
+
+    return JSON.parse(String(init?.body ?? "{}"));
+  }
+
+  throw new Error("No matching fetch call found");
 }
 
 export function jsonResponse(

--- a/ui/src/testing/app-shell-test-utils.tsx
+++ b/ui/src/testing/app-shell-test-utils.tsx
@@ -40,7 +40,11 @@ import {
   seedTimelineSnapshots,
 } from "./app-shell-timeline-seed-utils";
 import { DashboardSessionTestProvider } from "./dashboard-session-test-provider";
-import { sessionFactoryNamedExportDocument } from "./session-factory-mocks";
+import {
+  isSessionFactoryRequest,
+  mockGetSessionFactory,
+  sessionFactoryNamedExportDocument,
+} from "./session-factory-mocks";
 
 export {
   renderWithDashboardSessionTest,
@@ -216,12 +220,22 @@ export function renderApp({
 
   const fetchMock: FetchMock = vi
     .fn()
-    .mockImplementation(async (input: RequestInfo | URL) => {
+    .mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
       const path = fetchRequestPath(input);
+      const method = (init?.method ?? "GET").toUpperCase();
 
       if (path === "/factory-sessions") {
         return jsonResponse({
           sessions: factorySessions ?? [defaultFactorySessionSummary],
+        });
+      }
+
+      if (
+        method === "GET" &&
+        isSessionFactoryRequest(path, method, sessionID ?? undefined)
+      ) {
+        return mockGetSessionFactory({
+          document: sessionFactoryNamedExportDocument,
         });
       }
 
@@ -358,11 +372,6 @@ export function registerAppDashboardTestLifecycle(): void {
       selectedSessionID: "~default",
     });
     resetCurrentFactoryDocumentMock();
-    mockCurrentFactoryDocument({
-      data: sessionFactoryNamedExportDocument,
-      error: null,
-      status: "success",
-    } as never);
   });
 
   afterEach(() => {

--- a/ui/src/testing/app-shell-test-utils.tsx
+++ b/ui/src/testing/app-shell-test-utils.tsx
@@ -40,6 +40,7 @@ import {
   seedTimelineSnapshots,
 } from "./app-shell-timeline-seed-utils";
 import { DashboardSessionTestProvider } from "./dashboard-session-test-provider";
+import { sessionFactoryNamedExportDocument } from "./session-factory-mocks";
 
 export {
   renderWithDashboardSessionTest,
@@ -357,6 +358,11 @@ export function registerAppDashboardTestLifecycle(): void {
       selectedSessionID: "~default",
     });
     resetCurrentFactoryDocumentMock();
+    mockCurrentFactoryDocument({
+      data: sessionFactoryNamedExportDocument,
+      error: null,
+      status: "success",
+    } as never);
   });
 
   afterEach(() => {


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/issues2-editor-session-reset",
  "description": "Make factory graph editor state session-local: reset topology draft, editor chrome, and topology bridge handlers when the dashboard factory session changes, avoid showing the previous session's factory while the new session document loads, and preserve in-session save/discard/leave behavior.",
  "context": {
    "customerAsk": "Graph editor state does not leak between factory sessions; opening or switching sessions loads a clean editor snapshot for that session; existing persist/save flows still work within an active session.",
    "problem": "Operators switching factory workspace tabs can still see unsaved graph edits, editor mode/tools, or topology from the previous session because draft reset can race stale document cache data, transient editor chrome survives session changes, and global topology bridge handlers may remain registered.",
    "solution": "Use normalized dashboard sessionID as factoryDocumentScopeKey everywhere, hard-reset draft state on scope change without seeding from stale documents, exit editor mode and clear controllers/bridge on scope change, gate document-backed projection until the active session document loads, and keep in-session save/discard/leave flows unchanged."
  },
  "acceptanceCriteria": [
    "Unsaved graph edits from session A do not appear after switching to session B (no pending draft or unsaved chrome from A).",
    "Session switch exits graph editor mode and clears tools, confirmations, controller transients, and topology bridge handlers from the prior session.",
    "While the new session factory document GET is pending, the graph does not render the previous session's factory name or document-backed topology.",
    "Within one session, save, discard, leave-editor confirmation, and post-save cache updates behave as before this change.",
    "Automated tests cover draft reset on scope change, editor chrome reset, and at least one orchestration-level session-switch scenario.",
    "Typecheck, lint, and tests pass for touched UI packages."
  ],
  "userStories": [
    {
      "id": "issues2-editor-session-reset-001",
      "title": "Hard-reset graph draft when factory session scope changes",
      "description": "As an operator switching workspace tabs, I want pending graph topology edits cleared so I never continue editing another session's factory by mistake.",
      "acceptanceCriteria": [
        "When factoryDocumentScopeKey changes, useFactoryGraphDraftState clears pending draft edits (hasChanges false) and re-baselines only for the new scope.",
        "On scope change, draft reset does not rehydrate from a document that does not belong to the new scope (no seeding from stale React Query data while the new session GET is pending).",
        "When the new scope document arrives, graph projection reflects that session's factory only.",
        "Hook tests in factory-graph-draft.state.test.tsx and/or use-editable-factory-graph.document-plane.test.tsx cover scope change with delayed document arrival.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues2-editor-session-reset-002",
      "title": "Reset editor chrome and topology bridge on session change",
      "description": "As an operator, I want edit mode and graph tools to turn off when I change sessions so the UI cannot apply edits against the wrong session context.",
      "acceptanceCriteria": [
        "When factoryDocumentScopeKey changes, useCurrentActivityGraphEditor sets editorMode false, activeTool null, closes leave/save confirmation state, and resets save mutation and controller transient state equivalent to leaveEditor without cross-session save prompts.",
        "useFactoryGraphTopologyEditorBridge handlers are cleared (setHandlers(null)) on session change even if the previous session left editor mode active.",
        "Hook test proves chrome and bridge reset when scope key changes while the draft is dirty.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues2-editor-session-reset-003",
      "title": "Avoid cross-session factory flash while document loads",
      "description": "As an operator opening or switching to a session, I want the workflow graph to show loading or empty state until that session's factory document is available—not the previous tab's topology.",
      "acceptanceCriteria": [
        "After session switch, until useCurrentFactoryDocument succeeds for the active sessionID, the graph card does not render the previous session's factory name or document-backed workstation/work-state topology.",
        "Observe-mode projection uses the active session dashboard snapshot and does not show prior-session document-plane topology during the loading gap.",
        "Loading and error affordances remain accessible using existing patterns.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues2-editor-session-reset-004",
      "title": "Preserve in-session save and discard behavior",
      "description": "As an operator editing one factory session, I want save, discard, and leave-editor flows unchanged so session isolation does not weaken edit safety.",
      "acceptanceCriteria": [
        "With a constant factoryDocumentScopeKey, editor entry, edits, save, discard, and leave with unsaved changes follow existing confirmation and mutation behavior.",
        "Successful save clears pending draft edits and updates session-scoped document React Query cache without manual refresh.",
        "Save blocked by validation errors still surfaces the same operator-visible errors as before.",
        "Existing graph editor save-flow and leave-dialog tests pass without weakened assertions.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues2-editor-session-reset-005",
      "title": "End-to-end session switch verification",
      "description": "As an operator, I want to confirm in the running dashboard that session switches produce a clean graph editor and that editing still works within one session.",
      "acceptanceCriteria": [
        "Two sessions: unsaved graph edit in session A, switch to session B—B shows no unsaved chrome from A, editor mode is off, and topology matches B (or loading until B document loads).",
        "Returning to session A shows A's persisted factory, not spurious edits from the B switch unless saved in A before leaving.",
        "Within one session, edit, save, and discard work; leave-editor dialog appears when leaving with unsaved edits.",
        "Typecheck passes",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)