### PR TITLE
issues3-current-selection-save-notifications

### DIFF
--- a/ui/.storybook/dashboard-story-runtime.tsx
+++ b/ui/.storybook/dashboard-story-runtime.tsx
@@ -9,8 +9,9 @@ import type {
 import type { FactoryEvent } from "../src/api/events";
 import { resetSelectionHistoryStore } from "../src/features/current-selection/base/public";
 import { resetDashboardSessionStore } from "../src/features/dashboard/state/dashboardSessionStore";
-import { useFactoryTimelineStore } from "../src/features/timeline/state/factoryTimelineStore";
+import { AppNotificationToaster } from "../src/features/notifications/public";
 import type { WorldState } from "../src/features/timeline/state/factoryTimelineStore";
+import { useFactoryTimelineStore } from "../src/features/timeline/state/factoryTimelineStore";
 import { DashboardSessionTestProvider } from "../src/testing/dashboard-session-test-provider";
 
 const DASHBOARD_STORYBOOK_BASE_PATH = "/dashboard/ui/";
@@ -340,6 +341,7 @@ function StorybookDashboardRuntime({ children }: { children: ReactNode }) {
   return (
     <QueryClientProvider client={createQueryClient()}>
       {children}
+      <AppNotificationToaster />
     </QueryClientProvider>
   );
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -26,6 +26,7 @@
     "storybook": "storybook dev -p 6007",
     "storybook:choose-file-check": "node scripts/run-choose-file-browser-check.mjs",
     "storybook:prompt-syntax-save-check": "node scripts/run-prompt-syntax-save-browser-check.mjs",
+    "storybook:current-selection-save-notifications-check": "node scripts/run-current-selection-save-notifications-browser-check.mjs",
     "storybook:responsive-check": "node scripts/run-storybook-responsive-check.mjs",
     "storybook:serve-static": "http-server storybook-static -p 6008 -a 127.0.0.1 -s",
     "storybook:wait-for-index": "wait-on --timeout 30000 http://127.0.0.1:6008/index.json",

--- a/ui/scripts/run-current-selection-save-notifications-browser-check.mjs
+++ b/ui/scripts/run-current-selection-save-notifications-browser-check.mjs
@@ -1,0 +1,39 @@
+import { chromium } from "playwright";
+import { verifyCurrentSelectionSaveFlow } from "./verify-current-selection-storybook-responsive.mjs";
+import {
+  expectNoHorizontalOverflow,
+  expectVisible,
+  storyUrl,
+  waitForStoryRender,
+} from "./storybook-responsive-helpers.mjs";
+import { ensureStorybookServer } from "./run-storybook-responsive-check.mjs";
+
+const host = process.env.AGENT_FACTORY_STORYBOOK_HOST ?? "127.0.0.1";
+const port = process.env.AGENT_FACTORY_STORYBOOK_PORT ?? "6008";
+const storybookUrl = `http://${host}:${port}`;
+const storyId =
+  "you-agent-factory-dashboard-bento-cards--current-selection-save-notifications";
+
+const server = await ensureStorybookServer({ host, port: Number(port) });
+
+try {
+  const browser = await chromium.launch();
+  const page = await browser.newPage({
+    viewport: { height: 900, label: "desktop", width: 1440 },
+  });
+  await page.goto(storyUrl(storybookUrl, storyId), {
+    timeout: 90_000,
+    waitUntil: "networkidle",
+  });
+  await waitForStoryRender(page);
+  await verifyCurrentSelectionSaveFlow({
+    expectNoHorizontalOverflow,
+    expectVisible,
+    page,
+    viewport: { height: 900, label: "desktop", width: 1440 },
+  });
+  console.log("Current selection save notification browser verification passed.");
+  await browser.close();
+} finally {
+  await server.stop();
+}

--- a/ui/scripts/verify-current-selection-storybook-responsive.mjs
+++ b/ui/scripts/verify-current-selection-storybook-responsive.mjs
@@ -249,6 +249,46 @@ export async function verifyCurrentSelectionWorkstationDetailOrder({
   );
 }
 
+const INLINE_SAVE_SUCCESS_PATTERN = /^Running factory saved\./;
+const INLINE_SAVE_FAILURE_PREFIX = /^Saving failed\./;
+
+export async function expectCurrentSelectionSaveSuccessToast(
+  page,
+  expectVisible,
+  { description, title },
+) {
+  const toast = page.locator("[data-sonner-toast]").filter({ hasText: title });
+  await expectVisible(toast, `Save success toast: ${title}`);
+  if (description) {
+    await expectVisible(
+      toast.filter({ hasText: description }),
+      `Save success toast description for ${title}`,
+    );
+  }
+}
+
+export async function expectNoInlineSaveOutcomesInConfiguration(
+  configurationScope,
+) {
+  const inlineSuccessCount = await configurationScope
+    .getByText(INLINE_SAVE_SUCCESS_PATTERN)
+    .count();
+  if (inlineSuccessCount > 0) {
+    throw new Error(
+      "Configuration body should not render inline save success copy.",
+    );
+  }
+
+  const inlineFailureCount = await configurationScope
+    .getByText(INLINE_SAVE_FAILURE_PREFIX)
+    .count();
+  if (inlineFailureCount > 0) {
+    throw new Error(
+      "Configuration body should not render inline save failure copy.",
+    );
+  }
+}
+
 export async function verifyCurrentSelectionSaveFlow({
   expectNoHorizontalOverflow,
   expectVisible,
@@ -291,12 +331,12 @@ export async function verifyCurrentSelectionSaveFlow({
   });
   await overwriteButton.click();
 
-  await expectVisible(
-    currentSelection.getByText(
-      "Running factory saved. The editable workstation values were refreshed to the saved definition.",
-    ),
-    "Editable workstation save success message",
-  );
+  await expectCurrentSelectionSaveSuccessToast(page, expectVisible, {
+    description:
+      "The editable workstation values were refreshed to the saved definition.",
+    title: "Workstation saved",
+  });
+  await expectNoInlineSaveOutcomesInConfiguration(currentSelection);
   const overwriteDialogCount = await page
     .getByRole("dialog", {
       name: "Overwrite the running factory definition?",

--- a/ui/scripts/verify-current-selection-storybook-responsive.test.mjs
+++ b/ui/scripts/verify-current-selection-storybook-responsive.test.mjs
@@ -47,7 +47,10 @@ function createSaveFlowHarness() {
       .mockResolvedValueOnce(true),
   });
   saveButton.click = vi.fn().mockResolvedValue(undefined);
-  const successMessage = createVisibleLocator("Save success message");
+  const successToast = createVisibleLocator("Save success toast");
+  successToast.filter = vi.fn(function filter() {
+    return this;
+  });
   const confirmationDialog = createVisibleLocator("Confirmation dialog", {
     count: vi.fn().mockResolvedValue(0),
   });
@@ -79,11 +82,10 @@ function createSaveFlowHarness() {
       return createVisibleLocator(`${role}:${options?.name}`);
     }),
     getByText: vi.fn((text) => {
-      if (
-        text ===
-        "Running factory saved. The editable workstation values were refreshed to the saved definition."
-      ) {
-        return successMessage;
+      if (text instanceof RegExp) {
+        return createVisibleLocator(`text:${text}`, {
+          count: vi.fn().mockResolvedValue(0),
+        });
       }
       if (text === "Validating prompt variables for the current draft.") {
         return createVisibleLocator("Prompt validation status", {
@@ -97,6 +99,12 @@ function createSaveFlowHarness() {
   };
   const page = {
     evaluate: vi.fn().mockResolvedValue({ clientWidth: 390, scrollWidth: 390 }),
+    locator: vi.fn((selector) => {
+      if (selector === "[data-sonner-toast]") {
+        return successToast;
+      }
+      return createVisibleLocator(selector);
+    }),
     getByRole: vi.fn((role, options) => {
       if (role === "article" && options?.name === "Current selection") {
         return currentSelection;
@@ -123,7 +131,7 @@ function createSaveFlowHarness() {
     page,
     promptField,
     saveButton,
-    successMessage,
+    successToast,
     workerField,
   };
 }
@@ -339,7 +347,7 @@ describe("verifyCurrentSelectionSaveFlow", () => {
       page,
       promptField,
       saveButton,
-      successMessage,
+      successToast,
       workerField,
     } = createSaveFlowHarness();
     const expectVisible = vi.fn((_locator) => Promise.resolve());
@@ -361,9 +369,13 @@ describe("verifyCurrentSelectionSaveFlow", () => {
     );
     expect(saveButton.click).toHaveBeenCalled();
     expect(overwriteButton.click).toHaveBeenCalled();
+    expect(page.locator).toHaveBeenCalledWith("[data-sonner-toast]");
+    expect(successToast.filter).toHaveBeenCalledWith({
+      hasText: "Workstation saved",
+    });
     expect(expectVisible).toHaveBeenCalledWith(
-      successMessage,
-      "Editable workstation save success message",
+      successToast,
+      "Save success toast: Workstation saved",
     );
     expect(confirmationDialog.count).toHaveBeenCalled();
     expect(saveButton.isDisabled).toHaveBeenCalled();

--- a/ui/src/features/bento/components/dashboard-bento-current-selection-catalog.stories.tsx
+++ b/ui/src/features/bento/components/dashboard-bento-current-selection-catalog.stories.tsx
@@ -4,6 +4,7 @@ import "../../../styles.css";
 import { expectNoPageHorizontalOverflow } from "../../../stories/dashboardStorySupport";
 import {
   buildEditableConfigurationDocument,
+  buildEditableConfigurationSaveFetchMocks,
   buildEditableResourceConfigurationDocument,
   CurrentSelectionCardStory,
   CurrentSelectionEditableConfigurationStory,
@@ -14,6 +15,7 @@ import {
   expectBentoHeaderDragSurface,
   expectCurrentSelectionRunHistoryExpandFlow,
   expectEditableConfigurationPromptSyntaxSaveStoryFlow,
+  expectEditableConfigurationSaveNotificationStoryFlow,
   expectEditableConfigurationStoryFlow,
   expectResourceSelectedStoryFlow,
   promptTemplateSyntaxValidationResponse,
@@ -123,6 +125,20 @@ export const CurrentSelectionResourceSelected = {
   render: () => <CurrentSelectionResourceSelectedStory width={960} />,
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     await expectResourceSelectedStoryFlow(canvasElement);
+  },
+};
+
+export const CurrentSelectionSaveNotifications = {
+  parameters: {
+    dashboardApi: {
+      fetchMocks: buildEditableConfigurationSaveFetchMocks(),
+      snapshot: semanticWorkflowDashboardSnapshot,
+    },
+  },
+  render: () => <CurrentSelectionEditableConfigurationStory width={960} />,
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    await expectEditableConfigurationSaveNotificationStoryFlow(canvasElement);
+    expectNoPageHorizontalOverflow(canvasElement);
   },
 };
 

--- a/ui/src/features/bento/components/dashboard-bento-story-shared.tsx
+++ b/ui/src/features/bento/components/dashboard-bento-story-shared.tsx
@@ -12,6 +12,7 @@ import {
   currentSelectionWorkContentsDashboardSnapshot,
   semanticWorkflowDashboardSnapshot,
 } from "../../../components/dashboard/test-fixtures";
+import { incrementSessionFactoryVersion } from "../../../testing/session-factory-mocks";
 
 export {
   currentSelectionWorkContentsDashboardSnapshot,
@@ -548,10 +549,7 @@ export function promptTemplateSyntaxValidationResponse(init?: RequestInit) {
   const prompt =
     typeof requestBody.prompt === "string" ? requestBody.prompt : "";
 
-  if (
-    prompt.includes("{{ if .WorkID }}") &&
-    !prompt.includes("{{ end }}")
-  ) {
+  if (prompt.includes("{{ if .WorkID }}") && !prompt.includes("{{ end }}")) {
     return {
       diagnostics: [
         {
@@ -1254,6 +1252,97 @@ export async function expectEditableConfigurationPromptSyntaxSaveStoryFlow(
       name: "Overwrite the running factory definition?",
     }),
   ).toBeVisible();
+}
+
+export function buildEditableConfigurationSaveFetchMocks() {
+  return [
+    {
+      method: "GET",
+      path: "/factory-sessions/~default/factory",
+      response: {
+        body: buildEditableConfigurationDocument(),
+      },
+    },
+    {
+      method: "GET",
+      path: "/factory-sessions/~default/factory/workstations/Review/prompt-template-contract",
+      response: {
+        body: editableConfigurationPromptTemplateContract,
+      },
+    },
+    {
+      method: "POST",
+      path: "/factory-sessions/~default/factory/workstations/Review/prompt-template-validation",
+      response: (_input: RequestInfo | URL, init?: RequestInit) => ({
+        body: promptTemplateValidationResponse(init),
+      }),
+    },
+    {
+      method: "PUT",
+      path: "/factory-sessions/~default/factory",
+      response: (_input: RequestInfo | URL, init?: RequestInit) => {
+        const payload = JSON.parse(String(init?.body ?? "{}")) as {
+          baseVersion?: { logical: string; physical: string };
+          factory?: ReturnType<typeof buildEditableConfigurationDocument>;
+        };
+        const savedFactory =
+          payload.factory ?? buildEditableConfigurationDocument();
+        const nextVersion = incrementSessionFactoryVersion(
+          payload.baseVersion ?? savedFactory.version,
+        );
+
+        return {
+          body: {
+            ...savedFactory,
+            version: nextVersion,
+          },
+        };
+      },
+    },
+  ];
+}
+
+export async function expectEditableConfigurationSaveNotificationStoryFlow(
+  canvasElement: HTMLElement,
+): Promise<void> {
+  const canvas = within(canvasElement);
+  const card = await canvas.findByRole("article", {
+    name: "Current selection",
+  });
+  const cardScope = within(card);
+  const pageScope = within(document.body);
+
+  await userEvent.click(
+    cardScope.getByRole("button", { name: "Expand editable configuration" }),
+  );
+  const promptField = await cardScope.findByRole("textbox", { name: "Prompt" });
+  await userEvent.click(promptField, { pointerEventsCheck: 0 });
+  await userEvent.keyboard("{Control>}{KeyA}{/Control}");
+  await userEvent.paste("Browser verified save notification prompt.");
+
+  await waitFor(() => {
+    expect(
+      cardScope.getByRole("button", { name: "Save changes" }),
+    ).toBeEnabled();
+  });
+
+  await userEvent.click(
+    cardScope.getByRole("button", { name: "Save changes" }),
+  );
+  await userEvent.click(
+    canvas.getByRole("button", { name: "Overwrite factory" }),
+  );
+
+  await waitFor(() => {
+    expect(pageScope.getByText("Workstation saved")).toBeVisible();
+    expect(
+      pageScope.getByText(
+        "The editable workstation values were refreshed to the saved definition.",
+      ),
+    ).toBeVisible();
+  });
+  expect(cardScope.queryByText(/^Running factory saved\./)).toBeNull();
+  expect(cardScope.queryByText(/^Saving failed\./)).toBeNull();
 }
 
 export function InlineAddWidgetCardStory() {

--- a/ui/src/features/current-selection/base/components/current-selection-save-notifications.test.tsx
+++ b/ui/src/features/current-selection/base/components/current-selection-save-notifications.test.tsx
@@ -66,6 +66,26 @@ describe("CurrentSelectionSaveNotifications toast delivery", () => {
     expect(toast.warning).not.toHaveBeenCalled();
   });
 
+  it("delivers work type success notifications with entity-specific copy", () => {
+    renderNotifications({
+      documentSave: { status: "success" },
+      entityKind: "work-type",
+      messages: {
+        ...messages,
+        saveSuccessDescription:
+          'Running factory saved. "feature" was refreshed to the saved definition.',
+        saveSuccessTitle: "Work type saved",
+      },
+      saveAttemptRevision: 1,
+    });
+
+    expect(toast.success).toHaveBeenCalledWith("Work type saved", {
+      description:
+        'Running factory saved. "feature" was refreshed to the saved definition.',
+      duration: GLOBAL_TOAST_DURATION_MS,
+    });
+  });
+
   it("calls the sonner error hook when scoped document save fails", () => {
     renderNotifications({
       documentSave: {

--- a/ui/src/features/current-selection/base/components/current-selection-save-notifications.test.tsx
+++ b/ui/src/features/current-selection/base/components/current-selection-save-notifications.test.tsx
@@ -1,0 +1,210 @@
+import { render } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { toast } from "sonner";
+
+import { CurrentFactoryDefinitionError } from "../../../../api/current-factory-definition";
+import { workerFieldValidationTarget } from "../../../../testing/factory-validation-target-fixtures";
+import { buildGraphSaveErrorToastDescription } from "../../../factory-graph-editor/lib/graph-document-save-notifications";
+import {
+  GLOBAL_TOAST_DURATION_MS,
+  PERSISTENT_TOAST_DURATION_MS,
+} from "../../../notifications/public";
+import { CurrentSelectionSaveNotifications } from "./current-selection-save-notifications";
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+const messages = {
+  saveFailedAffectedSummary: (labels: string) => `Affected: ${labels}`,
+  saveFailedTitle: "Worker save failed",
+  saveSuccessDescription:
+    "Running factory saved. worker-1 was updated in the running factory definition.",
+  saveSuccessTitle: "Worker saved",
+  staleVersionDetail:
+    "Reload the latest running-factory values or keep this draft and retry after the editor refreshes.",
+};
+
+function renderNotifications(
+  overrides: Partial<
+    ComponentProps<typeof CurrentSelectionSaveNotifications>
+  > = {},
+) {
+  return render(
+    <CurrentSelectionSaveNotifications
+      documentSave={{ status: "idle" }}
+      entityKind="worker"
+      hasDraftChanges={false}
+      messages={messages}
+      saveAttemptRevision={0}
+      saveMutationError={null}
+      {...overrides}
+    />,
+  );
+}
+
+describe("CurrentSelectionSaveNotifications toast delivery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls the sonner success hook when scoped document save succeeds", () => {
+    renderNotifications({
+      documentSave: { status: "success" },
+      saveAttemptRevision: 1,
+    });
+
+    expect(toast.success).toHaveBeenCalledWith("Worker saved", {
+      description: messages.saveSuccessDescription,
+      duration: GLOBAL_TOAST_DURATION_MS,
+    });
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(toast.warning).not.toHaveBeenCalled();
+  });
+
+  it("calls the sonner error hook when scoped document save fails", () => {
+    renderNotifications({
+      documentSave: {
+        errorMessage: "Network dropped",
+        status: "error",
+      },
+      saveAttemptRevision: 1,
+    });
+
+    expect(toast.error).toHaveBeenCalledWith("Worker save failed", {
+      description: "Network dropped",
+      duration: PERSISTENT_TOAST_DURATION_MS,
+    });
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.warning).not.toHaveBeenCalled();
+  });
+
+  it("calls the sonner warning hook for stale version save failures", () => {
+    const saveMutationError = new CurrentFactoryDefinitionError(
+      "The factory definition changed on the server.",
+      {
+        code: "STALE_FACTORY_VERSION",
+        targets: [],
+      },
+    );
+
+    renderNotifications({
+      documentSave: {
+        message: saveMutationError.message,
+        status: "warning",
+      },
+      hasDraftChanges: true,
+      saveAttemptRevision: 1,
+      saveMutationError,
+    });
+
+    expect(toast.warning).toHaveBeenCalledWith(saveMutationError.message, {
+      description: messages.staleVersionDetail,
+      duration: GLOBAL_TOAST_DURATION_MS,
+    });
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("includes validation target summary in error toast descriptions", () => {
+    const targets = [
+      workerFieldValidationTarget("prompt", "Prompt is required."),
+      workerFieldValidationTarget("kind", "Kind is required."),
+    ];
+    const saveMutationError = new CurrentFactoryDefinitionError(
+      "Factory definition is invalid.",
+      {
+        code: "INVALID_FACTORY_DEFINITION",
+        targets,
+      },
+    );
+
+    renderNotifications({
+      documentSave: {
+        errorMessage: saveMutationError.message,
+        status: "error",
+      },
+      hasDraftChanges: true,
+      saveAttemptRevision: 1,
+      saveMutationError,
+    });
+
+    expect(toast.error).toHaveBeenCalledWith("Worker save failed", {
+      description: buildGraphSaveErrorToastDescription(
+        saveMutationError.message,
+        targets,
+        messages.saveFailedAffectedSummary,
+      ),
+      duration: PERSISTENT_TOAST_DURATION_MS,
+    });
+  });
+});
+
+describe("CurrentSelectionSaveNotifications dedupe and rendering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not repeat the same save notification across rerenders with the same attempt revision", () => {
+    const props = {
+      documentSave: { status: "success" as const },
+      saveAttemptRevision: 1,
+    };
+    const { rerender } = renderNotifications(props);
+
+    rerender(
+      <CurrentSelectionSaveNotifications
+        documentSave={{ status: "idle" }}
+        entityKind="worker"
+        hasDraftChanges={false}
+        messages={messages}
+        saveAttemptRevision={0}
+        saveMutationError={null}
+        {...props}
+      />,
+    );
+
+    expect(toast.success).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls toast.error twice for the same message on distinct save attempts", () => {
+    const errorProps = {
+      documentSave: {
+        errorMessage: "Network dropped",
+        status: "error" as const,
+      },
+    };
+    const { rerender } = renderNotifications({
+      ...errorProps,
+      saveAttemptRevision: 1,
+    });
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <CurrentSelectionSaveNotifications
+        entityKind="worker"
+        hasDraftChanges={false}
+        messages={messages}
+        saveMutationError={null}
+        {...errorProps}
+        saveAttemptRevision={2}
+      />,
+    );
+
+    expect(toast.error).toHaveBeenCalledTimes(2);
+  });
+
+  it("renders nothing to the DOM", () => {
+    const { container } = renderNotifications({
+      documentSave: { status: "success" },
+      saveAttemptRevision: 1,
+    });
+
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/ui/src/features/current-selection/base/components/current-selection-save-notifications.tsx
+++ b/ui/src/features/current-selection/base/components/current-selection-save-notifications.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+
+import type { CurrentFactoryDefinitionError } from "../../../../api/current-factory-definition";
+import {
+  buildCurrentSelectionSaveSuccessStableIdentity,
+  buildSaveErrorStableIdentity,
+  buildSaveErrorToastOptions,
+  buildSaveNotificationDeliveryKey,
+  buildSaveSuccessToastOptions,
+  type CurrentSelectionSaveEntityKind,
+  GLOBAL_TOAST_DURATION_MS,
+  type SaveNotificationDeliveryKey,
+  type SaveNotificationStableIdentity,
+  shouldDeliverSaveNotification,
+} from "../../../notifications/public";
+import type { FactoryDocumentSaveState } from "../hooks/factory-document-save-types";
+import {
+  type CurrentSelectionSaveToastMessages,
+  type CurrentSelectionSaveToastNotification,
+  resolveCurrentSelectionSaveToastNotification,
+} from "../lib/current-selection-save-notifications";
+
+function readSaveErrorCode(error: unknown): string | null {
+  if (
+    error !== null &&
+    typeof error === "object" &&
+    "code" in error &&
+    typeof (error as { code: unknown }).code === "string"
+  ) {
+    return (error as { code: string }).code;
+  }
+  return null;
+}
+
+function buildToastStableIdentity(
+  notification: CurrentSelectionSaveToastNotification,
+  saveMutationError: unknown,
+): SaveNotificationStableIdentity {
+  if (notification.kind === "success") {
+    return buildCurrentSelectionSaveSuccessStableIdentity(
+      notification.entityKind,
+    );
+  }
+
+  return buildSaveErrorStableIdentity({
+    message: notification.key,
+    code:
+      notification.kind === "warning"
+        ? (readSaveErrorCode(saveMutationError) ?? "warning")
+        : readSaveErrorCode(saveMutationError),
+  });
+}
+
+export type CurrentSelectionSaveNotificationsProps = {
+  documentSave: FactoryDocumentSaveState;
+  entityKind: CurrentSelectionSaveEntityKind;
+  hasDraftChanges: boolean;
+  /** Reserved for catalog resolution when wiring from the selection widget. */
+  locale?: string;
+  messages: CurrentSelectionSaveToastMessages;
+  saveAttemptRevision: number;
+  saveMutationError: Pick<
+    CurrentFactoryDefinitionError,
+    "code" | "message" | "targets"
+  > | null;
+};
+
+export function CurrentSelectionSaveNotifications({
+  documentSave,
+  entityKind,
+  hasDraftChanges,
+  messages,
+  saveAttemptRevision,
+  saveMutationError,
+}: CurrentSelectionSaveNotificationsProps) {
+  const lastDeliveredDeliveryKeyRef =
+    useRef<SaveNotificationDeliveryKey | null>(null);
+  const notification = resolveCurrentSelectionSaveToastNotification({
+    documentSave,
+    entityKind,
+    hasDraftChanges,
+    messages,
+    saveMutationError,
+  });
+
+  useEffect(() => {
+    if (notification === null) {
+      return;
+    }
+
+    const deliveryKey = buildSaveNotificationDeliveryKey(
+      buildToastStableIdentity(notification, saveMutationError),
+      saveAttemptRevision,
+    );
+
+    if (
+      !shouldDeliverSaveNotification(
+        deliveryKey,
+        lastDeliveredDeliveryKeyRef.current,
+      )
+    ) {
+      return;
+    }
+
+    lastDeliveredDeliveryKeyRef.current = deliveryKey;
+
+    if (notification.kind === "warning") {
+      toast.warning(notification.title, {
+        description: notification.description,
+        duration: GLOBAL_TOAST_DURATION_MS,
+      });
+      return;
+    }
+
+    if (notification.kind === "error") {
+      toast.error(notification.title, {
+        ...buildSaveErrorToastOptions(notification.description),
+      });
+      return;
+    }
+
+    toast.success(notification.title, {
+      ...buildSaveSuccessToastOptions(notification.description),
+    });
+  }, [notification, saveAttemptRevision, saveMutationError]);
+
+  return null;
+}

--- a/ui/src/features/current-selection/base/components/current-selection-save-toast-test-helpers.ts
+++ b/ui/src/features/current-selection/base/components/current-selection-save-toast-test-helpers.ts
@@ -1,0 +1,100 @@
+import { waitFor } from "@testing-library/react";
+import { expect } from "vitest";
+import { toast } from "sonner";
+
+import {
+  GLOBAL_TOAST_DURATION_MS,
+  PERSISTENT_TOAST_DURATION_MS,
+} from "../../../notifications/public";
+
+export const WORKSTATION_SAVE_SUCCESS_DESCRIPTION =
+  "Running factory saved. The editable workstation values were refreshed to the saved definition.";
+
+export const WORKSTATION_STALE_VERSION_DETAIL =
+  "Reload the latest running-factory values or keep this draft and retry after the editor refreshes.";
+
+export async function expectWorkstationSaveSuccessToast() {
+  await waitFor(() => {
+    expect(toast.success).toHaveBeenCalledWith(
+      "Workstation saved",
+      expect.objectContaining({
+        description: WORKSTATION_SAVE_SUCCESS_DESCRIPTION,
+      }),
+    );
+  });
+}
+
+export async function expectWorkstationSaveFailedToast(errorDetail: string) {
+  await waitFor(() => {
+    expect(toast.error).toHaveBeenCalledWith(
+      "Workstation save failed",
+      expect.objectContaining({
+        description: expect.stringContaining(errorDetail),
+        duration: PERSISTENT_TOAST_DURATION_MS,
+      }),
+    );
+  });
+}
+
+export async function expectWorkstationStaleSaveWarningToast(
+  warningTitle: string,
+) {
+  await waitFor(() => {
+    expect(toast.warning).toHaveBeenCalledWith(
+      warningTitle,
+      expect.objectContaining({
+        description: WORKSTATION_STALE_VERSION_DETAIL,
+        duration: GLOBAL_TOAST_DURATION_MS,
+      }),
+    );
+  });
+}
+
+export async function expectWorkerSaveSuccessToast(workerName: string) {
+  await waitFor(() => {
+    expect(toast.success).toHaveBeenCalledWith(
+      "Worker saved",
+      expect.objectContaining({
+        description: expect.stringContaining(
+          `${workerName} was updated in the running factory definition`,
+        ),
+      }),
+    );
+  });
+}
+
+export async function expectWorkerSaveFailedToast(errorDetail: string) {
+  await waitFor(() => {
+    expect(toast.error).toHaveBeenCalledWith(
+      "Worker save failed",
+      expect.objectContaining({
+        description: expect.stringContaining(errorDetail),
+        duration: PERSISTENT_TOAST_DURATION_MS,
+      }),
+    );
+  });
+}
+
+export async function expectResourceSaveSuccessToast(resourceName: string) {
+  await waitFor(() => {
+    expect(toast.success).toHaveBeenCalledWith(
+      "Resource saved",
+      expect.objectContaining({
+        description: expect.stringContaining(resourceName),
+      }),
+    );
+  });
+}
+
+export async function expectWorkStateSaveSuccessToast(stateName: string) {
+  await waitFor(() => {
+    expect(toast.success).toHaveBeenCalledWith(
+      "Work state saved",
+      expect.objectContaining({
+        description: expect.stringContaining(
+          `${stateName} was updated in the running factory definition`,
+        ),
+      }),
+    );
+  });
+}

--- a/ui/src/features/current-selection/base/components/current-selection-save-toast-test-helpers.ts
+++ b/ui/src/features/current-selection/base/components/current-selection-save-toast-test-helpers.ts
@@ -1,4 +1,4 @@
-import { waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import { expect } from "vitest";
 import { toast } from "sonner";
 
@@ -12,6 +12,47 @@ export const WORKSTATION_SAVE_SUCCESS_DESCRIPTION =
 
 export const WORKSTATION_STALE_VERSION_DETAIL =
   "Reload the latest running-factory values or keep this draft and retry after the editor refreshes.";
+
+const INLINE_SAVE_SUCCESS_PATTERN = /^Running factory saved\./;
+const INLINE_SAVE_FAILURE_PREFIX = /^Saving failed\./;
+
+export function currentSelectionConfigurationSection(
+  headingName: string,
+): HTMLElement {
+  const heading = screen.getAllByRole("heading", { name: headingName }).at(-1);
+  const section = heading?.closest("section");
+  if (!section) {
+    throw new Error(`expected ${headingName} configuration section`);
+  }
+
+  return section;
+}
+
+export function expectNoInlineSaveOutcomesIn(configurationRoot: HTMLElement) {
+  const scoped = within(configurationRoot);
+  expect(scoped.queryByText(INLINE_SAVE_SUCCESS_PATTERN)).toBeNull();
+  expect(scoped.queryByText(INLINE_SAVE_FAILURE_PREFIX)).toBeNull();
+
+  for (const status of scoped.queryAllByRole("status")) {
+    const text = status.textContent ?? "";
+    expect(text).not.toMatch(INLINE_SAVE_SUCCESS_PATTERN);
+  }
+
+  for (const alert of scoped.queryAllByRole("alert")) {
+    const text = alert.textContent ?? "";
+    expect(text).not.toMatch(INLINE_SAVE_SUCCESS_PATTERN);
+    expect(text).not.toMatch(INLINE_SAVE_FAILURE_PREFIX);
+    expect(text).not.toContain(WORKSTATION_STALE_VERSION_DETAIL);
+  }
+}
+
+export async function expectNoSaveToastDelivery() {
+  await waitFor(() => {
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(toast.warning).not.toHaveBeenCalled();
+  });
+}
 
 export async function expectWorkstationSaveSuccessToast() {
   await waitFor(() => {
@@ -81,6 +122,18 @@ export async function expectResourceSaveSuccessToast(resourceName: string) {
       "Resource saved",
       expect.objectContaining({
         description: expect.stringContaining(resourceName),
+      }),
+    );
+  });
+}
+
+export async function expectResourceSaveFailedToast(errorDetail: string) {
+  await waitFor(() => {
+    expect(toast.error).toHaveBeenCalledWith(
+      "Resource save failed",
+      expect.objectContaining({
+        description: expect.stringContaining(errorDetail),
+        duration: PERSISTENT_TOAST_DURATION_MS,
       }),
     );
   });

--- a/ui/src/features/current-selection/base/components/current-selection-save-toast-test-helpers.ts
+++ b/ui/src/features/current-selection/base/components/current-selection-save-toast-test-helpers.ts
@@ -104,18 +104,6 @@ export async function expectWorkerSaveSuccessToast(workerName: string) {
   });
 }
 
-export async function expectWorkerSaveFailedToast(errorDetail: string) {
-  await waitFor(() => {
-    expect(toast.error).toHaveBeenCalledWith(
-      "Worker save failed",
-      expect.objectContaining({
-        description: expect.stringContaining(errorDetail),
-        duration: PERSISTENT_TOAST_DURATION_MS,
-      }),
-    );
-  });
-}
-
 export async function expectResourceSaveSuccessToast(resourceName: string) {
   await waitFor(() => {
     expect(toast.success).toHaveBeenCalledWith(
@@ -147,31 +135,6 @@ export async function expectWorkStateSaveSuccessToast(stateName: string) {
         description: expect.stringContaining(
           `${stateName} was updated in the running factory definition`,
         ),
-      }),
-    );
-  });
-}
-
-export async function expectWorkTypeSaveSuccessToast(workTypeName: string) {
-  await waitFor(() => {
-    expect(toast.success).toHaveBeenCalledWith(
-      "Work type saved",
-      expect.objectContaining({
-        description: expect.stringContaining(
-          `"${workTypeName}" was refreshed to the saved definition`,
-        ),
-      }),
-    );
-  });
-}
-
-export async function expectWorkTypeSaveFailedToast(errorDetail: string) {
-  await waitFor(() => {
-    expect(toast.error).toHaveBeenCalledWith(
-      "Work type save failed",
-      expect.objectContaining({
-        description: expect.stringContaining(errorDetail),
-        duration: PERSISTENT_TOAST_DURATION_MS,
       }),
     );
   });

--- a/ui/src/features/current-selection/base/components/current-selection-save-toast-test-helpers.ts
+++ b/ui/src/features/current-selection/base/components/current-selection-save-toast-test-helpers.ts
@@ -1,6 +1,6 @@
 import { screen, waitFor, within } from "@testing-library/react";
-import { expect } from "vitest";
 import { toast } from "sonner";
+import { expect } from "vitest";
 
 import {
   GLOBAL_TOAST_DURATION_MS,
@@ -147,6 +147,31 @@ export async function expectWorkStateSaveSuccessToast(stateName: string) {
         description: expect.stringContaining(
           `${stateName} was updated in the running factory definition`,
         ),
+      }),
+    );
+  });
+}
+
+export async function expectWorkTypeSaveSuccessToast(workTypeName: string) {
+  await waitFor(() => {
+    expect(toast.success).toHaveBeenCalledWith(
+      "Work type saved",
+      expect.objectContaining({
+        description: expect.stringContaining(
+          `"${workTypeName}" was refreshed to the saved definition`,
+        ),
+      }),
+    );
+  });
+}
+
+export async function expectWorkTypeSaveFailedToast(errorDetail: string) {
+  await waitFor(() => {
+    expect(toast.error).toHaveBeenCalledWith(
+      "Work type save failed",
+      expect.objectContaining({
+        description: expect.stringContaining(errorDetail),
+        duration: PERSISTENT_TOAST_DURATION_MS,
       }),
     );
   });

--- a/ui/src/features/current-selection/base/components/detail-card-factory-save-feedback.test.tsx
+++ b/ui/src/features/current-selection/base/components/detail-card-factory-save-feedback.test.tsx
@@ -35,50 +35,6 @@ describe("DetailCardFactorySaveFeedback", () => {
     );
     expect(container.firstChild).toBeNull();
   });
-
-  it("renders success feedback with role=status and caller-supplied success copy", () => {
-    render(
-      <DetailCardFactorySaveFeedback
-        messages={messages}
-        saveState={{ status: "success" }}
-      />,
-    );
-
-    expect(screen.getByRole("status").textContent).toBe(messages.successMessage);
-  });
-
-  it("renders stale-version warning with role=alert and shared stale-version detail copy", () => {
-    render(
-      <DetailCardFactorySaveFeedback
-        messages={messages}
-        saveState={{
-          message: "The running factory changed while this draft was open.",
-          status: "warning",
-        }}
-      />,
-    );
-
-    expect(screen.getByRole("alert").textContent).toContain(
-      "The running factory changed while this draft was open.",
-    );
-    expect(screen.getByText(messages.staleVersionDetail)).toBeTruthy();
-  });
-
-  it("renders API error feedback with role=alert and the shared error prefix", () => {
-    render(
-      <DetailCardFactorySaveFeedback
-        messages={messages}
-        saveState={{
-          errorMessage: "Factory validation failed.",
-          status: "error",
-        }}
-      />,
-    );
-
-    expect(screen.getByRole("alert").textContent).toBe(
-      "Saving failed. Factory validation failed.",
-    );
-  });
 });
 
 describe("mergeDetailCardSaveFieldErrors", () => {

--- a/ui/src/features/current-selection/base/hooks/useScopedFactoryDocumentSave.test.tsx
+++ b/ui/src/features/current-selection/base/hooks/useScopedFactoryDocumentSave.test.tsx
@@ -19,6 +19,157 @@ beforeEach(() => {
   vi.restoreAllMocks();
 });
 
+describe("useScopedFactoryDocumentSave saveAttemptRevision", () => {
+  it("starts at zero", () => {
+    const saveMutation = mockFactoryDocumentSave({ mode: "idle" });
+    vi.spyOn(
+      factoryDocumentSaveHooks,
+      "useFactoryDocumentSave",
+    ).mockReturnValue(saveMutation as never);
+
+    const { result } = renderHook(
+      () =>
+        useScopedFactoryDocumentSave({
+          fallbackErrorMessage: "Unable to save the active factory.",
+          scopeKey: "review:transition:Review",
+        }),
+      { wrapper: createScopedFactoryDocumentSaveQueryClientWrapper() },
+    );
+
+    expect(result.current.saveAttemptRevision).toBe(0);
+  });
+
+  it("increments on each saveNow or confirmSave invocation that starts a save", async () => {
+    const saveMutation = mockFactoryDocumentSave({ mode: "success" });
+    vi.spyOn(
+      factoryDocumentSaveHooks,
+      "useFactoryDocumentSave",
+    ).mockReturnValue(saveMutation as never);
+
+    const { result } = renderHook(
+      () =>
+        useScopedFactoryDocumentSave({
+          fallbackErrorMessage: "Unable to save the active factory.",
+          scopeKey: "review:transition:Review",
+        }),
+      { wrapper: createScopedFactoryDocumentSaveQueryClientWrapper() },
+    );
+
+    await act(async () => {
+      await result.current.saveNow(defaultScopedFactoryDocumentSaveRequest);
+    });
+    expect(result.current.saveAttemptRevision).toBe(1);
+
+    await act(async () => {
+      await result.current.saveNow(defaultScopedFactoryDocumentSaveRequest);
+    });
+    expect(result.current.saveAttemptRevision).toBe(2);
+
+    act(() => {
+      result.current.beginConfirmation();
+    });
+
+    await act(async () => {
+      await result.current.confirmSave(defaultScopedFactoryDocumentSaveRequest);
+    });
+    expect(result.current.saveAttemptRevision).toBe(3);
+  });
+
+  it("does not increment on confirmation-only state transitions", () => {
+    const saveMutation = mockFactoryDocumentSave({ mode: "idle" });
+    vi.spyOn(
+      factoryDocumentSaveHooks,
+      "useFactoryDocumentSave",
+    ).mockReturnValue(saveMutation as never);
+
+    const { result } = renderHook(
+      () =>
+        useScopedFactoryDocumentSave({
+          fallbackErrorMessage: "Unable to save the active factory.",
+          scopeKey: "review:transition:Review",
+        }),
+      { wrapper: createScopedFactoryDocumentSaveQueryClientWrapper() },
+    );
+
+    act(() => {
+      result.current.beginConfirmation();
+    });
+    expect(result.current.saveAttemptRevision).toBe(0);
+
+    act(() => {
+      result.current.cancelConfirmation();
+    });
+    expect(result.current.saveAttemptRevision).toBe(0);
+  });
+
+  it("does not increment when duplicate save calls are deduplicated while in flight", async () => {
+    const pendingSave = mockPendingFactoryDocumentSave();
+    vi.spyOn(
+      factoryDocumentSaveHooks,
+      "useFactoryDocumentSave",
+    ).mockReturnValue(pendingSave.saveMutation as never);
+
+    const { result } = renderHook(
+      () =>
+        useScopedFactoryDocumentSave({
+          fallbackErrorMessage: "Unable to save the active factory.",
+          scopeKey: "review:transition:Review",
+        }),
+      { wrapper: createScopedFactoryDocumentSaveQueryClientWrapper() },
+    );
+
+    await act(async () => {
+      void result.current.saveNow(defaultScopedFactoryDocumentSaveRequest);
+      await Promise.resolve();
+      await result.current.saveNow(defaultScopedFactoryDocumentSaveRequest);
+    });
+
+    expect(result.current.saveAttemptRevision).toBe(1);
+
+    pendingSave.deferred.resolve({
+      name: "Current Factory",
+      version: {
+        logical: "8",
+        physical: "2026-05-23T15:52:00.001Z",
+      },
+      workers: [],
+      workstations: [],
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+  });
+
+  it("resets when scopeKey changes", async () => {
+    const saveMutation = mockFactoryDocumentSave({ mode: "success" });
+    vi.spyOn(
+      factoryDocumentSaveHooks,
+      "useFactoryDocumentSave",
+    ).mockReturnValue(saveMutation as never);
+
+    const { rerender, result } = renderHook(
+      ({ scopeKey }) =>
+        useScopedFactoryDocumentSave({
+          fallbackErrorMessage: "Unable to save the active factory.",
+          scopeKey,
+        }),
+      {
+        initialProps: { scopeKey: "review:transition:Review" },
+        wrapper: createScopedFactoryDocumentSaveQueryClientWrapper(),
+      },
+    );
+
+    await act(async () => {
+      await result.current.saveNow(defaultScopedFactoryDocumentSaveRequest);
+    });
+    expect(result.current.saveAttemptRevision).toBe(1);
+
+    rerender({ scopeKey: "worker:reviewer" });
+    expect(result.current.saveAttemptRevision).toBe(0);
+  });
+});
+
 describe("useScopedFactoryDocumentSave in-flight deduplication", () => {
   it("ignores repeated confirm and immediate save calls while a save is in flight", async () => {
     const pendingSave = mockPendingFactoryDocumentSave();

--- a/ui/src/features/current-selection/base/hooks/useScopedFactoryDocumentSave.ts
+++ b/ui/src/features/current-selection/base/hooks/useScopedFactoryDocumentSave.ts
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import type {
   CanonicalFactoryDefinition,
@@ -21,10 +29,7 @@ export interface UseScopedFactoryDocumentSaveOptions<
   fallbackErrorMessage: string;
   isDirty?: boolean;
   mapSaveErrorToFieldErrors?: (
-    error: Pick<
-      CurrentFactoryDefinitionError,
-      "code" | "message" | "targets"
-    >,
+    error: Pick<CurrentFactoryDefinitionError, "code" | "message" | "targets">,
   ) => TFieldErrors | undefined;
   scopeKey: string | null;
 }
@@ -39,6 +44,7 @@ export interface UseScopedFactoryDocumentSaveResult<
   error: CurrentFactoryDefinitionError | null;
   isPending: boolean;
   reset: () => void;
+  saveAttemptRevision: number;
   saveNow: (request: ScopedFactoryDocumentSaveRequest) => Promise<void>;
   saveState: FactoryDocumentSaveState<TFieldErrors>;
 }
@@ -69,6 +75,7 @@ export function useScopedFactoryDocumentSave<
   const [submittingScopeKey, setSubmittingScopeKey] = useState<string | null>(
     null,
   );
+  const [saveAttemptRevision, setSaveAttemptRevision] = useState(0);
   const saveInFlightRef = useRef(false);
   const activeScopeKeyRef = useRef(scopeKey);
   activeScopeKeyRef.current = scopeKey;
@@ -79,6 +86,7 @@ export function useScopedFactoryDocumentSave<
     setIsConfirming,
     setLastFailedScope,
     setLastSuccessfulScopeKey,
+    setSaveAttemptRevision,
   });
   const previousScopeKeyRef = useRef<string | null>(scopeKey);
   const hasScopeChanged = previousScopeKeyRef.current !== scopeKey;
@@ -123,13 +131,10 @@ export function useScopedFactoryDocumentSave<
         setIsConfirming,
         setLastFailedScope,
         setLastSuccessfulScopeKey,
+        setSaveAttemptRevision,
         setSubmittingScopeKey,
       }),
-    [
-      fallbackErrorMessage,
-      mapSaveErrorToFieldErrors,
-      saveAsync,
-    ],
+    [fallbackErrorMessage, mapSaveErrorToFieldErrors, saveAsync],
   );
 
   const beginConfirmation = useCallback(() => {
@@ -158,6 +163,7 @@ export function useScopedFactoryDocumentSave<
     error,
     isPending,
     reset,
+    saveAttemptRevision,
     saveNow: persistSave,
     saveState,
   };
@@ -175,15 +181,13 @@ async function executeScopedFactoryDocumentSave<
   setIsConfirming,
   setLastFailedScope,
   setLastSuccessfulScopeKey,
+  setSaveAttemptRevision,
   setSubmittingScopeKey,
 }: {
   activeScopeKeyRef: { current: string | null };
   fallbackErrorMessage: string;
   mapSaveErrorToFieldErrors?: (
-    error: Pick<
-      CurrentFactoryDefinitionError,
-      "code" | "message" | "targets"
-    >,
+    error: Pick<CurrentFactoryDefinitionError, "code" | "message" | "targets">,
   ) => TFieldErrors | undefined;
   request: ScopedFactoryDocumentSaveRequest;
   saveAsync: ReturnType<typeof useFactoryDocumentSave>["saveAsync"];
@@ -193,6 +197,7 @@ async function executeScopedFactoryDocumentSave<
     value: ScopedFactoryDocumentSaveErrorState<TFieldErrors> | null,
   ) => void;
   setLastSuccessfulScopeKey: (value: string | null) => void;
+  setSaveAttemptRevision: Dispatch<SetStateAction<number>>;
   setSubmittingScopeKey: (value: string | null) => void;
 }) {
   if (
@@ -203,6 +208,7 @@ async function executeScopedFactoryDocumentSave<
     return;
   }
 
+  setSaveAttemptRevision((revision) => revision + 1);
   setLastFailedScope(null);
   setLastSuccessfulScopeKey(null);
   saveInFlightRef.current = true;
@@ -293,13 +299,12 @@ function resolveDetailCardSaveState<
   return { status: "idle" };
 }
 
-function useResetExitedSaveScope<
-  TFieldErrors extends Record<string, string>,
->({
+function useResetExitedSaveScope<TFieldErrors extends Record<string, string>>({
   scopeKey,
   setIsConfirming,
   setLastFailedScope,
   setLastSuccessfulScopeKey,
+  setSaveAttemptRevision,
 }: {
   scopeKey: string | null;
   setIsConfirming: (value: boolean) => void;
@@ -307,6 +312,7 @@ function useResetExitedSaveScope<
     value: ScopedFactoryDocumentSaveErrorState<TFieldErrors> | null,
   ) => void;
   setLastSuccessfulScopeKey: (value: string | null) => void;
+  setSaveAttemptRevision: Dispatch<SetStateAction<number>>;
 }) {
   const previousScopeKeyRef = useRef<string | null>(scopeKey);
 
@@ -315,6 +321,7 @@ function useResetExitedSaveScope<
       setIsConfirming(false);
       setLastFailedScope(null);
       setLastSuccessfulScopeKey(null);
+      setSaveAttemptRevision(0);
       previousScopeKeyRef.current = scopeKey;
     }
   }, [
@@ -322,6 +329,7 @@ function useResetExitedSaveScope<
     setIsConfirming,
     setLastFailedScope,
     setLastSuccessfulScopeKey,
+    setSaveAttemptRevision,
   ]);
 }
 
@@ -345,9 +353,7 @@ function useResetSuccessfulSaveStateOnDraftChange({
   }, [isDirty, scopeKey, setLastSuccessfulScopeKey]);
 }
 
-function normalizeSaveError<
-  TFieldErrors extends Record<string, string>,
->(
+function normalizeSaveError<TFieldErrors extends Record<string, string>>(
   error: unknown,
   {
     fallbackMessage,

--- a/ui/src/features/current-selection/base/lib/build-current-selection-save-toast-messages.ts
+++ b/ui/src/features/current-selection/base/lib/build-current-selection-save-toast-messages.ts
@@ -1,0 +1,82 @@
+import type { CurrentSelectionSaveEntityKind } from "../../../notifications/lib/save-notification-delivery-policy";
+import {
+  getCurrentSelectionSaveToastCatalogMessages,
+  resolveCurrentSelectionSaveToastTitles,
+} from "../messages/current-selection-save-toast";
+import { getResourceDetailMessages } from "../../resource-selection/messages/resource-detail";
+import { getWorkerDetailMessages } from "../../worker-selection/messages/worker-detail";
+import { getWorkStateDetailMessages } from "../../work-state-selection/messages/work-state-detail";
+import { getWorkTypeDetailMessages } from "../../work-type-selection/messages/work-type-detail";
+import { getWorkstationDetailMessages } from "../../workstation-selection/messages/workstation-detail";
+import type { CurrentSelectionSaveToastMessages } from "./current-selection-save-notifications";
+
+export function buildCurrentSelectionSaveToastMessages({
+  entityDisplayName,
+  entityKind,
+  locale,
+}: {
+  entityDisplayName: string;
+  entityKind: CurrentSelectionSaveEntityKind;
+  locale?: string | null;
+}): CurrentSelectionSaveToastMessages {
+  const toastCatalog = getCurrentSelectionSaveToastCatalogMessages(locale);
+  const { saveFailedTitle, saveSuccessTitle } =
+    resolveCurrentSelectionSaveToastTitles(toastCatalog, entityKind);
+
+  switch (entityKind) {
+    case "workstation": {
+      const detailMessages = getWorkstationDetailMessages(locale);
+      return {
+        saveFailedAffectedSummary: toastCatalog.saveFailedAffectedSummary,
+        saveFailedTitle,
+        saveSuccessDescription: detailMessages.editableConfigurationSaveSuccess,
+        saveSuccessTitle,
+        staleVersionDetail: detailMessages.editableConfigurationSaveStaleVersionDetail,
+      };
+    }
+    case "worker": {
+      const detailMessages = getWorkerDetailMessages(locale);
+      return {
+        saveFailedAffectedSummary: toastCatalog.saveFailedAffectedSummary,
+        saveFailedTitle,
+        saveSuccessDescription:
+          detailMessages.editableConfigurationSaveSuccess(entityDisplayName),
+        saveSuccessTitle,
+        staleVersionDetail: detailMessages.editableConfigurationSaveStaleVersionDetail,
+      };
+    }
+    case "resource": {
+      const detailMessages = getResourceDetailMessages(locale);
+      return {
+        saveFailedAffectedSummary: toastCatalog.saveFailedAffectedSummary,
+        saveFailedTitle,
+        saveSuccessDescription:
+          detailMessages.editableConfigurationSaveSuccess(entityDisplayName),
+        saveSuccessTitle,
+        staleVersionDetail: detailMessages.editableConfigurationSaveStaleVersionDetail,
+      };
+    }
+    case "work-type": {
+      const detailMessages = getWorkTypeDetailMessages(locale);
+      return {
+        saveFailedAffectedSummary: toastCatalog.saveFailedAffectedSummary,
+        saveFailedTitle,
+        saveSuccessDescription:
+          detailMessages.editableConfigurationSaveSuccess(entityDisplayName),
+        saveSuccessTitle,
+        staleVersionDetail: detailMessages.editableConfigurationSaveStaleVersionDetail,
+      };
+    }
+    case "work-state": {
+      const detailMessages = getWorkStateDetailMessages(locale);
+      return {
+        saveFailedAffectedSummary: toastCatalog.saveFailedAffectedSummary,
+        saveFailedTitle,
+        saveSuccessDescription:
+          detailMessages.editableConfigurationSaveSuccess(entityDisplayName),
+        saveSuccessTitle,
+        staleVersionDetail: detailMessages.editableConfigurationSaveStaleVersionDetail,
+      };
+    }
+  }
+}

--- a/ui/src/features/current-selection/base/lib/current-selection-save-notifications.test.ts
+++ b/ui/src/features/current-selection/base/lib/current-selection-save-notifications.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+
+import { CurrentFactoryDefinitionError } from "../../../../api/current-factory-definition";
+import { workerFieldValidationTarget } from "../../../../testing/factory-validation-target-fixtures";
+import { buildGraphSaveErrorToastDescription } from "../../../factory-graph-editor/lib/graph-document-save-notifications";
+import { buildCurrentSelectionSaveSuccessStableIdentity } from "../../../notifications/lib/save-notification-delivery-policy";
+import { resolveCurrentSelectionSaveToastNotification } from "./current-selection-save-notifications";
+
+const messages = {
+  saveFailedAffectedSummary: (labels: string) => `Affected: ${labels}`,
+  saveFailedTitle: "Worker save failed",
+  saveSuccessDescription:
+    "Running factory saved. worker-1 was updated in the running factory definition.",
+  saveSuccessTitle: "Worker saved",
+  staleVersionDetail:
+    "Reload the latest running-factory values or keep this draft and retry after the editor refreshes.",
+};
+
+const formatAffectedSummary = messages.saveFailedAffectedSummary;
+
+describe("buildCurrentSelectionSaveSuccessStableIdentity", () => {
+  it("returns per-entity stable ids distinct from graph-save-success", () => {
+    expect(buildCurrentSelectionSaveSuccessStableIdentity("worker")).toEqual({
+      kind: "success",
+      stableId: "worker-save-success",
+    });
+    expect(buildCurrentSelectionSaveSuccessStableIdentity("workstation")).toEqual({
+      kind: "success",
+      stableId: "workstation-save-success",
+    });
+    expect(buildCurrentSelectionSaveSuccessStableIdentity("resource")).toEqual({
+      kind: "success",
+      stableId: "resource-save-success",
+    });
+    expect(buildCurrentSelectionSaveSuccessStableIdentity("work-type")).toEqual({
+      kind: "success",
+      stableId: "work-type-save-success",
+    });
+    expect(buildCurrentSelectionSaveSuccessStableIdentity("work-state")).toEqual({
+      kind: "success",
+      stableId: "work-state-save-success",
+    });
+  });
+});
+
+describe("resolveCurrentSelectionSaveToastNotification", () => {
+  it("returns success toast when scoped save succeeded and the draft is clean", () => {
+    expect(
+      resolveCurrentSelectionSaveToastNotification({
+        documentSave: { status: "success" },
+        entityKind: "worker",
+        hasDraftChanges: false,
+        messages,
+        saveMutationError: null,
+      }),
+    ).toEqual({
+      description: messages.saveSuccessDescription,
+      entityKind: "worker",
+      key: "success",
+      kind: "success",
+      title: messages.saveSuccessTitle,
+    });
+  });
+
+  it("suppresses success toast while draft changes remain", () => {
+    expect(
+      resolveCurrentSelectionSaveToastNotification({
+        documentSave: { status: "success" },
+        entityKind: "worker",
+        hasDraftChanges: true,
+        messages,
+        saveMutationError: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for idle, confirming, and submitting save states", () => {
+    expect(
+      resolveCurrentSelectionSaveToastNotification({
+        documentSave: { status: "idle" },
+        entityKind: "worker",
+        hasDraftChanges: false,
+        messages,
+        saveMutationError: null,
+      }),
+    ).toBeNull();
+    expect(
+      resolveCurrentSelectionSaveToastNotification({
+        documentSave: { status: "confirming" },
+        entityKind: "worker",
+        hasDraftChanges: false,
+        messages,
+        saveMutationError: null,
+      }),
+    ).toBeNull();
+    expect(
+      resolveCurrentSelectionSaveToastNotification({
+        documentSave: { status: "submitting" },
+        entityKind: "worker",
+        hasDraftChanges: false,
+        messages,
+        saveMutationError: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns warning toast for stale version save failures with stale-version detail", () => {
+    const saveMutationError = new CurrentFactoryDefinitionError(
+      "The factory definition changed on the server.",
+      {
+        code: "STALE_FACTORY_VERSION",
+        targets: [],
+      },
+    );
+
+    expect(
+      resolveCurrentSelectionSaveToastNotification({
+        documentSave: {
+          message: saveMutationError.message,
+          status: "warning",
+        },
+        entityKind: "worker",
+        hasDraftChanges: true,
+        messages,
+        saveMutationError,
+      }),
+    ).toEqual({
+      description: messages.staleVersionDetail,
+      entityKind: "worker",
+      key: `warning:${saveMutationError.message}`,
+      kind: "warning",
+      title: saveMutationError.message,
+    });
+  });
+
+  it("returns error toast with validation target summary when targets are present", () => {
+    const targets = [
+      workerFieldValidationTarget("prompt", "Prompt is required."),
+      workerFieldValidationTarget("kind", "Kind is required."),
+    ];
+    const saveMutationError = new CurrentFactoryDefinitionError(
+      "Factory definition is invalid.",
+      {
+        code: "INVALID_FACTORY_DEFINITION",
+        targets,
+      },
+    );
+
+    expect(
+      resolveCurrentSelectionSaveToastNotification({
+        documentSave: {
+          errorMessage: saveMutationError.message,
+          status: "error",
+        },
+        entityKind: "worker",
+        hasDraftChanges: true,
+        messages,
+        saveMutationError,
+      }),
+    ).toEqual({
+      description: buildGraphSaveErrorToastDescription(
+        saveMutationError.message,
+        targets,
+        formatAffectedSummary,
+      ),
+      entityKind: "worker",
+      key: `error:${saveMutationError.message}:${buildGraphSaveErrorToastDescription(
+        saveMutationError.message,
+        targets,
+        formatAffectedSummary,
+      )}`,
+      kind: "error",
+      title: messages.saveFailedTitle,
+    });
+  });
+
+  it("returns error toast with only the error message when no targets are present", () => {
+    expect(
+      resolveCurrentSelectionSaveToastNotification({
+        documentSave: {
+          errorMessage: "Network dropped",
+          status: "error",
+        },
+        entityKind: "workstation",
+        hasDraftChanges: true,
+        messages: {
+          ...messages,
+          saveFailedTitle: "Workstation save failed",
+        },
+        saveMutationError: null,
+      }),
+    ).toEqual({
+      description: "Network dropped",
+      entityKind: "workstation",
+      key: "error:Network dropped:Network dropped",
+      kind: "error",
+      title: "Workstation save failed",
+    });
+  });
+});

--- a/ui/src/features/current-selection/base/lib/current-selection-save-notifications.test.ts
+++ b/ui/src/features/current-selection/base/lib/current-selection-save-notifications.test.ts
@@ -24,7 +24,9 @@ describe("buildCurrentSelectionSaveSuccessStableIdentity", () => {
       kind: "success",
       stableId: "worker-save-success",
     });
-    expect(buildCurrentSelectionSaveSuccessStableIdentity("workstation")).toEqual({
+    expect(
+      buildCurrentSelectionSaveSuccessStableIdentity("workstation"),
+    ).toEqual({
       kind: "success",
       stableId: "workstation-save-success",
     });
@@ -32,18 +34,22 @@ describe("buildCurrentSelectionSaveSuccessStableIdentity", () => {
       kind: "success",
       stableId: "resource-save-success",
     });
-    expect(buildCurrentSelectionSaveSuccessStableIdentity("work-type")).toEqual({
-      kind: "success",
-      stableId: "work-type-save-success",
-    });
-    expect(buildCurrentSelectionSaveSuccessStableIdentity("work-state")).toEqual({
+    expect(buildCurrentSelectionSaveSuccessStableIdentity("work-type")).toEqual(
+      {
+        kind: "success",
+        stableId: "work-type-save-success",
+      },
+    );
+    expect(
+      buildCurrentSelectionSaveSuccessStableIdentity("work-state"),
+    ).toEqual({
       kind: "success",
       stableId: "work-state-save-success",
     });
   });
 });
 
-describe("resolveCurrentSelectionSaveToastNotification", () => {
+describe("resolveCurrentSelectionSaveToastNotification success and idle", () => {
   it("returns success toast when scoped save succeeded and the draft is clean", () => {
     expect(
       resolveCurrentSelectionSaveToastNotification({
@@ -103,7 +109,9 @@ describe("resolveCurrentSelectionSaveToastNotification", () => {
       }),
     ).toBeNull();
   });
+});
 
+describe("resolveCurrentSelectionSaveToastNotification errors", () => {
   it("returns warning toast for stale version save failures with stale-version detail", () => {
     const saveMutationError = new CurrentFactoryDefinitionError(
       "The factory definition changed on the server.",

--- a/ui/src/features/current-selection/base/lib/current-selection-save-notifications.ts
+++ b/ui/src/features/current-selection/base/lib/current-selection-save-notifications.ts
@@ -1,0 +1,115 @@
+import type { CurrentFactoryDefinitionError } from "../../../../api/current-factory-definition";
+import {
+  buildGraphSaveErrorToastDescription,
+} from "../../../factory-graph-editor/lib/graph-document-save-notifications";
+import type { CurrentSelectionSaveEntityKind } from "../../../notifications/lib/save-notification-delivery-policy";
+import type { FactoryDocumentSaveState } from "../hooks/factory-document-save-types";
+
+export type { CurrentSelectionSaveEntityKind } from "../../../notifications/lib/save-notification-delivery-policy";
+
+export type CurrentSelectionSaveToastKind = "success" | "error" | "warning";
+
+export type CurrentSelectionSaveToastNotification = {
+  description: string;
+  entityKind: CurrentSelectionSaveEntityKind;
+  key: string;
+  kind: CurrentSelectionSaveToastKind;
+  title: string;
+};
+
+export type CurrentSelectionSaveToastMessages = {
+  saveFailedAffectedSummary?: (labels: string) => string;
+  saveFailedTitle: string;
+  saveSuccessDescription: string;
+  saveSuccessTitle: string;
+  staleVersionDetail: string;
+};
+
+export function resolveCurrentSelectionSaveToastNotification({
+  documentSave,
+  entityKind,
+  hasDraftChanges,
+  messages,
+  saveMutationError,
+}: {
+  documentSave: FactoryDocumentSaveState;
+  entityKind: CurrentSelectionSaveEntityKind;
+  hasDraftChanges: boolean;
+  messages: CurrentSelectionSaveToastMessages;
+  saveMutationError: Pick<
+    CurrentFactoryDefinitionError,
+    "code" | "message" | "targets"
+  > | null;
+}): CurrentSelectionSaveToastNotification | null {
+  if (documentSave.status === "success" && !hasDraftChanges) {
+    return {
+      description: messages.saveSuccessDescription,
+      entityKind,
+      key: "success",
+      kind: "success",
+      title: messages.saveSuccessTitle,
+    };
+  }
+
+  if (shouldShowCurrentSelectionStaleSaveWarningToast(documentSave, saveMutationError)) {
+    const warningMessage = resolveCurrentSelectionStaleSaveWarningMessage(
+      documentSave,
+      saveMutationError,
+    );
+
+    return {
+      description: messages.staleVersionDetail,
+      entityKind,
+      key: `warning:${warningMessage}`,
+      kind: "warning",
+      title: warningMessage,
+    };
+  }
+
+  if (documentSave.status === "error") {
+    const description =
+      messages.saveFailedAffectedSummary === undefined
+        ? documentSave.errorMessage
+        : buildGraphSaveErrorToastDescription(
+            documentSave.errorMessage,
+            saveMutationError?.targets,
+            messages.saveFailedAffectedSummary,
+          );
+
+    return {
+      description,
+      entityKind,
+      key: `error:${documentSave.errorMessage}:${description}`,
+      kind: "error",
+      title: messages.saveFailedTitle,
+    };
+  }
+
+  return null;
+}
+
+function shouldShowCurrentSelectionStaleSaveWarningToast(
+  documentSave: FactoryDocumentSaveState,
+  saveMutationError: Pick<CurrentFactoryDefinitionError, "code"> | null,
+): boolean {
+  if (saveMutationError?.code === "STALE_FACTORY_VERSION") {
+    return true;
+  }
+
+  return documentSave.status === "warning";
+}
+
+function resolveCurrentSelectionStaleSaveWarningMessage(
+  documentSave: FactoryDocumentSaveState,
+  saveMutationError: Pick<CurrentFactoryDefinitionError, "code" | "message"> | null,
+): string {
+  if (saveMutationError?.code === "STALE_FACTORY_VERSION") {
+    return saveMutationError.message;
+  }
+
+  if (documentSave.status === "warning") {
+    return documentSave.message;
+  }
+
+  return saveMutationError?.message ?? "";
+}

--- a/ui/src/features/current-selection/base/messages/current-selection-save-toast.ts
+++ b/ui/src/features/current-selection/base/messages/current-selection-save-toast.ts
@@ -1,0 +1,119 @@
+import {
+  type LocalizedMessages,
+  resolveLocalizedMessages,
+} from "../../../../i18n";
+import type { CurrentSelectionSaveEntityKind } from "../../../notifications/lib/save-notification-delivery-policy";
+
+export interface CurrentSelectionSaveToastCatalogMessages {
+  resourceSaveFailedTitle: string;
+  resourceSaveSuccessTitle: string;
+  saveFailedAffectedSummary: (labels: string) => string;
+  workStateSaveFailedTitle: string;
+  workStateSaveSuccessTitle: string;
+  workTypeSaveFailedTitle: string;
+  workTypeSaveSuccessTitle: string;
+  workerSaveFailedTitle: string;
+  workerSaveSuccessTitle: string;
+  workstationSaveFailedTitle: string;
+  workstationSaveSuccessTitle: string;
+}
+
+const currentSelectionSaveToastMessagesByLocale = {
+  en: {
+    resourceSaveFailedTitle: "Resource save failed",
+    resourceSaveSuccessTitle: "Resource saved",
+    saveFailedAffectedSummary: (labels: string) => `Affected: ${labels}`,
+    workStateSaveFailedTitle: "Work state save failed",
+    workStateSaveSuccessTitle: "Work state saved",
+    workTypeSaveFailedTitle: "Work type save failed",
+    workTypeSaveSuccessTitle: "Work type saved",
+    workerSaveFailedTitle: "Worker save failed",
+    workerSaveSuccessTitle: "Worker saved",
+    workstationSaveFailedTitle: "Workstation save failed",
+    workstationSaveSuccessTitle: "Workstation saved",
+  },
+  "zh-CN": {
+    resourceSaveFailedTitle: "资源保存失败",
+    resourceSaveSuccessTitle: "资源已保存",
+    saveFailedAffectedSummary: (labels: string) => `受影响项：${labels}`,
+    workStateSaveFailedTitle: "工作状态保存失败",
+    workStateSaveSuccessTitle: "工作状态已保存",
+    workTypeSaveFailedTitle: "工作类型保存失败",
+    workTypeSaveSuccessTitle: "工作类型已保存",
+    workerSaveFailedTitle: "工作者保存失败",
+    workerSaveSuccessTitle: "工作者已保存",
+    workstationSaveFailedTitle: "工位保存失败",
+    workstationSaveSuccessTitle: "工位已保存",
+  },
+  ko: {
+    resourceSaveFailedTitle: "리소스 저장 실패",
+    resourceSaveSuccessTitle: "리소스 저장됨",
+    saveFailedAffectedSummary: (labels: string) => `영향 대상: ${labels}`,
+    workStateSaveFailedTitle: "작업 상태 저장 실패",
+    workStateSaveSuccessTitle: "작업 상태 저장됨",
+    workTypeSaveFailedTitle: "작업 유형 저장 실패",
+    workTypeSaveSuccessTitle: "작업 유형 저장됨",
+    workerSaveFailedTitle: "워커 저장 실패",
+    workerSaveSuccessTitle: "워커 저장됨",
+    workstationSaveFailedTitle: "워크스테이션 저장 실패",
+    workstationSaveSuccessTitle: "워크스테이션 저장됨",
+  },
+  ja: {
+    resourceSaveFailedTitle: "リソースの保存に失敗しました",
+    resourceSaveSuccessTitle: "リソースを保存しました",
+    saveFailedAffectedSummary: (labels: string) => `影響対象: ${labels}`,
+    workStateSaveFailedTitle: "作業状態の保存に失敗しました",
+    workStateSaveSuccessTitle: "作業状態を保存しました",
+    workTypeSaveFailedTitle: "作業タイプの保存に失敗しました",
+    workTypeSaveSuccessTitle: "作業タイプを保存しました",
+    workerSaveFailedTitle: "ワーカーの保存に失敗しました",
+    workerSaveSuccessTitle: "ワーカーを保存しました",
+    workstationSaveFailedTitle: "ワークステーションの保存に失敗しました",
+    workstationSaveSuccessTitle: "ワークステーションを保存しました",
+  },
+} satisfies LocalizedMessages<CurrentSelectionSaveToastCatalogMessages>;
+
+export function getCurrentSelectionSaveToastCatalogMessages(
+  locale?: string | null,
+): CurrentSelectionSaveToastCatalogMessages {
+  return resolveLocalizedMessages(
+    currentSelectionSaveToastMessagesByLocale,
+    locale,
+  );
+}
+
+export function resolveCurrentSelectionSaveToastTitles(
+  catalog: CurrentSelectionSaveToastCatalogMessages,
+  entityKind: CurrentSelectionSaveEntityKind,
+): {
+  saveFailedTitle: string;
+  saveSuccessTitle: string;
+} {
+  switch (entityKind) {
+    case "workstation":
+      return {
+        saveFailedTitle: catalog.workstationSaveFailedTitle,
+        saveSuccessTitle: catalog.workstationSaveSuccessTitle,
+      };
+    case "worker":
+      return {
+        saveFailedTitle: catalog.workerSaveFailedTitle,
+        saveSuccessTitle: catalog.workerSaveSuccessTitle,
+      };
+    case "resource":
+      return {
+        saveFailedTitle: catalog.resourceSaveFailedTitle,
+        saveSuccessTitle: catalog.resourceSaveSuccessTitle,
+      };
+    case "work-type":
+      return {
+        saveFailedTitle: catalog.workTypeSaveFailedTitle,
+        saveSuccessTitle: catalog.workTypeSaveSuccessTitle,
+      };
+    case "work-state":
+      return {
+        saveFailedTitle: catalog.workStateSaveFailedTitle,
+        saveSuccessTitle: catalog.workStateSaveSuccessTitle,
+      };
+  }
+}

--- a/ui/src/features/current-selection/base/public/index.ts
+++ b/ui/src/features/current-selection/base/public/index.ts
@@ -1,16 +1,20 @@
-export * from "../state/selection-types";
-export * from "../state/dashboardSelection";
-export * from "../state/dashboardStatePlaces";
-export * from "../state/selectionHistoryStore";
-
-export * from "../messages/current-selection-detail";
-export * from "../messages/current-selection-shell";
-export * from "../messages/current-selection-operational-enums";
-export * from "../messages/current-selection-dispatch-history";
-
-export * from "../components/current-selection-locale";
+export {
+  type FactoryDocumentSaveInput,
+  useFactoryDocumentSave,
+} from "../../../current-factory-definition/hooks/useFactoryDocumentSave";
 export * from "../components/current-selection-detail-layout";
 export * from "../components/current-selection-header-actions";
+export * from "../components/current-selection-locale";
+export {
+  CurrentSelectionSaveNotifications,
+  type CurrentSelectionSaveNotificationsProps,
+} from "../components/current-selection-save-notifications";
+export {
+  DetailCardFactorySaveFeedback,
+  type DetailCardFactorySaveFeedbackMessages,
+  type DetailCardFactorySaveFeedbackProps,
+  mergeDetailCardSaveFieldErrors,
+} from "../components/detail-card-factory-save-feedback";
 export * from "../components/detail-card-shared";
 export * from "../components/detail-card-types";
 export {
@@ -22,23 +26,20 @@ export {
   getEditableConfigurationControlsMessages,
   type EditableConfigurationControlsMessages,
 } from "../messages/editable-configuration-controls";
-export {
-  DetailCardFactorySaveFeedback,
-  mergeDetailCardSaveFieldErrors,
-  type DetailCardFactorySaveFeedbackMessages,
-  type DetailCardFactorySaveFeedbackProps,
-} from "../components/detail-card-factory-save-feedback";
 export { NoSelectionDetailCard } from "../components/no-selection-detail-card";
-
 export * from "../hooks/detail-card-save-types";
 export type { FactoryDocumentSaveState } from "../hooks/factory-document-save-types";
 export {
-  useFactoryDocumentSave,
-  type FactoryDocumentSaveInput,
-} from "../../../current-factory-definition/hooks/useFactoryDocumentSave";
-export {
-  useScopedFactoryDocumentSave,
   type ScopedFactoryDocumentSaveRequest,
   type UseScopedFactoryDocumentSaveOptions,
   type UseScopedFactoryDocumentSaveResult,
+  useScopedFactoryDocumentSave,
 } from "../hooks/useScopedFactoryDocumentSave";
+export * from "../messages/current-selection-detail";
+export * from "../messages/current-selection-dispatch-history";
+export * from "../messages/current-selection-operational-enums";
+export * from "../messages/current-selection-shell";
+export * from "../state/dashboardSelection";
+export * from "../state/dashboardStatePlaces";
+export * from "../state/selection-types";
+export * from "../state/selectionHistoryStore";

--- a/ui/src/features/current-selection/components/current-selection-widget-save-notifications.tsx
+++ b/ui/src/features/current-selection/components/current-selection-widget-save-notifications.tsx
@@ -1,0 +1,220 @@
+import { buildCurrentSelectionSaveToastMessages } from "../base/lib/build-current-selection-save-toast-messages";
+import { CurrentSelectionSaveNotifications } from "../base/public";
+import type { DashboardSelection } from "../base/state/selection-types";
+import type { CurrentSelectionState } from "../hooks/useCurrentSelection";
+import type { useEditableResourceConfigurationState } from "../resource-selection/hooks/use-editable-resource-configuration-state";
+import type { useEditableWorkStateConfigurationState } from "../work-state-selection/hooks/use-editable-work-state-configuration-state";
+import type { useEditableWorkTypeConfigurationState } from "../work-type-selection/hooks/use-editable-work-type-configuration-state";
+import type { useEditableWorkerConfigurationState } from "../worker-selection/hooks/use-editable-worker-configuration-state";
+import type { useEditableWorkstationConfigurationState } from "../workstation-selection/hooks/use-editable-workstation-configuration-state";
+import type { useCurrentSelectionDetailSave } from "./use-current-selection-detail-save";
+
+function hasEditableDraftChanges(
+  editableState: { status: string; isDirty?: boolean } | null | undefined,
+): boolean {
+  return editableState?.status === "ready" && editableState.isDirty === true;
+}
+
+function resolveEditableDisplayName({
+  draftName,
+  fallbackName,
+  editableState,
+}: {
+  draftName: string;
+  fallbackName: string;
+  editableState: { status: "ready" } | { status: string } | null | undefined;
+}): string {
+  if (editableState?.status !== "ready") {
+    return fallbackName;
+  }
+  return draftName.trim() || fallbackName;
+}
+
+export type CurrentSelectionWidgetSaveNotificationsProps = {
+  editableConfigurationState: ReturnType<
+    typeof useEditableWorkstationConfigurationState
+  >;
+  editableResourceConfigurationState: ReturnType<
+    typeof useEditableResourceConfigurationState
+  >;
+  editableWorkStateConfigurationState: ReturnType<
+    typeof useEditableWorkStateConfigurationState
+  >;
+  editableWorkerConfigurationState: ReturnType<
+    typeof useEditableWorkerConfigurationState
+  >;
+  editableWorkTypeConfigurationState: ReturnType<
+    typeof useEditableWorkTypeConfigurationState
+  >;
+  locale?: string;
+  resourceSave: ReturnType<
+    typeof useCurrentSelectionDetailSave
+  >["resourceSave"];
+  resourceSaveState: ReturnType<
+    typeof useCurrentSelectionDetailSave
+  >["resourceSaveState"];
+  selectedNode: CurrentSelectionState["selectedNode"];
+  selectedResourceName: string | null;
+  selectedWorkerName: string | null;
+  selectedWorkTypeName: string | null;
+  selection: DashboardSelection | null;
+  workStatePlaceId: string | null;
+  workStateSave: ReturnType<
+    typeof useCurrentSelectionDetailSave
+  >["workStateSave"];
+  workerSave: ReturnType<typeof useCurrentSelectionDetailSave>["workerSave"];
+  workerSaveState: ReturnType<
+    typeof useCurrentSelectionDetailSave
+  >["workerSaveState"];
+  workstationSave: ReturnType<
+    typeof useCurrentSelectionDetailSave
+  >["workstationSave"];
+  workstationSaveState: ReturnType<
+    typeof useCurrentSelectionDetailSave
+  >["workstationSaveState"];
+  workTypeSave: ReturnType<
+    typeof useCurrentSelectionDetailSave
+  >["workTypeSave"];
+};
+
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: one mount surface wires all five editable entity save toasts.
+export function CurrentSelectionWidgetSaveNotifications({
+  editableConfigurationState,
+  editableResourceConfigurationState,
+  editableWorkStateConfigurationState,
+  editableWorkerConfigurationState,
+  editableWorkTypeConfigurationState,
+  locale,
+  resourceSave,
+  resourceSaveState,
+  selectedNode,
+  selectedResourceName,
+  selectedWorkerName,
+  selectedWorkTypeName,
+  selection,
+  workStatePlaceId,
+  workStateSave,
+  workerSave,
+  workerSaveState,
+  workstationSave,
+  workstationSaveState,
+  workTypeSave,
+}: CurrentSelectionWidgetSaveNotificationsProps) {
+  const workerDisplayName = resolveEditableDisplayName({
+    draftName:
+      editableWorkerConfigurationState?.status === "ready"
+        ? editableWorkerConfigurationState.draft.name
+        : "",
+    editableState: editableWorkerConfigurationState,
+    fallbackName: selectedWorkerName ?? "",
+  });
+  const resourceDisplayName = resolveEditableDisplayName({
+    draftName:
+      editableResourceConfigurationState?.status === "ready"
+        ? editableResourceConfigurationState.draft.name
+        : "",
+    editableState: editableResourceConfigurationState,
+    fallbackName: selectedResourceName ?? "",
+  });
+  const workTypeDisplayName = resolveEditableDisplayName({
+    draftName:
+      editableWorkTypeConfigurationState?.status === "ready"
+        ? editableWorkTypeConfigurationState.draft.name
+        : "",
+    editableState: editableWorkTypeConfigurationState,
+    fallbackName: selectedWorkTypeName ?? "",
+  });
+  const workStateDisplayName =
+    editableWorkStateConfigurationState?.status === "ready"
+      ? editableWorkStateConfigurationState.draft.name.trim() ||
+        editableWorkStateConfigurationState.originalStateName
+      : (workStatePlaceId ?? "");
+
+  return (
+    <>
+      {selectedNode ? (
+        <CurrentSelectionSaveNotifications
+          documentSave={workstationSaveState}
+          entityKind="workstation"
+          hasDraftChanges={hasEditableDraftChanges(editableConfigurationState)}
+          locale={locale}
+          messages={buildCurrentSelectionSaveToastMessages({
+            entityDisplayName: selectedNode.workstation_name,
+            entityKind: "workstation",
+            locale,
+          })}
+          saveAttemptRevision={workstationSave.saveAttemptRevision}
+          saveMutationError={workstationSave.saveMutationError}
+        />
+      ) : null}
+      {selection?.kind === "worker" && selectedWorkerName ? (
+        <CurrentSelectionSaveNotifications
+          documentSave={workerSaveState}
+          entityKind="worker"
+          hasDraftChanges={hasEditableDraftChanges(
+            editableWorkerConfigurationState,
+          )}
+          locale={locale}
+          messages={buildCurrentSelectionSaveToastMessages({
+            entityDisplayName: workerDisplayName,
+            entityKind: "worker",
+            locale,
+          })}
+          saveAttemptRevision={workerSave.saveAttemptRevision}
+          saveMutationError={workerSave.saveMutationError}
+        />
+      ) : null}
+      {selection?.kind === "resource" && selectedResourceName ? (
+        <CurrentSelectionSaveNotifications
+          documentSave={resourceSaveState}
+          entityKind="resource"
+          hasDraftChanges={hasEditableDraftChanges(
+            editableResourceConfigurationState,
+          )}
+          locale={locale}
+          messages={buildCurrentSelectionSaveToastMessages({
+            entityDisplayName: resourceDisplayName,
+            entityKind: "resource",
+            locale,
+          })}
+          saveAttemptRevision={resourceSave.saveAttemptRevision}
+          saveMutationError={resourceSave.saveMutationError}
+        />
+      ) : null}
+      {selection?.kind === "work-type" && selectedWorkTypeName ? (
+        <CurrentSelectionSaveNotifications
+          documentSave={workTypeSave.saveState}
+          entityKind="work-type"
+          hasDraftChanges={hasEditableDraftChanges(
+            editableWorkTypeConfigurationState,
+          )}
+          locale={locale}
+          messages={buildCurrentSelectionSaveToastMessages({
+            entityDisplayName: workTypeDisplayName,
+            entityKind: "work-type",
+            locale,
+          })}
+          saveAttemptRevision={workTypeSave.saveAttemptRevision}
+          saveMutationError={workTypeSave.saveMutationError}
+        />
+      ) : null}
+      {selection?.kind === "state-node" && workStatePlaceId ? (
+        <CurrentSelectionSaveNotifications
+          documentSave={workStateSave.saveState}
+          entityKind="work-state"
+          hasDraftChanges={hasEditableDraftChanges(
+            editableWorkStateConfigurationState,
+          )}
+          locale={locale}
+          messages={buildCurrentSelectionSaveToastMessages({
+            entityDisplayName: workStateDisplayName,
+            entityKind: "work-state",
+            locale,
+          })}
+          saveAttemptRevision={workStateSave.saveAttemptRevision}
+          saveMutationError={workStateSave.saveMutationError}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/ui/src/features/current-selection/components/current-selection-widget.save-notifications.test.tsx
+++ b/ui/src/features/current-selection/components/current-selection-widget.save-notifications.test.tsx
@@ -1,0 +1,335 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { toast } from "sonner";
+
+import { CurrentFactoryDefinitionError } from "../../../api/current-factory-definition";
+import { semanticWorkflowDashboardSnapshot } from "../../../components/dashboard/test-fixtures";
+import { useCurrentFactoryDocument } from "../../current-factory-definition/hooks/useCurrentFactoryDefinition";
+import { useFactoryDocumentSave } from "../../current-factory-definition/hooks/useFactoryDocumentSave";
+import {
+  currentSelectionConfigurationSection,
+  expectNoInlineSaveOutcomesIn,
+  expectNoSaveToastDelivery,
+  expectResourceSaveFailedToast,
+  expectResourceSaveSuccessToast,
+  expectWorkerSaveSuccessToast,
+  expectWorkstationSaveFailedToast,
+} from "../base/components/current-selection-save-toast-test-helpers";
+import {
+  buildDetailCardEditableFactoryDocument,
+  buildDetailCardFactoryDocumentQueryResult,
+  buildDetailCardFactoryDocumentSaveHookReturn,
+  buildDetailCardMultiResourceFactoryDocument,
+  expandDetailCardResourceConfiguration,
+  expandDetailCardWorkstationConfiguration,
+} from "../base/components/detail-card-save-test-helpers";
+import {
+  buildDetailCardCurrentSelection,
+  clickWorkstationSave,
+  createDetailCardDeferredFactoryDocumentSave,
+} from "../base/components/detail-card-test-helpers";
+import { resetSelectionHistoryStore } from "../state/selectionHistoryStore";
+import { useCurrentWorkstationPromptTemplateValidation } from "../workstation-selection/hooks/useCurrentWorkstationPromptTemplateValidation";
+import { CurrentSelectionWidget } from "./current-selection-widget";
+import {
+  createCurrentSelectionWidgetQueryClient,
+  renderWithExistingQueryClient,
+  renderWithQueryClient,
+} from "./current-selection-widget-test-utils";
+
+const saveCurrentFactoryMutation = vi.fn();
+
+vi.mock("sonner", () => ({
+  toast: {
+    dismiss: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+vi.mock(
+  "../../current-factory-definition/hooks/useCurrentFactoryDefinition",
+  async () => {
+    const actual = await vi.importActual(
+      "../../current-factory-definition/hooks/useCurrentFactoryDefinition",
+    );
+
+    return {
+      ...actual,
+      useCurrentFactoryDocument: vi.fn(),
+    };
+  },
+);
+
+vi.mock(
+  "../../current-factory-definition/hooks/useFactoryDocumentSave",
+  () => ({
+    useFactoryDocumentSave: vi.fn(),
+  }),
+);
+
+vi.mock(
+  "../workstation-selection/hooks/useCurrentWorkstationPromptTemplateValidation",
+  () => ({
+    useCurrentWorkstationPromptTemplateValidation: vi.fn(),
+  }),
+);
+
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: cross-entity save notification regressions share one mocked save seam.
+describe("CurrentSelectionWidget save notification delivery", () => {
+  beforeEach(() => {
+    resetSelectionHistoryStore();
+    saveCurrentFactoryMutation.mockReset();
+    vi.mocked(toast.success).mockClear();
+    vi.mocked(toast.error).mockClear();
+    vi.mocked(toast.warning).mockClear();
+    vi.mocked(useCurrentWorkstationPromptTemplateValidation).mockReturnValue({
+      data: {
+        diagnostics: [],
+        valid: true,
+      },
+      error: null,
+      isError: false,
+      isPending: false,
+      isSuccess: true,
+      status: "success",
+    } as never);
+  });
+
+  afterEach(() => {
+    resetSelectionHistoryStore();
+  });
+
+  it("shows a worker success toast without inline save outcome copy", async () => {
+    vi.mocked(useCurrentFactoryDocument).mockReturnValue(
+      buildDetailCardFactoryDocumentQueryResult(
+        buildDetailCardEditableFactoryDocument(),
+      ),
+    );
+    vi.mocked(useFactoryDocumentSave).mockReturnValue(
+      buildDetailCardFactoryDocumentSaveHookReturn(
+        saveCurrentFactoryMutation,
+      ) as never,
+    );
+    saveCurrentFactoryMutation.mockResolvedValue(
+      buildDetailCardEditableFactoryDocument({ model: "gpt-5.9" }),
+    );
+
+    renderWithQueryClient(
+      <CurrentSelectionWidget
+        currentSelection={buildDetailCardCurrentSelection({
+          selectedWorkerName: "reviewer",
+          selection: { kind: "worker", workerName: "reviewer" },
+        })}
+        now={Date.parse("2026-04-08T12:00:04Z")}
+        selectedWorkExecutionDetails={null}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Model"), {
+      target: { value: "gpt-5.9" },
+    });
+    const saveWorkerButtons = screen.getAllByRole("button", {
+      name: "Save worker",
+    });
+    fireEvent.click(
+      saveWorkerButtons[saveWorkerButtons.length - 1] ?? saveWorkerButtons[0],
+    );
+
+    await expectWorkerSaveSuccessToast("reviewer");
+    expectNoInlineSaveOutcomesIn(
+      currentSelectionConfigurationSection("Worker configuration"),
+    );
+  });
+
+  it("shows a resource success toast without inline save outcome copy", async () => {
+    vi.mocked(useCurrentFactoryDocument).mockReturnValue(
+      buildDetailCardFactoryDocumentQueryResult(
+        buildDetailCardMultiResourceFactoryDocument(),
+      ),
+    );
+    vi.mocked(useFactoryDocumentSave).mockReturnValue(
+      buildDetailCardFactoryDocumentSaveHookReturn(
+        saveCurrentFactoryMutation,
+      ) as never,
+    );
+    saveCurrentFactoryMutation.mockResolvedValue({
+      ...buildDetailCardMultiResourceFactoryDocument(),
+      resources: [
+        {
+          capacity: 4,
+          name: "agent-slot",
+          type: "INVOCATION_SLOT",
+        },
+        {
+          capacity: 5,
+          model: "gpt-audio",
+          name: "voice-model",
+          type: "MODEL",
+        },
+      ],
+    });
+
+    renderWithQueryClient(
+      <CurrentSelectionWidget
+        currentSelection={buildDetailCardCurrentSelection({
+          selectedResourceName: "agent-slot",
+          selection: { kind: "resource", resourceName: "agent-slot" },
+        })}
+        now={Date.parse("2026-04-08T12:00:04Z")}
+        selectedWorkExecutionDetails={null}
+      />,
+    );
+
+    expandDetailCardResourceConfiguration();
+    fireEvent.change(screen.getByLabelText("Capacity"), {
+      target: { value: "4" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save resource" }));
+
+    await expectResourceSaveSuccessToast("agent-slot");
+    expectNoInlineSaveOutcomesIn(
+      currentSelectionConfigurationSection("Resource configuration"),
+    );
+  });
+
+  it("shows a persistent error toast without inline save failure copy", async () => {
+    vi.mocked(useCurrentFactoryDocument).mockReturnValue(
+      buildDetailCardFactoryDocumentQueryResult(
+        buildDetailCardMultiResourceFactoryDocument(),
+      ),
+    );
+    vi.mocked(useFactoryDocumentSave).mockReturnValue(
+      buildDetailCardFactoryDocumentSaveHookReturn(
+        saveCurrentFactoryMutation,
+      ) as never,
+    );
+    saveCurrentFactoryMutation.mockRejectedValue(
+      new CurrentFactoryDefinitionError(
+        "Current factory runtime must be idle before activation.",
+        { code: "FACTORY_NOT_IDLE" },
+      ),
+    );
+
+    renderWithQueryClient(
+      <CurrentSelectionWidget
+        currentSelection={buildDetailCardCurrentSelection({
+          selectedResourceName: "agent-slot",
+          selection: { kind: "resource", resourceName: "agent-slot" },
+        })}
+        now={Date.parse("2026-04-08T12:00:04Z")}
+        selectedWorkExecutionDetails={null}
+      />,
+    );
+
+    expandDetailCardResourceConfiguration();
+    fireEvent.change(screen.getByLabelText("Capacity"), {
+      target: { value: "9" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save resource" }));
+
+    await expectResourceSaveFailedToast(
+      "Current factory runtime must be idle before activation.",
+    );
+    expectNoInlineSaveOutcomesIn(
+      currentSelectionConfigurationSection("Resource configuration"),
+    );
+  });
+
+  it("does not replay a workstation success toast after switching selection", async () => {
+    const selectedNode =
+      semanticWorkflowDashboardSnapshot.topology.workstation_nodes_by_id.review;
+    const deferredSave = createDetailCardDeferredFactoryDocumentSave();
+    const queryClient = createCurrentSelectionWidgetQueryClient();
+    vi.mocked(useCurrentFactoryDocument).mockReturnValue(
+      buildDetailCardFactoryDocumentQueryResult(
+        buildDetailCardEditableFactoryDocument(),
+      ),
+    );
+    vi.mocked(useFactoryDocumentSave).mockReturnValue(
+      buildDetailCardFactoryDocumentSaveHookReturn(
+        saveCurrentFactoryMutation,
+      ) as never,
+    );
+    saveCurrentFactoryMutation.mockReturnValue(deferredSave.promise);
+
+    const { rerender } = renderWithExistingQueryClient(
+      queryClient,
+      <CurrentSelectionWidget
+        currentSelection={buildDetailCardCurrentSelection({
+          selectedNode,
+          selection: { kind: "node", nodeId: selectedNode.node_id },
+        })}
+        now={Date.parse("2026-04-08T12:00:04Z")}
+        selectedWorkExecutionDetails={null}
+      />,
+    );
+
+    expandDetailCardWorkstationConfiguration();
+    fireEvent.change(screen.getByLabelText("Prompt"), {
+      target: { value: "Deferred workstation save." },
+    });
+    clickWorkstationSave();
+    fireEvent.click(screen.getByRole("button", { name: "Overwrite factory" }));
+
+    rerender(
+      <CurrentSelectionWidget
+        currentSelection={buildDetailCardCurrentSelection({
+          selectedWorkerName: "reviewer",
+          selection: { kind: "worker", workerName: "reviewer" },
+        })}
+        now={Date.parse("2026-04-08T12:00:04Z")}
+        selectedWorkExecutionDetails={null}
+      />,
+    );
+
+    deferredSave.resolve(
+      buildDetailCardEditableFactoryDocument({
+        prompt: "Deferred workstation save.",
+      }),
+    );
+
+    await expectNoSaveToastDelivery();
+    expectNoInlineSaveOutcomesIn(
+      currentSelectionConfigurationSection("Worker configuration"),
+    );
+  });
+
+  it("shows a workstation failure toast without inline save failure copy", async () => {
+    const selectedNode =
+      semanticWorkflowDashboardSnapshot.topology.workstation_nodes_by_id.review;
+    vi.mocked(useCurrentFactoryDocument).mockReturnValue(
+      buildDetailCardFactoryDocumentQueryResult(
+        buildDetailCardEditableFactoryDocument(),
+      ),
+    );
+    vi.mocked(useFactoryDocumentSave).mockReturnValue(
+      buildDetailCardFactoryDocumentSaveHookReturn(
+        saveCurrentFactoryMutation,
+      ) as never,
+    );
+    saveCurrentFactoryMutation.mockRejectedValue(new Error("Network dropped"));
+
+    renderWithQueryClient(
+      <CurrentSelectionWidget
+        currentSelection={buildDetailCardCurrentSelection({
+          selectedNode,
+          selection: { kind: "node", nodeId: selectedNode.node_id },
+        })}
+        now={Date.parse("2026-04-08T12:00:04Z")}
+        selectedWorkExecutionDetails={null}
+      />,
+    );
+    expandDetailCardWorkstationConfiguration();
+    fireEvent.change(screen.getByLabelText("Prompt"), {
+      target: { value: "Keep this draft through a generic failure." },
+    });
+    clickWorkstationSave();
+    fireEvent.click(screen.getByRole("button", { name: "Overwrite factory" }));
+
+    await expectWorkstationSaveFailedToast("Network dropped");
+    expectNoInlineSaveOutcomesIn(
+      currentSelectionConfigurationSection("Configuration"),
+    );
+  });
+});

--- a/ui/src/features/current-selection/components/current-selection-widget.save.test.tsx
+++ b/ui/src/features/current-selection/components/current-selection-widget.save.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { toast } from "sonner";
 
 import {
   CurrentFactoryDefinitionError,
@@ -12,6 +13,14 @@ import {
   buildDetailCardMultiResourceFactoryDocument,
   expandDetailCardResourceConfiguration,
 } from "../base/components/detail-card-save-test-helpers";
+import {
+  expectWorkStateSaveSuccessToast,
+  expectWorkstationSaveFailedToast,
+  expectWorkstationSaveSuccessToast,
+  expectWorkstationStaleSaveWarningToast,
+  expectWorkerSaveSuccessToast,
+  WORKSTATION_SAVE_SUCCESS_DESCRIPTION,
+} from "../base/components/current-selection-save-toast-test-helpers";
 import {
   buildDetailCardCurrentSelection,
   buildDetailCardEditableFactoryDocument,
@@ -37,6 +46,15 @@ import {
 } from "./current-selection-widget-test-utils";
 
 const saveCurrentFactoryMutation = vi.fn();
+
+vi.mock("sonner", () => ({
+  toast: {
+    dismiss: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
 
 vi.mock(
   "../../current-factory-definition/hooks/useCurrentFactoryDefinition",
@@ -71,6 +89,9 @@ describe("CurrentSelectionWidget workstation save flow", () => {
   beforeEach(() => {
     resetSelectionHistoryStore();
     saveCurrentFactoryMutation.mockReset();
+    vi.mocked(toast.success).mockClear();
+    vi.mocked(toast.error).mockClear();
+    vi.mocked(toast.warning).mockClear();
     vi.mocked(useCurrentFactoryDocument).mockReturnValue(
       buildDetailCardFactoryDocumentQueryResult(
         buildDetailCardEditableFactoryDocument(),
@@ -263,13 +284,7 @@ describe("CurrentSelectionWidget workstation save flow", () => {
         }),
       );
     });
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          "Running factory saved. The editable workstation values were refreshed to the saved definition.",
-        ),
-      ).toBeTruthy();
-    });
+    await expectWorkstationSaveSuccessToast();
 
     expect((screen.getByLabelText("Prompt") as HTMLTextAreaElement).value).toBe(
       "Review the diff and verify browser behavior.",
@@ -298,13 +313,9 @@ describe("CurrentSelectionWidget workstation save flow", () => {
     clickWorkstationSave();
     fireEvent.click(screen.getByRole("button", { name: "Overwrite factory" }));
 
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          "Saving failed. Current factory runtime must be idle before activation.",
-        ),
-      ).toBeTruthy();
-    });
+    await expectWorkstationSaveFailedToast(
+      "Current factory runtime must be idle before activation.",
+    );
 
     expect((screen.getByLabelText("Prompt") as HTMLTextAreaElement).value).toBe(
       "Keep this draft while the save fails.",
@@ -326,9 +337,7 @@ describe("CurrentSelectionWidget workstation save flow", () => {
     clickWorkstationSave();
     fireEvent.click(screen.getByRole("button", { name: "Overwrite factory" }));
 
-    await waitFor(() => {
-      expect(screen.getByText("Saving failed. Network dropped")).toBeTruthy();
-    });
+    await expectWorkstationSaveFailedToast("Network dropped");
 
     expect((screen.getByLabelText("Prompt") as HTMLTextAreaElement).value).toBe(
       "Keep this draft through a generic failure.",
@@ -356,18 +365,9 @@ describe("CurrentSelectionWidget workstation save flow", () => {
     clickWorkstationSave();
     fireEvent.click(screen.getByRole("button", { name: "Overwrite factory" }));
 
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          "Current factory definition is stale. Refresh the dashboard before saving or importing again.",
-        ),
-      ).toBeTruthy();
-    });
-    expect(
-      screen.getByText(
-        "Reload the latest running-factory values or keep this draft and retry after the editor refreshes.",
-      ),
-    ).toBeTruthy();
+    await expectWorkstationStaleSaveWarningToast(
+      "Current factory definition is stale. Refresh the dashboard before saving or importing again.",
+    );
     expect((screen.getByLabelText("Prompt") as HTMLTextAreaElement).value).toBe(
       "Keep this draft through a stale write.",
     );
@@ -408,13 +408,9 @@ describe("CurrentSelectionWidget workstation save flow", () => {
     clickWorkstationSave();
     fireEvent.click(screen.getByRole("button", { name: "Overwrite factory" }));
 
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          "Saving failed. Worker selection must reference a configured worker.",
-        ),
-      ).toBeTruthy();
-    });
+    await expectWorkstationSaveFailedToast(
+      "Worker selection must reference a configured worker.",
+    );
     expect(screen.getByLabelText("Worker").getAttribute("aria-invalid")).toBe(
       "true",
     );
@@ -753,13 +749,7 @@ describe("CurrentSelectionWidget workstation save flow", () => {
     clickWorkstationSave();
     fireEvent.click(screen.getByRole("button", { name: "Overwrite factory" }));
 
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          "Running factory saved. The editable workstation values were refreshed to the saved definition.",
-        ),
-      ).toBeTruthy();
-    });
+    await expectWorkstationSaveSuccessToast();
 
     vi.mocked(useCurrentFactoryDocument).mockReturnValue(
       buildDetailCardFactoryDocumentQueryResult(savedFactory),
@@ -845,13 +835,7 @@ describe("CurrentSelectionWidget workstation save flow", () => {
       }),
     );
 
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          "Running factory saved. The editable workstation values were refreshed to the saved definition.",
-        ),
-      ).toBeTruthy();
-    });
+    await expectWorkstationSaveSuccessToast();
   });
 
   it("clears saved feedback after switching to another workstation and returning", async () => {
@@ -889,13 +873,7 @@ describe("CurrentSelectionWidget workstation save flow", () => {
     clickWorkstationSave();
     fireEvent.click(screen.getByRole("button", { name: "Overwrite factory" }));
 
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          "Running factory saved. The editable workstation values were refreshed to the saved definition.",
-        ),
-      ).toBeTruthy();
-    });
+    await expectWorkstationSaveSuccessToast();
 
     vi.mocked(useCurrentFactoryDocument).mockReturnValue(
       buildDetailCardFactoryDocumentQueryResult(savedFactory),
@@ -1061,13 +1039,9 @@ describe("CurrentSelectionWidget workstation save flow", () => {
     clickWorkstationSave();
     fireEvent.click(screen.getByRole("button", { name: "Overwrite factory" }));
 
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          "Saving failed. Current factory runtime must be idle before activation.",
-        ),
-      ).toBeTruthy();
-    });
+    await expectWorkstationSaveFailedToast(
+      "Current factory runtime must be idle before activation.",
+    );
 
     rerender(
       <CurrentSelectionWidget
@@ -1145,13 +1119,9 @@ describe("CurrentSelectionWidget workstation save flow", () => {
     clickWorkstationSave();
     fireEvent.click(screen.getByRole("button", { name: "Overwrite factory" }));
 
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          "Saving failed. Current factory runtime must be idle before activation.",
-        ),
-      ).toBeTruthy();
-    });
+    await expectWorkstationSaveFailedToast(
+      "Current factory runtime must be idle before activation.",
+    );
 
     rerender(
       <CurrentSelectionWidget
@@ -1200,6 +1170,9 @@ describe("CurrentSelectionWidget resource save flow", () => {
   beforeEach(() => {
     resetSelectionHistoryStore();
     saveCurrentFactoryMutation.mockReset();
+    vi.mocked(toast.success).mockClear();
+    vi.mocked(toast.error).mockClear();
+    vi.mocked(toast.warning).mockClear();
     vi.mocked(useCurrentFactoryDocument).mockReturnValue(
       buildDetailCardFactoryDocumentQueryResult(
         buildDetailCardMultiResourceFactoryDocument(),
@@ -1422,6 +1395,9 @@ describe("CurrentSelectionWidget work state save flow", () => {
   beforeEach(() => {
     resetSelectionHistoryStore();
     saveCurrentFactoryMutation.mockReset();
+    vi.mocked(toast.success).mockClear();
+    vi.mocked(toast.error).mockClear();
+    vi.mocked(toast.warning).mockClear();
     vi.mocked(useCurrentFactoryDocument).mockReturnValue(
       buildDetailCardFactoryDocumentQueryResult(
         buildDetailCardWorkStateFactoryDocument(),
@@ -1532,13 +1508,7 @@ describe("CurrentSelectionWidget work state save flow", () => {
     await waitFor(() => {
       expect(selectStateNode).toHaveBeenCalledWith("story:ready");
     });
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          "Running factory saved. ready was updated in the running factory definition.",
-        ),
-      ).toBeTruthy();
-    });
+    await expectWorkStateSaveSuccessToast("ready");
   });
 });
 
@@ -1546,6 +1516,9 @@ describe("CurrentSelectionWidget worker save flow", () => {
   beforeEach(() => {
     resetSelectionHistoryStore();
     saveCurrentFactoryMutation.mockReset();
+    vi.mocked(toast.success).mockClear();
+    vi.mocked(toast.error).mockClear();
+    vi.mocked(toast.warning).mockClear();
     vi.mocked(useCurrentFactoryDocument).mockReturnValue(
       buildDetailCardFactoryDocumentQueryResult(
         buildDetailCardEditableFactoryDocument(),
@@ -1600,13 +1573,7 @@ describe("CurrentSelectionWidget worker save flow", () => {
         }),
       );
     });
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          "Running factory saved. reviewer was updated in the running factory definition.",
-        ),
-      ).toBeTruthy();
-    });
+    await expectWorkerSaveSuccessToast("reviewer");
     for (const saveButton of screen.getAllByRole("button", {
       name: "Save worker",
     })) {

--- a/ui/src/features/current-selection/components/current-selection-widget.save.test.tsx
+++ b/ui/src/features/current-selection/components/current-selection-widget.save.test.tsx
@@ -14,12 +14,16 @@ import {
   expandDetailCardResourceConfiguration,
 } from "../base/components/detail-card-save-test-helpers";
 import {
+  currentSelectionConfigurationSection,
+  expectNoInlineSaveOutcomesIn,
+  expectNoSaveToastDelivery,
+  expectResourceSaveFailedToast,
+  expectResourceSaveSuccessToast,
   expectWorkStateSaveSuccessToast,
   expectWorkstationSaveFailedToast,
   expectWorkstationSaveSuccessToast,
   expectWorkstationStaleSaveWarningToast,
   expectWorkerSaveSuccessToast,
-  WORKSTATION_SAVE_SUCCESS_DESCRIPTION,
 } from "../base/components/current-selection-save-toast-test-helpers";
 import {
   buildDetailCardCurrentSelection,
@@ -285,6 +289,9 @@ describe("CurrentSelectionWidget workstation save flow", () => {
       );
     });
     await expectWorkstationSaveSuccessToast();
+    expectNoInlineSaveOutcomesIn(
+      currentSelectionConfigurationSection("Configuration"),
+    );
 
     expect((screen.getByLabelText("Prompt") as HTMLTextAreaElement).value).toBe(
       "Review the diff and verify browser behavior.",
@@ -316,6 +323,9 @@ describe("CurrentSelectionWidget workstation save flow", () => {
     await expectWorkstationSaveFailedToast(
       "Current factory runtime must be idle before activation.",
     );
+    expectNoInlineSaveOutcomesIn(
+      currentSelectionConfigurationSection("Configuration"),
+    );
 
     expect((screen.getByLabelText("Prompt") as HTMLTextAreaElement).value).toBe(
       "Keep this draft while the save fails.",
@@ -338,6 +348,9 @@ describe("CurrentSelectionWidget workstation save flow", () => {
     fireEvent.click(screen.getByRole("button", { name: "Overwrite factory" }));
 
     await expectWorkstationSaveFailedToast("Network dropped");
+    expectNoInlineSaveOutcomesIn(
+      currentSelectionConfigurationSection("Configuration"),
+    );
 
     expect((screen.getByLabelText("Prompt") as HTMLTextAreaElement).value).toBe(
       "Keep this draft through a generic failure.",
@@ -367,6 +380,9 @@ describe("CurrentSelectionWidget workstation save flow", () => {
 
     await expectWorkstationStaleSaveWarningToast(
       "Current factory definition is stale. Refresh the dashboard before saving or importing again.",
+    );
+    expectNoInlineSaveOutcomesIn(
+      currentSelectionConfigurationSection("Configuration"),
     );
     expect((screen.getByLabelText("Prompt") as HTMLTextAreaElement).value).toBe(
       "Keep this draft through a stale write.",
@@ -684,12 +700,9 @@ describe("CurrentSelectionWidget workstation save flow", () => {
     expandDetailCardWorkstationConfiguration();
 
     expect(screen.getByText("Plan")).toBeTruthy();
-    expect(
-      screen.queryByText(
-        "Running factory saved. The editable workstation values were refreshed to the saved definition.",
-      ),
-    ).toBeNull();
-    expect(screen.queryByText(/^Saving failed\./)).toBeNull();
+    expectNoInlineSaveOutcomesIn(
+      currentSelectionConfigurationSection("Configuration"),
+    );
     expect((screen.getByLabelText("Prompt") as HTMLTextAreaElement).value).toBe(
       "Plan the implementation.",
     );
@@ -703,13 +716,10 @@ describe("CurrentSelectionWidget workstation save flow", () => {
       }),
     );
 
-    await waitFor(() => {
-      expect(
-        screen.queryByText(
-          "Running factory saved. The editable workstation values were refreshed to the saved definition.",
-        ),
-      ).toBeNull();
-    });
+    await expectNoSaveToastDelivery();
+    expectNoInlineSaveOutcomesIn(
+      currentSelectionConfigurationSection("Configuration"),
+    );
     expect((screen.getByLabelText("Prompt") as HTMLTextAreaElement).value).toBe(
       "Plan the implementation.",
     );
@@ -763,12 +773,6 @@ describe("CurrentSelectionWidget workstation save flow", () => {
       />,
     );
 
-    expect(
-      screen.queryByText(
-        "Running factory saved. The editable workstation values were refreshed to the saved definition.",
-      ),
-    ).toBeNull();
-
     rerender(
       <CurrentSelectionWidget
         currentSelection={buildDetailCardCurrentSelection({
@@ -782,12 +786,9 @@ describe("CurrentSelectionWidget workstation save flow", () => {
 
     expandDetailCardWorkstationConfiguration();
 
-    expect(
-      screen.queryByText(
-        "Running factory saved. The editable workstation values were refreshed to the saved definition.",
-      ),
-    ).toBeNull();
-    expect(screen.queryByText(/^Saving failed\./)).toBeNull();
+    expectNoInlineSaveOutcomesIn(
+      currentSelectionConfigurationSection("Configuration"),
+    );
     expect((screen.getByLabelText("Prompt") as HTMLTextAreaElement).value).toBe(
       "Review the saved factory before approval.",
     );
@@ -892,11 +893,9 @@ describe("CurrentSelectionWidget workstation save flow", () => {
 
     expandDetailCardWorkstationConfiguration();
 
-    expect(
-      screen.queryByText(
-        "Running factory saved. The editable workstation values were refreshed to the saved definition.",
-      ),
-    ).toBeNull();
+    expectNoInlineSaveOutcomesIn(
+      currentSelectionConfigurationSection("Configuration"),
+    );
 
     rerender(
       <CurrentSelectionWidget
@@ -911,12 +910,9 @@ describe("CurrentSelectionWidget workstation save flow", () => {
 
     expandDetailCardWorkstationConfiguration();
 
-    expect(
-      screen.queryByText(
-        "Running factory saved. The editable workstation values were refreshed to the saved definition.",
-      ),
-    ).toBeNull();
-    expect(screen.queryByText(/^Saving failed\./)).toBeNull();
+    expectNoInlineSaveOutcomesIn(
+      currentSelectionConfigurationSection("Configuration"),
+    );
     expect((screen.getByLabelText("Prompt") as HTMLTextAreaElement).value).toBe(
       "Review the saved factory before approval.",
     );
@@ -985,14 +981,10 @@ describe("CurrentSelectionWidget workstation save flow", () => {
       ),
     );
 
-    await waitFor(() => {
-      expect(screen.queryByText(/^Saving failed\./)).toBeNull();
-    });
-    expect(
-      screen.queryByText(
-        "Saving failed. Current factory runtime must be idle before activation.",
-      ),
-    ).toBeNull();
+    await expectNoSaveToastDelivery();
+    expectNoInlineSaveOutcomesIn(
+      currentSelectionConfigurationSection("Configuration"),
+    );
     expect((screen.getByLabelText("Prompt") as HTMLTextAreaElement).value).toBe(
       "Plan the implementation.",
     );
@@ -1051,8 +1043,6 @@ describe("CurrentSelectionWidget workstation save flow", () => {
       />,
     );
 
-    expect(screen.queryByText(/^Saving failed\./)).toBeNull();
-
     rerender(
       <CurrentSelectionWidget
         currentSelection={buildDetailCardCurrentSelection({
@@ -1066,12 +1056,9 @@ describe("CurrentSelectionWidget workstation save flow", () => {
 
     expandDetailCardWorkstationConfiguration();
 
-    expect(screen.queryByText(/^Saving failed\./)).toBeNull();
-    expect(
-      screen.queryByText(
-        "Saving failed. Current factory runtime must be idle before activation.",
-      ),
-    ).toBeNull();
+    expectNoInlineSaveOutcomesIn(
+      currentSelectionConfigurationSection("Configuration"),
+    );
     expect((screen.getByLabelText("Prompt") as HTMLTextAreaElement).value).toBe(
       "Review the latest story changes before approval.",
     );
@@ -1136,7 +1123,9 @@ describe("CurrentSelectionWidget workstation save flow", () => {
 
     expandDetailCardWorkstationConfiguration();
 
-    expect(screen.queryByText(/^Saving failed\./)).toBeNull();
+    expectNoInlineSaveOutcomesIn(
+      currentSelectionConfigurationSection("Configuration"),
+    );
 
     rerender(
       <CurrentSelectionWidget
@@ -1151,12 +1140,9 @@ describe("CurrentSelectionWidget workstation save flow", () => {
 
     expandDetailCardWorkstationConfiguration();
 
-    expect(screen.queryByText(/^Saving failed\./)).toBeNull();
-    expect(
-      screen.queryByText(
-        "Saving failed. Current factory runtime must be idle before activation.",
-      ),
-    ).toBeNull();
+    expectNoInlineSaveOutcomesIn(
+      currentSelectionConfigurationSection("Configuration"),
+    );
     expect((screen.getByLabelText("Prompt") as HTMLTextAreaElement).value).toBe(
       "Review the latest story changes before approval.",
     );
@@ -1245,12 +1231,9 @@ describe("CurrentSelectionWidget resource save flow", () => {
     expandDetailCardResourceConfiguration();
 
     expect(screen.getByDisplayValue("5")).toBeTruthy();
-    expect(
-      screen.queryByText(
-        "Running factory saved. agent-slot was updated in the running factory definition.",
-      ),
-    ).toBeNull();
-    expect(screen.queryByText(/^Saving failed\./)).toBeNull();
+    expectNoInlineSaveOutcomesIn(
+      currentSelectionConfigurationSection("Resource configuration"),
+    );
     expect(
       screen
         .getByRole("button", { name: "Save resource" })
@@ -1274,13 +1257,10 @@ describe("CurrentSelectionWidget resource save flow", () => {
       ],
     });
 
-    await waitFor(() => {
-      expect(
-        screen.queryByText(
-          "Running factory saved. agent-slot was updated in the running factory definition.",
-        ),
-      ).toBeNull();
-    });
+    await expectNoSaveToastDelivery();
+    expectNoInlineSaveOutcomesIn(
+      currentSelectionConfigurationSection("Resource configuration"),
+    );
     expect((screen.getByLabelText("Capacity") as HTMLInputElement).value).toBe(
       "5",
     );
@@ -1336,14 +1316,10 @@ describe("CurrentSelectionWidget resource save flow", () => {
       ),
     );
 
-    await waitFor(() => {
-      expect(screen.queryByText(/^Saving failed\./)).toBeNull();
-    });
-    expect(
-      screen.queryByText(
-        "Saving failed. Current factory runtime must be idle before activation.",
-      ),
-    ).toBeNull();
+    await expectNoSaveToastDelivery();
+    expectNoInlineSaveOutcomesIn(
+      currentSelectionConfigurationSection("Resource configuration"),
+    );
     expect((screen.getByLabelText("Capacity") as HTMLInputElement).value).toBe(
       "5",
     );
@@ -1509,6 +1485,9 @@ describe("CurrentSelectionWidget work state save flow", () => {
       expect(selectStateNode).toHaveBeenCalledWith("story:ready");
     });
     await expectWorkStateSaveSuccessToast("ready");
+    expectNoInlineSaveOutcomesIn(
+      currentSelectionConfigurationSection("Work state configuration"),
+    );
   });
 });
 
@@ -1574,6 +1553,9 @@ describe("CurrentSelectionWidget worker save flow", () => {
       );
     });
     await expectWorkerSaveSuccessToast("reviewer");
+    expectNoInlineSaveOutcomesIn(
+      currentSelectionConfigurationSection("Worker configuration"),
+    );
     for (const saveButton of screen.getAllByRole("button", {
       name: "Save worker",
     })) {

--- a/ui/src/features/current-selection/components/current-selection-widget.tsx
+++ b/ui/src/features/current-selection/components/current-selection-widget.tsx
@@ -5,9 +5,11 @@ import type {
   DashboardTrace,
 } from "../../../api/dashboard/types";
 import type { LoadableProviderSessionRef } from "../../provider-session-detail/lib/provider-session-ref";
+import { buildCurrentSelectionSaveToastMessages } from "../base/lib/build-current-selection-save-toast-messages";
 import {
   CurrentSelectionHeaderActionProvider,
   CurrentSelectionLocaleProvider,
+  CurrentSelectionSaveNotifications,
 } from "../base/public";
 import type { CurrentSelectionState } from "../hooks/useCurrentSelection";
 import { useEditableResourceConfigurationState } from "../resource-selection/hooks/use-editable-resource-configuration-state";
@@ -343,6 +345,7 @@ export function CurrentSelectionWidget({
     );
   const {
     resourceHeaderAction,
+    resourceSave,
     resourceSaveState,
     saveWorkerConfiguration,
     saveWorkStateConfiguration,
@@ -350,6 +353,7 @@ export function CurrentSelectionWidget({
     workstationSave,
     workstationSaveState,
     workerHeaderAction,
+    workerSave,
     workerSaveState,
     workStateHeaderAction,
     workStateSaveState,
@@ -416,11 +420,123 @@ export function CurrentSelectionWidget({
     widgetId,
   });
 
+  const resolvedLocale = locale ?? undefined;
+  const workstationHasDraftChanges =
+    editableConfigurationState?.status === "ready" &&
+    editableConfigurationState.isDirty;
+  const workerHasDraftChanges =
+    editableWorkerConfigurationState?.status === "ready" &&
+    editableWorkerConfigurationState.isDirty;
+  const resourceHasDraftChanges =
+    editableResourceConfigurationState?.status === "ready" &&
+    editableResourceConfigurationState.isDirty;
+  const workTypeHasDraftChanges =
+    editableWorkTypeConfigurationState?.status === "ready" &&
+    editableWorkTypeConfigurationState.isDirty;
+  const workStateHasDraftChanges =
+    editableWorkStateConfigurationState?.status === "ready" &&
+    editableWorkStateConfigurationState.isDirty;
+  const workStateDisplayName =
+    editableWorkStateConfigurationState?.status === "ready"
+      ? editableWorkStateConfigurationState.draft.name.trim() ||
+        editableWorkStateConfigurationState.originalStateName
+      : workStatePlaceId ?? "";
+  const workerDisplayName =
+    editableWorkerConfigurationState?.status === "ready"
+      ? editableWorkerConfigurationState.draft.name.trim() ||
+        (selectedWorkerName ?? "")
+      : (selectedWorkerName ?? "");
+  const resourceDisplayName =
+    editableResourceConfigurationState?.status === "ready"
+      ? editableResourceConfigurationState.draft.name.trim() ||
+        (selectedResourceName ?? "")
+      : (selectedResourceName ?? "");
+  const workTypeDisplayName =
+    editableWorkTypeConfigurationState?.status === "ready"
+      ? editableWorkTypeConfigurationState.draft.name.trim() ||
+        (selectedWorkTypeName ?? "")
+      : (selectedWorkTypeName ?? "");
+
   return (
-    <CurrentSelectionLocaleProvider locale={locale ?? undefined}>
+    <CurrentSelectionLocaleProvider locale={resolvedLocale}>
       <CurrentSelectionHeaderActionProvider headerAction={headerAction ?? null}>
         {detailCard}
       </CurrentSelectionHeaderActionProvider>
+      {selectedNode ? (
+        <CurrentSelectionSaveNotifications
+          documentSave={workstationSaveState}
+          entityKind="workstation"
+          hasDraftChanges={workstationHasDraftChanges}
+          locale={resolvedLocale}
+          messages={buildCurrentSelectionSaveToastMessages({
+            entityDisplayName: selectedNode.workstation_name,
+            entityKind: "workstation",
+            locale,
+          })}
+          saveAttemptRevision={workstationSave.saveAttemptRevision}
+          saveMutationError={workstationSave.saveMutationError}
+        />
+      ) : null}
+      {selection?.kind === "worker" && selectedWorkerName ? (
+        <CurrentSelectionSaveNotifications
+          documentSave={workerSaveState}
+          entityKind="worker"
+          hasDraftChanges={workerHasDraftChanges}
+          locale={resolvedLocale}
+          messages={buildCurrentSelectionSaveToastMessages({
+            entityDisplayName: workerDisplayName,
+            entityKind: "worker",
+            locale,
+          })}
+          saveAttemptRevision={workerSave.saveAttemptRevision}
+          saveMutationError={workerSave.saveMutationError}
+        />
+      ) : null}
+      {selection?.kind === "resource" && selectedResourceName ? (
+        <CurrentSelectionSaveNotifications
+          documentSave={resourceSaveState}
+          entityKind="resource"
+          hasDraftChanges={resourceHasDraftChanges}
+          locale={resolvedLocale}
+          messages={buildCurrentSelectionSaveToastMessages({
+            entityDisplayName: resourceDisplayName,
+            entityKind: "resource",
+            locale,
+          })}
+          saveAttemptRevision={resourceSave.saveAttemptRevision}
+          saveMutationError={resourceSave.saveMutationError}
+        />
+      ) : null}
+      {selection?.kind === "work-type" && selectedWorkTypeName ? (
+        <CurrentSelectionSaveNotifications
+          documentSave={workTypeSave.saveState}
+          entityKind="work-type"
+          hasDraftChanges={workTypeHasDraftChanges}
+          locale={resolvedLocale}
+          messages={buildCurrentSelectionSaveToastMessages({
+            entityDisplayName: workTypeDisplayName,
+            entityKind: "work-type",
+            locale,
+          })}
+          saveAttemptRevision={workTypeSave.saveAttemptRevision}
+          saveMutationError={workTypeSave.saveMutationError}
+        />
+      ) : null}
+      {selection?.kind === "state-node" && workStatePlaceId ? (
+        <CurrentSelectionSaveNotifications
+          documentSave={workStateSave.saveState}
+          entityKind="work-state"
+          hasDraftChanges={workStateHasDraftChanges}
+          locale={resolvedLocale}
+          messages={buildCurrentSelectionSaveToastMessages({
+            entityDisplayName: workStateDisplayName,
+            entityKind: "work-state",
+            locale,
+          })}
+          saveAttemptRevision={workStateSave.saveAttemptRevision}
+          saveMutationError={workStateSave.saveMutationError}
+        />
+      ) : null}
       <CurrentSelectionWorkstationSaveDialog
         editableConfigurationState={editableConfigurationState}
         locale={locale}

--- a/ui/src/features/current-selection/components/current-selection-widget.tsx
+++ b/ui/src/features/current-selection/components/current-selection-widget.tsx
@@ -5,11 +5,9 @@ import type {
   DashboardTrace,
 } from "../../../api/dashboard/types";
 import type { LoadableProviderSessionRef } from "../../provider-session-detail/lib/provider-session-ref";
-import { buildCurrentSelectionSaveToastMessages } from "../base/lib/build-current-selection-save-toast-messages";
 import {
   CurrentSelectionHeaderActionProvider,
   CurrentSelectionLocaleProvider,
-  CurrentSelectionSaveNotifications,
 } from "../base/public";
 import type { CurrentSelectionState } from "../hooks/useCurrentSelection";
 import { useEditableResourceConfigurationState } from "../resource-selection/hooks/use-editable-resource-configuration-state";
@@ -32,6 +30,7 @@ import {
   WorkstationRequestDetailCard,
   WorkTypeDetailCard,
 } from "./current-selection-cards";
+import { CurrentSelectionWidgetSaveNotifications } from "./current-selection-widget-save-notifications";
 import {
   CurrentSelectionWorkstationSaveDialog,
   CurrentSelectionWorkTypeSaveDialog,
@@ -422,122 +421,36 @@ export function CurrentSelectionWidget({
   });
 
   const resolvedLocale = locale ?? undefined;
-  const workstationHasDraftChanges =
-    editableConfigurationState?.status === "ready" &&
-    editableConfigurationState.isDirty;
-  const workerHasDraftChanges =
-    editableWorkerConfigurationState?.status === "ready" &&
-    editableWorkerConfigurationState.isDirty;
-  const resourceHasDraftChanges =
-    editableResourceConfigurationState?.status === "ready" &&
-    editableResourceConfigurationState.isDirty;
-  const workTypeHasDraftChanges =
-    editableWorkTypeConfigurationState?.status === "ready" &&
-    editableWorkTypeConfigurationState.isDirty;
-  const workStateHasDraftChanges =
-    editableWorkStateConfigurationState?.status === "ready" &&
-    editableWorkStateConfigurationState.isDirty;
-  const workStateDisplayName =
-    editableWorkStateConfigurationState?.status === "ready"
-      ? editableWorkStateConfigurationState.draft.name.trim() ||
-        editableWorkStateConfigurationState.originalStateName
-      : workStatePlaceId ?? "";
-  const workerDisplayName =
-    editableWorkerConfigurationState?.status === "ready"
-      ? editableWorkerConfigurationState.draft.name.trim() ||
-        (selectedWorkerName ?? "")
-      : (selectedWorkerName ?? "");
-  const resourceDisplayName =
-    editableResourceConfigurationState?.status === "ready"
-      ? editableResourceConfigurationState.draft.name.trim() ||
-        (selectedResourceName ?? "")
-      : (selectedResourceName ?? "");
-  const workTypeDisplayName =
-    editableWorkTypeConfigurationState?.status === "ready"
-      ? editableWorkTypeConfigurationState.draft.name.trim() ||
-        (selectedWorkTypeName ?? "")
-      : (selectedWorkTypeName ?? "");
 
   return (
     <CurrentSelectionLocaleProvider locale={resolvedLocale}>
       <CurrentSelectionHeaderActionProvider headerAction={headerAction ?? null}>
         {detailCard}
       </CurrentSelectionHeaderActionProvider>
-      {selectedNode ? (
-        <CurrentSelectionSaveNotifications
-          documentSave={workstationSaveState}
-          entityKind="workstation"
-          hasDraftChanges={workstationHasDraftChanges}
-          locale={resolvedLocale}
-          messages={buildCurrentSelectionSaveToastMessages({
-            entityDisplayName: selectedNode.workstation_name,
-            entityKind: "workstation",
-            locale,
-          })}
-          saveAttemptRevision={workstationSave.saveAttemptRevision}
-          saveMutationError={workstationSave.saveMutationError}
-        />
-      ) : null}
-      {selection?.kind === "worker" && selectedWorkerName ? (
-        <CurrentSelectionSaveNotifications
-          documentSave={workerSaveState}
-          entityKind="worker"
-          hasDraftChanges={workerHasDraftChanges}
-          locale={resolvedLocale}
-          messages={buildCurrentSelectionSaveToastMessages({
-            entityDisplayName: workerDisplayName,
-            entityKind: "worker",
-            locale,
-          })}
-          saveAttemptRevision={workerSave.saveAttemptRevision}
-          saveMutationError={workerSave.saveMutationError}
-        />
-      ) : null}
-      {selection?.kind === "resource" && selectedResourceName ? (
-        <CurrentSelectionSaveNotifications
-          documentSave={resourceSaveState}
-          entityKind="resource"
-          hasDraftChanges={resourceHasDraftChanges}
-          locale={resolvedLocale}
-          messages={buildCurrentSelectionSaveToastMessages({
-            entityDisplayName: resourceDisplayName,
-            entityKind: "resource",
-            locale,
-          })}
-          saveAttemptRevision={resourceSave.saveAttemptRevision}
-          saveMutationError={resourceSave.saveMutationError}
-        />
-      ) : null}
-      {selection?.kind === "work-type" && selectedWorkTypeName ? (
-        <CurrentSelectionSaveNotifications
-          documentSave={workTypeSave.saveState}
-          entityKind="work-type"
-          hasDraftChanges={workTypeHasDraftChanges}
-          locale={resolvedLocale}
-          messages={buildCurrentSelectionSaveToastMessages({
-            entityDisplayName: workTypeDisplayName,
-            entityKind: "work-type",
-            locale,
-          })}
-          saveAttemptRevision={workTypeSave.saveAttemptRevision}
-          saveMutationError={workTypeSave.saveMutationError}
-        />
-      ) : null}
-      {selection?.kind === "state-node" && workStatePlaceId ? (
-        <CurrentSelectionSaveNotifications
-          documentSave={workStateSave.saveState}
-          entityKind="work-state"
-          hasDraftChanges={workStateHasDraftChanges}
-          locale={resolvedLocale}
-          messages={buildCurrentSelectionSaveToastMessages({
-            entityDisplayName: workStateDisplayName,
-            entityKind: "work-state",
-            locale,
-          })}
-          saveAttemptRevision={workStateSave.saveAttemptRevision}
-          saveMutationError={workStateSave.saveMutationError}
-        />
-      ) : null}
+      <CurrentSelectionWidgetSaveNotifications
+        editableConfigurationState={editableConfigurationState}
+        editableResourceConfigurationState={editableResourceConfigurationState}
+        editableWorkStateConfigurationState={
+          editableWorkStateConfigurationState
+        }
+        editableWorkerConfigurationState={editableWorkerConfigurationState}
+        editableWorkTypeConfigurationState={editableWorkTypeConfigurationState}
+        locale={resolvedLocale}
+        resourceSave={resourceSave}
+        resourceSaveState={resourceSaveState}
+        selectedNode={selectedNode}
+        selectedResourceName={selectedResourceName}
+        selectedWorkerName={selectedWorkerName}
+        selectedWorkTypeName={selectedWorkTypeName}
+        selection={selection}
+        workStatePlaceId={workStatePlaceId}
+        workStateSave={workStateSave}
+        workerSave={workerSave}
+        workerSaveState={workerSaveState}
+        workstationSave={workstationSave}
+        workstationSaveState={workstationSaveState}
+        workTypeSave={workTypeSave}
+      />
       <CurrentSelectionWorkstationSaveDialog
         editableConfigurationState={editableConfigurationState}
         locale={locale}

--- a/ui/src/features/current-selection/components/current-selection-widget.tsx
+++ b/ui/src/features/current-selection/components/current-selection-widget.tsx
@@ -356,6 +356,7 @@ export function CurrentSelectionWidget({
     workerSave,
     workerSaveState,
     workStateHeaderAction,
+    workStateSave,
     workStateSaveState,
     workTypeHeaderAction,
     workTypeSave,

--- a/ui/src/features/current-selection/components/use-current-selection-detail-save.tsx
+++ b/ui/src/features/current-selection/components/use-current-selection-detail-save.tsx
@@ -200,6 +200,7 @@ export function useCurrentSelectionDetailSave({
 
   return {
     resourceHeaderAction,
+    resourceSave,
     resourceSaveState: resourceSave.saveState,
     saveWorkerConfiguration: () => void workerSave.save(),
     saveWorkStateConfiguration: () => void workStateSave.save(),
@@ -207,6 +208,7 @@ export function useCurrentSelectionDetailSave({
     workstationSave,
     workstationSaveState: workstationSave.saveState,
     workerHeaderAction,
+    workerSave,
     workerSaveState: workerSave.saveState,
     workStateHeaderAction,
     workStateSaveState: workStateSave.saveState,

--- a/ui/src/features/current-selection/components/use-current-selection-detail-save.tsx
+++ b/ui/src/features/current-selection/components/use-current-selection-detail-save.tsx
@@ -211,6 +211,7 @@ export function useCurrentSelectionDetailSave({
     workerSave,
     workerSaveState: workerSave.saveState,
     workStateHeaderAction,
+    workStateSave,
     workStateSaveState: workStateSave.saveState,
     workTypeHeaderAction,
     workTypeSave,

--- a/ui/src/features/current-selection/resource-selection/components/resource-editable-configuration-section.tsx
+++ b/ui/src/features/current-selection/resource-selection/components/resource-editable-configuration-section.tsx
@@ -10,10 +10,7 @@ import {
 import { formatList } from "../../../../components/ui/formatters";
 import { cn } from "../../../../lib/cn";
 import { EDITABLE_RESOURCE_TYPES } from "../../../current-factory-definition/lib/resource-editable-values";
-import {
-  DetailCardFactorySaveFeedback,
-  mergeDetailCardSaveFieldErrors,
-} from "../../base/components/detail-card-factory-save-feedback";
+import { mergeDetailCardSaveFieldErrors } from "../../base/components/detail-card-factory-save-feedback";
 import {
   CURRENT_SELECTION_FIELD_PANEL_CLASS,
   CURRENT_SELECTION_WARNING_PANEL_CLASS,
@@ -151,17 +148,6 @@ function ResourceEditableConfigurationReadyForm({
 
   return (
     <form className="grid gap-3" onSubmit={(event) => event.preventDefault()}>
-      <DetailCardFactorySaveFeedback<EditableResourceSaveValidationErrors>
-        messages={{
-          errorPrefix: messages.editableConfigurationSaveErrorPrefix,
-          staleVersionDetail:
-            messages.editableConfigurationSaveStaleVersionDetail,
-          successMessage: messages.editableConfigurationSaveSuccess(
-            state.draft.name.trim() || resourceName,
-          ),
-        }}
-        saveState={saveState}
-      />
       <ResourceEditableConfigurationSharedImpactWarning
         messages={messages}
         resourceName={resourceName}

--- a/ui/src/features/current-selection/resource-selection/hooks/use-save-editable-resource-configuration.ts
+++ b/ui/src/features/current-selection/resource-selection/hooks/use-save-editable-resource-configuration.ts
@@ -16,10 +16,11 @@ interface UseSaveEditableResourceConfigurationOptions {
   scopeKey: string | null;
 }
 
-interface UseSaveEditableResourceConfigurationResult {
+export interface UseSaveEditableResourceConfigurationResult {
   canSave: boolean;
   save: () => Promise<void>;
   saveAttemptRevision: number;
+  saveMutationError: CurrentFactoryDefinitionError | null;
   saveState: EditableResourceSaveState;
 }
 
@@ -34,7 +35,7 @@ export function useSaveEditableResourceConfiguration({
     editableConfigurationState?.status === "ready" &&
     editableConfigurationState.isDirty;
 
-  const { isPending, saveAttemptRevision, saveNow, saveState } =
+  const { error: saveMutationError, isPending, saveAttemptRevision, saveNow, saveState } =
     useScopedFactoryDocumentSave<EditableResourceSaveValidationErrors>({
       fallbackErrorMessage: messages.editableConfigurationSaveFallbackError,
       isDirty,
@@ -80,9 +81,10 @@ export function useSaveEditableResourceConfiguration({
       canSave,
       save,
       saveAttemptRevision,
+      saveMutationError,
       saveState,
     }),
-    [canSave, save, saveAttemptRevision, saveState],
+    [canSave, save, saveAttemptRevision, saveMutationError, saveState],
   );
 }
 

--- a/ui/src/features/current-selection/resource-selection/hooks/use-save-editable-resource-configuration.ts
+++ b/ui/src/features/current-selection/resource-selection/hooks/use-save-editable-resource-configuration.ts
@@ -19,6 +19,7 @@ interface UseSaveEditableResourceConfigurationOptions {
 interface UseSaveEditableResourceConfigurationResult {
   canSave: boolean;
   save: () => Promise<void>;
+  saveAttemptRevision: number;
   saveState: EditableResourceSaveState;
 }
 
@@ -33,7 +34,7 @@ export function useSaveEditableResourceConfiguration({
     editableConfigurationState?.status === "ready" &&
     editableConfigurationState.isDirty;
 
-  const { isPending, saveNow, saveState } =
+  const { isPending, saveAttemptRevision, saveNow, saveState } =
     useScopedFactoryDocumentSave<EditableResourceSaveValidationErrors>({
       fallbackErrorMessage: messages.editableConfigurationSaveFallbackError,
       isDirty,
@@ -78,9 +79,10 @@ export function useSaveEditableResourceConfiguration({
     () => ({
       canSave,
       save,
+      saveAttemptRevision,
       saveState,
     }),
-    [canSave, save, saveState],
+    [canSave, save, saveAttemptRevision, saveState],
   );
 }
 

--- a/ui/src/features/current-selection/work-state-selection/components/work-state-editable-configuration-section.tsx
+++ b/ui/src/features/current-selection/work-state-selection/components/work-state-editable-configuration-section.tsx
@@ -7,7 +7,6 @@ import {
 } from "../../../../components/ui/dashboard-typography";
 import { cn } from "../../../../lib/cn";
 import {
-  DetailCardFactorySaveFeedback,
   mergeDetailCardSaveFieldErrors,
 } from "../../base/components/detail-card-factory-save-feedback";
 import {
@@ -84,18 +83,9 @@ function WorkStateEditableConfigurationReadyForm({
     EditableWorkStateValidationErrors & Record<string, string | undefined>,
     EditableWorkStateSaveValidationErrors
   >(state.validationErrors, saveState);
-  const displayStateName = state.draft.name.trim() || state.originalStateName;
 
   return (
     <form className="grid gap-3" onSubmit={(event) => event.preventDefault()}>
-      <DetailCardFactorySaveFeedback<EditableWorkStateSaveValidationErrors>
-        messages={{
-          errorPrefix: messages.editableConfigurationSaveErrorPrefix,
-          staleVersionDetail: messages.editableConfigurationSaveStaleVersionDetail,
-          successMessage: messages.editableConfigurationSaveSuccess(displayStateName),
-        }}
-        saveState={saveState}
-      />
       {validationErrors.contract ? (
         <p
           className={cn("m-0 text-af-danger-text", DASHBOARD_BODY_TEXT_CLASS)}

--- a/ui/src/features/current-selection/work-state-selection/hooks/use-save-editable-work-state-configuration.ts
+++ b/ui/src/features/current-selection/work-state-selection/hooks/use-save-editable-work-state-configuration.ts
@@ -20,6 +20,7 @@ interface UseSaveEditableWorkStateConfigurationOptions {
 interface UseSaveEditableWorkStateConfigurationResult {
   canSave: boolean;
   save: () => Promise<void>;
+  saveAttemptRevision: number;
   saveState: EditableWorkStateSaveState;
 }
 
@@ -34,7 +35,7 @@ export function useSaveEditableWorkStateConfiguration({
     editableConfigurationState?.status === "ready" &&
     editableConfigurationState.isDirty;
 
-  const { isPending, saveNow, saveState } =
+  const { isPending, saveAttemptRevision, saveNow, saveState } =
     useScopedFactoryDocumentSave<EditableWorkStateSaveValidationErrors>({
       fallbackErrorMessage: messages.editableConfigurationSaveFallbackError,
       isDirty,
@@ -85,9 +86,10 @@ export function useSaveEditableWorkStateConfiguration({
     () => ({
       canSave,
       save,
+      saveAttemptRevision,
       saveState,
     }),
-    [canSave, save, saveState],
+    [canSave, save, saveAttemptRevision, saveState],
   );
 }
 

--- a/ui/src/features/current-selection/work-state-selection/hooks/use-save-editable-work-state-configuration.ts
+++ b/ui/src/features/current-selection/work-state-selection/hooks/use-save-editable-work-state-configuration.ts
@@ -1,6 +1,8 @@
 import { useCallback, useMemo } from "react";
 
-import type { CurrentFactoryDefinitionError } from "../../../../api/current-factory-definition";
+import type {
+  CurrentFactoryDefinitionError,
+} from "../../../../api/current-factory-definition";
 import { useCurrentActivityGraphStore } from "../../../workflow-activity/state/currentActivityGraphStore";
 import { useScopedFactoryDocumentSave } from "../../base/hooks/useScopedFactoryDocumentSave";
 import type {
@@ -21,6 +23,7 @@ interface UseSaveEditableWorkStateConfigurationResult {
   canSave: boolean;
   save: () => Promise<void>;
   saveAttemptRevision: number;
+  saveMutationError: CurrentFactoryDefinitionError | null;
   saveState: EditableWorkStateSaveState;
 }
 
@@ -35,7 +38,7 @@ export function useSaveEditableWorkStateConfiguration({
     editableConfigurationState?.status === "ready" &&
     editableConfigurationState.isDirty;
 
-  const { isPending, saveAttemptRevision, saveNow, saveState } =
+  const { error: saveMutationError, isPending, saveAttemptRevision, saveNow, saveState } =
     useScopedFactoryDocumentSave<EditableWorkStateSaveValidationErrors>({
       fallbackErrorMessage: messages.editableConfigurationSaveFallbackError,
       isDirty,
@@ -87,9 +90,10 @@ export function useSaveEditableWorkStateConfiguration({
       canSave,
       save,
       saveAttemptRevision,
+      saveMutationError,
       saveState,
     }),
-    [canSave, save, saveAttemptRevision, saveState],
+    [canSave, save, saveAttemptRevision, saveMutationError, saveState],
   );
 }
 

--- a/ui/src/features/current-selection/work-state-selection/hooks/use-save-editable-work-state-configuration.ts
+++ b/ui/src/features/current-selection/work-state-selection/hooks/use-save-editable-work-state-configuration.ts
@@ -19,7 +19,7 @@ interface UseSaveEditableWorkStateConfigurationOptions {
   scopeKey: string | null;
 }
 
-interface UseSaveEditableWorkStateConfigurationResult {
+export interface UseSaveEditableWorkStateConfigurationResult {
   canSave: boolean;
   save: () => Promise<void>;
   saveAttemptRevision: number;

--- a/ui/src/features/current-selection/work-type-selection/components/work-type-ready-section.tsx
+++ b/ui/src/features/current-selection/work-type-selection/components/work-type-ready-section.tsx
@@ -7,7 +7,6 @@ import {
 } from "../../../../components/ui/dashboard-typography";
 import { cn } from "../../../../lib/cn";
 import {
-  DetailCardFactorySaveFeedback,
   mergeDetailCardSaveFieldErrors,
 } from "../../base/components/detail-card-factory-save-feedback";
 import {
@@ -45,16 +44,6 @@ export function WorkTypeReadySection({
 
   return (
     <form className="grid gap-2.5" onSubmit={(event) => event.preventDefault()}>
-      <DetailCardFactorySaveFeedback<EditableWorkTypeSaveValidationErrors>
-        messages={{
-          errorPrefix: messages.editableConfigurationSaveErrorPrefix,
-          staleVersionDetail: messages.editableConfigurationSaveStaleVersionDetail,
-          successMessage: messages.editableConfigurationSaveSuccess(
-            state.draft.name.trim() || workTypeName,
-          ),
-        }}
-        saveState={saveState}
-      />
       {validationErrors.contract ? (
         <p
           className={cn("m-0 text-af-danger-text", DASHBOARD_BODY_TEXT_CLASS)}

--- a/ui/src/features/current-selection/work-type-selection/hooks/use-save-editable-work-type-configuration.ts
+++ b/ui/src/features/current-selection/work-type-selection/hooks/use-save-editable-work-type-configuration.ts
@@ -22,6 +22,7 @@ export interface UseSaveEditableWorkTypeConfigurationResult {
   cancelSaveConfirmation: () => void;
   confirmSave: () => Promise<void>;
   saveAttemptRevision: number;
+  saveMutationError: CurrentFactoryDefinitionError | null;
   saveState: EditableWorkTypeSaveState;
 }
 
@@ -40,6 +41,7 @@ export function useSaveEditableWorkTypeConfiguration({
     beginConfirmation,
     cancelConfirmation,
     confirmSave: confirmScopedSave,
+    error: saveMutationError,
     isPending,
     saveAttemptRevision,
     saveState,
@@ -95,6 +97,7 @@ export function useSaveEditableWorkTypeConfiguration({
       cancelSaveConfirmation: cancelConfirmation,
       confirmSave,
       saveAttemptRevision,
+      saveMutationError,
       saveState,
     }),
     [
@@ -103,6 +106,7 @@ export function useSaveEditableWorkTypeConfiguration({
       cancelConfirmation,
       confirmSave,
       saveAttemptRevision,
+      saveMutationError,
       saveState,
     ],
   );

--- a/ui/src/features/current-selection/work-type-selection/hooks/use-save-editable-work-type-configuration.ts
+++ b/ui/src/features/current-selection/work-type-selection/hooks/use-save-editable-work-type-configuration.ts
@@ -21,6 +21,7 @@ export interface UseSaveEditableWorkTypeConfigurationResult {
   canSave: boolean;
   cancelSaveConfirmation: () => void;
   confirmSave: () => Promise<void>;
+  saveAttemptRevision: number;
   saveState: EditableWorkTypeSaveState;
 }
 
@@ -40,6 +41,7 @@ export function useSaveEditableWorkTypeConfiguration({
     cancelConfirmation,
     confirmSave: confirmScopedSave,
     isPending,
+    saveAttemptRevision,
     saveState,
   } = useScopedFactoryDocumentSave<EditableWorkTypeSaveValidationErrors>({
     fallbackErrorMessage: messages.editableConfigurationSaveFallbackError,
@@ -92,6 +94,7 @@ export function useSaveEditableWorkTypeConfiguration({
       canSave,
       cancelSaveConfirmation: cancelConfirmation,
       confirmSave,
+      saveAttemptRevision,
       saveState,
     }),
     [
@@ -99,6 +102,7 @@ export function useSaveEditableWorkTypeConfiguration({
       canSave,
       cancelConfirmation,
       confirmSave,
+      saveAttemptRevision,
       saveState,
     ],
   );

--- a/ui/src/features/current-selection/worker-selection/components/worker-detail-card.test.tsx
+++ b/ui/src/features/current-selection/worker-selection/components/worker-detail-card.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import type { CurrentFactoryDocument } from "../../../../api/current-factory-definition";
 import { useCurrentFactoryDocument } from "../../../current-factory-definition/hooks/useCurrentFactoryDefinition";
+import { expectNoInlineSaveOutcomesIn } from "../../base/components/current-selection-save-toast-test-helpers";
 import { CURRENT_SELECTION_VERTICAL_FORM_FIELDS_CLASS } from "../../base/components/detail-card-shared";
 import type {
   EditableWorkerConfigurationState,
@@ -580,11 +581,10 @@ describe("WorkerDetailCard", () => {
       />,
     );
 
-    expect(
-      screen.queryByText(
-        /reviewer was updated in the running factory definition/,
-      ),
-    ).toBeNull();
+    expectNoInlineSaveOutcomesIn(
+      screen.getByRole("heading", { name: "Worker configuration" }).closest("section") ??
+        document.body,
+    );
   });
 
   it("shows overwrite warning and server-changed hints for dirty worker drafts", () => {
@@ -966,10 +966,10 @@ describe("WorkerDetailCard", () => {
       />,
     );
 
-    expect(screen.queryByText(/^Saving failed\./)).toBeNull();
-    expect(
-      screen.queryByText("The running factory could not be saved."),
-    ).toBeNull();
+    expectNoInlineSaveOutcomesIn(
+      screen.getByRole("heading", { name: "Worker configuration" }).closest("section") ??
+        document.body,
+    );
   });
 
   it("shows model worker field help and allows save with provider only", () => {

--- a/ui/src/features/current-selection/worker-selection/components/worker-detail-card.test.tsx
+++ b/ui/src/features/current-selection/worker-selection/components/worker-detail-card.test.tsx
@@ -519,7 +519,7 @@ describe("WorkerDetailCard", () => {
     ).toBeNull();
   });
 
-  it("shows scoped save success feedback for the selected worker", () => {
+  it("does not render inline save success feedback for the selected worker", () => {
     mockFactoryDocumentQuery({
       data: buildFactoryDocument(),
       isPending: false,
@@ -581,10 +581,10 @@ describe("WorkerDetailCard", () => {
     );
 
     expect(
-      screen.getByText(
+      screen.queryByText(
         /reviewer was updated in the running factory definition/,
       ),
-    ).toBeTruthy();
+    ).toBeNull();
   });
 
   it("shows overwrite warning and server-changed hints for dirty worker drafts", () => {
@@ -894,17 +894,15 @@ describe("WorkerDetailCard", () => {
       />,
     );
 
-    expect(screen.getByRole("alert").textContent).toContain(
-      "Current factory definition is stale",
-    );
+    expect(screen.queryByText(/Current factory definition is stale/)).toBeNull();
     expect(
-      screen.getByText(
+      screen.queryByText(
         "Reload the latest running-factory values or keep this draft and retry after the editor refreshes.",
       ),
-    ).toBeTruthy();
+    ).toBeNull();
   });
 
-  it("shows scoped save error feedback when persistence fails", () => {
+  it("does not render inline save error feedback when persistence fails", () => {
     mockFactoryDocumentQuery({
       data: buildFactoryDocument(),
       isPending: false,
@@ -968,10 +966,10 @@ describe("WorkerDetailCard", () => {
       />,
     );
 
-    expect(screen.getByRole("alert").textContent).toContain("Saving failed.");
-    expect(screen.getByRole("alert").textContent).toContain(
-      "The running factory could not be saved.",
-    );
+    expect(screen.queryByText(/^Saving failed\./)).toBeNull();
+    expect(
+      screen.queryByText("The running factory could not be saved."),
+    ).toBeNull();
   });
 
   it("shows model worker field help and allows save with provider only", () => {

--- a/ui/src/features/current-selection/worker-selection/components/worker-editable-configuration-section.tsx
+++ b/ui/src/features/current-selection/worker-selection/components/worker-editable-configuration-section.tsx
@@ -16,10 +16,7 @@ import {
   EDITABLE_MODEL_PROVIDERS,
   EDITABLE_WORKER_TYPES,
 } from "../../../current-factory-definition/lib/worker-editable-values";
-import {
-  DetailCardFactorySaveFeedback,
-  mergeDetailCardSaveFieldErrors,
-} from "../../base/components/detail-card-factory-save-feedback";
+import { mergeDetailCardSaveFieldErrors } from "../../base/components/detail-card-factory-save-feedback";
 import {
   CURRENT_SELECTION_FIELD_PANEL_CLASS,
   CURRENT_SELECTION_VERTICAL_FORM_FIELDS_CLASS,
@@ -143,17 +140,6 @@ function WorkerEditableConfigurationReadyForm({
 
   return (
     <form className="grid gap-3" onSubmit={(event) => event.preventDefault()}>
-      <DetailCardFactorySaveFeedback<EditableWorkerSaveValidationErrors>
-        messages={{
-          errorPrefix: messages.editableConfigurationSaveErrorPrefix,
-          staleVersionDetail:
-            messages.editableConfigurationSaveStaleVersionDetail,
-          successMessage: messages.editableConfigurationSaveSuccess(
-            state.draft.name.trim() || workerName,
-          ),
-        }}
-        saveState={saveState}
-      />
       <WorkerEditableConfigurationSharedImpactWarning
         messages={messages}
         state={state}

--- a/ui/src/features/current-selection/worker-selection/hooks/use-save-editable-worker-configuration.ts
+++ b/ui/src/features/current-selection/worker-selection/hooks/use-save-editable-worker-configuration.ts
@@ -1,12 +1,11 @@
 import { useCallback, useMemo } from "react";
-
-import { mapWorkerSaveErrorToFieldErrors } from "../lib/worker-save-validation-field-mapping";
 import { useScopedFactoryDocumentSave } from "../../base/public";
 import type {
   EditableWorkerConfigurationState,
   EditableWorkerSaveState,
   EditableWorkerSaveValidationErrors,
 } from "../lib/detail-card-types";
+import { mapWorkerSaveErrorToFieldErrors } from "../lib/worker-save-validation-field-mapping";
 import { getWorkerDetailMessages } from "../messages/worker-detail";
 
 interface UseSaveEditableWorkerConfigurationOptions {
@@ -19,6 +18,7 @@ interface UseSaveEditableWorkerConfigurationOptions {
 interface UseSaveEditableWorkerConfigurationResult {
   canSave: boolean;
   save: () => Promise<void>;
+  saveAttemptRevision: number;
   saveState: EditableWorkerSaveState;
 }
 
@@ -33,7 +33,7 @@ export function useSaveEditableWorkerConfiguration({
     editableConfigurationState?.status === "ready" &&
     editableConfigurationState.isDirty;
 
-  const { isPending, saveNow, saveState } =
+  const { isPending, saveAttemptRevision, saveNow, saveState } =
     useScopedFactoryDocumentSave<EditableWorkerSaveValidationErrors>({
       fallbackErrorMessage: messages.editableConfigurationSaveFallbackError,
       isDirty,
@@ -61,8 +61,7 @@ export function useSaveEditableWorkerConfiguration({
       factory: editableConfigurationState.pendingFactoryDefinition,
       onSaved: () => {
         editableConfigurationState.markChangesSaved();
-        const savedWorkerName =
-          editableConfigurationState.draft.name.trim();
+        const savedWorkerName = editableConfigurationState.draft.name.trim();
         if (
           scopeKey != null &&
           savedWorkerName.length > 0 &&
@@ -79,8 +78,9 @@ export function useSaveEditableWorkerConfiguration({
     () => ({
       canSave,
       save,
+      saveAttemptRevision,
       saveState,
     }),
-    [canSave, save, saveState],
+    [canSave, save, saveAttemptRevision, saveState],
   );
 }

--- a/ui/src/features/current-selection/worker-selection/hooks/use-save-editable-worker-configuration.ts
+++ b/ui/src/features/current-selection/worker-selection/hooks/use-save-editable-worker-configuration.ts
@@ -1,4 +1,6 @@
 import { useCallback, useMemo } from "react";
+
+import type { CurrentFactoryDefinitionError } from "../../../../api/current-factory-definition";
 import { useScopedFactoryDocumentSave } from "../../base/public";
 import type {
   EditableWorkerConfigurationState,
@@ -15,10 +17,11 @@ interface UseSaveEditableWorkerConfigurationOptions {
   scopeKey: string | null;
 }
 
-interface UseSaveEditableWorkerConfigurationResult {
+export interface UseSaveEditableWorkerConfigurationResult {
   canSave: boolean;
   save: () => Promise<void>;
   saveAttemptRevision: number;
+  saveMutationError: CurrentFactoryDefinitionError | null;
   saveState: EditableWorkerSaveState;
 }
 
@@ -33,7 +36,7 @@ export function useSaveEditableWorkerConfiguration({
     editableConfigurationState?.status === "ready" &&
     editableConfigurationState.isDirty;
 
-  const { isPending, saveAttemptRevision, saveNow, saveState } =
+  const { error: saveMutationError, isPending, saveAttemptRevision, saveNow, saveState } =
     useScopedFactoryDocumentSave<EditableWorkerSaveValidationErrors>({
       fallbackErrorMessage: messages.editableConfigurationSaveFallbackError,
       isDirty,
@@ -79,8 +82,9 @@ export function useSaveEditableWorkerConfiguration({
       canSave,
       save,
       saveAttemptRevision,
+      saveMutationError,
       saveState,
     }),
-    [canSave, save, saveAttemptRevision, saveState],
+    [canSave, save, saveAttemptRevision, saveMutationError, saveState],
   );
 }

--- a/ui/src/features/current-selection/workstation-selection/components/workstation-detail-card.editable-configuration.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/workstation-detail-card.editable-configuration.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { semanticWorkflowDashboardSnapshot } from "../../../../components/dashboard/test-fixtures";
+import { expectNoInlineSaveOutcomesIn } from "../../base/components/current-selection-save-toast-test-helpers";
 import { CURRENT_SELECTION_VERTICAL_FORM_FIELDS_CLASS } from "../../base/components/detail-card-shared";
 import { buildDetailCardEditableFactoryDocument } from "../../base/components/detail-card-test-helpers";
 import type {
@@ -1779,15 +1780,7 @@ describe("WorkstationDetailCard editable configuration", () => {
       }),
     );
 
-    let configuration = editableConfigurationSection();
-    expect(
-      within(configuration).queryByText(
-        "Running factory saved. The editable workstation values were refreshed to the saved definition.",
-      ),
-    ).toBeNull();
-    expect(
-      within(configuration).queryByText(/^Saving failed\./),
-    ).toBeNull();
+    expectNoInlineSaveOutcomesIn(editableConfigurationSection());
 
     rerender(
       <WorkstationDetailCard
@@ -1803,12 +1796,7 @@ describe("WorkstationDetailCard editable configuration", () => {
       />,
     );
 
-    configuration = editableConfigurationSection();
-    expect(
-      within(configuration).queryByText(
-        "Saving failed. The current factory rejected the workstation update.",
-      ),
-    ).toBeNull();
+    expectNoInlineSaveOutcomesIn(editableConfigurationSection());
   });
 
   it("uses semantic panels for autocomplete and diagnostics feedback", () => {

--- a/ui/src/features/current-selection/workstation-selection/components/workstation-detail-card.editable-configuration.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/workstation-detail-card.editable-configuration.test.tsx
@@ -1759,7 +1759,7 @@ describe("WorkstationDetailCard editable configuration", () => {
     ).toContain("text-af-text-muted");
   });
 
-  it("keeps save feedback inside the configuration section after the reorder", () => {
+  it("does not render inline save outcome copy in the configuration section", () => {
     const snapshot = semanticWorkflowDashboardSnapshot;
     const selectedNode = snapshot.topology.workstation_nodes_by_id.review;
     const { rerender } = render(
@@ -1781,18 +1781,13 @@ describe("WorkstationDetailCard editable configuration", () => {
 
     let configuration = editableConfigurationSection();
     expect(
-      within(configuration).getByText(
+      within(configuration).queryByText(
         "Running factory saved. The editable workstation values were refreshed to the saved definition.",
       ),
-    ).toBeTruthy();
+    ).toBeNull();
     expect(
-      within(configuration)
-        .getAllByRole("status")
-        .map((element) => element.textContent)
-        .join(" "),
-    ).toContain(
-      "Running factory saved. The editable workstation values were refreshed to the saved definition.",
-    );
+      within(configuration).queryByText(/^Saving failed\./),
+    ).toBeNull();
 
     rerender(
       <WorkstationDetailCard
@@ -1810,10 +1805,10 @@ describe("WorkstationDetailCard editable configuration", () => {
 
     configuration = editableConfigurationSection();
     expect(
-      within(configuration).getByText(
+      within(configuration).queryByText(
         "Saving failed. The current factory rejected the workstation update.",
       ),
-    ).toBeTruthy();
+    ).toBeNull();
   });
 
   it("uses semantic panels for autocomplete and diagnostics feedback", () => {

--- a/ui/src/features/current-selection/workstation-selection/components/workstation-editable-configuration-section.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/workstation-editable-configuration-section.tsx
@@ -14,10 +14,7 @@ import {
 import { formatList } from "../../../../components/ui/formatters";
 import { cn } from "../../../../lib/cn";
 import { workstationRequiresWorkerAssignment } from "../../../current-factory-definition/lib/workstation-worker-assignment";
-import {
-  DetailCardFactorySaveFeedback,
-  mergeDetailCardSaveFieldErrors,
-} from "../../base/components/detail-card-factory-save-feedback";
+import { mergeDetailCardSaveFieldErrors } from "../../base/components/detail-card-factory-save-feedback";
 import {
   CURRENT_SELECTION_FIELD_PANEL_CLASS,
   CURRENT_SELECTION_VERTICAL_FORM_FIELDS_CLASS,
@@ -169,15 +166,6 @@ function EditableConfigurationReadyForm({
 
   return (
     <form className="grid gap-3" onSubmit={(event) => event.preventDefault()}>
-      <DetailCardFactorySaveFeedback<EditableWorkstationSaveValidationErrors>
-        messages={{
-          errorPrefix: messages.editableConfigurationSaveErrorPrefix,
-          staleVersionDetail:
-            messages.editableConfigurationSaveStaleVersionDetail,
-          successMessage: messages.editableConfigurationSaveSuccess,
-        }}
-        saveState={saveState}
-      />
       <EditableConfigurationOverwriteWarning
         messages={messages}
         overwriteFieldNames={state.overwriteFieldNames ?? []}

--- a/ui/src/features/current-selection/workstation-selection/hooks/use-save-editable-workstation-configuration.ts
+++ b/ui/src/features/current-selection/workstation-selection/hooks/use-save-editable-workstation-configuration.ts
@@ -1,4 +1,6 @@
 import { useCallback, useMemo } from "react";
+
+import type { CurrentFactoryDefinitionError } from "../../../../api/current-factory-definition";
 import { useScopedFactoryDocumentSave } from "../../base/public";
 import type {
   EditableWorkstationConfigurationState,
@@ -20,6 +22,7 @@ export interface UseSaveEditableWorkstationConfigurationResult {
   cancelSaveConfirmation: () => void;
   confirmSave: () => Promise<void>;
   saveAttemptRevision: number;
+  saveMutationError: CurrentFactoryDefinitionError | null;
   saveState: EditableWorkstationSaveState;
 }
 
@@ -37,6 +40,7 @@ export function useSaveEditableWorkstationConfiguration({
     beginConfirmation,
     cancelConfirmation,
     confirmSave: confirmScopedSave,
+    error: saveMutationError,
     isPending,
     saveAttemptRevision,
     saveState,
@@ -86,6 +90,7 @@ export function useSaveEditableWorkstationConfiguration({
       cancelSaveConfirmation: cancelConfirmation,
       confirmSave,
       saveAttemptRevision,
+      saveMutationError,
       saveState,
     }),
     [
@@ -94,6 +99,7 @@ export function useSaveEditableWorkstationConfiguration({
       cancelConfirmation,
       confirmSave,
       saveAttemptRevision,
+      saveMutationError,
       saveState,
     ],
   );

--- a/ui/src/features/current-selection/workstation-selection/hooks/use-save-editable-workstation-configuration.ts
+++ b/ui/src/features/current-selection/workstation-selection/hooks/use-save-editable-workstation-configuration.ts
@@ -1,12 +1,11 @@
 import { useCallback, useMemo } from "react";
-
-import { mapWorkstationSaveErrorToFieldErrors } from "../lib/workstation-save-validation-field-mapping";
 import { useScopedFactoryDocumentSave } from "../../base/public";
 import type {
   EditableWorkstationConfigurationState,
   EditableWorkstationSaveState,
   EditableWorkstationSaveValidationErrors,
 } from "../lib/detail-card-types";
+import { mapWorkstationSaveErrorToFieldErrors } from "../lib/workstation-save-validation-field-mapping";
 import { getWorkstationDetailMessages } from "../messages/workstation-detail";
 
 interface UseSaveEditableWorkstationConfigurationOptions {
@@ -20,6 +19,7 @@ export interface UseSaveEditableWorkstationConfigurationResult {
   canSave: boolean;
   cancelSaveConfirmation: () => void;
   confirmSave: () => Promise<void>;
+  saveAttemptRevision: number;
   saveState: EditableWorkstationSaveState;
 }
 
@@ -38,6 +38,7 @@ export function useSaveEditableWorkstationConfiguration({
     cancelConfirmation,
     confirmSave: confirmScopedSave,
     isPending,
+    saveAttemptRevision,
     saveState,
   } = useScopedFactoryDocumentSave<EditableWorkstationSaveValidationErrors>({
     fallbackErrorMessage: messages.editableConfigurationSaveFallbackError,
@@ -84,6 +85,7 @@ export function useSaveEditableWorkstationConfiguration({
       canSave,
       cancelSaveConfirmation: cancelConfirmation,
       confirmSave,
+      saveAttemptRevision,
       saveState,
     }),
     [
@@ -91,6 +93,7 @@ export function useSaveEditableWorkstationConfiguration({
       canSave,
       cancelConfirmation,
       confirmSave,
+      saveAttemptRevision,
       saveState,
     ],
   );

--- a/ui/src/features/notifications/lib/save-notification-delivery-policy.test.ts
+++ b/ui/src/features/notifications/lib/save-notification-delivery-policy.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildCurrentSelectionSaveSuccessStableIdentity,
   buildSaveErrorStableIdentity,
   buildSaveErrorToastOptions,
   buildSaveNotificationDeliveryKey,
@@ -75,5 +76,15 @@ describe("save notification delivery policy", () => {
       kind: "success",
       stableId: "graph-save-success",
     });
+  });
+
+  it("builds per-entity stable identities for current-selection save success", () => {
+    expect(buildCurrentSelectionSaveSuccessStableIdentity("worker")).toEqual({
+      kind: "success",
+      stableId: "worker-save-success",
+    });
+    expect(
+      buildCurrentSelectionSaveSuccessStableIdentity("workstation").stableId,
+    ).not.toBe(buildSaveSuccessStableIdentity().stableId);
   });
 });

--- a/ui/src/features/notifications/lib/save-notification-delivery-policy.ts
+++ b/ui/src/features/notifications/lib/save-notification-delivery-policy.ts
@@ -50,6 +50,23 @@ export function buildSaveSuccessStableIdentity(): SaveNotificationStableIdentity
   };
 }
 
+export type CurrentSelectionSaveEntityKind =
+  | "workstation"
+  | "worker"
+  | "resource"
+  | "work-type"
+  | "work-state";
+
+/** Stable identity for a current-selection entity save success toast. */
+export function buildCurrentSelectionSaveSuccessStableIdentity(
+  entityKind: CurrentSelectionSaveEntityKind,
+): SaveNotificationStableIdentity {
+  return {
+    kind: "success",
+    stableId: `${entityKind}-save-success`,
+  };
+}
+
 /**
  * Attempt-scoped delivery key. Includes save-attempt revision so operator retries
  * always qualify as new delivery even when stable identity is unchanged.

--- a/ui/src/features/notifications/public/index.ts
+++ b/ui/src/features/notifications/public/index.ts
@@ -5,6 +5,7 @@ export {
   resolveAppNotificationToastDuration,
 } from "../lib/notification-toaster-config";
 export {
+  buildCurrentSelectionSaveSuccessStableIdentity,
   buildSaveErrorStableIdentity,
   buildSaveErrorToastOptions,
   buildSaveNotificationDeliveryKey,
@@ -12,6 +13,7 @@ export {
   buildSaveSuccessToastOptions,
   GLOBAL_TOAST_DURATION_MS,
   PERSISTENT_TOAST_DURATION_MS,
+  type CurrentSelectionSaveEntityKind,
   type SaveNotificationDeliveryKey,
   type SaveNotificationKind,
   type SaveNotificationStableIdentity,


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/issues3-current-selection-save-notifications",
  "description": "Route current-selection editable save success, error, and stale-version feedback through the global Sonner notification toaster (matching the factory graph editor), and remove inline save outcome banners from configuration form bodies while preserving field-level validation errors.",
  "context": {
    "customerAsk": "Save success messages (e.g. executor-slot updated) render inline on current selection. Route all current-selection save success and failure feedback through the global notification component. Remove inline success banners on the configuration body. Error paths that currently surface inline text should also use notifications.",
    "problem": "Current-selection editable saves for workstation, worker, resource, work type, and work state show success, error, and stale-version outcomes as inline text at the top of the configuration form via DetailCardFactorySaveFeedback. The graph editor already uses global toasts with attempt-scoped deduplication, so current selection is inconsistent and easy to miss when the form is scrolled.",
    "solution": "Extend useScopedFactoryDocumentSave with saveAttemptRevision, add a pure current-selection save toast resolver and a CurrentSelectionSaveNotifications delivery component reusing save-notification-delivery-policy, mount it from current-selection-widget for all five entity saves, remove inline success/error/stale outcome banners from editable configuration sections, and migrate tests to assert toast delivery instead of inline DOM copy."
  },
  "acceptanceCriteria": [
    "Saving workstation, worker, resource, work type, or work state configuration shows a global success notification with entity-appropriate copy and no inline success paragraph in the editable configuration body.",
    "Save API failures and stale-version conflicts for those surfaces show global error or warning notifications with no inline save-outcome alert or stale-version panel in the configuration body.",
    "Field-level validation errors from failed saves still render on the affected form fields.",
    "Switching current selection does not replay save toasts from the previous entity; retrying a failed save shows a new error toast.",
    "Notification copy uses existing localized entity message catalogs with graph-editor-consistent toast duration and dismiss behavior.",
    "Typecheck, lint, and tests pass for touched UI packages."
  ],
  "userStories": [
    {
      "id": "issues3-current-selection-save-notifications-001",
      "title": "Track save attempt revision in scoped factory document save",
      "description": "As an operator retrying a failed save, I want each save attempt to qualify for its own notification so I am not silently suppressed after correcting my draft.",
      "acceptanceCriteria": [
        "useScopedFactoryDocumentSave increments an exposed saveAttemptRevision on each saveNow or confirmSave invocation.",
        "saveAttemptRevision resets when the scoped scopeKey changes (selection switch).",
        "Entity save hooks for workstation, worker, resource, work type, and work state expose saveAttemptRevision to callers.",
        "Unit tests cover increment-on-save, reset-on-scope-change, and no increment on confirmation-only state transitions.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues3-current-selection-save-notifications-002",
      "title": "Resolve current-selection save outcomes to toast payloads",
      "description": "As a maintainer, I need a pure mapping from scoped save state to toast notification payloads so delivery logic stays testable and aligned with the graph editor.",
      "acceptanceCriteria": [
        "A pure resolveCurrentSelectionSaveToastNotification maps FactoryDocumentSaveState, draft dirtiness, entity kind, and optional mutation error to a toast payload or null.",
        "Success resolves only when save status is success and the draft is clean, matching graph-editor semantics.",
        "Error resolves when save status is error, using entity save-failure title copy and the current error message.",
        "Stale-version warning resolves when save status is warning, using existing stale-version title and detail copy.",
        "Entity-specific success descriptions reuse existing editableConfigurationSaveSuccess strings.",
        "Per-entity stable success identities are available for notification deduplication, distinct from graph-save-success.",
        "Unit tests cover success, error, stale warning, idle states, and dirty-draft suppression after success.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues3-current-selection-save-notifications-003",
      "title": "Deliver current-selection save notifications via Sonner",
      "description": "As an operator saving configuration from current selection, I want save outcomes to appear as global notifications in the same toaster used elsewhere on the dashboard.",
      "acceptanceCriteria": [
        "A CurrentSelectionSaveNotifications render-null component calls toast.success, toast.error, or toast.warning via existing save toast option builders.",
        "Delivery uses buildSaveNotificationDeliveryKey and shouldDeliverSaveNotification for burst dedupe within a single attempt outcome.",
        "Component accepts entity kind, locale, save state, draft dirtiness, save mutation error, and saveAttemptRevision.",
        "Component renders nothing to the DOM and does not show inline fallback banners.",
        "Unit tests mock Sonner and assert toast kind, title, description, and dedupe across rerenders versus new attempt revision.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues3-current-selection-save-notifications-004",
      "title": "Wire notifications and remove inline save outcome banners",
      "description": "As an operator editing any current-selection entity, I want save feedback only in global notifications so the configuration form stays focused on fields.",
      "acceptanceCriteria": [
        "current-selection-widget.tsx mounts save notification delivery for workstation, worker, resource, work type, and work state saves.",
        "Editable configuration sections for all five entities no longer render inline success, API error, or stale-version outcome copy in the form body.",
        "mergeDetailCardSaveFieldErrors continues to merge field-level save errors onto form validation state.",
        "Save confirmation dialogs, header save actions, save-row buttons, and validation-disabled detail copy behave the same as before.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill: save a worker or resource change and confirm a top-right toast appears with no inline success banner in the form body"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues3-current-selection-save-notifications-005",
      "title": "Migrate save feedback tests from inline DOM to toast assertions",
      "description": "As a maintainer, I want automated tests to assert global notification delivery instead of inline configuration-body copy so regressions are caught at the correct UX boundary.",
      "acceptanceCriteria": [
        "current-selection-widget.save.test.tsx and selection-switch save isolation tests assert toast delivery instead of inline Running factory saved or Saving failed paragraphs.",
        "Entity detail-card save tests no longer expect inline save outcome banners where those were removed.",
        "detail-card-factory-save-feedback tests drop success, error, and warning rendering cases while keeping mergeDetailCardSaveFieldErrors coverage.",
        "Tests assert the configuration body does not contain save-outcome role=status or save-outcome role=alert paragraphs after save success or failure.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues3-current-selection-save-notifications-006",
      "title": "End-to-end notification verification across entity saves",
      "description": "As an operator, I want to confirm save success and failure notifications work consistently for each editable entity type in the dashboard.",
      "acceptanceCriteria": [
        "Workstation save success shows a global success toast with no inline success text in the workstation configuration body.",
        "Worker, resource, work type, and work state save success each show entity-appropriate global success toasts with no inline success banners.",
        "A save failure shows a persistent global error toast with no inline Saving failed paragraph in the configuration body.",
        "Switching selection after a save does not replay the previous entity toast.",
        "Typecheck passes",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 6,
      "passes": true,
      "notes": ""
    }
  ]
}
