### PR TITLE
migrate-calendar-color-roles

### DIFF
--- a/docs/internal/development/material-color-role-migration-rollout.md
+++ b/docs/internal/development/material-color-role-migration-rollout.md
@@ -79,9 +79,10 @@ Alias layer removal is **complete**. Role-backed `--color-af-*` product keys liv
 
 1. `ui/src/features/**` — no `bg-af-surface-*`, `text-af-text`, `bg-af-accent-*` (enforced by `feature-surface-color-roles.test.ts`).
 2. `ui/src/components/ui/**` — neutral and semantic contracts green (see shared-primitive `*.test.ts` files).
-3. `ui/src/components/prompt-editor/**` — Monaco shells, diagnostics rows, and resize handle on role utilities (enforced by `prompt-editor-neutral-surface-roles.test.ts`); RTL consumer tests in the same folder assert behavior only and do not pin transitional neutral class substrings.
-4. Storybook overview and palette selector reviewed on all five palettes.
-5. Full `cd ui && bun run tsc` and theme regression vitest bundle (above) pass.
+3. `ui/src/components/ui/calendar.tsx` — DayPicker selected, today, outside, disabled, and weekday cells on role utilities (enforced by `calendar-color-roles.test.ts`); `ui-foundation.test.tsx` and Storybook foundation showcase assert behavior/labels only and do not pin transitional accent/text class substrings on the calendar primitive.
+4. `ui/src/components/prompt-editor/**` — Monaco shells, diagnostics rows, and resize handle on role utilities (enforced by `prompt-editor-neutral-surface-roles.test.ts`); RTL consumer tests in the same folder assert behavior only and do not pin transitional neutral class substrings.
+5. Storybook overview and palette selector reviewed on all five palettes.
+6. Full `cd ui && bun run tsc` and theme regression vitest bundle (above) pass.
 
 ### Completed alias removal
 

--- a/docs/internal/development/material-color-role-migration-rollout.md
+++ b/docs/internal/development/material-color-role-migration-rollout.md
@@ -35,6 +35,7 @@ Implement and review in this sequence. Later phases assume earlier ones are merg
 | Layout scale | `ui/src/styles/layout-role-tokens.test.ts` | Layout spacing roles registered |
 | Shared primitive semantics | `ui/src/components/ui/shared-primitive-semantic-color-roles.test.ts` | No semantic misuse for brand emphasis |
 | Shared primitive neutrals | `ui/src/components/ui/shared-primitive-neutral-surface-roles.test.ts` | Neutral chrome on role utilities |
+| Calendar accent/text | `ui/src/components/ui/calendar-color-roles.test.ts` | DayPicker selected, today, outside, disabled, and weekday cells on role utilities |
 | Feature & graph surfaces | `ui/src/features/feature-surface-color-roles.test.ts` | Features avoid transitional tokens; graph/header samples use roles |
 | Prompt-editor neutrals | `ui/src/components/prompt-editor/prompt-editor-neutral-surface-roles.test.ts` | Monaco shells, diagnostics rows, and resize handle on role utilities |
 | Graph chrome | `ui/src/components/dashboard/dashboard-graph.test.tsx` | React Flow frame constraints; role CSS variables on canvas/controls |
@@ -50,6 +51,7 @@ cd ui && bun x vitest run src/styles/theme-role-regression.test.ts \
   src/styles/color-palette-presets.test.ts \
   src/features/feature-surface-color-roles.test.ts \
   src/components/ui/shared-primitive-neutral-surface-roles.test.ts \
+  src/components/ui/calendar-color-roles.test.ts \
   src/components/prompt-editor/prompt-editor-neutral-surface-roles.test.ts \
   src/components/ui/shared-primitive-semantic-color-roles.test.ts \
   src/components/dashboard/dashboard-graph.test.tsx

--- a/ui/src/components/ui/calendar-color-roles.test.ts
+++ b/ui/src/components/ui/calendar-color-roles.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const UI_COMPONENTS_DIR = join(dirname(fileURLToPath(import.meta.url)));
+
+/** Transitional accent/text tokens migrated to Material role utilities. */
+const FORBIDDEN_TRANSITIONAL_ACCENT_TEXT_PATTERNS = [
+  /\btext-af-accent\b/,
+  /\bbg-af-accent\b/,
+  /\btext-af-on-accent\b/,
+  /\bbg-af-accent-surface\b/,
+  /\btext-af-text-disabled\b/,
+  /\btext-af-text-subtle\b/,
+];
+
+function readCalendarSource(): string {
+  return readFileSync(join(UI_COMPONENTS_DIR, "calendar.tsx"), "utf8");
+}
+
+function expectNoForbiddenTransitionalAccentText(source: string): void {
+  for (const pattern of FORBIDDEN_TRANSITIONAL_ACCENT_TEXT_PATTERNS) {
+    expect(source).not.toMatch(pattern);
+  }
+}
+
+describe("calendar color roles", () => {
+  it("maps selected, today, outside, disabled, and weekday cells to role utilities", () => {
+    const source = readCalendarSource();
+
+    expect(source).toMatch(/day_button:[\s\S]*aria-selected:bg-primary/);
+    expect(source).toMatch(/day_button:[\s\S]*aria-selected:text-on-primary/);
+    expect(source).toMatch(
+      /outside:[\s\S]*aria-selected:bg-primary-container/,
+    );
+    expect(source).toMatch(
+      /outside:[\s\S]*aria-selected:text-on-primary-container/,
+    );
+    expect(source).toMatch(/today:\s*"[^"]*text-primary/);
+    expect(source).toMatch(/disabled:\s*"[^"]*text-on-surface-disabled/);
+    expect(source).toMatch(/outside:[\s\S]*text-on-surface-disabled/);
+    expect(source).toMatch(/weekday:[\s\S]*text-on-surface-variant/);
+
+    expectNoForbiddenTransitionalAccentText(source);
+  });
+
+  it("preserves shell chrome, nav buttons, focus ring, and day hover overlay", () => {
+    const source = readCalendarSource();
+
+    expect(source).toContain("border-outline");
+    expect(source).toContain("bg-surface-container-low");
+    expect(source).toContain("buttonVariants");
+    expect(source).toContain("focus-visible:ring-af-focus-ring");
+    expect(source).toContain("hover:bg-af-overlay");
+    expectNoForbiddenTransitionalAccentText(source);
+  });
+});

--- a/ui/src/components/ui/calendar.tsx
+++ b/ui/src/components/ui/calendar.tsx
@@ -34,18 +34,18 @@ export function Calendar({
         day: "h-10 w-10 p-0 font-medium text-on-surface aria-selected:opacity-100",
         day_button: cn(
           "h-10 w-10 rounded-lg text-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-af-focus-ring",
-          "hover:bg-af-overlay aria-selected:bg-af-accent aria-selected:text-af-on-accent",
+          "hover:bg-af-overlay aria-selected:bg-primary aria-selected:text-on-primary",
         ),
-        disabled: "text-af-text-disabled",
+        disabled: "text-on-surface-disabled",
         month: "space-y-4",
         nav: "flex items-center gap-2",
         outside:
-          "text-af-text-disabled aria-selected:bg-af-accent-surface aria-selected:text-af-on-accent",
+          "text-on-surface-disabled aria-selected:bg-primary-container aria-selected:text-on-primary-container",
         root: cn(defaultClassNames.root, "text-sm"),
         selected: "font-semibold",
-        today: "text-af-accent",
+        today: "text-primary",
         weekday:
-          "text-xs font-bold uppercase tracking-[0.08em] text-af-text-subtle",
+          "text-xs font-bold uppercase tracking-[0.08em] text-on-surface-variant",
         ...classNames,
       }}
       showOutsideDays={showOutsideDays}


### PR DESCRIPTION
{
  "project": "Migrate Calendar Accent and Text Tokens to Material Role Utilities",
  "branchName": "migrate-calendar-color-roles",
  "description": "Replace transitional accent and text af-* class tokens in ui/src/components/ui/calendar.tsx with Material color role utilities so selected days, today, outside-month cells, disabled text, and weekday labels match button.tsx and material-color-role-taxonomy.md; add calendar-color-roles.test.ts beside calendar.tsx to lock the migration; wire theme-role-regression.test.ts when that index lists sibling contract files; align ui-foundation.test.tsx or Storybook only when they pin old tokens; preserve shell surfaces, buttonVariants nav, focus ring, and hover:bg-af-overlay on day cells; maintain visual parity for DayPicker and foundation calendar showcase with no API or routing changes.",
  "context": {
    "customerAsk": "Migrate calendar.tsx accent and text tokens to Material role utilities: replace transitional accent and text product classes (text-af-accent, bg-af-accent, text-af-on-accent, bg-af-accent-surface, text-af-text-disabled, text-af-text-subtle) with Material role utilities consistent with button.tsx and material-color-role-taxonomy.md.",
    "problem": "ui/src/components/ui/calendar.tsx still uses transitional accent and text product classes while US-005 cleared other shared primitives and US-009 cleared ui/src/features/**. The calendar is on the buttonVariants allowlist but was not migrated, leaving the DayPicker primitive out of sync with the enforced Material role contract.",
    "solution": "Update calendar.tsx day cell class strings using documented role utility mappings while preserving border-outline, bg-surface-container-low, buttonVariants nav buttons, focus-visible:ring-af-focus-ring, and hover:bg-af-overlay on day cells; add calendar-color-roles.test.ts that reads calendar.tsx and asserts role utilities plus absence of forbidden transitional accent/text patterns; register the test in theme-role-regression.test.ts when that index lists siblings; update ui-foundation.test.tsx or Storybook only when assertions pin old tokens; pass cd ui && bun run tsc and targeted vitest with browser verification for visual parity on DayPicker and foundation calendar showcase."
  },
  "acceptanceCriteria": [
    "calendar.tsx day_button selected state uses bg-primary and text-on-primary instead of aria-selected:bg-af-accent and text-af-on-accent",
    "calendar.tsx outside cells use bg-primary-container and text-on-primary-container instead of bg-af-accent-surface and text-af-on-accent",
    "calendar.tsx today uses text-primary; disabled and muted outside text use text-on-surface-disabled; weekday uses text-on-surface-variant",
    "calendar.tsx contains none of text-af-accent, bg-af-accent, text-af-on-accent, bg-af-accent-surface, text-af-text-disabled, or text-af-text-subtle",
    "Shell classes, buttonVariants nav, focus-visible:ring-af-focus-ring, and hover:bg-af-overlay on day cells are preserved",
    "calendar-color-roles.test.ts reads calendar.tsx and asserts required role utilities and forbidden transitional accent/text patterns are absent",
    "theme-role-regression.test.ts includes calendar-color-roles.test.ts when that index lists sibling contract files",
    "DayPicker and foundation calendar showcase retain visual parity on at least two theme palettes",
    "cd ui && bun run tsc and targeted vitest for calendar color roles and theme regression pass",
    "Typecheck, lint, and tests pass"
  ],
  "userStories": [
    {
      "id": "migrate-calendar-color-roles-001",
      "title": "Replace transitional accent and text tokens in calendar.tsx",
      "description": "As a user of date pickers, I want the shared calendar DayPicker to use Material color role utilities for selected days, today, outside-month cells, disabled text, and weekday labels so accent and text styling matches migrated buttons without changing calendar behavior or shell chrome.",
      "acceptanceCriteria": [
        "day_button selected state: aria-selected:bg-af-accent becomes bg-primary (or equivalent selected-state role utility) and text-af-on-accent becomes text-on-primary",
        "outside: bg-af-accent-surface becomes bg-primary-container and text-af-on-accent becomes text-on-primary-container",
        "today: text-af-accent becomes text-primary",
        "disabled and muted outside text: text-af-text-disabled becomes text-on-surface-disabled",
        "weekday: text-af-text-subtle becomes text-on-surface-variant",
        "calendar.tsx contains no text-af-accent, bg-af-accent, text-af-on-accent, bg-af-accent-surface, text-af-text-disabled, or text-af-text-subtle after the change",
        "Shell classes (border-outline, bg-surface-container-low), buttonVariants nav buttons, focus-visible:ring-af-focus-ring, and hover:bg-af-overlay on day cells are unchanged",
        "Only ui/src/components/ui/calendar.tsx is edited in this story; no styles.css foundation keys, button-policy.stories.tsx, ui-foundation-showcase.tsx, or overlay/chart taxonomy changes",
        "Typecheck passes",
        "Verify in browser: DayPicker and foundation Storybook calendar showcase show the same selected-day, today, outside-month, disabled, and weekday label presentation as before on at least two theme palettes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "migrate-calendar-color-roles-002",
      "title": "Add focused vitest for calendar color roles",
      "description": "As a maintainer, I want a behavioral contract test on calendar.tsx so transitional accent and text tokens cannot reappear in the shared calendar primitive without a failing test.",
      "acceptanceCriteria": [
        "ui/src/components/ui/calendar-color-roles.test.ts reads calendar.tsx and asserts selected/today/disabled/weekday/outside cells use bg-primary, text-on-primary, bg-primary-container, text-on-primary-container, text-primary, text-on-surface-disabled, and text-on-surface-variant where accent/text styling applies",
        "The test asserts calendar.tsx does not contain forbidden transitional accent/text patterns aligned with feature-surface-color-roles.test.ts: text-af-accent, bg-af-accent, text-af-on-accent, bg-af-accent-surface, text-af-text-disabled, text-af-text-subtle",
        "The test does not scan file inventories, import graphs, route registrations, doc link topology, or asset-bundle internals",
        "shared-primitive-neutral-surface-roles.test.ts is not expanded to cover every file under components/ui/",
        "ui/src/styles/theme-role-regression.test.ts imports or references calendar-color-roles.test.ts when that index lists sibling contract files",
        "Typecheck passes",
        "Tests pass for calendar-color-roles.test.ts and the theme-role regression index when wired"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "migrate-calendar-color-roles-003",
      "title": "Align consumer tests and pass verification",
      "description": "As a reviewer, I want consumer tests and customer verification commands green so the calendar color-role migration ships with no regressions in foundation or theme coverage.",
      "acceptanceCriteria": [
        "ui-foundation.test.tsx or Storybook tests that assert class substrings pinning old transitional accent/text tokens are updated to expect new role utilities only when those tests fail due to the migration",
        "Consumer test updates preserve behavioral intent without adding layout-topology or allowlist-inventory meta-tests",
        "cd ui && bun run tsc exits 0",
        "Targeted vitest for calendar-color-roles.test.ts, theme-role-regression.test.ts, and any touched consumer tests passes",
        "No API, routing, or public Calendar/DayPicker prop surface changes",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)