### PR TITLE
cleanup-config-maptests-input-guard-portos-exceptions

### DIFF
--- a/pkg/config/maptests/config_mapper_input_guards_any_child_failed_test.go
+++ b/pkg/config/maptests/config_mapper_input_guards_any_child_failed_test.go
@@ -1,0 +1,102 @@
+package maptests
+
+import (
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/factory/state"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/petri"
+)
+
+func anyChildFailedFactoryConfig() *interfaces.FactoryConfig {
+	return &interfaces.FactoryConfig{
+		WorkTypes: []interfaces.WorkTypeConfig{
+			{
+				Name: "request",
+				States: []interfaces.StateConfig{
+					{Name: "init", Type: interfaces.StateTypeInitial},
+					{Name: "waiting", Type: interfaces.StateTypeProcessing},
+					{Name: "failed", Type: interfaces.StateTypeFailed},
+				},
+			},
+			{
+				Name: "page",
+				States: []interfaces.StateConfig{
+					{Name: "init", Type: interfaces.StateTypeInitial},
+					{Name: "failed", Type: interfaces.StateTypeFailed},
+				},
+			},
+		},
+		Workers: []interfaces.WorkerConfig{
+			{Name: "check-worker"},
+		},
+		Workstations: []interfaces.FactoryWorkstationConfig{
+			{
+				Name:           "failure-checker",
+				WorkerTypeName: "check-worker",
+				Inputs: []interfaces.IOConfig{
+					{StateName: "waiting", WorkTypeName: "request"},
+					{
+						StateName:    "failed",
+						WorkTypeName: "page",
+						Guard: &interfaces.InputGuardConfig{
+							Type:        interfaces.GuardTypeAnyChildFailed,
+							ParentInput: "request",
+						},
+					},
+				},
+				Outputs: []interfaces.IOConfig{
+					{StateName: "failed", WorkTypeName: "request"},
+				},
+			},
+		},
+	}
+}
+
+func assertAnyChildFailedFailureChecker(t *testing.T, outputNet *state.Net) {
+	t.Helper()
+
+	failureChecker := outputNet.Transitions["failure-checker"]
+	if failureChecker == nil {
+		t.Fatal("expected transition 'failure-checker' to exist")
+	}
+	if len(failureChecker.InputArcs) != 2 {
+		t.Fatalf("expected 2 input arcs on failure-checker, got %d", len(failureChecker.InputArcs))
+	}
+
+	assertAnyChildFailedParentArc(t, failureChecker.InputArcs[0])
+	assertAnyChildFailedChildArc(t, failureChecker.InputArcs[1])
+}
+
+func assertAnyChildFailedParentArc(t *testing.T, parentArc petri.Arc) {
+	t.Helper()
+
+	if parentArc.Name != "parent" {
+		t.Errorf("first input arc name: expected 'parent', got %q", parentArc.Name)
+	}
+	if parentArc.PlaceID != "request:waiting" {
+		t.Errorf("parent arc place: expected 'request:waiting', got %q", parentArc.PlaceID)
+	}
+}
+
+func assertAnyChildFailedChildArc(t *testing.T, childArc petri.Arc) {
+	t.Helper()
+
+	if childArc.PlaceID != "page:failed" {
+		t.Errorf("child arc place: expected 'page:failed', got %q", childArc.PlaceID)
+	}
+	if childArc.Mode != interfaces.ArcModeObserve {
+		t.Errorf("child arc mode: expected OBSERVE, got %d", childArc.Mode)
+	}
+	if childArc.Cardinality.Mode != petri.CardinalityOne {
+		t.Errorf("child arc cardinality: expected ONE, got %d", childArc.Cardinality.Mode)
+	}
+
+	guard, ok := childArc.Guard.(*petri.AnyWithParentGuard)
+	if !ok {
+		t.Fatalf("expected AnyWithParentGuard on child arc, got %T", childArc.Guard)
+	}
+	if guard.MatchBinding != "parent" {
+		t.Errorf("guard match binding: expected 'parent', got %q", guard.MatchBinding)
+	}
+}

--- a/pkg/config/maptests/config_mapper_input_guards_dynamic_test.go
+++ b/pkg/config/maptests/config_mapper_input_guards_dynamic_test.go
@@ -1,0 +1,177 @@
+package maptests
+
+import (
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/factory/state"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/petri"
+)
+
+const dynamicFanoutSpawnedByWorkstation = "parser"
+
+func dynamicFanoutFactoryConfig() *interfaces.FactoryConfig {
+	return &interfaces.FactoryConfig{
+		WorkTypes: []interfaces.WorkTypeConfig{
+			{
+				Name: "chapter",
+				States: []interfaces.StateConfig{
+					{Name: "init", Type: interfaces.StateTypeInitial},
+					{Name: "processing", Type: interfaces.StateTypeProcessing},
+					{Name: "complete", Type: interfaces.StateTypeTerminal},
+				},
+			},
+			{
+				Name: "page",
+				States: []interfaces.StateConfig{
+					{Name: "init", Type: interfaces.StateTypeInitial},
+					{Name: "complete", Type: interfaces.StateTypeTerminal},
+				},
+			},
+		},
+		Workers: []interfaces.WorkerConfig{
+			{Name: "parse-worker"},
+			{Name: "complete-worker"},
+		},
+		Workstations: []interfaces.FactoryWorkstationConfig{
+			{
+				Name:           dynamicFanoutSpawnedByWorkstation,
+				WorkerTypeName: "parse-worker",
+				Inputs: []interfaces.IOConfig{
+					{StateName: "init", WorkTypeName: "chapter"},
+				},
+				Outputs: []interfaces.IOConfig{
+					{StateName: "processing", WorkTypeName: "chapter"},
+				},
+			},
+			{
+				Name:           "chapter-complete",
+				WorkerTypeName: "complete-worker",
+				Inputs: []interfaces.IOConfig{
+					{StateName: "processing", WorkTypeName: "chapter"},
+					{
+						StateName:    "complete",
+						WorkTypeName: "page",
+						Guard: &interfaces.InputGuardConfig{
+							Type:        interfaces.GuardTypeAllChildrenComplete,
+							ParentInput: "chapter",
+							SpawnedBy:   dynamicFanoutSpawnedByWorkstation,
+						},
+					},
+				},
+				Outputs: []interfaces.IOConfig{
+					{StateName: "complete", WorkTypeName: "chapter"},
+				},
+			},
+		},
+	}
+}
+
+func assertDynamicFanoutTransition(t *testing.T, outputNet *state.Net) {
+	t.Helper()
+
+	assertDynamicFanoutTopology(t, outputNet)
+
+	tr := outputNet.Transitions["chapter-complete"]
+	if tr == nil {
+		t.Fatal("expected transition 'chapter-complete' to exist")
+	}
+	if len(tr.InputArcs) != 3 {
+		t.Fatalf("expected 3 input arcs, got %d", len(tr.InputArcs))
+	}
+	assertDynamicFanoutParentArc(t, tr.InputArcs[0])
+	assertDynamicFanoutCountArc(t, tr.InputArcs[1])
+	assertDynamicFanoutChildArc(t, tr.InputArcs[2])
+	assertDynamicFanoutSpawnedBy(t, outputNet)
+}
+
+func assertDynamicFanoutTopology(t *testing.T, outputNet *state.Net) {
+	t.Helper()
+
+	if outputNet.Transitions[dynamicFanoutSpawnedByWorkstation] == nil {
+		t.Fatalf("expected transition %q to exist for spawned-by fanout source", dynamicFanoutSpawnedByWorkstation)
+	}
+}
+
+func assertDynamicFanoutSpawnedBy(t *testing.T, outputNet *state.Net) {
+	t.Helper()
+
+	if outputNet.FanoutGroups == nil {
+		t.Fatal("expected FanoutGroups to be set for spawned-by fanout tracking")
+	}
+	countPlaceID, ok := outputNet.FanoutGroups[dynamicFanoutSpawnedByWorkstation]
+	if !ok {
+		t.Fatalf("expected FanoutGroups to include spawned-by workstation %q", dynamicFanoutSpawnedByWorkstation)
+	}
+	expectedCountPlaceID := dynamicFanoutSpawnedByWorkstation + ":fanout-count"
+	if countPlaceID != expectedCountPlaceID {
+		t.Errorf("FanoutGroups[%q]: expected %q, got %q", dynamicFanoutSpawnedByWorkstation, expectedCountPlaceID, countPlaceID)
+	}
+	if outputNet.Places[expectedCountPlaceID] == nil {
+		t.Fatalf("expected fanout count place %q to exist for spawned-by workstation %q", expectedCountPlaceID, dynamicFanoutSpawnedByWorkstation)
+	}
+}
+
+func assertDynamicFanoutParentArc(t *testing.T, parentArc petri.Arc) {
+	t.Helper()
+
+	if parentArc.Name != "parent" {
+		t.Errorf("arc[0] name: expected 'parent', got %q", parentArc.Name)
+	}
+	if parentArc.PlaceID != "chapter:processing" {
+		t.Errorf("arc[0] place: expected 'chapter:processing', got %q", parentArc.PlaceID)
+	}
+}
+
+func assertDynamicFanoutCountArc(t *testing.T, countArc petri.Arc) {
+	t.Helper()
+
+	if countArc.Name != "fanout-count" {
+		t.Errorf("arc[1] name: expected 'fanout-count', got %q", countArc.Name)
+	}
+	expectedCountPlaceID := dynamicFanoutSpawnedByWorkstation + ":fanout-count"
+	if countArc.PlaceID != expectedCountPlaceID {
+		t.Errorf("arc[1] place: expected %q, got %q", expectedCountPlaceID, countArc.PlaceID)
+	}
+	if countArc.Mode != interfaces.ArcModeConsume {
+		t.Errorf("arc[1] mode: expected CONSUME, got %d", countArc.Mode)
+	}
+
+	matchGuard, ok := countArc.Guard.(*petri.MatchColorGuard)
+	if !ok {
+		t.Fatalf("arc[1] guard: expected MatchColorGuard, got %T", countArc.Guard)
+	}
+	if matchGuard.Field != "parent_id" {
+		t.Errorf("spawned-by count guard field: expected 'parent_id', got %q", matchGuard.Field)
+	}
+	if matchGuard.MatchBinding != "parent" {
+		t.Errorf("spawned-by count guard match binding: expected 'parent', got %q", matchGuard.MatchBinding)
+	}
+	if matchGuard.MatchField != "work_id" {
+		t.Errorf("spawned-by count guard match field: expected 'work_id', got %q", matchGuard.MatchField)
+	}
+}
+
+func assertDynamicFanoutChildArc(t *testing.T, childArc petri.Arc) {
+	t.Helper()
+
+	if childArc.PlaceID != "page:complete" {
+		t.Errorf("arc[2] place: expected 'page:complete', got %q", childArc.PlaceID)
+	}
+	if childArc.Mode != interfaces.ArcModeObserve {
+		t.Errorf("arc[2] mode: expected OBSERVE, got %d", childArc.Mode)
+	}
+	if childArc.Cardinality.Mode != petri.CardinalityZeroOrMore {
+		t.Errorf("arc[2] cardinality: expected ZERO_OR_MORE, got %d", childArc.Cardinality.Mode)
+	}
+	fcGuard, ok := childArc.Guard.(*petri.FanoutCountGuard)
+	if !ok {
+		t.Fatalf("arc[2] guard: expected FanoutCountGuard, got %T", childArc.Guard)
+	}
+	if fcGuard.MatchBinding != "parent" {
+		t.Errorf("fanout guard match binding: expected 'parent', got %q", fcGuard.MatchBinding)
+	}
+	if fcGuard.CountBinding != "fanout-count" {
+		t.Errorf("fanout guard count binding: expected 'fanout-count', got %q", fcGuard.CountBinding)
+	}
+}

--- a/pkg/config/maptests/config_mapper_input_guards_static_test.go
+++ b/pkg/config/maptests/config_mapper_input_guards_static_test.go
@@ -1,0 +1,102 @@
+package maptests
+
+import (
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/factory/state"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/petri"
+)
+
+func staticAllChildrenCompleteFactoryConfig() *interfaces.FactoryConfig {
+	return &interfaces.FactoryConfig{
+		WorkTypes: []interfaces.WorkTypeConfig{
+			{
+				Name: "request",
+				States: []interfaces.StateConfig{
+					{Name: "init", Type: interfaces.StateTypeInitial},
+					{Name: "waiting", Type: interfaces.StateTypeProcessing},
+					{Name: "complete", Type: interfaces.StateTypeTerminal},
+				},
+			},
+			{
+				Name: "page",
+				States: []interfaces.StateConfig{
+					{Name: "init", Type: interfaces.StateTypeInitial},
+					{Name: "complete", Type: interfaces.StateTypeTerminal},
+				},
+			},
+		},
+		Workers: []interfaces.WorkerConfig{
+			{Name: "collect-worker"},
+		},
+		Workstations: []interfaces.FactoryWorkstationConfig{
+			{
+				Name:           "collector",
+				WorkerTypeName: "collect-worker",
+				Inputs: []interfaces.IOConfig{
+					{StateName: "waiting", WorkTypeName: "request"},
+					{
+						StateName:    "complete",
+						WorkTypeName: "page",
+						Guard: &interfaces.InputGuardConfig{
+							Type:        interfaces.GuardTypeAllChildrenComplete,
+							ParentInput: "request",
+						},
+					},
+				},
+				Outputs: []interfaces.IOConfig{
+					{StateName: "complete", WorkTypeName: "request"},
+				},
+			},
+		},
+	}
+}
+
+func assertStaticAllChildrenCompleteCollector(t *testing.T, outputNet *state.Net) {
+	t.Helper()
+
+	collector := outputNet.Transitions["collector"]
+	if collector == nil {
+		t.Fatal("expected transition 'collector' to exist")
+	}
+	if len(collector.InputArcs) != 2 {
+		t.Fatalf("expected 2 input arcs on collector, got %d", len(collector.InputArcs))
+	}
+
+	assertStaticAllChildrenCompleteParentArc(t, collector.InputArcs[0])
+	assertStaticAllChildrenCompleteChildArc(t, collector.InputArcs[1])
+}
+
+func assertStaticAllChildrenCompleteParentArc(t *testing.T, parentArc petri.Arc) {
+	t.Helper()
+
+	if parentArc.Name != "parent" {
+		t.Errorf("first input arc name: expected 'parent', got %q", parentArc.Name)
+	}
+	if parentArc.PlaceID != "request:waiting" {
+		t.Errorf("parent arc place: expected 'request:waiting', got %q", parentArc.PlaceID)
+	}
+}
+
+func assertStaticAllChildrenCompleteChildArc(t *testing.T, childArc petri.Arc) {
+	t.Helper()
+
+	if childArc.PlaceID != "page:complete" {
+		t.Errorf("child arc place: expected 'page:complete', got %q", childArc.PlaceID)
+	}
+	if childArc.Mode != interfaces.ArcModeObserve {
+		t.Errorf("child arc mode: expected OBSERVE, got %d", childArc.Mode)
+	}
+	if childArc.Cardinality.Mode != petri.CardinalityAll {
+		t.Errorf("child arc cardinality: expected ALL, got %d", childArc.Cardinality.Mode)
+	}
+
+	guard, ok := childArc.Guard.(*petri.AllWithParentGuard)
+	if !ok {
+		t.Fatalf("expected AllWithParentGuard on child arc, got %T", childArc.Guard)
+	}
+	if guard.MatchBinding != "parent" {
+		t.Errorf("guard match binding: expected 'parent', got %q", guard.MatchBinding)
+	}
+}

--- a/pkg/config/maptests/config_mapper_input_guards_test.go
+++ b/pkg/config/maptests/config_mapper_input_guards_test.go
@@ -32,79 +32,13 @@ func TestConfigMapping_PerInputGuard_DynamicFanout(t *testing.T) {
 }
 
 func TestConfigMapping_PerInputGuard_AnyChildFailed(t *testing.T) {
-	input := &interfaces.FactoryConfig{
-		WorkTypes: []interfaces.WorkTypeConfig{
-			{
-				Name: "request",
-				States: []interfaces.StateConfig{
-					{Name: "init", Type: interfaces.StateTypeInitial},
-					{Name: "waiting", Type: interfaces.StateTypeProcessing},
-					{Name: "failed", Type: interfaces.StateTypeFailed},
-				},
-			},
-			{
-				Name: "page",
-				States: []interfaces.StateConfig{
-					{Name: "init", Type: interfaces.StateTypeInitial},
-					{Name: "failed", Type: interfaces.StateTypeFailed},
-				},
-			},
-		},
-		Workers: []interfaces.WorkerConfig{
-			{Name: "check-worker"},
-		},
-		Workstations: []interfaces.FactoryWorkstationConfig{
-			{
-				Name:           "failure-checker",
-				WorkerTypeName: "check-worker",
-				Inputs: []interfaces.IOConfig{
-					{StateName: "waiting", WorkTypeName: "request"},
-					{
-						StateName:    "failed",
-						WorkTypeName: "page",
-						Guard: &interfaces.InputGuardConfig{
-							Type:        interfaces.GuardTypeAnyChildFailed,
-							ParentInput: "request",
-						},
-					},
-				},
-				Outputs: []interfaces.IOConfig{
-					{StateName: "failed", WorkTypeName: "request"},
-				},
-			},
-		},
-	}
-
 	mapper := testConfigMapper{}
-	outputNet, err := mapper.Map(context.Background(), input)
+	outputNet, err := mapper.Map(context.Background(), anyChildFailedFactoryConfig())
 	if err != nil {
 		t.Fatalf("failed to map config: %v", err)
 	}
 
-	tr := outputNet.Transitions["failure-checker"]
-	if tr == nil {
-		t.Fatal("expected transition 'failure-checker' to exist")
-	}
-
-	if len(tr.InputArcs) != 2 {
-		t.Fatalf("expected 2 input arcs, got %d", len(tr.InputArcs))
-	}
-
-	childArc := tr.InputArcs[1]
-	if childArc.Mode != interfaces.ArcModeObserve {
-		t.Errorf("child arc mode: expected OBSERVE, got %d", childArc.Mode)
-	}
-	if childArc.Cardinality.Mode != petri.CardinalityOne {
-		t.Errorf("child arc cardinality: expected ONE, got %d", childArc.Cardinality.Mode)
-	}
-
-	guard, ok := childArc.Guard.(*petri.AnyWithParentGuard)
-	if !ok {
-		t.Fatalf("expected AnyWithParentGuard, got %T", childArc.Guard)
-	}
-	if guard.MatchBinding != "parent" {
-		t.Errorf("guard match binding: expected 'parent', got %q", guard.MatchBinding)
-	}
+	assertAnyChildFailedFailureChecker(t, outputNet)
 }
 
 func TestConfigMapping_PerInputGuard_ValidationRejectsMissingParentInput(t *testing.T) {

--- a/pkg/config/maptests/config_mapper_input_guards_test.go
+++ b/pkg/config/maptests/config_mapper_input_guards_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/portpowered/infinite-you/pkg/factory/state"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/petri"
 )
@@ -22,65 +21,9 @@ func TestConfigMapping_PerInputGuard_StaticAllChildrenComplete(t *testing.T) {
 	assertStaticAllChildrenCompleteCollector(t, outputNet)
 }
 
-// portos:func-length-exception owner=agent-factory reason=legacy-input-guard-fixture review=2026-07-18 removal=split-dynamic-guard-fixture-before-next-input-guard-change
 func TestConfigMapping_PerInputGuard_DynamicFanout(t *testing.T) {
-	input := &interfaces.FactoryConfig{
-		WorkTypes: []interfaces.WorkTypeConfig{
-			{
-				Name: "chapter",
-				States: []interfaces.StateConfig{
-					{Name: "init", Type: interfaces.StateTypeInitial},
-					{Name: "processing", Type: interfaces.StateTypeProcessing},
-					{Name: "complete", Type: interfaces.StateTypeTerminal},
-				},
-			},
-			{
-				Name: "page",
-				States: []interfaces.StateConfig{
-					{Name: "init", Type: interfaces.StateTypeInitial},
-					{Name: "complete", Type: interfaces.StateTypeTerminal},
-				},
-			},
-		},
-		Workers: []interfaces.WorkerConfig{
-			{Name: "parse-worker"},
-			{Name: "complete-worker"},
-		},
-		Workstations: []interfaces.FactoryWorkstationConfig{
-			{
-				Name:           "parser",
-				WorkerTypeName: "parse-worker",
-				Inputs: []interfaces.IOConfig{
-					{StateName: "init", WorkTypeName: "chapter"},
-				},
-				Outputs: []interfaces.IOConfig{
-					{StateName: "processing", WorkTypeName: "chapter"},
-				},
-			},
-			{
-				Name:           "chapter-complete",
-				WorkerTypeName: "complete-worker",
-				Inputs: []interfaces.IOConfig{
-					{StateName: "processing", WorkTypeName: "chapter"},
-					{
-						StateName:    "complete",
-						WorkTypeName: "page",
-						Guard: &interfaces.InputGuardConfig{
-							Type:        interfaces.GuardTypeAllChildrenComplete,
-							ParentInput: "chapter",
-							SpawnedBy:   "parser",
-						},
-					},
-				},
-				Outputs: []interfaces.IOConfig{
-					{StateName: "complete", WorkTypeName: "chapter"},
-				},
-			},
-		},
-	}
-
 	mapper := testConfigMapper{}
-	outputNet, err := mapper.Map(context.Background(), input)
+	outputNet, err := mapper.Map(context.Background(), dynamicFanoutFactoryConfig())
 	if err != nil {
 		t.Fatalf("failed to map config: %v", err)
 	}
@@ -840,76 +783,3 @@ func TestConfigMapping_PerInputGuard_SameTraceIDBuildsConsumeGuardAgainstPeerInp
 	}
 }
 
-func assertDynamicFanoutTransition(t *testing.T, outputNet *state.Net) {
-	t.Helper()
-
-	tr := outputNet.Transitions["chapter-complete"]
-	if tr == nil {
-		t.Fatal("expected transition 'chapter-complete' to exist")
-	}
-	if len(tr.InputArcs) != 3 {
-		t.Fatalf("expected 3 input arcs, got %d", len(tr.InputArcs))
-	}
-	assertDynamicFanoutParentArc(t, tr.InputArcs[0])
-	assertDynamicFanoutCountArc(t, tr.InputArcs[1])
-	assertDynamicFanoutChildArc(t, tr.InputArcs[2])
-
-	if outputNet.FanoutGroups == nil {
-		t.Fatal("expected FanoutGroups to be set")
-	}
-	if outputNet.FanoutGroups["parser"] != "parser:fanout-count" {
-		t.Errorf("FanoutGroups[parser]: expected 'parser:fanout-count', got %q", outputNet.FanoutGroups["parser"])
-	}
-}
-
-func assertDynamicFanoutParentArc(t *testing.T, parentArc petri.Arc) {
-	t.Helper()
-
-	if parentArc.Name != "parent" {
-		t.Errorf("arc[0] name: expected 'parent', got %q", parentArc.Name)
-	}
-	if parentArc.PlaceID != "chapter:processing" {
-		t.Errorf("arc[0] place: expected 'chapter:processing', got %q", parentArc.PlaceID)
-	}
-}
-
-func assertDynamicFanoutCountArc(t *testing.T, countArc petri.Arc) {
-	t.Helper()
-
-	if countArc.Name != "fanout-count" {
-		t.Errorf("arc[1] name: expected 'fanout-count', got %q", countArc.Name)
-	}
-	if countArc.PlaceID != "parser:fanout-count" {
-		t.Errorf("arc[1] place: expected 'parser:fanout-count', got %q", countArc.PlaceID)
-	}
-	if countArc.Mode != interfaces.ArcModeConsume {
-		t.Errorf("arc[1] mode: expected CONSUME, got %d", countArc.Mode)
-	}
-	if _, ok := countArc.Guard.(*petri.MatchColorGuard); !ok {
-		t.Fatalf("arc[1] guard: expected MatchColorGuard, got %T", countArc.Guard)
-	}
-}
-
-func assertDynamicFanoutChildArc(t *testing.T, childArc petri.Arc) {
-	t.Helper()
-
-	if childArc.PlaceID != "page:complete" {
-		t.Errorf("arc[2] place: expected 'page:complete', got %q", childArc.PlaceID)
-	}
-	if childArc.Mode != interfaces.ArcModeObserve {
-		t.Errorf("arc[2] mode: expected OBSERVE, got %d", childArc.Mode)
-	}
-	if childArc.Cardinality.Mode != petri.CardinalityZeroOrMore {
-		t.Errorf("arc[2] cardinality: expected ZERO_OR_MORE, got %d", childArc.Cardinality.Mode)
-	}
-	fcGuard, ok := childArc.Guard.(*petri.FanoutCountGuard)
-	if !ok {
-		t.Fatalf("arc[2] guard: expected FanoutCountGuard, got %T", childArc.Guard)
-	}
-	if fcGuard.MatchBinding != "parent" {
-		t.Errorf("fanout guard match binding: expected 'parent', got %q", fcGuard.MatchBinding)
-	}
-	if fcGuard.CountBinding != "fanout-count" {
-		t.Errorf("fanout guard count binding: expected 'fanout-count', got %q", fcGuard.CountBinding)
-	}
-}

--- a/pkg/config/maptests/config_mapper_input_guards_test.go
+++ b/pkg/config/maptests/config_mapper_input_guards_test.go
@@ -12,95 +12,14 @@ import (
 
 // --- per-input guard tests ---
 
-// portos:func-length-exception owner=agent-factory reason=legacy-input-guard-fixture review=2026-07-18 removal=split-static-guard-fixture-before-next-input-guard-change
 func TestConfigMapping_PerInputGuard_StaticAllChildrenComplete(t *testing.T) {
-	input := &interfaces.FactoryConfig{
-		WorkTypes: []interfaces.WorkTypeConfig{
-			{
-				Name: "request",
-				States: []interfaces.StateConfig{
-					{Name: "init", Type: interfaces.StateTypeInitial},
-					{Name: "waiting", Type: interfaces.StateTypeProcessing},
-					{Name: "complete", Type: interfaces.StateTypeTerminal},
-				},
-			},
-			{
-				Name: "page",
-				States: []interfaces.StateConfig{
-					{Name: "init", Type: interfaces.StateTypeInitial},
-					{Name: "complete", Type: interfaces.StateTypeTerminal},
-				},
-			},
-		},
-		Workers: []interfaces.WorkerConfig{
-			{Name: "collect-worker"},
-		},
-		Workstations: []interfaces.FactoryWorkstationConfig{
-			{
-				Name:           "collector",
-				WorkerTypeName: "collect-worker",
-				Inputs: []interfaces.IOConfig{
-					{StateName: "waiting", WorkTypeName: "request"},
-					{
-						StateName:    "complete",
-						WorkTypeName: "page",
-						Guard: &interfaces.InputGuardConfig{
-							Type:        interfaces.GuardTypeAllChildrenComplete,
-							ParentInput: "request",
-						},
-					},
-				},
-				Outputs: []interfaces.IOConfig{
-					{StateName: "complete", WorkTypeName: "request"},
-				},
-			},
-		},
-	}
-
 	mapper := testConfigMapper{}
-	outputNet, err := mapper.Map(context.Background(), input)
+	outputNet, err := mapper.Map(context.Background(), staticAllChildrenCompleteFactoryConfig())
 	if err != nil {
 		t.Fatalf("failed to map config: %v", err)
 	}
 
-	collector := outputNet.Transitions["collector"]
-	if collector == nil {
-		t.Fatal("expected transition 'collector' to exist")
-	}
-
-	// Should have 2 input arcs: parent consume + child observe.
-	if len(collector.InputArcs) != 2 {
-		t.Fatalf("expected 2 input arcs on collector, got %d", len(collector.InputArcs))
-	}
-
-	// First arc: parent consume with named binding "parent".
-	parentArc := collector.InputArcs[0]
-	if parentArc.Name != "parent" {
-		t.Errorf("first input arc name: expected 'parent', got %q", parentArc.Name)
-	}
-	if parentArc.PlaceID != "request:waiting" {
-		t.Errorf("parent arc place: expected 'request:waiting', got %q", parentArc.PlaceID)
-	}
-
-	// Second arc: child observation with AllWithParentGuard.
-	childArc := collector.InputArcs[1]
-	if childArc.PlaceID != "page:complete" {
-		t.Errorf("child arc place: expected 'page:complete', got %q", childArc.PlaceID)
-	}
-	if childArc.Mode != interfaces.ArcModeObserve {
-		t.Errorf("child arc mode: expected OBSERVE, got %d", childArc.Mode)
-	}
-	if childArc.Cardinality.Mode != petri.CardinalityAll {
-		t.Errorf("child arc cardinality: expected ALL, got %d", childArc.Cardinality.Mode)
-	}
-
-	guard, ok := childArc.Guard.(*petri.AllWithParentGuard)
-	if !ok {
-		t.Fatalf("expected AllWithParentGuard on child arc, got %T", childArc.Guard)
-	}
-	if guard.MatchBinding != "parent" {
-		t.Errorf("guard match binding: expected 'parent', got %q", guard.MatchBinding)
-	}
+	assertStaticAllChildrenCompleteCollector(t, outputNet)
 }
 
 // portos:func-length-exception owner=agent-factory reason=legacy-input-guard-fixture review=2026-07-18 removal=split-dynamic-guard-fixture-before-next-input-guard-change


### PR DESCRIPTION
{
  "project": "Remove Input Guard Mapper Fixture Exceptions",
  "branchName": "cleanup-config-maptests-input-guard-portos-exceptions",
  "description": "Refactor the input-guard mapper tests so the static all-children-complete and dynamic fanout cases no longer require dated portos function-length exception comments, while preserving guard arc, binding, cardinality, spawned-by, and any-child-failed regression coverage.",
  "context": {
    "customerAsk": "Refactor pkg/config/maptests/config_mapper_input_guards_test.go so the static all-children-complete and dynamic fanout mapper tests no longer need portos:func-length-exception comments, while preserving the guard arc, binding, cardinality, and spawned-by behavior with focused go test proof.",
    "problem": "Two package-local input-guard mapper tests still carry dated portos:func-length-exception comments because their fixtures are too large, making the tests harder to maintain and leaving a temporary exception in place around important guard behavior coverage.",
    "solution": "Reshape the affected package-local test fixtures and assertions into focused, readable test code that removes the two exceptions while preserving the same observable mapper outcomes and proving them with the requested focused Go test command."
  },
  "acceptanceCriteria": [
    "The static all-children-complete input-guard mapper test no longer contains or requires a portos:func-length-exception comment.",
    "The dynamic fanout input-guard mapper test no longer contains or requires a portos:func-length-exception comment.",
    "Static all-children-complete behavior still proves the collector transition consumes the parent input, observes completed child work, uses all-child cardinality, and binds the child guard to the parent input.",
    "Dynamic fanout behavior still proves the chapter completion transition preserves guard arc behavior, parent binding, all-child cardinality, and spawned-by-specific matching.",
    "The existing any-child-failed input-guard regression remains covered by the focused command and continues to prove observe mode, one-child cardinality, and parent-bound failure guarding.",
    "Scope stays limited to this package-local test cleanup and does not change mapper production behavior, OpenAPI contracts, CLI behavior, UI behavior, docs, or generated files.",
    "Quality gate: typecheck, lint, and focused tests pass, including go test ./pkg/config/maptests -run 'TestConfigMapping_PerInputGuard_(StaticAllChildrenComplete|DynamicFanout|AnyChildFailed)' -count=1."
  ],
  "userStories": [
    {
      "id": "cleanup-config-maptests-input-guard-portos-exceptions-001",
      "title": "Preserve Static All-Children-Complete Guard Coverage Without an Exception",
      "description": "As a backend maintainer, I want the static all-children-complete mapper regression to remain clear and focused so that future guard changes can be reviewed without dated function-length exceptions.",
      "acceptanceCriteria": [
        "The static all-children-complete test no longer has a portos:func-length-exception comment.",
        "The static case still maps a collector transition with exactly two input arcs: a consumed parent request in request:waiting and an observed completed page in page:complete.",
        "The observed child arc still uses interfaces.ArcModeObserve, petri.CardinalityAll, and a petri.AllWithParentGuard whose match binding is parent.",
        "The parent arc still uses the binding name parent.",
        "Typecheck passes.",
        "Tests pass with go test ./pkg/config/maptests -run 'TestConfigMapping_PerInputGuard_(StaticAllChildrenComplete|DynamicFanout|AnyChildFailed)' -count=1."
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "cleanup-config-maptests-input-guard-portos-exceptions-002",
      "title": "Preserve Dynamic Fanout Spawned-By Guard Coverage Without an Exception",
      "description": "As a backend maintainer, I want the dynamic fanout mapper regression to remain clear and focused so that spawned-by guard behavior is protected without relying on a function-length exception.",
      "acceptanceCriteria": [
        "The dynamic fanout test no longer has a portos:func-length-exception comment.",
        "The dynamic case still maps the parser and chapter completion topology used to prove spawned-by matching from parser-created child work.",
        "The chapter completion transition still preserves parent binding, observed completed page input, all-child cardinality, and all-with-parent guard behavior.",
        "The dynamic spawned-by assertion remains reviewer-visible through direct test expectations, not only through fixture construction.",
        "Typecheck passes.",
        "Tests pass with go test ./pkg/config/maptests -run 'TestConfigMapping_PerInputGuard_(StaticAllChildrenComplete|DynamicFanout|AnyChildFailed)' -count=1."
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "cleanup-config-maptests-input-guard-portos-exceptions-003",
      "title": "Keep Any-Child-Failed Regression in the Focused Proof",
      "description": "As a backend maintainer, I want the existing any-child-failed regression to remain part of the same focused proof so that cleanup of neighboring fixtures does not accidentally weaken failure-guard coverage.",
      "acceptanceCriteria": [
        "The any-child-failed test remains runnable by the requested focused test command.",
        "The failure-checker transition still has exactly two input arcs and observes the failed child page input.",
        "The observed failure child arc still uses interfaces.ArcModeObserve, petri.CardinalityOne, and a petri.AnyWithParentGuard whose match binding is parent.",
        "Typecheck passes.",
        "Tests pass with go test ./pkg/config/maptests -run 'TestConfigMapping_PerInputGuard_(StaticAllChildrenComplete|DynamicFanout|AnyChildFailed)' -count=1."
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)