### PR TITLE
prompt-editor-diagnostics

### DIFF
--- a/ui/src/features/current-selection/workstation-selection/components/workstation-detail-card.editable-configuration.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/workstation-detail-card.editable-configuration.test.tsx
@@ -1921,6 +1921,64 @@ describe("WorkstationDetailCard editable configuration", () => {
     expect(screen.queryByText("Available variables")).toBeNull();
   });
 
+  it("keeps prompt variable help collapsed when diagnostics appear after the initial render", () => {
+    const snapshot = semanticWorkflowDashboardSnapshot;
+    const selectedNode = snapshot.topology.workstation_nodes_by_id.review;
+    const { rerender } = render(
+      <WorkstationDetailCard
+        activeExecutions={[]}
+        editableConfigurationState={buildReadyEditableConfigurationState()}
+        now={DETAIL_CARD_NOW}
+        providerSessions={[]}
+        selectedNode={selectedNode}
+      />,
+    );
+
+    expandEditableConfiguration();
+    expect(promptVariableHelpToggle().getAttribute("aria-expanded")).toBe(
+      "false",
+    );
+    expect(screen.queryByText("Available variables")).toBeNull();
+
+    rerender(
+      <WorkstationDetailCard
+        activeExecutions={[]}
+        editableConfigurationState={buildReadyEditableConfigurationState({
+          prompt: "Use {{ (index .Inputs 1).Payload }} now.",
+          promptDiagnostics: [
+            {
+              endOffset: 33,
+              kind: "UNAVAILABLE_VARIABLE",
+              message: "Only input 0 is available.",
+              path: ".Inputs[1]",
+              sourceText: "(index .Inputs 1)",
+              startOffset: 7,
+            },
+          ],
+          validationErrors: {
+            prompt: "See prompt diagnostics below.",
+          },
+        })}
+        now={DETAIL_CARD_NOW}
+        providerSessions={[]}
+        selectedNode={selectedNode}
+      />,
+    );
+
+    const toggle = promptVariableHelpToggle();
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByText("Available variables")).toBeNull();
+    expect(screen.queryByText("Unavailable access")).toBeNull();
+
+    const editor = editableConfigurationSection().querySelector(
+      "[data-monaco-editor='workstation-prompt']",
+    );
+    expect(editor?.getAttribute("data-monaco-marker-count")).toBe("1");
+    expect(editor?.closest(".border-af-danger-border")?.className).toContain(
+      "border-af-danger-border",
+    );
+  });
+
   it("resets prompt variable help disclosure when the selected workstation changes", () => {
     const snapshot = semanticWorkflowDashboardSnapshot;
     const reviewNode = snapshot.topology.workstation_nodes_by_id.review;

--- a/ui/src/features/current-selection/workstation-selection/components/workstation-prompt-field.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/workstation-prompt-field.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef, useState } from "react";
+import { useId, useState } from "react";
 import {
   CURRENT_SELECTION_WORKSTATION_PROMPT_MODEL_PATH,
   MonacoPromptEditor,
@@ -232,21 +232,9 @@ function EditableConfigurationReadyPromptFeedback({
   };
 }) {
   const [expanded, setExpanded] = useState(false);
-  const previousDiagnosticsCountRef = useRef(state.promptDiagnostics.length);
   const sectionId = useId();
   const contentId = `${sectionId}-prompt-feedback-content`;
   const promptHelpState = state.promptHelpState;
-
-  useEffect(() => {
-    if (
-      previousDiagnosticsCountRef.current === 0 &&
-      state.promptDiagnostics.length > 0
-    ) {
-      setExpanded(true);
-    }
-
-    previousDiagnosticsCountRef.current = state.promptDiagnostics.length;
-  }, [state.promptDiagnostics.length]);
 
   return (
     <CurrentSelectionFormField>


### PR DESCRIPTION
{
  "project": "Prompt Editor Diagnostics — No Auto-Expand on Error",
  "branchName": "ralph/prompt-editor-diagnostics",
  "description": "Stop the workstation prompt variable help collapsible section from auto-expanding when prompt validation diagnostics first appear, while preserving inline Monaco error feedback and manual disclosure control.",
  "context": {
    "customerAsk": "The prompt diagnostics expand the collapsible section they are in when an error appears. That is annoying. It should not make it expand at all.",
    "problem": "EditableConfigurationReadyPromptFeedback auto-expands the prompt variable help disclosure when promptDiagnostics transitions from zero to a positive count, causing unwanted layout shifts and revealing help content the user did not request.",
    "solution": "Remove the diagnostics-driven auto-expand effect, keep the disclosure user-controlled and collapsed by default, and preserve existing inline diagnostic signaling through Monaco markers, editor styling, and accessibility metadata."
  },
  "acceptanceCriteria": [
    "When prompt diagnostics transition from none to one or more while prompt variable help is collapsed, the disclosure trigger stays at aria-expanded=false and autocomplete list content remains hidden.",
    "Users can still manually expand the section to view the diagnostics panel and variable help lists.",
    "Monaco squiggle markers, editor danger styling, and aria-describedby links to the diagnostics region continue to work when the section is collapsed.",
    "Workstation selection changes still reset the disclosure to collapsed without regression.",
    "A focused unit test proves diagnostics no longer force expansion of the prompt variable help section.",
    "Quality gate: UI typecheck, lint, and tests pass for touched packages."
  ],
  "userStories": [
    {
      "id": "prompt-editor-diagnostics-001",
      "title": "Stop auto-expanding prompt variable help when diagnostics appear",
      "description": "As a factory operator editing a workstation prompt, I want the prompt variable help section to stay collapsed when validation errors appear so my layout does not jump and I can expand help only when I choose.",
      "acceptanceCriteria": [
        "Remove the useEffect and related ref in EditableConfigurationReadyPromptFeedback that sets expanded to true when promptDiagnostics.length goes from 0 to greater than 0.",
        "With the section collapsed, rendering or rerendering with new prompt diagnostics leaves the disclosure trigger at aria-expanded=false and keeps Available variables and Unavailable access content out of the visible document.",
        "Clicking the disclosure trigger still expands the section and shows diagnostics panel content plus autocomplete lists.",
        "Monaco squiggle markers and danger border styling still appear when diagnostics exist, independent of disclosure state.",
        "Add or update a unit test in workstation-detail-card.editable-configuration.test.tsx that proves diagnostics do not auto-expand the section.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser: expand editable configuration, leave prompt variable help collapsed, type an invalid prompt fragment, and confirm the help section does not open while squiggles and save blocking still appear."
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    }
  ]
}
