### PR TITLE
prd-factory-import-preserve-inbox-gitkeep

### DIFF
--- a/pkg/config/layout_expansion.go
+++ b/pkg/config/layout_expansion.go
@@ -133,7 +133,10 @@ func finalizeFactorySplitLayoutWrite(
 	if err := os.MkdirAll(inputsDir, 0o755); err != nil {
 		return fmt.Errorf("create inputs directory %s: %w", inputsDir, err)
 	}
-	return ensureDefaultInputChannelDirectories(targetDir, cfg)
+	if err := ensureDefaultInputChannelDirectories(targetDir, cfg); err != nil {
+		return err
+	}
+	return ensureCanonicalInputInboxSentinels(targetDir, cfg)
 }
 
 func copySupportedPortableBundledFilesFromSource(sourceDir, targetDir string, cfg *interfaces.FactoryConfig) error {
@@ -831,6 +834,57 @@ func ensureDefaultInputChannelDirectories(targetDir string, cfg *interfaces.Fact
 		if err := os.MkdirAll(channelDir, 0o755); err != nil {
 			return fmt.Errorf("create inputs/%s/%s directory: %w", workTypeName, interfaces.DefaultChannelName, err)
 		}
+	}
+	return nil
+}
+
+const batchInputInboxChannelName = "BATCH"
+
+func ensureCanonicalInputInboxSentinels(targetDir string, cfg *interfaces.FactoryConfig) error {
+	if err := ensureInputInboxGitkeep(
+		targetDir,
+		filepath.Join(interfaces.InputsDir, batchInputInboxChannelName, interfaces.DefaultChannelName, ".gitkeep"),
+	); err != nil {
+		return fmt.Errorf("ensure batch inbox sentinel: %w", err)
+	}
+	if cfg == nil {
+		return nil
+	}
+	for _, workType := range cfg.WorkTypes {
+		workTypeName := strings.TrimSpace(workType.Name)
+		if workTypeName == "" {
+			continue
+		}
+		relativePath := filepath.Join(
+			interfaces.InputsDir,
+			workTypeName,
+			interfaces.DefaultChannelName,
+			".gitkeep",
+		)
+		if err := ensureInputInboxGitkeep(targetDir, relativePath); err != nil {
+			return fmt.Errorf("ensure inputs/%s/%s .gitkeep: %w", workTypeName, interfaces.DefaultChannelName, err)
+		}
+	}
+	return nil
+}
+
+func ensureInputInboxGitkeep(targetDir, relativePath string) error {
+	path := filepath.Join(targetDir, relativePath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create %s parent directory: %w", relativePath, err)
+	}
+	info, err := os.Stat(path)
+	switch {
+	case err == nil:
+		if info.IsDir() {
+			return fmt.Errorf("%s exists as a directory", relativePath)
+		}
+		return nil
+	case !errors.Is(err, os.ErrNotExist):
+		return fmt.Errorf("stat %s: %w", relativePath, err)
+	}
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		return fmt.Errorf("create %s: %w", relativePath, err)
 	}
 	return nil
 }

--- a/pkg/config/portabletests/portable_bundled_files_integration_test.go
+++ b/pkg/config/portabletests/portable_bundled_files_integration_test.go
@@ -12,6 +12,46 @@ import (
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 )
 
+func TestPortableBundledFiles_FlattenOmitsGitkeepFromExportPayload(t *testing.T) {
+	projectDir, sourceDir := seedPortableBundledRoundTripFactory(t)
+
+	writePortableBundledRoundTripFile(t, filepath.Join(sourceDir, "scripts", ".gitkeep"), "")
+	writePortableBundledRoundTripFile(t, filepath.Join(sourceDir, "inputs", "task", "default", ".gitkeep"), "")
+	writePortableBundledRoundTripFile(t, filepath.Join(sourceDir, "inputs", "BATCH", "default", ".gitkeep"), "")
+
+	flattened, err := factoryconfig.FlattenFactoryConfig(sourceDir)
+	if err != nil {
+		t.Fatalf("FlattenFactoryConfig: %v", err)
+	}
+	cfg, err := factoryconfig.FactoryConfigFromOpenAPIJSON(flattened)
+	if err != nil {
+		t.Fatalf("FactoryConfigFromOpenAPIJSON: %v", err)
+	}
+	if cfg.ResourceManifest == nil {
+		t.Fatal("expected flattened config to include resourceManifest")
+	}
+	if len(cfg.ResourceManifest.BundledFiles) != 4 {
+		t.Fatalf("expected 4 bundled files (gitkeep omitted), got %#v", cfg.ResourceManifest.BundledFiles)
+	}
+	assertPortableBundledFilesExcludeGitkeep(t, cfg.ResourceManifest.BundledFiles)
+
+	portableDir := t.TempDir()
+	portablePath := filepath.Join(portableDir, interfaces.FactoryConfigFile)
+	if err := os.WriteFile(portablePath, flattened, 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", portablePath, err)
+	}
+	copyPortableBundledDiskBackedExport(t, projectDir, sourceDir, portableDir)
+
+	loaded, err := factoryconfig.LoadRuntimeConfig(portableDir, nil)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfig(standalone portable config): %v", err)
+	}
+	if loaded.FactoryConfig() == nil || loaded.FactoryConfig().ResourceManifest == nil {
+		t.Fatal("expected loaded config to include resourceManifest")
+	}
+	assertPortableBundledFilesExcludeGitkeep(t, loaded.FactoryConfig().ResourceManifest.BundledFiles)
+}
+
 func TestPortableBundledFiles_RoundTripAcrossFlattenAndExpand(t *testing.T) {
 	projectDir, sourceDir := seedPortableBundledRoundTripFactory(t)
 
@@ -453,6 +493,17 @@ func assertPortableBundledRoundTripScriptExecutable(t *testing.T, path string) {
 	}
 	if info.Mode().Perm()&0o111 == 0 {
 		t.Fatalf("%s mode = %#o, want executable bit set", path, info.Mode().Perm())
+	}
+}
+
+func assertPortableBundledFilesExcludeGitkeep(t *testing.T, bundledFiles []interfaces.BundledFileConfig) {
+	t.Helper()
+
+	for _, bundledFile := range bundledFiles {
+		if strings.HasSuffix(bundledFile.TargetPath, ".gitkeep") ||
+			strings.Contains(bundledFile.TargetPath, "/.gitkeep") {
+			t.Fatalf("bundled file targetPath must not include .gitkeep: %#v", bundledFile)
+		}
 	}
 }
 

--- a/pkg/config/runtimetests/runtime_config_named_factory_persist_inbox_sentinels_test.go
+++ b/pkg/config/runtimetests/runtime_config_named_factory_persist_inbox_sentinels_test.go
@@ -1,0 +1,66 @@
+package runtimetests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/portpowered/infinite-you/pkg/config"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+)
+
+func TestPersistNamedFactory_EnsuresCanonicalInputInboxGitkeepsOnCreate(t *testing.T) {
+	rootDir := t.TempDir()
+
+	factoryDir, err := PersistNamedFactory(rootDir, "alpha", namedFactoryPayload(t, "alpha"))
+	if err != nil {
+		t.Fatalf("PersistNamedFactory: %v", err)
+	}
+
+	assertInputInboxGitkeepFile(t, factoryDir, "BATCH")
+	assertInputInboxGitkeepFile(t, factoryDir, "task")
+}
+
+func TestReplaceNamedFactory_EnsuresCanonicalInputInboxGitkeepsWhenAbsentBeforeReplace(t *testing.T) {
+	rootDir := t.TempDir()
+
+	if _, err := PersistNamedFactory(rootDir, "alpha", namedFactoryPayload(t, "alpha")); err != nil {
+		t.Fatalf("PersistNamedFactory: %v", err)
+	}
+
+	factoryDir := filepath.Join(rootDir, "alpha")
+	removeInputInboxGitkeep(t, factoryDir, "BATCH")
+	removeInputInboxGitkeep(t, factoryDir, "task")
+
+	if _, err := ReplaceNamedFactory(rootDir, "alpha", namedFactoryPayloadWithBundledFiles(t, "alpha")); err != nil {
+		t.Fatalf("ReplaceNamedFactory: %v", err)
+	}
+
+	assertInputInboxGitkeepFile(t, factoryDir, "BATCH")
+	assertInputInboxGitkeepFile(t, factoryDir, "task")
+}
+
+func assertInputInboxGitkeepFile(t *testing.T, factoryDir, channel string) {
+	t.Helper()
+
+	path := filepath.Join(factoryDir, interfaces.InputsDir, channel, interfaces.DefaultChannelName, ".gitkeep")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("inputs/%s/%s/.gitkeep after materialization: %v", channel, interfaces.DefaultChannelName, err)
+	}
+	if info.IsDir() {
+		t.Fatalf("inputs/%s/%s/.gitkeep after materialization: got directory, want regular file", channel, interfaces.DefaultChannelName)
+	}
+	if info.Size() != 0 {
+		t.Fatalf("inputs/%s/%s/.gitkeep after materialization: size=%d, want empty sentinel", channel, interfaces.DefaultChannelName, info.Size())
+	}
+}
+
+func removeInputInboxGitkeep(t *testing.T, factoryDir, channel string) {
+	t.Helper()
+
+	path := filepath.Join(factoryDir, interfaces.InputsDir, channel, interfaces.DefaultChannelName, ".gitkeep")
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("Remove(%s): %v", path, err)
+	}
+}

--- a/pkg/config/runtimetests/runtime_config_named_factory_replace_gitkeep_test.go
+++ b/pkg/config/runtimetests/runtime_config_named_factory_replace_gitkeep_test.go
@@ -1,0 +1,51 @@
+package runtimetests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/portpowered/infinite-you/pkg/config"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+)
+
+func TestReplaceNamedFactory_PreservesBatchInboxGitkeepAcrossReplace(t *testing.T) {
+	rootDir := t.TempDir()
+
+	if _, err := PersistNamedFactory(rootDir, "alpha", namedFactoryPayload(t, "alpha")); err != nil {
+		t.Fatalf("PersistNamedFactory: %v", err)
+	}
+
+	factoryDir := filepath.Join(rootDir, "alpha")
+	batchGitkeep := filepath.Join(factoryDir, interfaces.InputsDir, "BATCH", interfaces.DefaultChannelName, ".gitkeep")
+	if err := os.MkdirAll(filepath.Dir(batchGitkeep), 0o755); err != nil {
+		t.Fatalf("MkdirAll(batch inbox): %v", err)
+	}
+	if err := os.WriteFile(batchGitkeep, nil, 0o644); err != nil {
+		t.Fatalf("WriteFile(batch .gitkeep): %v", err)
+	}
+
+	staleStarter := filepath.Join(factoryDir, interfaces.InputsDir, "task", interfaces.DefaultChannelName, "stale.md")
+	if err := os.WriteFile(staleStarter, []byte("stale starter\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(stale starter): %v", err)
+	}
+
+	replacePayload := namedFactoryPayloadWithBundledFiles(t, "alpha")
+	if _, err := ReplaceNamedFactory(rootDir, "alpha", replacePayload); err != nil {
+		t.Fatalf("ReplaceNamedFactory: %v", err)
+	}
+
+	if _, err := os.Stat(batchGitkeep); err != nil {
+		t.Fatalf("inputs/BATCH/default/.gitkeep after replace: %v", err)
+	}
+	if info, err := os.Stat(batchGitkeep); err == nil && info.IsDir() {
+		t.Fatalf("inputs/BATCH/default/.gitkeep after replace: got directory, want regular file")
+	}
+
+	if _, err := os.Stat(staleStarter); !os.IsNotExist(err) {
+		t.Fatalf("stale input file after replace: stat err=%v, want absent", err)
+	}
+
+	bundledStarter := filepath.Join(factoryDir, interfaces.InputsDir, "task", interfaces.DefaultChannelName, "starter.md")
+	assertRuntimeFactoryFileContent(t, bundledStarter, "starter work\n")
+}

--- a/prd.json
+++ b/prd.json
@@ -1,0 +1,79 @@
+{
+  "project": "Factory Import Preserves Inbox Gitkeep",
+  "branchName": "ralph/factory-import-preserve-inbox-gitkeep",
+  "description": "Ensure factory import and named-factory replace materialization preserve canonical input inbox .gitkeep sentinels—especially factory/inputs/BATCH/default/.gitkeep—without treating sentinels as portable bundled content or preserving stale non-sentinel input files.",
+  "context": {
+    "customerAsk": "Running factory import deletes the .gitkeep sentinel for the batch input directory. Preserve inbox .gitkeep files during import/activation, keep portable export unchanged, and add regression coverage when factory/inputs/BATCH/default/.gitkeep exists before import.",
+    "problem": "Named-factory replace builds a clean staging directory from the portable payload and atomically swaps it in. Portable bundled collection ignores .gitkeep and BATCH is not a work type, so ensureDefaultInputChannelDirectories never recreates the batch inbox sentinel. Maintainers lose tracked inbox directories after import.",
+    "solution": "After split-layout materialization on create and replace, ensure canonical input inbox directories and empty .gitkeep sentinels on disk (at minimum BATCH, plus default channels for declared work types). Keep .gitkeep out of export payloads. Add unit and functional regression tests proving import leaves factory/inputs/BATCH/default/.gitkeep present."
+  },
+  "acceptanceCriteria": [
+    "Given factory/inputs/BATCH/default/.gitkeep exists before import or named-factory replace, the file still exists on disk after activation completes.",
+    "Import/replace still updates factory definition, portable bundled files, and split runtime files per existing semantics; stale non-sentinel input files are not preserved unless portable rules already preserve them.",
+    "Portable export and roundtrip comparisons do not include .gitkeep in the public factory payload; collectSharedFactoryStarterWork continues to skip .gitkeep.",
+    "Regression tests at pkg/config and/or pkg/service plus functional bootstrap_portability cover the BATCH sentinel case.",
+    "No change to portable export schema, batch ingestion semantics, or global dotfile preservation.",
+    "Quality gate: Go typecheck, lint, and targeted tests for touched packages pass."
+  ],
+  "userStories": [
+    {
+      "id": "prd-factory-import-preserve-inbox-gitkeep-001",
+      "title": "Regression test for BATCH gitkeep across named-factory replace",
+      "description": "As a factory maintainer, I need a failing-then-passing test that proves named-factory replace does not delete factory/inputs/BATCH/default/.gitkeep when it existed before replace.",
+      "acceptanceCriteria": [
+        "A test in pkg/config or pkg/service seeds a named factory with inputs/BATCH/default/.gitkeep, runs ReplaceNamedFactory or the service save/replace path used by import with a valid portable payload, and asserts inputs/BATCH/default/.gitkeep still exists afterward.",
+        "The test asserts a stale non-sentinel file under an input default channel not in the payload is absent after replace when existing portable semantics would drop it.",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 1,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "prd-factory-import-preserve-inbox-gitkeep-002",
+      "title": "Ensure canonical inbox sentinels after materialization",
+      "description": "As a factory maintainer, I want import materialization to restore canonical inbox .gitkeep sentinels so batch and work-type inboxes remain present after replace.",
+      "acceptanceCriteria": [
+        "After writeFactorySplitLayout / named-factory persist commit, the factory directory contains inputs/BATCH/default/.gitkeep (create parent directories and an empty file when missing).",
+        "For each work type declared in the factory config, inputs/<workType>/default/.gitkeep exists after materialization when the default channel directory is ensured.",
+        "Sentinel restoration runs for both create and replace persist paths.",
+        "prd-factory-import-preserve-inbox-gitkeep-001 test passes without weakened assertions.",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 2,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "prd-factory-import-preserve-inbox-gitkeep-003",
+      "title": "Export/import functional smoke preserves BATCH sentinel",
+      "description": "As a maintainer running portability smoke tests, I want export/import activation to leave the batch inbox sentinel on disk in a realistic API harness.",
+      "acceptanceCriteria": [
+        "tests/functional/bootstrap_portability export/import harness seeds inputs/BATCH/default/.gitkeep before import and asserts the post-import factory directory on disk still has that file.",
+        "Existing export/import API contract assertions in the harness remain unchanged (no requirement for .gitkeep in exported factory JSON).",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 3,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "prd-factory-import-preserve-inbox-gitkeep-004",
+      "title": "Portable export still ignores gitkeep",
+      "description": "As an export/import user, I do not want .gitkeep treated as authored portable content in export payloads or roundtrip comparisons.",
+      "acceptanceCriteria": [
+        "collectSharedFactoryStarterWork and portable bundled read paths do not add .gitkeep files to bundled file lists when scanning input directories.",
+        "GetCurrentFactory / export readback tests that seed .gitkeep on disk continue to omit .gitkeep from inlined bundled files.",
+        "go test ./pkg/config/portabletests/... and portable bundled file unit tests pass without assertion weakening.",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 4,
+      "passes": false,
+      "notes": ""
+    }
+  ]
+}

--- a/prd.md
+++ b/prd.md
@@ -1,0 +1,138 @@
+# PRD: Factory Import Preserves Inbox Gitkeep
+
+## Introduction
+
+Factory import and named-factory replace materialize a fresh split-layout directory from the imported portable payload. That staging swap can remove tracked `.gitkeep` sentinels under canonical input inboxes—especially `factory/inputs/BATCH/default/.gitkeep`. Factory docs and the repository artifact contract treat those sentinels as required so inbox directories exist in clean checkouts and agents can submit batch requests. Import must activate imported factory content without stripping those sentinels or treating them as portable authored content.
+
+## Context
+
+### Customer ask
+
+Running factory import deletes the `.gitkeep` sentinel for the batch input directory. Preserve inbox `.gitkeep` files during import/activation, keep portable export behavior unchanged (`.gitkeep` is not bundled factory content), and add regression coverage when `factory/inputs/BATCH/default/.gitkeep` exists before import.
+
+### Problem
+
+- Named-factory **replace** (`ReplaceNamedFactory` / import activation) builds a clean staging directory and atomically swaps it in, which drops files not carried in the portable payload.
+- Portable bundled collection **ignores** `.gitkeep` by design (`isPortableBundledIgnoredFile`), so sentinels are never exported or re-materialized.
+- `ensureDefaultInputChannelDirectories` creates `inputs/<workType>/default/` for declared work types but does not write `.gitkeep` and does not cover the **`BATCH`** inbox (a canonical batch channel, not a work type).
+- Maintainers lose a tracked inbox directory after import; batch submission paths that expect `factory/inputs/BATCH/default/` break in git and on disk.
+
+### Solution
+
+After named-factory materialization (create and replace), **ensure canonical input inbox sentinels** on disk: create missing `inputs/<channel>/default/` directories and empty `.gitkeep` files for the repository canonical inbox set (at minimum `BATCH`, plus default channels for work types declared in the factory config). Do not add `.gitkeep` to portable export payloads. Add focused unit and functional tests proving import/replace leaves `factory/inputs/BATCH/default/.gitkeep` present while stale non-sentinel input files are still replaced per existing semantics.
+
+## Goals
+
+- Preserve or restore `.gitkeep` under canonical factory input inboxes after factory import, replace, and save materialization.
+- Keep portable export/import payload free of `.gitkeep` as authored bundled content.
+- Add regression coverage for import when `factory/inputs/BATCH/default/.gitkeep` exists locally.
+- Avoid preserving arbitrary stale input payloads when import intends to replace starter content.
+
+## Project-Level Acceptance Criteria
+
+- [ ] Given a factory root with `factory/inputs/BATCH/default/.gitkeep`, completing factory import or named-factory replace leaves that path on disk as a regular file.
+- [ ] Import/replace still updates factory definition, bundled portable files, and split runtime files according to existing import semantics.
+- [ ] Stale non-sentinel files under input default channels (for example old `starter.md` not in the imported payload) are not preserved unless today's portable semantics already preserve them.
+- [ ] Export and roundtrip comparisons do not require `.gitkeep` entries in the public factory payload; portable collect continues to skip `.gitkeep`.
+- [ ] Regression tests fail before the fix and pass after it at the appropriate layer (`pkg/config` and/or `pkg/service`, plus functional bootstrap portability where applicable).
+- [ ] No change to portable export payload schema, batch ingestion semantics, or global dotfile preservation rules.
+- [ ] Quality gate: Go typecheck, lint, and targeted tests for touched packages pass.
+
+## User Stories
+
+### prd-factory-import-preserve-inbox-gitkeep-001: Regression test for BATCH gitkeep across named-factory replace
+
+**Description:** As a factory maintainer, I need a failing-then-passing test that proves named-factory replace does not delete `factory/inputs/BATCH/default/.gitkeep` when it existed before replace.
+
+**Acceptance Criteria:**
+
+- [ ] A test in `pkg/config` or `pkg/service` seeds a named factory directory with `inputs/BATCH/default/.gitkeep`, runs `ReplaceNamedFactory` (or the service save/replace path used by import) with a valid portable factory payload, and asserts `inputs/BATCH/default/.gitkeep` still exists afterward.
+- [ ] The same test asserts a stale non-sentinel file under an input default channel (for example `inputs/task/default/stale.md` not present in the payload) is absent after replace when existing portable semantics would drop it.
+- [ ] Typecheck passes
+- [ ] Tests pass
+
+### prd-factory-import-preserve-inbox-gitkeep-002: Ensure canonical inbox sentinels after materialization
+
+**Description:** As a factory maintainer, I want import materialization to restore canonical inbox `.gitkeep` sentinels so batch and work-type inboxes remain present after replace.
+
+**Acceptance Criteria:**
+
+- [ ] After `writeFactorySplitLayout` / named-factory persist commit, the factory directory contains `inputs/BATCH/default/.gitkeep` (create parent directories and an empty file when missing).
+- [ ] For each work type declared in the factory config, `inputs/<workType>/default/.gitkeep` exists after materialization when the default channel directory is ensured (empty file if missing; do not overwrite non-empty sentinel content if already present).
+- [ ] Sentinel restoration runs for both create and replace persist paths, not only replace.
+- [ ] prd-factory-import-preserve-inbox-gitkeep-001 test passes without weakening assertions.
+- [ ] Typecheck passes
+- [ ] Tests pass
+
+### prd-factory-import-preserve-inbox-gitkeep-003: Export/import functional smoke preserves BATCH sentinel
+
+**Description:** As a maintainer running portability smoke tests, I want export/import activation to leave the batch inbox sentinel on disk in a realistic API harness.
+
+**Acceptance Criteria:**
+
+- [ ] `tests/functional/bootstrap_portability` export/import harness (or adjacent smoke) seeds `inputs/BATCH/default/.gitkeep` on the source factory directory before import and asserts the post-import factory directory on disk still has that file.
+- [ ] Existing export/import API contract assertions in the harness remain unchanged (no requirement for `.gitkeep` in exported factory JSON).
+- [ ] Typecheck passes
+- [ ] Tests pass
+
+### prd-factory-import-preserve-inbox-gitkeep-004: Portable export still ignores gitkeep
+
+**Description:** As an export/import user, I do not want `.gitkeep` treated as authored portable content in export payloads or roundtrip comparisons.
+
+**Acceptance Criteria:**
+
+- [ ] `collectSharedFactoryStarterWork` / portable bundled read paths do not add `.gitkeep` files to bundled file lists when scanning input directories.
+- [ ] `GetCurrentFactory` / export readback tests that seed `.gitkeep` on disk continue to omit `.gitkeep` from inlined bundled files (behavior aligned with `pkg/service/factory_test.go` portable readback patterns).
+- [ ] `go test ./pkg/config/portabletests/...` and portable bundled file unit tests pass without assertion weakening.
+- [ ] Typecheck passes
+- [ ] Tests pass
+
+## Functional Requirements
+
+- FR-1: Named-factory persist (create and replace) must leave canonical inbox sentinel files on disk after materialization.
+- FR-2: At minimum, `factory/inputs/BATCH/default/.gitkeep` must exist after import/replace materialization completes successfully.
+- FR-3: For each work type in the factory config, ensure `factory/inputs/<workType>/default/.gitkeep` exists when the default input channel directory is created.
+- FR-4: Portable bundled file collection and export must continue to ignore `.gitkeep` (no schema or payload change).
+- FR-5: Stale non-sentinel input files must not be preserved solely because of this change; only sentinel files and directories required for canonical inboxes are ensured.
+- FR-6: Add automated regression coverage at unit and functional layers for the BATCH sentinel case.
+
+## Non-Goals
+
+- No change to portable export payload schema or OpenAPI `Factory` bundled-file shape.
+- No change to batch ingestion, submit, or `FACTORY_REQUEST_BATCH` processing semantics.
+- No global preservation of arbitrary dotfiles (for example `.env`, `.DS_Store`).
+- No requirement to bundle `.gitkeep` content in export PNG/JSON payloads.
+- No UI-visible behavior change (dashboard import preview and confirm flows stay the same).
+
+## High-Level Technical Design
+
+**Root cause:** Import activation persists via staged `writeFactorySplitLayout` + atomic directory replace. Staging contains only portable payload files; `.gitkeep` is excluded from collection and `BATCH` is outside work-type channel creation.
+
+**Approach:** Extend finalize step of split-layout write (after `materializePortableBundledFiles` and input channel mkdir) with `ensureCanonicalInputInboxSentinels(targetDir, cfg)`:
+
+1. Always ensure `inputs/BATCH/default/` and an empty `.gitkeep` when absent.
+2. For each non-empty work type name in `cfg.WorkTypes`, ensure `inputs/<workType>/default/.gitkeep` when the default channel directory exists or is created.
+3. Use `O_CREATE|O_EXCL` or equivalent "create if missing" semantics so existing non-empty sentinels are not clobbered.
+
+**Ownership:** `pkg/config` (layout expansion / persist commit). Service import paths already call `ReplaceNamedFactory` / persist; no separate UI-only fix.
+
+**Verification surfaces:**
+
+- Unit: `pkg/config` layout/runtime persist tests; optional `pkg/service` factory save/replace test mirroring import.
+- Functional: `tests/functional/bootstrap_portability` export/import harness on-disk assertion.
+
+## Supporting Technical and UX Considerations
+
+- Canonical inbox paths are documented in `factory/docs/overview.md` and enumerated in `internal/testpath/artifact_contract.go` (BATCH, idea, plan, task, thoughts).
+- `.gitignore` already force-includes `!factory/inputs/*/default/.gitkeep`; restoring sentinels keeps git tracking aligned.
+- Dashboard import (`activateImportedFactoryForSession`) and CLI factory save converge on service persist → `pkg/config` replace; a single config-layer fix covers all import entrypoints.
+
+## Success Metrics
+
+- Importing or replacing a factory no longer removes `factory/inputs/BATCH/default/.gitkeep` in maintainer workflows.
+- Existing portable export/import and `pkg/config/portabletests` remain green.
+- No increase in stale input files surviving import beyond pre-change portable rules.
+
+## Open Questions
+
+**Resolved for implementation:** Recreate the **canonical repository inbox sentinel set** after materialization (BATCH plus work-type default channels declared in config), not only preserve pre-existing local sentinels. This fixes BATCH even when it was never part of the portable payload and matches the artifact contract. Pre-existing non-sentinel input files are unaffected.

--- a/progress.txt
+++ b/progress.txt
@@ -1,0 +1,13 @@
+## Codebase Patterns
+- Named-factory create/replace materialize split layout via `writeFactorySplitLayout` → `finalizeFactorySplitLayoutWrite`; when `OverwriteExistingSplitFiles` is true, input channel dirs and inbox `.gitkeep` sentinels are ensured on disk.
+- Portable bundled collection skips `.gitkeep` via `isPortableBundledIgnoredFile`; BATCH is not a work type, so batch inbox sentinels must be restored explicitly after materialization.
+- Regression tests for named-factory persist/replace belong in `pkg/config/runtimetests` using `namedFactoryPayload` / `namedFactoryPayloadWithBundledFiles` helpers.
+
+## 2026-06-02T19:06:18Z - prd-factory-import-preserve-inbox-gitkeep-001
+- What was implemented: Added `TestReplaceNamedFactory_PreservesBatchInboxGitkeepAcrossReplace` proving `inputs/BATCH/default/.gitkeep` survives named-factory replace and stale `inputs/task/default/stale.md` is removed when absent from the portable payload. Implemented `ensureCanonicalInputInboxSentinels` in `finalizeFactorySplitLayoutWrite` so the regression test and CI stay green (sentinel restoration is story 002 scope but required for passing tests).
+- Files changed: `pkg/config/runtimetests/runtime_config_named_factory_replace_gitkeep_test.go`, `pkg/config/layout_expansion.go`
+- **Learnings for future iterations:**
+  - Patterns discovered: Replace swaps the entire factory directory from staging; only portable payload + post-materialization hooks affect on-disk inputs.
+  - Gotchas encountered: `ensureDefaultInputChannelDirectories` creates work-type default dirs only—not BATCH and not `.gitkeep` files.
+  - Useful context: Use `namedFactoryPayloadWithBundledFiles` when replace should materialize `inputs/task/default/starter.md` from the payload while asserting stale files are dropped.
+---

--- a/tests/functional/bootstrap_portability/api_export_import_e2e_smoke_test.go
+++ b/tests/functional/bootstrap_portability/api_export_import_e2e_smoke_test.go
@@ -53,6 +53,16 @@ func TestExportImportSmoke_ExportedFactoryCanBeReimportedThroughCustomerPath(t *
 	}
 }
 
+func TestExportImportSmoke_PreservesBatchInboxGitkeepAfterImport(t *testing.T) {
+	fixture := newExportImportFixture(t)
+	harness := newExportImportSmokeHarness(fixture, withExportImportBeforeExport(seedBatchInboxGitkeep))
+
+	result := harness.Run(t)
+
+	result.AssertAPIContractSuccess(t, fixture)
+	assertBatchInboxGitkeepOnDisk(t, result.ImportedDir)
+}
+
 func TestExportImportSmoke_ImportedFactoryPersistsThinSplitRuntimeLayout(t *testing.T) {
 	fixture := newExportImportFixture(t)
 	harness := newExportImportSmokeHarness(fixture)
@@ -411,4 +421,29 @@ func stringPtrValue(value *string) string {
 		return ""
 	}
 	return *value
+}
+
+func seedBatchInboxGitkeep(t *testing.T, factoryDir string) {
+	t.Helper()
+
+	gitkeepPath := filepath.Join(factoryDir, interfaces.InputsDir, "BATCH", interfaces.DefaultChannelName, ".gitkeep")
+	if err := os.MkdirAll(filepath.Dir(gitkeepPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(batch inbox): %v", err)
+	}
+	if err := os.WriteFile(gitkeepPath, nil, 0o644); err != nil {
+		t.Fatalf("WriteFile(batch .gitkeep): %v", err)
+	}
+}
+
+func assertBatchInboxGitkeepOnDisk(t *testing.T, factoryDir string) {
+	t.Helper()
+
+	gitkeepPath := filepath.Join(factoryDir, interfaces.InputsDir, "BATCH", interfaces.DefaultChannelName, ".gitkeep")
+	info, err := os.Stat(gitkeepPath)
+	if err != nil {
+		t.Fatalf("inputs/BATCH/default/.gitkeep after import: %v", err)
+	}
+	if info.IsDir() {
+		t.Fatalf("inputs/BATCH/default/.gitkeep after import: got directory, want regular file")
+	}
 }

--- a/tests/functional/bootstrap_portability/export_import_harness_test.go
+++ b/tests/functional/bootstrap_portability/export_import_harness_test.go
@@ -25,6 +25,7 @@ type exportImportSmokeHarness struct {
 type exportImportSmokeHarnessOptions struct {
 	sourceFactoryName string
 	importFactoryName string
+	beforeExport      func(*testing.T, string)
 	afterImport       func(*testing.T, exportImportSmokeHarnessResult)
 }
 
@@ -64,6 +65,9 @@ func (h exportImportSmokeHarness) Run(t *testing.T) exportImportSmokeHarnessResu
 
 	rootDir := t.TempDir()
 	sourceFactoryDir := h.fixture.persistAs(t, rootDir, h.options.sourceFactoryName)
+	if h.options.beforeExport != nil {
+		h.options.beforeExport(t, sourceFactoryDir)
+	}
 	if err := config.WriteCurrentFactoryPointer(rootDir, h.options.sourceFactoryName); err != nil {
 		t.Fatalf("WriteCurrentFactoryPointer(%s): %v", h.options.sourceFactoryName, err)
 	}
@@ -203,6 +207,12 @@ func createNamedFactory(t *testing.T, serverURL string, namedFactory factoryapi.
 
 func ptrFactorySaveMode(mode factoryapi.FactorySaveMode) *factoryapi.FactorySaveMode {
 	return &mode
+}
+
+func withExportImportBeforeExport(fn func(*testing.T, string)) exportImportSmokeHarnessOption {
+	return func(options *exportImportSmokeHarnessOptions) {
+		options.beforeExport = fn
+	}
 }
 
 func getCurrentFactory(t *testing.T, serverURL string) factoryapi.Factory {


### PR DESCRIPTION
{
  "project": "Factory Import Preserves Inbox Gitkeep",
  "branchName": "ralph/factory-import-preserve-inbox-gitkeep",
  "description": "Ensure factory import and named-factory replace materialization preserve canonical input inbox .gitkeep sentinels—especially factory/inputs/BATCH/default/.gitkeep—without treating sentinels as portable bundled content or preserving stale non-sentinel input files.",
  "context": {
    "customerAsk": "Running factory import deletes the .gitkeep sentinel for the batch input directory. Preserve inbox .gitkeep files during import/activation, keep portable export unchanged, and add regression coverage when factory/inputs/BATCH/default/.gitkeep exists before import.",
    "problem": "Named-factory replace builds a clean staging directory from the portable payload and atomically swaps it in. Portable bundled collection ignores .gitkeep and BATCH is not a work type, so ensureDefaultInputChannelDirectories never recreates the batch inbox sentinel. Maintainers lose tracked inbox directories after import.",
    "solution": "After split-layout materialization on create and replace, ensure canonical input inbox directories and empty .gitkeep sentinels on disk (at minimum BATCH, plus default channels for declared work types). Keep .gitkeep out of export payloads. Add unit and functional regression tests proving import leaves factory/inputs/BATCH/default/.gitkeep present."
  },
  "acceptanceCriteria": [
    "Given factory/inputs/BATCH/default/.gitkeep exists before import or named-factory replace, the file still exists on disk after activation completes.",
    "Import/replace still updates factory definition, portable bundled files, and split runtime files per existing semantics; stale non-sentinel input files are not preserved unless portable rules already preserve them.",
    "Portable export and roundtrip comparisons do not include .gitkeep in the public factory payload; collectSharedFactoryStarterWork continues to skip .gitkeep.",
    "Regression tests at pkg/config and/or pkg/service plus functional bootstrap_portability cover the BATCH sentinel case.",
    "No change to portable export schema, batch ingestion semantics, or global dotfile preservation.",
    "Quality gate: Go typecheck, lint, and targeted tests for touched packages pass."
  ],
  "userStories": [
    {
      "id": "prd-factory-import-preserve-inbox-gitkeep-001",
      "title": "Regression test for BATCH gitkeep across named-factory replace",
      "description": "As a factory maintainer, I need a failing-then-passing test that proves named-factory replace does not delete factory/inputs/BATCH/default/.gitkeep when it existed before replace.",
      "acceptanceCriteria": [
        "A test in pkg/config or pkg/service seeds a named factory with inputs/BATCH/default/.gitkeep, runs ReplaceNamedFactory or the service save/replace path used by import with a valid portable payload, and asserts inputs/BATCH/default/.gitkeep still exists afterward.",
        "The test asserts a stale non-sentinel file under an input default channel not in the payload is absent after replace when existing portable semantics would drop it.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-factory-import-preserve-inbox-gitkeep-002",
      "title": "Ensure canonical inbox sentinels after materialization",
      "description": "As a factory maintainer, I want import materialization to restore canonical inbox .gitkeep sentinels so batch and work-type inboxes remain present after replace.",
      "acceptanceCriteria": [
        "After writeFactorySplitLayout / named-factory persist commit, the factory directory contains inputs/BATCH/default/.gitkeep (create parent directories and an empty file when missing).",
        "For each work type declared in the factory config, inputs/<workType>/default/.gitkeep exists after materialization when the default channel directory is ensured.",
        "Sentinel restoration runs for both create and replace persist paths.",
        "prd-factory-import-preserve-inbox-gitkeep-001 test passes without weakened assertions.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-factory-import-preserve-inbox-gitkeep-003",
      "title": "Export/import functional smoke preserves BATCH sentinel",
      "description": "As a maintainer running portability smoke tests, I want export/import activation to leave the batch inbox sentinel on disk in a realistic API harness.",
      "acceptanceCriteria": [
        "tests/functional/bootstrap_portability export/import harness seeds inputs/BATCH/default/.gitkeep before import and asserts the post-import factory directory on disk still has that file.",
        "Existing export/import API contract assertions in the harness remain unchanged (no requirement for .gitkeep in exported factory JSON).",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-factory-import-preserve-inbox-gitkeep-004",
      "title": "Portable export still ignores gitkeep",
      "description": "As an export/import user, I do not want .gitkeep treated as authored portable content in export payloads or roundtrip comparisons.",
      "acceptanceCriteria": [
        "collectSharedFactoryStarterWork and portable bundled read paths do not add .gitkeep files to bundled file lists when scanning input directories.",
        "GetCurrentFactory / export readback tests that seed .gitkeep on disk continue to omit .gitkeep from inlined bundled files.",
        "go test ./pkg/config/portabletests/... and portable bundled file unit tests pass without assertion weakening.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)