### PR TITLE
collapse-provider-failure-type-aliases

### DIFF
--- a/pkg/config/maptests/config_mapper_test.go
+++ b/pkg/config/maptests/config_mapper_test.go
@@ -653,9 +653,9 @@ func TestConfigMapping_FactoryInferenceThrottleGuardBlocksOnlyMatchingLaneAtRunt
 			{
 				DispatchID:   "d-throttle",
 				TransitionID: "claude-step",
-				ProviderFailure: &interfaces.ProviderFailureMetadata{
-					Family: interfaces.ProviderErrorFamilyThrottle,
-					Type:   interfaces.ProviderErrorTypeThrottled,
+				ProviderFailure: &interfaces.WorkFailureMetadata{
+					Family: interfaces.WorkFailureFamilyThrottle,
+					Type:   interfaces.WorkFailureTypeThrottled,
 				},
 				EndTime: time.Date(2026, time.May, 1, 10, 0, 0, 0, time.UTC),
 			},

--- a/pkg/factory/events/event_history_test.go
+++ b/pkg/factory/events/event_history_test.go
@@ -478,9 +478,9 @@ func TestFactoryEventHistory_RecordWorkstationResponse_CodexWindowsExitCode42949
 		TransitionID: "build",
 		Outcome:      interfaces.OutcomeFailed,
 		Error:        errorText,
-		ProviderFailure: &interfaces.ProviderFailureMetadata{
-			Family: interfaces.ProviderErrorFamilyRetryable,
-			Type:   interfaces.ProviderErrorTypeInternalServerError,
+		ProviderFailure: &interfaces.WorkFailureMetadata{
+			Family: interfaces.WorkFailureFamilyRetryable,
+			Type:   interfaces.WorkFailureTypeInternalServerError,
 		},
 	}
 	completed := interfaces.CompletedDispatch{
@@ -503,8 +503,8 @@ func TestFactoryEventHistory_RecordWorkstationResponse_CodexWindowsExitCode42949
 	if err != nil {
 		t.Fatalf("dispatch completed payload: %v", err)
 	}
-	if stringValueForEventHistoryTest(payload.FailureReason) != string(interfaces.ProviderErrorTypeInternalServerError) {
-		t.Fatalf("failure reason = %q, want %q", stringValueForEventHistoryTest(payload.FailureReason), interfaces.ProviderErrorTypeInternalServerError)
+	if stringValueForEventHistoryTest(payload.FailureReason) != string(interfaces.WorkFailureTypeInternalServerError) {
+		t.Fatalf("failure reason = %q, want %q", stringValueForEventHistoryTest(payload.FailureReason), interfaces.WorkFailureTypeInternalServerError)
 	}
 	if stringValueForEventHistoryTest(payload.FailureMessage) != errorText {
 		t.Fatalf("failure message = %q, want %q", stringValueForEventHistoryTest(payload.FailureMessage), errorText)
@@ -512,11 +512,11 @@ func TestFactoryEventHistory_RecordWorkstationResponse_CodexWindowsExitCode42949
 	if payload.ProviderFailure == nil {
 		t.Fatal("expected provider failure metadata on dispatch completed payload")
 	}
-	if stringValueForEventHistoryTest(payload.ProviderFailure.Family) != string(interfaces.ProviderErrorFamilyRetryable) {
-		t.Fatalf("provider failure family = %q, want %q", stringValueForEventHistoryTest(payload.ProviderFailure.Family), interfaces.ProviderErrorFamilyRetryable)
+	if stringValueForEventHistoryTest(payload.ProviderFailure.Family) != string(interfaces.WorkFailureFamilyRetryable) {
+		t.Fatalf("provider failure family = %q, want %q", stringValueForEventHistoryTest(payload.ProviderFailure.Family), interfaces.WorkFailureFamilyRetryable)
 	}
-	if stringValueForEventHistoryTest(payload.ProviderFailure.Type) != string(interfaces.ProviderErrorTypeInternalServerError) {
-		t.Fatalf("provider failure type = %q, want %q", stringValueForEventHistoryTest(payload.ProviderFailure.Type), interfaces.ProviderErrorTypeInternalServerError)
+	if stringValueForEventHistoryTest(payload.ProviderFailure.Type) != string(interfaces.WorkFailureTypeInternalServerError) {
+		t.Fatalf("provider failure type = %q, want %q", stringValueForEventHistoryTest(payload.ProviderFailure.Type), interfaces.WorkFailureTypeInternalServerError)
 	}
 }
 

--- a/pkg/factory/projections/projectiontests/world_state_support_test.go
+++ b/pkg/factory/projections/projectiontests/world_state_support_test.go
@@ -743,7 +743,7 @@ func generatedProviderSessionForProjectionTest(session *interfaces.ProviderSessi
 	}
 }
 
-func generatedProviderFailureForProjectionTest(failure *interfaces.ProviderFailureMetadata) *factoryapi.ProviderFailureMetadata {
+func generatedProviderFailureForProjectionTest(failure *interfaces.WorkFailureMetadata) *factoryapi.ProviderFailureMetadata {
 	if failure == nil {
 		return nil
 	}

--- a/pkg/factory/projections/projectiontests/world_state_test.go
+++ b/pkg/factory/projections/projectiontests/world_state_test.go
@@ -372,7 +372,7 @@ func TestReconstructFactoryWorldState_PreservesCanonicalProviderMetadata(t *test
 			Attempt:            1,
 			Outcome:            factoryapi.InferenceOutcomeFailed,
 			DurationMillis:     900,
-			ErrorClass:         stringPtrForProjectionTest(string(interfaces.ProviderErrorTypeTimeout)),
+			ErrorClass:         stringPtrForProjectionTest(string(interfaces.WorkFailureTypeTimeout)),
 			ProviderSession: generatedProviderSessionForProjectionTest(&interfaces.ProviderSessionMetadata{
 				Provider: "codex",
 				Kind:     "session_id",
@@ -383,7 +383,7 @@ func TestReconstructFactoryWorldState_PreservesCanonicalProviderMetadata(t *test
 			DispatchID:     "dispatch-1",
 			TransitionID:   "t-review",
 			Workstation:    interfaces.FactoryWorkstationRef{ID: "t-review", Name: "Review"},
-			Result:         interfaces.WorkstationResult{Outcome: "FAILED", ProviderFailure: &interfaces.ProviderFailureMetadata{Family: interfaces.ProviderErrorFamilyRetryable, Type: interfaces.ProviderErrorTypeTimeout}},
+			Result:         interfaces.WorkstationResult{Outcome: "FAILED", ProviderFailure: &interfaces.WorkFailureMetadata{Family: interfaces.WorkFailureFamilyRetryable, Type: interfaces.WorkFailureTypeTimeout}},
 			DurationMillis: 900,
 			TraceData:      &interfaces.FactoryTraceData{TraceID: "trace-1", WorkIDs: []string{"work-1"}},
 			ProviderSession: &interfaces.ProviderSessionMetadata{
@@ -409,8 +409,8 @@ func TestReconstructFactoryWorldState_PreservesCanonicalProviderMetadata(t *test
 	if completion.Result.ProviderFailure == nil {
 		t.Fatal("completion provider failure is nil, want canonical metadata")
 	}
-	if completion.Result.ProviderFailure.Family != interfaces.ProviderErrorFamilyRetryable ||
-		completion.Result.ProviderFailure.Type != interfaces.ProviderErrorTypeTimeout {
+	if completion.Result.ProviderFailure.Family != interfaces.WorkFailureFamilyRetryable ||
+		completion.Result.ProviderFailure.Type != interfaces.WorkFailureTypeTimeout {
 		t.Fatalf("completion provider failure = %#v, want retryable/timeout", completion.Result.ProviderFailure)
 	}
 	if len(state.ProviderSessions) != 1 || state.ProviderSessions[0].ProviderSession.ID != "sess-1" {

--- a/pkg/factory/projections/world_state_generated.go
+++ b/pkg/factory/projections/world_state_generated.go
@@ -32,7 +32,7 @@ func workstationResultFromGenerated(payload factoryapi.DispatchResponseEventPayl
 		FailureReason:               stringValue(payload.FailureReason),
 		FailureMessage:              stringValue(payload.FailureMessage),
 		FailureMetadata:             interfaces.CloneWorkFailureMetadata(failureMetadata),
-		ProviderFailure:             interfaces.CloneProviderFailureMetadata(failureMetadata),
+		ProviderFailure:             interfaces.CloneWorkFailureMetadata(failureMetadata),
 	}
 }
 

--- a/pkg/factory/runtime/factory_event_history_test.go
+++ b/pkg/factory/runtime/factory_event_history_test.go
@@ -236,12 +236,12 @@ func assertSafeBoundaryWorldState(t *testing.T, worldState interfaces.FactoryWor
 	if got := len(worldState.CompletedDispatches); got != 3 {
 		t.Fatalf("completed dispatch count = %d, want 3", got)
 	}
-	if got := worldState.FailureDetailsByWorkID["work-safe-failure"].FailureReason; got != string(interfaces.ProviderErrorTypeTimeout) {
+	if got := worldState.FailureDetailsByWorkID["work-safe-failure"].FailureReason; got != string(interfaces.WorkFailureTypeTimeout) {
 		t.Fatalf("failed work detail reason = %q, want timeout", got)
 	}
 	windowsDetail := worldState.FailureDetailsByWorkID["work-safe-windows-process-failure"]
-	if windowsDetail.FailureReason != string(interfaces.ProviderErrorTypeInternalServerError) {
-		t.Fatalf("windows failed work detail reason = %q, want %q", windowsDetail.FailureReason, interfaces.ProviderErrorTypeInternalServerError)
+	if windowsDetail.FailureReason != string(interfaces.WorkFailureTypeInternalServerError) {
+		t.Fatalf("windows failed work detail reason = %q, want %q", windowsDetail.FailureReason, interfaces.WorkFailureTypeInternalServerError)
 	}
 	if windowsDetail.FailureMessage != "provider error: internal_server_error: codex exited with code 4294967295: stderr: OpenAI Codex v0.118.0 (research preview)" {
 		t.Fatalf("windows failed work detail message = %q", windowsDetail.FailureMessage)
@@ -260,14 +260,14 @@ func assertSafeBoundaryRequestViews(t *testing.T, worldState interfaces.FactoryW
 	assertSafeBoundaryRequestView(t, worldState, requestViewForWork(t, worldState, "work-safe-success"),
 		"work-safe-success", "resp-safe-success", "", "", "")
 	assertSafeBoundaryRequestView(t, worldState, requestViewForWork(t, worldState, "work-safe-failure"),
-		"work-safe-failure", "sess-safe-failure", string(interfaces.ProviderErrorFamilyRetryable), string(interfaces.ProviderErrorTypeTimeout), "provider timed out")
+		"work-safe-failure", "sess-safe-failure", string(interfaces.WorkFailureFamilyRetryable), string(interfaces.WorkFailureTypeTimeout), "provider timed out")
 
 	windowsRequest := requestViewForWork(t, worldState, "work-safe-windows-process-failure")
 	assertSafeBoundaryRequestView(t, worldState, windowsRequest,
 		"work-safe-windows-process-failure",
 		"sess-safe-windows-4294967295",
-		string(interfaces.ProviderErrorFamilyRetryable),
-		string(interfaces.ProviderErrorTypeInternalServerError),
+		string(interfaces.WorkFailureFamilyRetryable),
+		string(interfaces.WorkFailureTypeInternalServerError),
 		"provider error: internal_server_error: codex exited with code 4294967295: stderr: OpenAI Codex v0.118.0 (research preview)",
 	)
 	assertNoAuthRemediationText(t, stringValueForRuntimeTest(windowsRequest.Response.FailureMessage))

--- a/pkg/factory/runtime/factory_runtime_test_helpers_test.go
+++ b/pkg/factory/runtime/factory_runtime_test_helpers_test.go
@@ -59,18 +59,18 @@ func (e *safeDiagnosticsBoundaryExecutor) Execute(_ context.Context, dispatch in
 			ID:       "resp-safe-success",
 		}, "1"), nil
 	case "work-safe-failure":
-		return safeBoundaryResult(dispatch, workID, interfaces.OutcomeFailed, "provider timed out", &interfaces.ProviderFailureMetadata{
-			Family: interfaces.ProviderErrorFamilyRetryable,
-			Type:   interfaces.ProviderErrorTypeTimeout,
+		return safeBoundaryResult(dispatch, workID, interfaces.OutcomeFailed, "provider timed out", &interfaces.WorkFailureMetadata{
+			Family: interfaces.WorkFailureFamilyRetryable,
+			Type:   interfaces.WorkFailureTypeTimeout,
 		}, &interfaces.ProviderSessionMetadata{
 			Provider: "codex",
 			Kind:     "session_id",
 			ID:       "sess-safe-failure",
 		}, "2"), nil
 	case "work-safe-windows-process-failure":
-		return safeBoundaryResult(dispatch, workID, interfaces.OutcomeFailed, "provider error: internal_server_error: codex exited with code 4294967295: stderr: OpenAI Codex v0.118.0 (research preview)", &interfaces.ProviderFailureMetadata{
-			Family: interfaces.ProviderErrorFamilyRetryable,
-			Type:   interfaces.ProviderErrorTypeInternalServerError,
+		return safeBoundaryResult(dispatch, workID, interfaces.OutcomeFailed, "provider error: internal_server_error: codex exited with code 4294967295: stderr: OpenAI Codex v0.118.0 (research preview)", &interfaces.WorkFailureMetadata{
+			Family: interfaces.WorkFailureFamilyRetryable,
+			Type:   interfaces.WorkFailureTypeInternalServerError,
 		}, &interfaces.ProviderSessionMetadata{
 			Provider: "codex",
 			Kind:     "session_id",
@@ -482,7 +482,7 @@ func safeBoundaryResult(
 	workID string,
 	outcome interfaces.WorkOutcome,
 	errText string,
-	providerFailure *interfaces.ProviderFailureMetadata,
+	providerFailure *interfaces.WorkFailureMetadata,
 	providerSession *interfaces.ProviderSessionMetadata,
 	retryCount string,
 ) interfaces.WorkResult {

--- a/pkg/factory/subsystems/dispatchertests/dispatcher_test.go
+++ b/pkg/factory/subsystems/dispatchertests/dispatcher_test.go
@@ -593,9 +593,9 @@ func throttledCompletedDispatch(dispatchID string, transitionID string, endTime 
 		DispatchID:   dispatchID,
 		TransitionID: transitionID,
 		Outcome:      interfaces.OutcomeFailed,
-		ProviderFailure: &interfaces.ProviderFailureMetadata{
-			Family: interfaces.ProviderErrorFamilyThrottle,
-			Type:   interfaces.ProviderErrorTypeThrottled,
+		ProviderFailure: &interfaces.WorkFailureMetadata{
+			Family: interfaces.WorkFailureFamilyThrottle,
+			Type:   interfaces.WorkFailureTypeThrottled,
 		},
 		EndTime: endTime,
 	}

--- a/pkg/factory/subsystems/history_transitioner_pipeline_test.go
+++ b/pkg/factory/subsystems/history_transitioner_pipeline_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/factory/state"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/petri"
-	"github.com/portpowered/infinite-you/pkg/workers"
+	workerprovider "github.com/portpowered/infinite-you/pkg/workers/provider"
 )
 
 type testPipeline struct {
@@ -168,9 +168,9 @@ func TestHistoryTransitionerPipeline_ThrottledFailureRequeuesConsumedWorkToOrigi
 		TransitionID: "t1",
 		Outcome:      interfaces.OutcomeFailed,
 		Error:        "provider error: claude rate limit exceeded",
-		ProviderFailure: &interfaces.ProviderFailureMetadata{
-			Family: interfaces.ProviderErrorFamilyThrottle,
-			Type:   interfaces.ProviderErrorTypeThrottled,
+		ProviderFailure: &interfaces.WorkFailureMetadata{
+			Family: interfaces.WorkFailureFamilyThrottle,
+			Type:   interfaces.WorkFailureTypeThrottled,
 		},
 	})
 	createdAt := time.Date(2026, time.April, 6, 10, 0, 0, 0, time.UTC)
@@ -289,8 +289,8 @@ func assertTimeoutFailureRequeueResult(t *testing.T, result *interfaces.TickResu
 	if completed.ProviderFailure == nil {
 		t.Fatal("completed dispatch ProviderFailure = nil, want mirrored timeout metadata")
 	}
-	if completed.ProviderFailure.Type != interfaces.ProviderErrorTypeTimeout {
-		t.Fatalf("completed dispatch ProviderFailure.Type = %q, want %q", completed.ProviderFailure.Type, interfaces.ProviderErrorTypeTimeout)
+	if completed.ProviderFailure.Type != interfaces.WorkFailureTypeTimeout {
+		t.Fatalf("completed dispatch ProviderFailure.Type = %q, want %q", completed.ProviderFailure.Type, interfaces.WorkFailureTypeTimeout)
 	}
 }
 
@@ -345,9 +345,9 @@ func TestHistoryTransitionerPipeline_InternalServerFailureRequeuesConsumedWorkTo
 		TransitionID: "t1",
 		Outcome:      interfaces.OutcomeFailed,
 		Error:        "provider error: internal_server_error",
-		ProviderFailure: &interfaces.ProviderFailureMetadata{
-			Family: interfaces.ProviderErrorFamilyRetryable,
-			Type:   interfaces.ProviderErrorTypeInternalServerError,
+		ProviderFailure: &interfaces.WorkFailureMetadata{
+			Family: interfaces.WorkFailureFamilyRetryable,
+			Type:   interfaces.WorkFailureTypeInternalServerError,
 		},
 	})
 
@@ -376,21 +376,21 @@ func TestHistoryTransitionerPipeline_InternalServerFailureRequeuesConsumedWorkTo
 func TestHistoryTransitionerPipeline_InternalServerFailureRequeuesFromNormalizedTypeWhenFamilyIsMissingOrStale(t *testing.T) {
 	testCases := []struct {
 		name     string
-		metadata *interfaces.ProviderFailureMetadata
+		metadata *interfaces.WorkFailureMetadata
 		workID   string
 	}{
 		{
 			name: "MissingFamily",
-			metadata: &interfaces.ProviderFailureMetadata{
-				Type: interfaces.ProviderErrorTypeInternalServerError,
+			metadata: &interfaces.WorkFailureMetadata{
+				Type: interfaces.WorkFailureTypeInternalServerError,
 			},
 			workID: "w-retryable-missing-family",
 		},
 		{
 			name: "StaleTerminalFamily",
-			metadata: &interfaces.ProviderFailureMetadata{
-				Family: interfaces.ProviderErrorFamilyTerminal,
-				Type:   interfaces.ProviderErrorTypeInternalServerError,
+			metadata: &interfaces.WorkFailureMetadata{
+				Family: interfaces.WorkFailureFamilyTerminal,
+				Type:   interfaces.WorkFailureTypeInternalServerError,
 			},
 			workID: "w-retryable-stale-family",
 		},
@@ -437,9 +437,9 @@ func TestHistoryTransitionerPipeline_CodexWindowsExitCode4294967295RequeuesAndPr
 	n := buildPipelineNet()
 	tp := newTestPipeline(n)
 	errorText := "provider error: internal_server_error: codex exited with code 4294967295: stderr: OpenAI Codex v0.118.0 (research preview)"
-	providerFailure := &interfaces.ProviderFailureMetadata{
-		Family: interfaces.ProviderErrorFamilyRetryable,
-		Type:   interfaces.ProviderErrorTypeInternalServerError,
+	providerFailure := &interfaces.WorkFailureMetadata{
+		Family: interfaces.WorkFailureFamilyRetryable,
+		Type:   interfaces.WorkFailureTypeInternalServerError,
 	}
 	tp.WriteResult(interfaces.WorkResult{
 		DispatchID:      "d-1",
@@ -479,22 +479,22 @@ func TestHistoryTransitionerPipeline_CodexWindowsExitCode4294967295RequeuesAndPr
 	if completed.ProviderFailure == nil {
 		t.Fatal("expected completed dispatch provider failure metadata")
 	}
-	if completed.ProviderFailure.Type != interfaces.ProviderErrorTypeInternalServerError {
-		t.Fatalf("completed dispatch provider failure type = %q, want %q", completed.ProviderFailure.Type, interfaces.ProviderErrorTypeInternalServerError)
+	if completed.ProviderFailure.Type != interfaces.WorkFailureTypeInternalServerError {
+		t.Fatalf("completed dispatch provider failure type = %q, want %q", completed.ProviderFailure.Type, interfaces.WorkFailureTypeInternalServerError)
 	}
-	if completed.ProviderFailure.Family != interfaces.ProviderErrorFamilyRetryable {
-		t.Fatalf("completed dispatch provider failure family = %q, want %q", completed.ProviderFailure.Family, interfaces.ProviderErrorFamilyRetryable)
+	if completed.ProviderFailure.Family != interfaces.WorkFailureFamilyRetryable {
+		t.Fatalf("completed dispatch provider failure family = %q, want %q", completed.ProviderFailure.Family, interfaces.WorkFailureFamilyRetryable)
 	}
-	decision := workers.ProviderFailureDecisionFromMetadata(completed.ProviderFailure)
+	decision := workerprovider.WorkFailureDecisionFromMetadata(completed.ProviderFailure)
 	if !decision.Retryable || decision.Terminal || decision.TriggersThrottlePause {
-		t.Fatalf("ProviderFailureDecisionFromMetadata(%#v) = %#v, want retryable non-terminal non-throttle", completed.ProviderFailure, decision)
+		t.Fatalf("WorkFailureDecisionFromMetadata(%#v) = %#v, want retryable non-terminal non-throttle", completed.ProviderFailure, decision)
 	}
-	providerFailure.Type = interfaces.ProviderErrorTypeAuthFailure
-	providerFailure.Family = interfaces.ProviderErrorFamilyTerminal
-	if completed.ProviderFailure.Type != interfaces.ProviderErrorTypeInternalServerError {
+	providerFailure.Type = interfaces.WorkFailureTypeAuthFailure
+	providerFailure.Family = interfaces.WorkFailureFamilyTerminal
+	if completed.ProviderFailure.Type != interfaces.WorkFailureTypeInternalServerError {
 		t.Fatalf("completed dispatch provider failure type after source mutation = %q, want detached original", completed.ProviderFailure.Type)
 	}
-	if completed.ProviderFailure.Family != interfaces.ProviderErrorFamilyRetryable {
+	if completed.ProviderFailure.Family != interfaces.WorkFailureFamilyRetryable {
 		t.Fatalf("completed dispatch provider failure family after source mutation = %q, want detached original", completed.ProviderFailure.Family)
 	}
 }

--- a/pkg/factory/subsystems/subsystem_transitioner.go
+++ b/pkg/factory/subsystems/subsystem_transitioner.go
@@ -242,7 +242,7 @@ func (t *TransitionerSubsystem) buildCompletedDispatch(
 		SelectedClassificationLabel: resolved.selectedClassificationLabel,
 		Reason:                      completedDispatchReason(resolved),
 		FailureMetadata:             interfaces.CloneWorkFailureMetadata(interfaces.CanonicalWorkFailureMetadata(result.FailureMetadata, result.ProviderFailure)),
-		ProviderFailure:             interfaces.CloneProviderFailureMetadata(interfaces.CanonicalWorkFailureMetadata(result.FailureMetadata, result.ProviderFailure)),
+		ProviderFailure:             interfaces.CloneWorkFailureMetadata(interfaces.CanonicalWorkFailureMetadata(result.FailureMetadata, result.ProviderFailure)),
 		ProviderSession:             interfaces.CloneProviderSessionMetadata(result.ProviderSession),
 		EndTime:                     endTime,
 		ConsumedTokens:              interfaces.CloneTokens(consumedTokens),

--- a/pkg/factory/throttle/windows.go
+++ b/pkg/factory/throttle/windows.go
@@ -12,7 +12,7 @@ type FailureRecord struct {
 	Model           string
 	OccurredAt      time.Time
 	FailureMetadata *interfaces.WorkFailureMetadata
-	ProviderFailure *interfaces.ProviderFailureMetadata
+	ProviderFailure *interfaces.WorkFailureMetadata
 }
 
 type laneKey struct {
@@ -91,5 +91,5 @@ func laneID(key laneKey) string {
 }
 
 func triggersThrottlePause(failure *interfaces.WorkFailureMetadata) bool {
-	return failure != nil && failure.Family == interfaces.ProviderErrorFamilyThrottle
+	return failure != nil && failure.Family == interfaces.WorkFailureFamilyThrottle
 }

--- a/pkg/factory/throttle/windows_test.go
+++ b/pkg/factory/throttle/windows_test.go
@@ -14,9 +14,9 @@ func TestDeriveActiveThrottlePauses_CreatesOneActiveLaneForThrottleFailure(t *te
 		Provider:   "claude",
 		Model:      "claude-sonnet",
 		OccurredAt: now.Add(-5 * time.Minute),
-		ProviderFailure: &interfaces.ProviderFailureMetadata{
-			Family: interfaces.ProviderErrorFamilyThrottle,
-			Type:   interfaces.ProviderErrorTypeThrottled,
+		ProviderFailure: &interfaces.WorkFailureMetadata{
+			Family: interfaces.WorkFailureFamilyThrottle,
+			Type:   interfaces.WorkFailureTypeThrottled,
 		},
 	}}, 30*time.Minute, now)
 
@@ -38,18 +38,18 @@ func TestDeriveActiveThrottlePauses_LaterFailureExtendsLaneExpiry(t *testing.T) 
 			Provider:   "claude",
 			Model:      "claude-sonnet",
 			OccurredAt: first,
-			ProviderFailure: &interfaces.ProviderFailureMetadata{
-				Family: interfaces.ProviderErrorFamilyThrottle,
-				Type:   interfaces.ProviderErrorTypeThrottled,
+			ProviderFailure: &interfaces.WorkFailureMetadata{
+				Family: interfaces.WorkFailureFamilyThrottle,
+				Type:   interfaces.WorkFailureTypeThrottled,
 			},
 		},
 		{
 			Provider:   "claude",
 			Model:      "claude-sonnet",
 			OccurredAt: second,
-			ProviderFailure: &interfaces.ProviderFailureMetadata{
-				Family: interfaces.ProviderErrorFamilyThrottle,
-				Type:   interfaces.ProviderErrorTypeThrottled,
+			ProviderFailure: &interfaces.WorkFailureMetadata{
+				Family: interfaces.WorkFailureFamilyThrottle,
+				Type:   interfaces.WorkFailureTypeThrottled,
 			},
 		},
 	}, 15*time.Minute, now)
@@ -72,9 +72,9 @@ func TestDeriveActiveThrottlePauses_OmitsExpiredWindows(t *testing.T) {
 		Provider:   "claude",
 		Model:      "claude-sonnet",
 		OccurredAt: now.Add(-45 * time.Minute),
-		ProviderFailure: &interfaces.ProviderFailureMetadata{
-			Family: interfaces.ProviderErrorFamilyThrottle,
-			Type:   interfaces.ProviderErrorTypeThrottled,
+		ProviderFailure: &interfaces.WorkFailureMetadata{
+			Family: interfaces.WorkFailureFamilyThrottle,
+			Type:   interfaces.WorkFailureTypeThrottled,
 		},
 	}}, 15*time.Minute, now)
 
@@ -91,18 +91,18 @@ func TestDeriveActiveThrottlePauses_KeepsProviderOnlyAndProviderModelLanesIsolat
 			Provider:   "claude",
 			Model:      "",
 			OccurredAt: now.Add(-5 * time.Minute),
-			ProviderFailure: &interfaces.ProviderFailureMetadata{
-				Family: interfaces.ProviderErrorFamilyThrottle,
-				Type:   interfaces.ProviderErrorTypeThrottled,
+			ProviderFailure: &interfaces.WorkFailureMetadata{
+				Family: interfaces.WorkFailureFamilyThrottle,
+				Type:   interfaces.WorkFailureTypeThrottled,
 			},
 		},
 		{
 			Provider:   "claude",
 			Model:      "claude-sonnet",
 			OccurredAt: now.Add(-4 * time.Minute),
-			ProviderFailure: &interfaces.ProviderFailureMetadata{
-				Family: interfaces.ProviderErrorFamilyThrottle,
-				Type:   interfaces.ProviderErrorTypeThrottled,
+			ProviderFailure: &interfaces.WorkFailureMetadata{
+				Family: interfaces.WorkFailureFamilyThrottle,
+				Type:   interfaces.WorkFailureTypeThrottled,
 			},
 		},
 	}, 30*time.Minute, now)
@@ -122,9 +122,9 @@ func TestDeriveActiveThrottlePauses_IgnoresRetryableNonThrottleFailures(t *testi
 		Provider:   "claude",
 		Model:      "claude-sonnet",
 		OccurredAt: now.Add(-5 * time.Minute),
-		ProviderFailure: &interfaces.ProviderFailureMetadata{
-			Family: interfaces.ProviderErrorFamilyRetryable,
-			Type:   interfaces.ProviderErrorTypeInternalServerError,
+		ProviderFailure: &interfaces.WorkFailureMetadata{
+			Family: interfaces.WorkFailureFamilyRetryable,
+			Type:   interfaces.WorkFailureTypeInternalServerError,
 		},
 	}}, 30*time.Minute, now)
 

--- a/pkg/interfaces/factory_events.go
+++ b/pkg/interfaces/factory_events.go
@@ -181,7 +181,7 @@ type WorkstationResult struct {
 	FailureReason               string                   `json:"failure_reason,omitempty"`
 	FailureMessage              string                   `json:"failure_message,omitempty"`
 	FailureMetadata             *WorkFailureMetadata     `json:"failure_metadata,omitempty"`
-	ProviderFailure             *ProviderFailureMetadata `json:"provider_failure,omitempty"`
+	ProviderFailure             *WorkFailureMetadata `json:"provider_failure,omitempty"`
 }
 
 // FactoryTraceData carries trace identifiers attached to a runtime event.

--- a/pkg/interfaces/runtime_lookup.go
+++ b/pkg/interfaces/runtime_lookup.go
@@ -108,7 +108,7 @@ type CompletedDispatch struct {
 	SelectedClassificationLabel string                   `json:"selected_classification_label,omitempty"`
 	Reason                      string                   `json:"reason,omitempty"`
 	FailureMetadata             *WorkFailureMetadata     `json:"failure_metadata,omitempty"`
-	ProviderFailure             *ProviderFailureMetadata `json:"provider_failure,omitempty"`
+	ProviderFailure             *WorkFailureMetadata `json:"provider_failure,omitempty"`
 	ProviderSession             *ProviderSessionMetadata `json:"provider_session,omitempty"`
 	StartTime                   time.Time                `json:"start_time"`
 	EndTime                     time.Time                `json:"end_time"`

--- a/pkg/interfaces/safe_diagnostics.go
+++ b/pkg/interfaces/safe_diagnostics.go
@@ -100,12 +100,6 @@ func WorkDiagnosticsFromSafeWorkDiagnostics(diagnostics *SafeWorkDiagnostics) *W
 	return out
 }
 
-// GeneratedProviderFailureMetadata converts canonical provider-failure metadata
-// into the generated event contract.
-func GeneratedProviderFailureMetadata(failure *ProviderFailureMetadata) *factoryapi.ProviderFailureMetadata {
-	return GeneratedWorkFailureMetadata(failure)
-}
-
 // GeneratedWorkFailureMetadata converts canonical work-failure metadata into
 // the generated event contract.
 func GeneratedWorkFailureMetadata(failure *WorkFailureMetadata) *factoryapi.ProviderFailureMetadata {

--- a/pkg/interfaces/work_execution.go
+++ b/pkg/interfaces/work_execution.go
@@ -36,7 +36,7 @@ type WorkResult struct {
 	Feedback                    string                   `json:"feedback,omitempty"`
 	SelectedClassificationLabel string                   `json:"selected_classification_label,omitempty"`
 	FailureMetadata             *WorkFailureMetadata     `json:"failure_metadata,omitempty"`
-	ProviderFailure             *ProviderFailureMetadata `json:"provider_failure,omitempty"`
+	ProviderFailure             *WorkFailureMetadata `json:"provider_failure,omitempty"`
 	ProviderSession             *ProviderSessionMetadata `json:"provider_session,omitempty"`
 	Diagnostics                 *WorkDiagnostics         `json:"diagnostics,omitempty"`
 	Metrics                     WorkMetrics              `json:"metrics"`
@@ -124,16 +124,6 @@ const (
 	WorkFailureFamilyThrottle  WorkFailureFamily = "throttle"
 )
 
-// ProviderErrorFamily remains as a compatibility alias while runtime paths
-// transition to generalized work-failure naming.
-type ProviderErrorFamily = WorkFailureFamily
-
-const (
-	ProviderErrorFamilyTerminal  ProviderErrorFamily = WorkFailureFamilyTerminal
-	ProviderErrorFamilyRetryable ProviderErrorFamily = WorkFailureFamilyRetryable
-	ProviderErrorFamilyThrottle  ProviderErrorFamily = WorkFailureFamilyThrottle
-)
-
 // WorkFailureType is the stable customer-facing normalized failure type for
 // scoped runtime work execution paths.
 type WorkFailureType string
@@ -148,20 +138,6 @@ const (
 	WorkFailureTypeMisconfigured       WorkFailureType = "misconfigured"
 )
 
-// ProviderErrorType remains as a compatibility alias while runtime paths
-// transition to generalized work-failure naming.
-type ProviderErrorType = WorkFailureType
-
-const (
-	ProviderErrorTypeAuthFailure         ProviderErrorType = WorkFailureTypeAuthFailure
-	ProviderErrorTypePermanentBadRequest ProviderErrorType = WorkFailureTypePermanentBadRequest
-	ProviderErrorTypeThrottled           ProviderErrorType = WorkFailureTypeThrottled
-	ProviderErrorTypeInternalServerError ProviderErrorType = WorkFailureTypeInternalServerError
-	ProviderErrorTypeTimeout             ProviderErrorType = WorkFailureTypeTimeout
-	ProviderErrorTypeUnknown             ProviderErrorType = WorkFailureTypeUnknown
-	ProviderErrorTypeMisconfigured       ProviderErrorType = WorkFailureTypeMisconfigured
-)
-
 // WorkFailureDecision is the normalized behavior contract consumed by
 // downstream retry, termination, and throttle-pause logic.
 type WorkFailureDecision struct {
@@ -170,10 +146,6 @@ type WorkFailureDecision struct {
 	TriggersThrottlePause bool
 }
 
-// ProviderFailureDecision remains as a compatibility alias while runtime paths
-// transition to generalized work-failure naming.
-type ProviderFailureDecision = WorkFailureDecision
-
 // WorkFailureMetadata carries the normalized failure contract
 // across runtime boundaries after the original error has been rendered.
 type WorkFailureMetadata struct {
@@ -181,14 +153,10 @@ type WorkFailureMetadata struct {
 	Type   WorkFailureType   `json:"type"`
 }
 
-// ProviderFailureMetadata remains as a compatibility alias while runtime paths
-// transition to generalized work-failure naming.
-type ProviderFailureMetadata = WorkFailureMetadata
-
 // CanonicalWorkFailureMetadata returns the generalized failure metadata from
 // the runtime result, falling back to the legacy provider-named field while
 // older callers are still being migrated.
-func CanonicalWorkFailureMetadata(failure *WorkFailureMetadata, providerFailure *ProviderFailureMetadata) *WorkFailureMetadata {
+func CanonicalWorkFailureMetadata(failure *WorkFailureMetadata, providerFailure *WorkFailureMetadata) *WorkFailureMetadata {
 	if failure != nil {
 		return failure
 	}

--- a/pkg/interfaces/work_runtime_test.go
+++ b/pkg/interfaces/work_runtime_test.go
@@ -786,8 +786,8 @@ func TestCloneProviderMetadata_PreserveNilValuesAndDetachCopies(t *testing.T) {
 	if CloneProviderSessionMetadata(nil) != nil {
 		t.Fatal("CloneProviderSessionMetadata(nil) = non-nil, want nil")
 	}
-	if CloneProviderFailureMetadata(nil) != nil {
-		t.Fatal("CloneProviderFailureMetadata(nil) = non-nil, want nil")
+	if CloneWorkFailureMetadata(nil) != nil {
+		t.Fatal("CloneWorkFailureMetadata(nil) = non-nil, want nil")
 	}
 
 	session := &ProviderSessionMetadata{
@@ -801,14 +801,14 @@ func TestCloneProviderMetadata_PreserveNilValuesAndDetachCopies(t *testing.T) {
 		t.Fatalf("original provider session = %#v, want sess-1 unchanged", session)
 	}
 
-	failure := &ProviderFailureMetadata{
-		Family: ProviderErrorFamilyRetryable,
-		Type:   ProviderErrorTypeTimeout,
+	failure := &WorkFailureMetadata{
+		Family: WorkFailureFamilyRetryable,
+		Type:   WorkFailureTypeTimeout,
 	}
-	clonedFailure := CloneProviderFailureMetadata(failure)
-	clonedFailure.Family = ProviderErrorFamilyTerminal
-	clonedFailure.Type = ProviderErrorTypeInternalServerError
-	if failure.Family != ProviderErrorFamilyRetryable || failure.Type != ProviderErrorTypeTimeout {
+	clonedFailure := CloneWorkFailureMetadata(failure)
+	clonedFailure.Family = WorkFailureFamilyTerminal
+	clonedFailure.Type = WorkFailureTypeInternalServerError
+	if failure.Family != WorkFailureFamilyRetryable || failure.Type != WorkFailureTypeTimeout {
 		t.Fatalf("original provider failure = %#v, want retryable timeout unchanged", failure)
 	}
 }
@@ -832,9 +832,9 @@ func testFactoryWorldDispatchCompletion() FactoryWorldDispatchCompletion {
 		DispatchID: "dispatch-1",
 		Result: WorkstationResult{
 			Outcome: "FAILED",
-			ProviderFailure: &ProviderFailureMetadata{
-				Family: ProviderErrorFamilyRetryable,
-				Type:   ProviderErrorTypeTimeout,
+			ProviderFailure: &WorkFailureMetadata{
+				Family: WorkFailureFamilyRetryable,
+				Type:   WorkFailureTypeTimeout,
 			},
 		},
 		WorkItemIDs: []string{"work-1"},
@@ -879,7 +879,7 @@ func testFactoryWorldDispatchCompletion() FactoryWorldDispatchCompletion {
 }
 
 func mutateClonedDispatchCompletion(cloned FactoryWorldDispatchCompletion) {
-	cloned.Result.ProviderFailure.Family = ProviderErrorFamilyTerminal
+	cloned.Result.ProviderFailure.Family = WorkFailureFamilyTerminal
 	cloned.ProviderSession.ID = "sess-2"
 	cloned.Diagnostics.RenderedPrompt.Variables["prompt_source"] = "mutated"
 	cloned.Diagnostics.Provider.RequestMetadata["session_id"] = "sess-2"
@@ -893,7 +893,7 @@ func mutateClonedDispatchCompletion(cloned FactoryWorldDispatchCompletion) {
 func assertOriginalDispatchCompletionUnchanged(t *testing.T, original FactoryWorldDispatchCompletion) {
 	t.Helper()
 
-	if original.Result.ProviderFailure.Family != ProviderErrorFamilyRetryable {
+	if original.Result.ProviderFailure.Family != WorkFailureFamilyRetryable {
 		t.Fatalf("original provider failure = %#v, want retryable metadata unchanged", original.Result.ProviderFailure)
 	}
 	if original.ProviderSession.ID != "sess-1" {

--- a/pkg/interfaces/world_state_clones.go
+++ b/pkg/interfaces/world_state_clones.go
@@ -90,12 +90,6 @@ func CloneWorkFailureMetadata(failure *WorkFailureMetadata) *WorkFailureMetadata
 	return &clone
 }
 
-// CloneProviderFailureMetadata retains the legacy helper name while runtime
-// paths migrate to generalized failure metadata.
-func CloneProviderFailureMetadata(failure *ProviderFailureMetadata) *ProviderFailureMetadata {
-	return CloneWorkFailureMetadata(failure)
-}
-
 // CloneSafeWorkDiagnostics returns a detached copy of the canonical safe
 // diagnostics boundary.
 func CloneSafeWorkDiagnostics(diagnostics *SafeWorkDiagnostics) *SafeWorkDiagnostics {
@@ -114,7 +108,7 @@ func CloneFactoryWorldDispatchCompletion(completion FactoryWorldDispatchCompleti
 	clone := completion
 	failureMetadata := CanonicalWorkFailureMetadata(completion.Result.FailureMetadata, completion.Result.ProviderFailure)
 	clone.Result.FailureMetadata = CloneWorkFailureMetadata(failureMetadata)
-	clone.Result.ProviderFailure = CloneProviderFailureMetadata(failureMetadata)
+	clone.Result.ProviderFailure = CloneWorkFailureMetadata(failureMetadata)
 	clone.WorkItemIDs = cloneStringSlice(completion.WorkItemIDs)
 	clone.ConsumedInputs = cloneWorkstationInputs(completion.ConsumedInputs)
 	clone.InputWorkItems = cloneFactoryWorkItems(completion.InputWorkItems)

--- a/pkg/petri/inference_throttle_guard.go
+++ b/pkg/petri/inference_throttle_guard.go
@@ -59,7 +59,7 @@ func (g *InferenceThrottleGuard) ActivePauses(ctx RuntimeGuardContext) []interfa
 	for i := range ctx.DispatchHistory {
 		record := ctx.DispatchHistory[i]
 		failureMetadata := interfaces.CanonicalWorkFailureMetadata(record.FailureMetadata, record.ProviderFailure)
-		if failureMetadata == nil || failureMetadata.Family != interfaces.ProviderErrorFamilyThrottle {
+		if failureMetadata == nil || failureMetadata.Family != interfaces.WorkFailureFamilyThrottle {
 			continue
 		}
 		if !g.historyDispatchMatchesLane(ctx, record.TransitionID) {
@@ -70,7 +70,7 @@ func (g *InferenceThrottleGuard) ActivePauses(ctx RuntimeGuardContext) []interfa
 			Model:           g.Model,
 			OccurredAt:      record.EndTime,
 			FailureMetadata: interfaces.CloneWorkFailureMetadata(failureMetadata),
-			ProviderFailure: interfaces.CloneProviderFailureMetadata(failureMetadata),
+			ProviderFailure: interfaces.CloneWorkFailureMetadata(failureMetadata),
 		})
 	}
 	return factorythrottle.DeriveActiveThrottlePauses(history, g.RefreshWindow, ctx.Now)

--- a/pkg/petri/inference_throttle_guard_test.go
+++ b/pkg/petri/inference_throttle_guard_test.go
@@ -158,8 +158,8 @@ func completedThrottleFailure(dispatchID, transitionID string, endedAt time.Time
 		DispatchID:   dispatchID,
 		TransitionID: transitionID,
 		EndTime:      endedAt,
-		ProviderFailure: &interfaces.ProviderFailureMetadata{
-			Family: interfaces.ProviderErrorFamilyThrottle,
+		ProviderFailure: &interfaces.WorkFailureMetadata{
+			Family: interfaces.WorkFailureFamilyThrottle,
 		},
 	}
 }
@@ -169,8 +169,8 @@ func completedNonThrottleFailure(dispatchID, transitionID string, endedAt time.T
 		DispatchID:   dispatchID,
 		TransitionID: transitionID,
 		EndTime:      endedAt,
-		ProviderFailure: &interfaces.ProviderFailureMetadata{
-			Family: interfaces.ProviderErrorFamilyRetryable,
+		ProviderFailure: &interfaces.WorkFailureMetadata{
+			Family: interfaces.WorkFailureFamilyRetryable,
 		},
 	}
 }

--- a/pkg/replay/artifact_test.go
+++ b/pkg/replay/artifact_test.go
@@ -195,9 +195,9 @@ func safeDiagnosticsReplayArtifact(t *testing.T) *interfaces.ReplayArtifact {
 			TransitionID: "transition-safe",
 			Outcome:      interfaces.OutcomeAccepted,
 			Output:       "completed",
-			ProviderFailure: &interfaces.ProviderFailureMetadata{
-				Family: interfaces.ProviderErrorFamilyRetryable,
-				Type:   interfaces.ProviderErrorTypeThrottled,
+			ProviderFailure: &interfaces.WorkFailureMetadata{
+				Family: interfaces.WorkFailureFamilyRetryable,
+				Type:   interfaces.WorkFailureTypeThrottled,
 			},
 		}, 3),
 	)
@@ -254,7 +254,7 @@ func assertStoredReplayDiagnosticsAreSafe(t *testing.T, loaded *interfaces.Repla
 		t.Fatalf("provider session id = %q, want resp-safe-123", got)
 	}
 	completionPayload := requireReplayDispatchCompleted(t, loaded.Events, "dispatch-safe")
-	if got := stringValue(completionPayload.ProviderFailure.Type); got != string(interfaces.ProviderErrorTypeThrottled) {
+	if got := stringValue(completionPayload.ProviderFailure.Type); got != string(interfaces.WorkFailureTypeThrottled) {
 		t.Fatalf("provider failure type = %q, want throttled", got)
 	}
 }

--- a/pkg/replay/delivery.go
+++ b/pkg/replay/delivery.go
@@ -617,7 +617,7 @@ func cloneReplayPlannedResult(result interfaces.WorkResult) interfaces.WorkResul
 	}
 	failureMetadata := interfaces.CanonicalWorkFailureMetadata(result.FailureMetadata, result.ProviderFailure)
 	clone.FailureMetadata = interfaces.CloneWorkFailureMetadata(failureMetadata)
-	clone.ProviderFailure = interfaces.CloneProviderFailureMetadata(failureMetadata)
+	clone.ProviderFailure = interfaces.CloneWorkFailureMetadata(failureMetadata)
 	clone.ProviderSession = interfaces.CloneProviderSessionMetadata(result.ProviderSession)
 	clone.Diagnostics = interfaces.CloneWorkDiagnostics(result.Diagnostics)
 	return clone

--- a/pkg/replay/delivery_test.go
+++ b/pkg/replay/delivery_test.go
@@ -311,9 +311,9 @@ func TestCompletionDeliveryPlan_LateDispatchCreatedTickKeepsRelativeDelay(t *tes
 
 func TestCompletionDeliveryPlan_PlannedResultClonesProviderMetadata(t *testing.T) {
 	completion := replayTestCompletion("completion-1", "dispatch-1", "process", 3)
-	completion.ProviderFailure = &interfaces.ProviderFailureMetadata{
-		Family: interfaces.ProviderErrorFamilyRetryable,
-		Type:   interfaces.ProviderErrorTypeInternalServerError,
+	completion.ProviderFailure = &interfaces.WorkFailureMetadata{
+		Family: interfaces.WorkFailureFamilyRetryable,
+		Type:   interfaces.WorkFailureTypeInternalServerError,
 	}
 
 	plan, err := NewCompletionDeliveryPlan(deliveryArtifact(t,
@@ -333,7 +333,7 @@ func TestCompletionDeliveryPlan_PlannedResultClonesProviderMetadata(t *testing.T
 		t.Fatalf("delivery match = (%t, %d), want (true, 3)", ok, deliveryTick)
 	}
 
-	completion.ProviderFailure.Type = interfaces.ProviderErrorTypeAuthFailure
+	completion.ProviderFailure.Type = interfaces.WorkFailureTypeAuthFailure
 
 	planned, ok, err := plan.PlannedResultForDispatch(observed)
 	if err != nil {
@@ -342,7 +342,7 @@ func TestCompletionDeliveryPlan_PlannedResultClonesProviderMetadata(t *testing.T
 	if !ok {
 		t.Fatal("expected planned result for observed dispatch")
 	}
-	if planned.ProviderFailure == nil || planned.ProviderFailure.Type != interfaces.ProviderErrorTypeInternalServerError {
+	if planned.ProviderFailure == nil || planned.ProviderFailure.Type != interfaces.WorkFailureTypeInternalServerError {
 		t.Fatalf("planned provider failure = %#v, want detached internal_server_error metadata", planned.ProviderFailure)
 	}
 }

--- a/pkg/replay/event_log_test.go
+++ b/pkg/replay/event_log_test.go
@@ -127,7 +127,7 @@ func replayDispatchCompletedEvent(t *testing.T, completionID string, result inte
 		OutputWork:      generatedReplayOutputWorkPtr(result.RecordedOutputWork),
 		Error:           stringPtrIfNotEmpty(result.Error),
 		Feedback:        stringPtrIfNotEmpty(result.Feedback),
-		ProviderFailure: interfaces.GeneratedProviderFailureMetadata(result.ProviderFailure),
+		ProviderFailure: interfaces.GeneratedWorkFailureMetadata(result.ProviderFailure),
 		Metrics:         generatedWorkMetrics(result.Metrics),
 	}
 	var union factoryapi.FactoryEvent_Payload
@@ -372,9 +372,9 @@ func safeDiagnosticReductionArtifact(t *testing.T) *interfaces.ReplayArtifact {
 			TransitionID: "transition-safe",
 			Outcome:      interfaces.OutcomeAccepted,
 			Output:       "recorded provider output",
-			ProviderFailure: &interfaces.ProviderFailureMetadata{
-				Family: interfaces.ProviderErrorFamilyRetryable,
-				Type:   interfaces.ProviderErrorTypeThrottled,
+			ProviderFailure: &interfaces.WorkFailureMetadata{
+				Family: interfaces.WorkFailureFamilyRetryable,
+				Type:   interfaces.WorkFailureTypeThrottled,
 			},
 		}, 4),
 	)
@@ -417,7 +417,7 @@ func assertReducedCompletionSafeDiagnostics(t *testing.T, completion replayCompl
 	if completion.result.ProviderSession == nil || completion.result.ProviderSession.ID != "resp-safe-123" {
 		t.Fatalf("provider session = %#v, want resp-safe-123", completion.result.ProviderSession)
 	}
-	if completion.result.ProviderFailure == nil || completion.result.ProviderFailure.Type != interfaces.ProviderErrorTypeThrottled {
+	if completion.result.ProviderFailure == nil || completion.result.ProviderFailure.Type != interfaces.WorkFailureTypeThrottled {
 		t.Fatalf("provider failure = %#v, want throttled", completion.result.ProviderFailure)
 	}
 	if completion.result.Diagnostics == nil || completion.result.Diagnostics.Provider == nil || completion.result.Diagnostics.RenderedPrompt == nil {

--- a/pkg/replay/event_reducer.go
+++ b/pkg/replay/event_reducer.go
@@ -404,7 +404,7 @@ func replayCompletionFromEvent(event factoryapi.FactoryEvent, inference replayIn
 			SelectedClassificationLabel: stringValue(payload.SelectedClassificationLabel),
 			RecordedOutputWork:          recordedOutputWork,
 			FailureMetadata:             interfaces.CloneWorkFailureMetadata(failureMetadata),
-			ProviderFailure:             interfaces.CloneProviderFailureMetadata(failureMetadata),
+			ProviderFailure:             interfaces.CloneWorkFailureMetadata(failureMetadata),
 			ProviderSession:             interfaces.CloneProviderSessionMetadata(inference.providerSession),
 			Metrics:                     replayWorkMetricsFromGenerated(payload.Metrics),
 			Diagnostics:                 diagnostics,

--- a/pkg/service/factory_dashboard_test.go
+++ b/pkg/service/factory_dashboard_test.go
@@ -77,7 +77,7 @@ func TestFactoryService_SimpleDashboardRenderInputUsesRenderData(t *testing.T) {
 	submitDashboardWorldViewWork(t, svc, "dashboard-world-failed", "trace-dashboard-failed")
 	provider.nextDispatch(t)
 	provider.respond(interfaces.InferenceResponse{}, workers.NewProviderErrorWithSession(
-		interfaces.ProviderErrorTypePermanentBadRequest,
+		interfaces.WorkFailureTypePermanentBadRequest,
 		"provider rejected dashboard world-view work",
 		errors.New("provider rejected"),
 		&interfaces.ProviderSessionMetadata{

--- a/pkg/service/factory_test_helpers_test.go
+++ b/pkg/service/factory_test_helpers_test.go
@@ -841,8 +841,8 @@ func serviceDispatchRequestMetadata(values map[string]string) *factoryapi.Dispat
 	}
 }
 
-func serviceProviderFailurePtr(failure *interfaces.ProviderFailureMetadata) *factoryapi.ProviderFailureMetadata {
-	return interfaces.GeneratedProviderFailureMetadata(failure)
+func serviceProviderFailurePtr(failure *interfaces.WorkFailureMetadata) *factoryapi.ProviderFailureMetadata {
+	return interfaces.GeneratedWorkFailureMetadata(failure)
 }
 
 func serviceWorkMetricsPtr(metrics interfaces.WorkMetrics) *factoryapi.WorkMetrics {

--- a/pkg/service/poller_watcher.go
+++ b/pkg/service/poller_watcher.go
@@ -748,28 +748,28 @@ func (fs *FactoryService) cronExecutionTimeout(
 }
 
 type cronTriggerFailure struct {
-	Family    interfaces.ProviderErrorFamily
-	Type      interfaces.ProviderErrorType
+	Family    interfaces.WorkFailureFamily
+	Type      interfaces.WorkFailureType
 	retryable bool
 }
 
 func classifyCronTriggerFailure(err error) cronTriggerFailure {
 	if errors.Is(err, context.DeadlineExceeded) {
 		return cronTriggerFailure{
-			Family:    interfaces.ProviderErrorFamilyRetryable,
-			Type:      interfaces.ProviderErrorTypeTimeout,
+			Family:    interfaces.WorkFailureFamilyRetryable,
+			Type:      interfaces.WorkFailureTypeTimeout,
 			retryable: true,
 		}
 	}
 	if errors.Is(err, context.Canceled) {
 		return cronTriggerFailure{
-			Family: interfaces.ProviderErrorFamilyTerminal,
-			Type:   interfaces.ProviderErrorTypeUnknown,
+			Family: interfaces.WorkFailureFamilyTerminal,
+			Type:   interfaces.WorkFailureTypeUnknown,
 		}
 	}
 	return cronTriggerFailure{
-		Family:    interfaces.ProviderErrorFamilyRetryable,
-		Type:      interfaces.ProviderErrorTypeInternalServerError,
+		Family:    interfaces.WorkFailureFamilyRetryable,
+		Type:      interfaces.WorkFailureTypeInternalServerError,
 		retryable: true,
 	}
 }

--- a/pkg/service/poller_watcher_test.go
+++ b/pkg/service/poller_watcher_test.go
@@ -1042,7 +1042,7 @@ func TestFactoryService_CronTickTimeoutFailureIsClassifiedAndBounded(t *testing.
 	}
 
 	failure := classifyCronTriggerFailure(err)
-	if !failure.retryable || failure.Family != interfaces.ProviderErrorFamilyRetryable || failure.Type != interfaces.ProviderErrorTypeTimeout {
+	if !failure.retryable || failure.Family != interfaces.WorkFailureFamilyRetryable || failure.Type != interfaces.WorkFailureTypeTimeout {
 		t.Fatalf("cron timeout classification = %#v, want retryable timeout", failure)
 	}
 }

--- a/pkg/service/replaytests/factory_replay_test.go
+++ b/pkg/service/replaytests/factory_replay_test.go
@@ -696,8 +696,8 @@ func serviceDispatchRequestMetadata(values map[string]string) *factoryapi.Dispat
 	}
 }
 
-func serviceProviderFailurePtr(failure *interfaces.ProviderFailureMetadata) *factoryapi.ProviderFailureMetadata {
-	return interfaces.GeneratedProviderFailureMetadata(failure)
+func serviceProviderFailurePtr(failure *interfaces.WorkFailureMetadata) *factoryapi.ProviderFailureMetadata {
+	return interfaces.GeneratedWorkFailureMetadata(failure)
 }
 
 func serviceWorkMetricsPtr(metrics interfaces.WorkMetrics) *factoryapi.WorkMetrics {

--- a/pkg/workers/executor/agent.go
+++ b/pkg/workers/executor/agent.go
@@ -106,7 +106,7 @@ func inferenceErrorWorkResult(dispatch interfaces.WorkDispatch, err error, diagn
 		Outcome:         interfaces.OutcomeFailed,
 		Error:           formatAgentProviderError(err),
 		FailureMetadata: interfaces.CloneWorkFailureMetadata(failureMetadata),
-		ProviderFailure: interfaces.CloneProviderFailureMetadata(failureMetadata),
+		ProviderFailure: interfaces.CloneWorkFailureMetadata(failureMetadata),
 		ProviderSession: providerSessionFromError(providerErr),
 		Diagnostics:     mergeWorkDiagnostics(withInferenceErrorDiagnostics(diagnostics, err, retryCount), providerDiagnosticsFromError(providerErr)),
 		Metrics:         agentWorkMetrics(start, retryCount),
@@ -252,7 +252,7 @@ func formatAgentProviderError(err error) string {
 	var providerErr *workerprovider.ProviderError
 	if errors.As(err, &providerErr) {
 		message := strings.TrimSpace(providerErr.Message)
-		if providerErr.Type == interfaces.ProviderErrorTypeTimeout && message == "execution timeout" {
+		if providerErr.Type == interfaces.WorkFailureTypeTimeout && message == "execution timeout" {
 			return message
 		}
 		if message != "" {
@@ -339,7 +339,7 @@ func RunnerFromProvider(provider Provider) Runner {
 func (a providerRunnerAdapter) Execute(ctx context.Context, request interfaces.RunnerExecutionRequest) (interfaces.RunnerExecutionResult, error) {
 	if a.inner == nil {
 		return interfaces.RunnerExecutionResult{}, workerprovider.NewProviderError(
-			interfaces.ProviderErrorTypeMisconfigured,
+			interfaces.WorkFailureTypeMisconfigured,
 			"runner requires a provider implementation",
 			nil,
 		)

--- a/pkg/workers/executor/agent_test.go
+++ b/pkg/workers/executor/agent_test.go
@@ -330,7 +330,7 @@ func TestAgentExecutor_ErrorDiagnosticsStayDetachedFromProviderMutation(t *testi
 		Metadata: map[string]string{"phase": "initial"},
 	}
 	provider := &agentMockProvider{
-		err: workerprovider.NewProviderError(interfaces.ProviderErrorTypeInternalServerError, "provider 500", nil),
+		err: workerprovider.NewProviderError(interfaces.WorkFailureTypeInternalServerError, "provider 500", nil),
 	}
 	var providerErr *ProviderError
 	if !errors.As(provider.err, &providerErr) {
@@ -623,8 +623,8 @@ func TestAgentExecutor_SuccessfulResponse_PreservesProviderSession(t *testing.T)
 func TestAgentExecutor_RetryableProviderError_RetriesTwiceBeforeSuccess(t *testing.T) {
 	provider := &agentMockProvider{
 		errors: []error{
-			workerprovider.NewProviderError(interfaces.ProviderErrorTypeInternalServerError, "provider 500", nil),
-			workerprovider.NewProviderError(interfaces.ProviderErrorTypeTimeout, "provider timeout", nil),
+			workerprovider.NewProviderError(interfaces.WorkFailureTypeInternalServerError, "provider 500", nil),
+			workerprovider.NewProviderError(interfaces.WorkFailureTypeTimeout, "provider timeout", nil),
 			nil,
 		},
 		responses: []interfaces.InferenceResponse{
@@ -737,15 +737,15 @@ func TestAgentExecutor_CodexWindowsExitCode4294967295_RetriesAndReturnsRetryable
 	if result.ProviderFailure == nil {
 		t.Fatal("expected provider failure metadata on failed result")
 	}
-	if result.ProviderFailure.Type != interfaces.ProviderErrorTypeInternalServerError {
-		t.Fatalf("provider failure type = %q, want %q", result.ProviderFailure.Type, interfaces.ProviderErrorTypeInternalServerError)
+	if result.ProviderFailure.Type != interfaces.WorkFailureTypeInternalServerError {
+		t.Fatalf("provider failure type = %q, want %q", result.ProviderFailure.Type, interfaces.WorkFailureTypeInternalServerError)
 	}
-	if result.ProviderFailure.Family != interfaces.ProviderErrorFamilyRetryable {
-		t.Fatalf("provider failure family = %q, want %q", result.ProviderFailure.Family, interfaces.ProviderErrorFamilyRetryable)
+	if result.ProviderFailure.Family != interfaces.WorkFailureFamilyRetryable {
+		t.Fatalf("provider failure family = %q, want %q", result.ProviderFailure.Family, interfaces.WorkFailureFamilyRetryable)
 	}
-	decision := workerprovider.ProviderFailureDecisionFromMetadata(result.ProviderFailure)
+	decision := workerprovider.WorkFailureDecisionFromMetadata(result.ProviderFailure)
 	if !decision.Retryable || decision.Terminal || decision.TriggersThrottlePause {
-		t.Fatalf("ProviderFailureDecisionFromMetadata(%#v) = %#v, want retryable non-terminal non-throttle", result.ProviderFailure, decision)
+		t.Fatalf("WorkFailureDecisionFromMetadata(%#v) = %#v, want retryable non-terminal non-throttle", result.ProviderFailure, decision)
 	}
 	if result.ProviderSession == nil {
 		t.Fatal("expected provider session metadata on failed result")
@@ -759,7 +759,7 @@ func TestAgentExecutor_TerminalProviderError_DoesNotRetry(t *testing.T) {
 	provider := &agentMockProvider{
 		errors: []error{
 			workerprovider.NewProviderErrorWithSession(
-				interfaces.ProviderErrorTypeAuthFailure,
+				interfaces.WorkFailureTypeAuthFailure,
 				"auth failed",
 				nil,
 				&interfaces.ProviderSessionMetadata{
@@ -821,7 +821,7 @@ func TestAgentExecutor_ClaudeProviderError_PreservesConfiguredSessionID(t *testi
 	provider := &agentMockProvider{
 		errors: []error{
 			workerprovider.NewProviderErrorWithSession(
-				interfaces.ProviderErrorTypeAuthFailure,
+				interfaces.WorkFailureTypeAuthFailure,
 				"auth failed",
 				nil,
 				&interfaces.ProviderSessionMetadata{
@@ -973,10 +973,10 @@ func TestAgentExecutor_RawDeadlineExceeded_ExhaustsRetriesIntoStructuredTimeoutF
 	if result.ProviderFailure == nil {
 		t.Fatal("ProviderFailure = nil, want timeout metadata")
 	}
-	if result.ProviderFailure.Type != interfaces.ProviderErrorTypeTimeout {
-		t.Fatalf("ProviderFailure.Type = %q, want %q", result.ProviderFailure.Type, interfaces.ProviderErrorTypeTimeout)
+	if result.ProviderFailure.Type != interfaces.WorkFailureTypeTimeout {
+		t.Fatalf("ProviderFailure.Type = %q, want %q", result.ProviderFailure.Type, interfaces.WorkFailureTypeTimeout)
 	}
-	if result.ProviderFailure.Family != interfaces.ProviderErrorFamilyRetryable {
-		t.Fatalf("ProviderFailure.Family = %q, want %q", result.ProviderFailure.Family, interfaces.ProviderErrorFamilyRetryable)
+	if result.ProviderFailure.Family != interfaces.WorkFailureFamilyRetryable {
+		t.Fatalf("ProviderFailure.Family = %q, want %q", result.ProviderFailure.Family, interfaces.WorkFailureFamilyRetryable)
 	}
 }

--- a/pkg/workers/executor/script_test.go
+++ b/pkg/workers/executor/script_test.go
@@ -166,7 +166,7 @@ func TestScriptExecutor_CancellationReturnsFailedResult(t *testing.T) {
 	if result.FailureMetadata == nil || result.FailureMetadata.Type != interfaces.WorkFailureTypeTimeout {
 		t.Fatalf("FailureMetadata = %#v, want timeout metadata", result.FailureMetadata)
 	}
-	if result.ProviderFailure == nil || result.ProviderFailure.Type != interfaces.ProviderErrorTypeTimeout {
+	if result.ProviderFailure == nil || result.ProviderFailure.Type != interfaces.WorkFailureTypeTimeout {
 		t.Fatalf("ProviderFailure = %#v, want timeout metadata", result.ProviderFailure)
 	}
 }
@@ -832,7 +832,7 @@ func TestScriptExecutor_TimeoutStopsProcessBeforeItCanFinish(t *testing.T) {
 	if result.FailureMetadata == nil || result.FailureMetadata.Type != interfaces.WorkFailureTypeTimeout {
 		t.Fatalf("FailureMetadata = %#v, want timeout metadata", result.FailureMetadata)
 	}
-	if result.ProviderFailure == nil || result.ProviderFailure.Type != interfaces.ProviderErrorTypeTimeout {
+	if result.ProviderFailure == nil || result.ProviderFailure.Type != interfaces.WorkFailureTypeTimeout {
 		t.Fatalf("ProviderFailure = %#v, want timeout metadata", result.ProviderFailure)
 	}
 

--- a/pkg/workers/executor/workstation/workstation_executor_timeout_test.go
+++ b/pkg/workers/executor/workstation/workstation_executor_timeout_test.go
@@ -78,7 +78,7 @@ func TestWorkstationExecutor_AppliesWorkstationExecutionTimeout(t *testing.T) {
 	if result.FailureMetadata == nil || result.FailureMetadata.Type != interfaces.WorkFailureTypeTimeout {
 		t.Fatalf("FailureMetadata = %#v, want timeout metadata", result.FailureMetadata)
 	}
-	if result.ProviderFailure == nil || result.ProviderFailure.Type != interfaces.ProviderErrorTypeTimeout {
+	if result.ProviderFailure == nil || result.ProviderFailure.Type != interfaces.WorkFailureTypeTimeout {
 		t.Fatalf("ProviderFailure = %#v, want timeout metadata", result.ProviderFailure)
 	}
 }
@@ -447,7 +447,7 @@ func TestWorkstationExecutor_ModelWorkerTimeoutCancelsLongRunningExecutor(t *tes
 	if result.Error != "execution timeout" {
 		t.Fatalf("Error = %q, want execution timeout", result.Error)
 	}
-	if result.ProviderFailure == nil || result.ProviderFailure.Type != interfaces.ProviderErrorTypeTimeout {
+	if result.ProviderFailure == nil || result.ProviderFailure.Type != interfaces.WorkFailureTypeTimeout {
 		t.Fatalf("ProviderFailure = %#v, want timeout metadata", result.ProviderFailure)
 	}
 }

--- a/pkg/workers/executor/workstation_executor.go
+++ b/pkg/workers/executor/workstation_executor.go
@@ -566,7 +566,7 @@ func timeoutWorkResult(dispatch interfaces.WorkDispatch, duration time.Duration)
 		Outcome:         interfaces.OutcomeFailed,
 		Error:           "execution timeout",
 		FailureMetadata: interfaces.CloneWorkFailureMetadata(failureMetadata),
-		ProviderFailure: interfaces.CloneProviderFailureMetadata(failureMetadata),
+		ProviderFailure: interfaces.CloneWorkFailureMetadata(failureMetadata),
 		Metrics:         interfaces.WorkMetrics{Duration: duration},
 	}
 }

--- a/pkg/workers/provider/inference_provider.go
+++ b/pkg/workers/provider/inference_provider.go
@@ -171,7 +171,7 @@ func (p *ScriptWrapProvider) Execute(ctx context.Context, req interfaces.RunnerE
 				"dispatcher", string(req.ModelProvider),
 				"error", err.Error())...)
 		return interfaces.InferenceResponse{}, newProviderErrorWithDiagnostics(
-			interfaces.ProviderErrorTypePermanentBadRequest,
+			interfaces.WorkFailureTypePermanentBadRequest,
 			err.Error(),
 			err,
 			nil,
@@ -256,17 +256,17 @@ func normalizeProviderExecutionError(provider string, result CommandResult, err 
 			diagnostics.Command.TimedOut = true
 		}
 		message := formatProviderTimeoutFailure(provider, result)
-		return newProviderErrorWithDiagnostics(interfaces.ProviderErrorTypeTimeout, message, err, session, diagnostics)
+		return newProviderErrorWithDiagnostics(interfaces.WorkFailureTypeTimeout, message, err, session, diagnostics)
 	case errors.Is(err, exec.ErrNotFound):
 		message := formatProviderCommandFailure(provider, result, err)
-		return newProviderErrorWithDiagnostics(interfaces.ProviderErrorTypeMisconfigured, message, err, session, diagnostics)
+		return newProviderErrorWithDiagnostics(interfaces.WorkFailureTypeMisconfigured, message, err, session, diagnostics)
 	default:
 		message := formatProviderCommandFailure(provider, result, err)
 		var execErr *exec.Error
 		if errors.As(err, &execErr) {
-			return newProviderErrorWithDiagnostics(interfaces.ProviderErrorTypeMisconfigured, message, err, session, diagnostics)
+			return newProviderErrorWithDiagnostics(interfaces.WorkFailureTypeMisconfigured, message, err, session, diagnostics)
 		}
-		return newProviderErrorWithDiagnostics(interfaces.ProviderErrorTypeUnknown, message, err, session, diagnostics)
+		return newProviderErrorWithDiagnostics(interfaces.WorkFailureTypeUnknown, message, err, session, diagnostics)
 	}
 }
 
@@ -282,7 +282,7 @@ func NormalizeProviderExitFailure(provider string, result CommandResult, session
 	return normalizeProviderExitFailure(provider, result, session, diagnostics)
 }
 
-func classifyProviderExitFailure(provider string, result CommandResult) interfaces.ProviderErrorType {
+func classifyProviderExitFailure(provider string, result CommandResult) interfaces.WorkFailureType {
 	return providerBehaviorForErrorClassification(provider).ClassifyExitFailure(result)
 }
 

--- a/pkg/workers/provider/inference_provider_error_normalization_test.go
+++ b/pkg/workers/provider/inference_provider_error_normalization_test.go
@@ -53,8 +53,8 @@ func TestScriptWrapProvider_Infer_CodexExitFailuresNormalizeIntoSharedContract(t
 				Name:           "codex_unknown_unclassified",
 				ExitCode:       1,
 				Stderr:         `some brand new failure`,
-				ExpectedType:   interfaces.ProviderErrorTypeUnknown,
-				ExpectedFamily: interfaces.ProviderErrorFamilyTerminal,
+				ExpectedType:   interfaces.WorkFailureTypeUnknown,
+				ExpectedFamily: interfaces.WorkFailureFamilyTerminal,
 			},
 		},
 	}
@@ -94,7 +94,7 @@ func TestScriptWrapProvider_Infer_CodexExitFailuresNormalizeIntoSharedContract(t
 			if decision.TriggersThrottlePause != tc.entry.TriggersThrottlePause {
 				t.Fatalf("%s TriggersThrottlePause = %t, want %t", entryLabel, decision.TriggersThrottlePause, tc.entry.TriggersThrottlePause)
 			}
-			wantTerminal := tc.entry.ExpectedFamily == interfaces.ProviderErrorFamilyTerminal
+			wantTerminal := tc.entry.ExpectedFamily == interfaces.WorkFailureFamilyTerminal
 			if decision.Terminal != wantTerminal {
 				t.Fatalf("%s Terminal = %t, want %t", entryLabel, decision.Terminal, wantTerminal)
 			}
@@ -106,8 +106,8 @@ func TestScriptWrapProvider_Infer_CodexNormalizedRetryDecisionRegressions(t *tes
 	testCases := []struct {
 		name              string
 		stderr            string
-		wantType          interfaces.ProviderErrorType
-		wantFamily        interfaces.ProviderErrorFamily
+		wantType          interfaces.WorkFailureType
+		wantFamily        interfaces.WorkFailureFamily
 		wantRetryable     bool
 		wantTerminal      bool
 		wantThrottlePause bool
@@ -115,8 +115,8 @@ func TestScriptWrapProvider_Infer_CodexNormalizedRetryDecisionRegressions(t *tes
 		{
 			name:              "InternalServerError_HighDemandTemporaryErrors_RetriesWithoutThrottlePause",
 			stderr:            `ERROR: We're currently experiencing high demand, which may cause temporary errors.`,
-			wantType:          interfaces.ProviderErrorTypeInternalServerError,
-			wantFamily:        interfaces.ProviderErrorFamilyRetryable,
+			wantType:          interfaces.WorkFailureTypeInternalServerError,
+			wantFamily:        interfaces.WorkFailureFamilyRetryable,
 			wantRetryable:     true,
 			wantTerminal:      false,
 			wantThrottlePause: false,
@@ -124,8 +124,8 @@ func TestScriptWrapProvider_Infer_CodexNormalizedRetryDecisionRegressions(t *tes
 		{
 			name:              "InternalServerError_UnexpectedStatus500_RetriesWithoutThrottlePause",
 			stderr:            `ERROR: unexpected status 500 Internal Server Error`,
-			wantType:          interfaces.ProviderErrorTypeInternalServerError,
-			wantFamily:        interfaces.ProviderErrorFamilyRetryable,
+			wantType:          interfaces.WorkFailureTypeInternalServerError,
+			wantFamily:        interfaces.WorkFailureFamilyRetryable,
 			wantRetryable:     true,
 			wantTerminal:      false,
 			wantThrottlePause: false,
@@ -133,8 +133,8 @@ func TestScriptWrapProvider_Infer_CodexNormalizedRetryDecisionRegressions(t *tes
 		{
 			name:              "AuthFailure_UnexpectedStatus401_IsTerminal",
 			stderr:            `ERROR: unexpected status 401 Unauthorized {"type":"authentication_error","message":"invalid api key"}`,
-			wantType:          interfaces.ProviderErrorTypeAuthFailure,
-			wantFamily:        interfaces.ProviderErrorFamilyTerminal,
+			wantType:          interfaces.WorkFailureTypeAuthFailure,
+			wantFamily:        interfaces.WorkFailureFamilyTerminal,
 			wantRetryable:     false,
 			wantTerminal:      true,
 			wantThrottlePause: false,
@@ -142,8 +142,8 @@ func TestScriptWrapProvider_Infer_CodexNormalizedRetryDecisionRegressions(t *tes
 		{
 			name:              "PermanentBadRequest_UnexpectedStatus400_IsTerminal",
 			stderr:            `ERROR: unexpected status 400 Bad Request {"type":"invalid_request_error","message":"bad request"}`,
-			wantType:          interfaces.ProviderErrorTypePermanentBadRequest,
-			wantFamily:        interfaces.ProviderErrorFamilyTerminal,
+			wantType:          interfaces.WorkFailureTypePermanentBadRequest,
+			wantFamily:        interfaces.WorkFailureFamilyTerminal,
 			wantRetryable:     false,
 			wantTerminal:      true,
 			wantThrottlePause: false,
@@ -175,21 +175,21 @@ func TestScriptWrapProvider_Infer_CodexNormalizedRetryDecisionRegressions(t *tes
 func TestScriptWrapProvider_Infer_CodexWindowsCorpusEntryRemainsDistinctFromAuthFailure(t *testing.T) {
 	testCases := []struct {
 		entryName          string
-		wantType           interfaces.ProviderErrorType
+		wantType           interfaces.WorkFailureType
 		wantRetryable      bool
 		wantThrottlePause  bool
 		wantRejectAuthType bool
 	}{
 		{
 			entryName:          "codex_windows_exit_code_4294967295",
-			wantType:           interfaces.ProviderErrorTypeInternalServerError,
+			wantType:           interfaces.WorkFailureTypeInternalServerError,
 			wantRetryable:      true,
 			wantThrottlePause:  false,
 			wantRejectAuthType: true,
 		},
 		{
 			entryName:         "codex_authentication_unauthorized",
-			wantType:          interfaces.ProviderErrorTypeAuthFailure,
+			wantType:          interfaces.WorkFailureTypeAuthFailure,
 			wantRetryable:     false,
 			wantThrottlePause: false,
 		},
@@ -217,7 +217,7 @@ func TestScriptWrapProvider_Infer_CodexWindowsCorpusEntryRemainsDistinctFromAuth
 			if providerErr.Type != tc.wantType {
 				t.Fatalf("%s Type = %q, want %q", providerErrorCorpusEntryLabel(entry), providerErr.Type, tc.wantType)
 			}
-			if tc.wantRejectAuthType && providerErr.Type == interfaces.ProviderErrorTypeAuthFailure {
+			if tc.wantRejectAuthType && providerErr.Type == interfaces.WorkFailureTypeAuthFailure {
 				t.Fatalf("%s Type = %q, want non-auth retryable failure", providerErrorCorpusEntryLabel(entry), providerErr.Type)
 			}
 
@@ -236,8 +236,8 @@ func TestScriptWrapProvider_Infer_CodexWindowsExitCode4294967295Normalization(t 
 	testCases := []struct {
 		name              string
 		result            CommandResult
-		wantType          interfaces.ProviderErrorType
-		wantFamily        interfaces.ProviderErrorFamily
+		wantType          interfaces.WorkFailureType
+		wantFamily        interfaces.WorkFailureFamily
 		wantMessage       string
 		wantRetryable     bool
 		wantTerminal      bool
@@ -253,8 +253,8 @@ func TestScriptWrapProvider_Infer_CodexWindowsExitCode4294967295Normalization(t 
 					"provider: openai",
 				}, "\n")),
 			},
-			wantType:          interfaces.ProviderErrorTypeInternalServerError,
-			wantFamily:        interfaces.ProviderErrorFamilyRetryable,
+			wantType:          interfaces.WorkFailureTypeInternalServerError,
+			wantFamily:        interfaces.WorkFailureFamilyRetryable,
 			wantMessage:       "codex exited with code 4294967295",
 			wantRetryable:     true,
 			wantTerminal:      false,
@@ -266,8 +266,8 @@ func TestScriptWrapProvider_Infer_CodexWindowsExitCode4294967295Normalization(t 
 				ExitCode: codexWindowsProcessFailureExitCode,
 				Stderr:   []byte(`ERROR: unexpected status 401 Unauthorized {"type":"authentication_error","message":"invalid api key"}`),
 			},
-			wantType:          interfaces.ProviderErrorTypeAuthFailure,
-			wantFamily:        interfaces.ProviderErrorFamilyTerminal,
+			wantType:          interfaces.WorkFailureTypeAuthFailure,
+			wantFamily:        interfaces.WorkFailureFamilyTerminal,
 			wantMessage:       `ERROR: unexpected status 401 Unauthorized {"type":"authentication_error","message":"invalid api key"}`,
 			wantRetryable:     false,
 			wantTerminal:      true,
@@ -371,8 +371,8 @@ func TestScriptWrapProvider_Infer_KnownCodexErrorLinesMapToProviderFailureCatego
 	testCases := []struct {
 		name                 string
 		result               CommandResult
-		wantType             interfaces.ProviderErrorType
-		wantFamily           interfaces.ProviderErrorFamily
+		wantType             interfaces.WorkFailureType
+		wantFamily           interfaces.WorkFailureFamily
 		wantMessage          string
 		wantRetryable        bool
 		wantTerminal         bool
@@ -385,8 +385,8 @@ func TestScriptWrapProvider_Infer_KnownCodexErrorLinesMapToProviderFailureCatego
 				ExitCode: 1,
 				Stdout:   capacityEntry.CommandResult().Stdout,
 			},
-			wantType:             interfaces.ProviderErrorTypeThrottled,
-			wantFamily:           interfaces.ProviderErrorFamilyThrottle,
+			wantType:             interfaces.WorkFailureTypeThrottled,
+			wantFamily:           interfaces.WorkFailureFamilyThrottle,
 			wantMessage:          capacityLine,
 			wantRetryable:        true,
 			wantThrottlePause:    true,
@@ -398,8 +398,8 @@ func TestScriptWrapProvider_Infer_KnownCodexErrorLinesMapToProviderFailureCatego
 				ExitCode: 1,
 				Stderr:   []byte("ERROR: command timed out while waiting for codex"),
 			},
-			wantType:      interfaces.ProviderErrorTypeTimeout,
-			wantFamily:    interfaces.ProviderErrorFamilyRetryable,
+			wantType:      interfaces.WorkFailureTypeTimeout,
+			wantFamily:    interfaces.WorkFailureFamilyRetryable,
 			wantMessage:   "ERROR: command timed out while waiting for codex",
 			wantRetryable: true,
 		},
@@ -409,8 +409,8 @@ func TestScriptWrapProvider_Infer_KnownCodexErrorLinesMapToProviderFailureCatego
 				ExitCode: 1,
 				Stdout:   []byte("ERROR: context deadline exceeded"),
 			},
-			wantType:      interfaces.ProviderErrorTypeTimeout,
-			wantFamily:    interfaces.ProviderErrorFamilyRetryable,
+			wantType:      interfaces.WorkFailureTypeTimeout,
+			wantFamily:    interfaces.WorkFailureFamilyRetryable,
 			wantMessage:   "ERROR: context deadline exceeded",
 			wantRetryable: true,
 		},
@@ -420,8 +420,8 @@ func TestScriptWrapProvider_Infer_KnownCodexErrorLinesMapToProviderFailureCatego
 				ExitCode: 1,
 				Stderr:   []byte("ERROR: The process with PID 1234 could not be terminated"),
 			},
-			wantType:          interfaces.ProviderErrorTypeUnknown,
-			wantFamily:        interfaces.ProviderErrorFamilyTerminal,
+			wantType:          interfaces.WorkFailureTypeUnknown,
+			wantFamily:        interfaces.WorkFailureFamilyTerminal,
 			wantMessage:       "ERROR: The process with PID 1234 could not be terminated",
 			wantTerminal:      true,
 			wantThrottlePause: false,
@@ -433,8 +433,8 @@ func TestScriptWrapProvider_Infer_KnownCodexErrorLinesMapToProviderFailureCatego
 				Stderr:   []byte(capacityLine),
 				Stdout:   []byte("request failed with 400 bad request after full transcript"),
 			},
-			wantType:             interfaces.ProviderErrorTypeThrottled,
-			wantFamily:           interfaces.ProviderErrorFamilyThrottle,
+			wantType:             interfaces.WorkFailureTypeThrottled,
+			wantFamily:           interfaces.WorkFailureFamilyThrottle,
 			wantMessage:          capacityLine,
 			wantRetryable:        true,
 			wantThrottlePause:    true,
@@ -561,8 +561,8 @@ func TestScriptWrapProvider_Infer_ClaudeExitFailuresNormalizeIntoSharedContract(
 				Name:           "claude_unknown_unclassified",
 				ExitCode:       1,
 				Stderr:         `some brand new claude failure`,
-				ExpectedType:   interfaces.ProviderErrorTypeUnknown,
-				ExpectedFamily: interfaces.ProviderErrorFamilyTerminal,
+				ExpectedType:   interfaces.WorkFailureTypeUnknown,
+				ExpectedFamily: interfaces.WorkFailureFamilyTerminal,
 			},
 		},
 	}
@@ -604,16 +604,16 @@ func TestScriptWrapProvider_Infer_RunErrorsNormalizeTimeoutAndMisconfigured(t *t
 		name        string
 		result      CommandResult
 		runErr      error
-		wantType    interfaces.ProviderErrorType
-		wantFamily  interfaces.ProviderErrorFamily
+		wantType    interfaces.WorkFailureType
+		wantFamily  interfaces.WorkFailureFamily
 		wantMessage string
 		rejectText  string
 	}{
 		{
 			name:        "DeadlineExceeded_IsTimeout",
 			runErr:      context.DeadlineExceeded,
-			wantType:    interfaces.ProviderErrorTypeTimeout,
-			wantFamily:  interfaces.ProviderErrorFamilyRetryable,
+			wantType:    interfaces.WorkFailureTypeTimeout,
+			wantFamily:  interfaces.WorkFailureFamilyRetryable,
 			wantMessage: "execution timeout",
 		},
 		{
@@ -622,8 +622,8 @@ func TestScriptWrapProvider_Infer_RunErrorsNormalizeTimeoutAndMisconfigured(t *t
 				Stderr: []byte("context canceled after command timed out"),
 			},
 			runErr:      context.Canceled,
-			wantType:    interfaces.ProviderErrorTypeTimeout,
-			wantFamily:  interfaces.ProviderErrorFamilyRetryable,
+			wantType:    interfaces.WorkFailureTypeTimeout,
+			wantFamily:  interfaces.WorkFailureFamilyRetryable,
 			wantMessage: "context canceled after command timed out",
 		},
 		{
@@ -637,8 +637,8 @@ func TestScriptWrapProvider_Infer_RunErrorsNormalizeTimeoutAndMisconfigured(t *t
 				}, "\n")),
 			},
 			runErr:      context.DeadlineExceeded,
-			wantType:    interfaces.ProviderErrorTypeTimeout,
-			wantFamily:  interfaces.ProviderErrorFamilyRetryable,
+			wantType:    interfaces.WorkFailureTypeTimeout,
+			wantFamily:  interfaces.WorkFailureFamilyRetryable,
 			wantMessage: capacityLine,
 			rejectText:  "raw inference transcript",
 		},
@@ -653,22 +653,22 @@ func TestScriptWrapProvider_Infer_RunErrorsNormalizeTimeoutAndMisconfigured(t *t
 				}, "\n")),
 			},
 			runErr:      context.Canceled,
-			wantType:    interfaces.ProviderErrorTypeTimeout,
-			wantFamily:  interfaces.ProviderErrorFamilyRetryable,
+			wantType:    interfaces.WorkFailureTypeTimeout,
+			wantFamily:  interfaces.WorkFailureFamilyRetryable,
 			wantMessage: "ERROR: context deadline exceeded while waiting for codex",
 			rejectText:  "raw inference transcript",
 		},
 		{
 			name:       "ExecutableMissing_IsMisconfigured",
 			runErr:     exec.ErrNotFound,
-			wantType:   interfaces.ProviderErrorTypeMisconfigured,
-			wantFamily: interfaces.ProviderErrorFamilyTerminal,
+			wantType:   interfaces.WorkFailureTypeMisconfigured,
+			wantFamily: interfaces.WorkFailureFamilyTerminal,
 		},
 		{
 			name:       "UnknownRuntimeFailure_IsUnknown",
 			runErr:     errors.New("pipe broke"),
-			wantType:   interfaces.ProviderErrorTypeUnknown,
-			wantFamily: interfaces.ProviderErrorFamilyTerminal,
+			wantType:   interfaces.WorkFailureTypeUnknown,
+			wantFamily: interfaces.WorkFailureFamilyTerminal,
 		},
 	}
 
@@ -687,9 +687,9 @@ func TestScriptWrapProvider_Infer_RunErrorsNormalizeTimeoutAndMisconfigured(t *t
 				wantFamily:             tc.wantFamily,
 				wantMessage:            tc.wantMessage,
 				rejectText:             tc.rejectText,
-				wantRetryable:          tc.wantType == interfaces.ProviderErrorTypeTimeout,
-				requireTimeoutDecision: tc.wantType == interfaces.ProviderErrorTypeTimeout,
-				requireTimeoutDiag:     tc.wantType == interfaces.ProviderErrorTypeTimeout,
+				wantRetryable:          tc.wantType == interfaces.WorkFailureTypeTimeout,
+				requireTimeoutDecision: tc.wantType == interfaces.WorkFailureTypeTimeout,
+				requireTimeoutDiag:     tc.wantType == interfaces.WorkFailureTypeTimeout,
 			})
 		})
 	}
@@ -734,7 +734,7 @@ func TestScriptWrapProvider_Infer_ProviderTimeoutTextNormalizesToRetryableTimeou
 				UserMessage:   "fix it",
 			})
 			assertNormalizedProviderFailure(t, err, normalizedProviderFailureExpectation{
-				wantType:               interfaces.ProviderErrorTypeTimeout,
+				wantType:               interfaces.WorkFailureTypeTimeout,
 				wantRetryable:          true,
 				requireTimeoutDecision: true,
 			})
@@ -743,8 +743,8 @@ func TestScriptWrapProvider_Infer_ProviderTimeoutTextNormalizesToRetryableTimeou
 }
 
 type normalizedProviderFailureExpectation struct {
-	wantType               interfaces.ProviderErrorType
-	wantFamily             interfaces.ProviderErrorFamily
+	wantType               interfaces.WorkFailureType
+	wantFamily             interfaces.WorkFailureFamily
 	wantMessage            string
 	rejectText             string
 	rejectTexts            []string

--- a/pkg/workers/provider/inference_provider_exit_failure_test.go
+++ b/pkg/workers/provider/inference_provider_exit_failure_test.go
@@ -28,7 +28,7 @@ type exitFailureInferenceTestCase struct {
 	provider    string
 	result      CommandResult
 	wantMessage string
-	wantType    interfaces.ProviderErrorType
+	wantType    interfaces.WorkFailureType
 }
 
 func genericNonCodexExitFailureTestCases() []exitFailureInferenceTestCase {
@@ -38,21 +38,21 @@ func genericNonCodexExitFailureTestCases() []exitFailureInferenceTestCase {
 			provider:    string(interfaces.ModelProviderGemini),
 			result:      CommandResult{ExitCode: 1, Stderr: []byte("resource exhausted by 429 quota")},
 			wantMessage: "resource exhausted by 429 quota",
-			wantType:    interfaces.ProviderErrorTypeThrottled,
+			wantType:    interfaces.WorkFailureTypeThrottled,
 		},
 		{
 			name:        "KiroFallsBackToProviderExitCodeWhenOutputMissing",
 			provider:    string(interfaces.ModelProviderKiro),
 			result:      CommandResult{ExitCode: 9},
 			wantMessage: "kiro-cli exited with code 9",
-			wantType:    interfaces.ProviderErrorTypeUnknown,
+			wantType:    interfaces.WorkFailureTypeUnknown,
 		},
 		{
 			name:        "OpenCodeClassifiesAuthenticationOutput",
 			provider:    string(interfaces.ModelProviderOpenCode),
 			result:      CommandResult{ExitCode: 1, Stdout: []byte("login required before continuing")},
 			wantMessage: "login required before continuing",
-			wantType:    interfaces.ProviderErrorTypeAuthFailure,
+			wantType:    interfaces.WorkFailureTypeAuthFailure,
 		},
 	}
 }
@@ -64,14 +64,14 @@ func codexDerivedExitFailureTestCases() []exitFailureInferenceTestCase {
 			provider:    string(interfaces.ModelProviderCursor),
 			result:      CommandResult{ExitCode: 1, Stderr: []byte("noise before\nERROR: unexpected status 500 from cursor upstream")},
 			wantMessage: "ERROR: unexpected status 500 from cursor upstream",
-			wantType:    interfaces.ProviderErrorTypeInternalServerError,
+			wantType:    interfaces.WorkFailureTypeInternalServerError,
 		},
 		{
 			name:        "CodexUsesCodexErrorExtraction",
 			provider:    string(interfaces.ModelProviderCodex),
 			result:      CommandResult{ExitCode: 1, Stderr: []byte("noise before\nERROR: unexpected status 500 from codex upstream")},
 			wantMessage: "ERROR: unexpected status 500 from codex upstream",
-			wantType:    interfaces.ProviderErrorTypeInternalServerError,
+			wantType:    interfaces.WorkFailureTypeInternalServerError,
 		},
 	}
 }

--- a/pkg/workers/provider/inference_provider_test.go
+++ b/pkg/workers/provider/inference_provider_test.go
@@ -519,8 +519,8 @@ func TestScriptWrapProvider_Infer_ClaudeRejectsImageContentBeforeRunner(t *testi
 	if !errors.As(err, &providerErr) {
 		t.Fatalf("expected ProviderError, got %T: %v", err, err)
 	}
-	if providerErr.Type != interfaces.ProviderErrorTypePermanentBadRequest {
-		t.Fatalf("provider error type = %q, want %q", providerErr.Type, interfaces.ProviderErrorTypePermanentBadRequest)
+	if providerErr.Type != interfaces.WorkFailureTypePermanentBadRequest {
+		t.Fatalf("provider error type = %q, want %q", providerErr.Type, interfaces.WorkFailureTypePermanentBadRequest)
 	}
 	if !strings.Contains(providerErr.Message, `input_tokens[0].color.content[1].file`) ||
 		!strings.Contains(providerErr.Message, `model provider claude`) ||

--- a/pkg/workers/provider/inference_provider_test_helpers_test.go
+++ b/pkg/workers/provider/inference_provider_test_helpers_test.go
@@ -96,7 +96,7 @@ type april11FailureShapeSample struct {
 	ExitCode              int                          `json:"exit_code"`
 	Stdout                string                       `json:"stdout"`
 	Stderr                string                       `json:"stderr"`
-	WantType              interfaces.ProviderErrorType `json:"want_type"`
+	WantType              interfaces.WorkFailureType `json:"want_type"`
 	WantMessage           string                       `json:"want_message"`
 	WantRetryable         bool                         `json:"want_retryable"`
 	WantTerminal          bool                         `json:"want_terminal"`
@@ -409,8 +409,8 @@ func TestScriptWrapProvider_Infer_CodexMissingImageFailsBeforeRunner(t *testing.
 	if !errors.As(err, &providerErr) {
 		t.Fatalf("expected ProviderError, got %T: %v", err, providerErr)
 	}
-	if providerErr.Type != interfaces.ProviderErrorTypePermanentBadRequest {
-		t.Fatalf("provider error type = %q, want %q", providerErr.Type, interfaces.ProviderErrorTypePermanentBadRequest)
+	if providerErr.Type != interfaces.WorkFailureTypePermanentBadRequest {
+		t.Fatalf("provider error type = %q, want %q", providerErr.Type, interfaces.WorkFailureTypePermanentBadRequest)
 	}
 	if !strings.Contains(providerErr.Message, `input_tokens[0].color.content[0].url`) ||
 		!strings.Contains(providerErr.Message, `media url not readable`) ||
@@ -521,8 +521,8 @@ func TestScriptWrapProvider_Infer_CodexInaccessibleRemoteImageFailsBeforeRunner(
 	if !errors.As(err, &providerErr) {
 		t.Fatalf("expected ProviderError, got %T: %v", err, providerErr)
 	}
-	if providerErr.Type != interfaces.ProviderErrorTypePermanentBadRequest {
-		t.Fatalf("provider error type = %q, want %q", providerErr.Type, interfaces.ProviderErrorTypePermanentBadRequest)
+	if providerErr.Type != interfaces.WorkFailureTypePermanentBadRequest {
+		t.Fatalf("provider error type = %q, want %q", providerErr.Type, interfaces.WorkFailureTypePermanentBadRequest)
 	}
 	if !strings.Contains(providerErr.Message, `input_tokens[0].color.content[0].url`) ||
 		!strings.Contains(providerErr.Message, `media url inaccessible`) {

--- a/pkg/workers/provider/provider_behavior.go
+++ b/pkg/workers/provider/provider_behavior.go
@@ -54,7 +54,7 @@ type providerBehavior interface {
 	BuildArgs(ctx context.Context, req interfaces.ProviderInferenceRequest, skipPermissions bool, buildCtx *ProviderBuildContext) ([]string, error)
 	BuildCommandRequest(req interfaces.ProviderInferenceRequest, args []string) CommandRequest
 	FormatExitFailure(provider string, result CommandResult) string
-	ClassifyExitFailure(result CommandResult) interfaces.ProviderErrorType
+	ClassifyExitFailure(result CommandResult) interfaces.WorkFailureType
 	FormatTimeoutFailure(result CommandResult) string
 }
 
@@ -135,21 +135,21 @@ func (sharedNonCodexProviderBehavior) FormatExitFailure(provider string, result 
 	return formatProviderOutputOrDefault(result, fmt.Sprintf("%s exited with code %d", provider, result.ExitCode))
 }
 
-func (sharedNonCodexProviderBehavior) ClassifyExitFailure(result CommandResult) interfaces.ProviderErrorType {
+func (sharedNonCodexProviderBehavior) ClassifyExitFailure(result CommandResult) interfaces.WorkFailureType {
 	normalizedOutput := strings.ToLower(formatCombinedProviderOutput(result))
 	switch {
 	case containsAny(normalizedOutput, "api key", "authentication", "unauthorized", "forbidden", "login required", "not authenticated"):
-		return interfaces.ProviderErrorTypeAuthFailure
+		return interfaces.WorkFailureTypeAuthFailure
 	case containsAny(normalizedOutput, "invalid argument", "bad request", "invalid request"):
-		return interfaces.ProviderErrorTypePermanentBadRequest
+		return interfaces.WorkFailureTypePermanentBadRequest
 	case containsAny(normalizedOutput, "rate limit", "too many requests", "resource exhausted", "429"):
-		return interfaces.ProviderErrorTypeThrottled
+		return interfaces.WorkFailureTypeThrottled
 	case containsAny(normalizedOutput, "internal server error", "unexpected status 500", "unexpected status 502", "unexpected status 503", "unexpected status 504"):
-		return interfaces.ProviderErrorTypeInternalServerError
+		return interfaces.WorkFailureTypeInternalServerError
 	case result.ExitCode == 124 || containsAny(normalizedOutput, "deadline exceeded", "timed out", "timeout"):
-		return interfaces.ProviderErrorTypeTimeout
+		return interfaces.WorkFailureTypeTimeout
 	default:
-		return interfaces.ProviderErrorTypeUnknown
+		return interfaces.WorkFailureTypeUnknown
 	}
 }
 
@@ -186,21 +186,21 @@ func (b claudeProviderBehavior) FormatExitFailure(provider string, result Comman
 	return fmt.Sprintf("%s exited with code %d", provider, result.ExitCode)
 }
 
-func (b claudeProviderBehavior) ClassifyExitFailure(result CommandResult) interfaces.ProviderErrorType {
+func (b claudeProviderBehavior) ClassifyExitFailure(result CommandResult) interfaces.WorkFailureType {
 	normalizedOutput := strings.ToLower(formatCombinedProviderOutput(result))
 	switch {
 	case containsAny(normalizedOutput, `"type":"authentication_error"`, `"type":"permission_error"`, "api key", "authentication error", "permission error", "unauthorized", "forbidden"):
-		return interfaces.ProviderErrorTypeAuthFailure
+		return interfaces.WorkFailureTypeAuthFailure
 	case containsAny(normalizedOutput, `"type":"invalid_request_error"`, "invalid_request_error", "bad request", "invalid request", "request_too_large"):
-		return interfaces.ProviderErrorTypePermanentBadRequest
+		return interfaces.WorkFailureTypePermanentBadRequest
 	case containsAny(normalizedOutput, `"type":"rate_limit_error"`, `"type":"overloaded_error"`, "rate limit", "too many requests", "overloaded", "529"):
-		return interfaces.ProviderErrorTypeThrottled
+		return interfaces.WorkFailureTypeThrottled
 	case containsAny(normalizedOutput, `"type":"api_error"`, "internal server error", "unexpected status 500", "unexpected status 502", "unexpected status 503", "unexpected status 504"):
-		return interfaces.ProviderErrorTypeInternalServerError
+		return interfaces.WorkFailureTypeInternalServerError
 	case result.ExitCode == 124 || containsAny(normalizedOutput, "deadline exceeded", "timed out", "timeout"):
-		return interfaces.ProviderErrorTypeTimeout
+		return interfaces.WorkFailureTypeTimeout
 	default:
-		return interfaces.ProviderErrorTypeUnknown
+		return interfaces.WorkFailureTypeUnknown
 	}
 }
 
@@ -248,27 +248,27 @@ func (b codexProviderBehavior) FormatExitFailure(provider string, result Command
 	return fmt.Sprintf("%s exited with code %d", provider, result.ExitCode)
 }
 
-func (b codexProviderBehavior) ClassifyExitFailure(result CommandResult) interfaces.ProviderErrorType {
+func (b codexProviderBehavior) ClassifyExitFailure(result CommandResult) interfaces.WorkFailureType {
 	normalizedOutput := strings.ToLower(formatCodexOutputForClassification(result))
 	switch {
 	case containsAny(normalizedOutput, `"type":"authentication_error"`, "authentication_error", "api key", "unauthorized", "forbidden", "401 unauthorized", "403 forbidden"):
-		return interfaces.ProviderErrorTypeAuthFailure
+		return interfaces.WorkFailureTypeAuthFailure
 	case containsAny(normalizedOutput, `"type":"invalid_request_error"`, "invalid_request_error", "bad request", "400 item", "400 previous response", "400 ") && !containsAny(normalizedOutput, "timeout"):
-		return interfaces.ProviderErrorTypePermanentBadRequest
+		return interfaces.WorkFailureTypePermanentBadRequest
 	case containsAny(normalizedOutput, codexThrottledFailureNeedles...):
-		return interfaces.ProviderErrorTypeThrottled
+		return interfaces.WorkFailureTypeThrottled
 	case containsAny(normalizedOutput, codexTemporaryServerFailureNeedles...):
-		return interfaces.ProviderErrorTypeInternalServerError
+		return interfaces.WorkFailureTypeInternalServerError
 	case result.ExitCode == 124 || containsAny(normalizedOutput, "deadline exceeded", "timed out", "timeout"):
-		return interfaces.ProviderErrorTypeTimeout
+		return interfaces.WorkFailureTypeTimeout
 	case result.ExitCode == codexWindowsProcessFailureExitCode:
 		// Windows sometimes reports interrupted Codex subprocess failures as
 		// 4294967295 without any audited provider signal. Keep that path on the
 		// shared retryable provider/process-failure class instead of falling
 		// through to a terminal bucket.
-		return interfaces.ProviderErrorTypeInternalServerError
+		return interfaces.WorkFailureTypeInternalServerError
 	default:
-		return interfaces.ProviderErrorTypeUnknown
+		return interfaces.WorkFailureTypeUnknown
 	}
 }
 
@@ -300,7 +300,7 @@ func (b geminiProviderBehavior) FormatExitFailure(provider string, result Comman
 	return b.sharedNonCodexProviderBehavior.FormatExitFailure(provider, result)
 }
 
-func (b geminiProviderBehavior) ClassifyExitFailure(result CommandResult) interfaces.ProviderErrorType {
+func (b geminiProviderBehavior) ClassifyExitFailure(result CommandResult) interfaces.WorkFailureType {
 	return b.sharedNonCodexProviderBehavior.ClassifyExitFailure(result)
 }
 
@@ -325,7 +325,7 @@ func (b kiroProviderBehavior) FormatExitFailure(provider string, result CommandR
 	return b.sharedNonCodexProviderBehavior.FormatExitFailure(provider, result)
 }
 
-func (b kiroProviderBehavior) ClassifyExitFailure(result CommandResult) interfaces.ProviderErrorType {
+func (b kiroProviderBehavior) ClassifyExitFailure(result CommandResult) interfaces.WorkFailureType {
 	return b.sharedNonCodexProviderBehavior.ClassifyExitFailure(result)
 }
 
@@ -359,7 +359,7 @@ func (b cursorProviderBehavior) FormatExitFailure(provider string, result Comman
 	return codexProviderBehavior{}.FormatExitFailure(provider, result)
 }
 
-func (b cursorProviderBehavior) ClassifyExitFailure(result CommandResult) interfaces.ProviderErrorType {
+func (b cursorProviderBehavior) ClassifyExitFailure(result CommandResult) interfaces.WorkFailureType {
 	return codexProviderBehavior{}.ClassifyExitFailure(result)
 }
 
@@ -391,7 +391,7 @@ func (b openCodeProviderBehavior) FormatExitFailure(provider string, result Comm
 	return b.sharedNonCodexProviderBehavior.FormatExitFailure(provider, result)
 }
 
-func (b openCodeProviderBehavior) ClassifyExitFailure(result CommandResult) interfaces.ProviderErrorType {
+func (b openCodeProviderBehavior) ClassifyExitFailure(result CommandResult) interfaces.WorkFailureType {
 	return b.sharedNonCodexProviderBehavior.ClassifyExitFailure(result)
 }
 

--- a/pkg/workers/provider/provider_behavior_test.go
+++ b/pkg/workers/provider/provider_behavior_test.go
@@ -662,11 +662,11 @@ func TestCursorAndCodexProviderBehavior_ExitFailureBehavior(t *testing.T) {
 		ExitCode: 1,
 		Stderr:   []byte("ERROR: unexpected status 500 from codex upstream"),
 	}
-	if got := cursorBehavior.ClassifyExitFailure(result); got != interfaces.ProviderErrorTypeInternalServerError {
-		t.Fatalf("cursor ClassifyExitFailure() = %q, want %q", got, interfaces.ProviderErrorTypeInternalServerError)
+	if got := cursorBehavior.ClassifyExitFailure(result); got != interfaces.WorkFailureTypeInternalServerError {
+		t.Fatalf("cursor ClassifyExitFailure() = %q, want %q", got, interfaces.WorkFailureTypeInternalServerError)
 	}
-	if got := codexBehavior.ClassifyExitFailure(result); got != interfaces.ProviderErrorTypeInternalServerError {
-		t.Fatalf("codex ClassifyExitFailure() = %q, want %q", got, interfaces.ProviderErrorTypeInternalServerError)
+	if got := codexBehavior.ClassifyExitFailure(result); got != interfaces.WorkFailureTypeInternalServerError {
+		t.Fatalf("codex ClassifyExitFailure() = %q, want %q", got, interfaces.WorkFailureTypeInternalServerError)
 	}
 }
 
@@ -746,37 +746,37 @@ func assertProviderExitFailureClassification(t *testing.T, behavior providerBeha
 	testCases := []struct {
 		name   string
 		result CommandResult
-		want   interfaces.ProviderErrorType
+		want   interfaces.WorkFailureType
 	}{
 		{
 			name:   "AuthFailure",
 			result: CommandResult{ExitCode: 1, Stderr: []byte("login required for this API key")},
-			want:   interfaces.ProviderErrorTypeAuthFailure,
+			want:   interfaces.WorkFailureTypeAuthFailure,
 		},
 		{
 			name:   "PermanentBadRequest",
 			result: CommandResult{ExitCode: 1, Stderr: []byte("invalid argument in request payload")},
-			want:   interfaces.ProviderErrorTypePermanentBadRequest,
+			want:   interfaces.WorkFailureTypePermanentBadRequest,
 		},
 		{
 			name:   "Throttled",
 			result: CommandResult{ExitCode: 1, Stderr: []byte("resource exhausted by 429 quota")},
-			want:   interfaces.ProviderErrorTypeThrottled,
+			want:   interfaces.WorkFailureTypeThrottled,
 		},
 		{
 			name:   "InternalServerError",
 			result: CommandResult{ExitCode: 1, Stderr: []byte("unexpected status 503 from upstream")},
-			want:   interfaces.ProviderErrorTypeInternalServerError,
+			want:   interfaces.WorkFailureTypeInternalServerError,
 		},
 		{
 			name:   "Timeout",
 			result: CommandResult{ExitCode: 124},
-			want:   interfaces.ProviderErrorTypeTimeout,
+			want:   interfaces.WorkFailureTypeTimeout,
 		},
 		{
 			name:   "Unknown",
 			result: CommandResult{ExitCode: 1, Stderr: []byte("provider stopped without classification markers")},
-			want:   interfaces.ProviderErrorTypeUnknown,
+			want:   interfaces.WorkFailureTypeUnknown,
 		},
 	}
 

--- a/pkg/workers/provider/provider_error_corpus.go
+++ b/pkg/workers/provider/provider_error_corpus.go
@@ -20,8 +20,8 @@ type ProviderErrorCorpusEntry struct {
 	ExitCode              int                            `json:"exit_code"`
 	Stdout                string                         `json:"stdout"`
 	Stderr                string                         `json:"stderr"`
-	ExpectedType          interfaces.ProviderErrorType   `json:"expected_type"`
-	ExpectedFamily        interfaces.ProviderErrorFamily `json:"expected_family"`
+	ExpectedType          interfaces.WorkFailureType   `json:"expected_type"`
+	ExpectedFamily        interfaces.WorkFailureFamily `json:"expected_family"`
 	Retryable             bool                           `json:"retryable"`
 	TriggersThrottlePause bool                           `json:"triggers_throttle_pause"`
 	Supported             bool                           `json:"supported"`
@@ -142,7 +142,7 @@ func validateProviderErrorCorpusEntry(entry ProviderErrorCorpusEntry) error {
 	if entry.ExpectedFamily == "" {
 		return fmt.Errorf("decode provider error corpus: entry %q missing expected family", entry.Name)
 	}
-	if entry.ExpectedFamily == interfaces.ProviderErrorFamilyThrottle && !entry.TriggersThrottlePause {
+	if entry.ExpectedFamily == interfaces.WorkFailureFamilyThrottle && !entry.TriggersThrottlePause {
 		return fmt.Errorf("decode provider error corpus: entry %q throttle family must trigger throttle pause", entry.Name)
 	}
 	if entry.TriggersThrottlePause && !entry.Retryable {

--- a/pkg/workers/provider/provider_errors.go
+++ b/pkg/workers/provider/provider_errors.go
@@ -13,15 +13,15 @@ import (
 // customer-messaging logic can make deterministic decisions without parsing raw
 // provider output at every call site.
 type ProviderError struct {
-	Family          interfaces.ProviderErrorFamily
-	Type            interfaces.ProviderErrorType
+	Family          interfaces.WorkFailureFamily
+	Type            interfaces.WorkFailureType
 	Message         string
 	ProviderSession *interfaces.ProviderSessionMetadata
 	Diagnostics     *interfaces.WorkDiagnostics
 	Cause           error
 }
 
-func NewProviderError(errorType interfaces.ProviderErrorType, message string, cause error) *ProviderError {
+func NewProviderError(errorType interfaces.WorkFailureType, message string, cause error) *ProviderError {
 	return &ProviderError{
 		Family:  providerErrorFamilyForType(errorType),
 		Type:    errorType,
@@ -30,13 +30,13 @@ func NewProviderError(errorType interfaces.ProviderErrorType, message string, ca
 	}
 }
 
-func NewProviderErrorWithSession(errorType interfaces.ProviderErrorType, message string, cause error, session *interfaces.ProviderSessionMetadata) *ProviderError {
+func NewProviderErrorWithSession(errorType interfaces.WorkFailureType, message string, cause error, session *interfaces.ProviderSessionMetadata) *ProviderError {
 	err := NewProviderError(errorType, message, cause)
 	err.ProviderSession = interfaces.CloneProviderSessionMetadata(session)
 	return err
 }
 
-func newProviderErrorWithDiagnostics(errorType interfaces.ProviderErrorType, message string, cause error, session *interfaces.ProviderSessionMetadata, diagnostics *interfaces.WorkDiagnostics) *ProviderError {
+func newProviderErrorWithDiagnostics(errorType interfaces.WorkFailureType, message string, cause error, session *interfaces.ProviderSessionMetadata, diagnostics *interfaces.WorkDiagnostics) *ProviderError {
 	err := NewProviderErrorWithSession(errorType, message, cause, session)
 	err.Diagnostics = interfaces.CloneWorkDiagnostics(diagnostics)
 	return err
@@ -60,16 +60,10 @@ func ClassifyProviderFailure(err *ProviderError) interfaces.WorkFailureDecision 
 	return providerFailureDecisionForFamily(err.Family)
 }
 
-// ProviderFailureDecisionFromMetadata resolves retry behavior from the durable
-// normalized provider-failure metadata carried across runtime boundaries.
-// The normalized type is canonical when present; family remains a fallback for
-// older or partial metadata that omitted type.
-func ProviderFailureDecisionFromMetadata(metadata *interfaces.ProviderFailureMetadata) interfaces.WorkFailureDecision {
-	return WorkFailureDecisionFromMetadata(metadata)
-}
-
 // WorkFailureDecisionFromMetadata resolves retry behavior from durable
 // generalized failure metadata carried across runtime boundaries.
+// The normalized type is canonical when present; family remains a fallback for
+// older or partial metadata that omitted type.
 func WorkFailureDecisionFromMetadata(metadata *interfaces.WorkFailureMetadata) interfaces.WorkFailureDecision {
 	if metadata == nil {
 		return interfaces.WorkFailureDecision{}
@@ -82,11 +76,11 @@ func WorkFailureDecisionFromMetadata(metadata *interfaces.WorkFailureMetadata) i
 
 func providerFailureDecisionForFamily(family interfaces.WorkFailureFamily) interfaces.WorkFailureDecision {
 	switch family {
-	case interfaces.ProviderErrorFamilyRetryable:
+	case interfaces.WorkFailureFamilyRetryable:
 		return interfaces.WorkFailureDecision{Retryable: true}
-	case interfaces.ProviderErrorFamilyThrottle:
+	case interfaces.WorkFailureFamilyThrottle:
 		return interfaces.WorkFailureDecision{Retryable: true, TriggersThrottlePause: true}
-	case interfaces.ProviderErrorFamilyTerminal:
+	case interfaces.WorkFailureFamilyTerminal:
 		return interfaces.WorkFailureDecision{Terminal: true}
 	default:
 		return interfaces.WorkFailureDecision{Terminal: true}
@@ -95,14 +89,14 @@ func providerFailureDecisionForFamily(family interfaces.WorkFailureFamily) inter
 
 func providerErrorFamilyForType(errorType interfaces.WorkFailureType) interfaces.WorkFailureFamily {
 	switch errorType {
-	case interfaces.ProviderErrorTypeThrottled:
-		return interfaces.ProviderErrorFamilyThrottle
-	case interfaces.ProviderErrorTypeInternalServerError, interfaces.ProviderErrorTypeTimeout:
-		return interfaces.ProviderErrorFamilyRetryable
-	case interfaces.ProviderErrorTypeAuthFailure, interfaces.ProviderErrorTypePermanentBadRequest, interfaces.ProviderErrorTypeUnknown, interfaces.ProviderErrorTypeMisconfigured:
-		return interfaces.ProviderErrorFamilyTerminal
+	case interfaces.WorkFailureTypeThrottled:
+		return interfaces.WorkFailureFamilyThrottle
+	case interfaces.WorkFailureTypeInternalServerError, interfaces.WorkFailureTypeTimeout:
+		return interfaces.WorkFailureFamilyRetryable
+	case interfaces.WorkFailureTypeAuthFailure, interfaces.WorkFailureTypePermanentBadRequest, interfaces.WorkFailureTypeUnknown, interfaces.WorkFailureTypeMisconfigured:
+		return interfaces.WorkFailureFamilyTerminal
 	default:
-		return interfaces.ProviderErrorFamilyTerminal
+		return interfaces.WorkFailureFamilyTerminal
 	}
 }
 
@@ -130,7 +124,7 @@ func NormalizeProviderExecutionError(err error) *ProviderError {
 		return providerErr
 	}
 	if errors.Is(err, context.DeadlineExceeded) {
-		return NewProviderError(interfaces.ProviderErrorTypeTimeout, "execution timeout", err)
+		return NewProviderError(interfaces.WorkFailureTypeTimeout, "execution timeout", err)
 	}
 	return nil
 }

--- a/pkg/workers/provider/provider_errors_test.go
+++ b/pkg/workers/provider/provider_errors_test.go
@@ -12,16 +12,16 @@ import (
 func TestNewProviderError_AssignsDeterministicFamilyFromType(t *testing.T) {
 	testCases := []struct {
 		name       string
-		errorType  interfaces.ProviderErrorType
-		wantFamily interfaces.ProviderErrorFamily
+		errorType  interfaces.WorkFailureType
+		wantFamily interfaces.WorkFailureFamily
 	}{
-		{name: "AuthFailure_IsTerminal", errorType: interfaces.ProviderErrorTypeAuthFailure, wantFamily: interfaces.ProviderErrorFamilyTerminal},
-		{name: "PermanentBadRequest_IsTerminal", errorType: interfaces.ProviderErrorTypePermanentBadRequest, wantFamily: interfaces.ProviderErrorFamilyTerminal},
-		{name: "Throttled_IsThrottle", errorType: interfaces.ProviderErrorTypeThrottled, wantFamily: interfaces.ProviderErrorFamilyThrottle},
-		{name: "InternalServerError_IsRetryable", errorType: interfaces.ProviderErrorTypeInternalServerError, wantFamily: interfaces.ProviderErrorFamilyRetryable},
-		{name: "Timeout_IsRetryable", errorType: interfaces.ProviderErrorTypeTimeout, wantFamily: interfaces.ProviderErrorFamilyRetryable},
-		{name: "Unknown_IsTerminal", errorType: interfaces.ProviderErrorTypeUnknown, wantFamily: interfaces.ProviderErrorFamilyTerminal},
-		{name: "Misconfigured_IsTerminal", errorType: interfaces.ProviderErrorTypeMisconfigured, wantFamily: interfaces.ProviderErrorFamilyTerminal},
+		{name: "AuthFailure_IsTerminal", errorType: interfaces.WorkFailureTypeAuthFailure, wantFamily: interfaces.WorkFailureFamilyTerminal},
+		{name: "PermanentBadRequest_IsTerminal", errorType: interfaces.WorkFailureTypePermanentBadRequest, wantFamily: interfaces.WorkFailureFamilyTerminal},
+		{name: "Throttled_IsThrottle", errorType: interfaces.WorkFailureTypeThrottled, wantFamily: interfaces.WorkFailureFamilyThrottle},
+		{name: "InternalServerError_IsRetryable", errorType: interfaces.WorkFailureTypeInternalServerError, wantFamily: interfaces.WorkFailureFamilyRetryable},
+		{name: "Timeout_IsRetryable", errorType: interfaces.WorkFailureTypeTimeout, wantFamily: interfaces.WorkFailureFamilyRetryable},
+		{name: "Unknown_IsTerminal", errorType: interfaces.WorkFailureTypeUnknown, wantFamily: interfaces.WorkFailureFamilyTerminal},
+		{name: "Misconfigured_IsTerminal", errorType: interfaces.WorkFailureTypeMisconfigured, wantFamily: interfaces.WorkFailureFamilyTerminal},
 	}
 
 	for _, tc := range testCases {
@@ -39,7 +39,7 @@ func TestNewProviderError_AssignsDeterministicFamilyFromType(t *testing.T) {
 
 func TestProviderError_Error_PrefersMessageThenCauseThenType(t *testing.T) {
 
-	if got := NewProviderError(interfaces.ProviderErrorTypeUnknown, "", nil).Error(); got != "provider error: unknown" {
+	if got := NewProviderError(interfaces.WorkFailureTypeUnknown, "", nil).Error(); got != "provider error: unknown" {
 		t.Fatalf("expected fallback type-based message, got %q", got)
 	}
 }
@@ -51,7 +51,7 @@ func TestNewProviderErrorWithSession_ClonesProviderSessionMetadata(t *testing.T)
 		ID:       "sess_codex_123",
 	}
 
-	providerErr := NewProviderErrorWithSession(interfaces.ProviderErrorTypeAuthFailure, "auth failed", nil, session)
+	providerErr := NewProviderErrorWithSession(interfaces.WorkFailureTypeAuthFailure, "auth failed", nil, session)
 	session.ID = "mutated-session"
 
 	if providerErr.ProviderSession == nil {
@@ -72,38 +72,38 @@ func TestClassifyProviderFailure_ReturnsDeterministicBehavior(t *testing.T) {
 	}{
 		{
 			name:         "AuthFailure_Terminates",
-			err:          NewProviderError(interfaces.ProviderErrorTypeAuthFailure, "", nil),
+			err:          NewProviderError(interfaces.WorkFailureTypeAuthFailure, "", nil),
 			wantTerminal: true,
 		},
 		{
 			name:         "PermanentBadRequest_Terminates",
-			err:          NewProviderError(interfaces.ProviderErrorTypePermanentBadRequest, "", nil),
+			err:          NewProviderError(interfaces.WorkFailureTypePermanentBadRequest, "", nil),
 			wantTerminal: true,
 		},
 		{
 			name:              "Throttled_RetriesAndPauses",
-			err:               NewProviderError(interfaces.ProviderErrorTypeThrottled, "", nil),
+			err:               NewProviderError(interfaces.WorkFailureTypeThrottled, "", nil),
 			wantRetryable:     true,
 			wantThrottlePause: true,
 		},
 		{
 			name:          "InternalServerError_Retries",
-			err:           NewProviderError(interfaces.ProviderErrorTypeInternalServerError, "", nil),
+			err:           NewProviderError(interfaces.WorkFailureTypeInternalServerError, "", nil),
 			wantRetryable: true,
 		},
 		{
 			name:          "Timeout_Retries",
-			err:           NewProviderError(interfaces.ProviderErrorTypeTimeout, "", nil),
+			err:           NewProviderError(interfaces.WorkFailureTypeTimeout, "", nil),
 			wantRetryable: true,
 		},
 		{
 			name:         "Unknown_Terminates",
-			err:          NewProviderError(interfaces.ProviderErrorTypeUnknown, "", nil),
+			err:          NewProviderError(interfaces.WorkFailureTypeUnknown, "", nil),
 			wantTerminal: true,
 		},
 		{
 			name:         "Misconfigured_Terminates",
-			err:          NewProviderError(interfaces.ProviderErrorTypeMisconfigured, "", nil),
+			err:          NewProviderError(interfaces.WorkFailureTypeMisconfigured, "", nil),
 			wantTerminal: true,
 		},
 	}
@@ -124,49 +124,49 @@ func TestClassifyProviderFailure_ReturnsDeterministicBehavior(t *testing.T) {
 	}
 }
 
-func TestProviderFailureDecisionFromMetadata_UsesNormalizedTypeAsCanonicalRetryClass(t *testing.T) {
+func TestWorkFailureDecisionFromMetadata_UsesNormalizedTypeAsCanonicalRetryClass(t *testing.T) {
 	testCases := []struct {
 		name              string
-		metadata          *interfaces.ProviderFailureMetadata
+		metadata          *interfaces.WorkFailureMetadata
 		wantRetryable     bool
 		wantTerminal      bool
 		wantThrottlePause bool
 	}{
 		{
 			name: "InternalServerErrorWithoutFamily_Retries",
-			metadata: &interfaces.ProviderFailureMetadata{
-				Type: interfaces.ProviderErrorTypeInternalServerError,
+			metadata: &interfaces.WorkFailureMetadata{
+				Type: interfaces.WorkFailureTypeInternalServerError,
 			},
 			wantRetryable: true,
 		},
 		{
 			name: "InternalServerErrorWithStaleTerminalFamily_StillRetries",
-			metadata: &interfaces.ProviderFailureMetadata{
-				Family: interfaces.ProviderErrorFamilyTerminal,
-				Type:   interfaces.ProviderErrorTypeInternalServerError,
+			metadata: &interfaces.WorkFailureMetadata{
+				Family: interfaces.WorkFailureFamilyTerminal,
+				Type:   interfaces.WorkFailureTypeInternalServerError,
 			},
 			wantRetryable: true,
 		},
 		{
 			name: "CodexWindowsExitCode4294967295WithStaleTerminalFamily_StillRetriesWithoutThrottlePause",
-			metadata: &interfaces.ProviderFailureMetadata{
-				Family: interfaces.ProviderErrorFamilyTerminal,
-				Type:   interfaces.ProviderErrorTypeInternalServerError,
+			metadata: &interfaces.WorkFailureMetadata{
+				Family: interfaces.WorkFailureFamilyTerminal,
+				Type:   interfaces.WorkFailureTypeInternalServerError,
 			},
 			wantRetryable: true,
 		},
 		{
 			name: "AuthFailureWithStaleRetryableFamily_StillTerminates",
-			metadata: &interfaces.ProviderFailureMetadata{
-				Family: interfaces.ProviderErrorFamilyRetryable,
-				Type:   interfaces.ProviderErrorTypeAuthFailure,
+			metadata: &interfaces.WorkFailureMetadata{
+				Family: interfaces.WorkFailureFamilyRetryable,
+				Type:   interfaces.WorkFailureTypeAuthFailure,
 			},
 			wantTerminal: true,
 		},
 		{
 			name: "ThrottleFamilyWithoutType_UsesFamilyFallback",
-			metadata: &interfaces.ProviderFailureMetadata{
-				Family: interfaces.ProviderErrorFamilyThrottle,
+			metadata: &interfaces.WorkFailureMetadata{
+				Family: interfaces.WorkFailureFamilyThrottle,
 			},
 			wantRetryable:     true,
 			wantThrottlePause: true,
@@ -175,7 +175,7 @@ func TestProviderFailureDecisionFromMetadata_UsesNormalizedTypeAsCanonicalRetryC
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := ProviderFailureDecisionFromMetadata(tc.metadata)
+			got := WorkFailureDecisionFromMetadata(tc.metadata)
 			if got.Retryable != tc.wantRetryable {
 				t.Fatalf("expected Retryable=%t, got %t", tc.wantRetryable, got.Retryable)
 			}
@@ -190,7 +190,7 @@ func TestProviderFailureDecisionFromMetadata_UsesNormalizedTypeAsCanonicalRetryC
 }
 
 func TestWorkFailureMetadataFromError_ProducesGeneralizedFailureMetadata(t *testing.T) {
-	providerErr := NewProviderError(interfaces.ProviderErrorTypeTimeout, "execution timeout", nil)
+	providerErr := NewProviderError(interfaces.WorkFailureTypeTimeout, "execution timeout", nil)
 
 	metadata := WorkFailureMetadataFromError(providerErr)
 	if metadata == nil {
@@ -306,11 +306,11 @@ func TestCodexProviderBehavior_ClassifiesUsageLimitAsThrottled(t *testing.T) {
 	result := providerErrorCorpusEntryForTest(t, "codex_usage_limit_reached").CommandResult()
 
 	providerErr := normalizeProviderExitFailure(string(interfaces.ModelProviderCodex), result, nil, nil)
-	if providerErr.Type != interfaces.ProviderErrorTypeThrottled {
-		t.Fatalf("expected usage limit to classify as %q, got %q", interfaces.ProviderErrorTypeThrottled, providerErr.Type)
+	if providerErr.Type != interfaces.WorkFailureTypeThrottled {
+		t.Fatalf("expected usage limit to classify as %q, got %q", interfaces.WorkFailureTypeThrottled, providerErr.Type)
 	}
-	if providerErr.Family != interfaces.ProviderErrorFamilyThrottle {
-		t.Fatalf("expected usage limit to be in family %q, got %q", interfaces.ProviderErrorFamilyThrottle, providerErr.Family)
+	if providerErr.Family != interfaces.WorkFailureFamilyThrottle {
+		t.Fatalf("expected usage limit to be in family %q, got %q", interfaces.WorkFailureFamilyThrottle, providerErr.Family)
 	}
 	if !strings.Contains(providerErr.Message, "usage limit") {
 		t.Fatalf("expected normalized error to preserve usage limit message, got %q", providerErr.Message)

--- a/pkg/workers/provider/recording_provider.go
+++ b/pkg/workers/provider/recording_provider.go
@@ -79,7 +79,7 @@ func (p *RecordingProvider) Infer(ctx context.Context, req interfaces.ProviderIn
 func (p *RecordingProvider) inferInner(ctx context.Context, req interfaces.ProviderInferenceRequest) (interfaces.InferenceResponse, error) {
 	if p.inner == nil {
 		return interfaces.InferenceResponse{}, NewProviderError(
-			interfaces.ProviderErrorTypeMisconfigured,
+			interfaces.WorkFailureTypeMisconfigured,
 			"recording provider requires an inner provider",
 			nil,
 		)
@@ -213,7 +213,7 @@ func providerErrorClass(err error) string {
 	if errors.As(err, &providerErr) && providerErr.Type != "" {
 		return string(providerErr.Type)
 	}
-	return string(interfaces.ProviderErrorTypeUnknown)
+	return string(interfaces.WorkFailureTypeUnknown)
 }
 
 func providerErrorExitCode(err error) *int {

--- a/pkg/workers/provider/recording_provider_test.go
+++ b/pkg/workers/provider/recording_provider_test.go
@@ -101,7 +101,7 @@ func TestRecordingProvider_Infer_NormalizesEventTimesToUTC(t *testing.T) {
 }
 
 func TestRecordingProvider_Infer_FailureEmitsFailedResponseWithProviderDetails(t *testing.T) {
-	providerErr := NewProviderError(interfaces.ProviderErrorTypeTimeout, "provider timed out", nil)
+	providerErr := NewProviderError(interfaces.WorkFailureTypeTimeout, "provider timed out", nil)
 	providerErr.Diagnostics = &interfaces.WorkDiagnostics{
 		Command: &interfaces.CommandDiagnostic{ExitCode: 124},
 	}
@@ -128,7 +128,7 @@ func TestRecordingProvider_Infer_FailureEmitsFailedResponseWithProviderDetails(t
 	if response.Outcome != factoryapi.InferenceOutcomeFailed {
 		t.Fatalf("response outcome = %s, want FAILED", response.Outcome)
 	}
-	if response.ErrorClass == nil || *response.ErrorClass != string(interfaces.ProviderErrorTypeTimeout) {
+	if response.ErrorClass == nil || *response.ErrorClass != string(interfaces.WorkFailureTypeTimeout) {
 		t.Fatalf("errorClass = %#v, want timeout", response.ErrorClass)
 	}
 	if response.ExitCode == nil || *response.ExitCode != 124 {
@@ -171,7 +171,7 @@ func TestRecordingProvider_Infer_FailureExitCodeEmissionMatchesDiagnosticPolicy(
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			providerErr := NewProviderError(interfaces.ProviderErrorTypeTimeout, "provider timed out", nil)
+			providerErr := NewProviderError(interfaces.WorkFailureTypeTimeout, "provider timed out", nil)
 			providerErr.Diagnostics = tc.diagnostics
 			fake := &recordingProviderFake{errors: []error{providerErr}}
 			events := &recordingEvents{}
@@ -263,7 +263,7 @@ func TestRecordingProvider_Infer_SuccessPreservesProviderSessionAndSafeDiagnosti
 
 func TestRecordingProvider_Infer_FailureZeroExitCodeStillPreservesProviderSessionAndSafeDiagnostics(t *testing.T) {
 	providerErr := NewProviderErrorWithSession(
-		interfaces.ProviderErrorTypeTimeout,
+		interfaces.WorkFailureTypeTimeout,
 		"provider timed out",
 		nil,
 		&interfaces.ProviderSessionMetadata{Provider: "claude", Kind: "session_id", ID: "sess-456"},
@@ -317,8 +317,8 @@ func TestRecordingProvider_Infer_MultipleAttemptsIncrementAndKeepUniqueRequestID
 	start := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
 	fake := &recordingProviderFake{
 		errors: []error{
-			NewProviderError(interfaces.ProviderErrorTypeInternalServerError, "provider 500", nil),
-			NewProviderError(interfaces.ProviderErrorTypeTimeout, "provider timeout", nil),
+			NewProviderError(interfaces.WorkFailureTypeInternalServerError, "provider 500", nil),
+			NewProviderError(interfaces.WorkFailureTypeTimeout, "provider timeout", nil),
 			nil,
 		},
 		responses: []interfaces.InferenceResponse{
@@ -366,8 +366,8 @@ func TestRecordingProvider_Infer_RetryableFailureKeepsAttemptCounterUntilTermina
 	start := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
 	fake := &recordingProviderFake{
 		errors: []error{
-			NewProviderError(interfaces.ProviderErrorTypeTimeout, "provider timed out", nil),
-			NewProviderError(interfaces.ProviderErrorTypePermanentBadRequest, "prompt invalid", nil),
+			NewProviderError(interfaces.WorkFailureTypeTimeout, "provider timed out", nil),
+			NewProviderError(interfaces.WorkFailureTypePermanentBadRequest, "prompt invalid", nil),
 			nil,
 		},
 		responses: []interfaces.InferenceResponse{
@@ -401,10 +401,10 @@ func TestRecordingProvider_Infer_RetryableFailureKeepsAttemptCounterUntilTermina
 	if firstFailure.Attempt != 1 || secondFailure.Attempt != 2 || finalSuccess.Attempt != 1 {
 		t.Fatalf("attempt sequence = [%d %d %d], want [1 2 1]", firstFailure.Attempt, secondFailure.Attempt, finalSuccess.Attempt)
 	}
-	if firstFailure.ErrorClass == nil || *firstFailure.ErrorClass != string(interfaces.ProviderErrorTypeTimeout) {
+	if firstFailure.ErrorClass == nil || *firstFailure.ErrorClass != string(interfaces.WorkFailureTypeTimeout) {
 		t.Fatalf("first failure errorClass = %#v, want timeout", firstFailure.ErrorClass)
 	}
-	if secondFailure.ErrorClass == nil || *secondFailure.ErrorClass != string(interfaces.ProviderErrorTypePermanentBadRequest) {
+	if secondFailure.ErrorClass == nil || *secondFailure.ErrorClass != string(interfaces.WorkFailureTypePermanentBadRequest) {
 		t.Fatalf("second failure errorClass = %#v, want permanent bad request", secondFailure.ErrorClass)
 	}
 	if finalSuccess.Outcome != factoryapi.InferenceOutcomeSucceeded {
@@ -430,8 +430,8 @@ func TestRecordingProvider_Infer_MissingInnerProviderEmitsMisconfiguredFailureEv
 	if !ok {
 		t.Fatalf("expected ProviderError, got %T", err)
 	}
-	if providerErr.Type != interfaces.ProviderErrorTypeMisconfigured {
-		t.Fatalf("provider error type = %q, want %q", providerErr.Type, interfaces.ProviderErrorTypeMisconfigured)
+	if providerErr.Type != interfaces.WorkFailureTypeMisconfigured {
+		t.Fatalf("provider error type = %q, want %q", providerErr.Type, interfaces.WorkFailureTypeMisconfigured)
 	}
 	if providerErr.Message != "recording provider requires an inner provider" {
 		t.Fatalf("provider error message = %q", providerErr.Message)
@@ -444,7 +444,7 @@ func TestRecordingProvider_Infer_MissingInnerProviderEmitsMisconfiguredFailureEv
 	if response.Outcome != factoryapi.InferenceOutcomeFailed {
 		t.Fatalf("response outcome = %s, want FAILED", response.Outcome)
 	}
-	if response.ErrorClass == nil || *response.ErrorClass != string(interfaces.ProviderErrorTypeMisconfigured) {
+	if response.ErrorClass == nil || *response.ErrorClass != string(interfaces.WorkFailureTypeMisconfigured) {
 		t.Fatalf("errorClass = %#v, want misconfigured", response.ErrorClass)
 	}
 	if response.ExitCode != nil {

--- a/pkg/workers/provider_compat.go
+++ b/pkg/workers/provider_compat.go
@@ -24,14 +24,10 @@ const (
 	codexWindowsProcessFailureExitCode = 4294967295
 )
 
-func NewProviderError(errorType interfaces.ProviderErrorType, message string, cause error) *ProviderError {
+func NewProviderError(errorType interfaces.WorkFailureType, message string, cause error) *ProviderError {
 	return workerprovider.NewProviderError(errorType, message, cause)
 }
 
-func NewProviderErrorWithSession(errorType interfaces.ProviderErrorType, message string, cause error, session *interfaces.ProviderSessionMetadata) *ProviderError {
+func NewProviderErrorWithSession(errorType interfaces.WorkFailureType, message string, cause error, session *interfaces.ProviderSessionMetadata) *ProviderError {
 	return workerprovider.NewProviderErrorWithSession(errorType, message, cause, session)
-}
-
-func ProviderFailureDecisionFromMetadata(metadata *interfaces.ProviderFailureMetadata) interfaces.ProviderFailureDecision {
-	return workerprovider.ProviderFailureDecisionFromMetadata(metadata)
 }

--- a/tests/functional/providers/cli_provider_error_long_test.go
+++ b/tests/functional/providers/cli_provider_error_long_test.go
@@ -59,8 +59,8 @@ func providerErrorLongCases() []providerLongCase {
 func runProviderErrorLongCase(t *testing.T, tc providerLongCase) {
 	t.Helper()
 
-	expectedType := interfaces.ProviderErrorTypeUnknown
-	expectedFamily := interfaces.ProviderErrorFamilyTerminal
+	expectedType := interfaces.WorkFailureTypeUnknown
+	expectedFamily := interfaces.WorkFailureFamilyTerminal
 	if tc.corpusEntry != "" {
 		entry := providerErrorCorpusEntryForTest(t, tc.corpusEntry)
 		expectedType = entry.ExpectedType
@@ -146,8 +146,8 @@ func assertProviderOutcome(
 	outcome testutil.ProviderErrorSmokeOutcome,
 	work testutil.ProviderErrorSmokeWork,
 	tc providerLongCase,
-	wantType interfaces.ProviderErrorType,
-	wantFamily interfaces.ProviderErrorFamily,
+	wantType interfaces.WorkFailureType,
+	wantFamily interfaces.WorkFailureFamily,
 ) {
 	t.Helper()
 
@@ -173,8 +173,8 @@ func assertProviderRequeueOutcome(
 	outcome testutil.ProviderErrorSmokeOutcome,
 	work testutil.ProviderErrorSmokeWork,
 	tc providerLongCase,
-	wantType interfaces.ProviderErrorType,
-	wantFamily interfaces.ProviderErrorFamily,
+	wantType interfaces.WorkFailureType,
+	wantFamily interfaces.WorkFailureFamily,
 ) {
 	t.Helper()
 
@@ -214,8 +214,8 @@ func assertProviderRequeueOutcome(
 func assertDispatchProviderFailureMatchesExpected(
 	t *testing.T,
 	dispatch interfaces.CompletedDispatch,
-	wantType interfaces.ProviderErrorType,
-	wantFamily interfaces.ProviderErrorFamily,
+	wantType interfaces.WorkFailureType,
+	wantFamily interfaces.WorkFailureFamily,
 ) {
 	t.Helper()
 

--- a/tests/functional/providers/cli_timeout_cleanup_smoke_test.go
+++ b/tests/functional/providers/cli_timeout_cleanup_smoke_test.go
@@ -152,11 +152,11 @@ Timeout once, then succeed after the Agent Factory requeues the work.
 	if first.ProviderFailure == nil {
 		t.Fatal("first dispatch ProviderFailure is nil, want timeout metadata")
 	}
-	if first.ProviderFailure.Type != interfaces.ProviderErrorTypeTimeout {
-		t.Fatalf("first dispatch provider failure type = %s, want %s", first.ProviderFailure.Type, interfaces.ProviderErrorTypeTimeout)
+	if first.ProviderFailure.Type != interfaces.WorkFailureTypeTimeout {
+		t.Fatalf("first dispatch provider failure type = %s, want %s", first.ProviderFailure.Type, interfaces.WorkFailureTypeTimeout)
 	}
-	if first.ProviderFailure.Family != interfaces.ProviderErrorFamilyRetryable {
-		t.Fatalf("first dispatch provider failure family = %s, want %s", first.ProviderFailure.Family, interfaces.ProviderErrorFamilyRetryable)
+	if first.ProviderFailure.Family != interfaces.WorkFailureFamilyRetryable {
+		t.Fatalf("first dispatch provider failure family = %s, want %s", first.ProviderFailure.Family, interfaces.WorkFailureFamilyRetryable)
 	}
 	if len(first.OutputMutations) == 0 || first.OutputMutations[0].ToPlace != "task:init" {
 		t.Fatalf("first dispatch mutations = %#v, want requeue to task:init", first.OutputMutations)

--- a/tests/functional/providers/cli_timeout_companion_smoke_long_test.go
+++ b/tests/functional/providers/cli_timeout_companion_smoke_long_test.go
@@ -70,11 +70,11 @@ Execute the script.
 	if first.ProviderFailure == nil {
 		t.Fatal("first timeout dispatch ProviderFailure is nil, want timeout metadata")
 	}
-	if first.ProviderFailure.Type != interfaces.ProviderErrorTypeTimeout {
-		t.Fatalf("first timeout dispatch provider failure type = %s, want %s", first.ProviderFailure.Type, interfaces.ProviderErrorTypeTimeout)
+	if first.ProviderFailure.Type != interfaces.WorkFailureTypeTimeout {
+		t.Fatalf("first timeout dispatch provider failure type = %s, want %s", first.ProviderFailure.Type, interfaces.WorkFailureTypeTimeout)
 	}
-	if first.ProviderFailure.Family != interfaces.ProviderErrorFamilyRetryable {
-		t.Fatalf("first timeout dispatch provider failure family = %s, want %s", first.ProviderFailure.Family, interfaces.ProviderErrorFamilyRetryable)
+	if first.ProviderFailure.Family != interfaces.WorkFailureFamilyRetryable {
+		t.Fatalf("first timeout dispatch provider failure family = %s, want %s", first.ProviderFailure.Family, interfaces.WorkFailureFamilyRetryable)
 	}
 	if len(first.OutputMutations) == 0 || first.OutputMutations[0].ToPlace != "task:init" {
 		t.Fatalf("first timeout dispatch mutations = %#v, want requeue to task:init", first.OutputMutations)

--- a/tests/functional/providers/provider_error_helpers_test.go
+++ b/tests/functional/providers/provider_error_helpers_test.go
@@ -264,17 +264,17 @@ func assertRetryableInternalServerRequeueOutcome(
 	}
 }
 
-func assertProviderFailureIsRetryableInternalServer(t *testing.T, failure *interfaces.ProviderFailureMetadata) {
+func assertProviderFailureIsRetryableInternalServer(t *testing.T, failure *interfaces.WorkFailureMetadata) {
 	t.Helper()
 
 	if failure == nil {
 		t.Fatal("ProviderFailure is nil, want normalized internal_server_error metadata")
 	}
-	if failure.Type != interfaces.ProviderErrorTypeInternalServerError {
-		t.Fatalf("provider failure type = %s, want %s", failure.Type, interfaces.ProviderErrorTypeInternalServerError)
+	if failure.Type != interfaces.WorkFailureTypeInternalServerError {
+		t.Fatalf("provider failure type = %s, want %s", failure.Type, interfaces.WorkFailureTypeInternalServerError)
 	}
-	if failure.Family != interfaces.ProviderErrorFamilyRetryable {
-		t.Fatalf("provider failure family = %s, want %s", failure.Family, interfaces.ProviderErrorFamilyRetryable)
+	if failure.Family != interfaces.WorkFailureFamilyRetryable {
+		t.Fatalf("provider failure family = %s, want %s", failure.Family, interfaces.WorkFailureFamilyRetryable)
 	}
 }
 

--- a/tests/functional/providers/provider_error_smoke_test.go
+++ b/tests/functional/providers/provider_error_smoke_test.go
@@ -189,11 +189,11 @@ func assertCodexTimeoutFailureNormalizesThroughWorkerPool(t *testing.T, timeoutE
 	if dispatch.ProviderFailure == nil {
 		t.Fatal("ProviderFailure is nil, want timeout metadata")
 	}
-	if dispatch.ProviderFailure.Type != interfaces.ProviderErrorTypeTimeout {
-		t.Fatalf("provider failure type = %s, want %s", dispatch.ProviderFailure.Type, interfaces.ProviderErrorTypeTimeout)
+	if dispatch.ProviderFailure.Type != interfaces.WorkFailureTypeTimeout {
+		t.Fatalf("provider failure type = %s, want %s", dispatch.ProviderFailure.Type, interfaces.WorkFailureTypeTimeout)
 	}
-	if dispatch.ProviderFailure.Family != interfaces.ProviderErrorFamilyRetryable {
-		t.Fatalf("provider failure family = %s, want %s", dispatch.ProviderFailure.Family, interfaces.ProviderErrorFamilyRetryable)
+	if dispatch.ProviderFailure.Family != interfaces.WorkFailureFamilyRetryable {
+		t.Fatalf("provider failure family = %s, want %s", dispatch.ProviderFailure.Family, interfaces.WorkFailureFamilyRetryable)
 	}
 	assertContainsAll(t, dispatch.Reason, []string{"provider error: timeout", conciseError})
 	for _, reject := range timeoutEntry.RejectMessageContains {
@@ -299,17 +299,17 @@ func TestProviderErrorSmoke_CodexWindowsExitCode4294967295RequeuesAndSurfacesRet
 	if completion.Outcome != factoryapi.WorkOutcomeFailed {
 		t.Fatalf("DISPATCH_COMPLETED outcome = %s, want %s", completion.Outcome, factoryapi.WorkOutcomeFailed)
 	}
-	if got := stringPointerValue(completion.FailureReason); got != string(interfaces.ProviderErrorTypeInternalServerError) {
-		t.Fatalf("DISPATCH_COMPLETED failureReason = %q, want %q", got, interfaces.ProviderErrorTypeInternalServerError)
+	if got := stringPointerValue(completion.FailureReason); got != string(interfaces.WorkFailureTypeInternalServerError) {
+		t.Fatalf("DISPATCH_COMPLETED failureReason = %q, want %q", got, interfaces.WorkFailureTypeInternalServerError)
 	}
 	if completion.ProviderFailure == nil {
 		t.Fatal("DISPATCH_COMPLETED providerFailure is nil, want canonical metadata")
 	}
-	if got := stringPointerValue(completion.ProviderFailure.Type); got != string(interfaces.ProviderErrorTypeInternalServerError) {
-		t.Fatalf("DISPATCH_COMPLETED providerFailure.type = %q, want %q", got, interfaces.ProviderErrorTypeInternalServerError)
+	if got := stringPointerValue(completion.ProviderFailure.Type); got != string(interfaces.WorkFailureTypeInternalServerError) {
+		t.Fatalf("DISPATCH_COMPLETED providerFailure.type = %q, want %q", got, interfaces.WorkFailureTypeInternalServerError)
 	}
-	if got := stringPointerValue(completion.ProviderFailure.Family); got != string(interfaces.ProviderErrorFamilyRetryable) {
-		t.Fatalf("DISPATCH_COMPLETED providerFailure.family = %q, want %q", got, interfaces.ProviderErrorFamilyRetryable)
+	if got := stringPointerValue(completion.ProviderFailure.Family); got != string(interfaces.WorkFailureFamilyRetryable) {
+		t.Fatalf("DISPATCH_COMPLETED providerFailure.family = %q, want %q", got, interfaces.WorkFailureFamilyRetryable)
 	}
 	assertContainsAll(
 		t,

--- a/tests/functional/runtime_api/api_inference_events_test.go
+++ b/tests/functional/runtime_api/api_inference_events_test.go
@@ -90,8 +90,8 @@ func TestInferenceEvents_HTTPStreamAndDashboardProjectionCorrelateRetryAttempts(
 			{Content: "Step two done. COMPLETE"},
 		},
 		[]error{
-			workers.NewProviderError(interfaces.ProviderErrorTypeTimeout, "provider timeout", nil),
-			workers.NewProviderError(interfaces.ProviderErrorTypeInternalServerError, "provider 500", nil),
+			workers.NewProviderError(interfaces.WorkFailureTypeTimeout, "provider timeout", nil),
+			workers.NewProviderError(interfaces.WorkFailureTypeInternalServerError, "provider 500", nil),
 			nil,
 			nil,
 		},

--- a/tests/functional/runtime_api/api_runtime_config_alignment_smoke_support_test.go
+++ b/tests/functional/runtime_api/api_runtime_config_alignment_smoke_support_test.go
@@ -573,11 +573,11 @@ func assertRuntimeConfigAlignmentDispatchHistory(t *testing.T, history []interfa
 	if timeoutDispatch.ProviderFailure == nil {
 		t.Fatalf("%s failed dispatch ProviderFailure = nil, want timeout metadata", runtimeConfigAlignmentExecuteWorkstation)
 	}
-	if timeoutDispatch.ProviderFailure.Type != interfaces.ProviderErrorTypeTimeout {
-		t.Fatalf("%s failed dispatch ProviderFailure.Type = %q, want %q", runtimeConfigAlignmentExecuteWorkstation, timeoutDispatch.ProviderFailure.Type, interfaces.ProviderErrorTypeTimeout)
+	if timeoutDispatch.ProviderFailure.Type != interfaces.WorkFailureTypeTimeout {
+		t.Fatalf("%s failed dispatch ProviderFailure.Type = %q, want %q", runtimeConfigAlignmentExecuteWorkstation, timeoutDispatch.ProviderFailure.Type, interfaces.WorkFailureTypeTimeout)
 	}
-	if timeoutDispatch.ProviderFailure.Family != interfaces.ProviderErrorFamilyRetryable {
-		t.Fatalf("%s failed dispatch ProviderFailure.Family = %q, want %q", runtimeConfigAlignmentExecuteWorkstation, timeoutDispatch.ProviderFailure.Family, interfaces.ProviderErrorFamilyRetryable)
+	if timeoutDispatch.ProviderFailure.Family != interfaces.WorkFailureFamilyRetryable {
+		t.Fatalf("%s failed dispatch ProviderFailure.Family = %q, want %q", runtimeConfigAlignmentExecuteWorkstation, timeoutDispatch.ProviderFailure.Family, interfaces.WorkFailureFamilyRetryable)
 	}
 	if !runtimeConfigAlignmentHasDispatch(history, runtimeConfigAlignmentExecuteWorkstation, interfaces.OutcomeAccepted, "") {
 		t.Fatalf("dispatch history missing accepted retry for %s: %#v", runtimeConfigAlignmentExecuteWorkstation, history)

--- a/tests/functional/runtime_api/dashboard_engine_state_test.go
+++ b/tests/functional/runtime_api/dashboard_engine_state_test.go
@@ -46,7 +46,7 @@ func TestDashboard_EngineStateSnapshot_EndToEnd(t *testing.T) {
 	submitDashboardWorldViewFunctionalWork(t, h, "world-view-failed", "trace-world-view-failed")
 	provider.nextDispatch(t)
 	provider.respond(interfaces.InferenceResponse{}, workers.NewProviderErrorWithSession(
-		interfaces.ProviderErrorTypePermanentBadRequest,
+		interfaces.WorkFailureTypePermanentBadRequest,
 		"provider rejected dashboard world-view work",
 		errors.New("provider rejected"),
 		&interfaces.ProviderSessionMetadata{Provider: "codex", Kind: "session_id", ID: "sess-world-view-failed"},


### PR DESCRIPTION
{
  "project": "you-agent-factory",
  "branchName": "collapse-provider-failure-type-aliases",
  "description": "Collapse duplicate ProviderError* and ProviderFailure* Go type aliases and compatibility shims to the canonical WorkFailure* naming family across pkg/interfaces, pkg/workers, pkg/factory, pkg/service, and pkg/replay while keeping published JSON and OpenAPI field names unchanged.",
  "context": {
    "customerAsk": "Remove ProviderError* and ProviderFailure* Go type aliases from pkg/interfaces/work_execution.go, delete or inline shim helpers in pkg/workers/provider_compat.go, migrate call sites under pkg/workers, pkg/factory, pkg/service, pkg/replay, and projection tests to WorkFailure* names, and update world_view_contract_guard_test.go allowlists only when symbol renames require it. Do not rename JSON or OpenAPI fields.",
    "problem": "pkg/interfaces/work_execution.go exports compatibility aliases that duplicate canonical WorkFailure* types, and pkg/workers/provider_compat.go adds shim indirection without changing wire behavior. Maintainers must choose between two Go naming families for the same normalized failure metadata.",
    "solution": "Use one Go naming family (WorkFailure*) for normalized failure metadata, remove alias types and const blocks from pkg/interfaces, delete or inline provider compat shims, update all scoped Go call sites and test assertions to WorkFailure* identifiers, and preserve published JSON/OpenAPI field names (providerFailure, ProviderFailureMetadata schema)."
  },
  "acceptanceCriteria": [
    "No ProviderErrorFamily, ProviderErrorType, ProviderFailureMetadata, or ProviderFailureDecision type aliases remain in pkg/interfaces/work_execution.go",
    "Shim helpers CloneProviderFailureMetadata, GeneratedProviderFailureMetadata, and ProviderFailureDecisionFromMetadata are removed or inlined; callers use WorkFailure* equivalents; pkg/workers/provider_compat.go is deleted or contains no duplicate re-exports",
    "Go call sites under pkg/workers, pkg/factory, pkg/service, and pkg/replay reference WorkFailure* names exclusively for failure metadata types and helpers",
    "go test ./pkg/interfaces/... ./pkg/workers/... ./pkg/factory/... ./pkg/service/... ./pkg/replay/... passes with behavioral tests updated only for renamed Go identifiers not wire JSON",
    "OpenAPI schema property names and JSON field names for provider failure metadata are unchanged",
    "Typecheck passes, lint passes, and tests pass for all changes in this work item"
  ],
  "userStories": [
    {
      "id": "collapse-provider-failure-type-aliases-001",
      "title": "Remove Provider* type aliases from interfaces package",
      "description": "As a backend maintainer, I want pkg/interfaces to export only WorkFailure* types for normalized failure metadata so the public Go contract has one naming family at the type boundary.",
      "acceptanceCriteria": [
        "ProviderErrorFamily, ProviderErrorType, ProviderFailureMetadata, and ProviderFailureDecision type aliases and associated const blocks are removed from pkg/interfaces/work_execution.go",
        "Canonical WorkFailure* types remain exported with unchanged wire-relevant struct tags and JSON field names",
        "pkg/interfaces tests compile and pass using WorkFailure* identifiers only",
        "pkg/interfaces/world_view_contract_guard_test.go allowlists are updated only if symbol renames require it; no new meta inventory tests are added",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "collapse-provider-failure-type-aliases-002",
      "title": "Remove provider compat shims and migrate workers package",
      "description": "As a worker-runtime maintainer, I want failure metadata helpers to call WorkFailure* functions directly so provider execution code does not depend on legacy shim indirection.",
      "acceptanceCriteria": [
        "CloneProviderFailureMetadata call sites use CloneWorkFailureMetadata; GeneratedProviderFailureMetadata call sites use GeneratedWorkFailureMetadata; ProviderFailureDecisionFromMetadata call sites use the equivalent WorkFailure* decision helper",
        "pkg/workers/provider_compat.go is deleted or contains no remaining re-exports that duplicate pkg/workers/provider symbols importable directly",
        "All pkg/workers Go references to ProviderError* and ProviderFailure* types are replaced with WorkFailure* names; failure classification behavior is unchanged",
        "go test ./pkg/workers/... passes",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "collapse-provider-failure-type-aliases-003",
      "title": "Migrate factory and service call sites to WorkFailure* names",
      "description": "As a factory/service maintainer, I want orchestration and delivery code to use WorkFailure* identifiers so failure handling reads consistently across runtime packages.",
      "acceptanceCriteria": [
        "All Go references under pkg/factory and pkg/service to removed ProviderError* and ProviderFailure* types or shim helpers are updated to WorkFailure* names",
        "Failure metadata serialization on WorkResult and WorkstationResult still emits the same JSON field names with unchanged payload shapes",
        "Existing failure classification and delivery tests pass after updating assertions for renamed Go identifiers only",
        "go test ./pkg/factory/... ./pkg/service/... passes",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "collapse-provider-failure-type-aliases-004",
      "title": "Migrate replay and projection tests to WorkFailure* names",
      "description": "As a replay/projection maintainer, I want replay delivery and world-state projection tests to assert against WorkFailure* types so test code matches production naming without changing observed wire output.",
      "acceptanceCriteria": [
        "All Go references under pkg/replay and projection-related tests to removed ProviderError* and ProviderFailure* types or shim helpers are updated to WorkFailure* names",
        "Replay delivery behavior and world-state projection outputs are unchanged; test updates are limited to Go identifier renames not JSON golden expectations",
        "Duplicate test helpers are removed only when touched for compilation; no broad cleanup beyond compilation requirements",
        "go test ./pkg/replay/... and projection tests in scoped packages pass",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "collapse-provider-failure-type-aliases-005",
      "title": "Verify no remaining Provider* Go aliases in scoped packages",
      "description": "As a reviewer, I want a final integration gate confirming the alias collapse is complete and wire contracts are untouched so this cleanup cannot regress customer-visible behavior.",
      "acceptanceCriteria": [
        "Search under pkg/interfaces, pkg/workers, pkg/factory, pkg/service, and pkg/replay finds zero ProviderErrorFamily, ProviderErrorType, ProviderFailureMetadata, or ProviderFailureDecision type alias definitions; legacy function names remain only if required by generated code boundaries",
        "go test ./pkg/interfaces/... ./pkg/workers/... ./pkg/factory/... ./pkg/service/... ./pkg/replay/... -count=1 passes",
        "OpenAPI schema and JSON field names for provider failure metadata are unchanged from pre-change baseline",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)