### PR TITLE
cleanup-test-cross-workflow-race-skip

### DIFF
--- a/tests/stress/cross_workflow_pipeline_test.go
+++ b/tests/stress/cross_workflow_pipeline_test.go
@@ -226,10 +226,13 @@ func TestCrossWorkflowPipelineNoRace(t *testing.T) {
 		}(g)
 	}
 
-	// 3 goroutines query marking concurrently.
+	// 3 goroutines query marking and runtime status concurrently while submissions
+	// and Work processing are still active.
+	codeChangeTerminalPlaces := []string{"code-change:complete", "code-change:failed"}
 	var queryWg sync.WaitGroup
 	queryDone := make(chan struct{})
-	var queryCount atomic.Int64
+	var markingQueryCount atomic.Int64
+	var statusQueryCount atomic.Int64
 	for range 3 {
 		queryWg.Add(1)
 		go func() {
@@ -244,14 +247,26 @@ func TestCrossWorkflowPipelineNoRace(t *testing.T) {
 						_ = tok.PlaceID
 						_ = tok.Color.WorkTypeID
 					}
-					queryCount.Add(1)
+					markingQueryCount.Add(1)
+
+					if stateSnap, err := hA.GetEngineStateSnapshot(); err == nil {
+						_ = stateSnap.RuntimeStatus
+						statusQueryCount.Add(1)
+					}
 				}
 			}
 		}()
 	}
 
 	submitWg.Wait()
-	pollUntilAllTerminalH(t, hA, []string{"code-change:complete", "code-change:failed"}, totalItems, 20*time.Second)
+	pollUntilAllTerminalH(t, hA, codeChangeTerminalPlaces, totalItems, 20*time.Second)
+
+	if markingQueryCount.Load() == 0 {
+		t.Fatal("expected concurrent marking queries before stopping query workers, got 0")
+	}
+	if statusQueryCount.Load() == 0 {
+		t.Fatal("expected concurrent status queries before stopping query workers, got 0")
+	}
 
 	close(queryDone)
 	queryWg.Wait()
@@ -259,12 +274,12 @@ func TestCrossWorkflowPipelineNoRace(t *testing.T) {
 	<-errChA
 
 	snapA := hA.Marking()
-	complete := len(snapA.TokensInPlace("code-change:complete"))
-	if complete != totalItems {
-		t.Errorf("expected %d complete, got %d", totalItems, complete)
-	}
+	assertMarkingConsistency(t, snapA, codeChangeTerminalPlaces, totalItems)
 
-	t.Logf("no-race test: %d items completed, %d queries", complete, queryCount.Load())
+	t.Logf("no-race test: %d terminal tokens, %d marking queries, %d status queries",
+		countTerminalTokens(snapA, codeChangeTerminalPlaces),
+		markingQueryCount.Load(),
+		statusQueryCount.Load())
 }
 
 // --- Helper configs for cross-workflow tests ---

--- a/tests/stress/cross_workflow_pipeline_test.go
+++ b/tests/stress/cross_workflow_pipeline_test.go
@@ -192,7 +192,6 @@ func TestCrossWorkflowPipelineRecursive(t *testing.T) {
 // TestCrossWorkflowPipelineNoRace verifies no data races during cross-workflow
 // submission with concurrent status queries.
 func TestCrossWorkflowPipelineNoRace(t *testing.T) {
-	t.Skip("bad arguments right now")
 	if testing.Short() {
 		t.Skip("skipping stress test in short mode")
 	}
@@ -200,7 +199,10 @@ func TestCrossWorkflowPipelineNoRace(t *testing.T) {
 	// Simple 1-stage code pipeline.
 	dirA := testutil.ScaffoldFactoryDir(t, oneStageCodePipelineCfg("coder"))
 	hA := testutil.NewServiceTestHarness(t, dirA, testutil.WithFullWorkerPoolAndScriptWrap(),
-		testutil.WithExtraOptions(factory.WithWorkerExecutor("coder", &delayExecutor{maxDelay: time.Millisecond})))
+		testutil.WithExtraOptions(
+			factory.WithServiceMode(),
+			factory.WithWorkerExecutor("coder", &delayExecutor{maxDelay: time.Millisecond}),
+		))
 
 	ctxA, cancelA := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelA()

--- a/tests/stress/cross_workflow_pipeline_test.go
+++ b/tests/stress/cross_workflow_pipeline_test.go
@@ -189,14 +189,16 @@ func TestCrossWorkflowPipelineRecursive(t *testing.T) {
 		scanCount.Load(), totalSubmittedToA.Load(), completeA, 5)
 }
 
-// TestCrossWorkflowPipelineNoRace verifies no data races during cross-workflow
-// submission with concurrent status queries.
+// TestCrossWorkflowPipelineNoRace verifies the Factory runtime has no race-sensitive
+// failures when goroutines submit code-change Work Requests concurrently while other
+// goroutines read marking and runtime status. Harness setup uses WithServiceMode so
+// the background runtime stays alive during concurrent submission; no runtime semantic
+// changes were required.
 func TestCrossWorkflowPipelineNoRace(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping stress test in short mode")
 	}
 
-	// Simple 1-stage code pipeline.
 	dirA := testutil.ScaffoldFactoryDir(t, oneStageCodePipelineCfg("coder"))
 	hA := testutil.NewServiceTestHarness(t, dirA, testutil.WithFullWorkerPoolAndScriptWrap(),
 		testutil.WithExtraOptions(
@@ -208,7 +210,7 @@ func TestCrossWorkflowPipelineNoRace(t *testing.T) {
 	defer cancelA()
 	errChA := hA.RunInBackground(ctxA)
 
-	// 5 goroutines submit work items concurrently.
+	// Five goroutines submit code-change Work Requests concurrently.
 	const totalItems = 15
 	var submitWg sync.WaitGroup
 	for g := range 5 {
@@ -262,10 +264,10 @@ func TestCrossWorkflowPipelineNoRace(t *testing.T) {
 	pollUntilAllTerminalH(t, hA, codeChangeTerminalPlaces, totalItems, 20*time.Second)
 
 	if markingQueryCount.Load() == 0 {
-		t.Fatal("expected concurrent marking queries before stopping query workers, got 0")
+		t.Fatal("expected concurrent marking reads before stopping query workers, got 0")
 	}
 	if statusQueryCount.Load() == 0 {
-		t.Fatal("expected concurrent status queries before stopping query workers, got 0")
+		t.Fatal("expected concurrent runtime status reads before stopping query workers, got 0")
 	}
 
 	close(queryDone)
@@ -276,7 +278,7 @@ func TestCrossWorkflowPipelineNoRace(t *testing.T) {
 	snapA := hA.Marking()
 	assertMarkingConsistency(t, snapA, codeChangeTerminalPlaces, totalItems)
 
-	t.Logf("no-race test: %d terminal tokens, %d marking queries, %d status queries",
+	t.Logf("no-race test: %d terminal Work tokens, %d marking reads, %d status reads",
 		countTerminalTokens(snapA, codeChangeTerminalPlaces),
 		markingQueryCount.Load(),
 		statusQueryCount.Load())


### PR DESCRIPTION
{
  "project": "Unskip Cross-Workflow Concurrent Submission Race Coverage",
  "branchName": "cleanup-test-cross-workflow-race-skip",
  "description": "Remove the unconditional skip from TestCrossWorkflowPipelineNoRace and make the stress regression submit valid Work through the current harness/API while proving concurrent submissions and marking/status queries complete without race-sensitive failures.",
  "context": {
    "customerAsk": "Fix the test setup, submit arguments, or helper usage so the concurrent cross-workflow submission and marking-query race test can run as a meaningful long/stress regression without the unconditional bad-arguments skip.",
    "problem": "TestCrossWorkflowPipelineNoRace is currently skipped with the note 'bad arguments right now'. The surrounding stress file covers cross-workflow fan-out and recursive submission, but the concurrent submit/query race case is disabled because its arguments or helper usage no longer match the current harness/API shape.",
    "solution": "Update the stress test to submit valid code-change Work through the supported harness/API, keep concurrent marking/status queries active while submissions and runtime processing occur, assert terminal completion for all submitted Work, and keep the cleanup narrowly scoped to this regression."
  },
  "acceptanceCriteria": [
    "TestCrossWorkflowPipelineNoRace no longer has the unconditional bad arguments right now skip or an equivalent unconditional bypass.",
    "The enabled test submits valid code-change Work requests through the current harness/API shape and all expected submitted items reach code-change:complete or code-change:failed.",
    "Marking/status queries run concurrently with Work submissions and runtime processing, and the test verifies query activity occurred before completion.",
    "The test remains stress-scoped and continues to skip only under testing.Short() if it is too slow for the default short suite.",
    "The change stays narrow: it does not broaden into unrelated stress skips, resource-exhaustion migration work, scheduler rewrites, or runtime semantic changes unless the test exposes a real focused bug.",
    "Quality gate: typecheck, lint, go test ./tests/stress -run TestCrossWorkflowPipelineNoRace -count=1 outside short mode, and any narrower package test needed for touched helpers pass."
  ],
  "userStories": [
    {
      "id": "cleanup-test-cross-workflow-race-skip-001",
      "title": "Submit valid Work through the current stress harness",
      "description": "As a Factory maintainer, I want the no-race stress test to submit valid code-change Work through the supported harness/API so that the test setup exercises real runtime behavior instead of failing before concurrency is tested.",
      "acceptanceCriteria": [
        "The unconditional bad arguments right now skip is removed from TestCrossWorkflowPipelineNoRace.",
        "The test submits the intended total number of code-change Work requests using the current harness/API shape without argument validation failures.",
        "Each submitted Work request has a unique trace ID and payload that the one-stage code pipeline accepts.",
        "The test remains skipped in testing.Short() mode if its runtime cost belongs in the stress suite.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "cleanup-test-cross-workflow-race-skip-002",
      "title": "Prove concurrent submissions and marking queries complete safely",
      "description": "As a Factory maintainer, I want submissions and marking queries to run concurrently while the runtime processes Work so that the stress test protects against race-sensitive failures in the cross-workflow execution path.",
      "acceptanceCriteria": [
        "Multiple submit goroutines add Work concurrently while the Factory runtime is running in the background.",
        "Multiple query goroutines call the current marking/status read path while submissions and Work processing are still active.",
        "The test asserts that marking/status queries occurred before query workers are stopped.",
        "The test waits for the expected number of submitted Work items to reach terminal state and reports a failure when terminal completion is short.",
        "Background runtime shutdown is explicit and does not leave the test blocked on goroutines or channels.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "cleanup-test-cross-workflow-race-skip-003",
      "title": "Keep any exposed runtime fix narrowly focused",
      "description": "As a reviewer, I want any implementation fix exposed by the re-enabled test to be the smallest behavior-preserving correction so that the cleanup does not become a scheduler or runtime redesign.",
      "acceptanceCriteria": [
        "If the enabled test exposes a real runtime or harness bug, the fix preserves existing scheduler and runtime semantics except for the failing concurrent submit/query behavior.",
        "Any touched helper has the smallest focused package-level test needed to prove the corrected behavior.",
        "No unrelated stress skips are removed, migrated, or rewritten as part of this work.",
        "Comments and failure messages use Factory, Work, Work Request, marking, and status terminology where public or maintainer-facing wording is appropriate.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "cleanup-test-cross-workflow-race-skip-004",
      "title": "Verify the stress regression directly",
      "description": "As a maintainer running regression verification, I want a focused stress command to prove this exact race coverage is active so that the cleanup can be reviewed without relying on broad suite execution.",
      "acceptanceCriteria": [
        "go test ./tests/stress -run TestCrossWorkflowPipelineNoRace -count=1 is run outside short mode and passes.",
        "Any narrower package test for touched harness or runtime helpers is run and passes.",
        "The final implementation evidence names the focused commands used for this regression.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)