### PR TITLE
cleanup-stress-poison-token-panic-skip

### DIFF
--- a/pkg/factory/runtime/dispatch_result_hook.go
+++ b/pkg/factory/runtime/dispatch_result_hook.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/portpowered/infinite-you/pkg/factory"
 	"github.com/portpowered/infinite-you/pkg/factory/state"
@@ -204,10 +205,11 @@ func executeDispatchSynchronously(
 			result interfaces.WorkResult
 			err    error
 		)
+		start := time.Now()
 		func() {
 			defer func() {
 				if recovered := recover(); recovered != nil {
-					result = workers.PanicAsFailedResult(dispatch, recovered, 0)
+					result = workers.PanicAsFailedResult(dispatch, recovered, time.Since(start))
 					err = nil
 				}
 			}()

--- a/pkg/factory/runtime/dispatch_result_hook_test.go
+++ b/pkg/factory/runtime/dispatch_result_hook_test.go
@@ -14,6 +14,14 @@ import (
 	"github.com/portpowered/infinite-you/pkg/workers"
 )
 
+type panicExecutor struct {
+	message string
+}
+
+func (e *panicExecutor) Execute(_ context.Context, _ interfaces.WorkDispatch) (interfaces.WorkResult, error) {
+	panic(e.message)
+}
+
 type recordingExecutor struct {
 	calls []interfaces.WorkDispatch
 }
@@ -83,6 +91,28 @@ func (p plannedCompletionPlanner) PlannedResultForDispatch(dispatch interfaces.W
 	result.DispatchID = dispatch.DispatchID
 	result.TransitionID = dispatch.TransitionID
 	return result, true, nil
+}
+
+func TestExecuteDispatchSynchronously_ExecutorPanicReturnsFailedResult(t *testing.T) {
+	dispatch := interfaces.WorkDispatch{
+		DispatchID:   "dispatch-panic",
+		TransitionID: "t-process",
+	}
+	executors := map[string]workers.WorkerExecutor{
+		"mock": &panicExecutor{message: "simulated executor panic"},
+	}
+
+	result := executeDispatchSynchronously(context.Background(), dispatch, "mock", executors)
+
+	if result.DispatchID != dispatch.DispatchID || result.TransitionID != dispatch.TransitionID {
+		t.Fatalf("panic result lost dispatch identity: %+v", result)
+	}
+	if result.Outcome != interfaces.OutcomeFailed {
+		t.Fatalf("panic result outcome = %q, want %q", result.Outcome, interfaces.OutcomeFailed)
+	}
+	if !strings.Contains(result.Error, "executor panic:") || !strings.Contains(result.Error, "simulated executor panic") {
+		t.Fatalf("panic result error = %q, want panic-derived failure message", result.Error)
+	}
 }
 
 func TestWorkerPoolDispatchResultHook_SubmitDispatchWithPlannerExecutesSynchronously(t *testing.T) {

--- a/pkg/factory/runtime/factory_constructor_test.go
+++ b/pkg/factory/runtime/factory_constructor_test.go
@@ -78,6 +78,57 @@ func TestNew_InlineDispatchWithNoopExecutorCompletesWorkflow(t *testing.T) {
 	}
 }
 
+func TestNew_InlineDispatchExecutorPanicRoutesFailedWork(t *testing.T) {
+	f, err := New(
+		factory.WithNet(buildSimpleNetWithFailureArc()),
+		factory.WithInlineDispatch(),
+		factory.WithWorkerExecutor("mock", &panicExecutor{message: "simulated catastrophic panic"}),
+		factory.WithLogger(logging.NoopLogger{}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if _, err := submitWorkRequests(context.Background(), f, []interfaces.SubmitRequest{{
+		WorkID:     "work-panic",
+		WorkTypeID: "task",
+		TraceID:    "trace-panic",
+	}}); err != nil {
+		t.Fatalf("SubmitWorkRequest: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := f.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	snapshot, err := f.GetEngineStateSnapshot(ctx)
+	if err != nil {
+		t.Fatalf("GetEngineStateSnapshot: %v", err)
+	}
+	if snapshot.FactoryState != string(interfaces.FactoryStateCompleted) {
+		t.Fatalf("factory state = %q, want %q", snapshot.FactoryState, interfaces.FactoryStateCompleted)
+	}
+	if !markingContainsWorkAtPlace(&snapshot.Marking, "work-panic", "task:failed") {
+		t.Fatalf("expected work-panic to reach task:failed, marking=%#v", snapshot.Marking.PlaceTokens)
+	}
+	if markingContainsWorkAtPlace(&snapshot.Marking, "work-panic", "task:done") {
+		t.Fatal("expected work-panic to avoid task:done after executor panic")
+	}
+	if len(snapshot.DispatchHistory) != 1 {
+		t.Fatalf("dispatch history count = %d, want 1", len(snapshot.DispatchHistory))
+	}
+	completed := snapshot.DispatchHistory[0]
+	if completed.Outcome != interfaces.OutcomeFailed {
+		t.Fatalf("dispatch outcome = %q, want %q", completed.Outcome, interfaces.OutcomeFailed)
+	}
+	if !strings.Contains(completed.Reason, "executor panic:") || !strings.Contains(completed.Reason, "simulated catastrophic panic") {
+		t.Fatalf("dispatch reason = %q, want panic-derived failure message", completed.Reason)
+	}
+}
+
 func TestNew_InlineDispatchWithoutRegisteredExecutorRecordsMissingExecutorFailure(t *testing.T) {
 	f, err := New(
 		factory.WithNet(buildSimpleNetWithFailureArc()),

--- a/tests/stress/poison_token_test.go
+++ b/tests/stress/poison_token_test.go
@@ -438,12 +438,43 @@ func TestPoisonTokenNoPanic(t *testing.T) {
 }
 
 // TestPoisonTokenExecutorPanic verifies that if an executor panics, the
-// syncDispatcher does not propagate the panic to crash the test runner.
-// Note: the current syncDispatcher does NOT recover from executor panics,
-// so this test documents the behavior and uses recover() in the test itself.
+// Factory runtime recovers the panic and routes the Work through failed-Work
+// semantics without crashing the test process.
 func TestPoisonTokenExecutorPanic(t *testing.T) {
-	// pending migration: panic recovery in inline dispatch not supported during Run()
-	t.Skip("pending migration: panic recovery in inline dispatch not supported during Run()")
+	if testing.Short() {
+		t.Skip("skipping stress test in short mode")
+	}
+
+	dir := testutil.ScaffoldFactoryDir(t, poisonExecCfg("panic-worker"))
+	h := testutil.NewServiceTestHarness(t, dir)
+
+	h.SetCustomExecutor("panic-worker", &panicWorkerExecutor{
+		message: "simulated executor catastrophic panic",
+	})
+
+	h.SubmitWork("task", []byte(`{"test": "executor-panic"}`))
+
+	// Executor panics are converted to OutcomeFailed WorkResults and routed via
+	// FailureArcs — RunUntilComplete should succeed (no panic escaping Run()).
+	h.RunUntilComplete(t, 10*time.Second)
+
+	h.Assert().
+		PlaceTokenCount("task:failed", 1).
+		HasNoTokenInPlace("task:init").
+		HasNoTokenInPlace("task:complete")
+
+	snap := h.Marking()
+	for _, tok := range snap.Tokens {
+		if tok.PlaceID == "task:failed" {
+			if !strings.Contains(tok.History.LastError, "executor panic:") {
+				t.Errorf("expected panic failure message in token history, got: %q", tok.History.LastError)
+			}
+			if !strings.Contains(tok.History.LastError, "simulated executor catastrophic panic") {
+				t.Errorf("expected panic value in token history, got: %q", tok.History.LastError)
+			}
+			break
+		}
+	}
 }
 
 // TestPoisonTokenExecutorError verifies that executors returning Go errors are
@@ -576,6 +607,15 @@ func (e *errorExecutor) Execute(_ context.Context, _ interfaces.WorkDispatch) (i
 	return interfaces.WorkResult{}, e.err
 }
 
+// panicWorkerExecutor panics from Execute to exercise executor panic recovery.
+type panicWorkerExecutor struct {
+	message string
+}
+
+func (e *panicWorkerExecutor) Execute(_ context.Context, _ interfaces.WorkDispatch) (interfaces.WorkResult, error) {
+	panic(e.message)
+}
+
 // ---------------------------------------------------------------------------
 // Helper functions
 // ---------------------------------------------------------------------------
@@ -640,4 +680,5 @@ var (
 	_ workers.WorkerExecutor = (*emptyResultExecutor)(nil)
 	_ workers.WorkerExecutor = (*massiveSpawnExecutor)(nil)
 	_ workers.WorkerExecutor = (*errorExecutor)(nil)
+	_ workers.WorkerExecutor = (*panicWorkerExecutor)(nil)
 )


### PR DESCRIPTION
{
  "project": "Replace Poison-Token Executor Panic Skip With Runnable Failure Coverage",
  "branchName": "cleanup-stress-poison-token-panic-skip",
  "description": "Make TestPoisonTokenExecutorPanic runnable by proving that an executor panic during Factory runtime dispatch does not crash the test process and is routed or recorded through existing failed-Work semantics.",
  "context": {
    "customerAsk": "Make TestPoisonTokenExecutorPanic runnable by proving the current factory runtime handles an executor panic without crashing the test process and routes or records the failure through the existing failed-work semantics. If the runtime already has a canonical panic-to-failure path, use that path; otherwise add the smallest backend recovery behavior needed at the dispatch/runtime boundary. Remove the pending-migration skip, keep the test in the stress package behind the existing short-mode gate if appropriate, and verify with the focused go test for tests/stress plus the narrow affected backend package tests.",
    "problem": "tests/stress/poison_token_test.go still contains TestPoisonTokenExecutorPanic with a pending-migration skip because inline dispatch panic recovery was not supported during Run(). That skip leaves executor panic handling outside active stress coverage and allows a bad worker failure mode to regress without proof that failed-Work semantics still apply.",
    "solution": "Use the existing canonical panic-to-failure path if one already covers executor invocation, or add the smallest recovery behavior at the dispatch/runtime boundary. Then enable the stress regression so a panicking executor is contained, routed to the configured failed state, and recorded with useful failure diagnostics."
  },
  "acceptanceCriteria": [
    "TestPoisonTokenExecutorPanic no longer has the pending-migration skip or an equivalent unconditional bypass.",
    "A worker executor panic during dispatch does not propagate out of the Factory runtime run loop or crash the Go test process.",
    "The panicking Work follows existing failed-Work semantics: configured failure routing places the Work in task:failed or the equivalent failed state for the tested workflow.",
    "Existing failure diagnostics record a useful panic failure reason on the failed Work, dispatch result, event, or token history surface already used for executor failures.",
    "The change stays narrow and does not rewrite scheduler behavior, worker execution, stress harness ownership, or unrelated poison-token coverage.",
    "The stress test remains behind testing.Short() if consistent with the surrounding stress suite.",
    "Quality gate: typecheck, lint, go test ./tests/stress -run TestPoisonTokenExecutorPanic -count=1, and the narrow affected backend package tests pass."
  ],
  "userStories": [
    {
      "id": "cleanup-stress-poison-token-panic-skip-001",
      "title": "Convert executor panics into failed Work outcomes",
      "description": "As a Factory maintainer, I want executor panics to be contained at the dispatch/runtime boundary so that a bad worker cannot crash the Factory runtime process.",
      "acceptanceCriteria": [
        "When a worker executor panics during dispatch, the panic is recovered before it can escape the Factory runtime run loop.",
        "The recovered panic is represented through the existing failed-Work path rather than a new public failure model.",
        "The failed result preserves the dispatch identity needed by existing failure routing and diagnostics.",
        "Non-panicking executor success, rejection, continuation, and returned-error behavior remain unchanged.",
        "Any new or changed backend test proves the panic recovery behavior at the narrowest affected package boundary.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "cleanup-stress-poison-token-panic-skip-002",
      "title": "Enable the poison-token executor panic stress regression",
      "description": "As a Factory maintainer, I want the poison-token executor panic test to run as active stress coverage so that panic recovery and failed-state routing cannot regress unnoticed.",
      "acceptanceCriteria": [
        "The pending-migration skip is removed from TestPoisonTokenExecutorPanic.",
        "The test installs a panicking executor, submits one valid task Work item, and runs the Factory runtime through the existing stress harness.",
        "The test fails if the runtime panics, returns an unexpected fatal run error, or leaves the Work outside terminal failed handling.",
        "The test asserts exactly one failed Work token reaches task:failed, with no completed token for the same Work.",
        "The test asserts the failure diagnostics include a panic-related message that is useful to a maintainer.",
        "The test keeps the existing short-mode skip if the surrounding poison-token stress tests remain short-mode gated.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "cleanup-stress-poison-token-panic-skip-003",
      "title": "Verify the panic failure lane without broad cleanup",
      "description": "As a reviewer, I want focused verification for the executor panic failure lane so that the cleanup can be reviewed without relying on unrelated stress-suite churn.",
      "acceptanceCriteria": [
        "go test ./tests/stress -run TestPoisonTokenExecutorPanic -count=1 runs outside short mode and passes.",
        "Narrow backend package tests for any touched dispatch, worker, or runtime package run and pass.",
        "Existing poison-token executor error coverage still passes and continues to prove returned errors route to failed Work.",
        "No unrelated stress skips, poison-token scenarios, scheduler policies, API contracts, CLI behavior, generated files, or UI surfaces are changed.",
        "Final implementation evidence names the focused commands used for this regression.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)