### PR TITLE
scroll-issues

### DIFF
--- a/ui/src/components/ui/widget-frame.test.tsx
+++ b/ui/src/components/ui/widget-frame.test.tsx
@@ -81,7 +81,6 @@ describe("DashboardWidgetFrame chrome", () => {
       <DashboardWidgetFrame
         bodyClassName="custom-widget-body"
         bodyProps={{ "data-widget-body": "trace-card" }}
-        bodyScroll={false}
         title="Trace"
         widgetId="trace"
       >
@@ -95,6 +94,20 @@ describe("DashboardWidgetFrame chrome", () => {
 
     expect(body?.getAttribute("data-widget-body")).toBe("trace-card");
     expect(body?.className).toContain("custom-widget-body");
+  });
+
+  it("uses page-flow bodies by default through the shared bento card", () => {
+    render(
+      <DashboardWidgetFrame title="Trace" widgetId="trace">
+        <p>Trace content</p>
+      </DashboardWidgetFrame>,
+    );
+
+    const card = screen.getByRole("article", { name: "Trace" });
+
+    expect(card.querySelector("[data-radix-scroll-area-viewport]")).toBeNull();
+    expect(card.className).not.toContain("h-full");
+    expect(card.className).not.toContain("overflow-hidden");
   });
 
   it("routes header actions through AgentBentoCard without a custom header slot", () => {

--- a/ui/src/features/bento/components/agent-bento.test.tsx
+++ b/ui/src/features/bento/components/agent-bento.test.tsx
@@ -76,6 +76,13 @@ function getGridItem(cardTitle: string): HTMLElement {
   return gridItem;
 }
 
+function expectNoVerticalScrollContainer(element: HTMLElement) {
+  expect(element.className).not.toMatch(/overflow-y-(auto|scroll)/);
+  expect(window.getComputedStyle(element).overflowY).not.toMatch(
+    /^(auto|scroll)$/,
+  );
+}
+
 describe("AgentBentoLayout", () => {
   beforeEach(() => {
     Object.defineProperty(HTMLElement.prototype, "offsetParent", {
@@ -127,6 +134,30 @@ describe("AgentBentoLayout", () => {
     expect(
       screen.queryByRole("button", { name: "Move Current activity" }),
     ).toBeNull();
+  });
+
+  it("lets the board and grid grow without creating a vertical scroll container", () => {
+    renderBentoBoard();
+
+    const board = screen.getByRole("region", {
+      name: "you-agent-factory bento board",
+    });
+    const grid = board.querySelector(".react-grid-layout");
+    const activityItem = getGridItem("Current activity");
+
+    if (!(grid instanceof HTMLElement)) {
+      throw new Error(
+        "expected bento board to render a react-grid-layout root",
+      );
+    }
+
+    expect(board.className).toContain("overflow-x-clip");
+    expect(board.className).not.toContain("overflow-x-hidden");
+    expectNoVerticalScrollContainer(board);
+    expectNoVerticalScrollContainer(grid);
+    expectNoVerticalScrollContainer(activityItem);
+    expect(grid.className).toContain("min-h-px");
+    expect(grid.style.height).not.toBe("");
   });
 
   it("keeps bento elevation on the card while graph-bearing interiors stay flat", () => {

--- a/ui/src/features/bento/components/agent-bento.test.tsx
+++ b/ui/src/features/bento/components/agent-bento.test.tsx
@@ -103,9 +103,9 @@ describe("AgentBentoLayout", () => {
     const activityTitle = within(activityCard).getByRole("heading", {
       name: "Current activity",
     });
-    const activityBody = activityCard.querySelector(
-      "[data-radix-scroll-area-viewport]",
-    );
+    const activityBody = screen
+      .getByText("Active workstation graph goes here.")
+      .closest(".af-dashboard-body-text");
 
     expect(
       screen.getByRole("region", { name: "you-agent-factory bento board" }),
@@ -585,9 +585,33 @@ describe("AgentBentoLayout", () => {
 });
 
 describe("AgentBentoCard", () => {
-  it("scrolls overflowing bodies through the shared ScrollArea primitive", () => {
+  it("renders page-flow card bodies by default without a nested ScrollArea", () => {
     render(
-      <AgentBentoCard title="Submit work">
+      <AgentBentoCard
+        bodyProps={{ "data-testid": "submit-work-body" }}
+        title="Submit work"
+      >
+        <p>Long form body</p>
+      </AgentBentoCard>,
+    );
+
+    const card = screen.getByRole("article", { name: "Submit work" });
+    const body = screen.getByTestId("submit-work-body");
+
+    expect(card.querySelector("[data-radix-scroll-area-viewport]")).toBeNull();
+    expect(card.className).not.toContain("h-full");
+    expect(card.className).not.toContain("overflow-hidden");
+    expect(body.className).toContain("af-dashboard-body-text");
+    expect(body.className).not.toContain("h-full");
+  });
+
+  it("supports explicit localized body scrolling through the shared ScrollArea primitive", () => {
+    render(
+      <AgentBentoCard
+        bodyProps={{ "data-testid": "submit-work-scroll-body" }}
+        bodyScroll
+        title="Submit work"
+      >
         <p>Long form body</p>
       </AgentBentoCard>,
     );
@@ -595,10 +619,13 @@ describe("AgentBentoCard", () => {
     const card = screen.getByRole("article", { name: "Submit work" });
     const viewport = card.querySelector("[data-radix-scroll-area-viewport]");
 
+    expect(card.className).toContain("h-full");
+    expect(card.className).toContain("overflow-hidden");
     expect(viewport).toBeTruthy();
     expect(viewport?.hasAttribute("data-radix-scroll-area-viewport")).toBe(
       true,
     );
+    expect(screen.getByTestId("submit-work-scroll-body")).toBe(viewport);
   });
 
   it("renders the canonical shared header with an h3 title and header drag handle", () => {
@@ -708,22 +735,26 @@ describe("AgentBentoCard", () => {
 
   it("supports compact shared chrome for dense dashboard cards", () => {
     render(
-      <AgentBentoCard chromeDensity="compact" title="Factory graph">
+      <AgentBentoCard
+        bodyProps={{ "data-testid": "factory-graph-body" }}
+        chromeDensity="compact"
+        title="Factory graph"
+      >
         <p>Graph content</p>
       </AgentBentoCard>,
     );
 
     const card = screen.getByRole("article", { name: "Factory graph" });
     const header = card.querySelector("header");
-    const viewport = card.querySelector("[data-radix-scroll-area-viewport]");
+    const body = screen.getByTestId("factory-graph-body");
 
     expect(header?.className).toContain("min-h-11");
     expect(header?.className).toContain("px-3");
     expect(header?.className).toContain("cursor-grab");
-    expect(viewport?.className).toContain("px-3");
-    expect(viewport?.className).toContain("pt-3");
-    expect(viewport?.className).toContain("pb-4");
-    expect(viewport?.className).toContain("gap-2");
+    expect(body.className).toContain("px-3");
+    expect(body.className).toContain("pt-3");
+    expect(body.className).toContain("pb-4");
+    expect(body.className).toContain("gap-2");
     expect(
       within(card).queryByRole("button", { name: "Move Factory graph" }),
     ).toBeNull();

--- a/ui/src/features/bento/components/agent-bento.tsx
+++ b/ui/src/features/bento/components/agent-bento.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes, ReactNode } from "react";
+import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
 import type { Layout, LayoutItem } from "react-grid-layout";
 import { GridLayout, useContainerWidth } from "react-grid-layout";
@@ -49,6 +49,7 @@ export interface AgentBentoCardProps {
   className?: string;
   chromeDensity?: "compact" | "default";
   headerAction?: ReactNode;
+  style?: CSSProperties;
   title: string;
 }
 
@@ -304,6 +305,7 @@ export function AgentBentoCard({
   className = "",
   chromeDensity = "default",
   headerAction,
+  style,
   title,
 }: AgentBentoCardProps) {
   const cardClassName = cn(
@@ -344,6 +346,7 @@ export function AgentBentoCard({
       as="article"
       className={cardClassName}
       shellKind="grid-card"
+      style={style}
     >
       <AgentBentoCardHeader
         chromeDensity={chromeDensity}

--- a/ui/src/features/bento/components/agent-bento.tsx
+++ b/ui/src/features/bento/components/agent-bento.tsx
@@ -73,7 +73,7 @@ const BENTO_RESIZE_HANDLES = ["se", "s", "e"] as const;
 const BENTO_DRAG_HANDLE_SELECTOR = "[data-bento-drag-handle='true']";
 const BENTO_DRAG_CANCEL_SELECTOR =
   "button,a,input,select,textarea,.react-resizable-handle";
-const BENTO_LAYOUT_CLASS = "min-w-0 w-full overflow-x-hidden";
+const BENTO_LAYOUT_CLASS = "min-w-0 w-full overflow-x-clip";
 const BENTO_CARD_CLASS = "flex h-full min-w-0 flex-col overflow-hidden";
 const BENTO_CARD_HEADER_CLASS =
   "relative z-10 flex min-h-13 shrink-0 cursor-grab items-center justify-between gap-3 border-b border-outline bg-surface-container-high px-3.5 py-3 active:cursor-grabbing";

--- a/ui/src/features/bento/components/agent-bento.tsx
+++ b/ui/src/features/bento/components/agent-bento.tsx
@@ -74,7 +74,8 @@ const BENTO_DRAG_HANDLE_SELECTOR = "[data-bento-drag-handle='true']";
 const BENTO_DRAG_CANCEL_SELECTOR =
   "button,a,input,select,textarea,.react-resizable-handle";
 const BENTO_LAYOUT_CLASS = "min-w-0 w-full overflow-x-clip";
-const BENTO_CARD_CLASS = "flex h-full min-w-0 flex-col overflow-hidden";
+const BENTO_CARD_CLASS = "flex min-w-0 flex-col";
+const BENTO_CARD_SCROLL_CLASS = "h-full overflow-hidden";
 const BENTO_CARD_HEADER_CLASS =
   "relative z-10 flex min-h-13 shrink-0 cursor-grab items-center justify-between gap-3 border-b border-outline bg-surface-container-high px-3.5 py-3 active:cursor-grabbing";
 const BENTO_CARD_HEADER_COMPACT_CLASS =
@@ -84,8 +85,9 @@ const BENTO_CARD_HEADER_TOOLS_CLASS =
 const BENTO_CARD_HEADER_TOOLS_COMPACT_CLASS =
   "w-full flex-wrap justify-between gap-1.5 sm:w-auto sm:justify-end";
 const BENTO_CARD_BODY_SCROLL_CLASS = "min-h-0 flex-1";
+const BENTO_CARD_BODY_SCROLL_VIEWPORT_CLASS = "h-full";
 const BENTO_CARD_BODY_CLASS = cn(
-  "grid h-full min-h-0 gap-2.5 px-3.5 pt-3.5 pb-4 [&>*]:pb-1 [&_p]:m-0",
+  "grid min-h-0 gap-2.5 px-3.5 pt-3.5 pb-4 [&>*]:pb-1 [&_p]:m-0",
   "af-dashboard-body-text",
 );
 const BENTO_CARD_BODY_COMPACT_CLASS = "gap-2 px-3 pt-3 pb-4 [&>*]:pb-1";
@@ -297,14 +299,18 @@ export function AgentBentoLayout({
 export function AgentBentoCard({
   bodyClassName = "",
   bodyProps,
-  bodyScroll = true,
+  bodyScroll = false,
   children,
   className = "",
   chromeDensity = "default",
   headerAction,
   title,
 }: AgentBentoCardProps) {
-  const cardClassName = cn(BENTO_CARD_CLASS, className);
+  const cardClassName = cn(
+    BENTO_CARD_CLASS,
+    bodyScroll && BENTO_CARD_SCROLL_CLASS,
+    className,
+  );
   const compactChrome = chromeDensity === "compact";
   const cardBodyClassName = cn(
     BENTO_CARD_BODY_CLASS,
@@ -322,7 +328,10 @@ export function AgentBentoCard({
     ) : (
       <ScrollArea
         className={BENTO_CARD_BODY_SCROLL_CLASS}
-        viewportClassName={cardBodyClassName}
+        viewportClassName={cn(
+          BENTO_CARD_BODY_SCROLL_VIEWPORT_CLASS,
+          cardBodyClassName,
+        )}
         viewportProps={bodyProps}
       >
         {children}

--- a/ui/src/features/dashboard/components/dashboard-screen.single-scroll.test.tsx
+++ b/ui/src/features/dashboard/components/dashboard-screen.single-scroll.test.tsx
@@ -1,0 +1,445 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach } from "vitest";
+import type { DashboardSnapshot } from "../../../api/dashboard/types";
+import { dashboardSemanticSnapshotFixtures } from "../../../components/dashboard/fixtures";
+import { installDashboardBrowserTestShims } from "../../../components/dashboard/test-browser-shims";
+import { DashboardScreen } from "./dashboard-screen";
+
+const VIEWPORT_HEIGHT = 768;
+const DOCUMENT_HEIGHT = 2600;
+const VERTICAL_SCROLL_CLASS_PATTERN =
+  /(?:^|\s)(?:overflow-(?:auto|scroll)|overflow-y-(?:auto|scroll))(?:\s|$)/;
+
+const dashboardSnapshotState = vi.hoisted(() => ({
+  value: {
+    error: null as Error | null,
+    isInitialLoading: false,
+    snapshot: null as DashboardSnapshot | null,
+  },
+}));
+
+let restoreBrowserShims: (() => void) | undefined;
+let restoreScrollMetrics: (() => void) | undefined;
+
+vi.mock("../../header/public", () => ({
+  DashboardExportDialog: () => null,
+  DashboardHeader: () => <header>Dashboard header</header>,
+  DashboardStatusPanel: ({ title }: { title: string }) => (
+    <section>
+      <h1>{title}</h1>
+    </section>
+  ),
+}));
+
+vi.mock("../hooks/useDashboardSnapshot", () => ({
+  useDashboardSnapshot: vi.fn(() => dashboardSnapshotState.value),
+}));
+
+vi.mock("../../bento/hooks/use-dashboard-bento-snapshot", () => ({
+  useDashboardBentoSnapshot: vi.fn(() => {
+    const snapshot = dashboardSnapshotState.value.snapshot;
+
+    if (!snapshot) {
+      throw new Error("Expected a dashboard snapshot fixture for bento tests.");
+    }
+
+    return {
+      currentSelection: {
+        canRedoSelection: false,
+        canUndoSelection: false,
+        clearSelectedWorkerIfMatching: vi.fn(),
+        completedWorkItems: [],
+        failedWorkItems: [],
+        openTerminalWorkDetail: vi.fn(),
+        redoSelection: vi.fn(),
+        selectedNode: null,
+        selectedNodeActiveExecutions: [],
+        selectedNodeProviderSessions: [],
+        selectedNodeWorkstationRequests: [],
+        selectedStateCurrentWorkItems: [],
+        selectedStatePlace: null,
+        selectedStateTerminalHistoryWorkItems: [],
+        selectedStateTokenCount: 0,
+        selectedWorkDispatchAttempts: [],
+        selectedWorkID: null,
+        selectedWorkProviderSessions: [],
+        selectedWorkRequestHistory: [],
+        selectedWorkWorkstationRequests: [],
+        selectedWorkstationRequest: null,
+        selection: null,
+        selectStateNode: vi.fn(),
+        selectStateWorkItem: vi.fn(),
+        selectWorkByID: vi.fn(),
+        selectWorkItem: vi.fn(),
+        selectWorkstation: vi.fn(),
+        selectWorkstationRequest: vi.fn(),
+        terminalWorkDetail: null,
+        undoSelection: vi.fn(),
+      },
+      selectedSnapshot: snapshot,
+      selectedTimelineTick: snapshot.tick_count,
+      snapshot,
+      timelineEvents: [],
+      worldViewCache: {
+        [snapshot.tick_count]: snapshot,
+      },
+    };
+  }),
+}));
+
+vi.mock("../../bento/hooks/useDashboardLayout", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../bento/hooks/useDashboardLayout")
+  >("../../bento/hooks/useDashboardLayout");
+
+  return {
+    ...actual,
+    useDashboardLayout: () => ({
+      addDashboardWidget: vi.fn(),
+      dashboardLayout: actual.DEFAULT_DASHBOARD_LAYOUT,
+      persistDashboardLayout: vi.fn(),
+      removeDashboardWidget: vi.fn(),
+    }),
+  };
+});
+
+vi.mock("../../bento/hooks/useDashboardNow", () => ({
+  useDashboardNow: () => 0,
+}));
+
+vi.mock("../../current-selection/hooks/useCurrentSelectionDetails", () => ({
+  useCurrentSelectionDetails: () => ({
+    selectedWorkExecutionDetails: null,
+    selectedWorkRelationshipGraph: { status: "empty" as const },
+  }),
+}));
+
+vi.mock(
+  "../../current-selection/work-selection/hooks/useSelectedProviderSessionState",
+  () => ({
+    useSelectedProviderSessionState: () => ({
+      selectedProviderSession: null,
+      selectedProviderSessionKey: null,
+      setSelectedProviderSession: vi.fn(),
+    }),
+  }),
+);
+
+vi.mock("../../trace-drilldown/hooks/useTraceDrilldown", () => ({
+  useTraceDrilldown: () => ({
+    selectedTrace: null,
+    traceGridState: { status: "empty" as const },
+  }),
+}));
+
+vi.mock("../../work-outcome/hooks/useWorkOutcomeChart", () => ({
+  useWorkOutcomeChart: () => ({ status: "empty" as const }),
+}));
+
+vi.mock(
+  "../../workflow-activity/hooks/current-activity-import-controller",
+  () => ({
+    useCurrentActivityImportController: () => ({
+      activationState: { status: "idle" as const },
+      activateImport: vi.fn(),
+      clearActivationError: vi.fn(),
+      closeImportPreview: vi.fn(),
+      importPreviewState: { status: "idle" as const },
+      openImportPreview: vi.fn(),
+    }),
+  }),
+);
+
+vi.mock("../../import/public", () => ({
+  DashboardImportPreviewDialog: () => null,
+}));
+
+vi.mock("../../current-selection/public", async () => {
+  const { DashboardWidgetFrame } = await vi.importActual<
+    typeof import("../../../components/ui/widget-frame")
+  >("../../../components/ui/widget-frame");
+
+  return {
+    CurrentSelectionWidget: ({
+      headerAction,
+    }: {
+      headerAction?: React.ReactNode;
+    }) => (
+      <DashboardWidgetFrame
+        headerAction={headerAction}
+        title="Current selection"
+        widgetId="current-selection"
+      >
+        <p>Current selection fixture content</p>
+      </DashboardWidgetFrame>
+    ),
+  };
+});
+
+vi.mock("../../provider-session-detail/public", async () => {
+  const { DashboardWidgetFrame } = await vi.importActual<
+    typeof import("../../../components/ui/widget-frame")
+  >("../../../components/ui/widget-frame");
+
+  return {
+    ProviderSessionWidget: ({
+      headerAction,
+    }: {
+      headerAction?: React.ReactNode;
+    }) => (
+      <DashboardWidgetFrame
+        headerAction={headerAction}
+        title="Provider session"
+        widgetId="provider-session"
+      >
+        <p>Provider session fixture content</p>
+      </DashboardWidgetFrame>
+    ),
+  };
+});
+
+vi.mock("../../submit-work/public", async () => {
+  const { DashboardWidgetFrame } = await vi.importActual<
+    typeof import("../../../components/ui/widget-frame")
+  >("../../../components/ui/widget-frame");
+
+  return {
+    SubmitWorkWidget: ({
+      headerAction,
+    }: {
+      headerAction?: React.ReactNode;
+    }) => (
+      <DashboardWidgetFrame
+        headerAction={headerAction}
+        title="Submit work"
+        widgetId="submit-work"
+      >
+        <p>Submit work fixture content</p>
+      </DashboardWidgetFrame>
+    ),
+  };
+});
+
+vi.mock("../../terminal-work/public", async () => {
+  const { DashboardWidgetFrame } = await vi.importActual<
+    typeof import("../../../components/ui/widget-frame")
+  >("../../../components/ui/widget-frame");
+
+  return {
+    TerminalWorkWidget: ({
+      headerAction,
+    }: {
+      headerAction?: React.ReactNode;
+    }) => (
+      <DashboardWidgetFrame
+        headerAction={headerAction}
+        title="Terminal work"
+        widgetId="terminal-work"
+      >
+        <p>Terminal work fixture content</p>
+      </DashboardWidgetFrame>
+    ),
+  };
+});
+
+vi.mock("../../trace-drilldown/public", async () => {
+  const { DashboardWidgetFrame } = await vi.importActual<
+    typeof import("../../../components/ui/widget-frame")
+  >("../../../components/ui/widget-frame");
+
+  return {
+    TraceDrilldownWidget: ({
+      headerAction,
+    }: {
+      headerAction?: React.ReactNode;
+    }) => (
+      <DashboardWidgetFrame
+        headerAction={headerAction}
+        title="Trace drilldown"
+        widgetId="trace-drilldown"
+      >
+        <p>Trace fixture content</p>
+      </DashboardWidgetFrame>
+    ),
+  };
+});
+
+vi.mock("../../work-outcome/public", async () => {
+  const { DashboardWidgetFrame } = await vi.importActual<
+    typeof import("../../../components/ui/widget-frame")
+  >("../../../components/ui/widget-frame");
+
+  return {
+    WorkOutcomeWidget: ({
+      headerAction,
+    }: {
+      headerAction?: React.ReactNode;
+    }) => (
+      <DashboardWidgetFrame
+        headerAction={headerAction}
+        title="Work outcome"
+        widgetId="work-outcome"
+      >
+        <p>Work outcome fixture content</p>
+      </DashboardWidgetFrame>
+    ),
+  };
+});
+
+vi.mock("../../work-totals/public", async () => {
+  const { DashboardWidgetFrame } = await vi.importActual<
+    typeof import("../../../components/ui/widget-frame")
+  >("../../../components/ui/widget-frame");
+
+  return {
+    WorkTotalsWidget: ({
+      headerAction,
+    }: {
+      headerAction?: React.ReactNode;
+    }) => (
+      <DashboardWidgetFrame
+        headerAction={headerAction}
+        title="Work totals"
+        widgetId="work-totals"
+      >
+        <p>Work totals fixture content</p>
+      </DashboardWidgetFrame>
+    ),
+  };
+});
+
+vi.mock("../../workflow-activity/public", async () => {
+  const { DashboardWidgetFrame } = await vi.importActual<
+    typeof import("../../../components/ui/widget-frame")
+  >("../../../components/ui/widget-frame");
+
+  return {
+    WorkflowActivityWidget: ({
+      headerAction,
+    }: {
+      headerAction?: React.ReactNode;
+    }) => (
+      <DashboardWidgetFrame
+        headerAction={headerAction}
+        title="Workflow activity"
+        widgetId="workflow-activity"
+      >
+        <p>Workflow activity fixture content</p>
+      </DashboardWidgetFrame>
+    ),
+  };
+});
+
+function setElementMetric(
+  element: Element,
+  property: "clientHeight" | "scrollHeight",
+  value: number,
+) {
+  const descriptor = Object.getOwnPropertyDescriptor(element, property);
+
+  Object.defineProperty(element, property, {
+    configurable: true,
+    value,
+  });
+
+  return () => {
+    if (descriptor) {
+      Object.defineProperty(element, property, descriptor);
+    } else {
+      Reflect.deleteProperty(element, property);
+    }
+  };
+}
+
+function installScrollMetricFixture(dashboardRoot: HTMLElement) {
+  const restoreFns = [
+    setElementMetric(document.documentElement, "clientHeight", VIEWPORT_HEIGHT),
+    setElementMetric(document.documentElement, "scrollHeight", DOCUMENT_HEIGHT),
+    setElementMetric(document.body, "clientHeight", DOCUMENT_HEIGHT),
+    setElementMetric(document.body, "scrollHeight", DOCUMENT_HEIGHT),
+    setElementMetric(dashboardRoot, "clientHeight", VIEWPORT_HEIGHT),
+    setElementMetric(dashboardRoot, "scrollHeight", DOCUMENT_HEIGHT),
+  ];
+
+  return () => {
+    for (const restore of restoreFns.reverse()) {
+      restore();
+    }
+  };
+}
+
+function isVerticalScrollOwner(element: HTMLElement) {
+  const overflowY = window.getComputedStyle(element).overflowY;
+  const isDocumentElement = element === document.documentElement;
+  const permitsScrolling =
+    isDocumentElement || overflowY === "auto" || overflowY === "scroll";
+
+  return element.scrollHeight > element.clientHeight && permitsScrolling;
+}
+
+function getVerticalScrollOwners(elements: HTMLElement[]) {
+  return elements.filter(isVerticalScrollOwner);
+}
+
+function expectNoNestedVerticalScrollports(dashboardRoot: HTMLElement) {
+  const elements = Array.from(dashboardRoot.querySelectorAll<HTMLElement>("*"));
+
+  expect(
+    dashboardRoot.querySelector("[data-radix-scroll-area-viewport]"),
+  ).toBeNull();
+
+  for (const element of elements) {
+    expect(element.getAttribute("class") ?? "").not.toMatch(
+      VERTICAL_SCROLL_CLASS_PATTERN,
+    );
+    expect(window.getComputedStyle(element).overflowY).not.toMatch(
+      /^(auto|scroll)$/,
+    );
+  }
+}
+
+describe("DashboardScreen single-scroll regression", () => {
+  beforeEach(() => {
+    restoreBrowserShims = installDashboardBrowserTestShims();
+    dashboardSnapshotState.value = {
+      error: null,
+      isInitialLoading: false,
+      snapshot: dashboardSemanticSnapshotFixtures.activeWork,
+    };
+  });
+
+  afterEach(() => {
+    restoreScrollMetrics?.();
+    restoreScrollMetrics = undefined;
+    restoreBrowserShims?.();
+    restoreBrowserShims = undefined;
+  });
+
+  it("renders a tall loaded dashboard with the document as the only vertical scroll owner", () => {
+    render(<DashboardScreen />);
+
+    const dashboardRoot = screen.getByRole("main");
+    const board = screen.getByRole("region", {
+      name: "you-agent-factory bento board",
+    });
+    const grid = board.querySelector(".react-grid-layout");
+
+    if (!(grid instanceof HTMLElement)) {
+      throw new Error("Expected the loaded dashboard to render a bento grid.");
+    }
+
+    expect(Number.parseFloat(grid.style.height)).toBeGreaterThan(
+      VIEWPORT_HEIGHT,
+    );
+    restoreScrollMetrics = installScrollMetricFixture(dashboardRoot);
+
+    expect(
+      getVerticalScrollOwners([
+        document.documentElement,
+        document.body,
+        dashboardRoot,
+      ]),
+    ).toEqual([document.documentElement]);
+    expectNoNestedVerticalScrollports(dashboardRoot);
+  });
+});

--- a/ui/src/features/dashboard/components/dashboard-screen.test.tsx
+++ b/ui/src/features/dashboard/components/dashboard-screen.test.tsx
@@ -5,6 +5,10 @@ import { getHeaderControlsMessages } from "../../header/messages/header-controls
 import { DashboardScreen } from "./dashboard-screen";
 
 const EXPECTED_DASHBOARD_SHELL_CLASS = "min-h-screen overflow-x-hidden p-2";
+const VERTICAL_SCROLL_CLASS_PATTERN =
+  /(?:^|\s)(?:overflow-(?:auto|scroll)|overflow-y-(?:auto|scroll))(?:\s|$)/;
+const VIEWPORT_HEIGHT_CLAMP_CLASS_PATTERN =
+  /(?:^|\s)(?:h-(?:screen|dvh|svh|lvh)|max-h-(?:screen|dvh|svh|lvh))(?:\s|$)/;
 
 let dashboardSnapshotState: ReturnType<
   typeof import("../hooks/useDashboardSnapshot").useDashboardSnapshot
@@ -30,7 +34,11 @@ function StatusPanelProbe({
 vi.mock("../../bento/public", () => ({
   DashboardBento: ({ locale }: { locale?: string }) => {
     const { locale: resolvedLocale } = useAppLocale(locale);
-    return <section>Dashboard bento {resolvedLocale}</section>;
+    return (
+      <section data-testid="dashboard-bento-probe">
+        Dashboard bento {resolvedLocale}
+      </section>
+    );
   },
 }));
 
@@ -56,13 +64,40 @@ vi.mock("../hooks/useDashboardSnapshot", () => ({
   useDashboardSnapshot: vi.fn(() => dashboardSnapshotState),
 }));
 
-describe("DashboardScreen", () => {
-  function expectDashboardShellContract() {
-    expect(screen.getByRole("main").className).toBe(
-      EXPECTED_DASHBOARD_SHELL_CLASS,
-    );
+function expectDashboardShellContract() {
+  const shell = screen.getByRole("main");
+
+  expect(shell.className).toBe(EXPECTED_DASHBOARD_SHELL_CLASS);
+  expectElementDoesNotOwnVerticalScroll(shell);
+  expect(shell.getAttribute("class")).not.toMatch(
+    VIEWPORT_HEIGHT_CLAMP_CLASS_PATTERN,
+  );
+}
+
+function expectElementDoesNotOwnVerticalScroll(element: HTMLElement) {
+  expect(element.getAttribute("class") ?? "").not.toMatch(
+    VERTICAL_SCROLL_CLASS_PATTERN,
+  );
+  expect(window.getComputedStyle(element).overflowY).not.toMatch(
+    /^(auto|scroll)$/,
+  );
+}
+
+function expectNoNestedDashboardScrollOwnerBetweenBentoAndShell() {
+  const shell = screen.getByRole("main");
+  const bento = screen.getByTestId("dashboard-bento-probe");
+  let currentElement: HTMLElement | null = bento;
+
+  while (currentElement && currentElement !== shell) {
+    expectElementDoesNotOwnVerticalScroll(currentElement);
+    currentElement = currentElement.parentElement;
   }
 
+  expect(currentElement).toBe(shell);
+  expectDashboardShellContract();
+}
+
+describe("DashboardScreen", () => {
   beforeEach(() => {
     dashboardSnapshotState = {
       error: null,
@@ -149,6 +184,18 @@ describe("DashboardScreen", () => {
     expect(screen.getByText("Dashboard header zh-CN")).toBeTruthy();
     expect(screen.getByText("Dashboard bento zh-CN")).toBeTruthy();
     expect(screen.getByText("Dashboard export dialog zh-CN")).toBeTruthy();
+  });
+
+  it("does not introduce a nested vertical scroll owner on the success path", () => {
+    dashboardSnapshotState = {
+      error: null,
+      isInitialLoading: false,
+      snapshot: {} as never,
+    };
+
+    render(<DashboardScreen />);
+
+    expectNoNestedDashboardScrollOwnerBetweenBentoAndShell();
   });
 
   it("keeps the header visible and renders an empty workspace state when no live session remains", () => {

--- a/ui/src/features/submit-work/components/submit-work-card.tsx
+++ b/ui/src/features/submit-work/components/submit-work-card.tsx
@@ -3,9 +3,9 @@ import { type ReactNode, useState } from "react";
 
 import {
   Button,
+  DashboardIconButtonShell,
   DashboardLabel,
   DashboardText,
-  DashboardIconButtonShell,
   DashboardWidgetFrame,
   Input,
   Popover,
@@ -148,17 +148,18 @@ export function SubmitWorkCard({
       widgetId={widgetId}
     >
       <form
-        className="grid h-full min-h-0 content-start gap-3"
+        className="grid content-start gap-3"
         onSubmit={(event) => {
           event.preventDefault();
           onSubmit();
         }}
       >
-        <div className="grid min-h-0 content-start gap-4 overflow-y-auto pr-1">
+        <div
+          className="grid content-start gap-4"
+          data-submit-work-primary-content=""
+        >
           <div className="grid gap-2">
-            <label
-              htmlFor={requestNameID}
-            >
+            <label htmlFor={requestNameID}>
               <DashboardLabel>{messages.requestNameLabel}</DashboardLabel>
             </label>
             <Input

--- a/ui/src/features/submit-work/components/submit-work-widget.test.tsx
+++ b/ui/src/features/submit-work/components/submit-work-widget.test.tsx
@@ -83,6 +83,35 @@ describe("SubmitWorkWidget form behavior", () => {
     expect(submitButton.className).toContain("justify-center");
   });
 
+  it("keeps primary form content in page flow without a nested vertical scrollport", () => {
+    renderSubmitWorkWidget(
+      <SubmitWorkWidget
+        submitWorkTypes={[
+          { work_type_name: "story" },
+          { work_type_name: "task" },
+        ]}
+      />,
+    );
+
+    const card = screen.getByRole("article", { name: "Submit work" });
+    const primaryContent = card.querySelector(
+      "[data-submit-work-primary-content]",
+    );
+
+    if (!(primaryContent instanceof HTMLElement)) {
+      throw new Error("Expected submit-work primary content region.");
+    }
+
+    expect(primaryContent.className).not.toMatch(/overflow-y-(auto|scroll)/);
+    expect(window.getComputedStyle(primaryContent).overflowY).not.toBe("auto");
+    expect(window.getComputedStyle(primaryContent).overflowY).not.toBe(
+      "scroll",
+    );
+    expect(
+      within(card).getByRole("list", { name: "Submission items" }),
+    ).toBeTruthy();
+  });
+
   it("orders submit-work header tools left of the header drag surface", () => {
     render(
       <SubmitWorkCard
@@ -1185,9 +1214,7 @@ describe("SubmitWorkWidget submission behavior", () => {
     expect(screen.getByRole("status").textContent).toBe(
       "Sending your request...",
     );
-    expect(screen.getByRole("status").className).toContain(
-      "bg-info-container",
-    );
+    expect(screen.getByRole("status").className).toContain("bg-info-container");
     expect(submittingStatus.className).toContain("af-dashboard-body-text");
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0]?.[0]).toBe(

--- a/ui/src/features/trace-drilldown/components/trace-drilldown-widget.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-drilldown-widget.test.tsx
@@ -1,10 +1,10 @@
 import { TraceDrilldownWidget } from "./trace-drilldown-widget";
 
-test("TraceDrilldownWidget keeps the compact trace shell minimum height inline on the bento card", () => {
+test("TraceDrilldownWidget keeps the compact trace shell minimum height without forcing full-height scroll", () => {
   const element = TraceDrilldownWidget({
     state: { message: "Select work to inspect trace history.", status: "idle" },
   });
 
-  expect(element.props.className).toContain("h-full");
+  expect(element.props.className).not.toContain("h-full");
   expect(element.props.className).toContain("min-h-[24rem]");
 });

--- a/ui/src/features/trace-drilldown/components/trace-drilldown-widget.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-drilldown-widget.tsx
@@ -20,7 +20,7 @@ export function TraceDrilldownWidget({
   return (
     <TraceGridBentoCard
       // tailwind-exception: intrinsic-sizing
-      className="h-full min-h-[24rem]"
+      className="min-h-[24rem]"
       headerAction={headerAction}
       locale={locale}
       onSelectWorkID={onSelectWorkID}

--- a/ui/src/features/trace-drilldown/components/trace-grid-card-scroll-ownership.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-grid-card-scroll-ownership.test.tsx
@@ -3,9 +3,9 @@ import { cleanup, render, screen, within } from "@testing-library/react";
 import { installDashboardBrowserTestShims } from "../../../components/dashboard/test-browser-shims";
 import {
   buildLongDispatchTrace,
-  constrainTraceCardHeight,
   expectNoVerticalScrollBetweenDispatchTableAndCardBody,
-  findTraceCardScrollContainer,
+  expectPageFlowCardBody,
+  findTraceCardBody,
   findTraceDispatchTableRegion,
 } from "../lib/trace-grid-card-scroll-test-helpers";
 import { TraceGridBentoCard } from "./trace-grid-card";
@@ -25,7 +25,7 @@ describe("TraceGridBentoCard dispatch scroll ownership regressions", () => {
     restoreBrowserShims = undefined;
   });
 
-  it("keeps vertical scroll ownership on the card body for a long dispatch fixture", () => {
+  it("keeps long dispatch content in the page-flow card body", () => {
     render(
       <TraceGridBentoCard
         state={{ status: "ready", trace: longDispatchTrace }}
@@ -33,11 +33,12 @@ describe("TraceGridBentoCard dispatch scroll ownership regressions", () => {
     );
 
     const card = screen.getByRole("article", { name: "Trace drill-down" });
+    expectPageFlowCardBody(findTraceCardBody(card));
     expectNoVerticalScrollBetweenDispatchTableAndCardBody(card);
     expect(within(card).getAllByRole("row")).toHaveLength(13);
   });
 
-  it("scrolls the card body when dispatch content exceeds the viewport height", () => {
+  it("does not opt the trace body into a localized scroll viewport under a constrained ancestor", () => {
     render(
       <div style={{ height: 240, overflow: "hidden" }}>
         <TraceGridBentoCard
@@ -47,16 +48,14 @@ describe("TraceGridBentoCard dispatch scroll ownership regressions", () => {
     );
 
     const card = screen.getByRole("article", { name: "Trace drill-down" });
-    const scrollContainer = constrainTraceCardHeight(card, 240);
+    const cardBody = findTraceCardBody(card);
     const tableRegion = findTraceDispatchTableRegion(card);
 
-    scrollContainer.scrollTop = 280;
-
-    expect(scrollContainer.scrollTop).toBe(280);
-    expect(tableRegion.scrollTop).toBe(0);
-    expect(scrollContainer.scrollHeight).toBeGreaterThan(
-      scrollContainer.clientHeight,
+    expectPageFlowCardBody(cardBody);
+    expect(tableRegion.hasAttribute("data-radix-scroll-area-viewport")).toBe(
+      false,
     );
+    expect(tableRegion.scrollTop).toBe(0);
   });
 
   it("does not add nested vertical scrollports between the dispatch table and card body", () => {
@@ -67,8 +66,8 @@ describe("TraceGridBentoCard dispatch scroll ownership regressions", () => {
     );
 
     const card = screen.getByRole("article", { name: "Trace drill-down" });
-    const scrollContainer = findTraceCardScrollContainer(card);
-    const traceGridRoot = scrollContainer.firstElementChild;
+    const cardBody = findTraceCardBody(card);
+    const traceGridRoot = cardBody.firstElementChild;
 
     expect(traceGridRoot?.className).not.toContain("overflow-x-clip");
     expectNoVerticalScrollBetweenDispatchTableAndCardBody(card);

--- a/ui/src/features/trace-drilldown/components/trace-grid-card-scroll.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-grid-card-scroll.test.tsx
@@ -3,17 +3,16 @@ import { cleanup, render, screen, within } from "@testing-library/react";
 import { installDashboardBrowserTestShims } from "../../../components/dashboard/test-browser-shims";
 import {
   buildLongDispatchTrace,
-  constrainTraceCardHeight,
-  expectAgentBentoScrollViewport,
   expectNoVerticalScrollContainer,
-  findTraceCardScrollContainer,
+  expectPageFlowCardBody,
+  findTraceCardBody,
   findTraceDispatchTableRegion,
 } from "../lib/trace-grid-card-scroll-test-helpers";
 import { TraceGridBentoCard } from "./trace-grid-card";
 
 const longDispatchTrace = buildLongDispatchTrace(12);
 
-describe("TraceGridBentoCard card-level scrolling", () => {
+describe("TraceGridBentoCard page-flow scrolling", () => {
   let restoreBrowserShims: (() => void) | undefined;
 
   beforeEach(() => {
@@ -26,7 +25,7 @@ describe("TraceGridBentoCard card-level scrolling", () => {
     restoreBrowserShims = undefined;
   });
 
-  it("keeps vertical scroll on the trace card body instead of the dispatch grid root", () => {
+  it("renders the trace card body in page flow instead of a ScrollArea viewport", () => {
     render(
       <TraceGridBentoCard
         state={{ status: "ready", trace: longDispatchTrace }}
@@ -34,11 +33,11 @@ describe("TraceGridBentoCard card-level scrolling", () => {
     );
 
     const card = screen.getByRole("article", { name: "Trace drill-down" });
-    const scrollContainer = findTraceCardScrollContainer(card);
-    const traceGridRoot = scrollContainer.firstElementChild;
+    const cardBody = findTraceCardBody(card);
+    const traceGridRoot = cardBody.firstElementChild;
     const tableRegion = card.querySelector("[data-trace-dispatch-table]");
 
-    expectAgentBentoScrollViewport(scrollContainer);
+    expectPageFlowCardBody(cardBody);
     expect(traceGridRoot).toBeTruthy();
     expect(traceGridRoot?.className).not.toContain("overflow-x-clip");
     expectNoVerticalScrollContainer(traceGridRoot as Element);
@@ -47,29 +46,23 @@ describe("TraceGridBentoCard card-level scrolling", () => {
     }
   });
 
-  it("scrolls the trace card body from the dispatch table without scrolling the table wrapper", () => {
+  it("renders long dispatch tables without a nested vertical scroll owner", () => {
     render(
-      <div style={{ height: 240, overflow: "hidden" }}>
-        <TraceGridBentoCard
-          state={{ status: "ready", trace: longDispatchTrace }}
-        />
-      </div>,
+      <TraceGridBentoCard
+        state={{ status: "ready", trace: longDispatchTrace }}
+      />,
     );
 
     const card = screen.getByRole("article", { name: "Trace drill-down" });
-    const scrollContainer = constrainTraceCardHeight(card, 240);
+    const cardBody = findTraceCardBody(card);
     const tableRegion = findTraceDispatchTableRegion(card);
 
-    scrollContainer.scrollTop = 280;
-
-    expect(scrollContainer.scrollTop).toBe(280);
-    expect(tableRegion.scrollTop).toBe(0);
-    expect(scrollContainer.scrollHeight).toBeGreaterThan(
-      scrollContainer.clientHeight,
-    );
+    expectPageFlowCardBody(cardBody);
+    expectNoVerticalScrollContainer(tableRegion);
+    expect(within(card).getAllByRole("row")).toHaveLength(13);
   });
 
-  it("keeps fixed-height graph shells while the card body scrolls", () => {
+  it("keeps fixed-height graph shells while the card body stays in page flow", () => {
     render(
       <TraceGridBentoCard
         state={{ status: "ready", trace: longDispatchTrace }}
@@ -88,9 +81,8 @@ describe("TraceGridBentoCard card-level scrolling", () => {
       expectNoVerticalScrollContainer(frame);
     }
 
-    const scrollContainer = constrainTraceCardHeight(card, 240);
-    scrollContainer.scrollTop = 320;
+    const cardBody = findTraceCardBody(card);
     expect(within(card).getByText("Dispatch flow")).toBeTruthy();
-    expect(scrollContainer.scrollTop).toBe(320);
+    expectPageFlowCardBody(cardBody);
   });
 });

--- a/ui/src/features/trace-drilldown/components/trace-grid-card.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-grid-card.tsx
@@ -38,7 +38,6 @@ import {
   DashboardEmptyStateTitle,
   DashboardWidgetFrame,
 } from "../../../components/ui/widget-frame";
-import { cn } from "../../../lib/cn";
 import { getTraceDrilldownMessages } from "../messages/trace-drilldown";
 import { TraceRelationFlow } from "./trace-relation-flow";
 import { TraceWorkstationPath } from "./trace-workstation-path";
@@ -74,9 +73,9 @@ export function TraceGridBentoCard({
   return (
     <DashboardWidgetFrame
       bodyProps={
-        { "data-trace-card-scroll": "" } as HTMLAttributes<HTMLDivElement>
+        { "data-trace-card-body": "" } as HTMLAttributes<HTMLDivElement>
       }
-      className={cn("h-full min-h-0 overflow-hidden", className)}
+      className={className}
       headerAction={headerAction}
       title={title ?? messages.title}
       wide

--- a/ui/src/features/trace-drilldown/lib/trace-grid-card-scroll-test-helpers.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-grid-card-scroll-test-helpers.ts
@@ -40,18 +40,19 @@ export function expectNoVerticalScrollContainer(
   expect(style.overflowY).not.toBe("scroll");
 }
 
-export function expectAgentBentoScrollViewport(element: HTMLElement): void {
-  expect(element.hasAttribute("data-radix-scroll-area-viewport")).toBe(true);
+export function expectPageFlowCardBody(element: HTMLElement): void {
+  expect(element.hasAttribute("data-radix-scroll-area-viewport")).toBe(false);
+  expectNoVerticalScrollContainer(element);
 }
 
-export function findTraceCardScrollContainer(card: HTMLElement): HTMLElement {
-  const scrollContainer = card.querySelector("[data-trace-card-scroll]");
-  if (!(scrollContainer instanceof HTMLElement)) {
-    throw new Error("Expected trace card scroll container.");
+export function findTraceCardBody(card: HTMLElement): HTMLElement {
+  const cardBody = card.querySelector("[data-trace-card-body]");
+  if (!(cardBody instanceof HTMLElement)) {
+    throw new Error("Expected trace card body.");
   }
 
-  expectAgentBentoScrollViewport(scrollContainer);
-  return scrollContainer;
+  expectPageFlowCardBody(cardBody);
+  return cardBody;
 }
 
 export function findTraceDispatchTableRegion(card: HTMLElement): HTMLElement {
@@ -63,40 +64,18 @@ export function findTraceDispatchTableRegion(card: HTMLElement): HTMLElement {
   return tableRegion;
 }
 
-export function constrainTraceCardHeight(
-  card: HTMLElement,
-  heightPx: number,
-): HTMLElement {
-  Object.defineProperty(card, "clientHeight", {
-    configurable: true,
-    value: heightPx,
-  });
-  const scrollContainer = findTraceCardScrollContainer(card);
-  Object.defineProperty(scrollContainer, "clientHeight", {
-    configurable: true,
-    value: heightPx - 64,
-  });
-  Object.defineProperty(scrollContainer, "scrollHeight", {
-    configurable: true,
-    value: 2400,
-  });
-  scrollContainer.scrollTop = 0;
-  return scrollContainer;
-}
-
 export function expectNoVerticalScrollBetweenDispatchTableAndCardBody(
   card: HTMLElement,
 ): void {
-  const scrollContainer = findTraceCardScrollContainer(card);
+  const cardBody = findTraceCardBody(card);
   const tableRegion = findTraceDispatchTableRegion(card);
 
-  expectAgentBentoScrollViewport(scrollContainer);
-
   let current: Element | null = tableRegion;
-  while (current && current !== scrollContainer) {
+  while (current && current !== cardBody) {
     expectNoVerticalScrollContainer(current);
     current = current.parentElement;
   }
 
-  expect(current).toBe(scrollContainer);
+  expect(current).toBe(cardBody);
+  expectPageFlowCardBody(cardBody);
 }

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-surface.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-surface.tsx
@@ -92,7 +92,10 @@ export function CurrentActivityGraphSurface({
   }
 
   return (
-    <div className="grid min-h-0 flex-1 gap-3">
+    <div
+      className="grid max-h-full min-h-0 flex-1 gap-3 overflow-hidden"
+      style={{ height: "100%", maxHeight: "100%", overflow: "hidden" }}
+    >
       {showSaveFailureNotice ? (
         <FactoryGraphEditorNotice
           dismissLabel={messages.noticeDismissLabel}

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-viewport.tsx
@@ -259,7 +259,10 @@ export function CurrentActivityGraphViewport({
   );
 
   return (
-    <div className="relative min-h-96 flex-1">
+    <div
+      className="relative max-h-full min-h-96 flex-1 overflow-hidden"
+      style={{ height: "100%", maxHeight: "100%", overflow: "hidden" }}
+    >
       <DashboardFlowAxisLegend
         className="absolute left-4 right-4 top-4 z-10"
         defaultExpanded={false}
@@ -272,7 +275,7 @@ export function CurrentActivityGraphViewport({
         aria-describedby={headingID}
         aria-label={editorMessages.viewportLabel}
         className={cn(
-          "relative h-full min-h-96 overflow-hidden rounded-3xl border shadow-none transition-colors",
+          "relative h-full max-h-full min-h-96 overflow-hidden rounded-3xl border shadow-none transition-colors",
           (imports.dropState.status === "drag-active" ||
             imports.dropState.status === "reading") &&
             "border-primary bg-primary-container",
@@ -285,6 +288,7 @@ export function CurrentActivityGraphViewport({
         )}
         data-current-activity-flow
         ref={flowContainerRef}
+        style={{ height: "100%", maxHeight: "100%", overflow: "hidden" }}
         onDragEnter={imports.onDragEnter}
         onDragLeave={imports.onDragLeave}
         onDragOver={imports.onDragOver}

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card.test.tsx
@@ -2249,6 +2249,12 @@ describe("ReactFlowCurrentActivityCard import flows", () => {
     expect(card?.className).toContain("relative");
     expect(card?.className).toContain("flex");
     expect(card?.className).toContain("h-full");
+    expect(card?.className).toContain("max-h-full");
+    expect(card?.className).toContain("min-h-0");
+    expect(card?.className).toContain("overflow-hidden");
+    expect((card as HTMLElement | null)?.style.height).toBe("100%");
+    expect((card as HTMLElement | null)?.style.maxHeight).toBe("100%");
+    expect((card as HTMLElement | null)?.style.overflow).toBe("hidden");
     expect(card?.className).not.toMatch(PADDING_CLASS_PATTERN);
     expect(
       screen.getByRole("heading", { name: "Current activity" }),
@@ -2259,6 +2265,11 @@ describe("ReactFlowCurrentActivityCard import flows", () => {
     expect(legend?.className).toContain("right-4");
     expect(legend?.className).toContain("top-4");
     expect(legend?.className).not.toMatch(PADDING_CLASS_PATTERN);
+    expect(viewport.className).toContain("max-h-full");
+    expect(viewport.className).toContain("overflow-hidden");
+    expect(viewport.style.height).toBe("100%");
+    expect(viewport.style.maxHeight).toBe("100%");
+    expect(viewport.style.overflow).toBe("hidden");
     expect(viewport.className).not.toMatch(PADDING_CLASS_PATTERN);
     expect(viewport.getAttribute("aria-describedby")).toMatch(
       /^workflow-graph-heading-/,

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card.tsx
@@ -139,7 +139,8 @@ export function ReactFlowCurrentActivityCardView(
     <GraphEditorPlacementProvider>
       <DashboardPanelShell
         aria-labelledby={headingID}
-        className="relative flex h-full min-h-0 min-w-0 flex-col"
+        className="relative flex h-full max-h-full min-h-0 min-w-0 flex-col overflow-hidden"
+        style={{ height: "100%", maxHeight: "100%", overflow: "hidden" }}
       >
         {showHeaderActions ? (
           <div className="mb-4">

--- a/ui/src/features/workflow-activity/components/workflow-activity-bento-card.test.tsx
+++ b/ui/src/features/workflow-activity/components/workflow-activity-bento-card.test.tsx
@@ -245,16 +245,38 @@ describe("WorkflowActivityBentoCard", () => {
     const viewport = await screen.findByRole("region", {
       name: messages.viewportLabel,
     });
+    const graphCard = screen.getByRole("article", {
+      name: messages.widgetTitle,
+    });
+    const graphBody = graphCard.querySelector(
+      "[data-workflow-activity-graph-body]",
+    );
     const workflowSection = viewport.closest<HTMLElement>(
       "section[aria-labelledby]",
     );
     const graphPanelShell = workflowSection?.parentElement;
 
+    expect(graphCard.className).toContain("h-full");
+    expect(graphCard.className).toContain("max-h-full");
+    expect(graphCard.className).toContain("min-h-0");
+    expect(graphCard.className).toContain("overflow-hidden");
+    expect(graphCard.style.height).toBe("100%");
+    expect(graphCard.style.maxHeight).toBe("100%");
+    expect(graphCard.style.overflow).toBe("hidden");
+    expect(graphBody?.className).toContain("h-full");
+    expect(graphBody?.className).toContain("max-h-full");
+    expect(graphBody?.className).toContain("min-h-0");
+    expect(graphBody?.className).toContain("overflow-hidden");
+    expect((graphBody as HTMLElement | null)?.style.height).toBe("100%");
+    expect((graphBody as HTMLElement | null)?.style.maxHeight).toBe("100%");
+    expect((graphBody as HTMLElement | null)?.style.overflow).toBe("hidden");
     expect(graphPanelShell?.tagName).toBe("SECTION");
     expect(graphPanelShell?.className).toContain("relative");
     expect(graphPanelShell?.className).toContain("h-full");
+    expect(graphPanelShell?.className).toContain("max-h-full");
     expect(graphPanelShell?.className).toContain("min-h-0");
     expect(graphPanelShell?.className).toContain("min-w-0");
+    expect(graphPanelShell?.className).toContain("overflow-hidden");
   });
 
   it("wraps the React Flow graph without a floating inspector", async () => {

--- a/ui/src/features/workflow-activity/components/workflow-activity-bento-card.tsx
+++ b/ui/src/features/workflow-activity/components/workflow-activity-bento-card.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect } from "react";
+import { type HTMLAttributes, type ReactNode, useEffect } from "react";
 
 import type { DashboardSnapshot } from "../../../api/dashboard/types";
 import { AgentBentoCard } from "../../bento/public";
@@ -88,8 +88,16 @@ export function WorkflowActivityBentoCard({
 
   return (
     <AgentBentoCard
+      bodyClassName="h-full max-h-full min-h-0 overflow-hidden"
+      bodyProps={
+        {
+          "data-workflow-activity-graph-body": "",
+          style: { height: "100%", maxHeight: "100%", overflow: "hidden" },
+        } as HTMLAttributes<HTMLDivElement>
+      }
       bodyScroll={false}
       chromeDensity="compact"
+      className="h-full max-h-full min-h-0 overflow-hidden"
       headerAction={
         <CurrentActivityGraphHeaderActions
           key={`graph-editor-header-${editor.editorMode}-${editor.draftState.hasChanges}`}
@@ -108,9 +116,13 @@ export function WorkflowActivityBentoCard({
           onToggle={editor.handleEditorModeToggle}
         />
       }
+      style={{ height: "100%", maxHeight: "100%", overflow: "hidden" }}
       title={messages.widgetTitle}
     >
-      <section className="relative h-full min-h-0 min-w-0">
+      <section
+        className="relative h-full max-h-full min-h-0 min-w-0 overflow-hidden"
+        style={{ height: "100%", maxHeight: "100%", overflow: "hidden" }}
+      >
         <ReactFlowCurrentActivityCardView
           editor={editor}
           importController={importController}


### PR DESCRIPTION
{
  "project": "Factory Dashboard Single Global Scroll",
  "branchName": "ralph/scroll-issues",
  "description": "Eliminate the duplicate vertical scroll on the factory dashboard by making the document the sole scroll owner for the header and bento board together, removing the independent bento-section scroll container and default card-body scrollports.",
  "context": {
    "customerAsk": "Right now there are two scroll areas on the right side because the factory bento cards section has an independent scroll region: (1) scroll for the global page with the header, and (2) scroll for the page without the header. Make it so there is only one global scroll, and the bento card section does not have its own scrollable area.",
    "problem": "The factory dashboard shows two vertical scrollbars—one for the full page and one for the bento card section below the header. Fixed-height bento grid cells, card shells with overflow clipping, and default Radix ScrollArea bodies create a viewport-constrained region that scrolls independently from the document, so the header and bento content do not move together.",
    "solution": "Establish document-level scroll as the only vertical scroll owner for the main dashboard. Remove section-level and default card-body vertical scroll from the dashboard shell, bento board layout, AgentBentoCard/DashboardWidgetFrame defaults, and affected widgets (trace drilldown, submit work). Update scroll-ownership tests and add a dashboard regression test so nested bento scroll cannot return."
  },
  "acceptanceCriteria": [
    "Scrolling the loaded factory dashboard moves the header and bento board together with no separate scroll region below the header.",
    "Only one vertical scrollbar appears on the right for the main dashboard view when content exceeds the viewport under normal desktop and mobile widths.",
    "The bento board region does not use overflow-y auto/scroll or a viewport-height clamp that creates an independent vertical scrollport.",
    "Default bento card bodies participate in page flow instead of owning a vertical ScrollArea scrollport for ordinary dashboard content.",
    "Updated dashboard widgets (trace drilldown, submit work, and other shared-frame cards) do not introduce nested vertical scroll between primary content and the page.",
    "Automated regression tests document the single-scroll contract and conflicting scroll-ownership tests are updated.",
    "Quality gate: UI typecheck, lint, and relevant tests pass for touched packages."
  ],
  "userStories": [
    {
      "id": "scroll-issues-001",
      "title": "Dashboard shell uses document scroll only",
      "description": "As a factory operator viewing the dashboard, I want the entire page—including the header—to scroll as one surface so I am never confused by a second scroll region below the header.",
      "acceptanceCriteria": [
        "The loaded dashboard success path (DashboardHeader + DashboardBento inside DashboardScreen) does not wrap the bento board in an element with computed overflow-y auto or overflow-y scroll.",
        "No dashboard-shell wrapper between body and the bento board applies a viewport-height clamp combined with vertical overflow that isolates the bento region from document scroll.",
        "Loading, error, and empty dashboard states keep the same single-page scroll behavior.",
        "dashboard-screen.test.tsx or equivalent asserts the shell does not introduce a nested vertical scroll container on the success path.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "scroll-issues-002",
      "title": "Bento board layout grows without section scroll",
      "description": "As a dashboard user, I want the bento grid to expand with its cards so the page grows taller instead of trapping content in a scrollable section.",
      "acceptanceCriteria": [
        "AgentBentoLayout board shell and react-grid-layout container do not create a vertical scrollport for the board region.",
        "The grid continues to size to its layout (autoSize) and increases document height when cards or rows need more space rather than clipping behind a section scrollbar.",
        "Grid item wrappers keep horizontal overflow controlled without adding a second vertical scroll owner for the section below the header.",
        "agent-bento.test.tsx includes a regression assertion that the bento board region is not a vertical scroll container.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "scroll-issues-003",
      "title": "Bento card bodies default to page-flow scroll",
      "description": "As a dashboard user, I want overflowing card content to extend the page height so I scroll the whole dashboard once instead of scrolling inside each card shell.",
      "acceptanceCriteria": [
        "AgentBentoCard defaults to page-flow bodies (bodyScroll false or equivalent) and does not wrap ordinary card content in Radix ScrollArea by default.",
        "Card shell classes no longer force h-full and overflow-hidden in a way that traps vertical overflow inside the card when bodyScroll is off.",
        "DashboardWidgetFrame passes the page-flow default through to AgentBentoCard unless a caller explicitly opts into localized scroll.",
        "Existing AgentBentoCard tests that asserted default ScrollArea usage are updated to assert page-flow bodies instead.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "scroll-issues-004",
      "title": "Dashboard widgets align with page scroll",
      "description": "As a dashboard user working in trace drilldown, submit work, and other bento-hosted widgets, I want their primary content to scroll with the page so widget internals do not reintroduce a second vertical scrollbar on the right.",
      "acceptanceCriteria": [
        "Trace drilldown cards no longer treat the card body as the primary vertical scroll owner; long dispatch tables scroll with the document.",
        "Submit-work and other bento widgets remove nested overflow-y-auto or overflow-y-scroll wrappers on primary form content.",
        "Cards that already use bodyScroll false continue to render correctly without new internal vertical scrollports.",
        "Trace and submit-work scroll-ownership tests are updated to assert no nested vertical scrollport between widget content and the page.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "scroll-issues-005",
      "title": "Single-scroll regression coverage for the loaded dashboard",
      "description": "As a maintainer, I want an automated regression test for the single-scroll contract so nested bento scroll cannot return unnoticed.",
      "acceptanceCriteria": [
        "A dashboard-level test loads a tall dashboard fixture and asserts exactly one vertical scroll owner among document.documentElement, document.body, and the dashboard root.",
        "The regression test uses behavioral checks (computed overflow-y, scroll height vs client height) rather than file or route inventories.",
        "Test fails if a nested vertical scroll container is reintroduced on the bento section or default card body path.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill: one scrollbar on the right; scrolling moves header and bottom bento cards together on a tall factory dashboard session."
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    }
  ]
}
