### PR TITLE
trace-drilldown-workstaiton-graph-dispatch-flow

### DIFF
--- a/ui/integration/event-stream-replay.integration.test.mjs
+++ b/ui/integration/event-stream-replay.integration.test.mjs
@@ -37,7 +37,7 @@ async function waitForTickLabel(page, label) {
       state: "visible",
       timeout: uiInteractionTimeoutMs,
     });
-  } catch (error) {
+  } catch (_error) {
     const sliderValue = await page
       .getByRole("slider", { name: "Timeline tick" })
       .inputValue();
@@ -158,7 +158,7 @@ async function exerciseSelectedWorkTrace(page, workstationName, options = {}) {
   await workstationButton.scrollIntoViewIfNeeded();
   try {
     await workstationButton.click({ force: true });
-  } catch (error) {
+  } catch (_error) {
     // React Flow workstation buttons can remain visible while clipping leaves the
     // actionable box outside the viewport in CI. Fall back to the DOM click so
     // the test still verifies replay behavior after the button renders.

--- a/ui/src/features/trace-drilldown/components/trace-dispatch-factory-graph-node.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-dispatch-factory-graph-node.tsx
@@ -1,29 +1,23 @@
 import type { NodeProps } from "@xyflow/react";
 
-import { DashboardText } from "../../../components/ui";
-import { formatTraceOutcome } from "../../../components/ui/formatters";
 import { cn } from "../../../lib/cn";
 import {
   ActivityGraphNodeBadge,
-  activityGraphNodeSurfaceClassName,
   activityGraphNodeTitleClassName,
 } from "../../flowchart/components/current-activity-node-chrome";
 import { ActivityGraphNodeShell } from "../../flowchart/components/current-activity-node-shell";
 import { GraphSemanticIcon } from "../../flowchart/components/graph-semantic-icon";
 import type { TraceDispatchFlowNode } from "../lib/trace-dispatch-factory-graph-flow";
-import { getTraceDrilldownMessages } from "../messages/trace-drilldown";
 
 const WORKSTATION_NODE_CLASS =
-  "min-w-0 w-full justify-start overflow-hidden text-left shadow-af-card";
+  "min-w-0 w-full justify-start overflow-hidden border-primary bg-primary-container text-left shadow-none";
 
 function TraceDispatchFactoryGraphNode({
   data,
 }: NodeProps<TraceDispatchFlowNode>) {
-  const messages = getTraceDrilldownMessages(data.locale);
-
   return (
     <ActivityGraphNodeShell
-      className={cn(WORKSTATION_NODE_CLASS, outcomeToneClassName(data.outcome))}
+      className={WORKSTATION_NODE_CLASS}
       handles={data.connectionAnchors.map((handle) => ({
         ...handle,
         hidden: true,
@@ -48,17 +42,8 @@ function TraceDispatchFactoryGraphNode({
               {data.kindLabel}
             </ActivityGraphNodeBadge>
           </div>
-          <ActivityGraphNodeBadge
-            className="shrink-0"
-            tone={outcomeBadgeTone(data.outcome)}
-            weight="label"
-          >
-            {data.outcome
-              ? formatTraceOutcome(data.outcome)
-              : messages.dispatchPathPendingOutcome}
-          </ActivityGraphNodeBadge>
         </div>
-        <DashboardText
+        <p
           className={cn(
             "m-0 [overflow-wrap:anywhere]",
             activityGraphNodeTitleClassName("font-mono text-sm"),
@@ -67,19 +52,7 @@ function TraceDispatchFactoryGraphNode({
           title={data.displayLabel}
         >
           {data.displayLabel}
-        </DashboardText>
-        <DashboardText
-          className="m-0 text-[0.76rem] text-on-surface-variant [overflow-wrap:anywhere]"
-          variant="supporting"
-        >
-          {messages.dispatchPathInputPrefix}: {data.inputSummary}
-        </DashboardText>
-        <DashboardText
-          className="m-0 text-[0.76rem] text-on-surface-variant [overflow-wrap:anywhere]"
-          variant="supporting"
-        >
-          {messages.dispatchPathOutputPrefix}: {data.outputSummary}
-        </DashboardText>
+        </p>
       </div>
     </ActivityGraphNodeShell>
   );
@@ -88,35 +61,3 @@ function TraceDispatchFactoryGraphNode({
 export const TRACE_DISPATCH_FACTORY_GRAPH_NODE_TYPES = {
   factoryEntity: TraceDispatchFactoryGraphNode,
 };
-
-function outcomeBadgeTone(
-  outcome?: string,
-): "danger" | "neutral" | "success" | "warning" {
-  if (!outcome) {
-    return "neutral";
-  }
-
-  const normalized = outcome.toUpperCase();
-  if (normalized === "FAILED" || normalized === "REJECTED") {
-    return "danger";
-  }
-  if (normalized === "CONTINUE") {
-    return "warning";
-  }
-  return "success";
-}
-
-function outcomeToneClassName(outcome?: string): string {
-  if (!outcome) {
-    return activityGraphNodeSurfaceClassName("neutral");
-  }
-
-  const normalized = outcome.toUpperCase();
-  if (normalized === "FAILED" || normalized === "REJECTED") {
-    return activityGraphNodeSurfaceClassName("danger");
-  }
-  if (normalized === "CONTINUE") {
-    return activityGraphNodeSurfaceClassName("warning");
-  }
-  return activityGraphNodeSurfaceClassName("success");
-}

--- a/ui/src/features/trace-drilldown/components/trace-dispatch-factory-graph-node.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-dispatch-factory-graph-node.tsx
@@ -9,15 +9,12 @@ import { ActivityGraphNodeShell } from "../../flowchart/components/current-activ
 import { GraphSemanticIcon } from "../../flowchart/components/graph-semantic-icon";
 import type { TraceDispatchFlowNode } from "../lib/trace-dispatch-factory-graph-flow";
 
-const WORKSTATION_NODE_CLASS =
-  "min-w-0 w-full justify-start overflow-hidden border-primary bg-primary-container text-left shadow-none";
-
 function TraceDispatchFactoryGraphNode({
   data,
 }: NodeProps<TraceDispatchFlowNode>) {
   return (
     <ActivityGraphNodeShell
-      className={WORKSTATION_NODE_CLASS}
+      className="min-w-0 w-full justify-start overflow-hidden border-primary bg-primary-container text-left shadow-none"
       handles={data.connectionAnchors.map((handle) => ({
         ...handle,
         hidden: true,

--- a/ui/src/features/trace-drilldown/components/trace-factory-graph-nodes.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-factory-graph-nodes.test.tsx
@@ -43,7 +43,7 @@ describe("Trace dispatch factory graph node", () => {
     cleanup();
   });
 
-  it("renders neutral dispatch chrome when outcome is missing", () => {
+  it("renders factory-style workstation identity without dispatch metadata", () => {
     render(
       <DispatchNode
         {...dispatchNodeProps({
@@ -61,40 +61,43 @@ describe("Trace dispatch factory graph node", () => {
       />,
     );
 
-    expect(screen.getByText("Observed")).toBeTruthy();
+    expect(screen.getByText("Workstation")).toBeTruthy();
+    expect(screen.queryByText("Observed")).toBeNull();
+    expect(screen.queryByText(/^In:/)).toBeNull();
+    expect(screen.queryByText(/^Out:/)).toBeNull();
     const node = screen.getByText("dispatch-pending").closest("article");
     if (!node) {
       throw new Error("Expected dispatch node shell to render.");
     }
-    expect(node.className).toContain("border-outline");
-    expect(node.className).toContain("bg-surface");
+    expect(node.className).toContain("border-primary");
+    expect(node.className).toContain("bg-primary-container");
   });
 
-  it("renders warning dispatch chrome for CONTINUE outcomes", () => {
+  it("keeps the factory workstation surface for failure outcomes", () => {
     render(
       <DispatchNode
         {...dispatchNodeProps({
           connectionAnchors: [],
-          dispatchId: "dispatch-continue",
-          displayLabel: "dispatch-continue",
-          factoryNodeId: "workstation:dispatch-continue",
+          dispatchId: "dispatch-failed",
+          displayLabel: "dispatch-failed",
+          factoryNodeId: "workstation:dispatch-failed",
           inputSummary: "None",
           kind: "workstation",
           kindLabel: "Workstation",
           locale: "en",
-          outcome: "CONTINUE",
+          outcome: "FAILED",
           outputSummary: "None",
-          workstationName: "dispatch-continue",
+          workstationName: "dispatch-failed",
         })}
       />,
     );
 
-    const node = screen.getByText("dispatch-continue").closest("article");
+    const node = screen.getByText("dispatch-failed").closest("article");
     if (!node) {
       throw new Error("Expected dispatch node shell to render.");
     }
-    expect(node.className).toContain("border-af-warning-border");
-    expect(node.className).toContain("bg-warning-container");
+    expect(node.className).toContain("border-primary");
+    expect(node.className).toContain("bg-primary-container");
   });
 });
 

--- a/ui/src/features/trace-drilldown/components/trace-graph-surfaces.stories.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-graph-surfaces.stories.tsx
@@ -92,3 +92,12 @@ export const VisualConsistency = {
     </div>
   ),
 };
+
+export const LocalizedZhCN = {
+  render: () => (
+    <div className="grid gap-4">
+      <TraceWorkstationPath dispatches={TRACE_DISPATCHES} locale="zh-CN" />
+      <TraceRelationFlow locale="zh-CN" relations={TRACE_RELATIONS} />
+    </div>
+  ),
+};

--- a/ui/src/features/trace-drilldown/components/trace-workstation-path.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-workstation-path.test.tsx
@@ -493,7 +493,7 @@ describe("TraceWorkstationPath layout", () => {
 });
 
 describe("TraceWorkstationPath semantics", () => {
-  it("renders semantic workstation path tones and muted supporting copy", async () => {
+  it("renders factory-style workstation identity without dispatch metadata", async () => {
     render(
       <TraceWorkstationPath
         dispatches={[
@@ -516,22 +516,23 @@ describe("TraceWorkstationPath semantics", () => {
 
     expect(screen.queryByText("Dispatch")).toBeNull();
     expect(screen.getAllByText("Workstation").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Accepted")).toBeNull();
+    expect(screen.queryByText("Failed")).toBeNull();
+    expect(screen.queryByText(/^In:/)).toBeNull();
+    expect(screen.queryByText(/^Out:/)).toBeNull();
 
     const acceptedNode = screen.getByText("dispatch-plan").closest("article");
     if (!acceptedNode) {
       throw new Error("Expected accepted workstation node to render.");
     }
-    expect(acceptedNode.className).toContain("border-af-success-border");
-    expect(acceptedNode.className).toContain("bg-success-container");
+    expect(acceptedNode.className).toContain("border-primary");
+    expect(acceptedNode.className).toContain("bg-primary-container");
 
     const failedNode = screen.getByText("dispatch-repair").closest("article");
     if (!failedNode) {
       throw new Error("Expected failed workstation node to render.");
     }
-    expect(failedNode.className).toContain("border-af-danger-border");
-    expect(failedNode.className).toContain("bg-error-container");
-
-    const inputSummary = screen.getAllByText(/^In:/)[0];
-    expect(inputSummary.className).toContain("text-on-surface-variant");
+    expect(failedNode.className).toContain("border-primary");
+    expect(failedNode.className).toContain("bg-primary-container");
   });
 });

--- a/ui/src/features/trace-drilldown/components/trace-workstation-path.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-workstation-path.test.tsx
@@ -377,6 +377,58 @@ describe("TraceWorkstationPath fallback lineage", () => {
   });
 });
 
+describe("TraceWorkstationPath localization", () => {
+  it("renders zh-CN graph chrome without changing workstation names", async () => {
+    render(
+      <TraceWorkstationPath
+        dispatches={[
+          buildDispatch("dispatch-plan", {
+            current_chaining_trace_id: "trace-plan-chain",
+            output_items: [
+              buildWorkItem("work-reviewed", {
+                current_chaining_trace_id: "trace-plan-chain",
+                display_name: "已审阅故事",
+              }),
+            ],
+            workstation_name: "计划",
+          }),
+          buildDispatch("dispatch-implement", {
+            input_items: [
+              buildWorkItem("work-reviewed", {
+                display_name: "已审阅故事",
+              }),
+            ],
+            previous_chaining_trace_ids: ["trace-plan-chain"],
+            workstation_name: "实现",
+          }),
+        ]}
+        locale="zh-CN"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen
+          .getByRole("region", { name: "分派关系图" })
+          .getAttribute("data-dashboard-graph-frame"),
+      ).toBe("true");
+    });
+
+    expect(screen.getByText("计划")).toBeTruthy();
+    expect(screen.getByText("实现")).toBeTruthy();
+    expect(
+      screen
+        .getByTestId("trace-react-flow-controls")
+        .getAttribute("data-fit-view-options"),
+    ).toBe(JSON.stringify({ maxZoom: 1.15, padding: 0.16 }));
+    expect(
+      screen
+        .getByTestId("trace-react-flow-controls")
+        .getAttribute("data-controls-style"),
+    ).toContain('"backgroundColor":"var(--color-surface)"');
+  });
+});
+
 describe("TraceWorkstationPath captured selections", () => {
   it("renders the captured trace-654e selection with seven dispatch nodes", async () => {
     render(

--- a/ui/src/features/trace-drilldown/lib/trace-dispatch-factory-graph.test.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-dispatch-factory-graph.test.ts
@@ -214,4 +214,35 @@ describe("projectTraceDispatchesToFactoryGraph overlays", () => {
       outputSummary: "(story):work-output",
     });
   });
+
+  it("preserves workstation display label fallbacks from transition ids and localized unknown copy", () => {
+    const projection = projectTraceDispatchesToFactoryGraph(
+      [
+        buildDispatch("dispatch-transition-fallback", {
+          transition_id: "review",
+          workstation_name: "   ",
+        }),
+        buildDispatch("dispatch-unknown-fallback", {
+          transition_id: "   ",
+          workstation_name: undefined,
+        }),
+      ],
+      "en",
+    );
+
+    expect(
+      projection.overlaysByNodeId.get(
+        projection.nodeIdByDispatchId.get("dispatch-transition-fallback") ?? "",
+      ),
+    ).toMatchObject({
+      displayLabel: "review",
+    });
+    expect(
+      projection.overlaysByNodeId.get(
+        projection.nodeIdByDispatchId.get("dispatch-unknown-fallback") ?? "",
+      ),
+    ).toMatchObject({
+      displayLabel: "Unknown workstation",
+    });
+  });
 });


### PR DESCRIPTION
{
  "project": "Trace Drill-Down Dispatch Flow Graph Standardization",
  "branchName": "ralph/trace-drilldown-workstation-graph-dispatch-flow",
  "description": "Standardize the trace drill-down dispatch flow graph so workstation nodes match factory-graph styling and name-first presentation, and zoom controls match the main factory graph.",
  "context": {
    "customerAsk": "The trace drilldown workstation graph dispatch flow is hard to use. It has too much text and weird formatting on the nodes. Standardize the formatting: use the same background colors as the factory graph, show only workstation names like the factory graph (not inputs and outputs), and share the same expand/shrink/focus buttons as the original graph.",
    "problem": "Dispatch-flow graph nodes stack outcome badges, input summaries, output summaries, and outcome-driven background colors. The result is text-heavy nodes that look different from factory-graph workstation nodes and are hard to scan.",
    "solution": "Render dispatch-flow workstation nodes with factory-graph workstation chrome and kind-based primary surface colors, removing input/output/outcome text from node bodies. Keep shared DashboardGraphControls zoom chrome (zoom in, zoom out, fit view) aligned with the factory graph, with tests and browser verification for the visible behavior."
  },
  "acceptanceCriteria": [
    "Dispatch-flow graph nodes show factory-style workstation identity (icon, kind label, workstation name) without input, output, or outcome badge text on the node body.",
    "Dispatch-flow workstation nodes use factory-graph workstation kind-based surface colors (primary container), not outcome-driven success/warning/danger/neutral backgrounds.",
    "Workstation name resolution and fallbacks behave the same as before the formatting change.",
    "Dispatch topology, edges, layout, drag-to-reposition, and empty-state handling do not regress.",
    "Dispatch-flow graph exposes zoom-in, zoom-out, and fit-view controls with the same dashboard graph control theming as the factory graph.",
    "Automated trace drill-down dispatch graph tests are updated to assert simplified nodes and control parity.",
    "Quality gate: typecheck, lint, and tests pass for the UI workspace."
  ],
  "userStories": [
    {
      "id": "trace-drilldown-workstaiton-graph-dispatch-flow-001",
      "title": "Align dispatch-flow nodes with factory-graph workstation presentation",
      "description": "As a dashboard operator viewing a trace's dispatch flow graph, I want workstation nodes to look like factory-graph workstation nodes so I can read the path without dense dispatch metadata on every node.",
      "acceptanceCriteria": [
        "Each dispatch-flow graph node renders the same visible workstation identity pattern as factory-graph workstation nodes: semantic workstation icon, localized kind label (for example Workstation), and the workstation display name.",
        "Nodes do not render visible outcome badges (for example Accepted, Observed, Failed).",
        "Nodes do not render visible input or output summary lines (for example In: …, Out: …).",
        "Workstation display names continue to resolve from dispatch payload fields with existing fallbacks (workstation_name, transition_id, localized unknown-workstation label).",
        "Dispatch-flow workstation nodes use factory-graph workstation surface styling (primary container / border-primary bg-primary-container) regardless of dispatch outcome.",
        "Nodes do not use outcome-driven surface colors (success, warning, danger, or neutral outcome fallback) for workstation backgrounds.",
        "Graph topology and edges between dispatches remain unchanged for the standard multi-dispatch test fixture.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "trace-drilldown-workstaiton-graph-dispatch-flow-002",
      "title": "Match factory-graph zoom controls on the dispatch-flow graph",
      "description": "As a dashboard operator, I want the dispatch flow graph to expose the same zoom controls as the factory graph so I can expand, shrink, and refocus the view consistently.",
      "acceptanceCriteria": [
        "The dispatch-flow graph renders React Flow zoom controls with zoom-in, zoom-out, and fit-view buttons inside the graph region.",
        "Zoom controls use the shared dashboard graph control styling (same CSS variable theming as the factory graph DashboardGraphControls surface).",
        "Clicking fit view reframes the dispatch-flow graph within the graph frame without layout breakage.",
        "The dispatch-flow graph retains its accessible region label, measured viewport behavior, and existing empty-state copy when no dispatches are present.",
        "The dispatch-flow graph remains visible and operable inside the trace drill-down card after expanding work items (no clipped or missing controls).",
        "Localized dispatch-flow graphs (for example zh-CN) still render workstation names correctly with the simplified node chrome.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
