### PR TITLE
migrate-prompt-editor-neutral-surface-roles

### DIFF
--- a/docs/internal/development/material-color-role-migration-rollout.md
+++ b/docs/internal/development/material-color-role-migration-rollout.md
@@ -77,8 +77,9 @@ Alias layer removal is **complete**. Role-backed `--color-af-*` product keys liv
 
 1. `ui/src/features/**` — no `bg-af-surface-*`, `text-af-text`, `bg-af-accent-*` (enforced by `feature-surface-color-roles.test.ts`).
 2. `ui/src/components/ui/**` — neutral and semantic contracts green (see shared-primitive `*.test.ts` files).
-3. Storybook overview and palette selector reviewed on all five palettes.
-4. Full `cd ui && bun run tsc` and theme regression vitest bundle (above) pass.
+3. `ui/src/components/prompt-editor/**` — Monaco shells, diagnostics rows, and resize handle on role utilities (enforced by `prompt-editor-neutral-surface-roles.test.ts`); RTL consumer tests in the same folder assert behavior only and do not pin transitional neutral class substrings.
+4. Storybook overview and palette selector reviewed on all five palettes.
+5. Full `cd ui && bun run tsc` and theme regression vitest bundle (above) pass.
 
 ### Completed alias removal
 

--- a/docs/internal/development/material-color-role-migration-rollout.md
+++ b/docs/internal/development/material-color-role-migration-rollout.md
@@ -36,6 +36,7 @@ Implement and review in this sequence. Later phases assume earlier ones are merg
 | Shared primitive semantics | `ui/src/components/ui/shared-primitive-semantic-color-roles.test.ts` | No semantic misuse for brand emphasis |
 | Shared primitive neutrals | `ui/src/components/ui/shared-primitive-neutral-surface-roles.test.ts` | Neutral chrome on role utilities |
 | Feature & graph surfaces | `ui/src/features/feature-surface-color-roles.test.ts` | Features avoid transitional tokens; graph/header samples use roles |
+| Prompt-editor neutrals | `ui/src/components/prompt-editor/prompt-editor-neutral-surface-roles.test.ts` | Monaco shells, diagnostics rows, and resize handle on role utilities |
 | Graph chrome | `ui/src/components/dashboard/dashboard-graph.test.tsx` | React Flow frame constraints; role CSS variables on canvas/controls |
 | Migration index | `ui/src/styles/theme-role-regression.test.ts` | Regression contract files remain wired |
 
@@ -49,6 +50,7 @@ cd ui && bun x vitest run src/styles/theme-role-regression.test.ts \
   src/styles/color-palette-presets.test.ts \
   src/features/feature-surface-color-roles.test.ts \
   src/components/ui/shared-primitive-neutral-surface-roles.test.ts \
+  src/components/prompt-editor/prompt-editor-neutral-surface-roles.test.ts \
   src/components/ui/shared-primitive-semantic-color-roles.test.ts \
   src/components/dashboard/dashboard-graph.test.tsx
 ```

--- a/ui/src/components/prompt-editor/monaco-guard-selector-editor.tsx
+++ b/ui/src/components/prompt-editor/monaco-guard-selector-editor.tsx
@@ -117,7 +117,7 @@ export function MonacoGuardSelectorEditor({
   return (
     <Editor
       className={cn(
-        "overflow-visible rounded-lg border border-af-border bg-transparent",
+        "overflow-visible rounded-lg border border-outline bg-transparent",
         hasError
           ? "border-af-danger-border focus-within:border-af-danger"
           : undefined,
@@ -200,7 +200,7 @@ function GuardSelectorEditorFallbackState({
     <div
       aria-describedby={ariaDescribedBy}
       aria-invalid={ariaInvalid ? "true" : undefined}
-      className="grid min-h-0 gap-1 overflow-auto rounded-lg border border-af-border bg-transparent px-3 py-2"
+      className="grid min-h-0 gap-1 overflow-auto rounded-lg border border-outline bg-transparent px-3 py-2"
       data-monaco-editor-fallback="workstation-guard-selector"
       id={id}
       role={status}

--- a/ui/src/components/prompt-editor/monaco-prompt-editor.tsx
+++ b/ui/src/components/prompt-editor/monaco-prompt-editor.tsx
@@ -175,7 +175,7 @@ export function MonacoPromptEditor({
   return (
     <Editor
       className={cn(
-        "overflow-visible rounded-xl border border-af-border bg-transparent",
+        "overflow-visible rounded-xl border border-outline bg-transparent",
         hasDiagnostics
           ? "border-af-danger-border focus-within:border-af-danger"
           : undefined,
@@ -312,7 +312,7 @@ function PromptEditorFallbackState({
     <div
       aria-describedby={ariaDescribedBy}
       aria-invalid={ariaInvalid ? "true" : undefined}
-      className="grid h-full min-h-0 gap-2 overflow-auto rounded-xl border border-af-border bg-transparent px-3 py-3"
+      className="grid h-full min-h-0 gap-2 overflow-auto rounded-xl border border-outline bg-transparent px-3 py-3"
       data-monaco-editor-fallback="workstation-prompt"
       role={status}
       style={{ height }}

--- a/ui/src/components/prompt-editor/prompt-editor-diagnostics-panel.tsx
+++ b/ui/src/components/prompt-editor/prompt-editor-diagnostics-panel.tsx
@@ -109,7 +109,7 @@ export function PromptEditorDiagnosticsPanel({
         <ul className="m-0 grid list-none gap-2 p-0">
           {diagnostics.map((diagnostic) => (
             <li
-              className="grid gap-1 rounded-lg border border-af-danger-border bg-af-surface-raised p-2"
+              className="grid gap-1 rounded-lg border border-af-danger-border bg-surface-container-high p-2"
               key={diagnosticListItemKey(diagnostic)}
             >
               <p

--- a/ui/src/components/prompt-editor/prompt-editor-neutral-surface-roles.test.ts
+++ b/ui/src/components/prompt-editor/prompt-editor-neutral-surface-roles.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const PROMPT_EDITOR_DIR = join(dirname(fileURLToPath(import.meta.url)));
+
+/** Transitional neutral surface/border tokens migrated to Material role utilities. */
+const FORBIDDEN_TRANSITIONAL_NEUTRAL_PATTERNS = [
+  /\bbg-af-surface-(subtle|raised)\b/,
+  /\bbg-af-surface\b/,
+  /\bborder-af-border\b/,
+  /\bborder-af-border-strong\b/,
+  /\bbg-af-border\b/,
+  /\bbg-af-border-strong\b/,
+  /\bhover:bg-af-border-strong\b/,
+];
+
+function readPromptEditorSource(fileName: string): string {
+  return readFileSync(join(PROMPT_EDITOR_DIR, fileName), "utf8");
+}
+
+function expectNoForbiddenTransitionalNeutralSurfaces(source: string): void {
+  for (const pattern of FORBIDDEN_TRANSITIONAL_NEUTRAL_PATTERNS) {
+    expect(source).not.toMatch(pattern);
+  }
+}
+
+describe("prompt-editor neutral surface roles", () => {
+  it("monaco-prompt-editor uses border-outline on editor shells", () => {
+    const source = readPromptEditorSource("monaco-prompt-editor.tsx");
+
+    expect(source).toContain("border-outline");
+    expectNoForbiddenTransitionalNeutralSurfaces(source);
+  });
+
+  it("monaco-guard-selector-editor uses border-outline on editor shells", () => {
+    const source = readPromptEditorSource("monaco-guard-selector-editor.tsx");
+
+    expect(source).toContain("border-outline");
+    expectNoForbiddenTransitionalNeutralSurfaces(source);
+  });
+
+  it("prompt-editor-diagnostics-panel uses bg-surface-container-high on diagnostic list items", () => {
+    const source = readPromptEditorSource("prompt-editor-diagnostics-panel.tsx");
+
+    expect(source).toContain("bg-surface-container-high");
+    expectNoForbiddenTransitionalNeutralSurfaces(source);
+  });
+
+  it("vertical-resizable-width uses outline role utilities on the resize handle", () => {
+    const source = readPromptEditorSource("vertical-resizable-width.tsx");
+
+    expect(source).toContain("bg-outline");
+    expect(source).toContain("hover:bg-outline-variant");
+    expectNoForbiddenTransitionalNeutralSurfaces(source);
+  });
+});

--- a/ui/src/components/prompt-editor/vertical-resizable-width.tsx
+++ b/ui/src/components/prompt-editor/vertical-resizable-width.tsx
@@ -120,7 +120,7 @@ export function VerticalResizableWidth({
       >
         <span
           aria-hidden="true"
-          className="mx-2 h-px flex-1 rounded-full bg-af-border transition-colors hover:bg-af-border-strong"
+          className="mx-2 h-px flex-1 rounded-full bg-outline transition-colors hover:bg-outline-variant"
         />
       </div>
     </div>


### PR DESCRIPTION
{
  "project": "Migrate Prompt-Editor Neutral Surfaces to Material Role Utilities",
  "branchName": "migrate-prompt-editor-neutral-surface-roles",
  "description": "Replace transitional neutral af-* surface and border class tokens in four in-scope prompt-editor files with Material color role utilities so Monaco editor shells, diagnostics list rows, and the vertical resize handle match input.tsx, dialog.tsx, and authored-body-text.tsx semantics; add a focused vitest that reads those source files and locks the migration; align consumer tests only when they pin old tokens; preserve danger semantic tokens, bg-transparent editor backgrounds, and visual parity on workstation prompt/guard editors with no API or routing changes.",
  "context": {
    "customerAsk": "Migrate prompt-editor neutral surfaces to Material role utilities: replace transitional neutral chrome (border-af-border, bg-af-surface-raised, bg-af-border / bg-af-border-strong on the resize handle) in ui/src/components/prompt-editor/** with the same Material role utilities used in input.tsx, dialog.tsx, and authored-body-text.tsx.",
    "problem": "ui/src/components/prompt-editor/** still uses transitional neutral chrome while US-009 cleared ui/src/features/** and shared primitives under ui/src/components/ui/**. Monaco editor shells and diagnostics list rows were missed, leaving prompt/guard workstation UI inconsistent with the enforced Material role contract.",
    "solution": "Update monaco-prompt-editor.tsx, monaco-guard-selector-editor.tsx, prompt-editor-diagnostics-panel.tsx, and vertical-resizable-width.tsx using documented role utility mappings while keeping danger tokens, bg-transparent editor backgrounds, and typography unchanged; add prompt-editor-neutral-surface-roles.test.ts (or extend existing monaco/diagnostics tests) that reads the four files and asserts role utilities plus absence of forbidden transitional neutral patterns; update consumer tests only when they pin old tokens; pass cd ui && bun run tsc and targeted vitest with browser verification for visual parity."
  },
  "acceptanceCriteria": [
    "monaco-prompt-editor.tsx and monaco-guard-selector-editor.tsx use border-outline on editor shells and contain no border-af-border",
    "prompt-editor-diagnostics-panel.tsx uses bg-surface-container-high on diagnostic list items and contains no bg-af-surface-raised",
    "vertical-resizable-width.tsx uses bg-outline and hover:bg-outline-variant on the resize handle with no bg-af-border or hover:bg-af-border-strong",
    "Danger semantic tokens (border-af-danger-border, bg-af-danger-surface, text-af-danger-text) remain unchanged where present",
    "A focused vitest reads the four in-scope source files and asserts required role utilities are present and forbidden transitional neutral patterns aligned with feature-surface-color-roles.test.ts are absent",
    "Consumer tests are updated only when they pin obsolete transitional class substrings, without weakening behavioral assertions",
    "Workstation prompt/guard editors and diagnostics panels retain visual parity on at least two theme palettes",
    "cd ui && bun run tsc and targeted vitest for prompt-editor neutral-surface migration pass",
    "Typecheck, lint, and tests pass"
  ],
  "userStories": [
    {
      "id": "migrate-prompt-editor-neutral-surface-roles-001",
      "title": "Replace transitional neutral tokens in in-scope prompt-editor files",
      "description": "As a workstation user, I want prompt and guard Monaco editor shells, diagnostics list rows, and the vertical resize handle to use Material color role utilities so neutral chrome matches migrated inputs and dialogs without changing editor behavior or danger styling.",
      "acceptanceCriteria": [
        "monaco-prompt-editor.tsx: border-af-border on editor shells is replaced with border-outline; no border-af-border remains",
        "monaco-guard-selector-editor.tsx: same border-af-border to border-outline migration on editor shells",
        "prompt-editor-diagnostics-panel.tsx: bg-af-surface-raised on diagnostic list items is replaced with bg-surface-container-high; no bg-af-surface-raised remains",
        "vertical-resizable-width.tsx: resize handle bg-af-border becomes bg-outline and hover:bg-af-border-strong becomes hover:bg-outline-variant; no bg-af-border or hover:bg-af-border-strong remains",
        "bg-transparent editor backgrounds and existing typography class composition are unchanged",
        "Danger semantic tokens (border-af-danger-border, bg-af-danger-surface, text-af-danger-text) are not modified",
        "Only the four in-scope files under ui/src/components/prompt-editor/** are edited; no Monaco theme internals, overlay/chart taxonomy, button-policy.stories.tsx, or ui-foundation-showcase.tsx changes",
        "Typecheck passes",
        "Verify in browser: workstation prompt editor, guard selector editor, diagnostics panel list rows, and vertical resize handle show the same neutral borders, row surfaces, and handle affordance as before on at least two theme palettes; danger styling unchanged where present"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "migrate-prompt-editor-neutral-surface-roles-002",
      "title": "Add focused vitest for prompt-editor neutral surface roles",
      "description": "As a maintainer, I want a behavioral test on the four in-scope prompt-editor source files so transitional neutral surface/border tokens cannot reappear without a failing test.",
      "acceptanceCriteria": [
        "A focused vitest such as ui/src/components/prompt-editor/prompt-editor-neutral-surface-roles.test.ts (or an extension of existing monaco-prompt-editor.test.tsx / prompt-editor-diagnostics-panel.test.tsx) reads the four in-scope source files and asserts required role utilities (border-outline, bg-surface-container-high, bg-outline, hover:bg-outline-variant) are present where borders/surfaces apply",
        "The test asserts the four files do not contain forbidden transitional neutral patterns aligned with feature-surface-color-roles.test.ts: bg-af-surface-*, border-af-border, border-af-border-strong, bg-af-border, bg-af-border-strong",
        "The test does not scan file inventories, import graphs, route registrations, doc link topology, or asset-bundle internals",
        "feature-surface-color-roles.test.ts is not expanded to cover all of ui/src/components/",
        "Typecheck passes",
        "Tests pass for the new or extended prompt-editor neutral-surface vitest"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "migrate-prompt-editor-neutral-surface-roles-003",
      "title": "Align consumer tests and pass verification",
      "description": "As a reviewer, I want consumer tests and customer verification commands green so the migration ships with no regressions in prompt-editor dependent coverage.",
      "acceptanceCriteria": [
        "monaco-prompt-editor.test.tsx, prompt-editor-diagnostics-panel.test.tsx, or other consumer tests that assert class substrings pinning old transitional tokens are updated to expect new role utilities only when those tests fail due to the migration",
        "Consumer test updates preserve behavioral intent without adding layout-topology or allowlist-inventory meta-tests",
        "cd ui && bun run tsc exits 0",
        "Targeted vitest for prompt-editor neutral-surface migration and any touched consumer tests passes",
        "No API, routing, Monaco theme export, or public component prop surface changes",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)