### PR TITLE
worker-executor-interface-alias-collapse

### DIFF
--- a/pkg/workers/executor_compat.go
+++ b/pkg/workers/executor_compat.go
@@ -20,6 +20,9 @@ type NoopExecutor = workerexecutor.NoopExecutor
 type WorkstationExecutor = workerexecutor.WorkstationExecutor
 type WorkerPool = workerexecutor.WorkerPool
 type WorkerRunner = workerexecutor.WorkerRunner
+type WorkerExecutor = workerexecutor.WorkerExecutor
+type WorkstationRequestExecutor = workerexecutor.WorkstationRequestExecutor
+type Runner = workerexecutor.Runner
 
 const (
 	WorkLogEventWorkerPoolSubmitted         = workerexecutor.WorkLogEventWorkerPoolSubmitted

--- a/pkg/workers/executor_compat_test.go
+++ b/pkg/workers/executor_compat_test.go
@@ -114,6 +114,41 @@ func TestWorkLogFieldsAddsStableExecutionFields(t *testing.T) {
 	}
 }
 
+func TestRootExecutionInterfaceAliasesAcceptImplementations(t *testing.T) {
+	worker := WorkerExecutor(stubWorkerExecutor{
+		result: interfaces.WorkResult{Outcome: interfaces.OutcomeAccepted},
+	})
+	workerResult, err := worker.Execute(context.Background(), interfaces.WorkDispatch{})
+	if err != nil {
+		t.Fatalf("worker executor returned error: %v", err)
+	}
+	if workerResult.Outcome != interfaces.OutcomeAccepted {
+		t.Fatalf("worker result outcome = %q, want %q", workerResult.Outcome, interfaces.OutcomeAccepted)
+	}
+
+	workstation := WorkstationRequestExecutor(stubWorkstationRequestExecutor{})
+	workstationResult, err := workstation.Execute(context.Background(), interfaces.WorkstationExecutionRequest{})
+	if err != nil {
+		t.Fatalf("workstation request executor returned error: %v", err)
+	}
+	if workstationResult.Outcome != interfaces.OutcomeAccepted {
+		t.Fatalf("workstation result outcome = %q, want %q", workstationResult.Outcome, interfaces.OutcomeAccepted)
+	}
+
+	runner := Runner(stubRunner{})
+	runnerResult, err := runner.Execute(context.Background(), interfaces.RunnerExecutionRequest{})
+	if err != nil {
+		t.Fatalf("runner returned error: %v", err)
+	}
+	if runnerResult.Content != "ok" {
+		t.Fatalf("runner content = %q, want %q", runnerResult.Content, "ok")
+	}
+}
+
+var _ WorkerExecutor = stubWorkerExecutor{}
+var _ WorkstationRequestExecutor = stubWorkstationRequestExecutor{}
+var _ Runner = stubRunner{}
+
 type stubProvider struct {
 	lastRequest interfaces.ProviderInferenceRequest
 	response    interfaces.InferenceResponse
@@ -130,4 +165,16 @@ type stubWorkerExecutor struct {
 
 func (s stubWorkerExecutor) Execute(_ context.Context, _ interfaces.WorkDispatch) (interfaces.WorkResult, error) {
 	return s.result, nil
+}
+
+type stubWorkstationRequestExecutor struct{}
+
+func (stubWorkstationRequestExecutor) Execute(_ context.Context, _ interfaces.WorkstationExecutionRequest) (interfaces.WorkResult, error) {
+	return interfaces.WorkResult{Outcome: interfaces.OutcomeAccepted}, nil
+}
+
+type stubRunner struct{}
+
+func (stubRunner) Execute(_ context.Context, _ interfaces.RunnerExecutionRequest) (interfaces.RunnerExecutionResult, error) {
+	return interfaces.RunnerExecutionResult{Content: "ok"}, nil
 }

--- a/pkg/workers/interfaces.go
+++ b/pkg/workers/interfaces.go
@@ -1,5 +1,5 @@
-// Package workers defines worker executor interfaces and implementations for
-// script and model-based workers.
+// Package workers defines worker dispatcher contracts and compatibility helpers
+// for script and model-based workers.
 package workers
 
 import (
@@ -8,25 +8,6 @@ import (
 
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 )
-
-// WorkerExecutor is the side-effect interface — what actually happens when
-// a transition fires. This is the only place where external I/O occurs.
-// Everything else in the factory is pure CPN state manipulation.
-type WorkerExecutor interface {
-	Execute(ctx context.Context, dispatch interfaces.WorkDispatch) (interfaces.WorkResult, error)
-}
-
-// WorkstationRequestExecutor handles worker-owned execution requests after the
-// dispatch-owned contract has been resolved for one workstation invocation.
-type WorkstationRequestExecutor interface {
-	Execute(ctx context.Context, request interfaces.WorkstationExecutionRequest) (interfaces.WorkResult, error)
-}
-
-// Runner executes one shared runner request and returns the normalized runner
-// result used by standard orchestration flows.
-type Runner interface {
-	Execute(ctx context.Context, request interfaces.RunnerExecutionRequest) (interfaces.RunnerExecutionResult, error)
-}
 
 // Dispatcher manages worker execution. It supports two execution modes:
 //   - Synchronous (via Tick): all queued dispatches are executed inline; used


### PR DESCRIPTION
{
  "project": "Worker Executor Interface Alias Collapse",
  "branchName": "ralph/worker-executor-interface-alias-collapse",
  "description": "Collapse duplicate worker execution interface declarations in pkg/workers and pkg/workers/executor by making executor/contracts.go the single source of truth and exposing root-package type aliases in executor_compat.go, preserving all existing workers.* import paths and runtime behavior.",
  "context": {
    "customerAsk": "Collapse the duplicate worker execution interface declarations split between pkg/workers and pkg/workers/executor, using executor package contracts as canonical and root-package aliases for compatibility.",
    "problem": "pkg/workers/interfaces.go and pkg/workers/executor/contracts.go both declare WorkerExecutor, WorkstationRequestExecutor, and Runner, creating two sources of truth for the same execution contracts despite executor_compat.go already aliasing many executor types back through the root workers package.",
    "solution": "Add type aliases in pkg/workers/executor_compat.go for the three execution interfaces, remove the duplicate interface declarations from pkg/workers/interfaces.go while keeping Dispatcher and token helpers there, and verify with focused backend tests in pkg/workers, pkg/factory/runtime, and pkg/service."
  },
  "acceptanceCriteria": [
    "Code importing pkg/workers can still refer to workers.WorkerExecutor, workers.WorkstationRequestExecutor, and workers.Runner without import-path changes",
    "Each of WorkerExecutor, WorkstationRequestExecutor, and Runner has exactly one concrete interface declaration in pkg/workers/executor/contracts.go",
    "pkg/workers/executor_compat.go exposes root-package type aliases for all three execution interfaces",
    "pkg/workers/interfaces.go retains Dispatcher, InputTokens, WorkDispatchInputTokens, and their supporting helpers and no longer declares the three execution interfaces",
    "No runtime, API, CLI, or frontend observable behavior changes are introduced",
    "Focused backend regression tests pass for pkg/workers, pkg/factory/runtime, and pkg/service",
    "Backend typecheck, lint, and focused test suites pass (quality gate)"
  ],
  "userStories": [
    {
      "id": "worker-executor-interface-alias-collapse-001",
      "title": "Alias root workers execution interfaces to executor contracts",
      "description": "As a backend maintainer, I want the root pkg/workers package to re-export the three execution interfaces as type aliases to pkg/workers/executor so there is one canonical contract definition while preserving existing import paths.",
      "acceptanceCriteria": [
        "pkg/workers/executor_compat.go adds type WorkerExecutor = workerexecutor.WorkerExecutor, type WorkstationRequestExecutor = workerexecutor.WorkstationRequestExecutor, and type Runner = workerexecutor.Runner",
        "The duplicate WorkerExecutor, WorkstationRequestExecutor, and Runner interface blocks are removed from pkg/workers/interfaces.go",
        "Dispatcher, InputTokens, WorkDispatchInputTokens, and their helper functions remain in pkg/workers/interfaces.go unchanged in behavior",
        "Existing root-package consumers such as pkg/service/factory_build.go, pkg/factory/runtime, and pkg/testutil/service_harness.go compile without changing their workers.* execution-interface references",
        "go test ./pkg/workers/... passes, including compatibility tests that exercise RunnerFromProvider, worker pool dispatch, and stub executor implementations through root-package types",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "worker-executor-interface-alias-collapse-002",
      "title": "Verify factory runtime and service wiring after alias collapse",
      "description": "As a factory operator relying on worker dispatch and service-built executors, I want factory runtime and service packages to keep building and running workers the same way after the interface alias collapse.",
      "acceptanceCriteria": [
        "go test ./pkg/factory/runtime passes, including dispatch hook, factory constructor, and harness tests that register workers.WorkerExecutor implementations",
        "go test ./pkg/service passes, including factory build and model-catalog paths that type against workers.WorkstationRequestExecutor and workers.Runner",
        "Worker dispatch outcomes, executor registration, and runner/provider wiring behave the same as before the alias collapse with no test assertion updates required for preserved behavior",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
