### PR TITLE
migrate-authored-body-text-color-roles

### DIFF
--- a/ui/src/features/current-selection/base/components/request-authored-text.test.tsx
+++ b/ui/src/features/current-selection/base/components/request-authored-text.test.tsx
@@ -28,11 +28,15 @@ describe("AuthoredBodyText", () => {
     expect(
       screen.getAllByText("bun test", { selector: "pre code" }),
     ).toHaveLength(1);
-    expect(container.firstElementChild?.className).toContain(
-      "[&_code]:rounded-sm",
+    const authoredShell = container.firstElementChild;
+    expect(authoredShell?.className).toContain("[&_code]:rounded-sm");
+    expect(authoredShell?.className).toContain("[&_code]:px-1");
+    expect(authoredShell?.className).toContain("[&_code]:py-0.5");
+    expect(authoredShell?.className).toContain("border-outline");
+    expect(authoredShell?.className).toContain("bg-surface-container-high");
+    expect(authoredShell?.className).toContain(
+      "[&_code]:bg-surface-container",
     );
-    expect(container.firstElementChild?.className).toContain("[&_code]:px-1");
-    expect(container.firstElementChild?.className).toContain("[&_code]:py-0.5");
   });
 
   it("renders plain text as readable fallback without requiring markdown syntax", () => {

--- a/ui/src/features/work-content/components/work-content-read-only-list.test.tsx
+++ b/ui/src/features/work-content/components/work-content-read-only-list.test.tsx
@@ -20,6 +20,12 @@ describe("WorkContentPartList", () => {
       screen.getByRole("heading", { level: 2, name: "Review notes" }),
     ).toBeTruthy();
     expect(screen.getByText("Confirm payload visibility")).toBeTruthy();
+
+    const authoredShell = screen
+      .getByRole("heading", { level: 2, name: "Review notes" })
+      .closest("div");
+    expect(authoredShell?.className).toContain("border-outline");
+    expect(authoredShell?.className).toContain("bg-surface-container-high");
   });
 
   it("renders JSON parts as formatted code blocks", () => {
@@ -35,6 +41,10 @@ describe("WorkContentPartList", () => {
     );
 
     expect(screen.getByText(/"status": "ready"/)).toBeTruthy();
+
+    const jsonShell = screen.getByText(/"status": "ready"/).closest("pre");
+    expect(jsonShell?.className).toContain("border-outline");
+    expect(jsonShell?.className).toContain("bg-surface-container-high");
   });
 
   it("renders non-text parts with readable fallback descriptions", () => {

--- a/ui/src/lib/authored-body-text.test.ts
+++ b/ui/src/lib/authored-body-text.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { REQUEST_AUTHORED_TEXT_CLASS } from "./authored-body-text";
+
+/** Transitional surface/border tokens migrated in REQUEST_AUTHORED_TEXT_CLASS. */
+const FORBIDDEN_TRANSITIONAL_PATTERNS = [
+  /\bbg-af-surface-(subtle|raised)\b/,
+  /\bbg-af-surface\b/,
+  /\bbg-af-background\b/,
+  /\bbg-af-bg\b/,
+  /\bborder-af-border\b/,
+  /\bborder-af-border-strong\b/,
+  /\bbg-af-overlay\b/,
+];
+
+describe("REQUEST_AUTHORED_TEXT_CLASS color roles", () => {
+  it("uses Material role utilities for container, pre, and inline code surfaces", () => {
+    expect(REQUEST_AUTHORED_TEXT_CLASS).toContain("border-outline");
+    expect(REQUEST_AUTHORED_TEXT_CLASS).toContain("bg-surface-container-high");
+    expect(REQUEST_AUTHORED_TEXT_CLASS).toContain("bg-surface-container-low");
+    expect(REQUEST_AUTHORED_TEXT_CLASS).toContain(
+      "[&_code]:bg-surface-container",
+    );
+  });
+
+  it.each(FORBIDDEN_TRANSITIONAL_PATTERNS.map((pattern) => [pattern.source]))(
+    "does not include transitional token %s",
+    (patternSource) => {
+      const pattern = new RegExp(patternSource);
+      expect(REQUEST_AUTHORED_TEXT_CLASS).not.toMatch(pattern);
+    },
+  );
+});

--- a/ui/src/lib/authored-body-text.tsx
+++ b/ui/src/lib/authored-body-text.tsx
@@ -4,7 +4,7 @@ import { DASHBOARD_BODY_TEXT_CLASS } from "../components/ui/dashboard-typography
 import { cn } from "./cn";
 
 export const REQUEST_AUTHORED_TEXT_CLASS = cn(
-  "grid gap-3 rounded-lg border border-af-border bg-af-surface-raised p-3 [overflow-wrap:anywhere] [&_code]:rounded-sm [&_code]:bg-af-overlay [&_code]:px-1 [&_code]:py-0.5 [&_h1]:text-xl [&_h1]:font-semibold [&_h2]:text-lg [&_h2]:font-semibold [&_h3]:text-base [&_h3]:font-semibold [&_ol]:m-0 [&_ol]:list-decimal [&_ol]:pl-5 [&_pre]:m-0 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:border [&_pre]:border-af-border [&_pre]:bg-af-surface-subtle [&_pre]:p-3 [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_ul]:m-0 [&_ul]:list-disc [&_ul]:pl-5",
+  "grid gap-3 rounded-lg border border-outline bg-surface-container-high p-3 [overflow-wrap:anywhere] [&_code]:rounded-sm [&_code]:bg-surface-container [&_code]:px-1 [&_code]:py-0.5 [&_h1]:text-xl [&_h1]:font-semibold [&_h2]:text-lg [&_h2]:font-semibold [&_h3]:text-base [&_h3]:font-semibold [&_ol]:m-0 [&_ol]:list-decimal [&_ol]:pl-5 [&_pre]:m-0 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:border [&_pre]:border-outline [&_pre]:bg-surface-container-low [&_pre]:p-3 [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_ul]:m-0 [&_ul]:list-disc [&_ul]:pl-5",
   DASHBOARD_BODY_TEXT_CLASS,
 );
 


### PR DESCRIPTION
{
  "project": "Migrate Authored-Body-Text to Material Color Role Utilities",
  "branchName": "migrate-authored-body-text-color-roles",
  "description": "Replace transitional af-* surface and border class tokens in REQUEST_AUTHORED_TEXT_CLASS with Material color role utilities so the shared authored-content shell matches feature-surface role semantics, add a focused vitest enforcing the constant contract, align consumer tests only when they pin old tokens, and preserve visual parity on dashboard authored request/work content blocks with no API or routing changes.",
  "context": {
    "customerAsk": "Migrate authored-body-text to Material color role utilities: replace transitional product class tokens (border-af-border, bg-af-surface-raised, bg-af-surface-subtle, bg-af-overlay) in REQUEST_AUTHORED_TEXT_CLASS with the same Material role utilities used elsewhere in feature surfaces.",
    "problem": "ui/src/lib/authored-body-text.tsx still uses transitional af-* surface/border tokens in REQUEST_AUTHORED_TEXT_CLASS after US-009 removed them from ui/src/features/**, leaving the shared authored-content shell out of sync with the enforced feature-surface role contract and creating inconsistent styling on dashboard authored request/work content blocks.",
    "solution": "Update REQUEST_AUTHORED_TEXT_CLASS in ui/src/lib/authored-body-text.tsx using the documented role utility mappings while keeping DASHBOARD_BODY_TEXT_CLASS unchanged; add a focused vitest that imports the constant and asserts role utilities plus absence of forbidden transitional patterns; update work-content or detail-card tests only when they pin old tokens; pass cd ui && bun run tsc and targeted vitest with browser verification for visual parity on dashboard authored content blocks."
  },
  "acceptanceCriteria": [
    "REQUEST_AUTHORED_TEXT_CLASS uses Material role utilities and contains no border-af-border, bg-af-surface-*, bg-af-background, or bg-af-overlay transitional tokens",
    "DASHBOARD_BODY_TEXT_CLASS composition is unchanged from pre-migration",
    "A focused vitest imports REQUEST_AUTHORED_TEXT_CLASS and asserts expected role utilities are present and forbidden transitional surface/border/accent patterns aligned with feature-surface-color-roles.test.ts are absent",
    "Work-content or detail-card consumer tests are updated only when they pin old transitional token substrings, without weakening behavioral assertions",
    "Dashboard authored request/work content blocks retain visual parity on at least two theme palettes",
    "cd ui && bun run tsc and targeted vitest for authored-body-text and any touched consumer tests pass",
    "Typecheck, lint, and tests pass"
  ],
  "userStories": [
    {
      "id": "migrate-authored-body-text-color-roles-001",
      "title": "Replace transitional tokens in REQUEST_AUTHORED_TEXT_CLASS",
      "description": "As a dashboard user, I want authored request and work body text to use Material color role utilities so surface and border styling matches the rest of the migrated feature surfaces without changing layout or typography behavior.",
      "acceptanceCriteria": [
        "border-af-border in REQUEST_AUTHORED_TEXT_CLASS is replaced with border-outline",
        "bg-af-surface-raised is replaced with bg-surface-container-high and bg-af-surface-subtle with bg-surface-container-low",
        "[&_code]:bg-af-overlay or equivalent transitional code overlay token is replaced with bg-surface-container or the neutral overlay role pattern used in ui/src/components/ui/button.tsx matching nearby feature conventions",
        "DASHBOARD_BODY_TEXT_CLASS is not modified",
        "REQUEST_AUTHORED_TEXT_CLASS contains no border-af-border, bg-af-surface-*, bg-af-background, or bg-af-overlay tokens after the change",
        "Only ui/src/lib/authored-body-text.tsx is edited in this story; no changes to ui/src/components/ui/**, overlay/chart token taxonomy, or feature-surface-color-roles.test.ts scope",
        "Typecheck passes",
        "Verify in browser: dashboard authored request and work content blocks show the same surface hierarchy, borders, and inline code background as before on at least two theme palettes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "migrate-authored-body-text-color-roles-002",
      "title": "Add focused vitest for authored-body-text role utilities",
      "description": "As a maintainer, I want a behavioral test on REQUEST_AUTHORED_TEXT_CLASS so transitional surface/border tokens cannot reappear in the shared authored-content shell without a failing test.",
      "acceptanceCriteria": [
        "A focused vitest such as ui/src/lib/authored-body-text.test.ts imports REQUEST_AUTHORED_TEXT_CLASS and asserts it includes border-outline, bg-surface-container-high, bg-surface-container-low, and the chosen code overlay role utility",
        "The test asserts REQUEST_AUTHORED_TEXT_CLASS does not match forbidden transitional patterns aligned with feature-surface-color-roles.test.ts such as border-af-border, bg-af-surface-raised, bg-af-surface-subtle, bg-af-background, and bg-af-overlay",
        "The test does not scan file inventories, import graphs, route registrations, or doc link topology",
        "feature-surface-color-roles.test.ts is not expanded to cover ui/src/lib/**",
        "Typecheck passes",
        "Tests pass for the new authored-body-text vitest"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "migrate-authored-body-text-color-roles-003",
      "title": "Align consumer tests and pass verification",
      "description": "As a reviewer, I want consumer tests and the customer verification commands green so the migration ships with no regressions in dependent work-content or detail-card coverage.",
      "acceptanceCriteria": [
        "Work-content or detail-card tests that assert class substrings pinning old transitional tokens are updated to expect new role utilities only when those tests fail due to the migration",
        "Consumer test updates preserve behavioral intent without adding layout-topology or allowlist-inventory meta-tests",
        "cd ui && bun run tsc exits 0",
        "Targeted vitest for authored-body-text and any touched consumer tests passes",
        "No API, routing, or public export surface changes",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)