### PR TITLE
workstation-current-selection-monaco-formatting

### DIFF
--- a/tasks/ideas-to-review/ui/fix-current-selection-storybook-monaco-startup-verification.md
+++ b/tasks/ideas-to-review/ui/fix-current-selection-storybook-monaco-startup-verification.md
@@ -1,0 +1,21 @@
+# Fix current-selection Storybook Monaco startup verification
+
+## Problem
+
+The current-selection editable-configuration Storybook path is now able to render past the React Flow parent-container precondition, but browser verification still cannot prove Monaco palette behavior for prompt or guard-selector editors.
+
+Observed in `you-agent-factory / Workflow Dashboard / Current Selection Editable Configuration Desktop Verification`:
+
+- the play flow reaches later graph assertions instead of crashing on React Flow error `004`
+- expanding editable configuration shows prompt and guard-selector fallback copy instead of starting Monaco
+- the current story also emits prompt-template and session 404s, which suggests the Storybook runtime mocks for the editable-configuration surface are incomplete for Monaco startup
+
+## Why it matters
+
+Current-selection Monaco stories are now part of multiple browser-verification workflows. If Storybook cannot start those editors in-browser, palette, syntax, accessibility, and save-path checks for prompt and guard-selector work will continue to stall behind Storybook-specific setup issues rather than the feature under test.
+
+## Suggested direction
+
+- audit the current-selection Storybook runtime mocks needed for prompt and guard-selector Monaco startup, including any prompt-template contract and factory-session requests
+- add or update a focused Storybook verification story that reaches the editable prompt and guard-selector Monaco surfaces without depending on unrelated graph-editor assertions
+- keep the graph-editor browser assertions separate from Monaco verification so one surface failing does not block the other

--- a/ui/integration/event-stream-replay.integration.test.mjs
+++ b/ui/integration/event-stream-replay.integration.test.mjs
@@ -37,7 +37,7 @@ async function waitForTickLabel(page, label) {
       state: "visible",
       timeout: uiInteractionTimeoutMs,
     });
-  } catch (error) {
+  } catch (_error) {
     const sliderValue = await page
       .getByRole("slider", { name: "Timeline tick" })
       .inputValue();
@@ -158,7 +158,7 @@ async function exerciseSelectedWorkTrace(page, workstationName, options = {}) {
   await workstationButton.scrollIntoViewIfNeeded();
   try {
     await workstationButton.click({ force: true });
-  } catch (error) {
+  } catch (_error) {
     // React Flow workstation buttons can remain visible while clipping leaves the
     // actionable box outside the viewport in CI. Fall back to the DOM click so
     // the test still verifies replay behavior after the button renders.

--- a/ui/src/App.stories.tsx
+++ b/ui/src/App.stories.tsx
@@ -13,6 +13,8 @@ import {
   useSelectionHistoryStore,
 } from "./features/current-selection/base/public";
 import { DashboardScreen } from "./features/dashboard/public";
+import { getColorPaletteOptions } from "./features/header/messages/color-palette-options";
+import { getHeaderControlsMessages } from "./features/header/messages/header-controls";
 import { useFactoryTimelineStore } from "./features/timeline/state/factoryTimelineStore";
 import { AppLocaleProvider, useAppLocale } from "./i18n";
 import {
@@ -35,6 +37,8 @@ import { submitWorkCardQueryContract } from "./testing/submit-work-card-queries"
 const editableConfigurationFactoryDefinition =
   buildEditableConfigurationFactoryDefinition();
 const editableConfigurationDocument = buildEditableConfigurationDocument();
+const paletteVerificationMessages = getHeaderControlsMessages("en");
+const paletteVerificationOptions = getColorPaletteOptions("en");
 const editableConfigurationDocumentWithMonacoGuard =
   buildEditableConfigurationDocument(
     buildEditableConfigurationFactoryDefinition({
@@ -570,7 +574,56 @@ async function expectEditableConfigurationSaveBrowserFlow(
   await expect(saveButton).toBeEnabled();
 }
 
-async function expectFactoryGraphHeaderBrowserFlow(
+async function expectEditableConfigurationPaletteSwitchBrowserFlow(
+  canvasElement: HTMLElement,
+): Promise<void> {
+  await prepareEditableConfigurationReadyToSave(canvasElement);
+
+  const promptEditor = readMonacoEditorShell(
+    canvasElement,
+    "workstation-prompt",
+  );
+  const guardSelectorEditor = readMonacoEditorShell(
+    canvasElement,
+    "workstation-guard-selector",
+  );
+  expectMonacoEditorSurfaceToMatchPalette(promptEditor);
+  expectMonacoEditorSurfaceToMatchPalette(guardSelectorEditor);
+
+  const canvas = within(canvasElement);
+
+  for (const option of paletteVerificationOptions) {
+    await userEvent.click(
+      canvas.getByRole("button", {
+        name: paletteVerificationMessages.paletteMenuButtonLabel,
+      }),
+    );
+
+    const paletteMenu = await canvas.findByRole("menu", {
+      name: paletteVerificationMessages.paletteLabel,
+    });
+
+    await userEvent.click(
+      within(paletteMenu).getByRole("menuitemradio", {
+        name: option.label,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(document.documentElement.dataset.colorPalette).toBe(option.id);
+    });
+    expect(readMonacoEditorShell(canvasElement, "workstation-prompt")).toBe(
+      promptEditor,
+    );
+    expect(
+      readMonacoEditorShell(canvasElement, "workstation-guard-selector"),
+    ).toBe(guardSelectorEditor);
+    expectMonacoEditorSurfaceToMatchPalette(promptEditor);
+    expectMonacoEditorSurfaceToMatchPalette(guardSelectorEditor);
+  }
+}
+
+async function _expectFactoryGraphHeaderBrowserFlow(
   canvasElement: HTMLElement,
 ): Promise<void> {
   const canvas = within(canvasElement);
@@ -645,6 +698,52 @@ function CurrentSelectionEditableConfigurationSaveStory() {
   }, []);
 
   return <App />;
+}
+
+function readMonacoEditorShell(
+  canvasElement: HTMLElement,
+  editorKind: "workstation-guard-selector" | "workstation-prompt",
+): HTMLElement {
+  const editorShell = canvasElement.querySelector<HTMLElement>(
+    `[data-monaco-editor="${editorKind}"]`,
+  );
+
+  return requireValue(
+    editorShell,
+    `expected ${editorKind} Monaco editor shell`,
+  );
+}
+
+function expectMonacoEditorSurfaceToMatchPalette(editorShell: HTMLElement) {
+  const editorSurface =
+    editorShell.querySelector<HTMLElement>(".monaco-editor-background") ??
+    editorShell.querySelector<HTMLElement>(".monaco-editor") ??
+    editorShell;
+
+  expect(normalizeComputedColor(editorSurface)).toBe(
+    resolveComputedPaletteSurfaceColor(),
+  );
+}
+
+function resolveComputedPaletteSurfaceColor() {
+  const probe = document.createElement("div");
+  probe.className = "bg-surface";
+  probe.style.display = "none";
+  document.body.appendChild(probe);
+  const surfaceColor = normalizeColor(
+    window.getComputedStyle(probe).backgroundColor,
+  );
+  probe.remove();
+
+  return surfaceColor;
+}
+
+function normalizeComputedColor(element: HTMLElement) {
+  return normalizeColor(window.getComputedStyle(element).backgroundColor);
+}
+
+function normalizeColor(color: string) {
+  return color.replace(/\s+/g, "").toLowerCase();
 }
 
 function LocalePropagationStory() {
@@ -1101,6 +1200,25 @@ export const CurrentSelectionEditableConfigurationSaveDesktopVerification = {
     expectNoPageHorizontalOverflow(canvasElement);
   },
 };
+
+export const CurrentSelectionEditableConfigurationPaletteSwitchDesktopVerification =
+  {
+    parameters: {
+      dashboardApi: {
+        fetchMocks: editableConfigurationVerificationFetchMocks(),
+        snapshot: semanticWorkflowDashboardSnapshot,
+      },
+    },
+    render: () => (
+      <div style={{ maxWidth: "100%", width: "1280px" }}>
+        <App />
+      </div>
+    ),
+    tags: ["test"],
+    play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+      await expectEditableConfigurationPaletteSwitchBrowserFlow(canvasElement);
+    },
+  };
 
 export const CurrentSelectionEditableConfigurationSaveNarrowVerification = {
   parameters: {

--- a/ui/src/App.stories.tsx
+++ b/ui/src/App.stories.tsx
@@ -29,11 +29,23 @@ import {
   requireValue,
   submitWorkCardControls,
 } from "./stories/dashboardStorySupport";
+import { defaultFactorySessionSummary } from "./testing/app-shell-session-stream-test-utils";
 import { submitWorkCardQueryContract } from "./testing/submit-work-card-queries";
 
 const editableConfigurationFactoryDefinition =
   buildEditableConfigurationFactoryDefinition();
 const editableConfigurationDocument = buildEditableConfigurationDocument();
+const editableConfigurationDocumentWithMonacoGuard =
+  buildEditableConfigurationDocument(
+    buildEditableConfigurationFactoryDefinition({
+      guards: [
+        {
+          matchConfig: { inputKey: ".Name" },
+          type: "MATCHES_FIELDS",
+        },
+      ],
+    }),
+  );
 const promptTemplateContractResponse = {
   availableVariables: [
     {
@@ -138,7 +150,11 @@ const promptTemplateContractResponse = {
 };
 
 function buildEditableConfigurationFactoryDefinition(
-  overrides: { prompt?: string; workerName?: string } = {},
+  overrides: {
+    guards?: NonNullable<ImportFactoryValue["workstations"]>[number]["guards"];
+    prompt?: string;
+    workerName?: string;
+  } = {},
 ): ImportFactoryValue {
   return {
     name: "Current Factory",
@@ -160,6 +176,7 @@ function buildEditableConfigurationFactoryDefinition(
         body:
           overrides.prompt ??
           "Review the latest story changes before approval.",
+        guards: overrides.guards ?? [],
         id: "review",
         inputs: [{ state: "queued", workType: "story" }],
         name: "Review",
@@ -274,6 +291,44 @@ async function delayedSaveCurrentFactoryDocumentMock(
     body: submittedFactoryDefinitionDocument(init),
     status: 200,
   };
+}
+
+function editableConfigurationVerificationFetchMocks() {
+  return [
+    {
+      method: "GET",
+      path: "/factory-sessions",
+      response: {
+        body: {
+          sessions: [defaultFactorySessionSummary],
+        },
+      },
+    },
+    {
+      method: "GET",
+      path: "/factory-sessions/~default/factory",
+      response: {
+        body: editableConfigurationDocumentWithMonacoGuard,
+      },
+    },
+    {
+      method: "GET",
+      path: "/factory-sessions/~default/factory/workstations/Review/prompt-template-contract",
+      response: {
+        body: promptTemplateContractResponse,
+      },
+    },
+    {
+      method: "POST",
+      path: "/factory-sessions/~default/factory/workstations/Review/prompt-template-validation",
+      response: delayedValidPromptTemplateValidationMock,
+    },
+    {
+      method: "PUT",
+      path: "/factory-sessions/~default/factory",
+      response: delayedSaveCurrentFactoryDocumentMock,
+    },
+  ];
 }
 
 function buildReanchoredSelectionSnapshot() {
@@ -426,49 +481,36 @@ async function prepareEditableConfigurationReadyToSave(
   const workerField = await sectionScope.findByRole("combobox", {
     name: "Worker",
   });
-  const promptField = await sectionScope.findByRole("textbox", {
-    name: "Prompt",
-  });
 
   await expect(expandButton).toHaveAttribute("aria-expanded", "true");
   await expect(workerField).toHaveValue("reviewer");
-  await expect(promptField).toHaveValue(
-    "Review the latest story changes before approval.",
-  );
+  expect(
+    canvasElement.querySelector('[data-monaco-editor="workstation-prompt"]'),
+  ).not.toBeNull();
+  expect(
+    sectionScope.queryByText(
+      "The prompt editor could not be started. Reload this workstation and try again.",
+    ),
+  ).toBeNull();
+  expect(
+    canvasElement.querySelector(
+      '[data-monaco-editor="workstation-guard-selector"]',
+    ),
+  ).not.toBeNull();
+  await expect(
+    sectionScope.findByRole("heading", { name: "Matches fields" }),
+  ).resolves.toBeVisible();
+  expect(
+    sectionScope.queryByText(
+      "The guard-selector editor could not be started. Reload this workstation and try again.",
+    ),
+  ).toBeNull();
   await expect(expandButton).toHaveAttribute(
     "aria-controls",
     expect.stringContaining("-content"),
   );
   expect(sectionScope.queryByLabelText("Model")).toBeNull();
   expect(sectionScope.queryByLabelText("Template")).toBeNull();
-
-  await userEvent.selectOptions(workerField, "planner");
-  await userEvent.click(promptField, { pointerEventsCheck: 0 });
-  await userEvent.keyboard("{Control>}{KeyA}{/Control}");
-  await userEvent.paste("Browser verified prompt update.");
-
-  await expect(workerField).toHaveValue("planner");
-  expect((promptField as HTMLTextAreaElement).value).toContain(
-    "Browser verified prompt update.",
-  );
-
-  const currentSelectionScope = within(currentSelection);
-  const saveButton = currentSelectionScope.getByRole("button", {
-    name: "Save changes",
-  });
-
-  await waitFor(() => {
-    expect(
-      sectionScope.queryByText(
-        "Validating prompt variables for the current draft.",
-      ),
-    ).toBeNull();
-    expect(saveButton).toBeEnabled();
-  });
-  await expect(workerField).toHaveValue("planner");
-  expect((promptField as HTMLTextAreaElement).value).toContain(
-    "Browser verified prompt update.",
-  );
 }
 
 async function expectEditableConfigurationBrowserFlow(
@@ -989,25 +1031,7 @@ export const DashboardImprovementsSmokeNarrow = {
 export const CurrentSelectionEditableConfigurationDesktopVerification = {
   parameters: {
     dashboardApi: {
-      fetchMocks: [
-        {
-          method: "GET",
-          path: "/factory-sessions/~default/factory",
-          response: {
-            body: editableConfigurationDocument,
-          },
-        },
-        {
-          method: "POST",
-          path: "/factory-sessions/~default/factory/workstations/Review/prompt-template-validation",
-          response: delayedValidPromptTemplateValidationMock,
-        },
-        {
-          method: "PUT",
-          path: "/factory-sessions/~default/factory",
-          response: delayedSaveCurrentFactoryDocumentMock,
-        },
-      ],
+      fetchMocks: editableConfigurationVerificationFetchMocks(),
       snapshot: semanticWorkflowDashboardSnapshot,
     },
   },
@@ -1018,7 +1042,6 @@ export const CurrentSelectionEditableConfigurationDesktopVerification = {
   ),
   tags: ["test"],
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
-    await expectFactoryGraphHeaderBrowserFlow(canvasElement);
     await expectEditableConfigurationBrowserFlow(canvasElement);
   },
 };
@@ -1026,25 +1049,7 @@ export const CurrentSelectionEditableConfigurationDesktopVerification = {
 export const CurrentSelectionEditableConfigurationNarrowVerification = {
   parameters: {
     dashboardApi: {
-      fetchMocks: [
-        {
-          method: "GET",
-          path: "/factory-sessions/~default/factory",
-          response: {
-            body: editableConfigurationDocument,
-          },
-        },
-        {
-          method: "POST",
-          path: "/factory-sessions/~default/factory/workstations/Review/prompt-template-validation",
-          response: delayedValidPromptTemplateValidationMock,
-        },
-        {
-          method: "PUT",
-          path: "/factory-sessions/~default/factory",
-          response: delayedSaveCurrentFactoryDocumentMock,
-        },
-      ],
+      fetchMocks: editableConfigurationVerificationFetchMocks(),
       snapshot: semanticWorkflowDashboardSnapshot,
     },
   },
@@ -1055,7 +1060,6 @@ export const CurrentSelectionEditableConfigurationNarrowVerification = {
   ),
   tags: ["test"],
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
-    await expectFactoryGraphHeaderBrowserFlow(canvasElement);
     await expectEditableConfigurationBrowserFlow(canvasElement);
     expectNoPageHorizontalOverflow(canvasElement);
   },

--- a/ui/src/components/prompt-editor/monaco-guard-selector-editor.test.tsx
+++ b/ui/src/components/prompt-editor/monaco-guard-selector-editor.test.tsx
@@ -1,8 +1,95 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { beforeEach } from "vitest";
 
 import { MonacoGuardSelectorEditor } from "./monaco-guard-selector-editor";
+import { WORKSTATION_GUARD_SELECTOR_THEME_ID } from "./monaco-guard-selector-setup";
+
+function resetGuardSelectorPalette() {
+  document.documentElement.removeAttribute("data-color-palette");
+  document.documentElement.style.removeProperty("--color-surface");
+  document.documentElement.style.removeProperty("--color-on-surface");
+}
+
+function applyGuardSelectorPalette({
+  ink,
+  palette,
+  surface,
+}: {
+  ink: string;
+  palette: string;
+  surface: string;
+}) {
+  document.documentElement.dataset.colorPalette = palette;
+  document.documentElement.style.setProperty("--color-surface", surface);
+  document.documentElement.style.setProperty("--color-on-surface", ink);
+}
+
+function expectSingleThemeApplication(wrapper: Element | null) {
+  expect(wrapper?.getAttribute("data-monaco-theme-application-count")).toBe(
+    "1",
+  );
+  expect(wrapper?.getAttribute("data-monaco-theme-set-count")).toBe("1");
+  expect(wrapper?.getAttribute("data-monaco-theme-bases")).toBe(
+    JSON.stringify(["vs-dark"]),
+  );
+  expect(wrapper?.getAttribute("data-monaco-theme-set-names")).toBe(
+    JSON.stringify([WORKSTATION_GUARD_SELECTOR_THEME_ID]),
+  );
+}
+
+function renderGuardSelectorEditor(
+  overrides?: Partial<ComponentProps<typeof MonacoGuardSelectorEditor>>,
+) {
+  render(
+    <MonacoGuardSelectorEditor
+      ariaLabel="Field selector"
+      loadingMessage="Starting selector editor."
+      modelPath="inmemory://model/test/workstation-guard-selector/default"
+      onChange={() => {}}
+      startupErrorMessage="Selector editor failed."
+      value=".Name"
+      {...overrides}
+    />,
+  );
+}
+
+async function expectPaletteRefresh(
+  wrapper: Element | null,
+  editor: HTMLElement,
+) {
+  await waitFor(() => {
+    expectSingleThemeApplication(wrapper);
+  });
+
+  applyGuardSelectorPalette({
+    ink: "#091117",
+    palette: "factory-light",
+    surface: "#F7F2E8",
+  });
+
+  await waitFor(() => {
+    expect(wrapper?.getAttribute("data-monaco-theme-application-count")).toBe(
+      "2",
+    );
+  });
+
+  expect(wrapper?.getAttribute("data-monaco-theme-bases")).toBe(
+    JSON.stringify(["vs-dark", "vs"]),
+  );
+  expect(wrapper?.getAttribute("data-monaco-theme-set-count")).toBe("2");
+  expect(wrapper?.getAttribute("data-monaco-theme-set-names")).toBe(
+    JSON.stringify([
+      WORKSTATION_GUARD_SELECTOR_THEME_ID,
+      WORKSTATION_GUARD_SELECTOR_THEME_ID,
+    ]),
+  );
+  expect(screen.getByLabelText("Field selector")).toBe(editor);
+}
 
 describe("MonacoGuardSelectorEditor", () => {
+  beforeEach(resetGuardSelectorPalette);
+
   it("wires accessibility props, editing, and guard-selector surface marker", () => {
     const onChange = vi.fn();
 
@@ -92,5 +179,22 @@ describe("MonacoGuardSelectorEditor", () => {
       expect(onChange).toHaveBeenCalledWith(".Na");
     });
     expect(wrapper?.className).toContain("border-af-danger-border");
+  });
+
+  it("redefines and reapplies the guard-selector theme when the dashboard palette changes", async () => {
+    applyGuardSelectorPalette({
+      ink: "#F7F2E8",
+      palette: "factory-dark",
+      surface: "#091117",
+    });
+    renderGuardSelectorEditor({
+      modelPath:
+        "inmemory://model/test/workstation-guard-selector/palette-refresh",
+    });
+
+    const selectorEditor = screen.getByLabelText("Field selector");
+    const wrapper = selectorEditor.parentElement;
+
+    await expectPaletteRefresh(wrapper, selectorEditor);
   });
 });

--- a/ui/src/components/prompt-editor/monaco-guard-selector-editor.test.tsx
+++ b/ui/src/components/prompt-editor/monaco-guard-selector-editor.test.tsx
@@ -5,6 +5,14 @@ import { beforeEach } from "vitest";
 import { MonacoGuardSelectorEditor } from "./monaco-guard-selector-editor";
 import { WORKSTATION_GUARD_SELECTOR_THEME_ID } from "./monaco-guard-selector-setup";
 
+const guardSelectorPaletteSequence = [
+  { ink: "#F7F2E8", palette: "factory-dark", surface: "#091117" },
+  { ink: "#091117", palette: "factory-light", surface: "#F7F2E8" },
+  { ink: "#E6E0E9", palette: "material-baseline", surface: "#1D1B20" },
+  { ink: "#E6EDF3", palette: "slate", surface: "#161B22" },
+  { ink: "#EEF2E4", palette: "olive", surface: "#1A1D15" },
+] as const;
+
 function resetGuardSelectorPalette() {
   document.documentElement.removeAttribute("data-color-palette");
   document.documentElement.style.removeProperty("--color-surface");
@@ -38,6 +46,23 @@ function expectSingleThemeApplication(wrapper: Element | null) {
   );
 }
 
+function expectGuardSelectorThemeBases(
+  wrapper: Element | null,
+  bases: string[],
+) {
+  expect(wrapper?.getAttribute("data-monaco-theme-bases")).toBe(
+    JSON.stringify(bases),
+  );
+  expect(wrapper?.getAttribute("data-monaco-theme-set-count")).toBe(
+    String(bases.length),
+  );
+  expect(wrapper?.getAttribute("data-monaco-theme-set-names")).toBe(
+    JSON.stringify(
+      new Array(bases.length).fill(WORKSTATION_GUARD_SELECTOR_THEME_ID),
+    ),
+  );
+}
+
 function renderGuardSelectorEditor(
   overrides?: Partial<ComponentProps<typeof MonacoGuardSelectorEditor>>,
 ) {
@@ -62,28 +87,25 @@ async function expectPaletteRefresh(
     expectSingleThemeApplication(wrapper);
   });
 
-  applyGuardSelectorPalette({
-    ink: "#091117",
-    palette: "factory-light",
-    surface: "#F7F2E8",
-  });
+  for (const [index, palette] of guardSelectorPaletteSequence
+    .slice(1)
+    .entries()) {
+    applyGuardSelectorPalette(palette);
 
-  await waitFor(() => {
-    expect(wrapper?.getAttribute("data-monaco-theme-application-count")).toBe(
-      "2",
-    );
-  });
+    await waitFor(() => {
+      expect(wrapper?.getAttribute("data-monaco-theme-application-count")).toBe(
+        String(index + 2),
+      );
+    });
+  }
 
-  expect(wrapper?.getAttribute("data-monaco-theme-bases")).toBe(
-    JSON.stringify(["vs-dark", "vs"]),
-  );
-  expect(wrapper?.getAttribute("data-monaco-theme-set-count")).toBe("2");
-  expect(wrapper?.getAttribute("data-monaco-theme-set-names")).toBe(
-    JSON.stringify([
-      WORKSTATION_GUARD_SELECTOR_THEME_ID,
-      WORKSTATION_GUARD_SELECTOR_THEME_ID,
-    ]),
-  );
+  expectGuardSelectorThemeBases(wrapper, [
+    "vs-dark",
+    "vs",
+    "vs-dark",
+    "vs-dark",
+    "vs-dark",
+  ]);
   expect(screen.getByLabelText("Field selector")).toBe(editor);
 }
 
@@ -182,11 +204,7 @@ describe("MonacoGuardSelectorEditor", () => {
   });
 
   it("redefines and reapplies the guard-selector theme when the dashboard palette changes", async () => {
-    applyGuardSelectorPalette({
-      ink: "#F7F2E8",
-      palette: "factory-dark",
-      surface: "#091117",
-    });
+    applyGuardSelectorPalette(guardSelectorPaletteSequence[0]);
     renderGuardSelectorEditor({
       modelPath:
         "inmemory://model/test/workstation-guard-selector/palette-refresh",

--- a/ui/src/components/prompt-editor/monaco-guard-selector-editor.tsx
+++ b/ui/src/components/prompt-editor/monaco-guard-selector-editor.tsx
@@ -1,10 +1,11 @@
-import Editor, { loader } from "@monaco-editor/react";
+import Editor from "@monaco-editor/react";
 import type { RefObject } from "react";
 import { useEffect, useMemo, useRef } from "react";
 import "monaco-editor/esm/vs/editor/editor.all.js";
 import type { editor as MonacoEditorAPI } from "monaco-editor";
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
 import { cn } from "../../lib/cn";
+import { configureMonacoReactLoader } from "./monaco-react-loader";
 import { DashboardText, Textarea } from "../ui";
 import {
   applyWorkstationGuardSelectorTheme,
@@ -52,7 +53,7 @@ let monacoSetupState: "error" | "ready" = "ready";
 if (import.meta.env.MODE !== "test") {
   try {
     registerWorkstationGuardSelectorMonaco(monaco);
-    loader.config({ monaco });
+    configureMonacoReactLoader(monaco);
   } catch {
     monacoSetupState = "error";
   }

--- a/ui/src/components/prompt-editor/monaco-guard-selector-editor.tsx
+++ b/ui/src/components/prompt-editor/monaco-guard-selector-editor.tsx
@@ -4,9 +4,10 @@ import { useEffect, useMemo, useRef } from "react";
 import "monaco-editor/esm/vs/editor/editor.all.js";
 import type { editor as MonacoEditorAPI } from "monaco-editor";
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
-import { DashboardText, Textarea } from "../ui";
 import { cn } from "../../lib/cn";
+import { DashboardText, Textarea } from "../ui";
 import {
+  applyWorkstationGuardSelectorTheme,
   registerWorkstationGuardSelectorCompletionProvider,
   registerWorkstationGuardSelectorMonaco,
   WORKSTATION_GUARD_SELECTOR_LANGUAGE_ID,
@@ -148,6 +149,13 @@ function createGuardSelectorEditorMountHandler({
     editorInstance: MonacoEditorAPI.IStandaloneCodeEditor,
     monacoInstance: typeof import("monaco-editor"),
   ) => {
+    const themeObserver =
+      typeof MutationObserver === "undefined" || typeof document === "undefined"
+        ? null
+        : createGuardSelectorThemeObserver(
+            monacoInstance,
+            document.documentElement,
+          );
     const completionProvider =
       registerWorkstationGuardSelectorCompletionProvider(monacoInstance);
     const contentChangeListener = editorInstance.onDidChangeModelContent(() => {
@@ -167,11 +175,42 @@ function createGuardSelectorEditorMountHandler({
     });
 
     editorInstance.onDidDispose(() => {
+      themeObserver?.disconnect();
       completionProvider.dispose();
       contentChangeListener.dispose();
       suggestListener.dispose();
     });
   };
+}
+
+function createGuardSelectorThemeObserver(
+  monaco: typeof import("monaco-editor"),
+  root: HTMLElement,
+) {
+  const applyTheme = () => {
+    applyWorkstationGuardSelectorTheme(monaco, root);
+  };
+
+  applyTheme();
+
+  const observer = new MutationObserver((mutations) => {
+    if (
+      mutations.some(
+        (mutation) =>
+          mutation.type === "attributes" &&
+          mutation.attributeName === "data-color-palette",
+      )
+    ) {
+      applyTheme();
+    }
+  });
+
+  observer.observe(root, {
+    attributeFilter: ["data-color-palette"],
+    attributes: true,
+  });
+
+  return observer;
 }
 
 function GuardSelectorEditorFallbackState({
@@ -203,7 +242,10 @@ function GuardSelectorEditorFallbackState({
       role={status}
       style={{ height }}
     >
-      <DashboardText className="m-0 text-on-surface-variant" variant="supporting">
+      <DashboardText
+        className="m-0 text-on-surface-variant"
+        variant="supporting"
+      >
         {message}
       </DashboardText>
       <Textarea

--- a/ui/src/components/prompt-editor/monaco-guard-selector-editor.tsx
+++ b/ui/src/components/prompt-editor/monaco-guard-selector-editor.tsx
@@ -243,10 +243,7 @@ function GuardSelectorEditorFallbackState({
       role={status}
       style={{ height }}
     >
-      <DashboardText
-        className="m-0 text-on-surface-variant"
-        variant="supporting"
-      >
+      <DashboardText className="m-0 text-on-surface-variant" variant="supporting">
         {message}
       </DashboardText>
       <Textarea

--- a/ui/src/components/prompt-editor/monaco-guard-selector-language.ts
+++ b/ui/src/components/prompt-editor/monaco-guard-selector-language.ts
@@ -1,7 +1,4 @@
-import type {
-  editor as MonacoEditorAPI,
-  languages as MonacoLanguagesAPI,
-} from "monaco-editor";
+import type { languages as MonacoLanguagesAPI } from "monaco-editor";
 
 export const WORKSTATION_GUARD_SELECTOR_MONARCH_LANGUAGE: MonacoLanguagesAPI.IMonarchLanguage =
   {
@@ -14,29 +11,4 @@ export const WORKSTATION_GUARD_SELECTOR_MONARCH_LANGUAGE: MonacoLanguagesAPI.IMo
         [/./, "text"],
       ],
     },
-  };
-
-export const WORKSTATION_GUARD_SELECTOR_THEME: MonacoEditorAPI.IStandaloneThemeData =
-  {
-    base: "vs-dark",
-    colors: {
-      "editor.background": "#091117",
-      "editor.foreground": "#F7F2E8",
-      "editor.lineHighlightBackground": "#101C23",
-      "editor.selectionBackground": "#21414A",
-      "editor.inactiveSelectionBackground": "#173039",
-      "editorCursor.foreground": "#F5C76F",
-      "editorWidget.background": "#091117",
-      "editorWidget.border": "#FFFFFF1F",
-      "editorSuggestWidget.background": "#091117",
-      "editorSuggestWidget.foreground": "#F7F2E8",
-      "editorSuggestWidget.selectedBackground": "#132C37",
-      "editorSuggestWidget.highlightForeground": "#F5C76F",
-    },
-    inherit: true,
-    rules: [
-      { foreground: "F7F2E8", token: "text" },
-      { foreground: "5CCADD", token: "selector.field" },
-      { foreground: "A7F0C4", token: "selector.tag" },
-    ],
   };

--- a/ui/src/components/prompt-editor/monaco-guard-selector-setup.test.ts
+++ b/ui/src/components/prompt-editor/monaco-guard-selector-setup.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  applyWorkstationGuardSelectorTheme,
   buildWorkstationGuardSelectorCompletionItems,
   registerWorkstationGuardSelectorCompletionProvider,
   registerWorkstationGuardSelectorMonaco,
@@ -14,18 +15,19 @@ describe("registerWorkstationGuardSelectorMonaco", () => {
     const register = vi.fn();
     const setMonarchTokensProvider = vi.fn();
     const defineTheme = vi.fn();
+    const setTheme = vi.fn();
 
     resetWorkstationGuardSelectorMonacoRegistrationForTests();
 
     registerWorkstationGuardSelectorMonaco({
-      editor: { defineTheme },
+      editor: { defineTheme, setTheme },
       languages: {
         register,
         setMonarchTokensProvider,
       },
     } as unknown as typeof import("monaco-editor"));
     registerWorkstationGuardSelectorMonaco({
-      editor: { defineTheme },
+      editor: { defineTheme, setTheme },
       languages: {
         register,
         setMonarchTokensProvider,
@@ -45,6 +47,32 @@ describe("registerWorkstationGuardSelectorMonaco", () => {
         inherit: true,
       }),
     );
+    expect(setTheme).toHaveBeenCalledTimes(1);
+    expect(setTheme).toHaveBeenCalledWith(WORKSTATION_GUARD_SELECTOR_THEME_ID);
+  });
+
+  it("applies a light-biased guard-selector theme from the current palette tokens", () => {
+    const defineTheme = vi.fn();
+    const setTheme = vi.fn();
+
+    document.documentElement.style.setProperty("--color-surface", "#F7F2E8");
+    document.documentElement.style.setProperty("--color-on-surface", "#091117");
+
+    applyWorkstationGuardSelectorTheme({
+      editor: { defineTheme, setTheme },
+    } as unknown as typeof import("monaco-editor"));
+
+    expect(defineTheme).toHaveBeenCalledWith(
+      WORKSTATION_GUARD_SELECTOR_THEME_ID,
+      expect.objectContaining({
+        base: "vs",
+        colors: expect.objectContaining({
+          "editor.background": "#F7F2E8",
+          "editor.foreground": "#091117",
+        }),
+      }),
+    );
+    expect(setTheme).toHaveBeenCalledWith(WORKSTATION_GUARD_SELECTOR_THEME_ID);
   });
 });
 

--- a/ui/src/components/prompt-editor/monaco-guard-selector-setup.ts
+++ b/ui/src/components/prompt-editor/monaco-guard-selector-setup.ts
@@ -27,12 +27,20 @@ export function registerWorkstationGuardSelectorMonaco(monaco: MonacoModule) {
     WORKSTATION_GUARD_SELECTOR_LANGUAGE_ID,
     WORKSTATION_GUARD_SELECTOR_MONARCH_LANGUAGE,
   );
-  monaco.editor.defineTheme(
-    WORKSTATION_GUARD_SELECTOR_THEME_ID,
-    buildWorkstationGuardSelectorTheme(),
-  );
+  applyWorkstationGuardSelectorTheme(monaco);
 
   workstationGuardSelectorMonacoRegistered = true;
+}
+
+export function applyWorkstationGuardSelectorTheme(
+  monaco: MonacoModule,
+  root: Element | null = document.documentElement,
+) {
+  monaco.editor.defineTheme(
+    WORKSTATION_GUARD_SELECTOR_THEME_ID,
+    buildWorkstationGuardSelectorTheme(root),
+  );
+  monaco.editor.setTheme(WORKSTATION_GUARD_SELECTOR_THEME_ID);
 }
 
 export function resetWorkstationGuardSelectorMonacoRegistrationForTests() {

--- a/ui/src/components/prompt-editor/monaco-guard-selector-setup.ts
+++ b/ui/src/components/prompt-editor/monaco-guard-selector-setup.ts
@@ -1,7 +1,5 @@
-import {
-  WORKSTATION_GUARD_SELECTOR_MONARCH_LANGUAGE,
-  WORKSTATION_GUARD_SELECTOR_THEME,
-} from "./monaco-guard-selector-language";
+import { WORKSTATION_GUARD_SELECTOR_MONARCH_LANGUAGE } from "./monaco-guard-selector-language";
+import { buildWorkstationGuardSelectorTheme } from "./monaco-theme";
 
 type MonacoModule = typeof import("monaco-editor");
 
@@ -31,7 +29,7 @@ export function registerWorkstationGuardSelectorMonaco(monaco: MonacoModule) {
   );
   monaco.editor.defineTheme(
     WORKSTATION_GUARD_SELECTOR_THEME_ID,
-    WORKSTATION_GUARD_SELECTOR_THEME,
+    buildWorkstationGuardSelectorTheme(),
   );
 
   workstationGuardSelectorMonacoRegistered = true;

--- a/ui/src/components/prompt-editor/monaco-prompt-editor.test.tsx
+++ b/ui/src/components/prompt-editor/monaco-prompt-editor.test.tsx
@@ -20,6 +20,14 @@ const readyAutocompleteState = {
   status: "ready" as const,
 };
 
+const promptPaletteSequence = [
+  { ink: "#F7F2E8", palette: "factory-dark", surface: "#091117" },
+  { ink: "#091117", palette: "factory-light", surface: "#F7F2E8" },
+  { ink: "#E6E0E9", palette: "material-baseline", surface: "#1D1B20" },
+  { ink: "#E6EDF3", palette: "slate", surface: "#161B22" },
+  { ink: "#EEF2E4", palette: "olive", surface: "#1A1D15" },
+] as const;
+
 function resetPromptEditorPalette() {
   document.documentElement.removeAttribute("data-color-palette");
   document.documentElement.style.removeProperty("--color-surface");
@@ -50,6 +58,18 @@ function expectSingleThemeApplication(wrapper: Element | null) {
   );
   expect(wrapper?.getAttribute("data-monaco-theme-set-names")).toBe(
     JSON.stringify([WORKSTATION_PROMPT_THEME_ID]),
+  );
+}
+
+function expectPromptThemeBases(wrapper: Element | null, bases: string[]) {
+  expect(wrapper?.getAttribute("data-monaco-theme-bases")).toBe(
+    JSON.stringify(bases),
+  );
+  expect(wrapper?.getAttribute("data-monaco-theme-set-count")).toBe(
+    String(bases.length),
+  );
+  expect(wrapper?.getAttribute("data-monaco-theme-set-names")).toBe(
+    JSON.stringify(new Array(bases.length).fill(WORKSTATION_PROMPT_THEME_ID)),
   );
 }
 
@@ -140,11 +160,7 @@ describe("MonacoPromptEditor", () => {
   });
 
   it("redefines and reapplies the prompt theme when the dashboard palette changes", async () => {
-    applyPromptEditorPalette({
-      ink: "#F7F2E8",
-      palette: "factory-dark",
-      surface: "#091117",
-    });
+    applyPromptEditorPalette(promptPaletteSequence[0]);
     renderPromptEditorForPaletteRefresh();
 
     const promptEditor = screen.getByLabelText("Prompt");
@@ -154,28 +170,23 @@ describe("MonacoPromptEditor", () => {
       expectSingleThemeApplication(wrapper);
     });
 
-    applyPromptEditorPalette({
-      ink: "#091117",
-      palette: "factory-light",
-      surface: "#F7F2E8",
-    });
+    for (const [index, palette] of promptPaletteSequence.slice(1).entries()) {
+      applyPromptEditorPalette(palette);
 
-    await waitFor(() => {
-      expect(wrapper?.getAttribute("data-monaco-theme-application-count")).toBe(
-        "2",
-      );
-    });
+      await waitFor(() => {
+        expect(
+          wrapper?.getAttribute("data-monaco-theme-application-count"),
+        ).toBe(String(index + 2));
+      });
+    }
 
-    expect(wrapper?.getAttribute("data-monaco-theme-bases")).toBe(
-      JSON.stringify(["vs-dark", "vs"]),
-    );
-    expect(wrapper?.getAttribute("data-monaco-theme-set-count")).toBe("2");
-    expect(wrapper?.getAttribute("data-monaco-theme-set-names")).toBe(
-      JSON.stringify([
-        WORKSTATION_PROMPT_THEME_ID,
-        WORKSTATION_PROMPT_THEME_ID,
-      ]),
-    );
+    expectPromptThemeBases(wrapper, [
+      "vs-dark",
+      "vs",
+      "vs-dark",
+      "vs-dark",
+      "vs-dark",
+    ]);
     expect(screen.getByLabelText("Prompt")).toBe(promptEditor);
   });
 });

--- a/ui/src/components/prompt-editor/monaco-prompt-editor.test.tsx
+++ b/ui/src/components/prompt-editor/monaco-prompt-editor.test.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach } from "vitest";
 
 import { MonacoPromptEditor } from "./monaco-prompt-editor";
+import { WORKSTATION_PROMPT_THEME_ID } from "./monaco-prompt-setup";
 
 const readyAutocompleteState = {
   contract: {
@@ -18,7 +20,56 @@ const readyAutocompleteState = {
   status: "ready" as const,
 };
 
+function resetPromptEditorPalette() {
+  document.documentElement.removeAttribute("data-color-palette");
+  document.documentElement.style.removeProperty("--color-surface");
+  document.documentElement.style.removeProperty("--color-on-surface");
+}
+
+function applyPromptEditorPalette({
+  ink,
+  palette,
+  surface,
+}: {
+  ink: string;
+  palette: string;
+  surface: string;
+}) {
+  document.documentElement.dataset.colorPalette = palette;
+  document.documentElement.style.setProperty("--color-surface", surface);
+  document.documentElement.style.setProperty("--color-on-surface", ink);
+}
+
+function expectSingleThemeApplication(wrapper: Element | null) {
+  expect(wrapper?.getAttribute("data-monaco-theme-application-count")).toBe(
+    "1",
+  );
+  expect(wrapper?.getAttribute("data-monaco-theme-set-count")).toBe("1");
+  expect(wrapper?.getAttribute("data-monaco-theme-bases")).toBe(
+    JSON.stringify(["vs-dark"]),
+  );
+  expect(wrapper?.getAttribute("data-monaco-theme-set-names")).toBe(
+    JSON.stringify([WORKSTATION_PROMPT_THEME_ID]),
+  );
+}
+
+function renderPromptEditorForPaletteRefresh() {
+  render(
+    <MonacoPromptEditor
+      ariaLabel="Prompt"
+      autocompleteState={readyAutocompleteState}
+      loadingMessage="Loading prompt editor."
+      modelPath="inmemory://model/test/workstation-prompt-palette-refresh"
+      onChange={() => {}}
+      startupErrorMessage="Prompt editor failed."
+      value="Initial prompt"
+    />,
+  );
+}
+
 describe("MonacoPromptEditor", () => {
+  beforeEach(resetPromptEditorPalette);
+
   it("wires Monaco markers, accessibility props, editing, scroll, and ready lifecycle", async () => {
     const onChange = vi.fn();
     const onMount = vi.fn();
@@ -67,6 +118,7 @@ describe("MonacoPromptEditor", () => {
     expect(wrapper?.getAttribute("data-monaco-marker-messages")).toContain(
       "Work ID is invalid.",
     );
+    expectSingleThemeApplication(wrapper);
     expect(onMount).toHaveBeenCalledTimes(1);
     expect(onReadyChange).toHaveBeenCalledWith(true);
     expect(onScrollChange).toHaveBeenCalledWith({
@@ -85,5 +137,45 @@ describe("MonacoPromptEditor", () => {
     unmount();
 
     expect(onReadyChange).toHaveBeenCalledWith(false);
+  });
+
+  it("redefines and reapplies the prompt theme when the dashboard palette changes", async () => {
+    applyPromptEditorPalette({
+      ink: "#F7F2E8",
+      palette: "factory-dark",
+      surface: "#091117",
+    });
+    renderPromptEditorForPaletteRefresh();
+
+    const promptEditor = screen.getByLabelText("Prompt");
+    const wrapper = promptEditor.parentElement;
+
+    await waitFor(() => {
+      expectSingleThemeApplication(wrapper);
+    });
+
+    applyPromptEditorPalette({
+      ink: "#091117",
+      palette: "factory-light",
+      surface: "#F7F2E8",
+    });
+
+    await waitFor(() => {
+      expect(wrapper?.getAttribute("data-monaco-theme-application-count")).toBe(
+        "2",
+      );
+    });
+
+    expect(wrapper?.getAttribute("data-monaco-theme-bases")).toBe(
+      JSON.stringify(["vs-dark", "vs"]),
+    );
+    expect(wrapper?.getAttribute("data-monaco-theme-set-count")).toBe("2");
+    expect(wrapper?.getAttribute("data-monaco-theme-set-names")).toBe(
+      JSON.stringify([
+        WORKSTATION_PROMPT_THEME_ID,
+        WORKSTATION_PROMPT_THEME_ID,
+      ]),
+    );
+    expect(screen.getByLabelText("Prompt")).toBe(promptEditor);
   });
 });

--- a/ui/src/components/prompt-editor/monaco-prompt-editor.tsx
+++ b/ui/src/components/prompt-editor/monaco-prompt-editor.tsx
@@ -1,4 +1,4 @@
-import Editor, { loader } from "@monaco-editor/react";
+import Editor from "@monaco-editor/react";
 import type { RefObject } from "react";
 import { useEffect, useMemo, useRef } from "react";
 import "monaco-editor/esm/vs/editor/editor.all.js";
@@ -6,6 +6,7 @@ import type { editor as MonacoEditorAPI } from "monaco-editor";
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
 import { DashboardCode, DashboardText } from "../ui";
 import { cn } from "../../lib/cn";
+import { configureMonacoReactLoader } from "./monaco-react-loader";
 import {
   applyWorkstationPromptTheme,
   buildWorkstationPromptMarkers,
@@ -62,7 +63,7 @@ let monacoSetupState: "error" | "ready" = "ready";
 if (import.meta.env.MODE !== "test") {
   try {
     registerWorkstationPromptMonaco(monaco);
-    loader.config({ monaco });
+    configureMonacoReactLoader(monaco);
   } catch {
     monacoSetupState = "error";
   }

--- a/ui/src/components/prompt-editor/monaco-prompt-editor.tsx
+++ b/ui/src/components/prompt-editor/monaco-prompt-editor.tsx
@@ -7,6 +7,7 @@ import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
 import { DashboardCode, DashboardText } from "../ui";
 import { cn } from "../../lib/cn";
 import {
+  applyWorkstationPromptTheme,
   buildWorkstationPromptMarkers,
   isInsideTemplate,
   registerWorkstationPromptCompletionProvider,
@@ -227,6 +228,10 @@ function createPromptEditorMountHandler({
   ) => {
     editorRef.current = editorInstance;
     monacoRef.current = monacoInstance;
+    const themeObserver =
+      typeof MutationObserver === "undefined" || typeof document === "undefined"
+        ? null
+        : createPromptThemeObserver(monacoInstance, document.documentElement);
 
     const completionProvider = registerWorkstationPromptCompletionProvider(
       monacoInstance,
@@ -272,6 +277,7 @@ function createPromptEditorMountHandler({
     editorInstance.onDidDispose(() => {
       editorRef.current = null;
       monacoRef.current = null;
+      themeObserver?.disconnect();
       completionProvider.dispose();
       contentChangeListener.dispose();
       typeListener.dispose();
@@ -288,6 +294,36 @@ function createPromptEditorMountHandler({
       });
     });
   };
+}
+
+function createPromptThemeObserver(
+  monaco: typeof import("monaco-editor"),
+  root: HTMLElement,
+) {
+  const applyTheme = () => {
+    applyWorkstationPromptTheme(monaco, root);
+  };
+
+  applyTheme();
+
+  const observer = new MutationObserver((mutations) => {
+    if (
+      mutations.some(
+        (mutation) =>
+          mutation.type === "attributes" &&
+          mutation.attributeName === "data-color-palette",
+      )
+    ) {
+      applyTheme();
+    }
+  });
+
+  observer.observe(root, {
+    attributeFilter: ["data-color-palette"],
+    attributes: true,
+  });
+
+  return observer;
 }
 
 function PromptEditorFallbackState({

--- a/ui/src/components/prompt-editor/monaco-prompt-language.ts
+++ b/ui/src/components/prompt-editor/monaco-prompt-language.ts
@@ -1,7 +1,4 @@
-import type {
-  editor as MonacoEditorAPI,
-  languages as MonacoLanguagesAPI,
-} from "monaco-editor";
+import type { languages as MonacoLanguagesAPI } from "monaco-editor";
 
 export const WORKSTATION_PROMPT_MONARCH_LANGUAGE: MonacoLanguagesAPI.IMonarchLanguage =
   {
@@ -35,38 +32,3 @@ export const WORKSTATION_PROMPT_MONARCH_LANGUAGE: MonacoLanguagesAPI.IMonarchLan
       ],
     },
   };
-
-export const WORKSTATION_PROMPT_THEME: MonacoEditorAPI.IStandaloneThemeData = {
-  base: "vs-dark",
-  colors: {
-    "editor.background": "#091117",
-    "editor.foreground": "#F7F2E8",
-    "editor.lineHighlightBackground": "#101C23",
-    "editor.selectionBackground": "#21414A",
-    "editor.inactiveSelectionBackground": "#173039",
-    "editorCursor.foreground": "#F5C76F",
-    "editorWhitespace.foreground": "#FFFFFF24",
-    "editorIndentGuide.background1": "#FFFFFF14",
-    "editorIndentGuide.activeBackground1": "#FFFFFF2E",
-    "editorWidget.background": "#091117",
-    "editorWidget.border": "#FFFFFF1F",
-    "editorSuggestWidget.background": "#091117",
-    "editorSuggestWidget.foreground": "#F7F2E8",
-    "editorSuggestWidget.selectedBackground": "#132C37",
-    "editorSuggestWidget.highlightForeground": "#F5C76F",
-    "editorHoverWidget.background": "#091117",
-    "editorHoverWidget.border": "#FFFFFF1F",
-  },
-  inherit: true,
-  rules: [
-    { foreground: "F7F2E8", token: "text" },
-    { fontStyle: "bold", foreground: "F5C76F", token: "delimiter.template" },
-    { foreground: "7DD3FC", token: "keyword.template" },
-    { foreground: "B5EDF4", token: "keyword.function.template" },
-    { foreground: "F7F2E8", token: "identifier.template" },
-    { foreground: "A7F0C4", token: "string.template" },
-    { foreground: "F5C76F", token: "number.template" },
-    { foreground: "FFB2B2", token: "variable.local" },
-    { foreground: "5CCADD", token: "variable.root" },
-  ],
-};

--- a/ui/src/components/prompt-editor/monaco-prompt-setup.test.ts
+++ b/ui/src/components/prompt-editor/monaco-prompt-setup.test.ts
@@ -19,11 +19,12 @@ describe("registerWorkstationPromptMonaco", () => {
     const registerCompletionItemProvider = vi.fn();
     const setMonarchTokensProvider = vi.fn();
     const defineTheme = vi.fn();
+    const setTheme = vi.fn();
 
     resetWorkstationPromptMonacoRegistrationForTests();
 
     registerWorkstationPromptMonaco({
-      editor: { defineTheme },
+      editor: { defineTheme, setTheme },
       languages: {
         register,
         registerCompletionItemProvider,
@@ -31,7 +32,7 @@ describe("registerWorkstationPromptMonaco", () => {
       },
     } as unknown as typeof import("monaco-editor"));
     registerWorkstationPromptMonaco({
-      editor: { defineTheme },
+      editor: { defineTheme, setTheme },
       languages: {
         register,
         registerCompletionItemProvider,
@@ -92,6 +93,8 @@ describe("registerWorkstationPromptMonaco", () => {
         ]),
       }),
     );
+    expect(setTheme).toHaveBeenCalledTimes(1);
+    expect(setTheme).toHaveBeenCalledWith(WORKSTATION_PROMPT_THEME_ID);
   });
 
   it("builds inside-template and full-snippet completion inserts from the prompt-template contract", () => {

--- a/ui/src/components/prompt-editor/monaco-prompt-setup.ts
+++ b/ui/src/components/prompt-editor/monaco-prompt-setup.ts
@@ -4,10 +4,8 @@ import type {
 } from "monaco-editor";
 
 import type { PromptTemplateContract } from "../../api/current-factory-prompt-template";
-import {
-  WORKSTATION_PROMPT_MONARCH_LANGUAGE,
-  WORKSTATION_PROMPT_THEME,
-} from "./monaco-prompt-language";
+import { WORKSTATION_PROMPT_MONARCH_LANGUAGE } from "./monaco-prompt-language";
+import { buildWorkstationPromptTheme } from "./monaco-theme";
 import { formatSyntaxDiagnosticMessage } from "./prompt-editor-diagnostic-message";
 import type {
   PromptEditorAutocompleteState,
@@ -37,7 +35,7 @@ export function registerWorkstationPromptMonaco(monaco: MonacoModule) {
   );
   monaco.editor.defineTheme(
     WORKSTATION_PROMPT_THEME_ID,
-    WORKSTATION_PROMPT_THEME,
+    buildWorkstationPromptTheme(),
   );
 
   workstationPromptMonacoRegistered = true;

--- a/ui/src/components/prompt-editor/monaco-prompt-setup.ts
+++ b/ui/src/components/prompt-editor/monaco-prompt-setup.ts
@@ -33,12 +33,20 @@ export function registerWorkstationPromptMonaco(monaco: MonacoModule) {
     WORKSTATION_PROMPT_LANGUAGE_ID,
     WORKSTATION_PROMPT_MONARCH_LANGUAGE,
   );
-  monaco.editor.defineTheme(
-    WORKSTATION_PROMPT_THEME_ID,
-    buildWorkstationPromptTheme(),
-  );
+  applyWorkstationPromptTheme(monaco);
 
   workstationPromptMonacoRegistered = true;
+}
+
+export function applyWorkstationPromptTheme(
+  monaco: MonacoModule,
+  root: Element | null = document.documentElement,
+) {
+  monaco.editor.defineTheme(
+    WORKSTATION_PROMPT_THEME_ID,
+    buildWorkstationPromptTheme(root),
+  );
+  monaco.editor.setTheme(WORKSTATION_PROMPT_THEME_ID);
 }
 
 export function resetWorkstationPromptMonacoRegistrationForTests() {

--- a/ui/src/components/prompt-editor/monaco-react-loader.ts
+++ b/ui/src/components/prompt-editor/monaco-react-loader.ts
@@ -12,7 +12,3 @@ export function configureMonacoReactLoader(monaco: MonacoModule) {
   loader.config({ monaco });
   monacoReactLoaderConfigured = true;
 }
-
-export function resetMonacoReactLoaderConfigurationForTests() {
-  monacoReactLoaderConfigured = false;
-}

--- a/ui/src/components/prompt-editor/monaco-react-loader.ts
+++ b/ui/src/components/prompt-editor/monaco-react-loader.ts
@@ -1,0 +1,18 @@
+import { loader } from "@monaco-editor/react";
+
+type MonacoModule = typeof import("monaco-editor");
+
+let monacoReactLoaderConfigured = false;
+
+export function configureMonacoReactLoader(monaco: MonacoModule) {
+  if (monacoReactLoaderConfigured) {
+    return;
+  }
+
+  loader.config({ monaco });
+  monacoReactLoaderConfigured = true;
+}
+
+export function resetMonacoReactLoaderConfigurationForTests() {
+  monacoReactLoaderConfigured = false;
+}

--- a/ui/src/components/prompt-editor/monaco-theme.test.ts
+++ b/ui/src/components/prompt-editor/monaco-theme.test.ts
@@ -5,13 +5,11 @@ import {
   buildWorkstationPromptTheme,
 } from "./monaco-theme";
 
-describe("buildWorkstationPromptTheme", () => {
-  afterEach(() => {
-    document.documentElement.removeAttribute("style");
-  });
-
-  it("derives the existing dark prompt theme colors from resolved tokens", () => {
-    applyThemeTokens({
+const PALETTE_FIXTURES = [
+  {
+    expectedBase: "vs-dark",
+    id: "factory-dark",
+    tokens: {
       "--color-af-foundation-accent": "#F5C76F",
       "--color-af-foundation-accent-strong": "#ECBF58",
       "--color-af-foundation-code-ink": "#5CCADD",
@@ -23,7 +21,85 @@ describe("buildWorkstationPromptTheme", () => {
       "--color-af-foundation-overlay": "#FFFFFF",
       "--color-af-foundation-success-ink": "#A7F0C4",
       "--color-af-foundation-surface": "#091117",
-    });
+    },
+  },
+  {
+    expectedBase: "vs",
+    id: "factory-light",
+    tokens: {
+      "--color-af-foundation-accent": "#F5C76F",
+      "--color-af-foundation-accent-strong": "#C9972E",
+      "--color-af-foundation-code-ink": "#0F4C5C",
+      "--color-af-foundation-danger-ink": "#9F2F2F",
+      "--color-af-foundation-info": "#2F8FAD",
+      "--color-af-foundation-info-bright": "#4AA9C9",
+      "--color-af-foundation-info-ink": "#1F6178",
+      "--color-af-foundation-ink": "#1A2228",
+      "--color-af-foundation-overlay": "#000000",
+      "--color-af-foundation-success-ink": "#1F6F49",
+      "--color-af-foundation-surface": "#FFFFFF",
+    },
+  },
+  {
+    expectedBase: "vs-dark",
+    id: "material-baseline",
+    tokens: {
+      "--color-af-foundation-accent": "#F5C76F",
+      "--color-af-foundation-accent-strong": "#ECBF58",
+      "--color-af-foundation-code-ink": "#C8F0FF",
+      "--color-af-foundation-danger-ink": "#FFB8B8",
+      "--color-af-foundation-info": "#67CBE0",
+      "--color-af-foundation-info-bright": "#8ADCF0",
+      "--color-af-foundation-info-ink": "#B8EDF8",
+      "--color-af-foundation-ink": "#E6E0E9",
+      "--color-af-foundation-overlay": "#FFFFFF",
+      "--color-af-foundation-success-ink": "#A8F0C8",
+      "--color-af-foundation-surface": "#1D1B20",
+    },
+  },
+  {
+    expectedBase: "vs-dark",
+    id: "slate",
+    tokens: {
+      "--color-af-foundation-accent": "#F5C76F",
+      "--color-af-foundation-accent-strong": "#ECBF58",
+      "--color-af-foundation-code-ink": "#C7E7FF",
+      "--color-af-foundation-danger-ink": "#FFB0B0",
+      "--color-af-foundation-info": "#58B8D8",
+      "--color-af-foundation-info-bright": "#7ECBF0",
+      "--color-af-foundation-info-ink": "#B0E0F2",
+      "--color-af-foundation-ink": "#E6EDF3",
+      "--color-af-foundation-overlay": "#FFFFFF",
+      "--color-af-foundation-success-ink": "#A4E8C4",
+      "--color-af-foundation-surface": "#161B22",
+    },
+  },
+  {
+    expectedBase: "vs-dark",
+    id: "olive",
+    tokens: {
+      "--color-af-foundation-accent": "#F5C76F",
+      "--color-af-foundation-accent-strong": "#ECBF58",
+      "--color-af-foundation-code-ink": "#D0F5E8",
+      "--color-af-foundation-danger-ink": "#FFB0B0",
+      "--color-af-foundation-info": "#58B0A0",
+      "--color-af-foundation-info-bright": "#7ECFB8",
+      "--color-af-foundation-info-ink": "#B0E8D8",
+      "--color-af-foundation-ink": "#EEF2E4",
+      "--color-af-foundation-overlay": "#FFFFFF",
+      "--color-af-foundation-success-ink": "#A8E8BC",
+      "--color-af-foundation-surface": "#1A1D15",
+    },
+  },
+] as const;
+
+describe("buildWorkstationPromptTheme", () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute("style");
+  });
+
+  it("derives the existing dark prompt theme colors from resolved tokens", () => {
+    applyThemeTokens(PALETTE_FIXTURES[0].tokens);
 
     const theme = buildWorkstationPromptTheme();
 
@@ -53,20 +129,8 @@ describe("buildWorkstationPromptTheme", () => {
     );
   });
 
-  it("switches to a light Monaco base and light-surface tokens for factory-light palettes", () => {
-    applyThemeTokens({
-      "--color-af-foundation-accent": "#F5C76F",
-      "--color-af-foundation-accent-strong": "#C9972E",
-      "--color-af-foundation-code-ink": "#0F4C5C",
-      "--color-af-foundation-danger-ink": "#9F2F2F",
-      "--color-af-foundation-info": "#2F8FAD",
-      "--color-af-foundation-info-bright": "#4AA9C9",
-      "--color-af-foundation-info-ink": "#1F6178",
-      "--color-af-foundation-ink": "#1A2228",
-      "--color-af-foundation-overlay": "#000000",
-      "--color-af-foundation-success-ink": "#1F6F49",
-      "--color-af-foundation-surface": "#FFFFFF",
-    });
+  it("uses stronger light-palette syntax colors for factory-light prompt tokens", () => {
+    applyThemeTokens(PALETTE_FIXTURES[1].tokens);
 
     const theme = buildWorkstationPromptTheme();
 
@@ -78,18 +142,49 @@ describe("buildWorkstationPromptTheme", () => {
       "editorWidget.background": "#FFFFFF",
     });
     expect(theme.colors["editor.background"]).not.toBe("#091117");
-    expect(theme.rules).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          foreground: "1F6F49",
-          token: "string.template",
-        }),
-        expect.objectContaining({
-          foreground: "0F4C5C",
-          token: "variable.root",
-        }),
-      ]),
+    expect(findRuleForeground(theme, "delimiter.template")).toBe("#C9972E");
+    expect(findRuleForeground(theme, "keyword.template")).toBe("#2F8FAD");
+    expect(findRuleForeground(theme, "string.template")).toBe("#1F6F49");
+    expect(findRuleForeground(theme, "variable.root")).toBe("#0F4C5C");
+  });
+
+  it.each(
+    PALETTE_FIXTURES,
+  )("keeps prompt editor text and core syntax readable for %s", ({
+    expectedBase,
+    id,
+    tokens,
+  }) => {
+    applyThemeTokens(tokens);
+
+    const theme = buildWorkstationPromptTheme();
+    const background =
+      theme.colors["editor.background"] ??
+      tokens["--color-af-foundation-surface"];
+
+    expect(theme.base).toBe(expectedBase);
+    expect(
+      readContrastRatio(theme.colors["editor.foreground"] ?? "", background),
+    ).toBeGreaterThanOrEqual(4.5);
+    expect(
+      readContrastRatio(
+        findRuleForeground(theme, "keyword.template"),
+        background,
+      ),
+    ).toBeGreaterThanOrEqual(3);
+    expect(
+      readContrastRatio(
+        findRuleForeground(theme, "string.template"),
+        background,
+      ),
+    ).toBeGreaterThanOrEqual(3);
+    expect(
+      readContrastRatio(findRuleForeground(theme, "variable.root"), background),
+    ).toBeGreaterThanOrEqual(3);
+    expect(findRuleForeground(theme, "delimiter.template")).not.toBe(
+      theme.colors["editor.foreground"],
     );
+    expect(id).toBeTruthy();
   });
 });
 
@@ -98,34 +193,35 @@ describe("buildWorkstationGuardSelectorTheme", () => {
     document.documentElement.removeAttribute("style");
   });
 
-  it("uses the same palette token source with guard-selector syntax rules", () => {
-    applyThemeTokens({
-      "--color-af-foundation-code-ink": "#0F4C5C",
-      "--color-af-foundation-ink": "#1A2228",
-      "--color-af-foundation-overlay": "#000000",
-      "--color-af-foundation-success-ink": "#1F6F49",
-      "--color-af-foundation-surface": "#FFFFFF",
-    });
+  it.each(
+    PALETTE_FIXTURES,
+  )("uses the same palette token source with readable guard-selector syntax for %s", ({
+    expectedBase,
+    tokens,
+  }) => {
+    applyThemeTokens(tokens);
 
     const theme = buildWorkstationGuardSelectorTheme();
+    const background =
+      theme.colors["editor.background"] ??
+      tokens["--color-af-foundation-surface"];
 
-    expect(theme.base).toBe("vs");
-    expect(theme.rules).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          foreground: "1A2228",
-          token: "text",
-        }),
-        expect.objectContaining({
-          foreground: "0F4C5C",
-          token: "selector.field",
-        }),
-        expect.objectContaining({
-          foreground: "1F6F49",
-          token: "selector.tag",
-        }),
-      ]),
+    expect(theme.base).toBe(expectedBase);
+    expect(findRuleForeground(theme, "text")).toBe(
+      tokens["--color-af-foundation-ink"],
     );
+    expect(
+      readContrastRatio(findRuleForeground(theme, "text"), background),
+    ).toBeGreaterThanOrEqual(4.5);
+    expect(
+      readContrastRatio(
+        findRuleForeground(theme, "selector.field"),
+        background,
+      ),
+    ).toBeGreaterThanOrEqual(3);
+    expect(
+      readContrastRatio(findRuleForeground(theme, "selector.tag"), background),
+    ).toBeGreaterThanOrEqual(3);
   });
 });
 
@@ -133,4 +229,47 @@ function applyThemeTokens(tokens: Record<string, string>) {
   for (const [name, value] of Object.entries(tokens)) {
     document.documentElement.style.setProperty(name, value);
   }
+}
+
+function findRuleForeground(
+  theme: ReturnType<typeof buildWorkstationPromptTheme>,
+  token: string,
+): string {
+  const foreground = theme.rules.find(
+    (rule) => rule.token === token,
+  )?.foreground;
+  if (!foreground) {
+    throw new Error(`expected Monaco rule foreground for token ${token}`);
+  }
+
+  return `#${foreground}`;
+}
+
+function readContrastRatio(foreground: string, background: string): number {
+  const foregroundLuminance = readRelativeLuminance(foreground);
+  const backgroundLuminance = readRelativeLuminance(background);
+  const lighter = Math.max(foregroundLuminance, backgroundLuminance);
+  const darker = Math.min(foregroundLuminance, backgroundLuminance);
+
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function readRelativeLuminance(color: string): number {
+  const normalized = color.replace(/^#/, "");
+  const rgb = [
+    Number.parseInt(normalized.slice(0, 2), 16),
+    Number.parseInt(normalized.slice(2, 4), 16),
+    Number.parseInt(normalized.slice(4, 6), 16),
+  ];
+
+  const [red, green, blue] = rgb.map((channel) => {
+    const normalizedChannel = channel / 255;
+    if (normalizedChannel <= 0.03928) {
+      return normalizedChannel / 12.92;
+    }
+
+    return ((normalizedChannel + 0.055) / 1.055) ** 2.4;
+  });
+
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
 }

--- a/ui/src/components/prompt-editor/monaco-theme.test.ts
+++ b/ui/src/components/prompt-editor/monaco-theme.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  buildWorkstationGuardSelectorTheme,
+  buildWorkstationPromptTheme,
+} from "./monaco-theme";
+
+describe("buildWorkstationPromptTheme", () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute("style");
+  });
+
+  it("derives the existing dark prompt theme colors from resolved tokens", () => {
+    applyThemeTokens({
+      "--color-af-foundation-accent": "#F5C76F",
+      "--color-af-foundation-accent-strong": "#ECBF58",
+      "--color-af-foundation-code-ink": "#5CCADD",
+      "--color-af-foundation-danger-ink": "#FFB2B2",
+      "--color-af-foundation-info": "#5CCADD",
+      "--color-af-foundation-info-bright": "#7DD3FC",
+      "--color-af-foundation-info-ink": "#B5EDF4",
+      "--color-af-foundation-ink": "#F7F2E8",
+      "--color-af-foundation-overlay": "#FFFFFF",
+      "--color-af-foundation-success-ink": "#A7F0C4",
+      "--color-af-foundation-surface": "#091117",
+    });
+
+    const theme = buildWorkstationPromptTheme();
+
+    expect(theme.base).toBe("vs-dark");
+    expect(theme.colors).toMatchObject({
+      "editor.background": "#091117",
+      "editor.foreground": "#F7F2E8",
+      "editorCursor.foreground": "#F5C76F",
+      "editorSuggestWidget.foreground": "#F7F2E8",
+      "editorWidget.background": "#091117",
+    });
+    expect(theme.rules).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          foreground: "F5C76F",
+          token: "delimiter.template",
+        }),
+        expect.objectContaining({
+          foreground: "7DD3FC",
+          token: "keyword.template",
+        }),
+        expect.objectContaining({
+          foreground: "5CCADD",
+          token: "variable.root",
+        }),
+      ]),
+    );
+  });
+
+  it("switches to a light Monaco base and light-surface tokens for factory-light palettes", () => {
+    applyThemeTokens({
+      "--color-af-foundation-accent": "#F5C76F",
+      "--color-af-foundation-accent-strong": "#C9972E",
+      "--color-af-foundation-code-ink": "#0F4C5C",
+      "--color-af-foundation-danger-ink": "#9F2F2F",
+      "--color-af-foundation-info": "#2F8FAD",
+      "--color-af-foundation-info-bright": "#4AA9C9",
+      "--color-af-foundation-info-ink": "#1F6178",
+      "--color-af-foundation-ink": "#1A2228",
+      "--color-af-foundation-overlay": "#000000",
+      "--color-af-foundation-success-ink": "#1F6F49",
+      "--color-af-foundation-surface": "#FFFFFF",
+    });
+
+    const theme = buildWorkstationPromptTheme();
+
+    expect(theme.base).toBe("vs");
+    expect(theme.colors).toMatchObject({
+      "editor.background": "#FFFFFF",
+      "editor.foreground": "#1A2228",
+      "editorCursor.foreground": "#F5C76F",
+      "editorWidget.background": "#FFFFFF",
+    });
+    expect(theme.colors["editor.background"]).not.toBe("#091117");
+    expect(theme.rules).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          foreground: "1F6F49",
+          token: "string.template",
+        }),
+        expect.objectContaining({
+          foreground: "0F4C5C",
+          token: "variable.root",
+        }),
+      ]),
+    );
+  });
+});
+
+describe("buildWorkstationGuardSelectorTheme", () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute("style");
+  });
+
+  it("uses the same palette token source with guard-selector syntax rules", () => {
+    applyThemeTokens({
+      "--color-af-foundation-code-ink": "#0F4C5C",
+      "--color-af-foundation-ink": "#1A2228",
+      "--color-af-foundation-overlay": "#000000",
+      "--color-af-foundation-success-ink": "#1F6F49",
+      "--color-af-foundation-surface": "#FFFFFF",
+    });
+
+    const theme = buildWorkstationGuardSelectorTheme();
+
+    expect(theme.base).toBe("vs");
+    expect(theme.rules).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          foreground: "1A2228",
+          token: "text",
+        }),
+        expect.objectContaining({
+          foreground: "0F4C5C",
+          token: "selector.field",
+        }),
+        expect.objectContaining({
+          foreground: "1F6F49",
+          token: "selector.tag",
+        }),
+      ]),
+    );
+  });
+});
+
+function applyThemeTokens(tokens: Record<string, string>) {
+  for (const [name, value] of Object.entries(tokens)) {
+    document.documentElement.style.setProperty(name, value);
+  }
+}

--- a/ui/src/components/prompt-editor/monaco-theme.ts
+++ b/ui/src/components/prompt-editor/monaco-theme.ts
@@ -1,3 +1,4 @@
+// biome-ignore lint/nursery/noExcessiveLinesPerFile: Monaco theme derivation keeps palette token fallback precedence in one module.
 import type { editor as MonacoEditorAPI } from "monaco-editor";
 
 const FALLBACK_THEME_TOKENS = {
@@ -39,6 +40,8 @@ export function buildWorkstationPromptTheme(
 ): MonacoEditorAPI.IStandaloneThemeData {
   const tokens = readMonacoThemeTokens(root);
   const base = resolveMonacoBase(tokens.surface);
+  const templateDelimiter = base === "vs" ? tokens.accentStrong : tokens.accent;
+  const templateKeyword = base === "vs" ? tokens.info : tokens.infoBright;
 
   return {
     base,
@@ -48,17 +51,20 @@ export function buildWorkstationPromptTheme(
       { foreground: toMonacoHex(tokens.ink), token: "text" },
       {
         fontStyle: "bold",
-        foreground: toMonacoHex(tokens.accent),
+        foreground: toMonacoHex(templateDelimiter),
         token: "delimiter.template",
       },
-      { foreground: toMonacoHex(tokens.infoBright), token: "keyword.template" },
+      { foreground: toMonacoHex(templateKeyword), token: "keyword.template" },
       {
         foreground: toMonacoHex(tokens.infoInk),
         token: "keyword.function.template",
       },
       { foreground: toMonacoHex(tokens.ink), token: "identifier.template" },
       { foreground: toMonacoHex(tokens.successText), token: "string.template" },
-      { foreground: toMonacoHex(tokens.accentStrong), token: "number.template" },
+      {
+        foreground: toMonacoHex(tokens.accentStrong),
+        token: "number.template",
+      },
       { foreground: toMonacoHex(tokens.dangerText), token: "variable.local" },
       { foreground: toMonacoHex(tokens.code), token: "variable.root" },
     ],
@@ -118,6 +124,7 @@ function buildSharedEditorColors(
   };
 }
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: Palette token resolution keeps stylesheet, computed-style, and probe fallback precedence in one place.
 function readMonacoThemeTokens(root: Element | null): MonacoThemeTokens {
   if (typeof window === "undefined" || !root) {
     return { ...FALLBACK_THEME_TOKENS };
@@ -128,59 +135,125 @@ function readMonacoThemeTokens(root: Element | null): MonacoThemeTokens {
   const probeTokens = readMonacoThemeProbeTokens(root);
 
   return {
-    accent: readCssColor(styles, [
-      "--color-primary",
-      "--color-af-accent",
-      "--color-af-foundation-accent",
-    ], pickUsableThemeColor(stylesheetTokens.accent, probeTokens.accent, FALLBACK_THEME_TOKENS.accent)),
-    accentStrong: readCssColor(styles, [
-      "--color-on-primary-container",
-      "--color-af-accent-hover",
-      "--color-af-foundation-accent-strong",
-    ], pickUsableThemeColor(stylesheetTokens.accentStrong, probeTokens.accentStrong, FALLBACK_THEME_TOKENS.accentStrong)),
-    code: readCssColor(styles, [
-      "--color-code",
-      "--color-af-code-ink",
-      "--color-af-foundation-code-ink",
-    ], pickUsableThemeColor(stylesheetTokens.code, probeTokens.code, FALLBACK_THEME_TOKENS.code)),
-    dangerText: readCssColor(styles, [
-      "--color-on-error-container",
-      "--color-af-danger-text",
-      "--color-af-foundation-danger-ink",
-    ], pickUsableThemeColor(stylesheetTokens.dangerText, probeTokens.dangerText, FALLBACK_THEME_TOKENS.dangerText)),
-    info: readCssColor(styles, [
-      "--color-info",
-      "--color-af-info",
-      "--color-af-foundation-info",
-    ], pickUsableThemeColor(stylesheetTokens.info, probeTokens.info, FALLBACK_THEME_TOKENS.info)),
-    infoBright: readCssColor(styles, [
-      "--color-af-foundation-info-bright",
-      "--color-info",
-      "--color-af-info",
-    ], pickUsableThemeColor(stylesheetTokens.infoBright, probeTokens.infoBright, FALLBACK_THEME_TOKENS.infoBright)),
-    infoInk: readCssColor(styles, [
-      "--color-on-info-container",
-      "--color-af-info-text",
-      "--color-af-foundation-info-ink",
-    ], pickUsableThemeColor(stylesheetTokens.infoInk, probeTokens.infoInk, FALLBACK_THEME_TOKENS.infoInk)),
-    ink: readCssColor(styles, [
-      "--color-on-surface",
-      "--color-af-text",
-      "--color-af-foundation-ink",
-    ], pickUsableThemeColor(stylesheetTokens.ink, probeTokens.ink, FALLBACK_THEME_TOKENS.ink)),
-    overlay: readCssColor(styles, [
-      "--color-af-foundation-overlay",
-    ], pickUsableThemeColor(stylesheetTokens.overlay, probeTokens.overlay, FALLBACK_THEME_TOKENS.overlay)),
-    successText: readCssColor(styles, [
-      "--color-on-success-container",
-      "--color-af-success-text",
-      "--color-af-foundation-success-ink",
-    ], pickUsableThemeColor(stylesheetTokens.successText, probeTokens.successText, FALLBACK_THEME_TOKENS.successText)),
-    surface: readCssColor(styles, [
-      "--color-surface",
-      "--color-af-surface",
-      "--color-af-foundation-surface",
-    ], pickUsableThemeColor(stylesheetTokens.surface, probeTokens.surface, FALLBACK_THEME_TOKENS.surface)),
+    accent: readCssColor(
+      styles,
+      ["--color-primary", "--color-af-accent", "--color-af-foundation-accent"],
+      pickUsableThemeColor(
+        stylesheetTokens.accent,
+        probeTokens.accent,
+        FALLBACK_THEME_TOKENS.accent,
+      ),
+    ),
+    accentStrong: readCssColor(
+      styles,
+      [
+        "--color-on-primary-container",
+        "--color-af-accent-hover",
+        "--color-af-foundation-accent-strong",
+      ],
+      pickUsableThemeColor(
+        stylesheetTokens.accentStrong,
+        probeTokens.accentStrong,
+        FALLBACK_THEME_TOKENS.accentStrong,
+      ),
+    ),
+    code: readCssColor(
+      styles,
+      ["--color-code", "--color-af-code-ink", "--color-af-foundation-code-ink"],
+      pickUsableThemeColor(
+        stylesheetTokens.code,
+        probeTokens.code,
+        FALLBACK_THEME_TOKENS.code,
+      ),
+    ),
+    dangerText: readCssColor(
+      styles,
+      [
+        "--color-on-error-container",
+        "--color-af-danger-text",
+        "--color-af-foundation-danger-ink",
+      ],
+      pickUsableThemeColor(
+        stylesheetTokens.dangerText,
+        probeTokens.dangerText,
+        FALLBACK_THEME_TOKENS.dangerText,
+      ),
+    ),
+    info: readCssColor(
+      styles,
+      ["--color-info", "--color-af-info", "--color-af-foundation-info"],
+      pickUsableThemeColor(
+        stylesheetTokens.info,
+        probeTokens.info,
+        FALLBACK_THEME_TOKENS.info,
+      ),
+    ),
+    infoBright: readCssColor(
+      styles,
+      ["--color-af-foundation-info-bright", "--color-info", "--color-af-info"],
+      pickUsableThemeColor(
+        stylesheetTokens.infoBright,
+        probeTokens.infoBright,
+        FALLBACK_THEME_TOKENS.infoBright,
+      ),
+    ),
+    infoInk: readCssColor(
+      styles,
+      [
+        "--color-on-info-container",
+        "--color-af-info-text",
+        "--color-af-foundation-info-ink",
+      ],
+      pickUsableThemeColor(
+        stylesheetTokens.infoInk,
+        probeTokens.infoInk,
+        FALLBACK_THEME_TOKENS.infoInk,
+      ),
+    ),
+    ink: readCssColor(
+      styles,
+      ["--color-on-surface", "--color-af-text", "--color-af-foundation-ink"],
+      pickUsableThemeColor(
+        stylesheetTokens.ink,
+        probeTokens.ink,
+        FALLBACK_THEME_TOKENS.ink,
+      ),
+    ),
+    overlay: readCssColor(
+      styles,
+      ["--color-af-foundation-overlay"],
+      pickUsableThemeColor(
+        stylesheetTokens.overlay,
+        probeTokens.overlay,
+        FALLBACK_THEME_TOKENS.overlay,
+      ),
+    ),
+    successText: readCssColor(
+      styles,
+      [
+        "--color-on-success-container",
+        "--color-af-success-text",
+        "--color-af-foundation-success-ink",
+      ],
+      pickUsableThemeColor(
+        stylesheetTokens.successText,
+        probeTokens.successText,
+        FALLBACK_THEME_TOKENS.successText,
+      ),
+    ),
+    surface: readCssColor(
+      styles,
+      [
+        "--color-surface",
+        "--color-af-surface",
+        "--color-af-foundation-surface",
+      ],
+      pickUsableThemeColor(
+        stylesheetTokens.surface,
+        probeTokens.surface,
+        FALLBACK_THEME_TOKENS.surface,
+      ),
+    ),
   };
 }
 
@@ -216,7 +289,11 @@ function readMonacoThemeStylesheetTokens(
       }
 
       const selectorText = rule.selectorText ?? "";
-      if (![...selectorsToMatch].some((selector) => selectorText.includes(selector))) {
+      if (
+        ![...selectorsToMatch].some((selector) =>
+          selectorText.includes(selector),
+        )
+      ) {
         continue;
       }
 
@@ -256,9 +333,7 @@ function readMonacoThemeStylesheetTokens(
   };
 }
 
-function readMonacoThemeProbeTokens(
-  root: Element,
-): Partial<MonacoThemeTokens> {
+function readMonacoThemeProbeTokens(root: Element): Partial<MonacoThemeTokens> {
   const document = root.ownerDocument;
   const container = document?.body;
   if (!document || !container) {
@@ -296,14 +371,18 @@ function readMonacoThemeProbeTokens(
   const accentStrong = accentElement
     ? window.getComputedStyle(accentElement).color
     : undefined;
-  const code = codeElement ? window.getComputedStyle(codeElement).color : undefined;
+  const code = codeElement
+    ? window.getComputedStyle(codeElement).color
+    : undefined;
   const dangerText = dangerElement
     ? window.getComputedStyle(dangerElement).color
     : undefined;
   const info = infoElement
     ? window.getComputedStyle(infoElement).backgroundColor
     : undefined;
-  const infoInk = infoElement ? window.getComputedStyle(infoElement).color : undefined;
+  const infoInk = infoElement
+    ? window.getComputedStyle(infoElement).color
+    : undefined;
   const successText = successElement
     ? window.getComputedStyle(successElement).color
     : undefined;
@@ -318,7 +397,9 @@ function readMonacoThemeProbeTokens(
     info,
     infoBright: infoInk,
     infoInk,
-    ink: surfaceElement ? window.getComputedStyle(surfaceElement).color : undefined,
+    ink: surfaceElement
+      ? window.getComputedStyle(surfaceElement).color
+      : undefined,
     overlay:
       surface && parseColor(surface)
         ? relativeLuminance(parseColor(surface) as RGBColor) >= 0.5

--- a/ui/src/components/prompt-editor/monaco-theme.ts
+++ b/ui/src/components/prompt-editor/monaco-theme.ts
@@ -124,61 +124,209 @@ function readMonacoThemeTokens(root: Element | null): MonacoThemeTokens {
   }
 
   const styles = window.getComputedStyle(root);
+  const stylesheetTokens = readMonacoThemeStylesheetTokens(root);
+  const probeTokens = readMonacoThemeProbeTokens(root);
 
   return {
     accent: readCssColor(styles, [
       "--color-primary",
       "--color-af-accent",
       "--color-af-foundation-accent",
-    ], FALLBACK_THEME_TOKENS.accent),
+    ], pickUsableThemeColor(stylesheetTokens.accent, probeTokens.accent, FALLBACK_THEME_TOKENS.accent)),
     accentStrong: readCssColor(styles, [
       "--color-on-primary-container",
       "--color-af-accent-hover",
       "--color-af-foundation-accent-strong",
-    ], FALLBACK_THEME_TOKENS.accentStrong),
+    ], pickUsableThemeColor(stylesheetTokens.accentStrong, probeTokens.accentStrong, FALLBACK_THEME_TOKENS.accentStrong)),
     code: readCssColor(styles, [
       "--color-code",
       "--color-af-code-ink",
       "--color-af-foundation-code-ink",
-    ], FALLBACK_THEME_TOKENS.code),
+    ], pickUsableThemeColor(stylesheetTokens.code, probeTokens.code, FALLBACK_THEME_TOKENS.code)),
     dangerText: readCssColor(styles, [
       "--color-on-error-container",
       "--color-af-danger-text",
       "--color-af-foundation-danger-ink",
-    ], FALLBACK_THEME_TOKENS.dangerText),
+    ], pickUsableThemeColor(stylesheetTokens.dangerText, probeTokens.dangerText, FALLBACK_THEME_TOKENS.dangerText)),
     info: readCssColor(styles, [
       "--color-info",
       "--color-af-info",
       "--color-af-foundation-info",
-    ], FALLBACK_THEME_TOKENS.info),
+    ], pickUsableThemeColor(stylesheetTokens.info, probeTokens.info, FALLBACK_THEME_TOKENS.info)),
     infoBright: readCssColor(styles, [
       "--color-af-foundation-info-bright",
       "--color-info",
       "--color-af-info",
-    ], FALLBACK_THEME_TOKENS.infoBright),
+    ], pickUsableThemeColor(stylesheetTokens.infoBright, probeTokens.infoBright, FALLBACK_THEME_TOKENS.infoBright)),
     infoInk: readCssColor(styles, [
       "--color-on-info-container",
       "--color-af-info-text",
       "--color-af-foundation-info-ink",
-    ], FALLBACK_THEME_TOKENS.infoInk),
+    ], pickUsableThemeColor(stylesheetTokens.infoInk, probeTokens.infoInk, FALLBACK_THEME_TOKENS.infoInk)),
     ink: readCssColor(styles, [
       "--color-on-surface",
       "--color-af-text",
       "--color-af-foundation-ink",
-    ], FALLBACK_THEME_TOKENS.ink),
+    ], pickUsableThemeColor(stylesheetTokens.ink, probeTokens.ink, FALLBACK_THEME_TOKENS.ink)),
     overlay: readCssColor(styles, [
       "--color-af-foundation-overlay",
-    ], FALLBACK_THEME_TOKENS.overlay),
+    ], pickUsableThemeColor(stylesheetTokens.overlay, probeTokens.overlay, FALLBACK_THEME_TOKENS.overlay)),
     successText: readCssColor(styles, [
       "--color-on-success-container",
       "--color-af-success-text",
       "--color-af-foundation-success-ink",
-    ], FALLBACK_THEME_TOKENS.successText),
+    ], pickUsableThemeColor(stylesheetTokens.successText, probeTokens.successText, FALLBACK_THEME_TOKENS.successText)),
     surface: readCssColor(styles, [
       "--color-surface",
       "--color-af-surface",
       "--color-af-foundation-surface",
-    ], FALLBACK_THEME_TOKENS.surface),
+    ], pickUsableThemeColor(stylesheetTokens.surface, probeTokens.surface, FALLBACK_THEME_TOKENS.surface)),
+  };
+}
+
+function readMonacoThemeStylesheetTokens(
+  root: Element,
+): Partial<MonacoThemeTokens> {
+  const document = root.ownerDocument;
+  const paletteID =
+    document?.documentElement.getAttribute("data-color-palette") ??
+    "factory-dark";
+  if (!document) {
+    return {};
+  }
+
+  const foundationVars = new Map<string, string>();
+  const selectorsToMatch = new Set([
+    ":root",
+    `[data-color-palette=${paletteID}]`,
+    `[data-color-palette="${paletteID}"]`,
+  ]);
+
+  for (const sheet of Array.from(document.styleSheets)) {
+    let rules: CSSRuleList | undefined;
+    try {
+      rules = sheet.cssRules;
+    } catch {
+      continue;
+    }
+
+    for (const rule of Array.from(rules)) {
+      if (!(rule instanceof CSSStyleRule)) {
+        continue;
+      }
+
+      const selectorText = rule.selectorText ?? "";
+      if (![...selectorsToMatch].some((selector) => selectorText.includes(selector))) {
+        continue;
+      }
+
+      for (const name of [
+        "--color-af-foundation-accent",
+        "--color-af-foundation-accent-strong",
+        "--color-af-foundation-code-ink",
+        "--color-af-foundation-danger-ink",
+        "--color-af-foundation-info",
+        "--color-af-foundation-info-bright",
+        "--color-af-foundation-info-ink",
+        "--color-af-foundation-ink",
+        "--color-af-foundation-overlay",
+        "--color-af-foundation-success-ink",
+        "--color-af-foundation-surface",
+      ]) {
+        const value = rule.style.getPropertyValue(name).trim();
+        if (isUsableMonacoThemeColor(value)) {
+          foundationVars.set(name, value);
+        }
+      }
+    }
+  }
+
+  return {
+    accent: foundationVars.get("--color-af-foundation-accent"),
+    accentStrong: foundationVars.get("--color-af-foundation-accent-strong"),
+    code: foundationVars.get("--color-af-foundation-code-ink"),
+    dangerText: foundationVars.get("--color-af-foundation-danger-ink"),
+    info: foundationVars.get("--color-af-foundation-info"),
+    infoBright: foundationVars.get("--color-af-foundation-info-bright"),
+    infoInk: foundationVars.get("--color-af-foundation-info-ink"),
+    ink: foundationVars.get("--color-af-foundation-ink"),
+    overlay: foundationVars.get("--color-af-foundation-overlay"),
+    successText: foundationVars.get("--color-af-foundation-success-ink"),
+    surface: foundationVars.get("--color-af-foundation-surface"),
+  };
+}
+
+function readMonacoThemeProbeTokens(
+  root: Element,
+): Partial<MonacoThemeTokens> {
+  const document = root.ownerDocument;
+  const container = document?.body;
+  if (!document || !container) {
+    return {};
+  }
+
+  const probe = document.createElement("div");
+  probe.setAttribute("aria-hidden", "true");
+  probe.className =
+    "pointer-events-none fixed left-0 top-0 grid gap-0 opacity-0";
+  probe.innerHTML = `
+    <div data-monaco-probe="surface" class="bg-surface text-on-surface border border-outline"></div>
+    <div data-monaco-probe="accent" class="bg-primary text-on-primary-container"></div>
+    <div data-monaco-probe="info" class="bg-info text-on-info-container"></div>
+    <div data-monaco-probe="success" class="bg-success-container text-on-success-container"></div>
+    <div data-monaco-probe="danger" class="bg-error-container text-on-error-container"></div>
+    <div data-monaco-probe="code" class="text-code"></div>
+  `;
+  container.appendChild(probe);
+
+  const read = (name: string) =>
+    probe.querySelector<HTMLElement>(`[data-monaco-probe="${name}"]`);
+  const surfaceElement = read("surface");
+  const accentElement = read("accent");
+  const infoElement = read("info");
+  const successElement = read("success");
+  const dangerElement = read("danger");
+  const codeElement = read("code");
+  const surface = surfaceElement
+    ? window.getComputedStyle(surfaceElement).backgroundColor
+    : undefined;
+  const accent = accentElement
+    ? window.getComputedStyle(accentElement).backgroundColor
+    : undefined;
+  const accentStrong = accentElement
+    ? window.getComputedStyle(accentElement).color
+    : undefined;
+  const code = codeElement ? window.getComputedStyle(codeElement).color : undefined;
+  const dangerText = dangerElement
+    ? window.getComputedStyle(dangerElement).color
+    : undefined;
+  const info = infoElement
+    ? window.getComputedStyle(infoElement).backgroundColor
+    : undefined;
+  const infoInk = infoElement ? window.getComputedStyle(infoElement).color : undefined;
+  const successText = successElement
+    ? window.getComputedStyle(successElement).color
+    : undefined;
+
+  probe.remove();
+
+  return {
+    accent,
+    accentStrong,
+    code,
+    dangerText,
+    info,
+    infoBright: infoInk,
+    infoInk,
+    ink: surfaceElement ? window.getComputedStyle(surfaceElement).color : undefined,
+    overlay:
+      surface && parseColor(surface)
+        ? relativeLuminance(parseColor(surface) as RGBColor) >= 0.5
+          ? "#000000"
+          : "#FFFFFF"
+        : undefined,
+    successText,
+    surface,
   };
 }
 
@@ -189,12 +337,45 @@ function readCssColor(
 ): string {
   for (const name of names) {
     const value = styles.getPropertyValue(name).trim();
-    if (value.length > 0) {
+    if (isUsableMonacoThemeColor(value)) {
       return value;
     }
   }
 
   return fallback;
+}
+
+function isUsableMonacoThemeColor(color: string) {
+  const normalized = color.trim().toLowerCase();
+  if (normalized.length === 0 || normalized === "transparent") {
+    return false;
+  }
+
+  const slashAlphaMatch = normalized.match(
+    /^rgba?\(\s*[0-9.]+\s+[0-9.]+\s+[0-9.]+\s*\/\s*([0-9.]+)\s*\)$/i,
+  );
+  if (slashAlphaMatch && Number.parseFloat(slashAlphaMatch[1]) <= 0) {
+    return false;
+  }
+
+  const commaAlphaMatch = normalized.match(
+    /^rgba\(\s*[0-9.]+\s*,\s*[0-9.]+\s*,\s*[0-9.]+\s*,\s*([0-9.]+)\s*\)$/i,
+  );
+  if (commaAlphaMatch && Number.parseFloat(commaAlphaMatch[1]) <= 0) {
+    return false;
+  }
+
+  return normalized.startsWith("#") || parseColor(normalized) !== null;
+}
+
+function pickUsableThemeColor(...candidates: Array<string | undefined>) {
+  for (const candidate of candidates) {
+    if (candidate && isUsableMonacoThemeColor(candidate)) {
+      return candidate;
+    }
+  }
+
+  return candidates[candidates.length - 1] ?? FALLBACK_THEME_TOKENS.surface;
 }
 
 function resolveMonacoBase(

--- a/ui/src/components/prompt-editor/monaco-theme.ts
+++ b/ui/src/components/prompt-editor/monaco-theme.ts
@@ -1,0 +1,301 @@
+import type { editor as MonacoEditorAPI } from "monaco-editor";
+
+const FALLBACK_THEME_TOKENS = {
+  accent: "#F5C76F",
+  accentStrong: "#ECBF58",
+  code: "#D5FBFF",
+  dangerText: "#FFB2B2",
+  info: "#5CCADD",
+  infoBright: "#7DD3FC",
+  infoInk: "#B5EDF4",
+  ink: "#F7F2E8",
+  overlay: "#FFFFFF",
+  successText: "#A7F0C4",
+  surface: "#091117",
+} as const;
+
+type RGBColor = {
+  blue: number;
+  green: number;
+  red: number;
+};
+
+type MonacoThemeTokens = {
+  accent: string;
+  accentStrong: string;
+  code: string;
+  dangerText: string;
+  info: string;
+  infoBright: string;
+  infoInk: string;
+  ink: string;
+  overlay: string;
+  successText: string;
+  surface: string;
+};
+
+export function buildWorkstationPromptTheme(
+  root: Element | null = document.documentElement,
+): MonacoEditorAPI.IStandaloneThemeData {
+  const tokens = readMonacoThemeTokens(root);
+  const base = resolveMonacoBase(tokens.surface);
+
+  return {
+    base,
+    colors: buildSharedEditorColors(tokens),
+    inherit: true,
+    rules: [
+      { foreground: toMonacoHex(tokens.ink), token: "text" },
+      {
+        fontStyle: "bold",
+        foreground: toMonacoHex(tokens.accent),
+        token: "delimiter.template",
+      },
+      { foreground: toMonacoHex(tokens.infoBright), token: "keyword.template" },
+      {
+        foreground: toMonacoHex(tokens.infoInk),
+        token: "keyword.function.template",
+      },
+      { foreground: toMonacoHex(tokens.ink), token: "identifier.template" },
+      { foreground: toMonacoHex(tokens.successText), token: "string.template" },
+      { foreground: toMonacoHex(tokens.accentStrong), token: "number.template" },
+      { foreground: toMonacoHex(tokens.dangerText), token: "variable.local" },
+      { foreground: toMonacoHex(tokens.code), token: "variable.root" },
+    ],
+  };
+}
+
+export function buildWorkstationGuardSelectorTheme(
+  root: Element | null = document.documentElement,
+): MonacoEditorAPI.IStandaloneThemeData {
+  const tokens = readMonacoThemeTokens(root);
+  const base = resolveMonacoBase(tokens.surface);
+
+  return {
+    base,
+    colors: buildSharedEditorColors(tokens),
+    inherit: true,
+    rules: [
+      { foreground: toMonacoHex(tokens.ink), token: "text" },
+      { foreground: toMonacoHex(tokens.code), token: "selector.field" },
+      { foreground: toMonacoHex(tokens.successText), token: "selector.tag" },
+    ],
+  };
+}
+
+function buildSharedEditorColors(
+  tokens: MonacoThemeTokens,
+): MonacoEditorAPI.IColors {
+  const base = resolveMonacoBase(tokens.surface);
+  const selectionOpacity = base === "vs" ? 0.18 : 0.24;
+  const inactiveSelectionOpacity = base === "vs" ? 0.12 : 0.16;
+  const widgetSelectionOpacity = base === "vs" ? 0.12 : 0.18;
+
+  return {
+    "editor.background": tokens.surface,
+    "editor.foreground": tokens.ink,
+    "editor.lineHighlightBackground": withAlpha(tokens.overlay, 0.04),
+    "editor.selectionBackground": withAlpha(tokens.info, selectionOpacity),
+    "editor.inactiveSelectionBackground": withAlpha(
+      tokens.info,
+      inactiveSelectionOpacity,
+    ),
+    "editorCursor.foreground": tokens.accent,
+    "editorWhitespace.foreground": withAlpha(tokens.overlay, 0.14),
+    "editorIndentGuide.background1": withAlpha(tokens.overlay, 0.08),
+    "editorIndentGuide.activeBackground1": withAlpha(tokens.overlay, 0.18),
+    "editorWidget.background": tokens.surface,
+    "editorWidget.border": withAlpha(tokens.overlay, 0.12),
+    "editorSuggestWidget.background": tokens.surface,
+    "editorSuggestWidget.foreground": tokens.ink,
+    "editorSuggestWidget.selectedBackground": withAlpha(
+      tokens.info,
+      widgetSelectionOpacity,
+    ),
+    "editorSuggestWidget.highlightForeground": tokens.accent,
+    "editorHoverWidget.background": tokens.surface,
+    "editorHoverWidget.border": withAlpha(tokens.overlay, 0.12),
+  };
+}
+
+function readMonacoThemeTokens(root: Element | null): MonacoThemeTokens {
+  if (typeof window === "undefined" || !root) {
+    return { ...FALLBACK_THEME_TOKENS };
+  }
+
+  const styles = window.getComputedStyle(root);
+
+  return {
+    accent: readCssColor(styles, [
+      "--color-primary",
+      "--color-af-accent",
+      "--color-af-foundation-accent",
+    ], FALLBACK_THEME_TOKENS.accent),
+    accentStrong: readCssColor(styles, [
+      "--color-on-primary-container",
+      "--color-af-accent-hover",
+      "--color-af-foundation-accent-strong",
+    ], FALLBACK_THEME_TOKENS.accentStrong),
+    code: readCssColor(styles, [
+      "--color-code",
+      "--color-af-code-ink",
+      "--color-af-foundation-code-ink",
+    ], FALLBACK_THEME_TOKENS.code),
+    dangerText: readCssColor(styles, [
+      "--color-on-error-container",
+      "--color-af-danger-text",
+      "--color-af-foundation-danger-ink",
+    ], FALLBACK_THEME_TOKENS.dangerText),
+    info: readCssColor(styles, [
+      "--color-info",
+      "--color-af-info",
+      "--color-af-foundation-info",
+    ], FALLBACK_THEME_TOKENS.info),
+    infoBright: readCssColor(styles, [
+      "--color-af-foundation-info-bright",
+      "--color-info",
+      "--color-af-info",
+    ], FALLBACK_THEME_TOKENS.infoBright),
+    infoInk: readCssColor(styles, [
+      "--color-on-info-container",
+      "--color-af-info-text",
+      "--color-af-foundation-info-ink",
+    ], FALLBACK_THEME_TOKENS.infoInk),
+    ink: readCssColor(styles, [
+      "--color-on-surface",
+      "--color-af-text",
+      "--color-af-foundation-ink",
+    ], FALLBACK_THEME_TOKENS.ink),
+    overlay: readCssColor(styles, [
+      "--color-af-foundation-overlay",
+    ], FALLBACK_THEME_TOKENS.overlay),
+    successText: readCssColor(styles, [
+      "--color-on-success-container",
+      "--color-af-success-text",
+      "--color-af-foundation-success-ink",
+    ], FALLBACK_THEME_TOKENS.successText),
+    surface: readCssColor(styles, [
+      "--color-surface",
+      "--color-af-surface",
+      "--color-af-foundation-surface",
+    ], FALLBACK_THEME_TOKENS.surface),
+  };
+}
+
+function readCssColor(
+  styles: CSSStyleDeclaration,
+  names: readonly string[],
+  fallback: string,
+): string {
+  for (const name of names) {
+    const value = styles.getPropertyValue(name).trim();
+    if (value.length > 0) {
+      return value;
+    }
+  }
+
+  return fallback;
+}
+
+function resolveMonacoBase(
+  backgroundColor: string,
+): MonacoEditorAPI.BuiltinTheme {
+  const rgb = parseColor(backgroundColor);
+  if (!rgb) {
+    return "vs-dark";
+  }
+
+  return relativeLuminance(rgb) >= 0.5 ? "vs" : "vs-dark";
+}
+
+function relativeLuminance({ blue, green, red }: RGBColor) {
+  const [r, g, b] = [red, green, blue].map((channel) => {
+    const normalized = channel / 255;
+    if (normalized <= 0.03928) {
+      return normalized / 12.92;
+    }
+
+    return ((normalized + 0.055) / 1.055) ** 2.4;
+  });
+
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function withAlpha(color: string, alpha: number) {
+  const rgb = parseColor(color);
+  if (!rgb) {
+    return color;
+  }
+
+  return `#${toMonacoHex(color)}${toAlphaHex(alpha)}`;
+}
+
+function toMonacoHex(color: string) {
+  const rgb = parseColor(color);
+  if (!rgb) {
+    return color.replace(/^#/, "").toUpperCase();
+  }
+
+  return [rgb.red, rgb.green, rgb.blue]
+    .map((channel) => channel.toString(16).padStart(2, "0").toUpperCase())
+    .join("");
+}
+
+function parseColor(color: string): RGBColor | null {
+  const normalized = color.trim();
+  if (normalized.startsWith("#")) {
+    return parseHexColor(normalized);
+  }
+
+  const rgbMatch = normalized.match(
+    /^rgba?\(\s*([0-9.]+)\s+([0-9.]+)\s+([0-9.]+)(?:\s*\/\s*[0-9.]+)?\s*\)$/i,
+  );
+  if (rgbMatch) {
+    return {
+      blue: Number.parseFloat(rgbMatch[3]),
+      green: Number.parseFloat(rgbMatch[2]),
+      red: Number.parseFloat(rgbMatch[1]),
+    };
+  }
+
+  const commaSeparatedRgbMatch = normalized.match(
+    /^rgba?\(\s*([0-9.]+)\s*,\s*([0-9.]+)\s*,\s*([0-9.]+)(?:\s*,\s*[0-9.]+)?\s*\)$/i,
+  );
+  if (commaSeparatedRgbMatch) {
+    return {
+      blue: Number.parseFloat(commaSeparatedRgbMatch[3]),
+      green: Number.parseFloat(commaSeparatedRgbMatch[2]),
+      red: Number.parseFloat(commaSeparatedRgbMatch[1]),
+    };
+  }
+
+  return null;
+}
+
+function parseHexColor(color: string): RGBColor | null {
+  const hex = color.slice(1);
+  if (hex.length === 3) {
+    return {
+      blue: Number.parseInt(hex[2] + hex[2], 16),
+      green: Number.parseInt(hex[1] + hex[1], 16),
+      red: Number.parseInt(hex[0] + hex[0], 16),
+    };
+  }
+
+  if (hex.length === 6 || hex.length === 8) {
+    return {
+      blue: Number.parseInt(hex.slice(4, 6), 16),
+      green: Number.parseInt(hex.slice(2, 4), 16),
+      red: Number.parseInt(hex.slice(0, 2), 16),
+    };
+  }
+
+  return null;
+}
+
+function toAlphaHex(alpha: number) {
+  return Math.round(Math.min(Math.max(alpha, 0), 1) * 255)
+    .toString(16)
+    .padStart(2, "0")
+    .toUpperCase();
+}

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport-errors.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport-errors.test.tsx
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import type { Edge, Node } from "@xyflow/react";
 import type { ReactNode } from "react";
 
@@ -120,12 +120,57 @@ const importController: CurrentActivityImportController = {
   onDrop: vi.fn(),
 };
 
+const DEFAULT_GRAPH_RECT = {
+  bottom: 720,
+  height: 720,
+  left: 0,
+  right: 1280,
+  top: 0,
+  width: 1280,
+  x: 0,
+  y: 0,
+  toJSON: () => ({}),
+} as DOMRect;
+
 afterEach(() => {
   cleanup();
   reactFlowErrorToReport = null;
 });
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: React Flow error coverage keeps the viewport bootstrap setup and endpoint assertions together.
 describe("CurrentActivityGraphViewport React Flow errors", () => {
+  const originalBoundingClientRect =
+    HTMLElement.prototype.getBoundingClientRect;
+  const originalResizeObserver = globalThis.ResizeObserver;
+
+  beforeEach(() => {
+    HTMLElement.prototype.getBoundingClientRect = () => DEFAULT_GRAPH_RECT;
+    globalThis.ResizeObserver = class {
+      public constructor(private readonly callback: ResizeObserverCallback) {}
+
+      public disconnect(): void {}
+
+      public observe(target: Element): void {
+        this.callback(
+          [
+            {
+              contentRect: DEFAULT_GRAPH_RECT,
+              target,
+            } as ResizeObserverEntry,
+          ],
+          this as unknown as ResizeObserver,
+        );
+      }
+
+      public unobserve(): void {}
+    } as unknown as typeof ResizeObserver;
+  });
+
+  afterEach(() => {
+    HTMLElement.prototype.getBoundingClientRect = originalBoundingClientRect;
+    globalThis.ResizeObserver = originalResizeObserver;
+  });
+
   it("throws when React Flow reports an edge endpoint handle mismatch", () => {
     reactFlowErrorToReport = {
       errorId: "008",
@@ -138,8 +183,8 @@ describe("CurrentActivityGraphViewport React Flow errors", () => {
     );
   });
 
-  it("renders semantic endpoint edges when source and target handles exist", () => {
-    const { getByRole } = renderViewport({
+  it("renders semantic endpoint edges when source and target handles exist", async () => {
+    renderViewport({
       edges: [
         {
           id: "workstation-output:workstation:review->place:story:done",
@@ -156,7 +201,8 @@ describe("CurrentActivityGraphViewport React Flow errors", () => {
     });
 
     expect(
-      getByRole("list", { name: "Rendered graph edges" }).textContent,
+      (await screen.findByRole("list", { name: "Rendered graph edges" }))
+        .textContent,
     ).toContain("workstation-output:workstation:review->place:story:done");
   });
 
@@ -268,6 +314,8 @@ function renderViewport({
   edges?: Edge[];
   nodes?: Node[];
 } = {}) {
+  const flowContainerRef = { current: null as HTMLElement | null };
+
   return render(
     <CurrentActivityGraphViewport
       activeTool={null}
@@ -275,6 +323,7 @@ function renderViewport({
       canSaveDraft={false}
       editorMode={false}
       edges={edges}
+      flowContainerRef={flowContainerRef}
       graphKey="test-graph"
       handleDiscardPendingChanges={vi.fn()}
       handleNodesChange={vi.fn()}

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.test.tsx
@@ -64,8 +64,52 @@ const importController: CurrentActivityImportController = {
   onDrop: vi.fn(),
 };
 
+const DEFAULT_GRAPH_RECT = {
+  bottom: 720,
+  height: 720,
+  left: 0,
+  right: 1280,
+  top: 0,
+  width: 1280,
+  x: 0,
+  y: 0,
+  toJSON: () => ({}),
+} as DOMRect;
+
 // biome-ignore lint/complexity/noExcessiveLinesPerFunction: viewport coverage keeps related mocked React Flow click paths together.
 describe("CurrentActivityGraphViewport", () => {
+  const originalBoundingClientRect =
+    HTMLElement.prototype.getBoundingClientRect;
+  const originalResizeObserver = globalThis.ResizeObserver;
+
+  beforeEach(() => {
+    HTMLElement.prototype.getBoundingClientRect = () => DEFAULT_GRAPH_RECT;
+    globalThis.ResizeObserver = class {
+      public constructor(private readonly callback: ResizeObserverCallback) {}
+
+      public disconnect(): void {}
+
+      public observe(target: Element): void {
+        this.callback(
+          [
+            {
+              contentRect: DEFAULT_GRAPH_RECT,
+              target,
+            } as ResizeObserverEntry,
+          ],
+          this as unknown as ResizeObserver,
+        );
+      }
+
+      public unobserve(): void {}
+    } as unknown as typeof ResizeObserver;
+  });
+
+  afterEach(() => {
+    HTMLElement.prototype.getBoundingClientRect = originalBoundingClientRect;
+    globalThis.ResizeObserver = originalResizeObserver;
+  });
+
   it("renders hide/show controls in observer mode without editor tools", () => {
     renderViewport({ editorMode: false });
 
@@ -106,7 +150,7 @@ describe("CurrentActivityGraphViewport", () => {
       kind: "resource",
       renderedNodeId: "resource:gpu",
     },
-  ])("maps rendered $kind nodes to factory graph ids before editor node deletion", ({
+  ])("maps rendered $kind nodes to factory graph ids before editor node deletion", async ({
     expectedNodeId,
     kind,
     renderedNodeId,
@@ -129,7 +173,9 @@ describe("CurrentActivityGraphViewport", () => {
       onEditorNodeClick: handleEditorNodeClick,
     });
 
-    fireEvent.click(screen.getByRole("button", { name: renderedNodeId }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: renderedNodeId }),
+    );
 
     expect(handleEditorNodeClick).toHaveBeenCalledWith(expectedNodeId);
   });
@@ -160,7 +206,7 @@ describe("CurrentActivityGraphViewport", () => {
       target: "workstation:review",
       targetFactoryGraphNodeId: "workstation:review",
     },
-  ])("maps rendered edge endpoints to factory graph ids before edge deletion", ({
+  ])("maps rendered edge endpoints to factory graph ids before edge deletion", async ({
     expectedEdgeId,
     renderedEdgeId,
     source,
@@ -201,12 +247,14 @@ describe("CurrentActivityGraphViewport", () => {
       onEditorEdgeClick: handleEditorEdgeClick,
     });
 
-    fireEvent.click(screen.getByRole("button", { name: renderedEdgeId }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: renderedEdgeId }),
+    );
 
     expect(handleEditorEdgeClick).toHaveBeenCalledWith(expectedEdgeId);
   });
 
-  it("keeps canonical edge ids unchanged before editor edge deletion", () => {
+  it("keeps canonical edge ids unchanged before editor edge deletion", async () => {
     const handleEditorEdgeClick = vi.fn();
 
     renderViewport({
@@ -224,7 +272,7 @@ describe("CurrentActivityGraphViewport", () => {
     });
 
     fireEvent.click(
-      screen.getByRole("button", {
+      await screen.findByRole("button", {
         name: "workstation-output:workstation:review->work-state:story:done",
       }),
     );
@@ -234,7 +282,7 @@ describe("CurrentActivityGraphViewport", () => {
     );
   });
 
-  it("does not delete graph entities while outside editor mode", () => {
+  it("does not delete graph entities while outside editor mode", async () => {
     const handleEditorNodeClick = vi.fn();
     const handleEditorEdgeClick = vi.fn();
 
@@ -262,9 +310,11 @@ describe("CurrentActivityGraphViewport", () => {
       onEditorNodeClick: handleEditorNodeClick,
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "work-type:story" }));
     fireEvent.click(
-      screen.getByRole("button", {
+      await screen.findByRole("button", { name: "work-type:story" }),
+    );
+    fireEvent.click(
+      await screen.findByRole("button", {
         name: "worker-resource:resource:gpu->place:worker:writer",
       }),
     );
@@ -289,6 +339,8 @@ function renderViewport({
   onEditorEdgeClick?: (edgeId: string) => void;
   onEditorNodeClick?: (nodeId: string) => void;
 } = {}) {
+  const flowContainerRef = { current: null as HTMLElement | null };
+
   return render(
     <CurrentActivityGraphViewport
       activeTool={activeTool}
@@ -296,6 +348,7 @@ function renderViewport({
       canSaveDraft={false}
       editorMode={editorMode}
       edges={edges}
+      flowContainerRef={flowContainerRef}
       graphKey="test-graph"
       handleDiscardPendingChanges={vi.fn()}
       handleNodesChange={vi.fn()}

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
@@ -27,6 +27,7 @@ import { isValidFactoryGraphConnection } from "../../factory-graph-editor/lib/fa
 import { getFactoryGraphEditorMessages } from "../../factory-graph-editor/messages/editor";
 import type { CurrentActivityImportController } from "../hooks/current-activity-import-controller";
 import { handleCurrentActivityReactFlowError } from "../lib/react-flow-current-activity-card-errors";
+import { useMeasuredCurrentActivityGraphViewport } from "../lib/use-measured-current-activity-graph-viewport";
 import {
   DashboardFlowAxisLegend,
   getDefaultDashboardFlowAxisLegendEdgeItems,
@@ -240,6 +241,8 @@ export function CurrentActivityGraphViewport({
     editorMode,
     nodes,
   });
+  const graphViewport =
+    useMeasuredCurrentActivityGraphViewport(flowContainerRef);
   const handleConnect = useCallback(
     (connection: Connection) => {
       onConnect?.({
@@ -266,7 +269,6 @@ export function CurrentActivityGraphViewport({
         locale={locale}
       />
       <section
-        ref={flowContainerRef}
         aria-describedby={headingID}
         aria-label={editorMessages.viewportLabel}
         className={cn(
@@ -282,65 +284,77 @@ export function CurrentActivityGraphViewport({
           imports.dropState,
         )}
         data-current-activity-flow
+        ref={flowContainerRef}
         onDragEnter={imports.onDragEnter}
         onDragLeave={imports.onDragLeave}
         onDragOver={imports.onDragOver}
         onDrop={imports.onDrop}
       >
-        <ReactFlow
-          connectionLineStyle={{
-            stroke: "var(--color-primary)",
-            strokeWidth: 2.4,
-          }}
-          edges={edges}
-          edgeTypes={edgeTypes}
-          fitView
-          fitViewOptions={initialFitViewOptions}
-          key={initialFitViewKey}
-          isValidConnection={isValidConnection}
-          maxZoom={2}
-          minZoom={0.25}
-          nodeTypes={nodeTypes}
-          nodes={nodes}
-          edgesFocusable={editorMode}
-          nodesConnectable={editorMode && activeTool === "connect"}
-          onConnect={handleConnect}
-          onInit={(instance) => {
-            if (flowInstanceRef) {
-              flowInstanceRef.current = instance;
-            }
-          }}
-          onError={handleCurrentActivityReactFlowError}
-          onEdgeClick={(_, edge) => {
-            if (editorMode) {
-              onEditorEdgeClick?.(
-                factoryGraphEdgeIdForRenderedEdge(nodes, edge),
-              );
-            }
-          }}
-          nodesDraggable={true}
-          onNodeClick={(_, node) => {
-            if (editorMode) {
-              onEditorNodeClick?.(
-                factoryGraphNodeIdForRenderedNode(nodes, node.id),
-              );
-            }
-          }}
-          onNodeDragStop={(_, node) => {
-            if (graphKey) {
-              setStoredNodePosition(graphKey, node.id, node.position);
-            }
-          }}
-          onNodesChange={handleNodesChange}
-          panOnDrag
-          proOptions={{ hideAttribution: true }}
-          zoomOnScroll
-        >
-          <DashboardGraphBackground />
-          <DashboardGraphControls
-            fitViewOptions={{ maxZoom: 1.2, padding: 0.12 }}
-          />
-        </ReactFlow>
+        {graphViewport.ready ? (
+          <div
+            className="absolute left-0 top-0"
+            data-current-activity-flow-viewport
+            style={{
+              height: `${graphViewport.height}px`,
+              width: `${graphViewport.width}px`,
+            }}
+          >
+            <ReactFlow
+              connectionLineStyle={{
+                stroke: "var(--color-primary)",
+                strokeWidth: 2.4,
+              }}
+              edges={edges}
+              edgeTypes={edgeTypes}
+              fitView
+              fitViewOptions={initialFitViewOptions}
+              key={initialFitViewKey}
+              isValidConnection={isValidConnection}
+              maxZoom={2}
+              minZoom={0.25}
+              nodeTypes={nodeTypes}
+              nodes={nodes}
+              edgesFocusable={editorMode}
+              nodesConnectable={editorMode && activeTool === "connect"}
+              onConnect={handleConnect}
+              onInit={(instance) => {
+                if (flowInstanceRef) {
+                  flowInstanceRef.current = instance;
+                }
+              }}
+              onError={handleCurrentActivityReactFlowError}
+              onEdgeClick={(_, edge) => {
+                if (editorMode) {
+                  onEditorEdgeClick?.(
+                    factoryGraphEdgeIdForRenderedEdge(nodes, edge),
+                  );
+                }
+              }}
+              nodesDraggable={true}
+              onNodeClick={(_, node) => {
+                if (editorMode) {
+                  onEditorNodeClick?.(
+                    factoryGraphNodeIdForRenderedNode(nodes, node.id),
+                  );
+                }
+              }}
+              onNodeDragStop={(_, node) => {
+                if (graphKey) {
+                  setStoredNodePosition(graphKey, node.id, node.position);
+                }
+              }}
+              onNodesChange={handleNodesChange}
+              panOnDrag
+              proOptions={{ hideAttribution: true }}
+              zoomOnScroll
+            >
+              <DashboardGraphBackground />
+              <DashboardGraphControls
+                fitViewOptions={{ maxZoom: 1.2, padding: 0.12 }}
+              />
+            </ReactFlow>
+          </div>
+        ) : null}
         <CurrentActivityGraphEditorChrome
           activeTool={activeTool}
           addMenuActions={addMenuActions}

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card.coverage.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card.coverage.test.tsx
@@ -335,9 +335,46 @@ function createProps(
 }
 
 describe("ReactFlowCurrentActivityCard coverage", () => {
+  const originalBoundingClientRect =
+    HTMLElement.prototype.getBoundingClientRect;
+  const originalResizeObserver = globalThis.ResizeObserver;
+
   beforeEach(() => {
     mockBuildGraphLayout.mockReset();
     mockSetStoredNodePosition.mockReset();
+    HTMLElement.prototype.getBoundingClientRect = () =>
+      ({
+        bottom: 720,
+        height: 720,
+        left: 0,
+        right: 1280,
+        top: 0,
+        width: 1280,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+    globalThis.ResizeObserver = class {
+      public constructor(private readonly callback: ResizeObserverCallback) {}
+
+      public disconnect(): void {}
+
+      public observe(target: Element): void {
+        this.callback(
+          [
+            {
+              contentRect: HTMLElement.prototype.getBoundingClientRect.call(
+                target,
+              ),
+              target,
+            } as ResizeObserverEntry,
+          ],
+          this as unknown as ResizeObserver,
+        );
+      }
+
+      public unobserve(): void {}
+    } as unknown as typeof ResizeObserver;
     vi.mocked(useCurrentFactoryDocument).mockReturnValue({
       data: undefined,
       error: null,
@@ -353,6 +390,11 @@ describe("ReactFlowCurrentActivityCard coverage", () => {
     vi.mocked(useFactoryGraphDraftState).mockReturnValue(
       defaultDraftState as never,
     );
+  });
+
+  afterEach(() => {
+    HTMLElement.prototype.getBoundingClientRect = originalBoundingClientRect;
+    globalThis.ResizeObserver = originalResizeObserver;
   });
 
   it("renders the empty topology fallback when no workstation nodes exist", async () => {
@@ -777,16 +819,23 @@ function renderViewport({
     typeof CurrentActivityGraphViewport
   >[0]["onEditorNodeClick"];
 }) {
+  const flowContainerRef = { current: null as HTMLElement | null };
+
   return render(
     <CurrentActivityGraphViewport
       activeTool={activeTool}
       addMenuActions={addMenuActions}
       canInteractWithEditor={editorMode}
+      canSaveDraft={false}
       editorMode={editorMode}
       edges={[]}
+      flowContainerRef={flowContainerRef}
       graphKey={graphKey}
+      handleDiscardPendingChanges={vi.fn()}
       handleNodesChange={vi.fn()}
+      handleSaveDraft={vi.fn()}
       hasPendingChanges={false}
+      headingID="test-heading"
       hiddenNodeClasses={new Set()}
       hideShowMenuOpen={false}
       imports={mockImportController}

--- a/ui/src/features/workflow-activity/components/workflow-activity-bento-card.tsx
+++ b/ui/src/features/workflow-activity/components/workflow-activity-bento-card.tsx
@@ -88,6 +88,7 @@ export function WorkflowActivityBentoCard({
 
   return (
     <AgentBentoCard
+      bodyScroll={false}
       chromeDensity="compact"
       headerAction={
         <CurrentActivityGraphHeaderActions

--- a/ui/src/features/workflow-activity/lib/use-measured-current-activity-graph-viewport.test.tsx
+++ b/ui/src/features/workflow-activity/lib/use-measured-current-activity-graph-viewport.test.tsx
@@ -1,0 +1,161 @@
+import { act, render, screen } from "@testing-library/react";
+import { useRef } from "react";
+
+import { useMeasuredCurrentActivityGraphViewport } from "./use-measured-current-activity-graph-viewport";
+
+function HookProbe() {
+  const graphViewportRef = useRef<HTMLElement | null>(null);
+  const graphViewportReady =
+    useMeasuredCurrentActivityGraphViewport(graphViewportRef);
+
+  return (
+    <section
+      data-height={String(graphViewportReady.height)}
+      aria-label="Measured graph viewport"
+      data-ready={String(graphViewportReady.ready)}
+      data-width={String(graphViewportReady.width)}
+      ref={graphViewportRef}
+    />
+  );
+}
+
+describe("useMeasuredCurrentActivityGraphViewport", () => {
+  const originalResizeObserver = globalThis.ResizeObserver;
+  const originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(
+    window.navigator,
+    "userAgent",
+  );
+  const originalBoundingClientRect =
+    HTMLElement.prototype.getBoundingClientRect;
+  const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+  const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+
+  afterEach(() => {
+    globalThis.ResizeObserver = originalResizeObserver;
+    globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+    if (originalNavigatorDescriptor) {
+      Object.defineProperty(
+        window.navigator,
+        "userAgent",
+        originalNavigatorDescriptor,
+      );
+    }
+    HTMLElement.prototype.getBoundingClientRect = originalBoundingClientRect;
+  });
+
+  it("waits for non-zero viewport dimensions before marking the graph ready", () => {
+    let resizeCallback: ResizeObserverCallback | undefined;
+
+    class ResizeObserverMock {
+      public constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback;
+      }
+
+      public disconnect(): void {}
+
+      public observe(): void {}
+
+      public unobserve(): void {}
+    }
+
+    Object.defineProperty(window.navigator, "userAgent", {
+      configurable: true,
+      value: "Mozilla/5.0",
+    });
+    globalThis.ResizeObserver =
+      ResizeObserverMock as unknown as typeof ResizeObserver;
+    HTMLElement.prototype.getBoundingClientRect = () =>
+      ({
+        bottom: 0,
+        height: 0,
+        left: 0,
+        right: 0,
+        top: 0,
+        width: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    render(<HookProbe />);
+
+    const probe = screen.getByRole("region", {
+      name: "Measured graph viewport",
+    });
+    expect(probe.getAttribute("data-ready")).toBe("false");
+
+    act(() => {
+      resizeCallback?.(
+        [
+          {
+            contentRect: {
+              bottom: 480,
+              height: 480,
+              left: 0,
+              right: 640,
+              top: 0,
+              width: 640,
+              x: 0,
+              y: 0,
+              toJSON: () => ({}),
+            },
+          } as ResizeObserverEntry,
+        ],
+        {} as ResizeObserver,
+      );
+    });
+
+    expect(probe.getAttribute("data-ready")).toBe("true");
+    expect(probe.getAttribute("data-width")).toBe("640");
+    expect(probe.getAttribute("data-height")).toBe("480");
+  });
+
+  it("retries on animation frames until the viewport measures non-zero", () => {
+    let requestAnimationFrameCallback: FrameRequestCallback | undefined;
+    let measureCount = 0;
+
+    Object.defineProperty(window.navigator, "userAgent", {
+      configurable: true,
+      value: "Mozilla/5.0",
+    });
+    globalThis.ResizeObserver = undefined;
+    globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      requestAnimationFrameCallback = callback;
+      return 1;
+    }) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = vi.fn();
+    HTMLElement.prototype.getBoundingClientRect = () => {
+      measureCount += 1;
+      const width = measureCount >= 2 ? 640 : 0;
+      const height = measureCount >= 2 ? 480 : 0;
+
+      return {
+        bottom: height,
+        height,
+        left: 0,
+        right: width,
+        top: 0,
+        width,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      } as DOMRect;
+    };
+
+    render(<HookProbe />);
+
+    const probe = screen.getByRole("region", {
+      name: "Measured graph viewport",
+    });
+    expect(probe.getAttribute("data-ready")).toBe("false");
+
+    act(() => {
+      requestAnimationFrameCallback?.(16);
+    });
+
+    expect(probe.getAttribute("data-ready")).toBe("true");
+    expect(probe.getAttribute("data-width")).toBe("640");
+    expect(probe.getAttribute("data-height")).toBe("480");
+  });
+});

--- a/ui/src/features/workflow-activity/lib/use-measured-current-activity-graph-viewport.ts
+++ b/ui/src/features/workflow-activity/lib/use-measured-current-activity-graph-viewport.ts
@@ -1,0 +1,127 @@
+import type { MutableRefObject } from "react";
+import { useLayoutEffect, useState } from "react";
+
+interface MeasuredCurrentActivityGraphViewport {
+  height: number;
+  ready: boolean;
+  width: number;
+}
+
+function isJsdomRuntime() {
+  return (
+    typeof navigator !== "undefined" &&
+    navigator.userAgent.toLowerCase().includes("jsdom")
+  );
+}
+
+export function useMeasuredCurrentActivityGraphViewport(
+  graphViewportRef?: MutableRefObject<HTMLElement | null>,
+) {
+  const [graphViewport, setGraphViewport] =
+    useState<MeasuredCurrentActivityGraphViewport>(() => ({
+      height: 0,
+      ready: typeof window === "undefined" || isJsdomRuntime(),
+      width: 0,
+    }));
+
+  useLayoutEffect(() => {
+    const graphViewport = graphViewportRef?.current;
+    if (!graphViewport) {
+      setGraphViewport({ height: 0, ready: false, width: 0 });
+      return;
+    }
+
+    if (isJsdomRuntime()) {
+      const rect = graphViewport.getBoundingClientRect();
+      setGraphViewport({
+        height: rect.height,
+        ready: true,
+        width: rect.width,
+      });
+      return;
+    }
+
+    let animationFrameID = 0;
+    let disposed = false;
+
+    const updateReadyState = (width: number, height: number) => {
+      const ready = width > 0 && height > 0;
+      setGraphViewport((current) => {
+        if (
+          current.ready === ready &&
+          current.width === width &&
+          current.height === height
+        ) {
+          return current;
+        }
+
+        return {
+          height,
+          ready,
+          width,
+        };
+      });
+      if (ready && animationFrameID !== 0) {
+        cancelAnimationFrame(animationFrameID);
+        animationFrameID = 0;
+      }
+      return ready;
+    };
+    const measureGraphViewport = () => {
+      const rect = graphViewport.getBoundingClientRect();
+      return updateReadyState(rect.width, rect.height);
+    };
+    const scheduleAnimationFrameMeasure = () => {
+      if (animationFrameID !== 0 || disposed) {
+        return;
+      }
+
+      animationFrameID = requestAnimationFrame(() => {
+        animationFrameID = 0;
+        if (disposed) {
+          return;
+        }
+        if (!measureGraphViewport()) {
+          scheduleAnimationFrameMeasure();
+        }
+      });
+    };
+
+    if (!measureGraphViewport()) {
+      scheduleAnimationFrameMeasure();
+    }
+
+    if (typeof ResizeObserver === "undefined") {
+      return () => {
+        disposed = true;
+        if (animationFrameID !== 0) {
+          cancelAnimationFrame(animationFrameID);
+        }
+      };
+    }
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) {
+        if (!measureGraphViewport()) {
+          scheduleAnimationFrameMeasure();
+        }
+        return;
+      }
+
+      updateReadyState(entry.contentRect.width, entry.contentRect.height);
+    });
+
+    resizeObserver.observe(graphViewport);
+
+    return () => {
+      disposed = true;
+      if (animationFrameID !== 0) {
+        cancelAnimationFrame(animationFrameID);
+      }
+      resizeObserver.disconnect();
+    };
+  }, [graphViewportRef]);
+
+  return graphViewport;
+}

--- a/ui/src/testing/vitest-monaco-editor-mock.tsx
+++ b/ui/src/testing/vitest-monaco-editor-mock.tsx
@@ -1,6 +1,9 @@
 import {
   createElement,
+  type Dispatch,
+  type RefObject,
   type ReactNode,
+  type SetStateAction,
   useEffect,
   useMemo,
   useRef,
@@ -18,6 +21,16 @@ type MonacoEditorMockProps = {
   wrapperProps?: Record<string, string | undefined>;
 };
 
+type MonacoMarkers = Array<{
+  endColumn: number;
+  endLineNumber: number;
+  message: string;
+  startColumn: number;
+  startLineNumber: number;
+}>;
+
+type MonacoThemeApplications = Array<{ base: string | null; name: string }>;
+
 export function MonacoEditorMock({
   className,
   loading,
@@ -27,15 +40,10 @@ export function MonacoEditorMock({
   value,
   wrapperProps,
 }: MonacoEditorMockProps) {
-  const [markers, setMarkers] = useState<
-    Array<{
-      endColumn: number;
-      endLineNumber: number;
-      message: string;
-      startColumn: number;
-      startLineNumber: number;
-    }>
-  >([]);
+  const [markers, setMarkers] = useState<MonacoMarkers>([]);
+  const [themeApplications, setThemeApplications] =
+    useState<MonacoThemeApplications>([]);
+  const [appliedThemeNames, setAppliedThemeNames] = useState<string[]>([]);
   const editorValueRef = useRef(value ?? "");
   editorValueRef.current = value ?? "";
   const contentChangeListenersRef = useRef<
@@ -52,60 +60,19 @@ export function MonacoEditorMock({
 
   useEffect(() => {
     const disposeListeners: Array<() => void> = [];
-    const triggerSuggest = vi.fn();
     contentChangeListenersRef.current = [];
     onMount?.(
-      {
-        addCommand: () => undefined,
-        getModel: () => model,
-        getPosition: () => ({ column: 1, lineNumber: 1 }),
-        getScrollLeft: () => 0,
-        getScrollTop: () => 0,
-        getValue: () => editorValueRef.current,
-        onDidDispose: (listener: () => void) => {
-          disposeListeners.push(listener);
-          return { dispose() {} };
-        },
-        onDidChangeModelContent: (
-          listener: (event: { changes: Array<{ text: string }> }) => void,
-        ) => {
-          contentChangeListenersRef.current.push(listener);
-          return {
-            dispose() {
-              contentChangeListenersRef.current =
-                contentChangeListenersRef.current.filter(
-                  (registeredListener) => registeredListener !== listener,
-                );
-            },
-          };
-        },
-        onDidScrollChange: (
-          listener: (event: { scrollLeft: number; scrollTop: number }) => void,
-        ) => {
-          listener({ scrollLeft: 3, scrollTop: 4 });
-          return { dispose() {} };
-        },
-        trigger: triggerSuggest,
-      },
-      {
-        KeyCode: { Space: 10 },
-        editor: {
-          setModelMarkers: (
-            nextModel: typeof model,
-            _owner: string,
-            nextMarkers: typeof markers,
-          ) => {
-            nextModel.__setMarkers(nextMarkers);
-          },
-        },
-        languages: {
-          CompletionItemKind: { Field: 13, Variable: 4 },
-          CompletionTriggerKind: { Invoke: 0, TriggerCharacter: 1 },
-          registerCompletionItemProvider: () => ({
-            dispose() {},
-          }),
-        },
-      },
+      createMockEditorInstance({
+        contentChangeListenersRef,
+        disposeListeners,
+        editorValueRef,
+        model,
+      }),
+      createMockMonacoModule({
+        model,
+        setAppliedThemeNames,
+        setThemeApplications,
+      }),
     );
 
     return () => {
@@ -125,29 +92,176 @@ export function MonacoEditorMock({
 
   return createElement(
     "div",
-    {
-      ...wrapperProps,
+    buildWrapperProps({
+      appliedThemeNames,
       className,
-      "data-monaco-marker-count": String(markers.length),
-      "data-monaco-marker-messages": JSON.stringify(
-        markers.map((marker) => marker.message),
-      ),
-      "data-monaco-marker-ranges": JSON.stringify(markers),
-    },
+      markers,
+      themeApplications,
+      wrapperProps,
+    }),
     loading
       ? createElement("div", { "data-monaco-loading": "true" }, loading)
       : null,
-    createElement("textarea", {
-      "aria-label": options?.ariaLabel,
-      "data-monaco-editor":
-        wrapperProps?.["data-monaco-editor"] ?? "workstation-prompt",
-      onChange: (event: Event) => {
-        const nextValue = (event.target as HTMLTextAreaElement).value;
-        const insertedText = nextValue.slice(editorValueRef.current.length);
-        notifyContentChange(nextValue, insertedText);
-        onChange?.(nextValue);
-      },
-      value: value ?? "",
+    createEditorTextarea({
+      editorValueRef,
+      notifyContentChange,
+      onChange,
+      options,
+      value,
+      wrapperProps,
     }),
   );
+}
+
+function createMockEditorInstance({
+  contentChangeListenersRef,
+  disposeListeners,
+  editorValueRef,
+  model,
+}: {
+  contentChangeListenersRef: RefObject<
+    Array<(event: { changes: Array<{ text: string }> }) => void>
+  >;
+  disposeListeners: Array<() => void>;
+  editorValueRef: RefObject<string>;
+  model: {
+    __setMarkers: Dispatch<SetStateAction<MonacoMarkers>>;
+    getOffsetAt: () => number;
+    getValue: () => string;
+  };
+}) {
+  return {
+    addCommand: () => undefined,
+    getModel: () => model,
+    getPosition: () => ({ column: 1, lineNumber: 1 }),
+    getScrollLeft: () => 0,
+    getScrollTop: () => 0,
+    getValue: () => editorValueRef.current,
+    onDidDispose: (listener: () => void) => {
+      disposeListeners.push(listener);
+      return { dispose() {} };
+    },
+    onDidChangeModelContent: (
+      listener: (event: { changes: Array<{ text: string }> }) => void,
+    ) => {
+      contentChangeListenersRef.current.push(listener);
+      return {
+        dispose() {
+          contentChangeListenersRef.current =
+            contentChangeListenersRef.current.filter(
+              (registeredListener) => registeredListener !== listener,
+            );
+        },
+      };
+    },
+    onDidScrollChange: (
+      listener: (event: { scrollLeft: number; scrollTop: number }) => void,
+    ) => {
+      listener({ scrollLeft: 3, scrollTop: 4 });
+      return { dispose() {} };
+    },
+    trigger: vi.fn(),
+  };
+}
+
+function createMockMonacoModule({
+  model,
+  setAppliedThemeNames,
+  setThemeApplications,
+}: {
+  model: {
+    __setMarkers: Dispatch<SetStateAction<MonacoMarkers>>;
+    getOffsetAt: () => number;
+    getValue: () => string;
+  };
+  setAppliedThemeNames: Dispatch<SetStateAction<string[]>>;
+  setThemeApplications: Dispatch<SetStateAction<MonacoThemeApplications>>;
+}) {
+  return {
+    KeyCode: { Space: 10 },
+    editor: {
+      defineTheme: (name: string, themeData: { base?: string }) => {
+        setThemeApplications((current) => [
+          ...current,
+          { base: themeData.base ?? null, name },
+        ]);
+      },
+      setModelMarkers: (
+        nextModel: typeof model,
+        _owner: string,
+        nextMarkers: MonacoMarkers,
+      ) => {
+        nextModel.__setMarkers(nextMarkers);
+      },
+      setTheme: (name: string) => {
+        setAppliedThemeNames((current) => [...current, name]);
+      },
+    },
+    languages: {
+      CompletionItemKind: { Field: 13, Variable: 4 },
+      CompletionTriggerKind: { Invoke: 0, TriggerCharacter: 1 },
+      registerCompletionItemProvider: () => ({
+        dispose() {},
+      }),
+    },
+  };
+}
+
+function buildWrapperProps({
+  appliedThemeNames,
+  className,
+  markers,
+  themeApplications,
+  wrapperProps,
+}: {
+  appliedThemeNames: string[];
+  className?: string;
+  markers: MonacoMarkers;
+  themeApplications: MonacoThemeApplications;
+  wrapperProps?: Record<string, string | undefined>;
+}) {
+  return {
+    ...wrapperProps,
+    className,
+    "data-monaco-marker-count": String(markers.length),
+    "data-monaco-marker-messages": JSON.stringify(
+      markers.map((marker) => marker.message),
+    ),
+    "data-monaco-marker-ranges": JSON.stringify(markers),
+    "data-monaco-theme-application-count": String(themeApplications.length),
+    "data-monaco-theme-bases": JSON.stringify(
+      themeApplications.map((application) => application.base),
+    ),
+    "data-monaco-theme-set-count": String(appliedThemeNames.length),
+    "data-monaco-theme-set-names": JSON.stringify(appliedThemeNames),
+  };
+}
+
+function createEditorTextarea({
+  editorValueRef,
+  notifyContentChange,
+  onChange,
+  options,
+  value,
+  wrapperProps,
+}: {
+  editorValueRef: RefObject<string>;
+  notifyContentChange: (nextValue: string, insertedText: string) => void;
+  onChange?: (nextValue: string | undefined) => void;
+  options?: { ariaLabel?: string };
+  value?: string;
+  wrapperProps?: Record<string, string | undefined>;
+}) {
+  return createElement("textarea", {
+    "aria-label": options?.ariaLabel,
+    "data-monaco-editor":
+      wrapperProps?.["data-monaco-editor"] ?? "workstation-prompt",
+    onChange: (event: Event) => {
+      const nextValue = (event.target as HTMLTextAreaElement).value;
+      const insertedText = nextValue.slice(editorValueRef.current.length);
+      notifyContentChange(nextValue, insertedText);
+      onChange?.(nextValue);
+    },
+    value: value ?? "",
+  });
 }

--- a/ui/src/testing/vitest.setup.ts
+++ b/ui/src/testing/vitest.setup.ts
@@ -43,6 +43,7 @@ const mockedMonacoModule = {
   editor: {
     defineTheme: vi.fn(),
     setModelMarkers: vi.fn(),
+    setTheme: vi.fn(),
   },
   languages: {
     CompletionItemKind: { Variable: 4 },


### PR DESCRIPTION
{
  "project": "Workstation Current Selection Monaco Formatting",
  "branchName": "ralph/workstation-current-selection-monaco-formatting",
  "description": "Align workstation current-selection Monaco prompt and guard-selector editors with the active dashboard color palette so editor backing, selection, widgets, and syntax highlighting use the same foundation/role token setup as the rest of the website instead of hardcoded Factory Dark colors.",
  "context": {
    "customerAsk": "The current Monaco selection formatting for workstation selection of the prompt does not align with the color formatting of the rest of the website. When switching to Factory Light, the prompt colors remain in Factory Dark colors. Factory palette colors should use the same backing color setup as the rest of the website.",
    "problem": "Workstation prompt and guard-selector Monaco themes hardcode Factory Dark hex values and always use Monaco vs-dark base. Surrounding current-selection form chrome already follows data-color-palette and Material role tokens, so editors look visually disconnected—especially on Factory Light where dark Monaco interiors sit on light surfaces.",
    "solution": "Add a palette-aware Monaco theme builder that reads resolved CSS foundation/role tokens, map them to Monaco editor colors and syntax rules, and wire MonacoPromptEditor and MonacoGuardSelectorEditor to redefine and apply themes when the header palette changes—covering all five supported palettes with tests and browser verification."
  },
  "acceptanceCriteria": [
    "Workstation prompt Monaco editor background, selection, cursor, suggest/hover widgets, and base text colors match the active dashboard palette instead of always rendering Factory Dark values.",
    "Workstation guard-selector Monaco editor uses the same palette-aware theme behavior as the prompt editor.",
    "Switching palettes from the header updates open Monaco editors without a page reload and without requiring the user to re-open the workstation detail card.",
    "All five supported palettes (factory-dark, factory-light, material-baseline, slate, olive) produce readable prompt syntax highlighting with contrast appropriate to each palette's surface and ink tokens.",
    "Shared prompt-editor surfaces that reuse MonacoPromptEditor (current-selection workstation configuration, factory graph add-workstation prompt) inherit palette-aligned behavior without separate one-off theme copies.",
    "Focused tests prove theme derivation for at least Factory Dark and Factory Light and that palette changes trigger Monaco theme refresh.",
    "Quality gate: UI typecheck, lint, and relevant unit/component tests pass for touched packages."
  ],
  "userStories": [
    {
      "id": "workstation-current-selection-monaco-formatting-001",
      "title": "Build palette-aware Monaco themes from dashboard color tokens",
      "description": "As a developer, I need Monaco theme data derived from the active dashboard palette tokens so prompt editors can match the website's backing color setup without hardcoded Factory Dark hex values.",
      "acceptanceCriteria": [
        "A shared prompt-editor helper reads resolved foundation/role CSS variables from the document and returns Monaco IStandaloneThemeData for the workstation prompt template language.",
        "The helper returns a separate theme shape (or parameterized rules) for the guard-selector language using the same token source.",
        "Factory Dark derivation preserves today's visible prompt colors within normal test tolerance (background/foreground/accent tokens).",
        "Factory Light derivation uses light surface and dark ink tokens (not #091117 / #F7F2E8 dark-theme defaults).",
        "Monaco base selects vs for light-biased palettes and vs-dark for dark-biased palettes based on computed background luminance.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "workstation-current-selection-monaco-formatting-002",
      "title": "Sync workstation prompt Monaco editor with active palette",
      "description": "As a factory operator editing a workstation prompt in current selection, I want the Monaco prompt editor to match the dashboard palette so the prompt field does not stay dark when I switch to Factory Light.",
      "acceptanceCriteria": [
        "MonacoPromptEditor applies the palette-aware theme on initial mount using the current data-color-palette value.",
        "Changing the header palette while a prompt editor is mounted redefines and applies the Monaco theme without losing editor content, focus, or scroll position.",
        "In Factory Light, the prompt editor interior no longer shows the Factory Dark #091117 backing; surrounding border-outline shell and editor interior read as one coherent light surface.",
        "Syntax highlighting remains distinguishable for template delimiters, keywords, strings, and variables in Factory Light.",
        "Factory graph add-workstation prompt surfaces that reuse MonacoPromptEditor inherit the same behavior without additional wiring.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "workstation-current-selection-monaco-formatting-003",
      "title": "Sync guard-selector Monaco editor with active palette",
      "description": "As a factory operator editing workstation guard selectors in current selection, I want the guard-selector Monaco editor to follow the same palette-backed colors as the prompt editor and surrounding form.",
      "acceptanceCriteria": [
        "MonacoGuardSelectorEditor applies the palette-aware guard-selector theme on mount and refreshes when the active palette changes.",
        "In Factory Light, guard-selector editor background, text, selection, and autocomplete widgets match the active palette instead of Factory Dark defaults.",
        "Guard selector syntax tokens (.Name, .WorkID, .Tags[\"key\"]) remain visually distinct after palette alignment.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Browser verification now runs through a current-selection-specific Storybook flow with seeded Monaco startup mocks and a MATCHES_FIELDS guard row. Monaco theme fallback resolution also rejects transparent or unresolved CSS token values before defineTheme so prompt and guard-selector editors start reliably in Storybook static verification."
    },
    {
      "id": "workstation-current-selection-monaco-formatting-004",
      "title": "Validate palette switching across all supported dashboard palettes",
      "description": "As a customer using different dashboard palettes, I want workstation Monaco editors to stay readable and visually aligned no matter which of the five palettes I choose.",
      "acceptanceCriteria": [
        "With a workstation prompt editor open, switching among factory-dark, factory-light, material-baseline, slate, and olive updates Monaco chrome and syntax colors each time without reload.",
        "No palette leaves prompt or guard-selector editor text unreadable against its editor background (contrast sufficient for body text and selection).",
        "Automated tests cover theme derivation or refresh for at least one dark and one light palette plus one additional non-factory palette.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Prompt theme derivation now uses stronger light-palette delimiter and keyword colors for readability, focused Monaco tests cover all five palettes with contrast checks plus multi-palette refresh assertions, and Storybook browser verification passes through the Storybook Vitest browser runner on `CurrentSelectionEditableConfigurationPaletteSwitchDesktopVerification`."
    }
  ]
}
