### PR TITLE
work-relationships-current-selection-graph-repair

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ factory/inputs/**
 !factory/inputs/BATCH/
 !factory/inputs/BATCH/default/
 !factory/inputs/BATCH/default/.gitkeep
+!factory/inputs/BATCH/default/factory-batch-local-agent-cli-runtime.json
 !factory/inputs/idea/
 !factory/inputs/idea/default/
 !factory/inputs/idea/default/.gitkeep

--- a/factory/inputs/BATCH/default/factory-batch-local-agent-cli-runtime.json
+++ b/factory/inputs/BATCH/default/factory-batch-local-agent-cli-runtime.json
@@ -1,0 +1,152 @@
+{
+  "requestId": "local-agent-cli-runtime-20260615",
+  "type": "FACTORY_REQUEST_BATCH",
+  "works": [
+    {
+      "name": "local-agent-cli-modelhost-data-plane",
+      "workTypeName": "task",
+      "payload": {
+        "title": "Model host data plane",
+        "sourcePath": "docs/temp/local-agent-cli/prd-modelhost-data-plane.md",
+        "planPath": "docs/temp/local-agent-cli/plan-runtime-taxonomy-and-model-host.md",
+        "currentProgress": [
+          "The repo already has managed runtime readiness, pull, and invocation surfaces through /models and pkg/localmodels.",
+          "The current local runtime is scoped to OmniVoice llama.cpp TTS behavior rather than a reusable model host boundary.",
+          "No clear pkg/modelhost data-plane package exists yet for assets, process supervision, readiness, leases, unload policy, and resource pressure."
+        ],
+        "requestedOutcome": "Create the modelhost boundary that owns model assets, process lifecycle, readiness, pull/install integration, leases, and provider-neutral failure classes while preserving existing managed-runtime API behavior."
+      }
+    },
+    {
+      "name": "local-agent-cli-inference-worker-run",
+      "workTypeName": "idea",
+      "payload": {
+        "title": "Inference worker and inference run",
+        "sourcePath": "docs/temp/local-agent-cli/prd-inference-worker-and-run.md",
+        "planPath": "docs/temp/local-agent-cli/plan-runtime-taxonomy-and-model-host.md",
+        "currentProgress": [
+          "OmniVoice TTS can already run through local model invocation surfaces, but it is still exposed as MODEL_WORKER and MODEL_INVOKE.",
+          "The codebase has operation binding and WorkContent output concepts that should be reused for one-shot inference.",
+          "llama.cpp text inference is not yet generalized as an INFERENCE_WORKER / INFERENCE_RUN path."
+        ],
+        "requestedOutcome": "Make harnessless model calls explicit inference behavior, preserve legacy OmniVoice compatibility, and route local llama.cpp text operations through modelhost leases and canonical WorkContent output."
+      }
+    },
+    {
+      "name": "local-agent-cli-agent-worker-run",
+      "workTypeName": "idea",
+      "payload": {
+        "title": "Agent worker and agent run",
+        "sourcePath": "docs/temp/local-agent-cli/prd-agent-worker-and-run.md",
+        "planPath": "docs/temp/local-agent-cli/plan-runtime-taxonomy-and-model-host.md",
+        "currentProgress": [
+          "The repo has model workers and script workers, but agentic harness-backed execution is not separated from default inference.",
+          "The requested harness is portpowered/go-agent-harness, using its agent-loop and gateway-oriented packages as libraries rather than as the user-facing CLI.",
+          "Tool execution must remain explicit factory or worker policy, not implicit model-host behavior."
+        ],
+        "requestedOutcome": "Add AGENT_WORKER / AGENT_RUN behavior backed by go-agent-harness, using modelhost-backed inferencer leases and explicit tool policy while mapping final output and diagnostics back to canonical factory results."
+      }
+    },
+    {
+      "name": "local-agent-cli-model-runtime-cli-api",
+      "workTypeName": "idea",
+      "payload": {
+        "title": "CLI and API model runtime experience",
+        "sourcePath": "docs/temp/local-agent-cli/prd-cli-api-model-runtime-experience.md",
+        "planPath": "docs/temp/local-agent-cli/plan-runtime-taxonomy-and-model-host.md",
+        "currentProgress": [
+          "Managed runtime APIs and you models commands already exist for listing, inspect, pull, and invocation.",
+          "The CLI/API language still reflects the old model-worker vocabulary and only proves the current local model slice.",
+          "The desired customer experience is Ollama-like without exposing raw llama.cpp internals in primary output."
+        ],
+        "requestedOutcome": "Update CLI, API, errors, docs, and invocation equivalence so users can list, inspect, pull, and run local inference or agent models with clear stdout/stderr and managed-runtime vocabulary."
+      }
+    },
+    {
+      "name": "local-agent-cli-runtime-configuration-ui",
+      "workTypeName": "idea",
+      "payload": {
+        "title": "Runtime configuration UI",
+        "sourcePath": "docs/temp/local-agent-cli/prd-runtime-configuration-ui.md",
+        "planPath": "docs/temp/local-agent-cli/plan-runtime-taxonomy-and-model-host.md",
+        "currentProgress": [
+          "The dashboard already edits workers, resources, operation metadata, and model invocation bindings.",
+          "The UI still presents raw or legacy model worker concepts rather than clear inference and agent choices.",
+          "Model readiness should be observed from /models server state and must not become durable UI-only state."
+        ],
+        "requestedOutcome": "Update the dashboard to configure inference workers, agent workers, model resources, and readiness status through canonical factory config and generated OpenAPI types."
+      }
+    },
+    {
+      "name": "local-agent-cli-runtime-loopback",
+      "workTypeName": "thoughts",
+      "payload": {
+        "title": "Meta-planner follow-up for local agent CLI runtime batch",
+        "sourcePath": "docs/temp/local-agent-cli/factory-batch-local-agent-cli-runtime.json",
+        "requestedOutcome": "Review the queued runtime work items after their plans are generated and decide whether to submit the next dependency-aware implementation batch."
+      }
+    }
+  ],
+  "relations": [
+    {
+      "type": "DEPENDS_ON",
+      "sourceWorkName": "local-agent-cli-inference-worker-run",
+      "targetWorkName": "local-agent-cli-modelhost-data-plane",
+      "requiredState": "complete"
+    },
+    {
+      "type": "DEPENDS_ON",
+      "sourceWorkName": "local-agent-cli-agent-worker-run",
+      "targetWorkName": "local-agent-cli-inference-worker-run",
+      "requiredState": "complete"
+    },
+    {
+      "type": "DEPENDS_ON",
+      "sourceWorkName": "local-agent-cli-model-runtime-cli-api",
+      "targetWorkName": "local-agent-cli-inference-worker-run",
+      "requiredState": "complete"
+    },
+    {
+      "type": "DEPENDS_ON",
+      "sourceWorkName": "local-agent-cli-model-runtime-cli-api",
+      "targetWorkName": "local-agent-cli-agent-worker-run",
+      "requiredState": "complete"
+    },
+    {
+      "type": "DEPENDS_ON",
+      "sourceWorkName": "local-agent-cli-runtime-configuration-ui",
+      "targetWorkName": "local-agent-cli-model-runtime-cli-api",
+      "requiredState": "complete"
+    },
+    {
+      "type": "DEPENDS_ON",
+      "sourceWorkName": "local-agent-cli-runtime-loopback",
+      "targetWorkName": "local-agent-cli-modelhost-data-plane",
+      "requiredState": "complete"
+    },
+    {
+      "type": "DEPENDS_ON",
+      "sourceWorkName": "local-agent-cli-runtime-loopback",
+      "targetWorkName": "local-agent-cli-inference-worker-run",
+      "requiredState": "complete"
+    },
+    {
+      "type": "DEPENDS_ON",
+      "sourceWorkName": "local-agent-cli-runtime-loopback",
+      "targetWorkName": "local-agent-cli-agent-worker-run",
+      "requiredState": "complete"
+    },
+    {
+      "type": "DEPENDS_ON",
+      "sourceWorkName": "local-agent-cli-runtime-loopback",
+      "targetWorkName": "local-agent-cli-model-runtime-cli-api",
+      "requiredState": "complete"
+    },
+    {
+      "type": "DEPENDS_ON",
+      "sourceWorkName": "local-agent-cli-runtime-loopback",
+      "targetWorkName": "local-agent-cli-runtime-configuration-ui",
+      "requiredState": "complete"
+    }
+  ]
+}

--- a/pkg/cli/submit/batch_test.go
+++ b/pkg/cli/submit/batch_test.go
@@ -794,6 +794,37 @@ func TestSubmitBatch_UsesDocsExampleStartupWorkFile(t *testing.T) {
 	}
 }
 
+func TestSubmitBatch_DryRunLocalAgentCliRuntimeBatchExample(t *testing.T) {
+	path := testutil.MustRepoPath(
+		t,
+		"factory/inputs/BATCH/default/factory-batch-local-agent-cli-runtime.json",
+	)
+
+	var out bytes.Buffer
+	err := SubmitBatch(BatchConfig{
+		Args:   []string{path},
+		DryRun: true,
+		Server: "http://127.0.0.1:1",
+		Output: &out,
+	})
+	if err != nil {
+		t.Fatalf("SubmitBatch dry-run on local agent CLI runtime batch example: %v", err)
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		"requestId: local-agent-cli-runtime-20260615",
+		"work count: 6",
+		"relationCount: 10",
+		"local-agent-cli-runtime-loopback",
+		"dry-run: no request sent",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func writeBatchFile(t *testing.T, content string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "batch.json")

--- a/prd.json
+++ b/prd.json
@@ -1,0 +1,75 @@
+{
+  "project": "Current Selection Work Relationships Graph Repair",
+  "branchName": "work-relationships-current-selection-graph-repair",
+  "description": "Repair the current-selection work relationships graph so it shows every supported relationship instance for the selected work item, including repeated DEPENDS_ON relationships, and improve node readability with clearer colors and non-clipping labels.",
+  "context": {
+    "customerAsk": "Currently, on the work relationships graph of a current selection, only a single relationship is presented when multiple can be presented. For example, if you have two DEPENDS_ON relationships, only the first is presented on the graph. Fix this so all relationships are present. Also make the work selection's nodes less inscrutable by using a different color similar to workstation nodes in the factory graph, and prevent text from getting cut off by using a smaller font or wrapping onto the next line.",
+    "problem": "The current-selection work-item detail graph does not fully represent repeated relationship instances, so customers can miss real dependencies when a selected work item has more than one relation of the same type. The graph is also hard to read because relationship nodes use an unclear visual treatment and long labels clip inside the node shell.",
+    "solution": "Preserve every supported relationship instance through the selected-work relationship graph model and rendered current-selection graph, then update relationship-node styling to use a clearer palette and readable label layout so operators can see all related work and understand the graph at a glance."
+  },
+  "acceptanceCriteria": [
+    "The current-selection work relationships graph shows every supported relationship instance for the selected work item instead of collapsing repeated relationships of the same type.",
+    "A selected work item with two distinct DEPENDS_ON relationships renders both dependency nodes and both dependency edges on the graph.",
+    "The concrete batch example in factory/inputs/BATCH/default/factory-batch-local-agent-cli-runtime.json can be used to reproduce and verify that multiple relationships now appear together.",
+    "Related-work node selection from the graph remains keyboard-accessible and continues to switch current selection to the clicked or activated related work item.",
+    "Relationship graph nodes use a more distinctive non-neutral palette aligned with workstation-node readability in the factory graph while preserving clear emphasis for the currently selected work item.",
+    "Long relationship-node labels remain readable at common current-selection card widths without clipping outside the node shell.",
+    "Quality gate: UI typecheck, lint, relevant automated tests, and browser verification pass."
+  ],
+  "userStories": [
+    {
+      "id": "work-relationships-current-selection-graph-repair-001",
+      "title": "Preserve all relationship instances for selected work",
+      "description": "As a maintainer, I want the selected-work relationship graph model to retain every supported relationship instance so the current-selection graph can represent multiple dependencies and parent relations accurately.",
+      "acceptanceCriteria": [
+        "Building the current-selection selected-work relationship graph keeps every supported relationship instance connected to the selected work item instead of collapsing repeated relationships by relationship type alone.",
+        "When one selected work item has two distinct DEPENDS_ON relations to two different target work items, the ready graph contains two dependency edges and both related work nodes.",
+        "Existing supported relationship kinds for this graph (DEPENDS_ON and PARENT_CHILD as rendered parent relationships) continue to project correctly alongside repeated dependency relationships.",
+        "The projected graph remains deterministic for the same input snapshot so reviewers can compare outputs reliably in tests.",
+        "Focused regression tests cover the repeated-DEPENDS_ON case and a mixed dependency-plus-parent case.",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 1,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "work-relationships-current-selection-graph-repair-002",
+      "title": "Render every relationship on the current-selection work graph",
+      "description": "As a dashboard operator, I want the work relationships graph in current selection to show every related work item and edge so I can understand all of the selected work's dependencies and lineage from one place.",
+      "acceptanceCriteria": [
+        "In the current-selection work-item detail card, the Work relationships region renders all related nodes and all relationship edges present in the ready selected-work relationship graph.",
+        "Repeated DEPENDS_ON relations do not disappear simply because they share the same relationship label; each distinct related work item is visible and selectable from the graph.",
+        "Activating each related-work node by click or keyboard still calls the existing current-selection work-switch action for that related work item.",
+        "Loading, empty, and error states for the Work relationships region remain explicit and unchanged in meaning.",
+        "Browser-visible verification covers the concrete batch example and confirms that multiple dependency relationships appear at the same time in current selection.",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 2,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "work-relationships-current-selection-graph-repair-003",
+      "title": "Make relationship nodes readable and scannable",
+      "description": "As a dashboard operator, I want relationship nodes in the current-selection graph to have clearer colors and readable labels so I can identify the selected work and related work items without fighting the layout.",
+      "acceptanceCriteria": [
+        "Relationship nodes in current selection use a more distinctive palette aligned with the workstation-node readability standard in the factory graph rather than the current inscrutable neutral treatment.",
+        "The currently selected work item still has a clearly stronger emphasis than surrounding related-work nodes after the palette update.",
+        "Long node labels no longer truncate awkwardly; labels wrap to additional lines, use a smaller readable font, or both, while staying inside the node shell.",
+        "Readability improvements hold at common current-selection card widths, including narrower dashboard layouts, without text overlapping adjacent chrome.",
+        "Accessible contrast, focus styling, and keyboard activation remain intact after the node styling update.",
+        "Focused component or integration coverage proves the new node classes and non-clipping text behavior for long labels.",
+        "Typecheck passes",
+        "Tests pass",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 3,
+      "passes": false,
+      "notes": ""
+    }
+  ]
+}

--- a/prd.md
+++ b/prd.md
@@ -1,175 +1,122 @@
-# PRD: Wire Real-Backend Factory Session Lifecycle-Control APIs
-
-## Introduction
-
-Customers can already use the real durable JavaScript Factory Session backend for start, list, get, result, events, dispatch reads, and artifact reads. The remaining backend API parity gap is lifecycle control: durable session clients still receive `501` stubs or incomplete behavior when they try to pause, resume, cancel, terminate, approve, or retry dispatches through the public Factory Session API.
-
-This work routes the existing lifecycle-control routes under `/factory-sessions/{session_id}` through the durable backend service and shared API surface mappers. HTTP clients should receive typed lifecycle-control success, no-op, invalid-state, terminal-session, conflict, and not-found responses while existing live Petri session compatibility remains intact for non-durable session IDs.
+# PRD: Current Selection Work Relationships Graph Repair
 
 ## Context
 
-### Customer Ask
+### Customer ask
 
-Wire real-backend Factory Session lifecycle-control APIs so HTTP clients can pause, resume, cancel, terminate, approve, and retry durable JavaScript Factory Sessions through the shared Factory Session API instead of receiving `501` stubs.
+On the current-selection work relationships graph, only one relationship is shown when multiple relationships of the same kind should be shown. For example, when a selected work item has two `DEPENDS_ON` relationships, only the first appears on the graph. The customer also wants the relationship nodes to be easier to read: use more distinctive colors similar to workstation nodes in the factory graph, and prevent node text from being cut off by wrapping it or reducing font size.
 
 ### Problem
 
-The real-backend session parity and dispatch/artifact parity slices are complete, but lifecycle-control endpoints are still the route family explicitly left as deferred stubs. This blocks generated clients and API consumers from controlling durable JavaScript sessions through the same typed public API they use for reads and inspection. It also leaves typed control errors, idempotent request handling, and inspection-link behavior unproven at the HTTP boundary.
+The current-selection work-item detail uses a shared relationship graph surface, but repeated relationship instances are not fully represented to the customer. This creates an inaccurate graph for selected work items with multiple dependencies and can hide required upstream work. Separately, the relationship nodes are visually flat and label text clips inside the node shell, making the graph difficult to scan and hard to trust.
 
 ### Solution
 
-Replace durable lifecycle-control stubs with handlers that route durable session IDs to the `factorysessionexecution.Service` lifecycle methods through `FactoryService` and shared `pkg/apisurface/factorysession` mappers. Use the real durable JavaScript runtime service for at least cancel or terminate loopback coverage, use fixture-backed fake service scenarios where real runtime support is not yet available, preserve existing live Petri behavior for non-durable IDs, and keep OpenAPI/generated clients synchronized if contract corrections are required.
+Preserve every supported relationship instance from the selected-work relationship data through graph projection and rendering, including repeated `DEPENDS_ON` edges with different targets. Then update the current-selection relationship-node presentation to use a clearer palette aligned with the factory graph's workstation-node treatment and make node labels readable by wrapping or shrinking text within the node bounds. Lock the behavior with fixture-based regression coverage using the factory batch example the customer called out and direct browser verification on the current-selection graph.
+
+## Project-level acceptance criteria
+
+- [ ] The current-selection work relationships graph shows every supported relationship instance for the selected work item instead of collapsing repeated relationships of the same type.
+- [ ] A selected work item with two distinct `DEPENDS_ON` relationships renders both dependency nodes and both dependency edges on the graph.
+- [ ] The concrete batch example in [factory-batch-local-agent-cli-runtime.json](/Users/abdifamily/infinite-you/factory/inputs/BATCH/default/factory-batch-local-agent-cli-runtime.json) can be used to reproduce and verify that multiple relationships now appear together.
+- [ ] Related-work node selection from the graph remains keyboard-accessible and continues to switch current selection to the clicked or activated related work item.
+- [ ] Relationship graph nodes use a more distinctive non-neutral palette aligned with workstation-node readability in the factory graph while preserving clear emphasis for the currently selected work item.
+- [ ] Long relationship-node labels remain readable at common current-selection card widths without clipping outside the node shell.
+- [ ] Quality gate: UI typecheck, lint, relevant automated tests, and browser verification pass.
 
 ## Goals
 
-- Return typed lifecycle-control responses for durable cancel and terminate instead of `501` stubs.
-- Return typed pause and resume success or invalid-state/conflict responses through shared service and mapper code.
-- Wire approve and retry-dispatch through the same durable lifecycle-control API boundary, with fixture-backed coverage acceptable where runtime scenarios are not yet available.
-- Preserve generated response vocabulary for typed errors, including operation, outcome, status, and inspection links when available.
-- Map missing durable sessions to the existing typed not-found API shape.
-- Preserve prior start/list/get/result/events and dispatch/artifact read parity after lifecycle-control wiring.
-- Keep this lane scoped to lifecycle-control APIs and related regression checks.
+- Make the current-selection work relationships graph complete and trustworthy for work items with repeated relationship types.
+- Preserve the existing loading, empty, error, and selection behaviors while repairing the graph data/rendering path.
+- Improve at-a-glance readability of relationship nodes through clearer color treatment and label layout.
+- Keep the work scoped to the current-selection work-item relationship graph rather than broad trace or factory-graph redesign.
 
-## Project-Level Acceptance Criteria
+## User stories
 
-- [ ] `POST /factory-sessions/{session_id}/cancel` or `POST /factory-sessions/{session_id}/terminate` for a runtime-backed durable JavaScript session returns a typed lifecycle-control response through the durable backend path and no longer returns a `501` stub.
-- [ ] `POST /factory-sessions/{session_id}/pause` and `POST /factory-sessions/{session_id}/resume` return typed lifecycle-control responses or typed invalid-state/conflict responses through shared service and mapper code.
-- [ ] `POST /factory-sessions/{session_id}/approve` and `POST /factory-sessions/{session_id}/retry-dispatch` are wired through the same durable lifecycle-control API boundary, with fixture-backed coverage acceptable where real runtime scenarios are not yet available.
-- [ ] Typed control errors preserve generated response vocabulary, include operation/outcome/status when available, and map missing sessions to the existing not-found API shape.
-- [ ] Focused tests prove lifecycle controls do not break prior start/list/get/result/events or dispatch/artifact read parity.
-- [ ] The lane does not implement website inspection, MCP install work, live-provider bridge behavior, standalone workflow-run resources, `/workflow-previews` expansion, or another broad API/event batch.
-- [ ] Quality gate passes: generated artifacts are synchronized when OpenAPI changes are made, typecheck passes, lint passes where applicable, and focused backend/API tests pass.
+### work-relationships-current-selection-graph-repair-001: Preserve all relationship instances for selected work
 
-## User Stories
-
-### dynamic-workflows-cell-real-backend-api-lifecycle-control-001: Cancel or Terminate Runtime-Backed Durable Sessions
-
-**Description:** As an HTTP client controlling a durable JavaScript Factory Session, I want cancel or terminate to return a typed lifecycle-control response from the real backend so that I can stop durable work without receiving a stub response.
+**Description:** As a maintainer, I want the selected-work relationship graph model to retain every supported relationship instance so the current-selection graph can represent multiple dependencies and parent relations accurately.
 
 **Acceptance Criteria:**
 
-- [ ] `POST /factory-sessions/{session_id}/cancel` or `POST /factory-sessions/{session_id}/terminate` routes `dur-sess-*` session IDs to the durable execution service instead of returning `501 NotImplemented`.
-- [ ] At least one focused API server test starts or uses a runtime-backed durable JavaScript session and proves cancel or terminate returns a typed lifecycle-control response.
-- [ ] The response includes generated lifecycle-control fields such as operation, outcome, lifecycle status, request identifier, and inspection links when available.
-- [ ] Missing durable sessions return the existing typed not-found API response.
-- [ ] Non-durable live session IDs preserve existing live Petri-compatible lifecycle behavior.
-- [ ] Typecheck passes.
-- [ ] Tests pass.
+- [x] Building the current-selection selected-work relationship graph keeps every supported relationship instance connected to the selected work item instead of collapsing repeated relationships by relationship type alone.
+- [x] When one selected work item has two distinct `DEPENDS_ON` relations to two different target work items, the ready graph contains two dependency edges and both related work nodes.
+- [x] Existing supported relationship kinds for this graph (`DEPENDS_ON`, `PARENT_CHILD` as rendered parent relationships) continue to project correctly alongside repeated dependency relationships.
+- [x] The projected graph remains deterministic for the same input snapshot so reviewers can compare outputs reliably in tests.
+- [x] Focused regression tests cover the repeated-`DEPENDS_ON` case and a mixed dependency-plus-parent case.
+- [x] Typecheck passes
+- [x] Tests pass
 
-### dynamic-workflows-cell-real-backend-api-lifecycle-control-002: Pause and Resume Durable Sessions with Typed Outcomes
+### work-relationships-current-selection-graph-repair-002: Render every relationship on the current-selection work graph
 
-**Description:** As an HTTP client managing a durable JavaScript Factory Session, I want pause and resume to return typed success or invalid-state responses so that generated clients can react without parsing strings.
-
-**Acceptance Criteria:**
-
-- [ ] `POST /factory-sessions/{session_id}/pause` routes durable session IDs through the durable lifecycle service boundary and returns a typed lifecycle-control response or typed invalid-state/conflict response.
-- [ ] `POST /factory-sessions/{session_id}/resume` routes durable session IDs through the durable lifecycle service boundary and returns a typed lifecycle-control response or typed invalid-state/conflict response.
-- [ ] Terminal sessions produce the generated terminal-session or invalid-state lifecycle-control vocabulary rather than an untyped server error.
-- [ ] Fixture-backed fake service coverage is acceptable for pause/resume states that cannot yet be produced by the real runtime, but HTTP behavior must still be proven at the API boundary.
-- [ ] Non-durable live session IDs continue to use the existing live Petri-compatible pause/resume behavior.
-- [ ] Typecheck passes.
-- [ ] Tests pass.
-
-### dynamic-workflows-cell-real-backend-api-lifecycle-control-003: Approve and Retry Dispatch Through the Durable Boundary
-
-**Description:** As an HTTP client resolving gated or failed durable work, I want approve and retry-dispatch to use the same typed lifecycle-control API boundary so that all lifecycle operations behave consistently.
+**Description:** As a dashboard operator, I want the work relationships graph in current selection to show every related work item and edge so I can understand all of the selected work's dependencies and lineage from one place.
 
 **Acceptance Criteria:**
 
-- [ ] `POST /factory-sessions/{session_id}/approve` normalizes the request through shared API surface code and delegates durable session IDs to the durable lifecycle service.
-- [ ] `POST /factory-sessions/{session_id}/retry-dispatch` normalizes the request through shared API surface code and delegates durable session IDs to the durable lifecycle service.
-- [ ] Approve and retry-dispatch responses use generated lifecycle-control success, no-op, invalid-state, terminal-session, or conflict shapes as appropriate for the scenario.
-- [ ] Fixture-backed fake service scenarios cover approve and retry-dispatch when real runtime scenarios for guarded approvals or retryable provider dispatches are not yet available.
-- [ ] The API does not introduce standalone workflow-run route families or `/workflow-previews` expansion for these controls.
-- [ ] Typecheck passes.
-- [ ] Tests pass.
+- [ ] In the current-selection work-item detail card, the Work relationships region renders all related nodes and all relationship edges present in the ready selected-work relationship graph.
+- [ ] Repeated `DEPENDS_ON` relations do not disappear simply because they share the same relationship label; each distinct related work item is visible and selectable from the graph.
+- [ ] Activating each related-work node by click or keyboard still calls the existing current-selection work-switch action for that related work item.
+- [ ] Loading, empty, and error states for the Work relationships region remain explicit and unchanged in meaning.
+- [ ] Browser-visible verification covers the concrete batch example and confirms that multiple dependency relationships appear at the same time in current selection.
+- [ ] Typecheck passes
+- [ ] Tests pass
+- [ ] Verify in browser using dev-browser skill
 
-### dynamic-workflows-cell-real-backend-api-lifecycle-control-004: Preserve Typed Control Errors and Request-Id Semantics
+### work-relationships-current-selection-graph-repair-003: Make relationship nodes readable and scannable
 
-**Description:** As a generated-client consumer, I want lifecycle-control failures and request-id replays to use stable typed API shapes so that client error handling is deterministic.
-
-**Acceptance Criteria:**
-
-- [ ] Validation failures, missing durable sessions, terminal-session controls, invalid-state controls, and request-id conflicts map to generated typed API response shapes with existing HTTP status semantics.
-- [ ] Missing durable sessions use the existing not-found API shape rather than a lifecycle-specific ad hoc error.
-- [ ] Idempotent request-id replay returns the same typed lifecycle-control result for the same control tuple where the service supports replay.
-- [ ] Conflicting request-id reuse returns the generated conflict response vocabulary without mutating session state.
-- [ ] Error responses preserve operation, outcome, status, and inspection-link fields when the service result provides them.
-- [ ] Typecheck passes.
-- [ ] Tests pass.
-
-### dynamic-workflows-cell-real-backend-api-lifecycle-control-005: Keep Lifecycle Contract and Mappers Synchronized
-
-**Description:** As a maintainer of the public Factory Session API, I want lifecycle-control route contracts and mappers to stay aligned so that generated Go and TypeScript clients receive stable typed responses.
+**Description:** As a dashboard operator, I want relationship nodes in the current-selection graph to have clearer colors and readable labels so I can identify the selected work and related work items without fighting the layout.
 
 **Acceptance Criteria:**
 
-- [x] If lifecycle-control route, schema, response, or error refs need correction, the authored OpenAPI fragments are updated and `make generate-api` synchronizes generated Go and TypeScript clients.
-- [x] API surface mapper tests cover lifecycle-control request normalization and response/error shaping for success, no-op or terminal-session, conflict, and not-found cases.
-- [x] Contract tests cover the existing lifecycle-control route family under `/factory-sessions/{session_id}` and the generated lifecycle-control response vocabulary.
-- [x] The deferred-route regression no longer treats lifecycle-control routes as unsupported future routes; only genuinely unsupported future routes remain deferred.
-- [x] Public vocabulary remains Factory Session lifecycle-control vocabulary and does not expose internal Petri-net terms or standalone workflow-run nouns.
-- [x] Typecheck passes.
-- [x] Tests pass.
+- [ ] Relationship nodes in current selection use a more distinctive palette aligned with the workstation-node readability standard in the factory graph rather than the current inscrutable neutral treatment.
+- [ ] The currently selected work item still has a clearly stronger emphasis than surrounding related-work nodes after the palette update.
+- [ ] Long node labels no longer truncate awkwardly; labels wrap to additional lines, use a smaller readable font, or both, while staying inside the node shell.
+- [ ] Readability improvements hold at common current-selection card widths, including narrower dashboard layouts, without text overlapping adjacent chrome.
+- [ ] Accessible contrast, focus styling, and keyboard activation remain intact after the node styling update.
+- [ ] Focused component or integration coverage proves the new node classes and non-clipping text behavior for long labels.
+- [ ] Typecheck passes
+- [ ] Tests pass
+- [ ] Verify in browser using dev-browser skill
 
-### dynamic-workflows-cell-real-backend-api-lifecycle-control-006: Protect Prior Durable Read and Inspection Parity
+## High-level technical design
 
-**Description:** As a maintainer extending durable Factory Session parity, I want lifecycle-control wiring to preserve start, read, result, event, dispatch, and artifact behavior so that the new controls do not regress completed slices.
+1. **Canonical data boundary**: Treat the selected-work relationship model as the source of truth for the current-selection graph. The graph model must preserve every supported relationship instance from the snapshot or selected-work relation payload rather than deduplicating by label or relation type.
+2. **Projected graph boundary**: The shared relation-graph surface should receive projected nodes and edges that keep identity per relation instance or per source-target pair, so two `DEPENDS_ON` edges from one work item to two different work items both survive projection and render.
+3. **UI surface boundary**: The current-selection work-item card remains responsible for loading, empty, error, and success states plus current-selection callbacks, while the shared graph surface handles only visual graph rendering and node interaction.
+4. **Visual treatment**: Reuse existing semantic palette tokens already trusted on graph surfaces where possible. Apply them to relationship nodes in a way that makes the selected node, related nodes, hover, focus, and keyboard activation states remain distinguishable.
+5. **Label layout**: Prefer CSS/layout changes that keep labels readable inside node bounds before adding bespoke truncation rules. If line wrapping is used, the node height and hit target must still remain stable enough for the current-selection card layout.
+6. **Verification**: Cover the bug at the graph-model layer and at the rendered current-selection card layer, then verify the visible repair in the browser using the cited batch example.
 
-**Acceptance Criteria:**
+## Functional requirements
 
-- [ ] Focused regression coverage proves durable JavaScript start, list, get, result, and event read/reconnect behavior still passes after lifecycle-control wiring.
-- [ ] Focused regression coverage proves durable dispatch and artifact list/detail reads still pass after lifecycle-control wiring.
-- [ ] Tests demonstrate lifecycle-control calls do not remove stable inspection links for session, result, dispatch, artifact, or event reads when those links are available.
-- [ ] Website inspection parity and live-provider bridge parity are recorded as named follow-up cells if encountered rather than implemented in this lane.
-- [ ] Typecheck passes.
-- [ ] Tests pass.
+- **FR-1:** The current-selection work relationships graph MUST render every supported relationship instance for the selected work item.
+- **FR-2:** Multiple `DEPENDS_ON` relationships from one selected work item to different target work items MUST all appear simultaneously on the graph.
+- **FR-3:** Existing parent/child relationship rendering MUST continue to work when repeated dependency relationships are also present.
+- **FR-4:** Selecting a related node from the relationship graph MUST continue to switch current selection to that work item by mouse and keyboard activation.
+- **FR-5:** The current-selection relationship graph MUST preserve explicit loading, empty, and error states.
+- **FR-6:** Relationship nodes MUST use a clearer palette that improves distinction between selected and related work nodes.
+- **FR-7:** Relationship-node labels MUST remain readable within node bounds at common dashboard widths without clipped text.
 
-## High-Level Technical Design
+## Non-goals
 
-Durable lifecycle-control requests should stay under the existing public Factory Session route family. API handlers identify durable session IDs and delegate approve, pause, resume, cancel, terminate, and retry-dispatch through `FactoryService` to `factorysessionexecution.Service`. Non-durable session IDs continue on the existing live Petri-compatible path.
+- Redesigning the trace drill-down graph, dispatch relationship graph, or factory topology graph outside this current-selection work-item surface.
+- Adding new relationship kinds or changing relationship semantics in backend event, API, or CLI contracts.
+- Reworking graph layout algorithms beyond what is necessary to show all existing relationships and readable labels.
+- Introducing user-configurable node colors, zoom controls, or broader current-selection card information architecture changes.
 
-Request normalization and response shaping belong in `pkg/apisurface/factorysession`, especially the existing control request and lifecycle-control response/error mappers. Handlers should not build durable lifecycle projections locally. Per-session runtime state remains owned by the durable session runtime/service layer; `FactoryService` coordinates access and dependencies but does not become the state owner.
+## Supporting technical and UX considerations
 
-Tests should prove behavior at the API boundary and mapper boundary. At least cancel or terminate must use the real durable JavaScript runtime service for loopback coverage. Pause/resume, approve, retry-dispatch, and typed conflict cases may use fixture-backed fake service scenarios when real runtime support is not yet available. If OpenAPI lifecycle-control schemas or refs need correction, update authored fragments first, then run `make generate-api`.
+- Keep terminology aligned with the product vocabulary in `docs/architecture/data-model.md`; this is customer-visible work-item relationship behavior, not an internal graph-theory refactor.
+- Follow `docs/internal/standards/code/general-website-standards.md` for accessible interactive graph nodes, readable contrast, keyboard behavior, and responsive layout.
+- Use the customer's cited factory batch example as a stable regression case, but prove the repair through observable rendered behavior rather than file inventory assertions.
+- Avoid widening scope into unrelated trace-drilldown node styling so reviewers can validate this lane independently.
 
-## Functional Requirements
+## Success metrics
 
-- FR-1: `POST /factory-sessions/{session_id}/cancel` must return a typed lifecycle-control response for durable JavaScript Factory Sessions through the durable execution service.
-- FR-2: `POST /factory-sessions/{session_id}/terminate` must return a typed lifecycle-control response for durable JavaScript Factory Sessions through the durable execution service.
-- FR-3: `POST /factory-sessions/{session_id}/pause` and `/resume` must return typed lifecycle-control responses or typed invalid-state/conflict responses for durable sessions.
-- FR-4: `POST /factory-sessions/{session_id}/approve` and `/retry-dispatch` must be wired through the same durable lifecycle-control service and mapper boundary.
-- FR-5: Missing durable sessions must map to the existing not-found API shape.
-- FR-6: Typed lifecycle-control errors must preserve generated response vocabulary, including operation, outcome, status, and inspection links when available.
-- FR-7: Request-id replay and conflict behavior must be deterministic and must not mutate unrelated session state.
-- FR-8: Existing live Petri session compatibility must remain intact for non-durable session IDs.
-- FR-9: Prior durable start/list/get/result/events and dispatch/artifact read parity must continue to pass focused regression coverage.
-- FR-10: Public route structure must remain under `/factory-sessions/{session_id}` lifecycle controls without introducing workflow-run resources.
+- Operators can see all dependencies and parent relationships for a selected work item without leaving current selection.
+- No repeated-relationship regression remains for the known batch example with multiple `DEPENDS_ON` edges.
+- Long work-item names on relationship nodes are readable without clipped text in the dashboard card.
 
-## Non-Goals
+## Open questions
 
-- No website or dashboard inspection parity.
-- No MCP host installation or install-smoke changes.
-- No live-provider bridge parity for JavaScript child-agent dispatch execution.
-- No standalone workflow-run API resources or `/workflow-previews` expansion.
-- No broad API/event route family beyond lifecycle controls and the regression checks needed to protect completed parity slices.
-- No broad handler refactor, package reshaping, or unrelated cleanup.
-
-## Supporting Technical and UX Considerations
-
-- Relevant references include `docs/temp/customer-ask.md`, `docs/temp/dynamic-workflow-plan.md`, `docs/internal/development/plans/dynamic-workflows/dynamic-workflow-design.md`, `docs/internal/processes/api-relevant-files.md`, `docs/architecture/architecture.md`, and `docs/architecture/data-model.md`.
-- Hard dependencies are completed `dynamic-workflows-cell-real-backend-api-session-parity`, completed `dynamic-workflows-cell-real-backend-api-dispatch-artifact`, and existing lifecycle-control service methods plus `pkg/apisurface/factorysession` mappers.
-- Recommended verification commands are `make generate-api` when contract files change, `go test ./pkg/api/servertests ./pkg/api/contracttests ./pkg/apisurface/... ./pkg/factorysessionexecution/...`, and `make api-smoke` when feasible.
-- The change is backend/API-visible, not browser-visible. Direct browser verification is not required unless implementation expands into dashboard behavior, which is out of scope for this lane.
-
-## Success Metrics
-
-- Durable lifecycle-control routes return typed responses instead of `501` stubs.
-- At least one real runtime-backed cancel or terminate API test proves the durable backend path.
-- Generated clients can distinguish accepted, no-op, invalid-state, terminal-session, conflict, and not-found outcomes using typed response vocabulary.
-- Prior durable read and inspection parity tests remain green.
-- No new workflow-run API resource, website behavior, MCP install behavior, or live-provider bridge behavior is introduced.
-
-## Open Questions
-
-None. Where real runtime scenarios are not yet available for a lifecycle operation, implementation should use fixture-backed coverage for this lane and record the missing real-provider/runtime scenario as follow-up work rather than expanding scope.
+None.

--- a/progress.txt
+++ b/progress.txt
@@ -1,0 +1,15 @@
+## Codebase Patterns
+- `buildSelectedWorkRelationshipGraph` in `ui/src/features/current-selection/work-selection/lib/selected-work-relationship-graph.ts` is the canonical selected-work relationship model; preserve relation instances with `relationInstanceKey` (type, source, target, required_state, request_id, trace_id).
+- Ready relationship graphs expose both `relations` and oriented `edges`; `projectSelectedWorkRelationshipGraphToDashboardRelations` prefers `relations` when present for rendering.
+- Timeline replay dedupes relations in `replayGraphState.ts` with `request_id` in the key; graph-model dedupe should stay aligned.
+- Split large UI test files under `work-selection/lib/` when Biome `noExcessiveLinesPerFile` or `noExcessiveLinesPerFunction` triggers; shared fixtures belong in `*.fixture.ts` siblings.
+
+## 2026-06-16T20:39:00Z - work-relationships-current-selection-graph-repair-001
+- Preserved every supported relationship instance in the selected-work relationship graph model by aligning dedupe keys with timeline replay (`request_id`, `trace_id`), orienting edges relative to the selected work item, and keeping transitive connected-component relations in canonical direction.
+- Added regression coverage for repeated `DEPENDS_ON`, mixed dependency-plus-parent snapshots, and duplicate instances that share endpoints.
+- Files changed: `selected-work-relationship-graph.ts`, `selected-work-relationship-graph.fixture.ts`, `selected-work-relationship-graph.test.ts`, `selected-work-relationship-graph.instances.test.ts`, `selected-work-relationship-graph.determinism.test.ts`
+- **Learnings for future iterations:**
+  - Repeated `DEPENDS_ON` to different targets already flowed through `connectedSupportedRelations`; the real collapse risk was `dedupeDashboardRelations` omitting `request_id`.
+  - `edgeForRelation` must only remap inbound/outbound roles when the selected work is an endpoint; transitive component edges should keep canonical source/target direction.
+  - Biome line-count rules require splitting relationship-graph tests across `*.test.ts`, `*.instances.test.ts`, and `*.determinism.test.ts` with a shared `*.fixture.ts`.
+---

--- a/tests/functional/guards_batch/same_name_consume_path_regression_test.go
+++ b/tests/functional/guards_batch/same_name_consume_path_regression_test.go
@@ -246,7 +246,6 @@ func TestSameNameConsumePathRegression_StaggeredArrivalCompletesWithoutStranding
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 			errCh := h.RunInBackground(ctx)
-			support.WaitForHarnessRuntimeAvailability(t, h, 3*time.Second)
 
 			for _, req := range tc.order {
 				h.SubmitFull(context.Background(), []interfaces.SubmitRequest{req})

--- a/tests/functional/internal/support/harness.go
+++ b/tests/functional/internal/support/harness.go
@@ -9,23 +9,6 @@ import (
 	"github.com/portpowered/infinite-you/pkg/testutil"
 )
 
-func WaitForHarnessRuntimeAvailability(
-	t *testing.T,
-	h *testutil.ServiceTestHarness,
-	timeout time.Duration,
-) {
-	t.Helper()
-
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if _, err := h.GetEngineStateSnapshot(); err == nil {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatal("timed out waiting for harness runtime availability")
-}
-
 func WaitForHarnessPlaceTokenCount(
 	t *testing.T,
 	h *testutil.ServiceTestHarness,

--- a/ui/scripts/feature-folder-file-count-allowlist.mjs
+++ b/ui/scripts/feature-folder-file-count-allowlist.mjs
@@ -57,4 +57,13 @@ export const allowlistedOversizedFeatureFolders = [
     maxFileCount: 14,
     relativeDirectoryPath: "src/features/trace-drilldown/lib",
   },
+  {
+    maxFileCount: 11,
+    relativeDirectoryPath:
+      "src/features/current-selection/work-selection/components/work-item",
+  },
+  {
+    maxFileCount: 11,
+    relativeDirectoryPath: "src/features/current-selection/work-selection/lib",
+  },
 ];

--- a/ui/src/features/current-selection/work-selection/components/work-item/work-item-relationship-graph.render.test.tsx
+++ b/ui/src/features/current-selection/work-selection/components/work-item/work-item-relationship-graph.render.test.tsx
@@ -13,6 +13,8 @@ import { installDashboardBrowserTestShims } from "../../../../../components/dash
 import { useCurrentSelectionDispatchHistoryMessages } from "../../../base/components/presentation/current-selection-locale";
 import { buildSelectedWorkRelationshipGraph } from "../../lib/selected-work-relationship-graph";
 import {
+  localAgentCliRuntimeBatchSnapshot,
+  localAgentCliRuntimeLoopbackWorkItem,
   selectedWorkItem,
   snapshotFixture,
 } from "../../lib/selected-work-relationship-graph.fixture";
@@ -115,6 +117,21 @@ function getTraceGraphNodeButton(
   }
 
   return button;
+}
+
+function LocalAgentCliRuntimeBatchHarness() {
+  const messages = useCurrentSelectionDispatchHistoryMessages();
+  const relationshipGraph = buildSelectedWorkRelationshipGraph({
+    selectedWorkItem: localAgentCliRuntimeLoopbackWorkItem(),
+    snapshot: localAgentCliRuntimeBatchSnapshot(),
+  });
+
+  return (
+    <WorkRelationshipsSection
+      messages={messages}
+      relationshipGraph={relationshipGraph}
+    />
+  );
 }
 
 function WorkRelationshipsSectionHarness({
@@ -224,5 +241,47 @@ describe("WorkRelationshipsSection repeated DEPENDS_ON rendering", () => {
       2,
       "work-second-dependency-story",
     );
+  });
+
+  it("renders every loopback dependency from the checked-in local agent CLI runtime batch example", async () => {
+    const loopbackWorkItem = localAgentCliRuntimeLoopbackWorkItem();
+    const relationshipGraph = buildSelectedWorkRelationshipGraph({
+      selectedWorkItem: loopbackWorkItem,
+      snapshot: localAgentCliRuntimeBatchSnapshot(),
+    });
+    if (relationshipGraph.status !== "ready") {
+      throw new Error(`expected ready graph, got ${relationshipGraph.status}`);
+    }
+
+    render(<LocalAgentCliRuntimeBatchHarness />);
+
+    const relationshipSection = screen.getByRole("region", {
+      name: "Work relationships",
+    });
+    const traceGraph = await within(relationshipSection).findByRole("region", {
+      name: "Batch relation graph",
+    });
+
+    await waitFor(() => {
+      expect(renderedEdgeCount(traceGraph)).toBe(relationshipGraph.relations.length);
+    });
+
+    const edgePayload = traceGraph
+      .querySelector("[data-testid='trace-relation-react-flow']")
+      ?.getAttribute("data-edge-payload");
+    if (!edgePayload) {
+      throw new Error("Expected rendered edge payload.");
+    }
+    const loopbackEdges = (JSON.parse(edgePayload) as Array<{ id: string }>).filter(
+      (edge) => edge.id.includes("work-local-agent-cli-runtime-loopback"),
+    );
+    expect(loopbackEdges).toHaveLength(5);
+    expect(
+      relationshipGraph.relations.filter(
+        (relation) =>
+          relation.type === "DEPENDS_ON" &&
+          relation.source_work_id === loopbackWorkItem.work_id,
+      ),
+    ).toHaveLength(5);
   });
 });

--- a/ui/src/features/current-selection/work-selection/components/work-item/work-item-relationship-graph.render.test.tsx
+++ b/ui/src/features/current-selection/work-selection/components/work-item/work-item-relationship-graph.render.test.tsx
@@ -1,0 +1,228 @@
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { installDashboardBrowserTestShims } from "../../../../../components/dashboard/test-browser-shims";
+import { useCurrentSelectionDispatchHistoryMessages } from "../../../base/components/presentation/current-selection-locale";
+import { buildSelectedWorkRelationshipGraph } from "../../lib/selected-work-relationship-graph";
+import {
+  selectedWorkItem,
+  snapshotFixture,
+} from "../../lib/selected-work-relationship-graph.fixture";
+import { WorkRelationshipsSection } from "./work-item-relationship-graph";
+
+const fitViewSpy = vi.fn();
+
+vi.mock("@xyflow/react", async () => {
+  return {
+    Background: () => <div data-testid="trace-relation-flow-background" />,
+    Controls: () => <div data-testid="trace-relation-flow-controls" />,
+    Handle: () => null,
+    MarkerType: { ArrowClosed: "arrowclosed" },
+    Position: { Left: "left", Right: "right" },
+    ReactFlow: ({
+      children,
+      edges,
+      nodeTypes,
+      nodes,
+      onInit,
+    }: {
+      children?: ReactNode;
+      edges: Array<{ id: string }>;
+      nodeTypes: Record<
+        string,
+        (props: { data: Record<string, unknown> }) => ReactNode
+      >;
+      nodes: Array<{
+        data: Record<string, unknown>;
+        id: string;
+        type: string;
+      }>;
+      onInit?: (instance: { fitView: typeof fitViewSpy }) => void;
+    }) => (
+      <div
+        data-edge-payload={JSON.stringify(edges)}
+        data-testid="trace-relation-react-flow"
+        ref={() => {
+          onInit?.({ fitView: fitViewSpy });
+        }}
+      >
+        {nodes.map((node) => {
+          const NodeView = nodeTypes[node.type];
+          return (
+            <div key={node.id}>
+              <NodeView data={node.data} />
+            </div>
+          );
+        })}
+        {children}
+      </div>
+    ),
+    applyNodeChanges: (
+      _changes: Array<Record<string, unknown>>,
+      nodes: Array<Record<string, unknown>>,
+    ) => nodes,
+  };
+});
+
+function repeatedDependsOnSnapshot() {
+  const snapshot = snapshotFixture();
+  snapshot.relationsByWorkID["work-active-story"] = [
+    {
+      source_work_id: "work-active-story",
+      sourceWorkName: "Active Story",
+      targetWorkId: "work-dependency-story",
+      targetWorkName: "Dependency Story",
+      type: "DEPENDS_ON",
+      requiredState: "ready",
+    },
+    {
+      source_work_id: "work-active-story",
+      sourceWorkName: "Active Story",
+      targetWorkId: "work-second-dependency-story",
+      targetWorkName: "Second Dependency Story",
+      type: "DEPENDS_ON",
+      requiredState: "ready",
+    },
+  ];
+  snapshot.runtime.active_executions_by_dispatch_id[
+    "dispatch-active-story"
+  ].work_items?.push({
+    display_name: "Second Dependency Story",
+    state: "ready",
+    trace_id: "trace-second-dependency-story",
+    work_id: "work-second-dependency-story",
+    work_type_id: "story",
+  });
+  return snapshot;
+}
+
+function getTraceGraphNodeButton(
+  container: HTMLElement,
+  label: string,
+): HTMLButtonElement {
+  const button = container.querySelector(`button[aria-label="${label}"]`);
+
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`expected trace graph node button for ${label}`);
+  }
+
+  return button;
+}
+
+function WorkRelationshipsSectionHarness({
+  onSelectWorkID,
+}: {
+  onSelectWorkID?: (workID: string) => void;
+}) {
+  const messages = useCurrentSelectionDispatchHistoryMessages();
+  const relationshipGraph = buildSelectedWorkRelationshipGraph({
+    selectedWorkItem,
+    snapshot: repeatedDependsOnSnapshot(),
+  });
+
+  return (
+    <WorkRelationshipsSection
+      messages={messages}
+      onSelectWorkID={onSelectWorkID}
+      relationshipGraph={relationshipGraph}
+    />
+  );
+}
+
+function readyRepeatedDependsOnGraph() {
+  const graph = buildSelectedWorkRelationshipGraph({
+    selectedWorkItem,
+    snapshot: repeatedDependsOnSnapshot(),
+  });
+  if (graph.status !== "ready") {
+    throw new Error(`expected ready graph, got ${graph.status}`);
+  }
+  return graph;
+}
+
+function renderedEdgeCount(container: HTMLElement): number {
+  const payload = container
+    .querySelector("[data-testid='trace-relation-react-flow']")
+    ?.getAttribute("data-edge-payload");
+  if (!payload) {
+    throw new Error("Expected rendered edge payload.");
+  }
+
+  return (JSON.parse(payload) as unknown[]).length;
+}
+
+describe("WorkRelationshipsSection repeated DEPENDS_ON rendering", () => {
+  let restoreBrowserShims: (() => void) | undefined;
+
+  beforeEach(() => {
+    restoreBrowserShims = installDashboardBrowserTestShims();
+  });
+
+  afterEach(() => {
+    cleanup();
+    fitViewSpy.mockReset();
+    restoreBrowserShims?.();
+    restoreBrowserShims = undefined;
+  });
+
+  it("renders every dependency node and edge from the ready relationship graph", async () => {
+    const onSelectWorkID = vi.fn();
+    const graph = readyRepeatedDependsOnGraph();
+
+    render(<WorkRelationshipsSectionHarness onSelectWorkID={onSelectWorkID} />);
+
+    const relationshipSection = screen.getByRole("region", {
+      name: "Work relationships",
+    });
+    const traceGraph = await within(relationshipSection).findByRole("region", {
+      name: "Batch relation graph",
+    });
+
+    expect(within(traceGraph).getByText("Dependency Story")).toBeTruthy();
+    expect(within(traceGraph).getByText("Second Dependency Story")).toBeTruthy();
+    expect(within(traceGraph).getByText("Active Story")).toBeTruthy();
+
+    await waitFor(() => {
+      expect(renderedEdgeCount(traceGraph)).toBe(graph.relations.length);
+    });
+    expect(
+      graph.relations.filter(
+        (relation) =>
+          relation.type === "DEPENDS_ON" &&
+          relation.source_work_id === "work-active-story",
+      ),
+    ).toHaveLength(2);
+  });
+
+  it("keeps related dependency nodes selectable by click and keyboard", async () => {
+    const user = userEvent.setup();
+    const onSelectWorkID = vi.fn();
+
+    render(<WorkRelationshipsSectionHarness onSelectWorkID={onSelectWorkID} />);
+
+    const relationshipSection = screen.getByRole("region", {
+      name: "Work relationships",
+    });
+    const traceGraph = await within(relationshipSection).findByRole("region", {
+      name: "Batch relation graph",
+    });
+
+    await user.click(getTraceGraphNodeButton(traceGraph, "Dependency Story"));
+    getTraceGraphNodeButton(traceGraph, "Second Dependency Story").focus();
+    await user.keyboard("{Enter}");
+
+    expect(onSelectWorkID).toHaveBeenNthCalledWith(1, "work-dependency-story");
+    expect(onSelectWorkID).toHaveBeenNthCalledWith(
+      2,
+      "work-second-dependency-story",
+    );
+  });
+});

--- a/ui/src/features/current-selection/work-selection/components/work-item/work-item-relationship-graph.tsx
+++ b/ui/src/features/current-selection/work-selection/components/work-item/work-item-relationship-graph.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { AlertPanel, AlertPanelText } from "../../../../../components/ui";
 import { TraceRelationFlow } from "../../../../trace-drilldown/public";
 import type { useCurrentSelectionDispatchHistoryMessages } from "../../../base/components/presentation/current-selection-locale";
@@ -8,6 +9,27 @@ import {
 import type { SelectedWorkRelationshipGraph } from "../../lib/selected-work-relationship-graph";
 import { projectSelectedWorkRelationshipGraphToDashboardRelations } from "../../lib/selected-work-relationship-relations";
 import { FocusedRelationshipSummary } from "./work-item-relationship-summary";
+
+function workItemsByWorkIdFromRelationshipGraph(
+  relationshipGraph: SelectedWorkRelationshipGraph,
+) {
+  if (relationshipGraph.status !== "ready") {
+    return undefined;
+  }
+
+  const workItems = [
+    relationshipGraph.selectedWork,
+    ...relationshipGraph.relatedWork,
+  ].map((node) => ({
+    display_name: node.label,
+    state: node.state,
+    trace_id: node.traceID,
+    work_id: node.workID,
+    work_type_id: node.workTypeID,
+  }));
+
+  return new Map(workItems.map((workItem) => [workItem.work_id, workItem]));
+}
 
 export function WorkRelationshipsSection({
   activeTraceID,
@@ -32,6 +54,13 @@ export function WorkRelationshipsSection({
     projectSelectedWorkRelationshipGraphToDashboardRelations(
       readyRelationshipGraph,
     );
+  const workItemsByWorkId = useMemo(
+    () =>
+      relationshipGraph
+        ? workItemsByWorkIdFromRelationshipGraph(relationshipGraph)
+        : undefined,
+    [relationshipGraph],
+  );
   const graphStatus = relationshipGraph?.status ?? "loading";
 
   return (
@@ -64,6 +93,7 @@ export function WorkRelationshipsSection({
             onSelectWorkID={onSelectWorkID}
             relations={relationships}
             selectedWorkID={readyRelationshipGraph.selectedWork.workID}
+            workItemsByWorkId={workItemsByWorkId}
           />
           <FocusedRelationshipSummary
             activeTraceID={activeTraceID}

--- a/ui/src/features/current-selection/work-selection/lib/selected-work-relationship-graph.determinism.test.ts
+++ b/ui/src/features/current-selection/work-selection/lib/selected-work-relationship-graph.determinism.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSelectedWorkRelationshipGraph } from "./selected-work-relationship-graph";
+import {
+  selectedWorkItem,
+  snapshotFixture,
+} from "./selected-work-relationship-graph.fixture";
+
+function mixedRelationshipSnapshot() {
+  const snapshot = snapshotFixture();
+  snapshot.relationsByWorkID = {
+    "work-active-story": [
+      {
+        request_id: "request-dep-1",
+        source_work_id: "work-active-story",
+        sourceWorkName: "Active Story",
+        targetWorkId: "work-dependency-story",
+        targetWorkName: "Dependency Story",
+        type: "DEPENDS_ON",
+        requiredState: "ready",
+      },
+      {
+        request_id: "request-dep-2",
+        source_work_id: "work-active-story",
+        sourceWorkName: "Active Story",
+        targetWorkId: "work-second-dependency-story",
+        targetWorkName: "Second Dependency Story",
+        type: "DEPENDS_ON",
+        requiredState: "ready",
+      },
+      {
+        request_id: "request-parent",
+        source_work_id: "work-active-story",
+        sourceWorkName: "Active Story",
+        targetWorkId: "work-parent-story",
+        targetWorkName: "Parent Story",
+        type: "PARENT_CHILD",
+      },
+    ],
+  };
+  snapshot.runtime.active_executions_by_dispatch_id[
+    "dispatch-active-story"
+  ].work_items?.push({
+    display_name: "Second Dependency Story",
+    state: "ready",
+    trace_id: "trace-second-dependency-story",
+    work_id: "work-second-dependency-story",
+    work_type_id: "story",
+  });
+  return snapshot;
+}
+
+describe("buildSelectedWorkRelationshipGraph mixed relationships", () => {
+  it("keeps repeated dependency and parent relationships together deterministically", () => {
+    const snapshot = mixedRelationshipSnapshot();
+    const firstGraph = buildSelectedWorkRelationshipGraph({
+      selectedWorkItem,
+      snapshot,
+    });
+    const secondGraph = buildSelectedWorkRelationshipGraph({
+      selectedWorkItem,
+      snapshot,
+    });
+
+    expect(firstGraph).toEqual(secondGraph);
+    if (firstGraph.status !== "ready") {
+      throw new Error(`expected ready graph, got ${firstGraph.status}`);
+    }
+
+    expect(firstGraph.relations).toEqual([
+      {
+        request_id: "request-dep-1",
+        required_state: "ready",
+        source_work_id: "work-active-story",
+        source_work_name: "Active Story",
+        target_work_id: "work-dependency-story",
+        target_work_name: "Dependency Story",
+        type: "DEPENDS_ON",
+      },
+      {
+        request_id: "request-dep-2",
+        required_state: "ready",
+        source_work_id: "work-active-story",
+        source_work_name: "Active Story",
+        target_work_id: "work-second-dependency-story",
+        target_work_name: "Second Dependency Story",
+        type: "DEPENDS_ON",
+      },
+      {
+        request_id: "request-parent",
+        source_work_id: "work-active-story",
+        source_work_name: "Active Story",
+        target_work_id: "work-parent-story",
+        target_work_name: "Parent Story",
+        type: "PARENT_CHILD",
+      },
+    ]);
+    expect(firstGraph.edges).toEqual([
+      {
+        relationship: "DEPENDS_ON",
+        requiredState: "ready",
+        sourceWorkID: "work-active-story",
+        targetWorkID: "work-dependency-story",
+      },
+      {
+        relationship: "DEPENDS_ON",
+        requiredState: "ready",
+        sourceWorkID: "work-active-story",
+        targetWorkID: "work-second-dependency-story",
+      },
+      {
+        relationship: "PARENT",
+        sourceWorkID: "work-active-story",
+        targetWorkID: "work-parent-story",
+      },
+    ]);
+  });
+});
+
+describe("buildSelectedWorkRelationshipGraph shared endpoints", () => {
+  it("preserves distinct relationship instances that share type and endpoints", () => {
+    const snapshot = snapshotFixture();
+    snapshot.relationsByWorkID = {
+      "work-active-story": [
+        {
+          request_id: "request-dep-a",
+          source_work_id: "work-active-story",
+          sourceWorkName: "Active Story",
+          targetWorkId: "work-dependency-story",
+          targetWorkName: "Dependency Story",
+          type: "DEPENDS_ON",
+          requiredState: "ready",
+        },
+        {
+          request_id: "request-dep-b",
+          source_work_id: "work-active-story",
+          sourceWorkName: "Active Story",
+          targetWorkId: "work-dependency-story",
+          targetWorkName: "Dependency Story",
+          type: "DEPENDS_ON",
+          requiredState: "ready",
+        },
+      ],
+    };
+
+    const graph = buildSelectedWorkRelationshipGraph({
+      selectedWorkItem,
+      snapshot,
+    });
+
+    expect(graph.status).toBe("ready");
+    if (graph.status !== "ready") {
+      throw new Error(`expected ready graph, got ${graph.status}`);
+    }
+
+    expect(graph.relations).toHaveLength(2);
+    expect(graph.relations.map((relation) => relation.request_id)).toEqual([
+      "request-dep-a",
+      "request-dep-b",
+    ]);
+    expect(graph.edges).toHaveLength(2);
+  });
+});

--- a/ui/src/features/current-selection/work-selection/lib/selected-work-relationship-graph.fixture.ts
+++ b/ui/src/features/current-selection/work-selection/lib/selected-work-relationship-graph.fixture.ts
@@ -1,7 +1,30 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import type {
   DashboardSnapshot,
   DashboardWorkItemRef,
 } from "../../../../api/dashboard/types";
+
+const uiRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+  "..",
+  "..",
+);
+const repoRoot = path.resolve(uiRoot, "..");
+
+export const localAgentCliRuntimeBatchPath = path.join(
+  repoRoot,
+  "factory",
+  "inputs",
+  "BATCH",
+  "default",
+  "factory-batch-local-agent-cli-runtime.json",
+);
 
 export const selectedWorkItem: DashboardWorkItemRef = {
   display_name: "Active Story",
@@ -125,5 +148,117 @@ export function snapshotFixture(): DashboardSnapshot & {
       workstation_nodes_by_id: {},
     },
     uptime_seconds: 42,
+  };
+}
+
+interface BatchWork {
+  name: string;
+  workTypeName: string;
+  payload?: { title?: string };
+}
+
+interface BatchRelation {
+  type: string;
+  sourceWorkName: string;
+  targetWorkName: string;
+  requiredState?: string;
+}
+
+interface BatchDocument {
+  relations: BatchRelation[];
+  works: BatchWork[];
+}
+
+function workIDForName(workName: string): string {
+  return `work-${workName}`;
+}
+
+function displayNameForWork(work: BatchWork): string {
+  return work.payload?.title?.trim() || work.name;
+}
+
+export function loadLocalAgentCliRuntimeBatch(): BatchDocument {
+  const raw = readFileSync(localAgentCliRuntimeBatchPath, "utf8");
+  return JSON.parse(raw) as BatchDocument;
+}
+
+export function localAgentCliRuntimeLoopbackWorkItem(): DashboardWorkItemRef {
+  const batch = loadLocalAgentCliRuntimeBatch();
+  const loopback = batch.works.find(
+    (work) => work.name === "local-agent-cli-runtime-loopback",
+  );
+  if (!loopback) {
+    throw new Error("Expected loopback work item in local agent CLI runtime batch.");
+  }
+
+  return {
+    display_name: displayNameForWork(loopback),
+    state: "queued",
+    trace_id: "trace-local-agent-cli-runtime-loopback",
+    work_id: workIDForName(loopback.name),
+    work_type_id: loopback.workTypeName,
+  };
+}
+
+export function localAgentCliRuntimeBatchSnapshot(): DashboardSnapshot & {
+  relationsByWorkID: Record<string, Array<Record<string, string>>>;
+} {
+  const batch = loadLocalAgentCliRuntimeBatch();
+  const workItems: DashboardWorkItemRef[] = batch.works.map((work) => ({
+    display_name: displayNameForWork(work),
+    state: "queued",
+    trace_id: `trace-${work.name}`,
+    work_id: workIDForName(work.name),
+    work_type_id: work.workTypeName,
+  }));
+
+  const relationsByWorkID: Record<string, Array<Record<string, string>>> = {};
+  for (const relation of batch.relations) {
+    const sourceWorkID = workIDForName(relation.sourceWorkName);
+    const targetWorkID = workIDForName(relation.targetWorkName);
+    const entry: Record<string, string> = {
+      source_work_id: sourceWorkID,
+      sourceWorkName: relation.sourceWorkName,
+      targetWorkId: targetWorkID,
+      targetWorkName: relation.targetWorkName,
+      type: relation.type,
+    };
+    if (relation.requiredState) {
+      entry.requiredState = relation.requiredState;
+    }
+    relationsByWorkID[sourceWorkID] = [...(relationsByWorkID[sourceWorkID] ?? []), entry];
+    if (!relationsByWorkID[targetWorkID]) {
+      relationsByWorkID[targetWorkID] = [];
+    }
+  }
+
+  return {
+    factory_state: "RUNNING",
+    relationsByWorkID,
+    runtime: {
+      active_executions_by_dispatch_id: {
+        "dispatch-local-agent-cli-runtime": {
+          dispatch_id: "dispatch-local-agent-cli-runtime",
+          started_at: "2026-06-16T12:00:00Z",
+          transition_id: "transition-local-agent-cli-runtime",
+          work_items: workItems,
+          workstation_node_id: "transition-local-agent-cli-runtime",
+        },
+      },
+      in_flight_dispatch_count: 1,
+      session: {
+        completed_count: 0,
+        dispatched_count: 1,
+        failed_count: 0,
+        has_data: true,
+      },
+    },
+    tick_count: 1,
+    topology: {
+      edges: [],
+      workstation_node_ids: [],
+      workstation_nodes_by_id: {},
+    },
+    uptime_seconds: 1,
   };
 }

--- a/ui/src/features/current-selection/work-selection/lib/selected-work-relationship-graph.fixture.ts
+++ b/ui/src/features/current-selection/work-selection/lib/selected-work-relationship-graph.fixture.ts
@@ -1,0 +1,129 @@
+import type {
+  DashboardSnapshot,
+  DashboardWorkItemRef,
+} from "../../../../api/dashboard/types";
+
+export const selectedWorkItem: DashboardWorkItemRef = {
+  display_name: "Active Story",
+  state: "in_progress",
+  trace_id: "trace-active-story",
+  work_id: "work-active-story",
+  work_type_id: "story",
+};
+
+export function snapshotFixture(): DashboardSnapshot & {
+  relationsByWorkID: Record<string, Array<Record<string, string>>>;
+} {
+  return {
+    factory_state: "RUNNING",
+    relationsByWorkID: {
+      "work-active-story": [
+        {
+          source_work_id: "work-active-story",
+          sourceWorkName: "Active Story",
+          targetWorkId: "work-dependency-story",
+          targetWorkName: "Dependency Story",
+          type: "DEPENDS_ON",
+          requiredState: "ready",
+        },
+        {
+          source_work_id: "work-active-story",
+          sourceWorkName: "Active Story",
+          targetWorkId: "work-parent-story",
+          targetWorkName: "Parent Story",
+          type: "PARENT_CHILD",
+        },
+      ],
+      "work-blocked-story": [
+        {
+          source_work_id: "work-blocked-story",
+          sourceWorkName: "Blocked Story",
+          targetWorkId: "work-active-story",
+          targetWorkName: "Active Story",
+          type: "DEPENDS_ON",
+          requiredState: "approved",
+        },
+      ],
+      "work-child-story": [
+        {
+          source_work_id: "work-child-story",
+          sourceWorkName: "Child Story",
+          targetWorkId: "work-active-story",
+          targetWorkName: "Active Story",
+          type: "PARENT_CHILD",
+        },
+      ],
+      "work-grandchild-story": [
+        {
+          source_work_id: "work-child-story",
+          sourceWorkName: "Child Story",
+          targetWorkId: "work-grandchild-story",
+          targetWorkName: "Grandchild Story",
+          type: "PARENT_CHILD",
+        },
+      ],
+    },
+    runtime: {
+      active_executions_by_dispatch_id: {
+        "dispatch-active-story": {
+          dispatch_id: "dispatch-active-story",
+          started_at: "2026-05-26T10:00:00Z",
+          transition_id: "transition-story",
+          work_items: [
+            selectedWorkItem,
+            {
+              display_name: "Dependency Story",
+              state: "ready",
+              trace_id: "trace-dependency-story",
+              work_id: "work-dependency-story",
+              work_type_id: "story",
+            },
+            {
+              display_name: "Parent Story",
+              state: "queued",
+              trace_id: "trace-parent-story",
+              work_id: "work-parent-story",
+              work_type_id: "epic",
+            },
+            {
+              display_name: "Blocked Story",
+              state: "blocked",
+              trace_id: "trace-blocked-story",
+              work_id: "work-blocked-story",
+              work_type_id: "story",
+            },
+            {
+              display_name: "Child Story",
+              state: "queued",
+              trace_id: "trace-child-story",
+              work_id: "work-child-story",
+              work_type_id: "task",
+            },
+            {
+              display_name: "Grandchild Story",
+              state: "queued",
+              trace_id: "trace-grandchild-story",
+              work_id: "work-grandchild-story",
+              work_type_id: "task",
+            },
+          ],
+          workstation_node_id: "transition-story",
+        },
+      },
+      in_flight_dispatch_count: 1,
+      session: {
+        completed_count: 0,
+        dispatched_count: 1,
+        failed_count: 0,
+        has_data: true,
+      },
+    },
+    tick_count: 4,
+    topology: {
+      edges: [],
+      workstation_node_ids: [],
+      workstation_nodes_by_id: {},
+    },
+    uptime_seconds: 42,
+  };
+}

--- a/ui/src/features/current-selection/work-selection/lib/selected-work-relationship-graph.instances.test.ts
+++ b/ui/src/features/current-selection/work-selection/lib/selected-work-relationship-graph.instances.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import { buildSelectedWorkRelationshipGraph } from "./selected-work-relationship-graph";
 import {
+  loadLocalAgentCliRuntimeBatch,
+  localAgentCliRuntimeBatchSnapshot,
+  localAgentCliRuntimeLoopbackWorkItem,
   selectedWorkItem,
   snapshotFixture,
 } from "./selected-work-relationship-graph.fixture";
@@ -83,5 +86,48 @@ describe("buildSelectedWorkRelationshipGraph repeated DEPENDS_ON", () => {
         "work-second-dependency-story",
       ]),
     );
+  });
+});
+
+describe("factory-batch-local-agent-cli-runtime relationship graph", () => {
+  it("preserves every DEPENDS_ON relation from the loopback work item in the checked-in batch example", () => {
+    const batch = loadLocalAgentCliRuntimeBatch();
+    const loopbackDependsOn = batch.relations.filter(
+      (relation) =>
+        relation.type === "DEPENDS_ON" &&
+        relation.sourceWorkName === "local-agent-cli-runtime-loopback",
+    );
+    expect(loopbackDependsOn).toHaveLength(5);
+
+    const graph = buildSelectedWorkRelationshipGraph({
+      selectedWorkItem: localAgentCliRuntimeLoopbackWorkItem(),
+      snapshot: localAgentCliRuntimeBatchSnapshot(),
+    });
+
+    expect(graph.status).toBe("ready");
+    if (graph.status !== "ready") {
+      throw new Error(`expected ready graph, got ${graph.status}`);
+    }
+
+    const dependencyTargets = loopbackDependsOn.map(
+      (relation) => `work-${relation.targetWorkName}`,
+    );
+    expect(
+      graph.relations.filter(
+        (relation) =>
+          relation.type === "DEPENDS_ON" &&
+          relation.source_work_id === "work-local-agent-cli-runtime-loopback",
+      ),
+    ).toHaveLength(5);
+    expect(graph.relatedWork.map((node) => node.workID)).toEqual(
+      expect.arrayContaining(dependencyTargets),
+    );
+    expect(
+      graph.edges.filter(
+        (edge) =>
+          edge.relationship === "DEPENDS_ON" &&
+          edge.sourceWorkID === "work-local-agent-cli-runtime-loopback",
+      ),
+    ).toHaveLength(5);
   });
 });

--- a/ui/src/features/current-selection/work-selection/lib/selected-work-relationship-graph.instances.test.ts
+++ b/ui/src/features/current-selection/work-selection/lib/selected-work-relationship-graph.instances.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSelectedWorkRelationshipGraph } from "./selected-work-relationship-graph";
+import {
+  selectedWorkItem,
+  snapshotFixture,
+} from "./selected-work-relationship-graph.fixture";
+
+describe("buildSelectedWorkRelationshipGraph repeated DEPENDS_ON", () => {
+  it("preserves every distinct DEPENDS_ON relationship from the selected work item", () => {
+    const snapshot = snapshotFixture();
+    snapshot.relationsByWorkID["work-active-story"] = [
+      {
+        source_work_id: "work-active-story",
+        sourceWorkName: "Active Story",
+        targetWorkId: "work-dependency-story",
+        targetWorkName: "Dependency Story",
+        type: "DEPENDS_ON",
+        requiredState: "ready",
+      },
+      {
+        source_work_id: "work-active-story",
+        sourceWorkName: "Active Story",
+        targetWorkId: "work-second-dependency-story",
+        targetWorkName: "Second Dependency Story",
+        type: "DEPENDS_ON",
+        requiredState: "ready",
+      },
+    ];
+    snapshot.runtime.active_executions_by_dispatch_id[
+      "dispatch-active-story"
+    ].work_items?.push({
+      display_name: "Second Dependency Story",
+      state: "ready",
+      trace_id: "trace-second-dependency-story",
+      work_id: "work-second-dependency-story",
+      work_type_id: "story",
+    });
+
+    const graph = buildSelectedWorkRelationshipGraph({
+      selectedWorkItem,
+      snapshot,
+    });
+
+    expect(graph.status).toBe("ready");
+    if (graph.status !== "ready") {
+      throw new Error(`expected ready graph, got ${graph.status}`);
+    }
+
+    expect(
+      graph.relations.filter((relation) => relation.type === "DEPENDS_ON"),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source_work_id: "work-active-story",
+          target_work_id: "work-dependency-story",
+          type: "DEPENDS_ON",
+        }),
+        expect.objectContaining({
+          source_work_id: "work-active-story",
+          target_work_id: "work-second-dependency-story",
+          type: "DEPENDS_ON",
+        }),
+      ]),
+    );
+    expect(
+      graph.edges.filter((edge) => edge.relationship === "DEPENDS_ON"),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sourceWorkID: "work-active-story",
+          targetWorkID: "work-dependency-story",
+        }),
+        expect.objectContaining({
+          sourceWorkID: "work-active-story",
+          targetWorkID: "work-second-dependency-story",
+        }),
+      ]),
+    );
+    expect(graph.relatedWork.map((node) => node.workID)).toEqual(
+      expect.arrayContaining([
+        "work-dependency-story",
+        "work-second-dependency-story",
+      ]),
+    );
+  });
+});

--- a/ui/src/features/current-selection/work-selection/lib/selected-work-relationship-graph.test.ts
+++ b/ui/src/features/current-selection/work-selection/lib/selected-work-relationship-graph.test.ts
@@ -1,135 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import type {
-  DashboardSnapshot,
-  DashboardWorkItemRef,
-} from "../../../../api/dashboard/types";
 import { buildSelectedWorkRelationshipGraph } from "./selected-work-relationship-graph";
-
-const selectedWorkItem: DashboardWorkItemRef = {
-  display_name: "Active Story",
-  state: "in_progress",
-  trace_id: "trace-active-story",
-  work_id: "work-active-story",
-  work_type_id: "story",
-};
-
-function snapshotFixture(): DashboardSnapshot & {
-  relationsByWorkID: Record<string, Array<Record<string, string>>>;
-} {
-  return {
-    factory_state: "RUNNING",
-    relationsByWorkID: {
-      "work-active-story": [
-        {
-          source_work_id: "work-active-story",
-          sourceWorkName: "Active Story",
-          targetWorkId: "work-dependency-story",
-          targetWorkName: "Dependency Story",
-          type: "DEPENDS_ON",
-          requiredState: "ready",
-        },
-        {
-          source_work_id: "work-active-story",
-          sourceWorkName: "Active Story",
-          targetWorkId: "work-parent-story",
-          targetWorkName: "Parent Story",
-          type: "PARENT_CHILD",
-        },
-      ],
-      "work-blocked-story": [
-        {
-          source_work_id: "work-blocked-story",
-          sourceWorkName: "Blocked Story",
-          targetWorkId: "work-active-story",
-          targetWorkName: "Active Story",
-          type: "DEPENDS_ON",
-          requiredState: "approved",
-        },
-      ],
-      "work-child-story": [
-        {
-          source_work_id: "work-child-story",
-          sourceWorkName: "Child Story",
-          targetWorkId: "work-active-story",
-          targetWorkName: "Active Story",
-          type: "PARENT_CHILD",
-        },
-      ],
-      "work-grandchild-story": [
-        {
-          source_work_id: "work-child-story",
-          sourceWorkName: "Child Story",
-          targetWorkId: "work-grandchild-story",
-          targetWorkName: "Grandchild Story",
-          type: "PARENT_CHILD",
-        },
-      ],
-    },
-    runtime: {
-      active_executions_by_dispatch_id: {
-        "dispatch-active-story": {
-          dispatch_id: "dispatch-active-story",
-          started_at: "2026-05-26T10:00:00Z",
-          transition_id: "transition-story",
-          work_items: [
-            selectedWorkItem,
-            {
-              display_name: "Dependency Story",
-              state: "ready",
-              trace_id: "trace-dependency-story",
-              work_id: "work-dependency-story",
-              work_type_id: "story",
-            },
-            {
-              display_name: "Parent Story",
-              state: "queued",
-              trace_id: "trace-parent-story",
-              work_id: "work-parent-story",
-              work_type_id: "epic",
-            },
-            {
-              display_name: "Blocked Story",
-              state: "blocked",
-              trace_id: "trace-blocked-story",
-              work_id: "work-blocked-story",
-              work_type_id: "story",
-            },
-            {
-              display_name: "Child Story",
-              state: "queued",
-              trace_id: "trace-child-story",
-              work_id: "work-child-story",
-              work_type_id: "task",
-            },
-            {
-              display_name: "Grandchild Story",
-              state: "queued",
-              trace_id: "trace-grandchild-story",
-              work_id: "work-grandchild-story",
-              work_type_id: "task",
-            },
-          ],
-          workstation_node_id: "transition-story",
-        },
-      },
-      in_flight_dispatch_count: 1,
-      session: {
-        completed_count: 0,
-        dispatched_count: 1,
-        failed_count: 0,
-        has_data: true,
-      },
-    },
-    tick_count: 4,
-    topology: {
-      edges: [],
-      workstation_node_ids: [],
-      workstation_nodes_by_id: {},
-    },
-    uptime_seconds: 42,
-  };
-}
+import {
+  selectedWorkItem,
+  snapshotFixture,
+} from "./selected-work-relationship-graph.fixture";
 
 describe("buildSelectedWorkRelationshipGraph", () => {
   it("builds the full connected relationship graph around the selected work item", () => {
@@ -167,19 +42,19 @@ describe("buildSelectedWorkRelationshipGraph", () => {
         type: "DEPENDS_ON",
       },
       {
-        source_work_id: "work-active-story",
-        source_work_name: "Active Story",
-        target_work_id: "work-parent-story",
-        target_work_name: "Parent Story",
-        type: "PARENT_CHILD",
-      },
-      {
         required_state: "approved",
         source_work_id: "work-blocked-story",
         source_work_name: "Blocked Story",
         target_work_id: "work-active-story",
         target_work_name: "Active Story",
         type: "DEPENDS_ON",
+      },
+      {
+        source_work_id: "work-active-story",
+        source_work_name: "Active Story",
+        target_work_id: "work-parent-story",
+        target_work_name: "Parent Story",
+        type: "PARENT_CHILD",
       },
       {
         source_work_id: "work-child-story",
@@ -198,10 +73,9 @@ describe("buildSelectedWorkRelationshipGraph", () => {
     ]);
     expect(graph.edges).toEqual([
       {
-        relationship: "DEPENDS_ON",
-        requiredState: "approved",
-        sourceWorkID: "work-blocked-story",
-        targetWorkID: "work-active-story",
+        relationship: "CHILD",
+        sourceWorkID: "work-active-story",
+        targetWorkID: "work-child-story",
       },
       {
         relationship: "DEPENDS_ON",
@@ -211,8 +85,8 @@ describe("buildSelectedWorkRelationshipGraph", () => {
       },
       {
         relationship: "PARENT",
-        sourceWorkID: "work-child-story",
-        targetWorkID: "work-active-story",
+        sourceWorkID: "work-active-story",
+        targetWorkID: "work-parent-story",
       },
       {
         relationship: "PARENT",
@@ -220,9 +94,10 @@ describe("buildSelectedWorkRelationshipGraph", () => {
         targetWorkID: "work-grandchild-story",
       },
       {
-        relationship: "PARENT",
+        relationship: "REQUIRED_BY",
+        requiredState: "approved",
         sourceWorkID: "work-active-story",
-        targetWorkID: "work-parent-story",
+        targetWorkID: "work-blocked-story",
       },
     ]);
   });

--- a/ui/src/features/current-selection/work-selection/lib/selected-work-relationship-graph.ts
+++ b/ui/src/features/current-selection/work-selection/lib/selected-work-relationship-graph.ts
@@ -92,7 +92,9 @@ export function buildSelectedWorkRelationshipGraph({
     selectedWork,
   );
   const relatedWorkByID = new Map<string, SelectedWorkRelationshipNode>();
-  const edges = relations.map(edgeForRelation).sort(compareEdges);
+  const edges = relations
+    .map((relation) => edgeForRelation(relation, selectedWork.workID))
+    .sort(compareEdges);
 
   for (const relation of relations) {
     if (relation.source_work_id !== selectedWork.workID) {
@@ -162,22 +164,6 @@ function nodeForWorkItem(
     workID: workItem.work_id,
     workTypeID: workItem.work_type_id || workItem.workTypeId,
   };
-}
-
-function _dedupeEdges(
-  edges: SelectedWorkRelationshipEdge[],
-): SelectedWorkRelationshipEdge[] {
-  const deduped = new Map<string, SelectedWorkRelationshipEdge>();
-  for (const edge of edges) {
-    const key = [
-      edge.relationship,
-      edge.sourceWorkID,
-      edge.targetWorkID,
-      edge.requiredState ?? "",
-    ].join("|");
-    deduped.set(key, edge);
-  }
-  return [...deduped.values()];
 }
 
 function connectedSupportedRelations(
@@ -259,40 +245,77 @@ function normalizeSupportedRelation(
     return null;
   }
 
+  const requestID =
+    trimString("requestId" in relation ? relation.requestId : undefined) ||
+    trimString("request_id" in relation ? relation.request_id : undefined);
+  const requiredState =
+    trimString(
+      "requiredState" in relation ? relation.requiredState : undefined,
+    ) ||
+    trimString(
+      "required_state" in relation ? relation.required_state : undefined,
+    );
+  const sourceWorkName =
+    trimString(
+      "sourceWorkName" in relation ? relation.sourceWorkName : undefined,
+    ) ||
+    trimString(
+      "source_work_name" in relation ? relation.source_work_name : undefined,
+    );
+  const targetWorkName =
+    trimString(
+      "targetWorkName" in relation ? relation.targetWorkName : undefined,
+    ) ||
+    trimString(
+      "target_work_name" in relation ? relation.target_work_name : undefined,
+    );
+  const traceID =
+    trimString("traceId" in relation ? relation.traceId : undefined) ||
+    trimString("trace_id" in relation ? relation.trace_id : undefined);
+
   return {
-    required_state:
-      trimString(
-        "requiredState" in relation ? relation.requiredState : undefined,
-      ) ||
-      trimString(
-        "required_state" in relation ? relation.required_state : undefined,
-      ),
+    ...(requestID ? { request_id: requestID } : {}),
+    ...(requiredState ? { required_state: requiredState } : {}),
     source_work_id: sourceWorkID,
-    source_work_name:
-      trimString(
-        "sourceWorkName" in relation ? relation.sourceWorkName : undefined,
-      ) ||
-      trimString(
-        "source_work_name" in relation ? relation.source_work_name : undefined,
-      ),
+    source_work_name: sourceWorkName,
+    ...(traceID ? { trace_id: traceID } : {}),
     target_work_id: targetWorkID,
-    target_work_name:
-      trimString(
-        "targetWorkName" in relation ? relation.targetWorkName : undefined,
-      ) ||
-      trimString(
-        "target_work_name" in relation ? relation.target_work_name : undefined,
-      ),
+    target_work_name: targetWorkName,
     type: type === "PARENT" ? "PARENT_CHILD" : type,
   };
 }
 
 function edgeForRelation(
   relation: ConnectedDashboardWorkRelation,
+  selectedWorkID: string,
 ): SelectedWorkRelationshipEdge {
+  if (relation.source_work_id === selectedWorkID) {
+    return {
+      relationship: relation.type === "PARENT_CHILD" ? "PARENT" : "DEPENDS_ON",
+      ...(relation.required_state
+        ? { requiredState: relation.required_state }
+        : {}),
+      sourceWorkID: relation.source_work_id,
+      targetWorkID: relation.target_work_id,
+    };
+  }
+
+  if (relation.target_work_id === selectedWorkID) {
+    return {
+      relationship: relation.type === "PARENT_CHILD" ? "CHILD" : "REQUIRED_BY",
+      ...(relation.required_state
+        ? { requiredState: relation.required_state }
+        : {}),
+      sourceWorkID: relation.target_work_id,
+      targetWorkID: relation.source_work_id,
+    };
+  }
+
   return {
     relationship: relation.type === "PARENT_CHILD" ? "PARENT" : "DEPENDS_ON",
-    requiredState: relation.required_state,
+    ...(relation.required_state
+      ? { requiredState: relation.required_state }
+      : {}),
     sourceWorkID: relation.source_work_id,
     targetWorkID: relation.target_work_id,
   };
@@ -303,12 +326,7 @@ function dedupeDashboardRelations(
 ): ConnectedDashboardWorkRelation[] {
   const deduped = new Map<string, ConnectedDashboardWorkRelation>();
   for (const relation of relations) {
-    const key = [
-      relation.type,
-      relation.source_work_id,
-      relation.target_work_id,
-      relation.required_state ?? "",
-    ].join("|");
+    const key = relationInstanceKey(relation);
     if (!deduped.has(key)) {
       deduped.set(key, relation);
     }
@@ -316,16 +334,22 @@ function dedupeDashboardRelations(
   return [...deduped.values()];
 }
 
+function relationInstanceKey(relation: ConnectedDashboardWorkRelation): string {
+  return [
+    relation.type,
+    relation.source_work_id,
+    relation.target_work_id,
+    relation.required_state ?? "",
+    relation.request_id ?? "",
+    relation.trace_id ?? "",
+  ].join("|");
+}
+
 function compareRelations(
   left: ConnectedDashboardWorkRelation,
   right: ConnectedDashboardWorkRelation,
 ): number {
-  return (
-    left.source_work_id.localeCompare(right.source_work_id) ||
-    left.target_work_id.localeCompare(right.target_work_id) ||
-    left.type.localeCompare(right.type) ||
-    (left.required_state ?? "").localeCompare(right.required_state ?? "")
-  );
+  return relationInstanceKey(left).localeCompare(relationInstanceKey(right));
 }
 
 function trimString(value: unknown): string | undefined {
@@ -338,6 +362,7 @@ function compareEdges(
 ): number {
   return (
     left.relationship.localeCompare(right.relationship) ||
+    left.sourceWorkID.localeCompare(right.sourceWorkID) ||
     left.targetWorkID.localeCompare(right.targetWorkID) ||
     (left.requiredState ?? "").localeCompare(right.requiredState ?? "")
   );

--- a/ui/src/features/current-selection/work-selection/lib/selected-work-relationship-relations.instances.test.ts
+++ b/ui/src/features/current-selection/work-selection/lib/selected-work-relationship-relations.instances.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSelectedWorkRelationshipGraph } from "./selected-work-relationship-graph";
+import {
+  selectedWorkItem,
+  snapshotFixture,
+} from "./selected-work-relationship-graph.fixture";
+import { projectSelectedWorkRelationshipGraphToDashboardRelations } from "./selected-work-relationship-relations";
+
+function repeatedDependsOnSnapshot() {
+  const snapshot = snapshotFixture();
+  snapshot.relationsByWorkID["work-active-story"] = [
+    {
+      source_work_id: "work-active-story",
+      sourceWorkName: "Active Story",
+      targetWorkId: "work-dependency-story",
+      targetWorkName: "Dependency Story",
+      type: "DEPENDS_ON",
+      requiredState: "ready",
+    },
+    {
+      source_work_id: "work-active-story",
+      sourceWorkName: "Active Story",
+      targetWorkId: "work-second-dependency-story",
+      targetWorkName: "Second Dependency Story",
+      type: "DEPENDS_ON",
+      requiredState: "ready",
+    },
+  ];
+  snapshot.runtime.active_executions_by_dispatch_id[
+    "dispatch-active-story"
+  ].work_items?.push({
+    display_name: "Second Dependency Story",
+    state: "ready",
+    trace_id: "trace-second-dependency-story",
+    work_id: "work-second-dependency-story",
+    work_type_id: "story",
+  });
+  return snapshot;
+}
+
+describe("projectSelectedWorkRelationshipGraphToDashboardRelations repeated DEPENDS_ON", () => {
+  it("projects every dependency relation instance from a ready selected-work graph", () => {
+    const graph = buildSelectedWorkRelationshipGraph({
+      selectedWorkItem,
+      snapshot: repeatedDependsOnSnapshot(),
+    });
+
+    expect(graph.status).toBe("ready");
+    if (graph.status !== "ready") {
+      throw new Error(`expected ready graph, got ${graph.status}`);
+    }
+
+    const relations = projectSelectedWorkRelationshipGraphToDashboardRelations(
+      graph,
+    );
+
+    expect(
+      relations?.filter(
+        (relation) =>
+          relation.type === "DEPENDS_ON" &&
+          relation.source_work_id === "work-active-story",
+      ),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source_work_id: "work-active-story",
+          target_work_id: "work-dependency-story",
+          type: "DEPENDS_ON",
+        }),
+        expect.objectContaining({
+          source_work_id: "work-active-story",
+          target_work_id: "work-second-dependency-story",
+          type: "DEPENDS_ON",
+        }),
+      ]),
+    );
+    expect(relations).toHaveLength(graph.relations.length);
+  });
+});

--- a/ui/src/features/current-selection/work-selection/lib/selected-work-relationship-relations.test.ts
+++ b/ui/src/features/current-selection/work-selection/lib/selected-work-relationship-relations.test.ts
@@ -136,4 +136,36 @@ describe("projectSelectedWorkRelationshipGraphToDashboardRelations", () => {
       }),
     ).toBeUndefined();
   });
+
+  it("projects repeated dependency edges when direct relations are unavailable", () => {
+    const graph = readyGraph();
+    const edgeOnlyGraph: SelectedWorkRelationshipGraph = {
+      ...graph,
+      relations: [],
+    };
+
+    expect(
+      projectSelectedWorkRelationshipGraphToDashboardRelations(edgeOnlyGraph),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          required_state: "ready",
+          source_work_id: "work-active-story",
+          target_work_id: "work-dependency-story",
+          type: "DEPENDS_ON",
+        }),
+        expect.objectContaining({
+          required_state: "approved",
+          source_work_id: "work-blocked-story",
+          target_work_id: "work-active-story",
+          type: "DEPENDS_ON",
+        }),
+        expect.objectContaining({
+          source_work_id: "work-active-story",
+          target_work_id: "work-parent-story",
+          type: "PARENT_CHILD",
+        }),
+      ]),
+    );
+  });
 });

--- a/ui/src/features/current-selection/work-selection/lib/selected-work-relationship-relations.ts
+++ b/ui/src/features/current-selection/work-selection/lib/selected-work-relationship-relations.ts
@@ -43,18 +43,24 @@ export function projectSelectedWorkRelationshipGraphToDashboardRelations(
 
   for (const edge of relationshipGraph.edges) {
     const relation = toDashboardRelation(edge, workNodesByID);
-    const key = [
-      relation.type,
-      relation.source_work_id ?? "",
-      relation.target_work_id,
-      relation.required_state ?? "",
-    ].join("|");
+    const key = relationInstanceKey(relation);
     if (!relationsByKey.has(key)) {
       relationsByKey.set(key, relation);
     }
   }
 
   return [...relationsByKey.values()];
+}
+
+function relationInstanceKey(relation: DashboardWorkRelation): string {
+  return [
+    relation.type,
+    relation.source_work_id ?? "",
+    relation.target_work_id,
+    relation.required_state ?? "",
+    relation.request_id ?? "",
+    relation.trace_id ?? "",
+  ].join("|");
 }
 
 function toDashboardRelation(

--- a/ui/src/features/graphs/components/work-relation-node.test.tsx
+++ b/ui/src/features/graphs/components/work-relation-node.test.tsx
@@ -1,0 +1,158 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { NodeProps } from "@xyflow/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { WorkRelationNode } from "./work-relation-node";
+import { WORK_RELATION_NODE_TYPES } from "./work-relation-node";
+
+const RelationNode = WORK_RELATION_NODE_TYPES.workRelation;
+
+function relationNodeProps(
+  data: WorkRelationNode["data"],
+): NodeProps<WorkRelationNode> {
+  return {
+    data,
+    dragging: false,
+    id: data.endpointKey ?? "work-a",
+    isConnectable: false,
+    selected: false,
+    type: "workRelation",
+    zIndex: 0,
+  };
+}
+
+function relationNodeData(
+  overrides: Partial<WorkRelationNode["data"]> = {},
+): WorkRelationNode["data"] {
+  return {
+    connectionAnchors: [],
+    displayLabel: "Story A",
+    endpointKey: "work-a",
+    factoryNodeId: "work-type:story-a:work-a",
+    isSelectedWork: false,
+    kind: "work-type",
+    kindLabel: "Work type",
+    locale: "en",
+    relationStates: [],
+    relationTypes: ["DEPENDS_ON"],
+    selectable: false,
+    ...overrides,
+  };
+}
+
+describe("WorkRelationNodeView readability", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("uses workstation-aligned surfaces for related work-type nodes", () => {
+    render(<RelationNode {...relationNodeProps(relationNodeData())} />);
+
+    const node = screen.getByText("Story A").closest("article");
+    if (!node) {
+      throw new Error("Expected relation node shell to render.");
+    }
+
+    expect(node.className).toContain("border-outline-variant");
+    expect(node.className).toContain("bg-surface-container-highest");
+    expect(node.className).toContain("border-info-border");
+  });
+
+  it("emphasizes the selected work item more strongly than related nodes", () => {
+    const { rerender } = render(
+      <RelationNode
+        {...relationNodeProps(
+          relationNodeData({
+            displayLabel: "Active Story",
+            isSelectedWork: true,
+          }),
+        )}
+      />,
+    );
+
+    const selectedNode = screen.getByText("Active Story").closest("article");
+    if (!selectedNode) {
+      throw new Error("Expected selected relation node shell to render.");
+    }
+
+    expect(selectedNode.className).toContain("border-primary");
+    expect(selectedNode.className).toContain("bg-primary-container");
+    expect(selectedNode.className).toContain("shadow-af-accent-selected");
+
+    rerender(
+      <RelationNode
+        {...relationNodeProps(
+          relationNodeData({
+            displayLabel: "Dependency Story",
+            selectable: true,
+            workID: "work-dependency-story",
+          }),
+        )}
+      />,
+    );
+
+    const relatedNode = screen.getByText("Dependency Story").closest("article");
+    if (!relatedNode) {
+      throw new Error("Expected related relation node shell to render.");
+    }
+
+    expect(relatedNode.className).toContain("bg-info-container");
+    expect(relatedNode.className).toContain("border-info-border");
+    expect(relatedNode.className).not.toContain("shadow-af-accent-selected");
+    expect(relatedNode.className).not.toContain(
+      "border-primary bg-primary-container shadow-af-accent-selected",
+    );
+  });
+
+  it("wraps long labels with a smaller readable font instead of truncating", () => {
+    const longLabel =
+      "Dependency Story With A Very Long Operator Readable Name";
+
+    render(
+      <RelationNode
+        {...relationNodeProps(
+          relationNodeData({
+            displayLabel: longLabel,
+          }),
+        )}
+      />,
+    );
+
+    const label = screen.getByText(longLabel);
+    expect(label.className).toContain("break-words");
+    expect(label.className).toContain("[overflow-wrap:anywhere]");
+    expect(label.className).toContain("text-[0.72rem]");
+    expect(label.className).not.toContain("truncate");
+    expect(label.className).not.toContain("whitespace-nowrap");
+  });
+
+  it("keeps keyboard activation and focus styling for selectable related work", async () => {
+    const onSelectWorkID = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <RelationNode
+        {...relationNodeProps(
+          relationNodeData({
+            displayLabel: "Story B",
+            onSelectWorkID,
+            selectable: true,
+            workID: "work-b",
+          }),
+        )}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Story B" });
+    fireEvent.click(button);
+    button.focus();
+    await user.keyboard("{Enter}");
+    await user.keyboard(" ");
+
+    expect(onSelectWorkID).toHaveBeenNthCalledWith(1, "work-b");
+    expect(onSelectWorkID).toHaveBeenNthCalledWith(2, "work-b");
+    expect(onSelectWorkID).toHaveBeenNthCalledWith(3, "work-b");
+    expect(button.className).toContain("focus-visible:ring-af-focus-ring");
+  });
+});

--- a/ui/src/features/graphs/components/work-relation-node.tsx
+++ b/ui/src/features/graphs/components/work-relation-node.tsx
@@ -5,7 +5,6 @@ import { cn } from "../../../lib/cn";
 import type { FactoryGraphNodeKind } from "../../factory-graph-editor/lib/draft/factory-graph-draft-types";
 import {
   activityGraphNodeSurfaceClassName,
-  activityGraphNodeTitleClassName,
 } from "../../flowchart/components/current-activity-node-chrome";
 import { GraphNodeButton } from "./graph-node-button";
 import {
@@ -27,19 +26,28 @@ export interface WorkRelationNodeData extends Record<string, unknown> {
 
 export type WorkRelationNode = Node<WorkRelationNodeData, "workRelation">;
 
+const RELATION_LABEL_COMPACT_LENGTH = 24;
+const RELATION_LABEL_DENSE_LENGTH = 40;
 const RELATION_NODE_ACTIVE_CLASS =
   "hover:border-primary hover:bg-primary-container";
 const RELATION_NODE_SELECTED_CLASS =
   "border-primary bg-primary-container shadow-af-accent-selected";
 const RELATION_NODE_CLASS =
-  "min-w-0 w-full justify-start overflow-hidden text-left shadow-none";
+  "min-w-0 w-full justify-start text-left shadow-none";
+const RELATION_WORKSTATION_SURFACE_CLASS = cn(
+  activityGraphNodeSurfaceClassName("workstation"),
+  "border-info-border",
+);
 
 export function WorkRelationNodeView({ data }: NodeProps<WorkRelationNode>) {
   const shellClassName = cn(
     RELATION_NODE_CLASS,
+    "border-2",
     data.isSelectedWork
       ? RELATION_NODE_SELECTED_CLASS
-      : relationNodeToneClassName(data.kind, data.relationStates),
+      : data.selectable
+        ? cn(RELATION_WORKSTATION_SURFACE_CLASS, "bg-info-container")
+        : relationNodeToneClassName(data.kind, data.relationStates),
     data.selectable ? RELATION_NODE_ACTIVE_CLASS : undefined,
   );
   const content = (
@@ -51,12 +59,9 @@ export function WorkRelationNodeView({ data }: NodeProps<WorkRelationNode>) {
       }))}
       nodeType={relationShellNodeType(data.kind)}
     >
-      <div className="grid h-full min-w-0 content-center">
+      <div className="grid h-full min-h-0 min-w-0 content-center">
         <DashboardText
-          className={cn(
-            "m-0 [overflow-wrap:anywhere]",
-            activityGraphNodeTitleClassName("text-sm"),
-          )}
+          className={relationNodeLabelClassName(data.displayLabel)}
           data-factory-entity-title
           title={data.workID ?? data.displayLabel}
         >
@@ -129,6 +134,20 @@ function relationStateToneClassName(
   return "warning";
 }
 
+function relationNodeLabelClassName(label: string): string {
+  const textSizeClassName =
+    label.length > RELATION_LABEL_DENSE_LENGTH
+      ? "text-[0.72rem]"
+      : label.length > RELATION_LABEL_COMPACT_LENGTH
+        ? "text-[0.78rem]"
+        : "text-sm";
+
+  return cn(
+    "m-0 block min-w-0 break-words font-bold leading-tight text-on-surface [overflow-wrap:anywhere]",
+    textSizeClassName,
+  );
+}
+
 function relationNodeToneClassName(
   kind: FactoryGraphNodeKind,
   relationStates: string[],
@@ -141,15 +160,16 @@ function relationNodeToneClassName(
     case "work-state":
       return activityGraphNodeSurfaceClassName("workState");
     case "workstation":
-      return activityGraphNodeSurfaceClassName("workstation");
-    case "worker":
+      return RELATION_WORKSTATION_SURFACE_CLASS;
     case "work-type":
+      return RELATION_WORKSTATION_SURFACE_CLASS;
+    case "worker":
       break;
   }
 
   const primaryState = relationStates[0];
   if (!primaryState) {
-    return activityGraphNodeSurfaceClassName("neutral");
+    return RELATION_WORKSTATION_SURFACE_CLASS;
   }
 
   const tone = relationStateToneClassName(primaryState);

--- a/ui/src/features/trace-drilldown/components/trace-factory-graph-nodes.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-factory-graph-nodes.test.tsx
@@ -162,7 +162,7 @@ describe("Trace relation factory graph node", () => {
     cleanup();
   });
 
-  it("renders only the work label while preserving neutral relation chrome", () => {
+  it("renders only the work label with workstation-aligned relation chrome", () => {
     render(
       <RelationNode
         {...relationNodeProps({
@@ -170,6 +170,7 @@ describe("Trace relation factory graph node", () => {
           displayLabel: "Story A",
           endpointKey: "work-a",
           factoryNodeId: "work-type:story-a:work-a",
+          isSelectedWork: false,
           kind: "work-type",
           kindLabel: "Work type",
           locale: "en",
@@ -187,8 +188,9 @@ describe("Trace relation factory graph node", () => {
     if (!node) {
       throw new Error("Expected relation node shell to render.");
     }
-    expect(node.className).toContain("border-outline");
-    expect(node.className).toContain("bg-surface");
+    expect(node.className).toContain("border-outline-variant");
+    expect(node.className).toContain("bg-surface-container-highest");
+    expect(node.className).toContain("border-info-border");
     expect(node.className).toContain("shadow-none");
     expect(node.className).not.toContain("shadow-af-card");
     expect(node.className).not.toContain("shadow-af-panel");
@@ -247,6 +249,7 @@ describe("Trace relation factory graph node", () => {
           displayLabel: "Story B",
           endpointKey: "work-b",
           factoryNodeId: "work-state:story:done",
+          isSelectedWork: false,
           kind: "work-state",
           kindLabel: "Work state",
           locale: "en",

--- a/ui/src/features/trace-drilldown/components/trace-factory-graph-nodes.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-factory-graph-nodes.test.tsx
@@ -1,15 +1,11 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { cleanup, render, screen } from "@testing-library/react";
 import type { NodeProps } from "@xyflow/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
-import { WORK_RELATION_NODE_TYPES } from "../../graphs/public";
 import type { TraceDispatchFlowNode } from "../lib/trace-dispatch-factory-graph-flow";
-import type { TraceRelationFlowNode } from "../lib/trace-relation-factory-graph-flow";
 import { TRACE_DISPATCH_FACTORY_GRAPH_NODE_TYPES } from "./trace-dispatch-factory-graph-node";
 
 const DispatchNode = TRACE_DISPATCH_FACTORY_GRAPH_NODE_TYPES.workstation;
-const RelationNode = WORK_RELATION_NODE_TYPES.workRelation;
 
 function dispatchNodeProps(
   data: TraceDispatchFlowNode["data"],
@@ -51,20 +47,6 @@ function dispatchNodeData(
     },
     ...overrides,
   } as never;
-}
-
-function relationNodeProps(
-  data: TraceRelationFlowNode["data"],
-): NodeProps<TraceRelationFlowNode> {
-  return {
-    data,
-    dragging: false,
-    id: data.endpointKey,
-    isConnectable: false,
-    selected: false,
-    type: "workRelation",
-    zIndex: 0,
-  };
 }
 
 describe("Trace dispatch factory graph node", () => {
@@ -152,134 +134,6 @@ describe("Trace dispatch factory graph node", () => {
       "border-outline-variant bg-surface-container-highest",
     );
     expect(node.className).toContain("border-info-border");
-    expect(node.className).not.toContain("shadow-af-card");
-    expect(node.className).not.toContain("shadow-af-panel");
-  });
-});
-
-describe("Trace relation factory graph node", () => {
-  afterEach(() => {
-    cleanup();
-  });
-
-  it("renders only the work label with workstation-aligned relation chrome", () => {
-    render(
-      <RelationNode
-        {...relationNodeProps({
-          connectionAnchors: [],
-          displayLabel: "Story A",
-          endpointKey: "work-a",
-          factoryNodeId: "work-type:story-a:work-a",
-          isSelectedWork: false,
-          kind: "work-type",
-          kindLabel: "Work type",
-          locale: "en",
-          relationStates: [],
-          relationTypes: ["DEPENDS_ON"],
-          selectable: false,
-        })}
-      />,
-    );
-
-    expect(screen.getByText("Story A")).toBeTruthy();
-    expect(screen.queryByText("Work type")).toBeNull();
-    expect(screen.queryByText("Depends on")).toBeNull();
-    const node = screen.getByText("Story A").closest("article");
-    if (!node) {
-      throw new Error("Expected relation node shell to render.");
-    }
-    expect(node.className).toContain("border-outline-variant");
-    expect(node.className).toContain("bg-surface-container-highest");
-    expect(node.className).toContain("border-info-border");
-    expect(node.className).toContain("shadow-none");
-    expect(node.className).not.toContain("shadow-af-card");
-    expect(node.className).not.toContain("shadow-af-panel");
-  });
-
-  it("does not render semantic icons or metadata badges for non-work nodes", () => {
-    render(
-      <RelationNode
-        {...relationNodeProps({
-          connectionAnchors: [],
-          displayLabel: "Worker A",
-          endpointKey: "worker-a",
-          factoryNodeId: "worker:worker-a",
-          kind: "worker",
-          kindLabel: "Worker",
-          locale: "en",
-          relationStates: [],
-          relationTypes: [],
-          selectable: false,
-        })}
-      />,
-    );
-    expect(screen.getByText("Worker A")).toBeTruthy();
-    expect(screen.queryByLabelText("Worker")).toBeNull();
-
-    cleanup();
-
-    render(
-      <RelationNode
-        {...relationNodeProps({
-          connectionAnchors: [],
-          displayLabel: "GPU",
-          endpointKey: "resource-gpu",
-          factoryNodeId: "resource:gpu",
-          kind: "resource",
-          kindLabel: "Resource",
-          locale: "en",
-          relationStates: [],
-          relationTypes: [],
-          selectable: false,
-        })}
-      />,
-    );
-    expect(screen.getByText("GPU")).toBeTruthy();
-    expect(screen.queryByLabelText("Resource")).toBeNull();
-  });
-
-  it("invokes onSelectWorkID for selectable relation endpoints", async () => {
-    const onSelectWorkID = vi.fn();
-    const user = userEvent.setup();
-
-    render(
-      <RelationNode
-        {...relationNodeProps({
-          connectionAnchors: [],
-          displayLabel: "Story B",
-          endpointKey: "work-b",
-          factoryNodeId: "work-state:story:done",
-          isSelectedWork: false,
-          kind: "work-state",
-          kindLabel: "Work state",
-          locale: "en",
-          onSelectWorkID,
-          relationStates: ["FAILED"],
-          relationTypes: ["RETRY"],
-          selectable: true,
-          workID: "work-b",
-        })}
-      />,
-    );
-
-    const button = screen.getByRole("button", { name: "Story B" });
-    fireEvent.click(button);
-    button.focus();
-    await user.keyboard("{Enter}");
-    await user.keyboard(" ");
-
-    expect(onSelectWorkID).toHaveBeenNthCalledWith(1, "work-b");
-    expect(onSelectWorkID).toHaveBeenNthCalledWith(2, "work-b");
-    expect(onSelectWorkID).toHaveBeenNthCalledWith(3, "work-b");
-    expect(screen.queryByText("Failed")).toBeNull();
-    expect(screen.queryByText("Retry")).toBeNull();
-    const node = screen.getByText("Story B").closest("article");
-    if (!node) {
-      throw new Error("Expected relation node shell to render.");
-    }
-    expect(node.className).toContain("border-info-border");
-    expect(node.className).toContain("bg-info-container");
-    expect(node.className).toContain("shadow-none");
     expect(node.className).not.toContain("shadow-af-card");
     expect(node.className).not.toContain("shadow-af-panel");
   });

--- a/ui/src/features/trace-drilldown/components/trace-relation-factory-graph-nodes.test.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-relation-factory-graph-nodes.test.tsx
@@ -1,0 +1,157 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { NodeProps } from "@xyflow/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { WORK_RELATION_NODE_TYPES } from "../../graphs/public";
+import type { TraceRelationFlowNode } from "../lib/trace-relation-factory-graph-flow";
+
+const RelationNode = WORK_RELATION_NODE_TYPES.workRelation;
+
+function relationNodeProps(
+  data: TraceRelationFlowNode["data"],
+): NodeProps<TraceRelationFlowNode> {
+  return {
+    data,
+    dragging: false,
+    id: data.endpointKey,
+    isConnectable: false,
+    selected: false,
+    type: "workRelation",
+    zIndex: 0,
+  };
+}
+
+describe("Trace relation factory graph node rendering", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders only the work label with workstation-aligned relation chrome", () => {
+    render(
+      <RelationNode
+        {...relationNodeProps({
+          connectionAnchors: [],
+          displayLabel: "Story A",
+          endpointKey: "work-a",
+          factoryNodeId: "work-type:story-a:work-a",
+          isSelectedWork: false,
+          kind: "work-type",
+          kindLabel: "Work type",
+          locale: "en",
+          relationStates: [],
+          relationTypes: ["DEPENDS_ON"],
+          selectable: false,
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Story A")).toBeTruthy();
+    expect(screen.queryByText("Work type")).toBeNull();
+    expect(screen.queryByText("Depends on")).toBeNull();
+    const node = screen.getByText("Story A").closest("article");
+    if (!node) {
+      throw new Error("Expected relation node shell to render.");
+    }
+    expect(node.className).toContain("border-outline-variant");
+    expect(node.className).toContain("bg-surface-container-highest");
+    expect(node.className).toContain("border-info-border");
+    expect(node.className).toContain("shadow-none");
+    expect(node.className).not.toContain("shadow-af-card");
+    expect(node.className).not.toContain("shadow-af-panel");
+  });
+
+  it("does not render semantic icons or metadata badges for non-work nodes", () => {
+    render(
+      <RelationNode
+        {...relationNodeProps({
+          connectionAnchors: [],
+          displayLabel: "Worker A",
+          endpointKey: "worker-a",
+          factoryNodeId: "worker:worker-a",
+          kind: "worker",
+          kindLabel: "Worker",
+          locale: "en",
+          relationStates: [],
+          relationTypes: [],
+          selectable: false,
+        })}
+      />,
+    );
+    expect(screen.getByText("Worker A")).toBeTruthy();
+    expect(screen.queryByLabelText("Worker")).toBeNull();
+
+    cleanup();
+
+    render(
+      <RelationNode
+        {...relationNodeProps({
+          connectionAnchors: [],
+          displayLabel: "GPU",
+          endpointKey: "resource-gpu",
+          factoryNodeId: "resource:gpu",
+          kind: "resource",
+          kindLabel: "Resource",
+          locale: "en",
+          relationStates: [],
+          relationTypes: [],
+          selectable: false,
+        })}
+      />,
+    );
+    expect(screen.getByText("GPU")).toBeTruthy();
+    expect(screen.queryByLabelText("Resource")).toBeNull();
+  });
+});
+
+describe("Trace relation factory graph node selection", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("invokes onSelectWorkID for selectable relation endpoints", async () => {
+    const onSelectWorkID = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <RelationNode
+        {...relationNodeProps({
+          connectionAnchors: [],
+          displayLabel: "Story B",
+          endpointKey: "work-b",
+          factoryNodeId: "work-state:story:done",
+          isSelectedWork: false,
+          kind: "work-state",
+          kindLabel: "Work state",
+          locale: "en",
+          onSelectWorkID,
+          relationStates: ["FAILED"],
+          relationTypes: ["RETRY"],
+          selectable: true,
+          workID: "work-b",
+        })}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Story B" });
+    fireEvent.click(button);
+    button.focus();
+    await user.keyboard("{Enter}");
+    await user.keyboard(" ");
+
+    expect(onSelectWorkID).toHaveBeenNthCalledWith(1, "work-b");
+    expect(onSelectWorkID).toHaveBeenNthCalledWith(2, "work-b");
+    expect(onSelectWorkID).toHaveBeenNthCalledWith(3, "work-b");
+    expect(screen.queryByText("Failed")).toBeNull();
+    expect(screen.queryByText("Retry")).toBeNull();
+    const node = screen.getByText("Story B").closest("article");
+    if (!node) {
+      throw new Error("Expected relation node shell to render.");
+    }
+    expect(node.className).toContain("border-info-border");
+    expect(node.className).toContain("bg-info-container");
+    expect(node.className).toContain("shadow-none");
+    expect(node.className).not.toContain("shadow-af-card");
+    expect(node.className).not.toContain("shadow-af-panel");
+  });
+});

--- a/ui/src/features/trace-drilldown/components/trace-relation-flow.tsx
+++ b/ui/src/features/trace-drilldown/components/trace-relation-flow.tsx
@@ -7,7 +7,10 @@ import {
   type ReactFlowInstance,
 } from "@xyflow/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { DashboardWorkRelation } from "../../../api/dashboard/types";
+import type {
+  DashboardWorkItemRef,
+  DashboardWorkRelation,
+} from "../../../api/dashboard/types";
 import {
   DashboardGraphBackground,
   DashboardGraphControls,
@@ -36,6 +39,7 @@ export interface TraceRelationFlowProps {
   onSelectWorkID?: (workID: string) => void;
   relations: DashboardWorkRelation[];
   selectedWorkID?: string | null;
+  workItemsByWorkId?: ReadonlyMap<string, DashboardWorkItemRef>;
 }
 
 export function TraceRelationFlow({
@@ -43,6 +47,7 @@ export function TraceRelationFlow({
   onSelectWorkID,
   relations,
   selectedWorkID,
+  workItemsByWorkId,
 }: TraceRelationFlowProps) {
   const graph = useMemo(
     () =>
@@ -50,8 +55,9 @@ export function TraceRelationFlow({
         locale,
         onSelectWorkID,
         selectedWorkID,
+        workItemsByWorkId,
       }),
-    [locale, onSelectWorkID, relations, selectedWorkID],
+    [locale, onSelectWorkID, relations, selectedWorkID, workItemsByWorkId],
   );
   const topologyKey = useMemo(
     () => traceRelationTopologyLayoutKey(graph.topology),

--- a/ui/src/features/trace-drilldown/lib/trace-relation-factory-graph-flow.test.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-relation-factory-graph-flow.test.ts
@@ -157,6 +157,44 @@ describe("buildTraceRelationFactoryGraphFlow relation styling", () => {
   });
 });
 
+describe("buildTraceRelationFactoryGraphFlow repeated DEPENDS_ON", () => {
+  it("renders distinct dependency edges and nodes for each relation instance", () => {
+    const flow = buildTraceRelationFactoryGraphFlow([
+      {
+        request_id: "request-dependency-a",
+        required_state: "ready",
+        source_work_id: "work-active-story",
+        source_work_name: "Active Story",
+        target_work_id: "work-dependency-story",
+        target_work_name: "Dependency Story",
+        type: "DEPENDS_ON",
+      },
+      {
+        request_id: "request-dependency-b",
+        required_state: "ready",
+        source_work_id: "work-active-story",
+        source_work_name: "Active Story",
+        target_work_id: "work-second-dependency-story",
+        target_work_name: "Second Dependency Story",
+        type: "DEPENDS_ON",
+      },
+    ]);
+
+    expect(flow.nodes.map((node) => node.id).sort()).toEqual([
+      "work-active-story",
+      "work-dependency-story",
+      "work-second-dependency-story",
+    ]);
+    expect(flow.edges).toHaveLength(2);
+    expect(
+      flow.edges.map((edge) => `${edge.source}->${edge.target}`).sort(),
+    ).toEqual([
+      "work-active-story->work-dependency-story",
+      "work-active-story->work-second-dependency-story",
+    ]);
+  });
+});
+
 describe("buildTraceRelationFactoryGraphFlow selection", () => {
   it("marks relation nodes selectable when onSelectWorkID is provided", () => {
     const onSelectWorkID = vi.fn();

--- a/ui/src/features/trace-drilldown/lib/trace-relation-factory-graph-flow.ts
+++ b/ui/src/features/trace-drilldown/lib/trace-relation-factory-graph-flow.ts
@@ -54,7 +54,7 @@ export function buildTraceRelationFactoryGraphFlow(
     mode: "observer",
     topology: traceProjection.topology,
   });
-  const nodes: TraceRelationFlowNode[] = [];
+  const nodesByEndpointKey = new Map<string, TraceRelationFlowNode>();
 
   for (const node of factoryProjection.nodes) {
     const overlay = traceProjection.overlaysByNodeId.get(node.id);
@@ -66,7 +66,7 @@ export function buildTraceRelationFactoryGraphFlow(
     const isSelectedWork = Boolean(
       selectedWorkID && overlay.workID === selectedWorkID,
     );
-    nodes.push({
+    const nextNode: TraceRelationFlowNode = {
       ...node,
       data: {
         ...node.data,
@@ -86,8 +86,20 @@ export function buildTraceRelationFactoryGraphFlow(
       sourcePosition: Position.Right,
       targetPosition: Position.Left,
       type: "workRelation",
-    });
+    };
+    const existingNode = nodesByEndpointKey.get(endpointKey);
+    if (existingNode) {
+      nodesByEndpointKey.set(
+        endpointKey,
+        mergeTraceRelationFlowNodes(existingNode, nextNode),
+      );
+      continue;
+    }
+
+    nodesByEndpointKey.set(endpointKey, nextNode);
   }
+
+  const nodes = [...nodesByEndpointKey.values()];
 
   const edges = factoryProjection.edges.map((edge) => {
     const overlay = traceProjection.edgeOverlaysByEdgeId.get(edge.id);
@@ -124,6 +136,30 @@ export function buildTraceRelationFactoryGraphFlow(
     endpointKeyByNodeId: traceProjection.endpointKeyByNodeId,
     nodes,
     topology: traceProjection.topology,
+  };
+}
+
+function mergeTraceRelationFlowNodes(
+  left: TraceRelationFlowNode,
+  right: TraceRelationFlowNode,
+): TraceRelationFlowNode {
+  return {
+    ...left,
+    data: {
+      ...left.data,
+      ...right.data,
+      relationStates: [
+        ...new Set([
+          ...left.data.relationStates,
+          ...right.data.relationStates,
+        ]),
+      ].sort(),
+      relationTypes: [
+        ...new Set([...left.data.relationTypes, ...right.data.relationTypes]),
+      ].sort(),
+      isSelectedWork: left.data.isSelectedWork || right.data.isSelectedWork,
+      selectable: left.data.selectable || right.data.selectable,
+    },
   };
 }
 


### PR DESCRIPTION
{
  "project": "Current Selection Work Relationships Graph Repair",
  "branchName": "work-relationships-current-selection-graph-repair",
  "description": "Repair the current-selection work relationships graph so it shows every supported relationship instance for the selected work item, including repeated DEPENDS_ON relationships, and improve node readability with clearer colors and non-clipping labels.",
  "context": {
    "customerAsk": "Currently, on the work relationships graph of a current selection, only a single relationship is presented when multiple can be presented. For example, if you have two DEPENDS_ON relationships, only the first is presented on the graph. Fix this so all relationships are present. Also make the work selection's nodes less inscrutable by using a different color similar to workstation nodes in the factory graph, and prevent text from getting cut off by using a smaller font or wrapping onto the next line.",
    "problem": "The current-selection work-item detail graph does not fully represent repeated relationship instances, so customers can miss real dependencies when a selected work item has more than one relation of the same type. The graph is also hard to read because relationship nodes use an unclear visual treatment and long labels clip inside the node shell.",
    "solution": "Preserve every supported relationship instance through the selected-work relationship graph model and rendered current-selection graph, then update relationship-node styling to use a clearer palette and readable label layout so operators can see all related work and understand the graph at a glance."
  },
  "acceptanceCriteria": [
    "The current-selection work relationships graph shows every supported relationship instance for the selected work item instead of collapsing repeated relationships of the same type.",
    "A selected work item with two distinct DEPENDS_ON relationships renders both dependency nodes and both dependency edges on the graph.",
    "The concrete batch example in factory/inputs/BATCH/default/factory-batch-local-agent-cli-runtime.json can be used to reproduce and verify that multiple relationships now appear together.",
    "Related-work node selection from the graph remains keyboard-accessible and continues to switch current selection to the clicked or activated related work item.",
    "Relationship graph nodes use a more distinctive non-neutral palette aligned with workstation-node readability in the factory graph while preserving clear emphasis for the currently selected work item.",
    "Long relationship-node labels remain readable at common current-selection card widths without clipping outside the node shell.",
    "Quality gate: UI typecheck, lint, relevant automated tests, and browser verification pass."
  ],
  "userStories": [
    {
      "id": "work-relationships-current-selection-graph-repair-001",
      "title": "Preserve all relationship instances for selected work",
      "description": "As a maintainer, I want the selected-work relationship graph model to retain every supported relationship instance so the current-selection graph can represent multiple dependencies and parent relations accurately.",
      "acceptanceCriteria": [
        "Building the current-selection selected-work relationship graph keeps every supported relationship instance connected to the selected work item instead of collapsing repeated relationships by relationship type alone.",
        "When one selected work item has two distinct DEPENDS_ON relations to two different target work items, the ready graph contains two dependency edges and both related work nodes.",
        "Existing supported relationship kinds for this graph (DEPENDS_ON and PARENT_CHILD as rendered parent relationships) continue to project correctly alongside repeated dependency relationships.",
        "The projected graph remains deterministic for the same input snapshot so reviewers can compare outputs reliably in tests.",
        "Focused regression tests cover the repeated-DEPENDS_ON case and a mixed dependency-plus-parent case.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "work-relationships-current-selection-graph-repair-002",
      "title": "Render every relationship on the current-selection work graph",
      "description": "As a dashboard operator, I want the work relationships graph in current selection to show every related work item and edge so I can understand all of the selected work's dependencies and lineage from one place.",
      "acceptanceCriteria": [
        "In the current-selection work-item detail card, the Work relationships region renders all related nodes and all relationship edges present in the ready selected-work relationship graph.",
        "Repeated DEPENDS_ON relations do not disappear simply because they share the same relationship label; each distinct related work item is visible and selectable from the graph.",
        "Activating each related-work node by click or keyboard still calls the existing current-selection work-switch action for that related work item.",
        "Loading, empty, and error states for the Work relationships region remain explicit and unchanged in meaning.",
        "Browser-visible verification covers the concrete batch example and confirms that multiple dependency relationships appear at the same time in current selection.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "work-relationships-current-selection-graph-repair-003",
      "title": "Make relationship nodes readable and scannable",
      "description": "As a dashboard operator, I want relationship nodes in the current-selection graph to have clearer colors and readable labels so I can identify the selected work and related work items without fighting the layout.",
      "acceptanceCriteria": [
        "Relationship nodes in current selection use a more distinctive palette aligned with the workstation-node readability standard in the factory graph rather than the current inscrutable neutral treatment.",
        "The currently selected work item still has a clearly stronger emphasis than surrounding related-work nodes after the palette update.",
        "Long node labels no longer truncate awkwardly; labels wrap to additional lines, use a smaller readable font, or both, while staying inside the node shell.",
        "Readability improvements hold at common current-selection card widths, including narrower dashboard layouts, without text overlapping adjacent chrome.",
        "Accessible contrast, focus styling, and keyboard activation remain intact after the node styling update.",
        "Focused component or integration coverage proves the new node classes and non-clipping text behavior for long labels.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)