### PR TITLE
cleanup-replay-submission-hook-assertion-exception

### DIFF
--- a/pkg/replay/delivery_test.go
+++ b/pkg/replay/delivery_test.go
@@ -44,20 +44,13 @@ func TestSubmissionHook_ReplaysWorkRequestEventsByTick(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OnTick before due tick: %v", err)
 	}
-	if len(before.GeneratedBatches) != 0 {
-		t.Fatalf("generated batches before due tick = %d, want 0", len(before.GeneratedBatches))
-	}
-	if !before.KeepAlive {
-		t.Fatal("before due tick KeepAlive = false, want true while future submissions remain")
-	}
+	assertSubmissionHookBeforeDueTick(t, before)
 
 	due, err := hook.OnTick(context.Background(), replaySubmissionHookContext(2))
 	if err != nil {
 		t.Fatalf("OnTick at due tick: %v", err)
 	}
-	if len(due.GeneratedBatches) != 1 {
-		t.Fatalf("generated batches at due tick = %d, want 1", len(due.GeneratedBatches))
-	}
+	assertSubmissionHookDueTickBatchCount(t, due, 1)
 	batch := due.GeneratedBatches[0]
 	if batch.Request.RequestID != "request-1" {
 		t.Fatalf("replayed request ID = %q, want request-1", batch.Request.RequestID)
@@ -74,8 +67,30 @@ func TestSubmissionHook_ReplaysWorkRequestEventsByTick(t *testing.T) {
 	if len(batch.Request.Relations) != 1 || batch.Request.Relations[0].SourceWorkName != "work-2" || batch.Request.Relations[0].TargetWorkName != "work-1" {
 		t.Fatalf("replayed relations = %#v, want work-2 depends on work-1", batch.Request.Relations)
 	}
-	if due.KeepAlive {
-		t.Fatal("due tick KeepAlive = true, want false after last submission is emitted")
+	assertSubmissionHookFinalKeepAliveShutdown(t, due)
+}
+
+func assertSubmissionHookBeforeDueTick(t *testing.T, got interfaces.SubmissionHookResult) {
+	t.Helper()
+	if len(got.GeneratedBatches) != 0 {
+		t.Fatalf("before-due batch count = %d, want 0", len(got.GeneratedBatches))
+	}
+	if !got.KeepAlive {
+		t.Fatal("before-due keep-alive = false, want true while future submissions remain")
+	}
+}
+
+func assertSubmissionHookDueTickBatchCount(t *testing.T, got interfaces.SubmissionHookResult, want int) {
+	t.Helper()
+	if len(got.GeneratedBatches) != want {
+		t.Fatalf("due-tick batch count = %d, want %d", len(got.GeneratedBatches), want)
+	}
+}
+
+func assertSubmissionHookFinalKeepAliveShutdown(t *testing.T, got interfaces.SubmissionHookResult) {
+	t.Helper()
+	if got.KeepAlive {
+		t.Fatal("final keep-alive shutdown = true, want false after last submission is emitted")
 	}
 }
 

--- a/pkg/replay/delivery_test.go
+++ b/pkg/replay/delivery_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/portpowered/infinite-you/pkg/workers"
 )
 
-// pkgmaintcheck:ignore-cyclomatic-complexity this replay hook test keeps the tick-ordered work request event contract readable in one end-to-end flow.
 func TestSubmissionHook_ReplaysWorkRequestEventsByTick(t *testing.T) {
 	hook, err := NewSubmissionHook(testReplayArtifact(t, replayWorkRequestEvent(t, "request-1", 2, "api", []factoryapi.Work{{
 		Name:         "work-1",

--- a/pkg/replay/delivery_test.go
+++ b/pkg/replay/delivery_test.go
@@ -52,21 +52,11 @@ func TestSubmissionHook_ReplaysWorkRequestEventsByTick(t *testing.T) {
 	}
 	assertSubmissionHookDueTickBatchCount(t, due, 1)
 	batch := due.GeneratedBatches[0]
-	if batch.Request.RequestID != "request-1" {
-		t.Fatalf("replayed request ID = %q, want request-1", batch.Request.RequestID)
-	}
-	if len(batch.Request.Works) != 2 {
-		t.Fatalf("replayed batch works = %d, want 2", len(batch.Request.Works))
-	}
-	if batch.Request.Works[0].WorkID != "work-1" || batch.Metadata.Source != "api" {
-		t.Fatalf("replayed generated batch = %#v, want work-1 from api", batch)
-	}
-	if got := batch.Request.Works[0].Content; len(got) != 2 || got[0].Text != "alpha" || got[1].URL != "file://fixtures/alpha.png" {
-		t.Fatalf("replayed content = %#v, want ordered text and image parts", got)
-	}
-	if len(batch.Request.Relations) != 1 || batch.Request.Relations[0].SourceWorkName != "work-2" || batch.Request.Relations[0].TargetWorkName != "work-1" {
-		t.Fatalf("replayed relations = %#v, want work-2 depends on work-1", batch.Request.Relations)
-	}
+	assertSubmissionHookReplayedRequestID(t, batch, "request-1")
+	assertSubmissionHookReplayedSourceMetadata(t, batch, "api")
+	assertSubmissionHookReplayedGeneratedWorkCount(t, batch, 2, "work-1")
+	assertSubmissionHookReplayedOrderedContent(t, batch.Request.Works[0], "alpha", "file://fixtures/alpha.png")
+	assertSubmissionHookReplayedDependencyRelation(t, batch, "work-2", "work-1")
 	assertSubmissionHookFinalKeepAliveShutdown(t, due)
 }
 
@@ -91,6 +81,56 @@ func assertSubmissionHookFinalKeepAliveShutdown(t *testing.T, got interfaces.Sub
 	t.Helper()
 	if got.KeepAlive {
 		t.Fatal("final keep-alive shutdown = true, want false after last submission is emitted")
+	}
+}
+
+func assertSubmissionHookReplayedRequestID(t *testing.T, batch interfaces.GeneratedSubmissionBatch, want string) {
+	t.Helper()
+	if batch.Request.RequestID != want {
+		t.Fatalf("replayed request ID = %q, want %q", batch.Request.RequestID, want)
+	}
+}
+
+func assertSubmissionHookReplayedSourceMetadata(t *testing.T, batch interfaces.GeneratedSubmissionBatch, want string) {
+	t.Helper()
+	if batch.Metadata.Source != want {
+		t.Fatalf("replayed source metadata = %q, want %q", batch.Metadata.Source, want)
+	}
+}
+
+func assertSubmissionHookReplayedGeneratedWorkCount(t *testing.T, batch interfaces.GeneratedSubmissionBatch, wantCount int, firstWorkID string) {
+	t.Helper()
+	if len(batch.Request.Works) != wantCount {
+		t.Fatalf("replayed generated work count = %d, want %d", len(batch.Request.Works), wantCount)
+	}
+	if batch.Request.Works[0].WorkID != firstWorkID {
+		t.Fatalf("replayed first work ID = %q, want %q", batch.Request.Works[0].WorkID, firstWorkID)
+	}
+}
+
+func assertSubmissionHookReplayedOrderedContent(t *testing.T, work interfaces.Work, wantText, wantImageURL string) {
+	t.Helper()
+	got := work.Content
+	if len(got) != 2 {
+		t.Fatalf("replayed content part count = %d, want 2", len(got))
+	}
+	if got[0].Text != wantText {
+		t.Fatalf("replayed first content text = %q, want %q", got[0].Text, wantText)
+	}
+	if got[1].URL != wantImageURL {
+		t.Fatalf("replayed second content image URL = %q, want %q", got[1].URL, wantImageURL)
+	}
+}
+
+func assertSubmissionHookReplayedDependencyRelation(t *testing.T, batch interfaces.GeneratedSubmissionBatch, sourceWork, targetWork string) {
+	t.Helper()
+	if len(batch.Request.Relations) != 1 {
+		t.Fatalf("replayed relation count = %d, want 1", len(batch.Request.Relations))
+	}
+	relation := batch.Request.Relations[0]
+	if relation.SourceWorkName != sourceWork || relation.TargetWorkName != targetWork {
+		t.Fatalf("replayed dependency relation = %q -> %q, want %q -> %q (source depends on target)",
+			relation.SourceWorkName, relation.TargetWorkName, sourceWork, targetWork)
 	}
 }
 


### PR DESCRIPTION
{
  "project": "you-agent-factory",
  "branchName": "cleanup-replay-submission-hook-assertion-exception",
  "description": "Remove the pkgmaint cyclomatic-complexity exception from the replay submission-hook work-request replay regression while preserving observable coverage for tick-gated emission, request identity, source metadata, generated work count, ordered content, dependency relation direction, and keep-alive shutdown.",
  "context": {
    "customerAsk": "Remove the pkgmaintcheck cyclomatic-complexity directive above TestSubmissionHook_ReplaysWorkRequestEventsByTick in pkg/replay/delivery_test.go because the test body can stay below the maintained complexity threshold after extracting setup and assertion helpers. Preserve explicit checks for before-due keep-alive, due-tick batch emission, canonical content ordering, dependency relation preservation, source metadata, request ID, generated work count, and final keep-alive shutdown.",
    "problem": "The replay submission-hook test protects a useful work-request replay regression but keeps a maintainer-check exception in place. The inline assertion flow makes it harder for reviewers to identify failures for request identity, source metadata, generated work count, ordered content, dependency relation direction, or keep-alive state.",
    "solution": "Refactor the test-only replay submission-hook coverage into small setup and assertion helpers or subtests that keep each observable replay behavior explicit. Remove the targeted pkgmaintcheck:ignore-cyclomatic-complexity directive and verify the exact replay regression plus the relevant package-maintenance check. Do not change replay delivery production behavior."
  },
  "acceptanceCriteria": [
    "The pkgmaintcheck:ignore-cyclomatic-complexity directive above TestSubmissionHook_ReplaysWorkRequestEventsByTick is removed from pkg/replay/delivery_test.go.",
    "The regression still proves the submission hook emits no generated batches before the due tick and keeps itself alive while a future submission remains.",
    "The regression still proves the due tick emits exactly one generated batch with request ID request-1, source metadata api, and exactly two generated work items.",
    "The regression still proves the first work item preserves ordered text and image content, including text alpha followed by image URL file://fixtures/alpha.png.",
    "The regression still proves the dependency relation direction remains work-2 depends on work-1 and the final due tick returns KeepAlive=false.",
    "No replay delivery production behavior, API contract, CLI behavior, generated code, dashboard behavior, or unrelated tests change.",
    "Quality gate: typecheck, lint or narrow package-maintenance check, go test ./pkg/replay -run TestSubmissionHook_ReplaysWorkRequestEventsByTick -count=1, and the relevant maintainer check or narrow equivalent pass."
  ],
  "userStories": [
    {
      "id": "cleanup-replay-submission-hook-assertion-exception-001",
      "title": "Keep tick-gated submission behavior explicit",
      "description": "As a backend maintainer, I want replay submission-hook coverage to clearly prove before-due and due-tick behavior so replayed work requests are emitted only at the recorded tick.",
      "acceptanceCriteria": [
        "The regression still calls the submission hook before the due tick and verifies zero generated batches.",
        "The regression still verifies before-due KeepAlive=true while the recorded future submission has not been emitted.",
        "The regression still calls the submission hook at the due tick and verifies exactly one generated batch is emitted.",
        "The regression still verifies final due-tick KeepAlive=false after the last recorded submission is emitted.",
        "Failure messages identify whether the failed condition is before-due batch count, before-due keep-alive, due-tick batch count, or final keep-alive shutdown.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "cleanup-replay-submission-hook-assertion-exception-002",
      "title": "Preserve canonical replayed work-request payload assertions",
      "description": "As a backend maintainer, I want replayed work-request payload assertions to remain explicit so regressions in request identity, source metadata, generated work count, content ordering, or dependency direction fail clearly.",
      "acceptanceCriteria": [
        "The regression still verifies the emitted batch request ID is request-1.",
        "The regression still verifies the emitted batch source metadata is api.",
        "The regression still verifies the emitted batch contains exactly two generated work items and the first work item has work ID work-1.",
        "The regression still verifies the first work item content has exactly two ordered parts: text alpha, then image URL file://fixtures/alpha.png.",
        "The regression still verifies exactly one relation exists with source work work-2 and target work work-1.",
        "Failure messages identify wrong request ID, source metadata, generated work count, ordered text or image content, and dependency relation direction.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "cleanup-replay-submission-hook-assertion-exception-003",
      "title": "Remove the maintainer-check exception and verify the focused lane",
      "description": "As a reviewer, I want the replay submission-hook complexity exception removed and mechanically verified so cleanup debt decreases without weakening replay delivery coverage.",
      "acceptanceCriteria": [
        "pkg/replay/delivery_test.go no longer contains the pkgmaintcheck:ignore-cyclomatic-complexity directive above TestSubmissionHook_ReplaysWorkRequestEventsByTick.",
        "The implementation uses test-local setup or assertion structure only where it improves the observable replay assertions and failure output.",
        "No replay delivery production files are changed unless required to keep existing behavior compiling, and any such change is explicitly justified by the implementing agent.",
        "Focused verification runs go test ./pkg/replay -run TestSubmissionHook_ReplaysWorkRequestEventsByTick -count=1.",
        "make pkg-maint or the narrow equivalent go run ./cmd/pkgmaintcheck ./pkg/replay passes and proves the removed exception is no longer required.",
        "The implementation does not add meta-tests for helper names, file layout, command inventories, route registrations, or maintainer-check internals.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}

Made with [Cursor](https://cursor.com)