### PR TITLE
runtime-cleanup-work-query-boundary

### DIFF
--- a/pkg/cli/cliserver/cliserver.go
+++ b/pkg/cli/cliserver/cliserver.go
@@ -63,7 +63,7 @@ func (b Base) String() string {
 	return u.String()
 }
 
-// JoinPath joins an API path onto the base without producing double slashes.
+// JoinPath joins an escaped API path onto the base without producing double slashes.
 // path may be absolute (leading slash) or relative; an empty path returns the base URL.
 func (b Base) JoinPath(path string) (url.URL, error) {
 	joined := b.URL
@@ -75,13 +75,19 @@ func (b Base) JoinPath(path string) (url.URL, error) {
 	if !strings.HasPrefix(apiPath, "/") {
 		apiPath = "/" + apiPath
 	}
+	decodedAPIPath, err := url.PathUnescape(apiPath)
+	if err != nil {
+		return url.URL{}, fmt.Errorf("invalid escaped API path %q: %w", path, err)
+	}
 
 	basePath := strings.TrimSuffix(joined.Path, "/")
+	escapedBasePath := strings.TrimSuffix(joined.EscapedPath(), "/")
 	if basePath == "" {
-		joined.Path = apiPath
+		joined.Path = decodedAPIPath
 	} else {
-		joined.Path = basePath + apiPath
+		joined.Path = basePath + decodedAPIPath
 	}
+	joined.RawPath = escapedBasePath + apiPath
 	return joined, nil
 }
 

--- a/pkg/cli/cliserver/cliserver_test.go
+++ b/pkg/cli/cliserver/cliserver_test.go
@@ -84,6 +84,12 @@ func TestJoinPath(t *testing.T) {
 			want:    "https://remote.example.com/api/v1/work",
 		},
 		{
+			name:    "escaped slash remains within path segment",
+			baseRaw: "https://remote.example.com/api/v1",
+			path:    "/factory-sessions/session%2Fbeta/work/work%2Freview",
+			want:    "https://remote.example.com/api/v1/factory-sessions/session%2Fbeta/work/work%2Freview",
+		},
+		{
 			name:    "empty path returns base",
 			baseRaw: "http://localhost:7437",
 			path:    "",
@@ -106,6 +112,18 @@ func TestJoinPath(t *testing.T) {
 				t.Fatalf("joined = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestJoinPath_RejectsMalformedEscape(t *testing.T) {
+	t.Parallel()
+
+	base, err := ResolveBase(DefaultBaseURI)
+	if err != nil {
+		t.Fatalf("ResolveBase: %v", err)
+	}
+	if _, err := base.JoinPath("/work/%zz"); err == nil {
+		t.Fatal("JoinPath() error = nil, want malformed escape error")
 	}
 }
 

--- a/pkg/cli/sessionpath/sessionpath.go
+++ b/pkg/cli/sessionpath/sessionpath.go
@@ -11,6 +11,21 @@ func CurrentFactoryPath(sessionID string) string {
 	return fmt.Sprintf("/factory-sessions/%s/factory", escapedSessionID(sessionID))
 }
 
+// WorkCollectionPath returns the work collection route for one factory session.
+func WorkCollectionPath(sessionID string) string {
+	return fmt.Sprintf("/factory-sessions/%s/work", escapedSessionID(sessionID))
+}
+
+// WorkItemPath returns the route for one work item in a factory session.
+func WorkItemPath(sessionID, workID string) string {
+	return fmt.Sprintf("%s/%s", WorkCollectionPath(sessionID), url.PathEscape(workID))
+}
+
+// WorkMovePath returns the move route for one work item in a factory session.
+func WorkMovePath(sessionID, workID string) string {
+	return WorkItemPath(sessionID, workID) + "/move"
+}
+
 func ScopedPath(legacyPath string, sessionID string) string {
 	return fmt.Sprintf("/factory-sessions/%s%s", escapedSessionID(sessionID), legacyPath)
 }

--- a/pkg/cli/sessionpath/sessionpath_test.go
+++ b/pkg/cli/sessionpath/sessionpath_test.go
@@ -57,3 +57,55 @@ func TestCurrentFactoryPath(t *testing.T) {
 		t.Fatalf("CurrentFactoryPath(\"session/beta\") = %q, want /factory-sessions/session%%2Fbeta/factory", got)
 	}
 }
+
+func TestWorkPaths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		sessionID  string
+		workID     string
+		collection string
+		item       string
+		move       string
+	}{
+		{
+			name:       "omitted session uses default",
+			workID:     "work-1",
+			collection: "/factory-sessions/~default/work",
+			item:       "/factory-sessions/~default/work/work-1",
+			move:       "/factory-sessions/~default/work/work-1/move",
+		},
+		{
+			name:       "explicit session",
+			sessionID:  "session-beta",
+			workID:     "work-2",
+			collection: "/factory-sessions/session-beta/work",
+			item:       "/factory-sessions/session-beta/work/work-2",
+			move:       "/factory-sessions/session-beta/work/work-2/move",
+		},
+		{
+			name:       "identifiers are independently escaped",
+			sessionID:  "session/beta",
+			workID:     "work/review",
+			collection: "/factory-sessions/session%2Fbeta/work",
+			item:       "/factory-sessions/session%2Fbeta/work/work%2Freview",
+			move:       "/factory-sessions/session%2Fbeta/work/work%2Freview/move",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := WorkCollectionPath(tt.sessionID); got != tt.collection {
+				t.Fatalf("WorkCollectionPath(%q) = %q, want %q", tt.sessionID, got, tt.collection)
+			}
+			if got := WorkItemPath(tt.sessionID, tt.workID); got != tt.item {
+				t.Fatalf("WorkItemPath(%q, %q) = %q, want %q", tt.sessionID, tt.workID, got, tt.item)
+			}
+			if got := WorkMovePath(tt.sessionID, tt.workID); got != tt.move {
+				t.Fatalf("WorkMovePath(%q, %q) = %q, want %q", tt.sessionID, tt.workID, got, tt.move)
+			}
+		})
+	}
+}

--- a/pkg/cli/work/list.go
+++ b/pkg/cli/work/list.go
@@ -15,10 +15,10 @@ import (
 
 	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
 	"github.com/portpowered/infinite-you/pkg/cli/clidiag"
-	"github.com/portpowered/infinite-you/pkg/workquery"
 	"github.com/portpowered/infinite-you/pkg/cli/clihttp"
 	"github.com/portpowered/infinite-you/pkg/cli/cliserver"
 	"github.com/portpowered/infinite-you/pkg/cli/sessionpath"
+	"github.com/portpowered/infinite-you/pkg/workquery"
 )
 
 const listRequestTimeout = 10 * time.Second
@@ -35,11 +35,11 @@ type ListConfig struct {
 	SortBy       string
 	MaxResults   int
 	NextToken    string
-	JSON        bool
-	Verbose     bool
-	Debug       bool
-	Output      io.Writer
-	Diagnostics io.Writer
+	JSON         bool
+	Verbose      bool
+	Debug        bool
+	Output       io.Writer
+	Diagnostics  io.Writer
 }
 
 // List requests available work from a running factory via HTTP.
@@ -148,7 +148,7 @@ func listFilterSummary(cfg ListConfig) string {
 }
 
 func listEndpoint(cfg ListConfig) (url.URL, error) {
-	endpointPath := sessionpath.ScopedPath("/work", cfg.SessionID)
+	endpointPath := sessionpath.WorkCollectionPath(cfg.SessionID)
 	endpointURL, err := cliserver.RequestURL(cfg.Server, endpointPath)
 	if err != nil {
 		return url.URL{}, err
@@ -258,7 +258,6 @@ func formatRelationSummary(relation factoryapi.Relation) string {
 	}
 	return builder.String()
 }
-
 
 func stringValue(value *string) string {
 	if value == nil {

--- a/pkg/cli/work/list.go
+++ b/pkg/cli/work/list.go
@@ -4,6 +4,7 @@ package work
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -47,14 +48,12 @@ func List(cfg ListConfig) error {
 	if cfg.Output == nil {
 		cfg.Output = os.Stdout
 	}
-	if err := validateListConfig(cfg); err != nil {
-		return err
-	}
 
-	endpoint, err := listEndpoint(cfg)
+	request, err := buildListRequest(cfg)
 	if err != nil {
-		return err
+		return listConfigError(err)
 	}
+	endpoint := request.endpoint
 	clidiag.Printf(
 		cfg.Diagnostics,
 		cfg.Verbose,
@@ -63,7 +62,7 @@ func List(cfg ListConfig) error {
 		endpoint.String(),
 		cfg.Server,
 		clidiag.SessionLabel(cfg.SessionID),
-		listFilterSummary(cfg),
+		request.filterSummary,
 		cfg.MaxResults,
 		cfg.NextToken != "",
 	)
@@ -111,71 +110,54 @@ func List(cfg ListConfig) error {
 	return renderListResult(cfg.Output, result)
 }
 
-func validateListConfig(cfg ListConfig) error {
-	if cfg.StateType != "" && !workquery.ValidWorkStateType(factoryapi.WorkStateType(cfg.StateType)) {
+func listConfigError(err error) error {
+	var validationErr *workquery.ValidationError
+	if !errors.As(err, &validationErr) {
+		return err
+	}
+	switch validationErr.Field {
+	case workquery.FilterStateType:
 		return fmt.Errorf("--state-type must be one of INITIAL, PROCESSING, TERMINAL, or FAILED")
-	}
-	if cfg.SortBy != "" && cfg.SortBy != string(factoryapi.SortByStateType) {
+	case "sortBy":
 		return fmt.Errorf("--sort-by must be state.type")
+	default:
+		return err
 	}
-	return nil
 }
 
-func listFilterSummary(cfg ListConfig) string {
-	parts := make([]string, 0, 6)
-	if cfg.StateName != "" {
-		parts = append(parts, "state.name")
-	}
-	if cfg.StateType != "" {
-		parts = append(parts, "state.type")
-	}
-	if cfg.Name != "" {
-		parts = append(parts, "name")
-	}
-	if cfg.WorkTypeName != "" {
-		parts = append(parts, "workTypeName")
-	}
-	if cfg.TraceID != "" {
-		parts = append(parts, "traceId")
-	}
-	if cfg.SortBy != "" {
-		parts = append(parts, "sortBy")
-	}
-	if len(parts) == 0 {
-		return "none"
-	}
-	return strings.Join(parts, ",")
+type listRequest struct {
+	endpoint      url.URL
+	filterSummary string
 }
 
-func listEndpoint(cfg ListConfig) (url.URL, error) {
+func buildListRequest(cfg ListConfig) (listRequest, error) {
+	query, err := workquery.NormalizeList(workquery.ListOptions{
+		Filters: map[string]string{
+			workquery.FilterStateName:    cfg.StateName,
+			workquery.FilterStateType:    cfg.StateType,
+			workquery.FilterName:         cfg.Name,
+			workquery.FilterWorkTypeName: cfg.WorkTypeName,
+			workquery.FilterTraceID:      cfg.TraceID,
+		},
+		SortBy:     cfg.SortBy,
+		MaxResults: cfg.MaxResults,
+		NextToken:  cfg.NextToken,
+	})
+	if err != nil {
+		return listRequest{}, err
+	}
+
 	endpointPath := sessionpath.WorkCollectionPath(cfg.SessionID)
 	endpointURL, err := cliserver.RequestURL(cfg.Server, endpointPath)
 	if err != nil {
-		return url.URL{}, err
+		return listRequest{}, err
 	}
 	endpoint, err := url.Parse(endpointURL)
 	if err != nil {
-		return url.URL{}, fmt.Errorf("parse work list endpoint: %w", err)
+		return listRequest{}, fmt.Errorf("parse work list endpoint: %w", err)
 	}
-	query := endpoint.Query()
-	setListQueryParam(query, "state.name", cfg.StateName)
-	setListQueryParam(query, "state.type", cfg.StateType)
-	setListQueryParam(query, "name", cfg.Name)
-	setListQueryParam(query, "workTypeName", cfg.WorkTypeName)
-	setListQueryParam(query, "traceId", cfg.TraceID)
-	setListQueryParam(query, "sortBy", cfg.SortBy)
-	if cfg.MaxResults > 0 {
-		query.Set("maxResults", fmt.Sprintf("%d", cfg.MaxResults))
-	}
-	setListQueryParam(query, "nextToken", cfg.NextToken)
-	endpoint.RawQuery = query.Encode()
-	return *endpoint, nil
-}
-
-func setListQueryParam(query url.Values, key, value string) {
-	if value != "" {
-		query.Set(key, value)
-	}
+	endpoint.RawQuery = query.Values().Encode()
+	return listRequest{endpoint: *endpoint, filterSummary: query.FilterSummary()}, nil
 }
 
 func renderListResult(output io.Writer, result factoryapi.ListWorkResponse) error {

--- a/pkg/cli/work/list_request_test.go
+++ b/pkg/cli/work/list_request_test.go
@@ -1,0 +1,108 @@
+package work
+
+import (
+	"bytes"
+	"net/url"
+	"testing"
+)
+
+func TestBuildListRequest_NormalizesQueryWithoutHTTP(t *testing.T) {
+	nextToken := encodeCursor("work/42")
+	request, err := buildListRequest(ListConfig{
+		Server:       "https://factory.example",
+		SessionID:    "session-alpha",
+		StateName:    "in review",
+		StateType:    "PROCESSING",
+		Name:         "Plan & review",
+		WorkTypeName: "story/type",
+		TraceID:      "trace+1",
+		SortBy:       "state.type",
+		MaxResults:   25,
+		NextToken:    nextToken,
+	})
+	if err != nil {
+		t.Fatalf("buildListRequest: %v", err)
+	}
+
+	wantQuery := url.Values{
+		"state.name":   {"in review"},
+		"state.type":   {"PROCESSING"},
+		"name":         {"Plan & review"},
+		"workTypeName": {"story/type"},
+		"traceId":      {"trace+1"},
+		"sortBy":       {"state.type"},
+		"maxResults":   {"25"},
+		"nextToken":    {nextToken},
+	}
+	if got := request.endpoint.Path; got != "/factory-sessions/session-alpha/work" {
+		t.Fatalf("endpoint path = %q", got)
+	}
+	if got := request.endpoint.RawQuery; got != wantQuery.Encode() {
+		t.Fatalf("query = %q, want %q", got, wantQuery.Encode())
+	}
+	if got := request.filterSummary; got != "state.name,state.type,name,workTypeName,traceId,sortBy" {
+		t.Fatalf("filter summary = %q", got)
+	}
+}
+
+func TestBuildListRequest_RejectsInvalidQueryWithoutHTTP(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  ListConfig
+		wantErr string
+	}{
+		{name: "state type", config: ListConfig{StateType: "UNKNOWN"}, wantErr: "state.type must be one of INITIAL, PROCESSING, TERMINAL, or FAILED"},
+		{name: "sort", config: ListConfig{SortBy: "name"}, wantErr: "sortBy must be state.type"},
+		{name: "page size", config: ListConfig{MaxResults: -1}, wantErr: "maxResults must be zero or greater"},
+		{name: "cursor", config: ListConfig{NextToken: "not-base64"}, wantErr: "nextToken must be valid standard base64 for a non-empty cursor"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.config.Server = "://invalid-server"
+			_, err := buildListRequest(tt.config)
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("buildListRequest() error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestList_InvalidQueryFailsBeforeRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  ListConfig
+		wantErr string
+	}{
+		{
+			name:    "state type",
+			config:  ListConfig{StateType: "UNKNOWN"},
+			wantErr: "--state-type must be one of INITIAL, PROCESSING, TERMINAL, or FAILED",
+		},
+		{
+			name:    "sort",
+			config:  ListConfig{SortBy: "name"},
+			wantErr: "--sort-by must be state.type",
+		},
+		{
+			name:    "negative page size",
+			config:  ListConfig{MaxResults: -1},
+			wantErr: "maxResults must be zero or greater",
+		},
+		{
+			name:    "malformed cursor",
+			config:  ListConfig{NextToken: "not-base64"},
+			wantErr: "nextToken must be valid standard base64 for a non-empty cursor",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.config.Server = "://invalid-server"
+			tt.config.Output = &bytes.Buffer{}
+			err := List(tt.config)
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("List() error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/cli/work/list_request_test.go
+++ b/pkg/cli/work/list_request_test.go
@@ -10,7 +10,7 @@ func TestBuildListRequest_NormalizesQueryWithoutHTTP(t *testing.T) {
 	nextToken := encodeCursor("work/42")
 	request, err := buildListRequest(ListConfig{
 		Server:       "https://factory.example",
-		SessionID:    "session-alpha",
+		SessionID:    "session/alpha",
 		StateName:    "in review",
 		StateType:    "PROCESSING",
 		Name:         "Plan & review",
@@ -34,8 +34,11 @@ func TestBuildListRequest_NormalizesQueryWithoutHTTP(t *testing.T) {
 		"maxResults":   {"25"},
 		"nextToken":    {nextToken},
 	}
-	if got := request.endpoint.Path; got != "/factory-sessions/session-alpha/work" {
+	if got := request.endpoint.Path; got != "/factory-sessions/session/alpha/work" {
 		t.Fatalf("endpoint path = %q", got)
+	}
+	if got := request.endpoint.EscapedPath(); got != "/factory-sessions/session%2Falpha/work" {
+		t.Fatalf("escaped endpoint path = %q", got)
 	}
 	if got := request.endpoint.RawQuery; got != wantQuery.Encode() {
 		t.Fatalf("query = %q, want %q", got, wantQuery.Encode())

--- a/pkg/cli/work/list_test.go
+++ b/pkg/cli/work/list_test.go
@@ -156,7 +156,7 @@ func TestList_VerboseDiagnosticsIncludeActiveFilterKeys(t *testing.T) {
 func TestList_SessionScopedRouteUsesFactorySessionPath(t *testing.T) {
 	var gotPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
+		gotPath = r.URL.EscapedPath()
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(factoryapi.ListWorkResponse{}); err != nil {
 			t.Fatalf("encode response: %v", err)
@@ -167,15 +167,15 @@ func TestList_SessionScopedRouteUsesFactorySessionPath(t *testing.T) {
 	var out bytes.Buffer
 	err := List(ListConfig{
 		Server:    serverBase(t, srv),
-		SessionID: "session-beta",
+		SessionID: "session/beta",
 		Output:    &out,
 	})
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
 
-	if gotPath != "/factory-sessions/session-beta/work" {
-		t.Fatalf("path = %q, want /factory-sessions/session-beta/work", gotPath)
+	if gotPath != "/factory-sessions/session%2Fbeta/work" {
+		t.Fatalf("path = %q, want /factory-sessions/session%%2Fbeta/work", gotPath)
 	}
 	if got := out.String(); got != "No work found.\n" {
 		t.Fatalf("output = %q, want empty-state output", got)

--- a/pkg/cli/work/list_test.go
+++ b/pkg/cli/work/list_test.go
@@ -2,6 +2,7 @@ package work
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -45,7 +46,7 @@ func TestList_SendsStateFilters(t *testing.T) {
 
 	var out bytes.Buffer
 	err := List(ListConfig{
-		Server: serverBase(t, srv),
+		Server:    serverBase(t, srv),
 		StateName: "review",
 		StateType: "PROCESSING",
 		SortBy:    "state.type",
@@ -165,7 +166,7 @@ func TestList_SessionScopedRouteUsesFactorySessionPath(t *testing.T) {
 
 	var out bytes.Buffer
 	err := List(ListConfig{
-		Server: serverBase(t, srv),
+		Server:    serverBase(t, srv),
 		SessionID: "session-beta",
 		Output:    &out,
 	})
@@ -474,13 +475,14 @@ func TestList_HumanOutputShowsDeterministicSummaryForMultipleRelations(t *testin
 }
 
 func TestList_SendsPaginationControlsAndEmitsJSONResponse(t *testing.T) {
-	nextToken := "cursor-2"
+	requestToken := encodeCursor("cursor-1")
+	nextToken := encodeCursor("cursor-2")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("maxResults") != "2" {
 			t.Fatalf("maxResults query = %q, want 2", r.URL.Query().Get("maxResults"))
 		}
-		if r.URL.Query().Get("nextToken") != "cursor-1" {
-			t.Fatalf("nextToken query = %q, want cursor-1", r.URL.Query().Get("nextToken"))
+		if r.URL.Query().Get("nextToken") != requestToken {
+			t.Fatalf("nextToken query = %q, want %q", r.URL.Query().Get("nextToken"), requestToken)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(factoryapi.ListWorkResponse{
@@ -505,9 +507,9 @@ func TestList_SendsPaginationControlsAndEmitsJSONResponse(t *testing.T) {
 
 	var out bytes.Buffer
 	err := List(ListConfig{
-		Server: serverBase(t, srv),
+		Server:     serverBase(t, srv),
 		MaxResults: 2,
-		NextToken:  "cursor-1",
+		NextToken:  requestToken,
 		JSON:       true,
 		Output:     &out,
 	})
@@ -528,7 +530,7 @@ func TestList_SendsPaginationControlsAndEmitsJSONResponse(t *testing.T) {
 }
 
 func TestList_JSONVerboseKeepsStdoutParseableAndDiagnosticsSeparate(t *testing.T) {
-	nextToken := "cursor-2"
+	nextToken := encodeCursor("cursor-2")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(factoryapi.ListWorkResponse{
@@ -553,12 +555,12 @@ func TestList_JSONVerboseKeepsStdoutParseableAndDiagnosticsSeparate(t *testing.T
 	var out bytes.Buffer
 	var diagnostics bytes.Buffer
 	err := List(ListConfig{
-		Server: serverBase(t, srv),
+		Server:      serverBase(t, srv),
 		SessionID:   "session-alpha",
 		StateName:   "review",
 		StateType:   "PROCESSING",
 		MaxResults:  1,
-		NextToken:   "cursor-1",
+		NextToken:   encodeCursor("cursor-1"),
 		JSON:        true,
 		Verbose:     true,
 		Output:      &out,
@@ -602,7 +604,7 @@ func TestList_VerboseLogsFailureStatus(t *testing.T) {
 	var out bytes.Buffer
 	var diagnostics bytes.Buffer
 	err := List(ListConfig{
-		Server: serverBase(t, srv),
+		Server:      serverBase(t, srv),
 		Verbose:     true,
 		Output:      &out,
 		Diagnostics: &diagnostics,
@@ -620,7 +622,7 @@ func TestList_VerboseLogsFailureStatus(t *testing.T) {
 }
 
 func TestList_JSONOutputOmitsResourcesAndPreservesPaginationAcrossVisibleWorkPages(t *testing.T) {
-	secondToken := "cursor-2"
+	secondToken := encodeCursor("cursor-2")
 	var requestCount int
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -640,7 +642,7 @@ func TestList_JSONOutputOmitsResourcesAndPreservesPaginationAcrossVisibleWorkPag
 
 	var firstOut bytes.Buffer
 	err := List(ListConfig{
-		Server: serverBase(t, srv),
+		Server:     serverBase(t, srv),
 		MaxResults: 1,
 		JSON:       true,
 		Output:     &firstOut,
@@ -655,7 +657,7 @@ func TestList_JSONOutputOmitsResourcesAndPreservesPaginationAcrossVisibleWorkPag
 
 	var secondOut bytes.Buffer
 	err = List(ListConfig{
-		Server: serverBase(t, srv),
+		Server:     serverBase(t, srv),
 		MaxResults: 1,
 		NextToken:  secondToken,
 		JSON:       true,
@@ -779,7 +781,7 @@ func TestList_JSONOutputSupportsAutomationSelectionWithFiltersAndPagination(t *t
 
 	var out bytes.Buffer
 	err := List(ListConfig{
-		Server: serverBase(t, srv),
+		Server:     serverBase(t, srv),
 		StateName:  "review",
 		StateType:  "PROCESSING",
 		MaxResults: 1,
@@ -857,28 +859,12 @@ func TestList_JSONOutputLeavesRelationsOmittedWhenAPIResponseDoesNotIncludeThem(
 	}
 }
 
-func TestList_InvalidStateType(t *testing.T) {
-	err := List(ListConfig{Server: "http://127.0.0.1:8080", StateType: "UNKNOWN", Output: &bytes.Buffer{}})
-	if err == nil {
-		t.Fatal("expected invalid state type error")
-	}
-	if got := err.Error(); got != "--state-type must be one of INITIAL, PROCESSING, TERMINAL, or FAILED" {
-		t.Fatalf("error = %q", got)
-	}
-}
-
-func TestList_InvalidSortBy(t *testing.T) {
-	err := List(ListConfig{Server: "http://127.0.0.1:8080", SortBy: "name", Output: &bytes.Buffer{}})
-	if err == nil {
-		t.Fatal("expected invalid sort-by error")
-	}
-	if got := err.Error(); got != "--sort-by must be state.type" {
-		t.Fatalf("error = %q", got)
-	}
-}
-
 func stringPtr(value string) *string {
 	return &value
+}
+
+func encodeCursor(value string) string {
+	return base64.StdEncoding.EncodeToString([]byte(value))
 }
 
 func assertListPageRequest(t *testing.T, r *http.Request, wantMaxResults string, wantNextToken string) {

--- a/pkg/cli/work/move.go
+++ b/pkg/cli/work/move.go
@@ -192,7 +192,7 @@ func loadWorkStateBeforeMove(cfg MoveConfig) (string, error) {
 }
 
 func moveEndpoint(cfg MoveConfig) (url.URL, error) {
-	endpointPath := sessionpath.ScopedPath("/work/"+url.PathEscape(cfg.WorkID)+"/move", cfg.SessionID)
+	endpointPath := sessionpath.WorkMovePath(cfg.SessionID, cfg.WorkID)
 	endpointURL, err := cliserver.RequestURL(cfg.Server, endpointPath)
 	if err != nil {
 		return url.URL{}, err

--- a/pkg/cli/work/move_test.go
+++ b/pkg/cli/work/move_test.go
@@ -100,10 +100,12 @@ func TestMove_JSONOutputEmitsStableEnvelope(t *testing.T) {
 }
 
 func TestMove_SessionScopedRouteUsesFactorySessionPath(t *testing.T) {
-	var gotMovePath string
+	var gotShowPath, gotMovePath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
-			gotMovePath = r.URL.Path
+			gotMovePath = r.URL.EscapedPath()
+		} else {
+			gotShowPath = r.URL.EscapedPath()
 		}
 		writeJSON(t, w, factoryapi.Work{
 			WorkId: stringPtr("work-1"),
@@ -115,16 +117,19 @@ func TestMove_SessionScopedRouteUsesFactorySessionPath(t *testing.T) {
 	var out bytes.Buffer
 	err := Move(MoveConfig{
 		Server:    serverBase(t, srv),
-		SessionID: "session-beta",
-		WorkID:    "work-1",
+		SessionID: "session/beta",
+		WorkID:    "work/review",
 		StateName: "complete",
 		Output:    &out,
 	})
 	if err != nil {
 		t.Fatalf("Move: %v", err)
 	}
-	if gotMovePath != "/factory-sessions/session-beta/work/work-1/move" {
-		t.Fatalf("move path = %q, want /factory-sessions/session-beta/work/work-1/move", gotMovePath)
+	if gotShowPath != "/factory-sessions/session%2Fbeta/work/work%2Freview" {
+		t.Fatalf("show path = %q, want slash-sensitive identifiers escaped as segments", gotShowPath)
+	}
+	if gotMovePath != "/factory-sessions/session%2Fbeta/work/work%2Freview/move" {
+		t.Fatalf("move path = %q, want slash-sensitive identifiers escaped as segments", gotMovePath)
 	}
 }
 

--- a/pkg/cli/work/show.go
+++ b/pkg/cli/work/show.go
@@ -108,7 +108,7 @@ func Show(cfg ShowConfig) error {
 }
 
 func showEndpoint(cfg ShowConfig) (url.URL, error) {
-	endpointPath := sessionpath.ScopedPath("/work/"+url.PathEscape(cfg.WorkID), cfg.SessionID)
+	endpointPath := sessionpath.WorkItemPath(cfg.SessionID, cfg.WorkID)
 	endpointURL, err := cliserver.RequestURL(cfg.Server, endpointPath)
 	if err != nil {
 		return url.URL{}, err

--- a/pkg/cli/work/show_test.go
+++ b/pkg/cli/work/show_test.go
@@ -270,7 +270,7 @@ func TestShow_NotFoundExitsWithClearError(t *testing.T) {
 func TestShow_SessionScopedRouteUsesFactorySessionPath(t *testing.T) {
 	var gotPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
+		gotPath = r.URL.EscapedPath()
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(factoryapi.Work{
 			Name:         "Plan feature",
@@ -286,15 +286,15 @@ func TestShow_SessionScopedRouteUsesFactorySessionPath(t *testing.T) {
 	var out bytes.Buffer
 	err := Show(ShowConfig{
 		Server:    serverBase(t, srv),
-		SessionID: "session-beta",
-		WorkID:    "work-1",
+		SessionID: "session/beta",
+		WorkID:    "work/review",
 		Output:    &out,
 	})
 	if err != nil {
 		t.Fatalf("Show: %v", err)
 	}
-	if gotPath != "/factory-sessions/session-beta/work/work-1" {
-		t.Fatalf("path = %q, want /factory-sessions/session-beta/work/work-1", gotPath)
+	if gotPath != "/factory-sessions/session%2Fbeta/work/work%2Freview" {
+		t.Fatalf("path = %q, want slash-sensitive identifiers escaped as segments", gotPath)
 	}
 }
 

--- a/pkg/workquery/list.go
+++ b/pkg/workquery/list.go
@@ -30,6 +30,21 @@ type ListOptions struct {
 	NextToken  string
 }
 
+// ValidationError identifies the public query field that failed validation.
+// Boundary adapters can use Field to present transport-specific field names.
+type ValidationError struct {
+	Field   string
+	message string
+}
+
+func (e *ValidationError) Error() string {
+	return e.message
+}
+
+func validationError(field, message string) error {
+	return &ValidationError{Field: field, message: message}
+}
+
 // ListQuery is a validated work-list query ready for use at a transport
 // boundary. Its values are immutable through the exported API.
 type ListQuery struct {
@@ -45,13 +60,16 @@ func NormalizeList(options ListOptions) (ListQuery, error) {
 	}
 	if stateType := options.Filters[FilterStateType]; stateType != "" &&
 		!ValidWorkStateType(factoryapi.WorkStateType(stateType)) {
-		return ListQuery{}, fmt.Errorf("%s must be one of INITIAL, PROCESSING, TERMINAL, or FAILED", FilterStateType)
+		return ListQuery{}, validationError(
+			FilterStateType,
+			fmt.Sprintf("%s must be one of INITIAL, PROCESSING, TERMINAL, or FAILED", FilterStateType),
+		)
 	}
 	if options.SortBy != "" && options.SortBy != SortByStateType {
-		return ListQuery{}, fmt.Errorf("sortBy must be %s", SortByStateType)
+		return ListQuery{}, validationError("sortBy", fmt.Sprintf("sortBy must be %s", SortByStateType))
 	}
 	if options.MaxResults < 0 {
-		return ListQuery{}, fmt.Errorf("maxResults must be zero or greater")
+		return ListQuery{}, validationError("maxResults", "maxResults must be zero or greater")
 	}
 	if err := validateNextToken(options.NextToken); err != nil {
 		return ListQuery{}, err
@@ -114,7 +132,7 @@ func validateFilterKeys(filters map[string]string) error {
 		return nil
 	}
 	sort.Strings(unsupported)
-	return fmt.Errorf("unsupported work-list filter %q", unsupported[0])
+	return validationError(unsupported[0], fmt.Sprintf("unsupported work-list filter %q", unsupported[0]))
 }
 
 func supportedFilterKey(key string) bool {
@@ -132,7 +150,7 @@ func validateNextToken(nextToken string) error {
 	}
 	decoded, err := base64.StdEncoding.DecodeString(nextToken)
 	if err != nil || len(decoded) == 0 {
-		return fmt.Errorf("nextToken must be valid standard base64 for a non-empty cursor")
+		return validationError("nextToken", "nextToken must be valid standard base64 for a non-empty cursor")
 	}
 	return nil
 }

--- a/pkg/workquery/list.go
+++ b/pkg/workquery/list.go
@@ -1,0 +1,138 @@
+package workquery
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
+)
+
+const (
+	FilterStateName    = "state.name"
+	FilterStateType    = "state.type"
+	FilterName         = "name"
+	FilterWorkTypeName = "workTypeName"
+	FilterTraceID      = "traceId"
+
+	SortByStateType = "state.type"
+)
+
+// ListOptions contains the filters, ordering, and pagination controls for a
+// work-list query. Filters are keyed by their public query parameter names.
+type ListOptions struct {
+	Filters    map[string]string
+	SortBy     string
+	MaxResults int
+	NextToken  string
+}
+
+// ListQuery is a validated work-list query ready for use at a transport
+// boundary. Its values are immutable through the exported API.
+type ListQuery struct {
+	values        url.Values
+	filterSummary string
+}
+
+// NormalizeList validates options and returns their canonical public query
+// values and active-filter summary.
+func NormalizeList(options ListOptions) (ListQuery, error) {
+	if err := validateFilterKeys(options.Filters); err != nil {
+		return ListQuery{}, err
+	}
+	if stateType := options.Filters[FilterStateType]; stateType != "" &&
+		!ValidWorkStateType(factoryapi.WorkStateType(stateType)) {
+		return ListQuery{}, fmt.Errorf("%s must be one of INITIAL, PROCESSING, TERMINAL, or FAILED", FilterStateType)
+	}
+	if options.SortBy != "" && options.SortBy != SortByStateType {
+		return ListQuery{}, fmt.Errorf("sortBy must be %s", SortByStateType)
+	}
+	if options.MaxResults < 0 {
+		return ListQuery{}, fmt.Errorf("maxResults must be zero or greater")
+	}
+	if err := validateNextToken(options.NextToken); err != nil {
+		return ListQuery{}, err
+	}
+
+	values := make(url.Values)
+	active := make([]string, 0, len(options.Filters)+1)
+	for _, key := range []string{
+		FilterStateName,
+		FilterStateType,
+		FilterName,
+		FilterWorkTypeName,
+		FilterTraceID,
+	} {
+		if value := options.Filters[key]; value != "" {
+			values.Set(key, value)
+			active = append(active, key)
+		}
+	}
+	if options.SortBy != "" {
+		values.Set("sortBy", options.SortBy)
+		active = append(active, "sortBy")
+	}
+	if options.MaxResults > 0 {
+		values.Set("maxResults", strconv.Itoa(options.MaxResults))
+	}
+	if options.NextToken != "" {
+		values.Set("nextToken", options.NextToken)
+	}
+
+	summary := "none"
+	if len(active) > 0 {
+		summary = strings.Join(active, ",")
+	}
+	return ListQuery{values: values, filterSummary: summary}, nil
+}
+
+// Values returns a copy of the normalized public query values.
+func (q ListQuery) Values() url.Values {
+	values := make(url.Values, len(q.values))
+	for key, entries := range q.values {
+		values[key] = append([]string(nil), entries...)
+	}
+	return values
+}
+
+// FilterSummary returns the active filter and sort keys in canonical order.
+func (q ListQuery) FilterSummary() string {
+	return q.filterSummary
+}
+
+func validateFilterKeys(filters map[string]string) error {
+	unsupported := make([]string, 0)
+	for key := range filters {
+		if !supportedFilterKey(key) {
+			unsupported = append(unsupported, key)
+		}
+	}
+	if len(unsupported) == 0 {
+		return nil
+	}
+	sort.Strings(unsupported)
+	return fmt.Errorf("unsupported work-list filter %q", unsupported[0])
+}
+
+func supportedFilterKey(key string) bool {
+	switch key {
+	case FilterStateName, FilterStateType, FilterName, FilterWorkTypeName, FilterTraceID:
+		return true
+	default:
+		return false
+	}
+}
+
+func validateNextToken(nextToken string) error {
+	if nextToken == "" {
+		return nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(nextToken)
+	if err != nil || len(decoded) == 0 {
+		return fmt.Errorf("nextToken must be valid standard base64 for a non-empty cursor")
+	}
+	return nil
+}

--- a/pkg/workquery/list_test.go
+++ b/pkg/workquery/list_test.go
@@ -1,0 +1,175 @@
+package workquery
+
+import (
+	"encoding/base64"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeListAcceptedCombination(t *testing.T) {
+	t.Parallel()
+
+	nextToken := base64.StdEncoding.EncodeToString([]byte("work/42"))
+	query, err := NormalizeList(ListOptions{
+		Filters: map[string]string{
+			FilterTraceID:      "trace value",
+			FilterName:         "Alpha & Beta",
+			FilterStateType:    "PROCESSING",
+			FilterWorkTypeName: "story/review",
+			FilterStateName:    "in review",
+		},
+		SortBy:     SortByStateType,
+		MaxResults: 25,
+		NextToken:  nextToken,
+	})
+	if err != nil {
+		t.Fatalf("NormalizeList() error = %v", err)
+	}
+
+	wantValues := url.Values{
+		"state.name":   {"in review"},
+		"state.type":   {"PROCESSING"},
+		"name":         {"Alpha & Beta"},
+		"workTypeName": {"story/review"},
+		"traceId":      {"trace value"},
+		"sortBy":       {"state.type"},
+		"maxResults":   {"25"},
+		"nextToken":    {nextToken},
+	}
+	if got := query.Values(); !reflect.DeepEqual(got, wantValues) {
+		t.Fatalf("Values() = %#v, want %#v", got, wantValues)
+	}
+	if got, want := query.FilterSummary(), "state.name,state.type,name,workTypeName,traceId,sortBy"; got != want {
+		t.Fatalf("FilterSummary() = %q, want %q", got, want)
+	}
+	if got := query.Values().Encode(); !strings.Contains(got, "nextToken="+url.QueryEscape(nextToken)) {
+		t.Fatalf("encoded values %q do not preserve nextToken %q", got, nextToken)
+	}
+}
+
+func TestNormalizeListOmitsEmptyAndUnspecifiedValues(t *testing.T) {
+	t.Parallel()
+
+	query, err := NormalizeList(ListOptions{
+		Filters: map[string]string{
+			FilterStateName: "",
+			FilterName:      "kept exactly ",
+		},
+		MaxResults: 0,
+		NextToken:  "",
+	})
+	if err != nil {
+		t.Fatalf("NormalizeList() error = %v", err)
+	}
+	if got, want := query.Values(), (url.Values{"name": {"kept exactly "}}); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Values() = %#v, want %#v", got, want)
+	}
+	if got, want := query.FilterSummary(), "name"; got != want {
+		t.Fatalf("FilterSummary() = %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeListEmptySummary(t *testing.T) {
+	t.Parallel()
+
+	query, err := NormalizeList(ListOptions{})
+	if err != nil {
+		t.Fatalf("NormalizeList() error = %v", err)
+	}
+	if got := query.Values(); len(got) != 0 {
+		t.Fatalf("Values() = %#v, want empty", got)
+	}
+	if got := query.FilterSummary(); got != "none" {
+		t.Fatalf("FilterSummary() = %q, want none", got)
+	}
+}
+
+func TestListQueryValuesReturnsCopy(t *testing.T) {
+	t.Parallel()
+
+	query, err := NormalizeList(ListOptions{Filters: map[string]string{FilterName: "alpha"}})
+	if err != nil {
+		t.Fatalf("NormalizeList() error = %v", err)
+	}
+	values := query.Values()
+	values.Set(FilterName, "changed")
+	if got := query.Values().Get(FilterName); got != "alpha" {
+		t.Fatalf("Values().Get(%q) = %q after caller mutation, want alpha", FilterName, got)
+	}
+}
+
+func TestNormalizeListRejectsInvalidInputs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		options ListOptions
+		wantErr string
+	}{
+		{
+			name:    "unsupported filter",
+			options: ListOptions{Filters: map[string]string{"stateName": "review"}},
+			wantErr: `unsupported work-list filter "stateName"`,
+		},
+		{
+			name:    "unsupported empty filter",
+			options: ListOptions{Filters: map[string]string{"unknown": ""}},
+			wantErr: `unsupported work-list filter "unknown"`,
+		},
+		{
+			name:    "unsupported state type",
+			options: ListOptions{Filters: map[string]string{FilterStateType: "RUNNING"}},
+			wantErr: "state.type must be one of INITIAL, PROCESSING, TERMINAL, or FAILED",
+		},
+		{
+			name:    "unsupported sort",
+			options: ListOptions{SortBy: "name"},
+			wantErr: "sortBy must be state.type",
+		},
+		{
+			name:    "negative page size",
+			options: ListOptions{MaxResults: -1},
+			wantErr: "maxResults must be zero or greater",
+		},
+		{
+			name:    "malformed cursor",
+			options: ListOptions{NextToken: "not-base64"},
+			wantErr: "nextToken must be valid standard base64 for a non-empty cursor",
+		},
+		{
+			name:    "empty decoded cursor",
+			options: ListOptions{NextToken: "===="},
+			wantErr: "nextToken must be valid standard base64 for a non-empty cursor",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NormalizeList(tt.options)
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("NormalizeList() error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestNormalizeListAcceptsEveryStateType(t *testing.T) {
+	t.Parallel()
+
+	for _, stateType := range []string{"INITIAL", "PROCESSING", "TERMINAL", "FAILED"} {
+		stateType := stateType
+		t.Run(stateType, func(t *testing.T) {
+			t.Parallel()
+			query, err := NormalizeList(ListOptions{Filters: map[string]string{FilterStateType: stateType}})
+			if err != nil {
+				t.Fatalf("NormalizeList() error = %v", err)
+			}
+			if got := query.Values().Get(FilterStateType); got != stateType {
+				t.Fatalf("Values().Get(%q) = %q, want %q", FilterStateType, got, stateType)
+			}
+		})
+	}
+}


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "runtime-cleanup-work-query-boundary",
  "description": "Extract reusable work-list validation, query normalization, filter summaries, and typed session-scoped work route construction below CLI rendering while preserving established CLI, HTTP, and server behavior.",
  "context": {
    "customerAsk": "Move reusable work-list filter validation, query normalization, filter summaries, and session-scoped route construction into a domain or transport helper so CLI files own rendering and command behavior only.",
    "problem": "The work-list CLI currently owns partial validation, public query-key assembly, and filter summaries, while work commands build session-scoped endpoints from legacy path strings. This duplicates contract knowledge, leaves some malformed inputs to transport or server behavior, and forces query-only CLI tests through live httptest servers.",
    "solution": "Establish a pure work-query boundary that validates and normalizes filters and pagination, returns deterministic URL values and summaries, add typed work collection, item, and move route constructors, and adapt CLI work commands to consume those seams without changing rendering, diagnostics, timeout, or HTTP response behavior."
  },
  "acceptanceCriteria": [
    "One reusable work-query owner validates supported filter keys, work state type, sort field, page size, and pagination cursor before a work-list HTTP request is attempted.",
    "Valid work-list inputs produce the same public query keys and values as today, omit unspecified optional inputs, and report active filters in a stable deterministic order.",
    "Invalid query inputs return actionable validation errors without making a network request, including unsupported filter keys, unsupported state types or sort fields, negative page sizes, and malformed non-empty pagination cursors.",
    "Default-session and explicit-session work collection, item, and move routes are produced by typed route constructors that escape session and work identifiers as path segments.",
    "CLI work-list query construction is directly testable without a live httptest server when HTTP transport behavior is not under test; focused HTTP tests remain only for request and response integration behavior.",
    "Existing human and JSON work-list rendering, verbose diagnostics, timeout handling, and HTTP or API error behavior remain unchanged, and the change does not alter OpenAPI, backend list semantics, events, UI behavior, or public command flags.",
    "Typecheck, lint, and tests pass, including go test ./pkg/workquery ./pkg/cli/work and focused work-query normalization and session-path tests."
  ],
  "userStories": [
    {
      "id": "runtime-cleanup-work-query-boundary-001",
      "title": "Normalize and validate work-list queries",
      "description": "As a CLI and backend maintainer, I want one pure work-query contract to normalize and validate list inputs so accepted query behavior and local failures cannot drift between callers.",
      "acceptanceCriteria": [
        "The work-query owner accepts only the supported filter keys state.name, state.type, name, workTypeName, and traceId, plus the supported sortBy, maxResults, and nextToken controls.",
        "state.type accepts only INITIAL, PROCESSING, TERMINAL, or FAILED, and sortBy accepts only state.type when those inputs are present.",
        "A page size of zero is normalized as unspecified, a positive page size is encoded as maxResults, and a negative page size returns an actionable validation error.",
        "An empty pagination cursor is omitted; a non-empty cursor must be valid standard base64 for a non-empty cursor value and is preserved exactly for URL encoding.",
        "Empty optional filters are omitted, non-empty filter values are preserved, and normalized query values use the existing public key spellings.",
        "The active-filter summary is none when no filters or sort are set and otherwise lists active filter and sort keys once in the stable order state.name,state.type,name,workTypeName,traceId,sortBy.",
        "Focused pkg/workquery tests cover accepted combinations, deterministic normalization and summaries, and each invalid-input class without network I/O.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "runtime-cleanup-work-query-boundary-002",
      "title": "Construct typed session-scoped work routes",
      "description": "As a maintainer, I want typed work route constructors so every work command targets the same safely escaped default or explicit Factory Session paths without assembling legacy path strings.",
      "acceptanceCriteria": [
        "A work collection route constructor returns /factory-sessions/~default/work when the session is omitted and /factory-sessions/{escapedSessionId}/work for an explicit session.",
        "Work item and move route constructors append an independently escaped work ID segment and, for move, the /move suffix.",
        "Session IDs and work IDs containing / are escaped as individual path segments rather than changing the route hierarchy.",
        "you work list, you work show, and you work move obtain their endpoint paths from typed work-route constructors and no longer pass command-assembled /work legacy strings into a generic session-scoping function.",
        "Focused session-path tests prove collection, item, and move paths for omitted, explicit, and path-sensitive identifiers without network I/O.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "runtime-cleanup-work-query-boundary-003",
      "title": "Preserve CLI work-list behavior through the reusable query boundary",
      "description": "As an operator, I want you work list to keep its established output, diagnostics, and request behavior while invalid inputs fail before contacting the service and maintainers can prove query construction directly.",
      "acceptanceCriteria": [
        "you work list builds its request query and verbose filter summary from the normalized work-query result rather than independently interpreting list fields.",
        "Valid combinations of state, name, work type, trace, sort, page-size, and cursor inputs produce the expected session-scoped URL and URL-encoded query values in direct tests that do not start an httptest server.",
        "Invalid state type, sort field, negative page size, malformed pagination cursor, or unsupported filter key returns an actionable local error before any HTTP request is attempted.",
        "Existing human empty and success output, JSON response output, verbose request and response diagnostics, request timeout, and non-200 API error outcomes remain unchanged in their appropriate rendering or HTTP integration tests.",
        "HTTP-backed CLI tests are retained only where they prove transport or response behavior; query-only assertions are covered through the pure boundary.",
        "go test ./pkg/workquery ./pkg/cli/work passes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}
