### PR TITLE
inline-dashboard-action-button-classes

### DIFF
--- a/ui/scripts/inline-component-class-usage-allowlist.mjs
+++ b/ui/scripts/inline-component-class-usage-allowlist.mjs
@@ -1,6 +1,4 @@
 export const allowlistedInlineComponentClassUsage = [
-  "src/components/ui/dashboard-action-button.tsx#DASHBOARD_ACTION_BUTTON_EXECUTING_OVERLAY_CLASS",
-  "src/components/ui/dashboard-action-button.tsx#DASHBOARD_ACTION_BUTTON_SPINNER_CLASS",
   "src/features/header/components/dashboard-header.tsx#DASHBOARD_TOOLBAR_CLASS",
   "src/features/header/components/dashboard-header.tsx#DASHBOARD_HEADER_ROWS_CLASS",
   "src/features/header/components/dashboard-header.tsx#DASHBOARD_PRIMARY_ROW_CLASS",

--- a/ui/src/components/ui/dashboard-action-button.tsx
+++ b/ui/src/components/ui/dashboard-action-button.tsx
@@ -12,8 +12,6 @@ const DASHBOARD_ACTION_BUTTON_SIZE_CLASS = {
 const DASHBOARD_ACTION_BUTTON_CONTENT_CLASS =
   "inline-flex items-center justify-center gap-2";
 const DASHBOARD_ACTION_BUTTON_EXECUTING_CONTENT_CLASS = "opacity-0";
-const DASHBOARD_ACTION_BUTTON_EXECUTING_OVERLAY_CLASS =
-  "pointer-events-none absolute inset-0 inline-flex items-center justify-center";
 const DASHBOARD_ACTION_BUTTON_SPINNER_CLASS = "size-4 animate-spin";
 
 export interface DashboardActionButtonProps
@@ -51,7 +49,7 @@ export const DashboardActionButton = forwardRef<
       {executing ? (
         <span
           aria-hidden="true"
-          className={DASHBOARD_ACTION_BUTTON_EXECUTING_OVERLAY_CLASS}
+          className="pointer-events-none absolute inset-0 inline-flex items-center justify-center"
         >
           <DashboardActionButtonSpinner />
         </span>

--- a/ui/src/components/ui/dashboard-action-button.tsx
+++ b/ui/src/components/ui/dashboard-action-button.tsx
@@ -12,7 +12,6 @@ const DASHBOARD_ACTION_BUTTON_SIZE_CLASS = {
 const DASHBOARD_ACTION_BUTTON_CONTENT_CLASS =
   "inline-flex items-center justify-center gap-2";
 const DASHBOARD_ACTION_BUTTON_EXECUTING_CONTENT_CLASS = "opacity-0";
-const DASHBOARD_ACTION_BUTTON_SPINNER_CLASS = "size-4 animate-spin";
 
 export interface DashboardActionButtonProps
   extends Omit<ButtonProps, "children" | "size"> {
@@ -95,7 +94,7 @@ function DashboardActionButtonSpinner() {
   return (
     <svg
       aria-hidden="true"
-      className={DASHBOARD_ACTION_BUTTON_SPINNER_CLASS}
+      className="size-4 animate-spin"
       fill="none"
       focusable="false"
       viewBox="0 0 16 16"

--- a/ui/src/components/ui/dashboard-action-controls.test.tsx
+++ b/ui/src/components/ui/dashboard-action-controls.test.tsx
@@ -41,6 +41,28 @@ describe("DashboardActionButton", () => {
     expect(button).toBeDisabled();
     expect(button.className).toContain("min-h-10");
     expect(button.querySelector(".animate-spin")).toBeTruthy();
+    const overlay = button.querySelector(
+      "span.pointer-events-none.absolute.inset-0",
+    );
+    expect(overlay).toBeTruthy();
+    expect(overlay?.className).toContain("inline-flex");
+    expect(overlay?.className).toContain("items-center");
+    expect(overlay?.className).toContain("justify-center");
+  });
+
+  it("renders executing overlay for icon-only buttons", () => {
+    render(
+      <DashboardActionButton aria-label="Export" executing iconOnly>
+        <svg aria-hidden="true" viewBox="0 0 16 16" />
+      </DashboardActionButton>,
+    );
+
+    const button = screen.getByRole("button", { name: "Export" });
+    const overlay = button.querySelector(
+      "span.pointer-events-none.absolute.inset-0",
+    );
+    expect(overlay).toBeTruthy();
+    expect(overlay?.querySelector(".animate-spin")).toBeTruthy();
   });
 
   it("keeps disabled and pressed semantics available for migrated surfaces", () => {

--- a/ui/src/components/ui/dashboard-action-controls.test.tsx
+++ b/ui/src/components/ui/dashboard-action-controls.test.tsx
@@ -40,7 +40,10 @@ describe("DashboardActionButton", () => {
     expect(button).toHaveAttribute("aria-busy", "true");
     expect(button).toBeDisabled();
     expect(button.className).toContain("min-h-10");
-    expect(button.querySelector(".animate-spin")).toBeTruthy();
+    const spinner = button.querySelector("svg.animate-spin");
+    expect(spinner).toBeTruthy();
+    expect(spinner?.classList.contains("size-4")).toBe(true);
+    expect(spinner?.classList.contains("animate-spin")).toBe(true);
     const overlay = button.querySelector(
       "span.pointer-events-none.absolute.inset-0",
     );
@@ -62,7 +65,10 @@ describe("DashboardActionButton", () => {
       "span.pointer-events-none.absolute.inset-0",
     );
     expect(overlay).toBeTruthy();
-    expect(overlay?.querySelector(".animate-spin")).toBeTruthy();
+    const spinner = overlay?.querySelector("svg.animate-spin");
+    expect(spinner).toBeTruthy();
+    expect(spinner?.classList.contains("size-4")).toBe(true);
+    expect(spinner?.classList.contains("animate-spin")).toBe(true);
   });
 
   it("keeps disabled and pressed semantics available for migrated surfaces", () => {


### PR DESCRIPTION
```json
{
  "project": "Inline Dashboard Action Button Classes",
  "branchName": "inline-dashboard-action-button-classes",
  "description": "Move two allowlisted Tailwind class constants in dashboard-action-button.tsx into JSX className props or inline cn(...) expressions, remove the constants and matching allowlist keys, and verify executing overlay/spinner UI for icon-only and default variants plus inline-class policy checks remain unchanged.",
  "context": {
    "customerAsk": "Remove the two remaining allowlisted inline component class constants from ui/src/components/ui/dashboard-action-button.tsx by merging them directly into JSX, then delete the matching entries from ui/scripts/inline-component-class-usage-allowlist.mjs.",
    "problem": "Two single-use module constants in dashboard-action-button.tsx are allowlisted exceptions to check:inline-component-class-usage, hiding executing-state styling from JSX and perpetuating a phased-out UI pattern.",
    "solution": "Inline the two allowlisted class strings or equivalent cn(...) compositions onto JSX className use sites in dashboard-action-button.tsx, delete those constants, remove only the two matching allowlist keys, and verify with check:inline-component-class-usage, lint, and existing dashboard-action-button tests."
  },
  "acceptanceCriteria": [
    "Both allowlisted constants are removed and their exact Tailwind strings or equivalent cn(...) compositions appear inline on the corresponding JSX className props.",
    "Executing-state behavior is unchanged: overlay and spinner appear during executing for icon-only and default variants; idle, hover, focus, and disabled states match current UI.",
    "Only the two specified allowlist keys are removed; unrelated entries including dashboard-header.tsx, trace-drilldown files, and work-chart.tsx remain untouched.",
    "cd ui && npm run check:inline-component-class-usage passes with no violations or stale keys for dashboard-action-button.tsx.",
    "UI typecheck, lint including check:inline-component-class-usage, and existing dashboard-action-button tests pass.",
    "Typecheck, lint, and tests pass."
  ],
  "userStories": [
    {
      "id": "inline-dashboard-action-button-classes-001",
      "title": "Inline executing overlay class",
      "priority": 1,
      "passes": true
    },
    {
      "id": "inline-dashboard-action-button-classes-002",
      "title": "Inline spinner class",
      "priority": 2,
      "passes": true
    },
    {
      "id": "inline-dashboard-action-button-classes-003",
      "title": "Remove allowlist keys and pass inline-class check",
      "priority": 3,
      "passes": true
    }
  ]
}
```

## Summary
- Inlined executing overlay and spinner Tailwind classes onto JSX in `dashboard-action-button.tsx`.
- Removed `DASHBOARD_ACTION_BUTTON_EXECUTING_OVERLAY_CLASS` and `DASHBOARD_ACTION_BUTTON_SPINNER_CLASS` constants.
- Deleted the two matching allowlist keys; `check:inline-component-class-usage` and full UI lint pass.

## Test plan
- [x] `cd ui && bun run tsc`
- [x] `cd ui && bun run lint` (includes `check:inline-component-class-usage`)
- [x] `cd ui && bun run test:unit -- dashboard-action-controls`

Made with [Cursor](https://cursor.com)