### PR TITLE
build-editor-handles-alias-retirement

### DIFF
--- a/ui/src/features/factory-graph-editor/lib/factory-graph-editor-connections.test.ts
+++ b/ui/src/features/factory-graph-editor/lib/factory-graph-editor-connections.test.ts
@@ -1,6 +1,6 @@
 // biome-ignore-all lint/complexity/noExcessiveLinesPerFunction: existing factory-graph connection coverage stayed intact during feature-root migration.
 
-import { buildEditorHandles } from "../../workflow-activity/lib/react-flow-current-activity-card-editor-handles";
+import { buildSemanticGraphHandles } from "../../workflow-activity/lib/react-flow-current-activity-card-editor-handles";
 import type {
   FactoryGraphDraft,
   FactoryGraphTopology,
@@ -425,13 +425,13 @@ describe("factory graph editor connections", () => {
         },
       },
     ]);
-    const withoutStopWordsHandles = buildEditorHandles({
+    const withoutStopWordsHandles = buildSemanticGraphHandles({
       connectionAnchorContext: standardProcessorWithoutStopWords,
       nodeId: "workstation:draft",
       nodeKind: "workstation",
       validationProjection,
     });
-    const withStopWordsHandles = buildEditorHandles({
+    const withStopWordsHandles = buildSemanticGraphHandles({
       connectionAnchorContext: standardProcessorWithStopWords,
       nodeId: "workstation:draft",
       nodeKind: "workstation",

--- a/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-editor-handles.ts
+++ b/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-editor-handles.ts
@@ -295,8 +295,6 @@ export function buildSemanticGraphHandles(args: {
   return handles;
 }
 
-export const buildEditorHandles = buildSemanticGraphHandles;
-
 function endpointNodeKind(
   nodeId: string,
   placeKind:

--- a/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-editor-handles.worker-assignment.test.ts
+++ b/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-editor-handles.worker-assignment.test.ts
@@ -7,7 +7,7 @@ import {
   dashboardWorkstationFromFactory,
 } from "./current-activity-factory-graph-layout";
 import {
-  buildEditorHandles,
+  buildSemanticGraphHandles,
   resolveWorkstationConnectionAnchorContext,
 } from "./react-flow-current-activity-card-editor-handles";
 import {
@@ -69,7 +69,7 @@ function handleIds(handles: { id: string }[]) {
 
 it("omits continue, failure, and reject handles on LOGICAL_MOVE workstations in connect mode", () => {
   const ids = handleIds(
-    buildEditorHandles({
+    buildSemanticGraphHandles({
       connectionAnchorContext: logicalMoveContext,
       editor: {
         activeTool: "connect",
@@ -90,7 +90,7 @@ it("omits continue, failure, and reject handles on LOGICAL_MOVE workstations in 
 
 it("keeps failure and omits continue and reject for a standard processor without stopWords", () => {
   const ids = handleIds(
-    buildEditorHandles({
+    buildSemanticGraphHandles({
       connectionAnchorContext: standardProcessorWithoutStopWords,
       editor: {
         activeTool: "connect",
@@ -111,7 +111,7 @@ it("keeps failure and omits continue and reject for a standard processor without
 
 it("renders all progress-outcome handles when stopWords are configured", () => {
   const ids = handleIds(
-    buildEditorHandles({
+    buildSemanticGraphHandles({
       connectionAnchorContext: standardProcessorWithStopWords,
       editor: {
         activeTool: "connect",
@@ -167,7 +167,7 @@ it("does not attach progress-outcome validation to hidden logical-move anchors",
       },
     },
   ]);
-  const handles = buildEditorHandles({
+  const handles = buildSemanticGraphHandles({
     connectionAnchorContext: logicalMoveContext,
     editor: {
       activeTool: "connect",
@@ -194,7 +194,7 @@ it("does not attach progress-outcome validation to hidden logical-move anchors",
 
 it("omits worker-assignment-target on LOGICAL_MOVE workstations", () => {
   const ids = handleIds(
-    buildEditorHandles({
+    buildSemanticGraphHandles({
       connectionAnchorContext: logicalMoveContext,
       editor: {
         activeTool: "connect",
@@ -220,7 +220,7 @@ it("omits worker-assignment-target on LOGICAL_MOVE workstations", () => {
 
 it("exposes worker-assignment-target on worker-backed workstations", () => {
   const ids = handleIds(
-    buildEditorHandles({
+    buildSemanticGraphHandles({
       connectionAnchorContext: modelWorkstationContext,
       editor: {
         activeTool: "connect",

--- a/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-graph.test.ts
+++ b/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-graph.test.ts
@@ -24,7 +24,7 @@ import {
 } from "./current-activity-factory-graph-layout";
 import { buildGraphEdges } from "./react-flow-current-activity-card-edges";
 import {
-  buildEditorHandles,
+  buildSemanticGraphHandles,
   supportedEditorHandleIdsForEdge,
 } from "./react-flow-current-activity-card-editor-handles";
 import {
@@ -1493,7 +1493,7 @@ describe("current activity graph editor handles", () => {
   it("wires shared handle click actions back through the editor anchor callback", () => {
     const onConnectionAnchorClick = vi.fn();
 
-    const handles = buildEditorHandles({
+    const handles = buildSemanticGraphHandles({
       editor: {
         activeTool: "connect",
         canInteractWithEditor: true,
@@ -1792,7 +1792,7 @@ describe("current activity graph active item labels", () => {
         },
       },
     ]);
-    const handles = buildEditorHandles({
+    const handles = buildSemanticGraphHandles({
       connectionAnchorContext,
       editor: {
         activeTool: "connect",
@@ -1845,7 +1845,7 @@ describe("current activity graph active item labels", () => {
         },
       },
     ]);
-    const handles = buildEditorHandles({
+    const handles = buildSemanticGraphHandles({
       connectionAnchorContext,
       editor: {
         activeTool: "connect",


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/build-editor-handles-alias-retirement",
  "description": "Retire the dead buildEditorHandles alias from the workflow-activity graph-handle module and consolidate the remaining test consumers on buildSemanticGraphHandles without changing observable graph-handle behavior in the React website.",
  "context": {
    "customerAsk": "Remove the buildEditorHandles alias export from ui/src/features/workflow-activity/lib/react-flow-current-activity-card-editor-handles.ts, update the remaining test imports and call sites to use buildSemanticGraphHandles directly, avoid adding a replacement alias-identity meta test, and keep the existing graph-handle behavior verification green.",
    "problem": "buildEditorHandles is only a pass-through alias of buildSemanticGraphHandles. Production graph rendering already uses the canonical name, so the alias remains only in three test files. That leaves a dead compatibility seam with no distinct behavior and makes the graph-handle surface look broader than the actual runtime contract.",
    "solution": "Delete the buildEditorHandles export, retarget the surviving graph-handle tests to import and call buildSemanticGraphHandles directly, and rely on the existing semantic graph, worker-assignment, and factory-graph editor behavioral tests to prove that graph-handle behavior stays unchanged."
  },
  "acceptanceCriteria": [
    "ui/src/features/workflow-activity/lib/react-flow-current-activity-card-editor-handles.ts no longer exports buildEditorHandles.",
    "All former buildEditorHandles imports and call sites in the touched tests use buildSemanticGraphHandles directly.",
    "Workflow-activity graph-handle behavior remains unchanged for the existing semantic graph, worker-assignment, and factory-graph editor regression scenarios already covered by the touched tests.",
    "No replacement compatibility alias, alias-identity assertion, or unrelated graph-editor cleanup is introduced as part of this lane.",
    "Repo-local verification for buildEditorHandles shows no remaining frontend references after the cleanup.",
    "Quality gate: frontend typecheck, lint, and relevant tests pass."
  ],
  "userStories": [
    {
      "id": "build-editor-handles-alias-retirement-001",
      "title": "Remove the dead editor-handles alias from the canonical graph-handle module",
      "description": "As a frontend maintainer, I want the graph-handle builder module to expose only buildSemanticGraphHandles so the workflow-activity graph projection has one canonical exported builder with no dead compatibility alias.",
      "acceptanceCriteria": [
        "ui/src/features/workflow-activity/lib/react-flow-current-activity-card-editor-handles.ts removes export const buildEditorHandles = buildSemanticGraphHandles.",
        "ui/src/features/workflow-activity/lib/react-flow-current-activity-card-graph.ts continues to use buildSemanticGraphHandles as the canonical runtime builder with no behavior change.",
        "The change does not introduce a replacement alias, wrapper, or alias-identity test for the retired name.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "build-editor-handles-alias-retirement-002",
      "title": "Retarget surviving graph-handle tests to the canonical builder and preserve behavior evidence",
      "description": "As a reviewer, I want the surviving graph-handle tests to call buildSemanticGraphHandles directly so the alias is fully retired while the same semantic graph, worker-assignment, and connection behavior remains covered.",
      "acceptanceCriteria": [
        "ui/src/features/workflow-activity/lib/react-flow-current-activity-card-graph.test.ts imports and calls buildSemanticGraphHandles directly while preserving its existing behavioral assertions.",
        "ui/src/features/workflow-activity/lib/react-flow-current-activity-card-editor-handles.worker-assignment.test.ts imports and calls buildSemanticGraphHandles directly while preserving its worker-assignment handle assertions.",
        "ui/src/features/factory-graph-editor/lib/factory-graph-editor-connections.test.ts imports and calls buildSemanticGraphHandles directly while preserving its factory-graph connection assertions.",
        "Repo-local verification confirms no remaining buildEditorHandles references under ui/src.",
        "Targeted frontend tests continue to prove unchanged graph-handle behavior for the touched regression cases instead of adding new topology or inventory assertions.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)