### PR TITLE
dashboard-public-barrel-meta-test-retirement

### DIFF
--- a/ui/src/features/dashboard/public/index.test.ts
+++ b/ui/src/features/dashboard/public/index.test.ts
@@ -1,8 +1,0 @@
-import { DashboardScreen } from "../components/dashboard-screen";
-import * as dashboardPublic from "./index";
-
-describe("dashboard public barrel", () => {
-  it("exports DashboardScreen as the app composition entrypoint", () => {
-    expect(dashboardPublic.DashboardScreen).toBe(DashboardScreen);
-  });
-});


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/dashboard-public-barrel-meta-test-retirement",
  "description": "Retire the dashboard public-barrel meta-test so the React website test suite stays focused on observable behavior instead of export-inventory topology, without changing public exports or runtime behavior.",
  "context": {
    "customerAsk": "Unstick failed plan work-plan-2 for dashboard-public-barrel-meta-test-retirement. Delete ui/src/features/dashboard/public/index.test.ts. Do not add a replacement meta-test, do not change public exports, and do not change production behavior. Keep existing behavioral coverage in dashboard-screen.public.smoke.test.tsx as the confidence source.",
    "problem": "ui/src/features/dashboard/public/index.test.ts only asserts that DashboardScreen re-exports match the component module (export identity). plan work-plan-2 failed before setup-workspace spawned task work, leaving idea batch-request-bff51adcc2b5aacead19dcbe75563a89-dashboard-public-barrel-meta-test-retirement stuck in to-complete with no matching task.",
    "solution": "Remove the meta-test file, leave the dashboard public barrel unchanged, and keep regression confidence anchored in dashboard-screen.public.smoke.test.tsx while verifying the cleanup with normal frontend quality gates and make ui-deadcode."
  },
  "acceptanceCriteria": [
    "ui/src/features/dashboard/public/index.test.ts is removed from the worktree.",
    "ui/src/features/dashboard/public/index.ts keeps the same public exports and does not gain a replacement export-inventory, Object.keys, export-count, or runtime-type assertion.",
    "ui/src/features/dashboard/public/dashboard-screen.public.smoke.test.tsx continues to pass.",
    "No public export surface, runtime behavior, API contract, or visible UI behavior changes as a result of the cleanup.",
    "make ui-deadcode still passes after the test retirement.",
    "Quality gate: frontend typecheck, lint, and tests pass."
  ],
  "userStories": [
    {
      "id": "dashboard-public-barrel-meta-test-retirement-001",
      "title": "Remove the dashboard public barrel meta-test",
      "description": "As a frontend maintainer, I want the dashboard public-barrel inventory test removed so the suite stops depending on brittle export-shape assertions that do not verify behavior.",
      "acceptanceCriteria": [
        "ui/src/features/dashboard/public/index.test.ts no longer exists in the worktree.",
        "ui/src/features/dashboard/public/index.ts keeps the same export surface and does not add any replacement export-inventory, Object.keys, export-count, or runtime-type assertion.",
        "No new test in dashboard or a nearby feature replaces the deleted file with another public-barrel meta-test.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "dashboard-public-barrel-meta-test-retirement-002",
      "title": "Prove the cleanup preserves existing behavioral coverage and quality gates",
      "description": "As a reviewer, I want the existing dashboard public smoke test and frontend verification to stay green so I can trust the meta-test removal did not weaken runtime confidence.",
      "acceptanceCriteria": [
        "ui/src/features/dashboard/public/dashboard-screen.public.smoke.test.tsx continues to pass.",
        "make ui-deadcode passes after the meta-test removal.",
        "The cleanup does not change public exports, runtime behavior, or browser-visible dashboard behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)