### PR TITLE
cleanup-invocations-inference-binding-pkgmaint-exception

### DIFF
--- a/pkg/invocations/inference_test.go
+++ b/pkg/invocations/inference_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 )
 
-// pkgmaintcheck:ignore-cyclomatic-complexity this binding-alignment test keeps legacy and inference workstation assertions together on one contract surface.
 func TestResolveInferenceOperationBindings_InferenceAndLegacyWorkstationTypesAlign(t *testing.T) {
 	worker := inferenceBindingWorkerFixture()
 	inputTokens := inferenceBindingInputTokensFixture()

--- a/pkg/invocations/inference_test.go
+++ b/pkg/invocations/inference_test.go
@@ -11,57 +11,14 @@ import (
 // pkgmaintcheck:ignore-cyclomatic-complexity this binding-alignment test keeps legacy and inference workstation assertions together on one contract surface.
 func TestResolveInferenceOperationBindings_InferenceAndLegacyWorkstationTypesAlign(t *testing.T) {
 	worker := inferenceBindingWorkerFixture()
-	inputTokens := []interfaces.Token{{
-		ID: "token-tts",
-		Color: interfaces.TokenColor{
-			Content: []interfaces.WorkContentPart{{
-				Type:  interfaces.WorkContentPartTypeText,
-				Label: "utterance",
-				Text:  "hello world",
-			}},
-		},
-	}}
+	inputTokens := inferenceBindingInputTokensFixture()
 
-	inferenceBindings, err := ResolveInferenceOperationBindings(
-		inferenceBindingWorkstationFixture(interfaces.WorkstationTypeInference),
-		worker,
-		inputTokens,
-	)
-	if err != nil {
-		t.Fatalf("ResolveInferenceOperationBindings inference run: %v", err)
-	}
-	legacyBindings, err := ResolveInferenceOperationBindings(
-		inferenceBindingWorkstationFixture(interfaces.WorkstationTypeInvoke),
-		worker,
-		inputTokens,
-	)
-	if err != nil {
-		t.Fatalf("ResolveInferenceOperationBindings legacy model invoke: %v", err)
-	}
+	inferenceBindings := mustResolveInferenceBindings(t, interfaces.WorkstationTypeInference, worker, inputTokens)
+	legacyBindings := mustResolveInferenceBindings(t, interfaces.WorkstationTypeInvoke, worker, inputTokens)
 
-	for _, got := range [][]interfaces.ResolvedModelOperationBinding{inferenceBindings, legacyBindings} {
-		if len(got) != 2 {
-			t.Fatalf("bindings = %#v, want 2 resolved slots", got)
-		}
-		if got[0].Slot != "text" || got[0].Source != interfaces.ModelOperationBindingSourceInput || got[0].Content[0].Text != "hello world" {
-			t.Fatalf("text binding = %#v, want input text binding", got[0])
-		}
-		if got[1].Slot != "voice" || got[1].Source != interfaces.ModelOperationBindingSourceConfig || string(got[1].Content[0].JSON) != `{"name":"alloy"}` {
-			t.Fatalf("voice binding = %#v, want config voice binding", got[1])
-		}
-	}
-
-	if len(legacyBindings) != len(inferenceBindings) {
-		t.Fatalf("legacy vs inference binding count = %d vs %d", len(legacyBindings), len(inferenceBindings))
-	}
-	for i := range legacyBindings {
-		if legacyBindings[i].Slot != inferenceBindings[i].Slot || legacyBindings[i].Source != inferenceBindings[i].Source {
-			t.Fatalf("binding[%d] = %#v vs %#v, want aligned slot/source", i, legacyBindings[i], inferenceBindings[i])
-		}
-		if len(legacyBindings[i].Content) != len(inferenceBindings[i].Content) || legacyBindings[i].Content[0].Text != inferenceBindings[i].Content[0].Text {
-			t.Fatalf("binding[%d] content = %#v vs %#v, want aligned content", i, legacyBindings[i].Content, inferenceBindings[i].Content)
-		}
-	}
+	assertInferenceBindingFixtureBindings(t, inferenceBindings)
+	assertInferenceBindingFixtureBindings(t, legacyBindings)
+	assertInferenceBindingsAligned(t, inferenceBindings, legacyBindings)
 }
 
 func TestWorkContentFromInferenceOutput_OrdersAudioBeforeExtraParts(t *testing.T) {
@@ -159,6 +116,75 @@ func TestOperationBindingsFromGenerated_MapsSelectorFields(t *testing.T) {
 	}})
 	if len(bindings) != 1 || bindings[0].Slot != "text" || bindings[0].Selector.Label != "utterance" {
 		t.Fatalf("bindings = %#v, want mapped selector", bindings)
+	}
+}
+
+func inferenceBindingInputTokensFixture() []interfaces.Token {
+	return []interfaces.Token{{
+		ID: "token-tts",
+		Color: interfaces.TokenColor{
+			Content: []interfaces.WorkContentPart{{
+				Type:  interfaces.WorkContentPartTypeText,
+				Label: "utterance",
+				Text:  "hello world",
+			}},
+		},
+	}}
+}
+
+func mustResolveInferenceBindings(
+	t *testing.T,
+	workstationType string,
+	worker *interfaces.WorkerConfig,
+	inputTokens []interfaces.Token,
+) []interfaces.ResolvedModelOperationBinding {
+	t.Helper()
+	bindings, err := ResolveInferenceOperationBindings(
+		inferenceBindingWorkstationFixture(workstationType),
+		worker,
+		inputTokens,
+	)
+	if err != nil {
+		t.Fatalf("ResolveInferenceOperationBindings %s: %v", workstationType, err)
+	}
+	return bindings
+}
+
+func assertInferenceBindingFixtureBindings(t *testing.T, bindings []interfaces.ResolvedModelOperationBinding) {
+	t.Helper()
+	if len(bindings) != 2 {
+		t.Fatalf("bindings = %#v, want 2 resolved slots", bindings)
+	}
+	assertInferenceBindingTextSlot(t, bindings[0])
+	assertInferenceBindingVoiceSlot(t, bindings[1])
+}
+
+func assertInferenceBindingTextSlot(t *testing.T, binding interfaces.ResolvedModelOperationBinding) {
+	t.Helper()
+	if binding.Slot != "text" || binding.Source != interfaces.ModelOperationBindingSourceInput || binding.Content[0].Text != "hello world" {
+		t.Fatalf("text binding = %#v, want input text binding", binding)
+	}
+}
+
+func assertInferenceBindingVoiceSlot(t *testing.T, binding interfaces.ResolvedModelOperationBinding) {
+	t.Helper()
+	if binding.Slot != "voice" || binding.Source != interfaces.ModelOperationBindingSourceConfig || string(binding.Content[0].JSON) != `{"name":"alloy"}` {
+		t.Fatalf("voice binding = %#v, want config voice binding", binding)
+	}
+}
+
+func assertInferenceBindingsAligned(t *testing.T, inference, legacy []interfaces.ResolvedModelOperationBinding) {
+	t.Helper()
+	if len(legacy) != len(inference) {
+		t.Fatalf("legacy vs inference binding count = %d vs %d", len(legacy), len(inference))
+	}
+	for i := range legacy {
+		if legacy[i].Slot != inference[i].Slot || legacy[i].Source != inference[i].Source {
+			t.Fatalf("binding[%d] = %#v vs %#v, want aligned slot/source", i, legacy[i], inference[i])
+		}
+		if len(legacy[i].Content) != len(inference[i].Content) || legacy[i].Content[0].Text != inference[i].Content[0].Text {
+			t.Fatalf("binding[%d] content = %#v vs %#v, want aligned content", i, legacy[i].Content, inference[i].Content)
+		}
 	}
 }
 


### PR DESCRIPTION
{
  "project": "you-agent-factory",
  "branchName": "cleanup-invocations-inference-binding-pkgmaint-exception",
  "description": "Remove the pkgmaint cyclomatic-complexity exception from the invocations inference binding alignment test while preserving observable coverage that INFERENCE_RUN and legacy MODEL_INVOKE resolve the same binding slots, sources, and content.",
  "context": {
    "customerAsk": "Refactor the inference binding alignment test into smaller reviewer-readable helpers or table-driven assertions so the pkgmaintcheck cyclomatic-complexity exception can be removed while preserving the same observable binding-alignment coverage for INFERENCE_RUN and legacy MODEL_INVOKE behavior. Keep the change bounded to pkg/invocations test code unless a tiny local helper is required, and verify with the focused invocations tests plus make pkg-maint or the equivalent pkgmaintcheck command.",
    "problem": "pkg/invocations/inference_test.go carries a pkgmaintcheck:ignore-cyclomatic-complexity comment on the test that verifies inference and legacy workstation binding alignment. The test proves useful behavior, but its single high-complexity body makes the coverage harder to review and leaves a targeted maintainer-check exception in place.",
    "solution": "Reshape the binding-alignment test into table-driven assertions or small local helpers that separately prove the INFERENCE_RUN binding outcomes, the legacy MODEL_INVOKE binding outcomes, and cross-workstation alignment. Remove the pkgmaintcheck exception once the test is below the checker threshold and verify with focused invocations tests plus make pkg-maint or the equivalent pkgmaintcheck command."
  },
  "acceptanceCriteria": [
    "The INFERENCE_RUN path still resolves exactly two bindings for the fixture: text from input content with hello world, and voice from config content with {\"name\":\"alloy\"}.",
    "The legacy MODEL_INVOKE path still resolves exactly the same binding slots, sources, and resolved content as the INFERENCE_RUN path for the same worker, workstation, and input fixture.",
    "The pkgmaintcheck:ignore-cyclomatic-complexity comment is removed from pkg/invocations/inference_test.go because the alignment coverage no longer exceeds the checker threshold.",
    "The implementation stays bounded to pkg/invocations test code and does not change production invocation behavior, public contracts, OpenAPI generation, UI behavior, or unrelated tests.",
    "Regression coverage remains behavioral and asserts invocation binding outcomes rather than helper existence, source topology, or command inventories.",
    "Focused verification passes for pkg/invocations tests and make pkg-maint or the equivalent pkgmaintcheck command that proves the exception is no longer needed.",
    "Quality gate: typecheck, lint, and relevant tests pass."
  ],
  "userStories": [
    {
      "id": "cleanup-invocations-inference-binding-pkgmaint-exception-001",
      "title": "Preserve binding outcomes with readable assertions",
      "description": "As a backend maintainer, I want the inference binding alignment test to express each expected resolved binding clearly so reviewers can confirm INFERENCE_RUN and legacy MODEL_INVOKE still produce the same invocation inputs.",
      "acceptanceCriteria": [
        "The refactored test still exercises both interfaces.WorkstationTypeInference and interfaces.WorkstationTypeInvoke using the same worker fixture and input token fixture.",
        "The INFERENCE_RUN assertion verifies exactly two resolved slots and confirms text comes from input content with hello world.",
        "The INFERENCE_RUN assertion verifies voice comes from config content with JSON equal to {\"name\":\"alloy\"}.",
        "The legacy MODEL_INVOKE assertion verifies the same expected text and voice binding outcomes, either through the same table-driven cases or shared local assertion helpers.",
        "The refactor uses local test helpers or table data only where they make the expected behavior easier to review; it does not introduce broad shared test infrastructure.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "cleanup-invocations-inference-binding-pkgmaint-exception-002",
      "title": "Remove the pkgmaint exception and prove the check",
      "description": "As a reviewer, I want the targeted pkgmaintcheck exception removed and verified so the cleanup batch retires the exception without losing binding-alignment regression coverage.",
      "acceptanceCriteria": [
        "pkg/invocations/inference_test.go no longer contains the pkgmaintcheck:ignore-cyclomatic-complexity comment for the inference and legacy workstation binding alignment test.",
        "The cross-workstation assertion still fails if legacy MODEL_INVOKE and INFERENCE_RUN differ in binding count, slot, source, or resolved content for the fixture.",
        "Focused invocations tests pass, preferably with go test ./pkg/invocations/... or the repository's equivalent focused invocation test command.",
        "make pkg-maint or the equivalent pkgmaintcheck command passes for the touched test surface.",
        "The implementation does not change production files in pkg/invocations unless a tiny local test-only helper requires adjacent support.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)