### PR TITLE
factory-graph-back-shadows

### DIFF
--- a/ui/src/components/dashboard/dashboard-graph.test.tsx
+++ b/ui/src/components/dashboard/dashboard-graph.test.tsx
@@ -34,6 +34,9 @@ describe("DashboardGraphFrame", () => {
     const frame = screen.getByRole("region", { name: "Graph frame" });
     expect(frame.className).toContain("w-full");
     expect(frame.className).toContain("min-w-0");
+    expect(frame.className).toContain("shadow-none");
     expect(frame.className).not.toContain("h-full");
+    expect(frame.className).not.toContain("shadow-af-card");
+    expect(frame.className).not.toContain("shadow-af-panel");
   });
 });

--- a/ui/src/components/dashboard/dashboard-graph.tsx
+++ b/ui/src/components/dashboard/dashboard-graph.tsx
@@ -44,7 +44,7 @@ export function DashboardGraphFrame({
   return (
     <section
       className={cn(
-        "relative min-h-0 w-full min-w-0 overflow-hidden rounded-3xl border transition-colors",
+        "relative min-h-0 w-full min-w-0 overflow-hidden rounded-3xl border shadow-none transition-colors",
         className,
       )}
       data-dashboard-graph-frame="true"

--- a/ui/src/features/bento/components/agent-bento.test.tsx
+++ b/ui/src/features/bento/components/agent-bento.test.tsx
@@ -112,8 +112,12 @@ describe("AgentBentoLayout", () => {
     expect(activityCard.dataset.dashboardPanelShell).toBe("grid-card");
     expect(activityCard.className).toContain("border-outline");
     expect(activityCard.className).toContain("bg-surface-container-high");
+    expect(activityCard.className).toContain("shadow-af-card");
     expect(getGridItem("Current activity").dataset.bentoCardId).toBe(
       "activity",
+    );
+    expect(getGridItem("Current activity").className).toContain(
+      "overflow-visible",
     );
     expect(getGridItem("Trace grid").dataset.bentoCardId).toBe("trace");
     expect(activityTitle.className).toContain("af-dashboard-section-heading");
@@ -123,6 +127,94 @@ describe("AgentBentoLayout", () => {
     expect(
       screen.queryByRole("button", { name: "Move Current activity" }),
     ).toBeNull();
+  });
+
+  it("keeps bento elevation on the card while graph-bearing interiors stay flat", () => {
+    render(
+      <AgentBentoLayout
+        cards={[
+          {
+            id: "activity",
+            widgetType: "activity",
+            children: (
+              <AgentBentoCard title="Current activity">
+                <section
+                  aria-label="Current activity graph"
+                  className="shadow-none"
+                  data-current-activity-flow
+                >
+                  <div className="react-flow shadow-none" />
+                </section>
+              </AgentBentoCard>
+            ),
+          },
+          {
+            id: "trace",
+            widgetType: "trace",
+            children: (
+              <AgentBentoCard title="Trace grid">
+                <section
+                  aria-label="Trace graph"
+                  className="shadow-none"
+                  data-dashboard-graph-frame
+                >
+                  <div className="react-flow shadow-none" />
+                </section>
+              </AgentBentoCard>
+            ),
+          },
+          {
+            id: "work-totals",
+            widgetType: "work-totals",
+            children: (
+              <WorkTotalsCard
+                completedCount={3}
+                dispatchedCount={5}
+                failedCount={1}
+                inFlightDispatchCount={2}
+              />
+            ),
+          },
+        ]}
+        initialWidth={1180}
+        layout={[
+          { h: 4, id: "activity", widgetType: "activity", w: 4, x: 0, y: 0 },
+          { h: 4, id: "trace", widgetType: "trace", w: 4, x: 4, y: 0 },
+          {
+            h: 2,
+            id: "work-totals",
+            widgetType: "work-totals",
+            w: 4,
+            x: 8,
+            y: 0,
+          },
+        ]}
+      />,
+    );
+
+    for (const cardTitle of ["Current activity", "Trace grid", "Work totals"]) {
+      const card = screen.getByRole("article", { name: cardTitle });
+      const gridItem = getGridItem(cardTitle);
+
+      expect(gridItem.className).toContain("overflow-visible");
+      expect(card.dataset.dashboardPanelShell).toBe("grid-card");
+      expect(card.className).toContain("shadow-af-card");
+    }
+
+    const activityGraph = screen.getByRole("region", {
+      name: "Current activity graph",
+    });
+    const traceGraph = screen.getByRole("region", { name: "Trace graph" });
+
+    for (const graphFrame of [activityGraph, traceGraph]) {
+      expect(graphFrame.className).toContain("shadow-none");
+      expect(graphFrame.className).not.toContain("shadow-af-card");
+      expect(graphFrame.className).not.toContain("shadow-af-panel");
+      const reactFlowCanvas = graphFrame.querySelector(".react-flow");
+      expect(reactFlowCanvas?.className).toContain("shadow-none");
+      expect(reactFlowCanvas?.className).not.toContain("shadow-af-card");
+      expect(reactFlowCanvas?.className).not.toContain("shadow-af-panel");
+    }
   });
 
   it("keeps movement enabled and updates grid position during pointer interaction", async () => {

--- a/ui/src/features/bento/components/agent-bento.tsx
+++ b/ui/src/features/bento/components/agent-bento.tsx
@@ -275,7 +275,7 @@ export function AgentBentoLayout({
       >
         {cards.map((card) => (
           <div
-            className="min-w-0"
+            className="min-w-0 overflow-visible"
             data-bento-card-id={card.widgetType}
             data-bento-instance-id={card.id}
             data-layout-signature={layoutSignature(

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-flow.test.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-flow.test.tsx
@@ -273,6 +273,12 @@ describe("factory graph editor edge labels", () => {
 
     expect(reviewNode).not.toBeNull();
     expect(writerNode).not.toBeNull();
+    expect(reviewNode?.className).toContain("shadow-none");
+    expect(reviewNode?.className).not.toContain("shadow-af-card");
+    expect(reviewNode?.className).not.toContain("shadow-af-panel");
+    expect(writerNode?.className).toContain("shadow-none");
+    expect(writerNode?.className).not.toContain("shadow-af-card");
+    expect(writerNode?.className).not.toContain("shadow-af-panel");
     expect(
       reviewNode.querySelector(
         "[data-factory-entity-semantic-icon] [data-graph-semantic-icon='workstation']",

--- a/ui/src/features/trace-drilldown/components/trace-factory-graph-nodes.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-factory-graph-nodes.test.tsx
@@ -72,6 +72,9 @@ describe("Trace dispatch factory graph node", () => {
     }
     expect(node.className).toContain("border-primary");
     expect(node.className).toContain("bg-primary-container");
+    expect(node.className).toContain("shadow-none");
+    expect(node.className).not.toContain("shadow-af-card");
+    expect(node.className).not.toContain("shadow-af-panel");
   });
 
   it("keeps the factory workstation surface for failure outcomes", () => {
@@ -99,6 +102,9 @@ describe("Trace dispatch factory graph node", () => {
     }
     expect(node.className).toContain("border-primary");
     expect(node.className).toContain("bg-primary-container");
+    expect(node.className).toContain("shadow-none");
+    expect(node.className).not.toContain("shadow-af-card");
+    expect(node.className).not.toContain("shadow-af-panel");
   });
 });
 
@@ -134,6 +140,9 @@ describe("Trace relation factory graph node", () => {
     }
     expect(node.className).toContain("border-outline");
     expect(node.className).toContain("bg-surface");
+    expect(node.className).toContain("shadow-none");
+    expect(node.className).not.toContain("shadow-af-card");
+    expect(node.className).not.toContain("shadow-af-panel");
   });
 
   it("does not render semantic icons or metadata badges for non-work nodes", () => {
@@ -217,5 +226,8 @@ describe("Trace relation factory graph node", () => {
       throw new Error("Expected relation node shell to render.");
     }
     expect(node.className).toContain("border-af-danger-border");
+    expect(node.className).toContain("shadow-none");
+    expect(node.className).not.toContain("shadow-af-card");
+    expect(node.className).not.toContain("shadow-af-panel");
   });
 });

--- a/ui/src/features/trace-drilldown/components/trace-grid-card.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-grid-card.test.tsx
@@ -367,6 +367,8 @@ describe("TraceGridBentoCard graph sizing", () => {
     const card = screen.getByRole("article", { name: "Trace drill-down" });
     expect(within(card).getByText("Dispatch flow")).toBeTruthy();
     expect(within(card).queryByTestId("trace-card-react-flow")).toBeNull();
+    expect(card.dataset.dashboardPanelShell).toBe("grid-card");
+    expect(card.className).toContain("shadow-af-card");
 
     const viewports = card.querySelectorAll("[data-trace-graph-viewport]");
     expect(viewports).toHaveLength(2);
@@ -377,7 +379,9 @@ describe("TraceGridBentoCard graph sizing", () => {
         (frame) =>
           frame.className.includes("resize") &&
           frame.className.includes("min-w-80") &&
-          frame.className.includes("max-w-full"),
+          frame.className.includes("max-w-full") &&
+          !frame.className.includes("shadow-af-card") &&
+          !frame.className.includes("shadow-af-panel"),
       ),
     ).toBe(true);
     expect(

--- a/ui/src/features/trace-drilldown/components/trace-relation-factory-graph-node.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-relation-factory-graph-node.tsx
@@ -16,7 +16,7 @@ import type { TraceRelationFlowNode } from "../lib/trace-relation-factory-graph-
 const RELATION_NODE_ACTIVE_CLASS =
   "hover:border-primary hover:bg-primary-container";
 const RELATION_NODE_CLASS =
-  "min-w-0 w-full justify-start overflow-hidden text-left shadow-af-card";
+  "min-w-0 w-full justify-start overflow-hidden text-left shadow-none";
 
 function TraceRelationFactoryGraphNode({
   data,

--- a/ui/src/features/trace-drilldown/components/trace-relation-flow.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-relation-flow.test.tsx
@@ -231,11 +231,15 @@ describe("TraceRelationFlow", () => {
     );
 
     await waitFor(() => {
-      expect(
-        screen
-          .getByRole("region", { name: "Batch relation graph" })
-          .getAttribute("data-dashboard-graph-frame"),
-      ).toBe("true");
+      const graphFrame = screen.getByRole("region", {
+        name: "Batch relation graph",
+      });
+      expect(graphFrame.getAttribute("data-dashboard-graph-frame")).toBe(
+        "true",
+      );
+      expect(graphFrame.className).toContain("shadow-none");
+      expect(graphFrame.className).not.toContain("shadow-af-card");
+      expect(graphFrame.className).not.toContain("shadow-af-panel");
     });
 
     expect(

--- a/ui/src/features/trace-drilldown/components/trace-workstation-path.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-workstation-path.test.tsx
@@ -289,11 +289,13 @@ describe("TraceWorkstationPath explicit lineage", () => {
       ]);
     });
 
-    expect(
-      screen
-        .getByRole("region", { name: "Dispatch relationship graph" })
-        .getAttribute("data-dashboard-graph-frame"),
-    ).toBe("true");
+    const graphFrame = screen.getByRole("region", {
+      name: "Dispatch relationship graph",
+    });
+    expect(graphFrame.getAttribute("data-dashboard-graph-frame")).toBe("true");
+    expect(graphFrame.className).toContain("shadow-none");
+    expect(graphFrame.className).not.toContain("shadow-af-card");
+    expect(graphFrame.className).not.toContain("shadow-af-panel");
     expect(
       screen
         .getByTestId("trace-react-flow-controls")

--- a/ui/src/features/work-totals/components/work-totals-card.test.tsx
+++ b/ui/src/features/work-totals/components/work-totals-card.test.tsx
@@ -52,6 +52,8 @@ describe("WorkTotalsCard", () => {
     expect(cardHeader?.className).toContain("px-3");
     expect(cardHeader?.getAttribute("data-bento-drag-handle")).toBe("true");
     expect(cardHeader?.className).toContain("cursor-grab");
+    expect(cardShell.dataset.dashboardPanelShell).toBe("grid-card");
+    expect(cardShell.className).toContain("shadow-af-card");
     expect(
       within(cardShell).queryByRole("button", { name: "Move Work totals" }),
     ).toBeNull();

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.test.tsx
@@ -13,19 +13,21 @@ vi.mock("@xyflow/react", async () => {
     Background: () => <div data-testid="graph-background" />,
     Controls: () => <div data-testid="graph-controls" />,
     ReactFlow: ({
+      className,
       children,
       edges,
       nodes,
       onEdgeClick,
       onNodeClick,
     }: {
+      className?: string;
       children: ReactNode;
       edges?: Edge[];
       nodes?: Node[];
       onEdgeClick?: (_event: unknown, edge: Edge) => void;
       onNodeClick?: (_event: unknown, node: { id: string }) => void;
     }) => (
-      <div data-testid="mock-react-flow">
+      <div className={className} data-testid="mock-react-flow">
         {(nodes ?? []).map((node) => (
           <button
             key={node.id}
@@ -271,6 +273,22 @@ describe("CurrentActivityGraphViewport", () => {
 
     expect(handleEditorNodeClick).not.toHaveBeenCalled();
     expect(handleEditorEdgeClick).not.toHaveBeenCalled();
+  });
+
+  it("keeps the current-activity graph shell and React Flow canvas flat", () => {
+    renderViewport();
+
+    const graphFrame = screen.getByRole("region", {
+      name: "Work graph viewport",
+    });
+    const reactFlow = screen.getByTestId("mock-react-flow");
+
+    expect(graphFrame.className).toContain("shadow-none");
+    expect(graphFrame.className).not.toContain("shadow-af-card");
+    expect(graphFrame.className).not.toContain("shadow-af-panel");
+    expect(reactFlow.className).toContain("shadow-none");
+    expect(reactFlow.className).not.toContain("shadow-af-card");
+    expect(reactFlow.className).not.toContain("shadow-af-panel");
   });
 });
 

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
@@ -270,7 +270,7 @@ export function CurrentActivityGraphViewport({
         aria-describedby={headingID}
         aria-label={editorMessages.viewportLabel}
         className={cn(
-          "relative h-full min-h-96 overflow-hidden rounded-3xl border transition-colors",
+          "relative h-full min-h-96 overflow-hidden rounded-3xl border shadow-none transition-colors",
           (imports.dropState.status === "drag-active" ||
             imports.dropState.status === "reading") &&
             "border-primary bg-primary-container",
@@ -288,6 +288,7 @@ export function CurrentActivityGraphViewport({
         onDrop={imports.onDrop}
       >
         <ReactFlow
+          className="shadow-none"
           connectionLineStyle={{
             stroke: "var(--color-primary)",
             strokeWidth: 2.4,

--- a/ui/src/features/workflow-activity/components/workflow-activity-bento-card.test.tsx
+++ b/ui/src/features/workflow-activity/components/workflow-activity-bento-card.test.tsx
@@ -266,8 +266,13 @@ describe("WorkflowActivityBentoCard", () => {
     expect(await screen.findByRole("heading", { name: "工厂图" })).toBeTruthy();
     const graphCard = screen.getByRole("article", { name: "工厂图" });
     const graphHeader = graphCard.querySelector("header");
+    const graphViewport = screen.getByRole("region", {
+      name: messages.viewportLabel,
+    });
 
     expect(graphHeader).toBeTruthy();
+    expect(graphCard.dataset.dashboardPanelShell).toBe("grid-card");
+    expect(graphCard.className).toContain("shadow-af-card");
     expect(graphHeader?.className).toContain("min-h-11");
     expect(graphHeader?.className).toContain("px-3");
     expect(
@@ -287,9 +292,10 @@ describe("WorkflowActivityBentoCard", () => {
     expect(
       within(graphCard).queryByRole("heading", { name: "当前活动" }),
     ).toBeNull();
-    expect(
-      screen.getByRole("region", { name: messages.viewportLabel }),
-    ).toBeTruthy();
+    expect(graphViewport).toBeTruthy();
+    expect(graphViewport.className).toContain("shadow-none");
+    expect(graphViewport.className).not.toContain("shadow-af-card");
+    expect(graphViewport.className).not.toContain("shadow-af-panel");
     expect(screen.queryByRole("complementary")).toBeNull();
     expect(
       screen.queryByRole("button", { name: /collapse inspector/i }),

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -246,7 +246,7 @@
   }
 
   :is([data-current-activity-flow], [data-dashboard-graph-frame]) .react-flow {
-    @apply rounded-lg border border-af-border bg-af-surface-subtle;
+    @apply rounded-lg border border-af-border bg-af-surface-subtle shadow-none;
     --xy-controls-box-shadow: none;
     --xy-controls-button-background-color: var(--color-af-surface-raised);
     --xy-controls-button-background-color-hover: var(--color-af-overlay);

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -362,7 +362,7 @@
   }
 
   [data-bento-card-id] {
-    overflow: hidden;
+    overflow: visible;
   }
 
   [data-bento-card-id] > .react-resizable-handle {


### PR DESCRIPTION
{
  "project": "Factory Graph Back Shadows",
  "branchName": "ralph/factory-graph-back-shadows",
  "description": "Move dashboard card elevation from factory graph React Flow canvases to bento widget cards so graph surfaces stay flat inside their widgets while bento cards provide the visible shadow.",
  "context": {
    "customerAsk": "The factory graph currently has a weird shadow on the back of it. Bento cards should have the shadows instead of the factory graph's React Flow graph. Move the shadow.",
    "problem": "Graph-bearing bento widgets nest a bordered React Flow canvas inside AgentBentoCard/DashboardPanelShell. Card-level shadow is either applied to the graph backdrop or is visually attributed to the graph because the outer bento shell does not present elevation cleanly. Bento grid wrappers use overflow: hidden, which can clip the intended shadow-af-card on DashboardPanelShell. Some embedded graph nodes also apply shadow-af-card, adding extra depth inside the canvas.",
    "solution": "Make React Flow graph shells explicitly flat (no card-level shadow on frames, viewport wrappers, or shared .react-flow styling), ensure bento cards are the single owner of dashboard widget elevation with visible shadow-af-card on the outer card surface, and keep semantic node-state shadows for selection, hover, and runtime status unchanged."
  },
  "acceptanceCriteria": [
    "Current-activity factory graph canvas and React Flow shell render without card-level box shadow; only border/background chrome remains.",
    "Dashboard bento cards visibly render shadow-af-card on the outer widget surface across representative widgets (current activity, trace, work totals).",
    "Embedded trace and factory-graph-editor graph frames follow the same flat-inner / elevated-outer pattern.",
    "Graph node semantic state shadows (selected, active flow, success chip, hover accent) still work after the change.",
    "Automated UI tests assert the new shadow ownership at the component level.",
    "Typecheck, lint, and tests pass for touched frontend packages."
  ],
  "userStories": [
    {
      "id": "factory-graph-back-shadows-001",
      "title": "Flatten current-activity factory graph shell elevation",
      "description": "As a dashboard user, I want the factory graph canvas to sit flat inside its widget so the graph does not look like a second floating card behind the nodes.",
      "acceptanceCriteria": [
        "CurrentActivityGraphViewport graph shell (data-current-activity-flow) and nested .react-flow canvas do not apply shadow-af-card or shadow-af-panel",
        "Shared dashboard graph CSS for [data-current-activity-flow] / [data-dashboard-graph-frame] .react-flow keeps border and background styling but remains shadow-free at the canvas level",
        "Current-activity graph controls remain explicitly flat (shadow-none / --xy-controls-box-shadow: none)",
        "Component tests cover the flat graph shell contract for the current-activity viewport",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "factory-graph-back-shadows-002",
      "title": "Render bento card elevation on the visible widget surface",
      "description": "As a dashboard user, I want each bento widget card—not the graph inside it—to provide the dashboard elevation so the board reads as a grid of cards.",
      "acceptanceCriteria": [
        "Bento grid items expose visible shadow-af-card on the outer widget card surface (DashboardPanelShell / AgentBentoCard) without being clipped by [data-bento-card-id] layout wrappers",
        "Representative bento widgets (current activity, trace, work totals) keep border and background chrome while showing card elevation at the widget boundary",
        "No duplicate card-level shadow appears on both the bento shell and the nested graph canvas for graph-bearing widgets",
        "Component tests verify bento cards retain shadow-af-card and graph shells inside those cards remain flat",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill on the dashboard bento board with the current-activity graph visible"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "factory-graph-back-shadows-003",
      "title": "Align embedded trace and editor graph surfaces",
      "description": "As a dashboard user, I want trace and editor graphs to follow the same elevation rules so no graph surface reintroduces a backdrop shadow.",
      "acceptanceCriteria": [
        "DashboardGraphFrame and trace relation/dispatch graph hosts remain flat at the frame level (no card-level shadow on the graph backdrop)",
        "Trace relation graph node shells no longer use card-level shadow-af-card; they rely on border/state styling like other factory graph nodes",
        "Factory graph editor node shells remain flat (shadow-none) and unchanged for semantic state shadows",
        "Trace drilldown and factory-graph-editor component tests cover the flat frame / flat node shell contract",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill on a trace graph card and factory graph editor surface"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}
