### PR TITLE
inline-dashboard-flow-axis-legend-classes

### DIFF
--- a/ui/scripts/inline-component-class-usage-allowlist.mjs
+++ b/ui/scripts/inline-component-class-usage-allowlist.mjs
@@ -74,11 +74,6 @@ export const allowlistedInlineComponentClassUsage = [
   "src/features/work-outcome/components/trend-cards.tsx#TREND_CAUSE_LABEL_CLASS",
   "src/features/work-outcome/components/trend-cards.tsx#TIMING_RANGE_SUMMARY_CLASS",
   "src/features/work-outcome/components/work-chart.tsx#WORK_CHART_TOOLBAR_CLASS",
-  "src/features/workflow-activity/components/dashboard-flow-axis-legend.tsx#TOGGLE_BUTTON_CLASS",
-  "src/features/workflow-activity/components/dashboard-flow-axis-legend.tsx#PANEL_CLASS",
-  "src/features/workflow-activity/components/dashboard-flow-axis-legend.tsx#PANEL_HEADER_CLASS",
-  "src/features/workflow-activity/components/dashboard-flow-axis-legend.tsx#PANEL_TITLE_CLASS",
-  "src/features/workflow-activity/components/dashboard-flow-axis-legend.tsx#COLLAPSE_BUTTON_CLASS",
   "src/features/workflow-activity/components/react-flow-current-activity-card.tsx#CURRENT_ACTIVITY_CARD_CLASS",
   "src/features/workflow-activity/components/react-flow-current-activity-card.tsx#CURRENT_ACTIVITY_TITLE_CLASS",
 ];

--- a/ui/src/features/workflow-activity/components/dashboard-flow-axis-legend.tsx
+++ b/ui/src/features/workflow-activity/components/dashboard-flow-axis-legend.tsx
@@ -136,14 +136,6 @@ export function getDefaultDashboardFlowAxisLegendPhaseItems(
 
 const DEFAULT_CONTAINER_CLASS =
   "pointer-events-none z-10 flex flex-col items-stretch gap-2 md:items-start";
-const TOGGLE_BUTTON_CLASS =
-  "dashboard-eyebrow pointer-events-auto inline-flex items-center gap-2 rounded-full border border-af-border bg-af-surface-raised px-3 py-2 text-af-text-muted shadow-af-card backdrop-blur-md transition-colors hover:border-af-border-strong hover:bg-af-overlay hover:text-af-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-af-focus-ring";
-const PANEL_CLASS =
-  "dashboard-body-sm pointer-events-auto w-full rounded-lg border border-af-border bg-af-surface-raised px-3 py-3 text-af-text-muted shadow-af-card backdrop-blur-md md:max-w-md";
-const PANEL_HEADER_CLASS = "mb-2 flex items-center justify-between gap-3";
-const PANEL_TITLE_CLASS = "dashboard-eyebrow m-0 text-af-accent";
-const COLLAPSE_BUTTON_CLASS =
-  "dashboard-eyebrow shrink-0 cursor-pointer rounded-full border border-af-border bg-af-surface-subtle px-3 py-2 text-af-text-muted transition hover:border-af-border-strong hover:bg-af-overlay hover:text-af-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-af-focus-ring";
 const ITEMS_LIST_CLASS =
   "m-0 grid list-none grid-cols-1 gap-x-3 gap-y-2 p-0 sm:grid-cols-2";
 const PHASE_SWATCH_CLASS = "h-3 w-3 shrink-0 rounded-sm border";
@@ -289,18 +281,20 @@ export function DashboardFlowAxisLegend({
       {expanded ? (
         <aside
           aria-label={resolvedAriaLabel}
-          className={PANEL_CLASS}
+          className="dashboard-body-sm pointer-events-auto w-full rounded-lg border border-af-border bg-af-surface-raised px-3 py-3 text-af-text-muted shadow-af-card backdrop-blur-md md:max-w-md"
           data-dashboard-flow-axis-legend-panel=""
           id={panelId}
         >
-          <div className={PANEL_HEADER_CLASS}>
+          <div className="mb-2 flex items-center justify-between gap-3">
             <div className="flex min-w-0 items-center gap-2">
               <LegendToggleGlyph />
-              <h3 className={PANEL_TITLE_CLASS}>{resolvedAriaLabel}</h3>
+              <h3 className="dashboard-eyebrow m-0 text-af-accent">
+                {resolvedAriaLabel}
+              </h3>
             </div>
             <DisclosureButton
               aria-label={messages.collapseToggleLabel(actionTargetLabel)}
-              className={COLLAPSE_BUTTON_CLASS}
+              className="dashboard-eyebrow shrink-0 cursor-pointer rounded-full border border-af-border bg-af-surface-subtle px-3 py-2 text-af-text-muted transition hover:border-af-border-strong hover:bg-af-overlay hover:text-af-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-af-focus-ring"
               controlsID={panelId}
               data-dashboard-flow-axis-legend-toggle=""
               expanded={true}
@@ -321,7 +315,7 @@ export function DashboardFlowAxisLegend({
       ) : (
         <DisclosureButton
           aria-label={messages.expandToggleLabel(actionTargetLabel)}
-          className={TOGGLE_BUTTON_CLASS}
+          className="dashboard-eyebrow pointer-events-auto inline-flex items-center gap-2 rounded-full border border-af-border bg-af-surface-raised px-3 py-2 text-af-text-muted shadow-af-card backdrop-blur-md transition-colors hover:border-af-border-strong hover:bg-af-overlay hover:text-af-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-af-focus-ring"
           controlsID={panelId}
           data-dashboard-flow-axis-legend-toggle=""
           expanded={false}


### PR DESCRIPTION
{
  "project": "Inline Dashboard Flow Axis Legend Layout Classes",
  "branchName": "ralph/inline-dashboard-flow-axis-legend-classes",
  "description": "Inline five allowlisted Tailwind layout class constants from DashboardFlowAxisLegend directly onto JSX className props, remove the matching inline-component-class allowlist entries, and preserve expand/collapse disclosure behavior, legend vocabulary, aria labels, and localized copy with no user-visible regression.",
  "context": {
    "customerAsk": "Inline TOGGLE_BUTTON_CLASS, PANEL_CLASS, PANEL_HEADER_CLASS, PANEL_TITLE_CLASS, and COLLAPSE_BUTTON_CLASS directly on JSX className props in dashboard-flow-axis-legend.tsx; remove the five matching entries from inline-component-class-usage-allowlist.mjs; do not change legend content, layout behavior, aria labels, message keys, or other workflow-activity files.",
    "problem": "dashboard-flow-axis-legend.tsx declares five module-scoped layout class constants, each allowlisted in inline-component-class-usage-allowlist.mjs, violating the inline-component-class policy and forcing readers to jump above JSX to see panel and toggle styles.",
    "solution": "Move each allowlisted class string to the JSX element that uses it, delete the five module constants, remove allowlist entries in the same change, and verify with existing dashboard-flow-axis-legend Vitest coverage plus check:inline-component-class-usage."
  },
  "acceptanceCriteria": [
    "dashboard-flow-axis-legend.tsx contains no TOGGLE_BUTTON_CLASS, PANEL_CLASS, PANEL_HEADER_CLASS, PANEL_TITLE_CLASS, or COLLAPSE_BUTTON_CLASS identifiers",
    "Minimized expand and expanded collapse DisclosureButtons retain dashboard-eyebrow styling and locale-backed aria labels; expanded aside retains dashboard-body-sm panel surface classes and title retains dashboard-eyebrow text-af-accent styling",
    "Expand/collapse state, data-dashboard-flow-axis-legend attributes, message keys, and DEFAULT_CONTAINER_CLASS, ITEMS_LIST_CLASS, PHASE_SWATCH_CLASS remain unchanged",
    "Five allowlist entries for dashboard-flow-axis-legend.tsx are removed; no other allowlist entries change",
    "cd ui && npm run check:inline-component-class-usage exits successfully",
    "Existing dashboard-flow-axis-legend.test.tsx passes without behavioral change; no allowlist or file-topology meta-tests",
    "Quality gate: cd ui && npm run lint, cd ui && npm run check, typecheck, and affected UI tests pass"
  ],
  "userStories": [
    {
      "id": "inline-dashboard-flow-axis-legend-classes-001",
      "title": "Inline legend panel and toggle classes",
      "description": "As a dashboard operator, I want the flow axis legend to look and behave the same when minimized or expanded so that inlining styling constants does not change layout, disclosure interaction, or accessibility.",
      "acceptanceCriteria": [
        "Minimized expand DisclosureButton uses inline className with the former TOGGLE_BUTTON_CLASS string including dashboard-eyebrow, rounded-full border, and focus-visible ring classes",
        "Expanded aside uses inline className with the former PANEL_CLASS string including dashboard-body-sm, raised surface, and backdrop blur classes",
        "Expanded panel header div uses inline className with the former PANEL_HEADER_CLASS flex layout string",
        "Legend title h3 uses inline className with the former PANEL_TITLE_CLASS string including dashboard-eyebrow and text-af-accent",
        "Expanded collapse DisclosureButton uses inline className with the former COLLAPSE_BUTTON_CLASS string including dashboard-eyebrow and focus-visible ring classes",
        "Module-level declarations for the five constants are deleted; DEFAULT_CONTAINER_CLASS, ITEMS_LIST_CLASS, and PHASE_SWATCH_CLASS remain unchanged",
        "Expand/collapse state, data-dashboard-flow-axis-legend attributes, message keys, and aria label wiring are unchanged",
        "dashboard-flow-axis-legend.test.tsx passes including dashboard-eyebrow and dashboard-body-sm class assertions on buttons and expanded panel",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "inline-dashboard-flow-axis-legend-classes-002",
      "title": "Drop allowlist exceptions and confirm inline-class guard",
      "description": "As a maintainer, I want this file fully compliant with the inline-component-class-usage policy so allowlist debt does not remain on the flow axis legend.",
      "acceptanceCriteria": [
        "Removed allowlist keys src/features/workflow-activity/components/dashboard-flow-axis-legend.tsx#TOGGLE_BUTTON_CLASS, #PANEL_CLASS, #PANEL_HEADER_CLASS, #PANEL_TITLE_CLASS, and #COLLAPSE_BUTTON_CLASS only",
        "cd ui && npm run check:inline-component-class-usage exits 0 with no stale allowlist entries for this file",
        "No other workflow-activity files or allowlisted components are modified in this change",
        "cd ui && npm run lint and cd ui && npm run check pass",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser: expand and collapse the dashboard flow axis legend; minimized toggle, expanded panel shell, title accent color, and legend item lists match pre-change"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)