### PR TITLE
trace-drilldown-node-types-inventory-test-retirement

### DIFF
--- a/ui/src/features/trace-drilldown/lib/trace-dispatch-factory-graph-flow.test.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-dispatch-factory-graph-flow.test.ts
@@ -3,7 +3,6 @@ import type {
   DashboardTraceDispatch,
   DashboardWorkItemRef,
 } from "../../../api/dashboard/types";
-import { TRACE_DISPATCH_FACTORY_GRAPH_NODE_TYPES } from "../components/trace-dispatch-factory-graph-node";
 import { buildTraceDispatchFactoryGraphFlow } from "./trace-dispatch-factory-graph-flow";
 
 function buildWorkItem(
@@ -99,9 +98,6 @@ describe("buildTraceDispatchFactoryGraphFlow", () => {
       buildDispatch("dispatch-plan"),
     ]);
 
-    expect(Object.keys(TRACE_DISPATCH_FACTORY_GRAPH_NODE_TYPES)).toEqual([
-      "workstation",
-    ]);
     expect(flow.nodes.every((node) => node.type === "workstation")).toBe(true);
     expect(flow.edges.every((edge) => edge.type === "factoryEditorEdge")).toBe(
       true,

--- a/ui/src/features/trace-drilldown/lib/trace-relation-factory-graph-flow.test.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-relation-factory-graph-flow.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { DashboardWorkRelation } from "../../../api/dashboard/types";
 import { getFactoryGraphEditorMessages } from "../../factory-graph-editor/messages/editor";
-import { WORK_RELATION_NODE_TYPES } from "../../graphs/public";
 import { buildTraceRelationFactoryGraphFlow } from "./trace-relation-factory-graph-flow";
 
 const RELATIONS: DashboardWorkRelation[] = [
@@ -81,9 +80,6 @@ describe("buildTraceRelationFactoryGraphFlow", () => {
   it("registers only shared work graph React Flow node types", () => {
     const flow = buildTraceRelationFactoryGraphFlow(RELATIONS);
 
-    expect(Object.keys(WORK_RELATION_NODE_TYPES)).toEqual([
-      "workRelation",
-    ]);
     expect(flow.nodes.every((node) => node.type === "workRelation")).toBe(true);
     expect(flow.edges.every((edge) => edge.type === "factoryEditorEdge")).toBe(
       true,


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/trace-drilldown-node-types-inventory-test-retirement",
  "description": "Retire redundant Object.keys(...NODE_TYPES) inventory assertions from trace-drilldown graph-flow tests while preserving behavior-focused projected node and edge type assertions.",
  "context": {
    "customerAsk": "Remove redundant Object.keys(NODE_TYPES) inventory assertions from ui/src/features/trace-drilldown/lib/trace-relation-factory-graph-flow.test.ts and ui/src/features/trace-drilldown/lib/trace-dispatch-factory-graph-flow.test.ts. Keep behavioral flow.nodes and flow.edges type assertions, remove unused imports, avoid production changes, avoid other test files, and do not touch manual-fixes-0 layout-preservation work.",
    "problem": "Two trace-drilldown flow tests duplicate existing behavioral checks by asserting exported NODE_TYPES map key inventories with Object.keys. Those meta-assertions add maintenance cost when node-type maps change without proving runtime graph-flow behavior.",
    "solution": "Delete only the two redundant Object.keys(...NODE_TYPES) expectations, remove imports that become unused, and keep the existing projected flow.nodes and flow.edges type assertions as the regression evidence. Verify the cleanup with targeted Vitest runs for the affected files plus frontend typecheck, lint, and relevant tests."
  },
  "acceptanceCriteria": [
    "trace-relation-factory-graph-flow.test.ts no longer asserts Object.keys(WORK_RELATION_NODE_TYPES) in \"registers only shared work graph React Flow node types\".",
    "trace-dispatch-factory-graph-flow.test.ts no longer asserts Object.keys(TRACE_DISPATCH_FACTORY_GRAPH_NODE_TYPES) in \"registers only shared workstation graph React Flow node types\".",
    "The affected it blocks still assert the projected flow.nodes type values and projected flow.edges type values for their existing fixtures.",
    "Node-type map imports removed by this cleanup do not remain as unused imports.",
    "No production flow builders, graph components, node-type maps, contracts, visible UI behavior, or unrelated test files are changed.",
    "Quality gate: frontend typecheck, lint, and relevant tests pass."
  ],
  "userStories": [
    {
      "id": "trace-drilldown-node-types-inventory-test-retirement-001",
      "title": "Retire redundant trace-drilldown node-type inventory assertions",
      "description": "As a frontend maintainer, I want trace-drilldown graph-flow tests to verify projected node and edge behavior instead of exported node-type map inventories so graph regression coverage stays tied to runtime flow output.",
      "acceptanceCriteria": [
        "trace-relation-factory-graph-flow.test.ts removes the Object.keys(WORK_RELATION_NODE_TYPES) expectation from \"registers only shared work graph React Flow node types\".",
        "trace-dispatch-factory-graph-flow.test.ts removes the Object.keys(TRACE_DISPATCH_FACTORY_GRAPH_NODE_TYPES) expectation from \"registers only shared workstation graph React Flow node types\".",
        "The relation flow test still verifies every projected node has type \"workRelation\" and every projected edge has the existing expected edge type.",
        "The dispatch flow test still verifies every projected node has type \"workstation\" and every projected edge has the existing expected edge type.",
        "WORK_RELATION_NODE_TYPES and TRACE_DISPATCH_FACTORY_GRAPH_NODE_TYPES imports are removed when no longer used.",
        "No replacement Object.keys(...NODE_TYPES) inventory assertion is added in trace-drilldown tests as part of this cleanup.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)