### PR TITLE
workstation-currente-selection-summary-fix

### DIFF
--- a/ui/src/App.current-selection.test.tsx
+++ b/ui/src/App.current-selection.test.tsx
@@ -838,7 +838,7 @@ describe("App current selection", () => {
     );
     fireEvent.click(
       within(requestHistorySection).getByRole("button", {
-        name: /\(dispatch-review-ready\)$/,
+        name: "Select workstation request dispatch-review-ready",
       }),
     );
 

--- a/ui/src/App.localization-times.test.tsx
+++ b/ui/src/App.localization-times.test.tsx
@@ -91,9 +91,7 @@ function selectReviewRequest(dispatchID: string): void {
   ensureRequestHistoryExpanded(selection);
   fireEvent.click(
     within(requestHistorySection(selection)).getByRole("button", {
-      name: new RegExp(
-        `\\(${dispatchID.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\)$`,
-      ),
+      name: `Select workstation request ${dispatchID}`,
     }),
   );
 }

--- a/ui/src/App.replay-dispatch-selection.test.tsx
+++ b/ui/src/App.replay-dispatch-selection.test.tsx
@@ -15,10 +15,6 @@ function requireValue<T>(value: T | null | undefined, message: string): T {
   return value;
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 async function selectReviewRequest(dispatchID: string): Promise<void> {
   const reviewWorkstationButton = screen.queryByRole("button", {
     name: "Select Review workstation",
@@ -45,7 +41,7 @@ async function selectReviewRequest(dispatchID: string): Promise<void> {
   );
   fireEvent.click(
     within(resolvedRequestHistorySection).getByRole("button", {
-      name: new RegExp(`\\(${escapeRegExp(dispatchID)}\\)$`),
+      name: `Select workstation request ${dispatchID}`,
     }),
   );
 }

--- a/ui/src/App.replay-workstation-requests.test.tsx
+++ b/ui/src/App.replay-workstation-requests.test.tsx
@@ -53,9 +53,7 @@ async function selectReviewRequest(dispatchID: string): Promise<void> {
   );
   fireEvent.click(
     within(requestHistorySection).getByRole("button", {
-      name: new RegExp(
-        `\\(${dispatchID.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\)$`,
-      ),
+      name: `Select workstation request ${dispatchID}`,
     }),
   );
 }

--- a/ui/src/features/current-selection/workstation-selection/components/workstation-active-work-list.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/workstation-active-work-list.tsx
@@ -1,7 +1,5 @@
 import {
   DashboardActionButton,
-  DashboardActionRow,
-  DashboardText,
 } from "../../../../components/ui";
 import {
   formatDurationFromISO,
@@ -12,6 +10,7 @@ import { CurrentSelectionExpandableSection } from "../../base/components/current
 import { CurrentSelectionExecutionPill } from "../../base/components/current-selection-pill";
 import { CurrentSelectionSupportingText } from "../../base/public";
 import type { WorkstationActiveWorkListProps } from "../lib/detail-card-types";
+import { WorkstationDispatchRow } from "./workstation-dispatch-row";
 
 export function WorkstationActiveWorkList({
   executions,
@@ -93,47 +92,39 @@ export function WorkstationActiveWorkList({
                 ) : undefined;
 
               return (
-                <DashboardText
-                  as="li"
-                  className="grid min-w-0 gap-2 rounded-lg px-3 py-2"
+                <WorkstationDispatchRow
+                  actions={headerActions}
                   key={`${execution.dispatch_id}-${workIdentifier}`}
-                >
-                  <div className="flex flex-wrap items-center justify-between gap-3">
-                    <strong className="min-w-0 flex-1 [overflow-wrap:anywhere]">
-                      {workLabel}
-                    </strong>
-                    <DashboardActionRow
-                      statuses={
-                        <CurrentSelectionExecutionPill>
-                          {messages.elapsedLabel}: {elapsed}
-                        </CurrentSelectionExecutionPill>
-                      }
-                      statusesClassName="justify-end"
-                      actions={headerActions}
-                      actionsClassName="justify-end"
-                      className="justify-end"
-                    />
-                  </div>
-                  {workItem ? null : (
-                    <CurrentSelectionSupportingText tone="status">
-                      {messages.workDetailsUnavailable(execution.dispatch_id)}
-                    </CurrentSelectionSupportingText>
-                  )}
-                  {requestSelected ? (
-                    <CurrentSelectionSupportingText tone="status">
-                      {messages.selectedRequestLabel(execution.dispatch_id)}
-                    </CurrentSelectionSupportingText>
-                  ) : null}
-                  {onSelectWorkstationRequest ? (
-                    request ? null : (
-                      <CurrentSelectionSupportingText tone="status">
-                        {messages.requestDetailsUnavailable(
-                          execution.dispatch_id,
-                        )}
-                      </CurrentSelectionSupportingText>
-                    )
-                  ) : null}
-                </DashboardText>
+                  status={
+                    <CurrentSelectionExecutionPill>
+                      {messages.elapsedLabel}: {elapsed}
+                    </CurrentSelectionExecutionPill>
+                  }
+                  supportingContent={
+                    <>
+                      {workItem ? null : (
+                        <CurrentSelectionSupportingText tone="status">
+                          {messages.workDetailsUnavailable(execution.dispatch_id)}
+                        </CurrentSelectionSupportingText>
+                      )}
+                      {requestSelected ? (
+                        <CurrentSelectionSupportingText tone="status">
+                          {messages.selectedRequestLabel(execution.dispatch_id)}
+                        </CurrentSelectionSupportingText>
+                      ) : null}
+                      {onSelectWorkstationRequest ? (
+                        request ? null : (
+                          <CurrentSelectionSupportingText tone="status">
+                            {messages.requestDetailsUnavailable(
+                              execution.dispatch_id,
+                            )}
+                          </CurrentSelectionSupportingText>
+                        )
+                      ) : null}
+                    </>
+                  }
+                  title={workLabel}
+                />
               );
             });
           })}

--- a/ui/src/features/current-selection/workstation-selection/components/workstation-detail-card.history.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/workstation-detail-card.history.test.tsx
@@ -177,6 +177,13 @@ describe("WorkstationDetailCard request history", () => {
       within(requestHistorySection).getByRole("button", { name: "Expand" }),
     );
 
+    const requestHistoryList = within(requestHistorySection).getByRole("list");
+    expect(requestHistoryList.className).toContain("gap-2.5");
+    const requestHistoryRows =
+      within(requestHistoryList).getAllByRole("listitem");
+    expect(requestHistoryRows).toHaveLength(2);
+    expect(requestHistoryRows[0]?.className).toContain("rounded-lg");
+
     const pendingRuntimePill = within(requestHistorySection).getByText(
       "Elapsed: 0ms",
     );

--- a/ui/src/features/current-selection/workstation-selection/components/workstation-detail-card.history.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/workstation-detail-card.history.test.tsx
@@ -189,8 +189,11 @@ describe("WorkstationDetailCard request history", () => {
     );
     expect(pendingRuntimePill.className).toContain("border-af-info-border");
     expect(
-      within(requestHistorySection).getByText("request-script-success-story"),
-    ).toBeTruthy();
+      within(requestHistorySection).getAllByText("Active Story").length,
+    ).toBeGreaterThan(0);
+    expect(
+      within(requestHistorySection).queryByText("request-script-success-story"),
+    ).toBeNull();
     const successfulRuntimePill = within(requestHistorySection).getByText(
       "Total runtime: 222ms",
     );
@@ -199,13 +202,16 @@ describe("WorkstationDetailCard request history", () => {
     );
     expect(
       within(requestHistorySection).getByRole("button", {
-        name: "Select request request-script-success-story (dispatch-review-script-success)",
+        name: "Select workstation request dispatch-review-script-success",
       }),
     ).toBeTruthy();
+    expect(
+      within(requestHistorySection).getAllByText("Open request details").length,
+    ).toBeGreaterThan(0);
 
     fireEvent.click(
       within(requestHistorySection).getByRole("button", {
-        name: "Select request request-script-success-story (dispatch-review-script-success)",
+        name: "Select workstation request dispatch-review-script-success",
       }),
     );
 

--- a/ui/src/features/current-selection/workstation-selection/components/workstation-detail-card.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/workstation-detail-card.test.tsx
@@ -130,7 +130,7 @@ function expectLocalizedSelectionControlNames() {
   );
   expect(
     within(resolvedRequestHistorySection).getByRole("button", {
-      name: "Select request Rejected Story (dispatch-review-rejected)",
+      name: "Select workstation request dispatch-review-rejected",
     }),
   ).toBeTruthy();
 
@@ -180,7 +180,7 @@ function expectLocalizedSelectionControlNames() {
   ).toBeTruthy();
   expect(
     within(resolvedRequestHistorySection).getByRole("button", {
-      name: "リクエスト Rejected Story (dispatch-review-rejected) を選択",
+      name: "ワークステーションリクエスト dispatch-review-rejected を選択",
     }),
   ).toBeTruthy();
 }
@@ -781,7 +781,7 @@ describe("WorkstationDetailCard", () => {
     );
     fireEvent.click(
       within(resolvedRequestHistorySection).getByRole("button", {
-        name: "Select request Rejected Story (dispatch-review-rejected)",
+        name: "Select workstation request dispatch-review-rejected",
       }),
     );
     expect(onSelectWorkstationRequest).toHaveBeenCalledWith(

--- a/ui/src/features/current-selection/workstation-selection/components/workstation-dispatch-row.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/workstation-dispatch-row.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+
+import { CurrentSelectionSupportingText } from "../../base/public";
+import { CurrentSelectionExecutionPill } from "../../base/components/current-selection-pill";
+import { WorkstationDispatchRow } from "./workstation-dispatch-row";
+
+describe("WorkstationDispatchRow", () => {
+  it("renders title, status, actions, and supporting content in the active-work row shell", () => {
+    render(
+      <ul>
+        <WorkstationDispatchRow
+          actions={<button type="button">Open request</button>}
+          status={
+            <CurrentSelectionExecutionPill>
+              Elapsed: 15s
+            </CurrentSelectionExecutionPill>
+          }
+          supportingContent={
+            <CurrentSelectionSupportingText tone="status">
+              Request details unavailable for dispatch-1
+            </CurrentSelectionSupportingText>
+          }
+          title="Review Story"
+        />
+      </ul>,
+    );
+
+    const item = screen.getByRole("listitem");
+    expect(item.className).toContain("rounded-lg");
+    expect(screen.getByText("Review Story")).toBeTruthy();
+    expect(screen.getByText("Elapsed: 15s")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Open request" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByText("Request details unavailable for dispatch-1"),
+    ).toBeTruthy();
+  });
+});

--- a/ui/src/features/current-selection/workstation-selection/components/workstation-dispatch-row.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/workstation-dispatch-row.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+
+import {
+  DashboardActionRow,
+  DashboardText,
+} from "../../../../components/ui";
+
+interface WorkstationDispatchRowProps {
+  actions?: ReactNode;
+  status?: ReactNode;
+  supportingContent?: ReactNode;
+  title: ReactNode;
+}
+
+export function WorkstationDispatchRow({
+  actions,
+  status,
+  supportingContent,
+  title,
+}: WorkstationDispatchRowProps) {
+  return (
+    <DashboardText as="li" className="grid min-w-0 gap-2 rounded-lg px-3 py-2">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <strong className="min-w-0 flex-1 [overflow-wrap:anywhere]">
+          {title}
+        </strong>
+        <DashboardActionRow
+          actions={actions}
+          actionsClassName="justify-end"
+          className="justify-end"
+          statuses={status}
+          statusesClassName="justify-end"
+        />
+      </div>
+      {supportingContent}
+    </DashboardText>
+  );
+}

--- a/ui/src/features/current-selection/workstation-selection/components/workstation-request-history-section.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/workstation-request-history-section.tsx
@@ -1,15 +1,11 @@
 import type { DashboardWorkstationRequest } from "../../../../api/dashboard/types";
-import {
-  DashboardActionButton,
-  DashboardStatusPill,
-} from "../../../../components/ui";
+import { DashboardActionButton } from "../../../../components/ui";
 import {
   formatDurationFromISO,
   formatDurationMillis,
   formatWorkItemLabel,
 } from "../../../../components/ui/formatters";
 import { DetailCopy } from "../../../../components/ui/widget-frame";
-import { cn } from "../../../../lib/cn";
 import { CurrentSelectionExpandableSection } from "../../base/components/current-selection-expandable-section";
 import { CurrentSelectionExecutionPill } from "../../base/components/current-selection-pill";
 import { CurrentSelectionSupportingText } from "../../base/public";
@@ -79,15 +75,11 @@ function WorkstationRequestHistoryRow({
   selectedRequest?: WorkstationRequestHistorySectionProps["selectedRequest"];
   selectedWorkID?: WorkstationRequestHistorySectionProps["selectedWorkID"];
 }) {
-  const requestLabel =
-    request.request_id ||
-    request.work_items.map(formatWorkItemLabel).join(", ") ||
-    request.dispatch_id;
   const primaryWorkItem = request.work_items[0];
   const requestSelected = selectedRequest?.dispatch_id === request.dispatch_id;
   const workLabel = primaryWorkItem
     ? formatWorkItemLabel(primaryWorkItem)
-    : requestLabel;
+    : messages.unknownActiveWorkLabel;
   const totalDurationMillis =
     request.total_duration_millis ?? request.script_response?.duration_millis;
   const normalizedOutcome = (
@@ -111,7 +103,6 @@ function WorkstationRequestHistoryRow({
         onSelectWorkstationRequest,
         primaryWorkItem,
         request,
-        requestLabel,
         requestSelected,
         selectedWorkID,
         workLabel,
@@ -130,7 +121,7 @@ function WorkstationRequestHistoryRow({
           </CurrentSelectionSupportingText>
         ) : null
       }
-      title={requestLabel}
+      title={workLabel}
     />
   );
 }
@@ -141,7 +132,6 @@ function renderWorkstationRequestActions({
   onSelectWorkstationRequest,
   primaryWorkItem,
   request,
-  requestLabel,
   requestSelected,
   selectedWorkID,
   workLabel,
@@ -153,7 +143,6 @@ function renderWorkstationRequestActions({
     | DashboardWorkstationRequest["work_items"][number]
     | undefined;
   request: DashboardWorkstationRequest;
-  requestLabel: string;
   requestSelected: boolean;
   selectedWorkID?: WorkstationRequestHistorySectionProps["selectedWorkID"];
   workLabel: string;
@@ -173,17 +162,14 @@ function renderWorkstationRequestActions({
     ) : null;
   const requestAction = onSelectWorkstationRequest ? (
     <DashboardActionButton
-      aria-label={messages.selectRequestLabel(
-        requestLabel,
-        request.dispatch_id,
-      )}
+      aria-label={messages.selectWorkstationRequestLabel(request.dispatch_id)}
       aria-pressed={requestSelected}
       onClick={() => onSelectWorkstationRequest(request)}
       type="button"
     >
       {requestSelected
         ? messages.requestSelectedAction
-        : messages.openRequestAction}
+        : messages.openRequestDetailsAction}
     </DashboardActionButton>
   ) : null;
 
@@ -214,17 +200,12 @@ function renderWorkstationRequestStatusPill({
 }) {
   if (totalDurationMillis !== undefined) {
     return (
-      <DashboardStatusPill
-        className={cn(
-          "min-h-0",
-          !hasFailedOutcome &&
-            "border-af-success-border bg-success-container text-success",
-        )}
-        tone={hasFailedOutcome ? "danger" : undefined}
+      <CurrentSelectionExecutionPill
+        tone={hasFailedOutcome ? "danger" : "success"}
       >
         {messages.totalRuntimeLabel}:{" "}
         {formatDurationMillis(totalDurationMillis)}
-      </DashboardStatusPill>
+      </CurrentSelectionExecutionPill>
     );
   }
 

--- a/ui/src/features/current-selection/workstation-selection/components/workstation-request-history-section.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/workstation-request-history-section.tsx
@@ -1,7 +1,6 @@
 import type { DashboardWorkstationRequest } from "../../../../api/dashboard/types";
 import {
   DashboardActionButton,
-  DashboardActionRow,
   DashboardStatusPill,
 } from "../../../../components/ui";
 import {
@@ -14,9 +13,9 @@ import { cn } from "../../../../lib/cn";
 import { CurrentSelectionExpandableSection } from "../../base/components/current-selection-expandable-section";
 import { CurrentSelectionExecutionPill } from "../../base/components/current-selection-pill";
 import { CurrentSelectionSupportingText } from "../../base/public";
-import { CurrentSelectionHistoryCard } from "../../history/public";
 import type { WorkstationRequestHistorySectionProps } from "../lib/detail-card-types";
 import type { getWorkstationDetailMessages } from "../messages/workstation-detail";
+import { WorkstationDispatchRow } from "./workstation-dispatch-row";
 
 export function WorkstationRequestHistorySection({
   messages,
@@ -42,18 +41,20 @@ export function WorkstationRequestHistorySection({
       }
     >
       {requests.length > 0 ? (
-        requests.map((request) => (
-          <WorkstationRequestHistoryCard
-            key={request.dispatch_id}
-            messages={messages}
-            now={now}
-            onSelectWorkID={onSelectWorkID}
-            onSelectWorkstationRequest={onSelectWorkstationRequest}
-            request={request}
-            selectedRequest={selectedRequest}
-            selectedWorkID={selectedWorkID}
-          />
-        ))
+        <ul className="m-0 grid list-none gap-2.5 p-0">
+          {requests.map((request) => (
+            <WorkstationRequestHistoryRow
+              key={request.dispatch_id}
+              messages={messages}
+              now={now}
+              onSelectWorkID={onSelectWorkID}
+              onSelectWorkstationRequest={onSelectWorkstationRequest}
+              request={request}
+              selectedRequest={selectedRequest}
+              selectedWorkID={selectedWorkID}
+            />
+          ))}
+        </ul>
       ) : (
         <DetailCopy>{messages.noWorkstationRequests}</DetailCopy>
       )}
@@ -61,7 +62,7 @@ export function WorkstationRequestHistorySection({
   );
 }
 
-function WorkstationRequestHistoryCard({
+function WorkstationRequestHistoryRow({
   messages,
   now,
   onSelectWorkID,
@@ -103,41 +104,34 @@ function WorkstationRequestHistoryCard({
     normalizedOutcome === "REJECTED";
 
   return (
-    <CurrentSelectionHistoryCard>
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <strong className="min-w-0 flex-1 [overflow-wrap:anywhere]">
-          {requestLabel}
-        </strong>
-        <DashboardActionRow
-          statuses={renderWorkstationRequestStatusPill({
-            hasFailedOutcome,
-            messages,
-            now,
-            request,
-            totalDurationMillis,
-          })}
-          statusesClassName="justify-end"
-          actions={renderWorkstationRequestActions({
-            messages,
-            onSelectWorkID,
-            onSelectWorkstationRequest,
-            primaryWorkItem,
-            request,
-            requestLabel,
-            requestSelected,
-            selectedWorkID,
-            workLabel,
-          })}
-          actionsClassName="justify-end"
-          className="justify-end"
-        />
-      </div>
-      {requestSelected ? (
-        <CurrentSelectionSupportingText tone="status">
-          {messages.selectedRequestLabel(request.dispatch_id)}
-        </CurrentSelectionSupportingText>
-      ) : null}
-    </CurrentSelectionHistoryCard>
+    <WorkstationDispatchRow
+      actions={renderWorkstationRequestActions({
+        messages,
+        onSelectWorkID,
+        onSelectWorkstationRequest,
+        primaryWorkItem,
+        request,
+        requestLabel,
+        requestSelected,
+        selectedWorkID,
+        workLabel,
+      })}
+      status={renderWorkstationRequestStatusPill({
+        hasFailedOutcome,
+        messages,
+        now,
+        request,
+        totalDurationMillis,
+      })}
+      supportingContent={
+        requestSelected ? (
+          <CurrentSelectionSupportingText tone="status">
+            {messages.selectedRequestLabel(request.dispatch_id)}
+          </CurrentSelectionSupportingText>
+        ) : null
+      }
+      title={requestLabel}
+    />
   );
 }
 


### PR DESCRIPTION
{
  "project": "Workstation Current Selection — Active Work / Request History Formatting Parity",
  "branchName": "ralph/workstation-current-selection-summary-fix",
  "description": "Standardize workstation request history row formatting to match active work by reusing the same list structure, shared dispatch row component, work-item titles, CurrentSelectionExecutionPill duration display, and request selection button copy—preserving navigation behavior and history-specific total-runtime semantics.",
  "context": {
    "customerAsk": "Currently the workstation active work and request history formatting is different. We want them to use a standard component and standard formatting. The active work formatting is better, so please move request history to use the standardized components built for active work.",
    "problem": "Workstation current selection renders active work and request history with different row containers (DashboardText li list vs CurrentSelectionHistoryCard articles), different primary titles (work item label vs request_id-first), different status pills (CurrentSelectionExecutionPill vs ad hoc DashboardStatusPill success/danger overrides), and different request button labels and aria patterns—so customers see two visual dialects for the same dispatch affordances.",
    "solution": "Extract the active-work dispatch row pattern into a shared component, render request history through the same ul/li list and row chrome, align titles and selection button copy with active work, and express historical durations via CurrentSelectionExecutionPill tones while preserving callbacks, empty states, section collapse behavior, and total-runtime vs elapsed semantics."
  },
  "acceptanceCriteria": [
    "Request history rows use the same list and row chrome as active work (ul + DashboardText li with matching spacing/padding); request history no longer wraps rows in CurrentSelectionHistoryCard.",
    "Historical request rows show the primary work item label as the row title using the same labeling rules and fallbacks as active work for comparable dispatches.",
    "Request and work selection buttons in request history use the same visible labels and accessible names as active work for the same dispatch (openRequestDetailsAction, selectWorkstationRequestLabel, etc.).",
    "Duration status in request history uses CurrentSelectionExecutionPill with appropriate tone for failed vs successful completed dispatches instead of ad hoc DashboardStatusPill class overrides; total-runtime and elapsed labels remain correct.",
    "Selecting a work item or workstation request from request history still invokes the same callbacks with the same payloads; selected-request supporting text and empty-state copy are unchanged in behavior.",
    "Accessibility semantics remain correct: list structure where applicable, aria-pressed on selection buttons, and discoverable button names in both sections.",
    "Quality gate: UI typecheck, lint, and relevant unit/component tests pass for touched packages."
  ],
  "userStories": [
    {
      "id": "workstation-currente-selection-summary-fix-001",
      "title": "Extract shared workstation dispatch row from active work",
      "description": "As a factory operator viewing workstation current selection, I want active work and request history to share one dispatch row renderer so both sections stay visually aligned as the product evolves.",
      "acceptanceCriteria": [
        "Active work list rows are rendered through a shared workstation dispatch row component extracted from the current active-work implementation.",
        "Active work section still renders the same titles, elapsed pills, work/request actions, unavailable supporting text, and selected-request supporting text as before (no customer-visible regression).",
        "Shared row component accepts title, status pill content, optional action buttons, and optional supporting text slots without history-specific branching in active-work call sites.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "workstation-currente-selection-summary-fix-002",
      "title": "Render request history with active-work list and row chrome",
      "description": "As a factory operator reviewing historical workstation requests, I want request history rows to look like active work rows so I can scan both sections with the same visual rhythm.",
      "acceptanceCriteria": [
        "Request history section renders its items inside a ul list with the same list gap/spacing classes as the active work section.",
        "Each historical request row uses the shared dispatch row component (same DashboardText li classes as active work); CurrentSelectionHistoryCard is no longer used for request history rows.",
        "Request history empty state (noWorkstationRequests) still appears only when expanded and the request list is empty.",
        "Section heading, expand/collapse behavior, resetKey collapse on workstation change, and request-count supporting text are unchanged.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "workstation-currente-selection-summary-fix-003",
      "title": "Align request history titles, actions, and duration pills with active work",
      "description": "As a factory operator selecting work or requests from history, I want historical rows to use the same labels, button copy, and execution pills as active work for the same dispatch.",
      "acceptanceCriteria": [
        "Historical request row primary title uses formatWorkItemLabel of the primary work item with the same unknown/unavailable fallback behavior as active work (not request_id-first titling).",
        "Request selection buttons in request history use openRequestDetailsAction / requestSelectedAction visible labels and selectWorkstationRequestLabel(dispatchId) accessible names, matching active work for the same dispatch.",
        "Work item selection buttons retain openWorkItemAction / workSelectedAction and selectWorkItemLabel behavior consistent with active work.",
        "Completed historical requests with total duration show Total runtime: {duration} inside CurrentSelectionExecutionPill with tone=danger for failed outcomes and a non-danger success/info tone for successful completions.",
        "Historical requests without total duration but with started_at show Elapsed: {duration} inside CurrentSelectionExecutionPill (info tone), matching active work.",
        "Request history no longer uses raw DashboardStatusPill with manual border-af-success-border / border-af-danger-border class overrides.",
        "Clicking work or request actions in request history still invokes onSelectWorkID / onSelectWorkstationRequest with the correct identifiers; selected-request supporting text still appears when the row dispatch is selected.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "workstation-currente-selection-summary-fix-004",
      "title": "Confirm workstation active work and request history parity end-to-end",
      "description": "As a customer using workstation current selection, I want active work and request history to read as one consistent surface when I compare them on the same workstation.",
      "acceptanceCriteria": [
        "With a workstation that has both active executions and projected request history, expanding Active work and Request history shows rows with matching list structure, title weight, pill placement, and action button styling.",
        "workstation-detail-card.test.tsx and workstation-detail-card.history.test.tsx scenarios for request selection, work selection, runtime pills, and localization continue to pass after presentation updates.",
        "No regression in provider-session run history when no projected workstation requests exist.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}
