### PR TITLE
session-repair-default-identity-contract-regression

### DIFF
--- a/pkg/api/contracttests/openapi_contract_authoring_test.go
+++ b/pkg/api/contracttests/openapi_contract_authoring_test.go
@@ -753,6 +753,58 @@ func TestGeneratedDispatchArtifactContracts_RuntimeTypesAgreeWithOpenAPI(t *test
 	assertGeneratedFieldType(t, reflect.TypeOf(factoryapi.FactoryArtifact{}), "AuditMode", reflect.TypeOf((*factoryapi.FactoryArtifactAuditMode)(nil)))
 }
 
+func TestOpenAPIAuthoring_FactorySessionRuntimeDispatchesRemainsOptionalArray(t *testing.T) {
+	data, err := os.ReadFile("../../../api/components/schemas/api/FactorySessionRuntime.yaml")
+	if err != nil {
+		t.Fatalf("read authored FactorySessionRuntime schema: %v", err)
+	}
+	var schema map[string]any
+	if err := yaml.Unmarshal(data, &schema); err != nil {
+		t.Fatalf("parse authored FactorySessionRuntime schema: %v", err)
+	}
+
+	properties := schemaProperties(t, schema, "FactorySessionRuntime")
+	assertArrayItemRef(t, properties, "dispatches", "../data-models/FactoryDispatch.yaml")
+	required, ok := schema["required"].([]any)
+	if !ok {
+		t.Fatal("FactorySessionRuntime.required is missing")
+	}
+	if containsString(required, "dispatches") {
+		t.Fatal("FactorySessionRuntime.dispatches is required, want optional")
+	}
+}
+
+func TestGeneratedFactorySessionRuntimeDispatches_RemainsOptionalJSONField(t *testing.T) {
+	runtimeType := reflect.TypeOf(factoryapi.FactorySessionRuntime{})
+	field, ok := runtimeType.FieldByName("Dispatches")
+	if !ok {
+		t.Fatal("generated FactorySessionRuntime.Dispatches is missing")
+	}
+	if got := field.Tag.Get("json"); got != "dispatches,omitempty" {
+		t.Fatalf("generated FactorySessionRuntime.Dispatches JSON tag = %q, want dispatches,omitempty", got)
+	}
+
+	assertRuntimeDispatchesJSON := func(t *testing.T, runtime factoryapi.FactorySessionRuntime, wantPresent bool) {
+		t.Helper()
+		encoded, err := json.Marshal(runtime)
+		if err != nil {
+			t.Fatalf("marshal generated FactorySessionRuntime: %v", err)
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(encoded, &payload); err != nil {
+			t.Fatalf("unmarshal generated FactorySessionRuntime JSON: %v", err)
+		}
+		_, present := payload["dispatches"]
+		if present != wantPresent {
+			t.Fatalf("generated FactorySessionRuntime JSON dispatches presence = %t, want %t: %s", present, wantPresent, encoded)
+		}
+	}
+
+	assertRuntimeDispatchesJSON(t, factoryapi.FactorySessionRuntime{}, false)
+	dispatches := []factoryapi.FactoryDispatch{}
+	assertRuntimeDispatchesJSON(t, factoryapi.FactorySessionRuntime{Dispatches: &dispatches}, true)
+}
+
 func TestGeneratedDispatchArtifactContracts_SessionReadListDetailTypesAgreeWithOpenAPI(t *testing.T) {
 	assertGeneratedFieldType(t, reflect.TypeOf(factoryapi.ListFactorySessionDispatchesResponse{}), "Dispatches", reflect.TypeOf([]factoryapi.FactorySessionDispatchSummary{}))
 	assertGeneratedFieldType(t, reflect.TypeOf(factoryapi.ListFactorySessionArtifactsResponse{}), "Artifacts", reflect.TypeOf([]factoryapi.FactorySessionArtifactSummary{}))

--- a/pkg/factorysessions/api.go
+++ b/pkg/factorysessions/api.go
@@ -46,7 +46,7 @@ func SummaryResponse(session *LiveSession) factoryapi.FactorySessionSummary {
 	return factoryapi.FactorySessionSummary{
 		FactoryDir: session.FactoryDir,
 		FolderPath: session.FolderPath,
-		Id:         session.ID,
+		Id:         CanonicalFactorySessionID(session),
 		IsDefault:  session.IsDefault,
 		Project:    session.Project,
 		Target: factoryapi.FactorySessionTargetRef{

--- a/pkg/factorysessions/controlplane/read_test.go
+++ b/pkg/factorysessions/controlplane/read_test.go
@@ -8,9 +8,11 @@ import (
 
 	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
 	"github.com/portpowered/infinite-you/pkg/apisurface"
+	"github.com/portpowered/infinite-you/pkg/factory/state"
 	"github.com/portpowered/infinite-you/pkg/factorysessions"
 	"github.com/portpowered/infinite-you/pkg/factorysessions/controlplane"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/petri"
 )
 
 type readTestHost struct {
@@ -18,6 +20,7 @@ type readTestHost struct {
 	sessions        map[string]*factorysessions.LiveSession
 	projectionErr   error
 	requireSessionE error
+	snapshot        *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]
 }
 
 type defaultIdentityTestHost struct {
@@ -85,7 +88,7 @@ func (h *readTestHost) BuildSessionProjectionContext(
 	if h.projectionErr != nil {
 		return factorysessions.ProjectionContext{}, h.projectionErr
 	}
-	return factorysessions.ProjectionContext{Session: session}, nil
+	return factorysessions.ProjectionContext{Session: session, Snapshot: h.snapshot}, nil
 }
 
 func TestIsDurableExecutionSessionID(t *testing.T) {
@@ -156,28 +159,34 @@ func TestDefaultSessionSelectorResolvesConsistentRuntimeIdentity(t *testing.T) {
 			sessions: map[string]*factorysessions.LiveSession{
 				factorysessions.DefaultSessionID: defaultSession,
 			},
+			snapshot: &interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{
+				Dispatches: map[string]*interfaces.DispatchEntry{
+					"dispatch-underlying": {
+						DispatchID:   "dispatch-underlying",
+						TransitionID: "transition-underlying",
+					},
+				},
+			},
 		},
 		session: defaultSession,
 	}
+	underlyingRuntime := factorysessions.ProjectRuntime(factorysessions.ProjectionContext{
+		Session:  defaultSession,
+		Snapshot: host.snapshot,
+	})
+	assertUnderlyingDispatchFixture(t, underlyingRuntime)
 
 	listed, err := controlplane.ListLiveFactorySessions(context.Background(), host)
 	if err != nil {
 		t.Fatalf("ListLiveFactorySessions: %v", err)
 	}
-	if len(listed.Sessions) != 1 {
-		t.Fatalf("listed sessions = %d, want 1", len(listed.Sessions))
-	}
-	if listed.Sessions[0].Id != allocatedSessionID || !listed.Sessions[0].IsDefault {
-		t.Fatalf("listed default session = %#v, want id %q and isDefault true", listed.Sessions[0], allocatedSessionID)
-	}
+	assertDefaultSessionListProjection(t, listed, allocatedSessionID)
 
 	got, err := controlplane.GetLiveFactorySession(context.Background(), host, factorysessions.DefaultSessionID)
 	if err != nil {
 		t.Fatalf("GetLiveFactorySession(%q): %v", factorysessions.DefaultSessionID, err)
 	}
-	if got.Id != allocatedSessionID {
-		t.Fatalf("get-by-alias session id = %q, want %q", got.Id, allocatedSessionID)
-	}
+	assertDefaultSessionDetailProjection(t, got, allocatedSessionID)
 
 	preflight, err := controlplane.GetLiveFactorySessionSyncPreflight(
 		context.Background(),
@@ -189,12 +198,69 @@ func TestDefaultSessionSelectorResolvesConsistentRuntimeIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetLiveFactorySessionSyncPreflight(%q): %v", factorysessions.DefaultSessionID, err)
 	}
+	assertDefaultSessionPreflightIdentity(t, preflight, allocatedSessionID)
+	assertResolvedSessionIDsAgree(t, listed, got, preflight)
+}
+
+func assertUnderlyingDispatchFixture(t *testing.T, runtime factoryapi.FactorySessionRuntime) {
+	t.Helper()
+	if runtime.Dispatches == nil || len(*runtime.Dispatches) != 1 {
+		t.Fatalf("underlying runtime dispatches = %#v, want one dispatch", runtime.Dispatches)
+	}
+}
+
+func assertDefaultSessionListProjection(
+	t *testing.T,
+	listed factoryapi.ListFactorySessionsResponse,
+	allocatedSessionID string,
+) {
+	t.Helper()
+	if len(listed.Sessions) != 1 {
+		t.Fatalf("listed sessions = %d, want 1", len(listed.Sessions))
+	}
+	if listed.Sessions[0].Id != allocatedSessionID || !listed.Sessions[0].IsDefault {
+		t.Fatalf("listed default session = %#v, want id %q and isDefault true", listed.Sessions[0], allocatedSessionID)
+	}
+	if listed.Sessions[0].Runtime == nil || listed.Sessions[0].Runtime.Dispatches != nil {
+		t.Fatalf("listed runtime dispatches = %#v, want omitted", listed.Sessions[0].Runtime)
+	}
+}
+
+func assertDefaultSessionDetailProjection(
+	t *testing.T,
+	got factoryapi.FactorySession,
+	allocatedSessionID string,
+) {
+	t.Helper()
+	if got.Id != allocatedSessionID {
+		t.Fatalf("get-by-alias session id = %q, want %q", got.Id, allocatedSessionID)
+	}
+	if got.Runtime.Dispatches != nil {
+		t.Fatalf("get-by-alias runtime dispatches = %#v, want omitted", got.Runtime.Dispatches)
+	}
+}
+
+func assertDefaultSessionPreflightIdentity(
+	t *testing.T,
+	preflight factoryapi.FactorySessionSyncPreflightResponse,
+	allocatedSessionID string,
+) {
+	t.Helper()
 	if preflight.RequestedSessionId != factorysessions.DefaultSessionID {
 		t.Fatalf("requestedSessionId = %q, want %q", preflight.RequestedSessionId, factorysessions.DefaultSessionID)
 	}
 	if preflight.FactorySessionId == nil || *preflight.FactorySessionId != allocatedSessionID {
 		t.Fatalf("factorySessionId = %#v, want %q", preflight.FactorySessionId, allocatedSessionID)
 	}
+}
+
+func assertResolvedSessionIDsAgree(
+	t *testing.T,
+	listed factoryapi.ListFactorySessionsResponse,
+	got factoryapi.FactorySession,
+	preflight factoryapi.FactorySessionSyncPreflightResponse,
+) {
+	t.Helper()
 	if listed.Sessions[0].Id != got.Id || got.Id != *preflight.FactorySessionId {
 		t.Fatalf(
 			"resolved ids differ: list=%q get=%q preflight=%q",

--- a/pkg/factorysessions/controlplane/read_test.go
+++ b/pkg/factorysessions/controlplane/read_test.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"testing"
 
+	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
 	"github.com/portpowered/infinite-you/pkg/apisurface"
 	"github.com/portpowered/infinite-you/pkg/factorysessions"
 	"github.com/portpowered/infinite-you/pkg/factorysessions/controlplane"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
 )
 
 type readTestHost struct {
@@ -16,6 +18,30 @@ type readTestHost struct {
 	sessions        map[string]*factorysessions.LiveSession
 	projectionErr   error
 	requireSessionE error
+}
+
+type defaultIdentityTestHost struct {
+	*readTestHost
+	session *factorysessions.LiveSession
+}
+
+func (h *defaultIdentityTestHost) ResolveSyncPreflightTarget(
+	_ string,
+	_ *interfaces.FactorySessionLogicalResolveHint,
+) (controlplane.SyncPreflightTarget, error) {
+	return controlplane.SyncPreflightTarget{Session: h.session}, nil
+}
+
+func (h *defaultIdentityTestHost) BackendScopeID() string {
+	return "backend-default-identity-test"
+}
+
+func (h *defaultIdentityTestHost) StreamGenerationID(*factorysessions.LiveSession) string {
+	return "stream-default-identity-test"
+}
+
+func (h *defaultIdentityTestHost) LiveSessionEvents(*factorysessions.LiveSession) []factoryapi.FactoryEvent {
+	return nil
 }
 
 func (h *readTestHost) DiscoverTargets(string) ([]factorysessions.Target, error) {
@@ -103,6 +129,79 @@ func TestListLiveFactorySessions_OrdersDefaultFirst(t *testing.T) {
 	}
 	if !response.Sessions[0].IsDefault || response.Sessions[0].Id != "~default" {
 		t.Fatalf("first session = %#v, want default first", response.Sessions[0])
+	}
+}
+
+func TestDefaultSessionSelectorResolvesConsistentRuntimeIdentity(t *testing.T) {
+	t.Parallel()
+
+	const allocatedSessionID = "11111111-1111-4111-8111-111111111111"
+	if allocatedSessionID == factorysessions.DefaultSessionID || !factorysessions.IsUUIDFactorySessionID(allocatedSessionID) {
+		t.Fatalf("allocated session id %q must be a UUID distinct from the default selector", allocatedSessionID)
+	}
+
+	defaultSession := &factorysessions.LiveSession{
+		ID:                      factorysessions.DefaultSessionID,
+		IsDefault:               true,
+		RuntimeFactorySessionID: allocatedSessionID,
+		SessionState: factorysessions.SessionState{
+			FactoryDir: "/tmp/default/factory",
+			FolderPath: "/tmp/default",
+		},
+		Target: factorysessions.TargetRef{Kind: factorysessions.TargetKindDefault},
+	}
+	host := &defaultIdentityTestHost{
+		readTestHost: &readTestHost{
+			sessionIDs: []string{factorysessions.DefaultSessionID},
+			sessions: map[string]*factorysessions.LiveSession{
+				factorysessions.DefaultSessionID: defaultSession,
+			},
+		},
+		session: defaultSession,
+	}
+
+	listed, err := controlplane.ListLiveFactorySessions(context.Background(), host)
+	if err != nil {
+		t.Fatalf("ListLiveFactorySessions: %v", err)
+	}
+	if len(listed.Sessions) != 1 {
+		t.Fatalf("listed sessions = %d, want 1", len(listed.Sessions))
+	}
+	if listed.Sessions[0].Id != allocatedSessionID || !listed.Sessions[0].IsDefault {
+		t.Fatalf("listed default session = %#v, want id %q and isDefault true", listed.Sessions[0], allocatedSessionID)
+	}
+
+	got, err := controlplane.GetLiveFactorySession(context.Background(), host, factorysessions.DefaultSessionID)
+	if err != nil {
+		t.Fatalf("GetLiveFactorySession(%q): %v", factorysessions.DefaultSessionID, err)
+	}
+	if got.Id != allocatedSessionID {
+		t.Fatalf("get-by-alias session id = %q, want %q", got.Id, allocatedSessionID)
+	}
+
+	preflight, err := controlplane.GetLiveFactorySessionSyncPreflight(
+		context.Background(),
+		host,
+		factorysessions.DefaultSessionID,
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("GetLiveFactorySessionSyncPreflight(%q): %v", factorysessions.DefaultSessionID, err)
+	}
+	if preflight.RequestedSessionId != factorysessions.DefaultSessionID {
+		t.Fatalf("requestedSessionId = %q, want %q", preflight.RequestedSessionId, factorysessions.DefaultSessionID)
+	}
+	if preflight.FactorySessionId == nil || *preflight.FactorySessionId != allocatedSessionID {
+		t.Fatalf("factorySessionId = %#v, want %q", preflight.FactorySessionId, allocatedSessionID)
+	}
+	if listed.Sessions[0].Id != got.Id || got.Id != *preflight.FactorySessionId {
+		t.Fatalf(
+			"resolved ids differ: list=%q get=%q preflight=%q",
+			listed.Sessions[0].Id,
+			got.Id,
+			*preflight.FactorySessionId,
+		)
 	}
 }
 

--- a/pkg/factorysessions/controlplane/sync_preflight.go
+++ b/pkg/factorysessions/controlplane/sync_preflight.go
@@ -68,7 +68,7 @@ func GetLiveFactorySessionSyncPreflight(
 
 	response.BackendScopeId = stringPointer(host.BackendScopeID())
 	response.LogicalSessionKeyId = stringPointer(logicalSessionKeyID(session))
-	response.FactorySessionId = stringPointer(session.ID)
+	response.FactorySessionId = stringPointer(factorysessions.CanonicalFactorySessionID(session))
 	response.StreamGenerationId = stringPointer(host.StreamGenerationID(session))
 	if resolved.Remapped {
 		response.ReasonCode = factoryapi.LogicalSessionRemap

--- a/pkg/factorysessions/projection.go
+++ b/pkg/factorysessions/projection.go
@@ -37,7 +37,7 @@ type ProjectionContext struct {
 // SessionResponse maps a live session and runtime projection to the API detail shape.
 func SessionResponse(ctx ProjectionContext) factoryapi.FactorySession {
 	summary := SummaryResponse(ctx.Session)
-	runtime := ProjectRuntime(ctx)
+	runtime := projectSessionReadRuntime(ctx)
 	return factoryapi.FactorySession{
 		FactoryDir: summary.FactoryDir,
 		FolderPath: summary.FolderPath,
@@ -52,9 +52,17 @@ func SessionResponse(ctx ProjectionContext) factoryapi.FactorySession {
 // SummaryWithRuntime maps a live session to the API summary shape with runtime projection.
 func SummaryWithRuntime(ctx ProjectionContext) factoryapi.FactorySessionSummary {
 	summary := SummaryResponse(ctx.Session)
-	runtime := ProjectRuntime(ctx)
+	runtime := projectSessionReadRuntime(ctx)
 	summary.Runtime = &runtime
 	return summary
+}
+
+// projectSessionReadRuntime keeps collection reads on their dedicated API
+// endpoints while preserving the broader runtime projection for other callers.
+func projectSessionReadRuntime(ctx ProjectionContext) factoryapi.FactorySessionRuntime {
+	runtime := ProjectRuntime(ctx)
+	runtime.Dispatches = nil
+	return runtime
 }
 
 // ProjectRuntime builds the orchestrator-aware runtime projection for one session.

--- a/pkg/service/runtime_session_runtime_test.go
+++ b/pkg/service/runtime_session_runtime_test.go
@@ -1531,8 +1531,12 @@ func TestFactoryService_GetFactorySession_ProjectsLegacyPetriRuntime(t *testing.
 	if err != nil {
 		t.Fatalf("GetFactorySession: %v", err)
 	}
-	if session.Id != defaultFactorySessionID {
-		t.Fatalf("session id = %q, want %q", session.Id, defaultFactorySessionID)
+	wantSessionID := factorysessions.CanonicalFactorySessionID(harness.requireSession(t, defaultFactorySessionID))
+	if wantSessionID == defaultFactorySessionID || !factorysessions.IsUUIDFactorySessionID(wantSessionID) {
+		t.Fatalf("default runtime session id = %q, want UUID distinct from %q", wantSessionID, defaultFactorySessionID)
+	}
+	if session.Id != wantSessionID {
+		t.Fatalf("session id = %q, want %q", session.Id, wantSessionID)
 	}
 	if session.Runtime.OrchestratorKind != factoryapi.PETRI {
 		t.Fatalf("orchestrator kind = %q, want PETRI", session.Runtime.OrchestratorKind)
@@ -1671,9 +1675,13 @@ func TestFactoryService_ListFactorySessions_IncludesRuntimeProjection(t *testing
 	if len(listed.Sessions) == 0 {
 		t.Fatal("expected at least one live session")
 	}
+	wantSessionID := factorysessions.CanonicalFactorySessionID(harness.requireSession(t, defaultFactorySessionID))
+	if wantSessionID == defaultFactorySessionID || !factorysessions.IsUUIDFactorySessionID(wantSessionID) {
+		t.Fatalf("default runtime session id = %q, want UUID distinct from %q", wantSessionID, defaultFactorySessionID)
+	}
 	found := false
 	for _, summary := range listed.Sessions {
-		if summary.Id != defaultFactorySessionID {
+		if summary.Id != wantSessionID {
 			continue
 		}
 		found = true


### PR DESCRIPTION
{
  "project": "Characterize Default-Session Identity and Embedded Dispatch Contract Gaps",
  "branchName": "session-repair-default-identity-contract-regression",
  "description": "Add focused Factory Session projection and API contract regressions proving that ~default remains a request selector while list, get-by-alias, and sync-preflight resolve to one distinct allocated UUID; require list/get projections to omit embedded dispatch collections while explicitly recording the current optional FactorySessionRuntime.dispatches OpenAPI and generated-contract exposure without changing that public contract.",
  "context": {
    "customerAsk": "Add contract and projection tests proving that ~default is accepted as a request selector while list/get responses expose the allocated UUID and do not embed dispatch collections, and record the current FactorySessionRuntime.dispatches exposure without silently changing the contract.",
    "problem": "Default Factory Sessions have a stable ~default request alias and a separate allocated live-session UUID, but existing tests do not compare list, get-by-alias, and sync-preflight identities in one scenario. This permits identity drift and accidental embedded dispatch projections, while the optional dispatches field still exposed by OpenAPI and generated types could be silently changed or mistaken for an already-resolved contract gap.",
    "solution": "Use one deterministic default-session fixture whose allocated UUID differs from ~default, assert list/get/sync-preflight identity semantics together, prove list and get projections omit dispatches even with underlying dispatch state, and add focused authored/generated contract assertions that explicitly preserve and document the current optional dispatches exposure."
  },
  "acceptanceCriteria": [
    "A regression scenario uses ~default as the request and registry alias and a valid allocated UUID that is explicitly different from ~default.",
    "One cohesive regression proves that list and get-by-alias expose the allocated UUID while sync preflight preserves requestedSessionId as ~default and exposes the same UUID as factorySessionId.",
    "Factory Session list and get projections omit embedded runtime dispatch collections even when the underlying fixture contains dispatch state.",
    "Focused OpenAPI and generated-contract coverage explicitly records that FactorySessionRuntime.dispatches remains an optional exposed field, without silently removing or regenerating the public contract.",
    "The change remains limited to default-session identity, projection omission, and direct regression evidence with no unrelated cleanup.",
    "Typecheck, lint, focused pkg/factorysessions projection tests, focused pkg/api OpenAPI/generated-contract tests, and affected tests pass."
  ],
  "userStories": [
    {
      "id": "session-repair-default-identity-contract-regression-001",
      "title": "Prove default selector and resolved UUID identity consistency",
      "description": "As an API client, I want ~default to remain a convenient request selector while session reads return the allocated UUID, so that I can reconnect and persist the correct live-session identity.",
      "acceptanceCriteria": [
        "The regression fixture represents one default live session registered or selected as ~default with a valid allocated UUID that differs from ~default.",
        "Listing Factory Sessions returns the default session with its top-level id equal to the allocated UUID and still marks it as the default session.",
        "Getting the same session through the ~default alias returns its top-level id equal to the same allocated UUID.",
        "Sync preflight requested through ~default returns requestedSessionId equal to ~default and factorySessionId equal to the same allocated UUID.",
        "List, get-by-alias, and sync-preflight identities are asserted together from the same scenario so a mismatch among the three surfaces fails the regression.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "session-repair-default-identity-contract-regression-002",
      "title": "Characterize omitted projections and the existing dispatch contract gap",
      "description": "As an API maintainer, I want session projections to omit embedded dispatch collections while contract tests explicitly record the currently exposed optional field, so that response behavior is protected without disguising an unapproved breaking contract change.",
      "acceptanceCriteria": [
        "The default-session scenario includes underlying dispatch state sufficient to detect accidental embedding rather than proving omission only from an empty fixture.",
        "Both list and get-by-alias response projections omit runtime.dispatches; callers continue to use the dedicated dispatch endpoints for dispatch collections.",
        "Focused authored-OpenAPI coverage explicitly confirms that FactorySessionRuntime.dispatches is currently an optional array of FactoryDispatch values.",
        "Focused generated-contract coverage explicitly confirms the current optional generated Dispatches field and its JSON exposure, making the known schema/projection gap visible to reviewers.",
        "No authored OpenAPI schema, bundled OpenAPI output, or generated Go or TypeScript contract is changed as part of this characterization story.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
