### PR TITLE
provider-failure-structured-observability

### DIFF
--- a/pkg/workers/process/command_test.go
+++ b/pkg/workers/process/command_test.go
@@ -475,13 +475,13 @@ func TestCommandRunnerWithLogging_PropagatesLoggerToExecCommandRunner(t *testing
 func commandCleanupTestRequest(t *testing.T) CommandRequest {
 	t.Helper()
 	return CommandRequest{
-		Command:           os.Args[0],
-		Args:              []string{"-test.run=TestExecCommandRunner_HelperProcess", "--", "success"},
-		Env:               append(os.Environ(), "GO_WANT_COMMAND_HELPER=1"),
-		WorkDir:           t.TempDir(),
-		DispatchID:        "dispatch-cleanup-log",
-		WorkerType:        "script",
-		WorkstationName:   "cleanup-test-station",
+		Command:         os.Args[0],
+		Args:            []string{"-test.run=TestExecCommandRunner_HelperProcess", "--", "success"},
+		Env:             append(os.Environ(), "GO_WANT_COMMAND_HELPER=1"),
+		WorkDir:         t.TempDir(),
+		DispatchID:      "dispatch-cleanup-log",
+		WorkerType:      "script",
+		WorkstationName: "cleanup-test-station",
 		Execution: interfaces.ExecutionMetadata{
 			RequestID: "request-cleanup-log",
 			TraceID:   "trace-cleanup-log",
@@ -596,20 +596,20 @@ func TestLoggingCommandRunner_LogsRequestAndCompletionStatuses(t *testing.T) {
 			name:            "non-zero exit",
 			result:          CommandResult{Stdout: []byte("partial\n"), Stderr: []byte("failed\n"), ExitCode: 17},
 			wantStatus:      "failed",
-			wantCommandData: true,
+			wantCommandData: false,
 		},
 		{
 			name:            "timeout",
 			result:          CommandResult{Stderr: []byte("deadline\n")},
 			err:             context.DeadlineExceeded,
 			wantStatus:      "timed_out",
-			wantCommandData: true,
+			wantCommandData: false,
 		},
 		{
 			name:            "system error",
 			err:             errors.New("start failed"),
 			wantStatus:      "error",
-			wantCommandData: true,
+			wantCommandData: false,
 		},
 	}
 

--- a/pkg/workers/process/log_context.go
+++ b/pkg/workers/process/log_context.go
@@ -9,10 +9,10 @@ import (
 )
 
 const (
-	workLogEventCommandRunnerRequested      = "command_runner.requested"
-	workLogEventCommandRunnerCompleted      = "command_runner.completed"
-	workLogEventCommandRunnerRequestDetails = "command_runner.request_details"
-	workLogEventCommandRunnerOutputDetails  = "command_runner.output_details"
+	workLogEventCommandRunnerRequested        = "command_runner.requested"
+	workLogEventCommandRunnerCompleted        = "command_runner.completed"
+	workLogEventCommandRunnerRequestDetails   = "command_runner.request_details"
+	workLogEventCommandRunnerOutputDetails    = "command_runner.output_details"
 	workLogEventCommandRunnerCleanupStarted   = "command_runner.cleanup_started"
 	workLogEventCommandRunnerCleanupGraceful  = "command_runner.cleanup_graceful"
 	workLogEventCommandRunnerCleanupForceKill = "command_runner.cleanup_force_kill"
@@ -50,7 +50,7 @@ func commandRequestLogFields(req CommandRequest) []any {
 		"event_name", workLogEventCommandRunnerRequested,
 		"status", "requested",
 		"command", req.Command,
-		"args", append([]string(nil), req.Args...),
+		"args_count", len(req.Args),
 		"working_dir", req.WorkDir,
 		"stdin_bytes", len(req.Stdin))
 }
@@ -60,17 +60,12 @@ func commandCompletionLogFields(req CommandRequest, result CommandResult, durati
 		"event_name", workLogEventCommandRunnerCompleted,
 		"status", status,
 		"command", req.Command,
-		"args", append([]string(nil), req.Args...),
+		"args_count", len(req.Args),
 		"working_dir", req.WorkDir,
 		"exit_code", result.ExitCode,
 		"duration_ms", duration.Milliseconds())
-	if status != "succeeded" || err != nil {
-		fields = append(fields,
-			"stdout", string(result.Stdout),
-			"stderr", string(result.Stderr))
-	}
 	if err != nil {
-		fields = append(fields, "error", err.Error())
+		fields = append(fields, "has_error", true)
 	}
 	return fields
 }

--- a/pkg/workers/provider/helpers.go
+++ b/pkg/workers/provider/helpers.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -29,7 +30,102 @@ const (
 const (
 	RedactedCommandEnvValue     = "<redacted>"
 	MetadataOnlyCommandEnvValue = "<metadata-only>"
+	ProviderDefaultModel        = "provider-default"
+	ProviderInvocationPrepared  = "provider.invocation_prepared"
+	RedactedProviderArgValue    = "<redacted>"
+	RedactedProviderPrompt      = "<redacted:prompt>"
 )
+
+var providerFlagsWithSafeValues = map[string]struct{}{
+	"--approval-mode": {}, "--model": {}, "--output-format": {}, "--sandbox": {},
+}
+
+var providerFlagsWithSensitiveValues = map[string]struct{}{
+	"--agent": {}, "--cd": {}, "--dir": {}, "--image": {}, "--prompt": {},
+	"--resume": {}, "--resume-id": {}, "--session": {}, "--system-prompt": {},
+	"--workspace": {}, "--worktree": {},
+}
+
+func providerModelForLog(model string) string {
+	if normalized := strings.TrimSpace(model); normalized != "" {
+		return normalized
+	}
+	return ProviderDefaultModel
+}
+
+func sanitizeProviderArgs(provider string, args []string) []string {
+	sanitized := make([]string, 0, len(args))
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		if providerInlineArgIsSensitive(arg) {
+			sanitized = append(sanitized, strings.SplitN(arg, "=", 2)[0]+"="+RedactedProviderArgValue)
+			continue
+		}
+		sanitized = append(sanitized, arg)
+		if _, ok := providerFlagsWithSafeValues[arg]; ok && index+1 < len(args) {
+			index++
+			sanitized = append(sanitized, args[index])
+			continue
+		}
+		if _, ok := providerFlagsWithSensitiveValues[arg]; ok && index+1 < len(args) {
+			index++
+			sanitized = append(sanitized, RedactedProviderArgValue)
+			continue
+		}
+		if providerArgIsSensitivePositional(provider, args, index) {
+			sanitized[len(sanitized)-1] = RedactedProviderPrompt
+		}
+	}
+	return sanitized
+}
+
+func providerInlineArgIsSensitive(arg string) bool {
+	name, _, ok := strings.Cut(arg, "=")
+	if !ok {
+		return false
+	}
+	normalized := strings.ToLower(name)
+	return strings.Contains(normalized, "key") || strings.Contains(normalized, "token") ||
+		strings.Contains(normalized, "secret") || strings.Contains(normalized, "password") ||
+		strings.Contains(normalized, "prompt") || strings.Contains(normalized, "credential")
+}
+
+func providerArgIsSensitivePositional(provider string, args []string, index int) bool {
+	if strings.HasPrefix(args[index], "-") {
+		return false
+	}
+	if index == 0 && (args[index] == "exec" || args[index] == "chat" || args[index] == "run") {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case string(interfaces.ModelProviderCodex):
+		return args[index] != "-"
+	default:
+		return true
+	}
+}
+
+func providerPreparedLogFields(ctx context.Context, req interfaces.ProviderInferenceRequest, execReq CommandRequest) []any {
+	fields := workLogFields(req.Dispatch.Execution,
+		"event_name", ProviderInvocationPrepared,
+		"provider", strings.ToLower(strings.TrimSpace(req.ModelProvider)),
+		"model", providerModelForLog(req.Model),
+		"command", execReq.Command,
+		"args", sanitizeProviderArgs(req.ModelProvider, execReq.Args),
+		"working_dir", execReq.WorkDir,
+		"stdin_bytes", len(execReq.Stdin),
+		"stdin_sha256", sha256Hex(execReq.Stdin),
+		"dispatch_id", req.Dispatch.DispatchID)
+	if deadline, ok := ctx.Deadline(); ok {
+		fields = append(fields, "deadline", deadline.UTC().Format(time.RFC3339Nano))
+	}
+	return fields
+}
+
+func sha256Hex(input []byte) string {
+	digest := sha256.Sum256(input)
+	return hex.EncodeToString(digest[:])
+}
 
 type CommandEnvClassification string
 

--- a/pkg/workers/provider/helpers.go
+++ b/pkg/workers/provider/helpers.go
@@ -32,6 +32,7 @@ const (
 	MetadataOnlyCommandEnvValue = "<metadata-only>"
 	ProviderDefaultModel        = "provider-default"
 	ProviderInvocationPrepared  = "provider.invocation_prepared"
+	ProviderFailureNormalized   = "provider.failure_normalized"
 	RedactedProviderArgValue    = "<redacted>"
 	RedactedProviderPrompt      = "<redacted:prompt>"
 )
@@ -120,6 +121,50 @@ func providerPreparedLogFields(ctx context.Context, req interfaces.ProviderInfer
 		fields = append(fields, "deadline", deadline.UTC().Format(time.RFC3339Nano))
 	}
 	return fields
+}
+
+func providerFailureLogFields(
+	req interfaces.ProviderInferenceRequest,
+	providerErr *ProviderError,
+	result CommandResult,
+	duration time.Duration,
+) []any {
+	decision := WorkFailureDecisionFromProviderError(providerErr)
+	fields := workLogFields(req.Dispatch.Execution,
+		"event_name", ProviderFailureNormalized,
+		"provider", strings.ToLower(strings.TrimSpace(req.ModelProvider)),
+		"model", providerModelForLog(req.Model),
+		"failure_reason", providerErr.Type,
+		"failure_message", safeProviderFailureLogMessage(req.ModelProvider, providerErr),
+		"retryable", decision.Retryable,
+		"duration_ms", duration.Milliseconds(),
+		"dispatch_id", req.Dispatch.DispatchID)
+	if result.ExitCode != 0 {
+		fields = append(fields, "exit_code", result.ExitCode)
+	}
+	return fields
+}
+
+func safeProviderFailureLogMessage(provider string, providerErr *ProviderError) string {
+	if strings.EqualFold(strings.TrimSpace(provider), string(interfaces.ModelProviderCodex)) {
+		return providerErr.Message
+	}
+	switch providerErr.Type {
+	case interfaces.WorkFailureTypeAuthFailure:
+		return "Provider authentication failed."
+	case interfaces.WorkFailureTypePermanentBadRequest:
+		return "Provider rejected the request as invalid."
+	case interfaces.WorkFailureTypeThrottled:
+		return "Provider is temporarily unavailable due to usage or capacity limits."
+	case interfaces.WorkFailureTypeInternalServerError:
+		return "Provider encountered a temporary server error."
+	case interfaces.WorkFailureTypeTimeout:
+		return "Provider request timed out."
+	case interfaces.WorkFailureTypeMisconfigured:
+		return "Provider command could not be started."
+	default:
+		return "Provider execution failed."
+	}
 }
 
 func sha256Hex(input []byte) string {

--- a/pkg/workers/provider/helpers.go
+++ b/pkg/workers/provider/helpers.go
@@ -146,7 +146,10 @@ func providerFailureLogFields(
 }
 
 func safeProviderFailureLogMessage(provider string, providerErr *ProviderError) string {
-	if strings.EqualFold(strings.TrimSpace(provider), string(interfaces.ModelProviderCodex)) {
+	// Codex exit failures are parsed into bounded, audited messages. Execution
+	// errors retain raw command diagnostics in the returned error, so they must
+	// use the same fixed reason-based messages as the other providers.
+	if strings.EqualFold(strings.TrimSpace(provider), string(interfaces.ModelProviderCodex)) && providerErr.Cause == nil {
 		return providerErr.Message
 	}
 	switch providerErr.Type {

--- a/pkg/workers/provider/inference_provider.go
+++ b/pkg/workers/provider/inference_provider.go
@@ -189,12 +189,8 @@ func (p *ScriptWrapProvider) Execute(ctx context.Context, req interfaces.RunnerE
 			workDiagnosticsForInferenceRequest(req),
 		)
 	}
-	logger.Info("inferencer: request arguments",
-		workLogFields(req.Dispatch.Execution, "arguments", args)...)
 	execReq := behavior.BuildCommandRequest(req, args)
-
-	logger.Debug("inferencer: request input",
-		workLogFields(req.Dispatch.Execution, "request", req.UserMessage)...)
+	logger.Info("provider invocation prepared", providerPreparedLogFields(ctx, req, execReq)...)
 	started := time.Now()
 	result, err := p.commandExec().Run(ctx, execReq)
 	duration := time.Since(started)
@@ -229,8 +225,6 @@ func (p *ScriptWrapProvider) Execute(ctx context.Context, req interfaces.RunnerE
 	}
 
 	content := string(result.Stdout)
-	logger.Debug("inference results:",
-		workLogFields(req.Dispatch.Execution, "output", result.Stdout)...)
 	logger.Info("inferencer: request completed",
 		workLogFields(req.Dispatch.Execution,
 			"dispatcher", string(req.ModelProvider),
@@ -349,20 +343,8 @@ func formatProviderTimeoutFailure(provider string, result CommandResult) string 
 }
 
 func cursorFailureLogFields(req interfaces.RunnerExecutionRequest, cursorProvider bool, result CommandResult, extra ...any) []any {
-	fields := workLogFields(req.Dispatch.Execution,
+	return workLogFields(req.Dispatch.Execution,
 		append([]any{"dispatcher", string(req.ModelProvider)}, extra...)...)
-	if !cursorProvider {
-		fields = append(fields,
-			"output", string(result.Stdout),
-			"stderr", string(result.Stderr),
-		)
-		return fields
-	}
-	fields = append(fields,
-		"stdout_preview", cursorpkg.BoundedCommandOutputExcerpt(result.Stdout, cursorpkg.CommandOutputLogPreviewLimit),
-		"stderr_preview", cursorpkg.BoundedCommandOutputExcerpt(result.Stderr, cursorpkg.CommandOutputLogPreviewLimit),
-	)
-	return fields
 }
 
 func cursorInferenceFailureDiagnostics(
@@ -399,13 +381,10 @@ func (p *ScriptWrapProvider) completeCursorInference(
 		return interfaces.InferenceResponse{}, providerErr
 	}
 	diagnostics := cursorpkg.WithResponseMetadata(commandDiagnostics, parsed.ResponseMetadata)
-	logger.Debug("inference results:",
-		workLogFields(req.Dispatch.Execution, "output", parsed.Content)...)
 	logger.Info("inferencer: request completed",
 		workLogFields(req.Dispatch.Execution,
 			"dispatcher", string(req.ModelProvider),
-			"output_len", len(parsed.Content),
-			"session_id", parsed.ProviderSession.ID)...)
+			"output_len", len(parsed.Content))...)
 	p.publishCompletedFragment(req.Dispatch.DispatchID, parsed.ProviderSession)
 	return interfaces.InferenceResponse{
 		Content:         parsed.Content,

--- a/pkg/workers/provider/inference_provider.go
+++ b/pkg/workers/provider/inference_provider.go
@@ -198,24 +198,24 @@ func (p *ScriptWrapProvider) Execute(ctx context.Context, req interfaces.RunnerE
 	providerSession := effectiveProviderSession(req, result)
 	cursorProvider := req.ModelProvider == string(interfaces.ModelProviderCursor)
 	if err != nil {
-		logger.Error("inferencer: request failed",
-			cursorFailureLogFields(req, cursorProvider, result,
-				"error", err.Error())...)
 		providerErr := normalizeProviderExecutionError(
 			req.ModelProvider, result, err, providerSession,
 			cursorInferenceFailureDiagnostics(cursorProvider, commandDiagnostics, result),
 		)
+		logger.Error("provider failure normalized", providerFailureLogFields(req, providerErr, result, duration)...)
+		logger.Error("inferencer: request failed",
+			cursorFailureLogFields(req, cursorProvider, result, "has_error", true)...)
 		p.publishFailureFragment(req.Dispatch.DispatchID, providerSession, providerErr)
 		return interfaces.InferenceResponse{}, providerErr
 	}
 	if result.ExitCode != 0 {
-		logger.Error("inferencer: request failed",
-			cursorFailureLogFields(req, cursorProvider, result,
-				"exit_code", result.ExitCode)...)
 		providerErr := normalizeProviderExitFailure(
 			req.ModelProvider, result, providerSession,
 			cursorInferenceFailureDiagnostics(cursorProvider, commandDiagnostics, result),
 		)
+		logger.Error("provider failure normalized", providerFailureLogFields(req, providerErr, result, duration)...)
+		logger.Error("inferencer: request failed",
+			cursorFailureLogFields(req, cursorProvider, result, "exit_code", result.ExitCode)...)
 		p.publishFailureFragment(req.Dispatch.DispatchID, providerSession, providerErr)
 		return interfaces.InferenceResponse{}, providerErr
 	}

--- a/pkg/workers/provider/inference_provider_exit_failure_test.go
+++ b/pkg/workers/provider/inference_provider_exit_failure_test.go
@@ -1,7 +1,10 @@
 package provider
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -9,6 +12,9 @@ import (
 	"testing"
 
 	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/logging"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 func TestScriptWrapProvider_Infer_GenericNonCodexExitFailuresPreserveMessageAndClassification(t *testing.T) {
@@ -48,6 +54,136 @@ func TestScriptWrapProvider_Infer_CodexGPT56SolFailureUsesCanonicalResultAndDeci
 	}
 	assertGPT56SolCanonicalFailure(t, providerErr)
 	assertGPT56SolFailureMetadata(t, providerErr, entry, result)
+}
+
+func TestScriptWrapProvider_Infer_LogsCorrelatedNormalizedCodexFailureAfterParsing(t *testing.T) {
+	const prompt = "synthetic prompt must not appear"
+	const credential = "credential-value-must-not-appear"
+	sequence := []string{}
+	logger := &preparedInvocationTestLogger{sequence: &sequence}
+	runner := &preparedInvocationTestRunner{
+		sequence: &sequence,
+		result: CommandResult{
+			ExitCode: 17,
+			Stderr:   []byte(`ERROR: {"type":"invalid_request_error","status":400,"message":"The 'gpt-5.6-sol' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again."}` + "\n" + credential),
+		},
+	}
+	provider := NewScriptWrapProvider(WithProviderLogger(logger), WithProviderCommandRunner(runner))
+	_, err := provider.Infer(context.Background(), interfaces.ProviderInferenceRequest{
+		ModelProvider: string(interfaces.ModelProviderCodex),
+		Model:         "gpt-5.6-sol",
+		UserMessage:   prompt,
+		EnvVars:       map[string]string{"API_TOKEN": credential},
+		Dispatch: interfaces.WorkDispatch{
+			DispatchID: "dispatch-failure-1",
+			Execution: interfaces.ExecutionMetadata{
+				RequestID: "request-failure-1", TraceID: "trace-failure-1", WorkIDs: []string{"work-failure-1", "work-failure-2"},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("Infer returned nil error")
+	}
+	if logger.failureCount != 1 {
+		t.Fatalf("normalized failure records = %d, want 1", logger.failureCount)
+	}
+	if len(sequence) < 3 || sequence[0] != ProviderInvocationPrepared || sequence[1] != "runner" || sequence[2] != ProviderFailureNormalized {
+		t.Fatalf("record sequence = %#v, want prepared, runner, normalized failure", sequence)
+	}
+	assertNormalizedFailureFields(t, logger.failureFields)
+	if strings.Contains(logger.allValues, prompt) || strings.Contains(logger.allValues, credential) {
+		t.Fatalf("provider logs contain prompt or credential: %s", logger.allValues)
+	}
+}
+
+func assertNormalizedFailureFields(t *testing.T, fields map[string]any) {
+	t.Helper()
+	if fields["provider"] != "codex" || fields["model"] != "gpt-5.6-sol" {
+		t.Fatalf("provider/model = %#v/%#v", fields["provider"], fields["model"])
+	}
+	if fields["failure_reason"] != interfaces.WorkFailureTypePermanentBadRequest || fields["failure_message"] != codexGPT56SolUpgradeMessage {
+		t.Fatalf("canonical failure = %#v", fields)
+	}
+	if fields["retryable"] != false || fields["exit_code"] != 17 {
+		t.Fatalf("retry/exit fields = %#v", fields)
+	}
+	if fields["request_id"] != "request-failure-1" || fields["trace_id"] != "trace-failure-1" || fields["work_id"] != "work-failure-1" || fields["dispatch_id"] != "dispatch-failure-1" {
+		t.Fatalf("correlation fields = %#v", fields)
+	}
+	if _, ok := fields["duration_ms"]; !ok {
+		t.Fatalf("duration_ms absent: %#v", fields)
+	}
+}
+
+func TestScriptWrapProvider_Infer_LogsNormalizedFailuresWithoutSyntheticExitCodes(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		err           error
+		wantReason    interfaces.WorkFailureType
+		wantRetryable bool
+	}{
+		{name: "timeout", err: context.DeadlineExceeded, wantReason: interfaces.WorkFailureTypeTimeout, wantRetryable: true},
+		{name: "command start", err: exec.ErrNotFound, wantReason: interfaces.WorkFailureTypeMisconfigured},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sequence := []string{}
+			logger := &preparedInvocationTestLogger{sequence: &sequence}
+			runner := &preparedInvocationTestRunner{sequence: &sequence, err: tc.err}
+			provider := NewScriptWrapProvider(WithProviderLogger(logger), WithProviderCommandRunner(runner))
+			_, err := provider.Infer(context.Background(), interfaces.ProviderInferenceRequest{
+				ModelProvider: string(interfaces.ModelProviderClaude),
+				UserMessage:   "private prompt",
+				Dispatch:      interfaces.WorkDispatch{DispatchID: "dispatch-no-exit"},
+			})
+			if err == nil {
+				t.Fatal("Infer returned nil error")
+			}
+			if logger.failureCount != 1 || logger.failureFields["failure_reason"] != tc.wantReason || logger.failureFields["retryable"] != tc.wantRetryable {
+				t.Fatalf("normalized failure fields = %#v", logger.failureFields)
+			}
+			if _, ok := logger.failureFields["exit_code"]; ok {
+				t.Fatalf("failure record invented exit code: %#v", logger.failureFields)
+			}
+			if logger.failureFields["model"] != ProviderDefaultModel {
+				t.Fatalf("model = %#v, want provider default", logger.failureFields["model"])
+			}
+		})
+	}
+}
+
+func TestScriptWrapProvider_Infer_CodexUpgradeFailureIsSearchableInJSONLogs(t *testing.T) {
+	var output bytes.Buffer
+	encoderConfig := zap.NewProductionEncoderConfig()
+	core := zapcore.NewCore(zapcore.NewJSONEncoder(encoderConfig), zapcore.AddSync(&output), zapcore.DebugLevel)
+	provider := NewScriptWrapProvider(
+		WithProviderLogger(logging.NewZapLogger(zap.New(core), false)),
+		WithProviderCommandRunner(&recordingProviderExec{result: CommandResult{
+			ExitCode: 2,
+			Stderr:   []byte(`ERROR: {"type":"invalid_request_error","status":400,"message":"The 'gpt-5.6-sol' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again."}`),
+		}}),
+	)
+	_, _ = provider.Infer(context.Background(), interfaces.ProviderInferenceRequest{
+		ModelProvider: string(interfaces.ModelProviderCodex),
+		UserMessage:   "json log prompt fixture",
+	})
+
+	for _, line := range strings.Split(strings.TrimSpace(output.String()), "\n") {
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("decode JSON log: %v", err)
+		}
+		if record["event_name"] != ProviderFailureNormalized {
+			continue
+		}
+		if record["failure_reason"] != string(interfaces.WorkFailureTypePermanentBadRequest) || record["failure_message"] != codexGPT56SolUpgradeMessage {
+			t.Fatalf("normalized JSON failure = %#v", record)
+		}
+		if strings.Contains(line, "json log prompt fixture") || strings.Contains(line, `\"status\":400`) {
+			t.Fatalf("normalized JSON failure leaked prompt or envelope: %s", line)
+		}
+		return
+	}
+	t.Fatalf("normalized failure absent from JSON logs: %s", output.String())
 }
 
 func assertGPT56SolCanonicalFailure(t *testing.T, providerErr *ProviderError) {

--- a/pkg/workers/provider/inference_provider_exit_failure_test.go
+++ b/pkg/workers/provider/inference_provider_exit_failure_test.go
@@ -151,6 +151,67 @@ func TestScriptWrapProvider_Infer_LogsNormalizedFailuresWithoutSyntheticExitCode
 	}
 }
 
+func TestScriptWrapProvider_Infer_CodexExecutionFailureJSONLogsExcludeCommandOutput(t *testing.T) {
+	const prompt = "codex execution prompt must not appear"
+	const stdoutSecret = "stdout-secret-must-not-appear"
+	const stderrSecret = "stderr-secret-must-not-appear"
+	for _, tc := range []struct {
+		name        string
+		err         error
+		wantReason  interfaces.WorkFailureType
+		wantMessage string
+	}{
+		{name: "timeout", err: context.DeadlineExceeded, wantReason: interfaces.WorkFailureTypeTimeout, wantMessage: "Provider request timed out."},
+		{name: "command start", err: exec.ErrNotFound, wantReason: interfaces.WorkFailureTypeMisconfigured, wantMessage: "Provider command could not be started."},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var output bytes.Buffer
+			encoderConfig := zap.NewProductionEncoderConfig()
+			core := zapcore.NewCore(zapcore.NewJSONEncoder(encoderConfig), zapcore.AddSync(&output), zapcore.DebugLevel)
+			provider := NewScriptWrapProvider(
+				WithProviderLogger(logging.NewZapLogger(zap.New(core), false)),
+				WithProviderCommandRunner(&recordingProviderExec{
+					result: CommandResult{Stdout: []byte(stdoutSecret), Stderr: []byte(stderrSecret)},
+					err:    tc.err,
+				}),
+			)
+			_, _ = provider.Infer(context.Background(), interfaces.ProviderInferenceRequest{
+				ModelProvider: string(interfaces.ModelProviderCodex),
+				UserMessage:   prompt,
+			})
+
+			record := normalizedFailureJSONRecord(t, output.String())
+			if record["failure_reason"] != string(tc.wantReason) || record["failure_message"] != tc.wantMessage {
+				t.Fatalf("normalized JSON failure = %#v", record)
+			}
+			encoded, err := json.Marshal(record)
+			if err != nil {
+				t.Fatalf("encode normalized failure: %v", err)
+			}
+			for _, secret := range []string{prompt, stdoutSecret, stderrSecret} {
+				if strings.Contains(string(encoded), secret) {
+					t.Fatalf("normalized JSON failure leaked %q: %s", secret, encoded)
+				}
+			}
+		})
+	}
+}
+
+func normalizedFailureJSONRecord(t *testing.T, logs string) map[string]any {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimSpace(logs), "\n") {
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("decode JSON log: %v", err)
+		}
+		if record["event_name"] == ProviderFailureNormalized {
+			return record
+		}
+	}
+	t.Fatalf("normalized failure absent from JSON logs: %s", logs)
+	return nil
+}
+
 func TestScriptWrapProvider_Infer_CodexUpgradeFailureIsSearchableInJSONLogs(t *testing.T) {
 	var output bytes.Buffer
 	encoderConfig := zap.NewProductionEncoderConfig()

--- a/pkg/workers/provider/inference_provider_test.go
+++ b/pkg/workers/provider/inference_provider_test.go
@@ -2,7 +2,10 @@ package provider
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -361,6 +364,117 @@ func TestScriptWrapProvider_Infer_PropagatesExecutionMetadataToProviderCommand(t
 	}
 
 	assertExecutionMetadataEqual(t, want, fakeExec.request.Execution)
+}
+
+func TestScriptWrapProvider_Infer_LogsSafePreparedInvocationBeforeExecution(t *testing.T) {
+	const prompt = "synthetic prompt secret"
+	sequence := []string{}
+	logger := &preparedInvocationTestLogger{sequence: &sequence}
+	runner := &preparedInvocationTestRunner{sequence: &sequence}
+	provider := NewScriptWrapProvider(
+		WithProviderLogger(logger),
+		WithProviderCommandRunner(runner),
+	)
+	ctx, cancel := context.WithDeadline(context.Background(), time.Date(2026, 7, 10, 12, 0, 0, 0, time.FixedZone("test", -7*60*60)))
+	defer cancel()
+	req := interfaces.ProviderInferenceRequest{
+		ModelProvider: string(interfaces.ModelProviderCodex),
+		UserMessage:   prompt,
+		Dispatch: interfaces.WorkDispatch{
+			DispatchID: "dispatch-1",
+			Execution: interfaces.ExecutionMetadata{
+				RequestID: "request-1", TraceID: "trace-1", WorkIDs: []string{"work-1", "work-2"},
+			},
+		},
+	}
+
+	if _, err := provider.Infer(ctx, req); err != nil {
+		t.Fatalf("Infer returned error: %v", err)
+	}
+	if len(sequence) < 2 || sequence[0] != ProviderInvocationPrepared || sequence[1] != "runner" {
+		t.Fatalf("sequence = %#v, want prepared record before runner", sequence)
+	}
+	if logger.preparedCount != 1 {
+		t.Fatalf("prepared records = %d, want 1", logger.preparedCount)
+	}
+	assertPreparedInvocationFields(t, logger.preparedFields, prompt)
+	if strings.Contains(logger.allValues, prompt) {
+		t.Fatalf("logs contain raw prompt: %s", logger.allValues)
+	}
+}
+
+func assertPreparedInvocationFields(t *testing.T, fields map[string]any, prompt string) {
+	t.Helper()
+	if fields["provider"] != "codex" || fields["model"] != ProviderDefaultModel {
+		t.Fatalf("provider/model = %#v/%#v", fields["provider"], fields["model"])
+	}
+	if fields["request_id"] != "request-1" || fields["trace_id"] != "trace-1" || fields["work_id"] != "work-1" || fields["dispatch_id"] != "dispatch-1" {
+		t.Fatalf("correlation fields = %#v", fields)
+	}
+	digest := sha256.Sum256([]byte(prompt))
+	if fields["stdin_bytes"] != len(prompt) || fields["stdin_sha256"] != hex.EncodeToString(digest[:]) {
+		t.Fatalf("stdin metadata = %#v", fields)
+	}
+	if fields["deadline"] != "2026-07-10T19:00:00Z" {
+		t.Fatalf("deadline = %#v, want UTC deadline", fields["deadline"])
+	}
+}
+
+func TestSanitizeProviderArgs_RedactsPromptCredentialsAndFreeFormValues(t *testing.T) {
+	args := []string{"-p", "--system-prompt", "system secret", "--model", "safe-model", "--resume", "session-secret", "user secret"}
+	want := []string{"-p", "--system-prompt", RedactedProviderArgValue, "--model", "safe-model", "--resume", RedactedProviderArgValue, RedactedProviderPrompt}
+	got := sanitizeProviderArgs(string(interfaces.ModelProviderClaude), args)
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Fatalf("sanitizeProviderArgs() = %#v, want %#v", got, want)
+	}
+	if sha256Hex([]byte("same")) != sha256Hex([]byte("same")) || sha256Hex([]byte("same")) == sha256Hex([]byte("different")) {
+		t.Fatal("stdin digest is not deterministic and input-sensitive")
+	}
+}
+
+type preparedInvocationTestRunner struct{ sequence *[]string }
+
+func (r *preparedInvocationTestRunner) Run(_ context.Context, _ CommandRequest) (CommandResult, error) {
+	*r.sequence = append(*r.sequence, "runner")
+	return CommandResult{Stdout: []byte("ok")}, nil
+}
+
+type preparedInvocationTestLogger struct {
+	sequence       *[]string
+	preparedCount  int
+	preparedFields map[string]any
+	allValues      string
+}
+
+func (l *preparedInvocationTestLogger) capture(keysAndValues ...any) {
+	l.allValues += strings.TrimSpace(strings.Join(anyValues(keysAndValues), " "))
+}
+func (l *preparedInvocationTestLogger) Debug(_ string, fields ...any)   { l.capture(fields...) }
+func (l *preparedInvocationTestLogger) Warn(_ string, fields ...any)    { l.capture(fields...) }
+func (l *preparedInvocationTestLogger) Error(_ string, fields ...any)   { l.capture(fields...) }
+func (l *preparedInvocationTestLogger) Verbose(_ string, fields ...any) { l.capture(fields...) }
+func (l *preparedInvocationTestLogger) Info(_ string, fields ...any) {
+	l.capture(fields...)
+	values := make(map[string]any, len(fields)/2)
+	for i := 0; i+1 < len(fields); i += 2 {
+		key, ok := fields[i].(string)
+		if ok {
+			values[key] = fields[i+1]
+		}
+	}
+	if values["event_name"] == ProviderInvocationPrepared {
+		l.preparedCount++
+		l.preparedFields = values
+		*l.sequence = append(*l.sequence, ProviderInvocationPrepared)
+	}
+}
+
+func anyValues(values []any) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		result = append(result, fmt.Sprint(value))
+	}
+	return result
 }
 
 func TestScriptWrapProvider_Infer_ClaudeWithoutSessionLeavesMetadataNil(t *testing.T) {

--- a/pkg/workers/provider/inference_provider_test.go
+++ b/pkg/workers/provider/inference_provider_test.go
@@ -432,29 +432,55 @@ func TestSanitizeProviderArgs_RedactsPromptCredentialsAndFreeFormValues(t *testi
 	}
 }
 
-type preparedInvocationTestRunner struct{ sequence *[]string }
+type preparedInvocationTestRunner struct {
+	sequence *[]string
+	result   CommandResult
+	err      error
+}
 
 func (r *preparedInvocationTestRunner) Run(_ context.Context, _ CommandRequest) (CommandResult, error) {
 	*r.sequence = append(*r.sequence, "runner")
-	return CommandResult{Stdout: []byte("ok")}, nil
+	if r.result.ExitCode == 0 && len(r.result.Stdout) == 0 && len(r.result.Stderr) == 0 {
+		r.result = CommandResult{Stdout: []byte("ok")}
+	}
+	return r.result, r.err
 }
 
 type preparedInvocationTestLogger struct {
 	sequence       *[]string
 	preparedCount  int
 	preparedFields map[string]any
+	failureCount   int
+	failureFields  map[string]any
 	allValues      string
 }
 
 func (l *preparedInvocationTestLogger) capture(keysAndValues ...any) {
 	l.allValues += strings.TrimSpace(strings.Join(anyValues(keysAndValues), " "))
 }
-func (l *preparedInvocationTestLogger) Debug(_ string, fields ...any)   { l.capture(fields...) }
-func (l *preparedInvocationTestLogger) Warn(_ string, fields ...any)    { l.capture(fields...) }
-func (l *preparedInvocationTestLogger) Error(_ string, fields ...any)   { l.capture(fields...) }
+func (l *preparedInvocationTestLogger) Debug(_ string, fields ...any) { l.capture(fields...) }
+func (l *preparedInvocationTestLogger) Warn(_ string, fields ...any)  { l.capture(fields...) }
+func (l *preparedInvocationTestLogger) Error(_ string, fields ...any) {
+	l.capture(fields...)
+	values := logFieldMap(fields)
+	if values["event_name"] == ProviderFailureNormalized {
+		l.failureCount++
+		l.failureFields = values
+		*l.sequence = append(*l.sequence, ProviderFailureNormalized)
+	}
+}
 func (l *preparedInvocationTestLogger) Verbose(_ string, fields ...any) { l.capture(fields...) }
 func (l *preparedInvocationTestLogger) Info(_ string, fields ...any) {
 	l.capture(fields...)
+	values := logFieldMap(fields)
+	if values["event_name"] == ProviderInvocationPrepared {
+		l.preparedCount++
+		l.preparedFields = values
+		*l.sequence = append(*l.sequence, ProviderInvocationPrepared)
+	}
+}
+
+func logFieldMap(fields []any) map[string]any {
 	values := make(map[string]any, len(fields)/2)
 	for i := 0; i+1 < len(fields); i += 2 {
 		key, ok := fields[i].(string)
@@ -462,11 +488,7 @@ func (l *preparedInvocationTestLogger) Info(_ string, fields ...any) {
 			values[key] = fields[i+1]
 		}
 	}
-	if values["event_name"] == ProviderInvocationPrepared {
-		l.preparedCount++
-		l.preparedFields = values
-		*l.sequence = append(*l.sequence, ProviderInvocationPrepared)
-	}
+	return values
 }
 
 func anyValues(values []any) []string {

--- a/pkg/workers/provider/provider_behavior.go
+++ b/pkg/workers/provider/provider_behavior.go
@@ -165,18 +165,18 @@ func (b claudeProviderBehavior) BuildArgs(_ context.Context, req interfaces.Prov
 		args = append(args, "--dangerously-skip-permissions")
 	}
 	if req.Worktree != "" {
-		logger.Info("inferencer: adding work directory to arguments", "worktree", req.Worktree)
+		logger.Info("inferencer: adding work directory to arguments")
 		args = append(args, "--worktree", req.Worktree)
 	}
 	if req.SystemPrompt != "" {
-		logger.Info("inferencer: adding system prompt to arguments", "system-prompt", req.SystemPrompt)
+		logger.Info("inferencer: adding system prompt to arguments")
 		args = append(args, "--system-prompt", req.SystemPrompt)
 	}
 	if req.Model != "" {
 		args = append(args, "--model", req.Model)
 	}
 	if req.SessionID != "" {
-		logger.Info("inferencer: resuming claude session", "session_id", req.SessionID)
+		logger.Info("inferencer: resuming claude session")
 		args = append(args, "--resume", req.SessionID)
 	}
 	args = append(args, req.UserMessage)
@@ -218,7 +218,7 @@ func (b codexProviderBehavior) BuildArgs(ctx context.Context, req interfaces.Pro
 
 	if req.WorkingDirectory != "" {
 		// TODO: we should check and validate the working directory target for an inference dispatch at runtime and handle the request as failing if the working directory is invalid.
-		logger.Debug("inferencer: codex passed a working directory argument", "working_directory", req.WorkingDirectory)
+		logger.Debug("inferencer: codex passed a working directory argument")
 		// args = append(args, "--cd", req.WorkingDirectory)
 	}
 

--- a/tests/functional/providers/mock_workers_agent_test.go
+++ b/tests/functional/providers/mock_workers_agent_test.go
@@ -38,7 +38,7 @@ func TestMockWorkers_AgentDefaultAcceptMovesWorkToOutputPlace(t *testing.T) {
 	}
 }
 
-func TestMockWorkers_AgentRejectConfigRoutesFailureAndLogsCommandOutput(t *testing.T) {
+func TestMockWorkers_AgentRejectConfigRoutesFailureWithoutLoggingCommandOutput(t *testing.T) {
 	dir := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "rejection_with_arcs"))
 	testutil.WriteSeedFile(t, dir, "task", []byte("mock reject payload"))
 	logDir := t.TempDir()
@@ -86,8 +86,11 @@ func TestMockWorkers_AgentRejectConfigRoutesFailureAndLogsCommandOutput(t *testi
 	if record["exit_code"] != float64(7) {
 		t.Fatalf("logged exit_code = %#v, want 7", record["exit_code"])
 	}
-	if record["stdout"] != "configured stdout" || record["stderr"] != "configured stderr" {
-		t.Fatalf("logged stdout/stderr = %#v/%#v, want configured output", record["stdout"], record["stderr"])
+	if _, ok := record["stdout"]; ok {
+		t.Fatalf("failure record unexpectedly included stdout: %#v", record)
+	}
+	if _, ok := record["stderr"]; ok {
+		t.Fatalf("failure record unexpectedly included stderr: %#v", record)
 	}
 }
 

--- a/tests/functional/providers/runtime_logging_smoke_test.go
+++ b/tests/functional/providers/runtime_logging_smoke_test.go
@@ -74,7 +74,7 @@ func TestRuntimeLoggingSmoke_SuccessAndFailureRespectOutputEnvAndRollingPolicies
 		assertRuntimeStartupRollingPolicy(t, result.records, result.logPath, rollingConfig)
 	})
 
-	t.Run("FailureIncludesSystemOutputAndRecordsEnvDiagnostics", func(t *testing.T) {
+	t.Run("FailureSuppressesSystemOutputAndRecordsEnvDiagnostics", func(t *testing.T) {
 		result := runRuntimeLoggingSmoke(t, runtimeLoggingSmokeRunner{
 			stdout:   "failure stdout context",
 			stderr:   "failure stderr context",
@@ -93,11 +93,11 @@ func TestRuntimeLoggingSmoke_SuccessAndFailureRespectOutputEnvAndRollingPolicies
 		if completionRecord["exit_code"] != float64(23) {
 			t.Fatalf("failure exit_code = %#v, want 23 in record %#v", completionRecord["exit_code"], completionRecord)
 		}
-		if completionRecord["stdout"] != "failure stdout context" {
-			t.Fatalf("failure stdout = %#v, want failure stdout context in record %#v", completionRecord["stdout"], completionRecord)
+		if _, ok := completionRecord["stdout"]; ok {
+			t.Fatalf("failure completion unexpectedly included stdout in system log: %#v", completionRecord)
 		}
-		if completionRecord["stderr"] != "failure stderr context" {
-			t.Fatalf("failure stderr = %#v, want failure stderr context in record %#v", completionRecord["stderr"], completionRecord)
+		if _, ok := completionRecord["stderr"]; ok {
+			t.Fatalf("failure completion unexpectedly included stderr in system log: %#v", completionRecord)
 		}
 
 		completion := requireRecordedCompletion(t, result.artifact)


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "provider-failure-structured-observability",
  "description": "Emit one safe structured record before each provider CLI execution and one correlated record after canonical failure parsing so operators can identify provider, requested or provider-default model, invocation shape, normalized reason, bounded safe message, retry decision, exit code, and duration without extracting raw stderr.",
  "context": {
    "customerAsk": "Emit concise structured records immediately before provider CLI execution and after provider failure normalization so operators can identify the provider, requested or provider-default model, invocation shape, normalized reason, safe message, retry decision, exit code, duration, and correlated execution without extracting raw stderr.",
    "problem": "Provider execution diagnostics are spread across generic command-runner and inferencer logs. Empty models are ambiguous, arguments and debug records can expose prompt-bearing values, and operators may need raw stdout or stderr to recover the normalized failure cause. There is no stable prepared/failure record pair carrying the same request, trace, work, and dispatch identity.",
    "solution": "Emit one prepared-provider-invocation JSON record after safe command construction and before subprocess execution, then emit one normalized-provider-failure JSON record after canonical parsing. Use an exact provider-default model marker, provider-aware argument redaction, stdin size and SHA-256 digest, shared execution correlation, canonical reason and bounded message, central retry policy, exit code, and duration while removing raw prompts, secrets, environment values, and transcripts from overlapping logs."
  },
  "acceptanceCriteria": [
    "Every provider CLI subprocess that reaches execution emits exactly one structured prepared-invocation record before the command runner is called.",
    "Prepared-invocation records use the exact provider-default model marker when no model was requested and contain sanitized command arguments, working directory, stdin byte count and SHA-256 digest, timeout/deadline and attempt when available, plus request, trace, work, and dispatch correlation fields.",
    "Every failed provider subprocess that reaches canonical failure parsing emits exactly one normalized-failure record after parsing with the same identity, provider, and model plus reason, bounded safe message, retry decision, exit code, and duration.",
    "The captured Codex model/version failure is searchable in JSON logs by failure_reason=permanent_bad_request and by its bounded safe requires-a-newer-version-of-Codex message without consulting stdout or stderr.",
    "Provider execution logs exclude raw prompt text, prompt-bearing argument values, credential values, complete environment values, and unbounded provider transcripts on success, non-zero exit, timeout, and command-start failure paths.",
    "Logging remains an isolated side effect around existing command construction, execution, and canonical failure normalization and does not change provider commands, parser results, retry policy, or returned execution outcomes.",
    "Typecheck, lint, and tests pass, including go test ./pkg/service/runtimelogtests ./pkg/workers/process ./pkg/workers/provider and the focused JSON-log regression for permanent_bad_request and the model/version message."
  ],
  "userStories": [
    {
      "id": "provider-failure-structured-observability-001",
      "title": "Log safe prepared provider invocations",
      "description": "As an operator, I want one concise structured record before each provider CLI execution so that I can identify the invocation shape and correlate it to work without exposing its prompt or secrets.",
      "acceptanceCriteria": [
        "A provider invocation that successfully completes argument construction emits exactly one prepared-invocation record after command preparation and before the command runner receives the request; validation failures that never reach execution do not emit it.",
        "The record has a stable event name and records normalized provider, model, sanitized command and arguments, working directory, stdin byte count, stdin SHA-256 digest, request ID, trace ID, primary work ID, work IDs, and dispatch ID.",
        "An explicitly requested model is logged as its normalized requested value, while an empty model is logged as the exact marker provider-default; neither case is inferred later from subprocess output.",
        "Argument sanitization preserves executable and non-sensitive option shape needed to distinguish invocations while replacing prompt-bearing positional values, prompt-bearing flag values, credential-bearing values, and other free-form sensitive values with stable redaction markers.",
        "Stdin is represented only by byte count and a deterministic SHA-256 digest; the digest is stable for identical bytes and changes when the input changes, and no raw or encoded stdin content is logged.",
        "Timeout or deadline and attempt are recorded when supplied by the execution context; unavailable optional values are omitted or represented consistently without inventing an attempt or deadline.",
        "The prepared record and any overlapping provider/process request logs omit raw prompt text, complete environment values, credential values, and unsanitized prompt-bearing arguments.",
        "Focused process/provider tests and a captured JSON runtime-log test prove record ordering before execution, field values, provider-default behavior, sanitization, digest behavior, optional timeout/attempt handling, and absence of synthetic secret and prompt fixtures.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "provider-failure-structured-observability-002",
      "title": "Log correlated normalized provider failures",
      "description": "As an operator, I want one structured record after provider failure parsing so that I can diagnose the canonical cause and retry outcome without searching raw provider output.",
      "acceptanceCriteria": [
        "A non-zero exit, timeout, or command execution error that produces a canonical provider failure emits exactly one normalized-failure record after parsing and before the failure is returned to its caller; successful invocations do not emit this record.",
        "The record has a stable event name and contains normalized provider, the same explicit requested model or provider-default marker as the prepared record, failure reason, bounded safe failure message, retry decision, exit code when available, duration in milliseconds, request ID, trace ID, primary work ID, work IDs, and dispatch ID.",
        "Retry decision is derived from the canonical normalized reason used by runtime policy and is not independently inferred from raw stdout, stderr, exit code, or message text.",
        "The prepared-invocation and normalized-failure records for one execution have identical provider, model, request, trace, work, and dispatch identity fields, including timeout and command-start failure paths where no exit code exists.",
        "For the captured Codex model/version regression, the JSON record contains failure_reason equal to permanent_bad_request, the bounded safe requires-a-newer-version-of-Codex message, a non-retry decision, the actual exit code, and measured duration.",
        "The failure message uses the canonical parser's sanitization and published-length bound; failure logging does not reconstruct a message from raw output or serialize a complete structured provider envelope.",
        "Normalized-failure and overlapping completion/error records omit raw prompts, credential values, complete environment values, stdout, stderr, and unbounded provider transcripts for structured, fallback, timeout, and command-start failures.",
        "Captured JSON-log regressions at the provider and runtime boundaries prove failure-field completeness, record ordering after parsing, prepared/failure correlation, reason-derived retry decisions, bounded messages, and absence of synthetic prompt, credential, environment, and transcript fixtures.",
        "go test ./pkg/service/runtimelogtests ./pkg/workers/process ./pkg/workers/provider passes",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
