### PR TITLE
migrate-shared-primitive-overlay-hover-color-roles

### DIFF
--- a/docs/internal/development/frontend-deadcode-baseline.json
+++ b/docs/internal/development/frontend-deadcode-baseline.json
@@ -5,6 +5,11 @@
     "name": "scripts/summarize-warning-inventory.mjs"
   },
   {
+    "file": "scripts/verify-overlay-hover-storybook.mjs",
+    "kind": "file",
+    "name": "scripts/verify-overlay-hover-storybook.mjs"
+  },
+  {
     "file": "src/features/factory-graph-editor/lib/factory-graph-operations.ts",
     "kind": "export",
     "name": "validateFactoryGraphState"

--- a/docs/internal/development/material-color-role-migration-rollout.md
+++ b/docs/internal/development/material-color-role-migration-rollout.md
@@ -68,6 +68,7 @@ cd ui && bun x vitest run src/styles/theme-role-regression.test.ts \
 | Migration overview (all pillars) | `Agent Factory/UI/Theme Role Migration Overview` |
 | Accent contrast | `Agent Factory/UI/Color Role Accent Contrast` |
 | Neutral surfaces | `Agent Factory/UI/Color Role Neutral Surfaces` |
+| Overlay hover (shared primitives) | `Agent Factory/UI/Color Role Overlay Hover Surfaces` (browser check: `node scripts/verify-overlay-hover-storybook.mjs` after `build-storybook`) |
 | Typography hierarchy | `Agent Factory/UI/Typography Role Hierarchy` |
 | Layout primitives | `Agent Factory/UI/Layout Role Primitives` |
 | Palette selector | `you-agent-factory/Dashboard/Color Palette Selector` |

--- a/docs/internal/development/material-color-role-migration-rollout.md
+++ b/docs/internal/development/material-color-role-migration-rollout.md
@@ -36,6 +36,7 @@ Implement and review in this sequence. Later phases assume earlier ones are merg
 | Shared primitive semantics | `ui/src/components/ui/shared-primitive-semantic-color-roles.test.ts` | No semantic misuse for brand emphasis |
 | Shared primitive neutrals | `ui/src/components/ui/shared-primitive-neutral-surface-roles.test.ts` | Neutral chrome on role utilities |
 | Shared primitive disabled text | `ui/src/components/ui/shared-primitive-disabled-text-color-roles.test.ts` | Disabled/muted copy on `text-on-surface-disabled` in input, panel trigger, chart legend, action button spinner |
+| Shared primitive overlay hover | `ui/src/components/ui/shared-primitive-overlay-hover-color-roles.test.ts` | Interactive hover and table selection on `hover:bg-surface-container*` in button, table, list selection, panel trigger |
 | Calendar accent/text | `ui/src/components/ui/calendar-color-roles.test.ts` | DayPicker selected, today, outside, disabled, and weekday cells on role utilities |
 | Feature & graph surfaces | `ui/src/features/feature-surface-color-roles.test.ts` | Features avoid transitional tokens; graph/header samples use roles |
 | Prompt-editor neutrals | `ui/src/components/prompt-editor/prompt-editor-neutral-surface-roles.test.ts` | Monaco shells, diagnostics rows, and resize handle on role utilities |
@@ -53,6 +54,7 @@ cd ui && bun x vitest run src/styles/theme-role-regression.test.ts \
   src/features/feature-surface-color-roles.test.ts \
   src/components/ui/shared-primitive-neutral-surface-roles.test.ts \
   src/components/ui/shared-primitive-disabled-text-color-roles.test.ts \
+  src/components/ui/shared-primitive-overlay-hover-color-roles.test.ts \
   src/components/ui/calendar-color-roles.test.ts \
   src/components/prompt-editor/prompt-editor-neutral-surface-roles.test.ts \
   src/components/ui/shared-primitive-semantic-color-roles.test.ts \

--- a/docs/internal/processes/manual-qa.md
+++ b/docs/internal/processes/manual-qa.md
@@ -117,6 +117,13 @@ Use this checklist when the open-session flow changes and reviewers need proof a
 
 ## Latest Evidence
 
+Date: `2026-06-04` (UTC)
+
+- `cd ui && bun run build-storybook` passed.
+- `cd ui && bun run tsc` passed.
+- `cd ui && bunx vitest run src/components/ui/shared-primitive-overlay-hover-color-roles.test.ts src/components/ui/shared-primitive-overlay-hover-color-roles.behavior.test.tsx` passed in happy-dom, confirming selected table rows resolve `--color-surface-container-low` and ghost hover tokens resolve per palette on `factory-dark` and `factory-light`.
+- `cd ui && bun run build-storybook` then `cd ui && AGENT_FACTORY_STORYBOOK_PORT=6026 node scripts/verify-overlay-hover-storybook.mjs` passed in headless Chromium against `agent-factory-ui-color-role-overlay-hover-surfaces--overlay-hover-palette-verification`, switching `factory-dark` and `factory-light` and asserting computed hover backgrounds change for outline/secondary buttons, neutral list rows, and section/compact panel triggers; selected table rows render visible `bg-surface-container-low`; ghost/table row controls retain the migrated `hover:bg-surface-container*` class hooks.
+
 Date: `2026-05-31` (UTC)
 
 - `cd ui && bun run vitest run integration/factory-graph-editor.integration.test.mjs -t "discards pending"` passed in Playwright against the dashboard preview harness, covering current-activity card enter editor → add work type → discard pending changes → leave editor with zero session factory PUTs (story `ui-graph-editor-orchestration-split-004` browser gate).

--- a/ui/scripts/check-hardcoded-ui-copy.ts
+++ b/ui/scripts/check-hardcoded-ui-copy.ts
@@ -40,7 +40,7 @@ const TEXTUAL_COMPONENT_PROP_NAMES = new Set([
 const EXCLUDED_RELATIVE_PATH_PATTERNS = [
   /^src\/api\/generated\//,
   /^src\/components\/dashboard\/fixtures\//,
-  /^src\/components\/ui\/(color-role-accent-contrast|color-role-neutral-surfaces|layout-role-showcase|typography-role-hierarchy|theme-role-migration-overview)\.tsx$/,
+  /^src\/components\/ui\/(color-role-accent-contrast|color-role-neutral-surfaces|color-role-overlay-hover-surfaces|layout-role-showcase|typography-role-hierarchy|theme-role-migration-overview)\.tsx$/,
   /^src\/testing\//,
   /\/messages\//,
   /\.stories\./,

--- a/ui/scripts/verify-overlay-hover-storybook.mjs
+++ b/ui/scripts/verify-overlay-hover-storybook.mjs
@@ -1,0 +1,128 @@
+import process from "node:process";
+import { chromium } from "playwright";
+
+import { storyUrl, waitForStoryRender } from "./storybook-responsive-helpers.mjs";
+
+const STORYBOOK_HOST = process.env.AGENT_FACTORY_STORYBOOK_HOST ?? "127.0.0.1";
+const STORYBOOK_PORT = process.env.AGENT_FACTORY_STORYBOOK_PORT ?? "6008";
+const STORYBOOK_URL = `http://${STORYBOOK_HOST}:${STORYBOOK_PORT}`;
+const STORY_ID =
+  "agent-factory-ui-color-role-overlay-hover-surfaces--overlay-hover-palette-verification";
+
+const PALETTES = ["factory-dark", "factory-light"];
+
+const OPAQUE_HOVER_TARGETS = [
+  "hover-outline-button",
+  "hover-secondary-button",
+  "hover-list-row",
+  "hover-panel-section",
+  "hover-panel-compact",
+];
+
+const GHOST_HOVER_TARGET = "hover-ghost-button";
+
+async function readBackground(page, testId) {
+  return page.getByTestId(testId).evaluate((node) => getComputedStyle(node).backgroundColor);
+}
+
+async function readHoverBackground(page, testId) {
+  const element = page.getByTestId(testId);
+  await element.hover();
+  return element.evaluate((node) => getComputedStyle(node).backgroundColor);
+}
+
+async function verifyPalette(page, paletteId) {
+  await page.evaluate((palette) => {
+    document.documentElement.dataset.colorPalette = palette;
+  }, paletteId);
+
+  const hoverBackgrounds = {};
+
+  const ghostClassName = await page
+    .getByTestId(GHOST_HOVER_TARGET)
+    .evaluate((node) => node.className);
+  if (!ghostClassName.includes("hover:bg-surface-container-low")) {
+    throw new Error(
+      `Expected ${GHOST_HOVER_TARGET} to keep hover:bg-surface-container-low on palette ${paletteId}.`,
+    );
+  }
+
+  for (const testId of OPAQUE_HOVER_TARGETS) {
+    const resting = await readBackground(page, testId);
+    const hovered = await readHoverBackground(page, testId);
+    if (resting === hovered) {
+      throw new Error(
+        `Expected ${testId} hover background to differ from resting on palette ${paletteId} (${resting}).`,
+      );
+    }
+    hoverBackgrounds[testId] = hovered;
+  }
+
+  const selectedBackground = await readBackground(page, "selected-table-row");
+  if (!selectedBackground || selectedBackground === "rgba(0, 0, 0, 0)") {
+    throw new Error(
+      `Expected selected-table-row to render a visible selected background on palette ${paletteId}.`,
+    );
+  }
+
+  const tableRowClassName = await page
+    .getByTestId("hover-table-row")
+    .evaluate((node) => node.className);
+  if (!tableRowClassName.includes("hover:bg-surface-container")) {
+    throw new Error(
+      `Expected hover-table-row to keep hover:bg-surface-container on palette ${paletteId}.`,
+    );
+  }
+
+  return { hoverBackgrounds, selectedBackground };
+}
+
+export async function verifyOverlayHoverStorybook({
+  storybookUrl = STORYBOOK_URL,
+  storyId = STORY_ID,
+} = {}) {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+
+  try {
+    await page.goto(storyUrl(storybookUrl, storyId));
+    await waitForStoryRender(page);
+
+    const results = {};
+    for (const paletteId of PALETTES) {
+      results[paletteId] = await verifyPalette(page, paletteId);
+    }
+
+    for (const testId of OPAQUE_HOVER_TARGETS) {
+      const dark = results["factory-dark"].hoverBackgrounds[testId];
+      const light = results["factory-light"].hoverBackgrounds[testId];
+      if (dark === light) {
+        throw new Error(
+          `Expected ${testId} hover background to differ between factory-dark (${dark}) and factory-light (${light}).`,
+        );
+      }
+    }
+
+    if (
+      results["factory-dark"].selectedBackground ===
+      results["factory-light"].selectedBackground
+    ) {
+      throw new Error(
+        "Expected selected-table-row background to differ between factory-dark and factory-light.",
+      );
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+async function main() {
+  await verifyOverlayHoverStorybook();
+  console.log(
+    `Overlay hover palette verification passed for ${PALETTES.join(", ")} on ${STORY_ID}.`,
+  );
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/ui/src/components/ui/button.tsx
+++ b/ui/src/components/ui/button.tsx
@@ -17,11 +17,11 @@ const BUTTON_TONE_CLASS: Record<NonNullable<ButtonProps["tone"]>, string> = {
   destructive:
     "border-error bg-error text-on-error hover:border-af-danger-hover hover:bg-af-danger-hover",
   ghost:
-    "border-transparent bg-transparent text-on-surface-variant hover:bg-af-overlay hover:text-on-surface",
+    "border-transparent bg-transparent text-on-surface-variant hover:bg-surface-container-low hover:text-on-surface",
   outline:
-    "border-outline bg-surface-container-high text-on-surface hover:border-outline-variant hover:bg-af-overlay",
+    "border-outline bg-surface-container-high text-on-surface hover:border-outline-variant hover:bg-surface-container-highest",
   secondary:
-    "border-outline-variant bg-surface-container-low text-primary hover:border-primary hover:bg-af-overlay",
+    "border-outline-variant bg-surface-container-low text-primary hover:border-primary hover:bg-surface-container",
 };
 const BUTTON_SIZE_CLASS: Record<NonNullable<ButtonProps["size"]>, string> = {
   default: "px-4 py-2.5 text-sm",

--- a/ui/src/components/ui/color-role-overlay-hover-surfaces.stories.tsx
+++ b/ui/src/components/ui/color-role-overlay-hover-surfaces.stories.tsx
@@ -1,0 +1,32 @@
+import "../../styles.css";
+
+import { expect, within } from "storybook/test";
+
+import { ColorRoleOverlayHoverSurfacesShowcase } from "./color-role-overlay-hover-surfaces";
+
+export default {
+  title: "Agent Factory/UI/Color Role Overlay Hover Surfaces",
+  component: ColorRoleOverlayHoverSurfacesShowcase,
+  tags: ["test"],
+};
+
+export const OverlayHoverPaletteVerification = {
+  render: () => <ColorRoleOverlayHoverSurfacesShowcase />,
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(
+      canvas.getByRole("heading", {
+        name: "Overlay hover migration (surface-container roles)",
+      }),
+    ).toBeVisible();
+    await expect(canvas.getByTestId("hover-ghost-button")).toBeVisible();
+    await expect(canvas.getByTestId("hover-outline-button")).toBeVisible();
+    await expect(canvas.getByTestId("hover-secondary-button")).toBeVisible();
+    await expect(canvas.getByTestId("hover-table-row")).toBeVisible();
+    await expect(canvas.getByTestId("selected-table-row")).toBeVisible();
+    await expect(canvas.getByTestId("hover-list-row")).toBeVisible();
+    await expect(canvas.getByTestId("hover-panel-section")).toBeVisible();
+    await expect(canvas.getByTestId("hover-panel-compact")).toBeVisible();
+  },
+};

--- a/ui/src/components/ui/color-role-overlay-hover-surfaces.tsx
+++ b/ui/src/components/ui/color-role-overlay-hover-surfaces.tsx
@@ -1,0 +1,97 @@
+import { Button } from "./button";
+import { ExpandablePanelTrigger } from "./expandable-panel-trigger";
+import {
+  StandardListSelection,
+  StandardListSelectionItem,
+} from "./standard-list-selection";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "./table";
+
+export const OVERLAY_HOVER_VERIFICATION_PALETTES = [
+  "factory-dark",
+  "factory-light",
+] as const;
+
+export type OverlayHoverVerificationPalette =
+  (typeof OVERLAY_HOVER_VERIFICATION_PALETTES)[number];
+
+export function ColorRoleOverlayHoverSurfacesShowcase() {
+  return (
+    <section
+      aria-label="Shared primitive overlay hover role verification"
+      className="grid max-w-3xl gap-6 rounded-2xl border border-outline bg-background p-6 text-on-surface"
+    >
+      <header className="grid gap-2">
+        <h2 className="m-0 font-display text-2xl tracking-tight">
+          Overlay hover migration (surface-container roles)
+        </h2>
+        <p className="m-0 max-w-2xl text-sm text-on-surface-variant">
+          Ghost, outline, and secondary buttons; table row hover and selection;
+          neutral list rows; and expandable panel triggers use surface-container
+          elevation steps instead of translucent overlay tokens.
+        </p>
+      </header>
+
+      <div className="flex flex-wrap gap-2">
+        <Button data-testid="hover-ghost-button" tone="ghost">
+          Ghost hover
+        </Button>
+        <Button data-testid="hover-outline-button" tone="outline">
+          Outline hover
+        </Button>
+        <Button data-testid="hover-secondary-button" tone="secondary">
+          Secondary hover
+        </Button>
+      </div>
+
+      <Table aria-label="Overlay hover table verification">
+        <TableHeader>
+          <TableRow>
+            <TableHead>Column</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow data-testid="hover-table-row">
+            <TableCell>Hover row</TableCell>
+          </TableRow>
+          <TableRow data-state="selected" data-testid="selected-table-row">
+            <TableCell>Selected row</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+
+      <StandardListSelection aria-label="Overlay hover list verification">
+        <StandardListSelectionItem data-testid="hover-list-row">
+          Neutral list row
+        </StandardListSelectionItem>
+      </StandardListSelection>
+
+      <div className="flex flex-wrap gap-2">
+        <ExpandablePanelTrigger
+          aria-label="Section panel trigger hover"
+          controlsID="overlay-hover-section-panel"
+          data-testid="hover-panel-section"
+          expanded={false}
+          variant="section"
+        >
+          Section trigger
+        </ExpandablePanelTrigger>
+        <ExpandablePanelTrigger
+          aria-label="Compact panel trigger hover"
+          controlsID="overlay-hover-compact-panel"
+          data-testid="hover-panel-compact"
+          expanded={false}
+          variant="compact"
+        >
+          Compact trigger
+        </ExpandablePanelTrigger>
+      </div>
+    </section>
+  );
+}

--- a/ui/src/components/ui/color-role-overlay-hover-surfaces.tsx
+++ b/ui/src/components/ui/color-role-overlay-hover-surfaces.tsx
@@ -18,9 +18,6 @@ export const OVERLAY_HOVER_VERIFICATION_PALETTES = [
   "factory-light",
 ] as const;
 
-export type OverlayHoverVerificationPalette =
-  (typeof OVERLAY_HOVER_VERIFICATION_PALETTES)[number];
-
 export function ColorRoleOverlayHoverSurfacesShowcase() {
   return (
     <section

--- a/ui/src/components/ui/expandable-panel-trigger.tsx
+++ b/ui/src/components/ui/expandable-panel-trigger.tsx
@@ -18,11 +18,11 @@ const EXPANDABLE_PANEL_TRIGGER_VARIANT_CLASS: Record<
   string
 > = {
   section: cn(
-    "shrink-0 cursor-pointer rounded-lg border border-outline bg-surface-container-high px-2.5 py-2 text-on-surface-variant transition hover:border-outline-variant hover:bg-af-overlay hover:text-on-surface focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-af-accent disabled:cursor-not-allowed disabled:border-outline disabled:bg-surface-container-low disabled:text-on-surface-disabled",
+    "shrink-0 cursor-pointer rounded-lg border border-outline bg-surface-container-high px-2.5 py-2 text-on-surface-variant transition hover:border-outline-variant hover:bg-surface-container-highest hover:text-on-surface focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-af-accent disabled:cursor-not-allowed disabled:border-outline disabled:bg-surface-container-low disabled:text-on-surface-disabled",
     DASHBOARD_SUPPORTING_TEXT_CLASS,
   ),
   compact: cn(
-    "min-h-9 shrink-0 gap-1.5 border-outline bg-surface-container-high px-2.5 py-1.5 text-xs text-on-surface-variant hover:border-outline-variant hover:bg-af-overlay hover:text-on-surface",
+    "min-h-9 shrink-0 gap-1.5 border-outline bg-surface-container-high px-2.5 py-1.5 text-xs text-on-surface-variant hover:border-outline-variant hover:bg-surface-container-highest hover:text-on-surface",
     DASHBOARD_SUPPORTING_TEXT_CLASS,
   ),
   outline: cn("shrink-0 gap-1.5", DASHBOARD_SUPPORTING_LABEL_CLASS),

--- a/ui/src/components/ui/shared-primitive-neutral-surface-roles.test.ts
+++ b/ui/src/components/ui/shared-primitive-neutral-surface-roles.test.ts
@@ -49,5 +49,7 @@ describe("shared primitive neutral surface roles", () => {
       "border-outline bg-surface-container-high text-on-surface",
     );
     expect(source).toContain("text-on-surface-variant");
+    expect(source).toContain("hover:bg-surface-container-low");
+    expect(source).toContain("hover:bg-surface-container-highest");
   });
 });

--- a/ui/src/components/ui/shared-primitive-overlay-hover-color-roles.behavior.test.tsx
+++ b/ui/src/components/ui/shared-primitive-overlay-hover-color-roles.behavior.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment happy-dom
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { compile } from "@tailwindcss/node";
+import { render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { applyDocumentColorPalette } from "../../theme/app-color-palette";
+import { Button } from "./button";
+import { OVERLAY_HOVER_VERIFICATION_PALETTES } from "./color-role-overlay-hover-surfaces";
+import { Table, TableBody, TableCell, TableRow } from "./table";
+
+const stylesDir = path.dirname(fileURLToPath(import.meta.url));
+const uiRoot = path.resolve(stylesDir, "../../..");
+const stylesSourcePath = path.join(uiRoot, "src", "styles.css");
+
+function injectCompiledRootRules(compiledCss: string): void {
+  const rootBlocks = compiledCss.match(/:root[^{]*\{[^}]*\}/g) ?? [];
+  const paletteBlocks =
+    compiledCss.match(/\[data-color-palette="[^"]+"\][^{]*\{[^}]*\}/g) ?? [];
+  const style = document.createElement("style");
+  style.textContent = [...rootBlocks, ...paletteBlocks].join("\n");
+  document.head.appendChild(style);
+}
+
+function readCssVariable(name: string): string {
+  return getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim();
+}
+
+describe("shared primitive overlay hover color roles (behavior)", () => {
+  beforeAll(async () => {
+    const source = readFileSync(stylesSourcePath, "utf8");
+    const compiled = await compile(source, {
+      base: path.dirname(stylesSourcePath),
+      from: stylesSourcePath,
+      onDependency: () => {},
+    });
+    injectCompiledRootRules(compiled.build([]));
+  });
+
+  it.each(OVERLAY_HOVER_VERIFICATION_PALETTES)(
+    "applies palette %s before reading surface-container-low",
+    (paletteId) => {
+      applyDocumentColorPalette(paletteId);
+      expect(document.documentElement.dataset.colorPalette).toBe(paletteId);
+      expect(readCssVariable("--color-surface-container-low")).toBeTruthy();
+    },
+  );
+
+  it("keeps distinct surface-container-low values across factory-dark and factory-light", () => {
+    applyDocumentColorPalette("factory-dark");
+    const darkLow = readCssVariable("--color-surface-container-low");
+
+    applyDocumentColorPalette("factory-light");
+    const lightLow = readCssVariable("--color-surface-container-low");
+
+    expect(darkLow).toBeTruthy();
+    expect(lightLow).toBeTruthy();
+    expect(darkLow).not.toBe(lightLow);
+  });
+
+  it("renders migrated controls with surface-container hover and selected class hooks", () => {
+    applyDocumentColorPalette("factory-dark");
+
+    render(
+      <>
+        <Button data-testid="ghost" tone="ghost">
+          Ghost
+        </Button>
+        <Button data-testid="outline" tone="outline">
+          Outline
+        </Button>
+        <Button data-testid="secondary" tone="secondary">
+          Secondary
+        </Button>
+        <Table>
+          <TableBody>
+            <TableRow data-testid="hover-row">
+              <TableCell>Hover</TableCell>
+            </TableRow>
+            <TableRow data-state="selected" data-testid="selected-row">
+              <TableCell>Selected</TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </>,
+    );
+
+    expect(screen.getByTestId("ghost").className).toContain(
+      "hover:bg-surface-container-low",
+    );
+    expect(screen.getByTestId("outline").className).toContain(
+      "hover:bg-surface-container-highest",
+    );
+    expect(screen.getByTestId("secondary").className).toContain(
+      "hover:bg-surface-container",
+    );
+    expect(screen.getByTestId("hover-row").className).toContain(
+      "hover:bg-surface-container",
+    );
+    expect(screen.getByTestId("selected-row").className).toContain(
+      "data-[state=selected]:bg-surface-container-low",
+    );
+  });
+});

--- a/ui/src/components/ui/shared-primitive-overlay-hover-color-roles.test.ts
+++ b/ui/src/components/ui/shared-primitive-overlay-hover-color-roles.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const UI_COMPONENTS_DIR = join(dirname(fileURLToPath(import.meta.url)));
+
+const IN_SCOPE_FILES = [
+  "button.tsx",
+  "table.tsx",
+  "standard-list-selection.tsx",
+  "expandable-panel-trigger.tsx",
+] as const;
+
+const FORBIDDEN_OVERLAY_HOVER = /\bhover:bg-af-overlay\b/;
+const FORBIDDEN_OVERLAY_SELECTED = /\bdata-\[state=selected\]:bg-af-overlay\b/;
+
+function readComponentSource(fileName: string): string {
+  return readFileSync(join(UI_COMPONENTS_DIR, fileName), "utf8");
+}
+
+function expectNoTransitionalOverlayHover(source: string): void {
+  expect(source).not.toMatch(FORBIDDEN_OVERLAY_HOVER);
+  expect(source).not.toMatch(FORBIDDEN_OVERLAY_SELECTED);
+}
+
+describe("shared primitive overlay hover color roles", () => {
+  it.each(IN_SCOPE_FILES)(
+    "does not use transitional overlay hover or selected tokens in %s",
+    (fileName) => {
+      expectNoTransitionalOverlayHover(readComponentSource(fileName));
+    },
+  );
+
+  it("maps button ghost, outline, and secondary hover to surface-container role utilities", () => {
+    const source = readComponentSource("button.tsx");
+
+    expect(source).toContain("hover:bg-surface-container-low");
+    expect(source).toContain("hover:bg-surface-container-highest");
+    expect(source).toContain("hover:bg-surface-container");
+    expectNoTransitionalOverlayHover(source);
+  });
+
+  it("maps table row hover and selected state to surface-container role utilities", () => {
+    const source = readComponentSource("table.tsx");
+
+    expect(source).toContain("hover:bg-surface-container");
+    expect(source).toContain("data-[state=selected]:bg-surface-container-low");
+    expectNoTransitionalOverlayHover(source);
+  });
+
+  it("maps standard list neutral row hover to surface-container", () => {
+    const source = readComponentSource("standard-list-selection.tsx");
+
+    expect(source).toContain("hover:bg-surface-container");
+    expectNoTransitionalOverlayHover(source);
+  });
+
+  it("maps expandable panel section and compact trigger hover to surface-container-highest", () => {
+    const source = readComponentSource("expandable-panel-trigger.tsx");
+
+    const highestHoverCount = (source.match(/\bhover:bg-surface-container-highest\b/g) ?? [])
+      .length;
+    expect(highestHoverCount).toBeGreaterThanOrEqual(2);
+    expectNoTransitionalOverlayHover(source);
+  });
+});

--- a/ui/src/components/ui/standard-list-selection.tsx
+++ b/ui/src/components/ui/standard-list-selection.tsx
@@ -26,7 +26,7 @@ const STANDARD_LIST_SELECTION_ROW_BASE_CLASS =
   "h-auto min-h-0 w-full justify-start gap-1 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-af-focus-ring";
 
 export const STANDARD_LIST_SELECTION_ROW_NEUTRAL_CLASS =
-  "border-outline bg-surface-container-high text-on-surface hover:border-outline-variant hover:bg-af-overlay";
+  "border-outline bg-surface-container-high text-on-surface hover:border-outline-variant hover:bg-surface-container";
 
 export const STANDARD_LIST_SELECTION_ROW_ACCENT_CLASS =
   "border-primary bg-primary-container text-on-primary";

--- a/ui/src/components/ui/table.tsx
+++ b/ui/src/components/ui/table.tsx
@@ -70,7 +70,7 @@ export const TableRow = forwardRef<
   return (
     <tr
       className={cn(
-        "transition-colors hover:bg-af-overlay data-[state=selected]:bg-af-overlay",
+        "transition-colors hover:bg-surface-container data-[state=selected]:bg-surface-container-low",
         className,
       )}
       ref={ref}


### PR DESCRIPTION
{
  "project": "Migrate Shared-Primitive Interactive Hover from Overlay to Surface-Container Role Utilities",
  "branchName": "migrate-shared-primitive-overlay-hover-color-roles",
  "description": "Replace transitional hover:bg-af-overlay and data-[state=selected]:bg-af-overlay class tokens with existing surface-container Material role utilities in four shared UI primitives under ui/src/components/ui/ (button, table, standard-list-selection, expandable-panel-trigger), add a focused vitest contract on those source files, align consumer tests only when they pin old tokens, and preserve visual parity for interactive hover and row selection with no API or routing changes.",
  "context": {
    "customerAsk": "Migrate shared-primitive interactive hover from af-overlay to surface role utilities: replace hover:bg-af-overlay and data-[state=selected]:bg-af-overlay in button.tsx, table.tsx, standard-list-selection.tsx, and expandable-panel-trigger.tsx with existing surface-container elevation steps so shared primitives no longer depend on overlay tokens for hover emphasis.",
    "problem": "Four shared primitives still use transitional hover:bg-af-overlay (and data-[state=selected]:bg-af-overlay on TableRow) for interactive hover and selection chrome while US-005 migrated neutral resting surfaces to Material role utilities, keeping shared primitives tied to --color-af-overlay in styles.css and split across two styling eras.",
    "solution": "Update the four in-scope files using documented surface-container hover/selected mappings while preserving border hover, text hover, focus rings, and disabled classes; add shared-primitive-overlay-hover-color-roles.test.ts reading only those four files to assert surface-container mappings and forbid overlay hover tokens; update button.test.tsx and theme-role-regression index only when needed; pass cd ui && bun run tsc and targeted vitest with browser verification for hover and selection parity."
  },
  "acceptanceCriteria": [
    "button.tsx ghost, outline, and secondary variants use surface-container hover utilities per mapping table with no hover:bg-af-overlay",
    "table.tsx TableRow uses hover:bg-surface-container and data-[state=selected]:bg-surface-container-low with no overlay hover or selected tokens",
    "standard-list-selection.tsx uses hover:bg-surface-container with no hover:bg-af-overlay",
    "expandable-panel-trigger.tsx default and compact variants use hover:bg-surface-container-highest with no hover:bg-af-overlay",
    "Border hover, text hover, focus rings, and disabled classes are preserved in all four in-scope files",
    "shared-primitive-overlay-hover-color-roles.test.ts reads only the four in-scope files, spot-checks expected hover:bg-surface-container* mappings, and forbids hover:bg-af-overlay and data-[state=selected]:bg-af-overlay",
    "Buttons, tables, list selection rows, and panel triggers retain visual parity on at least two theme palettes",
    "cd ui && bun run tsc and targeted vitest for the overlay-hover contract and touched consumer tests pass",
    "Typecheck, lint, and tests pass"
  ],
  "userStories": [
    {
      "id": "migrate-shared-primitive-overlay-hover-color-roles-001",
      "title": "Replace overlay hover and selected-row tokens in four shared primitives",
      "description": "As a dashboard user, I want buttons, table rows, list selection rows, and expandable panel triggers to use surface-container role utilities for hover and selection emphasis so shared primitives match migrated resting surfaces without changing interaction, layout, or focus behavior.",
      "acceptanceCriteria": [
        "button.tsx ghost: hover:bg-af-overlay becomes hover:bg-surface-container-low",
        "button.tsx outline: hover:bg-af-overlay becomes hover:bg-surface-container-highest",
        "button.tsx secondary: hover:bg-af-overlay becomes hover:bg-surface-container",
        "table.tsx TableRow: hover:bg-af-overlay becomes hover:bg-surface-container and data-[state=selected]:bg-af-overlay becomes data-[state=selected]:bg-surface-container-low",
        "standard-list-selection.tsx: hover:bg-af-overlay becomes hover:bg-surface-container",
        "expandable-panel-trigger.tsx default and compact variants: hover:bg-af-overlay becomes hover:bg-surface-container-highest",
        "No hover:bg-af-overlay or data-[state=selected]:bg-af-overlay remains in any of the four files",
        "hover:border-outline-variant, hover:text-on-surface, focus rings, and disabled classes are unchanged",
        "Only the four listed files under ui/src/components/ui/ are edited; calendar.tsx, dialog.tsx scrims, skeleton.tsx, ui/src/features/**, and styles.css overlay key removal are untouched",
        "Typecheck passes",
        "Verify in browser: ghost/outline/secondary button hover, table row hover and selected state, standard list row hover, and expandable panel trigger hover match pre-change emphasis on at least two theme palettes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "migrate-shared-primitive-overlay-hover-color-roles-002",
      "title": "Add focused vitest contract for shared-primitive overlay hover roles",
      "description": "As a maintainer, I want a behavioral contract test on the four in-scope shared primitive source files so transitional overlay hover class tokens cannot reappear without a failing test.",
      "acceptanceCriteria": [
        "ui/src/components/ui/shared-primitive-overlay-hover-color-roles.test.ts reads source content from button.tsx, table.tsx, standard-list-selection.tsx, and expandable-panel-trigger.tsx only",
        "The test asserts hover:bg-af-overlay and data-[state=selected]:bg-af-overlay are absent from all four in-scope files",
        "The test spot-checks expected hover:bg-surface-container* mappings per file aligned with the mapping table (ghost to surface-container-low, outline and panel trigger to surface-container-highest, secondary table and list to surface-container, table selected to surface-container-low)",
        "The test does not scan ui/src/features/**, unrelated components paths, file inventories, import graphs, route registrations, doc link topology, or asset-bundle internals",
        "shared-primitive-neutral-surface-roles.test.ts is extended only for a small optional hover spot-check and is not expanded to every file under components/ui/",
        "ui/src/styles/theme-role-regression.test.ts imports or references the new contract test when that index lists sibling contract files",
        "Typecheck passes",
        "Tests pass for the new shared-primitive overlay-hover contract vitest"
      ],
      "priority": 2,
      "passes": false,
      "notes": ""
    },
    {
      "id": "migrate-shared-primitive-overlay-hover-color-roles-003",
      "title": "Align consumer tests and pass verification",
      "description": "As a reviewer, I want consumer tests and customer verification commands green so the overlay-hover role migration ships with no regressions in shared-primitive dependent coverage.",
      "acceptanceCriteria": [
        "button.test.tsx updated only when tone class assertions pin hover:bg-af-overlay and fail due to the migration",
        "Consumer test updates preserve behavioral intent and prefer interaction or rendered structure over transitional class substring pins where updates are required",
        "cd ui && bun run tsc exits 0",
        "Targeted vitest passes for shared-primitive-overlay-hover-color-roles.test.ts, button.test.tsx when touched, and theme-role-regression.test.ts when wired",
        "No API, routing, or public component prop surface changes",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": false,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)