### PR TITLE
you-goal-p13-add-session-stream-runtime-plumbing

### DIFF
--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -3,6 +3,7 @@
 Use this map when changing the public REST contract.
 
 - `@you/goal` API contract boundary audit lives in `docs/internal/development/plans/you-goal/api-contract-audit.md`. Follow-on goal API PRs should cite that artifact before adding routes, OpenAPI fragments, or generated-client changes. Invocation reuse for goal mode stays on `POST /factory-sessions/{session_id}/invocations` with `Factory.invocationReturn` primary-result selection; internal `SessionResponseStream` / `SessionResponseStreamEvent` models and existing lifecycle routes (`/pause`, `/resume`, `DISPATCH_INTERRUPTED`) are documented in the audit lifecycle section. The only expected public OpenAPI delta for this slice is `Workstation.workPropagation` with companion `WorkPropagationMode` on `api/components/schemas/data-models/Workstation.yaml`; run `make generate-api` and `make api-smoke` when that field lands, but not for internal-only response-stream work.
+- Internal `SessionResponseStream` backpressure and diagnostics work stays below the public contract boundary. Verify it in `pkg/factorysessions/responsestream/*_test.go` and `pkg/service/runtime_session_runtime_test.go` using live-session `metricsSink` records and observed runtime logs rather than adding OpenAPI or generated-client changes.
 
 - `api/openapi-main.yaml` is the authored OpenAPI entrypoint. Register new component fragments under `components.schemas` here.
 - `api/components/schemas/api/` contains API request/response fragments.

--- a/pkg/factorysessions/responsestream/publisher.go
+++ b/pkg/factorysessions/responsestream/publisher.go
@@ -70,7 +70,10 @@ func (s *SessionResponseStream) appendCompactionSignal(event Event) {
 		return
 	}
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	if s.closed {
+		s.mu.Unlock()
+		return
+	}
 
 	for i, existing := range s.events {
 		if existing.Kind != EventKindCompactionSignal {
@@ -95,10 +98,16 @@ func (s *SessionResponseStream) appendCompactionSignal(event Event) {
 		}
 		s.totalBytes += replacement.PayloadBytes
 		s.events = append(s.events, replacement)
+		subscribers := s.subscribersSnapshotLocked()
+		s.mu.Unlock()
+		notifySubscribers(subscribers)
 		return
 	}
 
 	s.appendLocked(event, true)
+	subscribers := s.subscribersSnapshotLocked()
+	s.mu.Unlock()
+	notifySubscribers(subscribers)
 }
 
 // Diagnostics returns a snapshot of publication diagnostics for the stream.

--- a/pkg/factorysessions/responsestream/publisher_test.go
+++ b/pkg/factorysessions/responsestream/publisher_test.go
@@ -1,6 +1,8 @@
 package responsestream_test
 
 import (
+	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -224,5 +226,92 @@ func TestPublisher_PublishReportsRetentionCompaction(t *testing.T) {
 	}
 	if events[0].Payload != "second" || events[1].Kind != responsestream.EventKindCompactionSignal {
 		t.Fatalf("events = %#v, want truncated progress and compaction signal", events)
+	}
+}
+
+func TestPublisher_SlowSubscriberDoesNotBlockAndReceivesCompactionSignal(t *testing.T) {
+	stream := responsestream.NewSessionResponseStreamWithClock(
+		&fixedClock{now: time.Unix(0, 0).UTC()},
+		responsestream.RetentionLimits{MaxEvents: 2},
+	)
+	publisher := responsestream.NewPublisher(stream, nil)
+
+	subscription, err := stream.Subscribe(0)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer subscription.Detach()
+
+	first := publisher.Publish(responsestream.Event{
+		Kind:       responsestream.EventKindResponseFragment,
+		DispatchID: "dispatch-1",
+		Payload:    "retained-1",
+	})
+	initial, err := subscription.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next(initial): %v", err)
+	}
+	if len(initial.Events) != 1 || initial.Events[0].Sequence != first.Sequence {
+		t.Fatalf("initial events = %#v, want first retained event", initial.Events)
+	}
+
+	publishDone := make(chan struct{})
+	go func() {
+		for i := 0; i < 64; i++ {
+			payload := "chunk-" + strconv.Itoa(i)
+			if i%2 == 0 {
+				publisher.Publish(responsestream.Event{
+					Kind:       responsestream.EventKindProgressFragment,
+					DispatchID: "dispatch-1",
+					Payload:    payload,
+				})
+				continue
+			}
+			publisher.Publish(responsestream.Event{
+				Kind:       responsestream.EventKindResponseFragment,
+				DispatchID: "dispatch-1",
+				Payload:    payload,
+			})
+		}
+		close(publishDone)
+	}()
+
+	select {
+	case <-publishDone:
+	case <-time.After(time.Second):
+		t.Fatal("publishing stalled behind a slow subscriber")
+	}
+
+	catchUp, err := subscription.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next(catch-up): %v", err)
+	}
+	if !catchUp.BehindRetainedWindow {
+		t.Fatalf("catch-up result = %#v, want retained-window gap signal", catchUp)
+	}
+	if catchUp.Compaction == nil || catchUp.Compaction.Reason != responsestream.CompactionReasonTruncated {
+		t.Fatalf("catch-up compaction = %#v, want truncation summary", catchUp.Compaction)
+	}
+
+	foundSignal := false
+	for _, event := range catchUp.Events {
+		if event.Kind == responsestream.EventKindCompactionSignal {
+			foundSignal = true
+			if event.Compaction == nil {
+				t.Fatal("compaction signal missing summary")
+			}
+			break
+		}
+	}
+	if !foundSignal {
+		t.Fatalf("catch-up events = %#v, want retained compaction signal", catchUp.Events)
+	}
+
+	diagnostics := publisher.Diagnostics()
+	if diagnostics.PublishedCount != 65 {
+		t.Fatalf("published count = %d, want 65", diagnostics.PublishedCount)
+	}
+	if diagnostics.CompactionCount == 0 || diagnostics.LastCompaction == nil {
+		t.Fatalf("diagnostics = %#v, want recorded compaction", diagnostics)
 	}
 }

--- a/pkg/factorysessions/responsestream/publisher_test.go
+++ b/pkg/factorysessions/responsestream/publisher_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/portpowered/infinite-you/pkg/factorysessions"
 	"github.com/portpowered/infinite-you/pkg/factorysessions/responsestream"
 )
 
@@ -236,10 +237,7 @@ func TestPublisher_SlowSubscriberDoesNotBlockAndReceivesCompactionSignal(t *test
 	)
 	publisher := responsestream.NewPublisher(stream, nil)
 
-	subscription, err := stream.Subscribe(0)
-	if err != nil {
-		t.Fatalf("Subscribe: %v", err)
-	}
+	subscription := mustSubscribe(t, stream, 0)
 	defer subscription.Detach()
 
 	first := publisher.Publish(responsestream.Event{
@@ -247,30 +245,58 @@ func TestPublisher_SlowSubscriberDoesNotBlockAndReceivesCompactionSignal(t *test
 		DispatchID: "dispatch-1",
 		Payload:    "retained-1",
 	})
-	initial, err := subscription.Next(context.Background())
-	if err != nil {
-		t.Fatalf("Next(initial): %v", err)
-	}
+	initial := mustReadNext(t, subscription, "initial")
 	if len(initial.Events) != 1 || initial.Events[0].Sequence != first.Sequence {
 		t.Fatalf("initial events = %#v, want first retained event", initial.Events)
 	}
 
+	publishAlternatingFragmentsAsync(t, publisher, 64)
+	catchUp := mustReadNext(t, subscription, "catch-up")
+	assertRetainedWindowCompaction(t, catchUp)
+
+	diagnostics := publisher.Diagnostics()
+	if diagnostics.PublishedCount != 65 {
+		t.Fatalf("published count = %d, want 65", diagnostics.PublishedCount)
+	}
+	if diagnostics.CompactionCount == 0 || diagnostics.LastCompaction == nil {
+		t.Fatalf("diagnostics = %#v, want recorded compaction", diagnostics)
+	}
+}
+
+func mustSubscribe(t *testing.T, stream *factorysessions.SessionResponseStream, sequence int64) *responsestream.Subscription {
+	t.Helper()
+
+	subscription, err := stream.Subscribe(sequence)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	return subscription
+}
+
+func mustReadNext(t *testing.T, subscription *responsestream.Subscription, label string) responsestream.ReadResult {
+	t.Helper()
+
+	result, err := subscription.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next(%s): %v", label, err)
+	}
+	return result
+}
+
+func publishAlternatingFragmentsAsync(t *testing.T, publisher *responsestream.Publisher, count int) {
+	t.Helper()
+
 	publishDone := make(chan struct{})
 	go func() {
-		for i := 0; i < 64; i++ {
-			payload := "chunk-" + strconv.Itoa(i)
-			if i%2 == 0 {
-				publisher.Publish(responsestream.Event{
-					Kind:       responsestream.EventKindProgressFragment,
-					DispatchID: "dispatch-1",
-					Payload:    payload,
-				})
-				continue
+		for i := 0; i < count; i++ {
+			kind := responsestream.EventKindProgressFragment
+			if i%2 != 0 {
+				kind = responsestream.EventKindResponseFragment
 			}
 			publisher.Publish(responsestream.Event{
-				Kind:       responsestream.EventKindResponseFragment,
+				Kind:       kind,
 				DispatchID: "dispatch-1",
-				Payload:    payload,
+				Payload:    "chunk-" + strconv.Itoa(i),
 			})
 		}
 		close(publishDone)
@@ -281,37 +307,25 @@ func TestPublisher_SlowSubscriberDoesNotBlockAndReceivesCompactionSignal(t *test
 	case <-time.After(time.Second):
 		t.Fatal("publishing stalled behind a slow subscriber")
 	}
+}
 
-	catchUp, err := subscription.Next(context.Background())
-	if err != nil {
-		t.Fatalf("Next(catch-up): %v", err)
-	}
-	if !catchUp.BehindRetainedWindow {
-		t.Fatalf("catch-up result = %#v, want retained-window gap signal", catchUp)
-	}
-	if catchUp.Compaction == nil || catchUp.Compaction.Reason != responsestream.CompactionReasonTruncated {
-		t.Fatalf("catch-up compaction = %#v, want truncation summary", catchUp.Compaction)
-	}
+func assertRetainedWindowCompaction(t *testing.T, result responsestream.ReadResult) {
+	t.Helper()
 
-	foundSignal := false
-	for _, event := range catchUp.Events {
-		if event.Kind == responsestream.EventKindCompactionSignal {
-			foundSignal = true
-			if event.Compaction == nil {
-				t.Fatal("compaction signal missing summary")
-			}
-			break
+	if !result.BehindRetainedWindow {
+		t.Fatalf("catch-up result = %#v, want retained-window gap signal", result)
+	}
+	if result.Compaction == nil || result.Compaction.Reason != responsestream.CompactionReasonTruncated {
+		t.Fatalf("catch-up compaction = %#v, want truncation summary", result.Compaction)
+	}
+	for _, event := range result.Events {
+		if event.Kind != responsestream.EventKindCompactionSignal {
+			continue
 		}
+		if event.Compaction == nil {
+			t.Fatal("compaction signal missing summary")
+		}
+		return
 	}
-	if !foundSignal {
-		t.Fatalf("catch-up events = %#v, want retained compaction signal", catchUp.Events)
-	}
-
-	diagnostics := publisher.Diagnostics()
-	if diagnostics.PublishedCount != 65 {
-		t.Fatalf("published count = %d, want 65", diagnostics.PublishedCount)
-	}
-	if diagnostics.CompactionCount == 0 || diagnostics.LastCompaction == nil {
-		t.Fatalf("diagnostics = %#v, want recorded compaction", diagnostics)
-	}
+	t.Fatalf("catch-up events = %#v, want retained compaction signal", result.Events)
 }

--- a/pkg/factorysessions/responsestream/stream.go
+++ b/pkg/factorysessions/responsestream/stream.go
@@ -18,6 +18,9 @@ type SessionResponseStream struct {
 	nextSequence int64
 	events       []Event
 	totalBytes   int
+	closed       bool
+	nextSubID    int64
+	subscribers  map[int64]*streamSubscriber
 }
 
 // NewSessionResponseStream allocates an empty internal response stream with
@@ -30,8 +33,9 @@ func NewSessionResponseStream() *SessionResponseStream {
 // supplied clock and retention limits.
 func NewSessionResponseStreamWithClock(clock factory.Clock, limits RetentionLimits) *SessionResponseStream {
 	return &SessionResponseStream{
-		clock:  factory.EnsureClock(clock),
-		limits: limits,
+		clock:       factory.EnsureClock(clock),
+		limits:      limits,
+		subscribers: make(map[int64]*streamSubscriber),
 	}
 }
 
@@ -76,8 +80,15 @@ func (s *SessionResponseStream) Append(event Event) (Event, *CompactionSummary) 
 		return event, nil
 	}
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.appendLocked(event, true)
+	if s.closed {
+		s.mu.Unlock()
+		return event, nil
+	}
+	stored, compaction := s.appendLocked(event, true)
+	subscribers := s.subscribersSnapshotLocked()
+	s.mu.Unlock()
+	notifySubscribers(subscribers)
+	return stored, compaction
 }
 
 func (s *SessionResponseStream) appendLocked(event Event, enforceRetention bool) (Event, *CompactionSummary) {
@@ -307,7 +318,10 @@ func (s *SessionResponseStream) EventsAfter(afterSequence int64) ReadResult {
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	return s.eventsAfterLocked(afterSequence)
+}
 
+func (s *SessionResponseStream) eventsAfterLocked(afterSequence int64) ReadResult {
 	firstRetained := s.firstRetainedSequenceLocked()
 	if len(s.events) == 0 {
 		return ReadResult{FirstRetainedSequence: firstRetained}
@@ -317,7 +331,7 @@ func (s *SessionResponseStream) EventsAfter(afterSequence int64) ReadResult {
 		out := make([]Event, len(s.events))
 		copy(out, s.events)
 		return ReadResult{
-			Events:              out,
+			Events:                out,
 			BehindRetainedWindow:  true,
 			FirstRetainedSequence: firstRetained,
 			Compaction: &CompactionSummary{
@@ -336,9 +350,20 @@ func (s *SessionResponseStream) EventsAfter(afterSequence int64) ReadResult {
 		}
 	}
 	return ReadResult{
-		Events:              out,
+		Events:                out,
 		FirstRetainedSequence: firstRetained,
 	}
+}
+
+func (s *SessionResponseStream) subscribersSnapshotLocked() []*streamSubscriber {
+	if len(s.subscribers) == 0 {
+		return nil
+	}
+	subscribers := make([]*streamSubscriber, 0, len(s.subscribers))
+	for _, subscriber := range s.subscribers {
+		subscribers = append(subscribers, subscriber)
+	}
+	return subscribers
 }
 
 // LatestSequence returns the highest assigned stream sequence, or zero when the

--- a/pkg/factorysessions/responsestream/stream_set.go
+++ b/pkg/factorysessions/responsestream/stream_set.go
@@ -58,6 +58,16 @@ func (s *StreamSet) Stream(dispatchID string) *SessionResponseStream {
 	return stream
 }
 
+// Subscribe attaches one internal subscriber to the dispatch-scoped stream and
+// returns a retained-window cursor that can continue reading live events.
+func (s *StreamSet) Subscribe(dispatchID string, afterSequence int64) (*Subscription, error) {
+	stream := s.Stream(dispatchID)
+	if stream == nil {
+		return nil, ErrSubscriptionClosed
+	}
+	return stream.Subscribe(afterSequence)
+}
+
 // Count returns the number of dispatch-scoped streams currently allocated.
 func (s *StreamSet) Count() int {
 	if s == nil {
@@ -83,6 +93,56 @@ func (s *StreamSet) DispatchIDs() []string {
 	}
 	sort.Strings(ids)
 	return ids
+}
+
+// CloseDispatch detaches subscribers and removes one dispatch-scoped stream
+// from the set.
+func (s *StreamSet) CloseDispatch(dispatchID string) bool {
+	if s == nil {
+		return false
+	}
+	key := normalizeDispatchID(dispatchID)
+	s.mu.Lock()
+	stream := s.streams[key]
+	delete(s.streams, key)
+	s.mu.Unlock()
+	if stream == nil {
+		return false
+	}
+	stream.Close()
+	return true
+}
+
+// Close detaches all dispatch-scoped subscribers and clears the set.
+func (s *StreamSet) Close() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	streams := make([]*SessionResponseStream, 0, len(s.streams))
+	for _, stream := range s.streams {
+		streams = append(streams, stream)
+	}
+	s.streams = make(map[string]*SessionResponseStream)
+	s.mu.Unlock()
+	for _, stream := range streams {
+		stream.Close()
+	}
+}
+
+// SubscriberCount reports the number of active subscribers for one dispatch.
+func (s *StreamSet) SubscriberCount(dispatchID string) int {
+	if s == nil {
+		return 0
+	}
+	key := normalizeDispatchID(dispatchID)
+	s.mu.RLock()
+	stream := s.streams[key]
+	s.mu.RUnlock()
+	if stream == nil {
+		return 0
+	}
+	return stream.SubscriberCount()
 }
 
 func normalizeDispatchID(dispatchID string) string {

--- a/pkg/factorysessions/responsestream/stream_set.go
+++ b/pkg/factorysessions/responsestream/stream_set.go
@@ -9,9 +9,11 @@ import (
 // StreamSet keeps the dispatch-keyed internal response streams owned by one
 // live Factory Session runtime.
 type StreamSet struct {
-	mu        sync.RWMutex
-	streams   map[string]*SessionResponseStream
-	newStream func() *SessionResponseStream
+	mu               sync.RWMutex
+	streams          map[string]*SessionResponseStream
+	closedDispatches map[string]struct{}
+	closed           bool
+	newStream        func() *SessionResponseStream
 }
 
 // NewStreamSet allocates an empty response-stream set using the default stream
@@ -27,8 +29,9 @@ func NewStreamSetWithFactory(newStream func() *SessionResponseStream) *StreamSet
 		newStream = NewSessionResponseStream
 	}
 	return &StreamSet{
-		streams:   make(map[string]*SessionResponseStream),
-		newStream: newStream,
+		streams:          make(map[string]*SessionResponseStream),
+		closedDispatches: make(map[string]struct{}),
+		newStream:        newStream,
 	}
 }
 
@@ -43,15 +46,26 @@ func (s *StreamSet) Stream(dispatchID string) *SessionResponseStream {
 
 	s.mu.RLock()
 	stream := s.streams[key]
+	closed := s.closed
+	_, dispatchClosed := s.closedDispatches[key]
 	s.mu.RUnlock()
 	if stream != nil {
 		return stream
+	}
+	if closed || dispatchClosed {
+		return nil
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if stream = s.streams[key]; stream != nil {
 		return stream
+	}
+	if s.closed {
+		return nil
+	}
+	if _, dispatchClosed = s.closedDispatches[key]; dispatchClosed {
+		return nil
 	}
 	stream = s.newStream()
 	s.streams[key] = stream
@@ -103,8 +117,13 @@ func (s *StreamSet) CloseDispatch(dispatchID string) bool {
 	}
 	key := normalizeDispatchID(dispatchID)
 	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return false
+	}
 	stream := s.streams[key]
 	delete(s.streams, key)
+	s.closedDispatches[key] = struct{}{}
 	s.mu.Unlock()
 	if stream == nil {
 		return false
@@ -119,6 +138,11 @@ func (s *StreamSet) Close() {
 		return
 	}
 	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return
+	}
+	s.closed = true
 	streams := make([]*SessionResponseStream, 0, len(s.streams))
 	for _, stream := range s.streams {
 		streams = append(streams, stream)

--- a/pkg/factorysessions/responsestream/stream_set.go
+++ b/pkg/factorysessions/responsestream/stream_set.go
@@ -1,0 +1,90 @@
+package responsestream
+
+import (
+	"sort"
+	"strings"
+	"sync"
+)
+
+// StreamSet keeps the dispatch-keyed internal response streams owned by one
+// live Factory Session runtime.
+type StreamSet struct {
+	mu        sync.RWMutex
+	streams   map[string]*SessionResponseStream
+	newStream func() *SessionResponseStream
+}
+
+// NewStreamSet allocates an empty response-stream set using the default stream
+// constructor for newly observed dispatch identities.
+func NewStreamSet() *StreamSet {
+	return NewStreamSetWithFactory(NewSessionResponseStream)
+}
+
+// NewStreamSetWithFactory allocates an empty response-stream set using the
+// supplied stream constructor for newly observed dispatch identities.
+func NewStreamSetWithFactory(newStream func() *SessionResponseStream) *StreamSet {
+	if newStream == nil {
+		newStream = NewSessionResponseStream
+	}
+	return &StreamSet{
+		streams:   make(map[string]*SessionResponseStream),
+		newStream: newStream,
+	}
+}
+
+// Stream returns the stream for one dispatch identity, allocating it on first
+// use. Empty identities are retained under the empty-string key so providers
+// without dispatch metadata still stay scoped to one session-owned stream.
+func (s *StreamSet) Stream(dispatchID string) *SessionResponseStream {
+	if s == nil {
+		return nil
+	}
+	key := normalizeDispatchID(dispatchID)
+
+	s.mu.RLock()
+	stream := s.streams[key]
+	s.mu.RUnlock()
+	if stream != nil {
+		return stream
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if stream = s.streams[key]; stream != nil {
+		return stream
+	}
+	stream = s.newStream()
+	s.streams[key] = stream
+	return stream
+}
+
+// Count returns the number of dispatch-scoped streams currently allocated.
+func (s *StreamSet) Count() int {
+	if s == nil {
+		return 0
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.streams)
+}
+
+// DispatchIDs reports the currently allocated dispatch identities in sorted
+// order for deterministic tests and diagnostics.
+func (s *StreamSet) DispatchIDs() []string {
+	if s == nil {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	ids := make([]string, 0, len(s.streams))
+	for dispatchID := range s.streams {
+		ids = append(ids, dispatchID)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func normalizeDispatchID(dispatchID string) string {
+	return strings.TrimSpace(dispatchID)
+}

--- a/pkg/factorysessions/responsestream/stream_set_test.go
+++ b/pkg/factorysessions/responsestream/stream_set_test.go
@@ -1,6 +1,8 @@
 package responsestream_test
 
 import (
+	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 
@@ -50,5 +52,29 @@ func TestStreamSet_StreamFactoryRunsOncePerDispatch(t *testing.T) {
 	}
 	if got := calls.Load(); got != 2 {
 		t.Fatalf("factory calls = %d, want 2", got)
+	}
+}
+
+func TestStreamSet_CloseDispatchDetachesSubscribersAndRemovesStream(t *testing.T) {
+	set := responsestream.NewStreamSet()
+	subscription, err := set.Subscribe("dispatch-1", 0)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	if got := set.SubscriberCount("dispatch-1"); got != 1 {
+		t.Fatalf("subscriber count = %d, want 1", got)
+	}
+	if closed := set.CloseDispatch("dispatch-1"); !closed {
+		t.Fatal("CloseDispatch returned false, want stream closed")
+	}
+	if got := set.SubscriberCount("dispatch-1"); got != 0 {
+		t.Fatalf("subscriber count after close = %d, want 0", got)
+	}
+	if got := set.Count(); got != 0 {
+		t.Fatalf("stream count after close = %d, want 0", got)
+	}
+	if _, err := subscription.Next(context.Background()); !errors.Is(err, responsestream.ErrSubscriptionClosed) {
+		t.Fatalf("Next after dispatch close error = %v, want ErrSubscriptionClosed", err)
 	}
 }

--- a/pkg/factorysessions/responsestream/stream_set_test.go
+++ b/pkg/factorysessions/responsestream/stream_set_test.go
@@ -77,4 +77,33 @@ func TestStreamSet_CloseDispatchDetachesSubscribersAndRemovesStream(t *testing.T
 	if _, err := subscription.Next(context.Background()); !errors.Is(err, responsestream.ErrSubscriptionClosed) {
 		t.Fatalf("Next after dispatch close error = %v, want ErrSubscriptionClosed", err)
 	}
+	if stream := set.Stream("dispatch-1"); stream != nil {
+		t.Fatal("Stream after dispatch close = non-nil, want terminal dispatch tombstone")
+	}
+	if _, err := set.Subscribe("dispatch-1", 0); !errors.Is(err, responsestream.ErrSubscriptionClosed) {
+		t.Fatalf("Subscribe after dispatch close error = %v, want ErrSubscriptionClosed", err)
+	}
+	if got := set.Count(); got != 0 {
+		t.Fatalf("stream count after post-close subscribe = %d, want 0", got)
+	}
+}
+
+func TestStreamSet_ClosePreventsStreamRecreation(t *testing.T) {
+	set := responsestream.NewStreamSet()
+	stream := set.Stream("dispatch-1")
+	if stream == nil {
+		t.Fatal("Stream before close = nil, want allocated stream")
+	}
+
+	set.Close()
+
+	if stream := set.Stream("dispatch-1"); stream != nil {
+		t.Fatal("Stream after close = non-nil, want terminal closed set")
+	}
+	if _, err := set.Subscribe("dispatch-1", 0); !errors.Is(err, responsestream.ErrSubscriptionClosed) {
+		t.Fatalf("Subscribe after close error = %v, want ErrSubscriptionClosed", err)
+	}
+	if got := set.Count(); got != 0 {
+		t.Fatalf("stream count after closed subscribe = %d, want 0", got)
+	}
 }

--- a/pkg/factorysessions/responsestream/stream_set_test.go
+++ b/pkg/factorysessions/responsestream/stream_set_test.go
@@ -1,0 +1,54 @@
+package responsestream_test
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/factorysessions/responsestream"
+)
+
+func TestStreamSet_ReusesDispatchStreamAndSeparatesOtherDispatches(t *testing.T) {
+	set := responsestream.NewStreamSet()
+
+	alphaFirst := set.Stream("dispatch-alpha")
+	alphaSecond := set.Stream(" dispatch-alpha ")
+	beta := set.Stream("dispatch-beta")
+
+	if alphaFirst == nil || beta == nil {
+		t.Fatal("stream = nil, want allocated dispatch stream")
+	}
+	if alphaFirst != alphaSecond {
+		t.Fatal("same dispatch returned different streams")
+	}
+	if alphaFirst == beta {
+		t.Fatal("different dispatches shared a stream")
+	}
+	if got := set.Count(); got != 2 {
+		t.Fatalf("stream count = %d, want 2", got)
+	}
+	if got := set.DispatchIDs(); len(got) != 2 || got[0] != "dispatch-alpha" || got[1] != "dispatch-beta" {
+		t.Fatalf("dispatch ids = %#v, want sorted identities", got)
+	}
+}
+
+func TestStreamSet_StreamFactoryRunsOncePerDispatch(t *testing.T) {
+	var calls atomic.Int32
+	set := responsestream.NewStreamSetWithFactory(func() *responsestream.SessionResponseStream {
+		calls.Add(1)
+		return responsestream.NewSessionResponseStream()
+	})
+
+	first := set.Stream("dispatch-1")
+	second := set.Stream("dispatch-1")
+	third := set.Stream("dispatch-2")
+
+	if first == nil || second == nil || third == nil {
+		t.Fatal("stream = nil, want allocated streams")
+	}
+	if first != second {
+		t.Fatal("same dispatch returned different streams")
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("factory calls = %d, want 2", got)
+	}
+}

--- a/pkg/factorysessions/responsestream/subscription.go
+++ b/pkg/factorysessions/responsestream/subscription.go
@@ -1,0 +1,200 @@
+package responsestream
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+var ErrSubscriptionClosed = errors.New("session response stream subscription is closed")
+
+type streamSubscriber struct {
+	done chan struct{}
+	once sync.Once
+	wake chan struct{}
+}
+
+func newStreamSubscriber() *streamSubscriber {
+	return &streamSubscriber{
+		done: make(chan struct{}),
+		wake: make(chan struct{}, 1),
+	}
+}
+
+func (s *streamSubscriber) notify() {
+	if s == nil {
+		return
+	}
+	select {
+	case <-s.done:
+		return
+	default:
+	}
+	select {
+	case s.wake <- struct{}{}:
+	default:
+	}
+}
+
+func (s *streamSubscriber) close() {
+	if s == nil {
+		return
+	}
+	s.once.Do(func() {
+		close(s.done)
+	})
+}
+
+// Subscription is an internal live-session response-stream cursor.
+type Subscription struct {
+	stream       *SessionResponseStream
+	subscriber   *streamSubscriber
+	subscriberID int64
+
+	mu            sync.Mutex
+	afterSequence int64
+}
+
+// Subscribe registers one internal consumer starting after the supplied
+// sequence. The subscriber can immediately call Next to read the retained
+// window, then continue reading live updates in order.
+func (s *SessionResponseStream) Subscribe(afterSequence int64) (*Subscription, error) {
+	if s == nil {
+		return nil, ErrSubscriptionClosed
+	}
+	subscriber := newStreamSubscriber()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil, ErrSubscriptionClosed
+	}
+	s.nextSubID++
+	subscriberID := s.nextSubID
+	s.subscribers[subscriberID] = subscriber
+	return &Subscription{
+		stream:        s,
+		subscriber:    subscriber,
+		subscriberID:  subscriberID,
+		afterSequence: afterSequence,
+	}, nil
+}
+
+// SubscriberCount reports the number of active internal subscribers currently
+// attached to the stream.
+func (s *SessionResponseStream) SubscriberCount() int {
+	if s == nil {
+		return 0
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.subscribers)
+}
+
+// Close detaches all subscribers and prevents further publication or
+// subscription on the stream.
+func (s *SessionResponseStream) Close() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return
+	}
+	s.closed = true
+	subscribers := s.subscribersSnapshotLocked()
+	s.subscribers = make(map[int64]*streamSubscriber)
+	s.mu.Unlock()
+	closeSubscribers(subscribers)
+}
+
+// Detach releases the runtime-owned subscriber registration.
+func (s *Subscription) Detach() {
+	if s == nil {
+		return
+	}
+	stream := s.stream
+	if stream != nil {
+		stream.detachSubscriber(s.subscriberID)
+	}
+	if s.subscriber != nil {
+		s.subscriber.close()
+	}
+}
+
+// Next returns the next retained or live stream segment after the subscriber's
+// current cursor.
+func (s *Subscription) Next(ctx context.Context) (ReadResult, error) {
+	if s == nil || s.stream == nil || s.subscriber == nil {
+		return ReadResult{}, ErrSubscriptionClosed
+	}
+	for {
+		s.mu.Lock()
+		afterSequence := s.afterSequence
+		s.mu.Unlock()
+
+		result, closed := s.stream.readForSubscriber(afterSequence)
+		if closed {
+			return ReadResult{}, ErrSubscriptionClosed
+		}
+		if len(result.Events) > 0 || result.BehindRetainedWindow || result.Compaction != nil {
+			s.advance(result)
+			return result, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ReadResult{}, ctx.Err()
+		case <-s.subscriber.done:
+			return ReadResult{}, ErrSubscriptionClosed
+		case <-s.subscriber.wake:
+		}
+	}
+}
+
+func (s *Subscription) advance(result ReadResult) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(result.Events) > 0 {
+		s.afterSequence = result.Events[len(result.Events)-1].Sequence
+		return
+	}
+	if result.FirstRetainedSequence > 0 {
+		s.afterSequence = result.FirstRetainedSequence - 1
+	}
+}
+
+func (s *SessionResponseStream) readForSubscriber(afterSequence int64) (ReadResult, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		return ReadResult{}, true
+	}
+	return s.eventsAfterLocked(afterSequence), false
+}
+
+func (s *SessionResponseStream) detachSubscriber(id int64) {
+	if s == nil || id == 0 {
+		return
+	}
+	s.mu.Lock()
+	subscriber := s.subscribers[id]
+	delete(s.subscribers, id)
+	s.mu.Unlock()
+	if subscriber != nil {
+		subscriber.close()
+	}
+}
+
+func notifySubscribers(subscribers []*streamSubscriber) {
+	for _, subscriber := range subscribers {
+		subscriber.notify()
+	}
+}
+
+func closeSubscribers(subscribers []*streamSubscriber) {
+	for _, subscriber := range subscribers {
+		subscriber.close()
+	}
+}

--- a/pkg/factorysessions/responsestream/subscription_test.go
+++ b/pkg/factorysessions/responsestream/subscription_test.go
@@ -1,0 +1,91 @@
+package responsestream_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/pkg/factorysessions/responsestream"
+)
+
+func TestSessionResponseStreamSubscription_ReadsRetainedThenLiveEventsInOrder(t *testing.T) {
+	stream := responsestream.NewSessionResponseStream()
+	publisher := responsestream.NewPublisher(stream, nil)
+	first := publisher.Publish(progressEvent("dispatch-1", "retained-1"))
+	second := publisher.Publish(progressEvent("dispatch-1", "retained-2"))
+
+	subscription, err := stream.Subscribe(0)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer subscription.Detach()
+
+	initial, err := subscription.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next(initial): %v", err)
+	}
+	if len(initial.Events) != 2 {
+		t.Fatalf("initial event count = %d, want 2", len(initial.Events))
+	}
+	if initial.Events[0].Sequence != first.Sequence || initial.Events[1].Sequence != second.Sequence {
+		t.Fatalf("initial sequences = %#v, want [%d %d]", []int64{initial.Events[0].Sequence, initial.Events[1].Sequence}, first.Sequence, second.Sequence)
+	}
+
+	third := publisher.Publish(progressEvent("dispatch-1", "live-3"))
+	live, err := subscription.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next(live): %v", err)
+	}
+	if len(live.Events) != 1 || live.Events[0].Sequence != third.Sequence || live.Events[0].Payload != "live-3" {
+		t.Fatalf("live events = %#v, want retained live event", live.Events)
+	}
+}
+
+func TestSessionResponseStreamSubscription_DetachStopsFurtherDelivery(t *testing.T) {
+	stream := responsestream.NewSessionResponseStream()
+	subscription, err := stream.Subscribe(0)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	if got := stream.SubscriberCount(); got != 1 {
+		t.Fatalf("subscriber count = %d, want 1", got)
+	}
+	subscription.Detach()
+	if got := stream.SubscriberCount(); got != 0 {
+		t.Fatalf("subscriber count after detach = %d, want 0", got)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if _, err := subscription.Next(ctx); !errors.Is(err, responsestream.ErrSubscriptionClosed) {
+		t.Fatalf("Next after detach error = %v, want ErrSubscriptionClosed", err)
+	}
+}
+
+func TestSessionResponseStreamSubscription_CloseReleasesAllSubscribers(t *testing.T) {
+	stream := responsestream.NewSessionResponseStream()
+	first, err := stream.Subscribe(0)
+	if err != nil {
+		t.Fatalf("Subscribe(first): %v", err)
+	}
+	second, err := stream.Subscribe(0)
+	if err != nil {
+		t.Fatalf("Subscribe(second): %v", err)
+	}
+
+	if got := stream.SubscriberCount(); got != 2 {
+		t.Fatalf("subscriber count = %d, want 2", got)
+	}
+	stream.Close()
+	if got := stream.SubscriberCount(); got != 0 {
+		t.Fatalf("subscriber count after close = %d, want 0", got)
+	}
+
+	for _, subscription := range []*responsestream.Subscription{first, second} {
+		if _, err := subscription.Next(context.Background()); !errors.Is(err, responsestream.ErrSubscriptionClosed) {
+			t.Fatalf("Next after close error = %v, want ErrSubscriptionClosed", err)
+		}
+	}
+}

--- a/pkg/factorysessions/types.go
+++ b/pkg/factorysessions/types.go
@@ -80,6 +80,14 @@ type SessionResponseStreamEvent = responsestream.Event
 // SessionResponseStreamEventKind identifies internal response-stream semantics.
 type SessionResponseStreamEventKind = responsestream.EventKind
 
+// SessionResponseStreamReadResult is the internal bounded catch-up view for
+// one response-stream subscriber resume point.
+type SessionResponseStreamReadResult = responsestream.ReadResult
+
+// SessionResponseStreamCompactionSummary records bounded fidelity loss for
+// stream subscribers that resume after truncation or coalescing.
+type SessionResponseStreamCompactionSummary = responsestream.CompactionSummary
+
 // SessionResponseStreamRetentionLimits documents bounded-retention controls for
 // one internal session response stream.
 type SessionResponseStreamRetentionLimits = responsestream.RetentionLimits
@@ -101,3 +109,7 @@ func NewSessionResponseStreamSetWithFactory(
 ) *SessionResponseStreamSet {
 	return responsestream.NewStreamSetWithFactory(newStream)
 }
+
+// SessionResponseStreamSubscription is an internal live-session response-stream
+// cursor that can read retained and live dispatch progress.
+type SessionResponseStreamSubscription = responsestream.Subscription

--- a/pkg/factorysessions/types.go
+++ b/pkg/factorysessions/types.go
@@ -69,6 +69,10 @@ func NewSessionID() string {
 // and from service-coordinator state.
 type SessionResponseStream = responsestream.SessionResponseStream
 
+// SessionResponseStreamSet keeps the dispatch-keyed response streams owned by
+// one live Factory Session runtime.
+type SessionResponseStreamSet = responsestream.StreamSet
+
 // SessionResponseStreamEvent is the internal envelope for provider progress and
 // response fragments within one Factory Session runtime.
 type SessionResponseStreamEvent = responsestream.Event
@@ -88,4 +92,12 @@ type SessionResponseStreamRetentionAccounting = responsestream.RetentionAccounti
 // one live Factory Session runtime.
 func NewSessionResponseStream() *SessionResponseStream {
 	return responsestream.NewSessionResponseStream()
+}
+
+// NewSessionResponseStreamSetWithFactory allocates a dispatch-keyed stream set
+// using the supplied stream constructor.
+func NewSessionResponseStreamSetWithFactory(
+	newStream func() *SessionResponseStream,
+) *SessionResponseStreamSet {
+	return responsestream.NewStreamSetWithFactory(newStream)
 }

--- a/pkg/service/factory.go
+++ b/pkg/service/factory.go
@@ -100,6 +100,7 @@ type factoryRuntimeBundle struct {
 	recording            *replay.Recorder
 	recordPath           string
 	dispatchMetricFields sync.Map
+	dispatchCompleted    func(string)
 }
 
 type liveRuntimeHandle struct {

--- a/pkg/service/factory_build.go
+++ b/pkg/service/factory_build.go
@@ -63,6 +63,7 @@ type runtimeBundleBuildInput struct {
 	prefetchedLocalModels         localModelDomain
 	inferenceProgressPublisher    workerprovider.InferenceProgressPublisher
 	inferenceProgressPublisherSet bool
+	dispatchCompleted             func(string)
 }
 
 type liveSessionState struct {
@@ -499,6 +500,7 @@ func assembleRuntimeBundle(
 		metricsSink:       metricsSink,
 		recording:         recording,
 		recordPath:        input.recordPath,
+		dispatchCompleted: input.dispatchCompleted,
 	}
 	opts := []factory.FactoryOption{
 		factory.WithNet(net),
@@ -626,6 +628,9 @@ func (r *factoryRuntimeBundle) recordCompletionMetrics(record interfaces.Factory
 		r.emitMetricSample(runtimeMetricDispatchCost, record.Result.Metrics.Cost, "usd", metricFields)
 	}
 	r.emitWorkerBoundaryCompletionMetrics(record.Result, metricFields)
+	if r.dispatchCompleted != nil {
+		r.dispatchCompleted(record.DispatchID)
+	}
 }
 
 func runtimeDispatchMetricFields(dispatch interfaces.WorkDispatch) metrics.Fields {
@@ -1289,6 +1294,7 @@ func newRuntimeBuildService(
 	baseLogger *zap.Logger,
 	startupLocalModels *localModelDomain,
 	progressPublisherFactory inferenceProgressPublisherFactory,
+	dispatchCompletionFactory dispatchCompletionObserverFactory,
 ) *runtimebuild.Service {
 	buildCfg := runtimeBuildConfigFromService(cfg)
 	return runtimebuild.New(
@@ -1315,6 +1321,9 @@ func newRuntimeBuildService(
 			if progressPublisherFactory != nil {
 				bundleInput.inferenceProgressPublisher = progressPublisherFactory(bundleInput.sessionID)
 				bundleInput.inferenceProgressPublisherSet = true
+			}
+			if dispatchCompletionFactory != nil {
+				bundleInput.dispatchCompleted = dispatchCompletionFactory(bundleInput.sessionID)
 			}
 			if startupLocalModels != nil && startupLocalModels.manager != nil {
 				bundleInput.prefetchedLocalModels = *startupLocalModels

--- a/pkg/service/factory_build.go
+++ b/pkg/service/factory_build.go
@@ -70,8 +70,8 @@ type liveSessionState struct {
 	handle                *liveRuntimeHandle
 	spec                  *runtimebuild.SessionBuildSpec
 	javascriptCheckpoints *factorysessions.JavaScriptCheckpointStore
-	responseStreamOnce    sync.Once
-	responseStream        *factorysessions.SessionResponseStream
+	responseStreamsOnce   sync.Once
+	responseStreams       *factorysessions.SessionResponseStreamSet
 }
 
 // BuildFactoryService loads factory.json from the config directory, constructs

--- a/pkg/service/factory_editable_definition.go
+++ b/pkg/service/factory_editable_definition.go
@@ -441,9 +441,16 @@ func NewFactoryServiceCollaborators(
 ) FactoryServiceCollaborators {
 	startupLocalModels := newRuntimeLocalModelDependencies(cfg)
 	return FactoryServiceCollaborators{
-		Sessions:     sessions,
-		LocalModels:  startupLocalModels,
-		RuntimeBuild: newRuntimeBuildService(cfg, clock, baseLogger, &startupLocalModels, newInferenceProgressPublisherFactory(sessions, baseLogger)),
+		Sessions:    sessions,
+		LocalModels: startupLocalModels,
+		RuntimeBuild: newRuntimeBuildService(
+			cfg,
+			clock,
+			baseLogger,
+			&startupLocalModels,
+			newInferenceProgressPublisherFactory(sessions, baseLogger),
+			newSessionDispatchCompletionObserverFactory(sessions),
+		),
 	}
 }
 
@@ -468,7 +475,7 @@ func NewRuntimeBuildService(
 	baseLogger *zap.Logger,
 	localModels *LocalModelDomain,
 ) *runtimebuild.Service {
-	return newRuntimeBuildService(cfg, clock, baseLogger, localModels, nil)
+	return newRuntimeBuildService(cfg, clock, baseLogger, localModels, nil, nil)
 }
 
 // FactoryConfigLoadResult carries factory config load outputs needed before

--- a/pkg/service/runtime_session_runtime_test.go
+++ b/pkg/service/runtime_session_runtime_test.go
@@ -2614,6 +2614,41 @@ func TestFactoryService_SubscribeSessionResponseStream_ReadsRetainedAndLiveEvent
 }
 
 func TestFactoryService_InferenceProgressPublisher_SlowSubscriberCompactionEmitsDiagnostics(t *testing.T) {
+	sessionID := "session-progress-backpressure"
+	harness := newSlowSubscriberCompactionHarness(t, sessionID)
+	defer harness.metricsSink.Close()
+
+	publisher := harness.svc.inferenceProgressPublisher(sessionID, harness.logger)
+	if publisher == nil {
+		t.Fatal("publisher = nil, want inference progress publisher")
+	}
+
+	publisher(workerprovider.ResponseFragment("dispatch-1", nil, "retained-1"))
+	subscription := mustSubscribeSessionResponseStream(t, harness.svc, sessionID, "dispatch-1", 0)
+	defer subscription.Detach()
+
+	initial := mustReadSessionResponseSubscription(t, subscription, "initial")
+	if len(initial.Events) != 1 || initial.Events[0].Payload != "retained-1" {
+		t.Fatalf("initial events = %#v, want retained seed event", initial.Events)
+	}
+
+	publishProviderAlternatingFragmentsAsync(t, publisher, 64)
+	catchUp := mustReadSessionResponseSubscription(t, subscription, "catch-up")
+	assertRetainedWindowCompactionResult(t, catchUp)
+	assertResponseStreamCompactionMetric(t, harness.metricsSink.Path())
+	assertResponseStreamCompactionWarning(t, harness.observed)
+}
+
+type slowSubscriberCompactionHarness struct {
+	svc        *FactoryService
+	logger     *zap.Logger
+	observed   *observer.ObservedLogs
+	metricsSink *logging.RuntimeMetricsSink
+}
+
+func newSlowSubscriberCompactionHarness(t *testing.T, sessionID string) slowSubscriberCompactionHarness {
+	t.Helper()
+
 	metricsSink, err := logging.BuildRuntimeMetricsSink(
 		"session-progress-backpressure",
 		"runtime-progress-backpressure",
@@ -2625,12 +2660,10 @@ func TestFactoryService_InferenceProgressPublisher_SlowSubscriberCompactionEmits
 	if err != nil {
 		t.Fatalf("BuildRuntimeMetricsSink: %v", err)
 	}
-	defer metricsSink.Close()
 
 	core, observed := observer.New(zap.WarnLevel)
 	logger := zap.New(core)
 	sessions := factorysessions.NewRegistry()
-	sessionID := "session-progress-backpressure"
 	sessions.Upsert(factorysessions.NewLiveSession(
 		sessionID,
 		"/factory",
@@ -2645,38 +2678,61 @@ func TestFactoryService_InferenceProgressPublisher_SlowSubscriberCompactionEmits
 		"factory",
 	), true)
 
-	svc := &FactoryService{
-		sessions: sessions,
-		newSessionResponseStream: func() *factorysessions.SessionResponseStream {
-			return responsestream.NewSessionResponseStreamWithClock(
-				factory.RealClock{},
-				responsestream.RetentionLimits{MaxEvents: 2},
-			)
+	return slowSubscriberCompactionHarness{
+		svc: &FactoryService{
+			sessions: sessions,
+			newSessionResponseStream: func() *factorysessions.SessionResponseStream {
+				return responsestream.NewSessionResponseStreamWithClock(
+					factory.RealClock{},
+					responsestream.RetentionLimits{MaxEvents: 2},
+				)
+			},
 		},
+		logger:      logger,
+		observed:    observed,
+		metricsSink: metricsSink,
 	}
-	publisher := svc.inferenceProgressPublisher(sessionID, logger)
-	if publisher == nil {
-		t.Fatal("publisher = nil, want inference progress publisher")
-	}
+}
 
-	publisher(workerprovider.ResponseFragment("dispatch-1", nil, "retained-1"))
-	subscription, err := svc.SubscribeSessionResponseStream(sessionID, "dispatch-1", 0)
+func mustSubscribeSessionResponseStream(
+	t *testing.T,
+	svc *FactoryService,
+	sessionID, dispatchID string,
+	afterSequence int64,
+) *responsestream.Subscription {
+	t.Helper()
+
+	subscription, err := svc.SubscribeSessionResponseStream(sessionID, dispatchID, afterSequence)
 	if err != nil {
 		t.Fatalf("SubscribeSessionResponseStream: %v", err)
 	}
-	defer subscription.Detach()
+	return subscription
+}
 
-	initial, err := subscription.Next(context.Background())
+func mustReadSessionResponseSubscription(
+	t *testing.T,
+	subscription *responsestream.Subscription,
+	label string,
+) responsestream.ReadResult {
+	t.Helper()
+
+	result, err := subscription.Next(context.Background())
 	if err != nil {
-		t.Fatalf("Next(initial): %v", err)
+		t.Fatalf("Next(%s): %v", label, err)
 	}
-	if len(initial.Events) != 1 || initial.Events[0].Payload != "retained-1" {
-		t.Fatalf("initial events = %#v, want retained seed event", initial.Events)
-	}
+	return result
+}
+
+func publishProviderAlternatingFragmentsAsync(
+	t *testing.T,
+	publisher workerprovider.InferenceProgressPublisher,
+	count int,
+) {
+	t.Helper()
 
 	publishDone := make(chan struct{})
 	go func() {
-		for i := 0; i < 64; i++ {
+		for i := 0; i < count; i++ {
 			payload := "chunk-" + strconv.Itoa(i)
 			if i%2 == 0 {
 				publisher(workerprovider.ProgressFragment("dispatch-1", nil, payload))
@@ -2692,49 +2748,48 @@ func TestFactoryService_InferenceProgressPublisher_SlowSubscriberCompactionEmits
 	case <-time.After(time.Second):
 		t.Fatal("publishing stalled behind a slow subscriber")
 	}
+}
 
-	catchUp, err := subscription.Next(context.Background())
-	if err != nil {
-		t.Fatalf("Next(catch-up): %v", err)
-	}
-	if !catchUp.BehindRetainedWindow {
-		t.Fatalf("catch-up result = %#v, want retained-window gap signal", catchUp)
-	}
-	if catchUp.Compaction == nil || catchUp.Compaction.Reason != responsestream.CompactionReasonTruncated {
-		t.Fatalf("catch-up compaction = %#v, want truncation summary", catchUp.Compaction)
-	}
+func assertRetainedWindowCompactionResult(t *testing.T, result responsestream.ReadResult) {
+	t.Helper()
 
-	foundSignal := false
-	for _, event := range catchUp.Events {
+	if !result.BehindRetainedWindow {
+		t.Fatalf("catch-up result = %#v, want retained-window gap signal", result)
+	}
+	if result.Compaction == nil || result.Compaction.Reason != responsestream.CompactionReasonTruncated {
+		t.Fatalf("catch-up compaction = %#v, want truncation summary", result.Compaction)
+	}
+	for _, event := range result.Events {
 		if event.Kind == responsestream.EventKindCompactionSignal {
-			foundSignal = true
-			break
+			return
 		}
 	}
-	if !foundSignal {
-		t.Fatalf("catch-up events = %#v, want retained compaction signal", catchUp.Events)
-	}
+	t.Fatalf("catch-up events = %#v, want retained compaction signal", result.Events)
+}
 
-	waitForRuntimeMetricsRecord(t, metricsSink.Path(), time.Second, func(record map[string]any) bool {
+func assertResponseStreamCompactionMetric(t *testing.T, metricsPath string) {
+	t.Helper()
+
+	waitForRuntimeMetricsRecord(t, metricsPath, time.Second, func(record map[string]any) bool {
 		return runtimeMetricNameAndValue(record, runtimeMetricSessionResponseStreamCompacted, 1) &&
 			metricRecordString(record, "dispatch_id") == "dispatch-1" &&
 			metricRecordString(record, "reason") == string(responsestream.CompactionReasonTruncated)
 	}, "response stream compaction")
+}
 
-	foundWarn := false
+func assertResponseStreamCompactionWarning(t *testing.T, observed *observer.ObservedLogs) {
+	t.Helper()
+
 	for _, entry := range observed.All() {
 		if entry.Message != "session response stream compacted internal provider progress" {
 			continue
 		}
 		if entry.ContextMap()["dispatch_id"] == "dispatch-1" &&
 			entry.ContextMap()["compaction_reason"] == string(responsestream.CompactionReasonTruncated) {
-			foundWarn = true
-			break
+			return
 		}
 	}
-	if !foundWarn {
-		t.Fatalf("compaction warning log not found in %#v", observed.All())
-	}
+	t.Fatalf("compaction warning log not found in %#v", observed.All())
 }
 
 func TestFactoryService_DispatchCompletionObserverClosesDispatchSubscribers(t *testing.T) {

--- a/pkg/service/runtime_session_runtime_test.go
+++ b/pkg/service/runtime_session_runtime_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -21,6 +22,7 @@ import (
 	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
 	"github.com/portpowered/infinite-you/pkg/apisurface"
 	"github.com/portpowered/infinite-you/pkg/config"
+	"github.com/portpowered/infinite-you/pkg/factory"
 	factory_context "github.com/portpowered/infinite-you/pkg/factory/context"
 	"github.com/portpowered/infinite-you/pkg/factory/requests"
 	"github.com/portpowered/infinite-you/pkg/factory/runtime"
@@ -28,6 +30,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/factorysessions/responsestream"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/localmodels"
+	"github.com/portpowered/infinite-you/pkg/logging"
 	workflowsource "github.com/portpowered/infinite-you/pkg/orchestrators/javascript/source"
 	"github.com/portpowered/infinite-you/pkg/workers"
 	workerprompting "github.com/portpowered/infinite-you/pkg/workers/prompting"
@@ -2568,6 +2571,130 @@ func TestFactoryService_SubscribeSessionResponseStream_ReadsRetainedAndLiveEvent
 	}
 	if len(live.Events) != 1 || live.Events[0].Payload != "live-3" {
 		t.Fatalf("live events = %#v, want one live event", live.Events)
+	}
+}
+
+func TestFactoryService_InferenceProgressPublisher_SlowSubscriberCompactionEmitsDiagnostics(t *testing.T) {
+	metricsSink, err := logging.BuildRuntimeMetricsSink(
+		"session-progress-backpressure",
+		"runtime-progress-backpressure",
+		"/factory",
+		"/factory",
+		t.TempDir(),
+		logging.RuntimeMetricsConfig{},
+	)
+	if err != nil {
+		t.Fatalf("BuildRuntimeMetricsSink: %v", err)
+	}
+	defer metricsSink.Close()
+
+	core, observed := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+	sessions := factorysessions.NewRegistry()
+	sessionID := "session-progress-backpressure"
+	sessions.Upsert(factorysessions.NewLiveSession(
+		sessionID,
+		"/factory",
+		"/factory",
+		"/factory",
+		factorysessions.TargetRef{Kind: factorysessions.TargetKindDefault},
+		&liveSessionState{handle: &liveRuntimeHandle{runtime: &factoryRuntimeBundle{
+			logger:      logger,
+			metricsSink: metricsSink,
+		}}},
+		false,
+		"factory",
+	), true)
+
+	svc := &FactoryService{
+		sessions: sessions,
+		newSessionResponseStream: func() *factorysessions.SessionResponseStream {
+			return responsestream.NewSessionResponseStreamWithClock(
+				factory.RealClock{},
+				responsestream.RetentionLimits{MaxEvents: 2},
+			)
+		},
+	}
+	publisher := svc.inferenceProgressPublisher(sessionID, logger)
+	if publisher == nil {
+		t.Fatal("publisher = nil, want inference progress publisher")
+	}
+
+	publisher(workerprovider.ResponseFragment("dispatch-1", nil, "retained-1"))
+	subscription, err := svc.SubscribeSessionResponseStream(sessionID, "dispatch-1", 0)
+	if err != nil {
+		t.Fatalf("SubscribeSessionResponseStream: %v", err)
+	}
+	defer subscription.Detach()
+
+	initial, err := subscription.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next(initial): %v", err)
+	}
+	if len(initial.Events) != 1 || initial.Events[0].Payload != "retained-1" {
+		t.Fatalf("initial events = %#v, want retained seed event", initial.Events)
+	}
+
+	publishDone := make(chan struct{})
+	go func() {
+		for i := 0; i < 64; i++ {
+			payload := "chunk-" + strconv.Itoa(i)
+			if i%2 == 0 {
+				publisher(workerprovider.ProgressFragment("dispatch-1", nil, payload))
+				continue
+			}
+			publisher(workerprovider.ResponseFragment("dispatch-1", nil, payload))
+		}
+		close(publishDone)
+	}()
+
+	select {
+	case <-publishDone:
+	case <-time.After(time.Second):
+		t.Fatal("publishing stalled behind a slow subscriber")
+	}
+
+	catchUp, err := subscription.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next(catch-up): %v", err)
+	}
+	if !catchUp.BehindRetainedWindow {
+		t.Fatalf("catch-up result = %#v, want retained-window gap signal", catchUp)
+	}
+	if catchUp.Compaction == nil || catchUp.Compaction.Reason != responsestream.CompactionReasonTruncated {
+		t.Fatalf("catch-up compaction = %#v, want truncation summary", catchUp.Compaction)
+	}
+
+	foundSignal := false
+	for _, event := range catchUp.Events {
+		if event.Kind == responsestream.EventKindCompactionSignal {
+			foundSignal = true
+			break
+		}
+	}
+	if !foundSignal {
+		t.Fatalf("catch-up events = %#v, want retained compaction signal", catchUp.Events)
+	}
+
+	waitForRuntimeMetricsRecord(t, metricsSink.Path(), time.Second, func(record map[string]any) bool {
+		return runtimeMetricNameAndValue(record, runtimeMetricSessionResponseStreamCompacted, 1) &&
+			metricRecordString(record, "dispatch_id") == "dispatch-1" &&
+			metricRecordString(record, "reason") == string(responsestream.CompactionReasonTruncated)
+	}, "response stream compaction")
+
+	foundWarn := false
+	for _, entry := range observed.All() {
+		if entry.Message != "session response stream compacted internal provider progress" {
+			continue
+		}
+		if entry.ContextMap()["dispatch_id"] == "dispatch-1" &&
+			entry.ContextMap()["compaction_reason"] == string(responsestream.CompactionReasonTruncated) {
+			foundWarn = true
+			break
+		}
+	}
+	if !foundWarn {
+		t.Fatalf("compaction warning log not found in %#v", observed.All())
 	}
 }
 

--- a/pkg/service/runtime_session_runtime_test.go
+++ b/pkg/service/runtime_session_runtime_test.go
@@ -2337,20 +2337,27 @@ func TestFactoryService_SessionResponseStreamOwnedByLiveSessionRuntime(t *testin
 	}
 	svc := &FactoryService{}
 
-	first := svc.sessionResponseStream(session)
-	second := svc.sessionResponseStream(session)
-	if first == nil || second == nil {
+	first := svc.sessionResponseStream(session, "dispatch-a")
+	second := svc.sessionResponseStream(session, "dispatch-a")
+	third := svc.sessionResponseStream(session, "dispatch-b")
+	if first == nil || second == nil || third == nil {
 		t.Fatal("session response stream = nil, want live session runtime instance")
 	}
 	if first != second {
-		t.Fatal("session response stream instances differ, want one stream per live session")
+		t.Fatal("same dispatch stream instances differ, want one stream per live dispatch")
+	}
+	if first == third {
+		t.Fatal("different dispatches shared one stream, want dispatch-scoped session streams")
 	}
 
 	state := liveSessionRuntimeState(session)
-	if state == nil || state.responseStream != first {
-		t.Fatalf("live session state stream = %#v, want %p", state.responseStream, first)
+	if state == nil || state.responseStreams == nil {
+		t.Fatal("live session state stream set = nil, want session-owned stream set")
 	}
-	if svc.sessionResponseStream(nil) != nil {
+	if got := state.responseStreams.Count(); got != 2 {
+		t.Fatalf("session stream set count = %d, want 2", got)
+	}
+	if svc.sessionResponseStreams(nil) != nil {
 		t.Fatal("nil session stream = non-nil, want nil")
 	}
 }
@@ -2379,7 +2386,7 @@ func TestFactoryService_InferenceProgressPublisherPublishesOrderedInternalEvents
 	publisher(workerprovider.ResponseFragment("dispatch-1", nil, "partial-response"))
 
 	session := sessions.Get(sessionID)
-	stream := (&FactoryService{sessions: sessions}).sessionResponseStream(session)
+	stream := (&FactoryService{sessions: sessions}).sessionResponseStream(session, "dispatch-1")
 	if stream == nil {
 		t.Fatal("session stream = nil, want live session stream")
 	}
@@ -2450,7 +2457,7 @@ func TestFactoryService_InferenceProgressPublisherConcurrentFirstFragmentsShareO
 	}
 
 	session := sessions.Get(sessionID)
-	stream := svc.sessionResponseStream(session)
+	stream := svc.sessionResponseStream(session, "dispatch-1")
 	if stream == nil {
 		t.Fatal("session stream = nil, want live session stream")
 	}
@@ -2471,5 +2478,52 @@ func TestFactoryService_InferenceProgressPublisherConcurrentFirstFragmentsShareO
 	}
 	if payloads["stderr-fragment"] != responsestream.EventKindProgressFragment {
 		t.Fatalf("stderr fragment kind = %q, want %q", payloads["stderr-fragment"], responsestream.EventKindProgressFragment)
+	}
+}
+
+func TestFactoryService_InferenceProgressPublisherSeparatesDispatchScopedStreams(t *testing.T) {
+	sessions := factorysessions.NewRegistry()
+	sessionID := "session-progress-separate-dispatches"
+	sessions.Upsert(factorysessions.NewLiveSession(
+		sessionID,
+		"/factory",
+		"/factory",
+		"/factory",
+		factorysessions.TargetRef{Kind: factorysessions.TargetKindDefault},
+		&liveSessionState{},
+		false,
+		"factory",
+	), true)
+
+	publisher := (&FactoryService{sessions: sessions}).inferenceProgressPublisher(sessionID, nil)
+	if publisher == nil {
+		t.Fatal("publisher = nil, want session publisher")
+	}
+
+	publisher(workerprovider.ResponseFragment("dispatch-a", nil, "alpha-1"))
+	publisher(workerprovider.ResponseFragment("dispatch-b", nil, "beta-1"))
+	publisher(workerprovider.ProgressFragment("dispatch-a", nil, "alpha-2"))
+
+	session := sessions.Get(sessionID)
+	svc := &FactoryService{sessions: sessions}
+	alpha := svc.sessionResponseStream(session, "dispatch-a")
+	beta := svc.sessionResponseStream(session, "dispatch-b")
+	if alpha == nil || beta == nil {
+		t.Fatal("dispatch stream = nil, want allocated streams")
+	}
+	if alpha == beta {
+		t.Fatal("different dispatches shared one stream")
+	}
+
+	alphaEvents := alpha.Events()
+	betaEvents := beta.Events()
+	if len(alphaEvents) != 2 || len(betaEvents) != 1 {
+		t.Fatalf("dispatch events = (%#v, %#v), want isolated per-dispatch event windows", alphaEvents, betaEvents)
+	}
+	if alphaEvents[0].Sequence != 1 || alphaEvents[1].Sequence != 2 {
+		t.Fatalf("alpha sequences = %#v, want per-dispatch monotonic sequence", alphaEvents)
+	}
+	if betaEvents[0].Sequence != 1 {
+		t.Fatalf("beta sequences = %#v, want independent per-dispatch ordering", betaEvents)
 	}
 }

--- a/pkg/service/runtime_session_runtime_test.go
+++ b/pkg/service/runtime_session_runtime_test.go
@@ -2405,6 +2405,45 @@ func TestFactoryService_InferenceProgressPublisherPublishesOrderedInternalEvents
 	}
 }
 
+func TestFactoryService_InferenceProgressPublisher_DoesNotEmitCanonicalFactoryEvents(t *testing.T) {
+	harness := startRunningSessionService(t, runningSessionServiceOptions{
+		defaultFactory: "alpha",
+		namedFactories: []string{"alpha"},
+	})
+
+	session := harness.requireSession(t, defaultFactorySessionID)
+	runtimeFactory := liveSessionHandle(session).runtime.factory
+	before, err := runtimeFactory.GetFactoryEvents(context.Background())
+	if err != nil {
+		t.Fatalf("GetFactoryEvents(before): %v", err)
+	}
+
+	publisher := harness.svc.inferenceProgressPublisher(defaultFactorySessionID, nil)
+	if publisher == nil {
+		t.Fatal("publisher = nil, want inference progress publisher")
+	}
+	publisher(workerprovider.ResponseFragment("dispatch-private", nil, "internal-response-fragment"))
+	publisher(workerprovider.ProgressFragment("dispatch-private", nil, "internal-progress-fragment"))
+
+	after, err := runtimeFactory.GetFactoryEvents(context.Background())
+	if err != nil {
+		t.Fatalf("GetFactoryEvents(after): %v", err)
+	}
+	if len(after) != len(before) {
+		t.Fatalf("factory event count changed from %d to %d after internal stream publication", len(before), len(after))
+	}
+	for i := range before {
+		if after[i].Type != before[i].Type {
+			t.Fatalf("factory event types changed after internal stream publication: before=%v after=%v", serviceFactoryEventTypes(before), serviceFactoryEventTypes(after))
+		}
+	}
+
+	assertSessionEventsDoNotContain(t, session, "internal-response-fragment")
+	assertSessionEventsDoNotContain(t, session, "internal-progress-fragment")
+	assertSessionEventsDoNotContain(t, session, string(responsestream.EventKindResponseFragment))
+	assertSessionEventsDoNotContain(t, session, string(responsestream.EventKindProgressFragment))
+}
+
 func TestFactoryService_InferenceProgressPublisherConcurrentFirstFragmentsShareOneSessionStream(t *testing.T) {
 	sessions := factorysessions.NewRegistry()
 	sessionID := "session-progress-concurrent-first"

--- a/pkg/service/runtime_session_runtime_test.go
+++ b/pkg/service/runtime_session_runtime_test.go
@@ -2371,7 +2371,7 @@ func TestFactoryService_InferenceProgressPublisherPublishesOrderedInternalEvents
 		"/factory",
 		"/factory",
 		factorysessions.TargetRef{Kind: factorysessions.TargetKindDefault},
-		&liveSessionState{},
+		&liveSessionState{handle: &liveRuntimeHandle{runtime: &factoryRuntimeBundle{}}},
 		false,
 		"factory",
 	), true)
@@ -2411,7 +2411,7 @@ func TestFactoryService_InferenceProgressPublisherConcurrentFirstFragmentsShareO
 		"/factory",
 		"/factory",
 		factorysessions.TargetRef{Kind: factorysessions.TargetKindDefault},
-		&liveSessionState{},
+		&liveSessionState{handle: &liveRuntimeHandle{runtime: &factoryRuntimeBundle{}}},
 		false,
 		"factory",
 	), true)
@@ -2490,7 +2490,7 @@ func TestFactoryService_InferenceProgressPublisherSeparatesDispatchScopedStreams
 		"/factory",
 		"/factory",
 		factorysessions.TargetRef{Kind: factorysessions.TargetKindDefault},
-		&liveSessionState{},
+		&liveSessionState{handle: &liveRuntimeHandle{runtime: &factoryRuntimeBundle{}}},
 		false,
 		"factory",
 	), true)
@@ -2525,5 +2525,113 @@ func TestFactoryService_InferenceProgressPublisherSeparatesDispatchScopedStreams
 	}
 	if betaEvents[0].Sequence != 1 {
 		t.Fatalf("beta sequences = %#v, want independent per-dispatch ordering", betaEvents)
+	}
+}
+
+func TestFactoryService_SubscribeSessionResponseStream_ReadsRetainedAndLiveEvents(t *testing.T) {
+	sessions := factorysessions.NewRegistry()
+	sessionID := "session-progress-subscribe"
+	sessions.Upsert(factorysessions.NewLiveSession(
+		sessionID,
+		"/factory",
+		"/factory",
+		"/factory",
+		factorysessions.TargetRef{Kind: factorysessions.TargetKindDefault},
+		&liveSessionState{handle: &liveRuntimeHandle{runtime: &factoryRuntimeBundle{}}},
+		false,
+		"factory",
+	), true)
+
+	svc := &FactoryService{sessions: sessions}
+	publisher := svc.inferenceProgressPublisher(sessionID, nil)
+	publisher(workerprovider.ResponseFragment("dispatch-1", nil, "retained-1"))
+	publisher(workerprovider.ProgressFragment("dispatch-1", nil, "retained-2"))
+
+	subscription, err := svc.SubscribeSessionResponseStream(sessionID, "dispatch-1", 0)
+	if err != nil {
+		t.Fatalf("SubscribeSessionResponseStream: %v", err)
+	}
+	defer subscription.Detach()
+
+	initial, err := subscription.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next(initial): %v", err)
+	}
+	if len(initial.Events) != 2 {
+		t.Fatalf("initial event count = %d, want 2", len(initial.Events))
+	}
+
+	publisher(workerprovider.ResponseFragment("dispatch-1", nil, "live-3"))
+	live, err := subscription.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next(live): %v", err)
+	}
+	if len(live.Events) != 1 || live.Events[0].Payload != "live-3" {
+		t.Fatalf("live events = %#v, want one live event", live.Events)
+	}
+}
+
+func TestFactoryService_DispatchCompletionObserverClosesDispatchSubscribers(t *testing.T) {
+	sessions := factorysessions.NewRegistry()
+	sessionID := "session-progress-complete"
+	sessions.Upsert(factorysessions.NewLiveSession(
+		sessionID,
+		"/factory",
+		"/factory",
+		"/factory",
+		factorysessions.TargetRef{Kind: factorysessions.TargetKindDefault},
+		&liveSessionState{handle: &liveRuntimeHandle{runtime: &factoryRuntimeBundle{}}},
+		false,
+		"factory",
+	), true)
+
+	svc := &FactoryService{sessions: sessions}
+	subscription, err := svc.SubscribeSessionResponseStream(sessionID, "dispatch-1", 0)
+	if err != nil {
+		t.Fatalf("SubscribeSessionResponseStream: %v", err)
+	}
+
+	observerFactory := newSessionDispatchCompletionObserverFactory(sessions)
+	if observerFactory == nil {
+		t.Fatal("observer factory = nil, want dispatch completion observer")
+	}
+	observerFactory(sessionID)("dispatch-1")
+
+	if _, err := subscription.Next(context.Background()); !errors.Is(err, responsestream.ErrSubscriptionClosed) {
+		t.Fatalf("Next after dispatch completion error = %v, want ErrSubscriptionClosed", err)
+	}
+	session := sessions.Get(sessionID)
+	if got := svc.sessionResponseStreams(session).SubscriberCount("dispatch-1"); got != 0 {
+		t.Fatalf("subscriber count after dispatch completion = %d, want 0", got)
+	}
+}
+
+func TestFactoryService_StopFactorySession_ClosesSessionResponseStreamSubscribers(t *testing.T) {
+	sessionID := "session-progress-stop"
+	svc := &FactoryService{sessions: factorysessions.NewRegistry()}
+	runDone := make(chan struct{})
+	close(runDone)
+	handle := &liveRuntimeHandle{runDone: runDone, runtime: &factoryRuntimeBundle{}}
+	svc.sessions.Upsert(factorysessions.NewLiveSession(
+		sessionID,
+		"/factory",
+		"/factory",
+		"/factory",
+		factorysessions.TargetRef{Kind: factorysessions.TargetKindDefault},
+		&liveSessionState{handle: handle, responseStreams: factorysessions.NewSessionResponseStreamSetWithFactory(factorysessions.NewSessionResponseStream)},
+		false,
+		"factory",
+	), true)
+
+	subscription, err := svc.SubscribeSessionResponseStream(sessionID, "dispatch-1", 0)
+	if err != nil {
+		t.Fatalf("SubscribeSessionResponseStream: %v", err)
+	}
+
+	if err := svc.stopFactorySession(sessionID); err != nil {
+		t.Fatalf("stopFactorySession: %v", err)
+	}
+	if _, err := subscription.Next(context.Background()); !errors.Is(err, responsestream.ErrSubscriptionClosed) {
+		t.Fatalf("Next after session stop error = %v, want ErrSubscriptionClosed", err)
 	}
 }

--- a/pkg/service/runtime_session_runtime_test.go
+++ b/pkg/service/runtime_session_runtime_test.go
@@ -2640,9 +2640,9 @@ func TestFactoryService_InferenceProgressPublisher_SlowSubscriberCompactionEmits
 }
 
 type slowSubscriberCompactionHarness struct {
-	svc        *FactoryService
-	logger     *zap.Logger
-	observed   *observer.ObservedLogs
+	svc         *FactoryService
+	logger      *zap.Logger
+	observed    *observer.ObservedLogs
 	metricsSink *logging.RuntimeMetricsSink
 }
 
@@ -2824,6 +2824,15 @@ func TestFactoryService_DispatchCompletionObserverClosesDispatchSubscribers(t *t
 	session := sessions.Get(sessionID)
 	if got := svc.sessionResponseStreams(session).SubscriberCount("dispatch-1"); got != 0 {
 		t.Fatalf("subscriber count after dispatch completion = %d, want 0", got)
+	}
+	if _, err := svc.SubscribeSessionResponseStream(sessionID, "dispatch-1", 0); !errors.Is(err, responsestream.ErrSubscriptionClosed) {
+		t.Fatalf("Subscribe after dispatch completion error = %v, want ErrSubscriptionClosed", err)
+	}
+
+	publisher := svc.inferenceProgressPublisher(sessionID, nil)
+	publisher(workerprovider.ResponseFragment("dispatch-1", nil, "late-fragment"))
+	if got := svc.sessionResponseStreams(session).Count(); got != 0 {
+		t.Fatalf("stream count after late publish = %d, want 0", got)
 	}
 }
 

--- a/pkg/service/runtime_sessions.go
+++ b/pkg/service/runtime_sessions.go
@@ -48,6 +48,7 @@ type (
 	FactorySessionOpenResult          = factorysessions.OpenResult
 	liveFactorySession                = factorysessions.LiveSession
 	inferenceProgressPublisherFactory func(sessionID string) workerprovider.InferenceProgressPublisher
+	dispatchCompletionObserverFactory func(sessionID string) func(dispatchID string)
 )
 
 // FactoryCoordinator owns session tracking and runtime lifecycle orchestration.
@@ -233,6 +234,7 @@ func (fs *FactoryService) unregisterLiveSession(sessionID string) {
 	if fs == nil || fs.sessions == nil {
 		return
 	}
+	fs.closeSessionResponseStreams(fs.sessionByID(sessionID))
 	fs.sessions.Remove(sessionID)
 }
 
@@ -795,6 +797,7 @@ func (c *runtimeFactoryCoordinator) replaceSessionRuntime(
 			executionBaseDir = runtimeBaseDir
 		}
 	}
+	fs.closeSessionResponseStreams(session)
 	fs.sessions.Upsert(factorysessions.NewLiveSession(
 		session.ID,
 		replacement.dir,
@@ -1086,6 +1089,25 @@ func (fs *FactoryService) sessionResponseStreams(session *factorysessions.LiveSe
 	return state.responseStreams
 }
 
+func (fs *FactoryService) closeSessionResponseStreams(session *factorysessions.LiveSession) {
+	streams := fs.sessionResponseStreams(session)
+	if streams == nil {
+		return
+	}
+	streams.Close()
+}
+
+func (fs *FactoryService) closeSessionResponseStreamDispatch(
+	session *factorysessions.LiveSession,
+	dispatchID string,
+) bool {
+	streams := fs.sessionResponseStreams(session)
+	if streams == nil {
+		return false
+	}
+	return streams.CloseDispatch(dispatchID)
+}
+
 func (fs *FactoryService) sessionResponseStream(
 	session *factorysessions.LiveSession,
 	dispatchID string,
@@ -1095,6 +1117,25 @@ func (fs *FactoryService) sessionResponseStream(
 		return nil
 	}
 	return streams.Stream(dispatchID)
+}
+
+func (fs *FactoryService) SubscribeSessionResponseStream(
+	sessionID string,
+	dispatchID string,
+	afterSequence int64,
+) (*factorysessions.SessionResponseStreamSubscription, error) {
+	if fs == nil {
+		return nil, fmt.Errorf("factory service is required")
+	}
+	session, err := fs.requireSession(sessionID)
+	if err != nil {
+		return nil, err
+	}
+	streams := fs.sessionResponseStreams(session)
+	if streams == nil {
+		return nil, responsestream.ErrSubscriptionClosed
+	}
+	return streams.Subscribe(dispatchID, afterSequence)
 }
 
 func (fs *FactoryService) newSessionResponseStreamInstance() *factorysessions.SessionResponseStream {
@@ -1133,6 +1174,28 @@ func newInferenceProgressPublisherFactory(
 	svc := &FactoryService{sessions: sessions}
 	return func(sessionID string) workerprovider.InferenceProgressPublisher {
 		return svc.inferenceProgressPublisher(sessionID, logger)
+	}
+}
+
+func newSessionDispatchCompletionObserverFactory(
+	sessions *factorysessions.Registry,
+) dispatchCompletionObserverFactory {
+	if sessions == nil {
+		return nil
+	}
+	svc := &FactoryService{sessions: sessions}
+	return func(sessionID string) func(string) {
+		normalizedSessionID := strings.TrimSpace(sessionID)
+		if normalizedSessionID == "" {
+			normalizedSessionID = defaultFactorySessionID
+		}
+		return func(dispatchID string) {
+			session := sessions.Get(normalizedSessionID)
+			if session == nil && normalizedSessionID == defaultFactorySessionID {
+				session = sessions.Get(defaultFactorySessionID)
+			}
+			svc.closeSessionResponseStreamDispatch(session, dispatchID)
+		}
 	}
 }
 

--- a/pkg/service/runtime_sessions.go
+++ b/pkg/service/runtime_sessions.go
@@ -1075,15 +1075,26 @@ func (fs *FactoryService) javascriptCheckpointStore(session *factorysessions.Liv
 	return state.javascriptCheckpoints
 }
 
-func (fs *FactoryService) sessionResponseStream(session *factorysessions.LiveSession) *factorysessions.SessionResponseStream {
+func (fs *FactoryService) sessionResponseStreams(session *factorysessions.LiveSession) *factorysessions.SessionResponseStreamSet {
 	state := liveSessionRuntimeState(session)
 	if state == nil {
 		return nil
 	}
-	state.responseStreamOnce.Do(func() {
-		state.responseStream = fs.newSessionResponseStreamInstance()
+	state.responseStreamsOnce.Do(func() {
+		state.responseStreams = fs.newSessionResponseStreamSetInstance()
 	})
-	return state.responseStream
+	return state.responseStreams
+}
+
+func (fs *FactoryService) sessionResponseStream(
+	session *factorysessions.LiveSession,
+	dispatchID string,
+) *factorysessions.SessionResponseStream {
+	streams := fs.sessionResponseStreams(session)
+	if streams == nil {
+		return nil
+	}
+	return streams.Stream(dispatchID)
 }
 
 func (fs *FactoryService) newSessionResponseStreamInstance() *factorysessions.SessionResponseStream {
@@ -1091,6 +1102,12 @@ func (fs *FactoryService) newSessionResponseStreamInstance() *factorysessions.Se
 		return fs.newSessionResponseStream()
 	}
 	return factorysessions.NewSessionResponseStream()
+}
+
+func (fs *FactoryService) newSessionResponseStreamSetInstance() *factorysessions.SessionResponseStreamSet {
+	return factorysessions.NewSessionResponseStreamSetWithFactory(func() *factorysessions.SessionResponseStream {
+		return fs.newSessionResponseStreamInstance()
+	})
 }
 
 func mapInferenceProgressFragment(fragment workerprovider.InferenceProgressFragment) responsestream.Event {
@@ -1136,7 +1153,7 @@ func (fs *FactoryService) inferenceProgressPublisher(
 		if session == nil && normalizedSessionID == defaultFactorySessionID {
 			session = sessions.Get(defaultFactorySessionID)
 		}
-		stream := fs.sessionResponseStream(session)
+		stream := fs.sessionResponseStream(session, fragment.DispatchID)
 		if stream == nil {
 			if logger != nil {
 				logger.Warn("session response stream unavailable; dropping internal provider progress",

--- a/pkg/workers/provider/provider_behavior_test.go
+++ b/pkg/workers/provider/provider_behavior_test.go
@@ -895,3 +895,30 @@ func TestInferenceProgressPublishingCommandRunner_PublishesOrderedFragments(t *t
 		t.Fatalf("published fragments = %#v, want both response and progress kinds", published)
 	}
 }
+
+func TestInferenceProgressPublishingCommandRunner_WithoutPublisherPreservesExecBehavior(t *testing.T) {
+	t.Parallel()
+
+	scriptPath := filepath.Join(t.TempDir(), "nostream.sh")
+	script := "#!/bin/sh\necho stdout-fallback\necho stderr-fallback 1>&2\nexit 7\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	runner := NewInferenceProgressPublishingCommandRunner(nil, nil)
+	result, err := runner.Run(context.Background(), CommandRequest{
+		Command: scriptPath,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 7 {
+		t.Fatalf("exit code = %d, want 7", result.ExitCode)
+	}
+	if !strings.Contains(string(result.Stdout), "stdout-fallback") {
+		t.Fatalf("stdout = %q, want stdout-fallback", result.Stdout)
+	}
+	if !strings.Contains(string(result.Stderr), "stderr-fallback") {
+		t.Fatalf("stderr = %q, want stderr-fallback", result.Stderr)
+	}
+}


### PR DESCRIPTION
{
  "project": "you-agent-factory",
  "branchName": "you-goal-p13-add-session-stream-runtime-plumbing",
  "description": "Connect the merged internal session response-stream model to live Factory Session runtime ownership so active sessions can publish and subscribe to transient response-stream events without affecting canonical factory replay, public API contracts, or existing non-streaming execution behavior.",
  "context": {
    "customerAsk": "Connect the merged P12 internal response stream model to live Factory Session runtime ownership so active sessions can publish and subscribe to internal response stream events without affecting canonical factory replay. Runtime ownership must stay at the live session boundary, provider or runner execution must publish without importing public API handler packages, subscribers must attach and detach by session and dispatch identity without leaks, slow subscribers must not stall dispatch progress, and tests must prove publication, subscription, detach, cleanup, and no-public-event-emission behavior while existing non-streaming workers keep current behavior.",
    "problem": "P12 defined the bounded internal SessionResponseStream model, but live Factory Session runtimes still need concrete ownership and delivery plumbing. Without that plumbing, provider and runner integrations risk storing per-session stream state on the service coordinator, coupling execution code to public API packages, leaking subscriber resources, or blocking dispatch progress under slow-consumer pressure while replay and projection boundaries become harder to defend.",
    "solution": "Add session-runtime-owned response-stream plumbing that is created and cleaned up with each active Factory Session, exposes an internal publication seam for provider and runner execution, supports dispatch-scoped subscriber attach and detach while the session is active, preserves P12 bounded truncation and compaction semantics under backpressure, and keeps raw response-stream deltas out of canonical factory replay, public events, and generated clients."
  },
  "acceptanceCriteria": [
    "Each live Factory Session runtime owns the internal response-stream registry or buffer set for its own active session rather than storing it on FactoryService coordinator state or canonical replay state.",
    "Provider or runner execution code can publish internal SessionResponseStreamEvent records to the owning active session through an internal runtime seam without importing public API handler packages.",
    "Internal subscribers can attach by session and dispatch identity while a session is active, receive retained and live internal stream data in documented order, and detach without leaking goroutines, channels, or retained references.",
    "Slow, absent, or blocked subscribers cannot stall dispatch progress indefinitely; bounded loss, truncation, and compaction semantics from P12 remain the only degradation path under pressure.",
    "Session shutdown cleans up stream subscribers and runtime-owned stream state predictably, and post-close publication or subscription attempts fail or no-op with documented internal behavior rather than retaining live resources.",
    "Canonical factory replay, world-state projections, public FactoryEventType values, OpenAPI schemas, and generated clients remain unchanged because raw response-stream deltas stay non-canonical.",
    "Existing non-streaming providers and workers continue to behave exactly as before when no internal response-stream events are published.",
    "Quality gate: typecheck, lint, and relevant tests pass before merge."
  ],
  "userStories": [
    {
      "id": "you-goal-p13-add-session-stream-runtime-plumbing-001",
      "title": "Own session streams at the live runtime boundary",
      "description": "As a maintainer wiring live Factory Session execution, I want the active session runtime to own its internal response-stream registry and publication seam so that provider and runner code can publish progress without moving per-session state into the service coordinator or public API layers.",
      "acceptanceCriteria": [
        "A live Factory Session allocates and owns its internal response-stream runtime state for the life of the active session.",
        "Provider or runner execution can publish SessionResponseStreamEvent records to the owning session through an internal runtime-facing interface or handle rather than importing API handler packages.",
        "Publication targets one active session and one dispatch or response-stream identity at a time, with enough routing metadata to keep concurrent dispatch streams separated.",
        "This story introduces no new public REST endpoint, OpenAPI schema, generated client type, or FactoryEventType value for raw response-stream deltas.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "you-goal-p13-add-session-stream-runtime-plumbing-002",
      "title": "Let internal subscribers attach and detach by dispatch without leaks",
      "description": "As an internal consumer of active-session progress, I want to subscribe to one session and dispatch stream while it is active and detach cleanly so that CLI or runtime-local observers can read transient progress without leaking resources after completion or disconnect.",
      "acceptanceCriteria": [
        "Internal subscribers can attach to a live session by session identity plus dispatch or response-stream identity and receive the retained stream window plus subsequent live events in documented order.",
        "Multiple subscribers can observe the same active dispatch stream independently without mutating canonical session state.",
        "Detaching a subscriber releases its runtime-owned channel or callback registration and stops further delivery to that subscriber.",
        "Session closure or dispatch completion releases subscriber references and does not leave orphaned goroutines, blocked send loops, or retained subscriber state.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "you-goal-p13-add-session-stream-runtime-plumbing-003",
      "title": "Preserve bounded non-blocking delivery under subscriber backpressure",
      "description": "As an operator of long-running or noisy sessions, I want slow stream subscribers to degrade through the bounded P12 retention rules instead of blocking dispatch execution so that internal progress remains useful without harming runtime throughput or stability.",
      "acceptanceCriteria": [
        "A slow, paused, or absent subscriber cannot block provider or runner publication indefinitely or prevent dispatch progress from completing.",
        "Under subscriber backpressure, the runtime uses the existing bounded retention, truncation, or compaction semantics from P12 instead of introducing unbounded queues or per-subscriber growth.",
        "Subscribers can detect bounded fidelity loss through documented internal behavior such as retained-window replay, truncation markers, or equivalent gap signaling already defined by the stream model.",
        "Publication and delivery paths emit diagnosable internal logging or metrics when subscriber pressure causes drops, truncation, or compaction.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "you-goal-p13-add-session-stream-runtime-plumbing-004",
      "title": "Prove non-canonical boundaries and compatibility behavior",
      "description": "As a reviewer protecting replay and existing execution paths, I want regression coverage that proves internal session streams stay transient and optional so that replay, projections, and non-streaming providers keep their current behavior.",
      "acceptanceCriteria": [
        "Tests prove publication, subscription, detach, and session-close cleanup behavior with reviewer-verifiable assertions.",
        "Tests prove raw response-stream deltas do not emit canonical factory events and are not required by factory replay or world-state projection tests.",
        "SESSION_RESULT_UPDATED and existing dispatch lifecycle events remain the durable public result trail for partial or final result visibility.",
        "Existing non-streaming providers and workers continue to execute with unchanged observable behavior when internal stream publication is unused.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}
