### PR TITLE
default-work-type-configuration-currnt-selection

### DIFF
--- a/ui/integration/browser-test-harness.mjs
+++ b/ui/integration/browser-test-harness.mjs
@@ -53,6 +53,11 @@ export async function fillWorkstationPromptBody(scope, text) {
   }
 }
 
+/** Check a shared styled checkbox whose native input is visually hidden. */
+export async function checkStyledCheckbox(checkboxLocator) {
+  await checkboxLocator.check({ force: true });
+}
+
 /** Select a Radix/shadcn combobox option by visible option label. */
 export async function selectComboboxOption(combobox, optionName) {
   const page = combobox.page();
@@ -98,20 +103,22 @@ export async function fillModelWorkerAddOperationDraft(
   );
   await inputSlotNameField.scrollIntoViewIfNeeded();
   await inputSlotNameField.fill(inputSlotName);
-  await scope
-    .locator("#factory-graph-add-model-operation-input-slot-0-content-type-TEXT")
-    .check();
+  await checkStyledCheckbox(
+    scope.locator(
+      "#factory-graph-add-model-operation-input-slot-0-content-type-TEXT",
+    ),
+  );
 
   const outputSlotNameField = scope.locator(
     "#factory-graph-add-model-operation-output-slot-name-0",
   );
   await outputSlotNameField.scrollIntoViewIfNeeded();
   await outputSlotNameField.fill(outputSlotName);
-  await scope
-    .locator(
+  await checkStyledCheckbox(
+    scope.locator(
       "#factory-graph-add-model-operation-output-slot-0-content-type-AUDIO",
-    )
-    .check();
+    ),
+  );
 }
 
 const modelProviderOptionLabels = {

--- a/ui/package.json
+++ b/ui/package.json
@@ -29,6 +29,7 @@
     "storybook": "storybook dev -p 6007",
     "storybook:choose-file-check": "node scripts/run-choose-file-browser-check.mjs",
     "storybook:prompt-syntax-save-check": "node scripts/run-prompt-syntax-save-browser-check.mjs",
+    "storybook:checkbox-consistency-check": "node scripts/run-checkbox-consistency-browser-check.mjs",
     "storybook:current-selection-save-notifications-check": "node scripts/run-current-selection-save-notifications-browser-check.mjs",
     "storybook:responsive-check": "node scripts/run-storybook-responsive-check.mjs",
     "storybook:serve-static": "http-server storybook-static -p 6008 -a 127.0.0.1 -s",

--- a/ui/scripts/checkbox-consistency-assertions.mjs
+++ b/ui/scripts/checkbox-consistency-assertions.mjs
@@ -33,7 +33,7 @@ export async function assertStyledCheckboxTreatment(checkboxLocator, label) {
   }
 
   const indicatorClassName = await readCheckboxIndicatorClassName(checkboxLocator);
-  for (const marker of ["peer-checked:bg-primary", "border-outline"]) {
+  for (const marker of STYLED_CHECKBOX_INDICATOR_MARKERS) {
     if (!indicatorClassName.includes(marker)) {
       throw new Error(
         `${label}: checkbox indicator is missing ${marker} styling.`,

--- a/ui/scripts/checkbox-consistency-assertions.mjs
+++ b/ui/scripts/checkbox-consistency-assertions.mjs
@@ -1,0 +1,98 @@
+export const STYLED_CHECKBOX_INPUT_MARKER = "sr-only";
+
+export const STYLED_CHECKBOX_INDICATOR_MARKERS = [
+  "peer-checked:bg-primary",
+  "border-outline",
+  "peer-focus-visible:ring-af-focus-ring",
+  "peer-disabled:bg-surface-container-low",
+  "peer-aria-invalid:ring-af-danger-border",
+];
+
+export async function readCheckboxIndicatorClassName(checkboxLocator) {
+  const indicator = checkboxLocator.locator("xpath=following-sibling::*[1]");
+  await indicator.waitFor({ state: "attached" });
+  const className = await indicator.evaluate((element) => element.className);
+  if (typeof className !== "string" || className.length === 0) {
+    throw new Error("Could not read styled checkbox indicator className.");
+  }
+
+  return className;
+}
+
+export async function assertStyledCheckboxTreatment(checkboxLocator, label) {
+  const inputClassName = await checkboxLocator.evaluate(
+    (element) => element.className,
+  );
+  if (
+    typeof inputClassName !== "string" ||
+    !inputClassName.includes(STYLED_CHECKBOX_INPUT_MARKER)
+  ) {
+    throw new Error(
+      `${label}: checkbox input is missing ${STYLED_CHECKBOX_INPUT_MARKER} styling.`,
+    );
+  }
+
+  const indicatorClassName = await readCheckboxIndicatorClassName(checkboxLocator);
+  for (const marker of ["peer-checked:bg-primary", "border-outline"]) {
+    if (!indicatorClassName.includes(marker)) {
+      throw new Error(
+        `${label}: checkbox indicator is missing ${marker} styling.`,
+      );
+    }
+  }
+
+  const indicator = checkboxLocator.locator("xpath=following-sibling::*[1]");
+  const svgCount = await indicator.locator("svg").count();
+  if (svgCount === 0) {
+    throw new Error(`${label}: checkbox indicator is missing the checked mark.`);
+  }
+}
+
+export async function assertCheckboxCheckedState(
+  checkboxLocator,
+  expectedChecked,
+  label,
+) {
+  const checked = await checkboxLocator.isChecked();
+  if (checked !== expectedChecked) {
+    throw new Error(
+      `${label}: expected checked=${expectedChecked}, received checked=${checked}.`,
+    );
+  }
+}
+
+export async function assertCheckboxInvalidState(checkboxLocator, label) {
+  const ariaInvalid = await checkboxLocator.getAttribute("aria-invalid");
+  if (ariaInvalid !== "true") {
+    throw new Error(`${label}: expected aria-invalid="true".`);
+  }
+
+  const indicatorClassName = await readCheckboxIndicatorClassName(checkboxLocator);
+  if (
+    !indicatorClassName.includes("peer-aria-invalid:ring-af-danger-border")
+  ) {
+    throw new Error(`${label}: invalid checkbox indicator styling is missing.`);
+  }
+}
+
+export async function assertCheckboxDisabledState(checkboxLocator, label) {
+  if (!(await checkboxLocator.isDisabled())) {
+    throw new Error(`${label}: expected the checkbox to be disabled.`);
+  }
+
+  const indicatorClassName = await readCheckboxIndicatorClassName(checkboxLocator);
+  if (!indicatorClassName.includes("peer-disabled:bg-surface-container-low")) {
+    throw new Error(`${label}: disabled checkbox indicator styling is missing.`);
+  }
+}
+
+export async function toggleCheckboxFromLabel(page, labelText) {
+  const label = page.getByText(labelText, { exact: true });
+  await label.waitFor({ state: "visible" });
+  await label.click();
+}
+
+export async function toggleCheckboxWithSpace(page, checkboxLocator) {
+  await checkboxLocator.focus();
+  await page.keyboard.press("Space");
+}

--- a/ui/scripts/checkbox-consistency-assertions.test.mjs
+++ b/ui/scripts/checkbox-consistency-assertions.test.mjs
@@ -1,0 +1,118 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  assertCheckboxCheckedState,
+  assertCheckboxDisabledState,
+  assertCheckboxInvalidState,
+  assertStyledCheckboxTreatment,
+  readCheckboxIndicatorClassName,
+} from "./checkbox-consistency-assertions.mjs";
+
+function createCheckboxLocator({
+  ariaInvalid,
+  checked = false,
+  className = "peer sr-only",
+  disabled = false,
+  indicatorClassName = "peer-checked:bg-primary border-outline peer-focus-visible:ring-af-focus-ring peer-disabled:bg-surface-container-low peer-aria-invalid:ring-af-danger-border",
+  svgCount = 1,
+} = {}) {
+  const indicator = {
+    className: indicatorClassName,
+    evaluate: vi.fn(async (callback) =>
+      callback({ className: indicatorClassName }),
+    ),
+    locator: vi.fn(() => ({
+      count: vi.fn(async () => svgCount),
+    })),
+    waitFor: vi.fn().mockResolvedValue(undefined),
+  };
+
+  return {
+    evaluate: vi.fn(async (callback) => callback({ className })),
+    getAttribute: vi.fn(async (name) =>
+      name === "aria-invalid" ? ariaInvalid ?? null : null,
+    ),
+    isChecked: vi.fn(async () => checked),
+    isDisabled: vi.fn(async () => disabled),
+    locator: vi.fn((selector) => {
+      if (selector === "xpath=following-sibling::*[1]") {
+        return indicator;
+      }
+
+      throw new Error(`Unexpected locator selector: ${selector}`);
+    }),
+  };
+}
+
+describe("checkbox-consistency-assertions", () => {
+  test("assertStyledCheckboxTreatment accepts sr-only input and indicator markers", async () => {
+    await expect(
+      assertStyledCheckboxTreatment(createCheckboxLocator(), "test checkbox"),
+    ).resolves.toBeUndefined();
+  });
+
+  test("assertStyledCheckboxTreatment rejects native-looking inputs", async () => {
+    await expect(
+      assertStyledCheckboxTreatment(
+        createCheckboxLocator({ className: "h-4 w-4" }),
+        "test checkbox",
+      ),
+    ).rejects.toThrow(/sr-only/);
+  });
+
+  test("readCheckboxIndicatorClassName returns the sibling indicator class", async () => {
+    await expect(
+      readCheckboxIndicatorClassName(createCheckboxLocator()),
+    ).resolves.toContain("peer-checked:bg-primary");
+  });
+
+  test("assertCheckboxCheckedState compares checked state", async () => {
+    await expect(
+      assertCheckboxCheckedState(
+        createCheckboxLocator({ checked: true }),
+        true,
+        "checked checkbox",
+      ),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      assertCheckboxCheckedState(
+        createCheckboxLocator({ checked: false }),
+        true,
+        "unchecked checkbox",
+      ),
+    ).rejects.toThrow(/expected checked=true/);
+  });
+
+  test("assertCheckboxDisabledState requires disabled input and styling", async () => {
+    await expect(
+      assertCheckboxDisabledState(
+        createCheckboxLocator({ disabled: true }),
+        "disabled checkbox",
+      ),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      assertCheckboxDisabledState(
+        createCheckboxLocator({ disabled: false }),
+        "enabled checkbox",
+      ),
+    ).rejects.toThrow(/disabled/);
+  });
+
+  test("assertCheckboxInvalidState requires aria-invalid and styling", async () => {
+    await expect(
+      assertCheckboxInvalidState(
+        createCheckboxLocator({ ariaInvalid: "true" }),
+        "invalid checkbox",
+      ),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      assertCheckboxInvalidState(
+        createCheckboxLocator({ ariaInvalid: null }),
+        "valid checkbox",
+      ),
+    ).rejects.toThrow(/aria-invalid/);
+  });
+});

--- a/ui/scripts/run-checkbox-consistency-browser-check.mjs
+++ b/ui/scripts/run-checkbox-consistency-browser-check.mjs
@@ -1,0 +1,15 @@
+import { ensureStorybookServer } from "./run-storybook-responsive-check.mjs";
+import { verifyCheckboxConsistencyStories } from "./verify-checkbox-consistency-storybook-responsive.mjs";
+
+const host = process.env.AGENT_FACTORY_STORYBOOK_HOST ?? "127.0.0.1";
+const port = process.env.AGENT_FACTORY_STORYBOOK_PORT ?? "6008";
+const storybookUrl = `http://${host}:${port}`;
+
+const server = await ensureStorybookServer({ host, port: Number(port) });
+
+try {
+  await verifyCheckboxConsistencyStories({ storybookUrl });
+  console.log("Checkbox consistency browser verification passed.");
+} finally {
+  await server.stop();
+}

--- a/ui/scripts/run-storybook-ci.mjs
+++ b/ui/scripts/run-storybook-ci.mjs
@@ -335,6 +335,10 @@ export async function runStorybookCI({
       runCommand(["run", "storybook:choose-file-check"]),
       serverExit,
     ]);
+    await Promise.race([
+      runCommand(["run", "storybook:checkbox-consistency-check"]),
+      serverExit,
+    ]);
   } finally {
     shuttingDown = true;
     await stop(server);

--- a/ui/scripts/run-storybook-ci.test.mjs
+++ b/ui/scripts/run-storybook-ci.test.mjs
@@ -163,6 +163,14 @@ describe("runStorybookCI", () => {
       "run",
       "storybook:responsive-check",
     ]);
+    expect(runCommand).toHaveBeenNthCalledWith(3, [
+      "run",
+      "storybook:choose-file-check",
+    ]);
+    expect(runCommand).toHaveBeenNthCalledWith(4, [
+      "run",
+      "storybook:checkbox-consistency-check",
+    ]);
     expect(stop).toHaveBeenCalledWith(server);
   });
 

--- a/ui/scripts/verify-checkbox-consistency-storybook-responsive.mjs
+++ b/ui/scripts/verify-checkbox-consistency-storybook-responsive.mjs
@@ -1,0 +1,214 @@
+import { chromium } from "playwright";
+
+import {
+  assertCheckboxCheckedState,
+  assertCheckboxDisabledState,
+  assertCheckboxInvalidState,
+  assertStyledCheckboxTreatment,
+  toggleCheckboxFromLabel,
+  toggleCheckboxWithSpace,
+} from "./checkbox-consistency-assertions.mjs";
+import {
+  expectNoHorizontalOverflow,
+  storyUrl,
+  waitForStoryRender,
+} from "./storybook-responsive-helpers.mjs";
+
+export const CURRENT_SELECTION_CHECKBOX_STORY_ID =
+  "you-agent-factory-checkbox-consistency-current-selection--worker-skip-permissions";
+
+export const CURRENT_SELECTION_INVALID_CHECKBOX_STORY_ID =
+  "you-agent-factory-checkbox-consistency-current-selection--worker-skip-permissions-invalid";
+
+export const FACTORY_GRAPH_EDITOR_CHECKBOX_STORY_ID =
+  "you-agent-factory-checkbox-consistency-factory-graph-editor--cron-trigger-at-start";
+
+export const SHARED_CHECKBOX_STORY_ID =
+  "you-agent-factory-checkbox-consistency-shared-primitive--checkbox-state-showcase";
+
+export const CHECKBOX_CONSISTENCY_VIEWPORTS = [
+  { height: 844, label: "mobile", width: 390 },
+  { height: 900, label: "desktop", width: 1440 },
+];
+
+const SKIP_PERMISSIONS_LABEL = "Bypass provider permissions";
+const CRON_TRIGGER_LABEL = "Cron trigger at start";
+
+export async function verifyCurrentSelectionCheckboxSurface({
+  page,
+  storybookUrl,
+  viewport,
+}) {
+  await page.setViewportSize({
+    height: viewport.height,
+    width: viewport.width,
+  });
+  await page.goto(storyUrl(storybookUrl, CURRENT_SELECTION_CHECKBOX_STORY_ID), {
+    timeout: 90_000,
+    waitUntil: "networkidle",
+  });
+  await waitForStoryRender(page);
+  await expectNoHorizontalOverflow(
+    page,
+    `current-selection checkbox (${viewport.label})`,
+  );
+
+  const checkbox = page.getByRole("checkbox", {
+    name: SKIP_PERMISSIONS_LABEL,
+  });
+  await assertStyledCheckboxTreatment(
+    checkbox,
+    `current-selection skipPermissions (${viewport.label})`,
+  );
+  await assertCheckboxCheckedState(
+    checkbox,
+    false,
+    `current-selection skipPermissions initial (${viewport.label})`,
+  );
+
+  await toggleCheckboxFromLabel(page, SKIP_PERMISSIONS_LABEL);
+  await assertCheckboxCheckedState(
+    checkbox,
+    true,
+    `current-selection skipPermissions after label click (${viewport.label})`,
+  );
+
+  await toggleCheckboxWithSpace(page, checkbox);
+  await assertCheckboxCheckedState(
+    checkbox,
+    false,
+    `current-selection skipPermissions after Space (${viewport.label})`,
+  );
+}
+
+export async function verifyFactoryGraphEditorCheckboxSurface({
+  page,
+  storybookUrl,
+  viewport,
+}) {
+  await page.setViewportSize({
+    height: viewport.height,
+    width: viewport.width,
+  });
+  await page.goto(storyUrl(storybookUrl, FACTORY_GRAPH_EDITOR_CHECKBOX_STORY_ID), {
+    timeout: 90_000,
+    waitUntil: "networkidle",
+  });
+  await waitForStoryRender(page);
+  await expectNoHorizontalOverflow(
+    page,
+    `factory graph editor checkbox (${viewport.label})`,
+  );
+
+  const checkbox = page.getByRole("checkbox", {
+    name: CRON_TRIGGER_LABEL,
+  });
+  await assertStyledCheckboxTreatment(
+    checkbox,
+    `factory graph editor cron trigger (${viewport.label})`,
+  );
+  await assertCheckboxCheckedState(
+    checkbox,
+    false,
+    `factory graph editor cron trigger initial (${viewport.label})`,
+  );
+
+  await toggleCheckboxFromLabel(page, CRON_TRIGGER_LABEL);
+  await assertCheckboxCheckedState(
+    checkbox,
+    true,
+    `factory graph editor cron trigger after label click (${viewport.label})`,
+  );
+
+  await toggleCheckboxWithSpace(page, checkbox);
+  await assertCheckboxCheckedState(
+    checkbox,
+    false,
+    `factory graph editor cron trigger after Space (${viewport.label})`,
+  );
+}
+
+export async function verifySharedCheckboxStates({ page, storybookUrl }) {
+  await page.setViewportSize({ height: 900, width: 1440 });
+  await page.goto(storyUrl(storybookUrl, SHARED_CHECKBOX_STORY_ID), {
+    timeout: 90_000,
+    waitUntil: "networkidle",
+  });
+  await waitForStoryRender(page);
+
+  const optionalCheckbox = page.getByRole("checkbox", {
+    name: "Optional setting",
+  });
+  const disabledCheckbox = page.getByRole("checkbox", {
+    name: "Disabled setting",
+  });
+  const invalidCheckbox = page.getByRole("checkbox", {
+    name: "Invalid setting",
+  });
+
+  for (const [checkbox, label] of [
+    [optionalCheckbox, "shared optional setting"],
+    [disabledCheckbox, "shared disabled setting"],
+    [invalidCheckbox, "shared invalid setting"],
+  ]) {
+    await assertStyledCheckboxTreatment(checkbox, label);
+  }
+
+  await assertCheckboxDisabledState(disabledCheckbox, "shared disabled setting");
+  await assertCheckboxInvalidState(invalidCheckbox, "shared invalid setting");
+
+  await page.goto(
+    storyUrl(storybookUrl, CURRENT_SELECTION_INVALID_CHECKBOX_STORY_ID),
+    {
+      timeout: 90_000,
+      waitUntil: "networkidle",
+    },
+  );
+  await waitForStoryRender(page);
+
+  const invalidCurrentSelectionCheckbox = page.getByRole("checkbox", {
+    name: SKIP_PERMISSIONS_LABEL,
+  });
+  await assertStyledCheckboxTreatment(
+    invalidCurrentSelectionCheckbox,
+    "current-selection invalid skipPermissions",
+  );
+  await assertCheckboxInvalidState(
+    invalidCurrentSelectionCheckbox,
+    "current-selection invalid skipPermissions",
+  );
+  await page
+    .getByText("skipPermissions must be a boolean.")
+    .waitFor({ state: "visible" });
+}
+
+export async function verifyCheckboxConsistencyStories({
+  browserLauncher = chromium,
+  storybookUrl,
+  verifyCurrentSelection = verifyCurrentSelectionCheckboxSurface,
+  verifyFactoryGraphEditor = verifyFactoryGraphEditorCheckboxSurface,
+  verifySharedStates = verifySharedCheckboxStates,
+  viewports = CHECKBOX_CONSISTENCY_VIEWPORTS,
+} = {}) {
+  const browser = await browserLauncher.launch();
+  const page = await browser.newPage();
+
+  try {
+    for (const viewport of viewports) {
+      await verifyCurrentSelection({
+        page,
+        storybookUrl,
+        viewport,
+      });
+      await verifyFactoryGraphEditor({
+        page,
+        storybookUrl,
+        viewport,
+      });
+    }
+
+    await verifySharedStates({ page, storybookUrl });
+  } finally {
+    await browser.close();
+  }
+}

--- a/ui/scripts/verify-checkbox-consistency-storybook-responsive.test.mjs
+++ b/ui/scripts/verify-checkbox-consistency-storybook-responsive.test.mjs
@@ -1,0 +1,59 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  CHECKBOX_CONSISTENCY_VIEWPORTS,
+  CURRENT_SELECTION_CHECKBOX_STORY_ID,
+  FACTORY_GRAPH_EDITOR_CHECKBOX_STORY_ID,
+  verifyCheckboxConsistencyStories,
+  verifyCurrentSelectionCheckboxSurface,
+  verifyFactoryGraphEditorCheckboxSurface,
+} from "./verify-checkbox-consistency-storybook-responsive.mjs";
+
+describe("verify-checkbox-consistency-storybook-responsive", () => {
+  test("exports representative story ids and mobile/desktop viewports", () => {
+    expect(CURRENT_SELECTION_CHECKBOX_STORY_ID).toContain(
+      "checkbox-consistency-current-selection",
+    );
+    expect(FACTORY_GRAPH_EDITOR_CHECKBOX_STORY_ID).toContain(
+      "checkbox-consistency-factory-graph-editor",
+    );
+    expect(CHECKBOX_CONSISTENCY_VIEWPORTS).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "mobile", width: 390 }),
+        expect.objectContaining({ label: "desktop", width: 1440 }),
+      ]),
+    );
+  });
+
+  test("verifyCheckboxConsistencyStories exercises both surfaces at each viewport", async () => {
+    const verifyCurrentSelectionCheckboxSurfaceMock = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    const verifyFactoryGraphEditorCheckboxSurfaceMock = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    const verifySharedCheckboxStatesMock = vi.fn().mockResolvedValue(undefined);
+    const browser = {
+      close: vi.fn().mockResolvedValue(undefined),
+      newPage: vi.fn().mockResolvedValue({}),
+    };
+    const chromium = {
+      launch: vi.fn().mockResolvedValue(browser),
+    };
+
+    await verifyCheckboxConsistencyStories({
+      browserLauncher: chromium,
+      storybookUrl: "http://127.0.0.1:6008",
+      verifyCurrentSelection: verifyCurrentSelectionCheckboxSurfaceMock,
+      verifyFactoryGraphEditor: verifyFactoryGraphEditorCheckboxSurfaceMock,
+      verifySharedStates: verifySharedCheckboxStatesMock,
+      viewports: CHECKBOX_CONSISTENCY_VIEWPORTS,
+    });
+
+    expect(chromium.launch).toHaveBeenCalledTimes(1);
+    expect(verifyCurrentSelectionCheckboxSurfaceMock).toHaveBeenCalledTimes(2);
+    expect(verifyFactoryGraphEditorCheckboxSurfaceMock).toHaveBeenCalledTimes(2);
+    expect(verifySharedCheckboxStatesMock).toHaveBeenCalledTimes(1);
+    expect(browser.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/components/ui/checkbox-consistency-catalog.stories.tsx
+++ b/ui/src/components/ui/checkbox-consistency-catalog.stories.tsx
@@ -1,0 +1,74 @@
+import { expect, userEvent, within } from "storybook/test";
+import { useState } from "react";
+
+import "../../styles.css";
+import { expectStyledCheckboxInStory } from "../../testing/checkbox-story-helpers";
+import { Checkbox } from "./checkbox";
+
+function CheckboxStateShowcaseStory() {
+  const [optionalSetting, setOptionalSetting] = useState(false);
+
+  return (
+    <div className="flex flex-col gap-6 p-4">
+      <label className="inline-flex items-center gap-2" htmlFor="optional-setting">
+        <Checkbox
+          checked={optionalSetting}
+          id="optional-setting"
+          onChange={(event) => setOptionalSetting(event.currentTarget.checked)}
+        />
+        Optional setting
+      </label>
+      <Checkbox aria-label="Disabled setting" disabled onChange={() => undefined} />
+      <Checkbox
+        aria-invalid="true"
+        aria-label="Invalid setting"
+        onChange={() => undefined}
+      />
+    </div>
+  );
+}
+
+export default {
+  title: "you-agent-factory/Checkbox Consistency/Shared Primitive",
+  tags: ["test"],
+};
+
+export const CheckboxStateShowcase = {
+  render: () => <CheckboxStateShowcaseStory />,
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const optionalCheckbox = await canvas.findByRole("checkbox", {
+      name: "Optional setting",
+    });
+    const disabledCheckbox = canvas.getByRole("checkbox", {
+      name: "Disabled setting",
+    });
+    const invalidCheckbox = canvas.getByRole("checkbox", {
+      name: "Invalid setting",
+    });
+
+    for (const checkbox of [
+      optionalCheckbox,
+      disabledCheckbox,
+      invalidCheckbox,
+    ]) {
+      expectStyledCheckboxInStory(checkbox);
+    }
+
+    expect(optionalCheckbox).not.toBeChecked();
+    await userEvent.click(canvas.getByText("Optional setting"));
+    expect(optionalCheckbox).toBeChecked();
+
+    optionalCheckbox.focus();
+    await userEvent.keyboard(" ");
+    expect(optionalCheckbox).not.toBeChecked();
+
+    expect(disabledCheckbox).toBeDisabled();
+    expect(invalidCheckbox).toHaveAttribute("aria-invalid", "true");
+
+    optionalCheckbox.focus();
+    await expect(optionalCheckbox).toHaveFocus();
+    await userEvent.tab();
+    await expect(invalidCheckbox).toHaveFocus();
+  },
+};

--- a/ui/src/components/ui/checkbox.test.tsx
+++ b/ui/src/components/ui/checkbox.test.tsx
@@ -1,9 +1,10 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { Checkbox } from "./checkbox";
 
 describe("Checkbox", () => {
-  it("renders shared checkbox styling and preserves input attributes", () => {
+  it("renders a styled indicator while preserving native checkbox semantics", () => {
     render(
       <Checkbox
         aria-label="Enable cron trigger"
@@ -18,10 +19,85 @@ describe("Checkbox", () => {
     });
 
     expect(checkbox.getAttribute("type")).toBe("checkbox");
-    expect(checkbox.className).toContain("size-4");
-    expect(checkbox.className).toContain("border-outline");
-    expect(checkbox.className).toContain("focus-visible:ring-af-focus-ring");
-    expect(checkbox.className).toContain("mr-2");
+    expect(checkbox.className).toContain("sr-only");
     expect(checkbox.getAttribute("checked")).toBe("");
+
+    const indicator = checkbox.nextElementSibling;
+    expect(indicator?.className).toContain("border-outline");
+    expect(indicator?.className).toContain("peer-checked:bg-primary");
+    expect(indicator?.className).toContain(
+      "peer-focus-visible:ring-af-focus-ring",
+    );
+    expect(indicator?.querySelector("svg")).toBeTruthy();
+    expect(checkbox.parentElement?.className).toContain("mr-2");
+  });
+
+  it("hides the checked indicator when unchecked", () => {
+    render(
+      <Checkbox
+        aria-label="Optional setting"
+        checked={false}
+        onChange={() => undefined}
+      />,
+    );
+
+    const checkbox = screen.getByRole("checkbox", { name: "Optional setting" });
+    const indicator = checkbox.nextElementSibling;
+
+    expect(checkbox.getAttribute("checked")).toBeNull();
+    expect(indicator?.querySelector("svg")?.getAttribute("class")).toContain(
+      "opacity-0",
+    );
+  });
+
+  it("toggles with label clicks and Space while focused", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <>
+        <label htmlFor="cron-trigger-checkbox">Enable cron trigger</label>
+        <Checkbox id="cron-trigger-checkbox" onChange={onChange} />
+      </>,
+    );
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: "Enable cron trigger",
+    });
+
+    await user.click(screen.getByText("Enable cron trigger"));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0]?.[0].target.checked).toBe(true);
+
+    checkbox.focus();
+    await user.keyboard(" ");
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(onChange.mock.calls[1]?.[0].target.checked).toBe(false);
+  });
+
+  it("applies disabled and invalid styling through the shared indicator", () => {
+    render(
+      <Checkbox
+        aria-invalid="true"
+        aria-label="Skip permissions"
+        disabled
+        onChange={() => undefined}
+      />,
+    );
+
+    const checkbox = screen.getByRole("checkbox", { name: "Skip permissions" });
+    const indicator = checkbox.nextElementSibling;
+
+    expect(checkbox.hasAttribute("disabled")).toBe(true);
+    expect(checkbox.getAttribute("aria-invalid")).toBe("true");
+    expect(indicator?.className).toContain(
+      "peer-disabled:bg-surface-container-low",
+    );
+    expect(indicator?.className).toContain(
+      "peer-aria-invalid:ring-af-danger-border",
+    );
+    expect(checkbox.parentElement?.className).toContain(
+      "[&:has(:disabled)]:cursor-not-allowed",
+    );
   });
 });

--- a/ui/src/components/ui/checkbox.tsx
+++ b/ui/src/components/ui/checkbox.tsx
@@ -9,22 +9,20 @@ export interface CheckboxProps
 const CHECKBOX_ROOT_CLASS =
   "relative inline-flex size-4 shrink-0 items-center justify-center [&:has(:disabled)]:cursor-not-allowed";
 
-const CHECKBOX_INPUT_CLASS = "peer sr-only";
-
-const CHECKBOX_INDICATOR_CLASS =
-  "pointer-events-none flex size-4 items-center justify-center rounded border border-outline bg-surface-container-high text-on-primary transition-colors peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-af-focus-ring peer-disabled:border-outline peer-disabled:bg-surface-container-low peer-checked:border-primary peer-checked:bg-primary peer-aria-invalid:ring-2 peer-aria-invalid:ring-af-danger-border peer-checked:[&_svg]:opacity-100";
-
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
   function Checkbox({ className, ...props }, ref) {
     return (
       <span className={cn(CHECKBOX_ROOT_CLASS, className)}>
         <input
-          className={CHECKBOX_INPUT_CLASS}
+          className="peer sr-only"
           ref={ref}
           type="checkbox"
           {...props}
         />
-        <span aria-hidden="true" className={CHECKBOX_INDICATOR_CLASS}>
+        <span
+          aria-hidden="true"
+          className="pointer-events-none flex size-4 items-center justify-center rounded border border-outline bg-surface-container-high text-on-primary transition-colors peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-af-focus-ring peer-disabled:border-outline peer-disabled:bg-surface-container-low peer-checked:border-primary peer-checked:bg-primary peer-aria-invalid:ring-2 peer-aria-invalid:ring-af-danger-border peer-checked:[&_svg]:opacity-100"
+        >
           <Check className="size-3 opacity-0" strokeWidth={2.5} />
         </span>
       </span>

--- a/ui/src/components/ui/checkbox.tsx
+++ b/ui/src/components/ui/checkbox.tsx
@@ -1,3 +1,4 @@
+import { Check } from "lucide-react";
 import { forwardRef, type InputHTMLAttributes } from "react";
 
 import { cn } from "../../lib/cn";
@@ -5,18 +6,28 @@ import { cn } from "../../lib/cn";
 export interface CheckboxProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, "type"> {}
 
-const CHECKBOX_CLASS =
-  "size-4 rounded border border-outline bg-surface-container-high text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-af-focus-ring disabled:cursor-not-allowed disabled:border-outline disabled:bg-surface-container-low";
+const CHECKBOX_ROOT_CLASS =
+  "relative inline-flex size-4 shrink-0 items-center justify-center [&:has(:disabled)]:cursor-not-allowed";
+
+const CHECKBOX_INPUT_CLASS = "peer sr-only";
+
+const CHECKBOX_INDICATOR_CLASS =
+  "pointer-events-none flex size-4 items-center justify-center rounded border border-outline bg-surface-container-high text-on-primary transition-colors peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-af-focus-ring peer-disabled:border-outline peer-disabled:bg-surface-container-low peer-checked:border-primary peer-checked:bg-primary peer-aria-invalid:ring-2 peer-aria-invalid:ring-af-danger-border peer-checked:[&_svg]:opacity-100";
 
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
   function Checkbox({ className, ...props }, ref) {
     return (
-      <input
-        className={cn(CHECKBOX_CLASS, className)}
-        ref={ref}
-        type="checkbox"
-        {...props}
-      />
+      <span className={cn(CHECKBOX_ROOT_CLASS, className)}>
+        <input
+          className={CHECKBOX_INPUT_CLASS}
+          ref={ref}
+          type="checkbox"
+          {...props}
+        />
+        <span aria-hidden="true" className={CHECKBOX_INDICATOR_CLASS}>
+          <Check className="size-3 opacity-0" strokeWidth={2.5} />
+        </span>
+      </span>
     );
   },
 );

--- a/ui/src/features/current-selection/work-type-selection/components/work-type-detail-card.default-handling.test.tsx
+++ b/ui/src/features/current-selection/work-type-selection/components/work-type-detail-card.default-handling.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { CurrentFactoryDocument } from "../../../../api/current-factory-definition";
 import { useCurrentFactoryDocument } from "../../../current-factory-definition/hooks/useCurrentFactoryDefinition";
 import { useEditableWorkTypeConfigurationState } from "../hooks/use-editable-work-type-configuration-state";
@@ -71,6 +72,13 @@ function WorkTypeDetailCardHarness({ workTypeName }: { workTypeName: string }) {
   );
 }
 
+function expectStyledDefaultHandlingCheckbox(checkbox: HTMLElement) {
+  expect(checkbox.className).toContain("sr-only");
+  const indicator = checkbox.nextElementSibling;
+  expect(indicator?.className).toContain("peer-checked:bg-primary");
+  expect(indicator?.querySelector("svg")).toBeTruthy();
+}
+
 // biome-ignore lint/complexity/noExcessiveLinesPerFunction: default-handling coverage keeps factory reload and save-error cases together.
 describe("WorkTypeDetailCard default handling", () => {
   beforeEach(() => {
@@ -81,6 +89,52 @@ describe("WorkTypeDetailCard default handling", () => {
       isPending: false,
       status: "success",
     } as never);
+  });
+
+  it("renders the shared styled checkbox for the default handling control", () => {
+    render(<WorkTypeDetailCardHarness workTypeName="story" />);
+
+    const panel = screen.getByRole("article", { name: "Current selection" });
+    const defaultCheckbox = within(panel).getByRole("checkbox", {
+      name: "Mark as default work type",
+    });
+
+    expectStyledDefaultHandlingCheckbox(defaultCheckbox);
+    expect(defaultCheckbox.checked).toBe(false);
+  });
+
+  it("toggles default handling behavior from label clicks and Space while focused", async () => {
+    const user = userEvent.setup();
+
+    render(<WorkTypeDetailCardHarness workTypeName="story" />);
+
+    const panel = screen.getByRole("article", { name: "Current selection" });
+    const defaultCheckbox = within(panel).getByRole("checkbox", {
+      name: "Mark as default work type",
+    });
+
+    await user.click(within(panel).getByText("Mark as default work type"));
+
+    expect(defaultCheckbox.checked).toBe(true);
+    expect(within(panel).getByRole("status").textContent).toBe(
+      "Default work type",
+    );
+    expect(
+      within(panel).queryByText(
+        "Default work type supplies prompt text for simplified factory runs.",
+      ),
+    ).toBeNull();
+
+    defaultCheckbox.focus();
+    await user.keyboard(" ");
+
+    expect(defaultCheckbox.checked).toBe(false);
+    expect(within(panel).queryByRole("status")).toBeNull();
+    expect(
+      within(panel).getByText(
+        "Default work type supplies prompt text for simplified factory runs.",
+      ),
+    ).toBeTruthy();
   });
 
   it("shows default status and a checked control when the factory marks the work type default", () => {

--- a/ui/src/features/current-selection/worker-selection/components/worker-editable-configuration-section.checkbox-verification.stories.tsx
+++ b/ui/src/features/current-selection/worker-selection/components/worker-editable-configuration-section.checkbox-verification.stories.tsx
@@ -1,0 +1,176 @@
+import { expect, userEvent, within } from "storybook/test";
+import { useState } from "react";
+
+import "../../../../styles.css";
+import type { EditableWorkerSaveValidationErrors } from "../lib/detail-card-types";
+import { getWorkerDetailMessages } from "../messages/worker-detail";
+import { expectStyledCheckboxInStory } from "../../../../testing/checkbox-story-helpers";
+import { WorkerEditableConfigurationSection } from "./worker-editable-configuration-section";
+
+const messages = getWorkerDetailMessages();
+
+function buildStoryReadyWorkerState(
+  skipPermissions: boolean,
+  validationErrors: EditableWorkerSaveValidationErrors,
+) {
+  const hasValidationErrors = Object.keys(validationErrors).length > 0;
+
+  return {
+    baseVersion: {
+      logical: "1",
+      physical: "2026-06-08T00:00:00Z",
+    },
+    canSave: !hasValidationErrors,
+    draft: {
+      argsText: "",
+      authSecretRef: "",
+      body: "",
+      command: "",
+      executorProvider: null,
+      linearClaimAssigneeField: "",
+      linearMappingState: "",
+      linearMappingWorkType: "",
+      linearPollInterval: "",
+      linearStateIdsText: "",
+      linearTeamIdsText: "",
+      model: "gpt-5.5",
+      modelLocality: null,
+      modelProvider: "CURSOR",
+      name: "reviewer",
+      provider: null,
+      skipPermissions,
+      stopToken: "",
+      timeoutAmount: "",
+      timeoutUnit: "m",
+      type: "MODEL_WORKER" as const,
+    },
+    hasValidationErrors,
+    initialValues: {
+      args: [],
+      body: null,
+      command: null,
+      executorProvider: null,
+      model: "gpt-5.5",
+      modelLocality: null,
+      modelProvider: "CURSOR",
+      provider: null,
+      skipPermissions: null,
+      stopToken: null,
+      timeout: null,
+      type: "MODEL_WORKER" as const,
+      workerName: "reviewer",
+      workstationNames: ["Review"],
+      authSecretRef: null,
+      linearClaimAssigneeField: null,
+      linearClaimPresent: false,
+      linearMappingState: null,
+      linearMappingWorkType: null,
+      linearPollInterval: null,
+      linearStateIds: [],
+      linearTeamIds: [],
+    },
+    isDirty: true,
+    onArgsTextChange: () => undefined,
+    onAuthSecretRefChange: () => undefined,
+    onBodyChange: () => undefined,
+    onCommandChange: () => undefined,
+    onExecutorProviderChange: () => undefined,
+    onLinearClaimAssigneeFieldChange: () => undefined,
+    onLinearMappingStateChange: () => undefined,
+    onLinearMappingWorkTypeChange: () => undefined,
+    onLinearPollIntervalChange: () => undefined,
+    onLinearStateIdsTextChange: () => undefined,
+    onLinearTeamIdsTextChange: () => undefined,
+    onModelChange: () => undefined,
+    onModelLocalityChange: () => undefined,
+    onModelProviderChange: () => undefined,
+    onNameChange: () => undefined,
+    onProviderChange: () => undefined,
+    onSkipPermissionsChange: () => undefined,
+    onStopTokenChange: () => undefined,
+    onTimeoutAmountChange: () => undefined,
+    onTimeoutUnitChange: () => undefined,
+    markChangesSaved: () => undefined,
+    onResetToLatest: () => undefined,
+    onTypeChange: () => undefined,
+    overwriteFieldNames: [],
+    pendingFactoryDefinition: null,
+    savedFactoryDefinition: {
+      name: "Current Factory",
+      workers: [],
+      workstations: [],
+    },
+    status: "ready" as const,
+    validationErrors,
+  };
+}
+
+function WorkerSkipPermissionsVerificationStory({
+  validationErrors = {},
+}: {
+  validationErrors?: EditableWorkerSaveValidationErrors;
+}) {
+  const [skipPermissions, setSkipPermissions] = useState(false);
+  const state = buildStoryReadyWorkerState(skipPermissions, validationErrors);
+
+  return (
+    <WorkerEditableConfigurationSection
+      messages={messages}
+      state={{
+        ...state,
+        onSkipPermissionsChange: setSkipPermissions,
+      }}
+      workerName="reviewer"
+    />
+  );
+}
+
+export default {
+  title: "you-agent-factory/Checkbox Consistency/Current Selection",
+  tags: ["test"],
+};
+
+export const WorkerSkipPermissions = {
+  render: () => <WorkerSkipPermissionsVerificationStory />,
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const checkbox = await canvas.findByRole("checkbox", {
+      name: messages.skipPermissionsFieldLabel,
+    });
+
+    expectStyledCheckboxInStory(checkbox);
+    expect(checkbox).not.toBeChecked();
+    await expect(
+      canvas.getByText(messages.skipPermissionsFieldHelp),
+    ).toBeVisible();
+
+    await userEvent.click(canvas.getByText(messages.skipPermissionsFieldLabel));
+    expect(checkbox).toBeChecked();
+
+    checkbox.focus();
+    await userEvent.keyboard(" ");
+    expect(checkbox).not.toBeChecked();
+  },
+};
+
+export const WorkerSkipPermissionsInvalid = {
+  render: () => (
+    <WorkerSkipPermissionsVerificationStory
+      validationErrors={{
+        skipPermissions: "skipPermissions must be a boolean.",
+      }}
+    />
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const checkbox = await canvas.findByRole("checkbox", {
+      name: messages.skipPermissionsFieldLabel,
+    });
+
+    expectStyledCheckboxInStory(checkbox);
+    expect(checkbox).toHaveAttribute("aria-invalid", "true");
+    await expect(
+      canvas.getByText("skipPermissions must be a boolean."),
+    ).toBeVisible();
+  },
+};

--- a/ui/src/features/current-selection/worker-selection/components/worker-editable-configuration-section.skip-permissions.test.tsx
+++ b/ui/src/features/current-selection/worker-selection/components/worker-editable-configuration-section.skip-permissions.test.tsx
@@ -1,0 +1,147 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { installDashboardBrowserTestShims } from "../../../../components/dashboard/test-browser-shims";
+import { expectStyledCheckbox } from "../../../../testing/checkbox-test-helpers";
+
+import type { EditableWorkerConfigurationState } from "../lib/detail-card-types";
+import { WorkerEditableConfigurationSection } from "./worker-editable-configuration-section";
+import {
+  buildReadyWorkerEditableConfigurationState,
+  workerEditableConfigurationSectionMessages as messages,
+} from "./worker-editable-configuration-section.test-helpers";
+
+let restoreBrowserShims: (() => void) | undefined;
+
+beforeEach(() => {
+  restoreBrowserShims = installDashboardBrowserTestShims();
+});
+
+afterEach(() => {
+  cleanup();
+  restoreBrowserShims?.();
+  restoreBrowserShims = undefined;
+});
+
+describe("WorkerEditableConfigurationSection skipPermissions control", () => {
+  it("renders the shared styled checkbox for model workers", () => {
+    render(
+      <WorkerEditableConfigurationSection
+        messages={messages}
+        state={buildReadyWorkerEditableConfigurationState(["Review"])}
+        workerName="reviewer"
+      />,
+    );
+
+    const skipPermissionsCheckbox = screen.getByRole("checkbox", {
+      name: messages.skipPermissionsFieldLabel,
+    });
+
+    expectStyledCheckbox(skipPermissionsCheckbox);
+    expect(skipPermissionsCheckbox.checked).toBe(false);
+    expect(
+      screen.getByText(messages.skipPermissionsFieldHelp),
+    ).toBeInTheDocument();
+  });
+
+  it("toggles skipPermissions from label clicks and Space while focused", async () => {
+    const user = userEvent.setup();
+    const state = buildReadyWorkerEditableConfigurationState(["Review"]);
+    state.onSkipPermissionsChange = vi.fn((checked: boolean) => {
+      state.draft.skipPermissions = checked;
+    });
+
+    const { rerender } = render(
+      <WorkerEditableConfigurationSection
+        messages={messages}
+        state={state}
+        workerName="reviewer"
+      />,
+    );
+
+    const skipPermissionsCheckbox = screen.getByRole("checkbox", {
+      name: messages.skipPermissionsFieldLabel,
+    });
+
+    await user.click(screen.getByText(messages.skipPermissionsFieldLabel));
+    rerender(
+      <WorkerEditableConfigurationSection
+        messages={messages}
+        state={state}
+        workerName="reviewer"
+      />,
+    );
+    expect(skipPermissionsCheckbox.checked).toBe(true);
+
+    skipPermissionsCheckbox.focus();
+    await user.keyboard(" ");
+    rerender(
+      <WorkerEditableConfigurationSection
+        messages={messages}
+        state={state}
+        workerName="reviewer"
+      />,
+    );
+    expect(skipPermissionsCheckbox.checked).toBe(false);
+  });
+
+  it("exposes invalid state and validation feedback on skipPermissions errors", () => {
+    const validationMessage = "skipPermissions must be a boolean.";
+    const state = {
+      ...buildReadyWorkerEditableConfigurationState(["Review"]),
+      canSave: false,
+      hasValidationErrors: true,
+      validationErrors: {
+        skipPermissions: validationMessage,
+      },
+    };
+
+    render(
+      <WorkerEditableConfigurationSection
+        messages={messages}
+        state={state}
+        workerName="reviewer"
+      />,
+    );
+
+    const skipPermissionsCheckbox = screen.getByRole("checkbox", {
+      name: messages.skipPermissionsFieldLabel,
+    });
+
+    expectStyledCheckbox(skipPermissionsCheckbox);
+    expect(skipPermissionsCheckbox.getAttribute("aria-invalid")).toBe("true");
+    expect(screen.getByText(validationMessage)).toBeInTheDocument();
+  });
+
+  it("does not show the permission bypass toggle for script workers", () => {
+    const scriptWorkerState: Extract<
+      EditableWorkerConfigurationState,
+      { status: "ready" }
+    > = {
+      ...buildReadyWorkerEditableConfigurationState(["Review"]),
+      draft: {
+        ...buildReadyWorkerEditableConfigurationState(["Review"]).draft,
+        model: "",
+        modelProvider: null,
+        type: "SCRIPT_WORKER",
+        command: "node",
+      },
+    };
+
+    render(
+      <WorkerEditableConfigurationSection
+        messages={messages}
+        state={scriptWorkerState}
+        workerName="reviewer"
+      />,
+    );
+
+    expect(
+      screen.queryByRole("checkbox", {
+        name: messages.skipPermissionsFieldLabel,
+      }),
+    ).toBeNull();
+  });
+});

--- a/ui/src/features/current-selection/worker-selection/components/worker-editable-configuration-section.test-helpers.ts
+++ b/ui/src/features/current-selection/worker-selection/components/worker-editable-configuration-section.test-helpers.ts
@@ -1,0 +1,84 @@
+import { vi } from "vitest";
+
+import type { CanonicalFactoryDefinition } from "../../../../api/factory-definition/api";
+import {
+  EMPTY_HOSTED_LINEAR_EDITABLE_DRAFT_FIELDS,
+  EMPTY_HOSTED_LINEAR_EDITABLE_VALUES,
+} from "../../../current-factory-definition/lib/worker-editable-values";
+import type { EditableWorkerConfigurationState } from "../lib/detail-card-types";
+import { getWorkerDetailMessages } from "../messages/worker-detail";
+
+export const workerEditableConfigurationSectionMessages =
+  getWorkerDetailMessages();
+
+export function buildReadyWorkerEditableConfigurationState(
+  workstationNames: string[],
+): Extract<EditableWorkerConfigurationState, { status: "ready" }> {
+  return {
+    canSave: true,
+    draft: {
+      argsText: "",
+      body: "",
+      command: "",
+      executorProvider: null,
+      model: "gpt-5.5",
+      modelLocality: null,
+      modelProvider: "CURSOR",
+      name: "reviewer",
+      provider: null,
+      skipPermissions: false,
+      stopToken: "",
+      timeoutAmount: "",
+      timeoutUnit: "m",
+      type: "MODEL_WORKER",
+      ...EMPTY_HOSTED_LINEAR_EDITABLE_DRAFT_FIELDS,
+    },
+    hasValidationErrors: false,
+    initialValues: {
+      args: [],
+      body: null,
+      command: null,
+      executorProvider: null,
+      model: "gpt-5.5",
+      modelLocality: null,
+      modelProvider: "CURSOR",
+      name: "reviewer",
+      provider: null,
+      skipPermissions: null,
+      stopToken: null,
+      timeout: null,
+      type: "MODEL_WORKER",
+      workerName: "reviewer",
+      workstationNames,
+      ...EMPTY_HOSTED_LINEAR_EDITABLE_VALUES,
+    },
+    isDirty: true,
+    onArgsTextChange: vi.fn(),
+    onAuthSecretRefChange: vi.fn(),
+    onBodyChange: vi.fn(),
+    onCommandChange: vi.fn(),
+    onExecutorProviderChange: vi.fn(),
+    onLinearClaimAssigneeFieldChange: vi.fn(),
+    onLinearMappingStateChange: vi.fn(),
+    onLinearMappingWorkTypeChange: vi.fn(),
+    onLinearPollIntervalChange: vi.fn(),
+    onLinearStateIdsTextChange: vi.fn(),
+    onLinearTeamIdsTextChange: vi.fn(),
+    onModelChange: vi.fn(),
+    onModelLocalityChange: vi.fn(),
+    onModelProviderChange: vi.fn(),
+    onNameChange: vi.fn(),
+    onProviderChange: vi.fn(),
+    onSkipPermissionsChange: vi.fn(),
+    onStopTokenChange: vi.fn(),
+    onTimeoutAmountChange: vi.fn(),
+    onTimeoutUnitChange: vi.fn(),
+    markChangesSaved: vi.fn(),
+    onResetToLatest: vi.fn(),
+    onTypeChange: vi.fn(),
+    overwriteFieldNames: [],
+    pendingFactoryDefinition: {} as CanonicalFactoryDefinition,
+    status: "ready",
+    validationErrors: {},
+  };
+}

--- a/ui/src/features/current-selection/worker-selection/components/worker-editable-configuration-section.test-helpers.ts
+++ b/ui/src/features/current-selection/worker-selection/components/worker-editable-configuration-section.test-helpers.ts
@@ -1,12 +1,29 @@
 import { vi } from "vitest";
 
 import type { CanonicalFactoryDefinition } from "../../../../api/factory-definition/api";
-import {
-  EMPTY_HOSTED_LINEAR_EDITABLE_DRAFT_FIELDS,
-  EMPTY_HOSTED_LINEAR_EDITABLE_VALUES,
-} from "../../../current-factory-definition/lib/worker-editable-values";
 import type { EditableWorkerConfigurationState } from "../lib/detail-card-types";
 import { getWorkerDetailMessages } from "../messages/worker-detail";
+
+const EMPTY_HOSTED_LINEAR_EDITABLE_DRAFT_FIELDS = {
+  authSecretRef: "",
+  linearClaimAssigneeField: "",
+  linearMappingState: "",
+  linearMappingWorkType: "",
+  linearPollInterval: "",
+  linearStateIdsText: "",
+  linearTeamIdsText: "",
+};
+
+const EMPTY_HOSTED_LINEAR_EDITABLE_VALUES = {
+  authSecretRef: null,
+  linearClaimAssigneeField: null,
+  linearClaimPresent: false,
+  linearMappingState: null,
+  linearMappingWorkType: null,
+  linearPollInterval: null,
+  linearStateIds: [] as string[],
+  linearTeamIds: [] as string[],
+};
 
 export const workerEditableConfigurationSectionMessages =
   getWorkerDetailMessages();
@@ -14,7 +31,17 @@ export const workerEditableConfigurationSectionMessages =
 export function buildReadyWorkerEditableConfigurationState(
   workstationNames: string[],
 ): Extract<EditableWorkerConfigurationState, { status: "ready" }> {
+  const savedFactoryDefinition = {
+    name: "Current Factory",
+    workers: [],
+    workstations: [],
+  } as CanonicalFactoryDefinition;
+
   return {
+    baseVersion: {
+      logical: "1",
+      physical: "2026-06-08T00:00:00Z",
+    },
     canSave: true,
     draft: {
       argsText: "",
@@ -42,7 +69,6 @@ export function buildReadyWorkerEditableConfigurationState(
       model: "gpt-5.5",
       modelLocality: null,
       modelProvider: "CURSOR",
-      name: "reviewer",
       provider: null,
       skipPermissions: null,
       stopToken: null,
@@ -77,7 +103,8 @@ export function buildReadyWorkerEditableConfigurationState(
     onResetToLatest: vi.fn(),
     onTypeChange: vi.fn(),
     overwriteFieldNames: [],
-    pendingFactoryDefinition: {} as CanonicalFactoryDefinition,
+    pendingFactoryDefinition: null,
+    savedFactoryDefinition,
     status: "ready",
     validationErrors: {},
   };

--- a/ui/src/features/current-selection/worker-selection/components/worker-editable-configuration-section.test.tsx
+++ b/ui/src/features/current-selection/worker-selection/components/worker-editable-configuration-section.test.tsx
@@ -1,19 +1,15 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { installDashboardBrowserTestShims } from "../../../../components/dashboard/test-browser-shims";
 
-import type { CanonicalFactoryDefinition } from "../../../../api/factory-definition/api";
-import {
-  EMPTY_HOSTED_LINEAR_EDITABLE_DRAFT_FIELDS,
-  EMPTY_HOSTED_LINEAR_EDITABLE_VALUES,
-} from "../../../current-factory-definition/lib/worker-editable-values";
 import type { EditableWorkerConfigurationState } from "../lib/detail-card-types";
-import { getWorkerDetailMessages } from "../messages/worker-detail";
 import { WorkerEditableConfigurationSection } from "./worker-editable-configuration-section";
-
-const messages = getWorkerDetailMessages();
+import {
+  buildReadyWorkerEditableConfigurationState,
+  workerEditableConfigurationSectionMessages as messages,
+} from "./worker-editable-configuration-section.test-helpers";
 
 let restoreBrowserShims: (() => void) | undefined;
 
@@ -26,78 +22,6 @@ afterEach(() => {
   restoreBrowserShims?.();
   restoreBrowserShims = undefined;
 });
-
-function buildReadyWorkerEditableConfigurationState(
-  workstationNames: string[],
-): Extract<EditableWorkerConfigurationState, { status: "ready" }> {
-  return {
-    canSave: true,
-    draft: {
-      argsText: "",
-      body: "",
-      command: "",
-      executorProvider: null,
-      model: "gpt-5.5",
-      modelLocality: null,
-      modelProvider: "CURSOR",
-      name: "reviewer",
-      provider: null,
-      skipPermissions: false,
-      stopToken: "",
-      timeoutAmount: "",
-      timeoutUnit: "m",
-      type: "MODEL_WORKER",
-      ...EMPTY_HOSTED_LINEAR_EDITABLE_DRAFT_FIELDS,
-    },
-    hasValidationErrors: false,
-    initialValues: {
-      args: [],
-      body: null,
-      command: null,
-      executorProvider: null,
-      model: "gpt-5.5",
-      modelLocality: null,
-      modelProvider: "CURSOR",
-      name: "reviewer",
-      provider: null,
-      skipPermissions: null,
-      stopToken: null,
-      timeout: null,
-      type: "MODEL_WORKER",
-      workerName: "reviewer",
-      workstationNames,
-      ...EMPTY_HOSTED_LINEAR_EDITABLE_VALUES,
-    },
-    isDirty: true,
-    onArgsTextChange: vi.fn(),
-    onAuthSecretRefChange: vi.fn(),
-    onBodyChange: vi.fn(),
-    onCommandChange: vi.fn(),
-    onExecutorProviderChange: vi.fn(),
-    onLinearClaimAssigneeFieldChange: vi.fn(),
-    onLinearMappingStateChange: vi.fn(),
-    onLinearMappingWorkTypeChange: vi.fn(),
-    onLinearPollIntervalChange: vi.fn(),
-    onLinearStateIdsTextChange: vi.fn(),
-    onLinearTeamIdsTextChange: vi.fn(),
-    onModelChange: vi.fn(),
-    onModelLocalityChange: vi.fn(),
-    onModelProviderChange: vi.fn(),
-    onNameChange: vi.fn(),
-    onProviderChange: vi.fn(),
-    onSkipPermissionsChange: vi.fn(),
-    onStopTokenChange: vi.fn(),
-    onTimeoutAmountChange: vi.fn(),
-    onTimeoutUnitChange: vi.fn(),
-    markChangesSaved: vi.fn(),
-    onResetToLatest: vi.fn(),
-    onTypeChange: vi.fn(),
-    overwriteFieldNames: [],
-    pendingFactoryDefinition: {} as CanonicalFactoryDefinition,
-    status: "ready",
-    validationErrors: {},
-  };
-}
 
 describe("WorkerEditableConfigurationSection shared-impact warnings", () => {
   it("shows worker save-impact warning when multiple workstations reference the worker", () => {
@@ -177,54 +101,6 @@ describe("WorkerEditableConfigurationSection timeout control", () => {
     expect(
       screen.getByRole("spinbutton", { name: messages.timeoutFieldLabel }),
     ).toBeInTheDocument();
-  });
-});
-
-describe("WorkerEditableConfigurationSection skipPermissions control", () => {
-  it("shows the permission bypass toggle for model workers", () => {
-    render(
-      <WorkerEditableConfigurationSection
-        messages={messages}
-        state={buildReadyWorkerEditableConfigurationState(["Review"])}
-        workerName="reviewer"
-      />,
-    );
-
-    expect(
-      screen.getByRole("checkbox", {
-        name: messages.skipPermissionsFieldLabel,
-      }),
-    ).toBeInTheDocument();
-  });
-
-  it("does not show the permission bypass toggle for script workers", () => {
-    const scriptWorkerState: Extract<
-      EditableWorkerConfigurationState,
-      { status: "ready" }
-    > = {
-      ...buildReadyWorkerEditableConfigurationState(["Review"]),
-      draft: {
-        ...buildReadyWorkerEditableConfigurationState(["Review"]).draft,
-        model: "",
-        modelProvider: null,
-        type: "SCRIPT_WORKER",
-        command: "node",
-      },
-    };
-
-    render(
-      <WorkerEditableConfigurationSection
-        messages={messages}
-        state={scriptWorkerState}
-        workerName="reviewer"
-      />,
-    );
-
-    expect(
-      screen.queryByRole("checkbox", {
-        name: messages.skipPermissionsFieldLabel,
-      }),
-    ).toBeNull();
   });
 });
 

--- a/ui/src/features/current-selection/workstation-selection/components/editable/workstation-cron-fields.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/editable/workstation-cron-fields.tsx
@@ -186,6 +186,14 @@ function EditableConfigurationCronTriggerAtStartField({
         htmlFor={fieldId}
       >
         <Checkbox
+          aria-describedby={
+            state.validationErrors.cronTriggerAtStart
+              ? `${fieldId}-error`
+              : undefined
+          }
+          aria-invalid={
+            state.validationErrors.cronTriggerAtStart ? "true" : undefined
+          }
           checked={cron.triggerAtStart}
           id={fieldId}
           onChange={(event) =>

--- a/ui/src/features/current-selection/workstation-selection/components/editable/workstation-editable-configuration-section.cron.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/editable/workstation-editable-configuration-section.cron.test.tsx
@@ -123,6 +123,10 @@ describe("EditableConfigurationSection cron workstations", () => {
     });
 
     expectStyledCheckbox(triggerAtStartCheckbox);
+    expect(triggerAtStartCheckbox.getAttribute("aria-invalid")).toBe("true");
+    expect(triggerAtStartCheckbox.getAttribute("aria-describedby")).toBe(
+      "editable-workstation-cron-trigger-at-start-error",
+    );
     expect(screen.getByText(validationMessage)).toBeInTheDocument();
   });
 

--- a/ui/src/features/current-selection/workstation-selection/components/editable/workstation-editable-configuration-section.cron.test.tsx
+++ b/ui/src/features/current-selection/workstation-selection/components/editable/workstation-editable-configuration-section.cron.test.tsx
@@ -3,6 +3,8 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
+import { expectStyledCheckbox } from "../../../../../testing/checkbox-test-helpers";
+
 import { EditableConfigurationSection } from "./workstation-editable-configuration-section";
 import {
   buildEditableConfigurationSectionReadyState,
@@ -13,6 +15,53 @@ import {
 const messages = editableConfigurationSectionMessages;
 
 describe("EditableConfigurationSection cron workstations", () => {
+  it("renders the shared styled checkbox for cron trigger-at-start", () => {
+    render(
+      <EditableConfigurationSection
+        messages={messages}
+        state={buildEditableConfigurationSectionReadyState({
+          draft: { behavior: "CRON" },
+        })}
+      />,
+    );
+
+    expandEditableConfigurationSection();
+
+    const triggerAtStartCheckbox = screen.getByRole("checkbox", {
+      name: messages.cronTriggerAtStartFieldLabel,
+    });
+
+    expectStyledCheckbox(triggerAtStartCheckbox);
+    expect(triggerAtStartCheckbox.checked).toBe(true);
+  });
+
+  it("toggles cron trigger-at-start with Space while focused", async () => {
+    const user = userEvent.setup();
+    const onCronTriggerAtStartChange = vi.fn();
+
+    render(
+      <EditableConfigurationSection
+        messages={messages}
+        state={{
+          ...buildEditableConfigurationSectionReadyState({
+            draft: { behavior: "CRON" },
+          }),
+          onCronTriggerAtStartChange,
+        }}
+      />,
+    );
+
+    expandEditableConfigurationSection();
+
+    const triggerAtStartCheckbox = screen.getByRole("checkbox", {
+      name: messages.cronTriggerAtStartFieldLabel,
+    });
+
+    triggerAtStartCheckbox.focus();
+    await user.keyboard(" ");
+    expect(onCronTriggerAtStartChange).toHaveBeenCalledWith(false);
+  });
+
   it("renders cron fields for CRON workstations and wires cron mutators", async () => {
     const user = userEvent.setup();
     const onCronScheduleChange = vi.fn();
@@ -51,6 +100,30 @@ describe("EditableConfigurationSection cron workstations", () => {
       screen.getByLabelText(messages.cronTriggerAtStartFieldLabel),
     );
     expect(onCronTriggerAtStartChange).toHaveBeenCalledWith(false);
+  });
+
+  it("exposes invalid state and validation feedback on cron trigger-at-start errors", () => {
+    const validationMessage = "trigger_at_start must be a boolean";
+
+    render(
+      <EditableConfigurationSection
+        messages={messages}
+        state={buildEditableConfigurationSectionReadyState({
+          draft: { behavior: "CRON" },
+          hasValidationErrors: true,
+          validationErrors: { cronTriggerAtStart: validationMessage },
+        })}
+      />,
+    );
+
+    expandEditableConfigurationSection();
+
+    const triggerAtStartCheckbox = screen.getByRole("checkbox", {
+      name: messages.cronTriggerAtStartFieldLabel,
+    });
+
+    expectStyledCheckbox(triggerAtStartCheckbox);
+    expect(screen.getByText(validationMessage)).toBeInTheDocument();
   });
 
   it("shows validation alert when cron field errors exist", () => {

--- a/ui/src/features/factory-graph-editor/components/add-dialog/factory-graph-editor-add-workstation-fields.checkbox-verification.stories.tsx
+++ b/ui/src/features/factory-graph-editor/components/add-dialog/factory-graph-editor-add-workstation-fields.checkbox-verification.stories.tsx
@@ -1,0 +1,69 @@
+import { expect, userEvent, within } from "storybook/test";
+import { useState } from "react";
+
+import "../../../../styles.css";
+import { createEmptyEditableWorkstationCronDraft } from "../../../current-factory-definition/lib/workstation-editable-values";
+import { getWorkstationDetailMessages } from "../../../current-selection/workstation-selection/messages/workstation-detail";
+import { expectStyledCheckboxInStory } from "../../../../testing/checkbox-story-helpers";
+import type { FactoryGraphAddEntityDraft } from "../../lib/editor/factory-graph-editor-additions";
+import { getFactoryGraphEditorMessages } from "../../messages/editor";
+import { FactoryGraphEditorAddWorkstationFields } from "./factory-graph-editor-add-workstation-fields";
+
+const messages = getFactoryGraphEditorMessages();
+const workstationMessages = getWorkstationDetailMessages();
+
+function buildCronWorkstationDraft(): Extract<
+  FactoryGraphAddEntityDraft,
+  { kind: "workstation" }
+> {
+  return {
+    behavior: "CRON",
+    body: "",
+    cron: createEmptyEditableWorkstationCronDraft(),
+    kind: "workstation",
+    name: "scheduler",
+    workerName: "writer",
+    workstationType: "MODEL_WORKSTATION",
+  };
+}
+
+function FactoryGraphCronCheckboxVerificationStory() {
+  const [draft, setDraft] = useState(buildCronWorkstationDraft);
+
+  return (
+    <FactoryGraphEditorAddWorkstationFields
+      currentFactoryDefinition={null}
+      draft={draft}
+      errors={{}}
+      messages={messages}
+      onChange={setDraft}
+    />
+  );
+}
+
+export default {
+  title: "you-agent-factory/Checkbox Consistency/Factory Graph Editor",
+  tags: ["test"],
+};
+
+export const CronTriggerAtStart = {
+  render: () => <FactoryGraphCronCheckboxVerificationStory />,
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const checkbox = await canvas.findByRole("checkbox", {
+      name: workstationMessages.cronTriggerAtStartFieldLabel,
+    });
+
+    expectStyledCheckboxInStory(checkbox);
+    expect(checkbox).not.toBeChecked();
+
+    await userEvent.click(
+      canvas.getByText(workstationMessages.cronTriggerAtStartFieldLabel),
+    );
+    expect(checkbox).toBeChecked();
+
+    checkbox.focus();
+    await userEvent.keyboard(" ");
+    expect(checkbox).not.toBeChecked();
+  },
+};

--- a/ui/src/features/factory-graph-editor/components/add-dialog/factory-graph-editor-add-workstation-fields.test.tsx
+++ b/ui/src/features/factory-graph-editor/components/add-dialog/factory-graph-editor-add-workstation-fields.test.tsx
@@ -1,0 +1,115 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { installDashboardBrowserTestShims } from "../../../../components/dashboard/test-browser-shims";
+import { createEmptyEditableWorkstationCronDraft } from "../../../current-factory-definition/lib/workstation-editable-values";
+import { getWorkstationDetailMessages } from "../../../current-selection/workstation-selection/messages/workstation-detail";
+import { expectStyledCheckbox } from "../../../../testing/checkbox-test-helpers";
+import { getFactoryGraphEditorMessages } from "../../messages/editor";
+import { FactoryGraphEditorAddWorkstationFields } from "./factory-graph-editor-add-workstation-fields";
+
+let restoreBrowserShims: (() => void) | undefined;
+
+const messages = getFactoryGraphEditorMessages();
+const workstationMessages = getWorkstationDetailMessages();
+
+function buildCronWorkstationDraft() {
+  return {
+    behavior: "CRON" as const,
+    body: "",
+    cron: createEmptyEditableWorkstationCronDraft(),
+    kind: "workstation" as const,
+    name: "scheduler",
+    workerName: "writer",
+    workstationType: "MODEL_WORKSTATION" as const,
+  };
+}
+
+beforeEach(() => {
+  restoreBrowserShims = installDashboardBrowserTestShims();
+});
+
+afterEach(() => {
+  cleanup();
+  restoreBrowserShims?.();
+  restoreBrowserShims = undefined;
+});
+
+describe("FactoryGraphEditorAddWorkstationFields cron checkbox", () => {
+  it("renders the shared styled checkbox for cron trigger-at-start", () => {
+    render(
+      <FactoryGraphEditorAddWorkstationFields
+        currentFactoryDefinition={null}
+        draft={buildCronWorkstationDraft()}
+        errors={{}}
+        messages={messages}
+        onChange={vi.fn()}
+      />,
+    );
+
+    const triggerAtStartCheckbox = screen.getByRole("checkbox", {
+      name: workstationMessages.cronTriggerAtStartFieldLabel,
+    });
+
+    expectStyledCheckbox(triggerAtStartCheckbox);
+    expect(triggerAtStartCheckbox.checked).toBe(false);
+  });
+
+  it("toggles cron trigger-at-start from label clicks and Space while focused", async () => {
+    const user = userEvent.setup();
+    let draft = buildCronWorkstationDraft();
+    const onChange = vi.fn((nextDraft) => {
+      draft = nextDraft;
+    });
+
+    const { rerender } = render(
+      <FactoryGraphEditorAddWorkstationFields
+        currentFactoryDefinition={null}
+        draft={draft}
+        errors={{}}
+        messages={messages}
+        onChange={onChange}
+      />,
+    );
+
+    const triggerAtStartCheckbox = screen.getByRole("checkbox", {
+      name: workstationMessages.cronTriggerAtStartFieldLabel,
+    });
+
+    await user.click(
+      screen.getByText(workstationMessages.cronTriggerAtStartFieldLabel),
+    );
+
+    rerender(
+      <FactoryGraphEditorAddWorkstationFields
+        currentFactoryDefinition={null}
+        draft={draft}
+        errors={{}}
+        messages={messages}
+        onChange={onChange}
+      />,
+    );
+    expect(triggerAtStartCheckbox.checked).toBe(true);
+
+    triggerAtStartCheckbox.focus();
+    await user.keyboard(" ");
+
+    rerender(
+      <FactoryGraphEditorAddWorkstationFields
+        currentFactoryDefinition={null}
+        draft={draft}
+        errors={{}}
+        messages={messages}
+        onChange={onChange}
+      />,
+    );
+    expect(triggerAtStartCheckbox.checked).toBe(false);
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        cron: expect.objectContaining({ triggerAtStart: false }),
+      }),
+    );
+  });
+});

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-add-worker-model-operations-fields.styled-checkbox.test.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-add-worker-model-operations-fields.styled-checkbox.test.tsx
@@ -1,0 +1,128 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { installDashboardBrowserTestShims } from "../../../components/dashboard/test-browser-shims";
+import { expectStyledCheckbox } from "../../../testing/checkbox-test-helpers";
+import { FactoryGraphEditorAddWorkerModelOperationsFields } from "./factory-graph-editor-add-worker-model-operations-fields";
+import { buildOperationDraft } from "./factory-graph-editor-add-worker-model-operations-fields.test-helpers";
+
+let restoreBrowserShims: (() => void) | undefined;
+
+beforeEach(() => {
+  restoreBrowserShims = installDashboardBrowserTestShims();
+});
+
+afterEach(() => {
+  cleanup();
+  restoreBrowserShims?.();
+  restoreBrowserShims = undefined;
+});
+
+describe("FactoryGraphEditorAddWorkerModelOperationsFields styled checkboxes", () => {
+  it("renders shared styled checkboxes for content types and required input slot", () => {
+    render(
+      <FactoryGraphEditorAddWorkerModelOperationsFields
+        onChange={vi.fn()}
+        operations={[buildOperationDraft()]}
+      />,
+    );
+
+    const requiredCheckbox = screen.getByLabelText("Required input slot");
+    expectStyledCheckbox(requiredCheckbox);
+    expect(requiredCheckbox.checked).toBe(true);
+
+    const inputTextCheckbox = document.getElementById(
+      "factory-graph-add-model-operation-input-slot-0-content-type-TEXT",
+    );
+    expect(inputTextCheckbox).toBeTruthy();
+    expectStyledCheckbox(inputTextCheckbox as HTMLElement);
+    expect((inputTextCheckbox as HTMLInputElement).checked).toBe(true);
+
+    const outputAudioCheckbox = document.getElementById(
+      "factory-graph-add-model-operation-output-slot-0-content-type-AUDIO",
+    );
+    expect(outputAudioCheckbox).toBeTruthy();
+    expectStyledCheckbox(outputAudioCheckbox as HTMLElement);
+    expect((outputAudioCheckbox as HTMLInputElement).checked).toBe(true);
+  });
+
+  it("toggles required input slot with Space while focused", async () => {
+    const user = userEvent.setup();
+    let operations = [buildOperationDraft()];
+    const onChange = vi.fn((nextOperations) => {
+      operations = nextOperations;
+    });
+
+    const { rerender } = render(
+      <FactoryGraphEditorAddWorkerModelOperationsFields
+        onChange={onChange}
+        operations={operations}
+      />,
+    );
+
+    const requiredCheckbox = screen.getByLabelText("Required input slot");
+    requiredCheckbox.focus();
+    await user.keyboard(" ");
+
+    rerender(
+      <FactoryGraphEditorAddWorkerModelOperationsFields
+        onChange={onChange}
+        operations={operations}
+      />,
+    );
+
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({
+        inputs: [expect.objectContaining({ required: false })],
+      }),
+    ]);
+    expect(requiredCheckbox.checked).toBe(false);
+  });
+
+  it("toggles content type selection from checkbox clicks", async () => {
+    const user = userEvent.setup();
+    let operations = [buildOperationDraft()];
+    const onChange = vi.fn((nextOperations) => {
+      operations = nextOperations;
+    });
+
+    const { rerender } = render(
+      <FactoryGraphEditorAddWorkerModelOperationsFields
+        onChange={onChange}
+        operations={operations}
+      />,
+    );
+
+    const inputJsonCheckbox = document.getElementById(
+      "factory-graph-add-model-operation-input-slot-0-content-type-JSON",
+    );
+    expect(inputJsonCheckbox).toBeTruthy();
+    await user.click(inputJsonCheckbox as HTMLInputElement);
+
+    rerender(
+      <FactoryGraphEditorAddWorkerModelOperationsFields
+        onChange={onChange}
+        operations={operations}
+      />,
+    );
+
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({
+        inputs: [
+          expect.objectContaining({
+            contentTypes: expect.arrayContaining(["TEXT", "JSON"]),
+          }),
+        ],
+      }),
+    ]);
+    expect(
+      (
+        document.getElementById(
+          "factory-graph-add-model-operation-input-slot-0-content-type-JSON",
+        ) as HTMLInputElement
+      ).checked,
+    ).toBe(true);
+  });
+});

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-add-worker-model-operations-fields.test-helpers.ts
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-add-worker-model-operations-fields.test-helpers.ts
@@ -1,0 +1,20 @@
+import {
+  createEmptyFactoryGraphAddModelOperationDraft,
+  type FactoryGraphAddModelOperationDraft,
+} from "../lib/factory-graph-add-model-operation-draft";
+
+export function buildOperationDraft(): FactoryGraphAddModelOperationDraft {
+  const operation = createEmptyFactoryGraphAddModelOperationDraft();
+  operation.name = "TTS";
+  operation.inputs[0] = {
+    contentTypes: ["TEXT"],
+    name: "text",
+    required: true,
+  };
+  operation.outputs[0] = {
+    contentTypes: ["AUDIO"],
+    name: "audio",
+    required: false,
+  };
+  return operation;
+}

--- a/ui/src/features/factory-graph-editor/components/factory-graph-editor-add-worker-model-operations-fields.test.tsx
+++ b/ui/src/features/factory-graph-editor/components/factory-graph-editor-add-worker-model-operations-fields.test.tsx
@@ -4,29 +4,11 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { installDashboardBrowserTestShims } from "../../../components/dashboard/test-browser-shims";
-import {
-  createEmptyFactoryGraphAddModelOperationDraft,
-  type FactoryGraphAddModelOperationDraft,
-} from "../lib/factory-graph-add-model-operation-draft";
+import { createEmptyFactoryGraphAddModelOperationDraft } from "../lib/factory-graph-add-model-operation-draft";
 import { FactoryGraphEditorAddWorkerModelOperationsFields } from "./factory-graph-editor-add-worker-model-operations-fields";
+import { buildOperationDraft } from "./factory-graph-editor-add-worker-model-operations-fields.test-helpers";
 
 let restoreBrowserShims: (() => void) | undefined;
-
-function buildOperationDraft(): FactoryGraphAddModelOperationDraft {
-  const operation = createEmptyFactoryGraphAddModelOperationDraft();
-  operation.name = "TTS";
-  operation.inputs[0] = {
-    contentTypes: ["TEXT"],
-    name: "text",
-    required: true,
-  };
-  operation.outputs[0] = {
-    contentTypes: ["AUDIO"],
-    name: "audio",
-    required: false,
-  };
-  return operation;
-}
 
 beforeEach(() => {
   restoreBrowserShims = installDashboardBrowserTestShims();

--- a/ui/src/testing/checkbox-story-helpers.ts
+++ b/ui/src/testing/checkbox-story-helpers.ts
@@ -1,0 +1,9 @@
+import { expect } from "storybook/test";
+
+/** Assert the shared shadcn-style checkbox treatment in Storybook play functions. */
+export function expectStyledCheckboxInStory(checkbox: HTMLElement) {
+  expect(checkbox.className).toContain("sr-only");
+  const indicator = checkbox.nextElementSibling;
+  expect(indicator?.className).toContain("peer-checked:bg-primary");
+  expect(indicator?.querySelector("svg")).toBeTruthy();
+}

--- a/ui/src/testing/checkbox-test-helpers.ts
+++ b/ui/src/testing/checkbox-test-helpers.ts
@@ -1,0 +1,9 @@
+import { expect } from "vitest";
+
+/** Assert the shared shadcn-style checkbox treatment on a native checkbox input. */
+export function expectStyledCheckbox(checkbox: HTMLElement) {
+  expect(checkbox.className).toContain("sr-only");
+  const indicator = checkbox.nextElementSibling;
+  expect(indicator?.className).toContain("peer-checked:bg-primary");
+  expect(indicator?.querySelector("svg")).toBeTruthy();
+}


### PR DESCRIPTION
{
  "project": "Default Work Type Checkbox Styling Consistency",
  "branchName": "ralph/default-work-type-checkbox-styling-consistency",
  "description": "Replace native-looking website checkbox rendering with the shared shadcn-style checkbox treatment, starting with the default work type configuration checkbox and extending the same formatting to all other visible checkbox controls without changing their behavior.",
  "context": {
    "customerAsk": "The work type \"mark as default work type\" checkbox is unstyled because it uses default React/browser checkbox styling rather than the shadcn-style component. Fix it to use the styled component and apply the same formatting to all other checkboxes.",
    "problem": "Checkboxes in configuration and editor workflows can appear like native browser controls instead of first-class dashboard controls. This makes checked, focused, disabled, and invalid states feel inconsistent, especially on the default work type control that changes durable factory behavior.",
    "solution": "Upgrade or align the shared website checkbox primitive with the shadcn-style visual treatment, then ensure the default work type checkbox, current-selection configuration checkboxes, and factory graph editor checkbox flows all render through that primitive while preserving labels, validation, keyboard behavior, state updates, and saves."
  },
  "acceptanceCriteria": [
    "The shared checkbox control renders a styled box and visible checked indicator instead of relying on default browser checkbox appearance.",
    "The default work type configuration checkbox uses the shared styled checkbox treatment and preserves checked, unchecked, invalid, helper text, and save behavior.",
    "Every other visible website checkbox uses the same shared checkbox formatting, including current-selection worker/workstation settings and factory graph editor checkbox flows.",
    "Checkbox labels remain clickable, keyboard toggling works with Space, focus is visible, disabled checkboxes are visually distinct, and invalid checkboxes expose reviewer-verifiable error semantics.",
    "Existing loading, empty, error, and success states around checkbox-backed forms remain unchanged.",
    "Browser-visible checkbox styling is verified in the dashboard at desktop and mobile widths for at least one current-selection checkbox and one factory graph editor checkbox.",
    "Quality gate: UI typecheck, lint, and relevant tests pass."
  ],
  "userStories": [
    {
      "id": "default-work-type-configuration-currnt-selection-001",
      "title": "Style the shared checkbox primitive",
      "description": "As a dashboard user, I want every checkbox to have a clear styled checked, unchecked, focused, disabled, and invalid presentation so form state is understandable without relying on browser defaults.",
      "acceptanceCriteria": [
        "The shared checkbox primitive renders an explicit visual checked indicator when selected and no indicator when unselected.",
        "The checkbox keeps native checkbox semantics, including role=\"checkbox\" exposure, checked state, label activation, and Space-key toggling.",
        "Focus-visible styling is apparent and uses existing design tokens rather than raw one-off colors.",
        "Disabled styling prevents interaction and visually communicates that the control is unavailable.",
        "Invalid styling can be applied through existing aria-invalid usage without requiring feature-specific checkbox classes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "default-work-type-configuration-currnt-selection-002",
      "title": "Apply styled checkbox to default work type configuration",
      "description": "As a factory operator editing work type configuration, I want the \"mark as default work type\" checkbox to match the dashboard design system so I can trust it behaves like the rest of the form.",
      "acceptanceCriteria": [
        "The default work type checkbox renders with the shared styled checkbox appearance in both checked and unchecked states.",
        "Clicking the label toggles the checkbox and updates the draft handling behavior exactly as before.",
        "When the default work type value is invalid, the checkbox remains associated with the existing error message and exposes invalid state to assistive technology.",
        "Existing helper text, default status pill, save/discard enablement, and saved success behavior remain unchanged.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "default-work-type-configuration-currnt-selection-003",
      "title": "Standardize current-selection configuration checkboxes",
      "description": "As a factory operator editing current-selection configuration, I want all checkbox controls in worker and workstation settings to share the same styled presentation and interaction behavior.",
      "acceptanceCriteria": [
        "Worker configuration checkboxes render with the shared styled checkbox appearance while preserving their current checked state and draft update behavior.",
        "Workstation cron/start behavior checkboxes render with the shared styled checkbox appearance while preserving their current checked state and draft update behavior.",
        "Existing validation messages, server-changed hints, labels, and save/discard behavior remain unchanged around these checkboxes.",
        "Keyboard toggling and label click behavior work for each migrated current-selection checkbox.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "default-work-type-configuration-currnt-selection-004",
      "title": "Standardize factory graph editor checkboxes",
      "description": "As a factory editor user configuring worker model operations and workstation add-dialog options, I want checkbox controls in editor dialogs to match the dashboard checkbox style without changing dialog behavior.",
      "acceptanceCriteria": [
        "Factory graph editor operation checkboxes render with the shared styled checkbox appearance.",
        "Add-workstation dialog checkbox options render with the shared styled checkbox appearance.",
        "Existing dialog selection behavior, validation, disabled behavior, and submit behavior remain unchanged.",
        "Existing tests that click checkbox labels or checkbox inputs still verify the same user-observable outcomes.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "default-work-type-configuration-currnt-selection-005",
      "title": "Verify checkbox consistency across website surfaces",
      "description": "As a reviewer, I want direct evidence that all visible website checkboxes now share one styled behavior so this does not regress into mixed native and styled controls.",
      "acceptanceCriteria": [
        "A representative current-selection checkbox and a representative factory graph editor checkbox show the same unchecked, checked, focused, and disabled/invalid styling patterns where those states are available.",
        "Tab navigation reaches checkbox controls in a predictable order and Space toggles the focused checkbox without requiring a mouse.",
        "Existing form loading, empty, error, and success states still render appropriately around checkbox-backed fields.",
        "Browser verification captures desktop and mobile widths for visible checkbox behavior.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)