### PR TITLE
runner-id-openapi-alias-retirement

### DIFF
--- a/ui/scripts/feature-cross-import-allowlist.mjs
+++ b/ui/scripts/feature-cross-import-allowlist.mjs
@@ -102,6 +102,15 @@ export const allowlistedCrossFeatureBoundaryViolations = [
       "Legacy cross-feature internal import. Route reuse through the target feature public/ boundary or relocate shared behavior.",
   },
   {
+    relativeFilePath:
+      "src/features/current-factory-definition/lib/workstation-editable-values.ts",
+    importSpecifiers: [
+      "../../current-selection/workstation-selection/messages/runner-openapi-enums",
+    ],
+    reason:
+      "Canonical OpenAPI runner identifier type lives in workstation-selection runner-openapi-enums; cross-feature type import is allowlisted instead of re-exporting through public/.",
+  },
+  {
     relativeFilePath: "src/features/current-factory-definition/public/index.ts",
     importSpecifiers: [
       "../../current-selection/base/hooks/factory-document-save-types",

--- a/ui/src/features/current-factory-definition/lib/workstation-editable-values.ts
+++ b/ui/src/features/current-factory-definition/lib/workstation-editable-values.ts
@@ -1,10 +1,8 @@
 import type { CanonicalFactoryDefinition } from "../../../api/current-factory-definition";
 import type { DashboardWorkstationNode } from "../../../api/dashboard/types";
 import type { components } from "../../../api/generated/openapi";
-import {
-  BUILT_IN_RUNNER_IDS,
-  type ApiRunnerID,
-} from "../../current-selection/workstation-selection/public";
+import { BUILT_IN_RUNNER_IDS } from "../../current-selection/workstation-selection/public";
+import type { ApiRunnerID } from "../../current-selection/workstation-selection/messages/runner-openapi-enums";
 import {
   type ResolvedRunnerSelection,
   type RunnerSelectionSource,

--- a/ui/src/features/current-factory-definition/lib/workstation-editable-values.ts
+++ b/ui/src/features/current-factory-definition/lib/workstation-editable-values.ts
@@ -1,10 +1,8 @@
 import type { CanonicalFactoryDefinition } from "../../../api/current-factory-definition";
 import type { DashboardWorkstationNode } from "../../../api/dashboard/types";
 import type { components } from "../../../api/generated/openapi";
-import {
-  BUILT_IN_RUNNER_IDS,
-  type RunnerID,
-} from "../../current-selection/workstation-selection/public";
+import { BUILT_IN_RUNNER_IDS } from "../../current-selection/workstation-selection/public";
+import type { ApiRunnerID } from "../../current-selection/workstation-selection/messages/runner-openapi-enums";
 import {
   type ResolvedRunnerSelection,
   type RunnerSelectionSource,
@@ -81,8 +79,8 @@ export interface EditableWorkstationValues {
   behavior: EditableWorkstationBehavior;
   behaviorOptions: EditableWorkstationBehavior[];
   cron: EditableWorkstationCronDraft | null;
-  effectiveRunnerName: RunnerID;
-  factoryRunnerName: RunnerID | null;
+  effectiveRunnerName: ApiRunnerID;
+  factoryRunnerName: ApiRunnerID | null;
   modelInvokeWorkerOptions: string[];
   modelOperationsByWorkerName: ReturnType<
     typeof resolveModelOperationsByWorkerName
@@ -91,8 +89,8 @@ export interface EditableWorkstationValues {
   operationBindings: EditableModelInvokeBindingDraft[];
   prompt: string | null;
   resolvedRunnerSelection: ResolvedRunnerSelection;
-  runnerName: RunnerID | null;
-  runnerOptions: RunnerID[];
+  runnerName: ApiRunnerID | null;
+  runnerOptions: ApiRunnerID[];
   runnerSelectionSource: RunnerSelectionSource;
   sharedWorkerWorkstationNamesByWorkerName: Record<string, string[]>;
   sharedWorkerWorkstationNames: string[];
@@ -117,7 +115,7 @@ export interface EditableWorkstationDraft {
   operation: string;
   operationBindings: EditableModelInvokeBindingDraft[];
   prompt: string;
-  runnerName: RunnerID | null;
+  runnerName: ApiRunnerID | null;
   workerName: string;
   workstationType: EditableWorkstationType;
 }

--- a/ui/src/features/current-factory-definition/lib/workstation-editable-values.ts
+++ b/ui/src/features/current-factory-definition/lib/workstation-editable-values.ts
@@ -1,8 +1,10 @@
 import type { CanonicalFactoryDefinition } from "../../../api/current-factory-definition";
 import type { DashboardWorkstationNode } from "../../../api/dashboard/types";
 import type { components } from "../../../api/generated/openapi";
-import { BUILT_IN_RUNNER_IDS } from "../../current-selection/workstation-selection/public";
-import type { ApiRunnerID } from "../../current-selection/workstation-selection/messages/runner-openapi-enums";
+import {
+  BUILT_IN_RUNNER_IDS,
+  type ApiRunnerID,
+} from "../../current-selection/workstation-selection/public";
 import {
   type ResolvedRunnerSelection,
   type RunnerSelectionSource,

--- a/ui/src/features/current-selection/workstation-selection/components/fields/workstation-runner-field.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/fields/workstation-runner-field.tsx
@@ -3,10 +3,12 @@ import { resolveRunnerSelection } from "../../../../current-factory-definition/l
 import {
   getRunnerDisplayName,
   getRunnerMetadata,
-  type RunnerID,
 } from "../../editing/runner-metadata";
 import type { WorkstationDetailCardProps } from "../../lib/keys/detail-card-types";
-import { isOpenApiRunnerID } from "../../messages/runner-openapi-enums";
+import {
+  type ApiRunnerID,
+  isOpenApiRunnerID,
+} from "../../messages/runner-openapi-enums";
 import type { getWorkstationDetailMessages } from "../../messages/workstation-detail";
 
 type ReadyEditableConfigurationState = Extract<
@@ -50,7 +52,7 @@ export function EditableConfigurationRunnerField({
         id="editable-workstation-runner"
         onValueChange={(nextValue) =>
           state.onRunnerChange(
-            nextValue === null ? null : (nextValue as RunnerID),
+            nextValue === null ? null : (nextValue as ApiRunnerID),
           )
         }
         options={state.initialValues.runnerOptions.map((runnerID) => ({

--- a/ui/src/features/current-selection/workstation-selection/editing/editable-workstation-configuration-mutators.ts
+++ b/ui/src/features/current-selection/workstation-selection/editing/editable-workstation-configuration-mutators.ts
@@ -7,7 +7,7 @@ import {
   resolveDraftForBehaviorChange,
   updateEditableWorkstationCronDraft,
 } from "./editable-workstation-cron-draft-mutators";
-import type { RunnerID } from "./runner-metadata";
+import type { ApiRunnerID } from "../messages/runner-openapi-enums";
 
 export type EditableWorkstationSessionDraftState = {
   draft: EditableWorkstationDraft;
@@ -139,7 +139,7 @@ export function buildEditableWorkstationConfigurationMutators<
           : currentState,
       );
     },
-    onRunnerChange: (value: RunnerID | null) => {
+    onRunnerChange: (value: ApiRunnerID | null) => {
       updateDraft((draft) => ({ ...draft, runnerName: value }));
     },
     onWorkerChange: (value: string) => {

--- a/ui/src/features/current-selection/workstation-selection/editing/runner-metadata.test.ts
+++ b/ui/src/features/current-selection/workstation-selection/editing/runner-metadata.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { OPENAPI_RUNNER_IDS } from "../messages/runner-openapi-enums";
+import {
+  BUILT_IN_RUNNER_IDS,
+  getRunnerDisplayName,
+  getRunnerMetadata,
+} from "./runner-metadata";
+
+describe("runner-metadata", () => {
+  it("exposes built-in runner ids in OpenAPI contract order", () => {
+    expect(BUILT_IN_RUNNER_IDS).toEqual([...OPENAPI_RUNNER_IDS]);
+  });
+
+  it("returns metadata for every built-in runner id", () => {
+    for (const runnerID of BUILT_IN_RUNNER_IDS) {
+      expect(getRunnerMetadata(runnerID)).toMatchObject({
+        displayName: expect.any(String),
+        id: runnerID,
+      });
+    }
+  });
+
+  it("returns display names for built-in runner ids and null for unknown ids", () => {
+    expect(getRunnerDisplayName("codex")).toBe("Codex");
+    expect(getRunnerDisplayName("cursor-cli")).toBe("Cursor CLI");
+    expect(getRunnerDisplayName("claude")).toBeNull();
+    expect(getRunnerDisplayName(null)).toBeNull();
+    expect(getRunnerDisplayName(undefined)).toBeNull();
+  });
+
+  it("falls back safely for unknown runner ids", () => {
+    expect(getRunnerMetadata("claude")).toBeNull();
+    expect(getRunnerMetadata(null)).toBeNull();
+    expect(getRunnerMetadata(undefined)).toBeNull();
+  });
+});

--- a/ui/src/features/current-selection/workstation-selection/editing/runner-metadata.ts
+++ b/ui/src/features/current-selection/workstation-selection/editing/runner-metadata.ts
@@ -1,14 +1,14 @@
-import type { components } from "../../../../api/generated/openapi";
-import { OPENAPI_RUNNER_IDS } from "../messages/runner-openapi-enums";
-
-export type RunnerID = components["schemas"]["RunnerID"];
+import {
+  type ApiRunnerID,
+  OPENAPI_RUNNER_IDS,
+} from "../messages/runner-openapi-enums";
 
 export interface RunnerMetadata {
   displayName: string;
-  id: RunnerID;
+  id: ApiRunnerID;
 }
 
-const BUILT_IN_RUNNER_METADATA: Record<RunnerID, RunnerMetadata> = {
+const BUILT_IN_RUNNER_METADATA: Record<ApiRunnerID, RunnerMetadata> = {
   codex: {
     displayName: "Codex",
     id: "codex",
@@ -31,7 +31,7 @@ const BUILT_IN_RUNNER_METADATA: Record<RunnerID, RunnerMetadata> = {
   },
 };
 
-export const BUILT_IN_RUNNER_IDS: RunnerID[] = [...OPENAPI_RUNNER_IDS];
+export const BUILT_IN_RUNNER_IDS: ApiRunnerID[] = [...OPENAPI_RUNNER_IDS];
 
 export function getRunnerMetadata(
   runnerID: string | null | undefined,
@@ -40,7 +40,7 @@ export function getRunnerMetadata(
     return null;
   }
 
-  return BUILT_IN_RUNNER_METADATA[runnerID as RunnerID] ?? null;
+  return BUILT_IN_RUNNER_METADATA[runnerID as ApiRunnerID] ?? null;
 }
 
 export function getRunnerDisplayName(

--- a/ui/src/features/current-selection/workstation-selection/hooks/editable-workstation-ready-configuration-state.ts
+++ b/ui/src/features/current-selection/workstation-selection/hooks/editable-workstation-ready-configuration-state.ts
@@ -27,7 +27,7 @@ import {
 import { resolveDraftForWorkstationTypeChange } from "../editing/type/editable-workstation-type-mutators";
 import { resolveEditableWorkstationOverwriteFields } from "../editing/editable-workstation-overwrite-fields";
 import { resolveModelInvokeOperationOptionsState } from "../lib/editable-workstation-model-invoke-options";
-import type { RunnerID } from "../editing/runner-metadata";
+import type { ApiRunnerID } from "../messages/runner-openapi-enums";
 import type { EditableWorkstationType } from "../../../current-factory-definition/lib/workstation/workstation-type";
 import type {
   EditableWorkstationPromptHelpState,
@@ -135,7 +135,7 @@ function createEditableWorkstationDraftHandlers(
     onInputsChange: (inputs: EditableWorkstationDraft["inputs"]) => {
       updateDraft((draft) => ({ ...draft, inputs }));
     },
-    onRunnerChange: (value: RunnerID | null) => {
+    onRunnerChange: (value: ApiRunnerID | null) => {
       updateDraft((draft) => ({ ...draft, runnerName: value }));
     },
     onWorkstationTypeChange: (value: EditableWorkstationType) => {

--- a/ui/src/features/current-selection/workstation-selection/lib/keys/detail-card-types.ts
+++ b/ui/src/features/current-selection/workstation-selection/lib/keys/detail-card-types.ts
@@ -22,7 +22,7 @@ import type {
 import type { EditableModelInvokeBindingDraft } from "../../../../current-factory-definition/lib/workstation/workstation-model-invoke";
 import type { LoadableProviderSessionRef } from "../../../../provider-session-detail/lib/provider-session-ref";
 import type { DetailCardSaveState } from "../../../base/hooks/detail-card-save-types";
-import type { RunnerID } from "../../editing/runner-metadata";
+import type { ApiRunnerID } from "../../messages/runner-openapi-enums";
 import type { WorkstationDetailMessages } from "../../messages/workstation-detail-types";
 
 export interface WorkstationDetailCardProps {
@@ -155,7 +155,7 @@ export type EditableWorkstationConfigurationState =
       onResetToLatest: () => void;
       onGuardsChange: (guards: EditableWorkstationDraft["guards"]) => void;
       onInputsChange: (inputs: EditableWorkstationDraft["inputs"]) => void;
-      onRunnerChange: (value: RunnerID | null) => void;
+      onRunnerChange: (value: ApiRunnerID | null) => void;
       onWorkstationTypeChange: (value: EditableWorkstationValues["workstationType"]) => void;
       onWorkerChange: (value: string) => void;
       operationOptionsState: EditableWorkstationOperationOptionsState;

--- a/ui/src/features/current-selection/workstation-selection/public/index.test.ts
+++ b/ui/src/features/current-selection/workstation-selection/public/index.test.ts
@@ -44,6 +44,10 @@ describe("workstation-selection/public", () => {
     expect(workstationSelectionPublic).not.toHaveProperty("RunnerID");
   });
 
+  it("does not export ApiRunnerID as a secondary import surface", () => {
+    expect(workstationSelectionPublic).not.toHaveProperty("ApiRunnerID");
+  });
+
   it("does not export shared Monaco prompt editor setup helpers", () => {
     expect(workstationSelectionPublic).not.toHaveProperty("MonacoPromptEditor");
     expect(workstationSelectionPublic).not.toHaveProperty(

--- a/ui/src/features/current-selection/workstation-selection/public/index.test.ts
+++ b/ui/src/features/current-selection/workstation-selection/public/index.test.ts
@@ -40,6 +40,10 @@ describe("workstation-selection/public", () => {
     );
   });
 
+  it("does not export the retired RunnerID alias", () => {
+    expect(workstationSelectionPublic).not.toHaveProperty("RunnerID");
+  });
+
   it("does not export shared Monaco prompt editor setup helpers", () => {
     expect(workstationSelectionPublic).not.toHaveProperty("MonacoPromptEditor");
     expect(workstationSelectionPublic).not.toHaveProperty(

--- a/ui/src/features/current-selection/workstation-selection/public/index.ts
+++ b/ui/src/features/current-selection/workstation-selection/public/index.ts
@@ -13,7 +13,6 @@ export {
   getRunnerMetadata,
   type RunnerMetadata,
 } from "../editing/runner-metadata";
-export type { ApiRunnerID as RunnerID } from "../messages/runner-openapi-enums";
 export type {
   EditableWorkstationConfigurationState,
   EditableWorkstationOverwriteField,

--- a/ui/src/features/current-selection/workstation-selection/public/index.ts
+++ b/ui/src/features/current-selection/workstation-selection/public/index.ts
@@ -13,6 +13,7 @@ export {
   getRunnerMetadata,
   type RunnerMetadata,
 } from "../editing/runner-metadata";
+export type { ApiRunnerID } from "../messages/runner-openapi-enums";
 export type {
   EditableWorkstationConfigurationState,
   EditableWorkstationOverwriteField,

--- a/ui/src/features/current-selection/workstation-selection/public/index.ts
+++ b/ui/src/features/current-selection/workstation-selection/public/index.ts
@@ -13,7 +13,6 @@ export {
   getRunnerMetadata,
   type RunnerMetadata,
 } from "../editing/runner-metadata";
-export type { ApiRunnerID } from "../messages/runner-openapi-enums";
 export type {
   EditableWorkstationConfigurationState,
   EditableWorkstationOverwriteField,

--- a/ui/src/features/current-selection/workstation-selection/public/index.ts
+++ b/ui/src/features/current-selection/workstation-selection/public/index.ts
@@ -11,9 +11,9 @@ export {
 export {
   BUILT_IN_RUNNER_IDS,
   getRunnerMetadata,
-  type RunnerID,
   type RunnerMetadata,
 } from "../editing/runner-metadata";
+export type { ApiRunnerID as RunnerID } from "../messages/runner-openapi-enums";
 export type {
   EditableWorkstationConfigurationState,
   EditableWorkstationOverwriteField,


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/runner-id-openapi-alias-retirement",
  "description": "Retire the duplicate RunnerID OpenAPI alias from the workstation-selection frontend surface so all affected website code uses the canonical ApiRunnerID name from the runner OpenAPI enum module, without changing observable runner selection, metadata, or display behavior.",
  "context": {
    "customerAsk": "Remove the duplicate RunnerID type alias from ui/src/features/current-selection/workstation-selection/editing/runner-metadata.ts, update runner metadata and all remaining production and test consumers to use ApiRunnerID from ui/src/features/current-selection/workstation-selection/messages/runner-openapi-enums.ts, remove RunnerID from the workstation-selection public barrel, preserve getRunnerMetadata, getRunnerDisplayName, and BUILT_IN_RUNNER_IDS behavior, and verify the change with frontend tests, dead-code checks, and repo-local proof that the retired import path is gone.",
    "problem": "The website currently exposes two identical OpenAPI runner identifier aliases: RunnerID in the runner metadata module and ApiRunnerID in the runner OpenAPI enum module. Newer runner-selection code already uses ApiRunnerID, but older workstation-selection and current-factory-definition code still imports RunnerID directly or through the workstation-selection public barrel. Because both names resolve to the same generated OpenAPI schema type with no behavioral difference, the duplicate alias adds a dead compatibility seam, splits contract ownership, and weakens import-surface hygiene.",
    "solution": "Make ApiRunnerID the single canonical OpenAPI runner identifier name for the affected frontend surfaces. Remove RunnerID from runner metadata and the workstation-selection public barrel, retarget all affected production and test consumers to import ApiRunnerID directly from runner-openapi-enums.ts, and verify that runner metadata lookup, runner display names, built-in runner ids, dead-code checks, and targeted frontend tests all remain correct."
  },
  "acceptanceCriteria": [
    "The workstation runner metadata surface uses ApiRunnerID as its only OpenAPI runner identifier type, and RunnerID is no longer declared in ui/src/features/current-selection/workstation-selection/editing/runner-metadata.ts.",
    "All affected production and test code that previously imported RunnerID from runner metadata or the workstation-selection public barrel imports ApiRunnerID from ui/src/features/current-selection/workstation-selection/messages/runner-openapi-enums.ts instead.",
    "The workstation-selection public barrel no longer re-exports RunnerID.",
    "getRunnerMetadata, getRunnerDisplayName, and BUILT_IN_RUNNER_IDS preserve their existing observable behavior for built-in runner ids and unknown runner ids.",
    "Repo-local verification shows no remaining imports of RunnerID from runner metadata or the workstation-selection public barrel, excluding generated OpenAPI code and the separate FactoryRunnerID alias in ui/src/api/factory-definition/api.ts.",
    "make ui-test or targeted runner selection and workstation runner field tests pass, and make ui-deadcode remains at the expected clean frontend baseline.",
    "Quality gate: frontend typecheck, lint, and relevant tests pass."
  ],
  "userStories": [
    {
      "id": "runner-id-openapi-alias-retirement-001",
      "title": "Canonicalize workstation runner metadata on ApiRunnerID without changing runner behavior",
      "description": "As a frontend maintainer, I want workstation runner metadata and runner-editing flows to use ApiRunnerID directly so the website has one canonical OpenAPI runner identifier name while runner labels, built-in runner ids, and runner selection behavior stay the same.",
      "acceptanceCriteria": [
        "ui/src/features/current-selection/workstation-selection/editing/runner-metadata.ts removes the local RunnerID alias and imports ApiRunnerID from the runner OpenAPI enum module for RunnerMetadata, BUILT_IN_RUNNER_METADATA, BUILT_IN_RUNNER_IDS, and getRunnerMetadata.",
        "Workstation runner editing and detail-card typing that previously depended on the retired alias use ApiRunnerID | null directly, with no change to how built-in runner ids are accepted or displayed.",
        "getRunnerMetadata, getRunnerDisplayName, and BUILT_IN_RUNNER_IDS continue to return the same results for every built-in runner id and continue to fall back safely for unknown ids.",
        "The change does not modify OPENAPI_RUNNER_IDS, isOpenApiRunnerID, normalizeRunnerID, or generated ui/src/api/generated/openapi.ts.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "runner-id-openapi-alias-retirement-002",
      "title": "Retire the old RunnerID import path from consumers and the workstation-selection public surface",
      "description": "As a reviewer, I want all affected consumers to import ApiRunnerID from the canonical runner OpenAPI enum module so the duplicate runner-id alias and its public re-export disappear completely from the frontend import surface.",
      "acceptanceCriteria": [
        "Current workstation-selection, current-factory-definition, and touched test modules that previously imported RunnerID from runner metadata or the workstation-selection public barrel import ApiRunnerID from ui/src/features/current-selection/workstation-selection/messages/runner-openapi-enums.ts instead.",
        "ui/src/features/current-selection/workstation-selection/public/index.ts no longer re-exports RunnerID, and the cleanup does not introduce a replacement compatibility alias or secondary barrel name.",
        "Repo-local verification confirms there are no remaining imports of RunnerID from ui/src/features/current-selection/workstation-selection/editing/runner-metadata.ts or from the workstation-selection public barrel, excluding generated OpenAPI code and the separate FactoryRunnerID alias.",
        "make ui-deadcode remains clean, and targeted runner selection and workstation runner field tests continue to prove unchanged observable runner selection and display behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)