### PR TITLE
active-snapshot-alias-retirement

### DIFF
--- a/ui/src/App.current-selection.test.tsx
+++ b/ui/src/App.current-selection.test.tsx
@@ -12,10 +12,10 @@ import type {
   DashboardWorkItemRef,
 } from "./api/dashboard";
 import { dashboardWorkstationRequestFixtures } from "./components/dashboard/fixtures";
+import { semanticWorkflowDashboardSnapshot } from "./components/dashboard/test-fixtures";
 import { DASHBOARD_PRIMARY_WIDGET_INSTANCE_IDS } from "./features/bento/hooks/dashboardLayoutSchema";
 import { useCurrentWorkstationPromptTemplateValidation } from "./features/current-selection/workstation-selection/hooks/useCurrentWorkstationPromptTemplateValidation";
 import {
-  activeSnapshot,
   baselineSnapshot,
   MockEventSource,
   mockCurrentFactoryDocument,
@@ -36,7 +36,9 @@ const completedWorkID = "work-complete";
 const failedWorkID = "work-failed-story";
 const activeWorkLabel = "Active Story";
 
-const activeSnapshotWithoutTraceID = removeTraceIDsFromSnapshot(activeSnapshot);
+const activeSnapshotWithoutTraceID = removeTraceIDsFromSnapshot(
+  semanticWorkflowDashboardSnapshot,
+);
 const historicalTimelineSnapshot = {
   ...baselineSnapshot,
   tick_count: 1,
@@ -534,7 +536,7 @@ describe("App current selection", () => {
 
   it("renders a trace drill-down for a selected work item", async () => {
     renderApp({
-      snapshot: activeSnapshot,
+      snapshot: semanticWorkflowDashboardSnapshot,
       traceFixtures: activeStoryTraceFixtures,
     });
 
@@ -587,7 +589,7 @@ describe("App current selection", () => {
 
   it("renders one selected-work dispatch history list with mixed inference and script-backed rows", async () => {
     renderApp({
-      snapshot: activeSnapshot,
+      snapshot: semanticWorkflowDashboardSnapshot,
       traceFixtures: activeStoryTraceFixtures,
       workstationRequestsByDispatchID:
         dispatchHistoryWorkstationRequestsByDispatchID,
@@ -850,7 +852,7 @@ describe("App current selection", () => {
 
   it("follows the explicit selection contract: clicking work selects work, clicking a request selects a request", async () => {
     renderApp({
-      snapshot: activeSnapshot,
+      snapshot: semanticWorkflowDashboardSnapshot,
       traceFixtures: activeStoryTraceFixtures,
       workstationRequestsByDispatchID:
         readyDispatchWorkstationRequestsByDispatchID,
@@ -915,7 +917,7 @@ describe("App current selection", () => {
 
   it("keeps every current-selection kind on the canonical title and expandable section layout", async () => {
     renderApp({
-      snapshot: activeSnapshot,
+      snapshot: semanticWorkflowDashboardSnapshot,
       traceFixtures: activeStoryTraceFixtures,
       workstationRequestsByDispatchID:
         readyDispatchWorkstationRequestsByDispatchID,
@@ -1062,11 +1064,11 @@ describe("App current selection", () => {
 
   it("renders the selected-work empty dispatch-history state without reviving top-level execution details", async () => {
     const snapshotWithoutSelectedWorkDispatchHistory = {
-      ...activeSnapshot,
+      ...semanticWorkflowDashboardSnapshot,
       runtime: {
-        ...activeSnapshot.runtime,
+        ...semanticWorkflowDashboardSnapshot.runtime,
         session: {
-          ...activeSnapshot.runtime.session,
+          ...semanticWorkflowDashboardSnapshot.runtime.session,
           provider_sessions: [],
         },
         workstation_requests_by_dispatch_id: {},
@@ -1133,7 +1135,7 @@ describe("App current selection", () => {
   it("switches current-selection and trace enum labels to zh-CN without changing raw IDs", async () => {
     renderApp({
       initialLocale: "en",
-      snapshot: activeSnapshot,
+      snapshot: semanticWorkflowDashboardSnapshot,
       traceFixtures: activeStoryTraceFixtures,
     });
 
@@ -1184,7 +1186,7 @@ describe("App current selection", () => {
 
   it("keeps workstation and work-item selection usable after React Flow zoom", async () => {
     renderApp({
-      snapshot: activeSnapshot,
+      snapshot: semanticWorkflowDashboardSnapshot,
       traceFixtures: activeStoryTraceFixtures,
     });
 
@@ -1213,7 +1215,7 @@ describe("App current selection", () => {
 
   it("separates workstation selection from active work selection", async () => {
     renderApp({
-      snapshot: activeSnapshot,
+      snapshot: semanticWorkflowDashboardSnapshot,
       traceFixtures: activeStoryTraceFixtures,
     });
 
@@ -1288,7 +1290,7 @@ describe("App current selection", () => {
 
   it("shows active executions from the selected workstation instead of provider history", async () => {
     const reviewExecution =
-      activeSnapshot.runtime.active_executions_by_dispatch_id?.[
+      semanticWorkflowDashboardSnapshot.runtime.active_executions_by_dispatch_id?.[
         "dispatch-review-active"
       ];
     const resolvedReviewExecution = requireValue(
@@ -1297,9 +1299,9 @@ describe("App current selection", () => {
     );
 
     const snapshot = {
-      ...activeSnapshot,
+      ...semanticWorkflowDashboardSnapshot,
       runtime: {
-        ...activeSnapshot.runtime,
+        ...semanticWorkflowDashboardSnapshot.runtime,
         active_dispatch_ids: ["dispatch-review-active", "dispatch-plan-active"],
         active_executions_by_dispatch_id: {
           "dispatch-plan-active": {
@@ -1328,7 +1330,7 @@ describe("App current selection", () => {
         },
         active_workstation_node_ids: ["review", "plan"],
         session: {
-          ...activeSnapshot.runtime.session,
+          ...semanticWorkflowDashboardSnapshot.runtime.session,
           provider_sessions: [],
         },
       },
@@ -1421,7 +1423,7 @@ describe("App current selection", () => {
       status: "success",
     } as never);
 
-    renderApp({ snapshot: activeSnapshot });
+    renderApp({ snapshot: semanticWorkflowDashboardSnapshot });
 
     const expectSingleConfigurationForWorkstation = async ({
       actionLabel,
@@ -1506,13 +1508,13 @@ describe("App current selection", () => {
 
   it("renders localized workstation editing options with canonical values and keeps unknown fallbacks readable", async () => {
     const snapshot = {
-      ...activeSnapshot,
+      ...semanticWorkflowDashboardSnapshot,
       topology: {
-        ...activeSnapshot.topology,
+        ...semanticWorkflowDashboardSnapshot.topology,
         workstation_nodes_by_id: {
-          ...activeSnapshot.topology.workstation_nodes_by_id,
+          ...semanticWorkflowDashboardSnapshot.topology.workstation_nodes_by_id,
           review: {
-            ...activeSnapshot.topology.workstation_nodes_by_id.review,
+            ...semanticWorkflowDashboardSnapshot.topology.workstation_nodes_by_id.review,
             workstation_kind: "future-kind",
           },
         },
@@ -1601,7 +1603,7 @@ describe("App current selection", () => {
   });
 
   it("shows selected state node details from the graph", async () => {
-    renderApp({ snapshot: activeSnapshot });
+    renderApp({ snapshot: semanticWorkflowDashboardSnapshot });
 
     const stateButton = await screen.findByRole("button", {
       name: "Select story:implemented state",
@@ -1677,7 +1679,7 @@ describe("App current selection", () => {
   describe("layout", () => {
     it("keeps selection detail out of the workflow graph inspector layer", async () => {
       renderApp({
-        snapshot: activeSnapshot,
+        snapshot: semanticWorkflowDashboardSnapshot,
         traceFixtures: activeStoryTraceFixtures,
       });
 
@@ -1704,7 +1706,7 @@ describe("App current selection", () => {
 
     it("renders selected work and traces on the shared dashboard grid", async () => {
       renderApp({
-        snapshot: activeSnapshot,
+        snapshot: semanticWorkflowDashboardSnapshot,
         traceFixtures: activeStoryTraceFixtures,
       });
 
@@ -1736,7 +1738,7 @@ describe("App current selection", () => {
 
     it("supports rearranging shared-grid widgets without replacing graph selection", async () => {
       renderApp({
-        snapshot: activeSnapshot,
+        snapshot: semanticWorkflowDashboardSnapshot,
         traceFixtures: activeStoryTraceFixtures,
       });
 
@@ -1793,8 +1795,8 @@ describe("App current selection", () => {
 
       act(() => {
         stream.emit("snapshot", {
-          ...activeSnapshot,
-          tick_count: activeSnapshot.tick_count + 1,
+          ...semanticWorkflowDashboardSnapshot,
+          tick_count: semanticWorkflowDashboardSnapshot.tick_count + 1,
         } satisfies DashboardSnapshot);
       });
 
@@ -2413,7 +2415,7 @@ describe("App current selection", () => {
 
     it("shows an explicit unavailable state when no retained trace history exists", async () => {
       renderApp({
-        snapshot: activeSnapshot,
+        snapshot: semanticWorkflowDashboardSnapshot,
       });
 
       fireEvent.click(getActiveStorySelectionButton());

--- a/ui/src/App.follow-up-submit.test.tsx
+++ b/ui/src/App.follow-up-submit.test.tsx
@@ -2,12 +2,12 @@ import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { act } from "react";
 import { describe, expect, it } from "vitest";
 import { DEFAULT_FACTORY_SESSION_ID } from "./api/session-routing";
+import { semanticWorkflowDashboardSnapshot } from "./components/dashboard/test-fixtures";
 import {
   activeWorkLabel,
   submitWorkCardControls,
 } from "./testing/app-shell-submit-follow-up-test-utils";
 import {
-  activeSnapshot,
   baselineSnapshot,
   chainRenderAppFetchMock,
   jsonResponse,
@@ -94,7 +94,7 @@ describe("App follow-up flows", () => {
 
   describe("submit request flows", () => {
     it("submits configured and empty work requests, while preserving failed form state", async () => {
-      const { fetchMock } = renderApp({ snapshot: activeSnapshot });
+      const { fetchMock } = renderApp({ snapshot: semanticWorkflowDashboardSnapshot });
       chainRenderAppFetchMock(fetchMock, async (path, method, _input, init) => {
         if (method !== "POST" || !path.endsWith("/work")) {
           return undefined;
@@ -236,7 +236,7 @@ describe("App follow-up flows", () => {
 
   describe("multimodal submit", () => {
     it("submits a light text-plus-image multimodal request through the dashboard shell", async () => {
-      const { fetchMock } = renderApp({ snapshot: activeSnapshot });
+      const { fetchMock } = renderApp({ snapshot: semanticWorkflowDashboardSnapshot });
       chainRenderAppFetchMock(fetchMock, async (path, method) => {
         if (method !== "POST") {
           return undefined;
@@ -345,7 +345,7 @@ describe("App follow-up flows", () => {
 
   describe("workstation and live totals", () => {
     it("shows workstation-scoped workstation runs on the free-floating cards", async () => {
-      renderApp({ snapshot: activeSnapshot });
+      renderApp({ snapshot: semanticWorkflowDashboardSnapshot });
 
       fireEvent.click(
         await screen.findByRole("button", {

--- a/ui/src/App.follow-up-trace.test.tsx
+++ b/ui/src/App.follow-up-trace.test.tsx
@@ -4,9 +4,9 @@ import "./testing/app-shell-workflow-activity-stub";
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { DashboardTrace } from "./api/dashboard";
+import { semanticWorkflowDashboardSnapshot } from "./components/dashboard/test-fixtures";
 import { useFactoryTimelineStore } from "./features/timeline/state/factoryTimelineStore";
 import {
-  activeSnapshot,
   nonPromptTemplateFetchPaths,
   registerAppDashboardTestLifecycle,
   renderApp,
@@ -170,7 +170,7 @@ describe("App follow-up trace flows", () => {
 
   it("resolves trace drill-down from selected-tick events without fetching current trace state", async () => {
     const { fetchMock } = renderApp({
-      snapshot: activeSnapshot,
+      snapshot: semanticWorkflowDashboardSnapshot,
       traceFixtures: {
         [activeWorkID]: traceSnapshot,
       },

--- a/ui/src/App.layout-graph.test.tsx
+++ b/ui/src/App.layout-graph.test.tsx
@@ -1,13 +1,15 @@
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { DASHBOARD_WIDGET_IDS } from "./features/bento/hooks/dashboardLayoutSchema";
-import { twentyNodeDashboardSnapshot } from "./components/dashboard/test-fixtures";
+import {
+  semanticWorkflowDashboardSnapshot,
+  twentyNodeDashboardSnapshot,
+} from "./components/dashboard/test-fixtures";
 import {
   singleNodeSnapshotWithoutEdges,
   tickZeroInitialStructureRequestEvents,
 } from "./testing/app-shell-layout-test-utils";
 import {
-  activeSnapshot,
   baselineSnapshot,
   registerAppDashboardTestLifecycle,
   renderApp,
@@ -229,7 +231,7 @@ describe("App layout and graph behavior", () => {
       JSON.stringify(storedLayout),
     );
 
-    await renderAppWithDashboardShell({ snapshot: activeSnapshot });
+    await renderAppWithDashboardShell({ snapshot: semanticWorkflowDashboardSnapshot });
 
     const dashboardGrid = screen.getByRole("region", {
       name: "you-agent-factory bento board",
@@ -238,7 +240,7 @@ describe("App layout and graph behavior", () => {
   });
 
   it("renders distinct graph semantics for topology places, active work, and retry outcomes", async () => {
-    await renderAppWithDashboardShell({ snapshot: activeSnapshot });
+    await renderAppWithDashboardShell({ snapshot: semanticWorkflowDashboardSnapshot });
 
     await waitFor(() => {
       expect(

--- a/ui/src/App.localization-times.test.tsx
+++ b/ui/src/App.localization-times.test.tsx
@@ -2,12 +2,12 @@ import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { expect, it, vi } from "vitest";
 import type { DashboardTrace } from "./api/dashboard";
 import { dashboardWorkstationRequestFixtures } from "./components/dashboard/fixtures";
+import { semanticWorkflowDashboardSnapshot } from "./components/dashboard/test-fixtures";
 import {
   formatDurationMillis,
   formatLocalDateTime,
 } from "./components/ui/formatters";
 import {
-  activeSnapshot,
   registerAppDashboardTestLifecycle,
   renderApp,
 } from "./testing/app-shell-test-utils";
@@ -138,7 +138,7 @@ it("rerenders current-selection request history and request-detail times when th
   try {
     renderApp({
       initialLocale: "en",
-      snapshot: activeSnapshot,
+      snapshot: semanticWorkflowDashboardSnapshot,
       traceFixtures: activeStoryTraceFixtures,
       workstationRequestsByDispatchID: {
         [dashboardWorkstationRequestFixtures.ready.dispatch_id]:
@@ -263,7 +263,7 @@ it("shows localized fallback copy for invalid request-detail timestamps without 
 
     renderApp({
       initialLocale: "en",
-      snapshot: activeSnapshot,
+      snapshot: semanticWorkflowDashboardSnapshot,
       traceFixtures: activeStoryTraceFixtures,
       workstationRequestsByDispatchID: {
         [invalidRequest.dispatch_id]: invalidRequest,

--- a/ui/src/App.replay-dispatch-selection.test.tsx
+++ b/ui/src/App.replay-dispatch-selection.test.tsx
@@ -1,8 +1,8 @@
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { dashboardWorkstationRequestFixtures } from "./components/dashboard/fixtures";
+import { semanticWorkflowDashboardSnapshot } from "./components/dashboard/test-fixtures";
 import {
-  activeSnapshot,
   registerAppDashboardTestLifecycle,
   renderApp,
 } from "./testing/app-shell-test-utils";
@@ -198,7 +198,7 @@ describe("App replay dispatch selection flows", () => {
     verify,
   }) => {
     renderApp({
-      snapshot: activeSnapshot,
+      snapshot: semanticWorkflowDashboardSnapshot,
       workstationRequestsByDispatchID: {
         [requestProjection.dispatch_id]: requestProjection,
       },

--- a/ui/src/App.session-stream.test.tsx
+++ b/ui/src/App.session-stream.test.tsx
@@ -17,8 +17,8 @@ import { useDashboardStreamStore } from "./features/dashboard/state/dashboardStr
 import { sessionStreamToggleLabel } from "./features/header/lib/dashboard-session-tabs-utils";
 import { getHeaderControlsMessages } from "./features/header/messages/header-controls";
 import { useFactoryTimelineStore } from "./features/timeline/state/factoryTimelineStore";
+import { semanticWorkflowDashboardSnapshot } from "./components/dashboard/test-fixtures";
 import {
-  activeSnapshot,
   MockEventSource,
   registerAppDashboardTestLifecycle,
   renderApp,
@@ -59,7 +59,7 @@ describe("App dashboard session stream loading", () => {
     resetTimelineForInitialStreamLoad();
     renderApp({
       seedTimelineFromSnapshot: false,
-      snapshot: activeSnapshot,
+      snapshot: semanticWorkflowDashboardSnapshot,
     });
 
     await waitFor(() => {
@@ -97,7 +97,7 @@ describe("App dashboard session stream tab switch", () => {
 
     renderApp({
       factorySessions: [rootFactorySession, betaFactorySession],
-      snapshot: activeSnapshot,
+      snapshot: semanticWorkflowDashboardSnapshot,
     });
 
     await waitFor(() => {
@@ -114,7 +114,7 @@ describe("App dashboard session stream tab switch", () => {
       name: "Timeline tick",
     });
     await waitFor(() => {
-      expect(defaultSlider.value).toBe(String(activeSnapshot.tick_count));
+      expect(defaultSlider.value).toBe(String(semanticWorkflowDashboardSnapshot.tick_count));
     });
 
     act(() => {
@@ -156,7 +156,7 @@ describe("App dashboard session stream pause", () => {
 
     await renderAppWithDashboardShell({
       factorySessions: [rootFactorySession, betaFactorySession],
-      snapshot: activeSnapshot,
+      snapshot: semanticWorkflowDashboardSnapshot,
     });
 
     await screen.findByRole("tab", { name: "beta" });
@@ -218,7 +218,7 @@ describe("App dashboard session stream refresh", () => {
     resetTimelineForInitialStreamLoad();
     renderApp({
       seedTimelineFromSnapshot: false,
-      snapshot: activeSnapshot,
+      snapshot: semanticWorkflowDashboardSnapshot,
     });
 
     await waitFor(() => {

--- a/ui/src/testing/app-shell-test-utils.tsx
+++ b/ui/src/testing/app-shell-test-utils.tsx
@@ -118,23 +118,20 @@ type CurrentFactoryDocumentResult = ReturnType<
   typeof useCurrentFactoryDocument
 >;
 
-const terminalBaseSnapshot = semanticWorkflowDashboardSnapshot;
 const queryClients: QueryClient[] = [];
 let restoreBrowserTestShims: (() => void) | null = null;
 export const baselineSnapshot = buildDashboardSnapshotFixture(
   mediumBranchingDashboardTopology,
 );
 
-export const activeSnapshot = semanticWorkflowDashboardSnapshot;
-
 export const terminalSnapshot = {
-  ...terminalBaseSnapshot,
+  ...semanticWorkflowDashboardSnapshot,
   tick_count: 4,
   runtime: {
-    ...terminalBaseSnapshot.runtime,
+    ...semanticWorkflowDashboardSnapshot.runtime,
     place_occupancy_work_items_by_place_id: {
-      ...(terminalBaseSnapshot.runtime.place_occupancy_work_items_by_place_id ??
-        {}),
+      ...(semanticWorkflowDashboardSnapshot.runtime
+        .place_occupancy_work_items_by_place_id ?? {}),
       "story:blocked": [
         {
           display_name: "Failed Story",
@@ -153,16 +150,17 @@ export const terminalSnapshot = {
       ],
     },
     place_token_counts: {
-      ...(terminalBaseSnapshot.runtime.place_token_counts ?? {}),
+      ...(semanticWorkflowDashboardSnapshot.runtime.place_token_counts ?? {}),
       "story:blocked": 1,
       "story:complete": 1,
     },
     session: {
-      ...terminalBaseSnapshot.runtime.session,
+      ...semanticWorkflowDashboardSnapshot.runtime.session,
       completed_count: 1,
       completed_work_labels: ["Done Story"],
       provider_sessions: [
-        ...(terminalBaseSnapshot.runtime.session.provider_sessions ?? []),
+        ...(semanticWorkflowDashboardSnapshot.runtime.session
+          .provider_sessions ?? []),
         {
           dispatch_id: "dispatch-complete",
           outcome: "ACCEPTED",


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/active-snapshot-alias-retirement",
  "description": "Retire the dead activeSnapshot alias from the app-shell testing surface so App integration tests use the canonical semanticWorkflowDashboardSnapshot fixture directly, without changing dashboard snapshot semantics or existing test behavior.",
  "context": {
    "customerAsk": "Remove the redundant activeSnapshot export from ui/src/testing/app-shell-test-utils.tsx, update the listed App test files to import and use semanticWorkflowDashboardSnapshot directly, leave unrelated local variables named activeSnapshot alone, optionally inline terminalBaseSnapshot if it simplifies the module, and verify the cleanup with make ui-deadcode, the touched App tests, and grep.",
    "problem": "ui/src/testing/app-shell-test-utils.tsx exports activeSnapshot as a dead alias of semanticWorkflowDashboardSnapshot. The alias has no distinct behavior or ownership and survives only because several App integration tests still import it from the shared app-shell test utility module, leaving redundant fixture vocabulary and dead-code noise in the frontend testing surface.",
    "solution": "Delete the activeSnapshot export from ui/src/testing/app-shell-test-utils.tsx, retarget the affected App integration tests to import semanticWorkflowDashboardSnapshot directly from ui/src/components/dashboard/test-fixtures.ts, preserve all current behavioral assertions and fixture semantics, and verify the cleanup through make ui-deadcode, targeted App test execution, and repository grep."
  },
  "acceptanceCriteria": [
    "ui/src/testing/app-shell-test-utils.tsx no longer exports activeSnapshot.",
    "ui/src/App.layout-graph.test.tsx, ui/src/App.current-selection.test.tsx, ui/src/App.replay-dispatch-selection.test.tsx, ui/src/App.localization-times.test.tsx, ui/src/App.session-stream.test.tsx, ui/src/App.follow-up-trace.test.tsx, and ui/src/App.follow-up-submit.test.tsx import and use semanticWorkflowDashboardSnapshot directly instead of importing activeSnapshot from ./testing/app-shell-test-utils.",
    "The contents and semantics of semanticWorkflowDashboardSnapshot remain unchanged, and the touched App integration tests preserve their existing behavioral assertions.",
    "Repository verification confirms there is no remaining activeSnapshot export and no remaining imports of activeSnapshot from ui/src/testing/app-shell-test-utils.tsx; unrelated local variables named activeSnapshot remain untouched.",
    "make ui-deadcode passes with the expected zero-issue frontend baseline after the alias retirement.",
    "The touched App test files pass, preserving existing layout graph, current-selection, replay dispatch, localization time, session stream, follow-up trace, and follow-up submit behavior coverage.",
    "Quality gate: frontend typecheck, lint, and relevant tests pass."
  ],
  "userStories": [
    {
      "id": "active-snapshot-alias-retirement-001",
      "title": "Retire the redundant app-shell active snapshot alias",
      "description": "As a frontend maintainer, I want App integration tests to consume semanticWorkflowDashboardSnapshot directly so the app-shell testing surface has one authoritative dashboard snapshot name and no dead activeSnapshot alias remains in the repository.",
      "acceptanceCriteria": [
        "ui/src/testing/app-shell-test-utils.tsx no longer exports activeSnapshot, and the module does not introduce a replacement alias export.",
        "ui/src/App.layout-graph.test.tsx, ui/src/App.current-selection.test.tsx, ui/src/App.replay-dispatch-selection.test.tsx, ui/src/App.localization-times.test.tsx, ui/src/App.session-stream.test.tsx, ui/src/App.follow-up-trace.test.tsx, and ui/src/App.follow-up-submit.test.tsx import semanticWorkflowDashboardSnapshot from ui/src/components/dashboard/test-fixtures.ts and use that canonical fixture in place of the retired alias.",
        "Any optional cleanup to inline terminalBaseSnapshot stays inside ui/src/testing/app-shell-test-utils.tsx, does not create a new alias, and does not change the behavior of buildTerminalSnapshot.",
        "Repository search shows no remaining activeSnapshot export and no remaining imports of activeSnapshot from ui/src/testing/app-shell-test-utils.tsx, while unrelated local variables named activeSnapshot remain unchanged.",
        "The change does not alter the contents of semanticWorkflowDashboardSnapshot, app-shell harness behavior, or production code paths.",
        "make ui-deadcode passes with the same zero-issue frontend baseline expected before this change.",
        "The touched App test files pass, preserving their existing behavioral assertions.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)