### PR TITLE
inline-agent-bento-classes

### DIFF
--- a/ui/scripts/inline-component-class-usage-allowlist.mjs
+++ b/ui/scripts/inline-component-class-usage-allowlist.mjs
@@ -1,9 +1,6 @@
 export const allowlistedInlineComponentClassUsage = [
   "src/components/ui/dashboard-action-button.tsx#DASHBOARD_ACTION_BUTTON_EXECUTING_OVERLAY_CLASS",
   "src/components/ui/dashboard-action-button.tsx#DASHBOARD_ACTION_BUTTON_SPINNER_CLASS",
-  "src/features/bento/components/agent-bento.tsx#BENTO_GRID_CLASS",
-  "src/features/bento/components/agent-bento.tsx#BENTO_ITEM_CLASS",
-  "src/features/bento/components/agent-bento.tsx#BENTO_CARD_TITLE_CLASS",
   "src/features/header/components/dashboard-header.tsx#DASHBOARD_TOOLBAR_CLASS",
   "src/features/header/components/dashboard-header.tsx#DASHBOARD_HEADER_ROWS_CLASS",
   "src/features/header/components/dashboard-header.tsx#DASHBOARD_PRIMARY_ROW_CLASS",

--- a/ui/src/features/bento/components/agent-bento.tsx
+++ b/ui/src/features/bento/components/agent-bento.tsx
@@ -82,10 +82,6 @@ const BENTO_CARD_HEADER_CLASS =
   "flex min-h-13 cursor-grab items-center justify-between gap-3 border-af-border px-3.5 py-3 active:cursor-grabbing";
 const BENTO_CARD_HEADER_COMPACT_CLASS =
   "min-h-11 flex-wrap items-start gap-2 px-3 py-2.5";
-const BENTO_CARD_TITLE_CLASS = cn(
-  "m-0 min-w-0 flex-1 [overflow-wrap:anywhere]",
-  DASHBOARD_SECTION_HEADING_CLASS,
-);
 const BENTO_CARD_HEADER_TOOLS_CLASS =
   "flex min-w-0 shrink-0 items-center gap-2";
 const BENTO_CARD_HEADER_TOOLS_COMPACT_CLASS =
@@ -369,7 +365,14 @@ export function AgentBentoCardHeader({
       data-bento-drag-handle="true"
     >
       <div className="min-w-0 flex-1">
-        <h3 className={BENTO_CARD_TITLE_CLASS}>{title}</h3>
+        <h3
+          className={cn(
+            "m-0 min-w-0 flex-1 [overflow-wrap:anywhere]",
+            DASHBOARD_SECTION_HEADING_CLASS,
+          )}
+        >
+          {title}
+        </h3>
       </div>
       {headerAction ? (
         <div

--- a/ui/src/features/bento/components/agent-bento.tsx
+++ b/ui/src/features/bento/components/agent-bento.tsx
@@ -77,8 +77,6 @@ const BENTO_DRAG_HANDLE_SELECTOR = "[data-bento-drag-handle='true']";
 const BENTO_DRAG_CANCEL_SELECTOR =
   "button,a,input,select,textarea,.react-resizable-handle";
 const BENTO_LAYOUT_CLASS = "min-w-0 w-full overflow-x-hidden";
-const BENTO_GRID_CLASS = "min-h-px";
-const BENTO_ITEM_CLASS = "min-w-0";
 const BENTO_CARD_CLASS = "flex h-full min-w-0 flex-col overflow-hidden";
 const BENTO_CARD_HEADER_CLASS =
   "flex min-h-13 cursor-grab items-center justify-between gap-3 border-af-border px-3.5 py-3 active:cursor-grabbing";
@@ -262,7 +260,7 @@ export function AgentBentoLayout({
     >
       <GridLayout
         autoSize
-        className={BENTO_GRID_CLASS}
+        className="min-h-px"
         dragConfig={{
           cancel: BENTO_DRAG_CANCEL_SELECTOR,
           enabled: allowsInteractiveGrid,
@@ -284,7 +282,7 @@ export function AgentBentoLayout({
       >
         {cards.map((card) => (
           <div
-            className={BENTO_ITEM_CLASS}
+            className="min-w-0"
             data-bento-card-id={card.widgetType}
             data-bento-instance-id={card.id}
             data-layout-signature={layoutSignature(


### PR DESCRIPTION
{
  "project": "Inline Agent Bento Classes",
  "branchName": "inline-agent-bento-classes",
  "description": "Move three allowlisted Tailwind class constants in agent-bento.tsx into JSX className props or inline cn(...) expressions, remove the constants and matching allowlist keys, and verify agent bento grid layout, card chrome, and inline-class policy checks remain unchanged.",
  "context": {
    "customerAsk": "Ask 2.5: move allowlisted single-file class constants in ui/src/features/bento/components/agent-bento.tsx into JSX className expressions and shrink the repo-owned allowlist accordingly.",
    "problem": "Three single-use module constants in agent-bento.tsx are allowlisted exceptions to check:inline-component-class-usage, hiding styling from JSX and perpetuating a phased-out UI pattern.",
    "solution": "Inline the three allowlisted class strings or equivalent cn(...) compositions onto JSX className use sites in agent-bento.tsx, delete those constants, remove only the three matching allowlist keys, and verify with check:inline-component-class-usage, lint, and existing bento layout/card tests."
  },
  "acceptanceCriteria": [
    "All three allowlisted constants are removed and their exact Tailwind strings or equivalent cn(...) compositions appear inline on the corresponding JSX className props.",
    "Agent bento behavior is unchanged: grid layout, card chrome, drag/resize handles, compact mode, scroll behavior, hidden cards, and locale messages match current UI.",
    "Only the three specified allowlist keys are removed; unrelated entries including dashboard-header.tsx, trace-drilldown files, and dashboard-import-preview-dialog.tsx remain untouched.",
    "cd ui && npm run check:inline-component-class-usage passes with no violations or stale keys for agent-bento.tsx.",
    "UI typecheck, lint including check:inline-component-class-usage, and relevant bento layout/card tests pass.",
    "Typecheck, lint, and tests pass."
  ],
  "userStories": [
    {
      "id": "inline-agent-bento-classes-001",
      "title": "Inline bento grid and item layout classes",
      "description": "As a maintainer, I want the allowlisted grid and item wrapper class strings on JSX className so bento layout styling is visible at the use site without changing react-grid-layout behavior, drag/resize, or responsive breakpoints.",
      "acceptanceCriteria": [
        "BENTO_GRID_CLASS and BENTO_ITEM_CLASS are deleted from agent-bento.tsx.",
        "Each deleted constant's styling appears on the corresponding JSX className prop: raw string copied verbatim where applicable; equivalent cn(...) at the JSX site where the constant was composed.",
        "Non-allowlisted class constants in the same file remain unless already unused dead code.",
        "Bento grid and item wrappers render with the same layout, spacing, and responsive breakpoint behavior as before; react-grid-layout props are unchanged.",
        "Drag, resize, compact mode, scroll behavior, and hidden-card behavior are unchanged.",
        "Typecheck passes",
        "Tests pass for existing bento layout/card coverage when present",
        "Verify in browser: agent bento grid layout, card sizing, and drag/resize handles match pre-change appearance."
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "inline-agent-bento-classes-002",
      "title": "Inline bento card title class",
      "description": "As a maintainer, I want the allowlisted card title class string on the h3 JSX className so title styling is readable at the use site without changing typography composition or card chrome.",
      "acceptanceCriteria": [
        "BENTO_CARD_TITLE_CLASS is deleted from agent-bento.tsx.",
        "Its styling appears on the corresponding h3 className prop as a verbatim string or equivalent cn(...) composition.",
        "cn(...) composition with DASHBOARD_SECTION_HEADING_CLASS is preserved where that token was used with the deleted constant.",
        "Card title text renders with the same typography, spacing, and color as before; compact-mode card chrome is unchanged.",
        "Locale messages and card content structure are unchanged unless dropping a constant alias has no behavioral effect.",
        "Typecheck passes",
        "Tests pass for existing bento layout/card coverage when present",
        "Verify in browser: agent bento card titles match pre-change styling in default and compact modes."
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "inline-agent-bento-classes-003",
      "title": "Remove allowlist keys and pass inline-class check",
      "description": "As CI, I need the three obsolete allowlist exceptions removed so check:inline-component-class-usage enforces inline classes for agent bento going forward.",
      "acceptanceCriteria": [
        "The three specified allowlist keys are removed from ui/scripts/inline-component-class-usage-allowlist.mjs and no other allowlist entries are added, removed, or modified.",
        "cd ui && npm run check:inline-component-class-usage exits 0 with no violations for agent-bento.tsx.",
        "No stale allowlist keys remain referencing the deleted constants.",
        "cd ui && npm run lint passes.",
        "Typecheck passes",
        "Tests pass for bento behavioral assertions; extend only if needed to lock grid item sizing, card title rendering, or compact chrome without layout-inventory meta-tests."
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)