### PR TITLE
request-authored-text-class-rename

### DIFF
--- a/ui/src/features/work-content/components/work-content-part-list.tsx
+++ b/ui/src/features/work-content/components/work-content-part-list.tsx
@@ -2,7 +2,7 @@ import type { components } from "../../../api/generated/openapi";
 import { DashboardText, SurfacePanel } from "../../../components/ui";
 import {
   AuthoredBodyText,
-  REQUEST_AUTHORED_TEXT_CLASS,
+  AUTHORED_BODY_TEXT_CLASS,
 } from "../../../lib/authored-body-text";
 import { cn } from "../../../lib/cn";
 import { describeWorkContentPart } from "../lib/describe-work-content-part";
@@ -38,7 +38,7 @@ function renderWorkContentPart(part: WorkContentPart, index: number) {
         : JSON.stringify(part.json ?? null, null, 2);
     return (
       <pre
-        className={REQUEST_AUTHORED_TEXT_CLASS}
+        className={AUTHORED_BODY_TEXT_CLASS}
         key={`work-content-part-${index}`}
       >
         <code>{value}</code>

--- a/ui/src/lib/authored-body-text.test.ts
+++ b/ui/src/lib/authored-body-text.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import { REQUEST_AUTHORED_TEXT_CLASS } from "./authored-body-text";
+import { AUTHORED_BODY_TEXT_CLASS } from "./authored-body-text";
 
-/** Transitional surface/border tokens migrated in REQUEST_AUTHORED_TEXT_CLASS. */
+/** Transitional surface/border tokens migrated in AUTHORED_BODY_TEXT_CLASS. */
 const FORBIDDEN_TRANSITIONAL_PATTERNS = [
   /\bbg-af-surface-(subtle|raised)\b/,
   /\bbg-af-surface\b/,
@@ -13,12 +13,12 @@ const FORBIDDEN_TRANSITIONAL_PATTERNS = [
   /\bbg-af-overlay\b/,
 ];
 
-describe("REQUEST_AUTHORED_TEXT_CLASS color roles", () => {
+describe("AUTHORED_BODY_TEXT_CLASS color roles", () => {
   it("uses Material role utilities for container, pre, and inline code surfaces", () => {
-    expect(REQUEST_AUTHORED_TEXT_CLASS).toContain("border-outline");
-    expect(REQUEST_AUTHORED_TEXT_CLASS).toContain("bg-surface-container-high");
-    expect(REQUEST_AUTHORED_TEXT_CLASS).toContain("bg-surface-container-low");
-    expect(REQUEST_AUTHORED_TEXT_CLASS).toContain(
+    expect(AUTHORED_BODY_TEXT_CLASS).toContain("border-outline");
+    expect(AUTHORED_BODY_TEXT_CLASS).toContain("bg-surface-container-high");
+    expect(AUTHORED_BODY_TEXT_CLASS).toContain("bg-surface-container-low");
+    expect(AUTHORED_BODY_TEXT_CLASS).toContain(
       "[&_code]:bg-surface-container",
     );
   });
@@ -27,7 +27,7 @@ describe("REQUEST_AUTHORED_TEXT_CLASS color roles", () => {
     "does not include transitional token %s",
     (patternSource) => {
       const pattern = new RegExp(patternSource);
-      expect(REQUEST_AUTHORED_TEXT_CLASS).not.toMatch(pattern);
+      expect(AUTHORED_BODY_TEXT_CLASS).not.toMatch(pattern);
     },
   );
 });

--- a/ui/src/lib/authored-body-text.tsx
+++ b/ui/src/lib/authored-body-text.tsx
@@ -3,7 +3,7 @@ import { Fragment } from "react";
 import { DASHBOARD_BODY_TEXT_CLASS } from "../components/ui/dashboard-typography";
 import { cn } from "./cn";
 
-export const REQUEST_AUTHORED_TEXT_CLASS = cn(
+export const AUTHORED_BODY_TEXT_CLASS = cn(
   "grid gap-3 rounded-lg border border-outline bg-surface-container-high p-3 [overflow-wrap:anywhere] [&_code]:rounded-sm [&_code]:bg-surface-container [&_code]:px-1 [&_code]:py-0.5 [&_h1]:text-xl [&_h1]:font-semibold [&_h2]:text-lg [&_h2]:font-semibold [&_h3]:text-base [&_h3]:font-semibold [&_ol]:m-0 [&_ol]:list-decimal [&_ol]:pl-5 [&_pre]:m-0 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:border [&_pre]:border-outline [&_pre]:bg-surface-container-low [&_pre]:p-3 [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_ul]:m-0 [&_ul]:list-disc [&_ul]:pl-5",
   DASHBOARD_BODY_TEXT_CLASS,
 );
@@ -46,7 +46,7 @@ export function AuthoredBodyText({
   const blocks = parseRequestAuthoredBlocks(value);
 
   return (
-    <div className={cn(REQUEST_AUTHORED_TEXT_CLASS, className)}>
+    <div className={cn(AUTHORED_BODY_TEXT_CLASS, className)}>
       {blocks.map((block, index) => renderRequestAuthoredBlock(block, index))}
     </div>
   );


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/request-authored-text-class-rename",
  "description": "Rename the leftover REQUEST_AUTHORED_TEXT_CLASS export to AUTHORED_BODY_TEXT_CLASS so the authored-body styling surface matches the canonical AuthoredBodyText component name, without changing the class string, markdown parsing, or rendered behavior.",
  "context": {
    "customerAsk": "Rename REQUEST_AUTHORED_TEXT_CLASS to AUTHORED_BODY_TEXT_CLASS, update the checked-in consumers in ui/src/lib/authored-body-text.tsx, ui/src/lib/authored-body-text.test.ts, and ui/src/features/work-content/components/work-content-part-list.tsx, keep the authored-body class string and AuthoredBodyText behavior unchanged, and verify the cleanup with the targeted UI test plus touched typecheck/lint gates.",
    "problem": "ui/src/lib/authored-body-text.tsx still exports the styling constant under the retired REQUEST_AUTHORED_TEXT_CLASS name even though the canonical component surface is AuthoredBodyText. That leftover alias obscures the real public API, leaves redundant vocabulary in checked-in UI code, and makes future readers reconcile two names for one authored-body styling contract.",
    "solution": "Export AUTHORED_BODY_TEXT_CLASS from ui/src/lib/authored-body-text.tsx, update the direct checked-in consumers to use the canonical name, preserve the exact class string and authored-body rendering behavior, and verify that the old name is fully removed while the targeted authored-body test and touched UI quality gates continue to pass."
  },
  "acceptanceCriteria": [
    "ui/src/lib/authored-body-text.tsx exports AUTHORED_BODY_TEXT_CLASS instead of REQUEST_AUTHORED_TEXT_CLASS.",
    "ui/src/lib/authored-body-text.tsx, ui/src/lib/authored-body-text.test.ts, and ui/src/features/work-content/components/work-content-part-list.tsx reference AUTHORED_BODY_TEXT_CLASS and no longer use REQUEST_AUTHORED_TEXT_CLASS.",
    "No checked-in file still references REQUEST_AUTHORED_TEXT_CLASS.",
    "AuthoredBodyText keeps the same class string content, markdown parsing logic, and rendered authored-body behavior after the rename.",
    "cd ui && bun test src/lib/authored-body-text.test.ts passes and preserves the existing authored-body styling assertions.",
    "Quality gate: touched UI typecheck, lint, and relevant tests pass."
  ],
  "userStories": [
    {
      "id": "request-authored-text-class-rename-001",
      "title": "Retire the leftover request-authored styling alias",
      "description": "As a frontend maintainer, I want the authored-body styling constant to use the canonical AUTHORED_BODY_TEXT_CLASS name so the AuthoredBodyText public surface is clear and no retired RequestAuthoredText alias remains in checked-in UI code.",
      "acceptanceCriteria": [
        "ui/src/lib/authored-body-text.tsx exports AUTHORED_BODY_TEXT_CLASS, and AuthoredBodyText applies that renamed constant internally without changing the class string value.",
        "ui/src/lib/authored-body-text.test.ts and ui/src/features/work-content/components/work-content-part-list.tsx import and use AUTHORED_BODY_TEXT_CLASS.",
        "Repository search shows no remaining checked-in reference to REQUEST_AUTHORED_TEXT_CLASS.",
        "The rename does not change authored-body markdown parsing, AuthoredBodyText rendering behavior, or the styling applied to JSON and text work-content parts.",
        "cd ui && bun test src/lib/authored-body-text.test.ts passes with the existing styling assertions still targeting the renamed constant.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)