### PR TITLE
cleanup-engine-state-snapshot-pkgmaint-exception

### DIFF
--- a/pkg/factory/state/engine_state_test.go
+++ b/pkg/factory/state/engine_state_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/portpowered/infinite-you/pkg/petri"
 )
 
-// pkgmaintcheck:ignore-cyclomatic-complexity this snapshot contract test keeps all exported state fields visible in one reviewer-readable assertion flow.
 func TestEngineStateSnapshot_AllFieldsAccessible(t *testing.T) {
 	snap := engineStateSnapshotFixture()
 

--- a/pkg/factory/state/engine_state_test.go
+++ b/pkg/factory/state/engine_state_test.go
@@ -18,21 +18,13 @@ func TestEngineStateSnapshot_AllFieldsAccessible(t *testing.T) {
 	t.Run("factory metadata", func(t *testing.T) {
 		assertSnapshotFactoryMetadata(t, snap)
 	})
-
-	runtime := snap.RuntimeStateSnapshot()
-	if runtime.RuntimeStatus != snap.RuntimeStatus {
-		t.Fatalf("runtime status = %q, want %q", runtime.RuntimeStatus, snap.RuntimeStatus)
-	}
-	if runtime.TickCount != snap.TickCount {
-		t.Fatalf("runtime tick count = %d, want %d", runtime.TickCount, snap.TickCount)
-	}
-	if len(runtime.ActiveThrottlePauses) != 1 {
-		t.Fatalf("runtime active throttle pause count = %d, want 1", len(runtime.ActiveThrottlePauses))
-	}
-	aggregate := NewEngineStateSnapshot(runtime, "RUNNING", time.Minute, snap.Topology)
-	if len(aggregate.ActiveThrottlePauses) != 1 {
-		t.Fatalf("aggregate active throttle pause count = %d, want 1", len(aggregate.ActiveThrottlePauses))
-	}
+	t.Run("runtime projection", func(t *testing.T) {
+		assertRuntimeStateSnapshot(t, snap)
+	})
+	t.Run("aggregate construction", func(t *testing.T) {
+		runtime := snap.RuntimeStateSnapshot()
+		assertNewEngineStateSnapshot(t, runtime, "RUNNING", time.Minute, snap.Topology)
+	})
 }
 
 func assertSnapshotRuntimeFields(t *testing.T, snap interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *Net]) {
@@ -70,6 +62,45 @@ func assertSnapshotRuntimeFields(t *testing.T, snap interfaces.EngineStateSnapsh
 	}
 	if snap.ActiveThrottlePauses[0].LaneID != "claude/claude-sonnet" {
 		t.Fatalf("active throttle pause lane = %q, want claude/claude-sonnet", snap.ActiveThrottlePauses[0].LaneID)
+	}
+}
+
+func assertRuntimeStateSnapshot(t *testing.T, snap interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *Net]) {
+	t.Helper()
+
+	runtime := snap.RuntimeStateSnapshot()
+	if runtime.RuntimeStatus != snap.RuntimeStatus {
+		t.Errorf("runtime status = %q, want %q", runtime.RuntimeStatus, snap.RuntimeStatus)
+	}
+	if runtime.TickCount != snap.TickCount {
+		t.Errorf("runtime tick count = %d, want %d", runtime.TickCount, snap.TickCount)
+	}
+	if len(runtime.ActiveThrottlePauses) != len(snap.ActiveThrottlePauses) {
+		t.Fatalf("runtime active throttle pause count = %d, want %d", len(runtime.ActiveThrottlePauses), len(snap.ActiveThrottlePauses))
+	}
+}
+
+func assertNewEngineStateSnapshot(
+	t *testing.T,
+	runtime interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *Net],
+	factoryState string,
+	uptime time.Duration,
+	topology *Net,
+) {
+	t.Helper()
+
+	aggregate := NewEngineStateSnapshot(runtime, factoryState, uptime, topology)
+	if len(aggregate.ActiveThrottlePauses) != len(runtime.ActiveThrottlePauses) {
+		t.Errorf("aggregate active throttle pause count = %d, want %d", len(aggregate.ActiveThrottlePauses), len(runtime.ActiveThrottlePauses))
+	}
+	if aggregate.FactoryState != factoryState {
+		t.Errorf("aggregate factory state = %q, want %q", aggregate.FactoryState, factoryState)
+	}
+	if aggregate.Uptime != uptime {
+		t.Errorf("aggregate uptime = %v, want %v", aggregate.Uptime, uptime)
+	}
+	if aggregate.Topology != topology {
+		t.Fatalf("aggregate topology = %#v, want %#v", aggregate.Topology, topology)
 	}
 }
 

--- a/pkg/factory/state/engine_state_test.go
+++ b/pkg/factory/state/engine_state_test.go
@@ -12,7 +12,32 @@ import (
 func TestEngineStateSnapshot_AllFieldsAccessible(t *testing.T) {
 	snap := engineStateSnapshotFixture()
 
-	// Runtime state assertions.
+	t.Run("runtime fields", func(t *testing.T) {
+		assertSnapshotRuntimeFields(t, snap)
+	})
+	t.Run("factory metadata", func(t *testing.T) {
+		assertSnapshotFactoryMetadata(t, snap)
+	})
+
+	runtime := snap.RuntimeStateSnapshot()
+	if runtime.RuntimeStatus != snap.RuntimeStatus {
+		t.Fatalf("runtime status = %q, want %q", runtime.RuntimeStatus, snap.RuntimeStatus)
+	}
+	if runtime.TickCount != snap.TickCount {
+		t.Fatalf("runtime tick count = %d, want %d", runtime.TickCount, snap.TickCount)
+	}
+	if len(runtime.ActiveThrottlePauses) != 1 {
+		t.Fatalf("runtime active throttle pause count = %d, want 1", len(runtime.ActiveThrottlePauses))
+	}
+	aggregate := NewEngineStateSnapshot(runtime, "RUNNING", time.Minute, snap.Topology)
+	if len(aggregate.ActiveThrottlePauses) != 1 {
+		t.Fatalf("aggregate active throttle pause count = %d, want 1", len(aggregate.ActiveThrottlePauses))
+	}
+}
+
+func assertSnapshotRuntimeFields(t *testing.T, snap interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *Net]) {
+	t.Helper()
+
 	if len(snap.Marking.Tokens) != 1 {
 		t.Errorf("expected 1 token, got %d", len(snap.Marking.Tokens))
 	}
@@ -46,33 +71,19 @@ func TestEngineStateSnapshot_AllFieldsAccessible(t *testing.T) {
 	if snap.ActiveThrottlePauses[0].LaneID != "claude/claude-sonnet" {
 		t.Fatalf("active throttle pause lane = %q, want claude/claude-sonnet", snap.ActiveThrottlePauses[0].LaneID)
 	}
+}
 
-	// Factory state.
+func assertSnapshotFactoryMetadata(t *testing.T, snap interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *Net]) {
+	t.Helper()
+
 	if snap.FactoryState != "RUNNING" {
 		t.Errorf("expected FactoryState=RUNNING, got %s", snap.FactoryState)
 	}
-
-	// Uptime.
 	if snap.Uptime != 10*time.Minute {
 		t.Errorf("expected Uptime=10m, got %v", snap.Uptime)
 	}
 	if snap.Topology == nil || snap.Topology.ID != "snapshot-topology" {
 		t.Fatalf("expected topology snapshot-topology, got %#v", snap.Topology)
-	}
-
-	runtime := snap.RuntimeStateSnapshot()
-	if runtime.RuntimeStatus != snap.RuntimeStatus {
-		t.Fatalf("runtime status = %q, want %q", runtime.RuntimeStatus, snap.RuntimeStatus)
-	}
-	if runtime.TickCount != snap.TickCount {
-		t.Fatalf("runtime tick count = %d, want %d", runtime.TickCount, snap.TickCount)
-	}
-	if len(runtime.ActiveThrottlePauses) != 1 {
-		t.Fatalf("runtime active throttle pause count = %d, want 1", len(runtime.ActiveThrottlePauses))
-	}
-	aggregate := NewEngineStateSnapshot(runtime, "RUNNING", time.Minute, snap.Topology)
-	if len(aggregate.ActiveThrottlePauses) != 1 {
-		t.Fatalf("aggregate active throttle pause count = %d, want 1", len(aggregate.ActiveThrottlePauses))
 	}
 }
 


### PR DESCRIPTION
{
  "project": "you-agent-factory",
  "branchName": "cleanup-engine-state-snapshot-pkgmaint-exception",
  "description": "Remove the pkgmaint cyclomatic-complexity exception from the engine state snapshot contract test while preserving observable coverage for runtime fields, factory state, uptime, topology, throttle pauses, RuntimeStateSnapshot, and NewEngineStateSnapshot aggregation.",
  "context": {
    "customerAsk": "Split or simplify the engine state snapshot contract test so the pkgmaintcheck cyclomatic-complexity exception can be removed while preserving observable coverage for runtime fields, factory state, uptime, topology, throttle pauses, RuntimeStateSnapshot, and NewEngineStateSnapshot aggregation. Keep the change bounded to pkg/factory/state test code and verify with focused state tests plus make pkg-maint or the equivalent pkgmaintcheck command.",
    "problem": "pkg/factory/state/engine_state_test.go carries a pkgmaintcheck:ignore-cyclomatic-complexity comment on the exported engine state snapshot contract test. The test protects useful snapshot behavior, but the single high-complexity assertion flow is harder to review than necessary and leaves a targeted maintainer-check exception in place.",
    "solution": "Reshape the snapshot contract coverage into smaller tests, subtests, or package-local assertion helpers that separately prove runtime field coverage, factory metadata coverage, RuntimeStateSnapshot projection behavior, and NewEngineStateSnapshot aggregation behavior. Remove the pkgmaintcheck exception and verify with focused pkg/factory/state tests plus make pkg-maint or the equivalent pkgmaintcheck command."
  },
  "acceptanceCriteria": [
    "Engine state snapshot coverage still verifies runtime fields including marking tokens, active dispatches, consumed tokens, in-flight count, runtime status, tick count, completed dispatch history, output mutations, and active throttle pauses.",
    "Engine state snapshot coverage still verifies factory state, uptime, and topology values from the snapshot fixture.",
    "RuntimeStateSnapshot coverage still proves runtime-only fields are carried forward, including runtime status, tick count, and active throttle pauses.",
    "NewEngineStateSnapshot coverage still proves aggregate construction carries runtime throttle pauses while accepting factory state, uptime, and topology inputs.",
    "The targeted pkgmaintcheck:ignore-cyclomatic-complexity comment is removed from pkg/factory/state/engine_state_test.go.",
    "The implementation stays bounded to pkg/factory/state test code and does not change production runtime behavior, public contracts, generated files, CLI behavior, UI behavior, or unrelated tests.",
    "Quality gate: typecheck, lint, focused state tests, and make pkg-maint or the equivalent pkgmaintcheck command pass."
  ],
  "userStories": [
    {
      "id": "cleanup-engine-state-snapshot-pkgmaint-exception-001",
      "title": "Preserve exported snapshot field coverage with readable assertions",
      "passes": true
    },
    {
      "id": "cleanup-engine-state-snapshot-pkgmaint-exception-002",
      "title": "Preserve runtime projection and aggregate construction coverage",
      "passes": true
    },
    {
      "id": "cleanup-engine-state-snapshot-pkgmaint-exception-003",
      "title": "Remove the pkgmaint exception and verify the focused lane",
      "passes": true
    }
  ]
}

Made with [Cursor](https://cursor.com)