### PR TITLE
issues3-header-save-discard-icons

### DIFF
--- a/prd.json
+++ b/prd.json
@@ -1,0 +1,134 @@
+{
+  "project": "Infinite You Dashboard UI",
+  "branchName": "ralph/issues3-header-save-discard-icons",
+  "description": "Move primary Save and Discard actions for all editable current-selection configuration panels into the bento card header as icon buttons, and remove labeled footer save and body-level discard/reset controls from configuration forms.",
+  "context": {
+    "customerAsk": "Discard (and save where missing) should live in the bento header as icon buttons for every editable current-selection type, consistent with panels that already header-mount save. Configuration body no longer hosts primary save/discard actions.",
+    "problem": "Discard and labeled footer Save still appear inside Configuration forms for workers, workstations, work states, work types, and resources, while header save icons already exist—creating duplicate Save affordances and forcing operators to scroll the form to discard local edits.",
+    "solution": "Add a shared header discard icon pattern, wire save and discard together in each selection kind's bento header action slot, connect discard to existing onResetToLatest handlers, remove EditableConfigurationSaveRow and body discard rows from configuration forms, and update Vitest and browser verification so header actions are the only primary save/discard entry points."
+  },
+  "acceptanceCriteria": [
+    "Editable workstation, worker, work type, work state, and resource selections show Save and Discard local changes as icon-only controls in the bento header when configuration is dirty and editable",
+    "Configuration form bodies do not render EditableConfigurationSaveRow, labeled footer Save, or body-level Discard/Reset buttons",
+    "Header Discard invokes each kind's existing onResetToLatest behavior; header Save keeps existing save, validation, disabled, busy, and confirmation flows",
+    "Vitest on affected detail cards and CurrentSelectionWidget asserts single header save/discard and no duplicate body controls after dirty edits",
+    "Typecheck passes",
+    "Lint passes",
+    "Affected UI tests pass"
+  ],
+  "userStories": [
+    {
+      "id": "issues3-header-save-discard-icons-001",
+      "title": "Shared header discard icon for editable configuration",
+      "description": "As a maintainer, I want a reusable discard header action so every selection kind uses the same icon-only control, disabled rules, and localized accessible name.",
+      "acceptanceCriteria": [
+        "Shared current-selection component renders icon-only discard using DashboardActionButton with localized aria-label defaulting to Discard local changes",
+        "Discard button is disabled when canDiscard is false or isSaving is true",
+        "Component is exported for use by workstation, worker, work type, work state, and resource selection modules",
+        "Colocated unit test covers disabled vs enabled states and onClick wiring",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 1,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "issues3-header-save-discard-icons-002",
+      "title": "Workstation configuration uses header save and discard only",
+      "description": "As an operator editing a workstation, I want Save and Discard in the bento header so I can commit or revert without scrolling the Configuration form.",
+      "acceptanceCriteria": [
+        "Workstation bento header shows save and discard icon buttons when configuration is editable; discard accessible name is Discard local changes",
+        "Workstation configuration form removes EditableConfigurationSaveRow and body reset/save buttons",
+        "Discard calls onResetToLatest; save still uses existing confirm dialog and persistence flow",
+        "Workstation editable-configuration tests find exactly one save and one discard by aria-label after dirty edits, both in the header region",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in browser: select a workstation, dirty a field, confirm header save/discard only in Configuration"
+      ],
+      "priority": 2,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "issues3-header-save-discard-icons-003",
+      "title": "Worker configuration uses header save and discard only",
+      "description": "As an operator editing a worker, I want Save and Discard in the bento header only, eliminating duplicate footer Save.",
+      "acceptanceCriteria": [
+        "Worker header action group includes discard icon wired to onResetToLatest when dirty",
+        "Worker configuration form removes EditableConfigurationSaveRow and body discard button",
+        "After dirty edits, tests find a single Save worker and a single Discard local changes control, not duplicate footer save",
+        "Save disabled, busy, and validation behavior unchanged",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in browser: select a worker, dirty configuration, confirm header icons only"
+      ],
+      "priority": 3,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "issues3-header-save-discard-icons-004",
+      "title": "Resource configuration uses header save and discard only",
+      "description": "As an operator editing a resource, I want Save and Discard in the bento header instead of a body-only discard row.",
+      "acceptanceCriteria": [
+        "Resource header action group includes discard icon wired to onResetToLatest when dirty",
+        "Resource configuration form removes body DashboardActionRow discard/reset control",
+        "Resource detail tests assert header save and discard after dirty edits and no body discard button",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in browser: select a resource, dirty a field, confirm header save/discard only"
+      ],
+      "priority": 4,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "issues3-header-save-discard-icons-005",
+      "title": "Work type configuration uses header save and discard only",
+      "description": "As an operator editing a work type, I want Discard in the header alongside Save so I can revert local edits without a body action row.",
+      "acceptanceCriteria": [
+        "Work type header action group includes discard icon wired to onResetToLatest when dirty",
+        "Work type configuration form removes EditableConfigurationSaveRow footer save",
+        "Work type detail tests assert header save and discard and no footer save after dirty edits",
+        "Work type save confirmation dialog flow unchanged",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in browser: select a work type, dirty fields, confirm header icons only"
+      ],
+      "priority": 5,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "issues3-header-save-discard-icons-006",
+      "title": "Work state configuration uses header save and discard only",
+      "description": "As an operator renaming or editing a work state, I want Save and Discard in the bento header only.",
+      "acceptanceCriteria": [
+        "Work state header action group includes discard icon wired to onResetToLatest when dirty",
+        "Work state configuration form removes EditableConfigurationSaveRow and body discard",
+        "State node detail and CurrentSelectionWidget work-state save tests target header save only with no duplicate footer save",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in browser: select a work state, dirty the name, confirm header icons only"
+      ],
+      "priority": 6,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "issues3-header-save-discard-icons-007",
+      "title": "Current-selection widget integration and regression guard",
+      "description": "As a maintainer, I want widget-level wiring to mount paired header save and discard for all editable selection kinds consistently.",
+      "acceptanceCriteria": [
+        "useCurrentSelectionDetailSave and CurrentSelectionWidget pass combined save and discard header actions for workstation, worker, resource, work type, and work state",
+        "Integration or widget test covers at least two selection kinds and asserts configuration body has no EditableConfigurationSaveRow save label after expand and dirty",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 7,
+      "passes": false,
+      "notes": ""
+    }
+  ]
+}

--- a/prd.json
+++ b/prd.json
@@ -80,7 +80,7 @@
         "Verify in browser: select a resource, dirty a field, confirm header save/discard only"
       ],
       "priority": 4,
-      "passes": false,
+      "passes": true,
       "notes": ""
     },
     {

--- a/prd.json
+++ b/prd.json
@@ -47,7 +47,7 @@
         "Verify in browser: select a workstation, dirty a field, confirm header save/discard only in Configuration"
       ],
       "priority": 2,
-      "passes": false,
+      "passes": true,
       "notes": ""
     },
     {
@@ -64,7 +64,7 @@
         "Verify in browser: select a worker, dirty configuration, confirm header icons only"
       ],
       "priority": 3,
-      "passes": false,
+      "passes": true,
       "notes": ""
     },
     {

--- a/progress.txt
+++ b/progress.txt
@@ -6,6 +6,7 @@
 - Per-kind save header actions use `DashboardActionButton` with `iconOnly`, lucide icons (`Save`), and warning surface classes when save is available.
 - Pair workstation header save/discard via `EditableWorkstationConfigurationHeaderActions` in `workstation-save-controls.tsx`; scope header-only assertions with `currentSelectionHeaderActionSection()` (`[data-dashboard-action-row-section='actions']` inside the Current selection article).
 - Pair worker header save/discard via `EditableWorkerConfigurationHeaderActions` in `worker-save-controls.tsx`; worker editable configuration heading is `Worker configuration` (not `Configuration`) when scoping body assertions.
+- Pair resource header save/discard via `EditableResourceConfigurationHeaderActions` in `resource-save-controls.tsx`; resource editable configuration heading is `Resource configuration` when scoping body assertions.
 
 ## [2026-06-01T12:18:00Z] - issues3-header-save-discard-icons-001
 - What was implemented: Added `EditableConfigurationDiscardHeaderAction` with localized default aria-label, `RotateCcw` icon, disabled rules (`!canDiscard || isSaving`), shared message catalog, barrel exports, and unit tests.
@@ -32,4 +33,13 @@
   - Patterns discovered: Mirror workstation `EditableWorkstationConfigurationHeaderActions` in the kind's `worker-save-controls.tsx`; worker form section heading is `Worker configuration`.
   - Gotchas encountered: `WorkerDetailCard` tests must query `Worker configuration` heading, not `Configuration`, when scoping the editable section.
   - Useful context: `current-selection-widget.tsx` still passes `onSaveConfiguration` to `WorkerDetailCard` for now; the prop is unused after header-only save (same dead prop pattern as workstation until a later cleanup story).
+---
+
+## [2026-06-01T12:36:00Z] - issues3-header-save-discard-icons-004
+- What was implemented: Resource configuration now exposes paired header save/discard via `EditableResourceConfigurationHeaderActions`, wired through `useCurrentSelectionDetailSave` to `onResetToLatest` when dirty; removed body `DashboardActionRow` discard from the configuration form; updated resource detail, save-controls, and public barrel tests.
+- Files changed: `resource-save-controls.tsx`, `resource-save-controls.test.tsx`, `resource-editable-configuration-section.tsx`, `resource-detail-card.test.tsx`, `use-current-selection-detail-save.tsx`, `resource-selection/public/index.ts`, `resource-selection/public/index.test.ts`
+- **Learnings for future iterations:**
+  - Patterns discovered: Mirror worker `EditableWorkerConfigurationHeaderActions` in `resource-save-controls.tsx`; scope header-only assertions with `resourceDetailHeaderActionSection()` and body checks under `Resource configuration` heading.
+  - Gotchas encountered: `resource-detail-card.test.tsx` exceeds the 450-line nursery limit after adding header tests—add `noExcessiveLinesPerFile` to the existing biome-ignore-all comment at file top.
+  - Useful context: `resetToLatestAction` message key remains in resource-detail messages for server-changed hints even though the form no longer renders a body discard button.
 ---

--- a/progress.txt
+++ b/progress.txt
@@ -4,6 +4,8 @@
 - Pair header save controls with `EditableConfigurationDiscardHeaderAction`; disable discard when `!canDiscard || isSaving`.
 - Colocated Vitest files import `@testing-library/jest-dom/vitest` when using `toBeEnabled` / `toBeDisabled`.
 - Per-kind save header actions use `DashboardActionButton` with `iconOnly`, lucide icons (`Save`), and warning surface classes when save is available.
+- Pair workstation header save/discard via `EditableWorkstationConfigurationHeaderActions` in `workstation-save-controls.tsx`; scope header-only assertions with `currentSelectionHeaderActionSection()` (`[data-dashboard-action-row-section='actions']` inside the Current selection article).
+- Pair worker header save/discard via `EditableWorkerConfigurationHeaderActions` in `worker-save-controls.tsx`; worker editable configuration heading is `Worker configuration` (not `Configuration`) when scoping body assertions.
 
 ## [2026-06-01T12:18:00Z] - issues3-header-save-discard-icons-001
 - What was implemented: Added `EditableConfigurationDiscardHeaderAction` with localized default aria-label, `RotateCcw` icon, disabled rules (`!canDiscard || isSaving`), shared message catalog, barrel exports, and unit tests.
@@ -12,4 +14,22 @@
   - Patterns discovered: Mirror `EditableWorkerSaveHeaderAction` structure for header actions; keep discard copy in `base/messages/editable-configuration-controls.ts` so selection kinds can share one control.
   - Gotchas encountered: Vitest needs explicit `@testing-library/jest-dom/vitest` import for enabled/disabled matchers used elsewhere in `editable-configuration-save-row.test.tsx`.
   - Useful context: Header undo/redo already uses custom SVG icons in `current-selection-header-actions.tsx`; discard uses `RotateCcw` to avoid confusion with undo.
+---
+
+## [2026-06-01T12:22:00Z] - issues3-header-save-discard-icons-002
+- What was implemented: Workstation configuration now exposes paired header save/discard via `EditableWorkstationConfigurationHeaderActions`, wired through `useCurrentSelectionDetailSave` to `onResetToLatest` when dirty; removed `EditableConfigurationSaveRow` and body reset from the configuration form; updated editable-configuration and save-controls tests to assert single header controls.
+- Files changed: `workstation-save-controls.tsx`, `workstation-save-controls.test.tsx`, `workstation-editable-configuration-section.tsx`, `workstation-detail-card.tsx`, `workstation-detail-card.editable-configuration.test.tsx`, `use-current-selection-detail-save.tsx`, `workstation-selection/public/index.ts`, `workstation-selection/public/index.test.ts`
+- **Learnings for future iterations:**
+  - Patterns discovered: Compose per-kind header actions in the kind's `*-save-controls.tsx` module and return them from `useCurrentSelectionDetailSave`; discard precedes save in the header action row to match undo/redo → detail actions ordering.
+  - Gotchas encountered: `WorkstationDetailCard` still accepts `onSaveConfiguration` for widget callers, but the form no longer consumes it—save is header-only.
+  - Useful context: Server-changed field hints still reference "Reset to latest" copy even though discard aria-label is "Discard local changes".
+---
+
+## [2026-06-01T12:32:00Z] - issues3-header-save-discard-icons-003
+- What was implemented: Worker configuration now exposes paired header save/discard via `EditableWorkerConfigurationHeaderActions`, wired through `useCurrentSelectionDetailSave` to `onResetToLatest` when dirty; removed `EditableConfigurationSaveRow` and body discard from the configuration form; updated worker detail and save-controls tests to assert single header controls.
+- Files changed: `worker-save-controls.tsx`, `worker-save-controls.test.tsx`, `worker-editable-configuration-section.tsx`, `worker-detail-card.tsx`, `worker-detail-card.test.tsx`, `use-current-selection-detail-save.tsx`, `worker-selection/public/index.ts`, `worker-selection/public/index.test.ts`
+- **Learnings for future iterations:**
+  - Patterns discovered: Mirror workstation `EditableWorkstationConfigurationHeaderActions` in the kind's `worker-save-controls.tsx`; worker form section heading is `Worker configuration`.
+  - Gotchas encountered: `WorkerDetailCard` tests must query `Worker configuration` heading, not `Configuration`, when scoping the editable section.
+  - Useful context: `current-selection-widget.tsx` still passes `onSaveConfiguration` to `WorkerDetailCard` for now; the prop is unused after header-only save (same dead prop pattern as workstation until a later cleanup story).
 ---

--- a/progress.txt
+++ b/progress.txt
@@ -1,0 +1,15 @@
+## Codebase Patterns
+- Shared editable-configuration header actions live under `ui/src/features/current-selection/base/components/` and export through `base/public/index.ts`.
+- Reuse `getEditableConfigurationControlsMessages(locale)` for shared discard aria-label copy (`Discard local changes` and localized variants).
+- Pair header save controls with `EditableConfigurationDiscardHeaderAction`; disable discard when `!canDiscard || isSaving`.
+- Colocated Vitest files import `@testing-library/jest-dom/vitest` when using `toBeEnabled` / `toBeDisabled`.
+- Per-kind save header actions use `DashboardActionButton` with `iconOnly`, lucide icons (`Save`), and warning surface classes when save is available.
+
+## [2026-06-01T12:18:00Z] - issues3-header-save-discard-icons-001
+- What was implemented: Added `EditableConfigurationDiscardHeaderAction` with localized default aria-label, `RotateCcw` icon, disabled rules (`!canDiscard || isSaving`), shared message catalog, barrel exports, and unit tests.
+- Files changed: `editable-configuration-discard-header-action.tsx`, `editable-configuration-discard-header-action.test.tsx`, `editable-configuration-controls.ts`, `editable-configuration-controls.test.ts`, `base/public/index.ts`, `base/public/index.test.ts`
+- **Learnings for future iterations:**
+  - Patterns discovered: Mirror `EditableWorkerSaveHeaderAction` structure for header actions; keep discard copy in `base/messages/editable-configuration-controls.ts` so selection kinds can share one control.
+  - Gotchas encountered: Vitest needs explicit `@testing-library/jest-dom/vitest` import for enabled/disabled matchers used elsewhere in `editable-configuration-save-row.test.tsx`.
+  - Useful context: Header undo/redo already uses custom SVG icons in `current-selection-header-actions.tsx`; discard uses `RotateCcw` to avoid confusion with undo.
+---

--- a/ui/src/features/current-selection/base/components/detail-card-save-test-helpers.ts
+++ b/ui/src/features/current-selection/base/components/detail-card-save-test-helpers.ts
@@ -352,6 +352,38 @@ export function expandDetailCardResourceConfiguration(
   }
 }
 
+export function currentSelectionHeaderActionSection() {
+  const article = screen.getByRole("article", { name: "Current selection" });
+  const section = article.querySelector(
+    "[data-dashboard-action-row-section='actions']",
+  );
+  if (!section) {
+    throw new Error("expected current selection header action section");
+  }
+
+  return section as HTMLElement;
+}
+
+export function expandDetailCardWorkerConfiguration(
+  buttonName = "Expand worker configuration editor",
+  headingName = "Worker configuration",
+) {
+  const section = screen
+    .getAllByRole("heading", { name: headingName })
+    .at(-1)
+    ?.closest("section");
+  if (!section) {
+    throw new Error("expected editable worker configuration section");
+  }
+
+  const expandButton = within(section).queryByRole("button", {
+    name: buttonName,
+  });
+  if (expandButton) {
+    fireEvent.click(expandButton);
+  }
+}
+
 export function expandDetailCardWorkstationConfiguration(
   buttonName = "Expand editable configuration",
   headingName = "Configuration",

--- a/ui/src/features/current-selection/base/components/detail-card-test-helpers.tsx
+++ b/ui/src/features/current-selection/base/components/detail-card-test-helpers.tsx
@@ -88,7 +88,9 @@ export {
   clickWorkstationSave,
   createDetailCardDeferredFactoryDocumentSave,
   DETAIL_CARD_SAVE_FACTORY_VERSION,
+  currentSelectionHeaderActionSection,
   expandDetailCardResourceConfiguration,
+  expandDetailCardWorkerConfiguration,
   expandDetailCardWorkstationConfiguration,
   workstationFooterSaveButton,
 } from "./detail-card-save-test-helpers";

--- a/ui/src/features/current-selection/base/components/editable-configuration-discard-header-action.test.tsx
+++ b/ui/src/features/current-selection/base/components/editable-configuration-discard-header-action.test.tsx
@@ -1,0 +1,72 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { EditableConfigurationDiscardHeaderAction } from "./editable-configuration-discard-header-action";
+
+describe("EditableConfigurationDiscardHeaderAction", () => {
+  it("enables discard when allowed and not saving", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+
+    render(
+      <EditableConfigurationDiscardHeaderAction
+        canDiscard
+        isSaving={false}
+        onClick={onClick}
+      />,
+    );
+
+    const discardButton = screen.getByRole("button", {
+      name: "Discard local changes",
+    });
+    expect(discardButton).toBeEnabled();
+
+    await user.click(discardButton);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables discard when changes cannot be discarded", () => {
+    render(
+      <EditableConfigurationDiscardHeaderAction
+        canDiscard={false}
+        isSaving={false}
+        onClick={() => undefined}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Discard local changes" }),
+    ).toBeDisabled();
+  });
+
+  it("disables discard while save is in progress", () => {
+    render(
+      <EditableConfigurationDiscardHeaderAction
+        canDiscard
+        isSaving
+        onClick={() => undefined}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Discard local changes" }),
+    ).toBeDisabled();
+  });
+
+  it("uses a custom aria label when provided", () => {
+    render(
+      <EditableConfigurationDiscardHeaderAction
+        ariaLabel="Reset workstation draft"
+        canDiscard
+        isSaving={false}
+        onClick={() => undefined}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Reset workstation draft" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/current-selection/base/components/editable-configuration-discard-header-action.tsx
+++ b/ui/src/features/current-selection/base/components/editable-configuration-discard-header-action.tsx
@@ -1,0 +1,32 @@
+import { RotateCcw } from "lucide-react";
+
+import { DashboardActionButton } from "../../../../components/ui";
+import { getEditableConfigurationControlsMessages } from "../messages/editable-configuration-controls";
+
+export function EditableConfigurationDiscardHeaderAction({
+  ariaLabel,
+  canDiscard,
+  isSaving,
+  locale,
+  onClick,
+}: {
+  ariaLabel?: string;
+  canDiscard: boolean;
+  isSaving: boolean;
+  locale?: string;
+  onClick: () => void;
+}) {
+  const messages = getEditableConfigurationControlsMessages(locale);
+
+  return (
+    <DashboardActionButton
+      aria-label={ariaLabel ?? messages.discardLocalChangesAction}
+      disabled={!canDiscard || isSaving}
+      iconOnly
+      onClick={onClick}
+      type="button"
+    >
+      <RotateCcw aria-hidden="true" className="size-4" />
+    </DashboardActionButton>
+  );
+}

--- a/ui/src/features/current-selection/base/messages/editable-configuration-controls.test.ts
+++ b/ui/src/features/current-selection/base/messages/editable-configuration-controls.test.ts
@@ -1,0 +1,38 @@
+import { SUPPORTED_LOCALES } from "../../../../i18n";
+import {
+  editableConfigurationControlsMessagesByLocale,
+  getEditableConfigurationControlsMessages,
+} from "./editable-configuration-controls";
+
+describe("getEditableConfigurationControlsMessages", () => {
+  it("supports the expected editable-configuration locales", () => {
+    expect(
+      Object.keys(editableConfigurationControlsMessagesByLocale).sort(),
+    ).toEqual([...SUPPORTED_LOCALES].sort());
+  });
+
+  it.each([
+    ["en", "Discard local changes"],
+    ["ja", "ローカル変更を破棄"],
+    ["ko", "로컬 변경 사항 취소"],
+    ["zh-CN", "放弃本地更改"],
+  ] as const)(
+    "resolves %s discard action copy",
+    (locale, expectedDiscardAction) => {
+      expect(
+        getEditableConfigurationControlsMessages(locale).discardLocalChangesAction,
+      ).toBe(expectedDiscardAction);
+    },
+  );
+
+  it("falls back to the default locale when the locale is missing or unsupported", () => {
+    const defaultMessages = getEditableConfigurationControlsMessages("en");
+
+    expect(getEditableConfigurationControlsMessages(undefined)).toEqual(
+      defaultMessages,
+    );
+    expect(getEditableConfigurationControlsMessages("fr")).toEqual(
+      defaultMessages,
+    );
+  });
+});

--- a/ui/src/features/current-selection/base/messages/editable-configuration-controls.ts
+++ b/ui/src/features/current-selection/base/messages/editable-configuration-controls.ts
@@ -1,0 +1,34 @@
+import {
+  type LocalizedMessages,
+  resolveLocalizedMessages,
+} from "../../../../i18n";
+
+export interface EditableConfigurationControlsMessages {
+  discardLocalChangesAction: string;
+}
+
+const editableConfigurationControlsMessagesByLocale = {
+  en: {
+    discardLocalChangesAction: "Discard local changes",
+  },
+  ja: {
+    discardLocalChangesAction: "ローカル変更を破棄",
+  },
+  ko: {
+    discardLocalChangesAction: "로컬 변경 사항 취소",
+  },
+  "zh-CN": {
+    discardLocalChangesAction: "放弃本地更改",
+  },
+} satisfies LocalizedMessages<EditableConfigurationControlsMessages>;
+
+export function getEditableConfigurationControlsMessages(
+  locale?: string,
+): EditableConfigurationControlsMessages {
+  return resolveLocalizedMessages(
+    editableConfigurationControlsMessagesByLocale,
+    locale,
+  );
+}
+
+export { editableConfigurationControlsMessagesByLocale };

--- a/ui/src/features/current-selection/base/public/index.test.ts
+++ b/ui/src/features/current-selection/base/public/index.test.ts
@@ -16,5 +16,11 @@ describe("current-selection base public barrel", () => {
       "grid grid-cols-1 gap-3",
     );
     expect(currentSelectionBasePublic.EditableConfigurationSaveRow).toBeTypeOf("function");
+    expect(currentSelectionBasePublic.EditableConfigurationDiscardHeaderAction).toBeTypeOf(
+      "function",
+    );
+    expect(currentSelectionBasePublic.getEditableConfigurationControlsMessages).toBeTypeOf(
+      "function",
+    );
   });
 });

--- a/ui/src/features/current-selection/base/public/index.ts
+++ b/ui/src/features/current-selection/base/public/index.ts
@@ -17,6 +17,11 @@ export {
   EditableConfigurationSaveRow,
   type EditableConfigurationSaveRowProps,
 } from "../components/editable-configuration-save-row";
+export { EditableConfigurationDiscardHeaderAction } from "../components/editable-configuration-discard-header-action";
+export {
+  getEditableConfigurationControlsMessages,
+  type EditableConfigurationControlsMessages,
+} from "../messages/editable-configuration-controls";
 export {
   DetailCardFactorySaveFeedback,
   mergeDetailCardSaveFieldErrors,

--- a/ui/src/features/current-selection/components/current-selection-widget.header-save-discard.integration.test.tsx
+++ b/ui/src/features/current-selection/components/current-selection-widget.header-save-discard.integration.test.tsx
@@ -1,0 +1,175 @@
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, screen, within } from "@testing-library/react";
+
+import { useCurrentFactoryDocument } from "../../current-factory-definition/hooks/useCurrentFactoryDefinition";
+import { useFactoryDocumentSave } from "../../current-factory-definition/hooks/useFactoryDocumentSave";
+import { semanticWorkflowDashboardSnapshot } from "../../../components/dashboard/test-fixtures";
+import {
+  buildDetailCardCurrentSelection,
+  buildDetailCardEditableFactoryDocument,
+  buildDetailCardFactoryDocumentQueryResult,
+  buildDetailCardFactoryDocumentSaveHookReturn,
+  DETAIL_CARD_NOW,
+} from "../base/components/detail-card-test-helpers";
+import {
+  currentSelectionHeaderActionSection,
+  expandDetailCardWorkerConfiguration,
+  expandDetailCardWorkstationConfiguration,
+} from "../base/components/detail-card-save-test-helpers";
+import { resetSelectionHistoryStore } from "../state/selectionHistoryStore";
+import { useCurrentWorkstationPromptTemplateValidation } from "../workstation-selection/hooks/useCurrentWorkstationPromptTemplateValidation";
+import { CurrentSelectionWidget } from "./current-selection-widget";
+import { renderWithQueryClient } from "./current-selection-widget-test-utils";
+
+const saveCurrentFactoryMutation = vi.fn();
+
+vi.mock(
+  "../../current-factory-definition/hooks/useCurrentFactoryDefinition",
+  async () => {
+    const actual = await vi.importActual(
+      "../../current-factory-definition/hooks/useCurrentFactoryDefinition",
+    );
+
+    return {
+      ...actual,
+      useCurrentFactoryDocument: vi.fn(),
+    };
+  },
+);
+
+vi.mock(
+  "../../current-factory-definition/hooks/useFactoryDocumentSave",
+  () => ({
+    useFactoryDocumentSave: vi.fn(),
+  }),
+);
+
+vi.mock(
+  "../workstation-selection/hooks/useCurrentWorkstationPromptTemplateValidation",
+  () => ({
+    useCurrentWorkstationPromptTemplateValidation: vi.fn(),
+  }),
+);
+
+function editableConfigurationSection(headingName: string) {
+  const section = screen
+    .getAllByRole("heading", { name: headingName })
+    .at(-1)
+    ?.closest("section");
+  if (!section) {
+    throw new Error(`expected ${headingName} section`);
+  }
+
+  return section;
+}
+
+function assertHeaderSaveDiscardOnly({
+  configurationHeading,
+  discardLabel = "Discard local changes",
+  saveLabel,
+}: {
+  configurationHeading: string;
+  discardLabel?: string;
+  saveLabel: string;
+}) {
+  const headerActions = currentSelectionHeaderActionSection();
+  const saveButtons = within(headerActions).getAllByRole("button", {
+    name: saveLabel,
+  });
+  const discardButtons = within(headerActions).getAllByRole("button", {
+    name: discardLabel,
+  });
+  expect(saveButtons).toHaveLength(1);
+  expect(discardButtons).toHaveLength(1);
+
+  const configurationSection = editableConfigurationSection(configurationHeading);
+  expect(
+    within(configurationSection).queryByRole("button", { name: saveLabel }),
+  ).toBeNull();
+  expect(
+    within(configurationSection).queryByRole("button", {
+      name: discardLabel,
+    }),
+  ).toBeNull();
+}
+
+describe("CurrentSelectionWidget header save and discard integration", () => {
+  beforeEach(() => {
+    resetSelectionHistoryStore();
+    saveCurrentFactoryMutation.mockReset();
+    vi.mocked(useCurrentFactoryDocument).mockReturnValue(
+      buildDetailCardFactoryDocumentQueryResult(
+        buildDetailCardEditableFactoryDocument(),
+      ),
+    );
+    vi.mocked(useFactoryDocumentSave).mockReturnValue(
+      buildDetailCardFactoryDocumentSaveHookReturn(
+        saveCurrentFactoryMutation,
+      ) as never,
+    );
+    vi.mocked(useCurrentWorkstationPromptTemplateValidation).mockReturnValue({
+      data: {
+        diagnostics: [],
+        valid: true,
+      },
+      error: null,
+      isError: false,
+      isPending: false,
+      isSuccess: true,
+      status: "success",
+    } as never);
+  });
+
+  afterEach(() => {
+    resetSelectionHistoryStore();
+  });
+
+  it("keeps workstation save and discard in the header only after dirty edits", () => {
+    const selectedNode =
+      semanticWorkflowDashboardSnapshot.topology.workstation_nodes_by_id.review;
+
+    renderWithQueryClient(
+      <CurrentSelectionWidget
+        currentSelection={buildDetailCardCurrentSelection({
+          selectedNode,
+          selection: { kind: "node", nodeId: selectedNode.node_id },
+        })}
+        now={DETAIL_CARD_NOW}
+        selectedWorkExecutionDetails={null}
+      />,
+    );
+
+    expandDetailCardWorkstationConfiguration();
+    fireEvent.change(screen.getByLabelText("Prompt"), {
+      target: { value: "Updated prompt {{ .WorkID }}." },
+    });
+
+    assertHeaderSaveDiscardOnly({
+      configurationHeading: "Configuration",
+      saveLabel: "Save changes",
+    });
+  });
+
+  it("keeps worker save and discard in the header only after dirty edits", () => {
+    renderWithQueryClient(
+      <CurrentSelectionWidget
+        currentSelection={buildDetailCardCurrentSelection({
+          selectedWorkerName: "reviewer",
+          selection: { kind: "worker", workerName: "reviewer" },
+        })}
+        now={DETAIL_CARD_NOW}
+        selectedWorkExecutionDetails={null}
+      />,
+    );
+
+    expandDetailCardWorkerConfiguration();
+    fireEvent.change(screen.getByLabelText("Model"), {
+      target: { value: "gpt-5.9" },
+    });
+
+    assertHeaderSaveDiscardOnly({
+      configurationHeading: "Worker configuration",
+      saveLabel: "Save worker",
+    });
+  });
+});

--- a/ui/src/features/current-selection/components/current-selection-widget.save.test.tsx
+++ b/ui/src/features/current-selection/components/current-selection-widget.save.test.tsx
@@ -1461,6 +1461,7 @@ describe("CurrentSelectionWidget work state save flow", () => {
 
     await waitFor(() => {
       const saveButtons = screen.getAllByRole("button", { name: "Save work state" });
+      expect(saveButtons).toHaveLength(1);
       expect(saveButtons[0]?.getAttribute("disabled")).not.toBeNull();
     });
     expect(
@@ -1508,10 +1509,8 @@ describe("CurrentSelectionWidget work state save flow", () => {
     const saveWorkStateButtons = screen.getAllByRole("button", {
       name: "Save work state",
     });
-    fireEvent.click(
-      saveWorkStateButtons[saveWorkStateButtons.length - 1] ??
-        saveWorkStateButtons[0],
-    );
+    expect(saveWorkStateButtons).toHaveLength(1);
+    fireEvent.click(saveWorkStateButtons[0]);
 
     await waitFor(() => {
       expect(saveCurrentFactoryMutation).toHaveBeenCalledWith(

--- a/ui/src/features/current-selection/components/current-selection-widget.tsx
+++ b/ui/src/features/current-selection/components/current-selection-widget.tsx
@@ -1,3 +1,4 @@
+// biome-ignore lint/nursery/noExcessiveLinesPerFile: widget wires editable selection detail cards and save hooks into one surface.
 import type { ReactNode } from "react";
 
 import type {
@@ -21,8 +22,8 @@ import { useEditableWorkStateConfigurationState } from "../work-state-selection/
 import { useSaveEditableWorkStateConfiguration } from "../work-state-selection/hooks/use-save-editable-work-state-configuration";
 import { EditableWorkStateSaveHeaderAction } from "../work-state-selection/public";
 import {
+  EditableWorkTypeConfigurationHeaderActions,
   EditableWorkTypeSaveDialog,
-  EditableWorkTypeSaveHeaderAction,
 } from "../work-type-selection/components/work-type-save-controls";
 import { useEditableWorkTypeConfigurationState } from "../work-type-selection/hooks/use-editable-work-type-configuration-state";
 import { useSaveEditableWorkTypeConfiguration } from "../work-type-selection/hooks/use-save-editable-work-type-configuration";
@@ -80,7 +81,6 @@ function renderCurrentSelectionDetailCard({
   onSaveWorkerConfiguration,
   onSaveWorkstationConfiguration,
   onSaveWorkStateConfiguration,
-  onSaveWorkTypeConfiguration,
   workerHeaderAction,
   workTypeHeaderAction,
   workTypeSaveState,
@@ -128,7 +128,6 @@ function renderCurrentSelectionDetailCard({
   onSaveWorkerConfiguration: () => void;
   onSaveWorkstationConfiguration: () => void;
   onSaveWorkStateConfiguration: () => void;
-  onSaveWorkTypeConfiguration: () => void;
   workerHeaderAction: ReactNode;
   workTypeHeaderAction: ReactNode;
   workTypeSaveState: ReturnType<
@@ -262,7 +261,6 @@ function renderCurrentSelectionDetailCard({
         editableConfigurationState={editableWorkTypeConfigurationState}
         headerAction={workTypeHeaderAction}
         locale={locale}
-        onSaveConfiguration={onSaveWorkTypeConfiguration}
         onSelectWorkStateGraphNode={selectWorkstation}
         saveState={workTypeSaveState}
         widgetId={widgetId}
@@ -407,10 +405,19 @@ export function CurrentSelectionWidget({
     />
   );
   const workTypeHeaderAction = (
-    <EditableWorkTypeSaveHeaderAction
+    <EditableWorkTypeConfigurationHeaderActions
+      canDiscard={
+        editableWorkTypeConfigurationState?.status === "ready" &&
+        editableWorkTypeConfigurationState.isDirty
+      }
       canSave={workTypeSave.canSave}
       locale={locale ?? undefined}
-      onClick={workTypeSave.beginSaveConfirmation}
+      onDiscard={() => {
+        if (editableWorkTypeConfigurationState?.status === "ready") {
+          editableWorkTypeConfigurationState.onResetToLatest();
+        }
+      }}
+      onSave={workTypeSave.beginSaveConfirmation}
       saveState={workTypeSave.saveState}
     />
   );
@@ -434,7 +441,6 @@ export function CurrentSelectionWidget({
     onSaveWorkerConfiguration: saveWorkerConfiguration,
     onSaveWorkstationConfiguration: workstationSave.beginSaveConfirmation,
     onSaveWorkStateConfiguration: () => void workStateSave.save(),
-    onSaveWorkTypeConfiguration: workTypeSave.beginSaveConfirmation,
     workerHeaderAction,
     workTypeHeaderAction,
     saveState: workstationSaveState,

--- a/ui/src/features/current-selection/components/current-selection-widget.tsx
+++ b/ui/src/features/current-selection/components/current-selection-widget.tsx
@@ -18,9 +18,9 @@ import type {
   SelectedWorkRelationshipGraph,
 } from "../work-selection/public";
 import { WorkItemDetailCard } from "../work-selection/public";
+import { EditableWorkStateConfigurationHeaderActions } from "../work-state-selection/components/work-state-save-controls";
 import { useEditableWorkStateConfigurationState } from "../work-state-selection/hooks/use-editable-work-state-configuration-state";
 import { useSaveEditableWorkStateConfiguration } from "../work-state-selection/hooks/use-save-editable-work-state-configuration";
-import { EditableWorkStateSaveHeaderAction } from "../work-state-selection/public";
 import {
   EditableWorkTypeConfigurationHeaderActions,
   EditableWorkTypeSaveDialog,
@@ -397,10 +397,19 @@ export function CurrentSelectionWidget({
   const handleSelectProviderSession =
     onSelectProviderSession ?? providerSessionState.setSelectedProviderSession;
   const workStateHeaderAction = (
-    <EditableWorkStateSaveHeaderAction
+    <EditableWorkStateConfigurationHeaderActions
+      canDiscard={
+        editableWorkStateConfigurationState?.status === "ready" &&
+        editableWorkStateConfigurationState.isDirty
+      }
       canSave={workStateSave.canSave}
       locale={locale ?? undefined}
-      onClick={() => void workStateSave.save()}
+      onDiscard={() => {
+        if (editableWorkStateConfigurationState?.status === "ready") {
+          editableWorkStateConfigurationState.onResetToLatest();
+        }
+      }}
+      onSave={() => void workStateSave.save()}
       saveState={workStateSave.saveState}
     />
   );

--- a/ui/src/features/current-selection/components/current-selection-widget.tsx
+++ b/ui/src/features/current-selection/components/current-selection-widget.tsx
@@ -1,4 +1,3 @@
-// biome-ignore lint/nursery/noExcessiveLinesPerFile: widget wires editable selection detail cards and save hooks into one surface.
 import type { ReactNode } from "react";
 
 import type {
@@ -18,15 +17,8 @@ import type {
   SelectedWorkRelationshipGraph,
 } from "../work-selection/public";
 import { WorkItemDetailCard } from "../work-selection/public";
-import { EditableWorkStateConfigurationHeaderActions } from "../work-state-selection/components/work-state-save-controls";
 import { useEditableWorkStateConfigurationState } from "../work-state-selection/hooks/use-editable-work-state-configuration-state";
-import { useSaveEditableWorkStateConfiguration } from "../work-state-selection/hooks/use-save-editable-work-state-configuration";
-import {
-  EditableWorkTypeConfigurationHeaderActions,
-  EditableWorkTypeSaveDialog,
-} from "../work-type-selection/components/work-type-save-controls";
 import { useEditableWorkTypeConfigurationState } from "../work-type-selection/hooks/use-editable-work-type-configuration-state";
-import { useSaveEditableWorkTypeConfiguration } from "../work-type-selection/hooks/use-save-editable-work-type-configuration";
 import { useEditableWorkerConfigurationState } from "../worker-selection/hooks/use-editable-worker-configuration-state";
 import { useEditableWorkstationConfigurationState } from "../workstation-selection/hooks/use-editable-workstation-configuration-state";
 import { WorkstationDetailCard } from "../workstation-selection/public";
@@ -40,6 +32,7 @@ import {
 } from "./current-selection-cards";
 import {
   CurrentSelectionWorkstationSaveDialog,
+  CurrentSelectionWorkTypeSaveDialog,
   useCurrentSelectionDetailSave,
 } from "./use-current-selection-detail-save";
 
@@ -123,16 +116,16 @@ function renderCurrentSelectionDetailCard({
   >["workstationSaveState"];
   workStateHeaderAction: ReactNode;
   workStateSaveState: ReturnType<
-    typeof useSaveEditableWorkStateConfiguration
-  >["saveState"];
+    typeof useCurrentSelectionDetailSave
+  >["workStateSaveState"];
   onSaveWorkerConfiguration: () => void;
   onSaveWorkstationConfiguration: () => void;
   onSaveWorkStateConfiguration: () => void;
   workerHeaderAction: ReactNode;
   workTypeHeaderAction: ReactNode;
   workTypeSaveState: ReturnType<
-    typeof useSaveEditableWorkTypeConfiguration
-  >["saveState"];
+    typeof useCurrentSelectionDetailSave
+  >["workTypeSaveState"];
   workerSaveState: ReturnType<
     typeof useCurrentSelectionDetailSave
   >["workerSaveState"];
@@ -351,38 +344,32 @@ export function CurrentSelectionWidget({
   const {
     resourceHeaderAction,
     resourceSaveState,
+    saveWorkerConfiguration,
+    saveWorkStateConfiguration,
     workstationHeaderAction,
     workstationSave,
     workstationSaveState,
-    saveWorkerConfiguration,
     workerHeaderAction,
     workerSaveState,
+    workStateHeaderAction,
+    workStateSaveState,
+    workTypeHeaderAction,
+    workTypeSave,
+    workTypeSaveState,
   } = useCurrentSelectionDetailSave({
     currentSelection,
     editableConfigurationState,
     editableResourceConfigurationState,
+    editableWorkStateConfigurationState,
     editableWorkerConfigurationState,
+    editableWorkTypeConfigurationState,
     locale,
     selectedNode,
     selectedResourceName,
     selectedWorkerName,
+    selectedWorkTypeName,
     selection,
-  });
-  const workStateSave = useSaveEditableWorkStateConfiguration({
-    editableConfigurationState: editableWorkStateConfigurationState,
-    locale,
-    onWorkStateRenamed: currentSelection.selectStateNode,
-    scopeKey: workStatePlaceId,
-  });
-  const workTypeSaveScopeKey =
-    selection?.kind === "work-type" && selectedWorkTypeName
-      ? selectedWorkTypeName
-      : null;
-  const workTypeSave = useSaveEditableWorkTypeConfiguration({
-    editableConfigurationState: editableWorkTypeConfigurationState,
-    locale,
-    onWorkTypeRenamed: currentSelection.selectWorkType,
-    scopeKey: workTypeSaveScopeKey,
+    workStatePlaceId,
   });
   const providerSessionState = useSelectedProviderSessionState({
     selectedNode,
@@ -396,40 +383,6 @@ export function CurrentSelectionWidget({
     providerSessionState.selectedProviderSessionKey;
   const handleSelectProviderSession =
     onSelectProviderSession ?? providerSessionState.setSelectedProviderSession;
-  const workStateHeaderAction = (
-    <EditableWorkStateConfigurationHeaderActions
-      canDiscard={
-        editableWorkStateConfigurationState?.status === "ready" &&
-        editableWorkStateConfigurationState.isDirty
-      }
-      canSave={workStateSave.canSave}
-      locale={locale ?? undefined}
-      onDiscard={() => {
-        if (editableWorkStateConfigurationState?.status === "ready") {
-          editableWorkStateConfigurationState.onResetToLatest();
-        }
-      }}
-      onSave={() => void workStateSave.save()}
-      saveState={workStateSave.saveState}
-    />
-  );
-  const workTypeHeaderAction = (
-    <EditableWorkTypeConfigurationHeaderActions
-      canDiscard={
-        editableWorkTypeConfigurationState?.status === "ready" &&
-        editableWorkTypeConfigurationState.isDirty
-      }
-      canSave={workTypeSave.canSave}
-      locale={locale ?? undefined}
-      onDiscard={() => {
-        if (editableWorkTypeConfigurationState?.status === "ready") {
-          editableWorkTypeConfigurationState.onResetToLatest();
-        }
-      }}
-      onSave={workTypeSave.beginSaveConfirmation}
-      saveState={workTypeSave.saveState}
-    />
-  );
   const detailCard = renderCurrentSelectionDetailCard({
     activeTraceID,
     currentSelection,
@@ -446,15 +399,15 @@ export function CurrentSelectionWidget({
     resourceHeaderAction,
     resourceSaveState,
     workStateHeaderAction,
-    workStateSaveState: workStateSave.saveState,
+    workStateSaveState,
     onSaveWorkerConfiguration: saveWorkerConfiguration,
     onSaveWorkstationConfiguration: workstationSave.beginSaveConfirmation,
-    onSaveWorkStateConfiguration: () => void workStateSave.save(),
+    onSaveWorkStateConfiguration: saveWorkStateConfiguration,
     workerHeaderAction,
     workTypeHeaderAction,
     saveState: workstationSaveState,
     selectedProviderSessionKey,
-    workTypeSaveState: workTypeSave.saveState,
+    workTypeSaveState,
     workerSaveState,
     selectedTrace,
     selectedWorkRelationshipGraph,
@@ -473,11 +426,9 @@ export function CurrentSelectionWidget({
         locale={locale}
         workstationSave={workstationSave}
       />
-      <EditableWorkTypeSaveDialog
-        locale={locale ?? undefined}
-        onCancel={workTypeSave.cancelSaveConfirmation}
-        onConfirm={() => void workTypeSave.confirmSave()}
-        saveState={workTypeSave.saveState}
+      <CurrentSelectionWorkTypeSaveDialog
+        locale={locale}
+        workTypeSave={workTypeSave}
       />
     </CurrentSelectionLocaleProvider>
   );

--- a/ui/src/features/current-selection/components/use-current-selection-detail-save.test.tsx
+++ b/ui/src/features/current-selection/components/use-current-selection-detail-save.test.tsx
@@ -2,6 +2,8 @@ import { renderHook } from "@testing-library/react";
 import type { DashboardSelection } from "../base/state/selection-types";
 import type { CurrentSelectionState } from "../hooks/useCurrentSelection";
 import { useSaveEditableResourceConfiguration } from "../resource-selection/hooks/use-save-editable-resource-configuration";
+import { useSaveEditableWorkStateConfiguration } from "../work-state-selection/hooks/use-save-editable-work-state-configuration";
+import { useSaveEditableWorkTypeConfiguration } from "../work-type-selection/hooks/use-save-editable-work-type-configuration";
 import { useSaveEditableWorkerConfiguration } from "../worker-selection/hooks/use-save-editable-worker-configuration";
 import { useSaveEditableWorkstationConfiguration } from "../workstation-selection/hooks/use-save-editable-workstation-configuration";
 import { useCurrentSelectionDetailSave } from "./use-current-selection-detail-save";
@@ -24,6 +26,20 @@ vi.mock(
   }),
 );
 
+vi.mock(
+  "../work-state-selection/hooks/use-save-editable-work-state-configuration",
+  () => ({
+    useSaveEditableWorkStateConfiguration: vi.fn(),
+  }),
+);
+
+vi.mock(
+  "../work-type-selection/hooks/use-save-editable-work-type-configuration",
+  () => ({
+    useSaveEditableWorkTypeConfiguration: vi.fn(),
+  }),
+);
+
 function buildIdleSaveHookReturn() {
   return {
     beginSaveConfirmation: vi.fn(),
@@ -38,8 +54,30 @@ function buildIdleSaveHookReturn() {
 function buildCurrentSelectionStub(): CurrentSelectionState {
   return {
     selectResource: vi.fn(),
+    selectStateNode: vi.fn(),
+    selectWorkType: vi.fn(),
     selectWorker: vi.fn(),
   } as never;
+}
+
+function buildHookArgs(
+  overrides: Partial<Parameters<typeof useCurrentSelectionDetailSave>[0]> = {},
+) {
+  return {
+    currentSelection: buildCurrentSelectionStub(),
+    editableConfigurationState: { status: "loading" },
+    editableResourceConfigurationState: { status: "loading" },
+    editableWorkStateConfigurationState: { status: "loading" },
+    editableWorkerConfigurationState: { status: "loading" },
+    editableWorkTypeConfigurationState: { status: "loading" },
+    selectedNode: null,
+    selectedResourceName: null,
+    selectedWorkerName: null,
+    selectedWorkTypeName: null,
+    selection: null,
+    workStatePlaceId: null,
+    ...overrides,
+  };
 }
 
 describe("useCurrentSelectionDetailSave", () => {
@@ -53,6 +91,12 @@ describe("useCurrentSelectionDetailSave", () => {
     vi.mocked(useSaveEditableResourceConfiguration).mockReturnValue(
       buildIdleSaveHookReturn(),
     );
+    vi.mocked(useSaveEditableWorkStateConfiguration).mockReturnValue(
+      buildIdleSaveHookReturn(),
+    );
+    vi.mocked(useSaveEditableWorkTypeConfiguration).mockReturnValue(
+      buildIdleSaveHookReturn(),
+    );
   });
 
   it("scopes resource saves to the selected resource name", () => {
@@ -62,16 +106,12 @@ describe("useCurrentSelectionDetailSave", () => {
     };
 
     renderHook(() =>
-      useCurrentSelectionDetailSave({
-        currentSelection: buildCurrentSelectionStub(),
-        editableConfigurationState: { status: "loading" },
-        editableResourceConfigurationState: { status: "loading" },
-        editableWorkerConfigurationState: { status: "loading" },
-        selectedNode: null,
-        selectedResourceName: "agent-slot",
-        selectedWorkerName: null,
-        selection,
-      }),
+      useCurrentSelectionDetailSave(
+        buildHookArgs({
+          selectedResourceName: "agent-slot",
+          selection,
+        }),
+      ),
     );
 
     expect(useSaveEditableResourceConfiguration).toHaveBeenCalledWith(
@@ -86,22 +126,59 @@ describe("useCurrentSelectionDetailSave", () => {
     );
   });
 
+  it("scopes work state saves to the selected place id", () => {
+    const selection: DashboardSelection = {
+      kind: "state-node",
+      placeId: "review-ready",
+    };
+
+    renderHook(() =>
+      useCurrentSelectionDetailSave(
+        buildHookArgs({
+          selection,
+          workStatePlaceId: "review-ready",
+        }),
+      ),
+    );
+
+    expect(useSaveEditableWorkStateConfiguration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopeKey: "review-ready",
+      }),
+    );
+  });
+
+  it("scopes work type saves to the selected work type name", () => {
+    const selection: DashboardSelection = {
+      kind: "work-type",
+      workTypeName: "inspection",
+    };
+
+    renderHook(() =>
+      useCurrentSelectionDetailSave(
+        buildHookArgs({
+          selectedWorkTypeName: "inspection",
+          selection,
+        }),
+      ),
+    );
+
+    expect(useSaveEditableWorkTypeConfiguration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopeKey: "inspection",
+      }),
+    );
+  });
+
   it("returns header actions for each editable selection kind", () => {
     const { result } = renderHook(() =>
-      useCurrentSelectionDetailSave({
-        currentSelection: buildCurrentSelectionStub(),
-        editableConfigurationState: { status: "loading" },
-        editableResourceConfigurationState: { status: "loading" },
-        editableWorkerConfigurationState: { status: "loading" },
-        selectedNode: null,
-        selectedResourceName: null,
-        selectedWorkerName: null,
-        selection: null,
-      }),
+      useCurrentSelectionDetailSave(buildHookArgs()),
     );
 
     expect(result.current.resourceHeaderAction).toBeTruthy();
     expect(result.current.workerHeaderAction).toBeTruthy();
     expect(result.current.workstationHeaderAction).toBeTruthy();
+    expect(result.current.workStateHeaderAction).toBeTruthy();
+    expect(result.current.workTypeHeaderAction).toBeTruthy();
   });
 });

--- a/ui/src/features/current-selection/components/use-current-selection-detail-save.tsx
+++ b/ui/src/features/current-selection/components/use-current-selection-detail-save.tsx
@@ -3,6 +3,18 @@ import type { CurrentSelectionState } from "../hooks/useCurrentSelection";
 import { EditableResourceConfigurationHeaderActions } from "../resource-selection/components/resource-save-controls";
 import type { useEditableResourceConfigurationState } from "../resource-selection/hooks/use-editable-resource-configuration-state";
 import { useSaveEditableResourceConfiguration } from "../resource-selection/hooks/use-save-editable-resource-configuration";
+import { EditableWorkStateConfigurationHeaderActions } from "../work-state-selection/components/work-state-save-controls";
+import type { useEditableWorkStateConfigurationState } from "../work-state-selection/hooks/use-editable-work-state-configuration-state";
+import { useSaveEditableWorkStateConfiguration } from "../work-state-selection/hooks/use-save-editable-work-state-configuration";
+import {
+  EditableWorkTypeConfigurationHeaderActions,
+  EditableWorkTypeSaveDialog,
+} from "../work-type-selection/components/work-type-save-controls";
+import type { useEditableWorkTypeConfigurationState } from "../work-type-selection/hooks/use-editable-work-type-configuration-state";
+import {
+  type UseSaveEditableWorkTypeConfigurationResult,
+  useSaveEditableWorkTypeConfiguration,
+} from "../work-type-selection/hooks/use-save-editable-work-type-configuration";
 import type { useEditableWorkerConfigurationState } from "../worker-selection/hooks/use-editable-worker-configuration-state";
 import { useSaveEditableWorkerConfiguration } from "../worker-selection/hooks/use-save-editable-worker-configuration";
 import { EditableWorkerConfigurationHeaderActions } from "../worker-selection/components/worker-save-controls";
@@ -14,16 +26,21 @@ import {
 } from "../workstation-selection/hooks/use-save-editable-workstation-configuration";
 import { EditableWorkstationSaveDialog } from "../workstation-selection/public";
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: one hook wires save scopes and paired header actions for every editable selection kind.
 export function useCurrentSelectionDetailSave({
   currentSelection,
   editableConfigurationState,
   editableResourceConfigurationState,
+  editableWorkStateConfigurationState,
   editableWorkerConfigurationState,
+  editableWorkTypeConfigurationState,
   locale,
   selectedNode,
   selectedResourceName,
   selectedWorkerName,
+  selectedWorkTypeName,
   selection,
+  workStatePlaceId,
 }: {
   currentSelection: CurrentSelectionState;
   editableConfigurationState: ReturnType<
@@ -32,14 +49,22 @@ export function useCurrentSelectionDetailSave({
   editableResourceConfigurationState: ReturnType<
     typeof useEditableResourceConfigurationState
   >;
+  editableWorkStateConfigurationState: ReturnType<
+    typeof useEditableWorkStateConfigurationState
+  >;
   editableWorkerConfigurationState: ReturnType<
     typeof useEditableWorkerConfigurationState
+  >;
+  editableWorkTypeConfigurationState: ReturnType<
+    typeof useEditableWorkTypeConfigurationState
   >;
   locale?: string | null;
   selectedNode: CurrentSelectionState["selectedNode"];
   selectedResourceName: string | null;
   selectedWorkerName: string | null;
+  selectedWorkTypeName: string | null;
   selection: DashboardSelection | null;
+  workStatePlaceId: string | null;
 }) {
   const workstationSaveScopeKey =
     selection?.kind === "node" && selectedNode
@@ -69,6 +94,22 @@ export function useCurrentSelectionDetailSave({
     locale,
     onResourceRenamed: currentSelection.selectResource,
     scopeKey: resourceSaveScopeKey,
+  });
+  const workStateSave = useSaveEditableWorkStateConfiguration({
+    editableConfigurationState: editableWorkStateConfigurationState,
+    locale,
+    onWorkStateRenamed: currentSelection.selectStateNode,
+    scopeKey: workStatePlaceId,
+  });
+  const workTypeSaveScopeKey =
+    selection?.kind === "work-type" && selectedWorkTypeName
+      ? selectedWorkTypeName
+      : null;
+  const workTypeSave = useSaveEditableWorkTypeConfiguration({
+    editableConfigurationState: editableWorkTypeConfigurationState,
+    locale,
+    onWorkTypeRenamed: currentSelection.selectWorkType,
+    scopeKey: workTypeSaveScopeKey,
   });
 
   const workstationHeaderAction = (
@@ -122,16 +163,56 @@ export function useCurrentSelectionDetailSave({
       saveState={resourceSave.saveState}
     />
   );
+  const workStateHeaderAction = (
+    <EditableWorkStateConfigurationHeaderActions
+      canDiscard={
+        editableWorkStateConfigurationState?.status === "ready" &&
+        editableWorkStateConfigurationState.isDirty
+      }
+      canSave={workStateSave.canSave}
+      locale={locale ?? undefined}
+      onDiscard={() => {
+        if (editableWorkStateConfigurationState?.status === "ready") {
+          editableWorkStateConfigurationState.onResetToLatest();
+        }
+      }}
+      onSave={() => void workStateSave.save()}
+      saveState={workStateSave.saveState}
+    />
+  );
+  const workTypeHeaderAction = (
+    <EditableWorkTypeConfigurationHeaderActions
+      canDiscard={
+        editableWorkTypeConfigurationState?.status === "ready" &&
+        editableWorkTypeConfigurationState.isDirty
+      }
+      canSave={workTypeSave.canSave}
+      locale={locale ?? undefined}
+      onDiscard={() => {
+        if (editableWorkTypeConfigurationState?.status === "ready") {
+          editableWorkTypeConfigurationState.onResetToLatest();
+        }
+      }}
+      onSave={workTypeSave.beginSaveConfirmation}
+      saveState={workTypeSave.saveState}
+    />
+  );
 
   return {
     resourceHeaderAction,
     resourceSaveState: resourceSave.saveState,
     saveWorkerConfiguration: () => void workerSave.save(),
+    saveWorkStateConfiguration: () => void workStateSave.save(),
     workstationHeaderAction,
     workstationSave,
     workstationSaveState: workstationSave.saveState,
     workerHeaderAction,
     workerSaveState: workerSave.saveState,
+    workStateHeaderAction,
+    workStateSaveState: workStateSave.saveState,
+    workTypeHeaderAction,
+    workTypeSave,
+    workTypeSaveState: workTypeSave.saveState,
   };
 }
 
@@ -157,6 +238,23 @@ export function CurrentSelectionWorkstationSaveDialog({
           : []
       }
       saveState={workstationSave.saveState}
+    />
+  );
+}
+
+export function CurrentSelectionWorkTypeSaveDialog({
+  locale,
+  workTypeSave,
+}: {
+  locale?: string | null;
+  workTypeSave: UseSaveEditableWorkTypeConfigurationResult;
+}) {
+  return (
+    <EditableWorkTypeSaveDialog
+      locale={locale ?? undefined}
+      onCancel={workTypeSave.cancelSaveConfirmation}
+      onConfirm={() => void workTypeSave.confirmSave()}
+      saveState={workTypeSave.saveState}
     />
   );
 }

--- a/ui/src/features/current-selection/components/use-current-selection-detail-save.tsx
+++ b/ui/src/features/current-selection/components/use-current-selection-detail-save.tsx
@@ -6,15 +6,13 @@ import { useSaveEditableResourceConfiguration } from "../resource-selection/hook
 import type { useEditableWorkerConfigurationState } from "../worker-selection/hooks/use-editable-worker-configuration-state";
 import { useSaveEditableWorkerConfiguration } from "../worker-selection/hooks/use-save-editable-worker-configuration";
 import { EditableWorkerSaveHeaderAction } from "../worker-selection/public";
+import { EditableWorkstationConfigurationHeaderActions } from "../workstation-selection/components/workstation-save-controls";
 import type { useEditableWorkstationConfigurationState } from "../workstation-selection/hooks/use-editable-workstation-configuration-state";
 import {
   type UseSaveEditableWorkstationConfigurationResult,
   useSaveEditableWorkstationConfiguration,
 } from "../workstation-selection/hooks/use-save-editable-workstation-configuration";
-import {
-  EditableWorkstationSaveDialog,
-  EditableWorkstationSaveHeaderAction,
-} from "../workstation-selection/public";
+import { EditableWorkstationSaveDialog } from "../workstation-selection/public";
 
 export function useCurrentSelectionDetailSave({
   currentSelection,
@@ -74,10 +72,19 @@ export function useCurrentSelectionDetailSave({
   });
 
   const workstationHeaderAction = (
-    <EditableWorkstationSaveHeaderAction
+    <EditableWorkstationConfigurationHeaderActions
+      canDiscard={
+        editableConfigurationState?.status === "ready" &&
+        editableConfigurationState.isDirty
+      }
       canSave={workstationSave.canSave}
       locale={locale ?? undefined}
-      onClick={workstationSave.beginSaveConfirmation}
+      onDiscard={() => {
+        if (editableConfigurationState?.status === "ready") {
+          editableConfigurationState.onResetToLatest();
+        }
+      }}
+      onSave={workstationSave.beginSaveConfirmation}
       saveState={workstationSave.saveState}
     />
   );

--- a/ui/src/features/current-selection/components/use-current-selection-detail-save.tsx
+++ b/ui/src/features/current-selection/components/use-current-selection-detail-save.tsx
@@ -1,6 +1,6 @@
 import type { DashboardSelection } from "../base/state/selection-types";
 import type { CurrentSelectionState } from "../hooks/useCurrentSelection";
-import { EditableResourceSaveHeaderAction } from "../resource-selection/components/resource-save-controls";
+import { EditableResourceConfigurationHeaderActions } from "../resource-selection/components/resource-save-controls";
 import type { useEditableResourceConfigurationState } from "../resource-selection/hooks/use-editable-resource-configuration-state";
 import { useSaveEditableResourceConfiguration } from "../resource-selection/hooks/use-save-editable-resource-configuration";
 import type { useEditableWorkerConfigurationState } from "../worker-selection/hooks/use-editable-worker-configuration-state";
@@ -106,10 +106,19 @@ export function useCurrentSelectionDetailSave({
     />
   );
   const resourceHeaderAction = (
-    <EditableResourceSaveHeaderAction
+    <EditableResourceConfigurationHeaderActions
+      canDiscard={
+        editableResourceConfigurationState?.status === "ready" &&
+        editableResourceConfigurationState.isDirty
+      }
       canSave={resourceSave.canSave}
       locale={locale ?? undefined}
-      onClick={() => void resourceSave.save()}
+      onDiscard={() => {
+        if (editableResourceConfigurationState?.status === "ready") {
+          editableResourceConfigurationState.onResetToLatest();
+        }
+      }}
+      onSave={() => void resourceSave.save()}
       saveState={resourceSave.saveState}
     />
   );

--- a/ui/src/features/current-selection/components/use-current-selection-detail-save.tsx
+++ b/ui/src/features/current-selection/components/use-current-selection-detail-save.tsx
@@ -5,7 +5,7 @@ import type { useEditableResourceConfigurationState } from "../resource-selectio
 import { useSaveEditableResourceConfiguration } from "../resource-selection/hooks/use-save-editable-resource-configuration";
 import type { useEditableWorkerConfigurationState } from "../worker-selection/hooks/use-editable-worker-configuration-state";
 import { useSaveEditableWorkerConfiguration } from "../worker-selection/hooks/use-save-editable-worker-configuration";
-import { EditableWorkerSaveHeaderAction } from "../worker-selection/public";
+import { EditableWorkerConfigurationHeaderActions } from "../worker-selection/components/worker-save-controls";
 import { EditableWorkstationConfigurationHeaderActions } from "../workstation-selection/components/workstation-save-controls";
 import type { useEditableWorkstationConfigurationState } from "../workstation-selection/hooks/use-editable-workstation-configuration-state";
 import {
@@ -89,10 +89,19 @@ export function useCurrentSelectionDetailSave({
     />
   );
   const workerHeaderAction = (
-    <EditableWorkerSaveHeaderAction
+    <EditableWorkerConfigurationHeaderActions
+      canDiscard={
+        editableWorkerConfigurationState?.status === "ready" &&
+        editableWorkerConfigurationState.isDirty
+      }
       canSave={workerSave.canSave}
       locale={locale ?? undefined}
-      onClick={() => void workerSave.save()}
+      onDiscard={() => {
+        if (editableWorkerConfigurationState?.status === "ready") {
+          editableWorkerConfigurationState.onResetToLatest();
+        }
+      }}
+      onSave={() => void workerSave.save()}
       saveState={workerSave.saveState}
     />
   );

--- a/ui/src/features/current-selection/resource-selection/components/resource-detail-card.test.tsx
+++ b/ui/src/features/current-selection/resource-selection/components/resource-detail-card.test.tsx
@@ -1,11 +1,16 @@
 // biome-ignore-all lint/complexity/noExcessiveLinesPerFunction: resource detail card regressions share one mocked factory-document seam.
-import { fireEvent, render, screen } from "@testing-library/react";
+// biome-ignore-all lint/nursery/noExcessiveLinesPerFile: resource detail card regressions share one mocked factory-document seam.
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import type { CurrentFactoryDocument } from "../../../../api/current-factory-definition";
 import { useCurrentFactoryDocument } from "../../../current-factory-definition/hooks/useCurrentFactoryDefinition";
 import type { DashboardSelection } from "../../base/state/selection-types";
 import { useEditableResourceConfigurationState } from "../hooks/use-editable-resource-configuration-state";
-import type { EditableResourceConfigurationState } from "../lib/detail-card-types";
+import type {
+  EditableResourceConfigurationState,
+  EditableResourceSaveState,
+} from "../lib/detail-card-types";
 import { ResourceDetailCard } from "./resource-detail-card";
+import { EditableResourceConfigurationHeaderActions } from "./resource-save-controls";
 
 vi.mock(
   "../../../current-factory-definition/hooks/useCurrentFactoryDefinition",
@@ -124,6 +129,57 @@ function renderResourceDetailCard(
   }
 
   return render(<Harness />);
+}
+
+function resourceDetailHeaderActionSection() {
+  const card = screen.getByRole("article", { name: "Current selection" });
+  const undoButton = within(card).getByRole("button", {
+    name: "Undo selection",
+  });
+  const actionSection = undoButton.closest(
+    "[data-dashboard-action-row-section='actions']",
+  );
+  if (!actionSection) {
+    throw new Error("expected header action section");
+  }
+
+  return actionSection as HTMLElement;
+}
+
+function editableResourceConfigurationSection() {
+  const heading = screen.getByRole("heading", {
+    name: "Resource configuration",
+  });
+  const section = heading.closest("section");
+  if (!section) {
+    throw new Error("expected editable resource configuration section");
+  }
+
+  return section;
+}
+
+function buildResourceHeaderActions({
+  canDiscard = false,
+  canSave,
+  onDiscard = vi.fn(),
+  onSave = vi.fn(),
+  saveState = { status: "idle" },
+}: {
+  canDiscard?: boolean;
+  canSave: boolean;
+  onDiscard?: () => void;
+  onSave?: () => void;
+  saveState?: EditableResourceSaveState;
+}) {
+  return (
+    <EditableResourceConfigurationHeaderActions
+      canDiscard={canDiscard}
+      canSave={canSave}
+      onDiscard={onDiscard}
+      onSave={onSave}
+      saveState={saveState}
+    />
+  );
 }
 
 function renderReadOnlyResourceDetailCard(
@@ -409,5 +465,100 @@ describe("ResourceDetailCard", () => {
         /The running factory changed this field while you were editing/i,
       ),
     ).toBeTruthy();
+  });
+
+  it("keeps save and discard in the header only after dirty edits", () => {
+    const editableConfigurationState: EditableResourceConfigurationState = {
+      baseVersion: {
+        logical: "7",
+        physical: "2026-05-23T16:22:24Z",
+      },
+      canSave: true,
+      draft: {
+        backend: "",
+        capacityText: "3",
+        loadPolicy: "",
+        model: "",
+        name: "agent-slot",
+        provider: "",
+        type: "INVOCATION_SLOT",
+      },
+      hasValidationErrors: false,
+      initialValues: {
+        backend: null,
+        capacity: 2,
+        loadPolicy: null,
+        model: null,
+        provider: null,
+        resourceName: "agent-slot",
+        type: "INVOCATION_SLOT",
+        workerNames: ["reviewer"],
+        workstationNames: ["Review"],
+      },
+      isDirty: true,
+      markChangesSaved: vi.fn(),
+      onBackendChange: vi.fn(),
+      onCapacityChange: vi.fn(),
+      onLoadPolicyChange: vi.fn(),
+      onModelChange: vi.fn(),
+      onNameChange: vi.fn(),
+      onProviderChange: vi.fn(),
+      onResetToLatest: vi.fn(),
+      onTypeChange: vi.fn(),
+      overwriteFieldNames: [],
+      pendingFactoryDefinition: buildFactoryDocument(),
+      status: "ready",
+      validationErrors: {},
+    };
+
+    mockFactoryDocumentQuery({
+      data: buildFactoryDocument(),
+      isPending: false,
+      isSuccess: true,
+      status: "success",
+    } as never);
+
+    const onSave = vi.fn();
+    const onDiscard = vi.fn();
+
+    render(
+      <ResourceDetailCard
+        editableConfigurationState={editableConfigurationState}
+        headerAction={buildResourceHeaderActions({
+          canDiscard: true,
+          canSave: true,
+          onDiscard,
+          onSave,
+        })}
+        resourceName="agent-slot"
+      />,
+    );
+
+    const headerActions = resourceDetailHeaderActionSection();
+    const saveButtons = within(headerActions).getAllByRole("button", {
+      name: "Save resource",
+    });
+    const discardButtons = within(headerActions).getAllByRole("button", {
+      name: "Discard local changes",
+    });
+    expect(saveButtons).toHaveLength(1);
+    expect(discardButtons).toHaveLength(1);
+
+    fireEvent.click(saveButtons[0]);
+    expect(onSave).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(discardButtons[0]);
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+
+    expect(
+      within(editableResourceConfigurationSection()).queryByRole("button", {
+        name: "Save resource",
+      }),
+    ).toBeNull();
+    expect(
+      within(editableResourceConfigurationSection()).queryByRole("button", {
+        name: "Discard local changes",
+      }),
+    ).toBeNull();
   });
 });

--- a/ui/src/features/current-selection/resource-selection/components/resource-editable-configuration-section.tsx
+++ b/ui/src/features/current-selection/resource-selection/components/resource-editable-configuration-section.tsx
@@ -1,12 +1,7 @@
 // biome-ignore lint/nursery/noExcessiveLinesPerFile: resource editable fields, validation feedback, and runtime context stay colocated in one section.
 import { type ReactNode, useId, useState } from "react";
 
-import {
-  DashboardActionButton,
-  DashboardActionRow,
-  ExpandablePanelTrigger,
-  Select,
-} from "../../../../components/ui";
+import { ExpandablePanelTrigger, Select } from "../../../../components/ui";
 import {
   DASHBOARD_BODY_TEXT_CLASS,
   DASHBOARD_SUPPORTING_LABEL_CLASS,
@@ -283,18 +278,6 @@ function ResourceEditableConfigurationReadyForm({
         state={state}
         validationErrors={validationErrors}
       />
-      {state.isDirty || state.overwriteFieldNames.length > 0 ? (
-        <DashboardActionRow
-          actions={
-            <DashboardActionButton
-              onClick={state.onResetToLatest}
-              type="button"
-            >
-              {messages.resetToLatestAction}
-            </DashboardActionButton>
-          }
-        />
-      ) : null}
     </form>
   );
 }

--- a/ui/src/features/current-selection/resource-selection/components/resource-save-controls.test.tsx
+++ b/ui/src/features/current-selection/resource-selection/components/resource-save-controls.test.tsx
@@ -1,5 +1,39 @@
-import { render, screen } from "@testing-library/react";
-import { EditableResourceSaveHeaderAction } from "./resource-save-controls";
+import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  EditableResourceConfigurationHeaderActions,
+  EditableResourceSaveHeaderAction,
+} from "./resource-save-controls";
+
+describe("EditableResourceConfigurationHeaderActions", () => {
+  it("renders discard before save and wires both actions", () => {
+    const onDiscard = vi.fn();
+    const onSave = vi.fn();
+
+    render(
+      <EditableResourceConfigurationHeaderActions
+        canDiscard
+        canSave
+        onDiscard={onDiscard}
+        onSave={onSave}
+        saveState={{ status: "idle" }}
+      />,
+    );
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons.map((button) => button.getAttribute("aria-label"))).toEqual([
+      "Discard local changes",
+      "Save resource",
+    ]);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Discard local changes" }),
+    );
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save resource" }));
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe("EditableResourceSaveHeaderAction", () => {
   it("renders save action with warning emphasis when dirty and saveable", () => {

--- a/ui/src/features/current-selection/resource-selection/components/resource-save-controls.tsx
+++ b/ui/src/features/current-selection/resource-selection/components/resource-save-controls.tsx
@@ -1,8 +1,44 @@
 import { Save } from "lucide-react";
 import { DashboardActionButton } from "../../../../components/ui";
 import { cn } from "../../../../lib/cn";
+import { EditableConfigurationDiscardHeaderAction } from "../../base/public";
 import type { EditableResourceSaveState } from "../lib/detail-card-types";
 import { getResourceDetailMessages } from "../messages/resource-detail";
+
+export function EditableResourceConfigurationHeaderActions({
+  canDiscard,
+  canSave,
+  locale,
+  onDiscard,
+  onSave,
+  saveState,
+}: {
+  canDiscard: boolean;
+  canSave: boolean;
+  locale?: string;
+  onDiscard: () => void;
+  onSave: () => void;
+  saveState: EditableResourceSaveState;
+}) {
+  const isSaving = saveState.status === "submitting";
+
+  return (
+    <>
+      <EditableConfigurationDiscardHeaderAction
+        canDiscard={canDiscard}
+        isSaving={isSaving}
+        locale={locale}
+        onClick={onDiscard}
+      />
+      <EditableResourceSaveHeaderAction
+        canSave={canSave}
+        locale={locale}
+        onClick={onSave}
+        saveState={saveState}
+      />
+    </>
+  );
+}
 
 export function EditableResourceSaveHeaderAction({
   canSave,

--- a/ui/src/features/current-selection/resource-selection/public/index.test.ts
+++ b/ui/src/features/current-selection/resource-selection/public/index.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import * as resourceSelectionPublic from "./index";
+
+describe("resource-selection/public", () => {
+  it("keeps the public runtime surface focused on ResourceDetailCard", () => {
+    expect(Object.keys(resourceSelectionPublic).sort()).toEqual([
+      "EditableResourceConfigurationHeaderActions",
+      "EditableResourceSaveHeaderAction",
+      "ResourceDetailCard",
+    ]);
+    expect(resourceSelectionPublic.ResourceDetailCard).toBeTypeOf("function");
+  });
+});

--- a/ui/src/features/current-selection/resource-selection/public/index.ts
+++ b/ui/src/features/current-selection/resource-selection/public/index.ts
@@ -1,2 +1,5 @@
 export { ResourceDetailCard } from "../components/resource-detail-card";
-export { EditableResourceSaveHeaderAction } from "../components/resource-save-controls";
+export {
+  EditableResourceConfigurationHeaderActions,
+  EditableResourceSaveHeaderAction,
+} from "../components/resource-save-controls";

--- a/ui/src/features/current-selection/work-state-selection/components/state-node-detail.test.tsx
+++ b/ui/src/features/current-selection/work-state-selection/components/state-node-detail.test.tsx
@@ -1,18 +1,18 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import type { CurrentFactoryDocument } from "../../../../api/current-factory-definition";
 import { semanticWorkflowDashboardSnapshot } from "../../../../components/dashboard/test-fixtures";
-import { WIDGET_SUBTITLE_CLASS } from "../../../../components/ui/widget-frame";
 import { formatLocalDateTime } from "../../../../components/ui/formatters";
-import { describe, expect, it, vi } from "vitest";
-import { CURRENT_SELECTION_VERTICAL_FORM_FIELDS_CLASS } from "../../base/components/detail-card-shared";
+import { WIDGET_SUBTITLE_CLASS } from "../../../../components/ui/widget-frame";
 import { CurrentSelectionLocaleProvider } from "../../base/components/current-selection-locale";
+import { CURRENT_SELECTION_VERTICAL_FORM_FIELDS_CLASS } from "../../base/components/detail-card-shared";
 import type {
   EditableWorkStateConfigurationState,
   EditableWorkStateSaveState,
 } from "../lib/detail-card-types";
 import { getWorkStateDetailMessages } from "../messages/work-state-detail";
-import { EditableWorkStateSaveHeaderAction } from "./work-state-save-controls";
 import { StateNodeDetailCard } from "./state-node-detail";
+import { EditableWorkStateConfigurationHeaderActions } from "./work-state-save-controls";
 
 function requireValue<T>(value: T | null | undefined, message: string): T {
   if (value === null || value === undefined) {
@@ -29,11 +29,15 @@ describe("StateNodeDetailCard", () => {
 
   it("renders selected state node detail with current work item references", () => {
     const snapshot = semanticWorkflowDashboardSnapshot;
-    const selectedState = snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
-      (place) => place.place_id === "story:implemented",
-    );
+    const selectedState =
+      snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
+        (place) => place.place_id === "story:implemented",
+      );
 
-    const resolvedSelectedState = requireValue(selectedState, "expected implemented state fixture");
+    const resolvedSelectedState = requireValue(
+      selectedState,
+      "expected implemented state fixture",
+    );
 
     render(
       <StateNodeDetailCard
@@ -53,12 +57,26 @@ describe("StateNodeDetailCard", () => {
 
     const summaryDetails = screen.getByText("Count").closest("dl");
 
-    expect(screen.getByRole("heading", { name: "Current selection" })).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: "Current selection" }),
+    ).toBeTruthy();
     expect(screen.getByText("story: implemented")).toBeTruthy();
     expect(summaryDetails).toBeTruthy();
-    expect(within(requireValue(summaryDetails, "expected summary details")).queryByText("Work type")).toBeNull();
-    expect(within(requireValue(summaryDetails, "expected summary details")).queryByText("State")).toBeNull();
-    expect(within(requireValue(summaryDetails, "expected summary details")).queryByText("State node ID")).toBeNull();
+    expect(
+      within(
+        requireValue(summaryDetails, "expected summary details"),
+      ).queryByText("Work type"),
+    ).toBeNull();
+    expect(
+      within(
+        requireValue(summaryDetails, "expected summary details"),
+      ).queryByText("State"),
+    ).toBeNull();
+    expect(
+      within(
+        requireValue(summaryDetails, "expected summary details"),
+      ).queryByText("State node ID"),
+    ).toBeNull();
     expect(screen.getByText("Count")).toBeTruthy();
     expect(screen.getByText("Current work")).toBeTruthy();
     expect(screen.queryByText("Token count")).toBeNull();
@@ -82,11 +100,15 @@ describe("StateNodeDetailCard", () => {
 
   it("omits the supporting time row when current work has no started-at timestamp", () => {
     const snapshot = semanticWorkflowDashboardSnapshot;
-    const selectedState = snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
-      (place) => place.place_id === "story:implemented",
-    );
+    const selectedState =
+      snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
+        (place) => place.place_id === "story:implemented",
+      );
 
-    const resolvedSelectedState = requireValue(selectedState, "expected implemented state fixture");
+    const resolvedSelectedState = requireValue(
+      selectedState,
+      "expected implemented state fixture",
+    );
 
     render(
       <StateNodeDetailCard
@@ -105,51 +127,85 @@ describe("StateNodeDetailCard", () => {
     const summaryDetails = screen.getByText("Count").closest("dl");
 
     expect(summaryDetails).toBeTruthy();
-    expect(within(requireValue(summaryDetails, "expected summary details")).queryByText("Work type")).toBeNull();
+    expect(
+      within(
+        requireValue(summaryDetails, "expected summary details"),
+      ).queryByText("Work type"),
+    ).toBeNull();
     expect(screen.queryByText(/^Started at /)).toBeNull();
   });
 
   it("renders the state-node selection header as one combined summary", () => {
     const snapshot = semanticWorkflowDashboardSnapshot;
-    const selectedState = snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
-      (place) => place.place_id === "story:implemented",
+    const selectedState =
+      snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
+        (place) => place.place_id === "story:implemented",
+      );
+
+    const resolvedSelectedState = requireValue(
+      selectedState,
+      "expected implemented state fixture",
     );
 
-    const resolvedSelectedState = requireValue(selectedState, "expected implemented state fixture");
-
-    render(<StateNodeDetailCard currentWorkItems={[]} place={resolvedSelectedState} tokenCount={0} />);
+    render(
+      <StateNodeDetailCard
+        currentWorkItems={[]}
+        place={resolvedSelectedState}
+        tokenCount={0}
+      />,
+    );
 
     const header = screen.getByTitle("story:implemented");
-    const summary = within(header).getByText("story: implemented", { selector: "p" });
+    const summary = within(header).getByText("story: implemented", {
+      selector: "p",
+    });
     expect(summary.className).toContain(WIDGET_SUBTITLE_CLASS);
   });
 
   it("renders selected state node empty-position guidance", () => {
     const snapshot = semanticWorkflowDashboardSnapshot;
-    const selectedState = snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
-      (place) => place.place_id === "story:implemented",
+    const selectedState =
+      snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
+        (place) => place.place_id === "story:implemented",
+      );
+
+    const resolvedSelectedState = requireValue(
+      selectedState,
+      "expected implemented state fixture",
     );
 
-    const resolvedSelectedState = requireValue(selectedState, "expected implemented state fixture");
+    render(
+      <StateNodeDetailCard
+        currentWorkItems={[]}
+        place={resolvedSelectedState}
+        tokenCount={0}
+      />,
+    );
 
-    render(<StateNodeDetailCard currentWorkItems={[]} place={resolvedSelectedState} tokenCount={0} />);
-
-    expect(screen.getByRole("heading", { name: "Current selection" })).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: "Current selection" }),
+    ).toBeTruthy();
     expect(screen.getByText("story: implemented")).toBeTruthy();
     expect(screen.queryByText("State")).toBeNull();
     expect(screen.getByText("Current work")).toBeTruthy();
     expect(screen.queryByText("Token count")).toBeNull();
     expect(screen.queryByText(/terminal history/i)).toBeNull();
-    expect(screen.getByText("No current work is occupying this place.")).toBeTruthy();
+    expect(
+      screen.getByText("No current work is occupying this place."),
+    ).toBeTruthy();
   });
 
   it("renders selected terminal state node detail from terminal-history occupancy", () => {
     const snapshot = semanticWorkflowDashboardSnapshot;
-    const selectedState = snapshot.topology.workstation_nodes_by_id.review.output_places?.find(
-      (place) => place.place_id === "story:complete",
-    );
+    const selectedState =
+      snapshot.topology.workstation_nodes_by_id.review.output_places?.find(
+        (place) => place.place_id === "story:complete",
+      );
 
-    const resolvedSelectedState = requireValue(selectedState, "expected terminal state fixture");
+    const resolvedSelectedState = requireValue(
+      selectedState,
+      "expected terminal state fixture",
+    );
 
     render(
       <StateNodeDetailCard
@@ -168,7 +224,9 @@ describe("StateNodeDetailCard", () => {
       />,
     );
 
-    expect(screen.getByRole("heading", { name: "Current selection" })).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: "Current selection" }),
+    ).toBeTruthy();
     expect(screen.getByText("story: complete")).toBeTruthy();
     expect(screen.queryByText("State node ID")).toBeNull();
     expect(screen.getByText("Current work")).toBeTruthy();
@@ -183,16 +241,22 @@ describe("StateNodeDetailCard", () => {
     ).toBeTruthy();
     expect(screen.queryByText("trace-done-story")).toBeNull();
     expect(screen.queryByText(/^story$/)).toBeNull();
-    expect(screen.queryByText("No current work is occupying this place.")).toBeNull();
+    expect(
+      screen.queryByText("No current work is occupying this place."),
+    ).toBeNull();
   });
 
   it("renders failed terminal state diagnostics from retained failed-work details", () => {
     const snapshot = semanticWorkflowDashboardSnapshot;
-    const selectedState = snapshot.topology.workstation_nodes_by_id.implement.output_places?.find(
-      (place) => place.place_id === "story:blocked",
-    );
+    const selectedState =
+      snapshot.topology.workstation_nodes_by_id.implement.output_places?.find(
+        (place) => place.place_id === "story:blocked",
+      );
 
-    const resolvedSelectedState = requireValue(selectedState, "expected failed state fixture");
+    const resolvedSelectedState = requireValue(
+      selectedState,
+      "expected failed state fixture",
+    );
 
     render(
       <StateNodeDetailCard
@@ -200,7 +264,8 @@ describe("StateNodeDetailCard", () => {
         failedWorkDetailsByWorkID={{
           "work-failed-story": {
             dispatch_id: "dispatch-failed-story",
-            failure_message: "Provider rate limit exceeded while generating the repair.",
+            failure_message:
+              "Provider rate limit exceeded while generating the repair.",
             failure_reason: "provider_rate_limit",
             transition_id: "repair",
             work_item: {
@@ -239,38 +304,68 @@ describe("StateNodeDetailCard", () => {
     expect(screen.getByText("Failure reason")).toBeTruthy();
     expect(screen.getByText("provider_rate_limit")).toBeTruthy();
     expect(screen.getByText("Failure message")).toBeTruthy();
-    expect(screen.getByText("Provider rate limit exceeded while generating the repair.")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Provider rate limit exceeded while generating the repair.",
+      ),
+    ).toBeTruthy();
   });
 
   it("distinguishes empty terminal state positions from unavailable terminal history", () => {
     const snapshot = semanticWorkflowDashboardSnapshot;
-    const selectedState = snapshot.topology.workstation_nodes_by_id.review.output_places?.find(
-      (place) => place.place_id === "story:complete",
-    );
+    const selectedState =
+      snapshot.topology.workstation_nodes_by_id.review.output_places?.find(
+        (place) => place.place_id === "story:complete",
+      );
 
-    const resolvedSelectedState = requireValue(selectedState, "expected terminal state fixture");
+    const resolvedSelectedState = requireValue(
+      selectedState,
+      "expected terminal state fixture",
+    );
 
     const { rerender } = render(
-      <StateNodeDetailCard currentWorkItems={[]} place={resolvedSelectedState} tokenCount={0} />,
+      <StateNodeDetailCard
+        currentWorkItems={[]}
+        place={resolvedSelectedState}
+        tokenCount={0}
+      />,
     );
 
-    expect(screen.getByText("No work is recorded for this place at the selected tick.")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "No work is recorded for this place at the selected tick.",
+      ),
+    ).toBeTruthy();
     expect(screen.queryByText(/terminal history/i)).toBeNull();
 
-    rerender(<StateNodeDetailCard currentWorkItems={[]} place={resolvedSelectedState} tokenCount={1} />);
+    rerender(
+      <StateNodeDetailCard
+        currentWorkItems={[]}
+        place={resolvedSelectedState}
+        tokenCount={1}
+      />,
+    );
 
-    expect(screen.getByText("Represented work is unavailable for this place at the selected tick.")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Represented work is unavailable for this place at the selected tick.",
+      ),
+    ).toBeTruthy();
     expect(screen.queryByText(/terminal history/i)).toBeNull();
   });
 
   it("calls the selection callback when a listed work item is clicked", () => {
     const snapshot = semanticWorkflowDashboardSnapshot;
-    const selectedState = snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
-      (place) => place.place_id === "story:implemented",
-    );
+    const selectedState =
+      snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
+        (place) => place.place_id === "story:implemented",
+      );
     const onSelectWorkItem = vi.fn();
 
-    const resolvedSelectedState = requireValue(selectedState, "expected implemented state fixture");
+    const resolvedSelectedState = requireValue(
+      selectedState,
+      "expected implemented state fixture",
+    );
 
     render(
       <StateNodeDetailCard
@@ -288,7 +383,9 @@ describe("StateNodeDetailCard", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Select work item Active Story" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Select work item Active Story" }),
+    );
 
     expect(onSelectWorkItem).toHaveBeenCalledWith({
       display_name: "Active Story",
@@ -300,31 +397,45 @@ describe("StateNodeDetailCard", () => {
 
   it("renders state-node supporting copy from the zh-CN locale catalog", () => {
     const snapshot = semanticWorkflowDashboardSnapshot;
-    const selectedState = snapshot.topology.workstation_nodes_by_id.review.output_places?.find(
-      (place) => place.place_id === "story:complete",
-    );
+    const selectedState =
+      snapshot.topology.workstation_nodes_by_id.review.output_places?.find(
+        (place) => place.place_id === "story:complete",
+      );
 
-    const resolvedSelectedState = requireValue(selectedState, "expected terminal state fixture");
+    const resolvedSelectedState = requireValue(
+      selectedState,
+      "expected terminal state fixture",
+    );
 
     render(
       <CurrentSelectionLocaleProvider locale="zh-CN">
-        <StateNodeDetailCard currentWorkItems={[]} place={resolvedSelectedState} tokenCount={0} />
+        <StateNodeDetailCard
+          currentWorkItems={[]}
+          place={resolvedSelectedState}
+          tokenCount={0}
+        />
       </CurrentSelectionLocaleProvider>,
     );
 
     expect(screen.queryByText("状态")).toBeNull();
     expect(screen.queryByText("状态节点 ID")).toBeNull();
     expect(screen.getByText("当前工作")).toBeTruthy();
-    expect(screen.getByText("在所选时间刻度，这个位置暂时没有记录到工作。")).toBeTruthy();
+    expect(
+      screen.getByText("在所选时间刻度，这个位置暂时没有记录到工作。"),
+    ).toBeTruthy();
   });
 
   it("renders Started at with the same canonical formatter output as dispatch history for zh-CN", () => {
     const snapshot = semanticWorkflowDashboardSnapshot;
-    const selectedState = snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
-      (place) => place.place_id === "story:implemented",
-    );
+    const selectedState =
+      snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
+        (place) => place.place_id === "story:implemented",
+      );
 
-    const resolvedSelectedState = requireValue(selectedState, "expected implemented state fixture");
+    const resolvedSelectedState = requireValue(
+      selectedState,
+      "expected implemented state fixture",
+    );
 
     render(
       <CurrentSelectionLocaleProvider locale="zh-CN">
@@ -374,19 +485,53 @@ function buildFactoryDocument(
   };
 }
 
-function buildWorkStateHeaderSaveAction({
+function workStateDetailHeaderActionSection() {
+  const card = screen.getByRole("article", { name: "Current selection" });
+  const undoButton = within(card).getByRole("button", {
+    name: "Undo selection",
+  });
+  const actionSection = undoButton.closest(
+    "[data-dashboard-action-row-section='actions']",
+  );
+  if (!actionSection) {
+    throw new Error("expected header action section");
+  }
+
+  return actionSection as HTMLElement;
+}
+
+function editableWorkStateConfigurationForm() {
+  const panel = screen.getByRole("article", { name: "Current selection" });
+  const nameInput = within(panel).getByLabelText(
+    getWorkStateDetailMessages().nameFieldLabel,
+  );
+  const form = nameInput.closest("form");
+  if (!form) {
+    throw new Error("expected editable work state configuration form");
+  }
+
+  return form;
+}
+
+function buildWorkStateHeaderActions({
+  canDiscard = false,
   canSave,
-  onClick = vi.fn(),
+  onDiscard = vi.fn(),
+  onSave = vi.fn(),
   saveState = { status: "idle" },
 }: {
+  canDiscard?: boolean;
   canSave: boolean;
-  onClick?: () => void;
+  onDiscard?: () => void;
+  onSave?: () => void;
   saveState?: EditableWorkStateSaveState;
 }) {
   return (
-    <EditableWorkStateSaveHeaderAction
+    <EditableWorkStateConfigurationHeaderActions
+      canDiscard={canDiscard}
       canSave={canSave}
-      onClick={onClick}
+      onDiscard={onDiscard}
+      onSave={onSave}
       saveState={saveState}
     />
   );
@@ -397,10 +542,14 @@ describe("StateNodeDetailCard editable work state configuration", () => {
 
   it("renders editable name and read-only lifecycle type when configuration state is ready", () => {
     const snapshot = semanticWorkflowDashboardSnapshot;
-    const selectedState = snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
-      (place) => place.place_id === "story:implemented",
+    const selectedState =
+      snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
+        (place) => place.place_id === "story:implemented",
+      );
+    const resolvedSelectedState = requireValue(
+      selectedState,
+      "expected implemented state fixture",
     );
-    const resolvedSelectedState = requireValue(selectedState, "expected implemented state fixture");
     const editableConfigurationState: EditableWorkStateConfigurationState = {
       baseVersion: buildFactoryDocument().version,
       canSave: false,
@@ -430,25 +579,34 @@ describe("StateNodeDetailCard editable work state configuration", () => {
       <StateNodeDetailCard
         currentWorkItems={[]}
         editableConfigurationState={editableConfigurationState}
-        headerAction={buildWorkStateHeaderSaveAction({ canSave: false })}
+        headerAction={buildWorkStateHeaderActions({ canSave: false })}
         place={resolvedSelectedState}
         tokenCount={0}
       />,
     );
 
     expect(screen.getByLabelText(messages.nameFieldLabel)).toBeTruthy();
-    expect(screen.getByText(messages.localizeWorkStateType("PROCESSING"))).toBeTruthy();
+    expect(
+      screen.getByText(messages.localizeWorkStateType("PROCESSING")),
+    ).toBeTruthy();
     expect(screen.queryByText("story: implemented")).toBeNull();
-    expect(screen.getByText(messages.editableConfigurationHeading)).toBeTruthy();
+    expect(
+      screen.getByText(messages.editableConfigurationHeading),
+    ).toBeTruthy();
   });
 
   it("shows duplicate-name validation with aria-invalid and role alert", () => {
     const snapshot = semanticWorkflowDashboardSnapshot;
-    const selectedState = snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
-      (place) => place.place_id === "story:implemented",
+    const selectedState =
+      snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
+        (place) => place.place_id === "story:implemented",
+      );
+    const resolvedSelectedState = requireValue(
+      selectedState,
+      "expected implemented state fixture",
     );
-    const resolvedSelectedState = requireValue(selectedState, "expected implemented state fixture");
-    const duplicateMessage = messages.editableConfigurationNameDuplicate("complete");
+    const duplicateMessage =
+      messages.editableConfigurationNameDuplicate("complete");
 
     render(
       <StateNodeDetailCard
@@ -479,7 +637,7 @@ describe("StateNodeDetailCard editable work state configuration", () => {
           },
           workTypeName: "story",
         }}
-        headerAction={buildWorkStateHeaderSaveAction({ canSave: false })}
+        headerAction={buildWorkStateHeaderActions({ canSave: false })}
         place={resolvedSelectedState}
         tokenCount={0}
       />,
@@ -488,19 +646,26 @@ describe("StateNodeDetailCard editable work state configuration", () => {
     const nameInput = screen.getByLabelText(messages.nameFieldLabel);
     expect(nameInput.getAttribute("aria-invalid")).toBe("true");
     expect(screen.getByText(duplicateMessage)).toBeTruthy();
-    const saveButtons = screen.getAllByRole("button", {
+    const headerActions = workStateDetailHeaderActionSection();
+    const saveButtons = within(headerActions).getAllByRole("button", {
       name: messages.editableConfigurationSaveAction,
     });
+    expect(saveButtons).toHaveLength(1);
     expect(saveButtons[0]?.getAttribute("disabled")).not.toBeNull();
   });
 
-  it("stacks configuration fields vertically and renders a labeled footer Save", () => {
+  it("stacks configuration fields vertically and renders header save and discard only when dirty", () => {
     const snapshot = semanticWorkflowDashboardSnapshot;
-    const selectedState = snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
-      (place) => place.place_id === "story:implemented",
+    const selectedState =
+      snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
+        (place) => place.place_id === "story:implemented",
+      );
+    const resolvedSelectedState = requireValue(
+      selectedState,
+      "expected implemented state fixture",
     );
-    const resolvedSelectedState = requireValue(selectedState, "expected implemented state fixture");
-    const onSaveConfiguration = vi.fn();
+    const onSave = vi.fn();
+    const onDiscard = vi.fn();
 
     const { container } = render(
       <StateNodeDetailCard
@@ -529,8 +694,12 @@ describe("StateNodeDetailCard editable work state configuration", () => {
           validationErrors: {},
           workTypeName: "story",
         }}
-        headerAction={buildWorkStateHeaderSaveAction({ canSave: true })}
-        onSaveConfiguration={onSaveConfiguration}
+        headerAction={buildWorkStateHeaderActions({
+          canDiscard: true,
+          canSave: true,
+          onDiscard,
+          onSave,
+        })}
         place={resolvedSelectedState}
         tokenCount={0}
       />,
@@ -543,24 +712,44 @@ describe("StateNodeDetailCard editable work state configuration", () => {
     expect(fieldGroup?.className).not.toMatch(/sm:grid-cols-\d/);
     expect(fieldGroup?.className).not.toMatch(/md:grid-cols-\d/);
 
-    const saveButtons = screen.getAllByRole("button", {
+    const headerActions = workStateDetailHeaderActionSection();
+    const saveButtons = within(headerActions).getAllByRole("button", {
       name: messages.editableConfigurationSaveAction,
     });
-    expect(saveButtons).toHaveLength(2);
+    const discardButtons = within(headerActions).getAllByRole("button", {
+      name: messages.discardDraftAction,
+    });
+    expect(saveButtons).toHaveLength(1);
+    expect(discardButtons).toHaveLength(1);
 
-    fireEvent.click(saveButtons[1] ?? saveButtons[0]);
-    expect(onSaveConfiguration).toHaveBeenCalledTimes(1);
+    fireEvent.click(saveButtons[0]);
+    expect(onSave).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(discardButtons[0]);
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+
     expect(
-      screen.getByRole("button", { name: messages.discardDraftAction }),
-    ).toBeTruthy();
+      within(editableWorkStateConfigurationForm()).queryByRole("button", {
+        name: messages.editableConfigurationSaveAction,
+      }),
+    ).toBeNull();
+    expect(
+      within(editableWorkStateConfigurationForm()).queryByRole("button", {
+        name: messages.discardDraftAction,
+      }),
+    ).toBeNull();
   });
 
   it("keeps runtime work list content when editable configuration is ready", () => {
     const snapshot = semanticWorkflowDashboardSnapshot;
-    const selectedState = snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
-      (place) => place.place_id === "story:implemented",
+    const selectedState =
+      snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
+        (place) => place.place_id === "story:implemented",
+      );
+    const resolvedSelectedState = requireValue(
+      selectedState,
+      "expected implemented state fixture",
     );
-    const resolvedSelectedState = requireValue(selectedState, "expected implemented state fixture");
 
     render(
       <StateNodeDetailCard

--- a/ui/src/features/current-selection/work-state-selection/components/state-node-detail.tsx
+++ b/ui/src/features/current-selection/work-state-selection/components/state-node-detail.tsx
@@ -37,7 +37,6 @@ export function StateNodeDetailCard({
   failedWorkDetailsByWorkID,
   headerAction,
   locale,
-  onSaveConfiguration,
   onSelectWorkItem,
   place,
   saveState,
@@ -70,7 +69,6 @@ export function StateNodeDetailCard({
       {editableConfigurationState ? (
         <WorkStateEditableConfigurationSection
           messages={workStateMessages}
-          onSaveConfiguration={onSaveConfiguration}
           saveState={saveState}
           state={editableConfigurationState}
         />

--- a/ui/src/features/current-selection/work-state-selection/components/work-state-editable-configuration-section.tsx
+++ b/ui/src/features/current-selection/work-state-selection/components/work-state-editable-configuration-section.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 
-import { DashboardActionButton } from "../../../../components/ui";
 import {
   DASHBOARD_BODY_TEXT_CLASS,
   DASHBOARD_SUPPORTING_LABEL_CLASS,
@@ -16,7 +15,6 @@ import {
   CURRENT_SELECTION_VERTICAL_FORM_FIELDS_CLASS,
   CurrentSelectionSectionHeader,
 } from "../../base/components/detail-card-shared";
-import { EditableConfigurationSaveRow } from "../../base/components/editable-configuration-save-row";
 import type {
   EditableWorkStateConfigurationState,
   EditableWorkStateSaveState,
@@ -27,12 +25,10 @@ import type { getWorkStateDetailMessages } from "../messages/work-state-detail";
 
 export function WorkStateEditableConfigurationSection({
   messages,
-  onSaveConfiguration,
   saveState,
   state,
 }: {
   messages: ReturnType<typeof getWorkStateDetailMessages>;
-  onSaveConfiguration?: () => void;
   saveState?: EditableWorkStateSaveState;
   state?: EditableWorkStateConfigurationState;
 }) {
@@ -66,7 +62,6 @@ export function WorkStateEditableConfigurationSection({
         {state?.status === "ready" ? (
           <WorkStateEditableConfigurationReadyForm
             messages={messages}
-            onSaveConfiguration={onSaveConfiguration}
             saveState={saveState}
             state={state}
           />
@@ -78,12 +73,10 @@ export function WorkStateEditableConfigurationSection({
 
 function WorkStateEditableConfigurationReadyForm({
   messages,
-  onSaveConfiguration,
   saveState,
   state,
 }: {
   messages: ReturnType<typeof getWorkStateDetailMessages>;
-  onSaveConfiguration?: () => void;
   saveState?: EditableWorkStateSaveState;
   state: Extract<EditableWorkStateConfigurationState, { status: "ready" }>;
 }) {
@@ -91,7 +84,6 @@ function WorkStateEditableConfigurationReadyForm({
     EditableWorkStateValidationErrors & Record<string, string | undefined>,
     EditableWorkStateSaveValidationErrors
   >(state.validationErrors, saveState);
-  const isSaving = saveState?.status === "submitting";
   const displayStateName = state.draft.name.trim() || state.originalStateName;
 
   return (
@@ -145,26 +137,6 @@ function WorkStateEditableConfigurationReadyForm({
           label={messages.typeFieldLabel}
         />
       </div>
-      {onSaveConfiguration ? (
-        <EditableConfigurationSaveRow
-          busyLabel={messages.editableConfigurationSaveBusyAction}
-          canSave={state.canSave}
-          isSaving={isSaving}
-          onSave={onSaveConfiguration}
-          resetSlot={
-            state.isDirty ? (
-              <DashboardActionButton
-                disabled={isSaving}
-                onClick={state.onResetToLatest}
-                type="button"
-              >
-                {messages.discardDraftAction}
-              </DashboardActionButton>
-            ) : undefined
-          }
-          saveLabel={messages.editableConfigurationSaveAction}
-        />
-      ) : null}
     </form>
   );
 }

--- a/ui/src/features/current-selection/work-state-selection/components/work-state-save-controls.test.tsx
+++ b/ui/src/features/current-selection/work-state-selection/components/work-state-save-controls.test.tsx
@@ -1,6 +1,40 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
-import { EditableWorkStateSaveHeaderAction } from "./work-state-save-controls";
+import {
+  EditableWorkStateConfigurationHeaderActions,
+  EditableWorkStateSaveHeaderAction,
+} from "./work-state-save-controls";
+
+describe("EditableWorkStateConfigurationHeaderActions", () => {
+  it("renders discard before save and wires both actions", () => {
+    const onDiscard = vi.fn();
+    const onSave = vi.fn();
+
+    render(
+      <EditableWorkStateConfigurationHeaderActions
+        canDiscard
+        canSave
+        onDiscard={onDiscard}
+        onSave={onSave}
+        saveState={{ status: "idle" }}
+      />,
+    );
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons.map((button) => button.getAttribute("aria-label"))).toEqual([
+      "Discard local changes",
+      "Save work state",
+    ]);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Discard local changes" }),
+    );
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save work state" }));
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe("EditableWorkStateSaveHeaderAction", () => {
   it("uses warning styling when save is available and not submitting", () => {

--- a/ui/src/features/current-selection/work-state-selection/components/work-state-save-controls.tsx
+++ b/ui/src/features/current-selection/work-state-selection/components/work-state-save-controls.tsx
@@ -2,8 +2,44 @@ import { Save } from "lucide-react";
 
 import { DashboardActionButton } from "../../../../components/ui";
 import { cn } from "../../../../lib/cn";
+import { EditableConfigurationDiscardHeaderAction } from "../../base/public";
 import type { EditableWorkStateSaveState } from "../lib/detail-card-types";
 import { getWorkStateDetailMessages } from "../messages/work-state-detail";
+
+export function EditableWorkStateConfigurationHeaderActions({
+  canDiscard,
+  canSave,
+  locale,
+  onDiscard,
+  onSave,
+  saveState,
+}: {
+  canDiscard: boolean;
+  canSave: boolean;
+  locale?: string;
+  onDiscard: () => void;
+  onSave: () => void;
+  saveState: EditableWorkStateSaveState;
+}) {
+  const isSaving = saveState.status === "submitting";
+
+  return (
+    <>
+      <EditableConfigurationDiscardHeaderAction
+        canDiscard={canDiscard}
+        isSaving={isSaving}
+        locale={locale}
+        onClick={onDiscard}
+      />
+      <EditableWorkStateSaveHeaderAction
+        canSave={canSave}
+        locale={locale}
+        onClick={onSave}
+        saveState={saveState}
+      />
+    </>
+  );
+}
 
 export function EditableWorkStateSaveHeaderAction({
   canSave,

--- a/ui/src/features/current-selection/work-state-selection/public/index.test.ts
+++ b/ui/src/features/current-selection/work-state-selection/public/index.test.ts
@@ -4,9 +4,12 @@ import * as workStateSelectionPublic from "./index";
 
 describe("work-state-selection/public", () => {
   it("exports state node detail card, editable state types, and message helpers", () => {
-    expect(workStateSelectionPublic.EditableWorkStateSaveHeaderAction).toBeTypeOf(
-      "function",
-    );
+    expect(
+      workStateSelectionPublic.EditableWorkStateConfigurationHeaderActions,
+    ).toBeTypeOf("function");
+    expect(
+      workStateSelectionPublic.EditableWorkStateSaveHeaderAction,
+    ).toBeTypeOf("function");
     expect(workStateSelectionPublic.StateNodeDetailCard).toBeTypeOf("function");
     expect(workStateSelectionPublic.getWorkStateDetailMessages).toBeTypeOf(
       "function",

--- a/ui/src/features/current-selection/work-state-selection/public/index.ts
+++ b/ui/src/features/current-selection/work-state-selection/public/index.ts
@@ -1,5 +1,8 @@
-export { EditableWorkStateSaveHeaderAction } from "../components/work-state-save-controls";
 export { StateNodeDetailCard } from "../components/state-node-detail";
+export {
+  EditableWorkStateConfigurationHeaderActions,
+  EditableWorkStateSaveHeaderAction,
+} from "../components/work-state-save-controls";
 
 export type {
   EditableWorkStateConfigurationState,
@@ -8,7 +11,5 @@ export type {
   StatePositionWorkListItemProps,
   StatePositionWorkListProps,
 } from "../lib/detail-card-types";
-export {
-  getWorkStateDetailMessages,
-} from "../messages/work-state-detail";
+export { getWorkStateDetailMessages } from "../messages/work-state-detail";
 export type { WorkStateDetailMessages } from "../messages/work-state-detail-types";

--- a/ui/src/features/current-selection/work-type-selection/components/work-type-detail-card.test.tsx
+++ b/ui/src/features/current-selection/work-type-selection/components/work-type-detail-card.test.tsx
@@ -8,7 +8,9 @@ import type {
   EditableWorkTypeSaveState,
 } from "../lib/detail-card-types";
 import { WorkTypeDetailCard } from "./work-type-detail-card";
-import { EditableWorkTypeSaveHeaderAction } from "./work-type-save-controls";
+import {
+  EditableWorkTypeConfigurationHeaderActions,
+} from "./work-type-save-controls";
 
 vi.mock(
   "../../../current-factory-definition/hooks/useCurrentFactoryDefinition",
@@ -62,22 +64,54 @@ function buildFactoryDocument(
   };
 }
 
-function buildWorkTypeHeaderSaveAction({
+function buildWorkTypeHeaderActions({
+  canDiscard = false,
   canSave,
-  onClick = vi.fn(),
+  onDiscard = vi.fn(),
+  onSave = vi.fn(),
   saveState = { status: "idle" },
 }: {
+  canDiscard?: boolean;
   canSave: boolean;
-  onClick?: () => void;
+  onDiscard?: () => void;
+  onSave?: () => void;
   saveState?: EditableWorkTypeSaveState;
 }) {
   return (
-    <EditableWorkTypeSaveHeaderAction
+    <EditableWorkTypeConfigurationHeaderActions
+      canDiscard={canDiscard}
       canSave={canSave}
-      onClick={onClick}
+      onDiscard={onDiscard}
+      onSave={onSave}
       saveState={saveState}
     />
   );
+}
+
+function workTypeDetailHeaderActionSection() {
+  const card = screen.getByRole("article", { name: "Current selection" });
+  const undoButton = within(card).getByRole("button", {
+    name: "Undo selection",
+  });
+  const actionSection = undoButton.closest(
+    "[data-dashboard-action-row-section='actions']",
+  );
+  if (!actionSection) {
+    throw new Error("expected header action section");
+  }
+
+  return actionSection as HTMLElement;
+}
+
+function editableWorkTypeConfigurationForm() {
+  const panel = screen.getByRole("article", { name: "Current selection" });
+  const nameInput = within(panel).getByLabelText("Work type");
+  const form = nameInput.closest("form");
+  if (!form) {
+    throw new Error("expected editable work type configuration form");
+  }
+
+  return form;
 }
 
 function WorkTypeDetailCardHarness({
@@ -213,7 +247,7 @@ describe("WorkTypeDetailCard", () => {
     );
   });
 
-  it("stacks configuration fields vertically and renders a labeled footer Save", () => {
+  it("stacks configuration fields vertically and renders header save and discard only when dirty", () => {
     const editableConfigurationState: EditableWorkTypeConfigurationState = {
       baseVersion: buildFactoryDocument().version,
       canSave: true,
@@ -239,18 +273,22 @@ describe("WorkTypeDetailCard", () => {
       status: "ready",
       validationErrors: {},
     };
-    const onSaveConfiguration = vi.fn();
+    const onSave = vi.fn();
+    const onDiscard = vi.fn();
 
     const { container } = render(
       <WorkTypeDetailCard
         editableConfigurationState={editableConfigurationState}
-        headerAction={buildWorkTypeHeaderSaveAction({ canSave: true })}
-        onSaveConfiguration={onSaveConfiguration}
+        headerAction={buildWorkTypeHeaderActions({
+          canDiscard: true,
+          canSave: true,
+          onDiscard,
+          onSave,
+        })}
         workTypeName="story"
       />,
     );
 
-    const panel = screen.getByRole("article", { name: "Current selection" });
     const fieldGroup = container.querySelector(
       `.${CURRENT_SELECTION_VERTICAL_FORM_FIELDS_CLASS.replaceAll(" ", ".")}`,
     );
@@ -259,12 +297,31 @@ describe("WorkTypeDetailCard", () => {
     expect(fieldGroup?.className).not.toMatch(/md:grid-cols-\d/);
     expect(fieldGroup?.className).not.toMatch(/xl:grid-cols-\d/);
 
-    const saveButtons = within(panel).getAllByRole("button", {
+    const headerActions = workTypeDetailHeaderActionSection();
+    const saveButtons = within(headerActions).getAllByRole("button", {
       name: "Save changes",
     });
-    expect(saveButtons).toHaveLength(2);
+    const discardButtons = within(headerActions).getAllByRole("button", {
+      name: "Discard local changes",
+    });
+    expect(saveButtons).toHaveLength(1);
+    expect(discardButtons).toHaveLength(1);
 
-    fireEvent.click(saveButtons[1] ?? saveButtons[0]);
-    expect(onSaveConfiguration).toHaveBeenCalledTimes(1);
+    fireEvent.click(saveButtons[0]);
+    expect(onSave).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(discardButtons[0]);
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+
+    expect(
+      within(editableWorkTypeConfigurationForm()).queryByRole("button", {
+        name: "Save changes",
+      }),
+    ).toBeNull();
+    expect(
+      within(editableWorkTypeConfigurationForm()).queryByRole("button", {
+        name: "Discard local changes",
+      }),
+    ).toBeNull();
   });
 });

--- a/ui/src/features/current-selection/work-type-selection/components/work-type-detail-card.tsx
+++ b/ui/src/features/current-selection/work-type-selection/components/work-type-detail-card.tsx
@@ -11,7 +11,6 @@ export function WorkTypeDetailCard({
   editableConfigurationState,
   headerAction,
   locale,
-  onSaveConfiguration,
   onSelectWorkStateGraphNode,
   saveState,
   widgetId = "current-selection",
@@ -46,7 +45,6 @@ export function WorkTypeDetailCard({
       {editableConfigurationState?.status === "ready" ? (
         <WorkTypeReadySection
           messages={messages}
-          onSaveConfiguration={onSaveConfiguration}
           onSelectWorkStateGraphNode={onSelectWorkStateGraphNode}
           saveState={saveState}
           state={editableConfigurationState}

--- a/ui/src/features/current-selection/work-type-selection/components/work-type-ready-section.tsx
+++ b/ui/src/features/current-selection/work-type-selection/components/work-type-ready-section.tsx
@@ -14,7 +14,6 @@ import {
   CURRENT_SELECTION_FIELD_PANEL_CLASS,
   CURRENT_SELECTION_VERTICAL_FORM_FIELDS_CLASS,
 } from "../../base/components/detail-card-shared";
-import { EditableConfigurationSaveRow } from "../../base/components/editable-configuration-save-row";
 import type {
   EditableWorkTypeConfigurationState,
   EditableWorkTypeSaveState,
@@ -26,14 +25,12 @@ import { WorkTypeStatesList } from "./work-type-states-list";
 
 export function WorkTypeReadySection({
   messages,
-  onSaveConfiguration,
   onSelectWorkStateGraphNode,
   saveState,
   state,
   workTypeName,
 }: {
   messages: ReturnType<typeof getWorkTypeDetailMessages>;
-  onSaveConfiguration?: () => void;
   onSelectWorkStateGraphNode?: (graphNodeId: string) => void;
   saveState?: EditableWorkTypeSaveState;
   state: Extract<EditableWorkTypeConfigurationState, { status: "ready" }>;
@@ -45,7 +42,6 @@ export function WorkTypeReadySection({
   >(state.validationErrors, saveState);
   const hasDefaultHandlingBehavior =
     state.draft.handlingBehavior?.includes("DEFAULT") ?? false;
-  const isSaving = saveState?.status === "submitting";
 
   return (
     <form className="grid gap-2.5" onSubmit={(event) => event.preventDefault()}>
@@ -145,15 +141,6 @@ export function WorkTypeReadySection({
           workTypeName={workTypeName}
         />
       </div>
-      {onSaveConfiguration ? (
-        <EditableConfigurationSaveRow
-          busyLabel={messages.editableConfigurationSaveBusyAction}
-          canSave={state.canSave}
-          isSaving={isSaving}
-          onSave={onSaveConfiguration}
-          saveLabel={messages.editableConfigurationSaveAction}
-        />
-      ) : null}
     </form>
   );
 }

--- a/ui/src/features/current-selection/work-type-selection/components/work-type-save-controls.test.tsx
+++ b/ui/src/features/current-selection/work-type-selection/components/work-type-save-controls.test.tsx
@@ -1,9 +1,41 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
 
 import {
+  EditableWorkTypeConfigurationHeaderActions,
   EditableWorkTypeSaveDialog,
   EditableWorkTypeSaveHeaderAction,
 } from "./work-type-save-controls";
+
+describe("EditableWorkTypeConfigurationHeaderActions", () => {
+  it("renders discard before save and wires both actions", () => {
+    const onDiscard = vi.fn();
+    const onSave = vi.fn();
+
+    render(
+      <EditableWorkTypeConfigurationHeaderActions
+        canDiscard
+        canSave
+        onDiscard={onDiscard}
+        onSave={onSave}
+        saveState={{ status: "idle" }}
+      />,
+    );
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons.map((button) => button.getAttribute("aria-label"))).toEqual([
+      "Discard local changes",
+      "Save changes",
+    ]);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Discard local changes" }),
+    );
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe("EditableWorkTypeSaveHeaderAction", () => {
   it("uses warning styling when save is available and not submitting", () => {

--- a/ui/src/features/current-selection/work-type-selection/components/work-type-save-controls.tsx
+++ b/ui/src/features/current-selection/work-type-selection/components/work-type-save-controls.tsx
@@ -3,8 +3,44 @@ import { Save } from "lucide-react";
 import { DashboardMutationDialog } from "../../../workflow-activity/components/mutation-dialog";
 import { Button, DashboardActionButton } from "../../../../components/ui";
 import { cn } from "../../../../lib/cn";
-import { getWorkTypeDetailMessages } from "../messages/work-type-detail";
+import { EditableConfigurationDiscardHeaderAction } from "../../base/public";
 import type { EditableWorkTypeSaveState } from "../lib/detail-card-types";
+import { getWorkTypeDetailMessages } from "../messages/work-type-detail";
+
+export function EditableWorkTypeConfigurationHeaderActions({
+  canDiscard,
+  canSave,
+  locale,
+  onDiscard,
+  onSave,
+  saveState,
+}: {
+  canDiscard: boolean;
+  canSave: boolean;
+  locale?: string;
+  onDiscard: () => void;
+  onSave: () => void;
+  saveState: EditableWorkTypeSaveState;
+}) {
+  const isSaving = saveState.status === "submitting";
+
+  return (
+    <>
+      <EditableConfigurationDiscardHeaderAction
+        canDiscard={canDiscard}
+        isSaving={isSaving}
+        locale={locale}
+        onClick={onDiscard}
+      />
+      <EditableWorkTypeSaveHeaderAction
+        canSave={canSave}
+        locale={locale}
+        onClick={onSave}
+        saveState={saveState}
+      />
+    </>
+  );
+}
 
 export function EditableWorkTypeSaveHeaderAction({
   canSave,

--- a/ui/src/features/current-selection/work-type-selection/hooks/use-save-editable-work-type-configuration.ts
+++ b/ui/src/features/current-selection/work-type-selection/hooks/use-save-editable-work-type-configuration.ts
@@ -16,7 +16,7 @@ interface UseSaveEditableWorkTypeConfigurationOptions {
   scopeKey: string | null;
 }
 
-interface UseSaveEditableWorkTypeConfigurationResult {
+export interface UseSaveEditableWorkTypeConfigurationResult {
   beginSaveConfirmation: () => void;
   canSave: boolean;
   cancelSaveConfirmation: () => void;

--- a/ui/src/features/current-selection/work-type-selection/lib/detail-card-types.ts
+++ b/ui/src/features/current-selection/work-type-selection/lib/detail-card-types.ts
@@ -47,7 +47,6 @@ export interface WorkTypeDetailCardProps {
   editableConfigurationState?: EditableWorkTypeConfigurationState;
   headerAction?: ReactNode;
   locale?: string | null;
-  onSaveConfiguration?: () => void;
   onSelectWorkStateGraphNode?: (graphNodeId: string) => void;
   saveState?: EditableWorkTypeSaveState;
   widgetId?: string;

--- a/ui/src/features/current-selection/work-type-selection/public/index.test.ts
+++ b/ui/src/features/current-selection/work-type-selection/public/index.test.ts
@@ -3,6 +3,7 @@ import * as workTypeSelectionPublic from "./index";
 describe("work-type-selection/public", () => {
   it("exports the work type detail card and save controls", () => {
     expect(Object.keys(workTypeSelectionPublic).sort()).toEqual([
+      "EditableWorkTypeConfigurationHeaderActions",
       "EditableWorkTypeSaveDialog",
       "EditableWorkTypeSaveHeaderAction",
       "WorkTypeDetailCard",

--- a/ui/src/features/current-selection/work-type-selection/public/index.ts
+++ b/ui/src/features/current-selection/work-type-selection/public/index.ts
@@ -1,5 +1,6 @@
 export { WorkTypeDetailCard } from "../components/work-type-detail-card";
 export {
+  EditableWorkTypeConfigurationHeaderActions,
   EditableWorkTypeSaveDialog,
   EditableWorkTypeSaveHeaderAction,
 } from "../components/work-type-save-controls";

--- a/ui/src/features/current-selection/worker-selection/components/worker-detail-card.test.tsx
+++ b/ui/src/features/current-selection/worker-selection/components/worker-detail-card.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import type { CurrentFactoryDocument } from "../../../../api/current-factory-definition";
 import { useCurrentFactoryDocument } from "../../../current-factory-definition/hooks/useCurrentFactoryDefinition";
 import { CURRENT_SELECTION_VERTICAL_FORM_FIELDS_CLASS } from "../../base/components/detail-card-shared";
@@ -7,7 +7,7 @@ import type {
   EditableWorkerSaveState,
 } from "../lib/detail-card-types";
 import { WorkerDetailCard } from "./worker-detail-card";
-import { EditableWorkerSaveHeaderAction } from "./worker-save-controls";
+import { EditableWorkerConfigurationHeaderActions } from "./worker-save-controls";
 
 vi.mock(
   "../../../current-factory-definition/hooks/useCurrentFactoryDefinition",
@@ -53,19 +53,52 @@ function mockFactoryDocumentQuery(
   } as never);
 }
 
-function buildWorkerHeaderSaveAction({
+function workerDetailHeaderActionSection() {
+  const card = screen.getByRole("article", { name: "Current selection" });
+  const undoButton = within(card).getByRole("button", {
+    name: "Undo selection",
+  });
+  const actionSection = undoButton.closest(
+    "[data-dashboard-action-row-section='actions']",
+  );
+  if (!actionSection) {
+    throw new Error("expected header action section");
+  }
+
+  return actionSection as HTMLElement;
+}
+
+function editableConfigurationSection() {
+  const heading = screen.getByRole("heading", {
+    name: "Worker configuration",
+  });
+  const section = heading.closest("section");
+  if (!section) {
+    throw new Error("expected editable configuration section");
+  }
+
+  return section;
+}
+
+function buildWorkerHeaderActions({
+  canDiscard = false,
   canSave,
-  onClick = vi.fn(),
+  onDiscard = vi.fn(),
+  onSave = vi.fn(),
   saveState = { status: "idle" },
 }: {
+  canDiscard?: boolean;
   canSave: boolean;
-  onClick?: () => void;
+  onDiscard?: () => void;
+  onSave?: () => void;
   saveState?: EditableWorkerSaveState;
 }) {
   return (
-    <EditableWorkerSaveHeaderAction
+    <EditableWorkerConfigurationHeaderActions
+      canDiscard={canDiscard}
       canSave={canSave}
-      onClick={onClick}
+      onDiscard={onDiscard}
+      onSave={onSave}
       saveState={saveState}
     />
   );
@@ -346,8 +379,10 @@ describe("WorkerDetailCard", () => {
     render(
       <WorkerDetailCard
         editableConfigurationState={editableConfigurationState}
-        headerAction={buildWorkerHeaderSaveAction({ canSave: true })}
-        onSaveConfiguration={vi.fn()}
+        headerAction={buildWorkerHeaderActions({
+          canDiscard: true,
+          canSave: true,
+        })}
         workerName="reviewer"
       />,
     );
@@ -355,15 +390,29 @@ describe("WorkerDetailCard", () => {
     expect(screen.getByRole("alert").textContent).toContain(
       "Saving reviewer updates every workstation",
     );
-    expect(screen.getAllByRole("button", { name: "Save worker" })).toHaveLength(
-      2,
-    );
+
+    const headerActions = workerDetailHeaderActionSection();
     expect(
-      screen.getByRole("button", { name: "Discard local changes" }),
+      within(headerActions).getAllByRole("button", { name: "Save worker" }),
+    ).toHaveLength(1);
+    expect(
+      within(headerActions).getByRole("button", {
+        name: "Discard local changes",
+      }),
     ).toBeTruthy();
+    expect(
+      within(editableConfigurationSection()).queryByRole("button", {
+        name: "Save worker",
+      }),
+    ).toBeNull();
+    expect(
+      within(editableConfigurationSection()).queryByRole("button", {
+        name: "Discard local changes",
+      }),
+    ).toBeNull();
   });
 
-  it("stacks configuration fields vertically and renders a labeled footer Save", () => {
+  it("stacks configuration fields vertically and keeps save and discard in the header only", () => {
     const editableConfigurationState: EditableWorkerConfigurationState = {
       canSave: true,
       draft: {
@@ -419,13 +468,18 @@ describe("WorkerDetailCard", () => {
       status: "success",
     } as never);
 
-    const onSaveConfiguration = vi.fn();
+    const onSave = vi.fn();
+    const onDiscard = vi.fn();
 
     const { container } = render(
       <WorkerDetailCard
         editableConfigurationState={editableConfigurationState}
-        headerAction={buildWorkerHeaderSaveAction({ canSave: true })}
-        onSaveConfiguration={onSaveConfiguration}
+        headerAction={buildWorkerHeaderActions({
+          canDiscard: true,
+          canSave: true,
+          onDiscard,
+          onSave,
+        })}
         workerName="reviewer"
       />,
     );
@@ -437,15 +491,32 @@ describe("WorkerDetailCard", () => {
     expect(fieldGroup?.className).not.toMatch(/md:grid-cols-\d/);
     expect(fieldGroup?.className).not.toMatch(/xl:grid-cols-\d/);
 
-    const saveButtons = screen.getAllByRole("button", { name: "Save worker" });
-    expect(saveButtons).toHaveLength(2);
+    const headerActions = workerDetailHeaderActionSection();
+    const saveButtons = within(headerActions).getAllByRole("button", {
+      name: "Save worker",
+    });
+    const discardButtons = within(headerActions).getAllByRole("button", {
+      name: "Discard local changes",
+    });
+    expect(saveButtons).toHaveLength(1);
+    expect(discardButtons).toHaveLength(1);
 
-    fireEvent.click(saveButtons[1] ?? saveButtons[0]);
-    expect(onSaveConfiguration).toHaveBeenCalledTimes(1);
+    fireEvent.click(saveButtons[0]);
+    expect(onSave).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(discardButtons[0]);
+    expect(onDiscard).toHaveBeenCalledTimes(1);
 
     expect(
-      screen.getByRole("button", { name: "Discard local changes" }),
-    ).toBeTruthy();
+      within(editableConfigurationSection()).queryByRole("button", {
+        name: "Save worker",
+      }),
+    ).toBeNull();
+    expect(
+      within(editableConfigurationSection()).queryByRole("button", {
+        name: "Discard local changes",
+      }),
+    ).toBeNull();
   });
 
   it("shows scoped save success feedback for the selected worker", () => {
@@ -962,8 +1033,7 @@ describe("WorkerDetailCard", () => {
     render(
       <WorkerDetailCard
         editableConfigurationState={editableConfigurationState}
-        headerAction={buildWorkerHeaderSaveAction({ canSave: true })}
-        onSaveConfiguration={vi.fn()}
+        headerAction={buildWorkerHeaderActions({ canSave: true })}
         workerName="reviewer"
       />,
     );
@@ -981,10 +1051,11 @@ describe("WorkerDetailCard", () => {
     expect(
       screen.queryByText("Enter a model before saving this worker."),
     ).toBeNull();
-    const footerSave = screen.getAllByRole("button", {
-      name: "Save worker",
-    })[1];
-    expect(footerSave?.hasAttribute("disabled")).toBe(false);
+    const headerSave = within(workerDetailHeaderActionSection()).getByRole(
+      "button",
+      { name: "Save worker" },
+    );
+    expect(headerSave.hasAttribute("disabled")).toBe(false);
   });
 
   it("disables save and shows field errors while validation is unresolved", () => {
@@ -1048,8 +1119,7 @@ describe("WorkerDetailCard", () => {
     render(
       <WorkerDetailCard
         editableConfigurationState={editableConfigurationState}
-        headerAction={buildWorkerHeaderSaveAction({ canSave: false })}
-        onSaveConfiguration={vi.fn()}
+        headerAction={buildWorkerHeaderActions({ canSave: false })}
         workerName="reviewer"
       />,
     );
@@ -1065,10 +1135,15 @@ describe("WorkerDetailCard", () => {
     expect(
       screen.queryByText("Enter a model before saving this worker."),
     ).toBeNull();
-    for (const saveButton of screen.getAllByRole("button", {
-      name: "Save worker",
-    })) {
-      expect(saveButton.hasAttribute("disabled")).toBe(true);
-    }
+    expect(
+      within(workerDetailHeaderActionSection())
+        .getByRole("button", { name: "Save worker" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+    expect(
+      within(editableConfigurationSection()).queryByRole("button", {
+        name: "Save worker",
+      }),
+    ).toBeNull();
   });
 });

--- a/ui/src/features/current-selection/worker-selection/components/worker-detail-card.tsx
+++ b/ui/src/features/current-selection/worker-selection/components/worker-detail-card.tsx
@@ -12,7 +12,6 @@ export function WorkerDetailCard({
   editableConfigurationState,
   headerAction,
   locale,
-  onSaveConfiguration,
   saveState,
   widgetId = "current-selection",
   workerName,
@@ -51,7 +50,6 @@ export function WorkerDetailCard({
           />
           <WorkerEditableConfigurationSection
             messages={messages}
-            onSaveConfiguration={onSaveConfiguration}
             saveState={saveState}
             state={editableConfigurationState}
             workerName={workerName}

--- a/ui/src/features/current-selection/worker-selection/components/worker-editable-configuration-section.tsx
+++ b/ui/src/features/current-selection/worker-selection/components/worker-editable-configuration-section.tsx
@@ -1,11 +1,7 @@
 // biome-ignore lint/nursery/noExcessiveLinesPerFile: worker editable fields, validation feedback, save wiring, and shared-impact warnings stay colocated in one section.
 import { type ReactNode, useId, useState } from "react";
 
-import {
-  DashboardActionButton,
-  ExpandablePanelTrigger,
-  Select,
-} from "../../../../components/ui";
+import { ExpandablePanelTrigger, Select } from "../../../../components/ui";
 import {
   DASHBOARD_BODY_TEXT_CLASS,
   DASHBOARD_SUPPORTING_LABEL_CLASS,
@@ -30,7 +26,6 @@ import {
   CURRENT_SELECTION_WARNING_PANEL_CLASS,
   CurrentSelectionSectionHeader,
 } from "../../base/components/detail-card-shared";
-import { EditableConfigurationSaveRow } from "../../base/components/editable-configuration-save-row";
 import { formatEditableWorkerOverwriteFieldLabels } from "../editing/editable-worker-overwrite-fields";
 import type {
   EditableWorkerConfigurationState,
@@ -44,13 +39,11 @@ import type { getWorkerDetailMessages } from "../messages/worker-detail";
 
 export function WorkerEditableConfigurationSection({
   messages,
-  onSaveConfiguration,
   saveState,
   state,
   workerName,
 }: {
   messages: ReturnType<typeof getWorkerDetailMessages>;
-  onSaveConfiguration?: () => void;
   saveState?: EditableWorkerSaveState;
   state?: WorkerDetailCardProps["editableConfigurationState"];
   workerName: string;
@@ -121,7 +114,6 @@ export function WorkerEditableConfigurationSection({
           {state?.status === "ready" ? (
             <WorkerEditableConfigurationReadyForm
               messages={messages}
-              onSaveConfiguration={onSaveConfiguration}
               saveState={saveState}
               state={state}
               workerName={workerName}
@@ -135,13 +127,11 @@ export function WorkerEditableConfigurationSection({
 
 function WorkerEditableConfigurationReadyForm({
   messages,
-  onSaveConfiguration,
   saveState,
   state,
   workerName,
 }: {
   messages: ReturnType<typeof getWorkerDetailMessages>;
-  onSaveConfiguration?: () => void;
   saveState?: EditableWorkerSaveState;
   state: Extract<EditableWorkerConfigurationState, { status: "ready" }>;
   workerName: string;
@@ -150,7 +140,6 @@ function WorkerEditableConfigurationReadyForm({
     EditableWorkerValidationErrors & Record<string, string | undefined>,
     EditableWorkerSaveValidationErrors
   >(state.validationErrors, saveState);
-  const isSaving = saveState?.status === "submitting";
 
   return (
     <form className="grid gap-3" onSubmit={(event) => event.preventDefault()}>
@@ -252,26 +241,6 @@ function WorkerEditableConfigurationReadyForm({
           validationErrors={validationErrors}
         />
       </div>
-      {onSaveConfiguration ? (
-        <EditableConfigurationSaveRow
-          busyLabel={messages.editableConfigurationSaveBusyAction}
-          canSave={state.canSave}
-          isSaving={isSaving}
-          onSave={onSaveConfiguration}
-          resetSlot={
-            state.isDirty ? (
-              <DashboardActionButton
-                disabled={isSaving}
-                onClick={state.onResetToLatest}
-                type="button"
-              >
-                {messages.discardDraftAction}
-              </DashboardActionButton>
-            ) : undefined
-          }
-          saveLabel={messages.editableConfigurationSaveAction}
-        />
-      ) : null}
     </form>
   );
 }

--- a/ui/src/features/current-selection/worker-selection/components/worker-save-controls.test.tsx
+++ b/ui/src/features/current-selection/worker-selection/components/worker-save-controls.test.tsx
@@ -1,6 +1,40 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
-import { EditableWorkerSaveHeaderAction } from "./worker-save-controls";
+import {
+  EditableWorkerConfigurationHeaderActions,
+  EditableWorkerSaveHeaderAction,
+} from "./worker-save-controls";
+
+describe("EditableWorkerConfigurationHeaderActions", () => {
+  it("renders discard before save and wires both actions", () => {
+    const onDiscard = vi.fn();
+    const onSave = vi.fn();
+
+    render(
+      <EditableWorkerConfigurationHeaderActions
+        canDiscard
+        canSave
+        onDiscard={onDiscard}
+        onSave={onSave}
+        saveState={{ status: "idle" }}
+      />,
+    );
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons.map((button) => button.getAttribute("aria-label"))).toEqual([
+      "Discard local changes",
+      "Save worker",
+    ]);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Discard local changes" }),
+    );
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save worker" }));
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe("EditableWorkerSaveHeaderAction", () => {
   it("uses warning styling when save is available and not submitting", () => {

--- a/ui/src/features/current-selection/worker-selection/components/worker-save-controls.tsx
+++ b/ui/src/features/current-selection/worker-selection/components/worker-save-controls.tsx
@@ -1,8 +1,44 @@
 import { Save } from "lucide-react";
 import { DashboardActionButton } from "../../../../components/ui";
 import { cn } from "../../../../lib/cn";
-import { getWorkerDetailMessages } from "../messages/worker-detail";
+import { EditableConfigurationDiscardHeaderAction } from "../../base/public";
 import type { EditableWorkerSaveState } from "../lib/detail-card-types";
+import { getWorkerDetailMessages } from "../messages/worker-detail";
+
+export function EditableWorkerConfigurationHeaderActions({
+  canDiscard,
+  canSave,
+  locale,
+  onDiscard,
+  onSave,
+  saveState,
+}: {
+  canDiscard: boolean;
+  canSave: boolean;
+  locale?: string;
+  onDiscard: () => void;
+  onSave: () => void;
+  saveState: EditableWorkerSaveState;
+}) {
+  const isSaving = saveState.status === "submitting";
+
+  return (
+    <>
+      <EditableConfigurationDiscardHeaderAction
+        canDiscard={canDiscard}
+        isSaving={isSaving}
+        locale={locale}
+        onClick={onDiscard}
+      />
+      <EditableWorkerSaveHeaderAction
+        canSave={canSave}
+        locale={locale}
+        onClick={onSave}
+        saveState={saveState}
+      />
+    </>
+  );
+}
 
 export function EditableWorkerSaveHeaderAction({
   canSave,

--- a/ui/src/features/current-selection/worker-selection/public/index.test.ts
+++ b/ui/src/features/current-selection/worker-selection/public/index.test.ts
@@ -5,6 +5,7 @@ import * as workerSelectionPublic from "./index";
 describe("worker-selection/public", () => {
   it("keeps the public runtime surface focused on WorkerDetailCard", () => {
     expect(Object.keys(workerSelectionPublic).sort()).toEqual([
+      "EditableWorkerConfigurationHeaderActions",
       "EditableWorkerSaveHeaderAction",
       "WorkerDetailCard",
     ]);

--- a/ui/src/features/current-selection/worker-selection/public/index.ts
+++ b/ui/src/features/current-selection/worker-selection/public/index.ts
@@ -1,2 +1,5 @@
 export { WorkerDetailCard } from "../components/worker-detail-card";
-export { EditableWorkerSaveHeaderAction } from "../components/worker-save-controls";
+export {
+  EditableWorkerConfigurationHeaderActions,
+  EditableWorkerSaveHeaderAction,
+} from "../components/worker-save-controls";

--- a/ui/src/features/current-selection/workstation-selection/components/workstation-detail-card.editable-configuration.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/workstation-detail-card.editable-configuration.test.tsx
@@ -2,31 +2,52 @@ import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { semanticWorkflowDashboardSnapshot } from "../../../../components/dashboard/test-fixtures";
-import { buildDetailCardEditableFactoryDocument } from "../../base/components/detail-card-test-helpers";
 import { CURRENT_SELECTION_VERTICAL_FORM_FIELDS_CLASS } from "../../base/components/detail-card-shared";
+import { buildDetailCardEditableFactoryDocument } from "../../base/components/detail-card-test-helpers";
 import type {
   EditableWorkstationOverwriteField,
   EditableWorkstationSaveState,
 } from "../lib/detail-card-types";
 import { WorkstationDetailCard } from "./workstation-detail-card";
-import { EditableWorkstationSaveHeaderAction } from "./workstation-save-controls";
+import { EditableWorkstationConfigurationHeaderActions } from "./workstation-save-controls";
 
 const DETAIL_CARD_NOW = Date.parse("2026-04-08T12:00:04Z");
 const editableConfigurationCoverageTimeoutMs = 240_000;
 
-function buildWorkstationHeaderSaveAction({
+function currentSelectionHeaderActionSection() {
+  const card = screen.getByRole("article", { name: "Current selection" });
+  const undoButton = within(card).getByRole("button", {
+    name: "Undo selection",
+  });
+  const actionSection = undoButton.closest(
+    "[data-dashboard-action-row-section='actions']",
+  );
+  if (!actionSection) {
+    throw new Error("expected header action section");
+  }
+
+  return actionSection as HTMLElement;
+}
+
+function buildWorkstationHeaderActions({
+  canDiscard = false,
   canSave,
-  onClick = vi.fn(),
+  onDiscard = vi.fn(),
+  onSave = vi.fn(),
   saveState = { status: "idle" },
 }: {
+  canDiscard?: boolean;
   canSave: boolean;
-  onClick?: () => void;
+  onDiscard?: () => void;
+  onSave?: () => void;
   saveState?: EditableWorkstationSaveState;
 }) {
   return (
-    <EditableWorkstationSaveHeaderAction
+    <EditableWorkstationConfigurationHeaderActions
+      canDiscard={canDiscard}
       canSave={canSave}
-      onClick={onClick}
+      onDiscard={onDiscard}
+      onSave={onSave}
       saveState={saveState}
     />
   );
@@ -329,10 +350,11 @@ describe("WorkstationDetailCard editable configuration", () => {
     expect(screen.queryByLabelText("Worker")).toBeNull();
   });
 
-  it("stacks configuration fields vertically and renders a labeled footer Save", () => {
+  it("stacks configuration fields vertically and keeps save and discard in the header only", () => {
     const snapshot = semanticWorkflowDashboardSnapshot;
     const selectedNode = snapshot.topology.workstation_nodes_by_id.review;
-    const onSaveConfiguration = vi.fn();
+    const onSave = vi.fn();
+    const onDiscard = vi.fn();
 
     render(
       <WorkstationDetailCard
@@ -342,9 +364,13 @@ describe("WorkstationDetailCard editable configuration", () => {
           isDirty: true,
           pendingFactoryDefinition: buildDetailCardEditableFactoryDocument(),
         }}
-        headerAction={buildWorkstationHeaderSaveAction({ canSave: true })}
+        headerAction={buildWorkstationHeaderActions({
+          canDiscard: true,
+          canSave: true,
+          onDiscard,
+          onSave,
+        })}
         now={DETAIL_CARD_NOW}
-        onSaveConfiguration={onSaveConfiguration}
         providerSessions={[]}
         selectedNode={selectedNode}
       />,
@@ -363,15 +389,37 @@ describe("WorkstationDetailCard editable configuration", () => {
     expect(fieldGroup?.className).not.toMatch(/md:grid-cols-\d/);
     expect(fieldGroup?.className).not.toMatch(/xl:grid-cols-\d/);
 
-    const saveButtons = screen.getAllByRole("button", { name: "Save changes" });
-    expect(saveButtons).toHaveLength(2);
+    const headerActions = currentSelectionHeaderActionSection();
+    const saveButtons = within(headerActions).getAllByRole("button", {
+      name: "Save changes",
+    });
+    const discardButtons = within(headerActions).getAllByRole("button", {
+      name: "Discard local changes",
+    });
+    expect(saveButtons).toHaveLength(1);
+    expect(discardButtons).toHaveLength(1);
 
-    fireEvent.click(saveButtons[1] ?? saveButtons[0]);
-    expect(onSaveConfiguration).toHaveBeenCalledTimes(1);
+    fireEvent.click(saveButtons[0]);
+    expect(onSave).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(discardButtons[0]);
+    expect(onDiscard).toHaveBeenCalledTimes(1);
 
     expect(
-      screen.getByRole("button", { name: "Reset to latest" }),
-    ).toBeTruthy();
+      within(editableConfigurationSection()).queryByRole("button", {
+        name: "Save changes",
+      }),
+    ).toBeNull();
+    expect(
+      within(editableConfigurationSection()).queryByRole("button", {
+        name: "Discard local changes",
+      }),
+    ).toBeNull();
+    expect(
+      within(editableConfigurationSection()).queryByRole("button", {
+        name: "Reset to latest",
+      }),
+    ).toBeNull();
   });
 
   it("starts collapsed and expands with accessible disclosure behavior", () => {
@@ -520,7 +568,7 @@ describe("WorkstationDetailCard editable configuration", () => {
     expect(onPromptChange).toHaveBeenCalledWith("Updated prompt");
   });
 
-  it("marks server-changed fields and resets the draft to the latest values", () => {
+  it("marks server-changed fields and resets the draft from the header discard action", () => {
     const snapshot = semanticWorkflowDashboardSnapshot;
     const selectedNode = snapshot.topology.workstation_nodes_by_id.review;
     const onResetToLatest = vi.fn();
@@ -536,8 +584,12 @@ describe("WorkstationDetailCard editable configuration", () => {
           isDirty: true,
           onResetToLatest,
         }}
+        headerAction={buildWorkstationHeaderActions({
+          canDiscard: true,
+          canSave: false,
+          onDiscard: onResetToLatest,
+        })}
         now={DETAIL_CARD_NOW}
-        onSaveConfiguration={vi.fn()}
         providerSessions={[]}
         selectedNode={selectedNode}
       />,
@@ -556,12 +608,17 @@ describe("WorkstationDetailCard editable configuration", () => {
     ).toHaveLength(2);
 
     fireEvent.click(
-      within(editableConfigurationSection()).getByRole("button", {
-        name: "Reset to latest",
+      within(currentSelectionHeaderActionSection()).getByRole("button", {
+        name: "Discard local changes",
       }),
     );
 
     expect(onResetToLatest).toHaveBeenCalledTimes(1);
+    expect(
+      within(editableConfigurationSection()).queryByRole("button", {
+        name: "Reset to latest",
+      }),
+    ).toBeNull();
   });
 
   it("identifies shared workers and keeps worker-owned fields out of the workstation form", () => {
@@ -858,20 +915,18 @@ describe("WorkstationDetailCard editable configuration", () => {
     expect(screen.getByText("Available variables")).toBeTruthy();
     expect(screen.getByText(".WorkID")).toBeTruthy();
     expect(screen.getByText("{{ .WorkID }}")).toBeTruthy();
-    expect(
-      screen.getByText("The current work item identifier."),
-    ).toBeTruthy();
+    expect(screen.getByText("The current work item identifier.")).toBeTruthy();
     expect(screen.getByText("Unavailable access")).toBeTruthy();
     expect(screen.getByText(".Inputs[1].Payload")).toBeTruthy();
     expect(
-      screen.getByText(
-        "Only input 0 is available for this workstation.",
-      ),
+      screen.getByText("Only input 0 is available for this workstation."),
     ).toBeTruthy();
     expect(
-      within(editableConfigurationSection()).getByRole("button", {
-        name: "Close prompt variable help",
-      }).getAttribute("aria-expanded"),
+      within(editableConfigurationSection())
+        .getByRole("button", {
+          name: "Close prompt variable help",
+        })
+        .getAttribute("aria-expanded"),
     ).toBe("true");
   });
 
@@ -895,8 +950,7 @@ describe("WorkstationDetailCard editable configuration", () => {
             },
           ],
           validationErrors: {
-            prompt:
-              "See prompt diagnostics below.",
+            prompt: "See prompt diagnostics below.",
           },
         })}
         now={DETAIL_CARD_NOW}
@@ -966,8 +1020,7 @@ describe("WorkstationDetailCard editable configuration", () => {
             },
           ],
           validationErrors: {
-            prompt:
-              "See prompt diagnostics below.",
+            prompt: "See prompt diagnostics below.",
           },
         })}
         now={DETAIL_CARD_NOW}
@@ -982,9 +1035,7 @@ describe("WorkstationDetailCard editable configuration", () => {
       }),
     );
 
-    expect(
-      screen.getByText("line 1: unexpected EOF in if block"),
-    ).toBeTruthy();
+    expect(screen.getByText("line 1: unexpected EOF in if block")).toBeTruthy();
     expect(
       screen.queryByText("Template syntax: unexpected EOF in if block"),
     ).toBeNull();
@@ -1016,8 +1067,7 @@ describe("WorkstationDetailCard editable configuration", () => {
               },
             ],
             validationErrors: {
-              prompt:
-                "See prompt diagnostics below.",
+              prompt: "See prompt diagnostics below.",
             },
           })}
           now={DETAIL_CARD_NOW}
@@ -1164,7 +1214,9 @@ describe("WorkstationDetailCard editable configuration", () => {
     );
     expectHeadingBefore(resizable, promptVariableHelpToggle());
     expectHeadingBefore(resizable, diagnosticsPanel as HTMLElement);
-    expect(container.querySelector("[data-prompt-editor-resizable='true']")).toBeTruthy();
+    expect(
+      container.querySelector("[data-prompt-editor-resizable='true']"),
+    ).toBeTruthy();
   });
 
   it("links prompt editor accessibility metadata to validation and diagnostic feedback", () => {
@@ -1184,8 +1236,7 @@ describe("WorkstationDetailCard editable configuration", () => {
             },
           ],
           validationErrors: {
-            prompt:
-              "See prompt diagnostics below.",
+            prompt: "See prompt diagnostics below.",
           },
         })}
         now={DETAIL_CARD_NOW}
@@ -1243,8 +1294,7 @@ describe("WorkstationDetailCard editable configuration", () => {
             },
           ],
           validationErrors: {
-            prompt:
-              "See prompt diagnostics below.",
+            prompt: "See prompt diagnostics below.",
           },
         })}
         now={DETAIL_CARD_NOW}
@@ -1288,8 +1338,7 @@ describe("WorkstationDetailCard editable configuration", () => {
             },
           ],
           validationErrors: {
-            prompt:
-              "See prompt diagnostics below.",
+            prompt: "See prompt diagnostics below.",
           },
         })}
         now={DETAIL_CARD_NOW}
@@ -1331,8 +1380,7 @@ describe("WorkstationDetailCard editable configuration", () => {
             },
           ],
           validationErrors: {
-            prompt:
-              "See prompt diagnostics below.",
+            prompt: "See prompt diagnostics below.",
           },
         })}
         now={DETAIL_CARD_NOW}
@@ -1378,8 +1426,7 @@ describe("WorkstationDetailCard editable configuration", () => {
             },
           ],
           validationErrors: {
-            prompt:
-              "See prompt diagnostics below.",
+            prompt: "See prompt diagnostics below.",
           },
         })}
         now={DETAIL_CARD_NOW}
@@ -1427,9 +1474,11 @@ describe("WorkstationDetailCard editable configuration", () => {
     await user.keyboard("{Enter}");
 
     expect(
-      within(editableConfigurationSection()).getByRole("button", {
-        name: "Close prompt variable help",
-      }).getAttribute("aria-expanded"),
+      within(editableConfigurationSection())
+        .getByRole("button", {
+          name: "Close prompt variable help",
+        })
+        .getAttribute("aria-expanded"),
     ).toBe("true");
     expect(screen.getByText("Available variables")).toBeTruthy();
     expect(screen.getByText(".WorkID")).toBeTruthy();
@@ -1778,8 +1827,7 @@ describe("WorkstationDetailCard editable configuration", () => {
             },
           ],
           validationErrors: {
-            prompt:
-              "See prompt diagnostics below.",
+            prompt: "See prompt diagnostics below.",
           },
         })}
         now={DETAIL_CARD_NOW}

--- a/ui/src/features/current-selection/workstation-selection/components/workstation-detail-card.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/workstation-detail-card.tsx
@@ -1,10 +1,6 @@
 import { useEffect, useState } from "react";
 import type { DashboardWorkstationRequest } from "../../../../api/dashboard/types";
 import {
-  DETAIL_COPY_CLASS,
-  WIDGET_SUBTITLE_CLASS,
-} from "../../../../components/ui/widget-frame";
-import {
   DashboardActionButton,
   DashboardActionRow,
   DashboardStatusPill,
@@ -16,8 +12,11 @@ import {
   formatDurationMillis,
   formatWorkItemLabel,
 } from "../../../../components/ui/formatters";
+import {
+  DETAIL_COPY_CLASS,
+  WIDGET_SUBTITLE_CLASS,
+} from "../../../../components/ui/widget-frame";
 import { cn } from "../../../../lib/cn";
-import { getWorkstationDetailMessages } from "../messages/workstation-detail";
 import { SelectionDetailLayout } from "../../base/components/current-selection-detail-layout";
 import {
   CurrentSelectionSectionHeader,
@@ -29,6 +28,7 @@ import type {
   WorkstationActiveWorkListProps,
   WorkstationDetailCardProps,
 } from "../lib/detail-card-types";
+import { getWorkstationDetailMessages } from "../messages/workstation-detail";
 import { CollapsibleProviderSessionAttempts } from "./provider-session-attempts";
 import {
   EditableConfigurationSection,
@@ -41,7 +41,6 @@ export function WorkstationDetailCard({
   headerAction,
   locale,
   now,
-  onSaveConfiguration,
   onSelectProviderSession,
   onSelectWorkID,
   onSelectWorkstationRequest,
@@ -82,7 +81,6 @@ export function WorkstationDetailCard({
       <EditableConfigurationSection
         key={`editable-configuration:${selectedNode.node_id}`}
         messages={messages}
-        onSaveConfiguration={onSaveConfiguration}
         saveState={saveState}
         state={editableConfigurationState}
       />

--- a/ui/src/features/current-selection/workstation-selection/components/workstation-editable-configuration-section.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/workstation-editable-configuration-section.tsx
@@ -1,11 +1,7 @@
 // biome-ignore lint/nursery/noExcessiveLinesPerFile: current-selection editable workstation fields stay colocated so save feedback, overwrite hints, and responsive form structure evolve together.
 import { type ReactNode, useId, useState } from "react";
 
-import {
-  DashboardActionButton,
-  ExpandablePanelTrigger,
-  Select,
-} from "../../../../components/ui";
+import { ExpandablePanelTrigger, Select } from "../../../../components/ui";
 import {
   DASHBOARD_BODY_TEXT_CLASS,
   DASHBOARD_SUPPORTING_LABEL_CLASS,
@@ -18,13 +14,13 @@ import {
   mergeDetailCardSaveFieldErrors,
 } from "../../base/components/detail-card-factory-save-feedback";
 import {
-  CurrentSelectionSectionHeader,
   CURRENT_SELECTION_FIELD_PANEL_CLASS,
   CURRENT_SELECTION_VERTICAL_FORM_FIELDS_CLASS,
   CURRENT_SELECTION_WARNING_PANEL_CLASS,
+  CurrentSelectionSectionHeader,
   WORKSTATION_SUMMARY_ITEM_CLASS,
 } from "../../base/components/detail-card-shared";
-import { EditableConfigurationSaveRow } from "../../base/components/editable-configuration-save-row";
+import { formatEditableOverwriteFieldLabels } from "../editing/editable-workstation-overwrite-fields";
 import type {
   EditableWorkstationOverwriteField,
   EditableWorkstationSaveState,
@@ -34,24 +30,21 @@ import type {
   WorkstationSummaryItemProps,
   WorkstationSummaryProps,
 } from "../lib/detail-card-types";
-import { formatEditableOverwriteFieldLabels } from "../editing/editable-workstation-overwrite-fields";
 import type { getWorkstationDetailMessages } from "../messages/workstation-detail";
+import { EditableConfigurationPromptInput } from "./workstation-prompt-field";
 import { EditableConfigurationRunnerField } from "./workstation-runner-field";
 import {
   resolveWorkstationSummaryKindValue,
   resolveWorkstationSummaryRunnerValue,
   resolveWorkstationSummaryTypeValue,
 } from "./workstation-summary-field-values";
-import { EditableConfigurationPromptInput } from "./workstation-prompt-field";
 
 export function EditableConfigurationSection({
   messages,
-  onSaveConfiguration,
   saveState,
   state,
 }: {
   messages: ReturnType<typeof getWorkstationDetailMessages>;
-  onSaveConfiguration?: () => void;
   saveState?: EditableWorkstationSaveState;
   state?: WorkstationDetailCardProps["editableConfigurationState"];
 }) {
@@ -88,27 +81,39 @@ export function EditableConfigurationSection({
       {expanded ? (
         <div className="grid gap-2.5" id={contentId}>
           {state?.status === "loading" ? (
-            <p className={cn("m-0 text-af-text-muted", DASHBOARD_BODY_TEXT_CLASS)}>
+            <p
+              className={cn(
+                "m-0 text-af-text-muted",
+                DASHBOARD_BODY_TEXT_CLASS,
+              )}
+            >
               {messages.editableConfigurationLoading}
             </p>
           ) : null}
           {state?.status === "error" ? (
             <p
-              className={cn("m-0 text-af-danger-text", DASHBOARD_BODY_TEXT_CLASS)}
+              className={cn(
+                "m-0 text-af-danger-text",
+                DASHBOARD_BODY_TEXT_CLASS,
+              )}
               role="alert"
             >
               {messages.editableConfigurationErrorPrefix} {state.errorMessage}
             </p>
           ) : null}
           {state?.status === "empty" ? (
-            <p className={cn("m-0 text-af-text-muted", DASHBOARD_BODY_TEXT_CLASS)}>
+            <p
+              className={cn(
+                "m-0 text-af-text-muted",
+                DASHBOARD_BODY_TEXT_CLASS,
+              )}
+            >
               {state.message || messages.editableConfigurationEmpty}
             </p>
           ) : null}
           {state?.status === "ready" ? (
             <EditableConfigurationReadyForm
               messages={messages}
-              onSaveConfiguration={onSaveConfiguration}
               saveState={saveState}
               state={state}
             />
@@ -119,15 +124,12 @@ export function EditableConfigurationSection({
   );
 }
 
-// biome-ignore lint/complexity/noExcessiveLinesPerFunction: workstation ready form keeps save feedback, overwrite hints, and vertical field wiring colocated.
 function EditableConfigurationReadyForm({
   messages,
-  onSaveConfiguration,
   saveState,
   state,
 }: {
   messages: ReturnType<typeof getWorkstationDetailMessages>;
-  onSaveConfiguration?: () => void;
   saveState?: EditableWorkstationSaveState;
   state: Extract<
     NonNullable<WorkstationDetailCardProps["editableConfigurationState"]>,
@@ -138,12 +140,6 @@ function EditableConfigurationReadyForm({
     EditableWorkstationValidationErrors & Record<string, string | undefined>,
     EditableWorkstationSaveValidationErrors
   >(state.validationErrors, saveState);
-  const isSaving = saveState?.status === "submitting";
-  const canSave =
-    state.isDirty &&
-    !state.hasValidationErrors &&
-    state.pendingFactoryDefinition != null &&
-    !isSaving;
   const renderState = {
     ...state,
     validationErrors,
@@ -154,7 +150,8 @@ function EditableConfigurationReadyForm({
       <DetailCardFactorySaveFeedback<EditableWorkstationSaveValidationErrors>
         messages={{
           errorPrefix: messages.editableConfigurationSaveErrorPrefix,
-          staleVersionDetail: messages.editableConfigurationSaveStaleVersionDetail,
+          staleVersionDetail:
+            messages.editableConfigurationSaveStaleVersionDetail,
           successMessage: messages.editableConfigurationSaveSuccess,
         }}
         saveState={saveState}
@@ -244,30 +241,9 @@ function EditableConfigurationReadyForm({
           }
         />
       </div>
-      {onSaveConfiguration ? (
-        <EditableConfigurationSaveRow
-          busyLabel={messages.editableConfigurationSaveBusyAction}
-          canSave={canSave}
-          isSaving={isSaving}
-          onSave={onSaveConfiguration}
-          resetSlot={
-            state.isDirty ? (
-              <DashboardActionButton
-                disabled={isSaving}
-                onClick={state.onResetToLatest}
-                type="button"
-              >
-                {messages.editableConfigurationResetAction}
-              </DashboardActionButton>
-            ) : undefined
-          }
-          saveLabel={messages.editableConfigurationSaveAction}
-        />
-      ) : null}
     </form>
   );
 }
-
 
 function hasOnlyPromptBlockingValidationErrors(
   validationErrors: EditableWorkstationValidationErrors,
@@ -322,7 +298,12 @@ function EditableConfigurationDraftStatus({
             ? messages.editableConfigurationDirtyStatus
             : messages.editableConfigurationDraftNote}
       </p>
-      <p className={cn("m-0 text-af-text-subtle", DASHBOARD_SUPPORTING_TEXT_CLASS)}>
+      <p
+        className={cn(
+          "m-0 text-af-text-subtle",
+          DASHBOARD_SUPPORTING_TEXT_CLASS,
+        )}
+      >
         {messages.editableConfigurationDraftNote}
       </p>
     </div>
@@ -353,7 +334,12 @@ function EditableConfigurationOverwriteWarning({
       >
         {messages.editableConfigurationOverwriteWarning(formattedFields)}
       </p>
-      <p className={cn("m-0 text-af-text-subtle", DASHBOARD_SUPPORTING_TEXT_CLASS)}>
+      <p
+        className={cn(
+          "m-0 text-af-text-subtle",
+          DASHBOARD_SUPPORTING_TEXT_CLASS,
+        )}
+      >
         {messages.editableConfigurationOverwriteWarningDetail}
       </p>
     </div>
@@ -433,7 +419,9 @@ function EditableConfigurationBehaviorInput({
       className={DASHBOARD_BODY_TEXT_CLASS}
       id="editable-workstation-kind"
       onChange={(event) =>
-        state.onBehaviorChange(event.target.value as typeof state.draft.behavior)
+        state.onBehaviorChange(
+          event.target.value as typeof state.draft.behavior,
+        )
       }
       value={state.draft.behavior}
     >
@@ -462,7 +450,9 @@ function EditableConfigurationSharedWorkerHint({
   }
 
   return (
-    <p className={cn("m-0 text-af-text-subtle", DASHBOARD_SUPPORTING_TEXT_CLASS)}>
+    <p
+      className={cn("m-0 text-af-text-subtle", DASHBOARD_SUPPORTING_TEXT_CLASS)}
+    >
       {messages.editableConfigurationSharedWorkerScopeHint(
         valueOrFallback(state.draft.workerName, messages.notConfiguredValue),
         formatList(sharedWorkstationNames),
@@ -480,8 +470,7 @@ function resolveSharedWorkerWorkstationNames(
   return (
     state.initialValues.sharedWorkerWorkstationNamesByWorkerName[
       state.draft.workerName
-    ] ??
-    []
+    ] ?? []
   );
 }
 
@@ -524,7 +513,10 @@ export function WorkstationSummary({
   const sectionId = `workstation-summary-${selectedNode.node_id}`;
 
   return (
-    <section aria-labelledby={sectionId} className="mt-4 grid gap-2.5 [&_h4]:m-0">
+    <section
+      aria-labelledby={sectionId}
+      className="mt-4 grid gap-2.5 [&_h4]:m-0"
+    >
       <CurrentSelectionSectionHeader
         headingId={sectionId}
         title={messages.summaryHeading}

--- a/ui/src/features/current-selection/workstation-selection/components/workstation-save-controls.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/workstation-save-controls.test.tsx
@@ -1,9 +1,41 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
 
 import {
+  EditableWorkstationConfigurationHeaderActions,
   EditableWorkstationSaveDialog,
   EditableWorkstationSaveHeaderAction,
 } from "./workstation-save-controls";
+
+describe("EditableWorkstationConfigurationHeaderActions", () => {
+  it("renders discard before save and wires both actions", () => {
+    const onDiscard = vi.fn();
+    const onSave = vi.fn();
+
+    render(
+      <EditableWorkstationConfigurationHeaderActions
+        canDiscard
+        canSave
+        onDiscard={onDiscard}
+        onSave={onSave}
+        saveState={{ status: "idle" }}
+      />,
+    );
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons.map((button) => button.getAttribute("aria-label"))).toEqual([
+      "Discard local changes",
+      "Save changes",
+    ]);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Discard local changes" }),
+    );
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe("EditableWorkstationSaveHeaderAction", () => {
   it("uses warning styling when save is available and not submitting", () => {
@@ -28,9 +60,9 @@ describe("EditableWorkstationSaveHeaderAction", () => {
       />,
     );
 
-    expect(screen.getByRole("button", { name: "Save changes" }).className).not.toContain(
-      "border-af-warning-border",
-    );
+    expect(
+      screen.getByRole("button", { name: "Save changes" }).className,
+    ).not.toContain("border-af-warning-border");
   });
 
   it("does not use warning styling while save is submitting", () => {

--- a/ui/src/features/current-selection/workstation-selection/components/workstation-save-controls.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/workstation-save-controls.tsx
@@ -1,13 +1,49 @@
 import { Save } from "lucide-react";
-import { DashboardMutationDialog } from "../../../workflow-activity/components/mutation-dialog";
 import { Button, DashboardActionButton } from "../../../../components/ui";
 import { cn } from "../../../../lib/cn";
+import { DashboardMutationDialog } from "../../../workflow-activity/components/mutation-dialog";
+import { EditableConfigurationDiscardHeaderAction } from "../../base/public";
 import { formatEditableOverwriteFieldLabels } from "../editing/editable-workstation-overwrite-fields";
-import { getWorkstationDetailMessages } from "../messages/workstation-detail";
 import type {
   EditableWorkstationOverwriteField,
   EditableWorkstationSaveState,
 } from "../lib/detail-card-types";
+import { getWorkstationDetailMessages } from "../messages/workstation-detail";
+
+export function EditableWorkstationConfigurationHeaderActions({
+  canDiscard,
+  canSave,
+  locale,
+  onDiscard,
+  onSave,
+  saveState,
+}: {
+  canDiscard: boolean;
+  canSave: boolean;
+  locale?: string;
+  onDiscard: () => void;
+  onSave: () => void;
+  saveState: EditableWorkstationSaveState;
+}) {
+  const isSaving = saveState.status === "submitting";
+
+  return (
+    <>
+      <EditableConfigurationDiscardHeaderAction
+        canDiscard={canDiscard}
+        isSaving={isSaving}
+        locale={locale}
+        onClick={onDiscard}
+      />
+      <EditableWorkstationSaveHeaderAction
+        canSave={canSave}
+        locale={locale}
+        onClick={onSave}
+        saveState={saveState}
+      />
+    </>
+  );
+}
 
 export function EditableWorkstationSaveHeaderAction({
   canSave,

--- a/ui/src/features/current-selection/workstation-selection/public/index.test.ts
+++ b/ui/src/features/current-selection/workstation-selection/public/index.test.ts
@@ -13,6 +13,9 @@ describe("workstation-selection/public", () => {
     expect(
       workstationSelectionPublic.EditableWorkstationSaveHeaderAction,
     ).toBeTypeOf("function");
+    expect(
+      workstationSelectionPublic.EditableWorkstationConfigurationHeaderActions,
+    ).toBeTypeOf("function");
     expect(workstationSelectionPublic.getWorkstationDetailMessages).toBeTypeOf(
       "function",
     );

--- a/ui/src/features/current-selection/workstation-selection/public/index.ts
+++ b/ui/src/features/current-selection/workstation-selection/public/index.ts
@@ -4,6 +4,7 @@ export {
 } from "../components/provider-session-attempts";
 export { WorkstationDetailCard } from "../components/workstation-detail-card";
 export {
+  EditableWorkstationConfigurationHeaderActions,
   EditableWorkstationSaveDialog,
   EditableWorkstationSaveHeaderAction,
 } from "../components/workstation-save-controls";


### PR DESCRIPTION
{
  "project": "Infinite You Dashboard UI",
  "branchName": "ralph/issues3-header-save-discard-icons",
  "description": "Move primary Save and Discard actions for all editable current-selection configuration panels into the bento card header as icon buttons, and remove labeled footer save and body-level discard/reset controls from configuration forms.",
  "context": {
    "customerAsk": "Discard (and save where missing) should live in the bento header as icon buttons for every editable current-selection type, consistent with panels that already header-mount save. Configuration body no longer hosts primary save/discard actions.",
    "problem": "Discard and labeled footer Save still appear inside Configuration forms for workers, workstations, work states, work types, and resources, while header save icons already exist—creating duplicate Save affordances and forcing operators to scroll the form to discard local edits.",
    "solution": "Add a shared header discard icon pattern, wire save and discard together in each selection kind's bento header action slot, connect discard to existing onResetToLatest handlers, remove EditableConfigurationSaveRow and body discard rows from configuration forms, and update Vitest and browser verification so header actions are the only primary save/discard entry points."
  },
  "acceptanceCriteria": [
    "Editable workstation, worker, work type, work state, and resource selections show Save and Discard local changes as icon-only controls in the bento header when configuration is dirty and editable",
    "Configuration form bodies do not render EditableConfigurationSaveRow, labeled footer Save, or body-level Discard/Reset buttons",
    "Header Discard invokes each kind's existing onResetToLatest behavior; header Save keeps existing save, validation, disabled, busy, and confirmation flows",
    "Vitest on affected detail cards and CurrentSelectionWidget asserts single header save/discard and no duplicate body controls after dirty edits",
    "Typecheck passes",
    "Lint passes",
    "Affected UI tests pass"
  ],
  "userStories": [
    {
      "id": "issues3-header-save-discard-icons-001",
      "title": "Shared header discard icon for editable configuration",
      "description": "As a maintainer, I want a reusable discard header action so every selection kind uses the same icon-only control, disabled rules, and localized accessible name.",
      "acceptanceCriteria": [
        "Shared current-selection component renders icon-only discard using DashboardActionButton with localized aria-label defaulting to Discard local changes",
        "Discard button is disabled when canDiscard is false or isSaving is true",
        "Component is exported for use by workstation, worker, work type, work state, and resource selection modules",
        "Colocated unit test covers disabled vs enabled states and onClick wiring",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues3-header-save-discard-icons-002",
      "title": "Workstation configuration uses header save and discard only",
      "description": "As an operator editing a workstation, I want Save and Discard in the bento header so I can commit or revert without scrolling the Configuration form.",
      "acceptanceCriteria": [
        "Workstation bento header shows save and discard icon buttons when configuration is editable; discard accessible name is Discard local changes",
        "Workstation configuration form removes EditableConfigurationSaveRow and body reset/save buttons",
        "Discard calls onResetToLatest; save still uses existing confirm dialog and persistence flow",
        "Workstation editable-configuration tests find exactly one save and one discard by aria-label after dirty edits, both in the header region",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser: select a workstation, dirty a field, confirm header save/discard only in Configuration"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues3-header-save-discard-icons-003",
      "title": "Worker configuration uses header save and discard only",
      "description": "As an operator editing a worker, I want Save and Discard in the bento header only, eliminating duplicate footer Save.",
      "acceptanceCriteria": [
        "Worker header action group includes discard icon wired to onResetToLatest when dirty",
        "Worker configuration form removes EditableConfigurationSaveRow and body discard button",
        "After dirty edits, tests find a single Save worker and a single Discard local changes control, not duplicate footer save",
        "Save disabled, busy, and validation behavior unchanged",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser: select a worker, dirty configuration, confirm header icons only"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues3-header-save-discard-icons-004",
      "title": "Resource configuration uses header save and discard only",
      "description": "As an operator editing a resource, I want Save and Discard in the bento header instead of a body-only discard row.",
      "acceptanceCriteria": [
        "Resource header action group includes discard icon wired to onResetToLatest when dirty",
        "Resource configuration form removes body DashboardActionRow discard/reset control",
        "Resource detail tests assert header save and discard after dirty edits and no body discard button",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser: select a resource, dirty a field, confirm header save/discard only"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues3-header-save-discard-icons-005",
      "title": "Work type configuration uses header save and discard only",
      "description": "As an operator editing a work type, I want Discard in the header alongside Save so I can revert local edits without a body action row.",
      "acceptanceCriteria": [
        "Work type header action group includes discard icon wired to onResetToLatest when dirty",
        "Work type configuration form removes EditableConfigurationSaveRow footer save",
        "Work type detail tests assert header save and discard and no footer save after dirty edits",
        "Work type save confirmation dialog flow unchanged",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser: select a work type, dirty fields, confirm header icons only"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues3-header-save-discard-icons-006",
      "title": "Work state configuration uses header save and discard only",
      "description": "As an operator renaming or editing a work state, I want Save and Discard in the bento header only.",
      "acceptanceCriteria": [
        "Work state header action group includes discard icon wired to onResetToLatest when dirty",
        "Work state configuration form removes EditableConfigurationSaveRow and body discard",
        "State node detail and CurrentSelectionWidget work-state save tests target header save only with no duplicate footer save",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser: select a work state, dirty the name, confirm header icons only"
      ],
      "priority": 6,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues3-header-save-discard-icons-007",
      "title": "Current-selection widget integration and regression guard",
      "description": "As a maintainer, I want widget-level wiring to mount paired header save and discard for all editable selection kinds consistently.",
      "acceptanceCriteria": [
        "useCurrentSelectionDetailSave and CurrentSelectionWidget pass combined save and discard header actions for workstation, worker, resource, work type, and work state",
        "Integration or widget test covers at least two selection kinds and asserts configuration body has no EditableConfigurationSaveRow save label after expand and dirty",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 7,
      "passes": true,
      "notes": ""
    }
  ]
}
