### PR TITLE
system-factory-files-bug

### DIFF
--- a/pkg/config/portable_bundled_files.go
+++ b/pkg/config/portable_bundled_files.go
@@ -27,7 +27,8 @@ const portableBundledBatchInputDirName = "BATCH"
 // discovered on disk into cfg, optionally inlining file content for API/export
 // callers that need a self-contained manifest. When discoverUnlistedDocs is
 // false and the manifest already lists DOC entries, only manifest-listed docs
-// are merged from disk so authored deletes and renames stay authoritative.
+// and nested docs under factory/docs/** subdirectories are merged from disk so
+// authored top-level deletes and renames stay authoritative.
 func ApplySupportedPortableBundledFiles(factoryDir string, cfg *interfaces.FactoryConfig, includeInlineContent bool, discoverUnlistedDocs bool) error {
 	if cfg == nil {
 		return nil
@@ -335,12 +336,23 @@ func filterCollectedPortableBundledFiles(existing, collected []interfaces.Bundle
 
 	filtered := make([]interfaces.BundledFileConfig, 0, len(collected))
 	for _, bundledFile := range collected {
-		if bundledFile.Type == interfaces.BundledFileTypeDoc && !manifestDocPaths[bundledFile.TargetPath] {
+		if bundledFile.Type == interfaces.BundledFileTypeDoc &&
+			!manifestDocPaths[bundledFile.TargetPath] &&
+			!isNestedPortableBundledDocTarget(bundledFile.TargetPath) {
 			continue
 		}
 		filtered = append(filtered, bundledFile)
 	}
 	return filtered
+}
+
+func isNestedPortableBundledDocTarget(targetPath string) bool {
+	normalized := filepath.ToSlash(strings.TrimSpace(targetPath))
+	if !strings.HasPrefix(normalized, portableBundledDocRoot) {
+		return false
+	}
+	relativePath := strings.TrimPrefix(normalized, portableBundledDocRoot)
+	return strings.Contains(relativePath, "/")
 }
 
 func manifestDocTargetPaths(bundledFiles []interfaces.BundledFileConfig) map[string]bool {

--- a/pkg/config/portabletests/portable_bundled_files_integration_test.go
+++ b/pkg/config/portabletests/portable_bundled_files_integration_test.go
@@ -12,6 +12,72 @@ import (
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 )
 
+func TestPortableBundledFiles_FlattenAndLoadIncludeNestedDocsUnderFactoryDocs(t *testing.T) {
+	projectDir, sourceDir := seedPortableBundledRoundTripFactory(t)
+
+	const nestedDocPath = "factory/docs/standards/review.md"
+	const nestedDocBody = "# Review standards\n"
+	writePortableBundledRoundTripFile(t, filepath.Join(sourceDir, "docs", "standards", "review.md"), nestedDocBody)
+
+	writePortableBundledRoundTripFile(t, filepath.Join(sourceDir, interfaces.FactoryConfigFile), `{
+  "name":"portable-bundled-roundtrip-factory",
+  "supportingFiles":{
+    "bundledFiles":[
+      {"type":"DOC","targetPath":"factory/docs/README.md","content":{}}
+    ]
+  },
+  "workTypes": [{"name":"task","states":[{"name":"init","type":"INITIAL"},{"name":"complete","type":"TERMINAL"},{"name":"failed","type":"FAILED"}]}],
+  "workers": [{"name":"executor"}],
+  "workstations": [{
+    "name":"execute-story",
+    "worker":"executor",
+    "inputs":[{"workType":"task","state":"init"}],
+    "outputs":[{"workType":"task","state":"complete"}],
+    "onFailure":[{"workType":"task","state":"failed"}]
+  }]
+}`)
+
+	flattened, err := factoryconfig.FlattenFactoryConfig(sourceDir)
+	if err != nil {
+		t.Fatalf("FlattenFactoryConfig: %v", err)
+	}
+	cfg, err := factoryconfig.FactoryConfigFromOpenAPIJSON(flattened)
+	if err != nil {
+		t.Fatalf("FactoryConfigFromOpenAPIJSON: %v", err)
+	}
+	if cfg.ResourceManifest == nil {
+		t.Fatal("expected flattened config to include resourceManifest")
+	}
+	assertBundledFileRoundTripEntry(
+		t,
+		findPortableBundledFileByTarget(t, cfg.ResourceManifest.BundledFiles, nestedDocPath),
+		interfaces.BundledFileTypeDoc,
+		nestedDocPath,
+		nestedDocBody,
+	)
+
+	portableDir := t.TempDir()
+	portablePath := filepath.Join(portableDir, interfaces.FactoryConfigFile)
+	if err := os.WriteFile(portablePath, flattened, 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", portablePath, err)
+	}
+	copyPortableBundledDiskBackedExport(t, projectDir, sourceDir, portableDir)
+	copyPortableBundledExportFile(t, filepath.Join(sourceDir, "docs", "standards", "review.md"), filepath.Join(portableDir, "docs", "standards", "review.md"))
+
+	loaded, err := factoryconfig.LoadRuntimeConfig(portableDir, nil)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfig(nested docs): %v", err)
+	}
+	if loaded.FactoryConfig() == nil || loaded.FactoryConfig().ResourceManifest == nil {
+		t.Fatal("expected loaded config to include resourceManifest")
+	}
+	nested := findPortableBundledFileByTarget(t, loaded.FactoryConfig().ResourceManifest.BundledFiles, nestedDocPath)
+	if nested.TargetPath != nestedDocPath {
+		t.Fatalf("loaded nested doc target = %q, want %q", nested.TargetPath, nestedDocPath)
+	}
+	assertPortableBundledRoundTripFile(t, filepath.Join(portableDir, "docs", "standards", "review.md"), nestedDocBody)
+}
+
 func TestPortableBundledFiles_FlattenOmitsGitkeepFromExportPayload(t *testing.T) {
 	projectDir, sourceDir := seedPortableBundledRoundTripFactory(t)
 
@@ -632,6 +698,18 @@ func assertPortableBundledFilesExcludeGitkeep(t *testing.T, bundledFiles []inter
 			t.Fatalf("bundled file targetPath must not include .gitkeep: %#v", bundledFile)
 		}
 	}
+}
+
+func findPortableBundledFileByTarget(t *testing.T, bundledFiles []interfaces.BundledFileConfig, targetPath string) interfaces.BundledFileConfig {
+	t.Helper()
+
+	for _, bundledFile := range bundledFiles {
+		if bundledFile.TargetPath == targetPath {
+			return bundledFile
+		}
+	}
+	t.Fatalf("bundled files missing target %q: %#v", targetPath, bundledFiles)
+	return interfaces.BundledFileConfig{}
 }
 
 func assertBundledFileRoundTripEntry(t *testing.T, bundledFile interfaces.BundledFileConfig, wantType, wantTargetPath, wantInline string) {

--- a/pkg/config/runtime_config_additional_test.go
+++ b/pkg/config/runtime_config_additional_test.go
@@ -611,6 +611,49 @@ func TestMergePortableBundledFiles_ManifestAuthoritativeDocsSkipsUnlistedDiskDoc
 	}
 }
 
+func TestMergePortableBundledFiles_ManifestAuthoritativeDocsIncludesNestedUnlistedDiskDocs(t *testing.T) {
+	existing := []interfaces.BundledFileConfig{{
+		Type:       interfaces.BundledFileTypeDoc,
+		TargetPath: "factory/docs/README.md",
+		Content: interfaces.BundledFileContentConfig{
+			Encoding: interfaces.BundledFileEncodingUTF8,
+		},
+	}}
+	collected := []interfaces.BundledFileConfig{
+		{
+			Type:       interfaces.BundledFileTypeDoc,
+			TargetPath: "factory/docs/README.md",
+			Content: interfaces.BundledFileContentConfig{
+				Encoding: interfaces.BundledFileEncodingUTF8,
+				Inline:   "# Factory docs\n",
+			},
+		},
+		{
+			Type:       interfaces.BundledFileTypeDoc,
+			TargetPath: "factory/docs/standards/review.md",
+			Content: interfaces.BundledFileContentConfig{
+				Encoding: interfaces.BundledFileEncodingUTF8,
+				Inline:   "# Review standards\n",
+			},
+		},
+		{
+			Type:       interfaces.BundledFileTypeDoc,
+			TargetPath: "factory/docs/orphan.md",
+			Content: interfaces.BundledFileContentConfig{
+				Encoding: interfaces.BundledFileEncodingUTF8,
+				Inline:   "orphan content",
+			},
+		},
+	}
+
+	merged := mergePortableBundledFiles(existing, collected, false)
+	if len(merged) != 2 {
+		t.Fatalf("merged bundled files = %#v, want listed and nested docs only", merged)
+	}
+	assertPortableBundledDocsMergeTarget(t, merged, "factory/docs/README.md", "# Factory docs\n")
+	assertPortableBundledDocsMergeTarget(t, merged, "factory/docs/standards/review.md", "# Review standards\n")
+}
+
 func TestMergePortableBundledFiles_DiscoverUnlistedDocsAddsDiskOnlyDocs(t *testing.T) {
 	existing := []interfaces.BundledFileConfig{{
 		Type:       interfaces.BundledFileTypeDoc,
@@ -689,4 +732,19 @@ func assertPortableBundledDocsTestFile(t *testing.T, path, want string) {
 	if string(data) != want {
 		t.Fatalf("file %s = %q, want %q", path, string(data), want)
 	}
+}
+
+func assertPortableBundledDocsMergeTarget(t *testing.T, merged []interfaces.BundledFileConfig, targetPath, wantInline string) {
+	t.Helper()
+
+	for _, bundledFile := range merged {
+		if bundledFile.TargetPath != targetPath {
+			continue
+		}
+		if bundledFile.Content.Inline != wantInline {
+			t.Fatalf("merged doc %q inline = %q, want %q", targetPath, bundledFile.Content.Inline, wantInline)
+		}
+		return
+	}
+	t.Fatalf("merged bundled files missing target %q: %#v", targetPath, merged)
 }

--- a/pkg/service/factory_editable_definition.go
+++ b/pkg/service/factory_editable_definition.go
@@ -178,7 +178,7 @@ func (fs *FactoryService) serializeNamedFactory(
 		if err != nil {
 			return factoryapi.Factory{}, fmt.Errorf("clone named factory config: %w", err)
 		}
-		if err := factoryconfig.ApplySupportedPortableBundledFiles(current.FactoryDir(), clonedFactoryCfg, true, false); err != nil {
+		if err := factoryconfig.ApplySupportedPortableBundledFiles(current.FactoryDir(), clonedFactoryCfg, true, true); err != nil {
 			return factoryapi.Factory{}, fmt.Errorf("inline named factory bundled files: %w", err)
 		}
 		if err := factoryconfig.ApplySharedFactoryStarterWork(current.FactoryDir(), clonedFactoryCfg); err != nil {
@@ -212,7 +212,7 @@ func (fs *FactoryService) serializeNamedFactoryUpsertResponse(
 		if err != nil {
 			return factoryapi.Factory{}, fmt.Errorf("clone named factory config: %w", err)
 		}
-		if err := factoryconfig.ApplySupportedPortableBundledFiles(current.FactoryDir(), clonedFactoryCfg, false, false); err != nil {
+		if err := factoryconfig.ApplySupportedPortableBundledFiles(current.FactoryDir(), clonedFactoryCfg, false, true); err != nil {
 			return factoryapi.Factory{}, fmt.Errorf("merge named factory portable bundled files: %w", err)
 		}
 		if err := factoryconfig.ApplySharedFactoryStarterWork(current.FactoryDir(), clonedFactoryCfg); err != nil {

--- a/pkg/service/factory_editable_definition.go
+++ b/pkg/service/factory_editable_definition.go
@@ -178,7 +178,7 @@ func (fs *FactoryService) serializeNamedFactory(
 		if err != nil {
 			return factoryapi.Factory{}, fmt.Errorf("clone named factory config: %w", err)
 		}
-		if err := factoryconfig.ApplySupportedPortableBundledFiles(current.FactoryDir(), clonedFactoryCfg, true, true); err != nil {
+		if err := factoryconfig.ApplySupportedPortableBundledFiles(current.FactoryDir(), clonedFactoryCfg, true, false); err != nil {
 			return factoryapi.Factory{}, fmt.Errorf("inline named factory bundled files: %w", err)
 		}
 		if err := factoryconfig.ApplySharedFactoryStarterWork(current.FactoryDir(), clonedFactoryCfg); err != nil {
@@ -212,7 +212,7 @@ func (fs *FactoryService) serializeNamedFactoryUpsertResponse(
 		if err != nil {
 			return factoryapi.Factory{}, fmt.Errorf("clone named factory config: %w", err)
 		}
-		if err := factoryconfig.ApplySupportedPortableBundledFiles(current.FactoryDir(), clonedFactoryCfg, false, true); err != nil {
+		if err := factoryconfig.ApplySupportedPortableBundledFiles(current.FactoryDir(), clonedFactoryCfg, false, false); err != nil {
 			return factoryapi.Factory{}, fmt.Errorf("merge named factory portable bundled files: %w", err)
 		}
 		if err := factoryconfig.ApplySharedFactoryStarterWork(current.FactoryDir(), clonedFactoryCfg); err != nil {

--- a/pkg/service/factory_test.go
+++ b/pkg/service/factory_test.go
@@ -2709,6 +2709,47 @@ func TestFactoryService_GetCurrentFactory_CollectsSupportedPortableBundledFilesF
 	assertServiceBundledFactoryEntry(t, bundledFiles[1], factoryapi.BundledFileTypeSCRIPT, "factory/scripts/execute-story.ps1", servicePortableBundledScriptBody)
 }
 
+func TestFactoryService_GetCurrentFactory_CollectsNestedFactoryDocsFromDisk(t *testing.T) {
+	const nestedDocPath = "factory/docs/standards/review.md"
+	const nestedDocBody = "# Review standards\n"
+
+	rootDir := t.TempDir()
+
+	if _, err := config.PersistNamedFactory(rootDir, "alpha", serviceNamedFactoryPayload(t, "alpha")); err != nil {
+		t.Fatalf("PersistNamedFactory(alpha): %v", err)
+	}
+	if err := config.WriteCurrentFactoryPointer(rootDir, "alpha"); err != nil {
+		t.Fatalf("WriteCurrentFactoryPointer(alpha): %v", err)
+	}
+
+	alphaDir := filepath.Join(rootDir, "alpha")
+	writePortableServiceBundledFile(t, filepath.Join(alphaDir, "docs", "README.md"), "# Portable factory\n")
+	writePortableServiceBundledFile(t, filepath.Join(alphaDir, "docs", "standards", "review.md"), nestedDocBody)
+	writePortableServiceBundledFile(t, filepath.Join(alphaDir, "scripts", "execute-story.ps1"), servicePortableBundledScriptBody)
+
+	svc, err := BuildFactoryService(context.Background(), &FactoryServiceConfig{
+		Dir:               rootDir,
+		MockWorkersConfig: config.NewEmptyMockWorkersConfig(),
+		Logger:            zap.NewNop(),
+	})
+	if err != nil {
+		t.Fatalf("BuildFactoryService: %v", err)
+	}
+
+	current, err := svc.GetCurrentFactory(context.Background())
+	if err != nil {
+		t.Fatalf("GetCurrentFactory: %v", err)
+	}
+
+	got := serviceBundledFilesByTarget(t, current)
+	if entry, ok := got[nestedDocPath]; !ok {
+		t.Fatalf("current factory bundled files = %#v, want nested doc %q", got, nestedDocPath)
+	} else {
+		assertServiceBundledFactoryEntry(t, entry, factoryapi.BundledFileTypeDOC, nestedDocPath, nestedDocBody)
+	}
+	assertServiceBundledFactoryEntry(t, got["factory/docs/README.md"], factoryapi.BundledFileTypeDOC, "factory/docs/README.md", "# Portable factory\n")
+}
+
 func TestFactoryService_GetCurrentFactory_InlinesPortableFilesAndStarterInputs(t *testing.T) {
 	rootDir := t.TempDir()
 

--- a/pkg/service/factory_test.go
+++ b/pkg/service/factory_test.go
@@ -2750,6 +2750,88 @@ func TestFactoryService_GetCurrentFactory_CollectsNestedFactoryDocsFromDisk(t *t
 	assertServiceBundledFactoryEntry(t, got["factory/docs/README.md"], factoryapi.BundledFileTypeDOC, "factory/docs/README.md", "# Portable factory\n")
 }
 
+func TestFactoryService_GetCurrentFactory_ManifestAuthoritativeDocsExcludeUnlistedTopLevelOrphans(t *testing.T) {
+	const nestedDocPath = "factory/docs/standards/review.md"
+	const nestedDocBody = "# Review standards\n"
+	const orphanDocPath = "factory/docs/orphan.md"
+
+	rootDir := t.TempDir()
+	payload, err := json.Marshal(map[string]any{
+		"name": "alpha",
+		"id":   "alpha",
+		"workTypes": []map[string]any{{
+			"name": "task",
+			"states": []map[string]string{
+				{"name": "init", "type": "INITIAL"},
+				{"name": "complete", "type": "TERMINAL"},
+				{"name": "failed", "type": "FAILED"},
+			},
+		}},
+		"workers": []map[string]any{{
+			"name":          "worker-a",
+			"type":          "MODEL_WORKER",
+			"modelProvider": "CODEX",
+			"model":         "gpt-5-codex",
+			"body":          "You are worker alpha.",
+		}},
+		"workstations": []map[string]any{{
+			"name":      "process",
+			"worker":    "worker-a",
+			"inputs":    []map[string]string{{"workType": "task", "state": "init"}},
+			"outputs":   []map[string]string{{"workType": "task", "state": "complete"}},
+			"onFailure": []map[string]string{{"workType": "task", "state": "failed"}},
+			"type":      "MODEL_WORKSTATION",
+			"body":      "Do the alpha work.",
+		}},
+		"supportingFiles": map[string]any{
+			"bundledFiles": []map[string]any{{
+				"type":       "DOC",
+				"targetPath": "factory/docs/README.md",
+				"content": map[string]any{
+					"encoding": string(factoryapi.BundledFileContentEncodingUtf8),
+					"inline":   "# Portable factory\n",
+				},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal named factory payload: %v", err)
+	}
+
+	if _, err := config.PersistNamedFactory(rootDir, "alpha", payload); err != nil {
+		t.Fatalf("PersistNamedFactory(alpha): %v", err)
+	}
+	if err := config.WriteCurrentFactoryPointer(rootDir, "alpha"); err != nil {
+		t.Fatalf("WriteCurrentFactoryPointer(alpha): %v", err)
+	}
+
+	alphaDir := filepath.Join(rootDir, "alpha")
+	writePortableServiceBundledFile(t, filepath.Join(alphaDir, "docs", "README.md"), "# Portable factory\n")
+	writePortableServiceBundledFile(t, filepath.Join(alphaDir, "docs", "orphan.md"), "orphan content\n")
+	writePortableServiceBundledFile(t, filepath.Join(alphaDir, "docs", "standards", "review.md"), nestedDocBody)
+
+	svc, err := BuildFactoryService(context.Background(), &FactoryServiceConfig{
+		Dir:               rootDir,
+		MockWorkersConfig: config.NewEmptyMockWorkersConfig(),
+		Logger:            zap.NewNop(),
+	})
+	if err != nil {
+		t.Fatalf("BuildFactoryService: %v", err)
+	}
+
+	current, err := svc.GetCurrentFactory(context.Background())
+	if err != nil {
+		t.Fatalf("GetCurrentFactory: %v", err)
+	}
+
+	got := serviceBundledFilesByTarget(t, current)
+	if _, ok := got[orphanDocPath]; ok {
+		t.Fatalf("current factory bundled files = %#v, want unlisted top-level orphan doc excluded", got)
+	}
+	assertServiceBundledFactoryEntry(t, got["factory/docs/README.md"], factoryapi.BundledFileTypeDOC, "factory/docs/README.md", "# Portable factory\n")
+	assertServiceBundledFactoryEntry(t, got[nestedDocPath], factoryapi.BundledFileTypeDOC, nestedDocPath, nestedDocBody)
+}
+
 func TestFactoryService_GetCurrentFactory_InlinesPortableFilesAndStarterInputs(t *testing.T) {
 	rootDir := t.TempDir()
 

--- a/tests/functional/bootstrap_portability/export_import_nested_docs_test.go
+++ b/tests/functional/bootstrap_portability/export_import_nested_docs_test.go
@@ -1,0 +1,121 @@
+package bootstrap_portability
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
+)
+
+const (
+	exportImportPortableNestedDocPath = "factory/docs/standards/review.md"
+	exportImportPortableNestedDocBody = "# Review standards\n"
+)
+
+func TestExportImportSmoke_PreservesNestedFactoryDocsThroughExportImport(t *testing.T) {
+	fixture := newExportImportFixture(t)
+	harness := newExportImportSmokeHarness(fixture, withExportImportBeforeExport(seedNestedFactoryDocOnDisk))
+
+	result := harness.Run(t)
+
+	assertNestedFactoryDocInBundledFiles(
+		t,
+		result.ExportedFactory,
+		exportImportPortableNestedDocPath,
+		exportImportPortableNestedDocBody,
+		"exported factory",
+	)
+	assertNestedFactoryDocTargetPresent(
+		t,
+		result.ImportedFactory,
+		exportImportPortableNestedDocPath,
+		"imported factory",
+	)
+	assertNestedFactoryDocTargetPresent(
+		t,
+		result.CurrentFactory,
+		exportImportPortableNestedDocPath,
+		"current factory after import",
+	)
+	assertImportedPortableFile(
+		t,
+		filepath.Join(result.ImportedDir, "docs", "standards", "review.md"),
+		exportImportPortableNestedDocBody,
+	)
+
+	nestedDocPath := filepath.Join(result.SourceFactoryDir, "docs", "standards", "review.md")
+	assertImportedPortableFile(t, nestedDocPath, exportImportPortableNestedDocBody)
+}
+
+func seedNestedFactoryDocOnDisk(t *testing.T, factoryDir string) {
+	t.Helper()
+
+	nestedDocPath := filepath.Join(factoryDir, "docs", "standards", "review.md")
+	if err := os.MkdirAll(filepath.Dir(nestedDocPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(nestedDocPath), err)
+	}
+	if err := os.WriteFile(nestedDocPath, []byte(exportImportPortableNestedDocBody), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", nestedDocPath, err)
+	}
+}
+
+func assertNestedFactoryDocInBundledFiles(
+	t *testing.T,
+	factory factoryapi.Factory,
+	targetPath string,
+	wantInline string,
+	contextLabel string,
+) {
+	t.Helper()
+
+	bundledFile, ok := findBundledFileByTargetPath(factory, targetPath)
+	if !ok {
+		t.Fatalf("%s missing bundled doc target %q", contextLabel, targetPath)
+	}
+	if bundledFile.Type != factoryapi.BundledFileTypeDOC {
+		t.Fatalf(
+			"%s bundled file %q type = %q, want DOC",
+			contextLabel,
+			targetPath,
+			bundledFile.Type,
+		)
+	}
+	if bundledFile.Content.Inline != wantInline {
+		t.Fatalf(
+			"%s bundled doc %q inline = %q, want %q",
+			contextLabel,
+			targetPath,
+			bundledFile.Content.Inline,
+			wantInline,
+		)
+	}
+}
+
+func assertNestedFactoryDocTargetPresent(
+	t *testing.T,
+	factory factoryapi.Factory,
+	targetPath string,
+	contextLabel string,
+) {
+	t.Helper()
+
+	if _, ok := findBundledFileByTargetPath(factory, targetPath); !ok {
+		t.Fatalf("%s missing bundled doc target %q", contextLabel, targetPath)
+	}
+}
+
+func findBundledFileByTargetPath(
+	factory factoryapi.Factory,
+	targetPath string,
+) (factoryapi.BundledFile, bool) {
+	if factory.SupportingFiles == nil || factory.SupportingFiles.BundledFiles == nil {
+		return factoryapi.BundledFile{}, false
+	}
+	for _, bundledFile := range *factory.SupportingFiles.BundledFiles {
+		if bundledFile.TargetPath == targetPath {
+			return bundledFile, true
+		}
+	}
+	return factoryapi.BundledFile{}, false
+}

--- a/ui/src/features/current-factory-definition/lib/doc-editable-values.test.ts
+++ b/ui/src/features/current-factory-definition/lib/doc-editable-values.test.ts
@@ -124,6 +124,26 @@ describe("doc-editable-values", () => {
     expect(resolveEditableDocValues(factoryWithBundledFiles(undefined), "factory/docs/missing.md")).toBeNull();
   });
 
+  it("resolves editable values for nested bundled DOC entries", () => {
+    const nestedDocPath = "factory/docs/standards/review.md";
+    const factory = factoryWithBundledFiles({
+      bundledFiles: [
+        {
+          content: { encoding: "utf-8", inline: "# Review standards\n" },
+          targetPath: nestedDocPath,
+          type: "DOC",
+        },
+      ],
+    });
+
+    expect(resolveEditableDocValues(factory, nestedDocPath)).toEqual({
+      fileName: "standards/review.md",
+      inlineContent: "# Review standards\n",
+      targetPath: nestedDocPath,
+    });
+    expect(listFactoryDocTargetPaths(factory)).toEqual([nestedDocPath]);
+  });
+
   it("lists doc target paths and rejects invalid apply targets", () => {
     const factory = factoryWithBundledFiles({
       bundledFiles: [

--- a/ui/src/features/current-factory-definition/lib/doc-editable-values.test.ts
+++ b/ui/src/features/current-factory-definition/lib/doc-editable-values.test.ts
@@ -124,26 +124,6 @@ describe("doc-editable-values", () => {
     expect(resolveEditableDocValues(factoryWithBundledFiles(undefined), "factory/docs/missing.md")).toBeNull();
   });
 
-  it("resolves editable values for nested bundled DOC entries", () => {
-    const nestedDocPath = "factory/docs/standards/review.md";
-    const factory = factoryWithBundledFiles({
-      bundledFiles: [
-        {
-          content: { encoding: "utf-8", inline: "# Review standards\n" },
-          targetPath: nestedDocPath,
-          type: "DOC",
-        },
-      ],
-    });
-
-    expect(resolveEditableDocValues(factory, nestedDocPath)).toEqual({
-      fileName: "standards/review.md",
-      inlineContent: "# Review standards\n",
-      targetPath: nestedDocPath,
-    });
-    expect(listFactoryDocTargetPaths(factory)).toEqual([nestedDocPath]);
-  });
-
   it("lists doc target paths and rejects invalid apply targets", () => {
     const factory = factoryWithBundledFiles({
       bundledFiles: [
@@ -181,5 +161,27 @@ describe("doc-editable-values", () => {
         },
       ),
     ).toBeNull();
+  });
+});
+
+describe("doc-editable-values nested docs", () => {
+  it("resolves editable values for nested bundled DOC entries", () => {
+    const nestedDocPath = "factory/docs/standards/review.md";
+    const factory = factoryWithBundledFiles({
+      bundledFiles: [
+        {
+          content: { encoding: "utf-8", inline: "# Review standards\n" },
+          targetPath: nestedDocPath,
+          type: "DOC",
+        },
+      ],
+    });
+
+    expect(resolveEditableDocValues(factory, nestedDocPath)).toEqual({
+      fileName: "standards/review.md",
+      inlineContent: "# Review standards\n",
+      targetPath: nestedDocPath,
+    });
+    expect(listFactoryDocTargetPaths(factory)).toEqual([nestedDocPath]);
   });
 });

--- a/ui/src/features/current-selection/doc-selection/hooks/use-doc-detail-state.test.ts
+++ b/ui/src/features/current-selection/doc-selection/hooks/use-doc-detail-state.test.ts
@@ -20,6 +20,35 @@ describe("useDocDetailState", () => {
     });
   });
 
+  it("loads nested doc text from the graph-editor pending factory", () => {
+    const nestedDocPath = "factory/docs/standards/review.md";
+    act(() => {
+      useGraphEditorPendingFactoryBridge.getState().setPendingFactoryDefinition({
+        name: "Current Factory",
+        supportingFiles: {
+          bundledFiles: [
+            {
+              content: { encoding: "utf-8", inline: "# Review standards\n" },
+              targetPath: nestedDocPath,
+              type: "DOC",
+            },
+          ],
+        },
+      });
+    });
+
+    const { result } = renderHook(() =>
+      useDocDetailState({ targetPath: nestedDocPath }),
+    );
+
+    expect(result.current).toEqual({
+      status: "ready",
+      displayLabel: "review.md",
+      inlineContent: "# Review standards\n",
+      targetPath: nestedDocPath,
+    });
+  });
+
   it("loads doc text from the graph-editor pending factory when the saved event factory does not list it yet", () => {
     act(() => {
       useGraphEditorPendingFactoryBridge.getState().setPendingFactoryDefinition({

--- a/ui/src/features/dashboard/lib/dashboard-event-stream.test.ts
+++ b/ui/src/features/dashboard/lib/dashboard-event-stream.test.ts
@@ -319,6 +319,66 @@ describe("syncCurrentFactoryDefinition bundled docs", () => {
     ],
   };
 
+  it("preserves nested bundled docs when FACTORY_CHANGE omits supportingFiles", () => {
+    const queryClient = new QueryClient();
+    const nestedDocPath = "factory/docs/standards/review.md";
+    const existingDocument = {
+      name: "factory",
+      supportingFiles: {
+        bundledFiles: [
+          {
+            content: { encoding: "utf-8", inline: "# Overview" },
+            targetPath: "factory/docs/overview.md",
+            type: "DOC",
+          },
+          {
+            content: { encoding: "utf-8", inline: "# Review standards" },
+            targetPath: nestedDocPath,
+            type: "DOC",
+          },
+        ],
+      },
+      version: {
+        logical: "8",
+        physical: "2026-05-31T11:00:00Z",
+      },
+    };
+    queryClient.setQueryData(
+      currentFactoryDocumentQueryKey(sessionID),
+      existingDocument,
+    );
+
+    syncCurrentFactoryDefinition(
+      queryClient,
+      {
+        context: { eventTime: "2026-04-25T20:00:01Z", sequence: 1, tick: 1 },
+        id: "event-1",
+        payload: {
+          factory: {
+            ...validFactory,
+            version: {
+              logical: "9",
+              physical: "2026-05-31T12:00:00Z",
+            },
+          },
+        },
+        type: FACTORY_EVENT_TYPES.factoryChange,
+      },
+      sessionID,
+    );
+
+    expect(
+      queryClient.getQueryData(currentFactoryDocumentQueryKey(sessionID)),
+    ).toMatchObject({
+      supportingFiles: existingDocument.supportingFiles,
+      version: {
+        logical: "9",
+        physical: "2026-05-31T12:00:00Z",
+      },
+      workers: [expect.objectContaining({ model: "gpt-5.6" })],
+    });
+  });
+
   it("preserves bundled docs when FACTORY_CHANGE omits supportingFiles", () => {
     const queryClient = new QueryClient();
     const existingDocument = {

--- a/ui/src/features/workflow-activity/components/react-flow-current-activity-card.test.tsx
+++ b/ui/src/features/workflow-activity/components/react-flow-current-activity-card.test.tsx
@@ -1376,6 +1376,41 @@ function registerCurrentActivityCardEditorChromeTests(): void {
     ).toBeNull();
   });
 
+  it("renders nested bundled docs as observe-mode graph nodes from the saved factory document", async () => {
+    const snapshot = structuredClone(semanticWorkflowDashboardSnapshot);
+    refreshFactoryFromTopology(snapshot);
+    const nestedDocPath = "factory/docs/standards/review.md";
+    const savedDocument = {
+      ...currentFactoryDocumentFromSnapshot(snapshot),
+      supportingFiles: {
+        bundledFiles: [
+          {
+            content: { encoding: "utf-8", inline: "# Overview" },
+            targetPath: "factory/docs/overview.md",
+            type: "DOC",
+          },
+          {
+            content: { encoding: "utf-8", inline: "# Review standards" },
+            targetPath: nestedDocPath,
+            type: "DOC",
+          },
+        ],
+      },
+    };
+    snapshot.factory = savedDocument;
+
+    renderCurrentActivity({
+      snapshot,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Select review.md doc" }),
+      ).toBeTruthy();
+    });
+    expect(screen.getByText(nestedDocPath)).toBeTruthy();
+  });
+
   it("renders bundled docs as observe-mode graph nodes from the saved factory document", async () => {
     const snapshot = structuredClone(semanticWorkflowDashboardSnapshot);
     refreshFactoryFromTopology(snapshot);

--- a/ui/src/features/workflow-activity/hooks/observe-mode-live-doc-projection.test.ts
+++ b/ui/src/features/workflow-activity/hooks/observe-mode-live-doc-projection.test.ts
@@ -41,6 +41,8 @@ const timelineFactory = normalizeFactoryDefinition({
   ],
 });
 
+const nestedStandardsDocPath = "factory/docs/standards/review.md";
+
 const savedFactoryDocument = normalizeFactoryDefinition({
   ...timelineFactory,
   supportingFiles: {
@@ -53,6 +55,11 @@ const savedFactoryDocument = normalizeFactoryDefinition({
       {
         content: { encoding: "utf-8", inline: "# Planning" },
         targetPath: "factory/docs/planning.md",
+        type: "DOC",
+      },
+      {
+        content: { encoding: "utf-8", inline: "# Review standards" },
+        targetPath: nestedStandardsDocPath,
         type: "DOC",
       },
     ],
@@ -118,6 +125,7 @@ describe("observe-mode live doc projection", () => {
     expect(listFactoryBundledDocs(displayFactory)).toEqual([
       expect.objectContaining({ targetPath: "factory/docs/overview.md" }),
       expect.objectContaining({ targetPath: "factory/docs/planning.md" }),
+      expect.objectContaining({ targetPath: nestedStandardsDocPath }),
     ]);
   });
 
@@ -136,6 +144,7 @@ describe("observe-mode live doc projection", () => {
     expect(listFactoryBundledDocs(displayFactory)).toEqual([
       expect.objectContaining({ targetPath: "factory/docs/overview.md" }),
       expect.objectContaining({ targetPath: "factory/docs/planning.md" }),
+      expect.objectContaining({ targetPath: nestedStandardsDocPath }),
     ]);
   });
 
@@ -219,6 +228,7 @@ describe("observe-mode live doc projection", () => {
     ).toEqual([
       expect.objectContaining({ targetPath: "factory/docs/overview.md" }),
       expect.objectContaining({ targetPath: "factory/docs/planning.md" }),
+      expect.objectContaining({ targetPath: nestedStandardsDocPath }),
     ]);
   });
 });

--- a/ui/src/features/workflow-activity/lib/current-activity-factory-graph-layout.test.ts
+++ b/ui/src/features/workflow-activity/lib/current-activity-factory-graph-layout.test.ts
@@ -99,4 +99,29 @@ describe("buildCurrentActivityGraphLayoutFromFactory docs", () => {
       (docNode?.x ?? 0) + CURRENT_ACTIVITY_DOC_NODE_WIDTH,
     );
   });
+
+  it("includes nested bundled docs under factory/docs subdirectories", async () => {
+    const layout = await buildCurrentActivityGraphLayoutFromFactory(
+      factoryWithSupportingFiles({
+        bundledFiles: [
+          {
+            content: { encoding: "utf-8", inline: "# Review standards" },
+            targetPath: "factory/docs/standards/review.md",
+            type: "DOC",
+          },
+        ],
+      }),
+    );
+    const docNode = layout.nodes.find(
+      (node) => node.nodeId === "doc:factory/docs/standards/review.md",
+    );
+
+    expect(docNode).toMatchObject({
+      displayLabel: "review.md",
+      height: CURRENT_ACTIVITY_DOC_NODE_HEIGHT,
+      nodeKind: "doc",
+      targetPath: "factory/docs/standards/review.md",
+      width: CURRENT_ACTIVITY_DOC_NODE_WIDTH,
+    });
+  });
 });

--- a/ui/src/features/workflow-activity/lib/factory-bundled-docs.test.ts
+++ b/ui/src/features/workflow-activity/lib/factory-bundled-docs.test.ts
@@ -95,6 +95,41 @@ describe("factory bundled docs", () => {
     ]);
   });
 
+  it("lists nested DOC bundled files under factory/docs subdirectories", () => {
+    const docs = listFactoryBundledDocs({
+      supportingFiles: {
+        bundledFiles: [
+          {
+            content: { encoding: "utf-8", inline: "# Overview" },
+            targetPath: "factory/docs/overview.md",
+            type: "DOC",
+          },
+          {
+            content: { encoding: "utf-8", inline: "# Review standards" },
+            targetPath: "factory/docs/standards/review.md",
+            type: "DOC",
+          },
+        ],
+      },
+    });
+
+    expect(docs).toEqual([
+      {
+        displayLabel: "overview.md",
+        nodeId: "doc:factory/docs/overview.md",
+        targetPath: "factory/docs/overview.md",
+      },
+      {
+        displayLabel: "review.md",
+        nodeId: "doc:factory/docs/standards/review.md",
+        targetPath: "factory/docs/standards/review.md",
+      },
+    ]);
+    expect(
+      isFactoryBundledDocTargetPath("factory/docs/standards/review.md"),
+    ).toBe(true);
+  });
+
   it("checks doc existence against the current factory definition", () => {
     const factory = {
       supportingFiles: {

--- a/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-graph.test.ts
+++ b/ui/src/features/workflow-activity/lib/react-flow-current-activity-card-graph.test.ts
@@ -2086,6 +2086,61 @@ describe("current activity graph active item labels", () => {
     expect(scriptNode?.data).not.toHaveProperty("onSelectDoc");
   });
 
+  it("renders nested bundled docs as distinct selectable doc nodes", async () => {
+    const nestedDocPath = "factory/docs/standards/review.md";
+    const factory = {
+      ...baseFactoryDefinition,
+      supportingFiles: {
+        bundledFiles: [
+          {
+            content: { encoding: "utf-8", inline: "# Review standards" },
+            targetPath: nestedDocPath,
+            type: "DOC",
+          },
+        ],
+      },
+    };
+    const graphLayout =
+      await buildCurrentActivityGraphLayoutFromFactory(factory);
+    const onSelectDoc = vi.fn();
+
+    const nodes = buildCurrentActivityNodes({
+      activeExecutionsByWorkstationNodeID: {},
+      activeGraphHighlights: buildActiveGraphHighlights(
+        [],
+        graphLayout.edges,
+        graphLayout.nodes,
+      ),
+      activeItemLabelsByPlaceId: buildActiveItemLabelsByPlaceId([]),
+      factoryDefinition: factory,
+      graphLayout,
+      now: Date.parse("2026-06-08T00:00:00Z"),
+      onSelectStateNode: vi.fn(),
+      onSelectWorkID: vi.fn(),
+      onSelectDoc,
+      onSelectResource: vi.fn(),
+      onSelectWorker: vi.fn(),
+      onSelectWorkType: vi.fn(),
+      onSelectWorkstation: vi.fn(),
+      selection: { kind: "doc", targetPath: nestedDocPath },
+      snapshot: buildSampleFactorySnapshot(factory),
+    });
+
+    const docNode = nodes.find((node) => node.id === `doc:${nestedDocPath}`);
+
+    expect(docNode).toMatchObject({
+      type: "doc",
+      data: {
+        displayLabel: "review.md",
+        fileType: "DOC",
+        kind: "doc",
+        onSelectDoc,
+        selectedDoc: true,
+        targetPath: nestedDocPath,
+      },
+    });
+  });
+
   it("updates doc nodes when the saved factory document changes", async () => {
     const factory = {
       ...baseFactoryDefinition,


### PR DESCRIPTION
```json
{
  "project": "Recursive Factory Docs Inclusion for Import, Export, and Dashboard Projection",
  "branchName": "system-factory-files-bug",
  "description": "Fix the portability and projection regression where nested files under factory/docs/**, such as factory/docs/standards/..., are omitted during factory construction, export, or import, and ensure the dashboard can present those docs from event-stream-derived current-factory context.",
  "context": {
    "customerAsk": "Right now the factory when being constructed or parsing files to include does not include sub files under factory/docs/, such as factory/docs/standards. Write functional tests that confirm import/export are failing to consider these files, confirm the website can present these files when they arrive through the event stream context, and fix the issue once located.",
    "problem": "Nested documentation files under factory/docs/** are not consistently included in the bundled factory file set, which causes import/export round trips to drop those files and prevents the dashboard from presenting them through the current-factory event projection.",
    "solution": "Make bundled doc discovery recursive under factory/docs/** across factory construction and portability flows, preserve those nested docs through import/export and current-factory projection, and add functional plus UI regression coverage that proves the docs survive round trips and render from event-derived dashboard state."
  },
  "acceptanceCriteria": [
    "Flattened, exported, and imported factory documents include supported nested doc files under factory/docs/**, including paths such as factory/docs/standards/review.md.",
    "A functional regression test proves nested docs survive a real export/import round trip by asserting preserved target paths and content instead of only bundled file counts.",
    "Current-factory and event-driven session projections expose the same nested doc bundled files that are present in the canonical factory document.",
    "The dashboard renders nested bundled docs from event-stream-derived current-factory context and allows operators to inspect the nested doc content through the existing doc selection surface.",
    "The fix stays within the existing bundled-file portability and dashboard projection architecture without introducing a parallel document transport model.",
    "Typecheck, lint, and targeted backend, functional, and UI tests pass."
  ],
  "userStories": [
    {
      "id": "system-factory-files-bug-001",
      "title": "Prove nested docs survive factory export and import",
      "passes": true
    },
    {
      "id": "system-factory-files-bug-002",
      "title": "Include recursive factory docs in the canonical bundled-file model",
      "passes": true
    },
    {
      "id": "system-factory-files-bug-003",
      "title": "Project nested docs through the event stream and render them in the dashboard",
      "passes": true
    }
  ]
}
```

Made with [Cursor](https://cursor.com)