### PR TITLE
issues3-remove-verbose-unsaved-copy

### DIFF
--- a/ui/src/features/current-selection/resource-selection/components/resource-detail-card.test.tsx
+++ b/ui/src/features/current-selection/resource-selection/components/resource-detail-card.test.tsx
@@ -9,7 +9,6 @@ import type {
   EditableResourceConfigurationState,
   EditableResourceSaveState,
 } from "../lib/detail-card-types";
-import { ResourceDetailCard } from "./resource-detail-card";
 import { EditableResourceConfigurationHeaderActions } from "./resource-save-controls";
 
 vi.mock(
@@ -560,5 +559,83 @@ describe("ResourceDetailCard", () => {
         name: "Discard local changes",
       }),
     ).toBeNull();
+  });
+
+  it("omits global unsaved helper paragraphs for dirty ready-state resource drafts", () => {
+    const editableConfigurationState: EditableResourceConfigurationState = {
+      baseVersion: {
+        logical: "7",
+        physical: "2026-05-23T16:22:24Z",
+      },
+      canSave: true,
+      draft: {
+        backend: "",
+        capacityText: "3",
+        loadPolicy: "",
+        model: "",
+        name: "agent-slot",
+        provider: "",
+        type: "INVOCATION_SLOT",
+      },
+      hasValidationErrors: false,
+      initialValues: {
+        backend: null,
+        capacity: 2,
+        loadPolicy: null,
+        model: null,
+        provider: null,
+        resourceName: "agent-slot",
+        type: "INVOCATION_SLOT",
+        workerNames: ["reviewer"],
+        workstationNames: ["Review"],
+      },
+      isDirty: true,
+      markChangesSaved: vi.fn(),
+      onBackendChange: vi.fn(),
+      onCapacityChange: vi.fn(),
+      onLoadPolicyChange: vi.fn(),
+      onModelChange: vi.fn(),
+      onNameChange: vi.fn(),
+      onProviderChange: vi.fn(),
+      onResetToLatest: vi.fn(),
+      onTypeChange: vi.fn(),
+      overwriteFieldNames: [],
+      pendingFactoryDefinition: buildFactoryDocument(),
+      status: "ready",
+      validationErrors: {},
+    };
+
+    mockFactoryDocumentQuery({
+      data: buildFactoryDocument(),
+      isPending: false,
+      isSuccess: true,
+      status: "success",
+    } as never);
+
+    render(
+      <ResourceDetailCard
+        editableConfigurationState={editableConfigurationState}
+        headerAction={buildResourceHeaderActions({
+          canDiscard: true,
+          canSave: true,
+        })}
+        resourceName="agent-slot"
+      />,
+    );
+
+    expect(
+      screen.queryByText("You have unsaved changes for this resource."),
+    ).toBeNull();
+    expect(
+      screen.queryByText(
+        "Changes stay local to this edit session until you save the running factory.",
+      ),
+    ).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Save resource" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Discard local changes" }),
+    ).toBeTruthy();
   });
 });

--- a/ui/src/features/current-selection/resource-selection/components/resource-detail-card.test.tsx
+++ b/ui/src/features/current-selection/resource-selection/components/resource-detail-card.test.tsx
@@ -9,6 +9,7 @@ import type {
   EditableResourceConfigurationState,
   EditableResourceSaveState,
 } from "../lib/detail-card-types";
+import { ResourceDetailCard } from "./resource-detail-card";
 import { EditableResourceConfigurationHeaderActions } from "./resource-save-controls";
 
 vi.mock(

--- a/ui/src/features/current-selection/resource-selection/components/resource-editable-configuration-section.tsx
+++ b/ui/src/features/current-selection/resource-selection/components/resource-editable-configuration-section.tsx
@@ -606,43 +606,26 @@ function ResourceEditableConfigurationDraftStatus({
   messages: ReturnType<typeof getResourceDetailMessages>;
   state: Extract<EditableResourceConfigurationState, { status: "ready" }>;
 }) {
+  if (!state.hasValidationErrors) {
+    return null;
+  }
+
   return (
     <div className={CURRENT_SELECTION_FIELD_PANEL_CLASS}>
       <p
-        className={cn(
-          "m-0",
-          state.hasValidationErrors
-            ? "text-af-danger-text"
-            : "text-af-text-muted",
-          DASHBOARD_BODY_TEXT_CLASS,
-        )}
-        role={state.hasValidationErrors ? "alert" : "status"}
+        className={cn("m-0 text-af-danger-text", DASHBOARD_BODY_TEXT_CLASS)}
+        role="alert"
       >
-        {state.hasValidationErrors
-          ? messages.editableConfigurationValidationStatus
-          : state.isDirty
-            ? messages.editableConfigurationDirtyStatus
-            : messages.editableConfigurationDraftNote}
+        {messages.editableConfigurationValidationStatus}
       </p>
-      {state.hasValidationErrors ? (
-        <p
-          className={cn(
-            "m-0 text-af-text-subtle",
-            DASHBOARD_SUPPORTING_TEXT_CLASS,
-          )}
-        >
-          {messages.editableConfigurationSaveDisabledValidationDetail}
-        </p>
-      ) : (
-        <p
-          className={cn(
-            "m-0 text-af-text-subtle",
-            DASHBOARD_SUPPORTING_TEXT_CLASS,
-          )}
-        >
-          {messages.editableConfigurationDraftNote}
-        </p>
-      )}
+      <p
+        className={cn(
+          "m-0 text-af-text-subtle",
+          DASHBOARD_SUPPORTING_TEXT_CLASS,
+        )}
+      >
+        {messages.editableConfigurationSaveDisabledValidationDetail}
+      </p>
     </div>
   );
 }

--- a/ui/src/features/current-selection/resource-selection/messages/resource-detail-types.ts
+++ b/ui/src/features/current-selection/resource-selection/messages/resource-detail-types.ts
@@ -8,8 +8,6 @@ export interface ResourceDetailMessages {
   editableConfigurationCapacityInvalid: string;
   editableConfigurationCollapseActionLabel: string;
   editableConfigurationContractInvalidPrefix: string;
-  editableConfigurationDirtyStatus: string;
-  editableConfigurationDraftNote: string;
   editableConfigurationEmpty: string;
   editableConfigurationErrorPrefix: string;
   editableConfigurationExpandActionLabel: string;

--- a/ui/src/features/current-selection/resource-selection/messages/resource-detail.ts
+++ b/ui/src/features/current-selection/resource-selection/messages/resource-detail.ts
@@ -26,10 +26,6 @@ const resourceDetailMessagesByLocale = {
       "Collapse resource configuration editor",
     editableConfigurationContractInvalidPrefix:
       "Resource configuration is invalid.",
-    editableConfigurationDirtyStatus:
-      "You have unsaved changes for this resource.",
-    editableConfigurationDraftNote:
-      "Changes stay local to this edit session until you save the running factory.",
     editableConfigurationEmpty:
       "This running factory definition does not expose editable resource values.",
     editableConfigurationErrorPrefix: "Resource configuration unavailable.",
@@ -100,10 +96,6 @@ const resourceDetailMessagesByLocale = {
     editableConfigurationCollapseActionLabel:
       "リソース設定エディターを折りたたむ",
     editableConfigurationContractInvalidPrefix: "リソース設定が無効です。",
-    editableConfigurationDirtyStatus:
-      "このリソースに未保存の変更があります。",
-    editableConfigurationDraftNote:
-      "保存するまで変更はこの編集セッション内にのみ保持されます。",
     editableConfigurationEmpty:
       "実行中のファクトリ定義に編集可能なリソース値がありません。",
     editableConfigurationErrorPrefix: "リソース設定を利用できません。",
@@ -171,10 +163,6 @@ const resourceDetailMessagesByLocale = {
       "리소스 용량은 1보다 큰 정수여야 합니다.",
     editableConfigurationCollapseActionLabel: "리소스 구성 편집기 접기",
     editableConfigurationContractInvalidPrefix: "리소스 구성이 유효하지 않습니다.",
-    editableConfigurationDirtyStatus:
-      "이 리소스에 저장되지 않은 변경 사항이 있습니다.",
-    editableConfigurationDraftNote:
-      "저장하기 전까지 변경 사항은 이 편집 세션에만 유지됩니다.",
     editableConfigurationEmpty:
       "실행 중인 팩토리 정의에 편집 가능한 리소스 값이 없습니다.",
     editableConfigurationErrorPrefix: "리소스 구성을 사용할 수 없습니다.",
@@ -240,8 +228,6 @@ const resourceDetailMessagesByLocale = {
     editableConfigurationCapacityInvalid: "资源容量必须是大于零的整数。",
     editableConfigurationCollapseActionLabel: "收起资源配置编辑器",
     editableConfigurationContractInvalidPrefix: "资源配置无效。",
-    editableConfigurationDirtyStatus: "此资源有未保存的更改。",
-    editableConfigurationDraftNote: "保存前，更改仅保留在此编辑会话中。",
     editableConfigurationEmpty: "运行中的工厂定义没有可编辑的资源值。",
     editableConfigurationErrorPrefix: "无法加载资源配置。",
     editableConfigurationExpandActionLabel: "展开资源配置编辑器",

--- a/ui/src/features/current-selection/work-state-selection/components/state-node-detail.test.tsx
+++ b/ui/src/features/current-selection/work-state-selection/components/state-node-detail.test.tsx
@@ -774,8 +774,10 @@ describe("StateNodeDetailCard editable work state configuration", () => {
           validationErrors: {},
           workTypeName: "story",
         }}
-        headerAction={buildWorkStateHeaderSaveAction({ canSave: true })}
-        onSaveConfiguration={vi.fn()}
+        headerAction={buildWorkStateHeaderActions({
+          canDiscard: true,
+          canSave: true,
+        })}
         place={resolvedSelectedState}
         tokenCount={0}
       />,

--- a/ui/src/features/current-selection/work-state-selection/components/state-node-detail.test.tsx
+++ b/ui/src/features/current-selection/work-state-selection/components/state-node-detail.test.tsx
@@ -740,6 +740,64 @@ describe("StateNodeDetailCard editable work state configuration", () => {
     ).toBeNull();
   });
 
+  it("omits global unsaved helper paragraphs for dirty ready-state work state drafts", () => {
+    const snapshot = semanticWorkflowDashboardSnapshot;
+    const selectedState = snapshot.topology.workstation_nodes_by_id.review.input_places?.find(
+      (place) => place.place_id === "story:implemented",
+    );
+    const resolvedSelectedState = requireValue(selectedState, "expected implemented state fixture");
+
+    render(
+      <StateNodeDetailCard
+        currentWorkItems={[]}
+        editableConfigurationState={{
+          baseVersion: buildFactoryDocument().version,
+          canSave: true,
+          draft: {
+            name: "implemented",
+            type: "PROCESSING",
+          },
+          hasValidationErrors: false,
+          initialValues: {
+            stateName: "implemented",
+            stateNamesInWorkType: ["implemented", "complete"],
+            stateType: "PROCESSING",
+            workTypeName: "story",
+          },
+          isDirty: true,
+          markChangesSaved: vi.fn(),
+          onNameChange: vi.fn(),
+          onResetToLatest: vi.fn(),
+          originalStateName: "implemented",
+          pendingFactoryDefinition: buildFactoryDocument(),
+          status: "ready",
+          validationErrors: {},
+          workTypeName: "story",
+        }}
+        headerAction={buildWorkStateHeaderSaveAction({ canSave: true })}
+        onSaveConfiguration={vi.fn()}
+        place={resolvedSelectedState}
+        tokenCount={0}
+      />,
+    );
+
+    expect(
+      screen.queryByText("You have unsaved changes for this work state."),
+    ).toBeNull();
+    expect(
+      screen.queryByText(
+        "Changes stay local to this edit session until you save the running factory.",
+      ),
+    ).toBeNull();
+    expect(
+      screen.getAllByRole("button", { name: messages.editableConfigurationSaveAction })
+        .length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getByRole("button", { name: messages.discardDraftAction }),
+    ).toBeTruthy();
+  });
+
   it("keeps runtime work list content when editable configuration is ready", () => {
     const snapshot = semanticWorkflowDashboardSnapshot;
     const selectedState =

--- a/ui/src/features/current-selection/work-state-selection/components/work-state-editable-configuration-section.tsx
+++ b/ui/src/features/current-selection/work-state-selection/components/work-state-editable-configuration-section.tsx
@@ -148,43 +148,26 @@ function WorkStateEditableConfigurationDraftStatus({
   messages: ReturnType<typeof getWorkStateDetailMessages>;
   state: Extract<EditableWorkStateConfigurationState, { status: "ready" }>;
 }) {
+  if (!state.hasValidationErrors) {
+    return null;
+  }
+
   return (
     <div className={CURRENT_SELECTION_FIELD_PANEL_CLASS}>
       <p
-        className={cn(
-          "m-0",
-          state.hasValidationErrors
-            ? "text-af-danger-text"
-            : "text-af-text-muted",
-          DASHBOARD_BODY_TEXT_CLASS,
-        )}
-        role={state.hasValidationErrors ? "alert" : "status"}
+        className={cn("m-0 text-af-danger-text", DASHBOARD_BODY_TEXT_CLASS)}
+        role="alert"
       >
-        {state.hasValidationErrors
-          ? messages.editableConfigurationValidationStatus
-          : state.isDirty
-            ? messages.editableConfigurationDirtyStatus
-            : messages.editableConfigurationDraftNote}
+        {messages.editableConfigurationValidationStatus}
       </p>
-      {state.hasValidationErrors ? (
-        <p
-          className={cn(
-            "m-0 text-af-text-subtle",
-            DASHBOARD_SUPPORTING_TEXT_CLASS,
-          )}
-        >
-          {messages.editableConfigurationSaveDisabledValidationDetail}
-        </p>
-      ) : (
-        <p
-          className={cn(
-            "m-0 text-af-text-subtle",
-            DASHBOARD_SUPPORTING_TEXT_CLASS,
-          )}
-        >
-          {messages.editableConfigurationDraftNote}
-        </p>
-      )}
+      <p
+        className={cn(
+          "m-0 text-af-text-subtle",
+          DASHBOARD_SUPPORTING_TEXT_CLASS,
+        )}
+      >
+        {messages.editableConfigurationSaveDisabledValidationDetail}
+      </p>
     </div>
   );
 }

--- a/ui/src/features/current-selection/work-state-selection/messages/work-state-detail-types.ts
+++ b/ui/src/features/current-selection/work-state-selection/messages/work-state-detail-types.ts
@@ -9,8 +9,6 @@ export interface WorkStateDetailMessages {
   configurationLoading: string;
   discardDraftAction: string;
   editableConfigurationContractInvalidPrefix: string;
-  editableConfigurationDirtyStatus: string;
-  editableConfigurationDraftNote: string;
   editableConfigurationEmpty: string;
   editableConfigurationErrorPrefix: string;
   editableConfigurationHeading: string;

--- a/ui/src/features/current-selection/work-state-selection/messages/work-state-detail.ts
+++ b/ui/src/features/current-selection/work-state-selection/messages/work-state-detail.ts
@@ -24,10 +24,6 @@ const workStateDetailMessagesByLocale = {
     discardDraftAction: "Discard local changes",
     editableConfigurationContractInvalidPrefix:
       "Work state configuration is invalid.",
-    editableConfigurationDirtyStatus:
-      "You have unsaved changes for this work state.",
-    editableConfigurationDraftNote:
-      "Changes stay local to this edit session until you save the running factory.",
     editableConfigurationEmpty:
       "This running factory definition does not expose editable work state values.",
     editableConfigurationErrorPrefix: "Work state configuration unavailable.",
@@ -66,10 +62,6 @@ const workStateDetailMessagesByLocale = {
     discardDraftAction: "ローカルの変更を破棄",
     editableConfigurationContractInvalidPrefix:
       "ワーク状態の構成が無効です。",
-    editableConfigurationDirtyStatus:
-      "このワーク状態に未保存の変更があります。",
-    editableConfigurationDraftNote:
-      "実行中のファクトリーを保存するまで、変更はこの編集セッション内に留まります。",
     editableConfigurationEmpty:
       "実行中のファクトリー定義に、編集可能なワーク状態の値がありません。",
     editableConfigurationErrorPrefix: "ワーク状態の構成を利用できません。",
@@ -108,10 +100,6 @@ const workStateDetailMessagesByLocale = {
     discardDraftAction: "로컬 변경 사항 취소",
     editableConfigurationContractInvalidPrefix:
       "작업 상태 구성이 유효하지 않습니다.",
-    editableConfigurationDirtyStatus:
-      "이 작업 상태에 저장되지 않은 변경 사항이 있습니다.",
-    editableConfigurationDraftNote:
-      "실행 중인 팩토리를 저장할 때까지 변경 사항은 이 편집 세션에만 유지됩니다.",
     editableConfigurationEmpty:
       "실행 중인 팩토리 정의에 편집 가능한 작업 상태 값이 없습니다.",
     editableConfigurationErrorPrefix: "작업 상태 구성을 사용할 수 없습니다.",
@@ -147,9 +135,6 @@ const workStateDetailMessagesByLocale = {
     configurationLoading: "正在加载此工作状态的当前工厂定义。",
     discardDraftAction: "放弃本地更改",
     editableConfigurationContractInvalidPrefix: "工作状态配置无效。",
-    editableConfigurationDirtyStatus: "此工作状态有未保存的更改。",
-    editableConfigurationDraftNote:
-      "在保存运行中的工厂之前，更改仅保留在此编辑会话中。",
     editableConfigurationEmpty:
       "运行中的工厂定义未提供可编辑的工作状态值。",
     editableConfigurationErrorPrefix: "工作状态配置不可用。",

--- a/ui/src/features/current-selection/work-type-selection/components/work-type-detail-card.test.tsx
+++ b/ui/src/features/current-selection/work-type-selection/components/work-type-detail-card.test.tsx
@@ -324,4 +324,52 @@ describe("WorkTypeDetailCard", () => {
       }),
     ).toBeNull();
   });
+
+  it("omits global unsaved helper paragraphs for dirty ready-state work type drafts", () => {
+    const editableConfigurationState: EditableWorkTypeConfigurationState = {
+      baseVersion: buildFactoryDocument().version,
+      canSave: true,
+      draft: {
+        handlingBehavior: null,
+        name: "story",
+      },
+      hasValidationErrors: false,
+      initialValues: {
+        handlingBehavior: null,
+        name: "story",
+        states: [
+          { name: "queued", type: "INITIAL" },
+          { name: "done", type: "TERMINAL" },
+        ],
+      },
+      isDirty: true,
+      markChangesSaved: vi.fn(),
+      onHandlingBehaviorChange: vi.fn(),
+      onNameChange: vi.fn(),
+      onResetToLatest: vi.fn(),
+      pendingFactoryDefinition: buildFactoryDocument(),
+      status: "ready",
+      validationErrors: {},
+    };
+
+    render(
+      <WorkTypeDetailCard
+        editableConfigurationState={editableConfigurationState}
+        headerAction={buildWorkTypeHeaderSaveAction({ canSave: true })}
+        workTypeName="story"
+      />,
+    );
+
+    expect(
+      screen.queryByText("You have unsaved changes for this work type."),
+    ).toBeNull();
+    expect(
+      screen.queryByText(
+        "Changes stay local to this edit session until you save the running factory.",
+      ),
+    ).toBeNull();
+    expect(
+      screen.getAllByRole("button", { name: "Save changes" }).length,
+    ).toBeGreaterThan(0);
+  });
 });

--- a/ui/src/features/current-selection/work-type-selection/components/work-type-detail-card.test.tsx
+++ b/ui/src/features/current-selection/work-type-selection/components/work-type-detail-card.test.tsx
@@ -355,7 +355,10 @@ describe("WorkTypeDetailCard", () => {
     render(
       <WorkTypeDetailCard
         editableConfigurationState={editableConfigurationState}
-        headerAction={buildWorkTypeHeaderSaveAction({ canSave: true })}
+        headerAction={buildWorkTypeHeaderActions({
+          canDiscard: true,
+          canSave: true,
+        })}
         workTypeName="story"
       />,
     );

--- a/ui/src/features/current-selection/work-type-selection/components/work-type-ready-section.tsx
+++ b/ui/src/features/current-selection/work-type-selection/components/work-type-ready-section.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from "react";
 import {
   DASHBOARD_BODY_TEXT_CLASS,
   DASHBOARD_SUPPORTING_LABEL_CLASS,
-  DASHBOARD_SUPPORTING_TEXT_CLASS,
 } from "../../../../components/ui/dashboard-typography";
 import { cn } from "../../../../lib/cn";
 import {
@@ -69,11 +68,6 @@ export function WorkTypeReadySection({
           role="alert"
         >
           {messages.editableConfigurationValidationStatus}
-        </p>
-      ) : null}
-      {state.isDirty ? (
-        <p className={cn("m-0 text-af-text-muted", DASHBOARD_SUPPORTING_TEXT_CLASS)}>
-          {messages.editableConfigurationDirtyStatus}
         </p>
       ) : null}
       <div className={CURRENT_SELECTION_VERTICAL_FORM_FIELDS_CLASS}>

--- a/ui/src/features/current-selection/work-type-selection/messages/work-type-detail-types.ts
+++ b/ui/src/features/current-selection/work-type-selection/messages/work-type-detail-types.ts
@@ -10,7 +10,6 @@ export interface WorkTypeDetailMessages
   configurationEmpty: string;
   configurationErrorPrefix: string;
   configurationLoading: string;
-  editableConfigurationDirtyStatus: string;
   editableConfigurationSaveAction: string;
   editableConfigurationSaveBusyAction: string;
   editableConfigurationSaveConfirmationCancelAction: string;

--- a/ui/src/features/current-selection/work-type-selection/messages/work-type-detail.ts
+++ b/ui/src/features/current-selection/work-type-selection/messages/work-type-detail.ts
@@ -28,8 +28,6 @@ const workTypeDetailMessagesByLocale = {
       "Loading the current factory definition for this work type.",
     editableConfigurationContractInvalidPrefix:
       "Work type configuration is invalid.",
-    editableConfigurationDirtyStatus:
-      "You have unsaved changes for this work type.",
     editableConfigurationNameDuplicate: (workTypeName: string) =>
       `A work type named "${workTypeName}" already exists in the running factory definition.`,
     editableConfigurationNameRequired:
@@ -71,8 +69,6 @@ const workTypeDetailMessagesByLocale = {
     configurationLoading:
       "このワークタイプの現在のファクトリ定義を読み込んでいます。",
     editableConfigurationContractInvalidPrefix: "ワークタイプ設定が無効です。",
-    editableConfigurationDirtyStatus:
-      "このワークタイプに未保存の変更があります。",
     editableConfigurationNameDuplicate: (workTypeName: string) =>
       `実行中のファクトリ定義には、すでに「${workTypeName}」というワークタイプが存在します。`,
     editableConfigurationNameRequired:
@@ -127,8 +123,6 @@ const workTypeDetailMessagesByLocale = {
       "이 작업 유형의 현재 팩토리 정의를 불러오는 중입니다.",
     editableConfigurationContractInvalidPrefix:
       "작업 유형 구성이 유효하지 않습니다.",
-    editableConfigurationDirtyStatus:
-      "이 작업 유형에 저장되지 않은 변경 사항이 있습니다.",
     editableConfigurationNameDuplicate: (workTypeName: string) =>
       `실행 중인 팩토리 정의에 "${workTypeName}" 작업 유형이 이미 있습니다.`,
     editableConfigurationNameRequired:
@@ -179,7 +173,6 @@ const workTypeDetailMessagesByLocale = {
     configurationErrorPrefix: "工作类型定义不可用。",
     configurationLoading: "正在加载此工作类型的当前工厂定义。",
     editableConfigurationContractInvalidPrefix: "工作类型配置无效。",
-    editableConfigurationDirtyStatus: "此工作类型有未保存的更改。",
     editableConfigurationNameDuplicate: (workTypeName: string) =>
       `运行中的工厂定义中已存在名为“${workTypeName}”的工作类型。`,
     editableConfigurationNameRequired: "保存此工作类型前请输入工作类型名称。",

--- a/ui/src/features/current-selection/worker-selection/components/worker-detail-card.test.tsx
+++ b/ui/src/features/current-selection/worker-selection/components/worker-detail-card.test.tsx
@@ -717,8 +717,10 @@ describe("WorkerDetailCard", () => {
     render(
       <WorkerDetailCard
         editableConfigurationState={editableConfigurationState}
-        headerAction={buildWorkerHeaderSaveAction({ canSave: true })}
-        onSaveConfiguration={vi.fn()}
+        headerAction={buildWorkerHeaderActions({
+          canDiscard: true,
+          canSave: true,
+        })}
         workerName="reviewer"
       />,
     );

--- a/ui/src/features/current-selection/worker-selection/components/worker-detail-card.test.tsx
+++ b/ui/src/features/current-selection/worker-selection/components/worker-detail-card.test.tsx
@@ -658,6 +658,87 @@ describe("WorkerDetailCard", () => {
     ).toBeTruthy();
   });
 
+  it("omits global unsaved helper paragraphs for dirty ready-state worker drafts", () => {
+    const editableConfigurationState: EditableWorkerConfigurationState = {
+      canSave: true,
+      draft: {
+        argsText: "",
+        body: "",
+        command: "",
+        executorProvider: null,
+        model: "gpt-5.5",
+        modelLocality: null,
+        modelProvider: "CURSOR",
+        name: "reviewer",
+        provider: null,
+        type: "MODEL_WORKER",
+      },
+      hasValidationErrors: false,
+      initialValues: {
+        args: [],
+        body: null,
+        command: null,
+        executorProvider: null,
+        model: "gpt-5.5",
+        modelLocality: null,
+        modelProvider: "CURSOR",
+        name: "reviewer",
+        provider: null,
+        type: "MODEL_WORKER",
+        workerName: "reviewer",
+        workstationNames: ["Review"],
+      },
+      isDirty: true,
+      onArgsTextChange: vi.fn(),
+      onBodyChange: vi.fn(),
+      onCommandChange: vi.fn(),
+      onExecutorProviderChange: vi.fn(),
+      onModelChange: vi.fn(),
+      onModelLocalityChange: vi.fn(),
+      onModelProviderChange: vi.fn(),
+      onNameChange: vi.fn(),
+      onProviderChange: vi.fn(),
+      markChangesSaved: vi.fn(),
+      onResetToLatest: vi.fn(),
+      onTypeChange: vi.fn(),
+      overwriteFieldNames: [],
+      pendingFactoryDefinition: buildFactoryDocument(),
+      status: "ready",
+      validationErrors: {},
+    };
+
+    mockFactoryDocumentQuery({
+      data: buildFactoryDocument(),
+      isPending: false,
+      isSuccess: true,
+      status: "success",
+    } as never);
+
+    render(
+      <WorkerDetailCard
+        editableConfigurationState={editableConfigurationState}
+        headerAction={buildWorkerHeaderSaveAction({ canSave: true })}
+        onSaveConfiguration={vi.fn()}
+        workerName="reviewer"
+      />,
+    );
+
+    expect(
+      screen.queryByText("You have unsaved changes for this worker."),
+    ).toBeNull();
+    expect(
+      screen.queryByText(
+        "Changes stay local to this edit session until you save the running factory.",
+      ),
+    ).toBeNull();
+    expect(
+      screen.getAllByRole("button", { name: "Save worker" }).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getByRole("button", { name: "Discard local changes" }),
+    ).toBeTruthy();
+  });
+
   it("renders hosted worker provider fields in the editable configuration section", () => {
     const editableConfigurationState: EditableWorkerConfigurationState = {
       canSave: false,

--- a/ui/src/features/current-selection/worker-selection/components/worker-editable-configuration-section.tsx
+++ b/ui/src/features/current-selection/worker-selection/components/worker-editable-configuration-section.tsx
@@ -350,43 +350,26 @@ function WorkerEditableConfigurationDraftStatus({
   messages: ReturnType<typeof getWorkerDetailMessages>;
   state: Extract<EditableWorkerConfigurationState, { status: "ready" }>;
 }) {
+  if (!state.hasValidationErrors) {
+    return null;
+  }
+
   return (
     <div className={CURRENT_SELECTION_FIELD_PANEL_CLASS}>
       <p
-        className={cn(
-          "m-0",
-          state.hasValidationErrors
-            ? "text-af-danger-text"
-            : "text-af-text-muted",
-          DASHBOARD_BODY_TEXT_CLASS,
-        )}
-        role={state.hasValidationErrors ? "alert" : "status"}
+        className={cn("m-0 text-af-danger-text", DASHBOARD_BODY_TEXT_CLASS)}
+        role="alert"
       >
-        {state.hasValidationErrors
-          ? messages.editableConfigurationValidationStatus
-          : state.isDirty
-            ? messages.editableConfigurationDirtyStatus
-            : messages.editableConfigurationDraftNote}
+        {messages.editableConfigurationValidationStatus}
       </p>
-      {state.hasValidationErrors ? (
-        <p
-          className={cn(
-            "m-0 text-af-text-subtle",
-            DASHBOARD_SUPPORTING_TEXT_CLASS,
-          )}
-        >
-          {messages.editableConfigurationSaveDisabledValidationDetail}
-        </p>
-      ) : (
-        <p
-          className={cn(
-            "m-0 text-af-text-subtle",
-            DASHBOARD_SUPPORTING_TEXT_CLASS,
-          )}
-        >
-          {messages.editableConfigurationDraftNote}
-        </p>
-      )}
+      <p
+        className={cn(
+          "m-0 text-af-text-subtle",
+          DASHBOARD_SUPPORTING_TEXT_CLASS,
+        )}
+      >
+        {messages.editableConfigurationSaveDisabledValidationDetail}
+      </p>
     </div>
   );
 }

--- a/ui/src/features/current-selection/worker-selection/messages/worker-detail-types.ts
+++ b/ui/src/features/current-selection/worker-selection/messages/worker-detail-types.ts
@@ -16,8 +16,6 @@ export interface WorkerDetailMessages {
   editableConfigurationBodyRequired: string;
   editableConfigurationCommandRequired: string;
   editableConfigurationContractInvalidPrefix: string;
-  editableConfigurationDirtyStatus: string;
-  editableConfigurationDraftNote: string;
   editableConfigurationOverwriteWarning: (fields: string) => string;
   editableConfigurationOverwriteWarningDetail: string;
   editableConfigurationServerFieldChangedHint: string;

--- a/ui/src/features/current-selection/worker-selection/messages/worker-detail.ts
+++ b/ui/src/features/current-selection/worker-selection/messages/worker-detail.ts
@@ -41,10 +41,6 @@ const workerDetailMessagesByLocale = {
       "Enter a command before saving this worker.",
     editableConfigurationContractInvalidPrefix:
       "Worker configuration is invalid.",
-    editableConfigurationDirtyStatus:
-      "You have unsaved changes for this worker.",
-    editableConfigurationDraftNote:
-      "Changes stay local to this edit session until you save the running factory.",
     editableConfigurationOverwriteWarning: (fields) =>
       `The running factory changed after you started editing. Saving now will overwrite newer server values for ${fields}.`,
     editableConfigurationOverwriteWarningDetail:
@@ -130,9 +126,6 @@ const workerDetailMessagesByLocale = {
     editableConfigurationCommandRequired:
       "このワーカーを保存する前にコマンドを入力してください。",
     editableConfigurationContractInvalidPrefix: "ワーカー設定が無効です。",
-    editableConfigurationDirtyStatus: "このワーカーに未保存の変更があります。",
-    editableConfigurationDraftNote:
-      "保存するまで変更はこの編集セッション内にのみ保持されます。",
     editableConfigurationOverwriteWarning: (fields) =>
       `編集開始後に実行中のファクトリが変更されました。保存すると ${fields} の新しいサーバー値を上書きします。`,
     editableConfigurationOverwriteWarningDetail:
@@ -217,10 +210,6 @@ const workerDetailMessagesByLocale = {
       "이 워커를 저장하기 전에 명령을 입력하세요.",
     editableConfigurationContractInvalidPrefix:
       "워커 구성이 유효하지 않습니다.",
-    editableConfigurationDirtyStatus:
-      "이 워커에 저장되지 않은 변경 사항이 있습니다.",
-    editableConfigurationDraftNote:
-      "저장할 때까지 변경 사항은 이 편집 세션에만 유지됩니다.",
     editableConfigurationOverwriteWarning: (fields) =>
       `편집을 시작한 뒤 실행 중인 팩토리가 변경되었습니다. 저장하면 ${fields}의 최신 서버 값을 덮어씁니다.`,
     editableConfigurationOverwriteWarningDetail:
@@ -299,8 +288,6 @@ const workerDetailMessagesByLocale = {
     editableConfigurationBodyRequired: "保存此 worker 前请输入脚本正文。",
     editableConfigurationCommandRequired: "保存此 worker 前请输入命令。",
     editableConfigurationContractInvalidPrefix: "Worker 配置无效。",
-    editableConfigurationDirtyStatus: "此 worker 有未保存的更改。",
-    editableConfigurationDraftNote: "保存前，更改仅保留在此编辑会话中。",
     editableConfigurationOverwriteWarning: (fields) =>
       `开始编辑后运行中的工厂已更改。保存将覆盖 ${fields} 的较新服务器值。`,
     editableConfigurationOverwriteWarningDetail:

--- a/ui/src/features/current-selection/workstation-selection/components/workstation-detail-card.editable-configuration.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/workstation-detail-card.editable-configuration.test.tsx
@@ -2054,9 +2054,11 @@ describe("WorkstationDetailCard editable configuration", () => {
           isDirty: true,
           pendingFactoryDefinition: buildDetailCardEditableFactoryDocument(),
         }}
-        headerAction={buildWorkstationHeaderActions({ canSave: true })}
+        headerAction={buildWorkstationHeaderActions({
+          canDiscard: true,
+          canSave: true,
+        })}
         now={DETAIL_CARD_NOW}
-        onSaveConfiguration={vi.fn()}
         providerSessions={[]}
         selectedNode={selectedNode}
       />,
@@ -2076,7 +2078,7 @@ describe("WorkstationDetailCard editable configuration", () => {
       screen.getAllByRole("button", { name: "Save changes" }).length,
     ).toBeGreaterThan(0);
     expect(
-      screen.getByRole("button", { name: "Reset to latest" }),
+      screen.getByRole("button", { name: "Discard local changes" }),
     ).toBeTruthy();
   });
 });

--- a/ui/src/features/current-selection/workstation-selection/components/workstation-detail-card.editable-configuration.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/workstation-detail-card.editable-configuration.test.tsx
@@ -2039,4 +2039,44 @@ describe("WorkstationDetailCard editable configuration", () => {
     expect(within(configuration).getByLabelText("Runner")).toBeTruthy();
     expect(within(configuration).getByLabelText("Prompt")).toBeTruthy();
   });
+
+  it("omits global unsaved helper paragraphs for dirty ready-state workstation drafts", () => {
+    const snapshot = semanticWorkflowDashboardSnapshot;
+    const selectedNode = snapshot.topology.workstation_nodes_by_id.review;
+
+    render(
+      <WorkstationDetailCard
+        activeExecutions={[]}
+        editableConfigurationState={{
+          ...buildReadyEditableConfigurationState({
+            prompt: "Updated prompt for review.",
+          }),
+          isDirty: true,
+          pendingFactoryDefinition: buildDetailCardEditableFactoryDocument(),
+        }}
+        headerAction={buildWorkstationHeaderActions({ canSave: true })}
+        now={DETAIL_CARD_NOW}
+        onSaveConfiguration={vi.fn()}
+        providerSessions={[]}
+        selectedNode={selectedNode}
+      />,
+    );
+
+    expandEditableConfiguration();
+
+    expect(
+      screen.queryByText("You have unsaved changes for this workstation."),
+    ).toBeNull();
+    expect(
+      screen.queryByText(
+        "Changes stay local to this edit session until you save the running factory.",
+      ),
+    ).toBeNull();
+    expect(
+      screen.getAllByRole("button", { name: "Save changes" }).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getByRole("button", { name: "Reset to latest" }),
+    ).toBeTruthy();
+  });
 });

--- a/ui/src/features/current-selection/workstation-selection/components/workstation-editable-configuration-section.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/workstation-editable-configuration-section.tsx
@@ -320,35 +320,17 @@ function EditableConfigurationDraftStatus({
     state.promptDiagnostics,
   );
 
+  if (!state.hasValidationErrors || promptOnlyValidationErrors) {
+    return null;
+  }
+
   return (
     <div className={CURRENT_SELECTION_FIELD_PANEL_CLASS}>
       <p
-        className={cn(
-          "m-0",
-          state.hasValidationErrors && !promptOnlyValidationErrors
-            ? "text-af-danger-text"
-            : "text-af-text-muted",
-          DASHBOARD_BODY_TEXT_CLASS,
-        )}
-        role={
-          state.hasValidationErrors && !promptOnlyValidationErrors
-            ? "alert"
-            : "status"
-        }
+        className={cn("m-0 text-af-danger-text", DASHBOARD_BODY_TEXT_CLASS)}
+        role="alert"
       >
-        {state.hasValidationErrors && !promptOnlyValidationErrors
-          ? messages.editableConfigurationValidationStatus
-          : state.isDirty
-            ? messages.editableConfigurationDirtyStatus
-            : messages.editableConfigurationDraftNote}
-      </p>
-      <p
-        className={cn(
-          "m-0 text-af-text-subtle",
-          DASHBOARD_SUPPORTING_TEXT_CLASS,
-        )}
-      >
-        {messages.editableConfigurationDraftNote}
+        {messages.editableConfigurationValidationStatus}
       </p>
     </div>
   );

--- a/ui/src/features/current-selection/workstation-selection/messages/workstation-detail-types.ts
+++ b/ui/src/features/current-selection/workstation-selection/messages/workstation-detail-types.ts
@@ -9,8 +9,6 @@ export interface WorkstationDetailMessages {
   editableConfigurationExpandActionLabel: string;
   editableConfigurationHeading: string;
   editableConfigurationLoading: string;
-  editableConfigurationDirtyStatus: string;
-  editableConfigurationDraftNote: string;
   editableConfigurationModelSharedWorkerHint: string;
   editableConfigurationResetAction: string;
   editableConfigurationServerFieldChangedHint: string;

--- a/ui/src/features/current-selection/workstation-selection/messages/workstation-detail.ts
+++ b/ui/src/features/current-selection/workstation-selection/messages/workstation-detail.ts
@@ -30,10 +30,6 @@ const workstationDetailMessagesByLocale = {
     editableConfigurationCollapseActionLabel: "Collapse editable configuration",
     editableConfigurationExpandActionLabel: "Expand editable configuration",
     editableConfigurationHeading: "Configuration",
-    editableConfigurationDirtyStatus:
-      "You have unsaved changes for this workstation.",
-    editableConfigurationDraftNote:
-      "Changes stay local to this edit session until you save the running factory.",
     editableConfigurationModelSharedWorkerHint:
       "Model edits are disabled here because this workstation shares its worker with other workstations.",
     editableConfigurationResetAction: "Reset to latest",
@@ -217,10 +213,6 @@ const workstationDetailMessagesByLocale = {
     editableConfigurationCollapseActionLabel: "編集可能な構成を折りたたむ",
     editableConfigurationExpandActionLabel: "編集可能な構成を展開",
     editableConfigurationHeading: "構成",
-    editableConfigurationDirtyStatus:
-      "このワークステーションには未保存の変更があります。",
-    editableConfigurationDraftNote:
-      "変更は、実行中ファクトリーを保存するまでこの編集セッション内だけに保持されます。",
     editableConfigurationModelSharedWorkerHint:
       "このワークステーションは他のワークステーションと同じワーカーを共有しているため、ここではモデルを編集できません。",
     editableConfigurationResetAction: "最新へ戻す",
@@ -404,10 +396,6 @@ const workstationDetailMessagesByLocale = {
     editableConfigurationCollapseActionLabel: "편집 가능한 구성 접기",
     editableConfigurationExpandActionLabel: "편집 가능한 구성 펼치기",
     editableConfigurationHeading: "구성",
-    editableConfigurationDirtyStatus:
-      "이 워크스테이션에 저장되지 않은 변경 사항이 있습니다.",
-    editableConfigurationDraftNote:
-      "변경 사항은 실행 중인 팩토리를 저장할 때까지 이 편집 세션에만 로컬로 유지됩니다.",
     editableConfigurationModelSharedWorkerHint:
       "이 워크스테이션은 다른 워크스테이션과 같은 워커를 공유하므로 여기서는 모델을 편집할 수 없습니다.",
     editableConfigurationResetAction: "최신값으로 재설정",
@@ -587,9 +575,6 @@ const workstationDetailMessagesByLocale = {
     editableConfigurationCollapseActionLabel: "收起可编辑配置",
     editableConfigurationExpandActionLabel: "展开可编辑配置",
     editableConfigurationHeading: "配置",
-    editableConfigurationDirtyStatus: "此工作站存在未保存的更改。",
-    editableConfigurationDraftNote:
-      "在保存运行中的工厂之前，更改只会保留在当前编辑会话中。",
     editableConfigurationModelSharedWorkerHint:
       "此工作站与其他工作站共享同一个 worker，因此这里不能编辑模型。",
     editableConfigurationResetAction: "重置为最新值",


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/issues3-remove-verbose-unsaved-copy",
  "description": "Remove redundant global unsaved-state helper paragraphs from current-selection editable configuration surfaces while preserving header/save-row dirty affordances and actionable validation or conflict messaging.",
  "context": {
    "customerAsk": "Remove global unsaved helper sentences ('You have unsaved changes for this resource' and 'Changes stay local to this edit session until you save the running factory') from all current-selection editable surfaces. Unsaved state must still be indicated by header controls or existing affordances without the paragraph copy.",
    "problem": "Current-selection editable configuration panels show two repetitive paragraphs for unsaved and draft-session state. Operators already see dirty state through warning-styled save actions and discard controls, so the extra copy adds noise without actionable information.",
    "solution": "Stop rendering the global unsaved and draft-session helper paragraphs on resource, worker, workstation, work state, and work type editable surfaces. Keep validation errors, overwrite warnings, server-changed hints, and existing header/save-row dirty affordances. Remove obsolete i18n message keys and add regression tests."
  },
  "acceptanceCriteria": [
    "The target unsaved and draft-session helper sentences (and localized equivalents) do not appear on any current-selection editable configuration surface for resource, worker, workstation, work state, or work type.",
    "Dirty valid drafts still show warning-styled save emphasis and available discard/reset through existing header or save-row controls.",
    "Validation errors, overwrite warnings, and server-changed field hints still render when applicable.",
    "Obsolete editableConfigurationDirtyStatus and editableConfigurationDraftNote message keys are removed from types and all locale catalogs.",
    "UI regression tests assert removed copy is absent for dirty drafts while save/discard affordances remain.",
    "Typecheck, lint, and tests pass for the UI package."
  ],
  "userStories": [
    {
      "id": "issues3-remove-verbose-unsaved-copy-001",
      "title": "Stop rendering global unsaved helper paragraphs on editable configuration surfaces",
      "description": "As a factory operator editing running-factory configuration, I want the configuration panel to omit redundant unsaved-state paragraphs so I can focus on fields and actionable errors.",
      "acceptanceCriteria": [
        "On resource, worker, workstation, and work-state editable configuration surfaces, neither the dirty-status sentence nor the draft-session sentence appears when the draft is clean, dirty, or saveable.",
        "On the work-type editable configuration surface, the dirty-status sentence does not appear when the draft is dirty.",
        "When hasValidationErrors is true on surfaces that use a draft-status block, validation status and save-disabled detail copy still appear.",
        "When a draft is dirty and saveable, the save action still shows warning emphasis and discard/reset remains available without the removed paragraphs.",
        "Overwrite warnings and server-changed field hints are unchanged.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill: open a dirty resource or worker configuration and confirm helper paragraphs are gone while header save and discard still work"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "issues3-remove-verbose-unsaved-copy-002",
      "title": "Remove obsolete unsaved-helper message keys and lock in regression coverage",
      "description": "As a maintainer, I want unused unsaved-helper message catalog entries removed so copy cannot drift back into the UI accidentally.",
      "acceptanceCriteria": [
        "editableConfigurationDirtyStatus and editableConfigurationDraftNote are removed from message types and all locale catalogs (en, ja, ko, zh-CN) for resource, worker, workstation, and work state; work type loses editableConfigurationDirtyStatus only.",
        "No remaining UI or test references to the removed message keys.",
        "At least one component test per affected selection family asserts the removed English helper strings are not in the document when a dirty ready-state draft is rendered.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)