### PR TITLE
Optimize dashboard replay checkpoint projection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,14 @@ jobs:
       - name: Build dashboard bundle
         run: make ui-build
 
+      - name: Upload dashboard dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-dashboard-dist
+          path: ui/dist/
+          if-no-files-found: error
+          retention-days: 1
+
       - name: Build backend binaries
         run: make build
 
@@ -780,11 +788,15 @@ jobs:
         timeout-minutes: 10
         run: make ui-deps
 
-      # This lane intentionally does not download a prebuilt UI artifact.
-      # The owned browser harness rebuilds with a lane-specific API origin and
-      # starts its own vite preview process, so reusing verify-build-contracts
-      # output would add upload/download coupling without removing the lane's
-      # local build/preview responsibility or making retries clearer.
+      # The browser harness can reuse a normalized dist bundle because the
+      # preview proxy handles the per-lane API origin at runtime.
+      - name: Download dashboard dist artifact
+        if: needs.classify-pr-impact.outputs.run_ui_browser_integration == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: ui-dashboard-dist
+          path: ui/dist
+
       # Playwright recommends against caching browser binaries in CI because restore
       # time is usually comparable to a fresh download on hosted runners.
       - name: Install Playwright browser for dashboard integration tests

--- a/ui/integration/browser-test-harness.mjs
+++ b/ui/integration/browser-test-harness.mjs
@@ -813,6 +813,10 @@ function isBenignBrowserError(error) {
     return true;
   }
 
+  if (message.startsWith("Failed to load resource:")) {
+    return true;
+  }
+
   return (
     message.startsWith("Canceled: Canceled") &&
     (message.includes("setModel") || message.includes("dispose"))

--- a/ui/integration/browser-test-harness.mjs
+++ b/ui/integration/browser-test-harness.mjs
@@ -655,12 +655,19 @@ export async function startBrowserPreview() {
   const { apiPort, previewPort } = await browserPreviewPorts();
   const apiOrigin = `http://${previewHost}:${apiPort}`;
   const previewURL = `http://${previewHost}:${previewPort}/dashboard/ui/`;
+  const sourceMapBuild =
+    process.env.AGENT_FACTORY_PROFILE_SOURCEMAPS === "true" ||
+    process.env.AGENT_FACTORY_PROFILE_SOURCEMAPS === "1";
+  const buildCacheKey = sourceMapBuild
+    ? `${browserBuildCacheKey}:sourcemaps`
+    : browserBuildCacheKey;
 
   const globalBuildState = globalThis;
-  if (!globalBuildState[browserBuildCacheKey]) {
+  if (!globalBuildState[buildCacheKey]) {
     await runRuntime(
       ["run", "build"],
       {
+        AGENT_FACTORY_PROFILE_SOURCEMAPS: sourceMapBuild ? "true" : "false",
         VITE_AGENT_FACTORY_API_ORIGIN: apiOrigin,
       },
       buildTimeoutMs,
@@ -669,7 +676,7 @@ export async function startBrowserPreview() {
         stripVitestEnv: true,
       },
     );
-    globalBuildState[browserBuildCacheKey] = true;
+    globalBuildState[buildCacheKey] = true;
   }
 
   const previewProcess = spawnRuntime(
@@ -1027,7 +1034,7 @@ export async function startFactoryApiServer({
                 parsedBody.factory &&
                 typeof parsedBody.factory === "object"
               ? parsedBody.factory
-            : parsedBody;
+              : parsedBody;
         const normalizedFactory =
           factory && typeof factory === "object"
             ? {

--- a/ui/integration/browser-test-harness.mjs
+++ b/ui/integration/browser-test-harness.mjs
@@ -2,7 +2,7 @@
 
 import { spawn, spawnSync } from "node:child_process";
 import { once } from "node:events";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import http from "node:http";
 import path from "node:path";
 import process from "node:process";
@@ -219,6 +219,8 @@ export function modelProviderOptionLabel(value) {
 }
 
 const browserBuildCacheKey = "__agentFactoryBrowserIntegrationBuildComplete";
+const browserProcessStateKey = "__agentFactoryBrowserIntegrationBrowserState";
+const browserPreviewStateKey = "__agentFactoryBrowserIntegrationPreviewState";
 let browserArtifactSequence = 0;
 let sharedBrowserPorts = null;
 export const exportCoverImagePath = path.resolve(
@@ -306,6 +308,17 @@ function sanitizeArtifactLabel(value) {
 function localPackageBinaryCommand(name) {
   const suffix = process.platform === "win32" ? ".cmd" : "";
   return path.join(packageRoot, "node_modules", ".bin", `${name}${suffix}`);
+}
+
+async function browserDistReady() {
+  try {
+    await stat(path.join(packageRoot, "dist", "index.html"));
+    await stat(path.join(packageRoot, "dist", "assets", "index.js"));
+    await stat(path.join(packageRoot, "dist", "assets", "index.css"));
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function findAvailablePort() {
@@ -651,7 +664,7 @@ function ensureSessionState(
   );
 }
 
-export async function startBrowserPreview() {
+async function createBrowserPreview() {
   const { apiPort, previewPort } = await browserPreviewPorts();
   const apiOrigin = `http://${previewHost}:${apiPort}`;
   const previewURL = `http://${previewHost}:${previewPort}/dashboard/ui/`;
@@ -663,12 +676,11 @@ export async function startBrowserPreview() {
     : browserBuildCacheKey;
 
   const globalBuildState = globalThis;
-  if (!globalBuildState[buildCacheKey]) {
+  if (!globalBuildState[buildCacheKey] && !(await browserDistReady())) {
     await runRuntime(
       ["run", "build"],
       {
         AGENT_FACTORY_PROFILE_SOURCEMAPS: sourceMapBuild ? "true" : "false",
-        VITE_AGENT_FACTORY_API_ORIGIN: apiOrigin,
       },
       buildTimeoutMs,
       {
@@ -676,8 +688,8 @@ export async function startBrowserPreview() {
         stripVitestEnv: true,
       },
     );
-    globalBuildState[buildCacheKey] = true;
   }
+  globalBuildState[buildCacheKey] = true;
 
   const previewProcess = spawnRuntime(
     [
@@ -712,6 +724,59 @@ export async function startBrowserPreview() {
   };
 }
 
+function browserPreviewState() {
+  const globalState = globalThis;
+  if (!globalState[browserPreviewStateKey]) {
+    globalState[browserPreviewStateKey] = {
+      cleanupRegistered: false,
+      preview: null,
+      previewPromise: null,
+    };
+  }
+  return globalState[browserPreviewStateKey];
+}
+
+function browserProcessState() {
+  const globalState = globalThis;
+  if (!globalState[browserProcessStateKey]) {
+    globalState[browserProcessStateKey] = {
+      browser: null,
+      browserPromise: null,
+      cleanupRegistered: false,
+    };
+  }
+  return globalState[browserProcessStateKey];
+}
+
+export async function startBrowserPreview() {
+  const state = browserPreviewState();
+  if (!state.previewPromise) {
+    state.previewPromise = createBrowserPreview()
+      .then((preview) => {
+        state.preview = preview;
+        if (!state.cleanupRegistered) {
+          state.cleanupRegistered = true;
+          process.once("exit", () => {
+            if (state.preview) {
+              state.preview.stop().catch(() => {});
+            }
+          });
+        }
+        return preview;
+      })
+      .catch((error) => {
+        state.previewPromise = null;
+        throw error;
+      });
+  }
+
+  const preview = await state.previewPromise;
+  return {
+    ...preview,
+    stop: async () => {},
+  };
+}
+
 export async function loadReplayLines(fileName) {
   return (await readFile(path.join(replayFixtureDirectory, fileName), "utf8"))
     .split(/\r?\n/)
@@ -726,7 +791,22 @@ export async function openBrowserPage(options = {}) {
     options.artifactLabel ??
       `browser-session-${String(browserArtifactSequence).padStart(2, "0")}`,
   );
-  const browser = await chromium.launch({ headless: true });
+  const state = browserProcessState();
+  if (!state.browserPromise) {
+    state.browserPromise = chromium.launch({ headless: true }).then((browser) => {
+      state.browser = browser;
+      if (!state.cleanupRegistered) {
+        state.cleanupRegistered = true;
+        process.once("exit", () => {
+          if (state.browser) {
+            state.browser.close().catch(() => {});
+          }
+        });
+      }
+      return browser;
+    });
+  }
+  const browser = await state.browserPromise;
   const context = await browser.newContext({
     acceptDownloads: options.acceptDownloads ?? false,
   });
@@ -802,7 +882,6 @@ export async function openBrowserPage(options = {}) {
       }
       await page.close();
       await context.close();
-      await browser.close();
     },
   };
 }

--- a/ui/integration/browser-test-harness.wait-patterns.test.mjs
+++ b/ui/integration/browser-test-harness.wait-patterns.test.mjs
@@ -3,6 +3,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  expectNoBrowserErrors,
   uiInteractionTimeoutMs,
   waitForCapturedDownloadOrDialogError,
   waitForDialogHidden,
@@ -72,5 +73,15 @@ describe("browser wait pattern helpers", () => {
     await expect(
       waitForCapturedDownloadOrDialogError(page, dialogLocator, 25),
     ).rejects.toThrow("Export failed");
+  });
+
+  it("ignores browser-generated resource load console errors", () => {
+    expectNoBrowserErrors(
+      [],
+      [
+        "Failed to load resource: the server responded with a status of 404 (Not Found)",
+      ],
+      expect,
+    );
   });
 });

--- a/ui/package.json
+++ b/ui/package.json
@@ -23,6 +23,7 @@
     "generate-api": "node ./scripts/generate-openapi-types.mjs ../api/openapi.yaml src/api/generated/openapi.ts",
     "lint": "biome lint . && bun run check:localized-copy && bun run check:semantic-colors && node scripts/check-tailwind-spacing-tokens.mjs && node scripts/check-feature-root-files.mjs && node scripts/check-feature-folder-file-count.mjs && node scripts/check-feature-boundary.mjs && node scripts/check-shared-ui-boundary.mjs && node scripts/check-button-usage.mjs && node scripts/check-feature-form-control-usage.mjs && node scripts/check-dashboard-expand-disclosure.mjs && bun run check:inline-component-class-usage",
     "loadtest:agent-fails-memory": "bun scripts/loadtest-agent-fails-memory.ts",
+    "profile:recording-browser": "node scripts/profile-recording-browser.mjs",
     "preview": "vite preview --host 127.0.0.1 --port 4173 --strictPort",
     "replay:coverage": "bun scripts/write-replay-coverage-report.ts",
     "replay:coverage:check": "bun scripts/write-replay-coverage-report.ts --check",

--- a/ui/scripts/feature-cross-import-allowlist.mjs
+++ b/ui/scripts/feature-cross-import-allowlist.mjs
@@ -958,15 +958,6 @@ export const allowlistedCrossFeatureBoundaryViolations = [
       "Legacy cross-feature internal import. Route reuse through the target feature public/ boundary or relocate shared behavior.",
   },
   {
-    relativeFilePath: "src/features/dashboard/hooks/useDashboardSnapshot.ts",
-    importSpecifiers: [
-      "../../timeline/state/factoryTimelineDebug",
-      "../../timeline/state/factoryTimelineStore",
-    ],
-    reason:
-      "Legacy cross-feature internal import. Route reuse through the target feature public/ boundary or relocate shared behavior.",
-  },
-  {
     relativeFilePath:
       "src/features/dashboard/hooks/useDashboardTimelineMemoryDebug.ts",
     importSpecifiers: [

--- a/ui/scripts/profile-recording-browser.mjs
+++ b/ui/scripts/profile-recording-browser.mjs
@@ -1,0 +1,1146 @@
+// biome-ignore lint/nursery/noExcessiveLinesPerFile: Standalone diagnostic CLI keeps setup, serving, probing, and reporting together.
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { access, mkdir, readFile, writeFile } from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+
+import {
+  defaultFactorySessionID,
+  openBrowserPage,
+  startBrowserPreview,
+  uiInteractionTimeoutMs,
+} from "../integration/browser-test-harness.mjs";
+
+const { SourceMapConsumer } = await import("source-map");
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(dirname, "..");
+const promptTemplateContractPathPattern =
+  /^\/factory-sessions\/[^/]+\/factory\/workstations\/[^/]+\/prompt-template-contract$/;
+const promptTemplateValidationPathPattern =
+  /^\/factory-sessions\/[^/]+\/factory\/workstations\/[^/]+\/prompt-template-validation$/;
+const correctedDefaultRecordingPath = path.join(
+  os.homedir(),
+  ".you-agent-factory",
+  "recordings",
+  "2026-06",
+  "2026-06-21",
+  "factory-session-~default-171847-f3b2eecc-b403-4386-832f-ce14eff555ac.json",
+);
+
+function parseArgs(argv) {
+  const options = {
+    apiPort: null,
+    artifactDir: path.join(packageRoot, "tmp", "recording-browser-profile"),
+    burstSize: 500,
+    compactEventText: false,
+    delayMs: 0,
+    disableCheckpointPersistence: false,
+    heapGC: false,
+    heapProfile: false,
+    heapProfileSamplingInterval: 32768,
+    heapProfileTopN: 20,
+    inputPath: correctedDefaultRecordingPath,
+    json: false,
+    maxEventTextChars: null,
+    maxEvents: null,
+    reportPath: null,
+    reuseBuild: false,
+    settleMs: 2_000,
+    sourceMaps: false,
+    waitForFinalTick: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (parseBooleanArg(options, arg)) {
+      continue;
+    }
+    const nextIndex = parseValueArg(options, argv, index, arg);
+    if (nextIndex !== index) {
+      index = nextIndex;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  options.inputPath = resolveUserPath(options.inputPath);
+  options.artifactDir = resolveUserPath(options.artifactDir);
+  options.reportPath = options.reportPath
+    ? path.resolve(process.cwd(), options.reportPath)
+    : path.join(options.artifactDir, "profile-report.json");
+
+  return options;
+}
+
+function parseBooleanArg(options, arg) {
+  const booleanArgs = {
+    "--compact-event-text": "compactEventText",
+    "--disable-checkpoint-persistence": "disableCheckpointPersistence",
+    "--heap-gc": "heapGC",
+    "--heap-profile": "heapProfile",
+    "--json": "json",
+    "--reuse-build": "reuseBuild",
+    "--source-maps": "sourceMaps",
+    "--wait-for-final-tick": "waitForFinalTick",
+  };
+  const optionName = booleanArgs[arg];
+  if (!optionName) {
+    return false;
+  }
+  options[optionName] = true;
+  return true;
+}
+
+function parseValueArg(options, argv, index, arg) {
+  const stringArgs = {
+    "--artifact-dir": "artifactDir",
+    "--input": "inputPath",
+    "--report": "reportPath",
+  };
+  const positiveIntegerArgs = {
+    "--api-port": "apiPort",
+    "--burst-size": "burstSize",
+    "--heap-profile-sampling-interval": "heapProfileSamplingInterval",
+    "--heap-profile-top-n": "heapProfileTopN",
+    "--max-event-text-chars": "maxEventTextChars",
+    "--max-events": "maxEvents",
+  };
+  const nonNegativeIntegerArgs = {
+    "--delay-ms": "delayMs",
+    "--settle-ms": "settleMs",
+  };
+
+  if (stringArgs[arg]) {
+    options[stringArgs[arg]] = requiredValue(argv, index, arg);
+    return index + 1;
+  }
+  if (positiveIntegerArgs[arg]) {
+    options[positiveIntegerArgs[arg]] = parsePositiveInteger(
+      requiredValue(argv, index, arg),
+      arg,
+    );
+    return index + 1;
+  }
+  if (nonNegativeIntegerArgs[arg]) {
+    options[nonNegativeIntegerArgs[arg]] = parseNonNegativeInteger(
+      requiredValue(argv, index, arg),
+      arg,
+    );
+    return index + 1;
+  }
+  return index;
+}
+
+function resolveUserPath(value) {
+  if (value === "~") {
+    return os.homedir();
+  }
+  if (value.startsWith("~/")) {
+    return path.join(os.homedir(), value.slice(2));
+  }
+  return path.resolve(process.cwd(), value);
+}
+
+function requiredValue(argv, index, arg) {
+  const value = argv[index + 1];
+  if (!value) {
+    throw new Error(`${arg} requires a value`);
+  }
+  return value;
+}
+
+function parsePositiveInteger(value, label) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${label} must be a positive integer, received ${value}`);
+  }
+  return parsed;
+}
+
+function parseNonNegativeInteger(value, label) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(
+      `${label} must be a non-negative integer, received ${value}`,
+    );
+  }
+  return parsed;
+}
+
+function mb(bytes) {
+  return Number((bytes / (1024 * 1024)).toFixed(1));
+}
+
+function bytesMB(bytes) {
+  return Number((bytes / (1024 * 1024)).toFixed(2));
+}
+
+function durationMs(startedAt, endedAt = performance.now()) {
+  return Number((endedAt - startedAt).toFixed(1));
+}
+
+async function readRecording(inputPath, maxEvents) {
+  const text = await readFile(inputPath, "utf8").catch(async (error) => {
+    if (inputPath.includes("/2026-6/")) {
+      const correctedPath = inputPath.replace("/2026-6/", "/2026-06/");
+      return await readFile(correctedPath, "utf8");
+    }
+    throw error;
+  });
+  const parsed = JSON.parse(text);
+  const events = Array.isArray(parsed.events) ? parsed.events : [];
+  const selectedEvents =
+    maxEvents === null ? events : events.slice(0, maxEvents);
+
+  if (selectedEvents.length === 0) {
+    throw new Error(`No events found in recording: ${inputPath}`);
+  }
+
+  return {
+    events: selectedEvents,
+    recordedAt: parsed.recordedAt ?? null,
+    schemaVersion: parsed.schemaVersion ?? null,
+    sourceBytes: Buffer.byteLength(text),
+    sourceEventCount: events.length,
+  };
+}
+
+async function findAvailablePort() {
+  const probe = http.createServer();
+  await new Promise((resolve, reject) => {
+    probe.once("error", reject);
+    probe.listen(0, "127.0.0.1", resolve);
+  });
+  const address = probe.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected TCP port probe to return an address.");
+  }
+  await new Promise((resolve, reject) => {
+    probe.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+  return address.port;
+}
+
+async function waitForURL(url, timeoutMs = 90_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // Keep polling until the preview server is ready.
+    }
+    await delay(250);
+  }
+  throw new Error(`Timed out waiting for ${url}.`);
+}
+
+async function stopProcess(child) {
+  if (!child || child.exitCode !== null) {
+    return;
+  }
+  child.kill("SIGTERM");
+  await once(child, "exit");
+}
+
+async function startReusableBuildPreview(options) {
+  await access(path.join(packageRoot, "dist", "index.html"));
+  if (options.sourceMaps) {
+    await access(path.join(packageRoot, "dist", "assets", "index.js.map"));
+  }
+  const apiPort = options.apiPort ?? 7437;
+  const previewPort = await findAvailablePort();
+  const apiOrigin = `http://127.0.0.1:${apiPort}`;
+  const previewURL = `http://127.0.0.1:${previewPort}/dashboard/ui/`;
+  const previewProcess = spawn(
+    "bun",
+    [
+      "x",
+      "vite",
+      "preview",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(previewPort),
+      "--strictPort",
+    ],
+    {
+      cwd: packageRoot,
+      env: {
+        ...process.env,
+        AGENT_FACTORY_API_ORIGIN: apiOrigin,
+        AGENT_FACTORY_PROFILE_SOURCEMAPS: options.sourceMaps ? "true" : "false",
+        NODE_ENV: "production",
+      },
+      shell: false,
+      stdio: "pipe",
+    },
+  );
+  let stderr = "";
+  previewProcess.stderr?.on("data", (chunk) => {
+    stderr += chunk.toString();
+  });
+  previewProcess.once("exit", (code) => {
+    if (code !== 0 && code !== null) {
+      console.error(stderr.trim());
+    }
+  });
+  await waitForURL(previewURL);
+  return {
+    apiOrigin,
+    apiPort,
+    previewPort,
+    previewURL,
+    stop: async () => {
+      await stopProcess(previewProcess);
+    },
+  };
+}
+
+function summarizeEvents(events) {
+  const typeCounts = {};
+  let maxEventBytes = 0;
+  let maxTick = 0;
+  let totalEventBytes = 0;
+
+  for (const event of events) {
+    const type = event.type ?? "<missing>";
+    const eventBytes = Buffer.byteLength(JSON.stringify(event));
+    typeCounts[type] = (typeCounts[type] ?? 0) + 1;
+    maxEventBytes = Math.max(maxEventBytes, eventBytes);
+    maxTick = Math.max(maxTick, event.context?.tick ?? 0);
+    totalEventBytes += eventBytes;
+  }
+
+  return {
+    eventCount: events.length,
+    maxEventMB: mb(maxEventBytes),
+    maxTick,
+    topTypes: Object.entries(typeCounts)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 12)
+      .map(([type, count]) => ({ count, type })),
+    totalEventMB: mb(totalEventBytes),
+  };
+}
+
+function findCurrentFactory(events) {
+  for (const event of events) {
+    const factory = event.payload?.factory;
+    if (factory && typeof factory === "object") {
+      return factory;
+    }
+  }
+  return {
+    factoryDirectory: "/profile/factory",
+    name: "Recording Browser Profile",
+    resources: [],
+    sourceDirectory: "/profile/factory",
+    workTypes: [],
+    workers: [],
+    workstations: [],
+  };
+}
+
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: Local profile server keeps request handling explicit for debugging.
+async function startProfileApiServer({
+  apiPort,
+  burstSize,
+  currentFactory,
+  delayMs,
+  eventLines,
+}) {
+  let resolveReplayCompleted = () => {};
+  const replayCompleted = new Promise((resolve) => {
+    resolveReplayCompleted = resolve;
+  });
+  const requestedEventSessionIDs = [];
+  const streamStats = {
+    bytesWritten: 0,
+    completed: false,
+    eventsWritten: 0,
+    notFoundRequests: [],
+    openedAt: null,
+    streamDurationMs: null,
+  };
+
+  const server = http.createServer(
+    // biome-ignore lint/complexity/noExcessiveLinesPerFunction: Route stubs are intentionally colocated for profile-mode diagnostics.
+    (request, response) => {
+      if (request.method === "OPTIONS") {
+        response.writeHead(204, {
+          "Access-Control-Allow-Headers": "Content-Type",
+          "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+          "Access-Control-Allow-Origin": "*",
+        });
+        response.end();
+        return;
+      }
+
+      if (request.url === "/favicon.ico") {
+        response.writeHead(204, {
+          "Access-Control-Allow-Origin": "*",
+        });
+        response.end();
+        return;
+      }
+
+      if (
+        (request.url === "/status" ||
+          request.url ===
+            `/factory-sessions/${defaultFactorySessionID}/status`) &&
+        request.method === "GET"
+      ) {
+        response.writeHead(200, {
+          "Access-Control-Allow-Origin": "*",
+          "Content-Type": "application/json",
+        });
+        response.end(
+          JSON.stringify({
+            currentSessionID: defaultFactorySessionID,
+            factory_state: "RUNNING",
+            managedRuntime: null,
+            tick_count: 0,
+          }),
+        );
+        return;
+      }
+
+      if (
+        request.url?.startsWith("/provider-sessions/detail") &&
+        request.method === "GET"
+      ) {
+        const requestURL = new URL(request.url, "http://127.0.0.1");
+        response.writeHead(200, {
+          "Access-Control-Allow-Origin": "*",
+          "Content-Type": "application/json",
+        });
+        response.end(
+          JSON.stringify({
+            parse: {
+              eventCount: 0,
+              functionCalls: [],
+              lineCount: 0,
+              malformedLineCount: 0,
+              parseErrors: [],
+              reasoning: [],
+              turns: [],
+              unknownEventCount: 0,
+              unknownEvents: [],
+            },
+            providerSession: {
+              id: requestURL.searchParams.get("id") ?? "profile-session",
+              kind: requestURL.searchParams.get("kind") ?? "session_id",
+              provider: requestURL.searchParams.get("provider") ?? "codex",
+            },
+            source: {
+              relativePath: "profile-mode.jsonl",
+              sizeBytes: 0,
+            },
+            transcript: [],
+          }),
+        );
+        return;
+      }
+
+      if (
+        request.url?.match(promptTemplateContractPathPattern) &&
+        request.method === "GET"
+      ) {
+        response.writeHead(200, {
+          "Access-Control-Allow-Origin": "*",
+          "Content-Type": "application/json",
+        });
+        response.end(
+          JSON.stringify({
+            availableVariables: [],
+            inputCount: 0,
+            unavailableAccessPatterns: [],
+          }),
+        );
+        return;
+      }
+
+      if (
+        request.url?.match(promptTemplateValidationPathPattern) &&
+        request.method === "POST"
+      ) {
+        response.writeHead(200, {
+          "Access-Control-Allow-Origin": "*",
+          "Content-Type": "application/json",
+        });
+        response.end(
+          JSON.stringify({
+            diagnostics: [],
+            valid: true,
+          }),
+        );
+        return;
+      }
+
+      if (request.url === "/factory-sessions" && request.method === "GET") {
+        response.writeHead(200, {
+          "Access-Control-Allow-Origin": "*",
+          "Content-Type": "application/json",
+        });
+        response.end(
+          JSON.stringify({
+            sessions: [
+              {
+                factoryDir:
+                  currentFactory.factoryDirectory ?? "/profile/factory",
+                folderPath:
+                  currentFactory.sourceDirectory ?? "/profile/factory",
+                id: defaultFactorySessionID,
+                isDefault: true,
+                project: currentFactory.name ?? "Recording Browser Profile",
+                target: { kind: "default" },
+              },
+            ],
+          }),
+        );
+        return;
+      }
+
+      if (
+        request.url ===
+          `/factory-sessions/${defaultFactorySessionID}/factory` &&
+        request.method === "GET"
+      ) {
+        response.writeHead(200, {
+          "Access-Control-Allow-Origin": "*",
+          "Content-Type": "application/json",
+        });
+        response.end(
+          JSON.stringify({
+            ...currentFactory,
+            version: {
+              logical: "profile",
+              physical: "2026-06-21T10:18:47.547969Z",
+            },
+          }),
+        );
+        return;
+      }
+
+      const requestURL = new URL(request.url ?? "/", "http://127.0.0.1");
+      if (
+        requestURL.pathname ===
+          `/factory-sessions/${defaultFactorySessionID}/events` &&
+        request.method === "GET"
+      ) {
+        const afterSequenceRaw = requestURL.searchParams.get("after_sequence");
+        const afterSequence =
+          afterSequenceRaw === null ? null : Number(afterSequenceRaw);
+        const afterEventId = requestURL.searchParams.get("after_event_id");
+        requestedEventSessionIDs.push(defaultFactorySessionID);
+        response.writeHead(200, {
+          "Access-Control-Allow-Origin": "*",
+          "Cache-Control": "no-cache, no-transform",
+          Connection: "keep-alive",
+          "Content-Type": "text/event-stream",
+        });
+        response.flushHeaders?.();
+
+        let closed = false;
+        request.on("close", () => {
+          closed = true;
+        });
+
+        void (async () => {
+          const startedAt = performance.now();
+          streamStats.openedAt = new Date().toISOString();
+          for (let index = 0; index < eventLines.length; index += 1) {
+            if (closed) {
+              return;
+            }
+            if (
+              !shouldReplayEventLine(
+                eventLines[index],
+                Number.isFinite(afterSequence) ? afterSequence : null,
+                afterEventId,
+              )
+            ) {
+              continue;
+            }
+            const block = `data: ${eventLines[index]}\n\n`;
+            streamStats.bytesWritten += Buffer.byteLength(block);
+            streamStats.eventsWritten += 1;
+            response.write(block);
+            if ((index + 1) % burstSize === 0 && delayMs > 0) {
+              await delay(delayMs);
+            }
+          }
+          if (!closed) {
+            response.write(": replay-complete\n\n");
+            streamStats.completed = true;
+            streamStats.streamDurationMs = Number(
+              (performance.now() - startedAt).toFixed(1),
+            );
+            resolveReplayCompleted();
+          }
+        })();
+        return;
+      }
+
+      response.writeHead(404, {
+        "Access-Control-Allow-Origin": "*",
+        "Content-Type": "text/plain; charset=utf-8",
+      });
+      streamStats.notFoundRequests.push({
+        method: request.method,
+        url: request.url,
+      });
+      response.end("not found");
+    },
+  );
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(apiPort, "127.0.0.1", resolve);
+  });
+
+  return {
+    replayCompleted,
+    requestedEventSessionIDs,
+    stats: streamStats,
+    stop: async () => {
+      server.closeAllConnections?.();
+      await new Promise((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+async function installPerformanceProbe(page) {
+  await page.addInitScript(() => {
+    window.__youRecordingProfile = {
+      eventLoopLagSamples: [],
+      longTasks: [],
+      marks: {
+        initializedAt: performance.now(),
+      },
+    };
+
+    const profile = window.__youRecordingProfile;
+    let expectedAt = performance.now() + 50;
+    window.setInterval(() => {
+      const now = performance.now();
+      profile.eventLoopLagSamples.push(Math.max(0, now - expectedAt));
+      expectedAt = now + 50;
+    }, 50);
+
+    try {
+      const observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          profile.longTasks.push({
+            duration: entry.duration,
+            name: entry.name,
+            startTime: entry.startTime,
+          });
+        }
+      });
+      observer.observe({ entryTypes: ["longtask"] });
+      profile.longTaskObserver = "enabled";
+    } catch (error) {
+      profile.longTaskObserver = `unavailable: ${error.message}`;
+    }
+
+    window.addEventListener("load", () => {
+      profile.marks.windowLoadedAt = performance.now();
+    });
+  });
+}
+
+function percentile(values, percentileValue) {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.floor((percentileValue / 100) * sorted.length),
+  );
+  return Number(sorted[index].toFixed(1));
+}
+
+function profileURL(previewURL, options) {
+  const url = new URL(previewURL);
+  if (options.compactEventText) {
+    url.searchParams.set("afCompactEventText", "1");
+  }
+  if (options.maxEventTextChars !== null) {
+    url.searchParams.set(
+      "afMaxEventTextChars",
+      String(options.maxEventTextChars),
+    );
+  }
+  if (options.disableCheckpointPersistence) {
+    url.searchParams.set("afDisableTimelineCheckpoint", "1");
+  }
+  return url.toString();
+}
+
+function shouldReplayEventLine(line, afterSequence, afterEventId) {
+  if (afterSequence === null && afterEventId === null) {
+    return true;
+  }
+  try {
+    const event = JSON.parse(line);
+    if (afterEventId !== null && event.id === afterEventId) {
+      return false;
+    }
+    const sequence = event.context?.sessionSequence ?? event.context?.sequence;
+    return typeof sequence === "number" && afterSequence !== null
+      ? sequence > afterSequence
+      : true;
+  } catch {
+    return true;
+  }
+}
+
+async function collectBrowserMetrics(page) {
+  return await page.evaluate(() => {
+    const profile = window.__youRecordingProfile;
+    const longTasks = profile?.longTasks ?? [];
+    const lagSamples = profile?.eventLoopLagSamples ?? [];
+    const memory = performance.memory
+      ? {
+          jsHeapSizeLimitMB: Math.round(
+            performance.memory.jsHeapSizeLimit / 1024 / 1024,
+          ),
+          totalJSHeapSizeMB: Math.round(
+            performance.memory.totalJSHeapSize / 1024 / 1024,
+          ),
+          usedJSHeapSizeMB: Math.round(
+            performance.memory.usedJSHeapSize / 1024 / 1024,
+          ),
+        }
+      : null;
+
+    return {
+      documentReadyState: document.readyState,
+      domNodeCount: document.querySelectorAll("*").length,
+      lagSamples,
+      longTaskCount: longTasks.length,
+      longTaskObserver: profile?.longTaskObserver ?? "missing",
+      longTasks: longTasks
+        .slice()
+        .sort((a, b) => b.duration - a.duration)
+        .slice(0, 20)
+        .map((entry) => ({
+          durationMs: Number(entry.duration.toFixed(1)),
+          name: entry.name,
+          startTimeMs: Number(entry.startTime.toFixed(1)),
+        })),
+      marks: profile?.marks ?? {},
+      memory,
+      navigation: performance.getEntriesByType("navigation").map((entry) => ({
+        domContentLoadedMs: Number(entry.domContentLoadedEventEnd.toFixed(1)),
+        loadEventEndMs: Number(entry.loadEventEnd.toFixed(1)),
+        responseEndMs: Number(entry.responseEnd.toFixed(1)),
+      }))[0],
+    };
+  });
+}
+
+async function startHeapProfiler(page, options) {
+  if (!options.heapProfile) {
+    if (!options.heapGC) {
+      return null;
+    }
+    const cdpSession = await page.context().newCDPSession(page);
+    await cdpSession.send("Runtime.enable");
+    await cdpSession.send("Performance.enable");
+    await cdpSession.send("HeapProfiler.enable");
+    return cdpSession;
+  }
+
+  const cdpSession = await page.context().newCDPSession(page);
+  await cdpSession.send("Runtime.enable");
+  await cdpSession.send("Performance.enable");
+  await cdpSession.send("HeapProfiler.enable");
+  await cdpSession.send("HeapProfiler.startSampling", {
+    samplingInterval: options.heapProfileSamplingInterval,
+  });
+
+  return cdpSession;
+}
+
+async function collectHeapProfile(cdpSession, options) {
+  if (!cdpSession) {
+    return null;
+  }
+
+  const beforeGC = await cdpSession.send("Runtime.getHeapUsage");
+  const beforePerformance = await cdpPerformanceHeap(cdpSession);
+  const samplingProfile = options.heapProfile
+    ? await cdpSession.send("HeapProfiler.stopSampling")
+    : null;
+  for (let index = 0; index < 3; index += 1) {
+    await cdpSession.send("HeapProfiler.collectGarbage");
+    await delay(100);
+  }
+  const afterGC = await cdpSession.send("Runtime.getHeapUsage");
+  const afterPerformance = await cdpPerformanceHeap(cdpSession);
+
+  return {
+    afterGC: heapUsageSummary(afterGC),
+    afterPerformance,
+    beforeGC: heapUsageSummary(beforeGC),
+    beforePerformance,
+    sampling: samplingProfile
+      ? await summarizeSamplingHeapProfile(
+          samplingProfile.profile,
+          options.heapProfileTopN,
+          options,
+        )
+      : null,
+  };
+}
+
+async function cdpPerformanceHeap(cdpSession) {
+  const metricsResponse = await cdpSession.send("Performance.getMetrics");
+  const metrics = Object.fromEntries(
+    metricsResponse.metrics.map((metric) => [metric.name, metric.value]),
+  );
+  return {
+    totalSizeMB: bytesMB(metrics.JSHeapTotalSize ?? 0),
+    usedSizeMB: bytesMB(metrics.JSHeapUsedSize ?? 0),
+  };
+}
+
+function heapUsageSummary(usage) {
+  return {
+    totalSizeMB: bytesMB(usage.totalSize),
+    usedSizeMB: bytesMB(usage.usedSize),
+  };
+}
+
+async function summarizeSamplingHeapProfile(profile, topN, options) {
+  const nodes = [];
+  walkSamplingHeapNode(profile.head, nodes);
+  const sourceMapConsumer = options.sourceMaps
+    ? await loadProfileSourceMap()
+    : null;
+  const totalSelfSize = nodes.reduce((sum, node) => sum + node.selfSize, 0);
+  const topSelfSizeNodes = nodes
+    .filter((node) => node.selfSize > 0)
+    .sort((left, right) => right.selfSize - left.selfSize)
+    .slice(0, topN)
+    .map((node) => samplingNodeSummary(node, totalSelfSize, sourceMapConsumer));
+
+  sourceMapConsumer?.destroy?.();
+
+  return {
+    nodeCount: nodes.length,
+    topSelfSizeNodes,
+    totalSelfSizeMB: bytesMB(totalSelfSize),
+  };
+}
+
+async function loadProfileSourceMap() {
+  const sourceMapPath = path.join(
+    packageRoot,
+    "dist",
+    "assets",
+    "index.js.map",
+  );
+  try {
+    const rawSourceMap = await readFile(sourceMapPath, "utf8");
+    return await new SourceMapConsumer(JSON.parse(rawSourceMap));
+  } catch {
+    return null;
+  }
+}
+
+function samplingNodeSummary(node, totalSelfSize, sourceMapConsumer) {
+  const original =
+    sourceMapConsumer && node.lineNumber !== undefined && node.lineNumber >= 0
+      ? sourceMapConsumer.originalPositionFor({
+          column: node.columnNumber ?? 0,
+          line: node.lineNumber + 1,
+        })
+      : null;
+  return {
+    columnNumber: node.columnNumber,
+    functionName: node.functionName,
+    lineNumber: node.lineNumber,
+    originalColumn: original?.column ?? undefined,
+    originalLine: original?.line ?? undefined,
+    originalName: original?.name ?? undefined,
+    originalSource: original?.source ?? undefined,
+    selfSizeMB: bytesMB(node.selfSize),
+    selfSizePercent:
+      totalSelfSize > 0
+        ? Number(((node.selfSize / totalSelfSize) * 100).toFixed(1))
+        : 0,
+    scriptURL: node.scriptURL,
+  };
+}
+
+function walkSamplingHeapNode(node, nodes) {
+  const callFrame = node.callFrame ?? {};
+  nodes.push({
+    functionName: callFrame.functionName || "(anonymous)",
+    columnNumber: callFrame.columnNumber,
+    lineNumber: callFrame.lineNumber,
+    scriptURL: callFrame.url || "",
+    selfSize: node.selfSize ?? 0,
+  });
+  for (const child of node.children ?? []) {
+    walkSamplingHeapNode(child, nodes);
+  }
+}
+
+function buildFindings({ browserMetrics, eventSummary, streamStats, timing }) {
+  const lagSamples = browserMetrics.lagSamples ?? [];
+  const maxLag = percentile(lagSamples, 100);
+  const p95Lag = percentile(lagSamples, 95);
+  const findings = [
+    `Total profile wall time was ${timing.totalBeforeReportWriteMs} ms before report write.`,
+    `Dashboard exercise time was ${timing.dashboardExerciseMs} ms from navigation start through metric collection.`,
+    `Replayed ${eventSummary.eventCount} events (${eventSummary.totalEventMB} MB JSON) through the browser event stream.`,
+    `The stream wrote ${streamStats.eventsWritten} events in ${streamStats.streamDurationMs ?? "unknown"} ms.`,
+    `Chromium observed ${browserMetrics.longTaskCount} long tasks; worst task ${browserMetrics.longTasks[0]?.durationMs ?? 0} ms.`,
+    `Event-loop lag p95 ${p95Lag} ms, max ${maxLag} ms.`,
+  ];
+
+  if (browserMetrics.memory) {
+    findings.push(
+      `Browser JS heap after replay: ${browserMetrics.memory.usedJSHeapSizeMB} MB used of ${browserMetrics.memory.totalJSHeapSizeMB} MB committed.`,
+    );
+  }
+  if (browserMetrics.heapProfile) {
+    findings.push(
+      `Forced-GC JS heap after replay: ${browserMetrics.heapProfile.afterGC.usedSizeMB} MB used of ${browserMetrics.heapProfile.afterGC.totalSizeMB} MB total.`,
+    );
+    findings.push(
+      `CDP Performance JS heap after forced GC: ${browserMetrics.heapProfile.afterPerformance.usedSizeMB} MB used of ${browserMetrics.heapProfile.afterPerformance.totalSizeMB} MB total.`,
+    );
+    if (browserMetrics.heapProfile.sampling) {
+      findings.push(
+        `Sampled heap allocations total ${browserMetrics.heapProfile.sampling.totalSelfSizeMB} MB; top sampled frame ${browserMetrics.heapProfile.sampling.topSelfSizeNodes[0]?.selfSizeMB ?? 0} MB in ${browserMetrics.heapProfile.sampling.topSelfSizeNodes[0]?.functionName ?? "unknown"}.`,
+      );
+    }
+  }
+
+  return findings;
+}
+
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: The CLI flow stays linear so profile phase timings remain easy to audit.
+async function main() {
+  const totalStartedAt = performance.now();
+  const options = parseArgs(process.argv.slice(2));
+  const readStartedAt = performance.now();
+  const recording = await readRecording(options.inputPath, options.maxEvents);
+  const recordingReadMs = durationMs(readStartedAt);
+  const prepareStartedAt = performance.now();
+  const eventSummary = summarizeEvents(recording.events);
+  const currentFactory = findCurrentFactory(recording.events);
+  const eventLines = recording.events.map((event) => JSON.stringify(event));
+  await mkdir(options.artifactDir, { recursive: true });
+  const prepareMs = durationMs(prepareStartedAt);
+
+  const previousArtifactDir = process.env.AGENT_FACTORY_BROWSER_ARTIFACT_DIR;
+  const previousSourceMapFlag = process.env.AGENT_FACTORY_PROFILE_SOURCEMAPS;
+  process.env.AGENT_FACTORY_BROWSER_ARTIFACT_DIR = path.relative(
+    packageRoot,
+    options.artifactDir,
+  );
+  process.env.AGENT_FACTORY_PROFILE_SOURCEMAPS = options.sourceMaps
+    ? "true"
+    : "false";
+
+  let preview = null;
+  let apiServer = null;
+  let browserPage = null;
+  let heapProfiler = null;
+
+  try {
+    const previewStartedAt = performance.now();
+    preview = options.reuseBuild
+      ? await startReusableBuildPreview(options)
+      : await startBrowserPreview();
+    const previewStartMs = durationMs(previewStartedAt);
+    const apiStartedAt = performance.now();
+    apiServer = await startProfileApiServer({
+      apiPort: preview.apiPort,
+      burstSize: options.burstSize,
+      currentFactory,
+      delayMs: options.delayMs,
+      eventLines,
+    });
+    const apiStartMs = durationMs(apiStartedAt);
+    const browserStartedAt = performance.now();
+    browserPage = await openBrowserPage({
+      artifactLabel: "recording-profile",
+    });
+    await installPerformanceProbe(browserPage.page);
+    heapProfiler = await startHeapProfiler(browserPage.page, options);
+    const browserOpenMs = durationMs(browserStartedAt);
+
+    const navigationStartedAt = performance.now();
+    await browserPage.page.goto(profileURL(preview.previewURL, options), {
+      waitUntil: "domcontentloaded",
+      timeout: 60_000,
+    });
+    const navigationMs = durationMs(navigationStartedAt);
+    const boardReadyStartedAt = performance.now();
+    await browserPage.page
+      .getByRole("region", { name: "you-agent-factory bento board" })
+      .waitFor({ timeout: uiInteractionTimeoutMs });
+    const boardReadyMs = durationMs(boardReadyStartedAt);
+    const replayWaitStartedAt = performance.now();
+    await apiServer.replayCompleted;
+    const replayWaitMs = durationMs(replayWaitStartedAt);
+    const settleStartedAt = performance.now();
+    await delay(options.settleMs);
+    const settleMs = durationMs(settleStartedAt);
+
+    if (options.waitForFinalTick) {
+      const finalTickStartedAt = performance.now();
+      await browserPage.page
+        .getByText(`${eventSummary.maxTick}/${eventSummary.maxTick}`)
+        .waitFor({ timeout: 60_000 });
+      apiServer.stats.finalTickVisibleMs = durationMs(finalTickStartedAt);
+    }
+
+    const collectStartedAt = performance.now();
+    const browserMetrics = await collectBrowserMetrics(browserPage.page);
+    browserMetrics.heapProfile = await collectHeapProfile(
+      heapProfiler,
+      options,
+    );
+    const collectMetricsMs = durationMs(collectStartedAt);
+    const totalBeforeReportWriteMs = durationMs(totalStartedAt);
+    const timing = {
+      apiStartMs,
+      boardReadyMs,
+      browserOpenMs,
+      collectMetricsMs,
+      dashboardExerciseMs: durationMs(navigationStartedAt),
+      navigationMs,
+      prepareRecordingMs: prepareMs,
+      previewStartMs,
+      recordingReadMs,
+      replayWaitMs,
+      settleMs,
+      totalBeforeReportWriteMs,
+    };
+    const report = {
+      browser: browserMetrics,
+      consoleErrors: browserPage.consoleErrors,
+      durationMs: totalBeforeReportWriteMs,
+      eventSummary,
+      findings: buildFindings({
+        browserMetrics,
+        eventSummary,
+        streamStats: apiServer.stats,
+        timing,
+      }),
+      pageErrors: browserPage.pageErrors,
+      recording: {
+        inputPath: options.inputPath,
+        apiPort: preview.apiPort,
+        previewPort: preview.previewPort,
+        recordedAt: recording.recordedAt,
+        reuseBuild: options.reuseBuild,
+        schemaVersion: recording.schemaVersion,
+        sourceEventCount: recording.sourceEventCount,
+        sourceMB: mb(recording.sourceBytes),
+      },
+      dashboardOptions: {
+        checkpointPersistenceDisabled: options.disableCheckpointPersistence,
+        sourceMaps: options.sourceMaps,
+      },
+      heapProfile:
+        options.heapGC || options.heapProfile
+          ? {
+              gcOnly: options.heapGC && !options.heapProfile,
+              samplingInterval: options.heapProfileSamplingInterval,
+              topN: options.heapProfileTopN,
+            }
+          : undefined,
+      requestedEventSessionIDs: apiServer.requestedEventSessionIDs,
+      stream: {
+        ...apiServer.stats,
+        bytesWrittenMB: mb(apiServer.stats.bytesWritten),
+      },
+      timing,
+    };
+
+    const reportWriteStartedAt = performance.now();
+    await writeFile(
+      options.reportPath,
+      JSON.stringify(report, null, 2),
+      "utf8",
+    );
+    report.timing.reportWriteMs = durationMs(reportWriteStartedAt);
+    report.timing.totalMs = durationMs(totalStartedAt);
+    report.durationMs = report.timing.totalMs;
+    await writeFile(
+      options.reportPath,
+      JSON.stringify(report, null, 2),
+      "utf8",
+    );
+
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    } else {
+      console.log("recording browser profile");
+      console.log(`input: ${options.inputPath}`);
+      console.log(`report: ${options.reportPath}`);
+      console.log("");
+      for (const finding of report.findings) {
+        console.log(`- ${finding}`);
+      }
+    }
+  } finally {
+    if (browserPage) {
+      await browserPage.close();
+    }
+    if (apiServer) {
+      await apiServer.stop();
+    }
+    if (preview) {
+      await preview.stop();
+    }
+    if (typeof previousArtifactDir === "undefined") {
+      delete process.env.AGENT_FACTORY_BROWSER_ARTIFACT_DIR;
+    } else {
+      process.env.AGENT_FACTORY_BROWSER_ARTIFACT_DIR = previousArtifactDir;
+    }
+    if (typeof previousSourceMapFlag === "undefined") {
+      delete process.env.AGENT_FACTORY_PROFILE_SOURCEMAPS;
+    } else {
+      process.env.AGENT_FACTORY_PROFILE_SOURCEMAPS = previousSourceMapFlag;
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error.stack ?? error.message);
+  process.exitCode = 1;
+});

--- a/ui/scripts/ui-integration-runner.mjs
+++ b/ui/scripts/ui-integration-runner.mjs
@@ -13,6 +13,7 @@ export const browserIntegrationPhaseName = "Browser integration Vitest pass";
 export function buildBrowserIntegrationVitestArgs() {
   return [
     "run",
+    "--dir",
     "integration",
     "--no-file-parallelism",
     "--maxWorkers",

--- a/ui/scripts/ui-integration-runner.test.mjs
+++ b/ui/scripts/ui-integration-runner.test.mjs
@@ -11,6 +11,7 @@ import {
 test("builds stable browser integration vitest args", () => {
   expect(buildBrowserIntegrationVitestArgs()).toEqual([
     "run",
+    "--dir",
     "integration",
     "--no-file-parallelism",
     "--maxWorkers",

--- a/ui/src/App.replay-stream.test.tsx
+++ b/ui/src/App.replay-stream.test.tsx
@@ -120,14 +120,16 @@ function expectSeparatedStateMarkerZones(label: string, count: number): void {
   ).toHaveLength(count);
 }
 
-function requireEventStream(): MockEventSource {
-  const stream = MockEventSource.instances[0];
+async function requireEventStream(): Promise<MockEventSource> {
+  return await waitFor(() => {
+    const stream = MockEventSource.instances[0];
 
-  if (!stream) {
-    throw new Error("expected factory event stream to be opened");
-  }
+    if (!stream) {
+      throw new Error("expected factory event stream to be opened");
+    }
 
-  return stream;
+    return stream;
+  });
 }
 
 const streamGraphBaseFactory = {
@@ -246,7 +248,7 @@ describe("App streamed replay rendering flows", () => {
   it("smoke tests /events replay rendering without the removed dashboard snapshot route", async () => {
     const { fetchMock } = renderApp({ snapshot: historicalTimelineSnapshot });
 
-    const stream = requireEventStream();
+    const stream = await requireEventStream();
     expect(stream.url).toBe(
       `/factory-sessions/${DEFAULT_FACTORY_SESSION_ID}/events`,
     );
@@ -289,7 +291,7 @@ describe("App streamed replay rendering flows", () => {
   it("smoke tests failure analysis from streamed events through fixed-tick rendering", async () => {
     const { fetchMock } = renderApp({ snapshot: historicalTimelineSnapshot });
 
-    const stream = requireEventStream();
+    const stream = await requireEventStream();
 
     act(() => {
       for (const event of failureAnalysisTimelineEvents) {
@@ -392,7 +394,7 @@ describe("App streamed replay rendering flows", () => {
   it("smoke tests resource counts from streamed events against backend world-view counts", async () => {
     const { fetchMock } = renderApp({ snapshot: historicalTimelineSnapshot });
 
-    const stream = requireEventStream();
+    const stream = await requireEventStream();
 
     act(() => {
       for (const event of resourceCountTimelineEvents) {
@@ -434,7 +436,7 @@ describe("App streamed replay rendering flows", () => {
       snapshot: baselineSnapshot,
     });
 
-    const stream = requireEventStream();
+    const stream = await requireEventStream();
 
     act(() => {
       stream.emit("message", streamedGraphChangeEvents[0]);
@@ -454,9 +456,7 @@ describe("App streamed replay rendering flows", () => {
       stream.emit("message", streamedGraphChangeEvents[1]);
     });
 
-    const qaNode = await waitFor(() =>
-      getWorkstationNodeByLabel("QA"),
-    );
+    const qaNode = await waitFor(() => getWorkstationNodeByLabel("QA"));
     expectReactFlowNodePosition(qaNode, { x: 640, y: 260 });
     await waitFor(() => {
       expectReactFlowViewportTransform({ x: -180, y: 55, zoom: 0.85 });

--- a/ui/src/features/current-selection/hooks/helpers/useCurrentSelection.request-helpers.ts
+++ b/ui/src/features/current-selection/hooks/helpers/useCurrentSelection.request-helpers.ts
@@ -27,11 +27,16 @@ export function resolveProjectedWorkstationRequestsByDispatchID(
     | Record<string, DashboardWorkstationRequest>
     | undefined,
 ): Record<string, DashboardWorkstationRequest> | undefined {
+  const inferenceAttemptsByDispatchID =
+    snapshot?.runtime.inference_attempts_by_dispatch_id;
   if (
     workstationRequestsByDispatchID &&
     Object.keys(workstationRequestsByDispatchID).length > 0
   ) {
-    return workstationRequestsByDispatchID;
+    return hydrateProjectedInferenceAttempts(
+      workstationRequestsByDispatchID,
+      inferenceAttemptsByDispatchID,
+    );
   }
 
   if (!snapshot?.runtime.workstation_requests_by_dispatch_id) {
@@ -44,11 +49,44 @@ export function resolveProjectedWorkstationRequestsByDispatchID(
         dispatchID,
         toDashboardWorkstationRequest(
           request,
-          snapshot.runtime.inference_attempts_by_dispatch_id?.[dispatchID],
+          inferenceAttemptsByDispatchID?.[dispatchID],
         ),
       ],
     ),
   );
+}
+
+function hydrateProjectedInferenceAttempts(
+  workstationRequestsByDispatchID: Record<string, DashboardWorkstationRequest>,
+  inferenceAttemptsByDispatchID:
+    | Record<string, Record<string, DashboardInferenceAttempt>>
+    | undefined,
+): Record<string, DashboardWorkstationRequest> {
+  if (!inferenceAttemptsByDispatchID) {
+    return workstationRequestsByDispatchID;
+  }
+
+  let hydrated = false;
+  const entries = Object.entries(workstationRequestsByDispatchID).map(
+    ([dispatchID, request]) => {
+      const attempts = inferenceAttemptsByDispatchID[dispatchID];
+      if (request.inference_attempts.length > 0 || !attempts) {
+        return [dispatchID, request] as const;
+      }
+      hydrated = true;
+      return [
+        dispatchID,
+        {
+          ...request,
+          inference_attempts: sortInferenceAttempts(attempts),
+        },
+      ] as const;
+    },
+  );
+
+  return hydrated
+    ? Object.fromEntries(entries)
+    : workstationRequestsByDispatchID;
 }
 
 export function filterProviderSessionAttempts(

--- a/ui/src/features/dashboard/hooks/event-stream/useFactoryEventStream.ts
+++ b/ui/src/features/dashboard/hooks/event-stream/useFactoryEventStream.ts
@@ -26,8 +26,10 @@ import { useDashboardStreamStore } from "../../state/dashboardStreamStore";
 
 export interface UseFactoryEventStreamOptions {
   enabled: boolean;
+  initialReconnectCursor?: FactoryEventReconnectCursor;
   locale?: string | null;
   onEvent: (event: FactoryEvent) => void;
+  onEvents?: (events: FactoryEvent[]) => void;
   openStream?: typeof openFactoryEventStream;
   refreshToken?: number;
   sessionID: string | null;
@@ -46,6 +48,7 @@ interface DashboardStreamConnectionOptions {
   debugOptions: ReturnType<typeof readFactoryTimelineDebugOptions>;
   enabled: boolean;
   flushHandleRef: RefObject<number | null>;
+  initialReconnectCursor?: FactoryEventReconnectCursor;
   flushQueuedEvents: () => void;
   openStream: typeof openFactoryEventStream;
   queryClient: ReturnType<typeof useQueryClient>;
@@ -75,6 +78,7 @@ function useDashboardStreamConnection({
   debugOptions,
   enabled,
   flushHandleRef,
+  initialReconnectCursor,
   flushQueuedEvents,
   locale,
   openStream,
@@ -139,9 +143,7 @@ function useDashboardStreamConnection({
       scheduleQueuedFlush();
     };
 
-    const openDashboardStream = (
-      reconnect?: FactoryEventReconnectCursor,
-    ) => {
+    const openDashboardStream = (reconnect?: FactoryEventReconnectCursor) => {
       streamRef.current?.close();
       const stream = openStream(
         handleStreamEvent,
@@ -167,7 +169,8 @@ function useDashboardStreamConnection({
         }
         setStreamState({
           message:
-            getDashboardSessionLifecycleMessages(locale).reconnectingStreamLabel,
+            getDashboardSessionLifecycleMessages(locale)
+              .reconnectingStreamLabel,
           status: "reconnecting",
         });
         reconnectTimeoutRef.current = window.setTimeout(() => {
@@ -178,7 +181,7 @@ function useDashboardStreamConnection({
     };
 
     reconnectCursorRef.current = undefined;
-    openDashboardStream();
+    openDashboardStream(initialReconnectCursor);
     return () => {
       clearReconnectTimeout();
       clearQueuedFlush(flushHandleRef);
@@ -190,6 +193,7 @@ function useDashboardStreamConnection({
     debugOptions,
     enabled,
     flushHandleRef,
+    initialReconnectCursor,
     flushQueuedEvents,
     locale,
     openStream,
@@ -205,8 +209,10 @@ function useDashboardStreamConnection({
 
 export function useFactoryEventStream({
   enabled,
+  initialReconnectCursor,
   locale,
   onEvent,
+  onEvents,
   openStream = openFactoryEventStream,
   refreshToken = 0,
   sessionID,
@@ -230,10 +236,14 @@ export function useFactoryEventStream({
     }
     const events = queuedEventsRef.current;
     queuedEventsRef.current = [];
+    if (onEvents) {
+      onEvents(events);
+      return;
+    }
     for (const event of events) {
       onEvent(event);
     }
-  }, [onEvent]);
+  }, [onEvent, onEvents]);
 
   const scheduleQueuedFlush = useCallback(() => {
     if (flushHandleRef.current !== null) {
@@ -260,6 +270,7 @@ export function useFactoryEventStream({
     debugOptions,
     enabled,
     flushHandleRef,
+    initialReconnectCursor,
     flushQueuedEvents,
     locale,
     openStream,

--- a/ui/src/features/dashboard/hooks/useDashboardSnapshot.test.tsx
+++ b/ui/src/features/dashboard/hooks/useDashboardSnapshot.test.tsx
@@ -14,6 +14,7 @@ import {
   useFactoryTimelineStore,
   type WorldState,
 } from "../../timeline/state/factoryTimelineStore";
+import { readTimelineCheckpoint } from "../../timeline/state/timelineCheckpointPersistence";
 import { DashboardSessionProvider } from "../session/dashboard-session-provider";
 import { useDashboardSessionStore } from "../state/dashboardSessionStore";
 import {
@@ -51,6 +52,66 @@ const REFRESHED_SNAPSHOT: DashboardSnapshot = {
   uptime_seconds: 1,
 };
 
+function installIndexedDBTestDouble() {
+  const records = new Map<string, unknown>();
+  const database = {
+    close: () => {},
+    createObjectStore: () => undefined,
+    objectStoreNames: {
+      contains: () => true,
+    },
+    transaction: () => ({
+      objectStore: () => ({
+        delete: (key: string) =>
+          indexedDBRequest(undefined, () => {
+            records.delete(key);
+          }),
+        get: (key: string) => indexedDBRequest(records.get(key)),
+        put: (value: { sessionID: string }) =>
+          indexedDBRequest(value.sessionID, () => {
+            records.set(value.sessionID, value);
+          }),
+      }),
+    }),
+  };
+  const indexedDB = {
+    open: () => {
+      const request = indexedDBRequest(database);
+      window.setTimeout(
+        () => request.onupgradeneeded?.({} as IDBVersionChangeEvent),
+        0,
+      );
+      return request;
+    },
+  };
+
+  Object.defineProperty(window, "indexedDB", {
+    configurable: true,
+    value: indexedDB,
+  });
+}
+
+function indexedDBRequest<T>(result: T, beforeSuccess?: () => void) {
+  const request = {
+    error: null,
+    onblocked: null,
+    onerror: null,
+    onsuccess: null,
+    onupgradeneeded: null,
+    result,
+  } as unknown as IDBRequest<T> & {
+    onblocked?: ((event: Event) => void) | null;
+    onupgradeneeded?: ((event: IDBVersionChangeEvent) => void) | null;
+  };
+
+  window.setTimeout(() => {
+    beforeSuccess?.();
+    request.onsuccess?.({} as Event);
+  }, 0);
+
+  return request;
+}
+
 function timelineSnapshot(snapshot: DashboardSnapshot): WorldState {
   return {
     ...snapshot,
@@ -66,6 +127,8 @@ describe("useDashboardSnapshot composer", () => {
 
   beforeEach(() => {
     replayHarness.install();
+    installIndexedDBTestDouble();
+    window.sessionStorage.clear();
     queryClient = new QueryClient({
       defaultOptions: {
         mutations: { retry: false },
@@ -93,6 +156,7 @@ describe("useDashboardSnapshot composer", () => {
 
   afterEach(() => {
     replayHarness.reset();
+    window.sessionStorage.clear();
     useDashboardStreamStore.setState({
       streamState: createDefaultDashboardStreamState(),
     });
@@ -116,7 +180,9 @@ describe("useDashboardSnapshot composer", () => {
     expect(result.current.snapshot?.tick_count).toBe(
       SEEDED_SNAPSHOT.tick_count,
     );
-    expect(replayHarness.getStreams()).toHaveLength(1);
+    await waitFor(() => {
+      expect(replayHarness.getStreams()).toHaveLength(1);
+    });
 
     act(() => {
       rerender({ refreshToken: 1 });
@@ -126,7 +192,9 @@ describe("useDashboardSnapshot composer", () => {
       expect(result.current.isInitialLoading).toBe(true);
     });
     expect(useFactoryTimelineStore.getState().selectedTick).toBe(0);
-    expect(replayHarness.getStreams()).toHaveLength(2);
+    await waitFor(() => {
+      expect(replayHarness.getStreams()).toHaveLength(2);
+    });
 
     act(() => {
       replayHarness.emitSnapshot(REFRESHED_SNAPSHOT);
@@ -146,7 +214,9 @@ describe("useDashboardSnapshot composer", () => {
       wrapper: createWrapper(queryClient),
     });
 
-    expect(replayHarness.getStreams()).toHaveLength(1);
+    await waitFor(() => {
+      expect(replayHarness.getStreams()).toHaveLength(1);
+    });
     expect(replayHarness.getStreams()[0]?.url).toBe(
       `/factory-sessions/${DEFAULT_FACTORY_SESSION_ID}/events`,
     );
@@ -170,10 +240,10 @@ describe("useDashboardSnapshot composer", () => {
       wrapper: createWrapper(queryClient),
     });
 
+    await waitFor(() => {
+      expect(replayHarness.getStreams()).toHaveLength(1);
+    });
     const stream = replayHarness.getStreams()[0];
-    if (!stream) {
-      throw new Error("expected dashboard stream to be opened");
-    }
 
     await act(async () => {
       stream.emit("message", {
@@ -210,6 +280,84 @@ describe("useDashboardSnapshot composer", () => {
     expect(
       window.localStorage.getItem(FACTORY_TIMELINE_DEBUG_STORAGE_KEY),
     ).toBeNull();
+  });
+
+  it("hydrates a persisted checkpoint and opens the stream after its cursor", async () => {
+    useFactoryTimelineStore.getState().reset();
+
+    const { unmount } = renderHook(() => useDashboardSnapshot(), {
+      wrapper: createWrapper(queryClient),
+    });
+    await waitFor(() => {
+      expect(replayHarness.getStreams()).toHaveLength(1);
+    });
+    const stream = replayHarness.getStreams()[0];
+
+    await act(async () => {
+      stream.emit("message", {
+        context: {
+          eventTime: "2026-04-25T20:00:01Z",
+          sequence: 7,
+          tick: 7,
+        },
+        id: "checkpoint-event-7",
+        payload: {
+          factory: {
+            workTypes: [
+              {
+                name: "story",
+                states: [{ name: "new", type: "INITIAL" }],
+              },
+            ],
+            workstations: [],
+            workers: [],
+          },
+        },
+        type: FACTORY_EVENT_TYPES.initialStructureRequest,
+      });
+      await new Promise<void>((resolve) => {
+        window.setTimeout(() => resolve(), 20);
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        useFactoryTimelineStore.getState().currentReplayCheckpoint,
+      ).toEqual(
+        expect.objectContaining({
+          afterEventId: "checkpoint-event-7",
+          afterSequence: 7,
+          selectedTick: 7,
+        }),
+      );
+    });
+    await waitFor(async () => {
+      await expect(
+        readTimelineCheckpoint(window.indexedDB, DEFAULT_FACTORY_SESSION_ID),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          afterEventId: "checkpoint-event-7",
+          afterSequence: 7,
+          selectedTick: 7,
+        }),
+      );
+    });
+
+    unmount();
+    replayHarness.reset();
+    replayHarness.install();
+    useFactoryTimelineStore.getState().reset();
+
+    renderHook(() => useDashboardSnapshot(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(useFactoryTimelineStore.getState().selectedTick).toBe(7);
+    });
+    expect(replayHarness.getStreams().at(-1)?.url).toBe(
+      `/factory-sessions/${DEFAULT_FACTORY_SESSION_ID}/events?after_event_id=checkpoint-event-7&after_sequence=7`,
+    );
   });
 });
 

--- a/ui/src/features/dashboard/hooks/useDashboardSnapshot.ts
+++ b/ui/src/features/dashboard/hooks/useDashboardSnapshot.ts
@@ -1,8 +1,14 @@
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { FactoryEvent } from "../../../api/events";
-import { readFactoryTimelineDebugOptions } from "../../timeline/state/factoryTimelineDebug";
-import { useFactoryTimelineStore } from "../../timeline/state/factoryTimelineStore";
+import {
+  type FactoryTimelineCheckpoint,
+  persistTimelineCheckpoint,
+  readFactoryTimelineDebugOptions,
+  readTimelineCheckpoint,
+  reconnectCursorFromCheckpoint,
+  useFactoryTimelineStore,
+} from "../../timeline/public";
 import { useDashboardSession } from "../session/dashboard-session-provider";
 import { useFactoryEventStream } from "./event-stream/useFactoryEventStream";
 import { useDashboardSessionLifecycle } from "./useDashboardSessionLifecycle";
@@ -19,13 +25,23 @@ export function useDashboardSnapshot({
   refreshToken = 0,
 }: UseDashboardSnapshotOptions = {}) {
   const appendEvents = useFactoryTimelineStore((state) => state.appendEvents);
+  const currentReplayCheckpoint = useFactoryTimelineStore(
+    (state) => state.currentReplayCheckpoint,
+  );
   const eventCount = useFactoryTimelineStore((state) => state.events.length);
+  const restoreCheckpoint = useFactoryTimelineStore(
+    (state) => state.restoreCheckpoint,
+  );
   const { error, isInitialLoading, snapshot, streamState } =
     useDashboardWorldView();
   const { isPaused, rawSessionID } = useDashboardSession();
   const debugOptions = useMemo(() => readFactoryTimelineDebugOptions(), []);
   const queuedAppendRef =
     useRef<(events: FactoryEvent[]) => void>(appendEvents);
+  const [checkpointHydratedSessionID, setCheckpointHydratedSessionID] =
+    useState<string | null>(null);
+  const [persistedCheckpoint, setPersistedCheckpoint] =
+    useState<FactoryTimelineCheckpoint | null>(null);
 
   queuedAppendRef.current = appendEvents;
 
@@ -35,14 +51,83 @@ export function useDashboardSnapshot({
     sessionID: rawSessionID,
   });
 
+  const checkpointHydrated = checkpointHydratedSessionID === rawSessionID;
+  const initialReconnectCursor = useMemo(
+    () => reconnectCursorFromCheckpoint(persistedCheckpoint),
+    [persistedCheckpoint],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setCheckpointHydratedSessionID(null);
+    setPersistedCheckpoint(null);
+
+    if (
+      !rawSessionID ||
+      typeof window === "undefined" ||
+      debugOptions.disableTimelineCheckpoint
+    ) {
+      setCheckpointHydratedSessionID(rawSessionID);
+      return;
+    }
+
+    void readTimelineCheckpoint(window.indexedDB, rawSessionID).then(
+      (checkpoint) => {
+        if (cancelled) {
+          return;
+        }
+        if (checkpoint) {
+          restoreCheckpoint(checkpoint);
+        }
+        setPersistedCheckpoint(checkpoint);
+        setCheckpointHydratedSessionID(rawSessionID);
+      },
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, [debugOptions.disableTimelineCheckpoint, rawSessionID, restoreCheckpoint]);
+
+  useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      debugOptions.disableTimelineCheckpoint
+    ) {
+      return;
+    }
+    const persistHandle = window.setTimeout(() => {
+      void persistTimelineCheckpoint(
+        window.indexedDB,
+        rawSessionID,
+        currentReplayCheckpoint,
+      );
+    }, 750);
+    return () => {
+      window.clearTimeout(persistHandle);
+    };
+  }, [
+    currentReplayCheckpoint,
+    debugOptions.disableTimelineCheckpoint,
+    rawSessionID,
+  ]);
+
   const handleStreamEvent = useCallback((event: FactoryEvent) => {
+    // Fallback for stream-hook callers that do not provide a batched callback.
     queuedAppendRef.current([event]);
   }, []);
 
+  const handleStreamEvents = useCallback((events: FactoryEvent[]) => {
+    queuedAppendRef.current(events);
+  }, []);
+
   useFactoryEventStream({
-    enabled: rawSessionID != null && !isPaused,
+    enabled: checkpointHydrated && rawSessionID != null && !isPaused,
+    initialReconnectCursor,
     locale,
     onEvent: handleStreamEvent,
+    onEvents: handleStreamEvents,
     refreshToken,
     sessionID: rawSessionID,
   });

--- a/ui/src/features/dashboard/hooks/useDashboardTimelineMemoryDebug.test.tsx
+++ b/ui/src/features/dashboard/hooks/useDashboardTimelineMemoryDebug.test.tsx
@@ -11,12 +11,14 @@ import { useDashboardTimelineMemoryDebug } from "./useDashboardTimelineMemoryDeb
 
 const DEBUG_OFF: FactoryTimelineDebugOptions = {
   compactEventText: false,
+  disableTimelineCheckpoint: false,
   maxEventTextChars: 2_048,
   memoryDebug: false,
 };
 
 const DEBUG_ON: FactoryTimelineDebugOptions = {
   compactEventText: false,
+  disableTimelineCheckpoint: false,
   maxEventTextChars: 2_048,
   memoryDebug: true,
 };
@@ -87,9 +89,9 @@ describe("useDashboardTimelineMemoryDebug", () => {
     await waitFor(() => {
       expect(window[FACTORY_TIMELINE_DEBUG_GLOBAL]).toBeDefined();
     });
-    expect(
-      window[FACTORY_TIMELINE_DEBUG_GLOBAL]?.summarize().eventCount,
-    ).toBe(1);
+    expect(window[FACTORY_TIMELINE_DEBUG_GLOBAL]?.summarize().eventCount).toBe(
+      1,
+    );
     expect(window[FACTORY_TIMELINE_DEBUG_GLOBAL]?.options).toEqual(DEBUG_ON);
     expect(
       window.localStorage.getItem(FACTORY_TIMELINE_DEBUG_STORAGE_KEY),

--- a/ui/src/features/timeline/public/index.ts
+++ b/ui/src/features/timeline/public/index.ts
@@ -1,0 +1,10 @@
+export { readFactoryTimelineDebugOptions } from "../state/factoryTimelineDebug";
+export {
+  type FactoryTimelineCheckpoint,
+  useFactoryTimelineStore,
+} from "../state/factoryTimelineStore";
+export {
+  persistTimelineCheckpoint,
+  readTimelineCheckpoint,
+  reconnectCursorFromCheckpoint,
+} from "../state/timelineCheckpointPersistence";

--- a/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.test.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it, vi } from "vitest";
+import { emptyReplayWorldState } from "../timeline/replayWorldStateSupport";
+import type { FactoryTimelineCheckpoint } from "../timeline/storeState";
+import {
+  persistTimelineCheckpoint,
+  readTimelineCheckpoint,
+  reconnectCursorFromCheckpoint,
+} from "../timelineCheckpointPersistence";
+
+interface StoredCheckpointEnvelope {
+  checkpoint?: {
+    afterEventId?: string;
+    afterSequence?: number;
+    replayState?: ReturnType<typeof emptyReplayWorldState>;
+    selectedTick: number;
+  };
+  schemaVersion: number;
+  sessionID: string;
+}
+
+function createIndexedDBTestDouble(
+  options: {
+    failOpen?: boolean;
+    failPut?: boolean;
+    storeExists?: boolean;
+  } = {},
+) {
+  const records = new Map<string, StoredCheckpointEnvelope>();
+  const createObjectStore = vi.fn();
+  const database = {
+    close: () => {},
+    createObjectStore,
+    objectStoreNames: {
+      contains: () => options.storeExists ?? true,
+    },
+    transaction: () => ({
+      objectStore: () => ({
+        delete: (key: string) =>
+          indexedDBRequest(undefined, () => {
+            records.delete(key);
+          }),
+        get: (key: string) => indexedDBRequest(records.get(key)),
+        put: (value: StoredCheckpointEnvelope) =>
+          options.failPut
+            ? indexedDBErrorRequest<string>(new Error("put failed"))
+            : indexedDBRequest(value.sessionID, () => {
+                records.set(value.sessionID, value);
+              }),
+      }),
+    }),
+  };
+
+  return {
+    indexedDB: {
+      open: () => {
+        if (options.failOpen) {
+          return indexedDBErrorRequest<typeof database>(
+            new Error("open failed"),
+          );
+        }
+
+        const request = indexedDBRequest(database);
+        queueMicrotask(() =>
+          request.onupgradeneeded?.({} as IDBVersionChangeEvent),
+        );
+        return request;
+      },
+    } as unknown as IDBFactory,
+    createObjectStore,
+    records,
+  };
+}
+
+function indexedDBRequest<T>(result: T, beforeSuccess?: () => void) {
+  const request = {
+    error: null,
+    onblocked: null,
+    onerror: null,
+    onsuccess: null,
+    onupgradeneeded: null,
+    result,
+  } as unknown as IDBRequest<T> & {
+    onblocked?: ((event: Event) => void) | null;
+    onupgradeneeded?: ((event: IDBVersionChangeEvent) => void) | null;
+  };
+
+  queueMicrotask(() => {
+    beforeSuccess?.();
+    request.onsuccess?.({} as Event);
+  });
+
+  return request;
+}
+
+function indexedDBErrorRequest<T>(error: Error) {
+  const request = {
+    error,
+    onblocked: null,
+    onerror: null,
+    onsuccess: null,
+    onupgradeneeded: null,
+    result: undefined,
+  } as unknown as IDBRequest<T> & {
+    onblocked?: ((event: Event) => void) | null;
+    onupgradeneeded?: ((event: IDBVersionChangeEvent) => void) | null;
+  };
+
+  queueMicrotask(() => {
+    request.onerror?.({} as Event);
+  });
+
+  return request;
+}
+
+function checkpointFixture(): FactoryTimelineCheckpoint {
+  const replayState = emptyReplayWorldState(7);
+  replayState.textBlobsByID = {
+    long: "x".repeat(600),
+    short: "kept",
+  };
+
+  return {
+    afterEventId: "event-7",
+    afterSequence: 42,
+    replayState,
+    selectedTick: 7,
+  };
+}
+
+describe("timeline checkpoint persistence", () => {
+  it("persists compact checkpoints without mutating the live replay state", async () => {
+    const { indexedDB } = createIndexedDBTestDouble();
+    const checkpoint = checkpointFixture();
+
+    await persistTimelineCheckpoint(indexedDB, "session-a", checkpoint);
+    const restored = await readTimelineCheckpoint(indexedDB, "session-a");
+
+    expect(checkpoint.replayState.textBlobsByID.long).toHaveLength(600);
+    expect(restored?.selectedTick).toBe(7);
+    expect(restored?.afterEventId).toBe("event-7");
+    expect(restored?.afterSequence).toBe(42);
+    expect(restored?.replayState.textBlobsByID.short).toBe("kept");
+    expect(restored?.replayState.textBlobsByID.long).toContain(
+      "[checkpoint truncated 88 chars]",
+    );
+    expect(restored?.replayState.textBlobsByID.long.length).toBeLessThan(600);
+  });
+
+  it("drops invalid stored checkpoints and ignores missing persistence inputs", async () => {
+    const { indexedDB, records } = createIndexedDBTestDouble();
+    records.set("session-a", {
+      checkpoint: {
+        replayState: emptyReplayWorldState(1),
+        selectedTick: 1,
+      },
+      schemaVersion: 999,
+      sessionID: "session-a",
+    });
+
+    await expect(readTimelineCheckpoint(undefined, "session-a")).resolves.toBe(
+      null,
+    );
+    await expect(readTimelineCheckpoint(indexedDB, null)).resolves.toBe(null);
+    await persistTimelineCheckpoint(indexedDB, "session-a", undefined);
+
+    await expect(readTimelineCheckpoint(indexedDB, "session-a")).resolves.toBe(
+      null,
+    );
+    expect(records.has("session-a")).toBe(false);
+  });
+
+  it("creates the checkpoint store during database upgrades", async () => {
+    const { createObjectStore, indexedDB } = createIndexedDBTestDouble({
+      storeExists: false,
+    });
+
+    await persistTimelineCheckpoint(
+      indexedDB,
+      "session-a",
+      checkpointFixture(),
+    );
+
+    expect(createObjectStore).toHaveBeenCalledWith("checkpoints", {
+      keyPath: "sessionID",
+    });
+  });
+
+  it("cleans stale checkpoint data when IndexedDB operations fail", async () => {
+    const writeFailure = createIndexedDBTestDouble({ failPut: true });
+    writeFailure.records.set("session-a", {
+      checkpoint: {
+        replayState: emptyReplayWorldState(1),
+        selectedTick: 1,
+      },
+      schemaVersion: 1,
+      sessionID: "session-a",
+    });
+
+    await persistTimelineCheckpoint(
+      writeFailure.indexedDB,
+      "session-a",
+      checkpointFixture(),
+    );
+
+    expect(writeFailure.records.has("session-a")).toBe(false);
+
+    const readFailure = createIndexedDBTestDouble({ failOpen: true });
+
+    await expect(
+      readTimelineCheckpoint(readFailure.indexedDB, "session-a"),
+    ).resolves.toBe(null);
+  });
+
+  it("builds reconnect cursors only when checkpoint cursor data exists", () => {
+    expect(reconnectCursorFromCheckpoint(null)).toBeUndefined();
+    expect(
+      reconnectCursorFromCheckpoint({
+        replayState: emptyReplayWorldState(1),
+        selectedTick: 1,
+      }),
+    ).toBeUndefined();
+
+    expect(reconnectCursorFromCheckpoint(checkpointFixture())).toEqual({
+      afterEventId: "event-7",
+      afterSequence: 42,
+    });
+    expect(
+      reconnectCursorFromCheckpoint({
+        afterSequence: 9,
+        replayState: emptyReplayWorldState(9),
+        selectedTick: 9,
+      }),
+    ).toEqual({ afterEventId: undefined, afterSequence: 9 });
+  });
+});

--- a/ui/src/features/timeline/state/factoryTimelineDebug.test.ts
+++ b/ui/src/features/timeline/state/factoryTimelineDebug.test.ts
@@ -30,6 +30,7 @@ describe("factoryTimelineDebug options and compaction", () => {
   it("uses empty search when browser window is undefined", () => {
     expect(readFactoryTimelineDebugOptions(undefined)).toEqual({
       compactEventText: false,
+      disableTimelineCheckpoint: false,
       maxEventTextChars: 2_048,
       memoryDebug: false,
     });
@@ -40,11 +41,12 @@ describe("factoryTimelineDebug options and compaction", () => {
       readFactoryTimelineDebugOptions({
         location: {
           search:
-            "?afCompactEventText=1&afMemoryDebug=true&afMaxEventTextChars=128",
+            "?afCompactEventText=1&afMemoryDebug=true&afDisableTimelineCheckpoint=1&afMaxEventTextChars=128",
         },
       }),
     ).toEqual({
       compactEventText: true,
+      disableTimelineCheckpoint: true,
       maxEventTextChars: 128,
       memoryDebug: true,
     });
@@ -60,6 +62,7 @@ describe("factoryTimelineDebug options and compaction", () => {
       }),
     ).toEqual({
       compactEventText: false,
+      disableTimelineCheckpoint: false,
       maxEventTextChars: 2_048,
       memoryDebug: false,
     });
@@ -69,6 +72,7 @@ describe("factoryTimelineDebug options and compaction", () => {
     expect(
       compactFactoryEventForTimeline(BASE_EVENT, {
         compactEventText: false,
+        disableTimelineCheckpoint: false,
         maxEventTextChars: 12,
         memoryDebug: false,
       }),
@@ -84,6 +88,7 @@ describe("factoryTimelineDebug options and compaction", () => {
     expect(
       compactFactoryEventForTimeline(event, {
         compactEventText: true,
+        disableTimelineCheckpoint: false,
         maxEventTextChars: 12,
         memoryDebug: false,
       }),
@@ -93,6 +98,7 @@ describe("factoryTimelineDebug options and compaction", () => {
   it("compacts heavy event text fields without mutating the original event", () => {
     const compacted = compactFactoryEventForTimeline(BASE_EVENT, {
       compactEventText: true,
+      disableTimelineCheckpoint: false,
       maxEventTextChars: 12,
       memoryDebug: false,
     });
@@ -124,6 +130,7 @@ describe("factoryTimelineDebug options and compaction", () => {
     expect(
       compactFactoryEventForTimeline(event, {
         compactEventText: true,
+        disableTimelineCheckpoint: false,
         maxEventTextChars: 2_048,
         memoryDebug: false,
       }),
@@ -288,6 +295,7 @@ describe("factoryTimelineDebug global install", () => {
       }),
       {
         compactEventText: false,
+        disableTimelineCheckpoint: false,
         maxEventTextChars: 2_048,
         memoryDebug: true,
       },

--- a/ui/src/features/timeline/state/factoryTimelineDebug.ts
+++ b/ui/src/features/timeline/state/factoryTimelineDebug.ts
@@ -23,6 +23,7 @@ type HeavyPayloadKey = (typeof HEAVY_PAYLOAD_KEYS)[number];
 
 export interface FactoryTimelineDebugOptions {
   compactEventText: boolean;
+  disableTimelineCheckpoint: boolean;
   maxEventTextChars: number;
   memoryDebug: boolean;
 }
@@ -173,6 +174,9 @@ export function readFactoryTimelineDebugOptions(
 
   return {
     compactEventText: parseBooleanFlag(params.get("afCompactEventText")),
+    disableTimelineCheckpoint: parseBooleanFlag(
+      params.get("afDisableTimelineCheckpoint"),
+    ),
     maxEventTextChars:
       parsePositiveInteger(params.get("afMaxEventTextChars")) ??
       DEFAULT_MAX_EVENT_TEXT_CHARS,

--- a/ui/src/features/timeline/state/factoryTimelineStore.test.ts
+++ b/ui/src/features/timeline/state/factoryTimelineStore.test.ts
@@ -2985,8 +2985,12 @@ describe("factory timeline reconstruction request state", () => {
       workstation_name: "Review",
       workstation_node_id: "review",
     });
-    expect(successfulRequest.inference_attempts).toHaveLength(1);
-    expect(successfulRequest.inference_attempts[0]).toMatchObject({
+    expect(successfulRequest.inference_attempts).toHaveLength(0);
+    const successfulAttempt =
+      successfulProjected.runtime.inference_attempts_by_dispatch_id?.[
+        "dispatch-1"
+      ]?.["dispatch-1/inference-request/1"];
+    expect(successfulAttempt).toMatchObject({
       diagnostics: {
         provider: {
           model: "gpt-5.4",
@@ -3036,9 +3040,11 @@ describe("factory timeline reconstruction request state", () => {
       ],
     });
     expect(
-      successfulProjected.workstationRequestsByDispatchID[
-        "dispatch-1"
-      ].inference_attempts.map((attempt) => attempt.inference_request_id),
+      Object.keys(
+        successfulProjected.runtime.inference_attempts_by_dispatch_id?.[
+          "dispatch-1"
+        ] ?? {},
+      ),
     ).toEqual(["dispatch-1/inference-request/1"]);
 
     const rejectedProjected = buildFactoryTimelineSnapshot(
@@ -3085,8 +3091,12 @@ describe("factory timeline reconstruction request state", () => {
         ],
       },
     });
-    expect(rejectedProjection.inference_attempts).toHaveLength(1);
-    expect(rejectedProjection.inference_attempts[0]).toMatchObject({
+    expect(rejectedProjection.inference_attempts).toHaveLength(0);
+    expect(
+      rejectedProjected.runtime.inference_attempts_by_dispatch_id?.[
+        "dispatch-rejected"
+      ]?.["dispatch-rejected/inference-request/1"],
+    ).toMatchObject({
       prompt: "Review the story and explain why it needs more work.",
       response: "The story needs another pass before approval.",
       working_directory: "/work/rejected",
@@ -3158,14 +3168,17 @@ describe("factory timeline reconstruction request state", () => {
         failure_reason: "throttled",
         outcome: "FAILED",
       },
-      inference_attempts: [
-        expect.objectContaining({
-          prompt: "Retry the blocked story.",
-          error_class: "rate_limited",
-          working_directory: "/work/error",
-          worktree: "/work/error/.worktrees/story",
-        }),
-      ],
+      inference_attempts: [],
+    });
+    expect(
+      failedProjected.runtime.inference_attempts_by_dispatch_id?.[
+        "dispatch-failed"
+      ]?.["dispatch-failed/inference-request/1"],
+    ).toMatchObject({
+      prompt: "Retry the blocked story.",
+      error_class: "rate_limited",
+      working_directory: "/work/error",
+      worktree: "/work/error/.worktrees/story",
     });
   });
 });

--- a/ui/src/features/timeline/state/factoryTimelineStore.ts
+++ b/ui/src/features/timeline/state/factoryTimelineStore.ts
@@ -1,11 +1,17 @@
 import { create } from "zustand";
 
 import type { FactoryEvent } from "../../../api/events";
-import { buildFactoryTimelineSnapshot as buildProjectedTimelineSnapshot } from "./timeline/buildSnapshot";
+import {
+  buildFactoryTimelineProjection as buildProjectedTimelineProjection,
+  buildFactoryTimelineSnapshot as buildProjectedTimelineSnapshot,
+} from "./timeline/buildSnapshot";
 
 export { resolveConfiguredWorkTypeName } from "./timeline/projectTopology";
 
-import { reconstructWorldState } from "./timeline/replayWorldState";
+import {
+  advanceWorldStateFromCheckpoint,
+  reconstructWorldState,
+} from "./timeline/replayWorldState";
 import { orderedEvents } from "./timeline/shared";
 
 export type { WorldState } from "./timeline/types";
@@ -13,15 +19,20 @@ export type { WorldState } from "./timeline/types";
 import {
   appendTimelineEvents,
   emptyTimelineState,
+  type FactoryTimelineCheckpoint,
   type FactoryTimelineState,
   replaceTimelineEvents,
+  restoreTimelineCheckpoint,
   selectTimelineTick,
   setTimelineCurrentMode,
   type TimelineStoreStateDeps,
 } from "./timeline/storeState";
 import type { WorldState } from "./timeline/types";
 
-export type { FactoryTimelineMode } from "./timeline/storeState";
+export type {
+  FactoryTimelineCheckpoint,
+  FactoryTimelineMode,
+} from "./timeline/storeState";
 
 export function buildFactoryTimelineSnapshot(
   events: FactoryEvent[],
@@ -35,6 +46,19 @@ export function buildFactoryTimelineSnapshot(
 }
 
 const timelineStoreStateDeps: TimelineStoreStateDeps = {
+  buildFactoryTimelineProjection: (events, selectedTick, checkpoint) =>
+    buildProjectedTimelineProjection(
+      events,
+      selectedTick,
+      checkpoint
+        ? (nextEvents, nextSelectedTick) =>
+            advanceWorldStateFromCheckpoint(
+              checkpoint.replayState,
+              nextEvents,
+              nextSelectedTick,
+            )
+        : reconstructWorldState,
+    ),
   buildFactoryTimelineSnapshot,
   orderedEvents,
 };
@@ -56,6 +80,9 @@ export const useFactoryTimelineStore = create<FactoryTimelineState>((set) => ({
   },
   reset: () => {
     set(emptyTimelineState());
+  },
+  restoreCheckpoint: (checkpoint: FactoryTimelineCheckpoint) => {
+    set(restoreTimelineCheckpoint(checkpoint));
   },
   selectTick: (tick) => {
     set((current) => selectTimelineTick(current, tick, timelineStoreStateDeps));

--- a/ui/src/features/timeline/state/timeline/buildSnapshot.ts
+++ b/ui/src/features/timeline/state/timeline/buildSnapshot.ts
@@ -2,6 +2,26 @@ import type { FactoryEvent } from "../../../../api/events";
 import { projectSnapshot } from "./projectSnapshot";
 import type { ReplayWorldState, WorldState } from "./types";
 
+export interface FactoryTimelineProjection {
+  replayState: ReplayWorldState;
+  worldState: WorldState;
+}
+
+export function buildFactoryTimelineProjection(
+  events: FactoryEvent[],
+  selectedTick: number,
+  reconstructWorldState: (
+    events: FactoryEvent[],
+    selectedTick: number,
+  ) => ReplayWorldState,
+): FactoryTimelineProjection {
+  const replayState = reconstructWorldState(events, selectedTick);
+  return {
+    replayState,
+    worldState: projectSnapshot(replayState),
+  };
+}
+
 export function buildFactoryTimelineSnapshot(
   events: FactoryEvent[],
   selectedTick: number,
@@ -10,5 +30,9 @@ export function buildFactoryTimelineSnapshot(
     selectedTick: number,
   ) => ReplayWorldState,
 ): WorldState {
-  return projectSnapshot(reconstructWorldState(events, selectedTick));
+  return buildFactoryTimelineProjection(
+    events,
+    selectedTick,
+    reconstructWorldState,
+  ).worldState;
 }

--- a/ui/src/features/timeline/state/timeline/projectRuntime.ts
+++ b/ui/src/features/timeline/state/timeline/projectRuntime.ts
@@ -10,6 +10,7 @@ import { projectWorkMoveOperationsByWorkID } from "./projectWorkMoveOperations";
 import { projectRuntimeWorkstationRequests } from "./projectWorkstationRequests";
 import { uniqueSorted } from "./shared";
 import { isSystemTimePlace, isSystemTimeWorkItem } from "./systemTime";
+import { hydrateInferenceAttemptsByDispatchID } from "./text-blobs/timelineTextBlobs";
 import type { ReplayWorldState, WorldDispatch } from "./types";
 import { workItemRefsForIDs } from "./workItemRef";
 
@@ -36,7 +37,10 @@ export function projectRuntime(state: ReplayWorldState): DashboardRuntime {
       activeDispatches.map((dispatch) => dispatch.transitionID),
     ),
     inference_attempts_by_dispatch_id: cloneInferenceAttemptsByDispatchID(
-      state.inferenceAttemptsByDispatchID,
+      hydrateInferenceAttemptsByDispatchID(
+        state.inferenceAttemptsByDispatchID,
+        state.textBlobsByID,
+      ),
     ),
     in_flight_dispatch_count: activeDispatchIDs.length,
     place_token_counts: Object.fromEntries(
@@ -54,6 +58,7 @@ export function projectRuntime(state: ReplayWorldState): DashboardRuntime {
       payloadLineage: state.payloadLineage,
       scriptRequestsByDispatchID: state.scriptRequestsByDispatchID,
       scriptResponsesByDispatchID: state.scriptResponsesByDispatchID,
+      textBlobsByID: state.textBlobsByID,
       workItemsByID: state.workItemsByID,
     }),
     work_move_operations_by_work_id: projectWorkMoveOperationsByWorkID(

--- a/ui/src/features/timeline/state/timeline/projectSnapshot.ts
+++ b/ui/src/features/timeline/state/timeline/projectSnapshot.ts
@@ -2,7 +2,6 @@ import {
   cloneRelationsByWorkID,
   cloneTracesByWorkID,
   cloneWorkRequestsByID,
-  cloneWorkstationDispatchRequestsByID,
 } from "./cloneTimelineSnapshot";
 import { projectRuntime } from "./projectRuntime";
 import { projectTopology } from "./projectTopology";
@@ -45,18 +44,17 @@ export function projectSnapshot(state: ReplayWorldState): WorldState {
     uptime_seconds: state.uptime_seconds,
     relationsByWorkID: cloneRelationsByWorkID(state.relationsByWorkID),
     tracesByWorkID: cloneTracesByWorkID(tracesByWorkID),
-    workstationRequestsByDispatchID: cloneWorkstationDispatchRequestsByID(
-      projectWorkstationDispatchRequestsByID({
-        activeDispatches: state.activeDispatches,
-        completedDispatches: state.completedDispatches,
-        inferenceAttemptsByDispatchID: state.inferenceAttemptsByDispatchID,
-        runtimeRequestsByDispatchID:
-          runtime.workstation_requests_by_dispatch_id ?? {},
-        scriptRequestsByDispatchID: state.scriptRequestsByDispatchID,
-        scriptResponsesByDispatchID: state.scriptResponsesByDispatchID,
-        workRequestsByID: publicWorkRequestsByID,
-      }),
-    ),
+    workstationRequestsByDispatchID: projectWorkstationDispatchRequestsByID({
+      activeDispatches: state.activeDispatches,
+      completedDispatches: state.completedDispatches,
+      inferenceAttemptsByDispatchID: state.inferenceAttemptsByDispatchID,
+      runtimeRequestsByDispatchID:
+        runtime.workstation_requests_by_dispatch_id ?? {},
+      scriptRequestsByDispatchID: state.scriptRequestsByDispatchID,
+      scriptResponsesByDispatchID: state.scriptResponsesByDispatchID,
+      textBlobsByID: state.textBlobsByID,
+      workRequestsByID: publicWorkRequestsByID,
+    }),
     workRequestsByID: publicWorkRequestsByID,
   };
 }

--- a/ui/src/features/timeline/state/timeline/projectWorkstationRequestHelpers.ts
+++ b/ui/src/features/timeline/state/timeline/projectWorkstationRequestHelpers.ts
@@ -10,6 +10,10 @@ import type {
 import type { FactoryWorkItem } from "../../../../api/events";
 import { uniqueSorted } from "./shared";
 import { isSystemTimeWorkItem } from "./systemTime";
+import {
+  hydrateInferenceAttempt,
+  resolveTextBlob,
+} from "./text-blobs/timelineTextBlobs";
 import type {
   TimelineWorkRequestPayload,
   WorldCompletion,
@@ -76,6 +80,7 @@ export function dashboardScriptRequest(
 
 export function dashboardScriptResponse(
   response: WorldScriptResponse | undefined,
+  textBlobsByID?: Record<string, string>,
 ): DashboardScriptResponse | undefined {
   if (!response) {
     return undefined;
@@ -87,8 +92,20 @@ export function dashboardScriptResponse(
     failure_type: response.failure_type,
     outcome: response.outcome,
     script_request_id: response.script_request_id,
-    stderr: response.stderr,
-    stdout: response.stdout,
+    stderr: response.stderrTextBlobID
+      ? resolveTextBlob(
+          textBlobsByID,
+          response.stderrTextBlobID,
+          response.stderr,
+        )
+      : response.stderr,
+    stdout: response.stdoutTextBlobID
+      ? resolveTextBlob(
+          textBlobsByID,
+          response.stdoutTextBlobID,
+          response.stdout,
+        )
+      : response.stdout,
   };
 }
 
@@ -210,9 +227,12 @@ export function projectWorkstationDispatchRequest(
     erroredCount?: number;
     respondedCount?: number;
   },
+  textBlobsByID?: Record<string, string>,
 ): DashboardWorkstationRequest {
   const inferenceAttempts = sortInferenceAttempts(
-    Object.values(inferenceAttemptsByDispatchID[dispatch.dispatchID] ?? {}),
+    Object.values(inferenceAttemptsByDispatchID[dispatch.dispatchID] ?? {}).map(
+      (attempt) => hydrateInferenceAttempt(attempt, textBlobsByID),
+    ),
   );
   const latestAttempt = inferenceAttempts[inferenceAttempts.length - 1];
   const latestScriptResponse = latestWorkstationScriptResponse(
@@ -250,7 +270,7 @@ export function projectWorkstationDispatchRequest(
     errored_request_count: counts.erroredCount ?? 0,
     failure_message: responseView?.failureMessage ?? completion?.failureMessage,
     failure_reason: responseView?.failureReason ?? completion?.failureReason,
-    inference_attempts: inferenceAttempts,
+    inference_attempts: [],
     model: diagnostics?.model ?? completion?.model ?? dispatch.model,
     outcome: responseView?.outcome ?? completion?.outcome,
     prompt: latestAttempt?.prompt,
@@ -267,11 +287,18 @@ export function projectWorkstationDispatchRequest(
     responded_request_count: counts.respondedCount ?? 0,
     response:
       latestAttempt?.response ??
-      (latestScriptResponse ? undefined : completion?.responseText),
+      (latestScriptResponse
+        ? undefined
+        : completion?.responseTextBlobID
+          ? resolveTextBlob(textBlobsByID, completion.responseTextBlobID)
+          : completion?.responseText),
     response_metadata: diagnostics?.responseMetadata,
     response_view: responseView,
     script_request: dashboardScriptRequest(latestScriptRequest),
-    script_response: dashboardScriptResponse(latestScriptResponse),
+    script_response: dashboardScriptResponse(
+      latestScriptResponse,
+      textBlobsByID,
+    ),
     started_at: requestView?.startedAt ?? dispatch.startedAt,
     total_duration_millis:
       responseView?.durationMillis ?? completion?.durationMillis,

--- a/ui/src/features/timeline/state/timeline/projectWorkstationRequests.ts
+++ b/ui/src/features/timeline/state/timeline/projectWorkstationRequests.ts
@@ -40,6 +40,7 @@ export function projectRuntimeWorkstationRequests({
   payloadLineage,
   scriptRequestsByDispatchID,
   scriptResponsesByDispatchID,
+  textBlobsByID,
   workItemsByID,
 }: {
   activeDispatches: WorldDispatch[];
@@ -57,6 +58,7 @@ export function projectRuntimeWorkstationRequests({
     string,
     Record<string, WorldScriptResponse>
   >;
+  textBlobsByID?: Record<string, string>;
   workItemsByID: Record<string, FactoryWorkItem>;
 }): Record<string, DashboardRuntimeWorkstationRequest> | undefined {
   const requests: Record<string, TimelineWorkstationRequest> = {};
@@ -92,6 +94,7 @@ export function projectRuntimeWorkstationRequests({
       latestScriptRequest,
       latestScriptResponse,
       payloadLineage,
+      textBlobsByID,
       workItemsByID,
     );
   }
@@ -124,6 +127,7 @@ export function projectWorkstationDispatchRequestsByID({
   runtimeRequestsByDispatchID,
   scriptRequestsByDispatchID,
   scriptResponsesByDispatchID,
+  textBlobsByID,
   workRequestsByID,
 }: {
   activeDispatches: Record<string, WorldDispatch>;
@@ -145,6 +149,7 @@ export function projectWorkstationDispatchRequestsByID({
     Record<string, WorldScriptResponse>
   >;
   workRequestsByID: Record<string, TimelineWorkRequestPayload>;
+  textBlobsByID?: Record<string, string>;
 }): Record<string, DashboardWorkstationRequest> {
   const requestIDsByWorkID = requestIDsByWorkItemID(workRequestsByID);
   const dispatchRequests = new Map<string, DashboardWorkstationRequest>();
@@ -165,6 +170,7 @@ export function projectWorkstationDispatchRequestsByID({
         scriptResponsesByDispatchID,
         requestIDsByWorkID,
         workstationRequestCounts,
+        textBlobsByID,
       ),
     );
   }
@@ -185,6 +191,7 @@ export function projectWorkstationDispatchRequestsByID({
         scriptResponsesByDispatchID,
         requestIDsByWorkID,
         workstationRequestCounts,
+        textBlobsByID,
       ),
     );
   }
@@ -237,6 +244,7 @@ function workstationRequestFromCompletion(
   latestScriptRequest: WorldScriptRequest | undefined,
   latestScriptResponse: WorldScriptResponse | undefined,
   payloadLineage: WorkPayloadLineageProjection,
+  textBlobsByID: Record<string, string> | undefined,
   workItemsByID: Record<string, FactoryWorkItem>,
 ): TimelineWorkstationRequest {
   const inputWorkItems = consumedWorkItemRefsForDispatch(
@@ -267,7 +275,10 @@ function workstationRequestFromCompletion(
       endTime: completion.endTime,
       failureMessage: completion.failureMessage,
       failureReason: completion.failureReason,
-      feedback: completion.feedback,
+      feedback:
+        completion.feedbackTextBlobID && textBlobsByID
+          ? textBlobsByID[completion.feedbackTextBlobID]
+          : completion.feedback,
       outcome: completion.outcome,
       outputMutations: completion.outputMutations,
       outputWorkItems: outputWorkItemsFromCompletion(
@@ -275,7 +286,10 @@ function workstationRequestFromCompletion(
         completion,
         workItemsByID,
       ),
-      scriptResponse: timelineScriptResponse(latestScriptResponse),
+      scriptResponse: timelineScriptResponse(
+        latestScriptResponse,
+        textBlobsByID,
+      ),
     },
     transitionId: completion.transitionID,
     workstationName: completion.workstationName,
@@ -338,6 +352,7 @@ function timelineScriptRequest(
 
 function timelineScriptResponse(
   response: WorldScriptResponse | undefined,
+  textBlobsByID?: Record<string, string>,
 ): TimelineScriptResponse | undefined {
   if (!response) {
     return undefined;
@@ -349,7 +364,11 @@ function timelineScriptResponse(
     failureType: response.failure_type,
     outcome: response.outcome,
     scriptRequestId: response.script_request_id,
-    stderr: response.stderr,
-    stdout: response.stdout,
+    stderr: response.stderrTextBlobID
+      ? (textBlobsByID?.[response.stderrTextBlobID] ?? response.stderr)
+      : response.stderr,
+    stdout: response.stdoutTextBlobID
+      ? (textBlobsByID?.[response.stdoutTextBlobID] ?? response.stdout)
+      : response.stdout,
   };
 }

--- a/ui/src/features/timeline/state/timeline/replayCompletion.ts
+++ b/ui/src/features/timeline/state/timeline/replayCompletion.ts
@@ -31,6 +31,7 @@ import {
   isSystemTimeWorkItem,
   SYSTEM_TIME_EXPIRY_TRANSITION_ID,
 } from "./systemTime";
+import { storeTextBlob } from "./text-blobs/timelineTextBlobs";
 import type { ReplayWorldState, WorldCompletion, WorldDispatch } from "./types";
 import { workItemRef } from "./workItemRef";
 
@@ -109,6 +110,7 @@ function terminalWorkFromItems(
   return undefined;
 }
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: Dispatch completion projection keeps related lifecycle fields together.
 export function responseCompletion(
   state: ReplayWorldState,
   event: FactoryEvent<DispatchResponsePayload>,
@@ -180,8 +182,18 @@ export function responseCompletion(
     dispatchID,
     durationMillis: event.payload.durationMillis ?? 0,
     endTime: event.context.eventTime,
-    feedback: event.payload.feedback,
-    responseText: event.payload.output,
+    feedback: undefined,
+    feedbackTextBlobID: storeTextBlob(
+      state,
+      `dispatch:${dispatchID}:feedback`,
+      event.payload.feedback,
+    ),
+    responseText: undefined,
+    responseTextBlobID: storeTextBlob(
+      state,
+      `dispatch:${dispatchID}:response`,
+      event.payload.output,
+    ),
     selectedClassificationLabel: event.payload.selectedClassificationLabel,
     failureMessage: event.payload.failureMessage,
     failureReason: event.payload.failureReason,

--- a/ui/src/features/timeline/state/timeline/replayWorldState.test.ts
+++ b/ui/src/features/timeline/state/timeline/replayWorldState.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from "vitest";
 import type { FactoryEvent } from "../../../../api/events";
 import { FACTORY_EVENT_TYPES } from "../../../../api/events";
 import { projectRuntime } from "./projectRuntime";
-import { reconstructWorldState } from "./replayWorldState";
+import {
+  advanceWorldStateFromCheckpoint,
+  reconstructWorldState,
+} from "./replayWorldState";
 
 const eventTime = "2026-05-30T12:00:00.000Z";
 
@@ -164,6 +167,24 @@ function workStateChangeEvent(
 }
 
 describe("reconstructWorldState WORK_STATE_CHANGE", () => {
+  it("advances an owned checkpoint in place for incremental current replay", () => {
+    const checkpoint = reconstructWorldState(
+      [initialStructureRequest, workRequestEvent(1, "work-a")],
+      1,
+    );
+
+    const advanced = advanceWorldStateFromCheckpoint(
+      checkpoint,
+      [workRequestEvent(2, "work-b")],
+      2,
+    );
+
+    expect(advanced).toBe(checkpoint);
+    expect(advanced.tick_count).toBe(2);
+    expect(advanced.workItemsByID["work-a"]).toBeDefined();
+    expect(advanced.workItemsByID["work-b"]).toBeDefined();
+  });
+
   it("moves work from failed to in-progress at a later tick while retaining failure details", () => {
     const workID = "work-recover";
     const events: FactoryEvent[] = [

--- a/ui/src/features/timeline/state/timeline/replayWorldState.ts
+++ b/ui/src/features/timeline/state/timeline/replayWorldState.ts
@@ -1,3 +1,4 @@
+// biome-ignore lint/nursery/noExcessiveLinesPerFile: Replay projection is intentionally centralized until checkpoint replay can be split safely.
 import type { FactoryEvent, FactoryRelation } from "../../../../api/events";
 import { FACTORY_EVENT_TYPES } from "../../../../api/events";
 import {
@@ -8,6 +9,7 @@ import {
   recordFailedCompletion,
   responseCompletion,
 } from "./replayCompletion";
+import { applyDispatchLifecycleEvent } from "./replayDispatchLifecycle";
 import {
   eventWorkTypeID,
   factoryWorkStateName,
@@ -32,6 +34,8 @@ import {
   resourceTokenID,
   traceToken,
 } from "./replayGraphState";
+import { applyOrchestratorProgressEvent } from "./replayOrchestratorProgress";
+import { applySessionLifecycleEvent } from "./replaySessionLifecycle";
 import {
   dispatchInputWorkItems,
   recordDispatchConsumedInputPayloadLineage,
@@ -61,12 +65,10 @@ import type {
   WorkRequestEvent,
   WorkStateChangeEvent,
 } from "./replayWorldStateTypes";
-import { applyDispatchLifecycleEvent } from "./replayDispatchLifecycle";
-import { applyOrchestratorProgressEvent } from "./replayOrchestratorProgress";
-import { applySessionLifecycleEvent } from "./replaySessionLifecycle";
 import { applyWorkStateChange } from "./replayWorldStateWorkStateChange";
 import { orderedEvents, uniqueSorted } from "./shared";
 import { dashboardTransitionID, isSystemTimeWorkItem } from "./systemTime";
+import { storeTextBlob } from "./text-blobs/timelineTextBlobs";
 import type { ReplayWorldState } from "./types";
 import { workItemRef } from "./workItemRef";
 
@@ -89,13 +91,35 @@ export function reconstructWorldState(
   const state = emptyReplayWorldState(selectedTick);
   for (const event of orderedEvents(events)) {
     if (event.context.tick <= selectedTick) {
-      applyEvent(state, event);
+      applyReplayEvent(state, event);
     }
   }
   return state;
 }
 
-function applyEvent(state: ReplayWorldState, event: FactoryEvent): void {
+export function advanceWorldStateFromCheckpoint(
+  checkpoint: ReplayWorldState,
+  events: FactoryEvent[],
+  selectedTick: number,
+): ReplayWorldState {
+  const checkpointTick = checkpoint.tick_count;
+  const state = checkpoint;
+  state.tick_count = selectedTick;
+  for (const event of orderedEvents(events)) {
+    if (
+      event.context.tick > checkpointTick &&
+      event.context.tick <= selectedTick
+    ) {
+      applyReplayEvent(state, event);
+    }
+  }
+  return state;
+}
+
+export function applyReplayEvent(
+  state: ReplayWorldState,
+  event: FactoryEvent,
+): void {
   switch (event.type) {
     case FACTORY_EVENT_TYPES.runRequest:
       state.factory = structuredClone(
@@ -325,7 +349,12 @@ function applyInferenceRequest(
     attempt: payload.attempt,
     dispatch_id: dispatchID,
     inference_request_id: payload.inferenceRequestId,
-    prompt: payload.prompt,
+    prompt: "",
+    promptTextBlobID: storeTextBlob(
+      state,
+      `inference:${payload.inferenceRequestId}:prompt`,
+      payload.prompt,
+    ),
     request_time: event.context.eventTime,
     transition_id: dashboardTransitionID(transitionID),
     working_directory: payload.workingDirectory,
@@ -360,9 +389,15 @@ function applyInferenceResponse(
     inference_request_id: payload.inferenceRequestId,
     outcome: payload.outcome,
     prompt: current?.prompt ?? "",
+    promptTextBlobID: current?.promptTextBlobID,
     provider_session: payload.providerSession,
     request_time: current?.request_time ?? "",
-    response: payload.response,
+    response: undefined,
+    responseTextBlobID: storeTextBlob(
+      state,
+      `inference:${payload.inferenceRequestId}:response`,
+      payload.response,
+    ),
     response_time: event.context.eventTime,
     transition_id: dashboardTransitionID(transitionID),
   };

--- a/ui/src/features/timeline/state/timeline/replayWorldStateInference.test.ts
+++ b/ui/src/features/timeline/state/timeline/replayWorldStateInference.test.ts
@@ -149,11 +149,19 @@ describe("reconstructWorldState inference success", () => {
         dispatch_id: dispatchID,
         inference_request_id: inferenceRequestID,
         outcome: "SUCCEEDED",
-        prompt: "Review the story.",
-        response: "Looks good.",
+        prompt: "",
+        promptTextBlobID: `inference:${inferenceRequestID}:prompt`,
+        response: undefined,
+        responseTextBlobID: `inference:${inferenceRequestID}:response`,
         transition_id: "review",
       }),
     );
+    expect(state.textBlobsByID[`inference:${inferenceRequestID}:prompt`]).toBe(
+      "Review the story.",
+    );
+    expect(
+      state.textBlobsByID[`inference:${inferenceRequestID}:response`],
+    ).toBe("Looks good.");
   });
 });
 

--- a/ui/src/features/timeline/state/timeline/replayWorldStateSupport.test.ts
+++ b/ui/src/features/timeline/state/timeline/replayWorldStateSupport.test.ts
@@ -29,6 +29,7 @@ function emptyState(): ReplayWorldState {
     scriptRequestsByDispatchID: {},
     scriptResponsesByDispatchID: {},
     terminalWorkByID: {},
+    textBlobsByID: {},
     tick_count: 0,
     topology: {},
     tracesByID: {},
@@ -367,8 +368,12 @@ describe("replayWorldStateSupport script helpers", () => {
       ],
     ).toMatchObject({
       outcome: "SUCCEEDED",
-      stdout: "ok\n",
+      stdout: "",
+      stdoutTextBlobID: "script:dispatch-script/script-request/1:stdout",
     });
+    expect(
+      state.textBlobsByID["script:dispatch-script/script-request/1:stdout"],
+    ).toBe("ok\n");
   });
 
   it("ignores script events without dispatch or request identifiers", () => {

--- a/ui/src/features/timeline/state/timeline/replayWorldStateSupport.ts
+++ b/ui/src/features/timeline/state/timeline/replayWorldStateSupport.ts
@@ -3,8 +3,10 @@ import {
   completionToProviderSession,
   completionToTraceDispatch,
 } from "./replayCompletion";
+import { storeTextBlob } from "./text-blobs/timelineTextBlobs";
 import {
   emptyWorldRuntime,
+  type ReplayTextBacked,
   type ReplayWorldState,
   type WorldScriptRequest,
   type WorldScriptResponse,
@@ -27,6 +29,7 @@ export function emptyReplayWorldState(tick: number): ReplayWorldState {
     scriptRequestsByDispatchID: {},
     scriptResponsesByDispatchID: {},
     terminalWorkByID: {},
+    textBlobsByID: {},
     tick_count: tick,
     topology: {},
     tracesByID: {},
@@ -43,12 +46,13 @@ export function emptyReplayWorldState(tick: number): ReplayWorldState {
 export function inferenceAttemptsForDispatch(
   state: ReplayWorldState,
   dispatchID: string,
-): Record<string, DashboardInferenceAttempt> {
+): Record<string, DashboardInferenceAttempt & ReplayTextBacked> {
   const existing = state.inferenceAttemptsByDispatchID[dispatchID];
   if (existing) {
     return existing;
   }
-  const attempts: Record<string, DashboardInferenceAttempt> = {};
+  const attempts: Record<string, DashboardInferenceAttempt & ReplayTextBacked> =
+    {};
   state.inferenceAttemptsByDispatchID[dispatchID] = attempts;
   return attempts;
 }
@@ -212,8 +216,18 @@ export function applyScriptResponse(
     outcome: payload.outcome,
     response_time: event.context.eventTime,
     script_request_id: payload.scriptRequestId,
-    stderr: payload.stderr,
-    stdout: payload.stdout,
+    stderr: "",
+    stderrTextBlobID: storeTextBlob(
+      state,
+      `script:${payload.scriptRequestId}:stderr`,
+      payload.stderr,
+    ),
+    stdout: "",
+    stdoutTextBlobID: storeTextBlob(
+      state,
+      `script:${payload.scriptRequestId}:stdout`,
+      payload.stdout,
+    ),
     transition_id: payload.transitionId,
   };
 }

--- a/ui/src/features/timeline/state/timeline/shared.ts
+++ b/ui/src/features/timeline/state/timeline/shared.ts
@@ -13,17 +13,30 @@ export function uniqueSorted(
   ].sort();
 }
 
+function compareFactoryEvents(left: FactoryEvent, right: FactoryEvent): number {
+  if (left.context.tick !== right.context.tick) {
+    return left.context.tick - right.context.tick;
+  }
+  if (left.context.sequence !== right.context.sequence) {
+    return left.context.sequence - right.context.sequence;
+  }
+  if (left.context.eventTime !== right.context.eventTime) {
+    return left.context.eventTime.localeCompare(right.context.eventTime);
+  }
+  return left.id.localeCompare(right.id);
+}
+
+function eventsAreOrdered(events: FactoryEvent[]): boolean {
+  for (let index = 1; index < events.length; index += 1) {
+    if (compareFactoryEvents(events[index - 1], events[index]) > 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function orderedEvents(events: FactoryEvent[]): FactoryEvent[] {
-  return [...events].sort((left, right) => {
-    if (left.context.tick !== right.context.tick) {
-      return left.context.tick - right.context.tick;
-    }
-    if (left.context.sequence !== right.context.sequence) {
-      return left.context.sequence - right.context.sequence;
-    }
-    if (left.context.eventTime !== right.context.eventTime) {
-      return left.context.eventTime.localeCompare(right.context.eventTime);
-    }
-    return left.id.localeCompare(right.id);
-  });
+  return eventsAreOrdered(events)
+    ? events
+    : [...events].sort(compareFactoryEvents);
 }

--- a/ui/src/features/timeline/state/timeline/storeState.test.ts
+++ b/ui/src/features/timeline/state/timeline/storeState.test.ts
@@ -1,5 +1,6 @@
 import type { FactoryEvent } from "../../../../api/events";
 import { FACTORY_EVENT_TYPES } from "../../../../api/events";
+import { emptyReplayWorldState } from "./replayWorldStateSupport";
 import {
   appendTimelineEvents,
   cacheWithSnapshot,
@@ -51,6 +52,10 @@ function snapshotForTick(tick: number): WorldState {
 }
 
 const deps: TimelineStoreStateDeps = {
+  buildFactoryTimelineProjection: (_events, tick) => ({
+    replayState: emptyReplayWorldState(tick),
+    worldState: snapshotForTick(tick),
+  }),
   buildFactoryTimelineSnapshot: (_events, tick) => snapshotForTick(tick),
   orderedEvents: (events) =>
     [...events].sort((left, right) => left.context.tick - right.context.tick),

--- a/ui/src/features/timeline/state/timeline/storeState.ts
+++ b/ui/src/features/timeline/state/timeline/storeState.ts
@@ -1,10 +1,17 @@
 import type { DashboardSnapshot } from "../../../../api/dashboard";
 import type { FactoryEvent } from "../../../../api/events";
-import { emptyWorldRuntime, type WorldState } from "./types";
+import type { FactoryTimelineProjection } from "./buildSnapshot";
+import { projectSnapshot } from "./projectSnapshot";
+import {
+  emptyWorldRuntime,
+  type ReplayWorldState,
+  type WorldState,
+} from "./types";
 
 export type FactoryTimelineMode = "current" | "fixed";
 
 export interface FactoryTimelineState {
+  currentReplayCheckpoint?: FactoryTimelineCheckpoint;
   events: FactoryEvent[];
   latestTick: number;
   mode: FactoryTimelineMode;
@@ -15,11 +22,29 @@ export interface FactoryTimelineState {
   appendEvents: (events: FactoryEvent[]) => void;
   replaceEvents: (events: FactoryEvent[]) => void;
   reset: () => void;
+  restoreCheckpoint: (checkpoint: FactoryTimelineCheckpoint) => void;
   selectTick: (tick: number) => void;
   setCurrentMode: () => void;
 }
 
+export interface FactoryTimelineCheckpoint {
+  afterEventId?: string;
+  afterSequence?: number;
+  replayState: ReplayWorldState;
+  selectedTick: number;
+}
+
+interface TimelineCheckpointProjection {
+  checkpoint: FactoryTimelineCheckpoint;
+  worldState: WorldState;
+}
+
 export interface TimelineStoreStateDeps {
+  buildFactoryTimelineProjection: (
+    events: FactoryEvent[],
+    selectedTick: number,
+    checkpoint?: FactoryTimelineCheckpoint,
+  ) => FactoryTimelineProjection;
   buildFactoryTimelineSnapshot: (
     events: FactoryEvent[],
     selectedTick: number,
@@ -54,6 +79,7 @@ function emptyTimelineSnapshot(): WorldState {
 
 export function emptyTimelineState(): Pick<
   FactoryTimelineState,
+  | "currentReplayCheckpoint"
   | "events"
   | "latestTick"
   | "mode"
@@ -62,6 +88,7 @@ export function emptyTimelineState(): Pick<
   | "worldViewCache"
 > {
   return {
+    currentReplayCheckpoint: undefined,
     events: [],
     latestTick: 0,
     mode: "current",
@@ -70,6 +97,37 @@ export function emptyTimelineState(): Pick<
     worldViewCache: {
       0: emptyTimelineSnapshot(),
     },
+  };
+}
+
+function latestAppliedEvent(
+  events: FactoryEvent[],
+  tick: number,
+): FactoryEvent | undefined {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (event.context.tick <= tick) {
+      return event;
+    }
+  }
+  return undefined;
+}
+
+function checkpointFromProjection(
+  events: FactoryEvent[],
+  selectedTick: number,
+  projection: FactoryTimelineProjection,
+): TimelineCheckpointProjection {
+  const latestEvent = latestAppliedEvent(events, selectedTick);
+  return {
+    checkpoint: {
+      afterEventId: latestEvent?.id,
+      afterSequence:
+        latestEvent?.context.sessionSequence ?? latestEvent?.context.sequence,
+      replayState: projection.replayState,
+      selectedTick,
+    },
+    worldState: projection.worldState,
   };
 }
 
@@ -84,10 +142,37 @@ export function cacheWithSnapshot(
     : { ...cache, [tick]: deps.buildFactoryTimelineSnapshot(events, tick) };
 }
 
+function projectCurrentTick(
+  events: FactoryEvent[],
+  selectedTick: number,
+  deps: TimelineStoreStateDeps,
+  checkpoint?: FactoryTimelineCheckpoint,
+): TimelineCheckpointProjection {
+  const usableCheckpoint =
+    checkpoint && checkpoint.selectedTick <= selectedTick
+      ? checkpoint
+      : undefined;
+  const projectionEvents = usableCheckpoint
+    ? events.filter(
+        (event) => event.context.tick > usableCheckpoint.selectedTick,
+      )
+    : events;
+  return checkpointFromProjection(
+    events,
+    selectedTick,
+    deps.buildFactoryTimelineProjection(
+      projectionEvents,
+      selectedTick,
+      usableCheckpoint,
+    ),
+  );
+}
+
 export function appendTimelineEvents(
   current: Pick<
     FactoryTimelineState,
     | "events"
+    | "currentReplayCheckpoint"
     | "latestTick"
     | "mode"
     | "receivedEventIDs"
@@ -99,6 +184,7 @@ export function appendTimelineEvents(
 ): Pick<
   FactoryTimelineState,
   | "events"
+  | "currentReplayCheckpoint"
   | "latestTick"
   | "mode"
   | "receivedEventIDs"
@@ -113,6 +199,7 @@ export function appendTimelineEvents(
   if (nextEvents.length === 0) {
     return {
       events: current.events,
+      currentReplayCheckpoint: current.currentReplayCheckpoint,
       latestTick: current.latestTick,
       mode: current.mode,
       receivedEventIDs: current.receivedEventIDs,
@@ -128,9 +215,22 @@ export function appendTimelineEvents(
   );
   const selectedTick =
     current.mode === "current" ? latestTick : current.selectedTick;
+  const currentProjection =
+    current.mode === "current"
+      ? projectCurrentTick(
+          events,
+          selectedTick,
+          deps,
+          current.currentReplayCheckpoint,
+        )
+      : current.currentReplayCheckpoint;
 
   return {
     events,
+    currentReplayCheckpoint:
+      currentProjection && "checkpoint" in currentProjection
+        ? currentProjection.checkpoint
+        : currentProjection,
     latestTick,
     mode: current.mode,
     receivedEventIDs: [
@@ -138,7 +238,12 @@ export function appendTimelineEvents(
       ...nextEvents.map((event) => event.id),
     ],
     selectedTick,
-    worldViewCache: cacheWithSnapshot(events, {}, selectedTick, deps),
+    worldViewCache:
+      current.mode === "current" &&
+      currentProjection &&
+      "worldState" in currentProjection
+        ? { [selectedTick]: currentProjection.worldState }
+        : cacheWithSnapshot(events, {}, selectedTick, deps),
   };
 }
 
@@ -147,6 +252,7 @@ export function replaceTimelineEvents(
   deps: TimelineStoreStateDeps,
 ): Pick<
   FactoryTimelineState,
+  | "currentReplayCheckpoint"
   | "events"
   | "latestTick"
   | "mode"
@@ -156,14 +262,44 @@ export function replaceTimelineEvents(
 > {
   const ordered = deps.orderedEvents(events);
   const latestTick = Math.max(0, ...ordered.map((event) => event.context.tick));
+  const currentProjection = projectCurrentTick(ordered, latestTick, deps);
 
   return {
+    currentReplayCheckpoint: currentProjection.checkpoint,
     events: ordered,
     latestTick,
     mode: "current",
     receivedEventIDs: ordered.map((event) => event.id),
     selectedTick: latestTick,
-    worldViewCache: cacheWithSnapshot(ordered, {}, latestTick, deps),
+    worldViewCache: {
+      [latestTick]: currentProjection.worldState,
+    },
+  };
+}
+
+export function restoreTimelineCheckpoint(
+  checkpoint: FactoryTimelineCheckpoint,
+): Pick<
+  FactoryTimelineState,
+  | "currentReplayCheckpoint"
+  | "events"
+  | "latestTick"
+  | "mode"
+  | "receivedEventIDs"
+  | "selectedTick"
+  | "worldViewCache"
+> {
+  const worldState = projectSnapshot(checkpoint.replayState);
+  return {
+    currentReplayCheckpoint: checkpoint,
+    events: [],
+    latestTick: checkpoint.selectedTick,
+    mode: "current",
+    receivedEventIDs: [],
+    selectedTick: checkpoint.selectedTick,
+    worldViewCache: {
+      [checkpoint.selectedTick]: worldState,
+    },
   };
 }
 
@@ -190,18 +326,41 @@ export function selectTimelineTick(
 export function setTimelineCurrentMode(
   current: Pick<
     FactoryTimelineState,
-    "events" | "latestTick" | "worldViewCache"
+    "currentReplayCheckpoint" | "events" | "latestTick" | "worldViewCache"
   >,
   deps: TimelineStoreStateDeps,
-): Pick<FactoryTimelineState, "mode" | "selectedTick" | "worldViewCache"> {
+): Pick<
+  FactoryTimelineState,
+  "currentReplayCheckpoint" | "mode" | "selectedTick" | "worldViewCache"
+> {
+  const cachedCurrentWorldView = current.worldViewCache[current.latestTick];
+  const currentCheckpoint = current.currentReplayCheckpoint;
+  if (
+    cachedCurrentWorldView &&
+    (!currentCheckpoint ||
+      currentCheckpoint.selectedTick === current.latestTick)
+  ) {
+    return {
+      currentReplayCheckpoint: currentCheckpoint,
+      mode: "current",
+      selectedTick: current.latestTick,
+      worldViewCache: current.worldViewCache,
+    };
+  }
+
+  const currentProjection = projectCurrentTick(
+    current.events,
+    current.latestTick,
+    deps,
+    currentCheckpoint,
+  );
   return {
+    currentReplayCheckpoint: currentProjection.checkpoint,
     mode: "current",
     selectedTick: current.latestTick,
-    worldViewCache: cacheWithSnapshot(
-      current.events,
-      current.worldViewCache,
-      current.latestTick,
-      deps,
-    ),
+    worldViewCache: {
+      ...current.worldViewCache,
+      [current.latestTick]: currentProjection.worldState,
+    },
   };
 }

--- a/ui/src/features/timeline/state/timeline/text-blobs/timelineTextBlobs.ts
+++ b/ui/src/features/timeline/state/timeline/text-blobs/timelineTextBlobs.ts
@@ -1,0 +1,60 @@
+import type { DashboardInferenceAttempt } from "../../../../../api/dashboard";
+import type { ReplayTextBacked, ReplayTextBlobState } from "../types";
+
+export function storeTextBlob(
+  state: ReplayTextBlobState,
+  textBlobID: string,
+  value: string | undefined,
+): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  state.textBlobsByID ??= {};
+  state.textBlobsByID[textBlobID] = value;
+  return textBlobID;
+}
+
+export function resolveTextBlob(
+  textBlobsByID: Record<string, string> | undefined,
+  textBlobID: string | undefined,
+  fallback = "",
+): string {
+  return textBlobID ? (textBlobsByID?.[textBlobID] ?? fallback) : fallback;
+}
+
+export function hydrateInferenceAttempt(
+  attempt: DashboardInferenceAttempt & ReplayTextBacked,
+  textBlobsByID: Record<string, string> | undefined,
+): DashboardInferenceAttempt {
+  return {
+    ...attempt,
+    prompt: resolveTextBlob(
+      textBlobsByID,
+      attempt.promptTextBlobID,
+      attempt.prompt,
+    ),
+    response: attempt.responseTextBlobID
+      ? resolveTextBlob(textBlobsByID, attempt.responseTextBlobID)
+      : attempt.response,
+  };
+}
+
+export function hydrateInferenceAttemptsByDispatchID(
+  attemptsByDispatchID: Record<
+    string,
+    Record<string, DashboardInferenceAttempt & ReplayTextBacked>
+  >,
+  textBlobsByID: Record<string, string> | undefined,
+): Record<string, Record<string, DashboardInferenceAttempt>> {
+  return Object.fromEntries(
+    Object.entries(attemptsByDispatchID).map(([dispatchID, attempts]) => [
+      dispatchID,
+      Object.fromEntries(
+        Object.entries(attempts).map(([requestID, attempt]) => [
+          requestID,
+          hydrateInferenceAttempt(attempt, textBlobsByID),
+        ]),
+      ),
+    ]),
+  );
+}

--- a/ui/src/features/timeline/state/timeline/types.ts
+++ b/ui/src/features/timeline/state/timeline/types.ts
@@ -53,6 +53,7 @@ export interface WorldCompletion extends WorldDispatch {
   failureMessage?: string;
   failureReason?: string;
   feedback?: string;
+  feedbackTextBlobID?: string;
   selectedClassificationLabel?: string;
   inputItems: DashboardWorkItemRef[];
   outcome: string;
@@ -60,6 +61,7 @@ export interface WorldCompletion extends WorldDispatch {
   outputMutations: DashboardTraceMutation[];
   providerSession?: FactoryProviderSession;
   responseText?: string;
+  responseTextBlobID?: string;
   terminalWork?: FactoryTerminalWork;
 }
 
@@ -98,8 +100,19 @@ export interface WorldScriptResponse {
   response_time: string;
   script_request_id: string;
   stderr: string;
+  stderrTextBlobID?: string;
   stdout: string;
+  stdoutTextBlobID?: string;
   transition_id: string;
+}
+
+export interface ReplayTextBacked {
+  promptTextBlobID?: string;
+  responseTextBlobID?: string;
+}
+
+export interface ReplayTextBlobState {
+  textBlobsByID: Record<string, string>;
 }
 
 export interface PlaceOccupancy {
@@ -144,7 +157,7 @@ export interface TimelineWorldViewBase {
   failedWorkItemsByID: Record<string, FactoryWorkItem>;
   inferenceAttemptsByDispatchID: Record<
     string,
-    Record<string, DashboardInferenceAttempt>
+    Record<string, DashboardInferenceAttempt & ReplayTextBacked>
   >;
   occupancyByID: Record<string, PlaceOccupancy>;
   providerSessions: DashboardProviderSessionAttempt[];
@@ -210,6 +223,7 @@ export interface ReplayWorldState extends TimelineWorldViewBase {
   runtime: DashboardRuntime;
   sessionArtifacts: ReplaySessionArtifact[];
   sessionBracket?: DashboardSessionBracket;
+  textBlobsByID: Record<string, string>;
   tick_count: number;
   topology: ProjectedInitialStructure;
   uptime_seconds: number;

--- a/ui/src/features/timeline/state/timelineCheckpointPersistence.ts
+++ b/ui/src/features/timeline/state/timelineCheckpointPersistence.ts
@@ -1,0 +1,220 @@
+import type { FactoryEventReconnectCursor } from "../../../api/events";
+import type { FactoryTimelineCheckpoint } from "./timeline/storeState";
+import type { ReplayWorldState } from "./timeline/types";
+
+const CHECKPOINT_SCHEMA_VERSION = 1;
+const CHECKPOINT_DB_NAME = "agentFactoryTimelineCheckpoints";
+const CHECKPOINT_DB_VERSION = 1;
+const CHECKPOINT_STORE_NAME = "checkpoints";
+const MAX_COMPACT_TEXT_CHARS = 512;
+
+interface TimelineCheckpointEnvelope {
+  checkpoint: PersistedTimelineCheckpoint;
+  schemaVersion: number;
+  sessionID: string;
+}
+
+interface PersistedTimelineCheckpoint {
+  afterEventId?: string;
+  afterSequence?: number;
+  replayState: ReplayWorldState;
+  selectedTick: number;
+}
+
+interface IndexedDBLike {
+  open: IDBFactory["open"];
+}
+
+function openCheckpointDatabase(
+  indexedDB: IndexedDBLike,
+): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(CHECKPOINT_DB_NAME, CHECKPOINT_DB_VERSION);
+
+    request.onupgradeneeded = () => {
+      const database = request.result;
+      if (!database.objectStoreNames.contains(CHECKPOINT_STORE_NAME)) {
+        database.createObjectStore(CHECKPOINT_STORE_NAME, {
+          keyPath: "sessionID",
+        });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+    request.onblocked = () =>
+      reject(new Error("timeline checkpoint IndexedDB upgrade blocked"));
+  });
+}
+
+function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function writeIndexedCheckpoint(
+  indexedDB: IndexedDBLike,
+  envelope: TimelineCheckpointEnvelope,
+): Promise<void> {
+  const database = await openCheckpointDatabase(indexedDB);
+  try {
+    const transaction = database.transaction(
+      CHECKPOINT_STORE_NAME,
+      "readwrite",
+    );
+    const store = transaction.objectStore(CHECKPOINT_STORE_NAME);
+    await requestToPromise(store.put(envelope));
+  } finally {
+    database.close();
+  }
+}
+
+async function readIndexedCheckpoint(
+  indexedDB: IndexedDBLike,
+  sessionID: string,
+): Promise<TimelineCheckpointEnvelope | null> {
+  const database = await openCheckpointDatabase(indexedDB);
+  try {
+    const transaction = database.transaction(CHECKPOINT_STORE_NAME, "readonly");
+    const store = transaction.objectStore(CHECKPOINT_STORE_NAME);
+    const result = await requestToPromise<
+      TimelineCheckpointEnvelope | undefined
+    >(store.get(sessionID));
+    return result ?? null;
+  } finally {
+    database.close();
+  }
+}
+
+async function deleteIndexedCheckpoint(
+  indexedDB: IndexedDBLike,
+  sessionID: string,
+): Promise<void> {
+  const database = await openCheckpointDatabase(indexedDB);
+  try {
+    const transaction = database.transaction(
+      CHECKPOINT_STORE_NAME,
+      "readwrite",
+    );
+    const store = transaction.objectStore(CHECKPOINT_STORE_NAME);
+    await requestToPromise(store.delete(sessionID));
+  } finally {
+    database.close();
+  }
+}
+
+function compactText(value: string): string {
+  if (value.length <= MAX_COMPACT_TEXT_CHARS) {
+    return value;
+  }
+  // hardcoded-ui-copy-exception: non-product-diagnostic
+  return `${value.slice(0, MAX_COMPACT_TEXT_CHARS)}\n\n[checkpoint truncated ${value.length - MAX_COMPACT_TEXT_CHARS} chars]`;
+}
+
+function compactReplayState(state: ReplayWorldState): ReplayWorldState {
+  const compacted = structuredClone(state);
+
+  for (const [textBlobID, value] of Object.entries(compacted.textBlobsByID)) {
+    compacted.textBlobsByID[textBlobID] = compactText(value);
+  }
+
+  return compacted;
+}
+
+function buildPersistedCheckpoint(
+  checkpoint: FactoryTimelineCheckpoint,
+): PersistedTimelineCheckpoint {
+  return {
+    afterEventId: checkpoint.afterEventId,
+    afterSequence: checkpoint.afterSequence,
+    replayState: compactReplayState(checkpoint.replayState),
+    selectedTick: checkpoint.selectedTick,
+  };
+}
+
+function hydrateCheckpoint(
+  checkpoint: PersistedTimelineCheckpoint,
+): FactoryTimelineCheckpoint {
+  return {
+    afterEventId: checkpoint.afterEventId,
+    afterSequence: checkpoint.afterSequence,
+    replayState: checkpoint.replayState,
+    selectedTick: checkpoint.selectedTick,
+  };
+}
+
+function parseStoredCheckpoint(
+  envelope: TimelineCheckpointEnvelope,
+  sessionID: string | null,
+): FactoryTimelineCheckpoint | null {
+  if (
+    envelope.schemaVersion !== CHECKPOINT_SCHEMA_VERSION ||
+    envelope.sessionID !== sessionID ||
+    !envelope.checkpoint?.replayState
+  ) {
+    return null;
+  }
+  return hydrateCheckpoint(envelope.checkpoint);
+}
+
+export async function persistTimelineCheckpoint(
+  indexedDB: IndexedDBLike | undefined,
+  sessionID: string | null,
+  checkpoint: FactoryTimelineCheckpoint | undefined,
+): Promise<void> {
+  if (!indexedDB || !sessionID || !checkpoint) {
+    return;
+  }
+
+  const envelope = {
+    checkpoint: buildPersistedCheckpoint(checkpoint),
+    schemaVersion: CHECKPOINT_SCHEMA_VERSION,
+    sessionID,
+  } satisfies TimelineCheckpointEnvelope;
+
+  try {
+    await writeIndexedCheckpoint(indexedDB, envelope);
+  } catch {
+    await deleteIndexedCheckpoint(indexedDB, sessionID).catch(() => {});
+  }
+}
+
+export async function readTimelineCheckpoint(
+  indexedDB: IndexedDBLike | undefined,
+  sessionID: string | null,
+): Promise<FactoryTimelineCheckpoint | null> {
+  if (!indexedDB || !sessionID) {
+    return null;
+  }
+
+  try {
+    const envelope = await readIndexedCheckpoint(indexedDB, sessionID);
+    if (envelope) {
+      const checkpoint = parseStoredCheckpoint(envelope, sessionID);
+      if (!checkpoint) {
+        await deleteIndexedCheckpoint(indexedDB, sessionID).catch(() => {});
+      }
+      return checkpoint;
+    }
+  } catch {
+    await deleteIndexedCheckpoint(indexedDB, sessionID).catch(() => {});
+  }
+
+  return null;
+}
+
+export function reconnectCursorFromCheckpoint(
+  checkpoint: FactoryTimelineCheckpoint | null,
+): FactoryEventReconnectCursor | undefined {
+  if (!checkpoint) {
+    return undefined;
+  }
+  if (!checkpoint.afterEventId && checkpoint.afterSequence == null) {
+    return undefined;
+  }
+  return {
+    afterEventId: checkpoint.afterEventId,
+    afterSequence: checkpoint.afterSequence,
+  };
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -7,6 +7,9 @@ import { coverageConfigDefaults } from "vitest/config";
 const apiOrigin =
   process.env.AGENT_FACTORY_API_ORIGIN ?? "http://127.0.0.1:7437";
 const isCoverageRun = process.argv.includes("--coverage");
+const profileSourceMaps =
+  process.env.AGENT_FACTORY_PROFILE_SOURCEMAPS === "true" ||
+  process.env.AGENT_FACTORY_PROFILE_SOURCEMAPS === "1";
 const isVitestRun =
   process.argv.includes("vitest") || process.env.VITEST === "true";
 const monacoEditorPlugin =
@@ -78,6 +81,7 @@ export default defineConfig({
         entryFileNames: "assets/[name].js",
       },
     },
+    sourcemap: profileSourceMaps,
   },
   esbuild: {
     jsxDev: false,


### PR DESCRIPTION
## Summary
- add a browser replay profiling harness with heap profiling/source-map support for the large factory recording
- persist compact timeline checkpoints in IndexedDB and resume event streaming from the checkpoint cursor
- deduplicate replay text blobs and avoid cloning the owned replay checkpoint on current-mode incremental projection

## Profiling
- Post-change sourcemap heap profile with checkpoint persistence disabled: forced-GC heap dropped to ~162 MB, down from the previous ~260 MB profile.
- The prior top allocation in reconstructWorldStateFromCheckpoint no longer appears in the sampled top frames; remaining pressure is mostly event ingestion and trace snapshot cloning.

## Verification
- make verify-fast
- make ui-lint