### PR TITLE
runtime-cleanup-search-artifact-hygiene

### DIFF
--- a/docs/internal/development/development.md
+++ b/docs/internal/development/development.md
@@ -551,6 +551,10 @@ behavior explicit inside the test that needs it.
 
 ## Local Gotchas
 
+- Runtime cleanup ownership searches should use the source-only command in
+  [Runtime Cleanup Relevant Files](../processes/runtime-cleanup-relevant-files.md)
+  so generated, dependency, coverage, and build artifacts do not become routine
+  source evidence.
 - Embedded dashboard builds are generated local artifacts. Rebuild `ui/dist/` with `make ui-build` or `make dashboard-verify` after dashboard source changes so Go picks up the refreshed embed registration.
 - Do not run `ui-build` in parallel with Go vet, build, or test commands; Vite rotates hashed files under `ui/dist/assets`.
 - Treat `factory.json` as a generated-schema boundary: normalize legacy key styles first, then decode through `pkg/api/generated.Factory` with unknown-field rejection enabled. Keep any compatibility exceptions explicit and narrow instead of falling back to permissive handwritten DTOs.

--- a/docs/internal/processes/runtime-cleanup-relevant-files.md
+++ b/docs/internal/processes/runtime-cleanup-relevant-files.md
@@ -1,10 +1,15 @@
 # Runtime Cleanup Relevant Files
 
-Use this map when changing runtime cleanup ownership, package placement, startup
-wiring, or documentation that tells maintainers where new runtime behavior
-belongs. Start with `docs/architecture/architecture.md`, especially the runtime
-startup path, Factory Session state ownership, target package-family ownership
-map, and migration-era surfaces sections.
+Use this map when changing or auditing runtime cleanup ownership, package
+placement, startup wiring, stale references, or documentation that tells
+maintainers where new runtime behavior belongs. Start with
+`docs/architecture/architecture.md`, especially the runtime startup path,
+Factory Session state ownership, target package-family ownership map, and
+migration-era surfaces sections.
+
+Routine ownership scans should search authored source roots only so ignored
+local artifacts and generated outputs do not look like source ownership
+evidence.
 
 ## Placement Decision Guide
 
@@ -29,6 +34,53 @@ When a change spans rows, place the durable state or policy in its owner and
 adapt outward. For example, a new session read that exposes JavaScript
 orchestrator progress should keep progress derivation in Factory Session or
 orchestrator owners, then map it through API, CLI, MCP, or UI boundaries.
+
+## Source-Only Search Hygiene
+
+Run the source-only search from the repository root:
+
+```bash
+rg -n \
+  --glob '!api/openapi.yaml' \
+  --glob '!pkg/api/generated/server.gen.go' \
+  --glob '!pkg/generatedclient/client.gen.go' \
+  --glob '!ui/src/api/generated/openapi.ts' \
+  --glob '!ui/coverage/**' \
+  --glob '!ui/**/node_modules/**' \
+  --glob '!**/dist/**' \
+  --glob '!storybook-static/**' \
+  --glob '!**/storybook-static/**' \
+  --glob '!ui/.vitest-reports/**' \
+  --glob '!ui/.vitest-report-timings/**' \
+  --glob '!*.tsbuildinfo' \
+  --glob '!**/*.tsbuildinfo' \
+  '<pattern>' \
+  api/openapi-main.yaml api/components cmd docs internal pkg scripts tests ui/src ui/packages/components/src
+```
+
+Do not add `--no-ignore` for routine cleanup ownership scans. If an audit must
+inspect ignored local output, run that as a separate artifact inspection and
+label the evidence as artifact-only.
+
+## Generated Artifact Evidence
+
+Routine cleanup ownership decisions must not use generated OpenAPI/client
+files, coverage reports, dependency installs, or build outputs as source
+ownership evidence. Treat the following generated contract files as excluded
+from routine ownership scans:
+
+- `api/openapi.yaml`
+- `pkg/api/generated/server.gen.go`
+- `pkg/generatedclient/client.gen.go`
+- `ui/src/api/generated/openapi.ts`
+
+Generated files are still valid evidence when the audit target is generated
+contract drift, API regeneration, or generated output consistency. In those
+audits, start from the authored contract source (`api/openapi-main.yaml` and
+`api/components/`), regenerate with `make generate-api`, and use `make api-smoke`
+or `make verify-build-contracts` to prove the generated files match the authored
+contract. Do not treat generated files as independent ownership sources outside
+that drift/regeneration context.
 
 ## Root Package Guardrails
 

--- a/docs/internal/processes/runtime-cleanup-relevant-files.md
+++ b/docs/internal/processes/runtime-cleanup-relevant-files.md
@@ -120,8 +120,10 @@ For runtime-cleanup documentation changes, run a changed-docs vocabulary check
 after review against `docs/architecture/data-model.md`:
 
 ```sh
-changed_docs="$(git diff --name-only --diff-filter=ACMRT origin/main...HEAD -- docs prd.md)"
-test -z "$changed_docs" || rg -n "DynamicWorkflowRun|\\b(Petri|petri|tokens?|places|transitions|markings?)\\b" $changed_docs
+git diff --name-only --diff-filter=ACMRT origin/main...HEAD -- docs prd.md |
+  while IFS= read -r changed_doc; do
+    rg -n "DynamicWorkflowRun|\\b(Petri|petri|tokens?|places|transitions|markings?)\\b" "$changed_doc"
+  done
 ```
 
 Inspect each hit. Accept hits only when they are guardrail text or explicitly


### PR DESCRIPTION
{
  "project": "Runtime Cleanup Search Artifact Hygiene",
  "branchName": "runtime-cleanup-search-artifact-hygiene",
  "description": "Document source-only cleanup scan guidance so runtime ownership audits deliberately exclude ignored/generated artifacts while still explaining when generated files must be inspected for contract drift.",
  "context": {
    "customerAsk": "Document scoped search and generated-artifact hygiene for cleanup audits. Maintainer docs should include recommended rg globs or commands for source-only ownership scans, generated/coverage/build/dependency artifacts should not be treated as source ownership evidence, and docs or checks should explain when generated files should still be inspected for contract drift.",
    "problem": "Repository-wide cleanup searches can include ignored local artifacts or tracked generated outputs such as ui/coverage, nested node_modules, dist output, and generated OpenAPI/client files. Those results can be mistaken for source ownership evidence during runtime cleanup audits.",
    "solution": "Add maintainer-facing guidance with a copy-pastable source-only rg command that searches authored roots and excludes artifact paths, document that generated and ignored artifacts are not routine ownership evidence, and preserve a clear exception for generated contract drift and regeneration audits."
  },
  "acceptanceCriteria": [
    "Maintainer guidance or this implementation plan includes a copy-pastable source-only rg command for cleanup ownership scans.",
    "Routine ownership scan guidance excludes generated, coverage, build, and dependency artifacts, including ui/coverage, ui/**/node_modules, **/dist, and generated OpenAPI/client files.",
    "Guidance states that generated files should still be inspected when the audit is specifically about generated contract drift, API regeneration, or generated output consistency.",
    "git ls-files ui/coverage ui/packages/components/node_modules reports no tracked files.",
    "No generated OpenAPI files, generated Go clients, generated TypeScript clients, generated bundles, runtime behavior, REST contract, CLI behavior, or UI behavior changes as part of this hygiene documentation.",
    "Verification does not introduce meta-tests for docs link topology, command inventories, route inventories, or asset-bundle internals.",
    "Quality gate: typecheck, lint, and tests pass for the repository."
  ],
  "userStories": [
    {
      "id": "runtime-cleanup-search-artifact-hygiene-001",
      "title": "Document source-only cleanup scan command",
      "description": "As a maintainer, I want a documented source-only rg command so cleanup ownership scans report authored source candidates instead of local or generated artifacts.",
      "acceptanceCriteria": [
        "Maintainer guidance or this plan includes a copy-pastable rg command scoped to authored roots such as api/openapi-main.yaml, api/components, cmd, docs, pkg, tests, and ui/src.",
        "The command explicitly excludes ui/coverage, ui/**/node_modules, **/dist, Storybook/static build outputs, Vitest report output, TypeScript build-info files, and generated OpenAPI/client outputs.",
        "The command works with an arbitrary <pattern> placeholder without requiring maintainers to scan ignored artifacts with --no-ignore.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "runtime-cleanup-search-artifact-hygiene-002",
      "title": "Define generated-artifact evidence rules",
      "description": "As a reviewer, I want cleanup guidance to distinguish authored source evidence from generated drift evidence so ownership decisions are based on the right files.",
      "acceptanceCriteria": [
        "Guidance states that generated OpenAPI/client files, coverage reports, dependency installs, and build outputs are not source ownership evidence for routine cleanup audits.",
        "Guidance names the generated OpenAPI/client files excluded from routine ownership scans: api/openapi.yaml, pkg/api/generated/server.gen.go, pkg/generatedclient/client.gen.go, and ui/src/api/generated/openapi.ts.",
        "Guidance states that generated files should still be inspected when the audit target is generated contract drift, API regeneration, or generated output consistency.",
        "Generated drift guidance points reviewers back to authored contract source and the relevant generation/smoke checks rather than treating generated files as independent ownership sources.",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "runtime-cleanup-search-artifact-hygiene-003",
      "title": "Verify ignored artifact assumptions",
      "description": "As a maintainer, I want a focused verification path for artifact hygiene so cleanup scans can be trusted without adding meta-test inventory churn.",
      "acceptanceCriteria": [
        "git ls-files ui/coverage ui/packages/components/node_modules returns no tracked files.",
        "A focused source-only rg command is documented in this plan or in a durable maintainer process document.",
        "Verification does not add tests that assert docs link topology, command inventories, route inventories, or generated asset-bundle internals.",
        "No generated OpenAPI files, generated clients, runtime behavior, REST contract, CLI behavior, or UI behavior changes are made for this hygiene update.",
        "Typecheck passes"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}
