### PR TITLE
prd-named-factory-resolution-and-built-ins

### DIFF
--- a/docs/reference/authoring-factories.md
+++ b/docs/reference/authoring-factories.md
@@ -258,6 +258,49 @@ examples.
 Run `you docs mock-workers` for the `--with-mock-workers` JSON contract,
 selection fields, and deterministic outcome examples beyond this quick start.
 
+## Run Named Factories From Anywhere
+
+Persist reusable factories under a named-factory root when you want to run them
+without locating `factory.json` manually:
+
+```bash
+you factory save my-team-review --from ./factory.json
+```
+
+By default persisted project factories live under `./factory`, and
+`you run --named <name>` resolves that project-local root before checking the
+global shared root at `~/.you-agent-factory/factories`.
+
+```bash
+you run --named my-team-review
+```
+
+This precedence is selection-only: the CLI chooses exactly one matching named
+factory directory and never merges a project-local definition with a global
+definition of the same canonical name.
+
+First-party built-ins such as `@you/tts` also use the named-factory path:
+
+```bash
+you run --named @you/tts
+```
+
+On the first invocation the CLI materializes the built-in into
+`~/.you-agent-factory/factories`, then loads later runs from that on-disk copy.
+That keeps the built-in editable: if you modify the materialized
+`workers/*/AGENTS.md`, `workstations/*/AGENTS.md`, or other split-layout files,
+the next `you run --named @you/tts` invocation uses your edited version.
+
+Use `you factory list` to inspect one named-factory root at a time. The default
+command lists only the project-local `./factory` root; point `--dir` at the
+global root when you want to inspect shared built-ins and customer-wide named
+factories:
+
+```bash
+you factory list
+you factory list --dir ~/.you-agent-factory/factories
+```
+
 ### 4. Submit work
 
 Create a startup or watched-file request:

--- a/pkg/cli/factory/delete_test.go
+++ b/pkg/cli/factory/delete_test.go
@@ -147,3 +147,35 @@ func TestDelete_RemovesDirectoryFromDisk(t *testing.T) {
 		t.Fatalf("alpha directory still exists: %v", err)
 	}
 }
+
+func TestDelete_ScopedNonCurrentFactoryLeavesCurrentPointerResolvableInExplicitDir(t *testing.T) {
+	rootDir := t.TempDir()
+	if _, err := factoryconfig.PersistNamedFactory(rootDir, "@you/tts", saveTestNamedFactoryPayload(t, "tts")); err != nil {
+		t.Fatalf("PersistNamedFactory(scoped): %v", err)
+	}
+	if _, err := factoryconfig.PersistNamedFactory(rootDir, "alpha", saveTestNamedFactoryPayload(t, "alpha")); err != nil {
+		t.Fatalf("PersistNamedFactory(alpha): %v", err)
+	}
+	if err := factoryconfig.WriteCurrentFactoryPointer(rootDir, "alpha"); err != nil {
+		t.Fatalf("WriteCurrentFactoryPointer(alpha): %v", err)
+	}
+
+	if err := Delete(DeleteConfig{
+		Name:   "@you/tts",
+		Dir:    rootDir,
+		Output: ioDiscard(t),
+	}); err != nil {
+		t.Fatalf("Delete(scoped): %v", err)
+	}
+
+	resolvedDir, err := factoryconfig.ResolveCurrentFactoryDir(rootDir)
+	if err != nil {
+		t.Fatalf("ResolveCurrentFactoryDir: %v", err)
+	}
+	if want := filepath.Join(rootDir, "alpha"); resolvedDir != want {
+		t.Fatalf("resolved dir = %q, want %q", resolvedDir, want)
+	}
+	if _, err := os.Stat(filepath.Join(rootDir, "@you%2Ftts")); !os.IsNotExist(err) {
+		t.Fatalf("scoped factory directory still exists: %v", err)
+	}
+}

--- a/pkg/cli/factory/save_test.go
+++ b/pkg/cli/factory/save_test.go
@@ -199,6 +199,37 @@ func TestSaveFromFile_SetCurrentUpdatesPointer(t *testing.T) {
 	}
 }
 
+func TestSaveFromFile_SetCurrentScopedNameKeepsResolveCurrentFactoryDirAligned(t *testing.T) {
+	rootDir := t.TempDir()
+	from := writeFactoryConfigFile(t, rootDir, "tts", saveTestNamedFactoryPayload(t, "tts"))
+
+	if err := SaveFromFile(SaveFromFileConfig{
+		Name:       "@you/tts",
+		From:       from,
+		Dir:        rootDir,
+		SetCurrent: true,
+		Output:     ioDiscard(t),
+	}); err != nil {
+		t.Fatalf("SaveFromFile(scoped): %v", err)
+	}
+
+	current, err := factoryconfig.ReadCurrentFactoryPointer(rootDir)
+	if err != nil {
+		t.Fatalf("ReadCurrentFactoryPointer: %v", err)
+	}
+	if current != "@you/tts" {
+		t.Fatalf("current = %q, want @you/tts", current)
+	}
+
+	resolvedDir, err := factoryconfig.ResolveCurrentFactoryDir(rootDir)
+	if err != nil {
+		t.Fatalf("ResolveCurrentFactoryDir: %v", err)
+	}
+	if want := filepath.Join(rootDir, "@you%2Ftts"); resolvedDir != want {
+		t.Fatalf("resolved dir = %q, want %q", resolvedDir, want)
+	}
+}
+
 func TestSaveFromFile_OmitsSetCurrentLeavesPointerUnchanged(t *testing.T) {
 	rootDir := t.TempDir()
 	if _, err := factoryconfig.PersistNamedFactory(rootDir, "alpha", saveTestNamedFactoryPayload(t, "alpha")); err != nil {

--- a/pkg/cli/factory/update_test.go
+++ b/pkg/cli/factory/update_test.go
@@ -220,3 +220,48 @@ func TestUpdateFromFile_CurrentPointerUnchangedWhenReplacingCurrent(t *testing.T
 		t.Fatalf("list output = %q, want current alpha row %q", out.String(), wantRow)
 	}
 }
+
+func TestUpdateFromFile_ScopedCurrentPointerStillResolvesUpdatedFactoryInExplicitDir(t *testing.T) {
+	rootDir := t.TempDir()
+	if _, err := factoryconfig.PersistNamedFactory(rootDir, "@you/tts", saveTestNamedFactoryPayload(t, "tts")); err != nil {
+		t.Fatalf("PersistNamedFactory(scoped): %v", err)
+	}
+	if err := factoryconfig.WriteCurrentFactoryPointer(rootDir, "@you/tts"); err != nil {
+		t.Fatalf("WriteCurrentFactoryPointer(scoped): %v", err)
+	}
+	from := writeFactoryConfigFile(t, rootDir, "tts-updated", saveTestNamedFactoryPayload(t, "tts-v2"))
+
+	if err := UpdateFromFile(UpdateFromFileConfig{
+		Name:   "@you/tts",
+		From:   from,
+		Dir:    rootDir,
+		Output: ioDiscard(t),
+	}); err != nil {
+		t.Fatalf("UpdateFromFile(scoped): %v", err)
+	}
+
+	current, err := factoryconfig.ReadCurrentFactoryPointer(rootDir)
+	if err != nil {
+		t.Fatalf("ReadCurrentFactoryPointer: %v", err)
+	}
+	if current != "@you/tts" {
+		t.Fatalf("current = %q, want @you/tts", current)
+	}
+
+	resolvedDir, err := factoryconfig.ResolveCurrentFactoryDir(rootDir)
+	if err != nil {
+		t.Fatalf("ResolveCurrentFactoryDir: %v", err)
+	}
+	wantDir := filepath.Join(rootDir, "@you%2Ftts")
+	if resolvedDir != wantDir {
+		t.Fatalf("resolved dir = %q, want %q", resolvedDir, wantDir)
+	}
+
+	data, err := os.ReadFile(filepath.Join(resolvedDir, interfaces.FactoryConfigFile))
+	if err != nil {
+		t.Fatalf("ReadFile(updated scoped factory config): %v", err)
+	}
+	if !strings.Contains(string(data), "execute-tts-v2") {
+		t.Fatalf("factory config = %q, want updated scoped workstation body", string(data))
+	}
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -288,11 +288,16 @@ func newFactoryListCommand(globals *cliGlobalOptions, _ *cliDiagnosticsOptions) 
 		Use:   "list",
 		Short: "List persisted named factories",
 		Long: "List persisted named factories stored under a factory root.\n\n" +
-			"By default the command writes a human-readable table with each factory name, " +
-			"on-disk directory, and whether it is selected by .current-factory. " +
-			"Use --dir to scope discovery to a different factory root. Use global --json for scripting output.",
+			"By default the command lists project-local named factories from ./factory and writes a " +
+			"human-readable table with each factory name, on-disk directory, and whether it is selected " +
+			"by .current-factory. Global built-ins and customer-edited shared factories live under " +
+			"~/.you-agent-factory/factories and are listed only when you point --dir there explicitly. " +
+			"The command lists exactly one root at a time and never merges project-local and global entries. " +
+			"Use global --json for scripting output.",
 		Example: "  # List named factories under the default factory root.\n" +
 			"  " + cliBinaryName + " factory list\n\n" +
+			"  # List global built-ins and shared factories.\n" +
+			"  " + cliBinaryName + " factory list --dir ~/.you-agent-factory/factories\n\n" +
 			"  # List factories from a custom root as JSON.\n" +
 			"  " + cliBinaryName + " --json factory list --dir my-factory",
 		SilenceUsage: true,
@@ -729,6 +734,7 @@ func newRunCommand(globals *cliGlobalOptions, diagnostics *cliDiagnosticsOptions
 			"Use --with-mock-workers with an optional JSON config path to test workflows with deterministic mock worker outcomes. " +
 			"Use --quiet to suppress dashboard output for scripted or CI-oriented runs. " +
 			"Use --named with a persisted canonical factory name to resolve project-local factories before global built-ins under ~/.you-agent-factory/factories. " +
+			"Built-ins such as @you/tts materialize lazily into that global root on first use and stay editable on disk for later runs. " +
 			"Use --factory with a factory.json file path to run a portable factory config without guessing --dir. " +
 			"Runtime logs are structured JSON rolling files grouped by UTC start date under the selected log root; environment details are record-channel diagnostics only, and system logs include command stdout/stderr only on command failures.",
 		Example: "  # Start the out-of-the-box continuous factory.\n" +
@@ -766,7 +772,7 @@ func newRunCommand(globals *cliGlobalOptions, diagnostics *cliDiagnosticsOptions
 	cmd.Flags().BoolVar(&cfg.Continuously, "continuously", false, "keep the factory alive while idle until cancelled")
 	cmd.Flags().StringVar(&cfg.WorkFile, "work", "", "path to initial FACTORY_REQUEST_BATCH JSON file to submit")
 	cmd.Flags().StringVar(&cfg.Dir, "dir", cfg.Dir, "factory base directory")
-	cmd.Flags().StringVar(&cfg.NamedFactoryName, "named", "", "canonical persisted factory name resolved from ./factory before ~/.you-agent-factory/factories")
+	cmd.Flags().StringVar(&cfg.NamedFactoryName, "named", "", "canonical persisted factory name resolved from ./factory before ~/.you-agent-factory/factories; built-ins materialize there on first use and remain editable")
 	cmd.Flags().StringVar(&cfg.FactoryConfigPath, "factory", "", "path to factory.json for portable one-shot runs")
 	cmd.Flags().StringVar(&cfg.RunnerID, "runner", "", fmt.Sprintf("factory-level runner override (%s)", strings.Join([]string{
 		interfaces.RunnerIDCodex,

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -903,6 +903,7 @@ func resolveRunNamedFactorySelection(cfg *runcli.RunConfig) error {
 		return err
 	}
 	cfg.Dir = resolution.FactoryDir
+	cfg.NamedFactoryResolution = resolution
 	return nil
 }
 

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -23,6 +23,7 @@ import (
 	sessioncli "github.com/portpowered/infinite-you/pkg/cli/session"
 	submitcli "github.com/portpowered/infinite-you/pkg/cli/submit"
 	workcli "github.com/portpowered/infinite-you/pkg/cli/work"
+	factoryconfig "github.com/portpowered/infinite-you/pkg/config"
 	"github.com/portpowered/infinite-you/pkg/config/factoryrun"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/logging"
@@ -727,6 +728,7 @@ func newRunCommand(globals *cliGlobalOptions, diagnostics *cliDiagnosticsOptions
 			"Use --continuously to keep the factory alive while idle until you cancel it. " +
 			"Use --with-mock-workers with an optional JSON config path to test workflows with deterministic mock worker outcomes. " +
 			"Use --quiet to suppress dashboard output for scripted or CI-oriented runs. " +
+			"Use --named with a persisted canonical factory name to resolve project-local factories before global built-ins under ~/.you-agent-factory/factories. " +
 			"Use --factory with a factory.json file path to run a portable factory config without guessing --dir. " +
 			"Runtime logs are structured JSON rolling files grouped by UTC start date under the selected log root; environment details are record-channel diagnostics only, and system logs include command stdout/stderr only on command failures.",
 		Example: "  # Start the out-of-the-box continuous factory.\n" +
@@ -735,6 +737,8 @@ func newRunCommand(globals *cliGlobalOptions, diagnostics *cliDiagnosticsOptions
 			"  printf \"Fix the lint issues\\n\" > factory/inputs/task/default/fix-lint.md\n\n" +
 			"  # Run an existing factory once in explicit batch mode.\n" +
 			"  " + cliBinaryName + " run --dir factory\n\n" +
+			"  # Run a persisted named factory from any working directory.\n" +
+			"  " + cliBinaryName + " run --named @you/tts\n\n" +
 			"  # Run a portable factory.json with a one-shot prompt (see handlingBehavior DEFAULT).\n" +
 			"  " + cliBinaryName + " run --factory ./factory.json \"Fix the lint issues\"",
 		PreRunE: rejectDeprecatedPortFlag,
@@ -762,6 +766,7 @@ func newRunCommand(globals *cliGlobalOptions, diagnostics *cliDiagnosticsOptions
 	cmd.Flags().BoolVar(&cfg.Continuously, "continuously", false, "keep the factory alive while idle until cancelled")
 	cmd.Flags().StringVar(&cfg.WorkFile, "work", "", "path to initial FACTORY_REQUEST_BATCH JSON file to submit")
 	cmd.Flags().StringVar(&cfg.Dir, "dir", cfg.Dir, "factory base directory")
+	cmd.Flags().StringVar(&cfg.NamedFactoryName, "named", "", "canonical persisted factory name resolved from ./factory before ~/.you-agent-factory/factories")
 	cmd.Flags().StringVar(&cfg.FactoryConfigPath, "factory", "", "path to factory.json for portable one-shot runs")
 	cmd.Flags().StringVar(&cfg.RunnerID, "runner", "", fmt.Sprintf("factory-level runner override (%s)", strings.Join([]string{
 		interfaces.RunnerIDCodex,
@@ -855,6 +860,16 @@ func resolveRunBindFromServer(cmd *cobra.Command, server string, cfg *runcli.Run
 func resolveRunFactorySelection(cmd *cobra.Command, cfg *runcli.RunConfig) error {
 	factoryChanged := cmd.Flags().Changed("factory")
 	dirChanged := cmd.Flags().Changed("dir")
+	namedChanged := cmd.Flags().Changed("named")
+	if namedChanged {
+		switch {
+		case factoryChanged:
+			return fmt.Errorf("--named cannot be used with --factory")
+		case dirChanged:
+			return fmt.Errorf("--named cannot be used with --dir")
+		}
+		return resolveRunNamedFactorySelection(cfg)
+	}
 	if factoryChanged && dirChanged {
 		return fmt.Errorf("--factory cannot be used with --dir")
 	}
@@ -867,6 +882,27 @@ func resolveRunFactorySelection(cmd *cobra.Command, cfg *runcli.RunConfig) error
 		return err
 	}
 	cfg.Dir = factoryRoot
+	return nil
+}
+
+func resolveRunNamedFactorySelection(cfg *runcli.RunConfig) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolve current working directory for --named: %w", err)
+	}
+	projectRoot, err := factoryconfig.DefaultProjectNamedFactoryRoot(cwd)
+	if err != nil {
+		return fmt.Errorf("resolve project named-factory root: %w", err)
+	}
+	globalRoot, err := factoryconfig.DefaultGlobalNamedFactoryRoot()
+	if err != nil {
+		return fmt.Errorf("resolve global named-factory root: %w", err)
+	}
+	resolution, err := factoryconfig.ResolveNamedFactoryAcrossRoots(projectRoot, globalRoot, cfg.NamedFactoryName)
+	if err != nil {
+		return err
+	}
+	cfg.Dir = resolution.FactoryDir
 	return nil
 }
 

--- a/pkg/cli/root_factory_test.go
+++ b/pkg/cli/root_factory_test.go
@@ -56,3 +56,27 @@ func TestFactoryCommand_HelpDocumentsSubcommandsAndExamples(t *testing.T) {
 		t.Fatalf("factory help must not advertise --port:\n%s", help)
 	}
 }
+
+func TestFactoryListCommand_HelpDocumentsProjectAndGlobalRoots(t *testing.T) {
+	var out bytes.Buffer
+	root := NewRootCommand()
+	root.SetOut(&out)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"factory", "list", "--help"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute factory list --help: %v", err)
+	}
+
+	help := out.String()
+	for _, want := range []string{
+		"project-local named factories from ./factory",
+		"~/.you-agent-factory/factories",
+		"never merges project-local and global entries",
+		"you factory list --dir ~/.you-agent-factory/factories",
+	} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("factory list help missing %q:\n%s", want, help)
+		}
+	}
+}

--- a/pkg/cli/root_run_factory_prompt_test.go
+++ b/pkg/cli/root_run_factory_prompt_test.go
@@ -39,8 +39,21 @@ func TestRunCommand_FactoryFlagDocumentsPortableRun(t *testing.T) {
 	if !strings.Contains(runCmd.Long, "--named") {
 		t.Fatal("expected run command long help text to document --named")
 	}
+	if !strings.Contains(runCmd.Long, "resolve project-local factories before global built-ins") {
+		t.Fatal("expected run command long help text to document local-over-global named resolution")
+	}
+	if !strings.Contains(runCmd.Long, "materialize lazily into that global root on first use and stay editable on disk") {
+		t.Fatal("expected run command long help text to document built-in materialization and editability")
+	}
 	if !strings.Contains(runCmd.Example, "run --named @you/tts") {
 		t.Fatal("expected run command examples to document simplified --named run")
+	}
+	namedFlag := runCmd.Flags().Lookup("named")
+	if namedFlag == nil {
+		t.Fatal("expected --named flag on run command")
+	}
+	if !strings.Contains(namedFlag.Usage, "built-ins materialize there on first use and remain editable") {
+		t.Fatalf("--named usage = %q, want built-in editability guidance", namedFlag.Usage)
 	}
 	if !strings.Contains(runCmd.Example, "run --factory ./factory.json \"Fix the lint issues\"") {
 		t.Fatal("expected run command examples to document simplified --factory run")

--- a/pkg/cli/root_run_factory_prompt_test.go
+++ b/pkg/cli/root_run_factory_prompt_test.go
@@ -11,6 +11,9 @@ import (
 	"testing"
 
 	runcli "github.com/portpowered/infinite-you/pkg/cli/run"
+	factoryconfig "github.com/portpowered/infinite-you/pkg/config"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/testutil"
 )
 
 func TestRunCommand_FactoryFlagDocumentsPortableRun(t *testing.T) {
@@ -33,8 +36,212 @@ func TestRunCommand_FactoryFlagDocumentsPortableRun(t *testing.T) {
 	if !strings.Contains(runCmd.Long, "--factory") {
 		t.Fatal("expected run command long help text to document --factory")
 	}
+	if !strings.Contains(runCmd.Long, "--named") {
+		t.Fatal("expected run command long help text to document --named")
+	}
+	if !strings.Contains(runCmd.Example, "run --named @you/tts") {
+		t.Fatal("expected run command examples to document simplified --named run")
+	}
 	if !strings.Contains(runCmd.Example, "run --factory ./factory.json \"Fix the lint issues\"") {
 		t.Fatal("expected run command examples to document simplified --factory run")
+	}
+}
+
+func TestRunCommand_NamedFlagResolvesFactoryRootBeforeRun(t *testing.T) {
+	originalRunCLI := runCLI
+	defer func() {
+		runCLI = originalRunCLI
+	}()
+
+	workingDirectory := t.TempDir()
+	homeDirectory := t.TempDir()
+	originalWorkingDirectory, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(workingDirectory); err != nil {
+		t.Fatalf("Chdir(%q): %v", workingDirectory, err)
+	}
+	defer func() {
+		if chdirErr := os.Chdir(originalWorkingDirectory); chdirErr != nil {
+			t.Fatalf("restore working directory: %v", chdirErr)
+		}
+	}()
+	t.Setenv("HOME", homeDirectory)
+
+	globalRoot, err := factoryconfig.DefaultGlobalNamedFactoryRoot()
+	if err != nil {
+		t.Fatalf("DefaultGlobalNamedFactoryRoot: %v", err)
+	}
+
+	wantRoot, err := factoryconfig.PersistNamedFactory(globalRoot, "alpha", portableFactoryPayloadWithDefaultHandling())
+	if err != nil {
+		t.Fatalf("PersistNamedFactory(alpha): %v", err)
+	}
+
+	var got runcli.RunConfig
+	runCLI = func(_ context.Context, cfg runcli.RunConfig) error {
+		got = cfg
+		return nil
+	}
+
+	root := NewRootCommand()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"run", "--named", "alpha"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute run --named: %v", err)
+	}
+	if testutil.CanonicalPath(got.Dir) != testutil.CanonicalPath(wantRoot) {
+		t.Fatalf("dir = %q, want %q", got.Dir, wantRoot)
+	}
+	if got.NamedFactoryName != "alpha" {
+		t.Fatalf("named factory name = %q, want alpha", got.NamedFactoryName)
+	}
+}
+
+func TestRunCommand_NamedFlagPrefersProjectFactoryOverGlobal(t *testing.T) {
+	originalRunCLI := runCLI
+	defer func() {
+		runCLI = originalRunCLI
+	}()
+
+	homeDirectory := t.TempDir()
+	projectDirectory := t.TempDir()
+	originalWorkingDirectory, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(projectDirectory); err != nil {
+		t.Fatalf("Chdir(%q): %v", projectDirectory, err)
+	}
+	defer func() {
+		if chdirErr := os.Chdir(originalWorkingDirectory); chdirErr != nil {
+			t.Fatalf("restore working directory: %v", chdirErr)
+		}
+	}()
+	t.Setenv("HOME", homeDirectory)
+
+	globalRoot, err := factoryconfig.DefaultGlobalNamedFactoryRoot()
+	if err != nil {
+		t.Fatalf("DefaultGlobalNamedFactoryRoot: %v", err)
+	}
+	projectRoot, err := factoryconfig.DefaultProjectNamedFactoryRoot(projectDirectory)
+	if err != nil {
+		t.Fatalf("DefaultProjectNamedFactoryRoot: %v", err)
+	}
+
+	if _, err := factoryconfig.PersistNamedFactory(globalRoot, "alpha", portableFactoryPayloadWithDefaultHandling()); err != nil {
+		t.Fatalf("PersistNamedFactory(global alpha): %v", err)
+	}
+
+	wantRoot, err := factoryconfig.PersistNamedFactory(projectRoot, "alpha", portableFactoryPayloadWithDefaultHandling())
+	if err != nil {
+		t.Fatalf("PersistNamedFactory(local alpha): %v", err)
+	}
+
+	var got runcli.RunConfig
+	runCLI = func(_ context.Context, cfg runcli.RunConfig) error {
+		got = cfg
+		return nil
+	}
+
+	root := NewRootCommand()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"run", "--named", "alpha"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute run --named: %v", err)
+	}
+	if testutil.CanonicalPath(got.Dir) != testutil.CanonicalPath(wantRoot) {
+		t.Fatalf("dir = %q, want project-local %q", got.Dir, wantRoot)
+	}
+}
+
+func portableFactoryPayloadWithDefaultHandling() []byte {
+	return []byte(`{
+  "name": "portable",
+  "workTypes": [{
+    "name": "story",
+    "handlingBehavior": ["DEFAULT"],
+    "states": [
+      {"name": "init", "type": "INITIAL"},
+      {"name": "complete", "type": "TERMINAL"},
+      {"name": "failed", "type": "FAILED"}
+    ]
+  }],
+  "workstations": [{
+    "name": "ws",
+    "inputs": [{"workType": "story", "state": "init"}],
+    "outputs": [{"workType": "story", "state": "complete"}],
+    "onFailure": [{"workType": "story", "state": "failed"}]
+  }]
+}`)
+}
+
+func TestRunCommand_NamedAndDirFlagsRejectConflict(t *testing.T) {
+	originalRunCLI := runCLI
+	defer func() {
+		runCLI = originalRunCLI
+	}()
+
+	runCalled := false
+	runCLI = func(context.Context, runcli.RunConfig) error {
+		runCalled = true
+		return nil
+	}
+
+	root := NewRootCommand()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"run", "--named", "alpha", "--dir", "other-factory"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected conflict between --named and --dir")
+	}
+	if !strings.Contains(err.Error(), "--named cannot be used with --dir") {
+		t.Fatalf("error = %q, want conflict message", err.Error())
+	}
+	if runCalled {
+		t.Fatal("run should not start when --named conflicts with --dir")
+	}
+}
+
+func TestRunCommand_NamedAndFactoryFlagsRejectConflict(t *testing.T) {
+	originalRunCLI := runCLI
+	defer func() {
+		runCLI = originalRunCLI
+	}()
+
+	runCalled := false
+	runCLI = func(context.Context, runcli.RunConfig) error {
+		runCalled = true
+		return nil
+	}
+
+	dir := t.TempDir()
+	factoryPath := filepath.Join(dir, interfaces.FactoryConfigFile)
+	if err := os.WriteFile(factoryPath, []byte(`{"id":"portable"}`), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	root := NewRootCommand()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"run", "--named", "alpha", "--factory", factoryPath})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected conflict between --named and --factory")
+	}
+	if !strings.Contains(err.Error(), "--named cannot be used with --factory") {
+		t.Fatalf("error = %q, want conflict message", err.Error())
+	}
+	if runCalled {
+		t.Fatal("run should not start when --named conflicts with --factory")
 	}
 }
 

--- a/pkg/cli/root_run_test.go
+++ b/pkg/cli/root_run_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -14,6 +16,7 @@ import (
 	factorycli "github.com/portpowered/infinite-you/pkg/cli/factory"
 	runcli "github.com/portpowered/infinite-you/pkg/cli/run"
 	workcli "github.com/portpowered/infinite-you/pkg/cli/work"
+	factoryconfig "github.com/portpowered/infinite-you/pkg/config"
 	"github.com/portpowered/infinite-you/pkg/logging"
 )
 
@@ -877,5 +880,78 @@ func TestRunCommand_VerboseDiagnosticsUseStderr(t *testing.T) {
 	}
 	if got := stderr.String(); !strings.Contains(got, "diagnostic: run startup") {
 		t.Fatalf("stderr = %q, want run diagnostics", got)
+	}
+}
+
+func TestRunCommand_NamedFactoryResolutionMetadataFlowsIntoRunConfig(t *testing.T) {
+	originalRunCLI := runCLI
+	defer func() {
+		runCLI = originalRunCLI
+	}()
+
+	workingDirectory := t.TempDir()
+	homeDir := t.TempDir()
+	projectRoot := filepath.Join(workingDirectory, "factory")
+	projectPayload := []byte(`{
+	  "name": "project-alpha",
+	  "id": "project-alpha",
+	  "workTypes": [{"name":"task","states":[{"name":"init","type":"INITIAL"},{"name":"complete","type":"TERMINAL"}]}],
+	  "workers": [{"name":"executor","type":"MODEL_WORKER","body":"You are the executor."}],
+	  "workstations": [{"name":"execute-project-alpha","worker":"executor","inputs":[{"workType":"task","state":"init"}],"outputs":[{"workType":"task","state":"complete"}],"type":"MODEL_WORKSTATION","body":"Implement {{ .WorkID }}."}]
+	}`)
+	if _, err := factoryconfig.PersistNamedFactory(projectRoot, "alpha", projectPayload); err != nil {
+		t.Fatalf("PersistNamedFactory(project alpha): %v", err)
+	}
+	globalRoot := filepath.Join(homeDir, ".you-agent-factory", "factories")
+	globalPayload := []byte(`{
+	  "name": "global-alpha",
+	  "id": "global-alpha",
+	  "workTypes": [{"name":"task","states":[{"name":"init","type":"INITIAL"},{"name":"complete","type":"TERMINAL"}]}],
+	  "workers": [{"name":"executor","type":"MODEL_WORKER","body":"You are the executor."}],
+	  "workstations": [{"name":"execute-global-alpha","worker":"executor","inputs":[{"workType":"task","state":"init"}],"outputs":[{"workType":"task","state":"complete"}],"type":"MODEL_WORKSTATION","body":"Implement {{ .WorkID }}."}]
+	}`)
+	if _, err := factoryconfig.PersistNamedFactory(globalRoot, "alpha", globalPayload); err != nil {
+		t.Fatalf("PersistNamedFactory(global alpha): %v", err)
+	}
+
+	originalWorkingDirectory, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(workingDirectory); err != nil {
+		t.Fatalf("Chdir(%q): %v", workingDirectory, err)
+	}
+	defer func() {
+		if chdirErr := os.Chdir(originalWorkingDirectory); chdirErr != nil {
+			t.Fatalf("restore working directory: %v", chdirErr)
+		}
+	}()
+	t.Setenv("HOME", homeDir)
+
+	var got runcli.RunConfig
+	runCLI = func(_ context.Context, cfg runcli.RunConfig) error {
+		got = cfg
+		return nil
+	}
+
+	root := NewRootCommand()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"run", "--named", "alpha", "--no-record"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute run --named alpha: %v", err)
+	}
+	if got.NamedFactoryResolution == nil {
+		t.Fatal("expected named-factory resolution metadata")
+	}
+	if got.Dir != got.NamedFactoryResolution.FactoryDir {
+		t.Fatalf("run dir = %q, want resolved named-factory dir %q", got.Dir, got.NamedFactoryResolution.FactoryDir)
+	}
+	if got.NamedFactoryResolution.Source != factoryconfig.NamedFactoryResolutionSourceProjectLocal {
+		t.Fatalf("resolution source = %q, want %q", got.NamedFactoryResolution.Source, factoryconfig.NamedFactoryResolutionSourceProjectLocal)
+	}
+	if got.NamedFactoryResolution.PrecedenceDecision != factoryconfig.NamedFactoryPrecedenceDecisionProjectOverGlobal {
+		t.Fatalf("resolution precedence = %q, want %q", got.NamedFactoryResolution.PrecedenceDecision, factoryconfig.NamedFactoryPrecedenceDecisionProjectOverGlobal)
 	}
 }

--- a/pkg/cli/run/run.go
+++ b/pkg/cli/run/run.go
@@ -45,6 +45,9 @@ type RunConfig struct {
 	// NamedFactoryName is the canonical persisted named factory requested via
 	// you run --named. The CLI resolves it into Dir before service startup.
 	NamedFactoryName string
+	// NamedFactoryResolution carries the selected named-factory source and
+	// precedence metadata captured by CLI resolution before service startup.
+	NamedFactoryResolution *factoryconfig.NamedFactoryResolution
 	// FactoryConfigPath is the factory.json file path from you run --factory.
 	// The service uses Dir as the resolved factory root directory.
 	FactoryConfigPath string
@@ -358,6 +361,7 @@ func Run(ctx context.Context, cfg RunConfig) error {
 		}()
 		cfg.Port = reservedAPIServer.Port()
 	}
+	emitNamedFactoryResolutionDiagnostics(cfg, logger)
 	emitVerboseStartupDiagnostics(cfg, recordPath, requestedPort)
 
 	dashboardReady := make(chan struct{})
@@ -631,6 +635,50 @@ func emitVerboseStartupDiagnostics(cfg RunConfig, recordPath resolvedRunRecordPa
 		requestedPort,
 		autoPortDiagnostics(cfg.AutoPort, requestedPort, cfg.Port),
 	)
+}
+
+func emitNamedFactoryResolutionDiagnostics(cfg RunConfig, logger *zap.Logger) {
+	resolution := cfg.NamedFactoryResolution
+	if resolution == nil {
+		return
+	}
+
+	clidiag.Printf(
+		cfg.Diagnostics,
+		cfg.Verbose,
+		"run named-factory resolution name=%q source=%s resolvedFactoryDir=%q projectRoot=%q globalRoot=%q precedence=%s",
+		resolution.Name,
+		resolution.Source,
+		resolution.FactoryDir,
+		resolution.ProjectRoot,
+		resolution.GlobalRoot,
+		resolution.PrecedenceDecision,
+	)
+	logger.Info(
+		"named factory resolved",
+		zap.String("named_factory_name", resolution.Name),
+		zap.String("named_factory_resolution_source", string(resolution.Source)),
+		zap.String("named_factory_dir", resolution.FactoryDir),
+		zap.String("named_factory_project_root", resolution.ProjectRoot),
+		zap.String("named_factory_global_root", resolution.GlobalRoot),
+		zap.String("named_factory_precedence_decision", string(resolution.PrecedenceDecision)),
+	)
+	if resolution.PrecedenceDecision == factoryconfig.NamedFactoryPrecedenceDecisionProjectOverGlobal {
+		logger.Info(
+			"named factory precedence selected",
+			zap.String("named_factory_name", resolution.Name),
+			zap.String("named_factory_precedence_decision", string(resolution.PrecedenceDecision)),
+			zap.String("named_factory_resolution_source", string(resolution.Source)),
+		)
+	}
+	if resolution.Source == factoryconfig.NamedFactoryResolutionSourceBuiltin {
+		logger.Info(
+			"named factory built-in materialized",
+			zap.String("named_factory_name", resolution.Name),
+			zap.String("named_factory_target_dir", resolution.FactoryDir),
+			zap.String("named_factory_global_root", resolution.GlobalRoot),
+		)
+	}
 }
 
 func resolveFactoryDirForDiagnostics(dir string) string {

--- a/pkg/cli/run/run.go
+++ b/pkg/cli/run/run.go
@@ -42,6 +42,9 @@ type RunConfig struct {
 	Continuously bool
 	WorkFile     string
 	Dir          string
+	// NamedFactoryName is the canonical persisted named factory requested via
+	// you run --named. The CLI resolves it into Dir before service startup.
+	NamedFactoryName string
 	// FactoryConfigPath is the factory.json file path from you run --factory.
 	// The service uses Dir as the resolved factory root directory.
 	FactoryConfigPath string

--- a/pkg/cli/run/run_startup_test.go
+++ b/pkg/cli/run/run_startup_test.go
@@ -10,8 +10,10 @@ import (
 	"time"
 
 	"github.com/portpowered/infinite-you/pkg/apisurface"
+	factoryconfig "github.com/portpowered/infinite-you/pkg/config"
 	"github.com/portpowered/infinite-you/pkg/service"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestRun_StartupOutputFallsBackWhenDashboardOpenFails(t *testing.T) {
@@ -340,6 +342,116 @@ func TestRun_StartupDiagnosticsStaySilentWhenVerboseDisabled(t *testing.T) {
 	}
 	if diagnostics.Len() != 0 {
 		t.Fatalf("diagnostics = %q, want empty when verbose is disabled", diagnostics.String())
+	}
+}
+
+func TestRun_VerboseNamedFactoryDiagnosticsReportPrecedenceWithoutPayloadContent(t *testing.T) {
+	originalBuilder := buildFactoryService
+	defer func() {
+		buildFactoryService = originalBuilder
+	}()
+
+	buildFactoryService = func(_ context.Context, _ *service.FactoryServiceConfig) (factoryServiceRunner, error) {
+		return stubFactoryService{run: func(context.Context) error { return nil }}, nil
+	}
+
+	core, observed := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	resolution := &factoryconfig.NamedFactoryResolution{
+		Name:               "alpha",
+		FactoryDir:         "/tmp/project/factory/alpha",
+		Source:             factoryconfig.NamedFactoryResolutionSourceProjectLocal,
+		ProjectRoot:        "/tmp/project/factory",
+		GlobalRoot:         "/tmp/home/.you-agent-factory/factories",
+		PrecedenceDecision: factoryconfig.NamedFactoryPrecedenceDecisionProjectOverGlobal,
+	}
+
+	var diagnostics bytes.Buffer
+	err := Run(context.Background(), RunConfig{
+		Dir:                     resolution.FactoryDir,
+		DisableDefaultRecording: true,
+		Verbose:                 true,
+		Diagnostics:             &diagnostics,
+		Logger:                  logger,
+		NamedFactoryResolution:  resolution,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	gotDiagnostics := diagnostics.String()
+	for _, want := range []string{
+		"run named-factory resolution",
+		`name="alpha"`,
+		"source=project-local",
+		`resolvedFactoryDir="/tmp/project/factory/alpha"`,
+		"precedence=project-local-over-global",
+	} {
+		if !strings.Contains(gotDiagnostics, want) {
+			t.Fatalf("diagnostics missing %q:\n%s", want, gotDiagnostics)
+		}
+	}
+	if strings.Contains(gotDiagnostics, "secret") {
+		t.Fatalf("diagnostics leaked payload content: %s", gotDiagnostics)
+	}
+
+	resolvedLogs := observed.FilterMessage("named factory resolved").All()
+	if len(resolvedLogs) != 1 {
+		t.Fatalf("named factory resolved logs = %d, want 1", len(resolvedLogs))
+	}
+	resolvedContext := resolvedLogs[0].ContextMap()
+	if got := resolvedContext["named_factory_precedence_decision"]; got != "project-local-over-global" {
+		t.Fatalf("resolved log precedence = %#v, want project-local-over-global", got)
+	}
+	if got := resolvedContext["named_factory_resolution_source"]; got != "project-local" {
+		t.Fatalf("resolved log source = %#v, want project-local", got)
+	}
+	if observed.FilterMessage("named factory precedence selected").Len() != 1 {
+		t.Fatalf("named factory precedence logs = %d, want 1", observed.FilterMessage("named factory precedence selected").Len())
+	}
+}
+
+func TestRun_LogsBuiltInNamedFactoryMaterialization(t *testing.T) {
+	originalBuilder := buildFactoryService
+	defer func() {
+		buildFactoryService = originalBuilder
+	}()
+
+	buildFactoryService = func(_ context.Context, _ *service.FactoryServiceConfig) (factoryServiceRunner, error) {
+		return stubFactoryService{run: func(context.Context) error { return nil }}, nil
+	}
+
+	core, observed := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	resolution := &factoryconfig.NamedFactoryResolution{
+		Name:               "@you/tts",
+		FactoryDir:         "/tmp/home/.you-agent-factory/factories/@you%2Ftts",
+		Source:             factoryconfig.NamedFactoryResolutionSourceBuiltin,
+		ProjectRoot:        "/tmp/project/factory",
+		GlobalRoot:         "/tmp/home/.you-agent-factory/factories",
+		PrecedenceDecision: factoryconfig.NamedFactoryPrecedenceDecisionNone,
+	}
+
+	err := Run(context.Background(), RunConfig{
+		Dir:                     resolution.FactoryDir,
+		DisableDefaultRecording: true,
+		Logger:                  logger,
+		NamedFactoryResolution:  resolution,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	materializedLogs := observed.FilterMessage("named factory built-in materialized").All()
+	if len(materializedLogs) != 1 {
+		t.Fatalf("built-in materialized logs = %d, want 1", len(materializedLogs))
+	}
+	context := materializedLogs[0].ContextMap()
+	if got := context["named_factory_name"]; got != "@you/tts" {
+		t.Fatalf("built-in log name = %#v, want @you/tts", got)
+	}
+	if got := context["named_factory_target_dir"]; got != "/tmp/home/.you-agent-factory/factories/@you%2Ftts" {
+		t.Fatalf("built-in log target dir = %#v", got)
 	}
 }
 

--- a/pkg/config/agents_config.go
+++ b/pkg/config/agents_config.go
@@ -22,6 +22,54 @@ type WorkstationLoader interface {
 	Load(name string) (*interfaces.FactoryWorkstationConfig, error)
 }
 
+// ErrInvalidNamedFactoryName reports that the requested canonical named-factory
+// name failed validation before any on-disk lookup or persistence work began.
+var ErrInvalidNamedFactoryName = errors.New("invalid named factory name")
+
+// ErrNamedFactoryNotFound reports that a requested named factory was not found
+// in the searched root or roots.
+var ErrNamedFactoryNotFound = errors.New("named factory not found")
+
+type invalidNamedFactoryNameError struct {
+	name string
+	err  error
+}
+
+func (e *invalidNamedFactoryNameError) Error() string {
+	return fmt.Sprintf("invalid named factory name %q: %v", e.name, e.err)
+}
+
+func (e *invalidNamedFactoryNameError) Unwrap() []error {
+	return []error{ErrInvalidNamedFactoryName, e.err}
+}
+
+type namedFactoryNotFoundError struct{ name string }
+
+func (e *namedFactoryNotFoundError) Error() string {
+	return fmt.Sprintf("named factory %q not found", e.name)
+}
+
+func (e *namedFactoryNotFoundError) Unwrap() []error {
+	return []error{ErrNamedFactoryNotFound, os.ErrNotExist}
+}
+
+func wrapInvalidNamedFactoryName(name string, err error) error {
+	if err == nil || errors.Is(err, ErrInvalidNamedFactoryName) {
+		return err
+	}
+	return &invalidNamedFactoryNameError{name: strings.TrimSpace(name), err: err}
+}
+
+func newNamedFactoryNotFoundError(name string) error {
+	return &namedFactoryNotFoundError{name: strings.TrimSpace(name)}
+}
+
+// IsInvalidNamedFactoryName reports whether err wraps ErrInvalidNamedFactoryName.
+func IsInvalidNamedFactoryName(err error) bool { return errors.Is(err, ErrInvalidNamedFactoryName) }
+
+// IsNamedFactoryNotFound reports whether err wraps ErrNamedFactoryNotFound.
+func IsNamedFactoryNotFound(err error) bool { return errors.Is(err, ErrNamedFactoryNotFound) }
+
 // LoadWorkerConfig loads a worker configuration from the given directory.
 // It reads AGENTS.md, parses YAML frontmatter into WorkerConfig, and sets
 // Body to the remaining markdown content.

--- a/pkg/config/agents_config.go
+++ b/pkg/config/agents_config.go
@@ -30,6 +30,36 @@ var ErrInvalidNamedFactoryName = errors.New("invalid named factory name")
 // in the searched root or roots.
 var ErrNamedFactoryNotFound = errors.New("named factory not found")
 
+// NamedFactoryResolutionSource identifies the root that supplied a resolved
+// named factory.
+type NamedFactoryResolutionSource string
+
+const (
+	NamedFactoryResolutionSourceProjectLocal NamedFactoryResolutionSource = "project-local"
+	NamedFactoryResolutionSourceGlobal       NamedFactoryResolutionSource = "global"
+	NamedFactoryResolutionSourceBuiltin      NamedFactoryResolutionSource = "builtin-materialized"
+)
+
+// NamedFactoryPrecedenceDecision reports whether cross-root resolution observed
+// a local-over-global conflict before selecting a runnable directory.
+type NamedFactoryPrecedenceDecision string
+
+const (
+	NamedFactoryPrecedenceDecisionNone              NamedFactoryPrecedenceDecision = "none"
+	NamedFactoryPrecedenceDecisionProjectOverGlobal NamedFactoryPrecedenceDecision = "project-local-over-global"
+)
+
+// NamedFactoryResolution reports the selected runnable directory and the roots
+// considered during cross-root named-factory resolution.
+type NamedFactoryResolution struct {
+	Name               string
+	FactoryDir         string
+	Source             NamedFactoryResolutionSource
+	ProjectRoot        string
+	GlobalRoot         string
+	PrecedenceDecision NamedFactoryPrecedenceDecision
+}
+
 type invalidNamedFactoryNameError struct {
 	name string
 	err  error
@@ -58,6 +88,39 @@ func wrapInvalidNamedFactoryName(name string, err error) error {
 		return err
 	}
 	return &invalidNamedFactoryNameError{name: strings.TrimSpace(name), err: err}
+}
+
+func namedFactoryResolution(
+	name string,
+	factoryDir string,
+	source NamedFactoryResolutionSource,
+	projectRoot string,
+	globalRoot string,
+	precedence NamedFactoryPrecedenceDecision,
+) *NamedFactoryResolution {
+	return &NamedFactoryResolution{
+		Name:               name,
+		FactoryDir:         factoryDir,
+		Source:             source,
+		ProjectRoot:        projectRoot,
+		GlobalRoot:         globalRoot,
+		PrecedenceDecision: precedence,
+	}
+}
+
+func projectLocalPrecedenceDecision(globalRoot, canonicalName string) NamedFactoryPrecedenceDecision {
+	if globalRoot == "" {
+		return NamedFactoryPrecedenceDecisionNone
+	}
+	if hasNamedFactoryCandidate(globalRoot, canonicalName) {
+		return NamedFactoryPrecedenceDecisionProjectOverGlobal
+	}
+	return NamedFactoryPrecedenceDecisionNone
+}
+
+func hasNamedFactoryCandidate(rootDir, canonicalName string) bool {
+	_, found, err := resolveNamedFactoryCandidate(rootDir, canonicalName)
+	return err == nil && found
 }
 
 func newNamedFactoryNotFoundError(name string) error {

--- a/pkg/config/layout.go
+++ b/pkg/config/layout.go
@@ -802,7 +802,58 @@ type NamedFactoryResolutionSource string
 const (
 	NamedFactoryResolutionSourceProjectLocal NamedFactoryResolutionSource = "project-local"
 	NamedFactoryResolutionSourceGlobal       NamedFactoryResolutionSource = "global"
+	NamedFactoryResolutionSourceBuiltin      NamedFactoryResolutionSource = "builtin-materialized"
 )
+
+var builtInNamedFactoryCatalog = map[string][]byte{
+	"@you/tts": []byte(`{
+  "name": "@you/tts",
+  "id": "builtin-tts",
+  "workTypes": [
+    {
+      "name": "task",
+      "states": [
+        {
+          "name": "init",
+          "type": "INITIAL"
+        },
+        {
+          "name": "complete",
+          "type": "TERMINAL"
+        }
+      ]
+    }
+  ],
+  "workers": [
+    {
+      "name": "tts-executor",
+      "type": "MODEL_WORKER",
+      "body": "You are the @you/tts built-in factory worker."
+    }
+  ],
+  "workstations": [
+    {
+      "name": "execute-tts",
+      "type": "MODEL_WORKSTATION",
+      "worker": "tts-executor",
+      "inputs": [
+        {
+          "workType": "task",
+          "state": "init"
+        }
+      ],
+      "outputs": [
+        {
+          "workType": "task",
+          "state": "complete"
+        }
+      ],
+      "body": "Convert the requested text into speech for {{ .WorkID }}."
+    }
+  ]
+  }
+`),
+}
 
 // NamedFactoryResolution reports the selected runnable directory and the roots
 // considered during cross-root named-factory resolution.
@@ -854,6 +905,12 @@ func ResolveNamedFactoryAcrossRoots(projectRoot, globalRoot, name string) (*Name
 		return namedFactoryResolution(canonicalName, factoryDir, NamedFactoryResolutionSourceGlobal, projectRoot, globalRoot), nil
 	}
 
+	if factoryDir, materialized, err := resolveBuiltInNamedFactory(globalRoot, canonicalName); err != nil {
+		return nil, err
+	} else if materialized {
+		return namedFactoryResolution(canonicalName, factoryDir, NamedFactoryResolutionSourceBuiltin, projectRoot, globalRoot), nil
+	}
+
 	return nil, fmt.Errorf(
 		"resolve named factory %q in project root %s or global root %s: %w",
 		canonicalName,
@@ -896,4 +953,31 @@ func namedFactoryResolution(
 		ProjectRoot: projectRoot,
 		GlobalRoot:  globalRoot,
 	}
+}
+
+func resolveBuiltInNamedFactory(globalRoot, canonicalName string) (string, bool, error) {
+	payload, ok := builtInNamedFactoryCatalog[canonicalName]
+	if !ok {
+		return "", false, nil
+	}
+
+	segment, err := NamedFactoryNameToLayoutSegment(canonicalName)
+	if err != nil {
+		return "", false, err
+	}
+	targetDir := filepath.Join(globalRoot, segment)
+	if _, err := os.Stat(targetDir); err == nil {
+		if err := requireFactoryConfig(targetDir); err != nil {
+			return "", false, fmt.Errorf("materialize built-in named factory %q in global root %s: existing target invalid: %w", canonicalName, globalRoot, err)
+		}
+		return targetDir, true, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", false, fmt.Errorf("materialize built-in named factory %q in global root %s: check existing target: %w", canonicalName, globalRoot, err)
+	}
+
+	factoryDir, err := PersistNamedFactory(globalRoot, canonicalName, payload)
+	if err != nil {
+		return "", false, fmt.Errorf("materialize built-in named factory %q in global root %s: %w", canonicalName, globalRoot, err)
+	}
+	return factoryDir, true, nil
 }

--- a/pkg/config/layout.go
+++ b/pkg/config/layout.go
@@ -916,7 +916,7 @@ func ResolveNamedFactoryAcrossRoots(projectRoot, globalRoot, name string) (*Name
 		canonicalName,
 		projectRoot,
 		globalRoot,
-		ErrFactoryLayoutNotFound,
+		newNamedFactoryNotFoundError(canonicalName),
 	)
 }
 

--- a/pkg/config/layout.go
+++ b/pkg/config/layout.go
@@ -795,3 +795,105 @@ func restoreFactorySplitLayoutReplace(targetDir, backupDir string) {
 	_ = os.RemoveAll(trashDir)
 }
 
+// NamedFactoryResolutionSource identifies the root that supplied a resolved
+// named factory.
+type NamedFactoryResolutionSource string
+
+const (
+	NamedFactoryResolutionSourceProjectLocal NamedFactoryResolutionSource = "project-local"
+	NamedFactoryResolutionSourceGlobal       NamedFactoryResolutionSource = "global"
+)
+
+// NamedFactoryResolution reports the selected runnable directory and the roots
+// considered during cross-root named-factory resolution.
+type NamedFactoryResolution struct {
+	Name        string
+	FactoryDir  string
+	Source      NamedFactoryResolutionSource
+	ProjectRoot string
+	GlobalRoot  string
+}
+
+// ResolveNamedFactoryDirAcrossRoots returns the runnable factory directory for
+// name, checking the project-local root before the global root.
+func ResolveNamedFactoryDirAcrossRoots(projectRoot, globalRoot, name string) (string, error) {
+	resolution, err := ResolveNamedFactoryAcrossRoots(projectRoot, globalRoot, name)
+	if err != nil {
+		return "", err
+	}
+	return resolution.FactoryDir, nil
+}
+
+// ResolveNamedFactoryAcrossRoots resolves name from projectRoot first and
+// globalRoot second. It selects exactly one persisted factory directory and
+// never merges definitions across roots.
+func ResolveNamedFactoryAcrossRoots(projectRoot, globalRoot, name string) (*NamedFactoryResolution, error) {
+	projectRoot = strings.TrimSpace(projectRoot)
+	globalRoot = strings.TrimSpace(globalRoot)
+	if projectRoot == "" {
+		return nil, fmt.Errorf("project factory root is required")
+	}
+	if globalRoot == "" {
+		return nil, fmt.Errorf("global factory root is required")
+	}
+
+	canonicalName, err := canonicalNamedFactoryName(name)
+	if err != nil {
+		return nil, err
+	}
+
+	if factoryDir, found, err := resolveNamedFactoryCandidate(projectRoot, canonicalName); err != nil {
+		return nil, err
+	} else if found {
+		return namedFactoryResolution(canonicalName, factoryDir, NamedFactoryResolutionSourceProjectLocal, projectRoot, globalRoot), nil
+	}
+
+	if factoryDir, found, err := resolveNamedFactoryCandidate(globalRoot, canonicalName); err != nil {
+		return nil, err
+	} else if found {
+		return namedFactoryResolution(canonicalName, factoryDir, NamedFactoryResolutionSourceGlobal, projectRoot, globalRoot), nil
+	}
+
+	return nil, fmt.Errorf(
+		"resolve named factory %q in project root %s or global root %s: %w",
+		canonicalName,
+		projectRoot,
+		globalRoot,
+		ErrFactoryLayoutNotFound,
+	)
+}
+
+func canonicalNamedFactoryName(name string) (string, error) {
+	segment, err := NamedFactoryNameToLayoutSegment(name)
+	if err != nil {
+		return "", err
+	}
+	return NamedFactoryLayoutSegmentToName(segment)
+}
+
+func resolveNamedFactoryCandidate(rootDir, name string) (string, bool, error) {
+	factoryDir, err := ResolveNamedFactoryDir(rootDir, name)
+	if err == nil {
+		return factoryDir, true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return "", false, nil
+	}
+	return "", false, err
+}
+
+func namedFactoryResolution(
+	name string,
+	factoryDir string,
+	source NamedFactoryResolutionSource,
+	projectRoot string,
+	globalRoot string,
+) *NamedFactoryResolution {
+	return &NamedFactoryResolution{
+		Name:        name,
+		FactoryDir:  factoryDir,
+		Source:      source,
+		ProjectRoot: projectRoot,
+		GlobalRoot:  globalRoot,
+	}
+}

--- a/pkg/config/layout.go
+++ b/pkg/config/layout.go
@@ -795,16 +795,6 @@ func restoreFactorySplitLayoutReplace(targetDir, backupDir string) {
 	_ = os.RemoveAll(trashDir)
 }
 
-// NamedFactoryResolutionSource identifies the root that supplied a resolved
-// named factory.
-type NamedFactoryResolutionSource string
-
-const (
-	NamedFactoryResolutionSourceProjectLocal NamedFactoryResolutionSource = "project-local"
-	NamedFactoryResolutionSourceGlobal       NamedFactoryResolutionSource = "global"
-	NamedFactoryResolutionSourceBuiltin      NamedFactoryResolutionSource = "builtin-materialized"
-)
-
 var builtInNamedFactoryCatalog = map[string][]byte{
 	"@you/tts": []byte(`{
   "name": "@you/tts",
@@ -855,16 +845,6 @@ var builtInNamedFactoryCatalog = map[string][]byte{
 `),
 }
 
-// NamedFactoryResolution reports the selected runnable directory and the roots
-// considered during cross-root named-factory resolution.
-type NamedFactoryResolution struct {
-	Name        string
-	FactoryDir  string
-	Source      NamedFactoryResolutionSource
-	ProjectRoot string
-	GlobalRoot  string
-}
-
 // ResolveNamedFactoryDirAcrossRoots returns the runnable factory directory for
 // name, checking the project-local root before the global root.
 func ResolveNamedFactoryDirAcrossRoots(projectRoot, globalRoot, name string) (string, error) {
@@ -896,19 +876,40 @@ func ResolveNamedFactoryAcrossRoots(projectRoot, globalRoot, name string) (*Name
 	if factoryDir, found, err := resolveNamedFactoryCandidate(projectRoot, canonicalName); err != nil {
 		return nil, err
 	} else if found {
-		return namedFactoryResolution(canonicalName, factoryDir, NamedFactoryResolutionSourceProjectLocal, projectRoot, globalRoot), nil
+		return namedFactoryResolution(
+			canonicalName,
+			factoryDir,
+			NamedFactoryResolutionSourceProjectLocal,
+			projectRoot,
+			globalRoot,
+			projectLocalPrecedenceDecision(globalRoot, canonicalName),
+		), nil
 	}
 
 	if factoryDir, found, err := resolveNamedFactoryCandidate(globalRoot, canonicalName); err != nil {
 		return nil, err
 	} else if found {
-		return namedFactoryResolution(canonicalName, factoryDir, NamedFactoryResolutionSourceGlobal, projectRoot, globalRoot), nil
+		return namedFactoryResolution(
+			canonicalName,
+			factoryDir,
+			NamedFactoryResolutionSourceGlobal,
+			projectRoot,
+			globalRoot,
+			NamedFactoryPrecedenceDecisionNone,
+		), nil
 	}
 
 	if factoryDir, materialized, err := resolveBuiltInNamedFactory(globalRoot, canonicalName); err != nil {
 		return nil, err
 	} else if materialized {
-		return namedFactoryResolution(canonicalName, factoryDir, NamedFactoryResolutionSourceBuiltin, projectRoot, globalRoot), nil
+		return namedFactoryResolution(
+			canonicalName,
+			factoryDir,
+			NamedFactoryResolutionSourceBuiltin,
+			projectRoot,
+			globalRoot,
+			NamedFactoryPrecedenceDecisionNone,
+		), nil
 	}
 
 	return nil, fmt.Errorf(
@@ -937,22 +938,6 @@ func resolveNamedFactoryCandidate(rootDir, name string) (string, bool, error) {
 		return "", false, nil
 	}
 	return "", false, err
-}
-
-func namedFactoryResolution(
-	name string,
-	factoryDir string,
-	source NamedFactoryResolutionSource,
-	projectRoot string,
-	globalRoot string,
-) *NamedFactoryResolution {
-	return &NamedFactoryResolution{
-		Name:        name,
-		FactoryDir:  factoryDir,
-		Source:      source,
-		ProjectRoot: projectRoot,
-		GlobalRoot:  globalRoot,
-	}
 }
 
 func resolveBuiltInNamedFactory(globalRoot, canonicalName string) (string, bool, error) {

--- a/pkg/config/layout_expansion.go
+++ b/pkg/config/layout_expansion.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -715,6 +716,104 @@ type NamedFactoryListEntry struct {
 	Current    bool   `json:"current"`
 }
 
+const (
+	defaultNamedFactoryHomeDir     = ".you-agent-factory"
+	defaultGlobalNamedFactoryDir   = "factories"
+	defaultProjectNamedFactoryRoot = "factory"
+	scopedNamedFactoryPrefix       = "@"
+)
+
+// NamedFactoryNameToLayoutSegment maps a canonical named-factory display name
+// into the single on-disk directory segment used under a factory root.
+func NamedFactoryNameToLayoutSegment(name string) (string, error) {
+	trimmed := strings.TrimSpace(name)
+	if strings.HasPrefix(trimmed, scopedNamedFactoryPrefix) {
+		if err := validateScopedNamedFactoryName(trimmed); err != nil {
+			return "", err
+		}
+		segment := encodeScopedNamedFactoryLayoutSegment(trimmed)
+		if _, err := safeFactoryLayoutSegment("factory", segment); err != nil {
+			return "", err
+		}
+		return segment, nil
+	}
+	return safeFactoryLayoutSegment("factory", trimmed)
+}
+
+func encodeScopedNamedFactoryLayoutSegment(name string) string {
+	return strings.NewReplacer("%", "%25", "/", "%2F").Replace(name)
+}
+
+// NamedFactoryLayoutSegmentToName maps an on-disk named-factory directory
+// segment back to the canonical display name shown by list and API callers.
+func NamedFactoryLayoutSegmentToName(segment string) (string, error) {
+	safeSegment, err := safeFactoryLayoutSegment("factory", segment)
+	if err != nil {
+		return "", err
+	}
+	if !strings.HasPrefix(safeSegment, scopedNamedFactoryPrefix) {
+		return safeSegment, nil
+	}
+
+	name, err := url.PathUnescape(safeSegment)
+	if err != nil {
+		return "", fmt.Errorf("decode factory layout segment %q: %w", segment, err)
+	}
+	encoded, err := NamedFactoryNameToLayoutSegment(name)
+	if err != nil {
+		return "", err
+	}
+	if encoded != safeSegment {
+		return "", fmt.Errorf("factory layout segment %q is not canonical for %q", segment, name)
+	}
+	return name, nil
+}
+
+func validateScopedNamedFactoryName(name string) error {
+	parts := strings.Split(name, "/")
+	if len(parts) != 2 || parts[0] == scopedNamedFactoryPrefix || parts[1] == "" {
+		return fmt.Errorf("factory name %q must be scoped as @scope/name", name)
+	}
+	scope := strings.TrimPrefix(parts[0], scopedNamedFactoryPrefix)
+	if _, err := safeFactoryLayoutSegment("factory scope", scope); err != nil {
+		return err
+	}
+	if _, err := safeFactoryLayoutSegment("factory", parts[1]); err != nil {
+		return err
+	}
+	return nil
+}
+
+// GlobalNamedFactoryRootForHome builds the customer-owned global named-factory
+// root for a resolved home directory.
+func GlobalNamedFactoryRootForHome(homeDir string) (string, error) {
+	trimmed := strings.TrimSpace(homeDir)
+	if trimmed == "" {
+		return "", fmt.Errorf("user home directory is required")
+	}
+	return filepath.Join(trimmed, defaultNamedFactoryHomeDir, defaultGlobalNamedFactoryDir), nil
+}
+
+// DefaultGlobalNamedFactoryRoot returns the default global named-factory root
+// under the current user's home directory.
+func DefaultGlobalNamedFactoryRoot() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user home for named factories: %w", err)
+	}
+	return GlobalNamedFactoryRootForHome(homeDir)
+}
+
+// DefaultProjectNamedFactoryRoot returns the default project-local named
+// factory root for a caller working directory.
+func DefaultProjectNamedFactoryRoot(cwd string) (string, error) {
+	trimmed := strings.TrimSpace(cwd)
+	if trimmed == "" {
+		return "", fmt.Errorf("working directory is required")
+	}
+	return filepath.Join(trimmed, defaultProjectNamedFactoryRoot), nil
+}
+
 // ListNamedFactories discovers persisted named factories by scanning rootDir for
 // subdirectories that contain a valid factory.json layout.
 func ListNamedFactories(rootDir string) ([]NamedFactoryListEntry, error) {
@@ -756,10 +855,14 @@ func ListNamedFactories(rootDir string) ([]NamedFactoryListEntry, error) {
 		if err := requireFactoryConfig(factoryDir); err != nil {
 			continue
 		}
+		displayName, err := NamedFactoryLayoutSegmentToName(name)
+		if err != nil {
+			continue
+		}
 		entries = append(entries, NamedFactoryListEntry{
-			Name:       name,
+			Name:       displayName,
 			FactoryDir: factoryDir,
-			Current:    currentName != "" && name == currentName,
+			Current:    currentName != "" && displayName == currentName,
 		})
 	}
 
@@ -791,12 +894,16 @@ func DeleteNamedFactory(rootDir, name string) error {
 		return fmt.Errorf("factory root is required")
 	}
 
-	segment, err := safeFactoryLayoutSegment("factory", name)
+	segment, err := NamedFactoryNameToLayoutSegment(name)
+	if err != nil {
+		return err
+	}
+	canonicalName, err := NamedFactoryLayoutSegmentToName(segment)
 	if err != nil {
 		return err
 	}
 
-	factoryDir, err := ResolveNamedFactoryDir(rootDir, segment)
+	factoryDir, err := ResolveNamedFactoryDir(rootDir, name)
 	if err != nil {
 		return err
 	}
@@ -805,7 +912,7 @@ func DeleteNamedFactory(rootDir, name string) error {
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("read current factory pointer: %w", err)
 	}
-	if current == segment {
+	if current == canonicalName {
 		return fmt.Errorf(
 			"delete factory %q: %w: switch .current-factory to another factory first",
 			segment,

--- a/pkg/config/layout_expansion.go
+++ b/pkg/config/layout_expansion.go
@@ -723,29 +723,31 @@ const (
 	scopedNamedFactoryPrefix       = "@"
 )
 
-// NamedFactoryNameToLayoutSegment maps a canonical named-factory display name
-// into the single on-disk directory segment used under a factory root.
+// NamedFactoryNameToLayoutSegment maps a canonical named-factory display name into the single on-disk directory segment used under a factory root.
 func NamedFactoryNameToLayoutSegment(name string) (string, error) {
 	trimmed := strings.TrimSpace(name)
 	if strings.HasPrefix(trimmed, scopedNamedFactoryPrefix) {
 		if err := validateScopedNamedFactoryName(trimmed); err != nil {
-			return "", err
+			return "", wrapInvalidNamedFactoryName(trimmed, err)
 		}
 		segment := encodeScopedNamedFactoryLayoutSegment(trimmed)
 		if _, err := safeFactoryLayoutSegment("factory", segment); err != nil {
-			return "", err
+			return "", wrapInvalidNamedFactoryName(trimmed, err)
 		}
 		return segment, nil
 	}
-	return safeFactoryLayoutSegment("factory", trimmed)
+	if segment, err := safeFactoryLayoutSegment("factory", trimmed); err != nil {
+		return "", wrapInvalidNamedFactoryName(trimmed, err)
+	} else {
+		return segment, nil
+	}
 }
 
 func encodeScopedNamedFactoryLayoutSegment(name string) string {
 	return strings.NewReplacer("%", "%25", "/", "%2F").Replace(name)
 }
 
-// NamedFactoryLayoutSegmentToName maps an on-disk named-factory directory
-// segment back to the canonical display name shown by list and API callers.
+// NamedFactoryLayoutSegmentToName maps an on-disk named-factory directory segment back to the canonical display name shown by list and API callers.
 func NamedFactoryLayoutSegmentToName(segment string) (string, error) {
 	safeSegment, err := safeFactoryLayoutSegment("factory", segment)
 	if err != nil {

--- a/pkg/config/load/load.go
+++ b/pkg/config/load/load.go
@@ -10,8 +10,10 @@ import (
 
 // Re-export stable load error values for callers that import pkg/config/load only.
 var (
-	ErrInvalidNamedFactory   = config.ErrInvalidNamedFactory
-	ErrFactoryLayoutNotFound = config.ErrFactoryLayoutNotFound
+	ErrInvalidNamedFactory     = config.ErrInvalidNamedFactory
+	ErrInvalidNamedFactoryName = config.ErrInvalidNamedFactoryName
+	ErrFactoryLayoutNotFound   = config.ErrFactoryLayoutNotFound
+	ErrNamedFactoryNotFound    = config.ErrNamedFactoryNotFound
 )
 
 // LoadOptions configures canonical JSON load behavior.
@@ -49,7 +51,17 @@ func IsInvalidNamedFactory(err error) bool {
 	return errors.Is(err, ErrInvalidNamedFactory)
 }
 
+// IsInvalidNamedFactoryName reports whether err wraps ErrInvalidNamedFactoryName.
+func IsInvalidNamedFactoryName(err error) bool {
+	return errors.Is(err, ErrInvalidNamedFactoryName)
+}
+
 // IsFactoryLayoutNotFound reports whether err wraps ErrFactoryLayoutNotFound.
 func IsFactoryLayoutNotFound(err error) bool {
 	return errors.Is(err, ErrFactoryLayoutNotFound)
+}
+
+// IsNamedFactoryNotFound reports whether err wraps ErrNamedFactoryNotFound.
+func IsNamedFactoryNotFound(err error) bool {
+	return errors.Is(err, ErrNamedFactoryNotFound)
 }

--- a/pkg/config/load/load_test.go
+++ b/pkg/config/load/load_test.go
@@ -147,6 +147,26 @@ func TestIsInvalidNamedFactory_DetectsPersistValidationFailure(t *testing.T) {
 	}
 }
 
+func TestIsInvalidNamedFactoryName_DetectsNameValidationFailure(t *testing.T) {
+	_, err := config.ResolveNamedFactoryAcrossRoots(t.TempDir(), t.TempDir(), "@you")
+	if err == nil {
+		t.Fatal("expected invalid named factory name to fail")
+	}
+	if !load.IsInvalidNamedFactoryName(err) {
+		t.Fatalf("error = %v, want ErrInvalidNamedFactoryName", err)
+	}
+}
+
+func TestIsNamedFactoryNotFound_DetectsCrossRootMiss(t *testing.T) {
+	_, err := config.ResolveNamedFactoryAcrossRoots(t.TempDir(), t.TempDir(), "missing")
+	if err == nil {
+		t.Fatal("expected missing named factory to fail")
+	}
+	if !load.IsNamedFactoryNotFound(err) {
+		t.Fatalf("error = %v, want ErrNamedFactoryNotFound", err)
+	}
+}
+
 func TestLoadFromCanonicalJSON_MatchesLoadFromFactoryDirForInlineFactory(t *testing.T) {
 	factoryDir := t.TempDir()
 	inlineCfg := map[string]any{

--- a/pkg/config/persist/persist.go
+++ b/pkg/config/persist/persist.go
@@ -12,7 +12,9 @@ import (
 // Re-export stable persist error values for callers that import pkg/config/persist only.
 var (
 	ErrInvalidNamedFactory       = config.ErrInvalidNamedFactory
+	ErrInvalidNamedFactoryName   = config.ErrInvalidNamedFactoryName
 	ErrNamedFactoryAlreadyExists = config.ErrNamedFactoryAlreadyExists
+	ErrNamedFactoryNotFound      = config.ErrNamedFactoryNotFound
 )
 
 // NamedFactoryPersistResult reports the staged named-factory directory together
@@ -149,7 +151,17 @@ func IsInvalidNamedFactory(err error) bool {
 	return errors.Is(err, ErrInvalidNamedFactory)
 }
 
+// IsInvalidNamedFactoryName reports whether err wraps ErrInvalidNamedFactoryName.
+func IsInvalidNamedFactoryName(err error) bool {
+	return errors.Is(err, ErrInvalidNamedFactoryName)
+}
+
 // IsNamedFactoryAlreadyExists reports whether err wraps ErrNamedFactoryAlreadyExists.
 func IsNamedFactoryAlreadyExists(err error) bool {
 	return errors.Is(err, ErrNamedFactoryAlreadyExists)
+}
+
+// IsNamedFactoryNotFound reports whether err wraps ErrNamedFactoryNotFound.
+func IsNamedFactoryNotFound(err error) bool {
+	return errors.Is(err, ErrNamedFactoryNotFound)
 }

--- a/pkg/config/persist/persist.go
+++ b/pkg/config/persist/persist.go
@@ -114,6 +114,36 @@ func ValidateNamedFactoryName(name string) error {
 	return config.ValidateNamedFactoryName(name)
 }
 
+// NamedFactoryNameToLayoutSegment maps a canonical named-factory display name
+// into the single on-disk directory segment used under a factory root.
+func NamedFactoryNameToLayoutSegment(name string) (string, error) {
+	return config.NamedFactoryNameToLayoutSegment(name)
+}
+
+// NamedFactoryLayoutSegmentToName maps an on-disk named-factory directory
+// segment back to the canonical display name shown by list and API callers.
+func NamedFactoryLayoutSegmentToName(segment string) (string, error) {
+	return config.NamedFactoryLayoutSegmentToName(segment)
+}
+
+// GlobalNamedFactoryRootForHome builds the customer-owned global named-factory
+// root for a resolved home directory.
+func GlobalNamedFactoryRootForHome(homeDir string) (string, error) {
+	return config.GlobalNamedFactoryRootForHome(homeDir)
+}
+
+// DefaultGlobalNamedFactoryRoot returns the default global named-factory root
+// under the current user's home directory.
+func DefaultGlobalNamedFactoryRoot() (string, error) {
+	return config.DefaultGlobalNamedFactoryRoot()
+}
+
+// DefaultProjectNamedFactoryRoot returns the default project-local named
+// factory root for a caller working directory.
+func DefaultProjectNamedFactoryRoot(cwd string) (string, error) {
+	return config.DefaultProjectNamedFactoryRoot(cwd)
+}
+
 // IsInvalidNamedFactory reports whether err wraps ErrInvalidNamedFactory.
 func IsInvalidNamedFactory(err error) bool {
 	return errors.Is(err, ErrInvalidNamedFactory)

--- a/pkg/config/persist/persist_test.go
+++ b/pkg/config/persist/persist_test.go
@@ -133,6 +133,82 @@ func TestReadWriteCurrentFactoryPointer_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestNamedFactoryHelpers_MatchConfigPackage(t *testing.T) {
+	assertNamedFactorySegmentHelpersMatchConfig(t)
+	assertNamedFactoryRootHelpersMatchConfig(t)
+}
+
+func assertNamedFactorySegmentHelpersMatchConfig(t *testing.T) {
+	t.Helper()
+
+	facadeSegment, err := persist.NamedFactoryNameToLayoutSegment("@you/tts")
+	if err != nil {
+		t.Fatalf("persist.NamedFactoryNameToLayoutSegment: %v", err)
+	}
+	configSegment, err := config.NamedFactoryNameToLayoutSegment("@you/tts")
+	if err != nil {
+		t.Fatalf("config.NamedFactoryNameToLayoutSegment: %v", err)
+	}
+	if facadeSegment != configSegment {
+		t.Fatalf("layout segment = %q vs %q", facadeSegment, configSegment)
+	}
+
+	facadeName, err := persist.NamedFactoryLayoutSegmentToName(facadeSegment)
+	if err != nil {
+		t.Fatalf("persist.NamedFactoryLayoutSegmentToName: %v", err)
+	}
+	configName, err := config.NamedFactoryLayoutSegmentToName(configSegment)
+	if err != nil {
+		t.Fatalf("config.NamedFactoryLayoutSegmentToName: %v", err)
+	}
+	if facadeName != configName {
+		t.Fatalf("canonical name = %q vs %q", facadeName, configName)
+	}
+}
+
+func assertNamedFactoryRootHelpersMatchConfig(t *testing.T) {
+	t.Helper()
+
+	homeDir := t.TempDir()
+	facadeGlobalRoot, err := persist.GlobalNamedFactoryRootForHome(homeDir)
+	if err != nil {
+		t.Fatalf("persist.GlobalNamedFactoryRootForHome: %v", err)
+	}
+	configGlobalRoot, err := config.GlobalNamedFactoryRootForHome(homeDir)
+	if err != nil {
+		t.Fatalf("config.GlobalNamedFactoryRootForHome: %v", err)
+	}
+	if facadeGlobalRoot != configGlobalRoot {
+		t.Fatalf("global root = %q vs %q", facadeGlobalRoot, configGlobalRoot)
+	}
+
+	t.Setenv("HOME", homeDir)
+	facadeDefaultGlobalRoot, err := persist.DefaultGlobalNamedFactoryRoot()
+	if err != nil {
+		t.Fatalf("persist.DefaultGlobalNamedFactoryRoot: %v", err)
+	}
+	configDefaultGlobalRoot, err := config.DefaultGlobalNamedFactoryRoot()
+	if err != nil {
+		t.Fatalf("config.DefaultGlobalNamedFactoryRoot: %v", err)
+	}
+	if facadeDefaultGlobalRoot != configDefaultGlobalRoot {
+		t.Fatalf("default global root = %q vs %q", facadeDefaultGlobalRoot, configDefaultGlobalRoot)
+	}
+
+	cwd := filepath.Join("repo", "app")
+	facadeProjectRoot, err := persist.DefaultProjectNamedFactoryRoot(cwd)
+	if err != nil {
+		t.Fatalf("persist.DefaultProjectNamedFactoryRoot: %v", err)
+	}
+	configProjectRoot, err := config.DefaultProjectNamedFactoryRoot(cwd)
+	if err != nil {
+		t.Fatalf("config.DefaultProjectNamedFactoryRoot: %v", err)
+	}
+	if facadeProjectRoot != configProjectRoot {
+		t.Fatalf("project root = %q vs %q", facadeProjectRoot, configProjectRoot)
+	}
+}
+
 func TestReplaceFactoryLayoutAtDir_MatchesConfigPackage(t *testing.T) {
 	targetDir := t.TempDir()
 	payload := namedFactoryPayload(t, "alpha")

--- a/pkg/config/persist/persist_test.go
+++ b/pkg/config/persist/persist_test.go
@@ -303,6 +303,26 @@ func TestIsInvalidNamedFactory_DetectsPersistValidationFailure(t *testing.T) {
 	}
 }
 
+func TestIsInvalidNamedFactoryName_DetectsNameValidationFailure(t *testing.T) {
+	_, err := config.ResolveNamedFactoryDir(t.TempDir(), "@you")
+	if err == nil {
+		t.Fatal("expected invalid named factory name to fail")
+	}
+	if !persist.IsInvalidNamedFactoryName(err) {
+		t.Fatalf("error = %v, want ErrInvalidNamedFactoryName", err)
+	}
+}
+
+func TestIsNamedFactoryNotFound_DetectsResolveMiss(t *testing.T) {
+	_, err := config.ResolveNamedFactoryDir(t.TempDir(), "missing")
+	if err == nil {
+		t.Fatal("expected missing named factory to fail")
+	}
+	if !persist.IsNamedFactoryNotFound(err) {
+		t.Fatalf("error = %v, want ErrNamedFactoryNotFound", err)
+	}
+}
+
 func TestIsNamedFactoryAlreadyExists_DetectsDuplicatePersist(t *testing.T) {
 	rootDir := t.TempDir()
 	payload := namedFactoryPayload(t, "alpha")

--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -3,11 +3,12 @@ package config
 import (
 	"errors"
 	"fmt"
-	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/portpowered/infinite-you/pkg/interfaces"
 )
 
 // LoadedFactoryConfig is the effective runtime configuration assembled from
@@ -652,7 +653,7 @@ var ErrInvalidNamedFactory = errors.New("invalid named factory")
 // ValidateNamedFactoryName applies the canonical safe directory-segment rules
 // used by the named-factory on-disk layout.
 func ValidateNamedFactoryName(name string) error {
-	_, err := safeFactoryLayoutSegment("factory", name)
+	_, err := NamedFactoryNameToLayoutSegment(name)
 	return err
 }
 
@@ -749,7 +750,7 @@ func persistNamedFactory(
 		return nil, fmt.Errorf("factory root is required")
 	}
 
-	segment, err := safeFactoryLayoutSegment("factory", name)
+	segment, err := NamedFactoryNameToLayoutSegment(name)
 	if err != nil {
 		return nil, err
 	}
@@ -897,7 +898,11 @@ func ReadCurrentFactoryPointer(rootDir string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("read current factory pointer %s: %w", path, err)
 	}
-	return segment, nil
+	name, err := NamedFactoryLayoutSegmentToName(segment)
+	if err != nil {
+		return "", fmt.Errorf("read current factory pointer %s: %w", path, err)
+	}
+	return name, nil
 }
 
 // WriteCurrentFactoryPointer persists the selected named factory for later
@@ -907,7 +912,7 @@ func WriteCurrentFactoryPointer(rootDir, name string) error {
 		return fmt.Errorf("factory root is required")
 	}
 
-	segment, err := safeFactoryLayoutSegment("factory", name)
+	segment, err := NamedFactoryNameToLayoutSegment(name)
 	if err != nil {
 		return err
 	}
@@ -932,7 +937,7 @@ func ResolveNamedFactoryDir(rootDir, name string) (string, error) {
 		return "", fmt.Errorf("factory root is required")
 	}
 
-	segment, err := safeFactoryLayoutSegment("factory", name)
+	segment, err := NamedFactoryNameToLayoutSegment(name)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -937,14 +937,26 @@ func ResolveNamedFactoryDir(rootDir, name string) (string, error) {
 		return "", fmt.Errorf("factory root is required")
 	}
 
-	segment, err := NamedFactoryNameToLayoutSegment(name)
+	canonicalName, err := canonicalNamedFactoryName(name)
+	if err != nil {
+		return "", err
+	}
+	segment, err := NamedFactoryNameToLayoutSegment(canonicalName)
 	if err != nil {
 		return "", err
 	}
 
 	factoryDir := filepath.Join(rootDir, segment)
 	if err := requireFactoryConfig(factoryDir); err != nil {
-		return "", fmt.Errorf("resolve factory %q: %w", segment, err)
+		if errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf(
+				"resolve named factory %q in root %s: %w",
+				canonicalName,
+				rootDir,
+				newNamedFactoryNotFoundError(canonicalName),
+			)
+		}
+		return "", fmt.Errorf("resolve named factory %q in root %s: %w", canonicalName, rootDir, err)
 	}
 	return factoryDir, nil
 }

--- a/pkg/config/runtimetests/named_factory_delete_test.go
+++ b/pkg/config/runtimetests/named_factory_delete_test.go
@@ -56,6 +56,27 @@ func TestDeleteNamedFactory_RejectsCurrentFactory(t *testing.T) {
 	}
 }
 
+func TestDeleteNamedFactory_RejectsCurrentScopedFactory(t *testing.T) {
+	rootDir := t.TempDir()
+	if _, err := PersistNamedFactory(rootDir, "@you/tts", namedFactoryPayload(t, "tts")); err != nil {
+		t.Fatalf("PersistNamedFactory(scoped): %v", err)
+	}
+	if err := WriteCurrentFactoryPointer(rootDir, "@you/tts"); err != nil {
+		t.Fatalf("WriteCurrentFactoryPointer(scoped): %v", err)
+	}
+
+	err := DeleteNamedFactory(rootDir, "@you/tts")
+	if err == nil {
+		t.Fatal("expected delete current scoped factory to fail")
+	}
+	if !errors.Is(err, ErrNamedFactoryIsCurrent) {
+		t.Fatalf("error = %v, want ErrNamedFactoryIsCurrent", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(rootDir, "@you%2Ftts")); statErr != nil {
+		t.Fatalf("scoped factory should remain on disk: %v", statErr)
+	}
+}
+
 func TestDeleteNamedFactory_RejectsMissingFactory(t *testing.T) {
 	rootDir := t.TempDir()
 

--- a/pkg/config/runtimetests/named_factory_resolution_test.go
+++ b/pkg/config/runtimetests/named_factory_resolution_test.go
@@ -22,6 +22,9 @@ func TestResolveNamedFactoryAcrossRoots_ReturnsLocalFactory(t *testing.T) {
 	}
 
 	assertNamedFactoryResolution(t, resolution, "alpha", projectFactoryDir, NamedFactoryResolutionSourceProjectLocal, projectRoot, globalRoot)
+	if resolution.PrecedenceDecision != NamedFactoryPrecedenceDecisionNone {
+		t.Fatalf("resolution precedence = %q, want %q", resolution.PrecedenceDecision, NamedFactoryPrecedenceDecisionNone)
+	}
 }
 
 func TestResolveNamedFactoryAcrossRoots_PrefersLocalFactoryOverGlobal(t *testing.T) {
@@ -36,6 +39,9 @@ func TestResolveNamedFactoryAcrossRoots_PrefersLocalFactoryOverGlobal(t *testing
 	}
 
 	assertNamedFactoryResolution(t, resolution, "alpha", projectFactoryDir, NamedFactoryResolutionSourceProjectLocal, projectRoot, globalRoot)
+	if resolution.PrecedenceDecision != NamedFactoryPrecedenceDecisionProjectOverGlobal {
+		t.Fatalf("resolution precedence = %q, want %q", resolution.PrecedenceDecision, NamedFactoryPrecedenceDecisionProjectOverGlobal)
+	}
 	loaded, err := LoadRuntimeConfigFromFactoryDir(resolution.FactoryDir, nil)
 	if err != nil {
 		t.Fatalf("LoadRuntimeConfigFromFactoryDir(resolved local): %v", err)
@@ -124,6 +130,9 @@ func TestResolveNamedFactoryAcrossRoots_MaterializesBuiltInIntoGlobalRoot(t *tes
 
 	wantDir := filepath.Join(globalRoot, "@you%2Ftts")
 	assertNamedFactoryResolution(t, resolution, "@you/tts", wantDir, NamedFactoryResolutionSourceBuiltin, projectRoot, globalRoot)
+	if resolution.PrecedenceDecision != NamedFactoryPrecedenceDecisionNone {
+		t.Fatalf("resolution precedence = %q, want %q", resolution.PrecedenceDecision, NamedFactoryPrecedenceDecisionNone)
+	}
 	assertBuiltInMaterializedLayout(t, wantDir)
 
 	loaded, err := LoadRuntimeConfigFromFactoryDir(resolution.FactoryDir, nil)

--- a/pkg/config/runtimetests/named_factory_resolution_test.go
+++ b/pkg/config/runtimetests/named_factory_resolution_test.go
@@ -3,8 +3,12 @@ package runtimetests
 import (
 	"errors"
 	. "github.com/portpowered/infinite-you/pkg/config"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/interfaces"
 )
 
 func TestResolveNamedFactoryAcrossRoots_ReturnsLocalFactory(t *testing.T) {
@@ -90,6 +94,81 @@ func TestResolveNamedFactoryAcrossRoots_ReturnsNotFoundWhenBothRootsMiss(t *test
 	}
 }
 
+func TestResolveNamedFactoryAcrossRoots_MaterializesBuiltInIntoGlobalRoot(t *testing.T) {
+	projectRoot := t.TempDir()
+	globalRoot := t.TempDir()
+
+	resolution, err := ResolveNamedFactoryAcrossRoots(projectRoot, globalRoot, "@you/tts")
+	if err != nil {
+		t.Fatalf("ResolveNamedFactoryAcrossRoots(builtin): %v", err)
+	}
+
+	wantDir := filepath.Join(globalRoot, "@you%2Ftts")
+	assertNamedFactoryResolution(t, resolution, "@you/tts", wantDir, NamedFactoryResolutionSourceBuiltin, projectRoot, globalRoot)
+	assertBuiltInMaterializedLayout(t, wantDir)
+
+	loaded, err := LoadRuntimeConfigFromFactoryDir(resolution.FactoryDir, nil)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfigFromFactoryDir(materialized builtin): %v", err)
+	}
+	if loaded.FactoryConfig().Project != "builtin-tts" {
+		t.Fatalf("materialized builtin project = %q, want builtin-tts", loaded.FactoryConfig().Project)
+	}
+}
+
+func TestResolveNamedFactoryAcrossRoots_UsesEditedMaterializedBuiltInOnNextLoad(t *testing.T) {
+	projectRoot := t.TempDir()
+	globalRoot := t.TempDir()
+
+	resolution, err := ResolveNamedFactoryAcrossRoots(projectRoot, globalRoot, "@you/tts")
+	if err != nil {
+		t.Fatalf("ResolveNamedFactoryAcrossRoots(initial builtin): %v", err)
+	}
+
+	workerPath := filepath.Join(resolution.FactoryDir, interfaces.WorkersDir, "tts-executor", interfaces.FactoryAgentsFileName)
+	editedBody := "You are the customer-edited @you/tts built-in.\n"
+	if err := os.WriteFile(workerPath, []byte(editedBody), 0o644); err != nil {
+		t.Fatalf("WriteFile(materialized worker body): %v", err)
+	}
+
+	resolvedDir, err := ResolveNamedFactoryDirAcrossRoots(projectRoot, globalRoot, "@you/tts")
+	if err != nil {
+		t.Fatalf("ResolveNamedFactoryDirAcrossRoots(edited builtin): %v", err)
+	}
+	if resolvedDir != resolution.FactoryDir {
+		t.Fatalf("resolved dir after edit = %q, want %q", resolvedDir, resolution.FactoryDir)
+	}
+
+	loaded, err := LoadRuntimeConfigFromFactoryDir(resolvedDir, nil)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfigFromFactoryDir(edited builtin): %v", err)
+	}
+	worker, ok := loaded.Worker("tts-executor")
+	if !ok {
+		t.Fatal("expected materialized builtin worker")
+	}
+	if worker.Body != strings.TrimSpace(editedBody) {
+		t.Fatalf("edited builtin worker body = %q, want %q", worker.Body, strings.TrimSpace(editedBody))
+	}
+}
+
+func TestResolveNamedFactoryAcrossRoots_ReportsCorruptMaterializedBuiltInTarget(t *testing.T) {
+	projectRoot := t.TempDir()
+	globalRoot := t.TempDir()
+	corruptDir := filepath.Join(globalRoot, "@you%2Ftts")
+	if err := os.MkdirAll(corruptDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(corrupt builtin dir): %v", err)
+	}
+
+	_, err := ResolveNamedFactoryAcrossRoots(projectRoot, globalRoot, "@you/tts")
+	if err == nil {
+		t.Fatal("expected corrupt materialized builtin to fail")
+	}
+	if got := err.Error(); !containsAll(got, `materialize built-in named factory "@you/tts"`, "existing target invalid", "find factory config") {
+		t.Fatalf("expected corrupt-target resolution error, got %v", err)
+	}
+}
+
 func persistRuntimeNamedFactory(t *testing.T, rootDir, name, project string) string {
 	t.Helper()
 
@@ -137,4 +216,18 @@ func namedFactoryEntryNames(entries []NamedFactoryListEntry) []string {
 		names = append(names, entry.Name)
 	}
 	return names
+}
+
+func assertBuiltInMaterializedLayout(t *testing.T, factoryDir string) {
+	t.Helper()
+
+	for _, path := range []string{
+		filepath.Join(factoryDir, interfaces.FactoryConfigFile),
+		filepath.Join(factoryDir, interfaces.WorkersDir, "tts-executor", interfaces.FactoryAgentsFileName),
+		filepath.Join(factoryDir, interfaces.WorkstationsDir, "execute-tts", interfaces.FactoryAgentsFileName),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected built-in materialized path %s: %v", path, err)
+		}
+	}
 }

--- a/pkg/config/runtimetests/named_factory_resolution_test.go
+++ b/pkg/config/runtimetests/named_factory_resolution_test.go
@@ -1,0 +1,140 @@
+package runtimetests
+
+import (
+	"errors"
+	. "github.com/portpowered/infinite-you/pkg/config"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveNamedFactoryAcrossRoots_ReturnsLocalFactory(t *testing.T) {
+	projectRoot := t.TempDir()
+	globalRoot := t.TempDir()
+	projectFactoryDir := persistRuntimeNamedFactory(t, projectRoot, "alpha", "project-alpha")
+
+	resolution, err := ResolveNamedFactoryAcrossRoots(projectRoot, globalRoot, "alpha")
+	if err != nil {
+		t.Fatalf("ResolveNamedFactoryAcrossRoots(local): %v", err)
+	}
+
+	assertNamedFactoryResolution(t, resolution, "alpha", projectFactoryDir, NamedFactoryResolutionSourceProjectLocal, projectRoot, globalRoot)
+}
+
+func TestResolveNamedFactoryAcrossRoots_PrefersLocalFactoryOverGlobal(t *testing.T) {
+	projectRoot := t.TempDir()
+	globalRoot := t.TempDir()
+	projectFactoryDir := persistRuntimeNamedFactory(t, projectRoot, "alpha", "project-alpha")
+	persistRuntimeNamedFactory(t, globalRoot, "alpha", "global-alpha")
+
+	resolution, err := ResolveNamedFactoryAcrossRoots(projectRoot, globalRoot, "alpha")
+	if err != nil {
+		t.Fatalf("ResolveNamedFactoryAcrossRoots(conflict): %v", err)
+	}
+
+	assertNamedFactoryResolution(t, resolution, "alpha", projectFactoryDir, NamedFactoryResolutionSourceProjectLocal, projectRoot, globalRoot)
+	loaded, err := LoadRuntimeConfigFromFactoryDir(resolution.FactoryDir, nil)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfigFromFactoryDir(resolved local): %v", err)
+	}
+	if loaded.FactoryConfig().Project != "project-alpha" {
+		t.Fatalf("resolved project = %q, want project-alpha", loaded.FactoryConfig().Project)
+	}
+}
+
+func TestResolveNamedFactoryAcrossRoots_ReturnsGlobalWhenLocalMissing(t *testing.T) {
+	projectRoot := t.TempDir()
+	globalRoot := t.TempDir()
+	globalFactoryDir := persistRuntimeNamedFactory(t, globalRoot, "@you/tts", "global-tts")
+
+	factoryDir, err := ResolveNamedFactoryDirAcrossRoots(projectRoot, globalRoot, "@you/tts")
+	if err != nil {
+		t.Fatalf("ResolveNamedFactoryDirAcrossRoots(global): %v", err)
+	}
+	if factoryDir != globalFactoryDir {
+		t.Fatalf("resolved factory dir = %q, want %q", factoryDir, globalFactoryDir)
+	}
+}
+
+func TestResolveNamedFactoryAcrossRoots_SelectsOneFactoryFromMultipleNamedEntries(t *testing.T) {
+	projectRoot := t.TempDir()
+	globalRoot := t.TempDir()
+	persistRuntimeNamedFactory(t, projectRoot, "gamma", "project-gamma")
+	wantFactoryDir := persistRuntimeNamedFactory(t, projectRoot, "beta", "project-beta")
+	persistRuntimeNamedFactory(t, projectRoot, "alpha", "project-alpha")
+
+	entries, err := ListNamedFactories(projectRoot)
+	if err != nil {
+		t.Fatalf("ListNamedFactories(project root): %v", err)
+	}
+	if got := namedFactoryEntryNames(entries); len(got) != 3 || got[0] != "alpha" || got[1] != "beta" || got[2] != "gamma" {
+		t.Fatalf("project named factories = %#v, want deterministic alpha/beta/gamma ordering", got)
+	}
+
+	resolution, err := ResolveNamedFactoryAcrossRoots(projectRoot, globalRoot, "beta")
+	if err != nil {
+		t.Fatalf("ResolveNamedFactoryAcrossRoots(multiple): %v", err)
+	}
+	assertNamedFactoryResolution(t, resolution, "beta", wantFactoryDir, NamedFactoryResolutionSourceProjectLocal, projectRoot, globalRoot)
+}
+
+func TestResolveNamedFactoryAcrossRoots_ReturnsNotFoundWhenBothRootsMiss(t *testing.T) {
+	_, err := ResolveNamedFactoryAcrossRoots(t.TempDir(), t.TempDir(), "missing")
+	if err == nil {
+		t.Fatal("expected missing named factory to fail")
+	}
+	if !errors.Is(err, ErrFactoryLayoutNotFound) {
+		t.Fatalf("error = %v, want ErrFactoryLayoutNotFound", err)
+	}
+	if got := err.Error(); !containsAll(got, `resolve named factory "missing"`, "project root", "global root") {
+		t.Fatalf("expected cross-root not-found context, got %v", err)
+	}
+}
+
+func persistRuntimeNamedFactory(t *testing.T, rootDir, name, project string) string {
+	t.Helper()
+
+	factoryDir, err := PersistNamedFactory(rootDir, name, namedFactoryPayload(t, project))
+	if err != nil {
+		t.Fatalf("PersistNamedFactory(%s): %v", name, err)
+	}
+	return factoryDir
+}
+
+func assertNamedFactoryResolution(
+	t *testing.T,
+	resolution *NamedFactoryResolution,
+	name string,
+	factoryDir string,
+	source NamedFactoryResolutionSource,
+	projectRoot string,
+	globalRoot string,
+) {
+	t.Helper()
+
+	if resolution == nil {
+		t.Fatal("expected named factory resolution")
+	}
+	if resolution.Name != name {
+		t.Fatalf("resolution name = %q, want %q", resolution.Name, name)
+	}
+	if resolution.FactoryDir != factoryDir {
+		t.Fatalf("resolution factory dir = %q, want %q", resolution.FactoryDir, factoryDir)
+	}
+	if resolution.Source != source {
+		t.Fatalf("resolution source = %q, want %q", resolution.Source, source)
+	}
+	if resolution.ProjectRoot != filepath.Clean(projectRoot) {
+		t.Fatalf("resolution project root = %q, want %q", resolution.ProjectRoot, filepath.Clean(projectRoot))
+	}
+	if resolution.GlobalRoot != filepath.Clean(globalRoot) {
+		t.Fatalf("resolution global root = %q, want %q", resolution.GlobalRoot, filepath.Clean(globalRoot))
+	}
+}
+
+func namedFactoryEntryNames(entries []NamedFactoryListEntry) []string {
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name)
+	}
+	return names
+}

--- a/pkg/config/runtimetests/named_factory_resolution_test.go
+++ b/pkg/config/runtimetests/named_factory_resolution_test.go
@@ -86,11 +86,30 @@ func TestResolveNamedFactoryAcrossRoots_ReturnsNotFoundWhenBothRootsMiss(t *test
 	if err == nil {
 		t.Fatal("expected missing named factory to fail")
 	}
-	if !errors.Is(err, ErrFactoryLayoutNotFound) {
-		t.Fatalf("error = %v, want ErrFactoryLayoutNotFound", err)
+	if !errors.Is(err, ErrNamedFactoryNotFound) {
+		t.Fatalf("error = %v, want ErrNamedFactoryNotFound", err)
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("error = %v, want os.ErrNotExist", err)
 	}
 	if got := err.Error(); !containsAll(got, `resolve named factory "missing"`, "project root", "global root") {
 		t.Fatalf("expected cross-root not-found context, got %v", err)
+	}
+}
+
+func TestResolveNamedFactoryAcrossRoots_RejectsInvalidCanonicalName(t *testing.T) {
+	_, err := ResolveNamedFactoryAcrossRoots(t.TempDir(), t.TempDir(), "@you")
+	if err == nil {
+		t.Fatal("expected invalid named factory name to fail")
+	}
+	if !errors.Is(err, ErrInvalidNamedFactoryName) {
+		t.Fatalf("error = %v, want ErrInvalidNamedFactoryName", err)
+	}
+	if errors.Is(err, ErrNamedFactoryNotFound) {
+		t.Fatalf("error = %v, did not want ErrNamedFactoryNotFound", err)
+	}
+	if got := err.Error(); !containsAll(got, `invalid named factory name "@you"`, `must be scoped as @scope/name`) {
+		t.Fatalf("expected invalid-name error context, got %v", err)
 	}
 }
 
@@ -166,6 +185,22 @@ func TestResolveNamedFactoryAcrossRoots_ReportsCorruptMaterializedBuiltInTarget(
 	}
 	if got := err.Error(); !containsAll(got, `materialize built-in named factory "@you/tts"`, "existing target invalid", "find factory config") {
 		t.Fatalf("expected corrupt-target resolution error, got %v", err)
+	}
+}
+
+func TestResolveNamedFactoryAcrossRoots_ReturnsNotFoundForUnknownBuiltInName(t *testing.T) {
+	projectRoot := t.TempDir()
+	globalRoot := t.TempDir()
+
+	_, err := ResolveNamedFactoryAcrossRoots(projectRoot, globalRoot, "@you/missing")
+	if err == nil {
+		t.Fatal("expected unknown built-in name to fail")
+	}
+	if !errors.Is(err, ErrNamedFactoryNotFound) {
+		t.Fatalf("error = %v, want ErrNamedFactoryNotFound", err)
+	}
+	if got := err.Error(); strings.Contains(got, "materialize built-in named factory") || !containsAll(got, `resolve named factory "@you/missing"`, "project root", "global root") {
+		t.Fatalf("expected deterministic not-found error, got %v", err)
 	}
 }
 

--- a/pkg/config/runtimetests/runtime_config_named_factory_test.go
+++ b/pkg/config/runtimetests/runtime_config_named_factory_test.go
@@ -34,6 +34,157 @@ func TestPersistNamedFactory_WritesCanonicalNamedLayout(t *testing.T) {
 	}
 }
 
+func TestPersistNamedFactory_WritesScopedNamedLayout(t *testing.T) {
+	rootDir := t.TempDir()
+
+	factoryDir, err := PersistNamedFactory(rootDir, "@you/tts", namedFactoryPayload(t, "tts"))
+	if err != nil {
+		t.Fatalf("PersistNamedFactory(scoped): %v", err)
+	}
+
+	wantDir := filepath.Join(rootDir, "@you%2Ftts")
+	assertScopedNamedFactoryPaths(t, factoryDir, wantDir)
+
+	resolved, err := ResolveNamedFactoryDir(rootDir, "@you/tts")
+	if err != nil {
+		t.Fatalf("ResolveNamedFactoryDir(scoped): %v", err)
+	}
+	if resolved != wantDir {
+		t.Fatalf("resolved scoped factory = %q, want %q", resolved, wantDir)
+	}
+	assertScopedCurrentFactoryPointer(t, rootDir)
+	assertScopedNamedFactoryList(t, rootDir)
+}
+
+func assertScopedNamedFactoryPaths(t *testing.T, factoryDir, wantDir string) {
+	t.Helper()
+
+	if factoryDir != wantDir {
+		t.Fatalf("factory dir = %q, want %q", factoryDir, wantDir)
+	}
+	for _, path := range []string{
+		filepath.Join(factoryDir, interfaces.FactoryConfigFile),
+		filepath.Join(factoryDir, interfaces.WorkersDir, "executor", interfaces.FactoryAgentsFileName),
+		filepath.Join(factoryDir, interfaces.WorkstationsDir, "execute-tts", interfaces.FactoryAgentsFileName),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected scoped named-factory path %s: %v", path, err)
+		}
+	}
+}
+
+func assertScopedCurrentFactoryPointer(t *testing.T, rootDir string) {
+	t.Helper()
+
+	if err := WriteCurrentFactoryPointer(rootDir, "@you/tts"); err != nil {
+		t.Fatalf("WriteCurrentFactoryPointer(scoped): %v", err)
+	}
+	pointerBytes, err := os.ReadFile(filepath.Join(rootDir, interfaces.CurrentFactoryPointerFile))
+	if err != nil {
+		t.Fatalf("ReadFile(current pointer): %v", err)
+	}
+	if got := string(pointerBytes); got != "@you%2Ftts\n" {
+		t.Fatalf("current pointer content = %q, want encoded scoped segment", got)
+	}
+	current, err := ReadCurrentFactoryPointer(rootDir)
+	if err != nil {
+		t.Fatalf("ReadCurrentFactoryPointer(scoped): %v", err)
+	}
+	if current != "@you/tts" {
+		t.Fatalf("current scoped factory = %q, want @you/tts", current)
+	}
+}
+
+func assertScopedNamedFactoryList(t *testing.T, rootDir string) {
+	t.Helper()
+
+	entries, err := ListNamedFactories(rootDir)
+	if err != nil {
+		t.Fatalf("ListNamedFactories(scoped): %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name != "@you/tts" || !entries[0].Current {
+		t.Fatalf("scoped list entries = %#v, want current @you/tts", entries)
+	}
+}
+
+func TestNamedFactoryNameLayoutSegment_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name        string
+		wantSegment string
+	}{
+		{name: "alpha", wantSegment: "alpha"},
+		{name: "@you/tts", wantSegment: "@you%2Ftts"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			segment, err := NamedFactoryNameToLayoutSegment(tt.name)
+			if err != nil {
+				t.Fatalf("NamedFactoryNameToLayoutSegment: %v", err)
+			}
+			if segment != tt.wantSegment {
+				t.Fatalf("segment = %q, want %q", segment, tt.wantSegment)
+			}
+			if strings.ContainsAny(segment, `/\`) {
+				t.Fatalf("segment %q must not contain path separators", segment)
+			}
+			roundTrip, err := NamedFactoryLayoutSegmentToName(segment)
+			if err != nil {
+				t.Fatalf("NamedFactoryLayoutSegmentToName: %v", err)
+			}
+			if roundTrip != tt.name {
+				t.Fatalf("round trip = %q, want %q", roundTrip, tt.name)
+			}
+		})
+	}
+}
+
+func TestNamedFactoryNameLayoutSegment_RejectsInvalidNames(t *testing.T) {
+	tests := []string{
+		"../alpha",
+		"@you",
+		"@you/",
+		"@you/tts/extra",
+	}
+
+	for _, name := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := NamedFactoryNameToLayoutSegment(name); err == nil {
+				t.Fatal("expected invalid canonical factory name to fail")
+			}
+		})
+	}
+}
+
+func TestDefaultNamedFactoryRoots(t *testing.T) {
+	homeDir := filepath.Join("home", "customer")
+	globalRoot, err := GlobalNamedFactoryRootForHome(homeDir)
+	if err != nil {
+		t.Fatalf("GlobalNamedFactoryRootForHome: %v", err)
+	}
+	if want := filepath.Join(homeDir, ".you-agent-factory", "factories"); globalRoot != want {
+		t.Fatalf("global root = %q, want %q", globalRoot, want)
+	}
+
+	testHomeDir := t.TempDir()
+	t.Setenv("HOME", testHomeDir)
+	defaultGlobalRoot, err := DefaultGlobalNamedFactoryRoot()
+	if err != nil {
+		t.Fatalf("DefaultGlobalNamedFactoryRoot: %v", err)
+	}
+	if want := filepath.Join(testHomeDir, ".you-agent-factory", "factories"); defaultGlobalRoot != want {
+		t.Fatalf("default global root = %q, want %q", defaultGlobalRoot, want)
+	}
+
+	projectRoot, err := DefaultProjectNamedFactoryRoot(filepath.Join("repo", "app"))
+	if err != nil {
+		t.Fatalf("DefaultProjectNamedFactoryRoot: %v", err)
+	}
+	if want := filepath.Join("repo", "app", "factory"); projectRoot != want {
+		t.Fatalf("project root = %q, want %q", projectRoot, want)
+	}
+}
+
 func TestPersistNamedFactory_PreservesVersionMetadataAcrossLoadRoundTrip(t *testing.T) {
 	rootDir := t.TempDir()
 	versionTime := time.Date(2026, 5, 23, 11, 45, 0, 0, time.UTC)

--- a/pkg/config/runtimetests/runtime_config_named_factory_test.go
+++ b/pkg/config/runtimetests/runtime_config_named_factory_test.go
@@ -2,6 +2,7 @@ package runtimetests
 
 import (
 	"encoding/json"
+	"errors"
 	. "github.com/portpowered/infinite-you/pkg/config"
 	"os"
 	"path/filepath"
@@ -487,6 +488,9 @@ func TestValidateNamedFactoryName_RejectsPathTraversal(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected invalid named-factory segment to fail")
 	}
+	if !IsInvalidNamedFactoryName(err) {
+		t.Fatalf("error = %v, want IsInvalidNamedFactoryName", err)
+	}
 	if got := err.Error(); !containsAll(got, `factory name "../beta"`, "cannot contain path separators") {
 		t.Fatalf("expected path-separator validation error, got %v", err)
 	}
@@ -502,7 +506,13 @@ func TestResolveNamedFactoryDir_RejectsDirectoryWithoutFactoryConfig(t *testing.
 	if err == nil {
 		t.Fatal("expected missing named factory config to fail")
 	}
-	if got := err.Error(); !containsAll(got, `resolve factory "beta"`, "find factory config") {
+	if !errors.Is(err, ErrNamedFactoryNotFound) {
+		t.Fatalf("error = %v, want ErrNamedFactoryNotFound", err)
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("error = %v, want os.ErrNotExist", err)
+	}
+	if got := err.Error(); !containsAll(got, `resolve named factory "beta"`, "root", `named factory "beta" not found`) {
 		t.Fatalf("expected missing-config resolution error, got %v", err)
 	}
 }

--- a/pkg/service/factorysave/persist.go
+++ b/pkg/service/factorysave/persist.go
@@ -94,6 +94,9 @@ func mapUpsertNamedFactoryPersistError(err error) error {
 
 func isNamedFactoryResolveNotFound(err error) bool {
 	for err != nil {
+		if factoryconfig.IsNamedFactoryNotFound(err) {
+			return true
+		}
 		if errors.Is(err, os.ErrNotExist) {
 			return true
 		}

--- a/tests/functional/smoke/cli_factory_prompt_run_smoke_test.go
+++ b/tests/functional/smoke/cli_factory_prompt_run_smoke_test.go
@@ -202,6 +202,94 @@ func TestFactoryPromptRun_RealCLIAmbiguousPromptAndStdinFailsBeforeRuntimeStartu
 	}
 }
 
+func TestNamedFactoryRun_RealCLIResolvesGlobalFactoryFromUnrelatedWorkingDirectory(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow CLI named-factory run smoke")
+	}
+
+	homeDir := t.TempDir()
+
+	sourceDir := support.ScaffoldFactory(t, factoryPromptRunSmokeConfig())
+	loaded, err := factoryconfig.LoadRuntimeConfig(sourceDir, nil)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfig(source): %v", err)
+	}
+	canonical, err := factoryconfig.MarshalCanonicalFactoryConfig(loaded.FactoryConfig())
+	if err != nil {
+		t.Fatalf("MarshalCanonicalFactoryConfig: %v", err)
+	}
+	globalRoot := filepath.Join(homeDir, ".you-agent-factory", "factories")
+	namedFactoryDir, err := factoryconfig.PersistNamedFactory(globalRoot, "alpha", canonical)
+	if err != nil {
+		t.Fatalf("PersistNamedFactory(alpha): %v", err)
+	}
+
+	prompt := fmt.Sprintf("functional-smoke-named-factory-%d", time.Now().UnixNano())
+	testutil.WriteSeedRequest(t, namedFactoryDir, interfaces.SubmitRequest{
+		WorkID:     "named-factory-smoke-work",
+		WorkTypeID: defaultPromptRunWorkTypeName,
+		TraceID:    "named-factory-smoke-trace",
+		Payload:    []byte(prompt),
+	})
+
+	port, err := reserveLocalTCPPort()
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	mockWorkersPath := writeDefaultMockWorkersConfig(t)
+	binaryPath := buildYouCLIBinary(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	unrelatedWorkingDir := t.TempDir()
+	cmd := exec.CommandContext(
+		ctx,
+		binaryPath,
+		"run",
+		"--named", "alpha",
+		"--with-mock-workers",
+		"--no-record",
+		"--server", baseURL,
+		"--continuously",
+		"--quiet",
+		mockWorkersPath,
+	)
+	cmd.Dir = unrelatedWorkingDir
+	cmd.Env = append(os.Environ(), "HOME="+homeDir)
+
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start you run --named: %v", err)
+	}
+
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- cmd.Wait()
+	}()
+
+	item, err := waitForFactoryPromptWorkComplete(ctx, baseURL, defaultPromptRunWorkTypeName, prompt, 20*time.Second)
+	if err != nil {
+		if waitErr := <-waitCh; waitErr != nil {
+			t.Fatalf("you run --named: %v\nstdout:\n%s\nstderr:\n%s", waitErr, stdout.String(), stderr.String())
+		}
+		t.Fatalf("wait for completed named-factory work: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+	if stringPointerValue(item.WorkTypeName) != defaultPromptRunWorkTypeName {
+		t.Fatalf("work type = %q, want %q", stringPointerValue(item.WorkTypeName), defaultPromptRunWorkTypeName)
+	}
+	if !factoryPromptRunWorkContentIncludes(item, prompt) {
+		t.Fatalf("work content = %#v, want prompt text %q", item.Content, prompt)
+	}
+
+	cancel()
+	_ = <-waitCh
+}
+
 const defaultPromptRunWorkTypeName = "prompt-task"
 
 func factoryPromptRunSmokeConfig() map[string]any {


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/named-factory-resolution-and-built-ins",
  "description": "Add canonical named-factory invocation via `you run --named <factory-name>` with local-over-global resolution, lazy materialization of first-party built-ins such as `@you/tts` into an editable global factory root under ~/.you-agent-factory/factories, deterministic not-found errors, and observable resolution diagnostics—aligned with existing persisted named-factory layout.",
  "context": {
    "customerAsk": "Add a canonical named-factory invocation path so customers can run first-party or customized factories from anywhere with `you run --named <factory-name>`. Support editable built-ins on disk, local-over-global precedence, and predictable resolution behavior consistent with existing persisted factory concepts.",
    "problem": "Customers must manually locate factory.json and pass --dir or --factory to run. Packaged first-party factories like @you/tts are not invocable by name, are not materialized into a customer-owned global root, and there is no documented local-over-global precedence when the same name exists in project and global roots.",
    "solution": "Introduce scoped factory names, a global factory root at ~/.you-agent-factory/factories, lazy built-in materialization via the existing PersistNamedFactory pipeline, and a cross-root resolver that checks project factory/ before the global root. Wire you run --named to resolution and existing run startup. Emit structured diagnostics and metrics for resolution source, precedence, and materialization."
  },
  "acceptanceCriteria": [
    "`you run --named <name>` resolves and runs a named factory without requiring `--dir` or `--factory`.",
    "Project-local named factories override global named factories with the same canonical name; resolution never silently merges definitions.",
    "First-party built-ins such as `@you/tts` materialize under the customer-owned global factory root and load from disk on later invocations; customer edits affect the next invocation.",
    "Unknown named factories produce one deterministic not-found error naming the requested factory.",
    "Resolution, precedence, and materialization are observable through structured logs and targeted metrics where instrumented.",
    "Existing named-factory persist commands (`you factory save`, `update`, `delete`, `list` with explicit `--dir`) remain aligned with ResolveNamedFactoryDir and .current-factory semantics.",
    "Quality gate: typecheck, lint, and tests pass for all touched packages."
  ],
  "userStories": [
    {
      "id": "prd-named-factory-resolution-and-built-ins-001",
      "title": "Scoped factory names and global root layout",
      "description": "As a maintainer, I want canonical scoped factory names and a stable global factory root so that built-in names like @you/tts can be represented safely on disk.",
      "acceptanceCriteria": [
        "Canonical factory names accept persisted simple names (for example alpha) and scoped built-in names (for example @you/tts).",
        "Scoped names map to safe single-segment on-disk directory names under a factory root without path separators or traversal.",
        "Round-trip helpers convert between canonical display names and on-disk segments for list, save, and resolve operations.",
        "Default global factory root is ~/.you-agent-factory/factories, following the same home-directory discovery pattern as runtime logs and recordings.",
        "Default project-local factory root for resolution remains ./factory relative to the caller working directory unless overridden by existing --dir semantics on other commands.",
        "Unit tests cover name validation, encoding round-trip, and global-root path building.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-named-factory-resolution-and-built-ins-002",
      "title": "Cross-root named factory resolution with local-over-global precedence",
      "description": "As a customer, I want the resolver to search my project before the global root so that repository-specific customization wins predictably.",
      "acceptanceCriteria": [
        "A resolver function returns the runnable factory directory for a canonical name by checking the project-local root first, then the global root.",
        "When both roots contain the same canonical name, the project-local factory directory is selected.",
        "Resolution does not merge local and global definitions; it selects exactly one directory.",
        "The resolver reuses existing ResolveNamedFactoryDir and requireFactoryConfig validation for each candidate root.",
        "Multiple named factories under one root are discovered deterministically via existing ListNamedFactories ordering semantics.",
        "Unit tests cover one local named factory, one local and one global conflicting factory proving precedence, and multiple named factories under one root.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-named-factory-resolution-and-built-ins-003",
      "title": "Built-in catalog and lazy materialization",
      "description": "As a customer, I want first-party built-ins materialized on disk so that I can inspect and modify them without reinstalling the CLI.",
      "acceptanceCriteria": [
        "A built-in catalog registers at least @you/tts with an embedded canonical factory payload suitable for PersistNamedFactory.",
        "On first resolution of a registered built-in absent from the global root, the system materializes the built-in under ~/.you-agent-factory/factories using the existing named-factory persist pipeline.",
        "Subsequent resolutions load the on-disk materialized factory without re-copying unchanged content.",
        "Customer edits to files under the materialized built-in directory change the next invocation result.",
        "Invalid or corrupt materialization targets return a clear error without panicking.",
        "Lazy materialization is the default behavior (built-ins are prepared on first named invocation, not at CLI install time).",
        "Unit and functional tests cover first-run materialization and edit-after-materialize reload.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-named-factory-resolution-and-built-ins-004",
      "title": "Deterministic not-found and invalid-name errors",
      "description": "As a customer, I want resolution failures to be explicit so that I can tell whether a factory name is unknown, invalid, or malformed.",
      "acceptanceCriteria": [
        "Unknown named factories return a stable not-found error that includes the requested canonical name and indicates that neither the project-local nor global root contained a matching factory.",
        "Invalid canonical names return validation errors distinct from not-found.",
        "Built-in names missing from the catalog return not-found, not a partial materialization.",
        "CLI and programmatic callers surface the same error semantics without ad-hoc string rewriting.",
        "Unit tests cover not-found, invalid-name, and missing-catalog cases.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-named-factory-resolution-and-built-ins-005",
      "title": "`you run --named` invocation from any working directory",
      "description": "As a customer, I want to run `you run --named @you/tts` from any working directory so that I can use a packaged factory without locating factory.json.",
      "acceptanceCriteria": [
        "`you run` accepts `--named <canonical-name>` distinct from `--factory <path>` and `--dir <root>`.",
        "`--named` is mutually exclusive with `--dir` and `--factory`; conflicting flags return a clear usage error.",
        "Successful resolution sets the run factory directory to the resolved named factory path and starts the runtime using existing you run startup behavior.",
        "`you run --named <name>` works from a working directory that does not contain the resolved factory tree.",
        "CLI tests assert flag parsing, mutual exclusion, and successful handoff of the resolved directory into RunConfig.",
        "Functional test runs you run --named against a temp global built-in with mock workers or an equivalent short-lived run proof.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-named-factory-resolution-and-built-ins-006",
      "title": "Resolution diagnostics, logging, and metrics",
      "description": "As a maintainer, I want resolution and materialization to be observable so that I can debug precedence and built-in preparation.",
      "acceptanceCriteria": [
        "Verbose or debug CLI diagnostics log the selected resolution source (local, global, or builtin-materialized), canonical factory name, and resolved factory directory.",
        "When local overrides global, diagnostics or structured logs record a precedence decision without implying a merge.",
        "Built-in materialization emits a structured log line naming the canonical built-in and target global directory on first materialization.",
        "When metrics instrumentation is present in the touched path, emit counters for named-factory resolution, built-in materialization, not-found outcomes, and local-over-global precedence decisions.",
        "Logs and metrics never include prompt text or other sensitive factory payload content.",
        "Tests assert diagnostic output or structured log fields for at least one local-over-global and one materialization scenario.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-named-factory-resolution-and-built-ins-007",
      "title": "Factory list and customer reference documentation",
      "description": "As a customer, I want list and reference docs to explain where named factories live and how precedence works.",
      "acceptanceCriteria": [
        "`you factory list` help or output documents that global built-ins live under ~/.you-agent-factory/factories while project factories live under --dir (default factory/).",
        "When listing with default project root, output distinguishes project-local entries from global built-ins if both are shown, or help text clearly states list scope.",
        "`you run --help` documents --named, precedence (local over global), and built-in editability.",
        "Reference documentation in docs/reference/ adds a section on named-factory invocation, global built-in root, precedence, and lazy materialization.",
        "CLI docs tests cover new help strings where the repo already asserts command help content.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 7,
      "passes": true,
      "notes": ""
    },
    {
      "id": "prd-named-factory-resolution-and-built-ins-008",
      "title": "Stream-aware regression and scenario coverage",
      "description": "As a reviewer, I want targeted verification across CLI, backend config, and logs so that named-factory resolution is trustworthy and aligned with existing persist behavior.",
      "acceptanceCriteria": [
        "Coverage includes one local named factory, one local and one global conflicting factory, and multiple named factories under one root.",
        "Coverage includes named factory not found, invalid built-in materialization target, and lazy materialization while built-in is being prepared.",
        "Named-factory resolution integrates with existing .current-factory and ResolveCurrentFactoryDir semantics without breaking you factory save, update, or delete under an explicit --dir.",
        "No public OpenAPI contract changes are required; dashboard UI behavior is unchanged.",
        "Reusable validation or lint-style checks enforce built-in layout and scoped-name rules where ad-hoc string handling would be brittle.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 8,
      "passes": true,
      "notes": ""
    }
  ]
}
