### PR TITLE
runtime-cleanup-shim-markers

### DIFF
--- a/pkg/composebridge/doc.go
+++ b/pkg/composebridge/doc.go
@@ -1,4 +1,6 @@
-// Package composebridge owns startup core composition orchestration used by
-// pkg/initializer. Runtime bundle construction internals remain in pkg/service
-// until a dedicated runtime-bundle package split.
+// Package composebridge is a temporary startup bridge used by pkg/initializer.
+//
+// It keeps initializer/runtimehost startup wiring compiling during composition
+// migration. Dependency construction should move to pkg/inject as import-cycle
+// migration allows; this package should not become the final composition root.
 package composebridge

--- a/pkg/models/service/host.go
+++ b/pkg/models/service/host.go
@@ -7,7 +7,10 @@ import (
 	"go.uber.org/zap"
 )
 
-// Host exposes runtime seams owned by pkg/service for model-domain wiring.
+// Host is a temporary migration adapter, not the final dependency-injection
+// pattern for model-domain wiring. New model catalog, pull, or invocation
+// wiring should pass explicit collaborators to models/service.New(Dependencies)
+// instead of adding seams to a broad host object.
 type Host interface {
 	RuntimeConfig() func() *factoryconfig.LoadedFactoryConfig
 	ModelHost() func() modelhost.Host
@@ -18,7 +21,9 @@ type Host interface {
 	FactoryRunnerID() func() string
 }
 
-// NewFromHost constructs the canonical model-domain service from explicit host seams.
+// NewFromHost is a temporary migration adapter that converts a broad host
+// object into the canonical Dependencies shape. Prefer direct construction
+// through models/service.New(Dependencies) for new model-service wiring.
 func NewFromHost(host Host) *Service {
 	if host == nil {
 		return New(Dependencies{})

--- a/pkg/runtimehost/doc.go
+++ b/pkg/runtimehost/doc.go
@@ -1,6 +1,8 @@
-// Package runtimehost owns the authoritative factory runtime and session host.
+// Package runtimehost is a migration-era facade around factory runtime hosting.
 //
-// Transports compose a Core through pkg/initializer (via pkg/composebridge) and
-// wrap it in a Host with collaborators attached through runtimehost helpers.
-// Root pkg/service.FactoryService is a compatibility alias for runtimehost.Host.
+// Factory Session ownership lives in pkg/factorysessions and related session
+// services. New application composition should be injected through
+// pkg/initializer and, as import-cycle migration allows, pkg/inject rather than
+// adding new ownership to this facade. Root pkg/service.FactoryService remains
+// a compatibility alias for runtimehost.Host while callers migrate.
 package runtimehost

--- a/pkg/workflowpolicy/compat.go
+++ b/pkg/workflowpolicy/compat.go
@@ -1,5 +1,9 @@
-// Deprecated: use github.com/portpowered/infinite-you/pkg/orchestrators/javascript/policy instead.
-// This package is a Batch 001 compatibility shim; core runtime and API code must import the orchestrator-owned path directly.
+// Package workflowpolicy is a Batch 001 compatibility shim for the legacy root
+// workflow policy import path.
+//
+// Deprecated: canonical ownership for JavaScript workflow policy lives in
+// github.com/portpowered/infinite-you/pkg/orchestrators/javascript/policy. Core
+// runtime and API code must import pkg/orchestrators/javascript/policy directly.
 package workflowpolicy
 
 import target "github.com/portpowered/infinite-you/pkg/orchestrators/javascript/policy"
@@ -21,31 +25,31 @@ type (
 )
 
 const (
-	CodeInvalidConcurrency          = target.CodeInvalidConcurrency
-	CodeConcurrencyAboveMaxAgents   = target.CodeConcurrencyAboveMaxAgents
-	CodeExcessiveMaxAgents          = target.CodeExcessiveMaxAgents
-	CodeInvalidMaxAgents            = target.CodeInvalidMaxAgents
-	CodeWritableRootsReadOnly       = target.CodeWritableRootsReadOnly
-	CodeUnsupportedRunner           = target.CodeUnsupportedRunner
-	CodeUnsupportedModel            = target.CodeUnsupportedModel
-	CodeUnsupportedReasoning        = target.CodeUnsupportedReasoning
-	CodeUnsupportedRouteProfile     = target.CodeUnsupportedRouteProfile
-	CodeUnsupportedCommand          = target.CodeUnsupportedCommand
-	CodeUnsupportedSandboxMode      = target.CodeUnsupportedSandboxMode
-	CodeDeniedCapability            = target.CodeDeniedCapability
-	CodeInvalidPolicyDocument       = target.CodeInvalidPolicyDocument
-	CodeUnsupportedPolicyMode       = target.CodeUnsupportedPolicyMode
-	DefaultMaxAgents                = target.DefaultMaxAgents
-	DefaultDeploymentCap            = target.DefaultDeploymentCap
-	DefaultMaxDepth                 = target.DefaultMaxDepth
-	DefaultMaxRetries               = target.DefaultMaxRetries
-	DefaultConcurrencyCap           = target.DefaultConcurrencyCap
-	ModeReadOnly                    = target.ModeReadOnly
-	OutputAuditModeAuto             = target.OutputAuditModeAuto
-	CapabilityWorkspaceWrite        = target.CapabilityWorkspaceWrite
-	CapabilityFilesystemWrite       = target.CapabilityFilesystemWrite
-	CapabilityShellProcess          = target.CapabilityShellProcess
-	CapabilityNetwork               = target.CapabilityNetwork
-	CapabilityConnectors            = target.CapabilityConnectors
-	CapabilityDangerFullAccess      = target.CapabilityDangerFullAccess
+	CodeInvalidConcurrency        = target.CodeInvalidConcurrency
+	CodeConcurrencyAboveMaxAgents = target.CodeConcurrencyAboveMaxAgents
+	CodeExcessiveMaxAgents        = target.CodeExcessiveMaxAgents
+	CodeInvalidMaxAgents          = target.CodeInvalidMaxAgents
+	CodeWritableRootsReadOnly     = target.CodeWritableRootsReadOnly
+	CodeUnsupportedRunner         = target.CodeUnsupportedRunner
+	CodeUnsupportedModel          = target.CodeUnsupportedModel
+	CodeUnsupportedReasoning      = target.CodeUnsupportedReasoning
+	CodeUnsupportedRouteProfile   = target.CodeUnsupportedRouteProfile
+	CodeUnsupportedCommand        = target.CodeUnsupportedCommand
+	CodeUnsupportedSandboxMode    = target.CodeUnsupportedSandboxMode
+	CodeDeniedCapability          = target.CodeDeniedCapability
+	CodeInvalidPolicyDocument     = target.CodeInvalidPolicyDocument
+	CodeUnsupportedPolicyMode     = target.CodeUnsupportedPolicyMode
+	DefaultMaxAgents              = target.DefaultMaxAgents
+	DefaultDeploymentCap          = target.DefaultDeploymentCap
+	DefaultMaxDepth               = target.DefaultMaxDepth
+	DefaultMaxRetries             = target.DefaultMaxRetries
+	DefaultConcurrencyCap         = target.DefaultConcurrencyCap
+	ModeReadOnly                  = target.ModeReadOnly
+	OutputAuditModeAuto           = target.OutputAuditModeAuto
+	CapabilityWorkspaceWrite      = target.CapabilityWorkspaceWrite
+	CapabilityFilesystemWrite     = target.CapabilityFilesystemWrite
+	CapabilityShellProcess        = target.CapabilityShellProcess
+	CapabilityNetwork             = target.CapabilityNetwork
+	CapabilityConnectors          = target.CapabilityConnectors
+	CapabilityDangerFullAccess    = target.CapabilityDangerFullAccess
 )

--- a/pkg/workflowpreview/compat.go
+++ b/pkg/workflowpreview/compat.go
@@ -1,5 +1,9 @@
-// Deprecated: use github.com/portpowered/infinite-you/pkg/orchestrators/javascript/preview instead.
-// This package is a Batch 001 compatibility shim; core runtime and API code must import the orchestrator-owned path directly.
+// Package workflowpreview is a Batch 001 compatibility shim for the legacy root
+// workflow preview import path.
+//
+// Deprecated: canonical ownership for JavaScript workflow preview lives in
+// github.com/portpowered/infinite-you/pkg/orchestrators/javascript/preview. Core
+// runtime and API code must import pkg/orchestrators/javascript/preview directly.
 package workflowpreview
 
 import target "github.com/portpowered/infinite-you/pkg/orchestrators/javascript/preview"

--- a/pkg/workflowresult/compat.go
+++ b/pkg/workflowresult/compat.go
@@ -1,5 +1,9 @@
-// Deprecated: use github.com/portpowered/infinite-you/pkg/orchestrators/javascript/result instead.
-// This package is a Batch 001 compatibility shim; core runtime and API code must import the orchestrator-owned path directly.
+// Package workflowresult is a Batch 001 compatibility shim for the legacy root
+// workflow result import path.
+//
+// Deprecated: canonical ownership for JavaScript workflow result lives in
+// github.com/portpowered/infinite-you/pkg/orchestrators/javascript/result. Core
+// runtime and API code must import pkg/orchestrators/javascript/result directly.
 package workflowresult
 
 import target "github.com/portpowered/infinite-you/pkg/orchestrators/javascript/result"

--- a/pkg/workflowsource/compat.go
+++ b/pkg/workflowsource/compat.go
@@ -1,5 +1,9 @@
-// Deprecated: use github.com/portpowered/infinite-you/pkg/orchestrators/javascript/source instead.
-// This package is a Batch 001 compatibility shim; core runtime and API code must import the orchestrator-owned path directly.
+// Package workflowsource is a Batch 001 compatibility shim for the legacy root
+// workflow source import path.
+//
+// Deprecated: canonical ownership for JavaScript workflow source lives in
+// github.com/portpowered/infinite-you/pkg/orchestrators/javascript/source. Core
+// runtime and API code must import pkg/orchestrators/javascript/source directly.
 package workflowsource
 
 import target "github.com/portpowered/infinite-you/pkg/orchestrators/javascript/source"

--- a/pkg/workflowvalidation/compat.go
+++ b/pkg/workflowvalidation/compat.go
@@ -1,5 +1,10 @@
-// Deprecated: use github.com/portpowered/infinite-you/pkg/orchestrators/javascript/validation instead.
-// This package is a Batch 001 compatibility shim; core runtime and API code must import the orchestrator-owned path directly.
+// Package workflowvalidation is a Batch 001 compatibility shim for the legacy
+// root workflow validation import path.
+//
+// Deprecated: canonical ownership for JavaScript workflow validation lives in
+// github.com/portpowered/infinite-you/pkg/orchestrators/javascript/validation.
+// Core runtime and API code must import pkg/orchestrators/javascript/validation
+// directly.
 package workflowvalidation
 
 import target "github.com/portpowered/infinite-you/pkg/orchestrators/javascript/validation"


### PR DESCRIPTION
{
  "project": "Runtime Cleanup Shim Markers",
  "branchName": "runtime-cleanup-shim-markers",
  "description": "Add narrow maintainer-facing package docs and comments that mark runtime composition migration shims explicitly, name their canonical replacement owners, and preserve all runtime, API, CLI, model-service, and workflow behavior.",
  "context": {
    "customerAsk": "Add package docs or narrow comments that make migration shims explicit without changing behavior. pkg/runtimehost and pkg/composebridge must document their replacement owners; host-object DI adapters such as pkg/models/service/host.go must be marked temporary; root pkg/workflow* compatibility packages must point at pkg/orchestrators/javascript as canonical ownership.",
    "problem": "The runtime composition convergence plan intends to retire runtimehost, composebridge, broad service facades, host-object adapters, and root workflow shims, but some current package docs and adapter comments still read like active ownership. That makes it easy for future runtime, model, or workflow work to add behavior to migration-only surfaces.",
    "solution": "Add concise package docs or narrow comments at the existing shim surfaces that state their migration-only role, name the replacement owners, and preserve all exports, imports, behavior, tests, and runtime semantics. Verify the change with go test ./pkg/models/service/... and focused rg checks for shim marker text and canonical package names."
  },
  "acceptanceCriteria": [
    "pkg/runtimehost package documentation states it is a migration-era facade and names Factory Session ownership plus injected application composition as the replacement direction.",
    "pkg/composebridge package documentation states it is a temporary bridge for initializer/runtimehost startup and names injected dependency construction as the replacement owner.",
    "Host-object DI adapters, including pkg/models/service/host.go, are marked as temporary adapters and direct dependency constructors are identified as the canonical pattern.",
    "Root pkg/workflowpolicy, pkg/workflowpreview, pkg/workflowresult, pkg/workflowsource, and pkg/workflowvalidation compatibility packages continue to point callers to pkg/orchestrators/javascript/... as canonical ownership.",
    "No runtime behavior, exported API shape, CLI behavior, emitted events, OpenAPI contract, generated client, or UI behavior changes.",
    "Quality gate: typecheck, lint when run, go test ./pkg/models/service/..., and a focused rg marker check for shim text plus canonical package names pass."
  ],
  "userStories": [
    {
      "id": "runtime-cleanup-shim-markers-001",
      "title": "Mark runtime host and bridge packages as migration-only",
      "description": "As a backend maintainer, I want runtimehost and composebridge package docs to identify their replacement owners so future runtime composition work lands in the correct domain packages.",
      "acceptanceCriteria": [
        "pkg/runtimehost package documentation describes the package as a migration-era facade rather than the final owner of Factory Session runtime state.",
        "The runtimehost marker names Factory Session ownership and injected application composition as the replacement direction, including references to pkg/factorysessions, pkg/inject, and pkg/initializer where appropriate.",
        "pkg/composebridge package documentation describes the package as a temporary startup bridge rather than the final composition root.",
        "The composebridge marker names pkg/inject as the target owner for dependency construction once import-cycle migration allows it.",
        "Existing public exports, constructor behavior, runtime startup behavior, and tests are unchanged.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "runtime-cleanup-shim-markers-002",
      "title": "Mark host-object DI adapters as temporary",
      "description": "As a model-domain maintainer, I want host-object dependency-injection adapters to be labeled temporary so new model-service wiring uses explicit dependencies instead of broad host interfaces.",
      "acceptanceCriteria": [
        "pkg/models/service/host.go comments state that Host and NewFromHost are migration adapters, not the final dependency-injection pattern.",
        "The marker names direct construction through models/service.New(Dependencies) as the canonical model-service wiring pattern.",
        "The comment makes clear that broad host objects must not become the preferred seam for new model catalog, pull, or invocation dependencies.",
        "Existing Host interface shape, NewFromHost behavior, nil-host behavior, and model-service tests remain unchanged.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "runtime-cleanup-shim-markers-003",
      "title": "Ensure root workflow compatibility packages point to JavaScript orchestrator owners",
      "description": "As a workflow maintainer, I want root pkg/workflow* compatibility packages to point at pkg/orchestrators/javascript so downstream callers understand the canonical JavaScript workflow ownership path.",
      "acceptanceCriteria": [
        "pkg/workflowpolicy identifies pkg/orchestrators/javascript/policy as canonical ownership.",
        "pkg/workflowpreview identifies pkg/orchestrators/javascript/preview as canonical ownership.",
        "pkg/workflowresult identifies pkg/orchestrators/javascript/result as canonical ownership.",
        "pkg/workflowsource identifies pkg/orchestrators/javascript/source as canonical ownership.",
        "pkg/workflowvalidation identifies pkg/orchestrators/javascript/validation as canonical ownership.",
        "Existing aliases, constants, exported type behavior, import paths, and compatibility compile behavior are unchanged.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "runtime-cleanup-shim-markers-004",
      "title": "Verify markers and behavior preservation",
      "description": "As a reviewer, I want focused verification to show the cleanup is documentation-only and that the requested migration markers are present.",
      "acceptanceCriteria": [
        "go test ./pkg/models/service/... passes after the comments are added.",
        "A focused rg check finds migration-only or temporary-adapter marker text in pkg/runtimehost, pkg/composebridge, and pkg/models/service/host.go.",
        "A focused rg check finds canonical pkg/orchestrators/javascript ownership references in each root pkg/workflow* compatibility package.",
        "Observable compatibility behavior remains unchanged: model-service NewFromHost and nil-host behavior continue to pass, and root workflow compatibility imports and aliases continue to compile for downstream callers.",
        "No new meta tests are added solely to assert file inventories, route registration, generated asset contents, or docs link topology.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}
