### PR TITLE
website-work-payload-lineage

### DIFF
--- a/ui/src/App.follow-up-trace.test.tsx
+++ b/ui/src/App.follow-up-trace.test.tsx
@@ -16,6 +16,7 @@ import {
   renderTraceDrilldownHarness,
 } from "./testing/app-shell-trace-follow-up-test-utils";
 import { useFactoryTimelineStore } from "./features/timeline/state/factoryTimelineStore";
+import { expectDashboardWorkItemRef } from "./testing/expectDashboardWorkItemRef";
 
 const traceSnapshot: DashboardTrace = {
   trace_id: "trace-active-story",
@@ -85,32 +86,32 @@ describe("App follow-up trace flows", () => {
     expect(
       dispatchRequest?.request?.input_work_items,
     ).toEqual([
-      {
+      expectDashboardWorkItemRef({
         current_chaining_trace_id: "chain-b",
         display_name: "Research Context",
         trace_id: "chain-b",
         work_id: "work-research-context",
         work_type_id: "story",
-      },
-      {
+      }),
+      expectDashboardWorkItemRef({
         current_chaining_trace_id: "chain-a",
         display_name: "Reviewed Story",
         trace_id: "chain-a",
         work_id: "work-reviewed-story",
         work_type_id: "story",
-      },
+      }),
     ]);
     expect(
       dispatchRequest?.response?.output_work_items,
     ).toEqual([
-      {
+      expectDashboardWorkItemRef({
         current_chaining_trace_id: "chain-a",
         display_name: fanInResultLabel,
         previous_chaining_trace_ids: ["chain-a", "chain-b"],
         trace_id: "chain-a",
         work_id: fanInResultWorkID,
         work_type_id: "story",
-      },
+      }),
     ]);
 
     const traceCard = await screen.findByRole("article", {

--- a/ui/src/api/events/types.ts
+++ b/ui/src/api/events/types.ts
@@ -72,19 +72,24 @@ export type WorkRequestPayload = FactorySchemas["WorkRequestEventPayload"];
 export type RelationshipChangeRequestPayload =
   FactorySchemas["RelationshipChangeRequestEventPayload"];
 
-export type DispatchRequestPayload = FactorySchemas["DispatchRequestEventPayload"];
+export type DispatchRequestPayload =
+  FactorySchemas["DispatchRequestEventPayload"];
 
-export type InferenceRequestPayload = FactorySchemas["InferenceRequestEventPayload"];
+export type InferenceRequestPayload =
+  FactorySchemas["InferenceRequestEventPayload"];
 
-export type InferenceResponsePayload = FactorySchemas["InferenceResponseEventPayload"];
+export type InferenceResponsePayload =
+  FactorySchemas["InferenceResponseEventPayload"];
 
 export type InferenceOutcome = FactorySchemas["InferenceOutcome"];
 
 export type ScriptRequestPayload = FactorySchemas["ScriptRequestEventPayload"];
 
-export type ScriptResponsePayload = FactorySchemas["ScriptResponseEventPayload"];
+export type ScriptResponsePayload =
+  FactorySchemas["ScriptResponseEventPayload"];
 
-export type DispatchResponsePayload = FactorySchemas["DispatchResponseEventPayload"];
+export type DispatchResponsePayload =
+  FactorySchemas["DispatchResponseEventPayload"];
 
 export type WorkStateChangeEventPayload =
   FactorySchemas["WorkStateChangeEventPayload"];
@@ -112,12 +117,15 @@ export type WorkstationIO = FactorySchemas["WorkstationIO"];
 export type FactoryWork = FactorySchemas["Work"];
 
 export interface FactoryWorkItem {
+  chaining_trace_depth?: number;
+  content?: FactorySchemas["Work"]["content"];
   current_chaining_trace_id?: string;
   display_name?: string;
   id: string;
   parent_id?: string;
   place_id?: string;
   previous_chaining_trace_ids?: string[];
+  state?: string;
   tags?: Record<string, string>;
   trace_id?: string;
   work_type_id: string;

--- a/ui/src/features/timeline/state/factoryTimelineStore.test.ts
+++ b/ui/src/features/timeline/state/factoryTimelineStore.test.ts
@@ -6,6 +6,7 @@ import {
   resourceCountTimelineEvents,
 } from "../../../components/dashboard/fixtures";
 
+import { expectDashboardWorkItemRef } from "../../../testing/expectDashboardWorkItemRef";
 import {
   buildFactoryTimelineSnapshot,
   resolveConfiguredWorkTypeName,
@@ -1103,12 +1104,12 @@ describe("factory timeline reconstruction topology", () => {
     expect(
       snapshot.runtime.current_work_items_by_place_id?.["story:new"],
     ).toEqual([
-      {
+      expectDashboardWorkItemRef({
         display_name: "Timeline Story",
         trace_id: "trace-1",
         work_id: "work-1",
         work_type_id: "story",
-      },
+      }),
     ]);
   });
 
@@ -1137,12 +1138,12 @@ describe("factory timeline reconstruction topology", () => {
     expect(
       tickTwo.runtime.current_work_items_by_place_id?.["story:new"],
     ).toEqual([
-      {
+      expectDashboardWorkItemRef({
         display_name: "Timeline Story",
         trace_id: "trace-1",
         work_id: "work-1",
         work_type_id: "story",
-      },
+      }),
     ]);
     expect(
       tickTwo.runtime.current_work_items_by_place_id?.["story:review"],
@@ -1195,12 +1196,12 @@ describe("factory timeline reconstruction topology", () => {
     expect(
       tickTwo.runtime.current_work_items_by_place_id?.["story:new"],
     ).toEqual([
-      {
+      expectDashboardWorkItemRef({
         display_name: "Timeline Story",
         trace_id: "trace-1",
         work_id: "work-1",
         work_type_id: "story",
-      },
+      }),
     ]);
     expect(
       tickTwo.runtime.current_work_items_by_place_id?.["story:review"],
@@ -1248,12 +1249,12 @@ describe("factory timeline reconstruction topology", () => {
     expect(
       continued.runtime.current_work_items_by_place_id?.["story:retry"],
     ).toEqual([
-      {
+      expectDashboardWorkItemRef({
         display_name: "Continued Timeline Story",
         trace_id: "trace-continued",
         work_id: "work-continued",
         work_type_id: "story",
-      },
+      }),
     ]);
     expect(
       continued.runtime.current_work_items_by_place_id?.["story:done"],
@@ -1475,12 +1476,12 @@ describe("factory timeline reconstruction topology", () => {
     expect(
       queued.runtime.current_work_items_by_place_id?.["thoughts:init"],
     ).toEqual([
-      {
+      expectDashboardWorkItemRef({
         display_name: "agents-04-21-2026",
         trace_id: "trace-camel-1",
         work_id: "work-camel-1",
         work_type_id: "thoughts",
-      },
+      }),
     ]);
 
     expect(active.runtime.in_flight_dispatch_count).toBe(1);
@@ -1511,12 +1512,12 @@ describe("factory timeline reconstruction topology", () => {
         "thoughts:complete"
       ],
     ).toEqual([
-      {
+      expectDashboardWorkItemRef({
         display_name: "agents-04-21-2026",
         trace_id: "trace-camel-1",
         work_id: "work-camel-1",
         work_type_id: "thoughts",
-      },
+      }),
     ]);
     expect(
       completed.runtime.session.provider_sessions?.[0]?.provider_session?.id,
@@ -1750,97 +1751,97 @@ describe("factory timeline reconstruction trace lineage", () => {
       tickThree.runtime.active_executions_by_dispatch_id?.["dispatch-chain"]
         ?.work_items,
     ).toEqual([
-      {
+      expectDashboardWorkItemRef({
         current_chaining_trace_id: "chain-a",
         display_name: "Fan In A",
         trace_id: "chain-a",
         work_id: "work-chain-a",
         work_type_id: "story",
-      },
-      {
+      }),
+      expectDashboardWorkItemRef({
         current_chaining_trace_id: "chain-b",
         display_name: "Fan In B",
         trace_id: "chain-b",
         work_id: "work-chain-b",
         work_type_id: "story",
-      },
+      }),
     ]);
     expect(
       tickThree.workstationRequestsByDispatchID["dispatch-chain"]?.request_view
         ?.input_work_items,
     ).toEqual([
-      {
+      expectDashboardWorkItemRef({
         current_chaining_trace_id: "chain-a",
         display_name: "Fan In A",
         trace_id: "chain-a",
         work_id: "work-chain-a",
         work_type_id: "story",
-      },
-      {
+      }),
+      expectDashboardWorkItemRef({
         current_chaining_trace_id: "chain-b",
         display_name: "Fan In B",
         trace_id: "chain-b",
         work_id: "work-chain-b",
         work_type_id: "story",
-      },
+      }),
     ]);
     expect(
       tickFour.runtime.workstation_requests_by_dispatch_id?.["dispatch-chain"]
         ?.request?.input_work_items,
     ).toEqual([
-      {
+      expectDashboardWorkItemRef({
         current_chaining_trace_id: "chain-a",
         display_name: "Fan In A",
         trace_id: "chain-a",
         work_id: "work-chain-a",
         work_type_id: "story",
-      },
-      {
+      }),
+      expectDashboardWorkItemRef({
         current_chaining_trace_id: "chain-b",
         display_name: "Fan In B",
         trace_id: "chain-b",
         work_id: "work-chain-b",
         work_type_id: "story",
-      },
+      }),
     ]);
     expect(
       tickFour.runtime.workstation_requests_by_dispatch_id?.["dispatch-chain"]
         ?.response?.output_work_items,
     ).toEqual([
-      {
+      expectDashboardWorkItemRef({
         current_chaining_trace_id: "chain-a",
         display_name: "Fan In Result",
         previous_chaining_trace_ids: ["chain-a", "chain-b"],
         trace_id: "chain-a",
         work_id: "work-chain-result",
         work_type_id: "story",
-      },
+      }),
     ]);
     expect(
       tickFour.workstationRequestsByDispatchID["dispatch-chain"]?.response_view
         ?.output_work_items,
     ).toEqual([
-      {
+      expectDashboardWorkItemRef({
         current_chaining_trace_id: "chain-a",
         display_name: "Fan In Result",
         previous_chaining_trace_ids: ["chain-a", "chain-b"],
         trace_id: "chain-a",
         work_id: "work-chain-result",
         work_type_id: "story",
-      },
+      }),
     ]);
     expect(
       tickFour.workstationRequestsByDispatchID["dispatch-chain"]?.work_items,
     ).toEqual(
       expect.arrayContaining([
-        {
+        expectDashboardWorkItemRef({
           current_chaining_trace_id: "chain-a",
           display_name: "Fan In Result",
           previous_chaining_trace_ids: ["chain-a", "chain-b"],
           trace_id: "chain-a",
           work_id: "work-chain-result",
           work_type_id: "story",
-        },
+        }),
       ]),
     );
     expect(
@@ -2029,14 +2030,14 @@ describe("factory timeline reconstruction trace lineage", () => {
       tickFour.runtime.workstation_requests_by_dispatch_id?.["dispatch-chain"]
         ?.response?.output_work_items,
     ).toEqual([
-      {
+      expectDashboardWorkItemRef({
         current_chaining_trace_id: "chain-a",
         display_name: "Fan In Result",
         previous_chaining_trace_ids: ["chain-a", "chain-b"],
         trace_id: "chain-a",
         work_id: "work-chain-result",
         work_type_id: "story",
-      },
+      }),
     ]);
     expect(
       tickFour.tracesByWorkID["work-chain-result"].dispatches[0],
@@ -3832,12 +3833,12 @@ describe("factory timeline store replay", () => {
     expect(
       activeTick.runtime.current_work_items_by_place_id?.["story:new"],
     ).toEqual([
-      {
+      expectDashboardWorkItemRef({
         display_name: "Queued Analysis Story",
         trace_id: "trace-queued-analysis",
         work_id: "work-queued-analysis",
         work_type_id: "story",
-      },
+      }),
     ]);
 
     const failedTick = buildFactoryTimelineSnapshot(
@@ -3847,12 +3848,12 @@ describe("factory timeline store replay", () => {
     expect(
       failedTick.runtime.current_work_items_by_place_id?.["story:new"],
     ).toEqual([
-      {
+      expectDashboardWorkItemRef({
         display_name: "Queued Analysis Story",
         trace_id: "trace-queued-analysis",
         work_id: "work-queued-analysis",
         work_type_id: "story",
-      },
+      }),
     ]);
     expect(failedTick.runtime.session.failed_work_labels).toEqual([
       "Blocked Analysis Story",

--- a/ui/src/features/timeline/state/timeline/cloneTimelineSnapshot.ts
+++ b/ui/src/features/timeline/state/timeline/cloneTimelineSnapshot.ts
@@ -43,6 +43,10 @@ export function uniqueSortedWorkRefs(
 export function cloneWorkItemRef(item: DashboardWorkItemRef): DashboardWorkItemRef {
   return {
     ...item,
+    content: item.content?.map((part) => ({ ...part })),
+    lineage_parent_work_ids: item.lineage_parent_work_ids
+      ? [...item.lineage_parent_work_ids]
+      : undefined,
     previous_chaining_trace_ids: item.previous_chaining_trace_ids
       ? [...item.previous_chaining_trace_ids]
       : undefined,

--- a/ui/src/features/timeline/state/timeline/fixtures/payload-lineage/README.md
+++ b/ui/src/features/timeline/state/timeline/fixtures/payload-lineage/README.md
@@ -1,0 +1,10 @@
+# Payload lineage golden fixtures
+
+Synthetic SSE event sequences for `reconstructWorldState` → `projectRuntime` payload projection regression tests.
+
+| Fixture | Session / capture | Scenario |
+| --- | --- | --- |
+| `work-request-with-content.json` | `synthetic-golden-payload-lineage-work-request-with-content`, captured 2026-06-01T12:00:00Z | WORK_REQUEST carries text content; Current selection place occupancy resolves `payload_status: RESOLVED`. |
+| `dispatch-without-input-content.json` | `synthetic-golden-payload-lineage-dispatch-without-input-content`, captured 2026-06-01T12:00:00Z | DISPATCH_REQUEST input omits content; consumed-input pin resolves submit-time payload from prior WORK_REQUEST. |
+
+Each fixture JSON includes a `provenance` block with session id and capture timestamp. Replay expectations live in the fixture `expected` section and are asserted by `replayWorldState.payload-lineage.test.ts`.

--- a/ui/src/features/timeline/state/timeline/fixtures/payload-lineage/dispatch-without-input-content.json
+++ b/ui/src/features/timeline/state/timeline/fixtures/payload-lineage/dispatch-without-input-content.json
@@ -1,0 +1,108 @@
+{
+  "provenance": {
+    "sessionId": "synthetic-golden-payload-lineage-dispatch-without-input-content",
+    "capturedAt": "2026-06-01T12:00:00.000Z",
+    "description": "Synthetic golden fixture: DISPATCH_REQUEST input omits content but consumed-input lineage pins the prior WORK_REQUEST snapshot."
+  },
+  "selectedTick": 2,
+  "events": [
+    {
+      "context": {
+        "eventTime": "2026-06-01T12:00:00.000Z",
+        "sequence": 0,
+        "tick": 0
+      },
+      "id": "event-structure",
+      "payload": {
+        "factory": {
+          "workers": [
+            {
+              "name": "reviewer",
+              "type": "MODEL_WORKER"
+            }
+          ],
+          "workTypes": [
+            {
+              "name": "task",
+              "states": [
+                { "name": "init", "type": "INITIAL" },
+                { "name": "review", "type": "PROCESSING" },
+                { "name": "complete", "type": "TERMINAL" }
+              ]
+            }
+          ],
+          "workstations": [
+            {
+              "id": "t-review",
+              "inputs": [{ "state": "init", "workType": "task" }],
+              "name": "Review",
+              "outputs": [{ "state": "review", "workType": "task" }],
+              "worker": "reviewer"
+            }
+          ]
+        }
+      },
+      "type": "INITIAL_STRUCTURE_REQUEST"
+    },
+    {
+      "context": {
+        "eventTime": "2026-06-01T12:00:00.000Z",
+        "requestId": "request/work-1",
+        "sequence": 1,
+        "tick": 1,
+        "traceIds": ["trace-work-1"],
+        "workIds": ["work-1"]
+      },
+      "id": "event-work-request-work-1",
+      "payload": {
+        "source": "external-submit",
+        "type": "FACTORY_REQUEST_BATCH",
+        "works": [
+          {
+            "content": [{ "text": "submit payload", "type": "text" }],
+            "name": "Draft",
+            "traceId": "trace-work-1",
+            "workId": "work-1",
+            "workTypeName": "task"
+          }
+        ]
+      },
+      "type": "WORK_REQUEST"
+    },
+    {
+      "context": {
+        "dispatchId": "dispatch-1",
+        "eventTime": "2026-06-01T12:00:00.000Z",
+        "sequence": 2,
+        "tick": 2,
+        "traceIds": ["trace-work-1"],
+        "workIds": ["work-1"]
+      },
+      "id": "event-dispatch-request-dispatch-1",
+      "payload": {
+        "inputs": [{ "workId": "work-1" }],
+        "resources": [],
+        "transitionId": "t-review"
+      },
+      "type": "DISPATCH_REQUEST"
+    }
+  ],
+  "expected": {
+    "consumedByDispatchId": {
+      "dispatch-1": {
+        "work-1": {
+          "content": [{ "text": "submit payload", "type": "text" }],
+          "payload_status": "RESOLVED",
+          "work_id": "work-1"
+        }
+      }
+    },
+    "selectedByWorkId": {
+      "work-1": {
+        "content": [{ "text": "submit payload", "type": "text" }],
+        "payload_status": "RESOLVED",
+        "work_id": "work-1"
+      }
+    }
+  }
+}

--- a/ui/src/features/timeline/state/timeline/fixtures/payload-lineage/work-request-with-content.json
+++ b/ui/src/features/timeline/state/timeline/fixtures/payload-lineage/work-request-with-content.json
@@ -1,0 +1,90 @@
+{
+  "provenance": {
+    "sessionId": "synthetic-golden-payload-lineage-work-request-with-content",
+    "capturedAt": "2026-06-01T12:00:00.000Z",
+    "description": "Synthetic golden fixture: WORK_REQUEST carries text content so Current selection replay resolves payload_status RESOLVED with submitted text."
+  },
+  "selectedTick": 1,
+  "events": [
+    {
+      "context": {
+        "eventTime": "2026-06-01T12:00:00.000Z",
+        "sequence": 0,
+        "tick": 0
+      },
+      "id": "event-structure",
+      "payload": {
+        "factory": {
+          "workers": [
+            {
+              "name": "reviewer",
+              "type": "MODEL_WORKER"
+            }
+          ],
+          "workTypes": [
+            {
+              "name": "task",
+              "states": [
+                { "name": "init", "type": "INITIAL" },
+                { "name": "review", "type": "PROCESSING" }
+              ]
+            }
+          ],
+          "workstations": [
+            {
+              "id": "t-review",
+              "inputs": [{ "state": "init", "workType": "task" }],
+              "name": "Review",
+              "outputs": [{ "state": "review", "workType": "task" }],
+              "worker": "reviewer"
+            }
+          ]
+        }
+      },
+      "type": "INITIAL_STRUCTURE_REQUEST"
+    },
+    {
+      "context": {
+        "eventTime": "2026-06-01T12:00:00.000Z",
+        "requestId": "request/work-1",
+        "sequence": 1,
+        "tick": 1,
+        "traceIds": ["trace-work-1"],
+        "workIds": ["work-1"]
+      },
+      "id": "event-work-request-work-1",
+      "payload": {
+        "source": "external-submit",
+        "type": "FACTORY_REQUEST_BATCH",
+        "works": [
+          {
+            "content": [{ "text": "Fix the login bug", "type": "text" }],
+            "name": "Fix login",
+            "traceId": "trace-work-1",
+            "workId": "work-1",
+            "workTypeName": "task"
+          }
+        ]
+      },
+      "type": "WORK_REQUEST"
+    }
+  ],
+  "expected": {
+    "selectedByWorkId": {
+      "work-1": {
+        "content": [{ "text": "Fix the login bug", "type": "text" }],
+        "lineage_continuity": "INITIAL_SUBMISSION",
+        "lineage_source_kind": "WORK_REQUEST",
+        "payload_status": "RESOLVED",
+        "work_id": "work-1"
+      }
+    },
+    "placeOccupancyByWorkId": {
+      "work-1": {
+        "content": [{ "text": "Fix the login bug", "type": "text" }],
+        "payload_status": "RESOLVED",
+        "work_id": "work-1"
+      }
+    }
+  }
+}

--- a/ui/src/features/timeline/state/timeline/projectRuntime.test.ts
+++ b/ui/src/features/timeline/state/timeline/projectRuntime.test.ts
@@ -3,6 +3,7 @@ import { expect, it } from "vitest";
 import { projectRuntime } from "./projectRuntime";
 import type { ReplayWorldState } from "./types";
 import { emptyWorldRuntime } from "./types";
+import { emptyWorkPayloadLineageProjection } from "./workPayloadLineage";
 
 function buildReplayWorldState(): ReplayWorldState {
   return {
@@ -32,6 +33,7 @@ function buildReplayWorldState(): ReplayWorldState {
       },
     },
     inferenceAttemptsByDispatchID: {},
+    payloadLineage: emptyWorkPayloadLineageProjection(),
     occupancyByID: {
       "plan:failed": {
         placeID: "plan:failed",

--- a/ui/src/features/timeline/state/timeline/projectRuntime.ts
+++ b/ui/src/features/timeline/state/timeline/projectRuntime.ts
@@ -13,7 +13,7 @@ import { projectRuntimeWorkstationRequests } from "./projectWorkstationRequests"
 import { uniqueSorted } from "./shared";
 import { isSystemTimePlace, isSystemTimeWorkItem } from "./systemTime";
 import type { ReplayWorldState, WorldDispatch } from "./types";
-import { workRef } from "./workItemRef";
+import { workItemRefsForIDs } from "./workItemRef";
 
 export function projectRuntime(state: ReplayWorldState): DashboardRuntime {
   const activeDispatches = Object.values(state.activeDispatches);
@@ -23,7 +23,7 @@ export function projectRuntime(state: ReplayWorldState): DashboardRuntime {
   const activeExecutions = Object.fromEntries(
     customerActiveDispatches.map((dispatch) => [
       dispatch.dispatchID,
-      projectActiveExecution(dispatch),
+      projectActiveExecution(state, dispatch),
     ]),
   );
   const activeDispatchIDs = Object.keys(activeExecutions).sort();
@@ -48,8 +48,10 @@ export function projectRuntime(state: ReplayWorldState): DashboardRuntime {
       activeDispatches: customerActiveDispatches,
       attemptsByDispatchID: state.inferenceAttemptsByDispatchID,
       completedDispatches: customerCompletedDispatches,
+      payloadLineage: state.payloadLineage,
       scriptRequestsByDispatchID: state.scriptRequestsByDispatchID,
       scriptResponsesByDispatchID: state.scriptResponsesByDispatchID,
+      workItemsByID: state.workItemsByID,
     }),
     work_move_operations_by_work_id: projectWorkMoveOperationsByWorkID(
       state.workStateChangesByWorkID,
@@ -80,7 +82,7 @@ export function projectRuntime(state: ReplayWorldState): DashboardRuntime {
         Object.values(state.workItemsByID).some((item) => !isSystemTimeWorkItem(item)),
       provider_sessions: cloneProviderSessionAttempts(state.providerSessions),
     },
-    workstation_activity_by_node_id: projectActivity(customerActiveDispatches),
+    workstation_activity_by_node_id: projectActivity(state, customerActiveDispatches),
   };
 }
 
@@ -96,12 +98,17 @@ function projectCurrentWorkItemsByPlaceID(state: ReplayWorldState): DashboardRun
     .sort((left, right) => left.id.localeCompare(right.id))
     .map((place) => {
       const occupancy = state.occupancyByID[place.id];
-      const workItems = uniqueSorted(occupancy?.workItemIDs ?? [])
-        .map((workID) => state.workItemsByID[workID])
-        .filter((item): item is FactoryWorkItem => item !== undefined)
-        .filter((item) => state.failedWorkItemsByID[item.id] === undefined)
-        .filter((item) => state.terminalWorkByID[item.id] === undefined)
-        .map(workRef);
+      const workItemIDs = uniqueSorted(occupancy?.workItemIDs ?? []).filter(
+        (workID) =>
+          state.workItemsByID[workID] !== undefined &&
+          state.failedWorkItemsByID[workID] === undefined &&
+          state.terminalWorkByID[workID] === undefined,
+      );
+      const workItems = workItemRefsForIDs(
+        state.payloadLineage,
+        workItemIDs,
+        state.workItemsByID,
+      );
       return [place.id, workItems] as const;
     });
   return Object.fromEntries(entries);
@@ -114,18 +121,28 @@ function projectOccupancyWorkItemsByPlaceID(
     .sort((left, right) => left.id.localeCompare(right.id))
     .map((place) => {
       const occupancy = state.occupancyByID[place.id];
-      const workItems = uniqueSorted(occupancy?.workItemIDs ?? [])
-        .map((workID) => state.workItemsByID[workID])
-        .filter((item): item is FactoryWorkItem => item !== undefined)
-        .map(workRef);
+      const workItems = workItemRefsForIDs(
+        state.payloadLineage,
+        uniqueSorted(occupancy?.workItemIDs ?? []).filter(
+          (workID) => state.workItemsByID[workID] !== undefined,
+        ),
+        state.workItemsByID,
+      );
       return [place.id, workItems] as const;
     });
   return Object.fromEntries(entries);
 }
 
 function projectActiveExecution(
+  state: ReplayWorldState,
   dispatch: WorldDispatch,
 ): NonNullable<DashboardRuntime["active_executions_by_dispatch_id"]>[string] {
+  const workItemIDs = uniqueSorted([
+    ...dispatch.workItems.map((item) => item.work_id),
+    ...dispatch.consumedTokens
+      .map((token) => token.work_id)
+      .filter((workID): workID is string => Boolean(workID)),
+  ]);
   return {
     consumed_tokens: dispatch.consumedTokens,
     dispatch_id: dispatch.dispatchID,
@@ -135,7 +152,11 @@ function projectActiveExecution(
     started_at: dispatch.startedAt,
     trace_ids: [...dispatch.traceIDs],
     transition_id: dispatch.transitionID,
-    work_items: dispatch.workItems.map(cloneWorkItemRef),
+    work_items: workItemRefsForIDs(
+      state.payloadLineage,
+      workItemIDs,
+      state.workItemsByID,
+    ).map(cloneWorkItemRef),
     work_type_ids: uniqueSorted(
       dispatch.workItems.map((item) => item.work_type_id ?? ""),
     ),
@@ -145,18 +166,31 @@ function projectActiveExecution(
 }
 
 function projectActivity(
+  state: ReplayWorldState,
   activeDispatches: WorldDispatch[],
 ): DashboardRuntime["workstation_activity_by_node_id"] {
   return Object.fromEntries(
-    activeDispatches.map((dispatch) => [
-      dispatch.transitionID,
-      {
-        active_dispatch_ids: [dispatch.dispatchID],
-        active_work_items: dispatch.workItems.map(cloneWorkItemRef),
-        trace_ids: [...dispatch.traceIDs],
-        workstation_node_id: dispatch.transitionID,
-      },
-    ]),
+    activeDispatches.map((dispatch) => {
+      const workItemIDs = uniqueSorted([
+        ...dispatch.workItems.map((item) => item.work_id),
+        ...dispatch.consumedTokens
+          .map((token) => token.work_id)
+          .filter((workID): workID is string => Boolean(workID)),
+      ]);
+      return [
+        dispatch.transitionID,
+        {
+          active_dispatch_ids: [dispatch.dispatchID],
+          active_work_items: workItemRefsForIDs(
+            state.payloadLineage,
+            workItemIDs,
+            state.workItemsByID,
+          ).map(cloneWorkItemRef),
+          trace_ids: [...dispatch.traceIDs],
+          workstation_node_id: dispatch.transitionID,
+        },
+      ];
+    }),
   );
 }
 

--- a/ui/src/features/timeline/state/timeline/projectRuntimePayloadLineage.test.ts
+++ b/ui/src/features/timeline/state/timeline/projectRuntimePayloadLineage.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import type { FactoryEvent, FactoryWorkItem } from "../../../../api/events";
+import { FACTORY_EVENT_TYPES } from "../../../../api/events";
+import { projectRuntime } from "./projectRuntime";
+import { reconstructWorldState } from "./replayWorldState";
+
+const eventTime = "2026-06-01T12:00:00.000Z";
+
+function factoryEvent(
+  id: string,
+  tick: number,
+  type: FactoryEvent["type"],
+  payload: FactoryEvent["payload"],
+  context: Partial<FactoryEvent["context"]> = {},
+): FactoryEvent {
+  return {
+    context: {
+      eventTime,
+      sequence: tick,
+      tick,
+      ...context,
+    },
+    id,
+    payload,
+    type,
+  };
+}
+
+function workItem(id: string, text: string): FactoryWorkItem {
+  return {
+    id,
+    display_name: id,
+    trace_id: `trace-${id}`,
+    work_type_id: "task",
+    content: [{ type: "text", text }],
+  };
+}
+
+describe("projectRuntime payload lineage", () => {
+  it("projects selected payload into current_work_items_by_place_id", () => {
+    const item = workItem("work-1", "hello from sse");
+    const events: FactoryEvent[] = [
+      factoryEvent("event-structure", 0, FACTORY_EVENT_TYPES.initialStructureRequest, {
+        factory: {
+          workTypes: [
+            {
+              name: "task",
+              states: [
+                { name: "init", type: "INITIAL" },
+                { name: "review", type: "PROCESSING" },
+              ],
+            },
+          ],
+          workstations: [
+            {
+              id: "t-review",
+              inputs: [{ state: "init", workType: "task" }],
+              name: "Review",
+              outputs: [{ state: "review", workType: "task" }],
+              worker: "reviewer",
+            },
+          ],
+          workers: [{ name: "reviewer", type: "MODEL_WORKER" }],
+        },
+      }),
+      factoryEvent(
+        "event-work-request",
+        1,
+        FACTORY_EVENT_TYPES.workRequest,
+        {
+          source: "external-submit",
+          type: "FACTORY_REQUEST_BATCH",
+          works: [
+            {
+              content: item.content,
+              name: item.display_name,
+              traceId: item.trace_id,
+              workId: item.id,
+              workTypeName: item.work_type_id,
+            },
+          ],
+        },
+        {
+          requestId: "request/work-1",
+          traceIds: item.trace_id ? [item.trace_id] : undefined,
+          workIds: [item.id],
+        },
+      ),
+    ];
+
+    const state = reconstructWorldState(events, 1);
+    const runtime = projectRuntime(state);
+    const placeID = state.workItemsByID["work-1"]?.place_id;
+    const refs = placeID
+      ? runtime.current_work_items_by_place_id?.[placeID]
+      : undefined;
+
+    expect(refs).toEqual([
+      expect.objectContaining({
+        content: [{ type: "text", text: "hello from sse" }],
+        payload_status: "RESOLVED",
+        work_id: "work-1",
+      }),
+    ]);
+  });
+});

--- a/ui/src/features/timeline/state/timeline/projectWorkstationRequestHelpers.ts
+++ b/ui/src/features/timeline/state/timeline/projectWorkstationRequestHelpers.ts
@@ -16,7 +16,10 @@ import type {
   WorldScriptRequest,
   WorldScriptResponse,
 } from "./types";
-import { workRef } from "./workItemRef";
+import type { FactoryWorkItem } from "../../../../api/events";
+import type { WorkPayloadLineageProjection } from "./workPayloadLineage";
+import { workItemRefWithOutputPayload } from "./workItemRef";
+import { isSystemTimeWorkItem } from "./systemTime";
 
 const DASHBOARD_TIME_WORK_TYPE_ID = "time";
 
@@ -139,36 +142,44 @@ export function workItemsFromTokens(
 }
 
 export function outputWorkItemsFromCompletion(
+  lineage: WorkPayloadLineageProjection,
   completion: WorldCompletion,
+  workItemsByID: Record<string, FactoryWorkItem>,
 ): DashboardWorkItemRef[] | undefined {
-  const workItems: Record<string, DashboardWorkItemRef> = Object.fromEntries(
-    completion.outputItems
-      .filter((item) => item.work_type_id !== DASHBOARD_TIME_WORK_TYPE_ID)
-      .map((item) => [item.work_id, item] as const),
-  );
-  for (const mutation of completion.outputMutations) {
-    const token = mutation.resulting_token;
-    if (!token?.work_id || token.work_type_id === DASHBOARD_TIME_WORK_TYPE_ID) {
-      continue;
+  const seen = new Set<string>();
+  const refs: DashboardWorkItemRef[] = [];
+  const appendOutput = (workID: string | undefined) => {
+    if (!workID || seen.has(workID)) {
+      return;
     }
-    workItems[token.work_id] = {
-      display_name: token.name,
-      trace_id: token.trace_id,
-      work_id: token.work_id,
-      work_type_id: token.work_type_id,
-    };
+    const item = workItemsByID[workID];
+    if (!item || isSystemTimeWorkItem(item)) {
+      return;
+    }
+    seen.add(workID);
+    refs.push(
+      workItemRefWithOutputPayload(lineage, completion.dispatchID, item),
+    );
+  };
+
+  for (const item of completion.outputItems) {
+    appendOutput(item.work_id);
   }
-  if (
-    completion.terminalWork?.work_item &&
-    completion.terminalWork.work_item.work_type_id !== DASHBOARD_TIME_WORK_TYPE_ID
-  ) {
-    const item = completion.terminalWork.work_item;
-    workItems[item.id] = workRef(item);
+  for (const mutation of completion.outputMutations) {
+    appendOutput(mutation.resulting_token?.work_id);
   }
-  const values = Object.values(workItems).sort((left, right) =>
-    left.work_id.localeCompare(right.work_id),
+  appendOutput(completion.terminalWork?.work_item.id);
+
+  if (refs.length > 0) {
+    return refs.sort((left, right) => left.work_id.localeCompare(right.work_id));
+  }
+
+  const fallbackItems = completion.outputItems.filter(
+    (item) => item.work_type_id !== DASHBOARD_TIME_WORK_TYPE_ID,
   );
-  return values.length > 0 ? values : undefined;
+  return fallbackItems.length > 0
+    ? [...fallbackItems].sort((left, right) => left.work_id.localeCompare(right.work_id))
+    : undefined;
 }
 
 export function sortInferenceAttempts(

--- a/ui/src/features/timeline/state/timeline/projectWorkstationRequestHelpers.ts
+++ b/ui/src/features/timeline/state/timeline/projectWorkstationRequestHelpers.ts
@@ -4,7 +4,6 @@ import type {
   DashboardRuntimeWorkstationRequest,
   DashboardScriptRequest,
   DashboardScriptResponse,
-  DashboardTraceToken,
   DashboardWorkItemRef,
   DashboardWorkstationRequest,
 } from "../../../../api/dashboard";
@@ -100,45 +99,6 @@ export function scriptResponseErrored(response: WorldScriptResponse): boolean {
     response.outcome === "PROCESS_ERROR" ||
     response.outcome === "TIMED_OUT"
   );
-}
-
-export function workItemsFromTokens(
-  tokens: DashboardTraceToken[],
-  fallback: DashboardWorkItemRef[],
-): DashboardWorkItemRef[] {
-  const fallbackByID = new Map(fallback.map((item) => [item.work_id, item] as const));
-  const workItems = Object.values(
-    Object.fromEntries(
-      tokens
-        .filter(
-          (token) => token.work_id && token.work_type_id !== DASHBOARD_TIME_WORK_TYPE_ID,
-        )
-        .map((token) => [
-          token.work_id,
-          {
-            ...(fallbackByID.get(token.work_id)?.current_chaining_trace_id
-              ? {
-                  current_chaining_trace_id:
-                    fallbackByID.get(token.work_id)?.current_chaining_trace_id,
-                }
-              : {}),
-            display_name: token.name,
-            ...(fallbackByID.get(token.work_id)?.previous_chaining_trace_ids
-              ? {
-                  previous_chaining_trace_ids:
-                    fallbackByID.get(token.work_id)?.previous_chaining_trace_ids,
-                }
-              : {}),
-            trace_id: token.trace_id,
-            work_id: token.work_id,
-            work_type_id: token.work_type_id,
-          } satisfies DashboardWorkItemRef,
-        ]),
-    ),
-  );
-  return workItems.length > 0
-    ? workItems.sort((left, right) => left.work_id.localeCompare(right.work_id))
-    : [...fallback].sort((left, right) => left.work_id.localeCompare(right.work_id));
 }
 
 export function outputWorkItemsFromCompletion(

--- a/ui/src/features/timeline/state/timeline/projectWorkstationRequests.ts
+++ b/ui/src/features/timeline/state/timeline/projectWorkstationRequests.ts
@@ -1,3 +1,4 @@
+import type { FactoryWorkItem } from "../../../../api/events";
 import type {
   DashboardInferenceAttempt,
   DashboardRuntimeWorkstationRequest,
@@ -20,9 +21,10 @@ import {
   requestIDsByWorkItemID,
   scriptResponseErrored,
   workstationScriptRequestForProjection,
-  workItemsFromTokens,
 } from "./projectWorkstationRequestHelpers";
+import { consumedWorkItemRefsForDispatch } from "./workItemRef";
 import { uniqueSorted } from "./shared";
+import type { WorkPayloadLineageProjection } from "./workPayloadLineage";
 import type {
   TimelineWorkRequestPayload,
   WorldCompletion,
@@ -35,14 +37,18 @@ export function projectRuntimeWorkstationRequests({
   activeDispatches,
   attemptsByDispatchID,
   completedDispatches,
+  payloadLineage,
   scriptRequestsByDispatchID,
   scriptResponsesByDispatchID,
+  workItemsByID,
 }: {
   activeDispatches: WorldDispatch[];
   attemptsByDispatchID: Record<string, Record<string, DashboardInferenceAttempt>>;
   completedDispatches: WorldCompletion[];
+  payloadLineage: WorkPayloadLineageProjection;
   scriptRequestsByDispatchID: Record<string, Record<string, WorldScriptRequest>>;
   scriptResponsesByDispatchID: Record<string, Record<string, WorldScriptResponse>>;
+  workItemsByID: Record<string, FactoryWorkItem>;
 }): Record<string, DashboardRuntimeWorkstationRequest> | undefined {
   const requests: Record<string, TimelineWorkstationRequest> = {};
 
@@ -58,6 +64,8 @@ export function projectRuntimeWorkstationRequests({
       dispatch,
       attemptsByDispatchID[dispatch.dispatchID],
       latestScriptRequest,
+      payloadLineage,
+      workItemsByID,
     );
   }
 
@@ -74,6 +82,8 @@ export function projectRuntimeWorkstationRequests({
       attemptsByDispatchID[completion.dispatchID],
       latestScriptRequest,
       latestScriptResponse,
+      payloadLineage,
+      workItemsByID,
     );
   }
 
@@ -167,8 +177,15 @@ function workstationRequestFromActiveDispatch(
   dispatch: WorldDispatch,
   _attempts: Record<string, DashboardInferenceAttempt> | undefined,
   latestScriptRequest: WorldScriptRequest | undefined,
+  payloadLineage: WorkPayloadLineageProjection,
+  workItemsByID: Record<string, FactoryWorkItem>,
 ): TimelineWorkstationRequest {
-  const inputWorkItems = workItemsFromTokens(dispatch.consumedTokens, dispatch.workItems);
+  const inputWorkItems = consumedWorkItemRefsForDispatch(
+    payloadLineage,
+    dispatch.dispatchID,
+    dispatch.consumedTokens,
+    workItemsByID,
+  );
   return {
     counts: workstationRequestCounts(undefined, undefined, undefined),
     dispatchId: dispatch.dispatchID,
@@ -194,8 +211,15 @@ function workstationRequestFromCompletion(
   _attempts: Record<string, DashboardInferenceAttempt> | undefined,
   latestScriptRequest: WorldScriptRequest | undefined,
   latestScriptResponse: WorldScriptResponse | undefined,
+  payloadLineage: WorkPayloadLineageProjection,
+  workItemsByID: Record<string, FactoryWorkItem>,
 ): TimelineWorkstationRequest {
-  const inputWorkItems = workItemsFromTokens(completion.consumedTokens, completion.workItems);
+  const inputWorkItems = consumedWorkItemRefsForDispatch(
+    payloadLineage,
+    completion.dispatchID,
+    completion.consumedTokens,
+    workItemsByID,
+  );
   return {
     counts: workstationRequestCounts(undefined, undefined, undefined),
     dispatchId: completion.dispatchID,
@@ -219,7 +243,11 @@ function workstationRequestFromCompletion(
       feedback: completion.feedback,
       outcome: completion.outcome,
       outputMutations: completion.outputMutations,
-      outputWorkItems: outputWorkItemsFromCompletion(completion),
+      outputWorkItems: outputWorkItemsFromCompletion(
+        payloadLineage,
+        completion,
+        workItemsByID,
+      ),
       scriptResponse: timelineScriptResponse(latestScriptResponse),
     },
     transitionId: completion.transitionID,

--- a/ui/src/features/timeline/state/timeline/replayFactoryTopology.test.ts
+++ b/ui/src/features/timeline/state/timeline/replayFactoryTopology.test.ts
@@ -20,6 +20,7 @@ import {
   traceToken,
 } from "./replayGraphState";
 import type { ReplayWorldState } from "./types";
+import { emptyWorkPayloadLineageProjection } from "./workPayloadLineage";
 
 function replayStateWithResourcePlaces(): ReplayWorldState {
   return {
@@ -30,6 +31,7 @@ function replayStateWithResourcePlaces(): ReplayWorldState {
     failedWorkItemsByID: {},
     inferenceAttemptsByDispatchID: {},
     occupancyByID: {},
+    payloadLineage: emptyWorkPayloadLineageProjection(),
     providerSessions: [],
     relationsByWorkID: {},
     runtime: { in_flight_dispatch_count: 0, session: { has_data: false } },

--- a/ui/src/features/timeline/state/timeline/replayFactoryTopology.ts
+++ b/ui/src/features/timeline/state/timeline/replayFactoryTopology.ts
@@ -325,7 +325,12 @@ export function factoryWorkToItem(
     (isSystemTimeWorkType(workTypeID)
       ? SYSTEM_TIME_PENDING_PLACE_ID
       : undefined);
+  const content =
+    "content" in work && work.content
+      ? work.content.map((part) => ({ ...part }))
+      : existing?.content;
   return {
+    content,
     current_chaining_trace_id:
       legacyWork.current_chaining_trace_id ??
       existing?.current_chaining_trace_id,

--- a/ui/src/features/timeline/state/timeline/replayWorldState.payload-lineage.test.ts
+++ b/ui/src/features/timeline/state/timeline/replayWorldState.payload-lineage.test.ts
@@ -1,0 +1,453 @@
+import { describe, expect, it } from "vitest";
+
+import type { DashboardWorkItemRef } from "../../../../api/dashboard";
+import type { FactoryEvent, FactoryWorkItem } from "../../../../api/events";
+import { FACTORY_EVENT_TYPES } from "../../../../api/events";
+import dispatchWithoutInputContentFixture from "./fixtures/payload-lineage/dispatch-without-input-content.json";
+import workRequestWithContentFixture from "./fixtures/payload-lineage/work-request-with-content.json";
+import { projectRuntime } from "./projectRuntime";
+import { reconstructWorldState } from "./replayWorldState";
+import {
+  consumedWorkItemRefsForDispatch,
+  selectedWorkItemRefForID,
+} from "./workItemRef";
+
+interface PayloadLineageFixtureExpectedRef {
+  work_id: string;
+  payload_status: string;
+  content?: DashboardWorkItemRef["content"];
+  payload_unavailable_reason?: string;
+  lineage_continuity?: string;
+  lineage_source_kind?: string;
+}
+
+interface PayloadLineageGoldenFixture {
+  provenance: {
+    sessionId: string;
+    capturedAt: string;
+    description: string;
+  };
+  selectedTick: number;
+  events: FactoryEvent[];
+  expected: {
+    selectedByWorkId?: Record<string, PayloadLineageFixtureExpectedRef>;
+    placeOccupancyByWorkId?: Record<string, PayloadLineageFixtureExpectedRef>;
+    consumedByDispatchId?: Record<
+      string,
+      Record<string, PayloadLineageFixtureExpectedRef>
+    >;
+  };
+}
+
+const eventTime = "2026-06-01T12:00:00.000Z";
+
+function factoryEvent(
+  id: string,
+  tick: number,
+  type: FactoryEvent["type"],
+  payload: FactoryEvent["payload"],
+  context: Partial<FactoryEvent["context"]> = {},
+): FactoryEvent {
+  return {
+    context: {
+      eventTime,
+      sequence: tick,
+      tick,
+      ...context,
+    },
+    id,
+    payload,
+    type,
+  };
+}
+
+const initialStructureRequest = factoryEvent(
+  "event-structure",
+  0,
+  FACTORY_EVENT_TYPES.initialStructureRequest,
+  {
+    factory: {
+      workers: [{ name: "reviewer", type: "MODEL_WORKER" }],
+      workTypes: [
+        {
+          name: "task",
+          states: [
+            { name: "init", type: "INITIAL" },
+            { name: "review", type: "PROCESSING" },
+            { name: "complete", type: "TERMINAL" },
+          ],
+        },
+      ],
+      workstations: [
+        {
+          id: "t-review",
+          inputs: [{ state: "init", workType: "task" }],
+          name: "Review",
+          outputs: [{ state: "review", workType: "task" }],
+          worker: "reviewer",
+        },
+        {
+          id: "t-follow-up",
+          inputs: [{ state: "review", workType: "task" }],
+          name: "Follow Up",
+          outputs: [{ state: "complete", workType: "task" }],
+          worker: "reviewer",
+        },
+      ],
+    },
+  },
+);
+
+function lineageWorkItem(
+  id: string,
+  displayName: string,
+  traceID: string,
+  text: string,
+): FactoryWorkItem {
+  return {
+    id,
+    display_name: displayName,
+    trace_id: traceID,
+    work_type_id: "task",
+    content: [{ type: "text", text }],
+  };
+}
+
+function lineageWorkRequestEvent(
+  tick: number,
+  requestID: string,
+  item: FactoryWorkItem,
+): FactoryEvent {
+  return factoryEvent(
+    `event-work-${item.id}-${tick}`,
+    tick,
+    FACTORY_EVENT_TYPES.workRequest,
+    {
+      source: "external-submit",
+      type: "FACTORY_REQUEST_BATCH",
+      works: [
+        {
+          content: item.content,
+          name: item.display_name,
+          traceId: item.trace_id,
+          workId: item.id,
+          workTypeName: item.work_type_id,
+        },
+      ],
+    },
+    {
+      requestId: requestID,
+      traceIds: item.trace_id ? [item.trace_id] : undefined,
+      workIds: [item.id],
+    },
+  );
+}
+
+function lineageDispatchRequestEvent(
+  tick: number,
+  dispatchID: string,
+  transitionID: string,
+  item: FactoryWorkItem,
+): FactoryEvent {
+  return factoryEvent(
+    `event-dispatch-request-${dispatchID}`,
+    tick,
+    FACTORY_EVENT_TYPES.dispatchRequest,
+    {
+      inputs: [
+        {
+          content: item.content,
+          name: item.display_name,
+          traceId: item.trace_id,
+          workId: item.id,
+          workTypeName: item.work_type_id,
+        },
+      ],
+      resources: [],
+      transitionId: transitionID,
+    },
+    {
+      dispatchId: dispatchID,
+      traceIds: item.trace_id ? [item.trace_id] : undefined,
+      workIds: [item.id],
+    },
+  );
+}
+
+function lineageDispatchResponseEvent(
+  tick: number,
+  dispatchID: string,
+  transitionID: string,
+  traceIDs: string[],
+  workIDs: string[],
+  outputs: FactoryWorkItem[],
+): FactoryEvent {
+  return factoryEvent(
+    `event-dispatch-response-${dispatchID}`,
+    tick,
+    FACTORY_EVENT_TYPES.dispatchResponse,
+    {
+      outcome: "ACCEPTED",
+      outputWork: outputs.map((item) => ({
+        content: item.content,
+        name: item.display_name,
+        traceId: item.trace_id,
+        workId: item.id,
+        workTypeName: item.work_type_id,
+      })),
+      transitionId: transitionID,
+    },
+    {
+      dispatchId: dispatchID,
+      traceIds: traceIDs,
+      workIds: workIDs,
+    },
+  );
+}
+
+function expectRefMatchesExpected(
+  actual: DashboardWorkItemRef | undefined,
+  expected: PayloadLineageFixtureExpectedRef,
+): void {
+  expect(actual).toEqual(expect.objectContaining(expected));
+}
+
+function replayGoldenFixture(fixture: PayloadLineageGoldenFixture) {
+  const state = reconstructWorldState(fixture.events, fixture.selectedTick);
+  const runtime = projectRuntime(state);
+  return { runtime, state };
+}
+
+function findPlaceOccupancyRef(
+  runtime: ReturnType<typeof projectRuntime>,
+  state: ReturnType<typeof reconstructWorldState>,
+  workID: string,
+): DashboardWorkItemRef | undefined {
+  const placeID = state.workItemsByID[workID]?.place_id;
+  if (!placeID) {
+    return undefined;
+  }
+  return runtime.current_work_items_by_place_id?.[placeID]?.find(
+    (ref) => ref.work_id === workID,
+  );
+}
+
+describe("replayWorldState payload lineage golden fixtures", () => {
+  it("replays work-request-with-content and projects selected refs", () => {
+    const fixture = workRequestWithContentFixture as PayloadLineageGoldenFixture;
+    const { runtime, state } = replayGoldenFixture(fixture);
+
+    for (const [workID, expected] of Object.entries(
+      fixture.expected.selectedByWorkId ?? {},
+    )) {
+      const selected = selectedWorkItemRefForID(
+        state.payloadLineage,
+        workID,
+        state.workItemsByID[workID],
+      );
+      expectRefMatchesExpected(selected, expected);
+    }
+
+    for (const [workID, expected] of Object.entries(
+      fixture.expected.placeOccupancyByWorkId ?? {},
+    )) {
+      const placeRef = findPlaceOccupancyRef(runtime, state, workID);
+      expectRefMatchesExpected(placeRef, expected);
+    }
+  });
+
+  it("replays dispatch-without-input-content and projects consumed refs", () => {
+    const fixture =
+      dispatchWithoutInputContentFixture as PayloadLineageGoldenFixture;
+    const { state } = replayGoldenFixture(fixture);
+
+    for (const [dispatchID, consumedByWorkID] of Object.entries(
+      fixture.expected.consumedByDispatchId ?? {},
+    )) {
+      const dispatch = state.activeDispatches[dispatchID];
+      if (!dispatch) {
+        throw new Error(`expected active dispatch ${dispatchID}`);
+      }
+
+      const consumedRefs = consumedWorkItemRefsForDispatch(
+        state.payloadLineage,
+        dispatchID,
+        dispatch.consumedTokens,
+        state.workItemsByID,
+      );
+
+      for (const [workID, expected] of Object.entries(consumedByWorkID)) {
+        const consumedRef = consumedRefs.find((ref) => ref.work_id === workID);
+        expectRefMatchesExpected(consumedRef, expected);
+      }
+    }
+
+    for (const [workID, expected] of Object.entries(
+      fixture.expected.selectedByWorkId ?? {},
+    )) {
+      const selected = selectedWorkItemRefForID(
+        state.payloadLineage,
+        workID,
+        state.workItemsByID[workID],
+      );
+      expectRefMatchesExpected(selected, expected);
+    }
+  });
+});
+
+describe("replayWorldState payload lineage synthetic replay submit-only", () => {
+  it("projects submit-only content into place occupancy", () => {
+    const item = lineageWorkItem("work-submit-only", "Submit only", "trace-1", "submit-only-v1");
+    const events: FactoryEvent[] = [
+      initialStructureRequest,
+      lineageWorkRequestEvent(1, "request/submit-only", item),
+    ];
+
+    const state = reconstructWorldState(events, 1);
+    const runtime = projectRuntime(state);
+    const placeRef = findPlaceOccupancyRef(runtime, state, item.id);
+
+    expect(placeRef).toEqual(
+      expect.objectContaining({
+        content: [{ type: "text", text: "submit-only-v1" }],
+        payload_status: "RESOLVED",
+        work_id: "work-submit-only",
+      }),
+    );
+  });
+});
+
+describe("replayWorldState payload lineage synthetic replay consumed unavailable", () => {
+  it("marks consumed input unavailable when dispatch consumes work without a prior snapshot", () => {
+    const events: FactoryEvent[] = [
+      initialStructureRequest,
+      factoryEvent(
+        "event-dispatch-missing",
+        1,
+        FACTORY_EVENT_TYPES.dispatchRequest,
+        {
+          inputs: [{ workId: "work-missing" }],
+          resources: [],
+          transitionId: "t-review",
+        },
+        {
+          dispatchId: "dispatch-missing",
+          traceIds: ["trace-missing"],
+          workIds: ["work-missing"],
+        },
+      ),
+    ];
+
+    const state = reconstructWorldState(events, 1);
+    const dispatch = state.activeDispatches["dispatch-missing"];
+    const consumedRefs = consumedWorkItemRefsForDispatch(
+      state.payloadLineage,
+      "dispatch-missing",
+      dispatch.consumedTokens,
+      state.workItemsByID,
+    );
+
+    expect(consumedRefs).toEqual([
+      expect.objectContaining({
+        payload_status: "UNAVAILABLE",
+        payload_unavailable_reason:
+          "no lineage snapshot was recorded before this dispatch consumed the work item",
+        work_id: "work-missing",
+      }),
+    ]);
+  });
+});
+
+describe("replayWorldState payload lineage synthetic replay dispatch output", () => {
+  it("projects dispatch output work content into output refs", () => {
+    const initial = lineageWorkItem("work-1", "Draft", "trace-1", "draft-v1");
+    const continued = lineageWorkItem("work-1", "Draft", "trace-1", "draft-v2");
+    const downstream = lineageWorkItem(
+      "work-2",
+      "Follow up",
+      "trace-2",
+      "follow-up-v1",
+    );
+
+    const events: FactoryEvent[] = [
+      initialStructureRequest,
+      lineageWorkRequestEvent(1, "request/work-1-v1", initial),
+      lineageDispatchRequestEvent(2, "dispatch-1", "t-review", initial),
+      lineageDispatchResponseEvent(
+        3,
+        "dispatch-1",
+        "t-review",
+        ["trace-1", "trace-2"],
+        ["work-1", "work-2"],
+        [continued, downstream],
+      ),
+    ];
+
+    const state = reconstructWorldState(events, 3);
+    const runtime = projectRuntime(state);
+    const request = runtime.workstation_requests_by_dispatch_id?.["dispatch-1"];
+
+    expect(request?.response?.output_work_items).toEqual([
+      expect.objectContaining({
+        content: [{ type: "text", text: "draft-v2" }],
+        lineage_continuity: "SAME_WORK_ID_CONTINUATION",
+        payload_status: "RESOLVED",
+        work_id: "work-1",
+      }),
+      expect.objectContaining({
+        content: [{ type: "text", text: "follow-up-v1" }],
+        lineage_continuity: "NEW_DOWNSTREAM_WORK",
+        payload_status: "RESOLVED",
+        work_id: "work-2",
+      }),
+    ]);
+  });
+});
+
+describe("replayWorldState payload lineage synthetic replay consumed pin", () => {
+  it("keeps consumed-input pin unchanged when the same work ID is resubmitted later", () => {
+    const initial = lineageWorkItem("work-child", "Child", "trace-child", "child-v1");
+    const laterSelected = lineageWorkItem(
+      "work-child",
+      "Child",
+      "trace-child",
+      "child-v2",
+    );
+
+    const events: FactoryEvent[] = [
+      initialStructureRequest,
+      lineageWorkRequestEvent(1, "request/child-v1", initial),
+      lineageDispatchRequestEvent(2, "dispatch-consume-child", "t-follow-up", initial),
+      lineageWorkRequestEvent(3, "request/child-v2", laterSelected),
+    ];
+
+    const state = reconstructWorldState(events, 3);
+    const dispatch = state.activeDispatches["dispatch-consume-child"];
+    const consumedRefs = consumedWorkItemRefsForDispatch(
+      state.payloadLineage,
+      "dispatch-consume-child",
+      dispatch.consumedTokens,
+      state.workItemsByID,
+    );
+    const selected = selectedWorkItemRefForID(
+      state.payloadLineage,
+      "work-child",
+      state.workItemsByID["work-child"],
+    );
+
+    expect(consumedRefs).toEqual([
+      expect.objectContaining({
+        content: [{ type: "text", text: "child-v1" }],
+        payload_status: "RESOLVED",
+        work_id: "work-child",
+      }),
+    ]);
+    expect(selected).toEqual(
+      expect.objectContaining({
+        content: [{ type: "text", text: "child-v2" }],
+        payload_status: "RESOLVED",
+        work_id: "work-child",
+      }),
+    );
+  });
+});

--- a/ui/src/features/timeline/state/timeline/replayWorldState.ts
+++ b/ui/src/features/timeline/state/timeline/replayWorldState.ts
@@ -1,6 +1,7 @@
 import type {
   FactoryEvent,
   FactoryRelation,
+  FactoryWorkItem,
 } from "../../../../api/events";
 import { FACTORY_EVENT_TYPES } from "../../../../api/events";
 import {
@@ -60,8 +61,14 @@ import type {
 } from "./replayWorldStateTypes";
 import { orderedEvents, uniqueSorted } from "./shared";
 import { dashboardTransitionID, isSystemTimeWorkItem } from "./systemTime";
-import { emptyWorldRuntime, type ReplayWorldState } from "./types";
+import { emptyWorldRuntime, type ReplayWorldState, type WorldDispatch } from "./types";
 import { workRef } from "./workItemRef";
+import {
+  emptyWorkPayloadLineageProjection,
+  recordConsumedInputSnapshot,
+  recordDispatchOutputSnapshot,
+  recordWorkRequestSnapshot,
+} from "./workPayloadLineage";
 
 function emptyWorldState(tick: number): ReplayWorldState {
   return {
@@ -72,6 +79,7 @@ function emptyWorldState(tick: number): ReplayWorldState {
     failedWorkItemsByID: {},
     inferenceAttemptsByDispatchID: {},
     occupancyByID: {},
+    payloadLineage: emptyWorkPayloadLineageProjection(),
     providerSessions: [],
     relationsByWorkID: {},
     runtime: emptyWorldRuntime(),
@@ -205,6 +213,12 @@ function applyWorkRequest(
     if (isSystemTimeWorkItem(item)) {
       continue;
     }
+    recordWorkRequestSnapshot(
+      state.payloadLineage,
+      event.context.tick,
+      requestID,
+      item,
+    );
     addToken(state, item.place_id, item.id, item.id);
     addTraceWork(state, item);
     addTraceRequest(state, item.trace_id ?? traceID, requestID);
@@ -259,6 +273,7 @@ function applyRequest(
   for (const item of workItems) {
     removeWorkToken(state, item.id);
     state.workItemsByID[item.id] = item;
+    recordConsumedInputSnapshot(state.payloadLineage, dispatchID, item);
     if (isSystemTimeWorkItem(item)) {
       continue;
     }
@@ -392,6 +407,7 @@ function applyResponse(
   }
 
   const active = state.activeDispatches[dispatchID];
+  const consumedInputWorkItems = dispatchInputWorkItems(state, active);
   delete state.activeDispatches[dispatchID];
   releaseResourceUnits(
     state,
@@ -411,8 +427,18 @@ function applyResponse(
       ),
     ),
   );
-  for (const item of outputItems) {
+  for (const [index, item] of outputItems.entries()) {
     state.workItemsByID[item.id] = item;
+    if (item.id !== "") {
+      recordDispatchOutputSnapshot(
+        state.payloadLineage,
+        event.context.tick,
+        dispatchID,
+        consumedInputWorkItems,
+        item,
+        index,
+      );
+    }
     if (isSystemTimeWorkItem(item)) {
       continue;
     }
@@ -441,4 +467,16 @@ function applyResponse(
   for (const traceID of completion.traceIDs) {
     addTraceDispatch(state, traceID, completion);
   }
+}
+
+function dispatchInputWorkItems(
+  state: ReplayWorldState,
+  dispatch: WorldDispatch | undefined,
+): FactoryWorkItem[] {
+  if (!dispatch) {
+    return [];
+  }
+  return dispatch.consumedTokens
+    .map((token) => state.workItemsByID[token.work_id])
+    .filter((item): item is FactoryWorkItem => item !== undefined);
 }

--- a/ui/src/features/timeline/state/timeline/replayWorldState.ts
+++ b/ui/src/features/timeline/state/timeline/replayWorldState.ts
@@ -1,8 +1,4 @@
-import type {
-  FactoryEvent,
-  FactoryRelation,
-  FactoryWorkItem,
-} from "../../../../api/events";
+import type { FactoryEvent, FactoryRelation } from "../../../../api/events";
 import { FACTORY_EVENT_TYPES } from "../../../../api/events";
 import {
   completionToProviderSession,
@@ -37,13 +33,19 @@ import {
   traceToken,
 } from "./replayGraphState";
 import {
+  dispatchInputWorkItems,
+  recordDispatchConsumedInputPayloadLineage,
+  recordDispatchOutputPayloadLineage,
+  recordWorkRequestPayloadLineage,
+} from "./replayWorldStatePayloadLineage";
+import {
   applyScriptRequest,
   applyScriptResponse,
+  emptyReplayWorldState,
   inferenceAttemptsForDispatch,
   resolveDispatchTransitionID,
   syncCompletedDispatchAttempt,
 } from "./replayWorldStateSupport";
-import { applyWorkStateChange } from "./replayWorldStateWorkStateChange";
 import type {
   DispatchRequestEvent,
   DispatchResponseEvent,
@@ -59,44 +61,11 @@ import type {
   WorkRequestEvent,
   WorkStateChangeEvent,
 } from "./replayWorldStateTypes";
+import { applyWorkStateChange } from "./replayWorldStateWorkStateChange";
 import { orderedEvents, uniqueSorted } from "./shared";
 import { dashboardTransitionID, isSystemTimeWorkItem } from "./systemTime";
-import { emptyWorldRuntime, type ReplayWorldState, type WorldDispatch } from "./types";
+import type { ReplayWorldState } from "./types";
 import { workRef } from "./workItemRef";
-import {
-  emptyWorkPayloadLineageProjection,
-  recordConsumedInputSnapshot,
-  recordDispatchOutputSnapshot,
-  recordWorkRequestSnapshot,
-} from "./workPayloadLineage";
-
-function emptyWorldState(tick: number): ReplayWorldState {
-  return {
-    activeDispatches: {},
-    completedDispatches: [],
-    factory_state: "UNKNOWN",
-    failedWorkDetailsByWorkID: {},
-    failedWorkItemsByID: {},
-    inferenceAttemptsByDispatchID: {},
-    occupancyByID: {},
-    payloadLineage: emptyWorkPayloadLineageProjection(),
-    providerSessions: [],
-    relationsByWorkID: {},
-    runtime: emptyWorldRuntime(),
-    scriptRequestsByDispatchID: {},
-    scriptResponsesByDispatchID: {},
-    terminalWorkByID: {},
-    tick_count: tick,
-    topology: {},
-    tracesByID: {},
-    tracesByWorkID: {},
-    uptime_seconds: 0,
-    workItemsByID: {},
-    workStateChangesByWorkID: {},
-    workstationRequestsByDispatchID: {},
-    workRequestsByID: {},
-  };
-}
 
 function seedResourceOccupancy(state: ReplayWorldState): void {
   seedResourceOccupancyBase(state, addToken, resourceTokenID);
@@ -114,7 +83,7 @@ export function reconstructWorldState(
   events: FactoryEvent[],
   selectedTick: number,
 ): ReplayWorldState {
-  const state = emptyWorldState(selectedTick);
+  const state = emptyReplayWorldState(selectedTick);
   for (const event of orderedEvents(events)) {
     if (event.context.tick <= selectedTick) {
       applyEvent(state, event);
@@ -208,17 +177,17 @@ function applyWorkRequest(
     type: event.payload.type,
     work_items: workItems,
   };
+  recordWorkRequestPayloadLineage(
+    state,
+    event.context.tick,
+    requestID,
+    workItems,
+  );
   for (const item of workItems) {
     state.workItemsByID[item.id] = item;
     if (isSystemTimeWorkItem(item)) {
       continue;
     }
-    recordWorkRequestSnapshot(
-      state.payloadLineage,
-      event.context.tick,
-      requestID,
-      item,
-    );
     addToken(state, item.place_id, item.id, item.id);
     addTraceWork(state, item);
     addTraceRequest(state, item.trace_id ?? traceID, requestID);
@@ -270,10 +239,10 @@ function applyRequest(
   const workItems = (legacyPayload.inputs ?? event.payload.inputs).map((work) =>
     factoryWorkToItem(state, work),
   );
+  recordDispatchConsumedInputPayloadLineage(state, dispatchID, workItems);
   for (const item of workItems) {
     removeWorkToken(state, item.id);
     state.workItemsByID[item.id] = item;
-    recordConsumedInputSnapshot(state.payloadLineage, dispatchID, item);
     if (isSystemTimeWorkItem(item)) {
       continue;
     }
@@ -427,18 +396,15 @@ function applyResponse(
       ),
     ),
   );
-  for (const [index, item] of outputItems.entries()) {
+  recordDispatchOutputPayloadLineage(
+    state,
+    event.context.tick,
+    dispatchID,
+    consumedInputWorkItems,
+    outputItems,
+  );
+  for (const item of outputItems) {
     state.workItemsByID[item.id] = item;
-    if (item.id !== "") {
-      recordDispatchOutputSnapshot(
-        state.payloadLineage,
-        event.context.tick,
-        dispatchID,
-        consumedInputWorkItems,
-        item,
-        index,
-      );
-    }
     if (isSystemTimeWorkItem(item)) {
       continue;
     }
@@ -467,16 +433,4 @@ function applyResponse(
   for (const traceID of completion.traceIDs) {
     addTraceDispatch(state, traceID, completion);
   }
-}
-
-function dispatchInputWorkItems(
-  state: ReplayWorldState,
-  dispatch: WorldDispatch | undefined,
-): FactoryWorkItem[] {
-  if (!dispatch) {
-    return [];
-  }
-  return dispatch.consumedTokens
-    .map((token) => state.workItemsByID[token.work_id])
-    .filter((item): item is FactoryWorkItem => item !== undefined);
 }

--- a/ui/src/features/timeline/state/timeline/replayWorldStatePayloadLineage.test.ts
+++ b/ui/src/features/timeline/state/timeline/replayWorldStatePayloadLineage.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, it } from "vitest";
+
+import type { FactoryEvent, FactoryWorkItem } from "../../../../api/events";
+import { FACTORY_EVENT_TYPES } from "../../../../api/events";
+import { reconstructWorldState } from "./replayWorldState";
+import {
+  resolveConsumedInputSnapshot,
+  resolveInitialSubmittedSnapshot,
+  resolveOutputWorkSnapshot,
+  resolveSelectedWorkSnapshot,
+} from "./workPayloadLineage";
+
+const eventTime = "2026-06-01T12:00:00.000Z";
+
+function factoryEvent(
+  id: string,
+  tick: number,
+  type: FactoryEvent["type"],
+  payload: FactoryEvent["payload"],
+  context: Partial<FactoryEvent["context"]> = {},
+): FactoryEvent {
+  return {
+    context: {
+      eventTime,
+      sequence: tick,
+      tick,
+      ...context,
+    },
+    id,
+    payload,
+    type,
+  };
+}
+
+const initialStructureRequest = factoryEvent(
+  "event-structure",
+  0,
+  FACTORY_EVENT_TYPES.initialStructureRequest,
+  {
+    factory: {
+      workers: [
+        {
+          model: "gpt-5.4",
+          modelProvider: "openai",
+          name: "reviewer",
+          type: "MODEL_WORKER",
+        },
+      ],
+      workTypes: [
+        {
+          name: "task",
+          states: [
+            { name: "init", type: "INITIAL" },
+            { name: "review", type: "PROCESSING" },
+            { name: "complete", type: "TERMINAL" },
+            { name: "failed", type: "FAILED" },
+          ],
+        },
+      ],
+      workstations: [
+        {
+          id: "t-review",
+          inputs: [{ state: "init", workType: "task" }],
+          name: "Review",
+          onFailure: [{ state: "failed", workType: "task" }],
+          outputs: [{ state: "review", workType: "task" }],
+          worker: "reviewer",
+        },
+        {
+          id: "t-follow-up",
+          inputs: [{ state: "review", workType: "task" }],
+          name: "Follow Up",
+          outputs: [{ state: "complete", workType: "task" }],
+          worker: "reviewer",
+        },
+      ],
+    },
+  },
+);
+
+function lineageWorkItem(
+  id: string,
+  displayName: string,
+  traceID: string,
+  text: string,
+): FactoryWorkItem {
+  return {
+    id,
+    display_name: displayName,
+    trace_id: traceID,
+    work_type_id: "task",
+    content: [{ type: "text", text }],
+  };
+}
+
+function lineageWorkRequestEvent(
+  tick: number,
+  requestID: string,
+  item: FactoryWorkItem,
+): FactoryEvent {
+  return factoryEvent(
+    `event-work-${item.id}-${tick}`,
+    tick,
+    FACTORY_EVENT_TYPES.workRequest,
+    {
+      source: "external-submit",
+      type: "FACTORY_REQUEST_BATCH",
+      works: [
+        {
+          content: item.content,
+          name: item.display_name,
+          traceId: item.trace_id,
+          workId: item.id,
+          workTypeName: item.work_type_id,
+        },
+      ],
+    },
+    {
+      requestId: requestID,
+      traceIds: item.trace_id ? [item.trace_id] : undefined,
+      workIds: [item.id],
+    },
+  );
+}
+
+function lineageDispatchRequestEvent(
+  tick: number,
+  dispatchID: string,
+  transitionID: string,
+  item: FactoryWorkItem,
+): FactoryEvent {
+  return factoryEvent(
+    `event-dispatch-request-${dispatchID}`,
+    tick,
+    FACTORY_EVENT_TYPES.dispatchRequest,
+    {
+      inputs: [
+        {
+          content: item.content,
+          name: item.display_name,
+          traceId: item.trace_id,
+          workId: item.id,
+          workTypeName: item.work_type_id,
+        },
+      ],
+      resources: [],
+      transitionId: transitionID,
+    },
+    {
+      dispatchId: dispatchID,
+      traceIds: item.trace_id ? [item.trace_id] : undefined,
+      workIds: [item.id],
+    },
+  );
+}
+
+function lineageDispatchResponseEvent(
+  tick: number,
+  dispatchID: string,
+  transitionID: string,
+  traceIDs: string[],
+  workIDs: string[],
+  outputs: FactoryWorkItem[],
+): FactoryEvent {
+  return factoryEvent(
+    `event-dispatch-response-${dispatchID}`,
+    tick,
+    FACTORY_EVENT_TYPES.dispatchResponse,
+    {
+      outcome: "ACCEPTED",
+      outputWork: outputs.map((item) => ({
+        content: item.content,
+        name: item.display_name,
+        traceId: item.trace_id,
+        workId: item.id,
+        workTypeName: item.work_type_id,
+      })),
+      transitionId: transitionID,
+    },
+    {
+      dispatchId: dispatchID,
+      traceIds: traceIDs,
+      workIds: workIDs,
+    },
+  );
+}
+
+function assertLineageTextContent(item: FactoryWorkItem, want: string): void {
+  expect(item.content).toEqual([{ type: "text", text: want }]);
+}
+
+describe("reconstructWorldState payload lineage", () => {
+  it("records work-request, consumed-input, and dispatch-output snapshots during replay", () => {
+    const initial = lineageWorkItem("work-1", "Draft", "trace-1", "draft-v1");
+    const continued = lineageWorkItem(
+      "work-1",
+      "Draft",
+      "trace-1",
+      "draft-v2",
+    );
+    const downstream = lineageWorkItem(
+      "work-2",
+      "Follow up",
+      "trace-2",
+      "follow-up-v1",
+    );
+    const laterSelected = lineageWorkItem(
+      "work-1",
+      "Draft",
+      "trace-1",
+      "draft-v3",
+    );
+
+    const events: FactoryEvent[] = [
+      initialStructureRequest,
+      lineageWorkRequestEvent(1, "request/work-1-v1", initial),
+      lineageDispatchRequestEvent(2, "dispatch-1", "t-review", initial),
+      lineageDispatchResponseEvent(
+        3,
+        "dispatch-1",
+        "t-review",
+        ["trace-1", "trace-2"],
+        ["work-1", "work-2"],
+        [continued, downstream],
+      ),
+      lineageWorkRequestEvent(4, "request/work-1-v3", laterSelected),
+    ];
+
+    const state = reconstructWorldState(events, 4);
+    const lineage = state.payloadLineage;
+
+    expect(Object.keys(lineage.snapshots_by_id)).toHaveLength(4);
+
+    const initialResolution = resolveInitialSubmittedSnapshot(lineage, "work-1");
+    expect(initialResolution.status).toBe("RESOLVED");
+    assertLineageTextContent(initialResolution.snapshot!.work_item, "draft-v1");
+
+    const consumed = resolveConsumedInputSnapshot(lineage, "dispatch-1", "work-1");
+    expect(consumed.status).toBe("RESOLVED");
+    assertLineageTextContent(consumed.snapshot!.work_item, "draft-v1");
+
+    const selected = resolveSelectedWorkSnapshot(lineage, "work-1");
+    expect(selected.status).toBe("RESOLVED");
+    assertLineageTextContent(selected.snapshot!.work_item, "draft-v3");
+
+    const sameWorkOutput = resolveOutputWorkSnapshot(lineage, "dispatch-1", "work-1");
+    expect(sameWorkOutput.status).toBe("RESOLVED");
+    expect(sameWorkOutput.snapshot?.continuity).toBe("SAME_WORK_ID_CONTINUATION");
+    assertLineageTextContent(sameWorkOutput.snapshot!.work_item, "draft-v2");
+
+    const downstreamOutput = resolveOutputWorkSnapshot(lineage, "dispatch-1", "work-2");
+    expect(downstreamOutput.status).toBe("RESOLVED");
+    expect(downstreamOutput.snapshot?.continuity).toBe("NEW_DOWNSTREAM_WORK");
+    assertLineageTextContent(downstreamOutput.snapshot!.work_item, "follow-up-v1");
+  });
+
+  it("marks consumed-input lineage unavailable when no work-request snapshot exists", () => {
+    const events: FactoryEvent[] = [
+      initialStructureRequest,
+      factoryEvent(
+        "event-dispatch-missing",
+        1,
+        FACTORY_EVENT_TYPES.dispatchRequest,
+        {
+          inputs: [{ workId: "work-missing" }],
+          resources: [],
+          transitionId: "t-review",
+        },
+        {
+          dispatchId: "dispatch-missing",
+          traceIds: ["trace-missing"],
+          workIds: ["work-missing"],
+        },
+      ),
+    ];
+
+    const state = reconstructWorldState(events, 1);
+    const consumed = resolveConsumedInputSnapshot(
+      state.payloadLineage,
+      "dispatch-missing",
+      "work-missing",
+    );
+
+    expect(consumed.status).toBe("UNAVAILABLE");
+    expect(consumed.reason).toBe(
+      "no lineage snapshot was recorded before this dispatch consumed the work item",
+    );
+  });
+
+  it("preserves consumed-input pin when the same work ID is resubmitted later", () => {
+    const initial = lineageWorkItem("work-child", "Child", "trace-child", "child-v1");
+    const laterSelected = lineageWorkItem(
+      "work-child",
+      "Child",
+      "trace-child",
+      "child-v2",
+    );
+
+    const events: FactoryEvent[] = [
+      initialStructureRequest,
+      lineageWorkRequestEvent(1, "request/child-v1", initial),
+      lineageDispatchRequestEvent(2, "dispatch-consume-child", "t-follow-up", initial),
+      lineageWorkRequestEvent(3, "request/child-v2", laterSelected),
+    ];
+
+    const state = reconstructWorldState(events, 3);
+    const lineage = state.payloadLineage;
+
+    const consumed = resolveConsumedInputSnapshot(
+      lineage,
+      "dispatch-consume-child",
+      "work-child",
+    );
+    expect(consumed.status).toBe("RESOLVED");
+    assertLineageTextContent(consumed.snapshot!.work_item, "child-v1");
+
+    const selected = resolveSelectedWorkSnapshot(lineage, "work-child");
+    expect(selected.status).toBe("RESOLVED");
+    assertLineageTextContent(selected.snapshot!.work_item, "child-v2");
+  });
+});

--- a/ui/src/features/timeline/state/timeline/replayWorldStatePayloadLineage.test.ts
+++ b/ui/src/features/timeline/state/timeline/replayWorldStatePayloadLineage.test.ts
@@ -185,19 +185,21 @@ function lineageDispatchResponseEvent(
   );
 }
 
-function assertLineageTextContent(item: FactoryWorkItem, want: string): void {
-  expect(item.content).toEqual([{ type: "text", text: want }]);
+function assertLineageTextContent(
+  snapshot: { work_item: FactoryWorkItem } | undefined,
+  want: string,
+): void {
+  expect(snapshot).toBeDefined();
+  if (!snapshot) {
+    return;
+  }
+  expect(snapshot.work_item.content).toEqual([{ type: "text", text: want }]);
 }
 
-describe("reconstructWorldState payload lineage", () => {
+describe("reconstructWorldState payload lineage recording", () => {
   it("records work-request, consumed-input, and dispatch-output snapshots during replay", () => {
     const initial = lineageWorkItem("work-1", "Draft", "trace-1", "draft-v1");
-    const continued = lineageWorkItem(
-      "work-1",
-      "Draft",
-      "trace-1",
-      "draft-v2",
-    );
+    const continued = lineageWorkItem("work-1", "Draft", "trace-1", "draft-v2");
     const downstream = lineageWorkItem(
       "work-2",
       "Follow up",
@@ -231,29 +233,48 @@ describe("reconstructWorldState payload lineage", () => {
 
     expect(Object.keys(lineage.snapshots_by_id)).toHaveLength(4);
 
-    const initialResolution = resolveInitialSubmittedSnapshot(lineage, "work-1");
+    const initialResolution = resolveInitialSubmittedSnapshot(
+      lineage,
+      "work-1",
+    );
     expect(initialResolution.status).toBe("RESOLVED");
-    assertLineageTextContent(initialResolution.snapshot!.work_item, "draft-v1");
+    assertLineageTextContent(initialResolution.snapshot, "draft-v1");
 
-    const consumed = resolveConsumedInputSnapshot(lineage, "dispatch-1", "work-1");
+    const consumed = resolveConsumedInputSnapshot(
+      lineage,
+      "dispatch-1",
+      "work-1",
+    );
     expect(consumed.status).toBe("RESOLVED");
-    assertLineageTextContent(consumed.snapshot!.work_item, "draft-v1");
+    assertLineageTextContent(consumed.snapshot, "draft-v1");
 
     const selected = resolveSelectedWorkSnapshot(lineage, "work-1");
     expect(selected.status).toBe("RESOLVED");
-    assertLineageTextContent(selected.snapshot!.work_item, "draft-v3");
+    assertLineageTextContent(selected.snapshot, "draft-v3");
 
-    const sameWorkOutput = resolveOutputWorkSnapshot(lineage, "dispatch-1", "work-1");
+    const sameWorkOutput = resolveOutputWorkSnapshot(
+      lineage,
+      "dispatch-1",
+      "work-1",
+    );
     expect(sameWorkOutput.status).toBe("RESOLVED");
-    expect(sameWorkOutput.snapshot?.continuity).toBe("SAME_WORK_ID_CONTINUATION");
-    assertLineageTextContent(sameWorkOutput.snapshot!.work_item, "draft-v2");
+    expect(sameWorkOutput.snapshot?.continuity).toBe(
+      "SAME_WORK_ID_CONTINUATION",
+    );
+    assertLineageTextContent(sameWorkOutput.snapshot, "draft-v2");
 
-    const downstreamOutput = resolveOutputWorkSnapshot(lineage, "dispatch-1", "work-2");
+    const downstreamOutput = resolveOutputWorkSnapshot(
+      lineage,
+      "dispatch-1",
+      "work-2",
+    );
     expect(downstreamOutput.status).toBe("RESOLVED");
     expect(downstreamOutput.snapshot?.continuity).toBe("NEW_DOWNSTREAM_WORK");
-    assertLineageTextContent(downstreamOutput.snapshot!.work_item, "follow-up-v1");
+    assertLineageTextContent(downstreamOutput.snapshot, "follow-up-v1");
   });
+});
 
+describe("reconstructWorldState payload lineage resolution", () => {
   it("marks consumed-input lineage unavailable when no work-request snapshot exists", () => {
     const events: FactoryEvent[] = [
       initialStructureRequest,
@@ -288,7 +309,12 @@ describe("reconstructWorldState payload lineage", () => {
   });
 
   it("preserves consumed-input pin when the same work ID is resubmitted later", () => {
-    const initial = lineageWorkItem("work-child", "Child", "trace-child", "child-v1");
+    const initial = lineageWorkItem(
+      "work-child",
+      "Child",
+      "trace-child",
+      "child-v1",
+    );
     const laterSelected = lineageWorkItem(
       "work-child",
       "Child",
@@ -299,7 +325,12 @@ describe("reconstructWorldState payload lineage", () => {
     const events: FactoryEvent[] = [
       initialStructureRequest,
       lineageWorkRequestEvent(1, "request/child-v1", initial),
-      lineageDispatchRequestEvent(2, "dispatch-consume-child", "t-follow-up", initial),
+      lineageDispatchRequestEvent(
+        2,
+        "dispatch-consume-child",
+        "t-follow-up",
+        initial,
+      ),
       lineageWorkRequestEvent(3, "request/child-v2", laterSelected),
     ];
 
@@ -312,10 +343,10 @@ describe("reconstructWorldState payload lineage", () => {
       "work-child",
     );
     expect(consumed.status).toBe("RESOLVED");
-    assertLineageTextContent(consumed.snapshot!.work_item, "child-v1");
+    assertLineageTextContent(consumed.snapshot, "child-v1");
 
     const selected = resolveSelectedWorkSnapshot(lineage, "work-child");
     expect(selected.status).toBe("RESOLVED");
-    assertLineageTextContent(selected.snapshot!.work_item, "child-v2");
+    assertLineageTextContent(selected.snapshot, "child-v2");
   });
 });

--- a/ui/src/features/timeline/state/timeline/replayWorldStatePayloadLineage.ts
+++ b/ui/src/features/timeline/state/timeline/replayWorldStatePayloadLineage.ts
@@ -1,0 +1,66 @@
+import type { FactoryWorkItem } from "../../../../api/events";
+import { isSystemTimeWorkItem } from "./systemTime";
+import type { ReplayWorldState, WorldDispatch } from "./types";
+import {
+  recordConsumedInputSnapshot,
+  recordDispatchOutputSnapshot,
+  recordWorkRequestSnapshot,
+} from "./workPayloadLineage";
+
+export function recordWorkRequestPayloadLineage(
+  state: ReplayWorldState,
+  tick: number,
+  requestID: string,
+  workItems: FactoryWorkItem[],
+): void {
+  for (const item of workItems) {
+    if (isSystemTimeWorkItem(item)) {
+      continue;
+    }
+    recordWorkRequestSnapshot(state.payloadLineage, tick, requestID, item);
+  }
+}
+
+export function recordDispatchConsumedInputPayloadLineage(
+  state: ReplayWorldState,
+  dispatchID: string,
+  workItems: FactoryWorkItem[],
+): void {
+  for (const item of workItems) {
+    recordConsumedInputSnapshot(state.payloadLineage, dispatchID, item);
+  }
+}
+
+export function recordDispatchOutputPayloadLineage(
+  state: ReplayWorldState,
+  tick: number,
+  dispatchID: string,
+  consumedInputWorkItems: FactoryWorkItem[],
+  outputItems: FactoryWorkItem[],
+): void {
+  for (const [index, item] of outputItems.entries()) {
+    if (item.id === "") {
+      continue;
+    }
+    recordDispatchOutputSnapshot(
+      state.payloadLineage,
+      tick,
+      dispatchID,
+      consumedInputWorkItems,
+      item,
+      index,
+    );
+  }
+}
+
+export function dispatchInputWorkItems(
+  state: ReplayWorldState,
+  dispatch: WorldDispatch | undefined,
+): FactoryWorkItem[] {
+  if (!dispatch) {
+    return [];
+  }
+  return dispatch.consumedTokens
+    .map((token) => state.workItemsByID[token.work_id])
+    .filter((item): item is FactoryWorkItem => item !== undefined);
+}

--- a/ui/src/features/timeline/state/timeline/replayWorldStateSupport.test.ts
+++ b/ui/src/features/timeline/state/timeline/replayWorldStateSupport.test.ts
@@ -11,6 +11,7 @@ import {
   syncCompletedDispatchAttempt,
 } from "./replayWorldStateSupport";
 import { emptyWorldRuntime, type ReplayWorldState } from "./types";
+import { emptyWorkPayloadLineageProjection } from "./workPayloadLineage";
 
 function emptyState(): ReplayWorldState {
   return {
@@ -21,6 +22,7 @@ function emptyState(): ReplayWorldState {
     failedWorkItemsByID: {},
     inferenceAttemptsByDispatchID: {},
     occupancyByID: {},
+    payloadLineage: emptyWorkPayloadLineageProjection(),
     providerSessions: [],
     relationsByWorkID: {},
     runtime: emptyWorldRuntime(),

--- a/ui/src/features/timeline/state/timeline/replayWorldStateSupport.ts
+++ b/ui/src/features/timeline/state/timeline/replayWorldStateSupport.ts
@@ -3,11 +3,41 @@ import {
   completionToProviderSession,
   completionToTraceDispatch,
 } from "./replayCompletion";
-import type {
-  ReplayWorldState,
-  WorldScriptRequest,
-  WorldScriptResponse,
+import {
+  emptyWorldRuntime,
+  type ReplayWorldState,
+  type WorldScriptRequest,
+  type WorldScriptResponse,
 } from "./types";
+import { emptyWorkPayloadLineageProjection } from "./workPayloadLineage";
+
+export function emptyReplayWorldState(tick: number): ReplayWorldState {
+  return {
+    activeDispatches: {},
+    completedDispatches: [],
+    factory_state: "UNKNOWN",
+    failedWorkDetailsByWorkID: {},
+    failedWorkItemsByID: {},
+    inferenceAttemptsByDispatchID: {},
+    occupancyByID: {},
+    payloadLineage: emptyWorkPayloadLineageProjection(),
+    providerSessions: [],
+    relationsByWorkID: {},
+    runtime: emptyWorldRuntime(),
+    scriptRequestsByDispatchID: {},
+    scriptResponsesByDispatchID: {},
+    terminalWorkByID: {},
+    tick_count: tick,
+    topology: {},
+    tracesByID: {},
+    tracesByWorkID: {},
+    uptime_seconds: 0,
+    workItemsByID: {},
+    workStateChangesByWorkID: {},
+    workstationRequestsByDispatchID: {},
+    workRequestsByID: {},
+  };
+}
 
 export function inferenceAttemptsForDispatch(
   state: ReplayWorldState,
@@ -30,7 +60,11 @@ export function resolveDispatchTransitionID(
   if (activeTransitionID) {
     return activeTransitionID;
   }
-  for (let index = state.completedDispatches.length - 1; index >= 0; index -= 1) {
+  for (
+    let index = state.completedDispatches.length - 1;
+    index >= 0;
+    index -= 1
+  ) {
     const completion = state.completedDispatches[index];
     if (completion.dispatchID === dispatchID) {
       return completion.transitionID;
@@ -44,21 +78,27 @@ export function syncCompletedDispatchAttempt(
   dispatchID: string,
   attempt: DashboardInferenceAttempt,
 ): void {
-  for (let index = state.completedDispatches.length - 1; index >= 0; index -= 1) {
+  for (
+    let index = state.completedDispatches.length - 1;
+    index >= 0;
+    index -= 1
+  ) {
     const completion = state.completedDispatches[index];
     if (completion.dispatchID !== dispatchID) {
       continue;
     }
 
     completion.diagnostics = attempt.diagnostics ?? completion.diagnostics;
-    completion.providerSession = attempt.provider_session ?? completion.providerSession;
+    completion.providerSession =
+      attempt.provider_session ?? completion.providerSession;
 
     if (
       completion.providerSession?.id &&
       !state.providerSessions.some(
         (providerSession) =>
           providerSession.dispatch_id === completion.dispatchID &&
-          providerSession.provider_session?.id === completion.providerSession?.id,
+          providerSession.provider_session?.id ===
+            completion.providerSession?.id,
       )
     ) {
       state.providerSessions = [

--- a/ui/src/features/timeline/state/timeline/replayWorldStateWorkStateChange.test.ts
+++ b/ui/src/features/timeline/state/timeline/replayWorldStateWorkStateChange.test.ts
@@ -4,6 +4,7 @@ import type { FactoryWorkItem } from "../../../../api/events";
 import { applyWorkStateChange } from "./replayWorldStateWorkStateChange";
 import type { WorkStateChangeEvent } from "./replayWorldStateTypes";
 import { emptyWorldRuntime, type ReplayWorldState } from "./types";
+import { emptyWorkPayloadLineageProjection } from "./workPayloadLineage";
 
 function workStateChangeEvent(
   payload: WorkStateChangeEvent["payload"],
@@ -40,6 +41,7 @@ function replayStateWithWork(
     occupancyByID: {
       [placeID]: { placeID, resourceTokenIDs: [], workItemIDs: [workID] },
     },
+    payloadLineage: emptyWorkPayloadLineageProjection(),
     providerSessions: [],
     relationsByWorkID: {},
     runtime: emptyWorldRuntime(),

--- a/ui/src/features/timeline/state/timeline/types.ts
+++ b/ui/src/features/timeline/state/timeline/types.ts
@@ -20,6 +20,7 @@ import type {
   FactoryTerminalWork,
   FactoryWorkItem,
 } from "../../../../api/events";
+import type { WorkPayloadLineageProjection } from "./workPayloadLineage";
 
 export interface ResourceUnit {
   placeID: string;
@@ -167,6 +168,7 @@ export interface TimelineWorldViewBase {
 export interface ReplayWorldState extends TimelineWorldViewBase {
   factory?: FactoryDefinition;
   factory_state: string;
+  payloadLineage: WorkPayloadLineageProjection;
   runtime: DashboardRuntime;
   tick_count: number;
   topology: ProjectedInitialStructure;

--- a/ui/src/features/timeline/state/timeline/workItemRef.test.ts
+++ b/ui/src/features/timeline/state/timeline/workItemRef.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import type { FactoryWorkItem } from "../../../../api/events";
+import {
+  emptyWorkPayloadLineageProjection,
+  recordConsumedInputSnapshot,
+  recordWorkRequestSnapshot,
+} from "./workPayloadLineage";
+import {
+  selectedWorkItemRefForID,
+  workItemRef,
+  workItemRefWithConsumedPayload,
+  workItemRefWithSelectedPayload,
+} from "./workItemRef";
+
+function workItem(id: string, text: string): FactoryWorkItem {
+  return {
+    id,
+    display_name: id,
+    trace_id: `trace-${id}`,
+    work_type_id: "story",
+    content: [{ type: "text", text }],
+  };
+}
+
+describe("workItemRef lineage projection", () => {
+  it("projects selected snapshots with content and lineage metadata", () => {
+    const lineage = emptyWorkPayloadLineageProjection();
+    const item = workItem("work-1", "draft-v1");
+    recordWorkRequestSnapshot(lineage, 1, "request/work-1", item);
+
+    const ref = workItemRefWithSelectedPayload(lineage, item);
+
+    expect(ref).toEqual(
+      expect.objectContaining({
+        content: [{ type: "text", text: "draft-v1" }],
+        lineage_continuity: "INITIAL_SUBMISSION",
+        lineage_logical_work_id: "work-1",
+        lineage_source_kind: "WORK_REQUEST",
+        payload_status: "RESOLVED",
+        work_id: "work-1",
+      }),
+    );
+  });
+
+  it("marks unavailable selected refs with Go-aligned reason text", () => {
+    const lineage = emptyWorkPayloadLineageProjection();
+    const item = workItem("work-missing", "ignored");
+
+    const ref = selectedWorkItemRefForID(lineage, item.id, item);
+
+    expect(ref.payload_status).toBe("UNAVAILABLE");
+    expect(ref.payload_unavailable_reason).toBe(
+      "no lineage snapshot is available for this work item",
+    );
+    expect(ref.content).toBeUndefined();
+    expect(workItemRef(item)).not.toHaveProperty("payload_status");
+  });
+
+  it("pins consumed-input refs at dispatch time", () => {
+    const lineage = emptyWorkPayloadLineageProjection();
+    const initial = workItem("work-1", "draft-v1");
+    const resubmit = workItem("work-1", "draft-v2");
+    recordWorkRequestSnapshot(lineage, 1, "request/work-1-v1", initial);
+    recordConsumedInputSnapshot(lineage, "dispatch-1", initial);
+    recordWorkRequestSnapshot(lineage, 2, "request/work-1-v2", resubmit);
+
+    const consumed = workItemRefWithConsumedPayload(lineage, "dispatch-1", resubmit);
+    const selected = workItemRefWithSelectedPayload(lineage, resubmit);
+
+    expect(consumed.content).toEqual([{ type: "text", text: "draft-v1" }]);
+    expect(selected.content).toEqual([{ type: "text", text: "draft-v2" }]);
+  });
+});

--- a/ui/src/features/timeline/state/timeline/workItemRef.ts
+++ b/ui/src/features/timeline/state/timeline/workItemRef.ts
@@ -1,11 +1,29 @@
-import type { DashboardWorkItemRef } from "../../../../api/dashboard";
+import type {
+  DashboardTraceToken,
+  DashboardWorkItemRef,
+} from "../../../../api/dashboard";
 import type { FactoryWorkItem } from "../../../../api/events";
-import { dashboardWorkTypeID } from "./systemTime";
+import { uniqueSorted } from "./shared";
+import { dashboardWorkTypeID, isSystemTimeWorkItem } from "./systemTime";
+import {
+  cloneLineageWorkItem,
+  resolveConsumedInputSnapshot,
+  resolveOutputWorkSnapshot,
+  resolveSelectedWorkSnapshot,
+  type WorkPayloadLineageProjection,
+  type WorkPayloadSnapshot,
+} from "./workPayloadLineage";
 
 export function workRef(item: FactoryWorkItem): DashboardWorkItemRef {
+  return workItemRef(item);
+}
+
+export function workItemRef(item: FactoryWorkItem): DashboardWorkItemRef {
+  const currentChainingTraceID =
+    item.current_chaining_trace_id ?? item.trace_id;
   return {
-    ...(item.current_chaining_trace_id
-      ? { current_chaining_trace_id: item.current_chaining_trace_id }
+    ...(currentChainingTraceID
+      ? { current_chaining_trace_id: currentChainingTraceID }
       : {}),
     display_name: item.display_name,
     ...(item.previous_chaining_trace_ids
@@ -13,10 +31,157 @@ export function workRef(item: FactoryWorkItem): DashboardWorkItemRef {
           previous_chaining_trace_ids: [...item.previous_chaining_trace_ids],
         }
       : {}),
+    ...(item.state ? { state: item.state } : {}),
     trace_id: item.trace_id,
     work_id: item.id,
     work_type_id: dashboardWorkTypeID(item.work_type_id),
   };
 }
 
+export function workItemRefWithSelectedPayload(
+  lineage: WorkPayloadLineageProjection,
+  item: FactoryWorkItem,
+): DashboardWorkItemRef {
+  return selectedWorkItemRefForID(lineage, item.id, item);
+}
 
+export function selectedWorkItemRefForID(
+  lineage: WorkPayloadLineageProjection,
+  workID: string,
+  fallback?: FactoryWorkItem,
+): DashboardWorkItemRef {
+  const resolution = resolveSelectedWorkSnapshot(lineage, workID);
+  if (resolution.status === "RESOLVED" && resolution.snapshot) {
+    return lineageResolvedWorkItemRef(resolution.snapshot, resolution.status);
+  }
+
+  const item: FactoryWorkItem =
+    fallback ??
+    ({
+      id: workID,
+      work_type_id: "",
+    } satisfies FactoryWorkItem);
+  const ref = workItemRef(item);
+  if (!ref.work_id) {
+    ref.work_id = workID;
+  }
+  if (item.state) {
+    ref.state = item.state;
+  }
+  ref.payload_status = resolution.status;
+  ref.payload_unavailable_reason = resolution.reason;
+  return ref;
+}
+
+export function workItemRefWithConsumedPayload(
+  lineage: WorkPayloadLineageProjection,
+  dispatchID: string,
+  item: FactoryWorkItem,
+): DashboardWorkItemRef {
+  return consumedWorkItemRefForID(lineage, dispatchID, item.id, item);
+}
+
+export function workItemRefWithOutputPayload(
+  lineage: WorkPayloadLineageProjection,
+  dispatchID: string,
+  item: FactoryWorkItem,
+): DashboardWorkItemRef {
+  const resolution = resolveOutputWorkSnapshot(lineage, dispatchID, item.id);
+  if (resolution.status === "RESOLVED" && resolution.snapshot) {
+    return lineageResolvedWorkItemRef(resolution.snapshot, resolution.status);
+  }
+
+  const ref = workItemRef(item);
+  ref.payload_status = resolution.status;
+  ref.payload_unavailable_reason = resolution.reason;
+  return ref;
+}
+
+export function workItemRefsForIDs(
+  lineage: WorkPayloadLineageProjection,
+  ids: string[],
+  itemsByID: Record<string, FactoryWorkItem>,
+): DashboardWorkItemRef[] {
+  const refs: DashboardWorkItemRef[] = [];
+  for (const id of [...ids].sort()) {
+    const item = itemsByID[id];
+    if (!item?.id || isSystemTimeWorkItem(item)) {
+      continue;
+    }
+    refs.push(workItemRefWithSelectedPayload(lineage, item));
+  }
+  return refs;
+}
+
+function consumedWorkItemRefForID(
+  lineage: WorkPayloadLineageProjection,
+  dispatchID: string,
+  workID: string,
+  fallback?: FactoryWorkItem,
+): DashboardWorkItemRef {
+  const resolution = resolveConsumedInputSnapshot(lineage, dispatchID, workID);
+  if (resolution.status === "RESOLVED" && resolution.snapshot) {
+    return lineageResolvedWorkItemRef(resolution.snapshot, resolution.status);
+  }
+
+  const item: FactoryWorkItem =
+    fallback ??
+    ({
+      id: workID,
+      work_type_id: "",
+    } satisfies FactoryWorkItem);
+  const ref = workItemRef(item);
+  if (!ref.work_id) {
+    ref.work_id = workID;
+  }
+  if (item.state) {
+    ref.state = item.state;
+  }
+  ref.payload_status = resolution.status;
+  ref.payload_unavailable_reason = resolution.reason;
+  return ref;
+}
+
+export function consumedWorkItemRefsForDispatch(
+  lineage: WorkPayloadLineageProjection,
+  dispatchID: string,
+  consumedTokens: DashboardTraceToken[],
+  workItemsByID: Record<string, FactoryWorkItem>,
+): DashboardWorkItemRef[] {
+  const seen = new Set<string>();
+  const refs: DashboardWorkItemRef[] = [];
+  for (const workID of uniqueSorted(
+    consumedTokens
+      .map((token) => token.work_id)
+      .filter((workID): workID is string => Boolean(workID)),
+  )) {
+    if (seen.has(workID)) {
+      continue;
+    }
+    const item = workItemsByID[workID];
+    if (!item || isSystemTimeWorkItem(item)) {
+      continue;
+    }
+    seen.add(workID);
+    refs.push(workItemRefWithConsumedPayload(lineage, dispatchID, item));
+  }
+  return refs.sort((left, right) => left.work_id.localeCompare(right.work_id));
+}
+
+function lineageResolvedWorkItemRef(
+  snapshot: WorkPayloadSnapshot,
+  payloadStatus: string,
+): DashboardWorkItemRef {
+  const item = cloneLineageWorkItem(snapshot.work_item);
+  const ref = workItemRef(item);
+  ref.state = item.state;
+  ref.content = item.content;
+  ref.payload_status = payloadStatus;
+  ref.lineage_logical_work_id = snapshot.logical_work_id;
+  ref.lineage_source_kind = snapshot.source_kind;
+  ref.lineage_continuity = snapshot.continuity;
+  ref.lineage_parent_work_ids = snapshot.parent_work_ids
+    ? [...snapshot.parent_work_ids]
+    : undefined;
+  return ref;
+}

--- a/ui/src/features/timeline/state/timeline/workPayloadLineage.test.ts
+++ b/ui/src/features/timeline/state/timeline/workPayloadLineage.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, it } from "vitest";
+import type { FactoryWorkItem } from "../../../../api/events";
+import {
+  emptyWorkPayloadLineageProjection,
+  recordConsumedInputSnapshot,
+  recordDispatchOutputSnapshot,
+  recordWorkRequestSnapshot,
+  resolveConsumedInputSnapshot,
+  resolveInitialSubmittedSnapshot,
+  resolveOutputWorkSnapshot,
+  resolveSelectedWorkSnapshot,
+  type WorkPayloadLineageProjection,
+} from "./workPayloadLineage";
+
+function projectionWorkItem(
+  id: string,
+  displayName: string,
+  traceID: string,
+  placeID: string,
+  text: string,
+): FactoryWorkItem {
+  return {
+    id,
+    work_type_id: "task",
+    display_name: displayName,
+    trace_id: traceID,
+    place_id: placeID,
+    content: [{ type: "text", text }],
+  };
+}
+
+function assertLineageTextContent(item: FactoryWorkItem, want: string): void {
+  expect(item.content).toEqual([{ type: "text", text: want }]);
+}
+
+function buildCanonicalLineageProjection(): WorkPayloadLineageProjection {
+  const projection = emptyWorkPayloadLineageProjection();
+  const initial = projectionWorkItem(
+    "work-1",
+    "Draft",
+    "trace-1",
+    "task:init",
+    "draft-v1",
+  );
+  const continued = projectionWorkItem(
+    "work-1",
+    "Draft",
+    "trace-1",
+    "task:complete",
+    "draft-v2",
+  );
+  const downstream = projectionWorkItem(
+    "work-2",
+    "Follow up",
+    "trace-2",
+    "task:complete",
+    "follow-up-v1",
+  );
+  const laterSelected = projectionWorkItem(
+    "work-1",
+    "Draft",
+    "trace-1",
+    "task:complete",
+    "draft-v3",
+  );
+
+  recordWorkRequestSnapshot(projection, 1, "request/work-1-v1", initial);
+  recordConsumedInputSnapshot(projection, "dispatch-1", initial);
+  recordDispatchOutputSnapshot(
+    projection,
+    3,
+    "dispatch-1",
+    [initial],
+    continued,
+    0,
+  );
+  recordDispatchOutputSnapshot(
+    projection,
+    3,
+    "dispatch-1",
+    [initial],
+    downstream,
+    1,
+  );
+  recordWorkRequestSnapshot(projection, 4, "request/work-1-v3", laterSelected);
+
+  return projection;
+}
+
+function buildDownstreamLineageProjection(): WorkPayloadLineageProjection {
+  const projection = emptyWorkPayloadLineageProjection();
+  const initial = projectionWorkItem(
+    "work-root",
+    "Root",
+    "trace-root",
+    "task:init",
+    "root-v1",
+  );
+  const downstream = projectionWorkItem(
+    "work-child",
+    "Child",
+    "trace-child",
+    "task:review",
+    "child-v1",
+  );
+  const laterSelected = projectionWorkItem(
+    "work-child",
+    "Child",
+    "trace-child",
+    "task:done",
+    "child-v2",
+  );
+
+  recordWorkRequestSnapshot(projection, 1, "request/root-v1", initial);
+  recordConsumedInputSnapshot(projection, "dispatch-create-child", initial);
+  recordDispatchOutputSnapshot(
+    projection,
+    3,
+    "dispatch-create-child",
+    [initial],
+    downstream,
+    0,
+  );
+  recordConsumedInputSnapshot(projection, "dispatch-consume-child", downstream);
+  recordWorkRequestSnapshot(projection, 5, "request/child-v2", laterSelected);
+
+  return projection;
+}
+
+describe("WorkPayloadLineageProjection work-request snapshots", () => {
+  it("records initial work-request snapshots and resolves them", () => {
+    const projection = emptyWorkPayloadLineageProjection();
+    const item = projectionWorkItem(
+      "work-1",
+      "Draft",
+      "trace-1",
+      "task:init",
+      "draft-v1",
+    );
+
+    recordWorkRequestSnapshot(projection, 1, "request/work-1-v1", item);
+
+    const initial = resolveInitialSubmittedSnapshot(projection, "work-1");
+    expect(initial.status).toBe("RESOLVED");
+    expect(initial.snapshot?.source_kind).toBe("WORK_REQUEST");
+    expect(initial.snapshot?.continuity).toBe("INITIAL_SUBMISSION");
+    assertLineageTextContent(
+      initial.snapshot?.work_item ?? { id: "", work_type_id: "" },
+      "draft-v1",
+    );
+  });
+
+  it("continues same work ID across later work-request snapshots", () => {
+    const projection = emptyWorkPayloadLineageProjection();
+    const initial = projectionWorkItem(
+      "work-1",
+      "Draft",
+      "trace-1",
+      "task:init",
+      "draft-v1",
+    );
+    const continued = projectionWorkItem(
+      "work-1",
+      "Draft",
+      "trace-1",
+      "task:complete",
+      "draft-v3",
+    );
+
+    recordWorkRequestSnapshot(projection, 1, "request/work-1-v1", initial);
+    recordWorkRequestSnapshot(projection, 4, "request/work-1-v3", continued);
+
+    const selected = resolveSelectedWorkSnapshot(projection, "work-1");
+    expect(selected.status).toBe("RESOLVED");
+    expect(selected.snapshot?.continuity).toBe("SAME_WORK_ID_CONTINUATION");
+    expect(selected.snapshot?.logical_work_id).toBe("work-1");
+    assertLineageTextContent(
+      selected.snapshot?.work_item ?? { id: "", work_type_id: "" },
+      "draft-v3",
+    );
+    expect(selected.snapshot?.parent_work_ids).toEqual(["work-1"]);
+  });
+});
+
+describe("WorkPayloadLineageProjection consumed-input pinning", () => {
+  it("pins consumed-input snapshots at dispatch time", () => {
+    const projection = buildCanonicalLineageProjection();
+
+    const consumed = resolveConsumedInputSnapshot(
+      projection,
+      "dispatch-1",
+      "work-1",
+    );
+    expect(consumed.status).toBe("RESOLVED");
+    assertLineageTextContent(
+      consumed.snapshot?.work_item ?? { id: "", work_type_id: "" },
+      "draft-v1",
+    );
+
+    recordWorkRequestSnapshot(
+      projection,
+      5,
+      "request/work-1-v4",
+      projectionWorkItem(
+        "work-1",
+        "Draft",
+        "trace-1",
+        "task:complete",
+        "draft-v4",
+      ),
+    );
+
+    const consumedAfterResubmit = resolveConsumedInputSnapshot(
+      projection,
+      "dispatch-1",
+      "work-1",
+    );
+    assertLineageTextContent(
+      consumedAfterResubmit.snapshot?.work_item ?? { id: "", work_type_id: "" },
+      "draft-v1",
+    );
+
+    const selected = resolveSelectedWorkSnapshot(projection, "work-1");
+    assertLineageTextContent(
+      selected.snapshot?.work_item ?? { id: "", work_type_id: "" },
+      "draft-v4",
+    );
+  });
+
+  it("marks unavailable consumed input with Go-aligned reason text", () => {
+    const projection = emptyWorkPayloadLineageProjection();
+    recordConsumedInputSnapshot(
+      projection,
+      "dispatch-missing",
+      projectionWorkItem(
+        "work-missing",
+        "Missing",
+        "trace-missing",
+        "task:init",
+        "missing-v1",
+      ),
+    );
+
+    const consumed = resolveConsumedInputSnapshot(
+      projection,
+      "dispatch-missing",
+      "work-missing",
+    );
+    expect(consumed.status).toBe("UNAVAILABLE");
+    expect(consumed.reason).toBe(
+      "no lineage snapshot was recorded before this dispatch consumed the work item",
+    );
+  });
+});
+
+describe("WorkPayloadLineageProjection dispatch output snapshots", () => {
+  it("records dispatch output continuity for same-work and downstream outputs", () => {
+    const projection = buildCanonicalLineageProjection();
+
+    const sameWorkOutput = resolveOutputWorkSnapshot(
+      projection,
+      "dispatch-1",
+      "work-1",
+    );
+    expect(sameWorkOutput.status).toBe("RESOLVED");
+    assertLineageTextContent(
+      sameWorkOutput.snapshot?.work_item ?? { id: "", work_type_id: "" },
+      "draft-v2",
+    );
+    expect(sameWorkOutput.snapshot?.continuity).toBe(
+      "SAME_WORK_ID_CONTINUATION",
+    );
+    expect(sameWorkOutput.snapshot?.logical_work_id).toBe("work-1");
+
+    const downstreamOutput = resolveOutputWorkSnapshot(
+      projection,
+      "dispatch-1",
+      "work-2",
+    );
+    expect(downstreamOutput.status).toBe("RESOLVED");
+    assertLineageTextContent(
+      downstreamOutput.snapshot?.work_item ?? { id: "", work_type_id: "" },
+      "follow-up-v1",
+    );
+    expect(downstreamOutput.snapshot?.continuity).toBe("NEW_DOWNSTREAM_WORK");
+    expect(downstreamOutput.snapshot?.parent_work_ids).toEqual(["work-1"]);
+    expect(downstreamOutput.snapshot?.logical_work_id).toBe("work-2");
+  });
+
+  it("resolves selected latest snapshots separately from consumed dispatch-time snapshots", () => {
+    const projection = buildCanonicalLineageProjection();
+
+    const selected = resolveSelectedWorkSnapshot(projection, "work-1");
+    expect(selected.status).toBe("RESOLVED");
+    expect(selected.snapshot?.source_kind).toBe("WORK_REQUEST");
+    assertLineageTextContent(
+      selected.snapshot?.work_item ?? { id: "", work_type_id: "" },
+      "draft-v3",
+    );
+  });
+
+  it("resolves downstream output selection and chained consumption", () => {
+    const projection = buildDownstreamLineageProjection();
+
+    const selected = resolveSelectedWorkSnapshot(projection, "work-child");
+    expect(selected.status).toBe("RESOLVED");
+    assertLineageTextContent(
+      selected.snapshot?.work_item ?? { id: "", work_type_id: "" },
+      "child-v2",
+    );
+    expect(selected.snapshot?.logical_work_id).toBe("work-child");
+
+    const consumed = resolveConsumedInputSnapshot(
+      projection,
+      "dispatch-consume-child",
+      "work-child",
+    );
+    expect(consumed.status).toBe("RESOLVED");
+    assertLineageTextContent(
+      consumed.snapshot?.work_item ?? { id: "", work_type_id: "" },
+      "child-v1",
+    );
+    expect(consumed.snapshot?.source_kind).toBe("DISPATCH_RESPONSE_OUTPUT");
+    expect(consumed.snapshot?.continuity).toBe("NEW_DOWNSTREAM_WORK");
+    expect(consumed.snapshot?.parent_work_ids).toEqual(["work-root"]);
+  });
+});
+
+describe("WorkPayloadLineageProjection clone isolation", () => {
+  it("clones returned snapshots so callers cannot mutate stored lineage state", () => {
+    const projection = emptyWorkPayloadLineageProjection();
+    const item = projectionWorkItem(
+      "work-1",
+      "Draft",
+      "trace-1",
+      "task:init",
+      "draft-v1",
+    );
+    recordWorkRequestSnapshot(projection, 1, "request/work-1-v1", item);
+
+    const selected = resolveSelectedWorkSnapshot(projection, "work-1");
+    selected.snapshot?.work_item.content?.push({
+      type: "text",
+      text: "mutated",
+    });
+
+    const selectedAgain = resolveSelectedWorkSnapshot(projection, "work-1");
+    expect(selectedAgain.snapshot?.work_item.content).toEqual([
+      { type: "text", text: "draft-v1" },
+    ]);
+  });
+});

--- a/ui/src/features/timeline/state/timeline/workPayloadLineage.ts
+++ b/ui/src/features/timeline/state/timeline/workPayloadLineage.ts
@@ -1,0 +1,417 @@
+import type { FactoryWorkItem } from "../../../../api/events";
+import type { components } from "../../../../api/generated/openapi";
+
+export type WorkContent = components["schemas"]["WorkContent"];
+
+export type WorkPayloadSnapshotKind =
+  | "WORK_REQUEST"
+  | "DISPATCH_RESPONSE_OUTPUT";
+
+export type WorkPayloadContinuity =
+  | "INITIAL_SUBMISSION"
+  | "SAME_WORK_ID_CONTINUATION"
+  | "NEW_DOWNSTREAM_WORK";
+
+export type WorkPayloadResolutionStatus = "RESOLVED" | "UNAVAILABLE";
+
+export interface WorkPayloadSnapshot {
+  snapshot_id: string;
+  work_id: string;
+  logical_work_id: string;
+  source_kind: WorkPayloadSnapshotKind;
+  source_event_type: string;
+  request_id?: string;
+  dispatch_id?: string;
+  observed_tick?: number;
+  continuity: WorkPayloadContinuity;
+  parent_snapshot_ids?: string[];
+  parent_work_ids?: string[];
+  parent_logical_work_ids?: string[];
+  work_item: FactoryWorkItem;
+}
+
+export interface WorkPayloadRef {
+  status: WorkPayloadResolutionStatus;
+  snapshot_id?: string;
+  reason?: string;
+}
+
+export interface WorkPayloadResolution {
+  status: WorkPayloadResolutionStatus;
+  reason?: string;
+  snapshot?: WorkPayloadSnapshot;
+}
+
+export interface WorkPayloadLineageProjection {
+  snapshots_by_id: Record<string, WorkPayloadSnapshot>;
+  initial_snapshot_id_by_work_id: Record<string, string>;
+  latest_snapshot_id_by_work_id: Record<string, string>;
+  consumed_snapshot_refs_by_dispatch_id: Record<
+    string,
+    Record<string, WorkPayloadRef>
+  >;
+  output_snapshot_refs_by_dispatch_id: Record<
+    string,
+    Record<string, WorkPayloadRef>
+  >;
+  snapshot_ids_by_work_id: Record<string, string[]>;
+}
+
+export function emptyWorkPayloadLineageProjection(): WorkPayloadLineageProjection {
+  return {
+    snapshots_by_id: {},
+    initial_snapshot_id_by_work_id: {},
+    latest_snapshot_id_by_work_id: {},
+    consumed_snapshot_refs_by_dispatch_id: {},
+    output_snapshot_refs_by_dispatch_id: {},
+    snapshot_ids_by_work_id: {},
+  };
+}
+
+export function recordWorkRequestSnapshot(
+  projection: WorkPayloadLineageProjection,
+  observedTick: number,
+  requestID: string,
+  item: FactoryWorkItem,
+): void {
+  if (item.id === "") {
+    return;
+  }
+
+  let logicalWorkID = item.id;
+  let continuity: WorkPayloadContinuity = "INITIAL_SUBMISSION";
+  let parentSnapshotIDs: string[] | undefined;
+  let parentWorkIDs: string[] | undefined;
+  let parentLogicalWorkIDs: string[] | undefined;
+
+  const latest = snapshotByID(
+    projection,
+    projection.latest_snapshot_id_by_work_id[item.id],
+  );
+  if (latest) {
+    logicalWorkID = latest.logical_work_id;
+    continuity = "SAME_WORK_ID_CONTINUATION";
+    parentSnapshotIDs = [latest.snapshot_id];
+    parentWorkIDs = [latest.work_id];
+    parentLogicalWorkIDs = [latest.logical_work_id];
+  }
+
+  const snapshot: WorkPayloadSnapshot = {
+    snapshot_id: `work-request:${requestID}:${item.id}:${(projection.snapshot_ids_by_work_id[item.id]?.length ?? 0) + 1}`,
+    work_id: item.id,
+    logical_work_id: logicalWorkID,
+    source_kind: "WORK_REQUEST",
+    source_event_type: "WORK_REQUEST",
+    request_id: requestID,
+    observed_tick: observedTick,
+    continuity,
+    parent_snapshot_ids: parentSnapshotIDs,
+    parent_work_ids: parentWorkIDs,
+    parent_logical_work_ids: parentLogicalWorkIDs,
+    work_item: cloneLineageWorkItem(item),
+  };
+
+  projection.snapshots_by_id[snapshot.snapshot_id] = snapshot;
+  if (!(item.id in projection.initial_snapshot_id_by_work_id)) {
+    projection.initial_snapshot_id_by_work_id[item.id] = snapshot.snapshot_id;
+  }
+  projection.latest_snapshot_id_by_work_id[item.id] = snapshot.snapshot_id;
+  const snapshotIDs = projection.snapshot_ids_by_work_id[item.id] ?? [];
+  projection.snapshot_ids_by_work_id[item.id] = [
+    ...snapshotIDs,
+    snapshot.snapshot_id,
+  ];
+}
+
+export function recordConsumedInputSnapshot(
+  projection: WorkPayloadLineageProjection,
+  dispatchID: string,
+  item: FactoryWorkItem,
+): void {
+  if (dispatchID === "" || item.id === "") {
+    return;
+  }
+
+  const dispatchRefs =
+    projection.consumed_snapshot_refs_by_dispatch_id[dispatchID] ?? {};
+  projection.consumed_snapshot_refs_by_dispatch_id[dispatchID] = dispatchRefs;
+
+  const latest = snapshotByID(
+    projection,
+    projection.latest_snapshot_id_by_work_id[item.id],
+  );
+  if (latest) {
+    dispatchRefs[item.id] = {
+      status: "RESOLVED",
+      snapshot_id: latest.snapshot_id,
+    };
+    return;
+  }
+
+  dispatchRefs[item.id] = {
+    status: "UNAVAILABLE",
+    reason:
+      "no lineage snapshot was recorded before this dispatch consumed the work item",
+  };
+}
+
+export function recordDispatchOutputSnapshot(
+  projection: WorkPayloadLineageProjection,
+  observedTick: number,
+  dispatchID: string,
+  consumedInputs: FactoryWorkItem[],
+  item: FactoryWorkItem,
+  outputIndex: number,
+): void {
+  if (dispatchID === "" || item.id === "") {
+    return;
+  }
+
+  const parentSnapshots = resolvedConsumedSnapshotsForDispatch(
+    projection,
+    dispatchID,
+  );
+  const parentSnapshotIDs: string[] = [];
+  const parentWorkIDs: string[] = [];
+  const parentLogicalWorkIDs: string[] = [];
+  for (const snapshot of parentSnapshots) {
+    appendUniqueString(parentSnapshotIDs, snapshot.snapshot_id);
+    appendUniqueString(parentWorkIDs, snapshot.work_id);
+    appendUniqueString(parentLogicalWorkIDs, snapshot.logical_work_id);
+  }
+
+  let logicalWorkID = item.id;
+  let continuity: WorkPayloadContinuity = "NEW_DOWNSTREAM_WORK";
+  for (const snapshot of parentSnapshots) {
+    if (snapshot.work_id === item.id) {
+      logicalWorkID = snapshot.logical_work_id;
+      continuity = "SAME_WORK_ID_CONTINUATION";
+      break;
+    }
+  }
+  if (continuity === "NEW_DOWNSTREAM_WORK" && parentSnapshots.length === 0) {
+    for (const input of consumedInputs) {
+      if (input.id === item.id) {
+        logicalWorkID = item.id;
+        continuity = "SAME_WORK_ID_CONTINUATION";
+        break;
+      }
+    }
+  }
+
+  const snapshot: WorkPayloadSnapshot = {
+    snapshot_id: `dispatch-output:${dispatchID}:${item.id}:${outputIndex}`,
+    work_id: item.id,
+    logical_work_id: logicalWorkID,
+    source_kind: "DISPATCH_RESPONSE_OUTPUT",
+    source_event_type: "DISPATCH_RESPONSE_OUTPUT",
+    dispatch_id: dispatchID,
+    observed_tick: observedTick,
+    continuity,
+    parent_snapshot_ids:
+      parentSnapshotIDs.length > 0 ? parentSnapshotIDs : undefined,
+    parent_work_ids: parentWorkIDs.length > 0 ? parentWorkIDs : undefined,
+    parent_logical_work_ids:
+      parentLogicalWorkIDs.length > 0 ? parentLogicalWorkIDs : undefined,
+    work_item: cloneLineageWorkItem(item),
+  };
+
+  projection.snapshots_by_id[snapshot.snapshot_id] = snapshot;
+  projection.latest_snapshot_id_by_work_id[item.id] = snapshot.snapshot_id;
+  const snapshotIDs = projection.snapshot_ids_by_work_id[item.id] ?? [];
+  projection.snapshot_ids_by_work_id[item.id] = [
+    ...snapshotIDs,
+    snapshot.snapshot_id,
+  ];
+
+  const dispatchRefs =
+    projection.output_snapshot_refs_by_dispatch_id[dispatchID] ?? {};
+  projection.output_snapshot_refs_by_dispatch_id[dispatchID] = dispatchRefs;
+  dispatchRefs[item.id] = {
+    status: "RESOLVED",
+    snapshot_id: snapshot.snapshot_id,
+  };
+}
+
+export function resolveInitialSubmittedSnapshot(
+  projection: WorkPayloadLineageProjection,
+  workID: string,
+): WorkPayloadResolution {
+  return resolveSnapshotID(
+    projection,
+    projection.initial_snapshot_id_by_work_id[workID],
+    "no initial work-request payload snapshot was recorded for this work item",
+  );
+}
+
+export function resolveConsumedInputSnapshot(
+  projection: WorkPayloadLineageProjection,
+  dispatchID: string,
+  workID: string,
+): WorkPayloadResolution {
+  const dispatchRefs =
+    projection.consumed_snapshot_refs_by_dispatch_id[dispatchID];
+  if (!dispatchRefs) {
+    return unavailableWorkPayloadResolution(
+      "no consumed-input lineage was recorded for this dispatch",
+    );
+  }
+  const ref = dispatchRefs[workID];
+  if (!ref) {
+    return unavailableWorkPayloadResolution(
+      "the dispatch did not record a consumed lineage snapshot for this work item",
+    );
+  }
+  return resolveRef(projection, ref);
+}
+
+export function resolveSelectedWorkSnapshot(
+  projection: WorkPayloadLineageProjection,
+  workID: string,
+): WorkPayloadResolution {
+  return resolveSnapshotID(
+    projection,
+    projection.latest_snapshot_id_by_work_id[workID],
+    "no lineage snapshot is available for this work item",
+  );
+}
+
+export function resolveOutputWorkSnapshot(
+  projection: WorkPayloadLineageProjection,
+  dispatchID: string,
+  workID: string,
+): WorkPayloadResolution {
+  const dispatchRefs =
+    projection.output_snapshot_refs_by_dispatch_id[dispatchID];
+  if (!dispatchRefs) {
+    return unavailableWorkPayloadResolution(
+      "no output-work lineage was recorded for this dispatch",
+    );
+  }
+  const ref = dispatchRefs[workID];
+  if (!ref) {
+    return unavailableWorkPayloadResolution(
+      "the dispatch did not record an output lineage snapshot for this work item",
+    );
+  }
+  return resolveRef(projection, ref);
+}
+
+function resolveRef(
+  projection: WorkPayloadLineageProjection,
+  ref: WorkPayloadRef,
+): WorkPayloadResolution {
+  if (ref.status === "UNAVAILABLE") {
+    return unavailableWorkPayloadResolution(ref.reason ?? "");
+  }
+  return resolveSnapshotID(projection, ref.snapshot_id, ref.reason ?? "");
+}
+
+function resolveSnapshotID(
+  projection: WorkPayloadLineageProjection,
+  snapshotID: string | undefined,
+  unavailableReason: string,
+): WorkPayloadResolution {
+  const snapshot = snapshotByID(projection, snapshotID);
+  if (!snapshot) {
+    return unavailableWorkPayloadResolution(unavailableReason);
+  }
+  return {
+    status: "RESOLVED",
+    snapshot: cloneLineageSnapshot(snapshot),
+  };
+}
+
+function unavailableWorkPayloadResolution(
+  reason: string,
+): WorkPayloadResolution {
+  return {
+    status: "UNAVAILABLE",
+    reason,
+  };
+}
+
+function snapshotByID(
+  projection: WorkPayloadLineageProjection,
+  snapshotID: string | undefined,
+): WorkPayloadSnapshot | undefined {
+  if (!snapshotID) {
+    return undefined;
+  }
+  return projection.snapshots_by_id[snapshotID];
+}
+
+function resolvedConsumedSnapshotsForDispatch(
+  projection: WorkPayloadLineageProjection,
+  dispatchID: string,
+): WorkPayloadSnapshot[] {
+  const dispatchRefs =
+    projection.consumed_snapshot_refs_by_dispatch_id[dispatchID];
+  if (!dispatchRefs || Object.keys(dispatchRefs).length === 0) {
+    return [];
+  }
+
+  const snapshots: WorkPayloadSnapshot[] = [];
+  for (const workID of sortedStringKeys(dispatchRefs)) {
+    const ref = dispatchRefs[workID];
+    if (ref.status !== "RESOLVED") {
+      continue;
+    }
+    const snapshot = snapshotByID(projection, ref.snapshot_id);
+    if (!snapshot) {
+      continue;
+    }
+    snapshots.push(snapshot);
+  }
+  return snapshots;
+}
+
+function cloneLineageSnapshot(
+  snapshot: WorkPayloadSnapshot,
+): WorkPayloadSnapshot {
+  return {
+    ...snapshot,
+    parent_snapshot_ids: cloneStringSlice(snapshot.parent_snapshot_ids),
+    parent_work_ids: cloneStringSlice(snapshot.parent_work_ids),
+    parent_logical_work_ids: cloneStringSlice(snapshot.parent_logical_work_ids),
+    work_item: cloneLineageWorkItem(snapshot.work_item),
+  };
+}
+
+export function cloneLineageWorkItem(item: FactoryWorkItem): FactoryWorkItem {
+  return {
+    ...item,
+    previous_chaining_trace_ids: cloneStringSlice(
+      item.previous_chaining_trace_ids,
+    ),
+    content: cloneWorkContent(item.content),
+    tags: item.tags ? { ...item.tags } : undefined,
+  };
+}
+
+function cloneWorkContent(
+  content: WorkContent | undefined,
+): WorkContent | undefined {
+  if (!content) {
+    return undefined;
+  }
+  return content.map((part) => ({ ...part }));
+}
+
+function cloneStringSlice(values: string[] | undefined): string[] | undefined {
+  if (!values) {
+    return undefined;
+  }
+  return [...values];
+}
+
+function sortedStringKeys(values: Record<string, WorkPayloadRef>): string[] {
+  return Object.keys(values).sort();
+}
+
+function appendUniqueString(values: string[], value: string): void {
+  if (value === "" || values.includes(value)) {
+    return;
+  }
+  values.push(value);
+}

--- a/ui/src/testing/expectDashboardWorkItemRef.ts
+++ b/ui/src/testing/expectDashboardWorkItemRef.ts
@@ -1,0 +1,9 @@
+import { expect } from "vitest";
+import type { DashboardWorkItemRef } from "../api/dashboard";
+
+/** Partial matcher for lineage-enriched dashboard work item refs in tests. */
+export function expectDashboardWorkItemRef(
+  partial: Partial<DashboardWorkItemRef>,
+): DashboardWorkItemRef {
+  return expect.objectContaining(partial) as DashboardWorkItemRef;
+}


### PR DESCRIPTION
```json
{
  "project": "infinite-you",
  "branchName": "ralph/website-work-payload-lineage",
  "description": "Port Go WorkPayloadLineageProjection into dashboard timeline replay so Current selection and place occupancy expose work content, payload_status, and lineage metadata from factory SSE events with dispatch consumed-input pinning parity.",
  "context": {
    "customerAsk": "Port Go WorkPayloadLineageProjection into the dashboard timeline replay path so reconstructWorldState → projectRuntime → Current selection exposes work content and payload status from factory SSE events. When the same work ID is consumed by a workstation dispatch, show the submit-time payload (consumed-input pin), not a later WORK_REQUEST on the same ID.",
    "problem": "Timeline replay builds DashboardWorkItemRef without payload lineage: factoryWorkToItem and workRef drop Work.content even when WORK_REQUEST and DISPATCH_RESPONSE events carry text or multimodal parts, so Current selection shows empty work contents for live sessions.",
    "solution": "Add a replay-safe WorkPayloadLineageProjection in the UI timeline layer, record snapshots on WORK_REQUEST and dispatch created/completed events, resolve selected snapshots when projecting refs for Current selection and current_work_items_by_place_id, and lock behavior with Vitest golden SSE fixtures."
  },
  "acceptanceCriteria": [
    "After replaying SSE that includes WORK_REQUEST content, Current selection shows the same text/multimodal parts (not an empty work contents panel).",
    "current_work_items_by_place_id entries include payload_status RESOLVED and content when a work-request snapshot exists for that work ID.",
    "Payload lineage recording and resolution match Go for work-request, dispatch consumed-input pin, dispatch output, selected, consumed, and output lookups including UNAVAILABLE reason text.",
    "Consumed-input pin: when work ID W is consumed by dispatch D and later receives another WORK_REQUEST, consumed resolution for (D, W) stays submit-time while selected resolution for v1 surfaces uses the latest snapshot.",
    "Resolved DashboardWorkItemRef includes content, payload_status, and lineage metadata fields (lineageLogicalWorkId, lineageSourceKind, lineageContinuity, lineageParentWorkIds).",
    "Golden fixture tests under fixtures/payload-lineage/ fail before the fix and pass after; synthetic tests cover submit-only, dispatch without input content, output content, and same-ID resubmit.",
    "Quality gate: UI typecheck, lint, and timeline Vitest suite pass in CI; no SSE or backend lineage changes unless a test proves a server gap."
  ],
  "userStories": [
    {
      "id": "website-work-payload-lineage-001",
      "title": "Payload lineage projection module",
      "description": "As a maintainer, I need a replay-safe payload lineage projection in the timeline layer so work refs can resolve content the same way as Go without coupling to React.",
      "acceptanceCriteria": [
        "WorkPayloadLineageProjection (or equivalent) under ui/src/features/timeline/state/timeline/ exposes record APIs for work-request, dispatch consumed-input, and dispatch output snapshots and resolve APIs for selected, consumed, and output lookups aligned with pkg/interfaces/work_payload_lineage.go",
        "Unit tests cover initial work-request snapshot, same work ID continuation, consumed-input pin at dispatch tick, output continuity kinds, selected latest snapshot, and unavailable consumed input with Go-aligned reason text",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "website-work-payload-lineage-002",
      "title": "Record lineage during event replay",
      "description": "As a maintainer, I need replay reducers to record payload snapshots when canonical factory events are applied so lineage state stays consistent with Go world state.",
      "acceptanceCriteria": [
        "ReplayWorldState holds payloadLineage initialized for each replay",
        "applyWorkRequest records work-request snapshots with cloned content from event Work.content for each non-system-time work item",
        "applyRequest records consumed-input snapshots per (dispatchId, workId) at dispatch tick or marks unavailable when no snapshot exists",
        "applyResponse records dispatch-output snapshots from outputWork with Go-aligned continuity rules",
        "Replay tests assert lineage state updates on representative event sequences",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "website-work-payload-lineage-003",
      "title": "Project refs for Current selection and place occupancy",
      "description": "As a dashboard user, I want work contents in Current selection and place occupancy to show the submitted payload when the event stream included it.",
      "acceptanceCriteria": [
        "workRef or workItemRefWithLineage resolves selected snapshots into DashboardWorkItemRef with content, payload_status, and lineage fields; unresolved refs set UNAVAILABLE and payload_unavailable_reason",
        "projectRuntime current_work_items_by_place_id uses selected resolution instead of identity-only refs",
        "resolveDashboardSelection work items surface replayed content for live sessions",
        "Event recording paths read content from OpenAPI Work shapes on WORK_REQUEST and dispatch events",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser: select a work item submitted with text content via SSE; Current selection work detail shows the content"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "website-work-payload-lineage-004",
      "title": "Golden fixture regression pack",
      "description": "As a maintainer, I need golden SSE fixtures so payload projection cannot regress silently across replay refactors.",
      "acceptanceCriteria": [
        "Fixtures under ui/src/features/timeline/state/timeline/fixtures/payload-lineage/ include at least work-request-with-content.json and dispatch-without-input-content.json suitable for reconstructWorldState",
        "replayWorldState.payload-lineage.test.ts replays fixtures and asserts projected refs match expected content and payload_status",
        "Synthetic replay tests cover submit-only content, dispatch without input content, output work content, and same work ID resubmit with consumed pin unchanged",
        "Fixture provenance documented (session id or capture date)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}
```