### PR TITLE
you-goal-p02-materialize-editable-layout

### DIFF
--- a/pkg/cli/root_run_test.go
+++ b/pkg/cli/root_run_test.go
@@ -969,6 +969,89 @@ func TestRunCommand_NamedFactoryResolutionMetadataFlowsForBuiltInGoal(t *testing
 	}
 }
 
+func TestRunCommand_RepeatedBuiltInGoalRunReusesMaterializedCopy(t *testing.T) {
+	originalRunCLI := runCLI
+	defer func() {
+		runCLI = originalRunCLI
+	}()
+
+	workingDirectory := t.TempDir()
+	homeDir := t.TempDir()
+	originalWorkingDirectory, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(workingDirectory); err != nil {
+		t.Fatalf("Chdir(%q): %v", workingDirectory, err)
+	}
+	defer func() {
+		if chdirErr := os.Chdir(originalWorkingDirectory); chdirErr != nil {
+			t.Fatalf("restore working directory: %v", chdirErr)
+		}
+	}()
+	t.Setenv("HOME", homeDir)
+
+	var runs []runcli.RunConfig
+	runCLI = func(_ context.Context, cfg runcli.RunConfig) error {
+		runs = append(runs, cfg)
+		return nil
+	}
+
+	root := NewRootCommand()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+
+	for range 2 {
+		root.SetArgs([]string{"run", "--named", "@you/goal", "--no-record"})
+		if err := root.Execute(); err != nil {
+			t.Fatalf("execute run --named @you/goal: %v", err)
+		}
+	}
+	if len(runs) != 2 {
+		t.Fatalf("run count = %d, want 2", len(runs))
+	}
+
+	first := runs[0]
+	second := runs[1]
+	if first.NamedFactoryResolution.Source != factoryconfig.NamedFactoryResolutionSourceBuiltin {
+		t.Fatalf("first resolution source = %q, want %q", first.NamedFactoryResolution.Source, factoryconfig.NamedFactoryResolutionSourceBuiltin)
+	}
+	if second.NamedFactoryResolution.Source != factoryconfig.NamedFactoryResolutionSourceGlobal {
+		t.Fatalf("second resolution source = %q, want %q", second.NamedFactoryResolution.Source, factoryconfig.NamedFactoryResolutionSourceGlobal)
+	}
+	if second.NamedFactoryResolution.FactoryDir != first.NamedFactoryResolution.FactoryDir {
+		t.Fatalf("second factory dir = %q, want stable %q", second.NamedFactoryResolution.FactoryDir, first.NamedFactoryResolution.FactoryDir)
+	}
+
+	wantMaterializedDir := filepath.Join(homeDir, ".you-agent-factory", "factories", "@you%2Fgoal")
+	workerPath := filepath.Join(wantMaterializedDir, interfaces.WorkersDir, "goal-executor", interfaces.FactoryAgentsFileName)
+	editedBody := "You are the customer-edited @you/goal built-in.\n"
+	if err := os.WriteFile(workerPath, []byte(editedBody), 0o644); err != nil {
+		t.Fatalf("WriteFile(materialized goal worker body): %v", err)
+	}
+
+	root.SetArgs([]string{"run", "--named", "@you/goal", "--no-record"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute run --named @you/goal after edit: %v", err)
+	}
+	third := runs[2]
+	if third.NamedFactoryResolution.FactoryDir != wantMaterializedDir {
+		t.Fatalf("third factory dir = %q, want %q", third.NamedFactoryResolution.FactoryDir, wantMaterializedDir)
+	}
+
+	loaded, err := factoryconfig.LoadRuntimeConfigFromFactoryDir(third.NamedFactoryResolution.FactoryDir, nil)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfigFromFactoryDir(edited goal): %v", err)
+	}
+	worker, ok := loaded.Worker("goal-executor")
+	if !ok {
+		t.Fatal("expected materialized goal worker")
+	}
+	if worker.Body != strings.TrimSpace(editedBody) {
+		t.Fatalf("edited goal worker body = %q, want %q", worker.Body, strings.TrimSpace(editedBody))
+	}
+}
+
 func TestRunCommand_NamedFactoryResolutionMetadataFlowsIntoRunConfig(t *testing.T) {
 	originalRunCLI := runCLI
 	defer func() {

--- a/pkg/cli/root_run_test.go
+++ b/pkg/cli/root_run_test.go
@@ -896,21 +896,7 @@ func TestRunCommand_NamedFactoryResolutionMetadataFlowsForBuiltInGoal(t *testing
 		runCLI = originalRunCLI
 	}()
 
-	workingDirectory := t.TempDir()
-	homeDir := t.TempDir()
-	originalWorkingDirectory, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Getwd: %v", err)
-	}
-	if err := os.Chdir(workingDirectory); err != nil {
-		t.Fatalf("Chdir(%q): %v", workingDirectory, err)
-	}
-	defer func() {
-		if chdirErr := os.Chdir(originalWorkingDirectory); chdirErr != nil {
-			t.Fatalf("restore working directory: %v", chdirErr)
-		}
-	}()
-	t.Setenv("HOME", homeDir)
+	env := setupNamedGoalCLIEnv(t)
 
 	var got runcli.RunConfig
 	runCLI = func(_ context.Context, cfg runcli.RunConfig) error {
@@ -918,55 +904,8 @@ func TestRunCommand_NamedFactoryResolutionMetadataFlowsForBuiltInGoal(t *testing
 		return nil
 	}
 
-	root := NewRootCommand()
-	root.SetOut(io.Discard)
-	root.SetErr(io.Discard)
-	root.SetArgs([]string{"run", "--named", "@you/goal", "--no-record"})
-
-	if err := root.Execute(); err != nil {
-		t.Fatalf("execute run --named @you/goal: %v", err)
-	}
-	if got.NamedFactoryName != "@you/goal" {
-		t.Fatalf("named factory = %q, want @you/goal", got.NamedFactoryName)
-	}
-	if got.NamedFactoryResolution == nil {
-		t.Fatal("expected named-factory resolution metadata")
-	}
-	if got.Dir != got.NamedFactoryResolution.FactoryDir {
-		t.Fatalf("run dir = %q, want resolved named-factory dir %q", got.Dir, got.NamedFactoryResolution.FactoryDir)
-	}
-	if got.NamedFactoryResolution.Name != "@you/goal" {
-		t.Fatalf("resolution name = %q, want @you/goal", got.NamedFactoryResolution.Name)
-	}
-	if got.NamedFactoryResolution.Source != factoryconfig.NamedFactoryResolutionSourceBuiltin {
-		t.Fatalf("resolution source = %q, want %q", got.NamedFactoryResolution.Source, factoryconfig.NamedFactoryResolutionSourceBuiltin)
-	}
-	if got.NamedFactoryResolution.PrecedenceDecision != factoryconfig.NamedFactoryPrecedenceDecisionNone {
-		t.Fatalf("resolution precedence = %q, want %q", got.NamedFactoryResolution.PrecedenceDecision, factoryconfig.NamedFactoryPrecedenceDecisionNone)
-	}
-
-	wantMaterializedDir := filepath.Join(homeDir, ".you-agent-factory", "factories", "@you%2Fgoal")
-	if got.NamedFactoryResolution.FactoryDir != wantMaterializedDir {
-		t.Fatalf("materialized factory dir = %q, want %q", got.NamedFactoryResolution.FactoryDir, wantMaterializedDir)
-	}
-	for _, path := range []string{
-		filepath.Join(wantMaterializedDir, interfaces.FactoryConfigFile),
-		filepath.Join(wantMaterializedDir, interfaces.WorkersDir, "goal-executor", interfaces.FactoryAgentsFileName),
-		filepath.Join(wantMaterializedDir, interfaces.WorkstationsDir, "execute-goal", interfaces.FactoryAgentsFileName),
-	} {
-		if _, err := os.Stat(path); err != nil {
-			t.Fatalf("expected first-use materialized goal path %s: %v", path, err)
-		}
-	}
-	for _, dirName := range []string{interfaces.WorkersDir, interfaces.WorkstationsDir} {
-		info, err := os.Stat(filepath.Join(wantMaterializedDir, dirName))
-		if err != nil {
-			t.Fatalf("stat materialized goal %s: %v", dirName, err)
-		}
-		if !info.IsDir() {
-			t.Fatalf("materialized goal %s is not a directory", dirName)
-		}
-	}
+	executeNamedGoalRun(t, env.root)
+	assertBuiltInGoalFirstUseResolution(t, got, env.homeDir)
 }
 
 func TestRunCommand_RepeatedBuiltInGoalRunReusesMaterializedCopy(t *testing.T) {
@@ -975,21 +914,7 @@ func TestRunCommand_RepeatedBuiltInGoalRunReusesMaterializedCopy(t *testing.T) {
 		runCLI = originalRunCLI
 	}()
 
-	workingDirectory := t.TempDir()
-	homeDir := t.TempDir()
-	originalWorkingDirectory, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Getwd: %v", err)
-	}
-	if err := os.Chdir(workingDirectory); err != nil {
-		t.Fatalf("Chdir(%q): %v", workingDirectory, err)
-	}
-	defer func() {
-		if chdirErr := os.Chdir(originalWorkingDirectory); chdirErr != nil {
-			t.Fatalf("restore working directory: %v", chdirErr)
-		}
-	}()
-	t.Setenv("HOME", homeDir)
+	env := setupNamedGoalCLIEnv(t)
 
 	var runs []runcli.RunConfig
 	runCLI = func(_ context.Context, cfg runcli.RunConfig) error {
@@ -997,59 +922,29 @@ func TestRunCommand_RepeatedBuiltInGoalRunReusesMaterializedCopy(t *testing.T) {
 		return nil
 	}
 
-	root := NewRootCommand()
-	root.SetOut(io.Discard)
-	root.SetErr(io.Discard)
-
 	for range 2 {
-		root.SetArgs([]string{"run", "--named", "@you/goal", "--no-record"})
-		if err := root.Execute(); err != nil {
-			t.Fatalf("execute run --named @you/goal: %v", err)
-		}
+		executeNamedGoalRun(t, env.root)
 	}
 	if len(runs) != 2 {
 		t.Fatalf("run count = %d, want 2", len(runs))
 	}
+	assertGoalResolutionReusesMaterializedCopy(t, runs[0], runs[1])
 
-	first := runs[0]
-	second := runs[1]
-	if first.NamedFactoryResolution.Source != factoryconfig.NamedFactoryResolutionSourceBuiltin {
-		t.Fatalf("first resolution source = %q, want %q", first.NamedFactoryResolution.Source, factoryconfig.NamedFactoryResolutionSourceBuiltin)
-	}
-	if second.NamedFactoryResolution.Source != factoryconfig.NamedFactoryResolutionSourceGlobal {
-		t.Fatalf("second resolution source = %q, want %q", second.NamedFactoryResolution.Source, factoryconfig.NamedFactoryResolutionSourceGlobal)
-	}
-	if second.NamedFactoryResolution.FactoryDir != first.NamedFactoryResolution.FactoryDir {
-		t.Fatalf("second factory dir = %q, want stable %q", second.NamedFactoryResolution.FactoryDir, first.NamedFactoryResolution.FactoryDir)
-	}
-
-	wantMaterializedDir := filepath.Join(homeDir, ".you-agent-factory", "factories", "@you%2Fgoal")
+	wantMaterializedDir := materializedGoalDir(env.homeDir)
 	workerPath := filepath.Join(wantMaterializedDir, interfaces.WorkersDir, "goal-executor", interfaces.FactoryAgentsFileName)
 	editedBody := "You are the customer-edited @you/goal built-in.\n"
 	if err := os.WriteFile(workerPath, []byte(editedBody), 0o644); err != nil {
 		t.Fatalf("WriteFile(materialized goal worker body): %v", err)
 	}
 
-	root.SetArgs([]string{"run", "--named", "@you/goal", "--no-record"})
-	if err := root.Execute(); err != nil {
-		t.Fatalf("execute run --named @you/goal after edit: %v", err)
+	executeNamedGoalRun(t, env.root)
+	if len(runs) != 3 {
+		t.Fatalf("run count = %d, want 3", len(runs))
 	}
-	third := runs[2]
-	if third.NamedFactoryResolution.FactoryDir != wantMaterializedDir {
-		t.Fatalf("third factory dir = %q, want %q", third.NamedFactoryResolution.FactoryDir, wantMaterializedDir)
+	if runs[2].NamedFactoryResolution.FactoryDir != wantMaterializedDir {
+		t.Fatalf("third factory dir = %q, want %q", runs[2].NamedFactoryResolution.FactoryDir, wantMaterializedDir)
 	}
-
-	loaded, err := factoryconfig.LoadRuntimeConfigFromFactoryDir(third.NamedFactoryResolution.FactoryDir, nil)
-	if err != nil {
-		t.Fatalf("LoadRuntimeConfigFromFactoryDir(edited goal): %v", err)
-	}
-	worker, ok := loaded.Worker("goal-executor")
-	if !ok {
-		t.Fatal("expected materialized goal worker")
-	}
-	if worker.Body != strings.TrimSpace(editedBody) {
-		t.Fatalf("edited goal worker body = %q, want %q", worker.Body, strings.TrimSpace(editedBody))
-	}
+	assertLoadedGoalWorkerBody(t, runs[2].NamedFactoryResolution.FactoryDir, editedBody)
 }
 
 func TestRunCommand_NamedFactoryResolutionMetadataFlowsIntoRunConfig(t *testing.T) {
@@ -1301,6 +1196,132 @@ func TestRootCommand_DefaultProviderFlagResolvesSymbolicDefaultFromFile(t *testi
 	}
 	if got.OperatorDefaults.WorkerModelProviderSource != operatorconfig.SourceFlag {
 		t.Fatalf("provider source = %q, want flag", got.OperatorDefaults.WorkerModelProviderSource)
+	}
+}
+
+type namedGoalCLIEnv struct {
+	homeDir string
+	root    *cobra.Command
+}
+
+func setupNamedGoalCLIEnv(t *testing.T) namedGoalCLIEnv {
+	t.Helper()
+
+	workingDirectory := t.TempDir()
+	homeDir := t.TempDir()
+	originalWorkingDirectory, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(workingDirectory); err != nil {
+		t.Fatalf("Chdir(%q): %v", workingDirectory, err)
+	}
+	t.Cleanup(func() {
+		if chdirErr := os.Chdir(originalWorkingDirectory); chdirErr != nil {
+			t.Fatalf("restore working directory: %v", chdirErr)
+		}
+	})
+	t.Setenv("HOME", homeDir)
+
+	root := NewRootCommand()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	return namedGoalCLIEnv{homeDir: homeDir, root: root}
+}
+
+func materializedGoalDir(homeDir string) string {
+	return filepath.Join(homeDir, ".you-agent-factory", "factories", "@you%2Fgoal")
+}
+
+func executeNamedGoalRun(t *testing.T, root *cobra.Command) {
+	t.Helper()
+
+	root.SetArgs([]string{"run", "--named", "@you/goal", "--no-record"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute run --named @you/goal: %v", err)
+	}
+}
+
+func assertBuiltInGoalFirstUseResolution(t *testing.T, got runcli.RunConfig, homeDir string) {
+	t.Helper()
+
+	if got.NamedFactoryName != "@you/goal" {
+		t.Fatalf("named factory = %q, want @you/goal", got.NamedFactoryName)
+	}
+	if got.NamedFactoryResolution == nil {
+		t.Fatal("expected named-factory resolution metadata")
+	}
+	if got.Dir != got.NamedFactoryResolution.FactoryDir {
+		t.Fatalf("run dir = %q, want resolved named-factory dir %q", got.Dir, got.NamedFactoryResolution.FactoryDir)
+	}
+	if got.NamedFactoryResolution.Name != "@you/goal" {
+		t.Fatalf("resolution name = %q, want @you/goal", got.NamedFactoryResolution.Name)
+	}
+	if got.NamedFactoryResolution.Source != factoryconfig.NamedFactoryResolutionSourceBuiltin {
+		t.Fatalf("resolution source = %q, want %q", got.NamedFactoryResolution.Source, factoryconfig.NamedFactoryResolutionSourceBuiltin)
+	}
+	if got.NamedFactoryResolution.PrecedenceDecision != factoryconfig.NamedFactoryPrecedenceDecisionNone {
+		t.Fatalf("resolution precedence = %q, want %q", got.NamedFactoryResolution.PrecedenceDecision, factoryconfig.NamedFactoryPrecedenceDecisionNone)
+	}
+
+	wantMaterializedDir := materializedGoalDir(homeDir)
+	if got.NamedFactoryResolution.FactoryDir != wantMaterializedDir {
+		t.Fatalf("materialized factory dir = %q, want %q", got.NamedFactoryResolution.FactoryDir, wantMaterializedDir)
+	}
+	assertMaterializedGoalSplitLayout(t, wantMaterializedDir)
+}
+
+func assertMaterializedGoalSplitLayout(t *testing.T, materializedDir string) {
+	t.Helper()
+
+	for _, path := range []string{
+		filepath.Join(materializedDir, interfaces.FactoryConfigFile),
+		filepath.Join(materializedDir, interfaces.WorkersDir, "goal-executor", interfaces.FactoryAgentsFileName),
+		filepath.Join(materializedDir, interfaces.WorkstationsDir, "execute-goal", interfaces.FactoryAgentsFileName),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected first-use materialized goal path %s: %v", path, err)
+		}
+	}
+	for _, dirName := range []string{interfaces.WorkersDir, interfaces.WorkstationsDir} {
+		info, err := os.Stat(filepath.Join(materializedDir, dirName))
+		if err != nil {
+			t.Fatalf("stat materialized goal %s: %v", dirName, err)
+		}
+		if !info.IsDir() {
+			t.Fatalf("materialized goal %s is not a directory", dirName)
+		}
+	}
+}
+
+func assertGoalResolutionReusesMaterializedCopy(t *testing.T, first, second runcli.RunConfig) {
+	t.Helper()
+
+	if first.NamedFactoryResolution.Source != factoryconfig.NamedFactoryResolutionSourceBuiltin {
+		t.Fatalf("first resolution source = %q, want %q", first.NamedFactoryResolution.Source, factoryconfig.NamedFactoryResolutionSourceBuiltin)
+	}
+	if second.NamedFactoryResolution.Source != factoryconfig.NamedFactoryResolutionSourceGlobal {
+		t.Fatalf("second resolution source = %q, want %q", second.NamedFactoryResolution.Source, factoryconfig.NamedFactoryResolutionSourceGlobal)
+	}
+	if second.NamedFactoryResolution.FactoryDir != first.NamedFactoryResolution.FactoryDir {
+		t.Fatalf("second factory dir = %q, want stable %q", second.NamedFactoryResolution.FactoryDir, first.NamedFactoryResolution.FactoryDir)
+	}
+}
+
+func assertLoadedGoalWorkerBody(t *testing.T, factoryDir, editedBody string) {
+	t.Helper()
+
+	loaded, err := factoryconfig.LoadRuntimeConfigFromFactoryDir(factoryDir, nil)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfigFromFactoryDir(edited goal): %v", err)
+	}
+	worker, ok := loaded.Worker("goal-executor")
+	if !ok {
+		t.Fatal("expected materialized goal worker")
+	}
+	wantBody := strings.TrimSpace(editedBody)
+	if worker.Body != wantBody {
+		t.Fatalf("edited goal worker body = %q, want %q", worker.Body, wantBody)
 	}
 }
 

--- a/pkg/cli/root_run_test.go
+++ b/pkg/cli/root_run_test.go
@@ -20,6 +20,7 @@ import (
 	workcli "github.com/portpowered/infinite-you/pkg/cli/work"
 	factoryconfig "github.com/portpowered/infinite-you/pkg/config"
 	"github.com/portpowered/infinite-you/pkg/config/operatorconfig"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/logging"
 	"github.com/spf13/cobra"
 )
@@ -942,6 +943,29 @@ func TestRunCommand_NamedFactoryResolutionMetadataFlowsForBuiltInGoal(t *testing
 	}
 	if got.NamedFactoryResolution.PrecedenceDecision != factoryconfig.NamedFactoryPrecedenceDecisionNone {
 		t.Fatalf("resolution precedence = %q, want %q", got.NamedFactoryResolution.PrecedenceDecision, factoryconfig.NamedFactoryPrecedenceDecisionNone)
+	}
+
+	wantMaterializedDir := filepath.Join(homeDir, ".you-agent-factory", "factories", "@you%2Fgoal")
+	if got.NamedFactoryResolution.FactoryDir != wantMaterializedDir {
+		t.Fatalf("materialized factory dir = %q, want %q", got.NamedFactoryResolution.FactoryDir, wantMaterializedDir)
+	}
+	for _, path := range []string{
+		filepath.Join(wantMaterializedDir, interfaces.FactoryConfigFile),
+		filepath.Join(wantMaterializedDir, interfaces.WorkersDir, "goal-executor", interfaces.FactoryAgentsFileName),
+		filepath.Join(wantMaterializedDir, interfaces.WorkstationsDir, "execute-goal", interfaces.FactoryAgentsFileName),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected first-use materialized goal path %s: %v", path, err)
+		}
+	}
+	for _, dirName := range []string{interfaces.WorkersDir, interfaces.WorkstationsDir} {
+		info, err := os.Stat(filepath.Join(wantMaterializedDir, dirName))
+		if err != nil {
+			t.Fatalf("stat materialized goal %s: %v", dirName, err)
+		}
+		if !info.IsDir() {
+			t.Fatalf("materialized goal %s is not a directory", dirName)
+		}
 	}
 }
 

--- a/pkg/config/runtimetests/named_factory_resolution_test.go
+++ b/pkg/config/runtimetests/named_factory_resolution_test.go
@@ -169,6 +169,83 @@ func TestResolveNamedFactoryAcrossRoots_MaterializesBuiltInIntoGlobalRoot(t *tes
 	}
 }
 
+func TestResolveNamedFactoryAcrossRoots_RepeatedBuiltinGoalResolutionReusesMaterializedDir(t *testing.T) {
+	projectRoot := t.TempDir()
+	globalRoot := t.TempDir()
+
+	first, err := ResolveNamedFactoryAcrossRoots(projectRoot, globalRoot, "@you/goal")
+	if err != nil {
+		t.Fatalf("ResolveNamedFactoryAcrossRoots(first goal): %v", err)
+	}
+	second, err := ResolveNamedFactoryAcrossRoots(projectRoot, globalRoot, "@you/goal")
+	if err != nil {
+		t.Fatalf("ResolveNamedFactoryAcrossRoots(second goal): %v", err)
+	}
+	third, err := ResolveNamedFactoryAcrossRoots(projectRoot, globalRoot, "@you/goal")
+	if err != nil {
+		t.Fatalf("ResolveNamedFactoryAcrossRoots(third goal): %v", err)
+	}
+
+	if first.Source != NamedFactoryResolutionSourceBuiltin {
+		t.Fatalf("first resolution source = %q, want builtin materialization", first.Source)
+	}
+	for idx, resolution := range []*NamedFactoryResolution{first, second, third} {
+		if resolution.FactoryDir != first.FactoryDir {
+			t.Fatalf("resolution[%d] dir = %q, want stable %q", idx, resolution.FactoryDir, first.FactoryDir)
+		}
+	}
+	if second.Source != NamedFactoryResolutionSourceGlobal {
+		t.Fatalf("second resolution source = %q, want global reuse of materialized builtin", second.Source)
+	}
+	if third.Source != NamedFactoryResolutionSourceGlobal {
+		t.Fatalf("third resolution source = %q, want global reuse of materialized builtin", third.Source)
+	}
+
+	loaded, err := LoadRuntimeConfigFromFactoryDir(first.FactoryDir, nil)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfigFromFactoryDir(stable builtin goal): %v", err)
+	}
+	if loaded.FactoryConfig().Project != "builtin-goal" {
+		t.Fatalf("stable builtin goal project = %q, want builtin-goal", loaded.FactoryConfig().Project)
+	}
+}
+
+func TestResolveNamedFactoryAcrossRoots_UsesEditedMaterializedBuiltInGoalOnNextLoad(t *testing.T) {
+	projectRoot := t.TempDir()
+	globalRoot := t.TempDir()
+
+	resolution, err := ResolveNamedFactoryAcrossRoots(projectRoot, globalRoot, "@you/goal")
+	if err != nil {
+		t.Fatalf("ResolveNamedFactoryAcrossRoots(initial builtin goal): %v", err)
+	}
+
+	workerPath := filepath.Join(resolution.FactoryDir, interfaces.WorkersDir, "goal-executor", interfaces.FactoryAgentsFileName)
+	editedBody := "You are the customer-edited @you/goal built-in.\n"
+	if err := os.WriteFile(workerPath, []byte(editedBody), 0o644); err != nil {
+		t.Fatalf("WriteFile(materialized goal worker body): %v", err)
+	}
+
+	resolvedDir, err := ResolveNamedFactoryDirAcrossRoots(projectRoot, globalRoot, "@you/goal")
+	if err != nil {
+		t.Fatalf("ResolveNamedFactoryDirAcrossRoots(edited builtin goal): %v", err)
+	}
+	if resolvedDir != resolution.FactoryDir {
+		t.Fatalf("resolved dir after edit = %q, want %q", resolvedDir, resolution.FactoryDir)
+	}
+
+	loaded, err := LoadRuntimeConfigFromFactoryDir(resolvedDir, nil)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfigFromFactoryDir(edited builtin goal): %v", err)
+	}
+	worker, ok := loaded.Worker("goal-executor")
+	if !ok {
+		t.Fatal("expected materialized builtin goal worker")
+	}
+	if worker.Body != strings.TrimSpace(editedBody) {
+		t.Fatalf("edited builtin goal worker body = %q, want %q", worker.Body, strings.TrimSpace(editedBody))
+	}
+}
+
 func TestResolveNamedFactoryAcrossRoots_RepeatedBuiltinResolutionReusesMaterializedDir(t *testing.T) {
 	projectRoot := t.TempDir()
 	globalRoot := t.TempDir()

--- a/pkg/config/runtimetests/named_factory_resolution_test.go
+++ b/pkg/config/runtimetests/named_factory_resolution_test.go
@@ -373,6 +373,15 @@ func namedFactoryEntryNames(entries []NamedFactoryListEntry) []string {
 func assertBuiltInGoalMaterializedLayout(t *testing.T, factoryDir string) {
 	t.Helper()
 
+	for _, dirName := range []string{interfaces.WorkersDir, interfaces.WorkstationsDir} {
+		info, err := os.Stat(filepath.Join(factoryDir, dirName))
+		if err != nil {
+			t.Fatalf("stat built-in goal materialized %s: %v", dirName, err)
+		}
+		if !info.IsDir() {
+			t.Fatalf("built-in goal materialized %s is not a directory", dirName)
+		}
+	}
 	for _, path := range []string{
 		filepath.Join(factoryDir, interfaces.FactoryConfigFile),
 		filepath.Join(factoryDir, interfaces.WorkersDir, "goal-executor", interfaces.FactoryAgentsFileName),

--- a/pkg/packagedfactories/goal/materialize_edit_test.go
+++ b/pkg/packagedfactories/goal/materialize_edit_test.go
@@ -1,6 +1,7 @@
 package goal
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,12 +30,56 @@ func TestEditedMaterializedPackagedGoalFactoryChangesNextLoad(t *testing.T) {
 	}
 }
 
-func loadPackagedGoalWorker(t *testing.T, factoryDir string) *interfaces.WorkerConfig {
+func TestEditedMaterializedPackagedGoalFactoryWorkstationChangesNextLoad(t *testing.T) {
+	factoryDir := materializePackagedGoalFactory(t, t.TempDir())
+	initialWorkstation := loadPackagedGoalWorkstation(t, factoryDir)
+	if initialWorkstation.Body == "" {
+		t.Fatal("expected initial materialized goal workstation body")
+	}
+
+	editedBody := "Execute the customer-edited goal work for {{ .WorkID }}.\n"
+	editMaterializedWorkstationBody(t, factoryDir, PackagedInvokeWorkstationName, editedBody)
+
+	editedWorkstation := loadPackagedGoalWorkstation(t, factoryDir)
+	if editedWorkstation.Body != strings.TrimSpace(editedBody) {
+		t.Fatalf("edited workstation body = %q, want %q", editedWorkstation.Body, strings.TrimSpace(editedBody))
+	}
+	if editedWorkstation.Body == initialWorkstation.Body {
+		t.Fatalf("edited workstation body = %q, want change from initial materialized content", editedWorkstation.Body)
+	}
+}
+
+func TestEditedMaterializedPackagedGoalFactoryJSONChangesNextLoad(t *testing.T) {
+	const editedProject = "customer-edited-goal"
+	factoryDir := materializePackagedGoalFactory(t, t.TempDir())
+	initialLoaded := loadPackagedGoalRuntimeConfig(t, factoryDir)
+	if initialLoaded.FactoryConfig().Project != PackagedFactoryProject {
+		t.Fatalf("initial project = %q, want %s", initialLoaded.FactoryConfig().Project, PackagedFactoryProject)
+	}
+
+	editMaterializedFactoryProject(t, factoryDir, editedProject)
+
+	editedLoaded := loadPackagedGoalRuntimeConfig(t, factoryDir)
+	if editedLoaded.FactoryConfig().Project != editedProject {
+		t.Fatalf("edited project = %q, want %q", editedLoaded.FactoryConfig().Project, editedProject)
+	}
+	if editedLoaded.FactoryConfig().Project == initialLoaded.FactoryConfig().Project {
+		t.Fatalf("edited project = %q, want change from initial materialized content", editedLoaded.FactoryConfig().Project)
+	}
+}
+
+func loadPackagedGoalRuntimeConfig(t *testing.T, factoryDir string) *factoryconfig.LoadedFactoryConfig {
 	t.Helper()
 	loaded, err := factoryconfig.LoadRuntimeConfigFromFactoryDir(factoryDir, nil)
 	if err != nil {
 		t.Fatalf("LoadRuntimeConfigFromFactoryDir(%q): %v", factoryDir, err)
 	}
+	return loaded
+}
+
+func loadPackagedGoalWorker(t *testing.T, factoryDir string) *interfaces.WorkerConfig {
+	t.Helper()
+	loaded := loadPackagedGoalRuntimeConfig(t, factoryDir)
 	worker, ok := loaded.Worker("goal-executor")
 	if !ok {
 		t.Fatal("expected materialized goal-executor worker")
@@ -42,10 +87,52 @@ func loadPackagedGoalWorker(t *testing.T, factoryDir string) *interfaces.WorkerC
 	return worker
 }
 
+func loadPackagedGoalWorkstation(t *testing.T, factoryDir string) *interfaces.FactoryWorkstationConfig {
+	t.Helper()
+	loaded := loadPackagedGoalRuntimeConfig(t, factoryDir)
+	workstation, ok := loaded.Workstation(PackagedInvokeWorkstationName)
+	if !ok {
+		t.Fatal("expected materialized execute-goal workstation")
+	}
+	return workstation
+}
+
 func editMaterializedWorkerBody(t *testing.T, factoryDir, workerName, body string) {
 	t.Helper()
 	workerPath := filepath.Join(factoryDir, interfaces.WorkersDir, workerName, interfaces.FactoryAgentsFileName)
 	if err := os.WriteFile(workerPath, []byte(body), 0o644); err != nil {
 		t.Fatalf("WriteFile(materialized worker body): %v", err)
+	}
+}
+
+func editMaterializedWorkstationBody(t *testing.T, factoryDir, workstationName, body string) {
+	t.Helper()
+	workstationPath := filepath.Join(factoryDir, interfaces.WorkstationsDir, workstationName, interfaces.FactoryAgentsFileName)
+	if err := os.WriteFile(workstationPath, []byte(body), 0o644); err != nil {
+		t.Fatalf("WriteFile(materialized workstation body): %v", err)
+	}
+}
+
+func editMaterializedFactoryProject(t *testing.T, factoryDir, project string) {
+	t.Helper()
+	factoryJSONPath := filepath.Join(factoryDir, interfaces.FactoryConfigFile)
+	factoryJSON, err := os.ReadFile(factoryJSONPath)
+	if err != nil {
+		t.Fatalf("ReadFile(factory.json): %v", err)
+	}
+	var factoryDoc map[string]any
+	if err := json.Unmarshal(factoryJSON, &factoryDoc); err != nil {
+		t.Fatalf("Unmarshal(factory.json): %v", err)
+	}
+	factoryDoc["id"] = project
+	editedJSON, err := json.MarshalIndent(factoryDoc, "", "  ")
+	if err != nil {
+		t.Fatalf("Marshal(edited factory.json): %v", err)
+	}
+	if string(editedJSON) == string(factoryJSON) {
+		t.Fatal("expected edited factory.json to differ from initial materialized content")
+	}
+	if err := os.WriteFile(factoryJSONPath, editedJSON, 0o644); err != nil {
+		t.Fatalf("WriteFile(edited factory.json): %v", err)
 	}
 }

--- a/pkg/packagedfactories/goal/materialize_edit_test.go
+++ b/pkg/packagedfactories/goal/materialize_edit_test.go
@@ -1,0 +1,51 @@
+package goal
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	factoryconfig "github.com/portpowered/infinite-you/pkg/config"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+)
+
+func TestEditedMaterializedPackagedGoalFactoryChangesNextLoad(t *testing.T) {
+	factoryDir := materializePackagedGoalFactory(t, t.TempDir())
+	initialWorker := loadPackagedGoalWorker(t, factoryDir)
+	if initialWorker.Body == "" {
+		t.Fatal("expected initial materialized goal worker body")
+	}
+
+	editedBody := "You are the customer-edited @you/goal built-in.\n"
+	editMaterializedWorkerBody(t, factoryDir, "goal-executor", editedBody)
+
+	editedWorker := loadPackagedGoalWorker(t, factoryDir)
+	if editedWorker.Body != strings.TrimSpace(editedBody) {
+		t.Fatalf("edited worker body = %q, want %q", editedWorker.Body, strings.TrimSpace(editedBody))
+	}
+	if editedWorker.Body == initialWorker.Body {
+		t.Fatalf("edited worker body = %q, want change from initial materialized content", editedWorker.Body)
+	}
+}
+
+func loadPackagedGoalWorker(t *testing.T, factoryDir string) *interfaces.WorkerConfig {
+	t.Helper()
+	loaded, err := factoryconfig.LoadRuntimeConfigFromFactoryDir(factoryDir, nil)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfigFromFactoryDir(%q): %v", factoryDir, err)
+	}
+	worker, ok := loaded.Worker("goal-executor")
+	if !ok {
+		t.Fatal("expected materialized goal-executor worker")
+	}
+	return worker
+}
+
+func editMaterializedWorkerBody(t *testing.T, factoryDir, workerName, body string) {
+	t.Helper()
+	workerPath := filepath.Join(factoryDir, interfaces.WorkersDir, workerName, interfaces.FactoryAgentsFileName)
+	if err := os.WriteFile(workerPath, []byte(body), 0o644); err != nil {
+		t.Fatalf("WriteFile(materialized worker body): %v", err)
+	}
+}

--- a/pkg/packagedfactories/goal/materialize_test.go
+++ b/pkg/packagedfactories/goal/materialize_test.go
@@ -1,0 +1,68 @@
+package goal
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	factoryconfig "github.com/portpowered/infinite-you/pkg/config"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+)
+
+func TestMaterializePackagedGoalFactory_WritesEditableSplitLayout(t *testing.T) {
+	factoryDir := materializePackagedGoalFactory(t, t.TempDir())
+	assertMaterializedSplitLayout(t, factoryDir)
+
+	loaded, err := factoryconfig.LoadRuntimeConfigFromFactoryDir(factoryDir, nil)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfigFromFactoryDir: %v", err)
+	}
+	if loaded.FactoryConfig().Project != PackagedFactoryProject {
+		t.Fatalf("project = %q, want %s", loaded.FactoryConfig().Project, PackagedFactoryProject)
+	}
+	worker, ok := loaded.Worker("goal-executor")
+	if !ok {
+		t.Fatal("expected materialized goal-executor worker")
+	}
+	if worker.Body == "" {
+		t.Fatal("expected worker body loaded from split-layout workers/ directory")
+	}
+	workstation, ok := loaded.Workstation(PackagedInvokeWorkstationName)
+	if !ok {
+		t.Fatal("expected materialized execute-goal workstation")
+	}
+	if workstation.Body == "" {
+		t.Fatal("expected workstation body loaded from split-layout workstations/ directory")
+	}
+}
+
+func materializePackagedGoalFactory(t *testing.T, globalRoot string) string {
+	t.Helper()
+	factoryDir, err := factoryconfig.PersistNamedFactory(globalRoot, PackagedFactoryName, factoryconfig.BuiltInGoalFactoryJSON)
+	if err != nil {
+		t.Fatalf("PersistNamedFactory: %v", err)
+	}
+	return factoryDir
+}
+
+func assertMaterializedSplitLayout(t *testing.T, factoryDir string) {
+	t.Helper()
+	for _, dirName := range []string{interfaces.WorkersDir, interfaces.WorkstationsDir} {
+		info, err := os.Stat(filepath.Join(factoryDir, dirName))
+		if err != nil {
+			t.Fatalf("stat %s: %v", dirName, err)
+		}
+		if !info.IsDir() {
+			t.Fatalf("%s is not a directory", dirName)
+		}
+	}
+	for _, path := range []string{
+		filepath.Join(factoryDir, interfaces.FactoryConfigFile),
+		filepath.Join(factoryDir, interfaces.WorkersDir, "goal-executor", interfaces.FactoryAgentsFileName),
+		filepath.Join(factoryDir, interfaces.WorkstationsDir, PackagedInvokeWorkstationName, interfaces.FactoryAgentsFileName),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected materialized path %s: %v", path, err)
+		}
+	}
+}


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "you-goal-p02-materialize-editable-layout",
  "description": "Materialize @you/goal into the normal customer-editable split factory layout on first use, then preserve customer edits on later runs by loading the materialized copy instead of overwriting it from the built-in payload.",
  "context": {
    "customerAsk": "Materialize @you/goal into an editable split factory layout and preserve customer edits on later runs. The required observable outcomes are that @you/goal writes factory.json, workers/, and workstations/ on first use, later runs load the materialized copy instead of overwriting it, and tests mirror packaged TTS materialization and editability coverage.",
    "problem": "After P01, @you/goal can be resolvable as a built-in named factory, but that does not yet prove the packaged-factory editable-copy contract. Without explicit materialization behavior and regression coverage, @you/goal could remain an embedded payload, fail to produce the normal split layout, or overwrite local edits on later runs instead of behaving like the customer-owned packaged factories already modeled by @you/tts.",
    "solution": "Use the existing named-factory persist and load path to materialize @you/goal into the built-in factory root as a split layout on first use, author the packaged payload so factory.json, workers/, and workstations/ are written as the editable source files, and make later runs load the existing on-disk copy without re-copying the built-in payload. Add focused tests that mirror packaged TTS materialization and editability coverage."
  },
  "acceptanceCriteria": [
    "First use of @you/goal materializes a customer-editable split factory directory containing factory.json, workers/, and workstations/.",
    "The materialized @you/goal directory loads through the normal named-factory runtime/config path without a separate goal-specific loader.",
    "Later you run --named @you/goal resolutions load the existing materialized copy instead of overwriting it from the built-in payload.",
    "A customer edit made inside the materialized @you/goal layout affects the next load or invocation-facing behavior, proving the on-disk copy is authoritative after first materialization.",
    "Regression tests mirror the existing packaged TTS materialization and editability seams for @you/goal.",
    "No new resolver branch, overwrite-on-run behavior, or non-editable packaged-factory path is introduced for @you/goal.",
    "Quality gate: typecheck, lint, and relevant tests pass for touched packages."
  ],
  "userStories": [
    {
      "id": "you-goal-p02-materialize-editable-layout-001",
      "title": "Materialize @you/goal into the editable split factory layout",
      "description": "As a customer, I want first use of @you/goal to create the normal editable factory directory so that I can inspect and modify the packaged factory on disk.",
      "acceptanceCriteria": [
        "First materialization of @you/goal creates a named factory directory under the existing built-in factory root.",
        "The materialized directory contains factory.json, a workers/ directory, and a workstations/ directory.",
        "The materialized layout is loadable through the existing factory config/runtime loading path used for named factories.",
        "The implementation reuses the existing split-layout persist contract rather than writing a one-off packaged-factory file shape for @you/goal.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "you-goal-p02-materialize-editable-layout-002",
      "title": "Later runs preserve customer edits in the materialized copy",
      "description": "As a customer, I want later @you/goal runs to use my edited materialized copy so that the packaged built-in behaves like an owned starter factory rather than a repeatedly reset template.",
      "acceptanceCriteria": [
        "When an editable @you/goal copy already exists in the normal named-factory location, later resolution/load uses that on-disk copy instead of re-materializing from the built-in payload.",
        "Editing a field in the materialized @you/goal layout changes the next load or invocation-derived behavior in a way that proves the edited copy was used.",
        "Later runs do not silently overwrite customer changes in factory.json, workers/, or workstations/ when the existing materialized layout is valid.",
        "If the materialized copy is present and valid, the behavior matches the existing editable-copy precedence model already used for packaged named factories.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "you-goal-p02-materialize-editable-layout-003",
      "title": "Add packaged-factory regression coverage that mirrors TTS editability",
      "description": "As a maintainer, I want @you/goal tests to mirror packaged TTS materialization and editability coverage so that later packaged-factory changes cannot silently break the editable-copy contract.",
      "acceptanceCriteria": [
        "Focused tests prove @you/goal materializes into the expected split layout on first use.",
        "Focused tests prove an edit made to the materialized @you/goal layout changes the next load or invocation-facing behavior without requiring the built-in payload to change.",
        "The regression shape mirrors the existing packaged TTS coverage style rather than relying only on catalog registration or inventory assertions.",
        "Test fixtures stay narrow to materialization and editability and do not expand into unrelated goal topology, docs, UI, or API behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)