### PR TITLE
cleanup-config-maptests-resource-portos-exceptions

### DIFF
--- a/pkg/config/maptests/config_mapper_resources_test.go
+++ b/pkg/config/maptests/config_mapper_resources_test.go
@@ -56,9 +56,20 @@ func resourceUsageFactoryConfig() *interfaces.FactoryConfig {
 	}
 }
 
-// portos:func-length-exception owner=agent-factory reason=legacy-resource-fixture review=2026-07-18 removal=split-shared-resource-fixture-before-next-resource-change
 func TestConfigMapping_TwoWorkstationsSharingResource(t *testing.T) {
-	input := &interfaces.FactoryConfig{
+	mapper := testConfigMapper{}
+	outputNet, err := mapper.Map(context.Background(), twoWorkstationsSharingResourceFactoryConfig())
+	if err != nil {
+		t.Fatalf("failed to map config: %v", err)
+	}
+	assertMappedResourcePlace(t, outputNet)
+	for _, name := range []string{"step1", "step2"} {
+		assertMappedResourceTransition(t, outputNet, name)
+	}
+}
+
+func twoWorkstationsSharingResourceFactoryConfig() *interfaces.FactoryConfig {
+	return &interfaces.FactoryConfig{
 		WorkTypes: []interfaces.WorkTypeConfig{
 			{
 				Name: "task",
@@ -104,40 +115,6 @@ func TestConfigMapping_TwoWorkstationsSharingResource(t *testing.T) {
 				},
 			},
 		},
-	}
-
-	mapper := testConfigMapper{}
-	outputNet, err := mapper.Map(context.Background(), input)
-	if err != nil {
-		t.Fatalf("failed to map config: %v", err)
-	}
-
-	// Both transitions should have resource consume and release arcs.
-	for _, name := range []string{"step1", "step2"} {
-		tr := outputNet.Transitions[name]
-		if tr == nil {
-			t.Fatalf("expected transition %q to exist", name)
-		}
-		// 1 normal input + 1 consume = 2 input arcs.
-		if len(tr.InputArcs) != 2 {
-			t.Errorf("transition %q: expected 2 input arcs, got %d", name, len(tr.InputArcs))
-		}
-		// 1 normal output + 1 release = 2 output arcs.
-		if len(tr.OutputArcs) != 2 {
-			t.Errorf("transition %q: expected 2 output arcs, got %d", name, len(tr.OutputArcs))
-		}
-
-		// Verify consume arc references the shared resource.
-		consumeArc := tr.InputArcs[1]
-		if consumeArc.PlaceID != "gpu:available" {
-			t.Errorf("transition %q: consume arc place expected 'gpu:available', got %q", name, consumeArc.PlaceID)
-		}
-
-		// Verify release arc references the shared resource.
-		releaseArc := tr.OutputArcs[1]
-		if releaseArc.PlaceID != "gpu:available" {
-			t.Errorf("transition %q: release arc place expected 'gpu:available', got %q", name, releaseArc.PlaceID)
-		}
 	}
 }
 

--- a/pkg/config/maptests/config_mapper_resources_test.go
+++ b/pkg/config/maptests/config_mapper_resources_test.go
@@ -11,9 +11,18 @@ import (
 	"time"
 )
 
-// portos:func-length-exception owner=agent-factory reason=legacy-resource-fixture review=2026-07-18 removal=split-resource-config-fixture-before-next-resource-change
 func TestConfigMapping_ResourceUsage(t *testing.T) {
-	input := &interfaces.FactoryConfig{
+	mapper := testConfigMapper{}
+	outputNet, err := mapper.Map(context.Background(), resourceUsageFactoryConfig())
+	if err != nil {
+		t.Fatalf("failed to map config: %v", err)
+	}
+	assertMappedResourcePlace(t, outputNet)
+	assertMappedResourceTransition(t, outputNet, "processor")
+}
+
+func resourceUsageFactoryConfig() *interfaces.FactoryConfig {
+	return &interfaces.FactoryConfig{
 		WorkTypes: []interfaces.WorkTypeConfig{
 			{
 				Name: "task",
@@ -45,14 +54,6 @@ func TestConfigMapping_ResourceUsage(t *testing.T) {
 			},
 		},
 	}
-
-	mapper := testConfigMapper{}
-	outputNet, err := mapper.Map(context.Background(), input)
-	if err != nil {
-		t.Fatalf("failed to map config: %v", err)
-	}
-	assertMappedResourcePlace(t, outputNet)
-	assertMappedResourceTransition(t, outputNet, "processor")
 }
 
 // portos:func-length-exception owner=agent-factory reason=legacy-resource-fixture review=2026-07-18 removal=split-shared-resource-fixture-before-next-resource-change


### PR DESCRIPTION
```json
{
  "project": "Remove Resource Mapper Portos Fixture Exceptions",
  "branchName": "cleanup-config-maptests-resource-portos-exceptions",
  "description": "Refactor the resource mapper tests so the resource usage and shared-resource mapping coverage no longer need dated portos:func-length-exception comments, while preserving the same observable resource mapping and validation behavior.",
  "context": {
    "customerAsk": "Refactor pkg/config/maptests/config_mapper_resources_test.go so the resource usage and shared-resource mapper tests no longer need portos:func-length-exception comments, while preserving the same observable mapping behavior and focused go test proof.",
    "problem": "The resource mapper tests protect useful behavior, but TestConfigMapping_ResourceUsage and TestConfigMapping_TwoWorkstationsSharingResource still carry dated function-length suppressions because their fixtures and assertions are too large for the Portos check. This creates avoidable exception debt in a small, non-overlapping cleanup target.",
    "solution": "Reshape the resource mapper test fixtures and assertions into smaller readable units that preserve the same mapped resource place, consume arc, release arc, shared-resource, and nonexistent-resource validation outcomes. Remove the targeted suppressions and verify with the requested focused maptests command."
  },
  "acceptanceCriteria": [
    "TestConfigMapping_ResourceUsage still proves that a configured resource maps to the expected available resource place and that the resource-using workstation has the expected consume and release arcs.",
    "TestConfigMapping_TwoWorkstationsSharingResource still proves that both workstations using the shared resource have resource consume and release arcs targeting the shared available place.",
    "TestConfigMapping_ValidationRejectsNonexistentResource still proves mapping fails when a workstation references a resource that is not declared by the Factory config.",
    "The two dated portos:func-length-exception comments are removed without replacing them with equivalent suppressions.",
    "The implementation stays narrow: no production mapper behavior, API contract, generated file, CLI behavior, UI behavior, or unrelated tests change.",
    "Quality gate: typecheck, lint or Portos maintainer checks applicable to this test file, and go test ./pkg/config/maptests -run 'TestConfigMapping_(ResourceUsage|TwoWorkstationsSharingResource|ValidationRejectsNonexistentResource)' -count=1 pass."
  ],
  "userStories": [
    {
      "id": "cleanup-config-maptests-resource-portos-exceptions-001",
      "title": "Preserve single-resource workstation mapping without a function-length exception",
      "passes": true
    },
    {
      "id": "cleanup-config-maptests-resource-portos-exceptions-002",
      "title": "Preserve shared-resource mapping without a function-length exception",
      "passes": true
    },
    {
      "id": "cleanup-config-maptests-resource-portos-exceptions-003",
      "title": "Preserve nonexistent-resource validation and focused proof",
      "passes": true
    }
  ]
}
```

## Test plan

- [x] `go test ./pkg/config/maptests -run 'TestConfigMapping_(ResourceUsage|TwoWorkstationsSharingResource|ValidationRejectsNonexistentResource)' -count=1`
- [x] `make pkg-maint`

Made with [Cursor](https://cursor.com)