### PR TITLE
session-repair-multi-session-contamination-regression

### DIFF
--- a/ui/src/App.multi-session-checkpoint-debounce.test.tsx
+++ b/ui/src/App.multi-session-checkpoint-debounce.test.tsx
@@ -1,0 +1,229 @@
+import "./testing/app-shell-work-outcome-stub";
+import "./testing/app-shell-workflow-activity-stub";
+
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { requireEventStream } from "./App.session-stream.test-helpers";
+import type { DashboardSnapshot } from "./api/dashboard";
+import type { FactorySessionSummary } from "./api/factory-sessions/api";
+import { semanticWorkflowDashboardSnapshot } from "./components/dashboard/test-fixtures";
+import { useDashboardSessionStore } from "./features/dashboard/state/dashboardSessionStore";
+import {
+  readTimelineCheckpoint,
+  useFactoryTimelineStore,
+} from "./features/timeline/public";
+import {
+  jsonResponse,
+  MockEventSource,
+  type RenderAppFetchOverride,
+  registerAppDashboardTestLifecycle,
+  renderAppWithDashboardShell,
+} from "./testing/app-shell-test-utils";
+import {
+  MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO,
+  type MultiSessionTimelineCheckpointFixture,
+} from "./testing/multi-session-timeline-checkpoint-scenario";
+import { createTimelineCheckpointIndexedDBTestDouble } from "./testing/timeline-checkpoint-indexeddb-test-utils";
+
+const CHECKPOINT_DEBOUNCE_MS = 750;
+const { A, B } = MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO;
+
+const factorySessions: FactorySessionSummary[] = [
+  sessionSummary(A, "alpha"),
+  sessionSummary(B, "beta"),
+];
+
+function sessionSummary(
+  fixture: MultiSessionTimelineCheckpointFixture,
+  name: string,
+): FactorySessionSummary {
+  return {
+    factoryDir: `/workspace/${name}`,
+    folderPath: `/workspace/${name}`,
+    id: fixture.streamIdentity.factorySessionID,
+    isDefault: false,
+    project: name,
+    target: { kind: "named", name },
+  };
+}
+
+function snapshotFor(
+  fixture: MultiSessionTimelineCheckpointFixture,
+): DashboardSnapshot {
+  const snapshot = structuredClone(semanticWorkflowDashboardSnapshot);
+  snapshot.tick_count = fixture.checkpoint.selectedTick;
+  snapshot.runtime.session.dispatched_count = fixture.eventCount;
+  return snapshot;
+}
+
+function multiSessionPreflightFetch(): RenderAppFetchOverride {
+  return async (path, method) => {
+    if (method !== "GET") {
+      return undefined;
+    }
+    const match = path.match(/^\/factory-sessions\/([^/]+)\/sync-preflight/);
+    if (match) {
+      const sessionID = decodeURIComponent(match[1] ?? "");
+      const fixture = sessionID === A.streamIdentity.factorySessionID ? A : B;
+      return jsonResponse({
+        backendScopeId: fixture.streamIdentity.backendScopeID,
+        checkpointReusable: true,
+        factorySessionId: fixture.streamIdentity.factorySessionID,
+        logicalSessionKeyId: fixture.streamIdentity.logicalSessionKeyID,
+        reasonCode: "ok",
+        reconnectCursor: {
+          afterEventId: fixture.checkpoint.afterEventId,
+          afterSequence: fixture.checkpoint.afterSequence,
+          provided: true,
+          validForStreamGeneration: true,
+        },
+        requestedSessionId: sessionID,
+        streamGenerationId: fixture.streamIdentity.streamGenerationID,
+      });
+    }
+    if (/^\/factory-sessions\/[^/]+\/events\?/.test(path)) {
+      return new Response("event: ready\n\n", { status: 200 });
+    }
+    return undefined;
+  };
+}
+
+function expectedStreamURL(
+  fixture: MultiSessionTimelineCheckpointFixture,
+): string {
+  const query = new URLSearchParams({
+    after_event_id: fixture.checkpoint.afterEventId ?? "",
+    after_sequence: String(fixture.checkpoint.afterSequence),
+  });
+  return `/factory-sessions/${fixture.streamIdentity.factorySessionID}/events?${query}`;
+}
+
+async function flushFakeTimerEffects(): Promise<void> {
+  await act(async () => {
+    vi.advanceTimersByTime(0);
+    await Promise.resolve();
+  });
+}
+
+async function selectSession(
+  name: "alpha" | "beta",
+  fixture: MultiSessionTimelineCheckpointFixture,
+): Promise<void> {
+  fireEvent.click(screen.getByRole("tab", { name }));
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    await flushFakeTimerEffects();
+    if (MockEventSource.instances.at(-1)?.url === expectedStreamURL(fixture)) {
+      return;
+    }
+  }
+  expect(requireEventStream(MockEventSource.instances).url).toBe(
+    expectedStreamURL(fixture),
+  );
+}
+
+async function scheduleCheckpoint(
+  fixture: MultiSessionTimelineCheckpointFixture,
+): Promise<void> {
+  act(() => {
+    useFactoryTimelineStore.getState().restoreCheckpoint(fixture.checkpoint);
+  });
+  await flushFakeTimerEffects();
+  expect(useFactoryTimelineStore.getState().currentReplayCheckpoint).toEqual(
+    fixture.checkpoint,
+  );
+}
+
+async function advanceCheckpointTimer(milliseconds: number): Promise<void> {
+  await act(async () => {
+    vi.advanceTimersByTime(milliseconds);
+    await Promise.resolve();
+  });
+}
+
+describe("App multi-session checkpoint debounce regression", () => {
+  registerAppDashboardTestLifecycle();
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function renderSessionA(): Promise<IDBFactory> {
+    const { indexedDB } = createTimelineCheckpointIndexedDBTestDouble();
+    vi.stubGlobal("indexedDB", indexedDB);
+    useDashboardSessionStore.setState({
+      pausedSessionIDs: [],
+      selectedSessionID: A.streamIdentity.factorySessionID,
+    });
+    await renderAppWithDashboardShell({
+      factorySessions,
+      fetchOverride: multiSessionPreflightFetch(),
+      seedTimelineFromSnapshot: false,
+      snapshot: snapshotFor(A),
+    });
+    await waitFor(() => {
+      expect(requireEventStream(MockEventSource.instances).url).toBe(
+        expectedStreamURL(A),
+      );
+    });
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    return indexedDB;
+  }
+
+  it.fails("retains checkpoints that become due after A to B to A switching just before 750 ms", async () => {
+    const indexedDB = await renderSessionA();
+
+    await scheduleCheckpoint(A);
+    await advanceCheckpointTimer(CHECKPOINT_DEBOUNCE_MS - 1);
+    await selectSession("beta", B);
+    await scheduleCheckpoint(B);
+    await selectSession("alpha", A);
+    await advanceCheckpointTimer(1);
+
+    const aAtOriginalDueBoundary = await readTimelineCheckpoint(
+      indexedDB,
+      A.streamIdentity,
+    );
+
+    await scheduleCheckpoint(A);
+    await advanceCheckpointTimer(CHECKPOINT_DEBOUNCE_MS);
+    await selectSession("beta", B);
+    await scheduleCheckpoint(B);
+    await advanceCheckpointTimer(CHECKPOINT_DEBOUNCE_MS);
+
+    expect.soft(aAtOriginalDueBoundary).toEqual(A.checkpoint);
+    await expect(
+      readTimelineCheckpoint(indexedDB, A.streamIdentity),
+    ).resolves.toEqual(A.checkpoint);
+    await expect(
+      readTimelineCheckpoint(indexedDB, B.streamIdentity),
+    ).resolves.toEqual(B.checkpoint);
+  });
+
+  it("keeps A durable when switching A to B to A after its 750 ms boundary", async () => {
+    const indexedDB = await renderSessionA();
+
+    await scheduleCheckpoint(A);
+    await advanceCheckpointTimer(CHECKPOINT_DEBOUNCE_MS);
+    await expect(
+      readTimelineCheckpoint(indexedDB, A.streamIdentity),
+    ).resolves.toEqual(A.checkpoint);
+
+    await selectSession("beta", B);
+    await scheduleCheckpoint(B);
+    await advanceCheckpointTimer(CHECKPOINT_DEBOUNCE_MS);
+    await selectSession("alpha", A);
+
+    expect(requireEventStream(MockEventSource.instances).url).toBe(
+      expectedStreamURL(A),
+    );
+    expect(useFactoryTimelineStore.getState().selectedTick).toBe(
+      A.checkpoint.selectedTick,
+    );
+    await expect(
+      readTimelineCheckpoint(indexedDB, A.streamIdentity),
+    ).resolves.toEqual(A.checkpoint);
+    await expect(
+      readTimelineCheckpoint(indexedDB, B.streamIdentity),
+    ).resolves.toEqual(B.checkpoint);
+  });
+});

--- a/ui/src/App.multi-session-timeline-isolation.test.tsx
+++ b/ui/src/App.multi-session-timeline-isolation.test.tsx
@@ -1,0 +1,257 @@
+import "./testing/app-shell-work-outcome-stub";
+import "./testing/app-shell-workflow-activity-stub";
+
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { requireEventStream } from "./App.session-stream.test-helpers";
+import type { DashboardSnapshot } from "./api/dashboard";
+import type { FactorySessionSummary } from "./api/factory-sessions/api";
+import { semanticWorkflowDashboardSnapshot } from "./components/dashboard/test-fixtures";
+import { useDashboardSessionStore } from "./features/dashboard/state/dashboardSessionStore";
+import { sessionStreamToggleLabel } from "./features/header/lib/dashboard-session-tabs-utils";
+import { getHeaderControlsMessages } from "./features/header/messages/header-controls";
+import {
+  persistTimelineCheckpoint,
+  readTimelineCheckpoint,
+  useFactoryTimelineStore,
+} from "./features/timeline/public";
+import {
+  jsonResponse,
+  MockEventSource,
+  type RenderAppFetchOverride,
+  registerAppDashboardTestLifecycle,
+  renderAppWithDashboardShell,
+} from "./testing/app-shell-test-utils";
+import { MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO } from "./testing/multi-session-timeline-checkpoint-scenario";
+import { createTimelineCheckpointIndexedDBTestDouble } from "./testing/timeline-checkpoint-indexeddb-test-utils";
+
+const { A, B } = MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO;
+
+const factorySessions: FactorySessionSummary[] = [
+  sessionSummary(A.streamIdentity.factorySessionID, "alpha"),
+  sessionSummary(B.streamIdentity.factorySessionID, "beta"),
+];
+
+function sessionSummary(id: string, name: string): FactorySessionSummary {
+  return {
+    factoryDir: `/workspace/${name}`,
+    folderPath: `/workspace/${name}`,
+    id,
+    isDefault: false,
+    project: name,
+    target: { kind: "named", name },
+  };
+}
+
+function snapshotFor(fixture: typeof A | typeof B): DashboardSnapshot {
+  const snapshot = structuredClone(semanticWorkflowDashboardSnapshot);
+  snapshot.tick_count = fixture.checkpoint.selectedTick;
+  snapshot.runtime.session.dispatched_count = fixture.eventCount;
+  return snapshot;
+}
+
+function multiSessionPreflightFetch(): RenderAppFetchOverride {
+  return async (path, method) => {
+    if (
+      method === "DELETE" &&
+      path === `/factory-sessions/${A.streamIdentity.factorySessionID}`
+    ) {
+      return new Response(null, { status: 204 });
+    }
+    if (method !== "GET") {
+      return undefined;
+    }
+
+    const preflightMatch = path.match(
+      /^\/factory-sessions\/([^/]+)\/sync-preflight/,
+    );
+    if (preflightMatch) {
+      const sessionID = decodeURIComponent(preflightMatch[1] ?? "");
+      const fixture = sessionID === A.streamIdentity.factorySessionID ? A : B;
+      return jsonResponse({
+        backendScopeId: fixture.streamIdentity.backendScopeID,
+        checkpointReusable: true,
+        factorySessionId: fixture.streamIdentity.factorySessionID,
+        logicalSessionKeyId: fixture.streamIdentity.logicalSessionKeyID,
+        reasonCode: "ok",
+        reconnectCursor: {
+          afterEventId: fixture.checkpoint.afterEventId,
+          afterSequence: fixture.checkpoint.afterSequence,
+          provided: true,
+          validForStreamGeneration: true,
+        },
+        requestedSessionId: sessionID,
+        streamGenerationId: fixture.streamIdentity.streamGenerationID,
+      });
+    }
+
+    if (/^\/factory-sessions\/[^/]+\/events\?/.test(path)) {
+      return new Response("event: ready\n\n", { status: 200 });
+    }
+    return undefined;
+  };
+}
+
+function expectedStreamURL(fixture: typeof A | typeof B): string {
+  const query = new URLSearchParams({
+    after_event_id: fixture.checkpoint.afterEventId ?? "",
+    after_sequence: String(fixture.checkpoint.afterSequence),
+  });
+  return `/factory-sessions/${fixture.streamIdentity.factorySessionID}/events?${query}`;
+}
+
+async function selectSessionTab(name: "alpha" | "beta"): Promise<void> {
+  fireEvent.click(await screen.findByRole("tab", { name }));
+}
+
+function expectRenderedFixture(fixture: typeof A | typeof B): void {
+  const timeline = useFactoryTimelineStore.getState();
+  expect(timeline.selectedTick).toBe(fixture.checkpoint.selectedTick);
+  expect(
+    timeline.currentReplayCheckpoint?.replayState.runtime.session
+      .dispatched_count,
+  ).toBe(fixture.eventCount);
+  expect(
+    screen.getByRole<HTMLInputElement>("slider", { name: "Timeline tick" })
+      .value,
+  ).toBe(String(fixture.checkpoint.selectedTick));
+}
+
+describe("App multi-session timeline switching regression", () => {
+  registerAppDashboardTestLifecycle();
+
+  it.fails("restores each live A to B to A timeline instead of retaining the singleton's latest contents", async () => {
+    const { indexedDB } = createTimelineCheckpointIndexedDBTestDouble();
+    vi.stubGlobal("indexedDB", indexedDB);
+    useDashboardSessionStore.setState({
+      pausedSessionIDs: [],
+      selectedSessionID: A.streamIdentity.factorySessionID,
+    });
+
+    await renderAppWithDashboardShell({
+      factorySessions,
+      fetchOverride: multiSessionPreflightFetch(),
+      seedTimelineFromSnapshot: false,
+      snapshot: snapshotFor(A),
+    });
+
+    await waitFor(() => {
+      expect(requireEventStream(MockEventSource.instances).url).toBe(
+        expectedStreamURL(A),
+      );
+    });
+    act(() => {
+      requireEventStream(MockEventSource.instances).emit(
+        "snapshot",
+        snapshotFor(A),
+      );
+    });
+    await waitFor(() => expectRenderedFixture(A));
+
+    await selectSessionTab("beta");
+    await waitFor(() => {
+      expect(requireEventStream(MockEventSource.instances).url).toBe(
+        expectedStreamURL(B),
+      );
+    });
+    act(() => {
+      requireEventStream(MockEventSource.instances).emit(
+        "snapshot",
+        snapshotFor(B),
+      );
+    });
+    await waitFor(() => expectRenderedFixture(B));
+
+    await selectSessionTab("alpha");
+    await waitFor(() => {
+      expect(requireEventStream(MockEventSource.instances).url).toBe(
+        expectedStreamURL(A),
+      );
+      expectRenderedFixture(A);
+    });
+  });
+});
+
+describe("App multi-session timeline action isolation", () => {
+  registerAppDashboardTestLifecycle();
+
+  it("pauses only A while B keeps its persisted timeline, cursor, and live stream", async () => {
+    const messages = getHeaderControlsMessages("en");
+    const { indexedDB } = createTimelineCheckpointIndexedDBTestDouble();
+    vi.stubGlobal("indexedDB", indexedDB);
+    await persistTimelineCheckpoint(indexedDB, A.checkpoint, A.streamIdentity);
+    await persistTimelineCheckpoint(indexedDB, B.checkpoint, B.streamIdentity);
+    useDashboardSessionStore.setState({
+      pausedSessionIDs: [],
+      selectedSessionID: A.streamIdentity.factorySessionID,
+    });
+
+    await renderAppWithDashboardShell({
+      factorySessions,
+      fetchOverride: multiSessionPreflightFetch(),
+      seedTimelineFromSnapshot: false,
+      snapshot: snapshotFor(A),
+    });
+    await waitFor(() => expectRenderedFixture(A));
+    const aStream = requireEventStream(MockEventSource.instances);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: sessionStreamToggleLabel(factorySessions[0], false, messages),
+      }),
+    );
+    await waitFor(() => {
+      expect(aStream.closed).toBe(true);
+      expect(useDashboardSessionStore.getState().pausedSessionIDs).toEqual([
+        A.streamIdentity.factorySessionID,
+      ]);
+    });
+
+    await selectSessionTab("beta");
+    await waitFor(() => {
+      expect(requireEventStream(MockEventSource.instances).url).toBe(
+        expectedStreamURL(B),
+      );
+      expectRenderedFixture(B);
+    });
+    expect(requireEventStream(MockEventSource.instances).closed).toBe(false);
+    expect(useDashboardSessionStore.getState().pausedSessionIDs).not.toContain(
+      B.streamIdentity.factorySessionID,
+    );
+    await expect(
+      readTimelineCheckpoint(indexedDB, B.streamIdentity),
+    ).resolves.toEqual(B.checkpoint);
+  });
+
+  it.fails("clears only A's recovery checkpoint when A is closed from the session tabs", async () => {
+    const { indexedDB } = createTimelineCheckpointIndexedDBTestDouble();
+    vi.stubGlobal("indexedDB", indexedDB);
+    await persistTimelineCheckpoint(indexedDB, A.checkpoint, A.streamIdentity);
+    await persistTimelineCheckpoint(indexedDB, B.checkpoint, B.streamIdentity);
+    useDashboardSessionStore.setState({
+      pausedSessionIDs: [],
+      selectedSessionID: A.streamIdentity.factorySessionID,
+    });
+
+    await renderAppWithDashboardShell({
+      factorySessions,
+      fetchOverride: multiSessionPreflightFetch(),
+      seedTimelineFromSnapshot: false,
+      snapshot: snapshotFor(A),
+    });
+    await waitFor(() => expectRenderedFixture(A));
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Close alpha session" }),
+    );
+
+    await waitFor(async () => {
+      await expect(
+        readTimelineCheckpoint(indexedDB, A.streamIdentity),
+      ).resolves.toBe(null);
+      await expect(
+        readTimelineCheckpoint(indexedDB, B.streamIdentity),
+      ).resolves.toEqual(B.checkpoint);
+    });
+  });
+});

--- a/ui/src/App.multi-session-timeline-isolation.test.tsx
+++ b/ui/src/App.multi-session-timeline-isolation.test.tsx
@@ -223,7 +223,7 @@ describe("App multi-session timeline action isolation", () => {
     ).resolves.toEqual(B.checkpoint);
   });
 
-  it.fails("clears only A's recovery checkpoint when A is closed from the session tabs", async () => {
+  it.fails("clears only A while B keeps its timeline, cursor, checkpoint, and live stream", async () => {
     const { indexedDB } = createTimelineCheckpointIndexedDBTestDouble();
     vi.stubGlobal("indexedDB", indexedDB);
     await persistTimelineCheckpoint(indexedDB, A.checkpoint, A.streamIdentity);
@@ -240,18 +240,28 @@ describe("App multi-session timeline action isolation", () => {
       snapshot: snapshotFor(A),
     });
     await waitFor(() => expectRenderedFixture(A));
+    const aStream = requireEventStream(MockEventSource.instances);
 
     fireEvent.click(
       screen.getByRole("button", { name: "Close alpha session" }),
     );
 
-    await waitFor(async () => {
-      await expect(
-        readTimelineCheckpoint(indexedDB, A.streamIdentity),
-      ).resolves.toBe(null);
-      await expect(
-        readTimelineCheckpoint(indexedDB, B.streamIdentity),
-      ).resolves.toEqual(B.checkpoint);
+    await waitFor(() => {
+      expect(aStream.closed).toBe(true);
+      expect(useDashboardSessionStore.getState().selectedSessionID).toBe(
+        B.streamIdentity.factorySessionID,
+      );
+      expect(requireEventStream(MockEventSource.instances).url).toBe(
+        expectedStreamURL(B),
+      );
+      expectRenderedFixture(B);
     });
+    expect(requireEventStream(MockEventSource.instances).closed).toBe(false);
+    await expect(
+      readTimelineCheckpoint(indexedDB, B.streamIdentity),
+    ).resolves.toEqual(B.checkpoint);
+    await expect(
+      readTimelineCheckpoint(indexedDB, A.streamIdentity),
+    ).resolves.toBe(null);
   });
 });

--- a/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.multi-session.test.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.multi-session.test.ts
@@ -64,9 +64,9 @@ describe("multi-session timeline checkpoint identity regression", () => {
     ).resolves.toBe(null);
   });
 
-  it.fails.each(
+  it.each(
     checkpointInsertionOrders,
-  )("keeps B intact when ~default is cleared as resolved session A after %s then %s insertion", async (...order) => {
+  )("keeps B intact when resolved session A is cleared after %s then %s insertion", async (...order) => {
     const { indexedDB } = createTimelineCheckpointIndexedDBTestDouble();
     const { A, B } = MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO;
     await persistScenarioInOrder(indexedDB, order);
@@ -90,19 +90,29 @@ describe("multi-session timeline checkpoint identity regression", () => {
       )?.checkpoint,
       B,
     );
+  });
 
-    await persistTimelineCheckpoint(indexedDB, A.checkpoint, A.streamIdentity);
+  it.fails.each(
+    checkpointInsertionOrders,
+  )("does not clear either concrete checkpoint for ambiguous ~default after %s then %s insertion", async (...order) => {
+    const { indexedDB } = createTimelineCheckpointIndexedDBTestDouble();
+    const { A, B } = MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO;
+    await persistScenarioInOrder(indexedDB, order);
+
     await clearTimelineCheckpointsForSession(
       indexedDB,
       DEFAULT_FACTORY_SESSION_ID,
     );
 
-    await expect(
-      peekPersistedTimelineCheckpoint(
-        indexedDB,
-        A.streamIdentity.factorySessionID,
-      ),
-    ).resolves.toBe(null);
+    expectCheckpointToMatchScenario(
+      (
+        await peekPersistedTimelineCheckpoint(
+          indexedDB,
+          A.streamIdentity.factorySessionID,
+        )
+      )?.checkpoint,
+      A,
+    );
     expectCheckpointToMatchScenario(
       (
         await peekPersistedTimelineCheckpoint(

--- a/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.multi-session.test.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.multi-session.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_FACTORY_SESSION_ID } from "../../../../api/session-routing";
+import { MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO } from "../../../../testing/multi-session-timeline-checkpoint-scenario";
+import { createTimelineCheckpointIndexedDBTestDouble } from "../../../../testing/timeline-checkpoint-indexeddb-test-utils";
+import type { FactoryTimelineCheckpoint } from "../timeline/storeState";
+import {
+  clearTimelineCheckpointsForSession,
+  peekPersistedTimelineCheckpoint,
+  persistTimelineCheckpoint,
+} from "../timelineCheckpointPersistence";
+
+const checkpointInsertionOrders = [
+  ["A", "B"],
+  ["B", "A"],
+] as const;
+
+async function persistScenarioInOrder(
+  indexedDB: IDBFactory,
+  order: (typeof checkpointInsertionOrders)[number],
+): Promise<void> {
+  for (const sessionLabel of order) {
+    const session = MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO[sessionLabel];
+    await persistTimelineCheckpoint(
+      indexedDB,
+      session.checkpoint,
+      session.streamIdentity,
+    );
+  }
+}
+
+function expectCheckpointToMatchScenario(
+  checkpoint: FactoryTimelineCheckpoint | null | undefined,
+  session: (typeof MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO)["A" | "B"],
+): void {
+  expect(checkpoint?.selectedTick).toBe(session.checkpoint.selectedTick);
+  expect(checkpoint?.afterEventId).toBe(session.checkpoint.afterEventId);
+  expect(checkpoint?.afterSequence).toBe(session.checkpoint.afterSequence);
+  expect(checkpoint?.replayState.runtime.session.dispatched_count).toBe(
+    session.eventCount,
+  );
+}
+
+describe("multi-session timeline checkpoint identity regression", () => {
+  it.fails.each(
+    checkpointInsertionOrders,
+  )("does not choose an arbitrary concrete checkpoint for ~default after %s then %s insertion", async (...order) => {
+    const { indexedDB } = createTimelineCheckpointIndexedDBTestDouble();
+    const { A, B } = MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO;
+    await persistScenarioInOrder(indexedDB, order);
+
+    const selectedA = await peekPersistedTimelineCheckpoint(
+      indexedDB,
+      A.streamIdentity.factorySessionID,
+    );
+    const selectedB = await peekPersistedTimelineCheckpoint(
+      indexedDB,
+      B.streamIdentity.factorySessionID,
+    );
+    expectCheckpointToMatchScenario(selectedA?.checkpoint, A);
+    expectCheckpointToMatchScenario(selectedB?.checkpoint, B);
+
+    await expect(
+      peekPersistedTimelineCheckpoint(indexedDB, DEFAULT_FACTORY_SESSION_ID),
+    ).resolves.toBe(null);
+  });
+
+  it.fails.each(
+    checkpointInsertionOrders,
+  )("keeps B intact when ~default is cleared as resolved session A after %s then %s insertion", async (...order) => {
+    const { indexedDB } = createTimelineCheckpointIndexedDBTestDouble();
+    const { A, B } = MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO;
+    await persistScenarioInOrder(indexedDB, order);
+
+    await clearTimelineCheckpointsForSession(
+      indexedDB,
+      A.streamIdentity.factorySessionID,
+    );
+    await expect(
+      peekPersistedTimelineCheckpoint(
+        indexedDB,
+        A.streamIdentity.factorySessionID,
+      ),
+    ).resolves.toBe(null);
+    expectCheckpointToMatchScenario(
+      (
+        await peekPersistedTimelineCheckpoint(
+          indexedDB,
+          B.streamIdentity.factorySessionID,
+        )
+      )?.checkpoint,
+      B,
+    );
+
+    await persistTimelineCheckpoint(indexedDB, A.checkpoint, A.streamIdentity);
+    await clearTimelineCheckpointsForSession(
+      indexedDB,
+      DEFAULT_FACTORY_SESSION_ID,
+    );
+
+    await expect(
+      peekPersistedTimelineCheckpoint(
+        indexedDB,
+        A.streamIdentity.factorySessionID,
+      ),
+    ).resolves.toBe(null);
+    expectCheckpointToMatchScenario(
+      (
+        await peekPersistedTimelineCheckpoint(
+          indexedDB,
+          B.streamIdentity.factorySessionID,
+        )
+      )?.checkpoint,
+      B,
+    );
+  });
+});

--- a/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.test.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_FACTORY_SESSION_ID } from "../../../../api/session-routing";
-import { MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO } from "../../../../testing/multi-session-timeline-checkpoint-scenario";
 import {
   readSessionPersistenceInvalidationRecords,
   resetSessionPersistenceInvalidationRecords,
@@ -9,8 +8,6 @@ import { emptyReplayWorldState } from "../timeline/replayWorldStateSupport";
 import type { FactoryTimelineCheckpoint } from "../timeline/storeState";
 import {
   clearTimelineCheckpoint,
-  clearTimelineCheckpointsForSession,
-  peekPersistedTimelineCheckpoint,
   persistTimelineCheckpoint,
   purgeLegacyTimelineCheckpoints,
   readTimelineCheckpoint,
@@ -200,121 +197,6 @@ describe("timeline checkpoint persistence", () => {
   });
 });
 
-const checkpointInsertionOrders = [
-  ["A", "B"],
-  ["B", "A"],
-] as const;
-
-async function persistScenarioInOrder(
-  indexedDB: IDBFactory,
-  order: (typeof checkpointInsertionOrders)[number],
-): Promise<void> {
-  for (const sessionLabel of order) {
-    const session = MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO[sessionLabel];
-    await persistTimelineCheckpoint(
-      indexedDB,
-      session.checkpoint,
-      session.streamIdentity,
-    );
-  }
-}
-
-function expectCheckpointToMatchScenario(
-  checkpoint: FactoryTimelineCheckpoint | null | undefined,
-  session: (typeof MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO)["A" | "B"],
-): void {
-  expect(checkpoint?.selectedTick).toBe(session.checkpoint.selectedTick);
-  expect(checkpoint?.afterEventId).toBe(session.checkpoint.afterEventId);
-  expect(checkpoint?.afterSequence).toBe(session.checkpoint.afterSequence);
-  expect(checkpoint?.replayState.runtime.session.dispatched_count).toBe(
-    session.eventCount,
-  );
-}
-
-describe("multi-session timeline checkpoint identity regression", () => {
-  it.fails.each(checkpointInsertionOrders)(
-    "does not choose an arbitrary concrete checkpoint for ~default after %s then %s insertion",
-    async (...order) => {
-      const { indexedDB } = createIndexedDBTestDouble();
-      const { A, B } = MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO;
-      await persistScenarioInOrder(indexedDB, order);
-
-      const selectedA = await peekPersistedTimelineCheckpoint(
-        indexedDB,
-        A.streamIdentity.factorySessionID,
-      );
-      const selectedB = await peekPersistedTimelineCheckpoint(
-        indexedDB,
-        B.streamIdentity.factorySessionID,
-      );
-      expectCheckpointToMatchScenario(selectedA?.checkpoint, A);
-      expectCheckpointToMatchScenario(selectedB?.checkpoint, B);
-
-      await expect(
-        peekPersistedTimelineCheckpoint(
-          indexedDB,
-          DEFAULT_FACTORY_SESSION_ID,
-        ),
-      ).resolves.toBe(null);
-    },
-  );
-
-  it.fails.each(checkpointInsertionOrders)(
-    "keeps B intact when ~default is cleared as resolved session A after %s then %s insertion",
-    async (...order) => {
-      const { indexedDB } = createIndexedDBTestDouble();
-      const { A, B } = MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO;
-      await persistScenarioInOrder(indexedDB, order);
-
-      await clearTimelineCheckpointsForSession(
-        indexedDB,
-        A.streamIdentity.factorySessionID,
-      );
-      await expect(
-        peekPersistedTimelineCheckpoint(
-          indexedDB,
-          A.streamIdentity.factorySessionID,
-        ),
-      ).resolves.toBe(null);
-      expectCheckpointToMatchScenario(
-        (
-          await peekPersistedTimelineCheckpoint(
-            indexedDB,
-            B.streamIdentity.factorySessionID,
-          )
-        )?.checkpoint,
-        B,
-      );
-
-      await persistTimelineCheckpoint(
-        indexedDB,
-        A.checkpoint,
-        A.streamIdentity,
-      );
-      await clearTimelineCheckpointsForSession(
-        indexedDB,
-        DEFAULT_FACTORY_SESSION_ID,
-      );
-
-      await expect(
-        peekPersistedTimelineCheckpoint(
-          indexedDB,
-          A.streamIdentity.factorySessionID,
-        ),
-      ).resolves.toBe(null);
-      expectCheckpointToMatchScenario(
-        (
-          await peekPersistedTimelineCheckpoint(
-            indexedDB,
-            B.streamIdentity.factorySessionID,
-          )
-        )?.checkpoint,
-        B,
-      );
-    },
-  );
-});
-
 describe("timeline checkpoint persistence diagnostics", () => {
   it("records user-initiated checkpoint clears through session persistence diagnostics", async () => {
     resetSessionPersistenceInvalidationRecords();
@@ -443,10 +325,7 @@ describe("timeline checkpoint persistence resilience", () => {
     const readFailure = createIndexedDBTestDouble({ failOpen: true });
 
     await expect(
-      readTimelineCheckpoint(
-        readFailure.indexedDB,
-        streamIdentityFixture(),
-      ),
+      readTimelineCheckpoint(readFailure.indexedDB, streamIdentityFixture()),
     ).resolves.toBe(null);
   });
 });
@@ -514,9 +393,9 @@ describe("timeline checkpoint guard migration", () => {
 
     await persistTimelineCheckpoint(indexedDB, checkpoint, identityA);
 
-    await expect(
-      readTimelineCheckpoint(indexedDB, identityB),
-    ).resolves.toBe(null);
+    await expect(readTimelineCheckpoint(indexedDB, identityB)).resolves.toBe(
+      null,
+    );
   });
 });
 

--- a/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.test.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_FACTORY_SESSION_ID } from "../../../../api/session-routing";
+import { MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO } from "../../../../testing/multi-session-timeline-checkpoint-scenario";
 import {
   readSessionPersistenceInvalidationRecords,
   resetSessionPersistenceInvalidationRecords,
@@ -8,6 +9,8 @@ import { emptyReplayWorldState } from "../timeline/replayWorldStateSupport";
 import type { FactoryTimelineCheckpoint } from "../timeline/storeState";
 import {
   clearTimelineCheckpoint,
+  clearTimelineCheckpointsForSession,
+  peekPersistedTimelineCheckpoint,
   persistTimelineCheckpoint,
   purgeLegacyTimelineCheckpoints,
   readTimelineCheckpoint,
@@ -53,6 +56,7 @@ function createIndexedDBTestDouble(
             records.delete(key);
           }),
         get: (key: string) => indexedDBRequest(records.get(key)),
+        getAll: () => indexedDBRequest(Array.from(records.values())),
         put: (value: StoredCheckpointEnvelope) =>
           options.failPut
             ? indexedDBErrorRequest<string>(new Error("put failed"))
@@ -194,6 +198,121 @@ describe("timeline checkpoint persistence", () => {
       streamGenerationId: "stream-a",
     });
   });
+});
+
+const checkpointInsertionOrders = [
+  ["A", "B"],
+  ["B", "A"],
+] as const;
+
+async function persistScenarioInOrder(
+  indexedDB: IDBFactory,
+  order: (typeof checkpointInsertionOrders)[number],
+): Promise<void> {
+  for (const sessionLabel of order) {
+    const session = MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO[sessionLabel];
+    await persistTimelineCheckpoint(
+      indexedDB,
+      session.checkpoint,
+      session.streamIdentity,
+    );
+  }
+}
+
+function expectCheckpointToMatchScenario(
+  checkpoint: FactoryTimelineCheckpoint | null | undefined,
+  session: (typeof MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO)["A" | "B"],
+): void {
+  expect(checkpoint?.selectedTick).toBe(session.checkpoint.selectedTick);
+  expect(checkpoint?.afterEventId).toBe(session.checkpoint.afterEventId);
+  expect(checkpoint?.afterSequence).toBe(session.checkpoint.afterSequence);
+  expect(checkpoint?.replayState.runtime.session.dispatched_count).toBe(
+    session.eventCount,
+  );
+}
+
+describe("multi-session timeline checkpoint identity regression", () => {
+  it.fails.each(checkpointInsertionOrders)(
+    "does not choose an arbitrary concrete checkpoint for ~default after %s then %s insertion",
+    async (...order) => {
+      const { indexedDB } = createIndexedDBTestDouble();
+      const { A, B } = MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO;
+      await persistScenarioInOrder(indexedDB, order);
+
+      const selectedA = await peekPersistedTimelineCheckpoint(
+        indexedDB,
+        A.streamIdentity.factorySessionID,
+      );
+      const selectedB = await peekPersistedTimelineCheckpoint(
+        indexedDB,
+        B.streamIdentity.factorySessionID,
+      );
+      expectCheckpointToMatchScenario(selectedA?.checkpoint, A);
+      expectCheckpointToMatchScenario(selectedB?.checkpoint, B);
+
+      await expect(
+        peekPersistedTimelineCheckpoint(
+          indexedDB,
+          DEFAULT_FACTORY_SESSION_ID,
+        ),
+      ).resolves.toBe(null);
+    },
+  );
+
+  it.fails.each(checkpointInsertionOrders)(
+    "keeps B intact when ~default is cleared as resolved session A after %s then %s insertion",
+    async (...order) => {
+      const { indexedDB } = createIndexedDBTestDouble();
+      const { A, B } = MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO;
+      await persistScenarioInOrder(indexedDB, order);
+
+      await clearTimelineCheckpointsForSession(
+        indexedDB,
+        A.streamIdentity.factorySessionID,
+      );
+      await expect(
+        peekPersistedTimelineCheckpoint(
+          indexedDB,
+          A.streamIdentity.factorySessionID,
+        ),
+      ).resolves.toBe(null);
+      expectCheckpointToMatchScenario(
+        (
+          await peekPersistedTimelineCheckpoint(
+            indexedDB,
+            B.streamIdentity.factorySessionID,
+          )
+        )?.checkpoint,
+        B,
+      );
+
+      await persistTimelineCheckpoint(
+        indexedDB,
+        A.checkpoint,
+        A.streamIdentity,
+      );
+      await clearTimelineCheckpointsForSession(
+        indexedDB,
+        DEFAULT_FACTORY_SESSION_ID,
+      );
+
+      await expect(
+        peekPersistedTimelineCheckpoint(
+          indexedDB,
+          A.streamIdentity.factorySessionID,
+        ),
+      ).resolves.toBe(null);
+      expectCheckpointToMatchScenario(
+        (
+          await peekPersistedTimelineCheckpoint(
+            indexedDB,
+            B.streamIdentity.factorySessionID,
+          )
+        )?.checkpoint,
+        B,
+      );
+    },
+  );
 });
 
 describe("timeline checkpoint persistence diagnostics", () => {

--- a/ui/src/testing/multi-session-timeline-checkpoint-scenario.ts
+++ b/ui/src/testing/multi-session-timeline-checkpoint-scenario.ts
@@ -1,0 +1,85 @@
+import type {
+  FactoryTimelineCheckpoint,
+  TimelineCheckpointStreamIdentity,
+} from "../features/timeline/public";
+import { emptyReplayWorldState } from "../features/timeline/state/timeline/replayWorldStateSupport";
+
+export interface MultiSessionTimelineCheckpointFixture {
+  checkpoint: FactoryTimelineCheckpoint;
+  eventCount: number;
+  label: "A" | "B";
+  streamIdentity: TimelineCheckpointStreamIdentity;
+}
+
+function createSessionFixture({
+  afterEventId,
+  afterSequence,
+  eventCount,
+  factorySessionID,
+  label,
+  logicalSessionKeyID,
+  selectedTick,
+  streamGenerationID,
+}: {
+  afterEventId: string;
+  afterSequence: number;
+  eventCount: number;
+  factorySessionID: string;
+  label: MultiSessionTimelineCheckpointFixture["label"];
+  logicalSessionKeyID: string;
+  selectedTick: number;
+  streamGenerationID: string;
+}): MultiSessionTimelineCheckpointFixture {
+  const backendScopeID = "checkpoint-regression-backend";
+  const replayState = emptyReplayWorldState(selectedTick);
+  replayState.runtime.session.dispatched_count = eventCount;
+  replayState.runtime.session.has_data = true;
+
+  const streamIdentity = {
+    backendScopeID,
+    factorySessionID,
+    logicalSessionKeyID,
+    streamGenerationID,
+  } satisfies TimelineCheckpointStreamIdentity;
+
+  return {
+    checkpoint: {
+      afterEventId,
+      afterSequence,
+      replayState,
+      selectedTick,
+      syncIdentity: {
+        backendScopeId: backendScopeID,
+        factorySessionId: factorySessionID,
+        logicalSessionKeyId: logicalSessionKeyID,
+        streamGenerationId: streamGenerationID,
+      },
+    },
+    eventCount,
+    label,
+    streamIdentity,
+  };
+}
+
+export const MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO = {
+  A: createSessionFixture({
+    afterEventId: "session-a-event-7",
+    afterSequence: 17,
+    eventCount: 3,
+    factorySessionID: "11111111-1111-4111-8111-111111111111",
+    label: "A",
+    logicalSessionKeyID: "logical-session-a",
+    selectedTick: 7,
+    streamGenerationID: "2026-07-10T10:00:00Z",
+  }),
+  B: createSessionFixture({
+    afterEventId: "session-b-event-13",
+    afterSequence: 29,
+    eventCount: 5,
+    factorySessionID: "22222222-2222-4222-8222-222222222222",
+    label: "B",
+    logicalSessionKeyID: "logical-session-b",
+    selectedTick: 13,
+    streamGenerationID: "2026-07-10T11:00:00Z",
+  }),
+} satisfies Record<"A" | "B", MultiSessionTimelineCheckpointFixture>;

--- a/ui/src/testing/timeline-checkpoint-indexeddb-test-utils.ts
+++ b/ui/src/testing/timeline-checkpoint-indexeddb-test-utils.ts
@@ -1,0 +1,68 @@
+interface StoredCheckpointEnvelope {
+  storageKey?: string;
+}
+
+export function createTimelineCheckpointIndexedDBTestDouble(): {
+  indexedDB: IDBFactory;
+  records: Map<string, StoredCheckpointEnvelope>;
+} {
+  const records = new Map<string, StoredCheckpointEnvelope>();
+  const database = {
+    close: () => {},
+    createObjectStore: () => undefined,
+    deleteObjectStore: () => undefined,
+    objectStoreNames: {
+      contains: () => true,
+    },
+    transaction: () => ({
+      objectStore: () => ({
+        delete: (key: string) =>
+          indexedDBRequest(undefined, () => {
+            records.delete(key);
+          }),
+        get: (key: string) => indexedDBRequest(records.get(key)),
+        getAll: () => indexedDBRequest([...records.values()]),
+        put: (value: StoredCheckpointEnvelope) =>
+          indexedDBRequest(value.storageKey ?? "", () => {
+            if (value.storageKey) {
+              records.set(value.storageKey, value);
+            }
+          }),
+      }),
+    }),
+  };
+
+  return {
+    indexedDB: {
+      open: () => {
+        const request = indexedDBRequest(database);
+        queueMicrotask(() =>
+          request.onupgradeneeded?.({} as IDBVersionChangeEvent),
+        );
+        return request;
+      },
+    } as unknown as IDBFactory,
+    records,
+  };
+}
+
+function indexedDBRequest<T>(result: T, beforeSuccess?: () => void) {
+  const request = {
+    error: null,
+    onblocked: null,
+    onerror: null,
+    onsuccess: null,
+    onupgradeneeded: null,
+    result,
+  } as unknown as IDBRequest<T> & {
+    onblocked?: ((event: Event) => void) | null;
+    onupgradeneeded?: ((event: IDBVersionChangeEvent) => void) | null;
+  };
+
+  queueMicrotask(() => {
+    beforeSuccess?.();
+    request.onsuccess?.({} as Event);
+  });
+
+  return request;
+}


### PR DESCRIPTION
{
  "project": "Multi-Session Timeline Checkpoint Contamination Regression Characterization",
  "branchName": "session-repair-multi-session-contamination-regression",
  "description": "Add deterministic frontend regressions using distinct sessions A and B to expose default-alias wildcard checkpoint selection, singleton timeline replacement, and lost debounced checkpoint writes during rapid A to B to A switching, while proving that A-scoped clear and pause actions do not mutate B.",
  "context": {
    "customerAsk": "Create deterministic regressions with sessions A and B that use different UUIDs, logical keys, stream generations, ticks, counts, and cursors; vary IndexedDB insertion order; control A to B to A switching on both sides of the persistence debounce; and assert that clearing or pausing A does not mutate B.",
    "problem": "Checkpoint discovery can treat ~default as a wildcard and return the first concrete record supplied by IndexedDB, the App projects every tab through one singleton timeline, and the 750 millisecond persistence timer is canceled when session identity changes. Existing single-session coverage does not expose order-dependent selection, cross-tab timeline replacement, or lost writes during rapid switching.",
    "solution": "Use one typed, non-overlapping A/B scenario in focused checkpoint repository and App functional regressions. Permute IndexedDB insertion order, assert identity-scoped lookup and clear behavior, switch A to B to A while observing each session's timeline and cursor, and use fake timers immediately before and after the debounce boundary to make lost or misattributed writes deterministic without implementing the production repair."
  },
  "acceptanceCriteria": [
    "One deterministic scenario defines sessions A and B with different Factory Session UUIDs, logical session keys, stream generations, selected ticks, event counts, afterEventId values, and afterSequence values.",
    "Focused checkpoint repository coverage varies IndexedDB insertion order and proves that selecting or clearing A cannot select, return, or delete B through ~default first-match behavior.",
    "A focused App session-switch regression proves that A to B to A switching restores the timeline and reconnect cursor belonging to the selected session instead of replacing either session with the singleton store's most recent contents.",
    "Fake-timer coverage switches A to B to A immediately before and immediately after the 750 millisecond persistence boundary and proves that every checkpoint reaching its due boundary is retained under its own stream identity.",
    "Clearing or pausing A does not change B's selected tick, event count, reconnect cursor, persisted envelope, or stream lifecycle.",
    "The work remains a narrow frontend characterization with no production repair, public contract or generated artifact change, user-facing copy change, or unrelated cleanup.",
    "Typecheck and lint pass; unaffected tests remain green, and focused timeline checkpoint repository and App session-switch tests deterministically expose only the characterized isolation failures."
  ],
  "userStories": [
    {
      "id": "session-repair-multi-session-contamination-regression-001",
      "title": "Characterize identity-safe checkpoint lookup and clearing",
      "description": "As a dashboard user with multiple live sessions, I want checkpoint lookup and clearing to affect only the resolved session so that the ~default alias and IndexedDB ordering cannot select or delete another session's recovery state.",
      "acceptanceCriteria": [
        "The repository regression creates A and B with distinct UUIDs, logical keys, stream generations, ticks, event counts encoded in replay state, afterEventId values, and afterSequence values.",
        "The same A/B envelopes are inserted in A-then-B and B-then-A order, and the expected A lookup result is identical in both cases.",
        "A lookup requested through ~default plus A's resolved identity returns A's tick and cursor and never B's; an alias-only ambiguous lookup does not choose an arbitrary concrete record.",
        "Clearing A removes only A's concrete storage key; B remains readable with its original identity, tick, event count, and cursor in both insertion orders.",
        "The focused repository regression exposes the current default-alias first-match or over-broad-clear behavior for the intended identity-isolation reason.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added the shared typed A/B checkpoint scenario and deterministic A-then-B/B-then-A repository characterization. Four Vitest expected-failure cases expose arbitrary ~default lookup and over-broad clear behavior while concrete A/B reads and A-scoped clearing remain asserted."
    },
    {
      "id": "session-repair-multi-session-contamination-regression-002",
      "title": "Characterize timeline isolation during A to B to A switching",
      "description": "As a dashboard user switching between session tabs, I want each tab to recover its own timeline and cursor so that viewing or pausing A does not replace or mutate B's state.",
      "acceptanceCriteria": [
        "A focused App functional test opens A with A's UUID, logical key, stream generation, tick, event count, and reconnect cursor, switches to B with a fully distinct set, and then switches back to A.",
        "While B is selected, the rendered timeline tick and count and the opened stream cursor match B and contain no A values; after returning to A, the same observations match A's original state and contain no B values.",
        "The A to B to A assertions expose replacement caused by the singleton timeline rather than passing because A and B share fixture values.",
        "Pausing A closes or suppresses only A's stream and leaves B's timeline projection, persisted checkpoint envelope, cursor, and ability to resume or remain live unchanged.",
        "Clearing A through the App-visible recovery or session action removes A's recovery state without resetting, deleting, or rewriting B's state.",
        "The functional test asserts user-observable tab, timeline, and stream outcomes through the existing typed App test harness and does not rely on source topology or registration inventories.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added focused App characterization for A-to-B-to-A live timeline replacement and A-scoped close cleanup, plus passing pause isolation coverage that preserves B's checkpoint, reconnect cursor, timeline, and live stream. The current defects remain deterministic expected failures."
    },
    {
      "id": "session-repair-multi-session-contamination-regression-003",
      "title": "Characterize debounced writes across rapid session switches",
      "description": "As a dashboard user rapidly switching tabs, I want a checkpoint scheduled for one session to persist under that session's identity when its debounce becomes due so that switching away and back does not lose or misattribute recoverable progress.",
      "acceptanceCriteria": [
        "The App regression uses fake timers and the shared distinct A/B scenario; no wall-clock sleep or uncontrolled timer advancement determines the outcome.",
        "Before the boundary, the test schedules A's checkpoint, switches A to B to A before 750 milliseconds, advances precisely across the due boundary, and asserts that A's due checkpoint is retained or intentionally superseded only by a newer A checkpoint, never silently canceled by B.",
        "After the boundary, the test advances through A's 750 millisecond due point before switching, performs A to B to A, and proves A's persisted envelope remains intact while B is written only under B's storage key.",
        "After all due timers settle, A and B remain readable with their own UUIDs, logical keys, stream generations, ticks, event counts, and reconnect cursors; neither record contains the other's values.",
        "Repeated focused runs produce the same write order and results and expose the current lost-write behavior at the debounce boundary rather than depending on incidental React scheduling.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added focused App fake-timer characterization immediately before and after the 750 millisecond persistence boundary. The pre-boundary A-to-B-to-A case deterministically exposes the canceled A write as an expected failure, while the post-boundary case passes and proves distinct A/B envelopes, ticks, counts, stream identities, and reconnect cursors remain durable."
    }
  ]
}
