### PR TITLE
trace-drill-down-relationship-cleanup

### DIFF
--- a/ui/integration/event-stream-replay.integration.test.mjs
+++ b/ui/integration/event-stream-replay.integration.test.mjs
@@ -37,7 +37,7 @@ async function waitForTickLabel(page, label) {
       state: "visible",
       timeout: uiInteractionTimeoutMs,
     });
-  } catch (error) {
+  } catch (_error) {
     const sliderValue = await page
       .getByRole("slider", { name: "Timeline tick" })
       .inputValue();
@@ -158,7 +158,7 @@ async function exerciseSelectedWorkTrace(page, workstationName, options = {}) {
   await workstationButton.scrollIntoViewIfNeeded();
   try {
     await workstationButton.click({ force: true });
-  } catch (error) {
+  } catch (_error) {
     // React Flow workstation buttons can remain visible while clipping leaves the
     // actionable box outside the viewport in CI. Fall back to the DOM click so
     // the test still verifies replay behavior after the button renders.

--- a/ui/scripts/ui-coverage-runner.mjs
+++ b/ui/scripts/ui-coverage-runner.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { performance } from "node:perf_hooks";
 
@@ -284,6 +284,8 @@ export function formatPhaseElapsed(phaseName, elapsedMs) {
 export function cleanCoverageArtifacts() {
   rmSync("coverage", { force: true, recursive: true });
   rmSync(".vitest-reports", { force: true, recursive: true });
+  mkdirSync("coverage/.tmp", { recursive: true });
+  mkdirSync(".vitest-reports", { recursive: true });
 }
 
 export function runTimedPhase(phase, spawn = spawnSync, options = {}) {

--- a/ui/scripts/ui-coverage-runner.test.mjs
+++ b/ui/scripts/ui-coverage-runner.test.mjs
@@ -1,4 +1,11 @@
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -8,6 +15,7 @@ import {
   buildMainCoveredShardPhase,
   buildUiCoverageMergePhases,
   buildUiCoveragePhases,
+  cleanCoverageArtifacts,
   defaultCapturedStdoutMaxBuffer,
   defaultMainCoveredMaxWorkers,
   defaultShardMainCoveredMaxWorkers,
@@ -231,6 +239,25 @@ test("buildUiCoverageMergePhases runs follow-on phases without the main pass", (
     "Blob report merge pass",
     "Standalone script-style test",
   ]);
+});
+
+test("cleanCoverageArtifacts recreates coverage temp and blob report directories", () => {
+  const cwd = process.cwd();
+  const tempDir = mkdtempSync(join(tmpdir(), "ui-coverage-clean-"));
+
+  try {
+    process.chdir(tempDir);
+    mkdirSync("coverage/old", { recursive: true });
+    mkdirSync(".vitest-reports/old", { recursive: true });
+
+    cleanCoverageArtifacts();
+
+    expect(existsSync("coverage/.tmp")).toBe(true);
+    expect(existsSync(".vitest-reports")).toBe(true);
+  } finally {
+    process.chdir(cwd);
+    rmSync(tempDir, { force: true, recursive: true });
+  }
 });
 
 test("findMissingShardBlobIndices reports absent shard blobs", () => {

--- a/ui/src/features/trace-drilldown/components/trace-factory-graph-nodes.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-factory-graph-nodes.test.tsx
@@ -103,7 +103,7 @@ describe("Trace relation factory graph node", () => {
     cleanup();
   });
 
-  it("renders work-type relation chrome with default tone when relation states are empty", () => {
+  it("renders only the work label while preserving neutral relation chrome", () => {
     render(
       <RelationNode
         {...relationNodeProps({
@@ -121,8 +121,9 @@ describe("Trace relation factory graph node", () => {
       />,
     );
 
-    expect(screen.getByText("Work type")).toBeTruthy();
-    expect(screen.getByText("Depends on")).toBeTruthy();
+    expect(screen.getByText("Story A")).toBeTruthy();
+    expect(screen.queryByText("Work type")).toBeNull();
+    expect(screen.queryByText("Depends on")).toBeNull();
     const node = screen.getByText("Story A").closest("article");
     if (!node) {
       throw new Error("Expected relation node shell to render.");
@@ -131,7 +132,7 @@ describe("Trace relation factory graph node", () => {
     expect(node.className).toContain("bg-surface");
   });
 
-  it("renders resource and worker relation semantic icons", () => {
+  it("does not render semantic icons or metadata badges for non-work nodes", () => {
     render(
       <RelationNode
         {...relationNodeProps({
@@ -148,9 +149,8 @@ describe("Trace relation factory graph node", () => {
         })}
       />,
     );
-    expect(
-      screen.getByLabelText("Worker").getAttribute("data-graph-semantic-icon"),
-    ).toBe("active-work");
+    expect(screen.getByText("Worker A")).toBeTruthy();
+    expect(screen.queryByLabelText("Worker")).toBeNull();
 
     cleanup();
 
@@ -170,11 +170,8 @@ describe("Trace relation factory graph node", () => {
         })}
       />,
     );
-    expect(
-      screen
-        .getByLabelText("Resource")
-        .getAttribute("data-graph-semantic-icon"),
-    ).toBe("resource");
+    expect(screen.getByText("GPU")).toBeTruthy();
+    expect(screen.queryByLabelText("Resource")).toBeNull();
   });
 
   it("invokes onSelectWorkID for selectable relation endpoints", () => {
@@ -201,9 +198,8 @@ describe("Trace relation factory graph node", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Story B" }));
     expect(onSelectWorkID).toHaveBeenCalledWith("work-b");
-    expect(screen.getByText("Failed").className).toContain(
-      "bg-error-container",
-    );
+    expect(screen.queryByText("Failed")).toBeNull();
+    expect(screen.queryByText("Retry")).toBeNull();
     const node = screen.getByText("Story B").closest("article");
     if (!node) {
       throw new Error("Expected relation node shell to render.");

--- a/ui/src/features/trace-drilldown/components/trace-factory-graph-nodes.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-factory-graph-nodes.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { NodeProps } from "@xyflow/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -174,8 +175,9 @@ describe("Trace relation factory graph node", () => {
     expect(screen.queryByLabelText("Resource")).toBeNull();
   });
 
-  it("invokes onSelectWorkID for selectable relation endpoints", () => {
+  it("invokes onSelectWorkID for selectable relation endpoints", async () => {
     const onSelectWorkID = vi.fn();
+    const user = userEvent.setup();
 
     render(
       <RelationNode
@@ -196,8 +198,15 @@ describe("Trace relation factory graph node", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Story B" }));
-    expect(onSelectWorkID).toHaveBeenCalledWith("work-b");
+    const button = screen.getByRole("button", { name: "Story B" });
+    fireEvent.click(button);
+    button.focus();
+    await user.keyboard("{Enter}");
+    await user.keyboard(" ");
+
+    expect(onSelectWorkID).toHaveBeenNthCalledWith(1, "work-b");
+    expect(onSelectWorkID).toHaveBeenNthCalledWith(2, "work-b");
+    expect(onSelectWorkID).toHaveBeenNthCalledWith(3, "work-b");
     expect(screen.queryByText("Failed")).toBeNull();
     expect(screen.queryByText("Retry")).toBeNull();
     const node = screen.getByText("Story B").closest("article");

--- a/ui/src/features/trace-drilldown/components/trace-relation-factory-graph-node.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-relation-factory-graph-node.tsx
@@ -4,7 +4,6 @@ import { GraphNodeButton } from "../../../components/ui/graph-node-button";
 import { cn } from "../../../lib/cn";
 import type { FactoryGraphNodeKind } from "../../factory-graph-editor/lib/factory-graph-draft-types";
 import {
-  ActivityGraphNodeBadge,
   activityGraphNodeSurfaceClassName,
   activityGraphNodeTitleClassName,
 } from "../../flowchart/components/current-activity-node-chrome";
@@ -12,10 +11,7 @@ import {
   ActivityGraphNodeShell,
   type PlaceNodeType,
 } from "../../flowchart/components/current-activity-node-shell";
-import type { GraphSemanticIconKind } from "../../flowchart/components/graph-semantic-icon";
-import { GraphSemanticIcon } from "../../flowchart/components/graph-semantic-icon";
 import type { TraceRelationFlowNode } from "../lib/trace-relation-factory-graph-flow";
-import { getTraceDrilldownMessages } from "../messages/trace-drilldown";
 
 const RELATION_NODE_ACTIVE_CLASS =
   "hover:border-primary hover:bg-primary-container";
@@ -25,7 +21,6 @@ const RELATION_NODE_CLASS =
 function TraceRelationFactoryGraphNode({
   data,
 }: NodeProps<TraceRelationFlowNode>) {
-  const messages = getTraceDrilldownMessages(data.locale);
   const shellClassName = cn(
     RELATION_NODE_CLASS,
     relationNodeToneClassName(data.relationStates),
@@ -40,41 +35,7 @@ function TraceRelationFactoryGraphNode({
       }))}
       nodeType={relationShellNodeType(data.kind)}
     >
-      <div className="grid h-full min-w-0 content-start gap-2">
-        <div className="flex flex-wrap items-center gap-1.5">
-          <span
-            className="flex min-h-5 shrink-0 items-center"
-            data-factory-entity-semantic-icon
-            title={data.kindLabel}
-          >
-            <GraphSemanticIcon
-              className={cn("h-4 w-4", semanticIconClassName(data.kind))}
-              kind={semanticIconKind(data.kind)}
-              label={data.kindLabel}
-            />
-          </span>
-          <ActivityGraphNodeBadge weight="label">
-            {data.kindLabel}
-          </ActivityGraphNodeBadge>
-          {data.relationTypes.slice(0, 1).map((relationType) => (
-            <ActivityGraphNodeBadge
-              key={relationType}
-              tone="info"
-              weight="label"
-            >
-              {messages.localizeRelationType(relationType)}
-            </ActivityGraphNodeBadge>
-          ))}
-          {data.relationStates.slice(0, 1).map((relationState) => (
-            <ActivityGraphNodeBadge
-              key={relationState}
-              tone={relationStateToneClassName(relationState)}
-              weight="label"
-            >
-              {messages.localizeRelationState(relationState)}
-            </ActivityGraphNodeBadge>
-          ))}
-        </div>
+      <div className="grid h-full min-w-0 content-center">
         <DashboardText
           className={cn(
             "m-0 [overflow-wrap:anywhere]",
@@ -124,36 +85,6 @@ function relationShellNodeType(
       return "resource";
     case "worker":
       return "worker";
-  }
-}
-
-function semanticIconKind(kind: FactoryGraphNodeKind): GraphSemanticIconKind {
-  switch (kind) {
-    case "resource":
-      return "resource";
-    case "worker":
-      return "active-work";
-    case "workstation":
-      return "workstation";
-    case "work-type":
-      return "constraint";
-    case "work-state":
-      return "queue";
-  }
-}
-
-function semanticIconClassName(kind: FactoryGraphNodeKind): string {
-  switch (kind) {
-    case "resource":
-      return "text-success";
-    case "worker":
-      return "text-info";
-    case "workstation":
-      return "text-on-surface";
-    case "work-type":
-      return "text-info";
-    case "work-state":
-      return "text-on-surface-variant";
   }
 }
 

--- a/ui/src/features/trace-drilldown/components/trace-relation-flow.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-relation-flow.test.tsx
@@ -390,9 +390,16 @@ describe("TraceRelationFlow localization", () => {
 
     expect(screen.getByText("Review story")).toBeTruthy();
     expect(screen.getByText("Fix story")).toBeTruthy();
+    expect(screen.queryByText("派生自")).toBeNull();
+    expect(screen.queryByText("未知状态：escalated_review")).toBeNull();
     expect(renderedEdges()[0]?.ariaLabel).toBe(
       "派生自关系：从 Review story 到 Fix story，要求 未知状态：escalated_review",
     );
+    expect(renderedEdges()[0]?.style).toMatchObject({
+      stroke: "var(--color-on-warning-container)",
+      strokeDasharray: "7 5",
+      strokeWidth: 2,
+    });
   });
 
   it("renders fallback node labels when relation names are missing", async () => {

--- a/ui/src/features/trace-drilldown/components/trace-relation-flow.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-relation-flow.test.tsx
@@ -283,11 +283,11 @@ describe("TraceRelationFlow", () => {
     }
     expect(implementNode.className).toContain("border-af-success-border");
     expect(implementNode.className).toContain("bg-success-container");
-    expect(within(implementButton).getByText("Parent-child")).toBeTruthy();
-    expect(within(implementButton).getByText("Done")).toBeTruthy();
-    expect(screen.queryByText("Work items")).toBeNull();
-    expect(screen.getAllByText("Work state").length).toBeGreaterThan(0);
-    expect(screen.getByText("Failed")).toBeTruthy();
+    expect(within(implementButton).getByText("Implement story")).toBeTruthy();
+    expect(screen.queryByText("Parent-child")).toBeNull();
+    expect(screen.queryByText("Done")).toBeNull();
+    expect(screen.queryByText("Work state")).toBeNull();
+    expect(screen.queryByText("Failed")).toBeNull();
 
     fireEvent.click(implementButton);
     expect(onSelectWorkID).toHaveBeenCalledWith("work-implement");
@@ -388,12 +388,35 @@ describe("TraceRelationFlow localization", () => {
       expect(screen.getByRole("region", { name: "批次关系图" })).toBeTruthy();
     });
 
-    expect(screen.getAllByText("派生自").length).toBeGreaterThan(0);
-    expect(
-      screen.getAllByText("未知状态：escalated_review").length,
-    ).toBeGreaterThan(0);
+    expect(screen.getByText("Review story")).toBeTruthy();
+    expect(screen.getByText("Fix story")).toBeTruthy();
     expect(renderedEdges()[0]?.ariaLabel).toBe(
       "派生自关系：从 Review story 到 Fix story，要求 未知状态：escalated_review",
     );
+  });
+
+  it("renders fallback node labels when relation names are missing", async () => {
+    render(
+      <TraceRelationFlow
+        locale="zh-CN"
+        relations={[
+          {
+            request_id: "request-missing-source-name",
+            source_work_id: "",
+            source_work_name: "",
+            target_work_id: "work-target",
+            target_work_name: "",
+            type: "RELATED_TO",
+          },
+        ]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("region", { name: "批次关系图" })).toBeTruthy();
+    });
+
+    expect(screen.getByText("未知来源")).toBeTruthy();
+    expect(screen.getByText("work-target")).toBeTruthy();
   });
 });


### PR DESCRIPTION
{
  "project": "Trace Drill-Down Relationship Graph Node Cleanup",
  "branchName": "ralph/trace-drill-down-relationship-cleanup",
  "description": "Simplify trace drill-down work relationship graph nodes to show only the work name, removing dense badge and icon metadata from node bodies while preserving edge semantics and work selection.",
  "context": {
    "customerAsk": "The trace drill work relationship graph has too much text on it. Make the nodes for the work to just expose the \"name\" of the work, rather than anything else.",
    "problem": "Trace drill-down relation graph nodes currently stack kind, relation-type, relation-state badges, semantic icons, and the work name. The resulting text density makes the graph hard to scan and obscures which work items are connected.",
    "solution": "Render only the work display name as visible text in each relationship-graph node. Keep relation meaning on edges (stroke, dash, accessible labels) and preserve existing selection, layout, and name-fallback behavior without backend or API changes."
  },
  "acceptanceCriteria": [
    "Work relationship graph nodes in trace drill-down show only the work display name as visible text—no kind, relation-type, relation-state badges, or semantic icons in the node body.",
    "Work name resolution and fallbacks (work ID or localized unknown-source label when name is missing) behave the same as before the cleanup.",
    "Clicking a selectable work node still selects the correct work item.",
    "Relation edges continue to convey type and required-state semantics through stroke styling and accessible edge labels.",
    "Automated trace drill-down relation graph tests are updated to assert the simplified node presentation and unchanged interactions.",
    "No regressions to trace drill-down loading, empty, or error states outside the populated relation-graph node presentation.",
    "Quality gate: typecheck, lint, and tests pass for the UI workspace."
  ],
  "userStories": [
    {
      "id": "trace-drill-down-relationship-cleanup-001",
      "title": "Show only work name in relation graph nodes",
      "description": "As a dashboard operator viewing a trace's work relationship graph, I want each node to show only the work name so I can scan the graph without reading redundant metadata.",
      "acceptanceCriteria": [
        "Each node in the trace drill-down work relationship graph renders exactly one visible text label: the work display name.",
        "Nodes do not render visible kind labels (for example Work type, Work state, Worker, Resource).",
        "Nodes do not render visible relation-type badges (for example Parent-child, Depends on, Retry).",
        "Nodes do not render visible relation-state badges (for example Done, Failed).",
        "Nodes do not render visible semantic entity icons in the node body.",
        "When a work name is missing, the node shows the existing fallback label (work ID or localized unknown-source text), not an empty node.",
        "Selectable nodes remain keyboard-activatable buttons with an accessible name matching the displayed work label.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "trace-drill-down-relationship-cleanup-002",
      "title": "Preserve relation graph interactions and edge semantics after node simplification",
      "description": "As a dashboard operator, I want the simplified graph to remain usable so I can still select work items and understand how they relate.",
      "acceptanceCriteria": [
        "Clicking a selectable work node invokes work selection with the correct work_id.",
        "Relation edges continue to render with existing stroke color and dash patterns for relation type and required state.",
        "Edge accessible names continue to describe the relation (source name, target name, relation type, required state when present).",
        "The relationship graph region retains its existing accessible region label and graph frame chrome.",
        "Localized relation graphs (for example zh-CN) render work names correctly while node bodies remain name-only.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
