### PR TITLE
work-chart-card-alias-retirement

### DIFF
--- a/ui/src/features/bento/components/dashboard-widget-header-seam.test.tsx
+++ b/ui/src/features/bento/components/dashboard-widget-header-seam.test.tsx
@@ -10,7 +10,7 @@ import { getTerminalWorkMessages } from "../../terminal-work/messages/terminal-w
 import { TerminalWorkWidget } from "../../terminal-work/public";
 import { TraceDrilldownWidget } from "../../trace-drilldown/components/trace-drilldown-widget";
 import { getTraceDrilldownMessages } from "../../trace-drilldown/messages/trace-drilldown";
-import { D3CompletionInformationCard } from "../../work-outcome/components/d3-information-card";
+import { WorkChartCard } from "../../work-outcome/components/d3-information-card";
 import type { WorkChartModel } from "../../work-outcome/lib/trends";
 
 const minimalWorkChartModel: WorkChartModel = {
@@ -120,7 +120,7 @@ describe("dashboard widget header seam", () => {
 
   it("routes work outcome chart through the shared bento card header", () => {
     renderBentoWidget(
-      <D3CompletionInformationCard
+      <WorkChartCard
         headerAction={<button type="button">Remove chart</button>}
         model={minimalWorkChartModel}
       />,

--- a/ui/src/features/work-outcome/components/d3-information-card.stories.tsx
+++ b/ui/src/features/work-outcome/components/d3-information-card.stories.tsx
@@ -15,7 +15,7 @@ import {
 import { dragWorkChart } from "../lib/work-chart-zoom-story-contract";
 import { expectSingleWorkOutcomeCardHeader } from "../lib/work-outcome-card-header-contract";
 import { getWorkOutcomeMessages } from "../messages/work-outcome";
-import { D3CompletionInformationCard } from "./d3-information-card";
+import { WorkChartCard } from "./d3-information-card";
 import type { WorkChartState } from "./work-chart";
 import { WorkOutcomeWidget } from "./work-outcome-widget";
 
@@ -258,7 +258,7 @@ function renderResizableWorkOutcomeStoryShell({
             id: "work-outcome-chart",
             widgetType: "work-outcome-chart",
             children: chartState ? (
-              <D3CompletionInformationCard
+              <WorkChartCard
                 chartState={chartState}
                 model={model}
                 widgetId="work-outcome-chart-story"
@@ -346,14 +346,14 @@ async function expectStatusPanelResizeChrome(
 
 export default {
   title: "Agent Factory/Dashboard/Work Outcome Chart Card",
-  component: D3CompletionInformationCard,
+  component: WorkChartCard,
 };
 
 export const Populated = {
   render: () =>
     renderWorkOutcomeStoryShell({
       children: (
-        <D3CompletionInformationCard
+        <WorkChartCard
           model={populatedTrend}
           widgetId="work-outcome-chart-story"
         />
@@ -374,7 +374,7 @@ export const EmptyData = {
   render: () =>
     renderWorkOutcomeStoryShell({
       children: (
-        <D3CompletionInformationCard
+        <WorkChartCard
           model={emptyTrend}
           widgetId="work-outcome-chart-empty-story"
         />
@@ -401,7 +401,7 @@ export const LoadingData = {
   render: () =>
     renderWorkOutcomeStoryShell({
       children: (
-        <D3CompletionInformationCard
+        <WorkChartCard
           chartState={{ status: "loading" }}
           model={emptyTrend}
           widgetId="work-outcome-chart-loading-story"
@@ -431,7 +431,7 @@ export const ErrorState = {
   render: () =>
     renderWorkOutcomeStoryShell({
       children: (
-        <D3CompletionInformationCard
+        <WorkChartCard
           chartState={{ status: "error" }}
           model={emptyTrend}
           widgetId="work-outcome-chart-error-story"
@@ -461,7 +461,7 @@ export const ConstrainedWidth = {
   render: () =>
     renderWorkOutcomeStoryShell({
       children: (
-        <D3CompletionInformationCard
+        <WorkChartCard
           model={populatedTrend}
           widgetId="work-outcome-chart-narrow-story"
         />
@@ -484,7 +484,7 @@ export const LocalizedZhCN = {
   render: () =>
     renderWorkOutcomeStoryShell({
       children: (
-        <D3CompletionInformationCard
+        <WorkChartCard
           locale="zh-CN"
           model={populatedTrend}
           widgetId="work-outcome-chart-zh-cn-story"
@@ -525,7 +525,7 @@ export const ZoomInteraction = {
   render: () =>
     renderWorkOutcomeStoryShell({
       children: (
-        <D3CompletionInformationCard
+        <WorkChartCard
           model={populatedTrend}
           widgetId="work-outcome-chart-zoom-story"
         />

--- a/ui/src/features/work-outcome/components/d3-information-card.test.tsx
+++ b/ui/src/features/work-outcome/components/d3-information-card.test.tsx
@@ -18,7 +18,7 @@ import {
   expectWorkOutcomeCardFillsChartBody,
 } from "../lib/work-outcome-card-header-contract";
 import { getWorkOutcomeMessages } from "../messages/work-outcome";
-import { D3CompletionInformationCard } from "./d3-information-card";
+import { WorkChartCard } from "./d3-information-card";
 
 const populatedTrend: WorkChartModel = {
   delta: {
@@ -210,7 +210,7 @@ const emptyTrend: WorkChartModel = {
   series: [],
 };
 
-describe("D3CompletionInformationCard", () => {
+describe("WorkChartCard", () => {
   const restoreBrowserShims = installDashboardBrowserTestShims();
 
   afterAll(() => {
@@ -224,7 +224,7 @@ describe("D3CompletionInformationCard", () => {
   it("keeps the bento header while leaving the chart region titleless", () => {
     const messages = getWorkOutcomeMessages();
     render(
-      <D3CompletionInformationCard
+      <WorkChartCard
         headerAction={<button type="button">Remove chart</button>}
         model={populatedTrend}
         widgetId="work-outcome-chart"
@@ -245,7 +245,7 @@ describe("D3CompletionInformationCard", () => {
   it("flattens ready-state chart chrome without duplicating the bento card title", () => {
     const messages = getWorkOutcomeMessages();
     render(
-      <D3CompletionInformationCard
+      <WorkChartCard
         model={populatedTrend}
         widgetId="work-outcome-chart"
       />,
@@ -281,7 +281,7 @@ describe("D3CompletionInformationCard", () => {
 
   it("renders a shared-chart accessible work outcome visualization from dashboard samples", () => {
     render(
-      <D3CompletionInformationCard
+      <WorkChartCard
         model={populatedTrend}
         widgetId="work-outcome-chart"
       />,
@@ -340,7 +340,7 @@ describe("D3CompletionInformationCard", () => {
 
   it("toggles chart lines when the legend controls are clicked", () => {
     render(
-      <D3CompletionInformationCard
+      <WorkChartCard
         model={populatedTrend}
         widgetId="work-outcome-chart"
       />,
@@ -382,7 +382,7 @@ describe("D3CompletionInformationCard", () => {
   });
 
   it("renders an explicit empty state without a chart when samples are unavailable", () => {
-    render(<D3CompletionInformationCard model={emptyTrend} />);
+    render(<WorkChartCard model={emptyTrend} />);
 
     expect(
       screen.queryByRole("img", { name: "Work outcome chart for 15m" }),
@@ -408,7 +408,7 @@ describe("D3CompletionInformationCard", () => {
 
   it("renders an explicit loading state without dropping chart summary controls", () => {
     render(
-      <D3CompletionInformationCard
+      <WorkChartCard
         chartState={{ status: "loading" }}
         model={emptyTrend}
       />,
@@ -439,7 +439,7 @@ describe("D3CompletionInformationCard", () => {
   it("preserves compact legend, axis labels, and legend placement in embedded bento layout", () => {
     const messages = getWorkOutcomeMessages();
     render(
-      <D3CompletionInformationCard
+      <WorkChartCard
         model={zoomableTrend}
         widgetId="work-outcome-chart"
       />,
@@ -521,7 +521,7 @@ describe("D3CompletionInformationCard", () => {
     const user = userEvent.setup();
     const messages = getWorkOutcomeMessages();
     render(
-      <D3CompletionInformationCard
+      <WorkChartCard
         model={zoomableTrend}
         widgetId="work-outcome-chart"
       />,
@@ -574,7 +574,7 @@ describe("D3CompletionInformationCard", () => {
 
   it("renders an explicit error state with the card landmark preserved", () => {
     render(
-      <D3CompletionInformationCard
+      <WorkChartCard
         chartState={{ status: "error" }}
         model={emptyTrend}
       />,

--- a/ui/src/features/work-outcome/components/d3-information-card.tsx
+++ b/ui/src/features/work-outcome/components/d3-information-card.tsx
@@ -81,5 +81,3 @@ export function WorkChartCard({
     </DashboardWidgetFrame>
   );
 }
-
-export const D3CompletionInformationCard = WorkChartCard;

--- a/ui/src/features/work-outcome/lib/work-chart-legend-contract.ts
+++ b/ui/src/features/work-outcome/lib/work-chart-legend-contract.ts
@@ -1,6 +1,5 @@
-import "@testing-library/jest-dom/vitest";
+import { expect } from "storybook/test";
 import { within } from "@testing-library/react";
-import { expect } from "vitest";
 
 const DEFAULT_WORK_CHART_SERIES_LABELS = [
   "Queued",

--- a/ui/src/features/work-outcome/lib/work-outcome-card-header-contract.ts
+++ b/ui/src/features/work-outcome/lib/work-outcome-card-header-contract.ts
@@ -1,6 +1,5 @@
-import "@testing-library/jest-dom/vitest";
+import { expect } from "storybook/test";
 import { within } from "@testing-library/react";
-import { expect } from "vitest";
 
 export function expectSingleWorkOutcomeCardHeader(
   card: HTMLElement,


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/work-chart-card-alias-retirement",
  "description": "Retire the dead D3CompletionInformationCard alias from the work-outcome chart card module and consolidate tests and Storybook stories on the canonical WorkChartCard component without changing observable dashboard chart behavior.",
  "context": {
    "customerAsk": "Remove the dead D3CompletionInformationCard wrapper export from the work-outcome chart card module and consolidate stories/tests on the canonical WorkChartCard component, with no change to observable dashboard chart rendering behavior.",
    "problem": "D3CompletionInformationCard in ui/src/features/work-outcome/components/d3-information-card.tsx is only a pass-through alias for WorkChartCard, but Storybook stories and test files still reference it. That preserves a redundant legacy naming seam with no distinct behavior, styling, or runtime ownership.",
    "solution": "Delete the D3CompletionInformationCard export, retarget stories and tests to import and exercise WorkChartCard directly, keep the existing chart card behavioral assertions intact, and verify that chart rendering, localization, framing, and accessibility behavior remain unchanged."
  },
  "acceptanceCriteria": [
    "ui/src/features/work-outcome/components/d3-information-card.tsx exports only WorkChartCard and WorkChartCardProps; D3CompletionInformationCard is removed.",
    "No production, story, or test import under ui/src references D3CompletionInformationCard.",
    "Dashboard work-outcome chart rendering remains unchanged through WorkChartCard, including series labels, locale handling, widget framing, embedded chart presentation, and accessibility labels.",
    "Existing behavioral assertions in ui/src/features/work-outcome/components/d3-information-card.test.tsx, ui/src/features/bento/components/dashboard-widget-header-seam.test.tsx, and ui/src/features/work-outcome/components/work-chart.test.tsx still pass against WorkChartCard.",
    "Storybook work-outcome chart card stories render through WorkChartCard with no behavior change in chart chrome, localized labels, or header contract assertions.",
    "Repo verification with rg D3CompletionInformationCard returns no matches after the cleanup.",
    "Quality gate: frontend typecheck, lint, and relevant tests pass."
  ],
  "userStories": [
    {
      "id": "work-chart-card-alias-retirement-001",
      "title": "Retire the legacy chart-card alias from runtime and test surfaces",
      "description": "As a frontend maintainer, I want WorkChartCard to be the only chart-card export and test target so the work-outcome feature has one canonical component surface with no dead compatibility alias.",
      "acceptanceCriteria": [
        "ui/src/features/work-outcome/components/d3-information-card.tsx removes D3CompletionInformationCard and exports only WorkChartCard plus WorkChartCardProps.",
        "ui/src/features/work-outcome/components/d3-information-card.test.tsx imports and renders WorkChartCard directly while preserving its existing chart card, localization, header, legend, and accessibility assertions.",
        "ui/src/features/bento/components/dashboard-widget-header-seam.test.tsx imports WorkChartCard directly and continues to verify the same dashboard widget header seam contract.",
        "ui/src/features/work-outcome/components/work-chart.test.tsx continues to exercise the embedded card path through WorkChartCard with no assertion weakening.",
        "The chart card continues to render the same series labels, localized card title and region label, widget framing, and embedded chart presentation for unchanged fixture models.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "work-chart-card-alias-retirement-002",
      "title": "Retarget Storybook chart-card stories and prove alias removal end to end",
      "description": "As a maintainer, I want work-outcome Storybook stories and repo verification to use WorkChartCard directly so the retired alias is fully removed without changing observable chart-card behavior.",
      "acceptanceCriteria": [
        "ui/src/features/work-outcome/components/d3-information-card.stories.tsx imports WorkChartCard, sets the story component to WorkChartCard, and renders all existing variants through the canonical component.",
        "Storybook play functions continue to verify the same chart card behavior, including axis labels, legend contract, single-header contract, localized zh-CN copy, and resizable embedded chart presentation.",
        "Running rg D3CompletionInformationCard from the repo root returns no matches.",
        "No new compatibility wrapper, alternate alias, or unrelated work-outcome chart refactor is introduced as part of the cleanup.",
        "Verify in browser using dev-browser skill",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)