### PR TITLE
migrate-shared-primitive-disabled-text-color-roles

### DIFF
--- a/docs/internal/development/material-color-role-migration-rollout.md
+++ b/docs/internal/development/material-color-role-migration-rollout.md
@@ -35,6 +35,7 @@ Implement and review in this sequence. Later phases assume earlier ones are merg
 | Layout scale | `ui/src/styles/layout-role-tokens.test.ts` | Layout spacing roles registered |
 | Shared primitive semantics | `ui/src/components/ui/shared-primitive-semantic-color-roles.test.ts` | No semantic misuse for brand emphasis |
 | Shared primitive neutrals | `ui/src/components/ui/shared-primitive-neutral-surface-roles.test.ts` | Neutral chrome on role utilities |
+| Shared primitive disabled text | `ui/src/components/ui/shared-primitive-disabled-text-color-roles.test.ts` | Disabled/muted copy on `text-on-surface-disabled` in input, panel trigger, chart legend, action button spinner |
 | Calendar accent/text | `ui/src/components/ui/calendar-color-roles.test.ts` | DayPicker selected, today, outside, disabled, and weekday cells on role utilities |
 | Feature & graph surfaces | `ui/src/features/feature-surface-color-roles.test.ts` | Features avoid transitional tokens; graph/header samples use roles |
 | Prompt-editor neutrals | `ui/src/components/prompt-editor/prompt-editor-neutral-surface-roles.test.ts` | Monaco shells, diagnostics rows, and resize handle on role utilities |
@@ -51,6 +52,7 @@ cd ui && bun x vitest run src/styles/theme-role-regression.test.ts \
   src/styles/color-palette-presets.test.ts \
   src/features/feature-surface-color-roles.test.ts \
   src/components/ui/shared-primitive-neutral-surface-roles.test.ts \
+  src/components/ui/shared-primitive-disabled-text-color-roles.test.ts \
   src/components/ui/calendar-color-roles.test.ts \
   src/components/prompt-editor/prompt-editor-neutral-surface-roles.test.ts \
   src/components/ui/shared-primitive-semantic-color-roles.test.ts \

--- a/ui/src/components/ui/chart.tsx
+++ b/ui/src/components/ui/chart.tsx
@@ -262,7 +262,7 @@ export function ChartLegendContent({
             aria-pressed={!hidden}
             className={cn(
               "min-h-0 rounded-md border-transparent px-0 py-1 text-left font-normal focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-af-focus",
-              hidden ? "text-af-text-disabled" : "",
+              hidden ? "text-on-surface-disabled" : "",
               itemClassName,
             )}
             data-chart-legend-series={key}

--- a/ui/src/components/ui/dashboard-action-button.tsx
+++ b/ui/src/components/ui/dashboard-action-button.tsx
@@ -100,7 +100,7 @@ function DashboardActionButtonSpinner() {
       viewBox="0 0 16 16"
     >
       <circle
-        className="text-af-text-disabled"
+        className="text-on-surface-disabled"
         cx="8"
         cy="8"
         r="6"

--- a/ui/src/components/ui/expandable-panel-trigger.tsx
+++ b/ui/src/components/ui/expandable-panel-trigger.tsx
@@ -18,7 +18,7 @@ const EXPANDABLE_PANEL_TRIGGER_VARIANT_CLASS: Record<
   string
 > = {
   section: cn(
-    "shrink-0 cursor-pointer rounded-lg border border-outline bg-surface-container-high px-2.5 py-2 text-on-surface-variant transition hover:border-outline-variant hover:bg-af-overlay hover:text-on-surface focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-af-accent disabled:cursor-not-allowed disabled:border-outline disabled:bg-surface-container-low disabled:text-af-text-disabled",
+    "shrink-0 cursor-pointer rounded-lg border border-outline bg-surface-container-high px-2.5 py-2 text-on-surface-variant transition hover:border-outline-variant hover:bg-af-overlay hover:text-on-surface focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-af-accent disabled:cursor-not-allowed disabled:border-outline disabled:bg-surface-container-low disabled:text-on-surface-disabled",
     DASHBOARD_SUPPORTING_TEXT_CLASS,
   ),
   compact: cn(

--- a/ui/src/components/ui/input.tsx
+++ b/ui/src/components/ui/input.tsx
@@ -5,7 +5,7 @@ import { cn } from "../../lib/cn";
 export type InputProps = InputHTMLAttributes<HTMLInputElement>;
 
 export const INPUT_CLASS =
-  "flex min-h-11 w-full rounded-xl border border-outline bg-surface-container-high px-3 py-2.5 text-sm text-on-surface outline-none transition-colors placeholder:text-af-text-disabled focus-visible:border-outline-variant focus-visible:ring-2 focus-visible:ring-af-focus-ring disabled:cursor-not-allowed disabled:border-outline disabled:bg-surface-container-low disabled:text-af-text-disabled";
+  "flex min-h-11 w-full rounded-xl border border-outline bg-surface-container-high px-3 py-2.5 text-sm text-on-surface outline-none transition-colors placeholder:text-on-surface-disabled focus-visible:border-outline-variant focus-visible:ring-2 focus-visible:ring-af-focus-ring disabled:cursor-not-allowed disabled:border-outline disabled:bg-surface-container-low disabled:text-on-surface-disabled";
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
   { className, type = "text", ...props },

--- a/ui/src/components/ui/shared-primitive-disabled-text-color-roles.test.ts
+++ b/ui/src/components/ui/shared-primitive-disabled-text-color-roles.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const UI_COMPONENTS_DIR = join(dirname(fileURLToPath(import.meta.url)));
+
+const IN_SCOPE_FILES = [
+  "input.tsx",
+  "expandable-panel-trigger.tsx",
+  "chart.tsx",
+  "dashboard-action-button.tsx",
+] as const;
+
+const FORBIDDEN_TRANSITIONAL_DISABLED_TEXT = /\btext-af-text-disabled\b/;
+
+function readComponentSource(fileName: string): string {
+  return readFileSync(join(UI_COMPONENTS_DIR, fileName), "utf8");
+}
+
+function expectNoTransitionalDisabledText(source: string): void {
+  expect(source).not.toMatch(FORBIDDEN_TRANSITIONAL_DISABLED_TEXT);
+}
+
+describe("shared primitive disabled text color roles", () => {
+  it.each(IN_SCOPE_FILES)(
+    "does not use transitional text-af-text-disabled in %s",
+    (fileName) => {
+      expectNoTransitionalDisabledText(readComponentSource(fileName));
+    },
+  );
+
+  it("maps input placeholder and disabled copy to on-surface-disabled role utilities", () => {
+    const source = readComponentSource("input.tsx");
+
+    expect(source).toContain("placeholder:text-on-surface-disabled");
+    expect(source).toContain("disabled:text-on-surface-disabled");
+    expectNoTransitionalDisabledText(source);
+  });
+
+  it("maps expandable panel trigger disabled copy to on-surface-disabled", () => {
+    const source = readComponentSource("expandable-panel-trigger.tsx");
+
+    expect(source).toContain("disabled:text-on-surface-disabled");
+    expectNoTransitionalDisabledText(source);
+  });
+
+  it("maps chart hidden legend toggle copy to text-on-surface-disabled", () => {
+    const source = readComponentSource("chart.tsx");
+
+    expect(source).toMatch(/hidden\s*\?\s*"text-on-surface-disabled"/);
+    expectNoTransitionalDisabledText(source);
+  });
+
+  it("maps dashboard action button spinner circle to text-on-surface-disabled", () => {
+    const source = readComponentSource("dashboard-action-button.tsx");
+
+    expect(source).toContain('className="text-on-surface-disabled"');
+    expectNoTransitionalDisabledText(source);
+  });
+});


### PR DESCRIPTION
{
  "project": "Migrate Shared-Primitive Disabled Text to Material Role Utilities",
  "branchName": "migrate-shared-primitive-disabled-text-color-roles",
  "description": "Replace transitional text-af-text-disabled and placeholder:text-af-text-disabled class tokens with text-on-surface-disabled and placeholder:text-on-surface-disabled in four shared UI primitives under ui/src/components/ui/, add a focused vitest contract on those source files, align consumer tests only when they pin old tokens, and preserve visual parity for disabled inputs, panel triggers, chart legend toggles, and loading action buttons with no API or routing changes.",
  "context": {
    "customerAsk": "Migrate shared-primitive disabled text to role utilities: replace text-af-text-disabled and placeholder:text-af-text-disabled with text-on-surface-disabled and placeholder:text-on-surface-disabled in shared primitives only (ui/src/components/ui/).",
    "problem": "Four shared UI primitives (input.tsx, expandable-panel-trigger.tsx, chart.tsx, dashboard-action-button.tsx) still use transitional text-af-text-disabled while US-006 wired on-surface-disabled and button.tsx already uses disabled:text-on-surface-disabled, splitting shared primitives across two styling eras despite the product key remaining as an alias in color-role-tokens.css.",
    "solution": "Update the four in-scope files using documented role utility mappings while preserving non-disabled styling and interaction; add shared-primitive-disabled-text-color-roles.test.ts reading only those four files to assert role utilities and forbid text-af-text-disabled; update consumer tests only when they pin old tokens; pass cd ui && bun run tsc and targeted vitest with browser verification for disabled/muted copy parity."
  },
  "acceptanceCriteria": [
    "input.tsx uses placeholder:text-on-surface-disabled and disabled:text-on-surface-disabled with no text-af-text-disabled",
    "expandable-panel-trigger.tsx uses disabled:text-on-surface-disabled with no text-af-text-disabled",
    "chart.tsx hidden legend toggle uses text-on-surface-disabled with no text-af-text-disabled",
    "dashboard-action-button.tsx spinner circle uses text-on-surface-disabled with no text-af-text-disabled",
    "shared-primitive-disabled-text-color-roles.test.ts reads only the four in-scope files and asserts role utilities plus absence of text-af-text-disabled without scanning unrelated directories",
    "Existing shared-primitive consumer tests pass with updates only when they pin old transitional class substrings, preferring visible copy or ARIA",
    "Disabled inputs, panel triggers, chart legend toggles, and loading action buttons retain visual parity on at least two theme palettes",
    "cd ui && bun run tsc and targeted vitest for the disabled-text contract test pass",
    "Typecheck, lint, and tests pass"
  ],
  "userStories": [
    {
      "id": "migrate-shared-primitive-disabled-text-color-roles-001",
      "title": "Replace transitional disabled text tokens in four shared primitives",
      "description": "As a dashboard user, I want disabled and muted copy on shared inputs, panel triggers, chart legend toggles, and loading action buttons to use Material disabled text role utilities so styling matches migrated buttons without changing interaction or layout.",
      "acceptanceCriteria": [
        "input.tsx: placeholder:text-af-text-disabled becomes placeholder:text-on-surface-disabled and disabled:text-af-text-disabled becomes disabled:text-on-surface-disabled with no text-af-text-disabled remaining",
        "expandable-panel-trigger.tsx: disabled:text-af-text-disabled becomes disabled:text-on-surface-disabled with no text-af-text-disabled remaining",
        "chart.tsx: hidden legend toggle text-af-text-disabled becomes text-on-surface-disabled with no text-af-text-disabled remaining",
        "dashboard-action-button.tsx: spinner circle text-af-text-disabled becomes text-on-surface-disabled with no text-af-text-disabled remaining",
        "Non-disabled styling, hover:bg-af-overlay, chart series af-chart-* keys, and semantic danger tokens in these files are not modified",
        "Only the four listed files under ui/src/components/ui/ are edited; no changes to ui/src/features/**, Storybook fixtures, or overlay migration lanes",
        "Typecheck passes",
        "Verify in browser: disabled text inputs, disabled expandable panel triggers, chart hidden-legend toggles, and executing dashboard action button spinners match pre-change disabled/muted copy on at least two theme palettes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "migrate-shared-primitive-disabled-text-color-roles-002",
      "title": "Add focused vitest contract for shared-primitive disabled text roles",
      "description": "As a maintainer, I want a behavioral contract test on the four in-scope shared primitive source files so transitional disabled text class tokens cannot reappear without a failing test.",
      "acceptanceCriteria": [
        "A focused vitest such as ui/src/components/ui/shared-primitive-disabled-text-color-roles.test.ts reads source content from input.tsx, expandable-panel-trigger.tsx, chart.tsx, and dashboard-action-button.tsx only",
        "The test asserts text-on-surface-disabled is present where disabled or muted copy applies and input.tsx additionally asserts placeholder:text-on-surface-disabled",
        "The test asserts text-af-text-disabled is absent from all four in-scope files",
        "The test does not scan ui/src/features/**, unrelated components paths, file inventories, import graphs, route registrations, doc link topology, or asset-bundle internals",
        "Typecheck passes",
        "Tests pass for the new or updated shared-primitive disabled-text contract vitest"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "migrate-shared-primitive-disabled-text-color-roles-003",
      "title": "Align consumer tests and pass verification",
      "description": "As a reviewer, I want consumer tests and customer verification commands green so the disabled-text role migration ships with no regressions in shared-primitive dependent coverage.",
      "acceptanceCriteria": [
        "Shared-primitive consumer tests that pin text-af-text-disabled class substrings are updated only when they fail due to the migration",
        "Consumer test updates prefer visible copy, disabled state, or ARIA assertions over transitional class substrings without weakening behavioral intent",
        "cd ui && bun run tsc exits 0",
        "Targeted vitest passes for the disabled-text contract test (for example cd ui && bun x vitest run src/components/ui/shared-primitive-disabled-text-color-roles.test.ts)",
        "No API, routing, or public component prop surface changes",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)