### PR TITLE
payload-aware-work-item-alias-retirement-retry

### DIFF
--- a/ui/src/features/current-selection/work-selection/components/work-item/work-item-payload-details.tsx
+++ b/ui/src/features/current-selection/work-selection/components/work-item/work-item-payload-details.tsx
@@ -18,7 +18,6 @@ interface WorkItemPayloadMessages {
   workTypeLabel: string;
 }
 
-export type PayloadAwareWorkItem = DashboardWorkItemRef;
 type WorkItemPayloadListVariant = "panel" | "plain";
 
 export function WorkItemPayloadList({
@@ -32,7 +31,7 @@ export function WorkItemPayloadList({
   onSelectWorkID?: (workID: string) => void;
   selectedWorkID?: string | null;
   variant?: WorkItemPayloadListVariant;
-  workItems: PayloadAwareWorkItem[];
+  workItems: DashboardWorkItemRef[];
 }) {
   const fallbackMessages = useCurrentSelectionDetailMessages();
   const resolvedMessages = messages ?? fallbackMessages;
@@ -94,7 +93,7 @@ function WorkItemPayloadDetails({
   workItem,
 }: {
   messages: WorkItemPayloadMessages;
-  workItem: PayloadAwareWorkItem;
+  workItem: DashboardWorkItemRef;
 }) {
   const payloadStatus =
     workItem.payloadStatus ?? workItem.payload_status ?? undefined;
@@ -118,11 +117,11 @@ function WorkItemPayloadDetails({
   );
 }
 
-function _resolveWorkTypeID(workItem: PayloadAwareWorkItem) {
+function _resolveWorkTypeID(workItem: DashboardWorkItemRef) {
   return workItem.work_type_id ?? workItem.workTypeId;
 }
 
-function workItemHasPayloadDetails(workItem: PayloadAwareWorkItem) {
+function workItemHasPayloadDetails(workItem: DashboardWorkItemRef) {
   return Boolean(
     workItem.payloadStatus ||
       workItem.payload_status ||


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/payload-aware-work-item-alias-retirement-retry",
  "description": "Retry the retirement of the redundant PayloadAwareWorkItem type alias from the current-selection work payload details component so the surface uses DashboardWorkItemRef directly now that the PR #712 refactor window is closed, while preserving existing payload rendering, selection behavior, current-selection behavior, and the zero-issue frontend dead-code baseline.",
  "context": {
    "customerAsk": "Delete export type PayloadAwareWorkItem = DashboardWorkItemRef from ui/src/features/current-selection/work-selection/components/work-item-payload-details.tsx, replace its references in that file with DashboardWorkItemRef directly, keep WorkItemPayloadList, payload rendering, and selection behavior unchanged, and avoid unrelated current-selection refactors.",
    "problem": "ui/src/features/current-selection/work-selection/components/work-item-payload-details.tsx still exports PayloadAwareWorkItem as a local alias of DashboardWorkItemRef even though the alias has no distinct behavior, narrowing, or ownership role. An earlier cleanup attempt stalled during the PR #712 current-selection refactor window, but that refactor is now merged and the remaining alias is only redundant type vocabulary and frontend dead-code noise.",
    "solution": "Remove the PayloadAwareWorkItem alias from work-item-payload-details.tsx, replace the affected prop and helper annotations with DashboardWorkItemRef directly, preserve all existing current-selection payload rendering and selection behavior, and verify the retry with targeted work-item payload/current-selection tests plus make ui-deadcode."
  },
  "acceptanceCriteria": [
    "PayloadAwareWorkItem no longer appears anywhere in the repository.",
    "ui/src/features/current-selection/work-selection/components/work-item-payload-details.tsx uses DashboardWorkItemRef directly for WorkItemPayloadList, WorkItemPayloadDetails, _resolveWorkTypeID, and workItemHasPayloadDetails.",
    "Consumed payload details continue to render for dashboard work items in current-selection views with no change to payload content, empty/loading/unavailable handling, plain-versus-panel styling, or work-item selection behavior.",
    "Existing work-item payload and current-selection tests covering this surface pass after the alias retirement, with no new alias-identity or topology-only assertions added.",
    "make ui-deadcode passes with the expected zero-issue frontend baseline after the cleanup.",
    "The retry stays scoped to this single-file alias retirement and does not refactor unrelated current-selection, CurrentFactoryDocument, session-factory, or trace-graph surfaces.",
    "Quality gate: frontend typecheck, lint, and relevant tests pass."
  ],
  "userStories": [
    {
      "id": "payload-aware-work-item-alias-retirement-retry-001",
      "title": "Retire the redundant payload-aware work item alias from current selection payload details",
      "description": "As a frontend maintainer, I want work-item-payload-details.tsx to use DashboardWorkItemRef directly so the current-selection payload details surface has one canonical work-item reference type and no dead PayloadAwareWorkItem alias remains in the repository.",
      "acceptanceCriteria": [
        "ui/src/features/current-selection/work-selection/components/work-item-payload-details.tsx removes the exported PayloadAwareWorkItem alias and does not replace it with another alias.",
        "WorkItemPayloadList, WorkItemPayloadDetails, _resolveWorkTypeID, and workItemHasPayloadDetails all type their work-item inputs with DashboardWorkItemRef.",
        "Repository search returns no remaining PayloadAwareWorkItem identifier after the change.",
        "The change does not alter consumed payload rendering, payload-status messaging, plain-versus-panel presentation, or onSelectWorkID behavior for unchanged dashboard work-item inputs.",
        "Existing work-item payload and adjacent current-selection tests that cover this surface continue to pass without weakening their behavioral assertions.",
        "make ui-deadcode passes with the expected zero-issue frontend baseline.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)