### PR TITLE
you-goal-p11-api-contract-audit

### DIFF
--- a/docs/internal/development/plans/you-goal/api-contract-audit.md
+++ b/docs/internal/development/plans/you-goal/api-contract-audit.md
@@ -1,0 +1,162 @@
+# @you/goal API Contract Audit (P11)
+
+Implementation-ready contract boundary for the `@you/goal` slice. This audit
+maps each relevant surface to ownership, public vs internal scope, reuse vs
+change posture, and follow-on verification expectations.
+
+**Status:** in progress (story `you-goal-p11-api-contract-audit-001` complete)
+
+**Last updated:** 2026-06-20 UTC
+
+## Context
+
+The `@you/goal` planning direction is intentionally narrow: reuse existing
+public Factory Session invocation, lifecycle, and dispatch contracts; keep
+response-stream progress internal to runtime/session models; and limit the
+expected public OpenAPI delta to `Workstation.workPropagation`. This document is
+the single reviewer-verifiable artifact maintainers should cite before widening
+API scope in follow-on PRs.
+
+Canonical public vocabulary: `docs/architecture/data-model.md` (`Factory`,
+`Factory Session`, `Work`, `Work Request`, dispatch lifecycle, invocation
+result). Invocation equivalence rules: `docs/architecture/invocation-contract.md`.
+
+## Audit sections
+
+| Section | Story | Status |
+|---------|-------|--------|
+| [Invocation and adapter reuse boundaries](#invocation-and-adapter-reuse-boundaries) | `you-goal-p11-api-contract-audit-001` | complete |
+| Response streams vs lifecycle contracts | `you-goal-p11-api-contract-audit-002` | pending |
+| Public OpenAPI delta and generated-client expectations | `you-goal-p11-api-contract-audit-003` | pending |
+
+---
+
+## Invocation and adapter reuse boundaries
+
+`@you/goal` is a packaged named factory (`@you/goal`, project
+`builtin-goal`) resolved through the same live-session invocation path as other
+authored factories. Goal-mode work must not introduce a parallel invocation or
+result transport.
+
+### Boundary matrix
+
+| Surface | Ownership | Public / internal | @you/goal posture | Follow-on verification |
+|---------|-----------|-------------------|--------------------|------------------------|
+| `POST /factory-sessions/{session_id}/invocations` | Shared live-session invocation API (`invokeFactorySessionBySessionId`) | **Public** | **Reuse as-is** — canonical API entrypoint for `@you/goal` invocations against an open live Factory Session | API regression in `tests/functional/runtime_api/api_session_invocation_test.go`; contract description in `api/openapi-main.yaml` |
+| `InvocationRequest` / `InvocationResponse` | OpenAPI work schemas + `pkg/apisurface` projection | **Public** | **Reuse as-is** — text-first input via `WorkContent`; terminal status and `primaryResult` on `InvocationResponse` | OpenAPI contract tests in `pkg/api/contracttests/`; generated client sync via `make generate-api` only when these schemas change |
+| `Factory.invocationReturn` | Factory configuration on the active session factory | **Public** | **Reuse as-is** — sole public selector for the final primary result; default `SUBMITTED_WORK_TERMINAL` when omitted | Factory validation before runtime; primary-result selection tests in `pkg/invocations/primary_result_test.go` |
+| `you run --factory` / `you run --named @you/goal` | CLI transport adapter in `pkg/cli/run/` | **Public CLI** | **Reuse as-is** — must call the same shared resolver and primary-result selector as the API; no goal-specific transport contract | CLI tests in `pkg/cli/run/run_invocation_test.go`, `pkg/cli/root_run_factory_prompt_test.go`, and `pkg/cli/root_run_test.go` (`run --named @you/goal`) |
+| Shared invocation resolver (`pkg/invocations`) | Backend-owned input and return-policy logic | **Internal shared contract** | **Reuse as-is** — `ResolveTextInput` / `ResolveAPITextInputContent` for input; `ResolvePrimaryResult` for return policy | Unit tests in `pkg/invocations/input_test.go` and `pkg/invocations/primary_result_test.go` |
+| Goal-only result endpoint | — | — | **Out of scope** — this slice does **not** add `/goal/...`, `/results` variants, or any goal-named primary-result route | N/A — reject proposals that bypass `InvocationResponse.primaryResult` |
+
+### Canonical public API entrypoint
+
+`POST /factory-sessions/{session_id}/invocations` is the canonical public API
+entrypoint for `@you/goal`. The route:
+
+- Accepts one text-first `InvocationRequest` against an already-open live
+  Factory Session (`session_id`, typically `~default` for CLI-started sessions).
+- Submits work into the session runtime and blocks until terminal
+  primary-result selection completes (subject to `timeoutMillis`).
+- Returns `InvocationResponse` with `status` and, on success,
+  `primaryResult` as `WorkContent`.
+
+Durable JavaScript workflow execution routes (`POST /factory-sessions/async`,
+`POST /factory-sessions/sync`, `GET /factory-sessions/{session_id}/results`)
+are separate public surfaces for orchestrator-backed durable sessions. They are
+**not** the `@you/goal` invocation entrypoint for this slice. Goal follow-on
+work that needs one-shot live invocation against the packaged factory must use
+the existing invocation route, not durable start/result routes.
+
+**Authoritative references:**
+
+- OpenAPI: `api/openapi-main.yaml` (`/factory-sessions/{session_id}/invocations`)
+- Handler: `pkg/api/handlers_factory.go` → `FactoryService.InvokeFactorySession`
+- Service: `pkg/service/model_catalog.go` (`InvokeFactorySession`,
+  `resolveSessionInvocationInput`, session wait + primary-result projection)
+
+### `Factory.invocationReturn` as the public result selector
+
+`Factory.invocationReturn` on the active session factory remains the **only**
+public configuration for selecting the invocation's final primary result:
+
+| Policy | Behavior |
+|--------|----------|
+| *(omitted)* | `SUBMITTED_WORK_TERMINAL` — follow submitted work to terminal output and return that content as `InvocationResponse.primaryResult` |
+| `EXPLICIT` | Select by configured `workTypeName`, `terminalState`, and optional `workName` within the invocation submit scope |
+
+This slice does **not** add:
+
+- A goal-only result endpoint or response wrapper.
+- Per-invocation return-policy overrides on `InvocationRequest`.
+- A separate public selector for streaming or partial progress (those belong to
+  internal response-stream models; see story 002).
+
+Primary-result selection is implemented once in `pkg/invocations/primary_result.go`
+(`ResolvePrimaryResult`) and consumed by `pkg/service/model_catalog.go` after
+the session invocation wait completes. Unresolved selection surfaces as
+`InvocationResponse` status `FAILED` with code
+`INVOCATION_PRIMARY_RESULT_UNRESOLVED` and no `primaryResult`, matching the
+documented OpenAPI contract.
+
+The built-in `@you/goal` factory payload (`pkg/config/layout.go`,
+`BuiltInGoalFactoryJSON`) does not currently declare `invocationReturn`; runtime
+behavior therefore uses the documented `SUBMITTED_WORK_TERMINAL` default until
+an authored policy is added through normal factory configuration — not through
+new API routes.
+
+### CLI adapter reuse requirements
+
+CLI transports must remain thin adapters over the shared invocation contract:
+
+| CLI path | Adapter responsibility | Must not |
+|----------|------------------------|----------|
+| `you run --factory <factory.json> <text>` | Resolve positional/stdin text via `ResolveFactoryInvocationInput` → build `InvocationRequest` → `InvokeFactorySession` on `~default` | Invent separate conflict, empty-input, or primary-output rules |
+| `you run --named @you/goal <text>` | Resolve named factory to the same live-session invocation flow as `--factory` | Add goal-specific flags, headers, or response shapes |
+| Success output | Format `InvocationResponse.primaryResult` (e.g. text extraction in `writeInvocationSuccess`) | Return a goal-specific JSON envelope not derived from `InvocationResponse` |
+
+**Shared resolver chain (CLI and API must converge here):**
+
+1. **Input:** `pkg/invocations.ResolveTextInput` (CLI positional/stdin) and
+   `pkg/invocations.ResolveAPITextInputContent` (API `WorkContent`) — same
+   conflict and empty-input errors (`INVOCATION_INPUT_SOURCE_CONFLICT`,
+   `INVOCATION_INPUT_EMPTY`).
+2. **Submit + wait:** `FactoryService.InvokeFactorySession` with session
+   `invocationReturn` from runtime factory config.
+3. **Primary result:** `invocations.ResolvePrimaryResult` against selected-tick
+   world state — same policy semantics for CLI and API callers.
+
+Transport files: `pkg/cli/run/factory_invocation_input.go`,
+`pkg/cli/run/run.go`. Equivalence requirement is normative in
+`docs/architecture/invocation-contract.md`.
+
+### Reviewer evidence for this boundary
+
+Maintainers reviewing `@you/goal` invocation follow-on PRs should verify:
+
+| Evidence | What it proves |
+|----------|----------------|
+| `docs/architecture/invocation-contract.md` | CLI/API equivalence and return-policy ownership are documented public contract |
+| `pkg/invocations/input.go`, `pkg/invocations/primary_result.go` | Single backend-owned resolver and selector — no transport-specific forks |
+| `pkg/service/model_catalog.go` (`InvokeFactorySession`, `resolveSessionInvocationInput`) | API path uses shared resolver; `invocationReturn` read from session factory config |
+| `pkg/cli/run/factory_invocation_input.go` | CLI path uses `invocations.ResolveTextInput` and `InvokeFactorySession` |
+| `pkg/invocations/input_test.go`, `pkg/invocations/primary_result_test.go` | Unit coverage for input conflicts and both return policies |
+| `pkg/cli/run/run_invocation_test.go` | CLI request construction from positional/stdin sources |
+| `tests/functional/runtime_api/api_session_invocation_test.go` | End-to-end API invocation returns `primaryResult`; explicit `invocationReturn` policy honored |
+| `pkg/cli/root_run_test.go` (`run --named @you/goal`) | Named goal factory routes through standard invocation mode |
+
+**Follow-on implementation PRs** that touch invocation behavior should extend
+the evidence above (API functional tests, CLI run tests, and
+`pkg/invocations` unit tests) rather than adding goal-specific routes or
+adapters. Public OpenAPI or generated-client changes are **not** required for
+invocation reuse in this slice.
+
+---
+
+## Response streams vs lifecycle contracts
+
+*Pending story `you-goal-p11-api-contract-audit-002`.*
+
+## Public OpenAPI delta and generated-client expectations
+
+*Pending story `you-goal-p11-api-contract-audit-003`.*

--- a/docs/internal/development/plans/you-goal/api-contract-audit.md
+++ b/docs/internal/development/plans/you-goal/api-contract-audit.md
@@ -4,8 +4,8 @@ Implementation-ready contract boundary for the `@you/goal` slice. This audit
 maps each relevant surface to ownership, public vs internal scope, reuse vs
 change posture, and follow-on verification expectations.
 
-**Status:** in progress (stories `you-goal-p11-api-contract-audit-001` and
-`you-goal-p11-api-contract-audit-002` complete)
+**Status:** complete (all stories `you-goal-p11-api-contract-audit-001` through
+`you-goal-p11-api-contract-audit-003`)
 
 **Last updated:** 2026-06-20 UTC
 
@@ -28,7 +28,7 @@ result). Invocation equivalence rules: `docs/architecture/invocation-contract.md
 |---------|-------|--------|
 | [Invocation and adapter reuse boundaries](#invocation-and-adapter-reuse-boundaries) | `you-goal-p11-api-contract-audit-001` | complete |
 | [Response streams vs lifecycle contracts](#response-streams-vs-lifecycle-contracts) | `you-goal-p11-api-contract-audit-002` | complete |
-| Public OpenAPI delta and generated-client expectations | `you-goal-p11-api-contract-audit-003` | pending |
+| [Public OpenAPI delta and generated-client expectations](#public-openapi-delta-and-generated-client-expectations) | `you-goal-p11-api-contract-audit-003` | complete |
 
 ---
 
@@ -328,4 +328,119 @@ changes, or contract smoke updates unless story 003's public delta
 
 ## Public OpenAPI delta and generated-client expectations
 
-*Pending story `you-goal-p11-api-contract-audit-003`.*
+`@you/goal` follow-on API work may change **one** public factory-configuration
+field on the existing `Workstation` schema. Everything else in this slice —
+invocation routes, event vocabulary, lifecycle routes, internal response streams,
+and CLI invocation adapters — reuses or repairs existing public surfaces without
+new OpenAPI route families or generated-client churn.
+
+### Only expected public OpenAPI change
+
+| Surface | Current state | @you/goal posture | Follow-on verification |
+|---------|---------------|-------------------|------------------------|
+| `Workstation.workPropagation` | **Not yet in OpenAPI** — planned optional field on `api/components/schemas/data-models/Workstation.yaml` | **Add in follow-on PR** — sole expected public contract delta for this slice | `make generate-api`; `make api-smoke`; factory config load/save round-trip tests; dashboard factory-definition decode if the field is authorable in UI |
+| `WorkPropagationMode` | **Not yet in OpenAPI** — planned enum referenced by `workPropagation` | **Add in follow-on PR** — companion schema fragment under `api/components/schemas/data-models/` | Same as `workPropagation`; enum normalization in `pkg/interfaces/public_factory_enums.go` if runtime projection is required |
+| All other `Workstation` fields | Present in `Workstation.yaml` | **Reuse as-is** — no goal-prefixed duplicates | Existing factory validation and topology tests |
+| `Factory`, `FactorySession`, invocation, event, lifecycle schemas | Present | **Reuse as-is** — stories 001–002 lock reuse posture | Existing contract and servertests only |
+| `SessionResponseStream` / `SessionResponseStreamEvent` | Internal runtime models (not in OpenAPI) | **Internal-only** — must not appear in authored OpenAPI fragments | Runtime/session tests near implementing packages; **no** `make generate-api` |
+
+No other public OpenAPI additions are in scope for `@you/goal` in this slice:
+no new routes, no new `FactoryEventType` values, no response-stream endpoints,
+and no goal-prefixed configuration objects parallel to `Workstation`.
+
+### Stable follow-on terminology
+
+Later `@you/goal` PRs must use **exactly** these names across docs, OpenAPI
+fragments, backend config mapping, CLI/API adapters, and generated clients:
+
+| Name | Layer | Usage rule |
+|------|-------|------------|
+| `Workstation.workPropagation` | Public OpenAPI + factory JSON | JSON property name on each `Workstation` object in factory configuration; OpenAPI field on `Workstation.yaml` |
+| `WorkPropagationMode` | Public OpenAPI enum | Enum type for `workPropagation` values; fragment file `WorkPropagationMode.yaml` (or equivalent) registered in `api/openapi-main.yaml` |
+| `SessionResponseStream` | Internal runtime/session | In-process aggregate for ephemeral provider output; **never** a public schema, route, or generated-client type |
+| `SessionResponseStreamEvent` | Internal runtime/session | One internal stream record; **never** a `FactoryEventType`, SSE payload, or public client export |
+
+**Naming consistency requirements:**
+
+- Docs and planning artifacts use `Workstation.workPropagation` (schema-qualified)
+  when referring to the public field; use `workPropagation` only when describing
+  JSON/YAML on disk.
+- OpenAPI `x-enum-varnames` for `WorkPropagationMode` should follow existing
+  workstation enum style (for example `WorkPropagationModeImmediate` — exact
+  enum members are defined in the follow-on implementation PR, not this audit).
+- Go internal structs may use idiomatic Go field names (`WorkPropagation`) but
+  JSON tags and OpenAPI property names must remain `workPropagation`.
+- TypeScript factory-definition decoders must read the generated OpenAPI
+  `Workstation` shape — no parallel `goalWorkPropagation` or UI-only property
+  names.
+- CLI factory validate/save paths must accept the same factory JSON the API
+  exposes; no goal-only flags that bypass `Workstation.workPropagation`.
+
+### Generated-client and artifact rules
+
+Public generated artifacts are derived from authored OpenAPI only. Internal
+response-stream work must not touch them.
+
+| Change class | Regenerate? | Required verification |
+|--------------|-------------|----------------------|
+| Add or modify `Workstation.workPropagation` / `WorkPropagationMode` in authored OpenAPI | **Yes** — run `make generate-api` | `api/openapi.yaml`, `pkg/api/generated/server.gen.go`, `pkg/generatedclient/client.gen.go`, `ui/src/api/generated/openapi.ts` must match authored fragments; run `make api-smoke` when feasible |
+| Internal `SessionResponseStream` / `SessionResponseStreamEvent` implementation | **No** | Package-local runtime/session tests; reject PRs that regenerate public clients for stream-only diffs |
+| Invocation reuse, lifecycle behavioral repair, dispatch vocabulary reuse | **No** — unless an unrelated public schema also changes | Extend existing API/CLI/servertests from stories 001–002 |
+| Dashboard factory editor exposing `workPropagation` | **Yes** — only after OpenAPI field exists | UI decoders in `ui/src/api/factory-definition/` aligned with generated `Workstation`; `make ui-test` / `make verify-fast` for affected modules |
+
+**Generation pipeline (public contract changes only):**
+
+1. Author fragments under `api/components/schemas/data-models/` and register in
+   `api/openapi-main.yaml`.
+2. Run `make generate-api` (bundles `api/openapi.yaml`, regenerates Go server
+   and client, regenerates `ui/src/api/generated/openapi.ts`).
+3. Wire config load/save through `pkg/config/factory_config_mapping*.go` and
+   validation through `pkg/factory/validation/` if the field affects runtime
+   topology or dispatch behavior.
+4. Map API read/write surfaces through `pkg/apisurface/` when factory
+   configuration crosses the HTTP boundary.
+5. Run `make api-smoke` to prove bundled contract, generated drift checks, and
+   contract integration smoke stay aligned.
+
+**Explicitly not required** for internal-only response-stream PRs:
+
+- `make generate-api` or edits to generated files listed above.
+- `make api-smoke` solely because stream subscribers changed.
+- Meta tests that scan the repository for forbidden route names or file
+  inventories — observable API, CLI, runtime, and event behavior tests are
+  sufficient.
+
+### Boundary matrix (public vs internal artifacts)
+
+| Artifact | Role | @you/goal posture |
+|----------|------|-------------------|
+| `api/openapi-main.yaml` + `api/components/` | Authored public contract | Change only for `Workstation.workPropagation` / `WorkPropagationMode` |
+| `api/openapi.yaml` | Bundled contract | Regenerated; never hand-edited |
+| `pkg/api/generated/server.gen.go` | Go server types | Regenerated only on public OpenAPI change |
+| `pkg/generatedclient/client.gen.go` | Go HTTP client | Regenerated only on public OpenAPI change |
+| `ui/src/api/generated/openapi.ts` | TypeScript API types | Regenerated only on public OpenAPI change |
+| `pkg/api/contracttests/` | Contract smoke and authoring guards | Extend when `Workstation` schema changes; no new inventory tests for streams |
+| `pkg/config/layout.go` (`BuiltInGoalFactoryJSON`) | Built-in factory payload | May set `workPropagation` in follow-on PR without new routes; still no `make generate-api` until OpenAPI field lands |
+| Internal response-stream packages | Runtime/session plumbing | New Go packages only; zero OpenAPI footprint |
+
+### Reviewer evidence for this boundary
+
+Maintainers reviewing `@you/goal` public-contract follow-on PRs should verify:
+
+| Evidence | What it proves |
+|----------|----------------|
+| This section + stories 001–002 | Only `Workstation.workPropagation` may change OpenAPI; streams stay internal |
+| `api/components/schemas/data-models/Workstation.yaml` | Field and enum fragments use `workPropagation` / `WorkPropagationMode` naming |
+| `make generate-api` diff | Generated artifacts change only when authored OpenAPI changes |
+| `make api-smoke` | Bundled contract, drift checks, and integration smoke pass after public delta |
+| `pkg/api/contracttests/openapi_contract_surface_test.go` | Factory data-model schemas remain contract-complete when `Workstation` grows |
+| `pkg/config/mappingtests/` or factory validation tests | Factory JSON round-trips `workPropagation` through config mapping |
+| Absence of `SessionResponseStream*` in `api/components/` | Internal stream models did not leak into public contract |
+| Stories 001–002 reviewer tables | Invocation, events, and lifecycle reuse unchanged by `workPropagation` work |
+
+**Follow-on implementation PRs** that add only internal `SessionResponseStream`
+behavior should cite stories 001–002 and prove runtime behavior with focused
+tests. They must **not** include generated OpenAPI client diffs. PRs that add
+`Workstation.workPropagation` must include the full generation and
+`make api-smoke` verification path above and use the locked terminology table
+in this section.

--- a/docs/internal/development/plans/you-goal/api-contract-audit.md
+++ b/docs/internal/development/plans/you-goal/api-contract-audit.md
@@ -4,7 +4,8 @@ Implementation-ready contract boundary for the `@you/goal` slice. This audit
 maps each relevant surface to ownership, public vs internal scope, reuse vs
 change posture, and follow-on verification expectations.
 
-**Status:** in progress (story `you-goal-p11-api-contract-audit-001` complete)
+**Status:** in progress (stories `you-goal-p11-api-contract-audit-001` and
+`you-goal-p11-api-contract-audit-002` complete)
 
 **Last updated:** 2026-06-20 UTC
 
@@ -26,7 +27,7 @@ result). Invocation equivalence rules: `docs/architecture/invocation-contract.md
 | Section | Story | Status |
 |---------|-------|--------|
 | [Invocation and adapter reuse boundaries](#invocation-and-adapter-reuse-boundaries) | `you-goal-p11-api-contract-audit-001` | complete |
-| Response streams vs lifecycle contracts | `you-goal-p11-api-contract-audit-002` | pending |
+| [Response streams vs lifecycle contracts](#response-streams-vs-lifecycle-contracts) | `you-goal-p11-api-contract-audit-002` | complete |
 | Public OpenAPI delta and generated-client expectations | `you-goal-p11-api-contract-audit-003` | pending |
 
 ---
@@ -155,7 +156,175 @@ invocation reuse in this slice.
 
 ## Response streams vs lifecycle contracts
 
-*Pending story `you-goal-p11-api-contract-audit-002`.*
+`@you/goal` goal-mode progress must not widen the public OpenAPI surface through
+ephemeral provider output, partial token streams, or goal-specific control
+routes. This section separates **durable public history** (canonical
+`FactoryEvent` SSE streams and existing lifecycle routes) from **ephemeral
+internal progress** (response-stream plumbing inside the session runtime).
+
+### Durable public history vs ephemeral internal progress
+
+| Concern | Durable public history | Ephemeral internal progress |
+|---------|------------------------|-----------------------------|
+| Purpose | Replay-safe, customer-visible factory and session facts | Live provider/model output chunks, partial assistant text, and in-flight response assembly before terminal selection |
+| Transport | `GET /events`, `GET /factory-sessions/{session_id}/events` (SSE `FactoryEvent`) | In-process session/runtime subscribers only |
+| Persistence | Canonical event history (`pkg/factory/events/`, durable session replay in `pkg/factorysessionexecution/`) | Session-scoped runtime state; not a public REST resource |
+| `@you/goal` posture | **Reuse as-is** — observe progress through existing event types and lifecycle vocabulary | **Internal-only** — implement as `SessionResponseStream` / `SessionResponseStreamEvent`; never publish to OpenAPI |
+
+Existing public events such as `MODEL_RESPONSE`, `INFERENCE_RESPONSE`,
+`DISPATCH_RESPONSE`, and `WORK_STATE_CHANGE` already record terminal or
+checkpoint facts on the canonical stream. They are **not** substitutes for
+internal response streams and must not be extended with per-chunk streaming
+payloads for goal-mode partial output.
+
+### Boundary matrix
+
+| Surface | Ownership | Public / internal | @you/goal posture | Follow-on verification |
+|---------|-----------|-------------------|--------------------|------------------------|
+| `GET /events` | Runtime SSE (`getEvents`) | **Public** | **Reuse as-is** — process-wide canonical `FactoryEvent` history + live tail | `pkg/api/servertests/server_dashboard_events_test.go`; reconnect cursors in `pkg/factory/events/event_reconnect_test.go` |
+| `GET /factory-sessions/{session_id}/events` | Session-scoped SSE (`getEventsBySessionId`) | **Public** | **Reuse as-is** — same `FactoryEvent` vocabulary filtered to one live or durable session | `pkg/api/servertests/server_durable_session_events_test.go`; `FilterEventsAfterReconnect` in `pkg/factorysessionexecution/listing.go` |
+| `FactoryEventType` / event payloads | OpenAPI `api/components/schemas/events/` | **Public** | **Reuse as-is** — no new types for response-stream chunks | `pkg/api/contracttests/openapi_contract_common_test.go`; `ui/src/api/events/types.test.ts` |
+| `after_event_id` / `after_sequence` reconnect filters | OpenAPI parameters + `pkg/api/handlers_events.go` | **Public** | **Reuse as-is** — cursor filters apply only to canonical `FactoryEvent` replay | `pkg/factory/projections/projectiontests/session_reconnect_replay_test.go` |
+| `POST /factory-sessions/{session_id}/pause` / `/resume` | Durable lifecycle control API | **Public** | **Reuse routes** — behavioral repair may extend live `~default` sessions through the same routes; no `/goal/.../pause` family | `pkg/api/servertests/server_durable_session_lifecycle_control_test.go`; `pkg/factorysessionexecution/control.go` |
+| `POST /factory-sessions/{session_id}/cancel` / `/terminate` / `/retry-dispatch` | Durable lifecycle + dispatch recovery | **Public** | **Reuse as-is** — graceful cancel and forced terminate for control; `retry-dispatch` for recoverable interruptions | Same lifecycle servertests; `DISPATCH_RECONCILED` replay in dispatch projection tests |
+| Dispatch lifecycle events (`DISPATCH_QUEUED`, `DISPATCH_INTERRUPTED`, `DISPATCH_RECONCILED`) | `pkg/factory/events/event_history_dispatch_lifecycle.go` | **Public** (on canonical stream) | **Reuse vocabulary** — interrupt and recovery facts surface here; no parallel goal run/interrupt API | `pkg/factory/projections/projectiontests/dispatch_lifecycle_event_replay_test.go` |
+| `SessionResponseStream` | Session runtime read model (follow-on internal package) | **Internal** | **New internal model only** — aggregates ephemeral provider/model output for subscribers inside the runtime | Runtime/session unit tests near the implementing package; **no** OpenAPI or generated-client changes |
+| `SessionResponseStreamEvent` | Per-chunk or per-phase internal stream record | **Internal** | **New internal model only** — names follow-on partial-progress events; must not become `FactoryEventType` values | Same as above |
+| Public response-stream endpoint | — | — | **Out of scope** — no `GET .../response-stream`, SSE alias, or WebSocket surface | N/A — reject proposals that expose internal streams on REST |
+
+### Public factory event stream (durable history)
+
+The canonical factory event stream is the **only** public progress and lifecycle
+history transport for this slice:
+
+- **Process-wide:** `GET /events` streams historical then live `FactoryEvent`
+  records for the current runtime process.
+- **Session-scoped:** `GET /factory-sessions/{session_id}/events` streams the
+  same vocabulary for one session (`~default` live sessions and `dur-sess-*`
+  durable sessions).
+
+Reconnect clients use `after_event_id` or `after_sequence` (preferring
+`FactoryEvent.context.sessionSequence` for session-scoped lifecycle events) to
+resume after an acknowledged point. Durable session replays synthesize canonical
+events through `pkg/factorysessionexecution/listing.go`
+(`BuildCanonicalSessionEvents`, `BuildCanonicalRuntimeSessionEvents`).
+
+**Authoritative references:**
+
+- OpenAPI: `api/openapi-main.yaml` (`/events`,
+  `/factory-sessions/{session_id}/events`)
+- Handlers: `pkg/api/handlers_events.go`
+- Event vocabulary: `api/components/schemas/events/FactoryEventType.yaml`
+- UI consumer: `ui/src/features/dashboard/hooks/event-stream/useFactoryEventStream.ts`
+
+Dashboard and timeline features derive lifecycle banners and dispatch state from
+these public events (`replayDispatchLifecycle.ts`,
+`replaySessionLifecycle.ts`). Goal follow-on work must extend client projections
+from existing `FactoryEvent` types, not from internal response-stream models.
+
+### Response streams are internal-only
+
+For `@you/goal`, **response streams are internal runtime/session constructs** in
+this slice. They carry ephemeral partial output while work is in flight. They
+are **not** public OpenAPI resources.
+
+Follow-on internal implementation must use these stable names:
+
+| Internal name | Role |
+|---------------|------|
+| `SessionResponseStream` | Session-scoped aggregate of in-flight response output (subscribers, cursors, and flush-to-terminal behavior stay inside the runtime) |
+| `SessionResponseStreamEvent` | One internal stream record (chunk, phase marker, or provider-specific progress fact) |
+
+This slice **must not**:
+
+- Add `FactoryEventType` enum values (for example `RESPONSE_STREAM_CHUNK` or
+  goal-prefixed variants).
+- Add new public event payload schemas or variants under
+  `api/components/schemas/events/payloads/` for streaming chunks.
+- Extend `GET /events` or `GET /factory-sessions/{session_id}/events` with
+  response-stream filters, alternate SSE schemas, or secondary stream URLs.
+- Add public response-stream REST or SSE endpoints.
+- Regenerate Go or TypeScript public clients for internal response-stream model
+  changes (see story 003 for the public-contract generation rule).
+
+Internal streams may inform terminal facts that **later** appear on the canonical
+stream (`DISPATCH_RESPONSE`, `WORK_STATE_CHANGE`, invocation
+`primaryResult`), but partial chunks themselves stay out of public history.
+
+### Session pause/resume reuse
+
+Existing Factory Session lifecycle control routes are the public pause/resume
+surface for this slice:
+
+| Route | Current scope | @you/goal posture |
+|-------|---------------|-------------------|
+| `POST /factory-sessions/{session_id}/pause` | Durable `dur-sess-*` sessions (runtime-backed and fixture-backed) | **Reuse route** — goal-mode pause must target this route, not a goal-named variant |
+| `POST /factory-sessions/{session_id}/resume` | Durable sessions | **Reuse route** — same as pause |
+
+Responses use `FactorySessionLifecycleControlResponse` with typed outcomes
+(`ACCEPTED`, `NO_OP`, `INVALID_STATE`, `TERMINAL_SESSION`, `CONFLICT`) and
+`FactorySessionLifecycleControlLinks` for post-control inspection of results,
+dispatches, and artifacts.
+
+**Behavioral repair without new route families:** Live Factory Sessions opened
+through `POST /factory-sessions` or CLI `you run` (session `~default`) may
+receive pause/resume **behavior** on the existing `/pause` and `/resume` routes
+when follow-on work needs goal-mode control during an open live session. That
+repair extends handlers and runtime coordination (`pkg/api/handlers_factory.go`,
+`pkg/service/runtime_sessions.go`) — it does **not** justify
+`/factory-sessions/{session_id}/goal-pause`, MCP goal tools, or CLI-only pause
+commands.
+
+Today, non-durable session IDs may still return `501 NotImplemented` on pause
+(see `TestPauseFactorySession_NonDurableSessionPreservesLiveStub`). Treat that
+as a known behavioral gap repairable on the existing public routes, not as
+evidence that goal mode needs a separate control API.
+
+### Interrupt behavior and dispatch lifecycle vocabulary
+
+Goal-mode interrupt and recovery must reuse **existing dispatch lifecycle
+vocabulary** on the canonical event stream instead of inventing a parallel run
+or interrupt API:
+
+| Concept | Public vocabulary | Must not add |
+|---------|-------------------|--------------|
+| Dispatch interrupted | `DISPATCH_INTERRUPTED` (`DispatchInterruptedEventPayload`: `reason`, `observedStatus`, `interruptedAt`, `retryPlanned`, optional refs) | `POST /goal/interrupt`, per-goal cancel routes, or invocation-scoped interrupt endpoints |
+| Dispatch queued | `DISPATCH_QUEUED` | Goal-specific queue event types |
+| Dispatch reconciled | `DISPATCH_RECONCILED` | Separate recovery/rollback API families |
+| Session stop | `POST /factory-sessions/{session_id}/cancel` or `/terminate` (durable) | Goal-named terminate routes |
+
+Runtime emission lives in `pkg/factory/events/event_history_dispatch_lifecycle.go`;
+replay projection in `pkg/factory/projections/world_state_dispatch.go`. CLI and
+dashboard consumers already map `DISPATCH_INTERRUPTED` in
+`ui/src/api/events/types.ts`.
+
+For live `@you/goal` invocations, user-initiated interrupt during an in-flight
+`POST /factory-sessions/{session_id}/invocations` should be modeled through
+session/runtime cancellation that ultimately surfaces as dispatch lifecycle facts
+(`DISPATCH_INTERRUPTED` and related session bracket events), not through a new
+public "stop goal run" endpoint.
+
+### Reviewer evidence for this boundary
+
+Maintainers reviewing `@you/goal` streaming and control follow-on PRs should
+verify:
+
+| Evidence | What it proves |
+|----------|----------------|
+| This section + story 003 public OpenAPI delta | Response streams stay internal; only `Workstation.workPropagation` may change OpenAPI |
+| `api/components/schemas/events/FactoryEventType.yaml` | No new public event types for streaming chunks |
+| `pkg/api/handlers_events.go` | Public SSE exposes only `FactoryEvent`; no response-stream branch |
+| `pkg/factory/events/event_history_dispatch_lifecycle.go` | Interrupt facts use `DISPATCH_INTERRUPTED` emission path |
+| `pkg/factory/projections/projectiontests/dispatch_lifecycle_event_replay_test.go` | Dispatch lifecycle replay reconstructs interrupted/recovered state |
+| `pkg/api/servertests/server_durable_session_lifecycle_control_test.go` | Pause/resume/cancel/terminate reuse existing lifecycle routes |
+| `pkg/factorysessionexecution/control.go` | Lifecycle control semantics and idempotent replay for durable sessions |
+| `ui/src/api/events/types.ts` | Dashboard event mapping includes `DISPATCH_INTERRUPTED` without response-stream types |
+
+**Follow-on implementation PRs** for internal `SessionResponseStream` work
+should add runtime/session unit and integration tests near the implementing
+packages. They must **not** require `make generate-api`, OpenAPI fragment
+changes, or contract smoke updates unless story 003's public delta
+(`Workstation.workPropagation`) is also in scope.
 
 ## Public OpenAPI delta and generated-client expectations
 

--- a/docs/internal/development/plans/you-goal/api-contract-audit.md
+++ b/docs/internal/development/plans/you-goal/api-contract-audit.md
@@ -72,7 +72,8 @@ the existing invocation route, not durable start/result routes.
 **Authoritative references:**
 
 - OpenAPI: `api/openapi-main.yaml` (`/factory-sessions/{session_id}/invocations`)
-- Handler: `pkg/api/handlers_factory.go` → `FactoryService.InvokeFactorySession`
+- Handler: `pkg/api/handlers_work_write.go` → `Server.InvokeFactorySessionBySessionId`
+  (delegates to session runtime `InvokeFactorySession`)
 - Service: `pkg/service/model_catalog.go` (`InvokeFactorySession`,
   `resolveSessionInvocationInput`, session wait + primary-result projection)
 
@@ -143,8 +144,9 @@ Maintainers reviewing `@you/goal` invocation follow-on PRs should verify:
 | `pkg/cli/run/factory_invocation_input.go` | CLI path uses `invocations.ResolveTextInput` and `InvokeFactorySession` |
 | `pkg/invocations/input_test.go`, `pkg/invocations/primary_result_test.go` | Unit coverage for input conflicts and both return policies |
 | `pkg/cli/run/run_invocation_test.go` | CLI request construction from positional/stdin sources |
+| `pkg/cli/run/run_invocation_test.go` (`TestResolveFactoryInvocationRequest_NamedFactory*`) | Named factory positional/stdin text selects standard invocation mode and builds `InvocationRequest` through the shared resolver (same code path as `@you/goal`) |
 | `tests/functional/runtime_api/api_session_invocation_test.go` | End-to-end API invocation returns `primaryResult`; explicit `invocationReturn` policy honored |
-| `pkg/cli/root_run_test.go` (`run --named @you/goal`) | Named goal factory routes through standard invocation mode |
+| `pkg/cli/root_run_test.go` (`TestRunCommand_NamedFactoryResolutionMetadataFlowsForBuiltInGoal`) | `run --named @you/goal` resolves built-in goal factory metadata into `RunConfig` at the CLI flag layer |
 
 **Follow-on implementation PRs** that touch invocation behavior should extend
 the evidence above (API functional tests, CLI run tests, and

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -2,7 +2,7 @@
 
 Use this map when changing the public REST contract.
 
-- `@you/goal` API contract boundary audit lives in `docs/internal/development/plans/you-goal/api-contract-audit.md`. Follow-on goal API PRs should cite that artifact before adding routes, OpenAPI fragments, or generated-client changes. Invocation reuse for goal mode stays on `POST /factory-sessions/{session_id}/invocations` with `Factory.invocationReturn` primary-result selection; internal `SessionResponseStream` / `SessionResponseStreamEvent` models and existing lifecycle routes (`/pause`, `/resume`, `DISPATCH_INTERRUPTED`) are documented in the audit lifecycle section; `Workstation.workPropagation` scope is in story 003.
+- `@you/goal` API contract boundary audit lives in `docs/internal/development/plans/you-goal/api-contract-audit.md`. Follow-on goal API PRs should cite that artifact before adding routes, OpenAPI fragments, or generated-client changes. Invocation reuse for goal mode stays on `POST /factory-sessions/{session_id}/invocations` with `Factory.invocationReturn` primary-result selection; internal `SessionResponseStream` / `SessionResponseStreamEvent` models and existing lifecycle routes (`/pause`, `/resume`, `DISPATCH_INTERRUPTED`) are documented in the audit lifecycle section. The only expected public OpenAPI delta for this slice is `Workstation.workPropagation` with companion `WorkPropagationMode` on `api/components/schemas/data-models/Workstation.yaml`; run `make generate-api` and `make api-smoke` when that field lands, but not for internal-only response-stream work.
 
 - `api/openapi-main.yaml` is the authored OpenAPI entrypoint. Register new component fragments under `components.schemas` here.
 - `api/components/schemas/api/` contains API request/response fragments.

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -2,7 +2,7 @@
 
 Use this map when changing the public REST contract.
 
-- `@you/goal` API contract boundary audit lives in `docs/internal/development/plans/you-goal/api-contract-audit.md`. Follow-on goal API PRs should cite that artifact before adding routes, OpenAPI fragments, or generated-client changes. Invocation reuse for goal mode stays on `POST /factory-sessions/{session_id}/invocations` with `Factory.invocationReturn` primary-result selection; internal response-stream models and `Workstation.workPropagation` scope are defined in the audit sections as they land.
+- `@you/goal` API contract boundary audit lives in `docs/internal/development/plans/you-goal/api-contract-audit.md`. Follow-on goal API PRs should cite that artifact before adding routes, OpenAPI fragments, or generated-client changes. Invocation reuse for goal mode stays on `POST /factory-sessions/{session_id}/invocations` with `Factory.invocationReturn` primary-result selection; internal `SessionResponseStream` / `SessionResponseStreamEvent` models and existing lifecycle routes (`/pause`, `/resume`, `DISPATCH_INTERRUPTED`) are documented in the audit lifecycle section; `Workstation.workPropagation` scope is in story 003.
 
 - `api/openapi-main.yaml` is the authored OpenAPI entrypoint. Register new component fragments under `components.schemas` here.
 - `api/components/schemas/api/` contains API request/response fragments.

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -2,6 +2,8 @@
 
 Use this map when changing the public REST contract.
 
+- `@you/goal` API contract boundary audit lives in `docs/internal/development/plans/you-goal/api-contract-audit.md`. Follow-on goal API PRs should cite that artifact before adding routes, OpenAPI fragments, or generated-client changes. Invocation reuse for goal mode stays on `POST /factory-sessions/{session_id}/invocations` with `Factory.invocationReturn` primary-result selection; internal response-stream models and `Workstation.workPropagation` scope are defined in the audit sections as they land.
+
 - `api/openapi-main.yaml` is the authored OpenAPI entrypoint. Register new component fragments under `components.schemas` here.
 - `api/components/schemas/api/` contains API request/response fragments.
 - `api/components/schemas/data-models/` contains customer-facing factory and work data model fragments.


### PR DESCRIPTION
{
  "project": "you-agent-factory",
  "branchName": "you-goal-p11-api-contract-audit",
  "description": "Audit the @you/goal API contract boundary so maintainers know which existing public session, invocation, and dispatch surfaces are reused, that response streams remain internal-only in this slice, and that Workstation.workPropagation is the only expected public OpenAPI change.",
  "context": {
    "customerAsk": "Audit current API surfaces and confirm response streams are internal-only while workPropagation is the only expected public OpenAPI change. The audit must cover invocation response, event stream, session pause/resume, dispatch lifecycle, generated clients, and CLI adapters, and follow-on API PRs must use SessionResponseStream, SessionResponseStreamEvent, and Workstation.workPropagation terminology.",
    "problem": "The current @you/goal planning direction is intentionally narrow, but maintainers still need one implementation-ready audit artifact that states exactly which existing public API surfaces are reused, which public behaviors may be repaired without new route families, and which streaming concepts must stay out of public OpenAPI. Without that audit, follow-on API work can widen scope accidentally through public response-stream endpoints, event types, filters, or unnecessary generated-client changes.",
    "solution": "Produce a contract audit that maps each relevant surface to its intended ownership and scope, confirms invocation/result, session pause/resume, and dispatch lifecycle reuse, marks response streams as internal runtime/session models only, and identifies Workstation.workPropagation as the only expected public OpenAPI change with clear generated-client and verification expectations."
  },
  "acceptanceCriteria": [
    "The audit covers invocation response, event stream, session pause/resume, dispatch lifecycle, generated clients, and CLI adapters in one reviewer-verifiable artifact.",
    "The audit states that POST /factory-sessions/{session_id}/invocations and Factory.invocationReturn remain the canonical public invocation/result surfaces for this slice.",
    "The audit states that existing Factory Session pause/resume routes and existing dispatch lifecycle vocabulary are reused for goal-mode control behavior instead of adding goal-specific route families.",
    "The audit explicitly states that response streams are internal-only in this slice and must not be added to public OpenAPI events, event filters, or generated public clients.",
    "The audit identifies Workstation.workPropagation as the only expected public OpenAPI change in this slice and explains when generated clients and contract smoke verification are required.",
    "The audit locks follow-on terminology to SessionResponseStream, SessionResponseStreamEvent, and Workstation.workPropagation so later API PRs use one stable vocabulary across docs, contracts, and adapters.",
    "Quality gate: typecheck, lint, and relevant tests pass before merge."
  ],
  "userStories": [
    {
      "id": "you-goal-p11-api-contract-audit-001",
      "title": "Confirm invocation and adapter reuse boundaries",
      "description": "As a maintainer implementing @you/goal, I want the audit to identify the canonical invocation/result and adapter reuse surfaces so that follow-on API and CLI work stays aligned with the existing session invocation contract.",
      "acceptanceCriteria": [
        "The audit identifies POST /factory-sessions/{session_id}/invocations as the canonical public API entrypoint for @you/goal.",
        "The audit states that Factory.invocationReturn remains the public selector for the final primary result and that this slice does not add a goal-only result endpoint.",
        "The audit explains that CLI adapters must keep using the shared invocation resolver and response selection behavior rather than inventing a goal-specific transport contract.",
        "The audit names the reviewer evidence for this boundary, including invocation-contract alignment and any required API or CLI regression coverage in follow-on implementation PRs.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "you-goal-p11-api-contract-audit-002",
      "title": "Mark response streams as internal while reusing lifecycle contracts",
      "description": "As a maintainer designing streaming and control behavior, I want the audit to separate internal response-stream plumbing from public session and dispatch contracts so that goal-mode progress does not widen the OpenAPI surface accidentally.",
      "acceptanceCriteria": [
        "The audit covers the public factory event stream, existing Factory Session pause/resume behavior, and dispatch lifecycle vocabulary in one section that distinguishes durable public history from ephemeral internal progress.",
        "The audit explicitly states that response streams are internal-only for this slice and must not add FactoryEventType values, event payload variants, event endpoint filters, or public response-stream endpoints.",
        "The audit states that existing session pause/resume routes may be fixed or extended behaviorally for live sessions without introducing goal-specific pause/resume routes.",
        "The audit states that interrupt behavior must reuse existing dispatch lifecycle vocabulary, especially DISPATCH_INTERRUPTED, instead of creating a parallel run API.",
        "The audit names SessionResponseStream and SessionResponseStreamEvent as the internal runtime/session model names for follow-on work.",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "you-goal-p11-api-contract-audit-003",
      "title": "Lock the public OpenAPI delta and generated-client expectations",
      "description": "As a maintainer preparing follow-on API PRs, I want the audit to define the only expected public contract change and its generation rules so that later work updates OpenAPI and clients only when the public boundary actually changes.",
      "acceptanceCriteria": [
        "The audit identifies Workstation.workPropagation as the only expected public OpenAPI change in this slice.",
        "The audit states that follow-on public contract work must use the exact terminology Workstation.workPropagation and related WorkPropagationMode naming consistently across docs, OpenAPI fragments, CLI/API adapters, and generated clients.",
        "The audit explains that generated Go and TypeScript clients are regenerated only when the public OpenAPI contract changes, not when internal response-stream models change.",
        "The audit identifies the required follow-on verification for public contract changes, including generated artifact sync and API contract smoke coverage, without requiring inventory-style tests for internal-only response streams.",
        "Typecheck passes"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)