### PR TITLE
dynamic-workflows-cell-website-event-replay

### DIFF
--- a/ui/src/api/factory-sessions/event-replay.test.ts
+++ b/ui/src/api/factory-sessions/event-replay.test.ts
@@ -1,0 +1,84 @@
+import { FACTORY_EVENT_TYPES } from "../events";
+import {
+  listFactorySessionEventReplay,
+  parseFactoryEventReplayStream,
+} from "./event-replay";
+
+describe("factory session event replay API", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("parses a durable factory session replay stream into ordered Factory Events", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        [
+          "event: message",
+          'data: {"id":"evt-1","type":"SESSION_STARTED","context":{"sequence":1,"tick":1,"eventTime":"2026-06-25T10:00:00Z","sessionId":"dur-sess-js-success-002","sessionSequence":1},"payload":{"startedAt":"2026-06-25T10:00:00Z"}}',
+          "",
+          'data: {"id":"evt-2","type":"DISPATCH_QUEUED","context":{"sequence":2,"tick":2,"eventTime":"2026-06-25T10:00:02Z","sessionId":"dur-sess-js-success-002","sessionSequence":2,"dispatchId":"dispatch-1"},"payload":{"dispatchKind":"JAVASCRIPT_AGENT"}}',
+          "",
+        ].join("\n"),
+        {
+          headers: {
+            "Content-Type": "text/event-stream",
+          },
+          status: 200,
+        },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      listFactorySessionEventReplay("dur-sess-js-success-002"),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: "evt-1",
+        type: FACTORY_EVENT_TYPES.sessionStarted,
+      }),
+      expect.objectContaining({
+        id: "evt-2",
+        type: FACTORY_EVENT_TYPES.dispatchQueued,
+      }),
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/factory-sessions/dur-sess-js-success-002/events",
+      expect.objectContaining({
+        headers: { Accept: "text/event-stream" },
+        method: "GET",
+      }),
+    );
+  });
+
+  it("skips non-message SSE blocks and returns an empty event list for sparse history", () => {
+    expect(
+      parseFactoryEventReplayStream(
+        [
+          ": keepalive",
+          "",
+          "event: ping",
+          "data: ignored",
+          "",
+        ].join("\n"),
+      ),
+    ).toEqual([]);
+  });
+
+  it("rejects malformed Factory Event payloads", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("data: {\"id\":\"evt-1\"}\n\n", {
+        headers: {
+          "Content-Type": "text/event-stream",
+        },
+        status: 200,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      listFactorySessionEventReplay("dur-sess-js-success-002"),
+    ).rejects.toMatchObject({
+      message: "The factory sessions API returned an invalid response.",
+    });
+  });
+});

--- a/ui/src/api/factory-sessions/event-replay.test.ts
+++ b/ui/src/api/factory-sessions/event-replay.test.ts
@@ -1,5 +1,9 @@
 import { FACTORY_EVENT_TYPES } from "../events";
 import {
+  buildSuccessfulReplayEventStream,
+  successfulReplaySessionID,
+} from "../../testing/factory-session-event-replay-fixtures";
+import {
   listFactorySessionEventReplay,
   parseFactoryEventReplayStream,
 } from "./event-replay";
@@ -11,38 +15,40 @@ describe("factory session event replay API", () => {
 
   it("parses a durable factory session replay stream into ordered Factory Events", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
-      new Response(
-        [
-          "event: message",
-          'data: {"id":"evt-1","type":"SESSION_STARTED","context":{"sequence":1,"tick":1,"eventTime":"2026-06-25T10:00:00Z","sessionId":"dur-sess-js-success-002","sessionSequence":1},"payload":{"startedAt":"2026-06-25T10:00:00Z"}}',
-          "",
-          'data: {"id":"evt-2","type":"DISPATCH_QUEUED","context":{"sequence":2,"tick":2,"eventTime":"2026-06-25T10:00:02Z","sessionId":"dur-sess-js-success-002","sessionSequence":2,"dispatchId":"dispatch-1"},"payload":{"dispatchKind":"JAVASCRIPT_AGENT"}}',
-          "",
-        ].join("\n"),
-        {
-          headers: {
-            "Content-Type": "text/event-stream",
-          },
-          status: 200,
+      new Response(buildSuccessfulReplayEventStream(successfulReplaySessionID), {
+        headers: {
+          "Content-Type": "text/event-stream",
         },
-      ),
+        status: 200,
+      }),
     );
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(
-      listFactorySessionEventReplay("dur-sess-js-success-002"),
-    ).resolves.toEqual([
-      expect.objectContaining({
-        id: "evt-1",
-        type: FACTORY_EVENT_TYPES.sessionStarted,
-      }),
-      expect.objectContaining({
-        id: "evt-2",
-        type: FACTORY_EVENT_TYPES.dispatchQueued,
-      }),
-    ]);
+    const events = await listFactorySessionEventReplay(successfulReplaySessionID);
+
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "evt-1",
+          type: FACTORY_EVENT_TYPES.sessionStarted,
+        }),
+        expect.objectContaining({
+          id: "evt-2",
+          type: FACTORY_EVENT_TYPES.orchestratorPhaseChanged,
+        }),
+        expect.objectContaining({
+          id: "evt-3",
+          type: FACTORY_EVENT_TYPES.dispatchQueued,
+        }),
+      ]),
+    );
+    expect(events).toHaveLength(5);
+    expect(events[0]).toMatchObject({
+      id: "evt-1",
+      type: FACTORY_EVENT_TYPES.sessionStarted,
+    });
     expect(fetchMock).toHaveBeenCalledWith(
-      "/factory-sessions/dur-sess-js-success-002/events",
+      `/factory-sessions/${successfulReplaySessionID}/events`,
       expect.objectContaining({
         headers: { Accept: "text/event-stream" },
         method: "GET",
@@ -76,7 +82,7 @@ describe("factory session event replay API", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(
-      listFactorySessionEventReplay("dur-sess-js-success-002"),
+      listFactorySessionEventReplay(successfulReplaySessionID),
     ).rejects.toMatchObject({
       message: "The factory sessions API returned an invalid response.",
     });

--- a/ui/src/api/factory-sessions/event-replay.test.ts
+++ b/ui/src/api/factory-sessions/event-replay.test.ts
@@ -1,7 +1,16 @@
 import { FACTORY_EVENT_TYPES } from "../events";
 import {
+  awaitingReplaySessionID,
+  buildAwaitingDurableSession,
+  buildAwaitingReplayEventStream,
+  buildSuccessfulDurableSession,
+  buildSuccessfulReplayDispatchList,
   buildSuccessfulReplayEventStream,
+  buildWarningDurableSession,
+  buildWarningReplayDispatchList,
+  buildWarningReplayEventStream,
   successfulReplaySessionID,
+  warningReplaySessionID,
 } from "../../testing/factory-session-event-replay-fixtures";
 import {
   listFactorySessionEventReplay,
@@ -85,6 +94,79 @@ describe("factory session event replay API", () => {
       listFactorySessionEventReplay(successfulReplaySessionID),
     ).rejects.toMatchObject({
       message: "The factory sessions API returned an invalid response.",
+    });
+  });
+});
+
+describe("factory session event replay shared fixtures", () => {
+  it("parses warning and awaiting durable replay fixtures into ordered Factory Events", () => {
+    expect(parseFactoryEventReplayStream(buildWarningReplayEventStream())).toEqual([
+      expect.objectContaining({
+        id: "evt-w1",
+        type: "JAVASCRIPT_CHECKPOINT_REF",
+      }),
+      expect.objectContaining({
+        id: "evt-w2",
+        type: FACTORY_EVENT_TYPES.dispatchInterrupted,
+      }),
+      expect.objectContaining({
+        id: "evt-w3",
+        type: FACTORY_EVENT_TYPES.sessionCompleted,
+      }),
+    ]);
+
+    expect(parseFactoryEventReplayStream(buildAwaitingReplayEventStream())).toEqual([
+      expect.objectContaining({
+        context: expect.objectContaining({ sessionId: awaitingReplaySessionID }),
+        id: "session-started/dur-sess-js-awaiting-001",
+        type: FACTORY_EVENT_TYPES.sessionStarted,
+      }),
+      expect.objectContaining({
+        context: expect.objectContaining({ sessionId: awaitingReplaySessionID }),
+        id: "session-result-updated/dur-sess-js-awaiting-001",
+        type: FACTORY_EVENT_TYPES.sessionResultUpdated,
+      }),
+    ]);
+  });
+
+  it("keeps the shared durable session and dispatch fixtures aligned to their session ids", () => {
+    expect(buildSuccessfulDurableSession()).toMatchObject({
+      orchestratorKind: "JAVASCRIPT",
+      progress: expect.objectContaining({ totalDispatches: 2 }),
+      sessionId: successfulReplaySessionID,
+      status: "SUCCEEDED",
+    });
+    expect(buildWarningDurableSession()).toMatchObject({
+      orchestratorKind: "JAVASCRIPT",
+      progress: expect.objectContaining({ failedDispatches: 1 }),
+      sessionId: warningReplaySessionID,
+      status: "FAILED",
+    });
+    expect(buildAwaitingDurableSession()).toMatchObject({
+      orchestratorKind: "JAVASCRIPT",
+      resultSummary: expect.objectContaining({ resultStatus: "NOT_READY" }),
+      sessionId: awaitingReplaySessionID,
+      status: "AWAITING_APPROVAL",
+    });
+    expect(buildSuccessfulReplayDispatchList()).toEqual({
+      dispatches: [
+        expect.objectContaining({
+          id: "dispatch-1",
+          phase: "review",
+          status: "COMPLETED",
+        }),
+      ],
+      sessionId: successfulReplaySessionID,
+    });
+    expect(buildWarningReplayDispatchList()).toEqual({
+      dispatches: [
+        expect.objectContaining({
+          id: "dispatch-verify",
+          phase: "verify",
+          status: "FAILED",
+        }),
+      ],
+      sessionId: warningReplaySessionID,
     });
   });
 });

--- a/ui/src/api/factory-sessions/event-replay.ts
+++ b/ui/src/api/factory-sessions/event-replay.ts
@@ -1,0 +1,124 @@
+import { FACTORY_EVENTS_ENDPOINT, type FactoryEvent } from "../events";
+import { factoryAPIURL } from "../baseUrl";
+import { factorySessionScopedPath } from "../session-routing";
+import { readAPIResponseBody } from "../transport";
+import {
+  buildFactorySessionsAPIError,
+  FactorySessionsAPIError,
+} from "./api";
+
+export interface ListFactorySessionEventReplayOptions {
+  fetch?: typeof globalThis.fetch;
+}
+
+export async function listFactorySessionEventReplay(
+  sessionID: string,
+  options: ListFactorySessionEventReplayOptions = {},
+): Promise<FactoryEvent[]> {
+  const fetchImplementation = options.fetch ?? globalThis.fetch;
+  if (typeof fetchImplementation !== "function") {
+    throw new FactorySessionsAPIError(
+      "Factory sessions are unavailable in this environment.",
+      {
+        code: "NETWORK_ERROR",
+      },
+    );
+  }
+
+  let response: Response;
+  try {
+    response = await fetchImplementation(
+      factoryAPIURL(factorySessionScopedPath(FACTORY_EVENTS_ENDPOINT, sessionID)),
+      {
+        headers: {
+          Accept: "text/event-stream",
+        },
+        method: "GET",
+      },
+    );
+  } catch (error) {
+    throw new FactorySessionsAPIError(
+      "The dashboard could not reach the factory sessions API.",
+      {
+        code: "NETWORK_ERROR",
+        responseBody: error,
+      },
+    );
+  }
+
+  if (!response.ok) {
+    const responseBody = await readAPIResponseBody(response);
+    throw buildFactorySessionsAPIError(
+      response,
+      responseBody,
+      "The factory sessions API rejected the request.",
+    );
+  }
+
+  const replayStream = await response.text();
+  try {
+    return parseFactoryEventReplayStream(replayStream);
+  } catch (error) {
+    throw new FactorySessionsAPIError(
+      "The factory sessions API returned an invalid response.",
+      {
+        code: "INTERNAL_ERROR",
+        responseBody: error,
+        status: response.status,
+        statusText: response.statusText,
+      },
+    );
+  }
+}
+
+export function parseFactoryEventReplayStream(replayStream: string): FactoryEvent[] {
+  const events: FactoryEvent[] = [];
+  const normalized = replayStream.replace(/\r\n/g, "\n");
+  for (const block of normalized.split("\n\n")) {
+    const parsed = parseReplayEventBlock(block);
+    if (parsed) {
+      events.push(parsed);
+    }
+  }
+  return events;
+}
+
+function parseReplayEventBlock(block: string): FactoryEvent | null {
+  const lines = block
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0 && !line.startsWith(":"));
+  if (lines.length === 0) {
+    return null;
+  }
+
+  const dataLines: string[] = [];
+  let eventType = "message";
+  for (const line of lines) {
+    if (line.startsWith("event:")) {
+      eventType = line.slice("event:".length).trim();
+      continue;
+    }
+    if (line.startsWith("data:")) {
+      dataLines.push(line.slice("data:".length).trimStart());
+    }
+  }
+
+  if (eventType !== "message" || dataLines.length === 0) {
+    return null;
+  }
+
+  const candidate = JSON.parse(dataLines.join("\n")) as Partial<FactoryEvent>;
+  if (
+    typeof candidate.id !== "string" ||
+    typeof candidate.type !== "string" ||
+    typeof candidate.context !== "object" ||
+    candidate.context === null ||
+    typeof candidate.payload !== "object" ||
+    candidate.payload === null
+  ) {
+    throw new Error("invalid factory event replay payload");
+  }
+
+  return candidate as FactoryEvent;
+}

--- a/ui/src/api/factory-sessions/index.ts
+++ b/ui/src/api/factory-sessions/index.ts
@@ -1,2 +1,3 @@
 export * from "./api";
 export * from "./api-durable-inspection";
+export * from "./event-replay";

--- a/ui/src/features/factory-session-detail/components/event-replay/factory-session-detail-panel.event-replay.states.test.tsx
+++ b/ui/src/features/factory-session-detail/components/event-replay/factory-session-detail-panel.event-replay.states.test.tsx
@@ -2,9 +2,15 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { FactoryOrchestratorKind } from "../../../../api/generated/openapi";
+import {
+  buildSuccessfulDurableSession,
+  buildWarningDurableSession,
+  successfulReplaySessionID,
+  warningReplaySessionID,
+} from "../../../../testing/factory-session-event-replay-fixtures";
 import { FactorySessionDetailPanel } from "../factory-session-detail-panel";
 import {
+  createDeferred,
   jsonResponse,
   renderWithQueryClient,
 } from "../factory-session-detail-panel.test-helpers";
@@ -19,26 +25,21 @@ describe("FactorySessionDetailPanel event replay disclosure loading and empty st
   });
 
   it("renders an explicit loading state while durable replay is being read", async () => {
-    let resolveReplayResponse: ((value: Response) => void) | undefined;
-    const replayResponse = new Promise<Response>((resolve) => {
-      resolveReplayResponse = resolve;
-    });
+    const replayResponse = createDeferred<Response>();
 
     vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
       const url = String(input);
-      if (url.endsWith("/factory-sessions/dur-sess-js-success-002")) {
-        return jsonResponse(
-          buildSuccessfulDurableSession("dur-sess-js-success-002"),
-        );
+      if (url.endsWith(`/factory-sessions/${successfulReplaySessionID}`)) {
+        return jsonResponse(buildSuccessfulDurableSession());
       }
-      if (url.endsWith("/factory-sessions/dur-sess-js-success-002/events")) {
-        return replayResponse;
+      if (url.endsWith(`/factory-sessions/${successfulReplaySessionID}/events`)) {
+        return replayResponse.promise;
       }
       return new Response("not found", { status: 404 });
     });
 
     renderWithQueryClient(
-      <FactorySessionDetailPanel sessionID="dur-sess-js-success-002" />,
+      <FactorySessionDetailPanel sessionID={successfulReplaySessionID} />,
     );
 
     await waitFor(() => {
@@ -56,7 +57,7 @@ describe("FactorySessionDetailPanel event replay disclosure loading and empty st
       ).toBeTruthy();
     });
 
-    resolveReplayResponse?.(
+    replayResponse.resolve(
       new Response("", {
         headers: {
           "Content-Type": "text/event-stream",
@@ -77,12 +78,10 @@ describe("FactorySessionDetailPanel event replay disclosure loading and empty st
   it("renders an explicit empty state when durable replay has no events in scope", async () => {
     vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
       const url = String(input);
-      if (url.endsWith("/factory-sessions/dur-sess-js-success-002")) {
-        return jsonResponse(
-          buildSuccessfulDurableSession("dur-sess-js-success-002"),
-        );
+      if (url.endsWith(`/factory-sessions/${successfulReplaySessionID}`)) {
+        return jsonResponse(buildSuccessfulDurableSession());
       }
-      if (url.endsWith("/factory-sessions/dur-sess-js-success-002/events")) {
+      if (url.endsWith(`/factory-sessions/${successfulReplaySessionID}/events`)) {
         return new Response(
           [": keepalive", "", "event: ping", "data: ignored", ""].join("\n"),
           {
@@ -97,7 +96,7 @@ describe("FactorySessionDetailPanel event replay disclosure loading and empty st
     });
 
     renderWithQueryClient(
-      <FactorySessionDetailPanel sessionID="dur-sess-js-success-002" />,
+      <FactorySessionDetailPanel sessionID={successfulReplaySessionID} />,
     );
 
     await waitFor(() => {
@@ -131,19 +130,17 @@ describe("FactorySessionDetailPanel event replay disclosure unavailable and erro
   it("renders an explicit unavailable state when durable replay is omitted for the session", async () => {
     vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
       const url = String(input);
-      if (url.endsWith("/factory-sessions/dur-sess-js-warning-003")) {
-        return jsonResponse(
-          buildWarningDurableSession("dur-sess-js-warning-003"),
-        );
+      if (url.endsWith(`/factory-sessions/${warningReplaySessionID}`)) {
+        return jsonResponse(buildWarningDurableSession());
       }
-      if (url.endsWith("/factory-sessions/dur-sess-js-warning-003/events")) {
+      if (url.endsWith(`/factory-sessions/${warningReplaySessionID}/events`)) {
         return new Response("not found", { status: 404 });
       }
       return new Response("not found", { status: 404 });
     });
 
     renderWithQueryClient(
-      <FactorySessionDetailPanel sessionID="dur-sess-js-warning-003" />,
+      <FactorySessionDetailPanel sessionID={warningReplaySessionID} />,
     );
 
     await waitFor(() => {
@@ -169,12 +166,10 @@ describe("FactorySessionDetailPanel event replay disclosure unavailable and erro
   it("renders an explicit error state when the durable replay read fails", async () => {
     vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
       const url = String(input);
-      if (url.endsWith("/factory-sessions/dur-sess-js-warning-003")) {
-        return jsonResponse(
-          buildWarningDurableSession("dur-sess-js-warning-003"),
-        );
+      if (url.endsWith(`/factory-sessions/${warningReplaySessionID}`)) {
+        return jsonResponse(buildWarningDurableSession());
       }
-      if (url.endsWith("/factory-sessions/dur-sess-js-warning-003/events")) {
+      if (url.endsWith(`/factory-sessions/${warningReplaySessionID}/events`)) {
         return new Response(
           JSON.stringify({
             code: "INTERNAL_ERROR",
@@ -190,7 +185,7 @@ describe("FactorySessionDetailPanel event replay disclosure unavailable and erro
     });
 
     renderWithQueryClient(
-      <FactorySessionDetailPanel sessionID="dur-sess-js-warning-003" />,
+      <FactorySessionDetailPanel sessionID={warningReplaySessionID} />,
     );
 
     await waitFor(() => {
@@ -209,85 +204,3 @@ describe("FactorySessionDetailPanel event replay disclosure unavailable and erro
     expect(screen.getByText("Artifacts")).toBeTruthy();
   });
 });
-
-function buildSuccessfulDurableSession(sessionId: string) {
-  return {
-    artifactRefs: [
-      {
-        id: "art-js-success-001",
-        kind: "FINAL_RESULT",
-        label: "Docs refresh output",
-        visibility: "PUBLIC",
-      },
-    ],
-    dialect: "you-workflow-v1",
-    lifecycle: {
-      finishedAt: "2026-06-08T13:10:00Z",
-      startedAt: "2026-06-08T13:00:02Z",
-    },
-    orchestratorKind: FactoryOrchestratorKind.JAVASCRIPT,
-    progress: {
-      completedDispatches: 0,
-      failedDispatches: 0,
-      inFlightDispatches: 0,
-      totalDispatches: 0,
-    },
-    resolvedSource: {
-      kind: "WORKFLOW_FILE",
-      sourceRef: "workflow/.claude/workflows/docs-refresh.yaml",
-      sourceHash: "sha256:js-workflow-docs-refresh",
-    },
-    resultSummary: {
-      resultStatus: "FINAL",
-      summary: "Documentation refresh complete.",
-    },
-    sessionId,
-    status: "SUCCEEDED",
-    usage: { resources: [] },
-  };
-}
-
-function buildWarningDurableSession(sessionId: string) {
-  return {
-    artifactRefs: [
-      {
-        id: "artifact-release-verification-log",
-        kind: "FINAL_RESULT",
-        label: "Release verification log",
-        visibility: "PRIVATE",
-      },
-    ],
-    dialect: "you-workflow-v1",
-    lifecycle: {
-      finishedAt: "2026-06-25T11:10:00Z",
-      startedAt: "2026-06-25T11:00:00Z",
-    },
-    orchestratorKind: FactoryOrchestratorKind.JAVASCRIPT,
-    progress: {
-      completedDispatches: 0,
-      failedDispatches: 1,
-      inFlightDispatches: 0,
-      totalDispatches: 1,
-    },
-    resolvedSource: {
-      kind: "WORKFLOW_FILE",
-      sourceRef: "workflow/.claude/workflows/release-verify.yaml",
-      sourceHash: "sha256:release-verify",
-    },
-    resultSummary: {
-      artifactRefs: [
-        {
-          id: "artifact-release-verification-log",
-          kind: "FINAL_RESULT",
-          label: "Release verification log",
-          visibility: "PRIVATE",
-        },
-      ],
-      resultStatus: "FAILED_WITH_PARTIAL",
-      summary: "Release verification failed after checkpoint recovery.",
-    },
-    sessionId,
-    status: "FAILED",
-    usage: { resources: [] },
-  };
-}

--- a/ui/src/features/factory-session-detail/components/event-replay/factory-session-detail-panel.event-replay.states.test.tsx
+++ b/ui/src/features/factory-session-detail/components/event-replay/factory-session-detail-panel.event-replay.states.test.tsx
@@ -1,0 +1,293 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { FactoryOrchestratorKind } from "../../../../api/generated/openapi";
+import { FactorySessionDetailPanel } from "../factory-session-detail-panel";
+import {
+  jsonResponse,
+  renderWithQueryClient,
+} from "../factory-session-detail-panel.test-helpers";
+
+describe("FactorySessionDetailPanel event replay disclosure loading and empty states", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders an explicit loading state while durable replay is being read", async () => {
+    let resolveReplayResponse: ((value: Response) => void) | undefined;
+    const replayResponse = new Promise<Response>((resolve) => {
+      resolveReplayResponse = resolve;
+    });
+
+    vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/factory-sessions/dur-sess-js-success-002")) {
+        return jsonResponse(
+          buildSuccessfulDurableSession("dur-sess-js-success-002"),
+        );
+      }
+      if (url.endsWith("/factory-sessions/dur-sess-js-success-002/events")) {
+        return replayResponse;
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    renderWithQueryClient(
+      <FactorySessionDetailPanel sessionID="dur-sess-js-success-002" />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("JavaScript workflow")).toBeTruthy();
+    });
+
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole("button", { name: "Expand Factory Event replay" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Loading durable Factory Event replay…"),
+      ).toBeTruthy();
+    });
+
+    resolveReplayResponse?.(
+      new Response("", {
+        headers: {
+          "Content-Type": "text/event-stream",
+        },
+        status: 200,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "No durable Factory Events are available for this session.",
+        ),
+      ).toBeTruthy();
+    });
+  });
+
+  it("renders an explicit empty state when durable replay has no events in scope", async () => {
+    vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/factory-sessions/dur-sess-js-success-002")) {
+        return jsonResponse(
+          buildSuccessfulDurableSession("dur-sess-js-success-002"),
+        );
+      }
+      if (url.endsWith("/factory-sessions/dur-sess-js-success-002/events")) {
+        return new Response(
+          [": keepalive", "", "event: ping", "data: ignored", ""].join("\n"),
+          {
+            headers: {
+              "Content-Type": "text/event-stream",
+            },
+            status: 200,
+          },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    renderWithQueryClient(
+      <FactorySessionDetailPanel sessionID="dur-sess-js-success-002" />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("JavaScript workflow")).toBeTruthy();
+    });
+
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole("button", { name: "Expand Factory Event replay" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "No durable Factory Events are available for this session.",
+        ),
+      ).toBeTruthy();
+    });
+  });
+});
+
+describe("FactorySessionDetailPanel event replay disclosure unavailable and error states", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders an explicit unavailable state when durable replay is omitted for the session", async () => {
+    vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/factory-sessions/dur-sess-js-warning-003")) {
+        return jsonResponse(
+          buildWarningDurableSession("dur-sess-js-warning-003"),
+        );
+      }
+      if (url.endsWith("/factory-sessions/dur-sess-js-warning-003/events")) {
+        return new Response("not found", { status: 404 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    renderWithQueryClient(
+      <FactorySessionDetailPanel sessionID="dur-sess-js-warning-003" />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("JavaScript workflow")).toBeTruthy();
+    });
+
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole("button", { name: "Expand Factory Event replay" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Durable Factory Event replay is unavailable for this session.",
+        ),
+      ).toBeTruthy();
+    });
+
+    expect(screen.getByText("Partial result ref")).toBeTruthy();
+  });
+
+  it("renders an explicit error state when the durable replay read fails", async () => {
+    vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/factory-sessions/dur-sess-js-warning-003")) {
+        return jsonResponse(
+          buildWarningDurableSession("dur-sess-js-warning-003"),
+        );
+      }
+      if (url.endsWith("/factory-sessions/dur-sess-js-warning-003/events")) {
+        return new Response(
+          JSON.stringify({
+            code: "INTERNAL_ERROR",
+            message: "replay boom",
+          }),
+          {
+            headers: { "Content-Type": "application/json" },
+            status: 500,
+          },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    renderWithQueryClient(
+      <FactorySessionDetailPanel sessionID="dur-sess-js-warning-003" />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("JavaScript workflow")).toBeTruthy();
+    });
+
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole("button", { name: "Expand Factory Event replay" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("replay boom")).toBeTruthy();
+    });
+
+    expect(screen.getByText("Artifacts")).toBeTruthy();
+  });
+});
+
+function buildSuccessfulDurableSession(sessionId: string) {
+  return {
+    artifactRefs: [
+      {
+        id: "art-js-success-001",
+        kind: "FINAL_RESULT",
+        label: "Docs refresh output",
+        visibility: "PUBLIC",
+      },
+    ],
+    dialect: "you-workflow-v1",
+    lifecycle: {
+      finishedAt: "2026-06-08T13:10:00Z",
+      startedAt: "2026-06-08T13:00:02Z",
+    },
+    orchestratorKind: FactoryOrchestratorKind.JAVASCRIPT,
+    progress: {
+      completedDispatches: 0,
+      failedDispatches: 0,
+      inFlightDispatches: 0,
+      totalDispatches: 0,
+    },
+    resolvedSource: {
+      kind: "WORKFLOW_FILE",
+      sourceRef: "workflow/.claude/workflows/docs-refresh.yaml",
+      sourceHash: "sha256:js-workflow-docs-refresh",
+    },
+    resultSummary: {
+      resultStatus: "FINAL",
+      summary: "Documentation refresh complete.",
+    },
+    sessionId,
+    status: "SUCCEEDED",
+    usage: { resources: [] },
+  };
+}
+
+function buildWarningDurableSession(sessionId: string) {
+  return {
+    artifactRefs: [
+      {
+        id: "artifact-release-verification-log",
+        kind: "FINAL_RESULT",
+        label: "Release verification log",
+        visibility: "PRIVATE",
+      },
+    ],
+    dialect: "you-workflow-v1",
+    lifecycle: {
+      finishedAt: "2026-06-25T11:10:00Z",
+      startedAt: "2026-06-25T11:00:00Z",
+    },
+    orchestratorKind: FactoryOrchestratorKind.JAVASCRIPT,
+    progress: {
+      completedDispatches: 0,
+      failedDispatches: 1,
+      inFlightDispatches: 0,
+      totalDispatches: 1,
+    },
+    resolvedSource: {
+      kind: "WORKFLOW_FILE",
+      sourceRef: "workflow/.claude/workflows/release-verify.yaml",
+      sourceHash: "sha256:release-verify",
+    },
+    resultSummary: {
+      artifactRefs: [
+        {
+          id: "artifact-release-verification-log",
+          kind: "FINAL_RESULT",
+          label: "Release verification log",
+          visibility: "PRIVATE",
+        },
+      ],
+      resultStatus: "FAILED_WITH_PARTIAL",
+      summary: "Release verification failed after checkpoint recovery.",
+    },
+    sessionId,
+    status: "FAILED",
+    usage: { resources: [] },
+  };
+}

--- a/ui/src/features/factory-session-detail/components/event-replay/factory-session-detail-panel.event-replay.test.tsx
+++ b/ui/src/features/factory-session-detail/components/event-replay/factory-session-detail-panel.event-replay.test.tsx
@@ -5,6 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FactoryOrchestratorKind } from "../../../../api/generated/openapi";
 import { formatDateTime } from "../../../../i18n/formatters";
 import {
+  awaitingReplaySessionID,
+  buildAwaitingDurableSession,
+  buildAwaitingReplayEventStream,
   buildSuccessfulDurableSession,
   buildSuccessfulReplayEventStream,
   buildWarningDurableSession,
@@ -137,6 +140,50 @@ describe("FactorySessionDetailPanel event replay disclosure", () => {
     expect(
       screen.getByText("Phase verify · Checkpoint checkpoint-9"),
     ).toBeTruthy();
+  });
+
+  it("reveals replay for durable awaiting-approval sessions before result artifacts exist", async () => {
+    vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith(`/factory-sessions/${awaitingReplaySessionID}`)) {
+        return jsonResponse(buildAwaitingDurableSession());
+      }
+      if (url.endsWith(`/factory-sessions/${awaitingReplaySessionID}/events`)) {
+        return new Response(buildAwaitingReplayEventStream(), {
+          headers: {
+            "Content-Type": "text/event-stream",
+          },
+          status: 200,
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    renderWithQueryClient(
+      <FactorySessionDetailPanel sessionID={awaitingReplaySessionID} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Awaiting approval")).toBeTruthy();
+    });
+
+    const user = userEvent.setup();
+    const replayTrigger = screen.getByRole("button", {
+      name: "Expand Factory Event replay",
+    });
+
+    await user.click(replayTrigger);
+
+    await waitFor(() => {
+      expect(screen.getByText("Showing 2 Factory Events.")).toBeTruthy();
+    });
+
+    expect(screen.getByText("Session started")).toBeTruthy();
+    expect(screen.getByText("Session result updated")).toBeTruthy();
+    expect(
+      screen.getByText("Result status not ready"),
+    ).toBeTruthy();
+    expect(screen.getAllByText("Phase approval").length).toBe(2);
   });
 
   it("keeps replay disclosure out of non-durable session detail views", async () => {

--- a/ui/src/features/factory-session-detail/components/event-replay/factory-session-detail-panel.event-replay.test.tsx
+++ b/ui/src/features/factory-session-detail/components/event-replay/factory-session-detail-panel.event-replay.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FactoryOrchestratorKind } from "../../../../api/generated/openapi";
+import { formatDateTime } from "../../../../i18n/formatters";
 import { FactorySessionDetailPanel } from "../factory-session-detail-panel";
 import {
   jsonResponse,
@@ -63,7 +64,13 @@ describe("FactorySessionDetailPanel event replay disclosure", () => {
           [
             'data: {"id":"evt-1","type":"SESSION_STARTED","context":{"sequence":1,"tick":1,"eventTime":"2026-06-25T10:00:00Z","sessionId":"dur-sess-js-success-002","sessionSequence":1,"phaseName":"plan"},"payload":{"startedAt":"2026-06-25T10:00:00Z"}}',
             "",
-            'data: {"id":"evt-2","type":"DISPATCH_QUEUED","context":{"sequence":2,"tick":2,"eventTime":"2026-06-25T10:00:02Z","sessionId":"dur-sess-js-success-002","sessionSequence":2,"phaseName":"review","dispatchId":"dispatch-1","workIds":["work-1","work-2"]},"payload":{"dispatchKind":"JAVASCRIPT_AGENT"}}',
+            'data: {"id":"evt-2","type":"ORCHESTRATOR_PHASE_CHANGED","context":{"sequence":2,"tick":2,"eventTime":"2026-06-25T10:00:01Z","sessionId":"dur-sess-js-success-002","sessionSequence":2,"phaseName":"review"},"payload":{"phase":"review","progressSummary":"Review work scheduled."}}',
+            "",
+            'data: {"id":"evt-3","type":"DISPATCH_QUEUED","context":{"sequence":3,"tick":3,"eventTime":"2026-06-25T10:00:02Z","sessionId":"dur-sess-js-success-002","sessionSequence":3,"phaseName":"review","dispatchId":"dispatch-1","workIds":["work-1","work-2"]},"payload":{"dispatchKind":"JAVASCRIPT_AGENT","label":"Draft release notes","queuePosition":1}}',
+            "",
+            'data: {"id":"evt-4","type":"DISPATCH_RECONCILED","context":{"sequence":4,"tick":4,"eventTime":"2026-06-25T10:00:03Z","sessionId":"dur-sess-js-success-002","sessionSequence":4,"phaseName":"review","dispatchId":"dispatch-1"},"payload":{"reconciledStatus":"COMPLETED","resultArtifactRef":{"id":"artifact-release-notes","kind":"FINAL_RESULT","label":"Release notes"},"artifactIds":["artifact-release-notes"]}}',
+            "",
+            'data: {"id":"evt-5","type":"SESSION_COMPLETED","context":{"sequence":5,"tick":5,"eventTime":"2026-06-25T10:00:05Z","sessionId":"dur-sess-js-success-002","sessionSequence":5,"phaseName":"review"},"payload":{"finalStatus":"SUCCEEDED","completedAt":"2026-06-25T10:00:05Z","artifactIds":["artifact-release-notes"]}}',
             "",
           ].join("\n"),
           {
@@ -96,19 +103,130 @@ describe("FactorySessionDetailPanel event replay disclosure", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("Showing 2 Factory Events."),
+        screen.getByText("Showing 5 Factory Events."),
       ).toBeTruthy();
     });
 
     expect(replayTrigger.getAttribute("aria-expanded")).toBe("true");
-    expect(screen.getByText("Session Started")).toBeTruthy();
+    expect(screen.getByText("Session started")).toBeTruthy();
+    expect(screen.getByText("Phase changed")).toBeTruthy();
+    expect(screen.getByText("Review work scheduled.")).toBeTruthy();
+    expect(screen.getByText("Dispatch queued")).toBeTruthy();
+    expect(screen.getByText("Draft release notes · Queue position 1")).toBeTruthy();
+    expect(screen.getByText("Dispatch reconciled")).toBeTruthy();
+    expect(screen.getByText("Dispatch status completed")).toBeTruthy();
+    expect(screen.getAllByText(/artifact-release-notes/).length).toBeGreaterThan(0);
+    expect(screen.getByText("Session completed")).toBeTruthy();
+    expect(screen.getByText("Lifecycle status succeeded")).toBeTruthy();
     expect(screen.getByText("Dispatch Queued")).toBeTruthy();
     expect(
       screen.getByText(
         "Phase review · Dispatch dispatch-1 · 2 related work items",
       ),
     ).toBeTruthy();
-    expect(screen.getByText("2026-06-25T10:00:02Z")).toBeTruthy();
+    expect(screen.getByText("Session event 4 · Tick 4")).toBeTruthy();
+    expect(
+      screen.getAllByText(
+        formatDateTime("2026-06-25T10:00:03Z", "en", {
+          timeZone: "UTC",
+        }),
+      ).length,
+    ).toBeTruthy();
+  });
+
+  it("surfaces failed and warning replay cues inside the bounded timeline", async () => {
+    vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/factory-sessions/dur-sess-js-warning-003")) {
+        return jsonResponse({
+          artifactRefs: [
+            {
+              id: "artifact-release-verification-log",
+              kind: "FINAL_RESULT",
+              label: "Release verification log",
+              visibility: "PRIVATE",
+            },
+          ],
+          dialect: "you-workflow-v1",
+          lifecycle: {
+            finishedAt: "2026-06-25T11:10:00Z",
+            startedAt: "2026-06-25T11:00:00Z",
+          },
+          orchestratorKind: FactoryOrchestratorKind.JAVASCRIPT,
+          progress: {
+            completedDispatches: 0,
+            failedDispatches: 1,
+            inFlightDispatches: 0,
+            totalDispatches: 1,
+          },
+          resolvedSource: {
+            kind: "WORKFLOW_FILE",
+            sourceRef: "workflow/.claude/workflows/release-verify.yaml",
+            sourceHash: "sha256:release-verify",
+          },
+          resultSummary: {
+            artifactRefs: [
+              {
+                id: "artifact-release-verification-log",
+                kind: "FINAL_RESULT",
+                label: "Release verification log",
+                visibility: "PRIVATE",
+              },
+            ],
+            resultStatus: "FAILED_WITH_PARTIAL",
+            summary: "Release verification failed after checkpoint recovery.",
+          },
+          sessionId: "dur-sess-js-warning-003",
+          status: "FAILED",
+          usage: { resources: [] },
+        });
+      }
+      if (url.endsWith("/factory-sessions/dur-sess-js-warning-003/events")) {
+        return new Response(
+          [
+            'data: {"id":"evt-w1","type":"JAVASCRIPT_CHECKPOINT_REF","context":{"sequence":1,"tick":1,"eventTime":"2026-06-25T11:00:01Z","sessionId":"dur-sess-js-warning-003","sessionSequence":1,"phaseName":"verify","checkpointId":"checkpoint-9"},"payload":{"label":"Checkpoint before publish","warnings":[{"code":"CHECKPOINT_STALE","message":"Checkpoint is older than the latest source hash."}]}}',
+            "",
+            'data: {"id":"evt-w2","type":"DISPATCH_INTERRUPTED","context":{"sequence":2,"tick":2,"eventTime":"2026-06-25T11:00:02Z","sessionId":"dur-sess-js-warning-003","sessionSequence":2,"phaseName":"verify","dispatchId":"dispatch-verify"},"payload":{"reason":"Provider session timed out","observedStatus":"RUNNING","interruptedAt":"2026-06-25T11:00:02Z","retryPlanned":true}}',
+            "",
+            'data: {"id":"evt-w3","type":"SESSION_COMPLETED","context":{"sequence":3,"tick":3,"eventTime":"2026-06-25T11:00:05Z","sessionId":"dur-sess-js-warning-003","sessionSequence":3,"phaseName":"verify"},"payload":{"finalStatus":"FAILED","completedAt":"2026-06-25T11:00:05Z","failureDetail":{"message":"Release verification failed."}}}',
+            "",
+          ].join("\n"),
+          {
+            headers: {
+              "Content-Type": "text/event-stream",
+            },
+            status: 200,
+          },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    renderWithQueryClient(
+      <FactorySessionDetailPanel sessionID="dur-sess-js-warning-003" />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("JavaScript workflow")).toBeTruthy();
+    });
+
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole("button", { name: "Expand Factory Event replay" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Checkpoint recorded")).toBeTruthy();
+    });
+
+    expect(screen.getByText("Checkpoint before publish")).toBeTruthy();
+    expect(screen.getByText("Dispatch interrupted")).toBeTruthy();
+    expect(screen.getByText("Provider session timed out · Retry planned")).toBeTruthy();
+    expect(screen.getByText("Session completed")).toBeTruthy();
+    expect(screen.getByText("Release verification failed.")).toBeTruthy();
+    expect(
+      screen.getByText("Phase verify · Checkpoint checkpoint-9"),
+    ).toBeTruthy();
   });
 
   it("keeps replay disclosure out of non-durable session detail views", async () => {

--- a/ui/src/features/factory-session-detail/components/event-replay/factory-session-detail-panel.event-replay.test.tsx
+++ b/ui/src/features/factory-session-detail/components/event-replay/factory-session-detail-panel.event-replay.test.tsx
@@ -1,0 +1,166 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { FactoryOrchestratorKind } from "../../../../api/generated/openapi";
+import { FactorySessionDetailPanel } from "../factory-session-detail-panel";
+import {
+  jsonResponse,
+  renderWithQueryClient,
+} from "../factory-session-detail-panel.test-helpers";
+
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: focused event replay coverage keeps one fetch harness and assertion seam.
+describe("FactorySessionDetailPanel event replay disclosure", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reveals bounded durable Factory Event replay inline for durable JavaScript sessions", async () => {
+    vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/factory-sessions/dur-sess-js-success-002")) {
+        return jsonResponse({
+          artifactRefs: [
+            {
+              id: "art-js-success-001",
+              kind: "FINAL_RESULT",
+              label: "Docs refresh output",
+              visibility: "PUBLIC",
+            },
+          ],
+          dialect: "you-workflow-v1",
+          lifecycle: {
+            finishedAt: "2026-06-08T13:10:00Z",
+            startedAt: "2026-06-08T13:00:02Z",
+          },
+          orchestratorKind: FactoryOrchestratorKind.JAVASCRIPT,
+          progress: {
+            completedDispatches: 2,
+            failedDispatches: 0,
+            inFlightDispatches: 0,
+            totalDispatches: 2,
+          },
+          resolvedSource: {
+            kind: "WORKFLOW_FILE",
+            sourceRef: "workflow/.claude/workflows/docs-refresh.yaml",
+            sourceHash: "sha256:js-workflow-docs-refresh",
+          },
+          resultSummary: {
+            resultStatus: "FINAL",
+            summary: "Documentation refresh complete.",
+          },
+          sessionId: "dur-sess-js-success-002",
+          status: "SUCCEEDED",
+          usage: { resources: [] },
+        });
+      }
+      if (url.endsWith("/factory-sessions/dur-sess-js-success-002/events")) {
+        return new Response(
+          [
+            'data: {"id":"evt-1","type":"SESSION_STARTED","context":{"sequence":1,"tick":1,"eventTime":"2026-06-25T10:00:00Z","sessionId":"dur-sess-js-success-002","sessionSequence":1,"phaseName":"plan"},"payload":{"startedAt":"2026-06-25T10:00:00Z"}}',
+            "",
+            'data: {"id":"evt-2","type":"DISPATCH_QUEUED","context":{"sequence":2,"tick":2,"eventTime":"2026-06-25T10:00:02Z","sessionId":"dur-sess-js-success-002","sessionSequence":2,"phaseName":"review","dispatchId":"dispatch-1","workIds":["work-1","work-2"]},"payload":{"dispatchKind":"JAVASCRIPT_AGENT"}}',
+            "",
+          ].join("\n"),
+          {
+            headers: {
+              "Content-Type": "text/event-stream",
+            },
+            status: 200,
+          },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    renderWithQueryClient(
+      <FactorySessionDetailPanel sessionID="dur-sess-js-success-002" />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("JavaScript workflow")).toBeTruthy();
+    });
+
+    const user = userEvent.setup();
+    const replayTrigger = screen.getByRole("button", {
+      name: "Expand Factory Event replay",
+    });
+
+    expect(replayTrigger.getAttribute("aria-expanded")).toBe("false");
+
+    await user.click(replayTrigger);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Showing 2 Factory Events."),
+      ).toBeTruthy();
+    });
+
+    expect(replayTrigger.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText("Session Started")).toBeTruthy();
+    expect(screen.getByText("Dispatch Queued")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Phase review · Dispatch dispatch-1 · 2 related work items",
+      ),
+    ).toBeTruthy();
+    expect(screen.getByText("2026-06-25T10:00:02Z")).toBeTruthy();
+  });
+
+  it("keeps replay disclosure out of non-durable session detail views", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      jsonResponse({
+        factoryDir: "/workspace/root/beta",
+        folderPath: "/workspace/root",
+        id: "session-beta",
+        isDefault: false,
+        project: "beta",
+        runtime: {
+          artifacts: [],
+          dispatches: [],
+          javascript: {
+            checkpoints: [],
+            childDispatchCounts: {
+              completed: 0,
+              queued: 0,
+              running: 0,
+            },
+            phase: "review",
+            phases: ["review"],
+            scriptStatus: "IDLE",
+          },
+          lifecycle: {
+            startedAt: "2026-06-08T14:00:00Z",
+            updatedAt: "2026-06-08T14:05:00Z",
+          },
+          orchestratorKind: FactoryOrchestratorKind.JAVASCRIPT,
+          progress: {
+            categories: {},
+            factoryState: "RUNNING",
+            inFlightCount: 0,
+            totalTokens: 0,
+          },
+          status: "IDLE",
+          usage: { resources: [] },
+        },
+        target: { kind: "named", name: "beta" },
+      }),
+    );
+
+    renderWithQueryClient(
+      <FactorySessionDetailPanel sessionID="session-beta" />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("JavaScript workflow")).toBeTruthy();
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "Expand Factory Event replay" }),
+    ).toBeNull();
+  });
+});

--- a/ui/src/features/factory-session-detail/components/event-replay/factory-session-detail-panel.event-replay.test.tsx
+++ b/ui/src/features/factory-session-detail/components/event-replay/factory-session-detail-panel.event-replay.test.tsx
@@ -4,6 +4,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FactoryOrchestratorKind } from "../../../../api/generated/openapi";
 import { formatDateTime } from "../../../../i18n/formatters";
+import {
+  buildSuccessfulDurableSession,
+  buildSuccessfulReplayEventStream,
+  buildWarningDurableSession,
+  buildWarningReplayEventStream,
+  successfulReplaySessionID,
+  warningReplaySessionID,
+} from "../../../../testing/factory-session-event-replay-fixtures";
 import { FactorySessionDetailPanel } from "../factory-session-detail-panel";
 import {
   jsonResponse,
@@ -23,69 +31,22 @@ describe("FactorySessionDetailPanel event replay disclosure", () => {
   it("reveals bounded durable Factory Event replay inline for durable JavaScript sessions", async () => {
     vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
       const url = String(input);
-      if (url.endsWith("/factory-sessions/dur-sess-js-success-002")) {
-        return jsonResponse({
-          artifactRefs: [
-            {
-              id: "art-js-success-001",
-              kind: "FINAL_RESULT",
-              label: "Docs refresh output",
-              visibility: "PUBLIC",
-            },
-          ],
-          dialect: "you-workflow-v1",
-          lifecycle: {
-            finishedAt: "2026-06-08T13:10:00Z",
-            startedAt: "2026-06-08T13:00:02Z",
-          },
-          orchestratorKind: FactoryOrchestratorKind.JAVASCRIPT,
-          progress: {
-            completedDispatches: 2,
-            failedDispatches: 0,
-            inFlightDispatches: 0,
-            totalDispatches: 2,
-          },
-          resolvedSource: {
-            kind: "WORKFLOW_FILE",
-            sourceRef: "workflow/.claude/workflows/docs-refresh.yaml",
-            sourceHash: "sha256:js-workflow-docs-refresh",
-          },
-          resultSummary: {
-            resultStatus: "FINAL",
-            summary: "Documentation refresh complete.",
-          },
-          sessionId: "dur-sess-js-success-002",
-          status: "SUCCEEDED",
-          usage: { resources: [] },
-        });
+      if (url.endsWith(`/factory-sessions/${successfulReplaySessionID}`)) {
+        return jsonResponse(buildSuccessfulDurableSession());
       }
-      if (url.endsWith("/factory-sessions/dur-sess-js-success-002/events")) {
-        return new Response(
-          [
-            'data: {"id":"evt-1","type":"SESSION_STARTED","context":{"sequence":1,"tick":1,"eventTime":"2026-06-25T10:00:00Z","sessionId":"dur-sess-js-success-002","sessionSequence":1,"phaseName":"plan"},"payload":{"startedAt":"2026-06-25T10:00:00Z"}}',
-            "",
-            'data: {"id":"evt-2","type":"ORCHESTRATOR_PHASE_CHANGED","context":{"sequence":2,"tick":2,"eventTime":"2026-06-25T10:00:01Z","sessionId":"dur-sess-js-success-002","sessionSequence":2,"phaseName":"review"},"payload":{"phase":"review","progressSummary":"Review work scheduled."}}',
-            "",
-            'data: {"id":"evt-3","type":"DISPATCH_QUEUED","context":{"sequence":3,"tick":3,"eventTime":"2026-06-25T10:00:02Z","sessionId":"dur-sess-js-success-002","sessionSequence":3,"phaseName":"review","dispatchId":"dispatch-1","workIds":["work-1","work-2"]},"payload":{"dispatchKind":"JAVASCRIPT_AGENT","label":"Draft release notes","queuePosition":1}}',
-            "",
-            'data: {"id":"evt-4","type":"DISPATCH_RECONCILED","context":{"sequence":4,"tick":4,"eventTime":"2026-06-25T10:00:03Z","sessionId":"dur-sess-js-success-002","sessionSequence":4,"phaseName":"review","dispatchId":"dispatch-1"},"payload":{"reconciledStatus":"COMPLETED","resultArtifactRef":{"id":"artifact-release-notes","kind":"FINAL_RESULT","label":"Release notes"},"artifactIds":["artifact-release-notes"]}}',
-            "",
-            'data: {"id":"evt-5","type":"SESSION_COMPLETED","context":{"sequence":5,"tick":5,"eventTime":"2026-06-25T10:00:05Z","sessionId":"dur-sess-js-success-002","sessionSequence":5,"phaseName":"review"},"payload":{"finalStatus":"SUCCEEDED","completedAt":"2026-06-25T10:00:05Z","artifactIds":["artifact-release-notes"]}}',
-            "",
-          ].join("\n"),
-          {
-            headers: {
-              "Content-Type": "text/event-stream",
-            },
-            status: 200,
+      if (url.endsWith(`/factory-sessions/${successfulReplaySessionID}/events`)) {
+        return new Response(buildSuccessfulReplayEventStream(), {
+          headers: {
+            "Content-Type": "text/event-stream",
           },
-        );
+          status: 200,
+        });
       }
       return new Response("not found", { status: 404 });
     });
 
     renderWithQueryClient(
-      <FactorySessionDetailPanel sessionID="dur-sess-js-success-002" />,
+      <FactorySessionDetailPanel sessionID={successfulReplaySessionID} />,
     );
 
     await waitFor(() => {
@@ -137,73 +98,22 @@ describe("FactorySessionDetailPanel event replay disclosure", () => {
   it("surfaces failed and warning replay cues inside the bounded timeline", async () => {
     vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
       const url = String(input);
-      if (url.endsWith("/factory-sessions/dur-sess-js-warning-003")) {
-        return jsonResponse({
-          artifactRefs: [
-            {
-              id: "artifact-release-verification-log",
-              kind: "FINAL_RESULT",
-              label: "Release verification log",
-              visibility: "PRIVATE",
-            },
-          ],
-          dialect: "you-workflow-v1",
-          lifecycle: {
-            finishedAt: "2026-06-25T11:10:00Z",
-            startedAt: "2026-06-25T11:00:00Z",
-          },
-          orchestratorKind: FactoryOrchestratorKind.JAVASCRIPT,
-          progress: {
-            completedDispatches: 0,
-            failedDispatches: 1,
-            inFlightDispatches: 0,
-            totalDispatches: 1,
-          },
-          resolvedSource: {
-            kind: "WORKFLOW_FILE",
-            sourceRef: "workflow/.claude/workflows/release-verify.yaml",
-            sourceHash: "sha256:release-verify",
-          },
-          resultSummary: {
-            artifactRefs: [
-              {
-                id: "artifact-release-verification-log",
-                kind: "FINAL_RESULT",
-                label: "Release verification log",
-                visibility: "PRIVATE",
-              },
-            ],
-            resultStatus: "FAILED_WITH_PARTIAL",
-            summary: "Release verification failed after checkpoint recovery.",
-          },
-          sessionId: "dur-sess-js-warning-003",
-          status: "FAILED",
-          usage: { resources: [] },
-        });
+      if (url.endsWith(`/factory-sessions/${warningReplaySessionID}`)) {
+        return jsonResponse(buildWarningDurableSession());
       }
-      if (url.endsWith("/factory-sessions/dur-sess-js-warning-003/events")) {
-        return new Response(
-          [
-            'data: {"id":"evt-w1","type":"JAVASCRIPT_CHECKPOINT_REF","context":{"sequence":1,"tick":1,"eventTime":"2026-06-25T11:00:01Z","sessionId":"dur-sess-js-warning-003","sessionSequence":1,"phaseName":"verify","checkpointId":"checkpoint-9"},"payload":{"label":"Checkpoint before publish","warnings":[{"code":"CHECKPOINT_STALE","message":"Checkpoint is older than the latest source hash."}]}}',
-            "",
-            'data: {"id":"evt-w2","type":"DISPATCH_INTERRUPTED","context":{"sequence":2,"tick":2,"eventTime":"2026-06-25T11:00:02Z","sessionId":"dur-sess-js-warning-003","sessionSequence":2,"phaseName":"verify","dispatchId":"dispatch-verify"},"payload":{"reason":"Provider session timed out","observedStatus":"RUNNING","interruptedAt":"2026-06-25T11:00:02Z","retryPlanned":true}}',
-            "",
-            'data: {"id":"evt-w3","type":"SESSION_COMPLETED","context":{"sequence":3,"tick":3,"eventTime":"2026-06-25T11:00:05Z","sessionId":"dur-sess-js-warning-003","sessionSequence":3,"phaseName":"verify"},"payload":{"finalStatus":"FAILED","completedAt":"2026-06-25T11:00:05Z","failureDetail":{"message":"Release verification failed."}}}',
-            "",
-          ].join("\n"),
-          {
-            headers: {
-              "Content-Type": "text/event-stream",
-            },
-            status: 200,
+      if (url.endsWith(`/factory-sessions/${warningReplaySessionID}/events`)) {
+        return new Response(buildWarningReplayEventStream(), {
+          headers: {
+            "Content-Type": "text/event-stream",
           },
-        );
+          status: 200,
+        });
       }
       return new Response("not found", { status: 404 });
     });
 
     renderWithQueryClient(
-      <FactorySessionDetailPanel sessionID="dur-sess-js-warning-003" />,
+      <FactorySessionDetailPanel sessionID={warningReplaySessionID} />,
     );
 
     await waitFor(() => {

--- a/ui/src/features/factory-session-detail/components/event-replay/factory-session-event-replay-disclosure.tsx
+++ b/ui/src/features/factory-session-detail/components/event-replay/factory-session-event-replay-disclosure.tsx
@@ -86,6 +86,14 @@ function EventReplayState({
     );
   }
 
+  if (state.status === "unavailable") {
+    return (
+      <AlertPanel id={detailRegionID} tone="info">
+        {state.message ?? messages.eventReplayUnavailableState}
+      </AlertPanel>
+    );
+  }
+
   if (state.status !== "success") {
     return null;
   }

--- a/ui/src/features/factory-session-detail/components/event-replay/factory-session-event-replay-disclosure.tsx
+++ b/ui/src/features/factory-session-detail/components/event-replay/factory-session-event-replay-disclosure.tsx
@@ -1,6 +1,5 @@
 import { useId, useState } from "react";
 
-import type { FactoryEvent } from "../../../../api/events";
 import {
   AlertPanel,
   DashboardLabel,
@@ -10,6 +9,7 @@ import {
 import { ExpandablePanelTrigger } from "../../../../components/ui/expandable-panel-trigger";
 import { DetailCopy } from "../../../../components/ui/widget-frame";
 import { useFactorySessionEventReplay } from "../../hooks/use-factory-session-event-replay";
+import { buildFactorySessionEventReplayTimeline } from "../../lib/factory-session-event-replay-timeline";
 import { getFactorySessionDetailMessages } from "../../messages/factory-session-detail";
 
 const MAX_VISIBLE_REPLAY_EVENTS = 12;
@@ -98,6 +98,11 @@ function EventReplayState({
 
   const visibleEvents = state.events.slice(-MAX_VISIBLE_REPLAY_EVENTS);
   const truncatedCount = state.events.length - visibleEvents.length;
+  const timelineItems = buildFactorySessionEventReplayTimeline(
+    visibleEvents,
+    messages,
+    locale,
+  );
 
   return (
     <div
@@ -113,57 +118,28 @@ function EventReplayState({
           : messages.eventReplayVisibleSummary(visibleEvents.length)}
       </DashboardText>
       <ol className="grid gap-2">
-        {visibleEvents.map((event) => (
+        {timelineItems.map((item) => (
           <li
             className="grid gap-2 rounded-md border border-outline bg-surface px-3 py-2"
-            key={event.id}
+            key={item.id}
           >
             <div className="flex flex-wrap items-center gap-2">
-              <DashboardStatusPill size="compact">
-                {formatEventType(event.type)}
+              <DashboardStatusPill size="compact" tone={item.tone}>
+                {item.title}
               </DashboardStatusPill>
-              {event.context.sessionSequence != null ? (
-                <DashboardText variant="supporting">
-                  {messages.eventReplaySequenceLabel(event.context.sessionSequence)}
-                </DashboardText>
-              ) : null}
+              <DashboardStatusPill size="compact">
+                {item.typeLabel}
+              </DashboardStatusPill>
             </div>
-            <DashboardText>{formatEventContextSummary(event, messages)}</DashboardText>
-            <DashboardText variant="supporting">
-              {event.context.eventTime}
-            </DashboardText>
+            {item.detail ? <DashboardText>{item.detail}</DashboardText> : null}
+            <DashboardText variant="supporting">{item.referenceSummary}</DashboardText>
+            <div className="flex flex-wrap items-center gap-2">
+              <DashboardText variant="supporting">{item.orderLabel}</DashboardText>
+              <DashboardText variant="supporting">{item.timeLabel}</DashboardText>
+            </div>
           </li>
         ))}
       </ol>
     </div>
   );
-}
-
-function formatEventContextSummary(
-  event: FactoryEvent,
-  messages: ReturnType<typeof getFactorySessionDetailMessages>,
-): string {
-  const details: string[] = [];
-  const phase = event.context.phaseName ?? event.context.phaseId;
-  if (phase) {
-    details.push(messages.eventReplayPhaseLabel(phase));
-  }
-  if (event.context.dispatchId) {
-    details.push(messages.eventReplayDispatchLabel(event.context.dispatchId));
-  }
-  if (event.context.checkpointId) {
-    details.push(messages.eventReplayCheckpointLabel(event.context.checkpointId));
-  }
-  if (event.context.workIds && event.context.workIds.length > 0) {
-    details.push(messages.eventReplayWorkLabel(event.context.workIds.length));
-  }
-  return details.length > 0 ? details.join(" · ") : messages.eventReplayNoContext;
-}
-
-function formatEventType(eventType: string): string {
-  return eventType
-    .toLowerCase()
-    .split("_")
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
 }

--- a/ui/src/features/factory-session-detail/components/event-replay/factory-session-event-replay-disclosure.tsx
+++ b/ui/src/features/factory-session-detail/components/event-replay/factory-session-event-replay-disclosure.tsx
@@ -1,0 +1,169 @@
+import { useId, useState } from "react";
+
+import type { FactoryEvent } from "../../../../api/events";
+import {
+  AlertPanel,
+  DashboardLabel,
+  DashboardStatusPill,
+  DashboardText,
+} from "../../../../components/ui";
+import { ExpandablePanelTrigger } from "../../../../components/ui/expandable-panel-trigger";
+import { DetailCopy } from "../../../../components/ui/widget-frame";
+import { useFactorySessionEventReplay } from "../../hooks/use-factory-session-event-replay";
+import { getFactorySessionDetailMessages } from "../../messages/factory-session-detail";
+
+const MAX_VISIBLE_REPLAY_EVENTS = 12;
+
+export interface FactorySessionEventReplayDisclosureProps {
+  locale?: string;
+  sessionID: string;
+}
+
+export function FactorySessionEventReplayDisclosure({
+  locale,
+  sessionID,
+}: FactorySessionEventReplayDisclosureProps) {
+  const messages = getFactorySessionDetailMessages(locale);
+  const detailRegionID = useId();
+  const [expanded, setExpanded] = useState(false);
+  const replayState = useFactorySessionEventReplay(sessionID, expanded);
+
+  return (
+    <section className="grid gap-3 rounded-lg border border-outline bg-surface-container-low p-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="grid gap-2">
+          <DashboardLabel>{messages.eventReplayHeading}</DashboardLabel>
+          <DetailCopy>{messages.eventReplayHint}</DetailCopy>
+        </div>
+        <ExpandablePanelTrigger
+          aria-label={
+            expanded
+              ? messages.collapseEventReplayLabel
+              : messages.expandEventReplayLabel
+          }
+          controlsID={detailRegionID}
+          expanded={expanded}
+          onClick={() => setExpanded((current) => !current)}
+          variant="compact"
+        >
+          {messages.eventReplayHeading}
+        </ExpandablePanelTrigger>
+      </div>
+
+      {expanded ? (
+        <EventReplayState
+          detailRegionID={detailRegionID}
+          locale={locale}
+          state={replayState}
+        />
+      ) : null}
+    </section>
+  );
+}
+
+function EventReplayState({
+  detailRegionID,
+  locale,
+  state,
+}: {
+  detailRegionID: string;
+  locale?: string;
+  state: ReturnType<typeof useFactorySessionEventReplay>;
+}) {
+  const messages = getFactorySessionDetailMessages(locale);
+
+  if (state.status === "loading") {
+    return (
+      <DetailCopy id={detailRegionID}>{messages.eventReplayLoadingState}</DetailCopy>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <AlertPanel id={detailRegionID} tone="danger">
+        {state.message ?? messages.eventReplayErrorState}
+      </AlertPanel>
+    );
+  }
+
+  if (state.status !== "success") {
+    return null;
+  }
+
+  if (state.events.length === 0) {
+    return (
+      <DetailCopy id={detailRegionID}>{messages.eventReplayEmptyState}</DetailCopy>
+    );
+  }
+
+  const visibleEvents = state.events.slice(-MAX_VISIBLE_REPLAY_EVENTS);
+  const truncatedCount = state.events.length - visibleEvents.length;
+
+  return (
+    <div
+      className="grid gap-3 border-t border-outline pt-3"
+      id={detailRegionID}
+    >
+      <DashboardText as="div" variant="supporting">
+        {truncatedCount > 0
+          ? messages.eventReplaySummary(
+              visibleEvents.length,
+              state.events.length,
+            )
+          : messages.eventReplayVisibleSummary(visibleEvents.length)}
+      </DashboardText>
+      <ol className="grid gap-2">
+        {visibleEvents.map((event) => (
+          <li
+            className="grid gap-2 rounded-md border border-outline bg-surface px-3 py-2"
+            key={event.id}
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <DashboardStatusPill size="compact">
+                {formatEventType(event.type)}
+              </DashboardStatusPill>
+              {event.context.sessionSequence != null ? (
+                <DashboardText variant="supporting">
+                  {messages.eventReplaySequenceLabel(event.context.sessionSequence)}
+                </DashboardText>
+              ) : null}
+            </div>
+            <DashboardText>{formatEventContextSummary(event, messages)}</DashboardText>
+            <DashboardText variant="supporting">
+              {event.context.eventTime}
+            </DashboardText>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+function formatEventContextSummary(
+  event: FactoryEvent,
+  messages: ReturnType<typeof getFactorySessionDetailMessages>,
+): string {
+  const details: string[] = [];
+  const phase = event.context.phaseName ?? event.context.phaseId;
+  if (phase) {
+    details.push(messages.eventReplayPhaseLabel(phase));
+  }
+  if (event.context.dispatchId) {
+    details.push(messages.eventReplayDispatchLabel(event.context.dispatchId));
+  }
+  if (event.context.checkpointId) {
+    details.push(messages.eventReplayCheckpointLabel(event.context.checkpointId));
+  }
+  if (event.context.workIds && event.context.workIds.length > 0) {
+    details.push(messages.eventReplayWorkLabel(event.context.workIds.length));
+  }
+  return details.length > 0 ? details.join(" · ") : messages.eventReplayNoContext;
+}
+
+function formatEventType(eventType: string): string {
+  return eventType
+    .toLowerCase()
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}

--- a/ui/src/features/factory-session-detail/components/factory-session-detail-panel.stories.tsx
+++ b/ui/src/features/factory-session-detail/components/factory-session-detail-panel.stories.tsx
@@ -325,3 +325,97 @@ export const DurableReplayDisclosure = {
     );
   },
 };
+
+export const DurableReplayDisclosureUnavailable = {
+  parameters: {
+    dashboardApi: {
+      fetchMocks: [
+        {
+          method: "GET",
+          path: `/factory-sessions/dur-sess-js-unavailable-003`,
+          response: {
+            body: {
+              artifactRefs: [
+                {
+                  id: "artifact-release-verification-log",
+                  kind: "FINAL_RESULT",
+                  label: "Release verification log",
+                  visibility: "PRIVATE",
+                },
+              ],
+              dialect: "you-workflow-v1",
+              lifecycle: {
+                finishedAt: "2026-06-25T11:10:00Z",
+                startedAt: "2026-06-25T11:00:00Z",
+              },
+              orchestratorKind: FactoryOrchestratorKind.JAVASCRIPT,
+              progress: {
+                completedDispatches: 0,
+                failedDispatches: 1,
+                inFlightDispatches: 0,
+                totalDispatches: 1,
+              },
+              resolvedSource: {
+                kind: "WORKFLOW_FILE",
+                sourceRef: "workflow/.claude/workflows/release-verify.yaml",
+                sourceHash: "sha256:release-verify",
+              },
+              resultSummary: {
+                artifactRefs: [
+                  {
+                    id: "artifact-release-verification-log",
+                    kind: "FINAL_RESULT",
+                    label: "Release verification log",
+                    visibility: "PRIVATE",
+                  },
+                ],
+                resultStatus: "FAILED_WITH_PARTIAL",
+                summary:
+                  "Release verification failed after checkpoint recovery.",
+              },
+              sessionId: "dur-sess-js-unavailable-003",
+              status: "FAILED",
+              usage: { resources: [] },
+            },
+          },
+        },
+        {
+          method: "GET",
+          path: "/factory-sessions/dur-sess-js-unavailable-003/events",
+          response: {
+            status: 404,
+          },
+        },
+        {
+          method: "GET",
+          path: "/factory-sessions/dur-sess-js-unavailable-003/dispatches",
+          response: {
+            body: {
+              dispatches: [],
+              sessionId: "dur-sess-js-unavailable-003",
+            },
+          },
+        },
+      ],
+      sessionID: "dur-sess-js-unavailable-003",
+    },
+  },
+  render: () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          gcTime: Infinity,
+          retry: false,
+        },
+      },
+    });
+
+    return (
+      <div style={{ maxWidth: "100%", width: "960px" }}>
+        <QueryClientProvider client={queryClient}>
+          <FactorySessionDetailPanel sessionID="dur-sess-js-unavailable-003" />
+        </QueryClientProvider>
+      </div>
+    );
+  },
+};

--- a/ui/src/features/factory-session-detail/components/factory-session-detail-panel.stories.tsx
+++ b/ui/src/features/factory-session-detail/components/factory-session-detail-panel.stories.tsx
@@ -3,6 +3,9 @@ import { expect, userEvent, within } from "storybook/test";
 
 import { FactoryOrchestratorKind } from "../../../api/generated/openapi";
 import {
+  awaitingReplaySessionID,
+  buildAwaitingDurableSession,
+  buildAwaitingReplayEventStream,
   buildSuccessfulDurableSession,
   buildSuccessfulReplayDispatchList,
   buildSuccessfulReplayEventStream,
@@ -276,6 +279,46 @@ export const DurableReplayDisclosure = {
     expect(canvas.getByText("Dispatch status completed")).toBeTruthy();
   },
   render: () => renderFactorySessionDetailPanel(successfulReplaySessionID),
+};
+
+export const DurableReplayDisclosureAwaitingApproval = {
+  tags: ["test"],
+  parameters: {
+    dashboardApi: {
+      fetchMocks: [
+        {
+          method: "GET",
+          path: `/factory-sessions/${awaitingReplaySessionID}`,
+          response: {
+            body: buildAwaitingDurableSession(),
+          },
+        },
+        {
+          method: "GET",
+          path: `/factory-sessions/${awaitingReplaySessionID}/events`,
+          response: {
+            body: buildAwaitingReplayEventStream(),
+            headers: {
+              "Content-Type": "text/event-stream",
+            },
+          },
+        },
+      ],
+      sessionID: awaitingReplaySessionID,
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const user = userEvent.setup();
+
+    const trigger = await canvas.findByRole("button", {
+      name: "Expand Factory Event replay",
+    });
+    await user.click(trigger);
+    await expect(canvas.findByText("Showing 2 Factory Events.")).resolves.toBeTruthy();
+    await expect(canvas.getByText("Session result updated")).toBeTruthy();
+  },
+  render: () => renderFactorySessionDetailPanel(awaitingReplaySessionID),
 };
 
 export const DurableReplayDisclosureWarning = {

--- a/ui/src/features/factory-session-detail/components/factory-session-detail-panel.stories.tsx
+++ b/ui/src/features/factory-session-detail/components/factory-session-detail-panel.stories.tsx
@@ -4,6 +4,7 @@ import { FactoryOrchestratorKind } from "../../../api/generated/openapi";
 import { FactorySessionDetailPanel } from "./factory-session-detail-panel";
 
 const storySessionID = "session-beta";
+const durableReplayStorySessionID = "dur-sess-js-success-002";
 
 export default {
   title: "you-agent-factory/Current Selection/Factory Session Detail Panel",
@@ -212,6 +213,109 @@ export const DispatchDrilldownStates = {
       <div style={{ maxWidth: "100%", width: "960px" }}>
         <QueryClientProvider client={queryClient}>
           <FactorySessionDetailPanel sessionID={storySessionID} />
+        </QueryClientProvider>
+      </div>
+    );
+  },
+};
+
+export const DurableReplayDisclosure = {
+  parameters: {
+    dashboardApi: {
+      fetchMocks: [
+        {
+          method: "GET",
+          path: `/factory-sessions/${durableReplayStorySessionID}`,
+          response: {
+            body: {
+              artifactRefs: [
+                {
+                  id: "art-js-success-001",
+                  kind: "FINAL_RESULT",
+                  label: "Docs refresh output",
+                  visibility: "PUBLIC",
+                },
+              ],
+              dialect: "you-workflow-v1",
+              lifecycle: {
+                finishedAt: "2026-06-08T13:10:00Z",
+                startedAt: "2026-06-08T13:00:02Z",
+              },
+              orchestratorKind: FactoryOrchestratorKind.JAVASCRIPT,
+              progress: {
+                completedDispatches: 2,
+                failedDispatches: 0,
+                inFlightDispatches: 0,
+                totalDispatches: 2,
+              },
+              resolvedSource: {
+                kind: "WORKFLOW_FILE",
+                sourceRef: "workflow/.claude/workflows/docs-refresh.yaml",
+                sourceHash: "sha256:js-workflow-docs-refresh",
+              },
+              resultSummary: {
+                resultStatus: "FINAL",
+                summary: "Documentation refresh complete.",
+              },
+              sessionId: durableReplayStorySessionID,
+              status: "SUCCEEDED",
+              usage: { resources: [] },
+            },
+          },
+        },
+        {
+          method: "GET",
+          path: `/factory-sessions/${durableReplayStorySessionID}/events`,
+          response: {
+            body: [
+              'data: {"id":"evt-1","type":"SESSION_STARTED","context":{"sequence":1,"tick":1,"eventTime":"2026-06-25T10:00:00Z","sessionId":"dur-sess-js-success-002","sessionSequence":1,"phaseName":"plan"},"payload":{"startedAt":"2026-06-25T10:00:00Z"}}',
+              "",
+              'data: {"id":"evt-2","type":"ORCHESTRATOR_PHASE_CHANGED","context":{"sequence":2,"tick":2,"eventTime":"2026-06-25T10:00:01Z","sessionId":"dur-sess-js-success-002","sessionSequence":2,"phaseName":"review"},"payload":{"phase":"review"}}',
+              "",
+              'data: {"id":"evt-3","type":"DISPATCH_QUEUED","context":{"sequence":3,"tick":3,"eventTime":"2026-06-25T10:00:02Z","sessionId":"dur-sess-js-success-002","sessionSequence":3,"phaseName":"review","dispatchId":"dispatch-1","workIds":["work-1","work-2"]},"payload":{"dispatchKind":"JAVASCRIPT_AGENT"}}',
+              "",
+            ].join("\n"),
+            headers: {
+              "Content-Type": "text/event-stream",
+            },
+          },
+        },
+        {
+          method: "GET",
+          path: `/factory-sessions/${durableReplayStorySessionID}/dispatches`,
+          response: {
+            body: {
+              dispatches: [
+                {
+                  dispatchKind: "JAVASCRIPT_AGENT",
+                  id: "dispatch-1",
+                  outputArtifactIds: [],
+                  phase: "review",
+                  status: "COMPLETED",
+                },
+              ],
+              sessionId: durableReplayStorySessionID,
+            },
+          },
+        },
+      ],
+      sessionID: durableReplayStorySessionID,
+    },
+  },
+  render: () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          gcTime: Infinity,
+          retry: false,
+        },
+      },
+    });
+
+    return (
+      <div style={{ maxWidth: "100%", width: "960px" }}>
+        <QueryClientProvider client={queryClient}>
+          <FactorySessionDetailPanel sessionID={durableReplayStorySessionID} />
         </QueryClientProvider>
       </div>
     );

--- a/ui/src/features/factory-session-detail/components/factory-session-detail-panel.stories.tsx
+++ b/ui/src/features/factory-session-detail/components/factory-session-detail-panel.stories.tsx
@@ -270,9 +270,13 @@ export const DurableReplayDisclosure = {
             body: [
               'data: {"id":"evt-1","type":"SESSION_STARTED","context":{"sequence":1,"tick":1,"eventTime":"2026-06-25T10:00:00Z","sessionId":"dur-sess-js-success-002","sessionSequence":1,"phaseName":"plan"},"payload":{"startedAt":"2026-06-25T10:00:00Z"}}',
               "",
-              'data: {"id":"evt-2","type":"ORCHESTRATOR_PHASE_CHANGED","context":{"sequence":2,"tick":2,"eventTime":"2026-06-25T10:00:01Z","sessionId":"dur-sess-js-success-002","sessionSequence":2,"phaseName":"review"},"payload":{"phase":"review"}}',
+              'data: {"id":"evt-2","type":"ORCHESTRATOR_PHASE_CHANGED","context":{"sequence":2,"tick":2,"eventTime":"2026-06-25T10:00:01Z","sessionId":"dur-sess-js-success-002","sessionSequence":2,"phaseName":"review"},"payload":{"phase":"review","progressSummary":"Review work scheduled."}}',
               "",
-              'data: {"id":"evt-3","type":"DISPATCH_QUEUED","context":{"sequence":3,"tick":3,"eventTime":"2026-06-25T10:00:02Z","sessionId":"dur-sess-js-success-002","sessionSequence":3,"phaseName":"review","dispatchId":"dispatch-1","workIds":["work-1","work-2"]},"payload":{"dispatchKind":"JAVASCRIPT_AGENT"}}',
+              'data: {"id":"evt-3","type":"DISPATCH_QUEUED","context":{"sequence":3,"tick":3,"eventTime":"2026-06-25T10:00:02Z","sessionId":"dur-sess-js-success-002","sessionSequence":3,"phaseName":"review","dispatchId":"dispatch-1","workIds":["work-1","work-2"]},"payload":{"dispatchKind":"JAVASCRIPT_AGENT","label":"Draft release notes","queuePosition":1}}',
+              "",
+              'data: {"id":"evt-4","type":"DISPATCH_RECONCILED","context":{"sequence":4,"tick":4,"eventTime":"2026-06-25T10:00:03Z","sessionId":"dur-sess-js-success-002","sessionSequence":4,"phaseName":"review","dispatchId":"dispatch-1"},"payload":{"reconciledStatus":"COMPLETED","resultArtifactRef":{"id":"artifact-release-notes","kind":"FINAL_RESULT","label":"Release notes"},"artifactIds":["artifact-release-notes"]}}',
+              "",
+              'data: {"id":"evt-5","type":"SESSION_COMPLETED","context":{"sequence":5,"tick":5,"eventTime":"2026-06-25T10:00:05Z","sessionId":"dur-sess-js-success-002","sessionSequence":5,"phaseName":"review"},"payload":{"finalStatus":"SUCCEEDED","completedAt":"2026-06-25T10:00:05Z","artifactIds":["artifact-release-notes"]}}',
               "",
             ].join("\n"),
             headers: {

--- a/ui/src/features/factory-session-detail/components/factory-session-detail-panel.stories.tsx
+++ b/ui/src/features/factory-session-detail/components/factory-session-detail-panel.stories.tsx
@@ -1,15 +1,45 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { expect, userEvent, within } from "storybook/test";
 
 import { FactoryOrchestratorKind } from "../../../api/generated/openapi";
+import {
+  buildSuccessfulDurableSession,
+  buildSuccessfulReplayDispatchList,
+  buildSuccessfulReplayEventStream,
+  buildWarningDurableSession,
+  buildWarningReplayDispatchList,
+  buildWarningReplayEventStream,
+  successfulReplaySessionID,
+  unavailableReplaySessionID,
+  warningReplaySessionID,
+} from "../../../testing/factory-session-event-replay-fixtures";
 import { FactorySessionDetailPanel } from "./factory-session-detail-panel";
 
 const storySessionID = "session-beta";
-const durableReplayStorySessionID = "dur-sess-js-success-002";
 
 export default {
   title: "you-agent-factory/Current Selection/Factory Session Detail Panel",
   component: FactorySessionDetailPanel,
 };
+
+function renderFactorySessionDetailPanel(sessionID: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        gcTime: Infinity,
+        retry: false,
+      },
+    },
+  });
+
+  return (
+    <div style={{ maxWidth: "100%", width: "960px" }}>
+      <QueryClientProvider client={queryClient}>
+        <FactorySessionDetailPanel sessionID={sessionID} />
+      </QueryClientProvider>
+    </div>
+  );
+}
 
 export const DispatchDrilldownStates = {
   parameters: {
@@ -199,86 +229,26 @@ export const DispatchDrilldownStates = {
       sessionID: storySessionID,
     },
   },
-  render: () => {
-    const queryClient = new QueryClient({
-      defaultOptions: {
-        queries: {
-          gcTime: Infinity,
-          retry: false,
-        },
-      },
-    });
-
-    return (
-      <div style={{ maxWidth: "100%", width: "960px" }}>
-        <QueryClientProvider client={queryClient}>
-          <FactorySessionDetailPanel sessionID={storySessionID} />
-        </QueryClientProvider>
-      </div>
-    );
-  },
+  render: () => renderFactorySessionDetailPanel(storySessionID),
 };
 
 export const DurableReplayDisclosure = {
+  tags: ["test"],
   parameters: {
     dashboardApi: {
       fetchMocks: [
         {
           method: "GET",
-          path: `/factory-sessions/${durableReplayStorySessionID}`,
+          path: `/factory-sessions/${successfulReplaySessionID}`,
           response: {
-            body: {
-              artifactRefs: [
-                {
-                  id: "art-js-success-001",
-                  kind: "FINAL_RESULT",
-                  label: "Docs refresh output",
-                  visibility: "PUBLIC",
-                },
-              ],
-              dialect: "you-workflow-v1",
-              lifecycle: {
-                finishedAt: "2026-06-08T13:10:00Z",
-                startedAt: "2026-06-08T13:00:02Z",
-              },
-              orchestratorKind: FactoryOrchestratorKind.JAVASCRIPT,
-              progress: {
-                completedDispatches: 2,
-                failedDispatches: 0,
-                inFlightDispatches: 0,
-                totalDispatches: 2,
-              },
-              resolvedSource: {
-                kind: "WORKFLOW_FILE",
-                sourceRef: "workflow/.claude/workflows/docs-refresh.yaml",
-                sourceHash: "sha256:js-workflow-docs-refresh",
-              },
-              resultSummary: {
-                resultStatus: "FINAL",
-                summary: "Documentation refresh complete.",
-              },
-              sessionId: durableReplayStorySessionID,
-              status: "SUCCEEDED",
-              usage: { resources: [] },
-            },
+            body: buildSuccessfulDurableSession(),
           },
         },
         {
           method: "GET",
-          path: `/factory-sessions/${durableReplayStorySessionID}/events`,
+          path: `/factory-sessions/${successfulReplaySessionID}/events`,
           response: {
-            body: [
-              'data: {"id":"evt-1","type":"SESSION_STARTED","context":{"sequence":1,"tick":1,"eventTime":"2026-06-25T10:00:00Z","sessionId":"dur-sess-js-success-002","sessionSequence":1,"phaseName":"plan"},"payload":{"startedAt":"2026-06-25T10:00:00Z"}}',
-              "",
-              'data: {"id":"evt-2","type":"ORCHESTRATOR_PHASE_CHANGED","context":{"sequence":2,"tick":2,"eventTime":"2026-06-25T10:00:01Z","sessionId":"dur-sess-js-success-002","sessionSequence":2,"phaseName":"review"},"payload":{"phase":"review","progressSummary":"Review work scheduled."}}',
-              "",
-              'data: {"id":"evt-3","type":"DISPATCH_QUEUED","context":{"sequence":3,"tick":3,"eventTime":"2026-06-25T10:00:02Z","sessionId":"dur-sess-js-success-002","sessionSequence":3,"phaseName":"review","dispatchId":"dispatch-1","workIds":["work-1","work-2"]},"payload":{"dispatchKind":"JAVASCRIPT_AGENT","label":"Draft release notes","queuePosition":1}}',
-              "",
-              'data: {"id":"evt-4","type":"DISPATCH_RECONCILED","context":{"sequence":4,"tick":4,"eventTime":"2026-06-25T10:00:03Z","sessionId":"dur-sess-js-success-002","sessionSequence":4,"phaseName":"review","dispatchId":"dispatch-1"},"payload":{"reconciledStatus":"COMPLETED","resultArtifactRef":{"id":"artifact-release-notes","kind":"FINAL_RESULT","label":"Release notes"},"artifactIds":["artifact-release-notes"]}}',
-              "",
-              'data: {"id":"evt-5","type":"SESSION_COMPLETED","context":{"sequence":5,"tick":5,"eventTime":"2026-06-25T10:00:05Z","sessionId":"dur-sess-js-success-002","sessionSequence":5,"phaseName":"review"},"payload":{"finalStatus":"SUCCEEDED","completedAt":"2026-06-25T10:00:05Z","artifactIds":["artifact-release-notes"]}}',
-              "",
-            ].join("\n"),
+            body: buildSuccessfulReplayEventStream(),
             headers: {
               "Content-Type": "text/event-stream",
             },
@@ -286,44 +256,72 @@ export const DurableReplayDisclosure = {
         },
         {
           method: "GET",
-          path: `/factory-sessions/${durableReplayStorySessionID}/dispatches`,
+          path: `/factory-sessions/${successfulReplaySessionID}/dispatches`,
           response: {
-            body: {
-              dispatches: [
-                {
-                  dispatchKind: "JAVASCRIPT_AGENT",
-                  id: "dispatch-1",
-                  outputArtifactIds: [],
-                  phase: "review",
-                  status: "COMPLETED",
-                },
-              ],
-              sessionId: durableReplayStorySessionID,
-            },
+            body: buildSuccessfulReplayDispatchList(),
           },
         },
       ],
-      sessionID: durableReplayStorySessionID,
+      sessionID: successfulReplaySessionID,
     },
   },
-  render: () => {
-    const queryClient = new QueryClient({
-      defaultOptions: {
-        queries: {
-          gcTime: Infinity,
-          retry: false,
-        },
-      },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = await canvas.findByRole("button", {
+      name: "Expand Factory Event replay",
     });
-
-    return (
-      <div style={{ maxWidth: "100%", width: "960px" }}>
-        <QueryClientProvider client={queryClient}>
-          <FactorySessionDetailPanel sessionID={durableReplayStorySessionID} />
-        </QueryClientProvider>
-      </div>
-    );
+    await userEvent.click(trigger);
+    await canvas.findByText("Showing 5 Factory Events.");
+    expect(canvas.getByText("Session completed")).toBeTruthy();
+    expect(canvas.getByText("Dispatch status completed")).toBeTruthy();
   },
+  render: () => renderFactorySessionDetailPanel(successfulReplaySessionID),
+};
+
+export const DurableReplayDisclosureWarning = {
+  tags: ["test"],
+  parameters: {
+    dashboardApi: {
+      fetchMocks: [
+        {
+          method: "GET",
+          path: `/factory-sessions/${warningReplaySessionID}`,
+          response: {
+            body: buildWarningDurableSession(),
+          },
+        },
+        {
+          method: "GET",
+          path: `/factory-sessions/${warningReplaySessionID}/events`,
+          response: {
+            body: buildWarningReplayEventStream(),
+            headers: {
+              "Content-Type": "text/event-stream",
+            },
+          },
+        },
+        {
+          method: "GET",
+          path: `/factory-sessions/${warningReplaySessionID}/dispatches`,
+          response: {
+            body: buildWarningReplayDispatchList(),
+          },
+        },
+      ],
+      sessionID: warningReplaySessionID,
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = await canvas.findByRole("button", {
+      name: "Expand Factory Event replay",
+    });
+    await userEvent.click(trigger);
+    await canvas.findByText("Checkpoint recorded");
+    expect(canvas.getByText("Provider session timed out · Retry planned")).toBeTruthy();
+    expect(canvas.getByText("Release verification failed.")).toBeTruthy();
+  },
+  render: () => renderFactorySessionDetailPanel(warningReplaySessionID),
 };
 
 export const DurableReplayDisclosureUnavailable = {
@@ -332,90 +330,31 @@ export const DurableReplayDisclosureUnavailable = {
       fetchMocks: [
         {
           method: "GET",
-          path: `/factory-sessions/dur-sess-js-unavailable-003`,
+          path: `/factory-sessions/${unavailableReplaySessionID}`,
           response: {
-            body: {
-              artifactRefs: [
-                {
-                  id: "artifact-release-verification-log",
-                  kind: "FINAL_RESULT",
-                  label: "Release verification log",
-                  visibility: "PRIVATE",
-                },
-              ],
-              dialect: "you-workflow-v1",
-              lifecycle: {
-                finishedAt: "2026-06-25T11:10:00Z",
-                startedAt: "2026-06-25T11:00:00Z",
-              },
-              orchestratorKind: FactoryOrchestratorKind.JAVASCRIPT,
-              progress: {
-                completedDispatches: 0,
-                failedDispatches: 1,
-                inFlightDispatches: 0,
-                totalDispatches: 1,
-              },
-              resolvedSource: {
-                kind: "WORKFLOW_FILE",
-                sourceRef: "workflow/.claude/workflows/release-verify.yaml",
-                sourceHash: "sha256:release-verify",
-              },
-              resultSummary: {
-                artifactRefs: [
-                  {
-                    id: "artifact-release-verification-log",
-                    kind: "FINAL_RESULT",
-                    label: "Release verification log",
-                    visibility: "PRIVATE",
-                  },
-                ],
-                resultStatus: "FAILED_WITH_PARTIAL",
-                summary:
-                  "Release verification failed after checkpoint recovery.",
-              },
-              sessionId: "dur-sess-js-unavailable-003",
-              status: "FAILED",
-              usage: { resources: [] },
-            },
+            body: buildWarningDurableSession(unavailableReplaySessionID),
           },
         },
         {
           method: "GET",
-          path: "/factory-sessions/dur-sess-js-unavailable-003/events",
+          path: `/factory-sessions/${unavailableReplaySessionID}/events`,
           response: {
             status: 404,
           },
         },
         {
           method: "GET",
-          path: "/factory-sessions/dur-sess-js-unavailable-003/dispatches",
+          path: `/factory-sessions/${unavailableReplaySessionID}/dispatches`,
           response: {
             body: {
               dispatches: [],
-              sessionId: "dur-sess-js-unavailable-003",
+              sessionId: unavailableReplaySessionID,
             },
           },
         },
       ],
-      sessionID: "dur-sess-js-unavailable-003",
+      sessionID: unavailableReplaySessionID,
     },
   },
-  render: () => {
-    const queryClient = new QueryClient({
-      defaultOptions: {
-        queries: {
-          gcTime: Infinity,
-          retry: false,
-        },
-      },
-    });
-
-    return (
-      <div style={{ maxWidth: "100%", width: "960px" }}>
-        <QueryClientProvider client={queryClient}>
-          <FactorySessionDetailPanel sessionID="dur-sess-js-unavailable-003" />
-        </QueryClientProvider>
-      </div>
-    );
-  },
+  render: () => renderFactorySessionDetailPanel(unavailableReplaySessionID),
 };

--- a/ui/src/features/factory-session-detail/components/factory-session-detail-panel.tsx
+++ b/ui/src/features/factory-session-detail/components/factory-session-detail-panel.tsx
@@ -117,6 +117,7 @@ function FactorySessionRuntimeSections({
           locale={locale}
           partialResult={data.partialResult}
           result={data.result}
+          sessionID={data.session.id}
         />
       ) : (
         <PetriSessionProjection locale={locale} petri={runtime.petri} />
@@ -133,6 +134,7 @@ function JavaScriptSessionProjection({
   locale,
   partialResult,
   result,
+  sessionID,
 }: {
   artifacts?: FactoryArtifact[];
   durableLifecycleStatus?: components["schemas"]["FactorySessionDurableLifecycleStatus"];
@@ -141,6 +143,7 @@ function JavaScriptSessionProjection({
   locale?: string;
   partialResult?: components["schemas"]["FactorySessionPartialResult"];
   result?: components["schemas"]["FactorySessionLiveResult"];
+  sessionID: string;
 }) {
   const messages = getFactorySessionDetailMessages(locale);
   const [selectedDispatchID, setSelectedDispatchID] = useState<string | null>(
@@ -155,7 +158,7 @@ function JavaScriptSessionProjection({
     (dispatch) => dispatch.warnings ?? [],
   );
   const supportsEventReplay = isDurableJavaScriptSession(
-    result?.sessionId ?? partialResult?.sessionId ?? "",
+    sessionID,
     FactoryOrchestratorKind.JAVASCRIPT,
     durableLifecycleStatus,
   );
@@ -192,7 +195,7 @@ function JavaScriptSessionProjection({
       {supportsEventReplay ? (
         <FactorySessionEventReplayDisclosure
           locale={locale}
-          sessionID={result?.sessionId ?? partialResult?.sessionId ?? ""}
+          sessionID={sessionID}
         />
       ) : null}
 

--- a/ui/src/features/factory-session-detail/components/factory-session-detail-panel.tsx
+++ b/ui/src/features/factory-session-detail/components/factory-session-detail-panel.tsx
@@ -12,6 +12,7 @@ import {
 import { ExpandablePanelTrigger } from "../../../components/ui/expandable-panel-trigger";
 import { DetailCopy } from "../../../components/ui/widget-frame";
 import { DispatchDetailContent } from "./dispatch-detail-content";
+import { FactorySessionEventReplayDisclosure } from "./event-replay/factory-session-event-replay-disclosure";
 import { useFactorySessionDispatchDetail } from "../hooks/use-factory-session-dispatch-detail";
 import { useFactorySessionDetail } from "../hooks/use-factory-session-detail";
 import {
@@ -21,6 +22,7 @@ import {
 } from "../messages/factory-session-runtime-display";
 import { getFactorySessionDetailMessages } from "../messages/factory-session-detail";
 import { useId, useState } from "react";
+import { isDurableJavaScriptSession } from "../../../api/factory-sessions/normalize-durable-inspection";
 
 type FactoryArtifact = components["schemas"]["FactoryArtifact"];
 type FactoryDispatch = components["schemas"]["FactoryDispatch"];
@@ -109,6 +111,7 @@ function FactorySessionRuntimeSections({
       {runtime.orchestratorKind === FactoryOrchestratorKind.JAVASCRIPT ? (
         <JavaScriptSessionProjection
           artifacts={runtime.artifacts}
+          durableLifecycleStatus={data.durableLifecycleStatus}
           dispatches={runtime.dispatches}
           javascript={runtime.javascript}
           locale={locale}
@@ -124,6 +127,7 @@ function FactorySessionRuntimeSections({
 
 function JavaScriptSessionProjection({
   artifacts,
+  durableLifecycleStatus,
   dispatches,
   javascript,
   locale,
@@ -131,6 +135,7 @@ function JavaScriptSessionProjection({
   result,
 }: {
   artifacts?: FactoryArtifact[];
+  durableLifecycleStatus?: components["schemas"]["FactorySessionDurableLifecycleStatus"];
   dispatches?: FactoryDispatch[];
   javascript?: components["schemas"]["FactorySessionJavaScriptProjection"];
   locale?: string;
@@ -148,6 +153,11 @@ function JavaScriptSessionProjection({
 
   const warnings = (dispatches ?? []).flatMap(
     (dispatch) => dispatch.warnings ?? [],
+  );
+  const supportsEventReplay = isDurableJavaScriptSession(
+    result?.sessionId ?? partialResult?.sessionId ?? "",
+    FactoryOrchestratorKind.JAVASCRIPT,
+    durableLifecycleStatus,
   );
 
   return (
@@ -176,6 +186,13 @@ function JavaScriptSessionProjection({
         <CheckpointRefList
           checkpoints={javascript.checkpoints}
           heading={messages.checkpointRefsHeading}
+        />
+      ) : null}
+
+      {supportsEventReplay ? (
+        <FactorySessionEventReplayDisclosure
+          locale={locale}
+          sessionID={result?.sessionId ?? partialResult?.sessionId ?? ""}
         />
       ) : null}
 

--- a/ui/src/features/factory-session-detail/hooks/use-factory-session-event-replay.ts
+++ b/ui/src/features/factory-session-detail/hooks/use-factory-session-event-replay.ts
@@ -1,11 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
-
-import {
-  listFactorySessionEventReplay,
-  type FactorySessionsAPIError,
-} from "../../../api/factory-sessions";
 import type { FactoryEvent } from "../../../api/events";
+import {
+  type FactorySessionsAPIError,
+  listFactorySessionEventReplay,
+} from "../../../api/factory-sessions";
 
 export const FACTORY_SESSION_EVENT_REPLAY_QUERY_KEY = [
   "factory-session-event-replay",
@@ -14,6 +13,7 @@ export const FACTORY_SESSION_EVENT_REPLAY_QUERY_KEY = [
 export type FactorySessionEventReplayViewState =
   | { status: "idle" }
   | { status: "loading" }
+  | { status: "unavailable"; message?: string }
   | { status: "error"; message?: string }
   | { status: "success"; events: FactoryEvent[] };
 
@@ -29,8 +29,7 @@ export function useFactorySessionEventReplay(
       }
       return listFactorySessionEventReplay(sessionID);
     },
-    enabled:
-      enabled && sessionID !== null && sessionID.trim() !== "",
+    enabled: enabled && sessionID !== null && sessionID.trim() !== "",
     gcTime: 0,
     refetchOnWindowFocus: false,
     retry: false,
@@ -46,6 +45,9 @@ export function useFactorySessionEventReplay(
     }
 
     if (query.error) {
+      if (query.error.status === 404) {
+        return { status: "unavailable" };
+      }
       return { message: query.error.message, status: "error" };
     }
 

--- a/ui/src/features/factory-session-detail/hooks/use-factory-session-event-replay.ts
+++ b/ui/src/features/factory-session-detail/hooks/use-factory-session-event-replay.ts
@@ -1,0 +1,61 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import {
+  listFactorySessionEventReplay,
+  type FactorySessionsAPIError,
+} from "../../../api/factory-sessions";
+import type { FactoryEvent } from "../../../api/events";
+
+export const FACTORY_SESSION_EVENT_REPLAY_QUERY_KEY = [
+  "factory-session-event-replay",
+] as const;
+
+export type FactorySessionEventReplayViewState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "error"; message?: string }
+  | { status: "success"; events: FactoryEvent[] };
+
+export function useFactorySessionEventReplay(
+  sessionID: string | null,
+  enabled: boolean,
+): FactorySessionEventReplayViewState {
+  const query = useQuery<FactoryEvent[], FactorySessionsAPIError>({
+    queryKey: [...FACTORY_SESSION_EVENT_REPLAY_QUERY_KEY, sessionID ?? ""],
+    queryFn: async () => {
+      if (sessionID === null || sessionID.trim() === "") {
+        throw new Error("Factory session event replay requires a session id.");
+      }
+      return listFactorySessionEventReplay(sessionID);
+    },
+    enabled:
+      enabled && sessionID !== null && sessionID.trim() !== "",
+    gcTime: 0,
+    refetchOnWindowFocus: false,
+    retry: false,
+  });
+
+  return useMemo<FactorySessionEventReplayViewState>(() => {
+    if (!enabled || sessionID === null || sessionID.trim() === "") {
+      return { status: "idle" };
+    }
+
+    if (query.isPending || query.isFetching) {
+      return { status: "loading" };
+    }
+
+    if (query.error) {
+      return { message: query.error.message, status: "error" };
+    }
+
+    return { events: query.data ?? [], status: "success" };
+  }, [
+    enabled,
+    query.data,
+    query.error,
+    query.isFetching,
+    query.isPending,
+    sessionID,
+  ]);
+}

--- a/ui/src/features/factory-session-detail/lib/factory-session-event-replay-timeline.ts
+++ b/ui/src/features/factory-session-detail/lib/factory-session-event-replay-timeline.ts
@@ -1,0 +1,282 @@
+import {
+  FACTORY_EVENT_TYPES,
+  type FactoryEvent,
+} from "../../../api/events";
+import { formatDateTime } from "../../../i18n/formatters";
+import type { FactorySessionDetailMessages } from "../messages/factory-session-detail";
+
+export type FactorySessionEventReplayTone =
+  | "danger"
+  | "info"
+  | "neutral"
+  | "success"
+  | "warning";
+
+export interface FactorySessionEventReplayTimelineItem {
+  detail?: string;
+  id: string;
+  orderLabel: string;
+  referenceSummary?: string;
+  timeLabel: string;
+  title: string;
+  tone: FactorySessionEventReplayTone;
+  typeLabel: string;
+}
+
+export function buildFactorySessionEventReplayTimeline(
+  events: FactoryEvent[],
+  messages: FactorySessionDetailMessages,
+  locale?: string,
+): FactorySessionEventReplayTimelineItem[] {
+  return [...events]
+    .sort(compareFactoryReplayEvents)
+    .map((event) => buildTimelineItem(event, messages, locale));
+}
+
+function buildTimelineItem(
+  event: FactoryEvent,
+  messages: FactorySessionDetailMessages,
+  locale?: string,
+): FactorySessionEventReplayTimelineItem {
+  const eventDetails = describeEvent(event, messages);
+  const referenceSummary = buildReferenceSummary(event, messages);
+
+  return {
+    detail: eventDetails.detail,
+    id: event.id,
+    orderLabel: messages.eventReplaySequenceTickLabel(
+      event.context.sessionSequence ?? event.context.sequence,
+      event.context.tick,
+    ),
+    referenceSummary,
+    timeLabel: formatDateTime(event.context.eventTime, locale, {
+      timeZone: "UTC",
+    }),
+    title: eventDetails.title,
+    tone: eventDetails.tone,
+    typeLabel: humanizeEventText(event.type),
+  };
+}
+
+function describeEvent(
+  event: FactoryEvent,
+  messages: FactorySessionDetailMessages,
+): Pick<FactorySessionEventReplayTimelineItem, "detail" | "title" | "tone"> {
+  const payload = asRecord(event.payload);
+
+  switch (event.type) {
+    case FACTORY_EVENT_TYPES.sessionStarted:
+      return {
+        detail: summarizeText(payload.sourceRef),
+        title: messages.eventReplaySessionStartedTitle,
+        tone: "info",
+      };
+    case FACTORY_EVENT_TYPES.orchestratorPhaseChanged:
+    case "JAVASCRIPT_PHASE_CHANGE":
+      return {
+        detail:
+          summarizeText(payload.progressSummary) ??
+          summarizeText(event.context.phaseName) ??
+          summarizeText(payload.phase),
+        title: messages.eventReplayPhaseChangedTitle,
+        tone: "info",
+      };
+    case FACTORY_EVENT_TYPES.dispatchQueued:
+      return {
+        detail: [
+          summarizeText(payload.label),
+          typeof payload.queuePosition === "number"
+            ? messages.eventReplayQueuePositionLabel(payload.queuePosition)
+            : undefined,
+        ]
+          .filter(Boolean)
+          .join(" · "),
+        title: messages.eventReplayDispatchQueuedTitle,
+        tone: "info",
+      };
+    case "DISPATCH_RECONCILED": {
+      const status = summarizeText(payload.reconciledStatus);
+      return {
+        detail:
+          summarizeText(asRecord(payload.failureDetail).message) ??
+          (status ? messages.eventReplayDispatchStatusDetail(status) : undefined) ??
+          summarizeText(asRecord(payload.resultArtifactRef).label),
+        title: messages.eventReplayDispatchReconciledTitle,
+        tone: mapStatusTone(status),
+      };
+    }
+    case "DISPATCH_INTERRUPTED":
+      return {
+        detail: [
+          summarizeText(payload.reason),
+          payload.retryPlanned === true
+            ? messages.eventReplayRetryPlannedLabel
+            : undefined,
+        ]
+          .filter(Boolean)
+          .join(" · "),
+        title: messages.eventReplayDispatchInterruptedTitle,
+        tone: payload.retryPlanned === true ? "warning" : "danger",
+      };
+    case FACTORY_EVENT_TYPES.sessionResultUpdated: {
+      const resultStatus = summarizeText(payload.resultStatus);
+      return {
+        detail: resultStatus
+          ? messages.eventReplayResultStatusDetail(resultStatus)
+          : undefined,
+        title: messages.eventReplaySessionResultUpdatedTitle,
+        tone: mapStatusTone(resultStatus),
+      };
+    }
+    case FACTORY_EVENT_TYPES.sessionCompleted: {
+      const finalStatus = summarizeText(payload.finalStatus);
+      return {
+        detail:
+          summarizeText(asRecord(payload.failureDetail).message) ??
+          (finalStatus
+            ? messages.eventReplayLifecycleStatusDetail(finalStatus)
+            : undefined),
+        title: messages.eventReplaySessionCompletedTitle,
+        tone: mapStatusTone(finalStatus),
+      };
+    }
+    case "ORCHESTRATOR_CHECKPOINT_WRITTEN":
+    case "JAVASCRIPT_CHECKPOINT_REF": {
+      const warningCount = Array.isArray(payload.warnings)
+        ? payload.warnings.length
+        : 0;
+      return {
+        detail:
+          summarizeText(payload.label) ??
+          (warningCount > 0
+            ? messages.eventReplayWarningCountLabel(warningCount)
+            : undefined),
+        title: messages.eventReplayCheckpointRecordedTitle,
+        tone: warningCount > 0 ? "warning" : "info",
+      };
+    }
+    default:
+      return {
+        detail: undefined,
+        title: humanizeEventText(event.type),
+        tone: "neutral",
+      };
+  }
+}
+
+function buildReferenceSummary(
+  event: FactoryEvent,
+  messages: FactorySessionDetailMessages,
+): string | undefined {
+  const payload = asRecord(event.payload);
+  const references: string[] = [];
+  const phase = summarizeText(event.context.phaseName ?? event.context.phaseId);
+  if (phase) {
+    references.push(messages.eventReplayPhaseLabel(phase));
+  }
+  if (event.context.dispatchId) {
+    references.push(messages.eventReplayDispatchLabel(event.context.dispatchId));
+  }
+  if (event.context.checkpointId) {
+    references.push(
+      messages.eventReplayCheckpointLabel(event.context.checkpointId),
+    );
+  }
+
+  const artifactIDs = extractArtifactIDs(payload);
+  if (artifactIDs.length === 1) {
+    references.push(messages.eventReplayArtifactLabel(artifactIDs[0]));
+  } else if (artifactIDs.length > 1) {
+    references.push(messages.eventReplayArtifactCountLabel(artifactIDs.length));
+  }
+
+  if (event.context.workIds && event.context.workIds.length > 0) {
+    references.push(messages.eventReplayWorkLabel(event.context.workIds.length));
+  }
+
+  return references.length > 0
+    ? references.join(" · ")
+    : messages.eventReplayNoContext;
+}
+
+function extractArtifactIDs(payload: Record<string, unknown>): string[] {
+  const ids: string[] = [];
+  if (Array.isArray(payload.artifactIds)) {
+    for (const artifactID of payload.artifactIds) {
+      if (typeof artifactID === "string" && artifactID.trim() !== "") {
+        ids.push(artifactID);
+      }
+    }
+  }
+
+  const artifactRef = asRecord(payload.artifactRef);
+  if (typeof artifactRef.id === "string" && artifactRef.id.trim() !== "") {
+    ids.push(artifactRef.id);
+  }
+
+  const resultArtifactRef = asRecord(payload.resultArtifactRef);
+  if (
+    typeof resultArtifactRef.id === "string" &&
+    resultArtifactRef.id.trim() !== ""
+  ) {
+    ids.push(resultArtifactRef.id);
+  }
+
+  return [...new Set(ids)];
+}
+
+function compareFactoryReplayEvents(left: FactoryEvent, right: FactoryEvent): number {
+  const leftSequence = left.context.sessionSequence ?? left.context.sequence;
+  const rightSequence = right.context.sessionSequence ?? right.context.sequence;
+  if (leftSequence !== rightSequence) {
+    return leftSequence - rightSequence;
+  }
+  if (left.context.sequence !== right.context.sequence) {
+    return left.context.sequence - right.context.sequence;
+  }
+  return left.context.eventTime.localeCompare(right.context.eventTime);
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function summarizeText(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function humanizeEventText(value: string): string {
+  return value
+    .toLowerCase()
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function mapStatusTone(status: string | undefined): FactorySessionEventReplayTone {
+  switch (status) {
+    case "COMPLETED":
+    case "FINAL":
+    case "FINISHED":
+    case "SUCCEEDED":
+      return "success";
+    case "FAILED":
+    case "FAILED_WITH_PARTIAL":
+    case "INTERRUPTED":
+    case "TERMINATED":
+    case "TIMED_OUT":
+      return "danger";
+    case "CANCELED":
+    case "PAUSED":
+    case "UNAVAILABLE":
+      return "warning";
+    default:
+      return "neutral";
+  }
+}

--- a/ui/src/features/factory-session-detail/messages/factory-session-detail.event-replay.ts
+++ b/ui/src/features/factory-session-detail/messages/factory-session-detail.event-replay.ts
@@ -1,0 +1,123 @@
+export interface FactorySessionEventReplayMessages {
+  eventReplayArtifactCountLabel: (count: number) => string;
+  eventReplayArtifactLabel: (artifactID: string) => string;
+  eventReplayCheckpointRecordedTitle: string;
+  eventReplayCheckpointLabel: (checkpointID: string) => string;
+  eventReplayDispatchInterruptedTitle: string;
+  eventReplayDispatchLabel: (dispatchID: string) => string;
+  eventReplayDispatchQueuedTitle: string;
+  eventReplayDispatchReconciledTitle: string;
+  eventReplayDispatchStatusDetail: (status: string) => string;
+  eventReplayEmptyState: string;
+  eventReplayErrorState: string;
+  eventReplayHeading: string;
+  eventReplayHint: string;
+  eventReplayLifecycleStatusDetail: (status: string) => string;
+  eventReplayLoadingState: string;
+  eventReplayNoContext: string;
+  eventReplayPhaseChangedTitle: string;
+  eventReplayPhaseLabel: (phase: string) => string;
+  eventReplayQueuePositionLabel: (queuePosition: number) => string;
+  eventReplayResultStatusDetail: (status: string) => string;
+  eventReplayRetryPlannedLabel: string;
+  eventReplaySequenceTickLabel: (sequence: number, tick: number) => string;
+  eventReplaySessionCompletedTitle: string;
+  eventReplaySessionResultUpdatedTitle: string;
+  eventReplaySessionStartedTitle: string;
+  eventReplaySequenceLabel: (sequence: number) => string;
+  eventReplaySummary: (visibleCount: number, totalCount: number) => string;
+  eventReplayVisibleSummary: (visibleCount: number) => string;
+  eventReplayWarningCountLabel: (count: number) => string;
+  eventReplayWorkLabel: (count: number) => string;
+  expandEventReplayLabel: string;
+  collapseEventReplayLabel: string;
+}
+
+export const englishFactorySessionEventReplayMessages =
+  {
+    eventReplayArtifactCountLabel: (count) =>
+      `${count} Factory Artifact${count === 1 ? "" : "s"}`,
+    eventReplayArtifactLabel: (artifactID) => `Factory Artifact ${artifactID}`,
+    eventReplayCheckpointRecordedTitle: "Checkpoint recorded",
+    eventReplayCheckpointLabel: (checkpointID) => `Checkpoint ${checkpointID}`,
+    eventReplayDispatchInterruptedTitle: "Dispatch interrupted",
+    eventReplayDispatchLabel: (dispatchID) => `Dispatch ${dispatchID}`,
+    eventReplayDispatchQueuedTitle: "Dispatch queued",
+    eventReplayDispatchReconciledTitle: "Dispatch reconciled",
+    eventReplayDispatchStatusDetail: (status) =>
+      `Dispatch status ${status.toLowerCase().replaceAll("_", " ")}`,
+    eventReplayEmptyState:
+      "No durable Factory Events are available for this session.",
+    eventReplayErrorState: "The Factory Event replay could not be loaded.",
+    eventReplayHeading: "Factory Event replay",
+    eventReplayHint:
+      "Reveal bounded durable Factory Event history without leaving this session detail view.",
+    eventReplayLifecycleStatusDetail: (status) =>
+      `Lifecycle status ${status.toLowerCase().replaceAll("_", " ")}`,
+    eventReplayLoadingState: "Loading durable Factory Event replay…",
+    eventReplayNoContext: "Session-level Factory Event",
+    eventReplayPhaseChangedTitle: "Phase changed",
+    eventReplayPhaseLabel: (phase) => `Phase ${phase}`,
+    eventReplayQueuePositionLabel: (queuePosition) =>
+      `Queue position ${queuePosition}`,
+    eventReplayResultStatusDetail: (status) =>
+      `Result status ${status.toLowerCase().replaceAll("_", " ")}`,
+    eventReplayRetryPlannedLabel: "Retry planned",
+    eventReplaySequenceTickLabel: (sequence, tick) =>
+      `Session event ${sequence} · Tick ${tick}`,
+    eventReplaySessionCompletedTitle: "Session completed",
+    eventReplaySessionResultUpdatedTitle: "Session result updated",
+    eventReplaySessionStartedTitle: "Session started",
+    eventReplaySequenceLabel: (sequence) => `Session event ${sequence}`,
+    eventReplaySummary: (visibleCount, totalCount) =>
+      `Showing the latest ${visibleCount} of ${totalCount} Factory Events.`,
+    eventReplayVisibleSummary: (visibleCount) =>
+      `Showing ${visibleCount} Factory Event${visibleCount === 1 ? "" : "s"}.`,
+    eventReplayWarningCountLabel: (count) =>
+      `${count} warning${count === 1 ? "" : "s"}`,
+    eventReplayWorkLabel: (count) =>
+      `${count} related work item${count === 1 ? "" : "s"}`,
+    expandEventReplayLabel: "Expand Factory Event replay",
+    collapseEventReplayLabel: "Collapse Factory Event replay",
+  } satisfies FactorySessionEventReplayMessages;
+
+export const chineseFactorySessionEventReplayMessages =
+  {
+    eventReplayArtifactCountLabel: (count) => `${count} 个工厂工件`,
+    eventReplayArtifactLabel: (artifactID) => `工厂工件 ${artifactID}`,
+    eventReplayCheckpointRecordedTitle: "已记录检查点",
+    eventReplayCheckpointLabel: (checkpointID) => `检查点 ${checkpointID}`,
+    eventReplayDispatchInterruptedTitle: "调度已中断",
+    eventReplayDispatchLabel: (dispatchID) => `调度 ${dispatchID}`,
+    eventReplayDispatchQueuedTitle: "调度已排队",
+    eventReplayDispatchReconciledTitle: "调度已对账",
+    eventReplayDispatchStatusDetail: (status) =>
+      `调度状态 ${status.toLowerCase().replaceAll("_", " ")}`,
+    eventReplayEmptyState: "此会话没有可用的持久化工厂事件。",
+    eventReplayErrorState: "无法加载工厂事件回放。",
+    eventReplayHeading: "工厂事件回放",
+    eventReplayHint: "在当前会话详情内展开受限的持久化工厂事件历史。",
+    eventReplayLifecycleStatusDetail: (status) =>
+      `生命周期状态 ${status.toLowerCase().replaceAll("_", " ")}`,
+    eventReplayLoadingState: "正在加载持久化工厂事件回放…",
+    eventReplayNoContext: "会话级工厂事件",
+    eventReplayPhaseChangedTitle: "阶段已变更",
+    eventReplayPhaseLabel: (phase) => `阶段 ${phase}`,
+    eventReplayQueuePositionLabel: (queuePosition) => `队列位置 ${queuePosition}`,
+    eventReplayResultStatusDetail: (status) =>
+      `结果状态 ${status.toLowerCase().replaceAll("_", " ")}`,
+    eventReplayRetryPlannedLabel: "计划重试",
+    eventReplaySequenceTickLabel: (sequence, tick) =>
+      `会话事件 ${sequence} · Tick ${tick}`,
+    eventReplaySessionCompletedTitle: "会话已完成",
+    eventReplaySessionResultUpdatedTitle: "会话结果已更新",
+    eventReplaySessionStartedTitle: "会话已启动",
+    eventReplaySequenceLabel: (sequence) => `会话事件 ${sequence}`,
+    eventReplaySummary: (visibleCount, totalCount) =>
+      `显示最新 ${visibleCount} / ${totalCount} 条工厂事件。`,
+    eventReplayVisibleSummary: (visibleCount) => `显示 ${visibleCount} 条工厂事件。`,
+    eventReplayWarningCountLabel: (count) => `${count} 条警告`,
+    eventReplayWorkLabel: (count) => `${count} 个关联工作项`,
+    expandEventReplayLabel: "展开工厂事件回放",
+    collapseEventReplayLabel: "收起工厂事件回放",
+  } satisfies FactorySessionEventReplayMessages;

--- a/ui/src/features/factory-session-detail/messages/factory-session-detail.event-replay.ts
+++ b/ui/src/features/factory-session-detail/messages/factory-session-detail.event-replay.ts
@@ -26,6 +26,7 @@ export interface FactorySessionEventReplayMessages {
   eventReplaySessionStartedTitle: string;
   eventReplaySequenceLabel: (sequence: number) => string;
   eventReplaySummary: (visibleCount: number, totalCount: number) => string;
+  eventReplayUnavailableState: string;
   eventReplayVisibleSummary: (visibleCount: number) => string;
   eventReplayWarningCountLabel: (count: number) => string;
   eventReplayWorkLabel: (count: number) => string;
@@ -71,6 +72,8 @@ export const englishFactorySessionEventReplayMessages =
     eventReplaySequenceLabel: (sequence) => `Session event ${sequence}`,
     eventReplaySummary: (visibleCount, totalCount) =>
       `Showing the latest ${visibleCount} of ${totalCount} Factory Events.`,
+    eventReplayUnavailableState:
+      "Durable Factory Event replay is unavailable for this session.",
     eventReplayVisibleSummary: (visibleCount) =>
       `Showing ${visibleCount} Factory Event${visibleCount === 1 ? "" : "s"}.`,
     eventReplayWarningCountLabel: (count) =>
@@ -115,6 +118,7 @@ export const chineseFactorySessionEventReplayMessages =
     eventReplaySequenceLabel: (sequence) => `会话事件 ${sequence}`,
     eventReplaySummary: (visibleCount, totalCount) =>
       `显示最新 ${visibleCount} / ${totalCount} 条工厂事件。`,
+    eventReplayUnavailableState: "此会话的持久化工厂事件回放不可用。",
     eventReplayVisibleSummary: (visibleCount) => `显示 ${visibleCount} 条工厂事件。`,
     eventReplayWarningCountLabel: (count) => `${count} 条警告`,
     eventReplayWorkLabel: (count) => `${count} 个关联工作项`,

--- a/ui/src/features/factory-session-detail/messages/factory-session-detail.messages.test.ts
+++ b/ui/src/features/factory-session-detail/messages/factory-session-detail.messages.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import { getFactorySessionDetailMessages } from "./factory-session-detail";
+
+describe("factory session detail messages", () => {
+  it("formats english replay and dispatch detail labels through the shared catalog", () => {
+    const messages = getFactorySessionDetailMessages("en");
+
+    expect(messages.eventReplayArtifactCountLabel(2)).toBe(
+      "2 Factory Artifacts",
+    );
+    expect(messages.eventReplayArtifactLabel("artifact-7")).toBe(
+      "Factory Artifact artifact-7",
+    );
+    expect(messages.eventReplayCheckpointLabel("checkpoint-4")).toBe(
+      "Checkpoint checkpoint-4",
+    );
+    expect(messages.eventReplayDispatchLabel("dispatch-9")).toBe(
+      "Dispatch dispatch-9",
+    );
+    expect(messages.eventReplayDispatchStatusDetail("FAILED_WITH_PARTIAL")).toBe(
+      "Dispatch status failed with partial",
+    );
+    expect(messages.eventReplayLifecycleStatusDetail("AWAITING_APPROVAL")).toBe(
+      "Lifecycle status awaiting approval",
+    );
+    expect(messages.eventReplayPhaseLabel("review")).toBe("Phase review");
+    expect(messages.eventReplayQueuePositionLabel(3)).toBe("Queue position 3");
+    expect(messages.eventReplayResultStatusDetail("FAILED_WITH_PARTIAL")).toBe(
+      "Result status failed with partial",
+    );
+    expect(messages.eventReplaySequenceTickLabel(4, 9)).toBe(
+      "Session event 4 · Tick 9",
+    );
+    expect(messages.eventReplaySequenceLabel(5)).toBe("Session event 5");
+    expect(messages.eventReplaySummary(25, 140)).toBe(
+      "Showing the latest 25 of 140 Factory Events.",
+    );
+    expect(messages.eventReplayVisibleSummary(1)).toBe(
+      "Showing 1 Factory Event.",
+    );
+    expect(messages.eventReplayVisibleSummary(3)).toBe(
+      "Showing 3 Factory Events.",
+    );
+    expect(messages.eventReplayWarningCountLabel(1)).toBe("1 warning");
+    expect(messages.eventReplayWarningCountLabel(4)).toBe("4 warnings");
+    expect(messages.eventReplayWorkLabel(1)).toBe("1 related work item");
+    expect(messages.eventReplayWorkLabel(2)).toBe("2 related work items");
+    expect(messages.expandDispatchDetailLabel("dispatch-9")).toBe(
+      "Expand dispatch detail for dispatch-9",
+    );
+    expect(messages.collapseDispatchDetailLabel("dispatch-9")).toBe(
+      "Collapse dispatch detail for dispatch-9",
+    );
+  });
+
+  it("formats zh-CN replay and dispatch detail labels through the shared catalog", () => {
+    const messages = getFactorySessionDetailMessages("zh-CN");
+
+    expect(messages.eventReplayArtifactCountLabel(2)).toBe("2 个工厂工件");
+    expect(messages.eventReplayArtifactLabel("artifact-7")).toBe(
+      "工厂工件 artifact-7",
+    );
+    expect(messages.eventReplayCheckpointLabel("checkpoint-4")).toBe(
+      "检查点 checkpoint-4",
+    );
+    expect(messages.eventReplayDispatchLabel("dispatch-9")).toBe(
+      "调度 dispatch-9",
+    );
+    expect(messages.eventReplayDispatchStatusDetail("FAILED_WITH_PARTIAL")).toBe(
+      "调度状态 failed with partial",
+    );
+    expect(messages.eventReplayLifecycleStatusDetail("AWAITING_APPROVAL")).toBe(
+      "生命周期状态 awaiting approval",
+    );
+    expect(messages.eventReplayPhaseLabel("review")).toBe("阶段 review");
+    expect(messages.eventReplayQueuePositionLabel(3)).toBe("队列位置 3");
+    expect(messages.eventReplayResultStatusDetail("FAILED_WITH_PARTIAL")).toBe(
+      "结果状态 failed with partial",
+    );
+    expect(messages.eventReplaySequenceTickLabel(4, 9)).toBe(
+      "会话事件 4 · Tick 9",
+    );
+    expect(messages.eventReplaySequenceLabel(5)).toBe("会话事件 5");
+    expect(messages.eventReplaySummary(25, 140)).toBe(
+      "显示最新 25 / 140 条工厂事件。",
+    );
+    expect(messages.eventReplayVisibleSummary(3)).toBe("显示 3 条工厂事件。");
+    expect(messages.eventReplayWarningCountLabel(4)).toBe("4 条警告");
+    expect(messages.eventReplayWorkLabel(2)).toBe("2 个关联工作项");
+    expect(messages.expandDispatchDetailLabel("dispatch-9")).toBe(
+      "展开 dispatch-9 的调度详情",
+    );
+    expect(messages.collapseDispatchDetailLabel("dispatch-9")).toBe(
+      "收起 dispatch-9 的调度详情",
+    );
+  });
+});

--- a/ui/src/features/factory-session-detail/messages/factory-session-detail.ts
+++ b/ui/src/features/factory-session-detail/messages/factory-session-detail.ts
@@ -34,6 +34,21 @@ export interface FactorySessionDetailMessages {
   dynamicWorkflowShorthand: string;
   executionModeLabel: string;
   enabledTransitionsHeading: string;
+  eventReplayCheckpointLabel: (checkpointID: string) => string;
+  eventReplayDispatchLabel: (dispatchID: string) => string;
+  eventReplayEmptyState: string;
+  eventReplayErrorState: string;
+  eventReplayHeading: string;
+  eventReplayHint: string;
+  eventReplayLoadingState: string;
+  eventReplayNoContext: string;
+  eventReplayPhaseLabel: (phase: string) => string;
+  eventReplaySequenceLabel: (sequence: number) => string;
+  eventReplaySummary: (visibleCount: number, totalCount: number) => string;
+  eventReplayVisibleSummary: (visibleCount: number) => string;
+  eventReplayWorkLabel: (count: number) => string;
+  expandEventReplayLabel: string;
+  collapseEventReplayLabel: string;
   errorState: string;
   expandDispatchDetailLabel: (dispatchID: string) => string;
   failureDetailHeading: string;
@@ -224,6 +239,25 @@ const factorySessionDetailMessagesByLocale = {
     dynamicWorkflowShorthand: "Dynamic workflow (JavaScript factory session)",
     executionModeLabel: "Execution mode",
     enabledTransitionsHeading: "Enabled transitions",
+    eventReplayCheckpointLabel: (checkpointID) => `Checkpoint ${checkpointID}`,
+    eventReplayDispatchLabel: (dispatchID) => `Dispatch ${dispatchID}`,
+    eventReplayEmptyState: "No durable Factory Events are available for this session.",
+    eventReplayErrorState: "The Factory Event replay could not be loaded.",
+    eventReplayHeading: "Factory Event replay",
+    eventReplayHint:
+      "Reveal bounded durable Factory Event history without leaving this session detail view.",
+    eventReplayLoadingState: "Loading durable Factory Event replay…",
+    eventReplayNoContext: "Session-level Factory Event",
+    eventReplayPhaseLabel: (phase) => `Phase ${phase}`,
+    eventReplaySequenceLabel: (sequence) => `Session event ${sequence}`,
+    eventReplaySummary: (visibleCount, totalCount) =>
+      `Showing the latest ${visibleCount} of ${totalCount} Factory Events.`,
+    eventReplayVisibleSummary: (visibleCount) =>
+      `Showing ${visibleCount} Factory Event${visibleCount === 1 ? "" : "s"}.`,
+    eventReplayWorkLabel: (count) =>
+      `${count} related work item${count === 1 ? "" : "s"}`,
+    expandEventReplayLabel: "Expand Factory Event replay",
+    collapseEventReplayLabel: "Collapse Factory Event replay",
     errorState: "The factory session runtime could not be loaded.",
     expandDispatchDetailLabel: (dispatchID) =>
       `Expand dispatch detail for ${dispatchID}`,
@@ -300,6 +334,23 @@ const factorySessionDetailMessagesByLocale = {
     dynamicWorkflowShorthand: "动态工作流（JavaScript 工厂会话）",
     executionModeLabel: "执行模式",
     enabledTransitionsHeading: "已启用变迁",
+    eventReplayCheckpointLabel: (checkpointID) => `检查点 ${checkpointID}`,
+    eventReplayDispatchLabel: (dispatchID) => `调度 ${dispatchID}`,
+    eventReplayEmptyState: "此会话没有可用的持久化工厂事件。",
+    eventReplayErrorState: "无法加载工厂事件回放。",
+    eventReplayHeading: "工厂事件回放",
+    eventReplayHint: "在当前会话详情内展开受限的持久化工厂事件历史。",
+    eventReplayLoadingState: "正在加载持久化工厂事件回放…",
+    eventReplayNoContext: "会话级工厂事件",
+    eventReplayPhaseLabel: (phase) => `阶段 ${phase}`,
+    eventReplaySequenceLabel: (sequence) => `会话事件 ${sequence}`,
+    eventReplaySummary: (visibleCount, totalCount) =>
+      `显示最新 ${visibleCount} / ${totalCount} 条工厂事件。`,
+    eventReplayVisibleSummary: (visibleCount) =>
+      `显示 ${visibleCount} 条工厂事件。`,
+    eventReplayWorkLabel: (count) => `${count} 个关联工作项`,
+    expandEventReplayLabel: "展开工厂事件回放",
+    collapseEventReplayLabel: "收起工厂事件回放",
     errorState: "无法加载工厂会话运行时。",
     expandDispatchDetailLabel: (dispatchID) => `展开 ${dispatchID} 的调度详情`,
     failureDetailHeading: "失败详情",

--- a/ui/src/features/factory-session-detail/messages/factory-session-detail.ts
+++ b/ui/src/features/factory-session-detail/messages/factory-session-detail.ts
@@ -9,8 +9,14 @@ import {
   type LocalizedMessageCatalog,
   resolveLocalizedMessages,
 } from "../../../i18n";
+import {
+  chineseFactorySessionEventReplayMessages,
+  englishFactorySessionEventReplayMessages,
+  type FactorySessionEventReplayMessages,
+} from "./factory-session-detail.event-replay";
 
-export interface FactorySessionDetailMessages {
+export interface FactorySessionDetailMessages
+  extends FactorySessionEventReplayMessages {
   artifactLinksHeading: string;
   artifactRefActionLabel: string;
   artifactsHeading: string;
@@ -34,21 +40,6 @@ export interface FactorySessionDetailMessages {
   dynamicWorkflowShorthand: string;
   executionModeLabel: string;
   enabledTransitionsHeading: string;
-  eventReplayCheckpointLabel: (checkpointID: string) => string;
-  eventReplayDispatchLabel: (dispatchID: string) => string;
-  eventReplayEmptyState: string;
-  eventReplayErrorState: string;
-  eventReplayHeading: string;
-  eventReplayHint: string;
-  eventReplayLoadingState: string;
-  eventReplayNoContext: string;
-  eventReplayPhaseLabel: (phase: string) => string;
-  eventReplaySequenceLabel: (sequence: number) => string;
-  eventReplaySummary: (visibleCount: number, totalCount: number) => string;
-  eventReplayVisibleSummary: (visibleCount: number) => string;
-  eventReplayWorkLabel: (count: number) => string;
-  expandEventReplayLabel: string;
-  collapseEventReplayLabel: string;
   errorState: string;
   expandDispatchDetailLabel: (dispatchID: string) => string;
   failureDetailHeading: string;
@@ -239,25 +230,7 @@ const factorySessionDetailMessagesByLocale = {
     dynamicWorkflowShorthand: "Dynamic workflow (JavaScript factory session)",
     executionModeLabel: "Execution mode",
     enabledTransitionsHeading: "Enabled transitions",
-    eventReplayCheckpointLabel: (checkpointID) => `Checkpoint ${checkpointID}`,
-    eventReplayDispatchLabel: (dispatchID) => `Dispatch ${dispatchID}`,
-    eventReplayEmptyState: "No durable Factory Events are available for this session.",
-    eventReplayErrorState: "The Factory Event replay could not be loaded.",
-    eventReplayHeading: "Factory Event replay",
-    eventReplayHint:
-      "Reveal bounded durable Factory Event history without leaving this session detail view.",
-    eventReplayLoadingState: "Loading durable Factory Event replay…",
-    eventReplayNoContext: "Session-level Factory Event",
-    eventReplayPhaseLabel: (phase) => `Phase ${phase}`,
-    eventReplaySequenceLabel: (sequence) => `Session event ${sequence}`,
-    eventReplaySummary: (visibleCount, totalCount) =>
-      `Showing the latest ${visibleCount} of ${totalCount} Factory Events.`,
-    eventReplayVisibleSummary: (visibleCount) =>
-      `Showing ${visibleCount} Factory Event${visibleCount === 1 ? "" : "s"}.`,
-    eventReplayWorkLabel: (count) =>
-      `${count} related work item${count === 1 ? "" : "s"}`,
-    expandEventReplayLabel: "Expand Factory Event replay",
-    collapseEventReplayLabel: "Collapse Factory Event replay",
+    ...englishFactorySessionEventReplayMessages,
     errorState: "The factory session runtime could not be loaded.",
     expandDispatchDetailLabel: (dispatchID) =>
       `Expand dispatch detail for ${dispatchID}`,
@@ -334,23 +307,7 @@ const factorySessionDetailMessagesByLocale = {
     dynamicWorkflowShorthand: "动态工作流（JavaScript 工厂会话）",
     executionModeLabel: "执行模式",
     enabledTransitionsHeading: "已启用变迁",
-    eventReplayCheckpointLabel: (checkpointID) => `检查点 ${checkpointID}`,
-    eventReplayDispatchLabel: (dispatchID) => `调度 ${dispatchID}`,
-    eventReplayEmptyState: "此会话没有可用的持久化工厂事件。",
-    eventReplayErrorState: "无法加载工厂事件回放。",
-    eventReplayHeading: "工厂事件回放",
-    eventReplayHint: "在当前会话详情内展开受限的持久化工厂事件历史。",
-    eventReplayLoadingState: "正在加载持久化工厂事件回放…",
-    eventReplayNoContext: "会话级工厂事件",
-    eventReplayPhaseLabel: (phase) => `阶段 ${phase}`,
-    eventReplaySequenceLabel: (sequence) => `会话事件 ${sequence}`,
-    eventReplaySummary: (visibleCount, totalCount) =>
-      `显示最新 ${visibleCount} / ${totalCount} 条工厂事件。`,
-    eventReplayVisibleSummary: (visibleCount) =>
-      `显示 ${visibleCount} 条工厂事件。`,
-    eventReplayWorkLabel: (count) => `${count} 个关联工作项`,
-    expandEventReplayLabel: "展开工厂事件回放",
-    collapseEventReplayLabel: "收起工厂事件回放",
+    ...chineseFactorySessionEventReplayMessages,
     errorState: "无法加载工厂会话运行时。",
     expandDispatchDetailLabel: (dispatchID) => `展开 ${dispatchID} 的调度详情`,
     failureDetailHeading: "失败详情",

--- a/ui/src/testing/factory-session-event-replay-fixtures.ts
+++ b/ui/src/testing/factory-session-event-replay-fixtures.ts
@@ -2,6 +2,7 @@ import { FactoryOrchestratorKind } from "../api/generated/openapi";
 
 export const successfulReplaySessionID = "dur-sess-js-success-002";
 export const warningReplaySessionID = "dur-sess-js-warning-003";
+export const awaitingReplaySessionID = "dur-sess-js-awaiting-001";
 export const unavailableReplaySessionID = "dur-sess-js-unavailable-003";
 
 export function buildSuccessfulDurableSession(sessionId = successfulReplaySessionID) {
@@ -82,6 +83,36 @@ export function buildWarningDurableSession(sessionId = warningReplaySessionID) {
     },
     sessionId,
     status: "FAILED",
+    usage: { resources: [] },
+  };
+}
+
+export function buildAwaitingDurableSession(sessionId = awaitingReplaySessionID) {
+  return {
+    artifactRefs: [],
+    dialect: "you-workflow-v1",
+    lifecycle: {
+      awaitingApprovalAt: "2026-06-08T15:00:01Z",
+      queuedAt: "2026-06-08T15:00:00Z",
+    },
+    orchestratorKind: FactoryOrchestratorKind.JAVASCRIPT,
+    progress: {
+      completedDispatches: 0,
+      failedDispatches: 0,
+      inFlightDispatches: 0,
+      totalDispatches: 0,
+    },
+    resolvedSource: {
+      kind: "WORKFLOW_FILE",
+      sourceRef: "workflow/.claude/workflows/policy-gated-release.yaml",
+      sourceHash: "sha256:js-workflow-policy-gated-release",
+    },
+    resultSummary: {
+      resultStatus: "NOT_READY",
+      summary: "Awaiting orchestrator policy approval before execution.",
+    },
+    sessionId,
+    status: "AWAITING_APPROVAL",
     usage: { resources: [] },
   };
 }
@@ -249,6 +280,48 @@ export function buildWarningReplayEventStream(
         failureDetail: {
           message: "Release verification failed.",
         },
+      },
+    })}`,
+    "",
+  ].join("\n");
+}
+
+export function buildAwaitingReplayEventStream(
+  sessionId = awaitingReplaySessionID,
+) {
+  return [
+    `data: ${JSON.stringify({
+      id: "session-started/dur-sess-js-awaiting-001",
+      type: "SESSION_STARTED",
+      context: {
+        sequence: 1,
+        tick: 1,
+        eventTime: "2026-06-08T15:00:00Z",
+        sessionId,
+        sessionSequence: 0,
+        phaseName: "approval",
+      },
+      payload: {
+        sourceRef: "workflow/.claude/workflows/policy-gated-release.yaml",
+        sourceHash: "sha256:js-workflow-policy-gated-release",
+        policyHash: "eff-policy-gated-release",
+        startedAt: "2026-06-08T15:00:00Z",
+      },
+    })}`,
+    "",
+    `data: ${JSON.stringify({
+      id: "session-result-updated/dur-sess-js-awaiting-001",
+      type: "SESSION_RESULT_UPDATED",
+      context: {
+        sequence: 2,
+        tick: 2,
+        eventTime: "2026-06-08T15:00:01Z",
+        sessionId,
+        sessionSequence: 1,
+        phaseName: "approval",
+      },
+      payload: {
+        resultStatus: "NOT_READY",
       },
     })}`,
     "",

--- a/ui/src/testing/factory-session-event-replay-fixtures.ts
+++ b/ui/src/testing/factory-session-event-replay-fixtures.ts
@@ -1,0 +1,290 @@
+import { FactoryOrchestratorKind } from "../api/generated/openapi";
+
+export const successfulReplaySessionID = "dur-sess-js-success-002";
+export const warningReplaySessionID = "dur-sess-js-warning-003";
+export const unavailableReplaySessionID = "dur-sess-js-unavailable-003";
+
+export function buildSuccessfulDurableSession(sessionId = successfulReplaySessionID) {
+  return {
+    artifactRefs: [
+      {
+        id: "art-js-success-001",
+        kind: "FINAL_RESULT",
+        label: "Docs refresh output",
+        visibility: "PUBLIC",
+      },
+    ],
+    dialect: "you-workflow-v1",
+    lifecycle: {
+      finishedAt: "2026-06-08T13:10:00Z",
+      startedAt: "2026-06-08T13:00:02Z",
+    },
+    orchestratorKind: FactoryOrchestratorKind.JAVASCRIPT,
+    progress: {
+      completedDispatches: 2,
+      failedDispatches: 0,
+      inFlightDispatches: 0,
+      totalDispatches: 2,
+    },
+    resolvedSource: {
+      kind: "WORKFLOW_FILE",
+      sourceRef: "workflow/.claude/workflows/docs-refresh.yaml",
+      sourceHash: "sha256:js-workflow-docs-refresh",
+    },
+    resultSummary: {
+      resultStatus: "FINAL",
+      summary: "Documentation refresh complete.",
+    },
+    sessionId,
+    status: "SUCCEEDED",
+    usage: { resources: [] },
+  };
+}
+
+export function buildWarningDurableSession(sessionId = warningReplaySessionID) {
+  return {
+    artifactRefs: [
+      {
+        id: "artifact-release-verification-log",
+        kind: "FINAL_RESULT",
+        label: "Release verification log",
+        visibility: "PRIVATE",
+      },
+    ],
+    dialect: "you-workflow-v1",
+    lifecycle: {
+      finishedAt: "2026-06-25T11:10:00Z",
+      startedAt: "2026-06-25T11:00:00Z",
+    },
+    orchestratorKind: FactoryOrchestratorKind.JAVASCRIPT,
+    progress: {
+      completedDispatches: 0,
+      failedDispatches: 1,
+      inFlightDispatches: 0,
+      totalDispatches: 1,
+    },
+    resolvedSource: {
+      kind: "WORKFLOW_FILE",
+      sourceRef: "workflow/.claude/workflows/release-verify.yaml",
+      sourceHash: "sha256:release-verify",
+    },
+    resultSummary: {
+      artifactRefs: [
+        {
+          id: "artifact-release-verification-log",
+          kind: "FINAL_RESULT",
+          label: "Release verification log",
+          visibility: "PRIVATE",
+        },
+      ],
+      resultStatus: "FAILED_WITH_PARTIAL",
+      summary: "Release verification failed after checkpoint recovery.",
+    },
+    sessionId,
+    status: "FAILED",
+    usage: { resources: [] },
+  };
+}
+
+export function buildSuccessfulReplayEventStream(
+  sessionId = successfulReplaySessionID,
+) {
+  return [
+    `data: ${JSON.stringify({
+      id: "evt-1",
+      type: "SESSION_STARTED",
+      context: {
+        sequence: 1,
+        tick: 1,
+        eventTime: "2026-06-25T10:00:00Z",
+        sessionId,
+        sessionSequence: 1,
+        phaseName: "plan",
+      },
+      payload: { startedAt: "2026-06-25T10:00:00Z" },
+    })}`,
+    "",
+    `data: ${JSON.stringify({
+      id: "evt-2",
+      type: "ORCHESTRATOR_PHASE_CHANGED",
+      context: {
+        sequence: 2,
+        tick: 2,
+        eventTime: "2026-06-25T10:00:01Z",
+        sessionId,
+        sessionSequence: 2,
+        phaseName: "review",
+      },
+      payload: {
+        phase: "review",
+        progressSummary: "Review work scheduled.",
+      },
+    })}`,
+    "",
+    `data: ${JSON.stringify({
+      id: "evt-3",
+      type: "DISPATCH_QUEUED",
+      context: {
+        sequence: 3,
+        tick: 3,
+        eventTime: "2026-06-25T10:00:02Z",
+        sessionId,
+        sessionSequence: 3,
+        phaseName: "review",
+        dispatchId: "dispatch-1",
+        workIds: ["work-1", "work-2"],
+      },
+      payload: {
+        dispatchKind: "JAVASCRIPT_AGENT",
+        label: "Draft release notes",
+        queuePosition: 1,
+      },
+    })}`,
+    "",
+    `data: ${JSON.stringify({
+      id: "evt-4",
+      type: "DISPATCH_RECONCILED",
+      context: {
+        sequence: 4,
+        tick: 4,
+        eventTime: "2026-06-25T10:00:03Z",
+        sessionId,
+        sessionSequence: 4,
+        phaseName: "review",
+        dispatchId: "dispatch-1",
+      },
+      payload: {
+        reconciledStatus: "COMPLETED",
+        resultArtifactRef: {
+          id: "artifact-release-notes",
+          kind: "FINAL_RESULT",
+          label: "Release notes",
+        },
+        artifactIds: ["artifact-release-notes"],
+      },
+    })}`,
+    "",
+    `data: ${JSON.stringify({
+      id: "evt-5",
+      type: "SESSION_COMPLETED",
+      context: {
+        sequence: 5,
+        tick: 5,
+        eventTime: "2026-06-25T10:00:05Z",
+        sessionId,
+        sessionSequence: 5,
+        phaseName: "review",
+      },
+      payload: {
+        finalStatus: "SUCCEEDED",
+        completedAt: "2026-06-25T10:00:05Z",
+        artifactIds: ["artifact-release-notes"],
+      },
+    })}`,
+    "",
+  ].join("\n");
+}
+
+export function buildWarningReplayEventStream(
+  sessionId = warningReplaySessionID,
+) {
+  return [
+    `data: ${JSON.stringify({
+      id: "evt-w1",
+      type: "JAVASCRIPT_CHECKPOINT_REF",
+      context: {
+        sequence: 1,
+        tick: 1,
+        eventTime: "2026-06-25T11:00:01Z",
+        sessionId,
+        sessionSequence: 1,
+        phaseName: "verify",
+        checkpointId: "checkpoint-9",
+      },
+      payload: {
+        label: "Checkpoint before publish",
+        warnings: [
+          {
+            code: "CHECKPOINT_STALE",
+            message: "Checkpoint is older than the latest source hash.",
+          },
+        ],
+      },
+    })}`,
+    "",
+    `data: ${JSON.stringify({
+      id: "evt-w2",
+      type: "DISPATCH_INTERRUPTED",
+      context: {
+        sequence: 2,
+        tick: 2,
+        eventTime: "2026-06-25T11:00:02Z",
+        sessionId,
+        sessionSequence: 2,
+        phaseName: "verify",
+        dispatchId: "dispatch-verify",
+      },
+      payload: {
+        reason: "Provider session timed out",
+        observedStatus: "RUNNING",
+        interruptedAt: "2026-06-25T11:00:02Z",
+        retryPlanned: true,
+      },
+    })}`,
+    "",
+    `data: ${JSON.stringify({
+      id: "evt-w3",
+      type: "SESSION_COMPLETED",
+      context: {
+        sequence: 3,
+        tick: 3,
+        eventTime: "2026-06-25T11:00:05Z",
+        sessionId,
+        sessionSequence: 3,
+        phaseName: "verify",
+      },
+      payload: {
+        finalStatus: "FAILED",
+        completedAt: "2026-06-25T11:00:05Z",
+        failureDetail: {
+          message: "Release verification failed.",
+        },
+      },
+    })}`,
+    "",
+  ].join("\n");
+}
+
+export function buildSuccessfulReplayDispatchList(
+  sessionId = successfulReplaySessionID,
+) {
+  return {
+    dispatches: [
+      {
+        dispatchKind: "JAVASCRIPT_AGENT",
+        id: "dispatch-1",
+        outputArtifactIds: [],
+        phase: "review",
+        status: "COMPLETED",
+      },
+    ],
+    sessionId,
+  };
+}
+
+export function buildWarningReplayDispatchList(
+  sessionId = warningReplaySessionID,
+) {
+  return {
+    dispatches: [
+      {
+        dispatchKind: "JAVASCRIPT_VERIFY",
+        id: "dispatch-verify",
+        outputArtifactIds: ["artifact-release-verification-log"],
+        phase: "verify",
+        status: "FAILED",
+      },
+    ],
+    sessionId,
+  };
+}

--- a/ui/src/testing/replay-coverage.test.ts
+++ b/ui/src/testing/replay-coverage.test.ts
@@ -46,6 +46,16 @@ describe("replay coverage reporting", () => {
     );
   });
 
+  it("renders uncovered surfaces as none yet in the markdown matrix", () => {
+    const markdown = formatReplayCoverageReportMarkdown(
+      buildReplayCoverageReport(),
+    );
+
+    expect(markdown).toContain(
+      "| `script-request-history` | gap | none yet | Replay-driven mixed script and inference request-history rendering. |",
+    );
+  });
+
   it("reuses the replay coverage catalog for browser integration scenarios", () => {
     expect(
       listBrowserIntegrationReplayScenarios().map((scenario) => scenario.id),
@@ -70,6 +80,36 @@ describe("replay coverage reporting", () => {
   it("keeps replay coverage metadata internally consistent", () => {
     expect(validateReplayCoverageReport(buildReplayCoverageReport())).toEqual(
       [],
+    );
+  });
+
+  it("reports invalid scenario and surface metadata explicitly", () => {
+    const report = buildReplayCoverageReport();
+    const invalidReport = structuredClone(report);
+
+    invalidReport.scenarios[0] = {
+      ...invalidReport.scenarios[0],
+      surfaces: [],
+      verificationLayers: [],
+    };
+    invalidReport.scenarios[1] = {
+      ...invalidReport.scenarios[1],
+      surfaces: ["unknown-surface"],
+    };
+    invalidReport.surfaces[0] = {
+      ...invalidReport.surfaces[0],
+      scenarios: ["missing-scenario"],
+      status: "gap",
+    };
+
+    expect(validateReplayCoverageReport(invalidReport)).toEqual(
+      expect.arrayContaining([
+        "Scenario 'baseline' is missing verification layers.",
+        "Scenario 'baseline' is missing covered surfaces.",
+        "Scenario 'failureAnalysis' references unknown surface 'unknown-surface'.",
+        "Surface 'dashboard-shell' has status 'gap' but should be 'covered'.",
+        "Surface 'dashboard-shell' references unknown scenario 'missing-scenario'.",
+      ]),
     );
   });
 });

--- a/ui/src/testing/replay-fixtures.test.ts
+++ b/ui/src/testing/replay-fixtures.test.ts
@@ -4,6 +4,7 @@ import { FACTORY_EVENT_TYPES } from "../api/events";
 import {
   buildReplayFixtureTimelineSnapshot,
   loadReplayFixtureEvents,
+  parseReplayFixtureEvents,
   REPLAY_FIXTURE_DIRECTORY,
   replayFixtureCatalog,
 } from "./replay-fixtures";
@@ -29,6 +30,38 @@ describe("replay fixture helpers", () => {
     expect(events.every((event) => typeof event.id === "string")).toBe(true);
   });
 
+  it("parses raw replay fixture text into trimmed typed events", () => {
+    expect(
+      parseReplayFixtureEvents(
+        [
+          "",
+          "  ",
+          JSON.stringify({
+            context: { tick: 2 },
+            id: "evt-a",
+            type: FACTORY_EVENT_TYPES.sessionStarted,
+          }),
+          "",
+          JSON.stringify({
+            context: { tick: 3 },
+            id: "evt-b",
+            type: FACTORY_EVENT_TYPES.sessionCompleted,
+          }),
+          "",
+        ].join("\n"),
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        id: "evt-a",
+        type: FACTORY_EVENT_TYPES.sessionStarted,
+      }),
+      expect.objectContaining({
+        id: "evt-b",
+        type: FACTORY_EVENT_TYPES.sessionCompleted,
+      }),
+    ]);
+  });
+
   it("builds timeline snapshots through the canonical replay projection seam", () => {
     const snapshot = buildReplayFixtureTimelineSnapshot(
       "runtimeConfigInterfaceConsolidation",
@@ -43,6 +76,18 @@ describe("replay fixture helpers", () => {
     );
   });
 
+  it("derives the latest tick when no replay snapshot tick is provided", () => {
+    const snapshot = buildReplayFixtureTimelineSnapshot("baseline");
+    const latestTick = Math.max(
+      ...loadReplayFixtureEvents("baseline").map((event) => event.context.tick),
+    );
+
+    expect(snapshot.tick_count).toBeGreaterThan(0);
+    expect(snapshot.tick_count).toBe(latestTick);
+  });
+});
+
+describe("replay fixture projections", () => {
   it("preserves setup-workspace python3 script requests and task handoff evidence", () => {
     const events = loadReplayFixtureEvents(
       "runtimeConfigInterfaceConsolidation",
@@ -107,5 +152,11 @@ describe("replay fixture helpers", () => {
       "Rejected Story",
       "Reworked Story",
     ]);
+  });
+
+  it("rejects unknown replay fixture ids at the helper boundary", () => {
+    expect(() =>
+      loadReplayFixtureEvents("unknown-fixture" as keyof typeof replayFixtureCatalog),
+    ).toThrowError("Unknown replay fixture: unknown-fixture");
   });
 });


### PR DESCRIPTION
{
  "project": "Add Bounded Durable Event Replay Disclosure To The Factory Session Website Detail Surface",
  "branchName": "dynamic-workflows-cell-website-event-replay",
  "description": "Extend the existing Factory Session website detail experience with one bounded durable event replay disclosure for JavaScript-backed sessions so customers can inspect ordered replayable Factory Event history from the current session detail surface, with explicit sparse-data states, shared vocabulary, and focused verification.",
  "context": {
    "customerAsk": "Extend the existing factory-session detail experience with one bounded durable event replay disclosure for JavaScript-backed Factory Sessions so a user can inspect replayable Factory Event history or a bounded event timeline without leaving the current session detail surface.",
    "problem": "The website already shows durable Factory Session summary data, dispatch drilldown, artifact drilldown, and result references, but it still lacks a bounded way to inspect the durable event history that produced those projections. Customers can see current state without being able to reconstruct the ordered session timeline from the website.",
    "solution": "Reuse the shared durable Factory Event read path and the existing Factory Session detail feature family. Add one bounded disclosure inside the current session detail surface that loads, normalizes, and renders ordered durable event history using customer-facing Factory Session, Factory Event, Dispatch, and Factory Artifact vocabulary, while keeping loading, empty, unavailable, error, and success states explicit and adding only minimal shared contract shaping if required."
  },
  "acceptanceCriteria": [
    "A customer can reveal bounded durable Factory Event replay detail from the existing Factory Session detail surface without navigating to a new website route or feature family.",
    "The replay disclosure renders an ordered event timeline for a JavaScript-backed durable Factory Session using shared Factory Event data and customer-facing Factory Session, Dispatch, and Factory Artifact vocabulary.",
    "The replay disclosure shows explicit loading, empty, unavailable, error, and success states so sparse or missing replay data stays understandable.",
    "If the durable event contract needs a small extension, backend, generated types, adapters, and website projections stay aligned and bounded to the replay disclosure need.",
    "Deterministic fixtures and focused tests prove at least one successful session timeline and one warning or failed session timeline without regressing the existing session detail, dispatch drilldown, or artifact drilldown behavior.",
    "Quality gate passes: typecheck, lint, and the narrow relevant tests pass."
  ],
  "userStories": [
    {
      "id": "dynamic-workflows-cell-website-event-replay-001",
      "title": "Reveal bounded replay detail from the existing Factory Session surface",
      "description": "As a customer inspecting a durable JavaScript Factory Session, I want one focused interaction in the existing detail surface to reveal replay history so that I can inspect how the session progressed without leaving the current inspection flow.",
      "acceptanceCriteria": [
        "The existing Factory Session detail surface exposes one bounded replay disclosure interaction for JavaScript-backed durable sessions.",
        "Activating the interaction reveals replay content inline on the existing session detail surface instead of navigating to a separate route, modal, or event explorer.",
        "The replay disclosure remains scoped to durable Factory Event history for the currently selected Factory Session and does not widen into lifecycle controls or live-provider inspection.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using the Browser plugin"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "dynamic-workflows-cell-website-event-replay-002",
      "title": "Render a bounded durable Factory Event timeline with shared vocabulary",
      "description": "As a customer reviewing replay history, I want the website to show an ordered durable event timeline so that I can understand the sequence of session activity and related dispatch or artifact context.",
      "acceptanceCriteria": [
        "The replay disclosure renders a bounded ordered list or timeline of durable Factory Events for the selected session.",
        "Each rendered event shows the customer-usable metadata already supported by the backend, such as event kind, ordering or timestamp information, status or severity cues when present, and related session, dispatch, artifact, or result references when available.",
        "Event presentation stays within shared Factory Session, Factory Event, Dispatch, and Factory Artifact vocabulary rather than introducing workflow-run-specific naming.",
        "If the durable event payload exposes a small shaping gap, the fix is made through shared contract or normalization boundaries rather than a website-only synthetic event model.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using the Browser plugin"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "dynamic-workflows-cell-website-event-replay-003",
      "title": "Keep sparse and failed replay states explicit and understandable",
      "description": "As a customer opening replay history for different session outcomes, I want explicit non-success and sparse-data states so that the website explains what replay information is available instead of collapsing into blank space or ambiguous fallback copy.",
      "acceptanceCriteria": [
        "The replay disclosure renders an explicit loading state while durable event history is being read.",
        "When a session has no durable replayable events in scope, the disclosure renders an explicit empty state.",
        "When durable replay is unsupported, unavailable, or omitted for the selected session, the disclosure renders an explicit unavailable state without breaking the rest of the session detail surface.",
        "When the replay read fails, the disclosure renders an explicit error state consistent with existing website inspection patterns.",
        "The non-success states stay inside the existing Factory Session detail surface and do not regress the adjacent dispatch or artifact drilldown panels.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using the Browser plugin"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "dynamic-workflows-cell-website-event-replay-004",
      "title": "Prove replay disclosure against successful and warning or failed durable timelines",
      "description": "As a maintainer landing website replay inspection, I want deterministic fixtures and focused verification so that the bounded event replay disclosure is reviewable, regression-resistant, and safe to extend later.",
      "acceptanceCriteria": [
        "Deterministic durable fixtures cover at least one successful session timeline and one warning or failed session timeline for the replay disclosure.",
        "Focused adapter, hook, or UI tests prove success, empty, and error or unavailable replay states without regressing the existing session detail, dispatch drilldown, or artifact drilldown behavior.",
        "Browser-sensitive verification covers the replay disclosure interaction and confirms the timeline or disclosure layout remains usable when event history is present.",
        "Deferred follow-up such as lifecycle controls, live-provider-only diagnostics, or a standalone event browser remains out of scope rather than being bundled into this lane.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}
