### PR TITLE
dashboard-fixture-catalog-inventory-test-retirement

### DIFF
--- a/ui/src/components/dashboard/fixtures/public-api.test.ts
+++ b/ui/src/components/dashboard/fixtures/public-api.test.ts
@@ -4,7 +4,6 @@ import { failureAnalysisTimelineEvents } from "./failure-analysis-events";
 import {
   activeWorkRuntimeOverlay,
   buildDashboardSnapshotFixture,
-  dashboardRuntimeOverlays,
   dashboardSemanticSnapshotFixtures,
 } from "./runtime";
 import { runtimeDetailsBackendWorkstationRequestsByDispatchID } from "./runtime-details-backend-world-view";
@@ -39,12 +38,6 @@ describe("dashboard fixture catalog", () => {
     expect(dashboardTopologyFixtures.twentyNode).toBe(
       twentyNodeDashboardTopology,
     );
-    expect(Object.keys(dashboardRuntimeOverlays)).toEqual([
-      "activeWork",
-      "retryAttempt",
-      "failedOutcome",
-      "rejectedOutcome",
-    ]);
     expect(activeSnapshot.runtime.active_workstation_node_ids).toContain(
       "review",
     );
@@ -77,22 +70,6 @@ describe("dashboard fixture catalog", () => {
     expect(runtimeDetailsFixtureIDs.completedSystemPromptHash).toMatch(
       /^sha256:/,
     );
-    expect(Object.keys(dashboardWorkstationRequestFixtures)).toEqual([
-      "noResponse",
-      "ready",
-      "rejected",
-      "errored",
-      "scriptFailed",
-      "scriptPending",
-      "scriptSuccess",
-    ]);
-    expect(
-      new Set(
-        Object.values(dashboardWorkstationRequestFixtures).map(
-          (request) => request.dispatch_id,
-        ),
-      ).size,
-    ).toBe(Object.keys(dashboardWorkstationRequestFixtures).length);
     expect(dashboardWorkstationRequestFixtures.ready.request_id).toBe(
       "request-ready-story",
     );


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ralph/dashboard-fixture-catalog-inventory-test-retirement",
  "description": "Retire redundant dashboard fixture catalog inventory assertions from the frontend public API smoke test while preserving behavior-focused fixture checks for topology exports, snapshot overlays, timeline events, backend failure fields, representative workstation request fields, and hash formatting.",
  "context": {
    "customerAsk": "Remove redundant Object.keys catalog inventory assertions for dashboardRuntimeOverlays and dashboardWorkstationRequestFixtures from ui/src/components/dashboard/fixtures/public-api.test.ts, plus the inventory-derived workstation request Set size uniqueness check. Keep the behavioral assertions in the same it block, remove unused imports, and do not change production fixture modules or unrelated tests.",
    "problem": "ui/src/components/dashboard/fixtures/public-api.test.ts mixes useful behavioral fixture smoke checks with exact fixture-map inventory assertions. Those inventories add maintenance cost when fixture maps grow or rename keys without proving additional dashboard runtime behavior beyond the direct fixture field and snapshot checks already present.",
    "solution": "Delete only the three inventory-derived expectations from public-api.test.ts, preserve the existing behavior-focused assertions in the same test block, remove any imports that become unused, and verify with the targeted dashboard fixture public API test plus frontend typecheck, lint, and relevant tests."
  },
  "acceptanceCriteria": [
    "ui/src/components/dashboard/fixtures/public-api.test.ts no longer asserts Object.keys(dashboardRuntimeOverlays).",
    "ui/src/components/dashboard/fixtures/public-api.test.ts no longer asserts Object.keys(dashboardWorkstationRequestFixtures).",
    "ui/src/components/dashboard/fixtures/public-api.test.ts no longer contains the workstation request Set size versus fixture-map length uniqueness check.",
    "The catalog it block still verifies topology fixture exports, snapshot overlay behavior, semantic snapshot in-flight dispatch count, timeline event type presence, backend failure reasons, representative workstation request fields, and completedSystemPromptHash format.",
    "Imports made unused by the cleanup are removed, with no production fixture module or unrelated test file changes.",
    "Quality gate: frontend typecheck, lint, and tests pass."
  ],
  "userStories": [
    {
      "id": "dashboard-fixture-catalog-inventory-test-retirement-001",
      "title": "Retire redundant dashboard fixture catalog inventory assertions",
      "description": "As a frontend maintainer, I want the dashboard fixture public API test to verify representative fixture behavior instead of exact fixture-map inventories so fixture catalog changes do not require updating non-behavioral assertions.",
      "acceptanceCriteria": [
        "public-api.test.ts removes the Object.keys(dashboardRuntimeOverlays) exact key-list expectation.",
        "public-api.test.ts removes the Object.keys(dashboardWorkstationRequestFixtures) exact key-list expectation.",
        "public-api.test.ts removes the workstation request Set size versus Object.keys(dashboardWorkstationRequestFixtures).length uniqueness expectation.",
        "The same it block still verifies dashboardTopologyFixtures.oneNode, mediumBranching, and twentyNode identity against direct topology exports.",
        "The same it block still verifies buildDashboardSnapshotFixture applies activeWorkRuntimeOverlay to active_workstation_node_ids, and dashboardSemanticSnapshotFixtures.activeWork.runtime.in_flight_dispatch_count is 1.",
        "The same it block still verifies timeline event type presence for failure analysis, runtime details, and script dashboard integration fixtures.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "dashboard-fixture-catalog-inventory-test-retirement-002",
      "title": "Preserve representative backend and workstation fixture field coverage",
      "description": "As a dashboard fixture consumer, I want the remaining public API smoke test to keep checking representative backend and workstation request fields so fixture regressions remain visible without enforcing full catalog inventories.",
      "acceptanceCriteria": [
        "The same it block still verifies runtime-details backend failure reason using runtimeDetailsFixtureIDs.failedDispatchID and failedFailureReason.",
        "The same it block still verifies script-dashboard-integration backend failure reason using scriptDashboardIntegrationFixtureIDs.failedDispatchID and failedFailureReason.",
        "The same it block still verifies runtimeDetailsFixtureIDs.completedSystemPromptHash matches the sha256: prefix format.",
        "The same it block still verifies representative workstation request fixture fields, including ready.request_id and rejected.outcome.",
        "Any imports that become unused after deleting the inventory assertions are removed.",
        "No production fixture modules, other dashboard tests, replay fixture tests, layout-preservation work, or trace-drilldown cleanup files are changed.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)