### PR TITLE
interfaces-work-content-clone-helper-collapse

### DIFF
--- a/pkg/interfaces/work_dispatch.go
+++ b/pkg/interfaces/work_dispatch.go
@@ -212,7 +212,7 @@ func CloneResolvedModelOperationBindings(values []ResolvedModelOperationBinding)
 		cloned[i] = ResolvedModelOperationBinding{
 			Slot:    value.Slot,
 			Source:  value.Source,
-			Content: cloneWorkContentParts(value.Content),
+			Content: CloneWorkContentParts(value.Content),
 		}
 	}
 	return cloned

--- a/pkg/interfaces/work_payload_lineage.go
+++ b/pkg/interfaces/work_payload_lineage.go
@@ -338,7 +338,7 @@ func cloneLineageSnapshot(snapshot WorkPayloadSnapshot) WorkPayloadSnapshot {
 
 func cloneLineageWorkItem(item FactoryWorkItem) FactoryWorkItem {
 	item.PreviousChainingTraceIDs = cloneStringSlice(item.PreviousChainingTraceIDs)
-	item.Content = cloneWorkContentParts(item.Content)
+	item.Content = CloneWorkContentParts(item.Content)
 	item.Tags = cloneStringMap(item.Tags)
 	return item
 }

--- a/pkg/interfaces/work_runtime_test.go
+++ b/pkg/interfaces/work_runtime_test.go
@@ -588,6 +588,26 @@ func TestCloneProviderInferenceRequest_DetachesProviderFields(t *testing.T) {
 	}
 }
 
+func TestWorkPayloadLineageProjection_RecordWorkRequestSnapshotDetachesContent(t *testing.T) {
+	t.Parallel()
+
+	projection := WorkPayloadLineageProjection{}
+	original := FactoryWorkItem{
+		ID:      "work-1",
+		Content: []WorkContentPart{{Type: WorkContentPartTypeText, Text: "hello"}},
+		Tags:    map[string]string{"origin": "request"},
+	}
+
+	projection.RecordWorkRequestSnapshot(7, "request-1", original)
+	snapshotID := projection.InitialSnapshotIDByWorkID[original.ID]
+	snapshot := projection.SnapshotsByID[snapshotID]
+	snapshot.WorkItem.Content[0].Text = "changed"
+
+	if original.Content[0].Text != "hello" {
+		t.Fatalf("work item content mutated original: %#v", original.Content)
+	}
+}
+
 func testWorkDispatch() WorkDispatch {
 	return WorkDispatch{
 		DispatchID:             "dispatch-1",

--- a/pkg/interfaces/world_state_clones.go
+++ b/pkg/interfaces/world_state_clones.go
@@ -54,10 +54,6 @@ func CloneWorkContentParts(parts []WorkContentPart) []WorkContentPart {
 	return clone
 }
 
-func cloneWorkContentParts(parts []WorkContentPart) []WorkContentPart {
-	return CloneWorkContentParts(parts)
-}
-
 // CloneTokenHistory returns a detached copy of canonical runtime token history.
 func CloneTokenHistory(history TokenHistory) TokenHistory {
 	return TokenHistory{


### PR DESCRIPTION
{
  "project": "Collapse Redundant Work-Content Clone Helper",
  "branchName": "ralph/interfaces-work-content-clone-helper-collapse",
  "description": "Remove the redundant private cloneWorkContentParts passthrough in pkg/interfaces and route internal work-dispatch and payload-lineage call sites through the canonical CloneWorkContentParts helper, preserving detached-copy semantics with no runtime, API, or CLI behavior changes.",
  "context": {
    "customerAsk": "Remove the redundant package-local cloneWorkContentParts(...) passthrough in pkg/interfaces and route the remaining internal call sites directly through the canonical CloneWorkContentParts(...) helper.",
    "problem": "pkg/interfaces currently maintains both a public CloneWorkContentParts helper and a private cloneWorkContentParts passthrough that adds no behavior. The duplicate path increases maintenance surface inside a shared contract boundary and is used only by CloneResolvedModelOperationBindings and payload-lineage item cloning.",
    "solution": "Update work_dispatch.go and work_payload_lineage.go to call CloneWorkContentParts(...) directly, delete the private passthrough from world_state_clones.go, and rely on existing clone/runtime and payload-lineage projection tests to prove detachment contracts are unchanged."
  },
  "acceptanceCriteria": [
    "pkg/interfaces exposes exactly one work-content clone helper for []WorkContentPart: CloneWorkContentParts(...)",
    "No cloneWorkContentParts(...) symbol remains in pkg/interfaces",
    "CloneResolvedModelOperationBindings(...) still returns detached copies where mutating cloned binding content does not affect the original input slice",
    "Payload lineage work-item cloning still returns detached copies where mutating cloned work-item content does not affect the original input slice",
    "No runtime, API, or CLI observable behavior changes are introduced",
    "Existing clone/runtime and payload-lineage projection tests continue to pass without adding file-layout or package-inventory assertions",
    "Backend typecheck, lint, and focused test suites pass (quality gate)"
  ],
  "userStories": [
    {
      "id": "interfaces-work-content-clone-helper-collapse-001",
      "title": "Route internal clone call sites through canonical helper",
      "description": "As a backend maintainer, I want work-dispatch binding cloning and payload-lineage item cloning to call CloneWorkContentParts(...) directly so internal code uses the same public clone contract as the rest of the package.",
      "acceptanceCriteria": [
        "CloneResolvedModelOperationBindings(...) in pkg/interfaces/work_dispatch.go clones binding Content via CloneWorkContentParts(...) instead of cloneWorkContentParts(...)",
        "cloneLineageWorkItem(...) in pkg/interfaces/work_payload_lineage.go clones work-item Content via CloneWorkContentParts(...) instead of cloneWorkContentParts(...)",
        "Mutating cloned model-binding content in TestCloneProviderInferenceRequest_DetachesProviderFields still leaves the original binding content unchanged",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-work-content-clone-helper-collapse-002",
      "title": "Remove redundant passthrough wrapper",
      "description": "As a backend maintainer, I want the private cloneWorkContentParts(...) passthrough removed so pkg/interfaces owns one canonical work-content clone helper.",
      "acceptanceCriteria": [
        "The cloneWorkContentParts(...) function is deleted from pkg/interfaces/world_state_clones.go",
        "A repo-wide search finds no remaining references to cloneWorkContentParts in production code",
        "CloneWorkContentParts(...) remains the sole helper for cloning []WorkContentPart and still returns nil for empty input and a detached slice copy otherwise",
        "Existing pkg/interfaces clone/runtime tests that cover detached mutable fields (including token color content) continue to pass",
        "Existing payload-lineage projection tests that exercise cloned work content in downstream projections continue to pass",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
