### PR TITLE
migrate-submit-clihttp

### DIFF
--- a/pkg/cli/clihttp/clihttp.go
+++ b/pkg/cli/clihttp/clihttp.go
@@ -35,6 +35,12 @@ func PostJSON(ctx context.Context, client *http.Client, url string, body io.Read
 	return doJSON(ctx, client, http.MethodPost, url, body, dst, http.StatusOK, opts)
 }
 
+// PostJSONCreated executes an HTTP POST with an optional JSON body and decodes JSON into dst when
+// the response status is 201 Created.
+func PostJSONCreated(ctx context.Context, client *http.Client, url string, body io.Reader, dst any, opts RequestOptions) (*http.Response, error) {
+	return doJSON(ctx, client, http.MethodPost, url, body, dst, http.StatusCreated, opts)
+}
+
 // PutJSON executes an HTTP PUT with an optional JSON body and decodes JSON into dst when the
 // response status is 200 OK.
 func PutJSON(ctx context.Context, client *http.Client, url string, body io.Reader, dst any, opts RequestOptions) (*http.Response, error) {

--- a/pkg/cli/clihttp/clihttp_test.go
+++ b/pkg/cli/clihttp/clihttp_test.go
@@ -194,6 +194,132 @@ func TestPostJSON_SendsJSONBodyAndDecodesResponse(t *testing.T) {
 	}
 }
 
+func TestPostJSONCreated_DecodesSuccessResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Fatalf("content-type = %q, want application/json", r.Header.Get("Content-Type"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		if err := json.NewEncoder(w).Encode(map[string]string{"workId": "work-1"}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	var result map[string]string
+	resp, err := PostJSONCreated(
+		context.Background(),
+		srv.Client(),
+		srv.URL+"/work",
+		strings.NewReader(`{"name":"demo"}`),
+		&result,
+		RequestOptions{EndpointPath: "/work", LogLabel: "submit"},
+	)
+	if err != nil {
+		t.Fatalf("PostJSONCreated: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status = %d, want 201", resp.StatusCode)
+	}
+	if result["workId"] != "work-1" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestPostJSONCreated_ReturnsResponseForNonCreatedStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		if err := json.NewEncoder(w).Encode(factoryapi.ErrorResponse{
+			Message: "invalid work",
+			Code:    factoryapi.ErrorResponseCode("INVALID_REQUEST"),
+			Family:  factoryapi.ErrorFamilyBadRequest,
+		}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	var result map[string]string
+	resp, err := PostJSONCreated(
+		context.Background(),
+		srv.Client(),
+		srv.URL,
+		strings.NewReader(`{"name":"demo"}`),
+		&result,
+		RequestOptions{EndpointPath: "/work", LogLabel: "submit"},
+	)
+	if err != nil {
+		t.Fatalf("PostJSONCreated: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestPostJSONCreated_PropagatesTransportFailure(t *testing.T) {
+	client := &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, io.ErrUnexpectedEOF
+	})}
+
+	var diagnostics bytes.Buffer
+	_, err := PostJSONCreated(
+		context.Background(),
+		client,
+		"http://127.0.0.1:1/work",
+		strings.NewReader(`{"name":"demo"}`),
+		nil,
+		RequestOptions{
+			Diagnostics:  &diagnostics,
+			Verbose:      true,
+			EndpointPath: "/work",
+			LogLabel:     "submit",
+		},
+	)
+	if err == nil {
+		t.Fatal("PostJSONCreated: want transport error")
+	}
+	if !strings.Contains(diagnostics.String(), "submit response endpointPath=/work error=unreachable") {
+		t.Fatalf("diagnostics = %q", diagnostics.String())
+	}
+}
+
+func TestPostJSONCreated_LogsStatusDiagnosticForNonCreated(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	var diagnostics bytes.Buffer
+	resp, err := PostJSONCreated(
+		context.Background(),
+		srv.Client(),
+		srv.URL,
+		strings.NewReader(`{"name":"demo"}`),
+		nil,
+		RequestOptions{
+			Diagnostics:  &diagnostics,
+			Verbose:      true,
+			EndpointPath: "/work",
+			LogLabel:     "submit",
+		},
+	)
+	if err != nil {
+		t.Fatalf("PostJSONCreated: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if !strings.Contains(diagnostics.String(), "submit response endpointPath=/work status=500") {
+		t.Fatalf("diagnostics = %q", diagnostics.String())
+	}
+}
+
 func TestPutJSON_SendsJSONBodyAndDecodesResponse(t *testing.T) {
 	var gotMethod string
 	var gotContentType string

--- a/pkg/cli/submit/submit.go
+++ b/pkg/cli/submit/submit.go
@@ -3,6 +3,7 @@ package submit
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,9 +14,12 @@ import (
 
 	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
 	"github.com/portpowered/infinite-you/pkg/cli/clidiag"
+	"github.com/portpowered/infinite-you/pkg/cli/clihttp"
 	"github.com/portpowered/infinite-you/pkg/cli/cliserver"
 	"github.com/portpowered/infinite-you/pkg/cli/sessionpath"
 )
+
+const submitRequestTimeout = 15 * time.Second
 
 // SubmitConfig holds parameters for the submit command.
 type SubmitConfig struct {
@@ -85,28 +89,39 @@ func Submit(cfg SubmitConfig) error {
 		len(body),
 	)
 	started := time.Now()
-	resp, err := http.Post(endpointURL, "application/json", bytes.NewReader(body))
+	client := &http.Client{Timeout: submitRequestTimeout}
+	var result factoryapi.SubmitWorkResponse
+	resp, err := clihttp.PostJSONCreated(
+		context.Background(),
+		client,
+		endpointURL,
+		bytes.NewReader(body),
+		&result,
+		clihttp.RequestOptions{
+			Diagnostics:  cfg.Diagnostics,
+			Verbose:      cfg.Verbose,
+			EndpointPath: endpointPath,
+			LogLabel:     "submit",
+		},
+	)
 	if err != nil {
-		clidiag.Printf(cfg.Diagnostics, cfg.Verbose, "submit response endpointPath=%s error=unreachable durationMillis=%d", endpointPath, time.Since(started).Milliseconds())
 		return fmt.Errorf("factory not reachable at %s: %w", endpointURL, err)
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("read response: %w", err)
-	}
-
 	if resp.StatusCode != http.StatusCreated {
-		clidiag.Printf(cfg.Diagnostics, cfg.Verbose, "submit response endpointPath=%s status=%d durationMillis=%d responseBytes=%d", endpointPath, resp.StatusCode, time.Since(started).Milliseconds(), len(respBody))
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("read response: %w", err)
+		}
 		return submitFailureError(resp.StatusCode, respBody)
 	}
 
-	var result factoryapi.SubmitWorkResponse
-	if err := json.Unmarshal(respBody, &result); err != nil {
-		return fmt.Errorf("parse response: %w", err)
+	responseBytes := 0
+	if encoded, marshalErr := json.Marshal(result); marshalErr == nil {
+		responseBytes = len(encoded)
 	}
-	clidiag.Printf(cfg.Diagnostics, cfg.Verbose, "submit response endpointPath=%s status=%d durationMillis=%d responseBytes=%d traceId=%s", endpointPath, resp.StatusCode, time.Since(started).Milliseconds(), len(respBody), result.TraceId)
+	clidiag.Printf(cfg.Diagnostics, cfg.Verbose, "submit response endpointPath=%s status=%d durationMillis=%d responseBytes=%d traceId=%s", endpointPath, resp.StatusCode, time.Since(started).Milliseconds(), responseBytes, result.TraceId)
 
 	if cfg.JSON {
 		return writeJSONSubmitSuccess(

--- a/pkg/cli/submit/submit_transport_test.go
+++ b/pkg/cli/submit/submit_transport_test.go
@@ -1,0 +1,178 @@
+package submit
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
+	"github.com/portpowered/infinite-you/pkg/cli/cliserver"
+	"github.com/portpowered/infinite-you/pkg/cli/sessionpath"
+)
+
+// Transport-edge regression tests guard clihttp migration outcomes at the HTTP boundary.
+
+func TestSubmit_Transport_HTTP201CreatedSuccess(t *testing.T) {
+	workID := "transport-work-201"
+	name := "transport-submit"
+	workType := "task"
+	traceID := "transport-trace-201"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		if err := json.NewEncoder(w).Encode(factoryapi.SubmitWorkResponse{
+			TraceId:      traceID,
+			WorkId:       &workID,
+			Name:         &name,
+			WorkTypeName: &workType,
+		}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	payloadPath := filepath.Join(dir, "work.json")
+	if err := os.WriteFile(payloadPath, []byte(`{"title":"transport edge task"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	server := mustServerBase(t, srv.URL)
+	baseCfg := SubmitConfig{
+		Name:         name,
+		WorkTypeName: workType,
+		Payload:      payloadPath,
+		Server:       server,
+	}
+
+	t.Run("humanStdout", func(t *testing.T) {
+		var out bytes.Buffer
+		cfg := baseCfg
+		cfg.Output = &out
+		if err := Submit(cfg); err != nil {
+			t.Fatalf("Submit: %v", err)
+		}
+		got := out.String()
+		for _, want := range []string{
+			"Submitted: transport-submit (task)\n",
+			"traceId: transport-trace-201\n",
+			"workId: transport-work-201\n",
+			"Verify: you work show transport-work-201\n",
+		} {
+			if !strings.Contains(got, want) {
+				t.Fatalf("stdout missing %q:\n%s", want, got)
+			}
+		}
+	})
+
+	t.Run("jsonStdout", func(t *testing.T) {
+		var out bytes.Buffer
+		cfg := baseCfg
+		cfg.JSON = true
+		cfg.Output = &out
+		if err := Submit(cfg); err != nil {
+			t.Fatalf("Submit: %v", err)
+		}
+		var envelope SubmitSuccessResult
+		if err := json.Unmarshal(out.Bytes(), &envelope); err != nil {
+			t.Fatalf("stdout is not valid submit success JSON: %v\n%s", err, out.String())
+		}
+		if envelope.WorkID == nil || *envelope.WorkID != workID {
+			t.Fatalf("workId = %v, want %q", envelope.WorkID, workID)
+		}
+		if envelope.Name != name {
+			t.Fatalf("name = %q, want %q", envelope.Name, name)
+		}
+		if envelope.WorkTypeName != workType {
+			t.Fatalf("workTypeName = %q, want %q", envelope.WorkTypeName, workType)
+		}
+		if envelope.TraceID != traceID {
+			t.Fatalf("traceId = %q, want %q", envelope.TraceID, traceID)
+		}
+		if envelope.SessionID != "~default" {
+			t.Fatalf("sessionId = %q, want ~default", envelope.SessionID)
+		}
+		if envelope.EndpointPath != "/factory-sessions/~default/work" {
+			t.Fatalf("endpointPath = %q, want /factory-sessions/~default/work", envelope.EndpointPath)
+		}
+	})
+}
+
+func TestSubmit_Transport_UnreachableFactory(t *testing.T) {
+	server := "http://127.0.0.1:19999"
+	endpointPath := sessionpath.ScopedPath("/work", "")
+	endpointURL, err := cliserver.RequestURL(server, endpointPath)
+	if err != nil {
+		t.Fatalf("RequestURL: %v", err)
+	}
+
+	dir := t.TempDir()
+	payloadPath := filepath.Join(dir, "work.json")
+	if err := os.WriteFile(payloadPath, []byte(`{"title":"test"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	submitErr := Submit(SubmitConfig{
+		Name:         "transport-unreachable",
+		WorkTypeName: "task",
+		Payload:      payloadPath,
+		Server:       server,
+		Output:       &out,
+	})
+	if submitErr == nil {
+		t.Fatal("expected error when factory is not running")
+	}
+	wantPrefix := "factory not reachable at " + endpointURL
+	if got := submitErr.Error(); !strings.HasPrefix(got, wantPrefix) {
+		t.Fatalf("error = %q, want prefix %q", got, wantPrefix)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty on transport failure", out.String())
+	}
+}
+
+func TestSubmit_Transport_StructuredAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		if err := json.NewEncoder(w).Encode(factoryapi.ErrorResponse{
+			Message: "workTypeName is required",
+			Code:    factoryapi.BADREQUEST,
+			Family:  factoryapi.ErrorFamilyBadRequest,
+		}); err != nil {
+			t.Fatalf("encode error response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	payloadPath := filepath.Join(dir, "work.json")
+	if err := os.WriteFile(payloadPath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	err := Submit(SubmitConfig{
+		Name:         "transport-api-error",
+		WorkTypeName: "task",
+		Payload:      payloadPath,
+		Server:       mustServerBase(t, srv.URL),
+		Output:       &out,
+	})
+	if err == nil {
+		t.Fatal("expected structured API error")
+	}
+	if got := err.Error(); got != "submission failed (400): workTypeName is required" {
+		t.Fatalf("error = %q, want submission failed (400): workTypeName is required", got)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty on API failure", out.String())
+	}
+}


### PR DESCRIPTION
{
  "project": "Migrate submit CLI transport to clihttp",
  "branchName": "ralph/migrate-submit-clihttp",
  "description": "Consolidate single-work `you submit` onto the shared `pkg/cli/clihttp` transport (201-aware POST helper, timeout client, aligned diagnostics) while preserving human/JSON success output, failure error strings, and verbose logging contracts.",
  "context": {
    "customerAsk": "Migrate pkg/cli/submit/submit.go from raw http.Post to pkg/cli/clihttp: add PostJSONCreated for HTTP 201 success, use timeout client and RequestOptions (LogLabel submit), use DecodeAPIError where it helps without changing submitFailureError wording for bad bodies, keep success output unchanged, and strengthen behavioral submit tests.",
    "problem": "submit.go is the remaining standalone CLI submission path using http.Post without the shared clihttp layer or request timeouts; PostJSON only treats 200 as success while submit requires 201 Created.",
    "solution": "Add clihttp.PostJSONCreated with tests, refactor Submit() to use timeout http.Client and PostJSONCreated with submit-specific verbose and error mapping preserved, then lock behavior with targeted submit_test.go assertions for 201 success, unreachable factory, and structured API errors."
  },
  "acceptanceCriteria": [
    "clihttp.PostJSONCreated exists, treats HTTP 201 as success, and is covered by clihttp_test.go",
    "submit.go uses clihttp.PostJSONCreated with timeout http.Client and RequestOptions LogLabel submit; no http.Post",
    "Human and JSON submit success output and failure error strings remain compatible with existing submit_test.go contracts",
    "Verbose submit request and success response diagnostics remain compatible with existing verbose submit tests",
    "go test ./pkg/cli/clihttp/... ./pkg/cli/submit/... passes",
    "Quality gate: Go typecheck, lint, and tests pass for touched packages"
  ],
  "userStories": [
    {
      "id": "migrate-submit-clihttp-001",
      "title": "Add PostJSONCreated to shared CLI HTTP transport",
      "description": "As a CLI maintainer, I need a reusable POST helper that treats HTTP 201 as success so submit does not misuse PostJSON (200-only).",
      "acceptanceCriteria": [
        "PostJSONCreated performs POST with application/json, decodes JSON into dst on HTTP 201 Created, and returns (resp, nil) for other HTTP statuses without transport error",
        "Transport failure logs {LogLabel} response endpointPath=... error=unreachable durationMillis=... when Verbose is enabled via RequestOptions",
        "Non-201 HTTP status logs {LogLabel} response endpointPath=... status=... durationMillis=... when Verbose is enabled",
        "clihttp_test.go includes behavioral tests for 201 decode success, non-201 response without transport error, and transport failure with unreachable diagnostic",
        "Typecheck passes",
        "Tests pass (go test ./pkg/cli/clihttp/...)"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "migrate-submit-clihttp-002",
      "title": "Route Submit() through clihttp without changing CLI behavior",
      "description": "As an operator or agent running you submit, I want the same success output, failure messages, and verbose diagnostics after the transport migration.",
      "acceptanceCriteria": [
        "Submit() uses context.Background(), http.Client with submitRequestTimeout, and clihttp.PostJSONCreated for the scoped work POST",
        "clihttp.RequestOptions supplies Diagnostics, Verbose, EndpointPath, and LogLabel submit for transport-level response logging",
        "Pre-request verbose metadata line (payload path/type/bytes, session, request fields) is unchanged from current behavior",
        "On HTTP 201, human and JSON success writers are unchanged; verbose success line still includes status=201, responseBytes, and traceId when applicable",
        "On transport error, error text remains factory not reachable at {url}: {err}",
        "On non-201, submitFailureError preserves submission failed (N): ... wording including bounded preview and workId suffix; DecodeAPIError used only when it does not alter those contracts for malformed bodies",
        "No http.Post or http.DefaultClient in submit.go",
        "All existing pkg/cli/submit/submit_test.go cases pass without loosening assertions",
        "Typecheck passes",
        "Tests pass (go test ./pkg/cli/submit/...)"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "migrate-submit-clihttp-003",
      "title": "Strengthen submit behavioral tests for transport edge cases",
      "description": "As a maintainer, I want explicit regression tests on submit HTTP boundary outcomes so the clihttp migration cannot silently change success output or failure strings.",
      "acceptanceCriteria": [
        "Test asserts HTTP 201 success: human stdout includes Submitted, traceId, and work metadata; --json stdout unmarshals to SubmitSuccessResult with expected fields",
        "Test asserts unreachable factory: error contains factory not reachable at with resolved URL and stdout is empty on failure",
        "Test asserts structured API error JSON with message field yields submission failed ({status}): {message}",
        "Tests assert runtime CLI outcomes only, not import paths, file names, or registration inventories",
        "Typecheck passes",
        "Tests pass (go test ./pkg/cli/clihttp/... ./pkg/cli/submit/...)"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)