### PR TITLE
migrate-submit-batch-clihttp

### DIFF
--- a/pkg/cli/clihttp/clihttp.go
+++ b/pkg/cli/clihttp/clihttp.go
@@ -47,6 +47,12 @@ func PutJSON(ctx context.Context, client *http.Client, url string, body io.Reade
 	return doJSON(ctx, client, http.MethodPut, url, body, dst, http.StatusOK, opts)
 }
 
+// PutJSONCreated executes an HTTP PUT with an optional JSON body and decodes JSON into dst when
+// the response status is 201 Created.
+func PutJSONCreated(ctx context.Context, client *http.Client, url string, body io.Reader, dst any, opts RequestOptions) (*http.Response, error) {
+	return doJSON(ctx, client, http.MethodPut, url, body, dst, http.StatusCreated, opts)
+}
+
 func doJSON(
 	ctx context.Context,
 	client *http.Client,

--- a/pkg/cli/clihttp/clihttp_test.go
+++ b/pkg/cli/clihttp/clihttp_test.go
@@ -320,6 +320,132 @@ func TestPostJSONCreated_LogsStatusDiagnosticForNonCreated(t *testing.T) {
 	}
 }
 
+func TestPutJSONCreated_DecodesSuccessResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Fatalf("method = %s, want PUT", r.Method)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Fatalf("content-type = %q, want application/json", r.Header.Get("Content-Type"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		if err := json.NewEncoder(w).Encode(map[string]string{"batchId": "batch-1"}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	var result map[string]string
+	resp, err := PutJSONCreated(
+		context.Background(),
+		srv.Client(),
+		srv.URL+"/work/batch",
+		strings.NewReader(`{"items":[]}`),
+		&result,
+		RequestOptions{EndpointPath: "/work/batch", LogLabel: "submit batch"},
+	)
+	if err != nil {
+		t.Fatalf("PutJSONCreated: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status = %d, want 201", resp.StatusCode)
+	}
+	if result["batchId"] != "batch-1" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestPutJSONCreated_ReturnsResponseForNonCreatedStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		if err := json.NewEncoder(w).Encode(factoryapi.ErrorResponse{
+			Message: "invalid batch",
+			Code:    factoryapi.ErrorResponseCode("INVALID_REQUEST"),
+			Family:  factoryapi.ErrorFamilyBadRequest,
+		}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	var result map[string]string
+	resp, err := PutJSONCreated(
+		context.Background(),
+		srv.Client(),
+		srv.URL,
+		strings.NewReader(`{"items":[]}`),
+		&result,
+		RequestOptions{EndpointPath: "/work/batch", LogLabel: "submit batch"},
+	)
+	if err != nil {
+		t.Fatalf("PutJSONCreated: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestPutJSONCreated_PropagatesTransportFailure(t *testing.T) {
+	client := &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, io.ErrUnexpectedEOF
+	})}
+
+	var diagnostics bytes.Buffer
+	_, err := PutJSONCreated(
+		context.Background(),
+		client,
+		"http://127.0.0.1:1/work/batch",
+		strings.NewReader(`{"items":[]}`),
+		nil,
+		RequestOptions{
+			Diagnostics:  &diagnostics,
+			Verbose:      true,
+			EndpointPath: "/work/batch",
+			LogLabel:     "submit batch",
+		},
+	)
+	if err == nil {
+		t.Fatal("PutJSONCreated: want transport error")
+	}
+	if !strings.Contains(diagnostics.String(), "submit batch response endpointPath=/work/batch error=unreachable") {
+		t.Fatalf("diagnostics = %q", diagnostics.String())
+	}
+}
+
+func TestPutJSONCreated_LogsStatusDiagnosticForNonCreated(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	var diagnostics bytes.Buffer
+	resp, err := PutJSONCreated(
+		context.Background(),
+		srv.Client(),
+		srv.URL,
+		strings.NewReader(`{"items":[]}`),
+		nil,
+		RequestOptions{
+			Diagnostics:  &diagnostics,
+			Verbose:      true,
+			EndpointPath: "/work/batch",
+			LogLabel:     "submit batch",
+		},
+	)
+	if err != nil {
+		t.Fatalf("PutJSONCreated: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if !strings.Contains(diagnostics.String(), "submit batch response endpointPath=/work/batch status=500") {
+		t.Fatalf("diagnostics = %q", diagnostics.String())
+	}
+}
+
 func TestPutJSON_SendsJSONBodyAndDecodesResponse(t *testing.T) {
 	var gotMethod string
 	var gotContentType string

--- a/pkg/cli/submit/batch.go
+++ b/pkg/cli/submit/batch.go
@@ -2,6 +2,7 @@ package submit
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,6 +13,7 @@ import (
 
 	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
 	"github.com/portpowered/infinite-you/pkg/cli/clidiag"
+	"github.com/portpowered/infinite-you/pkg/cli/clihttp"
 	"github.com/portpowered/infinite-you/pkg/cli/cliserver"
 	"github.com/portpowered/infinite-you/pkg/factory/requests"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
@@ -130,34 +132,39 @@ func upsertBatchHTTP(cfg BatchConfig, req interfaces.WorkRequest, body []byte, b
 	)
 
 	started := time.Now()
-	httpReq, err := http.NewRequest(http.MethodPut, endpointURL, bytes.NewReader(body))
+	client := &http.Client{Timeout: submitRequestTimeout}
+	var result factoryapi.UpsertWorkRequestResponse
+	resp, err := clihttp.PutJSONCreated(
+		context.Background(),
+		client,
+		endpointURL,
+		bytes.NewReader(body),
+		&result,
+		clihttp.RequestOptions{
+			Diagnostics:  cfg.Diagnostics,
+			Verbose:      cfg.Verbose,
+			EndpointPath: endpointPath,
+			LogLabel:     "submit batch",
+		},
+	)
 	if err != nil {
-		return fmt.Errorf("build request: %w", err)
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	resp, err := http.DefaultClient.Do(httpReq)
-	if err != nil {
-		clidiag.Printf(cfg.Diagnostics, cfg.Verbose, "submit batch response endpointPath=%s error=unreachable durationMillis=%d", endpointPath, time.Since(started).Milliseconds())
 		return fmt.Errorf("factory not reachable at %s: %w", endpointURL, err)
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("read response: %w", err)
-	}
-
 	if resp.StatusCode != http.StatusCreated {
-		clidiag.Printf(cfg.Diagnostics, cfg.Verbose, "submit batch response endpointPath=%s status=%d durationMillis=%d responseBytes=%d", endpointPath, resp.StatusCode, time.Since(started).Milliseconds(), len(respBody))
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("read response: %w", err)
+		}
 		return batchSubmissionHTTPError(resp.StatusCode, respBody)
 	}
 
-	var result factoryapi.UpsertWorkRequestResponse
-	if err := json.Unmarshal(respBody, &result); err != nil {
-		return fmt.Errorf("parse response: %w", err)
+	responseBytes := 0
+	if encoded, marshalErr := json.Marshal(result); marshalErr == nil {
+		responseBytes = len(encoded)
 	}
-	clidiag.Printf(cfg.Diagnostics, cfg.Verbose, "submit batch response endpointPath=%s status=%d durationMillis=%d responseBytes=%d requestId=%s traceId=%s workCount=%d", endpointPath, resp.StatusCode, time.Since(started).Milliseconds(), len(respBody), result.RequestId, result.TraceId, len(result.Works))
+	clidiag.Printf(cfg.Diagnostics, cfg.Verbose, "submit batch response endpointPath=%s status=%d durationMillis=%d responseBytes=%d requestId=%s traceId=%s workCount=%d", endpointPath, resp.StatusCode, time.Since(started).Milliseconds(), responseBytes, result.RequestId, result.TraceId, len(result.Works))
 
 	if cfg.JSON {
 		return printBatchSuccessJSON(cfg.Output, cfg.SessionID, endpointPath, batchSource, req, result)


### PR DESCRIPTION
{
  "project": "Migrate submit batch to clihttp",
  "branchName": "ralph/migrate-submit-batch-clihttp",
  "description": "Route `you submit batch` HTTP upsert through `pkg/cli/clihttp` via a new `PutJSONCreated` helper so batch PUT transport matches standalone `you submit`, without changing CLI-visible behavior, diagnostics, or error messages.",
  "context": {
    "customerAsk": "Migrate `pkg/cli/submit/batch.go` `upsertBatchHTTP` through `pkg/cli/clihttp` so batch PUT transport matches the standalone submit migration on `main`, without changing CLI behavior.",
    "problem": "Batch upsert still uses raw `http.NewRequest`, `http.DefaultClient.Do`, and manual body read/decode on HTTP 201, while `you submit` already uses `clihttp.PostJSONCreated` with a bounded client and shared diagnostics. `clihttp` has `PutJSON` (200 OK) but batch upsert succeeds with 201 Created.",
    "solution": "Add `PutJSONCreated` mirroring `PostJSONCreated`, unit-test it in `clihttp_test.go`, refactor `upsertBatchHTTP` to use it with the same timeout and `RequestOptions` pattern as `submit.go` (`LogLabel: \"submit batch\"`), preserve batch-specific diagnostics and `batchSubmissionHTTPError`, and keep or lightly adjust `batch_test.go` only for behavioral coverage."
  },
  "acceptanceCriteria": [
    "`PutJSONCreated` exists in `pkg/cli/clihttp` and decodes JSON on HTTP 201 for PUT requests with the same logging contract as `PostJSONCreated`.",
    "`upsertBatchHTTP` uses `PutJSONCreated` with a timeout-configured client and does not use `http.DefaultClient` or manual `io.ReadAll` on the HTTP 201 success path.",
    "Operator-visible behavior is unchanged: dry-run, human/JSON success output, `factory not reachable at` errors, `batch submission failed` wording, and verbose `submit batch request` / `submit batch response` metadata without payload leakage.",
    "`go test ./pkg/cli/clihttp/... ./pkg/cli/submit/...` passes with direct behavioral tests only (no transport or file-layout inventory tests).",
    "Out of scope items are untouched: session `--port` migration, other CLI packages, website/UI.",
    "Project quality gate: typecheck, lint, and tests pass for all touched packages."
  ],
  "userStories": [
    {
      "id": "migrate-submit-batch-clihttp-001",
      "title": "Add PutJSONCreated transport helper",
      "description": "As a CLI maintainer, I need a shared PUT + 201 JSON helper so batch upsert can reuse the same `doJSON` transport as standalone submit without duplicating HTTP plumbing.",
      "acceptanceCriteria": [
        "`PutJSONCreated` in `pkg/cli/clihttp` uses PUT and treats HTTP 201 as success, delegating to the same `doJSON` implementation as `PostJSONCreated`.",
        "On transport failure, verbose diagnostics log `{LogLabel} response endpointPath=... error=unreachable`; on non-201, log status and return the response with nil transport error.",
        "`clihttp_test.go` covers 201 decode success, non-201 status return, and transport failure with unreachable diagnostic.",
        "Typecheck passes",
        "Tests pass (`go test ./pkg/cli/clihttp/...`)"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "migrate-submit-batch-clihttp-002",
      "title": "Route submit batch upsert through clihttp",
      "description": "As an operator running `you submit batch`, I want HTTP upsert to use the same bounded, context-aware transport as `you submit` without any change to command output or error messages I already rely on.",
      "acceptanceCriteria": [
        "`upsertBatchHTTP` calls `clihttp.PutJSONCreated` with `context.Background()`, a timeout-configured `http.Client` matching `submit.go`, and `RequestOptions` with `LogLabel: \"submit batch\"` and the batch endpoint path.",
        "Pre-request and post-success verbose diagnostics keep `submit batch request` / `submit batch response` labels and existing metadata fields; dry-run bypasses HTTP unchanged.",
        "Non-201 responses read the body and return `batchSubmissionHTTPError` with unchanged message shapes; unreachable errors remain `factory not reachable at %s: %w`.",
        "`batch.go` does not call `http.DefaultClient` or `io.ReadAll` on the HTTP 201 success path.",
        "Typecheck passes",
        "Tests pass (`go test ./pkg/cli/clihttp/... ./pkg/cli/submit/...`)"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "migrate-submit-batch-clihttp-003",
      "title": "Confirm batch behavioral tests after migration",
      "description": "As a reviewer, I need existing batch CLI behavioral tests to pass unchanged so the transport refactor does not regress operator-visible outcomes.",
      "acceptanceCriteria": [
        "`pkg/cli/submit/batch_test.go` still verifies unreachable factory error shape, verbose metadata without payload leakage, human and JSON success output, and API error message decoding on HTTP failure.",
        "No new meta tests for import lists, file layout, or helper registration inventories.",
        "Typecheck passes",
        "Tests pass (`go test ./pkg/cli/submit/...`)"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)