### PR TITLE
runtime-cleanup-model-direct-di

### DIFF
--- a/pkg/models/service/pull.go
+++ b/pkg/models/service/pull.go
@@ -34,7 +34,7 @@ const (
 
 // PullModel starts or reports managed-runtime pull materialization for one model.
 func (s *Service) PullModel(ctx context.Context, modelName string) (apisurface.ModelPullResult, error) {
-	started := time.Now()
+	started := s.now()
 	host := s.modelHost()
 	if host == nil {
 		puller := s.modelAssetPuller()
@@ -43,11 +43,11 @@ func (s *Service) PullModel(ctx context.Context, modelName string) (apisurface.M
 			SourceResolver:        localmodels.DefaultManagedRuntimeSourceResolver(),
 		}
 		result, err := localmodels.PullModelWithOptions(puller, ctx, s.runtimeConfig(), modelName, opts)
-		s.recordManagedRuntimePull(modelName, result, err, time.Since(started))
+		s.recordManagedRuntimePull(modelName, result, err, s.now().Sub(started))
 		return result, err
 	}
 	result, err := s.pullWithModelHost(ctx, host, modelName)
-	s.recordManagedRuntimePull(modelName, result, err, time.Since(started))
+	s.recordManagedRuntimePull(modelName, result, err, s.now().Sub(started))
 	return result, err
 }
 

--- a/pkg/models/service/pull_model_test.go
+++ b/pkg/models/service/pull_model_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
 	"github.com/portpowered/infinite-you/pkg/apisurface"
@@ -298,6 +299,46 @@ func TestService_PullModel_LogsSuccessAndFailureOutcomes(t *testing.T) {
 	}
 	if observed.FilterMessage("managed runtime pull failed").Len() != 1 {
 		t.Fatalf("failure logs = %d, want 1", observed.FilterMessage("managed runtime pull failed").Len())
+	}
+}
+
+func TestService_PullModel_UsesInjectedClockForDuration(t *testing.T) {
+	t.Parallel()
+
+	runtimeCfg := mustLoadedCatalogConfig(t, catalogFactoryConfig(true))
+	core, observed := observer.New(zap.InfoLevel)
+	times := []time.Time{
+		time.Date(2026, time.July, 10, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, time.July, 10, 12, 0, 2, 500_000_000, time.UTC),
+	}
+	svc := modelsservice.New(modelsservice.Dependencies{
+		RuntimeConfig: func() *factoryconfig.LoadedFactoryConfig { return runtimeCfg },
+		Clock: func() time.Time {
+			now := times[0]
+			times = times[1:]
+			return now
+		},
+		Logger: func() *zap.Logger { return zap.New(core) },
+		ModelAssetPuller: func() localmodels.AssetPuller {
+			return &stubPullAssetPuller{result: apisurface.ModelPullResult{
+				ModelName:          "OMNIVOICE_Q4_K_M",
+				ManagedPullOutcome: "ALREADY_READY",
+				ReadinessState:     "READY",
+				LifecycleState:     "READY",
+				SourceKind:         "MANAGED_RUNTIME",
+			}}
+		},
+	})
+
+	if _, err := svc.PullModel(context.Background(), "OMNIVOICE_Q4_K_M"); err != nil {
+		t.Fatalf("PullModel: %v", err)
+	}
+	entries := observed.FilterMessage("managed runtime pull completed").All()
+	if len(entries) != 1 {
+		t.Fatalf("success logs = %d, want 1", len(entries))
+	}
+	if got := entries[0].ContextMap()["duration"]; got != 2500*time.Millisecond {
+		t.Fatalf("logged duration = %#v, want 2.5s in nanoseconds", got)
 	}
 }
 

--- a/pkg/models/service/service.go
+++ b/pkg/models/service/service.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"time"
+
 	factoryconfig "github.com/portpowered/infinite-you/pkg/config"
 	"github.com/portpowered/infinite-you/pkg/localmodels"
 	"github.com/portpowered/infinite-you/pkg/modelhost"
@@ -13,6 +15,7 @@ type Dependencies struct {
 	ModelHost               func() modelhost.Host
 	ModelAssetPuller        func() localmodels.AssetPuller
 	Logger                  func() *zap.Logger
+	Clock                   func() time.Time
 	ModelPullMetrics        func() PullMetricsRecorder
 	ModelInvocationExecutor ModelInvocationExecutor
 	FactoryRunnerID         func() string
@@ -40,4 +43,11 @@ func (s *Service) modelHost() modelhost.Host {
 		return nil
 	}
 	return s.deps.ModelHost()
+}
+
+func (s *Service) now() time.Time {
+	if s == nil || s.deps.Clock == nil {
+		return time.Now()
+	}
+	return s.deps.Clock()
 }

--- a/pkg/runtimehost/model_catalog.go
+++ b/pkg/runtimehost/model_catalog.go
@@ -93,6 +93,7 @@ func wireModelServiceCollaborator(fs *Host, cfg *Config) apisurface.ModelAPI {
 		ModelHost:        fs.modelHost,
 		ModelAssetPuller: fs.modelAssetPuller,
 		Logger:           func() *zap.Logger { return fs.logger },
+		Clock:            fs.modelServiceClock,
 		ModelPullMetrics: func() modelsservice.PullMetricsRecorder {
 			recorder := fs.modelPullMetricsRecorder()
 			if recorder == nil {
@@ -103,6 +104,13 @@ func wireModelServiceCollaborator(fs *Host, cfg *Config) apisurface.ModelAPI {
 		ModelInvocationExecutor: fs.modelInvocationExecutor,
 		FactoryRunnerID:         fs.factoryRunnerID,
 	})
+}
+
+func (fs *Host) modelServiceClock() time.Time {
+	if fs == nil || fs.clock == nil {
+		return time.Now()
+	}
+	return fs.clock.Now()
 }
 
 // ModelService returns the canonical model-domain collaborator used by the

--- a/pkg/runtimehost/model_catalog_test.go
+++ b/pkg/runtimehost/model_catalog_test.go
@@ -6,10 +6,21 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
+	"github.com/jonboulle/clockwork"
 	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
 	"github.com/portpowered/infinite-you/pkg/apisurface"
 )
+
+func TestHostModelServiceClockUsesCompositionClock(t *testing.T) {
+	want := time.Date(2026, time.July, 10, 21, 30, 0, 0, time.UTC)
+	host := &Host{clock: clockwork.NewFakeClockAt(want)}
+
+	if got := host.modelServiceClock(); !got.Equal(want) {
+		t.Fatalf("modelServiceClock() = %s, want %s", got, want)
+	}
+}
 
 func TestHostModelMethodsForwardContextResultsAndErrorsUnchanged(t *testing.T) {
 	t.Parallel()

--- a/pkg/service/factory_runtime_mode_test.go
+++ b/pkg/service/factory_runtime_mode_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jonboulle/clockwork"
 	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
 	"github.com/portpowered/infinite-you/pkg/apisurface"
 	"github.com/portpowered/infinite-you/pkg/config"
@@ -1264,6 +1265,15 @@ func TestBuildFactoryService_ConstructsExplicitCollaborators(t *testing.T) {
 	}
 	if svc.coordinatorPolicy().dir != alphaDir {
 		t.Fatalf("service dir = %q, want %q", svc.coordinatorPolicy().dir, alphaDir)
+	}
+}
+
+func TestFactoryService_ModelServiceClockUsesCompositionClock(t *testing.T) {
+	want := time.Date(2026, time.July, 10, 21, 30, 0, 0, time.UTC)
+	svc := &FactoryService{clock: clockwork.NewFakeClockAt(want)}
+
+	if got := svc.modelServiceClock(); !got.Equal(want) {
+		t.Fatalf("modelServiceClock() = %s, want %s", got, want)
 	}
 }
 

--- a/pkg/service/model_catalog.go
+++ b/pkg/service/model_catalog.go
@@ -93,6 +93,7 @@ func wireModelServiceCollaborator(fs *FactoryService, cfg *FactoryServiceConfig)
 		ModelHost:        fs.modelHost,
 		ModelAssetPuller: fs.modelAssetPuller,
 		Logger:           func() *zap.Logger { return fs.logger },
+		Clock:            fs.modelServiceClock,
 		ModelPullMetrics: func() modelsservice.PullMetricsRecorder {
 			recorder := fs.modelPullMetricsRecorder()
 			if recorder == nil {
@@ -103,6 +104,13 @@ func wireModelServiceCollaborator(fs *FactoryService, cfg *FactoryServiceConfig)
 		ModelInvocationExecutor: fs.modelInvocationExecutor,
 		FactoryRunnerID:         fs.factoryRunnerID,
 	})
+}
+
+func (fs *FactoryService) modelServiceClock() time.Time {
+	if fs == nil || fs.clock == nil {
+		return time.Now()
+	}
+	return fs.clock.Now()
 }
 
 // ProvideModelServiceCollaborator constructs the model-domain collaborator for a


### PR DESCRIPTION
{
  "project": "Replace Model Service Host-Object DI with Direct Dependencies",
  "branchName": "runtime-cleanup-model-direct-di",
  "description": "Replace production model-service host-object construction with New(Dependencies), make all runtime capabilities explicit, preserve catalog, pull, metrics, and invocation behavior, and delete NewFromHost plus its production adapters.",
  "context": {
    "customerAsk": "Move production callers from modelsservice.NewFromHost to New(Dependencies), explicitly inject logger, clock, runtime configuration reader, model host, asset puller, metrics recorder, and invocation callbacks, and leave host-object adapters only as deleted code or package-local test helpers.",
    "problem": "Both production composition paths still hide model-service inputs behind adapters around FactoryService or runtimehost.Host, duplicate wiring, and leave pull timing coupled to the process clock. The broad construction seam obscures ownership and makes isolated tests less representative of production.",
    "solution": "Complete the Dependencies contract with an explicit clock and clearly named callbacks, wire both production compositions directly through New(Dependencies), preserve observable model behavior, and remove NewFromHost, its Host interface, and production adapter types."
  },
  "acceptanceCriteria": [
    "Production model-service composition uses New(Dependencies) and never passes FactoryService, runtimehost.Host, or an adapter around either object",
    "Logger, clock, runtime configuration reader, model host reader, asset puller, metrics recorder, invocation executor callback, and factory runner identity callback are explicit constructor dependencies",
    "Model listing, inspection, pulling, metrics, and direct invocation preserve their existing observable results and errors",
    "Pull duration metrics use the injected clock and remain deterministic in focused tests without changing production timing semantics",
    "NewFromHost, its broad Host contract, and production host adapters are deleted, with any retained fixture adapter confined to package-local test code",
    "Direct constructor tests prove representative success, failure, and nil or partial dependency behavior without a live coordinator or runtime host",
    "Typecheck, lint, go test ./pkg/models/service/..., focused composition tests, and the focused production-usage check pass"
  ],
  "userStories": [
    {
      "id": "runtime-cleanup-model-direct-di-001",
      "title": "Make model-service runtime inputs explicit",
      "description": "As a maintainer, I want the direct model-service constructor to receive every runtime input explicitly so that model behavior can be assembled and tested without a broad host object.",
      "acceptanceCriteria": [
        "New(Dependencies) accepts explicit logger, clock, runtime configuration reader, model host reader, asset puller, metrics recorder, invocation executor callback, and factory runner identity callback dependencies",
        "A pull performed with a deterministic clock reports the same outcome and metric labels as today and derives its duration from that clock rather than process-global time",
        "Listing, inspection, pull, and invocation use only the supplied direct dependencies and retain their existing success results and typed failure behavior",
        "Nil receivers and nil or partial dependency sets preserve the existing safe behavior and do not panic",
        "Focused New(Dependencies) tests prove dependency use through representative catalog, pull, metric, and invocation outcomes, including a dependency failure",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "runtime-cleanup-model-direct-di-002",
      "title": "Use direct dependencies in production composition",
      "description": "As an operator, I want both production runtime compositions to build the model service from the same explicit contract so that API and CLI model operations behave consistently without hidden coordinator coupling.",
      "acceptanceCriteria": [
        "The FactoryService production composition path constructs the model service with New(Dependencies) and explicitly supplies its existing live runtime readers, configured asset puller, logger, metrics recorder, invocation executor, runner identity, and production clock",
        "The runtimehost.Host production composition path constructs the model service with New(Dependencies) and supplies the equivalent explicit dependencies",
        "Existing explicit ModelAPI overrides continue to take precedence over default production construction",
        "Representative composition tests prove catalog or pull behavior and direct invocation behavior remain equivalent through both production facades, including propagation of a dependency error",
        "Metrics remain emitted once per canonical pull attempt and direct wiring adds no duplicate recording or logging side effects",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "runtime-cleanup-model-direct-di-003",
      "title": "Retire broad host-object construction",
      "description": "As a maintainer, I want the obsolete broad-host construction path removed so that future production code has one clear and reviewable way to construct the model service.",
      "acceptanceCriteria": [
        "NewFromHost and the model service broad Host interface are removed from production code after both callers migrate",
        "The FactoryService and runtimehost.Host model-service adapter types and their compile-time host assertions are removed",
        "No production Go code constructs the model service by passing FactoryService, runtimehost.Host, or an adapter around either and the focused production usage check returns no NewFromHost matches",
        "Any adapter retained to simplify fixtures is unexported and defined only in a _test.go file inside the package that uses it",
        "Focused model-service and composition tests pass after the compatibility constructor and adapters are deleted",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}
