### PR TITLE
twenty-node-snapshot-alias-retirement

### DIFF
--- a/ui/src/App.layout-graph.test.tsx
+++ b/ui/src/App.layout-graph.test.tsx
@@ -1,10 +1,10 @@
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { DASHBOARD_WIDGET_IDS } from "./features/bento/hooks/dashboardLayoutSchema";
+import { twentyNodeDashboardSnapshot } from "./components/dashboard/test-fixtures";
 import {
   singleNodeSnapshotWithoutEdges,
   tickZeroInitialStructureRequestEvents,
-  twentyNodeSnapshot,
 } from "./testing/app-shell-layout-test-utils";
 import {
   activeSnapshot,
@@ -318,7 +318,7 @@ describe("App layout and graph behavior", () => {
   it(
     "renders a 20-node workflow through React Flow",
     async () => {
-      renderApp({ snapshot: twentyNodeSnapshot });
+      renderApp({ snapshot: twentyNodeDashboardSnapshot });
       await waitForDashboardShell();
       await waitForAppShellWorkGraphReady();
 

--- a/ui/src/testing/app-shell-layout-test-utils.ts
+++ b/ui/src/testing/app-shell-layout-test-utils.ts
@@ -5,7 +5,6 @@ import {
   buildDashboardSnapshotFixture,
   oneNodeDashboardTopology,
 } from "../components/dashboard/fixtures";
-import { twentyNodeDashboardSnapshot } from "../components/dashboard/test-fixtures";
 
 export const tickZeroInitialStructureRequestEvents: FactoryEvent[] = [
   {
@@ -47,5 +46,3 @@ export const singleNodeSnapshotWithoutEdges = {
     oneNodeDashboardTopology,
   ),
 } as unknown as DashboardSnapshot;
-
-export const twentyNodeSnapshot = twentyNodeDashboardSnapshot;


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/twenty-node-snapshot-alias-retirement",
  "description": "Retire the dead twenty-node app-shell test alias so layout-graph tests use the canonical twentyNodeDashboardSnapshot fixture directly while preserving existing dashboard test behavior and dead-code cleanliness.",
  "context": {
    "customerAsk": "Retire the dead twenty-node snapshot test alias so the app-shell layout graph test uses the canonical `twentyNodeDashboardSnapshot` fixture directly.",
    "problem": "`ui/src/testing/app-shell-layout-test-utils.ts` re-exported `twentyNodeDashboardSnapshot` under a redundant alias even though the alias had no distinct behavior. The extra name added redundant test-surface vocabulary and weakened dead-code hygiene without providing value.",
    "solution": "Remove the redundant alias, update `ui/src/App.layout-graph.test.tsx` to import `twentyNodeDashboardSnapshot` directly from `ui/src/components/dashboard/test-fixtures.ts`, and verify that the targeted layout-graph tests and `make ui-deadcode` remain green without changing snapshot contents or production code."
  },
  "acceptanceCriteria": [
    "Tracked git files on the branch contain no remaining references to the retired twenty-node snapshot alias export.",
    "`ui/src/App.layout-graph.test.tsx` imports and uses `twentyNodeDashboardSnapshot` directly from `ui/src/components/dashboard/test-fixtures.ts`.",
    "The contents of `twentyNodeDashboardSnapshot` remain unchanged and no production code behavior changes as part of this work.",
    "`cd ui && bun run vitest run src/App.layout-graph.test.tsx` passes, preserving the existing graph rendering, widget placement, and selection interaction assertions in that file.",
    "`make ui-deadcode` still reports the zero-issue frontend baseline.",
    "Typecheck, lint, and relevant tests pass for the completed change set."
  ],
  "userStories": [
    {
      "id": "twenty-node-snapshot-alias-retirement-001",
      "title": "Retire the redundant twenty-node snapshot alias",
      "description": "As a frontend maintainer, I want the app-shell layout graph test to consume the canonical twenty-node dashboard fixture directly so the test surface has one authoritative fixture name and no dead alias remains in the repository.",
      "acceptanceCriteria": [
        "`ui/src/testing/app-shell-layout-test-utils.ts` no longer exports the redundant twenty-node snapshot alias.",
        "`ui/src/App.layout-graph.test.tsx` imports `twentyNodeDashboardSnapshot` from `ui/src/components/dashboard/test-fixtures.ts` and uses that fixture in place of the retired alias.",
        "`git grep twentyNodeSnapshot` returns no matches in tracked files on the branch.",
        "The change does not alter the contents of `twentyNodeDashboardSnapshot`, dashboard layout behavior, or production code paths.",
        "`cd ui && bun run vitest run src/App.layout-graph.test.tsx` passes, including the existing graph rendering, widget placement, and selection interaction checks in that file.",
        "`make ui-deadcode` passes with the same zero-issue frontend baseline expected before this change.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    }
  ]
}