### PR TITLE
inline-react-flow-current-activity-card-classes

### DIFF
--- a/ui/scripts/inline-component-class-usage-allowlist.mjs
+++ b/ui/scripts/inline-component-class-usage-allowlist.mjs
@@ -79,6 +79,4 @@ export const allowlistedInlineComponentClassUsage = [
   "src/features/workflow-activity/components/dashboard-flow-axis-legend.tsx#PANEL_HEADER_CLASS",
   "src/features/workflow-activity/components/dashboard-flow-axis-legend.tsx#PANEL_TITLE_CLASS",
   "src/features/workflow-activity/components/dashboard-flow-axis-legend.tsx#COLLAPSE_BUTTON_CLASS",
-  "src/features/workflow-activity/components/react-flow-current-activity-card.tsx#CURRENT_ACTIVITY_CARD_CLASS",
-  "src/features/workflow-activity/components/react-flow-current-activity-card.tsx#CURRENT_ACTIVITY_TITLE_CLASS",
 ];

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card.tsx
@@ -4,10 +4,10 @@ import { useId } from "react";
 
 import type { DashboardSnapshot } from "../../../api/dashboard/types";
 import type { ImportFactoryValue } from "../../../api/session-factory";
-import { useDashboardSession } from "../../dashboard/session/dashboard-session-provider";
 import { DASHBOARD_PANEL_SHELL_CLASS } from "../../../components/ui/dashboard-shell";
 import { DASHBOARD_SECTION_HEADING_CLASS } from "../../../components/ui/dashboard-typography";
 import { cn } from "../../../lib/cn";
+import { useDashboardSession } from "../../dashboard/session/dashboard-session-provider";
 import type { ReadFactoryImportFile } from "../../import/hooks/use-factory-png-drop";
 import type { FactoryImportConfirmInput } from "../../import/lib/factory-import-save-choice";
 import type { FactoryPngImportValue } from "../../import/lib/factory-png-import";
@@ -19,24 +19,17 @@ import { useCurrentActivityGraphEditor } from "../hooks/react-flow-current-activ
 import { useCurrentActivityGraphViewModel } from "../hooks/react-flow-current-activity-card-graph-view-model";
 import type { CurrentActivitySelection } from "../lib/react-flow-current-activity-card-types";
 import { getWorkflowActivityShellMessages } from "../messages/activity-shell";
+import { GraphEditorPlacementProvider } from "./graph-editor-placement-context";
 import { CurrentActivityGraphHeaderActions } from "./react-flow-current-activity-card-editor-chrome";
 import { CurrentActivityGraphEditorDialogs } from "./react-flow-current-activity-card-editor-dialogs";
 import { CurrentActivityGraphSaveNotifications } from "./react-flow-current-activity-card-save-notifications";
-import { GraphEditorPlacementProvider } from "./graph-editor-placement-context";
 import { CurrentActivityGraphSurface } from "./react-flow-current-activity-card-surface";
 
+export { useCurrentActivityGraphViewModel } from "../hooks/react-flow-current-activity-card-graph-view-model";
 export {
   currentActivityGraphKey,
   currentActivityTopologyKey,
 } from "../lib/react-flow-current-activity-card-keys";
-
-export { useCurrentActivityGraphViewModel } from "../hooks/react-flow-current-activity-card-graph-view-model";
-
-const CURRENT_ACTIVITY_CARD_CLASS = cn(
-  DASHBOARD_PANEL_SHELL_CLASS,
-  "relative flex h-full min-h-0 min-w-0 flex-col",
-);
-const CURRENT_ACTIVITY_TITLE_CLASS = cn("m-0", DASHBOARD_SECTION_HEADING_CLASS);
 
 export type { CurrentActivitySelection } from "../lib/react-flow-current-activity-card-types";
 
@@ -61,7 +54,7 @@ function CurrentActivityCardHeading({
 
   return (
     <div>
-      <h2 className={CURRENT_ACTIVITY_TITLE_CLASS} id={headingID}>
+      <h2 className={cn("m-0", DASHBOARD_SECTION_HEADING_CLASS)} id={headingID}>
         {messages.title}
       </h2>
     </div>
@@ -77,7 +70,9 @@ function useCurrentActivityAccessibilityIDs(widgetInstanceID?: string) {
 }
 
 interface ReactFlowCurrentActivityCardProps {
-  activateFactory?: (input: FactoryImportConfirmInput) => Promise<ImportFactoryValue>;
+  activateFactory?: (
+    input: FactoryImportConfirmInput,
+  ) => Promise<ImportFactoryValue>;
   importController?: CurrentActivityImportController;
   locale?: string;
   now: number;
@@ -143,61 +138,64 @@ export function ReactFlowCurrentActivityCardView(
 
   return (
     <GraphEditorPlacementProvider>
-    <section
-      aria-labelledby={headingID}
-      className={CURRENT_ACTIVITY_CARD_CLASS}
-    >
-      {showHeaderActions ? (
-        <div className="mb-4">
-          <CurrentActivityGraphHeaderActions
-            editorMode={editor.editorMode}
-            editorUnavailableClassifierWorkstationName={
-              editor.editorUnavailableClassifierWorkstationName
-            }
-            hasChanges={editor.draftState.hasChanges}
-            isDefinitionLoading={
-              editor.editableDefinitionQuery.status === "pending"
-            }
-            loadErrorMessage={editor.editableDefinitionQuery.error?.message}
+      <section
+        aria-labelledby={headingID}
+        className={cn(
+          DASHBOARD_PANEL_SHELL_CLASS,
+          "relative flex h-full min-h-0 min-w-0 flex-col",
+        )}
+      >
+        {showHeaderActions ? (
+          <div className="mb-4">
+            <CurrentActivityGraphHeaderActions
+              editorMode={editor.editorMode}
+              editorUnavailableClassifierWorkstationName={
+                editor.editorUnavailableClassifierWorkstationName
+              }
+              hasChanges={editor.draftState.hasChanges}
+              isDefinitionLoading={
+                editor.editableDefinitionQuery.status === "pending"
+              }
+              loadErrorMessage={editor.editableDefinitionQuery.error?.message}
+              locale={props.locale}
+              onToggle={editor.handleEditorModeToggle}
+            />
+          </div>
+        ) : null}
+        {showHeaderActions ? (
+          <CurrentActivityCardHeading
+            headingID={headingID}
             locale={props.locale}
-            onToggle={editor.handleEditorModeToggle}
           />
-        </div>
-      ) : null}
-      {showHeaderActions ? (
-        <CurrentActivityCardHeading
+        ) : (
+          <CurrentActivityCardHeading
+            headingID={headingID}
+            hidden
+            locale={props.locale}
+          />
+        )}
+        <CurrentActivityGraphSurface
+          editor={editor}
+          graph={graph}
           headingID={headingID}
+          imports={imports}
+          locale={props.locale}
+          selection={props.selection}
+          snapshot={props.snapshot}
+        />
+        <CurrentActivityGraphSaveNotifications
+          editor={editor}
           locale={props.locale}
         />
-      ) : (
-        <CurrentActivityCardHeading
-          headingID={headingID}
-          hidden
+        <CurrentActivityGraphEditorDialogs
+          currentSessionFactoryName={props.snapshot.factory?.name ?? "factory"}
+          editor={editor}
+          imports={imports}
           locale={props.locale}
+          readyImportPreviewState={readyImportPreviewState}
+          shouldRenderImportPreviewDialog={shouldRenderImportPreviewDialog}
         />
-      )}
-      <CurrentActivityGraphSurface
-        editor={editor}
-        graph={graph}
-        headingID={headingID}
-        imports={imports}
-        locale={props.locale}
-        selection={props.selection}
-        snapshot={props.snapshot}
-      />
-      <CurrentActivityGraphSaveNotifications
-        editor={editor}
-        locale={props.locale}
-      />
-      <CurrentActivityGraphEditorDialogs
-        currentSessionFactoryName={props.snapshot.factory?.name ?? "factory"}
-        editor={editor}
-        imports={imports}
-        locale={props.locale}
-        readyImportPreviewState={readyImportPreviewState}
-        shouldRenderImportPreviewDialog={shouldRenderImportPreviewDialog}
-      />
-    </section>
+      </section>
     </GraphEditorPlacementProvider>
   );
 }


### PR DESCRIPTION
{
  "project": "Infinite You Dashboard UI",
  "branchName": "ralph/inline-react-flow-current-activity-card-classes",
  "description": "Inline the last two allowlisted layout class constants on react-flow-current-activity-card.tsx (card shell and section heading) directly onto JSX className props, remove the module-level constants and matching allowlist entries, and preserve current visual structure and accessibility.",
  "context": {
    "customerAsk": "After PR #587, inline CURRENT_ACTIVITY_CARD_CLASS and CURRENT_ACTIVITY_TITLE_CLASS on react-flow-current-activity-card.tsx in one exact-file change; remove both allowlist entries; preserve panel shell, heading typography, and h2/sr-only accessibility structure; do not touch other allowlisted files or issues3 work.",
    "problem": "Two module-level cn(...) class constants on the current-activity card remain allowlisted debt. Readers must jump above JSX to see shell and title styles, and the inline-component-class-usage guard still exempts this file.",
    "solution": "Move both cn expressions onto the consuming section and h2 className props, delete the constants, remove the two allowlist keys, and verify with the existing Vitest card/heading assertions plus check:inline-component-class-usage."
  },
  "acceptanceCriteria": [
    "react-flow-current-activity-card.tsx contains no CURRENT_ACTIVITY_CARD_CLASS or CURRENT_ACTIVITY_TITLE_CLASS identifiers",
    "Root section keeps DASHBOARD_PANEL_SHELL_CLASS plus relative flex h-full min-h-0 min-w-0 flex-col via inline className; visible h2 keeps m-0 and DASHBOARD_SECTION_HEADING_CLASS with id={headingID}",
    "aria-labelledby on section and sr-only hidden heading path remain unchanged",
    "Both allowlist entries for react-flow-current-activity-card.tsx are removed; no other allowlist files change",
    "cd ui && npm run check:inline-component-class-usage exits successfully",
    "Existing react-flow-current-activity-card Vitest coverage for card classes and Current activity heading still passes",
    "Typecheck passes, lint passes, and affected UI tests pass"
  ],
  "userStories": [
    {
      "id": "inline-react-flow-current-activity-card-classes-001",
      "title": "Inline card shell and section heading classes",
      "description": "As a dashboard operator, I want the current-activity card to look and read the same as today so that inlining styling constants does not change layout or accessibility.",
      "acceptanceCriteria": [
        "Root section uses inline className={cn(DASHBOARD_PANEL_SHELL_CLASS, \"relative flex h-full min-h-0 min-w-0 flex-col\")} equivalent to former CURRENT_ACTIVITY_CARD_CLASS",
        "Visible h2 in CurrentActivityCardHeading uses inline className={cn(\"m-0\", DASHBOARD_SECTION_HEADING_CLASS)} with id={headingID}",
        "Hidden heading path still renders sr-only span with id={headingID}",
        "Module-level CURRENT_ACTIVITY_CARD_CLASS and CURRENT_ACTIVITY_TITLE_CLASS are deleted",
        "react-flow-current-activity-card.test.tsx assertions for card className (relative, flex, h-full) and heading name Current activity still pass",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "inline-react-flow-current-activity-card-classes-002",
      "title": "Drop allowlist exceptions and confirm inline-class guard",
      "description": "As a maintainer, I want this file fully compliant with the inline-component-class-usage policy so allowlist debt does not remain on the current-activity card.",
      "acceptanceCriteria": [
        "Removed allowlist keys src/features/workflow-activity/components/react-flow-current-activity-card.tsx#CURRENT_ACTIVITY_CARD_CLASS and #CURRENT_ACTIVITY_TITLE_CLASS only",
        "cd ui && npm run check:inline-component-class-usage exits 0 with no stale allowlist entries for this file",
        "No other allowlisted components are modified in this change",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser: ReactFlowCurrentActivityCard with header actions shows unchanged panel shell, Current activity heading, and graph layout"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)