### PR TITLE
current-activity-node-types-alias-retirement

### DIFF
--- a/ui/src/features/flowchart/components/current-activity-nodes.tsx
+++ b/ui/src/features/flowchart/components/current-activity-nodes.tsx
@@ -41,7 +41,7 @@ const NODE_TYPES = {
   workstation: WorkstationNodeView,
 };
 
-export { NODE_TYPES as CURRENT_ACTIVITY_NODE_TYPES };
+export { NODE_TYPES };
 export type CurrentActivityNode =
   | CurrentActivityWorkstationNode
   | CurrentActivityPlaceNode

--- a/ui/src/features/flowchart/public/index.test.tsx
+++ b/ui/src/features/flowchart/public/index.test.tsx
@@ -1,14 +1,34 @@
 import { render, screen } from "@testing-library/react";
 
-import { GraphSemanticIcon } from "./index";
+import * as flowchartPublic from "./index";
 
 describe("flowchart public barrel", () => {
-  it("renders GraphSemanticIcon with accessible output and semantic kind surface", () => {
-    render(<GraphSemanticIcon kind="queue" />);
+  it("keeps current activity nodes and graph semantic icons available", () => {
+    expect(flowchartPublic.NODE_TYPES).toMatchObject({
+      constraint: expect.any(Function),
+      resource: expect.any(Function),
+      statePosition: expect.any(Function),
+      worker: expect.any(Function),
+      workType: expect.any(Function),
+      workstation: expect.any(Function),
+    });
+    expect(flowchartPublic.GRAPH_SEMANTIC_ICON_KINDS).toContain("queue");
+
+    render(<flowchartPublic.GraphSemanticIcon kind="queue" />);
 
     const icon = screen.getByRole("img", { name: "Queue state" });
 
     expect(icon.tagName.toLowerCase()).toBe("svg");
     expect(icon.getAttribute("data-graph-semantic-icon")).toBe("queue");
+  });
+
+  it("does not expose workstation icon metadata helpers through the public barrel", () => {
+    expect(flowchartPublic).not.toHaveProperty("workstationIconMetadata");
+    expect(flowchartPublic).not.toHaveProperty(
+      "SUPPORTED_WORKSTATION_ICON_METADATA",
+    );
+    expect(flowchartPublic).not.toHaveProperty(
+      "EXHAUSTION_WORKSTATION_ICON_METADATA",
+    );
   });
 });

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card-surface.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card-surface.tsx
@@ -5,7 +5,7 @@ import type { DashboardSnapshot } from "../../../api/dashboard/types";
 import { AlertPanel } from "../../../components/ui";
 import { FactoryGraphEditorNotice } from "../../factory-graph-editor/components/controls/factory-graph-editor-controls";
 import { getFactoryGraphEditorMessages } from "../../factory-graph-editor/messages/editor";
-import { CURRENT_ACTIVITY_NODE_TYPES } from "../../flowchart/public";
+import { NODE_TYPES } from "../../flowchart/public";
 import type { CurrentActivityImportController } from "../hooks/current-activity-import-controller";
 import type { useCurrentActivityGraphEditor } from "../hooks/react-flow-current-activity-card-editor";
 import type { useCurrentActivityGraphViewModel } from "../hooks/react-flow-current-activity-card-graph-view-model";
@@ -197,7 +197,7 @@ export function CurrentActivityGraphSurface({
         initialFitViewOptions={graph.initialFitViewOptions}
         isSavingDraft={editor.saveEditableDefinition.isPending}
         locale={locale}
-        nodeTypes={CURRENT_ACTIVITY_NODE_TYPES}
+        nodeTypes={NODE_TYPES}
         nodes={graph.nodes}
         onAddAction={editor.handleAddEntityAction}
         onAddMenuOpenChange={editor.setAddMenuOpen}


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/current-activity-node-types-alias-retirement",
  "description": "Retire the redundant CURRENT_ACTIVITY_NODE_TYPES alias so the workflow-activity current-activity React Flow surface consumes the canonical NODE_TYPES export from the flowchart public barrel without changing current-activity graph rendering behavior.",
  "context": {
    "customerAsk": "Retire CURRENT_ACTIVITY_NODE_TYPES, export NODE_TYPES directly from ui/src/features/flowchart/components/current-activity-nodes.tsx, keep NODE_TYPES available through ui/src/features/flowchart/public/index.ts, update ui/src/features/workflow-activity/components/react-flow-current-activity-card-surface.tsx to import and pass NODE_TYPES to React Flow, confirm no checked-in references to CURRENT_ACTIVITY_NODE_TYPES remain, and verify the change with the current-activity surface test, make ui-deadcode, and the frontend quality gate.",
    "problem": "CURRENT_ACTIVITY_NODE_TYPES is a one-line alias over the canonical NODE_TYPES React Flow node-type map. The alias has no distinct behavior, typing, or ownership and survives only because the workflow-activity current-activity card surface imports that extra name, leaving a redundant public naming seam in the flowchart surface.",
    "solution": "Export NODE_TYPES directly from the current-activity node module, keep the flowchart public barrel forwarding that canonical name, update the workflow-activity current-activity card surface to pass NODE_TYPES into React Flow directly, and verify that CURRENT_ACTIVITY_NODE_TYPES no longer appears in checked-in code while current-activity rendering behavior remains unchanged."
  },
  "acceptanceCriteria": [
    "CURRENT_ACTIVITY_NODE_TYPES is fully removed from the repository.",
    "ui/src/features/flowchart/public/index.ts exports NODE_TYPES, and ui/src/features/workflow-activity/components/react-flow-current-activity-card-surface.tsx imports and passes NODE_TYPES to the React Flow nodeTypes prop.",
    "The current-activity node-type map contents remain unchanged, preserving the same bindings for constraint, resource, statePosition, worker, workType, and workstation node views.",
    "Current-activity React Flow rendering behavior is unchanged after the alias retirement for the same dashboard snapshot and editor state inputs.",
    "cd ui && bun run test -- src/features/workflow-activity/components/react-flow-current-activity-card-surface.test.tsx passes.",
    "make ui-deadcode continues to match the zero-issue frontend baseline.",
    "Quality gate: frontend typecheck, lint, and relevant tests pass."
  ],
  "userStories": [
    {
      "id": "current-activity-node-types-alias-retirement-001",
      "title": "Retire the redundant current-activity node types alias",
      "description": "As a frontend maintainer, I want the workflow-activity current-activity graph surface to consume the canonical NODE_TYPES export directly so the flowchart surface has one authoritative node-type map name and no redundant CURRENT_ACTIVITY_NODE_TYPES alias remains.",
      "acceptanceCriteria": [
        "ui/src/features/flowchart/components/current-activity-nodes.tsx exports NODE_TYPES directly and no longer exports CURRENT_ACTIVITY_NODE_TYPES or another replacement alias.",
        "ui/src/features/flowchart/public/index.ts continues to expose NODE_TYPES as the public flowchart entry point for the current-activity node-type map.",
        "ui/src/features/workflow-activity/components/react-flow-current-activity-card-surface.tsx imports NODE_TYPES from ../../flowchart/public and passes it to the React Flow nodeTypes prop without changing the surrounding editor, validation, or empty-state wiring.",
        "The node-type map contents stay unchanged, preserving the same React Flow node view bindings for constraint, resource, statePosition, worker, workType, and workstation nodes.",
        "Repository search shows no checked-in references to CURRENT_ACTIVITY_NODE_TYPES after the change.",
        "cd ui && bun run test -- src/features/workflow-activity/components/react-flow-current-activity-card-surface.test.tsx passes, preserving current-activity card surface behavior coverage.",
        "make ui-deadcode passes with the expected zero-issue frontend baseline.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)