### PR TITLE
prd-factory-graph-add-node-placement

### DIFF
--- a/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
+++ b/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
@@ -519,6 +519,69 @@ describe.sequential("factory graph editor node placement browser integration", (
   );
 
   it(
+    "places a newly added workstation near the visible viewport center after panning",
+    async () => {
+      const server = await startFactoryApiServer({
+        apiPort: preview.apiPort,
+        currentFactory: editableGraphFactoryDefinition,
+        eventLines: editableGraphFactoryReplayLines,
+      });
+      const browserPage = await openBrowserPage();
+
+      try {
+        await browserPage.page.goto(preview.previewURL, {
+          waitUntil: "domcontentloaded",
+        });
+        await server.replayCompleted;
+
+        const toolbar = await enterGraphEditor(browserPage.page);
+        await panGraphViewport(browserPage.page, -220, 160);
+
+        await addWorkstation(browserPage.page, toolbar, {
+          body: "Review the drafted story.",
+          name: "review",
+        });
+
+        const workstationNode = browserPage.page.getByTestId(
+          "rf__node-workstation:review",
+        );
+        await workstationNode.waitFor({
+          state: "visible",
+          timeout: uiInteractionTimeoutMs,
+        });
+
+        const viewportMetrics = await viewportScreenMetrics(browserPage.page);
+        const addedWorkstationCenter = await nodeScreenCenter(
+          browserPage.page,
+          "rf__node-workstation:review",
+        );
+
+        expect(
+          isNearViewportCenter(addedWorkstationCenter, viewportMetrics),
+        ).toBe(true);
+
+        const flowPosition = await readNodeFlowPosition(
+          browserPage.page,
+          "rf__node-workstation:review",
+        );
+        expect(flowPosition).not.toBeNull();
+        expect(Number.isFinite(flowPosition.x)).toBe(true);
+        expect(Number.isFinite(flowPosition.y)).toBe(true);
+
+        expectNoBrowserErrors(
+          browserPage.pageErrors,
+          browserPage.consoleErrors,
+          expect,
+        );
+      } finally {
+        await server.stop();
+        await browserPage.close();
+      }
+    },
+    browserScenarioTimeoutMs,
+  );
+
+  it(
     "nudges a newly added workstation away from an existing viewport-center worker",
     async () => {
       const server = await startFactoryApiServer({

--- a/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
+++ b/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
@@ -159,12 +159,6 @@ const editableGraphFactoryReplayLines = [
 const viewportCenterToleranceRatio = 0.35;
 const flowPositionTolerancePx = 8;
 
-function distanceBetweenPoints(left, right) {
-  const deltaX = left.x - right.x;
-  const deltaY = left.y - right.y;
-  return Math.hypot(deltaX, deltaY);
-}
-
 function flowPositionsMatchWithinTolerance(left, right) {
   if (!left || !right) {
     return false;
@@ -460,75 +454,6 @@ describe.sequential("factory graph editor node placement browser integration", (
   afterEach(async () => {
     await new Promise((resolve) => setTimeout(resolve, 250));
   });
-
-  it(
-    "places a newly added worker near the visible viewport center after panning",
-    async () => {
-      const server = await startFactoryApiServer({
-        apiPort: preview.apiPort,
-        currentFactory: editableGraphFactoryDefinition,
-        eventLines: editableGraphFactoryReplayLines,
-      });
-      const browserPage = await openBrowserPage();
-
-      try {
-        await browserPage.page.goto(preview.previewURL, {
-          waitUntil: "domcontentloaded",
-        });
-        await server.replayCompleted;
-
-        const toolbar = await enterGraphEditor(browserPage.page);
-        await panGraphViewport(browserPage.page, 240, 180);
-
-        const existingDraftCenter = await nodeScreenCenter(
-          browserPage.page,
-          "rf__node-workstation:draft",
-        );
-        await addWorker(browserPage.page, toolbar, { name: "assistant" });
-
-        const newWorkerNode = browserPage.page.getByTestId(
-          "rf__node-worker:assistant",
-        );
-        await newWorkerNode.waitFor({
-          state: "visible",
-          timeout: uiInteractionTimeoutMs,
-        });
-
-        const viewportMetrics = await viewportScreenMetrics(browserPage.page);
-        const addedWorkerCenter = await nodeScreenCenter(
-          browserPage.page,
-          "rf__node-worker:assistant",
-        );
-        const distanceFromExistingDraft = distanceBetweenPoints(
-          addedWorkerCenter,
-          existingDraftCenter,
-        );
-
-        expect(isNearViewportCenter(addedWorkerCenter, viewportMetrics)).toBe(
-          true,
-        );
-        expect(distanceFromExistingDraft).toBeGreaterThan(80);
-
-        const flowPosition = await readNodeFlowPosition(
-          browserPage.page,
-          "rf__node-worker:assistant",
-        );
-        expect(flowPosition).not.toBeNull();
-        expect(Number.isFinite(flowPosition.x)).toBe(true);
-        expect(Number.isFinite(flowPosition.y)).toBe(true);
-
-        expectNoBrowserErrors(
-          browserPage.pageErrors,
-          browserPage.consoleErrors,
-          expect,
-        );
-      } finally {
-        await server.stop();
-        await browserPage.close();
-      }
-    },
-    browserScenarioTimeoutMs,
-  );
 
   it(
     "places a newly added workstation near the visible viewport center after panning",

--- a/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
+++ b/ui/integration/factory-graph-editor-node-placement.integration.test.mjs
@@ -157,11 +157,23 @@ const editableGraphFactoryReplayLines = [
 ];
 
 const viewportCenterToleranceRatio = 0.35;
+const flowPositionTolerancePx = 8;
 
 function distanceBetweenPoints(left, right) {
   const deltaX = left.x - right.x;
   const deltaY = left.y - right.y;
   return Math.hypot(deltaX, deltaY);
+}
+
+function flowPositionsMatchWithinTolerance(left, right) {
+  if (!left || !right) {
+    return false;
+  }
+
+  return (
+    Math.abs(left.x - right.x) <= flowPositionTolerancePx &&
+    Math.abs(left.y - right.y) <= flowPositionTolerancePx
+  );
 }
 
 function boundingBoxesOverlap(left, right) {
@@ -631,6 +643,85 @@ describe.sequential("factory graph editor node placement browser integration", (
         );
 
         expect(boundingBoxesOverlap(anchorBox, workstationBox)).toBe(false);
+
+        expectNoBrowserErrors(
+          browserPage.pageErrors,
+          browserPage.consoleErrors,
+          expect,
+        );
+      } finally {
+        await server.stop();
+        await browserPage.close();
+      }
+    },
+    browserScenarioTimeoutMs,
+  );
+
+  it(
+    "keeps a newly added workstation flow position after save and reload",
+    async () => {
+      const server = await startFactoryApiServer({
+        apiPort: preview.apiPort,
+        currentFactory: editableGraphFactoryDefinition,
+        eventLines: editableGraphFactoryReplayLines,
+      });
+      const browserPage = await openBrowserPage();
+
+      try {
+        await browserPage.page.goto(preview.previewURL, {
+          waitUntil: "domcontentloaded",
+        });
+        await server.replayCompleted;
+
+        const toolbar = await enterGraphEditor(browserPage.page);
+        await panGraphViewport(browserPage.page, -180, 140);
+
+        await addWorkstation(browserPage.page, toolbar, {
+          body: "Review the drafted story.",
+          name: "review",
+        });
+
+        const workstationTestId = "rf__node-workstation:review";
+        await browserPage.page
+          .getByTestId(workstationTestId)
+          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+
+        const positionBeforeSave = await readNodeFlowPosition(
+          browserPage.page,
+          workstationTestId,
+        );
+        expect(positionBeforeSave).not.toBeNull();
+
+        await saveGraphDraft(browserPage.page, toolbar);
+
+        const positionAfterSave = await readNodeFlowPosition(
+          browserPage.page,
+          workstationTestId,
+        );
+        expect(
+          flowPositionsMatchWithinTolerance(
+            positionBeforeSave,
+            positionAfterSave,
+          ),
+        ).toBe(true);
+
+        await browserPage.page.reload({ waitUntil: "domcontentloaded" });
+        await server.replayCompleted;
+        await enterGraphEditor(browserPage.page);
+        await browserPage.page
+          .getByTestId(workstationTestId)
+          .waitFor({ state: "visible", timeout: uiInteractionTimeoutMs });
+
+        const positionAfterReload = await readNodeFlowPosition(
+          browserPage.page,
+          workstationTestId,
+        );
+        expect(
+          flowPositionsMatchWithinTolerance(
+            positionBeforeSave,
+            positionAfterReload,
+          ),
+        ).toBe(true);
 
         expectNoBrowserErrors(
           browserPage.pageErrors,

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-save-layout-boundary.test.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-save-layout-boundary.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+
+import { applyFactoryGraphAddEntityDraft } from "./factory-graph-editor-additions";
+import { baseFactoryDefinition } from "./factory-graph-draft.test-helpers";
+import { createEmptyFactoryGraphDraft } from "./factory-graph-draft-types";
+import {
+  addFactoryGraphNode,
+  applyFactoryGraphPendingEdits,
+  buildFactoryGraphState,
+} from "./factory-graph-operations";
+import {
+  factoryDefinitionSavePayloadHasGraphLayoutFields,
+  findGraphLayoutPropertyPaths,
+} from "./factory-graph-save-layout-boundary";
+
+describe("factory graph save layout boundary", () => {
+  it("detects nested layout coordinate metadata", () => {
+    expect(
+      findGraphLayoutPropertyPaths({
+        workstations: [
+          {
+            layout: { x: 10, y: 20 },
+            name: "draft",
+          },
+        ],
+      }),
+    ).toEqual(
+      expect.arrayContaining(["workstations[0].layout", "workstations[0].layout.x"]),
+    );
+  });
+
+  it("ignores unrelated factory definition fields", () => {
+    expect(
+      findGraphLayoutPropertyPaths({
+        name: "Current Factory",
+        workstations: [
+          {
+            body: "Draft the story.",
+            name: "draft",
+            worker: "writer",
+          },
+        ],
+      }),
+    ).toEqual([]);
+  });
+
+  it("does not add layout fields when adding a workstation to the draft", () => {
+    const addResult = addFactoryGraphNode({
+      baseFactoryDefinition,
+      draft: createEmptyFactoryGraphDraft(),
+      node: {
+        behavior: "DEFAULT",
+        body: "Review the draft.",
+        kind: "workstation",
+        name: "review-station",
+        workerName: "writer",
+      },
+    });
+    expect(addResult.ok).toBe(true);
+    if (!addResult.ok) {
+      return;
+    }
+
+    expect(findGraphLayoutPropertyPaths(addResult.value)).toEqual([]);
+  });
+
+  it("does not add layout fields to the save payload for a newly added workstation", () => {
+    const addResult = addFactoryGraphNode({
+      baseFactoryDefinition,
+      draft: createEmptyFactoryGraphDraft(),
+      node: {
+        behavior: "DEFAULT",
+        body: "Review the draft.",
+        kind: "workstation",
+        name: "review-station",
+        workerName: "writer",
+      },
+    });
+    expect(addResult.ok).toBe(true);
+    if (!addResult.ok) {
+      return;
+    }
+
+    const saveInput = applyFactoryGraphPendingEdits({
+      baseFactoryDefinition,
+      draft: addResult.value,
+    });
+    expect(saveInput.ok).toBe(true);
+    if (!saveInput.ok) {
+      return;
+    }
+
+    expect(factoryDefinitionSavePayloadHasGraphLayoutFields(saveInput.value)).toBe(
+      false,
+    );
+    expect(
+      saveInput.value.workstations?.find(
+        (workstation) => workstation.name === "review-station",
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        body: "Review the draft.",
+        name: "review-station",
+        worker: "writer",
+      }),
+    );
+  });
+
+  it("keeps graph draft additions free of layout metadata for all add kinds", () => {
+    let draft = createEmptyFactoryGraphDraft();
+
+    draft = applyFactoryGraphAddEntityDraft(draft, {
+      capacity: "2",
+      kind: "resource",
+      name: "gpu",
+    });
+    draft = applyFactoryGraphAddEntityDraft(draft, {
+      argsText: "",
+      command: "node",
+      kind: "worker",
+      model: "",
+      modelProvider: "",
+      name: "runner",
+      workerType: "SCRIPT_WORKER",
+    });
+    draft = applyFactoryGraphAddEntityDraft(draft, {
+      initialStateName: "queued",
+      kind: "work-type",
+      name: "task",
+    });
+    draft = applyFactoryGraphAddEntityDraft(draft, {
+      kind: "work-state",
+      name: "done",
+      stateType: "TERMINAL",
+      workTypeName: "task",
+    });
+    draft = applyFactoryGraphAddEntityDraft(draft, {
+      behavior: "DEFAULT",
+      body: "",
+      kind: "workstation",
+      name: "process",
+      workerName: "runner",
+    });
+
+    expect(findGraphLayoutPropertyPaths(draft)).toEqual([]);
+    expect(
+      factoryDefinitionSavePayloadHasGraphLayoutFields(
+        buildFactoryGraphState({
+          baseFactoryDefinition,
+          draft,
+        }).saveInput,
+      ),
+    ).toBe(false);
+  });
+});

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-save-layout-boundary.test.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-save-layout-boundary.test.ts
@@ -13,7 +13,7 @@ import {
   findGraphLayoutPropertyPaths,
 } from "./factory-graph-save-layout-boundary";
 
-describe("factory graph save layout boundary", () => {
+describe("findGraphLayoutPropertyPaths", () => {
   it("detects nested layout coordinate metadata", () => {
     expect(
       findGraphLayoutPropertyPaths({
@@ -43,7 +43,9 @@ describe("factory graph save layout boundary", () => {
       }),
     ).toEqual([]);
   });
+});
 
+describe("factory graph save layout boundary", () => {
   it("does not add layout fields when adding a workstation to the draft", () => {
     const addResult = addFactoryGraphNode({
       baseFactoryDefinition,

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-save-layout-boundary.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-save-layout-boundary.ts
@@ -1,0 +1,56 @@
+const GRAPH_LAYOUT_PROPERTY_NAMES = new Set([
+  "coordinates",
+  "graphLayout",
+  "graphPosition",
+  "graphPositions",
+  "layout",
+  "nodeLayout",
+  "nodePosition",
+  "nodePositions",
+  "position",
+  "positions",
+]);
+
+/**
+ * Returns dotted paths to graph-layout metadata that must not appear in
+ * factory definition save payloads. Positions belong in the UI position store.
+ */
+export function findGraphLayoutPropertyPaths(
+  value: unknown,
+  path = "",
+): string[] {
+  if (value === null || typeof value !== "object") {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((entry, index) =>
+      findGraphLayoutPropertyPaths(entry, `${path}[${index}]`),
+    );
+  }
+
+  const paths: string[] = [];
+  for (const [key, entry] of Object.entries(value)) {
+    const nextPath = path.length > 0 ? `${path}.${key}` : key;
+    if (GRAPH_LAYOUT_PROPERTY_NAMES.has(key)) {
+      paths.push(nextPath);
+    }
+    if (key === "x" || key === "y") {
+      const sibling = value as Record<string, unknown>;
+      const hasCoordinatePair =
+        typeof sibling.x === "number" && typeof sibling.y === "number";
+      if (hasCoordinatePair) {
+        paths.push(nextPath);
+      }
+    }
+    paths.push(...findGraphLayoutPropertyPaths(entry, nextPath));
+  }
+
+  return paths;
+}
+
+export function factoryDefinitionSavePayloadHasGraphLayoutFields(
+  factoryDefinition: unknown,
+): boolean {
+  return findGraphLayoutPropertyPaths(factoryDefinition).length > 0;
+}

--- a/ui/src/features/workflow-activity/components/graph-editor-placement-context.tsx
+++ b/ui/src/features/workflow-activity/components/graph-editor-placement-context.tsx
@@ -76,8 +76,10 @@ export function GraphEditorPlacementRegistrar({
   storedNodePositions: GraphNodePositions;
 }) {
   const apiRef = useContext(GraphEditorPlacementContext);
-  const [pendingDraft, setPendingDraft] =
-    useState<FactoryGraphAddEntityDraft | null>(null);
+  const [pendingPlacement, setPendingPlacement] = useState<{
+    draft: FactoryGraphAddEntityDraft;
+    storageGraphKey: string;
+  } | null>(null);
   const placementInput = useMemo(
     () => ({
       graphKey,
@@ -95,13 +97,17 @@ export function GraphEditorPlacementRegistrar({
 
     apiRef.current = {
       placeAddedNode: (draft) => {
-        setPendingDraft(draft);
+        const nodeId = factoryGraphNodeIdForAddEntityDraft(draft);
+        setPendingPlacement({
+          draft,
+          storageGraphKey: graphKeyAfterAddingNode(graphKey, nodeId),
+        });
       },
     };
-  }, [apiRef]);
+  }, [apiRef, graphKey]);
 
   useEffect(() => {
-    if (!pendingDraft || !placementInput.graphKey) {
+    if (!pendingPlacement || !placementInput.graphKey) {
       return;
     }
 
@@ -112,7 +118,7 @@ export function GraphEditorPlacementRegistrar({
     }
 
     const topLeft = resolveInitialPlacementTopLeft({
-      draft: pendingDraft,
+      draft: pendingPlacement.draft,
       nodes: placementInput.nodes,
       storedPositions: placementInput.storedNodePositions,
       viewportCenter: viewportCenterInFlowCoordinates(
@@ -121,18 +127,18 @@ export function GraphEditorPlacementRegistrar({
       ),
     });
     if (!topLeft) {
-      setPendingDraft(null);
+      setPendingPlacement(null);
       return;
     }
 
-    const nodeId = factoryGraphNodeIdForAddEntityDraft(pendingDraft);
+    const nodeId = factoryGraphNodeIdForAddEntityDraft(pendingPlacement.draft);
     placementInput.setStoredNodePosition(
-      graphKeyAfterAddingNode(placementInput.graphKey, nodeId),
+      pendingPlacement.storageGraphKey,
       nodeId,
       topLeft,
     );
-    setPendingDraft(null);
-  }, [flowContainerRef, flowInstanceRef, pendingDraft, placementInput]);
+    setPendingPlacement(null);
+  }, [flowContainerRef, flowInstanceRef, pendingPlacement, placementInput]);
 
   return null;
 }

--- a/ui/src/features/workflow-activity/components/graph-editor-placement-registrar.test.tsx
+++ b/ui/src/features/workflow-activity/components/graph-editor-placement-registrar.test.tsx
@@ -1,0 +1,107 @@
+import { render, waitFor } from "@testing-library/react";
+import type { ReactFlowInstance } from "@xyflow/react";
+import { useEffect, useRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { graphEditorNodeDimensionsForKind } from "../lib/graph-editor-node-placement";
+import { graphKeyAfterAddingNode } from "../lib/react-flow-current-activity-card-keys";
+import {
+  GraphEditorPlacementProvider,
+  GraphEditorPlacementRegistrar,
+  useGraphEditorPlaceAddedNode,
+} from "./graph-editor-placement-context";
+
+function mockContainerRect(): DOMRect {
+  return {
+    bottom: 650,
+    height: 600,
+    left: 100,
+    right: 900,
+    toJSON: () => ({}),
+    top: 50,
+    width: 800,
+    x: 100,
+    y: 50,
+  } as DOMRect;
+}
+
+function TriggerWorkstationPlacement() {
+  const placeAddedNode = useGraphEditorPlaceAddedNode();
+
+  useEffect(() => {
+    placeAddedNode?.({
+      behavior: "STANDARD",
+      body: "",
+      kind: "workstation",
+      name: "review",
+      workerName: "writer",
+    });
+  }, [placeAddedNode]);
+
+  return null;
+}
+
+describe("GraphEditorPlacementRegistrar regression", () => {
+  it("stores add placement under the post-add graph key from the live viewport center", async () => {
+    const setStoredNodePosition = vi.fn();
+    const graphKey =
+      "worker:writer|workstation:draft::workstation-input:place:story:queued->workstation:draft";
+    const workstationSize = graphEditorNodeDimensionsForKind("workstation");
+    const screenCenter = { x: 500, y: 350 };
+    const flowCenter = { x: 300, y: 200 };
+
+    function Harness() {
+      const flowContainerRef = useRef<HTMLDivElement>(null);
+      const flowInstanceRef = useRef<ReactFlowInstance>({
+        screenToFlowPosition: vi.fn(({ x, y }) => ({
+          x: x - (screenCenter.x - flowCenter.x),
+          y: y - (screenCenter.y - flowCenter.y),
+        })),
+      } as unknown as ReactFlowInstance);
+
+      return (
+        <div
+          ref={(element) => {
+            flowContainerRef.current = element;
+            if (element) {
+              element.getBoundingClientRect = () => mockContainerRect();
+            }
+          }}
+        >
+          <GraphEditorPlacementRegistrar
+            flowContainerRef={flowContainerRef}
+            flowInstanceRef={flowInstanceRef}
+            graphKey={graphKey}
+            nodes={[]}
+            setStoredNodePosition={setStoredNodePosition}
+            storedNodePositions={{}}
+          />
+          <TriggerWorkstationPlacement />
+        </div>
+      );
+    }
+
+    render(
+      <GraphEditorPlacementProvider>
+        <Harness />
+      </GraphEditorPlacementProvider>,
+    );
+
+    const expectedTopLeft = {
+      x: flowCenter.x - workstationSize.width / 2,
+      y: flowCenter.y - workstationSize.height / 2,
+    };
+    const storageGraphKey = graphKeyAfterAddingNode(
+      graphKey,
+      "workstation:review",
+    );
+
+    await waitFor(() => {
+      expect(setStoredNodePosition).toHaveBeenCalledWith(
+        storageGraphKey,
+        "workstation:review",
+        expectedTopLeft,
+      );
+    });
+  });
+});

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-surface.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-surface.tsx
@@ -13,7 +13,6 @@ import {
   saveErrorNoticeMessages,
   validationMessagesForGraphSelection,
 } from "../lib/react-flow-current-activity-card-validation";
-import { useCurrentActivityGraphStore } from "../state/currentActivityGraphStore";
 import { GraphEditorPlacementRegistrar } from "./graph-editor-placement-context";
 import type { CurrentActivitySelection } from "./react-flow-current-activity-card";
 import { CurrentActivityGraphViewport } from "./react-flow-current-activity-card-viewport";
@@ -39,9 +38,7 @@ export function CurrentActivityGraphSurface({
   const messages = getFactoryGraphEditorMessages(locale);
   const flowContainerRef = useRef<HTMLElement | null>(null);
   const flowInstanceRef = useRef<ReactFlowInstance | null>(null);
-  const storedNodePositions = useCurrentActivityGraphStore(
-    (state) => state.positionsByGraphKey[graph.graphKey] ?? {},
-  );
+  const storedNodePositions = graph.storedNodePositions;
   const saveError = editor.saveEditableDefinition.error;
   const editorValidationProjection = useMemo(() => {
     if (!editor.editorMode) {

--- a/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
+++ b/ui/src/features/workflow-activity/hooks/react-flow-current-activity-card-graph-view-model.ts
@@ -3,7 +3,13 @@ import {
   type FitViewOptions,
   type NodeChange,
 } from "@xyflow/react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from "react";
 
 import type {
   DashboardActiveExecution,
@@ -24,6 +30,7 @@ import {
   buildHandleAssignments,
   EMPTY_NODE_POSITIONS,
 } from "../lib/react-flow-current-activity-card-graph";
+import { resolveStoredNodePositionsForGraphKey } from "../lib/bridge-graph-layout-positions";
 import { currentActivityGraphKey } from "../lib/react-flow-current-activity-card-keys";
 import type { CurrentActivitySelection } from "../lib/react-flow-current-activity-card-types";
 import { useCurrentActivityGraphStore } from "../state/currentActivityGraphStore";
@@ -340,12 +347,38 @@ export function useCurrentActivityGraphViewModel({
     () => currentActivityGraphKey(graphLayout),
     [graphLayout],
   );
-  const storedNodePositions = useCurrentActivityGraphStore(
-    (state) => state.positionsByGraphKey[graphKey] ?? EMPTY_NODE_POSITIONS,
+  const layoutNodeIds = useMemo(
+    () => graphLayout.nodes.map((node) => node.nodeId),
+    [graphLayout.nodes],
+  );
+  const positionsByGraphKey = useCurrentActivityGraphStore(
+    (state) => state.positionsByGraphKey,
+  );
+  const bridgePositionsToGraphKey = useCurrentActivityGraphStore(
+    (state) => state.bridgePositionsToGraphKey,
+  );
+  const storedNodePositions = useMemo(
+    () =>
+      graphKey
+        ? resolveStoredNodePositionsForGraphKey(
+            positionsByGraphKey,
+            graphKey,
+            layoutNodeIds,
+          )
+        : EMPTY_NODE_POSITIONS,
+    [graphKey, layoutNodeIds, positionsByGraphKey],
   );
   const setStoredNodePosition = useCurrentActivityGraphStore(
     (state) => state.setNodePosition,
   );
+
+  useLayoutEffect(() => {
+    if (!graphKey || layoutNodeIds.length === 0) {
+      return;
+    }
+
+    bridgePositionsToGraphKey(graphKey, layoutNodeIds);
+  }, [bridgePositionsToGraphKey, graphKey, layoutNodeIds]);
   const { pendingAdditionEdgeIds, visibleGraphEdges } = useMemo(
     () =>
       buildVisibleGraphEdgesWithDraft({
@@ -407,5 +440,6 @@ export function useCurrentActivityGraphViewModel({
     initialFitViewOptions,
     nodes: displayNodes,
     setStoredNodePosition,
+    storedNodePositions,
   };
 }

--- a/ui/src/features/workflow-activity/lib/bridge-graph-layout-positions.test.ts
+++ b/ui/src/features/workflow-activity/lib/bridge-graph-layout-positions.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from "vitest";
+import {
+  bridgeGraphLayoutPositions,
+  findBridgedNodePosition,
+  nodeIdsFromGraphKey,
+  resolveStoredNodePositionsForGraphKey,
+} from "./bridge-graph-layout-positions";
+import { currentActivityGraphKey } from "./react-flow-current-activity-card-keys";
+
+const baseLayout = {
+  height: 100,
+  width: 400,
+  nodes: [
+    {
+      column: 0,
+      height: 86,
+      nodeId: "worker:writer",
+      nodeKind: "worker" as const,
+      row: 0,
+      width: 164,
+      x: 0,
+      y: 0,
+    },
+    {
+      column: 1,
+      height: 196,
+      nodeId: "workstation:draft",
+      nodeKind: "workstation" as const,
+      row: 0,
+      width: 156,
+      x: 200,
+      y: 0,
+    },
+  ],
+};
+
+describe("nodeIdsFromGraphKey", () => {
+  it("parses sorted node ids from the graph key node segment", () => {
+    const graphKey = currentActivityGraphKey({
+      ...baseLayout,
+      edges: [{ edgeId: "edge-a", fromNodeId: "a", toNodeId: "b" }],
+    });
+
+    expect([...nodeIdsFromGraphKey(graphKey)].sort()).toEqual([
+      "worker:writer",
+      "workstation:draft",
+    ]);
+  });
+});
+
+describe("findBridgedNodePosition", () => {
+  it("returns a position stored under a prior graph key when edges change on save", () => {
+    const beforeSaveKey = currentActivityGraphKey({
+      ...baseLayout,
+      edges: [
+        {
+          edgeId: "edge-draft",
+          fromNodeId: "workstation:draft",
+          toNodeId: "worker:writer",
+        },
+      ],
+      nodes: [
+        ...baseLayout.nodes,
+        {
+          column: 2,
+          height: 196,
+          nodeId: "workstation:review",
+          nodeKind: "workstation",
+          row: 0,
+          width: 156,
+          x: 420,
+          y: 0,
+        },
+      ],
+    });
+    const afterSaveKey = currentActivityGraphKey({
+      ...baseLayout,
+      edges: [
+        {
+          edgeId: "edge-saved",
+          fromNodeId: "workstation:draft",
+          toNodeId: "worker:writer",
+        },
+      ],
+      nodes: [
+        ...baseLayout.nodes,
+        {
+          column: 2,
+          height: 196,
+          nodeId: "workstation:review",
+          nodeKind: "workstation",
+          row: 0,
+          width: 156,
+          x: 420,
+          y: 0,
+        },
+      ],
+    });
+
+    const positionsByGraphKey = {
+      [beforeSaveKey]: {
+        "workstation:review": { x: 512, y: 288 },
+      },
+    };
+
+    expect(
+      findBridgedNodePosition(
+        positionsByGraphKey,
+        afterSaveKey,
+        "workstation:review",
+      ),
+    ).toEqual({ x: 512, y: 288 });
+    expect(positionsByGraphKey[afterSaveKey]).toBeUndefined();
+  });
+
+  it("does not bridge from graph keys that never included the node id", () => {
+    const preAddKey = currentActivityGraphKey({
+      ...baseLayout,
+      edges: [{ edgeId: "edge-a", fromNodeId: "a", toNodeId: "b" }],
+    });
+
+    expect(
+      findBridgedNodePosition(
+        {
+          [preAddKey]: {
+            "workstation:draft": { x: 10, y: 20 },
+          },
+        },
+        currentActivityGraphKey({
+          ...baseLayout,
+          edges: [{ edgeId: "edge-a", fromNodeId: "a", toNodeId: "b" }],
+          nodes: [
+            ...baseLayout.nodes,
+            {
+              column: 2,
+              height: 196,
+              nodeId: "workstation:review",
+              nodeKind: "workstation",
+              row: 0,
+              width: 156,
+              x: 420,
+              y: 0,
+            },
+          ],
+        }),
+        "workstation:review",
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("resolveStoredNodePositionsForGraphKey", () => {
+  it("merges bridged positions for layout node ids", () => {
+    const storedKey = currentActivityGraphKey({
+      ...baseLayout,
+      edges: [{ edgeId: "edge-old", fromNodeId: "a", toNodeId: "b" }],
+      nodes: [
+        ...baseLayout.nodes,
+        {
+          column: 2,
+          height: 196,
+          nodeId: "workstation:review",
+          nodeKind: "workstation",
+          row: 0,
+          width: 156,
+          x: 420,
+          y: 0,
+        },
+      ],
+    });
+    const lookupKey = currentActivityGraphKey({
+      ...baseLayout,
+      edges: [{ edgeId: "edge-new", fromNodeId: "a", toNodeId: "b" }],
+      nodes: [
+        ...baseLayout.nodes,
+        {
+          column: 2,
+          height: 196,
+          nodeId: "workstation:review",
+          nodeKind: "workstation",
+          row: 0,
+          width: 156,
+          x: 420,
+          y: 0,
+        },
+      ],
+    });
+
+    const resolved = resolveStoredNodePositionsForGraphKey(
+      {
+        [storedKey]: {
+          "workstation:review": { x: 901, y: 402 },
+        },
+      },
+      lookupKey,
+      ["workstation:review", "workstation:draft"],
+    );
+
+    expect(resolved["workstation:review"]).toEqual({ x: 901, y: 402 });
+  });
+});
+
+describe("bridgeGraphLayoutPositions", () => {
+  it("writes bridged positions onto the target graph key", () => {
+    const storedKey = currentActivityGraphKey({
+      ...baseLayout,
+      edges: [{ edgeId: "edge-old", fromNodeId: "a", toNodeId: "b" }],
+      nodes: [
+        ...baseLayout.nodes,
+        {
+          column: 2,
+          height: 196,
+          nodeId: "workstation:review",
+          nodeKind: "workstation",
+          row: 0,
+          width: 156,
+          x: 420,
+          y: 0,
+        },
+      ],
+    });
+    const targetKey = currentActivityGraphKey({
+      ...baseLayout,
+      edges: [{ edgeId: "edge-new", fromNodeId: "a", toNodeId: "b" }],
+      nodes: [
+        ...baseLayout.nodes,
+        {
+          column: 2,
+          height: 196,
+          nodeId: "workstation:review",
+          nodeKind: "workstation",
+          row: 0,
+          width: 156,
+          x: 420,
+          y: 0,
+        },
+      ],
+    });
+    const positionsByGraphKey = {
+      [storedKey]: {
+        "workstation:review": { x: 120, y: 240 },
+      },
+    };
+
+    const bridged = bridgeGraphLayoutPositions({
+      nodeIds: ["workstation:review"],
+      positionsByGraphKey,
+      targetGraphKey: targetKey,
+    });
+
+    expect(bridged?.[targetKey]?.["workstation:review"]).toEqual({
+      x: 120,
+      y: 240,
+    });
+    expect(bridged?.[storedKey]?.["workstation:review"]).toEqual({
+      x: 120,
+      y: 240,
+    });
+  });
+
+  it("returns null when the target key already has stored positions", () => {
+    const graphKey = currentActivityGraphKey({
+      ...baseLayout,
+      edges: [{ edgeId: "edge-a", fromNodeId: "a", toNodeId: "b" }],
+    });
+
+    expect(
+      bridgeGraphLayoutPositions({
+        nodeIds: ["workstation:draft"],
+        positionsByGraphKey: {
+          [graphKey]: {
+            "workstation:draft": { x: 1, y: 2 },
+          },
+        },
+        targetGraphKey: graphKey,
+      }),
+    ).toBeNull();
+  });
+});

--- a/ui/src/features/workflow-activity/lib/bridge-graph-layout-positions.ts
+++ b/ui/src/features/workflow-activity/lib/bridge-graph-layout-positions.ts
@@ -1,0 +1,129 @@
+import type {
+  GraphNodePosition,
+  GraphNodePositions,
+} from "../state/currentActivityGraphStore";
+
+function finitePosition(
+  position: GraphNodePosition | undefined,
+): position is GraphNodePosition {
+  return (
+    position !== undefined &&
+    Number.isFinite(position.x) &&
+    Number.isFinite(position.y)
+  );
+}
+
+export function nodeIdsFromGraphKey(graphKey: string): ReadonlySet<string> {
+  const separatorIndex = graphKey.indexOf("::");
+  const nodePart =
+    separatorIndex === -1 ? graphKey : graphKey.slice(0, separatorIndex);
+  return new Set(nodePart.split("|").filter((nodeId) => nodeId.length > 0));
+}
+
+export function findBridgedNodePosition(
+  positionsByGraphKey: Record<string, GraphNodePositions>,
+  targetGraphKey: string,
+  nodeId: string,
+): GraphNodePosition | undefined {
+  const direct = positionsByGraphKey[targetGraphKey]?.[nodeId];
+  if (finitePosition(direct)) {
+    return direct;
+  }
+
+  const targetNodeIds = nodeIdsFromGraphKey(targetGraphKey);
+  let bestMatch: { overlap: number; position: GraphNodePosition } | undefined;
+
+  for (const [graphKey, positions] of Object.entries(positionsByGraphKey)) {
+    if (graphKey === targetGraphKey) {
+      continue;
+    }
+
+    if (!nodeIdsFromGraphKey(graphKey).has(nodeId)) {
+      continue;
+    }
+
+    const position = positions[nodeId];
+    if (!finitePosition(position)) {
+      continue;
+    }
+
+    const overlap = [...targetNodeIds].filter((candidateNodeId) =>
+      nodeIdsFromGraphKey(graphKey).has(candidateNodeId),
+    ).length;
+    if (!bestMatch || overlap > bestMatch.overlap) {
+      bestMatch = { overlap, position };
+    }
+  }
+
+  return bestMatch?.position;
+}
+
+export function resolveStoredNodePositionsForGraphKey(
+  positionsByGraphKey: Record<string, GraphNodePositions>,
+  graphKey: string,
+  nodeIds: readonly string[],
+): GraphNodePositions {
+  const direct = positionsByGraphKey[graphKey] ?? {};
+  const resolved: GraphNodePositions = { ...direct };
+
+  for (const nodeId of nodeIds) {
+    if (finitePosition(resolved[nodeId])) {
+      continue;
+    }
+
+    const bridged = findBridgedNodePosition(
+      positionsByGraphKey,
+      graphKey,
+      nodeId,
+    );
+    if (bridged) {
+      resolved[nodeId] = bridged;
+    }
+  }
+
+  return resolved;
+}
+
+export function bridgeGraphLayoutPositions({
+  nodeIds,
+  positionsByGraphKey,
+  targetGraphKey,
+}: {
+  nodeIds: readonly string[];
+  positionsByGraphKey: Record<string, GraphNodePositions>;
+  targetGraphKey: string;
+}): Record<string, GraphNodePositions> | null {
+  if (!targetGraphKey) {
+    return null;
+  }
+
+  const targetPositions = { ...(positionsByGraphKey[targetGraphKey] ?? {}) };
+  let changed = false;
+
+  for (const nodeId of nodeIds) {
+    if (finitePosition(targetPositions[nodeId])) {
+      continue;
+    }
+
+    const bridged = findBridgedNodePosition(
+      positionsByGraphKey,
+      targetGraphKey,
+      nodeId,
+    );
+    if (!bridged) {
+      continue;
+    }
+
+    targetPositions[nodeId] = bridged;
+    changed = true;
+  }
+
+  if (!changed) {
+    return null;
+  }
+
+  return {
+    ...positionsByGraphKey,
+    [targetGraphKey]: targetPositions,
+  };
+}

--- a/ui/src/features/workflow-activity/lib/graph-add-placement-reprojection.regression.test.ts
+++ b/ui/src/features/workflow-activity/lib/graph-add-placement-reprojection.regression.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+
+import type { DashboardSnapshot } from "../../../api/dashboard/types";
+import type { CanonicalFactoryDefinition } from "../../../api/factory-definition";
+import { baseFactoryDefinition } from "../../factory-graph-editor/lib/factory-graph-draft.test-helpers";
+import { resolveStoredNodePositionsForGraphKey } from "./bridge-graph-layout-positions";
+import {
+  buildCurrentActivityGraphLayoutFromFactory,
+  dashboardWorkstationFromFactory,
+} from "./current-activity-factory-graph-layout";
+import {
+  buildActiveGraphHighlights,
+  buildActiveItemLabelsByPlaceId,
+  buildCurrentActivityNodes,
+  buildVisibleGraphEdges,
+} from "./react-flow-current-activity-card-graph";
+import { currentActivityGraphKey } from "./react-flow-current-activity-card-keys";
+
+const factoryWithReviewWorkstation: CanonicalFactoryDefinition = {
+  ...baseFactoryDefinition,
+  workstations: [
+    ...(baseFactoryDefinition.workstations ?? []),
+    {
+      body: "Review the story.",
+      inputs: [{ state: "queued", workType: "story" }],
+      name: "review",
+      outputs: [{ state: "done", workType: "story" }],
+      resources: [{ capacity: 2, name: "gpu" }],
+      type: "MODEL_WORKSTATION",
+      worker: "writer",
+    },
+  ],
+};
+
+function buildSnapshot(factory: CanonicalFactoryDefinition): DashboardSnapshot {
+  const workstations = (factory.workstations ?? []).map(
+    dashboardWorkstationFromFactory,
+  );
+
+  return {
+    factory,
+    factory_state: "IDLE",
+    runtime: {
+      active_executions_by_dispatch_id: {},
+      current_work_items_by_place_id: {},
+      place_occupancy_work_items_by_place_id: {},
+      place_token_counts: {},
+      session: {
+        completed_count: 0,
+        dispatched_count: 0,
+        failed_count: 0,
+        has_data: true,
+        provider_sessions: [],
+      },
+      workstation_requests_by_dispatch_id: {},
+    },
+    tick_count: 0,
+    topology: {
+      edges: [],
+      workstation_node_ids: workstations.map(
+        (workstation) => workstation.node_id,
+      ),
+      workstation_nodes_by_id: Object.fromEntries(
+        workstations.map((workstation) => [workstation.node_id, workstation]),
+      ),
+    },
+    uptime_seconds: 0,
+  };
+}
+
+describe("graph add placement reprojection regression", () => {
+  it("keeps a newly added workstation stored position after topology graph key changes", async () => {
+    const snapshot = buildSnapshot(factoryWithReviewWorkstation);
+    const graphLayout = await buildCurrentActivityGraphLayoutFromFactory(
+      factoryWithReviewWorkstation,
+    );
+    const layoutNode = graphLayout.nodes.find(
+      (node) => node.nodeId === "workstation:review",
+    );
+    expect(layoutNode).toBeDefined();
+
+    const layoutFallback = { x: layoutNode?.x ?? 0, y: layoutNode?.y ?? 0 };
+    const storedPosition = { x: 512, y: 288 };
+    expect(storedPosition).not.toEqual(layoutFallback);
+
+    const beforeSaveKey = currentActivityGraphKey({
+      ...graphLayout,
+      edges: [
+        {
+          edgeId: "edge-before-save",
+          fromNodeId: "workstation:draft",
+          toNodeId: "worker:writer",
+        },
+      ],
+    });
+    const afterSaveKey = currentActivityGraphKey({
+      ...graphLayout,
+      edges: [
+        {
+          edgeId: "edge-after-save",
+          fromNodeId: "workstation:draft",
+          toNodeId: "worker:writer",
+        },
+      ],
+    });
+    expect(beforeSaveKey).not.toEqual(afterSaveKey);
+
+    const positionsByGraphKey = {
+      [beforeSaveKey]: {
+        "workstation:review": storedPosition,
+      },
+    };
+    const nodeIds = graphLayout.nodes.map((node) => node.nodeId);
+    const storedNodePositions = resolveStoredNodePositionsForGraphKey(
+      positionsByGraphKey,
+      afterSaveKey,
+      nodeIds,
+    );
+
+    expect(storedNodePositions["workstation:review"]).toEqual(storedPosition);
+
+    const visibleGraphEdges = buildVisibleGraphEdges(graphLayout);
+    const nodes = buildCurrentActivityNodes({
+      activeExecutionsByWorkstationNodeID: {},
+      activeGraphHighlights: buildActiveGraphHighlights(
+        [],
+        visibleGraphEdges,
+        graphLayout.nodes,
+      ),
+      activeItemLabelsByPlaceId: buildActiveItemLabelsByPlaceId([]),
+      graphLayout,
+      now: Date.parse("2026-06-04T00:00:00Z"),
+      onSelectResource: vi.fn(),
+      onSelectStateNode: vi.fn(),
+      onSelectWorkID: vi.fn(),
+      onSelectWorker: vi.fn(),
+      onSelectWorkType: vi.fn(),
+      onSelectWorkstation: vi.fn(),
+      selection: null,
+      snapshot,
+      storedNodePositions,
+    });
+
+    const reviewNode = nodes.find((node) => node.id === "workstation:review");
+    expect(reviewNode?.position).toEqual(storedPosition);
+    expect(reviewNode?.position).not.toEqual(layoutFallback);
+  });
+});

--- a/ui/src/features/workflow-activity/lib/graph-editor-add-node-placement.regression.test.ts
+++ b/ui/src/features/workflow-activity/lib/graph-editor-add-node-placement.regression.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import type { FactoryGraphAddEntityDraft } from "../../factory-graph-editor/lib/factory-graph-editor-additions";
+import { resolveInitialPlacementTopLeft } from "./graph-editor-add-node-placement";
+import { graphEditorNodeDimensionsForKind } from "./graph-editor-node-placement";
+
+/**
+ * Regression guard for add placement ignoring the live viewport (pre-pan coordinates).
+ * Pure tests cover every addable kind; browser integration covers workstation pan-add only.
+ */
+describe("graph editor add placement regression", () => {
+  const prePanCenter = { x: 120, y: 80 };
+  const postPanCenter = { x: 880, y: 640 };
+
+  const addDraftsByKind: FactoryGraphAddEntityDraft[] = [
+    { capacity: 1, kind: "resource", name: "extra-gpu" },
+    { kind: "worker", model: "gpt", name: "assistant" },
+    { kind: "work-type", name: "review-story" },
+    {
+      kind: "work-state",
+      name: "blocked",
+      stateType: "PROCESSING",
+      workTypeName: "story",
+    },
+    {
+      behavior: "STANDARD",
+      body: "",
+      kind: "workstation",
+      name: "review",
+      workerName: "writer",
+    },
+  ];
+
+  it.each(
+    addDraftsByKind,
+  )("changes initial top-left when the viewport center moves for $kind adds", (draft) => {
+    const nearTopLeft = resolveInitialPlacementTopLeft({
+      draft,
+      nodes: [],
+      storedPositions: {},
+      viewportCenter: prePanCenter,
+    });
+    const farTopLeft = resolveInitialPlacementTopLeft({
+      draft,
+      nodes: [],
+      storedPositions: {},
+      viewportCenter: postPanCenter,
+    });
+
+    expect(nearTopLeft).not.toBeNull();
+    expect(farTopLeft).not.toBeNull();
+    expect(nearTopLeft).not.toEqual(farTopLeft);
+  });
+
+  it("derives top-left from kind dimensions at the viewport center", () => {
+    const viewportCenter = { x: 640, y: 360 };
+    const workstationSize = graphEditorNodeDimensionsForKind("workstation");
+
+    const topLeft = resolveInitialPlacementTopLeft({
+      draft: {
+        behavior: "STANDARD",
+        body: "",
+        kind: "workstation",
+        name: "review",
+        workerName: "writer",
+      },
+      nodes: [],
+      storedPositions: {},
+      viewportCenter,
+    });
+
+    expect(topLeft).toEqual({
+      x: viewportCenter.x - workstationSize.width / 2,
+      y: viewportCenter.y - workstationSize.height / 2,
+    });
+  });
+});

--- a/ui/src/features/workflow-activity/lib/graph-editor-add-node-placement.test.ts
+++ b/ui/src/features/workflow-activity/lib/graph-editor-add-node-placement.test.ts
@@ -2,6 +2,7 @@ import type { Node } from "@xyflow/react";
 import { describe, expect, it } from "vitest";
 
 import type { FactoryGraphAddEntityDraft } from "../../factory-graph-editor/lib/factory-graph-editor-additions";
+import { graphEditorNodeDimensionsForKind } from "./graph-editor-node-placement";
 import {
   factoryGraphNodeIdForAddEntityDraft,
   occupiedRectsFromRenderedNodes,
@@ -15,6 +16,19 @@ function workerNode(id: string, position: { x: number; y: number }): Node {
     id,
     position,
     width: 164,
+  };
+}
+
+function workstationNode(
+  id: string,
+  position: { x: number; y: number },
+): Node {
+  return {
+    data: { kind: "workstation" },
+    height: 196,
+    id,
+    position,
+    width: 156,
   };
 }
 
@@ -148,6 +162,55 @@ describe("resolveInitialPlacementTopLeft", () => {
   });
 });
 
+describe("resolveInitialPlacementTopLeft for workstations", () => {
+  const workstationDraft: FactoryGraphAddEntityDraft = {
+    behavior: "STANDARD",
+    body: "",
+    kind: "workstation",
+    name: "review",
+    workerName: "writer",
+  };
+
+  it("centers at the viewport when the canvas center is free", () => {
+    const viewportCenter = { x: 500, y: 300 };
+    const workstationSize = graphEditorNodeDimensionsForKind("workstation");
+
+    const topLeft = resolveInitialPlacementTopLeft({
+      draft: workstationDraft,
+      nodes: [],
+      storedPositions: {},
+      viewportCenter,
+    });
+
+    expect(topLeft).toEqual({
+      x: viewportCenter.x - workstationSize.width / 2,
+      y: viewportCenter.y - workstationSize.height / 2,
+    });
+  });
+
+  it("nudges away from occupied nodes at the viewport center", () => {
+    const viewportCenter = { x: 500, y: 300 };
+    const workstationSize = graphEditorNodeDimensionsForKind("workstation");
+    const centeredTopLeft = {
+      x: viewportCenter.x - workstationSize.width / 2,
+      y: viewportCenter.y - workstationSize.height / 2,
+    };
+    const nodes = [
+      workstationNode("workstation:writer", centeredTopLeft),
+    ];
+
+    const topLeft = resolveInitialPlacementTopLeft({
+      draft: workstationDraft,
+      nodes,
+      storedPositions: {},
+      viewportCenter,
+    });
+
+    expect(topLeft).not.toEqual(centeredTopLeft);
+    expect(topLeft).not.toBeNull();
+  });
+});
+
 describe("occupiedRectsFromRenderedNodes", () => {
   it("builds axis-aligned rects from rendered node positions and kind dimensions", () => {
     const rects = occupiedRectsFromRenderedNodes([
@@ -155,5 +218,18 @@ describe("occupiedRectsFromRenderedNodes", () => {
     ]);
 
     expect(rects).toEqual([{ height: 86, width: 164, x: 100, y: 200 }]);
+  });
+
+  it("uses measured node size when kind metadata is unavailable", () => {
+    const rects = occupiedRectsFromRenderedNodes([
+      {
+        height: 120,
+        id: "unknown:node",
+        position: { x: 40, y: 50 },
+        width: 80,
+      },
+    ]);
+
+    expect(rects).toEqual([{ height: 120, width: 80, x: 40, y: 50 }]);
   });
 });

--- a/ui/src/features/workflow-activity/lib/graph-editor-add-node-placement.test.ts
+++ b/ui/src/features/workflow-activity/lib/graph-editor-add-node-placement.test.ts
@@ -102,6 +102,50 @@ describe("resolveInitialPlacementTopLeft", () => {
 
     expect(topLeft).toEqual({ x: 418, y: 257 });
   });
+
+  it("changes the computed top-left when the viewport center moves for worker and workstation kinds", () => {
+    const workstationDraft: FactoryGraphAddEntityDraft = {
+      behavior: "STANDARD",
+      body: "",
+      kind: "workstation",
+      name: "review",
+      workerName: "writer",
+    };
+    const nearCenter = { x: 500, y: 300 };
+    const farCenter = { x: 1200, y: 900 };
+
+    const workerNear = resolveInitialPlacementTopLeft({
+      draft: workerDraft,
+      nodes: [],
+      storedPositions: {},
+      viewportCenter: nearCenter,
+    });
+    const workerFar = resolveInitialPlacementTopLeft({
+      draft: workerDraft,
+      nodes: [],
+      storedPositions: {},
+      viewportCenter: farCenter,
+    });
+    const workstationNear = resolveInitialPlacementTopLeft({
+      draft: workstationDraft,
+      nodes: [],
+      storedPositions: {},
+      viewportCenter: nearCenter,
+    });
+    const workstationFar = resolveInitialPlacementTopLeft({
+      draft: workstationDraft,
+      nodes: [],
+      storedPositions: {},
+      viewportCenter: farCenter,
+    });
+
+    expect(workerNear).not.toEqual(workerFar);
+    expect(workstationNear).not.toEqual(workstationFar);
+    expect(workerNear).not.toBeNull();
+    expect(workerFar).not.toBeNull();
+    expect(workstationNear).not.toBeNull();
+    expect(workstationFar).not.toBeNull();
+  });
 });
 
 describe("occupiedRectsFromRenderedNodes", () => {

--- a/ui/src/features/workflow-activity/lib/graph-editor-node-placement.test.ts
+++ b/ui/src/features/workflow-activity/lib/graph-editor-node-placement.test.ts
@@ -10,6 +10,7 @@ import {
 } from "./graph-editor-node-placement";
 
 const workerSize = graphEditorNodeDimensionsForKind("worker");
+const workstationSize = graphEditorNodeDimensionsForKind("workstation");
 
 describe("graphEditorNodeDimensionsForKind", () => {
   it("matches factory graph editor layout dimensions", () => {
@@ -38,6 +39,44 @@ describe("resolveViewportCenterNodePlacement", () => {
       collidesAtCenter: false,
       exhaustedSearch: false,
     });
+  });
+
+  it("centers a workstation on an empty canvas", () => {
+    const viewportCenter = { x: 640, y: 360 };
+
+    const result = resolveViewportCenterNodePlacement({
+      candidateSize: workstationSize,
+      occupiedRects: [],
+      viewportCenter,
+    });
+
+    expect(result).toEqual({
+      attemptsUsed: 1,
+      center: viewportCenter,
+      collidesAtCenter: false,
+      exhaustedSearch: false,
+    });
+  });
+
+  it("nudges a workstation away when the viewport center is blocked", () => {
+    const viewportCenter = { x: 300, y: 240 };
+    const blockerTopLeft = topLeftFromAxisAlignedRectCenter(
+      viewportCenter,
+      workstationSize,
+    );
+
+    const result = resolveViewportCenterNodePlacement({
+      candidateSize: workstationSize,
+      occupiedRects: [
+        axisAlignedRectFromTopLeft(blockerTopLeft, workstationSize),
+      ],
+      viewportCenter,
+    });
+
+    expect(result.collidesAtCenter).toBe(true);
+    expect(result.exhaustedSearch).toBe(false);
+    expect(result.center).not.toEqual(viewportCenter);
+    expect(result.attemptsUsed).toBeGreaterThan(1);
   });
 
   it("nudges away when the viewport center is blocked", () => {

--- a/ui/src/features/workflow-activity/state/currentActivityGraphStore.ts
+++ b/ui/src/features/workflow-activity/state/currentActivityGraphStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
+import { bridgeGraphLayoutPositions } from "../lib/bridge-graph-layout-positions";
 import { migrateWorkStateGraphLayoutPositions } from "../lib/migrate-work-state-graph-layout-positions";
 
 export interface GraphNodePosition {
@@ -17,6 +18,10 @@ export interface MigrateWorkStateNodePositionsInput {
 }
 
 interface CurrentActivityGraphState {
+  bridgePositionsToGraphKey: (
+    graphKey: string,
+    nodeIds: readonly string[],
+  ) => void;
   migrateWorkStateNodePositions: (
     input: MigrateWorkStateNodePositionsInput,
   ) => void;
@@ -34,6 +39,20 @@ export const CURRENT_ACTIVITY_GRAPH_STORAGE_KEY =
 export const useCurrentActivityGraphStore = create<CurrentActivityGraphState>()(
   persist(
     (set) => ({
+      bridgePositionsToGraphKey: (graphKey, nodeIds) => {
+        set((state) => {
+          const nextPositionsByGraphKey = bridgeGraphLayoutPositions({
+            nodeIds,
+            positionsByGraphKey: state.positionsByGraphKey,
+            targetGraphKey: graphKey,
+          });
+          if (!nextPositionsByGraphKey) {
+            return state;
+          }
+
+          return { positionsByGraphKey: nextPositionsByGraphKey };
+        });
+      },
       migrateWorkStateNodePositions: (input) => {
         set((state) => ({
           positionsByGraphKey: migrateWorkStateGraphLayoutPositions({


### PR DESCRIPTION
{
  "project": "Factory Graph Add Node Placement",
  "branchName": "ralph/factory-graph-add-node-placement",
  "description": "Make factory graph add placement deterministic: newly added resources, workers, workstations, work types, and work states appear near the visible viewport center after pan/zoom, nudge away from collisions, keep the camera still, and retain UI-stored positions through save and reload without persisting layout into the factory definition.",
  "context": {
    "customerAsk": "Fix factory graph add placement so new nodes appear near the visible viewport center after panning, avoid overlapping existing nodes, do not move the camera on add, and keep locally stored positions stable across save and reload for all addable kinds—without adding layout metadata to factory.json.",
    "problem": "Panning before add can still yield the same flow coordinates as before the pan; newly added workstations can jump to default layered positions after save. Users lose trust in manual layout when placement ignores the live camera or stored UI positions are overwritten on topology key changes.",
    "solution": "Compute placement from the live React Flow camera and container bounds at add time, store results in the existing current-activity graph position store with correct graph-key bridging across add and save, nudge using kind dimensions and occupied rendered-node bounds, skip placement when a finite stored position exists, and add focused pure/component tests plus workstation browser integration for pan-add and save-reload persistence."
  },
  "acceptanceCriteria": [
    "After panning or zooming, adding any supported graph entity kind places the node near the visible viewport center in flow coordinates, not at pre-pan coordinates",
    "Add placement does not trigger fitView, recenter, or otherwise move the user's camera viewport",
    "Occupied viewport centers nudge new nodes to non-overlapping locations using kind-specific dimensions; the node being placed is excluded from collision checks",
    "A newly added workstation keeps its UI-stored position after saving topology and after page reload when the workstation remains in the saved factory definition",
    "Factory definition save payloads do not gain node coordinate or layout metadata; manual drag positions continue to override autogenerated placement",
    "Focused automated tests prove panned-viewport placement and save/reload position stability, with browser coverage for workstation add flows when component tests cannot model the real camera",
    "Quality gate: UI typecheck, lint, and targeted frontend test commands for touched graph placement code pass"
  ],
  "userStories": [
    {
      "id": "prd-factory-graph-add-node-placement-001",
      "title": "Place added nodes at the current viewport center",
      "description": "As a factory graph editor user, I want newly added entities to appear near the part of the graph I am currently viewing so that I can add and connect nodes without hunting around the canvas.",
      "acceptanceCriteria": [
        "Adding a workstation after panning the React Flow viewport places it near the visible viewport center within a tolerance band relative to the flow container, not at the same flow coordinates used before panning",
        "Viewport-centered placement applies to resources, workers, work types, and work states when no finite stored position exists for that node id",
        "Placement uses the current React Flow instance transform and flow container bounds at add time via screen-to-flow conversion of the container center",
        "The add action does not trigger fitView, recenter the graph, or otherwise move the camera",
        "A component or pure test proves that changing the supplied viewport center changes the computed initial top-left for at least two add kinds",
        "A browser integration test pans the graph, adds a workstation, and asserts the new node appears near the visible viewport center using tolerant screen-space distance checks",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-factory-graph-add-node-placement-002",
      "title": "Avoid overlap for newly added nodes",
      "description": "As a graph editor user, I want newly added nodes to avoid covering existing visible nodes so that the graph remains readable immediately after add.",
      "acceptanceCriteria": [
        "If the viewport center is free, the added node is centered there with top-left derived from kind-specific dimensions",
        "If the viewport center is occupied, the added node is nudged to the nearest practical non-overlapping location within the existing search budget",
        "Collision checks use kind-specific graph editor dimensions or rendered node measured size when available",
        "The newly added node id is excluded from occupied bounds when resolving its own placement",
        "Pure or component tests cover free-center placement and occupied-center nudge for at least worker and workstation kinds; existing overlap tests remain passing",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-factory-graph-add-node-placement-003",
      "title": "Preserve added node positions across save and reload",
      "description": "As a graph editor user, I want newly added node positions to remain stable after saving so that save does not undo my current layout.",
      "acceptanceCriteria": [
        "A newly added workstation keeps its locally stored position immediately after saving graph topology changes",
        "The same workstation keeps its locally stored position after a full page reload when the saved factory definition includes that workstation",
        "Saving topology changes does not replace the added node's stored position with default layered column/row fallback coordinates",
        "Position storage bridges pre-add graph key, post-add graph key, and post-save topology key so the stored entry is found on reprojection",
        "Manual dragged positions continue to take precedence over autogenerated initial placement",
        "A browser integration test adds a workstation, saves topology, reloads the page, and asserts the workstation flow position is unchanged within tolerance",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-factory-graph-add-node-placement-004",
      "title": "Keep position state UI-owned",
      "description": "As a maintainer, I want graph node positions to remain local UI state so that factory definitions do not gain layout metadata as part of this placement fix.",
      "acceptanceCriteria": [
        "Node positions continue to be stored through the existing current-activity graph position store or its direct successor",
        "Factory definition save payloads do not include node coordinate or layout fields for newly added entities",
        "React Flow node positions remain a projection from canonical graph topology plus local UI position state",
        "The implementation does not reconstruct canonical factory graph data from React Flow node positions",
        "Tests assert that saving a newly added workstation does not add layout coordinate fields to the persisted factory definition payload",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-factory-graph-add-node-placement-005",
      "title": "Add focused regression evidence",
      "description": "As a maintainer, I want tests that fail on the current bad placement behavior so future layout changes do not reintroduce it.",
      "acceptanceCriteria": [
        "A focused test proves that changing viewport center input changes the computed initial placement top-left",
        "A focused test proves that saving or reprojection does not reset a newly added workstation stored position when the topology key changes but the node id persists",
        "Component-level tests are preferred for placement registrar and graph-key bridge behavior; browser integration is used only where the real React Flow camera is required",
        "Browser coverage for add-after-pan and save-reload persistence targets workstation add only; other kinds are covered by pure or component tests",
        "Browser assertions use bounded waits and tolerant distance checks, not exact pixel coordinates",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)