### PR TITLE
dynamic-workflows-cell-website-event-replay

### DIFF
--- a/ui/src/api/factory-sessions/event-replay.test.ts
+++ b/ui/src/api/factory-sessions/event-replay.test.ts
@@ -3,13 +3,17 @@ import {
   awaitingReplaySessionID,
   buildAwaitingDurableSession,
   buildAwaitingReplayEventStream,
+  buildEmptyReplayEventStream,
   buildSuccessfulDurableSession,
   buildSuccessfulReplayDispatchList,
   buildSuccessfulReplayEventStream,
   buildWarningDurableSession,
   buildWarningReplayDispatchList,
   buildWarningReplayEventStream,
+  emptyReplaySessionID,
+  errorReplaySessionID,
   successfulReplaySessionID,
+  unavailableReplaySessionID,
   warningReplaySessionID,
 } from "../../testing/factory-session-event-replay-fixtures";
 import {
@@ -66,17 +70,9 @@ describe("factory session event replay API", () => {
   });
 
   it("skips non-message SSE blocks and returns an empty event list for sparse history", () => {
-    expect(
-      parseFactoryEventReplayStream(
-        [
-          ": keepalive",
-          "",
-          "event: ping",
-          "data: ignored",
-          "",
-        ].join("\n"),
-      ),
-    ).toEqual([]);
+    expect(parseFactoryEventReplayStream(buildEmptyReplayEventStream())).toEqual(
+      [],
+    );
   });
 
   it("rejects malformed Factory Event payloads", async () => {
@@ -147,6 +143,18 @@ describe("factory session event replay shared fixtures", () => {
       resultSummary: expect.objectContaining({ resultStatus: "NOT_READY" }),
       sessionId: awaitingReplaySessionID,
       status: "AWAITING_APPROVAL",
+    });
+    expect(buildSuccessfulDurableSession(emptyReplaySessionID)).toMatchObject({
+      sessionId: emptyReplaySessionID,
+      status: "SUCCEEDED",
+    });
+    expect(buildWarningDurableSession(errorReplaySessionID)).toMatchObject({
+      sessionId: errorReplaySessionID,
+      status: "FAILED",
+    });
+    expect(buildWarningDurableSession(unavailableReplaySessionID)).toMatchObject({
+      sessionId: unavailableReplaySessionID,
+      status: "FAILED",
     });
     expect(buildSuccessfulReplayDispatchList()).toEqual({
       dispatches: [

--- a/ui/src/features/factory-session-detail/components/event-replay/factory-session-detail-panel.event-replay.states.test.tsx
+++ b/ui/src/features/factory-session-detail/components/event-replay/factory-session-detail-panel.event-replay.states.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildSuccessfulDurableSession,
   buildWarningDurableSession,
+  buildEmptyReplayEventStream,
   successfulReplaySessionID,
   warningReplaySessionID,
 } from "../../../../testing/factory-session-event-replay-fixtures";
@@ -82,15 +83,12 @@ describe("FactorySessionDetailPanel event replay disclosure loading and empty st
         return jsonResponse(buildSuccessfulDurableSession());
       }
       if (url.endsWith(`/factory-sessions/${successfulReplaySessionID}/events`)) {
-        return new Response(
-          [": keepalive", "", "event: ping", "data: ignored", ""].join("\n"),
-          {
-            headers: {
-              "Content-Type": "text/event-stream",
-            },
-            status: 200,
+        return new Response(buildEmptyReplayEventStream(), {
+          headers: {
+            "Content-Type": "text/event-stream",
           },
-        );
+          status: 200,
+        });
       }
       return new Response("not found", { status: 404 });
     });

--- a/ui/src/features/factory-session-detail/components/event-replay/factory-session-detail-panel.event-replay.stories.tsx
+++ b/ui/src/features/factory-session-detail/components/event-replay/factory-session-detail-panel.event-replay.stories.tsx
@@ -1,0 +1,306 @@
+import { expect, userEvent, within } from "storybook/test";
+
+import {
+  awaitingReplaySessionID,
+  buildAwaitingDurableSession,
+  buildAwaitingReplayEventStream,
+  buildEmptyReplayEventStream,
+  buildSuccessfulDurableSession,
+  buildSuccessfulReplayDispatchList,
+  buildSuccessfulReplayEventStream,
+  buildWarningDurableSession,
+  buildWarningReplayDispatchList,
+  buildWarningReplayEventStream,
+  emptyReplaySessionID,
+  errorReplaySessionID,
+  successfulReplaySessionID,
+  unavailableReplaySessionID,
+  warningReplaySessionID,
+} from "../../../../testing/factory-session-event-replay-fixtures";
+import { FactorySessionDetailPanel } from "../factory-session-detail-panel";
+import { renderFactorySessionDetailPanel } from "../factory-session-detail-panel.stories.shared";
+
+export default {
+  title: "you-agent-factory/Current Selection/Factory Session Detail Panel/Event Replay",
+  component: FactorySessionDetailPanel,
+};
+
+export const DurableReplayDisclosure = {
+  tags: ["test"],
+  parameters: {
+    dashboardApi: {
+      fetchMocks: [
+        {
+          method: "GET",
+          path: `/factory-sessions/${successfulReplaySessionID}`,
+          response: {
+            body: buildSuccessfulDurableSession(),
+          },
+        },
+        {
+          method: "GET",
+          path: `/factory-sessions/${successfulReplaySessionID}/events`,
+          response: {
+            body: buildSuccessfulReplayEventStream(),
+            headers: {
+              "Content-Type": "text/event-stream",
+            },
+          },
+        },
+        {
+          method: "GET",
+          path: `/factory-sessions/${successfulReplaySessionID}/dispatches`,
+          response: {
+            body: buildSuccessfulReplayDispatchList(),
+          },
+        },
+      ],
+      sessionID: successfulReplaySessionID,
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = await canvas.findByRole("button", {
+      name: "Expand Factory Event replay",
+    });
+    await userEvent.click(trigger);
+    await canvas.findByText("Showing 5 Factory Events.");
+    expect(canvas.getByText("Session completed")).toBeTruthy();
+    expect(canvas.getByText("Dispatch status completed")).toBeTruthy();
+
+    const timeline = canvas
+      .getAllByRole("list")
+      .find((element) => element.tagName === "OL");
+    expect(timeline).toBeTruthy();
+    const timelineItems = within(timeline!).getAllByRole("listitem");
+    expect(timelineItems).toHaveLength(5);
+    expect(within(timelineItems[0]!).getByText("Session started")).toBeTruthy();
+    expect(
+      within(timelineItems[4]!).getByText("Session event 5 · Tick 5"),
+    ).toBeTruthy();
+  },
+  render: () => renderFactorySessionDetailPanel(successfulReplaySessionID),
+};
+
+export const DurableReplayDisclosureAwaitingApproval = {
+  tags: ["test"],
+  parameters: {
+    dashboardApi: {
+      fetchMocks: [
+        {
+          method: "GET",
+          path: `/factory-sessions/${awaitingReplaySessionID}`,
+          response: {
+            body: buildAwaitingDurableSession(),
+          },
+        },
+        {
+          method: "GET",
+          path: `/factory-sessions/${awaitingReplaySessionID}/events`,
+          response: {
+            body: buildAwaitingReplayEventStream(),
+            headers: {
+              "Content-Type": "text/event-stream",
+            },
+          },
+        },
+      ],
+      sessionID: awaitingReplaySessionID,
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const user = userEvent.setup();
+
+    const trigger = await canvas.findByRole("button", {
+      name: "Expand Factory Event replay",
+    });
+    await user.click(trigger);
+    await expect(canvas.findByText("Showing 2 Factory Events.")).resolves.toBeTruthy();
+    await expect(canvas.getByText("Session result updated")).toBeTruthy();
+  },
+  render: () => renderFactorySessionDetailPanel(awaitingReplaySessionID),
+};
+
+export const DurableReplayDisclosureWarning = {
+  tags: ["test"],
+  parameters: {
+    dashboardApi: {
+      fetchMocks: [
+        {
+          method: "GET",
+          path: `/factory-sessions/${warningReplaySessionID}`,
+          response: {
+            body: buildWarningDurableSession(),
+          },
+        },
+        {
+          method: "GET",
+          path: `/factory-sessions/${warningReplaySessionID}/events`,
+          response: {
+            body: buildWarningReplayEventStream(),
+            headers: {
+              "Content-Type": "text/event-stream",
+            },
+          },
+        },
+        {
+          method: "GET",
+          path: `/factory-sessions/${warningReplaySessionID}/dispatches`,
+          response: {
+            body: buildWarningReplayDispatchList(),
+          },
+        },
+      ],
+      sessionID: warningReplaySessionID,
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = await canvas.findByRole("button", {
+      name: "Expand Factory Event replay",
+    });
+    await userEvent.click(trigger);
+    await canvas.findByText("Checkpoint recorded");
+    expect(canvas.getByText("Provider session timed out · Retry planned")).toBeTruthy();
+    expect(canvas.getByText("Release verification failed.")).toBeTruthy();
+  },
+  render: () => renderFactorySessionDetailPanel(warningReplaySessionID),
+};
+
+export const DurableReplayDisclosureEmpty = {
+  tags: ["test"],
+  parameters: {
+    dashboardApi: {
+      fetchMocks: [
+        {
+          method: "GET",
+          path: `/factory-sessions/${emptyReplaySessionID}`,
+          response: {
+            body: buildSuccessfulDurableSession(emptyReplaySessionID),
+          },
+        },
+        {
+          method: "GET",
+          path: `/factory-sessions/${emptyReplaySessionID}/events`,
+          response: {
+            body: buildEmptyReplayEventStream(),
+            headers: {
+              "Content-Type": "text/event-stream",
+            },
+          },
+        },
+      ],
+      sessionID: emptyReplaySessionID,
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = await canvas.findByRole("button", {
+      name: "Expand Factory Event replay",
+    });
+    await userEvent.click(trigger);
+    await canvas.findByText(
+      "No durable Factory Events are available for this session.",
+    );
+    expect(
+      canvas
+        .queryAllByRole("list")
+        .some((element) => element.tagName === "OL"),
+    ).toBe(false);
+  },
+  render: () => renderFactorySessionDetailPanel(emptyReplaySessionID),
+};
+
+export const DurableReplayDisclosureUnavailable = {
+  tags: ["test"],
+  parameters: {
+    dashboardApi: {
+      fetchMocks: [
+        {
+          method: "GET",
+          path: `/factory-sessions/${unavailableReplaySessionID}`,
+          response: {
+            body: buildWarningDurableSession(unavailableReplaySessionID),
+          },
+        },
+        {
+          method: "GET",
+          path: `/factory-sessions/${unavailableReplaySessionID}/events`,
+          response: {
+            status: 404,
+          },
+        },
+        {
+          method: "GET",
+          path: `/factory-sessions/${unavailableReplaySessionID}/dispatches`,
+          response: {
+            body: {
+              dispatches: [],
+              sessionId: unavailableReplaySessionID,
+            },
+          },
+        },
+      ],
+      sessionID: unavailableReplaySessionID,
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = await canvas.findByRole("button", {
+      name: "Expand Factory Event replay",
+    });
+    await userEvent.click(trigger);
+    await canvas.findByText(
+      "Durable Factory Event replay is unavailable for this session.",
+    );
+    expect(canvas.getByText("Partial result ref")).toBeTruthy();
+  },
+  render: () => renderFactorySessionDetailPanel(unavailableReplaySessionID),
+};
+
+export const DurableReplayDisclosureError = {
+  tags: ["test"],
+  parameters: {
+    dashboardApi: {
+      fetchMocks: [
+        {
+          method: "GET",
+          path: `/factory-sessions/${errorReplaySessionID}`,
+          response: {
+            body: buildWarningDurableSession(errorReplaySessionID),
+          },
+        },
+        {
+          method: "GET",
+          path: `/factory-sessions/${errorReplaySessionID}/events`,
+          response: {
+            body: {
+              code: "INTERNAL_ERROR",
+              message: "replay boom",
+            },
+            status: 500,
+          },
+        },
+        {
+          method: "GET",
+          path: `/factory-sessions/${errorReplaySessionID}/dispatches`,
+          response: {
+            body: buildWarningReplayDispatchList(errorReplaySessionID),
+          },
+        },
+      ],
+      sessionID: errorReplaySessionID,
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = await canvas.findByRole("button", {
+      name: "Expand Factory Event replay",
+    });
+    await userEvent.click(trigger);
+    await canvas.findByText("replay boom");
+    expect(canvas.getByText("Artifacts")).toBeTruthy();
+  },
+  render: () => renderFactorySessionDetailPanel(errorReplaySessionID),
+};

--- a/ui/src/features/factory-session-detail/components/event-replay/factory-session-detail-panel.event-replay.stories.tsx
+++ b/ui/src/features/factory-session-detail/components/event-replay/factory-session-detail-panel.event-replay.stories.tsx
@@ -71,13 +71,18 @@ export const DurableReplayDisclosure = {
     const timeline = canvas
       .getAllByRole("list")
       .find((element) => element.tagName === "OL");
-    expect(timeline).toBeTruthy();
-    const timelineItems = within(timeline!).getAllByRole("listitem");
+    if (!timeline) {
+      throw new Error("Expected replay timeline <ol> to be present.");
+    }
+    const timelineItems = within(timeline).getAllByRole("listitem");
     expect(timelineItems).toHaveLength(5);
-    expect(within(timelineItems[0]!).getByText("Session started")).toBeTruthy();
-    expect(
-      within(timelineItems[4]!).getByText("Session event 5 · Tick 5"),
-    ).toBeTruthy();
+    const firstItem = timelineItems[0];
+    const lastItem = timelineItems[4];
+    if (!firstItem || !lastItem) {
+      throw new Error("Expected replay timeline to include five list items.");
+    }
+    expect(within(firstItem).getByText("Session started")).toBeTruthy();
+    expect(within(lastItem).getByText("Session event 5 · Tick 5")).toBeTruthy();
   },
   render: () => renderFactorySessionDetailPanel(successfulReplaySessionID),
 };

--- a/ui/src/features/factory-session-detail/components/factory-session-detail-panel.stories.shared.tsx
+++ b/ui/src/features/factory-session-detail/components/factory-session-detail-panel.stories.shared.tsx
@@ -1,0 +1,22 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { FactorySessionDetailPanel } from "./factory-session-detail-panel";
+
+export function renderFactorySessionDetailPanel(sessionID: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        gcTime: Infinity,
+        retry: false,
+      },
+    },
+  });
+
+  return (
+    <div style={{ maxWidth: "100%", width: "960px" }}>
+      <QueryClientProvider client={queryClient}>
+        <FactorySessionDetailPanel sessionID={sessionID} />
+      </QueryClientProvider>
+    </div>
+  );
+}

--- a/ui/src/testing/factory-session-event-replay-fixtures.ts
+++ b/ui/src/testing/factory-session-event-replay-fixtures.ts
@@ -4,6 +4,8 @@ export const successfulReplaySessionID = "dur-sess-js-success-002";
 export const warningReplaySessionID = "dur-sess-js-warning-003";
 export const awaitingReplaySessionID = "dur-sess-js-awaiting-001";
 export const unavailableReplaySessionID = "dur-sess-js-unavailable-003";
+export const emptyReplaySessionID = "dur-sess-js-empty-004";
+export const errorReplaySessionID = "dur-sess-js-error-005";
 
 export function buildSuccessfulDurableSession(sessionId = successfulReplaySessionID) {
   return {
@@ -284,6 +286,10 @@ export function buildWarningReplayEventStream(
     })}`,
     "",
   ].join("\n");
+}
+
+export function buildEmptyReplayEventStream() {
+  return [": keepalive", "", "event: ping", "data: ignored", ""].join("\n");
 }
 
 export function buildAwaitingReplayEventStream(


### PR DESCRIPTION
{
  "project": "Add Bounded Durable Event Replay Disclosure To The Factory Session Website Detail Surface",
  "branchName": "dynamic-workflows-cell-website-event-replay",
  "description": "Extend the existing Factory Session website detail experience with one bounded durable event replay disclosure for JavaScript-backed sessions so customers can inspect ordered replayable Factory Event history from the current session detail surface, with explicit sparse-data states, shared vocabulary, and focused verification.",
  "context": {
    "customerAsk": "Extend the existing factory-session detail experience with one bounded durable event replay disclosure for JavaScript-backed Factory Sessions so a user can inspect replayable Factory Event history or a bounded event timeline without leaving the current session detail surface.",
    "problem": "The website already shows durable Factory Session summary data, dispatch drilldown, artifact drilldown, and result references, but it still lacks a bounded way to inspect the durable event history that produced those projections. Customers can see current state without being able to reconstruct the ordered session timeline from the website.",
    "solution": "Reuse the shared durable Factory Event read path and the existing Factory Session detail feature family. Add one bounded disclosure inside the current session detail surface that loads, normalizes, and renders ordered durable event history using customer-facing Factory Session, Factory Event, Dispatch, and Factory Artifact vocabulary, while keeping loading, empty, unavailable, error, and success states explicit and adding only minimal shared contract shaping if required."
  },
  "acceptanceCriteria": [
    "A customer can reveal bounded durable Factory Event replay detail from the existing Factory Session detail surface without navigating to a new website route or feature family.",
    "The replay disclosure renders an ordered event timeline for a JavaScript-backed durable Factory Session using shared Factory Event data and customer-facing Factory Session, Dispatch, and Factory Artifact vocabulary.",
    "The replay disclosure shows explicit loading, empty, unavailable, error, and success states so sparse or missing replay data stays understandable.",
    "If the durable event contract needs a small extension, backend, generated types, adapters, and website projections stay aligned and bounded to the replay disclosure need.",
    "Deterministic fixtures and focused tests prove at least one successful session timeline and one empty or failed session timeline without regressing the existing session detail, dispatch drilldown, or artifact drilldown behavior.",
    "Quality gate passes: typecheck, lint, and the narrow relevant tests pass."
  ],
  "userStories": [
    {
      "id": "dynamic-workflows-cell-website-event-replay-001",
      "title": "Reveal bounded replay detail from the existing Factory Session surface",
      "description": "As a customer inspecting a durable JavaScript Factory Session, I want one focused interaction in the existing detail surface to reveal replay history so that I can inspect how the session progressed without leaving the current inspection flow.",
      "acceptanceCriteria": [
        "The existing Factory Session detail surface exposes one bounded replay disclosure interaction for JavaScript-backed durable sessions.",
        "Activating the interaction reveals replay content inline on the existing session detail surface instead of navigating to a separate route, modal, or event explorer.",
        "The replay disclosure remains scoped to durable Factory Event history for the currently selected Factory Session and does not widen into lifecycle controls or live-provider inspection.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using the Browser plugin"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Verified on branch head 8cba7a4 (merged via PR #885): inline ExpandablePanelTrigger disclosure in FactorySessionDetailPanel for durable JavaScript sessions keyed off session.id via isDurableJavaScriptSession."
    },
    {
      "id": "dynamic-workflows-cell-website-event-replay-002",
      "title": "Render a bounded durable Factory Event timeline with shared vocabulary",
      "description": "As a customer reviewing replay history, I want the website to show an ordered durable event timeline so that I can understand the sequence of session activity and related dispatch or artifact context.",
      "acceptanceCriteria": [
        "The replay disclosure renders a bounded ordered list or timeline of durable Factory Events for the selected session.",
        "Each rendered event shows the customer-usable metadata already supported by the backend, such as event kind, ordering or timestamp information, status or severity cues when present, and related session, dispatch, artifact, or result references when available.",
        "Event presentation stays within shared Factory Session, Factory Event, Dispatch, and Factory Artifact vocabulary rather than introducing workflow-run-specific naming.",
        "If the durable event payload exposes a small shaping gap, the fix is made through shared contract or normalization boundaries rather than a website-only synthetic event model.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using the Browser plugin"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Verified on branch head 8cba7a4: bounded ordered timeline via buildFactorySessionEventReplayTimeline (max 12 events), customer-facing event kind/status/reference labels, shared Factory Event adapter path; vitest event-replay suite (13 tests), typecheck, and lint pass."
    },
    {
      "id": "dynamic-workflows-cell-website-event-replay-003",
      "title": "Keep sparse and failed replay states explicit and understandable",
      "description": "As a customer opening replay history for different session outcomes, I want explicit non-success and sparse-data states so that the website explains what replay information is available instead of collapsing into blank space or ambiguous fallback copy.",
      "acceptanceCriteria": [
        "The replay disclosure renders an explicit loading state while durable event history is being read.",
        "When a session has no durable replayable events in scope, the disclosure renders an explicit empty state.",
        "When durable replay is unsupported, unavailable, or omitted for the selected session, the disclosure renders an explicit unavailable state without breaking the rest of the session detail surface.",
        "When the replay read fails, the disclosure renders an explicit error state consistent with existing website inspection patterns.",
        "The non-success states stay inside the existing Factory Session detail surface and do not regress the adjacent dispatch or artifact drilldown panels.",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using the Browser plugin"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Verified on branch head 8cba7a4: explicit loading (DetailCopy), empty (no events), unavailable (404→AlertPanel info), and error (AlertPanel danger with API message) states in FactorySessionEventReplayDisclosure; vitest states suite (4 tests) confirms adjacent dispatch/artifact drilldown unaffected; typecheck, lint, and Storybook panel stories (5 passed) pass."
    },
    {
      "id": "dynamic-workflows-cell-website-event-replay-004",
      "title": "Prove replay disclosure against successful and empty or failed durable timelines",
      "description": "As a maintainer landing website replay inspection, I want deterministic fixtures and focused verification so that the bounded event replay disclosure is reviewable, regression-resistant, and safe to extend later.",
      "acceptanceCriteria": [
        "Deterministic durable fixtures cover at least one successful session timeline and one empty or failed session timeline for the replay disclosure.",
        "Focused adapter, hook, or UI tests prove success, empty, and error or unavailable replay states without regressing the existing session detail, dispatch drilldown, or artifact drilldown behavior.",
        "Browser-sensitive verification covers the replay disclosure interaction and confirms the timeline or disclosure layout remains usable when event history is present.",
        "Deferred follow-up such as lifecycle controls, live-provider-only diagnostics, or a standalone event browser remains out of scope rather than being bundled into this lane.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Verified on branch head: shared fixtures include successful, warning/failed, awaiting, empty (`buildEmptyReplayEventStream`), unavailable, and error session ids; vitest replay suite (13 tests) and Storybook play tests (6 stories in event-replay.stories.tsx) cover success timeline layout (`<ol>`), empty, unavailable, error, warning, and awaiting-approval states without regressing adjacent artifact/dispatch panels."
    }
  ]
}

Made with [Cursor](https://cursor.com)