### PR TITLE
request-authored-text-alias-retirement

### DIFF
--- a/ui/src/features/current-selection/base/components/request-authored-text.test.tsx
+++ b/ui/src/features/current-selection/base/components/request-authored-text.test.tsx
@@ -1,8 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import {
-  AuthoredBodyText,
-  RequestAuthoredText,
-} from "../../../../lib/authored-body-text";
+import { AuthoredBodyText } from "../../../../lib/authored-body-text";
 
 describe("AuthoredBodyText", () => {
   it("renders headings, lists, inline code, and fenced code blocks for markdown-authored request text", () => {
@@ -72,13 +69,5 @@ describe("AuthoredBodyText", () => {
     expect(container.querySelector("script")).toBeNull();
     expect(container.textContent).toContain("<button>danger</button>");
     expect(container.textContent).toContain('<script>alert("xss")</script>');
-  });
-
-  it("keeps the request-authored wrapper aligned with the shared formatter", () => {
-    render(<RequestAuthoredText value="## Review checklist" />);
-
-    expect(
-      screen.getByRole("heading", { level: 2, name: "Review checklist" }),
-    ).toBeTruthy();
   });
 });

--- a/ui/src/lib/authored-body-text.tsx
+++ b/ui/src/lib/authored-body-text.tsx
@@ -52,10 +52,6 @@ export function AuthoredBodyText({
   );
 }
 
-export function RequestAuthoredText({ value }: { value: string }) {
-  return <AuthoredBodyText value={value} />;
-}
-
 function parseRequestAuthoredBlocks(value: string): RequestAuthoredBlock[] {
   const lines = value.split(/\r?\n/);
   const blocks: RequestAuthoredBlock[] = [];


### PR DESCRIPTION
{
  "project": "Request Authored Text Alias Retirement",
  "branchName": "ralph/request-authored-text-alias-retirement",
  "description": "Remove the dead RequestAuthoredText wrapper export from the shared authored-markdown module and consolidate test coverage on the canonical AuthoredBodyText renderer, with no change to observable markdown rendering behavior.",
  "context": {
    "customerAsk": "Remove the dead RequestAuthoredText wrapper from ui/src/lib/authored-body-text.tsx and keep the authored-markdown rendering surface anchored on AuthoredBodyText.",
    "problem": "RequestAuthoredText is a pass-through alias with no distinct behavior, styling, or ownership. Only its test coverage references it; production callers already import AuthoredBodyText directly. Keeping both exports preserves a redundant naming seam in a shared formatting surface.",
    "solution": "Delete the RequestAuthoredText export, retarget authored-text tests to exercise AuthoredBodyText directly, and leave markdown parsing, shell classes, and HTML-safety behavior unchanged."
  },
  "acceptanceCriteria": [
    "ui/src/lib/authored-body-text.tsx exports only the canonical authored-text renderer needed by live callers; RequestAuthoredText is removed",
    "No production or test imports reference RequestAuthoredText",
    "Authored markdown rendering behavior is unchanged through AuthoredBodyText: headings, lists, inline and fenced code, plain-text fallback, and inert raw HTML",
    "Existing shell styling and HTML-safety assertions in authored-text tests still pass against AuthoredBodyText",
    "Live production callers continue to use AuthoredBodyText without behavior changes",
    "Frontend typecheck, lint, and tests pass with no regressions"
  ],
  "userStories": [
    {
      "id": "request-authored-text-alias-retirement-001",
      "title": "Retarget authored-text tests to AuthoredBodyText",
      "description": "As a maintainer, I want authored-text behavioral tests to target AuthoredBodyText directly so test coverage reflects the canonical renderer instead of a dead alias.",
      "acceptanceCriteria": [
        "request-authored-text.test.tsx imports and renders AuthoredBodyText only; it does not import RequestAuthoredText",
        "The wrapper-parity test case is removed; behavioral coverage for headings, lists, inline and fenced code, plain-text fallback, and inert raw HTML remains on AuthoredBodyText",
        "Shell class assertions for border, surface, and code styling still pass against the rendered AuthoredBodyText container",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "request-authored-text-alias-retirement-002",
      "title": "Remove RequestAuthoredText export",
      "description": "As a maintainer, I want the authored-text module to expose a single canonical renderer so future callers cannot accidentally depend on a redundant alias.",
      "acceptanceCriteria": [
        "RequestAuthoredText is deleted from ui/src/lib/authored-body-text.tsx; AuthoredBodyText and REQUEST_AUTHORED_TEXT_CLASS remain exported unchanged",
        "Repository search shows no remaining imports of RequestAuthoredText in production or test code",
        "Live callers in work content, provider session detail, and inference attempt surfaces continue to render authored markdown with no behavior change",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
