### PR TITLE
inline-dashboard-header-allowlist-classes

### DIFF
--- a/ui/scripts/inline-component-class-usage-allowlist.mjs
+++ b/ui/scripts/inline-component-class-usage-allowlist.mjs
@@ -1,7 +1,3 @@
 export const allowlistedInlineComponentClassUsage = [
-  "src/features/header/components/dashboard-header.tsx#DASHBOARD_CONTROLS_CLASS",
-  "src/features/header/components/dashboard-header.tsx#DASHBOARD_HEADER_ACTION_ROW_CLASS",
-  "src/features/header/components/dashboard-header.tsx#DASHBOARD_TIMELINE_ACTIONS_CLASS",
-  "src/features/header/components/dashboard-header.tsx#LOCALE_MENU_PANEL_CLASS",
   "src/features/work-outcome/components/work-chart.tsx#WORK_CHART_TOOLBAR_CLASS",
 ];

--- a/ui/scripts/inline-component-class-usage-allowlist.mjs
+++ b/ui/scripts/inline-component-class-usage-allowlist.mjs
@@ -1,8 +1,4 @@
 export const allowlistedInlineComponentClassUsage = [
-  "src/features/header/components/dashboard-header.tsx#DASHBOARD_TOOLBAR_CLASS",
-  "src/features/header/components/dashboard-header.tsx#DASHBOARD_HEADER_ROWS_CLASS",
-  "src/features/header/components/dashboard-header.tsx#DASHBOARD_PRIMARY_ROW_CLASS",
-  "src/features/header/components/dashboard-header.tsx#DASHBOARD_SECONDARY_ROW_CLASS",
   "src/features/header/components/dashboard-header.tsx#DASHBOARD_TIMELINE_CLUSTER_CLASS",
   "src/features/header/components/dashboard-header.tsx#DASHBOARD_SESSION_STRIP_CLASS",
   "src/features/header/components/dashboard-header.tsx#DASHBOARD_TIMELINE_OPERATIONS_ROW_CLASS",

--- a/ui/scripts/inline-component-class-usage-allowlist.mjs
+++ b/ui/scripts/inline-component-class-usage-allowlist.mjs
@@ -1,7 +1,4 @@
 export const allowlistedInlineComponentClassUsage = [
-  "src/features/header/components/dashboard-header.tsx#DASHBOARD_TIMELINE_CLUSTER_CLASS",
-  "src/features/header/components/dashboard-header.tsx#DASHBOARD_SESSION_STRIP_CLASS",
-  "src/features/header/components/dashboard-header.tsx#DASHBOARD_TIMELINE_OPERATIONS_ROW_CLASS",
   "src/features/header/components/dashboard-header.tsx#DASHBOARD_CONTROLS_CLASS",
   "src/features/header/components/dashboard-header.tsx#DASHBOARD_HEADER_ACTION_ROW_CLASS",
   "src/features/header/components/dashboard-header.tsx#DASHBOARD_TIMELINE_ACTIONS_CLASS",

--- a/ui/src/features/header/components/dashboard-header.tsx
+++ b/ui/src/features/header/components/dashboard-header.tsx
@@ -31,14 +31,8 @@ import { TickSliderControl } from "./tick-slider-control";
 
 const DASHBOARD_BRAND_SLOT_CLASS = "min-w-0 self-end pb-2";
 const DASHBOARD_TITLE_CLASS = cn("m-0 shrink-0", DASHBOARD_PAGE_HEADING_CLASS);
-const DASHBOARD_CONTROLS_CLASS = "shrink-0 self-end pb-2";
-const DASHBOARD_HEADER_ACTION_ROW_CLASS = "justify-end max-md:w-full";
 const DASHBOARD_HEADER_ACTION_ROW_ACTIONS_CLASS =
   "max-md:w-full max-md:justify-end";
-const DASHBOARD_TIMELINE_ACTIONS_CLASS =
-  "ml-auto flex shrink-0 items-center gap-1.5";
-const LOCALE_MENU_PANEL_CLASS =
-  "absolute right-0 top-full z-10 mt-2 min-w-44 overflow-hidden rounded-2xl border border-af-border bg-af-surface-raised p-1 text-af-text shadow-af-panel backdrop-blur-lg";
 const LOCALE_MENU_ITEM_CLASS = cn(
   "min-h-0 w-full justify-start rounded-xl border-transparent px-3 py-2 text-sm",
   "[&>span]:grid [&>span]:w-full [&>span]:grid-cols-[minmax(0,1fr)_auto] [&>span]:items-center [&>span]:gap-2 [&>span]:text-left",
@@ -95,7 +89,7 @@ export function DashboardHeader({ locale }: DashboardHeaderProps) {
             actions={
               <fieldset
                 aria-label={headerMessages.globalHeaderActionsLabel}
-                className={DASHBOARD_CONTROLS_CLASS}
+                className="shrink-0 self-end pb-2"
               >
                 <DashboardLocaleMenu
                   locale={resolvedLocale}
@@ -104,13 +98,13 @@ export function DashboardHeader({ locale }: DashboardHeaderProps) {
               </fieldset>
             }
             actionsClassName={DASHBOARD_HEADER_ACTION_ROW_ACTIONS_CLASS}
-            className={DASHBOARD_HEADER_ACTION_ROW_CLASS}
+            className="justify-end max-md:w-full"
           />
         </div>
         <div className="flex min-w-0">
           <div className="relative flex min-w-0 w-full rounded-sm items-center gap-1.5 rounded-t-2xl bg-af-surface-subtle pb-2 px-2 pt-1">
             <TickSliderControl locale={resolvedLocale} />
-            <div className={DASHBOARD_TIMELINE_ACTIONS_CLASS}>
+            <div className="ml-auto flex shrink-0 items-center gap-1.5">
               {sessionTabsState.activeSession ? (
                 <DashboardHeaderActionButton
                   aria-label={sessionStreamToggleLabel(
@@ -306,7 +300,7 @@ function DashboardLocaleMenuList({
   return (
     <div
       aria-label={label}
-      className={LOCALE_MENU_PANEL_CLASS}
+      className="absolute right-0 top-full z-10 mt-2 min-w-44 overflow-hidden rounded-2xl border border-af-border bg-af-surface-raised p-1 text-af-text shadow-af-panel backdrop-blur-lg"
       id={id}
       onKeyDown={(event) => {
         if (event.key === "Escape") {

--- a/ui/src/features/header/components/dashboard-header.tsx
+++ b/ui/src/features/header/components/dashboard-header.tsx
@@ -30,11 +30,6 @@ import { DashboardSessionTabs } from "./dashboard-session-tabs";
 import { TickSliderControl } from "./tick-slider-control";
 
 const DASHBOARD_BRAND_SLOT_CLASS = "min-w-0 self-end pb-2";
-const DASHBOARD_TIMELINE_CLUSTER_CLASS = "flex min-w-0 w-full flex-1";
-const DASHBOARD_SESSION_STRIP_CLASS =
-  "flex min-w-0 h-full w-full items-stretch overflow-x-auto px-4 pt-1";
-const DASHBOARD_TIMELINE_OPERATIONS_ROW_CLASS =
-  "relative flex min-w-0 w-full rounded-sm items-center gap-1.5 rounded-t-2xl bg-af-surface-subtle pb-2 px-2 pt-1";
 const DASHBOARD_TITLE_CLASS = cn("m-0 shrink-0", DASHBOARD_PAGE_HEADING_CLASS);
 const DASHBOARD_CONTROLS_CLASS = "shrink-0 self-end pb-2";
 const DASHBOARD_HEADER_ACTION_ROW_CLASS = "justify-end max-md:w-full";
@@ -88,8 +83,8 @@ export function DashboardHeader({ locale }: DashboardHeaderProps) {
               wordmarkClassName="truncate"
             />
           </h1>
-          <div className={DASHBOARD_TIMELINE_CLUSTER_CLASS}>
-            <div className={DASHBOARD_SESSION_STRIP_CLASS}>
+          <div className="flex min-w-0 w-full flex-1">
+            <div className="flex min-w-0 h-full w-full items-stretch overflow-x-auto px-4 pt-1">
               <DashboardSessionTabs
                 locale={resolvedLocale}
                 state={sessionTabsState}
@@ -113,7 +108,7 @@ export function DashboardHeader({ locale }: DashboardHeaderProps) {
           />
         </div>
         <div className="flex min-w-0">
-          <div className={DASHBOARD_TIMELINE_OPERATIONS_ROW_CLASS}>
+          <div className="relative flex min-w-0 w-full rounded-sm items-center gap-1.5 rounded-t-2xl bg-af-surface-subtle pb-2 px-2 pt-1">
             <TickSliderControl locale={resolvedLocale} />
             <div className={DASHBOARD_TIMELINE_ACTIONS_CLASS}>
               {sessionTabsState.activeSession ? (

--- a/ui/src/features/header/components/dashboard-header.tsx
+++ b/ui/src/features/header/components/dashboard-header.tsx
@@ -29,16 +29,6 @@ import { DashboardHeaderActionButton } from "./dashboard-header-action-button";
 import { DashboardSessionTabs } from "./dashboard-session-tabs";
 import { TickSliderControl } from "./tick-slider-control";
 
-const DASHBOARD_TOOLBAR_CLASS = cn(
-  DASHBOARD_PANEL_SHELL_CLASS,
-  "mb-3 grid gap-2 ",
-);
-const DASHBOARD_HEADER_ROWS_CLASS = "flex min-w-0 flex-col gap-0";
-const DASHBOARD_PRIMARY_ROW_CLASS = cn(
-  "flex min-w-0 items-stretch gap-2",
-  "max-md:flex-col px-2",
-);
-const DASHBOARD_SECONDARY_ROW_CLASS = "flex min-w-0";
 const DASHBOARD_BRAND_SLOT_CLASS = "min-w-0 self-end pb-2";
 const DASHBOARD_TIMELINE_CLUSTER_CLASS = "flex min-w-0 w-full flex-1";
 const DASHBOARD_SESSION_STRIP_CLASS =
@@ -83,10 +73,15 @@ export function DashboardHeader({ locale }: DashboardHeaderProps) {
   return (
     <section
       aria-label={headerMessages.dashboardSummaryLabel}
-      className={DASHBOARD_TOOLBAR_CLASS}
+      className={cn(DASHBOARD_PANEL_SHELL_CLASS, "mb-3 grid gap-2 ")}
     >
-      <div className={DASHBOARD_HEADER_ROWS_CLASS}>
-        <div className={DASHBOARD_PRIMARY_ROW_CLASS}>
+      <div className="flex min-w-0 flex-col gap-0">
+        <div
+          className={cn(
+            "flex min-w-0 items-stretch gap-2",
+            "max-md:flex-col px-2",
+          )}
+        >
           <h1 className={cn(DASHBOARD_TITLE_CLASS, DASHBOARD_BRAND_SLOT_CLASS)}>
             <DashboardBrandLockup
               locale={resolvedLocale}
@@ -117,7 +112,7 @@ export function DashboardHeader({ locale }: DashboardHeaderProps) {
             className={DASHBOARD_HEADER_ACTION_ROW_CLASS}
           />
         </div>
-        <div className={DASHBOARD_SECONDARY_ROW_CLASS}>
+        <div className="flex min-w-0">
           <div className={DASHBOARD_TIMELINE_OPERATIONS_ROW_CLASS}>
             <TickSliderControl locale={resolvedLocale} />
             <div className={DASHBOARD_TIMELINE_ACTIONS_CLASS}>


### PR DESCRIPTION
{
  "project": "Inline Dashboard Header Allowlist Component Classes",
  "branchName": "inline-dashboard-header-allowlist-classes",
  "description": "Move eleven allowlisted Tailwind class constants in dashboard-header.tsx into JSX className props or inline cn(...) expressions, remove the constants and matching allowlist keys, and verify dashboard header toolbar, timeline, session strip, controls, action rows, and locale menu presentation and behavior remain unchanged.",
  "context": {
    "customerAsk": "Inline dashboard header allowlist component classes: move eleven allowlisted file-level Tailwind class constants in dashboard-header.tsx into JSX className props and remove only the matching allowlist entries.",
    "problem": "Eleven single-use module-level *CLASS constants in dashboard-header.tsx are allowlisted exceptions to check:inline-component-class-usage, hiding header toolbar, timeline, session strip, and locale menu styling from JSX and blocking allowlist shrinkage after the trace-drilldown slice landed.",
    "solution": "Inline each allowlisted Tailwind string or equivalent cn(...) composition onto the corresponding JSX className use sites in dashboard-header.tsx, delete those eleven constants, remove only the eleven matching keys from inline-component-class-usage-allowlist.mjs, leave work-chart.tsx untouched, and verify with check:inline-component-class-usage, lint, typecheck, and header/session-tabs tests."
  },
  "acceptanceCriteria": [
    "All eleven allowlisted constants are removed and their exact Tailwind strings or equivalent cn(...) compositions appear inline on the corresponding JSX className props.",
    "Dashboard header behavior and layout are unchanged: toolbar shell, primary/secondary rows, timeline cluster, session strip, timeline operations row, controls cluster, header action row, timeline actions, and locale menu panel match pre-change presentation; session tabs, tick slider, export/locale actions, and keyboard focus behavior are unchanged.",
    "Non-allowlisted constants in dashboard-header.tsx such as DASHBOARD_BRAND_SLOT_CLASS, DASHBOARD_TITLE_CLASS, and LOCALE_MENU_ITEM_CLASS remain unless already dead code.",
    "Only the eleven specified dashboard-header.tsx allowlist keys are removed; work-chart.tsx#WORK_CHART_TOOLBAR_CLASS stays untouched.",
    "cd ui && npm run check:inline-component-class-usage exits 0 with no violations or stale keys for dashboard-header.tsx.",
    "cd ui && npm run lint passes; UI typecheck and existing header/session-tabs behavioral tests pass.",
    "Typecheck, lint, and tests pass."
  ],
  "userStories": [
    {
      "id": "inline-dashboard-header-allowlist-classes-001",
      "title": "Inline toolbar and header row layout classes",
      "description": "As a maintainer, I want the allowlisted toolbar and primary/secondary row class strings on JSX className props so header shell layout is visible at the use site without changing toolbar structure or row stacking behavior.",
      "acceptanceCriteria": [
        "DASHBOARD_TOOLBAR_CLASS, DASHBOARD_HEADER_ROWS_CLASS, DASHBOARD_PRIMARY_ROW_CLASS, and DASHBOARD_SECONDARY_ROW_CLASS are deleted from dashboard-header.tsx.",
        "Each deleted constant's styling appears on the corresponding JSX className prop: verbatim strings where applicable; equivalent cn(...) at JSX sites where the constant used cn.",
        "Non-allowlisted constants in the same file such as DASHBOARD_BRAND_SLOT_CLASS and DASHBOARD_TITLE_CLASS remain unless already unused dead code.",
        "Toolbar shell and primary/secondary row layout match pre-change presentation.",
        "Brand slot, title, and row content placement behave the same as before.",
        "Typecheck passes",
        "Tests pass for existing dashboard header coverage when present",
        "Verify in browser: dashboard header toolbar and primary/secondary rows match pre-change layout at desktop and narrow widths."
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "inline-dashboard-header-allowlist-classes-002",
      "title": "Inline timeline cluster, session strip, and operations row classes",
      "description": "As a maintainer, I want the allowlisted timeline cluster, session strip, and timeline operations row class strings on JSX className props so timeline header chrome is readable at use sites without changing session tabs, tick slider, or timeline control behavior.",
      "acceptanceCriteria": [
        "DASHBOARD_TIMELINE_CLUSTER_CLASS, DASHBOARD_SESSION_STRIP_CLASS, and DASHBOARD_TIMELINE_OPERATIONS_ROW_CLASS are deleted from dashboard-header.tsx.",
        "Each deleted constant's styling appears on the corresponding JSX className prop as a verbatim string or equivalent cn(...) composition.",
        "Timeline cluster, session strip, and timeline operations row chrome match pre-change presentation.",
        "Session tabs rendering, tick slider interaction, and timeline operations controls behave the same as before.",
        "Typecheck passes",
        "Tests pass for existing header and session-tabs behavioral coverage when present",
        "Verify in browser: timeline cluster, session strip, and operations row match pre-change appearance; session tabs and tick slider keyboard focus behavior unchanged."
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "inline-dashboard-header-allowlist-classes-003",
      "title": "Inline controls, action rows, timeline actions, and locale menu panel classes",
      "description": "As a maintainer, I want the allowlisted controls cluster, header action row, timeline actions, and locale menu panel class strings on JSX className props so action and locale menu styling is visible at use sites without changing export/locale actions or menu keyboard behavior.",
      "acceptanceCriteria": [
        "DASHBOARD_CONTROLS_CLASS, DASHBOARD_HEADER_ACTION_ROW_CLASS, DASHBOARD_TIMELINE_ACTIONS_CLASS, and LOCALE_MENU_PANEL_CLASS are deleted from dashboard-header.tsx.",
        "Each deleted constant's styling appears on the corresponding JSX className prop as a verbatim string or equivalent cn(...) composition.",
        "Non-allowlisted LOCALE_MENU_ITEM_CLASS remains unless already unused dead code.",
        "Controls cluster, header action row, timeline actions, and locale menu panel chrome match pre-change presentation.",
        "Export and locale menu actions, menu open/close, and keyboard focus order behave the same as before.",
        "Typecheck passes",
        "Tests pass for existing header and locale menu behavioral coverage when present",
        "Verify in browser: controls cluster, action rows, timeline actions, and locale menu panel match pre-change appearance and keyboard interaction."
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "inline-dashboard-header-allowlist-classes-004",
      "title": "Remove allowlist keys and pass inline-class check",
      "description": "As CI, I need the eleven obsolete allowlist exceptions removed so check:inline-component-class-usage enforces inline classes for dashboard header sites going forward.",
      "acceptanceCriteria": [
        "The eleven specified allowlist keys are removed from ui/scripts/inline-component-class-usage-allowlist.mjs and no other allowlist entries are added, removed, or modified, including work-chart.tsx#WORK_CHART_TOOLBAR_CLASS.",
        "cd ui && npm run check:inline-component-class-usage exits 0 with no violations for dashboard-header.tsx.",
        "No stale allowlist keys remain referencing the deleted constants.",
        "cd ui && npm run lint passes.",
        "Typecheck passes",
        "Tests pass for existing header and session-tabs behavioral assertions; extend only if needed to lock header structure without allowlist-topology, file-layout, or route-registration meta-tests."
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)