### PR TITLE
twenty-node-dashboard-topology-reexport-retirement

### DIFF
--- a/ui/src/components/dashboard/test-fixtures.test.ts
+++ b/ui/src/components/dashboard/test-fixtures.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import * as dashboardTestFixtures from "./test-fixtures";
+import { twentyNodeDashboardTopology } from "./fixtures/topologies";
+
+describe("dashboard/test-fixtures", () => {
+  it("does not re-export the canonical twenty-node topology fixture", () => {
+    expect(dashboardTestFixtures).not.toHaveProperty(
+      "twentyNodeDashboardTopology",
+    );
+  });
+
+  it("keeps twentyNodeDashboardSnapshot wired to the canonical topology fixture", () => {
+    expect(dashboardTestFixtures.twentyNodeDashboardSnapshot.topology).toBe(
+      twentyNodeDashboardTopology,
+    );
+  });
+});

--- a/ui/src/components/dashboard/test-fixtures.ts
+++ b/ui/src/components/dashboard/test-fixtures.ts
@@ -84,8 +84,6 @@ export const twentyNodeDashboardSnapshot: DashboardSnapshot =
     failedOutcomeRuntimeOverlay,
   ]);
 
-export const twentyNodeDashboardTopology = twentyNodeDashboardSnapshot.topology;
-
 export function resourceOccupancySnapshotForTick(
   tick: number,
 ): DashboardSnapshot {

--- a/ui/src/features/flowchart/lib/layout.large.test.ts
+++ b/ui/src/features/flowchart/lib/layout.large.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { twentyNodeDashboardTopology } from "../../../components/dashboard/test-fixtures";
+import { twentyNodeDashboardTopology } from "../../../components/dashboard/fixtures/topologies";
 import { buildGraphLayout } from "./layout";
 
 describe("buildGraphLayout", () => {


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/twenty-node-dashboard-topology-reexport-retirement",
  "description": "Retire the redundant twenty-node dashboard topology re-export from the dashboard test-fixture barrel so tests use the canonical topology fixture path while preserving snapshot behavior and production code.",
  "context": {
    "customerAsk": "Retire the redundant twentyNodeDashboardTopology re-export from the dashboard test-fixture barrel, update the affected flowchart test to import the canonical topology fixture directly from ui/src/components/dashboard/fixtures/topologies.ts, keep twentyNodeDashboardSnapshot and the canonical topology contents unchanged, avoid production-code changes, and verify the focused Vitest coverage and make ui-deadcode baseline still pass.",
    "problem": "ui/src/components/dashboard/test-fixtures.ts currently exposes twentyNodeDashboardTopology as an alias of twentyNodeDashboardSnapshot.topology even though the canonical topology already lives in ui/src/components/dashboard/fixtures/topologies.ts. That duplicate fixture path does not change behavior because the snapshot builder stores the topology by reference, but it duplicates fixture vocabulary, weakens dead-code hygiene, and leaves two import paths for the same data.",
    "solution": "Remove the redundant twentyNodeDashboardTopology export from ui/src/components/dashboard/test-fixtures.ts, switch ui/src/features/flowchart/lib/layout.large.test.ts to import the topology from ui/src/components/dashboard/fixtures/topologies.ts, keep twentyNodeDashboardSnapshot and the topology data unchanged, and verify the cleanup with import-path checks, the targeted Vitest command, and the frontend dead-code baseline."
  },
  "acceptanceCriteria": [
    "ui/src/components/dashboard/test-fixtures.ts no longer re-exports twentyNodeDashboardTopology.",
    "ui/src/features/flowchart/lib/layout.large.test.ts imports twentyNodeDashboardTopology from ui/src/components/dashboard/fixtures/topologies.ts.",
    "Tracked git files contain no remaining imports of twentyNodeDashboardTopology from ui/src/components/dashboard/test-fixtures.ts.",
    "twentyNodeDashboardSnapshot behavior and the canonical topology fixture contents remain unchanged, with no production-code changes introduced.",
    "cd ui && bun run vitest run src/features/flowchart/lib/layout.large.test.ts passes.",
    "make ui-deadcode still reports the zero-issue frontend baseline.",
    "Quality gate: typecheck, lint, and relevant automated tests pass."
  ],
  "userStories": [
    {
      "id": "twenty-node-dashboard-topology-reexport-retirement-001",
      "title": "Retire the redundant topology alias and use the canonical fixture path",
      "description": "As a frontend maintainer, I want tests to import the twenty-node dashboard topology from its canonical fixture module so that the dashboard fixture surface exposes one clear source of truth for that topology data.",
      "acceptanceCriteria": [
        "ui/src/components/dashboard/test-fixtures.ts removes only the redundant twentyNodeDashboardTopology re-export and keeps twentyNodeDashboardSnapshot unchanged.",
        "ui/src/features/flowchart/lib/layout.large.test.ts imports twentyNodeDashboardTopology directly from ui/src/components/dashboard/fixtures/topologies.ts.",
        "No production code imports, dashboard snapshot behavior, or canonical topology fixture contents change as part of this cleanup.",
        "The change does not add a replacement alias, compatibility shim, or alternate duplicate import path for the twenty-node topology fixture.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "twenty-node-dashboard-topology-reexport-retirement-002",
      "title": "Prove the duplicate fixture path is gone and the focused frontend checks still hold",
      "description": "As a reviewer, I want focused verification that the dashboard test-fixture barrel no longer exposes the redundant topology alias while the flowchart regression test and dead-code baseline still pass so that the cleanup is clearly complete and behavior-preserving.",
      "acceptanceCriteria": [
        "Tracked git files contain no remaining imports of twentyNodeDashboardTopology from ui/src/components/dashboard/test-fixtures.ts.",
        "Focused verification confirms ui/src/components/dashboard/test-fixtures.ts no longer exports twentyNodeDashboardTopology.",
        "cd ui && bun run vitest run src/features/flowchart/lib/layout.large.test.ts passes.",
        "make ui-deadcode reports the zero-issue frontend baseline after the cleanup.",
        "Verification remains limited to the redundant topology export seam and does not expand into broader dashboard fixture or flowchart refactors.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)