### PR TITLE
inline-trend-cards-classes

### DIFF
--- a/ui/scripts/inline-component-class-usage-allowlist.mjs
+++ b/ui/scripts/inline-component-class-usage-allowlist.mjs
@@ -35,13 +35,5 @@ export const allowlistedInlineComponentClassUsage = [
   "src/features/trace-drilldown/components/trace-grid-card.tsx#TRACE_WORK_ITEM_BUTTON_CLASS",
   "src/features/trace-drilldown/components/trace-relation-flow.tsx#GRAPH_SHELL_CLASS",
   "src/features/trace-drilldown/components/trace-workstation-path.tsx#GRAPH_SHELL_CLASS",
-  "src/features/work-outcome/components/trend-cards.tsx#TREND_TOOLBAR_CLASS",
-  "src/features/work-outcome/components/trend-cards.tsx#TREND_RANGE_LABEL_CLASS",
-  "src/features/work-outcome/components/trend-cards.tsx#TREND_RANGE_TEXT_CLASS",
-  "src/features/work-outcome/components/trend-cards.tsx#TREND_RANGE_SELECT_CLASS",
-  "src/features/work-outcome/components/trend-cards.tsx#TREND_CAUSE_LIST_CLASS",
-  "src/features/work-outcome/components/trend-cards.tsx#TREND_CAUSE_ITEM_CLASS",
-  "src/features/work-outcome/components/trend-cards.tsx#TREND_CAUSE_LABEL_CLASS",
-  "src/features/work-outcome/components/trend-cards.tsx#TIMING_RANGE_SUMMARY_CLASS",
   "src/features/work-outcome/components/work-chart.tsx#WORK_CHART_TOOLBAR_CLASS",
 ];

--- a/ui/src/features/work-outcome/components/trend-cards.tsx
+++ b/ui/src/features/work-outcome/components/trend-cards.tsx
@@ -53,15 +53,6 @@ interface TimingTrendCardProps {
   widgetId?: string;
 }
 
-const TREND_TOOLBAR_CLASS =
-  "mb-4 flex flex-col items-start justify-between gap-3 md:flex-row";
-const TREND_RANGE_LABEL_CLASS =
-  "grid w-full gap-1 md:w-auto md:shrink-0 md:basis-36";
-const TREND_RANGE_TEXT_CLASS = DASHBOARD_SUPPORTING_LABEL_CLASS;
-const TREND_RANGE_SELECT_CLASS = cn(
-  "rounded-lg border border-af-accent-border bg-af-surface-raised px-2 py-2 text-af-text",
-  DASHBOARD_BODY_TEXT_CLASS,
-);
 const TREND_SUMMARY_CLASS = cn(
   "mb-4 grid grid-cols-1 gap-3 [&_dd]:m-0 [&_div]:rounded-lg [&_div]:border [&_div]:border-af-border [&_div]:bg-af-surface-subtle [&_div]:p-3 [&_dt]:mb-1 md:grid-cols-3",
   DASHBOARD_SUPPORTING_LABELS_CLASS,
@@ -109,13 +100,18 @@ export function FailureTrendCard({
       title={messages.failureTitle}
       widgetId={widgetId}
     >
-      <div className={TREND_TOOLBAR_CLASS}>
+      <div className="mb-4 flex flex-col items-start justify-between gap-3 md:flex-row">
         <p className={WIDGET_SUBTITLE_CLASS}>{messages.failureSummary}</p>
-        <label className={TREND_RANGE_LABEL_CLASS}>
-          <span className={TREND_RANGE_TEXT_CLASS}>{messages.rangeLabel}</span>
+        <label className="grid w-full gap-1 md:w-auto md:shrink-0 md:basis-36">
+          <span className={DASHBOARD_SUPPORTING_LABEL_CLASS}>
+            {messages.rangeLabel}
+          </span>
           <select
             aria-label={messages.rangeLabel}
-            className={TREND_RANGE_SELECT_CLASS}
+            className={cn(
+              "rounded-lg border border-af-accent-border bg-af-surface-raised px-2 py-2 text-af-text",
+              DASHBOARD_BODY_TEXT_CLASS,
+            )}
             value={rangeID}
             onChange={(event) => changeRange(event.target.value)}
           >

--- a/ui/src/features/work-outcome/components/trend-cards.tsx
+++ b/ui/src/features/work-outcome/components/trend-cards.tsx
@@ -61,10 +61,6 @@ const TREND_CHART_CLASS = cn(
   DASHBOARD_CHART_SURFACE_CLASS,
   "min-h-44 border border-af-border",
 );
-const TIMING_RANGE_SUMMARY_CLASS = cn(
-  TREND_SUMMARY_CLASS,
-  "mt-3 md:grid-cols-2",
-);
 const TREND_SUMMARY_TERM_CLASS = DASHBOARD_SUPPORTING_LABEL_CLASS;
 const TREND_SUMMARY_VALUE_CLASS = WIDGET_SUBTITLE_CLASS;
 const FAILURE_TREND_CHART_STYLE =
@@ -363,7 +359,7 @@ export function TimingTrendCard({
             ))}
           </svg>
           <dl
-            className={TIMING_RANGE_SUMMARY_CLASS}
+            className={cn(TREND_SUMMARY_CLASS, "mt-3 md:grid-cols-2")}
             aria-label={messages.timingRangeLabel}
           >
             <div>

--- a/ui/src/features/work-outcome/components/trend-cards.tsx
+++ b/ui/src/features/work-outcome/components/trend-cards.tsx
@@ -61,13 +61,6 @@ const TREND_CHART_CLASS = cn(
   DASHBOARD_CHART_SURFACE_CLASS,
   "min-h-44 border border-af-border",
 );
-const TREND_CAUSE_LIST_CLASS = "mt-4 grid list-none gap-2 p-0";
-const TREND_CAUSE_ITEM_CLASS =
-  "flex items-center justify-between gap-3 rounded-lg border border-af-border bg-af-surface-subtle px-3 py-2.5";
-const TREND_CAUSE_LABEL_CLASS = cn(
-  "min-w-0 text-af-text-muted [overflow-wrap:anywhere]",
-  DASHBOARD_BODY_TEXT_CLASS,
-);
 const TIMING_RANGE_SUMMARY_CLASS = cn(
   TREND_SUMMARY_CLASS,
   "mt-3 md:grid-cols-2",
@@ -181,12 +174,22 @@ export function FailureTrendCard({
 
       {model.groups.length > 0 ? (
         <ul
-          className={TREND_CAUSE_LIST_CLASS}
+          className="mt-4 grid list-none gap-2 p-0"
           aria-label={messages.causeGroupsRegionLabel}
         >
           {model.groups.map((group) => (
-            <li className={TREND_CAUSE_ITEM_CLASS} key={group.label}>
-              <span className={TREND_CAUSE_LABEL_CLASS}>{group.label}</span>
+            <li
+              className="flex items-center justify-between gap-3 rounded-lg border border-af-border bg-af-surface-subtle px-3 py-2.5"
+              key={group.label}
+            >
+              <span
+                className={cn(
+                  "min-w-0 text-af-text-muted [overflow-wrap:anywhere]",
+                  DASHBOARD_BODY_TEXT_CLASS,
+                )}
+              >
+                {group.label}
+              </span>
               <strong className="shrink-0 text-af-danger-text">
                 {group.count}
               </strong>


### PR DESCRIPTION
{
  "project": "Inline Trend Cards Classes",
  "branchName": "inline-trend-cards-classes",
  "description": "Move eight allowlisted Tailwind class constants in work-outcome trend-cards.tsx into JSX className props or inline cn(...) expressions, remove the constants and matching allowlist keys, and verify trend card UI behavior and inline-class policy checks remain unchanged.",
  "context": {
    "customerAsk": "Ask 2.5: move allowlisted single-file class constants in ui/src/features/work-outcome/components/trend-cards.tsx into JSX className expressions and shrink the repo-owned allowlist accordingly.",
    "problem": "Eight single-use module constants in trend-cards.tsx are allowlisted exceptions to check:inline-component-class-usage, hiding styling from JSX and perpetuating a phased-out UI pattern.",
    "solution": "Inline the eight allowlisted class strings or equivalent cn(...) compositions onto JSX className use sites in trend-cards.tsx, delete those constants, remove only the eight matching allowlist keys, and verify with check:inline-component-class-usage, lint, and existing work-outcome/trend card tests."
  },
  "acceptanceCriteria": [
    "All eight allowlisted constants are removed and their exact Tailwind strings or equivalent cn(...) compositions appear inline on the corresponding JSX className props.",
    "Trend card behavior is unchanged: range selection, chart rendering, toolbar layout, cause group lists, and timing range summary presentation match current UI.",
    "Only the eight specified allowlist keys are removed; unrelated entries including dashboard-header.tsx, submit-work-card.tsx, and terminal-work-card.tsx remain untouched.",
    "cd ui && npm run check:inline-component-class-usage passes with no violations or stale keys for trend-cards.tsx.",
    "UI typecheck, lint including check:inline-component-class-usage, and relevant work-outcome/trend card tests pass.",
    "Typecheck, lint, and tests pass."
  ],
  "userStories": [
    {
      "id": "inline-trend-cards-classes-001",
      "title": "Inline toolbar and range control classes",
      "description": "As a maintainer, I want the four allowlisted toolbar and range-control class strings on JSX className props so styling is visible at the use site without changing trend card range selection behavior.",
      "acceptanceCriteria": [
        "TREND_TOOLBAR_CLASS, TREND_RANGE_LABEL_CLASS, TREND_RANGE_TEXT_CLASS, and TREND_RANGE_SELECT_CLASS are deleted from trend-cards.tsx.",
        "Each deleted constant's styling appears on the corresponding JSX className prop: raw strings copied verbatim where applicable; TREND_RANGE_TEXT_CLASS inlined via the existing DASHBOARD_SUPPORTING_LABEL_CLASS import; TREND_RANGE_SELECT_CLASS inlined as an equivalent cn(...) composition preserving shared typography tokens.",
        "Non-allowlisted constants in the same file such as TREND_SUMMARY_CLASS and TREND_CHART_CLASS remain unless already unused dead code.",
        "Trend card toolbar, range label, range text, and range select render and behave the same as before for layout, typography, focus, and range selection.",
        "Typecheck passes",
        "Tests pass for existing work-outcome and trend card coverage when present",
        "Verify in browser: trend card toolbar and range controls match pre-change appearance and range selection behavior."
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "inline-trend-cards-classes-002",
      "title": "Inline cause list classes",
      "description": "As a maintainer, I want the three allowlisted cause-list class strings on JSX className props so cause group styling is readable at the use site without changing cause list behavior.",
      "acceptanceCriteria": [
        "TREND_CAUSE_LIST_CLASS, TREND_CAUSE_ITEM_CLASS, and TREND_CAUSE_LABEL_CLASS are deleted from trend-cards.tsx.",
        "Each deleted constant's styling appears on the corresponding JSX className prop: raw strings copied verbatim where applicable; TREND_CAUSE_LABEL_CLASS inlined as an equivalent cn(...) composition preserving shared typography tokens.",
        "Cause group lists render with the same layout, spacing, typography, and item structure as before.",
        "Typecheck passes",
        "Tests pass for existing work-outcome and trend card coverage when present",
        "Verify in browser: trend card cause group lists match pre-change appearance."
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "inline-trend-cards-classes-003",
      "title": "Inline timing range summary class",
      "description": "As a maintainer, I want the timing range summary styling inline on JSX so the timing card dl follows the class-in-JSX standard without changing summary presentation.",
      "acceptanceCriteria": [
        "TIMING_RANGE_SUMMARY_CLASS is deleted from trend-cards.tsx.",
        "Its styling appears on the timing card dl className prop as either a single equivalent composed Tailwind string or an inline cn(...) that matches the prior composition with TREND_SUMMARY_CLASS, without introducing a new file-level *_CLASS constant.",
        "Timing range summary presentation for layout, typography, and spacing matches pre-change UI.",
        "Typecheck passes",
        "Tests pass for existing work-outcome and trend card coverage when present",
        "Verify in browser: timing range summary on trend cards matches pre-change styling."
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "inline-trend-cards-classes-004",
      "title": "Remove allowlist keys and pass inline-class check",
      "description": "As CI, I need the eight obsolete allowlist exceptions removed so check:inline-component-class-usage enforces inline classes for trend card sites going forward.",
      "acceptanceCriteria": [
        "The eight specified allowlist keys are removed from ui/scripts/inline-component-class-usage-allowlist.mjs and no other allowlist entries are added, removed, or modified.",
        "cd ui && npm run check:inline-component-class-usage exits 0 with no violations for trend-cards.tsx.",
        "No stale allowlist keys remain referencing the deleted constants.",
        "cd ui && npm run lint passes.",
        "Typecheck passes",
        "Tests pass for existing work-outcome and trend card behavioral tests; add or extend a focused render smoke only if needed to lock toolbar/range/cause-list structure."
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)