### PR TITLE
factory-graph-logical-move-handles

### DIFF
--- a/ui/integration/factory-graph-editor-session-switch.integration.test.mjs
+++ b/ui/integration/factory-graph-editor-session-switch.integration.test.mjs
@@ -317,9 +317,13 @@ async function runSessionSwitchClearsDirtyEditorScenario(preview) {
 
     await enterGraphEditor(browserPage.page);
     await addUnsavedWorkType(browserPage.page, "essay");
-    expect(
-      await browserPage.page.getByTestId("rf__node-work-type:essay").count(),
-    ).toBe(1);
+    await expect
+      .poll(
+        async () =>
+          await browserPage.page.getByTestId("rf__node-work-type:essay").count(),
+        { timeout: uiInteractionTimeoutMs },
+      )
+      .toBe(1);
 
     await betaTab.click();
     await expect

--- a/ui/src/features/current-factory-definition/lib/workstation-progress-outcome-routes.test.ts
+++ b/ui/src/features/current-factory-definition/lib/workstation-progress-outcome-routes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   workstationHasZAxisIncompleteForConnections,
+  workstationSupportsProgressOutcomeFailureRoute,
   workstationSupportsProgressOutcomeRoutes,
 } from "./workstation-progress-outcome-routes";
 
@@ -69,6 +70,43 @@ describe("workstationSupportsProgressOutcomeRoutes", () => {
         ],
       }),
     ).toBe(false);
+  });
+
+  it("returns false for logical-move workstations", () => {
+    expect(
+      workstationSupportsProgressOutcomeRoutes({
+        type: "LOGICAL_MOVE",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("workstationSupportsProgressOutcomeFailureRoute", () => {
+  it("returns false for logical-move workstations", () => {
+    expect(
+      workstationSupportsProgressOutcomeFailureRoute({
+        type: "LOGICAL_MOVE",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true for a standard model processor without stopWords", () => {
+    expect(
+      workstationSupportsProgressOutcomeFailureRoute({
+        type: "MODEL_WORKSTATION",
+        behavior: "STANDARD",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for a standard model processor with stopWords", () => {
+    expect(
+      workstationSupportsProgressOutcomeFailureRoute({
+        type: "MODEL_WORKSTATION",
+        behavior: "STANDARD",
+        stopWords: ["DONE"],
+      }),
+    ).toBe(true);
   });
 });
 

--- a/ui/src/features/current-factory-definition/lib/workstation-progress-outcome-routes.ts
+++ b/ui/src/features/current-factory-definition/lib/workstation-progress-outcome-routes.ts
@@ -33,6 +33,10 @@ export function workstationSupportsProgressOutcomeRoutes(
     return false;
   }
 
+  if (resolveEditableWorkstationType(workstation) === "LOGICAL_MOVE") {
+    return false;
+  }
+
   const behavior = resolveEditableWorkstationBehavior(workstation);
   if (behavior === "REPEATER") {
     return true;
@@ -51,6 +55,13 @@ export function workstationSupportsProgressOutcomeRoutes(
   }
 
   return workstationHasConfiguredStopWords(workstation.stopWords);
+}
+
+/** True when the Failure progress-outcome connect anchor may render (false for logical-move only). */
+export function workstationSupportsProgressOutcomeFailureRoute(
+  workstation: WorkstationProgressOutcomeRouteContext,
+): boolean {
+  return resolveEditableWorkstationType(workstation) !== "LOGICAL_MOVE";
 }
 
 /** True when Continue/Reject connect anchors are omitted for missing stopWords on a standard model processor. */

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-flow.progress-outcome-routes.test.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-flow.progress-outcome-routes.test.tsx
@@ -150,7 +150,7 @@ function renderProgressOutcomeRouteFlow(
   );
 }
 
-describe("factory graph editor progress outcome route handles", () => {
+function useProgressOutcomeRouteFlowTestHooks() {
   let restoreBrowserTestShims: (() => void) | null = null;
 
   beforeEach(() => {
@@ -162,6 +162,10 @@ describe("factory graph editor progress outcome route handles", () => {
     restoreBrowserTestShims?.();
     restoreBrowserTestShims = null;
   });
+}
+
+describe("factory graph editor progress outcome route handles", () => {
+  useProgressOutcomeRouteFlowTestHooks();
 
   it("hides continue and reject connect handles for standard processors without stopWords", async () => {
     const { container } = renderProgressOutcomeRouteFlow([
@@ -241,6 +245,10 @@ describe("factory graph editor progress outcome route handles", () => {
       container.querySelectorAll("[data-z-axis-incomplete-hint]"),
     ).toHaveLength(0);
   });
+});
+
+describe("factory graph editor logical-move progress outcome route handles", () => {
+  useProgressOutcomeRouteFlowTestHooks();
 
   it("hides continue, failure, and reject connect handles on logical-move workstations", async () => {
     renderProgressOutcomeRouteFlow([logicalMoveWorkstation], {

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-flow.progress-outcome-routes.test.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-flow.progress-outcome-routes.test.tsx
@@ -63,6 +63,44 @@ const standardProcessorWithStopWords: FactoryWorkstation = {
   stopWords: ["DONE"],
 };
 
+const logicalMoveWorkstation: FactoryWorkstation = {
+  body: "Move work downstream.",
+  inputs: [
+    {
+      state: "queued",
+      workType: "story",
+    },
+  ],
+  name: "router",
+  outputs: [
+    {
+      state: "done",
+      workType: "story",
+    },
+  ],
+  resources: [
+    {
+      capacity: 2,
+      name: "gpu",
+    },
+  ],
+  type: "LOGICAL_MOVE",
+  worker: "",
+};
+
+const logicalMoveComparisonTopology: FactoryGraphTopology = {
+  ...PROGRESS_OUTCOME_ROUTE_TOPOLOGY,
+  nodes: [
+    ...PROGRESS_OUTCOME_ROUTE_TOPOLOGY.nodes,
+    {
+      id: "workstation:router",
+      key: { kind: "workstation", name: "router" },
+      kind: "workstation",
+      label: "router",
+    },
+  ],
+};
+
 const onRejectionValidationProjection = projectFactoryValidationTargets([
   {
     code: "factory.workstation.missingRejectionRoute",
@@ -79,6 +117,7 @@ const onRejectionValidationProjection = projectFactoryValidationTargets([
 function renderProgressOutcomeRouteFlow(
   workstations: readonly FactoryWorkstation[],
   options?: {
+    topology?: FactoryGraphTopology;
     validationProjection?: typeof onRejectionValidationProjection;
   },
 ) {
@@ -89,7 +128,7 @@ function renderProgressOutcomeRouteFlow(
     pendingConnectionSource: null,
     pendingRemovalEdgeIds: new Set<string>(),
     pendingRemovalNodeIds: new Set<string>(),
-    topology: PROGRESS_OUTCOME_ROUTE_TOPOLOGY,
+    topology: options?.topology ?? PROGRESS_OUTCOME_ROUTE_TOPOLOGY,
     validationProjection: options?.validationProjection,
     workstations,
   });
@@ -201,5 +240,57 @@ describe("factory graph editor progress outcome route handles", () => {
     expect(
       container.querySelectorAll("[data-z-axis-incomplete-hint]"),
     ).toHaveLength(0);
+  });
+
+  it("hides continue, failure, and reject connect handles on logical-move workstations", async () => {
+    renderProgressOutcomeRouteFlow([logicalMoveWorkstation], {
+      topology: logicalMoveComparisonTopology,
+    });
+
+    await screen.findByRole("button", { name: "Connect: router Success" });
+    expect(
+      screen.getByRole("button", { name: "Connect: router Input" }),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Connect: router Resource" }),
+    ).not.toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Connect: router Failure" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Connect: router Continue" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Connect: router Reject" }),
+    ).toBeNull();
+  });
+
+  it("keeps standard processor outcome handles when logical-move is on the same graph", async () => {
+    renderProgressOutcomeRouteFlow(
+      [standardProcessorWithoutStopWords, logicalMoveWorkstation],
+      { topology: logicalMoveComparisonTopology },
+    );
+
+    await screen.findByRole("button", { name: "Connect: draft Success" });
+    expect(
+      screen.getByRole("button", { name: "Connect: draft Failure" }),
+    ).not.toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Connect: draft Continue" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Connect: draft Reject" }),
+    ).toBeNull();
+
+    await screen.findByRole("button", { name: "Connect: router Success" });
+    expect(
+      screen.queryByRole("button", { name: "Connect: router Failure" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Connect: router Continue" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Connect: router Reject" }),
+    ).toBeNull();
   });
 });

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-flow.stories.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-flow.stories.tsx
@@ -492,7 +492,46 @@ const standardProcessorWithStopWords: FactoryWorkstation = {
   stopWords: ["DONE"],
 };
 
+const logicalMoveWorkstation: FactoryWorkstation = {
+  body: "Move work downstream.",
+  inputs: [
+    {
+      state: "queued",
+      workType: "story",
+    },
+  ],
+  name: "router",
+  outputs: [
+    {
+      state: "done",
+      workType: "story",
+    },
+  ],
+  resources: [
+    {
+      capacity: 2,
+      name: "gpu",
+    },
+  ],
+  type: "LOGICAL_MOVE",
+  worker: "",
+};
+
+const logicalMoveComparisonTopology: FactoryGraphTopology = {
+  ...PROGRESS_OUTCOME_ROUTE_TOPOLOGY,
+  nodes: [
+    ...PROGRESS_OUTCOME_ROUTE_TOPOLOGY.nodes,
+    {
+      id: "workstation:router",
+      key: { kind: "workstation", name: "router" },
+      kind: "workstation",
+      label: "router",
+    },
+  ],
+};
+
 function ProgressOutcomeRoutesStory(input: {
+  topology?: FactoryGraphTopology;
   workstations: readonly FactoryWorkstation[];
 }) {
   const flow = buildFactoryGraphEditorFlowModel({
@@ -502,7 +541,7 @@ function ProgressOutcomeRoutesStory(input: {
     pendingAdditionNodeIds: new Set<string>(),
     pendingRemovalEdgeIds: new Set<string>(),
     pendingRemovalNodeIds: new Set<string>(),
-    topology: PROGRESS_OUTCOME_ROUTE_TOPOLOGY,
+    topology: input.topology ?? PROGRESS_OUTCOME_ROUTE_TOPOLOGY,
     workstations: input.workstations,
   });
 
@@ -522,6 +561,27 @@ function ProgressOutcomeRoutesStory(input: {
       </ReactFlow>
     </div>
   );
+}
+
+async function expectLogicalMoveConnectHandles(canvas: ReturnType<typeof within>) {
+  await expect(
+    canvas.getByRole("button", { name: "Connect: router Success" }),
+  ).toBeVisible();
+  await expect(
+    canvas.getByRole("button", { name: "Connect: router Input" }),
+  ).toBeVisible();
+  await expect(
+    canvas.getByRole("button", { name: "Connect: router Resource" }),
+  ).toBeVisible();
+  await expect(
+    canvas.queryByRole("button", { name: "Connect: router Failure" }),
+  ).toBeNull();
+  await expect(
+    canvas.queryByRole("button", { name: "Connect: router Continue" }),
+  ).toBeNull();
+  await expect(
+    canvas.queryByRole("button", { name: "Connect: router Reject" }),
+  ).toBeNull();
 }
 
 async function expectProgressOutcomeRouteHandles(
@@ -777,6 +837,42 @@ export const ProgressOutcomeRoutesWithStopWords = {
     await expectProgressOutcomeRouteHandles(canvas, {
       includeContinueAndReject: true,
     });
+    await expectZAxisIncompleteHints(canvasElement, { expectHints: false });
+  },
+};
+
+export const LogicalMoveProgressOutcomeHandles = {
+  render: () => (
+    <ProgressOutcomeRoutesStory
+      topology={logicalMoveComparisonTopology}
+      workstations={[logicalMoveWorkstation]}
+    />
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText("router")).toBeVisible();
+    await expectLogicalMoveConnectHandles(canvas);
+    await expectZAxisIncompleteHints(canvasElement, { expectHints: false });
+  },
+};
+
+export const LogicalMoveComparedToStandardProcessor = {
+  render: () => (
+    <ProgressOutcomeRoutesStory
+      topology={logicalMoveComparisonTopology}
+      workstations={[standardProcessorWithoutStopWords, logicalMoveWorkstation]}
+    />
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText("draft")).toBeVisible();
+    await expect(canvas.getByText("router")).toBeVisible();
+    await expectProgressOutcomeRouteHandles(canvas, {
+      includeContinueAndReject: false,
+    });
+    await expectLogicalMoveConnectHandles(canvas);
     await expectZAxisIncompleteHints(canvasElement, { expectHints: false });
   },
 };

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-editor-connections.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-editor-connections.ts
@@ -1,5 +1,6 @@
 import {
   type WorkstationProgressOutcomeRouteContext,
+  workstationSupportsProgressOutcomeFailureRoute,
   workstationSupportsProgressOutcomeRoutes,
 } from "../../current-factory-definition/lib/workstation-progress-outcome-routes";
 import { workstationRequiresWorkerAssignment } from "../../current-factory-definition/lib/workstation-worker-assignment";
@@ -198,15 +199,22 @@ function filterWorkstationConnectionAnchors(
     context && !workstationRequiresWorkerAssignment(context.workstation)
       ? anchors.filter((anchor) => anchor.id !== "worker-assignment-target")
       : anchors;
-  if (
-    !context ||
-    workstationSupportsProgressOutcomeRoutes(context.workstation)
-  ) {
+  if (!context) {
     return filtered;
   }
-  return filtered.filter(
-    (anchor) => !PROGRESS_OUTCOME_SOURCE_ANCHOR_IDS.has(anchor.id),
-  );
+
+  let result = filtered;
+  if (!workstationSupportsProgressOutcomeRoutes(context.workstation)) {
+    result = result.filter(
+      (anchor) => !PROGRESS_OUTCOME_SOURCE_ANCHOR_IDS.has(anchor.id),
+    );
+  }
+  if (!workstationSupportsProgressOutcomeFailureRoute(context.workstation)) {
+    result = result.filter(
+      (anchor) => anchor.id !== "workstation-on-failure-source",
+    );
+  }
+  return result;
 }
 
 export function getFactoryGraphConnectionAnchors(

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-editor-connections.worker-assignment.test.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-editor-connections.worker-assignment.test.ts
@@ -4,6 +4,7 @@ import {
   createFactoryGraphWorkstationResolver,
   factoryGraphConnectionAnchorContext,
   getLocalizedFactoryGraphConnectionAnchors,
+  isValidFactoryGraphConnection,
 } from "./factory-graph-editor-connections";
 
 const logicalMoveContext = factoryGraphConnectionAnchorContext({
@@ -23,6 +24,16 @@ const workerAssignmentTopology: FactoryGraphTopology = {
       key: { kind: "worker", name: "writer" },
       kind: "worker",
       label: "writer",
+    },
+    {
+      id: "work-state:story:queued",
+      key: {
+        kind: "work-state",
+        stateName: "queued",
+        workTypeName: "story",
+      },
+      kind: "work-state",
+      label: "story:queued",
     },
     {
       id: "workstation:router",
@@ -54,6 +65,60 @@ it("omits worker-assignment-target for LOGICAL_MOVE workstations", () => {
       "workstation-output-source",
     ]),
   );
+});
+
+it("omits continue, failure, and reject anchors for LOGICAL_MOVE workstations", () => {
+  const anchorIds = getLocalizedFactoryGraphConnectionAnchors(
+    "workstation",
+    "en",
+    logicalMoveContext,
+  ).map((anchor) => anchor.id);
+
+  expect(anchorIds).not.toContain("workstation-on-continue-source");
+  expect(anchorIds).not.toContain("workstation-on-failure-source");
+  expect(anchorIds).not.toContain("workstation-on-rejection-source");
+});
+
+it("rejects new progress-outcome connections from hidden logical-move anchors", () => {
+  const logicalMoveWorkstation = logicalMoveContext.workstation;
+
+  for (const sourceAnchorId of [
+    "workstation-on-continue-source",
+    "workstation-on-failure-source",
+    "workstation-on-rejection-source",
+  ] as const) {
+    expect(
+      isValidFactoryGraphConnection({
+        sourceAnchorId,
+        sourceNodeKind: "workstation",
+        targetAnchorId: "work-state-input-target",
+        targetNodeKind: "work-state",
+        sourceWorkstation: logicalMoveWorkstation,
+      }),
+    ).toBe(false);
+  }
+
+  expect(
+    buildFactoryGraphEdgeChangeFromConnection(
+      workerAssignmentTopology,
+      {
+        sourceAnchorId: "workstation-on-failure-source",
+        sourceNodeId: "workstation:router",
+        targetAnchorId: "work-state-input-target",
+        targetNodeId: "work-state:story:queued",
+      },
+      createFactoryGraphWorkstationResolver([
+        {
+          body: "Route work downstream.",
+          inputs: [],
+          name: "router",
+          outputs: [],
+          type: "LOGICAL_MOVE",
+          worker: "",
+        },
+      ]),
+    ),
+  ).toBeNull();
 });
 
 it("exposes worker-assignment-target for worker-backed workstations", () => {

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-react-flow-projection.test.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-react-flow-projection.test.ts
@@ -583,6 +583,10 @@ describe("factory graph React Flow projection", () => {
 
     expect(logicalMoveAnchorIds).not.toContain("worker-assignment-target");
     expect(modelWorkstationAnchorIds).toContain("worker-assignment-target");
+    expect(logicalMoveAnchorIds).not.toContain("workstation-on-continue-source");
+    expect(logicalMoveAnchorIds).not.toContain("workstation-on-failure-source");
+    expect(logicalMoveAnchorIds).not.toContain("workstation-on-rejection-source");
+    expect(modelWorkstationAnchorIds).toContain("workstation-on-failure-source");
   });
 
   it("exposes continue and reject handles when stopWords is configured", () => {

--- a/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-editor-handles.ts
+++ b/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-editor-handles.ts
@@ -2,6 +2,7 @@ import type { CanonicalFactoryDefinition } from "../../../api/current-factory-de
 import type { FactoryValidationTarget } from "../../../api/factory-validation";
 import {
   workstationHasZAxisIncompleteForConnections,
+  workstationSupportsProgressOutcomeFailureRoute,
   workstationSupportsProgressOutcomeRoutes,
 } from "../../current-factory-definition/lib/workstation-progress-outcome-routes";
 import type {
@@ -206,12 +207,15 @@ export function buildSemanticGraphHandles(args: {
     args.editor.canInteractWithEditor &&
     args.editor.activeTool === "connect";
 
+  const workstation = args.connectionAnchorContext?.workstation;
   const supportsProgressOutcomeRoutes =
     args.nodeKind !== "workstation" ||
-    !args.connectionAnchorContext ||
-    workstationSupportsProgressOutcomeRoutes(
-      args.connectionAnchorContext.workstation,
-    );
+    !workstation ||
+    workstationSupportsProgressOutcomeRoutes(workstation);
+  const supportsProgressOutcomeFailureRoute =
+    args.nodeKind !== "workstation" ||
+    !workstation ||
+    workstationSupportsProgressOutcomeFailureRoute(workstation);
 
   let anchors = getLocalizedFactoryGraphConnectionAnchors(
     args.nodeKind,
@@ -228,8 +232,10 @@ export function buildSemanticGraphHandles(args: {
   const handles: ActivityGraphNodeHandle[] = anchors.map((anchor) => {
     const isAuthoredOnlyProgressOutcomeHandle =
       args.nodeKind === "workstation" &&
-      !supportsProgressOutcomeRoutes &&
-      PROGRESS_OUTCOME_SOURCE_ANCHOR_IDS.has(anchor.id);
+      ((!supportsProgressOutcomeRoutes &&
+        PROGRESS_OUTCOME_SOURCE_ANCHOR_IDS.has(anchor.id)) ||
+        (!supportsProgressOutcomeFailureRoute &&
+          anchor.id === "workstation-on-failure-source"));
     const handleValidation = validationHandleErrors?.get(anchor.id);
     const rendersHandleValidation =
       args.nodeKind !== "workstation" ||

--- a/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-editor-handles.worker-assignment.test.ts
+++ b/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-editor-handles.worker-assignment.test.ts
@@ -1,5 +1,6 @@
 import type { CanonicalFactoryDefinition } from "../../../api/current-factory-definition";
 import { baseFactoryDefinition } from "../../factory-graph-editor/lib/factory-graph-draft.test-helpers";
+import { projectFactoryValidationTargets } from "../../factory-graph-editor/lib/factory-validation-graph-projection";
 import {
   buildCurrentActivityGraphLayoutFromFactory,
   dashboardWorkstationFromFactory,
@@ -24,6 +25,17 @@ const logicalMoveContext = factoryGraphConnectionAnchorContext({
 const modelWorkstationContext = factoryGraphConnectionAnchorContext({
   type: "MODEL_WORKSTATION",
   behavior: "STANDARD",
+});
+
+const standardProcessorWithoutStopWords = factoryGraphConnectionAnchorContext({
+  type: "MODEL_WORKSTATION",
+  behavior: "STANDARD",
+});
+
+const standardProcessorWithStopWords = factoryGraphConnectionAnchorContext({
+  type: "MODEL_WORKSTATION",
+  behavior: "STANDARD",
+  stopWords: ["DONE"],
 });
 
 const factoryWithLogicalMove = {
@@ -54,6 +66,125 @@ const factoryWithLogicalMove = {
 function handleIds(handles: { id: string }[]) {
   return handles.map((handle) => handle.id);
 }
+
+it("omits continue, failure, and reject handles on LOGICAL_MOVE workstations in connect mode", () => {
+  const ids = handleIds(
+    buildEditorHandles({
+      connectionAnchorContext: logicalMoveContext,
+      editor: {
+        activeTool: "connect",
+        canInteractWithEditor: true,
+        editorMode: true,
+        onConnectionAnchorClick: () => {},
+        pendingConnectionSource: null,
+      },
+      nodeId: "workstation:router",
+      nodeKind: "workstation",
+    }),
+  );
+
+  expect(ids).not.toContain("workstation-on-continue-source");
+  expect(ids).not.toContain("workstation-on-failure-source");
+  expect(ids).not.toContain("workstation-on-rejection-source");
+});
+
+it("keeps failure and omits continue and reject for a standard processor without stopWords", () => {
+  const ids = handleIds(
+    buildEditorHandles({
+      connectionAnchorContext: standardProcessorWithoutStopWords,
+      editor: {
+        activeTool: "connect",
+        canInteractWithEditor: true,
+        editorMode: true,
+        onConnectionAnchorClick: () => {},
+        pendingConnectionSource: null,
+      },
+      nodeId: "workstation:draft",
+      nodeKind: "workstation",
+    }),
+  );
+
+  expect(ids).toContain("workstation-on-failure-source");
+  expect(ids).not.toContain("workstation-on-continue-source");
+  expect(ids).not.toContain("workstation-on-rejection-source");
+});
+
+it("renders all progress-outcome handles when stopWords are configured", () => {
+  const ids = handleIds(
+    buildEditorHandles({
+      connectionAnchorContext: standardProcessorWithStopWords,
+      editor: {
+        activeTool: "connect",
+        canInteractWithEditor: true,
+        editorMode: true,
+        onConnectionAnchorClick: () => {},
+        pendingConnectionSource: null,
+      },
+      nodeId: "workstation:draft",
+      nodeKind: "workstation",
+    }),
+  );
+
+  expect(ids).toEqual(
+    expect.arrayContaining([
+      "workstation-on-continue-source",
+      "workstation-on-failure-source",
+      "workstation-on-rejection-source",
+    ]),
+  );
+});
+
+it("does not attach progress-outcome validation to hidden logical-move anchors", () => {
+  const validationProjection = projectFactoryValidationTargets([
+    {
+      code: "factory.workstation.missingFailureRoute",
+      message: "Workstation router must define a failure route.",
+      severity: "error",
+      subject: {
+        id: "router",
+        location: "ON_FAILURE",
+        type: "WORKSTATION",
+      },
+    },
+    {
+      code: "factory.workstation.missingRejectionRoute",
+      message: "Workstation router must define a reject route.",
+      severity: "error",
+      subject: {
+        id: "router",
+        location: "ON_REJECTION",
+        type: "WORKSTATION",
+      },
+    },
+    {
+      code: "factory.workstation.missingContinueRoute",
+      message: "Workstation router must define a continue route.",
+      severity: "error",
+      subject: {
+        id: "router",
+        location: "ON_CONTINUE",
+        type: "WORKSTATION",
+      },
+    },
+  ]);
+  const handles = buildEditorHandles({
+    connectionAnchorContext: logicalMoveContext,
+    editor: {
+      activeTool: "connect",
+      canInteractWithEditor: true,
+      editorMode: true,
+      onConnectionAnchorClick: () => {},
+      pendingConnectionSource: null,
+    },
+    nodeId: "workstation:router",
+    nodeKind: "workstation",
+    validationProjection,
+  });
+
+  expect(handles.find((handle) => handle.id === "workstation-on-failure-source")).toBeUndefined();
+  expect(handles.find((handle) => handle.id === "workstation-on-rejection-source")).toBeUndefined();
+  expect(handles.find((handle) => handle.id === "workstation-on-continue-source")).toBeUndefined();
+});
 
 it("omits worker-assignment-target on LOGICAL_MOVE workstations", () => {
   const ids = handleIds(
@@ -170,5 +301,8 @@ it("builds current-activity workstation nodes without worker-assignment handles 
   );
 
   expect(logicalMoveHandles).not.toContain("worker-assignment-target");
+  expect(logicalMoveHandles).not.toContain("workstation-on-continue-source");
+  expect(logicalMoveHandles).not.toContain("workstation-on-failure-source");
+  expect(logicalMoveHandles).not.toContain("workstation-on-rejection-source");
   expect(modelWorkstationHandles).toContain("worker-assignment-target");
 });


### PR DESCRIPTION
{
  "project": "Factory graph logical-move handle visibility",
  "branchName": "ralph/factory-graph-logical-move-handles",
  "description": "Hide Continue, Failure, and Reject factory graph connection handles on LOGICAL_MOVE workstations because they do not support onContinue, onFailure, or onRejection edges. Align editor and current-activity graph handle filtering with the workstation contract while preserving model workstation stop-words behavior.",
  "context": {
    "customerAsk": "Logical move factory workstations are exposed with handles for on failure/on continue/on rejection, but that doesn't make sense since those types of workstations do not even support those types of edges. Hide those handles for logical move workstations.",
    "problem": "Factory graph and current-activity graph UIs render progress-outcome connect handles on LOGICAL_MOVE nodes. Authors can attempt invalid topology wiring. Shared eligibility currently treats LOGICAL_MOVE as supporting progress-outcome routes, and failure handles are not filtered with continue/reject when routes are unsupported.",
    "solution": "Centralize LOGICAL_MOVE as ineligible for progress-outcome connection handles, filter all three outcome source anchors for logical-move workstations in connection anchor resolution and editor handle projections, reject new connections from hidden anchors, and cover behavior with focused unit tests plus browser verification."
  },
  "acceptanceCriteria": [
    "LOGICAL_MOVE workstation nodes in factory graph editor connect mode show only input, output, and resource handles—no Continue, Failure, or Reject handles.",
    "Standard model workstations without stopWords still show Failure and hide Continue/Reject; with stopWords all three outcome handles remain available.",
    "New drag-connect attempts from hidden logical-move outcome anchors cannot create draft edges.",
    "Current-activity factory graph editor mode applies the same logical-move handle filtering as the dedicated factory graph editor.",
    "No regression for worker-assignment handle hiding on LOGICAL_MOVE or for non-logical workstation outcome handle rules.",
    "Typecheck, lint, and targeted tests pass for all changed behavior."
  ],
  "userStories": [
    {
      "id": "factory-graph-logical-move-handles-001",
      "title": "Logical-move workstations do not support progress-outcome connection handles",
      "description": "As a maintainer, I need a single authoritative rule that logical-move workstations never expose progress-outcome connect anchors, so all graph surfaces filter handles consistently.",
      "acceptanceCriteria": [
        "workstationSupportsProgressOutcomeRoutes (or equivalent shared helper) returns false when resolved workstation type is LOGICAL_MOVE",
        "Failure anchor omission applies only to LOGICAL_MOVE; standard MODEL_WORKSTATION without stopWords still supports rendering the Failure handle",
        "Unit tests cover LOGICAL_MOVE vs standard processor vs standard-with-stopWords eligibility",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "factory-graph-logical-move-handles-002",
      "title": "Factory graph editor hides outcome handles on logical-move nodes",
      "description": "As a factory author using the topology editor, I want logical-move workstations to show only valid handles so I cannot wire impossible progress-outcome edges.",
      "acceptanceCriteria": [
        "getFactoryGraphConnectionAnchors omits workstation-on-continue-source, workstation-on-failure-source, and workstation-on-rejection-source for LOGICAL_MOVE context",
        "isValidFactoryGraphConnection and buildFactoryGraphEdgeChangeFromConnection reject new connections from those anchors on logical-move workstations",
        "projectFactoryGraphToReactFlow connection anchors for a logical-move node exclude all three outcome handles",
        "Standard processor without stopWords still omits Continue/Reject and retains Failure; with stopWords retains all three outcome handles",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "factory-graph-logical-move-handles-003",
      "title": "Current-activity graph editor handles match logical-move filtering",
      "description": "As a dashboard user editing the running factory graph, I want logical-move nodes on the current-activity card to hide the same invalid handles as the dedicated factory graph editor.",
      "acceptanceCriteria": [
        "buildEditorHandles for LOGICAL_MOVE workstation nodes in connect mode omit Continue, Failure, and Reject handle ids",
        "Worker-backed workstations on the same graph still expose worker-assignment-target and correct outcome handles per stop-words rules",
        "Validation badges for progress-outcome routes do not attach to hidden logical-move anchors",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "factory-graph-logical-move-handles-004",
      "title": "Author-visible verification in browser",
      "description": "As a factory author, I want to confirm in the UI that logical-move stations no longer show progress-outcome handles when connecting edges.",
      "acceptanceCriteria": [
        "In factory graph editor or current-activity graph connect mode, a LOGICAL_MOVE workstation shows only input, output, and resource handles",
        "A standard processor on the same graph still shows Failure and Continue/Reject handles according to stopWords configuration",
        "Typecheck passes",
        "Verify in browser"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)