### PR TITLE
log-test-cleanup

### DIFF
--- a/pkg/factory/service/build.go
+++ b/pkg/factory/service/build.go
@@ -325,6 +325,17 @@ func runtimeFileLoggingEnabled(policy RuntimeFileLoggingPolicy) bool {
 	}
 }
 
+func runtimeMetricsEnabled(policy RuntimeMetricsPolicy) bool {
+	switch policy {
+	case "", RuntimeMetricsPolicyEnabled:
+		return true
+	case RuntimeMetricsPolicyDisabled:
+		return false
+	default:
+		return true
+	}
+}
+
 func runtimeSessionBaseLogger(baseLogger *zap.Logger, logSink *logging.RuntimeLogSink) *zap.Logger {
 	if logSink != nil {
 		return logSink.Logger()
@@ -342,6 +353,9 @@ func buildRuntimeMetricsSink(
 	folderPath string,
 	factoryDir string,
 ) (*logging.RuntimeMetricsSink, error) {
+	if !runtimeMetricsEnabled(cfg.RuntimeMetricsPolicy) {
+		return nil, nil
+	}
 	metricsSink, err := logging.BuildRuntimeMetricsSink(
 		sessionID,
 		runtimeInstanceID,

--- a/pkg/factory/service/build_test.go
+++ b/pkg/factory/service/build_test.go
@@ -2,6 +2,7 @@ package service_test
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/jonboulle/clockwork"
@@ -49,5 +50,89 @@ func TestBuild_ConstructsRunnableBundleWithoutRootService(t *testing.T) {
 	}
 	if bundle.Net == nil {
 		t.Fatal("bundle.Net = nil")
+	}
+}
+
+func TestBuild_ProductionObservabilityPoliciesEnableRuntimeSinksByDefault(t *testing.T) {
+	dir := t.TempDir()
+	logDir := t.TempDir()
+	metricsDir := t.TempDir()
+	factoryfixtures.WriteFactoryJSON(t, dir, factoryfixtures.MinimalFactoryConfig())
+
+	loaded, err := configload.LoadRuntimeConfigFromFactoryDir(dir, nil)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfigFromFactoryDir: %v", err)
+	}
+
+	bundle, err := factoryservice.Build(context.Background(), factoryservice.BuildInput{
+		Dir:              dir,
+		FolderPath:       dir,
+		SessionID:        "~default",
+		Config: factoryservice.Config{
+			RuntimeMode:       interfaces.RuntimeModeBatch,
+			RuntimeLogDir:     logDir,
+			RuntimeMetricsDir: metricsDir,
+		},
+		LoadedFactoryCfg: loaded,
+		BaseLogger:       zap.NewNop(),
+		Clock:            factory.EnsureClock(clockwork.NewFakeClock()),
+		LoadWorkerOpts: func(*factoryevents.FactoryEventHistory, *zap.Logger) ([]factory.FactoryOption, error) {
+			return nil, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if bundle == nil {
+		t.Fatal("bundle = nil")
+	}
+	if bundle.LogSink == nil {
+		t.Fatal("LogSink = nil, want runtime log sink when production policy is unset")
+	}
+	if bundle.MetricsSink == nil {
+		t.Fatal("MetricsSink = nil, want runtime metrics sink when production policy is unset")
+	}
+	if bundle.LogSink.RootDir() != logDir {
+		t.Fatalf("LogSink.RootDir() = %q, want %q", bundle.LogSink.RootDir(), logDir)
+	}
+	if bundle.MetricsSink.RootDir() != metricsDir {
+		t.Fatalf("MetricsSink.RootDir() = %q, want %q", bundle.MetricsSink.RootDir(), metricsDir)
+	}
+	if filepath.Base(bundle.LogSink.Path()) == "" {
+		t.Fatal("LogSink.Path() = empty")
+	}
+	if filepath.Base(bundle.MetricsSink.Path()) == "" {
+		t.Fatal("MetricsSink.Path() = empty")
+	}
+
+	disabledBundle, err := factoryservice.Build(context.Background(), factoryservice.BuildInput{
+		Dir:              dir,
+		FolderPath:       dir,
+		SessionID:        "~default",
+		Config: factoryservice.Config{
+			RuntimeMode:              interfaces.RuntimeModeBatch,
+			RuntimeLogDir:            logDir,
+			RuntimeMetricsDir:        metricsDir,
+			RuntimeFileLoggingPolicy: factoryservice.RuntimeFileLoggingPolicyDisabled,
+			RuntimeMetricsPolicy:     factoryservice.RuntimeMetricsPolicyDisabled,
+		},
+		LoadedFactoryCfg: loaded,
+		BaseLogger:       zap.NewNop(),
+		Clock:            factory.EnsureClock(clockwork.NewFakeClock()),
+		LoadWorkerOpts: func(*factoryevents.FactoryEventHistory, *zap.Logger) ([]factory.FactoryOption, error) {
+			return nil, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build disabled policy: %v", err)
+	}
+	if disabledBundle == nil {
+		t.Fatal("disabled policy bundle = nil")
+	}
+	if disabledBundle.LogSink != nil {
+		t.Fatal("LogSink = non-nil, want nil when runtime file logging is explicitly disabled")
+	}
+	if disabledBundle.MetricsSink != nil {
+		t.Fatal("MetricsSink = non-nil, want nil when runtime metrics policy is explicitly disabled")
 	}
 }

--- a/pkg/factory/service/config.go
+++ b/pkg/factory/service/config.go
@@ -22,6 +22,14 @@ const (
 	RuntimeFileLoggingPolicyDisabled RuntimeFileLoggingPolicy = "disabled"
 )
 
+// RuntimeMetricsPolicy controls whether bundle construction creates a runtime metrics sink.
+type RuntimeMetricsPolicy string
+
+const (
+	RuntimeMetricsPolicyEnabled  RuntimeMetricsPolicy = "enabled"
+	RuntimeMetricsPolicyDisabled RuntimeMetricsPolicy = "disabled"
+)
+
 // Config carries host-level settings required to build one runnable runtime bundle.
 type Config struct {
 	RunnerID                                string
@@ -31,6 +39,7 @@ type Config struct {
 	RuntimeLogDir                           string
 	RuntimeLogConfig                        logging.RuntimeLogConfig
 	RuntimeFileLoggingPolicy                RuntimeFileLoggingPolicy
+	RuntimeMetricsPolicy                    RuntimeMetricsPolicy
 	RuntimeMetricsDir                       string
 	RuntimeMetricsConfig                    logging.RuntimeMetricsConfig
 	RecordPath                              string
@@ -144,6 +153,7 @@ type HostConfigInput struct {
 	RuntimeLogDir                           string
 	RuntimeLogConfig                        logging.RuntimeLogConfig
 	RuntimeFileLoggingPolicy                RuntimeFileLoggingPolicy
+	RuntimeMetricsPolicy                    RuntimeMetricsPolicy
 	RuntimeMetricsDir                       string
 	RuntimeMetricsConfig                    logging.RuntimeMetricsConfig
 	RecordPath                              string
@@ -173,6 +183,7 @@ func ConfigFromHostInput(input HostConfigInput) Config {
 		RuntimeLogDir:                           input.RuntimeLogDir,
 		RuntimeLogConfig:                        input.RuntimeLogConfig,
 		RuntimeFileLoggingPolicy:                input.RuntimeFileLoggingPolicy,
+		RuntimeMetricsPolicy:                    input.RuntimeMetricsPolicy,
 		RuntimeMetricsDir:                       input.RuntimeMetricsDir,
 		RuntimeMetricsConfig:                    input.RuntimeMetricsConfig,
 		RecordPath:                              input.RecordPath,

--- a/pkg/runtimehost/host.go
+++ b/pkg/runtimehost/host.go
@@ -158,6 +158,13 @@ const (
 	RuntimeFileLoggingPolicyDisabled RuntimeFileLoggingPolicy = "disabled"
 )
 
+type RuntimeMetricsPolicy string
+
+const (
+	RuntimeMetricsPolicyEnabled  RuntimeMetricsPolicy = "enabled"
+	RuntimeMetricsPolicyDisabled RuntimeMetricsPolicy = "disabled"
+)
+
 // Config holds all parameters needed to build and run a factory.
 type Config struct {
 	// Dir is the factory root directory containing factory.json and inputs/.
@@ -201,6 +208,9 @@ type Config struct {
 	// RuntimeLogConfig controls bounded runtime file logging behavior.
 	// Zero values use defaults that match the package rolling policy.
 	RuntimeLogConfig logging.RuntimeLogConfig
+	// RuntimeMetricsPolicy controls whether the service creates a runtime
+	// metrics sink. Empty defaults to enabled for production-facing behavior.
+	RuntimeMetricsPolicy RuntimeMetricsPolicy
 	// RuntimeMetricsDir optionally overrides the default
 	// ~/.you-agent-factory/metrics directory. Tests use this to keep
 	// file-backed metrics isolated.

--- a/pkg/service/factory_build.go
+++ b/pkg/service/factory_build.go
@@ -237,6 +237,7 @@ func hostConfigFromService(cfg *FactoryServiceConfig) factoryservice.Config {
 		RuntimeLogDir:                           cfg.RuntimeLogDir,
 		RuntimeLogConfig:                        cfg.RuntimeLogConfig,
 		RuntimeFileLoggingPolicy:                factoryservice.RuntimeFileLoggingPolicy(cfg.RuntimeFileLoggingPolicy),
+		RuntimeMetricsPolicy:                    factoryservice.RuntimeMetricsPolicy(cfg.RuntimeMetricsPolicy),
 		RuntimeMetricsDir:                       cfg.RuntimeMetricsDir,
 		RuntimeMetricsConfig:                    cfg.RuntimeMetricsConfig,
 		RecordPath:                              cfg.RecordPath,

--- a/pkg/service/factory_compat.go
+++ b/pkg/service/factory_compat.go
@@ -88,6 +88,7 @@ type (
 	SimpleDashboardRenderer     = runtimehost.SimpleDashboardRenderer
 	APIServerStarter            = runtimehost.APIServerStarter
 	RuntimeFileLoggingPolicy    = runtimehost.RuntimeFileLoggingPolicy
+	RuntimeMetricsPolicy        = runtimehost.RuntimeMetricsPolicy
 	RuntimeLogDiagnostics       = runtimehost.RuntimeLogDiagnostics
 	InvocationMetricsRecorder   = runtimehost.InvocationMetricsRecorder
 	InvocationMetric            = runtimehost.InvocationMetric
@@ -104,6 +105,8 @@ var (
 const (
 	RuntimeFileLoggingPolicyEnabled  = runtimehost.RuntimeFileLoggingPolicyEnabled
 	RuntimeFileLoggingPolicyDisabled = runtimehost.RuntimeFileLoggingPolicyDisabled
+	RuntimeMetricsPolicyEnabled      = runtimehost.RuntimeMetricsPolicyEnabled
+	RuntimeMetricsPolicyDisabled     = runtimehost.RuntimeMetricsPolicyDisabled
 )
 
 type (

--- a/pkg/service/factoryvalidationtests/factory_compose_equivalence_test.go
+++ b/pkg/service/factoryvalidationtests/factory_compose_equivalence_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/config/operatorconfig"
 	"github.com/portpowered/infinite-you/pkg/service"
 	"github.com/portpowered/infinite-you/pkg/testutil/factoryfixtures"
-	"go.uber.org/zap"
+	"github.com/portpowered/infinite-you/pkg/testutil/testdeps"
 )
 
 func TestFactoryServiceComposeCollaboratorsMatchBuildFactoryService(t *testing.T) {
@@ -17,7 +17,7 @@ func TestFactoryServiceComposeCollaboratorsMatchBuildFactoryService(t *testing.T
 	factoryfixtures.WriteFactoryJSON(t, dir, factoryfixtures.MinimalFactoryConfig())
 
 	ctx := t.Context()
-	cfg := &service.FactoryServiceConfig{Dir: dir}
+	cfg := testdeps.QuietFactoryServiceConfig(&service.FactoryServiceConfig{Dir: dir})
 
 	built, err := service.BuildFactoryService(ctx, cfg)
 	if err != nil {
@@ -120,7 +120,7 @@ func TestFactoryServiceComposeCollaboratorsMatchBuildFactoryServiceWithOperatorD
 	factoryfixtures.WriteFactoryJSON(t, dir, factoryfixtures.MinimalFactoryConfig())
 
 	ctx := t.Context()
-	cfg := &service.FactoryServiceConfig{
+	cfg := testdeps.QuietFactoryServiceConfig(&service.FactoryServiceConfig{
 		Dir: dir,
 		OperatorDefaults: operatorconfig.ResolvedDefaults{
 			WorkerModelProvider:       "CODEX",
@@ -130,8 +130,7 @@ func TestFactoryServiceComposeCollaboratorsMatchBuildFactoryServiceWithOperatorD
 		},
 		MockWorkersConfig:                       config.NewEmptyMockWorkersConfig(),
 		SkipBuiltInRunnerPrerequisiteValidation: true,
-		Logger:                                  zap.NewNop(),
-	}
+	})
 
 	built, err := service.BuildFactoryService(ctx, cfg)
 	if err != nil {

--- a/pkg/service/factoryvalidationtests/factory_validation_equivalence_test.go
+++ b/pkg/service/factoryvalidationtests/factory_validation_equivalence_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/factorysessions"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/service"
-	"go.uber.org/zap"
+	"github.com/portpowered/infinite-you/pkg/testutil/testdeps"
 )
 
 func TestFactoryValidation_EquivalentCanonicalTargetsAcrossPackageConfigAndSavePaths(t *testing.T) {
@@ -84,15 +84,14 @@ func canonicalTargetsFromEditableSaveRejection(t *testing.T, invalid factoryapi.
 		t.Fatalf("WriteCurrentFactoryPointer(alpha): %v", err)
 	}
 
-	svc, err := service.BuildFactoryService(context.Background(), &service.FactoryServiceConfig{
+	svc, err := service.BuildFactoryService(context.Background(), testdeps.QuietFactoryServiceConfig(&service.FactoryServiceConfig{
 		Dir: rootDir,
 		OperatorDefaults: operatorconfig.ResolvedDefaults{
 			WorkerModelProvider: "CODEX",
 			WorkerModel:         "gpt-5-codex",
 		},
 		MockWorkersConfig: config.NewEmptyMockWorkersConfig(),
-		Logger:            zap.NewNop(),
-	})
+	}))
 	if err != nil {
 		t.Fatalf("BuildFactoryService: %v", err)
 	}

--- a/pkg/service/opencodeagenttests/factory_opencode_agent_test.go
+++ b/pkg/service/opencodeagenttests/factory_opencode_agent_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/service"
 	"github.com/portpowered/infinite-you/pkg/testutil/factoryfixtures"
-	"go.uber.org/zap"
+	"github.com/portpowered/infinite-you/pkg/testutil/testdeps"
 )
 
 func TestBuildFactoryService_RejectsOpenCodeAgentOnNonOpenCodeRunner(t *testing.T) {
@@ -27,12 +27,11 @@ You are a helpful assistant.
 `)
 	writeWorkstationAgentsMD(t, dir, "process")
 
-	_, err := service.BuildFactoryService(context.Background(), &service.FactoryServiceConfig{
+	_, err := service.BuildFactoryService(context.Background(), testdeps.QuietFactoryServiceConfig(&service.FactoryServiceConfig{
 		Dir:                                     dir,
 		MockWorkersConfig:                       config.NewEmptyMockWorkersConfig(),
-		Logger:                                  zap.NewNop(),
 		SkipBuiltInRunnerPrerequisiteValidation: true,
-	})
+	}))
 	if err == nil || !strings.Contains(err.Error(), "openCodeAgent") || !strings.Contains(err.Error(), "reviewer") {
 		t.Fatalf("BuildFactoryService error = %v, want openCodeAgent configuration error", err)
 	}
@@ -53,13 +52,12 @@ You are a helpful assistant.
 `)
 	writeWorkstationAgentsMD(t, dir, "process")
 
-	_, err := service.BuildFactoryService(context.Background(), &service.FactoryServiceConfig{
+	_, err := service.BuildFactoryService(context.Background(), testdeps.QuietFactoryServiceConfig(&service.FactoryServiceConfig{
 		Dir:                                     dir,
 		RunnerID:                                interfaces.RunnerIDOpenCode,
 		MockWorkersConfig:                       config.NewEmptyMockWorkersConfig(),
-		Logger:                                  zap.NewNop(),
 		SkipBuiltInRunnerPrerequisiteValidation: true,
-	})
+	}))
 	if err != nil {
 		t.Fatalf("BuildFactoryService error = %v, want openCodeAgent with opencode runner", err)
 	}
@@ -77,12 +75,11 @@ You are a helpful assistant.
 `)
 	writeWorkstationAgentsMD(t, dir, "process")
 
-	_, err := service.BuildFactoryService(context.Background(), &service.FactoryServiceConfig{
+	_, err := service.BuildFactoryService(context.Background(), testdeps.QuietFactoryServiceConfig(&service.FactoryServiceConfig{
 		Dir:                                     dir,
 		MockWorkersConfig:                       config.NewEmptyMockWorkersConfig(),
-		Logger:                                  zap.NewNop(),
 		SkipBuiltInRunnerPrerequisiteValidation: true,
-	})
+	}))
 	if err != nil {
 		t.Fatalf("BuildFactoryService error = %v, want unchanged non-opencode runner behavior", err)
 	}

--- a/pkg/service/replaytests/factory_replay_test.go
+++ b/pkg/service/replaytests/factory_replay_test.go
@@ -20,8 +20,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/testutil/factoryfixtures"
 	"github.com/portpowered/infinite-you/pkg/testutil/testdeps"
 	"github.com/portpowered/infinite-you/pkg/workers"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zaptest/observer"
+	"go.uber.org/zap/zapcore"
 )
 
 func TestBuildFactoryService_ReplayModeLoadsEmbeddedConfigWithoutFactoryFiles(t *testing.T) {
@@ -425,10 +424,10 @@ func TestBuildFactoryService_ReplayModeWarnsOnCurrentConfigHashMismatch(t *testi
 	mismatchedConfig["workers"] = []map[string]string{{"name": "worker-a"}, {"name": "worker-b"}}
 	factoryfixtures.WriteFactoryJSON(t, sourceDir, mismatchedConfig)
 
-	core, observedLogs := observer.New(zap.WarnLevel)
+	capturingLogger, observedLogs := testdeps.CapturingZapLogger(zapcore.WarnLevel)
 	_, err := service.BuildFactoryService(context.Background(), &service.FactoryServiceConfig{
 		Dir:        sourceDir,
-		Logger:     zap.New(core),
+		Logger:     capturingLogger,
 		ReplayPath: artifactPath,
 	})
 	if err != nil {

--- a/pkg/service/replaytests/factory_replay_test.go
+++ b/pkg/service/replaytests/factory_replay_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/replay"
 	service "github.com/portpowered/infinite-you/pkg/service"
 	"github.com/portpowered/infinite-you/pkg/testutil/factoryfixtures"
+	"github.com/portpowered/infinite-you/pkg/testutil/testdeps"
 	"github.com/portpowered/infinite-you/pkg/workers"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -40,12 +41,11 @@ func TestBuildFactoryService_ReplayModeLoadsEmbeddedConfigWithoutFactoryFiles(t 
 	}
 
 	replayDir := t.TempDir()
-	svc, err := service.BuildFactoryService(context.Background(), &service.FactoryServiceConfig{
+	svc, err := service.BuildFactoryService(context.Background(), testdeps.QuietFactoryServiceConfig(&service.FactoryServiceConfig{
 		Dir:               replayDir,
 		MockWorkersConfig: config.NewEmptyMockWorkersConfig(),
-		Logger:            zap.NewNop(),
 		ReplayPath:        artifactPath,
-	})
+	}))
 	if err != nil {
 		t.Fatalf("BuildFactoryService replay: %v", err)
 	}
@@ -75,12 +75,11 @@ func TestBuildFactoryService_ReplayModeDefaultsToDeterministicClock(t *testing.T
 		t.Fatalf("Save artifact: %v", err)
 	}
 
-	svc, err := service.BuildFactoryService(context.Background(), &service.FactoryServiceConfig{
+	svc, err := service.BuildFactoryService(context.Background(), testdeps.QuietFactoryServiceConfig(&service.FactoryServiceConfig{
 		Dir:               t.TempDir(),
 		MockWorkersConfig: config.NewEmptyMockWorkersConfig(),
-		Logger:            zap.NewNop(),
 		ReplayPath:        artifactPath,
-	})
+	}))
 	if err != nil {
 		t.Fatalf("BuildFactoryService replay: %v", err)
 	}
@@ -121,11 +120,10 @@ func TestBuildFactoryService_ReplayModeUsesRecordedProviderSideEffects(t *testin
 		},
 	})
 
-	svc, err := service.BuildFactoryService(context.Background(), &service.FactoryServiceConfig{
+	svc, err := service.BuildFactoryService(context.Background(), testdeps.QuietFactoryServiceConfig(&service.FactoryServiceConfig{
 		Dir:        t.TempDir(),
-		Logger:     zap.NewNop(),
 		ReplayPath: artifactPath,
-	})
+	}))
 	if err != nil {
 		t.Fatalf("BuildFactoryService replay: %v", err)
 	}
@@ -190,16 +188,15 @@ func TestBuildFactoryService_ReplayModeDeliversRecordedCompletionAtLogicalTick(t
 	}
 
 	var completions []interfaces.FactoryCompletionRecord
-	svc, err := service.BuildFactoryService(context.Background(), &service.FactoryServiceConfig{
+	svc, err := service.BuildFactoryService(context.Background(), testdeps.QuietFactoryServiceConfig(&service.FactoryServiceConfig{
 		Dir:        t.TempDir(),
-		Logger:     zap.NewNop(),
 		ReplayPath: artifactPath,
 		ExtraOptions: []factory.FactoryOption{
 			factory.WithCompletionRecorder(func(record interfaces.FactoryCompletionRecord) {
 				completions = append(completions, record)
 			}),
 		},
-	})
+	}))
 	if err != nil {
 		t.Fatalf("BuildFactoryService replay: %v", err)
 	}
@@ -259,12 +256,11 @@ func TestBuildFactoryService_ReplayModeReplaysOperatorWorkStateChange(t *testing
 		t.Fatalf("Save replay artifact: %v", err)
 	}
 
-	svc, err := service.BuildFactoryService(context.Background(), &service.FactoryServiceConfig{
+	svc, err := service.BuildFactoryService(context.Background(), testdeps.QuietFactoryServiceConfig(&service.FactoryServiceConfig{
 		Dir:               t.TempDir(),
 		MockWorkersConfig: config.NewEmptyMockWorkersConfig(),
-		Logger:            zap.NewNop(),
 		ReplayPath:        artifactPath,
-	})
+	}))
 	if err != nil {
 		t.Fatalf("BuildFactoryService replay: %v", err)
 	}
@@ -320,11 +316,10 @@ func TestBuildFactoryService_ReplayModeUsesRecordedCommandRunnerSideEffects(t *t
 		},
 	})
 
-	svc, err := service.BuildFactoryService(context.Background(), &service.FactoryServiceConfig{
+	svc, err := service.BuildFactoryService(context.Background(), testdeps.QuietFactoryServiceConfig(&service.FactoryServiceConfig{
 		Dir:        t.TempDir(),
-		Logger:     zap.NewNop(),
 		ReplayPath: artifactPath,
-	})
+	}))
 	if err != nil {
 		t.Fatalf("BuildFactoryService replay: %v", err)
 	}
@@ -368,11 +363,10 @@ func TestBuildFactoryService_ReplayModeStopsOnDispatchDivergence(t *testing.T) {
 		},
 	})
 
-	svc, err := service.BuildFactoryService(context.Background(), &service.FactoryServiceConfig{
+	svc, err := service.BuildFactoryService(context.Background(), testdeps.QuietFactoryServiceConfig(&service.FactoryServiceConfig{
 		Dir:        t.TempDir(),
-		Logger:     zap.NewNop(),
 		ReplayPath: artifactPath,
-	})
+	}))
 	if err != nil {
 		t.Fatalf("BuildFactoryService replay: %v", err)
 	}

--- a/pkg/service/runtimelogtests/factory_runtime_metrics_policy_test.go
+++ b/pkg/service/runtimelogtests/factory_runtime_metrics_policy_test.go
@@ -1,0 +1,121 @@
+package runtimelogtests
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/pkg/config"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/service"
+	"github.com/portpowered/infinite-you/pkg/testutil/factoryfixtures"
+	"go.uber.org/zap"
+)
+
+func TestFactoryService_RuntimeMetricsPolicy_PreservesProductionDefaultAndAllowsExplicitDisable(t *testing.T) {
+	dir := t.TempDir()
+	factoryfixtures.WriteFactoryJSON(t, dir, factoryfixtures.MinimalFactoryConfig())
+	writeWorkstationAgentsMD(t, dir, "process")
+	if err := os.MkdirAll(filepath.Join(dir, interfaces.InputsDir), 0o755); err != nil {
+		t.Fatalf("create inputs dir: %v", err)
+	}
+
+	t.Run("default policy stays enabled for direct service construction", func(t *testing.T) {
+		metricsDir := t.TempDir()
+		runtimeInstanceID := "runtime-metrics-default-enabled"
+
+		svc, err := service.BuildFactoryService(context.Background(), &service.FactoryServiceConfig{
+			Dir:               dir,
+			MockWorkersConfig: config.NewEmptyMockWorkersConfig(),
+			Logger:            zap.NewNop(),
+			RuntimeMetricsDir: metricsDir,
+			RuntimeInstanceID: runtimeInstanceID,
+		})
+		if err != nil {
+			t.Fatalf("BuildFactoryService: %v", err)
+		}
+
+		bundle := svc.CurrentRuntimeBundle()
+		if bundle == nil {
+			t.Fatal("expected startup runtime bundle")
+		}
+		if bundle.MetricsSink == nil {
+			t.Fatal("MetricsSink = nil, want runtime metrics sink when production-facing policy is unset")
+		}
+		if bundle.MetricsSink.RootDir() != metricsDir {
+			t.Fatalf("MetricsSink.RootDir() = %q, want %q", bundle.MetricsSink.RootDir(), metricsDir)
+		}
+		if bundle.MetricsSink.Path() == "" {
+			t.Fatal("MetricsSink.Path() = empty, want runtime metrics path when production-facing policy is unset")
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := svc.Run(ctx); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+
+		metricFiles := collectRuntimeMetricsFiles(t, metricsDir)
+		if len(metricFiles) == 0 {
+			t.Fatalf("runtime metrics files under %s = none, want at least one metrics artifact", metricsDir)
+		}
+	})
+
+	t.Run("explicit disabled policy suppresses runtime metrics artifacts", func(t *testing.T) {
+		metricsDir := t.TempDir()
+
+		svc, err := service.BuildFactoryService(context.Background(), &service.FactoryServiceConfig{
+			Dir:                  dir,
+			MockWorkersConfig:    config.NewEmptyMockWorkersConfig(),
+			Logger:               zap.NewNop(),
+			RuntimeMetricsDir:    metricsDir,
+			RuntimeInstanceID:    "runtime-metrics-disabled",
+			RuntimeMetricsPolicy: service.RuntimeMetricsPolicyDisabled,
+		})
+		if err != nil {
+			t.Fatalf("BuildFactoryService: %v", err)
+		}
+
+		bundle := svc.CurrentRuntimeBundle()
+		if bundle == nil {
+			t.Fatal("expected startup runtime bundle")
+		}
+		if bundle.MetricsSink != nil {
+			t.Fatal("MetricsSink = non-nil, want nil when runtime metrics policy is disabled")
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := svc.Run(ctx); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+
+		metricFiles := collectRuntimeMetricsFiles(t, metricsDir)
+		if len(metricFiles) != 0 {
+			t.Fatalf("runtime metrics files = %v, want none", metricFiles)
+		}
+	})
+}
+
+func collectRuntimeMetricsFiles(t *testing.T, dir string) []string {
+	t.Helper()
+
+	var metricFiles []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		metricFiles = append(metricFiles, path)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkDir(%s): %v", dir, err)
+	}
+	return metricFiles
+}

--- a/pkg/testutil/service_harness.go
+++ b/pkg/testutil/service_harness.go
@@ -19,6 +19,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/logging"
 	"github.com/portpowered/infinite-you/pkg/petri"
 	"github.com/portpowered/infinite-you/pkg/service"
+	"github.com/portpowered/infinite-you/pkg/testutil/testdeps"
 	"github.com/portpowered/infinite-you/pkg/workers"
 )
 
@@ -201,6 +202,7 @@ func NewServiceTestHarness(t *testing.T, dir string, opts ...ServiceTestHarnessO
 	for _, opt := range opts {
 		opt(cfg)
 	}
+	testdeps.Default().ApplyFactoryServiceConfig(&cfg.serviceConfig)
 
 	if cfg.asyncMode {
 		// Async mode: wrap all registered executors with the mock/custom

--- a/pkg/testutil/service_harness.go
+++ b/pkg/testutil/service_harness.go
@@ -21,6 +21,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/service"
 	"github.com/portpowered/infinite-you/pkg/testutil/testdeps"
 	"github.com/portpowered/infinite-you/pkg/workers"
+	"go.uber.org/zap"
 )
 
 // ServiceTestHarness wraps a FactoryService built via BuildFactoryService()
@@ -100,6 +101,22 @@ func WithMockWorkersConfig(mockCfg *factoryconfig.MockWorkersConfig) ServiceTest
 func WithRuntimeMode(mode interfaces.RuntimeMode) ServiceTestHarnessOption {
 	return func(cfg *harnessConfig) {
 		cfg.serviceConfig.RuntimeMode = mode
+	}
+}
+
+// WithZapLogger sets an explicit zap logger for observability tests. The logger
+// is preserved when quiet defaults are applied afterward.
+func WithZapLogger(logger *zap.Logger) ServiceTestHarnessOption {
+	return func(cfg *harnessConfig) {
+		cfg.serviceConfig.Logger = logger
+	}
+}
+
+// WithInvocationMetricsRecorder sets an explicit invocation metrics recorder for
+// observability tests. The recorder is preserved when quiet defaults are applied.
+func WithInvocationMetricsRecorder(recorder service.InvocationMetricsRecorder) ServiceTestHarnessOption {
+	return func(cfg *harnessConfig) {
+		cfg.serviceConfig.InvocationMetricsRecorder = recorder
 	}
 }
 

--- a/pkg/testutil/service_harness_internal_test.go
+++ b/pkg/testutil/service_harness_internal_test.go
@@ -12,7 +12,17 @@ import (
 	"github.com/portpowered/infinite-you/pkg/apisurface"
 	"github.com/portpowered/infinite-you/pkg/factorysessionexecution"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/runtimehost"
+	"github.com/portpowered/infinite-you/pkg/testutil/testdeps"
+	"go.uber.org/zap/zapcore"
 )
+
+type waitUntilCancelExecutor struct{}
+
+func (waitUntilCancelExecutor) Execute(ctx context.Context, _ interfaces.WorkDispatch) (interfaces.WorkResult, error) {
+	<-ctx.Done()
+	return interfaces.WorkResult{Outcome: interfaces.OutcomeFailed}, ctx.Err()
+}
 
 func TestServiceTestHarnessMarkingFallsBackToCachedSnapshot(t *testing.T) {
 	cfg := PipelineConfig(1, "processor")
@@ -42,6 +52,63 @@ func TestServiceTestHarnessMarkingFallsBackToCachedSnapshot(t *testing.T) {
 	}
 	if got := len(snap.TokensInPlace("task:init")); got != 0 {
 		t.Fatalf("TokensInPlace(task:init) = %d, want 0", got)
+	}
+}
+
+func TestNewServiceTestHarness_WithZapLogger_PreservesCapturingLoggerThroughRun(t *testing.T) {
+	cfg := PipelineConfig(1, "processor")
+	dir := ScaffoldFactoryDir(t, cfg)
+	logDir := t.TempDir()
+
+	capturingLogger, observed := testdeps.CapturingZapLogger(zapcore.InfoLevel)
+	h := NewServiceTestHarness(t, dir,
+		WithZapLogger(capturingLogger),
+		WithRuntimeFileLoggingEnabled(true),
+		WithRuntimeLogDir(logDir),
+		WithRuntimeInstanceID("harness-capture"),
+	)
+	h.MockWorker("processor", interfaces.WorkResult{Outcome: interfaces.OutcomeAccepted})
+
+	if err := h.SubmitWork("task", []byte(`{"title":"capture harness logger"}`)); err != nil {
+		t.Fatalf("submit work: %v", err)
+	}
+	h.RunUntilComplete(t, 5*time.Second)
+
+	logs := observed.FilterMessage("factory started").All()
+	if len(logs) != 1 {
+		t.Fatalf("factory started logs = %d, want 1", len(logs))
+	}
+}
+
+func TestNewServiceTestHarness_WithInvocationMetricsRecorder_RecordsSessionInvocationMetrics(t *testing.T) {
+	cfg := PipelineConfig(1, "processor")
+	dir := ScaffoldFactoryDir(t, cfg)
+
+	recorder := testdeps.NewRecordingInvocationMetrics()
+	h := NewServiceTestHarness(t, dir,
+		WithInvocationMetricsRecorder(recorder),
+		WithRunAsync(),
+	)
+	h.SetCustomExecutor("processor", waitUntilCancelExecutor{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := h.SubmitWork("task", []byte(`{"title":"keep runtime available for invocation metrics"}`)); err != nil {
+		t.Fatalf("submit work: %v", err)
+	}
+
+	errCh := h.RunInBackground(ctx)
+	if err := h.WaitForRuntimeAvailability(ctx, errCh); err != nil {
+		t.Fatalf("WaitForRuntimeAvailability: %v", err)
+	}
+
+	_, err := h.svc.InvokeFactorySession(ctx, runtimehost.DefaultFactorySessionID, factoryapi.InvocationRequest{})
+	if err == nil {
+		t.Fatal("InvokeFactorySession() error = nil, want invocation error")
+	}
+	if !recorder.Contains(runtimehost.InvocationMetricNormalizationAttempts, nil) {
+		t.Fatalf("expected %q invocation metric via harness recorder", runtimehost.InvocationMetricNormalizationAttempts)
 	}
 }
 

--- a/pkg/testutil/testdeps/capture.go
+++ b/pkg/testutil/testdeps/capture.go
@@ -1,0 +1,181 @@
+package testdeps
+
+import (
+	"context"
+	"maps"
+	"sync"
+
+	"github.com/portpowered/infinite-you/pkg/internal/metrics"
+	"github.com/portpowered/infinite-you/pkg/logging"
+	"github.com/portpowered/infinite-you/pkg/service"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// Capture holds handles for asserting on recorded log and metric emissions from
+// explicit observability opt-in.
+type Capture struct {
+	ObservedLogs *observer.ObservedLogs
+	Metrics      *RecordingMetricsEmitter
+}
+
+// CapturingZapLogger returns a zap logger and observer for tests that assert on
+// expected log records.
+func CapturingZapLogger(level zapcore.Level) (*zap.Logger, *observer.ObservedLogs) {
+	core, observed := observer.New(level)
+	return zap.New(core), observed
+}
+
+// Capturing returns observability dependencies that record routine log and
+// metric emissions for tests where diagnostics are the behavior under test.
+func Capturing(level zapcore.Level) (Observability, Capture) {
+	zapLogger, observed := CapturingZapLogger(level)
+	recorder := NewRecordingMetricsEmitter()
+	verbose := level <= zapcore.InfoLevel
+	return Observability{
+			Logger:         logging.NewZapLogger(zapLogger, verbose),
+			MetricsEmitter: recorder,
+			ZapLogger:      zapLogger,
+		}, Capture{
+			ObservedLogs: observed,
+			Metrics:      recorder,
+		}
+}
+
+// RecordingMetricsEmitter records metrics.MetricsEmitter emissions for test
+// assertions.
+type RecordingMetricsEmitter struct {
+	mu       sync.Mutex
+	counters []recordedCounter
+	gauges   []recordedGauge
+	samples  []recordedSample
+}
+
+type recordedCounter struct {
+	name   string
+	delta  float64
+	fields metrics.Fields
+}
+
+type recordedGauge struct {
+	name   string
+	value  float64
+	fields metrics.Fields
+}
+
+type recordedSample struct {
+	name   string
+	value  float64
+	unit   string
+	fields metrics.Fields
+}
+
+// NewRecordingMetricsEmitter returns an in-memory metrics emitter for tests
+// that assert on expected metric samples.
+func NewRecordingMetricsEmitter() *RecordingMetricsEmitter {
+	return &RecordingMetricsEmitter{}
+}
+
+// Counter implements metrics.MetricsEmitter.
+func (r *RecordingMetricsEmitter) Counter(_ context.Context, name string, delta float64, fields metrics.Fields) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.counters = append(r.counters, recordedCounter{name: name, delta: delta, fields: fields})
+	return nil
+}
+
+// Gauge implements metrics.MetricsEmitter.
+func (r *RecordingMetricsEmitter) Gauge(_ context.Context, name string, value float64, fields metrics.Fields) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.gauges = append(r.gauges, recordedGauge{name: name, value: value, fields: fields})
+	return nil
+}
+
+// Sample implements metrics.MetricsEmitter.
+func (r *RecordingMetricsEmitter) Sample(_ context.Context, name string, value float64, unit string, fields metrics.Fields) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.samples = append(r.samples, recordedSample{name: name, value: value, unit: unit, fields: fields})
+	return nil
+}
+
+// ContainsCounter reports whether a counter emission with the given name,
+// delta, and fields was recorded.
+func (r *RecordingMetricsEmitter) ContainsCounter(name string, delta float64, fields metrics.Fields) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, counter := range r.counters {
+		if counter.name == name && counter.delta == delta && counter.fields == fields {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsSample reports whether a sample emission with the given name, value,
+// unit, and fields was recorded.
+func (r *RecordingMetricsEmitter) ContainsSample(name string, value float64, unit string, fields metrics.Fields) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, sample := range r.samples {
+		if sample.name == name && sample.value == value && sample.unit == unit && sample.fields == fields {
+			return true
+		}
+	}
+	return false
+}
+
+// RecordingInvocationMetrics records service.InvocationMetricsRecorder emissions
+// for FactoryService observability tests.
+type RecordingInvocationMetrics struct {
+	mu      sync.Mutex
+	metrics []service.InvocationMetric
+}
+
+// NewRecordingInvocationMetrics returns a recorder for
+// FactoryServiceConfig.InvocationMetricsRecorder assertions.
+func NewRecordingInvocationMetrics() *RecordingInvocationMetrics {
+	return &RecordingInvocationMetrics{}
+}
+
+// RecordInvocationMetric implements service.InvocationMetricsRecorder.
+func (r *RecordingInvocationMetrics) RecordInvocationMetric(metric service.InvocationMetric) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	labels := make(map[string]string, len(metric.Labels))
+	maps.Copy(labels, metric.Labels)
+	r.metrics = append(r.metrics, service.InvocationMetric{
+		Name:   metric.Name,
+		Labels: labels,
+	})
+}
+
+// Contains reports whether an invocation metric with the given name and labels
+// was recorded.
+func (r *RecordingInvocationMetrics) Contains(name string, labels map[string]string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, metric := range r.metrics {
+		if metric.Name != name {
+			continue
+		}
+		match := true
+		for key, value := range labels {
+			if metric.Labels[key] != value {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+var (
+	_ metrics.MetricsEmitter           = (*RecordingMetricsEmitter)(nil)
+	_ service.InvocationMetricsRecorder = (*RecordingInvocationMetrics)(nil)
+)

--- a/pkg/testutil/testdeps/observability.go
+++ b/pkg/testutil/testdeps/observability.go
@@ -1,0 +1,41 @@
+package testdeps
+
+import (
+	"github.com/portpowered/infinite-you/pkg/internal/metrics"
+	"github.com/portpowered/infinite-you/pkg/logging"
+	"github.com/portpowered/infinite-you/pkg/service"
+	"go.uber.org/zap"
+)
+
+// Observability holds injectable logging and metrics dependencies for tests.
+type Observability struct {
+	Logger         logging.Logger
+	MetricsEmitter metrics.MetricsEmitter
+	ZapLogger      *zap.Logger
+}
+
+// Default returns quiet noop observability for ordinary tests.
+func Default() Observability {
+	return Observability{
+		Logger:         logging.NoopLogger{},
+		MetricsEmitter: metrics.NoopEmitter{},
+		ZapLogger:      zap.NewNop(),
+	}
+}
+
+// ApplyFactoryServiceConfig applies quiet observability defaults to cfg when
+// callers have not set explicit observability dependencies.
+func (o Observability) ApplyFactoryServiceConfig(cfg *service.FactoryServiceConfig) {
+	if cfg == nil {
+		return
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = o.ZapLogger
+	}
+	if cfg.RuntimeFileLoggingPolicy == "" {
+		cfg.RuntimeFileLoggingPolicy = service.RuntimeFileLoggingPolicyDisabled
+	}
+	if cfg.RuntimeMetricsPolicy == "" {
+		cfg.RuntimeMetricsPolicy = service.RuntimeMetricsPolicyDisabled
+	}
+}

--- a/pkg/testutil/testdeps/observability.go
+++ b/pkg/testutil/testdeps/observability.go
@@ -23,6 +23,16 @@ func Default() Observability {
 	}
 }
 
+// QuietFactoryServiceConfig applies quiet observability defaults to cfg and
+// returns it for ordinary tests that build FactoryService directly.
+func QuietFactoryServiceConfig(cfg *service.FactoryServiceConfig) *service.FactoryServiceConfig {
+	if cfg == nil {
+		cfg = &service.FactoryServiceConfig{}
+	}
+	Default().ApplyFactoryServiceConfig(cfg)
+	return cfg
+}
+
 // ApplyFactoryServiceConfig applies quiet observability defaults to cfg when
 // callers have not set explicit observability dependencies.
 func (o Observability) ApplyFactoryServiceConfig(cfg *service.FactoryServiceConfig) {

--- a/pkg/testutil/testdeps/observability_test.go
+++ b/pkg/testutil/testdeps/observability_test.go
@@ -287,6 +287,32 @@ func TestRecordingInvocationMetrics_CapturesFactoryServiceMetrics(t *testing.T) 
 	}
 }
 
+func TestProductionFactoryServiceConfig_PreservesEnabledObservabilityPoliciesWithoutTestDeps(t *testing.T) {
+	t.Parallel()
+
+	productionCfg := &service.FactoryServiceConfig{}
+	if productionCfg.RuntimeFileLoggingPolicy != "" {
+		t.Fatalf("RuntimeFileLoggingPolicy = %q, want empty production default", productionCfg.RuntimeFileLoggingPolicy)
+	}
+	if productionCfg.RuntimeMetricsPolicy != "" {
+		t.Fatalf("RuntimeMetricsPolicy = %q, want empty production default", productionCfg.RuntimeMetricsPolicy)
+	}
+	if productionCfg.Logger != nil {
+		t.Fatal("expected unset logger before production wiring")
+	}
+
+	quietCfg := testdeps.QuietFactoryServiceConfig(&service.FactoryServiceConfig{})
+	if quietCfg.RuntimeFileLoggingPolicy != service.RuntimeFileLoggingPolicyDisabled {
+		t.Fatalf("RuntimeFileLoggingPolicy = %q, want disabled after testdeps", quietCfg.RuntimeFileLoggingPolicy)
+	}
+	if quietCfg.RuntimeMetricsPolicy != service.RuntimeMetricsPolicyDisabled {
+		t.Fatalf("RuntimeMetricsPolicy = %q, want disabled after testdeps", quietCfg.RuntimeMetricsPolicy)
+	}
+	if quietCfg.Logger == nil {
+		t.Fatal("expected quiet logger after testdeps")
+	}
+}
+
 func TestApplyFactoryServiceConfig_PreservesCapturingLoggerAndMetricsRecorder(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/testutil/testdeps/observability_test.go
+++ b/pkg/testutil/testdeps/observability_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/portpowered/infinite-you/pkg/internal/metrics"
 	"github.com/portpowered/infinite-you/pkg/logging"
+	"github.com/portpowered/infinite-you/pkg/config"
 	"github.com/portpowered/infinite-you/pkg/service"
 	"github.com/portpowered/infinite-you/pkg/testutil/factoryfixtures"
 	"github.com/portpowered/infinite-you/pkg/testutil/testdeps"
@@ -100,6 +101,78 @@ func TestApplyFactoryServiceConfig_SetsQuietDefaultsWithoutOverridingExplicitVal
 	}
 	if emptyCfg.RuntimeMetricsPolicy != service.RuntimeMetricsPolicyDisabled {
 		t.Fatalf("RuntimeMetricsPolicy = %q, want disabled", emptyCfg.RuntimeMetricsPolicy)
+	}
+}
+
+func TestQuietFactoryServiceConfig_RepresentativeOrdinaryBuildPatternsStayQuiet(t *testing.T) {
+	dir := t.TempDir()
+	factoryfixtures.WriteFactoryJSON(t, dir, factoryfixtures.MinimalFactoryConfig())
+	metricsDir := t.TempDir()
+	logDir := t.TempDir()
+
+	cfg := testdeps.QuietFactoryServiceConfig(&service.FactoryServiceConfig{
+		Dir:                                     dir,
+		MockWorkersConfig:                       config.NewEmptyMockWorkersConfig(),
+		RuntimeMetricsDir:                       metricsDir,
+		RuntimeLogDir:                           logDir,
+		SkipBuiltInRunnerPrerequisiteValidation: true,
+	})
+	if cfg.Logger == nil {
+		t.Fatal("expected quiet factory service config to assign noop logger")
+	}
+	if cfg.RuntimeFileLoggingPolicy != service.RuntimeFileLoggingPolicyDisabled {
+		t.Fatalf("RuntimeFileLoggingPolicy = %q, want disabled", cfg.RuntimeFileLoggingPolicy)
+	}
+	if cfg.RuntimeMetricsPolicy != service.RuntimeMetricsPolicyDisabled {
+		t.Fatalf("RuntimeMetricsPolicy = %q, want disabled", cfg.RuntimeMetricsPolicy)
+	}
+
+	svc, err := service.BuildFactoryService(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("BuildFactoryService: %v", err)
+	}
+	bundle := svc.CurrentRuntimeBundle()
+	if bundle == nil {
+		t.Fatal("expected startup runtime bundle")
+	}
+	if bundle.MetricsSink != nil {
+		t.Fatal("expected disabled runtime metrics policy to skip metrics sink creation")
+	}
+
+	var metricFiles []string
+	err = filepath.WalkDir(metricsDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		metricFiles = append(metricFiles, path)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkDir(%s): %v", metricsDir, err)
+	}
+	if len(metricFiles) != 0 {
+		t.Fatalf("metrics files = %v, want none", metricFiles)
+	}
+
+	var logFiles []string
+	err = filepath.WalkDir(logDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		logFiles = append(logFiles, path)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkDir(%s): %v", logDir, err)
+	}
+	if len(logFiles) != 0 {
+		t.Fatalf("runtime log files = %v, want none", logFiles)
 	}
 }
 

--- a/pkg/testutil/testdeps/observability_test.go
+++ b/pkg/testutil/testdeps/observability_test.go
@@ -1,0 +1,150 @@
+package testdeps_test
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/internal/metrics"
+	"github.com/portpowered/infinite-you/pkg/logging"
+	"github.com/portpowered/infinite-you/pkg/service"
+	"github.com/portpowered/infinite-you/pkg/testutil/factoryfixtures"
+	"github.com/portpowered/infinite-you/pkg/testutil/testdeps"
+)
+
+func TestDefaultObservability_UsesNoopLoggerAndMetricsEmitter(t *testing.T) {
+	t.Parallel()
+
+	obs := testdeps.Default()
+	if _, ok := obs.Logger.(logging.NoopLogger); !ok {
+		t.Fatalf("Logger = %T, want logging.NoopLogger", obs.Logger)
+	}
+	if _, ok := obs.MetricsEmitter.(metrics.NoopEmitter); !ok {
+		t.Fatalf("MetricsEmitter = %T, want metrics.NoopEmitter", obs.MetricsEmitter)
+	}
+	if obs.ZapLogger == nil {
+		t.Fatal("ZapLogger = nil, want non-nil nop logger")
+	}
+}
+
+func TestDefaultObservability_DiscardsRoutineLogAndMetricCalls(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	obs := testdeps.Default()
+	obs.Logger.Info("routine test log", "key", "value")
+	obs.Logger.Warn("routine warning")
+	obs.Logger.Error("routine error")
+	obs.Logger.Debug("routine debug")
+	obs.Logger.Verbose("routine verbose", "detail", true)
+
+	fields := metrics.Fields{DispatchID: "dispatch-1", Workstation: "review"}
+	if err := obs.MetricsEmitter.Counter(context.Background(), "dispatch.started", 1, fields); err != nil {
+		t.Fatalf("Counter: %v", err)
+	}
+	if err := obs.MetricsEmitter.Gauge(context.Background(), "queue.depth", 2, fields); err != nil {
+		t.Fatalf("Gauge: %v", err)
+	}
+	if err := obs.MetricsEmitter.Sample(context.Background(), "dispatch.duration", 12.5, "ms", fields); err != nil {
+		t.Fatalf("Sample: %v", err)
+	}
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("default observability wrote files: %v", entries)
+	}
+}
+
+func TestDefaultObservability_ZapLoggerIsNoop(t *testing.T) {
+	t.Parallel()
+
+	quiet := testdeps.Default()
+	if quiet.ZapLogger == nil {
+		t.Fatal("ZapLogger = nil")
+	}
+	quiet.ZapLogger.Info("discarded by nop logger")
+}
+
+func TestApplyFactoryServiceConfig_SetsQuietDefaultsWithoutOverridingExplicitValues(t *testing.T) {
+	t.Parallel()
+
+	explicitLogger := testdeps.Default().ZapLogger
+	cfg := &service.FactoryServiceConfig{
+		Logger:                   explicitLogger,
+		RuntimeFileLoggingPolicy: service.RuntimeFileLoggingPolicyEnabled,
+		RuntimeMetricsPolicy:     service.RuntimeMetricsPolicyEnabled,
+	}
+	testdeps.Default().ApplyFactoryServiceConfig(cfg)
+
+	if cfg.Logger != explicitLogger {
+		t.Fatal("ApplyFactoryServiceConfig replaced explicit logger")
+	}
+	if cfg.RuntimeFileLoggingPolicy != service.RuntimeFileLoggingPolicyEnabled {
+		t.Fatalf("RuntimeFileLoggingPolicy = %q, want enabled", cfg.RuntimeFileLoggingPolicy)
+	}
+	if cfg.RuntimeMetricsPolicy != service.RuntimeMetricsPolicyEnabled {
+		t.Fatalf("RuntimeMetricsPolicy = %q, want enabled", cfg.RuntimeMetricsPolicy)
+	}
+
+	emptyCfg := &service.FactoryServiceConfig{}
+	testdeps.Default().ApplyFactoryServiceConfig(emptyCfg)
+	if emptyCfg.Logger == nil {
+		t.Fatal("expected default zap logger to be assigned")
+	}
+	if emptyCfg.RuntimeFileLoggingPolicy != service.RuntimeFileLoggingPolicyDisabled {
+		t.Fatalf("RuntimeFileLoggingPolicy = %q, want disabled", emptyCfg.RuntimeFileLoggingPolicy)
+	}
+	if emptyCfg.RuntimeMetricsPolicy != service.RuntimeMetricsPolicyDisabled {
+		t.Fatalf("RuntimeMetricsPolicy = %q, want disabled", emptyCfg.RuntimeMetricsPolicy)
+	}
+}
+
+func TestApplyFactoryServiceConfig_BuildFactoryServiceDoesNotCreateMetricsFiles(t *testing.T) {
+	dir := t.TempDir()
+	factoryfixtures.WriteFactoryJSON(t, dir, factoryfixtures.MinimalFactoryConfig())
+	metricsDir := t.TempDir()
+
+	cfg := &service.FactoryServiceConfig{
+		Dir:                                     dir,
+		RuntimeMetricsDir:                       metricsDir,
+		SkipBuiltInRunnerPrerequisiteValidation: true,
+	}
+	testdeps.Default().ApplyFactoryServiceConfig(cfg)
+
+	svc, err := service.BuildFactoryService(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("BuildFactoryService: %v", err)
+	}
+	if svc == nil {
+		t.Fatal("BuildFactoryService returned nil service")
+	}
+	bundle := svc.CurrentRuntimeBundle()
+	if bundle == nil {
+		t.Fatal("expected startup runtime bundle")
+	}
+	if bundle.MetricsSink != nil {
+		t.Fatal("expected disabled runtime metrics policy to skip metrics sink creation")
+	}
+
+	var metricFiles []string
+	err = filepath.WalkDir(metricsDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		metricFiles = append(metricFiles, path)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkDir(%s): %v", metricsDir, err)
+	}
+	if len(metricFiles) != 0 {
+		t.Fatalf("metrics files = %v, want none", metricFiles)
+	}
+}

--- a/pkg/testutil/testdeps/observability_test.go
+++ b/pkg/testutil/testdeps/observability_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/service"
 	"github.com/portpowered/infinite-you/pkg/testutil/factoryfixtures"
 	"github.com/portpowered/infinite-you/pkg/testutil/testdeps"
+	"go.uber.org/zap/zapcore"
 )
 
 func TestDefaultObservability_UsesNoopLoggerAndMetricsEmitter(t *testing.T) {
@@ -219,5 +220,93 @@ func TestApplyFactoryServiceConfig_BuildFactoryServiceDoesNotCreateMetricsFiles(
 	}
 	if len(metricFiles) != 0 {
 		t.Fatalf("metrics files = %v, want none", metricFiles)
+	}
+}
+
+func TestCapturingObservability_RecordsLogAndMetricEmissions(t *testing.T) {
+	t.Parallel()
+
+	obs, capture := testdeps.Capturing(zapcore.InfoLevel)
+	obs.Logger.Info("observability under test", "detail", "value")
+
+	fields := metrics.Fields{DispatchID: "dispatch-1", Workstation: "review"}
+	if err := obs.MetricsEmitter.Counter(context.Background(), "dispatch.started", 1, fields); err != nil {
+		t.Fatalf("Counter: %v", err)
+	}
+	if err := obs.MetricsEmitter.Sample(context.Background(), "dispatch.duration", 12.5, "ms", fields); err != nil {
+		t.Fatalf("Sample: %v", err)
+	}
+
+	logs := capture.ObservedLogs.FilterMessage("observability under test").All()
+	if len(logs) != 1 {
+		t.Fatalf("observed logs = %d, want 1", len(logs))
+	}
+	if !capture.Metrics.ContainsCounter("dispatch.started", 1, fields) {
+		t.Fatal("expected captured counter emission")
+	}
+	if !capture.Metrics.ContainsSample("dispatch.duration", 12.5, "ms", fields) {
+		t.Fatal("expected captured sample emission")
+	}
+}
+
+func TestCapturingObservability_DoesNotAffectDefaultQuietObservability(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	obs, capture := testdeps.Capturing(zapcore.InfoLevel)
+	obs.Logger.Info("isolated capture log")
+	if len(capture.ObservedLogs.All()) != 1 {
+		t.Fatalf("capturing logs = %d, want 1", len(capture.ObservedLogs.All()))
+	}
+
+	quiet := testdeps.Default()
+	quiet.Logger.Info("quiet default log")
+	if err := quiet.MetricsEmitter.Counter(context.Background(), "dispatch.started", 1, metrics.Fields{}); err != nil {
+		t.Fatalf("Counter: %v", err)
+	}
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("default observability wrote files after isolated capture: %v", entries)
+	}
+}
+
+func TestRecordingInvocationMetrics_CapturesFactoryServiceMetrics(t *testing.T) {
+	t.Parallel()
+
+	recorder := testdeps.NewRecordingInvocationMetrics()
+	recorder.RecordInvocationMetric(service.InvocationMetric{
+		Name:   "runtime.loaded",
+		Labels: map[string]string{"identity": "model-a"},
+	})
+
+	if !recorder.Contains("runtime.loaded", map[string]string{"identity": "model-a"}) {
+		t.Fatal("expected captured invocation metric")
+	}
+}
+
+func TestApplyFactoryServiceConfig_PreservesCapturingLoggerAndMetricsRecorder(t *testing.T) {
+	t.Parallel()
+
+	obs, capture := testdeps.Capturing(zapcore.WarnLevel)
+	recorder := testdeps.NewRecordingInvocationMetrics()
+	cfg := &service.FactoryServiceConfig{
+		Logger:                    obs.ZapLogger,
+		InvocationMetricsRecorder: recorder,
+	}
+	testdeps.Default().ApplyFactoryServiceConfig(cfg)
+
+	if cfg.Logger != obs.ZapLogger {
+		t.Fatal("ApplyFactoryServiceConfig replaced explicit capturing logger")
+	}
+	if cfg.InvocationMetricsRecorder != recorder {
+		t.Fatal("ApplyFactoryServiceConfig replaced explicit metrics recorder")
+	}
+
+	obs.ZapLogger.Warn("preserved capturing logger")
+	if len(capture.ObservedLogs.FilterMessage("preserved capturing logger").All()) != 1 {
+		t.Fatal("expected capturing logger to remain observable after quiet defaults")
 	}
 }

--- a/tests/functional/internal/support/api_server.go
+++ b/tests/functional/internal/support/api_server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/petri"
 	"github.com/portpowered/infinite-you/pkg/service"
+	"github.com/portpowered/infinite-you/pkg/testutil/testdeps"
 	"go.uber.org/zap"
 )
 
@@ -50,12 +51,10 @@ func StartFunctionalAPIServer(t *testing.T, cfg FunctionalAPIServerConfig) *Func
 	var handler http.Handler
 	readyCh := make(chan struct{})
 
-	serviceCfg := &service.FactoryServiceConfig{
-		Dir:                      cfg.FactoryDir,
-		Port:                     1,
-		Logger:                   zap.NewNop(),
-		RuntimeFileLoggingPolicy: service.RuntimeFileLoggingPolicyDisabled,
-		ExtraOptions:             cfg.ExtraOptions,
+	serviceCfg := testdeps.QuietFactoryServiceConfig(&service.FactoryServiceConfig{
+		Dir:          cfg.FactoryDir,
+		Port:         1,
+		ExtraOptions: cfg.ExtraOptions,
 		APIServerStarter: func(ctx context.Context, surface apisurface.APISurface, port int, l *zap.Logger) error {
 			if cfg.CaptureAPISurface != nil {
 				cfg.CaptureAPISurface(surface)
@@ -65,7 +64,7 @@ func StartFunctionalAPIServer(t *testing.T, cfg FunctionalAPIServerConfig) *Func
 			<-ctx.Done()
 			return nil
 		},
-	}
+	})
 	if cfg.UseMockWorkers {
 		serviceCfg.MockWorkersConfig = config.NewEmptyMockWorkersConfig()
 	}

--- a/tests/functional/providers/mock_workers_service_runner_test.go
+++ b/tests/functional/providers/mock_workers_service_runner_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/service"
 	"github.com/portpowered/infinite-you/pkg/testutil"
+	"github.com/portpowered/infinite-you/pkg/testutil/testdeps"
 	"github.com/portpowered/infinite-you/pkg/workers"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
-	"go.uber.org/zap"
 )
 
 func TestMockWorkers_ServiceCommandRunnerCompletesModelAndScriptWorkers(t *testing.T) {
@@ -45,13 +45,13 @@ func TestMockWorkers_ServiceCommandRunnerCompletesModelAndScriptWorkers(t *testi
 			logDir := t.TempDir()
 			runtimeID := strings.ReplaceAll(tt.name, " ", "-")
 
-			svc, err := service.BuildFactoryService(context.Background(), &service.FactoryServiceConfig{
-				Dir:               dir,
-				MockWorkersConfig: config.NewEmptyMockWorkersConfig(),
-				Logger:            zap.NewNop(),
-				RuntimeLogDir:     logDir,
-				RuntimeInstanceID: runtimeID,
-			})
+			svc, err := service.BuildFactoryService(context.Background(), testdeps.QuietFactoryServiceConfig(&service.FactoryServiceConfig{
+				Dir:                      dir,
+				MockWorkersConfig:        config.NewEmptyMockWorkersConfig(),
+				RuntimeLogDir:            logDir,
+				RuntimeInstanceID:        runtimeID,
+				RuntimeFileLoggingPolicy: service.RuntimeFileLoggingPolicyEnabled,
+			}))
 			if err != nil {
 				t.Fatalf("BuildFactoryService: %v", err)
 			}

--- a/tests/functional/smoke/service_lifecycle_smoke_long_test.go
+++ b/tests/functional/smoke/service_lifecycle_smoke_long_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/service"
 	"github.com/portpowered/infinite-you/pkg/testutil"
+	"github.com/portpowered/infinite-you/pkg/testutil/testdeps"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
-	"go.uber.org/zap"
 )
 
 func TestServiceLifecycle_InitInputCompletesThroughFactoryService(t *testing.T) {
@@ -68,12 +68,11 @@ func TestServiceLifecycle_WorkFileSubmissionCompletesTwoStagePipeline(t *testing
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	svc, err := service.BuildFactoryService(ctx, &service.FactoryServiceConfig{
+	svc, err := service.BuildFactoryService(ctx, testdeps.QuietFactoryServiceConfig(&service.FactoryServiceConfig{
 		Dir:               dir,
 		MockWorkersConfig: config.NewEmptyMockWorkersConfig(),
-		Logger:            zap.NewNop(),
 		WorkFile:          workFilePath,
-	})
+	}))
 	if err != nil {
 		t.Fatalf("BuildFactoryService: %v", err)
 	}
@@ -240,11 +239,10 @@ func writeParallelIsolationSeed(t *testing.T, dir, payload string) {
 func buildFunctionalService(t *testing.T, ctx context.Context, dir string) *service.FactoryService {
 	t.Helper()
 
-	svc, err := service.BuildFactoryService(ctx, &service.FactoryServiceConfig{
+	svc, err := service.BuildFactoryService(ctx, testdeps.QuietFactoryServiceConfig(&service.FactoryServiceConfig{
 		Dir:               dir,
 		MockWorkersConfig: config.NewEmptyMockWorkersConfig(),
-		Logger:            zap.NewNop(),
-	})
+	}))
 	if err != nil {
 		t.Fatalf("BuildFactoryService: %v", err)
 	}


### PR DESCRIPTION
{
  "project": "Log Test Cleanup",
  "branchName": "log-test-cleanup",
  "description": "Make ordinary backend and runtime tests quiet by default by wiring test dependency injection to noop logging and noop metrics recording, while preserving explicit opt-in capture for observability-specific tests and leaving production observability unchanged.",
  "context": {
    "customerAsk": "Tests currently generate very many logs and metrics. Update the tests so they do not generate logs unless necessary, and set up the default injection mechanism to use a noop logger and metrics recorder.",
    "problem": "Routine tests currently create noisy logs and metrics through default injected observability dependencies even when no assertion depends on those diagnostics. This makes local and CI output harder to scan, can mix incidental records with intentional observability assertions, and hides real failures behind low-value diagnostic noise.",
    "solution": "Make the test-owned default dependency injection path provide noop logging and noop metrics recording, update ordinary tests to rely on that quiet default, preserve explicit capturing dependencies for tests that verify logs or metrics, and add focused regression evidence for quiet defaults and opt-in observability capture."
  },
  "acceptanceCriteria": [
    "Standard test dependency injection returns a noop logger and noop metrics recorder when the test does not explicitly request observability capture.",
    "Representative ordinary backend/runtime tests complete without emitting routine log output or recording metric samples through injected dependencies.",
    "Tests that intentionally verify logs or metrics can explicitly opt into a capturing logger or recorder and keep asserting on the expected diagnostic records.",
    "Production-facing dependency wiring and runtime observability behavior remain unchanged outside test-owned injection paths.",
    "Regression coverage proves both quiet-by-default behavior and opt-in diagnostic capture using runtime-observable outcomes, not helper inventories or file-topology checks.",
    "The implementation stays narrow to test dependency defaults and directly affected test harness usage, with no broad unrelated cleanup.",
    "Quality gate: typecheck, lint, and relevant Go tests pass."
  ],
  "userStories": [
    {
      "id": "log-test-cleanup-001",
      "title": "Default test injection to noop observability",
      "description": "As a maintainer writing ordinary tests, I want the standard test dependency injection path to provide noop logging and metrics so that tests do not emit diagnostics unless they explicitly need them.",
      "acceptanceCriteria": [
        "A test that constructs dependencies through the standard test injection path receives a logger that discards routine log records by default.",
        "A test that constructs dependencies through the standard test injection path receives a metrics recorder that ignores routine metric samples by default.",
        "The default noop behavior is scoped to test-owned dependency injection and does not change production-facing dependency wiring.",
        "Regression coverage proves that representative injected log and metric calls produce no captured output or recorded samples in the default test path.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "log-test-cleanup-002",
      "title": "Keep ordinary test runs quiet through default wiring",
      "description": "As a maintainer running the backend test suite, I want representative ordinary tests to run without routine log or metrics noise so that local and CI output highlights real failures.",
      "acceptanceCriteria": [
        "Representative backend/runtime tests that do not assert on observability use the quiet default injection path rather than constructing real loggers or metrics recorders incidentally.",
        "Those representative tests complete without writing routine log output through injected loggers.",
        "Those representative tests complete without accumulating routine metric samples through injected recorders.",
        "The cleanup does not weaken behavioral assertions unrelated to logging or metrics.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "log-test-cleanup-003",
      "title": "Preserve explicit observability capture for diagnostics tests",
      "description": "As a maintainer of logging and metrics coverage, I want tests that verify observability behavior to opt into capturing dependencies so that important diagnostics remain testable without making every test noisy.",
      "acceptanceCriteria": [
        "A test can explicitly request a capturing logger and assert on expected log records when logging is the behavior under test.",
        "A test can explicitly request a capturing metrics recorder and assert on expected metric samples when metrics are the behavior under test.",
        "Opt-in capture remains isolated to the requesting test and does not affect quiet defaults for other tests.",
        "Existing observability-specific coverage continues to verify important failure, lifecycle, or runtime diagnostic records after the default changes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "log-test-cleanup-004",
      "title": "Prove production observability remains unchanged",
      "description": "As an operator relying on runtime diagnostics, I want production-facing wiring to keep real logging and metrics behavior so that test cleanup does not reduce operational visibility.",
      "acceptanceCriteria": [
        "Production-facing service or runtime construction continues to configure the same real logger behavior it used before this test cleanup.",
        "Production-facing service or runtime construction continues to configure the same real metrics recorder behavior it used before this test cleanup.",
        "Regression coverage or focused smoke evidence proves that only test-owned default injection changes to noop observability.",
        "The change does not alter public API, CLI, event-stream, or dashboard contracts.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)