### PR TITLE
inline-work-chart-toolbar-class

### DIFF
--- a/ui/scripts/inline-component-class-usage-allowlist.mjs
+++ b/ui/scripts/inline-component-class-usage-allowlist.mjs
@@ -1,3 +1,1 @@
-export const allowlistedInlineComponentClassUsage = [
-  "src/features/work-outcome/components/work-chart.tsx#WORK_CHART_TOOLBAR_CLASS",
-];
+export const allowlistedInlineComponentClassUsage = [];

--- a/ui/src/features/work-outcome/components/work-chart.tsx
+++ b/ui/src/features/work-outcome/components/work-chart.tsx
@@ -59,8 +59,6 @@ const WORK_CHART_STATUS_PANEL_CLASS =
   "flex h-full min-h-[14rem] min-w-0 w-full flex-1 flex-col justify-center";
 const WORK_CHART_SHELL_CLASS =
   "flex h-full min-h-0 min-w-0 w-full flex-1 flex-col gap-3";
-const WORK_CHART_TOOLBAR_CLASS =
-  "flex flex-wrap items-center justify-end gap-2";
 const WORK_CHART_Y_AXIS_WIDTH = 52;
 
 export type WorkChartState =
@@ -216,7 +214,7 @@ function ReadyWorkChart({
     <div className={cn(WORK_CHART_SHELL_CLASS, className)}>
       {zoomRange === null ? null : (
         <div
-          className={WORK_CHART_TOOLBAR_CLASS}
+          className="flex flex-wrap items-center justify-end gap-2"
           data-work-chart-toolbar="true"
         >
           <Button


### PR DESCRIPTION
{
  "project": "Inline Work Chart Toolbar Class",
  "branchName": "inline-work-chart-toolbar-class",
  "description": "Inline the final allowlisted WORK_CHART_TOOLBAR_CLASS constant in work-chart.tsx onto the toolbar wrapper className, remove the constant and matching allowlist key, and verify work chart zoom toolbar, legend, and series behavior remain unchanged while completing the repo-owned inline-class allowlist migration.",
  "context": {
    "customerAsk": "Inline the last repo-owned allowlist entry work-chart.tsx#WORK_CHART_TOOLBAR_CLASS: move the single-use WORK_CHART_TOOLBAR_CLASS Tailwind string onto the toolbar JSX className, delete the constant, and remove the matching key from inline-component-class-usage-allowlist.mjs after the dashboard header slice (PR #645).",
    "problem": "WORK_CHART_TOOLBAR_CLASS is the only remaining allowlisted exception to check:inline-component-class-usage, hiding work chart toolbar row styling from JSX and blocking allowlist completion after PR #645 removed the eleven dashboard header keys.",
    "solution": "Copy the toolbar Tailwind string onto the toolbar wrapper className in work-chart.tsx, delete WORK_CHART_TOOLBAR_CLASS, remove work-chart.tsx#WORK_CHART_TOOLBAR_CLASS from inline-component-class-usage-allowlist.mjs leaving an empty array export, and verify with check:inline-component-class-usage, lint, typecheck, and existing work-chart behavioral tests."
  },
  "acceptanceCriteria": [
    "WORK_CHART_TOOLBAR_CLASS is removed from work-chart.tsx and its Tailwind string (flex flex-wrap items-center justify-end gap-2) or equivalent cn(...) appears inline on the toolbar wrapper className prop.",
    "Work chart toolbar layout and behavior are unchanged: reset-zoom control when zoomed, toolbar outside chart interaction surface, keyboard operable reset, data-work-chart-toolbar=true, and unchanged legend placement and series visibility toggles.",
    "Other work-chart constants such as WORK_CHART_SHELL_CLASS, legend classes, and presentation exports remain unless already dead code.",
    "work-chart.tsx#WORK_CHART_TOOLBAR_CLASS is removed from the allowlist; cd ui && npm run check:inline-component-class-usage exits 0 with allowlistedInlineComponentClassUsage empty.",
    "cd ui && npm run lint passes; work-chart.test.tsx, work-chart-warning-regression.test.tsx, and d3-information-card.test.tsx behavioral tests pass without allowlist-topology meta-tests.",
    "Typecheck, lint, and tests pass."
  ],
  "userStories": [
    {
      "id": "inline-work-chart-toolbar-class-001",
      "title": "Inline toolbar class on work chart JSX",
      "description": "As a maintainer, I want the allowlisted work chart toolbar class string on the toolbar wrapper JSX className so zoom-reset row styling is visible at the use site without changing when the toolbar appears or how reset zoom behaves.",
      "acceptanceCriteria": [
        "WORK_CHART_TOOLBAR_CLASS is deleted from work-chart.tsx.",
        "The deleted constant's styling (flex flex-wrap items-center justify-end gap-2) appears on the toolbar wrapper className prop as a verbatim string or equivalent cn(...) composition.",
        "Non-allowlisted work-chart constants in the same file such as WORK_CHART_SHELL_CLASS, WORK_CHART_LEGEND_*, and WORK_CHART_STATUS_PANEL_CLASS remain unless already unused dead code.",
        "The toolbar wrapper retains data-work-chart-toolbar=true.",
        "When zoomRange is non-null, the reset-zoom button renders in the toolbar row, is not contained inside the chart img interaction surface, and restores full tick visibility on click or keyboard activation; when zoomRange is null, the toolbar row is not rendered.",
        "Legend row placement, series visibility toggles, and chart ready/overlay data-work-chart-* attributes match pre-change behavior.",
        "Typecheck passes",
        "Tests pass for work-chart.test.tsx, work-chart-warning-regression.test.tsx, and d3-information-card.test.tsx zoom/toolbar behavioral coverage",
        "Verify in browser: zoom the work outcome chart, confirm reset toolbar alignment and reset action; confirm legend and series toggles match pre-change layout."
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "inline-work-chart-toolbar-class-002",
      "title": "Clear allowlist and pass inline-class check",
      "description": "As CI, I need the final obsolete allowlist exception removed so check:inline-component-class-usage enforces inline classes repo-wide with zero allowlisted entries.",
      "acceptanceCriteria": [
        "src/features/work-outcome/components/work-chart.tsx#WORK_CHART_TOOLBAR_CLASS is removed from ui/scripts/inline-component-class-usage-allowlist.mjs and no other allowlist entries are added.",
        "allowlistedInlineComponentClassUsage is an empty array export (or the file is removed only if check:inline-component-class-usage and lint scripts tolerate it without modification).",
        "cd ui && npm run check:inline-component-class-usage exits 0 with no violations for work-chart.tsx and no stale keys referencing WORK_CHART_TOOLBAR_CLASS.",
        "cd ui && npm run lint passes.",
        "Typecheck passes",
        "Tests pass for existing work-chart and d3-information-card behavioral assertions; extend only if needed to lock toolbar via data-work-chart-toolbar or reset-zoom control behavior, not allowlist topology or file inventories."
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)