### PR TITLE
migrate-prompt-editor-muted-text-color-roles

### DIFF
--- a/ui/src/components/prompt-editor/monaco-guard-selector-editor.tsx
+++ b/ui/src/components/prompt-editor/monaco-guard-selector-editor.tsx
@@ -208,7 +208,7 @@ function GuardSelectorEditorFallbackState({
     >
       <p
         className={cn(
-          "m-0 text-af-text-muted",
+          "m-0 text-on-surface-variant",
           DASHBOARD_SUPPORTING_TEXT_CLASS,
         )}
       >
@@ -217,7 +217,7 @@ function GuardSelectorEditorFallbackState({
       <textarea
         aria-label={ariaLabel}
         className={cn(
-          "m-0 w-full resize-none border-0 bg-transparent p-0 text-af-text outline-none",
+          "m-0 w-full resize-none border-0 bg-transparent p-0 text-on-surface outline-none",
           DASHBOARD_BODY_TEXT_CLASS,
         )}
         defaultValue={value}

--- a/ui/src/components/prompt-editor/monaco-prompt-editor.tsx
+++ b/ui/src/components/prompt-editor/monaco-prompt-editor.tsx
@@ -319,7 +319,7 @@ function PromptEditorFallbackState({
     >
       <p
         className={cn(
-          "m-0 text-af-text-muted",
+          "m-0 text-on-surface-variant",
           DASHBOARD_SUPPORTING_TEXT_CLASS,
         )}
       >
@@ -327,7 +327,7 @@ function PromptEditorFallbackState({
       </p>
       <pre
         className={cn(
-          "m-0 whitespace-pre-wrap break-words text-af-text-muted [overflow-wrap:anywhere]",
+          "m-0 whitespace-pre-wrap break-words text-on-surface-variant [overflow-wrap:anywhere]",
           DASHBOARD_BODY_TEXT_CLASS,
         )}
       >

--- a/ui/src/components/prompt-editor/prompt-editor-neutral-surface-roles.test.ts
+++ b/ui/src/components/prompt-editor/prompt-editor-neutral-surface-roles.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 const PROMPT_EDITOR_DIR = join(dirname(fileURLToPath(import.meta.url)));
 
 /** Transitional neutral surface/border tokens migrated to Material role utilities. */
-const FORBIDDEN_TRANSITIONAL_NEUTRAL_PATTERNS = [
+const FORBIDDEN_TRANSITIONAL_NEUTRAL_SURFACE_PATTERNS = [
   /\bbg-af-surface-(subtle|raised)\b/,
   /\bbg-af-surface\b/,
   /\bborder-af-border\b/,
@@ -16,17 +16,67 @@ const FORBIDDEN_TRANSITIONAL_NEUTRAL_PATTERNS = [
   /\bhover:bg-af-border-strong\b/,
 ];
 
+/** Transitional neutral text tokens migrated to Material role utilities. */
+const FORBIDDEN_TRANSITIONAL_NEUTRAL_TEXT_PATTERNS = [
+  /\btext-af-text(?!-)/,
+  /\btext-af-text-muted\b/,
+];
+
+function walkPromptEditorProductionSources(dir: string): string[] {
+  const files: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) {
+      files.push(...walkPromptEditorProductionSources(path));
+    } else if (/\.(tsx|ts)$/.test(name)) {
+      if (
+        /\.(test|stories)\.(tsx|ts)$/.test(name) ||
+        name.includes(".coverage.test.")
+      ) {
+        continue;
+      }
+      if (name === "prompt-editor-neutral-surface-roles.test.ts") {
+        continue;
+      }
+      files.push(path);
+    }
+  }
+  return files;
+}
+
 function readPromptEditorSource(fileName: string): string {
   return readFileSync(join(PROMPT_EDITOR_DIR, fileName), "utf8");
 }
 
+function relativePromptEditorPath(absolutePath: string): string {
+  return absolutePath.slice(PROMPT_EDITOR_DIR.length + 1);
+}
+
 function expectNoForbiddenTransitionalNeutralSurfaces(source: string): void {
-  for (const pattern of FORBIDDEN_TRANSITIONAL_NEUTRAL_PATTERNS) {
+  for (const pattern of FORBIDDEN_TRANSITIONAL_NEUTRAL_SURFACE_PATTERNS) {
+    expect(source).not.toMatch(pattern);
+  }
+}
+
+function expectNoForbiddenTransitionalNeutralText(source: string): void {
+  for (const pattern of FORBIDDEN_TRANSITIONAL_NEUTRAL_TEXT_PATTERNS) {
     expect(source).not.toMatch(pattern);
   }
 }
 
 describe("prompt-editor neutral surface roles", () => {
+  const productionSources = walkPromptEditorProductionSources(PROMPT_EDITOR_DIR);
+
+  it.each(
+    productionSources.map((path) => [relativePromptEditorPath(path), path]),
+  )(
+    "%s avoids transitional neutral text class tokens",
+    (_label, filePath) => {
+      const source = readFileSync(filePath, "utf8");
+      expectNoForbiddenTransitionalNeutralText(source);
+    },
+  );
+
   it("monaco-prompt-editor uses border-outline on editor shells", () => {
     const source = readPromptEditorSource("monaco-prompt-editor.tsx");
 
@@ -34,11 +84,35 @@ describe("prompt-editor neutral surface roles", () => {
     expectNoForbiddenTransitionalNeutralSurfaces(source);
   });
 
+  it("monaco-prompt-editor fallback helper and body copy use text-on-surface-variant", () => {
+    const source = readPromptEditorSource("monaco-prompt-editor.tsx");
+
+    expect(source).toMatch(
+      /className=\{cn\(\s*"m-0 text-on-surface-variant",\s*DASHBOARD_SUPPORTING_TEXT_CLASS,/,
+    );
+    expect(source).toMatch(
+      /className=\{cn\(\s*"m-0 whitespace-pre-wrap break-words text-on-surface-variant/,
+    );
+    expectNoForbiddenTransitionalNeutralText(source);
+  });
+
   it("monaco-guard-selector-editor uses border-outline on editor shells", () => {
     const source = readPromptEditorSource("monaco-guard-selector-editor.tsx");
 
     expect(source).toContain("border-outline");
     expectNoForbiddenTransitionalNeutralSurfaces(source);
+  });
+
+  it("monaco-guard-selector-editor fallback uses text-on-surface-variant helper and text-on-surface textarea", () => {
+    const source = readPromptEditorSource("monaco-guard-selector-editor.tsx");
+
+    expect(source).toMatch(
+      /className=\{cn\(\s*"m-0 text-on-surface-variant",\s*DASHBOARD_SUPPORTING_TEXT_CLASS,/,
+    );
+    expect(source).toMatch(
+      /className=\{cn\(\s*"m-0 w-full resize-none border-0 bg-transparent p-0 text-on-surface outline-none",\s*DASHBOARD_BODY_TEXT_CLASS,/,
+    );
+    expectNoForbiddenTransitionalNeutralText(source);
   });
 
   it("prompt-editor-diagnostics-panel uses bg-surface-container-high on diagnostic list items", () => {


### PR DESCRIPTION
{
  "project": "Migrate Prompt-Editor Muted Text to Material Role Utilities",
  "branchName": "migrate-prompt-editor-muted-text-color-roles",
  "description": "Replace transitional text-af-text-muted and text-af-text class tokens on prompt-editor Monaco fallback shells with Material text-on-surface-variant and text-on-surface role utilities, extend the prompt-editor neutral contract vitest to forbid those transitional patterns across production sources, align consumer tests only when they pin old tokens, and preserve visual parity for workstation prompt and guard-selector fallback helper and body copy with no API or routing changes.",
  "context": {
    "customerAsk": "Migrate prompt-editor muted text to Material role utilities: replace text-af-text-muted and text-af-text on Monaco fallback shells in ui/src/components/prompt-editor/** with text-on-surface-variant and text-on-surface per the material color role taxonomy.",
    "problem": "PR #661 migrated neutral surfaces in ui/src/components/prompt-editor/** but monaco-prompt-editor.tsx and monaco-guard-selector-editor.tsx still use transitional text-af-text-muted and text-af-text on fallback helper and textarea chrome, splitting the package across two styling eras and inviting forbidden feature token copy-paste.",
    "solution": "Update monaco-prompt-editor.tsx and monaco-guard-selector-editor.tsx using documented role utility mappings while keeping dashboard typography composition, bg-transparent shells, danger tokens, and surface roles unchanged; extend prompt-editor-neutral-surface-roles.test.ts (or add a sibling contract test) to forbid text-af-text-muted and standalone text-af-text in prompt-editor production sources; update consumer tests only when they pin old tokens; pass cd ui && bun run tsc and targeted vitest with browser verification for fallback copy parity."
  },
  "acceptanceCriteria": [
    "monaco-prompt-editor.tsx uses text-on-surface-variant for fallback helper and body copy with no text-af-text-muted",
    "monaco-guard-selector-editor.tsx uses text-on-surface-variant for helper copy and text-on-surface on the read-only textarea with no text-af-text-muted or standalone text-af-text",
    "prompt-editor-neutral-surface-roles.test.ts or a sibling contract test forbids text-af-text-muted and standalone text-af-text in ui/src/components/prompt-editor/** production sources excluding *.test.ts(x)",
    "Existing prompt-editor RTL and behavior tests pass without pinning transitional text class substrings; updates use visible copy or ARIA only when needed",
    "Danger semantic tokens and neutral surface role utilities from the prompt-editor surface migration remain unchanged",
    "Workstation prompt and guard-selector fallback shells retain visual parity for helper and body copy on at least two theme palettes",
    "cd ui && bun run tsc and targeted vitest for prompt-editor contracts and src/components/prompt-editor/ pass",
    "Typecheck, lint, and tests pass"
  ],
  "userStories": [
    {
      "id": "migrate-prompt-editor-muted-text-color-roles-001",
      "title": "Replace transitional text tokens on Monaco fallback shells",
      "description": "As a workstation user, I want prompt and guard-selector Monaco fallback helper and body copy to use Material text role utilities so muted and primary copy matches migrated inputs and diagnostics without changing editor behavior or danger styling.",
      "acceptanceCriteria": [
        "monaco-prompt-editor.tsx: both fallback text-af-text-muted class strings are replaced with text-on-surface-variant; no text-af-text-muted remains",
        "monaco-guard-selector-editor.tsx: fallback helper text-af-text-muted becomes text-on-surface-variant and read-only textarea text-af-text becomes text-on-surface; no text-af-text-muted or standalone text-af-text remains",
        "DASHBOARD_SUPPORTING_TEXT_CLASS and DASHBOARD_BODY_TEXT_CLASS composition on those elements is unchanged aside from the text utility swap",
        "Danger semantic tokens and neutral surface role utilities from the prompt-editor surface migration are not modified",
        "Only monaco-prompt-editor.tsx and monaco-guard-selector-editor.tsx are edited; no Monaco theme internals, overlay or chart taxonomy, diagnostics panel, or repo-wide text migration",
        "Typecheck passes",
        "Verify in browser: workstation prompt editor and guard-selector editor fallback states show the same helper and body copy contrast hierarchy as before on at least two theme palettes; danger styling unchanged where present"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "migrate-prompt-editor-muted-text-color-roles-002",
      "title": "Extend prompt-editor contract test for neutral text roles",
      "description": "As a maintainer, I want a behavioral contract test on prompt-editor production sources so transitional neutral text class tokens cannot reappear without a failing test.",
      "acceptanceCriteria": [
        "prompt-editor-neutral-surface-roles.test.ts is extended or a sibling contract test reads production sources under ui/src/components/prompt-editor/** excluding *.test.ts(x) files",
        "The test asserts no production prompt-editor source matches text-af-text-muted or standalone text-af-text with the same boundary semantics as feature-surface-color-roles.test.ts",
        "monaco-prompt-editor.tsx and monaco-guard-selector-editor.tsx assert text-on-surface-variant on muted helper copy and text-on-surface on the guard-selector read-only textarea",
        "The test does not scan file inventories, import graphs, route registrations, doc link topology, or asset-bundle internals",
        "feature-surface-color-roles.test.ts is not expanded to cover all of ui/src/components/",
        "Typecheck passes",
        "Tests pass for the extended or new prompt-editor text-role contract vitest"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "migrate-prompt-editor-muted-text-color-roles-003",
      "title": "Align consumer tests and pass verification",
      "description": "As a reviewer, I want consumer tests and customer verification commands green so the text-role migration ships with no regressions in prompt-editor dependent coverage.",
      "acceptanceCriteria": [
        "monaco-prompt-editor.test.tsx, monaco-guard-selector-editor.test.tsx, or other prompt-editor tests that pin text-af-text-muted or text-af-text class substrings are updated only when they fail due to the migration",
        "Consumer test updates prefer visible helper or body copy or ARIA assertions over transitional class substrings without weakening behavioral intent",
        "cd ui && bun run tsc exits 0",
        "Targeted vitest passes for prompt-editor contract tests and src/components/prompt-editor/ (for example cd ui && bun x vitest run src/components/prompt-editor/prompt-editor-neutral-surface-roles.test.ts src/components/prompt-editor/)",
        "No API, routing, Monaco theme export, or public component prop surface changes",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)