### PR TITLE
issues2-graph-hide-show-tool

### DIFF
--- a/ui/integration/factory-graph-editor.integration.test.mjs
+++ b/ui/integration/factory-graph-editor.integration.test.mjs
@@ -915,11 +915,11 @@ describe.sequential("factory graph editor browser integration", () => {
             { timeout: uiInteractionTimeoutMs },
           )
           .toBe(0);
-        await expect(
-          toolbar.getByRole("button", {
+        await toolbar
+          .getByRole("button", {
             name: "Open hide or show node classes menu",
-          }),
-        ).toBeVisible();
+          })
+          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
 
         expect(saveRequests).toHaveLength(0);
         expectNoBrowserErrors(

--- a/ui/integration/factory-graph-editor.integration.test.mjs
+++ b/ui/integration/factory-graph-editor.integration.test.mjs
@@ -908,10 +908,18 @@ describe.sequential("factory graph editor browser integration", () => {
         await browserPage.page
           .getByRole("button", { name: "Enter factory graph editor" })
           .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
-        await toolbar.waitFor({
-          state: "hidden",
-          timeout: uiInteractionTimeoutMs,
-        });
+        await expect
+          .poll(
+            async () =>
+              await toolbar.getByRole("button", { name: "Open add entity menu" }).count(),
+            { timeout: uiInteractionTimeoutMs },
+          )
+          .toBe(0);
+        await expect(
+          toolbar.getByRole("button", {
+            name: "Open hide or show node classes menu",
+          }),
+        ).toBeVisible();
 
         expect(saveRequests).toHaveLength(0);
         expectNoBrowserErrors(

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-controls.test.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-controls.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 
+import type { FactoryGraphNodeKind } from "../lib/factory-graph-draft-types";
 import {
   FactoryGraphEditorActionPopover,
   FactoryGraphEditorConfirmationDialog,
@@ -14,12 +15,21 @@ import {
 
 function renderToolbar({
   hasPendingChanges = true,
+  hiddenNodeClasses = new Set<FactoryGraphNodeKind>(),
+  hideShowVisible = true,
+  onToggleHiddenNodeClass = vi.fn(),
+  visible = true,
 }: {
   hasPendingChanges?: boolean;
+  hiddenNodeClasses?: ReadonlySet<FactoryGraphNodeKind>;
+  hideShowVisible?: boolean;
+  onToggleHiddenNodeClass?: (kind: FactoryGraphNodeKind) => void;
+  visible?: boolean;
 } = {}) {
   function ToolbarHarness() {
     const [activeTool, setActiveTool] = useState<FactoryGraphEditorTool>(null);
     const [menuOpen, setMenuOpen] = useState(false);
+    const [hideShowMenuOpen, setHideShowMenuOpen] = useState(false);
 
     return (
       <div className="relative min-h-48">
@@ -36,13 +46,18 @@ function renderToolbar({
           canSave={true}
           canDiscard={true}
           hasPendingChanges={hasPendingChanges}
+          hiddenNodeClasses={hiddenNodeClasses}
+          hideShowMenuOpen={hideShowMenuOpen}
+          hideShowVisible={hideShowVisible}
           onDiscard={() => {}}
           onAddAction={() => {}}
           onAddMenuOpenChange={setMenuOpen}
+          onHideShowMenuOpenChange={setHideShowMenuOpen}
           onSave={() => {}}
           onSelectTool={setActiveTool}
+          onToggleHiddenNodeClass={onToggleHiddenNodeClass}
           openAddMenu={menuOpen}
-          visible={true}
+          visible={visible}
         />
       </div>
     );
@@ -63,7 +78,7 @@ describe("factory graph editor toolbar controls", () => {
     expect(addMenuButton.textContent).toBe("");
     expect(addMenuButton.getAttribute("aria-expanded")).toBe("false");
 
-    await user.tab();
+    addMenuButton.focus();
     await user.keyboard("{Enter}");
 
     const menu = await screen.findByLabelText("Add graph entity menu");
@@ -317,6 +332,65 @@ describe("factory graph editor status and popover controls", () => {
     const menu = await screen.findByText("Node actions");
     expect(menu).toBeTruthy();
     expect(screen.getByRole("button", { name: "Rename node" })).toBeTruthy();
+  });
+});
+
+describe("factory graph editor hide/show controls", () => {
+  it("opens the hide/show menu from the keyboard and toggles node class visibility", async () => {
+    const user = userEvent.setup();
+    const onToggleHiddenNodeClass = vi.fn();
+
+    renderToolbar({ onToggleHiddenNodeClass });
+
+    const hideShowButton = screen.getByRole("button", {
+      name: "Open hide or show node classes menu",
+    });
+    expect(hideShowButton.getAttribute("aria-pressed")).toBe("false");
+    expect(hideShowButton.getAttribute("aria-expanded")).toBe("false");
+
+    await user.tab();
+    await user.keyboard("{Enter}");
+
+    const menu = await screen.findByLabelText(
+      "Factory graph node class visibility menu",
+    );
+    expect(menu).toBeTruthy();
+    expect(hideShowButton.getAttribute("aria-expanded")).toBe("true");
+    expect(hideShowButton.getAttribute("aria-pressed")).toBe("true");
+
+    const workStateToggle = within(menu).getByRole("menuitemcheckbox", {
+      name: "Work state",
+    });
+    expect(workStateToggle.getAttribute("aria-checked")).toBe("true");
+
+    await user.click(workStateToggle);
+    expect(onToggleHiddenNodeClass).toHaveBeenCalledWith("work-state");
+  });
+
+  it("marks the hide/show button pressed when any node class is hidden", () => {
+    renderToolbar({
+      hiddenNodeClasses: new Set<FactoryGraphNodeKind>(["worker"]),
+    });
+
+    expect(
+      screen
+        .getByRole("button", { name: "Open hide or show node classes menu" })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+  });
+
+  it("renders hide/show in observer mode without editor tools", () => {
+    renderToolbar({ hideShowVisible: true, visible: false });
+
+    expect(
+      screen.getByRole("button", {
+        name: "Open hide or show node classes menu",
+      }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Open add entity menu" }),
+    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Connect" })).toBeNull();
   });
 });
 

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-controls.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-controls.tsx
@@ -16,13 +16,13 @@ import {
 } from "../../../components/ui";
 import { cn } from "../../../lib/cn";
 import type { FactoryGraphNodeKind } from "../lib/factory-graph-draft-types";
-import { FACTORY_GRAPH_TOGGLEABLE_NODE_KINDS } from "../lib/factory-graph-node-class-visibility";
 import { getFactoryGraphEditorMessages } from "../messages/editor";
 export { FactoryGraphEditorWorkStatePhaseLegend } from "./factory-graph-editor-work-state-phase-legend";
 export {
   FactoryGraphEditorModeToggle,
   FactoryGraphEditorStatus,
 } from "./factory-graph-editor-mode-controls";
+import { FactoryGraphEditorHideShowMenu } from "./factory-graph-editor-hide-show-menu";
 import {
   FactoryGraphEditorTooltipActionButton,
 } from "./factory-graph-editor-tooltip-button";
@@ -269,124 +269,6 @@ function FactoryGraphEditorToolbarButton({
     >
       {icon}
     </FactoryGraphEditorTooltipActionButton>
-  );
-}
-
-function FactoryGraphEditorHideShowMenu({
-  hiddenNodeClasses,
-  locale,
-  onOpenChange,
-  onToggleHiddenNodeClass,
-  open,
-  pressed,
-}: {
-  hiddenNodeClasses: ReadonlySet<FactoryGraphNodeKind>;
-  locale?: string;
-  onOpenChange?: (open: boolean) => void;
-  onToggleHiddenNodeClass: (kind: FactoryGraphNodeKind) => void;
-  open: boolean;
-  pressed: boolean;
-}) {
-  const messages = getFactoryGraphEditorMessages(locale);
-
-  return (
-    <Popover onOpenChange={onOpenChange} open={open}>
-      <PopoverTrigger asChild>
-        <FactoryGraphEditorTooltipActionButton
-          aria-label={messages.toolbarOpenHideShowMenuLabel}
-          aria-pressed={pressed}
-          iconOnly
-          tooltip={messages.toolbarHideShowDescription}
-          tone={open ? "secondary" : "outline"}
-          type="button"
-        >
-          <HideShowIcon />
-        </FactoryGraphEditorTooltipActionButton>
-      </PopoverTrigger>
-      <PopoverContent
-        align="start"
-        aria-label={messages.toolbarHideShowMenuAriaLabel}
-        avoidCollisions={false}
-        className="grid max-h-[min(var(--radix-popover-content-available-height),calc(100vh-8rem))] gap-2 overflow-y-auto"
-        side="top"
-        sideOffset={12}
-      >
-        <div className="grid gap-1">
-          <p className="m-0 text-sm font-semibold text-af-text">
-            {messages.toolbarHideShowMenuTitle}
-          </p>
-          <p className="m-0 text-xs leading-5 text-af-text-muted">
-            {messages.toolbarHideShowMenuDescription}
-          </p>
-        </div>
-        <div className={MENU_LIST_CLASS} role="menu">
-          {FACTORY_GRAPH_TOGGLEABLE_NODE_KINDS.map((kind) => {
-            const visible = !hiddenNodeClasses.has(kind);
-            const label = messages.kindLabel(kind);
-
-            return (
-              <DashboardActionButton
-                aria-checked={visible}
-                aria-label={label}
-                className={MENU_ACTION_CLASS}
-                key={kind}
-                onClick={() => onToggleHiddenNodeClass(kind)}
-                role="menuitemcheckbox"
-                tone="ghost"
-                type="button"
-              >
-                <span className="flex w-full items-center justify-between gap-3">
-                  <span className="grid justify-items-start gap-0.5">
-                    <span className={MENU_ACTION_LABEL_CLASS}>{label}</span>
-                    <span className={MENU_ACTION_DESCRIPTION_CLASS}>
-                      {messages.nodeClassVisibilityDescription(kind)}
-                    </span>
-                  </span>
-                  {visible ? <MenuCheckIcon /> : null}
-                </span>
-              </DashboardActionButton>
-            );
-          })}
-        </div>
-      </PopoverContent>
-    </Popover>
-  );
-}
-
-function MenuCheckIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      fill="none"
-      height="16"
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="1.8"
-      viewBox="0 0 24 24"
-      width="16"
-    >
-      <path d="m5 12 4 4L19 6" />
-    </svg>
-  );
-}
-
-function HideShowIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      fill="none"
-      height="18"
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="1.8"
-      viewBox="0 0 24 24"
-      width="18"
-    >
-      <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z" />
-      <circle cx="12" cy="12" r="3" />
-    </svg>
   );
 }
 

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-controls.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-controls.tsx
@@ -15,6 +15,8 @@ import {
   PopoverTrigger,
 } from "../../../components/ui";
 import { cn } from "../../../lib/cn";
+import type { FactoryGraphNodeKind } from "../lib/factory-graph-draft-types";
+import { FACTORY_GRAPH_TOGGLEABLE_NODE_KINDS } from "../lib/factory-graph-node-class-visibility";
 import { getFactoryGraphEditorMessages } from "../messages/editor";
 export { FactoryGraphEditorWorkStatePhaseLegend } from "./factory-graph-editor-work-state-phase-legend";
 export {
@@ -71,12 +73,17 @@ export function FactoryGraphEditorToolbar({
   canSave = false,
   canDiscard = true,
   hasPendingChanges = false,
+  hiddenNodeClasses = new Set<FactoryGraphNodeKind>(),
+  hideShowMenuOpen = false,
+  hideShowVisible = true,
   isSaving = false,
   locale,
   onDiscard,
   onAddAction,
   onAddMenuOpenChange,
+  onHideShowMenuOpenChange,
   onSave,
+  onToggleHiddenNodeClass,
   saveDisabledReason,
   visible,
   onSelectTool,
@@ -88,27 +95,46 @@ export function FactoryGraphEditorToolbar({
   canSave?: boolean;
   canDiscard?: boolean;
   hasPendingChanges?: boolean;
+  hiddenNodeClasses?: ReadonlySet<FactoryGraphNodeKind>;
+  hideShowMenuOpen?: boolean;
+  hideShowVisible?: boolean;
   isSaving?: boolean;
   locale?: string;
   onDiscard?: () => void;
   onAddAction?: (actionID: string) => void;
   onAddMenuOpenChange?: (open: boolean) => void;
+  onHideShowMenuOpenChange?: (open: boolean) => void;
   onSave?: () => void;
+  onToggleHiddenNodeClass?: (kind: FactoryGraphNodeKind) => void;
   saveDisabledReason?: string;
   visible: boolean;
   onSelectTool: (tool: FactoryGraphEditorTool) => void;
   openAddMenu?: boolean;
 }) {
-  if (!visible) {
+  if (!visible && !hideShowVisible) {
     return null;
   }
   const messages = getFactoryGraphEditorMessages(locale);
+  const hideShowActive =
+    hideShowMenuOpen || hiddenNodeClasses.size > 0;
 
   return (
     <section
       aria-label={messages.toolbarAriaLabel}
       className={TOOLBAR_SHELL_CLASS}
     >
+      {hideShowVisible && onToggleHiddenNodeClass ? (
+        <FactoryGraphEditorHideShowMenu
+          hiddenNodeClasses={hiddenNodeClasses}
+          locale={locale}
+          onOpenChange={onHideShowMenuOpenChange}
+          onToggleHiddenNodeClass={onToggleHiddenNodeClass}
+          open={hideShowMenuOpen}
+          pressed={hideShowActive}
+        />
+      ) : null}
+      {visible ? (
+        <>
       <FactoryGraphEditorAddMenu
         actions={addMenuActions}
         canInteract={canInteract}
@@ -168,6 +194,8 @@ export function FactoryGraphEditorToolbar({
           actionsClassName={TOOLBAR_ACTIONS_CLASS}
           className={TOOLBAR_MIXED_ROW_CLASS}
         />
+      ) : null}
+        </>
       ) : null}
     </section>
   );
@@ -241,6 +269,124 @@ function FactoryGraphEditorToolbarButton({
     >
       {icon}
     </FactoryGraphEditorTooltipActionButton>
+  );
+}
+
+function FactoryGraphEditorHideShowMenu({
+  hiddenNodeClasses,
+  locale,
+  onOpenChange,
+  onToggleHiddenNodeClass,
+  open,
+  pressed,
+}: {
+  hiddenNodeClasses: ReadonlySet<FactoryGraphNodeKind>;
+  locale?: string;
+  onOpenChange?: (open: boolean) => void;
+  onToggleHiddenNodeClass: (kind: FactoryGraphNodeKind) => void;
+  open: boolean;
+  pressed: boolean;
+}) {
+  const messages = getFactoryGraphEditorMessages(locale);
+
+  return (
+    <Popover onOpenChange={onOpenChange} open={open}>
+      <PopoverTrigger asChild>
+        <FactoryGraphEditorTooltipActionButton
+          aria-label={messages.toolbarOpenHideShowMenuLabel}
+          aria-pressed={pressed}
+          iconOnly
+          tooltip={messages.toolbarHideShowDescription}
+          tone={open ? "secondary" : "outline"}
+          type="button"
+        >
+          <HideShowIcon />
+        </FactoryGraphEditorTooltipActionButton>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        aria-label={messages.toolbarHideShowMenuAriaLabel}
+        avoidCollisions={false}
+        className="grid max-h-[min(var(--radix-popover-content-available-height),calc(100vh-8rem))] gap-2 overflow-y-auto"
+        side="top"
+        sideOffset={12}
+      >
+        <div className="grid gap-1">
+          <p className="m-0 text-sm font-semibold text-af-text">
+            {messages.toolbarHideShowMenuTitle}
+          </p>
+          <p className="m-0 text-xs leading-5 text-af-text-muted">
+            {messages.toolbarHideShowMenuDescription}
+          </p>
+        </div>
+        <div className={MENU_LIST_CLASS} role="menu">
+          {FACTORY_GRAPH_TOGGLEABLE_NODE_KINDS.map((kind) => {
+            const visible = !hiddenNodeClasses.has(kind);
+            const label = messages.kindLabel(kind);
+
+            return (
+              <DashboardActionButton
+                aria-checked={visible}
+                aria-label={label}
+                className={MENU_ACTION_CLASS}
+                key={kind}
+                onClick={() => onToggleHiddenNodeClass(kind)}
+                role="menuitemcheckbox"
+                tone="ghost"
+                type="button"
+              >
+                <span className="flex w-full items-center justify-between gap-3">
+                  <span className="grid justify-items-start gap-0.5">
+                    <span className={MENU_ACTION_LABEL_CLASS}>{label}</span>
+                    <span className={MENU_ACTION_DESCRIPTION_CLASS}>
+                      {messages.nodeClassVisibilityDescription(kind)}
+                    </span>
+                  </span>
+                  {visible ? <MenuCheckIcon /> : null}
+                </span>
+              </DashboardActionButton>
+            );
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function MenuCheckIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="16"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.8"
+      viewBox="0 0 24 24"
+      width="16"
+    >
+      <path d="m5 12 4 4L19 6" />
+    </svg>
+  );
+}
+
+function HideShowIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="18"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.8"
+      viewBox="0 0 24 24"
+      width="18"
+    >
+      <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
   );
 }
 

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-hide-show-menu.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-hide-show-menu.tsx
@@ -1,0 +1,124 @@
+import { DashboardActionButton, Popover, PopoverContent, PopoverTrigger } from "../../../components/ui";
+import type { FactoryGraphNodeKind } from "../lib/factory-graph-draft-types";
+import { FACTORY_GRAPH_TOGGLEABLE_NODE_KINDS } from "../lib/factory-graph-node-class-visibility";
+import { getFactoryGraphEditorMessages } from "../messages/editor";
+import { FactoryGraphEditorTooltipActionButton } from "./factory-graph-editor-tooltip-button";
+
+export function FactoryGraphEditorHideShowMenu({
+  hiddenNodeClasses,
+  locale,
+  onOpenChange,
+  onToggleHiddenNodeClass,
+  open,
+  pressed,
+}: {
+  hiddenNodeClasses: ReadonlySet<FactoryGraphNodeKind>;
+  locale?: string;
+  onOpenChange?: (open: boolean) => void;
+  onToggleHiddenNodeClass: (kind: FactoryGraphNodeKind) => void;
+  open: boolean;
+  pressed: boolean;
+}) {
+  const messages = getFactoryGraphEditorMessages(locale);
+
+  return (
+    <Popover onOpenChange={onOpenChange} open={open}>
+      <PopoverTrigger asChild>
+        <FactoryGraphEditorTooltipActionButton
+          aria-label={messages.toolbarOpenHideShowMenuLabel}
+          aria-pressed={pressed}
+          iconOnly
+          tooltip={messages.toolbarHideShowDescription}
+          tone={open ? "secondary" : "outline"}
+          type="button"
+        >
+          <HideShowIcon />
+        </FactoryGraphEditorTooltipActionButton>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        aria-label={messages.toolbarHideShowMenuAriaLabel}
+        avoidCollisions={false}
+        // tailwind-exception: intrinsic-sizing
+        className="grid max-h-[min(var(--radix-popover-content-available-height),calc(100vh-8rem))] gap-2 overflow-y-auto"
+        side="top"
+        sideOffset={12}
+      >
+        <div className="grid gap-1">
+          <p className="m-0 text-sm font-semibold text-af-text">
+            {messages.toolbarHideShowMenuTitle}
+          </p>
+          <p className="m-0 text-xs leading-5 text-af-text-muted">
+            {messages.toolbarHideShowMenuDescription}
+          </p>
+        </div>
+        <div className="grid gap-1" role="menu">
+          {FACTORY_GRAPH_TOGGLEABLE_NODE_KINDS.map((kind) => {
+            const visible = !hiddenNodeClasses.has(kind);
+            const label = messages.kindLabel(kind);
+
+            return (
+              <DashboardActionButton
+                aria-checked={visible}
+                aria-label={label}
+                className="min-h-0 w-full justify-start rounded-2xl border-transparent px-3 py-2 text-left [&>span]:grid [&>span]:w-full [&>span]:justify-items-start"
+                key={kind}
+                onClick={() => onToggleHiddenNodeClass(kind)}
+                role="menuitemcheckbox"
+                tone="ghost"
+                type="button"
+              >
+                <span className="flex w-full items-center justify-between gap-3">
+                  <span className="grid justify-items-start gap-0.5">
+                    <span className="text-sm font-semibold text-af-text">{label}</span>
+                    <span className="text-xs leading-5 text-af-text-muted">
+                      {messages.nodeClassVisibilityDescription(kind)}
+                    </span>
+                  </span>
+                  {visible ? <MenuCheckIcon /> : null}
+                </span>
+              </DashboardActionButton>
+            );
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function MenuCheckIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="16"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.8"
+      viewBox="0 0 24 24"
+      width="16"
+    >
+      <path d="m5 12 4 4L19 6" />
+    </svg>
+  );
+}
+
+function HideShowIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="18"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.8"
+      viewBox="0 0 24 24"
+      width="18"
+    >
+      <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  );
+}

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-draft-types.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-draft-types.ts
@@ -43,6 +43,7 @@ export type FactoryGraphEdgeKind =
   | "workstation-on-rejection"
   | "workstation-output"
   | "workstation-resource"
+  | "work-state-visibility-bypass"
   | "work-type-state";
 
 export interface FactoryGraphNodeReference {
@@ -70,11 +71,19 @@ export interface FactoryGraphNode {
 export interface FactoryGraphEdge {
   id: string;
   kind: FactoryGraphEdgeKind;
+  /** Outcome route label for display-only work-state bypass edges. */
+  outcomeRouteKind?: WorkstationToWorkStateRouteKind;
   source: FactoryGraphNodeKey;
   sourceId: string;
   target: FactoryGraphNodeKey;
   targetId: string;
 }
+
+export type WorkstationToWorkStateRouteKind =
+  | "workstation-on-continue"
+  | "workstation-on-failure"
+  | "workstation-on-rejection"
+  | "workstation-output";
 
 export interface FactoryGraphDraftValidationError {
   code:

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-editor-connections.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-editor-connections.ts
@@ -398,7 +398,10 @@ export function applyFactoryGraphEdgeRemoval(
   edge: FactoryGraphEdge,
 ): FactoryGraphDraft {
   const nextDraft = structuredClone(currentDraft);
-  if (edge.kind === "work-type-state") {
+  if (
+    edge.kind === "work-type-state" ||
+    edge.kind === "work-state-visibility-bypass"
+  ) {
     return nextDraft;
   }
   const nextEdgeId = edge.id;

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-editor-connections.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-editor-connections.ts
@@ -267,8 +267,10 @@ export function buildFactoryGraphEdgeChangeFromConnection(
   },
   resolver?: FactoryGraphConnectionResolver,
 ): FactoryGraphDraftEdgeChange | null {
-  const sourceNode = findNode(topology, endpoint.sourceNodeId);
-  const targetNode = findNode(topology, endpoint.targetNodeId);
+  const sourceNode =
+    topology.nodes.find((node) => node.id === endpoint.sourceNodeId) ?? null;
+  const targetNode =
+    topology.nodes.find((node) => node.id === endpoint.targetNodeId) ?? null;
   if (!sourceNode || !targetNode) {
     return null;
   }
@@ -480,6 +482,3 @@ function appendUniqueEdgeChange(
   return [...edges, edgeChange];
 }
 
-function findNode(topology: FactoryGraphTopology, nodeId: string) {
-  return topology.nodes.find((node) => node.id === nodeId) ?? null;
-}

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-editor-edge-removal-copy.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-editor-edge-removal-copy.ts
@@ -8,6 +8,9 @@ export function buildEdgeRemovalDescription(
   edge: FactoryGraphEdge,
   locale?: string | null,
 ) {
+  if (edge.kind === "work-state-visibility-bypass") {
+    return "";
+  }
   const messages = getFactoryGraphEditorMessages(locale);
   return messages.removalEdgeDescription(
     edge.kind,
@@ -20,6 +23,9 @@ export function describeEdgeLabel(
   edge: FactoryGraphEdge,
   locale?: string | null,
 ) {
+  if (edge.kind === "work-state-visibility-bypass") {
+    return "";
+  }
   const messages = getFactoryGraphEditorMessages(locale);
   return messages.removalEdgeLabel(edge.kind, describeNodeLabel(edge.source));
 }

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-editor-removals.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-editor-removals.ts
@@ -379,7 +379,10 @@ function shouldRemoveEdgeForNode(
 function toDraftEdgeRemoval(
   edge: FactoryGraphEdge,
 ): FactoryGraphDraftEdgeChange | null {
-  if (edge.kind === "work-type-state") {
+  if (
+    edge.kind === "work-type-state" ||
+    edge.kind === "work-state-visibility-bypass"
+  ) {
     return null;
   }
 

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-node-class-visibility-bypass-projection.test.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-node-class-visibility-bypass-projection.test.ts
@@ -1,0 +1,58 @@
+import { buildFactoryGraphTopologyFromDefinition } from "./factory-graph-draft-graph";
+import type { CanonicalFactoryDefinition } from "./factory-graph-draft-types";
+import { projectFactoryGraphByHiddenNodeClasses } from "./factory-graph-node-class-visibility";
+import { projectFactoryGraphToReactFlow } from "./factory-graph-react-flow-projection";
+
+const workstationChainFactory = {
+  name: "work-state-bypass-projection-fixture",
+  resources: [],
+  workers: [{ name: "reviewer" }, { name: "drafter" }],
+  workTypes: [
+    {
+      name: "story",
+      states: [{ name: "done", type: "TERMINAL" as const }],
+    },
+  ],
+  workstations: [
+    {
+      inputs: [],
+      name: "review",
+      outputs: [{ state: "done", workType: "story" }],
+      worker: "reviewer",
+    },
+    {
+      inputs: [{ state: "done", workType: "story" }],
+      name: "draft",
+      outputs: [],
+      worker: "drafter",
+    },
+  ],
+} satisfies CanonicalFactoryDefinition;
+
+describe("projectFactoryGraphToReactFlow with hidden work states", () => {
+  it("projects bypass edges onto workstation output and input handles", () => {
+    const topology = buildFactoryGraphTopologyFromDefinition(
+      workstationChainFactory,
+    );
+    const visibleTopology = projectFactoryGraphByHiddenNodeClasses(
+      topology,
+      new Set(["work-state"]),
+    );
+    const projection = projectFactoryGraphToReactFlow({
+      filterEdgesToRenderedHandles: true,
+      topology: visibleTopology,
+    });
+
+    const bypassEdge = projection.edges.find(
+      (edge) => edge.data?.kind === "work-state-visibility-bypass",
+    );
+
+    expect(bypassEdge).toMatchObject({
+      source: "workstation:review",
+      sourceHandle: "workstation-output-source",
+      target: "workstation:draft",
+      targetHandle: "workstation-input-target",
+    });
+    expect(bypassEdge?.data?.label).toBe("Success route");
+  });
+});

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-node-class-visibility.test.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-node-class-visibility.test.ts
@@ -1,0 +1,125 @@
+import {
+  SYSTEM_TIME_WORK_TYPE_ID,
+  systemTimeGraphNodeId,
+} from "./factory-graph-customer-display";
+import { buildFactoryGraphTopologyFromDefinition } from "./factory-graph-draft-graph";
+import type { FactoryGraphNodeKind } from "./factory-graph-draft-types";
+import {
+  FACTORY_GRAPH_TOGGLEABLE_NODE_KINDS,
+  projectFactoryGraphByHiddenNodeClasses,
+} from "./factory-graph-node-class-visibility";
+import { maintainerRuntimeShapedFactory } from "./maintainer-runtime-shaped-factory.fixture";
+
+const runtimeTopology = buildFactoryGraphTopologyFromDefinition(
+  maintainerRuntimeShapedFactory,
+);
+
+function nodeIds(topology: { nodes: { id: string }[] }) {
+  return topology.nodes.map((node) => node.id);
+}
+
+function edgeIds(topology: { edges: { id: string }[] }) {
+  return topology.edges.map((edge) => edge.id);
+}
+
+function nodesByKind(kind: FactoryGraphNodeKind) {
+  return runtimeTopology.nodes.filter((node) => node.kind === kind);
+}
+
+function hiddenSet(...kinds: FactoryGraphNodeKind[]) {
+  return new Set(kinds);
+}
+
+describe("projectFactoryGraphByHiddenNodeClasses", () => {
+  it("keeps customer-display topology when no classes are hidden", () => {
+    const projected = projectFactoryGraphByHiddenNodeClasses(
+      runtimeTopology,
+      new Set(),
+    );
+
+    expect(nodeIds(projected)).not.toEqual(
+      expect.arrayContaining([
+        systemTimeGraphNodeId("work-type", SYSTEM_TIME_WORK_TYPE_ID),
+      ]),
+    );
+    expect(nodeIds(projected)).toEqual(
+      expect.arrayContaining([
+        "work-type:task",
+        "work-state:task:init",
+        "workstation:process",
+        "worker:processor",
+        "resource:executor-slot",
+      ]),
+    );
+  });
+
+  it.each(
+    FACTORY_GRAPH_TOGGLEABLE_NODE_KINDS,
+  )("hides %s nodes and incident edges when that class is hidden", (kind) => {
+    const projected = projectFactoryGraphByHiddenNodeClasses(
+      runtimeTopology,
+      hiddenSet(kind),
+    );
+
+    expect(projected.nodes.every((node) => node.kind !== kind)).toBe(true);
+    const hiddenNodeIds = new Set(nodesByKind(kind).map((node) => node.id));
+    expect(
+      projected.edges.every(
+        (edge) =>
+          !hiddenNodeIds.has(edge.sourceId) &&
+          !hiddenNodeIds.has(edge.targetId),
+      ),
+    ).toBe(true);
+    expect(projected.nodes.length).toBeLessThan(runtimeTopology.nodes.length);
+  });
+
+  it("hides multiple node classes together", () => {
+    const projected = projectFactoryGraphByHiddenNodeClasses(
+      runtimeTopology,
+      hiddenSet("work-state", "resource", "worker"),
+    );
+
+    expect(nodeIds(projected)).not.toEqual(
+      expect.arrayContaining([
+        "work-state:task:init",
+        "work-state:task:done",
+        "resource:executor-slot",
+        "worker:processor",
+        "worker:workspace-setup",
+      ]),
+    );
+    expect(nodeIds(projected)).toEqual(
+      expect.arrayContaining(["work-type:task", "workstation:process"]),
+    );
+    expect(
+      edgeIds(projected).every(
+        (edgeId) =>
+          !edgeId.includes("work-state:") &&
+          !edgeId.startsWith("worker-") &&
+          !edgeId.startsWith("workstation-resource:"),
+      ),
+    ).toBe(true);
+  });
+
+  it("drops layout positions for hidden nodes when layout input is provided", () => {
+    const layoutPositionsByNodeId = new Map(
+      runtimeTopology.nodes.map((node, index) => [
+        node.id,
+        { x: index * 10, y: index * 5 },
+      ]),
+    );
+
+    const projected = projectFactoryGraphByHiddenNodeClasses(
+      { layoutPositionsByNodeId, topology: runtimeTopology },
+      hiddenSet("workstation"),
+    );
+
+    expect(projected.layoutPositionsByNodeId?.has("workstation:process")).toBe(
+      false,
+    );
+    expect(projected.layoutPositionsByNodeId?.has("work-type:task")).toBe(true);
+    expect(projected.layoutPositionsByNodeId?.size).toBe(
+      projected.nodes.length,
+    );
+  });
+});

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-node-class-visibility.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-node-class-visibility.ts
@@ -1,0 +1,74 @@
+import { filterFactoryGraphTopologyForCustomerDisplay } from "./factory-graph-customer-display";
+import type {
+  FactoryGraphNodeKind,
+  FactoryGraphTopology,
+} from "./factory-graph-draft-types";
+
+export const FACTORY_GRAPH_TOGGLEABLE_NODE_KINDS = [
+  "work-type",
+  "work-state",
+  "workstation",
+  "worker",
+  "resource",
+] as const satisfies readonly FactoryGraphNodeKind[];
+
+export type FactoryGraphNodeClassVisibilityInput =
+  | FactoryGraphTopology
+  | {
+      layoutPositionsByNodeId?: ReadonlyMap<string, { x: number; y: number }>;
+      topology: FactoryGraphTopology;
+    };
+
+export type FactoryGraphNodeClassVisibilityResult = FactoryGraphTopology & {
+  layoutPositionsByNodeId?: Map<string, { x: number; y: number }>;
+};
+
+function resolveVisibilityInput(input: FactoryGraphNodeClassVisibilityInput): {
+  layoutPositionsByNodeId?: ReadonlyMap<string, { x: number; y: number }>;
+  topology: FactoryGraphTopology;
+} {
+  if ("topology" in input) {
+    return {
+      layoutPositionsByNodeId: input.layoutPositionsByNodeId,
+      topology: input.topology,
+    };
+  }
+
+  return { topology: input };
+}
+
+export function projectFactoryGraphByHiddenNodeClasses(
+  input: FactoryGraphNodeClassVisibilityInput,
+  hiddenNodeClasses: ReadonlySet<FactoryGraphNodeKind>,
+): FactoryGraphNodeClassVisibilityResult {
+  const { layoutPositionsByNodeId, topology } = resolveVisibilityInput(input);
+  const displayTopology =
+    filterFactoryGraphTopologyForCustomerDisplay(topology);
+
+  const hiddenNodeIds = new Set(
+    displayTopology.nodes
+      .filter((node) => hiddenNodeClasses.has(node.kind))
+      .map((node) => node.id),
+  );
+
+  const nodes = displayTopology.nodes.filter(
+    (node) => !hiddenNodeIds.has(node.id),
+  );
+  const visibleNodeIds = new Set(nodes.map((node) => node.id));
+  const edges = displayTopology.edges.filter(
+    (edge) =>
+      visibleNodeIds.has(edge.sourceId) && visibleNodeIds.has(edge.targetId),
+  );
+
+  const result: FactoryGraphNodeClassVisibilityResult = { edges, nodes };
+
+  if (layoutPositionsByNodeId) {
+    result.layoutPositionsByNodeId = new Map(
+      [...layoutPositionsByNodeId].filter(([nodeId]) =>
+        visibleNodeIds.has(nodeId),
+      ),
+    );
+  }
+
+  return result;
+}

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-node-class-visibility.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-node-class-visibility.ts
@@ -3,6 +3,7 @@ import type {
   FactoryGraphNodeKind,
   FactoryGraphTopology,
 } from "./factory-graph-draft-types";
+import { synthesizeWorkStateVisibilityBypassEdges } from "./factory-graph-work-state-visibility-bypass";
 
 export const FACTORY_GRAPH_TOGGLEABLE_NODE_KINDS = [
   "work-type",
@@ -55,10 +56,22 @@ export function projectFactoryGraphByHiddenNodeClasses(
     (node) => !hiddenNodeIds.has(node.id),
   );
   const visibleNodeIds = new Set(nodes.map((node) => node.id));
-  const edges = displayTopology.edges.filter(
+  const filteredEdges = displayTopology.edges.filter(
     (edge) =>
       visibleNodeIds.has(edge.sourceId) && visibleNodeIds.has(edge.targetId),
   );
+  const bypassEdges = hiddenNodeClasses.has("work-state")
+    ? synthesizeWorkStateVisibilityBypassEdges(
+        displayTopology,
+        new Set(
+          displayTopology.nodes
+            .filter((node) => node.kind === "work-state")
+            .map((node) => node.id),
+        ),
+        visibleNodeIds,
+      )
+    : [];
+  const edges = [...filteredEdges, ...bypassEdges];
 
   const result: FactoryGraphNodeClassVisibilityResult = { edges, nodes };
 

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-react-flow-projection.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-react-flow-projection.ts
@@ -126,6 +126,7 @@ const EDGE_COLOR_BY_KIND = {
   "workstation-on-rejection": "var(--color-af-warning-text)",
   "workstation-output": "var(--color-af-accent)",
   "workstation-resource": "var(--color-af-success)",
+  "work-state-visibility-bypass": "var(--color-af-accent)",
 } as const;
 const COLUMN_X = 232;
 const ROW_Y = 118;
@@ -301,7 +302,14 @@ function buildFactoryGraphReactFlowEdge(
   const pendingRemoval =
     input.editor?.pendingRemovalEdgeIds.has(edge.id) ?? false;
   const active = input.runtime?.activeEdgeIds?.has(edge.id) ?? false;
-  const edgeLabel = messages.edgeKindLabel(edge.kind);
+  const edgeLabel =
+    edge.kind === "work-state-visibility-bypass" && edge.outcomeRouteKind
+      ? messages.edgeKindLabel(edge.outcomeRouteKind)
+      : messages.edgeKindLabel(
+          edge.kind === "work-state-visibility-bypass"
+            ? "workstation-output"
+            : edge.kind,
+        );
   const handleAssignment = getEdgeHandleAssignment(
     edge,
     input.topology,
@@ -393,6 +401,25 @@ function getEdgeHandleAssignment(
 ): { sourceHandle: string; targetHandle: string } | null {
   const sourceNode = findTopologyNode(topology, edge.sourceId);
   const targetNode = findTopologyNode(topology, edge.targetId);
+  if (edge.kind === "work-state-visibility-bypass" && edge.outcomeRouteKind) {
+    const sourceHandle = getNodeHandleId(
+      sourceNode,
+      edge.outcomeRouteKind,
+      "source",
+      workstationResolver,
+    );
+    const targetHandle = getNodeHandleId(
+      targetNode,
+      "workstation-input",
+      "target",
+      workstationResolver,
+    );
+    if (!sourceHandle || !targetHandle) {
+      return null;
+    }
+    return { sourceHandle, targetHandle };
+  }
+
   const sourceHandle = getNodeHandleId(
     sourceNode,
     edge.kind,
@@ -417,7 +444,7 @@ function getNodeHandleId(
   role: "source" | "target",
   workstationResolver?: FactoryGraphConnectionResolver,
 ) {
-  if (edgeKind === "work-type-state") {
+  if (edgeKind === "work-type-state" || edgeKind === "work-state-visibility-bypass") {
     return null;
   }
 

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-work-state-visibility-bypass.test.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-work-state-visibility-bypass.test.ts
@@ -1,0 +1,199 @@
+import { buildFactoryGraphTopologyFromDefinition } from "./factory-graph-draft-graph";
+import type { CanonicalFactoryDefinition } from "./factory-graph-draft-types";
+import { projectFactoryGraphByHiddenNodeClasses } from "./factory-graph-node-class-visibility";
+import { synthesizeWorkStateVisibilityBypassEdges } from "./factory-graph-work-state-visibility-bypass";
+
+const workstationChainFactory = {
+  name: "work-state-bypass-fixture",
+  resources: [],
+  workers: [{ name: "reviewer" }, { name: "drafter" }],
+  workTypes: [
+    {
+      name: "story",
+      states: [
+        { name: "queued", type: "INITIAL" as const },
+        { name: "done", type: "TERMINAL" as const },
+      ],
+    },
+  ],
+  workstations: [
+    {
+      inputs: [],
+      name: "review",
+      onFailure: [{ state: "queued", workType: "story" }],
+      outputs: [{ state: "done", workType: "story" }],
+      worker: "reviewer",
+    },
+    {
+      inputs: [{ state: "done", workType: "story" }],
+      name: "draft",
+      outputs: [],
+      worker: "drafter",
+    },
+  ],
+} satisfies CanonicalFactoryDefinition;
+
+const topology = buildFactoryGraphTopologyFromDefinition(
+  workstationChainFactory,
+);
+
+describe("synthesizeWorkStateVisibilityBypassEdges", () => {
+  it("connects producing workstations to consuming workstations through a hidden state", () => {
+    const hiddenWorkStateIds = new Set(["work-state:story:done"]);
+    const visibleNodeIds = new Set(
+      topology.nodes
+        .filter((node) => node.kind !== "work-state")
+        .map((node) => node.id),
+    );
+
+    const bypassEdges = synthesizeWorkStateVisibilityBypassEdges(
+      topology,
+      hiddenWorkStateIds,
+      visibleNodeIds,
+    );
+
+    expect(bypassEdges).toEqual([
+      expect.objectContaining({
+        id: "work-state-visibility-bypass:workstation-output:review->draft:via-work-state:story:done",
+        kind: "work-state-visibility-bypass",
+        outcomeRouteKind: "workstation-output",
+        sourceId: "workstation:review",
+        targetId: "workstation:draft",
+      }),
+    ]);
+  });
+
+  it("fans out bypass edges for multiple producers and consumers of the same hidden state", () => {
+    const fanOutFactory = {
+      ...workstationChainFactory,
+      workstations: [
+        {
+          inputs: [],
+          name: "review-a",
+          outputs: [{ state: "queued", workType: "story" }],
+          worker: "reviewer",
+        },
+        {
+          inputs: [],
+          name: "review-b",
+          outputs: [{ state: "queued", workType: "story" }],
+          worker: "reviewer",
+        },
+        {
+          inputs: [{ state: "queued", workType: "story" }],
+          name: "draft-a",
+          outputs: [],
+          worker: "drafter",
+        },
+        {
+          inputs: [{ state: "queued", workType: "story" }],
+          name: "draft-b",
+          outputs: [],
+          worker: "drafter",
+        },
+      ],
+    } satisfies CanonicalFactoryDefinition;
+    const fanOutTopology =
+      buildFactoryGraphTopologyFromDefinition(fanOutFactory);
+    const hiddenWorkStateIds = new Set(["work-state:story:queued"]);
+    const visibleNodeIds = new Set(
+      fanOutTopology.nodes
+        .filter((node) => node.kind !== "work-state")
+        .map((node) => node.id),
+    );
+
+    const bypassEdges = synthesizeWorkStateVisibilityBypassEdges(
+      fanOutTopology,
+      hiddenWorkStateIds,
+      visibleNodeIds,
+    );
+
+    expect(bypassEdges).toHaveLength(4);
+    expect(bypassEdges.map((edge) => edge.id).sort()).toEqual(
+      [
+        "work-state-visibility-bypass:workstation-output:review-a->draft-a:via-work-state:story:queued",
+        "work-state-visibility-bypass:workstation-output:review-a->draft-b:via-work-state:story:queued",
+        "work-state-visibility-bypass:workstation-output:review-b->draft-a:via-work-state:story:queued",
+        "work-state-visibility-bypass:workstation-output:review-b->draft-b:via-work-state:story:queued",
+      ].sort(),
+    );
+  });
+
+  it("preserves outcome route metadata for non-success producer routes", () => {
+    const failureTopology = buildFactoryGraphTopologyFromDefinition({
+      ...workstationChainFactory,
+      workstations: [
+        {
+          inputs: [],
+          name: "review",
+          onFailure: [{ state: "queued", workType: "story" }],
+          outputs: [],
+          worker: "reviewer",
+        },
+        {
+          inputs: [{ state: "queued", workType: "story" }],
+          name: "draft",
+          outputs: [],
+          worker: "drafter",
+        },
+      ],
+    });
+    const hiddenWorkStateIds = new Set(["work-state:story:queued"]);
+    const visibleNodeIds = new Set(
+      failureTopology.nodes
+        .filter((node) => node.kind !== "work-state")
+        .map((node) => node.id),
+    );
+
+    const bypassEdges = synthesizeWorkStateVisibilityBypassEdges(
+      failureTopology,
+      hiddenWorkStateIds,
+      visibleNodeIds,
+    );
+
+    expect(bypassEdges).toEqual([
+      expect.objectContaining({
+        outcomeRouteKind: "workstation-on-failure",
+        sourceId: "workstation:review",
+        targetId: "workstation:draft",
+      }),
+    ]);
+  });
+});
+
+describe("projectFactoryGraphByHiddenNodeClasses work-state bypass", () => {
+  it("adds bypass edges when work states are hidden and removes them when shown", () => {
+    const hidden = projectFactoryGraphByHiddenNodeClasses(
+      topology,
+      new Set(["work-state"]),
+    );
+    const visible = projectFactoryGraphByHiddenNodeClasses(topology, new Set());
+
+    expect(hidden.nodes.some((node) => node.kind === "work-state")).toBe(false);
+    expect(
+      hidden.edges.some(
+        (edge) => edge.kind === "work-state-visibility-bypass",
+      ),
+    ).toBe(true);
+    expect(
+      hidden.edges.some(
+        (edge) =>
+          edge.kind !== "work-state-visibility-bypass" &&
+          (edge.sourceId === "work-state:story:done" ||
+            edge.targetId === "work-state:story:done"),
+      ),
+    ).toBe(false);
+    expect(
+      visible.edges.some(
+        (edge) => edge.kind === "work-state-visibility-bypass",
+      ),
+    ).toBe(false);
+    expect(
+      visible.edges.some(
+        (edge) =>
+          edge.kind === "workstation-output" &&
+          edge.targetId === "work-state:story:done",
+      ),
+    ).toBe(true);
+  });
+});

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-work-state-visibility-bypass.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-work-state-visibility-bypass.ts
@@ -1,0 +1,165 @@
+import type {
+  FactoryGraphEdge,
+  FactoryGraphEdgeKind,
+  FactoryGraphNode,
+  FactoryGraphNodeReference,
+  FactoryGraphTopology,
+  WorkstationToWorkStateRouteKind,
+} from "./factory-graph-draft-types";
+import { buildEdge } from "./factory-graph-draft-types";
+
+const WORKSTATION_OUTPUT_ROUTE_KINDS = [
+  "workstation-output",
+  "workstation-on-continue",
+  "workstation-on-failure",
+  "workstation-on-rejection",
+] as const satisfies readonly WorkstationToWorkStateRouteKind[];
+
+export type FactoryGraphVisibilityBypassEdge = FactoryGraphEdge & {
+  kind: "work-state-visibility-bypass";
+  outcomeRouteKind: WorkstationToWorkStateRouteKind;
+};
+
+export function synthesizeWorkStateVisibilityBypassEdges(
+  topology: FactoryGraphTopology,
+  hiddenWorkStateNodeIds: ReadonlySet<string>,
+  visibleNodeIds: ReadonlySet<string>,
+): FactoryGraphVisibilityBypassEdge[] {
+  if (hiddenWorkStateNodeIds.size === 0) {
+    return [];
+  }
+
+  const nodesById = new Map(topology.nodes.map((node) => [node.id, node]));
+  const bypassEdges: FactoryGraphVisibilityBypassEdge[] = [];
+  const seenBypassIds = new Set<string>();
+
+  for (const workStateId of hiddenWorkStateNodeIds) {
+    const producers = collectWorkstationProducersForState(
+      topology.edges,
+      workStateId,
+    );
+    const consumers = collectWorkstationConsumersForState(
+      topology.edges,
+      workStateId,
+    );
+
+    for (const producer of producers) {
+      for (const consumer of consumers) {
+        if (
+          !visibleNodeIds.has(producer.workstationId) ||
+          !visibleNodeIds.has(consumer.workstationId)
+        ) {
+          continue;
+        }
+
+        const bypass = buildWorkStateVisibilityBypassEdge({
+          consumer,
+          nodesById,
+          producer,
+          workStateId,
+        });
+        if (seenBypassIds.has(bypass.id)) {
+          continue;
+        }
+        seenBypassIds.add(bypass.id);
+        bypassEdges.push(bypass);
+      }
+    }
+  }
+
+  return bypassEdges.sort((left, right) => left.id.localeCompare(right.id));
+}
+
+function collectWorkstationProducersForState(
+  edges: readonly FactoryGraphEdge[],
+  workStateId: string,
+) {
+  const producers: Array<{
+    outcomeRouteKind: WorkstationToWorkStateRouteKind;
+    workstationId: string;
+  }> = [];
+
+  for (const edge of edges) {
+    if (edge.targetId !== workStateId) {
+      continue;
+    }
+    if (!isWorkstationToWorkStateRouteKind(edge.kind)) {
+      continue;
+    }
+    producers.push({
+      outcomeRouteKind: edge.kind,
+      workstationId: edge.sourceId,
+    });
+  }
+
+  return producers;
+}
+
+function collectWorkstationConsumersForState(
+  edges: readonly FactoryGraphEdge[],
+  workStateId: string,
+) {
+  const consumers: Array<{ workstationId: string }> = [];
+
+  for (const edge of edges) {
+    if (edge.sourceId !== workStateId || edge.kind !== "workstation-input") {
+      continue;
+    }
+    consumers.push({ workstationId: edge.targetId });
+  }
+
+  return consumers;
+}
+
+function buildWorkStateVisibilityBypassEdge(input: {
+  consumer: { workstationId: string };
+  nodesById: ReadonlyMap<string, FactoryGraphNode>;
+  producer: {
+    outcomeRouteKind: WorkstationToWorkStateRouteKind;
+    workstationId: string;
+  };
+  workStateId: string;
+}): FactoryGraphVisibilityBypassEdge {
+  const source = workstationReference(
+    input.nodesById,
+    input.producer.workstationId,
+  );
+  const target = workstationReference(
+    input.nodesById,
+    input.consumer.workstationId,
+  );
+  const edge = buildEdge(
+    "work-state-visibility-bypass",
+    source,
+    target,
+  ) as FactoryGraphVisibilityBypassEdge;
+
+  return {
+    ...edge,
+    id: [
+      "work-state-visibility-bypass",
+      input.producer.outcomeRouteKind,
+      `${source.name}->${target.name}`,
+      `via-${input.workStateId}`,
+    ].join(":"),
+    outcomeRouteKind: input.producer.outcomeRouteKind,
+  };
+}
+
+function workstationReference(
+  nodesById: ReadonlyMap<string, FactoryGraphNode>,
+  workstationId: string,
+): FactoryGraphNodeReference {
+  const node = nodesById.get(workstationId);
+  if (!node || node.key.kind !== "workstation") {
+    throw new Error(`Expected workstation node ${workstationId}`);
+  }
+
+  return node.key;
+}
+
+function isWorkstationToWorkStateRouteKind(
+  kind: FactoryGraphEdgeKind,
+): kind is WorkstationToWorkStateRouteKind {
+  return (WORKSTATION_OUTPUT_ROUTE_KINDS as readonly string[]).includes(kind);
+}

--- a/ui/src/features/factory-graph-editor/messages/editor.test.ts
+++ b/ui/src/features/factory-graph-editor/messages/editor.test.ts
@@ -138,6 +138,10 @@ describe("getFactoryGraphEditorMessages", () => {
     expect(messages.kindLabel("workstation")).toBe("工作站");
     expect(messages.kindLabel("work-type")).toBe("工作类型");
     expect(messages.kindLabel("work-state")).toBe("工作状态");
+    expect(messages.toolbarOpenHideShowMenuLabel).toBe("打开隐藏或显示节点类别菜单");
+    expect(messages.nodeClassVisibilityDescription("work-state")).toBe(
+      "在图上显示工作状态节点。",
+    );
     expect(messages.visibilityPresetAllLabel).toBe("全部");
     expect(messages.visibilityPresetWorkflowLabel).toBe("工作流");
     expect(messages.visibilityPresetExecutionLabel).toBe("执行");

--- a/ui/src/features/factory-graph-editor/messages/editor.ts
+++ b/ui/src/features/factory-graph-editor/messages/editor.ts
@@ -116,7 +116,14 @@ export interface FactoryGraphEditorMessages {
   toolbarConnectLabel: string;
   toolbarDeleteDescription: string;
   toolbarDeleteLabel: string;
+  toolbarHideShowDescription: string;
+  toolbarHideShowLabel: string;
+  toolbarHideShowMenuAriaLabel: string;
+  toolbarHideShowMenuDescription: string;
+  toolbarHideShowMenuTitle: string;
   toolbarOpenAddMenuLabel: string;
+  toolbarOpenHideShowMenuLabel: string;
+  nodeClassVisibilityDescription: (kind: FactoryGraphNodeKind) => string;
   toolbarVisibilityMenuAriaLabel: string;
   toolbarVisibilityMenuDescription: string;
   toolbarVisibilityMenuTitle: string;
@@ -212,6 +219,10 @@ function describeEnglishKind(kind: FactoryGraphNodeKind) {
     case "work-state":
       return "Work state";
   }
+}
+
+function describeEnglishNodeClassVisibility(kind: FactoryGraphNodeKind) {
+  return `Show ${describeEnglishKind(kind).toLowerCase()} nodes on the graph.`;
 }
 
 function describeEnglishWorkerStatus(status: FactoryGraphWorkerRuntimeStatus) {
@@ -526,7 +537,15 @@ const factoryGraphEditorMessagesByLocale: LocalizedMessageCatalog<FactoryGraphEd
       toolbarConnectLabel: "Connect",
       toolbarDeleteDescription: "Remove nodes or edges from the draft",
       toolbarDeleteLabel: "Delete",
+      toolbarHideShowDescription: "Show or hide node classes on the graph",
+      toolbarHideShowLabel: "Hide or show",
+      toolbarHideShowMenuAriaLabel: "Factory graph node class visibility menu",
+      toolbarHideShowMenuDescription:
+        "Toggle which node classes appear on the graph. Hidden classes stay out of the view until you show them again.",
+      toolbarHideShowMenuTitle: "Hide or show node classes",
       toolbarOpenAddMenuLabel: "Open add entity menu",
+      toolbarOpenHideShowMenuLabel: "Open hide or show node classes menu",
+      nodeClassVisibilityDescription: describeEnglishNodeClassVisibility,
       toolbarVisibilityMenuAriaLabel: "Add graph entity menu",
       toolbarVisibilityMenuDescription:
         "Choose a supported entity to add to the current draft.",
@@ -903,7 +922,18 @@ const factoryGraphEditorMessagesByLocale: LocalizedMessageCatalog<FactoryGraphEd
       toolbarConnectLabel: "连接",
       toolbarDeleteDescription: "从草稿中移除节点或边",
       toolbarDeleteLabel: "删除",
+      toolbarHideShowDescription: "在图上显示或隐藏节点类别",
+      toolbarHideShowLabel: "隐藏或显示",
+      toolbarHideShowMenuAriaLabel: "工厂图节点类别可见性菜单",
+      toolbarHideShowMenuDescription:
+        "切换哪些节点类别显示在图上。隐藏的类别会保持不可见，直到你再次显示它们。",
+      toolbarHideShowMenuTitle: "隐藏或显示节点类别",
       toolbarOpenAddMenuLabel: "打开添加实体菜单",
+      toolbarOpenHideShowMenuLabel: "打开隐藏或显示节点类别菜单",
+      nodeClassVisibilityDescription: (kind) => {
+        const label = getFactoryGraphEditorMessages("zh-CN").kindLabel(kind);
+        return `在图上显示${label}节点。`;
+      },
       toolbarVisibilityMenuAriaLabel: "添加图实体菜单",
       toolbarVisibilityMenuDescription: "选择要添加到当前草稿的受支持实体。",
       toolbarVisibilityMenuTitle: "添加图实体",

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-surface.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-surface.test.tsx
@@ -117,6 +117,8 @@ function createEditorStub(overrides: Record<string, unknown> = {}) {
     handleEditorConnect: vi.fn(),
     handleEditorEdgeDelete: vi.fn(),
     handleEditorNodeDelete: vi.fn(),
+    hiddenNodeClasses: new Set(),
+    hideShowMenuOpen: false,
     hasActiveWork: true,
     isStaleDraft: true,
     saveBlockedReason: "Stop active work before saving this draft.",
@@ -126,7 +128,9 @@ function createEditorStub(overrides: Record<string, unknown> = {}) {
     },
     setActiveTool: vi.fn(),
     setAddMenuOpen: vi.fn(),
+    setHideShowMenuOpen: vi.fn(),
     setIsConfirmingSave: vi.fn(),
+    toggleHiddenNodeClass: vi.fn(),
     ...overrides,
   };
 }

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-surface.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-surface.tsx
@@ -175,6 +175,10 @@ export function CurrentActivityGraphSurface({
         nodes={graph.nodes}
         onAddAction={editor.handleAddEntityAction}
         onAddMenuOpenChange={editor.setAddMenuOpen}
+        hiddenNodeClasses={editor.hiddenNodeClasses}
+        hideShowMenuOpen={editor.hideShowMenuOpen}
+        onHideShowMenuOpenChange={editor.setHideShowMenuOpen}
+        onToggleHiddenNodeClass={editor.toggleHiddenNodeClass}
         onConnect={editor.handleEditorConnect}
         onEditorEdgeClick={editor.handleEditorEdgeDelete}
         onEditorNodeClick={editor.handleEditorNodeDelete}

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport-errors.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport-errors.test.tsx
@@ -279,12 +279,16 @@ function renderViewport({
       handleNodesChange={vi.fn()}
       handleSaveDraft={vi.fn()}
       hasPendingChanges={false}
+      hiddenNodeClasses={new Set()}
+      hideShowMenuOpen={false}
       headingID="test-heading"
       imports={importController}
       initialFitViewKey="full-graph"
       initialFitViewOptions={{ padding: 0.18 }}
       nodeTypes={{}}
       nodes={nodes}
+      onHideShowMenuOpenChange={vi.fn()}
+      onToggleHiddenNodeClass={vi.fn()}
       onSelectTool={vi.fn()}
       setStoredNodePosition={vi.fn()}
     />,

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.test.tsx
@@ -66,6 +66,19 @@ const importController: CurrentActivityImportController = {
 
 // biome-ignore lint/complexity/noExcessiveLinesPerFunction: viewport coverage keeps related mocked React Flow click paths together.
 describe("CurrentActivityGraphViewport", () => {
+  it("renders hide/show controls in observer mode without editor tools", () => {
+    renderViewport({ editorMode: false });
+
+    expect(
+      screen.getByRole("button", {
+        name: "Open hide or show node classes menu",
+      }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Open add entity menu" }),
+    ).toBeNull();
+  });
+
   it.each([{ editorMode: false }, { editorMode: true }])(
     "does not render the top-right work-state phase legend when editorMode is $editorMode",
     ({ editorMode }) => {
@@ -290,6 +303,8 @@ function renderViewport({
       handleNodesChange={vi.fn()}
       handleSaveDraft={vi.fn()}
       hasPendingChanges={false}
+      hiddenNodeClasses={new Set()}
+      hideShowMenuOpen={false}
       headingID="test-heading"
       imports={importController}
       initialFitViewKey="full-graph"
@@ -298,6 +313,8 @@ function renderViewport({
       nodes={nodes}
       onEditorEdgeClick={onEditorEdgeClick}
       onEditorNodeClick={onEditorNodeClick}
+      onHideShowMenuOpenChange={vi.fn()}
+      onToggleHiddenNodeClass={vi.fn()}
       onSelectTool={vi.fn()}
       setStoredNodePosition={vi.fn()}
     />,

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
@@ -47,11 +47,15 @@ function CurrentActivityGraphEditorChrome(props: {
   handleDiscardPendingChanges: () => void;
   handleSaveDraft: () => void;
   hasPendingChanges: boolean;
+  hiddenNodeClasses: ReadonlySet<FactoryGraphNodeKind>;
+  hideShowMenuOpen: boolean;
   isSavingDraft?: boolean;
   locale?: string;
   onAddAction?: (actionID: string) => void;
   onAddMenuOpenChange?: (open: boolean) => void;
+  onHideShowMenuOpenChange: (open: boolean) => void;
   onSelectTool: (tool: "add" | "connect" | "delete" | null) => void;
+  onToggleHiddenNodeClass: (kind: FactoryGraphNodeKind) => void;
   openAddMenu?: boolean;
   saveDisabledReason?: string;
 }) {
@@ -63,13 +67,18 @@ function CurrentActivityGraphEditorChrome(props: {
       canInteract={props.canInteractWithEditor}
       canSave={props.canSaveDraft}
       hasPendingChanges={props.hasPendingChanges}
+      hiddenNodeClasses={props.hiddenNodeClasses}
+      hideShowMenuOpen={props.hideShowMenuOpen}
+      hideShowVisible={true}
       isSaving={props.isSavingDraft}
       locale={props.locale}
       onAddAction={props.onAddAction}
       onAddMenuOpenChange={props.onAddMenuOpenChange}
       onDiscard={props.handleDiscardPendingChanges}
+      onHideShowMenuOpenChange={props.onHideShowMenuOpenChange}
       onSave={props.handleSaveDraft}
       onSelectTool={props.onSelectTool}
+      onToggleHiddenNodeClass={props.onToggleHiddenNodeClass}
       openAddMenu={props.openAddMenu}
       saveDisabledReason={props.saveDisabledReason}
       visible={props.editorMode}
@@ -155,6 +164,8 @@ export function CurrentActivityGraphViewport({
   canSaveDraft,
   handleDiscardPendingChanges,
   handleSaveDraft,
+  hiddenNodeClasses,
+  hideShowMenuOpen,
   editorMode,
   edges,
   graphKey,
@@ -171,6 +182,8 @@ export function CurrentActivityGraphViewport({
   nodes,
   onAddAction,
   onAddMenuOpenChange,
+  onHideShowMenuOpenChange,
+  onToggleHiddenNodeClass,
   onConnect,
   onEditorEdgeClick,
   onEditorNodeClick,
@@ -187,6 +200,8 @@ export function CurrentActivityGraphViewport({
   canSaveDraft: boolean;
   handleDiscardPendingChanges: () => void;
   handleSaveDraft: () => void;
+  hiddenNodeClasses: ReadonlySet<FactoryGraphNodeKind>;
+  hideShowMenuOpen: boolean;
   editorMode: boolean;
   edges: Edge[];
   graphKey: string;
@@ -203,6 +218,8 @@ export function CurrentActivityGraphViewport({
   nodes: Node[];
   onAddAction?: (actionID: string) => void;
   onAddMenuOpenChange?: (open: boolean) => void;
+  onHideShowMenuOpenChange: (open: boolean) => void;
+  onToggleHiddenNodeClass: (kind: FactoryGraphNodeKind) => void;
   onConnect?: (connection: Connection) => void;
   onEditorEdgeClick?: (edgeId: string) => void;
   onEditorNodeClick?: (nodeId: string) => void;
@@ -333,11 +350,15 @@ export function CurrentActivityGraphViewport({
           handleDiscardPendingChanges={handleDiscardPendingChanges}
           handleSaveDraft={handleSaveDraft}
           hasPendingChanges={hasPendingChanges}
+          hiddenNodeClasses={hiddenNodeClasses}
+          hideShowMenuOpen={hideShowMenuOpen}
           isSavingDraft={isSavingDraft}
           locale={locale}
           onAddAction={onAddAction}
           onAddMenuOpenChange={onAddMenuOpenChange}
+          onHideShowMenuOpenChange={onHideShowMenuOpenChange}
           onSelectTool={onSelectTool}
+          onToggleHiddenNodeClass={onToggleHiddenNodeClass}
           openAddMenu={openAddMenu}
           saveDisabledReason={saveDisabledReason}
         />

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card.coverage.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card.coverage.test.tsx
@@ -782,6 +782,8 @@ function renderViewport({
       graphKey={graphKey}
       handleNodesChange={vi.fn()}
       hasPendingChanges={false}
+      hiddenNodeClasses={new Set()}
+      hideShowMenuOpen={false}
       imports={mockImportController}
       initialFitViewKey="full-graph"
       initialFitViewOptions={{ padding: 0.18 }}
@@ -791,6 +793,8 @@ function renderViewport({
       onConnect={onConnect}
       onEditorEdgeClick={onEditorEdgeClick}
       onEditorNodeClick={onEditorNodeClick}
+      onHideShowMenuOpenChange={vi.fn()}
+      onToggleHiddenNodeClass={vi.fn()}
       onSelectTool={vi.fn()}
       setStoredNodePosition={mockSetStoredNodePosition}
     />,

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card.coverage.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card.coverage.test.tsx
@@ -628,6 +628,7 @@ describe("ReactFlowCurrentActivityCard coverage", () => {
         canInteractWithEditor: true,
         draftState: createConnectionDraftState(),
         editableGraph,
+        hiddenNodeClasses: new Set(),
       }),
     );
 
@@ -665,6 +666,7 @@ describe("ReactFlowCurrentActivityCard coverage", () => {
           canInteractWithEditor,
           draftState: createConnectionDraftState(),
           editableGraph,
+          hiddenNodeClasses: new Set(),
         }),
       {
         initialProps: {

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card.test.tsx
@@ -908,8 +908,16 @@ function registerCurrentActivityCardEditorChromeTests(): void {
     expect(
       screen.getByRole("button", { name: "Enter factory graph editor" }),
     ).toBeTruthy();
+    const toolbar = screen.getByRole("region", {
+      name: "Factory graph editor tools",
+    });
     expect(
-      screen.queryByRole("region", { name: "Factory graph editor tools" }),
+      within(toolbar).getByRole("button", {
+        name: "Open hide or show node classes menu",
+      }),
+    ).toBeTruthy();
+    expect(
+      within(toolbar).queryByRole("button", { name: "Open add entity menu" }),
     ).toBeNull();
     expect(screen.getByText("Observe mode")).toBeTruthy();
   });
@@ -981,12 +989,18 @@ function registerCurrentActivityCardEditorChromeTests(): void {
 
     fireEvent.click(enterEditorButton);
 
-    await waitFor(() => {
-      expect(
-        screen.queryByRole("region", { name: "Factory graph editor tools" }),
-      ).toBeNull();
+    const toolbar = screen.getByRole("region", {
+      name: "Factory graph editor tools",
     });
-    expect(screen.queryByText("Observe mode")).toBeNull();
+    expect(
+      within(toolbar).getByRole("button", {
+        name: "Open hide or show node classes menu",
+      }),
+    ).toBeTruthy();
+    expect(
+      within(toolbar).queryByRole("button", { name: "Open add entity menu" }),
+    ).toBeNull();
+    expect(screen.queryByText("Editor mode active")).toBeNull();
   });
 
   it("lists the supported add-entity options and validates duplicate worker names before mutating the draft", async () => {

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor-connections.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor-connections.ts
@@ -8,6 +8,7 @@ import {
   useState,
 } from "react";
 import type { FactoryGraphEditorTool } from "../../factory-graph-editor/components/factory-graph-editor-controls";
+import type { FactoryGraphNodeKind } from "../../factory-graph-editor/lib/factory-graph-draft-types";
 import { getFactoryGraphEditorMessages } from "../../factory-graph-editor/messages/editor";
 import {
   createFactoryGraphWorkstationResolver,
@@ -35,6 +36,7 @@ function handleFactoryGraphConnectionAnchorClick(
     commitConnection,
     draftNodes,
     locale,
+    hiddenNodeClasses,
     pendingConnectionSource,
     setConnectionNotice,
     setPendingConnectionSource,
@@ -44,6 +46,7 @@ function handleFactoryGraphConnectionAnchorClick(
     canInteractWithEditor: boolean;
     commitConnection: FactoryGraphConnectionCommit;
     draftNodes: EditableFactoryGraphViewModel["draftState"]["graph"]["nodes"];
+    hiddenNodeClasses: ReadonlySet<FactoryGraphNodeKind>;
     locale?: string | null;
     pendingConnectionSource: FactoryGraphConnectionEndpoint | null;
     setConnectionNotice: (notice: string | null) => void;
@@ -58,7 +61,7 @@ function handleFactoryGraphConnectionAnchorClick(
   }
 
   const node = draftNodes.find((entry) => entry.id === endpoint.nodeId);
-  if (!node) {
+  if (!node || hiddenNodeClasses.has(node.kind)) {
     return;
   }
 
@@ -106,12 +109,14 @@ export function useFactoryGraphConnectionController({
   canInteractWithEditor,
   draftState,
   editableGraph,
+  hiddenNodeClasses,
   locale,
 }: {
   activeTool: FactoryGraphEditorTool;
   canInteractWithEditor: boolean;
   draftState: EditableFactoryGraphViewModel["draftState"];
   editableGraph: EditableFactoryGraphViewModel;
+  hiddenNodeClasses: ReadonlySet<FactoryGraphNodeKind>;
   locale?: string | null;
 }) {
   const [connectionNotice, setConnectionNotice] = useState<string | null>(null);
@@ -162,6 +167,20 @@ export function useFactoryGraphConnectionController({
       ) {
         return;
       }
+
+      const sourceNode = draftState.graph.nodes.find(
+        (entry) => entry.id === connection.source,
+      );
+      const targetNode = draftState.graph.nodes.find(
+        (entry) => entry.id === connection.target,
+      );
+      if (
+        (sourceNode && hiddenNodeClasses.has(sourceNode.kind)) ||
+        (targetNode && hiddenNodeClasses.has(targetNode.kind))
+      ) {
+        return;
+      }
+
       commitConnection({
         sourceAnchorId: connection.sourceHandle,
         sourceNodeId: connection.source,
@@ -169,7 +188,13 @@ export function useFactoryGraphConnectionController({
         targetNodeId: connection.target,
       });
     },
-    [activeTool, canInteractWithEditor, commitConnection],
+    [
+      activeTool,
+      canInteractWithEditor,
+      commitConnection,
+      draftState.graph.nodes,
+      hiddenNodeClasses,
+    ],
   );
   const handleConnectionAnchorClick = useCallback(
     (endpoint: FactoryGraphConnectionEndpoint) => {
@@ -178,6 +203,7 @@ export function useFactoryGraphConnectionController({
         canInteractWithEditor,
         commitConnection,
         draftNodes: draftState.graph.nodes,
+        hiddenNodeClasses,
         locale,
         pendingConnectionSource,
         setConnectionNotice,
@@ -190,6 +216,7 @@ export function useFactoryGraphConnectionController({
       canInteractWithEditor,
       commitConnection,
       draftState.graph.nodes,
+      hiddenNodeClasses,
       locale,
       pendingConnectionSource,
       workstationResolver,

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor-controllers.test.tsx
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor-controllers.test.tsx
@@ -130,6 +130,7 @@ describe("current activity graph editor controllers", () => {
         canInteractWithEditor: true,
         draftState,
         editableGraph,
+        hiddenNodeClasses: new Set(),
       }),
     );
 
@@ -179,6 +180,7 @@ describe("current activity graph editor controllers", () => {
         canInteractWithEditor: true,
         draftState,
         editableGraph,
+        hiddenNodeClasses: new Set(),
       }),
     );
 
@@ -230,6 +232,7 @@ describe("current activity graph editor controllers", () => {
         canInteractWithEditor: true,
         draftState,
         editableGraph,
+        hiddenNodeClasses: new Set(),
       }),
     );
 
@@ -267,6 +270,7 @@ describe("current activity graph editor controllers", () => {
         canInteractWithEditor: true,
         draftState,
         editableGraph,
+        hiddenNodeClasses: new Set(),
         saveEditableDefinition: {
           reset,
         } as never,
@@ -303,6 +307,7 @@ describe("current activity graph editor controllers", () => {
         canInteractWithEditor: true,
         draftState,
         editableGraph,
+        hiddenNodeClasses: new Set(),
         saveEditableDefinition: {
           reset,
         } as never,
@@ -355,6 +360,7 @@ describe("current activity graph editor controllers", () => {
         canInteractWithEditor: true,
         draftState,
         editableGraph,
+        hiddenNodeClasses: new Set(),
         saveEditableDefinition: {
           reset,
         } as never,
@@ -384,6 +390,7 @@ describe("current activity graph editor controllers", () => {
         canInteractWithEditor: true,
         draftState,
         editableGraph,
+        hiddenNodeClasses: new Set(),
         saveEditableDefinition: {
           reset,
         } as never,
@@ -435,6 +442,7 @@ describe("current activity graph editor controllers", () => {
         canInteractWithEditor: true,
         draftState,
         editableGraph,
+        hiddenNodeClasses: new Set(),
         onNodeRemovedFromDraft,
         saveEditableDefinition: {
           reset,
@@ -489,6 +497,7 @@ describe("current activity graph editor controllers", () => {
         canInteractWithEditor: true,
         draftState,
         editableGraph,
+        hiddenNodeClasses: new Set(),
         saveEditableDefinition: {
           reset,
         } as never,

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor-removals.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor-removals.ts
@@ -2,6 +2,7 @@ import { useCallback, useState } from "react";
 
 import type { EditableFactoryGraphSaveMutation } from "../../factory-graph-editor/hooks/use-editable-factory-graph-types";
 import type { FactoryGraphEditorTool } from "../../factory-graph-editor/components/factory-graph-editor-controls";
+import type { FactoryGraphNodeKind } from "../../factory-graph-editor/lib/factory-graph-draft-types";
 import type { EditableFactoryGraphViewModel } from "../../factory-graph-editor/hooks/use-editable-factory-graph-types";
 import {
   buildFactoryGraphEdgeRemovalIntent,
@@ -14,6 +15,7 @@ export function useFactoryGraphRemovalController({
   canInteractWithEditor,
   draftState,
   editableGraph,
+  hiddenNodeClasses,
   locale,
   onNodeRemovedFromDraft,
   saveEditableDefinition,
@@ -22,6 +24,7 @@ export function useFactoryGraphRemovalController({
   canInteractWithEditor: boolean;
   draftState: EditableFactoryGraphViewModel["draftState"];
   editableGraph: EditableFactoryGraphViewModel;
+  hiddenNodeClasses: ReadonlySet<FactoryGraphNodeKind>;
   locale?: string | null;
   onNodeRemovedFromDraft?: (nodeId: string) => void;
   saveEditableDefinition: EditableFactoryGraphSaveMutation;
@@ -72,6 +75,7 @@ export function useFactoryGraphRemovalController({
     applyConfirmedNodeRemoval,
     canInteractWithEditor,
     draftState,
+    hiddenNodeClasses,
     locale,
     saveEditableDefinition,
     setBlockedRemovalReason,
@@ -163,6 +167,7 @@ function useFactoryGraphNodeRemovalRequest({
   applyConfirmedNodeRemoval,
   canInteractWithEditor,
   draftState,
+  hiddenNodeClasses,
   locale,
   saveEditableDefinition,
   setBlockedRemovalReason,
@@ -172,6 +177,7 @@ function useFactoryGraphNodeRemovalRequest({
   applyConfirmedNodeRemoval: (nodeId: string) => boolean;
   canInteractWithEditor: boolean;
   draftState: EditableFactoryGraphViewModel["draftState"];
+  hiddenNodeClasses: ReadonlySet<FactoryGraphNodeKind>;
   locale?: string | null;
   saveEditableDefinition: EditableFactoryGraphSaveMutation;
   setBlockedRemovalReason: (reason: string | null) => void;
@@ -181,6 +187,11 @@ function useFactoryGraphNodeRemovalRequest({
   return useCallback(
     (nodeId: string) => {
       if (!canInteractWithEditor || !draftState.latestDocument) {
+        return;
+      }
+
+      const node = draftState.graph.nodes.find((entry) => entry.id === nodeId);
+      if (node && hiddenNodeClasses.has(node.kind)) {
         return;
       }
 
@@ -212,7 +223,9 @@ function useFactoryGraphNodeRemovalRequest({
       applyConfirmedNodeRemoval,
       canInteractWithEditor,
       draftState.draft,
+      draftState.graph.nodes,
       draftState.latestDocument,
+      hiddenNodeClasses,
       locale,
       saveEditableDefinition,
       setBlockedRemovalReason,

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor-value.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor-value.ts
@@ -1,7 +1,10 @@
 import type { useCurrentFactoryDocument } from "../../current-factory-definition/hooks/useCurrentFactoryDefinition";
 import type { useFactoryGraphDraftState } from "../../factory-graph-editor/hooks/factory-graph-draft-hook";
 import type { FactoryGraphEditorTool } from "../../factory-graph-editor/components/factory-graph-editor-controls";
-import type { CanonicalFactoryDefinition } from "../../factory-graph-editor/lib/factory-graph-draft-types";
+import type {
+  CanonicalFactoryDefinition,
+  FactoryGraphNodeKind,
+} from "../../factory-graph-editor/lib/factory-graph-draft-types";
 import type { buildFactoryGraphAddEntityMenuActions } from "../../factory-graph-editor/lib/factory-graph-editor-additions";
 import type { buildFactoryGraphSaveSummary } from "../../factory-graph-editor/lib/factory-graph-editor-save-summary";
 import type { FactoryDocumentSaveState } from "../../current-selection/base/public";
@@ -68,6 +71,10 @@ export function buildCurrentActivityGraphEditorValue(args: {
   setPendingRemovalEdgeId: (edgeId: string | null) => void;
   setPendingRemovalNodeId: (nodeId: string | null) => void;
   structuralValidation: ReturnType<typeof useFactoryValidation>;
+  hiddenNodeClasses: ReadonlySet<FactoryGraphNodeKind>;
+  hideShowMenuOpen: boolean;
+  setHideShowMenuOpen: (open: boolean) => void;
+  toggleHiddenNodeClass: (kind: FactoryGraphNodeKind) => void;
 }) {
   return {
     activeTool: args.activeTool,
@@ -123,5 +130,9 @@ export function buildCurrentActivityGraphEditorValue(args: {
     setPendingRemovalEdgeId: args.setPendingRemovalEdgeId,
     setPendingRemovalNodeId: args.setPendingRemovalNodeId,
     structuralValidation: args.structuralValidation,
+    hiddenNodeClasses: args.hiddenNodeClasses,
+    hideShowMenuOpen: args.hideShowMenuOpen,
+    setHideShowMenuOpen: args.setHideShowMenuOpen,
+    toggleHiddenNodeClass: args.toggleHiddenNodeClass,
   };
 }

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor.tsx
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor.tsx
@@ -57,6 +57,7 @@ export function useCurrentActivityGraphEditor(
     currentFactoryDefinition: session.currentFactoryDefinition,
     draftState,
     editableGraph,
+    hiddenNodeClasses,
     locale,
     onNodeRemovedFromDraft,
     saveEditableDefinition,

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor.tsx
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-editor.tsx
@@ -9,6 +9,7 @@ import { buildCurrentActivityGraphEditorValue } from "./react-flow-current-activ
 import { useGraphEditorControllers } from "./use-graph-editor-controllers";
 import { useGraphEditorSaveFlow } from "./use-graph-editor-save-flow";
 import { useGraphEditorSession } from "./use-graph-editor-session";
+import { useHiddenFactoryGraphNodeClasses } from "./use-hidden-factory-graph-node-classes";
 
 // biome-ignore lint/complexity/noExcessiveLinesPerFunction: graph editor hook wires session, controllers, and save flow into one card value model.
 export function useCurrentActivityGraphEditor(
@@ -19,6 +20,12 @@ export function useCurrentActivityGraphEditor(
 ) {
   const [editorMode, setEditorMode] = useState(false);
   const [activeTool, setActiveTool] = useState<FactoryGraphEditorTool>(null);
+  const {
+    hiddenNodeClasses,
+    hideShowMenuOpen,
+    setHideShowMenuOpen,
+    toggleHiddenNodeClass,
+  } = useHiddenFactoryGraphNodeClasses();
   const leaveEditorBridge = useGraphEditorLeaveEditorBridge();
   const { currentFactoryQuery, editableGraph, saveEditableDefinition } =
     useCurrentActivityEditableGraph({
@@ -123,5 +130,9 @@ export function useCurrentActivityGraphEditor(
     setPendingRemovalEdgeId: controllers.setPendingRemovalEdgeId,
     setPendingRemovalNodeId: controllers.setPendingRemovalNodeId,
     structuralValidation,
+    hiddenNodeClasses,
+    hideShowMenuOpen,
+    setHideShowMenuOpen,
+    toggleHiddenNodeClass,
   });
 }

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-layout.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-layout.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 
 import type { DashboardSnapshot } from "../../../api/dashboard/types";
+import type { FactoryGraphNodeKind } from "../../factory-graph-editor/lib/factory-graph-draft-types";
 import type { GraphLayout } from "../../flowchart/lib/layout";
 import { buildCurrentActivityGraphLayoutFromFactory } from "../lib/current-activity-factory-graph-layout";
 import { EMPTY_GRAPH_LAYOUT } from "../lib/react-flow-current-activity-card-graph";
@@ -11,30 +12,41 @@ import {
 
 const GRAPH_LAYOUT_CACHE = createWorkflowTopologyAsyncCache<GraphLayout>();
 
-export function useCurrentActivityGraphLayout(snapshot: DashboardSnapshot) {
-  return useCurrentActivityGraphLayoutForFactory(snapshot);
+export function useCurrentActivityGraphLayout(
+  snapshot: DashboardSnapshot,
+  hiddenNodeClasses: ReadonlySet<FactoryGraphNodeKind> = new Set(),
+) {
+  return useCurrentActivityGraphLayoutForFactory(
+    snapshot,
+    undefined,
+    hiddenNodeClasses,
+  );
 }
 
 export function useCurrentActivityGraphLayoutForFactory(
   snapshot: DashboardSnapshot,
   /** Omit to use `snapshot.factory`; pass `null` to keep an empty layout while the document GET is pending. */
   factoryOverride?: DashboardSnapshot["factory"] | null,
+  hiddenNodeClasses: ReadonlySet<FactoryGraphNodeKind> = new Set(),
 ) {
   const factory =
     factoryOverride === undefined ? snapshot.factory : factoryOverride;
+  const hiddenClassesKey = [...hiddenNodeClasses].sort().join(",");
   const layoutSource = useMemo(
     () =>
       factory
         ? {
             factory,
-            key: currentActivityFactoryKey(factory),
+            hiddenClassesKey,
+            key: `${currentActivityFactoryKey(factory)}|hidden:${hiddenClassesKey}`,
             kind: "factory" as const,
           }
         : {
-            key: "missing-factory",
+            hiddenClassesKey,
+            key: `missing-factory|hidden:${hiddenClassesKey}`,
             kind: "missing-factory" as const,
           },
-    [factory],
+    [factory, hiddenClassesKey],
   );
 
   return useWorkflowTopologyAsyncCache({
@@ -44,7 +56,10 @@ export function useCurrentActivityGraphLayoutForFactory(
     initialValue: EMPTY_GRAPH_LAYOUT,
     loadLayout: () =>
       layoutSource.kind === "factory"
-        ? buildCurrentActivityGraphLayoutFromFactory(layoutSource.factory)
+        ? buildCurrentActivityGraphLayoutFromFactory(
+            layoutSource.factory,
+            hiddenNodeClasses,
+          )
         : Promise.resolve(EMPTY_GRAPH_LAYOUT),
     mapResolvedLayout: identityGraphLayout,
     topologyKey: layoutSource.key,

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
@@ -190,6 +190,7 @@ function useEditorCurrentActivityGraphLayout(
   return useCurrentActivityGraphLayoutForFactory(
     snapshot,
     currentActivityCardFactoryDefinition(editor, snapshot),
+    editor.hiddenNodeClasses,
   );
 }
 

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
@@ -159,7 +159,7 @@ function useActiveGraphHighlights({
 
 export function currentActivityCardFactoryDefinition(
   editor: ReturnType<typeof useCurrentActivityGraphEditor>,
-  snapshot: DashboardSnapshot,
+  _snapshot: DashboardSnapshot,
 ): DashboardSnapshot["factory"] | null | undefined {
   if (!editor.editorMode) {
     return undefined;

--- a/ui/src/features/workflow-activity/hooks/use-graph-editor-controllers.test.ts
+++ b/ui/src/features/workflow-activity/hooks/use-graph-editor-controllers.test.ts
@@ -100,6 +100,7 @@ describe("useGraphEditorControllers", () => {
         currentFactoryDefinition: null,
         draftState: buildEditableGraph().draftState,
         editableGraph: buildEditableGraph(),
+        hiddenNodeClasses: new Set(),
         locale: "en",
         saveEditableDefinition: {
           error: null,

--- a/ui/src/features/workflow-activity/hooks/use-graph-editor-controllers.ts
+++ b/ui/src/features/workflow-activity/hooks/use-graph-editor-controllers.ts
@@ -1,7 +1,10 @@
 import type { EditableFactoryGraphSaveMutation } from "../../factory-graph-editor/hooks/use-editable-factory-graph-types";
 import type { FactoryGraphEditorTool } from "../../factory-graph-editor/components/factory-graph-editor-controls";
 import type { EditableFactoryGraphViewModel } from "../../factory-graph-editor/hooks/use-editable-factory-graph-types";
-import type { CanonicalFactoryDefinition } from "../../factory-graph-editor/lib/factory-graph-draft-types";
+import type {
+  CanonicalFactoryDefinition,
+  FactoryGraphNodeKind,
+} from "../../factory-graph-editor/lib/factory-graph-draft-types";
 import { useFactoryGraphAddEntityController } from "../components/react-flow-current-activity-card-editor-chrome";
 import { useFactoryGraphConnectionController } from "./react-flow-current-activity-card-editor-connections";
 import { useFactoryGraphRemovalController } from "./react-flow-current-activity-card-editor-removals";
@@ -12,6 +15,7 @@ export function useGraphEditorControllers({
   currentFactoryDefinition,
   draftState,
   editableGraph,
+  hiddenNodeClasses,
   locale,
   onNodeRemovedFromDraft,
   saveEditableDefinition,
@@ -22,6 +26,7 @@ export function useGraphEditorControllers({
   currentFactoryDefinition: CanonicalFactoryDefinition | null;
   draftState: EditableFactoryGraphViewModel["draftState"];
   editableGraph: EditableFactoryGraphViewModel;
+  hiddenNodeClasses: ReadonlySet<FactoryGraphNodeKind>;
   locale?: string | null;
   onNodeRemovedFromDraft?: (nodeId: string) => void;
   saveEditableDefinition: EditableFactoryGraphSaveMutation;
@@ -37,6 +42,7 @@ export function useGraphEditorControllers({
     canInteractWithEditor,
     draftState,
     editableGraph,
+    hiddenNodeClasses,
     locale,
   });
   const removalController = useFactoryGraphRemovalController({
@@ -44,6 +50,7 @@ export function useGraphEditorControllers({
     canInteractWithEditor,
     draftState,
     editableGraph,
+    hiddenNodeClasses,
     locale,
     onNodeRemovedFromDraft,
     saveEditableDefinition,

--- a/ui/src/features/workflow-activity/hooks/use-hidden-factory-graph-node-classes.test.ts
+++ b/ui/src/features/workflow-activity/hooks/use-hidden-factory-graph-node-classes.test.ts
@@ -1,0 +1,23 @@
+import { act, renderHook } from "@testing-library/react";
+
+import { useHiddenFactoryGraphNodeClasses } from "./use-hidden-factory-graph-node-classes";
+
+describe("useHiddenFactoryGraphNodeClasses", () => {
+  it("starts with every node class visible and toggles hidden classes", () => {
+    const { result } = renderHook(() => useHiddenFactoryGraphNodeClasses());
+
+    expect(result.current.hiddenNodeClasses.size).toBe(0);
+
+    act(() => {
+      result.current.toggleHiddenNodeClass("work-state");
+    });
+
+    expect(result.current.hiddenNodeClasses.has("work-state")).toBe(true);
+
+    act(() => {
+      result.current.toggleHiddenNodeClass("work-state");
+    });
+
+    expect(result.current.hiddenNodeClasses.has("work-state")).toBe(false);
+  });
+});

--- a/ui/src/features/workflow-activity/hooks/use-hidden-factory-graph-node-classes.ts
+++ b/ui/src/features/workflow-activity/hooks/use-hidden-factory-graph-node-classes.ts
@@ -1,0 +1,29 @@
+import { useCallback, useState } from "react";
+
+import type { FactoryGraphNodeKind } from "../../factory-graph-editor/lib/factory-graph-draft-types";
+
+export function useHiddenFactoryGraphNodeClasses() {
+  const [hiddenNodeClasses, setHiddenNodeClasses] = useState<
+    ReadonlySet<FactoryGraphNodeKind>
+  >(() => new Set());
+  const [hideShowMenuOpen, setHideShowMenuOpen] = useState(false);
+
+  const toggleHiddenNodeClass = useCallback((kind: FactoryGraphNodeKind) => {
+    setHiddenNodeClasses((current) => {
+      const next = new Set(current);
+      if (next.has(kind)) {
+        next.delete(kind);
+      } else {
+        next.add(kind);
+      }
+      return next;
+    });
+  }, []);
+
+  return {
+    hiddenNodeClasses,
+    hideShowMenuOpen,
+    setHideShowMenuOpen,
+    toggleHiddenNodeClass,
+  };
+}

--- a/ui/src/features/workflow-activity/lib/current-activity-factory-graph-layout.ts
+++ b/ui/src/features/workflow-activity/lib/current-activity-factory-graph-layout.ts
@@ -15,6 +15,8 @@ import type {
   FactoryGraphNodeKind,
   FactoryGraphTopology,
 } from "../../factory-graph-editor/lib/factory-graph-draft-types";
+import { projectFactoryGraphByHiddenNodeClasses } from "../../factory-graph-editor/lib/factory-graph-node-class-visibility";
+import { getFactoryGraphEditorMessages } from "../../factory-graph-editor/messages/editor";
 import { buildLayeredGraphLayout } from "../../flowchart/lib/layered-layout";
 import type { GraphLayout, PositionedNode } from "../../flowchart/lib/layout";
 import {
@@ -310,8 +312,16 @@ function stateCategoryForFactoryGraphNode(
 }
 
 function edgeLabelForFactoryGraphEdge(
+  edge: FactoryGraphEdge,
   targetNode: FactoryGraphNode | undefined,
 ) {
+  if (
+    edge.kind === "work-state-visibility-bypass" &&
+    edge.outcomeRouteKind
+  ) {
+    return getFactoryGraphEditorMessages().edgeKindLabel(edge.outcomeRouteKind);
+  }
+
   return targetNode?.kind === "work-state" ? targetNode.label : "";
 }
 
@@ -428,7 +438,7 @@ function seedEdgeFromFactoryGraphEdge(
     edgeId,
     fromNodeId,
     id: edgeId,
-    label: targetResourceName ? "" : edgeLabelForFactoryGraphEdge(targetNode),
+    label: targetResourceName ? "" : edgeLabelForFactoryGraphEdge(edge, targetNode),
     outcomeKind: edgeOutcomeKind(edge),
     sourcePlaceKind: sourceResourceName
       ? "resource"
@@ -546,6 +556,7 @@ export function findFactoryWorkstationByNodeId(
 
 export async function buildCurrentActivityGraphLayoutFromFactory(
   factory: CanonicalFactoryDefinition,
+  hiddenNodeClasses: ReadonlySet<FactoryGraphNodeKind> = new Set(),
 ): Promise<GraphLayout> {
   const nodes = new Map<string, FactoryGraphSeedNode>();
   const edges = new Map<string, FactoryGraphSeedEdge>();
@@ -553,8 +564,11 @@ export async function buildCurrentActivityGraphLayoutFromFactory(
   const categories = stateCategoryByName(normalizedFactory);
   const resourceAvailabilityWorkTypes =
     resourceAvailabilityWorkTypeNames(normalizedFactory);
-  const topology = filterFactoryGraphTopologyForCustomerDisplay(
-    buildFactoryGraphTopologyFromDefinition(normalizedFactory),
+  const topology = projectFactoryGraphByHiddenNodeClasses(
+    filterFactoryGraphTopologyForCustomerDisplay(
+      buildFactoryGraphTopologyFromDefinition(normalizedFactory),
+    ),
+    hiddenNodeClasses,
   );
 
   for (const node of topology.nodes) {

--- a/ui/src/features/workflow-activity/lib/current-activity-factory-graph-layout.ts
+++ b/ui/src/features/workflow-activity/lib/current-activity-factory-graph-layout.ts
@@ -373,6 +373,7 @@ function edgeOutcomeKind(edge: FactoryGraphEdge): DashboardEdgeOutcomeKind {
     case "workstation-output":
     case "workstation-resource":
     case "work-type-state":
+    case "work-state-visibility-bypass":
       return "accepted";
   }
 }

--- a/ui/src/features/workflow-activity/lib/current-activity-factory-graph-node-class-visibility.test.ts
+++ b/ui/src/features/workflow-activity/lib/current-activity-factory-graph-node-class-visibility.test.ts
@@ -1,0 +1,243 @@
+import type { CanonicalFactoryDefinition } from "../../../api/factory-definition";
+import type { DashboardSnapshot } from "../../../api/dashboard/types";
+import { buildGraphEdges } from "./react-flow-current-activity-card-edges";
+import {
+  buildCurrentActivityNodes,
+  buildHandleAssignments,
+  EMPTY_NODE_POSITIONS,
+} from "./react-flow-current-activity-card-graph";
+import { buildCurrentActivityGraphLayoutFromFactory } from "./current-activity-factory-graph-layout";
+
+const workstationChainFactory = {
+  name: "work-state-bypass-activity-fixture",
+  resources: [],
+  workers: [{ name: "reviewer" }, { name: "drafter" }],
+  workTypes: [
+    {
+      name: "story",
+      states: [
+        { name: "queued", type: "INITIAL" as const },
+        { name: "done", type: "TERMINAL" as const },
+      ],
+    },
+  ],
+  workstations: [
+    {
+      inputs: [],
+      name: "review",
+      outputs: [{ state: "done", workType: "story" }],
+      worker: "reviewer",
+    },
+    {
+      inputs: [{ state: "done", workType: "story" }],
+      name: "draft",
+      outputs: [],
+      worker: "drafter",
+    },
+  ],
+} satisfies CanonicalFactoryDefinition;
+
+const resourceFixtureFactory = {
+  ...workstationChainFactory,
+  resources: [{ capacity: 1, name: "gpu" }],
+  workstations: [
+    {
+      ...workstationChainFactory.workstations[0],
+      resources: [{ capacity: 1, name: "gpu" }],
+    },
+    workstationChainFactory.workstations[1],
+  ],
+} satisfies CanonicalFactoryDefinition;
+
+async function expectBypassEdgesRenderWithHandles(
+  hiddenStateLayout: Awaited<
+    ReturnType<typeof buildCurrentActivityGraphLayoutFromFactory>
+  >,
+) {
+  const bypassEdge = hiddenStateLayout.edges.find((edge) =>
+    edge.edgeId.startsWith("work-state-visibility-bypass:"),
+  );
+  expect(bypassEdge).toMatchObject({
+    fromNodeId: "workstation:review",
+    label: "Success route",
+    toNodeId: "workstation:draft",
+  });
+
+  const nodes = buildCurrentActivityNodes({
+    activeExecutionsByWorkstationNodeID: {},
+    activeGraphHighlights: {
+      activeEdgeIds: new Set(),
+      activePlaceNodeIds: new Set(),
+      activeWorkstationNodeIds: new Set(),
+      hasActiveFlow: false,
+      relatedNodeIds: new Set(),
+    },
+    activeItemLabelsByPlaceId: new Map(),
+    editor: {
+      activeTool: null,
+      canInteractWithEditor: false,
+      editorMode: false,
+      onConnectionAnchorClick: () => undefined,
+      pendingConnectionSource: null,
+    },
+    graphLayout: hiddenStateLayout,
+    now: 0,
+    onSelectStateNode: () => undefined,
+    onSelectWorkID: () => undefined,
+    onSelectWorker: () => undefined,
+    onSelectWorkType: () => undefined,
+    onSelectWorkstation: () => undefined,
+    selection: null,
+    snapshot: workstationChainSnapshot(workstationChainFactory),
+    storedNodePositions: EMPTY_NODE_POSITIONS,
+  });
+  const handleAssignments = buildHandleAssignments(
+    hiddenStateLayout.edges,
+    hiddenStateLayout.nodes,
+  );
+  const reactFlowEdges = buildGraphEdges(
+    {
+      activeEdgeIds: new Set(),
+      activePlaceNodeIds: new Set(),
+      activeWorkstationNodeIds: new Set(),
+      hasActiveFlow: false,
+      relatedNodeIds: new Set(),
+    },
+    handleAssignments,
+    new Set(),
+    hiddenStateLayout.edges,
+    nodes,
+  );
+
+  expect(reactFlowEdges).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        id: bypassEdge?.edgeId,
+        source: "workstation:review",
+        sourceHandle: "workstation-output-source",
+        target: "workstation:draft",
+        targetHandle: "workstation-input-target",
+      }),
+    ]),
+  );
+}
+
+function workstationChainSnapshot(
+  factory: CanonicalFactoryDefinition,
+): DashboardSnapshot {
+  return {
+    factory,
+    factory_state: "IDLE",
+    runtime: {
+      active_executions_by_dispatch_id: {},
+      current_work_items_by_place_id: {},
+      place_occupancy_work_items_by_place_id: {},
+      place_token_counts: {},
+      session: {
+        completed_count: 0,
+        dispatched_count: 0,
+        failed_count: 0,
+        has_data: true,
+        provider_sessions: [],
+      },
+      workstation_requests_by_dispatch_id: {},
+    },
+    tick_count: 0,
+    topology: {
+      edges: [],
+      workstation_node_ids: [],
+      workstation_nodes_by_id: {},
+    },
+    uptime_seconds: 0,
+  };
+}
+
+describe("buildCurrentActivityGraphLayoutFromFactory work-state visibility", () => {
+  it("hides work states and renders workstation bypass edges with valid handles", async () => {
+    const visibleLayout = await buildCurrentActivityGraphLayoutFromFactory(
+      workstationChainFactory,
+    );
+    const hiddenStateLayout = await buildCurrentActivityGraphLayoutFromFactory(
+      workstationChainFactory,
+      new Set(["work-state"]),
+    );
+
+    expect(visibleLayout.nodes.map((node) => node.nodeId)).toEqual(
+      expect.arrayContaining([
+        "work-state:story:done",
+        "work-state:story:queued",
+      ]),
+    );
+    expect(hiddenStateLayout.nodes.map((node) => node.nodeId)).not.toEqual(
+      expect.arrayContaining([
+        "work-state:story:done",
+        "work-state:story:queued",
+      ]),
+    );
+
+    await expectBypassEdgesRenderWithHandles(hiddenStateLayout);
+  });
+
+  it("restores state-mediated edges when work states are shown again", async () => {
+    const hiddenStateLayout = await buildCurrentActivityGraphLayoutFromFactory(
+      workstationChainFactory,
+      new Set(["work-state"]),
+    );
+    const visibleLayout = await buildCurrentActivityGraphLayoutFromFactory(
+      workstationChainFactory,
+      new Set(),
+    );
+
+    expect(
+      hiddenStateLayout.edges.some((edge) =>
+        edge.edgeId.startsWith("work-state-visibility-bypass:"),
+      ),
+    ).toBe(true);
+    expect(
+      visibleLayout.edges.some((edge) =>
+        edge.edgeId.startsWith("workstation-output:"),
+      ),
+    ).toBe(true);
+    expect(
+      visibleLayout.edges.some((edge) =>
+        edge.edgeId.startsWith("workstation-input:"),
+      ),
+    ).toBe(true);
+    expect(
+      visibleLayout.edges.some((edge) =>
+        edge.edgeId.startsWith("work-state-visibility-bypass:"),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("buildCurrentActivityGraphLayoutFromFactory non-bypass visibility", () => {
+  it("hides worker or resource classes without synthesizing bypass edges", async () => {
+    const hiddenWorkerLayout = await buildCurrentActivityGraphLayoutFromFactory(
+      resourceFixtureFactory,
+      new Set(["worker"]),
+    );
+    const hiddenResourceLayout =
+      await buildCurrentActivityGraphLayoutFromFactory(
+        resourceFixtureFactory,
+        new Set(["resource"]),
+      );
+
+    expect(hiddenWorkerLayout.nodes.map((node) => node.nodeId)).not.toContain(
+      "worker:reviewer",
+    );
+    expect(
+      hiddenResourceLayout.nodes.map((node) => node.nodeId),
+    ).not.toContain("resource:gpu");
+    expect(
+      hiddenWorkerLayout.edges.some((edge) =>
+        edge.edgeId.startsWith("work-state-visibility-bypass:"),
+      ),
+    ).toBe(false);
+    expect(
+      hiddenResourceLayout.edges.some((edge) =>
+        edge.edgeId.startsWith("work-state-visibility-bypass:"),
+      ),
+    ).toBe(false);
+  });
+});

--- a/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-editor-handles.ts
+++ b/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-editor-handles.ts
@@ -391,7 +391,6 @@ function isWorkstationToWorkStateRouteKind(
   value: string | undefined,
 ): value is WorkstationToWorkStateRouteKind {
   return (
-    value === "workstation-input" ||
     value === "workstation-on-continue" ||
     value === "workstation-on-failure" ||
     value === "workstation-on-rejection" ||
@@ -411,8 +410,6 @@ function visibilityBypassSourceHandleId(
       return "workstation-on-rejection-source";
     case "workstation-output":
       return "workstation-output-source";
-    case "workstation-input":
-      return "workstation-input-source";
   }
 }
 

--- a/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-editor-handles.ts
+++ b/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-editor-handles.ts
@@ -7,6 +7,7 @@ import {
 import type {
   FactoryGraphEdgeKind,
   FactoryGraphNodeKind,
+  WorkstationToWorkStateRouteKind,
 } from "../../factory-graph-editor/lib/factory-graph-draft-types";
 import {
   type FactoryGraphConnectionAnchorContext,
@@ -60,6 +61,18 @@ export function supportedSemanticHandleIdsForEdge(
   );
   if (!edgeKind || !sourceKind || !targetKind) {
     return null;
+  }
+
+  if (edgeKind === "work-state-visibility-bypass") {
+    const outcomeRouteKind = visibilityBypassOutcomeRouteKind(edge.edgeId);
+    if (!outcomeRouteKind) {
+      return null;
+    }
+
+    return {
+      sourceHandleId: visibilityBypassSourceHandleId(outcomeRouteKind),
+      targetHandleId: "workstation-input-target",
+    };
   }
 
   const sourceHandleId = connectionAnchorId(sourceKind, edgeKind, "source");
@@ -356,8 +369,51 @@ function isFactoryGraphEdgeKind(value: string): value is FactoryGraphEdgeKind {
     value === "workstation-on-rejection" ||
     value === "workstation-output" ||
     value === "workstation-resource" ||
+    value === "work-state-visibility-bypass" ||
     value === "work-type-state"
   );
+}
+
+function visibilityBypassOutcomeRouteKind(
+  edgeId: string,
+): WorkstationToWorkStateRouteKind | null {
+  if (!edgeId.startsWith("work-state-visibility-bypass:")) {
+    return null;
+  }
+
+  const outcomeRouteKind = edgeId.split(":")[1];
+  return isWorkstationToWorkStateRouteKind(outcomeRouteKind)
+    ? outcomeRouteKind
+    : null;
+}
+
+function isWorkstationToWorkStateRouteKind(
+  value: string | undefined,
+): value is WorkstationToWorkStateRouteKind {
+  return (
+    value === "workstation-input" ||
+    value === "workstation-on-continue" ||
+    value === "workstation-on-failure" ||
+    value === "workstation-on-rejection" ||
+    value === "workstation-output"
+  );
+}
+
+function visibilityBypassSourceHandleId(
+  outcomeRouteKind: WorkstationToWorkStateRouteKind,
+): string {
+  switch (outcomeRouteKind) {
+    case "workstation-on-continue":
+      return "workstation-on-continue-source";
+    case "workstation-on-failure":
+      return "workstation-on-failure-source";
+    case "workstation-on-rejection":
+      return "workstation-on-rejection-source";
+    case "workstation-output":
+      return "workstation-output-source";
+    case "workstation-input":
+      return "workstation-input-source";
+  }
 }
 
 function connectionAnchorId(

--- a/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-editor-handles.ts
+++ b/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-editor-handles.ts
@@ -365,7 +365,7 @@ function connectionAnchorId(
   edgeKind: FactoryGraphEdgeKind,
   role: "source" | "target",
 ) {
-  if (edgeKind === "work-type-state") {
+  if (edgeKind === "work-type-state" || edgeKind === "work-state-visibility-bypass") {
     return null;
   }
 


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/issues2-graph-hide-show-tool",
  "description": "Add a Hide/Show tool to the factory graph toolbar so customers can toggle visibility of node classes; when work states are hidden, synthesize display-only bypass edges from upstream workstations to downstream consumers while keeping projected edges aligned with rendered handles.",
  "context": {
    "customerAsk": "Add hide/show tool to hide node types. When work states are hidden, edges should connect outward to consuming workstations as if the hidden state were bypassed. Handles must support hidden topology. Toolbar control toggles visibility of configured node classes. Hide/show works with handle/edge filtering rules.",
    "problem": "The workflow graph always renders every node class with no toolbar affordance to toggle class visibility. Naively hiding nodes drops flow edges, and any bypass must stay compatible with React Flow handle-presence filtering to avoid endpoint errors.",
    "solution": "Add session-scoped hidden node-class toggles from a new Hide/Show toolbar tool, project topology through shared class filtering and work-state bypass edge synthesis, then run the existing rendered-handle edge filter before React Flow updates."
  },
  "acceptanceCriteria": [
    "Factory graph toolbar includes a Hide/Show tool with per-class toggles for work type, work state, workstation, worker, and resource",
    "Toggling a class off removes those nodes from the rendered graph without mutating factory topology or draft data",
    "When work states are hidden, upstream workstations connect directly to downstream consuming workstations via display-only bypass edges with valid rendered handles",
    "Post-visibility edges pass rendered-handle filtering; toggling hide/show does not throw React Flow endpoint errors in observer or editor mode",
    "Automated tests cover class filtering, work-state bypass rewiring, and handle-aligned edge projection",
    "UI typecheck, lint, and affected tests pass"
  ],
  "userStories": [
    {
      "id": "issues2-graph-hide-show-tool-001",
      "title": "Project graph topology by hidden node classes",
      "description": "As a developer, I need a pure visibility projection over factory graph topology so node-class hiding is testable and reusable across graph surfaces.",
      "acceptanceCriteria": [
        "Shared helper accepts topology or layout input plus hidden FactoryGraphNodeKind values and returns visible nodes and edges whose endpoints remain visible",
        "Hidden classes include work-type, work-state, workstation, worker, and resource; system-time and empty-worker customer-display omissions remain hidden regardless of toggles",
        "Unit tests cover hiding each class independently and multiple classes together; edges incident on hidden nodes are excluded unless bypass logic applies",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues2-graph-hide-show-tool-002",
      "title": "Rewire edges when work states are hidden",
      "description": "As a factory operator hiding work states, I want upstream workstations to connect directly to downstream consumers so I still see how work moves without intermediate state nodes.",
      "acceptanceCriteria": [
        "When work-state is hidden, projection emits display-only bypass edges from each producing workstation through hidden states to each consuming workstation",
        "Bypass edges use handle ids present on visible workstation nodes such as workstation-output-source and workstation-input-target",
        "Showing work states again removes bypass edges and restores original state-mediated edges",
        "Unit tests use a W to state to W fixture and assert bypass edge endpoints, ids, and outcome label metadata",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues2-graph-hide-show-tool-003",
      "title": "Add Hide/Show toolbar control with per-class toggles",
      "description": "As a factory operator, I want a toolbar Hide/Show tool so I can quickly toggle which node classes appear on the graph.",
      "acceptanceCriteria": [
        "FactoryGraphEditorToolbar includes a Hide/Show button that opens a popover with a toggle per node class; default is all classes visible",
        "Toolbar button uses aria-pressed; menu items expose checked state and localized labels for supported locales",
        "Hide/Show is available in observer and editor modes without blocking other toolbar tools",
        "Component tests assert keyboard reachability, toggle callbacks, and accessible names",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill: open Hide/Show menu, hide work states, confirm checked state and toolbar semantics"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues2-graph-hide-show-tool-004",
      "title": "Apply visibility projection to workflow graph rendering with handle filtering",
      "description": "As a factory operator, I want hide/show changes to immediately update the workflow graph without React Flow errors or stale edges.",
      "acceptanceCriteria": [
        "Workflow Activity graph projection pipes layout through hidden-class filtering and work-state bypass before building React Flow nodes and edges",
        "filterGraphEdgesForRenderedHandles or filterEdgesToRenderedHandles runs on the post-visibility edge set",
        "Toggling hidden classes in observer and editor modes does not throw CurrentActivityGraphEndpointError 008",
        "Connect, delete, and add tools ignore hidden nodes; showing a class restores interaction",
        "Integration tests cover hide work-state with bypass visible, show work-state restores original edges, and hide worker or resource without bypass",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill: hide work states on a workstation-state-workstation chain and confirm direct edges; show work states and confirm nodes return"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)