### PR TITLE
issues3-current-selection-graph-refresh-topology

### DIFF
--- a/ui/src/App.current-selection.test.tsx
+++ b/ui/src/App.current-selection.test.tsx
@@ -1322,7 +1322,11 @@ describe("App current selection", () => {
     expect(stateSelectionSlot?.getAttribute("data-bento-card-id")).toBe(
       "current-selection",
     );
-    expect(within(stateInfo).getByTitle("story:implemented")).toBeTruthy();
+    expect(
+      within(stateInfo).getByRole("heading", {
+        name: "Work state configuration",
+      }),
+    ).toBeTruthy();
     expect(within(stateInfo).getByText("Count")).toBeTruthy();
     expect(within(stateInfo).getByText("Current work")).toBeTruthy();
     expect(within(stateInfo).getByText(activeWorkLabel)).toBeTruthy();
@@ -1350,8 +1354,11 @@ describe("App current selection", () => {
     const emptyStateInfo = await screen.findByRole("article", {
       name: "Current selection",
     });
-    expect(within(emptyStateInfo).getByText("story: blocked")).toBeTruthy();
-    expect(within(emptyStateInfo).getByTitle("story:blocked")).toBeTruthy();
+    expect(
+      within(emptyStateInfo).getByRole("heading", {
+        name: "Work state configuration",
+      }),
+    ).toBeTruthy();
     expect(
       within(emptyStateInfo).getByText(
         "No work is recorded for this place at the selected tick.",
@@ -2023,7 +2030,6 @@ describe("App current selection", () => {
     const completedDetail = await within(dashboardGrid).findByRole("article", {
       name: "Current selection",
     });
-    expect(within(completedDetail).getByTitle("story:complete")).toBeTruthy();
     expect(within(completedDetail).getByText("Count")).toBeTruthy();
     expect(within(completedDetail).getByText("Current work")).toBeTruthy();
     expect(within(completedDetail).getByText("Done Story")).toBeTruthy();
@@ -2062,7 +2068,6 @@ describe("App current selection", () => {
         name: "Current selection",
       });
 
-      expect(within(failedDetail).getByText("story: blocked")).toBeTruthy();
       expect(within(failedDetail).getByText("Count")).toBeTruthy();
       expect(within(failedDetail).getByText("Current work")).toBeTruthy();
       expect(within(failedDetail).getByText("Failed Story")).toBeTruthy();

--- a/ui/src/App.follow-up-submit.test.tsx
+++ b/ui/src/App.follow-up-submit.test.tsx
@@ -53,6 +53,7 @@ describe("App follow-up flows", () => {
   it("keeps the export toolbar action available alongside the submit-work card", async () => {
     renderApp({
       snapshot: terminalSnapshot,
+      seedCurrentFactoryDocument: false,
       fetchOverride: async (path, method) => {
         if (method === "GET" && isSessionFactoryRequest(path, method)) {
           return jsonResponse(

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-topology-impact.test.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-topology-impact.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+
+import { baseFactoryDefinition } from "./factory-graph-draft.test-helpers";
+import type { CanonicalFactoryDefinition } from "./factory-graph-draft-types";
+import { doesFactoryDefinitionChangeAffectGraphTopology } from "./factory-graph-topology-impact";
+
+function cloneDefinition(
+  definition: CanonicalFactoryDefinition = baseFactoryDefinition,
+): CanonicalFactoryDefinition {
+  return structuredClone(definition);
+}
+
+function firstWorkType(definition: CanonicalFactoryDefinition) {
+  const workType = definition.workTypes?.[0];
+  if (!workType) {
+    throw new Error("expected work type fixture");
+  }
+  return workType;
+}
+
+function firstWorkstation(definition: CanonicalFactoryDefinition) {
+  const workstation = definition.workstations?.[0];
+  if (!workstation) {
+    throw new Error("expected workstation fixture");
+  }
+  return workstation;
+}
+
+function firstWorker(definition: CanonicalFactoryDefinition) {
+  const worker = definition.workers?.[0];
+  if (!worker) {
+    throw new Error("expected worker fixture");
+  }
+  return worker;
+}
+
+describe("doesFactoryDefinitionChangeAffectGraphTopology work types", () => {
+  it("returns true when a work type is added", () => {
+    const previous = cloneDefinition();
+    const next = cloneDefinition();
+    next.workTypes = [
+      ...(next.workTypes ?? []),
+      {
+        name: "bug",
+        states: [{ name: "open", type: "INITIAL" }],
+      },
+    ];
+
+    expect(doesFactoryDefinitionChangeAffectGraphTopology(previous, next)).toBe(
+      true,
+    );
+  });
+
+  it("returns false when only handling behavior changes", () => {
+    const previous = cloneDefinition();
+    const next = cloneDefinition();
+    next.workTypes = [
+      {
+        ...firstWorkType(previous),
+        handlingBehavior: ["DEFAULT"],
+      },
+    ];
+
+    expect(doesFactoryDefinitionChangeAffectGraphTopology(previous, next)).toBe(
+      false,
+    );
+  });
+});
+
+describe("doesFactoryDefinitionChangeAffectGraphTopology work states", () => {
+  it("returns true when a work state is added", () => {
+    const previous = cloneDefinition();
+    const workType = firstWorkType(previous);
+    const next = cloneDefinition();
+    next.workTypes = [
+      {
+        ...workType,
+        states: [...workType.states, { name: "review", type: "PROCESSING" }],
+      },
+    ];
+
+    expect(doesFactoryDefinitionChangeAffectGraphTopology(previous, next)).toBe(
+      true,
+    );
+  });
+
+  it("returns false when only a work state type changes", () => {
+    const previous = cloneDefinition();
+    const workType = firstWorkType(previous);
+    const next = cloneDefinition();
+    next.workTypes = [
+      {
+        ...workType,
+        states: workType.states.map((state) =>
+          state.name === "queued" ? { ...state, type: "PROCESSING" } : state,
+        ),
+      },
+    ];
+
+    expect(doesFactoryDefinitionChangeAffectGraphTopology(previous, next)).toBe(
+      false,
+    );
+  });
+});
+
+describe("doesFactoryDefinitionChangeAffectGraphTopology workstations", () => {
+  it("returns true when workstation worker assignment changes", () => {
+    const previous = cloneDefinition();
+    const next = cloneDefinition();
+    next.workers = [
+      ...(next.workers ?? []),
+      {
+        model: "gpt-5",
+        name: "reviewer",
+        type: "MODEL_WORKER",
+      },
+    ];
+    next.workstations = [
+      {
+        ...firstWorkstation(previous),
+        worker: "reviewer",
+      },
+    ];
+
+    expect(doesFactoryDefinitionChangeAffectGraphTopology(previous, next)).toBe(
+      true,
+    );
+  });
+
+  it("returns false when only workstation prompt body changes", () => {
+    const previous = cloneDefinition();
+    const next = cloneDefinition();
+    next.workstations = [
+      {
+        ...firstWorkstation(previous),
+        body: "Updated workstation instructions.",
+      },
+    ];
+
+    expect(doesFactoryDefinitionChangeAffectGraphTopology(previous, next)).toBe(
+      false,
+    );
+  });
+});
+
+describe("doesFactoryDefinitionChangeAffectGraphTopology workers", () => {
+  it("returns true when a worker gains a resource link", () => {
+    const previous = cloneDefinition();
+    const next = cloneDefinition();
+    next.resources = [
+      {
+        capacity: 1,
+        name: "gpu",
+      },
+    ];
+    next.workers = [
+      {
+        ...firstWorker(previous),
+        resources: [{ name: "gpu" }],
+      },
+    ];
+
+    expect(doesFactoryDefinitionChangeAffectGraphTopology(previous, next)).toBe(
+      true,
+    );
+  });
+
+  it("returns false when only worker model changes", () => {
+    const previous = cloneDefinition();
+    const next = cloneDefinition();
+    next.workers = [
+      {
+        ...firstWorker(previous),
+        model: "gpt-5.2",
+      },
+    ];
+
+    expect(doesFactoryDefinitionChangeAffectGraphTopology(previous, next)).toBe(
+      false,
+    );
+  });
+});
+
+describe("doesFactoryDefinitionChangeAffectGraphTopology resources", () => {
+  it("returns true when a resource is added", () => {
+    const previous = cloneDefinition();
+    const next = cloneDefinition();
+    next.resources = [
+      ...(next.resources ?? []),
+      {
+        capacity: 2,
+        name: "disk",
+      },
+    ];
+
+    expect(doesFactoryDefinitionChangeAffectGraphTopology(previous, next)).toBe(
+      true,
+    );
+  });
+
+  it("returns false when only resource capacity changes", () => {
+    const previous = cloneDefinition();
+    previous.resources = [
+      {
+        capacity: 2,
+        name: "gpu",
+      },
+    ];
+    const next = cloneDefinition(previous);
+    next.resources = [
+      {
+        capacity: 8,
+        name: "gpu",
+      },
+    ];
+
+    expect(doesFactoryDefinitionChangeAffectGraphTopology(previous, next)).toBe(
+      false,
+    );
+  });
+});

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-topology-impact.test.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-topology-impact.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import { baseFactoryDefinition } from "./factory-graph-draft.test-helpers";
 import type { CanonicalFactoryDefinition } from "./factory-graph-draft-types";
-import { doesFactoryDefinitionChangeAffectGraphTopology } from "./factory-graph-topology-impact";
+import {
+  buildFactoryGraphLayoutTopologyKey,
+  doesFactoryDefinitionChangeAffectGraphTopology,
+} from "./factory-graph-topology-impact";
 
 function cloneDefinition(
   definition: CanonicalFactoryDefinition = baseFactoryDefinition,
@@ -216,6 +219,23 @@ describe("doesFactoryDefinitionChangeAffectGraphTopology resources", () => {
 
     expect(doesFactoryDefinitionChangeAffectGraphTopology(previous, next)).toBe(
       false,
+    );
+  });
+});
+
+describe("buildFactoryGraphLayoutTopologyKey", () => {
+  it("returns the same key when only workstation prompt body changes", () => {
+    const previous = cloneDefinition();
+    const next = cloneDefinition();
+    next.workstations = [
+      {
+        ...firstWorkstation(previous),
+        body: "Updated workstation instructions.",
+      },
+    ];
+
+    expect(buildFactoryGraphLayoutTopologyKey(previous)).toBe(
+      buildFactoryGraphLayoutTopologyKey(next),
     );
   });
 });

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-topology-impact.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-topology-impact.ts
@@ -1,0 +1,27 @@
+import { buildFactoryGraphTopologyFromDefinition } from "./factory-graph-draft-graph";
+import type { CanonicalFactoryDefinition } from "./factory-graph-draft-types";
+
+/**
+ * Whether replacing `previous` with `next` changes nodes or edges on the factory graph.
+ * Uses the same topology projection as graph rendering so non-structural field edits
+ * (prompt, cron, model, capacity, handling behavior, and similar) do not report impact.
+ */
+export function doesFactoryDefinitionChangeAffectGraphTopology(
+  previous: CanonicalFactoryDefinition,
+  next: CanonicalFactoryDefinition,
+): boolean {
+  return (
+    factoryGraphTopologySignature(previous) !==
+    factoryGraphTopologySignature(next)
+  );
+}
+
+function factoryGraphTopologySignature(
+  definition: CanonicalFactoryDefinition,
+): string {
+  const topology = buildFactoryGraphTopologyFromDefinition(definition);
+  return JSON.stringify({
+    edgeIds: topology.edges.map((edge) => edge.id).sort(),
+    nodeIds: topology.nodes.map((node) => node.id).sort(),
+  });
+}

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-topology-impact.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-topology-impact.ts
@@ -11,12 +11,13 @@ export function doesFactoryDefinitionChangeAffectGraphTopology(
   next: CanonicalFactoryDefinition,
 ): boolean {
   return (
-    factoryGraphTopologySignature(previous) !==
-    factoryGraphTopologySignature(next)
+    buildFactoryGraphLayoutTopologyKey(previous) !==
+    buildFactoryGraphLayoutTopologyKey(next)
   );
 }
 
-function factoryGraphTopologySignature(
+/** Stable cache key for factory graph layout derived from rendered node/edge ids. */
+export function buildFactoryGraphLayoutTopologyKey(
   definition: CanonicalFactoryDefinition,
 ): string {
   const topology = buildFactoryGraphTopologyFromDefinition(definition);

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card.test.tsx
@@ -128,6 +128,8 @@ interface RenderCurrentActivityOptions {
   activateFactory?: (
     input: FactoryImportConfirmInput,
   ) => Promise<ImportFactoryValue>;
+  currentFactoryDocument?: typeof baseFactoryDefinitionDocument | null;
+  currentFactoryDocumentStatus?: "error" | "pending" | "success";
   importController?: CurrentActivityImportController;
   locale?: string;
   onFactoryActivated?: () => void;
@@ -364,6 +366,8 @@ function expectFixedWorkstationNodeDimensions(node: Element | null) {
 
 function renderCurrentActivity({
   activateFactory,
+  currentFactoryDocument,
+  currentFactoryDocumentStatus = "success",
   importController,
   locale,
   onFactoryActivated,
@@ -373,6 +377,17 @@ function renderCurrentActivity({
   selection = null,
   widgetInstanceID,
 }: RenderCurrentActivityOptions) {
+  const factoryDocument =
+    currentFactoryDocument !== undefined
+      ? currentFactoryDocument
+      : currentFactoryDocumentFromSnapshot(snapshot);
+
+  vi.mocked(useCurrentFactoryDocument).mockReturnValue({
+    data: factoryDocument ?? undefined,
+    error: null,
+    status: currentFactoryDocumentStatus,
+  } as never);
+
   const onSelectWorkID =
     vi.fn<
       (workID: string, hint?: { dispatchID?: string; nodeID?: string }) => void
@@ -873,11 +888,6 @@ function registerCurrentActivityCardTestLifecycle(): void {
     window.localStorage.clear();
     useCurrentActivityGraphStore.setState({ positionsByGraphKey: {} });
     restoreBrowserTestShims = installDashboardBrowserTestShims();
-    vi.mocked(useCurrentFactoryDocument).mockReturnValue({
-      data: baseFactoryDefinitionDocument,
-      error: null,
-      status: "success",
-    } as never);
     vi.mocked(useFactoryDocumentSave).mockReturnValue({
       error: null,
       isPending: false,
@@ -956,11 +966,6 @@ function registerCurrentActivityCardEditorChromeTests(): void {
   });
 
   it("keeps classifier workstations out of the editable graph flow", async () => {
-    vi.mocked(useCurrentFactoryDocument).mockReturnValue({
-      data: undefined,
-      error: null,
-      status: "pending",
-    } as never);
     const snapshot = dashboardSnapshotWithActiveWorkItemCount(0);
     snapshot.topology.workstation_nodes_by_id.review.workstation_kind =
       "CLASSIFIER_WORKSTATION";
@@ -982,6 +987,8 @@ function registerCurrentActivityCardEditorChromeTests(): void {
     }
 
     renderCurrentActivity({
+      currentFactoryDocument: null,
+      currentFactoryDocumentStatus: "pending",
       snapshot,
     });
 
@@ -1296,11 +1303,6 @@ function registerCurrentActivityCardEditorChromeTests(): void {
 
   it("does not render prior-session snapshot workstations in observe mode while the factory document is pending", async () => {
     const snapshot = buildDivergentPlaneDashboardSnapshot();
-    vi.mocked(useCurrentFactoryDocument).mockReturnValue({
-      data: undefined,
-      error: null,
-      status: "pending",
-    } as never);
     wireMockEditableFactoryGraph(
       {
         useEditableFactoryGraph: vi.mocked(useEditableFactoryGraph),
@@ -1313,7 +1315,11 @@ function registerCurrentActivityCardEditorChromeTests(): void {
       }),
     );
 
-    renderCurrentActivity({ snapshot });
+    renderCurrentActivity({
+      currentFactoryDocument: null,
+      currentFactoryDocumentStatus: "pending",
+      snapshot,
+    });
 
     expect(
       await screen.findByRole("region", { name: "Work graph viewport" }),
@@ -1332,11 +1338,6 @@ function registerCurrentActivityCardEditorChromeTests(): void {
 
   it("renders saved document workstations in observe mode when the document plane diverges from the snapshot", async () => {
     const snapshot = buildDivergentPlaneDashboardSnapshot();
-    vi.mocked(useCurrentFactoryDocument).mockReturnValue({
-      data: divergentDocumentPlaneFactoryDocument,
-      error: null,
-      status: "success",
-    } as never);
     wireMockEditableFactoryGraph(
       {
         useEditableFactoryGraph: vi.mocked(useEditableFactoryGraph),
@@ -1349,7 +1350,10 @@ function registerCurrentActivityCardEditorChromeTests(): void {
       }),
     );
 
-    renderCurrentActivity({ snapshot });
+    renderCurrentActivity({
+      currentFactoryDocument: divergentDocumentPlaneFactoryDocument,
+      snapshot,
+    });
 
     await waitFor(() => {
       expect(
@@ -1367,11 +1371,6 @@ function registerCurrentActivityCardEditorChromeTests(): void {
 
   it("renders document-only workstations in edit mode when the snapshot plane diverges", async () => {
     const snapshot = buildDivergentPlaneDashboardSnapshot();
-    vi.mocked(useCurrentFactoryDocument).mockReturnValue({
-      data: divergentDocumentPlaneFactoryDocument,
-      error: null,
-      status: "success",
-    } as never);
     wireMockEditableFactoryGraph(
       {
         useEditableFactoryGraph: vi.mocked(useEditableFactoryGraph),
@@ -1384,7 +1383,10 @@ function registerCurrentActivityCardEditorChromeTests(): void {
       }),
     );
 
-    renderCurrentActivity({ snapshot });
+    renderCurrentActivity({
+      currentFactoryDocument: divergentDocumentPlaneFactoryDocument,
+      snapshot,
+    });
 
     fireEvent.click(
       screen.getByRole("button", { name: "Enter factory graph editor" }),
@@ -1406,11 +1408,6 @@ function registerCurrentActivityCardEditorChromeTests(): void {
 
   it("does not render snapshot-only workstations in editor mode while the factory document is loading", async () => {
     const snapshot = buildDivergentPlaneDashboardSnapshot();
-    vi.mocked(useCurrentFactoryDocument).mockReturnValue({
-      data: undefined,
-      error: null,
-      status: "pending",
-    } as never);
     wireMockEditableFactoryGraph(
       {
         useEditableFactoryGraph: vi.mocked(useEditableFactoryGraph),
@@ -1423,7 +1420,11 @@ function registerCurrentActivityCardEditorChromeTests(): void {
       }),
     );
 
-    renderCurrentActivity({ snapshot });
+    renderCurrentActivity({
+      currentFactoryDocument: null,
+      currentFactoryDocumentStatus: "pending",
+      snapshot,
+    });
 
     fireEvent.click(
       screen.getByRole("button", { name: "Enter factory graph editor" }),
@@ -1632,13 +1633,9 @@ function registerCurrentActivityCardEditorLeaveAndSaveTests(): void {
   });
 
   it("shows a loading editor state while the editable definition is still fetching", async () => {
-    vi.mocked(useCurrentFactoryDocument).mockReturnValue({
-      data: undefined,
-      error: null,
-      status: "pending",
-    } as never);
-
     renderCurrentActivity({
+      currentFactoryDocument: null,
+      currentFactoryDocumentStatus: "pending",
       snapshot: semanticWorkflowDashboardSnapshot,
     });
 
@@ -2536,11 +2533,6 @@ describe("ReactFlowCurrentActivityCard graph semantics", () => {
 
   it("renders active observer graph state from the canonical snapshot factory without topology fallback", async () => {
     const snapshot = canonicalObserverSnapshot();
-    vi.mocked(useCurrentFactoryDocument).mockReturnValue({
-      data: currentFactoryDocumentFromSnapshot(snapshot),
-      error: null,
-      status: "success",
-    } as never);
 
     renderCurrentActivity({ snapshot });
 

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card.test.tsx
@@ -1330,7 +1330,7 @@ function registerCurrentActivityCardEditorChromeTests(): void {
     ).toBeNull();
   });
 
-  it("renders snapshot-only workstations in observe mode when the document plane diverges", async () => {
+  it("renders saved document workstations in observe mode when the document plane diverges from the snapshot", async () => {
     const snapshot = buildDivergentPlaneDashboardSnapshot();
     vi.mocked(useCurrentFactoryDocument).mockReturnValue({
       data: divergentDocumentPlaneFactoryDocument,
@@ -1357,12 +1357,12 @@ function registerCurrentActivityCardEditorChromeTests(): void {
           name: "Select Document Only workstation",
         }),
       ).toBeTruthy();
-      expect(
-        screen.getByRole("button", {
-          name: "Select Snapshot Only workstation",
-        }),
-      ).toBeTruthy();
     });
+    expect(
+      screen.queryByRole("button", {
+        name: "Select Snapshot Only workstation",
+      }),
+    ).toBeNull();
   });
 
   it("renders document-only workstations in edit mode when the snapshot plane diverges", async () => {

--- a/ui/src/features/workflow-activity/hooks/current-selection-save-graph-refresh.test.tsx
+++ b/ui/src/features/workflow-activity/hooks/current-selection-save-graph-refresh.test.tsx
@@ -1,0 +1,363 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { CurrentFactoryDocument } from "../../../api/current-factory-definition";
+import type { DashboardSnapshot } from "../../../api/dashboard/types";
+import { singleNodeDashboardSnapshot } from "../../../components/dashboard/test-fixtures";
+import { createMockGraphEditorDraftState } from "../../../testing/graph-editor-harness";
+import {
+  baseFactoryDefinition,
+  currentFactoryDocument,
+} from "../../factory-graph-editor/lib/factory-graph-draft.test-helpers";
+import { buildFactoryGraphLayoutTopologyKey } from "../../factory-graph-editor/lib/factory-graph-topology-impact";
+import * as currentActivityFactoryGraphLayout from "../lib/current-activity-factory-graph-layout";
+import { currentActivityGraphKey } from "../lib/react-flow-current-activity-card-keys";
+import type { useCurrentActivityGraphEditor } from "./react-flow-current-activity-card-editor";
+import { useCurrentActivityGraphLayoutForFactory } from "./react-flow-current-activity-card-graph-layout";
+import { currentActivityCardFactoryDefinition } from "./react-flow-current-activity-card-graph-view-model";
+import { useTopologyStableFactoryForLayout } from "./use-topology-stable-factory-for-layout";
+
+function cloneSavedDocument(
+  document: CurrentFactoryDocument = currentFactoryDocument,
+): CurrentFactoryDocument {
+  return structuredClone(document);
+}
+
+function createObserverEditorStub(savedDocument: CurrentFactoryDocument) {
+  return {
+    draftState: createMockGraphEditorDraftState({
+      baseDocument: savedDocument,
+      latestDocument: savedDocument,
+    }),
+    editableDefinitionQuery: {
+      data: savedDocument,
+      status: "success" as const,
+    },
+    editorMode: false,
+    hiddenNodeClasses: new Set(),
+  } as unknown as ReturnType<typeof useCurrentActivityGraphEditor>;
+}
+
+function useObserverGraphAfterCurrentSelectionSave({
+  savedDocument,
+  snapshot,
+}: {
+  savedDocument: CurrentFactoryDocument;
+  snapshot: DashboardSnapshot;
+}) {
+  const editor = createObserverEditorStub(savedDocument);
+  const displayFactory =
+    currentActivityCardFactoryDefinition(editor, snapshot) ?? undefined;
+  const layoutFactory = useTopologyStableFactoryForLayout(displayFactory);
+  const graphLayout = useCurrentActivityGraphLayoutForFactory(
+    snapshot,
+    layoutFactory,
+  );
+
+  return {
+    displayFactory,
+    graphKey: currentActivityGraphKey(graphLayout),
+    graphLayout,
+    layoutTopologyKey: layoutFactory
+      ? buildFactoryGraphLayoutTopologyKey(layoutFactory)
+      : "",
+    edgeIds: graphLayout.edges.map((edge) => edge.edgeId).sort(),
+    nodeIds: graphLayout.nodes.map((node) => node.nodeId).sort(),
+  };
+}
+
+function buildStaleSnapshotFactoryDocument(
+  document: CurrentFactoryDocument = currentFactoryDocument,
+): DashboardSnapshot {
+  const snapshot = structuredClone(singleNodeDashboardSnapshot);
+  snapshot.factory = structuredClone(document);
+  snapshot.topology = {
+    edges: [],
+    workstation_node_ids: [],
+    workstation_nodes_by_id: {},
+  };
+  return snapshot;
+}
+
+function firstWorkType(document: CurrentFactoryDocument) {
+  const workType = document.workTypes?.[0];
+  if (!workType) {
+    throw new Error("expected work type fixture");
+  }
+  return workType;
+}
+
+function firstWorkstation(document: CurrentFactoryDocument) {
+  const workstation = document.workstations?.[0];
+  if (!workstation) {
+    throw new Error("expected workstation fixture");
+  }
+  return workstation;
+}
+
+function firstWorker(document: CurrentFactoryDocument) {
+  const worker = document.workers?.[0];
+  if (!worker) {
+    throw new Error("expected worker fixture");
+  }
+  return worker;
+}
+
+function afterWorkstationWorkerAssignmentSave(
+  previous: CurrentFactoryDocument,
+): CurrentFactoryDocument {
+  const next = cloneSavedDocument(previous);
+  next.workers = [
+    ...(next.workers ?? []),
+    {
+      model: "gpt-5",
+      name: "reviewer",
+      type: "MODEL_WORKER",
+    },
+  ];
+  next.workstations = [
+    {
+      ...firstWorkstation(previous),
+      worker: "reviewer",
+    },
+  ];
+  next.version = { logical: "6", physical: "2026-06-01T12:00:00Z" };
+  return next;
+}
+
+function afterWorkerResourceLinkSave(
+  previous: CurrentFactoryDocument,
+): CurrentFactoryDocument {
+  const next = cloneSavedDocument(previous);
+  next.workers = [
+    {
+      ...firstWorker(previous),
+      resources: [{ name: "gpu" }],
+    },
+  ];
+  next.version = { logical: "7", physical: "2026-06-01T13:00:00Z" };
+  return next;
+}
+
+function afterWorkTypeAddSave(
+  previous: CurrentFactoryDocument,
+): CurrentFactoryDocument {
+  const next = cloneSavedDocument(previous);
+  next.workTypes = [
+    ...(next.workTypes ?? []),
+    {
+      name: "bug",
+      states: [{ name: "open", type: "INITIAL" }],
+    },
+  ];
+  next.version = { logical: "8", physical: "2026-06-01T14:00:00Z" };
+  return next;
+}
+
+function afterWorkStateAddSave(
+  previous: CurrentFactoryDocument,
+): CurrentFactoryDocument {
+  const next = cloneSavedDocument(previous);
+  const workType = firstWorkType(previous);
+  next.workTypes = [
+    {
+      ...workType,
+      states: [...workType.states, { name: "review", type: "PROCESSING" }],
+    },
+  ];
+  next.version = { logical: "9", physical: "2026-06-01T15:00:00Z" };
+  return next;
+}
+
+function afterResourceAddSave(
+  previous: CurrentFactoryDocument,
+): CurrentFactoryDocument {
+  const next = cloneSavedDocument(previous);
+  next.resources = [
+    ...(next.resources ?? []),
+    {
+      capacity: 4,
+      name: "disk",
+    },
+  ];
+  next.version = { logical: "10", physical: "2026-06-01T16:00:00Z" };
+  return next;
+}
+
+function afterWorkstationPromptOnlySave(
+  previous: CurrentFactoryDocument,
+): CurrentFactoryDocument {
+  const next = cloneSavedDocument(previous);
+  next.workstations = [
+    {
+      ...firstWorkstation(previous),
+      body: "Updated workstation instructions.",
+    },
+  ];
+  next.version = { logical: "11", physical: "2026-06-01T17:00:00Z" };
+  return next;
+}
+
+async function waitForGraphNodes(result: {
+  current: ReturnType<typeof useObserverGraphAfterCurrentSelectionSave>;
+}) {
+  await waitFor(() => {
+    expect(result.current.nodeIds.length).toBeGreaterThan(0);
+  });
+}
+
+const topologySaveCases = [
+  [
+    "workstation worker assignment",
+    afterWorkstationWorkerAssignmentSave,
+    (before: string[], after: string[]) => {
+      expect(after).toContain("worker:reviewer");
+      expect(after).not.toEqual(before);
+    },
+  ],
+  [
+    "worker resource link",
+    afterWorkerResourceLinkSave,
+    (before: string[], after: string[]) => {
+      expect(after).toContain("worker-resource:resource:gpu->worker:writer");
+      expect(before).not.toContain("worker-resource:resource:gpu->worker:writer");
+    },
+  ],
+  [
+    "work type add",
+    afterWorkTypeAddSave,
+    (before: string[], after: string[]) => {
+      expect(after).toContain("work-type:bug");
+      expect(after).not.toEqual(before);
+    },
+  ],
+  [
+    "work state add",
+    afterWorkStateAddSave,
+    (before: string[], after: string[]) => {
+      expect(after).toContain("work-state:story:review");
+      expect(after).not.toEqual(before);
+    },
+  ],
+  [
+    "resource add",
+    afterResourceAddSave,
+    (before: string[], after: string[]) => {
+      expect(after).toContain("resource:disk");
+      expect(after).not.toEqual(before);
+    },
+  ],
+] as const;
+
+describe("current-selection save graph refresh", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it.each(topologySaveCases)(
+    "refreshes observer graph layout after topology-affecting %s save",
+    async (_label, applySave, assertRefresh) => {
+      const snapshot = buildStaleSnapshotFactoryDocument();
+      const initialDocument = cloneSavedDocument();
+      const { result, rerender } = renderHook(
+        ({ savedDocument }) =>
+          useObserverGraphAfterCurrentSelectionSave({
+            savedDocument,
+            snapshot,
+          }),
+        { initialProps: { savedDocument: initialDocument } },
+      );
+
+      await waitForGraphNodes(result);
+      const graphIdsBeforeSave = [
+        ...result.current.nodeIds,
+        ...result.current.edgeIds,
+      ];
+
+      rerender({
+        savedDocument: applySave(initialDocument),
+      });
+
+      await waitFor(() => {
+        assertRefresh(graphIdsBeforeSave, [
+          ...result.current.nodeIds,
+          ...result.current.edgeIds,
+        ]);
+      });
+      expect(result.current.layoutTopologyKey).not.toBe(
+        buildFactoryGraphLayoutTopologyKey(initialDocument),
+      );
+    },
+  );
+
+  it("keeps graph layout topology key stable after non-topology workstation prompt save", async () => {
+    const buildLayoutSpy = vi.spyOn(
+      currentActivityFactoryGraphLayout,
+      "buildCurrentActivityGraphLayoutFromFactory",
+    );
+    const snapshot = buildStaleSnapshotFactoryDocument();
+    const initialDocument = cloneSavedDocument();
+    const promptOnlyDocument = afterWorkstationPromptOnlySave(initialDocument);
+
+    expect(buildFactoryGraphLayoutTopologyKey(initialDocument)).toBe(
+      buildFactoryGraphLayoutTopologyKey(promptOnlyDocument),
+    );
+
+    const { result, rerender } = renderHook(
+      ({ savedDocument }) =>
+        useObserverGraphAfterCurrentSelectionSave({
+          savedDocument,
+          snapshot,
+        }),
+      { initialProps: { savedDocument: initialDocument } },
+    );
+
+    await waitForGraphNodes(result);
+    const graphKeyBeforeSave = result.current.graphKey;
+    const layoutTopologyKeyBeforeSave = result.current.layoutTopologyKey;
+    const callsAfterInitialRender = buildLayoutSpy.mock.calls.length;
+
+    rerender({ savedDocument: promptOnlyDocument });
+
+    await waitForGraphNodes(result);
+
+    expect(result.current.layoutTopologyKey).toBe(layoutTopologyKeyBeforeSave);
+    expect(result.current.graphKey).toBe(graphKeyBeforeSave);
+    expect(buildLayoutSpy.mock.calls.length).toBe(callsAfterInitialRender);
+
+    buildLayoutSpy.mockRestore();
+  });
+
+  it("renders graph nodes from the saved document when the snapshot factory remains stale", async () => {
+    const snapshot = buildStaleSnapshotFactoryDocument();
+    snapshot.factory = {
+      ...structuredClone(baseFactoryDefinition),
+      workstations: [
+        ...(baseFactoryDefinition.workstations ?? []),
+        {
+          body: "Stale snapshot workstation.",
+          inputs: [{ state: "queued", workType: "story" }],
+          name: "stale-only",
+          outputs: [{ state: "done", workType: "story" }],
+          type: "MODEL_WORKSTATION",
+          worker: "writer",
+        },
+      ],
+    };
+    const savedDocument = afterWorkstationWorkerAssignmentSave(
+      cloneSavedDocument(),
+    );
+
+    const { result } = renderHook(() =>
+      useObserverGraphAfterCurrentSelectionSave({
+        savedDocument,
+        snapshot,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.nodeIds).toContain("worker:reviewer");
+    });
+    expect(result.current.nodeIds).not.toContain("workstation:stale-only");
+  });
+});

--- a/ui/src/features/workflow-activity/hooks/current-selection-save-graph-refresh.test.tsx
+++ b/ui/src/features/workflow-activity/hooks/current-selection-save-graph-refresh.test.tsx
@@ -47,7 +47,8 @@ function useObserverGraphAfterCurrentSelectionSave({
 }) {
   const editor = createObserverEditorStub(savedDocument);
   const displayFactory =
-    currentActivityCardFactoryDefinition(editor, snapshot) ?? undefined;
+    currentActivityCardFactoryDefinition(editor, snapshot, "current") ??
+      undefined;
   const layoutFactory = useTopologyStableFactoryForLayout(displayFactory);
   const graphLayout = useCurrentActivityGraphLayoutForFactory(
     snapshot,

--- a/ui/src/features/workflow-activity/hooks/observe-mode-factory-definition.test.ts
+++ b/ui/src/features/workflow-activity/hooks/observe-mode-factory-definition.test.ts
@@ -7,6 +7,7 @@ import {
   buildDivergentSnapshotPlaneFactory,
   divergentDocumentPlaneFactoryDocument,
 } from "../../../testing/graph-editor-harness";
+import { sessionFactoryDocumentFromSnapshot } from "../../../testing/session-factory-mocks";
 import { resolveObserveModeFactoryDefinition } from "./observe-mode-factory-definition";
 
 describe("resolveObserveModeFactoryDefinition", () => {
@@ -23,10 +24,33 @@ describe("resolveObserveModeFactoryDefinition", () => {
     ).toEqual(divergentDocumentPlaneFactoryDocument);
   });
 
+  it("prefers the saved document when it adds work type states ahead of the snapshot", () => {
+    const snapshot = buildDashboardSnapshotFixture(mediumBranchingDashboardTopology);
+    const savedDocument = {
+      ...baseFactoryDefinitionDocument,
+      workTypes: [
+        ...(baseFactoryDefinitionDocument.workTypes ?? []),
+        {
+          name: "task",
+          states: [{ name: "open", type: "INITIAL" as const }],
+        },
+      ],
+    };
+
+    expect(
+      resolveObserveModeFactoryDefinition({
+        document: savedDocument,
+        snapshotFactory: snapshot.factory,
+        timelineMode: "current",
+      }),
+    ).toEqual(savedDocument);
+  });
+
   it("prefers the timeline snapshot factory when replay diverges structurally at the current tick", () => {
     const snapshot = buildDashboardSnapshotFixture(mediumBranchingDashboardTopology);
+    const persistedDocument = sessionFactoryDocumentFromSnapshot(snapshot);
     const replayFactory = {
-      ...baseFactoryDefinitionDocument,
+      ...persistedDocument,
       workTypes: [
         {
           name: "story",
@@ -51,7 +75,7 @@ describe("resolveObserveModeFactoryDefinition", () => {
 
     expect(
       resolveObserveModeFactoryDefinition({
-        document: baseFactoryDefinitionDocument,
+        document: persistedDocument,
         snapshotFactory: replayFactory,
         timelineMode: "current",
       }),

--- a/ui/src/features/workflow-activity/hooks/observe-mode-factory-definition.test.ts
+++ b/ui/src/features/workflow-activity/hooks/observe-mode-factory-definition.test.ts
@@ -122,6 +122,47 @@ describe("resolveObserveModeFactoryDefinition", () => {
 });
 
 describe("resolveObserveModeFactoryDefinition — unrelated session imports", () => {
+  it("prefers the timeline snapshot factory while replay has not hydrated work types yet", () => {
+    const snapshot = buildDashboardSnapshotFixture(
+      mediumBranchingDashboardTopology,
+    );
+    snapshot.factory = {
+      ...snapshot.factory,
+      workTypes: [],
+      workstations: [],
+    };
+
+    const importedSessionDocument = {
+      name: "Review Session Import Factory",
+      workTypes: [
+        {
+          name: "request",
+          states: [
+            { name: "queued", type: "INITIAL" as const },
+            { name: "done", type: "TERMINAL" as const },
+          ],
+        },
+      ],
+      workstations: [
+        {
+          inputs: [{ state: "queued", workType: "request" }],
+          name: "Review import workstation",
+          outputs: [{ state: "done", workType: "request" }],
+          type: "MODEL_WORKSTATION" as const,
+          worker: "review-import-worker",
+        },
+      ],
+    };
+
+    expect(
+      resolveObserveModeFactoryDefinition({
+        document: importedSessionDocument,
+        snapshotFactory: snapshot.factory,
+        timelineMode: "current",
+      }),
+    ).toEqual(snapshot.factory);
+  });
+
   it("prefers the timeline snapshot factory when the saved document defines unrelated work types", () => {
     const snapshot = buildDashboardSnapshotFixture(
       mediumBranchingDashboardTopology,

--- a/ui/src/features/workflow-activity/hooks/observe-mode-factory-definition.test.ts
+++ b/ui/src/features/workflow-activity/hooks/observe-mode-factory-definition.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { buildDashboardSnapshotFixture } from "../../../components/dashboard/fixtures";
+import { mediumBranchingDashboardTopology } from "../../../components/dashboard/fixtures/topologies";
+import {
+  baseFactoryDefinitionDocument,
+  buildDivergentSnapshotPlaneFactory,
+  divergentDocumentPlaneFactoryDocument,
+} from "../../../testing/graph-editor-harness";
+import { resolveObserveModeFactoryDefinition } from "./observe-mode-factory-definition";
+
+describe("resolveObserveModeFactoryDefinition", () => {
+  it("prefers the saved document when the snapshot plane is a strict workstation superset", () => {
+    const snapshot = buildDashboardSnapshotFixture(mediumBranchingDashboardTopology);
+    snapshot.factory = buildDivergentSnapshotPlaneFactory();
+
+    expect(
+      resolveObserveModeFactoryDefinition({
+        document: divergentDocumentPlaneFactoryDocument,
+        snapshotFactory: snapshot.factory,
+        timelineMode: "current",
+      }),
+    ).toEqual(divergentDocumentPlaneFactoryDocument);
+  });
+
+  it("prefers the timeline snapshot factory when replay diverges structurally at the current tick", () => {
+    const snapshot = buildDashboardSnapshotFixture(mediumBranchingDashboardTopology);
+    const replayFactory = {
+      ...baseFactoryDefinitionDocument,
+      workTypes: [
+        {
+          name: "story",
+          states: [
+            { name: "new", type: "INITIAL" as const },
+            { name: "done", type: "TERMINAL" as const },
+          ],
+        },
+      ],
+      workstations: [
+        {
+          id: "review",
+          inputs: [{ state: "new", workType: "story" }],
+          name: "Review",
+          outputs: [{ state: "done", workType: "story" }],
+          type: "MODEL_WORKSTATION" as const,
+          worker: "reviewer",
+        },
+      ],
+    };
+    snapshot.factory = replayFactory;
+
+    expect(
+      resolveObserveModeFactoryDefinition({
+        document: baseFactoryDefinitionDocument,
+        snapshotFactory: replayFactory,
+        timelineMode: "current",
+      }),
+    ).toEqual(replayFactory);
+  });
+
+  it("prefers the timeline snapshot factory while scrubbing a fixed tick", () => {
+    const snapshot = buildDashboardSnapshotFixture(mediumBranchingDashboardTopology);
+
+    expect(
+      resolveObserveModeFactoryDefinition({
+        document: divergentDocumentPlaneFactoryDocument,
+        snapshotFactory: snapshot.factory,
+        timelineMode: "fixed",
+      }),
+    ).toEqual(snapshot.factory);
+  });
+});

--- a/ui/src/features/workflow-activity/hooks/observe-mode-factory-definition.test.ts
+++ b/ui/src/features/workflow-activity/hooks/observe-mode-factory-definition.test.ts
@@ -11,7 +11,9 @@ import { resolveObserveModeFactoryDefinition } from "./observe-mode-factory-defi
 
 describe("resolveObserveModeFactoryDefinition", () => {
   it("prefers the saved document when the snapshot plane is a strict workstation superset", () => {
-    const snapshot = buildDashboardSnapshotFixture(mediumBranchingDashboardTopology);
+    const snapshot = buildDashboardSnapshotFixture(
+      mediumBranchingDashboardTopology,
+    );
     snapshot.factory = buildDivergentSnapshotPlaneFactory();
 
     expect(
@@ -24,7 +26,9 @@ describe("resolveObserveModeFactoryDefinition", () => {
   });
 
   it("prefers the saved document when it adds work type states ahead of the snapshot", () => {
-    const snapshot = buildDashboardSnapshotFixture(mediumBranchingDashboardTopology);
+    const snapshot = buildDashboardSnapshotFixture(
+      mediumBranchingDashboardTopology,
+    );
     const savedDocument = sessionFactoryDocumentFromSnapshot(snapshot);
     savedDocument.workTypes = [
       ...(savedDocument.workTypes ?? []),
@@ -44,7 +48,9 @@ describe("resolveObserveModeFactoryDefinition", () => {
   });
 
   it("prefers the timeline snapshot factory when replay diverges structurally at the current tick", () => {
-    const snapshot = buildDashboardSnapshotFixture(mediumBranchingDashboardTopology);
+    const snapshot = buildDashboardSnapshotFixture(
+      mediumBranchingDashboardTopology,
+    );
     const persistedDocument = sessionFactoryDocumentFromSnapshot(snapshot);
     const replayFactory = {
       ...persistedDocument,
@@ -80,7 +86,9 @@ describe("resolveObserveModeFactoryDefinition", () => {
   });
 
   it("prefers the timeline snapshot factory while scrubbing a fixed tick", () => {
-    const snapshot = buildDashboardSnapshotFixture(mediumBranchingDashboardTopology);
+    const snapshot = buildDashboardSnapshotFixture(
+      mediumBranchingDashboardTopology,
+    );
 
     expect(
       resolveObserveModeFactoryDefinition({
@@ -92,7 +100,9 @@ describe("resolveObserveModeFactoryDefinition", () => {
   });
 
   it("prefers the timeline snapshot factory when the saved document is a minimal replay stub", () => {
-    const snapshot = buildDashboardSnapshotFixture(mediumBranchingDashboardTopology);
+    const snapshot = buildDashboardSnapshotFixture(
+      mediumBranchingDashboardTopology,
+    );
     const replayStubDocument = {
       name: "Browser Replay Factory",
       version: {
@@ -109,9 +119,13 @@ describe("resolveObserveModeFactoryDefinition", () => {
       }),
     ).toEqual(snapshot.factory);
   });
+});
 
+describe("resolveObserveModeFactoryDefinition — unrelated session imports", () => {
   it("prefers the timeline snapshot factory when the saved document defines unrelated work types", () => {
-    const snapshot = buildDashboardSnapshotFixture(mediumBranchingDashboardTopology);
+    const snapshot = buildDashboardSnapshotFixture(
+      mediumBranchingDashboardTopology,
+    );
     const replayFactory = {
       ...snapshot.factory,
       workTypes: [

--- a/ui/src/features/workflow-activity/hooks/observe-mode-factory-definition.test.ts
+++ b/ui/src/features/workflow-activity/hooks/observe-mode-factory-definition.test.ts
@@ -93,4 +93,23 @@ describe("resolveObserveModeFactoryDefinition", () => {
       }),
     ).toEqual(snapshot.factory);
   });
+
+  it("prefers the timeline snapshot factory when the saved document is a minimal replay stub", () => {
+    const snapshot = buildDashboardSnapshotFixture(mediumBranchingDashboardTopology);
+    const replayStubDocument = {
+      name: "Browser Replay Factory",
+      version: {
+        logical: "1",
+        physical: "2026-06-01T00:00:00Z",
+      },
+    };
+
+    expect(
+      resolveObserveModeFactoryDefinition({
+        document: replayStubDocument,
+        snapshotFactory: snapshot.factory,
+        timelineMode: "current",
+      }),
+    ).toEqual(snapshot.factory);
+  });
 });

--- a/ui/src/features/workflow-activity/hooks/observe-mode-factory-definition.test.ts
+++ b/ui/src/features/workflow-activity/hooks/observe-mode-factory-definition.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import { buildDashboardSnapshotFixture } from "../../../components/dashboard/fixtures";
 import { mediumBranchingDashboardTopology } from "../../../components/dashboard/fixtures/topologies";
 import {
-  baseFactoryDefinitionDocument,
   buildDivergentSnapshotPlaneFactory,
   divergentDocumentPlaneFactoryDocument,
 } from "../../../testing/graph-editor-harness";
@@ -26,16 +25,14 @@ describe("resolveObserveModeFactoryDefinition", () => {
 
   it("prefers the saved document when it adds work type states ahead of the snapshot", () => {
     const snapshot = buildDashboardSnapshotFixture(mediumBranchingDashboardTopology);
-    const savedDocument = {
-      ...baseFactoryDefinitionDocument,
-      workTypes: [
-        ...(baseFactoryDefinitionDocument.workTypes ?? []),
-        {
-          name: "task",
-          states: [{ name: "open", type: "INITIAL" as const }],
-        },
-      ],
-    };
+    const savedDocument = sessionFactoryDocumentFromSnapshot(snapshot);
+    savedDocument.workTypes = [
+      ...(savedDocument.workTypes ?? []),
+      {
+        name: "task",
+        states: [{ name: "open", type: "INITIAL" as const }],
+      },
+    ];
 
     expect(
       resolveObserveModeFactoryDefinition({
@@ -111,5 +108,67 @@ describe("resolveObserveModeFactoryDefinition", () => {
         timelineMode: "current",
       }),
     ).toEqual(snapshot.factory);
+  });
+
+  it("prefers the timeline snapshot factory when the saved document defines unrelated work types", () => {
+    const snapshot = buildDashboardSnapshotFixture(mediumBranchingDashboardTopology);
+    const replayFactory = {
+      ...snapshot.factory,
+      workTypes: [
+        {
+          name: "story",
+          states: [
+            { name: "queued", type: "INITIAL" as const },
+            { name: "done", type: "TERMINAL" as const },
+          ],
+        },
+      ],
+      workstations: [
+        {
+          inputs: [{ state: "queued", workType: "story" }],
+          name: "Session Review",
+          outputs: [{ state: "done", workType: "story" }],
+          type: "MODEL_WORKSTATION" as const,
+          worker: "writer",
+        },
+      ],
+    };
+    snapshot.factory = replayFactory;
+
+    const importedSessionDocument = {
+      name: "Review Session Import Factory",
+      workTypes: [
+        {
+          name: "request",
+          states: [
+            { name: "queued", type: "INITIAL" as const },
+            { name: "done", type: "TERMINAL" as const },
+          ],
+        },
+      ],
+      workstations: [
+        {
+          inputs: [{ state: "queued", workType: "request" }],
+          name: "Review import workstation",
+          outputs: [{ state: "done", workType: "request" }],
+          type: "MODEL_WORKSTATION" as const,
+          worker: "review-import-worker",
+        },
+      ],
+      workers: [
+        {
+          name: "review-import-worker",
+          type: "MODEL_WORKER" as const,
+        },
+      ],
+    };
+
+    expect(
+      resolveObserveModeFactoryDefinition({
+        document: importedSessionDocument,
+        snapshotFactory: replayFactory,
+        timelineMode: "current",
+      }),
+    ).toEqual(replayFactory);
   });
 });

--- a/ui/src/features/workflow-activity/hooks/observe-mode-factory-definition.ts
+++ b/ui/src/features/workflow-activity/hooks/observe-mode-factory-definition.ts
@@ -1,0 +1,90 @@
+import type { DashboardSnapshot } from "../../../api/dashboard/types";
+import type { CurrentFactoryDocument } from "../../../api/current-factory-definition";
+import type { FactoryTimelineMode } from "../../timeline/state/factoryTimelineStore";
+import { doesFactoryDefinitionChangeAffectGraphTopology } from "../../factory-graph-editor/lib/factory-graph-topology-impact";
+
+type FactoryDefinitionLike = NonNullable<DashboardSnapshot["factory"]>;
+
+function factoryWorkTypeStateSkeleton(
+  factory: FactoryDefinitionLike,
+): string {
+  const workTypes = [...(factory.workTypes ?? [])].sort((left, right) =>
+    left.name.localeCompare(right.name),
+  );
+
+  return workTypes
+    .map((workType) => {
+      const states = [...(workType.states ?? [])]
+        .map((state) => state.name)
+        .sort()
+        .join(",");
+      return `${workType.name}:${states}`;
+    })
+    .join("|");
+}
+
+function factoryWorkstationIds(factory: FactoryDefinitionLike): Set<string> {
+  return new Set(
+    (factory.workstations ?? [])
+      .map((workstation) => workstation.id ?? workstation.name)
+      .filter((id): id is string => Boolean(id)),
+  );
+}
+
+function isSnapshotFactoryStrictWorkstationSuperset(
+  snapshotFactory: FactoryDefinitionLike,
+  document: CurrentFactoryDocument,
+): boolean {
+  const snapshotWorkstations = factoryWorkstationIds(snapshotFactory);
+  const documentWorkstations = factoryWorkstationIds(document);
+
+  if (snapshotWorkstations.size <= documentWorkstations.size) {
+    return false;
+  }
+
+  return [...documentWorkstations].every((workstationId) =>
+    snapshotWorkstations.has(workstationId),
+  );
+}
+
+/**
+ * Chooses the factory definition that should drive observer-mode graph rendering.
+ * Prefers the saved document after current-selection saves and timeline-fixed ticks
+ * from the dashboard snapshot when replay projection diverges structurally.
+ */
+export function resolveObserveModeFactoryDefinition({
+  document,
+  snapshotFactory,
+  timelineMode,
+}: {
+  document: CurrentFactoryDocument;
+  snapshotFactory?: FactoryDefinitionLike;
+  timelineMode: FactoryTimelineMode;
+}): FactoryDefinitionLike {
+  if (!snapshotFactory) {
+    return document;
+  }
+
+  if (timelineMode === "fixed") {
+    return snapshotFactory;
+  }
+
+  if (
+    !doesFactoryDefinitionChangeAffectGraphTopology(document, snapshotFactory)
+  ) {
+    return document;
+  }
+
+  if (
+    factoryWorkTypeStateSkeleton(document) !==
+    factoryWorkTypeStateSkeleton(snapshotFactory)
+  ) {
+    return snapshotFactory;
+  }
+
+  if (isSnapshotFactoryStrictWorkstationSuperset(snapshotFactory, document)) {
+    return document;
+  }
+
+  return document;
+}

--- a/ui/src/features/workflow-activity/hooks/observe-mode-factory-definition.ts
+++ b/ui/src/features/workflow-activity/hooks/observe-mode-factory-definition.ts
@@ -1,7 +1,7 @@
-import type { DashboardSnapshot } from "../../../api/dashboard/types";
 import type { CurrentFactoryDocument } from "../../../api/current-factory-definition";
-import type { FactoryTimelineMode } from "../../timeline/state/factoryTimelineStore";
+import type { DashboardSnapshot } from "../../../api/dashboard/types";
 import { doesFactoryDefinitionChangeAffectGraphTopology } from "../../factory-graph-editor/lib/factory-graph-topology-impact";
+import type { FactoryTimelineMode } from "../../timeline/state/factoryTimelineStore";
 
 type FactoryDefinitionLike = NonNullable<DashboardSnapshot["factory"]>;
 

--- a/ui/src/features/workflow-activity/hooks/observe-mode-factory-definition.ts
+++ b/ui/src/features/workflow-activity/hooks/observe-mode-factory-definition.ts
@@ -39,7 +39,7 @@ function isDocumentWorkTypeStructureAheadOfSnapshot(
   const snapshotWorkTypes = workTypeStateMap(snapshotFactory);
 
   if (snapshotWorkTypes.size === 0) {
-    return documentWorkTypes.size > 0;
+    return false;
   }
 
   for (const [workTypeName, snapshotStates] of snapshotWorkTypes) {
@@ -69,6 +69,22 @@ function isDocumentWorkTypeStructureAheadOfSnapshot(
       if (!snapshotStates.has(stateName)) {
         return true;
       }
+    }
+  }
+
+  return false;
+}
+
+function sharesWorkTypeSkeletonWithSnapshot(
+  document: CurrentFactoryDocument,
+  snapshotFactory: FactoryDefinitionLike,
+): boolean {
+  const documentWorkTypes = workTypeStateMap(document);
+  const snapshotWorkTypes = workTypeStateMap(snapshotFactory);
+
+  for (const workTypeName of snapshotWorkTypes.keys()) {
+    if (documentWorkTypes.has(workTypeName)) {
+      return true;
     }
   }
 
@@ -148,10 +164,18 @@ export function resolveObserveModeFactoryDefinition({
     return snapshotFactory;
   }
 
+  if (workTypeStateMap(snapshotFactory).size === 0) {
+    return snapshotFactory;
+  }
+
   if (
     !doesFactoryDefinitionChangeAffectGraphTopology(document, snapshotFactory)
   ) {
     return document;
+  }
+
+  if (!sharesWorkTypeSkeletonWithSnapshot(document, snapshotFactory)) {
+    return snapshotFactory;
   }
 
   if (isDocumentWorkTypeStructureAheadOfSnapshot(document, snapshotFactory)) {

--- a/ui/src/features/workflow-activity/hooks/observe-mode-factory-definition.ts
+++ b/ui/src/features/workflow-activity/hooks/observe-mode-factory-definition.ts
@@ -5,22 +5,66 @@ import { doesFactoryDefinitionChangeAffectGraphTopology } from "../../factory-gr
 
 type FactoryDefinitionLike = NonNullable<DashboardSnapshot["factory"]>;
 
-function factoryWorkTypeStateSkeleton(
+function workTypeStateMap(
   factory: FactoryDefinitionLike,
-): string {
-  const workTypes = [...(factory.workTypes ?? [])].sort((left, right) =>
-    left.name.localeCompare(right.name),
-  );
+): Map<string, Set<string>> {
+  const statesByWorkType = new Map<string, Set<string>>();
 
-  return workTypes
-    .map((workType) => {
-      const states = [...(workType.states ?? [])]
-        .map((state) => state.name)
-        .sort()
-        .join(",");
-      return `${workType.name}:${states}`;
-    })
-    .join("|");
+  for (const workType of factory.workTypes ?? []) {
+    statesByWorkType.set(
+      workType.name,
+      new Set((workType.states ?? []).map((state) => state.name)),
+    );
+  }
+
+  return statesByWorkType;
+}
+
+function isDocumentWorkTypeStructureAheadOfSnapshot(
+  document: CurrentFactoryDocument,
+  snapshotFactory: FactoryDefinitionLike,
+): boolean {
+  const documentWorkTypes = workTypeStateMap(document);
+  const snapshotWorkTypes = workTypeStateMap(snapshotFactory);
+
+  for (const [workTypeName, documentStates] of documentWorkTypes) {
+    const snapshotStates = snapshotWorkTypes.get(workTypeName);
+    if (!snapshotStates) {
+      return true;
+    }
+
+    const includesAllSnapshotStates = [...snapshotStates].every((stateName) =>
+      documentStates.has(stateName),
+    );
+    const addsStates = [...documentStates].some(
+      (stateName) => !snapshotStates.has(stateName),
+    );
+
+    if (includesAllSnapshotStates && addsStates) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isSnapshotWorkTypeReplayProjection(
+  document: CurrentFactoryDocument,
+  snapshotFactory: FactoryDefinitionLike,
+): boolean {
+  const documentWorkTypes = workTypeStateMap(document);
+  const snapshotWorkTypes = workTypeStateMap(snapshotFactory);
+
+  return [...snapshotWorkTypes].some(([workTypeName, snapshotStates]) => {
+    const documentStates = documentWorkTypes.get(workTypeName);
+    if (!documentStates) {
+      return false;
+    }
+
+    return [...snapshotStates].some(
+      (stateName) => !documentStates.has(stateName),
+    );
+  });
 }
 
 function factoryWorkstationIds(factory: FactoryDefinitionLike): Set<string> {
@@ -75,10 +119,11 @@ export function resolveObserveModeFactoryDefinition({
     return document;
   }
 
-  if (
-    factoryWorkTypeStateSkeleton(document) !==
-    factoryWorkTypeStateSkeleton(snapshotFactory)
-  ) {
+  if (isDocumentWorkTypeStructureAheadOfSnapshot(document, snapshotFactory)) {
+    return document;
+  }
+
+  if (isSnapshotWorkTypeReplayProjection(document, snapshotFactory)) {
     return snapshotFactory;
   }
 

--- a/ui/src/features/workflow-activity/hooks/observe-mode-factory-definition.ts
+++ b/ui/src/features/workflow-activity/hooks/observe-mode-factory-definition.ts
@@ -58,7 +58,7 @@ function isSnapshotWorkTypeReplayProjection(
   return [...snapshotWorkTypes].some(([workTypeName, snapshotStates]) => {
     const documentStates = documentWorkTypes.get(workTypeName);
     if (!documentStates) {
-      return false;
+      return snapshotStates.size > 0;
     }
 
     return [...snapshotStates].some(
@@ -81,6 +81,10 @@ function isSnapshotFactoryStrictWorkstationSuperset(
 ): boolean {
   const snapshotWorkstations = factoryWorkstationIds(snapshotFactory);
   const documentWorkstations = factoryWorkstationIds(document);
+
+  if (documentWorkstations.size === 0) {
+    return false;
+  }
 
   if (snapshotWorkstations.size <= documentWorkstations.size) {
     return false;

--- a/ui/src/features/workflow-activity/hooks/observe-mode-factory-definition.ts
+++ b/ui/src/features/workflow-activity/hooks/observe-mode-factory-definition.ts
@@ -20,6 +20,17 @@ function workTypeStateMap(
   return statesByWorkType;
 }
 
+function isSavedDocumentMinimalReplayStub(
+  document: CurrentFactoryDocument,
+): boolean {
+  return (
+    (document.workTypes?.length ?? 0) === 0 &&
+    (document.workstations?.length ?? 0) === 0 &&
+    (document.workers?.length ?? 0) === 0 &&
+    (document.resources?.length ?? 0) === 0
+  );
+}
+
 function isDocumentWorkTypeStructureAheadOfSnapshot(
   document: CurrentFactoryDocument,
   snapshotFactory: FactoryDefinitionLike,
@@ -27,21 +38,37 @@ function isDocumentWorkTypeStructureAheadOfSnapshot(
   const documentWorkTypes = workTypeStateMap(document);
   const snapshotWorkTypes = workTypeStateMap(snapshotFactory);
 
+  if (snapshotWorkTypes.size === 0) {
+    return documentWorkTypes.size > 0;
+  }
+
+  for (const [workTypeName, snapshotStates] of snapshotWorkTypes) {
+    const documentStates = documentWorkTypes.get(workTypeName);
+    if (!documentStates) {
+      return false;
+    }
+
+    for (const stateName of snapshotStates) {
+      if (!documentStates.has(stateName)) {
+        return false;
+      }
+    }
+  }
+
+  if (documentWorkTypes.size > snapshotWorkTypes.size) {
+    return true;
+  }
+
   for (const [workTypeName, documentStates] of documentWorkTypes) {
     const snapshotStates = snapshotWorkTypes.get(workTypeName);
     if (!snapshotStates) {
-      return true;
+      continue;
     }
 
-    const includesAllSnapshotStates = [...snapshotStates].every((stateName) =>
-      documentStates.has(stateName),
-    );
-    const addsStates = [...documentStates].some(
-      (stateName) => !snapshotStates.has(stateName),
-    );
-
-    if (includesAllSnapshotStates && addsStates) {
-      return true;
+    for (const stateName of documentStates) {
+      if (!snapshotStates.has(stateName)) {
+        return true;
+      }
     }
   }
 
@@ -114,6 +141,10 @@ export function resolveObserveModeFactoryDefinition({
   }
 
   if (timelineMode === "fixed") {
+    return snapshotFactory;
+  }
+
+  if (isSavedDocumentMinimalReplayStub(document)) {
     return snapshotFactory;
   }
 

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-layout.test.tsx
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-layout.test.tsx
@@ -1,11 +1,13 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import type { DashboardSnapshot } from "../../../api/dashboard/types";
 import { singleNodeDashboardSnapshot } from "../../../components/dashboard/test-fixtures";
+import { buildFactoryGraphLayoutTopologyKey } from "../../factory-graph-editor/lib/factory-graph-topology-impact";
 import type { GraphLayout } from "../../flowchart/lib/layout";
 import {
   useCurrentActivityGraphLayout,
   useCurrentActivityGraphLayoutForFactory,
 } from "./react-flow-current-activity-card-graph-layout";
+import * as currentActivityFactoryGraphLayout from "../lib/current-activity-factory-graph-layout";
 
 type BuildGraphLayout = (
   topology: typeof singleNodeDashboardSnapshot.topology,
@@ -237,6 +239,88 @@ describe("useCurrentActivityGraphLayout", () => {
       expect(result.current.edges).toHaveLength(0);
     });
     expect(mockBuildGraphLayout).not.toHaveBeenCalled();
+  });
+
+  it("reuses cached layout when a non-topology factory override arrives", async () => {
+    const buildLayoutSpy = vi.spyOn(
+      currentActivityFactoryGraphLayout,
+      "buildCurrentActivityGraphLayoutFromFactory",
+    );
+    const snapshot: DashboardSnapshot = {
+      ...structuredClone(singleNodeDashboardSnapshot),
+      factory: {
+        name: "prompt-only-cache-test",
+        resources: [{ capacity: 2, name: "gpu-prompt-cache" }],
+        workers: [
+          {
+            model: "gpt-5",
+            name: "writer-prompt-cache",
+            resources: [{ capacity: 1, name: "gpu-prompt-cache" }],
+            type: "MODEL_WORKER",
+          },
+        ],
+        workTypes: [
+          {
+            name: "story-prompt-cache",
+            states: [
+              { name: "queued", type: "INITIAL" },
+              { name: "done", type: "TERMINAL" },
+            ],
+          },
+        ],
+        workstations: [
+          {
+            body: "Original prompt.",
+            id: "draft-prompt-cache",
+            inputs: [{ state: "queued", workType: "story-prompt-cache" }],
+            name: "Draft Prompt Cache",
+            outputs: [{ state: "done", workType: "story-prompt-cache" }],
+            resources: [{ capacity: 1, name: "gpu-prompt-cache" }],
+            type: "MODEL_WORKSTATION",
+            worker: "writer-prompt-cache",
+          },
+        ],
+      },
+      topology: {
+        edges: [],
+        workstation_node_ids: [],
+        workstation_nodes_by_id: {},
+      },
+    };
+    const promptOnlyUpdate: NonNullable<DashboardSnapshot["factory"]> = {
+      ...structuredClone(snapshot.factory ?? {}),
+      workstations: [
+        {
+          ...(snapshot.factory?.workstations?.[0] ?? {}),
+          body: "Updated prompt only.",
+        },
+      ],
+    };
+
+    expect(buildFactoryGraphLayoutTopologyKey(snapshot.factory ?? {})).toBe(
+      buildFactoryGraphLayoutTopologyKey(promptOnlyUpdate),
+    );
+
+    const { result, rerender } = renderHook(
+      ({ factoryOverride }) =>
+        useCurrentActivityGraphLayoutForFactory(snapshot, factoryOverride),
+      { initialProps: { factoryOverride: snapshot.factory } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.nodes.length).toBeGreaterThan(0);
+    });
+    const callsAfterInitialRender = buildLayoutSpy.mock.calls.length;
+    expect(callsAfterInitialRender).toBeGreaterThan(0);
+
+    rerender({ factoryOverride: promptOnlyUpdate });
+
+    await waitFor(() => {
+      expect(result.current.nodes.length).toBeGreaterThan(0);
+    });
+    expect(buildLayoutSpy.mock.calls.length).toBe(callsAfterInitialRender);
+
+    buildLayoutSpy.mockRestore();
   });
 });
 

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-layout.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-layout.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 
 import type { DashboardSnapshot } from "../../../api/dashboard/types";
 import type { FactoryGraphNodeKind } from "../../factory-graph-editor/lib/factory-graph-draft-types";
+import { buildFactoryGraphLayoutTopologyKey } from "../../factory-graph-editor/lib/factory-graph-topology-impact";
 import type { GraphLayout } from "../../flowchart/lib/layout";
 import { buildCurrentActivityGraphLayoutFromFactory } from "../lib/current-activity-factory-graph-layout";
 import { EMPTY_GRAPH_LAYOUT } from "../lib/react-flow-current-activity-card-graph";
@@ -38,7 +39,7 @@ export function useCurrentActivityGraphLayoutForFactory(
         ? {
             factory,
             hiddenClassesKey,
-            key: `${currentActivityFactoryKey(factory)}|hidden:${hiddenClassesKey}`,
+            key: `${buildFactoryGraphLayoutTopologyKey(factory)}|hidden:${hiddenClassesKey}`,
             kind: "factory" as const,
           }
         : {
@@ -68,60 +69,4 @@ export function useCurrentActivityGraphLayoutForFactory(
 
 function identityGraphLayout(layout: GraphLayout) {
   return layout;
-}
-
-function currentActivityFactoryKey(
-  factory: NonNullable<DashboardSnapshot["factory"]>,
-): string {
-  const legacyFactory = factory as typeof factory & {
-    work_types?: typeof factory.workTypes;
-  };
-  return JSON.stringify({
-    resources: (factory.resources ?? [])
-      .map((resource) => resource.name)
-      .sort(),
-    workers: (factory.workers ?? [])
-      .map((worker) => ({
-        name: worker.name,
-        resources: (worker.resources ?? [])
-          .map((resource) => resource.name)
-          .sort(),
-      }))
-      .sort((left, right) => left.name.localeCompare(right.name)),
-    workTypes: (factory.workTypes ?? legacyFactory.work_types ?? [])
-      .map((workType) => ({
-        name: workType.name,
-        states: workType.states.map((state) => ({
-          name: state.name,
-          type: state.type,
-        })),
-      }))
-      .sort((left, right) => left.name.localeCompare(right.name)),
-    workstations: (factory.workstations ?? [])
-      .map((workstation) => ({
-        id: workstation.id ?? "",
-        inputs: workstation.inputs ?? [],
-        name: workstation.name,
-        onContinue:
-          workstation.onContinue ??
-          (workstation as typeof workstation & { on_continue?: unknown })
-            .on_continue ??
-          [],
-        onFailure:
-          workstation.onFailure ??
-          (workstation as typeof workstation & { on_failure?: unknown })
-            .on_failure ??
-          [],
-        onRejection:
-          workstation.onRejection ??
-          (workstation as typeof workstation & { on_rejection?: unknown })
-            .on_rejection ??
-          [],
-        outputs: workstation.outputs ?? [],
-        resources: workstation.resources ?? [],
-        type: workstation.type ?? "",
-        worker: workstation.worker,
-      }))
-      .sort((left, right) => left.name.localeCompare(right.name)),
-  });
 }

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.test.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.test.ts
@@ -32,7 +32,7 @@ function createEditorStub(
 }
 
 describe("currentActivityCardFactoryDefinition", () => {
-  it("returns null in observe mode while the scoped factory document is pending", () => {
+  it("returns the timeline snapshot in observe mode while the scoped factory document is pending", () => {
     const snapshot = structuredClone(singleNodeDashboardSnapshot);
 
     expect(
@@ -44,7 +44,7 @@ describe("currentActivityCardFactoryDefinition", () => {
         snapshot,
         "current",
       ),
-    ).toBeNull();
+    ).toEqual(snapshot.factory);
   });
 
   it("returns the saved factory document in observe mode once the scoped factory document succeeds", () => {

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.test.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.test.ts
@@ -94,4 +94,57 @@ describe("currentActivityCardFactoryDefinition", () => {
       ),
     ).toEqual(baseFactoryDefinitionDocument);
   });
+
+  it("keeps the pending draft definition in editor mode when a topology save updates the saved document", () => {
+    const snapshot = structuredClone(singleNodeDashboardSnapshot);
+    const pendingDraft = {
+      ...baseFactoryDefinitionDocument,
+      workers: [
+        ...(baseFactoryDefinitionDocument.workers ?? []),
+        {
+          model: "gpt-5-mini",
+          name: "reviewer",
+          type: "MODEL_WORKER" as const,
+        },
+      ],
+    };
+    const savedAfterTopologyChange = {
+      ...baseFactoryDefinitionDocument,
+      version: {
+        logical: "10",
+        physical: "2026-06-01T12:00:00Z",
+      },
+      workstations: [
+        {
+          ...(baseFactoryDefinitionDocument.workstations?.[0] ?? {
+            inputs: [],
+            name: "draft",
+            outputs: [],
+            type: "MODEL_WORKSTATION" as const,
+          }),
+          worker: "reviewer",
+        },
+      ],
+    };
+    const draftState = createMockGraphEditorDraftState({
+      baseDocument: baseFactoryDefinitionDocument,
+      hasChanges: true,
+      latestDocument: savedAfterTopologyChange,
+      pendingFactoryDefinition: pendingDraft,
+    });
+
+    expect(
+      currentActivityCardFactoryDefinition(
+        createEditorStub({
+          draftState,
+          editableDefinitionQuery: {
+            data: savedAfterTopologyChange,
+            status: "success",
+          },
+          editorMode: true,
+        }),
+        snapshot,
+      ),
+    ).toEqual(pendingDraft);
+  });
 });

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.test.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.test.ts
@@ -4,6 +4,7 @@ import { singleNodeDashboardSnapshot } from "../../../components/dashboard/test-
 import {
   baseFactoryDefinitionDocument,
   createMockGraphEditorDraftState,
+  divergentDocumentPlaneFactoryDocument,
 } from "../../../testing/graph-editor-harness";
 import { currentActivityCardFactoryDefinition } from "./react-flow-current-activity-card-graph-view-model";
 
@@ -11,6 +12,7 @@ function createEditorStub(
   overrides: {
     draftState?: ReturnType<typeof createMockGraphEditorDraftState>;
     editableDefinitionQuery?: {
+      data?: typeof baseFactoryDefinitionDocument;
       status: "error" | "pending" | "success";
     };
     editorMode?: boolean;
@@ -19,6 +21,9 @@ function createEditorStub(
   return {
     draftState: overrides.draftState ?? createMockGraphEditorDraftState(),
     editableDefinitionQuery: {
+      data:
+        overrides.editableDefinitionQuery?.data ??
+        baseFactoryDefinitionDocument,
       status: overrides.editableDefinitionQuery?.status ?? "success",
     },
     editorMode: overrides.editorMode ?? false,
@@ -40,18 +45,21 @@ describe("currentActivityCardFactoryDefinition", () => {
     ).toBeNull();
   });
 
-  it("returns undefined in observe mode once the scoped factory document succeeds", () => {
+  it("returns the saved factory document in observe mode once the scoped factory document succeeds", () => {
     const snapshot = structuredClone(singleNodeDashboardSnapshot);
 
     expect(
       currentActivityCardFactoryDefinition(
         createEditorStub({
-          editableDefinitionQuery: { status: "success" },
+          editableDefinitionQuery: {
+            data: divergentDocumentPlaneFactoryDocument,
+            status: "success",
+          },
           editorMode: false,
         }),
         snapshot,
       ),
-    ).toBeUndefined();
+    ).toEqual(divergentDocumentPlaneFactoryDocument);
   });
 
   it("returns null in editor mode while the scoped factory document is pending", () => {

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.test.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { singleNodeDashboardSnapshot } from "../../../components/dashboard/test-fixtures";
 import {
   baseFactoryDefinitionDocument,
+  buildDivergentPlaneDashboardSnapshot,
   createMockGraphEditorDraftState,
   divergentDocumentPlaneFactoryDocument,
 } from "../../../testing/graph-editor-harness";
@@ -41,12 +42,13 @@ describe("currentActivityCardFactoryDefinition", () => {
           editorMode: false,
         }),
         snapshot,
+        "current",
       ),
     ).toBeNull();
   });
 
   it("returns the saved factory document in observe mode once the scoped factory document succeeds", () => {
-    const snapshot = structuredClone(singleNodeDashboardSnapshot);
+    const snapshot = buildDivergentPlaneDashboardSnapshot();
 
     expect(
       currentActivityCardFactoryDefinition(
@@ -58,6 +60,7 @@ describe("currentActivityCardFactoryDefinition", () => {
           editorMode: false,
         }),
         snapshot,
+        "current",
       ),
     ).toEqual(divergentDocumentPlaneFactoryDocument);
   });
@@ -72,6 +75,7 @@ describe("currentActivityCardFactoryDefinition", () => {
           editorMode: true,
         }),
         snapshot,
+        "current",
       ),
     ).toBeNull();
   });
@@ -91,6 +95,7 @@ describe("currentActivityCardFactoryDefinition", () => {
           editorMode: true,
         }),
         snapshot,
+        "current",
       ),
     ).toEqual(baseFactoryDefinitionDocument);
   });
@@ -144,6 +149,7 @@ describe("currentActivityCardFactoryDefinition", () => {
           editorMode: true,
         }),
         snapshot,
+        "current",
       ),
     ).toEqual(pendingDraft);
   });

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
@@ -31,6 +31,8 @@ import {
   useActiveExecutions,
 } from "./react-flow-current-activity-card-active-executions";
 import type { useCurrentActivityGraphEditor } from "./react-flow-current-activity-card-editor";
+import { useFactoryTimelineStore } from "../../timeline/state/factoryTimelineStore";
+import { resolveObserveModeFactoryDefinition } from "./observe-mode-factory-definition";
 import { useCurrentActivityGraphLayoutForFactory } from "./react-flow-current-activity-card-graph-layout";
 import { useTopologyStableFactoryForLayout } from "./use-topology-stable-factory-for-layout";
 
@@ -165,14 +167,15 @@ function useActiveGraphHighlights({
 
 export function currentActivityCardFactoryDefinition(
   editor: ReturnType<typeof useCurrentActivityGraphEditor>,
-  _snapshot: DashboardSnapshot,
+  snapshot: DashboardSnapshot,
+  timelineMode: ReturnType<typeof useFactoryTimelineStore.getState>["mode"],
 ): DashboardSnapshot["factory"] | null | undefined {
   if (editor.editableDefinitionQuery?.status !== "success") {
     return null;
   }
 
   if (!editor.editorMode) {
-    return observeModeFactoryDefinition(editor);
+    return observeModeFactoryDefinition(editor, snapshot, timelineMode);
   }
 
   return editorModeFactoryDefinition(editor) ?? null;
@@ -180,8 +183,19 @@ export function currentActivityCardFactoryDefinition(
 
 function observeModeFactoryDefinition(
   editor: ReturnType<typeof useCurrentActivityGraphEditor>,
+  snapshot: DashboardSnapshot,
+  timelineMode: ReturnType<typeof useFactoryTimelineStore.getState>["mode"],
 ): DashboardSnapshot["factory"] | undefined {
-  return editor.editableDefinitionQuery?.data ?? undefined;
+  const document = editor.editableDefinitionQuery?.data;
+  if (!document) {
+    return snapshot.factory;
+  }
+
+  return resolveObserveModeFactoryDefinition({
+    document,
+    snapshotFactory: snapshot.factory,
+    timelineMode,
+  });
 }
 
 function editorModeFactoryDefinition(
@@ -236,9 +250,11 @@ function useStableCurrentActivityGraphLayout(
   snapshot: DashboardSnapshot,
   editor: ReturnType<typeof useCurrentActivityGraphEditor>,
 ) {
+  const timelineMode = useFactoryTimelineStore((state) => state.mode);
   const displayFactoryDefinition = currentActivityCardFactoryDefinition(
     editor,
     snapshot,
+    timelineMode,
   );
   const layoutFactoryDefinition = useTopologyStableFactoryForLayout(
     displayFactoryDefinition,

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
@@ -207,10 +207,16 @@ export function currentActivityCardFactoryDefinition(
   }
 
   if (!editor.editorMode) {
-    return undefined;
+    return observeModeFactoryDefinition(editor);
   }
 
   return editorModeFactoryDefinition(editor) ?? null;
+}
+
+function observeModeFactoryDefinition(
+  editor: ReturnType<typeof useCurrentActivityGraphEditor>,
+): DashboardSnapshot["factory"] | undefined {
+  return editor.editableDefinitionQuery?.data ?? undefined;
 }
 
 function editorModeFactoryDefinition(

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
@@ -11,6 +11,7 @@ import type {
 } from "../../../api/dashboard/types";
 import type { GraphLayout } from "../../flowchart/lib/layout";
 import type { CurrentActivityNode } from "../../flowchart/public";
+import { useFactoryTimelineStore } from "../../timeline/state/factoryTimelineStore";
 import { buildVisibleGraphEdgesWithDraft } from "../lib/react-flow-current-activity-card-draft-edges";
 import {
   buildGraphEdges,
@@ -26,13 +27,12 @@ import {
 import { currentActivityGraphKey } from "../lib/react-flow-current-activity-card-keys";
 import type { CurrentActivitySelection } from "../lib/react-flow-current-activity-card-types";
 import { useCurrentActivityGraphStore } from "../state/currentActivityGraphStore";
+import { resolveObserveModeFactoryDefinition } from "./observe-mode-factory-definition";
 import {
   groupActiveExecutionsByWorkstationNodeID,
   useActiveExecutions,
 } from "./react-flow-current-activity-card-active-executions";
 import type { useCurrentActivityGraphEditor } from "./react-flow-current-activity-card-editor";
-import { useFactoryTimelineStore } from "../../timeline/state/factoryTimelineStore";
-import { resolveObserveModeFactoryDefinition } from "./observe-mode-factory-definition";
 import { useCurrentActivityGraphLayoutForFactory } from "./react-flow-current-activity-card-graph-layout";
 import { useTopologyStableFactoryForLayout } from "./use-topology-stable-factory-for-layout";
 
@@ -170,12 +170,16 @@ export function currentActivityCardFactoryDefinition(
   snapshot: DashboardSnapshot,
   timelineMode: ReturnType<typeof useFactoryTimelineStore.getState>["mode"],
 ): DashboardSnapshot["factory"] | null | undefined {
-  if (editor.editableDefinitionQuery?.status !== "success") {
-    return null;
+  if (!editor.editorMode) {
+    if (editor.editableDefinitionQuery?.status !== "success") {
+      return snapshot.factory ?? null;
+    }
+
+    return observeModeFactoryDefinition(editor, snapshot, timelineMode);
   }
 
-  if (!editor.editorMode) {
-    return observeModeFactoryDefinition(editor, snapshot, timelineMode);
+  if (editor.editableDefinitionQuery?.status !== "success") {
+    return null;
   }
 
   return editorModeFactoryDefinition(editor) ?? null;

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
@@ -32,6 +32,7 @@ import {
 } from "./react-flow-current-activity-card-active-executions";
 import type { useCurrentActivityGraphEditor } from "./react-flow-current-activity-card-editor";
 import { useCurrentActivityGraphLayoutForFactory } from "./react-flow-current-activity-card-graph-layout";
+import { useTopologyStableFactoryForLayout } from "./use-topology-stable-factory-for-layout";
 
 export type CurrentActivityGraphViewModelInput = {
   editor: ReturnType<typeof useCurrentActivityGraphEditor>;
@@ -162,42 +163,6 @@ function useActiveGraphHighlights({
   );
 }
 
-function useCurrentActivityDisplayNodes(baseNodes: CurrentActivityNode[]) {
-  const [nodes, setNodes] = useState<CurrentActivityNode[]>([]);
-
-  useEffect(() => {
-    setNodes((currentNodes) => {
-      const currentPositions = new Map(
-        currentNodes.map((node) => [node.id, node.position]),
-      );
-      return baseNodes.map((node) => ({
-        ...node,
-        position: currentPositions.get(node.id) ?? node.position,
-      }));
-    });
-  }, [baseNodes]);
-
-  const handleNodesChange = useCallback((changes: NodeChange[]) => {
-    setNodes(
-      (currentNodes) =>
-        applyNodeChanges(changes, currentNodes) as CurrentActivityNode[],
-    );
-  }, []);
-
-  const displayNodes = useMemo(() => {
-    const positionOverrides = new Map(
-      nodes.map((node) => [node.id, node.position] as const),
-    );
-
-    return baseNodes.map((node) => ({
-      ...node,
-      position: positionOverrides.get(node.id) ?? node.position,
-    }));
-  }, [baseNodes, nodes]);
-
-  return { displayNodes, handleNodesChange };
-}
-
 export function currentActivityCardFactoryDefinition(
   editor: ReturnType<typeof useCurrentActivityGraphEditor>,
   _snapshot: DashboardSnapshot,
@@ -230,15 +195,61 @@ function editorModeFactoryDefinition(
   );
 }
 
-function useEditorCurrentActivityGraphLayout(
+function useCurrentActivityGraphNodePresentation(
+  baseNodes: CurrentActivityNode[],
+) {
+  const [nodes, setNodes] = useState<CurrentActivityNode[]>([]);
+
+  useEffect(() => {
+    setNodes((currentNodes) => {
+      const currentPositions = new Map(
+        currentNodes.map((node) => [node.id, node.position]),
+      );
+      return baseNodes.map((node) => ({
+        ...node,
+        position: currentPositions.get(node.id) ?? node.position,
+      }));
+    });
+  }, [baseNodes]);
+
+  const handleNodesChange = useCallback((changes: NodeChange[]) => {
+    setNodes(
+      (currentNodes) =>
+        applyNodeChanges(changes, currentNodes) as CurrentActivityNode[],
+    );
+  }, []);
+  const displayNodes = useMemo(() => {
+    const positionOverrides = new Map(
+      nodes.map((node) => [node.id, node.position] as const),
+    );
+
+    return baseNodes.map((node) => ({
+      ...node,
+      position: positionOverrides.get(node.id) ?? node.position,
+    }));
+  }, [baseNodes, nodes]);
+
+  return { displayNodes, handleNodesChange };
+}
+
+function useStableCurrentActivityGraphLayout(
   snapshot: DashboardSnapshot,
   editor: ReturnType<typeof useCurrentActivityGraphEditor>,
 ) {
-  return useCurrentActivityGraphLayoutForFactory(
+  const displayFactoryDefinition = currentActivityCardFactoryDefinition(
+    editor,
     snapshot,
-    currentActivityCardFactoryDefinition(editor, snapshot),
+  );
+  const layoutFactoryDefinition = useTopologyStableFactoryForLayout(
+    displayFactoryDefinition,
+  );
+  const graphLayout = useCurrentActivityGraphLayoutForFactory(
+    snapshot,
+    layoutFactoryDefinition,
     editor.hiddenNodeClasses,
   );
+
+  return { displayFactoryDefinition, graphLayout };
 }
 
 function useCurrentActivityGraphEdges({
@@ -303,7 +314,8 @@ export function useCurrentActivityGraphViewModel({
     () => groupActiveExecutionsByWorkstationNodeID(activeExecutions),
     [activeExecutions],
   );
-  const graphLayout = useEditorCurrentActivityGraphLayout(snapshot, editor);
+  const { displayFactoryDefinition, graphLayout } =
+    useStableCurrentActivityGraphLayout(snapshot, editor);
   const graphKey = useMemo(
     () => currentActivityGraphKey(graphLayout),
     [graphLayout],
@@ -340,8 +352,7 @@ export function useCurrentActivityGraphViewModel({
     activeGraphHighlights,
     activeItemLabelsByPlaceId,
     editor,
-    factoryDefinition:
-      currentActivityCardFactoryDefinition(editor, snapshot) ?? undefined,
+    factoryDefinition: displayFactoryDefinition ?? undefined,
     graphLayout,
     locale,
     now,
@@ -356,7 +367,7 @@ export function useCurrentActivityGraphViewModel({
     storedNodePositions,
   });
   const { displayNodes, handleNodesChange } =
-    useCurrentActivityDisplayNodes(baseNodes);
+    useCurrentActivityGraphNodePresentation(baseNodes);
   const edges = useCurrentActivityGraphEdges({
     activeGraphHighlights,
     displayNodes,

--- a/ui/src/features/workflow-activity/hooks/use-topology-stable-factory-for-layout.test.ts
+++ b/ui/src/features/workflow-activity/hooks/use-topology-stable-factory-for-layout.test.ts
@@ -1,0 +1,62 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { baseFactoryDefinition } from "../../factory-graph-editor/lib/factory-graph-draft.test-helpers";
+import type { CanonicalFactoryDefinition } from "../../factory-graph-editor/lib/factory-graph-draft-types";
+import { useTopologyStableFactoryForLayout } from "./use-topology-stable-factory-for-layout";
+
+function cloneDefinition(): CanonicalFactoryDefinition {
+  return structuredClone(baseFactoryDefinition);
+}
+
+describe("useTopologyStableFactoryForLayout", () => {
+  it("keeps the previous factory reference when only non-topology fields change", () => {
+    const previous = cloneDefinition();
+    const next = cloneDefinition();
+    next.workstations = [
+      {
+        ...(next.workstations?.[0] ?? {}),
+        body: "Updated workstation instructions.",
+      },
+    ];
+
+    const { result, rerender } = renderHook(
+      ({ factory }) => useTopologyStableFactoryForLayout(factory),
+      { initialProps: { factory: previous } },
+    );
+
+    expect(result.current).toBe(previous);
+
+    rerender({ factory: next });
+
+    expect(result.current).toBe(previous);
+  });
+
+  it("returns the new factory reference when topology changes", () => {
+    const previous = cloneDefinition();
+    const next = cloneDefinition();
+    next.workers = [
+      ...(next.workers ?? []),
+      {
+        model: "gpt-5",
+        name: "reviewer",
+        type: "MODEL_WORKER",
+      },
+    ];
+    next.workstations = [
+      {
+        ...(next.workstations?.[0] ?? {}),
+        worker: "reviewer",
+      },
+    ];
+
+    const { result, rerender } = renderHook(
+      ({ factory }) => useTopologyStableFactoryForLayout(factory),
+      { initialProps: { factory: previous } },
+    );
+
+    rerender({ factory: next });
+
+    expect(result.current).toBe(next);
+  });
+});

--- a/ui/src/features/workflow-activity/hooks/use-topology-stable-factory-for-layout.ts
+++ b/ui/src/features/workflow-activity/hooks/use-topology-stable-factory-for-layout.ts
@@ -10,13 +10,18 @@ import { doesFactoryDefinitionChangeAffectGraphTopology } from "../../factory-gr
  */
 export function useTopologyStableFactoryForLayout(
   factory: DashboardSnapshot["factory"] | null | undefined,
-): DashboardSnapshot["factory"] | undefined {
+): DashboardSnapshot["factory"] | null | undefined {
   const stableFactoryRef = useRef<
     NonNullable<DashboardSnapshot["factory"]> | undefined
   >(undefined);
 
   return useMemo(() => {
-    if (!factory) {
+    if (factory === null) {
+      stableFactoryRef.current = undefined;
+      return null;
+    }
+
+    if (factory === undefined) {
       stableFactoryRef.current = undefined;
       return undefined;
     }

--- a/ui/src/features/workflow-activity/hooks/use-topology-stable-factory-for-layout.ts
+++ b/ui/src/features/workflow-activity/hooks/use-topology-stable-factory-for-layout.ts
@@ -1,0 +1,35 @@
+import { useMemo, useRef } from "react";
+
+import type { DashboardSnapshot } from "../../../api/dashboard/types";
+import { doesFactoryDefinitionChangeAffectGraphTopology } from "../../factory-graph-editor/lib/factory-graph-topology-impact";
+
+/**
+ * Keeps the factory definition reference used for graph layout stable across
+ * non-topology document updates so layout cache keys and persisted positions
+ * are not invalidated by prompt-only or other metadata saves.
+ */
+export function useTopologyStableFactoryForLayout(
+  factory: DashboardSnapshot["factory"] | null | undefined,
+): DashboardSnapshot["factory"] | undefined {
+  const stableFactoryRef = useRef<
+    NonNullable<DashboardSnapshot["factory"]> | undefined
+  >(undefined);
+
+  return useMemo(() => {
+    if (!factory) {
+      stableFactoryRef.current = undefined;
+      return undefined;
+    }
+
+    const previous = stableFactoryRef.current;
+    if (
+      previous &&
+      !doesFactoryDefinitionChangeAffectGraphTopology(previous, factory)
+    ) {
+      return previous;
+    }
+
+    stableFactoryRef.current = factory;
+    return factory;
+  }, [factory]);
+}

--- a/ui/src/testing/app-shell-test-utils.tsx
+++ b/ui/src/testing/app-shell-test-utils.tsx
@@ -19,7 +19,10 @@ import { installDashboardBrowserTestShims } from "../components/dashboard/test-b
 import { semanticWorkflowDashboardSnapshot } from "../components/dashboard/test-fixtures";
 import { reloadDashboardLayoutFromStorage } from "../features/bento/hooks/useDashboardLayout";
 import { useDashboardBentoStore } from "../features/bento/state/dashboardBentoStore";
-import { useCurrentFactoryDocument } from "../features/current-factory-definition/hooks/useCurrentFactoryDefinition";
+import {
+  currentFactoryDocumentQueryKey,
+  useCurrentFactoryDocument,
+} from "../features/current-factory-definition/hooks/useCurrentFactoryDefinition";
 import { resetSelectionHistoryStore } from "../features/current-selection/base/public";
 import { useDashboardSessionStore } from "../features/dashboard/state/dashboardSessionStore";
 import {
@@ -43,7 +46,7 @@ import { DashboardSessionTestProvider } from "./dashboard-session-test-provider"
 import {
   isSessionFactoryRequest,
   mockGetSessionFactory,
-  sessionFactoryNamedExportDocument,
+  sessionFactoryDocumentFromSnapshot,
 } from "./session-factory-mocks";
 
 export {
@@ -219,6 +222,10 @@ export function renderApp({
     },
   });
   queryClients.push(queryClient);
+  queryClient.setQueryData(
+    currentFactoryDocumentQueryKey(sessionID ?? DEFAULT_FACTORY_SESSION_ID),
+    sessionFactoryDocumentFromSnapshot(snapshot),
+  );
 
   const fetchMock: FetchMock = vi
     .fn()
@@ -237,7 +244,7 @@ export function renderApp({
         isSessionFactoryRequest(path, method, sessionID ?? undefined)
       ) {
         return mockGetSessionFactory({
-          document: sessionFactoryNamedExportDocument,
+          document: sessionFactoryDocumentFromSnapshot(snapshot),
         });
       }
 

--- a/ui/src/testing/app-shell-test-utils.tsx
+++ b/ui/src/testing/app-shell-test-utils.tsx
@@ -97,6 +97,7 @@ interface RenderAppOptions {
   locationSearch?: string | null;
   sessionID?: string | null;
   seedTimelineFromSnapshot?: boolean;
+  seedCurrentFactoryDocument?: boolean;
   snapshot: DashboardSnapshot;
   timelineEvents?: FactoryEvent[];
   timelineSnapshots?: DashboardSnapshot[];
@@ -206,6 +207,7 @@ export function renderApp({
   initialLocale,
   locationSearch,
   seedTimelineFromSnapshot = true,
+  seedCurrentFactoryDocument = true,
   sessionID,
   snapshot,
   timelineEvents,
@@ -222,10 +224,12 @@ export function renderApp({
     },
   });
   queryClients.push(queryClient);
-  queryClient.setQueryData(
-    currentFactoryDocumentQueryKey(sessionID ?? DEFAULT_FACTORY_SESSION_ID),
-    sessionFactoryDocumentFromSnapshot(snapshot),
-  );
+  if (seedCurrentFactoryDocument) {
+    queryClient.setQueryData(
+      currentFactoryDocumentQueryKey(sessionID ?? DEFAULT_FACTORY_SESSION_ID),
+      sessionFactoryDocumentFromSnapshot(snapshot),
+    );
+  }
 
   const fetchMock: FetchMock = vi
     .fn()

--- a/ui/src/testing/session-factory-mocks.ts
+++ b/ui/src/testing/session-factory-mocks.ts
@@ -3,6 +3,7 @@ import type {
   CurrentFactoryDocument,
   CurrentFactoryVersion,
 } from "../api/current-factory-definition";
+import type { DashboardSnapshot } from "../api/dashboard";
 import type { components } from "../api/generated/openapi";
 import type { ImportFactoryValue } from "../api/session-factory";
 import { currentFactorySessionPath } from "../api/session-routing";
@@ -39,6 +40,20 @@ export const sessionFactoryNamedExportDocument: SessionFactoryDocument = {
   name: "semantic-workflow",
   version: defaultSessionFactoryVersion,
 };
+
+export function sessionFactoryDocumentFromSnapshot(
+  snapshot: Pick<DashboardSnapshot, "factory">,
+  version: SessionFactoryVersion = defaultSessionFactoryVersion,
+): SessionFactoryDocument {
+  if (!snapshot.factory) {
+    return sessionFactoryNamedExportDocument;
+  }
+
+  return {
+    ...snapshot.factory,
+    version,
+  };
+}
 
 export interface MockGetSessionFactoryOptions {
   document?: SessionFactoryDocument;


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/issues3-current-selection-graph-refresh-topology",
  "description": "After current-selection saves that change factory topology, reload the factory graph from the saved running-factory document so nodes and routing update immediately, while non-structural saves preserve graph layout and manual node positions.",
  "context": {
    "customerAsk": "Saving work types, work states, workstations, workers, or resources refreshes the factory graph view. Non-topology saves do not unnecessarily reset graph layout. Graph reflects saved definition without manual reload.",
    "problem": "Current-selection saves update the running factory successfully but the factory graph card keeps showing pre-save topology until a page reload or delayed dashboard snapshot refresh. Observer-mode layout prefers snapshot.factory and does not reliably re-project from the saved current-factory document.",
    "solution": "Classify current-selection saves as topology-affecting or not. On topology-affecting success, reload graph definition and layout inputs from the saved current-factory document in observer and edit modes, reset graph draft baseline when no local draft exists, and preserve stale-draft behavior when a graph draft is dirty. On non-topology saves, avoid invalidating layout cache keys or clearing persisted node positions."
  },
  "acceptanceCriteria": [
    "Successful topology-affecting saves from current selection for work types, work states, workstations, workers, or resources update the factory graph to match the saved definition without a manual page reload.",
    "Topology-affecting changes include structural edits (add/remove/rename, routing, worker assignment, resource/worker links visible on the graph); non-topology edits do not force layout reset.",
    "Observer-mode graph layout uses the saved current-factory document when it reflects the successful save rather than a stale dashboard snapshot.",
    "Graph draft baseline reloads from the saved document when there are no local graph draft changes; dirty graph drafts are not silently discarded.",
    "Automated UI tests cover topology refresh per entity family and at least one non-topology save preserving layout/positions.",
    "Typecheck, lint, and tests pass for the UI package."
  ],
  "userStories": [
    {
      "id": "issues3-current-selection-graph-refresh-topology-001",
      "title": "Classify current-selection saves as topology-affecting or not",
      "description": "As an implementer, I need a shared, testable rule for whether a saved factory definition change alters graph structure so refresh behavior stays consistent across all current-selection save paths.",
      "acceptanceCriteria": [
        "A shared classifier accepts previous and next canonical factory definitions and returns whether the change affects graph topology.",
        "Returns true for structural changes to work types, work states, workstations, workers, or resources (add/remove/rename, routing arcs, workstation worker assignment, resource/worker graph links).",
        "Returns false when only non-structural fields change (for example workstation prompt/cron/guard-only edits with unchanged graph structure).",
        "Unit tests cover at least one positive and one negative case per entity family.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues3-current-selection-graph-refresh-topology-002",
      "title": "Reload graph definition after topology-affecting current-selection save",
      "description": "As a factory operator, I want the factory graph to update immediately after I save a structural change in current selection so I can confirm the running factory matches what I edited.",
      "acceptanceCriteria": [
        "After a successful topology-affecting save from workstation, worker, work type, work state, or resource current selection, the factory graph renders nodes, edges, and labels from the saved current-factory document without reloading the page.",
        "In observer mode (graph editor off), graph layout uses the saved current-factory document when it is newer than the dashboard snapshot factory.",
        "When the graph editor has no pending draft changes, the graph draft baseline reloads from the saved document.",
        "When the graph editor has pending draft changes, the saved document version updates and stale-draft warning behavior remains; the draft is not silently discarded.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill: change a workstation worker assignment in current selection, save, and confirm the graph updates without reload"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues3-current-selection-graph-refresh-topology-003",
      "title": "Preserve graph layout on non-topology current-selection saves",
      "description": "As a factory operator editing non-structural fields, I want the graph to stay visually stable so manual node positions and zoom are not reset by saves that do not change topology.",
      "acceptanceCriteria": [
        "After a successful non-topology save (for example workstation prompt-only edit), the factory graph does not re-run full layout recomputation solely because the save succeeded.",
        "Persisted node positions for the current graph key remain available after a non-topology save.",
        "The graph layout cache key does not change when the classifier reports no topology impact.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill: drag a graph node, save a non-structural workstation field, and confirm the node stays at the dragged position"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues3-current-selection-graph-refresh-topology-004",
      "title": "Regression coverage for all topology save entry points",
      "description": "As a maintainer, I want automated coverage across current-selection save hooks so graph refresh cannot regress silently for any topology entity type.",
      "acceptanceCriteria": [
        "Component or hook tests assert graph layout or topology inputs refresh after simulated successful topology saves for workstation, worker, work type, work state, and resource current-selection save flows.",
        "At least one test asserts non-topology workstation save does not trigger graph layout key invalidation.",
        "Tests use behavioral assertions (rendered labels, node counts, layout key stability) rather than source inventories.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)