### PR TITLE
setup-workspace-dirty-tree-git-sync

### DIFF
--- a/factory/scripts/setup-workspace.py
+++ b/factory/scripts/setup-workspace.py
@@ -45,19 +45,30 @@ def read_prd(prd_path):
         return json.load(f)
 
 
-def sync_main(repo_root):
-    """Run git pull unless the repo has no upstream configured."""
-    result = run_git("pull", cwd=repo_root, check=False)
-    if result.returncode == 0:
-        return
+def origin_remote_exists(repo_root):
+    """Return True when the repository has an origin remote configured."""
+    result = run_git("remote", "get-url", "origin", cwd=repo_root, check=False)
+    return result.returncode == 0
 
-    stderr = result.stderr.lower()
-    if "there is no tracking information for the current branch" in stderr:
-        return
 
-    raise RuntimeError(
-        f"git pull failed (exit {result.returncode}): {result.stderr.strip()}"
+def origin_main_ref_exists(repo_root):
+    """Return True when refs/remotes/origin/main exists locally."""
+    result = run_git(
+        "rev-parse", "--verify", "refs/remotes/origin/main",
+        cwd=repo_root, check=False,
     )
+    return result.returncode == 0
+
+
+def sync_main(repo_root):
+    """Fetch origin and sync local main when remote tracking is available."""
+    if not origin_remote_exists(repo_root):
+        return
+
+    run_git("fetch", "origin", cwd=repo_root, check=False)
+
+    if not origin_main_ref_exists(repo_root):
+        return
 
 
 def prune_worktrees(repo_root):

--- a/factory/scripts/setup-workspace.py
+++ b/factory/scripts/setup-workspace.py
@@ -79,7 +79,9 @@ def sync_main(repo_root):
     if not origin_remote_exists(repo_root):
         return
 
-    run_git("fetch", "origin", cwd=repo_root, check=False)
+    fetch_result = run_git("fetch", "origin", cwd=repo_root, check=False)
+    if fetch_result.returncode != 0:
+        return
 
     if not origin_main_ref_exists(repo_root):
         return

--- a/factory/scripts/setup-workspace.py
+++ b/factory/scripts/setup-workspace.py
@@ -91,7 +91,10 @@ def sync_main(repo_root):
     if not origin_remote_exists(repo_root):
         return
 
-    fetch_result = run_git("fetch", "origin", cwd=repo_root, check=False)
+    fetch_result = run_git(
+        "fetch", "origin", "refs/heads/main:refs/remotes/origin/main",
+        cwd=repo_root, check=False,
+    )
     if fetch_result.returncode != 0:
         return
 

--- a/factory/scripts/setup-workspace.py
+++ b/factory/scripts/setup-workspace.py
@@ -69,6 +69,18 @@ def local_main_is_ancestor_of_origin_main(repo_root):
     return result.returncode == 0
 
 
+def main_is_checked_out(repo_root):
+    """Return True when refs/heads/main is checked out in any linked worktree."""
+    result = run_git("worktree", "list", "--porcelain", cwd=repo_root, check=False)
+    if result.returncode != 0:
+        return True
+
+    for line in result.stdout.splitlines():
+        if line == "branch refs/heads/main":
+            return True
+    return False
+
+
 def fast_forward_local_main(repo_root, origin_main_sha):
     """Update refs/heads/main to origin/main without checking out main."""
     run_git("update-ref", "refs/heads/main", origin_main_sha, cwd=repo_root)
@@ -99,6 +111,9 @@ def sync_main(repo_root):
         return
 
     if not local_main_is_ancestor_of_origin_main(repo_root):
+        return
+
+    if main_is_checked_out(repo_root):
         return
 
     fast_forward_local_main(repo_root, origin_main_sha)

--- a/factory/scripts/setup-workspace.py
+++ b/factory/scripts/setup-workspace.py
@@ -60,6 +60,20 @@ def origin_main_ref_exists(repo_root):
     return result.returncode == 0
 
 
+def local_main_is_ancestor_of_origin_main(repo_root):
+    """Return True when local main can be fast-forwarded to origin/main."""
+    result = run_git(
+        "merge-base", "--is-ancestor", "refs/heads/main", "refs/remotes/origin/main",
+        cwd=repo_root, check=False,
+    )
+    return result.returncode == 0
+
+
+def fast_forward_local_main(repo_root, origin_main_sha):
+    """Update refs/heads/main to origin/main without checking out main."""
+    run_git("update-ref", "refs/heads/main", origin_main_sha, cwd=repo_root)
+
+
 def sync_main(repo_root):
     """Fetch origin and sync local main when remote tracking is available."""
     if not origin_remote_exists(repo_root):
@@ -69,6 +83,23 @@ def sync_main(repo_root):
 
     if not origin_main_ref_exists(repo_root):
         return
+
+    if not branch_exists_locally(repo_root, "main"):
+        return
+
+    local_main_sha = run_git(
+        "rev-parse", "refs/heads/main", cwd=repo_root,
+    ).stdout.strip()
+    origin_main_sha = run_git(
+        "rev-parse", "refs/remotes/origin/main", cwd=repo_root,
+    ).stdout.strip()
+    if local_main_sha == origin_main_sha:
+        return
+
+    if not local_main_is_ancestor_of_origin_main(repo_root):
+        return
+
+    fast_forward_local_main(repo_root, origin_main_sha)
 
 
 def prune_worktrees(repo_root):

--- a/tests/factory/scripts/test_setup_workspace_sync.py
+++ b/tests/factory/scripts/test_setup_workspace_sync.py
@@ -161,6 +161,53 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
             )
         )
 
+    def test_sync_main_skips_fast_forward_when_main_is_checked_out_dirty(self):
+        local_repo = self.repo_path / "local"
+        setup_repo_with_origin_main_ahead(local_repo, self.repo_path)
+        git(["checkout", "main"], local_repo)
+
+        dirty_file = local_repo / "f.txt"
+        dirty_file.write_text("dirty content\n", encoding="utf-8")
+        status_before = git(["status", "--porcelain"], local_repo).stdout
+        head_before = git(["rev-parse", "HEAD"], local_repo).stdout.strip()
+        branch_before = git(["branch", "--show-current"], local_repo).stdout.strip()
+        local_main_sha_before = git(
+            ["rev-parse", "refs/heads/main"],
+            local_repo,
+        ).stdout.strip()
+        origin_main_sha = git(
+            ["rev-parse", "refs/remotes/origin/main"],
+            local_repo,
+        ).stdout.strip()
+        self.assertNotEqual(local_main_sha_before, origin_main_sha)
+
+        recorded, original_run_git = self.record_git_commands()
+        try:
+            self.module.sync_main(local_repo)
+        finally:
+            self.module.run_git = original_run_git
+
+        self.assertEqual(
+            git(["rev-parse", "refs/heads/main"], local_repo).stdout.strip(),
+            local_main_sha_before,
+        )
+        self.assertEqual(git(["rev-parse", "HEAD"], local_repo).stdout.strip(), head_before)
+        self.assertEqual(
+            git(["branch", "--show-current"], local_repo).stdout.strip(),
+            branch_before,
+        )
+        self.assertEqual(git(["status", "--porcelain"], local_repo).stdout, status_before)
+        self.assertEqual(
+            dirty_file.read_text(encoding="utf-8"),
+            "dirty content\n",
+        )
+        self.assertFalse(
+            any(
+                args[:3] == ("update-ref", "refs/heads/main", origin_main_sha)
+                for args in recorded
+            )
+        )
+
     def test_sync_main_fast_forwards_main_without_pull_on_dirty_tree(self):
         local_repo = self.repo_path / "local"
         setup_repo_with_origin_main_ahead(local_repo, self.repo_path)

--- a/tests/factory/scripts/test_setup_workspace_sync.py
+++ b/tests/factory/scripts/test_setup_workspace_sync.py
@@ -124,6 +124,43 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
         self.assertTrue(any(args[:2] == ("fetch", "origin") for args in recorded))
         self.assertFalse(self.module.origin_main_ref_exists(self.repo_path))
 
+    def test_sync_main_does_not_fast_forward_after_failed_fetch(self):
+        local_repo = self.repo_path / "local"
+        setup_repo_with_origin_main_ahead(local_repo, self.repo_path)
+
+        origin_main_sha = git(
+            ["rev-parse", "refs/remotes/origin/main"],
+            local_repo,
+        ).stdout.strip()
+        local_main_sha_before = git(
+            ["rev-parse", "refs/heads/main"],
+            local_repo,
+        ).stdout.strip()
+        self.assertNotEqual(local_main_sha_before, origin_main_sha)
+        self.assertTrue(self.module.origin_main_ref_exists(local_repo))
+
+        missing_remote = self.repo_path / "missing-remote.git"
+        git(["remote", "set-url", "origin", str(missing_remote)], local_repo)
+
+        recorded, original_run_git = self.record_git_commands()
+        try:
+            self.module.sync_main(local_repo)
+        finally:
+            self.module.run_git = original_run_git
+
+        local_main_sha_after = git(
+            ["rev-parse", "refs/heads/main"],
+            local_repo,
+        ).stdout.strip()
+        self.assertEqual(local_main_sha_after, local_main_sha_before)
+        self.assertNotEqual(local_main_sha_after, origin_main_sha)
+        self.assertFalse(
+            any(
+                args[:3] == ("update-ref", "refs/heads/main", origin_main_sha)
+                for args in recorded
+            )
+        )
+
     def test_sync_main_fast_forwards_main_without_pull_on_dirty_tree(self):
         local_repo = self.repo_path / "local"
         setup_repo_with_origin_main_ahead(local_repo, self.repo_path)

--- a/tests/factory/scripts/test_setup_workspace_sync.py
+++ b/tests/factory/scripts/test_setup_workspace_sync.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Regression tests for setup-workspace sync_main quiet-skip behavior."""
+
+import importlib.util
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "factory" / "scripts" / "setup-workspace.py"
+
+
+def load_setup_workspace_module():
+    spec = importlib.util.spec_from_file_location("setup_workspace", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def init_local_repo(repo_path):
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo_path, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "setup-workspace-test@example.com"],
+        cwd=repo_path,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Setup Workspace Test"],
+        cwd=repo_path,
+        check=True,
+    )
+    readme = repo_path / "README.md"
+    readme.write_text("setup-workspace test repo\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=repo_path, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo_path, check=True)
+
+
+def git(args, cwd):
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+class SetupWorkspaceSyncTest(unittest.TestCase):
+    def setUp(self):
+        self.module = load_setup_workspace_module()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.repo_path = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def record_git_commands(self):
+        recorded = []
+        original_run_git = self.module.run_git
+
+        def tracking_run_git(*args, **kwargs):
+            recorded.append(args)
+            return original_run_git(*args, **kwargs)
+
+        self.module.run_git = tracking_run_git
+        return recorded, original_run_git
+
+    def test_sync_main_skips_quietly_without_origin_remote(self):
+        init_local_repo(self.repo_path)
+
+        recorded, original_run_git = self.record_git_commands()
+        try:
+            self.module.sync_main(self.repo_path)
+        finally:
+            self.module.run_git = original_run_git
+
+        self.assertFalse(any(args and args[0] == "pull" for args in recorded))
+        self.assertFalse(any(args and args[0] == "fetch" for args in recorded))
+
+    def test_sync_main_skips_quietly_without_origin_main(self):
+        init_local_repo(self.repo_path)
+        bare_remote = self.repo_path / "remote.git"
+        bare_remote.mkdir()
+        git(["init", "--bare", "-b", "develop"], bare_remote)
+        git(["remote", "add", "origin", str(bare_remote)], self.repo_path)
+        git(["fetch", "origin"], self.repo_path)
+
+        recorded, original_run_git = self.record_git_commands()
+        try:
+            self.module.sync_main(self.repo_path)
+        finally:
+            self.module.run_git = original_run_git
+
+        self.assertFalse(any(args and args[0] == "pull" for args in recorded))
+        self.assertTrue(any(args[:2] == ("fetch", "origin") for args in recorded))
+        self.assertFalse(self.module.origin_main_ref_exists(self.repo_path))
+
+    def test_setup_workspace_continues_after_sync_skip(self):
+        init_local_repo(self.repo_path)
+        prd_name = "test-workspace-prd"
+        tasks_dir = self.repo_path / "tasks" / "todo"
+        tasks_dir.mkdir(parents=True)
+        prd_json = tasks_dir / f"{prd_name}.json"
+        prd_json.write_text(
+            json.dumps({"branchName": prd_name}),
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            ["python3", str(SCRIPT_PATH), prd_name],
+            cwd=self.repo_path,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "ready")
+        worktree_path = Path(payload["worktree"])
+        self.assertTrue(worktree_path.exists())
+        self.assertTrue((worktree_path / "prd.json").exists())
+        self.assertEqual(payload["branch"], prd_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/factory/scripts/test_setup_workspace_sync.py
+++ b/tests/factory/scripts/test_setup_workspace_sync.py
@@ -38,14 +38,40 @@ def init_local_repo(repo_path):
     subprocess.run(["git", "commit", "-m", "init"], cwd=repo_path, check=True)
 
 
-def git(args, cwd):
+def git(args, cwd, check=True):
     return subprocess.run(
         ["git", *args],
         cwd=cwd,
-        check=True,
+        check=check,
         capture_output=True,
         text=True,
     )
+
+
+def setup_repo_with_origin_main_ahead(local_repo, repo_root):
+    """Create a bare remote ahead of local main; local repo on a feature branch."""
+    bare_remote = repo_root / "remote.git"
+    bare_remote.mkdir()
+    git(["init", "--bare", "-b", "main"], bare_remote)
+
+    upstream = repo_root / "upstream"
+    upstream.mkdir()
+    init_local_repo(upstream)
+    git(["remote", "add", "origin", str(bare_remote)], upstream)
+    git(["push", "-u", "origin", "main"], upstream)
+
+    (upstream / "ahead.txt").write_text("origin is ahead\n", encoding="utf-8")
+    git(["add", "ahead.txt"], upstream)
+    git(["commit", "-m", "advance origin main"], upstream)
+    git(["push", "origin", "main"], upstream)
+
+    git(["clone", str(bare_remote), str(local_repo.name)], repo_root)
+    git(["reset", "--hard", "HEAD~1"], local_repo)
+    git(["checkout", "-b", "feature-branch"], local_repo)
+    (local_repo / "dirty.txt").write_text("unstaged change\n", encoding="utf-8")
+    git(["fetch", "origin"], local_repo)
+
+    return bare_remote
 
 
 class SetupWorkspaceSyncTest(unittest.TestCase):
@@ -97,6 +123,89 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
         self.assertFalse(any(args and args[0] == "pull" for args in recorded))
         self.assertTrue(any(args[:2] == ("fetch", "origin") for args in recorded))
         self.assertFalse(self.module.origin_main_ref_exists(self.repo_path))
+
+    def test_sync_main_fast_forwards_main_without_pull_on_dirty_tree(self):
+        local_repo = self.repo_path / "local"
+        setup_repo_with_origin_main_ahead(local_repo, self.repo_path)
+
+        origin_main_sha = git(
+            ["rev-parse", "refs/remotes/origin/main"],
+            local_repo,
+        ).stdout.strip()
+        local_main_sha_before = git(
+            ["rev-parse", "refs/heads/main"],
+            local_repo,
+        ).stdout.strip()
+        self.assertNotEqual(local_main_sha_before, origin_main_sha)
+
+        recorded, original_run_git = self.record_git_commands()
+        try:
+            self.module.sync_main(local_repo)
+        finally:
+            self.module.run_git = original_run_git
+
+        local_main_sha_after = git(
+            ["rev-parse", "refs/heads/main"],
+            local_repo,
+        ).stdout.strip()
+        self.assertEqual(local_main_sha_after, origin_main_sha)
+        self.assertEqual(
+            git(["branch", "--show-current"], local_repo).stdout.strip(),
+            "feature-branch",
+        )
+        self.assertEqual(
+            (local_repo / "dirty.txt").read_text(encoding="utf-8"),
+            "unstaged change\n",
+        )
+        status = git(["status", "--porcelain"], local_repo).stdout
+        self.assertIn("?? dirty.txt", status)
+
+        self.assertFalse(any(args and args[0] == "pull" for args in recorded))
+        self.assertTrue(any(args[:2] == ("fetch", "origin") for args in recorded))
+        self.assertTrue(
+            any(
+                args[:3] == ("update-ref", "refs/heads/main", origin_main_sha)
+                for args in recorded
+            )
+        )
+        self.assertFalse(any(args and args[0] == "checkout" for args in recorded))
+
+    def test_setup_workspace_exits_zero_through_sync_on_dirty_tree(self):
+        local_repo = self.repo_path / "local"
+        setup_repo_with_origin_main_ahead(local_repo, self.repo_path)
+
+        prd_name = "dirty-tree-prd"
+        tasks_dir = local_repo / "tasks" / "todo"
+        tasks_dir.mkdir(parents=True)
+        prd_json = tasks_dir / f"{prd_name}.json"
+        prd_json.write_text(
+            json.dumps({"branchName": prd_name}),
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            ["python3", str(SCRIPT_PATH), prd_name],
+            cwd=local_repo,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        origin_main_sha = git(
+            ["rev-parse", "refs/remotes/origin/main"],
+            local_repo,
+        ).stdout.strip()
+        local_main_sha = git(
+            ["rev-parse", "refs/heads/main"],
+            local_repo,
+        ).stdout.strip()
+        self.assertEqual(local_main_sha, origin_main_sha)
+        self.assertEqual(
+            git(["branch", "--show-current"], local_repo).stdout.strip(),
+            "feature-branch",
+        )
+        self.assertIn("?? dirty.txt", git(["status", "--porcelain"], local_repo).stdout)
 
     def test_setup_workspace_continues_after_sync_skip(self):
         init_local_repo(self.repo_path)

--- a/tests/factory/scripts/test_setup_workspace_sync.py
+++ b/tests/factory/scripts/test_setup_workspace_sync.py
@@ -124,6 +124,45 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
         self.assertTrue(any(args[:2] == ("fetch", "origin") for args in recorded))
         self.assertFalse(self.module.origin_main_ref_exists(self.repo_path))
 
+    def test_sync_main_does_not_fast_forward_from_stale_origin_main_after_remote_deleted(self):
+        local_repo = self.repo_path / "local"
+        bare_remote = setup_repo_with_origin_main_ahead(local_repo, self.repo_path)
+
+        origin_main_sha = git(
+            ["rev-parse", "refs/remotes/origin/main"],
+            local_repo,
+        ).stdout.strip()
+        local_main_sha_before = git(
+            ["rev-parse", "refs/heads/main"],
+            local_repo,
+        ).stdout.strip()
+        self.assertNotEqual(local_main_sha_before, origin_main_sha)
+        self.assertTrue(self.module.origin_main_ref_exists(local_repo))
+
+        git(["update-ref", "-d", "refs/heads/main"], bare_remote)
+        plain_fetch = git(["fetch", "origin"], local_repo, check=False)
+        self.assertEqual(plain_fetch.returncode, 0)
+        self.assertTrue(self.module.origin_main_ref_exists(local_repo))
+
+        recorded, original_run_git = self.record_git_commands()
+        try:
+            self.module.sync_main(local_repo)
+        finally:
+            self.module.run_git = original_run_git
+
+        local_main_sha_after = git(
+            ["rev-parse", "refs/heads/main"],
+            local_repo,
+        ).stdout.strip()
+        self.assertEqual(local_main_sha_after, local_main_sha_before)
+        self.assertNotEqual(local_main_sha_after, origin_main_sha)
+        self.assertFalse(
+            any(
+                args[:3] == ("update-ref", "refs/heads/main", origin_main_sha)
+                for args in recorded
+            )
+        )
+
     def test_sync_main_does_not_fast_forward_after_failed_fetch(self):
         local_repo = self.repo_path / "local"
         setup_repo_with_origin_main_ahead(local_repo, self.repo_path)

--- a/tests/factory/scripts/test_setup_workspace_worktree.py
+++ b/tests/factory/scripts/test_setup_workspace_worktree.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Regression tests for setup-workspace worktree setup after safe sync."""
+
+import importlib.util
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "factory" / "scripts" / "setup-workspace.py"
+
+EXPECTED_RESULT_KEYS = {
+    "status",
+    "worktree",
+    "branch",
+    "prd_path",
+    "prd_md_path",
+    "reused",
+}
+
+
+def load_setup_workspace_module():
+    spec = importlib.util.spec_from_file_location("setup_workspace", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def init_local_repo(repo_path):
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo_path, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "setup-workspace-test@example.com"],
+        cwd=repo_path,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Setup Workspace Test"],
+        cwd=repo_path,
+        check=True,
+    )
+    readme = repo_path / "README.md"
+    readme.write_text("setup-workspace test repo\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=repo_path, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo_path, check=True)
+
+
+def git(args, cwd, check=True):
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def write_prd(repo_path, prd_name, include_md=False):
+    tasks_dir = repo_path / "tasks" / "todo"
+    tasks_dir.mkdir(parents=True)
+    prd_json = tasks_dir / f"{prd_name}.json"
+    prd_json.write_text(
+        json.dumps({"branchName": prd_name}),
+        encoding="utf-8",
+    )
+    prd_md = None
+    if include_md:
+        prd_md = tasks_dir / f"{prd_name}.md"
+        prd_md.write_text(f"# {prd_name}\n", encoding="utf-8")
+    return prd_json, prd_md
+
+
+def run_setup_workspace(repo_path, prd_name):
+    return subprocess.run(
+        ["python3", str(SCRIPT_PATH), prd_name],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class SetupWorkspaceWorktreeTest(unittest.TestCase):
+    def setUp(self):
+        self.module = load_setup_workspace_module()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.repo_path = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def record_git_commands(self):
+        recorded = []
+        original_run_git = self.module.run_git
+
+        def tracking_run_git(*args, **kwargs):
+            recorded.append(args)
+            return original_run_git(*args, **kwargs)
+
+        self.module.run_git = tracking_run_git
+        return recorded, original_run_git
+
+    def test_prune_runs_after_sync_and_before_worktree_creation(self):
+        init_local_repo(self.repo_path)
+        prd_name = "prune-order-prd"
+        write_prd(self.repo_path, prd_name)
+
+        recorded, original_run_git = self.record_git_commands()
+        try:
+            self.module.sync_main(self.repo_path)
+            self.module.prune_worktrees(self.repo_path)
+            worktree_dir = (
+                self.repo_path
+                / ".claude"
+                / "worktrees"
+                / self.module.normalize_branch(prd_name)
+            )
+            self.module.create_or_reuse_worktree(
+                self.repo_path, prd_name, worktree_dir,
+            )
+        finally:
+            self.module.run_git = original_run_git
+
+        prune_index = next(
+            i for i, args in enumerate(recorded) if args[:2] == ("worktree", "prune")
+        )
+        add_index = next(
+            i for i, args in enumerate(recorded) if args[:2] == ("worktree", "add")
+        )
+        self.assertLess(prune_index, add_index)
+
+    def test_reuses_valid_worktree_with_expected_json_shape(self):
+        init_local_repo(self.repo_path)
+        prd_name = "reuse-worktree-prd"
+        write_prd(self.repo_path, prd_name, include_md=True)
+
+        first = run_setup_workspace(self.repo_path, prd_name)
+        self.assertEqual(first.returncode, 0, first.stderr)
+        first_payload = json.loads(first.stdout)
+        self.assertEqual(set(first_payload), EXPECTED_RESULT_KEYS)
+        self.assertFalse(first_payload["reused"])
+
+        marker = Path(first_payload["worktree"]) / "reuse-marker.txt"
+        marker.write_text("keep me\n", encoding="utf-8")
+
+        second = run_setup_workspace(self.repo_path, prd_name)
+        self.assertEqual(second.returncode, 0, second.stderr)
+        second_payload = json.loads(second.stdout)
+        self.assertEqual(set(second_payload), EXPECTED_RESULT_KEYS)
+        self.assertTrue(second_payload["reused"])
+        self.assertEqual(second_payload["worktree"], first_payload["worktree"])
+        self.assertEqual(second_payload["branch"], prd_name)
+        self.assertTrue(marker.exists())
+
+    def test_creates_new_worktree_from_main_when_branch_missing(self):
+        init_local_repo(self.repo_path)
+        prd_name = "new-branch-prd"
+        write_prd(self.repo_path, prd_name)
+
+        main_sha = git(["rev-parse", "main"], self.repo_path).stdout.strip()
+        self.assertFalse(self.module.branch_exists_locally(self.repo_path, prd_name))
+        self.assertFalse(self.module.branch_exists_on_remote(self.repo_path, prd_name))
+
+        result = run_setup_workspace(self.repo_path, prd_name)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        payload = json.loads(result.stdout)
+        worktree_path = Path(payload["worktree"])
+        self.assertTrue(worktree_path.exists())
+        branch_sha = git(
+            ["rev-parse", prd_name],
+            worktree_path,
+        ).stdout.strip()
+        self.assertEqual(branch_sha, main_sha)
+        self.assertTrue(self.module.branch_exists_locally(self.repo_path, prd_name))
+
+    def test_copies_prd_json_and_optional_markdown(self):
+        init_local_repo(self.repo_path)
+        prd_name = "copy-prd-prd"
+        prd_json, prd_md = write_prd(self.repo_path, prd_name, include_md=True)
+
+        result = run_setup_workspace(self.repo_path, prd_name)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        payload = json.loads(result.stdout)
+        worktree_path = Path(payload["worktree"])
+        self.assertEqual(
+            (worktree_path / "prd.json").read_text(encoding="utf-8"),
+            prd_json.read_text(encoding="utf-8"),
+        )
+        self.assertEqual(
+            (worktree_path / "prd.md").read_text(encoding="utf-8"),
+            prd_md.read_text(encoding="utf-8"),
+        )
+        self.assertEqual(payload["prd_path"], str(worktree_path / "prd.json"))
+        self.assertEqual(payload["prd_md_path"], str(worktree_path / "prd.md"))
+
+    def test_copies_prd_json_without_markdown_when_md_missing(self):
+        init_local_repo(self.repo_path)
+        prd_name = "json-only-prd"
+        write_prd(self.repo_path, prd_name, include_md=False)
+
+        result = run_setup_workspace(self.repo_path, prd_name)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        payload = json.loads(result.stdout)
+        worktree_path = Path(payload["worktree"])
+        self.assertTrue((worktree_path / "prd.json").exists())
+        self.assertFalse((worktree_path / "prd.md").exists())
+        self.assertIsNone(payload["prd_md_path"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
{
  "project": "Setup Workspace Dirty-Tree Git Sync",
  "branchName": "ralph/setup-workspace-dirty-tree-git-sync",
  "description": "Make factory setup-workspace main-branch synchronization safe for dirty maintainer checkouts by replacing git pull with fetch plus fast-forward ref updates, preserving quiet skip behavior and existing worktree setup behavior.",
  "context": {
    "customerAsk": "Replace sync_main() in factory/scripts/setup-workspace.py with a working-tree-safe sync: fetch origin, compare origin/main to local main, fast-forward refs/heads/main with git update-ref when safe, skip quietly when remote tracking is unavailable, and do not run git pull on the current branch.",
    "problem": "Maintainer plan:init -> setup-workspace dispatches fail when the repository root has unstaged changes because sync_main() runs git pull in the active checkout. Git pull with rebase refuses to run on dirty trees, blocking all plan spawns before worktree setup can begin.",
    "solution": "Change setup-workspace sync to fetch origin and update the local main ref directly only when origin/main is ahead and local main is an ancestor, without checkout, merge, rebase, or pull. Add focused regression coverage for dirty working trees and preserve existing worktree create/reuse behavior."
  },
  "acceptanceCriteria": [
    "setup-workspace.py exits 0 when the repo root has unstaged changes and origin/main is ahead of local main.",
    "sync_main() never invokes git pull on the repo root or current branch.",
    "When no origin remote or no origin/main ref exists, setup-workspace skips sync quietly and continues to worktree setup.",
    "When local main is a strict ancestor of origin/main, local refs/heads/main is fast-forwarded to the remote SHA without checkout.",
    "Existing worktree create/reuse behavior and PRD file copy behavior remain unchanged.",
    "Focused regression coverage simulates a dirty working tree and verifies the no-pull sync behavior.",
    "Quality gate passes: python3 -m py_compile factory/scripts/setup-workspace.py, lint if applicable, and affected tests pass."
  ],
  "userStories": [
    {
      "id": "setup-workspace-dirty-tree-git-sync-001",
      "title": "Skip sync quietly when remote main is unavailable",
      "description": "As a maintainer running setup-workspace in a local-only or partially configured repository, I want sync to skip quietly when remote tracking is unavailable so worktree setup can continue instead of failing before branch creation.",
      "acceptanceCriteria": [
        "Given a repository with no origin remote, sync_main() returns without raising a git sync error.",
        "Given a repository with an origin remote but no refs/remotes/origin/main, sync_main() returns without raising a git sync error.",
        "Existing downstream setup-workspace behavior still reaches worktree prune/create/reuse after sync skips.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "setup-workspace-dirty-tree-git-sync-002",
      "title": "Fast-forward local main without touching a dirty checkout",
      "description": "As a maintainer with active unstaged work on a feature branch, I want setup-workspace to update local main from origin/main without pulling or checking out branches so plan spawns are not blocked by my dirty tree.",
      "acceptanceCriteria": [
        "Given unstaged changes in the current checkout and origin/main ahead of refs/heads/main, setup-workspace.py exits 0 through the sync phase.",
        "Given local main is an ancestor of origin/main, refs/heads/main is updated to the remote SHA using a ref update without checking out main.",
        "The active branch and unstaged working-tree changes remain intact after sync.",
        "The sync path uses git fetch origin and does not invoke git pull.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "setup-workspace-dirty-tree-git-sync-003",
      "title": "Preserve worktree setup behavior after safe sync",
      "description": "As a maintainer dispatching plan work, I want setup-workspace to keep creating or reusing the requested PRD worktree after the safe sync change so the fix does not regress the rest of the pipeline.",
      "acceptanceCriteria": [
        "After safe sync completes or skips, existing worktree pruning still runs before worktree creation/reuse.",
        "Existing valid worktrees for the target PRD branch are reused with the same output JSON shape as before.",
        "New worktrees are still created from local main when the target branch does not exist locally or on origin.",
        "PRD JSON and optional Markdown files are still copied into the worktree root.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)