### PR TITLE
pause-resume-p02-resume-wakes-and-drains

### DIFF
--- a/pkg/factory/interfaces.go
+++ b/pkg/factory/interfaces.go
@@ -41,8 +41,9 @@ type Factory interface {
 	// Pause pauses the factory loop. No transitions fire until resumed.
 	Pause(ctx context.Context) error
 
-	// Resume re-enables processing for a paused factory and wakes the engine
-	// when buffered submissions or worker results are waiting.
+	// Resume resumes a paused factory loop and actively wakes the engine so
+	// already-buffered submissions and worker results can drain. When the
+	// factory is already running, resume is an accepted no-op.
 	Resume(ctx context.Context) error
 
 	// GetFactoryEvents returns the current-process canonical event history.

--- a/pkg/factory/runtime/factory.go
+++ b/pkg/factory/runtime/factory.go
@@ -454,7 +454,7 @@ func (f *factoryImpl) Pause(_ context.Context) error {
 	return nil
 }
 
-// Resume re-enables processing for a paused factory.
+// Resume resumes a paused factory and wakes the engine so buffered work can drain.
 func (f *factoryImpl) Resume(_ context.Context) error {
 	f.mu.Lock()
 	previousState := f.state

--- a/pkg/factory/runtime/factory_buffered_pause_test_helpers_test.go
+++ b/pkg/factory/runtime/factory_buffered_pause_test_helpers_test.go
@@ -261,16 +261,49 @@ func assertWorksNotAtDonePlace(t *testing.T, f factory.Factory, workIDs []string
 
 func waitForWorkDoneAfterResume(t *testing.T, f factory.Factory, workID string) {
 	t.Helper()
-	waitForAggregateSnapshot(t, f, func(snap *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) bool {
+	waitForAggregateSnapshotWithTimeout(t, f, 2*time.Second, func(snap *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) bool {
 		return markingContainsWorkAtPlace(&snap.Marking, workID, "task:done")
 	})
 }
 
 func waitForQuiescentWorksAtDone(t *testing.T, f factory.Factory, workIDs []string) *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net] {
 	t.Helper()
-	return waitForAggregateSnapshot(t, f, func(snap *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) bool {
+	return waitForAggregateSnapshotWithTimeout(t, f, 5*time.Second, func(snap *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) bool {
 		return allWorksAtDonePlace(&snap.Marking, workIDs) && snap.InFlightCount == 0
 	})
+}
+
+func waitForAggregateSnapshotWithTimeout(
+	t *testing.T,
+	f factory.Factory,
+	timeout time.Duration,
+	match func(*interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) bool,
+) *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net] {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	var last *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]
+	for time.Now().Before(deadline) {
+		snap, err := f.GetEngineStateSnapshot(context.Background())
+		if err != nil {
+			t.Fatalf("GetEngineStateSnapshot: %v", err)
+		}
+		last = snap
+		if match(snap) {
+			return snap
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if last == nil {
+		t.Fatal("timed out waiting for aggregate snapshot; no snapshot captured")
+	}
+	t.Fatalf("timed out waiting for aggregate snapshot after %s; last status=%q in_flight=%d tick=%d",
+		timeout,
+		last.RuntimeStatus,
+		last.InFlightCount,
+		last.TickCount,
+	)
+	return nil
 }
 
 func assertDispatchOrder(t *testing.T, history []interfaces.CompletedDispatch, wantWorkIDs []string) {

--- a/pkg/factory/runtime/factory_buffered_pause_test_helpers_test.go
+++ b/pkg/factory/runtime/factory_buffered_pause_test_helpers_test.go
@@ -229,3 +229,63 @@ func countTokensAtPlace(snap *interfaces.EngineStateSnapshot[petri.MarkingSnapsh
 	}
 	return count
 }
+
+func submitTaskWithWorkID(t *testing.T, f factory.Factory, workID, traceID string) {
+	t.Helper()
+	if _, err := submitWorkRequests(context.Background(), f, []interfaces.SubmitRequest{{
+		WorkID:     workID,
+		WorkTypeID: "task",
+		TraceID:    traceID,
+	}}); err != nil {
+		t.Fatalf("SubmitWorkRequest for %q: %v", workID, err)
+	}
+}
+
+func assertWorkNotAtDonePlace(t *testing.T, f factory.Factory, workID string) {
+	t.Helper()
+	snap, err := f.GetEngineStateSnapshot(context.Background())
+	if err != nil {
+		t.Fatalf("GetEngineStateSnapshot: %v", err)
+	}
+	if markingContainsWorkAtPlace(&snap.Marking, workID, "task:done") {
+		t.Fatalf("marking = %#v, want work %q to remain unprocessed before resume", snap.Marking.Tokens, workID)
+	}
+}
+
+func assertWorksNotAtDonePlace(t *testing.T, f factory.Factory, workIDs []string) {
+	t.Helper()
+	for _, workID := range workIDs {
+		assertWorkNotAtDonePlace(t, f, workID)
+	}
+}
+
+func waitForWorkDoneAfterResume(t *testing.T, f factory.Factory, workID string) {
+	t.Helper()
+	waitForAggregateSnapshot(t, f, func(snap *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) bool {
+		return markingContainsWorkAtPlace(&snap.Marking, workID, "task:done")
+	})
+}
+
+func waitForQuiescentWorksAtDone(t *testing.T, f factory.Factory, workIDs []string) *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net] {
+	t.Helper()
+	return waitForAggregateSnapshot(t, f, func(snap *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]) bool {
+		return allWorksAtDonePlace(&snap.Marking, workIDs) && snap.InFlightCount == 0
+	})
+}
+
+func assertDispatchOrder(t *testing.T, history []interfaces.CompletedDispatch, wantWorkIDs []string) {
+	t.Helper()
+	gotOrder := workIDsFromDispatchHistory(history)
+	for i, wantWorkID := range wantWorkIDs {
+		if gotOrder[i] != wantWorkID {
+			t.Fatalf("dispatch history order = %v, want %v", gotOrder, wantWorkIDs)
+		}
+	}
+}
+
+func resumeFactory(t *testing.T, f factory.Factory) {
+	t.Helper()
+	if err := f.Resume(context.Background()); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+}

--- a/pkg/factory/runtime/factory_resume_wake_test.go
+++ b/pkg/factory/runtime/factory_resume_wake_test.go
@@ -78,83 +78,21 @@ func allWorksAtDonePlace(marking *petri.MarkingSnapshot, workIDs []string) bool 
 }
 
 func TestResumeWakesOneBufferedSubmissionWhilePaused(t *testing.T) {
-	f, err := New(
+	h := startServiceModeRunHarness(t,
 		factory.WithNet(buildSimpleNet()),
 		factory.WithServiceMode(),
 		factory.WithInlineDispatch(),
 		factory.WithWorkerExecutor("mock", &passExecutor{}),
 		factory.WithLogger(logging.NoopLogger{}),
 	)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+	defer h.stop()
 
-	ctx := context.Background()
-	runCtx, cancelRun := context.WithCancel(ctx)
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- f.Run(runCtx)
-	}()
+	h.pauseAndWait()
+	submitTaskWithWorkID(t, h.Factory, "work-resume-wake", "trace-resume-wake")
+	assertWorkNotAtDonePlace(t, h.Factory, "work-resume-wake")
 
-	select {
-	case err := <-errCh:
-		t.Fatalf("Run returned before pause/resume scenario: %v", err)
-	case <-time.After(150 * time.Millisecond):
-	}
-
-	if err := f.Pause(ctx); err != nil {
-		t.Fatalf("Pause: %v", err)
-	}
-
-	if _, err := submitWorkRequests(ctx, f, []interfaces.SubmitRequest{{
-		WorkID:     "work-resume-wake",
-		WorkTypeID: "task",
-		TraceID:    "trace-resume-wake",
-	}}); err != nil {
-		t.Fatalf("SubmitWorkRequest while paused: %v", err)
-	}
-
-	time.Sleep(100 * time.Millisecond)
-
-	snapBeforeResume, err := f.GetEngineStateSnapshot(ctx)
-	if err != nil {
-		t.Fatalf("GetEngineStateSnapshot before resume: %v", err)
-	}
-	if markingContainsWorkAtPlace(&snapBeforeResume.Marking, "work-resume-wake", "task:done") {
-		t.Fatalf("marking = %#v, want buffered work to remain unprocessed before resume", snapBeforeResume.Marking.Tokens)
-	}
-
-	if err := f.Resume(ctx); err != nil {
-		t.Fatalf("Resume: %v", err)
-	}
-
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		snap, err := f.GetEngineStateSnapshot(ctx)
-		if err != nil {
-			t.Fatalf("GetEngineStateSnapshot after resume: %v", err)
-		}
-		if markingContainsWorkAtPlace(&snap.Marking, "work-resume-wake", "task:done") {
-			if snap.FactoryState != string(interfaces.FactoryStateRunning) {
-				t.Fatalf("factory state = %q, want %q after resume", snap.FactoryState, interfaces.FactoryStateRunning)
-			}
-			cancelRun()
-			select {
-			case err := <-errCh:
-				if err != nil {
-					t.Fatalf("Run after cancellation: %v", err)
-				}
-			case <-time.After(time.Second):
-				t.Fatal("timed out waiting for service-mode runtime to stop after resume drain")
-			}
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-
-	cancelRun()
-	<-errCh
-	t.Fatal("buffered submission did not reach task:done after resume without a post-resume external signal")
+	resumeFactory(t, h.Factory)
+	waitForWorkDoneAfterResume(t, h.Factory, "work-resume-wake")
 }
 
 func TestResumeWakesOneBufferedWorkerResultWhilePaused(t *testing.T) {
@@ -162,174 +100,44 @@ func TestResumeWakesOneBufferedWorkerResultWhilePaused(t *testing.T) {
 		started: make(chan struct{}),
 		release: make(chan struct{}),
 	}
-	f, err := New(
+	h := startServiceModeRunHarness(t,
 		factory.WithNet(buildSimpleNet()),
 		factory.WithServiceMode(),
 		factory.WithWorkerExecutor("mock", executor),
 		factory.WithLogger(logging.NoopLogger{}),
 	)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+	defer h.stop()
 
-	ctx := context.Background()
-	runCtx, cancelRun := context.WithCancel(ctx)
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- f.Run(runCtx)
-	}()
-
-	if _, err := submitWorkRequests(ctx, f, []interfaces.SubmitRequest{{
-		WorkID:     "work-resume-result",
-		WorkTypeID: "task",
-		TraceID:    "trace-resume-result",
-	}}); err != nil {
-		t.Fatalf("SubmitWorkRequest: %v", err)
-	}
-
-	select {
-	case <-executor.started:
-	case err := <-errCh:
-		t.Fatalf("Run returned before worker started: %v", err)
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for worker to start")
-	}
-
-	if err := f.Pause(ctx); err != nil {
-		t.Fatalf("Pause: %v", err)
-	}
-
+	submitTaskWithWorkID(t, h.Factory, "work-resume-result", "trace-resume-result")
+	waitForBlockingWorkerStart(t, executor, h.errCh)
+	h.pauseAndWait()
 	close(executor.release)
+	assertWorkNotAtDonePlace(t, h.Factory, "work-resume-result")
 
-	time.Sleep(100 * time.Millisecond)
-
-	snapBeforeResume, err := f.GetEngineStateSnapshot(ctx)
-	if err != nil {
-		t.Fatalf("GetEngineStateSnapshot before resume: %v", err)
-	}
-	if markingContainsWorkAtPlace(&snapBeforeResume.Marking, "work-resume-result", "task:done") {
-		t.Fatalf("marking = %#v, want buffered worker result to remain unprocessed before resume", snapBeforeResume.Marking.Tokens)
-	}
-
-	if err := f.Resume(ctx); err != nil {
-		t.Fatalf("Resume: %v", err)
-	}
-
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		snap, err := f.GetEngineStateSnapshot(ctx)
-		if err != nil {
-			t.Fatalf("GetEngineStateSnapshot after resume: %v", err)
-		}
-		if markingContainsWorkAtPlace(&snap.Marking, "work-resume-result", "task:done") {
-			cancelRun()
-			select {
-			case err := <-errCh:
-				if err != nil {
-					t.Fatalf("Run after cancellation: %v", err)
-				}
-			case <-time.After(time.Second):
-				t.Fatal("timed out waiting for service-mode runtime to stop after resume drain")
-			}
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-
-	cancelRun()
-	<-errCh
-	t.Fatal("buffered worker result did not reach task:done after resume without a post-resume external signal")
+	resumeFactory(t, h.Factory)
+	waitForWorkDoneAfterResume(t, h.Factory, "work-resume-result")
 }
 
 func TestResumeDrainsMultipleBufferedSubmissionsToQuiescenceWhilePaused(t *testing.T) {
 	workIDs := []string{"work-resume-drain-a", "work-resume-drain-b", "work-resume-drain-c"}
-	f, err := New(
+	h := startServiceModeRunHarness(t,
 		factory.WithNet(buildSimpleNet()),
 		factory.WithServiceMode(),
 		factory.WithInlineDispatch(),
 		factory.WithWorkerExecutor("mock", &passExecutor{}),
 		factory.WithLogger(logging.NoopLogger{}),
 	)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+	defer h.stop()
 
-	ctx := context.Background()
-	runCtx, cancelRun := context.WithCancel(ctx)
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- f.Run(runCtx)
-	}()
-
-	select {
-	case err := <-errCh:
-		t.Fatalf("Run returned before pause/resume scenario: %v", err)
-	case <-time.After(150 * time.Millisecond):
-	}
-
-	if err := f.Pause(ctx); err != nil {
-		t.Fatalf("Pause: %v", err)
-	}
-
+	h.pauseAndWait()
 	for _, workID := range workIDs {
-		if _, err := submitWorkRequests(ctx, f, []interfaces.SubmitRequest{{
-			WorkID:     workID,
-			WorkTypeID: "task",
-			TraceID:    "trace-" + workID,
-		}}); err != nil {
-			t.Fatalf("SubmitWorkRequest for %q while paused: %v", workID, err)
-		}
+		submitTaskWithWorkID(t, h.Factory, workID, "trace-"+workID)
 	}
+	assertWorksNotAtDonePlace(t, h.Factory, workIDs)
 
-	time.Sleep(100 * time.Millisecond)
-
-	snapBeforeResume, err := f.GetEngineStateSnapshot(ctx)
-	if err != nil {
-		t.Fatalf("GetEngineStateSnapshot before resume: %v", err)
-	}
-	for _, workID := range workIDs {
-		if markingContainsWorkAtPlace(&snapBeforeResume.Marking, workID, "task:done") {
-			t.Fatalf("marking = %#v, want buffered work %q to remain unprocessed before resume", snapBeforeResume.Marking.Tokens, workID)
-		}
-	}
-
-	if err := f.Resume(ctx); err != nil {
-		t.Fatalf("Resume: %v", err)
-	}
-
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		snap, err := f.GetEngineStateSnapshot(ctx)
-		if err != nil {
-			t.Fatalf("GetEngineStateSnapshot after resume: %v", err)
-		}
-		if allWorksAtDonePlace(&snap.Marking, workIDs) && snap.InFlightCount == 0 {
-			gotOrder := workIDsFromDispatchHistory(snap.DispatchHistory)
-			for i, wantWorkID := range workIDs {
-				if gotOrder[i] != wantWorkID {
-					t.Fatalf("dispatch history order = %v, want %v", gotOrder, workIDs)
-				}
-			}
-			if snap.FactoryState != string(interfaces.FactoryStateRunning) {
-				t.Fatalf("factory state = %q, want %q after resume drain", snap.FactoryState, interfaces.FactoryStateRunning)
-			}
-			cancelRun()
-			select {
-			case err := <-errCh:
-				if err != nil {
-					t.Fatalf("Run after cancellation: %v", err)
-				}
-			case <-time.After(time.Second):
-				t.Fatal("timed out waiting for service-mode runtime to stop after resume drain")
-			}
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-
-	cancelRun()
-	<-errCh
-	t.Fatal("buffered submissions did not drain to quiescence after resume without a post-resume external signal")
+	resumeFactory(t, h.Factory)
+	snap := waitForQuiescentWorksAtDone(t, h.Factory, workIDs)
+	assertDispatchOrder(t, snap.DispatchHistory, workIDs)
 }
 
 func TestResumeDrainsMultipleBufferedWorkerResultsToQuiescenceWhilePaused(t *testing.T) {
@@ -338,110 +146,38 @@ func TestResumeDrainsMultipleBufferedWorkerResultsToQuiescenceWhilePaused(t *tes
 		started: make(chan struct{}, len(workIDs)),
 		release: make(chan struct{}),
 	}
-	f, err := New(
+	h := startServiceModeRunHarness(t,
 		factory.WithNet(buildSimpleNet()),
 		factory.WithServiceMode(),
 		factory.WithWorkerExecutor("mock", executor),
 		factory.WithLogger(logging.NoopLogger{}),
 	)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-
-	ctx := context.Background()
-	runCtx, cancelRun := context.WithCancel(ctx)
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- f.Run(runCtx)
-	}()
+	defer h.stop()
 
 	for _, workID := range workIDs {
-		if _, err := submitWorkRequests(ctx, f, []interfaces.SubmitRequest{{
-			WorkID:     workID,
-			WorkTypeID: "task",
-			TraceID:    "trace-" + workID,
-		}}); err != nil {
-			t.Fatalf("SubmitWorkRequest for %q: %v", workID, err)
-		}
+		submitTaskWithWorkID(t, h.Factory, workID, "trace-"+workID)
 	}
-
 	waitForWorkerStarts(t, executor.started, len(workIDs))
-
-	if err := f.Pause(ctx); err != nil {
-		t.Fatalf("Pause: %v", err)
-	}
-
+	h.pauseAndWait()
 	close(executor.release)
+	assertWorksNotAtDonePlace(t, h.Factory, workIDs)
 
-	time.Sleep(100 * time.Millisecond)
-
-	snapBeforeResume, err := f.GetEngineStateSnapshot(ctx)
-	if err != nil {
-		t.Fatalf("GetEngineStateSnapshot before resume: %v", err)
-	}
-	for _, workID := range workIDs {
-		if markingContainsWorkAtPlace(&snapBeforeResume.Marking, workID, "task:done") {
-			t.Fatalf("marking = %#v, want buffered worker result for %q to remain unprocessed before resume", snapBeforeResume.Marking.Tokens, workID)
-		}
-	}
-
-	if err := f.Resume(ctx); err != nil {
-		t.Fatalf("Resume: %v", err)
-	}
-
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		snap, err := f.GetEngineStateSnapshot(ctx)
-		if err != nil {
-			t.Fatalf("GetEngineStateSnapshot after resume: %v", err)
-		}
-		if allWorksAtDonePlace(&snap.Marking, workIDs) && snap.InFlightCount == 0 {
-			dispatchHistoryContainsWorkIDs(t, snap.DispatchHistory, workIDs)
-			cancelRun()
-			select {
-			case err := <-errCh:
-				if err != nil {
-					t.Fatalf("Run after cancellation: %v", err)
-				}
-			case <-time.After(time.Second):
-				t.Fatal("timed out waiting for service-mode runtime to stop after resume drain")
-			}
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-
-	cancelRun()
-	<-errCh
-	t.Fatal("buffered worker results did not drain to quiescence after resume without a post-resume external signal")
+	resumeFactory(t, h.Factory)
+	snap := waitForQuiescentWorksAtDone(t, h.Factory, workIDs)
+	dispatchHistoryContainsWorkIDs(t, snap.DispatchHistory, workIDs)
 }
 
 func TestResumeOnRunningFactoryIsAcceptedNoOp(t *testing.T) {
-	f, err := New(
+	h := startServiceModeRunHarness(t,
 		factory.WithNet(buildSimpleNet()),
 		factory.WithServiceMode(),
 		factory.WithInlineDispatch(),
 		factory.WithWorkerExecutor("mock", &passExecutor{}),
 		factory.WithLogger(logging.NoopLogger{}),
 	)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+	defer h.stop()
 
-	ctx := context.Background()
-	runCtx, cancelRun := context.WithCancel(ctx)
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- f.Run(runCtx)
-	}()
-
-	select {
-	case err := <-errCh:
-		t.Fatalf("Run returned before resume no-op scenario: %v", err)
-	case <-time.After(150 * time.Millisecond):
-	}
-
-	snapBefore, err := f.GetEngineStateSnapshot(ctx)
+	snapBefore, err := h.Factory.GetEngineStateSnapshot(context.Background())
 	if err != nil {
 		t.Fatalf("GetEngineStateSnapshot before resume: %v", err)
 	}
@@ -449,13 +185,10 @@ func TestResumeOnRunningFactoryIsAcceptedNoOp(t *testing.T) {
 		t.Fatalf("factory state = %q, want %q before resume no-op", snapBefore.FactoryState, interfaces.FactoryStateRunning)
 	}
 
-	if err := f.Resume(ctx); err != nil {
-		t.Fatalf("Resume on running factory: %v", err)
-	}
-
+	resumeFactory(t, h.Factory)
 	time.Sleep(100 * time.Millisecond)
 
-	snapAfter, err := f.GetEngineStateSnapshot(ctx)
+	snapAfter, err := h.Factory.GetEngineStateSnapshot(context.Background())
 	if err != nil {
 		t.Fatalf("GetEngineStateSnapshot after resume: %v", err)
 	}
@@ -468,88 +201,30 @@ func TestResumeOnRunningFactoryIsAcceptedNoOp(t *testing.T) {
 	if snapAfter.InFlightCount != snapBefore.InFlightCount {
 		t.Fatalf("in-flight count = %d, want unchanged %d after resume no-op", snapAfter.InFlightCount, snapBefore.InFlightCount)
 	}
-
-	cancelRun()
-	select {
-	case err := <-errCh:
-		if err != nil {
-			t.Fatalf("Run after cancellation: %v", err)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for service-mode runtime to stop after resume no-op")
-	}
 }
 
 func TestResumeRepeatedAfterBufferedDrainDoesNotReprocessWork(t *testing.T) {
-	f, err := New(
+	h := startServiceModeRunHarness(t,
 		factory.WithNet(buildSimpleNet()),
 		factory.WithServiceMode(),
 		factory.WithInlineDispatch(),
 		factory.WithWorkerExecutor("mock", &passExecutor{}),
 		factory.WithLogger(logging.NoopLogger{}),
 	)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+	defer h.stop()
 
-	ctx := context.Background()
-	runCtx, cancelRun := context.WithCancel(ctx)
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- f.Run(runCtx)
-	}()
+	h.pauseAndWait()
+	submitTaskWithWorkID(t, h.Factory, "work-resume-repeat", "trace-resume-repeat")
+	resumeFactory(t, h.Factory)
 
-	select {
-	case err := <-errCh:
-		t.Fatalf("Run returned before pause/resume scenario: %v", err)
-	case <-time.After(150 * time.Millisecond):
-	}
+	snap := waitForQuiescentWorksAtDone(t, h.Factory, []string{"work-resume-repeat"})
+	drainedDispatchCount := len(snap.DispatchHistory)
 
-	if err := f.Pause(ctx); err != nil {
-		t.Fatalf("Pause: %v", err)
-	}
-
-	if _, err := submitWorkRequests(ctx, f, []interfaces.SubmitRequest{{
-		WorkID:     "work-resume-repeat",
-		WorkTypeID: "task",
-		TraceID:    "trace-resume-repeat",
-	}}); err != nil {
-		t.Fatalf("SubmitWorkRequest while paused: %v", err)
-	}
-
-	if err := f.Resume(ctx); err != nil {
-		t.Fatalf("Resume: %v", err)
-	}
-
-	deadline := time.Now().Add(time.Second)
-	var drainedDispatchCount int
-	for time.Now().Before(deadline) {
-		snap, err := f.GetEngineStateSnapshot(ctx)
-		if err != nil {
-			t.Fatalf("GetEngineStateSnapshot after first resume: %v", err)
-		}
-		if markingContainsWorkAtPlace(&snap.Marking, "work-resume-repeat", "task:done") && snap.InFlightCount == 0 {
-			drainedDispatchCount = len(snap.DispatchHistory)
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	if drainedDispatchCount == 0 {
-		cancelRun()
-		<-errCh
-		t.Fatal("buffered submission did not drain after first resume")
-	}
-
-	if err := f.Resume(ctx); err != nil {
-		t.Fatalf("second Resume after drain: %v", err)
-	}
-	if err := f.Resume(ctx); err != nil {
-		t.Fatalf("third Resume after drain: %v", err)
-	}
-
+	resumeFactory(t, h.Factory)
+	resumeFactory(t, h.Factory)
 	time.Sleep(100 * time.Millisecond)
 
-	snapAfter, err := f.GetEngineStateSnapshot(ctx)
+	snapAfter, err := h.Factory.GetEngineStateSnapshot(context.Background())
 	if err != nil {
 		t.Fatalf("GetEngineStateSnapshot after repeated resume: %v", err)
 	}
@@ -566,88 +241,23 @@ func TestResumeRepeatedAfterBufferedDrainDoesNotReprocessWork(t *testing.T) {
 	if snapAfter.InFlightCount != 0 {
 		t.Fatalf("in-flight count = %d, want 0 after repeated resume", snapAfter.InFlightCount)
 	}
-
-	cancelRun()
-	select {
-	case err := <-errCh:
-		if err != nil {
-			t.Fatalf("Run after cancellation: %v", err)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for service-mode runtime to stop after repeated resume")
-	}
 }
 
 func TestResumeRepeatedWhilePausedWakesBufferedWorkOnce(t *testing.T) {
-	f, err := New(
+	h := startServiceModeRunHarness(t,
 		factory.WithNet(buildSimpleNet()),
 		factory.WithServiceMode(),
 		factory.WithInlineDispatch(),
 		factory.WithWorkerExecutor("mock", &passExecutor{}),
 		factory.WithLogger(logging.NoopLogger{}),
 	)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+	defer h.stop()
 
-	ctx := context.Background()
-	runCtx, cancelRun := context.WithCancel(ctx)
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- f.Run(runCtx)
-	}()
+	h.pauseAndWait()
+	submitTaskWithWorkID(t, h.Factory, "work-resume-double", "trace-resume-double")
+	resumeFactory(t, h.Factory)
+	resumeFactory(t, h.Factory)
 
-	select {
-	case err := <-errCh:
-		t.Fatalf("Run returned before pause/resume scenario: %v", err)
-	case <-time.After(150 * time.Millisecond):
-	}
-
-	if err := f.Pause(ctx); err != nil {
-		t.Fatalf("Pause: %v", err)
-	}
-
-	if _, err := submitWorkRequests(ctx, f, []interfaces.SubmitRequest{{
-		WorkID:     "work-resume-double",
-		WorkTypeID: "task",
-		TraceID:    "trace-resume-double",
-	}}); err != nil {
-		t.Fatalf("SubmitWorkRequest while paused: %v", err)
-	}
-
-	if err := f.Resume(ctx); err != nil {
-		t.Fatalf("first Resume: %v", err)
-	}
-	if err := f.Resume(ctx); err != nil {
-		t.Fatalf("second Resume: %v", err)
-	}
-
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		snap, err := f.GetEngineStateSnapshot(ctx)
-		if err != nil {
-			t.Fatalf("GetEngineStateSnapshot after repeated resume: %v", err)
-		}
-		if markingContainsWorkAtPlace(&snap.Marking, "work-resume-double", "task:done") && snap.InFlightCount == 0 {
-			dispatchHistoryContainsWorkIDs(t, snap.DispatchHistory, []string{"work-resume-double"})
-			if snap.FactoryState != string(interfaces.FactoryStateRunning) {
-				t.Fatalf("factory state = %q, want %q after repeated resume", snap.FactoryState, interfaces.FactoryStateRunning)
-			}
-			cancelRun()
-			select {
-			case err := <-errCh:
-				if err != nil {
-					t.Fatalf("Run after cancellation: %v", err)
-				}
-			case <-time.After(time.Second):
-				t.Fatal("timed out waiting for service-mode runtime to stop after repeated resume")
-			}
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-
-	cancelRun()
-	<-errCh
-	t.Fatal("buffered submission was not processed exactly once after repeated resume while paused")
+	snap := waitForQuiescentWorksAtDone(t, h.Factory, []string{"work-resume-double"})
+	dispatchHistoryContainsWorkIDs(t, snap.DispatchHistory, []string{"work-resume-double"})
 }

--- a/pkg/factory/runtime/factory_resume_wake_test.go
+++ b/pkg/factory/runtime/factory_resume_wake_test.go
@@ -8,7 +8,74 @@ import (
 	"github.com/portpowered/infinite-you/pkg/factory"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/logging"
+	"github.com/portpowered/infinite-you/pkg/petri"
 )
+
+type gatedMultiWorkerExecutor struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (e *gatedMultiWorkerExecutor) Execute(_ context.Context, dispatch interfaces.WorkDispatch) (interfaces.WorkResult, error) {
+	e.started <- struct{}{}
+	<-e.release
+	return interfaces.WorkResult{
+		DispatchID:   dispatch.DispatchID,
+		TransitionID: dispatch.TransitionID,
+		Outcome:      interfaces.OutcomeAccepted,
+		Output:       "done",
+	}, nil
+}
+
+func waitForWorkerStarts(t *testing.T, started <-chan struct{}, count int) {
+	t.Helper()
+	for i := 0; i < count; i++ {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for worker start %d/%d", i+1, count)
+		}
+	}
+}
+
+func workIDsFromDispatchHistory(history []interfaces.CompletedDispatch) []string {
+	workIDs := make([]string, 0, len(history))
+	for _, completed := range history {
+		for _, token := range completed.ConsumedTokens {
+			if token.Color.WorkID != "" {
+				workIDs = append(workIDs, token.Color.WorkID)
+				break
+			}
+		}
+	}
+	return workIDs
+}
+
+func dispatchHistoryContainsWorkIDs(t *testing.T, history []interfaces.CompletedDispatch, wantWorkIDs []string) {
+	t.Helper()
+	got := workIDsFromDispatchHistory(history)
+	if len(got) != len(wantWorkIDs) {
+		t.Fatalf("dispatch history count = %d, want %d: %#v", len(got), len(wantWorkIDs), history)
+	}
+	seen := make(map[string]int, len(got))
+	for _, workID := range got {
+		seen[workID]++
+	}
+	for _, workID := range wantWorkIDs {
+		if seen[workID] != 1 {
+			t.Fatalf("dispatch history work IDs = %v, want each of %v exactly once", got, wantWorkIDs)
+		}
+	}
+}
+
+func allWorksAtDonePlace(marking *petri.MarkingSnapshot, workIDs []string) bool {
+	for _, workID := range workIDs {
+		if !markingContainsWorkAtPlace(marking, workID, "task:done") {
+			return false
+		}
+	}
+	return true
+}
 
 func TestResumeWakesOneBufferedSubmissionWhilePaused(t *testing.T) {
 	f, err := New(
@@ -172,4 +239,179 @@ func TestResumeWakesOneBufferedWorkerResultWhilePaused(t *testing.T) {
 	cancelRun()
 	<-errCh
 	t.Fatal("buffered worker result did not reach task:done after resume without a post-resume external signal")
+}
+
+func TestResumeDrainsMultipleBufferedSubmissionsToQuiescenceWhilePaused(t *testing.T) {
+	workIDs := []string{"work-resume-drain-a", "work-resume-drain-b", "work-resume-drain-c"}
+	f, err := New(
+		factory.WithNet(buildSimpleNet()),
+		factory.WithServiceMode(),
+		factory.WithInlineDispatch(),
+		factory.WithWorkerExecutor("mock", &passExecutor{}),
+		factory.WithLogger(logging.NoopLogger{}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+	runCtx, cancelRun := context.WithCancel(ctx)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- f.Run(runCtx)
+	}()
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("Run returned before pause/resume scenario: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	if err := f.Pause(ctx); err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+
+	for _, workID := range workIDs {
+		if _, err := submitWorkRequests(ctx, f, []interfaces.SubmitRequest{{
+			WorkID:     workID,
+			WorkTypeID: "task",
+			TraceID:    "trace-" + workID,
+		}}); err != nil {
+			t.Fatalf("SubmitWorkRequest for %q while paused: %v", workID, err)
+		}
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	snapBeforeResume, err := f.GetEngineStateSnapshot(ctx)
+	if err != nil {
+		t.Fatalf("GetEngineStateSnapshot before resume: %v", err)
+	}
+	for _, workID := range workIDs {
+		if markingContainsWorkAtPlace(&snapBeforeResume.Marking, workID, "task:done") {
+			t.Fatalf("marking = %#v, want buffered work %q to remain unprocessed before resume", snapBeforeResume.Marking.Tokens, workID)
+		}
+	}
+
+	if err := f.Resume(ctx); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		snap, err := f.GetEngineStateSnapshot(ctx)
+		if err != nil {
+			t.Fatalf("GetEngineStateSnapshot after resume: %v", err)
+		}
+		if allWorksAtDonePlace(&snap.Marking, workIDs) && snap.InFlightCount == 0 {
+			gotOrder := workIDsFromDispatchHistory(snap.DispatchHistory)
+			for i, wantWorkID := range workIDs {
+				if gotOrder[i] != wantWorkID {
+					t.Fatalf("dispatch history order = %v, want %v", gotOrder, workIDs)
+				}
+			}
+			if snap.FactoryState != string(interfaces.FactoryStateRunning) {
+				t.Fatalf("factory state = %q, want %q after resume drain", snap.FactoryState, interfaces.FactoryStateRunning)
+			}
+			cancelRun()
+			select {
+			case err := <-errCh:
+				if err != nil {
+					t.Fatalf("Run after cancellation: %v", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for service-mode runtime to stop after resume drain")
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cancelRun()
+	<-errCh
+	t.Fatal("buffered submissions did not drain to quiescence after resume without a post-resume external signal")
+}
+
+func TestResumeDrainsMultipleBufferedWorkerResultsToQuiescenceWhilePaused(t *testing.T) {
+	workIDs := []string{"work-resume-result-a", "work-resume-result-b", "work-resume-result-c"}
+	executor := &gatedMultiWorkerExecutor{
+		started: make(chan struct{}, len(workIDs)),
+		release: make(chan struct{}),
+	}
+	f, err := New(
+		factory.WithNet(buildSimpleNet()),
+		factory.WithServiceMode(),
+		factory.WithWorkerExecutor("mock", executor),
+		factory.WithLogger(logging.NoopLogger{}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+	runCtx, cancelRun := context.WithCancel(ctx)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- f.Run(runCtx)
+	}()
+
+	for _, workID := range workIDs {
+		if _, err := submitWorkRequests(ctx, f, []interfaces.SubmitRequest{{
+			WorkID:     workID,
+			WorkTypeID: "task",
+			TraceID:    "trace-" + workID,
+		}}); err != nil {
+			t.Fatalf("SubmitWorkRequest for %q: %v", workID, err)
+		}
+	}
+
+	waitForWorkerStarts(t, executor.started, len(workIDs))
+
+	if err := f.Pause(ctx); err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+
+	close(executor.release)
+
+	time.Sleep(100 * time.Millisecond)
+
+	snapBeforeResume, err := f.GetEngineStateSnapshot(ctx)
+	if err != nil {
+		t.Fatalf("GetEngineStateSnapshot before resume: %v", err)
+	}
+	for _, workID := range workIDs {
+		if markingContainsWorkAtPlace(&snapBeforeResume.Marking, workID, "task:done") {
+			t.Fatalf("marking = %#v, want buffered worker result for %q to remain unprocessed before resume", snapBeforeResume.Marking.Tokens, workID)
+		}
+	}
+
+	if err := f.Resume(ctx); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		snap, err := f.GetEngineStateSnapshot(ctx)
+		if err != nil {
+			t.Fatalf("GetEngineStateSnapshot after resume: %v", err)
+		}
+		if allWorksAtDonePlace(&snap.Marking, workIDs) && snap.InFlightCount == 0 {
+			dispatchHistoryContainsWorkIDs(t, snap.DispatchHistory, workIDs)
+			cancelRun()
+			select {
+			case err := <-errCh:
+				if err != nil {
+					t.Fatalf("Run after cancellation: %v", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for service-mode runtime to stop after resume drain")
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cancelRun()
+	<-errCh
+	t.Fatal("buffered worker results did not drain to quiescence after resume without a post-resume external signal")
 }

--- a/pkg/factory/runtime/factory_resume_wake_test.go
+++ b/pkg/factory/runtime/factory_resume_wake_test.go
@@ -1,0 +1,175 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/pkg/factory"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/logging"
+)
+
+func TestResumeWakesOneBufferedSubmissionWhilePaused(t *testing.T) {
+	f, err := New(
+		factory.WithNet(buildSimpleNet()),
+		factory.WithServiceMode(),
+		factory.WithInlineDispatch(),
+		factory.WithWorkerExecutor("mock", &passExecutor{}),
+		factory.WithLogger(logging.NoopLogger{}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+	runCtx, cancelRun := context.WithCancel(ctx)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- f.Run(runCtx)
+	}()
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("Run returned before pause/resume scenario: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	if err := f.Pause(ctx); err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+
+	if _, err := submitWorkRequests(ctx, f, []interfaces.SubmitRequest{{
+		WorkID:     "work-resume-wake",
+		WorkTypeID: "task",
+		TraceID:    "trace-resume-wake",
+	}}); err != nil {
+		t.Fatalf("SubmitWorkRequest while paused: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	snapBeforeResume, err := f.GetEngineStateSnapshot(ctx)
+	if err != nil {
+		t.Fatalf("GetEngineStateSnapshot before resume: %v", err)
+	}
+	if markingContainsWorkAtPlace(&snapBeforeResume.Marking, "work-resume-wake", "task:done") {
+		t.Fatalf("marking = %#v, want buffered work to remain unprocessed before resume", snapBeforeResume.Marking.Tokens)
+	}
+
+	if err := f.Resume(ctx); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		snap, err := f.GetEngineStateSnapshot(ctx)
+		if err != nil {
+			t.Fatalf("GetEngineStateSnapshot after resume: %v", err)
+		}
+		if markingContainsWorkAtPlace(&snap.Marking, "work-resume-wake", "task:done") {
+			if snap.FactoryState != string(interfaces.FactoryStateRunning) {
+				t.Fatalf("factory state = %q, want %q after resume", snap.FactoryState, interfaces.FactoryStateRunning)
+			}
+			cancelRun()
+			select {
+			case err := <-errCh:
+				if err != nil {
+					t.Fatalf("Run after cancellation: %v", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for service-mode runtime to stop after resume drain")
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cancelRun()
+	<-errCh
+	t.Fatal("buffered submission did not reach task:done after resume without a post-resume external signal")
+}
+
+func TestResumeWakesOneBufferedWorkerResultWhilePaused(t *testing.T) {
+	executor := &blockingExecutor{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	f, err := New(
+		factory.WithNet(buildSimpleNet()),
+		factory.WithServiceMode(),
+		factory.WithWorkerExecutor("mock", executor),
+		factory.WithLogger(logging.NoopLogger{}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+	runCtx, cancelRun := context.WithCancel(ctx)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- f.Run(runCtx)
+	}()
+
+	if _, err := submitWorkRequests(ctx, f, []interfaces.SubmitRequest{{
+		WorkID:     "work-resume-result",
+		WorkTypeID: "task",
+		TraceID:    "trace-resume-result",
+	}}); err != nil {
+		t.Fatalf("SubmitWorkRequest: %v", err)
+	}
+
+	select {
+	case <-executor.started:
+	case err := <-errCh:
+		t.Fatalf("Run returned before worker started: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for worker to start")
+	}
+
+	if err := f.Pause(ctx); err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+
+	close(executor.release)
+
+	time.Sleep(100 * time.Millisecond)
+
+	snapBeforeResume, err := f.GetEngineStateSnapshot(ctx)
+	if err != nil {
+		t.Fatalf("GetEngineStateSnapshot before resume: %v", err)
+	}
+	if markingContainsWorkAtPlace(&snapBeforeResume.Marking, "work-resume-result", "task:done") {
+		t.Fatalf("marking = %#v, want buffered worker result to remain unprocessed before resume", snapBeforeResume.Marking.Tokens)
+	}
+
+	if err := f.Resume(ctx); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		snap, err := f.GetEngineStateSnapshot(ctx)
+		if err != nil {
+			t.Fatalf("GetEngineStateSnapshot after resume: %v", err)
+		}
+		if markingContainsWorkAtPlace(&snap.Marking, "work-resume-result", "task:done") {
+			cancelRun()
+			select {
+			case err := <-errCh:
+				if err != nil {
+					t.Fatalf("Run after cancellation: %v", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for service-mode runtime to stop after resume drain")
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cancelRun()
+	<-errCh
+	t.Fatal("buffered worker result did not reach task:done after resume without a post-resume external signal")
+}

--- a/pkg/factory/runtime/factory_resume_wake_test.go
+++ b/pkg/factory/runtime/factory_resume_wake_test.go
@@ -415,3 +415,239 @@ func TestResumeDrainsMultipleBufferedWorkerResultsToQuiescenceWhilePaused(t *tes
 	<-errCh
 	t.Fatal("buffered worker results did not drain to quiescence after resume without a post-resume external signal")
 }
+
+func TestResumeOnRunningFactoryIsAcceptedNoOp(t *testing.T) {
+	f, err := New(
+		factory.WithNet(buildSimpleNet()),
+		factory.WithServiceMode(),
+		factory.WithInlineDispatch(),
+		factory.WithWorkerExecutor("mock", &passExecutor{}),
+		factory.WithLogger(logging.NoopLogger{}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+	runCtx, cancelRun := context.WithCancel(ctx)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- f.Run(runCtx)
+	}()
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("Run returned before resume no-op scenario: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	snapBefore, err := f.GetEngineStateSnapshot(ctx)
+	if err != nil {
+		t.Fatalf("GetEngineStateSnapshot before resume: %v", err)
+	}
+	if snapBefore.FactoryState != string(interfaces.FactoryStateRunning) {
+		t.Fatalf("factory state = %q, want %q before resume no-op", snapBefore.FactoryState, interfaces.FactoryStateRunning)
+	}
+
+	if err := f.Resume(ctx); err != nil {
+		t.Fatalf("Resume on running factory: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	snapAfter, err := f.GetEngineStateSnapshot(ctx)
+	if err != nil {
+		t.Fatalf("GetEngineStateSnapshot after resume: %v", err)
+	}
+	if snapAfter.FactoryState != string(interfaces.FactoryStateRunning) {
+		t.Fatalf("factory state = %q, want %q after resume no-op", snapAfter.FactoryState, interfaces.FactoryStateRunning)
+	}
+	if len(snapAfter.DispatchHistory) != len(snapBefore.DispatchHistory) {
+		t.Fatalf("dispatch history count = %d, want unchanged %d after resume no-op", len(snapAfter.DispatchHistory), len(snapBefore.DispatchHistory))
+	}
+	if snapAfter.InFlightCount != snapBefore.InFlightCount {
+		t.Fatalf("in-flight count = %d, want unchanged %d after resume no-op", snapAfter.InFlightCount, snapBefore.InFlightCount)
+	}
+
+	cancelRun()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Run after cancellation: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for service-mode runtime to stop after resume no-op")
+	}
+}
+
+func TestResumeRepeatedAfterBufferedDrainDoesNotReprocessWork(t *testing.T) {
+	f, err := New(
+		factory.WithNet(buildSimpleNet()),
+		factory.WithServiceMode(),
+		factory.WithInlineDispatch(),
+		factory.WithWorkerExecutor("mock", &passExecutor{}),
+		factory.WithLogger(logging.NoopLogger{}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+	runCtx, cancelRun := context.WithCancel(ctx)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- f.Run(runCtx)
+	}()
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("Run returned before pause/resume scenario: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	if err := f.Pause(ctx); err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+
+	if _, err := submitWorkRequests(ctx, f, []interfaces.SubmitRequest{{
+		WorkID:     "work-resume-repeat",
+		WorkTypeID: "task",
+		TraceID:    "trace-resume-repeat",
+	}}); err != nil {
+		t.Fatalf("SubmitWorkRequest while paused: %v", err)
+	}
+
+	if err := f.Resume(ctx); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	var drainedDispatchCount int
+	for time.Now().Before(deadline) {
+		snap, err := f.GetEngineStateSnapshot(ctx)
+		if err != nil {
+			t.Fatalf("GetEngineStateSnapshot after first resume: %v", err)
+		}
+		if markingContainsWorkAtPlace(&snap.Marking, "work-resume-repeat", "task:done") && snap.InFlightCount == 0 {
+			drainedDispatchCount = len(snap.DispatchHistory)
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if drainedDispatchCount == 0 {
+		cancelRun()
+		<-errCh
+		t.Fatal("buffered submission did not drain after first resume")
+	}
+
+	if err := f.Resume(ctx); err != nil {
+		t.Fatalf("second Resume after drain: %v", err)
+	}
+	if err := f.Resume(ctx); err != nil {
+		t.Fatalf("third Resume after drain: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	snapAfter, err := f.GetEngineStateSnapshot(ctx)
+	if err != nil {
+		t.Fatalf("GetEngineStateSnapshot after repeated resume: %v", err)
+	}
+	if snapAfter.FactoryState != string(interfaces.FactoryStateRunning) {
+		t.Fatalf("factory state = %q, want %q after repeated resume", snapAfter.FactoryState, interfaces.FactoryStateRunning)
+	}
+	if len(snapAfter.DispatchHistory) != drainedDispatchCount {
+		t.Fatalf("dispatch history count = %d, want unchanged %d after repeated resume", len(snapAfter.DispatchHistory), drainedDispatchCount)
+	}
+	dispatchHistoryContainsWorkIDs(t, snapAfter.DispatchHistory, []string{"work-resume-repeat"})
+	if !markingContainsWorkAtPlace(&snapAfter.Marking, "work-resume-repeat", "task:done") {
+		t.Fatalf("marking = %#v, want work-resume-repeat at task:done after repeated resume", snapAfter.Marking.Tokens)
+	}
+	if snapAfter.InFlightCount != 0 {
+		t.Fatalf("in-flight count = %d, want 0 after repeated resume", snapAfter.InFlightCount)
+	}
+
+	cancelRun()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Run after cancellation: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for service-mode runtime to stop after repeated resume")
+	}
+}
+
+func TestResumeRepeatedWhilePausedWakesBufferedWorkOnce(t *testing.T) {
+	f, err := New(
+		factory.WithNet(buildSimpleNet()),
+		factory.WithServiceMode(),
+		factory.WithInlineDispatch(),
+		factory.WithWorkerExecutor("mock", &passExecutor{}),
+		factory.WithLogger(logging.NoopLogger{}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+	runCtx, cancelRun := context.WithCancel(ctx)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- f.Run(runCtx)
+	}()
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("Run returned before pause/resume scenario: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	if err := f.Pause(ctx); err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+
+	if _, err := submitWorkRequests(ctx, f, []interfaces.SubmitRequest{{
+		WorkID:     "work-resume-double",
+		WorkTypeID: "task",
+		TraceID:    "trace-resume-double",
+	}}); err != nil {
+		t.Fatalf("SubmitWorkRequest while paused: %v", err)
+	}
+
+	if err := f.Resume(ctx); err != nil {
+		t.Fatalf("first Resume: %v", err)
+	}
+	if err := f.Resume(ctx); err != nil {
+		t.Fatalf("second Resume: %v", err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		snap, err := f.GetEngineStateSnapshot(ctx)
+		if err != nil {
+			t.Fatalf("GetEngineStateSnapshot after repeated resume: %v", err)
+		}
+		if markingContainsWorkAtPlace(&snap.Marking, "work-resume-double", "task:done") && snap.InFlightCount == 0 {
+			dispatchHistoryContainsWorkIDs(t, snap.DispatchHistory, []string{"work-resume-double"})
+			if snap.FactoryState != string(interfaces.FactoryStateRunning) {
+				t.Fatalf("factory state = %q, want %q after repeated resume", snap.FactoryState, interfaces.FactoryStateRunning)
+			}
+			cancelRun()
+			select {
+			case err := <-errCh:
+				if err != nil {
+					t.Fatalf("Run after cancellation: %v", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for service-mode runtime to stop after repeated resume")
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cancelRun()
+	<-errCh
+	t.Fatal("buffered submission was not processed exactly once after repeated resume while paused")
+}

--- a/pkg/packagedfactories/goal/materialize_edit_test.go
+++ b/pkg/packagedfactories/goal/materialize_edit_test.go
@@ -38,7 +38,7 @@ func TestEditedMaterializedPackagedGoalFactoryWorkstationChangesNextLoad(t *test
 	}
 
 	editedBody := "Execute the customer-edited goal work for {{ .WorkID }}.\n"
-	editMaterializedWorkstationBody(t, factoryDir, PackagedInvokeWorkstationName, editedBody)
+	editMaterializedWorkstationBody(t, factoryDir, PackagedExecuteWorkstationName, editedBody)
 
 	editedWorkstation := loadPackagedGoalWorkstation(t, factoryDir)
 	if editedWorkstation.Body != strings.TrimSpace(editedBody) {
@@ -90,7 +90,7 @@ func loadPackagedGoalWorker(t *testing.T, factoryDir string) *interfaces.WorkerC
 func loadPackagedGoalWorkstation(t *testing.T, factoryDir string) *interfaces.FactoryWorkstationConfig {
 	t.Helper()
 	loaded := loadPackagedGoalRuntimeConfig(t, factoryDir)
-	workstation, ok := loaded.Workstation(PackagedInvokeWorkstationName)
+	workstation, ok := loaded.Workstation(PackagedExecuteWorkstationName)
 	if !ok {
 		t.Fatal("expected materialized execute-goal workstation")
 	}

--- a/pkg/packagedfactories/goal/materialize_test.go
+++ b/pkg/packagedfactories/goal/materialize_test.go
@@ -27,7 +27,7 @@ func TestMaterializePackagedGoalFactory_WritesEditableSplitLayout(t *testing.T) 
 	if worker.Body == "" {
 		t.Fatal("expected worker body loaded from split-layout workers/ directory")
 	}
-	workstation, ok := loaded.Workstation(PackagedInvokeWorkstationName)
+	workstation, ok := loaded.Workstation(PackagedExecuteWorkstationName)
 	if !ok {
 		t.Fatal("expected materialized execute-goal workstation")
 	}
@@ -59,7 +59,7 @@ func assertMaterializedSplitLayout(t *testing.T, factoryDir string) {
 	for _, path := range []string{
 		filepath.Join(factoryDir, interfaces.FactoryConfigFile),
 		filepath.Join(factoryDir, interfaces.WorkersDir, "goal-executor", interfaces.FactoryAgentsFileName),
-		filepath.Join(factoryDir, interfaces.WorkstationsDir, PackagedInvokeWorkstationName, interfaces.FactoryAgentsFileName),
+		filepath.Join(factoryDir, interfaces.WorkstationsDir, PackagedExecuteWorkstationName, interfaces.FactoryAgentsFileName),
 	} {
 		if _, err := os.Stat(path); err != nil {
 			t.Fatalf("expected materialized path %s: %v", path, err)

--- a/pkg/service/factory_runtime_state.go
+++ b/pkg/service/factory_runtime_state.go
@@ -720,7 +720,7 @@ func (fs *FactoryService) Pause(ctx context.Context) error {
 	return nil
 }
 
-// Resume resumes the current runtime instance.
+// Resume resumes the current runtime instance and wakes buffered work.
 func (fs *FactoryService) Resume(ctx context.Context) error {
 	activeFactory := fs.currentFactory()
 	if activeFactory == nil {


### PR DESCRIPTION
{
  "project": "P02 Resume Wakes and Drains Buffered Work",
  "branchName": "pause-resume-p02-resume-wakes-and-drains",
  "description": "Guarantee that resuming a paused live Factory Session actively wakes the existing runtime loop and drains already-buffered submissions and worker results to quiescence without waiting for a later external signal, while preserving ordering and explicit repeated-resume outcomes.",
  "context": {
    "customerAsk": "Guarantee that resuming a paused live Factory Session actively wakes the engine and drains already-buffered submissions and worker results through the normal runtime loop without waiting for a later external signal.",
    "problem": "Buffered submissions and completed worker results can remain reachable after pause semantics preserve them, but resume is still unreliable if the original wake signal was already consumed and no later external signal arrives. In that state, a paused session can appear resumable while ready buffered work remains idle, and repeated resume behavior can be ambiguous for automation.",
    "solution": "Treat resume as an active runtime wake that re-enters the existing engine execution path and lets runUntilQuiescent drain all ready buffered submissions and completed worker results through the normal loop. Preserve ordering and exact-once behavior, keep current tick-numbering semantics unless proven impossible, and define explicit accepted no-op or invalid-state outcomes for repeated resume requests."
  },
  "acceptanceCriteria": [
    "Resuming a paused live Factory Session triggers a runtime wake-up even when no new submission, worker result, or dispatch-hook signal arrives afterward.",
    "A focused regression test covers pause, receipt of one wake-producing buffered item, resume, and processing of that buffered work without any extra external signal.",
    "A focused regression test covers pause, receipt of multiple ready buffered submissions and/or worker results, resume, and draining all ready buffered work to quiescence.",
    "Resume processing preserves existing dispatch ordering, result ordering, generated follow-up submission ordering, and exact-once handling for completed results and buffered submissions.",
    "Repeated resume calls and resume on an already-running live session have explicit accepted no-op or invalid-state expectations and do not duplicate, skip, or strand buffered work.",
    "Pause/resume wake-path regression tests live under the affected runtime packages and are named so the resume wake/drain intent is obvious to reviewers.",
    "Typecheck, lint, go test ./pkg/factory/... ./pkg/service/... ./pkg/factorysessions/..., and make test pass."
  ],
  "userStories": [
    {
      "id": "pause-resume-p02-resume-wakes-and-drains-001",
      "title": "Resume wakes one buffered signal path",
      "description": "As an operator, I want one resume call to restart a paused live Factory Session when exactly one buffered submission or result is waiting so that I do not need a second outside signal to continue processing.",
      "acceptanceCriteria": [
        "After a live Factory Session is paused and exactly one wake-producing submission or completed worker result is buffered, a single resume call re-enters the existing runtime execution path without requiring any later external signal.",
        "The buffered submission or completed result is processed through the same engine behavior it would use while running and is applied exactly once.",
        "The resulting dispatch, completion, and status progression matches normal running-session behavior for the same input order.",
        "A focused regression test proves pause, one buffered signal, resume, and successful processing with no post-resume signal injection.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pause-resume-p02-resume-wakes-and-drains-002",
      "title": "Resume drains buffered work to quiescence",
      "description": "As an operator, I want resume to drain all ready buffered work, not just the first item, so that a paused session can fully catch up once I allow it to run again.",
      "acceptanceCriteria": [
        "When multiple ready submissions and/or completed worker results are buffered behind a consumed wake signal, one successful resume call drives the runtime until no more ready buffered work remains.",
        "Resume processing uses the existing engine loop and runUntilQuiescent behavior rather than a special replay path for buffered items.",
        "Draining buffered work preserves existing dispatch ordering, result ordering, and generated follow-up submission ordering for the buffered sequence.",
        "A focused regression test proves pause, multiple buffered items, resume, and drain-to-quiescence with no post-resume external signal.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pause-resume-p02-resume-wakes-and-drains-003",
      "title": "Resume outcomes stay explicit and lossless",
      "description": "As an operator, I want repeated resume requests and resume on an already-running session to have defined outcomes so that automation can call resume safely without duplicating or skipping work.",
      "acceptanceCriteria": [
        "Resuming an already-running live Factory Session returns the documented accepted no-op or invalid-state outcome for the control surface and does not start duplicate engine work.",
        "Repeating resume after a successful wake-and-drain does not reprocess completed results, does not duplicate generated submissions, and does not change the final quiescent outcome.",
        "If buffered work has already drained, subsequent resume calls preserve the existing session lifecycle and work state without stranding or reordering work.",
        "Focused regression tests cover repeated resume behavior with names that make the resume wake/drain regression intent obvious in the affected runtime packages.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)