### PR TITLE
timeline-work-content-type-consolidation

### DIFF
--- a/ui/src/features/timeline/state/timeline/workPayloadLineage.ts
+++ b/ui/src/features/timeline/state/timeline/workPayloadLineage.ts
@@ -1,7 +1,5 @@
 import type { FactoryWorkItem } from "../../../../api/events";
-import type { components } from "../../../../api/generated/openapi";
-
-export type WorkContent = components["schemas"]["WorkContent"];
+import type { WorkContent } from "../../../work-content/lib/work-content-types";
 
 export type WorkPayloadSnapshotKind =
   | "WORK_REQUEST"

--- a/ui/src/features/timeline/state/timeline/workPayloadLineage.ts
+++ b/ui/src/features/timeline/state/timeline/workPayloadLineage.ts
@@ -1,5 +1,5 @@
 import type { FactoryWorkItem } from "../../../../api/events";
-import type { WorkContent } from "../../../work-content/lib/work-content-types";
+import type { WorkContent } from "../../../work-content/public";
 
 export type WorkPayloadSnapshotKind =
   | "WORK_REQUEST"

--- a/ui/src/features/work-content/public/index.ts
+++ b/ui/src/features/work-content/public/index.ts
@@ -2,6 +2,7 @@ export { WorkContentItemShell } from "../components/work-content-item-shell";
 export { WorkContentPartList } from "../components/work-content-part-list";
 export { WorkContentReadOnlyList } from "../components/work-content-read-only-list";
 export { describeWorkContentPart } from "../lib/describe-work-content-part";
+export type { WorkContent, WorkContentPart } from "../lib/work-content-types";
 export { workContentPartTypeLabel } from "../lib/work-content-part-type-label";
 export {
   getWorkContentInspectMessages,


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/timeline-work-content-type-consolidation",
  "description": "Consolidate the timeline payload-lineage module onto the canonical work-content feature-owned WorkContent alias so the frontend has one source of truth for the shared schema type while preserving snapshot recording, clone detachment, and replay behavior.",
  "context": {
    "customerAsk": "Collapse the remaining duplicate WorkContent alias in ui/src/features/timeline/state/timeline/workPayloadLineage.ts by importing WorkContent from ui/src/features/work-content/lib/work-content-types.ts instead of re-declaring the OpenAPI schema alias locally.",
    "problem": "ui/src/features/timeline/state/timeline/workPayloadLineage.ts still declares WorkContent as components[\"schemas\"][\"WorkContent\"] even though ui/src/features/work-content/lib/work-content-types.ts is now the canonical definition site for that alias. The duplicate alias is only used inside the lineage clone helpers, adds a second apparent source of truth, and provides no distinct runtime behavior.",
    "solution": "Remove the local WorkContent alias from workPayloadLineage.ts, import the canonical WorkContent type from the work-content feature, keep cloneLineageWorkItem, cloneWorkContent, and payload-lineage snapshot behavior unchanged, and verify the cleanup with the existing timeline payload-lineage and replay tests plus frontend dead-code and typecheck gates."
  },
  "acceptanceCriteria": [
    "ui/src/features/timeline/state/timeline/workPayloadLineage.ts imports WorkContent from ui/src/features/work-content/lib/work-content-types.ts and no longer declares its own identical OpenAPI alias.",
    "cloneLineageWorkItem and cloneWorkContent continue to produce detached payload copies so later source mutation does not change previously recorded lineage snapshots.",
    "Existing work-request, consumed-input, dispatch-output, and replay payload-lineage behavior remains unchanged for the current timeline fixtures and tests.",
    "The change stays scoped to the timeline payload-lineage module and does not rename, move, or re-export unrelated timeline types such as CURRENT_ACTIVITY_NODE_TYPES, ImportFactoryValue, or CurrentFactoryDocument.",
    "Verification relies on the existing workPayloadLineage.test.ts, replayWorldStatePayloadLineage.test.ts, and related timeline replay coverage rather than new export-inventory or file-topology assertions.",
    "Quality gate: frontend typecheck, make ui-deadcode, and the relevant existing timeline payload-lineage tests pass."
  ],
  "userStories": [
    {
      "id": "timeline-work-content-type-consolidation-001",
      "title": "Use the canonical work-content alias in timeline lineage",
      "description": "As a frontend maintainer, I want the timeline payload-lineage module to import WorkContent from the canonical work-content feature so the frontend has one clear ownership point for the shared schema alias without changing lineage snapshot behavior.",
      "acceptanceCriteria": [
        "ui/src/features/timeline/state/timeline/workPayloadLineage.ts removes its local WorkContent = components[\"schemas\"][\"WorkContent\"] alias and imports WorkContent from ui/src/features/work-content/lib/work-content-types.ts.",
        "workPayloadLineage.ts does not add a replacement alias or re-export WorkContent from the timeline module.",
        "cloneWorkContent still returns undefined for missing content and still returns a detached mapped copy for present content.",
        "cloneLineageWorkItem, recordWorkRequestSnapshot, and recordDispatchOutputSnapshot continue to preserve the current payload snapshot text/content outcomes covered by the existing timeline lineage tests.",
        "The change does not rename or move unrelated timeline types or widen into broader timeline cleanup.",
        "Existing behavioral verification remains centered on ui/src/features/timeline/state/timeline/workPayloadLineage.test.ts, ui/src/features/timeline/state/timeline/replayWorldStatePayloadLineage.test.ts, and related replay tests rather than new alias-identity or topology assertions.",
        "make ui-deadcode passes with the expected frontend baseline.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)