### PR TITLE
dedupe-valid-work-state-type-validation

### DIFF
--- a/pkg/api/handlers_work_read.go
+++ b/pkg/api/handlers_work_read.go
@@ -19,6 +19,7 @@ import (
 
 	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
 	"github.com/portpowered/infinite-you/pkg/apisurface"
+	"github.com/portpowered/infinite-you/pkg/workquery"
 	"github.com/portpowered/infinite-you/pkg/factory/state"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/materialize"
@@ -72,7 +73,7 @@ func (s *Server) listWork(
 	params factoryapi.ListWorkParams,
 	loadSnapshot func(context.Context) (*interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], error),
 ) {
-	if params.StateType != nil && !validWorkStateType(factoryapi.WorkStateType(*params.StateType)) {
+	if params.StateType != nil && !workquery.ValidWorkStateType(factoryapi.WorkStateType(*params.StateType)) {
 		s.writeError(w, http.StatusBadRequest, "state.type must be one of INITIAL, PROCESSING, TERMINAL, or FAILED", "BAD_REQUEST")
 		return
 	}
@@ -139,18 +140,6 @@ func (s *Server) listWork(
 	}
 
 	s.writeJSON(w, http.StatusOK, resp)
-}
-
-func validWorkStateType(stateType factoryapi.WorkStateType) bool {
-	switch stateType {
-	case factoryapi.WorkStateTypeINITIAL,
-		factoryapi.WorkStateTypePROCESSING,
-		factoryapi.WorkStateTypeTERMINAL,
-		factoryapi.WorkStateTypeFAILED:
-		return true
-	default:
-		return false
-	}
 }
 
 type listWorkItem struct {

--- a/pkg/cli/work/list.go
+++ b/pkg/cli/work/list.go
@@ -15,6 +15,7 @@ import (
 
 	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
 	"github.com/portpowered/infinite-you/pkg/cli/clidiag"
+	"github.com/portpowered/infinite-you/pkg/workquery"
 	"github.com/portpowered/infinite-you/pkg/cli/clihttp"
 	"github.com/portpowered/infinite-you/pkg/cli/cliserver"
 	"github.com/portpowered/infinite-you/pkg/cli/sessionpath"
@@ -111,7 +112,7 @@ func List(cfg ListConfig) error {
 }
 
 func validateListConfig(cfg ListConfig) error {
-	if cfg.StateType != "" && !validWorkStateType(cfg.StateType) {
+	if cfg.StateType != "" && !workquery.ValidWorkStateType(factoryapi.WorkStateType(cfg.StateType)) {
 		return fmt.Errorf("--state-type must be one of INITIAL, PROCESSING, TERMINAL, or FAILED")
 	}
 	if cfg.SortBy != "" && cfg.SortBy != string(factoryapi.SortByStateType) {
@@ -258,17 +259,6 @@ func formatRelationSummary(relation factoryapi.Relation) string {
 	return builder.String()
 }
 
-func validWorkStateType(stateType string) bool {
-	switch factoryapi.WorkStateType(stateType) {
-	case factoryapi.WorkStateTypeINITIAL,
-		factoryapi.WorkStateTypePROCESSING,
-		factoryapi.WorkStateTypeTERMINAL,
-		factoryapi.WorkStateTypeFAILED:
-		return true
-	default:
-		return false
-	}
-}
 
 func stringValue(value *string) string {
 	if value == nil {

--- a/pkg/workquery/state_type.go
+++ b/pkg/workquery/state_type.go
@@ -1,0 +1,16 @@
+package workquery
+
+import factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
+
+// ValidWorkStateType reports whether stateType is an allowed work-list state.type filter.
+func ValidWorkStateType(stateType factoryapi.WorkStateType) bool {
+	switch stateType {
+	case factoryapi.WorkStateTypeINITIAL,
+		factoryapi.WorkStateTypePROCESSING,
+		factoryapi.WorkStateTypeTERMINAL,
+		factoryapi.WorkStateTypeFAILED:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/workquery/state_type_test.go
+++ b/pkg/workquery/state_type_test.go
@@ -1,0 +1,34 @@
+package workquery
+
+import (
+	"testing"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
+)
+
+func TestValidWorkStateType_AllowedValues(t *testing.T) {
+	t.Parallel()
+
+	allowed := []factoryapi.WorkStateType{
+		factoryapi.WorkStateTypeINITIAL,
+		factoryapi.WorkStateTypePROCESSING,
+		factoryapi.WorkStateTypeTERMINAL,
+		factoryapi.WorkStateTypeFAILED,
+	}
+	for _, stateType := range allowed {
+		t.Run(string(stateType), func(t *testing.T) {
+			t.Parallel()
+			if !ValidWorkStateType(stateType) {
+				t.Fatalf("ValidWorkStateType(%q) = false, want true", stateType)
+			}
+		})
+	}
+}
+
+func TestValidWorkStateType_RejectedValue(t *testing.T) {
+	t.Parallel()
+
+	if ValidWorkStateType(factoryapi.WorkStateType("UNKNOWN")) {
+		t.Fatal("ValidWorkStateType(UNKNOWN) = true, want false")
+	}
+}

--- a/ui/integration/factory-graph-editor-session-switch.integration.test.mjs
+++ b/ui/integration/factory-graph-editor-session-switch.integration.test.mjs
@@ -263,7 +263,11 @@ async function expectEditorModeOff(page) {
       .getByRole("region", { name: "Factory graph editor tools" })
       .count(),
   ).toBe(0);
-  expect(await graphCard.getByText("Unsaved changes").count()).toBe(0);
+  await expect
+    .poll(async () => graphCard.getByText("Unsaved changes").count(), {
+      timeout: uiInteractionTimeoutMs,
+    })
+    .toBe(0);
 }
 
 async function runSessionSwitchClearsDirtyEditorScenario(preview) {

--- a/ui/integration/factory-graph-editor-session-switch.integration.test.mjs
+++ b/ui/integration/factory-graph-editor-session-switch.integration.test.mjs
@@ -258,14 +258,20 @@ async function expectEditorModeOff(page) {
   await graphCard
     .getByRole("button", { name: "Enter factory graph editor" })
     .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+  const toolbar = graphCard.getByRole("region", {
+    name: "Factory graph editor tools",
+  });
   await expect
     .poll(
       async () => {
-        const toolbarCount = await graphCard
-          .getByRole("region", { name: "Factory graph editor tools" })
+        const addMenuCount = await toolbar
+          .getByRole("button", { name: "Open add entity menu" })
           .count();
         const unsavedCount = await graphCard.getByText("Unsaved changes").count();
-        return toolbarCount + unsavedCount;
+        const editorActiveCount = await graphCard
+          .getByText("Editor mode active")
+          .count();
+        return addMenuCount + unsavedCount + editorActiveCount;
       },
       { timeout: uiInteractionTimeoutMs },
     )

--- a/ui/integration/factory-graph-editor-session-switch.integration.test.mjs
+++ b/ui/integration/factory-graph-editor-session-switch.integration.test.mjs
@@ -258,15 +258,17 @@ async function expectEditorModeOff(page) {
   await graphCard
     .getByRole("button", { name: "Enter factory graph editor" })
     .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
-  expect(
-    await graphCard
-      .getByRole("region", { name: "Factory graph editor tools" })
-      .count(),
-  ).toBe(0);
   await expect
-    .poll(async () => graphCard.getByText("Unsaved changes").count(), {
-      timeout: uiInteractionTimeoutMs,
-    })
+    .poll(
+      async () => {
+        const toolbarCount = await graphCard
+          .getByRole("region", { name: "Factory graph editor tools" })
+          .count();
+        const unsavedCount = await graphCard.getByText("Unsaved changes").count();
+        return toolbarCount + unsavedCount;
+      },
+      { timeout: uiInteractionTimeoutMs },
+    )
     .toBe(0);
 }
 

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-draft-types.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-draft-types.ts
@@ -251,6 +251,17 @@ export function edgeChangeId(
   return `${edgeChange.kind}:${nodeKeyId(edgeChange.source)}->${nodeKeyId(edgeChange.target)}`;
 }
 
+export function appendUniqueEdgeChange(
+  edges: FactoryGraphDraftEdgeChange[],
+  edgeChange: FactoryGraphDraftEdgeChange,
+) {
+  const nextEdgeId = edgeChangeId(edgeChange);
+  if (edges.some((entry) => edgeChangeId(entry) === nextEdgeId)) {
+    return edges;
+  }
+  return [...edges, edgeChange];
+}
+
 export function nodeKeyId(key: FactoryGraphNodeKey): string {
   switch (key.kind) {
     case "resource":

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-editor-connections.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-editor-connections.ts
@@ -2,16 +2,17 @@ import type { WorkstationProgressOutcomeRouteContext } from "../../current-facto
 import { workstationSupportsProgressOutcomeRoutes } from "../../current-factory-definition/lib/workstation-progress-outcome-routes";
 import { workstationRequiresWorkerAssignment } from "../../current-factory-definition/lib/workstation-worker-assignment";
 import { getFactoryGraphEditorMessages } from "../messages/editor";
-import type {
-  FactoryGraphDraft,
-  FactoryGraphDraftEdgeChange,
-  FactoryGraphEdge,
-  FactoryGraphNode,
-  FactoryGraphNodeKind,
-  FactoryGraphTopology,
-  FactoryWorkstation,
+import {
+  type FactoryGraphDraft,
+  type FactoryGraphDraftEdgeChange,
+  type FactoryGraphEdge,
+  type FactoryGraphNode,
+  type FactoryGraphNodeKind,
+  type FactoryGraphTopology,
+  type FactoryWorkstation,
+  appendUniqueEdgeChange,
+  edgeChangeId,
 } from "./factory-graph-draft-types";
-import { edgeChangeId } from "./factory-graph-draft-types";
 import { PROGRESS_OUTCOME_SOURCE_ANCHOR_IDS } from "./factory-graph-progress-outcome-connection-anchors";
 
 export {
@@ -471,16 +472,5 @@ export function buildFactoryGraphConnectionNotice(options: {
     messages.connectionAnchorLabel(targetAnchor.id),
     options.targetNode.label,
   );
-}
-
-function appendUniqueEdgeChange(
-  edges: FactoryGraphDraftEdgeChange[],
-  edgeChange: FactoryGraphDraftEdgeChange,
-) {
-  const nextEdgeId = edgeChangeId(edgeChange);
-  if (edges.some((entry) => edgeChangeId(entry) === nextEdgeId)) {
-    return edges;
-  }
-  return [...edges, edgeChange];
 }
 

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
@@ -199,6 +199,42 @@ function useEditorCurrentActivityGraphLayout(
   );
 }
 
+function useSyncedDisplayNodes(baseNodes: CurrentActivityNode[]) {
+  const [nodes, setNodes] = useState<CurrentActivityNode[]>([]);
+
+  useEffect(() => {
+    setNodes((currentNodes) => {
+      const currentPositions = new Map(
+        currentNodes.map((node) => [node.id, node.position]),
+      );
+      return baseNodes.map((node) => ({
+        ...node,
+        position: currentPositions.get(node.id) ?? node.position,
+      }));
+    });
+  }, [baseNodes]);
+
+  const handleNodesChange = useCallback((changes: NodeChange[]) => {
+    setNodes(
+      (currentNodes) =>
+        applyNodeChanges(changes, currentNodes) as CurrentActivityNode[],
+    );
+  }, []);
+
+  const displayNodes = useMemo(() => {
+    const positionOverrides = new Map(
+      nodes.map((node) => [node.id, node.position] as const),
+    );
+
+    return baseNodes.map((node) => ({
+      ...node,
+      position: positionOverrides.get(node.id) ?? node.position,
+    }));
+  }, [baseNodes, nodes]);
+
+  return { displayNodes, handleNodesChange };
+}
+
 export function useCurrentActivityGraphViewModel({
   editor,
   locale,
@@ -269,36 +305,7 @@ export function useCurrentActivityGraphViewModel({
     snapshot,
     storedNodePositions,
   });
-  const [nodes, setNodes] = useState<CurrentActivityNode[]>([]);
-
-  useEffect(() => {
-    setNodes((currentNodes) => {
-      const currentPositions = new Map(
-        currentNodes.map((node) => [node.id, node.position]),
-      );
-      return baseNodes.map((node) => ({
-        ...node,
-        position: currentPositions.get(node.id) ?? node.position,
-      }));
-    });
-  }, [baseNodes]);
-
-  const handleNodesChange = useCallback((changes: NodeChange[]) => {
-    setNodes(
-      (currentNodes) =>
-        applyNodeChanges(changes, currentNodes) as CurrentActivityNode[],
-    );
-  }, []);
-  const displayNodes = useMemo(() => {
-    const positionOverrides = new Map(
-      nodes.map((node) => [node.id, node.position] as const),
-    );
-
-    return baseNodes.map((node) => ({
-      ...node,
-      position: positionOverrides.get(node.id) ?? node.position,
-    }));
-  }, [baseNodes, nodes]);
+  const { displayNodes, handleNodesChange } = useSyncedDisplayNodes(baseNodes);
   const edges = useMemo(
     () =>
       buildGraphEdges(

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
@@ -199,40 +199,48 @@ function useEditorCurrentActivityGraphLayout(
   );
 }
 
-function useSyncedDisplayNodes(baseNodes: CurrentActivityNode[]) {
-  const [nodes, setNodes] = useState<CurrentActivityNode[]>([]);
+function useCurrentActivityGraphEdges({
+  activeGraphHighlights,
+  displayNodes,
+  handleAssignments,
+  pendingAdditionEdgeIds,
+  visibleGraphEdges,
+}: {
+  activeGraphHighlights: ReturnType<typeof buildActiveGraphHighlights>;
+  displayNodes: CurrentActivityNode[];
+  handleAssignments: ReturnType<typeof buildHandleAssignments>;
+  pendingAdditionEdgeIds: ReadonlySet<string>;
+  visibleGraphEdges: GraphLayout["edges"];
+}) {
+  return useMemo(
+    () =>
+      buildGraphEdges(
+        activeGraphHighlights,
+        handleAssignments,
+        pendingAdditionEdgeIds,
+        visibleGraphEdges,
+        displayNodes,
+      ),
+    [
+      activeGraphHighlights,
+      displayNodes,
+      handleAssignments,
+      pendingAdditionEdgeIds,
+      visibleGraphEdges,
+    ],
+  );
+}
 
-  useEffect(() => {
-    setNodes((currentNodes) => {
-      const currentPositions = new Map(
-        currentNodes.map((node) => [node.id, node.position]),
-      );
-      return baseNodes.map((node) => ({
-        ...node,
-        position: currentPositions.get(node.id) ?? node.position,
-      }));
-    });
-  }, [baseNodes]);
-
-  const handleNodesChange = useCallback((changes: NodeChange[]) => {
-    setNodes(
-      (currentNodes) =>
-        applyNodeChanges(changes, currentNodes) as CurrentActivityNode[],
-    );
-  }, []);
-
-  const displayNodes = useMemo(() => {
-    const positionOverrides = new Map(
-      nodes.map((node) => [node.id, node.position] as const),
-    );
-
-    return baseNodes.map((node) => ({
-      ...node,
-      position: positionOverrides.get(node.id) ?? node.position,
-    }));
-  }, [baseNodes, nodes]);
-
-  return { displayNodes, handleNodesChange };
+function useInitialFitViewOptions(graphLayout: GraphLayout) {
+  return useMemo<FitViewOptions>(
+    () => ({
+      maxZoom: 1.15,
+      minZoom: 0.7,
+      nodes: initialFocusNodes(graphLayout),
+      padding: 0.18,
+    }),
+    [graphLayout],
+  );
 }
 
 export function useCurrentActivityGraphViewModel({
@@ -305,33 +313,44 @@ export function useCurrentActivityGraphViewModel({
     snapshot,
     storedNodePositions,
   });
-  const { displayNodes, handleNodesChange } = useSyncedDisplayNodes(baseNodes);
-  const edges = useMemo(
-    () =>
-      buildGraphEdges(
-        activeGraphHighlights,
-        handleAssignments,
-        pendingAdditionEdgeIds,
-        visibleGraphEdges,
-        displayNodes,
-      ),
-    [
-      activeGraphHighlights,
-      displayNodes,
-      handleAssignments,
-      pendingAdditionEdgeIds,
-      visibleGraphEdges,
-    ],
-  );
-  const initialFitViewOptions = useMemo<FitViewOptions>(
-    () => ({
-      maxZoom: 1.15,
-      minZoom: 0.7,
-      nodes: initialFocusNodes(graphLayout),
-      padding: 0.18,
-    }),
-    [graphLayout],
-  );
+  const [nodes, setNodes] = useState<CurrentActivityNode[]>([]);
+
+  useEffect(() => {
+    setNodes((currentNodes) => {
+      const currentPositions = new Map(
+        currentNodes.map((node) => [node.id, node.position]),
+      );
+      return baseNodes.map((node) => ({
+        ...node,
+        position: currentPositions.get(node.id) ?? node.position,
+      }));
+    });
+  }, [baseNodes]);
+
+  const handleNodesChange = useCallback((changes: NodeChange[]) => {
+    setNodes(
+      (currentNodes) =>
+        applyNodeChanges(changes, currentNodes) as CurrentActivityNode[],
+    );
+  }, []);
+  const displayNodes = useMemo(() => {
+    const positionOverrides = new Map(
+      nodes.map((node) => [node.id, node.position] as const),
+    );
+
+    return baseNodes.map((node) => ({
+      ...node,
+      position: positionOverrides.get(node.id) ?? node.position,
+    }));
+  }, [baseNodes, nodes]);
+  const edges = useCurrentActivityGraphEdges({
+    activeGraphHighlights,
+    displayNodes,
+    handleAssignments,
+    pendingAdditionEdgeIds,
+    visibleGraphEdges,
+  });
+  const initialFitViewOptions = useInitialFitViewOptions(graphLayout);
 
   return {
     edges,


### PR DESCRIPTION
{
  "project": "Dedupe validWorkStateType Validation Between API and CLI Work List",
  "branchName": "ralph/dedupe-valid-work-state-type-validation",
  "description": "Extract the duplicated work-list state.type allowlist (INITIAL, PROCESSING, TERMINAL, FAILED) from pkg/api/handlers_work_read.go and pkg/cli/work/list.go into one shared helper accepting factoryapi.WorkStateType, retarget both callers, and prove unchanged API/CLI error behavior with existing list tests.",
  "context": {
    "customerAsk": "Create one shared owner for validWorkStateType validation used by GET /work and you work list. Keep the helper near the work-list surface, accept factoryapi.WorkStateType, preserve exact API and CLI error strings, and do not widen into clihttp, submit, or session cleanup.",
    "problem": "handlers_work_read.go and list.go each define an identical validWorkStateType allowlist for INITIAL, PROCESSING, TERMINAL, and FAILED. The duplication risks drift and requires double maintenance for a narrow validation rule.",
    "solution": "Add a focused pkg/workquery (or equivalent) helper ValidWorkStateType(factoryapi.WorkStateType) bool with unit tests. Retarget API listWork and CLI validateListConfig to call it (CLI casts string once). Delete local duplicates. Verify with existing TestListWork and TestList invalid state.type and sortBy tests."
  },
  "acceptanceCriteria": [
    "Only one maintained implementation of the work-state-type allowlist is used by API listWork and CLI validateListConfig",
    "GET /work?state.type=UNKNOWN returns 400 BAD_REQUEST with message state.type must be one of INITIAL, PROCESSING, TERMINAL, or FAILED",
    "you work list --state-type UNKNOWN fails before HTTP with --state-type must be one of INITIAL, PROCESSING, TERMINAL, or FAILED",
    "Invalid sortBy and --sort-by validation behavior and messages remain unchanged",
    "No new legacy compatibility branches or special cases are added",
    "Typecheck, lint, and tests pass for touched packages"
  ],
  "userStories": [
    {
      "id": "dedupe-valid-work-state-type-validation-001",
      "title": "Shared work-state-type allowlist helper",
      "description": "As a maintainer, I want one exported validation helper for work-list state.type filters so API and CLI cannot drift on the allowlist.",
      "acceptanceCriteria": [
        "A focused package near the work-list query surface (e.g. pkg/workquery) exports ValidWorkStateType(stateType factoryapi.WorkStateType) bool",
        "The helper returns true only for INITIAL, PROCESSING, TERMINAL, and FAILED; all other values return false",
        "Unit tests cover each allowed value and at least one rejected value such as UNKNOWN",
        "The helper does not depend on clihttp, HTTP handlers, or CLI config types",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "dedupe-valid-work-state-type-validation-002",
      "title": "Retarget API and CLI work-list callers",
      "description": "As an operator or API consumer, I want invalid work-state-type filters to behave exactly as before while maintainers edit only one allowlist.",
      "acceptanceCriteria": [
        "listWork in handlers_work_read.go calls the shared helper and no longer defines a local validWorkStateType",
        "validateListConfig in pkg/cli/work/list.go casts cfg.StateType to factoryapi.WorkStateType once and calls the shared helper; local duplicate is removed",
        "API error message remains exactly: state.type must be one of INITIAL, PROCESSING, TERMINAL, or FAILED",
        "CLI error message remains exactly: --state-type must be one of INITIAL, PROCESSING, TERMINAL, or FAILED",
        "TestListWork_InvalidStateTypeReturnsBadRequest passes unchanged",
        "TestListWork_InvalidSortByReturnsBadRequest passes unchanged",
        "TestList_InvalidStateType passes unchanged",
        "TestList_InvalidSortBy passes unchanged",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
