### PR TITLE
trace-relation-node-types-alias-retirement

### DIFF
--- a/ui/src/features/trace-drilldown/components/trace-factory-graph-nodes.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-factory-graph-nodes.test.tsx
@@ -5,11 +5,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { TraceDispatchFlowNode } from "../lib/trace-dispatch-factory-graph-flow";
 import type { TraceRelationFlowNode } from "../lib/trace-relation-factory-graph-flow";
+import { WORK_RELATION_NODE_TYPES } from "../../graphs/public";
 import { TRACE_DISPATCH_FACTORY_GRAPH_NODE_TYPES } from "./trace-dispatch-factory-graph-node";
-import { TRACE_RELATION_FACTORY_GRAPH_NODE_TYPES } from "./trace-relation-factory-graph-node";
 
 const DispatchNode = TRACE_DISPATCH_FACTORY_GRAPH_NODE_TYPES.workstation;
-const RelationNode = TRACE_RELATION_FACTORY_GRAPH_NODE_TYPES.workRelation;
+const RelationNode = WORK_RELATION_NODE_TYPES.workRelation;
 
 function dispatchNodeProps(
   data: TraceDispatchFlowNode["data"],

--- a/ui/src/features/trace-drilldown/components/trace-relation-factory-graph-node.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-relation-factory-graph-node.tsx
@@ -1,1 +1,0 @@
-export { WORK_RELATION_NODE_TYPES as TRACE_RELATION_FACTORY_GRAPH_NODE_TYPES } from "../../graphs/public";

--- a/ui/src/features/trace-drilldown/components/trace-relation-flow.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-relation-flow.tsx
@@ -13,7 +13,10 @@ import {
   DashboardGraphControls,
   DashboardGraphFrame,
 } from "../../../components/dashboard/dashboard-graph";
-import { FACTORY_GRAPH_EDGE_TYPES } from "../../graphs/public";
+import {
+  FACTORY_GRAPH_EDGE_TYPES,
+  WORK_RELATION_NODE_TYPES,
+} from "../../graphs/public";
 import {
   traceRelationTopologyLayoutKey,
   useTraceRelationFactoryGraphLayoutPositions,
@@ -24,8 +27,6 @@ import type { TraceRelationFlowNode } from "../lib/trace-relation-factory-graph-
 import { buildTraceRelationFactoryGraphFlow } from "../lib/trace-relation-factory-graph-flow";
 import { useMeasuredTraceGraphViewport } from "../lib/use-measured-trace-graph-viewport";
 import { getTraceDrilldownMessages } from "../messages/trace-drilldown";
-import { TRACE_RELATION_FACTORY_GRAPH_NODE_TYPES } from "./trace-relation-factory-graph-node";
-
 const GRAPH_SHELL_STYLE = { height: 352, minHeight: 288 };
 const GRAPH_VIEWPORT_STYLE = { height: "100%", width: "100%" };
 const GRAPH_FIT_VIEW_OPTIONS = { maxZoom: 1.5, padding: 0.08 } as const;
@@ -213,7 +214,7 @@ function TraceRelationReactFlow({
       minZoom={0.35}
       nodes={nodes}
       nodesDraggable={true}
-      nodeTypes={TRACE_RELATION_FACTORY_GRAPH_NODE_TYPES}
+      nodeTypes={WORK_RELATION_NODE_TYPES}
       onInit={(instance) => {
         flowInstanceRef.current = instance;
       }}

--- a/ui/src/features/trace-drilldown/lib/trace-relation-factory-graph-flow.test.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-relation-factory-graph-flow.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { DashboardWorkRelation } from "../../../api/dashboard/types";
 import { getFactoryGraphEditorMessages } from "../../factory-graph-editor/messages/editor";
-import { TRACE_RELATION_FACTORY_GRAPH_NODE_TYPES } from "../components/trace-relation-factory-graph-node";
+import { WORK_RELATION_NODE_TYPES } from "../../graphs/public";
 import { buildTraceRelationFactoryGraphFlow } from "./trace-relation-factory-graph-flow";
 
 const RELATIONS: DashboardWorkRelation[] = [
@@ -81,7 +81,7 @@ describe("buildTraceRelationFactoryGraphFlow", () => {
   it("registers only shared work graph React Flow node types", () => {
     const flow = buildTraceRelationFactoryGraphFlow(RELATIONS);
 
-    expect(Object.keys(TRACE_RELATION_FACTORY_GRAPH_NODE_TYPES)).toEqual([
+    expect(Object.keys(WORK_RELATION_NODE_TYPES)).toEqual([
       "workRelation",
     ]);
     expect(flow.nodes.every((node) => node.type === "workRelation")).toBe(true);


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/trace-relation-node-types-alias-retirement",
  "description": "Retire the redundant trace-drilldown alias for relation-node React Flow types so trace relation runtime and tests import the canonical WORK_RELATION_NODE_TYPES surface from graphs directly, without changing workRelation node registration or trace graph behavior.",
  "context": {
    "customerAsk": "Delete the trace-drilldown forwarding alias module if it remains a pure re-export, update the listed trace-drilldown runtime and test consumers to import WORK_RELATION_NODE_TYPES directly from the graphs public surface, replace TRACE_RELATION_FACTORY_GRAPH_NODE_TYPES references, and preserve current node rendering, graph layout, trace replay semantics, unit-test coverage, and make ui-deadcode cleanliness.",
    "problem": "ui/src/features/trace-drilldown/components/trace-relation-factory-graph-node.tsx exists only to re-export WORK_RELATION_NODE_TYPES from ui/src/features/graphs/public as TRACE_RELATION_FACTORY_GRAPH_NODE_TYPES. The alias adds duplicate vocabulary and an unnecessary dependency hop even though graphs already owns the canonical relation-node type registration.",
    "solution": "Retarget trace-drilldown relation-flow runtime and tests to import WORK_RELATION_NODE_TYPES from the graphs public surface directly, remove all TRACE_RELATION_FACTORY_GRAPH_NODE_TYPES references, delete the forwarding module when it no longer owns behavior, and verify that trace relation graphs still register workRelation and keep current node-rendering and flow behavior through focused UI tests and make ui-deadcode."
  },
  "acceptanceCriteria": [
    "TRACE_RELATION_FACTORY_GRAPH_NODE_TYPES is removed from the repository, and ui/src/features/trace-drilldown/components/trace-relation-factory-graph-node.tsx is deleted if it remains only a forwarding alias module.",
    "ui/src/features/trace-drilldown/components/trace-relation-flow.tsx, ui/src/features/trace-drilldown/lib/trace-relation-factory-graph-flow.test.ts, and ui/src/features/trace-drilldown/components/trace-factory-graph-nodes.test.tsx import WORK_RELATION_NODE_TYPES from the graphs public surface directly.",
    "Trace relation React Flow views continue to register the same node type key set, with workRelation still mapped to the shared work-relation node implementation.",
    "Existing trace relation node-rendering behavior remains unchanged for current tests, including selectable work-node interaction, neutral relation chrome, and omission of relation metadata badges.",
    "Existing trace relation flow behavior remains unchanged for current tests, including shared work-node projection and factoryEditorEdge wiring.",
    "make ui-deadcode passes with the expected zero-issue frontend baseline after the alias retirement.",
    "Quality gate: frontend typecheck, lint, and relevant tests pass."
  ],
  "userStories": [
    {
      "id": "trace-relation-node-types-alias-retirement-001",
      "title": "Retire the trace relation node-type alias and keep graph behavior unchanged",
      "description": "As a frontend maintainer, I want trace-drilldown relation flows and tests to import WORK_RELATION_NODE_TYPES directly so the graphs feature remains the single canonical owner of relation-node type registration without changing trace relation behavior.",
      "acceptanceCriteria": [
        "trace-relation-flow.tsx uses WORK_RELATION_NODE_TYPES from the graphs public surface for the React Flow nodeTypes prop instead of a trace-drilldown alias module.",
        "trace-relation-factory-graph-flow.test.ts asserts against WORK_RELATION_NODE_TYPES directly and continues to verify that the registered trace relation node type key list is exactly [\"workRelation\"].",
        "trace-factory-graph-nodes.test.tsx renders the relation node via WORK_RELATION_NODE_TYPES.workRelation and preserves its existing behavioral assertions for label-only rendering, neutral chrome, hidden semantic badges, and selectable work-node activation.",
        "ui/src/features/trace-drilldown/components/trace-relation-factory-graph-node.tsx is deleted when it no longer owns any behavior, and repository search finds no remaining TRACE_RELATION_FACTORY_GRAPH_NODE_TYPES references.",
        "The change does not alter trace relation node rendering, graph layout application, or trace replay semantics for unchanged inputs.",
        "make ui-deadcode passes with the expected zero-issue frontend baseline.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)