### PR TITLE
you-agent-factory-components-name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ define run_timed_step
 	exit $$status
 endef
 
-.PHONY: default build intall bundle-api generate-api generate-go-api generate-go-server-api generate-go-client-api generate-ui-api generate-wire wire-smoke api-smoke docs-reference-check docs-reference-smoke test test-full test-functional test-functional-long verify-fast verify-pr verify-pr-inference verify-extended verify-build-contracts verify-tests run-concurrent-ui-verification-lanes run-sharded-ui-coverage verify test-ui-coverage test-ui-coverage-merge test-ui-browser-integration test-backend-coverage test-backend-functional test-backend-verification long-tests long-tests-managed-runtime long-tests-functional-runtime pr-inference-approval test-coverage-go script-timeout-companion-smoke-100 cron-time-work-smoke current-factory-watcher-switch-smoke release-surface-smoke artifact-contract-closeout lint backend-size pkg-maint pkg-file-count readme-check deadcode ui-deadcode test-race fmt vet deps deps-tidy dashboard-verify typecheck release ci ci-typecheck ci-verify-build-contracts ci-verify-tests ui-deps ui-lint ui-build ui-test ui-integration-test ui-test-coverage ui-replay-coverage-check ui-install-playwright ui-storybook ui-test-storybook clean
+.PHONY: default build intall bundle-api generate-api generate-go-api generate-go-server-api generate-go-client-api generate-ui-api generate-wire wire-smoke api-smoke docs-reference-check docs-reference-smoke test test-full test-functional test-functional-long verify-fast verify-pr verify-pr-inference verify-extended verify-build-contracts verify-tests run-concurrent-ui-verification-lanes run-sharded-ui-coverage verify test-ui-coverage test-ui-coverage-merge test-ui-browser-integration test-backend-coverage test-backend-functional test-backend-verification long-tests long-tests-managed-runtime long-tests-functional-runtime pr-inference-approval test-coverage-go script-timeout-companion-smoke-100 cron-time-work-smoke current-factory-watcher-switch-smoke release-surface-smoke artifact-contract-closeout lint backend-size pkg-maint pkg-file-count readme-check deadcode ui-deadcode test-race fmt vet deps deps-tidy dashboard-verify typecheck release ci ci-typecheck ci-verify-build-contracts ci-verify-tests ui-deps ui-lint ui-build ui-test ui-integration-test ui-test-coverage ui-replay-coverage-check ui-install-playwright ui-storybook ui-test-storybook ui-verify-fresh-npm-install clean
 
 default:
 	$(MAKE) generate-api
@@ -300,6 +300,9 @@ release-surface-smoke:
 
 ui-deps:
 	cd ui && $(UI_INSTALL)
+
+ui-verify-fresh-npm-install:
+	cd ui && $(NPM) run verify:fresh-npm-install
 
 ui-lint:
 	cd ui && $(UI_SCRIPT) lint

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ GO          ?= go
 INSTALL_DIR := $(or $(GOBIN),$(shell $(GO) env GOPATH)/bin)
 NPM         ?= npm
 BUN_BIN     := $(shell command -v bun 2>/dev/null)
+BUN_INSTALL := $(BUN_BIN) install --frozen-lockfile
+BUN_PACKAGE_DIRS := ui/packages/components ui
 UI_SCRIPT   := $(if $(BUN_BIN),$(BUN_BIN) run,$(NPM) run)
 UI_EXEC     := $(if $(BUN_BIN),$(BUN_BIN) x,$(NPM) exec)
 UI_INSTALL  := $(if $(BUN_BIN),$(BUN_BIN) install --frozen-lockfile,$(NPM) install --no-package-lock)
@@ -69,7 +71,7 @@ define run_timed_step
 	exit $$status
 endef
 
-.PHONY: default build intall bundle-api generate-api generate-go-api generate-go-server-api generate-go-client-api generate-ui-api generate-wire wire-smoke api-smoke docs-reference-check docs-reference-smoke test test-full test-functional test-functional-long verify-fast verify-pr verify-pr-inference verify-extended verify-build-contracts verify-tests run-concurrent-ui-verification-lanes run-sharded-ui-coverage verify test-ui-coverage test-ui-coverage-merge test-ui-browser-integration test-backend-coverage test-backend-functional test-backend-verification long-tests long-tests-managed-runtime long-tests-functional-runtime pr-inference-approval test-coverage-go script-timeout-companion-smoke-100 cron-time-work-smoke current-factory-watcher-switch-smoke release-surface-smoke artifact-contract-closeout lint backend-size pkg-maint pkg-file-count readme-check deadcode ui-deadcode test-race fmt vet deps deps-tidy dashboard-verify typecheck release ci ci-typecheck ci-verify-build-contracts ci-verify-tests ui-deps ui-lint ui-build ui-test ui-integration-test ui-test-coverage ui-replay-coverage-check ui-install-playwright ui-storybook ui-test-storybook ui-verify-fresh-npm-install clean
+.PHONY: default build intall bundle-api generate-api generate-go-api generate-go-server-api generate-go-client-api generate-ui-api generate-wire wire-smoke api-smoke docs-reference-check docs-reference-smoke test test-full test-functional test-functional-long verify-fast verify-pr verify-pr-inference verify-extended verify-build-contracts verify-tests run-concurrent-ui-verification-lanes run-sharded-ui-coverage verify test-ui-coverage test-ui-coverage-merge test-ui-browser-integration test-backend-coverage test-backend-functional test-backend-verification long-tests long-tests-managed-runtime long-tests-functional-runtime pr-inference-approval test-coverage-go script-timeout-companion-smoke-100 cron-time-work-smoke current-factory-watcher-switch-smoke release-surface-smoke artifact-contract-closeout lint backend-size pkg-maint pkg-file-count readme-check deadcode ui-deadcode test-race fmt vet deps deps-tidy init dashboard-verify typecheck release ci ci-typecheck ci-verify-build-contracts ci-verify-tests ui-deps ui-lint ui-build ui-test ui-integration-test ui-test-coverage ui-replay-coverage-check ui-install-playwright ui-storybook ui-test-storybook ui-verify-fresh-npm-install clean
 
 default:
 	$(MAKE) generate-api
@@ -321,6 +323,19 @@ deps:
 
 deps-tidy:
 	$(GO) mod tidy
+
+init:
+ifeq ($(BUN_BIN),)
+	$(error init requires bun on PATH; install Bun 1.3.12+ per ui/package.json packageManager and retry)
+endif
+	@set -e; \
+	for dir in $(BUN_PACKAGE_DIRS); do \
+		printf '%s\n' "==> bun install ($$dir)"; \
+		(cd "$$dir" && $(BUN_INSTALL)) || { \
+			printf '%s\n' "FAIL: bun install failed in $$dir. Rerun from repository root: cd $$dir && bun install --frozen-lockfile"; \
+			exit 1; \
+		}; \
+	done
 
 ui-build:
 ifeq ($(BUN_BIN),)

--- a/docs/internal/development/development.md
+++ b/docs/internal/development/development.md
@@ -52,6 +52,7 @@ make fmt
 make dashboard-verify
 make release VERSION=v1.2.3
 make ui-deps
+make ui-verify-fresh-npm-install
 make ui-build
 make ui-test
 make ui-integration-test
@@ -69,6 +70,7 @@ Run dashboard package commands from `ui/` with Bun 1.3.12+ on PATH. Root `make` 
 | Coverage thresholds and replay fixture guard | `make test-ui-coverage` | Bun covered phases via `test:coverage`, then replay check |
 | Playwright integration | `cd ui && bun run test:integration` or `make ui-integration-test` | Vitest + Playwright |
 | Unit then integration | `cd ui && bun run test` | Bun unit lane, then Vitest integration |
+| Fresh npm install proof for scoped local components | `make ui-verify-fresh-npm-install` or `cd ui && npm run verify:fresh-npm-install` | Node script runs an isolated dashboard `npm install` and asserts `@you-agent-factory/components` resolves from `packages/components` |
 | Storybook browser stories | `cd ui && bun run storybook:test-runner:ci` or `make ui-test-storybook` | Vitest Storybook project (`vitest.storybook.config.ts`) |
 
 Prefer `bun run test:unit` (or `make ui-test`) over ad hoc `bun test <paths>` for dashboard unit work so batching, exclusions, preload, and worker policy stay aligned with CI. Targeted unit proof may still use `cd ui && bun test <paths>` when a story explicitly needs one file or subtree. Storybook browser, Storybook script verifiers, and the coverage standalone dashboard-shell script phase remain Vitest-only; idea and cleanup writeups should cite `bun run test:unit`, `make ui-test`, `make test-ui-coverage`, or the Storybook Vitest commands above instead of legacy `vitest run` unit invocations.

--- a/docs/internal/development/development.md
+++ b/docs/internal/development/development.md
@@ -28,7 +28,10 @@ This checkout is operated from the repository root that contains `go.mod`, `Make
 
 Run commands from the repository root shown above.
 
+Fresh checkouts should run `make init` once to install Bun dependencies for the dashboard (`ui/`) and the scoped components package (`ui/packages/components/`). The target requires Bun on `PATH`, stops on the first failed install, and does not require changing directories manually.
+
 ```bash
+make init
 make build
 make generate-api
 make api-smoke

--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -26,7 +26,7 @@
         "react-resizable-panels": "^4.10.0",
         "recharts": "^3.8.1",
         "sonner": "^2.0.7",
-        "youagentfactory/components": "file:./packages/components",
+        "@you-agent-factory/components": "file:./packages/components",
         "zustand": "^4.5.7",
       },
       "devDependencies": {
@@ -1353,7 +1353,7 @@
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
-    "youagentfactory/components": ["youagentfactory/components@file:packages/components", { "dependencies": { "@xyflow/react": "^12.10.2", "recharts": "^3.8.1" }, "peerDependencies": { "react": "^19.0.0", "react-dom": "^19.0.0" } }],
+    "@you-agent-factory/components": ["@you-agent-factory/components@file:packages/components", { "dependencies": { "@xyflow/react": "^12.10.2", "recharts": "^3.8.1" }, "peerDependencies": { "react": "^19.0.0", "react-dom": "^19.0.0" } }],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -17,6 +17,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tanstack/react-query": "^5.90.2",
         "@xyflow/react": "^12.10.2",
+        "@you-agent-factory/components": "file:./packages/components",
         "cron-parser": "4.9.0",
         "d3": "^7.9.0",
         "elkjs": "^0.11.1",
@@ -3719,6 +3720,10 @@
         "d3-selection": "^3.0.0",
         "d3-zoom": "^3.0.0"
       }
+    },
+    "node_modules/@you-agent-factory/components": {
+      "resolved": "packages/components",
+      "link": true
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -7769,6 +7774,18 @@
         "react": {
           "optional": true
         }
+      }
+    },
+    "packages/components": {
+      "name": "@you-agent-factory/components",
+      "version": "0.0.0",
+      "dependencies": {
+        "@xyflow/react": "^12.10.2",
+        "recharts": "^3.8.1"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     }
   }

--- a/ui/package.json
+++ b/ui/package.json
@@ -68,7 +68,7 @@
     "react-resizable-panels": "^4.10.0",
     "recharts": "^3.8.1",
     "sonner": "^2.0.7",
-    "youagentfactory/components": "file:./packages/components",
+    "@you-agent-factory/components": "file:./packages/components",
     "zustand": "^4.5.7"
   },
   "devDependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -44,7 +44,8 @@
     "test": "vitest run --exclude 'integration/*.integration.test.mjs' && vitest run integration --no-file-parallelism --maxWorkers 1",
     "test-storybook": "bun scripts/run-storybook-ci.mjs",
     "tsc": "tsc -b --noEmit --pretty false",
-    "typecheck": "tsc -b --noEmit --pretty false"
+    "typecheck": "tsc -b --noEmit --pretty false",
+    "verify:fresh-npm-install": "node scripts/verify-fresh-npm-install.mjs"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",

--- a/ui/packages/components/README.md
+++ b/ui/packages/components/README.md
@@ -1,4 +1,4 @@
-# youagentfactory/components
+# @you-agent-factory/components
 
 Presentation components, shared design tokens, and small utilities for building
 factory-style UIs outside the dashboard. The package is domain-free: it does not
@@ -12,13 +12,13 @@ uses a workspace link:
 ```json
 {
   "dependencies": {
-    "youagentfactory/components": "file:./packages/components"
+    "@you-agent-factory/components": "file:./packages/components"
   }
 }
 ```
 
 Published consumers should depend on the same package name
-(`youagentfactory/components`) from their chosen distribution channel.
+(`@you-agent-factory/components`) from their chosen distribution channel.
 
 Peer dependencies:
 
@@ -35,7 +35,7 @@ Import the package styles entrypoint once in your application CSS (or an
 equivalent global stylesheet hook) before rendering components:
 
 ```css
-@import "youagentfactory/components/styles.css";
+@import "@you-agent-factory/components/styles.css";
 ```
 
 With Tailwind CSS v4, a typical host `styles.css` also imports Tailwind and may
@@ -43,7 +43,7 @@ layer app-specific utilities after the package tokens:
 
 ```css
 @import "tailwindcss";
-@import "youagentfactory/components/styles.css";
+@import "@you-agent-factory/components/styles.css";
 
 /* Host-only utilities and foundation overrides */
 ```
@@ -57,18 +57,18 @@ API clients, or generated OpenAPI types to use these tokens.
 Category entrypoints are deep imports under the package name:
 
 ```ts
-import { COMPONENTS_PACKAGE_NAME } from "youagentfactory/components";
-import * as primitives from "youagentfactory/components/primitives";
-import * as forms from "youagentfactory/components/forms";
-import { cn } from "youagentfactory/components/utilities";
+import { COMPONENTS_PACKAGE_NAME } from "@you-agent-factory/components";
+import * as primitives from "@you-agent-factory/components/primitives";
+import * as forms from "@you-agent-factory/components/forms";
+import { cn } from "@you-agent-factory/components/utilities";
 ```
 
 `COMPONENTS_PACKAGE_NAME` is the stable package identifier
-(`"youagentfactory/components"`). Category paths include `primitives`, `forms`,
+(`"@you-agent-factory/components"`). Category paths include `primitives`, `forms`,
 `layout`, `feedback`, `data-display`, `navigation`, `overlays`, `charts`,
 `graphs`, `recipes`, `icons`, `utilities`, `testing`, and `tokens`.
 
-Use `cn` from `youagentfactory/components/utilities` for class name composition
+Use `cn` from `@you-agent-factory/components/utilities` for class name composition
 in component code instead of dashboard-local helpers.
 
 ## Consumer responsibilities
@@ -119,7 +119,7 @@ utility sheets.
 Some teams copy component source into their repository to customize markup or
 styles while keeping the same token foundation. Supported patterns today:
 
-1. Import `youagentfactory/components/styles.css` in the host app so copied
+1. Import `@you-agent-factory/components/styles.css` in the host app so copied
    components receive the same tokens.
 2. Copy the component files you need from the package category you depend on.
 3. Keep copied code on the package side of your boundary — do not pull in

--- a/ui/packages/components/package.json
+++ b/ui/packages/components/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "youagentfactory/components",
+  "name": "@you-agent-factory/components",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/ui/packages/components/scripts/check-package-boundary.mjs
+++ b/ui/packages/components/scripts/check-package-boundary.mjs
@@ -137,13 +137,13 @@ async function main() {
 
   if (violations.length === 0) {
     process.stdout.write(
-      "youagentfactory/components package boundary check passed.\n",
+      "@you-agent-factory/components package boundary check passed.\n",
     );
     return;
   }
 
   process.stderr.write(
-    "youagentfactory/components package boundary check failed:\n",
+    "@you-agent-factory/components package boundary check failed:\n",
   );
 
   for (const violation of violations) {

--- a/ui/packages/components/src/category-paths.ts
+++ b/ui/packages/components/src/category-paths.ts
@@ -1,4 +1,4 @@
-/** Planned deep import paths for `youagentfactory/components` category entrypoints. */
+/** Planned deep import paths for `@you-agent-factory/components` category entrypoints. */
 export const COMPONENT_CATEGORY_EXPORT_PATHS = [
   "primitives",
   "forms",

--- a/ui/packages/components/src/charts/index.ts
+++ b/ui/packages/components/src/charts/index.ts
@@ -1,4 +1,4 @@
-/** Stable category path for `youagentfactory/components/charts`. */
+/** Stable category path for `@you-agent-factory/components/charts`. */
 export const COMPONENTS_CATEGORY = "charts" as const;
 
 export type ComponentsCategory = typeof COMPONENTS_CATEGORY;

--- a/ui/packages/components/src/data-display/index.ts
+++ b/ui/packages/components/src/data-display/index.ts
@@ -1,4 +1,4 @@
-/** Stable category path for `youagentfactory/components/data-display`. */
+/** Stable category path for `@you-agent-factory/components/data-display`. */
 export const COMPONENTS_CATEGORY = "data-display" as const;
 
 export type ComponentsCategory = typeof COMPONENTS_CATEGORY;

--- a/ui/packages/components/src/dependency-policy.test.ts
+++ b/ui/packages/components/src/dependency-policy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-describe("youagentfactory/components dependency policy", () => {
+describe("@you-agent-factory/components dependency policy", () => {
   it("resolves recharts as an installable package dependency", async () => {
     const recharts = await import("recharts");
     expect(recharts.ResponsiveContainer).toBeDefined();

--- a/ui/packages/components/src/feedback/index.ts
+++ b/ui/packages/components/src/feedback/index.ts
@@ -1,4 +1,4 @@
-/** Stable category path for `youagentfactory/components/feedback`. */
+/** Stable category path for `@you-agent-factory/components/feedback`. */
 export const COMPONENTS_CATEGORY = "feedback" as const;
 
 export type ComponentsCategory = typeof COMPONENTS_CATEGORY;

--- a/ui/packages/components/src/forms/index.ts
+++ b/ui/packages/components/src/forms/index.ts
@@ -1,4 +1,4 @@
-/** Stable category path for `youagentfactory/components/forms`. */
+/** Stable category path for `@you-agent-factory/components/forms`. */
 export const COMPONENTS_CATEGORY = "forms" as const;
 
 export type ComponentsCategory = typeof COMPONENTS_CATEGORY;

--- a/ui/packages/components/src/graphs/index.ts
+++ b/ui/packages/components/src/graphs/index.ts
@@ -1,4 +1,4 @@
-/** Stable category path for `youagentfactory/components/graphs`. */
+/** Stable category path for `@you-agent-factory/components/graphs`. */
 export const COMPONENTS_CATEGORY = "graphs" as const;
 
 export type ComponentsCategory = typeof COMPONENTS_CATEGORY;

--- a/ui/packages/components/src/icons/index.ts
+++ b/ui/packages/components/src/icons/index.ts
@@ -1,4 +1,4 @@
-/** Stable category path for `youagentfactory/components/icons`. */
+/** Stable category path for `@you-agent-factory/components/icons`. */
 export const COMPONENTS_CATEGORY = "icons" as const;
 
 export type ComponentsCategory = typeof COMPONENTS_CATEGORY;

--- a/ui/packages/components/src/index.ts
+++ b/ui/packages/components/src/index.ts
@@ -1,5 +1,5 @@
-/** Stable package identifier for `youagentfactory/components` consumers. */
-export const COMPONENTS_PACKAGE_NAME = "youagentfactory/components" as const;
+/** Stable package identifier for `@you-agent-factory/components` consumers. */
+export const COMPONENTS_PACKAGE_NAME = "@you-agent-factory/components" as const;
 
 export type ComponentsPackageName = typeof COMPONENTS_PACKAGE_NAME;
 

--- a/ui/packages/components/src/layout/index.ts
+++ b/ui/packages/components/src/layout/index.ts
@@ -1,4 +1,4 @@
-/** Stable category path for `youagentfactory/components/layout`. */
+/** Stable category path for `@you-agent-factory/components/layout`. */
 export const COMPONENTS_CATEGORY = "layout" as const;
 
 export type ComponentsCategory = typeof COMPONENTS_CATEGORY;

--- a/ui/packages/components/src/navigation/index.ts
+++ b/ui/packages/components/src/navigation/index.ts
@@ -1,4 +1,4 @@
-/** Stable category path for `youagentfactory/components/navigation`. */
+/** Stable category path for `@you-agent-factory/components/navigation`. */
 export const COMPONENTS_CATEGORY = "navigation" as const;
 
 export type ComponentsCategory = typeof COMPONENTS_CATEGORY;

--- a/ui/packages/components/src/overlays/index.ts
+++ b/ui/packages/components/src/overlays/index.ts
@@ -1,4 +1,4 @@
-/** Stable category path for `youagentfactory/components/overlays`. */
+/** Stable category path for `@you-agent-factory/components/overlays`. */
 export const COMPONENTS_CATEGORY = "overlays" as const;
 
 export type ComponentsCategory = typeof COMPONENTS_CATEGORY;

--- a/ui/packages/components/src/package-import-resolution.test.ts
+++ b/ui/packages/components/src/package-import-resolution.test.ts
@@ -5,23 +5,23 @@ import { beforeAll, describe, expect, it } from "vitest";
 import {
   COMPONENT_CATEGORY_EXPORT_PATHS,
   COMPONENTS_PACKAGE_NAME,
-} from "youagentfactory/components";
-import stylesCss from "youagentfactory/components/styles.css?inline";
-import * as charts from "youagentfactory/components/charts";
-import * as dataDisplay from "youagentfactory/components/data-display";
-import * as feedback from "youagentfactory/components/feedback";
-import * as forms from "youagentfactory/components/forms";
-import * as graphs from "youagentfactory/components/graphs";
-import * as icons from "youagentfactory/components/icons";
-import * as layout from "youagentfactory/components/layout";
-import * as navigation from "youagentfactory/components/navigation";
-import * as overlays from "youagentfactory/components/overlays";
-import * as primitives from "youagentfactory/components/primitives";
-import * as recipes from "youagentfactory/components/recipes";
-import * as testing from "youagentfactory/components/testing";
-import * as tokens from "youagentfactory/components/tokens";
-import { cn, COMPONENTS_CATEGORY as utilitiesCategory } from "youagentfactory/components/utilities";
-import * as utilities from "youagentfactory/components/utilities";
+} from "@you-agent-factory/components";
+import stylesCss from "@you-agent-factory/components/styles.css?inline";
+import * as charts from "@you-agent-factory/components/charts";
+import * as dataDisplay from "@you-agent-factory/components/data-display";
+import * as feedback from "@you-agent-factory/components/feedback";
+import * as forms from "@you-agent-factory/components/forms";
+import * as graphs from "@you-agent-factory/components/graphs";
+import * as icons from "@you-agent-factory/components/icons";
+import * as layout from "@you-agent-factory/components/layout";
+import * as navigation from "@you-agent-factory/components/navigation";
+import * as overlays from "@you-agent-factory/components/overlays";
+import * as primitives from "@you-agent-factory/components/primitives";
+import * as recipes from "@you-agent-factory/components/recipes";
+import * as testing from "@you-agent-factory/components/testing";
+import * as tokens from "@you-agent-factory/components/tokens";
+import { cn, COMPONENTS_CATEGORY as utilitiesCategory } from "@you-agent-factory/components/utilities";
+import * as utilities from "@you-agent-factory/components/utilities";
 
 import {
   injectCompiledPackageTokenStyles,
@@ -45,7 +45,7 @@ const categoryModules = {
   tokens,
 } as const;
 
-describe("youagentfactory/components package import resolution", () => {
+describe("@you-agent-factory/components package import resolution", () => {
   let documentRoot: HTMLElement;
 
   beforeAll(async () => {
@@ -53,7 +53,7 @@ describe("youagentfactory/components package import resolution", () => {
   });
 
   it("imports the package root through the configured package path", () => {
-    expect(COMPONENTS_PACKAGE_NAME).toBe("youagentfactory/components");
+    expect(COMPONENTS_PACKAGE_NAME).toBe("@you-agent-factory/components");
   });
 
   it("imports the CSS entrypoint through the configured package path", () => {

--- a/ui/packages/components/src/primitives/index.ts
+++ b/ui/packages/components/src/primitives/index.ts
@@ -1,4 +1,4 @@
-/** Stable category path for `youagentfactory/components/primitives`. */
+/** Stable category path for `@you-agent-factory/components/primitives`. */
 export const COMPONENTS_CATEGORY = "primitives" as const;
 
 export type ComponentsCategory = typeof COMPONENTS_CATEGORY;

--- a/ui/packages/components/src/recipes/index.ts
+++ b/ui/packages/components/src/recipes/index.ts
@@ -1,4 +1,4 @@
-/** Stable category path for `youagentfactory/components/recipes`. */
+/** Stable category path for `@you-agent-factory/components/recipes`. */
 export const COMPONENTS_CATEGORY = "recipes" as const;
 
 export type ComponentsCategory = typeof COMPONENTS_CATEGORY;

--- a/ui/packages/components/src/styles.css
+++ b/ui/packages/components/src/styles.css
@@ -1,5 +1,5 @@
 /*
- * youagentfactory/components package styles entrypoint.
+ * @you-agent-factory/components package styles entrypoint.
  * Shared role, palette, typography, and layout tokens for component consumers.
  */
 

--- a/ui/packages/components/src/styles/package-token-styles-fixture.css
+++ b/ui/packages/components/src/styles/package-token-styles-fixture.css
@@ -4,6 +4,6 @@
  */
 
 @import "tailwindcss";
-@import "youagentfactory/components/styles.css";
+@import "@you-agent-factory/components/styles.css";
 
 @source "./package-token-fixture-usage.ts";

--- a/ui/packages/components/src/styles/token-styles.test.ts
+++ b/ui/packages/components/src/styles/token-styles.test.ts
@@ -7,7 +7,7 @@ import {
   readDocumentCssVariable,
 } from "./compile-package-token-styles";
 
-describe("youagentfactory/components token styles entrypoint", () => {
+describe("@you-agent-factory/components token styles entrypoint", () => {
   let documentRoot: HTMLElement;
 
   beforeAll(async () => {

--- a/ui/packages/components/src/testing/index.ts
+++ b/ui/packages/components/src/testing/index.ts
@@ -1,4 +1,4 @@
-/** Stable category path for `youagentfactory/components/testing`. */
+/** Stable category path for `@you-agent-factory/components/testing`. */
 export const COMPONENTS_CATEGORY = "testing" as const;
 
 export type ComponentsCategory = typeof COMPONENTS_CATEGORY;

--- a/ui/packages/components/src/tokens/index.ts
+++ b/ui/packages/components/src/tokens/index.ts
@@ -1,4 +1,4 @@
-/** Stable category path for `youagentfactory/components/tokens`. */
+/** Stable category path for `@you-agent-factory/components/tokens`. */
 export const COMPONENTS_CATEGORY = "tokens" as const;
 
 export type ComponentsCategory = typeof COMPONENTS_CATEGORY;

--- a/ui/packages/components/src/utilities/index.ts
+++ b/ui/packages/components/src/utilities/index.ts
@@ -1,4 +1,4 @@
-/** Stable category path for `youagentfactory/components/utilities`. */
+/** Stable category path for `@you-agent-factory/components/utilities`. */
 export const COMPONENTS_CATEGORY = "utilities" as const;
 
 export type ComponentsCategory = typeof COMPONENTS_CATEGORY;

--- a/ui/packages/components/src/vite-aliases.ts
+++ b/ui/packages/components/src/vite-aliases.ts
@@ -7,26 +7,26 @@ type ComponentsPackageAlias = {
   replacement: string;
 };
 
-/** Vite/Vitest alias entries for `youagentfactory/components` root, CSS, and deep category paths. */
+/** Vite/Vitest alias entries for `@you-agent-factory/components` root, CSS, and deep category paths. */
 export function createComponentsPackageAliases(
   componentsPackageRoot: string,
 ): ComponentsPackageAlias[] {
   const aliases: ComponentsPackageAlias[] = [
     {
       // Exact root match only; a prefix alias incorrectly captures subpaths such as
-      // `youagentfactory/components/styles.css`.
-      find: /^youagentfactory\/components$/,
+      // `@you-agent-factory/components/styles.css`.
+      find: /^@you-agent-factory\/components$/,
       replacement: path.join(componentsPackageRoot, "index.ts"),
     },
     {
-      find: /^youagentfactory\/components\/styles\.css(\?.*)?$/,
+      find: /^@you-agent-factory\/components\/styles\.css(\?.*)?$/,
       replacement: path.join(componentsPackageRoot, "styles.css"),
     },
   ];
 
   for (const categoryPath of COMPONENT_CATEGORY_EXPORT_PATHS) {
     aliases.push({
-      find: `youagentfactory/components/${categoryPath}`,
+      find: `@you-agent-factory/components/${categoryPath}`,
       replacement: path.join(
         componentsPackageRoot,
         categoryPath,

--- a/ui/packages/components/vitest.config.ts
+++ b/ui/packages/components/vitest.config.ts
@@ -16,20 +16,20 @@ function createComponentsPackageResolvePlugin(
 ): Plugin {
   const categoryAliases = new Map(
     COMPONENT_CATEGORY_EXPORT_PATHS.map((categoryPath) => [
-      `youagentfactory/components/${categoryPath}`,
+      `@you-agent-factory/components/${categoryPath}`,
       path.join(packageRoot, categoryPath, "index.ts"),
     ]),
   );
 
   return {
-    name: "youagentfactory-components-package-resolve",
+    name: "you-agent-factory-components-package-resolve",
     resolveId(source) {
-      if (source === "youagentfactory/components") {
+      if (source === "@you-agent-factory/components") {
         return path.join(packageRoot, "index.ts");
       }
 
       const [specifierPath] = source.split("?", 1);
-      if (specifierPath === "youagentfactory/components/styles.css") {
+      if (specifierPath === "@you-agent-factory/components/styles.css") {
         return path.join(packageRoot, "styles.css");
       }
 
@@ -53,7 +53,7 @@ export default defineConfig({
     include: ["src/**/*.test.ts"],
     server: {
       deps: {
-        inline: [/^youagentfactory\/components/],
+        inline: [/^@you-agent-factory\/components/],
       },
     },
   },

--- a/ui/scripts/verify-fresh-npm-install.mjs
+++ b/ui/scripts/verify-fresh-npm-install.mjs
@@ -1,0 +1,168 @@
+import { execFile } from "node:child_process";
+import {
+  access,
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const defaultUiDir = path.resolve(scriptDir, "..");
+const COMPONENTS_PACKAGE_NAME = "@you-agent-factory/components";
+const COMPONENTS_RELATIVE_PATH = path.join("packages", "components");
+
+async function createIsolatedWorkDir(prefix) {
+  const bases = [
+    os.tmpdir(),
+    "/tmp",
+    path.join(defaultUiDir, "node_modules", ".cache"),
+  ];
+  const seen = new Set();
+
+  for (const base of bases) {
+    const resolvedBase = path.resolve(base);
+    if (seen.has(resolvedBase)) {
+      continue;
+    }
+    seen.add(resolvedBase);
+
+    try {
+      await mkdir(resolvedBase, { recursive: true });
+      return await mkdtemp(path.join(resolvedBase, prefix));
+    } catch (error) {
+      if (error?.code === "ENOENT") {
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  throw new Error(
+    "Could not create a temporary directory for fresh npm install verification.",
+  );
+}
+
+/**
+ * Assert the dashboard npm install graph resolved the scoped local components package.
+ *
+ * @param {string} installRoot
+ * @returns {Promise<{ packageName: string; resolvedPath: string }>}
+ */
+export async function assertScopedComponentsResolved(installRoot) {
+  const installedPackagePath = path.join(
+    installRoot,
+    "node_modules",
+    "@you-agent-factory",
+    "components",
+  );
+  const expectedComponentsPath = path.join(
+    installRoot,
+    COMPONENTS_RELATIVE_PATH,
+  );
+
+  await access(installedPackagePath);
+
+  const [resolvedInstallPath, resolvedComponentsPath] = await Promise.all([
+    realpath(installedPackagePath),
+    realpath(expectedComponentsPath),
+  ]);
+
+  if (resolvedInstallPath !== resolvedComponentsPath) {
+    throw new Error(
+      [
+        `Expected ${COMPONENTS_PACKAGE_NAME} to resolve from ${COMPONENTS_RELATIVE_PATH}.`,
+        `Installed path: ${resolvedInstallPath}`,
+        `Expected path: ${resolvedComponentsPath}`,
+      ].join("\n"),
+    );
+  }
+
+  const manifest = JSON.parse(
+    await readFile(path.join(resolvedComponentsPath, "package.json"), "utf8"),
+  );
+
+  if (manifest.name !== COMPONENTS_PACKAGE_NAME) {
+    throw new Error(
+      `Expected ${COMPONENTS_RELATIVE_PATH}/package.json name ${COMPONENTS_PACKAGE_NAME}, received ${manifest.name ?? "<missing>"}.`,
+    );
+  }
+
+  return {
+    packageName: manifest.name,
+    resolvedPath: resolvedInstallPath,
+  };
+}
+
+/**
+ * Run a fresh npm install for the dashboard dependency graph in an isolated workspace.
+ *
+ * @param {{ uiDir?: string; workDir?: string; npmCommand?: string }} [options]
+ */
+export async function verifyFreshNpmInstall(options = {}) {
+  const uiDir = path.resolve(options.uiDir ?? defaultUiDir);
+  const workDir =
+    options.workDir ?? (await createIsolatedWorkDir("verify-fresh-npm-install-"));
+  const npmCommand = options.npmCommand ?? "npm";
+  const ownsWorkDir = !options.workDir;
+
+  try {
+    await cp(path.join(uiDir, "package.json"), path.join(workDir, "package.json"));
+    await cp(path.join(uiDir, "packages"), path.join(workDir, "packages"), {
+      recursive: true,
+    });
+
+    const packageLockPath = path.join(uiDir, "package-lock.json");
+    try {
+      await access(packageLockPath);
+      await cp(packageLockPath, path.join(workDir, "package-lock.json"));
+    } catch {
+      // Fresh installs without a lockfile still prove manifest resolution.
+    }
+
+    await execFileAsync(npmCommand, ["install"], {
+      cwd: workDir,
+      env: process.env,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+
+    return await assertScopedComponentsResolved(workDir);
+  } finally {
+    if (ownsWorkDir) {
+      await rm(workDir, { force: true, recursive: true });
+    }
+  }
+}
+
+async function main() {
+  const uiDir = process.env.AGENT_FACTORY_UI_DIR
+    ? path.resolve(process.env.AGENT_FACTORY_UI_DIR)
+    : defaultUiDir;
+
+  const result = await verifyFreshNpmInstall({ uiDir });
+
+  console.log(
+    [
+      "Fresh npm install verification passed.",
+      `${COMPONENTS_PACKAGE_NAME} resolved from ${COMPONENTS_RELATIVE_PATH}.`,
+      `Resolved path: ${result.resolvedPath}`,
+    ].join("\n"),
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main().catch((error) => {
+    console.error(
+      error instanceof Error ? error.message : "Fresh npm install verification failed.",
+    );
+    process.exitCode = 1;
+  });
+}

--- a/ui/scripts/verify-fresh-npm-install.test.mjs
+++ b/ui/scripts/verify-fresh-npm-install.test.mjs
@@ -1,0 +1,74 @@
+// @vitest-environment node
+
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  assertScopedComponentsResolved,
+} from "./verify-fresh-npm-install.mjs";
+
+async function createResolvedInstallFixture() {
+  const installRoot = await mkdtemp(
+    path.join(os.tmpdir(), "verify-fresh-npm-install-fixture-"),
+  );
+  const componentsDir = path.join(installRoot, "packages", "components");
+  const scopedDir = path.join(
+    installRoot,
+    "node_modules",
+    "@you-agent-factory",
+  );
+
+  await mkdir(scopedDir, { recursive: true });
+  await mkdir(componentsDir, { recursive: true });
+  await writeFile(
+    path.join(componentsDir, "package.json"),
+    JSON.stringify({ name: "@you-agent-factory/components" }, null, 2),
+  );
+  await symlink(
+    path.join(installRoot, "packages", "components"),
+    path.join(scopedDir, "components"),
+  );
+
+  return installRoot;
+}
+
+describe("assertScopedComponentsResolved", () => {
+  it("accepts a scoped local file dependency resolved to packages/components", async () => {
+    const installRoot = await createResolvedInstallFixture();
+
+    try {
+      const expectedResolvedPath = await realpath(
+        path.join(installRoot, "packages", "components"),
+      );
+
+      await expect(assertScopedComponentsResolved(installRoot)).resolves.toEqual({
+        packageName: "@you-agent-factory/components",
+        resolvedPath: expectedResolvedPath,
+      });
+    } finally {
+      await rm(installRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects installs that point at a different directory", async () => {
+    const installRoot = await createResolvedInstallFixture();
+    const wrongTarget = path.join(installRoot, "packages", "wrong-components");
+
+    try {
+      await mkdir(wrongTarget, { recursive: true });
+      await rm(path.join(installRoot, "node_modules", "@you-agent-factory", "components"));
+      await symlink(
+        wrongTarget,
+        path.join(installRoot, "node_modules", "@you-agent-factory", "components"),
+      );
+
+      await expect(assertScopedComponentsResolved(installRoot)).rejects.toThrow(
+        /Expected @you-agent-factory\/components to resolve from packages\/components/,
+      );
+    } finally {
+      await rm(installRoot, { force: true, recursive: true });
+    }
+  });
+});

--- a/ui/src/lib/cn.ts
+++ b/ui/src/lib/cn.ts
@@ -1,1 +1,1 @@
-export { cn } from "youagentfactory/components/utilities";
+export { cn } from "@you-agent-factory/components/utilities";

--- a/ui/src/lib/components-package-resolution.test.ts
+++ b/ui/src/lib/components-package-resolution.test.ts
@@ -7,9 +7,9 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   COMPONENT_CATEGORY_EXPORT_PATHS,
   COMPONENTS_PACKAGE_NAME,
-} from "youagentfactory/components";
-import stylesCss from "youagentfactory/components/styles.css?inline";
-import * as primitives from "youagentfactory/components/primitives";
+} from "@you-agent-factory/components";
+import stylesCss from "@you-agent-factory/components/styles.css?inline";
+import * as primitives from "@you-agent-factory/components/primitives";
 import { dashboardComponentsPackageName } from "./components-package-resolution";
 import viteConfig from "../../vite.config";
 
@@ -18,7 +18,7 @@ const importerPath = path.join(
   "components-package-resolution.test.ts",
 );
 
-describe("dashboard youagentfactory/components package resolution", () => {
+describe("dashboard @you-agent-factory/components package resolution", () => {
   let viteServer: ViteDevServer;
 
   beforeAll(async () => {
@@ -30,15 +30,15 @@ describe("dashboard youagentfactory/components package resolution", () => {
   });
 
   it("imports the package root through the configured package path", () => {
-    expect(dashboardComponentsPackageName).toBe("youagentfactory/components");
-    expect(COMPONENTS_PACKAGE_NAME).toBe("youagentfactory/components");
+    expect(dashboardComponentsPackageName).toBe("@you-agent-factory/components");
+    expect(COMPONENTS_PACKAGE_NAME).toBe("@you-agent-factory/components");
   });
 
   it("imports the CSS entrypoint through the dashboard Vite resolver", async () => {
     expect(typeof stylesCss).toBe("string");
 
     const resolved = await viteServer.pluginContainer.resolveId(
-      "youagentfactory/components/styles.css",
+      "@you-agent-factory/components/styles.css",
       importerPath,
       { ssr: false },
     );
@@ -52,7 +52,7 @@ describe("dashboard youagentfactory/components package resolution", () => {
 
   it("resolves the CSS entrypoint with Vite resolveId", async () => {
     const resolved = await viteServer.pluginContainer.resolveId(
-      "youagentfactory/components/styles.css",
+      "@you-agent-factory/components/styles.css",
       importerPath,
       { ssr: false },
     );
@@ -62,10 +62,10 @@ describe("dashboard youagentfactory/components package resolution", () => {
   });
 
   it.each(COMPONENT_CATEGORY_EXPORT_PATHS)(
-    "resolves deep import youagentfactory/components/%s with Vite resolveId",
+    "resolves deep import @you-agent-factory/components/%s with Vite resolveId",
     async (categoryPath) => {
       const resolved = await viteServer.pluginContainer.resolveId(
-        `youagentfactory/components/${categoryPath}`,
+        `@you-agent-factory/components/${categoryPath}`,
         importerPath,
         { ssr: false },
       );

--- a/ui/src/lib/components-package-resolution.ts
+++ b/ui/src/lib/components-package-resolution.ts
@@ -1,8 +1,8 @@
 import {
   COMPONENTS_PACKAGE_NAME,
   type ComponentsPackageName,
-} from "youagentfactory/components";
+} from "@you-agent-factory/components";
 
-/** Dashboard anchor proving `youagentfactory/components` resolves through the workspace package path. */
+/** Dashboard anchor proving `@you-agent-factory/components` resolves through the workspace package path. */
 export const dashboardComponentsPackageName: ComponentsPackageName =
   COMPONENTS_PACKAGE_NAME;

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1,5 +1,5 @@
 @import "tailwindcss";
-@import "youagentfactory/components/styles.css";
+@import "@you-agent-factory/components/styles.css";
 @import "./styles/typography-role-utilities.css";
 
 @source "./**/*.{ts,tsx}";

--- a/ui/src/styles/layout-role-tokens.test.ts
+++ b/ui/src/styles/layout-role-tokens.test.ts
@@ -65,7 +65,7 @@ describe("layout-role-tokens (US-007)", () => {
 
   it("imports layout tokens from the component package styles entrypoint", () => {
     expect(stylesSource).toContain(
-      '@import "youagentfactory/components/styles.css";',
+      '@import "@you-agent-factory/components/styles.css";',
     );
   });
 

--- a/ui/src/test-support/compile-dashboard-styles.ts
+++ b/ui/src/test-support/compile-dashboard-styles.ts
@@ -18,7 +18,7 @@ const componentsPackageStylesPath = path.join(
 
 export function createComponentsPackageCssResolver(): Resolver {
   return async (id) => {
-    if (id === "youagentfactory/components/styles.css") {
+    if (id === "@you-agent-factory/components/styles.css") {
       return componentsPackageStylesPath;
     }
     return undefined;

--- a/ui/tsconfig.app.json
+++ b/ui/tsconfig.app.json
@@ -4,8 +4,8 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "baseUrl": ".",
     "paths": {
-      "youagentfactory/components": ["packages/components/src/index.ts"],
-      "youagentfactory/components/*": ["packages/components/src/*"]
+      "@you-agent-factory/components": ["packages/components/src/index.ts"],
+      "@you-agent-factory/components/*": ["packages/components/src/*"]
     },
     "target": "ES2022",
     "useDefineForClassFields": true,


### PR DESCRIPTION
{
  "project": "you-agent-factory components package identity and init workflow",
  "branchName": "you-agent-factory-components-name",
  "description": "Rename the local components library to the npm-addressable scoped package name @you-agent-factory/components, verify that a fresh npm install resolves it, and add a root make init target that installs dependencies for every Bun-managed package in the repository.",
  "context": {
    "customerAsk": "The components library name is breaking because it does not work as an npm-addressable package name. Add the @ to make it @you-agent-factory/components, test that a fresh npm install does not break, and set up a new make init that runs bun install in all appropriate packages.",
    "problem": "The components package currently uses an unscoped slash package name, so package managers cannot treat it as a valid scoped npm package. The dashboard dependency must align with the package's declared name, and repository setup currently requires contributors to know multiple Bun package install locations manually.",
    "solution": "Rename the components package and dashboard local dependency to @you-agent-factory/components, add direct fresh npm install verification for the dashboard dependency graph, and add a root make init target that runs Bun installs for the dashboard and components package directories with clear failure behavior."
  },
  "acceptanceCriteria": [
    "The components package declares the name @you-agent-factory/components.",
    "Dashboard package dependencies reference @you-agent-factory/components for the local file dependency and no runtime code depends on the old package name.",
    "A fresh npm install of the dashboard dependency graph completes without package-name errors and resolves the local scoped components package.",
    "make init installs dependencies for every Bun-managed package in the repository that requires a local install, including the dashboard and components package.",
    "The init workflow fails clearly when a required install step fails instead of silently continuing.",
    "Typecheck, lint, and affected install/test verification commands pass."
  ],
  "userStories": [
    {
      "id": "you-agent-factory-components-name-001",
      "title": "Use a valid scoped components package name",
      "description": "As a dashboard maintainer, I want the components library to use the scoped package name @you-agent-factory/components so package managers and consumers can resolve it as an npm-addressable local package.",
      "acceptanceCriteria": [
        "The components package manifest declares @you-agent-factory/components as its package name.",
        "The dashboard package manifest depends on @you-agent-factory/components through the existing local file dependency path.",
        "Existing imports, package-boundary checks, and generated dependency metadata no longer reference the old youagentfactory/components package name.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "you-agent-factory-components-name-002",
      "title": "Prove fresh npm install resolves the scoped local dependency",
      "description": "As a maintainer validating a clean checkout, I want a fresh npm install to complete successfully so the scoped components package name does not break dependency setup.",
      "acceptanceCriteria": [
        "From a clean dependency state for the dashboard package, npm install completes without package-name or local file dependency resolution errors.",
        "The resulting installed dependency graph includes @you-agent-factory/components resolved from the local packages/components directory.",
        "The install verification is documented or scripted so reviewers can rerun the same fresh-install check.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "you-agent-factory-components-name-003",
      "title": "Add root make init for all Bun package installs",
      "description": "As a contributor setting up the repository, I want make init to run Bun installs in every appropriate package directory so dependency setup is complete from one command.",
      "acceptanceCriteria": [
        "make init runs bun install for the dashboard package directory.",
        "make init runs bun install for the components package directory.",
        "make init executes install steps from the repository root without requiring the caller to change directories manually.",
        "make init stops with a non-zero exit when any package install fails.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)