### PR TITLE
factory-graph-validate-wrapper-deadcode-cleanup

### DIFF
--- a/docs/internal/development/frontend-deadcode-baseline.json
+++ b/docs/internal/development/frontend-deadcode-baseline.json
@@ -5,11 +5,6 @@
     "name": "scripts/summarize-warning-inventory.mjs"
   },
   {
-    "file": "src/features/factory-graph-editor/lib/factory-graph-operations.ts",
-    "kind": "export",
-    "name": "validateFactoryGraphState"
-  },
-  {
     "file": "src/features/factory-graph-editor/lib/factory-graph-react-flow-projection.ts",
     "kind": "export",
     "name": "emptyFactoryGraphReactFlowEditorOverlay"

--- a/ui/src/features/factory-graph-editor/lib/factory-graph-operations.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-operations.ts
@@ -311,18 +311,6 @@ export function disconnectFactoryGraphEdge(options: {
   };
 }
 
-export function validateFactoryGraphState(options: {
-  baseFactoryDefinition: CanonicalFactoryDefinition;
-  draft: FactoryGraphDraft;
-  locale?: string | null;
-}): FactoryGraphDraftValidationError[] {
-  return validateFactoryGraphDraft(
-    options.baseFactoryDefinition,
-    options.draft,
-    options.locale,
-  );
-}
-
 export function applyFactoryGraphPendingEdits(options: {
   baseFactoryDefinition: CanonicalFactoryDefinition;
   draft: FactoryGraphDraft;


### PR DESCRIPTION
{
  "project": "Remove Dead Factory-Graph Validation Wrapper",
  "branchName": "ralph/factory-graph-validate-wrapper-deadcode-cleanup",
  "description": "Remove the unused validateFactoryGraphState export from the factory graph editor and clear its frontend deadcode baseline entry, without changing canonical draft validation, pending projection, or save-input behavior.",
  "context": {
    "customerAsk": "Remove the dead factory-graph validation wrapper: delete the unused validateFactoryGraphState export from factory-graph-operations.ts, remove its entry from frontend-deadcode-baseline.json, and keep existing validator-backed behavior in pending-projection and save paths unchanged.",
    "problem": "validateFactoryGraphState is still exported from factory-graph-operations.ts but has no callers anywhere in the repo. It duplicates validateFactoryGraphDraft, which buildFactoryGraphState and save paths already use, and remains listed as accepted frontend deadcode debt.",
    "solution": "Delete the unused wrapper export and its deadcode baseline record. Leave buildFactoryGraphState, applyFactoryGraphPendingEdits, and validateFactoryGraphDraft unchanged so draft validation, invalid-draft projection, and save blocking behave exactly as before."
  },
  "acceptanceCriteria": [
    "validateFactoryGraphState is not exported from ui/src/features/factory-graph-editor/lib/factory-graph-operations.ts",
    "Repo-wide search finds no production callers of validateFactoryGraphState after cleanup",
    "docs/internal/development/frontend-deadcode-baseline.json no longer lists validateFactoryGraphState",
    "buildFactoryGraphState still derives validationErrors, pendingFactoryDefinition, and saveInput from the canonical draft validator without behavior change",
    "applyFactoryGraphPendingEdits and the editable-graph save path still block invalid drafts through the same underlying validation surface",
    "Existing behavioral tests for invalid draft projection and save-input generation pass without adding replacement meta tests",
    "Frontend typecheck, lint, and relevant test suites pass (quality gate)"
  ],
  "userStories": [
    {
      "id": "factory-graph-validate-wrapper-deadcode-cleanup-001",
      "title": "Remove unused validation wrapper export",
      "description": "As a maintainer, I want the unused validateFactoryGraphState export removed so the factory-graph operations module exposes only behavior that is actually consumed.",
      "acceptanceCriteria": [
        "validateFactoryGraphState is deleted from ui/src/features/factory-graph-editor/lib/factory-graph-operations.ts and is no longer re-exported from that module",
        "buildFactoryGraphState, applyFactoryGraphPendingEdits, and other draft-validation call sites remain unchanged and still use validateFactoryGraphDraft directly",
        "Existing factory-graph behavioral tests for state building, pending projection, and save-input generation pass without modification to their assertions",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "factory-graph-validate-wrapper-deadcode-cleanup-002",
      "title": "Clear deadcode baseline entry",
      "description": "As a maintainer, I want the frontend deadcode baseline updated so it no longer tracks an export that no longer exists.",
      "acceptanceCriteria": [
        "The validateFactoryGraphState export entry is removed from docs/internal/development/frontend-deadcode-baseline.json",
        "Remaining baseline entries are unchanged",
        "Repo-wide search confirms validateFactoryGraphState has no production references after cleanup",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
