### PR TITLE
issues2-factory-graph-red-dots-rules

### DIFF
--- a/ui/scripts/verify-progress-outcome-route-handles-storybook-responsive.mjs
+++ b/ui/scripts/verify-progress-outcome-route-handles-storybook-responsive.mjs
@@ -30,25 +30,11 @@ export async function verifyProgressOutcomeRoutesWithoutStopWords(
     );
   }
 
-  const hints = page.locator("[data-z-axis-incomplete-hint]");
-  const hintCount = await hints.count();
-  if (hintCount !== 2) {
+  const hintCount = await page.locator("[data-z-axis-incomplete-hint]").count();
+  if (hintCount !== 0) {
     throw new Error(
-      `Expected 2 z-axis incomplete hints without stopWords at ${viewport.label}, found ${hintCount}.`,
+      `Expected no z-axis incomplete hints without stopWords at ${viewport.label}, found ${hintCount}.`,
     );
-  }
-
-  for (const anchorId of [
-    "workstation-on-continue-source",
-    "workstation-on-rejection-source",
-  ]) {
-    const hint = page.locator(`[data-z-axis-incomplete-hint="${anchorId}"]`);
-    if ((await hint.count()) !== 1) {
-      throw new Error(
-        `Expected z-axis incomplete hint at ${anchorId} without stopWords at ${viewport.label}.`,
-      );
-    }
-    await expectVisible(hint, `Z-axis incomplete hint (${anchorId})`);
   }
 }
 

--- a/ui/scripts/verify-progress-outcome-route-handles-storybook-responsive.test.mjs
+++ b/ui/scripts/verify-progress-outcome-route-handles-storybook-responsive.test.mjs
@@ -67,11 +67,11 @@ describe("verifyProgressOutcomeRouteHandlesStorybookResponsive", () => {
 
     await verifyProgressOutcomeRoutesWithoutStopWords(
       { expectVisible },
-      createPage(buttons, 2),
+      createPage(buttons, 0),
       { label: "desktop" },
     );
 
-    expect(expectVisible).toHaveBeenCalledTimes(4);
+    expect(expectVisible).toHaveBeenCalledTimes(2);
   });
 
   test("fails when continue handles remain visible without stopWords", async () => {
@@ -122,10 +122,10 @@ describe("verifyProgressOutcomeRouteHandlesStorybookResponsive", () => {
     await expect(
       verifyProgressOutcomeRoutesWithoutStopWords(
         { expectVisible },
-        createPage(buttons, 0),
+        createPage(buttons, 2),
         { label: "desktop" },
       ),
-    ).rejects.toThrow(/Expected 2 z-axis incomplete hints/);
+    ).rejects.toThrow(/Expected no z-axis incomplete hints/);
   });
 
   test("fails when z-axis hints remain visible with stopWords configured", async () => {

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-flow.progress-outcome-routes.test.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-flow.progress-outcome-routes.test.tsx
@@ -5,7 +5,6 @@ import { Background, ReactFlow, ReactFlowProvider } from "@xyflow/react";
 
 import { installDashboardBrowserTestShims } from "../../../components/dashboard/test-browser-shims";
 import "../../../styles.css";
-import { getFactoryGraphEditorMessages } from "../messages/editor";
 import { baseFactoryDefinition } from "../lib/factory-graph-draft.test-helpers";
 import type { FactoryGraphTopology } from "../lib/factory-graph-draft-types";
 import {
@@ -110,14 +109,9 @@ describe("factory graph editor progress outcome route handles", () => {
       screen.queryByRole("button", { name: "Connect: draft Reject" }),
     ).toBeNull();
 
-    const hints = container.querySelectorAll("[data-z-axis-incomplete-hint]");
-    expect(hints).toHaveLength(2);
-    const hintMessage =
-      getFactoryGraphEditorMessages().zAxisIncompleteConnectionHint;
-    for (const hint of hints) {
-      expect(hint.getAttribute("aria-label")).toBe(hintMessage);
-      expect(hint.getAttribute("title")).toBe(hintMessage);
-    }
+    expect(
+      container.querySelectorAll("[data-z-axis-incomplete-hint]"),
+    ).toHaveLength(0);
   });
 
   it("shows continue and reject connect handles when stopWords are configured", async () => {

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-flow.progress-outcome-routes.test.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-flow.progress-outcome-routes.test.tsx
@@ -6,7 +6,11 @@ import { Background, ReactFlow, ReactFlowProvider } from "@xyflow/react";
 import { installDashboardBrowserTestShims } from "../../../components/dashboard/test-browser-shims";
 import "../../../styles.css";
 import { baseFactoryDefinition } from "../lib/factory-graph-draft.test-helpers";
-import type { FactoryGraphTopology } from "../lib/factory-graph-draft-types";
+import type {
+  FactoryGraphTopology,
+  FactoryWorkstation,
+} from "../lib/factory-graph-draft-types";
+import { projectFactoryValidationTargets } from "../lib/factory-validation-graph-projection";
 import {
   buildFactoryGraphEditorFlowModel,
   FACTORY_GRAPH_EDITOR_EDGE_TYPES,
@@ -45,8 +49,38 @@ const PROGRESS_OUTCOME_ROUTE_TOPOLOGY: FactoryGraphTopology = {
   ],
 };
 
+const standardProcessorWithoutStopWords: FactoryWorkstation = {
+  ...baseFactoryDefinition.workstations[0],
+  behavior: "STANDARD",
+  name: "draft",
+  stopWords: undefined,
+};
+
+const standardProcessorWithStopWords: FactoryWorkstation = {
+  ...baseFactoryDefinition.workstations[0],
+  behavior: "STANDARD",
+  name: "draft",
+  stopWords: ["DONE"],
+};
+
+const onRejectionValidationProjection = projectFactoryValidationTargets([
+  {
+    code: "factory.workstation.missingRejectionRoute",
+    message: "missing reject route",
+    severity: "error",
+    subject: {
+      id: "draft",
+      location: "ON_REJECTION",
+      type: "WORKSTATION",
+    },
+  },
+]);
+
 function renderProgressOutcomeRouteFlow(
-  workstations: NonNullable<typeof baseFactoryDefinition.workstations>,
+  workstations: readonly FactoryWorkstation[],
+  options?: {
+    validationProjection?: typeof onRejectionValidationProjection;
+  },
 ) {
   const flow = buildFactoryGraphEditorFlowModel({
     canEditConnections: true,
@@ -56,6 +90,7 @@ function renderProgressOutcomeRouteFlow(
     pendingRemovalEdgeIds: new Set<string>(),
     pendingRemovalNodeIds: new Set<string>(),
     topology: PROGRESS_OUTCOME_ROUTE_TOPOLOGY,
+    validationProjection: options?.validationProjection,
     workstations,
   });
 
@@ -91,11 +126,7 @@ describe("factory graph editor progress outcome route handles", () => {
 
   it("hides continue and reject connect handles for standard processors without stopWords", async () => {
     const { container } = renderProgressOutcomeRouteFlow([
-      {
-        ...baseFactoryDefinition.workstations[0],
-        behavior: "STANDARD",
-        stopWords: undefined,
-      },
+      standardProcessorWithoutStopWords,
     ]);
 
     await screen.findByRole("button", { name: "Connect: draft Success" });
@@ -116,11 +147,7 @@ describe("factory graph editor progress outcome route handles", () => {
 
   it("shows continue and reject connect handles when stopWords are configured", async () => {
     const { container } = renderProgressOutcomeRouteFlow([
-      {
-        ...baseFactoryDefinition.workstations[0],
-        behavior: "STANDARD",
-        stopWords: ["DONE"],
-      },
+      standardProcessorWithStopWords,
     ]);
 
     await screen.findByRole("button", { name: "Connect: draft Continue" });
@@ -130,5 +157,49 @@ describe("factory graph editor progress outcome route handles", () => {
     expect(container.querySelectorAll("[data-z-axis-incomplete-hint]")).toHaveLength(
       0,
     );
+  });
+
+  it("does not show API validation or z-axis hints on omitted continue and reject handles without stopWords", async () => {
+    const { container } = renderProgressOutcomeRouteFlow(
+      [standardProcessorWithoutStopWords],
+      { validationProjection: onRejectionValidationProjection },
+    );
+
+    await screen.findByRole("button", { name: "Connect: draft Success" });
+    expect(
+      screen.queryByRole("button", { name: "Connect: draft Continue" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Connect: draft Reject" }),
+    ).toBeNull();
+    expect(
+      container.querySelectorAll("[data-z-axis-incomplete-hint]"),
+    ).toHaveLength(0);
+    expect(
+      container.querySelectorAll(
+        '[data-z-axis-incomplete-hint="workstation-on-continue-source"], [data-z-axis-incomplete-hint="workstation-on-rejection-source"]',
+      ),
+    ).toHaveLength(0);
+    expect(
+      container.querySelectorAll(
+        '[aria-invalid="true"].ring-af-danger-border',
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("shows API validation on rendered reject handle when stopWords are configured", async () => {
+    const { container } = renderProgressOutcomeRouteFlow(
+      [standardProcessorWithStopWords],
+      { validationProjection: onRejectionValidationProjection },
+    );
+
+    const rejectHandle = await screen.findByRole("button", {
+      name: "missing reject route",
+    });
+    expect(rejectHandle.className).toContain("ring-af-danger-border");
+    expect(rejectHandle.getAttribute("aria-invalid")).toBe("true");
+    expect(
+      container.querySelectorAll("[data-z-axis-incomplete-hint]"),
+    ).toHaveLength(0);
   });
 });

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-flow.stories.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-flow.stories.tsx
@@ -760,7 +760,7 @@ export const ProgressOutcomeRoutesWithoutStopWords = {
     await expectProgressOutcomeRouteHandles(canvas, {
       includeContinueAndReject: false,
     });
-    await expectZAxisIncompleteHints(canvasElement, { expectHints: true });
+    await expectZAxisIncompleteHints(canvasElement, { expectHints: false });
   },
 };
 

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-flow.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-flow.tsx
@@ -19,6 +19,7 @@ import type {
 import { createFactoryGraphWorkstationResolver } from "../lib/factory-graph-editor-connections";
 import type { FactoryGraphConnectionEndpoint } from "../lib/factory-graph-editor-connections";
 import type { FactoryGraphWorkerRuntimeStatus } from "../lib/factory-graph-editor-runtime";
+import type { FactoryValidationGraphProjection } from "../lib/factory-validation-graph-projection";
 import {
   type FactoryGraphReactFlowNode,
   projectFactoryGraphToReactFlow,
@@ -58,6 +59,7 @@ export function buildFactoryGraphEditorFlowModel(input: {
   pendingRemovalEdgeIds: ReadonlySet<string>;
   pendingRemovalNodeIds: ReadonlySet<string>;
   topology: FactoryGraphTopology;
+  validationProjection?: FactoryValidationGraphProjection;
   workstations?: readonly FactoryWorkstation[];
   workerStatusByName?: ReadonlyMap<string, FactoryGraphWorkerRuntimeStatus>;
 }): {
@@ -75,6 +77,7 @@ export function buildFactoryGraphEditorFlowModel(input: {
       pendingConnectionSource: input.pendingConnectionSource,
       pendingRemovalEdgeIds: input.pendingRemovalEdgeIds,
       pendingRemovalNodeIds: input.pendingRemovalNodeIds,
+      validationProjection: input.validationProjection,
     },
     layoutPositionsByNodeId: input.layoutPositionsByNodeId,
     locale: input.locale,

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-editor-connections.test.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-editor-connections.test.ts
@@ -15,6 +15,8 @@ import {
   isValidFactoryGraphConnection,
   workstationRendersProgressOutcomeZAxisHintAnchors,
 } from "./factory-graph-editor-connections";
+import { buildEditorHandles } from "../../workflow-activity/lib/react-flow-current-activity-card-editor-handles";
+import { projectFactoryValidationTargets } from "./factory-validation-graph-projection";
 
 const baseDraft: FactoryGraphDraft = {
   additions: {
@@ -348,5 +350,48 @@ describe("factory graph editor connections", () => {
         standardProcessorWithStopWords,
       ),
     ).toBe(true);
+  });
+
+  it("allows progress-outcome handle validation only on rendered continue and reject anchors", () => {
+    const validationProjection = projectFactoryValidationTargets([
+      {
+        code: "factory.workstation.missingRejectionRoute",
+        message: "missing reject route",
+        severity: "error",
+        subject: {
+          id: "draft",
+          location: "ON_REJECTION",
+          type: "WORKSTATION",
+        },
+      },
+    ]);
+    const withoutStopWordsHandles = buildEditorHandles({
+      connectionAnchorContext: standardProcessorWithoutStopWords,
+      nodeId: "workstation:draft",
+      nodeKind: "workstation",
+      validationProjection,
+    });
+    const withStopWordsHandles = buildEditorHandles({
+      connectionAnchorContext: standardProcessorWithStopWords,
+      nodeId: "workstation:draft",
+      nodeKind: "workstation",
+      validationProjection,
+    });
+
+    expect(
+      withoutStopWordsHandles.find(
+        (handle) => handle.id === "workstation-on-rejection-source",
+      ),
+    ).toBeUndefined();
+    expect(
+      withStopWordsHandles.find(
+        (handle) => handle.id === "workstation-on-rejection-source",
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        validationError: true,
+        validationMessage: "missing reject route",
+      }),
+    );
   });
 });

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-editor-connections.test.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-editor-connections.test.ts
@@ -13,6 +13,7 @@ import {
   factoryGraphConnectionAnchorContext,
   getLocalizedFactoryGraphConnectionAnchors,
   isValidFactoryGraphConnection,
+  workstationRendersProgressOutcomeZAxisHintAnchors,
 } from "./factory-graph-editor-connections";
 
 const baseDraft: FactoryGraphDraft = {
@@ -334,5 +335,18 @@ describe("factory graph editor connections", () => {
 
     expect(nextDraft.edgeChanges.additions).toEqual([]);
     expect(nextDraft.edgeChanges.removals).toEqual([]);
+  });
+
+  it("does not render z-axis hint anchor slots when continue and reject handles are omitted", () => {
+    expect(
+      workstationRendersProgressOutcomeZAxisHintAnchors(
+        standardProcessorWithoutStopWords,
+      ),
+    ).toBe(false);
+    expect(
+      workstationRendersProgressOutcomeZAxisHintAnchors(
+        standardProcessorWithStopWords,
+      ),
+    ).toBe(true);
   });
 });

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-editor-connections.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-editor-connections.ts
@@ -218,6 +218,20 @@ export function getFactoryGraphConnectionAnchors(
   return filterWorkstationConnectionAnchors(anchors, context);
 }
 
+/** True when progress-outcome handle validation and selection messages may surface for an anchor. */
+export function workstationRendersProgressOutcomeHandleValidation(
+  context: FactoryGraphConnectionAnchorContext,
+  anchorId: string,
+): boolean {
+  if (!PROGRESS_OUTCOME_SOURCE_ANCHOR_IDS.has(anchorId)) {
+    return true;
+  }
+
+  return getFactoryGraphConnectionAnchors("workstation", context).some(
+    (anchor) => anchor.id === anchorId,
+  );
+}
+
 /** True when Continue/Reject connect anchors are on the rendered workstation rail. */
 export function workstationRendersProgressOutcomeZAxisHintAnchors(
   context: FactoryGraphConnectionAnchorContext,

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-editor-connections.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-editor-connections.ts
@@ -218,6 +218,25 @@ export function getFactoryGraphConnectionAnchors(
   return filterWorkstationConnectionAnchors(anchors, context);
 }
 
+/** True when Continue/Reject connect anchors are on the rendered workstation rail. */
+export function workstationRendersProgressOutcomeZAxisHintAnchors(
+  context: FactoryGraphConnectionAnchorContext,
+): boolean {
+  const renderedIds = new Set(
+    getFactoryGraphConnectionAnchors("workstation", context).map(
+      (anchor) => anchor.id,
+    ),
+  );
+
+  for (const anchorId of PROGRESS_OUTCOME_SOURCE_ANCHOR_IDS) {
+    if (!renderedIds.has(anchorId)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 export function getLocalizedFactoryGraphConnectionAnchors(
   kind: FactoryGraphNodeKind,
   locale?: string | null,

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-editor-connections.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-editor-connections.ts
@@ -218,38 +218,7 @@ export function getFactoryGraphConnectionAnchors(
   return filterWorkstationConnectionAnchors(anchors, context);
 }
 
-/** True when progress-outcome handle validation and selection messages may surface for an anchor. */
-export function workstationRendersProgressOutcomeHandleValidation(
-  context: FactoryGraphConnectionAnchorContext,
-  anchorId: string,
-): boolean {
-  if (!PROGRESS_OUTCOME_SOURCE_ANCHOR_IDS.has(anchorId)) {
-    return true;
-  }
-
-  return getFactoryGraphConnectionAnchors("workstation", context).some(
-    (anchor) => anchor.id === anchorId,
-  );
-}
-
-/** True when Continue/Reject connect anchors are on the rendered workstation rail. */
-export function workstationRendersProgressOutcomeZAxisHintAnchors(
-  context: FactoryGraphConnectionAnchorContext,
-): boolean {
-  const renderedIds = new Set(
-    getFactoryGraphConnectionAnchors("workstation", context).map(
-      (anchor) => anchor.id,
-    ),
-  );
-
-  for (const anchorId of PROGRESS_OUTCOME_SOURCE_ANCHOR_IDS) {
-    if (!renderedIds.has(anchorId)) {
-      return false;
-    }
-  }
-
-  return true;
-}
+export { workstationRendersProgressOutcomeHandleValidation, workstationRendersProgressOutcomeZAxisHintAnchors } from "./factory-graph-progress-outcome-handle-visibility";
 
 export function getLocalizedFactoryGraphConnectionAnchors(
   kind: FactoryGraphNodeKind,

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-progress-outcome-handle-visibility.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-progress-outcome-handle-visibility.ts
@@ -1,0 +1,36 @@
+import type { FactoryGraphConnectionAnchorContext } from "./factory-graph-editor-connections";
+import { getFactoryGraphConnectionAnchors } from "./factory-graph-editor-connections";
+import { PROGRESS_OUTCOME_SOURCE_ANCHOR_IDS } from "./factory-graph-progress-outcome-connection-anchors";
+
+/** True when progress-outcome handle validation and selection messages may surface for an anchor. */
+export function workstationRendersProgressOutcomeHandleValidation(
+  context: FactoryGraphConnectionAnchorContext,
+  anchorId: string,
+): boolean {
+  if (!PROGRESS_OUTCOME_SOURCE_ANCHOR_IDS.has(anchorId)) {
+    return true;
+  }
+
+  return getFactoryGraphConnectionAnchors("workstation", context).some(
+    (anchor) => anchor.id === anchorId,
+  );
+}
+
+/** True when Continue/Reject connect anchors are on the rendered workstation rail. */
+export function workstationRendersProgressOutcomeZAxisHintAnchors(
+  context: FactoryGraphConnectionAnchorContext,
+): boolean {
+  const renderedIds = new Set(
+    getFactoryGraphConnectionAnchors("workstation", context).map(
+      (anchor) => anchor.id,
+    ),
+  );
+
+  for (const anchorId of PROGRESS_OUTCOME_SOURCE_ANCHOR_IDS) {
+    if (!renderedIds.has(anchorId)) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-react-flow-projection.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-react-flow-projection.ts
@@ -25,8 +25,14 @@ import {
   getLocalizedFactoryGraphConnectionAnchors,
   isValidFactoryGraphConnection,
   resolveFactoryGraphConnectionAnchorContext,
+  workstationRendersProgressOutcomeHandleValidation,
   workstationRendersProgressOutcomeZAxisHintAnchors,
 } from "./factory-graph-editor-connections";
+import {
+  filterValidationHandleErrorsForWorkstation,
+  type FactoryValidationGraphProjection,
+  validationHandleErrorsForNode,
+} from "./factory-validation-graph-projection";
 import type { FactoryGraphWorkerRuntimeStatus } from "./factory-graph-editor-runtime";
 import {
   type FactoryGraphWorkStateType,
@@ -95,6 +101,7 @@ export interface FactoryGraphReactFlowEditorOverlay {
   pendingRemovalEdgeIds: ReadonlySet<string>;
   pendingRemovalNodeIds: ReadonlySet<string>;
   validationErrors?: readonly FactoryGraphDraftValidationError[];
+  validationProjection?: FactoryValidationGraphProjection;
 }
 
 export interface ProjectFactoryGraphToReactFlowOptions {
@@ -494,6 +501,20 @@ function buildNodeHandles(input: {
           pendingSourceNode,
           input.workstationResolver,
         )?.workstation;
+  const rawValidationHandleErrors =
+    input.node.kind === "workstation" && input.editor?.validationProjection
+      ? validationHandleErrorsForNode(
+          input.editor.validationProjection,
+          input.node.id,
+        )
+      : undefined;
+  const validationHandleErrors =
+    rawValidationHandleErrors === undefined
+      ? undefined
+      : filterValidationHandleErrorsForWorkstation(
+          rawValidationHandleErrors,
+          anchorContext?.workstation,
+        );
 
   return getLocalizedFactoryGraphConnectionAnchors(
     input.node.kind,
@@ -515,15 +536,28 @@ function buildNodeHandles(input: {
         targetNodeKind: input.node.kind,
         targetWorkstation: anchorContext?.workstation,
       });
+    const handleValidation = validationHandleErrors?.get(anchor.id);
+    const rendersHandleValidation =
+      input.node.kind !== "workstation" ||
+      !anchorContext ||
+      workstationRendersProgressOutcomeHandleValidation(
+        anchorContext,
+        anchor.id,
+      );
+    const showHandleValidation =
+      handleValidation !== undefined && rendersHandleValidation;
 
     return {
-      buttonAriaLabel:
-        anchor.role === "source"
+      buttonAriaLabel: showHandleValidation
+        ? handleValidation.message
+        : anchor.role === "source"
           ? `${messages.toolbarConnectLabel}: ${input.node.label} ${anchor.label}`
           : `${messages.toolbarConnectLabel}: ${input.node.label} ${anchor.label}`,
       buttonDisabled: !canEditConnections || nodeIsPendingRemoval,
       buttonPressed: selected || undefined,
-      buttonTitle: anchor.description,
+      buttonTitle: showHandleValidation
+        ? handleValidation.message
+        : anchor.description,
       connectable: canEditConnections && !nodeIsPendingRemoval,
       id: anchor.id,
       label: anchor.label,
@@ -539,13 +573,19 @@ function buildNodeHandles(input: {
           : undefined,
       side: anchor.side,
       type: anchor.role,
-      variant: selected
-        ? "selected"
-        : compatible
-          ? "valid-target"
-          : canEditConnections
-            ? "default"
-            : "muted",
+      validationError: showHandleValidation || undefined,
+      validationMessage: showHandleValidation
+        ? handleValidation.message
+        : undefined,
+      variant: showHandleValidation
+        ? "error"
+        : selected
+          ? "selected"
+          : compatible
+            ? "valid-target"
+            : canEditConnections
+              ? "default"
+              : "muted",
     } satisfies ActivityGraphNodeHandle;
   });
 }

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-react-flow-projection.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-react-flow-projection.ts
@@ -25,6 +25,7 @@ import {
   getLocalizedFactoryGraphConnectionAnchors,
   isValidFactoryGraphConnection,
   resolveFactoryGraphConnectionAnchorContext,
+  workstationRendersProgressOutcomeZAxisHintAnchors,
 } from "./factory-graph-editor-connections";
 import type { FactoryGraphWorkerRuntimeStatus } from "./factory-graph-editor-runtime";
 import {
@@ -447,7 +448,8 @@ export function resolveFactoryGraphZAxisIncompleteHints(input: {
     !input.anchorContext?.workstation ||
     !workstationHasZAxisIncompleteForConnections(
       input.anchorContext.workstation,
-    )
+    ) ||
+    !workstationRendersProgressOutcomeZAxisHintAnchors(input.anchorContext)
   ) {
     return null;
   }

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-react-flow-projection.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-react-flow-projection.ts
@@ -17,6 +17,7 @@ import type {
   FactoryGraphTopology,
 } from "./factory-graph-draft-types";
 import type {
+  FactoryGraphConnectionAnchor,
   FactoryGraphConnectionEndpoint,
   FactoryGraphConnectionResolver,
 } from "./factory-graph-editor-connections";
@@ -470,6 +471,61 @@ export function resolveFactoryGraphZAxisIncompleteHints(input: {
   };
 }
 
+function projectEditorConnectionAnchorHandle(input: {
+  anchor: FactoryGraphConnectionAnchor;
+  canEditConnections: boolean;
+  compatible: boolean;
+  editor?: FactoryGraphReactFlowEditorOverlay;
+  handleValidation?: { message: string };
+  messages: ReturnType<typeof getFactoryGraphEditorMessages>;
+  node: FactoryGraphNode;
+  nodeIsPendingRemoval: boolean;
+  rendersHandleValidation: boolean;
+  selected: boolean;
+}): ActivityGraphNodeHandle {
+  const handleValidation = input.handleValidation;
+  const showHandleValidation =
+    handleValidation !== undefined && input.rendersHandleValidation;
+  const validationMessage = showHandleValidation
+    ? handleValidation.message
+    : undefined;
+
+  return {
+    buttonAriaLabel: showHandleValidation
+      ? validationMessage
+      : `${input.messages.toolbarConnectLabel}: ${input.node.label} ${input.anchor.label}`,
+    buttonDisabled: !input.canEditConnections || input.nodeIsPendingRemoval,
+    buttonPressed: input.selected || undefined,
+    buttonTitle: showHandleValidation ? validationMessage : input.anchor.description,
+    connectable: input.canEditConnections && !input.nodeIsPendingRemoval,
+    id: input.anchor.id,
+    label: input.anchor.label,
+    onButtonClick:
+      input.editor?.onConnectionAnchorClick &&
+      input.canEditConnections &&
+      !input.nodeIsPendingRemoval
+        ? () =>
+            input.editor?.onConnectionAnchorClick?.({
+              anchorId: input.anchor.id,
+              nodeId: input.node.id,
+            })
+        : undefined,
+    side: input.anchor.side,
+    type: input.anchor.role,
+    validationError: showHandleValidation || undefined,
+    validationMessage,
+    variant: showHandleValidation
+      ? "error"
+      : input.selected
+        ? "selected"
+        : input.compatible
+          ? "valid-target"
+          : input.canEditConnections
+            ? "default"
+            : "muted",
+  } satisfies ActivityGraphNodeHandle;
+}
+
 function buildNodeHandles(input: {
   editor?: FactoryGraphReactFlowEditorOverlay;
   locale?: string;
@@ -544,49 +600,19 @@ function buildNodeHandles(input: {
         anchorContext,
         anchor.id,
       );
-    const showHandleValidation =
-      handleValidation !== undefined && rendersHandleValidation;
 
-    return {
-      buttonAriaLabel: showHandleValidation
-        ? handleValidation.message
-        : anchor.role === "source"
-          ? `${messages.toolbarConnectLabel}: ${input.node.label} ${anchor.label}`
-          : `${messages.toolbarConnectLabel}: ${input.node.label} ${anchor.label}`,
-      buttonDisabled: !canEditConnections || nodeIsPendingRemoval,
-      buttonPressed: selected || undefined,
-      buttonTitle: showHandleValidation
-        ? handleValidation.message
-        : anchor.description,
-      connectable: canEditConnections && !nodeIsPendingRemoval,
-      id: anchor.id,
-      label: anchor.label,
-      onButtonClick:
-        input.editor?.onConnectionAnchorClick &&
-        canEditConnections &&
-        !nodeIsPendingRemoval
-          ? () =>
-              input.editor?.onConnectionAnchorClick?.({
-                anchorId: anchor.id,
-                nodeId: input.node.id,
-              })
-          : undefined,
-      side: anchor.side,
-      type: anchor.role,
-      validationError: showHandleValidation || undefined,
-      validationMessage: showHandleValidation
-        ? handleValidation.message
-        : undefined,
-      variant: showHandleValidation
-        ? "error"
-        : selected
-          ? "selected"
-          : compatible
-            ? "valid-target"
-            : canEditConnections
-              ? "default"
-              : "muted",
-    } satisfies ActivityGraphNodeHandle;
+    return projectEditorConnectionAnchorHandle({
+      anchor,
+      canEditConnections,
+      compatible,
+      editor: input.editor,
+      handleValidation,
+      messages,
+      node: input.node,
+      nodeIsPendingRemoval,
+      rendersHandleValidation,
+      selected,
+    });
   });
 }
 

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-react-flow-projection.z-axis-hints.test.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-react-flow-projection.z-axis-hints.test.ts
@@ -48,12 +48,10 @@ describe("factory graph React Flow projection z-axis incomplete hints", () => {
     ).toBeNull();
   });
 
-  it("sets z-axis incomplete hints when connection editing is enabled without stopWords", () => {
+  it("omits z-axis incomplete hints when continue and reject handles are not rendered", () => {
     const topology = buildFactoryGraphTopologyFromDefinition(
       factoryWithoutStopWords,
     );
-    const hintMessage =
-      getFactoryGraphEditorMessages().zAxisIncompleteConnectionHint;
 
     const projection = projectFactoryGraphToReactFlow({
       editor: {
@@ -71,10 +69,7 @@ describe("factory graph React Flow projection z-axis incomplete hints", () => {
       (node) => node.id === "workstation:draft",
     );
 
-    expect(workstationNode?.data.zAxisIncompleteHints).toEqual({
-      accessibleLabel: hintMessage,
-      title: hintMessage,
-    });
+    expect(workstationNode?.data.zAxisIncompleteHints).toBeNull();
     expect(
       projection.nodes.find((node) => node.id === "work-state:story:queued")
         ?.data.zAxisIncompleteHints,

--- a/ui/src/features/factory-graph-editor/lib/factory-validation-graph-projection.test.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-validation-graph-projection.test.ts
@@ -5,11 +5,13 @@ import {
   factoryGraphNodeIdForWorkState,
   factoryGraphNodeIdForWorkstation,
   factoryGraphNodeIdForWorkType,
+  filterValidationHandleErrorsForWorkstation,
   parseFactoryGraphWorkStateNodeId,
   parseFactoryGraphWorkTypeNodeId,
   projectFactoryValidationTargets,
   validationHandleErrorsForNode,
   validationNodeErrorForNode,
+  validationTargetIsRenderedForWorkstation,
   workstationHandleIdForValidationLocation,
 } from "./factory-validation-graph-projection";
 
@@ -137,5 +139,75 @@ describe("factory-validation-graph-projection", () => {
       code: "factory.workState.missingTerminalCompletionPath",
       message: 'work state "story:queued" has no terminal completion path.',
     });
+  });
+
+  it("filters progress-outcome handle errors using rendered workstation anchors", () => {
+    const targets: FactoryValidationTarget[] = [
+      {
+        code: "factory.workstation.missingRejectionRoute",
+        message: "Workstation draft must define a reject route.",
+        severity: "error",
+        subject: {
+          id: "draft",
+          location: "ON_REJECTION",
+          type: "WORKSTATION",
+        },
+      },
+      {
+        code: "factory.workstation.missingFailureRoute",
+        message: 'Workstation "draft" must define a failure route.',
+        severity: "error",
+        subject: {
+          id: "draft",
+          location: "ON_FAILURE",
+          type: "WORKSTATION",
+        },
+      },
+    ];
+    const projection = projectFactoryValidationTargets(targets);
+    const draftNodeId = factoryGraphNodeIdForWorkstation("draft");
+    const handleErrors = validationHandleErrorsForNode(projection, draftNodeId);
+    expect(handleErrors).toBeDefined();
+
+    const standardProcessorWithoutStopWords = {
+      type: "MODEL_WORKSTATION" as const,
+      behavior: "STANDARD" as const,
+    };
+    const repeaterWorkstation = {
+      type: "MODEL_WORKSTATION" as const,
+      behavior: "REPEATER" as const,
+    };
+
+    const filteredWithoutStopWords = filterValidationHandleErrorsForWorkstation(
+      handleErrors!,
+      standardProcessorWithoutStopWords,
+    );
+    expect([...filteredWithoutStopWords.keys()]).toEqual([
+      "workstation-on-failure-source",
+    ]);
+    expect(
+      validationTargetIsRenderedForWorkstation(
+        targets[0],
+        standardProcessorWithoutStopWords,
+      ),
+    ).toBe(false);
+    expect(
+      validationTargetIsRenderedForWorkstation(
+        targets[1],
+        standardProcessorWithoutStopWords,
+      ),
+    ).toBe(true);
+
+    const filteredForRepeater = filterValidationHandleErrorsForWorkstation(
+      handleErrors!,
+      repeaterWorkstation,
+    );
+    expect([...filteredForRepeater.keys()]).toEqual([
+      "workstation-on-rejection-source",
+      "workstation-on-failure-source",
+    ]);
+    expect(
+      validationTargetIsRenderedForWorkstation(targets[0], repeaterWorkstation),
+    ).toBe(true);
   });
 });

--- a/ui/src/features/factory-graph-editor/lib/factory-validation-graph-projection.test.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-validation-graph-projection.test.ts
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/complexity/noExcessiveLinesPerFunction: validation projection scenarios stay grouped around shared workstation fixtures.
 import { describe, expect, it } from "vitest";
 
 import type { FactoryValidationTarget } from "../../../api/factory-validation";

--- a/ui/src/features/factory-graph-editor/lib/factory-validation-graph-projection.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-validation-graph-projection.ts
@@ -1,4 +1,9 @@
+import type { WorkstationProgressOutcomeRouteContext } from "../../current-factory-definition/lib/workstation-progress-outcome-routes";
 import type { FactoryValidationTarget } from "../../../api/factory-validation";
+import {
+  factoryGraphConnectionAnchorContext,
+  workstationRendersProgressOutcomeHandleValidation,
+} from "./factory-graph-editor-connections";
 
 export type FactoryValidationSubjectLocation =
   FactoryValidationTarget["subject"]["location"];
@@ -196,6 +201,45 @@ export function validationHandleErrorsForNode(
   nodeId: string,
 ): ReadonlyMap<string, FactoryValidationHandleError> | undefined {
   return projection.handleErrorsByNodeId.get(nodeId);
+}
+
+export function filterValidationHandleErrorsForWorkstation(
+  handleErrors: ReadonlyMap<string, FactoryValidationHandleError>,
+  workstation: WorkstationProgressOutcomeRouteContext | undefined,
+): ReadonlyMap<string, FactoryValidationHandleError> {
+  if (!workstation) {
+    return handleErrors;
+  }
+
+  const context = factoryGraphConnectionAnchorContext(workstation);
+  const filtered = new Map<string, FactoryValidationHandleError>();
+  for (const [handleId, error] of handleErrors) {
+    if (workstationRendersProgressOutcomeHandleValidation(context, handleId)) {
+      filtered.set(handleId, error);
+    }
+  }
+  return filtered;
+}
+
+export function validationTargetIsRenderedForWorkstation(
+  target: FactoryValidationTarget,
+  workstation: WorkstationProgressOutcomeRouteContext | undefined,
+): boolean {
+  if (target.subject.type !== "WORKSTATION" || !workstation) {
+    return true;
+  }
+
+  const handleId = workstationHandleIdForValidationLocation(
+    target.subject.location,
+  );
+  if (!handleId) {
+    return true;
+  }
+
+  return workstationRendersProgressOutcomeHandleValidation(
+    factoryGraphConnectionAnchorContext(workstation),
+    handleId,
+  );
 }
 
 export function validationNodeErrorForNode(

--- a/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-editor-handles.ts
+++ b/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-editor-handles.ts
@@ -208,6 +208,15 @@ export function buildSemanticGraphHandles(args: {
       !supportsProgressOutcomeRoutes &&
       PROGRESS_OUTCOME_SOURCE_ANCHOR_IDS.has(anchor.id);
     const handleValidation = validationHandleErrors?.get(anchor.id);
+    const rendersHandleValidation =
+      args.nodeKind !== "workstation" ||
+      !args.connectionAnchorContext ||
+      workstationRendersProgressOutcomeHandleValidation(
+        args.connectionAnchorContext,
+        anchor.id,
+      );
+    const showHandleValidation =
+      handleValidation !== undefined && rendersHandleValidation;
     const selected =
       args.editor?.pendingConnectionSource?.nodeId === args.nodeId &&
       args.editor.pendingConnectionSource.anchorId === anchor.id;
@@ -220,13 +229,15 @@ export function buildSemanticGraphHandles(args: {
     const visible = args.editor?.editorMode === true;
 
     return {
-      buttonAriaLabel: handleValidation
+      buttonAriaLabel: showHandleValidation
         ? handleValidation.message
         : anchor.description,
       buttonPressed: selected || undefined,
       buttonDisabled:
         !visible || isAuthoredOnlyProgressOutcomeHandle || undefined,
-      buttonTitle: handleValidation?.message ?? anchor.description,
+      buttonTitle: showHandleValidation
+        ? handleValidation.message
+        : anchor.description,
       connectable: connectable && !isAuthoredOnlyProgressOutcomeHandle,
       hidden: !visible || isAuthoredOnlyProgressOutcomeHandle || undefined,
       id: anchor.id,
@@ -238,9 +249,11 @@ export function buildSemanticGraphHandles(args: {
         }),
       side: anchor.side,
       type: anchor.role,
-      validationError: handleValidation !== undefined,
-      validationMessage: handleValidation?.message,
-      variant: handleValidation
+      validationError: showHandleValidation,
+      validationMessage: showHandleValidation
+        ? handleValidation.message
+        : undefined,
+      variant: showHandleValidation
         ? "error"
         : selected
           ? "selected"
@@ -254,6 +267,19 @@ export function buildSemanticGraphHandles(args: {
 }
 
 export const buildEditorHandles = buildSemanticGraphHandles;
+
+function workstationRendersProgressOutcomeHandleValidation(
+  context: FactoryGraphConnectionAnchorContext,
+  anchorId: string,
+): boolean {
+  if (!PROGRESS_OUTCOME_SOURCE_ANCHOR_IDS.has(anchorId)) {
+    return true;
+  }
+
+  return getFactoryGraphConnectionAnchors("workstation", context).some(
+    (anchor) => anchor.id === anchorId,
+  );
+}
 
 function endpointNodeKind(
   nodeId: string,

--- a/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-editor-handles.ts
+++ b/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-editor-handles.ts
@@ -16,6 +16,7 @@ import {
   getLocalizedFactoryGraphConnectionAnchors,
   mergeAuthoredProgressOutcomeConnectionAnchors,
   PROGRESS_OUTCOME_SOURCE_ANCHOR_IDS,
+  workstationRendersProgressOutcomeHandleValidation,
   workstationRendersProgressOutcomeZAxisHintAnchors,
 } from "../../factory-graph-editor/lib/factory-graph-editor-connections";
 import type { FactoryValidationGraphProjection } from "../../factory-graph-editor/lib/factory-validation-graph-projection";
@@ -267,19 +268,6 @@ export function buildSemanticGraphHandles(args: {
 }
 
 export const buildEditorHandles = buildSemanticGraphHandles;
-
-function workstationRendersProgressOutcomeHandleValidation(
-  context: FactoryGraphConnectionAnchorContext,
-  anchorId: string,
-): boolean {
-  if (!PROGRESS_OUTCOME_SOURCE_ANCHOR_IDS.has(anchorId)) {
-    return true;
-  }
-
-  return getFactoryGraphConnectionAnchors("workstation", context).some(
-    (anchor) => anchor.id === anchorId,
-  );
-}
 
 function endpointNodeKind(
   nodeId: string,

--- a/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-editor-handles.ts
+++ b/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-editor-handles.ts
@@ -16,6 +16,7 @@ import {
   getLocalizedFactoryGraphConnectionAnchors,
   mergeAuthoredProgressOutcomeConnectionAnchors,
   PROGRESS_OUTCOME_SOURCE_ANCHOR_IDS,
+  workstationRendersProgressOutcomeZAxisHintAnchors,
 } from "../../factory-graph-editor/lib/factory-graph-editor-connections";
 import type { FactoryValidationGraphProjection } from "../../factory-graph-editor/lib/factory-validation-graph-projection";
 import { validationHandleErrorsForNode } from "../../factory-graph-editor/lib/factory-validation-graph-projection";
@@ -147,6 +148,9 @@ export function resolveZAxisIncompleteHints(args: {
   if (
     !workstationHasZAxisIncompleteForConnections(
       args.connectionAnchorContext.workstation,
+    ) ||
+    !workstationRendersProgressOutcomeZAxisHintAnchors(
+      args.connectionAnchorContext,
     )
   ) {
     return null;

--- a/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-graph.test.ts
+++ b/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-graph.test.ts
@@ -936,10 +936,7 @@ describe("current activity graph editor handles", () => {
     );
     expect(handleIds).not.toContain("workstation-on-continue-source");
     expect(handleIds).not.toContain("workstation-on-rejection-source");
-    expect(workstationNode?.data.zAxisIncompleteHints).toEqual({
-      accessibleLabel: getFactoryGraphEditorMessages().zAxisIncompleteConnectionHint,
-      title: getFactoryGraphEditorMessages().zAxisIncompleteConnectionHint,
-    });
+    expect(workstationNode?.data.zAxisIncompleteHints).toBeNull();
   });
 
   it("keeps hidden continue and reject handles for authored edges without stopWords", async () => {
@@ -988,10 +985,7 @@ describe("current activity graph editor handles", () => {
         id: "workstation-on-rejection-source",
       }),
     );
-    expect(reviewNode?.data.zAxisIncompleteHints).toEqual({
-      accessibleLabel: getFactoryGraphEditorMessages().zAxisIncompleteConnectionHint,
-      title: getFactoryGraphEditorMessages().zAxisIncompleteConnectionHint,
-    });
+    expect(reviewNode?.data.zAxisIncompleteHints).toBeNull();
   });
 
   it("includes continue and reject editor handles when stopWords are configured", async () => {

--- a/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-graph.test.ts
+++ b/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-graph.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import type { DashboardSnapshot } from "../../../api/dashboard/types";
 import type { CanonicalFactoryDefinition } from "../../../api/factory-definition";
+import type { FactoryValidationTarget } from "../../../api/factory-validation";
 import { semanticWorkflowDashboardSnapshot } from "../../../components/dashboard/test-fixtures";
 import { resolveDashboardSelection } from "../../current-selection/base/public";
 import {
@@ -11,9 +12,9 @@ import {
   systemTimeGraphNodeId,
 } from "../../factory-graph-editor/lib/factory-graph-customer-display";
 import { baseFactoryDefinition } from "../../factory-graph-editor/lib/factory-graph-draft.test-helpers";
-import { getFactoryGraphEditorMessages } from "../../factory-graph-editor/messages/editor";
 import { buildFactoryGraphTopologyFromDefinition } from "../../factory-graph-editor/lib/factory-graph-draft-graph";
-import type { FactoryValidationTarget } from "../../../api/factory-validation";
+import { factoryGraphConnectionAnchorContext } from "../../factory-graph-editor/lib/factory-graph-editor-connections";
+import { projectFactoryValidationTargets } from "../../factory-graph-editor/lib/factory-validation-graph-projection";
 import { buildGraphLayout } from "../../flowchart/lib/layout";
 import {
   buildCurrentActivityGraphLayoutFromFactory,
@@ -1551,6 +1552,157 @@ describe("current activity graph active item labels", () => {
           variant: "error",
         }),
       ]),
+    );
+  });
+
+  it("suppresses ON_REJECTION handle validation on standard processors without stopWords", () => {
+    const connectionAnchorContext = factoryGraphConnectionAnchorContext({
+      type: "MODEL_WORKSTATION",
+      behavior: "STANDARD",
+    });
+    const validationProjection = projectFactoryValidationTargets([
+      {
+        code: "factory.workstation.missingRejectionRoute",
+        message: "Workstation draft must define a reject route.",
+        severity: "error",
+        subject: {
+          id: "draft",
+          location: "ON_REJECTION",
+          type: "WORKSTATION",
+        },
+      },
+    ]);
+    const handles = buildEditorHandles({
+      connectionAnchorContext,
+      editor: {
+        activeTool: "connect",
+        canInteractWithEditor: true,
+        editorMode: true,
+        onConnectionAnchorClick: vi.fn(),
+        pendingConnectionSource: null,
+      },
+      nodeId: "workstation:draft",
+      nodeKind: "workstation",
+      validationProjection,
+    });
+
+    expect(handles).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "workstation-on-rejection-source",
+          validationError: true,
+        }),
+        expect.objectContaining({
+          id: "workstation-on-continue-source",
+          validationError: true,
+        }),
+      ]),
+    );
+    expect(
+      handles.find((handle) => handle.id === "workstation-on-failure-source"),
+    ).toEqual(
+      expect.objectContaining({
+        validationError: false,
+        validationMessage: undefined,
+      }),
+    );
+  });
+
+  it("keeps ON_REJECTION handle validation when reject anchors are rendered", () => {
+    const connectionAnchorContext = factoryGraphConnectionAnchorContext({
+      type: "MODEL_WORKSTATION",
+      behavior: "REPEATER",
+    });
+    const validationProjection = projectFactoryValidationTargets([
+      {
+        code: "factory.workstation.missingRejectionRoute",
+        message: "Workstation process must define a reject route.",
+        severity: "error",
+        subject: {
+          id: "process",
+          location: "ON_REJECTION",
+          type: "WORKSTATION",
+        },
+      },
+    ]);
+    const handles = buildEditorHandles({
+      connectionAnchorContext,
+      editor: {
+        activeTool: "connect",
+        canInteractWithEditor: true,
+        editorMode: true,
+        onConnectionAnchorClick: vi.fn(),
+        pendingConnectionSource: null,
+      },
+      nodeId: "workstation:process",
+      nodeKind: "workstation",
+      validationProjection,
+    });
+
+    expect(handles).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "workstation-on-rejection-source",
+          validationError: true,
+          validationMessage: "Workstation process must define a reject route.",
+          variant: "error",
+        }),
+      ]),
+    );
+  });
+
+  it("suppresses ON_REJECTION validation on hidden authored reject handles without stopWords", async () => {
+    const factory = loadSampleFactoryDefinition();
+    const graphLayout =
+      await buildCurrentActivityGraphLayoutFromFactory(factory);
+    const validationTargets: FactoryValidationTarget[] = [
+      {
+        code: "factory.workstation.missingRejectionRoute",
+        message: 'Workstation "review" must define a reject route.',
+        severity: "error",
+        subject: {
+          id: "review",
+          location: "ON_REJECTION",
+          type: "WORKSTATION",
+        },
+      },
+    ];
+    const nodes = buildCurrentActivityNodes({
+      activeExecutionsByWorkstationNodeID: {},
+      activeGraphHighlights: buildActiveGraphHighlights([], graphLayout.edges),
+      activeItemLabelsByPlaceId: buildActiveItemLabelsByPlaceId([]),
+      editor: {
+        activeTool: "connect",
+        canInteractWithEditor: true,
+        editorMode: true,
+        onConnectionAnchorClick: vi.fn(),
+        pendingConnectionSource: null,
+      },
+      validationTargets,
+      factoryDefinition: factory,
+      graphLayout,
+      now: Date.parse("2026-05-24T00:00:00Z"),
+      onSelectStateNode: vi.fn(),
+      onSelectWorkID: vi.fn(),
+      onSelectWorker: vi.fn(),
+      onSelectWorkType: vi.fn(),
+      onSelectWorkstation: vi.fn(),
+      selection: null,
+      snapshot: buildSampleFactorySnapshot(factory),
+      storedNodePositions: EMPTY_NODE_POSITIONS,
+    });
+    const reviewNode = nodes.find((node) => node.id === "workstation:review");
+    const rejectionHandle = reviewNode?.data.handles?.find(
+      (handle) => handle.id === "workstation-on-rejection-source",
+    );
+
+    expect(rejectionHandle).toEqual(
+      expect.objectContaining({
+        hidden: true,
+        validationError: false,
+        validationMessage: undefined,
+        variant: "default",
+      }),
     );
   });
 });

--- a/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-validation.test.ts
+++ b/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-validation.test.ts
@@ -73,6 +73,94 @@ describe("validationMessagesForSelectedWorkstation", () => {
       'Workstation "process" references missing place "story:missing-state".',
     ]);
   });
+
+  it("excludes ON_REJECTION selection messages when continue and reject handles are not rendered", () => {
+    const targets: FactoryValidationTarget[] = [
+      {
+        code: "factory.workstation.missingRejectionRoute",
+        message: "Workstation draft must define a reject route.",
+        severity: "error",
+        subject: {
+          id: "draft",
+          location: "ON_REJECTION",
+          type: "WORKSTATION",
+        },
+      },
+      {
+        code: "factory.workstation.missingFailureRoute",
+        message: 'Workstation "draft" must define a failure route.',
+        severity: "error",
+        subject: {
+          id: "draft",
+          location: "ON_FAILURE",
+          type: "WORKSTATION",
+        },
+      },
+    ];
+
+    const messages = validationMessagesForSelectedWorkstation({
+      factoryDefinition: {
+        name: "alpha",
+        workTypes: [],
+        workers: [{ name: "worker-a", type: "MODEL_WORKER" }],
+        workstations: [
+          {
+            behavior: "STANDARD",
+            inputs: [],
+            name: "draft",
+            outputs: [],
+            type: "MODEL_WORKSTATION",
+            worker: "worker-a",
+          },
+        ],
+      },
+      projection: projectFactoryValidationTargets(targets),
+      selectionNodeId: "workstation:draft",
+    });
+
+    expect(messages).toEqual([
+      'Workstation "draft" must define a failure route.',
+    ]);
+  });
+
+  it("keeps ON_REJECTION selection messages when reject handle is rendered", () => {
+    const targets: FactoryValidationTarget[] = [
+      {
+        code: "factory.workstation.missingRejectionRoute",
+        message: "Workstation process must define a reject route.",
+        severity: "error",
+        subject: {
+          id: "process",
+          location: "ON_REJECTION",
+          type: "WORKSTATION",
+        },
+      },
+    ];
+
+    const messages = validationMessagesForSelectedWorkstation({
+      factoryDefinition: {
+        name: "alpha",
+        workTypes: [],
+        workers: [{ name: "worker-a", type: "MODEL_WORKER" }],
+        workstations: [
+          {
+            behavior: "REPEATER",
+            inputs: [],
+            name: "process",
+            outputs: [],
+            type: "MODEL_WORKSTATION",
+            worker: "worker-a",
+          },
+        ],
+      },
+      projection: projectFactoryValidationTargets(targets),
+      selectionNodeId: "workstation:process",
+    });
+
+    expect(messages).toEqual([
+      "Workstation process must define a reject route.",
+    ]);
+  });
 });
 
 describe("saveErrorNoticeMessages", () => {

--- a/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-validation.test.ts
+++ b/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-validation.test.ts
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/complexity/noExcessiveLinesPerFunction: selection validation scenarios stay grouped around shared projection fixtures.
 import { describe, expect, it } from "vitest";
 
 import { CurrentFactoryDefinitionError } from "../../../api/current-factory-definition";

--- a/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-validation.ts
+++ b/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-validation.ts
@@ -1,9 +1,12 @@
 import type { FactoryValidationTarget } from "../../../api/factory-validation";
 import { CurrentFactoryDefinitionError } from "../../../api/current-factory-definition";
 import type { CanonicalFactoryDefinition } from "../../../api/factory-definition";
+import type { WorkstationProgressOutcomeRouteContext } from "../../current-factory-definition/lib/workstation-progress-outcome-routes";
 import {
+  filterValidationHandleErrorsForWorkstation,
   projectFactoryValidationTargets,
   type FactoryValidationGraphProjection,
+  validationTargetIsRenderedForWorkstation,
 } from "../../factory-graph-editor/lib/factory-validation-graph-projection";
 import {
   factoryGraphNodeIdForWorkState,
@@ -65,6 +68,32 @@ function collectMessagesForNodeIds(
   return [...messages];
 }
 
+function collectWorkstationMessagesForSelection(
+  messagesByNodeId: ReadonlyMap<
+    string,
+    readonly FactoryValidationTarget[]
+  >,
+  nodeIds: ReadonlySet<string>,
+  workstation: WorkstationProgressOutcomeRouteContext | undefined,
+): string[] {
+  const messages = new Set<string>();
+
+  for (const [nodeId, targets] of messagesByNodeId) {
+    if (!nodeIds.has(nodeId)) {
+      continue;
+    }
+
+    for (const target of targets) {
+      if (!validationTargetIsRenderedForWorkstation(target, workstation)) {
+        continue;
+      }
+      messages.add(target.message);
+    }
+  }
+
+  return [...messages];
+}
+
 function workstationGraphNodeIdsForSelection(
   factoryDefinition: CanonicalFactoryDefinition | undefined,
   selectionNodeId: string,
@@ -106,6 +135,24 @@ function workStateGraphNodeIdsForPlaceId(placeId: string): ReadonlySet<string> {
   return new Set([factoryGraphNodeIdForWorkState(placeId), placeId]);
 }
 
+function findCanonicalWorkstationByNodeId(
+  factoryDefinition: CanonicalFactoryDefinition | undefined,
+  nodeId: string,
+): WorkstationProgressOutcomeRouteContext | undefined {
+  if (!factoryDefinition) {
+    return undefined;
+  }
+
+  const normalizedNodeId = nodeId.startsWith(WORKSTATION_GRAPH_NODE_PREFIX)
+    ? nodeId.slice(WORKSTATION_GRAPH_NODE_PREFIX.length)
+    : nodeId;
+
+  return factoryDefinition.workstations?.find(
+    (candidate) =>
+      candidate.id === normalizedNodeId || candidate.name === normalizedNodeId,
+  );
+}
+
 export function validationMessagesForSelectedWorkstation(args: {
   factoryDefinition?: CanonicalFactoryDefinition;
   projection: FactoryValidationGraphProjection;
@@ -123,10 +170,16 @@ export function validationMessagesForSelectedWorkstation(args: {
     return [];
   }
 
+  const workstation = findCanonicalWorkstationByNodeId(
+    args.factoryDefinition,
+    args.selectionNodeId,
+  );
+
   const messages = new Set(
-    collectMessagesForNodeIds(
+    collectWorkstationMessagesForSelection(
       args.projection.workstationMessagesByNodeId,
       workstationNodeIds,
+      workstation,
     ),
   );
 
@@ -135,7 +188,10 @@ export function validationMessagesForSelectedWorkstation(args: {
     if (!handleErrors) {
       continue;
     }
-    for (const error of handleErrors.values()) {
+    for (const error of filterValidationHandleErrorsForWorkstation(
+      handleErrors,
+      workstation,
+    ).values()) {
       messages.add(error.message);
     }
   }


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/issues2-factory-graph-red-dots-rules",
  "description": "Align factory graph edit-mode red dots (z-axis incomplete hints and API validation handle errors) with rendered workstation handles so standard processors without Continue/Reject anchors do not show phantom validation on hidden onRejection/onContinue positions, consistent with progress-outcome edge filtering.",
  "context": {
    "customerAsk": "Process workstations without onRejection/onContinue must not show red dots on those handles. Validation rules must align with rendered handle availability. Behavior must match edge filtering from the onRejection handle fix.",
    "problem": "Edit mode renders red z-axis incomplete hints and can apply API validation styling at Continue/Reject positions even when connection anchors are omitted for typical standard model processors without stopWords. Operators see validation on handles the graph does not expose.",
    "solution": "Gate z-axis incomplete hints and handle-level validation projection on the same rendered anchor set produced by workstationSupportsProgressOutcomeRoutes and getFactoryGraphConnectionAnchors (plus authored merge), filter selection validation messages for suppressed handles, and lock behavior with updated unit tests and Connect-mode Vitest/browser verification."
  },
  "acceptanceCriteria": [
    "Standard model processors without stopWords show zero data-z-axis-incomplete-hint elements for continue/reject while those connect handles remain absent",
    "Workstations with rendered Continue/Reject handles retain normal connect and validation behavior without false suppression of failure/output handles",
    "API ON_REJECTION targets do not produce validationError or red dots on non-rendered continue/reject handle ids",
    "Validation selection messages and projection follow the same rendered-handle rule as hints and edges",
    "Automated tests cover without-stopWords, with-stopWords, and repeater/authored-route cases",
    "Quality gate: ui typecheck, lint, and affected tests pass"
  ],
  "userStories": [
    {
      "id": "issues2-factory-graph-red-dots-rules-001",
      "title": "Suppress z-axis incomplete hints when progress-outcome handles are not rendered",
      "description": "As a factory operator editing connections, I should not see red incomplete-connection orbs at Continue/Reject positions when those handles are not on the workstation node.",
      "acceptanceCriteria": [
        "resolveFactoryGraphZAxisIncompleteHints returns null when getFactoryGraphConnectionAnchors omits workstation-on-continue-source and workstation-on-rejection-source for the workstation",
        "Workflow Activity resolveZAxisIncompleteHints follows the same rendered-handle rule in editor Connect mode",
        "factory-graph-react-flow-projection.z-axis-hints.test.ts and factory-graph-editor-flow.progress-outcome-routes.test.tsx expect no z-axis hint elements for processors without stopWords",
        "react-flow-current-activity-card-graph.test.ts expects zAxisIncompleteHints null for processors without stopWords",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues2-factory-graph-red-dots-rules-002",
      "title": "Apply API validation handle errors only on rendered workstation anchors",
      "description": "As a factory operator, I want server validation red dots only on handles I can see so validation matches the graph.",
      "acceptanceCriteria": [
        "buildSemanticGraphHandles sets validationError for ON_REJECTION-mapped anchors only when the anchor id is in the rendered anchor list after connection-anchor filtering and authored merge",
        "Hidden authored-only progress-outcome handles when workstationSupportsProgressOutcomeRoutes is false do not show validationError styling",
        "Unit test: ON_REJECTION target for standard processor without stopWords does not set validationError on continue/reject handle ids",
        "Unit test: repeater or workstation with rendered reject handle still shows handle validation when ON_REJECTION target is present",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues2-factory-graph-red-dots-rules-003",
      "title": "Filter validation projection and selection messages to rendered handles",
      "description": "As a factory operator selecting a workstation, I should not see reject-route validation in graph chrome for handles that are not rendered.",
      "acceptanceCriteria": [
        "validationMessagesForSelectedWorkstation excludes handle-level messages for continue/reject handle ids not rendered for the selected workstation",
        "Factory validation graph projection has unit coverage for filtered vs unfiltered handle targets with workstation context",
        "ON_FAILURE and OUTPUTS handle targets and node-level workstation messages are unchanged",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues2-factory-graph-red-dots-rules-004",
      "title": "End-to-end Vitest coverage on factory graph editor Connect mode",
      "description": "As a maintainer, I want regression tests on the React Flow editor surface so red dots cannot reappear on hidden progress-outcome slots.",
      "acceptanceCriteria": [
        "Vitest renders factory graph editor flow in Connect mode with standard processor without stopWords and asserts zero data-z-axis-incomplete-hint elements",
        "With stopWords configured, Continue/Reject connect buttons exist and no phantom z-axis hints appear",
        "Mocked API validation with ON_REJECTION for unsupported processor does not produce z-axis hints or validationError rings on omitted anchors",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill: Connect mode on processor without stopWords shows no red orbs at Continue/Reject; with stopWords handles appear without phantom dots"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)