### PR TITLE
canonical-work-request-retired-field-errors

### DIFF
--- a/pkg/api/handlers_common.go
+++ b/pkg/api/handlers_common.go
@@ -111,10 +111,7 @@ func decodeStrictJSON[T any](body io.Reader) (T, error) {
 }
 
 func validateCanonicalWorkRequestJSONForAPI(data []byte) error {
-	if err := factoryrequests.ValidateCanonicalWorkRequestJSON(data); err != nil {
-		return translateCanonicalWorkRequestValidationError(err)
-	}
-	return nil
+	return factoryrequests.ValidateCanonicalWorkRequestJSON(data)
 }
 
 func validateWorkContentField(fields map[string]json.RawMessage, prefix string) error {
@@ -340,32 +337,6 @@ func requireOnlyFields(fields map[string]json.RawMessage, prefix string, allowed
 		return requestFieldValidationError{message: fmt.Sprintf("%s%s is not supported", prefix, field)}
 	}
 	return nil
-}
-
-func translateCanonicalWorkRequestValidationError(err error) error {
-	if err == nil {
-		return nil
-	}
-
-	message := err.Error()
-	message = strings.TrimPrefix(message, "work request batch ")
-	message = strings.ReplaceAll(message, " uses retired work_type_id field; use workTypeName", ".work_type_id is not supported; use workTypeName")
-	message = strings.ReplaceAll(message, " uses retired target_state field; use state", ".target_state is not supported; use state")
-	if strings.HasPrefix(message, "works[") && strings.Contains(message, "] ") {
-		message = strings.Replace(message, "] ", "].", 1)
-	}
-	if strings.HasSuffix(message, ".work_type_id is not supported; use workTypeName") ||
-		strings.HasSuffix(message, ".target_state is not supported; use state") {
-		return requestFieldValidationError{message: message}
-	}
-	switch message {
-	case "uses retired work_type_id field; use workTypeName":
-		return requestFieldValidationError{message: "work_type_id is not supported; use workTypeName"}
-	case "uses retired target_state field; use state":
-		return requestFieldValidationError{message: "target_state is not supported; use state"}
-	default:
-		return requestFieldValidationError{message: message}
-	}
 }
 
 func stringValue(value *string) string {

--- a/pkg/api/handlers_work_write.go
+++ b/pkg/api/handlers_work_write.go
@@ -554,7 +554,7 @@ func decodeSubmitWorkRequestBody(body io.Reader) (factoryapi.SubmitWorkBySession
 		return factoryapi.SubmitWorkBySessionIdJSONRequestBody{}, err
 	}
 	if err := validateCanonicalWorkRequestJSONForAPI(data); err != nil {
-		return factoryapi.SubmitWorkBySessionIdJSONRequestBody{}, err
+		return factoryapi.SubmitWorkBySessionIdJSONRequestBody{}, requestFieldValidationError{message: err.Error()}
 	}
 
 	var fields map[string]json.RawMessage
@@ -584,7 +584,7 @@ func decodeWorkRequestBody(body io.Reader) (factoryapi.UpsertWorkRequestBySessio
 		return factoryapi.UpsertWorkRequestBySessionIdJSONRequestBody{}, err
 	}
 	if err := validateCanonicalWorkRequestJSONForAPI(data); err != nil {
-		return factoryapi.UpsertWorkRequestBySessionIdJSONRequestBody{}, err
+		return factoryapi.UpsertWorkRequestBySessionIdJSONRequestBody{}, requestFieldValidationError{message: err.Error()}
 	}
 
 	if req.Works == nil || len(*req.Works) == 0 {

--- a/pkg/cli/batchload/load_test.go
+++ b/pkg/cli/batchload/load_test.go
@@ -101,8 +101,9 @@ func TestLoadFromFile_RejectsRetiredTargetStateAlias(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected retired target_state alias to fail")
 	}
-	if !strings.Contains(err.Error(), "target_state") || !strings.Contains(err.Error(), "state") {
-		t.Fatalf("error = %q, want target_state rejection with state guidance", err.Error())
+	want := "works[0].target_state is not supported; use state"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %q, want %q", err.Error(), want)
 	}
 }
 

--- a/pkg/cli/submit/batch_test.go
+++ b/pkg/cli/submit/batch_test.go
@@ -572,8 +572,9 @@ func TestSubmitBatch_RetiredFieldFailsWithGuidanceBeforeHTTP(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected retired-field validation error")
 	}
-	if !strings.Contains(err.Error(), "retired work_type_id") || !strings.Contains(err.Error(), "workTypeName") {
-		t.Fatalf("error = %v, want retired-field guidance", err)
+	want := "works[0].work_type_id is not supported; use workTypeName"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want %q", err, want)
 	}
 	if called {
 		t.Fatal("expected no HTTP call for retired-field batch")

--- a/pkg/factory/requests/work_request_json.go
+++ b/pkg/factory/requests/work_request_json.go
@@ -83,7 +83,7 @@ func validateConflictingWorkRequestTraceFields(raw canonicalWorkRequestJSON) err
 		raw.TraceID,
 		raw.LegacyTraceID,
 	); err != nil {
-		return fmt.Errorf("work request batch %w", err)
+		return err
 	}
 	for i := range raw.Works {
 		if err := ValidateWorkRequestTraceFieldAliases(
@@ -92,7 +92,7 @@ func validateConflictingWorkRequestTraceFields(raw canonicalWorkRequestJSON) err
 			raw.Works[i].TraceID,
 			raw.Works[i].LegacyTraceID,
 		); err != nil {
-			return fmt.Errorf("work request batch works[%d] %w", i, err)
+			return fmt.Errorf("works[%d].%w", i, err)
 		}
 	}
 	return nil

--- a/pkg/factory/requests/work_request_json.go
+++ b/pkg/factory/requests/work_request_json.go
@@ -60,17 +60,17 @@ func ValidateCanonicalWorkRequestJSON(data []byte) error {
 
 func validateRetiredWorkRequestFieldAliases(raw canonicalWorkRequestJSON) error {
 	if raw.WorkTypeID != nil {
-		return fmt.Errorf("work request batch uses retired work_type_id field; use workTypeName")
+		return fmt.Errorf("work_type_id is not supported; use workTypeName")
 	}
 	if raw.TargetState != nil {
-		return fmt.Errorf("work request batch uses retired target_state field; use state")
+		return fmt.Errorf("target_state is not supported; use state")
 	}
 	for i := range raw.Works {
 		if raw.Works[i].WorkTypeID != nil {
-			return fmt.Errorf("work request batch works[%d] uses retired work_type_id field; use workTypeName", i)
+			return fmt.Errorf("works[%d].work_type_id is not supported; use workTypeName", i)
 		}
 		if raw.Works[i].TargetState != nil {
-			return fmt.Errorf("work request batch works[%d] uses retired target_state field; use state", i)
+			return fmt.Errorf("works[%d].target_state is not supported; use state", i)
 		}
 	}
 	return nil

--- a/pkg/factory/requests/work_request_json_test.go
+++ b/pkg/factory/requests/work_request_json_test.go
@@ -126,7 +126,7 @@ func TestParseCanonicalWorkRequestJSON_RejectsRetiredAliases(t *testing.T) {
 				"work_type_id": "task",
 				"works": [{"name": "draft", "workTypeName": "task"}]
 			}`,
-			wantErr: "work request batch uses retired work_type_id field; use workTypeName",
+			wantErr: "work_type_id is not supported; use workTypeName",
 		},
 		{
 			name: "nested work type id",
@@ -135,7 +135,7 @@ func TestParseCanonicalWorkRequestJSON_RejectsRetiredAliases(t *testing.T) {
 				"type": "FACTORY_REQUEST_BATCH",
 				"works": [{"name": "draft", "work_type_id": "task"}]
 			}`,
-			wantErr: "work request batch works[0] uses retired work_type_id field; use workTypeName",
+			wantErr: "works[0].work_type_id is not supported; use workTypeName",
 		},
 		{
 			name: "top level target state",
@@ -144,7 +144,7 @@ func TestParseCanonicalWorkRequestJSON_RejectsRetiredAliases(t *testing.T) {
 				"workTypeName": "task",
 				"target_state": "queued"
 			}`,
-			wantErr: "work request batch uses retired target_state field; use state",
+			wantErr: "target_state is not supported; use state",
 		},
 		{
 			name: "nested target state",
@@ -153,7 +153,7 @@ func TestParseCanonicalWorkRequestJSON_RejectsRetiredAliases(t *testing.T) {
 				"type": "FACTORY_REQUEST_BATCH",
 				"works": [{"name": "draft", "workTypeName": "task", "target_state": "queued"}]
 			}`,
-			wantErr: "work request batch works[0] uses retired target_state field; use state",
+			wantErr: "works[0].target_state is not supported; use state",
 		},
 	}
 

--- a/pkg/factory/requests/work_request_json_test.go
+++ b/pkg/factory/requests/work_request_json_test.go
@@ -89,7 +89,7 @@ func TestParseCanonicalWorkRequestJSON_RejectsRequestLevelConflictingCurrentChai
 			}
 		]
 	}`))
-	if err == nil || err.Error() != "work request batch currentChainingTraceId and traceId must match when both are provided" {
+	if err == nil || err.Error() != "currentChainingTraceId and traceId must match when both are provided" {
 		t.Fatalf("ParseCanonicalWorkRequestJSON error = %v, want request-level conflict rejection", err)
 	}
 }
@@ -107,7 +107,7 @@ func TestParseCanonicalWorkRequestJSON_RejectsLegacyConflictingCurrentChainingTr
 			}
 		]
 	}`))
-	if err == nil || err.Error() != "work request batch works[0] currentChainingTraceId and traceId must match when both are provided" {
+	if err == nil || err.Error() != "works[0].currentChainingTraceId and traceId must match when both are provided" {
 		t.Fatalf("ParseCanonicalWorkRequestJSON error = %v, want legacy conflict rejection", err)
 	}
 }

--- a/pkg/service/factory_runtime_mode_test.go
+++ b/pkg/service/factory_runtime_mode_test.go
@@ -521,8 +521,9 @@ func TestBuildFactoryService_WorkFileRejectsRetiredTargetStateAlias(t *testing.T
 	if err == nil {
 		t.Fatal("expected retired target_state alias to fail")
 	}
-	if !strings.Contains(err.Error(), "target_state") || !strings.Contains(err.Error(), "state") {
-		t.Fatalf("error = %q, want target_state rejection with state guidance", err.Error())
+	want := "works[0].target_state is not supported; use state"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %q, want %q", err.Error(), want)
 	}
 }
 

--- a/pkg/service/ingest/filewatcher_test.go
+++ b/pkg/service/ingest/filewatcher_test.go
@@ -539,8 +539,9 @@ func TestFileWatcher_JSONFactoryRequestBatchRejectsWorkTypeIDAlias(t *testing.T)
 	if err == nil {
 		t.Fatal("expected retired work_type_id alias to fail")
 	}
-	if !strings.Contains(err.Error(), "work_type_id") || !strings.Contains(err.Error(), "workTypeName") {
-		t.Fatalf("error = %q, want work_type_id rejection with workTypeName guidance", err.Error())
+	want := "works[0].work_type_id is not supported; use workTypeName"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %q, want %q", err.Error(), want)
 	}
 	if submitted := mf.getSubmitted(); len(submitted) != 0 {
 		t.Fatalf("expected no partial submissions, got %d", len(submitted))
@@ -572,8 +573,9 @@ func TestFileWatcher_JSONFactoryRequestBatchRejectsTargetStateAlias(t *testing.T
 	if err == nil {
 		t.Fatal("expected retired target_state alias to fail")
 	}
-	if !strings.Contains(err.Error(), "target_state") || !strings.Contains(err.Error(), "state") {
-		t.Fatalf("error = %q, want target_state rejection with state guidance", err.Error())
+	want := "works[0].target_state is not supported; use state"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %q, want %q", err.Error(), want)
 	}
 	if submitted := mf.getSubmitted(); len(submitted) != 0 {
 		t.Fatalf("expected no partial submissions, got %d", len(submitted))


### PR DESCRIPTION
## Summary

Canonicalize retired work-request field validation errors: emit final public messages from `validateRetiredWorkRequestFieldAliases` in `pkg/factory/requests`, remove the `pkg/api` string-translation shim, and align CLI, batch load, file watcher, and runtime tests so every ingress path surfaces identical copy.

## PRD

```json
{
  "project": "you-agent-factory",
  "branchName": "canonical-work-request-retired-field-errors",
  "description": "Emit canonical public rejection messages for retired work-request fields (work_type_id, target_state) directly from pkg/factory/requests validation, remove the pkg/api string-translation shim, and align CLI, batch load, file watcher, and runtime tests so every ingress path surfaces identical copy.",
  "context": {
    "customerAsk": "Canonicalize retired work-request field validation errors: emit final public messages from validateRetiredWorkRequestFieldAliases in pkg/factory/requests/work_request_json.go, delete translateCanonicalWorkRequestValidationError in pkg/api/handlers_common.go, and update tests that assert internal uses retired wording so API, CLI, batch load, file watcher, and poller paths agree.",
    "problem": "Retired-field validation copy is split between pkg/factory/requests (internal uses retired strings) and pkg/api (rewrites to public is not supported messages). CLI, batch load, file watcher, and poller expose internal wording while the API exposes rewritten copy for the same rejection.",
    "solution": "Return canonical top-level and works[N] messages from validateRetiredWorkRequestFieldAliases, call ValidateCanonicalWorkRequestJSON directly from validateCanonicalWorkRequestJSONForAPI without translation, and update factory, API, CLI, ingest, and runtime tests to assert the same public strings without changing OpenAPI schema or accepted-field parsing."
  },
  "acceptanceCriteria": [
    "validateRetiredWorkRequestFieldAliases returns only canonical public messages for work_type_id and target_state at top level and under works[N]",
    "translateCanonicalWorkRequestValidationError and any equivalent string-rewrite shim are removed from pkg/api; validateCanonicalWorkRequestJSONForAPI returns ValidateCanonicalWorkRequestJSON errors unchanged",
    "pkg/api/server_submit_work_test.go and pkg/api/server_work_query_test.go pass with unchanged expected BAD_REQUEST bodies",
    "CLI submit, batch load, file watcher, and factory-runtime tests assert full canonical messages not uses retired substring checks",
    "go test ./pkg/factory/requests ./pkg/api ./pkg/cli/submit ./pkg/cli/batchload ./pkg/service/ingest -count=1 passes with no changes under ui/src/features/current-selection",
    "Typecheck passes, lint passes, and tests pass for all changes in this work item"
  ],
  "userStories": [
    {
      "id": "canonical-work-request-retired-field-errors-001",
      "title": "Emit canonical retired-field messages at validation source",
      "description": "As an operator submitting work via CLI, batch load, or file watcher, I need retired-field rejections to use the same public wording the API already exposes so I know which canonical field to use without decoding internal phrasing.",
      "acceptanceCriteria": [
        "validateRetiredWorkRequestFieldAliases returns top-level work_type_id is not supported; use workTypeName and target_state is not supported; use state for root-level retired keys",
        "For batch works entries returns works[N].work_type_id is not supported; use workTypeName and works[N].target_state is not supported; use state with zero-based N",
        "No retired-alias validation error strings contain uses retired",
        "pkg/factory/requests/work_request_json_test.go asserts exact canonical messages for top-level and nested retired fields",
        "Accepted-field parsing and trace-alias conflict rules are unchanged",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "canonical-work-request-retired-field-errors-002",
      "title": "Remove API validation error translation shim",
      "description": "As an API maintainer, I want work-request validation to surface factory validator errors directly so public copy cannot drift between pkg/factory/requests and pkg/api.",
      "acceptanceCriteria": [
        "translateCanonicalWorkRequestValidationError is deleted from pkg/api/handlers_common.go with no remaining callers",
        "validateCanonicalWorkRequestJSONForAPI invokes ValidateCanonicalWorkRequestJSON and returns its error unchanged",
        "pkg/api/server_submit_work_test.go and pkg/api/server_work_query_test.go pass with the same expected BAD_REQUEST message bodies as before",
        "OpenAPI schema and generated types are untouched",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "canonical-work-request-retired-field-errors-003",
      "title": "Align CLI, ingest, and runtime tests with canonical messages",
      "description": "As a maintainer running ingress integration tests, I need CLI submit, batch load, file watcher, and factory-runtime tests to assert the same canonical retired-field strings the API and factory validator emit.",
      "acceptanceCriteria": [
        "pkg/cli/submit/batch_test.go expects full canonical retired-field messages not uses retired substring-only checks",
        "pkg/cli/batchload/load_test.go expects full canonical retired-field messages for rejected batch payloads",
        "pkg/service/ingest/filewatcher_test.go expects full canonical retired-field messages for invalid watched work-request files",
        "pkg/service/factory_runtime_mode_test.go expects full canonical retired-field messages where retired-alias rejection is exercised",
        "go test ./pkg/factory/requests ./pkg/api ./pkg/cli/submit ./pkg/cli/batchload ./pkg/service/ingest -count=1 passes",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": false,
      "notes": ""
    }
  ]
}
```

Made with [Cursor](https://cursor.com)