### PR TITLE
prd-you-run-clean-invocation-contract

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,8 +17,9 @@ run `you docs <topic>` for packaged topics such as `agents`,
   - prefer `factory/docs/overview.md` for the instance pipeline, work types, and
     read-before-submit guidance;
   - otherwise `factory/docs/README.md` when that file exists.
-- Repo-level factory pointers live in [`factory/README.md`](../factory/README.md);
-  do not duplicate instance walkthroughs in the root factory README.
+- Repo-level factory pointers live in
+  [`factory/docs/overview.md`](../factory/docs/overview.md); do not duplicate
+  instance walkthroughs in the root docs index.
 
 ## Packaged CLI Reference Topics
 
@@ -91,8 +92,8 @@ These are the fixed topic names accepted by `you docs <topic>`.
   `AGENTS.md` file shape, prompt placement, and authoring patterns.
 - [The Zen of flow](reference/the-zen-of-flow.md) explains the project’s workflow
   philosophy.
-- [Understand a run timeline](internal/development/run-timeline.md) explains how
-  `/events`, recordings, replay, and the dashboard use one ordered event timeline.
+- [Record/replay reference](reference/record-replay.md) explains how recordings,
+  replay, and related runtime inspection flows fit together.
 
 ## Maintainer workflow (packaged CLI reference)
 
@@ -104,12 +105,7 @@ These are the fixed topic names accepted by `you docs <topic>`.
 ## Contributor Guides
 
 - [Development guide](internal/development/development.md)
-- [Architecture](internal/development/architecture.md)
-- [API inventory](internal/development/api-inventory.md)
-- [CLI release policy](internal/development/cli-release-policy.md)
-- [Dashboard UI replay testing](internal/development/dashboard-ui-replay-testing.md)
-- [Factory config generated-schema boundary inventory](internal/development/factory-config-generated-schema-boundary-inventory.md)
-- [Live dashboard](internal/development/live-dashboard.md)
-- [Parent-aware fan-in](internal/development/parent-aware-fan-in.md)
-- [Record/replay maintainer guide](internal/development/record-replay.md)
-- [Workstation guards and guarded loop breakers](internal/development/workstation-guards-and-guarded-loop-breakers.md)
+- [Architecture](architecture/architecture.md)
+- [Data model](architecture/data-model.md)
+- [Cursor agent session storage](internal/development/cursor-agent-session-storage.md)
+- [React UI test warning inventory](internal/development/react-ui-test-warning-inventory.md)

--- a/docs/reference/authoring-agents-md.md
+++ b/docs/reference/authoring-agents-md.md
@@ -292,4 +292,4 @@ For complete current examples that include workers and workstations, see:
 - `you docs workstations` - workstation runtime fields, routing, and logical moves
 - `you docs authoring-factories` - factory sequencing and mock-worker checks
 - `you docs templates` - complete variable listing, supported surfaces, and quoting examples
-- [Architecture](../internal/development/architecture.md) - engine design and subsystem details
+- [Architecture](../architecture/architecture.md) - engine design and subsystem details

--- a/docs/reference/authoring-factories.md
+++ b/docs/reference/authoring-factories.md
@@ -680,7 +680,7 @@ review-loop workflow.
 - `you docs workstations`
 - `you docs workers`
 - `you docs batch-inputs`
-- [Parent-Aware Fan-In](../internal/development/parent-aware-fan-in.md)
-- [Workstation Guards And Guarded Loop Breakers](../internal/development/workstation-guards-and-guarded-loop-breakers.md)
+- `you docs relationships`
+- `you docs guards`
 - `you docs templates`
 - `docs/reference/README.md`

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -390,6 +390,101 @@ you run --factory ./factory.json "Fix the lint issues"
 `--factory` cannot be combined with `--dir`. Use `--dir` for the traditional
 factory-directory layout and inbox workflows.
 
+### Clean invocation contract for `you run --factory`
+
+One-shot batch `you run --factory` invocations enter a clean invocation mode
+when they submit prompt or work input and are not `--continuously`. This mode
+is intended for shell pipelines and other result-oriented automation.
+
+Operator-oriented runs keep the existing startup behavior:
+
+- `you` with no args
+- `you run --continuously`
+- `you run --dir ...` without factory prompt submission
+
+#### Input source rules
+
+Clean invocation accepts exactly one primary input source per invocation:
+
+- a trailing positional prompt
+- stdin via `-`
+- piped non-TTY stdin
+- `--work <path>` for a canonical batch file
+
+Do not combine multiple payload sources in the same invocation. If stdin and a
+non-empty positional prompt are both present, the command exits non-zero before
+runtime startup and writes a stable stderr error with code
+`RUN_INVOCATION_AMBIGUOUS_INPUT` naming the conflicting sources.
+
+Example ambiguity failure:
+
+```bash
+printf 'from stdin' | you run --factory ./factory.json "from arg"
+```
+
+Text stderr:
+
+```text
+RUN_INVOCATION_AMBIGUOUS_INPUT: conflicting input sources: positional prompt, stdin
+```
+
+JSON stderr with global `--json`:
+
+```json
+{"code":"RUN_INVOCATION_AMBIGUOUS_INPUT","message":"conflicting input sources: positional prompt, stdin"}
+```
+
+#### Success stdout contract
+
+On success, stdout carries only the primary result from the sole work type that
+declares `handlingBehavior: ["DEFAULT"]`.
+
+- Default text mode writes the result body only.
+- Global `--json` writes exactly one JSON object to stdout.
+- Clean invocation never adds startup banners, dashboard URLs, runtime-log
+  paths, simple-dashboard snapshots, or recording-path notices to stdout.
+
+Text success example:
+
+```bash
+you run --factory ./factory.json "Summarize the changelog" > result.txt
+```
+
+JSON success example:
+
+```bash
+you --json run --factory ./factory.json "Summarize the changelog"
+```
+
+```json
+{"output":"Summary text","workId":"work-123","workTypeName":"task","traceId":"trace-123","sessionId":"~default"}
+```
+
+Stdin-only example:
+
+```bash
+printf 'Summarize stdin input' | you run --factory ./factory.json
+```
+
+#### Failure stderr contract
+
+When a clean invocation fails, is cancelled, or times out, it exits non-zero,
+emits no success payload on stdout, and writes the failure contract to stderr.
+
+Stable error codes include:
+
+- `RUN_INVOCATION_FAILED` for runtime or work failures
+- `RUN_INVOCATION_CANCELLED` for SIGINT or SIGTERM cancellation
+- `RUN_INVOCATION_TIMEOUT` when the invocation deadline is exceeded
+- `RUN_INVOCATION_AMBIGUOUS_INPUT` when payload sources conflict before startup
+
+Without `--json`, stderr is a single concise text line beginning with the stable
+error code. With global `--json`, stderr is a single parseable JSON object with
+at least `code` and `message`.
+
+Default replay recording still follows the configured recording behavior; clean
+invocation only changes what reaches stdout and stderr.
+
 Canonical guides: `you docs mock-workers` and
 `you docs record-replay`. For an end-to-end authoring walkthrough,
 see `you docs authoring-factories`.

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -798,8 +798,11 @@ func runFactory(cmd *cobra.Command, cfg runcli.RunConfig, promptArgs []string, g
 	cfg.Logger = logger
 	cfg.Verbose = verbose || debug
 	cfg.CleanInvocation = cleanInvocation
+	cfg.JSON = globals.json
 	cfg.SuppressDashboardRendering = cfg.SuppressDashboardRendering || cleanInvocation
-	if !cleanInvocation {
+	if cleanInvocation {
+		cfg.Output = cmd.OutOrStdout()
+	} else {
 		cfg.StartupOutput = cmd.OutOrStdout()
 	}
 	cfg.Diagnostics = cmd.ErrOrStderr()

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -713,8 +713,9 @@ func newRunCommand(globals *cliGlobalOptions, diagnostics *cliDiagnosticsOptions
 	cfg := defaultcmd.ExplicitRunConfig()
 
 	cmd := &cobra.Command{
-		Use:   "run",
-		Short: "Load workflow and run the factory engine",
+		Use:           "run",
+		Short:         "Load workflow and run the factory engine",
+		SilenceErrors: true,
 		Long: "Load workflow and run the factory engine.\n\n" +
 			"For the quickest local setup, run " + cliBinaryName + " with no arguments. " +
 			"That default flow bootstraps ./factory, watches factory/inputs/task/default, " +
@@ -748,7 +749,11 @@ func newRunCommand(globals *cliGlobalOptions, diagnostics *cliDiagnosticsOptions
 					cfg.MockWorkersConfigPath = ""
 				}
 			}
-			return runFactory(cmd, cfg, promptArgs, globals, diagnostics.verboseEnabled(), diagnostics.debug)
+			err := runFactory(cmd, cfg, promptArgs, globals, diagnostics.verboseEnabled(), diagnostics.debug)
+			if err != nil && !runcli.WriteInvocationError(cmd.ErrOrStderr(), err, globals.json) {
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), err)
+			}
+			return err
 		},
 	}
 

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -785,6 +785,13 @@ func newRunCommand(globals *cliGlobalOptions, diagnostics *cliDiagnosticsOptions
 }
 
 func runFactory(cmd *cobra.Command, cfg runcli.RunConfig, promptArgs []string, globals *cliGlobalOptions, verbose, debug bool) error {
+	logger, err := logging.BuildLogger(verbose, debug)
+	if err != nil {
+		return err
+	}
+	cfg.Logger = logger
+	cfg.Verbose = verbose || debug
+
 	if err := resolveRunBindFromServer(cmd, globals.server, &cfg); err != nil {
 		return err
 	}
@@ -792,16 +799,10 @@ func runFactory(cmd *cobra.Command, cfg runcli.RunConfig, promptArgs []string, g
 		return err
 	}
 	if err := resolveRunFactoryPrompt(cmd, &cfg, promptArgs); err != nil {
+		runcli.ObserveInvocationRejection(logger, err)
 		return err
 	}
 	cleanInvocation := shouldUseCleanRunInvocation(cmd, cfg)
-
-	logger, err := logging.BuildLogger(verbose, debug)
-	if err != nil {
-		return err
-	}
-	cfg.Logger = logger
-	cfg.Verbose = verbose || debug
 	cfg.CleanInvocation = cleanInvocation
 	cfg.JSON = globals.json
 	cfg.SuppressDashboardRendering = cfg.SuppressDashboardRendering || cleanInvocation
@@ -889,6 +890,9 @@ func resolveRunFactoryPrompt(cmd *cobra.Command, cfg *runcli.RunConfig, promptAr
 	if workChanged && input.Payload != "" {
 		return fmt.Errorf("%s cannot be used with --work", input.Source)
 	}
+	if workChanged {
+		cfg.CleanInvocationInputSource = runcli.InvocationInputSourceWorkFile
+	}
 	if len(promptArgs) > 0 && input.Payload == "" {
 		return fmt.Errorf("prompt is required for you run --factory")
 	}
@@ -901,6 +905,7 @@ func resolveRunFactoryPrompt(cmd *cobra.Command, cfg *runcli.RunConfig, promptAr
 		return err
 	}
 	cfg.WorkFile = workFile
+	cfg.CleanInvocationInputSource = input.Source
 	return nil
 }
 

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -15,7 +15,6 @@ import (
 	"github.com/portpowered/infinite-you/pkg/cli/cliserver"
 	configcli "github.com/portpowered/infinite-you/pkg/cli/config"
 	defaultcmd "github.com/portpowered/infinite-you/pkg/cli/default"
-	"github.com/portpowered/infinite-you/pkg/config/factoryrun"
 	docscli "github.com/portpowered/infinite-you/pkg/cli/docs"
 	factorycli "github.com/portpowered/infinite-you/pkg/cli/factory"
 	initcmd "github.com/portpowered/infinite-you/pkg/cli/init"
@@ -24,6 +23,7 @@ import (
 	sessioncli "github.com/portpowered/infinite-you/pkg/cli/session"
 	submitcli "github.com/portpowered/infinite-you/pkg/cli/submit"
 	workcli "github.com/portpowered/infinite-you/pkg/cli/work"
+	"github.com/portpowered/infinite-you/pkg/config/factoryrun"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/logging"
 	"github.com/spf13/cobra"
@@ -255,7 +255,7 @@ func newFactorySaveCommand(globals *cliGlobalOptions, diagnostics *cliDiagnostic
 			"  " + cliBinaryName + " --json factory save --session session-beta",
 		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
-		PreRunE: rejectDeprecatedPortFlag,
+		PreRunE:      rejectDeprecatedPortFlag,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				liveCfg.Server = globals.server
@@ -324,7 +324,7 @@ func newFactoryQueryCommand(globals *cliGlobalOptions, diagnostics *cliDiagnosti
 			"  # Query a factory API on a non-default host or port.\n" +
 			"  " + cliBinaryName + " --server http://localhost:9090 --json factory query",
 		SilenceUsage: true,
-		PreRunE: rejectDeprecatedPortFlag,
+		PreRunE:      rejectDeprecatedPortFlag,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg.Server = globals.server
 			cfg.JSON = globals.json
@@ -475,8 +475,8 @@ func newModelsCommand(globals *cliGlobalOptions, diagnostics *cliDiagnosticsOpti
 func newModelsListCommand(globals *cliGlobalOptions, diagnostics *cliDiagnosticsOptions) *cobra.Command {
 	cfg := modelscli.ListConfig{Server: globals.server}
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List discovered models",
+		Use:     "list",
+		Short:   "List discovered models",
 		PreRunE: rejectDeprecatedPortFlag,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg.Server = globals.server
@@ -495,9 +495,9 @@ func newModelsListCommand(globals *cliGlobalOptions, diagnostics *cliDiagnostics
 func newModelsInspectCommand(globals *cliGlobalOptions, diagnostics *cliDiagnosticsOptions) *cobra.Command {
 	cfg := modelscli.InspectConfig{Server: globals.server}
 	cmd := &cobra.Command{
-		Use:   "inspect <model-name>",
-		Short: "Inspect one discovered model",
-		Args:  cobra.ExactArgs(1),
+		Use:     "inspect <model-name>",
+		Short:   "Inspect one discovered model",
+		Args:    cobra.ExactArgs(1),
 		PreRunE: rejectDeprecatedPortFlag,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg.Server = globals.server
@@ -517,9 +517,9 @@ func newModelsInspectCommand(globals *cliGlobalOptions, diagnostics *cliDiagnost
 func newModelsInvokeCommand(globals *cliGlobalOptions, diagnostics *cliDiagnosticsOptions) *cobra.Command {
 	cfg := modelscli.InvokeConfig{Server: globals.server, Operation: "TTS"}
 	cmd := &cobra.Command{
-		Use:   "invoke <model-name>",
-		Short: "Invoke one discovered model",
-		Args:  cobra.ExactArgs(1),
+		Use:     "invoke <model-name>",
+		Short:   "Invoke one discovered model",
+		Args:    cobra.ExactArgs(1),
 		PreRunE: rejectDeprecatedPortFlag,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg.Server = globals.server
@@ -542,9 +542,9 @@ func newModelsInvokeCommand(globals *cliGlobalOptions, diagnostics *cliDiagnosti
 func newModelsPullCommand(globals *cliGlobalOptions, diagnostics *cliDiagnosticsOptions) *cobra.Command {
 	cfg := modelscli.PullConfig{Server: globals.server}
 	cmd := &cobra.Command{
-		Use:   "pull <model-name>",
-		Short: "Pull one discovered local model into the managed cache",
-		Args:  cobra.ExactArgs(1),
+		Use:     "pull <model-name>",
+		Short:   "Pull one discovered local model into the managed cache",
+		Args:    cobra.ExactArgs(1),
 		PreRunE: rejectDeprecatedPortFlag,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg.Server = globals.server
@@ -853,25 +853,31 @@ func resolveRunFactorySelection(cmd *cobra.Command, cfg *runcli.RunConfig) error
 func resolveRunFactoryPrompt(cmd *cobra.Command, cfg *runcli.RunConfig, promptArgs []string) error {
 	factoryChanged := cmd.Flags().Changed("factory")
 	workChanged := cmd.Flags().Changed("work")
-	prompt := strings.TrimSpace(strings.Join(promptArgs, " "))
+	input, err := runcli.ResolveFactoryInvocationInput(runcli.FactoryInvocationInputConfig{
+		PromptArgs: promptArgs,
+		Stdin:      cmd.InOrStdin(),
+	})
+	if err != nil {
+		return err
+	}
 
 	if !factoryChanged {
-		if prompt != "" {
+		if input.Payload != "" {
 			return fmt.Errorf("positional prompt arguments require --factory")
 		}
 		return nil
 	}
-	if workChanged && prompt != "" {
-		return fmt.Errorf("positional prompt arguments cannot be used with --work")
+	if workChanged && input.Payload != "" {
+		return fmt.Errorf("%s cannot be used with --work", input.Source)
 	}
-	if len(promptArgs) > 0 && prompt == "" {
+	if len(promptArgs) > 0 && input.Payload == "" {
 		return fmt.Errorf("prompt is required for you run --factory")
 	}
-	if prompt == "" {
+	if input.Payload == "" {
 		return nil
 	}
 
-	workFile, err := runcli.PrepareFactoryPromptWorkFile(cfg.FactoryConfigPath, prompt)
+	workFile, err := runcli.PrepareFactoryPromptWorkFile(cfg.FactoryConfigPath, input.Payload)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -789,6 +789,7 @@ func runFactory(cmd *cobra.Command, cfg runcli.RunConfig, promptArgs []string, g
 	if err := resolveRunFactoryPrompt(cmd, &cfg, promptArgs); err != nil {
 		return err
 	}
+	cleanInvocation := shouldUseCleanRunInvocation(cmd, cfg)
 
 	logger, err := logging.BuildLogger(verbose, debug)
 	if err != nil {
@@ -796,7 +797,11 @@ func runFactory(cmd *cobra.Command, cfg runcli.RunConfig, promptArgs []string, g
 	}
 	cfg.Logger = logger
 	cfg.Verbose = verbose || debug
-	cfg.StartupOutput = cmd.OutOrStdout()
+	cfg.CleanInvocation = cleanInvocation
+	cfg.SuppressDashboardRendering = cfg.SuppressDashboardRendering || cleanInvocation
+	if !cleanInvocation {
+		cfg.StartupOutput = cmd.OutOrStdout()
+	}
 	cfg.Diagnostics = cmd.ErrOrStderr()
 
 	ctx, cancel := context.WithCancel(cmd.Context())
@@ -815,6 +820,12 @@ func runFactory(cmd *cobra.Command, cfg runcli.RunConfig, promptArgs []string, g
 	}()
 
 	return runCLI(ctx, cfg)
+}
+
+func shouldUseCleanRunInvocation(cmd *cobra.Command, cfg runcli.RunConfig) bool {
+	return cmd.Flags().Changed("factory") &&
+		strings.TrimSpace(cfg.WorkFile) != "" &&
+		!cfg.Continuously
 }
 
 func resolveRunBindFromServer(cmd *cobra.Command, server string, cfg *runcli.RunConfig) error {

--- a/pkg/cli/root_run_factory_prompt_test.go
+++ b/pkg/cli/root_run_factory_prompt_test.go
@@ -300,7 +300,7 @@ func TestRunCommand_FactoryPromptSelectsCleanInvocationMode(t *testing.T) {
 	root := NewRootCommand()
 	root.SetOut(&stdout)
 	root.SetErr(io.Discard)
-	root.SetArgs([]string{"run", "--factory", factoryPath, "Fix the lint issues"})
+	root.SetArgs([]string{"--json", "run", "--factory", factoryPath, "Fix the lint issues"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("execute clean factory prompt run: %v", err)
@@ -317,6 +317,12 @@ func TestRunCommand_FactoryPromptSelectsCleanInvocationMode(t *testing.T) {
 	}
 	if got.StartupOutput != nil {
 		t.Fatalf("startup output = %#v, want nil for clean invocation mode", got.StartupOutput)
+	}
+	if !got.JSON {
+		t.Fatal("expected global --json to map to clean run config")
+	}
+	if got.Output == nil {
+		t.Fatal("expected clean run config to receive stdout writer")
 	}
 	assertRunStdoutFreeOfOperatorChatter(t, stdout.String())
 }

--- a/pkg/cli/root_run_factory_prompt_test.go
+++ b/pkg/cli/root_run_factory_prompt_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"os"
@@ -275,6 +276,120 @@ func TestRunCommand_FactoryStdinPromptSubmitsDefaultWorkTypeWorkFile(t *testing.
 	}
 }
 
+func TestRunCommand_FactoryPromptSelectsCleanInvocationMode(t *testing.T) {
+	originalRunCLI := runCLI
+	defer func() {
+		runCLI = originalRunCLI
+	}()
+
+	dir := t.TempDir()
+	factoryPath := writePortableFactoryWithDefaultHandling(t, dir)
+
+	var got runcli.RunConfig
+	runCLI = func(_ context.Context, cfg runcli.RunConfig) error {
+		got = cfg
+		if cfg.StartupOutput != nil {
+			io.WriteString(cfg.StartupOutput, "Factory initiated: unexpected\n")
+			io.WriteString(cfg.StartupOutput, "Dashboard URL: unexpected\n")
+			io.WriteString(cfg.StartupOutput, "Recording saved: unexpected\n")
+		}
+		return nil
+	}
+
+	var stdout bytes.Buffer
+	root := NewRootCommand()
+	root.SetOut(&stdout)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"run", "--factory", factoryPath, "Fix the lint issues"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute clean factory prompt run: %v", err)
+	}
+	if got.WorkFile == "" {
+		t.Fatal("expected generated work file for factory prompt run")
+	}
+	t.Cleanup(func() { _ = os.Remove(got.WorkFile) })
+	if !got.CleanInvocation {
+		t.Fatal("expected factory prompt batch run to select clean invocation mode")
+	}
+	if !got.SuppressDashboardRendering {
+		t.Fatal("expected clean invocation mode to suppress dashboard rendering")
+	}
+	if got.StartupOutput != nil {
+		t.Fatalf("startup output = %#v, want nil for clean invocation mode", got.StartupOutput)
+	}
+	assertRunStdoutFreeOfOperatorChatter(t, stdout.String())
+}
+
+func TestRunCommand_FactoryWorkFileSelectsCleanInvocationMode(t *testing.T) {
+	originalRunCLI := runCLI
+	defer func() {
+		runCLI = originalRunCLI
+	}()
+
+	dir := t.TempDir()
+	factoryPath := writePortableFactoryWithDefaultHandling(t, dir)
+	workPath := filepath.Join(dir, "work.json")
+
+	var got runcli.RunConfig
+	runCLI = func(_ context.Context, cfg runcli.RunConfig) error {
+		got = cfg
+		return nil
+	}
+
+	root := NewRootCommand()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"run", "--factory", factoryPath, "--work", workPath})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute clean factory work-file run: %v", err)
+	}
+	if !got.CleanInvocation {
+		t.Fatal("expected factory work-file batch run to select clean invocation mode")
+	}
+	if !got.SuppressDashboardRendering {
+		t.Fatal("expected clean invocation mode to suppress dashboard rendering")
+	}
+	if got.StartupOutput != nil {
+		t.Fatalf("startup output = %#v, want nil for clean invocation mode", got.StartupOutput)
+	}
+}
+
+func TestRunCommand_FactoryContinuousPromptKeepsOperatorOutputMode(t *testing.T) {
+	originalRunCLI := runCLI
+	defer func() {
+		runCLI = originalRunCLI
+	}()
+
+	dir := t.TempDir()
+	factoryPath := writePortableFactoryWithDefaultHandling(t, dir)
+
+	var got runcli.RunConfig
+	runCLI = func(_ context.Context, cfg runcli.RunConfig) error {
+		got = cfg
+		return nil
+	}
+
+	root := NewRootCommand()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"run", "--factory", factoryPath, "--continuously", "Fix the lint issues"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute continuous factory prompt run: %v", err)
+	}
+	if got.CleanInvocation {
+		t.Fatal("continuous factory run should keep operator output mode")
+	}
+	if got.SuppressDashboardRendering {
+		t.Fatal("continuous factory run should not implicitly suppress dashboard rendering")
+	}
+	if got.StartupOutput == nil {
+		t.Fatal("continuous factory run should keep startup output configured")
+	}
+}
+
 func TestRunCommand_FactoryPromptRejectsEmptyPrompt(t *testing.T) {
 	originalRunCLI := runCLI
 	defer func() {
@@ -304,6 +419,23 @@ func TestRunCommand_FactoryPromptRejectsEmptyPrompt(t *testing.T) {
 	}
 	if runCalled {
 		t.Fatal("run should not start for empty factory prompt")
+	}
+}
+
+func assertRunStdoutFreeOfOperatorChatter(t *testing.T, stdout string) {
+	t.Helper()
+
+	for _, forbidden := range []string{
+		"Factory initiated",
+		"Dashboard URL",
+		"Runtime log",
+		"Opening dashboard",
+		"Factory:",
+		"Recording saved",
+	} {
+		if strings.Contains(stdout, forbidden) {
+			t.Fatalf("stdout = %q, want no %q chatter", stdout, forbidden)
+		}
 	}
 }
 

--- a/pkg/cli/root_run_factory_prompt_test.go
+++ b/pkg/cli/root_run_factory_prompt_test.go
@@ -234,6 +234,47 @@ func TestRunCommand_FactoryPromptSubmitsDefaultWorkTypeWorkFile(t *testing.T) {
 	}
 }
 
+func TestRunCommand_FactoryStdinPromptSubmitsDefaultWorkTypeWorkFile(t *testing.T) {
+	originalRunCLI := runCLI
+	defer func() {
+		runCLI = originalRunCLI
+	}()
+
+	dir := t.TempDir()
+	factoryPath := writePortableFactoryWithDefaultHandling(t, dir)
+
+	var got runcli.RunConfig
+	runCLI = func(_ context.Context, cfg runcli.RunConfig) error {
+		got = cfg
+		return nil
+	}
+
+	root := NewRootCommand()
+	root.SetIn(strings.NewReader("Fix the stdin path\n"))
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"run", "--factory", factoryPath, "-"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute run --factory with stdin prompt: %v", err)
+	}
+	if got.WorkFile == "" {
+		t.Fatal("expected generated work file for stdin factory prompt run")
+	}
+	t.Cleanup(func() { _ = os.Remove(got.WorkFile) })
+
+	workRequest, err := runcli.LoadWorkFile(got.WorkFile)
+	if err != nil {
+		t.Fatalf("LoadWorkFile: %v", err)
+	}
+	if len(workRequest.Works) != 1 || workRequest.Works[0].WorkTypeID != "story" {
+		t.Fatalf("works = %#v, want one story work item", workRequest.Works)
+	}
+	if payload, ok := workRequest.Works[0].Payload.(string); !ok || payload != "Fix the stdin path" {
+		t.Fatalf("payload = %#v, want stdin prompt text", workRequest.Works[0].Payload)
+	}
+}
+
 func TestRunCommand_FactoryPromptRejectsEmptyPrompt(t *testing.T) {
 	originalRunCLI := runCLI
 	defer func() {
@@ -263,6 +304,45 @@ func TestRunCommand_FactoryPromptRejectsEmptyPrompt(t *testing.T) {
 	}
 	if runCalled {
 		t.Fatal("run should not start for empty factory prompt")
+	}
+}
+
+func TestRunCommand_FactoryPromptRejectsAmbiguousPositionalAndStdin(t *testing.T) {
+	originalRunCLI := runCLI
+	defer func() {
+		runCLI = originalRunCLI
+	}()
+
+	dir := t.TempDir()
+	factoryPath := writePortableFactoryWithDefaultHandling(t, dir)
+
+	runCalled := false
+	runCLI = func(context.Context, runcli.RunConfig) error {
+		runCalled = true
+		return nil
+	}
+
+	root := NewRootCommand()
+	root.SetIn(strings.NewReader("Fix from stdin\n"))
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"run", "--factory", factoryPath, "Fix from args", "-"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected ambiguous positional and stdin prompt rejection")
+	}
+	for _, want := range []string{
+		runcli.InvocationErrorCodeAmbiguousInput,
+		string(runcli.InvocationInputSourcePositional),
+		string(runcli.InvocationInputSourceStdin),
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want %q", err.Error(), want)
+		}
+	}
+	if runCalled {
+		t.Fatal("run should not start for ambiguous factory prompt input")
 	}
 }
 

--- a/pkg/cli/root_run_factory_prompt_test.go
+++ b/pkg/cli/root_run_factory_prompt_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -542,5 +543,81 @@ func TestRunCommand_PositionalPromptRequiresFactoryFlag(t *testing.T) {
 	}
 	if runCalled {
 		t.Fatal("run should not start for positional prompt without --factory")
+	}
+}
+
+func TestRunCommand_CleanInvocationFailureWritesPlaintextToStderr(t *testing.T) {
+	originalRunCLI := runCLI
+	defer func() {
+		runCLI = originalRunCLI
+	}()
+
+	dir := t.TempDir()
+	factoryPath := writePortableFactoryWithDefaultHandling(t, dir)
+
+	var stdout, stderr bytes.Buffer
+	runCLI = func(context.Context, runcli.RunConfig) error {
+		return &runcli.InvocationError{
+			Code:    runcli.InvocationErrorCodeFailed,
+			Message: "clean invocation failed: mock worker rejected",
+		}
+	}
+
+	root := NewRootCommand()
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"run", "--factory", factoryPath, "Fix the lint issues"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected clean invocation failure")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if got := stderr.String(); got != "RUN_INVOCATION_FAILED: clean invocation failed: mock worker rejected\n" {
+		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func TestRunCommand_CleanInvocationJSONFailureWritesSingleErrorObjectToStderr(t *testing.T) {
+	originalRunCLI := runCLI
+	defer func() {
+		runCLI = originalRunCLI
+	}()
+
+	dir := t.TempDir()
+	factoryPath := writePortableFactoryWithDefaultHandling(t, dir)
+
+	var stdout, stderr bytes.Buffer
+	runCLI = func(context.Context, runcli.RunConfig) error {
+		return &runcli.InvocationError{
+			Code:    runcli.InvocationErrorCodeTimeout,
+			Message: "clean invocation timed out",
+		}
+	}
+
+	root := NewRootCommand()
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"--json", "run", "--factory", factoryPath, "Fix the lint issues"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected clean invocation timeout")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+
+	var payload map[string]string
+	if decodeErr := json.Unmarshal(stderr.Bytes(), &payload); decodeErr != nil {
+		t.Fatalf("stderr is not one JSON object: %v\n%s", decodeErr, stderr.String())
+	}
+	if payload["code"] != runcli.InvocationErrorCodeTimeout {
+		t.Fatalf("code = %q, want %q", payload["code"], runcli.InvocationErrorCodeTimeout)
+	}
+	if payload["message"] != "clean invocation timed out" {
+		t.Fatalf("message = %q", payload["message"])
 	}
 }

--- a/pkg/cli/run/factory_invocation_input.go
+++ b/pkg/cli/run/factory_invocation_input.go
@@ -1,0 +1,112 @@
+package run
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+const (
+	InvocationErrorCodeAmbiguousInput = "RUN_INVOCATION_AMBIGUOUS_INPUT"
+)
+
+type InvocationInputSource string
+
+const (
+	InvocationInputSourcePositional InvocationInputSource = "positional prompt"
+	InvocationInputSourceStdin      InvocationInputSource = "stdin"
+)
+
+type FactoryInvocationInputConfig struct {
+	PromptArgs []string
+	Stdin      io.Reader
+	StdinIsTTY func() bool
+}
+
+type FactoryInvocationInput struct {
+	Source  InvocationInputSource
+	Payload string
+}
+
+// ResolveFactoryInvocationInput resolves the one-shot invocation payload from
+// positional prompt args, explicit "-" stdin, or piped non-TTY stdin.
+func ResolveFactoryInvocationInput(cfg FactoryInvocationInputConfig) (FactoryInvocationInput, error) {
+	positionalPrompt, explicitStdin := splitInvocationPromptArgs(cfg.PromptArgs)
+	stdinPayload, hasStdin, err := resolveInvocationStdin(cfg, explicitStdin)
+	if err != nil {
+		return FactoryInvocationInput{}, err
+	}
+
+	var sources []InvocationInputSource
+	if positionalPrompt != "" {
+		sources = append(sources, InvocationInputSourcePositional)
+	}
+	if hasStdin {
+		sources = append(sources, InvocationInputSourceStdin)
+	}
+	if len(sources) > 1 {
+		return FactoryInvocationInput{}, ambiguousInvocationInputError(sources)
+	}
+	if positionalPrompt != "" {
+		return FactoryInvocationInput{Source: InvocationInputSourcePositional, Payload: positionalPrompt}, nil
+	}
+	if hasStdin {
+		return FactoryInvocationInput{Source: InvocationInputSourceStdin, Payload: stdinPayload}, nil
+	}
+	return FactoryInvocationInput{}, nil
+}
+
+func splitInvocationPromptArgs(args []string) (prompt string, explicitStdin bool) {
+	positional := make([]string, 0, len(args))
+	for _, arg := range args {
+		if strings.TrimSpace(arg) == "-" {
+			explicitStdin = true
+			continue
+		}
+		positional = append(positional, arg)
+	}
+	return strings.TrimSpace(strings.Join(positional, " ")), explicitStdin
+}
+
+func resolveInvocationStdin(cfg FactoryInvocationInputConfig, explicitStdin bool) (string, bool, error) {
+	if !explicitStdin && invocationStdinIsTTY(cfg) {
+		return "", false, nil
+	}
+
+	stdin := cfg.Stdin
+	if stdin == nil {
+		stdin = os.Stdin
+	}
+	data, err := io.ReadAll(stdin)
+	if err != nil {
+		return "", false, fmt.Errorf("read invocation stdin: %w", err)
+	}
+	payload := strings.TrimSpace(string(data))
+	if payload == "" {
+		if explicitStdin {
+			return "", false, fmt.Errorf("stdin input is empty")
+		}
+		return "", false, nil
+	}
+	return payload, true, nil
+}
+
+func invocationStdinIsTTY(cfg FactoryInvocationInputConfig) bool {
+	if cfg.StdinIsTTY != nil {
+		return cfg.StdinIsTTY()
+	}
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return true
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+func ambiguousInvocationInputError(sources []InvocationInputSource) error {
+	labels := make([]string, 0, len(sources))
+	for _, source := range sources {
+		labels = append(labels, string(source))
+	}
+	return fmt.Errorf("%s: ambiguous invocation input sources: %s", InvocationErrorCodeAmbiguousInput, strings.Join(labels, " and "))
+}

--- a/pkg/cli/run/factory_invocation_input.go
+++ b/pkg/cli/run/factory_invocation_input.go
@@ -16,6 +16,7 @@ type InvocationInputSource string
 const (
 	InvocationInputSourcePositional InvocationInputSource = "positional prompt"
 	InvocationInputSourceStdin      InvocationInputSource = "stdin"
+	InvocationInputSourceWorkFile   InvocationInputSource = "work file"
 )
 
 type FactoryInvocationInputConfig struct {
@@ -104,9 +105,39 @@ func invocationStdinIsTTY(cfg FactoryInvocationInputConfig) bool {
 }
 
 func ambiguousInvocationInputError(sources []InvocationInputSource) error {
+	labels := invocationInputSourceLabels(sources)
+	return &AmbiguousInvocationInputError{
+		invocationErr: &InvocationError{
+			Code:    InvocationErrorCodeAmbiguousInput,
+			Message: fmt.Sprintf("ambiguous invocation input sources: %s", strings.Join(labels, " and ")),
+		},
+		Sources: append([]InvocationInputSource(nil), sources...),
+	}
+}
+
+type AmbiguousInvocationInputError struct {
+	invocationErr *InvocationError
+	Sources       []InvocationInputSource
+}
+
+func (e *AmbiguousInvocationInputError) Error() string {
+	if e == nil || e.invocationErr == nil {
+		return ""
+	}
+	return e.invocationErr.Error()
+}
+
+func (e *AmbiguousInvocationInputError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.invocationErr
+}
+
+func invocationInputSourceLabels(sources []InvocationInputSource) []string {
 	labels := make([]string, 0, len(sources))
 	for _, source := range sources {
 		labels = append(labels, string(source))
 	}
-	return fmt.Errorf("%s: ambiguous invocation input sources: %s", InvocationErrorCodeAmbiguousInput, strings.Join(labels, " and "))
+	return labels
 }

--- a/pkg/cli/run/factory_invocation_input_test.go
+++ b/pkg/cli/run/factory_invocation_input_test.go
@@ -3,6 +3,9 @@ package run
 import (
 	"strings"
 	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestResolveFactoryInvocationInput_PositionalOnly(t *testing.T) {
@@ -79,5 +82,55 @@ func TestResolveFactoryInvocationInput_RejectsPositionalAndStdinConflict(t *test
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error = %q, want %q", err.Error(), want)
 		}
+	}
+}
+
+func TestObserveInvocationRejection_AmbiguousInputRecordsStructuredLogAndMetrics(t *testing.T) {
+	resetCleanInvocationMetricsForTest()
+
+	_, err := ResolveFactoryInvocationInput(FactoryInvocationInputConfig{
+		PromptArgs: []string{"Fix", "tests"},
+		Stdin:      strings.NewReader("Fix from stdin\n"),
+		StdinIsTTY: func() bool { return false },
+	})
+	if err == nil {
+		t.Fatal("expected ambiguous input error")
+	}
+
+	core, observed := observer.New(zap.InfoLevel)
+	ObserveInvocationRejection(zap.New(core), err)
+
+	entry := observed.FilterMessage(cleanInvocationLogMessageRejected).AllUntimed()
+	if len(entry) != 1 {
+		t.Fatalf("rejected logs = %d, want 1", len(entry))
+	}
+	fields := entry[0].ContextMap()
+	if fields["mode"] != cleanInvocationModeLabel {
+		t.Fatalf("mode = %#v, want clean", fields["mode"])
+	}
+	if fields["reason"] != cleanInvocationRejectReason {
+		t.Fatalf("reason = %#v, want ambiguous_input", fields["reason"])
+	}
+	conflictingAny, ok := fields["conflictingSources"].([]interface{})
+	if !ok {
+		t.Fatalf("conflictingSources = %#v, want []interface{}", fields["conflictingSources"])
+	}
+	conflicting := make([]string, 0, len(conflictingAny))
+	for _, value := range conflictingAny {
+		label, ok := value.(string)
+		if !ok {
+			t.Fatalf("conflictingSources entry = %#v, want string", value)
+		}
+		conflicting = append(conflicting, label)
+	}
+	if len(conflicting) != 2 || conflicting[0] != "positional_prompt" || conflicting[1] != "stdin" {
+		t.Fatalf("conflictingSources = %#v", conflicting)
+	}
+
+	if got := snapshotCleanInvocationMetrics(); got != (CleanInvocationMetricsSnapshot{
+		Attempts:          1,
+		AmbiguityRejected: 1,
+	}) {
+		t.Fatalf("metrics = %#v", got)
 	}
 }

--- a/pkg/cli/run/factory_invocation_input_test.go
+++ b/pkg/cli/run/factory_invocation_input_test.go
@@ -1,0 +1,83 @@
+package run
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveFactoryInvocationInput_PositionalOnly(t *testing.T) {
+	got, err := ResolveFactoryInvocationInput(FactoryInvocationInputConfig{
+		PromptArgs: []string{"Fix", "the", "lint", "issues"},
+		StdinIsTTY: func() bool {
+			return true
+		},
+	})
+	if err != nil {
+		t.Fatalf("ResolveFactoryInvocationInput: %v", err)
+	}
+	if got.Source != InvocationInputSourcePositional {
+		t.Fatalf("source = %q, want positional prompt", got.Source)
+	}
+	if got.Payload != "Fix the lint issues" {
+		t.Fatalf("payload = %q, want joined prompt text", got.Payload)
+	}
+}
+
+func TestResolveFactoryInvocationInput_StdinOnlyFromDash(t *testing.T) {
+	got, err := ResolveFactoryInvocationInput(FactoryInvocationInputConfig{
+		PromptArgs: []string{"-"},
+		Stdin:      strings.NewReader("Fix the tests\n"),
+		StdinIsTTY: func() bool {
+			return true
+		},
+	})
+	if err != nil {
+		t.Fatalf("ResolveFactoryInvocationInput: %v", err)
+	}
+	if got.Source != InvocationInputSourceStdin {
+		t.Fatalf("source = %q, want stdin", got.Source)
+	}
+	if got.Payload != "Fix the tests" {
+		t.Fatalf("payload = %q, want stdin payload", got.Payload)
+	}
+}
+
+func TestResolveFactoryInvocationInput_StdinOnlyFromPipe(t *testing.T) {
+	got, err := ResolveFactoryInvocationInput(FactoryInvocationInputConfig{
+		Stdin: strings.NewReader("Fix from pipe\n"),
+		StdinIsTTY: func() bool {
+			return false
+		},
+	})
+	if err != nil {
+		t.Fatalf("ResolveFactoryInvocationInput: %v", err)
+	}
+	if got.Source != InvocationInputSourceStdin {
+		t.Fatalf("source = %q, want stdin", got.Source)
+	}
+	if got.Payload != "Fix from pipe" {
+		t.Fatalf("payload = %q, want stdin payload", got.Payload)
+	}
+}
+
+func TestResolveFactoryInvocationInput_RejectsPositionalAndStdinConflict(t *testing.T) {
+	_, err := ResolveFactoryInvocationInput(FactoryInvocationInputConfig{
+		PromptArgs: []string{"Fix", "the", "lint", "issues"},
+		Stdin:      strings.NewReader("Fix from stdin\n"),
+		StdinIsTTY: func() bool {
+			return false
+		},
+	})
+	if err == nil {
+		t.Fatal("expected ambiguous input error")
+	}
+	for _, want := range []string{
+		InvocationErrorCodeAmbiguousInput,
+		string(InvocationInputSourcePositional),
+		string(InvocationInputSourceStdin),
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want %q", err.Error(), want)
+		}
+	}
+}

--- a/pkg/cli/run/invocation_error.go
+++ b/pkg/cli/run/invocation_error.go
@@ -1,0 +1,67 @@
+package run
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	InvocationErrorCodeFailed    = "RUN_INVOCATION_FAILED"
+	InvocationErrorCodeCancelled = "RUN_INVOCATION_CANCELLED"
+	InvocationErrorCodeTimeout   = "RUN_INVOCATION_TIMEOUT"
+)
+
+type InvocationError struct {
+	Code    string
+	Message string
+	Cause   error
+}
+
+func (e *InvocationError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if strings.TrimSpace(e.Message) == "" {
+		return e.Code
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+func (e *InvocationError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+type invocationErrorPayload struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// WriteInvocationError renders the stable clean-invocation failure contract to
+// stderr. It returns true when err matched an invocation contract error.
+func WriteInvocationError(w io.Writer, err error, jsonOutput bool) bool {
+	var invocationErr *InvocationError
+	if !errors.As(err, &invocationErr) {
+		return false
+	}
+	if w == nil {
+		return true
+	}
+	if jsonOutput {
+		data, marshalErr := json.Marshal(invocationErrorPayload{
+			Code:    invocationErr.Code,
+			Message: invocationErr.Message,
+		})
+		if marshalErr == nil {
+			_, _ = fmt.Fprintln(w, string(data))
+			return true
+		}
+	}
+	_, _ = fmt.Fprintln(w, invocationErr.Error())
+	return true
+}

--- a/pkg/cli/run/invocation_observability.go
+++ b/pkg/cli/run/invocation_observability.go
@@ -1,0 +1,204 @@
+package run
+
+import (
+	"errors"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/portpowered/infinite-you/pkg/factory/state"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/petri"
+	"go.uber.org/zap"
+)
+
+const (
+	cleanInvocationLogMessageCompleted = "run.invocation.completed"
+	cleanInvocationLogMessageRejected  = "run.invocation.rejected"
+	cleanInvocationModeLabel           = "clean"
+	cleanInvocationRejectReason        = "ambiguous_input"
+	cleanInvocationOutcomeSuccess      = "success"
+	cleanInvocationOutcomeFailure      = "failure"
+	cleanInvocationOutcomeCancelled    = "cancelled"
+	cleanInvocationOutcomeTimeout      = "timeout"
+	cleanInvocationErrorSummaryLimit   = 160
+)
+
+type cleanInvocationCounterSet struct {
+	attempts          atomic.Int64
+	successes         atomic.Int64
+	failures          atomic.Int64
+	ambiguityRejected atomic.Int64
+	cancellations     atomic.Int64
+}
+
+type CleanInvocationMetricsSnapshot struct {
+	Attempts          int64
+	Successes         int64
+	Failures          int64
+	AmbiguityRejected int64
+	Cancellations     int64
+}
+
+type cleanInvocationCompletionLogInput struct {
+	StartedAt time.Time
+	Snapshot  *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]
+	Target    *cleanInvocationWorkTarget
+	Success   *cleanInvocationSuccess
+	Err       error
+}
+
+var cleanInvocationMetrics cleanInvocationCounterSet
+
+func recordCleanInvocationAttempt() {
+	cleanInvocationMetrics.attempts.Add(1)
+}
+
+func ObserveInvocationRejection(logger *zap.Logger, err error) {
+	var ambiguousErr *AmbiguousInvocationInputError
+	if !errors.As(err, &ambiguousErr) {
+		return
+	}
+	recordCleanInvocationAttempt()
+	cleanInvocationMetrics.ambiguityRejected.Add(1)
+	cleanInvocationLogger(logger).Info(
+		cleanInvocationLogMessageRejected,
+		zap.String("mode", cleanInvocationModeLabel),
+		zap.String("reason", cleanInvocationRejectReason),
+		zap.Strings("conflictingSources", invocationInputSourceLogLabels(ambiguousErr.Sources)),
+	)
+}
+
+func recordCleanInvocationCompletion(logger *zap.Logger, cfg RunConfig, input cleanInvocationCompletionLogInput) {
+	logger = cleanInvocationLogger(logger)
+	duration := time.Since(input.StartedAt)
+	if input.StartedAt.IsZero() {
+		duration = 0
+	}
+
+	fields := []zap.Field{
+		zap.String("mode", cleanInvocationModeLabel),
+		zap.String("inputSource", invocationInputSourceLogLabel(cfg.CleanInvocationInputSource)),
+		zap.Int64("durationMs", duration.Milliseconds()),
+	}
+
+	if input.Success != nil {
+		cleanInvocationMetrics.successes.Add(1)
+		fields = append(fields,
+			zap.String("outcome", cleanInvocationOutcomeSuccess),
+			zap.String("workId", input.Success.WorkID),
+			zap.String("workTypeName", input.Success.WorkTypeName),
+		)
+		if strings.TrimSpace(input.Success.TraceID) != "" {
+			fields = append(fields, zap.String("traceId", input.Success.TraceID))
+		}
+		if strings.TrimSpace(input.Success.SessionID) != "" {
+			fields = append(fields, zap.String("sessionId", input.Success.SessionID))
+		}
+		logger.Info(cleanInvocationLogMessageCompleted, fields...)
+		return
+	}
+
+	if input.Target != nil {
+		fields = append(fields,
+			zap.String("workId", input.Target.WorkID),
+			zap.String("workTypeName", input.Target.WorkTypeName),
+		)
+	}
+
+	outcome, code, summary := cleanInvocationFailureLogFields(input.Err)
+	switch outcome {
+	case cleanInvocationOutcomeCancelled:
+		cleanInvocationMetrics.cancellations.Add(1)
+	case cleanInvocationOutcomeFailure, cleanInvocationOutcomeTimeout:
+		cleanInvocationMetrics.failures.Add(1)
+	}
+	fields = append(fields,
+		zap.String("outcome", outcome),
+		zap.String("errorCode", code),
+	)
+	if summary != "" {
+		fields = append(fields, zap.String("errorSummary", summary))
+	}
+	logger.Info(cleanInvocationLogMessageCompleted, fields...)
+}
+
+func cleanInvocationFailureLogFields(err error) (string, string, string) {
+	var invocationErr *InvocationError
+	if errors.As(err, &invocationErr) {
+		switch invocationErr.Code {
+		case InvocationErrorCodeCancelled:
+			return cleanInvocationOutcomeCancelled, invocationErr.Code, boundedInvocationErrorSummary(invocationErr.Message)
+		case InvocationErrorCodeTimeout:
+			return cleanInvocationOutcomeTimeout, invocationErr.Code, boundedInvocationErrorSummary(invocationErr.Message)
+		default:
+			return cleanInvocationOutcomeFailure, invocationErr.Code, boundedInvocationErrorSummary(invocationErr.Message)
+		}
+	}
+	summary := boundedInvocationErrorSummary(errString(err))
+	if summary == "" {
+		return cleanInvocationOutcomeFailure, InvocationErrorCodeFailed, ""
+	}
+	return cleanInvocationOutcomeFailure, InvocationErrorCodeFailed, summary
+}
+
+func cleanInvocationLogger(logger *zap.Logger) *zap.Logger {
+	if logger == nil {
+		return zap.NewNop()
+	}
+	return logger
+}
+
+func invocationInputSourceLogLabels(sources []InvocationInputSource) []string {
+	labels := make([]string, 0, len(sources))
+	for _, source := range sources {
+		labels = append(labels, invocationInputSourceLogLabel(source))
+	}
+	return labels
+}
+
+func invocationInputSourceLogLabel(source InvocationInputSource) string {
+	switch source {
+	case InvocationInputSourcePositional:
+		return "positional_prompt"
+	case InvocationInputSourceStdin:
+		return "stdin"
+	case InvocationInputSourceWorkFile:
+		return "work_file"
+	default:
+		return "unknown"
+	}
+}
+
+func boundedInvocationErrorSummary(message string) string {
+	message = strings.Join(strings.Fields(strings.TrimSpace(message)), " ")
+	if len(message) <= cleanInvocationErrorSummaryLimit {
+		return message
+	}
+	return message[:cleanInvocationErrorSummaryLimit] + "..."
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func snapshotCleanInvocationMetrics() CleanInvocationMetricsSnapshot {
+	return CleanInvocationMetricsSnapshot{
+		Attempts:          cleanInvocationMetrics.attempts.Load(),
+		Successes:         cleanInvocationMetrics.successes.Load(),
+		Failures:          cleanInvocationMetrics.failures.Load(),
+		AmbiguityRejected: cleanInvocationMetrics.ambiguityRejected.Load(),
+		Cancellations:     cleanInvocationMetrics.cancellations.Load(),
+	}
+}
+
+func resetCleanInvocationMetricsForTest() {
+	cleanInvocationMetrics.attempts.Store(0)
+	cleanInvocationMetrics.successes.Store(0)
+	cleanInvocationMetrics.failures.Store(0)
+	cleanInvocationMetrics.ambiguityRejected.Store(0)
+	cleanInvocationMetrics.cancellations.Store(0)
+}

--- a/pkg/cli/run/run.go
+++ b/pkg/cli/run/run.go
@@ -483,33 +483,13 @@ func runFactoryServiceAndEmitResult(
 ) error {
 	err := factorySvc.Run(ctx)
 	reportRecordingPathOnShutdown(cfg.StartupOutput, recordPath)
+	if cfg.CleanInvocation {
+		return emitCleanInvocationOutcome(ctx, cfg, factorySvc, err)
+	}
 	if err != nil {
 		return err
-	}
-	if cfg.CleanInvocation {
-		return emitCleanInvocationSuccess(ctx, cfg, factorySvc)
 	}
 	return nil
-}
-
-func emitCleanInvocationSuccess(ctx context.Context, cfg RunConfig, runner factoryServiceRunner) error {
-	provider, ok := runner.(engineStateSnapshotProvider)
-	if !ok {
-		return fmt.Errorf("clean invocation result snapshot is unavailable")
-	}
-	snapshot, err := provider.GetEngineStateSnapshot(ctx)
-	if err != nil {
-		return err
-	}
-	target, err := cleanInvocationWorkTargetFromFile(cfg.WorkFile)
-	if err != nil {
-		return err
-	}
-	result, ok := cleanInvocationSuccessFromSnapshot(snapshot, target)
-	if !ok {
-		return fmt.Errorf("clean invocation completed without a terminal result for work %q", target.WorkID)
-	}
-	return writeCleanInvocationSuccess(cfg, result)
 }
 
 func cleanInvocationWorkTargetFromFile(workFile string) (cleanInvocationWorkTarget, error) {

--- a/pkg/cli/run/run.go
+++ b/pkg/cli/run/run.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strconv"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -41,7 +41,7 @@ type RunConfig struct {
 	// FactoryConfigPath is the factory.json file path from you run --factory.
 	// The service uses Dir as the resolved factory root directory.
 	FactoryConfigPath string
-	RunnerID     string
+	RunnerID          string
 	// ExecutionBaseDir overrides the base directory used to resolve relative
 	// runtime execution paths. Empty defaults to the caller's current working
 	// directory for CLI-style runs.
@@ -73,6 +73,9 @@ type RunConfig struct {
 	// SuppressDashboardRendering disables the simple stdout dashboard while
 	// preserving the normal service-layer run path.
 	SuppressDashboardRendering bool
+	// CleanInvocation suppresses operator-facing stdout chatter for one-shot
+	// result-oriented invocations. It does not disable replay recording.
+	CleanInvocation bool
 	// OpenDashboard attempts to open the embedded dashboard URL in a browser.
 	OpenDashboard bool
 	// StartupOutput receives human-facing startup messages. Nil suppresses
@@ -279,6 +282,7 @@ func (r *reservedAPIServerListener) CloseIfUnused() error {
 // FactoryService. The CLI is a thin wrapper — all orchestration logic
 // (file watcher, dashboard, API server, engine) lives in the service layer.
 func Run(ctx context.Context, cfg RunConfig) error {
+	cfg = normalizeRunInvocationMode(cfg)
 	logger := cfg.Logger
 	if logger == nil {
 		logger = zap.NewNop()
@@ -344,6 +348,16 @@ func Run(ctx context.Context, cfg RunConfig) error {
 	err = factorySvc.Run(ctx)
 	reportRecordingPathOnShutdown(cfg.StartupOutput, recordPath)
 	return err
+}
+
+func normalizeRunInvocationMode(cfg RunConfig) RunConfig {
+	if !cfg.CleanInvocation {
+		return cfg
+	}
+	cfg.SuppressDashboardRendering = true
+	cfg.StartupOutput = nil
+	cfg.OpenDashboard = false
+	return cfg
 }
 
 func resolveRecordPathForRun(cfg RunConfig) (resolvedRunRecordPath, error) {

--- a/pkg/cli/run/run.go
+++ b/pkg/cli/run/run.go
@@ -3,6 +3,7 @@ package run
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -11,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -25,6 +27,8 @@ import (
 	initcmd "github.com/portpowered/infinite-you/pkg/cli/init"
 	"github.com/portpowered/infinite-you/pkg/cli/timedisplay"
 	factoryconfig "github.com/portpowered/infinite-you/pkg/config"
+	"github.com/portpowered/infinite-you/pkg/factory/requests"
+	"github.com/portpowered/infinite-you/pkg/factory/state"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/logging"
 	"github.com/portpowered/infinite-you/pkg/petri"
@@ -76,6 +80,10 @@ type RunConfig struct {
 	// CleanInvocation suppresses operator-facing stdout chatter for one-shot
 	// result-oriented invocations. It does not disable replay recording.
 	CleanInvocation bool
+	// JSON emits the clean invocation success result as a single JSON object.
+	JSON bool
+	// Output receives clean invocation success payloads. Nil defaults to stdout.
+	Output io.Writer
 	// OpenDashboard attempts to open the embedded dashboard URL in a browser.
 	OpenDashboard bool
 	// StartupOutput receives human-facing startup messages. Nil suppresses
@@ -93,6 +101,23 @@ type factoryServiceRunner interface {
 
 type runtimeLogDiagnosticsProvider interface {
 	RuntimeLogDiagnostics() service.RuntimeLogDiagnostics
+}
+
+type engineStateSnapshotProvider interface {
+	GetEngineStateSnapshot(context.Context) (*interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], error)
+}
+
+type cleanInvocationSuccess struct {
+	Output       string `json:"output"`
+	WorkID       string `json:"workId"`
+	WorkTypeName string `json:"workTypeName"`
+	TraceID      string `json:"traceId,omitempty"`
+	SessionID    string `json:"sessionId,omitempty"`
+}
+
+type cleanInvocationWorkTarget struct {
+	WorkID       string
+	WorkTypeName string
 }
 
 // FactoryServiceBuilder constructs the factory service used by Run.
@@ -345,9 +370,7 @@ func Run(ctx context.Context, cfg RunConfig) error {
 	}
 	defer waitForDashboardOpen()
 
-	err = factorySvc.Run(ctx)
-	reportRecordingPathOnShutdown(cfg.StartupOutput, recordPath)
-	return err
+	return runFactoryServiceAndEmitResult(ctx, cfg, factorySvc, recordPath)
 }
 
 func normalizeRunInvocationMode(cfg RunConfig) RunConfig {
@@ -450,6 +473,153 @@ func buildRunServiceConfig(
 		svcCfg.SimpleDashboardRenderer = renderSimpleDashboard
 	}
 	return svcCfg
+}
+
+func runFactoryServiceAndEmitResult(
+	ctx context.Context,
+	cfg RunConfig,
+	factorySvc factoryServiceRunner,
+	recordPath resolvedRunRecordPath,
+) error {
+	err := factorySvc.Run(ctx)
+	reportRecordingPathOnShutdown(cfg.StartupOutput, recordPath)
+	if err != nil {
+		return err
+	}
+	if cfg.CleanInvocation {
+		return emitCleanInvocationSuccess(ctx, cfg, factorySvc)
+	}
+	return nil
+}
+
+func emitCleanInvocationSuccess(ctx context.Context, cfg RunConfig, runner factoryServiceRunner) error {
+	provider, ok := runner.(engineStateSnapshotProvider)
+	if !ok {
+		return fmt.Errorf("clean invocation result snapshot is unavailable")
+	}
+	snapshot, err := provider.GetEngineStateSnapshot(ctx)
+	if err != nil {
+		return err
+	}
+	target, err := cleanInvocationWorkTargetFromFile(cfg.WorkFile)
+	if err != nil {
+		return err
+	}
+	result, ok := cleanInvocationSuccessFromSnapshot(snapshot, target)
+	if !ok {
+		return fmt.Errorf("clean invocation completed without a terminal result for work %q", target.WorkID)
+	}
+	return writeCleanInvocationSuccess(cfg, result)
+}
+
+func cleanInvocationWorkTargetFromFile(workFile string) (cleanInvocationWorkTarget, error) {
+	request, err := LoadWorkFile(workFile)
+	if err != nil {
+		return cleanInvocationWorkTarget{}, err
+	}
+	normalized, err := requests.NormalizeWorkRequest(request, interfaces.WorkRequestNormalizeOptions{})
+	if err != nil {
+		return cleanInvocationWorkTarget{}, err
+	}
+	if len(normalized) != 1 {
+		return cleanInvocationWorkTarget{}, fmt.Errorf("clean invocation requires exactly one work item, got %d", len(normalized))
+	}
+	return cleanInvocationWorkTarget{
+		WorkID:       normalized[0].WorkID,
+		WorkTypeName: normalized[0].WorkTypeID,
+	}, nil
+}
+
+func cleanInvocationSuccessFromSnapshot(
+	snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net],
+	target cleanInvocationWorkTarget,
+) (cleanInvocationSuccess, bool) {
+	if snapshot == nil || snapshot.Topology == nil {
+		return cleanInvocationSuccess{}, false
+	}
+	if result, ok := cleanInvocationSuccessFromTerminalTokens(snapshot, target); ok {
+		return result, true
+	}
+	return cleanInvocationSuccessFromDispatchHistory(snapshot, target)
+}
+
+func cleanInvocationSuccessFromTerminalTokens(
+	snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net],
+	target cleanInvocationWorkTarget,
+) (cleanInvocationSuccess, bool) {
+	tokens := make([]*interfaces.Token, 0, len(snapshot.Marking.Tokens))
+	for _, token := range snapshot.Marking.Tokens {
+		if token != nil {
+			tokens = append(tokens, token)
+		}
+	}
+	sort.Slice(tokens, func(i, j int) bool {
+		return tokens[i].ID < tokens[j].ID
+	})
+	for _, token := range tokens {
+		if cleanInvocationTokenMatches(snapshot.Topology, token, target) {
+			return cleanInvocationSuccessFromToken(token), true
+		}
+	}
+	return cleanInvocationSuccess{}, false
+}
+
+func cleanInvocationSuccessFromDispatchHistory(
+	snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net],
+	target cleanInvocationWorkTarget,
+) (cleanInvocationSuccess, bool) {
+	for i := len(snapshot.DispatchHistory) - 1; i >= 0; i-- {
+		completion := snapshot.DispatchHistory[i]
+		if completion.Outcome != interfaces.OutcomeAccepted {
+			continue
+		}
+		for _, mutation := range completion.OutputMutations {
+			if cleanInvocationTokenMatches(snapshot.Topology, mutation.Token, target) {
+				return cleanInvocationSuccessFromToken(mutation.Token), true
+			}
+		}
+	}
+	return cleanInvocationSuccess{}, false
+}
+
+func cleanInvocationTokenMatches(net *state.Net, token *interfaces.Token, target cleanInvocationWorkTarget) bool {
+	if net == nil || token == nil {
+		return false
+	}
+	if token.Color.DataType == interfaces.DataTypeResource {
+		return false
+	}
+	if token.Color.WorkID != target.WorkID || token.Color.WorkTypeID != target.WorkTypeName {
+		return false
+	}
+	return net.StateCategoryForPlace(token.PlaceID) == state.StateCategoryTerminal
+}
+
+func cleanInvocationSuccessFromToken(token *interfaces.Token) cleanInvocationSuccess {
+	return cleanInvocationSuccess{
+		Output:       string(token.Color.Payload),
+		WorkID:       token.Color.WorkID,
+		WorkTypeName: token.Color.WorkTypeID,
+		TraceID:      token.Color.TraceID,
+		SessionID:    defaultFactorySessionID,
+	}
+}
+
+func writeCleanInvocationSuccess(cfg RunConfig, result cleanInvocationSuccess) error {
+	output := cfg.Output
+	if output == nil {
+		output = os.Stdout
+	}
+	if cfg.JSON {
+		data, err := json.Marshal(result)
+		if err != nil {
+			return err
+		}
+		_, err = output.Write(data)
+		return err
+	}
+	_, err := io.WriteString(output, result.Output)
+	return err
 }
 
 func emitVerboseStartupDiagnostics(cfg RunConfig, recordPath resolvedRunRecordPath, requestedPort int) {

--- a/pkg/cli/run/run.go
+++ b/pkg/cli/run/run.go
@@ -82,6 +82,9 @@ type RunConfig struct {
 	CleanInvocation bool
 	// JSON emits the clean invocation success result as a single JSON object.
 	JSON bool
+	// CleanInvocationInputSource describes how a one-shot clean invocation
+	// received its primary input payload.
+	CleanInvocationInputSource InvocationInputSource
 	// Output receives clean invocation success payloads. Nil defaults to stdout.
 	Output io.Writer
 	// OpenDashboard attempts to open the embedded dashboard URL in a browser.
@@ -481,10 +484,14 @@ func runFactoryServiceAndEmitResult(
 	factorySvc factoryServiceRunner,
 	recordPath resolvedRunRecordPath,
 ) error {
+	startedAt := time.Now().UTC()
+	if cfg.CleanInvocation {
+		recordCleanInvocationAttempt()
+	}
 	err := factorySvc.Run(ctx)
 	reportRecordingPathOnShutdown(cfg.StartupOutput, recordPath)
 	if cfg.CleanInvocation {
-		return emitCleanInvocationOutcome(ctx, cfg, factorySvc, err)
+		return emitCleanInvocationOutcome(ctx, cfg, factorySvc, err, startedAt)
 	}
 	if err != nil {
 		return err

--- a/pkg/cli/run/run_clean_invocation.go
+++ b/pkg/cli/run/run_clean_invocation.go
@@ -5,46 +5,101 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/portpowered/infinite-you/pkg/factory/state"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/petri"
 )
 
-func emitCleanInvocationOutcome(ctx context.Context, cfg RunConfig, runner factoryServiceRunner, runErr error) error {
+func emitCleanInvocationOutcome(ctx context.Context, cfg RunConfig, runner factoryServiceRunner, runErr error, startedAt time.Time) error {
+	logger := cleanInvocationLogger(cfg.Logger)
 	provider, ok := runner.(engineStateSnapshotProvider)
 	if !ok {
 		if runErr == nil {
-			return &InvocationError{
+			err := &InvocationError{
 				Code:    InvocationErrorCodeFailed,
 				Message: "clean invocation result snapshot is unavailable",
 			}
+			recordCleanInvocationCompletion(logger, cfg, cleanInvocationCompletionLogInput{
+				StartedAt: startedAt,
+				Err:       err,
+			})
+			return err
 		}
-		return newInvocationErrorForRunFailure(runErr, nil)
+		err := newInvocationErrorForRunFailure(runErr, nil)
+		recordCleanInvocationCompletion(logger, cfg, cleanInvocationCompletionLogInput{
+			StartedAt: startedAt,
+			Err:       err,
+		})
+		return err
 	}
 	snapshot, err := provider.GetEngineStateSnapshot(ctx)
 	if err != nil {
 		if runErr == nil {
-			return &InvocationError{
+			invocationErr := &InvocationError{
 				Code:    InvocationErrorCodeFailed,
 				Message: "clean invocation result snapshot is unavailable",
 				Cause:   err,
 			}
+			recordCleanInvocationCompletion(logger, cfg, cleanInvocationCompletionLogInput{
+				StartedAt: startedAt,
+				Err:       invocationErr,
+			})
+			return invocationErr
 		}
-		return newInvocationErrorForRunFailure(runErr, nil)
+		invocationErr := newInvocationErrorForRunFailure(runErr, nil)
+		recordCleanInvocationCompletion(logger, cfg, cleanInvocationCompletionLogInput{
+			StartedAt: startedAt,
+			Err:       invocationErr,
+		})
+		return invocationErr
 	}
 	if runErr != nil {
-		return newInvocationErrorForRunFailure(runErr, snapshot)
+		invocationErr := newInvocationErrorForRunFailure(runErr, snapshot)
+		recordCleanInvocationCompletion(logger, cfg, cleanInvocationCompletionLogInput{
+			StartedAt: startedAt,
+			Snapshot:  snapshot,
+			Err:       invocationErr,
+		})
+		return invocationErr
 	}
 	target, err := cleanInvocationWorkTargetFromFile(cfg.WorkFile)
 	if err != nil {
+		recordCleanInvocationCompletion(logger, cfg, cleanInvocationCompletionLogInput{
+			StartedAt: startedAt,
+			Snapshot:  snapshot,
+			Err:       err,
+		})
 		return err
 	}
 	result, ok := cleanInvocationSuccessFromSnapshot(snapshot, target)
 	if !ok {
-		return cleanInvocationFailureFromSnapshot(snapshot, target)
+		invocationErr := cleanInvocationFailureFromSnapshot(snapshot, target)
+		recordCleanInvocationCompletion(logger, cfg, cleanInvocationCompletionLogInput{
+			StartedAt: startedAt,
+			Snapshot:  snapshot,
+			Target:    &target,
+			Err:       invocationErr,
+		})
+		return invocationErr
 	}
-	return writeCleanInvocationSuccess(cfg, result)
+	if err := writeCleanInvocationSuccess(cfg, result); err != nil {
+		recordCleanInvocationCompletion(logger, cfg, cleanInvocationCompletionLogInput{
+			StartedAt: startedAt,
+			Snapshot:  snapshot,
+			Target:    &target,
+			Err:       err,
+		})
+		return err
+	}
+	recordCleanInvocationCompletion(logger, cfg, cleanInvocationCompletionLogInput{
+		StartedAt: startedAt,
+		Snapshot:  snapshot,
+		Target:    &target,
+		Success:   &result,
+	})
+	return nil
 }
 
 func newInvocationErrorForRunFailure(

--- a/pkg/cli/run/run_clean_invocation.go
+++ b/pkg/cli/run/run_clean_invocation.go
@@ -1,0 +1,194 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/portpowered/infinite-you/pkg/factory/state"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/petri"
+)
+
+func emitCleanInvocationOutcome(ctx context.Context, cfg RunConfig, runner factoryServiceRunner, runErr error) error {
+	provider, ok := runner.(engineStateSnapshotProvider)
+	if !ok {
+		if runErr == nil {
+			return &InvocationError{
+				Code:    InvocationErrorCodeFailed,
+				Message: "clean invocation result snapshot is unavailable",
+			}
+		}
+		return newInvocationErrorForRunFailure(runErr, nil)
+	}
+	snapshot, err := provider.GetEngineStateSnapshot(ctx)
+	if err != nil {
+		if runErr == nil {
+			return &InvocationError{
+				Code:    InvocationErrorCodeFailed,
+				Message: "clean invocation result snapshot is unavailable",
+				Cause:   err,
+			}
+		}
+		return newInvocationErrorForRunFailure(runErr, nil)
+	}
+	if runErr != nil {
+		return newInvocationErrorForRunFailure(runErr, snapshot)
+	}
+	target, err := cleanInvocationWorkTargetFromFile(cfg.WorkFile)
+	if err != nil {
+		return err
+	}
+	result, ok := cleanInvocationSuccessFromSnapshot(snapshot, target)
+	if !ok {
+		return cleanInvocationFailureFromSnapshot(snapshot, target)
+	}
+	return writeCleanInvocationSuccess(cfg, result)
+}
+
+func newInvocationErrorForRunFailure(
+	runErr error,
+	snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net],
+) error {
+	switch {
+	case errors.Is(runErr, context.DeadlineExceeded):
+		return &InvocationError{
+			Code:    InvocationErrorCodeTimeout,
+			Message: "clean invocation timed out",
+			Cause:   runErr,
+		}
+	case errors.Is(runErr, context.Canceled):
+		return &InvocationError{
+			Code:    InvocationErrorCodeCancelled,
+			Message: "clean invocation cancelled",
+			Cause:   runErr,
+		}
+	}
+
+	if timeoutFailure, ok := cleanInvocationTimeoutFromSnapshot(snapshot); ok {
+		return timeoutFailure
+	}
+	return &InvocationError{
+		Code:    InvocationErrorCodeFailed,
+		Message: "clean invocation failed",
+		Cause:   runErr,
+	}
+}
+
+func cleanInvocationFailureFromSnapshot(
+	snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net],
+	target cleanInvocationWorkTarget,
+) error {
+	if timeoutFailure, ok := cleanInvocationTimeoutForTarget(snapshot, target); ok {
+		return timeoutFailure
+	}
+	if failureReason, ok := cleanInvocationFailedForTarget(snapshot, target); ok {
+		message := "clean invocation failed"
+		if failureReason != "" {
+			message = fmt.Sprintf("clean invocation failed: %s", failureReason)
+		}
+		return &InvocationError{
+			Code:    InvocationErrorCodeFailed,
+			Message: message,
+		}
+	}
+	return &InvocationError{
+		Code:    InvocationErrorCodeFailed,
+		Message: fmt.Sprintf("clean invocation completed without a terminal success result for work %q", target.WorkID),
+	}
+}
+
+func cleanInvocationTimeoutFromSnapshot(
+	snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net],
+) (*InvocationError, bool) {
+	if snapshot == nil {
+		return nil, false
+	}
+	for i := len(snapshot.DispatchHistory) - 1; i >= 0; i-- {
+		failure := snapshot.DispatchHistory[i].FailureMetadata
+		if failure != nil && failure.Type == interfaces.WorkFailureTypeTimeout {
+			return &InvocationError{
+				Code:    InvocationErrorCodeTimeout,
+				Message: "clean invocation timed out",
+			}, true
+		}
+	}
+	return nil, false
+}
+
+func cleanInvocationTimeoutForTarget(
+	snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net],
+	target cleanInvocationWorkTarget,
+) (*InvocationError, bool) {
+	if snapshot == nil {
+		return nil, false
+	}
+	for i := len(snapshot.DispatchHistory) - 1; i >= 0; i-- {
+		completion := snapshot.DispatchHistory[i]
+		if !cleanInvocationCompletionMatchesTarget(completion, target) {
+			continue
+		}
+		if completion.FailureMetadata != nil && completion.FailureMetadata.Type == interfaces.WorkFailureTypeTimeout {
+			return &InvocationError{
+				Code:    InvocationErrorCodeTimeout,
+				Message: "clean invocation timed out",
+			}, true
+		}
+	}
+	return nil, false
+}
+
+func cleanInvocationFailedForTarget(
+	snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net],
+	target cleanInvocationWorkTarget,
+) (string, bool) {
+	if snapshot == nil {
+		return "", false
+	}
+	for i := len(snapshot.DispatchHistory) - 1; i >= 0; i-- {
+		completion := snapshot.DispatchHistory[i]
+		if completion.Outcome != interfaces.OutcomeFailed {
+			continue
+		}
+		if !cleanInvocationCompletionMatchesTarget(completion, target) {
+			continue
+		}
+		return strings.TrimSpace(completion.Reason), true
+	}
+	if snapshot.Topology == nil {
+		return "", false
+	}
+	for _, token := range snapshot.Marking.Tokens {
+		if token == nil {
+			continue
+		}
+		if token.Color.WorkID != target.WorkID || token.Color.WorkTypeID != target.WorkTypeName {
+			continue
+		}
+		if snapshot.Topology.StateCategoryForPlace(token.PlaceID) == state.StateCategoryFailed {
+			return "", true
+		}
+	}
+	return "", false
+}
+
+func cleanInvocationCompletionMatchesTarget(
+	completion interfaces.CompletedDispatch,
+	target cleanInvocationWorkTarget,
+) bool {
+	for _, token := range completion.ConsumedTokens {
+		if token.Color.WorkID == target.WorkID && token.Color.WorkTypeID == target.WorkTypeName {
+			return true
+		}
+	}
+	for _, mutation := range completion.OutputMutations {
+		if mutation.Token == nil {
+			continue
+		}
+		if mutation.Token.Color.WorkID == target.WorkID && mutation.Token.Color.WorkTypeID == target.WorkTypeName {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/cli/run/run_dashboard_test.go
+++ b/pkg/cli/run/run_dashboard_test.go
@@ -60,6 +60,41 @@ func TestRun_SuppressDashboardRendering_SkipsSimpleDashboardOutput(t *testing.T)
 	}
 }
 
+func TestRun_CleanInvocationKeepsOperatorChatterOffStdout(t *testing.T) {
+	originalDefaultRecordPath := defaultLiveRunRecordPath
+	defer func() {
+		defaultLiveRunRecordPath = originalDefaultRecordPath
+	}()
+
+	dir, workFile := writeDashboardRunFixture(t)
+	recordPath := filepath.Join(t.TempDir(), "factory-session-__factory_session_id__-clean.json")
+	defaultLiveRunRecordPath = func() (string, error) {
+		return recordPath, nil
+	}
+
+	var startupOut bytes.Buffer
+	output, err := runWithCapturedStdout(t, RunConfig{
+		Dir:                dir,
+		Port:               0,
+		WorkFile:           workFile,
+		MockWorkersEnabled: true,
+		CleanInvocation:    true,
+		StartupOutput:      &startupOut,
+		Logger:             zap.NewNop(),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	assertNoOperatorChatter(t, output)
+	if startupOut.Len() != 0 {
+		t.Fatalf("startup output = %q, want clean invocation to suppress operator chatter", startupOut.String())
+	}
+	if _, err := os.Stat(resolveDefaultSessionRecordPath(recordPath)); err != nil {
+		t.Fatalf("default recording was not written: %v", err)
+	}
+}
+
 func TestRun_ContinuouslyUsesServiceModeUntilCanceled(t *testing.T) {
 	originalBuilder := buildFactoryService
 	defer func() {
@@ -139,6 +174,23 @@ func TestRun_OOTBIntegrationSmokeBootstrapsProcessesDefaultTaskAndReportsDashboa
 	assertContinuousRunStillActive(t, errCh)
 	assertOOTBSmokeStartupOutput(t, out.String(), dir, port)
 	stopOOTBSmokeRun(t, cancel, errCh)
+}
+
+func assertNoOperatorChatter(t *testing.T, output string) {
+	t.Helper()
+
+	for _, forbidden := range []string{
+		"Factory initiated",
+		"Dashboard URL",
+		"Runtime log",
+		"Opening dashboard",
+		"Factory:",
+		"Recording saved",
+	} {
+		if strings.Contains(output, forbidden) {
+			t.Fatalf("output = %q, want no %q chatter", output, forbidden)
+		}
+	}
 }
 
 func installOOTBSmokeBootstrap(taskPath string) {

--- a/pkg/cli/run/run_dashboard_test.go
+++ b/pkg/cli/run/run_dashboard_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/petri"
 	"github.com/portpowered/infinite-you/pkg/service"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestRun_DefaultDashboardRendering_PrintsSimpleDashboardOutput(t *testing.T) {
@@ -155,6 +156,67 @@ func TestRun_CleanInvocationJSONEmitsSinglePrimaryResultObject(t *testing.T) {
 	}
 }
 
+func TestRun_CleanInvocationSuccessRecordsStructuredLogAndMetrics(t *testing.T) {
+	resetCleanInvocationMetricsForTest()
+
+	dir, workFile := writeDashboardRunFixture(t)
+	core, observed := observer.New(zap.InfoLevel)
+
+	output, err := runWithCapturedStdout(t, RunConfig{
+		Dir:                        dir,
+		Port:                       0,
+		WorkFile:                   workFile,
+		MockWorkersEnabled:         true,
+		CleanInvocation:            true,
+		CleanInvocationInputSource: InvocationInputSourcePositional,
+		DisableDefaultRecording:    true,
+		Logger:                     zap.New(core),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if output != "mock worker accepted" {
+		t.Fatalf("stdout = %q, want primary clean invocation output", output)
+	}
+
+	entry := observed.FilterMessage(cleanInvocationLogMessageCompleted).AllUntimed()
+	if len(entry) != 1 {
+		t.Fatalf("completed logs = %d, want 1", len(entry))
+	}
+	fields := entry[0].ContextMap()
+	if fields["outcome"] != cleanInvocationOutcomeSuccess {
+		t.Fatalf("outcome = %#v, want success", fields["outcome"])
+	}
+	if fields["mode"] != cleanInvocationModeLabel {
+		t.Fatalf("mode = %#v, want clean", fields["mode"])
+	}
+	if fields["inputSource"] != "positional_prompt" {
+		t.Fatalf("inputSource = %#v, want positional_prompt", fields["inputSource"])
+	}
+	if fields["workId"] != "dashboard-render-test-work" {
+		t.Fatalf("workId = %#v", fields["workId"])
+	}
+	if fields["workTypeName"] != "task" {
+		t.Fatalf("workTypeName = %#v", fields["workTypeName"])
+	}
+	if fields["traceId"] != "dashboard-render-test-trace" {
+		t.Fatalf("traceId = %#v", fields["traceId"])
+	}
+	if fields["sessionId"] != defaultFactorySessionID {
+		t.Fatalf("sessionId = %#v", fields["sessionId"])
+	}
+	if duration, ok := fields["durationMs"].(int64); !ok || duration < 0 {
+		t.Fatalf("durationMs = %#v, want non-negative int64", fields["durationMs"])
+	}
+
+	if got := snapshotCleanInvocationMetrics(); got != (CleanInvocationMetricsSnapshot{
+		Attempts:  1,
+		Successes: 1,
+	}) {
+		t.Fatalf("metrics = %#v", got)
+	}
+}
+
 func TestRun_CleanInvocationFailureReturnsStableErrorAndNoStdout(t *testing.T) {
 	originalBuilder := buildFactoryService
 	defer func() {
@@ -266,6 +328,59 @@ func TestRun_CleanInvocationCancellationReturnsStableErrorAndNoStdout(t *testing
 	}
 	if invocationErr.Message != "clean invocation cancelled" {
 		t.Fatalf("message = %q", invocationErr.Message)
+	}
+}
+
+func TestRun_CleanInvocationCancellationRecordsStructuredLogAndMetrics(t *testing.T) {
+	resetCleanInvocationMetricsForTest()
+
+	originalBuilder := buildFactoryService
+	defer func() {
+		buildFactoryService = originalBuilder
+	}()
+
+	_, workFile := writeDashboardRunFixture(t)
+	core, observed := observer.New(zap.InfoLevel)
+	buildFactoryService = func(_ context.Context, _ *service.FactoryServiceConfig) (factoryServiceRunner, error) {
+		return stubFactoryService{
+			run: func(context.Context) error { return context.Canceled },
+			snapshot: func(context.Context) (*interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], error) {
+				return nil, errors.New("snapshot not needed")
+			},
+		}, nil
+	}
+
+	err := Run(context.Background(), RunConfig{
+		WorkFile:                   workFile,
+		CleanInvocation:            true,
+		CleanInvocationInputSource: InvocationInputSourceWorkFile,
+		DisableDefaultRecording:    true,
+		Logger:                     zap.New(core),
+	})
+	if err == nil {
+		t.Fatal("expected cancellation error")
+	}
+
+	entry := observed.FilterMessage(cleanInvocationLogMessageCompleted).AllUntimed()
+	if len(entry) != 1 {
+		t.Fatalf("completed logs = %d, want 1", len(entry))
+	}
+	fields := entry[0].ContextMap()
+	if fields["outcome"] != cleanInvocationOutcomeCancelled {
+		t.Fatalf("outcome = %#v, want cancelled", fields["outcome"])
+	}
+	if fields["errorCode"] != InvocationErrorCodeCancelled {
+		t.Fatalf("errorCode = %#v, want %q", fields["errorCode"], InvocationErrorCodeCancelled)
+	}
+	if fields["inputSource"] != "work_file" {
+		t.Fatalf("inputSource = %#v, want work_file", fields["inputSource"])
+	}
+
+	if got := snapshotCleanInvocationMetrics(); got != (CleanInvocationMetricsSnapshot{
+		Attempts:      1,
+		Cancellations: 1,
+	}) {
+		t.Fatalf("metrics = %#v", got)
 	}
 }
 

--- a/pkg/cli/run/run_dashboard_test.go
+++ b/pkg/cli/run/run_dashboard_test.go
@@ -86,12 +86,71 @@ func TestRun_CleanInvocationKeepsOperatorChatterOffStdout(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
+	if output != "mock worker accepted" {
+		t.Fatalf("stdout = %q, want primary clean invocation output", output)
+	}
 	assertNoOperatorChatter(t, output)
 	if startupOut.Len() != 0 {
 		t.Fatalf("startup output = %q, want clean invocation to suppress operator chatter", startupOut.String())
 	}
 	if _, err := os.Stat(resolveDefaultSessionRecordPath(recordPath)); err != nil {
 		t.Fatalf("default recording was not written: %v", err)
+	}
+}
+
+func TestRun_CleanInvocationEmitsPrimaryTextOutputRepeatedly(t *testing.T) {
+	for i := 0; i < 2; i++ {
+		dir, workFile := writeDashboardRunFixture(t)
+
+		output, err := runWithCapturedStdout(t, RunConfig{
+			Dir:                     dir,
+			Port:                    0,
+			WorkFile:                workFile,
+			MockWorkersEnabled:      true,
+			CleanInvocation:         true,
+			DisableDefaultRecording: true,
+			Logger:                  zap.NewNop(),
+		})
+		if err != nil {
+			t.Fatalf("Run iteration %d: %v", i, err)
+		}
+		if output != "mock worker accepted" {
+			t.Fatalf("iteration %d stdout = %q, want primary clean invocation output", i, output)
+		}
+		assertNoOperatorChatter(t, output)
+	}
+}
+
+func TestRun_CleanInvocationJSONEmitsSinglePrimaryResultObject(t *testing.T) {
+	dir, workFile := writeDashboardRunFixture(t)
+
+	output, err := runWithCapturedStdout(t, RunConfig{
+		Dir:                     dir,
+		Port:                    0,
+		WorkFile:                workFile,
+		MockWorkersEnabled:      true,
+		CleanInvocation:         true,
+		JSON:                    true,
+		DisableDefaultRecording: true,
+		Logger:                  zap.NewNop(),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	assertNoOperatorChatter(t, output)
+
+	var got cleanInvocationSuccess
+	if err := json.Unmarshal([]byte(output), &got); err != nil {
+		t.Fatalf("stdout is not one JSON object: %v\n%s", err, output)
+	}
+	if got.Output != "mock worker accepted" {
+		t.Fatalf("output = %q, want primary clean invocation output", got.Output)
+	}
+	if got.WorkID != "dashboard-render-test-work" ||
+		got.WorkTypeName != "task" ||
+		got.TraceID != "dashboard-render-test-trace" ||
+		got.SessionID != defaultFactorySessionID {
+		t.Fatalf("json result = %#v", got)
 	}
 }
 

--- a/pkg/cli/run/run_dashboard_test.go
+++ b/pkg/cli/run/run_dashboard_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -151,6 +152,180 @@ func TestRun_CleanInvocationJSONEmitsSinglePrimaryResultObject(t *testing.T) {
 		got.TraceID != "dashboard-render-test-trace" ||
 		got.SessionID != defaultFactorySessionID {
 		t.Fatalf("json result = %#v", got)
+	}
+}
+
+func TestRun_CleanInvocationFailureReturnsStableErrorAndNoStdout(t *testing.T) {
+	originalBuilder := buildFactoryService
+	defer func() {
+		buildFactoryService = originalBuilder
+	}()
+
+	_, workFile := writeDashboardRunFixture(t)
+	buildFactoryService = func(_ context.Context, _ *service.FactoryServiceConfig) (factoryServiceRunner, error) {
+		return stubFactoryService{
+			run: func(context.Context) error { return nil },
+			snapshot: func(context.Context) (*interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], error) {
+				return failedCleanInvocationSnapshot("mock worker rejected"), nil
+			},
+		}, nil
+	}
+
+	output, err := runWithCapturedStdout(t, RunConfig{
+		WorkFile:                workFile,
+		CleanInvocation:         true,
+		DisableDefaultRecording: true,
+		Logger:                  zap.NewNop(),
+	})
+	if output != "" {
+		t.Fatalf("stdout = %q, want empty on failure", output)
+	}
+
+	var invocationErr *InvocationError
+	if !errors.As(err, &invocationErr) {
+		t.Fatalf("error = %#v, want InvocationError", err)
+	}
+	if invocationErr.Code != InvocationErrorCodeFailed {
+		t.Fatalf("code = %q, want %q", invocationErr.Code, InvocationErrorCodeFailed)
+	}
+	if invocationErr.Message != "clean invocation failed: mock worker rejected" {
+		t.Fatalf("message = %q", invocationErr.Message)
+	}
+}
+
+func TestRun_CleanInvocationTimeoutReturnsStableErrorAndNoStdout(t *testing.T) {
+	originalBuilder := buildFactoryService
+	defer func() {
+		buildFactoryService = originalBuilder
+	}()
+
+	_, workFile := writeDashboardRunFixture(t)
+	buildFactoryService = func(_ context.Context, _ *service.FactoryServiceConfig) (factoryServiceRunner, error) {
+		return stubFactoryService{
+			run: func(context.Context) error { return nil },
+			snapshot: func(context.Context) (*interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], error) {
+				return timedOutCleanInvocationSnapshot(), nil
+			},
+		}, nil
+	}
+
+	output, err := runWithCapturedStdout(t, RunConfig{
+		WorkFile:                workFile,
+		CleanInvocation:         true,
+		DisableDefaultRecording: true,
+		Logger:                  zap.NewNop(),
+	})
+	if output != "" {
+		t.Fatalf("stdout = %q, want empty on timeout", output)
+	}
+
+	var invocationErr *InvocationError
+	if !errors.As(err, &invocationErr) {
+		t.Fatalf("error = %#v, want InvocationError", err)
+	}
+	if invocationErr.Code != InvocationErrorCodeTimeout {
+		t.Fatalf("code = %q, want %q", invocationErr.Code, InvocationErrorCodeTimeout)
+	}
+	if invocationErr.Message != "clean invocation timed out" {
+		t.Fatalf("message = %q", invocationErr.Message)
+	}
+}
+
+func TestRun_CleanInvocationCancellationReturnsStableErrorAndNoStdout(t *testing.T) {
+	originalBuilder := buildFactoryService
+	defer func() {
+		buildFactoryService = originalBuilder
+	}()
+
+	_, workFile := writeDashboardRunFixture(t)
+	buildFactoryService = func(_ context.Context, _ *service.FactoryServiceConfig) (factoryServiceRunner, error) {
+		return stubFactoryService{
+			run: func(context.Context) error { return context.Canceled },
+			snapshot: func(context.Context) (*interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], error) {
+				return nil, errors.New("snapshot not needed")
+			},
+		}, nil
+	}
+
+	output, err := runWithCapturedStdout(t, RunConfig{
+		WorkFile:                workFile,
+		CleanInvocation:         true,
+		DisableDefaultRecording: true,
+		Logger:                  zap.NewNop(),
+	})
+	if output != "" {
+		t.Fatalf("stdout = %q, want empty on cancellation", output)
+	}
+
+	var invocationErr *InvocationError
+	if !errors.As(err, &invocationErr) {
+		t.Fatalf("error = %#v, want InvocationError", err)
+	}
+	if invocationErr.Code != InvocationErrorCodeCancelled {
+		t.Fatalf("code = %q, want %q", invocationErr.Code, InvocationErrorCodeCancelled)
+	}
+	if invocationErr.Message != "clean invocation cancelled" {
+		t.Fatalf("message = %q", invocationErr.Message)
+	}
+}
+
+func TestRun_CleanInvocationKeepsStdoutEmptyUntilTerminalOutcome(t *testing.T) {
+	originalBuilder := buildFactoryService
+	defer func() {
+		buildFactoryService = originalBuilder
+	}()
+
+	_, workFile := writeDashboardRunFixture(t)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	buildFactoryService = func(_ context.Context, _ *service.FactoryServiceConfig) (factoryServiceRunner, error) {
+		return stubFactoryService{
+			run: func(context.Context) error {
+				close(started)
+				<-release
+				return context.Canceled
+			},
+			snapshot: func(context.Context) (*interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], error) {
+				return nil, errors.New("snapshot not needed")
+			},
+		}, nil
+	}
+
+	var stdout bytes.Buffer
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- Run(context.Background(), RunConfig{
+			WorkFile:                workFile,
+			CleanInvocation:         true,
+			Output:                  &stdout,
+			DisableDefaultRecording: true,
+			Logger:                  zap.NewNop(),
+		})
+	}()
+
+	select {
+	case <-started:
+	case err := <-errCh:
+		t.Fatalf("Run returned before blocking phase: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for clean invocation startup")
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("stdout before terminal outcome = %q, want empty", got)
+	}
+
+	close(release)
+
+	err := <-errCh
+	if got := stdout.String(); got != "" {
+		t.Fatalf("stdout after terminal outcome = %q, want empty", got)
+	}
+	var invocationErr *InvocationError
+	if !errors.As(err, &invocationErr) {
+		t.Fatalf("error = %#v, want InvocationError", err)
+	}
+	if invocationErr.Code != InvocationErrorCodeCancelled {
+		t.Fatalf("code = %q, want %q", invocationErr.Code, InvocationErrorCodeCancelled)
 	}
 }
 
@@ -566,4 +741,43 @@ func runWithCapturedStdout(t *testing.T, cfg RunConfig) (string, error) {
 	}
 
 	return string(output), runErr
+}
+
+func failedCleanInvocationSnapshot(reason string) *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net] {
+	return &interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{
+		DispatchHistory: []interfaces.CompletedDispatch{{
+			Outcome: interfaces.OutcomeFailed,
+			Reason:  reason,
+			ConsumedTokens: []interfaces.Token{{
+				ID:      "failed-token",
+				PlaceID: "task:init",
+				Color: interfaces.TokenColor{
+					WorkID:     "dashboard-render-test-work",
+					WorkTypeID: "task",
+					TraceID:    "dashboard-render-test-trace",
+				},
+			}},
+		}},
+	}
+}
+
+func timedOutCleanInvocationSnapshot() *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net] {
+	return &interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{
+		DispatchHistory: []interfaces.CompletedDispatch{{
+			Outcome: interfaces.OutcomeFailed,
+			ConsumedTokens: []interfaces.Token{{
+				ID:      "timeout-token",
+				PlaceID: "task:init",
+				Color: interfaces.TokenColor{
+					WorkID:     "dashboard-render-test-work",
+					WorkTypeID: "task",
+					TraceID:    "dashboard-render-test-trace",
+				},
+			}},
+			FailureMetadata: &interfaces.WorkFailureMetadata{
+				Family: interfaces.WorkFailureFamilyRetryable,
+				Type:   interfaces.WorkFailureTypeTimeout,
+			},
+		}},
+	}
 }

--- a/pkg/cli/run/run_test.go
+++ b/pkg/cli/run/run_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/apisurface"
 	initcmd "github.com/portpowered/infinite-you/pkg/cli/init"
 	factoryconfig "github.com/portpowered/infinite-you/pkg/config"
+	"github.com/portpowered/infinite-you/pkg/factory/state"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/petri"
 	"github.com/portpowered/infinite-you/pkg/service"
@@ -24,6 +25,7 @@ import (
 
 type stubFactoryService struct {
 	run                   func(context.Context) error
+	snapshot              func(context.Context) (*interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], error)
 	runtimeLogDiagnostics service.RuntimeLogDiagnostics
 }
 
@@ -33,6 +35,13 @@ func (s stubFactoryService) Run(ctx context.Context) error {
 
 func (s stubFactoryService) RuntimeLogDiagnostics() service.RuntimeLogDiagnostics {
 	return s.runtimeLogDiagnostics
+}
+
+func (s stubFactoryService) GetEngineStateSnapshot(ctx context.Context) (*interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], error) {
+	if s.snapshot == nil {
+		return nil, errors.New("snapshot unavailable")
+	}
+	return s.snapshot(ctx)
 }
 
 type capturedOOTBSmokeRun struct {

--- a/tests/functional/smoke/cli_factory_prompt_run_smoke_test.go
+++ b/tests/functional/smoke/cli_factory_prompt_run_smoke_test.go
@@ -120,6 +120,88 @@ func TestFactoryPromptRun_RealCLIRejectsFactoryWithoutDefaultHandling(t *testing
 	}
 }
 
+func TestFactoryPromptRun_RealCLICleanInvocationStdoutRemainsPipeableAcrossRuns(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow CLI factory prompt run smoke")
+	}
+
+	dir := support.ScaffoldFactory(t, factoryPromptRunSmokeConfig())
+	factoryPath := filepath.Join(dir, interfaces.FactoryConfigFile)
+	mockWorkersPath := writeDefaultMockWorkersConfig(t)
+	binaryPath := buildYouCLIBinary(t)
+
+	for _, prompt := range []string{
+		"functional-clean-stdout-first",
+		"functional-clean-stdout-second",
+	} {
+		stdout, stderr, err := runFactoryPromptCLI(t, dir, binaryPath, mockWorkersPath, nil, factoryPath, prompt)
+		if err != nil {
+			t.Fatalf("run clean invocation for prompt %q: %v\nstdout:\n%s\nstderr:\n%s", prompt, err, stdout, stderr)
+		}
+		assertFactoryPromptCleanInvocationStdout(t, stdout, prompt)
+	}
+}
+
+func TestFactoryPromptRun_RealCLIStdinOnlyCleanInvocationStdoutRemainsPipeable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow CLI factory prompt run smoke")
+	}
+
+	dir := support.ScaffoldFactory(t, factoryPromptRunSmokeConfig())
+	factoryPath := filepath.Join(dir, interfaces.FactoryConfigFile)
+	mockWorkersPath := writeDefaultMockWorkersConfig(t)
+	binaryPath := buildYouCLIBinary(t)
+
+	stdout, stderr, err := runFactoryPromptCLI(
+		t,
+		dir,
+		binaryPath,
+		mockWorkersPath,
+		strings.NewReader("functional-clean-stdin-only\n"),
+		factoryPath,
+	)
+	if err != nil {
+		t.Fatalf("run stdin-only clean invocation: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	assertFactoryPromptCleanInvocationStdout(t, stdout, "functional-clean-stdin-only")
+}
+
+func TestFactoryPromptRun_RealCLIAmbiguousPromptAndStdinFailsBeforeRuntimeStartup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow CLI factory prompt run smoke")
+	}
+
+	dir := support.ScaffoldFactory(t, factoryPromptRunSmokeConfig())
+	factoryPath := filepath.Join(dir, interfaces.FactoryConfigFile)
+	mockWorkersPath := writeDefaultMockWorkersConfig(t)
+	binaryPath := buildYouCLIBinary(t)
+
+	stdout, stderr, err := runFactoryPromptCLI(
+		t,
+		dir,
+		binaryPath,
+		mockWorkersPath,
+		strings.NewReader("functional-clean-stdin-conflict\n"),
+		factoryPath,
+		"functional-clean-positional-conflict",
+	)
+	if err == nil {
+		t.Fatalf("expected ambiguous stdin and prompt invocation to fail\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty on ambiguous input failure", stdout)
+	}
+	for _, want := range []string{
+		"RUN_INVOCATION_AMBIGUOUS_INPUT",
+		"positional prompt",
+		"stdin",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("stderr = %q, want %q", stderr, want)
+		}
+	}
+}
+
 const defaultPromptRunWorkTypeName = "prompt-task"
 
 func factoryPromptRunSmokeConfig() map[string]any {
@@ -127,9 +209,9 @@ func factoryPromptRunSmokeConfig() map[string]any {
 		"name": "factory-prompt-run-smoke",
 		"workTypes": []map[string]any{
 			{
-				"name":               defaultPromptRunWorkTypeName,
-				"handlingBehavior":   []string{"DEFAULT"},
-				"states":             promptRunWorkTypeStates(),
+				"name":             defaultPromptRunWorkTypeName,
+				"handlingBehavior": []string{"DEFAULT"},
+				"states":           promptRunWorkTypeStates(),
 			},
 		},
 		"workers": []map[string]string{
@@ -185,6 +267,63 @@ func writeDefaultMockWorkersConfig(t *testing.T) string {
 		t.Fatalf("write mock-workers config: %v", err)
 	}
 	return path
+}
+
+func runFactoryPromptCLI(
+	t *testing.T,
+	dir string,
+	binaryPath string,
+	mockWorkersPath string,
+	stdin *strings.Reader,
+	factoryPath string,
+	promptArgs ...string,
+) (stdout string, stderr string, runErr error) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	t.Cleanup(cancel)
+
+	args := []string{
+		"run",
+		"--factory", factoryPath,
+		"--with-mock-workers",
+		"--no-record",
+		"--quiet",
+		mockWorkersPath,
+	}
+	args = append(args, promptArgs...)
+
+	cmd := exec.CommandContext(ctx, binaryPath, args...)
+	cmd.Dir = dir
+	if stdin != nil {
+		cmd.Stdin = stdin
+	}
+
+	var outBuf, errBuf strings.Builder
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	runErr = cmd.Run()
+	return outBuf.String(), errBuf.String(), runErr
+}
+
+func assertFactoryPromptCleanInvocationStdout(t *testing.T, got string, want string) {
+	t.Helper()
+
+	if got != want {
+		t.Fatalf("stdout = %q, want exact primary clean invocation output", got)
+	}
+	for _, forbidden := range []string{
+		"Factory initiated",
+		"Dashboard URL",
+		"Runtime log",
+		"Opening dashboard",
+		"Recording saved to",
+		"Factory:",
+	} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("stdout = %q, should not contain operator chatter %q", got, forbidden)
+		}
+	}
 }
 
 func buildYouCLIBinary(t *testing.T) string {


### PR DESCRIPTION
{
  "project": "Clean you run Invocation Contract",
  "branchName": "ralph/you-run-clean-invocation-contract",
  "description": "Redefine batch result-oriented you run invocations as a shell-friendly contract: stdout carries only the primary work result on success, ambiguous input sources are rejected up front, operator chatter stays off stdout, and failures expose stable error codes on stderr with structured logs and invocation metrics.",
  "context": {
    "customerAsk": "Redefine you run as a clean invocation surface for result-oriented workflows. Successful invocations should emit only the primary result on stdout, reject ambiguous input-source combinations, and avoid dashboard-style terminal noise while keeping failures machine-usable.",
    "problem": "you run currently prints factory startup banners, dashboard URLs, runtime-log paths, simple-dashboard snapshots, and default recording notices on stdout via StartupOutput and SimpleDashboardRenderer. Positional prompt and piped stdin are not mutually exclusive, global --json is not wired for run results, and failures lack stable machine-readable error codes separate from free-form messages.",
    "solution": "Introduce clean invocation mode for one-shot batch you run --factory runs: resolve input from exactly one source and reject ambiguity before startup, route operator chatter to stderr or logs, emit only the DEFAULT-handling primary work output on stdout (text or single JSON with --json), return stable stderr error codes on failure/cancel/timeout with empty success stdout, and add structured logs plus invocation counters without disabling default replay recording."
  },
  "acceptanceCriteria": [
    "One-shot batch you run --factory invocations enter clean invocation mode and write only the primary result to stdout on success.",
    "Clean invocation mode never prints dashboard rendering, startup banners, runtime-log paths, or recording-path notices to stdout.",
    "Ambiguous simultaneous input sources are rejected before runtime startup with non-zero exit, a message naming conflicting sources, and code RUN_INVOCATION_AMBIGUOUS_INPUT on stderr.",
    "Failed, cancelled, or timed-out clean invocations return non-zero, emit no success payload on stdout, and expose stable machine-readable error codes with concise human-readable messages on stderr.",
    "Structured logs and invocation metrics cover success, failure, ambiguity rejection, and cancellation for clean invocations.",
    "Operator-oriented continuous and no-arg you run behavior remains unchanged for this PRD.",
    "Quality gate: Go typecheck, lint, and tests pass for touched packages."
  ],
  "userStories": [
    {
      "id": "prd-you-run-clean-invocation-contract-001",
      "title": "Reject ambiguous invocation input sources",
      "description": "As a customer scripting you run, I want conflicting input sources rejected before the factory starts so invocation behavior stays predictable across text, audio, and future multimodal flows.",
      "acceptanceCriteria": [
        "Clean invocation input resolution accepts exactly one payload source among positional prompt, stdin (- or piped non-TTY stdin), and reserved future file or stream reference slots documented in the contract.",
        "Supplying both a non-empty positional prompt and non-empty stdin for the same invocation returns non-zero exit before factory startup.",
        "The stderr error message names the conflicting sources (for example positional prompt and stdin) and includes stable code RUN_INVOCATION_AMBIGUOUS_INPUT.",
        "Unit tests in pkg/cli/run cover positional-only, stdin-only, and conflicting combinations without starting a factory runtime.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-you-run-clean-invocation-contract-002",
      "title": "Keep operator chatter off stdout in clean invocation mode",
      "description": "As a customer piping you run output, I want startup and dashboard messages kept off stdout so only the work result is captured by downstream tools.",
      "acceptanceCriteria": [
        "Clean invocation mode is selected for batch you run --factory runs that submit prompt or work input and are not --continuously.",
        "Successful clean invocations do not print Factory initiated, Dashboard URL, Runtime log, Opening dashboard, simple-dashboard snapshots, or Recording saved to stdout.",
        "Operator-oriented invocations (you with no args, you run --continuously, you run --dir without --factory prompt submission) retain existing startup and dashboard stdout behavior.",
        "Default replay recording still occurs when enabled without adding stdout noise on the success path.",
        "CLI tests prove a successful mock-worker clean invocation leaves stdout free of dashboard and startup banner substrings.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-you-run-clean-invocation-contract-003",
      "title": "Emit only the primary result on successful clean invocation",
      "description": "As a customer, I want successful you run to write only the primary work result to stdout so I can pipe it into files and other tools without cleanup.",
      "acceptanceCriteria": [
        "After a successful clean invocation, stdout contains only the primary output from the sole handlingBehavior DEFAULT work item that reached terminal success.",
        "Default non-JSON success writes the primary text body only with no trailing diagnostic lines or banners.",
        "With global --json, success writes exactly one parseable JSON object to stdout and exits 0; the object includes at minimum output, workId, workTypeName, traceId, and sessionId when available.",
        "Repeated successful clean invocations in one test session each emit a clean stdout payload with no accumulated dashboard or startup chatter.",
        "Functional or CLI integration tests cover at least one text success and one JSON success using mock workers.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-you-run-clean-invocation-contract-004",
      "title": "Enforce failure, cancellation, and timeout channel discipline",
      "description": "As a customer automating you run, I want failures to stay off the success channel so scripts can trust stdout and exit codes.",
      "acceptanceCriteria": [
        "Runtime failures in clean invocation mode return non-zero exit and write no success text or JSON object to stdout.",
        "Failures expose stable machine-readable error codes on stderr with concise messages; at minimum RUN_INVOCATION_FAILED for runtime or work failures.",
        "User cancellation (SIGINT or SIGTERM) uses code RUN_INVOCATION_CANCELLED, non-zero exit, and empty success stdout.",
        "Context timeout or exceeded invocation deadline uses code RUN_INVOCATION_TIMEOUT when applicable, non-zero exit, and empty success stdout.",
        "With --json on failure, stderr carries a single parseable JSON error object with code and message keys and stdout remains free of success payloads.",
        "Tests cover runtime failure, cancellation, and at least one startup or loading-period case where stdout stays empty until a terminal outcome.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-you-run-clean-invocation-contract-005",
      "title": "Log and measure clean invocation outcomes",
      "description": "As an operator, I want structured logs and invocation counters for clean runs so I can audit success, failure, ambiguity, and cancellation without reading stdout.",
      "acceptanceCriteria": [
        "Clean invocation success emits structured info logs (for example run.invocation.completed) with outcome=success, mode=clean, inputSource, durationMs, and correlation ids when present.",
        "Clean invocation failure emits run.invocation.completed or equivalent with outcome=failure, stable errorCode, and a bounded error summary without full prompts or payloads.",
        "Ambiguity rejection emits run.invocation.rejected with reason=ambiguous_input and conflicting source labels.",
        "Cancellation emits run.invocation.completed with outcome=cancelled and errorCode=RUN_INVOCATION_CANCELLED.",
        "Metrics or counters record invocation attempts, successes, failures, ambiguity rejections, and cancellations (for example run_invocation_attempts_total and related outcome counters) when instrumentation is present or added in this change.",
        "Tests assert log fields for at least one success and one ambiguity-rejection path using the recording-logger pattern where practical.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-you-run-clean-invocation-contract-006",
      "title": "Prove end-to-end pipability across repeated invocations",
      "description": "As a maintainer, I want regression evidence that clean invocation stdout discipline holds under real CLI execution and repeated batch usage.",
      "acceptanceCriteria": [
        "A functional smoke test runs you run --factory with mock workers, captures stdout, and asserts the payload equals the expected primary result with no dashboard or startup substrings.",
        "A second back-to-back invocation in the same test proves stdout cleanliness does not degrade across runs.",
        "A test pipes mock input via stdin for a stdin-only clean invocation and receives only the primary result on stdout.",
        "An ambiguity test pipes stdin while also passing a positional prompt and observes non-zero exit with RUN_INVOCATION_AMBIGUOUS_INPUT before work completes.",
        "Tests use bounded timeouts and t.Cleanup hooks consistent with existing functional smoke patterns.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-you-run-clean-invocation-contract-007",
      "title": "Document the clean invocation contract for customers",
      "description": "As a customer, I want packaged CLI reference docs to describe clean invocation stdout and stderr behavior so I can script you run without reading source code.",
      "acceptanceCriteria": [
        "docs/reference/config.md or a linked canonical section documents clean invocation mode scope, input-source rules, ambiguity rejection, success stdout shapes for text and --json, failure stderr codes, and the operator-mode exception.",
        "you docs config or the chosen topic includes at least one copy-pasteable example showing piped you run --factory output.",
        "make docs-reference-smoke passes after doc updates.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 7,
      "passes": true,
      "notes": ""
    }
  ]
}
