### PR TITLE
cleanup-test-batch-ideation-resource-color-skip

### DIFF
--- a/pkg/factory/subsystems/history_transitioner_pipeline_test.go
+++ b/pkg/factory/subsystems/history_transitioner_pipeline_test.go
@@ -743,55 +743,31 @@ func newAcceptedReleasesConsumedResourceFixture(workFirst bool) (*testPipeline, 
 	return tp, snapshot, resourceConsumed
 }
 
+func assertReleasedResourcePipelineHistory(t *testing.T, released *interfaces.Token, resourceConsumed interfaces.Token) {
+	t.Helper()
+	if released.ID != resourceConsumed.ID || released.Color.WorkID != resourceConsumed.Color.WorkID {
+		t.Fatalf("released resource token = %#v, want preserved identity from %#v", released, resourceConsumed)
+	}
+	if !released.CreatedAt.Equal(resourceConsumed.CreatedAt) {
+		t.Fatalf("CreatedAt = %v, want %v", released.CreatedAt, resourceConsumed.CreatedAt)
+	}
+	if released.Color.Tags["pool"] != "shared" {
+		t.Fatalf("tag pool = %q, want %q", released.Color.Tags["pool"], "shared")
+	}
+	if released.History.PlaceVisits["agent-slot:available"] != 4 {
+		t.Fatalf("PlaceVisits = %#v, want preserved history", released.History.PlaceVisits)
+	}
+}
+
 func assertAcceptedMixedWorkResourceRelease(t *testing.T, result *interfaces.TickResult, resourceConsumed interfaces.Token) {
 	t.Helper()
 	if result == nil || len(result.Mutations) != 2 {
 		t.Fatalf("expected 2 mutations, got %+v", result)
 	}
-
-	var workMutation *interfaces.MarkingMutation
-	var released *interfaces.MarkingMutation
-	for i := range result.Mutations {
-		if result.Mutations[i].NewToken == nil {
-			continue
-		}
-		switch result.Mutations[i].NewToken.Color.DataType {
-		case interfaces.DataTypeWork:
-			workMutation = &result.Mutations[i]
-		case interfaces.DataTypeResource:
-			released = &result.Mutations[i]
-		}
-	}
-	if workMutation == nil {
-		t.Fatal("expected work output mutation")
-	}
-	if workMutation.ToPlace != "story:complete" {
-		t.Fatalf("work ToPlace = %q, want story:complete", workMutation.ToPlace)
-	}
-	if workMutation.NewToken.Color.TraceID != "trace-batch-idea-001" {
-		t.Fatalf("work TraceID = %q, want trace-batch-idea-001", workMutation.NewToken.Color.TraceID)
-	}
-	if released == nil {
-		t.Fatal("expected released resource mutation")
-	}
-	if released.ToPlace != "agent-slot:available" {
-		t.Fatalf("ToPlace = %q, want %q", released.ToPlace, "agent-slot:available")
-	}
-	if released.NewToken.ID != resourceConsumed.ID || released.NewToken.Color.WorkID != resourceConsumed.Color.WorkID {
-		t.Fatalf("released resource token = %#v, want preserved identity from %#v", released.NewToken, resourceConsumed)
-	}
-	if !released.NewToken.CreatedAt.Equal(resourceConsumed.CreatedAt) {
-		t.Fatalf("CreatedAt = %v, want %v", released.NewToken.CreatedAt, resourceConsumed.CreatedAt)
-	}
-	if released.NewToken.Color.Tags["pool"] != "shared" {
-		t.Fatalf("tag pool = %q, want %q", released.NewToken.Color.Tags["pool"], "shared")
-	}
-	if released.NewToken.Color.TraceID != "" {
-		t.Fatalf("released resource TraceID = %q, want empty", released.NewToken.Color.TraceID)
-	}
-	if released.NewToken.History.PlaceVisits["agent-slot:available"] != 4 {
-		t.Fatalf("PlaceVisits = %#v, want preserved history", released.NewToken.History.PlaceVisits)
-	}
+	workMutation, released := findWorkAndResourceMutations(result.Mutations)
+	assertAcceptedMixedWorkOutputMutation(t, workMutation)
+	assertReleasedResourceMutationBasics(t, released, resourceConsumed)
+	assertReleasedResourcePipelineHistory(t, released.NewToken, resourceConsumed)
 }
 
 func TestTransitioner_CalculateMutations_PreservesCreatedAtForSameTypeTransitions(t *testing.T) {

--- a/pkg/factory/subsystems/history_transitioner_pipeline_test.go
+++ b/pkg/factory/subsystems/history_transitioner_pipeline_test.go
@@ -627,6 +627,173 @@ func assertReleasedResourceMutation(t *testing.T, result *interfaces.TickResult,
 	}
 }
 
+func TestHistoryTransitionerPipeline_AcceptedReleasesConsumedResourceTokenIdentityRegardlessOfInputOrder(t *testing.T) {
+	orderings := []struct {
+		name           string
+		consumedTokens []interfaces.Token
+	}{
+		{name: "resource-first"},
+		{name: "work-first"},
+	}
+
+	for _, ordering := range orderings {
+		t.Run(ordering.name, func(t *testing.T) {
+			tp, snapshot, resourceConsumed := newAcceptedReleasesConsumedResourceFixture(ordering.name == "work-first")
+			result, err := tp.Execute(context.Background(), snapshot)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			assertAcceptedMixedWorkResourceRelease(t, result, resourceConsumed)
+		})
+	}
+}
+
+func newAcceptedReleasesConsumedResourceFixture(workFirst bool) (*testPipeline, *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], interfaces.Token) {
+	n := &state.Net{
+		Places: map[string]*petri.Place{
+			"story:in-review":      {ID: "story:in-review", TypeID: "story", State: "in-review"},
+			"story:complete":       {ID: "story:complete", TypeID: "story", State: "complete"},
+			"agent-slot:available": {ID: "agent-slot:available", TypeID: "agent-slot", State: "available"},
+		},
+		Transitions: map[string]*petri.Transition{
+			"t1": {
+				ID:         "t1",
+				Name:       "review-story",
+				WorkerType: "reviewer",
+				InputArcs: []petri.Arc{
+					{ID: "a1", Name: "work", PlaceID: "story:in-review", Direction: petri.ArcInput, Cardinality: petri.ArcCardinality{Mode: petri.CardinalityOne}},
+					{ID: "a2", Name: "resource", PlaceID: "agent-slot:available", Direction: petri.ArcInput, Cardinality: petri.ArcCardinality{Mode: petri.CardinalityOne}},
+				},
+				OutputArcs: []petri.Arc{
+					{ID: "a3", Name: "complete", PlaceID: "story:complete", Direction: petri.ArcOutput},
+					{ID: "a4", Name: "resource", PlaceID: "agent-slot:available", Direction: petri.ArcOutput},
+				},
+			},
+		},
+		WorkTypes: map[string]*state.WorkType{
+			"story": {
+				ID: "story",
+				States: []state.StateDefinition{
+					{Value: "in-review", Category: state.StateCategoryProcessing},
+					{Value: "complete", Category: state.StateCategoryTerminal},
+				},
+			},
+		},
+	}
+	tp := newTestPipeline(n)
+	tp.WriteResult(interfaces.WorkResult{DispatchID: "d-1", TransitionID: "t1", Outcome: interfaces.OutcomeAccepted, Output: "Done. COMPLETE ACCEPTED"})
+
+	now := time.Date(2026, time.April, 7, 14, 0, 0, 0, time.UTC)
+	resourceConsumed := interfaces.Token{
+		ID:        "agent-slot:resource:0",
+		PlaceID:   "agent-slot:available",
+		CreatedAt: now.Add(-3 * time.Hour),
+		EnteredAt: now.Add(-3 * time.Hour),
+		Color: interfaces.TokenColor{
+			WorkID:     "agent-slot:0",
+			WorkTypeID: "agent-slot",
+			DataType:   interfaces.DataTypeResource,
+			Tags:       map[string]string{"pool": "shared"},
+		},
+		History: interfaces.TokenHistory{
+			PlaceVisits: map[string]int{"agent-slot:available": 4},
+		},
+	}
+	workConsumed := interfaces.Token{
+		ID:        "tok-1",
+		PlaceID:   "story:in-review",
+		CreatedAt: now.Add(-time.Hour),
+		EnteredAt: now.Add(-time.Hour),
+		Color: interfaces.TokenColor{
+			WorkID:     "work-story-1",
+			WorkTypeID: "story",
+			DataType:   interfaces.DataTypeWork,
+			TraceID:    "trace-batch-idea-001",
+		},
+		History: interfaces.TokenHistory{
+			TotalVisits:         map[string]int{},
+			ConsecutiveFailures: map[string]int{},
+			PlaceVisits:         map[string]int{},
+		},
+	}
+	consumedTokens := []interfaces.Token{resourceConsumed, workConsumed}
+	if workFirst {
+		consumedTokens = []interfaces.Token{workConsumed, resourceConsumed}
+	}
+
+	snapshot := &interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{
+		Marking: petri.MarkingSnapshot{
+			Tokens: map[string]*interfaces.Token{
+				workConsumed.ID:     &workConsumed,
+				resourceConsumed.ID: &resourceConsumed,
+			},
+			PlaceTokens: map[string][]string{
+				"story:in-review":      {workConsumed.ID},
+				"agent-slot:available": {resourceConsumed.ID},
+			},
+		},
+		Dispatches: map[string]*interfaces.DispatchEntry{
+			"d-1": {
+				DispatchID:     "d-1",
+				TransitionID:   "t1",
+				ConsumedTokens: consumedTokens,
+			},
+		},
+	}
+	return tp, snapshot, resourceConsumed
+}
+
+func assertAcceptedMixedWorkResourceRelease(t *testing.T, result *interfaces.TickResult, resourceConsumed interfaces.Token) {
+	t.Helper()
+	if result == nil || len(result.Mutations) != 2 {
+		t.Fatalf("expected 2 mutations, got %+v", result)
+	}
+
+	var workMutation *interfaces.MarkingMutation
+	var released *interfaces.MarkingMutation
+	for i := range result.Mutations {
+		if result.Mutations[i].NewToken == nil {
+			continue
+		}
+		switch result.Mutations[i].NewToken.Color.DataType {
+		case interfaces.DataTypeWork:
+			workMutation = &result.Mutations[i]
+		case interfaces.DataTypeResource:
+			released = &result.Mutations[i]
+		}
+	}
+	if workMutation == nil {
+		t.Fatal("expected work output mutation")
+	}
+	if workMutation.ToPlace != "story:complete" {
+		t.Fatalf("work ToPlace = %q, want story:complete", workMutation.ToPlace)
+	}
+	if workMutation.NewToken.Color.TraceID != "trace-batch-idea-001" {
+		t.Fatalf("work TraceID = %q, want trace-batch-idea-001", workMutation.NewToken.Color.TraceID)
+	}
+	if released == nil {
+		t.Fatal("expected released resource mutation")
+	}
+	if released.ToPlace != "agent-slot:available" {
+		t.Fatalf("ToPlace = %q, want %q", released.ToPlace, "agent-slot:available")
+	}
+	if released.NewToken.ID != resourceConsumed.ID || released.NewToken.Color.WorkID != resourceConsumed.Color.WorkID {
+		t.Fatalf("released resource token = %#v, want preserved identity from %#v", released.NewToken, resourceConsumed)
+	}
+	if !released.NewToken.CreatedAt.Equal(resourceConsumed.CreatedAt) {
+		t.Fatalf("CreatedAt = %v, want %v", released.NewToken.CreatedAt, resourceConsumed.CreatedAt)
+	}
+	if released.NewToken.Color.Tags["pool"] != "shared" {
+		t.Fatalf("tag pool = %q, want %q", released.NewToken.Color.Tags["pool"], "shared")
+	}
+	if released.NewToken.Color.TraceID != "" {
+		t.Fatalf("released resource TraceID = %q, want empty", released.NewToken.Color.TraceID)
+	}
+	if released.NewToken.History.PlaceVisits["agent-slot:available"] != 4 {
+		t.Fatalf("PlaceVisits = %#v, want preserved history", released.NewToken.History.PlaceVisits)
+	}
+}
+
 func TestTransitioner_CalculateMutations_PreservesCreatedAtForSameTypeTransitions(t *testing.T) {
 	n := buildPipelineNet()
 	transitioner := NewTransitioner(n, nil)

--- a/pkg/factory/subsystems/subsystem_transitioner_mutations_test.go
+++ b/pkg/factory/subsystems/subsystem_transitioner_mutations_test.go
@@ -780,7 +780,16 @@ func TestCalculateMutations_PackagedGoalReviewClassifierPreservesCarriedSummary(
 	}
 }
 
-func TestCalculateMutations_AcceptedMixedWorkResource_ReleasesConsumedResourceRegardlessOfInputOrder(t *testing.T) {
+type acceptedMixedWorkResourceMutationFixture struct {
+	transformer *token_transformer.Transformer
+	resource    interfaces.Token
+	work        interfaces.Token
+	arcs        []petri.Arc
+	result      resolvedWorkResult
+	now         time.Time
+}
+
+func newAcceptedMixedWorkResourceMutationFixture() acceptedMixedWorkResourceMutationFixture {
 	now := time.Date(2026, time.April, 7, 14, 0, 0, 0, time.UTC)
 	createdAt := now.Add(-time.Hour)
 	places := map[string]*petri.Place{
@@ -791,109 +800,120 @@ func TestCalculateMutations_AcceptedMixedWorkResource_ReleasesConsumedResourceRe
 	workTypes := map[string]*state.WorkType{
 		"story": {ID: "story"},
 	}
-	transformer := token_transformer.New(places, workTypes, token_transformer.WithWorkIDGenerator(petri.NewWorkIDGenerator()))
-	resource := interfaces.Token{
-		ID:        "agent-slot:resource:0",
-		PlaceID:   "agent-slot:available",
-		CreatedAt: createdAt,
-		EnteredAt: createdAt,
-		Color: interfaces.TokenColor{
-			WorkID:     "agent-slot:0",
-			WorkTypeID: "agent-slot",
-			DataType:   interfaces.DataTypeResource,
+	return acceptedMixedWorkResourceMutationFixture{
+		transformer: token_transformer.New(places, workTypes, token_transformer.WithWorkIDGenerator(petri.NewWorkIDGenerator())),
+		resource: interfaces.Token{
+			ID:        "agent-slot:resource:0",
+			PlaceID:   "agent-slot:available",
+			CreatedAt: createdAt,
+			EnteredAt: createdAt,
+			Color: interfaces.TokenColor{
+				WorkID:     "agent-slot:0",
+				WorkTypeID: "agent-slot",
+				DataType:   interfaces.DataTypeResource,
+			},
 		},
-	}
-	work := interfaces.Token{
-		ID:        "work-story-1",
-		PlaceID:   "story:in-review",
-		CreatedAt: createdAt,
-		EnteredAt: createdAt,
-		Color: interfaces.TokenColor{
-			WorkID:     "work-story-1",
-			WorkTypeID: "story",
-			DataType:   interfaces.DataTypeWork,
-			TraceID:    "trace-batch-idea-001",
+		work: interfaces.Token{
+			ID:        "work-story-1",
+			PlaceID:   "story:in-review",
+			CreatedAt: createdAt,
+			EnteredAt: createdAt,
+			Color: interfaces.TokenColor{
+				WorkID:     "work-story-1",
+				WorkTypeID: "story",
+				DataType:   interfaces.DataTypeWork,
+				TraceID:    "trace-batch-idea-001",
+			},
+			History: interfaces.TokenHistory{
+				TotalVisits:         map[string]int{},
+				ConsecutiveFailures: map[string]int{},
+				PlaceVisits:         map[string]int{},
+			},
 		},
-		History: interfaces.TokenHistory{
-			TotalVisits:         map[string]int{},
-			ConsecutiveFailures: map[string]int{},
-			PlaceVisits:         map[string]int{},
+		arcs: []petri.Arc{
+			{ID: "work-out", PlaceID: "story:complete"},
+			{ID: "slot-out", PlaceID: "agent-slot:available"},
 		},
+		result: resolvedWorkResult{
+			transitionID: "review-story",
+			outcome:      interfaces.OutcomeAccepted,
+			output:       "Done. COMPLETE ACCEPTED",
+		},
+		now: now,
 	}
-	arcs := []petri.Arc{
-		{ID: "work-out", PlaceID: "story:complete"},
-		{ID: "slot-out", PlaceID: "agent-slot:available"},
-	}
-	result := resolvedWorkResult{
-		transitionID: "review-story",
-		outcome:      interfaces.OutcomeAccepted,
-		output:       "Done. COMPLETE ACCEPTED",
+}
+
+func assertAcceptedMixedWorkResourceMutations(t *testing.T, mutations []interfaces.MarkingMutation, resource interfaces.Token) {
+	t.Helper()
+	if len(mutations) != 2 {
+		t.Fatalf("mutation count = %d, want 2 (work output + resource release)", len(mutations))
 	}
 
+	var workMutation *interfaces.MarkingMutation
+	var resourceMutation *interfaces.MarkingMutation
+	for i := range mutations {
+		if mutations[i].NewToken == nil {
+			continue
+		}
+		switch mutations[i].NewToken.Color.DataType {
+		case interfaces.DataTypeWork:
+			workMutation = &mutations[i]
+		case interfaces.DataTypeResource:
+			resourceMutation = &mutations[i]
+		}
+	}
+	if workMutation == nil {
+		t.Fatal("expected work output mutation")
+	}
+	if workMutation.ToPlace != "story:complete" {
+		t.Fatalf("work ToPlace = %q, want story:complete", workMutation.ToPlace)
+	}
+	if workMutation.NewToken.Color.TraceID != "trace-batch-idea-001" {
+		t.Fatalf("work TraceID = %q, want trace-batch-idea-001", workMutation.NewToken.Color.TraceID)
+	}
+	if resourceMutation == nil {
+		t.Fatal("expected resource release mutation")
+	}
+	if resourceMutation.ToPlace != "agent-slot:available" {
+		t.Fatalf("resource ToPlace = %q, want agent-slot:available", resourceMutation.ToPlace)
+	}
+	if resourceMutation.NewToken.ID != resource.ID {
+		t.Fatalf("released resource ID = %q, want consumed identity %q", resourceMutation.NewToken.ID, resource.ID)
+	}
+	if resourceMutation.NewToken.Color.WorkID != "agent-slot:0" {
+		t.Fatalf("released resource WorkID = %q, want agent-slot:0", resourceMutation.NewToken.Color.WorkID)
+	}
+	if resourceMutation.NewToken.Color.TraceID != "" {
+		t.Fatalf("released resource TraceID = %q, want empty", resourceMutation.NewToken.Color.TraceID)
+	}
+}
+
+func TestCalculateMutations_AcceptedMixedWorkResource_ReleasesConsumedResourceRegardlessOfInputOrder(t *testing.T) {
+	fixture := newAcceptedMixedWorkResourceMutationFixture()
 	orderings := []struct {
 		name     string
 		consumed []interfaces.Token
 	}{
-		{name: "resource-first", consumed: []interfaces.Token{resource, work}},
-		{name: "work-first", consumed: []interfaces.Token{work, resource}},
+		{name: "resource-first", consumed: []interfaces.Token{fixture.resource, fixture.work}},
+		{name: "work-first", consumed: []interfaces.Token{fixture.work, fixture.resource}},
 	}
 
 	for _, ordering := range orderings {
 		t.Run(ordering.name, func(t *testing.T) {
 			mutations, err := calculateMutations(mutationCalculationInput{
 				transition:  &petri.Transition{ID: "review-story"},
-				arcs:        arcs,
+				arcs:        fixture.arcs,
 				consumed:    ordering.consumed,
-				result:      result,
-				now:         now,
-				history:     work.History,
+				result:      fixture.result,
+				now:         fixture.now,
+				history:     fixture.work.History,
 				inputColors: tokenColorsFromTokens(ordering.consumed),
-				transformer: transformer,
+				transformer: fixture.transformer,
 			})
 			if err != nil {
 				t.Fatalf("calculateMutations() error = %v", err)
 			}
-			if len(mutations) != 2 {
-				t.Fatalf("mutation count = %d, want 2 (work output + resource release)", len(mutations))
-			}
-
-			var workMutation *interfaces.MarkingMutation
-			var resourceMutation *interfaces.MarkingMutation
-			for i := range mutations {
-				if mutations[i].NewToken == nil {
-					continue
-				}
-				switch mutations[i].NewToken.Color.DataType {
-				case interfaces.DataTypeWork:
-					workMutation = &mutations[i]
-				case interfaces.DataTypeResource:
-					resourceMutation = &mutations[i]
-				}
-			}
-			if workMutation == nil {
-				t.Fatal("expected work output mutation")
-			}
-			if workMutation.ToPlace != "story:complete" {
-				t.Fatalf("work ToPlace = %q, want story:complete", workMutation.ToPlace)
-			}
-			if workMutation.NewToken.Color.TraceID != "trace-batch-idea-001" {
-				t.Fatalf("work TraceID = %q, want trace-batch-idea-001", workMutation.NewToken.Color.TraceID)
-			}
-			if resourceMutation == nil {
-				t.Fatal("expected resource release mutation")
-			}
-			if resourceMutation.ToPlace != "agent-slot:available" {
-				t.Fatalf("resource ToPlace = %q, want agent-slot:available", resourceMutation.ToPlace)
-			}
-			if resourceMutation.NewToken.ID != resource.ID {
-				t.Fatalf("released resource ID = %q, want consumed identity %q", resourceMutation.NewToken.ID, resource.ID)
-			}
-			if resourceMutation.NewToken.Color.WorkID != "agent-slot:0" {
-				t.Fatalf("released resource WorkID = %q, want agent-slot:0", resourceMutation.NewToken.Color.WorkID)
-			}
-			if resourceMutation.NewToken.Color.TraceID != "" {
-				t.Fatalf("released resource TraceID = %q, want empty", resourceMutation.NewToken.Color.TraceID)
-			}
+			assertAcceptedMixedWorkResourceMutations(t, mutations, fixture.resource)
 		})
 	}
 }

--- a/pkg/factory/subsystems/subsystem_transitioner_mutations_test.go
+++ b/pkg/factory/subsystems/subsystem_transitioner_mutations_test.go
@@ -779,3 +779,121 @@ func TestCalculateMutations_PackagedGoalReviewClassifierPreservesCarriedSummary(
 		t.Fatalf("terminal content = %q, want carried execution summary not classifier label", token.Color.Content[0].Text)
 	}
 }
+
+func TestCalculateMutations_AcceptedMixedWorkResource_ReleasesConsumedResourceRegardlessOfInputOrder(t *testing.T) {
+	now := time.Date(2026, time.April, 7, 14, 0, 0, 0, time.UTC)
+	createdAt := now.Add(-time.Hour)
+	places := map[string]*petri.Place{
+		"story:complete":       {ID: "story:complete", TypeID: "story", State: "complete"},
+		"agent-slot:available": {ID: "agent-slot:available", TypeID: "agent-slot", State: "available"},
+		"story:in-review":      {ID: "story:in-review", TypeID: "story", State: "in-review"},
+	}
+	workTypes := map[string]*state.WorkType{
+		"story": {ID: "story"},
+	}
+	transformer := token_transformer.New(places, workTypes, token_transformer.WithWorkIDGenerator(petri.NewWorkIDGenerator()))
+	resource := interfaces.Token{
+		ID:        "agent-slot:resource:0",
+		PlaceID:   "agent-slot:available",
+		CreatedAt: createdAt,
+		EnteredAt: createdAt,
+		Color: interfaces.TokenColor{
+			WorkID:     "agent-slot:0",
+			WorkTypeID: "agent-slot",
+			DataType:   interfaces.DataTypeResource,
+		},
+	}
+	work := interfaces.Token{
+		ID:        "work-story-1",
+		PlaceID:   "story:in-review",
+		CreatedAt: createdAt,
+		EnteredAt: createdAt,
+		Color: interfaces.TokenColor{
+			WorkID:     "work-story-1",
+			WorkTypeID: "story",
+			DataType:   interfaces.DataTypeWork,
+			TraceID:    "trace-batch-idea-001",
+		},
+		History: interfaces.TokenHistory{
+			TotalVisits:         map[string]int{},
+			ConsecutiveFailures: map[string]int{},
+			PlaceVisits:         map[string]int{},
+		},
+	}
+	arcs := []petri.Arc{
+		{ID: "work-out", PlaceID: "story:complete"},
+		{ID: "slot-out", PlaceID: "agent-slot:available"},
+	}
+	result := resolvedWorkResult{
+		transitionID: "review-story",
+		outcome:      interfaces.OutcomeAccepted,
+		output:       "Done. COMPLETE ACCEPTED",
+	}
+
+	orderings := []struct {
+		name     string
+		consumed []interfaces.Token
+	}{
+		{name: "resource-first", consumed: []interfaces.Token{resource, work}},
+		{name: "work-first", consumed: []interfaces.Token{work, resource}},
+	}
+
+	for _, ordering := range orderings {
+		t.Run(ordering.name, func(t *testing.T) {
+			mutations, err := calculateMutations(mutationCalculationInput{
+				transition:  &petri.Transition{ID: "review-story"},
+				arcs:        arcs,
+				consumed:    ordering.consumed,
+				result:      result,
+				now:         now,
+				history:     work.History,
+				inputColors: tokenColorsFromTokens(ordering.consumed),
+				transformer: transformer,
+			})
+			if err != nil {
+				t.Fatalf("calculateMutations() error = %v", err)
+			}
+			if len(mutations) != 2 {
+				t.Fatalf("mutation count = %d, want 2 (work output + resource release)", len(mutations))
+			}
+
+			var workMutation *interfaces.MarkingMutation
+			var resourceMutation *interfaces.MarkingMutation
+			for i := range mutations {
+				if mutations[i].NewToken == nil {
+					continue
+				}
+				switch mutations[i].NewToken.Color.DataType {
+				case interfaces.DataTypeWork:
+					workMutation = &mutations[i]
+				case interfaces.DataTypeResource:
+					resourceMutation = &mutations[i]
+				}
+			}
+			if workMutation == nil {
+				t.Fatal("expected work output mutation")
+			}
+			if workMutation.ToPlace != "story:complete" {
+				t.Fatalf("work ToPlace = %q, want story:complete", workMutation.ToPlace)
+			}
+			if workMutation.NewToken.Color.TraceID != "trace-batch-idea-001" {
+				t.Fatalf("work TraceID = %q, want trace-batch-idea-001", workMutation.NewToken.Color.TraceID)
+			}
+			if resourceMutation == nil {
+				t.Fatal("expected resource release mutation")
+			}
+			if resourceMutation.ToPlace != "agent-slot:available" {
+				t.Fatalf("resource ToPlace = %q, want agent-slot:available", resourceMutation.ToPlace)
+			}
+			if resourceMutation.NewToken.ID != resource.ID {
+				t.Fatalf("released resource ID = %q, want consumed identity %q", resourceMutation.NewToken.ID, resource.ID)
+			}
+			if resourceMutation.NewToken.Color.WorkID != "agent-slot:0" {
+				t.Fatalf("released resource WorkID = %q, want agent-slot:0", resourceMutation.NewToken.Color.WorkID)
+			}
+			if resourceMutation.NewToken.Color.TraceID != "" {
+				t.Fatalf("released resource TraceID = %q, want empty", resourceMutation.NewToken.Color.TraceID)
+			}
+		})
+	}
+}

--- a/pkg/factory/subsystems/subsystem_transitioner_mutations_test.go
+++ b/pkg/factory/subsystems/subsystem_transitioner_mutations_test.go
@@ -843,12 +843,7 @@ func newAcceptedMixedWorkResourceMutationFixture() acceptedMixedWorkResourceMuta
 	}
 }
 
-func assertAcceptedMixedWorkResourceMutations(t *testing.T, mutations []interfaces.MarkingMutation, resource interfaces.Token) {
-	t.Helper()
-	if len(mutations) != 2 {
-		t.Fatalf("mutation count = %d, want 2 (work output + resource release)", len(mutations))
-	}
-
+func findWorkAndResourceMutations(mutations []interfaces.MarkingMutation) (*interfaces.MarkingMutation, *interfaces.MarkingMutation) {
 	var workMutation *interfaces.MarkingMutation
 	var resourceMutation *interfaces.MarkingMutation
 	for i := range mutations {
@@ -862,6 +857,11 @@ func assertAcceptedMixedWorkResourceMutations(t *testing.T, mutations []interfac
 			resourceMutation = &mutations[i]
 		}
 	}
+	return workMutation, resourceMutation
+}
+
+func assertAcceptedMixedWorkOutputMutation(t *testing.T, workMutation *interfaces.MarkingMutation) {
+	t.Helper()
 	if workMutation == nil {
 		t.Fatal("expected work output mutation")
 	}
@@ -871,6 +871,10 @@ func assertAcceptedMixedWorkResourceMutations(t *testing.T, mutations []interfac
 	if workMutation.NewToken.Color.TraceID != "trace-batch-idea-001" {
 		t.Fatalf("work TraceID = %q, want trace-batch-idea-001", workMutation.NewToken.Color.TraceID)
 	}
+}
+
+func assertReleasedResourceMutationBasics(t *testing.T, resourceMutation *interfaces.MarkingMutation, resource interfaces.Token) {
+	t.Helper()
 	if resourceMutation == nil {
 		t.Fatal("expected resource release mutation")
 	}
@@ -886,6 +890,16 @@ func assertAcceptedMixedWorkResourceMutations(t *testing.T, mutations []interfac
 	if resourceMutation.NewToken.Color.TraceID != "" {
 		t.Fatalf("released resource TraceID = %q, want empty", resourceMutation.NewToken.Color.TraceID)
 	}
+}
+
+func assertAcceptedMixedWorkResourceMutations(t *testing.T, mutations []interfaces.MarkingMutation, resource interfaces.Token) {
+	t.Helper()
+	if len(mutations) != 2 {
+		t.Fatalf("mutation count = %d, want 2 (work output + resource release)", len(mutations))
+	}
+	workMutation, resourceMutation := findWorkAndResourceMutations(mutations)
+	assertAcceptedMixedWorkOutputMutation(t, workMutation)
+	assertReleasedResourceMutationBasics(t, resourceMutation, resource)
 }
 
 func TestCalculateMutations_AcceptedMixedWorkResource_ReleasesConsumedResourceRegardlessOfInputOrder(t *testing.T) {

--- a/pkg/factory/token_transformer/transformer.go
+++ b/pkg/factory/token_transformer/transformer.go
@@ -399,7 +399,9 @@ func (t *Transformer) resolveOutputColor(arcIdx int, arcs []petri.Arc, inputColo
 	}
 
 	if matched := findMatchingInput(inputColors, targetTypeID); matched != nil {
-		return interfaces.CloneTokenColor(*matched), nil
+		color := interfaces.CloneTokenColor(*matched)
+		ensureWorkOutputDataType(&color, targetTypeID, t.workTypes)
+		return color, nil
 	}
 
 	first := firstNonResourceInput(inputColors)
@@ -415,7 +417,7 @@ func (t *Transformer) resolveOutputColor(arcIdx int, arcs []petri.Arc, inputColo
 		parentID = first.WorkID
 	}
 
-	return interfaces.TokenColor{
+	color := interfaces.TokenColor{
 		WorkTypeID:               targetTypeID,
 		WorkID:                   t.nextWorkID(targetTypeID),
 		Name:                     name,
@@ -425,7 +427,18 @@ func (t *Transformer) resolveOutputColor(arcIdx int, arcs []petri.Arc, inputColo
 		PreviousChainingTraceIDs: interfaces.PreviousChainingTraceIDsFromTokenColors(inputColors),
 		TraceID:                  traceID,
 		ParentID:                 parentID,
-	}, nil
+	}
+	ensureWorkOutputDataType(&color, targetTypeID, t.workTypes)
+	return color, nil
+}
+
+func ensureWorkOutputDataType(color *interfaces.TokenColor, targetTypeID string, workTypes map[string]*state.WorkType) {
+	if color == nil || targetTypeID == "" || color.DataType == interfaces.DataTypeResource {
+		return
+	}
+	if _, isWorkType := workTypes[targetTypeID]; isWorkType {
+		color.DataType = interfaces.DataTypeWork
+	}
 }
 
 func (t *Transformer) nextWorkID(workTypeID string) string {

--- a/pkg/factory/token_transformer/transformer.go
+++ b/pkg/factory/token_transformer/transformer.go
@@ -432,6 +432,9 @@ func (t *Transformer) resolveOutputColor(arcIdx int, arcs []petri.Arc, inputColo
 	return color, nil
 }
 
+// ensureWorkOutputDataType marks routed outputs into registered work-type places as
+// Work tokens. Cross-type transitions that clone a consumed Work token can inherit
+// an empty DataType; mixed Work/resource dispatches must still emit Work lineage.
 func ensureWorkOutputDataType(color *interfaces.TokenColor, targetTypeID string, workTypes map[string]*state.WorkType) {
 	if color == nil || targetTypeID == "" || color.DataType == interfaces.DataTypeResource {
 		return

--- a/pkg/factory/token_transformer/transformer_test.go
+++ b/pkg/factory/token_transformer/transformer_test.go
@@ -287,6 +287,9 @@ func TestOutputToken_CrossType_UsesWorkIDGenerator(t *testing.T) {
 	if token.Color.WorkTypeID != "target-type" {
 		t.Errorf("WorkTypeID = %q, want %q", token.Color.WorkTypeID, "target-type")
 	}
+	if token.Color.DataType != interfaces.DataTypeWork {
+		t.Errorf("DataType = %q, want %q", token.Color.DataType, interfaces.DataTypeWork)
+	}
 	if token.Color.ParentID != "work-source-type-1" {
 		t.Errorf("ParentID = %q, want %q", token.Color.ParentID, "work-source-type-1")
 	}
@@ -596,6 +599,191 @@ func TestOutputToken_Resource_DoesNotInventWorkChainingLineage(t *testing.T) {
 	}
 	if token.Color.TraceID != "" {
 		t.Fatalf("TraceID = %q, want empty for resource output", token.Color.TraceID)
+	}
+}
+
+func TestOutputToken_MixedWorkResource_PreservesWorkTraceLineageRegardlessOfInputOrder(t *testing.T) {
+	now := time.Date(2026, time.April, 7, 12, 0, 0, 0, time.UTC)
+	createdAt := now.Add(-time.Hour)
+	transformer := New(
+		map[string]*petri.Place{
+			"story:complete":       {ID: "story:complete", TypeID: "story", State: "complete"},
+			"agent-slot:available": {ID: "agent-slot:available", TypeID: "agent-slot", State: "available"},
+		},
+		map[string]*state.WorkType{
+			"story": {ID: "story"},
+		},
+		WithWorkIDGenerator(petri.NewWorkIDGenerator()),
+	)
+	resource := interfaces.Token{
+		ID:        "agent-slot:resource:0",
+		PlaceID:   "agent-slot:available",
+		CreatedAt: createdAt,
+		EnteredAt: createdAt,
+		Color: interfaces.TokenColor{
+			WorkID:     "agent-slot:0",
+			WorkTypeID: "agent-slot",
+			DataType:   interfaces.DataTypeResource,
+		},
+	}
+	work := interfaces.Token{
+		ID:        "work-story-1",
+		PlaceID:   "story:in-review",
+		CreatedAt: createdAt,
+		EnteredAt: createdAt,
+		Color: interfaces.TokenColor{
+			WorkID:                   "work-story-1",
+			WorkTypeID:               "story",
+			TraceID:                  "trace-batch-idea-001",
+			CurrentChainingTraceID:   "trace-batch-idea-001",
+			PreviousChainingTraceIDs: []string{"trace-batch-idea-001"},
+			ChainingTraceDepth:       3,
+		},
+	}
+	arcs := []petri.Arc{
+		{ID: "work-out", PlaceID: "story:complete", Direction: petri.ArcOutput},
+		{ID: "slot-out", PlaceID: "agent-slot:available", Direction: petri.ArcOutput},
+	}
+	baseHistory := interfaces.TokenHistory{
+		TotalVisits:         map[string]int{},
+		ConsecutiveFailures: map[string]int{},
+		PlaceVisits:         map[string]int{},
+	}
+
+	orderings := []struct {
+		name           string
+		consumed       []interfaces.Token
+		inputColors    []interfaces.TokenColor
+		resourceIndex  int
+	}{
+		{
+			name:          "resource-first",
+			consumed:      []interfaces.Token{resource, work},
+			inputColors:   []interfaces.TokenColor{resource.Color, work.Color},
+			resourceIndex: 0,
+		},
+		{
+			name:          "work-first",
+			consumed:      []interfaces.Token{work, resource},
+			inputColors:   []interfaces.TokenColor{work.Color, resource.Color},
+			resourceIndex: 0,
+		},
+	}
+
+	for _, ordering := range orderings {
+		t.Run(ordering.name, func(t *testing.T) {
+			workToken, err := transformer.OutputToken(OutputTokenInput{
+				ArcIndex:       0,
+				Arcs:           arcs,
+				ConsumedTokens: ordering.consumed,
+				InputColors:    ordering.inputColors,
+				Outcome:        interfaces.OutcomeAccepted,
+				Now:            now,
+				History:        baseHistory,
+			})
+			if err != nil {
+				t.Fatalf("work OutputToken() error = %v", err)
+			}
+			if workToken.Color.DataType != interfaces.DataTypeWork {
+				t.Fatalf("work DataType = %q, want %q", workToken.Color.DataType, interfaces.DataTypeWork)
+			}
+			if workToken.Color.TraceID != "trace-batch-idea-001" {
+				t.Fatalf("work TraceID = %q, want trace-batch-idea-001", workToken.Color.TraceID)
+			}
+			if workToken.Color.CurrentChainingTraceID != "trace-batch-idea-001" {
+				t.Fatalf("work CurrentChainingTraceID = %q, want trace-batch-idea-001", workToken.Color.CurrentChainingTraceID)
+			}
+			if workToken.Color.WorkID != "work-story-1" {
+				t.Fatalf("work WorkID = %q, want work-story-1", workToken.Color.WorkID)
+			}
+
+			resourceToken, err := transformer.OutputToken(OutputTokenInput{
+				ArcIndex:           1,
+				Arcs:               arcs,
+				ConsumedTokens:     ordering.consumed,
+				InputColors:        ordering.inputColors,
+				ResourceTokenIndex: ordering.resourceIndex,
+				Outcome:            interfaces.OutcomeAccepted,
+				Now:                now,
+				History:            baseHistory,
+			})
+			if err != nil {
+				t.Fatalf("resource OutputToken() error = %v", err)
+			}
+			if resourceToken.ID != resource.ID {
+				t.Fatalf("resource ID = %q, want %q", resourceToken.ID, resource.ID)
+			}
+			if resourceToken.Color.DataType != interfaces.DataTypeResource {
+				t.Fatalf("resource DataType = %q, want %q", resourceToken.Color.DataType, interfaces.DataTypeResource)
+			}
+			if resourceToken.Color.WorkID != "agent-slot:0" {
+				t.Fatalf("resource WorkID = %q, want agent-slot:0", resourceToken.Color.WorkID)
+			}
+			if resourceToken.Color.TraceID != "" {
+				t.Fatalf("resource TraceID = %q, want empty", resourceToken.Color.TraceID)
+			}
+			if resourceToken.Color.CurrentChainingTraceID != "" {
+				t.Fatalf("resource CurrentChainingTraceID = %q, want empty", resourceToken.Color.CurrentChainingTraceID)
+			}
+		})
+	}
+}
+
+func TestOutputToken_CrossTypeWithResource_PreservesWorkTraceRegardlessOfInputOrder(t *testing.T) {
+	now := time.Date(2026, time.April, 7, 12, 0, 0, 0, time.UTC)
+	transformer := New(
+		map[string]*petri.Place{
+			"prd:init": {ID: "prd:init", TypeID: "prd", State: "init"},
+		},
+		map[string]*state.WorkType{
+			"idea": {ID: "idea"},
+			"prd":  {ID: "prd"},
+		},
+		WithWorkIDGenerator(petri.NewWorkIDGenerator()),
+	)
+	resource := interfaces.TokenColor{
+		WorkID:     "agent-slot:0",
+		WorkTypeID: "agent-slot",
+		DataType:   interfaces.DataTypeResource,
+	}
+	work := interfaces.TokenColor{
+		WorkID:     "work-idea-1",
+		WorkTypeID: "idea",
+		TraceID:    "trace-batch-idea-002",
+	}
+	orderings := [][]interfaces.TokenColor{
+		{resource, work},
+		{work, resource},
+	}
+
+	for i, inputColors := range orderings {
+		token, err := transformer.OutputToken(OutputTokenInput{
+			ArcIndex:    0,
+			Arcs:        []petri.Arc{{PlaceID: "prd:init", Direction: petri.ArcOutput}},
+			InputColors: inputColors,
+			Outcome:     interfaces.OutcomeAccepted,
+			Now:         now,
+			History: interfaces.TokenHistory{
+				TotalVisits:         map[string]int{},
+				ConsecutiveFailures: map[string]int{},
+				PlaceVisits:         map[string]int{},
+			},
+		})
+		if err != nil {
+			t.Fatalf("ordering %d OutputToken() error = %v", i, err)
+		}
+		if token.Color.DataType != interfaces.DataTypeWork {
+			t.Fatalf("ordering %d DataType = %q, want work", i, token.Color.DataType)
+		}
+		if token.Color.TraceID != "trace-batch-idea-002" {
+			t.Fatalf("ordering %d TraceID = %q, want trace-batch-idea-002", i, token.Color.TraceID)
+		}
+		if token.Color.WorkTypeID != "prd" {
+			t.Fatalf("ordering %d WorkTypeID = %q, want prd", i, token.Color.WorkTypeID)
+		}
+		if token.Color.ParentID != "work-idea-1" {
+			t.Fatalf("ordering %d ParentID = %q, want work-idea-1", i, token.Color.ParentID)
+		}
 	}
 }
 

--- a/pkg/factory/token_transformer/transformer_test.go
+++ b/pkg/factory/token_transformer/transformer_test.go
@@ -828,3 +828,117 @@ func TestReleasedResourceToken_PreservesConsumedTokenIdentity(t *testing.T) {
 		t.Fatalf("PlaceVisits after source mutation = %#v, want detached original", released.History.PlaceVisits)
 	}
 }
+
+func TestOutputToken_MixedWorkResource_ReleasesConsumedResourceIdentityRegardlessOfInputOrder(t *testing.T) {
+	now := time.Date(2026, time.April, 7, 14, 0, 0, 0, time.UTC)
+	createdAt := now.Add(-time.Hour)
+	transformer := New(
+		map[string]*petri.Place{
+			"story:complete":       {ID: "story:complete", TypeID: "story", State: "complete"},
+			"agent-slot:available": {ID: "agent-slot:available", TypeID: "agent-slot", State: "available"},
+		},
+		map[string]*state.WorkType{
+			"story": {ID: "story"},
+		},
+		WithWorkIDGenerator(petri.NewWorkIDGenerator()),
+	)
+	resource := interfaces.Token{
+		ID:        "agent-slot:resource:0",
+		PlaceID:   "agent-slot:available",
+		CreatedAt: createdAt,
+		EnteredAt: createdAt,
+		Color: interfaces.TokenColor{
+			WorkID:     "agent-slot:0",
+			WorkTypeID: "agent-slot",
+			DataType:   interfaces.DataTypeResource,
+		},
+		History: interfaces.TokenHistory{
+			PlaceVisits: map[string]int{"agent-slot:available": 3},
+		},
+	}
+	work := interfaces.Token{
+		ID:        "work-story-1",
+		PlaceID:   "story:in-review",
+		CreatedAt: createdAt,
+		EnteredAt: createdAt,
+		Color: interfaces.TokenColor{
+			WorkID:     "work-story-1",
+			WorkTypeID: "story",
+			DataType:   interfaces.DataTypeWork,
+			TraceID:    "trace-batch-idea-001",
+		},
+		History: interfaces.TokenHistory{
+			TotalVisits:         map[string]int{},
+			ConsecutiveFailures: map[string]int{},
+			PlaceVisits:         map[string]int{},
+		},
+	}
+	arcs := []petri.Arc{
+		{ID: "work-out", PlaceID: "story:complete", Direction: petri.ArcOutput},
+		{ID: "slot-out", PlaceID: "agent-slot:available", Direction: petri.ArcOutput},
+	}
+	baseHistory := interfaces.TokenHistory{
+		TotalVisits:         map[string]int{},
+		ConsecutiveFailures: map[string]int{},
+		PlaceVisits:         map[string]int{},
+	}
+
+	orderings := []struct {
+		name    string
+		consumed []interfaces.Token
+	}{
+		{name: "resource-first", consumed: []interfaces.Token{resource, work}},
+		{name: "work-first", consumed: []interfaces.Token{work, resource}},
+	}
+
+	for _, ordering := range orderings {
+		t.Run(ordering.name, func(t *testing.T) {
+			inputColors := tokenColorsFromTokens(ordering.consumed)
+			resourceToken, err := transformer.OutputToken(OutputTokenInput{
+				ArcIndex:           1,
+				Arcs:               arcs,
+				ConsumedTokens:     ordering.consumed,
+				InputColors:        inputColors,
+				ResourceTokenIndex: 0,
+				Outcome:            interfaces.OutcomeAccepted,
+				Now:                now,
+				History:            baseHistory,
+			})
+			if err != nil {
+				t.Fatalf("resource OutputToken() error = %v", err)
+			}
+			if resourceToken.ID != resource.ID {
+				t.Fatalf("resource ID = %q, want %q", resourceToken.ID, resource.ID)
+			}
+			if resourceToken.PlaceID != "agent-slot:available" {
+				t.Fatalf("resource PlaceID = %q, want agent-slot:available", resourceToken.PlaceID)
+			}
+			if resourceToken.Color.DataType != interfaces.DataTypeResource {
+				t.Fatalf("resource DataType = %q, want %q", resourceToken.Color.DataType, interfaces.DataTypeResource)
+			}
+			if resourceToken.Color.WorkID != "agent-slot:0" {
+				t.Fatalf("resource WorkID = %q, want agent-slot:0", resourceToken.Color.WorkID)
+			}
+			if resourceToken.Color.TraceID != "" || resourceToken.Color.CurrentChainingTraceID != "" {
+				t.Fatalf("resource trace fields = (%q,%q), want empty", resourceToken.Color.TraceID, resourceToken.Color.CurrentChainingTraceID)
+			}
+			if !resourceToken.CreatedAt.Equal(createdAt) {
+				t.Fatalf("resource CreatedAt = %v, want %v", resourceToken.CreatedAt, createdAt)
+			}
+			if !resourceToken.EnteredAt.Equal(now) {
+				t.Fatalf("resource EnteredAt = %v, want %v", resourceToken.EnteredAt, now)
+			}
+			if resourceToken.History.PlaceVisits["agent-slot:available"] != 3 {
+				t.Fatalf("resource PlaceVisits = %#v, want preserved history", resourceToken.History.PlaceVisits)
+			}
+		})
+	}
+}
+
+func tokenColorsFromTokens(tokens []interfaces.Token) []interfaces.TokenColor {
+	colors := make([]interfaces.TokenColor, len(tokens))
+	for i, token := range tokens {
+		colors[i] = token.Color
+	}
+	return colors
+}

--- a/pkg/factory/token_transformer/transformer_test.go
+++ b/pkg/factory/token_transformer/transformer_test.go
@@ -602,129 +602,151 @@ func TestOutputToken_Resource_DoesNotInventWorkChainingLineage(t *testing.T) {
 	}
 }
 
-func TestOutputToken_MixedWorkResource_PreservesWorkTraceLineageRegardlessOfInputOrder(t *testing.T) {
+type mixedWorkResourceOutputFixture struct {
+	transformer *Transformer
+	resource    interfaces.Token
+	work        interfaces.Token
+	arcs        []petri.Arc
+	baseHistory interfaces.TokenHistory
+	now         time.Time
+}
+
+func newMixedWorkResourceTraceLineageFixture() mixedWorkResourceOutputFixture {
 	now := time.Date(2026, time.April, 7, 12, 0, 0, 0, time.UTC)
 	createdAt := now.Add(-time.Hour)
-	transformer := New(
-		map[string]*petri.Place{
-			"story:complete":       {ID: "story:complete", TypeID: "story", State: "complete"},
-			"agent-slot:available": {ID: "agent-slot:available", TypeID: "agent-slot", State: "available"},
+	return mixedWorkResourceOutputFixture{
+		transformer: New(
+			map[string]*petri.Place{
+				"story:complete":       {ID: "story:complete", TypeID: "story", State: "complete"},
+				"agent-slot:available": {ID: "agent-slot:available", TypeID: "agent-slot", State: "available"},
+			},
+			map[string]*state.WorkType{
+				"story": {ID: "story"},
+			},
+			WithWorkIDGenerator(petri.NewWorkIDGenerator()),
+		),
+		resource: interfaces.Token{
+			ID:        "agent-slot:resource:0",
+			PlaceID:   "agent-slot:available",
+			CreatedAt: createdAt,
+			EnteredAt: createdAt,
+			Color: interfaces.TokenColor{
+				WorkID:     "agent-slot:0",
+				WorkTypeID: "agent-slot",
+				DataType:   interfaces.DataTypeResource,
+			},
 		},
-		map[string]*state.WorkType{
-			"story": {ID: "story"},
+		work: interfaces.Token{
+			ID:        "work-story-1",
+			PlaceID:   "story:in-review",
+			CreatedAt: createdAt,
+			EnteredAt: createdAt,
+			Color: interfaces.TokenColor{
+				WorkID:                   "work-story-1",
+				WorkTypeID:               "story",
+				TraceID:                  "trace-batch-idea-001",
+				CurrentChainingTraceID:   "trace-batch-idea-001",
+				PreviousChainingTraceIDs: []string{"trace-batch-idea-001"},
+				ChainingTraceDepth:       3,
+			},
 		},
-		WithWorkIDGenerator(petri.NewWorkIDGenerator()),
-	)
-	resource := interfaces.Token{
-		ID:        "agent-slot:resource:0",
-		PlaceID:   "agent-slot:available",
-		CreatedAt: createdAt,
-		EnteredAt: createdAt,
-		Color: interfaces.TokenColor{
-			WorkID:     "agent-slot:0",
-			WorkTypeID: "agent-slot",
-			DataType:   interfaces.DataTypeResource,
+		arcs: []petri.Arc{
+			{ID: "work-out", PlaceID: "story:complete", Direction: petri.ArcOutput},
+			{ID: "slot-out", PlaceID: "agent-slot:available", Direction: petri.ArcOutput},
 		},
-	}
-	work := interfaces.Token{
-		ID:        "work-story-1",
-		PlaceID:   "story:in-review",
-		CreatedAt: createdAt,
-		EnteredAt: createdAt,
-		Color: interfaces.TokenColor{
-			WorkID:                   "work-story-1",
-			WorkTypeID:               "story",
-			TraceID:                  "trace-batch-idea-001",
-			CurrentChainingTraceID:   "trace-batch-idea-001",
-			PreviousChainingTraceIDs: []string{"trace-batch-idea-001"},
-			ChainingTraceDepth:       3,
+		baseHistory: interfaces.TokenHistory{
+			TotalVisits:         map[string]int{},
+			ConsecutiveFailures: map[string]int{},
+			PlaceVisits:         map[string]int{},
 		},
+		now: now,
 	}
-	arcs := []petri.Arc{
-		{ID: "work-out", PlaceID: "story:complete", Direction: petri.ArcOutput},
-		{ID: "slot-out", PlaceID: "agent-slot:available", Direction: petri.ArcOutput},
-	}
-	baseHistory := interfaces.TokenHistory{
-		TotalVisits:         map[string]int{},
-		ConsecutiveFailures: map[string]int{},
-		PlaceVisits:         map[string]int{},
-	}
+}
 
+func assertMixedWorkOutputPreservesTraceLineage(t *testing.T, workToken *interfaces.Token) {
+	t.Helper()
+	if workToken.Color.DataType != interfaces.DataTypeWork {
+		t.Fatalf("work DataType = %q, want %q", workToken.Color.DataType, interfaces.DataTypeWork)
+	}
+	if workToken.Color.TraceID != "trace-batch-idea-001" {
+		t.Fatalf("work TraceID = %q, want trace-batch-idea-001", workToken.Color.TraceID)
+	}
+	if workToken.Color.CurrentChainingTraceID != "trace-batch-idea-001" {
+		t.Fatalf("work CurrentChainingTraceID = %q, want trace-batch-idea-001", workToken.Color.CurrentChainingTraceID)
+	}
+	if workToken.Color.WorkID != "work-story-1" {
+		t.Fatalf("work WorkID = %q, want work-story-1", workToken.Color.WorkID)
+	}
+}
+
+func assertMixedResourceOutputPreservesIdentity(t *testing.T, resourceToken *interfaces.Token, consumed interfaces.Token) {
+	t.Helper()
+	if resourceToken.ID != consumed.ID {
+		t.Fatalf("resource ID = %q, want %q", resourceToken.ID, consumed.ID)
+	}
+	if resourceToken.Color.DataType != interfaces.DataTypeResource {
+		t.Fatalf("resource DataType = %q, want %q", resourceToken.Color.DataType, interfaces.DataTypeResource)
+	}
+	if resourceToken.Color.WorkID != "agent-slot:0" {
+		t.Fatalf("resource WorkID = %q, want agent-slot:0", resourceToken.Color.WorkID)
+	}
+	if resourceToken.Color.TraceID != "" || resourceToken.Color.CurrentChainingTraceID != "" {
+		t.Fatalf("resource trace fields = (%q,%q), want empty", resourceToken.Color.TraceID, resourceToken.Color.CurrentChainingTraceID)
+	}
+}
+
+func TestOutputToken_MixedWorkResource_PreservesWorkTraceLineageRegardlessOfInputOrder(t *testing.T) {
+	fixture := newMixedWorkResourceTraceLineageFixture()
 	orderings := []struct {
-		name           string
-		consumed       []interfaces.Token
-		inputColors    []interfaces.TokenColor
-		resourceIndex  int
+		name          string
+		consumed      []interfaces.Token
+		inputColors   []interfaces.TokenColor
+		resourceIndex int
 	}{
 		{
 			name:          "resource-first",
-			consumed:      []interfaces.Token{resource, work},
-			inputColors:   []interfaces.TokenColor{resource.Color, work.Color},
+			consumed:      []interfaces.Token{fixture.resource, fixture.work},
+			inputColors:   []interfaces.TokenColor{fixture.resource.Color, fixture.work.Color},
 			resourceIndex: 0,
 		},
 		{
 			name:          "work-first",
-			consumed:      []interfaces.Token{work, resource},
-			inputColors:   []interfaces.TokenColor{work.Color, resource.Color},
+			consumed:      []interfaces.Token{fixture.work, fixture.resource},
+			inputColors:   []interfaces.TokenColor{fixture.work.Color, fixture.resource.Color},
 			resourceIndex: 0,
 		},
 	}
 
 	for _, ordering := range orderings {
 		t.Run(ordering.name, func(t *testing.T) {
-			workToken, err := transformer.OutputToken(OutputTokenInput{
+			workToken, err := fixture.transformer.OutputToken(OutputTokenInput{
 				ArcIndex:       0,
-				Arcs:           arcs,
+				Arcs:           fixture.arcs,
 				ConsumedTokens: ordering.consumed,
 				InputColors:    ordering.inputColors,
 				Outcome:        interfaces.OutcomeAccepted,
-				Now:            now,
-				History:        baseHistory,
+				Now:            fixture.now,
+				History:        fixture.baseHistory,
 			})
 			if err != nil {
 				t.Fatalf("work OutputToken() error = %v", err)
 			}
-			if workToken.Color.DataType != interfaces.DataTypeWork {
-				t.Fatalf("work DataType = %q, want %q", workToken.Color.DataType, interfaces.DataTypeWork)
-			}
-			if workToken.Color.TraceID != "trace-batch-idea-001" {
-				t.Fatalf("work TraceID = %q, want trace-batch-idea-001", workToken.Color.TraceID)
-			}
-			if workToken.Color.CurrentChainingTraceID != "trace-batch-idea-001" {
-				t.Fatalf("work CurrentChainingTraceID = %q, want trace-batch-idea-001", workToken.Color.CurrentChainingTraceID)
-			}
-			if workToken.Color.WorkID != "work-story-1" {
-				t.Fatalf("work WorkID = %q, want work-story-1", workToken.Color.WorkID)
-			}
+			assertMixedWorkOutputPreservesTraceLineage(t, workToken)
 
-			resourceToken, err := transformer.OutputToken(OutputTokenInput{
+			resourceToken, err := fixture.transformer.OutputToken(OutputTokenInput{
 				ArcIndex:           1,
-				Arcs:               arcs,
+				Arcs:               fixture.arcs,
 				ConsumedTokens:     ordering.consumed,
 				InputColors:        ordering.inputColors,
 				ResourceTokenIndex: ordering.resourceIndex,
 				Outcome:            interfaces.OutcomeAccepted,
-				Now:                now,
-				History:            baseHistory,
+				Now:                fixture.now,
+				History:            fixture.baseHistory,
 			})
 			if err != nil {
 				t.Fatalf("resource OutputToken() error = %v", err)
 			}
-			if resourceToken.ID != resource.ID {
-				t.Fatalf("resource ID = %q, want %q", resourceToken.ID, resource.ID)
-			}
-			if resourceToken.Color.DataType != interfaces.DataTypeResource {
-				t.Fatalf("resource DataType = %q, want %q", resourceToken.Color.DataType, interfaces.DataTypeResource)
-			}
-			if resourceToken.Color.WorkID != "agent-slot:0" {
-				t.Fatalf("resource WorkID = %q, want agent-slot:0", resourceToken.Color.WorkID)
-			}
-			if resourceToken.Color.TraceID != "" {
-				t.Fatalf("resource TraceID = %q, want empty", resourceToken.Color.TraceID)
-			}
-			if resourceToken.Color.CurrentChainingTraceID != "" {
-				t.Fatalf("resource CurrentChainingTraceID = %q, want empty", resourceToken.Color.CurrentChainingTraceID)
-			}
+			assertMixedResourceOutputPreservesIdentity(t, resourceToken, fixture.resource)
 		})
 	}
 }
@@ -829,108 +851,107 @@ func TestReleasedResourceToken_PreservesConsumedTokenIdentity(t *testing.T) {
 	}
 }
 
-func TestOutputToken_MixedWorkResource_ReleasesConsumedResourceIdentityRegardlessOfInputOrder(t *testing.T) {
+func newMixedWorkResourceReleaseFixture() mixedWorkResourceOutputFixture {
 	now := time.Date(2026, time.April, 7, 14, 0, 0, 0, time.UTC)
 	createdAt := now.Add(-time.Hour)
-	transformer := New(
-		map[string]*petri.Place{
-			"story:complete":       {ID: "story:complete", TypeID: "story", State: "complete"},
-			"agent-slot:available": {ID: "agent-slot:available", TypeID: "agent-slot", State: "available"},
+	return mixedWorkResourceOutputFixture{
+		transformer: New(
+			map[string]*petri.Place{
+				"story:complete":       {ID: "story:complete", TypeID: "story", State: "complete"},
+				"agent-slot:available": {ID: "agent-slot:available", TypeID: "agent-slot", State: "available"},
+			},
+			map[string]*state.WorkType{
+				"story": {ID: "story"},
+			},
+			WithWorkIDGenerator(petri.NewWorkIDGenerator()),
+		),
+		resource: interfaces.Token{
+			ID:        "agent-slot:resource:0",
+			PlaceID:   "agent-slot:available",
+			CreatedAt: createdAt,
+			EnteredAt: createdAt,
+			Color: interfaces.TokenColor{
+				WorkID:     "agent-slot:0",
+				WorkTypeID: "agent-slot",
+				DataType:   interfaces.DataTypeResource,
+			},
+			History: interfaces.TokenHistory{
+				PlaceVisits: map[string]int{"agent-slot:available": 3},
+			},
 		},
-		map[string]*state.WorkType{
-			"story": {ID: "story"},
+		work: interfaces.Token{
+			ID:        "work-story-1",
+			PlaceID:   "story:in-review",
+			CreatedAt: createdAt,
+			EnteredAt: createdAt,
+			Color: interfaces.TokenColor{
+				WorkID:     "work-story-1",
+				WorkTypeID: "story",
+				DataType:   interfaces.DataTypeWork,
+				TraceID:    "trace-batch-idea-001",
+			},
+			History: interfaces.TokenHistory{
+				TotalVisits:         map[string]int{},
+				ConsecutiveFailures: map[string]int{},
+				PlaceVisits:         map[string]int{},
+			},
 		},
-		WithWorkIDGenerator(petri.NewWorkIDGenerator()),
-	)
-	resource := interfaces.Token{
-		ID:        "agent-slot:resource:0",
-		PlaceID:   "agent-slot:available",
-		CreatedAt: createdAt,
-		EnteredAt: createdAt,
-		Color: interfaces.TokenColor{
-			WorkID:     "agent-slot:0",
-			WorkTypeID: "agent-slot",
-			DataType:   interfaces.DataTypeResource,
+		arcs: []petri.Arc{
+			{ID: "work-out", PlaceID: "story:complete", Direction: petri.ArcOutput},
+			{ID: "slot-out", PlaceID: "agent-slot:available", Direction: petri.ArcOutput},
 		},
-		History: interfaces.TokenHistory{
-			PlaceVisits: map[string]int{"agent-slot:available": 3},
-		},
-	}
-	work := interfaces.Token{
-		ID:        "work-story-1",
-		PlaceID:   "story:in-review",
-		CreatedAt: createdAt,
-		EnteredAt: createdAt,
-		Color: interfaces.TokenColor{
-			WorkID:     "work-story-1",
-			WorkTypeID: "story",
-			DataType:   interfaces.DataTypeWork,
-			TraceID:    "trace-batch-idea-001",
-		},
-		History: interfaces.TokenHistory{
+		baseHistory: interfaces.TokenHistory{
 			TotalVisits:         map[string]int{},
 			ConsecutiveFailures: map[string]int{},
 			PlaceVisits:         map[string]int{},
 		},
+		now: now,
 	}
-	arcs := []petri.Arc{
-		{ID: "work-out", PlaceID: "story:complete", Direction: petri.ArcOutput},
-		{ID: "slot-out", PlaceID: "agent-slot:available", Direction: petri.ArcOutput},
-	}
-	baseHistory := interfaces.TokenHistory{
-		TotalVisits:         map[string]int{},
-		ConsecutiveFailures: map[string]int{},
-		PlaceVisits:         map[string]int{},
-	}
+}
 
+func assertMixedResourceOutputPreservesConsumedHistory(t *testing.T, resourceToken *interfaces.Token, consumed interfaces.Token, now time.Time) {
+	t.Helper()
+	assertMixedResourceOutputPreservesIdentity(t, resourceToken, consumed)
+	if resourceToken.PlaceID != "agent-slot:available" {
+		t.Fatalf("resource PlaceID = %q, want agent-slot:available", resourceToken.PlaceID)
+	}
+	if !resourceToken.CreatedAt.Equal(consumed.CreatedAt) {
+		t.Fatalf("resource CreatedAt = %v, want %v", resourceToken.CreatedAt, consumed.CreatedAt)
+	}
+	if !resourceToken.EnteredAt.Equal(now) {
+		t.Fatalf("resource EnteredAt = %v, want %v", resourceToken.EnteredAt, now)
+	}
+	if resourceToken.History.PlaceVisits["agent-slot:available"] != 3 {
+		t.Fatalf("resource PlaceVisits = %#v, want preserved history", resourceToken.History.PlaceVisits)
+	}
+}
+
+func TestOutputToken_MixedWorkResource_ReleasesConsumedResourceIdentityRegardlessOfInputOrder(t *testing.T) {
+	fixture := newMixedWorkResourceReleaseFixture()
 	orderings := []struct {
-		name    string
+		name     string
 		consumed []interfaces.Token
 	}{
-		{name: "resource-first", consumed: []interfaces.Token{resource, work}},
-		{name: "work-first", consumed: []interfaces.Token{work, resource}},
+		{name: "resource-first", consumed: []interfaces.Token{fixture.resource, fixture.work}},
+		{name: "work-first", consumed: []interfaces.Token{fixture.work, fixture.resource}},
 	}
 
 	for _, ordering := range orderings {
 		t.Run(ordering.name, func(t *testing.T) {
-			inputColors := tokenColorsFromTokens(ordering.consumed)
-			resourceToken, err := transformer.OutputToken(OutputTokenInput{
+			resourceToken, err := fixture.transformer.OutputToken(OutputTokenInput{
 				ArcIndex:           1,
-				Arcs:               arcs,
+				Arcs:               fixture.arcs,
 				ConsumedTokens:     ordering.consumed,
-				InputColors:        inputColors,
+				InputColors:        tokenColorsFromTokens(ordering.consumed),
 				ResourceTokenIndex: 0,
 				Outcome:            interfaces.OutcomeAccepted,
-				Now:                now,
-				History:            baseHistory,
+				Now:                fixture.now,
+				History:            fixture.baseHistory,
 			})
 			if err != nil {
 				t.Fatalf("resource OutputToken() error = %v", err)
 			}
-			if resourceToken.ID != resource.ID {
-				t.Fatalf("resource ID = %q, want %q", resourceToken.ID, resource.ID)
-			}
-			if resourceToken.PlaceID != "agent-slot:available" {
-				t.Fatalf("resource PlaceID = %q, want agent-slot:available", resourceToken.PlaceID)
-			}
-			if resourceToken.Color.DataType != interfaces.DataTypeResource {
-				t.Fatalf("resource DataType = %q, want %q", resourceToken.Color.DataType, interfaces.DataTypeResource)
-			}
-			if resourceToken.Color.WorkID != "agent-slot:0" {
-				t.Fatalf("resource WorkID = %q, want agent-slot:0", resourceToken.Color.WorkID)
-			}
-			if resourceToken.Color.TraceID != "" || resourceToken.Color.CurrentChainingTraceID != "" {
-				t.Fatalf("resource trace fields = (%q,%q), want empty", resourceToken.Color.TraceID, resourceToken.Color.CurrentChainingTraceID)
-			}
-			if !resourceToken.CreatedAt.Equal(createdAt) {
-				t.Fatalf("resource CreatedAt = %v, want %v", resourceToken.CreatedAt, createdAt)
-			}
-			if !resourceToken.EnteredAt.Equal(now) {
-				t.Fatalf("resource EnteredAt = %v, want %v", resourceToken.EnteredAt, now)
-			}
-			if resourceToken.History.PlaceVisits["agent-slot:available"] != 3 {
-				t.Fatalf("resource PlaceVisits = %#v, want preserved history", resourceToken.History.PlaceVisits)
-			}
+			assertMixedResourceOutputPreservesConsumedHistory(t, resourceToken, fixture.resource, fixture.now)
 		})
 	}
 }

--- a/tests/functional/workflow/batch_ideation_pipeline_test.go
+++ b/tests/functional/workflow/batch_ideation_pipeline_test.go
@@ -28,10 +28,10 @@ func seedBatchIdeas(t *testing.T, dir string, count int) []string {
 	return traceIDs
 }
 
-// TestBatchIdeationPipeline_ConcurrencyLimit2 verifies that 3 ideas seeded
-// via seed files independently progress through the full ideation pipeline
-// (idea → prd → story → complete) with resource-based concurrency limits
-// (agent-slot capacity=2) throttling execution without deadlock.
+// TestBatchIdeationPipeline_ConcurrencyLimit2 verifies that three idea Work
+// requests seeded via submit files independently progress through the full
+// ideation pipeline (idea → prd → story → complete) with resource-limited
+// concurrency (agent-slot capacity=2) throttling execution without deadlock.
 //
 // Each idea pipeline requires: planner(1) + executor(1) + reviewer(1) = 3
 // provider calls. Converter is LOGICAL_MOVE — no provider call.
@@ -112,8 +112,8 @@ func TestBatchIdeationPipeline_ConcurrencyLimit2(t *testing.T) {
 }
 
 // TestSerialIdeationPipeline_ConcurrencyLimit1 verifies that with agent-slot
-// capacity of 1, submitting 3 ideas results in fully serialized processing
-// where only one agent runs at a time and all work completes without deadlock.
+// capacity of 1, three idea Work requests are processed serially so only one
+// agent runs at a time and all Work completes without deadlock.
 //
 // Same topology as TestBatchIdeationPipeline_ConcurrencyLimit2 but capacity=1.
 // Total: 3 ideas × 3 provider calls = 9.

--- a/tests/functional/workflow/batch_ideation_pipeline_test.go
+++ b/tests/functional/workflow/batch_ideation_pipeline_test.go
@@ -35,15 +35,8 @@ func seedBatchIdeas(t *testing.T, dir string, count int) []string {
 //
 // Each idea pipeline requires: planner(1) + executor(1) + reviewer(1) = 3
 // provider calls. Converter is LOGICAL_MOVE — no provider call.
-// Total: 3 ideas × 3 calls = 9 provider calls minimum.
-//
-// NOTE: TraceID lineage across work types with resource_usage has a known
-// framework issue where output arc color assignment is non-deterministic
-// (see tasks/ideas-to-review/resource-token-color-corruption.md).
-// This test verifies completion and resource management; US-004 covers
-// TraceID lineage in detail without resource interference.
+// Total: 3 ideas × 3 calls = 9 provider calls.
 func TestBatchIdeationPipeline_ConcurrencyLimit2(t *testing.T) {
-	t.Skip("Flaky test skipped pending framework fix for resource token color assignment issue (see tasks/ideas-to-review/resource-token-color-corruption.md)")
 	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "batch_ideation_pipeline"))
 
 	// Every response contains ALL stop tokens (COMPLETE + ACCEPTED) since
@@ -82,27 +75,34 @@ func TestBatchIdeationPipeline_ConcurrencyLimit2(t *testing.T) {
 		HasNoTokenInPlace("story:init").
 		HasNoTokenInPlace("story:in-review")
 
-	// Each idea lineage (TraceID) is independent and traceable through work
-	// tokens. Due to a known framework issue with resource output arc color
-	// assignment, some tokens may have empty colors — we verify the work tokens
-	// that do carry TraceIDs.
+	// Each completed story Work item preserves one of the seeded trace IDs.
 	foundTraces := make(map[string]bool)
 	for _, tok := range storyCompleteTokens {
-		if tok.Color.DataType == interfaces.DataTypeWork && tok.Color.TraceID != "" {
-			foundTraces[tok.Color.TraceID] = true
+		if tok.Color.DataType != interfaces.DataTypeWork {
+			t.Errorf("story:complete token %s: expected work DataType, got %q", tok.ID, tok.Color.DataType)
+			continue
 		}
+		if tok.Color.TraceID == "" {
+			t.Errorf("story:complete token %s: expected TraceID lineage", tok.ID)
+			continue
+		}
+		if !slices.Contains(traceIDs, tok.Color.TraceID) {
+			t.Errorf("unexpected TraceID %q in story:complete", tok.Color.TraceID)
+			continue
+		}
+		foundTraces[tok.Color.TraceID] = true
 	}
-	// Verify all found traces are from our expected set.
-	for traceID := range foundTraces {
-		if !slices.Contains(traceIDs, traceID) {
-			t.Errorf("unexpected TraceID %q in story:complete", traceID)
+	for _, traceID := range traceIDs {
+		if !foundTraces[traceID] {
+			t.Errorf("expected TraceID %q in story:complete, not found", traceID)
 		}
 	}
 
-	// Provider called at least 9 times: 3 planner + 3 executor + 3 reviewer.
-	if provider.CallCount() < 9 {
-		t.Errorf("expected provider called at least 9 times, got %d", provider.CallCount())
+	// Total provider calls: 3 planner + 3 executor + 3 reviewer = 9.
+	if provider.CallCount() != 9 {
+		t.Errorf("expected exactly 9 provider calls, got %d", provider.CallCount())
 	}
+	assertSerialPipelineProviderCallsUseAgentsMD(t, provider.Calls())
 
 	// Resource tokens returned: 2 tokens in agent-slot:available (capacity=2).
 	resourceTokens := snap.TokensInPlace("agent-slot:available")


### PR DESCRIPTION
{
  "project": "Unskip Batch Ideation Resource-Color Functional Coverage",
  "branchName": "cleanup-test-batch-ideation-resource-color-skip",
  "description": "Stabilize resource-limited concurrent batch ideation so the skipped capacity-2 functional regression can run by default and prove completion, trace lineage, provider work, and resource-token return behavior.",
  "context": {
    "customerAsk": "Fix the resource-token color or trace propagation behavior enough to re-enable TestBatchIdeationPipeline_ConcurrencyLimit2 as a stable short functional regression, preserving the test's observable proof that three seeded ideas complete under agent-slot capacity 2 without deadlock and with resource tokens returned.",
    "problem": "TestBatchIdeationPipeline_ConcurrencyLimit2 is skipped because concurrent resource usage can produce nondeterministic output arc color assignment. The adjacent serial ideation test remains enabled, leaving the concurrent resource-limited batch path without short-suite regression coverage.",
    "solution": "Make mixed Work/resource dispatch completion preserve Work trace lineage deterministically while returning resource tokens correctly, add focused package-level coverage for any shared runtime helper touched, and re-enable or replace the skipped functional test with equivalent non-skipped behavioral assertions."
  },
  "acceptanceCriteria": [
    "The concurrent batch ideation regression is enabled or replaced by an equivalent non-skipped test that proves three seeded ideas complete under agent-slot capacity 2 without deadlock.",
    "Completed story Work tokens preserve expected trace lineage for the three seeded ideas; the regression is not weakened to only count unrelated terminal tokens.",
    "Resource tokens are returned to agent-slot:available at capacity 2 after the concurrent run completes.",
    "The resource-token color or trace-lineage behavior that made the test flaky is covered by the smallest focused package-level test when shared runtime helpers are touched.",
    "The change stays narrow and does not unskip unrelated long tests, migrate stress coverage, or change public terminology away from Factory, Work, Work Request, and resource vocabulary.",
    "Quality gate: typecheck, lint, go test ./tests/functional/workflow -run TestBatchIdeationPipeline_ConcurrencyLimit2 -count=1, and the narrow package tests for any touched runtime helpers pass."
  ],
  "userStories": [
    {
      "id": "cleanup-test-batch-ideation-resource-color-skip-001",
      "title": "Preserve Work lineage through resource-limited dispatch",
      "description": "As a Factory maintainer, I want dispatches that consume both Work and resource tokens to produce output Work with deterministic trace lineage so that concurrent resource-limited runs remain replayable and reviewable.",
      "acceptanceCriteria": [
        "A dispatch that consumes a Work token and an agent-slot resource token emits output Work whose trace identity comes from the Work token, not from the resource token or nondeterministic input ordering.",
        "The same dispatch path keeps resource-token color and identity suitable for returning the resource token to its original resource place.",
        "A focused package-level regression covers the mixed Work/resource token case if runtime token color, trace propagation, or output arc assignment helpers are changed.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "cleanup-test-batch-ideation-resource-color-skip-002",
      "title": "Return resource tokens after concurrent Work completion",
      "description": "As a Factory maintainer, I want concurrent provider dispatches to release resource tokens exactly once after completion so that resource-limited Work can continue without deadlock or capacity leaks.",
      "acceptanceCriteria": [
        "A concurrent resource-limited run returns consumed agent-slot resource tokens to agent-slot:available after provider dispatch completion.",
        "Resource release behavior remains tied to the consumed resource token identity and does not create extra resource tokens or drop capacity.",
        "Focused runtime or projection coverage proves capacity is restored for the mixed Work/resource dispatch case when shared resource-release behavior is touched.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "cleanup-test-batch-ideation-resource-color-skip-003",
      "title": "Re-enable concurrent batch ideation functional regression",
      "description": "As a maintainer running functional workflow tests, I want the concurrent batch ideation regression to run by default so that capacity-2 batch execution remains covered in the short suite.",
      "acceptanceCriteria": [
        "TestBatchIdeationPipeline_ConcurrencyLimit2 is no longer skipped, or it is replaced by an equivalent non-skipped regression covering the same concurrent batch ideation behavior.",
        "The regression seeds three idea Work requests and verifies that three story Work items reach story:complete under agent-slot capacity 2 without intermediate Work left in idea:init, prd:init, story:init, or story:in-review.",
        "The regression verifies each completed story Work item carries one of the seeded trace IDs and that all three seeded trace IDs are represented.",
        "The regression verifies the provider is invoked for the expected planner, executor, and reviewer Work without relying on unrelated terminal-token counts.",
        "The regression verifies exactly two resource tokens are available in agent-slot:available after completion.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "cleanup-test-batch-ideation-resource-color-skip-004",
      "title": "Keep cleanup scope limited to the skipped resource-color case",
      "description": "As a reviewer, I want the cleanup to remove this specific coverage exception without broadening into unrelated skipped tests or stress-suite reshaping so that the change remains reviewable and low risk.",
      "acceptanceCriteria": [
        "The change removes only the batch ideation concurrency coverage exception or its direct replacement and does not unskip unrelated long or stress tests.",
        "Public-facing comments and failure messages use Factory, Work, Work Request, and resource terminology where customer-facing vocabulary is appropriate.",
        "Any internal comments about token colors, traces, or output arcs are limited to explaining the runtime invariant needed for this regression.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)