### PR TITLE
session-repair-quiet-reload-regression

### DIFF
--- a/ui/src/App.session-stream.test.tsx
+++ b/ui/src/App.session-stream.test.tsx
@@ -25,6 +25,7 @@ import {
   renderAppWithDashboardShell,
   settleAppShellDashboardEffects,
 } from "./testing/app-shell-test-utils";
+import { createQuietCheckpointReloadFixture } from "./testing/quiet-checkpoint-reload-test-utils";
 import { APP_SHELL_RESOLVED_DEFAULT_SESSION_UUID } from "./testing/app-shell-session-preflight-test-utils";
 import { selectedTickTimelineEvents } from "./testing/app-shell-timeline-test-utils";
 
@@ -88,6 +89,67 @@ describe("App dashboard session stream loading", () => {
       expect(slider.value).toBe("1");
     });
     await settleAppShellDashboardEffects();
+  });
+
+  it("renders a restored tick-zero checkpoint after preflight and a quiet stream open", async () => {
+    const messages = getHeaderControlsMessages("en");
+    const fixture = createQuietCheckpointReloadFixture(0);
+    await fixture.installCheckpoint();
+
+    renderApp({
+      fetchOverride: fixture.fetchOverride,
+      seedTimelineFromSnapshot: false,
+      snapshot: semanticWorkflowDashboardSnapshot,
+    });
+
+    expect(fixture.observations()).toEqual({
+      checkpointHydrated: false,
+      eventArrived: false,
+      preflightCompleted: false,
+      streamOpened: false,
+    });
+
+    fixture.completePreflight();
+    await fixture.waitForCheckpointHydration();
+    const stream = await fixture.waitForStreamCreation();
+
+    expect(fixture.observations()).toEqual({
+      checkpointHydrated: true,
+      eventArrived: false,
+      preflightCompleted: true,
+      streamOpened: false,
+    });
+
+    act(() => {
+      fixture.openStream(stream);
+    });
+
+    expect(fixture.observations()).toEqual({
+      checkpointHydrated: true,
+      eventArrived: false,
+      preflightCompleted: true,
+      streamOpened: true,
+    });
+    expect(stream.messageEventCount).toBe(0);
+    expect(useFactoryTimelineStore.getState()).toMatchObject({
+      events: [],
+      mode: "current",
+      selectedTick: 0,
+    });
+    expect(
+      useFactoryTimelineStore.getState().worldViewCache[0]?.factory_state,
+    ).toBe("CHECKPOINT_CURRENT_AT_0");
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("heading", { name: messages.loadingDashboardTitle }),
+      ).toBeNull();
+      expect(
+        screen.getByRole<HTMLInputElement>("slider", {
+          name: messages.sliderAriaLabel,
+        }).value,
+      ).toBe("0");
+    });
   });
 });
 

--- a/ui/src/App.session-stream.test.tsx
+++ b/ui/src/App.session-stream.test.tsx
@@ -91,7 +91,7 @@ describe("App dashboard session stream loading", () => {
     await settleAppShellDashboardEffects();
   });
 
-  it("renders a restored tick-zero checkpoint after preflight and a quiet stream open", async () => {
+  it.fails("renders a restored tick-zero checkpoint after preflight and a quiet stream open", async () => {
     const messages = getHeaderControlsMessages("en");
     const fixture = createQuietCheckpointReloadFixture(0);
     await fixture.installCheckpoint();

--- a/ui/src/features/dashboard/lib/dashboard-world-view.test.ts
+++ b/ui/src/features/dashboard/lib/dashboard-world-view.test.ts
@@ -17,6 +17,11 @@ const RECOVERY_FAILED_STREAM = {
   message: "The dashboard could not restore this session automatically.",
 };
 
+const LIVE_STREAM = {
+  status: "live" as const,
+  message: "Factory event stream connected.",
+};
+
 describe("deriveDashboardWorldViewShellState", () => {
   it("reports initial loading while a session is selected and the stream is still connecting", () => {
     expect(
@@ -100,5 +105,35 @@ describe("deriveDashboardWorldViewShellState", () => {
     expect(errored.isInitialLoading).toBe(false);
     expect(errored.error?.message).toBe(RECOVERY_FAILED_STREAM.message);
     expect(errored.hasEvents).toBe(false);
+  });
+
+  it.fails("treats a hydrated tick-zero checkpoint as current while the reopened stream is quiet", () => {
+    const ready = deriveDashboardWorldViewShellState({
+      eventCount: 0,
+      rawSessionID: "session-alpha",
+      selectedTick: 0,
+      streamState: LIVE_STREAM,
+    });
+
+    expect(ready).toEqual({
+      error: null,
+      hasEvents: false,
+      isInitialLoading: false,
+    });
+  });
+
+  it("treats a hydrated nonzero checkpoint as current while the reopened stream is quiet", () => {
+    const ready = deriveDashboardWorldViewShellState({
+      eventCount: 0,
+      rawSessionID: "session-alpha",
+      selectedTick: 7,
+      streamState: LIVE_STREAM,
+    });
+
+    expect(ready).toEqual({
+      error: null,
+      hasEvents: false,
+      isInitialLoading: false,
+    });
   });
 });

--- a/ui/src/testing/app-shell-session-stream-test-utils.ts
+++ b/ui/src/testing/app-shell-session-stream-test-utils.ts
@@ -8,8 +8,10 @@ export class MockEventSource {
   public static instances: MockEventSource[] = [];
 
   public closed = false;
+  public messageEventCount = 0;
   public onerror: ((event: Event) => void) | null = null;
   public onopen: ((event: Event) => void) | null = null;
+  public opened = false;
 
   private readonly listeners = new Map<string, EventListener[]>();
 
@@ -27,7 +29,15 @@ export class MockEventSource {
     this.closed = true;
   }
 
+  public open(): void {
+    this.opened = true;
+    this.onopen?.(new Event("open"));
+  }
+
   public emit(type: string, data: unknown): void {
+    if (type === "message") {
+      this.messageEventCount += 1;
+    }
     if (type === "snapshot") {
       const state = useFactoryTimelineStore.getState();
       const tracesByWorkID =

--- a/ui/src/testing/quiet-checkpoint-reload-test-utils.test.ts
+++ b/ui/src/testing/quiet-checkpoint-reload-test-utils.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useFactoryTimelineStore } from "../features/timeline/state/factoryTimelineStore";
+import { MockEventSource } from "./app-shell-session-stream-test-utils";
+import { createQuietCheckpointReloadFixture } from "./quiet-checkpoint-reload-test-utils";
+
+describe.each([0, 7])("quiet checkpoint reload fixture at tick %i", (tick) => {
+  afterEach(() => {
+    MockEventSource.instances = [];
+    useFactoryTimelineStore.getState().reset();
+    vi.unstubAllGlobals();
+  });
+
+  it("controls hydration, preflight, stream opening, and event arrival independently", async () => {
+    const fixture = createQuietCheckpointReloadFixture(tick);
+    await fixture.installCheckpoint();
+    const preflight = fixture.fetchOverride(
+      "/factory-sessions/~default/sync-preflight?after_sequence=0",
+      "GET",
+      "/factory-sessions/~default/sync-preflight?after_sequence=0",
+    );
+
+    expect(fixture.observations()).toEqual({
+      checkpointHydrated: false,
+      eventArrived: false,
+      preflightCompleted: false,
+      streamOpened: false,
+    });
+
+    fixture.completePreflight();
+    await expect(preflight).resolves.toBeInstanceOf(Response);
+    expect(fixture.observations().preflightCompleted).toBe(true);
+    expect(fixture.observations().checkpointHydrated).toBe(false);
+
+    fixture.hydrateCheckpoint();
+    expect(fixture.observations()).toEqual({
+      checkpointHydrated: true,
+      eventArrived: false,
+      preflightCompleted: true,
+      streamOpened: false,
+    });
+
+    const stream = new MockEventSource("/factory-sessions/test/events");
+    fixture.openStream(stream);
+
+    expect(fixture.observations()).toEqual({
+      checkpointHydrated: true,
+      eventArrived: false,
+      preflightCompleted: true,
+      streamOpened: true,
+    });
+    expect(useFactoryTimelineStore.getState()).toMatchObject({
+      events: [],
+      mode: "current",
+      selectedTick: tick,
+    });
+    expect(
+      useFactoryTimelineStore.getState().worldViewCache[tick]?.factory_state,
+    ).toBe(`CHECKPOINT_CURRENT_AT_${tick}`);
+    expect(stream.messageEventCount).toBe(0);
+  });
+});

--- a/ui/src/testing/quiet-checkpoint-reload-test-utils.ts
+++ b/ui/src/testing/quiet-checkpoint-reload-test-utils.ts
@@ -1,0 +1,238 @@
+import { waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+
+import type { FactoryEvent } from "../api/events";
+import { useFactoryTimelineStore } from "../features/timeline/state/factoryTimelineStore";
+import { emptyReplayWorldState } from "../features/timeline/state/timeline/replayWorldStateSupport";
+import type { FactoryTimelineCheckpoint } from "../features/timeline/state/timeline/storeState";
+import {
+  persistTimelineCheckpoint,
+  type TimelineCheckpointStreamIdentity,
+} from "../features/timeline/state/timelineCheckpointPersistence";
+import type { RenderAppFetchOverride } from "./app-shell-fetch-test-utils";
+import { APP_SHELL_RESOLVED_DEFAULT_SESSION_UUID } from "./app-shell-session-preflight-test-utils";
+import { MockEventSource } from "./app-shell-session-stream-test-utils";
+
+const BACKEND_SCOPE_ID = "/workspace::test-backend";
+const LOGICAL_SESSION_KEY_ID = "lsk-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const STREAM_GENERATION_ID = "2026-06-26T00:00:00Z";
+
+interface StoredCheckpointEnvelope {
+  storageKey?: string;
+}
+
+export interface QuietCheckpointReloadObservations {
+  checkpointHydrated: boolean;
+  eventArrived: boolean;
+  preflightCompleted: boolean;
+  streamOpened: boolean;
+}
+
+export interface QuietCheckpointReloadFixture {
+  completePreflight: () => void;
+  fetchOverride: RenderAppFetchOverride;
+  hydrateCheckpoint: () => void;
+  installCheckpoint: () => Promise<void>;
+  observations: () => QuietCheckpointReloadObservations;
+  openStream: (stream?: MockEventSource) => MockEventSource;
+  scenario: {
+    checkpoint: FactoryTimelineCheckpoint;
+    streamIdentity: TimelineCheckpointStreamIdentity;
+    tick: number;
+  };
+  waitForCheckpointHydration: () => Promise<void>;
+  waitForStreamCreation: () => Promise<MockEventSource>;
+}
+
+function indexedDBRequest<T>(result: T, beforeSuccess?: () => void) {
+  const request = {
+    error: null,
+    onblocked: null,
+    onerror: null,
+    onsuccess: null,
+    onupgradeneeded: null,
+    result,
+  } as unknown as IDBRequest<T> & {
+    onupgradeneeded?: ((event: IDBVersionChangeEvent) => void) | null;
+  };
+
+  queueMicrotask(() => {
+    beforeSuccess?.();
+    request.onsuccess?.({} as Event);
+  });
+  return request;
+}
+
+function createIndexedDBTestDouble(): IDBFactory {
+  const records = new Map<string, StoredCheckpointEnvelope>();
+  const database = {
+    close: () => {},
+    createObjectStore: () => undefined,
+    deleteObjectStore: () => undefined,
+    objectStoreNames: { contains: () => true },
+    transaction: () => ({
+      objectStore: () => ({
+        delete: (key: string) =>
+          indexedDBRequest(undefined, () => records.delete(key)),
+        get: (key: string) => indexedDBRequest(records.get(key)),
+        getAll: () => indexedDBRequest([...records.values()]),
+        put: (value: StoredCheckpointEnvelope) =>
+          indexedDBRequest(value.storageKey ?? "", () => {
+            if (value.storageKey) {
+              records.set(value.storageKey, value);
+            }
+          }),
+      }),
+    }),
+  };
+
+  return {
+    open: () => {
+      const request = indexedDBRequest(database);
+      queueMicrotask(() =>
+        request.onupgradeneeded?.({} as IDBVersionChangeEvent),
+      );
+      return request;
+    },
+  } as unknown as IDBFactory;
+}
+
+function preflightResponse(checkpoint: FactoryTimelineCheckpoint): Response {
+  return new Response(
+    JSON.stringify({
+      backendScopeId: BACKEND_SCOPE_ID,
+      checkpointReusable: true,
+      factorySessionId: APP_SHELL_RESOLVED_DEFAULT_SESSION_UUID,
+      logicalSessionKeyId: LOGICAL_SESSION_KEY_ID,
+      reasonCode: "ok",
+      reconnectCursor: {
+        afterEventId: checkpoint.afterEventId,
+        afterSequence: checkpoint.afterSequence,
+        provided: true,
+        validForStreamGeneration: true,
+      },
+      requestedSessionId: "~default",
+      streamGenerationId: STREAM_GENERATION_ID,
+    }),
+    { headers: { "Content-Type": "application/json" } },
+  );
+}
+
+export function createQuietCheckpointReloadFixture(
+  tick: number,
+): QuietCheckpointReloadFixture {
+  const replayState = emptyReplayWorldState(tick);
+  replayState.factory_state = `CHECKPOINT_CURRENT_AT_${tick}`;
+  replayState.runtime.session.has_data = true;
+
+  const checkpoint: FactoryTimelineCheckpoint = {
+    afterEventId: `quiet-checkpoint-event-${tick}`,
+    afterSequence: tick,
+    replayState,
+    selectedTick: tick,
+    syncIdentity: {
+      backendScopeId: BACKEND_SCOPE_ID,
+      factorySessionId: APP_SHELL_RESOLVED_DEFAULT_SESSION_UUID,
+      logicalSessionKeyId: LOGICAL_SESSION_KEY_ID,
+      streamGenerationId: STREAM_GENERATION_ID,
+    },
+  };
+  const streamIdentity: TimelineCheckpointStreamIdentity = {
+    backendScopeID: BACKEND_SCOPE_ID,
+    factorySessionID: APP_SHELL_RESOLVED_DEFAULT_SESSION_UUID,
+    logicalSessionKeyID: LOGICAL_SESSION_KEY_ID,
+    streamGenerationID: STREAM_GENERATION_ID,
+  };
+  const observed = {
+    checkpointHydrated: false,
+    preflightCompleted: false,
+  };
+  let releasePreflight: (() => void) | undefined;
+  const preflightGate = new Promise<void>((resolve) => {
+    releasePreflight = resolve;
+  });
+
+  const fetchOverride: RenderAppFetchOverride = async (
+    path,
+    method,
+    _input,
+    init,
+  ) => {
+    if (method === "GET" && path.includes("/sync-preflight")) {
+      await preflightGate;
+      observed.preflightCompleted = true;
+      return preflightResponse(checkpoint);
+    }
+    if (
+      method === "GET" &&
+      path.includes("/events?") &&
+      new Headers(init?.headers).get("Accept") === "text/event-stream"
+    ) {
+      return new Response(null, { status: 200 });
+    }
+    return undefined;
+  };
+
+  return {
+    completePreflight: () => releasePreflight?.(),
+    fetchOverride,
+    hydrateCheckpoint: () => {
+      useFactoryTimelineStore.getState().restoreCheckpoint(checkpoint);
+      observed.checkpointHydrated = true;
+    },
+    installCheckpoint: async () => {
+      const indexedDB = createIndexedDBTestDouble();
+      vi.stubGlobal("indexedDB", indexedDB);
+      await persistTimelineCheckpoint(indexedDB, checkpoint, streamIdentity);
+    },
+    observations: () => {
+      const stream = MockEventSource.instances.at(-1);
+      return {
+        checkpointHydrated: observed.checkpointHydrated,
+        eventArrived: (stream?.messageEventCount ?? 0) > 0,
+        preflightCompleted: observed.preflightCompleted,
+        streamOpened: stream?.opened ?? false,
+      };
+    },
+    openStream: (stream = MockEventSource.instances.at(-1)) => {
+      if (!stream) {
+        throw new Error("expected quiet reload event stream to be created");
+      }
+      stream.open();
+      return stream;
+    },
+    scenario: { checkpoint, streamIdentity, tick },
+    waitForCheckpointHydration: async () => {
+      await waitFor(() => {
+        const state = useFactoryTimelineStore.getState();
+        if (
+          state.currentReplayCheckpoint?.afterEventId !==
+            checkpoint.afterEventId ||
+          state.selectedTick !== tick ||
+          state.worldViewCache[tick]?.factory_state !==
+            replayState.factory_state
+        ) {
+          throw new Error("quiet reload checkpoint has not hydrated");
+        }
+      });
+      observed.checkpointHydrated = true;
+    },
+    waitForStreamCreation: async () => {
+      let stream: MockEventSource | undefined;
+      await waitFor(() => {
+        stream = MockEventSource.instances.at(-1);
+        if (!stream) {
+          throw new Error("quiet reload event stream has not been created");
+        }
+      });
+      return stream as MockEventSource;
+    },
+  };
+}
+
+export function emitQuietReloadEvent(
+  stream: MockEventSource,
+  event: FactoryEvent,
+): void {
+  stream.emit("message", event);
+}

--- a/ui/src/testing/quiet-checkpoint-reload-test-utils.ts
+++ b/ui/src/testing/quiet-checkpoint-reload-test-utils.ts
@@ -1,7 +1,6 @@
 import { waitFor } from "@testing-library/react";
 import { vi } from "vitest";
 
-import type { FactoryEvent } from "../api/events";
 import { useFactoryTimelineStore } from "../features/timeline/state/factoryTimelineStore";
 import { emptyReplayWorldState } from "../features/timeline/state/timeline/replayWorldStateSupport";
 import type { FactoryTimelineCheckpoint } from "../features/timeline/state/timeline/storeState";
@@ -228,11 +227,4 @@ export function createQuietCheckpointReloadFixture(
       return stream as MockEventSource;
     },
   };
-}
-
-export function emitQuietReloadEvent(
-  stream: MockEventSource,
-  event: FactoryEvent,
-): void {
-  stream.emit("message", event);
 }


### PR DESCRIPTION
{
  "project": "Quiet Checkpoint Reload Regression Characterization",
  "branchName": "session-repair-quiet-reload-regression",
  "description": "Add deterministic, failing behavioral coverage proving that a dashboard restored from a valid checkpoint is current after successful sync preflight and SSE opening, even when no new stream event arrives. Cover both tick zero and a matching nonzero checkpoint without changing the production heuristic.",
  "context": {
    "customerAsk": "Add a failing behavioral regression that restores a valid tick-zero checkpoint, completes sync preflight, opens SSE without receiving a message, and proves the dashboard must render as current rather than waiting for events. Distinguish each reload milestone and include a matching nonzero checkpoint case.",
    "problem": "The dashboard world-view shell currently treats selected tick zero plus an empty in-memory event list as incomplete initial loading. A valid tick-zero checkpoint can already represent the current world while the resumed SSE stream legitimately remains quiet, so the dashboard can wait indefinitely and existing tests do not expose the defect.",
    "solution": "Create deterministic fixture controls for checkpoint hydration, successful sync preflight, SSE opening, and event arrival, then use them in focused world-view state and App-level mock EventSource regressions. Expect restored tick-zero and nonzero checkpoints to render as current before any new event, leaving the tick-zero case as an intentional failure against the existing heuristic for a follow-up repair."
  },
  "acceptanceCriteria": [
    "A deterministic fixture exposes separate observations for checkpoint hydration, successful session sync preflight, SSE connection opening, and SSE event arrival; no observation implicitly advances another.",
    "The tick-zero scenario restores a valid current checkpoint, completes preflight, opens SSE, emits no message, and expects the dashboard world-view shell to be ready rather than initially loading.",
    "The tick-zero regression demonstrably fails against the current selectedTick/events-length loading heuristic for the intended loading-shell reason.",
    "A matching valid nonzero checkpoint follows the same quiet-stream sequence and expects the same ready/current outcome, preventing a tick-specific workaround.",
    "Focused state-level and App-level coverage prove the behavior without changing production dashboard behavior or relying on source-topology, registration, route-inventory, or asset-bundle assertions.",
    "Typecheck and lint pass; existing tests remain green, and the focused regression run records the new characterization as the single intentional failure against the current heuristic."
  ],
  "userStories": [
    {
      "id": "session-repair-quiet-reload-regression-001",
      "title": "Control quiet reload milestones independently",
      "description": "As a dashboard maintainer, I want the reload fixture to control checkpoint hydration, sync preflight, SSE opening, and event arrival independently so that quiet-stream behavior can be reproduced without accidentally making the dashboard ready through an emitted event.",
      "acceptanceCriteria": [
        "The fixture can install a valid persisted checkpoint at tick zero and, using the same scenario shape, at a nonzero tick.",
        "The test can observe checkpoint hydration completing before it observes the SSE connection opening.",
        "The test can observe successful sync preflight independently from checkpoint hydration and SSE opening.",
        "Opening the mock EventSource does not emit an SSE message or mutate the fixture's event-arrival observation.",
        "The fixture can assert that no message arrived while retaining the hydrated checkpoint world as the selected current snapshot.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added a persisted-checkpoint quiet reload fixture with independent preflight, hydration, EventSource-open, and message-arrival observations for tick zero and tick seven."
    },
    {
      "id": "session-repair-quiet-reload-regression-002",
      "title": "Characterize restored dashboards as current before a new event",
      "description": "As a dashboard user reloading a valid session, I want the restored current world to render after checkpoint hydration and successful preflight even when the reopened event stream is quiet, so that I am not left waiting indefinitely for an event that may not occur.",
      "acceptanceCriteria": [
        "A focused dashboard world-view state test covers a valid hydrated tick-zero checkpoint with zero in-memory events and expects isInitialLoading to be false once preflight is successful and SSE is open without a message.",
        "The focused state regression fails under the current selectedTick === 0 plus empty-events heuristic, with the failure attributable to the incorrect loading result.",
        "The same focused state coverage includes a valid hydrated nonzero checkpoint, zero newly arrived events, successful preflight, and an open quiet stream, and expects the same ready/current shell state.",
        "An App-level mock EventSource reload test proves that the tick-zero checkpoint-backed dashboard content is rendered and the loading heading is absent after hydration, successful preflight, and stream opening, without emitting a stream message.",
        "The App-level fixture assertions distinguish checkpoint hydration, preflight completion, SSE opening, and the absence of event arrival.",
        "The regression does not change production logic, public contracts, user-facing copy, or unrelated dashboard tests.",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added pure world-view tick-zero and tick-seven quiet-stream readiness characterizations plus an App-level persisted tick-zero reload regression. The focused run reports the App loading-shell assertion as the single intentional failure under the unchanged production heuristic."
    }
  ]
}
