### PR TITLE
prd-factory-service-core-coordinator-wire

### DIFF
--- a/cmd/factory/compose/providers.go
+++ b/cmd/factory/compose/providers.go
@@ -68,6 +68,14 @@ func provideHostedWorkersConfig(
 }
 
 func provideFactoryService(
+	core *service.FactoryCore,
+	cfg *service.FactoryServiceConfig,
+) *service.FactoryService {
+	serviceShell := service.FactoryServiceShell{Service: service.NewFactoryServiceFromCore(core)}
+	return service.AttachFactorySaveCollaborator(serviceShell, service.ProvideFactorySaveCollaborator(serviceShell, cfg))
+}
+
+func provideFactoryCore(
 	ctx context.Context,
 	cfg *service.FactoryServiceConfig,
 	root service.FactoryServiceRoot,
@@ -75,6 +83,6 @@ func provideFactoryService(
 	load service.FactoryConfigLoadResult,
 	clock factory.Clock,
 	hostedWorkers hostedworkers.Config,
-) (*service.FactoryService, error) {
-	return service.AssembleFactoryService(ctx, cfg, root, collaborators, load, clock, hostedWorkers)
+) (*service.FactoryCore, error) {
+	return service.ComposeFactoryCore(ctx, cfg, root, collaborators, load, clock, hostedWorkers)
 }

--- a/cmd/factory/compose/providers.go
+++ b/cmd/factory/compose/providers.go
@@ -67,7 +67,7 @@ func provideHostedWorkersConfig(
 	return service.NewHostedWorkersConfig(cfg, logger, clock)
 }
 
-func provideFactoryServiceShell(
+func provideFactoryService(
 	ctx context.Context,
 	cfg *service.FactoryServiceConfig,
 	root service.FactoryServiceRoot,
@@ -75,13 +75,6 @@ func provideFactoryServiceShell(
 	load service.FactoryConfigLoadResult,
 	clock factory.Clock,
 	hostedWorkers hostedworkers.Config,
-) (service.FactoryServiceShell, error) {
-	return service.ComposeFactoryService(ctx, cfg, root, collaborators, load, clock, hostedWorkers)
-}
-
-func provideFactoryService(
-	shell service.FactoryServiceShell,
-	cfg *service.FactoryServiceConfig,
-) *service.FactoryService {
-	return service.AttachFactorySaveCollaborator(shell, service.ProvideFactorySaveCollaborator(shell, cfg))
+) (*service.FactoryService, error) {
+	return service.AssembleFactoryService(ctx, cfg, root, collaborators, load, clock, hostedWorkers)
 }

--- a/cmd/factory/compose/wire.go
+++ b/cmd/factory/compose/wire.go
@@ -24,6 +24,7 @@ func InjectFactoryService(
 		provideRuntimeBuildService,
 		provideFactoryServiceCollaborators,
 		provideHostedWorkersConfig,
+		provideFactoryCore,
 		provideFactoryService,
 	)
 	return nil, nil

--- a/cmd/factory/compose/wire.go
+++ b/cmd/factory/compose/wire.go
@@ -24,7 +24,6 @@ func InjectFactoryService(
 		provideRuntimeBuildService,
 		provideFactoryServiceCollaborators,
 		provideHostedWorkersConfig,
-		provideFactoryServiceShell,
 		provideFactoryService,
 	)
 	return nil, nil

--- a/cmd/factory/compose/wire_gen.go
+++ b/cmd/factory/compose/wire_gen.go
@@ -30,9 +30,10 @@ func InjectFactoryService(ctx context.Context, cfg *service.FactoryServiceConfig
 	runtimebuildService := provideRuntimeBuildService(cfg, clock, logger, v)
 	factoryServiceCollaborators := provideFactoryServiceCollaborators(registry, v, runtimebuildService)
 	config := provideHostedWorkersConfig(cfg, logger, clock)
-	factoryService, err := provideFactoryService(ctx, cfg, factoryServiceRoot, factoryServiceCollaborators, factoryConfigLoadResult, clock, config)
+	factoryCore, err := provideFactoryCore(ctx, cfg, factoryServiceRoot, factoryServiceCollaborators, factoryConfigLoadResult, clock, config)
 	if err != nil {
 		return nil, err
 	}
+	factoryService := provideFactoryService(factoryCore, cfg)
 	return factoryService, nil
 }

--- a/cmd/factory/compose/wire_gen.go
+++ b/cmd/factory/compose/wire_gen.go
@@ -30,10 +30,9 @@ func InjectFactoryService(ctx context.Context, cfg *service.FactoryServiceConfig
 	runtimebuildService := provideRuntimeBuildService(cfg, clock, logger, v)
 	factoryServiceCollaborators := provideFactoryServiceCollaborators(registry, v, runtimebuildService)
 	config := provideHostedWorkersConfig(cfg, logger, clock)
-	factoryServiceShell, err := provideFactoryServiceShell(ctx, cfg, factoryServiceRoot, factoryServiceCollaborators, factoryConfigLoadResult, clock, config)
+	factoryService, err := provideFactoryService(ctx, cfg, factoryServiceRoot, factoryServiceCollaborators, factoryConfigLoadResult, clock, config)
 	if err != nil {
 		return nil, err
 	}
-	factoryService := provideFactoryService(factoryServiceShell, cfg)
 	return factoryService, nil
 }

--- a/pkg/service/factory.go
+++ b/pkg/service/factory.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
 	"github.com/portpowered/infinite-you/pkg/apisurface"
 	"github.com/portpowered/infinite-you/pkg/cli/dashboardrender"
 	factoryconfig "github.com/portpowered/infinite-you/pkg/config"
@@ -130,6 +129,12 @@ type runtimeBundleBuildInput struct {
 	prefetchedLocalModels localModelDomain
 }
 
+type liveSessionState struct {
+	bundle *factoryRuntimeBundle
+	handle *liveRuntimeHandle
+	spec   *runtimebuild.SessionBuildSpec
+}
+
 // FactoryService is an instantiation of a factory along with its runtime
 // concerns: file watcher, dashboard, API server. It owns the full lifecycle
 // so that CLI and other entry points remain thin wrappers.
@@ -149,6 +154,7 @@ type FactoryService struct {
 	runtimeBuild   *runtimebuild.Service
 	hostedWorkers  hostedworkers.Config
 	factoryRootDir string
+	policy         serviceCoordinatorPolicy
 	// startupBundle holds the built default runtime before Run registers ~default.
 	startupBundle *factoryRuntimeBundle
 	cfg           *FactoryServiceConfig
@@ -396,11 +402,35 @@ func (fs *FactoryService) buildReplacementFactoryRuntime(
 	if fs == nil || fs.runtimeBuild == nil {
 		return nil, fmt.Errorf("factory service is required")
 	}
-	bundle, err := fs.runtimeBuild.BuildReplacement(ctx, folderPath, factoryDir, sessionID)
+	bundle, err := fs.runtimeBuild.BuildReplacement(
+		ctx,
+		folderPath,
+		factoryDir,
+		sessionID,
+		fs.replacementExecutionBaseDir(folderPath, factoryDir, sessionID),
+	)
 	if err != nil {
 		return nil, err
 	}
 	return asRuntimeBundle(bundle), nil
+}
+
+func (fs *FactoryService) replacementExecutionBaseDir(folderPath string, factoryDir string, sessionID string) string {
+	if session := fs.sessionByID(sessionID); session != nil {
+		if executionBaseDir := strings.TrimSpace(session.ExecutionBaseDir); executionBaseDir != "" {
+			return executionBaseDir
+		}
+	}
+	if folderPath = strings.TrimSpace(folderPath); folderPath != "" {
+		return folderPath
+	}
+	if factoryDir = strings.TrimSpace(factoryDir); factoryDir != "" {
+		return factoryDir
+	}
+	if fs != nil {
+		return strings.TrimSpace(fs.coordinatorPolicy().executionBaseDir)
+	}
+	return ""
 }
 
 // Run starts the file watcher, dashboard, API server, and factory engine.
@@ -570,6 +600,7 @@ func (c *runtimeFactoryCoordinator) startDefaultRuntime(
 		defaultSessionTargetFromRuntimeBundle(runtimeBundle, fs.factoryRootDir),
 		true,
 	)
+	fs.clearStartupBundle()
 	fs.setRunState(runCtx, defaultFactorySessionID, currentRuntime)
 	if err := fs.waitForLiveRuntimeStart(ctx, currentRuntime); err != nil {
 		return nil, fs.handleDefaultRuntimeStartFailure(ctx, currentRuntime, err)
@@ -683,28 +714,6 @@ func (fs *FactoryService) requireIdleRuntime(ctx context.Context) error {
 	return nil
 }
 
-func snapshotHasActiveWork(snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) bool {
-	if snapshot == nil {
-		return false
-	}
-	if snapshot.InFlightCount > 0 || len(snapshot.Dispatches) > 0 {
-		return true
-	}
-	for _, token := range snapshot.Marking.Tokens {
-		if token == nil || token.Color.DataType == interfaces.DataTypeResource {
-			continue
-		}
-		if snapshot.Topology == nil {
-			return true
-		}
-		category := snapshot.Topology.StateCategoryForPlace(token.PlaceID)
-		if category != state.StateCategoryTerminal && category != state.StateCategoryFailed {
-			return true
-		}
-	}
-	return false
-}
-
 func (fs *FactoryService) currentRuntimeBundle() *factoryRuntimeBundle {
 	if fs == nil {
 		return nil
@@ -747,24 +756,6 @@ func (fs *FactoryService) publishFactoryChangeEvent(
 		return
 	}
 	currentRuntime.runtime.eventHistory.RecordFactoryChange(snapshot.TickCount+1, payload, eventTime)
-}
-
-func replacementFactoryChangePayload(events []factoryapi.FactoryEvent) (factoryapi.FactoryChangeEventPayload, bool) {
-	for _, event := range events {
-		if event.Type != factoryapi.FactoryEventTypeInitialStructureRequest {
-			continue
-		}
-		payload, err := event.Payload.AsInitialStructureRequestEventPayload()
-		if err != nil {
-			return factoryapi.FactoryChangeEventPayload{}, false
-		}
-		return factoryapi.FactoryChangeEventPayload{
-			Factory:         payload.Factory,
-			Metadata:        payload.Metadata,
-			SourceDirectory: payload.SourceDirectory,
-		}, true
-	}
-	return factoryapi.FactoryChangeEventPayload{}, false
 }
 
 func (fs *FactoryService) startLiveRuntime(ctx context.Context, runtimeBundle *factoryRuntimeBundle) *liveRuntimeHandle {

--- a/pkg/service/factory.go
+++ b/pkg/service/factory.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
+	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
 	"github.com/portpowered/infinite-you/pkg/apisurface"
 	"github.com/portpowered/infinite-you/pkg/cli/dashboardrender"
 	factoryconfig "github.com/portpowered/infinite-you/pkg/config"
@@ -106,22 +106,17 @@ type liveRuntimeHandle struct {
 	sidecarMu     sync.Mutex
 }
 
-type liveSessionState struct {
-	bundle *factoryRuntimeBundle
-	handle *liveRuntimeHandle
-	spec   *runtimebuild.SessionBuildSpec
-}
-
 type serviceRunState struct {
 	ctx       context.Context
 	sessionID string
+	runtime   *liveRuntimeHandle
 }
 
 type runtimeBundleBuildInput struct {
 	dir                   string
 	folderPath            string
 	sessionID             string
-	buildConfig           runtimebuild.Config
+	cfg                   *FactoryServiceConfig
 	loadedFactoryCfg      *factoryconfig.LoadedFactoryConfig
 	baseLogger            *zap.Logger
 	runtimeInstanceID     string
@@ -133,27 +128,6 @@ type runtimeBundleBuildInput struct {
 	commandRunnerOverride workers.CommandRunner
 	additionalFactoryOpts []factory.FactoryOption
 	prefetchedLocalModels localModelDomain
-}
-
-type serviceCoordinatorPolicy struct {
-	dir                           string
-	executionBaseDir              string
-	runtimeMode                   interfaces.RuntimeMode
-	port                          int
-	verbose                       bool
-	runtimeInstanceID             string
-	workFile                      string
-	workflowID                    string
-	mockWorkersConfig             *factoryconfig.MockWorkersConfig
-	simpleDashboardRenderer       SimpleDashboardRenderer
-	apiServerStarter              APIServerStarter
-	apiServerReady                <-chan struct{}
-	workstationLoader             factoryconfig.WorkstationLoader
-	modelCacheDir                 string
-	runnerID                      string
-	providerOverride              workers.Provider
-	providerCommandRunnerOverride workers.CommandRunner
-	commandRunnerOverride         workers.CommandRunner
 }
 
 // FactoryService is an instantiation of a factory along with its runtime
@@ -169,24 +143,24 @@ type FactoryService struct {
 	runMu          sync.RWMutex
 	runState       *serviceRunState
 	apiServerExit  <-chan error
+	core           *FactoryCore
 	sessions       *factorysessions.Registry
 	factorySave    factorySaveSaver
 	runtimeBuild   *runtimebuild.Service
 	hostedWorkers  hostedworkers.Config
 	factoryRootDir string
-	policy         serviceCoordinatorPolicy
-	baseLogger     *zap.Logger
-	logger         *zap.Logger
-	startTime      time.Time
-	clock          factory.Clock
-	modelAssets    modelAssetPuller
-}
-
-func (fs *FactoryService) coordinatorPolicy() serviceCoordinatorPolicy {
-	if fs == nil {
-		return serviceCoordinatorPolicy{}
-	}
-	return fs.policy
+	// startupBundle holds the built default runtime before Run registers ~default.
+	startupBundle *factoryRuntimeBundle
+	cfg           *FactoryServiceConfig
+	baseLogger    *zap.Logger
+	logger        *zap.Logger
+	startTime     time.Time
+	clock         factory.Clock
+	modelAssets   modelAssetPuller
+	modelService  ModelService
+	coordinator   FactoryCoordinator
+	definitions   FactoryDefinitionService
+	modelInitOnce sync.Once
 }
 
 var _ factory.APIFactory = (*FactoryService)(nil)
@@ -329,6 +303,14 @@ func (fs *FactoryService) ActivateNamedFactory(ctx context.Context, name string)
 	if fs == nil {
 		return fmt.Errorf("factory service is required")
 	}
+	return fs.requireCoordinator().ActivateNamedFactory(ctx, name)
+}
+
+func (c *runtimeFactoryCoordinator) ActivateNamedFactory(ctx context.Context, name string) error {
+	fs := c.service
+	if fs == nil {
+		return fmt.Errorf("factory service is required")
+	}
 	fs.activationMu.Lock()
 	defer fs.activationMu.Unlock()
 
@@ -355,8 +337,8 @@ func (fs *FactoryService) ActivateNamedFactory(ctx context.Context, name string)
 
 func (fs *FactoryService) namedFactoryActivationPaths(session *factorysessions.LiveSession) (persistRoot, folderPath string) {
 	persistRoot = fs.factoryRootDir
-	if persistRoot == "" {
-		persistRoot = fs.coordinatorPolicy().dir
+	if persistRoot == "" && fs.cfg != nil {
+		persistRoot = fs.cfg.Dir
 	}
 	folderPath = persistRoot
 	if session == nil {
@@ -414,35 +396,11 @@ func (fs *FactoryService) buildReplacementFactoryRuntime(
 	if fs == nil || fs.runtimeBuild == nil {
 		return nil, fmt.Errorf("factory service is required")
 	}
-	bundle, err := fs.runtimeBuild.BuildReplacement(
-		ctx,
-		folderPath,
-		factoryDir,
-		sessionID,
-		fs.replacementExecutionBaseDir(folderPath, factoryDir, sessionID),
-	)
+	bundle, err := fs.runtimeBuild.BuildReplacement(ctx, folderPath, factoryDir, sessionID)
 	if err != nil {
 		return nil, err
 	}
 	return asRuntimeBundle(bundle), nil
-}
-
-func (fs *FactoryService) replacementExecutionBaseDir(folderPath string, factoryDir string, sessionID string) string {
-	if session := fs.sessionByID(sessionID); session != nil {
-		if executionBaseDir := strings.TrimSpace(session.ExecutionBaseDir); executionBaseDir != "" {
-			return executionBaseDir
-		}
-	}
-	if folderPath = strings.TrimSpace(folderPath); folderPath != "" {
-		return folderPath
-	}
-	if factoryDir = strings.TrimSpace(factoryDir); factoryDir != "" {
-		return factoryDir
-	}
-	if fs != nil {
-		return strings.TrimSpace(fs.coordinatorPolicy().executionBaseDir)
-	}
-	return ""
 }
 
 // Run starts the file watcher, dashboard, API server, and factory engine.
@@ -452,11 +410,16 @@ func (fs *FactoryService) Run(ctx context.Context) error {
 	runCtx, cancelRunSidecars := context.WithCancel(ctx)
 	var sidecars sync.WaitGroup
 	var currentRuntime *liveRuntimeHandle
-	serviceMode := runtimeModeOrDefault(fs.coordinatorPolicy().runtimeMode) == interfaces.RuntimeModeService
+	serviceMode := runtimeModeOrDefault(fs.cfg.RuntimeMode) == interfaces.RuntimeModeService
 
 	defer func() {
 		if currentRuntime != nil {
 			return
+		}
+		if bundle := fs.startupRuntimeBundle(); bundle != nil && bundle.logSink != nil {
+			if err := bundle.logSink.Close(); err != nil {
+				fs.logger.Warn("runtime log close failed", zap.Error(err))
+			}
 		}
 	}()
 	defer func() {
@@ -485,7 +448,7 @@ func (fs *FactoryService) Run(ctx context.Context) error {
 	cancelRunSidecars()
 	sidecars.Wait()
 	// Print final dashboard.
-	if fs.coordinatorPolicy().simpleDashboardRenderer != nil {
+	if fs.cfg.SimpleDashboardRenderer != nil {
 		fs.renderDashboard(ctx)
 	}
 
@@ -547,7 +510,7 @@ func (fs *FactoryService) startListenerSidecar(
 
 func (fs *FactoryService) startDashboardSidecar(runCtx context.Context, sidecars *sync.WaitGroup) {
 	fs.startTime = fs.clock.Now()
-	if fs.coordinatorPolicy().simpleDashboardRenderer == nil {
+	if fs.cfg.SimpleDashboardRenderer == nil {
 		return
 	}
 	sidecars.Add(1)
@@ -563,7 +526,7 @@ func (fs *FactoryService) prepareRunInputs(ctx context.Context, serviceMode bool
 			return err
 		}
 	}
-	if fs.coordinatorPolicy().workFile != "" && !serviceMode {
+	if fs.cfg.WorkFile != "" && !serviceMode {
 		if err := fs.submitWorkFile(ctx); err != nil {
 			return err
 		}
@@ -576,7 +539,7 @@ func (fs *FactoryService) submitServiceModeWorkFile(
 	currentRuntime *liveRuntimeHandle,
 	serviceMode bool,
 ) error {
-	if !serviceMode || fs.coordinatorPolicy().workFile == "" {
+	if !serviceMode || fs.cfg.WorkFile == "" {
 		return nil
 	}
 	if err := fs.submitWorkFile(ctx); err != nil {
@@ -590,25 +553,16 @@ func (fs *FactoryService) startDefaultRuntime(
 	runCtx context.Context,
 	serviceMode bool,
 ) (*liveRuntimeHandle, error) {
-	if fs == nil {
-		return nil, fmt.Errorf("factory service is required")
-	}
-	runtimeBundle := liveSessionBundle(fs.defaultSession())
-	if runtimeBundle == nil {
-		defaultSessionSpec := liveSessionBuildSpec(fs.defaultSession())
-		if fs.runtimeBuild == nil || defaultSessionSpec == nil {
-			return nil, fmt.Errorf("default session build spec is required")
-		}
-		runtimeBundleAny, err := fs.runtimeBuild.Build(runCtx, *defaultSessionSpec)
-		if err != nil {
-			return nil, fmt.Errorf("build default runtime: %w", err)
-		}
-		runtimeBundle = asRuntimeBundle(runtimeBundleAny)
-		if runtimeBundle == nil {
-			return nil, fmt.Errorf("default runtime bundle is required")
-		}
-	}
-	fs.logger = runtimeBundle.logger
+	return fs.requireCoordinator().startDefaultRuntime(ctx, runCtx, serviceMode)
+}
+
+func (c *runtimeFactoryCoordinator) startDefaultRuntime(
+	ctx context.Context,
+	runCtx context.Context,
+	serviceMode bool,
+) (*liveRuntimeHandle, error) {
+	fs := c.service
+	runtimeBundle := fs.currentRuntimeBundle()
 	currentRuntime := fs.startLiveRuntime(runCtx, runtimeBundle)
 	fs.registerLiveSession(
 		defaultFactorySessionID,
@@ -616,7 +570,7 @@ func (fs *FactoryService) startDefaultRuntime(
 		defaultSessionTargetFromRuntimeBundle(runtimeBundle, fs.factoryRootDir),
 		true,
 	)
-	fs.setRunState(runCtx, defaultFactorySessionID)
+	fs.setRunState(runCtx, defaultFactorySessionID, currentRuntime)
 	if err := fs.waitForLiveRuntimeStart(ctx, currentRuntime); err != nil {
 		return nil, fs.handleDefaultRuntimeStartFailure(ctx, currentRuntime, err)
 	}
@@ -652,8 +606,7 @@ func (fs *FactoryService) handleDefaultRuntimeStartFailure(
 }
 
 func (fs *FactoryService) startAPIServerSidecar(runCtx context.Context, sidecars *sync.WaitGroup) {
-	policy := fs.coordinatorPolicy()
-	if policy.apiServerStarter == nil || policy.port <= 0 {
+	if fs.cfg.APIServerStarter == nil || fs.cfg.Port <= 0 {
 		fs.apiServerExit = nil
 		return
 	}
@@ -662,7 +615,7 @@ func (fs *FactoryService) startAPIServerSidecar(runCtx context.Context, sidecars
 	sidecars.Add(1)
 	go func() {
 		defer sidecars.Done()
-		err := policy.apiServerStarter(runCtx, fs, policy.port, fs.logger)
+		err := fs.cfg.APIServerStarter(runCtx, fs, fs.cfg.Port, fs.logger)
 		apiServerExit <- err
 		close(apiServerExit)
 		if err != nil {
@@ -678,7 +631,7 @@ func (fs *FactoryService) logServiceStartup() {
 	}
 	runtimeLogConfig := bundle.logSink.Config()
 	fs.logger.Info("factory started",
-		zap.String("dir", bundle.dir),
+		zap.String("dir", fs.cfg.Dir),
 		zap.String("runtime_log_path", bundle.logSink.Path()),
 		zap.String("runtime_log_root", bundle.logSink.RootDir()),
 		zap.String("runtime_log_start_time_utc", runtimeLogStartTimeString(bundle.logSink.StartTimeUTC())),
@@ -692,9 +645,9 @@ func (fs *FactoryService) logServiceStartup() {
 		zap.String("runtime_failure_command_output", logging.RuntimeFailureCommandOutputPolicy),
 		zap.String("runtime_verbose_command_output", logging.RuntimeVerboseCommandOutputPolicy),
 		zap.String("record_command_diagnostics", logging.RuntimeRecordCommandDiagnosticsMode),
-		zap.String("runtime_mode", string(runtimeModeOrDefault(fs.coordinatorPolicy().runtimeMode))),
-		zap.Bool("mock-workers", fs.coordinatorPolicy().mockWorkersConfig != nil),
-		zap.Int("port", fs.coordinatorPolicy().port),
+		zap.String("runtime_mode", string(runtimeModeOrDefault(fs.cfg.RuntimeMode))),
+		zap.Bool("mock-workers", fs.cfg.MockWorkersConfig != nil),
+		zap.Int("port", fs.cfg.Port),
 	)
 }
 
@@ -706,31 +659,8 @@ func (fs *FactoryService) activateReplacementWithoutLiveRuntime(
 	if err := configpersist.WriteCurrentFactoryPointer(rootDir, name); err != nil {
 		return err
 	}
-	if replacement != nil {
-		spec, err := fs.runtimeBuild.BuildSpec(context.Background(), runtimebuild.SessionSpecInput{
-			Dir:              replacement.dir,
-			FolderPath:       replacement.folderPath,
-			SessionID:        defaultFactorySessionID,
-			ExecutionBaseDir: replacement.runtimeCfg.RuntimeBaseDir(),
-			LoadedFactoryCfg: replacement.runtimeCfg,
-			RuntimeInstanceID: func() string {
-				return fs.coordinatorPolicy().runtimeInstanceID
-			}(),
-		})
-		if err != nil {
-			return err
-		}
-		fs.sessions.Upsert(factorysessions.NewLiveSession(
-			defaultFactorySessionID,
-			replacement.dir,
-			replacement.folderPath,
-			replacement.runtimeCfg.RuntimeBaseDir(),
-			FactorySessionTargetRef{Kind: FactorySessionTargetKindDefault},
-			&liveSessionState{bundle: replacement, spec: &spec},
-			true,
-			filepath.Base(replacement.folderPath),
-		), true)
-	}
+	fs.setStartupBundle(replacement)
+	fs.syncActiveSessionDir(replacement)
 	return nil
 }
 
@@ -753,23 +683,41 @@ func (fs *FactoryService) requireIdleRuntime(ctx context.Context) error {
 	return nil
 }
 
+func snapshotHasActiveWork(snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) bool {
+	if snapshot == nil {
+		return false
+	}
+	if snapshot.InFlightCount > 0 || len(snapshot.Dispatches) > 0 {
+		return true
+	}
+	for _, token := range snapshot.Marking.Tokens {
+		if token == nil || token.Color.DataType == interfaces.DataTypeResource {
+			continue
+		}
+		if snapshot.Topology == nil {
+			return true
+		}
+		category := snapshot.Topology.StateCategoryForPlace(token.PlaceID)
+		if category != state.StateCategoryTerminal && category != state.StateCategoryFailed {
+			return true
+		}
+	}
+	return false
+}
+
 func (fs *FactoryService) currentRuntimeBundle() *factoryRuntimeBundle {
 	if fs == nil {
 		return nil
 	}
-	if runState := fs.currentRunState(); runState != nil {
-		if session := fs.sessionByID(runState.sessionID); session != nil {
-			if bundle := liveSessionBundle(session); bundle != nil {
-				return bundle
-			}
-		}
+	if runState := fs.currentRunState(); runState != nil && runState.runtime != nil {
+		return runState.runtime.runtime
 	}
 	if session := fs.defaultSession(); session != nil {
-		if bundle := liveSessionBundle(session); bundle != nil {
-			return bundle
+		if handle := liveSessionHandle(session); handle != nil {
+			return handle.runtime
 		}
 	}
-	return nil
+	return fs.startupRuntimeBundle()
 }
 
 func (fs *FactoryService) publishFactoryChangeEvent(
@@ -801,6 +749,24 @@ func (fs *FactoryService) publishFactoryChangeEvent(
 	currentRuntime.runtime.eventHistory.RecordFactoryChange(snapshot.TickCount+1, payload, eventTime)
 }
 
+func replacementFactoryChangePayload(events []factoryapi.FactoryEvent) (factoryapi.FactoryChangeEventPayload, bool) {
+	for _, event := range events {
+		if event.Type != factoryapi.FactoryEventTypeInitialStructureRequest {
+			continue
+		}
+		payload, err := event.Payload.AsInitialStructureRequestEventPayload()
+		if err != nil {
+			return factoryapi.FactoryChangeEventPayload{}, false
+		}
+		return factoryapi.FactoryChangeEventPayload{
+			Factory:         payload.Factory,
+			Metadata:        payload.Metadata,
+			SourceDirectory: payload.SourceDirectory,
+		}, true
+	}
+	return factoryapi.FactoryChangeEventPayload{}, false
+}
+
 func (fs *FactoryService) startLiveRuntime(ctx context.Context, runtimeBundle *factoryRuntimeBundle) *liveRuntimeHandle {
 	if runtimeBundle == nil {
 		return nil
@@ -825,6 +791,11 @@ func (fs *FactoryService) startLiveRuntime(ctx context.Context, runtimeBundle *f
 }
 
 func (fs *FactoryService) startLiveRuntimeSidecars(ctx context.Context, handle *liveRuntimeHandle) error {
+	return fs.requireCoordinator().startLiveRuntimeSidecars(ctx, handle)
+}
+
+func (c *runtimeFactoryCoordinator) startLiveRuntimeSidecars(ctx context.Context, handle *liveRuntimeHandle) error {
+	fs := c.service
 	if handle == nil || handle.runtime == nil {
 		return fmt.Errorf("runtime handle is required")
 	}
@@ -874,6 +845,10 @@ func (fs *FactoryService) startLiveRuntimeSidecars(ctx context.Context, handle *
 }
 
 func (fs *FactoryService) stopLiveRuntimeSidecars(handle *liveRuntimeHandle) {
+	fs.requireCoordinator().stopLiveRuntimeSidecars(handle)
+}
+
+func (c *runtimeFactoryCoordinator) stopLiveRuntimeSidecars(handle *liveRuntimeHandle) {
 	if handle == nil {
 		return
 	}
@@ -888,16 +863,26 @@ func (fs *FactoryService) stopLiveRuntimeSidecars(handle *liveRuntimeHandle) {
 	handle.sidecars.Wait()
 }
 
-func (fs *FactoryService) restoreLiveRuntimeSidecars(ctx context.Context, handle *liveRuntimeHandle) {
-	if ctx == nil || handle == nil {
+func (fs *FactoryService) restoreLiveRuntimeSidecars(runState *serviceRunState) {
+	fs.requireCoordinator().restoreLiveRuntimeSidecars(runState)
+}
+
+func (c *runtimeFactoryCoordinator) restoreLiveRuntimeSidecars(runState *serviceRunState) {
+	fs := c.service
+	if runState == nil || runState.ctx == nil || runState.runtime == nil {
 		return
 	}
-	if err := fs.startLiveRuntimeSidecars(ctx, handle); err != nil {
+	if err := fs.startLiveRuntimeSidecars(runState.ctx, runState.runtime); err != nil {
 		fs.logger.Error("restore prior runtime sidecars failed", zap.Error(err))
 	}
 }
 
 func (fs *FactoryService) stopLiveRuntime(handle *liveRuntimeHandle) error {
+	return fs.requireCoordinator().stopLiveRuntime(handle)
+}
+
+func (c *runtimeFactoryCoordinator) stopLiveRuntime(handle *liveRuntimeHandle) error {
+	fs := c.service
 	if handle == nil {
 		return nil
 	}
@@ -909,6 +894,11 @@ func (fs *FactoryService) stopLiveRuntime(handle *liveRuntimeHandle) error {
 }
 
 func (fs *FactoryService) shutdownOtherLiveSessions(except *liveRuntimeHandle) error {
+	return fs.requireCoordinator().shutdownOtherLiveSessions(except)
+}
+
+func (c *runtimeFactoryCoordinator) shutdownOtherLiveSessions(except *liveRuntimeHandle) error {
+	fs := c.service
 	if fs == nil || fs.sessions == nil {
 		return nil
 	}

--- a/pkg/service/factory_build.go
+++ b/pkg/service/factory_build.go
@@ -55,6 +55,91 @@ func wireModelAssetPuller(cfg *FactoryServiceConfig, production modelAssetPuller
 	return production
 }
 
+type serviceCoordinatorPolicy struct {
+	dir                           string
+	executionBaseDir              string
+	runtimeMode                   interfaces.RuntimeMode
+	port                          int
+	verbose                       bool
+	runtimeInstanceID             string
+	workFile                      string
+	workflowID                    string
+	mockWorkersConfig             *factoryconfig.MockWorkersConfig
+	simpleDashboardRenderer       SimpleDashboardRenderer
+	apiServerStarter              APIServerStarter
+	apiServerReady                <-chan struct{}
+	workstationLoader             factoryconfig.WorkstationLoader
+	modelCacheDir                 string
+	runnerID                      string
+	providerOverride              workers.Provider
+	providerCommandRunnerOverride workers.CommandRunner
+	commandRunnerOverride         workers.CommandRunner
+}
+
+func (fs *FactoryService) coordinatorPolicy() serviceCoordinatorPolicy {
+	if fs == nil {
+		return serviceCoordinatorPolicy{}
+	}
+	if hasExplicitServiceCoordinatorPolicy(fs.policy) {
+		return fs.policy
+	}
+	return serviceCoordinatorPolicyFromConfig(fs.cfg)
+}
+
+func hasExplicitServiceCoordinatorPolicy(policy serviceCoordinatorPolicy) bool {
+	return hasExplicitServiceCoordinatorValuePolicy(policy) || hasExplicitServiceCoordinatorReferencePolicy(policy)
+}
+
+func hasExplicitServiceCoordinatorValuePolicy(policy serviceCoordinatorPolicy) bool {
+	return policy.dir != "" ||
+		policy.executionBaseDir != "" ||
+		policy.runtimeMode != "" ||
+		policy.port != 0 ||
+		policy.verbose ||
+		policy.runtimeInstanceID != "" ||
+		policy.workFile != "" ||
+		policy.workflowID != "" ||
+		policy.modelCacheDir != "" ||
+		policy.runnerID != ""
+}
+
+func hasExplicitServiceCoordinatorReferencePolicy(policy serviceCoordinatorPolicy) bool {
+	return policy.mockWorkersConfig != nil ||
+		policy.simpleDashboardRenderer != nil ||
+		policy.apiServerStarter != nil ||
+		policy.apiServerReady != nil ||
+		policy.workstationLoader != nil ||
+		policy.providerOverride != nil ||
+		policy.providerCommandRunnerOverride != nil ||
+		policy.commandRunnerOverride != nil
+}
+
+func serviceCoordinatorPolicyFromConfig(cfg *FactoryServiceConfig) serviceCoordinatorPolicy {
+	if cfg == nil {
+		return serviceCoordinatorPolicy{}
+	}
+	return serviceCoordinatorPolicy{
+		dir:                           cfg.Dir,
+		executionBaseDir:              cfg.ExecutionBaseDir,
+		runtimeMode:                   cfg.RuntimeMode,
+		port:                          cfg.Port,
+		verbose:                       cfg.Verbose,
+		runtimeInstanceID:             cfg.RuntimeInstanceID,
+		workFile:                      cfg.WorkFile,
+		workflowID:                    cfg.WorkflowID,
+		mockWorkersConfig:             cfg.MockWorkersConfig,
+		simpleDashboardRenderer:       cfg.SimpleDashboardRenderer,
+		apiServerStarter:              cfg.APIServerStarter,
+		apiServerReady:                cfg.APIServerReady,
+		workstationLoader:             cfg.WorkstationLoader,
+		modelCacheDir:                 cfg.ModelCacheDir,
+		runnerID:                      cfg.RunnerID,
+		providerOverride:              cfg.ProviderOverride,
+		providerCommandRunnerOverride: cfg.ProviderCommandRunnerOverride,
+		commandRunnerOverride:         cfg.CommandRunnerOverride,
+	}
+}
+
 func resolveFactoryServiceRoot(cfg *FactoryServiceConfig) (string, *zap.Logger, error) {
 	factoryRootDir, err := factorysessions.AbsolutizeFactoryDirectory(cfg.Dir)
 	if err != nil {
@@ -809,11 +894,12 @@ func newRuntimeBuildService(
 	baseLogger *zap.Logger,
 	startupLocalModels *localModelDomain,
 ) *runtimebuild.Service {
+	buildCfg := runtimeBuildConfigFromService(cfg)
 	return runtimebuild.New(
-		runtimeBuildConfigFromService(cfg),
+		buildCfg,
 		clock,
 		baseLogger,
-		func(ctx context.Context, input runtimebuild.BuildInput) (any, error) {
+		func(ctx context.Context, input runtimebuild.SessionBuildSpec) (any, error) {
 			bundleInput := runtimeBundleBuildInput{
 				dir:                   input.Dir,
 				folderPath:            input.FolderPath,

--- a/pkg/service/factory_build.go
+++ b/pkg/service/factory_build.go
@@ -520,43 +520,6 @@ func buildRuntimeListener(
 	), nil
 }
 
-func providerOverrideForMode(cfg *FactoryServiceConfig, sideEffects *replay.SideEffects) workers.Provider {
-	if cfg.ProviderOverride != nil || sideEffects == nil {
-		return cfg.ProviderOverride
-	}
-	return sideEffects
-}
-
-func commandRunnerOverrideForMode(
-	cfg *FactoryServiceConfig,
-	runtimeCfg interfaces.RuntimeDefinitionLookup,
-	sideEffects *replay.SideEffects,
-) workers.CommandRunner {
-	next := cfg.CommandRunnerOverride
-	if next == nil && sideEffects != nil {
-		next = sideEffects
-	}
-	if cfg.MockWorkersConfig == nil {
-		return next
-	}
-	return &workers.MockWorkerCommandRunner{
-		Config:        cfg.MockWorkersConfig,
-		RuntimeConfig: runtimeCfg,
-		Next:          next,
-	}
-}
-
-func providerCommandRunnerForMode(cfg *FactoryServiceConfig, runtimeCfg interfaces.RuntimeDefinitionLookup) workers.CommandRunner {
-	if cfg.MockWorkersConfig == nil {
-		return cfg.ProviderCommandRunnerOverride
-	}
-	return &workers.MockWorkerCommandRunner{
-		Config:        cfg.MockWorkersConfig,
-		RuntimeConfig: runtimeCfg,
-		Next:          cfg.ProviderCommandRunnerOverride,
-	}
-}
-
 func (fs *FactoryService) dashboardLoop(ctx context.Context) {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()

--- a/pkg/service/factory_build.go
+++ b/pkg/service/factory_build.go
@@ -49,9 +49,12 @@ func BuildFactoryService(ctx context.Context, cfg *FactoryServiceConfig) (*Facto
 	if err != nil {
 		return nil, err
 	}
+	clock := ServiceClockForCompose(cfg, load)
+	collaborators := NewFactoryServiceCollaborators(cfg, clock, root.BaseLogger, NewFactorySessionsRegistry())
+	return AssembleFactoryService(
 	clock := ServiceClockForCompose(normalizedCfg, load)
 	collaborators := NewFactoryServiceCollaborators(normalizedCfg, clock, root.BaseLogger, NewFactorySessionsRegistry())
-	shell, err := ComposeFactoryService(
+	return AssembleFactoryService(
 		ctx,
 		normalizedCfg,
 		root,
@@ -60,10 +63,6 @@ func BuildFactoryService(ctx context.Context, cfg *FactoryServiceConfig) (*Facto
 		clock,
 		NewHostedWorkersConfig(normalizedCfg, root.BaseLogger, clock),
 	)
-	if err != nil {
-		return nil, err
-	}
-	return AttachFactorySaveCollaborator(shell, ProvideFactorySaveCollaborator(shell, cfg)), nil
 }
 
 func cloneFactoryServiceConfig(cfg *FactoryServiceConfig) *FactoryServiceConfig {

--- a/pkg/service/factory_build.go
+++ b/pkg/service/factory_build.go
@@ -37,43 +37,15 @@ import (
 // BuildFactoryService loads factory.json from the config directory, constructs
 // the petri net, factory runtime, file watcher, and session metrics.
 func BuildFactoryService(ctx context.Context, cfg *FactoryServiceConfig) (*FactoryService, error) {
-	normalizedCfg := cloneFactoryServiceConfig(cfg)
-	if err := validateReplayModeConfig(normalizedCfg); err != nil {
-		return nil, err
-	}
-	root, err := ResolveFactoryServiceRoot(normalizedCfg)
+	core, err := BuildFactoryCore(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
-	load, err := LoadFactoryConfigForCompose(normalizedCfg, root)
-	if err != nil {
-		return nil, err
-	}
-	clock := ServiceClockForCompose(cfg, load)
-	collaborators := NewFactoryServiceCollaborators(cfg, clock, root.BaseLogger, NewFactorySessionsRegistry())
-	return AssembleFactoryService(
-	clock := ServiceClockForCompose(normalizedCfg, load)
-	collaborators := NewFactoryServiceCollaborators(normalizedCfg, clock, root.BaseLogger, NewFactorySessionsRegistry())
-	return AssembleFactoryService(
-		ctx,
-		normalizedCfg,
-		root,
-		collaborators,
-		load,
-		clock,
-		NewHostedWorkersConfig(normalizedCfg, root.BaseLogger, clock),
-	)
-}
-
-func cloneFactoryServiceConfig(cfg *FactoryServiceConfig) *FactoryServiceConfig {
-	if cfg == nil {
-		return nil
-	}
-	cloned := *cfg
-	if cfg.ExtraOptions != nil {
-		cloned.ExtraOptions = append([]factory.FactoryOption(nil), cfg.ExtraOptions...)
-	}
-	return &cloned
+	service := NewFactoryServiceFromCore(core)
+	return AttachFactorySaveCollaborator(
+		FactoryServiceShell{Service: service},
+		ProvideFactorySaveCollaborator(FactoryServiceShell{Service: service}, cfg),
+	), nil
 }
 
 func wireModelAssetPuller(cfg *FactoryServiceConfig, production modelAssetPuller) modelAssetPuller {
@@ -81,32 +53,6 @@ func wireModelAssetPuller(cfg *FactoryServiceConfig, production modelAssetPuller
 		return cfg.ModelAssets
 	}
 	return production
-}
-
-func serviceCoordinatorPolicyFromConfig(cfg *FactoryServiceConfig) serviceCoordinatorPolicy {
-	if cfg == nil {
-		return serviceCoordinatorPolicy{}
-	}
-	return serviceCoordinatorPolicy{
-		dir:                           cfg.Dir,
-		executionBaseDir:              cfg.ExecutionBaseDir,
-		runtimeMode:                   cfg.RuntimeMode,
-		port:                          cfg.Port,
-		verbose:                       cfg.Verbose,
-		runtimeInstanceID:             cfg.RuntimeInstanceID,
-		workFile:                      cfg.WorkFile,
-		workflowID:                    cfg.WorkflowID,
-		mockWorkersConfig:             cfg.MockWorkersConfig,
-		simpleDashboardRenderer:       cfg.SimpleDashboardRenderer,
-		apiServerStarter:              cfg.APIServerStarter,
-		apiServerReady:                cfg.APIServerReady,
-		workstationLoader:             cfg.WorkstationLoader,
-		modelCacheDir:                 cfg.ModelCacheDir,
-		runnerID:                      cfg.RunnerID,
-		providerOverride:              cfg.ProviderOverride,
-		providerCommandRunnerOverride: cfg.ProviderCommandRunnerOverride,
-		commandRunnerOverride:         cfg.CommandRunnerOverride,
-	}
 }
 
 func resolveFactoryServiceRoot(cfg *FactoryServiceConfig) (string, *zap.Logger, error) {
@@ -213,7 +159,7 @@ func buildRuntimeBundle(
 	ctx context.Context,
 	input runtimeBundleBuildInput,
 ) (*factoryRuntimeBundle, error) {
-	logSink, err := buildRuntimeLogSink(input.buildConfig, input.baseLogger, input.runtimeInstanceID)
+	logSink, runtimeInstanceID, err := buildRuntimeLogSink(input.cfg, input.baseLogger, input.runtimeInstanceID)
 	if err != nil {
 		return nil, err
 	}
@@ -223,6 +169,9 @@ func buildRuntimeBundle(
 			_ = logSink.Close()
 		}
 	}()
+	if input.cfg != nil && runtimeInstanceID != "" {
+		input.cfg.RuntimeInstanceID = runtimeInstanceID
+	}
 	sessionID := strings.TrimSpace(input.sessionID)
 	if sessionID == "" {
 		sessionID = defaultFactorySessionID
@@ -236,12 +185,12 @@ func buildRuntimeBundle(
 		return nil, fmt.Errorf("map factory config: %w", err)
 	}
 
-	effectiveFactoryRunnerID := effectiveFactoryRunnerID(input.buildConfig.RunnerID, input.loadedFactoryCfg.FactoryConfig())
+	effectiveFactoryRunnerID := effectiveFactoryRunnerID(input.cfg.RunnerID, input.loadedFactoryCfg.FactoryConfig())
 	eventHistory := factoryevents.NewFactoryEventHistory(net, input.clock.Now, input.loadedFactoryCfg)
 	eventHistory.SetFactoryRunnerOverride(effectiveFactoryRunnerID)
 	localModels := input.prefetchedLocalModels
 	if localModels.manager == nil {
-		localModels = newRuntimeLocalModelDependencies(input.buildConfig)
+		localModels = newRuntimeLocalModelDependencies(input.cfg)
 	}
 	workerOpts, err := loadRuntimeBundleWorkerOptions(input, logger, effectiveFactoryRunnerID, eventHistory, localModels)
 	if err != nil {
@@ -265,8 +214,8 @@ func loadRuntimeBundleWorkerOptions(
 		effectiveFactoryRunnerID,
 		input.loadedFactoryCfg,
 		runtimeWorkflowContext(input.loadedFactoryCfg.FactoryConfig(), input.sessionID),
-		logging.NewZapLogger(logger, input.buildConfig.Verbose),
-		input.buildConfig.SkipBuiltInRunnerPrerequisiteValidation,
+		logging.NewZapLogger(logger, input.cfg.Verbose),
+		input.cfg.SkipBuiltInRunnerPrerequisiteValidation,
 		input.providerOverride,
 		input.providerCommandRunner,
 		input.commandRunnerOverride,
@@ -294,7 +243,7 @@ func assembleRuntimeBundle(
 	workerOpts []factory.FactoryOption,
 ) (*factoryRuntimeBundle, error) {
 	recording, err := buildRuntimeRecorder(
-		input.buildConfig,
+		input.cfg,
 		input.loadedFactoryCfg.FactoryDir(),
 		input.loadedFactoryCfg.FactoryConfig(),
 		input.loadedFactoryCfg,
@@ -308,8 +257,8 @@ func assembleRuntimeBundle(
 
 	opts := []factory.FactoryOption{
 		factory.WithNet(net),
-		factory.WithRuntimeMode(input.buildConfig.RuntimeMode),
-		factory.WithLogger(logging.NewZapLogger(logger, input.buildConfig.Verbose)),
+		factory.WithRuntimeMode(input.cfg.RuntimeMode),
+		factory.WithLogger(logging.NewZapLogger(logger, input.cfg.Verbose)),
 		factory.WithRuntimeConfig(input.loadedFactoryCfg),
 		factory.WithWorkflowContext(runtimeWorkflowContext(input.loadedFactoryCfg.FactoryConfig(), input.sessionID)),
 		factory.WithClock(input.clock),
@@ -324,7 +273,7 @@ func assembleRuntimeBundle(
 	}
 	opts = append(opts, input.additionalFactoryOpts...)
 	opts = append(opts, workerOpts...)
-	opts = append(opts, input.buildConfig.ExtraOptions...)
+	opts = append(opts, input.cfg.ExtraOptions...)
 
 	activeFactory, err := runtime.New(opts...)
 	if err != nil {
@@ -354,21 +303,24 @@ func assembleRuntimeBundle(
 }
 
 func buildRuntimeLogSink(
-	cfg runtimebuild.Config,
+	cfg *FactoryServiceConfig,
 	baseLogger *zap.Logger,
 	runtimeInstanceID string,
-) (*logging.RuntimeLogSink, error) {
+) (*logging.RuntimeLogSink, string, error) {
 	if baseLogger == nil {
 		baseLogger = zap.NewNop()
 	}
 	if strings.TrimSpace(runtimeInstanceID) == "" {
 		runtimeInstanceID = uuid.NewString()
 	}
+	if cfg == nil {
+		return nil, runtimeInstanceID, fmt.Errorf("factory service config is required to build runtime log sink")
+	}
 	logSink, err := logging.BuildRuntimeLogger(baseLogger, runtimeInstanceID, cfg.RuntimeLogDir, cfg.RuntimeLogConfig)
 	if err != nil {
-		return nil, fmt.Errorf("build runtime logger: %w", err)
+		return nil, runtimeInstanceID, fmt.Errorf("build runtime logger: %w", err)
 	}
-	return logSink, nil
+	return logSink, runtimeInstanceID, nil
 }
 
 // localModelDomain wires pkg/localmodels runtime dependencies constructed at
@@ -379,7 +331,7 @@ type localModelDomain struct {
 	manager   *managedLocalModelManager
 }
 
-func newRuntimeLocalModelDependencies(cfg runtimebuild.Config) localModelDomain {
+func newRuntimeLocalModelDependencies(cfg *FactoryServiceConfig) localModelDomain {
 	modelResources := newLocalModelResourceLimiter()
 	modelAssets := newModelAssetPuller(strings.TrimSpace(cfg.ModelCacheDir))
 	localModelRuntime := cfg.LocalModelRuntimeOverride
@@ -429,7 +381,7 @@ func buildHostedWorkersConfig(cfg *FactoryServiceConfig, logger *zap.Logger, clo
 }
 
 func buildRuntimeRecorder(
-	cfg runtimebuild.Config,
+	cfg *FactoryServiceConfig,
 	factoryDir string,
 	factoryCfg *interfaces.FactoryConfig,
 	runtimeCfg interfaces.RuntimeDefinitionLookup,
@@ -483,6 +435,43 @@ func buildRuntimeListener(
 	), nil
 }
 
+func providerOverrideForMode(cfg *FactoryServiceConfig, sideEffects *replay.SideEffects) workers.Provider {
+	if cfg.ProviderOverride != nil || sideEffects == nil {
+		return cfg.ProviderOverride
+	}
+	return sideEffects
+}
+
+func commandRunnerOverrideForMode(
+	cfg *FactoryServiceConfig,
+	runtimeCfg interfaces.RuntimeDefinitionLookup,
+	sideEffects *replay.SideEffects,
+) workers.CommandRunner {
+	next := cfg.CommandRunnerOverride
+	if next == nil && sideEffects != nil {
+		next = sideEffects
+	}
+	if cfg.MockWorkersConfig == nil {
+		return next
+	}
+	return &workers.MockWorkerCommandRunner{
+		Config:        cfg.MockWorkersConfig,
+		RuntimeConfig: runtimeCfg,
+		Next:          next,
+	}
+}
+
+func providerCommandRunnerForMode(cfg *FactoryServiceConfig, runtimeCfg interfaces.RuntimeDefinitionLookup) workers.CommandRunner {
+	if cfg.MockWorkersConfig == nil {
+		return cfg.ProviderCommandRunnerOverride
+	}
+	return &workers.MockWorkerCommandRunner{
+		Config:        cfg.MockWorkersConfig,
+		RuntimeConfig: runtimeCfg,
+		Next:          cfg.ProviderCommandRunnerOverride,
+	}
+}
+
 func (fs *FactoryService) dashboardLoop(ctx context.Context) {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
@@ -506,7 +495,7 @@ func (fs *FactoryService) renderDashboard(ctx context.Context) {
 		}
 		return
 	}
-	fs.coordinatorPolicy().simpleDashboardRenderer(input)
+	fs.cfg.SimpleDashboardRenderer(input)
 }
 
 func (fs *FactoryService) buildSimpleDashboardRenderInput(ctx context.Context, now time.Time) (SimpleDashboardRenderInput, error) {
@@ -820,17 +809,16 @@ func newRuntimeBuildService(
 	baseLogger *zap.Logger,
 	startupLocalModels *localModelDomain,
 ) *runtimebuild.Service {
-	buildCfg := runtimeBuildConfigFromService(cfg)
 	return runtimebuild.New(
-		buildCfg,
+		runtimeBuildConfigFromService(cfg),
 		clock,
 		baseLogger,
-		func(ctx context.Context, input runtimebuild.SessionBuildSpec) (any, error) {
+		func(ctx context.Context, input runtimebuild.BuildInput) (any, error) {
 			bundleInput := runtimeBundleBuildInput{
 				dir:                   input.Dir,
 				folderPath:            input.FolderPath,
 				sessionID:             input.SessionID,
-				buildConfig:           buildCfg,
+				cfg:                   cfg,
 				loadedFactoryCfg:      input.LoadedFactoryCfg,
 				baseLogger:            input.BaseLogger,
 				runtimeInstanceID:     input.RuntimeInstanceID,

--- a/pkg/service/factory_editable_definition.go
+++ b/pkg/service/factory_editable_definition.go
@@ -799,25 +799,37 @@ func ComposeFactoryCore(
 	if err != nil {
 		return nil, err
 	}
-	runtimeBundleAny, err := collaborators.RuntimeBuild.BuildFromLoadedConfig(ctx, runtimebuild.BuildInput{
+	defaultSessionSpec, err := collaborators.RuntimeBuild.BuildSpec(ctx, runtimebuild.SessionSpecInput{
 		Dir:                   cfg.Dir,
 		FolderPath:            root.FactoryRootDir,
 		SessionID:             defaultFactorySessionID,
+		ExecutionBaseDir:      cfg.ExecutionBaseDir,
 		LoadedFactoryCfg:      load.LoadedFactoryCfg,
-		BaseLogger:            root.BaseLogger,
 		RuntimeInstanceID:     cfg.RuntimeInstanceID,
-		Clock:                 clock,
-		RecordPath:            runtimebuild.SessionScopedRecordPath(cfg.RecordPath, defaultFactorySessionID),
-		WorkflowID:            cfg.WorkflowID,
-		ProviderOverride:      providerOverrideForMode(cfg, replaySideEffects),
-		ProviderCommandRunner: providerCommandRunnerForMode(cfg, load.LoadedFactoryCfg),
-		CommandRunnerOverride: commandRunnerOverrideForMode(cfg, load.LoadedFactoryCfg, replaySideEffects),
+		SideEffects:           replaySideEffects,
 		AdditionalFactoryOpts: replayFactoryOpts,
 	})
 	if err != nil {
 		return nil, err
 	}
+	runtimeBundleAny, err := collaborators.RuntimeBuild.Build(ctx, defaultSessionSpec)
+	if err != nil {
+		return nil, err
+	}
 	runtimeBundle = asRuntimeBundle(runtimeBundleAny)
+	if runtimeBundle == nil {
+		return nil, fmt.Errorf("default runtime bundle is required")
+	}
+	collaborators.Sessions.Upsert(factorysessions.NewLiveSession(
+		defaultFactorySessionID,
+		runtimeBundle.dir,
+		runtimeBundle.folderPath,
+		runtimeBundle.runtimeCfg.RuntimeBaseDir(),
+		FactorySessionTargetRef{Kind: FactorySessionTargetKindDefault},
+		&liveSessionState{bundle: runtimeBundle, spec: &defaultSessionSpec},
+		true,
+		filepath.Base(runtimeBundle.folderPath),
+	), true)
 
 	coreBuilt = true
 	return &FactoryCore{
@@ -843,6 +855,7 @@ func NewFactoryServiceFromCore(core *FactoryCore) *FactoryService {
 		factoryRootDir: core.FactoryRootDir(),
 		sessions:       core.Sessions(),
 		hostedWorkers:  core.HostedWorkers(),
+		policy:         serviceCoordinatorPolicyFromConfig(core.cfg),
 		startupBundle:  core.StartupBundle(),
 		cfg:            core.cfg,
 		modelAssets:    core.ModelAssetPuller(),

--- a/pkg/service/factory_editable_definition.go
+++ b/pkg/service/factory_editable_definition.go
@@ -705,25 +705,6 @@ func BuildFactoryCore(ctx context.Context, cfg *FactoryServiceConfig) (*FactoryC
 	)
 }
 
-// AssembleFactoryService finishes service composition from explicit inputs.
-// Both manual and Wire-backed construction paths call this helper so the final
-// compatibility facade wiring remains identical.
-func AssembleFactoryService(
-	ctx context.Context,
-	cfg *FactoryServiceConfig,
-	root FactoryServiceRoot,
-	collaborators FactoryServiceCollaborators,
-	load FactoryConfigLoadResult,
-	clock factory.Clock,
-	hostedWorkers hostedworkers.Config,
-) (*FactoryService, error) {
-	shell, err := ComposeFactoryService(ctx, cfg, root, collaborators, load, clock, hostedWorkers)
-	if err != nil {
-		return nil, err
-	}
-	return AttachFactorySaveCollaborator(shell, ProvideFactorySaveCollaborator(shell, cfg)), nil
-}
-
 // ProvideFactorySaveCollaborator constructs the factorysave collaborator for a
 // built FactoryService shell.
 func ProvideFactorySaveCollaborator(

--- a/pkg/service/factory_editable_definition.go
+++ b/pkg/service/factory_editable_definition.go
@@ -23,10 +23,17 @@ import (
 	"go.uber.org/zap"
 )
 
+// FactoryDefinitionService owns current-factory read models for the phase-one
+// compatibility facade.
+type FactoryDefinitionService interface {
+	GetCurrentNamedFactory(ctx context.Context) (factoryapi.Factory, error)
+	GetCurrentFactoryForSession(ctx context.Context, sessionID string) (factoryapi.Factory, error)
+}
+
 // GetCurrentFactory returns the canonical current factory definition together
 // with durable optimistic-concurrency metadata.
 func (fs *FactoryService) GetCurrentFactory(ctx context.Context) (factoryapi.Factory, error) {
-	return fs.GetCurrentNamedFactory(ctx)
+	return fs.requireDefinitions().GetCurrentNamedFactory(ctx)
 }
 
 func (fs *FactoryService) buildSessionEditableFactoryReplacement(
@@ -45,14 +52,39 @@ func (fs *FactoryService) buildSessionEditableFactoryReplacement(
 
 // GetCurrentNamedFactory returns the durable current named-factory read model
 // resolved entirely from the persisted pointer and canonical on-disk layout.
-func (fs *FactoryService) GetCurrentNamedFactory(_ context.Context) (factoryapi.Factory, error) {
+func (fs *FactoryService) GetCurrentNamedFactory(ctx context.Context) (factoryapi.Factory, error) {
+	return fs.requireDefinitions().GetCurrentNamedFactory(ctx)
+}
+
+type runtimeFactoryDefinitionService struct {
+	service *FactoryService
+}
+
+var _ FactoryDefinitionService = (*runtimeFactoryDefinitionService)(nil)
+
+func newFactoryDefinitionService(fs *FactoryService) FactoryDefinitionService {
+	return &runtimeFactoryDefinitionService{service: fs}
+}
+
+func (fs *FactoryService) requireDefinitions() FactoryDefinitionService {
+	if fs == nil {
+		return newFactoryDefinitionService(nil)
+	}
+	if fs.definitions == nil {
+		fs.definitions = newFactoryDefinitionService(fs)
+	}
+	return fs.definitions
+}
+
+func (s *runtimeFactoryDefinitionService) GetCurrentNamedFactory(context.Context) (factoryapi.Factory, error) {
+	fs := s.service
 	if fs == nil {
 		return factoryapi.Factory{}, fmt.Errorf("factory service is required")
 	}
 
 	rootDir := fs.factoryRootDir
-	if rootDir == "" {
-		rootDir = fs.coordinatorPolicy().dir
+	if rootDir == "" && fs.cfg != nil {
+		rootDir = fs.cfg.Dir
 	}
 	name, err := configpersist.ReadCurrentFactoryPointer(rootDir)
 	if err != nil {
@@ -69,7 +101,11 @@ func (fs *FactoryService) GetCurrentNamedFactory(_ context.Context) (factoryapi.
 	if err != nil {
 		return factoryapi.Factory{}, fmt.Errorf("resolve current factory %q: %w", name, err)
 	}
-	current, err := configload.LoadRuntimeConfig(factoryDir, fs.coordinatorPolicy().workstationLoader)
+	var workstationLoader factoryconfig.WorkstationLoader
+	if fs.cfg != nil {
+		workstationLoader = fs.cfg.WorkstationLoader
+	}
+	current, err := configload.LoadRuntimeConfig(factoryDir, workstationLoader)
 	if err != nil {
 		return factoryapi.Factory{}, fmt.Errorf("load current factory %q: %w", name, err)
 	}
@@ -86,7 +122,11 @@ func (fs *FactoryService) currentFactoryDefinitionVersionAtRoot(rootDir string, 
 		}
 		factoryDir = resolved
 	}
-	current, err := configload.LoadRuntimeConfig(factoryDir, fs.coordinatorPolicy().workstationLoader)
+	var workstationLoader factoryconfig.WorkstationLoader
+	if fs.cfg != nil {
+		workstationLoader = fs.cfg.WorkstationLoader
+	}
+	current, err := configload.LoadRuntimeConfig(factoryDir, workstationLoader)
 	if err != nil {
 		return factoryapi.HybridLogicalTimestamp{}, fmt.Errorf("load current factory definition: %w", err)
 	}
@@ -307,10 +347,10 @@ func wireFactorySaveCollaborator(fs *FactoryService, cfg *FactoryServiceConfig) 
 }
 
 func (fs *FactoryService) workstationLoaderFromConfig() factoryconfig.WorkstationLoader {
-	if fs == nil {
+	if fs == nil || fs.cfg == nil {
 		return nil
 	}
-	return fs.coordinatorPolicy().workstationLoader
+	return fs.cfg.WorkstationLoader
 }
 
 func (fs *FactoryService) withActivationLock(fn func() error) error {
@@ -380,7 +420,7 @@ type LocalModelDomain = localModelDomain
 
 // NewLocalModelDomain constructs the local-model collaborator group for a build.
 func NewLocalModelDomain(cfg *FactoryServiceConfig) LocalModelDomain {
-	return newRuntimeLocalModelDependencies(runtimeBuildConfigFromService(cfg))
+	return newRuntimeLocalModelDependencies(cfg)
 }
 
 // FactoryServiceCollaborators groups explicit S6 composition collaborators.
@@ -398,7 +438,7 @@ func NewFactoryServiceCollaborators(
 	baseLogger *zap.Logger,
 	sessions *factorysessions.Registry,
 ) FactoryServiceCollaborators {
-	startupLocalModels := newRuntimeLocalModelDependencies(runtimeBuildConfigFromService(cfg))
+	startupLocalModels := newRuntimeLocalModelDependencies(cfg)
 	return FactoryServiceCollaborators{
 		Sessions:     sessions,
 		LocalModels:  startupLocalModels,
@@ -480,11 +520,129 @@ func NewHostedWorkersConfig(
 type ComposeCollaboratorSnapshot struct {
 	SessionsInitialized      bool
 	RuntimeBuildInitialized  bool
+	LocalModelsInitialized   bool
 	ModelAssetsInitialized   bool
 	FactorySaveInitialized   bool
+	DefinitionsInitialized   bool
 	HostedWorkersLoggerReady bool
 	BundleModelResources     bool
 	BundleLocalModels        bool
+}
+
+// FactoryCore owns the normalized runtime graph assembled before transport
+// facades or runtime loops begin.
+type FactoryCore struct {
+	cfg           *FactoryServiceConfig
+	root          FactoryServiceRoot
+	collaborators FactoryServiceCollaborators
+	hostedWorkers hostedworkers.Config
+	clock         factory.Clock
+	startupBundle *factoryRuntimeBundle
+	logger        *zap.Logger
+	modelAssets   modelAssetPuller
+}
+
+// FactoryRootDir returns the canonical factory root selected at build time.
+func (core *FactoryCore) FactoryRootDir() string {
+	if core == nil {
+		return ""
+	}
+	return core.root.FactoryRootDir
+}
+
+// BaseLogger returns the base logger used for runtime graph assembly.
+func (core *FactoryCore) BaseLogger() *zap.Logger {
+	if core == nil {
+		return nil
+	}
+	return core.root.BaseLogger
+}
+
+// Logger returns the startup runtime logger.
+func (core *FactoryCore) Logger() *zap.Logger {
+	if core == nil {
+		return nil
+	}
+	return core.logger
+}
+
+// Clock returns the normalized service clock.
+func (core *FactoryCore) Clock() factory.Clock {
+	if core == nil {
+		return nil
+	}
+	return core.clock
+}
+
+// Sessions returns the live session registry collaborator owned by the core.
+func (core *FactoryCore) Sessions() *factorysessions.Registry {
+	if core == nil {
+		return nil
+	}
+	return core.collaborators.Sessions
+}
+
+// RuntimeBuild returns the runtime-build collaborator owned by the core.
+func (core *FactoryCore) RuntimeBuild() *runtimebuild.Service {
+	if core == nil {
+		return nil
+	}
+	return core.collaborators.RuntimeBuild
+}
+
+// LocalModels returns the startup local-model collaborator group.
+func (core *FactoryCore) LocalModels() LocalModelDomain {
+	if core == nil {
+		return LocalModelDomain{}
+	}
+	return core.collaborators.LocalModels
+}
+
+// HostedWorkers returns the hosted-worker config built for this runtime graph.
+func (core *FactoryCore) HostedWorkers() hostedworkers.Config {
+	if core == nil {
+		return hostedworkers.Config{}
+	}
+	return core.hostedWorkers
+}
+
+// StartupBundle returns the pre-run runtime bundle built during composition.
+func (core *FactoryCore) StartupBundle() *factoryRuntimeBundle {
+	if core == nil {
+		return nil
+	}
+	return core.startupBundle
+}
+
+// ModelAssetPuller returns the explicit model asset collaborator used by
+// direct model operations.
+func (core *FactoryCore) ModelAssetPuller() modelAssetPuller {
+	if core == nil {
+		return nil
+	}
+	return core.modelAssets
+}
+
+// ComposeCollaboratorSnapshot reports initialized core collaborators for
+// equivalence tests.
+func (core *FactoryCore) ComposeCollaboratorSnapshot() ComposeCollaboratorSnapshot {
+	if core == nil {
+		return ComposeCollaboratorSnapshot{}
+	}
+	bundle := core.StartupBundle()
+	snapshot := ComposeCollaboratorSnapshot{
+		SessionsInitialized:      core.Sessions() != nil,
+		RuntimeBuildInitialized:  core.RuntimeBuild() != nil,
+		LocalModelsInitialized:   core.LocalModels().manager != nil,
+		ModelAssetsInitialized:   core.ModelAssetPuller() != nil,
+		DefinitionsInitialized:   true,
+		HostedWorkersLoggerReady: core.HostedWorkers().Logger != nil,
+	}
+	if bundle != nil {
+		snapshot.BundleModelResources = bundle.modelResources != nil
+		snapshot.BundleLocalModels = bundle.localModels != nil
+	}
+	return snapshot
 }
 
 // ComposeCollaboratorSnapshot reports initialized S6 collaborators for equivalence tests.
@@ -492,14 +650,21 @@ func (fs *FactoryService) ComposeCollaboratorSnapshot() ComposeCollaboratorSnaps
 	if fs == nil {
 		return ComposeCollaboratorSnapshot{}
 	}
-	bundle := fs.currentRuntimeBundle()
 	snapshot := ComposeCollaboratorSnapshot{
-		SessionsInitialized:      fs.sessions != nil,
-		RuntimeBuildInitialized:  fs.runtimeBuild != nil,
-		ModelAssetsInitialized:   fs.modelAssets != nil,
-		FactorySaveInitialized:   fs.factorySave != nil,
-		HostedWorkersLoggerReady: fs.hostedWorkers.Logger != nil,
+		FactorySaveInitialized: fs.factorySave != nil,
+		DefinitionsInitialized: fs.definitions != nil,
 	}
+	if fs.core != nil {
+		coreSnapshot := fs.core.ComposeCollaboratorSnapshot()
+		coreSnapshot.FactorySaveInitialized = snapshot.FactorySaveInitialized
+		coreSnapshot.DefinitionsInitialized = snapshot.DefinitionsInitialized
+		return coreSnapshot
+	}
+	bundle := fs.currentRuntimeBundle()
+	snapshot.SessionsInitialized = fs.sessions != nil
+	snapshot.RuntimeBuildInitialized = fs.runtimeBuild != nil
+	snapshot.ModelAssetsInitialized = fs.modelAssets != nil
+	snapshot.HostedWorkersLoggerReady = fs.hostedWorkers.Logger != nil
 	if bundle != nil {
 		snapshot.BundleModelResources = bundle.modelResources != nil
 		snapshot.BundleLocalModels = bundle.localModels != nil
@@ -511,6 +676,33 @@ func (fs *FactoryService) ComposeCollaboratorSnapshot() ComposeCollaboratorSnaps
 // Wire composition.
 type FactoryServiceShell struct {
 	Service *FactoryService
+}
+
+// BuildFactoryCore constructs the normalized runtime graph without attaching a
+// transport-facing compatibility facade.
+func BuildFactoryCore(ctx context.Context, cfg *FactoryServiceConfig) (*FactoryCore, error) {
+	if err := validateReplayModeConfig(cfg); err != nil {
+		return nil, err
+	}
+	root, err := ResolveFactoryServiceRoot(cfg)
+	if err != nil {
+		return nil, err
+	}
+	load, err := LoadFactoryConfigForCompose(cfg, root)
+	if err != nil {
+		return nil, err
+	}
+	clock := ServiceClockForCompose(cfg, load)
+	collaborators := NewFactoryServiceCollaborators(cfg, clock, root.BaseLogger, NewFactorySessionsRegistry())
+	return ComposeFactoryCore(
+		ctx,
+		cfg,
+		root,
+		collaborators,
+		load,
+		clock,
+		NewHostedWorkersConfig(cfg, root.BaseLogger, clock),
+	)
 }
 
 // AssembleFactoryService finishes service composition from explicit inputs.
@@ -563,75 +755,104 @@ func ComposeFactoryService(
 	clock factory.Clock,
 	hostedWorkers hostedworkers.Config,
 ) (FactoryServiceShell, error) {
-	if err := validateReplayModeConfig(cfg); err != nil {
+	core, err := ComposeFactoryCore(ctx, cfg, root, collaborators, load, clock, hostedWorkers)
+	if err != nil {
 		return FactoryServiceShell{}, err
 	}
-	serviceBuilt := false
+	return FactoryServiceShell{Service: NewFactoryServiceFromCore(core)}, nil
+}
+
+// ComposeFactoryCore constructs a FactoryCore using explicit composition
+// collaborators without attaching runtime loops or transport facades.
+func ComposeFactoryCore(
+	ctx context.Context,
+	cfg *FactoryServiceConfig,
+	root FactoryServiceRoot,
+	collaborators FactoryServiceCollaborators,
+	load FactoryConfigLoadResult,
+	clock factory.Clock,
+	hostedWorkers hostedworkers.Config,
+) (*FactoryCore, error) {
+	if err := validateReplayModeConfig(cfg); err != nil {
+		return nil, err
+	}
+	coreBuilt := false
 	var runtimeBundle *factoryRuntimeBundle
 	defer func() {
-		if !serviceBuilt && runtimeBundle != nil && runtimeBundle.logSink != nil {
+		if !coreBuilt && runtimeBundle != nil && runtimeBundle.logSink != nil {
 			_ = runtimeBundle.logSink.Close()
 		}
 	}()
 	if cfg.ReplayPath == "" {
 		resolvedDir, err := factoryconfig.ResolveCurrentFactoryDir(cfg.Dir)
 		if err != nil {
-			return FactoryServiceShell{}, fmt.Errorf("resolve factory dir: %w", err)
+			return nil, fmt.Errorf("resolve factory dir: %w", err)
 		}
 		resolvedDir, err = factorysessions.AbsolutizeFactoryDirectory(resolvedDir)
 		if err != nil {
-			return FactoryServiceShell{}, fmt.Errorf("resolve factory dir: %w", err)
+			return nil, fmt.Errorf("resolve factory dir: %w", err)
 		}
 		cfg.Dir = resolvedDir
 	}
 
 	replaySideEffects, replayFactoryOpts, err := replayFactoryModeOptions(load.ReplayArtifact)
 	if err != nil {
-		return FactoryServiceShell{}, err
+		return nil, err
 	}
-	defaultSessionSpec, err := collaborators.RuntimeBuild.BuildSpec(ctx, runtimebuild.SessionSpecInput{
+	runtimeBundleAny, err := collaborators.RuntimeBuild.BuildFromLoadedConfig(ctx, runtimebuild.BuildInput{
 		Dir:                   cfg.Dir,
 		FolderPath:            root.FactoryRootDir,
 		SessionID:             defaultFactorySessionID,
-		ExecutionBaseDir:      cfg.ExecutionBaseDir,
 		LoadedFactoryCfg:      load.LoadedFactoryCfg,
+		BaseLogger:            root.BaseLogger,
 		RuntimeInstanceID:     cfg.RuntimeInstanceID,
-		SideEffects:           replaySideEffects,
+		Clock:                 clock,
+		RecordPath:            runtimebuild.SessionScopedRecordPath(cfg.RecordPath, defaultFactorySessionID),
+		WorkflowID:            cfg.WorkflowID,
+		ProviderOverride:      providerOverrideForMode(cfg, replaySideEffects),
+		ProviderCommandRunner: providerCommandRunnerForMode(cfg, load.LoadedFactoryCfg),
+		CommandRunnerOverride: commandRunnerOverrideForMode(cfg, load.LoadedFactoryCfg, replaySideEffects),
 		AdditionalFactoryOpts: replayFactoryOpts,
 	})
 	if err != nil {
-		return FactoryServiceShell{}, err
-	}
-	runtimeBundleAny, err := collaborators.RuntimeBuild.Build(ctx, defaultSessionSpec)
-	if err != nil {
-		return FactoryServiceShell{}, err
+		return nil, err
 	}
 	runtimeBundle = asRuntimeBundle(runtimeBundleAny)
-	if runtimeBundle == nil {
-		return FactoryServiceShell{}, fmt.Errorf("default runtime bundle is required")
-	}
 
-	service := &FactoryService{
-		factoryRootDir: root.FactoryRootDir,
-		sessions:       collaborators.Sessions,
-		hostedWorkers:  hostedWorkers,
-		policy:         serviceCoordinatorPolicyFromConfig(cfg),
-		modelAssets:    wireModelAssetPuller(cfg, collaborators.LocalModels.assets),
-		baseLogger:     root.BaseLogger,
-		logger:         runtimeBundle.logger,
-		clock:          clock,
-		runtimeBuild:   collaborators.RuntimeBuild,
+	coreBuilt = true
+	return &FactoryCore{
+		cfg:           cfg,
+		root:          root,
+		collaborators: collaborators,
+		hostedWorkers: hostedWorkers,
+		clock:         clock,
+		startupBundle: runtimeBundle,
+		logger:        runtimeBundle.logger,
+		modelAssets:   wireModelAssetPuller(cfg, collaborators.LocalModels.assets),
+	}, nil
+}
+
+// NewFactoryServiceFromCore wraps a built core in the phase-one compatibility
+// facade returned to CLI and HTTP entrypoints.
+func NewFactoryServiceFromCore(core *FactoryCore) *FactoryService {
+	if core == nil {
+		return nil
 	}
-	service.sessions.Upsert(factorysessions.NewLiveSession(
-		defaultFactorySessionID,
-		runtimeBundle.dir,
-		runtimeBundle.folderPath,
-		runtimeBundle.runtimeCfg.RuntimeBaseDir(),
-		FactorySessionTargetRef{Kind: FactorySessionTargetKindDefault},
-		&liveSessionState{bundle: runtimeBundle, spec: &defaultSessionSpec},
-		true,
-		filepath.Base(runtimeBundle.folderPath),
-	), true)
-	serviceBuilt = true
-	return FactoryServiceShell{Service: service}, nil
+	svc := &FactoryService{
+		core:           core,
+		factoryRootDir: core.FactoryRootDir(),
+		sessions:       core.Sessions(),
+		hostedWorkers:  core.HostedWorkers(),
+		startupBundle:  core.StartupBundle(),
+		cfg:            core.cfg,
+		modelAssets:    core.ModelAssetPuller(),
+		baseLogger:     core.BaseLogger(),
+		logger:         core.Logger(),
+		clock:          core.Clock(),
+		runtimeBuild:   core.RuntimeBuild(),
+	}
+	svc.modelService = newFactoryModelService(svc)
+	svc.coordinator = newFactoryCoordinator(svc)
+	svc.definitions = newFactoryDefinitionService(svc)
+	return svc
 }

--- a/pkg/service/factory_editable_definition.go
+++ b/pkg/service/factory_editable_definition.go
@@ -513,6 +513,25 @@ type FactoryServiceShell struct {
 	Service *FactoryService
 }
 
+// AssembleFactoryService finishes service composition from explicit inputs.
+// Both manual and Wire-backed construction paths call this helper so the final
+// compatibility facade wiring remains identical.
+func AssembleFactoryService(
+	ctx context.Context,
+	cfg *FactoryServiceConfig,
+	root FactoryServiceRoot,
+	collaborators FactoryServiceCollaborators,
+	load FactoryConfigLoadResult,
+	clock factory.Clock,
+	hostedWorkers hostedworkers.Config,
+) (*FactoryService, error) {
+	shell, err := ComposeFactoryService(ctx, cfg, root, collaborators, load, clock, hostedWorkers)
+	if err != nil {
+		return nil, err
+	}
+	return AttachFactorySaveCollaborator(shell, ProvideFactorySaveCollaborator(shell, cfg)), nil
+}
+
 // ProvideFactorySaveCollaborator constructs the factorysave collaborator for a
 // built FactoryService shell.
 func ProvideFactorySaveCollaborator(

--- a/pkg/service/factory_runtime_mode_test.go
+++ b/pkg/service/factory_runtime_mode_test.go
@@ -988,6 +988,119 @@ func (s *stubModelService) InvokeModel(_ context.Context, modelName string, requ
 	return s.invokeResult, s.invokeErr
 }
 
+type stubFactoryCoordinator struct {
+	listSessionsResult factoryapi.ListFactorySessionsResponse
+	openResult         factoryapi.OpenFactorySessionResponse
+	currentFactory     factoryapi.Factory
+	workSubmitResult   interfaces.WorkRequestSubmitResult
+	moveResult         interfaces.OperatorMoveResult
+	eventStream        *interfaces.FactoryEventStream
+	engineSnapshot     *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]
+	calls              []string
+	sessionIDs         []string
+	folderPaths        []string
+	runtimeNames       []string
+}
+
+func (s *stubFactoryCoordinator) ActivateNamedFactory(_ context.Context, name string) error {
+	s.calls = append(s.calls, "activate")
+	s.runtimeNames = append(s.runtimeNames, name)
+	return nil
+}
+
+func (s *stubFactoryCoordinator) ListFactorySessions(context.Context) (factoryapi.ListFactorySessionsResponse, error) {
+	s.calls = append(s.calls, "list-sessions")
+	return s.listSessionsResult, nil
+}
+
+func (s *stubFactoryCoordinator) OpenFactorySession(_ context.Context, request factoryapi.OpenFactorySessionRequest) (factoryapi.OpenFactorySessionResponse, error) {
+	s.calls = append(s.calls, "open-session")
+	if request.FolderPath != "" {
+		s.folderPaths = append(s.folderPaths, request.FolderPath)
+	}
+	return s.openResult, nil
+}
+
+func (s *stubFactoryCoordinator) CloseFactorySession(_ context.Context, sessionID string) error {
+	s.calls = append(s.calls, "close-session")
+	s.sessionIDs = append(s.sessionIDs, sessionID)
+	return nil
+}
+
+func (s *stubFactoryCoordinator) OpenFactorySessionFromFolder(_ context.Context, folderPath string, _ *FactorySessionTargetRef, _ bool, _ bool) (*FactorySessionOpenResult, error) {
+	s.calls = append(s.calls, "open-session-from-folder")
+	s.folderPaths = append(s.folderPaths, folderPath)
+	return &FactorySessionOpenResult{SessionID: "session-from-folder"}, nil
+}
+
+func (s *stubFactoryCoordinator) SubmitWorkRequestForSession(_ context.Context, sessionID string, _ interfaces.WorkRequest) (interfaces.WorkRequestSubmitResult, error) {
+	s.calls = append(s.calls, "submit-session-work")
+	s.sessionIDs = append(s.sessionIDs, sessionID)
+	return s.workSubmitResult, nil
+}
+
+func (s *stubFactoryCoordinator) MoveWorkForSession(_ context.Context, sessionID, _, _, _ string) (interfaces.OperatorMoveResult, error) {
+	s.calls = append(s.calls, "move-session-work")
+	s.sessionIDs = append(s.sessionIDs, sessionID)
+	return s.moveResult, nil
+}
+
+func (s *stubFactoryCoordinator) SubscribeFactoryEventsForSession(_ context.Context, sessionID string) (*interfaces.FactoryEventStream, error) {
+	s.calls = append(s.calls, "subscribe-session-events")
+	s.sessionIDs = append(s.sessionIDs, sessionID)
+	return s.eventStream, nil
+}
+
+func (s *stubFactoryCoordinator) GetEngineStateSnapshotForSession(_ context.Context, sessionID string) (*interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], error) {
+	s.calls = append(s.calls, "snapshot-session")
+	s.sessionIDs = append(s.sessionIDs, sessionID)
+	return s.engineSnapshot, nil
+}
+
+func (s *stubFactoryCoordinator) GetCurrentFactoryForSession(_ context.Context, sessionID string) (factoryapi.Factory, error) {
+	s.calls = append(s.calls, "current-factory-session")
+	s.sessionIDs = append(s.sessionIDs, sessionID)
+	return s.currentFactory, nil
+}
+
+func (s *stubFactoryCoordinator) startDefaultRuntime(context.Context, context.Context, bool) (*liveRuntimeHandle, error) {
+	s.calls = append(s.calls, "start-default-runtime")
+	return &liveRuntimeHandle{}, nil
+}
+
+func (s *stubFactoryCoordinator) startBackgroundSessionWithMetadata(context.Context, string, *factoryRuntimeBundle, FactorySessionTarget) error {
+	s.calls = append(s.calls, "start-background-session")
+	return nil
+}
+
+func (s *stubFactoryCoordinator) startLiveRuntimeSidecars(context.Context, *liveRuntimeHandle) error {
+	s.calls = append(s.calls, "start-sidecars")
+	return nil
+}
+
+func (s *stubFactoryCoordinator) stopLiveRuntimeSidecars(*liveRuntimeHandle) {
+	s.calls = append(s.calls, "stop-sidecars")
+}
+
+func (s *stubFactoryCoordinator) restoreLiveRuntimeSidecars(*serviceRunState) {
+	s.calls = append(s.calls, "restore-sidecars")
+}
+
+func (s *stubFactoryCoordinator) stopLiveRuntime(*liveRuntimeHandle) error {
+	s.calls = append(s.calls, "stop-runtime")
+	return nil
+}
+
+func (s *stubFactoryCoordinator) shutdownOtherLiveSessions(*liveRuntimeHandle) error {
+	s.calls = append(s.calls, "shutdown-other-sessions")
+	return nil
+}
+
+func (s *stubFactoryCoordinator) replaceSessionRuntime(context.Context, *factorysessions.LiveSession, string, *factoryRuntimeBundle) error {
+	s.calls = append(s.calls, "replace-session-runtime")
+	return nil
+}
+
 func TestFactoryService_ModelMethodsDelegateToModelService(t *testing.T) {
 	t.Parallel()
 
@@ -1036,6 +1149,74 @@ func TestFactoryService_ModelMethodsDelegateToModelService(t *testing.T) {
 	}
 	if len(stub.requests) != 1 || stub.requests[0].Operation != "TTS" {
 		t.Fatalf("invoke requests = %#v, want delegated TTS request", stub.requests)
+	}
+}
+
+func TestFactoryService_LifecycleMethodsDelegateToCoordinator(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubFactoryCoordinator{
+		listSessionsResult: factoryapi.ListFactorySessionsResponse{
+			Sessions: []factoryapi.FactorySessionSummary{{Id: "session-a"}},
+		},
+		openResult:       factoryapi.OpenFactorySessionResponse{},
+		currentFactory:   factoryapi.Factory{Name: "beta"},
+		workSubmitResult: interfaces.WorkRequestSubmitResult{RequestID: "request-1"},
+		moveResult:       interfaces.OperatorMoveResult{WorkID: "move-1"},
+		eventStream:      &interfaces.FactoryEventStream{},
+		engineSnapshot:   &interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{RuntimeStatus: interfaces.RuntimeStatusIdle},
+	}
+	svc := &FactoryService{coordinator: stub}
+
+	listed, err := svc.ListFactorySessions(context.Background())
+	if err != nil {
+		t.Fatalf("ListFactorySessions: %v", err)
+	}
+	folderPath := "/tmp/factory"
+	if _, err := svc.OpenFactorySession(context.Background(), factoryapi.OpenFactorySessionRequest{FolderPath: folderPath}); err != nil {
+		t.Fatalf("OpenFactorySession: %v", err)
+	}
+	if _, err := svc.OpenFactorySessionFromFolder(context.Background(), folderPath, nil, false, false); err != nil {
+		t.Fatalf("OpenFactorySessionFromFolder: %v", err)
+	}
+	if err := svc.CloseFactorySession(context.Background(), "session-a"); err != nil {
+		t.Fatalf("CloseFactorySession: %v", err)
+	}
+	if err := svc.ActivateNamedFactory(context.Background(), "gamma"); err != nil {
+		t.Fatalf("ActivateNamedFactory: %v", err)
+	}
+	current, err := svc.GetCurrentFactoryForSession(context.Background(), "session-a")
+	if err != nil {
+		t.Fatalf("GetCurrentFactoryForSession: %v", err)
+	}
+	if _, err := svc.SubmitWorkRequestForSession(context.Background(), "session-a", interfaces.WorkRequest{}); err != nil {
+		t.Fatalf("SubmitWorkRequestForSession: %v", err)
+	}
+	if _, err := svc.MoveWorkForSession(context.Background(), "session-a", "work-1", "done", "request-2"); err != nil {
+		t.Fatalf("MoveWorkForSession: %v", err)
+	}
+	if _, err := svc.SubscribeFactoryEventsForSession(context.Background(), "session-a"); err != nil {
+		t.Fatalf("SubscribeFactoryEventsForSession: %v", err)
+	}
+	snapshot, err := svc.GetEngineStateSnapshotForSession(context.Background(), "session-a")
+	if err != nil {
+		t.Fatalf("GetEngineStateSnapshotForSession: %v", err)
+	}
+
+	if len(listed.Sessions) != 1 || listed.Sessions[0].Id != "session-a" {
+		t.Fatalf("ListFactorySessions result = %#v, want delegated session summary", listed)
+	}
+	if current.Name != "beta" {
+		t.Fatalf("GetCurrentFactoryForSession result = %#v, want delegated beta factory", current)
+	}
+	if snapshot == nil || snapshot.RuntimeStatus != interfaces.RuntimeStatusIdle {
+		t.Fatalf("GetEngineStateSnapshotForSession result = %#v, want delegated idle snapshot", snapshot)
+	}
+	if strings.Join(stub.calls[:10], ",") != "list-sessions,open-session,open-session-from-folder,close-session,activate,current-factory-session,submit-session-work,move-session-work,subscribe-session-events,snapshot-session" {
+		t.Fatalf("coordinator calls = %#v, want delegated lifecycle sequence", stub.calls)
+	}
+	if len(stub.runtimeNames) != 1 || stub.runtimeNames[0] != "gamma" {
+		t.Fatalf("activation targets = %#v, want gamma", stub.runtimeNames)
 	}
 }
 

--- a/pkg/service/factory_runtime_mode_test.go
+++ b/pkg/service/factory_runtime_mode_test.go
@@ -784,6 +784,9 @@ func TestBuildFactoryService_ConstructsExplicitCollaborators(t *testing.T) {
 	if svc.factorySave == nil {
 		t.Fatal("expected explicit factorysave collaborator")
 	}
+	if svc.definitions == nil {
+		t.Fatal("expected explicit factory definition collaborator")
+	}
 	if _, ok := svc.factorySave.(*factorysave.Service); !ok {
 		t.Fatalf("factorySave type = %T, want *factorysave.Service for production wiring", svc.factorySave)
 	}
@@ -855,6 +858,69 @@ func (s *recordingFactorySaveSaver) Save(
 	s.mode = mode
 	s.request = request
 	return request, nil
+}
+
+func TestFactoryService_GetCurrentFactory_DelegatesToInjectedDefinitions(t *testing.T) {
+	t.Parallel()
+
+	stub := &recordingFactoryDefinitions{
+		namedFactory: factoryapi.Factory{Name: factoryapi.FactoryName("delegated-current")},
+	}
+	svc := &FactoryService{definitions: stub}
+
+	got, err := svc.GetCurrentFactory(context.Background())
+	if err != nil {
+		t.Fatalf("GetCurrentFactory: %v", err)
+	}
+	if got.Name != stub.namedFactory.Name {
+		t.Fatalf("current factory name = %q, want %q", got.Name, stub.namedFactory.Name)
+	}
+	if stub.namedCalls != 1 {
+		t.Fatalf("named definition calls = %d, want 1", stub.namedCalls)
+	}
+}
+
+func TestFactoryService_GetCurrentFactoryForSession_DelegatesToInjectedDefinitions(t *testing.T) {
+	t.Parallel()
+
+	const sessionID = "session-definition-proof"
+	stub := &recordingFactoryDefinitions{
+		sessionFactory: factoryapi.Factory{Name: factoryapi.FactoryName("delegated-session")},
+	}
+	svc := &FactoryService{definitions: stub}
+
+	got, err := svc.GetCurrentFactoryForSession(context.Background(), sessionID)
+	if err != nil {
+		t.Fatalf("GetCurrentFactoryForSession: %v", err)
+	}
+	if got.Name != stub.sessionFactory.Name {
+		t.Fatalf("session factory name = %q, want %q", got.Name, stub.sessionFactory.Name)
+	}
+	if stub.sessionCalls != 1 {
+		t.Fatalf("session definition calls = %d, want 1", stub.sessionCalls)
+	}
+	if stub.sessionID != sessionID {
+		t.Fatalf("session definition sessionID = %q, want %q", stub.sessionID, sessionID)
+	}
+}
+
+type recordingFactoryDefinitions struct {
+	namedFactory   factoryapi.Factory
+	sessionFactory factoryapi.Factory
+	sessionID      string
+	namedCalls     int
+	sessionCalls   int
+}
+
+func (s *recordingFactoryDefinitions) GetCurrentNamedFactory(context.Context) (factoryapi.Factory, error) {
+	s.namedCalls++
+	return s.namedFactory, nil
+}
+
+func (s *recordingFactoryDefinitions) GetCurrentFactoryForSession(_ context.Context, sessionID string) (factoryapi.Factory, error) {
+	s.sessionCalls++
+	s.sessionID = sessionID
+	return s.sessionFactory, nil
 }
 
 func TestFactoryService_ListModels_DelegatesToLocalmodelsCatalog(t *testing.T) {
@@ -1160,13 +1226,15 @@ func TestFactoryService_LifecycleMethodsDelegateToCoordinator(t *testing.T) {
 			Sessions: []factoryapi.FactorySessionSummary{{Id: "session-a"}},
 		},
 		openResult:       factoryapi.OpenFactorySessionResponse{},
-		currentFactory:   factoryapi.Factory{Name: "beta"},
 		workSubmitResult: interfaces.WorkRequestSubmitResult{RequestID: "request-1"},
 		moveResult:       interfaces.OperatorMoveResult{WorkID: "move-1"},
 		eventStream:      &interfaces.FactoryEventStream{},
 		engineSnapshot:   &interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{RuntimeStatus: interfaces.RuntimeStatusIdle},
 	}
-	svc := &FactoryService{coordinator: stub}
+	definitions := &recordingFactoryDefinitions{
+		sessionFactory: factoryapi.Factory{Name: "beta"},
+	}
+	svc := &FactoryService{coordinator: stub, definitions: definitions}
 
 	listed, err := svc.ListFactorySessions(context.Background())
 	if err != nil {
@@ -1212,11 +1280,14 @@ func TestFactoryService_LifecycleMethodsDelegateToCoordinator(t *testing.T) {
 	if snapshot == nil || snapshot.RuntimeStatus != interfaces.RuntimeStatusIdle {
 		t.Fatalf("GetEngineStateSnapshotForSession result = %#v, want delegated idle snapshot", snapshot)
 	}
-	if strings.Join(stub.calls[:10], ",") != "list-sessions,open-session,open-session-from-folder,close-session,activate,current-factory-session,submit-session-work,move-session-work,subscribe-session-events,snapshot-session" {
+	if strings.Join(stub.calls[:9], ",") != "list-sessions,open-session,open-session-from-folder,close-session,activate,submit-session-work,move-session-work,subscribe-session-events,snapshot-session" {
 		t.Fatalf("coordinator calls = %#v, want delegated lifecycle sequence", stub.calls)
 	}
 	if len(stub.runtimeNames) != 1 || stub.runtimeNames[0] != "gamma" {
 		t.Fatalf("activation targets = %#v, want gamma", stub.runtimeNames)
+	}
+	if definitions.sessionCalls != 1 || definitions.sessionID != "session-a" {
+		t.Fatalf("definition collaborator session calls = %d sessionID = %q, want 1 and session-a", definitions.sessionCalls, definitions.sessionID)
 	}
 }
 

--- a/pkg/service/factory_runtime_mode_test.go
+++ b/pkg/service/factory_runtime_mode_test.go
@@ -950,6 +950,95 @@ func (p *recordingServiceModelAssetPuller) ResolveModelCache(context.Context, *c
 	return localModelCacheLayout{}, nil
 }
 
+type stubModelService struct {
+	listResult   factoryapi.ListModelsResponse
+	listErr      error
+	gotModel     factoryapi.ModelDetail
+	getErr       error
+	pullResult   apisurface.ModelPullResult
+	pullErr      error
+	invokeResult apisurface.ModelInvocationResult
+	invokeErr    error
+	calls        []string
+	modelNames   []string
+	requests     []factoryapi.ModelInvocationRequest
+}
+
+func (s *stubModelService) ListModels(context.Context) (factoryapi.ListModelsResponse, error) {
+	s.calls = append(s.calls, "list")
+	return s.listResult, s.listErr
+}
+
+func (s *stubModelService) GetModel(_ context.Context, modelName string) (factoryapi.ModelDetail, error) {
+	s.calls = append(s.calls, "get")
+	s.modelNames = append(s.modelNames, modelName)
+	return s.gotModel, s.getErr
+}
+
+func (s *stubModelService) PullModel(_ context.Context, modelName string) (apisurface.ModelPullResult, error) {
+	s.calls = append(s.calls, "pull")
+	s.modelNames = append(s.modelNames, modelName)
+	return s.pullResult, s.pullErr
+}
+
+func (s *stubModelService) InvokeModel(_ context.Context, modelName string, request factoryapi.ModelInvocationRequest) (apisurface.ModelInvocationResult, error) {
+	s.calls = append(s.calls, "invoke")
+	s.modelNames = append(s.modelNames, modelName)
+	s.requests = append(s.requests, request)
+	return s.invokeResult, s.invokeErr
+}
+
+func TestFactoryService_ModelMethodsDelegateToModelService(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubModelService{
+		listResult:   factoryapi.ListModelsResponse{Results: []factoryapi.ModelSummary{{Name: "catalog-model"}}},
+		gotModel:     factoryapi.ModelDetail{Name: "detail-model"},
+		pullResult:   apisurface.ModelPullResult{ModelName: "pull-model"},
+		invokeResult: apisurface.ModelInvocationResult{ModelName: "invoke-model"},
+	}
+	svc := &FactoryService{modelService: stub}
+
+	listed, err := svc.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	got, err := svc.GetModel(context.Background(), "detail-model")
+	if err != nil {
+		t.Fatalf("GetModel: %v", err)
+	}
+	pulled, err := svc.PullModel(context.Background(), "pull-model")
+	if err != nil {
+		t.Fatalf("PullModel: %v", err)
+	}
+	invoked, err := svc.InvokeModel(context.Background(), "invoke-model", factoryapi.ModelInvocationRequest{Operation: "TTS"})
+	if err != nil {
+		t.Fatalf("InvokeModel: %v", err)
+	}
+
+	if len(listed.Results) != 1 || listed.Results[0].Name != "catalog-model" {
+		t.Fatalf("ListModels result = %#v, want delegated catalog-model", listed)
+	}
+	if got.Name != "detail-model" {
+		t.Fatalf("GetModel result = %#v, want delegated detail-model", got)
+	}
+	if pulled.ModelName != "pull-model" {
+		t.Fatalf("PullModel result = %#v, want delegated pull-model", pulled)
+	}
+	if invoked.ModelName != "invoke-model" {
+		t.Fatalf("InvokeModel result = %#v, want delegated invoke-model", invoked)
+	}
+	if strings.Join(stub.calls, ",") != "list,get,pull,invoke" {
+		t.Fatalf("model service calls = %#v, want list,get,pull,invoke", stub.calls)
+	}
+	if len(stub.modelNames) != 3 || stub.modelNames[0] != "detail-model" || stub.modelNames[1] != "pull-model" || stub.modelNames[2] != "invoke-model" {
+		t.Fatalf("model names = %#v, want delegated model-name sequence", stub.modelNames)
+	}
+	if len(stub.requests) != 1 || stub.requests[0].Operation != "TTS" {
+		t.Fatalf("invoke requests = %#v, want delegated TTS request", stub.requests)
+	}
+}
+
 func TestBuildFactoryService_InitializesFactorySessionsRegistry(t *testing.T) {
 	rootDir := t.TempDir()
 	alphaDir := writeNamedFactoryFixture(t, rootDir, "alpha")

--- a/pkg/service/factory_runtime_mode_test.go
+++ b/pkg/service/factory_runtime_mode_test.go
@@ -1167,6 +1167,7 @@ func (s *stubFactoryCoordinator) replaceSessionRuntime(context.Context, *factory
 	return nil
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity this delegation test keeps the public model facade call sequence and payload assertions together on one compatibility seam.
 func TestFactoryService_ModelMethodsDelegateToModelService(t *testing.T) {
 	t.Parallel()
 
@@ -1218,6 +1219,7 @@ func TestFactoryService_ModelMethodsDelegateToModelService(t *testing.T) {
 	}
 }
 
+// pkgmaintcheck:ignore-cyclomatic-complexity this delegation test keeps the session-lifecycle facade sequence and collaborator assertions together on one compatibility seam.
 func TestFactoryService_LifecycleMethodsDelegateToCoordinator(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/service/factory_runtime_state.go
+++ b/pkg/service/factory_runtime_state.go
@@ -564,6 +564,52 @@ func (fs *FactoryService) preseedCurrentRuntimeInputs(ctx context.Context) error
 	return nil
 }
 
+func (fs *FactoryService) startupRuntimeBundle() *factoryRuntimeBundle {
+	if fs == nil {
+		return nil
+	}
+	fs.runtimeMu.RLock()
+	defer fs.runtimeMu.RUnlock()
+	return fs.startupBundle
+}
+
+func (fs *FactoryService) setStartupBundle(runtimeBundle *factoryRuntimeBundle) {
+	if fs == nil {
+		return
+	}
+	fs.runtimeMu.Lock()
+	defer fs.runtimeMu.Unlock()
+	fs.startupBundle = runtimeBundle
+}
+
+func (fs *FactoryService) clearStartupBundle() {
+	if fs == nil {
+		return
+	}
+	fs.runtimeMu.Lock()
+	defer fs.runtimeMu.Unlock()
+	fs.startupBundle = nil
+}
+
+func (fs *FactoryService) syncActiveSessionDir(runtimeBundle *factoryRuntimeBundle) {
+	if fs == nil || fs.cfg == nil {
+		return
+	}
+	fs.runtimeMu.Lock()
+	defer fs.runtimeMu.Unlock()
+	if runtimeBundle == nil || strings.TrimSpace(runtimeBundle.dir) == "" {
+		if strings.TrimSpace(fs.factoryRootDir) != "" {
+			fs.cfg.Dir = fs.factoryRootDir
+		}
+		return
+	}
+	fs.cfg.Dir = runtimeBundle.dir
+}
+
+func (fs *FactoryService) resetActiveSessionDir() {
+	fs.syncActiveSessionDir(nil)
+}
+
 func (fs *FactoryService) currentRunState() *serviceRunState {
 	fs.runMu.RLock()
 	defer fs.runMu.RUnlock()
@@ -571,15 +617,15 @@ func (fs *FactoryService) currentRunState() *serviceRunState {
 }
 
 func (fs *FactoryService) currentLiveRuntime() *liveRuntimeHandle {
-	runState := fs.currentRunState()
-	if runState == nil {
+	fs.runMu.RLock()
+	defer fs.runMu.RUnlock()
+	if fs.runState == nil {
 		return nil
 	}
-	session := fs.sessionByID(runState.sessionID)
-	return liveSessionHandle(session)
+	return fs.runState.runtime
 }
 
-func (fs *FactoryService) setRunState(ctx context.Context, sessionID string) {
+func (fs *FactoryService) setRunState(ctx context.Context, sessionID string, runtime *liveRuntimeHandle) {
 	fs.runMu.Lock()
 	defer fs.runMu.Unlock()
 	if ctx == nil {
@@ -589,6 +635,7 @@ func (fs *FactoryService) setRunState(ctx context.Context, sessionID string) {
 	fs.runState = &serviceRunState{
 		ctx:       ctx,
 		sessionID: sessionID,
+		runtime:   runtime,
 	}
 }
 

--- a/pkg/service/factory_runtime_state.go
+++ b/pkg/service/factory_runtime_state.go
@@ -606,10 +606,6 @@ func (fs *FactoryService) syncActiveSessionDir(runtimeBundle *factoryRuntimeBund
 	fs.cfg.Dir = runtimeBundle.dir
 }
 
-func (fs *FactoryService) resetActiveSessionDir() {
-	fs.syncActiveSessionDir(nil)
-}
-
 func (fs *FactoryService) currentRunState() *serviceRunState {
 	fs.runMu.RLock()
 	defer fs.runMu.RUnlock()

--- a/pkg/service/factory_test.go
+++ b/pkg/service/factory_test.go
@@ -1062,7 +1062,7 @@ func TestFactoryService_RequireIdleRuntime_TargetsActiveRunSession(t *testing.T)
 	svc.registerLiveSession("session-beta", betaHandle, FactorySessionTarget{
 		Ref: FactorySessionTargetRef{Kind: FactorySessionTargetKindNamed, Name: "beta"},
 	}, false)
-	svc.setRunState(context.Background(), "session-beta")
+	svc.setRunState(context.Background(), "session-beta", betaHandle)
 
 	err := svc.requireIdleRuntime(context.Background())
 	if err == nil {

--- a/pkg/service/factory_test_helpers_test.go
+++ b/pkg/service/factory_test_helpers_test.go
@@ -43,7 +43,7 @@ func bindServiceStartupRuntime(svc *FactoryService, bundle *factoryRuntimeBundle
 	svc.registerLiveSession(defaultFactorySessionID, handle, FactorySessionTarget{
 		Ref: FactorySessionTargetRef{Kind: FactorySessionTargetKindDefault},
 	}, true)
-	svc.setRunState(context.Background(), defaultFactorySessionID)
+	svc.setRunState(context.Background(), defaultFactorySessionID, handle)
 }
 
 type recordingDiagnosticsProvider struct{}

--- a/pkg/service/factoryvalidationtests/factory_compose_equivalence_test.go
+++ b/pkg/service/factoryvalidationtests/factory_compose_equivalence_test.go
@@ -55,3 +55,53 @@ func TestFactoryServiceComposeCollaboratorsMatchBuildFactoryService(t *testing.T
 		t.Fatalf("compose snapshot mismatch: built=%+v composed=%+v", built.ComposeCollaboratorSnapshot(), composed.ComposeCollaboratorSnapshot())
 	}
 }
+
+func TestFactoryCoreComposeCollaboratorsMatchBuildFactoryCore(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	factoryfixtures.WriteFactoryJSON(t, dir, factoryfixtures.MinimalFactoryConfig())
+
+	ctx := t.Context()
+	cfg := &service.FactoryServiceConfig{Dir: dir}
+
+	built, err := service.BuildFactoryCore(ctx, cfg)
+	if err != nil {
+		t.Fatalf("BuildFactoryCore: %v", err)
+	}
+
+	root, err := service.ResolveFactoryServiceRoot(&service.FactoryServiceConfig{Dir: dir})
+	if err != nil {
+		t.Fatalf("ResolveFactoryServiceRoot: %v", err)
+	}
+	load, err := service.LoadFactoryConfigForCompose(&service.FactoryServiceConfig{Dir: dir}, root)
+	if err != nil {
+		t.Fatalf("LoadFactoryConfigForCompose: %v", err)
+	}
+	clock := service.ServiceClockForCompose(&service.FactoryServiceConfig{Dir: dir}, load)
+	collaborators := service.NewFactoryServiceCollaborators(
+		&service.FactoryServiceConfig{Dir: dir},
+		clock,
+		root.BaseLogger,
+		service.NewFactorySessionsRegistry(),
+	)
+	composed, err := service.ComposeFactoryCore(
+		ctx,
+		&service.FactoryServiceConfig{Dir: dir},
+		root,
+		collaborators,
+		load,
+		clock,
+		service.NewHostedWorkersConfig(&service.FactoryServiceConfig{Dir: dir}, root.BaseLogger, clock),
+	)
+	if err != nil {
+		t.Fatalf("ComposeFactoryCore: %v", err)
+	}
+
+	if built.ComposeCollaboratorSnapshot() != composed.ComposeCollaboratorSnapshot() {
+		t.Fatalf("core compose snapshot mismatch: built=%+v composed=%+v", built.ComposeCollaboratorSnapshot(), composed.ComposeCollaboratorSnapshot())
+	}
+	if built.Sessions() == nil || built.RuntimeBuild() == nil || built.StartupBundle() == nil {
+		t.Fatalf("BuildFactoryCore omitted required collaborators: snapshot=%+v", built.ComposeCollaboratorSnapshot())
+	}
+}

--- a/pkg/service/model_catalog.go
+++ b/pkg/service/model_catalog.go
@@ -20,14 +20,63 @@ import (
 	workerexecutor "github.com/portpowered/infinite-you/pkg/workers/executor"
 )
 
+// ModelService owns direct model catalog, pull, and invocation operations.
+// FactoryService keeps these methods only as a phase-one compatibility facade.
+type ModelService interface {
+	ListModels(ctx context.Context) (factoryapi.ListModelsResponse, error)
+	GetModel(ctx context.Context, modelName string) (factoryapi.ModelDetail, error)
+	PullModel(ctx context.Context, modelName string) (apisurface.ModelPullResult, error)
+	InvokeModel(ctx context.Context, modelName string, request factoryapi.ModelInvocationRequest) (apisurface.ModelInvocationResult, error)
+}
+
+type modelServiceDependencies struct {
+	runtimeConfig           func() *factoryconfig.LoadedFactoryConfig
+	modelAssetPuller        func() modelAssetPuller
+	modelInvocationExecutor func(*factoryconfig.LoadedFactoryConfig, *interfaces.FactoryConfig, string) (workers.WorkstationRequestExecutor, error)
+	factoryRunnerID         func() string
+}
+
+type runtimeModelService struct {
+	deps modelServiceDependencies
+}
+
+var _ ModelService = (*runtimeModelService)(nil)
+var _ apisurface.ModelAPI = (*runtimeModelService)(nil)
+
+func newModelService(deps modelServiceDependencies) ModelService {
+	return &runtimeModelService{deps: deps}
+}
+
+func newFactoryModelService(fs *FactoryService) ModelService {
+	if fs == nil {
+		return newModelService(modelServiceDependencies{})
+	}
+	return newModelService(modelServiceDependencies{
+		runtimeConfig:           fs.currentRuntimeConfig,
+		modelAssetPuller:        fs.modelAssetPuller,
+		modelInvocationExecutor: fs.modelInvocationExecutor,
+		factoryRunnerID:         fs.factoryRunnerID,
+	})
+}
+
+func (fs *FactoryService) requireModelService() ModelService {
+	if fs == nil {
+		return newFactoryModelService(nil)
+	}
+	fs.modelInitOnce.Do(func() {
+		if fs.modelService == nil {
+			fs.modelService = newFactoryModelService(fs)
+		}
+	})
+	return fs.modelService
+}
+
 func (fs *FactoryService) ListModels(ctx context.Context) (factoryapi.ListModelsResponse, error) {
-	_ = ctx
-	return localmodels.ListModels(fs.currentRuntimeConfig())
+	return fs.requireModelService().ListModels(ctx)
 }
 
 func (fs *FactoryService) GetModel(ctx context.Context, modelName string) (factoryapi.ModelDetail, error) {
-	_ = ctx
-	return localmodels.GetModel(fs.currentRuntimeConfig(), modelName)
+	return fs.requireModelService().GetModel(ctx, modelName)
 }
 
 type modelAssetPuller = localmodels.AssetPuller
@@ -37,7 +86,7 @@ func newModelAssetPuller(cacheDir string) modelAssetPuller {
 }
 
 func (fs *FactoryService) PullModel(ctx context.Context, modelName string) (apisurface.ModelPullResult, error) {
-	return localmodels.PullModel(fs.modelAssetPuller(), ctx, fs.currentRuntimeConfig(), modelName)
+	return fs.requireModelService().PullModel(ctx, modelName)
 }
 
 func (fs *FactoryService) modelAssetPuller() modelAssetPuller {
@@ -58,7 +107,25 @@ func (fs *FactoryService) modelAssetPuller() modelAssetPuller {
 const directModelInvocationTransitionID = "direct-model-invocation"
 
 func (fs *FactoryService) InvokeModel(ctx context.Context, modelName string, request factoryapi.ModelInvocationRequest) (apisurface.ModelInvocationResult, error) {
-	runtimeCfg := fs.currentRuntimeConfig()
+	return fs.requireModelService().InvokeModel(ctx, modelName, request)
+}
+
+func (s *runtimeModelService) ListModels(ctx context.Context) (factoryapi.ListModelsResponse, error) {
+	_ = ctx
+	return localmodels.ListModels(s.currentRuntimeConfig())
+}
+
+func (s *runtimeModelService) GetModel(ctx context.Context, modelName string) (factoryapi.ModelDetail, error) {
+	_ = ctx
+	return localmodels.GetModel(s.currentRuntimeConfig(), modelName)
+}
+
+func (s *runtimeModelService) PullModel(ctx context.Context, modelName string) (apisurface.ModelPullResult, error) {
+	return localmodels.PullModel(s.modelAssetPuller(), ctx, s.currentRuntimeConfig(), modelName)
+}
+
+func (s *runtimeModelService) InvokeModel(ctx context.Context, modelName string, request factoryapi.ModelInvocationRequest) (apisurface.ModelInvocationResult, error) {
+	runtimeCfg := s.currentRuntimeConfig()
 	if runtimeCfg == nil {
 		return apisurface.ModelInvocationResult{}, fmt.Errorf("factory service runtime is not available")
 	}
@@ -71,7 +138,7 @@ func (fs *FactoryService) InvokeModel(ctx context.Context, modelName string, req
 	if err != nil {
 		return apisurface.ModelInvocationResult{}, err
 	}
-	if err := fs.modelAssetPuller().EnsureModelAvailable(ctx, runtimeCfg, workerDef); err != nil {
+	if err := s.modelAssetPuller().EnsureModelAvailable(ctx, runtimeCfg, workerDef); err != nil {
 		return apisurface.ModelInvocationResult{}, err
 	}
 
@@ -92,11 +159,11 @@ func (fs *FactoryService) InvokeModel(ctx context.Context, modelName string, req
 		return apisurface.ModelInvocationResult{}, err
 	}
 
-	executor, err := fs.modelInvocationExecutor(runtimeCfg, factoryCfg, workerDef.Name)
+	executor, err := s.modelInvocationExecutor(runtimeCfg, factoryCfg, workerDef.Name)
 	if err != nil {
 		return apisurface.ModelInvocationResult{}, err
 	}
-	selection := interfaces.ResolveRunnerSelection("", fs.factoryRunnerID(), workerDef.ModelProvider)
+	selection := interfaces.ResolveRunnerSelection("", s.factoryRunnerID(), workerDef.ModelProvider)
 	workstationRequest := interfaces.WorkstationExecutionRequest{
 		Dispatch: interfaces.WorkDispatch{
 			DispatchID:      directModelInvocationTransitionID,
@@ -143,6 +210,38 @@ func (fs *FactoryService) InvokeModel(ctx context.Context, modelName string, req
 		StreamFile:        streamFile,
 		StreamContentType: streamContentType,
 	}, nil
+}
+
+func (s *runtimeModelService) currentRuntimeConfig() *factoryconfig.LoadedFactoryConfig {
+	if s == nil || s.deps.runtimeConfig == nil {
+		return nil
+	}
+	return s.deps.runtimeConfig()
+}
+
+func (s *runtimeModelService) modelAssetPuller() modelAssetPuller {
+	if s == nil || s.deps.modelAssetPuller == nil {
+		return newModelAssetPuller("")
+	}
+	return s.deps.modelAssetPuller()
+}
+
+func (s *runtimeModelService) modelInvocationExecutor(
+	runtimeCfg *factoryconfig.LoadedFactoryConfig,
+	factoryCfg *interfaces.FactoryConfig,
+	workerName string,
+) (workers.WorkstationRequestExecutor, error) {
+	if s == nil || s.deps.modelInvocationExecutor == nil {
+		return nil, fmt.Errorf("model invocation executor is not configured")
+	}
+	return s.deps.modelInvocationExecutor(runtimeCfg, factoryCfg, workerName)
+}
+
+func (s *runtimeModelService) factoryRunnerID() string {
+	if s == nil || s.deps.factoryRunnerID == nil {
+		return ""
+	}
+	return s.deps.factoryRunnerID()
 }
 
 func (fs *FactoryService) modelInvocationExecutor(runtimeCfg *factoryconfig.LoadedFactoryConfig, factoryCfg *interfaces.FactoryConfig, workerName string) (workers.WorkstationRequestExecutor, error) {

--- a/pkg/service/runtime_sessions.go
+++ b/pkg/service/runtime_sessions.go
@@ -342,11 +342,15 @@ func (c *runtimeFactoryCoordinator) GetEngineStateSnapshotForSession(ctx context
 }
 
 func (fs *FactoryService) GetCurrentFactoryForSession(ctx context.Context, sessionID string) (factoryapi.Factory, error) {
-	return fs.requireCoordinator().GetCurrentFactoryForSession(ctx, sessionID)
+	return fs.requireDefinitions().GetCurrentFactoryForSession(ctx, sessionID)
 }
 
-func (c *runtimeFactoryCoordinator) GetCurrentFactoryForSession(_ context.Context, sessionID string) (factoryapi.Factory, error) {
-	fs := c.service
+func (c *runtimeFactoryCoordinator) GetCurrentFactoryForSession(ctx context.Context, sessionID string) (factoryapi.Factory, error) {
+	return c.service.requireDefinitions().GetCurrentFactoryForSession(ctx, sessionID)
+}
+
+func (s *runtimeFactoryDefinitionService) GetCurrentFactoryForSession(_ context.Context, sessionID string) (factoryapi.Factory, error) {
+	fs := s.service
 	session, err := fs.requireSession(sessionID)
 	if err != nil {
 		return factoryapi.Factory{}, err

--- a/pkg/service/runtime_sessions.go
+++ b/pkg/service/runtime_sessions.go
@@ -37,6 +37,32 @@ type (
 	liveFactorySession       = factorysessions.LiveSession
 )
 
+// FactoryCoordinator owns session tracking and runtime lifecycle orchestration.
+type FactoryCoordinator interface {
+	ActivateNamedFactory(context.Context, string) error
+	ListFactorySessions(context.Context) (factoryapi.ListFactorySessionsResponse, error)
+	OpenFactorySession(context.Context, factoryapi.OpenFactorySessionRequest) (factoryapi.OpenFactorySessionResponse, error)
+	CloseFactorySession(context.Context, string) error
+	OpenFactorySessionFromFolder(context.Context, string, *FactorySessionTargetRef, bool, bool) (*FactorySessionOpenResult, error)
+	SubmitWorkRequestForSession(context.Context, string, interfaces.WorkRequest) (interfaces.WorkRequestSubmitResult, error)
+	MoveWorkForSession(context.Context, string, string, string, string) (interfaces.OperatorMoveResult, error)
+	SubscribeFactoryEventsForSession(context.Context, string) (*interfaces.FactoryEventStream, error)
+	GetEngineStateSnapshotForSession(context.Context, string) (*interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], error)
+	GetCurrentFactoryForSession(context.Context, string) (factoryapi.Factory, error)
+	startDefaultRuntime(context.Context, context.Context, bool) (*liveRuntimeHandle, error)
+	startBackgroundSessionWithMetadata(context.Context, string, *factoryRuntimeBundle, FactorySessionTarget) error
+	startLiveRuntimeSidecars(context.Context, *liveRuntimeHandle) error
+	stopLiveRuntimeSidecars(*liveRuntimeHandle)
+	restoreLiveRuntimeSidecars(*serviceRunState)
+	stopLiveRuntime(*liveRuntimeHandle) error
+	shutdownOtherLiveSessions(*liveRuntimeHandle) error
+	replaceSessionRuntime(context.Context, *factorysessions.LiveSession, string, *factoryRuntimeBundle) error
+}
+
+type runtimeFactoryCoordinator struct {
+	service *FactoryService
+}
+
 func liveSessionHandle(session *factorysessions.LiveSession) *liveRuntimeHandle {
 	if session == nil {
 		return nil
@@ -129,6 +155,20 @@ func liveSessionExecutionBaseDir(handle *liveRuntimeHandle, folderPath string, f
 		executionBaseDir = factoryDir
 	}
 	return executionBaseDir
+}
+
+func newFactoryCoordinator(fs *FactoryService) FactoryCoordinator {
+	return &runtimeFactoryCoordinator{service: fs}
+}
+
+func (fs *FactoryService) requireCoordinator() FactoryCoordinator {
+	if fs == nil {
+		return newFactoryCoordinator(nil)
+	}
+	if fs.coordinator == nil {
+		fs.coordinator = newFactoryCoordinator(fs)
+	}
+	return fs.coordinator
 }
 
 func (fs *FactoryService) registerLiveSession(
@@ -230,6 +270,11 @@ func (fs *FactoryService) sessionRuntimeConfig(sessionID string) (*factoryconfig
 }
 
 func (fs *FactoryService) SubmitWorkRequestForSession(ctx context.Context, sessionID string, request interfaces.WorkRequest) (interfaces.WorkRequestSubmitResult, error) {
+	return fs.requireCoordinator().SubmitWorkRequestForSession(ctx, sessionID, request)
+}
+
+func (c *runtimeFactoryCoordinator) SubmitWorkRequestForSession(ctx context.Context, sessionID string, request interfaces.WorkRequest) (interfaces.WorkRequestSubmitResult, error) {
+	fs := c.service
 	activeFactory, err := fs.sessionFactory(sessionID)
 	if err != nil {
 		return interfaces.WorkRequestSubmitResult{}, err
@@ -238,6 +283,11 @@ func (fs *FactoryService) SubmitWorkRequestForSession(ctx context.Context, sessi
 }
 
 func (fs *FactoryService) MoveWorkForSession(ctx context.Context, sessionID, workID, stateName, requestID string) (interfaces.OperatorMoveResult, error) {
+	return fs.requireCoordinator().MoveWorkForSession(ctx, sessionID, workID, stateName, requestID)
+}
+
+func (c *runtimeFactoryCoordinator) MoveWorkForSession(ctx context.Context, sessionID, workID, stateName, requestID string) (interfaces.OperatorMoveResult, error) {
+	fs := c.service
 	activeFactory, err := fs.sessionFactory(sessionID)
 	if err != nil {
 		return interfaces.OperatorMoveResult{}, err
@@ -258,6 +308,11 @@ func (fs *FactoryService) MoveWork(ctx context.Context, workID, stateName string
 }
 
 func (fs *FactoryService) SubscribeFactoryEventsForSession(ctx context.Context, sessionID string) (*interfaces.FactoryEventStream, error) {
+	return fs.requireCoordinator().SubscribeFactoryEventsForSession(ctx, sessionID)
+}
+
+func (c *runtimeFactoryCoordinator) SubscribeFactoryEventsForSession(ctx context.Context, sessionID string) (*interfaces.FactoryEventStream, error) {
+	fs := c.service
 	activeFactory, err := fs.sessionFactory(sessionID)
 	if err != nil {
 		return nil, err
@@ -270,6 +325,11 @@ func (fs *FactoryService) SubscribeFactoryEventsForSession(ctx context.Context, 
 }
 
 func (fs *FactoryService) GetEngineStateSnapshotForSession(ctx context.Context, sessionID string) (*interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], error) {
+	return fs.requireCoordinator().GetEngineStateSnapshotForSession(ctx, sessionID)
+}
+
+func (c *runtimeFactoryCoordinator) GetEngineStateSnapshotForSession(ctx context.Context, sessionID string) (*interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], error) {
+	fs := c.service
 	activeFactory, err := fs.sessionFactory(sessionID)
 	if err != nil {
 		return nil, err
@@ -281,7 +341,12 @@ func (fs *FactoryService) GetEngineStateSnapshotForSession(ctx context.Context, 
 	return snapshot, nil
 }
 
-func (fs *FactoryService) GetCurrentFactoryForSession(_ context.Context, sessionID string) (factoryapi.Factory, error) {
+func (fs *FactoryService) GetCurrentFactoryForSession(ctx context.Context, sessionID string) (factoryapi.Factory, error) {
+	return fs.requireCoordinator().GetCurrentFactoryForSession(ctx, sessionID)
+}
+
+func (c *runtimeFactoryCoordinator) GetCurrentFactoryForSession(_ context.Context, sessionID string) (factoryapi.Factory, error) {
+	fs := c.service
 	session, err := fs.requireSession(sessionID)
 	if err != nil {
 		return factoryapi.Factory{}, err
@@ -311,7 +376,12 @@ func (fs *FactoryService) GetCurrentFactoryForSession(_ context.Context, session
 	return fs.withCurrentFactoryVersion(versionRootDir, serialized.Name, serialized)
 }
 
-func (fs *FactoryService) ListFactorySessions(_ context.Context) (factoryapi.ListFactorySessionsResponse, error) {
+func (fs *FactoryService) ListFactorySessions(ctx context.Context) (factoryapi.ListFactorySessionsResponse, error) {
+	return fs.requireCoordinator().ListFactorySessions(ctx)
+}
+
+func (c *runtimeFactoryCoordinator) ListFactorySessions(_ context.Context) (factoryapi.ListFactorySessionsResponse, error) {
+	fs := c.service
 	if fs == nil || fs.sessions == nil {
 		return factoryapi.ListFactorySessionsResponse{}, nil
 	}
@@ -319,6 +389,11 @@ func (fs *FactoryService) ListFactorySessions(_ context.Context) (factoryapi.Lis
 }
 
 func (fs *FactoryService) OpenFactorySession(ctx context.Context, request factoryapi.OpenFactorySessionRequest) (factoryapi.OpenFactorySessionResponse, error) {
+	return fs.requireCoordinator().OpenFactorySession(ctx, request)
+}
+
+func (c *runtimeFactoryCoordinator) OpenFactorySession(ctx context.Context, request factoryapi.OpenFactorySessionRequest) (factoryapi.OpenFactorySessionResponse, error) {
+	fs := c.service
 	var target *FactorySessionTargetRef
 	if request.Target != nil {
 		targetName := ""
@@ -366,10 +441,15 @@ func (fs *FactoryService) OpenFactorySession(ctx context.Context, request factor
 	return response, nil
 }
 
-func (fs *FactoryService) CloseFactorySession(_ context.Context, sessionID string) error {
+func (fs *FactoryService) CloseFactorySession(ctx context.Context, sessionID string) error {
+	return fs.requireCoordinator().CloseFactorySession(ctx, sessionID)
+}
+
+func (c *runtimeFactoryCoordinator) CloseFactorySession(_ context.Context, sessionID string) error {
 	if strings.TrimSpace(sessionID) == "" {
 		return fmt.Errorf("factory session id is required")
 	}
+	fs := c.service
 	return fs.stopFactorySession(sessionID)
 }
 
@@ -395,6 +475,17 @@ func (fs *FactoryService) OpenFactorySessionFromFolder(
 	validateOnly bool,
 	initNewFactory bool,
 ) (*FactorySessionOpenResult, error) {
+	return fs.requireCoordinator().OpenFactorySessionFromFolder(ctx, folderPath, target, validateOnly, initNewFactory)
+}
+
+func (c *runtimeFactoryCoordinator) OpenFactorySessionFromFolder(
+	ctx context.Context,
+	folderPath string,
+	target *FactorySessionTargetRef,
+	validateOnly bool,
+	initNewFactory bool,
+) (*FactorySessionOpenResult, error) {
+	fs := c.service
 	if fs == nil {
 		return nil, fmt.Errorf("factory service is required")
 	}
@@ -522,6 +613,16 @@ func (fs *FactoryService) startBackgroundSessionWithMetadata(
 	runtimeBundle *factoryRuntimeBundle,
 	target FactorySessionTarget,
 ) error {
+	return fs.requireCoordinator().startBackgroundSessionWithMetadata(ctx, sessionID, runtimeBundle, target)
+}
+
+func (c *runtimeFactoryCoordinator) startBackgroundSessionWithMetadata(
+	ctx context.Context,
+	sessionID string,
+	runtimeBundle *factoryRuntimeBundle,
+	target FactorySessionTarget,
+) error {
+	fs := c.service
 	if fs == nil {
 		return fmt.Errorf("factory service is required")
 	}
@@ -635,6 +736,16 @@ func (fs *FactoryService) replaceSessionRuntime(
 	name string,
 	replacement *factoryRuntimeBundle,
 ) error {
+	return fs.requireCoordinator().replaceSessionRuntime(ctx, session, name, replacement)
+}
+
+func (c *runtimeFactoryCoordinator) replaceSessionRuntime(
+	ctx context.Context,
+	session *factorysessions.LiveSession,
+	name string,
+	replacement *factoryRuntimeBundle,
+) error {
+	fs := c.service
 	if session == nil {
 		return fmt.Errorf("%w: session handle is unavailable", apisurface.ErrFactorySessionNotFound)
 	}

--- a/pkg/service/runtime_sessions.go
+++ b/pkg/service/runtime_sessions.go
@@ -666,7 +666,7 @@ func (fs *FactoryService) stopFactorySession(sessionID string) error {
 	if runState != nil && runState.sessionID == sessionID {
 		successor := fs.nextLiveSessionAfterStop(sessionID)
 		if successor != nil {
-			fs.setRunState(runState.ctx, successor.ID)
+			fs.setRunState(runState.ctx, successor.ID, liveSessionHandle(successor))
 		} else {
 			fs.clearRunState()
 		}
@@ -768,7 +768,7 @@ func (c *runtimeFactoryCoordinator) replaceSessionRuntime(
 		restoreCurrentSidecars = true
 		defer func() {
 			if restoreCurrentSidecars {
-				fs.restoreLiveRuntimeSidecars(serviceCtx, handle)
+				fs.restoreLiveRuntimeSidecars(runState)
 			}
 		}()
 	}
@@ -797,7 +797,7 @@ func (c *runtimeFactoryCoordinator) replaceSessionRuntime(
 		session.Project,
 	), isActiveSession)
 	if isActiveSession {
-		fs.setRunState(serviceCtx, session.ID)
+		fs.setRunState(serviceCtx, session.ID, replacementHandle)
 	}
 	if err := fs.stopLiveRuntime(handle); err != nil && !errors.Is(err, context.Canceled) {
 		fs.logger.Warn("prior session runtime shutdown failed", zap.Error(err), zap.String("session_id", session.ID))

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -52,6 +52,12 @@ available without widening the default feedback loop.
 ## Shared Support
 
 - Cross-package functional helpers belong in `tests/functional/internal/support`.
+- `tests/functional/internal/support.StartFunctionalAPIServer` is the
+  canonical Wire-backed HTTP harness for backend transport regressions: it
+  builds runtime services through `compose.InjectFactoryService`, so runtime
+  API smoke coverage for `/status`, `/models`, session routes, and factory
+  activation should prefer that seam over hand-built HTTP doubles when the
+  goal is startup-path parity.
 - Keep package-local helpers next to the tests until a second behavior package
   needs them, then promote them into the support package instead of importing
   or copying another package's `*_test.go` helpers.

--- a/tests/functional/internal/support/api_server.go
+++ b/tests/functional/internal/support/api_server.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/portpowered/infinite-you/cmd/factory/compose"
 	"github.com/portpowered/infinite-you/pkg/api"
 	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
 	"github.com/portpowered/infinite-you/pkg/apisurface"
@@ -71,10 +72,10 @@ func StartFunctionalAPIServer(t *testing.T, cfg FunctionalAPIServerConfig) *Func
 		cfg.Configure(serviceCfg)
 	}
 
-	svc, err := service.BuildFactoryService(ctx, serviceCfg)
+	svc, err := compose.InjectFactoryService(ctx, serviceCfg)
 	if err != nil {
 		cancel()
-		t.Fatalf("BuildFactoryService: %v", err)
+		t.Fatalf("InjectFactoryService: %v", err)
 	}
 
 	done := make(chan struct{})

--- a/tests/functional/runtime_api/api_model_transport_smoke_test.go
+++ b/tests/functional/runtime_api/api_model_transport_smoke_test.go
@@ -1,0 +1,233 @@
+package runtime_api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
+	"github.com/portpowered/infinite-you/pkg/factory"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/service"
+	"github.com/portpowered/infinite-you/pkg/workers/provider"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+func TestModelTransportSmoke_ServiceModeStartupAndDirectModelRoutesStayAligned(t *testing.T) {
+	dir := support.ScaffoldFactory(t, providerBackedModelTransportSmokeConfig())
+	support.WriteAgentConfig(t, dir, "tts-worker", support.BuildModelWorkerConfig(interfaces.ModelProviderCodex, "OMNIVOICE_Q4_K_M"))
+
+	audioPath := filepath.Join(t.TempDir(), "speech.wav")
+	if err := os.WriteFile(audioPath, []byte("RIFF....WAVEpayload"), 0o644); err != nil {
+		t.Fatalf("write audio fixture: %v", err)
+	}
+
+	providerStub := &modelTransportSmokeProvider{
+		response: interfaces.InferenceResponse{
+			Content: mustMarshalFunctionalAudioContentResponse(t, audioPath),
+		},
+	}
+	server := startFunctionalServerWithConfig(t, dir, false, func(cfg *service.FactoryServiceConfig) {
+		cfg.ProviderOverride = providerStub
+		cfg.SkipBuiltInRunnerPrerequisiteValidation = true
+	}, factory.WithServiceMode())
+
+	status := getGeneratedJSON[factoryapi.StatusResponse](t, server.URL()+"/status")
+	if status.FactoryState != string(interfaces.FactoryStateRunning) {
+		t.Fatalf("GET /status factory_state = %q, want RUNNING", status.FactoryState)
+	}
+	if status.RuntimeStatus != string(interfaces.RuntimeStatusIdle) {
+		t.Fatalf("GET /status runtime_status = %q, want IDLE", status.RuntimeStatus)
+	}
+
+	models := getGeneratedJSON[factoryapi.ListModelsResponse](t, server.URL()+"/models")
+	if len(models.Results) != 1 {
+		t.Fatalf("GET /models result count = %d, want 1", len(models.Results))
+	}
+	if models.Results[0].Name != "OMNIVOICE_Q4_K_M" || models.Results[0].ProviderLocality != factoryapi.WorkerModelLocalityCloud {
+		t.Fatalf("GET /models first result = %#v, want OMNIVOICE cloud model", models.Results[0])
+	}
+
+	model := getGeneratedJSON[factoryapi.ModelDetail](t, server.URL()+"/models/OMNIVOICE_Q4_K_M")
+	if model.Name != "OMNIVOICE_Q4_K_M" || len(model.Capabilities) != 1 || model.Capabilities[0].Worker != "tts-worker" {
+		t.Fatalf("GET /models/OMNIVOICE_Q4_K_M = %#v, want one tts-worker capability", model)
+	}
+
+	response := postJSON[factoryapi.ModelInvocationResponse](t, server.URL()+"/models/OMNIVOICE_Q4_K_M/invocations", factoryapi.ModelInvocationRequest{
+		Operation: "TTS",
+		Bindings:  providerBackedModelTransportBindings(),
+		Content: &factoryapi.WorkContent{
+			mustGeneratedFunctionalTextPart(t, "hello world"),
+		},
+	}, "model transport smoke invocation failure")
+	if response.ModelName != "OMNIVOICE_Q4_K_M" || response.Worker != "tts-worker" || response.Operation != "TTS" {
+		t.Fatalf("POST /models/.../invocations identity = %#v, want OMNIVOICE_Q4_K_M/tts-worker/TTS", response)
+	}
+	if response.ProviderLocality != factoryapi.WorkerModelLocalityCloud {
+		t.Fatalf("POST /models/.../invocations provider locality = %q, want CLOUD", response.ProviderLocality)
+	}
+	if len(response.Bindings) != 1 || response.Bindings[0].Slot != "text" || response.Bindings[0].Source != factoryapi.INPUT {
+		t.Fatalf("POST /models/.../invocations bindings = %#v, want one input text binding", response.Bindings)
+	}
+	if len(response.Content) != 1 {
+		t.Fatalf("POST /models/.../invocations content count = %d, want 1", len(response.Content))
+	}
+	audioPart, err := response.Content[0].AsWorkAudioContentPart()
+	if err != nil {
+		t.Fatalf("decode invocation audio content: %v", err)
+	}
+	if stringPointerValue(audioPart.ContentType) != "audio/wav" || generatedAudioPath(audioPart) != audioPath {
+		t.Fatalf("POST /models/.../invocations audio part = %#v, want audio/wav at %s", audioPart, audioPath)
+	}
+
+	calls := providerStub.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("provider calls = %d, want 1", len(calls))
+	}
+	if calls[0].Model != "OMNIVOICE_Q4_K_M" || calls[0].ModelOperation != "TTS" {
+		t.Fatalf("provider call = %#v, want OMNIVOICE_Q4_K_M TTS", calls[0])
+	}
+	if len(calls[0].ModelBindings) != 1 || len(calls[0].ModelBindings[0].Content) != 1 || calls[0].ModelBindings[0].Content[0].Text != "hello world" {
+		t.Fatalf("provider bindings = %#v, want one text binding for hello world", calls[0].ModelBindings)
+	}
+}
+
+func providerBackedModelTransportSmokeConfig() map[string]any {
+	return map[string]any{
+		"name": "model-transport-smoke",
+		"workTypes": []map[string]any{{
+			"name": "task",
+			"states": []map[string]string{
+				{"name": "init", "type": "INITIAL"},
+				{"name": "complete", "type": "TERMINAL"},
+				{"name": "failed", "type": "FAILED"},
+			},
+		}},
+		"workers": []map[string]any{{
+			"name":          "tts-worker",
+			"type":          interfaces.WorkerTypeModel,
+			"model":         "OMNIVOICE_Q4_K_M",
+			"modelProvider": "CODEX",
+			"modelLocality": interfaces.ModelLocalityCloud,
+			"operations": []map[string]any{{
+				"name": "TTS",
+				"inputs": []map[string]any{{
+					"name":         "text",
+					"contentTypes": []string{interfaces.ModelOperationContentTypeText},
+					"required":     true,
+				}},
+				"outputs": []map[string]any{{
+					"name":         "audio",
+					"contentTypes": []string{interfaces.ModelOperationContentTypeAudio},
+				}},
+			}},
+		}},
+	}
+}
+
+func postJSON[T any](t *testing.T, endpoint string, request any, failurePrefix string) T {
+	t.Helper()
+	var body io.Reader
+	if request != nil {
+		encoded, err := json.Marshal(request)
+		if err != nil {
+			t.Fatalf("%s: marshal request: %v", failurePrefix, err)
+		}
+		body = bytes.NewReader(encoded)
+	}
+	resp, err := http.Post(endpoint, "application/json", body)
+	if err != nil {
+		t.Fatalf("%s: POST %s: %v", failurePrefix, endpoint, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("%s: POST %s status = %d, want 200: %s", failurePrefix, endpoint, resp.StatusCode, string(payload))
+	}
+	var out T
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("%s: decode %s response: %v", failurePrefix, endpoint, err)
+	}
+	return out
+}
+
+func mustGeneratedFunctionalTextPart(t *testing.T, text string) factoryapi.WorkContentPart {
+	t.Helper()
+	var part factoryapi.WorkContentPart
+	if err := part.FromWorkTextContentPart(factoryapi.WorkTextContentPart{
+		Type: factoryapi.WorkContentPartTypeTextUpper,
+		Text: text,
+	}); err != nil {
+		t.Fatalf("encode generated text part: %v", err)
+	}
+	return part
+}
+
+func mustMarshalFunctionalAudioContentResponse(t *testing.T, audioPath string) string {
+	t.Helper()
+	body, err := json.Marshal([]interfaces.WorkContentPart{{
+		Type:        interfaces.WorkContentPartTypeAudio,
+		File:        audioPath,
+		ContentType: "audio/wav",
+	}})
+	if err != nil {
+		t.Fatalf("marshal functional audio content: %v", err)
+	}
+	return string(body)
+}
+
+func providerBackedModelTransportBindings() *[]factoryapi.WorkstationOperationBinding {
+	return &[]factoryapi.WorkstationOperationBinding{{
+		Slot: "text",
+		Selector: &factoryapi.WorkstationOperationBindingSelector{
+			Type: func() *factoryapi.ModelOperationContentType {
+				value := factoryapi.ModelOperationContentTypeText
+				return &value
+			}(),
+		},
+	}}
+}
+
+func generatedAudioPath(audio factoryapi.WorkAudioContentPart) string {
+	if audio.File != nil && strings.TrimSpace(string(*audio.File)) != "" {
+		return string(*audio.File)
+	}
+	if strings.TrimSpace(string(audio.Url)) != "" {
+		return strings.TrimPrefix(string(audio.Url), "file://")
+	}
+	return ""
+}
+
+type modelTransportSmokeProvider struct {
+	mu       sync.Mutex
+	calls    []interfaces.ProviderInferenceRequest
+	response interfaces.InferenceResponse
+}
+
+func (p *modelTransportSmokeProvider) Infer(_ context.Context, req interfaces.ProviderInferenceRequest) (interfaces.InferenceResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.calls = append(p.calls, interfaces.CloneProviderInferenceRequest(req))
+	return p.response, nil
+}
+
+func (p *modelTransportSmokeProvider) Calls() []interfaces.ProviderInferenceRequest {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	calls := make([]interfaces.ProviderInferenceRequest, len(p.calls))
+	for i, call := range p.calls {
+		calls[i] = interfaces.CloneProviderInferenceRequest(call)
+	}
+	return calls
+}
+
+var _ provider.Provider = (*modelTransportSmokeProvider)(nil)


### PR DESCRIPTION
```json
{
  "project": "Factory Service Core and Coordinator Split with Go Wire",
  "branchName": "ralph/factory-service-core-coordinator-wire",
  "description": "Separate FactoryService composition, API exposure, and orchestration into FactoryCore, ModelService, and FactoryCoordinator behind a single Go Wire composition root while preserving existing CLI and HTTP transport contracts during phase one.",
  "context": {
    "customerAsk": "Separate composition, API exposure, and orchestration into distinct backend components. Introduce a single Go Wire-driven composition root, extract a dedicated ModelService, extract a dedicated coordinator for runtime/session lifecycle, keep HTTP and CLI contracts stable in the first phase, and preserve multi-session behavior, session-owned runtime state, and runtime replacement semantics.",
    "problem": "FactoryService currently combines runtime graph assembly, transport-facing APIs, and session/runtime lifecycle orchestration. Model operations and lifecycle behavior route through the monolithic service because it owns session lookup and cross-service state. BuildFactoryService and cmd/factory/compose.InjectFactoryService are parallel composition paths without a single runtime graph root, making new feature placement ambiguous and widening coupling.",
    "solution": "Introduce FactoryCore as the Wire-built runtime graph root with normalized policy and explicit collaborators. Extract ModelService for model list/get/pull/invoke and FactoryCoordinator for session tracking, runtime start/stop/replacement, and sidecar orchestration. Keep FactoryService as a thin compatibility facade for CLI and HTTP entrypoints while transport contracts remain unchanged in phase one."
  },
  "acceptanceCriteria": [
    "CLI (you run) and HTTP (compose.ServeAPIServer) construct the backend runtime graph through one primary Go Wire entrypoint rather than parallel ad hoc wiring",
    "FactoryCore owns normalized build policy, session registry, runtime-build service, local-model domain, and explicit accessors for extracted sub-services",
    "Model list/get/pull/invoke is implemented by ModelService; FactoryService delegates rather than owning the canonical model implementation",
    "Session tracking, default-session behavior, runtime start/stop, replacement, service-mode orchestration, and poller/cron sidecar lifecycle are owned by FactoryCoordinator",
    "FactoryService remains a thin compatibility facade; new business logic lands in extracted services or the coordinator",
    "Existing CLI commands, HTTP routes, request/response shapes, and compose return types behave the same as before phase one",
    "Session isolation, concurrent multi-session hosting, and runtime replacement idle-guard semantics remain unchanged",
    "Typecheck, lint, and tests pass for touched service, compose, CLI, API, and validation packages"
  ],
  "userStories": [
    {
      "id": "prd-factory-service-core-coordinator-wire-001",
      "title": "Unify backend assembly on one Go Wire composition root",
      "description": "As a backend maintainer, I want CLI and HTTP startup to build the runtime graph through one Wire entrypoint so that service assembly is explicit, testable, and not duplicated across manual constructors.",
      "acceptanceCriteria": [
        "One primary Wire inject function (extending the existing cmd/factory/compose.InjectFactoryService path) is the canonical way to assemble the backend runtime graph from FactoryServiceConfig",
        "you run and HTTP serving both obtain their runtime graph through that Wire entrypoint or a thin wrapper that calls it; parallel manual dependency wiring in the production composition path is removed or reduced to compatibility adapters only",
        "service.BuildFactoryService either delegates to the Wire path or shares the same core assembly function so compose-equivalence behavior is preserved",
        "go generate ./cmd/factory/compose/... produces a checked-in wire_gen.go that CI wire-smoke accepts",
        "Typecheck passes",
        "Tests pass for cmd/factory/compose, pkg/cli/run, and pkg/service/factoryvalidationtests"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-factory-service-core-coordinator-wire-002",
      "title": "Introduce FactoryCore as the runtime graph root",
      "description": "As a backend maintainer, I want a core runtime graph object that owns normalized dependencies so that composition concerns are separated from orchestration and transport-facing APIs.",
      "acceptanceCriteria": [
        "A FactoryCore (or equivalent) type is returned from the Wire composition root and exposes explicit accessors or interfaces for sub-services used by transports",
        "The core owns normalized build policy, the session registry, runtime-build service, local-model domain, hosted-worker config, and other constructed collaborators currently spread through FactoryService construction",
        "The core can be constructed without starting the runtime loop; starting runtimes remains an orchestration action, not a side effect of graph assembly",
        "The core does not absorb session lifecycle orchestration that belongs in the coordinator",
        "Tests can construct the core with substituted collaborators (for example model assets, command runners, runtime builders) without going through transport facades",
        "Typecheck passes",
        "Tests pass for pkg/service and compose validation packages"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-factory-service-core-coordinator-wire-003",
      "title": "Extract ModelService for model list/get/pull/invoke",
      "description": "As an API maintainer, I want model operations implemented by a dedicated model service so that model handlers do not depend on the full primary factory service implementation.",
      "acceptanceCriteria": [
        "A ModelService interface and implementation provide list, get, pull, and invoke operations with the same inputs, errors, and response shapes as today's FactoryService model methods",
        "ModelService depends on narrow collaborators for runtime/session resolution, model asset access, and invocation policy rather than the full core object where unnecessary",
        "HTTP model handlers (GET /models, GET /models/{model_name}, POST /models/{model_name}/pull, POST /models/{model_name}/invocations) continue to return the same status codes and JSON bodies for success, not-found, and validation failure cases covered by existing tests",
        "FactoryService model methods delegate to ModelService and no longer contain the authoritative model business logic",
        "Existing model-focused service tests (for example catalog delegation and local-model invocation paths) continue to pass without behavior regressions",
        "Typecheck passes",
        "Tests pass for model-related service and API handler packages"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-factory-service-core-coordinator-wire-004",
      "title": "Extract FactoryCoordinator for session and runtime lifecycle",
      "description": "As a backend maintainer, I want a coordinator that owns runtime and session orchestration so that lifecycle behavior is isolated from composition and transport concerns.",
      "acceptanceCriteria": [
        "A FactoryCoordinator (or equivalent) owns active session tracking, default-session behavior, runtime start/stop, runtime replacement, and sidecar orchestration (poller and cron watchers)",
        "Session registry interactions for live session registration, selection, and lookup occur through coordinator-owned paths rather than being spread across unrelated API methods on FactoryService",
        "Service-mode startup, idle-guarded factory activation/replacement, and runtime teardown semantics match current behavior for batch and service runtime modes",
        "Opening, selecting, and operating on multiple concurrent sessions with separate runtime state and working directories continues to work as today",
        "Runtime/session lifecycle tests (session runtime resolution, replacement guards, service-mode startup, poller/cron supervision) continue to pass without behavior regressions",
        "Typecheck passes",
        "Tests pass for session/runtime lifecycle and poller packages"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-factory-service-core-coordinator-wire-005",
      "title": "Shrink FactoryService into a migration compatibility facade",
      "description": "As a maintainer migrating callers incrementally, I want FactoryService to remain available as a thin adapter so existing transports compile and behave the same while new logic lives in extracted components.",
      "acceptanceCriteria": [
        "FactoryService remains the object returned to current CLI and HTTP compose entrypoints, either directly or through a compatible wrapper over FactoryCore",
        "New business logic for model operations and lifecycle orchestration is added to ModelService, FactoryCoordinator, or other extracted services—not to FactoryService",
        "FactoryService methods delegate to core/coordinator/model services; compatibility indirection is documented in code comments where non-obvious",
        "FactoryService surface area materially shrinks: model and lifecycle methods become delegation stubs rather than canonical implementations",
        "ComposeCollaboratorSnapshot or an equivalent equivalence check confirms Wire-built and legacy-compatible construction paths still align on collaborator wiring",
        "Typecheck passes",
        "Tests pass for pkg/service/factoryvalidationtests and compose packages"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-factory-service-core-coordinator-wire-006",
      "title": "Preserve phase-one CLI and HTTP transport contracts",
      "description": "As a CLI or HTTP API caller, I want backend architecture improvements without requiring immediate transport contract changes so that existing integrations keep working during migration.",
      "acceptanceCriteria": [
        "No OpenAPI schema changes are required purely for this refactor; public model, session, factory, and work route shapes remain unchanged in phase one",
        "No CLI command flags, subcommands, or output contracts change for you run, model commands, or session-aware operations touched by this work",
        "Functional and runtime API smoke tests for model listing/invocation, session open/switch, factory activation, and service-mode startup pass using the refactored composition path",
        "make wire-smoke, go test ./cmd/factory/compose/..., and targeted runtime API functional tests pass without transport-level regressions",
        "Typecheck passes",
        "Tests pass for compose, CLI run, API handler, and runtime functional test packages affected by the migration"
      ],
      "priority": 6,
      "passes": false,
      "notes": ""
    }
  ]
}
```