### PR TITLE
Fix replay integration workstation click

### DIFF
--- a/ui/integration/event-stream-replay.integration.test.mjs
+++ b/ui/integration/event-stream-replay.integration.test.mjs
@@ -155,7 +155,17 @@ async function exerciseSelectedWorkTrace(page, workstationName, options = {}) {
     state: "visible",
     timeout: uiInteractionTimeoutMs,
   });
-  await workstationButton.click({ force: true });
+  await workstationButton.scrollIntoViewIfNeeded();
+  try {
+    await workstationButton.click({ force: true });
+  } catch (error) {
+    // React Flow workstation buttons can remain visible while clipping leaves the
+    // actionable box outside the viewport in CI. Fall back to the DOM click so
+    // the test still verifies replay behavior after the button renders.
+    await workstationButton.evaluate((button) => {
+      button.click();
+    });
+  }
 
   await page.getByRole("article", { name: "Current selection" }).waitFor({
     state: "visible",


### PR DESCRIPTION
## Summary
- harden the event stream replay workstation selection click in browser integration tests
- scroll the button into view before clicking
- fall back to a DOM click when React Flow clipping leaves the visible button hitbox outside the viewport in CI

## Testing
- cd ui && bun x vitest run integration/event-stream-replay.integration.test.mjs --no-file-parallelism --maxWorkers 1 --reporter=verbose
- cd ui && bun run test:integration