### PR TITLE
dynamic-workflows-recovery-setup-workspace-git-pull-hygiene

### DIFF
--- a/factory/scripts/setup-workspace.py
+++ b/factory/scripts/setup-workspace.py
@@ -45,18 +45,102 @@ def read_prd(prd_path):
         return json.load(f)
 
 
+def has_origin_remote(repo_root):
+    """Return True when an origin remote is configured."""
+    result = run_git("remote", "get-url", "origin", cwd=repo_root, check=False)
+    return result.returncode == 0
+
+
+def origin_main_ref_exists(repo_root):
+    """Return True when refs/remotes/origin/main exists locally."""
+    result = run_git(
+        "rev-parse", "--verify", "refs/remotes/origin/main",
+        cwd=repo_root, check=False,
+    )
+    return result.returncode == 0
+
+
+def local_main_ref_exists(repo_root):
+    """Return True when refs/heads/main exists locally."""
+    result = run_git(
+        "rev-parse", "--verify", "refs/heads/main",
+        cwd=repo_root, check=False,
+    )
+    return result.returncode == 0
+
+
+def remote_main_sha(repo_root):
+    """Return origin/main sha from ls-remote, or None when missing/unreachable."""
+    result = run_git(
+        "ls-remote", "--exit-code", "origin", "refs/heads/main",
+        cwd=repo_root, check=False,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    return result.stdout.strip().split()[0]
+
+
+def is_main_checked_out_with_local_changes(repo_root):
+    """True when main is checked out and the working tree has local changes."""
+    current = run_git(
+        "branch", "--show-current", cwd=repo_root, check=False,
+    ).stdout.strip()
+    if current != "main":
+        return False
+    status = run_git("status", "--porcelain", cwd=repo_root, check=False)
+    return bool(status.stdout.strip())
+
+
+def can_fast_forward_main(repo_root, local_sha, remote_sha):
+    """True when remote_sha is a strict fast-forward of local_sha."""
+    if local_sha == remote_sha:
+        return False
+    merge_base = run_git(
+        "merge-base", local_sha, remote_sha,
+        cwd=repo_root, check=False,
+    )
+    return merge_base.returncode == 0 and merge_base.stdout.strip() == local_sha
+
+
 def sync_main(repo_root):
-    """Run git pull unless the repo has no upstream configured."""
-    result = run_git("pull", cwd=repo_root, check=False)
-    if result.returncode == 0:
-        return
+    """Best-effort root main sync without disturbing the working tree.
 
-    stderr = result.stderr.lower()
-    if "there is no tracking information for the current branch" in stderr:
-        return
+    Uses fetch plus refs/heads/main fast-forward when safe instead of git pull,
+    so dirty-root checkouts can continue workspace setup from local state.
+    Returns a human-readable outcome string for logging.
+    """
+    if not has_origin_remote(repo_root):
+        return "skipped (no origin remote)"
 
-    raise RuntimeError(
-        f"git pull failed (exit {result.returncode}): {result.stderr.strip()}"
+    fetch_result = run_git("fetch", "origin", cwd=repo_root, check=False)
+    if fetch_result.returncode != 0:
+        return f"skipped (fetch failed: {fetch_result.stderr.strip()})"
+
+    remote_sha = remote_main_sha(repo_root)
+    if remote_sha is None:
+        return "skipped (origin has no main branch)"
+
+    if not local_main_ref_exists(repo_root):
+        run_git("update-ref", "refs/heads/main", remote_sha, cwd=repo_root)
+        return f"created refs/heads/main at {remote_sha[:8]}"
+
+    local_sha = run_git("rev-parse", "refs/heads/main", cwd=repo_root).stdout.strip()
+    if local_sha == remote_sha:
+        return "already up to date"
+
+    if is_main_checked_out_with_local_changes(repo_root):
+        return (
+            "skipped (main checked out with local changes; "
+            "did not run git pull or fast-forward refs/heads/main)"
+        )
+
+    if not can_fast_forward_main(repo_root, local_sha, remote_sha):
+        return "skipped (local main is not a fast-forward behind origin/main)"
+
+    run_git("update-ref", "refs/heads/main", remote_sha, cwd=repo_root)
+    return (
+        f"fast-forwarded refs/heads/main to {remote_sha[:8]} "
+        "(fetch-only; did not run git pull)"
     )
 
 
@@ -187,7 +271,8 @@ def main():
 
     # Sync main and prune worktrees.
     try:
-        sync_main(repo_root)
+        sync_outcome = sync_main(repo_root)
+        print(f"Root sync: {sync_outcome}", file=sys.stderr)
         prune_worktrees(repo_root)
     except RuntimeError as e:
         print(f"Git sync failed: {e}", file=sys.stderr)

--- a/factory/scripts/setup-workspace.py
+++ b/factory/scripts/setup-workspace.py
@@ -130,7 +130,11 @@ def sync_main(repo_root):
     Returns a human-readable outcome string for logging.
     """
     if not has_origin_remote(repo_root):
-        return "skipped (no origin remote)"
+        if local_main_ref_exists(repo_root):
+            return "skipped (no origin remote)"
+        raise RuntimeError(
+            "no origin remote and refs/heads/main is missing"
+        )
 
     fetch_result = run_git("fetch", "origin", cwd=repo_root, check=False)
     fetch_succeeded = fetch_result.returncode == 0

--- a/factory/scripts/setup-workspace.py
+++ b/factory/scripts/setup-workspace.py
@@ -80,6 +80,26 @@ def remote_main_sha(repo_root):
     return result.stdout.strip().split()[0]
 
 
+def stale_origin_main_sha(repo_root):
+    """Return local origin/main sha when the remote-tracking ref exists."""
+    if not origin_main_ref_exists(repo_root):
+        return None
+    result = run_git(
+        "rev-parse", "refs/remotes/origin/main",
+        cwd=repo_root, check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def resolve_remote_main_sha(repo_root, fetch_succeeded):
+    """Resolve the best available origin/main sha for root sync."""
+    if fetch_succeeded:
+        return remote_main_sha(repo_root)
+    return stale_origin_main_sha(repo_root)
+
+
 def is_main_checked_out_with_local_changes(repo_root):
     """True when main is checked out and the working tree has local changes."""
     current = run_git(
@@ -113,12 +133,23 @@ def sync_main(repo_root):
         return "skipped (no origin remote)"
 
     fetch_result = run_git("fetch", "origin", cwd=repo_root, check=False)
-    if fetch_result.returncode != 0:
-        return f"skipped (fetch failed: {fetch_result.stderr.strip()})"
+    fetch_succeeded = fetch_result.returncode == 0
+    if not fetch_succeeded:
+        if local_main_ref_exists(repo_root):
+            return f"skipped (fetch failed: {fetch_result.stderr.strip()})"
+        if not origin_main_ref_exists(repo_root):
+            raise RuntimeError(
+                "fetch failed and refs/heads/main is missing: "
+                f"{fetch_result.stderr.strip()}"
+            )
 
-    remote_sha = remote_main_sha(repo_root)
+    remote_sha = resolve_remote_main_sha(repo_root, fetch_succeeded)
     if remote_sha is None:
-        return "skipped (origin has no main branch)"
+        if local_main_ref_exists(repo_root):
+            return "skipped (origin has no main branch)"
+        raise RuntimeError(
+            "origin has no main branch and refs/heads/main is missing"
+        )
 
     if not local_main_ref_exists(repo_root):
         run_git("update-ref", "refs/heads/main", remote_sha, cwd=repo_root)

--- a/factory/scripts/setup-workspace.py
+++ b/factory/scripts/setup-workspace.py
@@ -182,16 +182,52 @@ def branch_exists_on_remote(repo_root, branch):
     return result.returncode == 0
 
 
+def branch_upstream_ref(git_dir, branch):
+    """Return upstream ref for branch, or None when no upstream is configured."""
+    result = run_git(
+        "rev-parse", "--abbrev-ref", f"{branch}@{{upstream}}",
+        cwd=git_dir, check=False,
+    )
+    if result.returncode != 0:
+        return None
+    upstream = result.stdout.strip()
+    return upstream or None
+
+
+def sync_reused_worktree_branch(repo_root, worktree_path, branch):
+    """Checkout branch in a reused worktree and fast-forward when safe.
+
+    No-upstream and missing-remote-branch conditions are non-fatal. Unsafe
+    fast-forward failures raise RuntimeError for worktree-preparation reporting.
+    Returns a human-readable outcome string for logging.
+    """
+    run_git("checkout", branch, cwd=worktree_path)
+
+    if branch_upstream_ref(worktree_path, branch) is None:
+        return "skipped (no upstream configured)"
+
+    if not branch_exists_on_remote(repo_root, branch):
+        return "skipped (branch has no origin ref)"
+
+    pull_result = run_git("pull", "--ff-only", cwd=worktree_path, check=False)
+    if pull_result.returncode == 0:
+        return "fast-forwarded from upstream"
+
+    stderr = pull_result.stderr.strip()
+    lowered = stderr.lower()
+    if "no tracking information" in lowered:
+        return "skipped (no upstream configured)"
+
+    raise RuntimeError(
+        f"worktree branch update failed for {branch}: {stderr}"
+    )
+
+
 def create_or_reuse_worktree(repo_root, branch, worktree_path):
     """Create a new worktree or reuse an existing one. Returns reused flag."""
     if worktree_path.exists() and worktree_is_valid(worktree_path):
-        # Reuse: checkout branch and pull latest.
-        run_git("-C", str(worktree_path), "checkout", branch, cwd=repo_root)
-        if branch_exists_on_remote(repo_root, branch):
-            run_git(
-                "-C", str(worktree_path), "pull", "--ff-only",
-                cwd=repo_root, check=False,
-            )
+        sync_outcome = sync_reused_worktree_branch(repo_root, worktree_path, branch)
+        print(f"Worktree branch sync: {sync_outcome}", file=sys.stderr)
         return True
 
     # Remove stale path if it exists but is invalid.
@@ -283,7 +319,7 @@ def main():
     try:
         reused = create_or_reuse_worktree(repo_root, branch, worktree_dir)
     except RuntimeError as e:
-        print(f"Worktree setup failed: {e}", file=sys.stderr)
+        print(f"Worktree preparation failed: {e}", file=sys.stderr)
         sys.exit(1)
 
     # Copy PRD files into worktree.

--- a/factory/scripts/setup-workspace.py
+++ b/factory/scripts/setup-workspace.py
@@ -7,7 +7,7 @@ Reads tasks/todo/<prd-name>.json, uses <prd-name> as the branch/worktree name,
 syncs main, creates or reuses a git worktree, copies the PRD (and optional .md)
 into the worktree root, and prints a JSON result to stdout.
 
-Exit 0 on success (stdout = JSON blob), exit 1 on failure (stderr = error).
+Exit 0 on success (stdout = JSON blob), exit 1 on failure (stderr = stage-specific error).
 """
 
 import json
@@ -311,7 +311,7 @@ def main():
         print(f"Root sync: {sync_outcome}", file=sys.stderr)
         prune_worktrees(repo_root)
     except RuntimeError as e:
-        print(f"Git sync failed: {e}", file=sys.stderr)
+        print(f"Root sync failed: {e}", file=sys.stderr)
         sys.exit(1)
 
     # Create or reuse worktree.
@@ -326,7 +326,7 @@ def main():
     try:
         dest_json, dest_md = copy_prd_files(prd_json_path, prd_md_path, worktree_dir)
     except OSError as e:
-        print(f"Failed to copy PRD files: {e}", file=sys.stderr)
+        print(f"PRD copy failed: {e}", file=sys.stderr)
         sys.exit(1)
 
     # Output result.

--- a/prd.json
+++ b/prd.json
@@ -61,7 +61,7 @@
         "Tests pass"
       ],
       "priority": 3,
-      "passes": false,
+      "passes": true,
       "notes": ""
     }
   ]

--- a/prd.json
+++ b/prd.json
@@ -1,31 +1,30 @@
 {
-  "project": "Factory Session Backend Runtime for Simple JavaScript Workflows",
-  "branchName": "dynamic-workflows-cell-session-backend-runtime",
-  "description": "Wire the shared Factory Session execution service to the real simple JavaScript runtime path so simple JavaScript workflows can be started, inspected, replayed, and retrieved through stable backend session read models while preserving request-id idempotency and keeping FakeService available for mock-provider transports.",
+  "project": "infinite-you",
+  "branchName": "dynamic-workflows-recovery-setup-workspace-git-pull-hygiene",
+  "description": "Repair shared setup-workspace behavior so executor worktrees can be created or reused from safe local repository state even when the root checkout has pull-blocking local changes, while preserving user work, emitting categorized setup failures, and proving dirty-root, no-upstream, and reusable-worktree behavior with focused verification.",
   "context": {
-    "customerAsk": "The shared Factory Session execution service can start a simple JavaScript workflow against the real runtime path, expose status/result/progress/read models, and preserve idempotent request behavior.",
-    "problem": "The durable Factory Session contract and fake service paths exist, but the backend service path still needs a real simple JavaScript runtime implementation for session start and inspection. Transports can prove fixture shapes today, but they cannot yet run a real simple JavaScript workflow through lifecycle, result projection, replay, and request-id semantics.",
-    "solution": "Add a real runtime-backed implementation or mode behind the existing factorysessionexecution.Service contract. Normalize starts through orchestrator-owned source, validation, policy, args, wait, and result packages; execute simple JavaScript sessions through the runtime boundary; maintain explicit in-memory session projections and canonical events; preserve request-id replay/conflict behavior; and keep FakeService available for mock-provider paths."
+    "customerAsk": "Repair shared setup-workspace behavior so a plan lane can create or reuse its executor worktree even when the root repository has staged or otherwise pull-blocking local changes, while preserving user work, emitting concrete failure diagnostics, and leaving a clear next step for requeueing the blocked MCP-install plan lanes.",
+    "problem": "The current setup-workspace script unconditionally runs a root-level git pull before any worktree reuse or creation, so dirty root state blocks unrelated plan lanes before they reach safe reusable-worktree or local-state creation paths, and the resulting failure output is too generic for later queue recovery to classify confidently.",
+    "solution": "Make root sync a safe, explicit prerequisite rather than an unconditional blocker, continue workspace setup from local repository state when dirty-root or no-upstream conditions allow it, preserve existing valid worktree reuse, and emit stage-specific failure diagnostics for root sync, worktree preparation, and PRD copy outcomes backed by focused regression coverage."
   },
   "acceptanceCriteria": [
-    "Service tests prove async start, sync completed start, sync timeout, get session, and get result using a real simple JavaScript fixture through the runtime-backed service path",
-    "Service tests prove exact request-id replay returns the same session/result response and conflicting request-id reuse is rejected",
-    "Projection tests show session lifecycle, result summary, source hash, policy hash, and inspection links remain consistent with existing API-shaped read models",
-    "Canonical lifecycle and result update events can be replayed idempotently to reconstruct the same session projection",
-    "FakeService tests continue to pass and remain usable for CLI, MCP, API, and mock-provider paths",
-    "No provider dispatch bridge, website UI, MCP install packaging, or broad persistent database storage is introduced in this cell",
-    "Quality gate: Go typecheck/compile, lint where applicable, and focused tests pass, including go test ./pkg/factorysessionexecution ./pkg/orchestrators/javascript/..."
+    "setup-workspace can create a new executor worktree from local repository state when the root checkout has staged or otherwise pull-blocking local changes, without resetting, overwriting, or unstaging that root state.",
+    "setup-workspace can reuse an existing valid executor worktree when the root checkout cannot be pulled, and reusable-worktree preparation still completes when no additional sync is required.",
+    "Root sync behavior still treats no-upstream configuration as non-fatal when local state is sufficient for workspace preparation.",
+    "Failure output identifies whether setup stopped during root sync, worktree preparation, or PRD copy so later planner or queue-repair passes do not need to guess.",
+    "The fix stays within shared workspace-preparation behavior, preserves current Factory and worktree vocabulary, and leaves a clear rerun-and-requeue path for the blocked MCP-install plan lanes.",
+    "Typecheck, lint, and focused tests for setup-workspace behavior pass."
   ],
   "userStories": [
     {
-      "id": "dynamic-workflows-cell-session-backend-runtime-001",
-      "title": "Normalize real session start inputs",
-      "description": "As a backend maintainer, I want real JavaScript session starts to use the shared start contract and orchestrator-owned normalization so the runtime path behaves like API, CLI, and MCP callers expect.",
+      "id": "dynamic-workflows-recovery-setup-workspace-git-pull-hygiene-001",
+      "title": "Continue workspace setup when root sync is blocked by local changes",
+      "description": "As a maintainer recovering blocked plan lanes, I want workspace setup to continue from safe local repository state when root pull is blocked by local changes so executor worktrees can still be created without mutating the root checkout.",
       "acceptanceCriteria": [
-        "A start request resolves JavaScript source using the existing Factory Session start source flow and records the resolved source identity and source hash on the session read model",
-        "A start request validates source, args, requested policy, and wait options before runtime execution begins",
-        "Policy projection records the effective policy hash used for the session",
-        "Invalid source, invalid args, or denied policy returns the existing service error shape without creating a completed session",
+        "When the root checkout has staged or otherwise pull-blocking local changes, running setup-workspace does not reset, overwrite, or unstage those root changes.",
+        "In the same dirty-root scenario, setup-workspace can still create the expected executor worktree for a PRD lane when the local repository already has enough history to do so safely.",
+        "If root sync is skipped or downgraded because local changes would block pull, the observable script output makes that outcome explicit.",
+        "The story remains limited to shared workspace-preparation behavior and does not introduce separate workflow-run terminology or unrelated git tooling cleanup.",
         "Typecheck passes",
         "Tests pass"
       ],
@@ -34,14 +33,14 @@
       "notes": ""
     },
     {
-      "id": "dynamic-workflows-cell-session-backend-runtime-002",
-      "title": "Start simple JavaScript sessions asynchronously",
-      "description": "As a transport caller, I want to start a simple JavaScript workflow asynchronously so I can receive a session identifier immediately and inspect progress through the shared service.",
+      "id": "dynamic-workflows-recovery-setup-workspace-git-pull-hygiene-002",
+      "title": "Reuse existing worktrees and preserve no-upstream behavior",
+      "description": "As a maintainer rerunning blocked work items, I want reusable-worktree and no-upstream cases to keep working under the repaired sync policy so existing plan lanes can recover without extra manual branch repair.",
       "acceptanceCriteria": [
-        "StartAsync against a real simple JavaScript fixture returns a session id, accepted/running lifecycle state, orchestrator identity, source hash, policy hash, and inspection links",
-        "The runtime-backed service records enough in-memory session state for a later GetSession call to report lifecycle status, progress, result availability, dispatch stubs, artifact stubs, and links",
-        "The service emits or models canonical session-started and lifecycle/progress facts for the async session",
-        "Async service tests use a real simple JavaScript fixture rather than a fake scenario fixture",
+        "When the expected executor worktree already exists and is valid, setup-workspace reuses it successfully even if the root checkout has pull-blocking local changes.",
+        "When the repository branch has no upstream configured, setup-workspace still treats that condition as non-fatal and can continue to reuse or create the executor worktree from local state.",
+        "If a reusable worktree needs its own branch update and that update cannot proceed safely, the script reports that failure as a worktree-preparation problem rather than a generic root-sync error.",
+        "Focused verification covers reusable-worktree and no-upstream paths without depending on unrelated dynamic-workflow runtime, API, or MCP-install behavior.",
         "Typecheck passes",
         "Tests pass"
       ],
@@ -50,83 +49,19 @@
       "notes": ""
     },
     {
-      "id": "dynamic-workflows-cell-session-backend-runtime-003",
-      "title": "Complete or time out synchronous starts",
-      "description": "As a transport caller, I want synchronous JavaScript session starts to either return the completed result within the wait budget or return a live session that can be inspected later.",
+      "id": "dynamic-workflows-recovery-setup-workspace-git-pull-hygiene-003",
+      "title": "Emit categorized setup failures that support queue recovery",
+      "description": "As a later planner or queue-repair pass, I want setup-workspace failures categorized by stage so I can distinguish root sync failure, worktree preparation failure, and PRD copy failure without guessing.",
       "acceptanceCriteria": [
-        "StartSync with a sufficient wait budget runs the real simple JavaScript fixture and returns a completed session result with the expected primary result summary",
-        "StartSync with an exhausted or too-small wait budget returns the existing timeout/pending result shape with session id, lifecycle status, result availability, and inspection links",
-        "Sync completion and timeout paths both persist the same session state that GetSession and GetResult later read",
-        "Timeout behavior does not duplicate sessions or lose the eventual runtime result",
+        "When root sync truly fails in a way that should still block setup, the script emits failure output that identifies the root-sync stage and the concrete blocking reason.",
+        "When worktree creation or reuse fails, the script emits failure output that identifies the worktree-preparation stage and preserves the actionable git or filesystem reason.",
+        "When PRD artifact copy fails after worktree preparation, the script emits failure output that identifies the PRD-copy stage separately from git setup failures.",
+        "Failure output is concrete enough that a reviewer can map a blocked lane to the right follow-up action, including rerunning workspace setup and requeueing blocked MCP-install plan lanes after the shared blocker is fixed.",
         "Typecheck passes",
         "Tests pass"
       ],
       "priority": 3,
-      "passes": true,
-      "notes": ""
-    },
-    {
-      "id": "dynamic-workflows-cell-session-backend-runtime-004",
-      "title": "Read session and result projections",
-      "description": "As a caller inspecting a Factory Session, I want status and result reads to match the established durable session API shapes so later API, CLI, and MCP work can consume one shared backend projection.",
-      "acceptanceCriteria": [
-        "GetSession returns a durable session read model with lifecycle status, phase/progress summary, result summary, source hash, policy hash, dispatch/artifact counts or stubs, recoverability/action availability, and inspection links",
-        "GetResult returns final result data for a completed simple JavaScript session and an availability response for sessions that are still running or timed out",
-        "Result projection uses the existing JavaScript result normalization rules for primary result, artifacts, and summary fields",
-        "Projection tests compare the runtime-backed read models to the existing API-shaped expectations without changing public schema names",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 4,
-      "passes": true,
-      "notes": ""
-    },
-    {
-      "id": "dynamic-workflows-cell-session-backend-runtime-005",
-      "title": "Preserve request-id idempotency",
-      "description": "As a caller retrying a start request, I want exact request-id replays to be safe and conflicting request-id reuse to fail so retries do not create duplicate or ambiguous sessions.",
-      "acceptanceCriteria": [
-        "Replaying the same normalized async start request with the same request id returns the original async start response and session id",
-        "Replaying the same normalized sync start request with the same request id returns the original sync response shape, including completed or timeout status as originally observed",
-        "Reusing a request id with a different normalized tuple returns the existing request-id conflict error and does not create a new runtime session",
-        "Idempotency tests cover async start, sync completed start, sync timeout, and conflict using the real simple JavaScript fixture",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 5,
-      "passes": true,
-      "notes": ""
-    },
-    {
-      "id": "dynamic-workflows-cell-session-backend-runtime-006",
-      "title": "Replay lifecycle and result events consistently",
-      "description": "As a maintainer, I want canonical session lifecycle and result update events from real JavaScript sessions to replay into the same projection so API/event parity has a stable source.",
-      "acceptanceCriteria": [
-        "Runtime-backed sessions model or emit canonical start, result-updated, completed, and timeout/recoverable lifecycle events where applicable",
-        "Replaying the event sequence reconstructs the same lifecycle status, result summary, source hash, policy hash, and links as the live service projection",
-        "Replaying the same event sequence more than once does not duplicate result summaries, links, dispatch stubs, or artifact stubs",
-        "Projection tests use the real simple JavaScript fixture event sequence and existing durable session API-shaped projection expectations",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 6,
-      "passes": true,
-      "notes": ""
-    },
-    {
-      "id": "dynamic-workflows-cell-session-backend-runtime-007",
-      "title": "Keep FakeService mock paths intact",
-      "description": "As a maintainer of CLI, MCP, and API mock paths, I want the fake session service to keep working while real runtime support is added so parallel transport work stays unblocked.",
-      "acceptanceCriteria": [
-        "Existing FakeService behavior and fixture-backed scenarios continue to pass without requiring real JavaScript runtime setup",
-        "Fake async, sync, get session, get result, event replay, and idempotency behaviors remain compatible with the shared factorysessionexecution.Service contract",
-        "Runtime-backed service wiring does not remove or rename fake-service constructors or scenario-loading APIs used by mock-provider tests",
-        "Focused fake service tests pass alongside the new runtime-backed service tests",
-        "Typecheck passes",
-        "Tests pass"
-      ],
-      "priority": 7,
-      "passes": true,
+      "passes": false,
       "notes": ""
     }
   ]

--- a/prd.md
+++ b/prd.md
@@ -1,186 +1,114 @@
-# PRD: UI CI Acceleration and Test Rationalization
-
-## Introduction
-
-The current required CI path spends too much wall clock time in UI verification, especially covered Vitest runs and browser integration tests. Because the required lanes run serially today, browser integration failures can arrive only after a long covered UI pass completes. This slows merge feedback, makes flaky failures more expensive, and makes it harder for maintainers to tell whether a failing test is proving a unique product contract or repeating assertions already covered elsewhere.
-
-This project will make browser failures surface earlier, reduce required UI CI wall clock time, use the existing sharded coverage runner, add stable timing visibility, and rationalize redundant UI tests while preserving defect detection. The intended outcome is a faster, more trustworthy PR verification path where each test lane has a clear purpose, clear rerun command, and clear failure output.
+# PRD: Dynamic Workflows Recovery Setup Workspace Git Pull Hygiene
 
 ## Context
 
+### Project Overview
+
+`infinite-you` uses a shared workspace-preparation path to create or reuse executor worktrees for queued implementation lanes. Dynamic workflow plan lanes depend on `factory/scripts/setup-workspace.py` to prepare a `.claude/worktrees/<work-item>` checkout, copy the PRD artifacts into that worktree, and leave the lane ready for implementation work without damaging the user's existing root checkout.
+
 ### Customer Ask
 
-Accelerate the UI-heavy portions of CI and rationalize redundant tests so browser integration regressions fail faster, covered UI runs complete sooner, and maintainers have enough timing evidence to keep the suite from regressing.
+Repair shared `setup-workspace` behavior so a plan lane can create or reuse its executor worktree even when the root repository has staged or otherwise pull-blocking local changes. The fix must preserve user work, emit concrete failure diagnostics, cover the dirty-root or pull-failure cases with focused verification, and leave a clear next step for requeueing the blocked MCP-install plan lanes after the shared blocker is removed.
 
-### Concrete Problem
+### Problem
 
-The current `make ci` flow waits for long covered UI verification before browser integration can report failures. The covered UI runner already has sharding support, but the canonical PR path does not use it. Several slow tests are broad app-shell or React Flow-heavy suites that repeatedly mount expensive dashboard state for narrower behaviors. Browser, jsdom integration, and unit-style tests also overlap in places, increasing runtime without adding proportional confidence.
+`factory/scripts/setup-workspace.py` currently runs a root-level `git pull` before any worktree reuse or creation. When the root checkout has local staged or otherwise pull-blocking changes, setup fails before it reaches reusable-worktree or new-worktree paths. This blocks unrelated PRD execution lanes even though those lanes only need a safe executor worktree and PRD copies. The current failure surface is also too generic for later planning or queue-repair passes to distinguish root sync failure from worktree creation failure or PRD copy failure.
 
 ### High-Level Solution
 
-Introduce a canonical PR verification flow that either runs browser integration before UI coverage or runs both through a repo-owned orchestrator with fast-fail semantics. Use sharded UI coverage in CI with deterministic merged coverage output. Add stable slow-test reporting for covered UI and browser lanes. Define lane boundaries and split the highest-cost redundant suites into lower-cost feature-scoped tests where that preserves the same observable confidence.
+Adjust shared workspace preparation so root-repo sync is attempted only when it is safe and necessary, and so dirty-root or pull-blocked conditions do not prevent reuse or creation of an executor worktree from the existing local repository state. Keep the change bounded to setup-workspace behavior, reuse current Factory and worktree vocabulary, and make remaining failures concrete enough for later queue inspection and requeue work. Add focused regression coverage for dirty-root fallback, no-upstream behavior, reusable-worktree behavior, and categorized failure output.
 
 ## Project-Level Acceptance Criteria
 
-- [ ] Browser integration no longer waits for the full covered UI lane to finish before starting in the canonical PR verification flow.
-- [ ] The required UI-related CI wall clock time is reduced by at least 30% from the current measured baseline, or the closeout artifact explains the measured blocker and next tuning step.
-- [ ] Sharded UI coverage preserves merged coverage reports, threshold enforcement, replay coverage checking, and clear failure output when a shard fails.
-- [ ] Covered UI and browser integration lanes emit stable slow-file summaries that maintainers can compare across runs.
-- [ ] Lane boundaries explain what belongs in unit/jsdom coverage, covered feature integration, and browser integration, with duplicate assertion patterns removed from at least one high-cost area.
-- [ ] Browser integration remains deterministic: failures identify the lane and rerun command, and concurrent execution avoids port, preview server, and shared download conflicts.
-- [ ] Typecheck, lint, and relevant tests pass for CI orchestration, coverage sharding, reporting, and changed UI test behavior.
+- `setup-workspace` can create a new executor worktree from the local repository state when the root checkout has staged or otherwise pull-blocking local changes, without resetting, overwriting, or unstaging that root state.
+- `setup-workspace` can reuse an existing valid executor worktree when the root checkout cannot be pulled, and reusable-worktree preparation still completes when no additional sync is required.
+- Root sync behavior still handles the no-upstream case safely and does not convert "no upstream configured" into a fatal error for workspace preparation.
+- Failure output from `setup-workspace` identifies whether the blocking problem happened during root sync, worktree preparation, or PRD copy so later planner or queue-repair passes do not need to guess.
+- The change stays inside shared workspace-preparation surfaces and preserves current Factory, Factory Session, and worktree terminology without introducing a separate workflow-run model.
+- The repaired behavior leaves blocked plan lanes with an obvious requeue path once setup succeeds, such as rerunning workspace setup and moving the blocked MCP-install plan lanes back toward `plan:init`.
+- Typecheck, lint, and focused tests for setup-workspace behavior pass.
 
 ## Goals
 
-- Reduce required UI-related CI wall clock time by at least 30%.
-- Surface browser integration failures before or alongside covered UI failures.
-- Cut median time-to-first-actionable browser regression failure to under 10 minutes.
-- Use existing UI coverage sharding and merge behavior instead of weakening coverage thresholds.
-- Establish stable timing visibility for the slowest covered UI and browser integration files.
-- Reduce redundant UI coverage across app-shell, replay, React Flow, and import/export scenarios.
-- Preserve or improve defect detection quality while decreasing runtime and flake exposure.
+- Preserve user work in the root checkout while allowing executor worktree setup to proceed.
+- Make dirty-root and pull-blocked cases observable, intentional, and reviewer-verifiable.
+- Keep reusable-worktree and no-upstream paths working as part of the same shared setup flow.
+- Produce concrete diagnostics that support later queue inspection and plan-lane recovery.
+- Keep the fix narrowly scoped to workspace preparation rather than widening into dynamic workflow runtime or MCP behavior.
 
 ## User Stories
 
-### prd-ui-ci-acceleration-and-test-rationalization-001: Fast-Fail Required UI CI Flow
-
-**Description:** As an engineer merging a UI change, I want browser integration to start before or alongside covered UI verification so that browser regressions become actionable sooner.
-
-**Acceptance Criteria:**
-
-- [ ] The canonical PR verification flow starts browser integration before covered UI completion, either by ordering browser first or by running browser and coverage through one orchestrated concurrent flow.
-- [ ] Failure output names the failed lane and includes the target or command an engineer should rerun locally.
-- [ ] Concurrent lanes, if used, keep lane logs attributable and avoid shared-state conflicts between browser-oriented processes.
-- [ ] The chosen ordering or concurrency behavior is documented in the developer-facing CI target help or adjacent CI documentation.
-- [ ] Tests pass.
-- [ ] Typecheck passes.
-
-### prd-ui-ci-acceleration-and-test-rationalization-002: Sharded Covered UI Verification
-
-**Description:** As an engineer waiting on CI, I want covered UI tests to run in shards and merge coverage afterward so that wall clock time drops without weakening coverage enforcement.
+### dynamic-workflows-recovery-setup-workspace-git-pull-hygiene-001: Continue workspace setup when root sync is blocked by local changes
+**Description:** As a maintainer recovering blocked plan lanes, I want workspace setup to continue from safe local repository state when root pull is blocked by local changes so executor worktrees can still be created without mutating the root checkout.
 
 **Acceptance Criteria:**
-
-- [ ] The canonical PR verification flow uses the repo-owned UI coverage shard and merge behavior with a documented default shard count.
-- [ ] The merged coverage report preserves threshold enforcement and replay coverage checking after all expected shards finish.
-- [ ] A missing or failed shard produces a clear failure that identifies the shard and does not silently produce partial coverage.
-- [ ] Shard count can be tuned through a documented environment variable or CI setting without changing test semantics.
-- [ ] Tests pass.
+- [ ] When the root checkout has staged or otherwise pull-blocking local changes, running `setup-workspace` does not reset, overwrite, or unstage those root changes.
+- [ ] In the same dirty-root scenario, `setup-workspace` can still create the expected executor worktree for a PRD lane when the local repository already has enough history to do so safely.
+- [ ] If root sync is skipped or downgraded because local changes would block pull, the outcome is explicit in observable script output rather than hidden behavior.
+- [ ] The story remains limited to shared workspace-preparation behavior and does not introduce separate workflow-run terminology or unrelated git tooling cleanup.
 - [ ] Typecheck passes.
+- [ ] Tests pass.
 
-### prd-ui-ci-acceleration-and-test-rationalization-003: Stable UI Test Cost Reporting
-
-**Description:** As a maintainer, I want CI to report the slowest covered UI and browser integration files with cost categories so that runtime regressions are visible and actionable.
+### dynamic-workflows-recovery-setup-workspace-git-pull-hygiene-002: Reuse existing worktrees and preserve no-upstream behavior under the safer sync policy
+**Description:** As a maintainer rerunning blocked work items, I want reusable-worktree and no-upstream cases to keep working under the repaired sync policy so existing plan lanes can recover without extra manual branch repair.
 
 **Acceptance Criteria:**
+- [x] When the expected executor worktree already exists and is valid, `setup-workspace` reuses it successfully even if the root checkout has pull-blocking local changes.
+- [x] When the repository branch has no upstream configured, `setup-workspace` still treats that condition as non-fatal and can continue to reuse or create the executor worktree from local state.
+- [x] If a reusable worktree needs its own branch update and that update cannot proceed safely, the script reports that failure as a worktree-preparation problem rather than a generic root-sync error.
+- [x] Focused verification covers reusable-worktree and no-upstream paths without depending on unrelated dynamic-workflow runtime, API, or MCP-install behavior.
+- [x] Typecheck passes.
+- [x] Tests pass.
 
-- [ ] Covered UI verification emits a stable top-slowest file summary after the run or after shard merge.
-- [ ] Browser integration emits per-file timing or an equivalent top-slowest summary after the run.
-- [ ] The report categorizes slow files into app-shell integration, React Flow graph tests, replay/timeline tests, import/export tests, script-style tests, or uncategorized.
-- [ ] The report format is suitable for closeout notes and can be compared across CI runs without requiring source topology assertions.
-- [ ] Tests pass.
-- [ ] Typecheck passes.
-
-### prd-ui-ci-acceleration-and-test-rationalization-004: Lane Boundary and Redundancy Policy
-
-**Description:** As a maintainer, I want explicit test-lane boundaries so that unit, covered jsdom, and browser tests each verify distinct behavior.
+### dynamic-workflows-recovery-setup-workspace-git-pull-hygiene-003: Emit categorized setup failures that support queue recovery
+**Description:** As a later planner or queue-repair pass, I want setup-workspace failures categorized by stage so I can distinguish root sync failure, worktree preparation failure, and PRD copy failure without guessing.
 
 **Acceptance Criteria:**
-
-- [ ] The test strategy defines what observable contracts belong in unit tests, covered feature/jsdom integration tests, and browser integration tests.
-- [ ] Browser integration guidance prioritizes durable behavior such as saved payloads, network effects, downloads, imports, and final visible state over repeated copy-only assertions.
-- [ ] Export/import and graph-editing flows have a documented minimum browser contract that avoids repeating every jsdom UI assertion.
-- [ ] At least one existing duplicate assertion pattern is removed or moved to the cheaper lane while preserving the durable behavior check.
-- [ ] Tests pass.
+- [ ] When root sync truly fails in a way that should still block setup, the script emits failure output that identifies the root-sync stage and the concrete blocking reason.
+- [ ] When worktree creation or reuse fails, the script emits failure output that identifies the worktree-preparation stage and preserves the actionable git or filesystem reason.
+- [ ] When PRD artifact copy fails after worktree preparation, the script emits failure output that identifies the PRD-copy stage separately from git setup failures.
+- [ ] Failure output is concrete enough that a reviewer can map a blocked lane to the right follow-up action, including rerunning workspace setup and requeueing blocked MCP-install plan lanes after the shared blocker is fixed.
 - [ ] Typecheck passes.
-
-### prd-ui-ci-acceleration-and-test-rationalization-005: Split One High-Cost App-Shell Suite
-
-**Description:** As a maintainer, I want at least one oversized app-shell test suite replaced with smaller feature-focused coverage so that the same behavior is proven with less setup cost.
-
-**Acceptance Criteria:**
-
-- [ ] One high-cost app-shell suite is selected from the current slow-file inventory and its unique observable behaviors are listed before changes.
-- [ ] Equivalent behavior is covered by smaller feature-owned tests where whole-dashboard mounting is not required.
-- [ ] Any remaining app-shell coverage is limited to cross-feature behavior that cannot be proven reliably at a lower layer.
-- [ ] Before/after timing for the selected suite or replacement tests is captured in the closeout artifact.
 - [ ] Tests pass.
-- [ ] Typecheck passes.
-
-### prd-ui-ci-acceleration-and-test-rationalization-006: Browser Integration Stability and Runtime Boundaries
-
-**Description:** As an engineer debugging browser failures, I want browser integration tests to be isolated and deterministic so that failures are attributable and retries remain rare.
-
-**Acceptance Criteria:**
-
-- [ ] Browser integration documentation states which suites must remain sequential because of shared preview servers, ports, downloads, or global browser state.
-- [ ] Any browser test concurrency introduced by this project uses isolated ports, preview state, and download locations per worker or file.
-- [ ] Shared browser helpers expose or document a recommended wait pattern for durable network and UI checkpoints.
-- [ ] At least one flaky or over-constrained browser assertion is simplified to assert durable behavior rather than transient copy, animation, or timing state.
-- [ ] Direct browser verification confirms changed browser-visible test flows still exercise the intended final UI state.
-- [ ] Tests pass.
-- [ ] Typecheck passes.
 
 ## High-Level Technical Design
 
-The canonical PR verification path should remain easy to run by target name. If the implementation chooses concurrency, use a repo-owned orchestration target or script that prefixes or buffers lane output so failures remain attributable. If the implementation chooses ordering, run browser integration as an earlier fast-fail lane and keep covered UI as the authoritative coverage lane.
-
-Covered UI verification should use the existing shard and merge model. Each shard must produce an identifiable artifact, and merge must fail when an expected shard result is missing. The merged report remains the only source for coverage threshold enforcement and replay coverage checking.
-
-Slow-test observability should be generated by the test lanes themselves or by repo-owned wrappers, not by a one-time spreadsheet. Reports should include top slow files, elapsed time, lane name, and a likely cost category. Categories are for maintainer triage and should not become a brittle source-inventory test.
-
-Test rationalization should start with the slowest app-shell and React Flow-heavy suites. Implementers should preserve user-visible or maintainer-visible behavior while moving repeated setup-heavy assertions into feature-scoped tests where possible. Browser tests should keep durable end-to-end contracts and avoid duplicating copy-only assertions already covered in jsdom.
+- Keep ownership in the shared setup-workspace script and any directly associated verification surfaces. Do not widen into runtime, MCP host install, or API contract changes.
+- Treat root sync as a best-effort preparation step with explicit safety checks. If local root state would make `git pull` unsafe or impossible, continue from local state when worktree preparation can still proceed safely.
+- Preserve current worktree creation and reuse semantics, but make the decision points explicit: root sync outcome, worktree reuse or add outcome, and PRD copy outcome should each have distinct observable result categories.
+- Prefer deterministic, stage-oriented diagnostics over generic shell failure text so later queue inspection can distinguish whether the next step is "retry after cleaning root," "repair or remove invalid worktree," or "fix PRD artifact copy."
+- Verification should focus on observable script behavior: dirty-root fallback, no-upstream continuation, reusable-worktree success, and categorized failures.
 
 ## Functional Requirements
 
-- FR-1: The canonical PR verification flow must start browser integration before the covered UI lane completes.
-- FR-2: If test lanes run concurrently, lane logs must remain attributable, buffered or prefixed, and rerunnable by target name.
-- FR-3: Browser integration failures must provide a fast-fail signal without waiting for the full covered UI lane to complete.
-- FR-4: The covered UI lane must support shard-based execution in CI using the repo-owned shard and merge behavior.
-- FR-5: The default coverage shard count and tuning mechanism must be documented.
-- FR-6: Coverage merge must fail clearly when expected shard artifacts are missing.
-- FR-7: The covered UI lane must preserve merged coverage reports, coverage thresholds, and replay coverage checks.
-- FR-8: Covered UI and browser integration lanes must emit stable slow-file summaries.
-- FR-9: Slow-file summaries must include top N files, lane name, elapsed time, and a likely optimization category.
-- FR-10: The maintained slow-test inventory must include current-selection app shell, layout/graph app shell, replay stream, React Flow edit integration, import/export browser flows, and layout performance tests when present in the measured run.
-- FR-11: The test strategy must define lane boundaries for unit tests, covered jsdom integration tests, and browser integration tests.
-- FR-12: Browser integration tests must prioritize durable assertions such as saved payloads, network requests, downloaded or imported artifacts, and final visible state.
-- FR-13: Repeated whole-dashboard setup patterns must be replaced with lower-cost feature harnesses where the behavior under test is feature-local.
-- FR-14: At least one broad app-shell suite must be split or reduced without removing coverage of its unique observable behavior.
-- FR-15: Browser integration sequencing and any safe concurrency rules must be documented with port, preview server, and download-state constraints.
-- FR-16: The project must produce a closeout artifact or note with before/after timing for CI wall clock time, covered UI time, browser lane time, and top slow files.
+1. FR-1: The workspace-setup flow must preserve staged and other local root changes and must not reset, overwrite, or unstage them as part of creating or reusing an executor worktree.
+2. FR-2: The workspace-setup flow must allow worktree creation to continue from existing local repository state when root-level pull is blocked by local changes and no additional remote sync is required for safe creation.
+3. FR-3: The workspace-setup flow must continue treating "no tracking information for the current branch" or equivalent no-upstream conditions as non-fatal when local state is sufficient to continue.
+4. FR-4: The workspace-setup flow must reuse an existing valid executor worktree when possible under the same safer sync policy.
+5. FR-5: The script must emit failure output that categorizes the failed stage as root sync, worktree preparation, or PRD copy.
+6. FR-6: Focused automated verification must cover dirty-root fallback, reusable-worktree behavior, no-upstream behavior, and categorized failure output.
+7. FR-7: Documentation or task-facing output must leave a clear recovery path for rerunning setup and requeueing blocked plan lanes after the shared blocker is removed.
 
 ## Non-Goals
 
-- Rewriting the entire UI test stack.
-- Eliminating browser integration tests.
-- Lowering coverage thresholds as the primary speed strategy.
-- Parallelizing browser tests in a way that knowingly increases flakiness or port conflicts.
-- Replacing targeted end-to-end coverage with only unit tests.
-- Fixing every historical React `act(...)` warning or unrelated console warning.
-- Performing broad unrelated cleanup while changing CI and test strategy.
+- No changes to dynamic workflow runtime, Factory Session execution, MCP tools, MCP host installation, API handlers, or dashboard behavior.
+- No broad git-tooling cleanup outside the shared workspace-preparation flow.
+- No new workflow-run vocabulary or separate product model outside the current Factory and worktree grammar.
+- No automatic queue mutation or lane requeue orchestration beyond leaving clear diagnostics and next steps.
 
-## Supporting Technical and UX Considerations
+## Supporting Technical Considerations
 
-- CI operator experience matters: required lanes should remain easy to run locally and failures should identify the exact rerun command.
-- Faster CI is only valuable if failures remain deterministic and attributable.
-- Browser integration logs must stay readable when run near other long-running lanes.
-- Sharding should respect CI executor capacity; too many shards may add overhead without improving wall clock time.
-- Browser tests that use preview servers, downloads, ports, or global browser state need explicit isolation before any file-level concurrency.
-- Frontend-visible changes to test fixtures or browser flows should still be verified in a browser, including loading, success, empty, and failure states when those states are affected.
-- Test reports should measure runtime behavior and outcomes, not enforce brittle source-file inventories unless the report itself is the product behavior under test.
+- The script sits at a process and filesystem boundary, so failure handling should preserve actionable subprocess stderr while still classifying the stage clearly.
+- Safe behavior should prefer existing local refs and worktree reuse before requiring remote sync.
+- Regression tests should stay focused on behavior and avoid asserting internal helper layout or script structure.
+- If script output is machine-consumed by later automation, failure categorization should remain stable enough for a planner pass to branch on it.
 
 ## Success Metrics
 
-- Required UI-related `make ci` wall clock time drops by at least 30% from the current measured baseline.
-- Browser integration failures surface before full UI coverage completion in at least 90% of failing browser-regression cases.
-- Main covered UI wall clock time drops by at least 25%.
-- The top 10 slowest UI test files are remeasured after changes, and at least 5 improve materially or have documented blockers.
-- The number of broad app-shell tests above 10 seconds decreases release over release.
-- Browser integration retries due to flake do not increase after CI orchestration and sharding changes.
+- A blocked plan lane can prepare its executor worktree successfully in a dirty-root repository without altering root user work.
+- Reviewers can tell from one failed setup run whether the next action belongs to root cleanup, worktree repair, or PRD artifact repair.
+- The two blocked MCP-install-related plan lanes have a clear shared-path recovery once workspace setup is repaired.
 
 ## Open Questions
 
-- Should the canonical PR path run browser integration first, or run browser integration and UI coverage concurrently under a shared orchestrator?
-- Should the layout performance test remain in the required covered lane, or move to a separate performance verification lane with its own runtime budget?
-- What CI executor capacity is available for coverage sharding, and what default shard count gives the best wall clock improvement without overhead dominating?
+- None.

--- a/progress.txt
+++ b/progress.txt
@@ -1,6 +1,7 @@
 ## Codebase Patterns
 - `factory/scripts/setup-workspace.py` root sync uses fetch plus `update-ref refs/heads/main` when safe instead of unconditional `git pull`, so dirty-root checkouts can continue worktree setup without touching the working tree. Skip fast-forward when `main` is checked out with local changes; verify remote `main` via `git ls-remote` before updating refs so stale `origin/main` refs do not fast-forward after remote branch deletion.
-- Reused executor worktrees sync through `sync_reused_worktree_branch`: skip `git pull --ff-only` when `branch@{upstream}` is unset or stderr reports no tracking information; log `Worktree branch sync:` outcomes on stderr; raise `RuntimeError` for non-fast-forward pull failures so `main()` reports `Worktree preparation failed` instead of a root-sync error.
+- Reused executor worktrees sync through `sync_reused_worktree_branch`: skip `git pull --ff-only` when `branch@{upstream}` is unset or stderr reports no tracking information; log `Worktree branch sync:` outcomes on stderr; raise `RuntimeError` for non-fast-forward pull failures so `main()` reports `Worktree preparation failed:` instead of a root-sync error.
+- `factory/scripts/setup-workspace.py` stderr failure lines use stable stage prefixes: `Root sync failed:`, `Worktree preparation failed:`, and `PRD copy failed:` so queue-recovery passes can branch on setup stage without parsing generic git errors.
 - Keep `FakeService` and `RuntimeService` as parallel `factorysessionexecution.Service` implementations: mock-provider transports inject `FakeService` via `NewFakeService`, `NewFakeServiceFromContractFixtures`, `WithFakeScenarios`, and `WithPersistedSessionSeeds` without JavaScript runtime setup; real simple-workflow execution uses `NewRuntimeService` behind the same contract. Prove coexistence in `fake_service_coexistence_test.go` alongside `fake_service_test.go` and runtime-backed tests.
 - Use `factorysessionexecution.PrepareStart` to normalize durable JavaScript session starts: it chains `NormalizeStartRequest`, `resolveStartSourceWithResolution`, wrapped-source validation (IIFE wrap matching `workflowruntime.Run`), args JSON checks, `workflowpolicy.Resolve`, and wait-option validation before runtime execution.
 - Runtime simple-workflow fixtures live in `pkg/orchestrators/javascript/runtime/testdata/`; factorysessionexecution tests can read them via `../orchestrators/javascript/runtime/testdata/<name>`.
@@ -128,4 +129,15 @@
   - `git worktree add` fails when the target branch is already checked out at the root; integration tests that pre-create tracked branches must `git checkout main` before calling `setup-workspace`.
   - Reuse-path branch sync should use `cwd=worktree_path` rather than `-C` from the repo root for clearer git subprocess boundaries.
   - No-upstream is detectable via `git rev-parse --abbrev-ref branch@{upstream}` before attempting pull; treat pull stderr containing `no tracking information` as the same non-fatal skip.
+---
+
+## 2026-06-15T18:00:00Z - dynamic-workflows-recovery-setup-workspace-git-pull-hygiene-003
+- Renamed setup-workspace fatal stderr labels to stable stage prefixes: `Root sync failed:`, `Worktree preparation failed:`, and `PRD copy failed:`.
+- Added `tests/factory/scripts/test_setup_workspace_failures.py` covering root-sync, worktree-preparation, and PRD-copy failure categorization with stage-isolated assertions.
+- Updated worktree unsafe-update regression to expect `Root sync failed` instead of the old `Git sync failed` label.
+- Files changed: `factory/scripts/setup-workspace.py`, `tests/factory/scripts/test_setup_workspace_failures.py`, `tests/factory/scripts/test_setup_workspace_worktree.py`
+- **Learnings for future iterations:**
+  - Direct `main()` failure tests must `os.chdir` into the temp git repo before calling the module; `get_repo_root()` resolves from process cwd, not the test file location.
+  - PRD copy failures are easy to trigger on reuse by chmodding an existing worktree `prd.json` read-only before rerunning setup.
+  - Root sync fatal paths are easiest to exercise by patching `prune_worktrees` in-process; integration git breakage is less deterministic across git versions.
 ---

--- a/progress.txt
+++ b/progress.txt
@@ -1,4 +1,6 @@
 ## Codebase Patterns
+- `factory/scripts/setup-workspace.py` root sync uses fetch plus `update-ref refs/heads/main` when safe instead of unconditional `git pull`, so dirty-root checkouts can continue worktree setup without touching the working tree. Skip fast-forward when `main` is checked out with local changes; verify remote `main` via `git ls-remote` before updating refs so stale `origin/main` refs do not fast-forward after remote branch deletion.
+- Reused executor worktrees sync through `sync_reused_worktree_branch`: skip `git pull --ff-only` when `branch@{upstream}` is unset or stderr reports no tracking information; log `Worktree branch sync:` outcomes on stderr; raise `RuntimeError` for non-fast-forward pull failures so `main()` reports `Worktree preparation failed` instead of a root-sync error.
 - Keep `FakeService` and `RuntimeService` as parallel `factorysessionexecution.Service` implementations: mock-provider transports inject `FakeService` via `NewFakeService`, `NewFakeServiceFromContractFixtures`, `WithFakeScenarios`, and `WithPersistedSessionSeeds` without JavaScript runtime setup; real simple-workflow execution uses `NewRuntimeService` behind the same contract. Prove coexistence in `fake_service_coexistence_test.go` alongside `fake_service_test.go` and runtime-backed tests.
 - Use `factorysessionexecution.PrepareStart` to normalize durable JavaScript session starts: it chains `NormalizeStartRequest`, `resolveStartSourceWithResolution`, wrapped-source validation (IIFE wrap matching `workflowruntime.Run`), args JSON checks, `workflowpolicy.Resolve`, and wait-option validation before runtime execution.
 - Runtime simple-workflow fixtures live in `pkg/orchestrators/javascript/runtime/testdata/`; factorysessionexecution tests can read them via `../orchestrators/javascript/runtime/testdata/<name>`.
@@ -105,4 +107,25 @@
 - **Learnings for future iterations:**
   - CI `Build, Lint, and API` runs `make backend-size` after `make vet`; large table-driven or assertion-heavy tests should use `t.Helper()` assertion helpers early to stay under the 100-line function cap.
   - `go vet` passing locally does not imply the full `Build, Lint, and API` job is green—run `make backend-size` when adding substantial test functions in owned backend packages.
+---
+
+## 2026-06-15T00:00:00Z - dynamic-workflows-recovery-setup-workspace-git-pull-hygiene-001
+- Replaced unconditional root `git pull` in `factory/scripts/setup-workspace.py` with safe fetch + `update-ref refs/heads/main` fast-forward when origin/main is reachable and main is not checked out dirty.
+- Added helper probes (`has_origin_remote`, `origin_main_ref_exists`, `remote_main_sha`) and explicit `Root sync:` stderr logging for skip/downgrade outcomes.
+- Extended `tests/factory/scripts/test_setup_workspace_sync.py` with staged-root and dirty-main checkout integration coverage.
+- Files changed: `factory/scripts/setup-workspace.py`, `tests/factory/scripts/test_setup_workspace_sync.py`
+- **Learnings for future iterations:**
+  - Regression tests in `tests/factory/scripts/` already encoded the desired sync policy; implement helpers they reference (`origin_main_ref_exists`) rather than changing tests to match `git pull`.
+  - Use `git ls-remote origin refs/heads/main` to distinguish live remote main from stale `refs/remotes/origin/main` after remote branch deletion.
+  - Root sync skip due to dirty main checkout should still allow worktree creation; only ref fast-forward is blocked, not workspace setup.
+---
+
+## 2026-06-15T12:00:00Z - dynamic-workflows-recovery-setup-workspace-git-pull-hygiene-002
+- Added `branch_upstream_ref` and `sync_reused_worktree_branch` so reused worktrees skip non-fatal no-upstream pulls, log `Worktree branch sync:` outcomes, and fail with `Worktree preparation failed` when `git pull --ff-only` cannot proceed safely.
+- Extended `tests/factory/scripts/test_setup_workspace_worktree.py` with dirty-root reuse, no-upstream create/reuse, and diverged-branch unsafe-update coverage.
+- Files changed: `factory/scripts/setup-workspace.py`, `tests/factory/scripts/test_setup_workspace_worktree.py`
+- **Learnings for future iterations:**
+  - `git worktree add` fails when the target branch is already checked out at the root; integration tests that pre-create tracked branches must `git checkout main` before calling `setup-workspace`.
+  - Reuse-path branch sync should use `cwd=worktree_path` rather than `-C` from the repo root for clearer git subprocess boundaries.
+  - No-upstream is detectable via `git rev-parse --abbrev-ref branch@{upstream}` before attempting pull; treat pull stderr containing `no tracking information` as the same non-fatal skip.
 ---

--- a/tests/factory/scripts/test_setup_workspace_failures.py
+++ b/tests/factory/scripts/test_setup_workspace_failures.py
@@ -114,6 +114,35 @@ class SetupWorkspaceFailureTest(unittest.TestCase):
         self.assertNotIn("Worktree preparation failed", stderr)
         self.assertNotIn("PRD copy failed", stderr)
 
+    def test_reports_root_sync_failure_when_no_origin_and_local_main_missing(self):
+        init_local_repo(self.repo_path)
+        subprocess.run(
+            ["git", "checkout", "-b", "feature-branch"],
+            cwd=self.repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "update-ref", "-d", "refs/heads/main"],
+            cwd=self.repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "remote", "remove", "origin"],
+            cwd=self.repo_path,
+            check=False,
+        )
+
+        prd_name = "no-origin-missing-main-prd"
+        write_prd(self.repo_path, prd_name)
+
+        result = run_setup_workspace(self.repo_path, prd_name)
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("Root sync failed:", result.stderr)
+        self.assertIn("no origin remote", result.stderr.lower())
+        self.assertIn("refs/heads/main is missing", result.stderr)
+        self.assertNotIn("Worktree preparation failed", result.stderr)
+        self.assertNotIn("PRD copy failed", result.stderr)
+
     def test_reports_root_sync_failure_when_fetch_fails_without_local_main(self):
         bare_remote = self.repo_path / "remote.git"
         bare_remote.mkdir()

--- a/tests/factory/scripts/test_setup_workspace_failures.py
+++ b/tests/factory/scripts/test_setup_workspace_failures.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Regression tests for setup-workspace categorized failure output."""
+
+import importlib.util
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "factory" / "scripts" / "setup-workspace.py"
+
+
+def load_setup_workspace_module():
+    spec = importlib.util.spec_from_file_location("setup_workspace", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def init_local_repo(repo_path):
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo_path, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "setup-workspace-test@example.com"],
+        cwd=repo_path,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Setup Workspace Test"],
+        cwd=repo_path,
+        check=True,
+    )
+    readme = repo_path / "README.md"
+    readme.write_text("setup-workspace test repo\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=repo_path, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo_path, check=True)
+
+
+def write_prd(repo_path, prd_name, include_md=False):
+    tasks_dir = repo_path / "tasks" / "todo"
+    tasks_dir.mkdir(parents=True)
+    prd_json = tasks_dir / f"{prd_name}.json"
+    prd_json.write_text(
+        json.dumps({"branchName": prd_name}),
+        encoding="utf-8",
+    )
+    prd_md = None
+    if include_md:
+        prd_md = tasks_dir / f"{prd_name}.md"
+        prd_md.write_text(f"# {prd_name}\n", encoding="utf-8")
+    return prd_json, prd_md
+
+
+def run_setup_workspace(repo_path, prd_name):
+    return subprocess.run(
+        ["python3", str(SCRIPT_PATH), prd_name],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class SetupWorkspaceFailureTest(unittest.TestCase):
+    def setUp(self):
+        self.module = load_setup_workspace_module()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.repo_path = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def run_main_in_repo(self, prd_name):
+        stderr = io.StringIO()
+        original_cwd = os.getcwd()
+        os.chdir(self.repo_path)
+        try:
+            with mock.patch.object(sys, "argv", ["setup-workspace.py", prd_name]):
+                with redirect_stderr(stderr):
+                    with self.assertRaises(SystemExit) as raised:
+                        self.module.main()
+        finally:
+            os.chdir(original_cwd)
+        return raised.exception.code, stderr.getvalue()
+
+    def test_reports_root_sync_failure_with_concrete_reason(self):
+        init_local_repo(self.repo_path)
+        prd_name = "root-sync-fail-prd"
+        write_prd(self.repo_path, prd_name)
+
+        original_prune = self.module.prune_worktrees
+
+        def failing_prune(_repo_root):
+            raise RuntimeError(
+                "git worktree prune failed (exit 128): simulated prune failure"
+            )
+
+        self.module.prune_worktrees = failing_prune
+        try:
+            exit_code, stderr = self.run_main_in_repo(prd_name)
+        finally:
+            self.module.prune_worktrees = original_prune
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("Root sync failed:", stderr)
+        self.assertIn("simulated prune failure", stderr)
+        self.assertNotIn("Worktree preparation failed", stderr)
+        self.assertNotIn("PRD copy failed", stderr)
+
+    def test_reports_worktree_preparation_failure_without_root_sync_label(self):
+        bare_remote = self.repo_path / "remote.git"
+        bare_remote.mkdir()
+        subprocess.run(
+            ["git", "init", "--bare", "-b", "main"],
+            cwd=bare_remote,
+            check=True,
+        )
+
+        upstream = self.repo_path / "upstream"
+        upstream.mkdir()
+        init_local_repo(upstream)
+        subprocess.run(
+            ["git", "remote", "add", "origin", str(bare_remote)],
+            cwd=upstream,
+            check=True,
+        )
+        subprocess.run(["git", "push", "-u", "origin", "main"], cwd=upstream, check=True)
+
+        local_repo = self.repo_path / "local"
+        subprocess.run(
+            ["git", "clone", str(bare_remote), str(local_repo.name)],
+            cwd=self.repo_path,
+            check=True,
+        )
+
+        prd_name = "worktree-failure-prd"
+        write_prd(local_repo, prd_name)
+        subprocess.run(["git", "checkout", "-b", prd_name], cwd=local_repo, check=True)
+        (local_repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+        subprocess.run(["git", "add", "seed.txt"], cwd=local_repo, check=True)
+        subprocess.run(["git", "commit", "-m", "seed branch"], cwd=local_repo, check=True)
+        subprocess.run(
+            ["git", "push", "-u", "origin", prd_name],
+            cwd=local_repo,
+            check=True,
+        )
+        subprocess.run(["git", "checkout", "main"], cwd=local_repo, check=True)
+
+        first = run_setup_workspace(local_repo, prd_name)
+        self.assertEqual(first.returncode, 0, first.stderr)
+        worktree_path = Path(json.loads(first.stdout)["worktree"])
+
+        (worktree_path / "local-only.txt").write_text("local commit\n", encoding="utf-8")
+        subprocess.run(["git", "add", "local-only.txt"], cwd=worktree_path, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "diverge locally"],
+            cwd=worktree_path,
+            check=True,
+        )
+
+        subprocess.run(["git", "fetch", "origin"], cwd=upstream, check=True)
+        subprocess.run(
+            ["git", "checkout", "-B", prd_name, f"origin/{prd_name}"],
+            cwd=upstream,
+            check=True,
+        )
+        (upstream / "remote-only.txt").write_text("remote commit\n", encoding="utf-8")
+        subprocess.run(["git", "add", "remote-only.txt"], cwd=upstream, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "diverge on remote"],
+            cwd=upstream,
+            check=True,
+        )
+        subprocess.run(["git", "push", "origin", prd_name], cwd=upstream, check=True)
+        subprocess.run(["git", "fetch", "origin"], cwd=local_repo, check=True)
+
+        second = run_setup_workspace(local_repo, prd_name)
+        self.assertEqual(second.returncode, 1, second.stdout)
+        self.assertIn("Worktree preparation failed:", second.stderr)
+        self.assertIn("worktree branch update failed", second.stderr.lower())
+        self.assertNotIn("Root sync failed", second.stderr)
+        self.assertNotIn("PRD copy failed", second.stderr)
+
+    def test_reports_prd_copy_failure_after_worktree_preparation(self):
+        init_local_repo(self.repo_path)
+        prd_name = "prd-copy-fail-prd"
+        prd_json, _ = write_prd(self.repo_path, prd_name)
+
+        first = run_setup_workspace(self.repo_path, prd_name)
+        self.assertEqual(first.returncode, 0, first.stderr)
+        worktree_path = Path(json.loads(first.stdout)["worktree"])
+        dest_json = worktree_path / "prd.json"
+        dest_json.chmod(0o444)
+
+        prd_json.write_text(
+            json.dumps({"branchName": prd_name, "updated": True}),
+            encoding="utf-8",
+        )
+
+        try:
+            second = run_setup_workspace(self.repo_path, prd_name)
+        finally:
+            dest_json.chmod(0o644)
+
+        self.assertEqual(second.returncode, 1, second.stdout)
+        self.assertIn("PRD copy failed:", second.stderr)
+        self.assertIn("Permission denied", second.stderr)
+        self.assertNotIn("Root sync failed", second.stderr)
+        self.assertNotIn("Worktree preparation failed", second.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/factory/scripts/test_setup_workspace_failures.py
+++ b/tests/factory/scripts/test_setup_workspace_failures.py
@@ -114,6 +114,55 @@ class SetupWorkspaceFailureTest(unittest.TestCase):
         self.assertNotIn("Worktree preparation failed", stderr)
         self.assertNotIn("PRD copy failed", stderr)
 
+    def test_reports_root_sync_failure_when_fetch_fails_without_local_main(self):
+        bare_remote = self.repo_path / "remote.git"
+        bare_remote.mkdir()
+        subprocess.run(
+            ["git", "init", "--bare", "-b", "main"],
+            cwd=bare_remote,
+            check=True,
+        )
+
+        local_repo = self.repo_path / "local"
+        subprocess.run(
+            ["git", "clone", str(bare_remote), str(local_repo.name)],
+            cwd=self.repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "checkout", "-b", "feature-branch"],
+            cwd=local_repo,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "update-ref", "-d", "refs/heads/main"],
+            cwd=local_repo,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "update-ref", "-d", "refs/remotes/origin/main"],
+            cwd=local_repo,
+            check=True,
+        )
+
+        unreachable_remote = self.repo_path / "missing-remote.git"
+        subprocess.run(
+            ["git", "remote", "set-url", "origin", str(unreachable_remote)],
+            cwd=local_repo,
+            check=True,
+        )
+
+        prd_name = "blocking-root-sync-prd"
+        write_prd(local_repo, prd_name)
+
+        result = run_setup_workspace(local_repo, prd_name)
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("Root sync failed:", result.stderr)
+        self.assertIn("fetch failed", result.stderr.lower())
+        self.assertIn("refs/heads/main is missing", result.stderr)
+        self.assertNotIn("Worktree preparation failed", result.stderr)
+        self.assertNotIn("PRD copy failed", result.stderr)
+
     def test_reports_worktree_preparation_failure_without_root_sync_label(self):
         bare_remote = self.repo_path / "remote.git"
         bare_remote.mkdir()

--- a/tests/factory/scripts/test_setup_workspace_sync.py
+++ b/tests/factory/scripts/test_setup_workspace_sync.py
@@ -357,6 +357,74 @@ class SetupWorkspaceSyncTest(unittest.TestCase):
         self.assertTrue((worktree_path / "prd.json").exists())
         self.assertEqual(payload["branch"], prd_name)
 
+    def test_setup_workspace_creates_worktree_with_staged_root_changes(self):
+        local_repo = self.repo_path / "local"
+        setup_repo_with_origin_main_ahead(local_repo, self.repo_path)
+
+        staged_file = local_repo / "staged.txt"
+        staged_file.write_text("staged change\n", encoding="utf-8")
+        git(["add", "staged.txt"], local_repo)
+
+        prd_name = "staged-root-prd"
+        tasks_dir = local_repo / "tasks" / "todo"
+        tasks_dir.mkdir(parents=True)
+        prd_json = tasks_dir / f"{prd_name}.json"
+        prd_json.write_text(
+            json.dumps({"branchName": prd_name}),
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            ["python3", str(SCRIPT_PATH), prd_name],
+            cwd=local_repo,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("A  staged.txt", git(["status", "--porcelain"], local_repo).stdout)
+        self.assertIn("?? dirty.txt", git(["status", "--porcelain"], local_repo).stdout)
+        self.assertEqual(
+            staged_file.read_text(encoding="utf-8"),
+            "staged change\n",
+        )
+        payload = json.loads(result.stdout)
+        worktree_path = Path(payload["worktree"])
+        self.assertTrue(worktree_path.exists())
+        self.assertTrue((worktree_path / "prd.json").exists())
+        self.assertIn("Root sync:", result.stderr)
+
+    def test_setup_workspace_reports_sync_skip_on_dirty_main_checkout(self):
+        local_repo = self.repo_path / "local"
+        setup_repo_with_origin_main_ahead(local_repo, self.repo_path)
+        git(["checkout", "main"], local_repo)
+
+        dirty_file = local_repo / "dirty-main.txt"
+        dirty_file.write_text("dirty on main\n", encoding="utf-8")
+
+        prd_name = "dirty-main-prd"
+        tasks_dir = local_repo / "tasks" / "todo"
+        tasks_dir.mkdir(parents=True)
+        prd_json = tasks_dir / f"{prd_name}.json"
+        prd_json.write_text(
+            json.dumps({"branchName": prd_name}),
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            ["python3", str(SCRIPT_PATH), prd_name],
+            cwd=local_repo,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Root sync:", result.stderr)
+        self.assertIn("local changes", result.stderr.lower())
+        self.assertIn("?? dirty-main.txt", git(["status", "--porcelain"], local_repo).stdout)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/factory/scripts/test_setup_workspace_worktree.py
+++ b/tests/factory/scripts/test_setup_workspace_worktree.py
@@ -338,7 +338,7 @@ class SetupWorkspaceWorktreeTest(unittest.TestCase):
         second = run_setup_workspace(local_repo, prd_name)
         self.assertEqual(second.returncode, 1, second.stdout)
         self.assertIn("Worktree preparation failed", second.stderr)
-        self.assertNotIn("Git sync failed", second.stderr)
+        self.assertNotIn("Root sync failed", second.stderr)
         self.assertIn("worktree branch update failed", second.stderr.lower())
 
 

--- a/tests/factory/scripts/test_setup_workspace_worktree.py
+++ b/tests/factory/scripts/test_setup_workspace_worktree.py
@@ -72,6 +72,32 @@ def write_prd(repo_path, prd_name, include_md=False):
     return prd_json, prd_md
 
 
+def setup_repo_with_origin_main_ahead(local_repo, repo_root):
+    """Create a bare remote ahead of local main; local repo on a feature branch."""
+    bare_remote = repo_root / "remote.git"
+    bare_remote.mkdir()
+    git(["init", "--bare", "-b", "main"], bare_remote)
+
+    upstream = repo_root / "upstream"
+    upstream.mkdir()
+    init_local_repo(upstream)
+    git(["remote", "add", "origin", str(bare_remote)], upstream)
+    git(["push", "-u", "origin", "main"], upstream)
+
+    (upstream / "ahead.txt").write_text("origin is ahead\n", encoding="utf-8")
+    git(["add", "ahead.txt"], upstream)
+    git(["commit", "-m", "advance origin main"], upstream)
+    git(["push", "origin", "main"], upstream)
+
+    git(["clone", str(bare_remote), str(local_repo.name)], repo_root)
+    git(["reset", "--hard", "HEAD~1"], local_repo)
+    git(["checkout", "-b", "feature-branch"], local_repo)
+    (local_repo / "dirty.txt").write_text("unstaged change\n", encoding="utf-8")
+    git(["fetch", "origin"], local_repo)
+
+    return bare_remote
+
+
 def run_setup_workspace(repo_path, prd_name):
     return subprocess.run(
         ["python3", str(SCRIPT_PATH), prd_name],
@@ -210,6 +236,110 @@ class SetupWorkspaceWorktreeTest(unittest.TestCase):
         self.assertTrue((worktree_path / "prd.json").exists())
         self.assertFalse((worktree_path / "prd.md").exists())
         self.assertIsNone(payload["prd_md_path"])
+
+    def test_reuses_valid_worktree_when_root_has_staged_changes(self):
+        local_repo = self.repo_path / "local"
+        setup_repo_with_origin_main_ahead(local_repo, self.repo_path)
+
+        staged_file = local_repo / "staged.txt"
+        staged_file.write_text("staged change\n", encoding="utf-8")
+        git(["add", "staged.txt"], local_repo)
+
+        prd_name = "reuse-dirty-root-prd"
+        write_prd(local_repo, prd_name)
+
+        first = run_setup_workspace(local_repo, prd_name)
+        self.assertEqual(first.returncode, 0, first.stderr)
+        first_payload = json.loads(first.stdout)
+        marker = Path(first_payload["worktree"]) / "reuse-marker.txt"
+        marker.write_text("keep me\n", encoding="utf-8")
+
+        second = run_setup_workspace(local_repo, prd_name)
+        self.assertEqual(second.returncode, 0, second.stderr)
+        second_payload = json.loads(second.stdout)
+        self.assertTrue(second_payload["reused"])
+        self.assertEqual(second_payload["worktree"], first_payload["worktree"])
+        self.assertTrue(marker.exists())
+        self.assertIn("A  staged.txt", git(["status", "--porcelain"], local_repo).stdout)
+        self.assertIn("?? dirty.txt", git(["status", "--porcelain"], local_repo).stdout)
+
+    def test_creates_worktree_when_branch_has_no_upstream(self):
+        init_local_repo(self.repo_path)
+        prd_name = "no-upstream-create-prd"
+        write_prd(self.repo_path, prd_name)
+
+        result = run_setup_workspace(self.repo_path, prd_name)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        payload = json.loads(result.stdout)
+        worktree_path = Path(payload["worktree"])
+        self.assertTrue(worktree_path.exists())
+        self.assertIsNone(self.module.branch_upstream_ref(worktree_path, prd_name))
+
+    def test_reuses_worktree_when_branch_has_no_upstream(self):
+        init_local_repo(self.repo_path)
+        prd_name = "no-upstream-reuse-prd"
+        write_prd(self.repo_path, prd_name)
+
+        first = run_setup_workspace(self.repo_path, prd_name)
+        self.assertEqual(first.returncode, 0, first.stderr)
+        first_payload = json.loads(first.stdout)
+        worktree_path = Path(first_payload["worktree"])
+        self.assertIsNone(self.module.branch_upstream_ref(worktree_path, prd_name))
+        marker = worktree_path / "reuse-marker.txt"
+        marker.write_text("keep me\n", encoding="utf-8")
+
+        second = run_setup_workspace(self.repo_path, prd_name)
+        self.assertEqual(second.returncode, 0, second.stderr)
+        second_payload = json.loads(second.stdout)
+        self.assertTrue(second_payload["reused"])
+        self.assertTrue(marker.exists())
+        self.assertIn("no upstream", second.stderr.lower())
+
+    def test_reports_worktree_preparation_failure_when_branch_update_unsafe(self):
+        bare_remote = self.repo_path / "remote.git"
+        bare_remote.mkdir()
+        git(["init", "--bare", "-b", "main"], bare_remote)
+
+        upstream = self.repo_path / "upstream"
+        upstream.mkdir()
+        init_local_repo(upstream)
+        git(["remote", "add", "origin", str(bare_remote)], upstream)
+        git(["push", "-u", "origin", "main"], upstream)
+
+        local_repo = self.repo_path / "local"
+        git(["clone", str(bare_remote), str(local_repo.name)], self.repo_path)
+
+        prd_name = "unsafe-branch-update-prd"
+        write_prd(local_repo, prd_name)
+        git(["checkout", "-b", prd_name], local_repo)
+        (local_repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+        git(["add", "seed.txt"], local_repo)
+        git(["commit", "-m", "seed branch"], local_repo)
+        git(["push", "-u", "origin", prd_name], local_repo)
+        git(["checkout", "main"], local_repo)
+
+        first = run_setup_workspace(local_repo, prd_name)
+        self.assertEqual(first.returncode, 0, first.stderr)
+        worktree_path = Path(json.loads(first.stdout)["worktree"])
+
+        (worktree_path / "local-only.txt").write_text("local commit\n", encoding="utf-8")
+        git(["add", "local-only.txt"], worktree_path)
+        git(["commit", "-m", "diverge locally"], worktree_path)
+
+        git(["fetch", "origin"], upstream)
+        git(["checkout", "-B", prd_name, f"origin/{prd_name}"], upstream)
+        (upstream / "remote-only.txt").write_text("remote commit\n", encoding="utf-8")
+        git(["add", "remote-only.txt"], upstream)
+        git(["commit", "-m", "diverge on remote"], upstream)
+        git(["push", "origin", prd_name], upstream)
+        git(["fetch", "origin"], local_repo)
+
+        second = run_setup_workspace(local_repo, prd_name)
+        self.assertEqual(second.returncode, 1, second.stdout)
+        self.assertIn("Worktree preparation failed", second.stderr)
+        self.assertNotIn("Git sync failed", second.stderr)
+        self.assertIn("worktree branch update failed", second.stderr.lower())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "dynamic-workflows-recovery-setup-workspace-git-pull-hygiene",
  "description": "Repair shared setup-workspace behavior so executor worktrees can be created or reused from safe local repository state even when the root checkout has pull-blocking local changes, while preserving user work, emitting categorized setup failures, and proving dirty-root, no-upstream, and reusable-worktree behavior with focused verification.",
  "context": {
    "customerAsk": "Repair shared setup-workspace behavior so a plan lane can create or reuse its executor worktree even when the root repository has staged or otherwise pull-blocking local changes, while preserving user work, emitting concrete failure diagnostics, and leaving a clear next step for requeueing the blocked MCP-install plan lanes.",
    "problem": "The current setup-workspace script unconditionally runs a root-level git pull before any worktree reuse or creation, so dirty root state blocks unrelated plan lanes before they reach safe reusable-worktree or local-state creation paths, and the resulting failure output is too generic for later queue recovery to classify confidently.",
    "solution": "Make root sync a safe, explicit prerequisite rather than an unconditional blocker, continue workspace setup from local repository state when dirty-root or no-upstream conditions allow it, preserve existing valid worktree reuse, and emit stage-specific failure diagnostics for root sync, worktree preparation, and PRD copy outcomes backed by focused regression coverage."
  },
  "acceptanceCriteria": [
    "setup-workspace can create a new executor worktree from local repository state when the root checkout has staged or otherwise pull-blocking local changes, without resetting, overwriting, or unstaging that root state.",
    "setup-workspace can reuse an existing valid executor worktree when the root checkout cannot be pulled, and reusable-worktree preparation still completes when no additional sync is required.",
    "Root sync behavior still treats no-upstream configuration as non-fatal when local state is sufficient for workspace preparation.",
    "Failure output identifies whether setup stopped during root sync, worktree preparation, or PRD copy so later planner or queue-repair passes do not need to guess.",
    "The fix stays within shared workspace-preparation behavior, preserves current Factory and worktree vocabulary, and leaves a clear rerun-and-requeue path for the blocked MCP-install plan lanes.",
    "Typecheck, lint, and focused tests for setup-workspace behavior pass."
  ],
  "userStories": [
    {
      "id": "dynamic-workflows-recovery-setup-workspace-git-pull-hygiene-001",
      "title": "Continue workspace setup when root sync is blocked by local changes",
      "description": "As a maintainer recovering blocked plan lanes, I want workspace setup to continue from safe local repository state when root pull is blocked by local changes so executor worktrees can still be created without mutating the root checkout.",
      "acceptanceCriteria": [
        "When the root checkout has staged or otherwise pull-blocking local changes, running setup-workspace does not reset, overwrite, or unstage those root changes.",
        "In the same dirty-root scenario, setup-workspace can still create the expected executor worktree for a PRD lane when the local repository already has enough history to do so safely.",
        "If root sync is skipped or downgraded because local changes would block pull, the observable script output makes that outcome explicit.",
        "The story remains limited to shared workspace-preparation behavior and does not introduce separate workflow-run terminology or unrelated git tooling cleanup.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "dynamic-workflows-recovery-setup-workspace-git-pull-hygiene-002",
      "title": "Reuse existing worktrees and preserve no-upstream behavior",
      "description": "As a maintainer rerunning blocked work items, I want reusable-worktree and no-upstream cases to keep working under the repaired sync policy so existing plan lanes can recover without extra manual branch repair.",
      "acceptanceCriteria": [
        "When the expected executor worktree already exists and is valid, setup-workspace reuses it successfully even if the root checkout has pull-blocking local changes.",
        "When the repository branch has no upstream configured, setup-workspace still treats that condition as non-fatal and can continue to reuse or create the executor worktree from local state.",
        "If a reusable worktree needs its own branch update and that update cannot proceed safely, the script reports that failure as a worktree-preparation problem rather than a generic root-sync error.",
        "Focused verification covers reusable-worktree and no-upstream paths without depending on unrelated dynamic-workflow runtime, API, or MCP-install behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "dynamic-workflows-recovery-setup-workspace-git-pull-hygiene-003",
      "title": "Emit categorized setup failures that support queue recovery",
      "description": "As a later planner or queue-repair pass, I want setup-workspace failures categorized by stage so I can distinguish root sync failure, worktree preparation failure, and PRD copy failure without guessing.",
      "acceptanceCriteria": [
        "When root sync truly fails in a way that should still block setup, the script emits failure output that identifies the root-sync stage and the concrete blocking reason.",
        "When worktree creation or reuse fails, the script emits failure output that identifies the worktree-preparation stage and preserves the actionable git or filesystem reason.",
        "When PRD artifact copy fails after worktree preparation, the script emits failure output that identifies the PRD-copy stage separately from git setup failures.",
        "Failure output is concrete enough that a reviewer can map a blocked lane to the right follow-up action, including rerunning workspace setup and requeueing blocked MCP-install plan lanes after the shared blocker is fixed.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)