### PR TITLE
you-goal-p01-register-packaged-factory

### DIFF
--- a/cmd/gocoveragecheck/main_entrypoint_test.go
+++ b/cmd/gocoveragecheck/main_entrypoint_test.go
@@ -138,10 +138,13 @@ func TestMainFailsWhenZeroCoveragePackagesDetectedViaFailf(t *testing.T) {
 	var stderr bytes.Buffer
 	var exitCode int
 
+	baselinePath := emptyPackageCoverageBaselinePath(t)
+
 	flag.CommandLine = flag.NewFlagSet("gocoveragecheck", flag.ExitOnError)
 	os.Args = []string{
 		"gocoveragecheck",
 		"-min=80",
+		"-package-baseline=" + baselinePath,
 		"-coverpkg=" + strings.Join([]string{
 			modulePath + "/pkg/config",
 			modulePath + "/pkg/service",
@@ -193,10 +196,13 @@ func TestMainFailsWithZeroCoveragePackageSummary(t *testing.T) {
 	var stderr bytes.Buffer
 	var exitCode int
 
+	baselinePath := emptyPackageCoverageBaselinePath(t)
+
 	flag.CommandLine = flag.NewFlagSet("gocoveragecheck", flag.ExitOnError)
 	os.Args = []string{
 		"gocoveragecheck",
 		"-min=80",
+		"-package-baseline=" + baselinePath,
 		"-coverpkg=" + strings.Join([]string{
 			modulePath + "/pkg/config",
 			modulePath + "/pkg/service",
@@ -248,10 +254,13 @@ func TestMainFailsWithZeroCoverageOKPackageSummary(t *testing.T) {
 	var stderr bytes.Buffer
 	var exitCode int
 
+	baselinePath := emptyPackageCoverageBaselinePath(t)
+
 	flag.CommandLine = flag.NewFlagSet("gocoveragecheck", flag.ExitOnError)
 	os.Args = []string{
 		"gocoveragecheck",
 		"-min=80",
+		"-package-baseline=" + baselinePath,
 		"-coverpkg=" + strings.Join([]string{
 			modulePath + "/pkg/config",
 			modulePath + "/pkg/service",
@@ -303,10 +312,13 @@ func TestMainFailsWithZeroCoverageCoverpkgOKPackageSummary(t *testing.T) {
 	var stderr bytes.Buffer
 	var exitCode int
 
+	baselinePath := emptyPackageCoverageBaselinePath(t)
+
 	flag.CommandLine = flag.NewFlagSet("gocoveragecheck", flag.ExitOnError)
 	os.Args = []string{
 		"gocoveragecheck",
 		"-min=80",
+		"-package-baseline=" + baselinePath,
 		"-coverpkg=" + strings.Join([]string{
 			modulePath + "/pkg/config",
 			modulePath + "/pkg/service",

--- a/cmd/gocoveragecheck/main_run_test.go
+++ b/cmd/gocoveragecheck/main_run_test.go
@@ -128,7 +128,8 @@ func TestExecuteFailsWhenCoverageBelowMinimumAndZeroCoveragePackage(t *testing.T
 	stderrWriter = &stderr
 
 	err := execute(config{
-		min: 100.1,
+		min:             100.1,
+		packageBaseline: emptyPackageCoverageBaselinePath(t),
 		coverpkg: strings.Join([]string{
 			modulePath + "/pkg/config",
 			modulePath + "/pkg/service",
@@ -182,7 +183,8 @@ func TestExecuteFailsWhenZeroCoveragePackageOnly(t *testing.T) {
 	stderrWriter = &stderr
 
 	err := execute(config{
-		min: 80,
+		min:             80,
+		packageBaseline: emptyPackageCoverageBaselinePath(t),
 		coverpkg: strings.Join([]string{
 			modulePath + "/pkg/config",
 			modulePath + "/pkg/service",

--- a/cmd/gocoveragecheck/main_test.go
+++ b/cmd/gocoveragecheck/main_test.go
@@ -11,6 +11,13 @@ import (
 
 var emptyCoverageBaseline = map[string]struct{}{}
 
+const emptyPackageCoverageBaselineRelPath = "cmd/gocoveragecheck/testdata/empty-package-baseline.txt"
+
+func emptyPackageCoverageBaselinePath(t *testing.T) string {
+	t.Helper()
+	return emptyPackageCoverageBaselineRelPath
+}
+
 func TestIsBackendCoveragePackage(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/gocoveragecheck/testdata/empty-package-baseline.txt
+++ b/cmd/gocoveragecheck/testdata/empty-package-baseline.txt
@@ -1,0 +1,1 @@
+# Intentionally empty baseline for gocoveragecheck integration tests.

--- a/docs/internal/development/go-coverage-package-baseline.txt
+++ b/docs/internal/development/go-coverage-package-baseline.txt
@@ -30,6 +30,7 @@ github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime
 github.com/portpowered/infinite-you/pkg/orchestrators/javascript/source
 github.com/portpowered/infinite-you/pkg/orchestrators/javascript/store
 github.com/portpowered/infinite-you/pkg/orchestrators/javascript/validation
+github.com/portpowered/infinite-you/pkg/packagedfactories/goal
 github.com/portpowered/infinite-you/pkg/packagedfactories/tts
 github.com/portpowered/infinite-you/pkg/replay
 github.com/portpowered/infinite-you/pkg/service

--- a/pkg/cli/root_run_test.go
+++ b/pkg/cli/root_run_test.go
@@ -889,6 +889,62 @@ func TestRunCommand_VerboseDiagnosticsUseStderr(t *testing.T) {
 	}
 }
 
+func TestRunCommand_NamedFactoryResolutionMetadataFlowsForBuiltInGoal(t *testing.T) {
+	originalRunCLI := runCLI
+	defer func() {
+		runCLI = originalRunCLI
+	}()
+
+	workingDirectory := t.TempDir()
+	homeDir := t.TempDir()
+	originalWorkingDirectory, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(workingDirectory); err != nil {
+		t.Fatalf("Chdir(%q): %v", workingDirectory, err)
+	}
+	defer func() {
+		if chdirErr := os.Chdir(originalWorkingDirectory); chdirErr != nil {
+			t.Fatalf("restore working directory: %v", chdirErr)
+		}
+	}()
+	t.Setenv("HOME", homeDir)
+
+	var got runcli.RunConfig
+	runCLI = func(_ context.Context, cfg runcli.RunConfig) error {
+		got = cfg
+		return nil
+	}
+
+	root := NewRootCommand()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"run", "--named", "@you/goal", "--no-record"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute run --named @you/goal: %v", err)
+	}
+	if got.NamedFactoryName != "@you/goal" {
+		t.Fatalf("named factory = %q, want @you/goal", got.NamedFactoryName)
+	}
+	if got.NamedFactoryResolution == nil {
+		t.Fatal("expected named-factory resolution metadata")
+	}
+	if got.Dir != got.NamedFactoryResolution.FactoryDir {
+		t.Fatalf("run dir = %q, want resolved named-factory dir %q", got.Dir, got.NamedFactoryResolution.FactoryDir)
+	}
+	if got.NamedFactoryResolution.Name != "@you/goal" {
+		t.Fatalf("resolution name = %q, want @you/goal", got.NamedFactoryResolution.Name)
+	}
+	if got.NamedFactoryResolution.Source != factoryconfig.NamedFactoryResolutionSourceBuiltin {
+		t.Fatalf("resolution source = %q, want %q", got.NamedFactoryResolution.Source, factoryconfig.NamedFactoryResolutionSourceBuiltin)
+	}
+	if got.NamedFactoryResolution.PrecedenceDecision != factoryconfig.NamedFactoryPrecedenceDecisionNone {
+		t.Fatalf("resolution precedence = %q, want %q", got.NamedFactoryResolution.PrecedenceDecision, factoryconfig.NamedFactoryPrecedenceDecisionNone)
+	}
+}
+
 func TestRunCommand_NamedFactoryResolutionMetadataFlowsIntoRunConfig(t *testing.T) {
 	originalRunCLI := runCLI
 	defer func() {

--- a/pkg/config/layout.go
+++ b/pkg/config/layout.go
@@ -922,7 +922,7 @@ func resolveNamedFactoryCandidate(rootDir, name string) (string, bool, error) {
 	if err == nil {
 		return factoryDir, true, nil
 	}
-	if errors.Is(err, os.ErrNotExist) {
+	if errors.Is(err, ErrNamedFactoryNotFound) {
 		return "", false, nil
 	}
 	return "", false, err

--- a/pkg/config/layout.go
+++ b/pkg/config/layout.go
@@ -1,5 +1,5 @@
-// backendsizecheck:ignore-file built-in catalog layout and @you/tts factory JSON remain co-located until dedicated config seams split.
-// pkgmaintcheck:ignore-file-lines built-in catalog layout and @you/tts factory JSON remain co-located until dedicated config seams split.
+// backendsizecheck:ignore-file built-in catalog layout and packaged factory JSON remain co-located until dedicated config seams split.
+// pkgmaintcheck:ignore-file-lines built-in catalog layout and packaged factory JSON remain co-located until dedicated config seams split.
 package config
 
 import (
@@ -829,7 +829,8 @@ func restoreFactorySplitLayoutReplace(targetDir, backupDir string) {
 }
 
 var builtInNamedFactoryCatalog = map[string][]byte{
-	"@you/tts": BuiltInTTSFactoryJSON,
+	"@you/goal": BuiltInGoalFactoryJSON,
+	"@you/tts":  BuiltInTTSFactoryJSON,
 }
 
 // ResolveNamedFactoryDirAcrossRoots returns the runnable factory directory for
@@ -953,6 +954,47 @@ func resolveBuiltInNamedFactory(globalRoot, canonicalName string) (string, bool,
 	}
 	return factoryDir, true, nil
 }
+
+// BuiltInGoalFactoryJSON is the canonical runnable @you/goal packaged factory payload.
+var BuiltInGoalFactoryJSON = []byte(`{
+  "name": "@you/goal",
+  "id": "builtin-goal",
+  "workTypes": [
+    {
+      "name": "task",
+      "handlingBehavior": ["DEFAULT"],
+      "states": [
+        {"name": "init", "type": "INITIAL"},
+        {"name": "complete", "type": "TERMINAL"},
+        {"name": "failed", "type": "FAILED"}
+      ]
+    }
+  ],
+  "workers": [
+    {
+      "name": "goal-executor",
+      "type": "MODEL_WORKER",
+      "body": "You are the @you/goal built-in factory worker."
+    }
+  ],
+  "workstations": [
+    {
+      "name": "execute-goal",
+      "type": "MODEL_WORKSTATION",
+      "worker": "goal-executor",
+      "inputs": [
+        {"workType": "task", "state": "init"}
+      ],
+      "outputs": [
+        {"workType": "task", "state": "complete"}
+      ],
+      "onFailure": [
+        {"workType": "task", "state": "failed"}
+      ],
+      "body": "Execute the requested goal work for {{ .WorkID }}."
+    }
+  ]
+}`)
 
 // BuiltInTTSFactoryJSON is the canonical runnable @you/tts packaged factory payload.
 var BuiltInTTSFactoryJSON = []byte(`{

--- a/pkg/config/portable_bundled_files.go
+++ b/pkg/config/portable_bundled_files.go
@@ -877,6 +877,14 @@ func ResolveNamedFactoryDir(rootDir, name string) (string, error) {
 	factoryDir := filepath.Join(rootDir, segment)
 	if err := requireFactoryConfig(factoryDir); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
+			if info, statErr := os.Stat(factoryDir); statErr == nil && info.IsDir() {
+				return "", fmt.Errorf(
+					"resolve named factory %q in root %s: existing target could not be loaded: %w",
+					canonicalName,
+					rootDir,
+					err,
+				)
+			}
 			return "", fmt.Errorf(
 				"resolve named factory %q in root %s: %w",
 				canonicalName,

--- a/pkg/config/portable_bundled_files.go
+++ b/pkg/config/portable_bundled_files.go
@@ -1,8 +1,8 @@
 package config
 
 import (
-	"errors"
 	"bytes"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -813,6 +813,7 @@ func resolvePortableBundledLinkTarget(path, linkTarget string) (string, bool, er
 	}
 	return resolvedPath, true, nil
 }
+
 // ReadCurrentFactoryPointer returns the current named factory selected for the
 // root directory's named-factory layout.
 func ReadCurrentFactoryPointer(rootDir string) (string, error) {

--- a/pkg/config/runtime_config_additional_test.go
+++ b/pkg/config/runtime_config_additional_test.go
@@ -351,6 +351,9 @@ func TestNamedFactoryHelpers_ValidateAndResolvePreparedPayload(t *testing.T) {
 	if err := ValidateNamedFactoryName("@you/tts"); err != nil {
 		t.Fatalf("ValidateNamedFactoryName(@you/tts): %v", err)
 	}
+	if err := ValidateNamedFactoryName("@you/goal"); err != nil {
+		t.Fatalf("ValidateNamedFactoryName(@you/goal): %v", err)
+	}
 	if err := ValidateNamedFactoryName("@broken"); err == nil {
 		t.Fatal("expected invalid scoped name to fail")
 	}

--- a/pkg/config/runtimetests/named_factory_resolution_test.go
+++ b/pkg/config/runtimetests/named_factory_resolution_test.go
@@ -119,6 +119,31 @@ func TestResolveNamedFactoryAcrossRoots_RejectsInvalidCanonicalName(t *testing.T
 	}
 }
 
+func TestResolveNamedFactoryAcrossRoots_MaterializesBuiltInGoalIntoGlobalRoot(t *testing.T) {
+	projectRoot := t.TempDir()
+	globalRoot := t.TempDir()
+
+	resolution, err := ResolveNamedFactoryAcrossRoots(projectRoot, globalRoot, "@you/goal")
+	if err != nil {
+		t.Fatalf("ResolveNamedFactoryAcrossRoots(builtin goal): %v", err)
+	}
+
+	wantDir := filepath.Join(globalRoot, "@you%2Fgoal")
+	assertNamedFactoryResolution(t, resolution, "@you/goal", wantDir, NamedFactoryResolutionSourceBuiltin, projectRoot, globalRoot)
+	if resolution.PrecedenceDecision != NamedFactoryPrecedenceDecisionNone {
+		t.Fatalf("resolution precedence = %q, want %q", resolution.PrecedenceDecision, NamedFactoryPrecedenceDecisionNone)
+	}
+	assertBuiltInGoalMaterializedLayout(t, wantDir)
+
+	loaded, err := LoadRuntimeConfigFromFactoryDir(resolution.FactoryDir, nil)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfigFromFactoryDir(materialized builtin goal): %v", err)
+	}
+	if loaded.FactoryConfig().Project != "builtin-goal" {
+		t.Fatalf("materialized builtin project = %q, want builtin-goal", loaded.FactoryConfig().Project)
+	}
+}
+
 func TestResolveNamedFactoryAcrossRoots_MaterializesBuiltInIntoGlobalRoot(t *testing.T) {
 	projectRoot := t.TempDir()
 	globalRoot := t.TempDir()
@@ -301,6 +326,20 @@ func namedFactoryEntryNames(entries []NamedFactoryListEntry) []string {
 		names = append(names, entry.Name)
 	}
 	return names
+}
+
+func assertBuiltInGoalMaterializedLayout(t *testing.T, factoryDir string) {
+	t.Helper()
+
+	for _, path := range []string{
+		filepath.Join(factoryDir, interfaces.FactoryConfigFile),
+		filepath.Join(factoryDir, interfaces.WorkersDir, "goal-executor", interfaces.FactoryAgentsFileName),
+		filepath.Join(factoryDir, interfaces.WorkstationsDir, "execute-goal", interfaces.FactoryAgentsFileName),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected built-in goal materialized path %s: %v", path, err)
+		}
+	}
 }
 
 func assertBuiltInMaterializedLayout(t *testing.T, factoryDir string) {

--- a/pkg/config/runtimetests/named_factory_resolution_test.go
+++ b/pkg/config/runtimetests/named_factory_resolution_test.go
@@ -258,8 +258,50 @@ func TestResolveNamedFactoryAcrossRoots_ReportsCorruptMaterializedBuiltInTarget(
 	if err == nil {
 		t.Fatal("expected corrupt materialized builtin to fail")
 	}
-	if got := err.Error(); !containsAll(got, `materialize built-in named factory "@you/tts"`, "existing target invalid", "find factory config") {
+	if got := err.Error(); !containsAll(got, `resolve named factory "@you/tts"`, "existing target could not be loaded", "find factory config") {
 		t.Fatalf("expected corrupt-target resolution error, got %v", err)
+	}
+}
+
+func TestResolveNamedFactoryAcrossRoots_ReportsCorruptProjectEditableGoalTarget(t *testing.T) {
+	projectRoot := t.TempDir()
+	globalRoot := t.TempDir()
+	corruptDir := filepath.Join(projectRoot, "@you%2Fgoal")
+	if err := os.MkdirAll(corruptDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(corrupt project goal dir): %v", err)
+	}
+
+	_, err := ResolveNamedFactoryAcrossRoots(projectRoot, globalRoot, "@you/goal")
+	if err == nil {
+		t.Fatal("expected corrupt project editable goal to fail")
+	}
+	got := err.Error()
+	if !containsAll(got, `resolve named factory "@you/goal"`, "existing target could not be loaded", "find factory config") {
+		t.Fatalf("expected corrupt project editable goal resolution error, got %v", err)
+	}
+	if strings.Contains(got, "materialize built-in named factory") {
+		t.Fatalf("expected project editable failure without builtin fallback, got %v", err)
+	}
+}
+
+func TestResolveNamedFactoryAcrossRoots_ReportsCorruptGlobalEditableGoalTarget(t *testing.T) {
+	projectRoot := t.TempDir()
+	globalRoot := t.TempDir()
+	corruptDir := filepath.Join(globalRoot, "@you%2Fgoal")
+	if err := os.MkdirAll(corruptDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(corrupt global goal dir): %v", err)
+	}
+
+	_, err := ResolveNamedFactoryAcrossRoots(projectRoot, globalRoot, "@you/goal")
+	if err == nil {
+		t.Fatal("expected corrupt global editable goal to fail")
+	}
+	got := err.Error()
+	if !containsAll(got, `resolve named factory "@you/goal"`, "existing target could not be loaded", "find factory config") {
+		t.Fatalf("expected corrupt global editable goal resolution error, got %v", err)
+	}
+	if strings.Contains(got, "materialize built-in named factory") {
+		t.Fatalf("expected global editable failure without builtin fallback, got %v", err)
 	}
 }
 

--- a/pkg/config/runtimetests/runtime_config_named_factory_test.go
+++ b/pkg/config/runtimetests/runtime_config_named_factory_test.go
@@ -573,14 +573,11 @@ func TestResolveNamedFactoryDir_RejectsDirectoryWithoutFactoryConfig(t *testing.
 	if err == nil {
 		t.Fatal("expected missing named factory config to fail")
 	}
-	if !errors.Is(err, ErrNamedFactoryNotFound) {
-		t.Fatalf("error = %v, want ErrNamedFactoryNotFound", err)
+	if errors.Is(err, ErrNamedFactoryNotFound) {
+		t.Fatalf("error = %v, did not want ErrNamedFactoryNotFound for existing invalid target", err)
 	}
-	if !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("error = %v, want os.ErrNotExist", err)
-	}
-	if got := err.Error(); !containsAll(got, `resolve named factory "beta"`, "root", `named factory "beta" not found`) {
-		t.Fatalf("expected missing-config resolution error, got %v", err)
+	if got := err.Error(); !containsAll(got, `resolve named factory "beta"`, "root", "existing target could not be loaded", "find factory config") {
+		t.Fatalf("expected invalid-target resolution error, got %v", err)
 	}
 }
 

--- a/pkg/packagedfactories/goal/factory_test.go
+++ b/pkg/packagedfactories/goal/factory_test.go
@@ -1,0 +1,27 @@
+package goal
+
+import (
+	"testing"
+
+	factoryconfig "github.com/portpowered/infinite-you/pkg/config"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+)
+
+func TestBuiltInFactoryJSON_LoadsRunnablePackagedGoalFactory(t *testing.T) {
+	cfg, err := factoryconfig.FactoryConfigFromOpenAPIJSON(factoryconfig.BuiltInGoalFactoryJSON)
+	if err != nil {
+		t.Fatalf("ParseFactoryConfig: %v", err)
+	}
+	if cfg.Name != "@you/goal" {
+		t.Fatalf("factory name = %q, want @you/goal", cfg.Name)
+	}
+	if cfg.Project != PackagedFactoryProject {
+		t.Fatalf("factory project = %q, want %s", cfg.Project, PackagedFactoryProject)
+	}
+	if len(cfg.WorkTypes) != 1 || cfg.WorkTypes[0].HandlingBehavior[0] != interfaces.WorkTypeHandlingBehaviorDefault {
+		t.Fatalf("workTypes = %#v, want one DEFAULT handling work type", cfg.WorkTypes)
+	}
+	if len(cfg.Workstations) != 1 || cfg.Workstations[0].Name != PackagedInvokeWorkstationName {
+		t.Fatalf("workstations = %#v, want packaged goal workstation", cfg.Workstations)
+	}
+}

--- a/pkg/packagedfactories/goal/metadata.go
+++ b/pkg/packagedfactories/goal/metadata.go
@@ -1,0 +1,10 @@
+package goal
+
+const (
+	// PackagedFactoryName is the canonical named factory identifier for @you/goal.
+	PackagedFactoryName = "@you/goal"
+	// PackagedFactoryProject identifies the built-in @you/goal factory project id.
+	PackagedFactoryProject = "builtin-goal"
+	// PackagedInvokeWorkstationName is the workstation that runs goal work.
+	PackagedInvokeWorkstationName = "execute-goal"
+)


### PR DESCRIPTION
{
  "project": "you-agent-factory",
  "branchName": "you-goal-p01-register-packaged-factory",
  "description": "Register @you/goal as a resolvable built-in named factory so `you run --named @you/goal` enters the existing named-factory resolution path, while preserving editable-copy precedence and clear load failures.",
  "context": {
    "customerAsk": "Add @you/goal as a resolvable built-in named factory entry. `you run --named @you/goal` should reach the normal named-factory resolution path, and tests should cover load failure and successful built-in lookup.",
    "problem": "The broader @you/goal work cannot be invoked or extended until the package name is recognized by the existing named-factory resolver. Without a built-in catalog entry, the CLI fails before normal materialization, editable-copy precedence, validation, and invocation behavior can run.",
    "solution": "Register @you/goal in the existing built-in named-factory catalog with a valid packaged factory payload, keep project/global editable copies ahead of built-ins, and add focused tests proving successful built-in lookup and invalid editable-copy load failure."
  },
  "acceptanceCriteria": [
    "@you/goal is recognized as a built-in named factory name.",
    "`you run --named @you/goal` reaches normal named-factory resolution rather than failing as an unknown or missing named factory.",
    "Successful built-in lookup returns named-factory resolution metadata that identifies the source as built-in and preserves the requested name @you/goal.",
    "If an invalid editable @you/goal named factory already exists, resolution fails with a clear load/validation error and does not silently fall back to the built-in definition.",
    "The registration uses the existing built-in packaged-factory catalog and named-factory precedence behavior; no separate goal-specific resolver is introduced.",
    "Quality gate: backend and CLI typecheck, lint, and relevant tests pass before merge."
  ],
  "userStories": [
    {
      "id": "you-goal-p01-register-packaged-factory-001",
      "title": "Resolve @you/goal as a built-in named factory",
      "description": "As a CLI user, I want `you run --named @you/goal` to resolve as a first-party named factory so that I can invoke the packaged goal workflow through the standard named-factory path.",
      "acceptanceCriteria": [
        "@you/goal is accepted by named-factory lookup as a built-in name when no project or global editable copy exists.",
        "The resolved named-factory metadata preserves the requested name @you/goal, reports the source as built-in, and uses the existing named-factory precedence order.",
        "`you run --named @you/goal` proceeds past named-factory selection into the normal run startup path; later validation or runtime failures must not be caused by missing name registration.",
        "A focused config or CLI test proves successful built-in lookup for @you/goal.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "you-goal-p01-register-packaged-factory-002",
      "title": "Preserve load-failure behavior for invalid editable @you/goal factories",
      "description": "As a maintainer, I want invalid existing @you/goal named factories to fail through the normal load path so that customer edits are respected and broken editable copies are reported clearly instead of being overwritten by the built-in.",
      "acceptanceCriteria": [
        "When a project or global editable @you/goal factory exists but cannot be loaded as a valid factory layout, named-factory resolution returns a clear load/validation failure.",
        "The load-failure path does not fall back to the built-in @you/goal payload when an editable copy is present.",
        "The error identifies the requested named factory @you/goal and the fact that the existing target could not be loaded.",
        "A focused regression test proves the invalid editable-copy failure path for @you/goal.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)