### PR TITLE
submit-work-cleanup-error-handling

### DIFF
--- a/ui/src/App.follow-up-submit.test.tsx
+++ b/ui/src/App.follow-up-submit.test.tsx
@@ -149,7 +149,7 @@ describe("App follow-up flows", () => {
         }),
       ).toBeTruthy();
       await user.keyboard("{Escape}");
-      expect(submitButton.disabled).toBe(true);
+      expect(submitButton.disabled).toBe(false);
       expect(
         submitWorkScope.queryByText(
           "Choose a work type and enter a request name to continue.",

--- a/ui/src/App.stories.tsx
+++ b/ui/src/App.stories.tsx
@@ -955,10 +955,10 @@ export const DashboardImprovementsSmoke = {
       within(graphCard).queryByRole("heading", { name: "Current activity" }),
     ).toBeNull();
     await expect(
-      within(submitWorkCard).getByRole("combobox", { name: "Work type" }),
+      within(submitWorkCard).getByRole("combobox", { name: /Work type/ }),
     ).toBeVisible();
     await expect(
-      within(submitWorkCard).getByRole("textbox", { name: "Request name" }),
+      within(submitWorkCard).getByRole("textbox", { name: /Request name/ }),
     ).toBeVisible();
     await expect(
       within(submitWorkCard).getByRole("list", {
@@ -972,7 +972,7 @@ export const DashboardImprovementsSmoke = {
     ).toBeVisible();
     await expect(
       within(submitWorkCard).getByRole("button", { name: "Submit work" }),
-    ).toBeDisabled();
+    ).toBeEnabled();
     expect(
       within(submitWorkCard).queryByText(
         "Ready to submit. Request details are optional.",
@@ -1388,24 +1388,24 @@ export const DashboardSubmitWorkIntegrationSmoke = {
       submitButton,
       workTypeField,
     } = await submitWorkCardControls(canvasElement);
-    const disabledSubmitStyle = buttonVisibleStyle(submitButton);
+    const outlineSubmitStyle = buttonVisibleStyle(submitButton);
 
     await userEvent.click(workTypeField);
     await expect(
       await screen.findByRole("option", { name: "story" }),
     ).toBeVisible();
-    await expect(submitButton).toBeDisabled();
+    await expect(submitButton).toBeEnabled();
     await userEvent.type(requestNameField, "Dashboard smoke request");
-    await expect(submitButton).toBeDisabled();
+    await expect(submitButton).toBeEnabled();
     await userEvent.type(
       requestField,
       "Review the failed dashboard submission smoke.",
     );
-    await expect(submitButton).toBeDisabled();
+    await expect(submitButton).toBeEnabled();
     await selectComboboxOption(userEvent, workTypeField, "story");
     await expect(submitButton).toBeEnabled();
     await waitFor(() => {
-      expect(buttonVisibleStyle(submitButton)).not.toEqual(disabledSubmitStyle);
+      expect(buttonVisibleStyle(submitButton)).not.toEqual(outlineSubmitStyle);
     });
     await userEvent.click(submitButton);
     await expect(
@@ -1416,9 +1416,9 @@ export const DashboardSubmitWorkIntegrationSmoke = {
     await expect(requestNameField).toHaveValue("");
     await expect(requestField).toHaveValue("");
     await expect(workTypeField).toHaveTextContent("story");
-    await expect(submitButton).toBeDisabled();
+    await expect(submitButton).toBeEnabled();
     await waitFor(() => {
-      expect(buttonVisibleStyle(submitButton)).toEqual(disabledSubmitStyle);
+      expect(buttonVisibleStyle(submitButton)).toEqual(outlineSubmitStyle);
     });
   },
 };

--- a/ui/src/components/ui/input.test.tsx
+++ b/ui/src/components/ui/input.test.tsx
@@ -30,6 +30,8 @@ describe("Input primitives", () => {
 
     const textarea = screen.getByLabelText("Factory notes");
     expect(textarea.className).toContain("min-h-28");
+    expect(textarea.className).toContain("max-h-52");
+    expect(textarea.className).toContain("overflow-y-auto");
     expect(textarea.className).toContain("border-outline");
   });
 

--- a/ui/src/components/ui/input.test.tsx
+++ b/ui/src/components/ui/input.test.tsx
@@ -38,4 +38,12 @@ describe("Input primitives", () => {
       "custom-input",
     );
   });
+
+  it("applies the shared invalid field treatment when aria-invalid is true", () => {
+    render(<Input aria-invalid="true" aria-label="Factory name" />);
+
+    const input = screen.getByLabelText("Factory name");
+    expect(input.className).toContain("aria-invalid:border-af-danger-border");
+    expect(input.className).toContain("aria-invalid:ring-af-danger-border");
+  });
 });

--- a/ui/src/components/ui/input.tsx
+++ b/ui/src/components/ui/input.tsx
@@ -5,7 +5,7 @@ import { cn } from "../../lib/cn";
 export type InputProps = InputHTMLAttributes<HTMLInputElement>;
 
 const INPUT_CLASS =
-  "flex min-h-11 w-full rounded-xl border border-outline bg-surface-container-high px-3 py-2.5 text-sm text-on-surface outline-none transition-colors placeholder:text-on-surface-disabled focus-visible:border-outline-variant focus-visible:ring-2 focus-visible:ring-af-focus-ring disabled:cursor-not-allowed disabled:border-outline disabled:bg-surface-container-low disabled:text-on-surface-disabled";
+  "flex min-h-11 w-full rounded-xl border border-outline bg-surface-container-high px-3 py-2.5 text-sm text-on-surface outline-none transition-colors placeholder:text-on-surface-disabled focus-visible:border-outline-variant focus-visible:ring-2 focus-visible:ring-af-focus-ring aria-invalid:border-af-danger-border aria-invalid:ring-2 aria-invalid:ring-af-danger-border disabled:cursor-not-allowed disabled:border-outline disabled:bg-surface-container-low disabled:text-on-surface-disabled";
 
 export function inputVariants({ className }: { className?: string } = {}) {
   return cn(INPUT_CLASS, className);

--- a/ui/src/components/ui/textarea.test.tsx
+++ b/ui/src/components/ui/textarea.test.tsx
@@ -1,0 +1,79 @@
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+import { Textarea, textareaVariants } from "./textarea";
+
+describe("Textarea", () => {
+  it("applies the shared field surface with scroll constraints", () => {
+    render(<Textarea aria-label="Factory notes" />);
+
+    const textarea = screen.getByLabelText("Factory notes");
+    expect(textarea.className).toContain("min-h-28");
+    expect(textarea.className).toContain("max-h-52");
+    expect(textarea.className).toContain("overflow-y-auto");
+    expect(textarea.className).toContain("resize-none");
+    expect(textarea.className).toContain("border-outline");
+  });
+
+  it("exposes variant class generation for sibling primitive composition", () => {
+    expect(textareaVariants({ className: "custom-textarea" })).toContain(
+      "custom-textarea",
+    );
+    expect(textareaVariants()).toContain("overflow-y-auto");
+  });
+
+  it("keeps the plain variant free of field chrome and resize handles", () => {
+    render(<Textarea aria-label="Inline notes" variant="plain" />);
+
+    const textarea = screen.getByLabelText("Inline notes");
+    expect(textarea.className).toContain("resize-none");
+    expect(textarea.className).not.toContain("border-outline");
+    expect(textarea.className).not.toContain("overflow-y-auto");
+  });
+
+  it("allows long content to scroll inside the field surface", () => {
+    const longText = "line\n".repeat(40);
+    render(<Textarea aria-label="Factory notes" defaultValue={longText} />);
+
+    const textarea = screen.getByLabelText<HTMLTextAreaElement>("Factory notes");
+    Object.defineProperty(textarea, "scrollHeight", {
+      configurable: true,
+      value: 480,
+    });
+    Object.defineProperty(textarea, "clientHeight", {
+      configurable: true,
+      value: 208,
+    });
+
+    expect(textarea.scrollHeight).toBeGreaterThan(textarea.clientHeight);
+    textarea.scrollTop = 64;
+    expect(textarea.scrollTop).toBe(64);
+  });
+
+  it("preserves authoring behavior and disabled treatment", () => {
+    const onChange = vi.fn();
+
+    const { rerender } = render(
+      <Textarea aria-label="Factory notes" onChange={onChange} />,
+    );
+
+    const textarea = screen.getByLabelText<HTMLTextAreaElement>("Factory notes");
+    fireEvent.change(textarea, { target: { value: "Updated notes" } });
+    expect(onChange).toHaveBeenCalled();
+
+    fireEvent.paste(textarea, {
+      clipboardData: {
+        getData: () => " pasted",
+      },
+    });
+
+    textarea.focus();
+    expect(textarea).toHaveFocus();
+
+    rerender(
+      <Textarea aria-label="Factory notes" disabled onChange={onChange} />,
+    );
+    expect(screen.getByLabelText("Factory notes")).toBeDisabled();
+  });
+});

--- a/ui/src/components/ui/textarea.tsx
+++ b/ui/src/components/ui/textarea.tsx
@@ -6,9 +6,16 @@ import { inputVariants } from "./input";
 const TEXTAREA_PLAIN_CLASS =
   "m-0 w-full resize-none border-0 bg-transparent p-0 text-sm leading-6 text-on-surface outline-none";
 
+const TEXTAREA_FIELD_CLASS =
+  "min-h-28 max-h-52 resize-none overflow-y-auto py-3";
+
 export interface TextareaProps
   extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   variant?: "field" | "plain";
+}
+
+export function textareaVariants({ className }: { className?: string } = {}) {
+  return inputVariants({ className: cn(TEXTAREA_FIELD_CLASS, className) });
 }
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
@@ -18,9 +25,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         className={
           variant === "plain"
             ? cn(TEXTAREA_PLAIN_CLASS, className)
-            : inputVariants({
-                className: `min-h-28 resize-y py-3 ${className ?? ""}`,
-              })
+            : textareaVariants({ className })
         }
         ref={ref}
         {...props}

--- a/ui/src/features/bento/components/dashboard-widget-header-seam.test.tsx
+++ b/ui/src/features/bento/components/dashboard-widget-header-seam.test.tsx
@@ -200,7 +200,9 @@ describe("dashboard widget header seam", () => {
       title: messages.cardTitle,
     });
     expect(
-      within(card).getByRole("combobox", { name: messages.workTypeLabel }),
+      within(card).getByRole("combobox", {
+        name: `${messages.workTypeLabel} (${messages.workTypeRequiredAffordance})`,
+      }),
     ).toBeTruthy();
   });
 });

--- a/ui/src/features/bento/components/dashboard-widget-header-seam.test.tsx
+++ b/ui/src/features/bento/components/dashboard-widget-header-seam.test.tsx
@@ -165,6 +165,9 @@ describe("dashboard widget header seam", () => {
     ).toBeNull();
   });
 
+});
+
+describe("submit work dashboard widget header seam", () => {
   it("routes submit work header controls through the shared tools region without a separate move handle", () => {
     const messages = getSubmitWorkMessages();
     renderBentoWidget(

--- a/ui/src/features/submit-work/components/submit-work-card.stories.tsx
+++ b/ui/src/features/submit-work/components/submit-work-card.stories.tsx
@@ -92,7 +92,7 @@ export const Configured = {
         "Send a new request to the current factory from the dashboard.",
       ),
     ).toBeNull();
-    const workType = scope.getByRole("combobox", { name: "Work type" });
+    const workType = scope.getByRole("combobox", { name: /Work type/ });
     const requestName = scope.getByRole("textbox", { name: "Request name" });
     const requestText = scope.getByRole("textbox", { name: "Text item 1" });
     const submitButton = scope.getByRole("button", { name: "Submit work" });
@@ -118,7 +118,7 @@ export const Unconfigured = {
     const scope = within(card);
 
     await expect(
-      scope.getByRole("combobox", { name: "Work type" }),
+      scope.getByRole("combobox", { name: /Work type/ }),
     ).toBeDisabled();
     await expect(
       scope.getByRole("textbox", { name: "Request name" }),
@@ -169,7 +169,7 @@ export const FailureRetry = {
     const scope = within(card);
 
     await expect(
-      scope.getByRole("combobox", { name: "Work type" }),
+      scope.getByRole("combobox", { name: /Work type/ }),
     ).toHaveTextContent("story");
     await expect(
       scope.getByRole("textbox", { name: "Request name" }),
@@ -195,7 +195,7 @@ export const LocalizedZhCN = {
     const scope = within(card);
 
     await expect(
-      scope.getByRole("combobox", { name: "工作类型" }),
+      scope.getByRole("combobox", { name: /工作类型/ }),
     ).toBeVisible();
     await expect(
       scope.getByRole("textbox", { name: "请求名称" }),

--- a/ui/src/features/submit-work/components/submit-work-card.stories.tsx
+++ b/ui/src/features/submit-work/components/submit-work-card.stories.tsx
@@ -93,11 +93,18 @@ export const Configured = {
       ),
     ).toBeNull();
     const workType = scope.getByRole("combobox", { name: /Work type/ });
-    const requestName = scope.getByRole("textbox", { name: "Request name" });
+    const requestName = scope.getByRole("textbox", { name: /Request name/ });
     const requestText = scope.getByRole("textbox", { name: "Text item 1" });
     const submitButton = scope.getByRole("button", { name: "Submit work" });
 
-    await expect(submitButton).toBeDisabled();
+    await expect(submitButton).toBeEnabled();
+    await userEvent.click(submitButton);
+    await expect(
+      scope.getByText("Choose a work type before submitting."),
+    ).toBeVisible();
+    await expect(
+      scope.getByText("Enter a request name before submitting."),
+    ).toBeVisible();
     await selectComboboxOption(userEvent, workType, "story");
     await userEvent.type(requestName, "Driver review");
     await userEvent.type(
@@ -121,7 +128,7 @@ export const Unconfigured = {
       scope.getByRole("combobox", { name: /Work type/ }),
     ).toBeDisabled();
     await expect(
-      scope.getByRole("textbox", { name: "Request name" }),
+      scope.getByRole("textbox", { name: /Request name/ }),
     ).toBeDisabled();
     await expect(
       scope.getByRole("textbox", { name: "Text item 1" }),
@@ -172,7 +179,7 @@ export const FailureRetry = {
       scope.getByRole("combobox", { name: /Work type/ }),
     ).toHaveTextContent("story");
     await expect(
-      scope.getByRole("textbox", { name: "Request name" }),
+      scope.getByRole("textbox", { name: /Request name/ }),
     ).toHaveValue("Retry dashboard request");
     await expect(
       scope.getByRole("textbox", { name: "Text item 1" }),
@@ -206,7 +213,7 @@ export const LocalizedZhCN = {
     ).toBeVisible();
     await expect(
       scope.getByRole("button", { name: "提交工作" }),
-    ).toBeDisabled();
+    ).toBeEnabled();
   },
 };
 

--- a/ui/src/features/submit-work/components/submit-work-card.test.tsx
+++ b/ui/src/features/submit-work/components/submit-work-card.test.tsx
@@ -50,8 +50,35 @@ function renderSubmitWorkCard(
 }
 
 describe("SubmitWorkCard request name field", () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
   afterEach(() => {
     cleanup();
+  });
+
+  it("keeps submit enabled so validation can be triggered through user interaction", async () => {
+    const onSubmit = vi.fn();
+
+    renderSubmitWorkCard({
+      draft: {
+        ...defaultDraft,
+        requestName: "",
+        workTypeName: "",
+      },
+      onSubmit,
+    });
+
+    const submitButton = screen.getByRole("button", {
+      name: messages.submitAction,
+    });
+
+    expect(submitButton).toBeEnabled();
+    await user.click(submitButton);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 
   it("communicates that the request name is required before submission", () => {

--- a/ui/src/features/submit-work/components/submit-work-card.test.tsx
+++ b/ui/src/features/submit-work/components/submit-work-card.test.tsx
@@ -263,3 +263,147 @@ describe("SubmitWorkCard work type selector", () => {
     ).toBeNull();
   });
 });
+
+describe("SubmitWorkCard form-level status", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("keeps required-field validation on the controls without a detached status panel", () => {
+    renderSubmitWorkCard({
+      draft: {
+        ...defaultDraft,
+        requestName: "",
+        workTypeName: "",
+      },
+      validationErrors: {
+        requestName: messages.validationMessages.requestRequired,
+        workTypeName: messages.validationMessages.workTypeRequired,
+      },
+    });
+
+    expect(
+      screen.getByText(messages.validationMessages.requestRequired),
+    ).toHaveAttribute("role", "alert");
+    expect(
+      screen.getByText(messages.validationMessages.workTypeRequired),
+    ).toHaveAttribute("role", "alert");
+    expect(
+      screen.queryByText(messages.validationMessages.bothMissing),
+    ).toBeNull();
+    expect(screen.queryByRole("alert", { name: /before submitting/i })).toBeNull();
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("shows server submission failures through the card status panel", () => {
+    renderSubmitWorkCard({
+      draft: {
+        ...defaultDraft,
+        requestName: "Driver review",
+      },
+      status: {
+        kind: "error",
+        message: "work_type_name is required",
+      },
+    });
+
+    const statusPanel = screen.getByRole("alert");
+    expect(statusPanel).toHaveTextContent("work_type_name is required");
+    expect(statusPanel.className).toContain("bg-error-container");
+    expect(
+      screen.queryByText(messages.validationMessages.requestRequired),
+    ).toBeNull();
+    expect(
+      screen.queryByText(messages.validationMessages.workTypeRequired),
+    ).toBeNull();
+    expect(
+      screen.getByRole("textbox", {
+        name: `${messages.requestNameLabel} (${messages.requestNameRequiredAffordance})`,
+      }),
+    ).not.toHaveAttribute("aria-invalid");
+  });
+
+});
+
+describe("SubmitWorkCard submission outcomes", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows successful submissions through the card status panel without stale field invalid styling", () => {
+    renderSubmitWorkCard({
+      draft: {
+        ...defaultDraft,
+        requestName: "",
+      },
+      status: {
+        kind: "success",
+        message: messages.statusMessages.success("trace-submit-story"),
+      },
+    });
+
+    const statusPanel = screen.getByRole("status");
+    expect(statusPanel).toHaveTextContent("trace-submit-story");
+    expect(statusPanel.className).toContain("bg-success-container");
+    expect(
+      screen.getByRole("textbox", {
+        name: `${messages.requestNameLabel} (${messages.requestNameRequiredAffordance})`,
+      }),
+    ).not.toHaveAttribute("aria-invalid");
+    expect(
+      screen.getByRole("combobox", {
+        name: `${messages.workTypeLabel} (${messages.workTypeRequiredAffordance})`,
+      }),
+    ).not.toHaveAttribute("aria-invalid");
+    expect(
+      screen.queryByText(messages.validationMessages.requestRequired),
+    ).toBeNull();
+    expect(
+      screen.queryByText(messages.validationMessages.workTypeRequired),
+    ).toBeNull();
+  });
+
+  it("keeps submission-item validation on the detached status channel", () => {
+    renderSubmitWorkCard({
+      draft: {
+        items: [
+          {
+            fileName: "ui.png",
+            id: "submission-item-1",
+            mediaType: "image/png",
+            stagedFileRef: "staged://submit-work/ui.png",
+            stagingStatus: "idle",
+            type: "image",
+          },
+        ],
+        requestName: "Driver review",
+        workTypeName: "story",
+      },
+      status: {
+        kind: "validation-error",
+        message: messages.validationMessages.fileItemNeedsStaging,
+      },
+      validationErrors: {
+        submissionItems: messages.validationMessages.fileItemNeedsStaging,
+      },
+    });
+
+    const statusPanel = screen.getByRole("alert");
+    expect(statusPanel).toHaveTextContent(
+      messages.validationMessages.fileItemNeedsStaging,
+    );
+    expect(
+      screen.getAllByText(messages.validationMessages.fileItemNeedsStaging),
+    ).toHaveLength(2);
+    expect(
+      screen.getByRole("textbox", {
+        name: `${messages.requestNameLabel} (${messages.requestNameRequiredAffordance})`,
+      }),
+    ).not.toHaveAttribute("aria-invalid");
+    expect(
+      screen.getByRole("combobox", {
+        name: `${messages.workTypeLabel} (${messages.workTypeRequiredAffordance})`,
+      }),
+    ).not.toHaveAttribute("aria-invalid");
+  });
+});

--- a/ui/src/features/submit-work/components/submit-work-card.test.tsx
+++ b/ui/src/features/submit-work/components/submit-work-card.test.tsx
@@ -407,3 +407,103 @@ describe("SubmitWorkCard submission outcomes", () => {
     ).not.toHaveAttribute("aria-invalid");
   });
 });
+
+describe("SubmitWorkCard submission textarea", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("uses the shared textarea primitive with scroll constraints for long text", () => {
+    renderSubmitWorkCard({
+      draft: {
+        ...defaultDraft,
+        items: [
+          {
+            id: "submission-item-1",
+            text: "line\n".repeat(40),
+            type: "text",
+          },
+        ],
+      },
+    });
+
+    const submissionTextarea = screen.getByRole<HTMLTextAreaElement>("textbox", {
+      name: messages.requestItemLabel(1),
+    });
+
+    expect(submissionTextarea.className).toContain("min-h-28");
+    expect(submissionTextarea.className).toContain("max-h-52");
+    expect(submissionTextarea.className).toContain("overflow-y-auto");
+    expect(submissionTextarea.className).toContain("resize-none");
+    expect(submissionTextarea.className).toContain("border-outline");
+
+    Object.defineProperty(submissionTextarea, "scrollHeight", {
+      configurable: true,
+      value: 480,
+    });
+    Object.defineProperty(submissionTextarea, "clientHeight", {
+      configurable: true,
+      value: 208,
+    });
+
+    expect(submissionTextarea.scrollHeight).toBeGreaterThan(
+      submissionTextarea.clientHeight,
+    );
+    submissionTextarea.scrollTop = 72;
+    expect(submissionTextarea.scrollTop).toBe(72);
+  });
+
+  it("preserves authoring behavior and disabled treatment on the submission textarea", () => {
+    const onItemTextChange = vi.fn();
+
+    const { rerender } = renderSubmitWorkCard({
+      onItemTextChange,
+    });
+
+    const submissionTextarea = screen.getByRole<HTMLTextAreaElement>("textbox", {
+      name: messages.requestItemLabel(1),
+    });
+
+    fireEvent.change(submissionTextarea, {
+      target: { value: "Driver review details" },
+    });
+    expect(onItemTextChange).toHaveBeenCalledWith(
+      "submission-item-1",
+      "Driver review details",
+    );
+
+    fireEvent.paste(submissionTextarea, {
+      clipboardData: {
+        getData: () => " pasted",
+      },
+    });
+
+    submissionTextarea.focus();
+    expect(submissionTextarea).toHaveFocus();
+
+    rerender(
+      <SubmitWorkCard
+        draft={defaultDraft}
+        isSubmitting
+        onAddItem={() => {}}
+        onItemTextChange={onItemTextChange}
+        onRemoveItem={() => {}}
+        onRequestNameChange={() => {}}
+        onStageFileItems={() => {}}
+        onSubmit={() => {}}
+        onWorkTypeNameChange={() => {}}
+        status={{
+          kind: "submitting",
+          message: messages.statusMessages.submitting,
+        }}
+        submitWorkTypeNames={["story", "task"]}
+      />,
+    );
+
+    expect(
+      screen.getByRole<HTMLTextAreaElement>("textbox", {
+        name: messages.requestItemLabel(1),
+      }),
+    ).toBeDisabled();
+  });
+});

--- a/ui/src/features/submit-work/components/submit-work-card.test.tsx
+++ b/ui/src/features/submit-work/components/submit-work-card.test.tsx
@@ -1,8 +1,17 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { installDashboardBrowserTestShims } from "../../../components/dashboard/test-browser-shims";
+import { selectComboboxOption } from "../../../testing/select-test-helpers";
 import { getSubmitWorkMessages } from "../messages/submit-work";
 import { SubmitWorkCard } from "./submit-work-card";
 
@@ -118,6 +127,139 @@ describe("SubmitWorkCard request name field", () => {
     expect(requestName).not.toHaveAttribute("aria-describedby");
     expect(
       screen.queryByText(messages.validationMessages.requestRequired),
+    ).toBeNull();
+  });
+});
+
+describe("SubmitWorkCard work type selector", () => {
+  let restoreBrowserShims: (() => void) | undefined;
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    restoreBrowserShims = installDashboardBrowserTestShims();
+    user = userEvent.setup();
+  });
+
+  afterEach(() => {
+    cleanup();
+    restoreBrowserShims?.();
+    restoreBrowserShims = undefined;
+  });
+
+  it("communicates that the work type is required before submission", () => {
+    renderSubmitWorkCard({
+      draft: {
+        ...defaultDraft,
+        workTypeName: "",
+      },
+    });
+
+    expect(
+      screen.getByRole("combobox", {
+        name: `${messages.workTypeLabel} (${messages.workTypeRequiredAffordance})`,
+      }),
+    ).toHaveAttribute("aria-required", "true");
+  });
+
+  it("marks the work type selector invalid with accessible field feedback on submit", () => {
+    renderSubmitWorkCard({
+      draft: {
+        ...defaultDraft,
+        requestName: "Driver review",
+        workTypeName: "",
+      },
+      validationErrors: {
+        workTypeName: messages.validationMessages.workTypeRequired,
+      },
+    });
+
+    const workType = screen.getByRole("combobox", {
+      name: `${messages.workTypeLabel} (${messages.workTypeRequiredAffordance})`,
+    });
+    const error = screen.getByText(messages.validationMessages.workTypeRequired);
+
+    expect(workType).toHaveAttribute("aria-invalid", "true");
+    expect(workType).toHaveAttribute("aria-describedby", error.id);
+    expect(error).toHaveAttribute("role", "alert");
+    expect(
+      screen.queryByText(messages.validationMessages.bothMissing),
+    ).toBeNull();
+  });
+
+  it("opens the work type selector with keyboard interaction", async () => {
+    const onWorkTypeNameChange = vi.fn();
+
+    renderSubmitWorkCard({
+      draft: {
+        ...defaultDraft,
+        workTypeName: "",
+      },
+      onWorkTypeNameChange,
+    });
+
+    const workType = screen.getByRole("combobox", {
+      name: `${messages.workTypeLabel} (${messages.workTypeRequiredAffordance})`,
+    });
+
+    workType.focus();
+    await user.keyboard("{Enter}");
+    await screen.findByRole("listbox");
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    expect(onWorkTypeNameChange).toHaveBeenCalledWith("story");
+  });
+
+  it("clears work type invalid styling when a valid option is selected", async () => {
+    const onWorkTypeNameChange = vi.fn();
+    const { rerender } = renderSubmitWorkCard({
+      draft: {
+        ...defaultDraft,
+        requestName: "Driver review",
+        workTypeName: "",
+      },
+      onWorkTypeNameChange,
+      validationErrors: {
+        workTypeName: messages.validationMessages.workTypeRequired,
+      },
+    });
+
+    const workType = screen.getByRole("combobox", {
+      name: `${messages.workTypeLabel} (${messages.workTypeRequiredAffordance})`,
+    });
+
+    await selectComboboxOption(user, workType, "story");
+    expect(onWorkTypeNameChange).toHaveBeenCalledWith("story");
+
+    rerender(
+      <SubmitWorkCard
+        draft={{
+          ...defaultDraft,
+          requestName: "Driver review",
+          workTypeName: "story",
+        }}
+        onAddItem={() => {}}
+        onItemTextChange={() => {}}
+        onRemoveItem={() => {}}
+        onRequestNameChange={() => {}}
+        onStageFileItems={() => {}}
+        onSubmit={() => {}}
+        onWorkTypeNameChange={onWorkTypeNameChange}
+        status={{
+          kind: "guidance",
+          message: messages.statusMessages.ready,
+        }}
+        submitWorkTypeNames={["story", "task"]}
+      />,
+    );
+
+    const correctedWorkType = screen.getByRole("combobox", {
+      name: `${messages.workTypeLabel} (${messages.workTypeRequiredAffordance})`,
+    });
+
+    expect(correctedWorkType).not.toHaveAttribute("aria-invalid");
+    expect(correctedWorkType).not.toHaveAttribute("aria-describedby");
+    expect(
+      screen.queryByText(messages.validationMessages.workTypeRequired),
     ).toBeNull();
   });
 });

--- a/ui/src/features/submit-work/components/submit-work-card.test.tsx
+++ b/ui/src/features/submit-work/components/submit-work-card.test.tsx
@@ -1,3 +1,4 @@
+// biome-ignore lint/nursery/noExcessiveLinesPerFile: submit-work card field, status, and textarea coverage stay together for one render helper.
 import "@testing-library/jest-dom/vitest";
 import {
   cleanup,
@@ -50,35 +51,8 @@ function renderSubmitWorkCard(
 }
 
 describe("SubmitWorkCard request name field", () => {
-  let user: ReturnType<typeof userEvent.setup>;
-
-  beforeEach(() => {
-    user = userEvent.setup();
-  });
-
   afterEach(() => {
     cleanup();
-  });
-
-  it("keeps submit enabled so validation can be triggered through user interaction", async () => {
-    const onSubmit = vi.fn();
-
-    renderSubmitWorkCard({
-      draft: {
-        ...defaultDraft,
-        requestName: "",
-        workTypeName: "",
-      },
-      onSubmit,
-    });
-
-    const submitButton = screen.getByRole("button", {
-      name: messages.submitAction,
-    });
-
-    expect(submitButton).toBeEnabled();
-    await user.click(submitButton);
-    expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 
   it("communicates that the request name is required before submission", () => {

--- a/ui/src/features/submit-work/components/submit-work-card.test.tsx
+++ b/ui/src/features/submit-work/components/submit-work-card.test.tsx
@@ -1,0 +1,123 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getSubmitWorkMessages } from "../messages/submit-work";
+import { SubmitWorkCard } from "./submit-work-card";
+
+const messages = getSubmitWorkMessages("en");
+const defaultDraft = {
+  items: [{ id: "submission-item-1", text: "", type: "text" as const }],
+  requestName: "",
+  workTypeName: "story",
+};
+
+function renderSubmitWorkCard(
+  overrides: Partial<ComponentProps<typeof SubmitWorkCard>> = {},
+) {
+  const onRequestNameChange = vi.fn();
+
+  const view = render(
+    <SubmitWorkCard
+      draft={defaultDraft}
+      onAddItem={() => {}}
+      onItemTextChange={() => {}}
+      onRemoveItem={() => {}}
+      onRequestNameChange={onRequestNameChange}
+      onStageFileItems={() => {}}
+      onSubmit={() => {}}
+      onWorkTypeNameChange={() => {}}
+      status={{
+        kind: "guidance",
+        message: messages.statusMessages.ready,
+      }}
+      submitWorkTypeNames={["story", "task"]}
+      {...overrides}
+    />,
+  );
+
+  return { onRequestNameChange, ...view };
+}
+
+describe("SubmitWorkCard request name field", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("communicates that the request name is required before submission", () => {
+    renderSubmitWorkCard();
+
+    const card = screen.getByRole("article", { name: messages.cardTitle });
+    expect(within(card).getByText("(required)")).toBeInTheDocument();
+    expect(
+      within(card).getByRole("textbox", {
+        name: `${messages.requestNameLabel} (${messages.requestNameRequiredAffordance})`,
+      }),
+    ).toHaveAttribute("aria-required", "true");
+  });
+
+  it("marks the request name invalid with accessible field feedback on submit", () => {
+    renderSubmitWorkCard({
+      validationErrors: {
+        requestName: messages.validationMessages.requestRequired,
+      },
+    });
+
+    const requestName = screen.getByRole<HTMLInputElement>("textbox", {
+      name: `${messages.requestNameLabel} (${messages.requestNameRequiredAffordance})`,
+    });
+    const error = screen.getByText(messages.validationMessages.requestRequired);
+
+    expect(requestName).toHaveAttribute("aria-invalid", "true");
+    expect(requestName).toHaveAttribute("aria-describedby", error.id);
+    expect(error).toHaveAttribute("role", "alert");
+    expect(
+      screen.queryByText(messages.validationMessages.bothMissing),
+    ).toBeNull();
+  });
+
+  it("clears request name invalid styling when a non-empty value is provided", () => {
+    const { onRequestNameChange, rerender } = renderSubmitWorkCard({
+      validationErrors: {
+        requestName: messages.validationMessages.requestRequired,
+      },
+    });
+
+    fireEvent.change(
+      screen.getByRole("textbox", {
+        name: `${messages.requestNameLabel} (${messages.requestNameRequiredAffordance})`,
+      }),
+      { target: { value: "Driver review" } },
+    );
+    expect(onRequestNameChange).toHaveBeenCalledWith("Driver review");
+
+    rerender(
+      <SubmitWorkCard
+        draft={{ ...defaultDraft, requestName: "Driver review" }}
+        onAddItem={() => {}}
+        onItemTextChange={() => {}}
+        onRemoveItem={() => {}}
+        onRequestNameChange={onRequestNameChange}
+        onStageFileItems={() => {}}
+        onSubmit={() => {}}
+        onWorkTypeNameChange={() => {}}
+        status={{
+          kind: "guidance",
+          message: messages.statusMessages.ready,
+        }}
+        submitWorkTypeNames={["story", "task"]}
+      />,
+    );
+
+    const requestName = screen.getByRole<HTMLInputElement>("textbox", {
+      name: `${messages.requestNameLabel} (${messages.requestNameRequiredAffordance})`,
+    });
+
+    expect(requestName).not.toHaveAttribute("aria-invalid");
+    expect(requestName).not.toHaveAttribute("aria-describedby");
+    expect(
+      screen.queryByText(messages.validationMessages.requestRequired),
+    ).toBeNull();
+  });
+});

--- a/ui/src/features/submit-work/components/submit-work-card.tsx
+++ b/ui/src/features/submit-work/components/submit-work-card.tsx
@@ -6,6 +6,7 @@ import {
   DashboardIconButtonShell,
   DashboardLabel,
   DashboardText,
+  FormError,
   Input,
   Popover,
   PopoverContent,
@@ -160,28 +161,35 @@ export function SubmitWorkCard({
         >
           <div className="grid gap-2">
             <label htmlFor={requestNameID}>
-              <DashboardLabel>{messages.requestNameLabel}</DashboardLabel>
+              <DashboardLabel>
+                {messages.requestNameLabel}{" "}
+                <DashboardText
+                  as="span"
+                  className="text-on-error-container"
+                  variant="supporting"
+                >
+                  ({messages.requestNameRequiredAffordance})
+                </DashboardText>
+              </DashboardLabel>
             </label>
             <Input
               aria-describedby={
                 validationErrors?.requestName ? requestNameErrorID : undefined
               }
               aria-invalid={validationErrors?.requestName ? "true" : undefined}
+              aria-required="true"
               disabled={controlsDisabled}
               id={requestNameID}
               onChange={(event) => onRequestNameChange(event.target.value)}
               placeholder={messages.requestNamePlaceholder}
+              required
               type="text"
               value={draft.requestName}
             />
             {validationErrors?.requestName ? (
-              <DashboardText
-                className="text-on-error-container"
-                id={requestNameErrorID}
-                variant="supporting"
-              >
+              <FormError id={requestNameErrorID}>
                 {validationErrors.requestName}
-              </DashboardText>
+              </FormError>
             ) : null}
           </div>
 

--- a/ui/src/features/submit-work/components/submit-work-card.tsx
+++ b/ui/src/features/submit-work/components/submit-work-card.tsx
@@ -271,13 +271,14 @@ function SubmitWorkHeaderControls({
     <div className="flex min-w-0 flex-wrap items-center justify-end gap-2">
       <div className="grid min-w-36 gap-1">
         <label className="sr-only" htmlFor={workTypeID}>
-          {messages.workTypeLabel}
+          {messages.workTypeLabel} ({messages.workTypeRequiredAffordance})
         </label>
         <OptionalEnumSelect
           aria-describedby={
             validationErrors?.workTypeName ? workTypeErrorID : undefined
           }
           aria-invalid={validationErrors?.workTypeName ? "true" : undefined}
+          aria-required="true"
           className="min-h-9 py-2 text-xs"
           disabled={controlsDisabled}
           emptyOptionLabel={messages.selectWorkTypePlaceholder}
@@ -290,9 +291,9 @@ function SubmitWorkHeaderControls({
           value={workTypeName || null}
         />
         {validationErrors?.workTypeName ? (
-          <p className="sr-only" id={workTypeErrorID}>
+          <FormError id={workTypeErrorID}>
             {validationErrors.workTypeName}
-          </p>
+          </FormError>
         ) : null}
       </div>
       <AddSubmissionItemMenu

--- a/ui/src/features/submit-work/components/submit-work-card.tsx
+++ b/ui/src/features/submit-work/components/submit-work-card.tsx
@@ -109,12 +109,10 @@ export function SubmitWorkCard({
   const hasSelectedWorkType = draft.workTypeName.length > 0;
   const hasValidRequestName = draft.requestName.trim().length > 0;
   const controlsDisabled = !hasConfiguredWorkTypes || isSubmitting;
-  const canSubmit =
-    hasConfiguredWorkTypes &&
-    !hasIncompleteFileItems &&
-    hasSelectedWorkType &&
-    hasValidRequestName &&
-    !isSubmitting;
+  const canAttemptSubmit =
+    hasConfiguredWorkTypes && !hasIncompleteFileItems && !isSubmitting;
+  const isFormReady =
+    canAttemptSubmit && hasSelectedWorkType && hasValidRequestName;
   const requestNameID = `${widgetId}-request-name`;
   const requestNameErrorID = `${widgetId}-request-name-error`;
   const submissionItemsID = `${widgetId}-submission-items`;
@@ -182,7 +180,6 @@ export function SubmitWorkCard({
               id={requestNameID}
               onChange={(event) => onRequestNameChange(event.target.value)}
               placeholder={messages.requestNamePlaceholder}
-              required
               type="text"
               value={draft.requestName}
             />
@@ -226,8 +223,8 @@ export function SubmitWorkCard({
           <Button
             aria-busy={isSubmitting ? "true" : undefined}
             className="w-full justify-center"
-            disabled={!canSubmit}
-            tone={canSubmit ? "default" : "outline"}
+            disabled={!canAttemptSubmit}
+            tone={isFormReady ? "default" : "outline"}
             type="submit"
           >
             {isSubmitting ? messages.submittingAction : messages.submitAction}

--- a/ui/src/features/submit-work/components/submit-work-widget.test.tsx
+++ b/ui/src/features/submit-work/components/submit-work-widget.test.tsx
@@ -30,7 +30,7 @@ let restoreBrowserShims: (() => void) | undefined;
 let user: ReturnType<typeof userEvent.setup>;
 
 async function selectWorkType(
-  label: string | RegExp = "Work type",
+  label: string | RegExp = /Work type/,
   optionName = "story",
 ) {
   await selectLabeledComboboxOption(user, label, optionName);
@@ -70,7 +70,7 @@ describe("SubmitWorkWidget form behavior", () => {
       ),
     ).toBeNull();
     expect(
-      within(card).getByRole("combobox", { name: "Work type" }),
+      within(card).getByRole("combobox", { name: /Work type/ }),
     ).toBeTruthy();
     expect(
       within(card).getByRole("textbox", { name: /Request name/ }),
@@ -160,7 +160,7 @@ describe("SubmitWorkWidget form behavior", () => {
       />,
     );
 
-    const workType = screen.getByRole("combobox", { name: "Work type" });
+    const workType = screen.getByRole("combobox", { name: /Work type/ });
     const addInput = screen.getByRole("button", { name: "Add input" });
     const remove = screen.getByRole("button", {
       name: "Remove Submit work widget from dashboard",
@@ -258,9 +258,12 @@ describe("SubmitWorkWidget form behavior", () => {
         "Choose a work type and enter a request name before submitting.",
       ),
     ).toBeNull();
+    const workType = screen.getByRole("combobox", { name: /Work type/ });
+
     expect(
       screen.getByText("Choose a work type before submitting."),
-    ).toBeTruthy();
+    ).toHaveAttribute("role", "alert");
+    expect(workType.getAttribute("aria-invalid")).toBe("true");
     expect(
       screen.getByText("Enter a request name before submitting."),
     ).toHaveAttribute("role", "alert");
@@ -998,7 +1001,7 @@ describe("SubmitWorkWidget file-backed item behavior", () => {
       />,
     );
 
-    await selectWorkType("工作类型");
+    await selectWorkType(/工作类型/);
     fireEvent.change(screen.getByRole("textbox", { name: /请求名称/ }), {
       target: { value: "中文请求" },
     });
@@ -1206,7 +1209,7 @@ describe("SubmitWorkWidget submission behavior", () => {
     );
 
     const workType = screen.getByRole("combobox", {
-      name: "Work type",
+      name: /Work type/,
     });
     const requestName = screen.getByRole<HTMLInputElement>("textbox", {
       name: /Request name/,
@@ -1293,7 +1296,7 @@ describe("SubmitWorkWidget submission behavior", () => {
     );
 
     const workType = screen.getByRole("combobox", {
-      name: "Work type",
+      name: /Work type/,
     });
 
     await selectWorkType();
@@ -1307,7 +1310,7 @@ describe("SubmitWorkWidget submission behavior", () => {
       </QueryClientProvider>,
     );
 
-    expect(screen.getByRole("combobox", { name: "Work type" })).toHaveTextContent(
+    expect(screen.getByRole("combobox", { name: /Work type/ })).toHaveTextContent(
       "Select a work type",
     );
   });
@@ -1488,7 +1491,7 @@ describe("SubmitWorkWidget submission behavior", () => {
     );
 
     const workType = screen.getByRole("combobox", {
-      name: "Work type",
+      name: /Work type/,
     });
     const requestName = screen.getByRole<HTMLInputElement>("textbox", {
       name: /Request name/,
@@ -1571,7 +1574,7 @@ describe("SubmitWorkWidget submission behavior", () => {
     );
 
     const workType = screen.getByRole("combobox", {
-      name: "Work type",
+      name: /Work type/,
     });
     const requestName = screen.getByRole<HTMLInputElement>("textbox", {
       name: /Request name/,
@@ -1621,7 +1624,7 @@ describe("SubmitWorkWidget submission behavior", () => {
     renderSubmitWorkWidget(<SubmitWorkWidget submitWorkTypes={[]} />);
 
     const workType = screen.getByRole("combobox", {
-      name: "Work type",
+      name: /Work type/,
     });
     const requestName = screen.getByRole<HTMLInputElement>("textbox", {
       name: /Request name/,
@@ -1653,7 +1656,7 @@ describe("SubmitWorkWidget submission behavior", () => {
     const card = screen.getByRole("article", { name: "提交工作" });
 
     expect(
-      within(card).getByRole("combobox", { name: "工作类型" }),
+      within(card).getByRole("combobox", { name: /工作类型/ }),
     ).toBeTruthy();
     expect(
       within(card).getByRole("textbox", { name: /请求名称/ }),

--- a/ui/src/features/submit-work/components/submit-work-widget.test.tsx
+++ b/ui/src/features/submit-work/components/submit-work-widget.test.tsx
@@ -1469,6 +1469,88 @@ describe("SubmitWorkWidget submission behavior", () => {
     });
   });
 
+  it("clears stale required-field invalid styling after a successful submit", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ traceId: "trace-submit-story" }), {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        status: 201,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    renderSubmitWorkWidget(
+      <SubmitWorkWidget submitWorkTypes={[{ work_type_name: "story" }]} />,
+    );
+
+    const submitButton = screen.getByRole<HTMLButtonElement>("button", {
+      name: "Submit work",
+    });
+    const form = submitButton.closest("form");
+    if (!(form instanceof HTMLFormElement)) {
+      throw new Error(
+        "expected the submit button to be rendered inside a form",
+      );
+    }
+
+    fireEvent.submit(form);
+
+    const requestName = screen.getByRole<HTMLInputElement>("textbox", {
+      name: /Request name/,
+    });
+    const workType = screen.getByRole("combobox", { name: /Work type/ });
+
+    expect(requestName.getAttribute("aria-invalid")).toBe("true");
+    expect(workType.getAttribute("aria-invalid")).toBe("true");
+    expect(screen.queryByRole("status")).toBeNull();
+
+    await selectWorkType();
+    fireEvent.change(requestName, {
+      target: { value: "Driver review" },
+    });
+    fireEvent.click(submitButton);
+
+    expect(
+      await screen.findByText(
+        "Your request was submitted. Trace ID: trace-submit-story.",
+      ),
+    ).toBeTruthy();
+    expect(requestName).not.toHaveAttribute("aria-invalid");
+    expect(workType).not.toHaveAttribute("aria-invalid");
+    expect(
+      screen.queryByText("Enter a request name before submitting."),
+    ).toBeNull();
+    expect(
+      screen.queryByText("Choose a work type before submitting."),
+    ).toBeNull();
+  });
+
+  it("shows network submission failures through the card status panel", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"));
+    vi.stubGlobal("fetch", fetchMock);
+    renderSubmitWorkWidget(
+      <SubmitWorkWidget submitWorkTypes={[{ work_type_name: "story" }]} />,
+    );
+
+    await selectWorkType();
+    fireEvent.change(screen.getByRole("textbox", { name: /Request name/ }), {
+      target: { value: "Driver review" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Submit work" }));
+
+    const statusPanel = await screen.findByRole("alert");
+    expect(statusPanel).toHaveTextContent(
+      "We couldn't submit your request. Try again in a moment.",
+    );
+    expect(statusPanel.className).toContain("bg-error-container");
+    expect(
+      screen.getByRole("textbox", { name: /Request name/ }),
+    ).not.toHaveAttribute("aria-invalid");
+    expect(screen.getByRole("combobox", { name: /Work type/ })).not.toHaveAttribute(
+      "aria-invalid",
+    );
+  });
+
   it("shows the server error inline and preserves the draft after a failed submission", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(

--- a/ui/src/features/submit-work/components/submit-work-widget.test.tsx
+++ b/ui/src/features/submit-work/components/submit-work-widget.test.tsx
@@ -183,7 +183,7 @@ describe("SubmitWorkWidget form behavior", () => {
     ).toBe(true);
   });
 
-  it("enables submission only after a configured work type and non-blank request name are present", async () => {
+  it("keeps submit reachable for validation and uses primary styling when required fields are complete", async () => {
     renderSubmitWorkWidget(
       <SubmitWorkWidget
         submitWorkTypes={[
@@ -203,7 +203,8 @@ describe("SubmitWorkWidget form behavior", () => {
       name: "Submit work",
     });
 
-    expect(submitButton.disabled).toBe(true);
+    expect(submitButton.disabled).toBe(false);
+    expect(submitButton.className).not.toContain("bg-primary");
     expect(
       screen.queryByText(
         "Choose a work type and enter a request name to continue.",
@@ -211,14 +212,17 @@ describe("SubmitWorkWidget form behavior", () => {
     ).toBeNull();
 
     await selectWorkType();
-    expect(submitButton.disabled).toBe(true);
+    expect(submitButton.disabled).toBe(false);
+    expect(submitButton.className).not.toContain("bg-primary");
     expect(screen.getByText("(required)")).toBeTruthy();
 
     fireEvent.change(requestName, { target: { value: "   " } });
-    expect(submitButton.disabled).toBe(true);
+    expect(submitButton.disabled).toBe(false);
+    expect(submitButton.className).not.toContain("bg-primary");
 
     fireEvent.change(requestName, { target: { value: "Driver review" } });
     expect(submitButton.disabled).toBe(false);
+    expect(submitButton.className).toContain("bg-primary");
 
     fireEvent.change(requestText, {
       target: { value: "Review the failed driver trace." },
@@ -242,15 +246,8 @@ describe("SubmitWorkWidget form behavior", () => {
     const submitButton = screen.getByRole<HTMLButtonElement>("button", {
       name: "Submit work",
     });
-    const form = submitButton.closest("form");
 
-    if (!(form instanceof HTMLFormElement)) {
-      throw new Error(
-        "expected the submit button to be rendered inside a form",
-      );
-    }
-
-    fireEvent.submit(form);
+    await user.click(submitButton);
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(
@@ -266,6 +263,30 @@ describe("SubmitWorkWidget form behavior", () => {
     expect(workType.getAttribute("aria-invalid")).toBe("true");
     expect(
       screen.getByText("Enter a request name before submitting."),
+    ).toHaveAttribute("role", "alert");
+  });
+
+  it("shows field validation when pressing Enter in the request name field", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    renderSubmitWorkWidget(
+      <SubmitWorkWidget submitWorkTypes={[{ work_type_name: "story" }]} />,
+    );
+
+    const requestName = screen.getByRole<HTMLInputElement>("textbox", {
+      name: /Request name/,
+    });
+
+    requestName.focus();
+    await user.keyboard("{Enter}");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(requestName.getAttribute("aria-invalid")).toBe("true");
+    expect(
+      screen.getByText("Enter a request name before submitting."),
+    ).toHaveAttribute("role", "alert");
+    expect(
+      screen.getByText("Choose a work type before submitting."),
     ).toHaveAttribute("role", "alert");
   });
 
@@ -1337,19 +1358,12 @@ describe("SubmitWorkWidget submission behavior", () => {
     });
 
     await selectWorkType();
-    expect(submitButton.disabled).toBe(true);
+    expect(submitButton.disabled).toBe(false);
 
     fireEvent.change(requestName, { target: { value: "   " } });
-    expect(submitButton.disabled).toBe(true);
+    expect(submitButton.disabled).toBe(false);
 
-    const form = submitButton.closest("form");
-    if (!(form instanceof HTMLFormElement)) {
-      throw new Error(
-        "expected the submit button to be rendered inside a form",
-      );
-    }
-
-    fireEvent.submit(form);
+    await user.click(submitButton);
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(
@@ -1486,14 +1500,8 @@ describe("SubmitWorkWidget submission behavior", () => {
     const submitButton = screen.getByRole<HTMLButtonElement>("button", {
       name: "Submit work",
     });
-    const form = submitButton.closest("form");
-    if (!(form instanceof HTMLFormElement)) {
-      throw new Error(
-        "expected the submit button to be rendered inside a form",
-      );
-    }
 
-    fireEvent.submit(form);
+    await user.click(submitButton);
 
     const requestName = screen.getByRole<HTMLInputElement>("textbox", {
       name: /Request name/,
@@ -1508,7 +1516,7 @@ describe("SubmitWorkWidget submission behavior", () => {
     fireEvent.change(requestName, {
       target: { value: "Driver review" },
     });
-    fireEvent.click(submitButton);
+    await user.click(submitButton);
 
     expect(
       await screen.findByText(

--- a/ui/src/features/submit-work/components/submit-work-widget.test.tsx
+++ b/ui/src/features/submit-work/components/submit-work-widget.test.tsx
@@ -73,7 +73,7 @@ describe("SubmitWorkWidget form behavior", () => {
       within(card).getByRole("combobox", { name: "Work type" }),
     ).toBeTruthy();
     expect(
-      within(card).getByRole("textbox", { name: "Request name" }),
+      within(card).getByRole("textbox", { name: /Request name/ }),
     ).toBeTruthy();
     expect(
       within(card).getByRole("list", { name: "Submission items" }),
@@ -194,7 +194,7 @@ describe("SubmitWorkWidget form behavior", () => {
     );
 
     const requestName = screen.getByRole<HTMLInputElement>("textbox", {
-      name: "Request name",
+      name: /Request name/,
     });
     const requestText = screen.getByRole<HTMLTextAreaElement>("textbox", {
       name: "Text item 1",
@@ -212,7 +212,7 @@ describe("SubmitWorkWidget form behavior", () => {
 
     await selectWorkType();
     expect(submitButton.disabled).toBe(true);
-    expect(screen.getByText("Enter a request name to continue.")).toBeTruthy();
+    expect(screen.getByText("(required)")).toBeTruthy();
 
     fireEvent.change(requestName, { target: { value: "   " } });
     expect(submitButton.disabled).toBe(true);
@@ -254,16 +254,16 @@ describe("SubmitWorkWidget form behavior", () => {
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(
-      await screen.findAllByText(
+      screen.queryByText(
         "Choose a work type and enter a request name before submitting.",
       ),
-    ).toHaveLength(1);
+    ).toBeNull();
     expect(
       screen.getByText("Choose a work type before submitting."),
     ).toBeTruthy();
     expect(
       screen.getByText("Enter a request name before submitting."),
-    ).toBeTruthy();
+    ).toHaveAttribute("role", "alert");
   });
 
   it("renders a seeded ordered submission-items list with one blank text item by default", () => {
@@ -999,7 +999,7 @@ describe("SubmitWorkWidget file-backed item behavior", () => {
     );
 
     await selectWorkType("工作类型");
-    fireEvent.change(screen.getByRole("textbox", { name: "请求名称" }), {
+    fireEvent.change(screen.getByRole("textbox", { name: /请求名称/ }), {
       target: { value: "中文请求" },
     });
     fireEvent.change(screen.getByRole("textbox", { name: "文本项 1" }), {
@@ -1209,7 +1209,7 @@ describe("SubmitWorkWidget submission behavior", () => {
       name: "Work type",
     });
     const requestName = screen.getByRole<HTMLInputElement>("textbox", {
-      name: "Request name",
+      name: /Request name/,
     });
     const requestText = screen.getByRole<HTMLTextAreaElement>("textbox", {
       name: "Text item 1",
@@ -1330,7 +1330,7 @@ describe("SubmitWorkWidget submission behavior", () => {
       name: "Submit work",
     });
     const requestName = screen.getByRole<HTMLInputElement>("textbox", {
-      name: "Request name",
+      name: /Request name/,
     });
 
     await selectWorkType();
@@ -1350,8 +1350,13 @@ describe("SubmitWorkWidget submission behavior", () => {
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(
-      await screen.findAllByText("Enter a request name before submitting."),
-    ).toHaveLength(2);
+      screen.getByText("Enter a request name before submitting."),
+    ).toHaveAttribute("role", "alert");
+    expect(
+      screen.queryByText(
+        "Choose a work type and enter a request name before submitting.",
+      ),
+    ).toBeNull();
     expect(requestName.getAttribute("aria-invalid")).toBe("true");
   });
 
@@ -1371,7 +1376,7 @@ describe("SubmitWorkWidget submission behavior", () => {
 
     const card = screen.getByRole("article", { name: "Submit work" });
     const requestName = screen.getByRole<HTMLInputElement>("textbox", {
-      name: "Request name",
+      name: /Request name/,
     });
     const defaultTextItem = screen.getByRole<HTMLTextAreaElement>("textbox", {
       name: "Text item 1",
@@ -1430,7 +1435,7 @@ describe("SubmitWorkWidget submission behavior", () => {
     );
 
     await selectWorkType();
-    fireEvent.change(screen.getByRole("textbox", { name: "Request name" }), {
+    fireEvent.change(screen.getByRole("textbox", { name: /Request name/ }), {
       target: { value: "Ordered text payload" },
     });
     fireEvent.change(screen.getByRole("textbox", { name: "Text item 1" }), {
@@ -1486,7 +1491,7 @@ describe("SubmitWorkWidget submission behavior", () => {
       name: "Work type",
     });
     const requestName = screen.getByRole<HTMLInputElement>("textbox", {
-      name: "Request name",
+      name: /Request name/,
     });
     const requestText = screen.getByRole<HTMLTextAreaElement>("textbox", {
       name: "Text item 1",
@@ -1525,7 +1530,7 @@ describe("SubmitWorkWidget submission behavior", () => {
     await selectWorkType();
     fireEvent.change(
       screen.getByRole<HTMLInputElement>("textbox", {
-        name: "Request name",
+        name: /Request name/,
       }),
       {
         target: { value: "Beta submission" },
@@ -1569,7 +1574,7 @@ describe("SubmitWorkWidget submission behavior", () => {
       name: "Work type",
     });
     const requestName = screen.getByRole<HTMLInputElement>("textbox", {
-      name: "Request name",
+      name: /Request name/,
     });
     const requestText = screen.getByRole<HTMLTextAreaElement>("textbox", {
       name: "Text item 1",
@@ -1619,7 +1624,7 @@ describe("SubmitWorkWidget submission behavior", () => {
       name: "Work type",
     });
     const requestName = screen.getByRole<HTMLInputElement>("textbox", {
-      name: "Request name",
+      name: /Request name/,
     });
     const requestText = screen.getByRole<HTMLTextAreaElement>("textbox", {
       name: "Text item 1",
@@ -1651,7 +1656,7 @@ describe("SubmitWorkWidget submission behavior", () => {
       within(card).getByRole("combobox", { name: "工作类型" }),
     ).toBeTruthy();
     expect(
-      within(card).getByRole("textbox", { name: "请求名称" }),
+      within(card).getByRole("textbox", { name: /请求名称/ }),
     ).toBeTruthy();
     expect(within(card).getByRole("list", { name: "提交项" })).toBeTruthy();
     expect(

--- a/ui/src/features/submit-work/hooks/use-submit-work-widget-helpers.test.ts
+++ b/ui/src/features/submit-work/hooks/use-submit-work-widget-helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { SubmitWorkAPIError } from "../../../api/work";
 import type { SubmitWorkDraft } from "../components/submit-work-card";
 import { getSubmitWorkMessages } from "../messages/submit-work";
 import {
@@ -114,6 +115,54 @@ describe("buildStatus", () => {
     ).toEqual({
       kind: "guidance",
       message: messages.statusMessages.ready,
+    });
+  });
+
+  it("prioritizes server submission failures over guidance and validation status", () => {
+    const draft = {
+      ...createDefaultDraft(),
+      requestName: "Driver review",
+      workTypeName: "story",
+    };
+
+    expect(
+      buildStatus({
+        draft,
+        error: new SubmitWorkAPIError({
+          code: "BAD_REQUEST",
+          message: "work_type_name is required",
+          status: 400,
+          statusText: "Bad Request",
+        }),
+        isSubmitting: false,
+        isSuccess: false,
+        messages,
+        showValidation: true,
+        submitWorkTypeNames: ["story"],
+      }),
+    ).toEqual({
+      kind: "error",
+      message: "work_type_name is required",
+    });
+  });
+
+  it("prioritizes successful submission status over validation state", () => {
+    const draft = createDefaultDraft();
+
+    expect(
+      buildStatus({
+        draft,
+        error: null,
+        isSubmitting: false,
+        isSuccess: true,
+        messages,
+        resultTraceID: "trace-submit-story",
+        showValidation: true,
+        submitWorkTypeNames: ["story"],
+      }),
+    ).toEqual({
+      kind: "success",
+      message: messages.statusMessages.success("trace-submit-story"),
     });
   });
 

--- a/ui/src/features/submit-work/hooks/use-submit-work-widget-helpers.test.ts
+++ b/ui/src/features/submit-work/hooks/use-submit-work-widget-helpers.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import type { SubmitWorkDraft } from "../components/submit-work-card";
-import { buildStructuredSubmitItems } from "./use-submit-work-widget-helpers";
+import { getSubmitWorkMessages } from "../messages/submit-work";
+import {
+  buildStatus,
+  buildStructuredSubmitItems,
+  createDefaultDraft,
+} from "./use-submit-work-widget-helpers";
 
 function fileContentURL(path: string): string {
   return path.startsWith("/") ? `file://${path}` : `file:///${path}`;
@@ -62,5 +67,53 @@ describe("buildStructuredSubmitItems", () => {
     };
 
     expect(buildStructuredSubmitItems(draft)).toEqual([]);
+  });
+});
+
+describe("buildStatus", () => {
+  const messages = getSubmitWorkMessages("en");
+
+  it("keeps missing request name feedback field-scoped after a submit attempt", () => {
+    const draft = {
+      ...createDefaultDraft(),
+      workTypeName: "story",
+    };
+
+    expect(
+      buildStatus({
+        draft,
+        error: null,
+        isSubmitting: false,
+        isSuccess: false,
+        messages,
+        showValidation: true,
+        submitWorkTypeNames: ["story"],
+      }),
+    ).toEqual({
+      kind: "guidance",
+      message: messages.statusMessages.ready,
+    });
+  });
+
+  it("still surfaces detached validation for non-request-name field issues", () => {
+    const draft = {
+      ...createDefaultDraft(),
+      requestName: "Driver review",
+    };
+
+    expect(
+      buildStatus({
+        draft,
+        error: null,
+        isSubmitting: false,
+        isSuccess: false,
+        messages,
+        showValidation: true,
+        submitWorkTypeNames: ["story"],
+      }),
+    ).toEqual({
+      kind: "validation-error",
+      message: messages.validationMessages.workTypeRequired,
+    });
   });
 });

--- a/ui/src/features/submit-work/hooks/use-submit-work-widget-helpers.test.ts
+++ b/ui/src/features/submit-work/hooks/use-submit-work-widget-helpers.test.ts
@@ -95,7 +95,7 @@ describe("buildStatus", () => {
     });
   });
 
-  it("still surfaces detached validation for non-request-name field issues", () => {
+  it("keeps missing work type feedback field-scoped after a submit attempt", () => {
     const draft = {
       ...createDefaultDraft(),
       requestName: "Driver review",
@@ -112,8 +112,40 @@ describe("buildStatus", () => {
         submitWorkTypeNames: ["story"],
       }),
     ).toEqual({
+      kind: "guidance",
+      message: messages.statusMessages.ready,
+    });
+  });
+
+  it("still surfaces detached validation for submission item issues", () => {
+    const draft: SubmitWorkDraft = {
+      items: [
+        {
+          fileName: "ui.png",
+          id: "submission-item-1",
+          mediaType: "image/png",
+          stagedFileRef: "staged://submit-work/ui.png",
+          stagingStatus: "idle",
+          type: "image",
+        },
+      ],
+      requestName: "Driver review",
+      workTypeName: "story",
+    };
+
+    expect(
+      buildStatus({
+        draft,
+        error: null,
+        isSubmitting: false,
+        isSuccess: false,
+        messages,
+        showValidation: true,
+        submitWorkTypeNames: ["story"],
+      }),
+    ).toEqual({
       kind: "validation-error",
-      message: messages.validationMessages.workTypeRequired,
+      message: messages.validationMessages.fileItemNeedsStaging,
     });
   });
 });

--- a/ui/src/features/submit-work/hooks/use-submit-work-widget-helpers.ts
+++ b/ui/src/features/submit-work/hooks/use-submit-work-widget-helpers.ts
@@ -111,7 +111,11 @@ export function buildStatus({
   }
 
   const validationErrors = validateDraft(draft, messages);
-  if (showValidation && hasValidationErrors(validationErrors)) {
+  if (
+    showValidation &&
+    hasValidationErrors(validationErrors) &&
+    !validationErrors.requestName
+  ) {
     return {
       kind: "validation-error",
       message: buildValidationSummary(validationErrors, messages),
@@ -120,19 +124,19 @@ export function buildStatus({
 
   if (draft.workTypeName.length === 0) {
     if (draft.requestName.trim().length === 0) {
+      if (!showValidation) {
+        return {
+          kind: "guidance",
+          message: messages.statusMessages.emptyGuidance,
+        };
+      }
+    } else if (!showValidation) {
       return {
         kind: "guidance",
-        message: messages.statusMessages.emptyGuidance,
+        message: messages.statusMessages.workTypeOnly,
       };
     }
-
-    return {
-      kind: "guidance",
-      message: messages.statusMessages.workTypeOnly,
-    };
-  }
-
-  if (draft.requestName.trim().length === 0) {
+  } else if (draft.requestName.trim().length === 0 && !showValidation) {
     return {
       kind: "guidance",
       message: messages.statusMessages.requestOnly,

--- a/ui/src/features/submit-work/hooks/use-submit-work-widget-helpers.ts
+++ b/ui/src/features/submit-work/hooks/use-submit-work-widget-helpers.ts
@@ -114,7 +114,8 @@ export function buildStatus({
   if (
     showValidation &&
     hasValidationErrors(validationErrors) &&
-    !validationErrors.requestName
+    !validationErrors.requestName &&
+    !validationErrors.workTypeName
   ) {
     return {
       kind: "validation-error",

--- a/ui/src/features/submit-work/messages/submit-work.ts
+++ b/ui/src/features/submit-work/messages/submit-work.ts
@@ -31,6 +31,7 @@ export interface SubmitWorkMessages {
   submittingAction: string;
   textItemTypeLabel: string;
   workTypeLabel: string;
+  workTypeRequiredAffordance: string;
   statusMessages: {
     emptyGuidance: string;
     errorFallback: string;
@@ -103,6 +104,7 @@ const submitWorkMessagesByLocale = {
     submittingAction: "Submitting...",
     textItemTypeLabel: "Text",
     workTypeLabel: "Work type",
+    workTypeRequiredAffordance: "required",
     statusMessages: {
       emptyGuidance: "Choose a work type and enter a request name to continue.",
       errorFallback: "We couldn't submit your request. Try again in a moment.",
@@ -165,6 +167,7 @@ const submitWorkMessagesByLocale = {
     submittingAction: "正在提交...",
     textItemTypeLabel: "文本",
     workTypeLabel: "工作类型",
+    workTypeRequiredAffordance: "必填",
     statusMessages: {
       emptyGuidance: "先选择工作类型并填写请求名称，然后即可继续。",
       errorFallback: "无法提交你的请求。请稍后再试。",

--- a/ui/src/features/submit-work/messages/submit-work.ts
+++ b/ui/src/features/submit-work/messages/submit-work.ts
@@ -22,6 +22,7 @@ export interface SubmitWorkMessages {
   requestHint?: string;
   requestItemLabel: (position: number) => string;
   requestNameLabel: string;
+  requestNameRequiredAffordance: string;
   requestNamePlaceholder: string;
   requestPlaceholder: string;
   selectWorkTypePlaceholder: string;
@@ -91,6 +92,7 @@ const submitWorkMessagesByLocale = {
       `Remove ${typeLabel.toLowerCase()} item ${position}`,
     replaceFileAction: "Replace file",
     requestNameLabel: "Request name",
+    requestNameRequiredAffordance: "required",
     requestNamePlaceholder: "Add a name for this request.",
     requestPlaceholder:
       "Optional: describe what you want this request to accomplish.",
@@ -153,6 +155,7 @@ const submitWorkMessagesByLocale = {
     removeItemLabel: (typeLabel, position) => `移除${typeLabel}项 ${position}`,
     replaceFileAction: "替换文件",
     requestNameLabel: "请求名称",
+    requestNameRequiredAffordance: "必填",
     requestNamePlaceholder: "为此请求添加名称。",
     requestPlaceholder: "可选：描述你希望这个请求完成什么。",
     requestItemLabel: (position) => `文本项 ${position}`,

--- a/ui/src/features/submit-work/public/index.test.tsx
+++ b/ui/src/features/submit-work/public/index.test.tsx
@@ -21,7 +21,7 @@ describe("submit-work public barrel", () => {
       within(card).getByRole("combobox", { name: "Work type" }),
     ).toBeTruthy();
     expect(
-      within(card).getByRole("textbox", { name: "Request name" }),
+      within(card).getByRole("textbox", { name: /Request name/ }),
     ).toBeTruthy();
     expect(
       within(card).getByRole("list", { name: "Submission items" }),

--- a/ui/src/features/submit-work/public/index.test.tsx
+++ b/ui/src/features/submit-work/public/index.test.tsx
@@ -18,7 +18,7 @@ describe("submit-work public barrel", () => {
     const card = screen.getByRole("article", { name: "Submit work" });
 
     expect(
-      within(card).getByRole("combobox", { name: "Work type" }),
+      within(card).getByRole("combobox", { name: /Work type/ }),
     ).toBeTruthy();
     expect(
       within(card).getByRole("textbox", { name: /Request name/ }),

--- a/ui/src/testing/submit-work-card-queries.ts
+++ b/ui/src/testing/submit-work-card-queries.ts
@@ -19,12 +19,12 @@ export type AsyncRoleQuery = SyncRoleQuery & {
 export const submitWorkCardQueryContract = {
   addInputButtonName: "Add input",
   dashboardRegionName: "you-agent-factory bento board",
-  requestNameFieldName: "Request name",
+  requestNameFieldName: /Request name/,
   requestFieldName: "Text item 1",
   submissionItemsListName: "Submission items",
   submitButtonName: "Submit work",
   submitWorkCardName: "Submit work",
-  workTypeFieldName: "Work type",
+  workTypeFieldName: /Work type/,
 } as const;
 
 export function getSubmitWorkCard<QueryScope extends SyncRoleQuery>(


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/submit-work-cleanup-error-handling",
  "description": "Replace the Submit work card's detached required-field error panel with field-level validation on the request name input and work-type selector, use shared shadcn-aligned form primitives and invalid variants, and standardize the submission textarea's scroll behavior.",
  "context": {
    "customerAsk": "When there are form issues in the Submit work card, the UI currently shows a strange error panel. Instead, highlight the selector and request name when either is invalid. Use shadcn input and select button primitives with invalid variants; mark request name as required and red when empty, similar to the idea selector. Also make the submission textarea use the same scroll behavior as the rest of the interface, either through an existing standard textarea or a reusable one.",
    "problem": "Required-field validation is presented away from the controls that need correction, forcing users to infer whether the work type selector or request name caused the issue. The request name requirement is not clearly annotated, invalid styling is inconsistent, and the submission textarea scroll behavior does not match other dashboard controls for long text.",
    "solution": "Move missing-field feedback into the request name input and work-type selector using shared shadcn-aligned form primitives, required metadata, accessible invalid states, and standard invalid variants. Keep non-field server or network failures in the card's existing status/error surface, and standardize the submission textarea by using or extending the shared textarea primitive with the dashboard's default scroll behavior."
  },
  "acceptanceCriteria": [
    "Missing request name highlights the request name input with the standard invalid field treatment, exposes an accessible required/error state, and does not rely on a detached error panel to explain the issue.",
    "Missing work type highlights the work-type selector with the standard invalid select treatment, exposes an accessible required/error state, and preserves keyboard interaction.",
    "When both required fields are valid, their invalid styling and field-level validation messages clear without requiring a page refresh.",
    "Non-field submission failures, such as network or server rejection after a valid form submission, still surface in the Submit work card through the existing appropriate status/error channel.",
    "The submission textarea uses the shared textarea/scroll behavior, remains usable for long text, and visually matches the surrounding dashboard controls across mobile, tablet, and desktop widths.",
    "Focused frontend tests and direct browser verification cover invalid field feedback, correction behavior, preserved success/error states, keyboard accessibility, and textarea scrolling.",
    "Quality gate: frontend typecheck, lint, and relevant tests pass before merge."
  ],
  "userStories": [
    {
      "id": "submit-work-cleanup-error-handling-001",
      "title": "Show request name validation on the field",
      "description": "As a dashboard user, I want the request name field to clearly show when it is required and invalid so I can correct the form without interpreting a separate error panel.",
      "acceptanceCriteria": [
        "The request name control uses the shared Input primitive or an established shadcn-aligned field wrapper.",
        "The request name label or field affordance clearly communicates that the field is required before submission.",
        "Attempting to submit with an empty request name marks the input invalid with the standard red invalid treatment and an accessible error association.",
        "Entering a non-empty request name clears the invalid visual state and field-level error text for that field.",
        "The missing request name case does not render the detached form-issue error panel.",
        "Component coverage proves the empty, invalid, and corrected request name states.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "submit-work-cleanup-error-handling-002",
      "title": "Show work-type selector validation on the selector",
      "description": "As a dashboard user, I want the work-type selector to show its own invalid state when no work type is selected so I can identify and correct the missing selection directly.",
      "acceptanceCriteria": [
        "The work-type control uses the shared shadcn-aligned select button/select field primitive rather than a bespoke selector button for this form validation path.",
        "Attempting to submit without a selected work type marks the selector invalid with the standard red invalid treatment and an accessible error association.",
        "The selector remains keyboard reachable, opens with keyboard interaction, and exposes the selected value to assistive technologies.",
        "Selecting a valid work type clears the invalid visual state and field-level error text for that selector.",
        "The missing work-type case does not render the detached form-issue error panel.",
        "Component coverage proves the empty, invalid, keyboard-openable, and corrected work-type states.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "submit-work-cleanup-error-handling-003",
      "title": "Keep form-level status for non-field submission failures only",
      "description": "As a dashboard user, I want server or network submission failures to remain visible while ordinary missing-field issues are shown on the relevant fields.",
      "acceptanceCriteria": [
        "Submitting with missing required fields blocks the network request and shows only field-level validation feedback for those missing fields.",
        "Submitting a valid form that receives a server or network failure still shows the existing non-field submission error/status treatment in the card.",
        "A successful valid submission still shows the existing success treatment and does not leave stale invalid styling on request name or work type.",
        "Component coverage proves that required-field validation, server failure, and success states are visually and semantically distinct.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "submit-work-cleanup-error-handling-004",
      "title": "Standardize submission textarea scrolling and styling",
      "description": "As a dashboard user, I want the submission text area to scroll and look like the rest of the interface so long requests remain comfortable to author.",
      "acceptanceCriteria": [
        "The submission text editor uses the shared Textarea primitive or a new reusable standard textarea primitive when the existing one cannot provide the required scroll behavior.",
        "Long submission text scrolls inside the textarea using the dashboard's standard scroll styling instead of expanding or clipping awkwardly.",
        "The textarea preserves expected authoring behavior, including typing, selection, paste, focus ring, disabled/loading state, and form submission.",
        "The textarea remains usable without overlap or clipped controls at mobile, tablet, and desktop widths.",
        "Component coverage proves long-text scrolling constraints and disabled/loading treatment where applicable.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)