### PR TITLE
runtime-cleanup-worker-sidecar-owner

### DIFF
--- a/docs/internal/development/deadcode-baseline.txt
+++ b/docs/internal/development/deadcode-baseline.txt
@@ -5,7 +5,6 @@ pkg/runtimehost/factory_runtime_state.go: unreachable func: markModelExecutionLo
 pkg/runtimehost/factory_runtime_state.go: unreachable func: markModelExecutionResourceWaitFinished
 pkg/runtimehost/factory_runtime_state.go: unreachable func: markModelExecutionResourceWaitStarted
 pkg/runtimehost/factory_runtime_state.go: unreachable func: modelExecutionTraceFromContext
-pkg/runtimehost/poller_watcher.go: unreachable func: Host.cronWorkflowIdentity
 pkg/runtimehost/poller_watcher.go: unreachable func: Host.submitCronTick
 pkg/runtimehost/runtime_sessions.go: unreachable func: Host.inferenceProgressPublisher
 pkg/runtimehost/runtime_sessions.go: unreachable func: Host.openFactorySession

--- a/pkg/composebridge/core.go
+++ b/pkg/composebridge/core.go
@@ -51,6 +51,9 @@ func ComposeCore(
 	clock factory.Clock,
 	hostedWorkers hostedworkers.Config,
 ) (*runtimehost.Core, error) {
+	if collaborators.WorkersScheduler == nil {
+		return nil, fmt.Errorf("compose runtime host core: worker sidecar owner is required")
+	}
 	if err := runtimehost.ValidateReplayModeConfig(cfg); err != nil {
 		return nil, err
 	}

--- a/pkg/factory/service/lifecycle.go
+++ b/pkg/factory/service/lifecycle.go
@@ -173,12 +173,13 @@ func WaitForStart(ctx context.Context, handle *Handle) error {
 	}
 }
 
-// Stop cancels the hosted run loop when needed, waits for completion, finalizes lifecycle
-// metrics, and closes replay, log, and metrics artifacts.
+// Stop cancels and joins session sidecars before stopping the hosted run loop,
+// then finalizes lifecycle metrics and closes replay, log, and metrics artifacts.
 func Stop(handle *Handle, clock factory.Clock) error {
 	if handle == nil {
 		return nil
 	}
+	StopSidecars(handle)
 	handle.CancelRun()
 	runErr := handle.Wait()
 	finalizeRuntimeLifecycleMetrics(handle, runtimeMetricsObservation{})

--- a/pkg/factory/service/lifecycle_test.go
+++ b/pkg/factory/service/lifecycle_test.go
@@ -27,6 +27,22 @@ type lifecycleObserverFactory struct {
 	engineState *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]
 }
 
+type orderedStopFactory struct {
+	lifecycleObserverFactory
+	sidecarExited      <-chan struct{}
+	runStoppedTooEarly chan<- struct{}
+}
+
+func (f *orderedStopFactory) Run(ctx context.Context) error {
+	<-ctx.Done()
+	select {
+	case <-f.sidecarExited:
+	default:
+		close(f.runStoppedTooEarly)
+	}
+	return ctx.Err()
+}
+
 func (f *lifecycleObserverFactory) Run(context.Context) error { return nil }
 func (f *lifecycleObserverFactory) SubmitWorkRequest(context.Context, interfaces.WorkRequest) (interfaces.WorkRequestSubmitResult, error) {
 	return interfaces.WorkRequestSubmitResult{}, nil
@@ -150,6 +166,43 @@ func TestStop_EmitsCompletedLifecycleMetricWithoutRootService(t *testing.T) {
 		return metricNameAndValue(record, "runtime.lifecycle.stopped", 1) &&
 			metricRecordString(record, "outcome") == "completed"
 	}, "completed stop through extracted host")
+}
+
+func TestStop_CancelsAndJoinsSidecarsBeforeStoppingRunLoop(t *testing.T) {
+	sidecarExited := make(chan struct{})
+	runStoppedTooEarly := make(chan struct{})
+	factoryStub := &orderedStopFactory{
+		sidecarExited:      sidecarExited,
+		runStoppedTooEarly: runStoppedTooEarly,
+	}
+	handle := factoryservice.Start(context.Background(), &factoryservice.Bundle{
+		Factory: factoryStub,
+		Logger:  zap.NewNop(),
+	})
+
+	sidecarCtx, cancelSidecar := context.WithCancel(context.Background())
+	handle.SidecarCancel = cancelSidecar
+	handle.Sidecars.Add(1)
+	go func() {
+		defer handle.Sidecars.Done()
+		<-sidecarCtx.Done()
+		close(sidecarExited)
+	}()
+
+	err := factoryservice.Stop(handle, clockwork.NewFakeClock())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Stop error = %v, want context canceled", err)
+	}
+	select {
+	case <-sidecarExited:
+	default:
+		t.Fatal("Stop returned before the sidecar exited")
+	}
+	select {
+	case <-runStoppedTooEarly:
+		t.Fatal("runtime run loop stopped before its sidecars exited")
+	default:
+	}
 }
 
 func TestWaitForStart_ReportsRunningReadinessWithoutRootService(t *testing.T) {

--- a/pkg/runtimehost/doc.go
+++ b/pkg/runtimehost/doc.go
@@ -1,8 +1,0 @@
-// Package runtimehost is a migration-era facade around factory runtime hosting.
-//
-// Factory Session ownership lives in pkg/factorysessions and related session
-// services. New application composition should be injected through
-// pkg/initializer and, as import-cycle migration allows, pkg/inject rather than
-// adding new ownership to this facade. Root pkg/service.FactoryService remains
-// a compatibility alias for runtimehost.Host while callers migrate.
-package runtimehost

--- a/pkg/runtimehost/host.go
+++ b/pkg/runtimehost/host.go
@@ -41,7 +41,6 @@ import (
 	"github.com/portpowered/infinite-you/pkg/petri"
 	"github.com/portpowered/infinite-you/pkg/service/runtimebuild"
 	"github.com/portpowered/infinite-you/pkg/workers"
-	workersservice "github.com/portpowered/infinite-you/pkg/workers/service"
 
 	"go.uber.org/zap"
 )
@@ -123,7 +122,7 @@ type Host struct {
 	factorySave      FactorySaveSaver
 	sessionGateway   SessionGateway
 	runtimeBuild     *runtimebuild.Service
-	workersScheduler *workersservice.Service
+	workersScheduler workerSidecarOwner
 	hostedWorkers    hostedworkers.Config
 	factoryRootDir   string
 	policy           hostCoordinatorPolicy

--- a/pkg/runtimehost/host.go
+++ b/pkg/runtimehost/host.go
@@ -819,14 +819,19 @@ func (c *runtimeCoordinator) StartLiveRuntimeSidecars(ctx context.Context, handl
 		}()
 	}
 
-	fs.startSchedulerSidecarsForRuntime(
+	if err := fs.startSchedulerSidecarsForRuntime(
 		sidecarCtx,
 		&handle.Sidecars,
 		handle.Bundle.RuntimeCfg.FactoryDir(),
 		handle.Bundle.RuntimeCfg.FactoryConfig(),
 		handle.Bundle.RuntimeCfg,
 		submitWorkRequestWithFactory(handle.Bundle.Factory),
-	)
+	); err != nil {
+		sidecarCancel()
+		handle.Sidecars.Wait()
+		handle.SidecarCancel = nil
+		return fmt.Errorf("attach worker sidecars: %w", err)
+	}
 	if handle.Bundle.Listener != nil {
 		if err := handle.Bundle.Listener.PreseedInputs(sidecarCtx); err != nil {
 			sidecarCancel()

--- a/pkg/runtimehost/host.go
+++ b/pkg/runtimehost/host.go
@@ -859,9 +859,7 @@ func (c *runtimeCoordinator) StopLiveRuntime(handle *liveRuntimeHandle) error {
 	if handle == nil {
 		return nil
 	}
-	err := factoryservice.Stop(handle, fs.clock)
-	fs.StopLiveRuntimeSidecars(handle)
-	return err
+	return factoryservice.Stop(handle, fs.clock)
 }
 
 func (fs *Host) ShutdownOtherLiveSessions(except *liveRuntimeHandle) error {

--- a/pkg/runtimehost/poller_watcher.go
+++ b/pkg/runtimehost/poller_watcher.go
@@ -2,16 +2,12 @@ package runtimehost
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
-	"github.com/jonboulle/clockwork"
-	"github.com/portpowered/infinite-you/pkg/factory"
-	"github.com/portpowered/infinite-you/pkg/hostedworkers"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
-	"github.com/portpowered/infinite-you/pkg/workers"
 	workersservice "github.com/portpowered/infinite-you/pkg/workers/service"
-	"go.uber.org/zap"
 )
 
 type workRequestSubmitter func(context.Context, interfaces.WorkRequest) error
@@ -23,12 +19,16 @@ func (fs *Host) startSchedulerSidecarsForRuntime(
 	factoryCfg *interfaces.FactoryConfig,
 	runtimeCfg interfaces.RuntimeConfigLookup,
 	submitter workRequestSubmitter,
-) {
+) error {
 	if runtimeModeOrDefault(fs.coordinatorPolicy().runtimeMode) != interfaces.RuntimeModeService || factoryCfg == nil || runtimeCfg == nil || sidecars == nil || submitter == nil {
-		return
+		return nil
 	}
 
-	fs.requireWorkersScheduler().StartSchedulerSidecarsForRuntime(
+	workersScheduler, err := fs.requireWorkersScheduler()
+	if err != nil {
+		return err
+	}
+	workersScheduler.StartSchedulerSidecarsForRuntime(
 		ctx,
 		sidecars,
 		workersservice.RuntimeSidecarsInput{
@@ -38,41 +38,14 @@ func (fs *Host) startSchedulerSidecarsForRuntime(
 			Submitter:  workersservice.WorkRequestSubmitter(submitter),
 		},
 	)
+	return nil
 }
 
-func (fs *Host) requireWorkersScheduler() *workersservice.Service {
-	if fs == nil {
-		return workersservice.New(workersservice.Config{})
+func (fs *Host) requireWorkersScheduler() (*workersservice.Service, error) {
+	if fs == nil || fs.workersScheduler == nil {
+		return nil, fmt.Errorf("worker sidecar owner is not initialized: construct Host through the runtime initializer")
 	}
-	if fs.workersScheduler != nil {
-		return fs.workersScheduler
-	}
-	if fs.cfg != nil {
-		return NewWorkersSchedulerService(fs.cfg, fs.clock, fs.logger, fs.hostedWorkers)
-	}
-	clock := clockwork.NewRealClock()
-	if supervisorClock, ok := fs.clock.(clockwork.Clock); ok && supervisorClock != nil {
-		clock = supervisorClock
-	}
-	runner := workers.CommandRunner(workers.ExecCommandRunner{})
-	if fs.coordinatorPolicy().commandRunnerOverride != nil {
-		runner = fs.coordinatorPolicy().commandRunnerOverride
-	}
-	logger := zap.NewNop()
-	if fs.logger != nil {
-		logger = fs.logger
-	}
-	hosted := fs.hostedWorkers
-	return workersservice.New(workersservice.Config{
-		Logger:               logger,
-		Clock:                clock,
-		CommandRunner:        runner,
-		WorkflowID:           fs.coordinatorPolicy().workflowID,
-		DefaultFactoryDir:    fs.coordinatorPolicy().dir,
-		HostedHTTPClient:     hosted.HTTPClient,
-		HostedSecretResolver: hosted.SecretResolver,
-		HostedLinearEndpoint: hosted.LinearEndpoint,
-	})
+	return fs.workersScheduler, nil
 }
 
 func (fs *Host) submitCronTick(
@@ -80,14 +53,18 @@ func (fs *Host) submitCronTick(
 	ws interfaces.FactoryWorkstationConfig,
 	firedAt time.Time,
 ) error {
+	workersScheduler, err := fs.requireWorkersScheduler()
+	if err != nil {
+		return err
+	}
 	runtimeCfg := fs.currentRuntimeConfig()
 	workflowIdentity := ""
 	runtimeLookup := interfaces.FirstRuntimeWorkstationLookup(runtimeCfg)
 	submitter := fs.currentRuntimeSubmitter()
 	if runtimeCfg != nil {
-		workflowIdentity = fs.cronWorkflowIdentity(runtimeCfg.FactoryDir())
+		workflowIdentity = workersScheduler.WorkflowIdentityForFactoryDir(runtimeCfg.FactoryDir())
 	}
-	return fs.requireWorkersScheduler().SubmitCronTick(
+	return workersScheduler.SubmitCronTick(
 		ctx,
 		runtimeLookup,
 		workflowIdentity,
@@ -95,47 +72,4 @@ func (fs *Host) submitCronTick(
 		ws,
 		firedAt,
 	)
-}
-
-func (fs *Host) cronWorkflowIdentity(factoryDir string) string {
-	return fs.requireWorkersScheduler().WorkflowIdentityForFactoryDir(factoryDir)
-}
-
-// NewWorkersSchedulerService constructs the workers scheduling collaborator for
-// runtime-host poller and cron supervision.
-func NewWorkersSchedulerService(
-	cfg *Config,
-	clock factory.Clock,
-	logger *zap.Logger,
-	hostedWorkers hostedworkers.Config,
-) *workersservice.Service {
-	supervisorClock := clockwork.NewRealClock()
-	if clock != nil {
-		if clockworkClock, ok := clock.(clockwork.Clock); ok && clockworkClock != nil {
-			supervisorClock = clockworkClock
-		}
-	}
-	if logger == nil {
-		logger = zap.NewNop()
-	}
-	runner := workers.CommandRunner(workers.ExecCommandRunner{})
-	workflowID := ""
-	defaultFactoryDir := ""
-	if cfg != nil {
-		if cfg.CommandRunnerOverride != nil {
-			runner = cfg.CommandRunnerOverride
-		}
-		workflowID = cfg.WorkflowID
-		defaultFactoryDir = cfg.Dir
-	}
-	return workersservice.New(workersservice.Config{
-		Logger:               logger,
-		Clock:                supervisorClock,
-		CommandRunner:        runner,
-		WorkflowID:           workflowID,
-		DefaultFactoryDir:    defaultFactoryDir,
-		HostedHTTPClient:     hostedWorkers.HTTPClient,
-		HostedSecretResolver: hostedWorkers.SecretResolver,
-		HostedLinearEndpoint: hostedWorkers.LinearEndpoint,
-	})
 }

--- a/pkg/runtimehost/poller_watcher.go
+++ b/pkg/runtimehost/poller_watcher.go
@@ -12,6 +12,12 @@ import (
 
 type workRequestSubmitter func(context.Context, interfaces.WorkRequest) error
 
+type workerSidecarOwner interface {
+	StartSchedulerSidecarsForRuntime(context.Context, *sync.WaitGroup, workersservice.RuntimeSidecarsInput)
+	WorkflowIdentityForFactoryDir(string) string
+	SubmitCronTick(context.Context, interfaces.RuntimeWorkstationLookup, string, workersservice.WorkRequestSubmitter, interfaces.FactoryWorkstationConfig, time.Time) error
+}
+
 func (fs *Host) startSchedulerSidecarsForRuntime(
 	ctx context.Context,
 	sidecars *sync.WaitGroup,
@@ -41,7 +47,7 @@ func (fs *Host) startSchedulerSidecarsForRuntime(
 	return nil
 }
 
-func (fs *Host) requireWorkersScheduler() (*workersservice.Service, error) {
+func (fs *Host) requireWorkersScheduler() (workerSidecarOwner, error) {
 	if fs == nil || fs.workersScheduler == nil {
 		return nil, fmt.Errorf("worker sidecar owner is not initialized: construct Host through the runtime initializer")
 	}

--- a/pkg/runtimehost/poller_watcher_test.go
+++ b/pkg/runtimehost/poller_watcher_test.go
@@ -1,0 +1,107 @@
+package runtimehost
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	workersservice "github.com/portpowered/infinite-you/pkg/workers/service"
+)
+
+type recordingWorkerSidecarOwner struct {
+	calls int
+	ctx   context.Context
+	group *sync.WaitGroup
+	input workersservice.RuntimeSidecarsInput
+}
+
+func (o *recordingWorkerSidecarOwner) StartSchedulerSidecarsForRuntime(
+	ctx context.Context,
+	group *sync.WaitGroup,
+	input workersservice.RuntimeSidecarsInput,
+) {
+	o.calls++
+	o.ctx = ctx
+	o.group = group
+	o.input = input
+}
+
+func (*recordingWorkerSidecarOwner) WorkflowIdentityForFactoryDir(string) string { return "" }
+
+func (*recordingWorkerSidecarOwner) SubmitCronTick(
+	context.Context,
+	interfaces.RuntimeWorkstationLookup,
+	string,
+	workersservice.WorkRequestSubmitter,
+	interfaces.FactoryWorkstationConfig,
+	time.Time,
+) error {
+	return nil
+}
+
+func TestHostStartSchedulerSidecarsForRuntimeDelegatesCompleteSessionInput(t *testing.T) {
+	owner := &recordingWorkerSidecarOwner{}
+	host := &Host{
+		workersScheduler: owner,
+		policy:           hostCoordinatorPolicy{runtimeMode: interfaces.RuntimeModeService},
+	}
+	ctx := context.Background()
+	group := &sync.WaitGroup{}
+	factoryCfg := &interfaces.FactoryConfig{Workstations: []interfaces.FactoryWorkstationConfig{
+		{Name: "script", Kind: interfaces.WorkstationKindPoller},
+		{Name: "hosted", Kind: interfaces.WorkstationKindPoller},
+		{Name: "cron", Kind: interfaces.WorkstationKindCron},
+	}}
+	runtimeCfg := &sidecarRuntimeConfig{factoryCfg: factoryCfg}
+	submitter := workRequestSubmitter(func(context.Context, interfaces.WorkRequest) error { return nil })
+
+	err := host.startSchedulerSidecarsForRuntime(ctx, group, "/factory", factoryCfg, runtimeCfg, submitter)
+	if err != nil {
+		t.Fatalf("startSchedulerSidecarsForRuntime: %v", err)
+	}
+	if owner.calls != 1 {
+		t.Fatalf("worker sidecar owner calls = %d, want 1", owner.calls)
+	}
+	if owner.ctx != ctx || owner.group != group {
+		t.Fatal("worker sidecar owner did not receive the session context and wait group unchanged")
+	}
+	if owner.input.FactoryDir != "/factory" || owner.input.FactoryCfg != factoryCfg || owner.input.RuntimeCfg != runtimeCfg || owner.input.Submitter == nil {
+		t.Fatalf("worker sidecar input = %#v, want complete active-session input", owner.input)
+	}
+}
+
+func TestHostStartSchedulerSidecarsForRuntimeSkipsNonServiceRuntime(t *testing.T) {
+	owner := &recordingWorkerSidecarOwner{}
+	host := &Host{workersScheduler: owner, policy: hostCoordinatorPolicy{runtimeMode: interfaces.RuntimeModeBatch}}
+	factoryCfg := &interfaces.FactoryConfig{}
+	runtimeCfg := &sidecarRuntimeConfig{factoryCfg: factoryCfg}
+
+	err := host.startSchedulerSidecarsForRuntime(
+		context.Background(),
+		&sync.WaitGroup{},
+		"/factory",
+		factoryCfg,
+		runtimeCfg,
+		func(context.Context, interfaces.WorkRequest) error { return nil },
+	)
+	if err != nil {
+		t.Fatalf("startSchedulerSidecarsForRuntime: %v", err)
+	}
+	if owner.calls != 0 {
+		t.Fatalf("worker sidecar owner calls = %d, want 0", owner.calls)
+	}
+}
+
+type sidecarRuntimeConfig struct {
+	factoryCfg *interfaces.FactoryConfig
+}
+
+func (c *sidecarRuntimeConfig) FactoryConfig() *interfaces.FactoryConfig     { return c.factoryCfg }
+func (*sidecarRuntimeConfig) FactoryDir() string                             { return "/factory" }
+func (*sidecarRuntimeConfig) RuntimeBaseDir() string                         { return "/factory" }
+func (*sidecarRuntimeConfig) Worker(string) (*interfaces.WorkerConfig, bool) { return nil, false }
+func (*sidecarRuntimeConfig) Workstation(string) (*interfaces.FactoryWorkstationConfig, bool) {
+	return nil, false
+}

--- a/pkg/service/factory.go
+++ b/pkg/service/factory.go
@@ -827,9 +827,7 @@ func (c *runtimeFactoryCoordinator) stopLiveRuntime(handle *liveRuntimeHandle) e
 	if handle == nil {
 		return nil
 	}
-	err := factoryservice.Stop(handle, fs.clock)
-	fs.stopLiveRuntimeSidecars(handle)
-	return err
+	return factoryservice.Stop(handle, fs.clock)
 }
 
 func (fs *FactoryService) shutdownOtherLiveSessions(except *liveRuntimeHandle) error {

--- a/pkg/service/factory.go
+++ b/pkg/service/factory.go
@@ -786,14 +786,19 @@ func (c *runtimeFactoryCoordinator) startLiveRuntimeSidecars(ctx context.Context
 		}()
 	}
 
-	fs.startSchedulerSidecarsForRuntime(
+	if err := fs.startSchedulerSidecarsForRuntime(
 		sidecarCtx,
 		&handle.Sidecars,
 		handle.Bundle.RuntimeCfg.FactoryDir(),
 		handle.Bundle.RuntimeCfg.FactoryConfig(),
 		handle.Bundle.RuntimeCfg,
 		submitWorkRequestWithFactory(handle.Bundle.Factory),
-	)
+	); err != nil {
+		sidecarCancel()
+		handle.Sidecars.Wait()
+		handle.SidecarCancel = nil
+		return fmt.Errorf("attach worker sidecars: %w", err)
+	}
 	if handle.Bundle.Listener != nil {
 		if err := handle.Bundle.Listener.PreseedInputs(sidecarCtx); err != nil {
 			sidecarCancel()

--- a/pkg/service/factory_build.go
+++ b/pkg/service/factory_build.go
@@ -36,12 +36,51 @@ import (
 	"github.com/portpowered/infinite-you/pkg/runtimehost"
 	"github.com/portpowered/infinite-you/pkg/service/runtimebuild"
 	"github.com/portpowered/infinite-you/pkg/workers"
-	workeragentrun "github.com/portpowered/infinite-you/pkg/workers/executor/agentrun"
 	workerexecutor "github.com/portpowered/infinite-you/pkg/workers/executor"
+	workeragentrun "github.com/portpowered/infinite-you/pkg/workers/executor/agentrun"
 	workerprompting "github.com/portpowered/infinite-you/pkg/workers/prompting"
 	workerprovider "github.com/portpowered/infinite-you/pkg/workers/provider"
+	workersservice "github.com/portpowered/infinite-you/pkg/workers/service"
 	"go.uber.org/zap"
 )
+
+// NewWorkersSchedulerService constructs the worker-sidecar owner at the
+// runtime composition boundary. Watcher paths must only use this initialized
+// instance and never reconstruct its dependencies.
+func NewWorkersSchedulerService(
+	cfg *FactoryServiceConfig,
+	clock factory.Clock,
+	logger *zap.Logger,
+	hostedWorkers hostedworkers.Config,
+) *workersservice.Service {
+	supervisorClock := clockwork.NewRealClock()
+	if clockworkClock, ok := clock.(clockwork.Clock); ok && clockworkClock != nil {
+		supervisorClock = clockworkClock
+	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	runner := workers.CommandRunner(workers.ExecCommandRunner{})
+	workflowID := ""
+	defaultFactoryDir := ""
+	if cfg != nil {
+		if cfg.CommandRunnerOverride != nil {
+			runner = cfg.CommandRunnerOverride
+		}
+		workflowID = cfg.WorkflowID
+		defaultFactoryDir = cfg.Dir
+	}
+	return workersservice.New(workersservice.Config{
+		Logger:               logger,
+		Clock:                supervisorClock,
+		CommandRunner:        runner,
+		WorkflowID:           workflowID,
+		DefaultFactoryDir:    defaultFactoryDir,
+		HostedHTTPClient:     hostedWorkers.HTTPClient,
+		HostedSecretResolver: hostedWorkers.SecretResolver,
+		HostedLinearEndpoint: hostedWorkers.LinearEndpoint,
+	})
+}
 
 type runtimeBundleBuildInput struct {
 	dir                           string
@@ -1400,9 +1439,9 @@ func factoryServiceCollaboratorsFromRuntimeHost(core *runtimehost.Core) FactoryS
 		return FactoryServiceCollaborators{}
 	}
 	return FactoryServiceCollaborators{
-		Sessions:       core.Sessions(),
-		LocalModels:    core.LocalModels(),
-		RuntimeBuild:   core.RuntimeBuild(),
+		Sessions:         core.Sessions(),
+		LocalModels:      core.LocalModels(),
+		RuntimeBuild:     core.RuntimeBuild(),
 		WorkersScheduler: core.WorkersScheduler(),
 	}
 }

--- a/pkg/service/factory_editable_definition.go
+++ b/pkg/service/factory_editable_definition.go
@@ -9,9 +9,9 @@ import (
 	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
 	factoryconfig "github.com/portpowered/infinite-you/pkg/config"
 	configpersist "github.com/portpowered/infinite-you/pkg/config/persist"
-	factorydefinition "github.com/portpowered/infinite-you/pkg/factorydefinition/service"
 	"github.com/portpowered/infinite-you/pkg/factory"
 	factoryservice "github.com/portpowered/infinite-you/pkg/factory/service"
+	factorydefinition "github.com/portpowered/infinite-you/pkg/factorydefinition/service"
 	"github.com/portpowered/infinite-you/pkg/factorysessions"
 	"github.com/portpowered/infinite-you/pkg/hostedworkers"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
@@ -612,17 +612,17 @@ func NewHostedWorkersConfig(
 // ComposeCollaboratorSnapshot records whether S6 collaborators were initialized
 // on a built FactoryService. Tests compare snapshots across wire and direct build paths.
 type ComposeCollaboratorSnapshot struct {
-	SessionsInitialized          bool
-	RuntimeBuildInitialized      bool
-	WorkersSchedulerInitialized  bool
-	LocalModelsInitialized       bool
-	ModelAssetsInitialized   bool
-	ModelServiceInitialized  bool
-	FactorySaveInitialized   bool
-	DefinitionsInitialized   bool
-	HostedWorkersLoggerReady bool
-	BundleModelResources     bool
-	BundleLocalModels        bool
+	SessionsInitialized         bool
+	RuntimeBuildInitialized     bool
+	WorkersSchedulerInitialized bool
+	LocalModelsInitialized      bool
+	ModelAssetsInitialized      bool
+	ModelServiceInitialized     bool
+	FactorySaveInitialized      bool
+	DefinitionsInitialized      bool
+	HostedWorkersLoggerReady    bool
+	BundleModelResources        bool
+	BundleLocalModels           bool
 }
 
 // FactoryCore owns the normalized runtime graph assembled before transport
@@ -747,9 +747,9 @@ func (core *FactoryCore) ComposeCollaboratorSnapshot() ComposeCollaboratorSnapsh
 		RuntimeBuildInitialized:     core.RuntimeBuild() != nil,
 		WorkersSchedulerInitialized: core.WorkersScheduler() != nil,
 		LocalModelsInitialized:      core.LocalModels().Manager != nil,
-		ModelAssetsInitialized:   core.ModelAssetPuller() != nil,
-		DefinitionsInitialized:   true,
-		HostedWorkersLoggerReady: core.HostedWorkers().Logger != nil,
+		ModelAssetsInitialized:      core.ModelAssetPuller() != nil,
+		DefinitionsInitialized:      true,
+		HostedWorkersLoggerReady:    core.HostedWorkers().Logger != nil,
 	}
 	if bundle != nil {
 		snapshot.BundleModelResources = bundle.ModelResources != nil
@@ -873,6 +873,9 @@ func ComposeFactoryCore(
 	clock factory.Clock,
 	hostedWorkers hostedworkers.Config,
 ) (*FactoryCore, error) {
+	if collaborators.WorkersScheduler == nil {
+		return nil, fmt.Errorf("compose factory core: worker sidecar owner is required")
+	}
 	if err := validateReplayModeConfig(cfg); err != nil {
 		return nil, err
 	}
@@ -903,14 +906,14 @@ func ComposeFactoryCore(
 		return nil, err
 	}
 	defaultSessionSpec, err := collaborators.RuntimeBuild.BuildSpec(ctx, runtimebuild.SessionSpecInput{
-		Dir:                                   cfg.Dir,
-		FolderPath:                            root.FactoryRootDir,
-		SessionID:                             defaultFactorySessionID,
-		ExecutionBaseDir:                      cfg.ExecutionBaseDir,
-		LoadedFactoryCfg:                      load.LoadedFactoryCfg,
-		RuntimeInstanceID:                     cfg.RuntimeInstanceID,
-		SideEffects:                           replaySideEffects,
-		AdditionalFactoryOpts:                 replayFactoryOpts,
+		Dir:                                    cfg.Dir,
+		FolderPath:                             root.FactoryRootDir,
+		SessionID:                              defaultFactorySessionID,
+		ExecutionBaseDir:                       cfg.ExecutionBaseDir,
+		LoadedFactoryCfg:                       load.LoadedFactoryCfg,
+		RuntimeInstanceID:                      cfg.RuntimeInstanceID,
+		SideEffects:                            replaySideEffects,
+		AdditionalFactoryOpts:                  replayFactoryOpts,
 		PreserveCompatibilityDefaultRecordPath: true,
 	})
 	if err != nil {
@@ -957,17 +960,17 @@ func NewFactoryServiceFromCore(core *FactoryCore) *FactoryService {
 		return nil
 	}
 	svc := &FactoryService{
-		core:           core,
-		factoryRootDir: core.FactoryRootDir(),
-		sessions:       core.Sessions(),
-		hostedWorkers:  core.HostedWorkers(),
-		policy:         serviceCoordinatorPolicyFromConfig(core.cfg),
-		startupBundle:  core.StartupBundle(),
-		cfg:            core.cfg,
-		modelAssets:    core.ModelAssetPuller(),
-		baseLogger:     core.BaseLogger(),
-		logger:         core.Logger(),
-		clock:          core.Clock(),
+		core:             core,
+		factoryRootDir:   core.FactoryRootDir(),
+		sessions:         core.Sessions(),
+		hostedWorkers:    core.HostedWorkers(),
+		policy:           serviceCoordinatorPolicyFromConfig(core.cfg),
+		startupBundle:    core.StartupBundle(),
+		cfg:              core.cfg,
+		modelAssets:      core.ModelAssetPuller(),
+		baseLogger:       core.BaseLogger(),
+		logger:           core.Logger(),
+		clock:            core.Clock(),
 		runtimeBuild:     core.RuntimeBuild(),
 		workersScheduler: core.WorkersScheduler(),
 	}

--- a/pkg/service/factory_test.go
+++ b/pkg/service/factory_test.go
@@ -271,6 +271,7 @@ func stopServiceModeRun(t *testing.T, cancel context.CancelFunc, errCh <-chan er
 }
 
 type aggregateSnapshotFactory struct {
+	mu                       sync.Mutex
 	engineState              *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]
 	engineStateErr           error
 	engineStateSnapshotCalls int
@@ -295,12 +296,19 @@ func (f *aggregateSnapshotFactory) SubmitWorkRequest(ctx context.Context, reques
 	if len(normalized) > 0 {
 		result.TraceID = normalized[0].TraceID
 	}
+	f.mu.Lock()
 	f.submitCalls++
 	f.submissions = append(f.submissions, request)
+	f.mu.Unlock()
 	if f.submitFunc != nil {
 		return result, f.submitFunc(ctx, request)
 	}
 	return result, nil
+}
+func (f *aggregateSnapshotFactory) submissionSnapshot() (int, []interfaces.WorkRequest) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.submitCalls, append([]interfaces.WorkRequest(nil), f.submissions...)
 }
 func (f *aggregateSnapshotFactory) SubscribeFactoryEvents(context.Context, *interfaces.FactoryEventReconnectCursor, interfaces.FactoryEventReconnectScope) (*interfaces.FactoryEventStream, error) {
 	streamGenerationID := strings.TrimSpace(f.streamGenerationID)
@@ -716,6 +724,7 @@ type runningSessionServiceOptions struct {
 	runtimeLogDir  string
 	recordPath     string
 	extraOptions   []factory.FactoryOption
+	logger         *zap.Logger
 }
 
 type runningSessionService struct {
@@ -760,11 +769,15 @@ func startRunningSessionService(t *testing.T, options runningSessionServiceOptio
 		}
 	}
 
+	logger := options.logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	svc, err := BuildFactoryService(context.Background(), &FactoryServiceConfig{
 		Dir:                 rootDir,
 		RuntimeMode:         interfaces.RuntimeModeService,
 		MockWorkersConfig:   config.NewEmptyMockWorkersConfig(),
-		Logger:              zap.NewNop(),
+		Logger:              logger,
 		RuntimeLogDir:       runtimeLogDir,
 		RuntimeMetricsDir:   runtimeMetricsDir,
 		RecordPath:          options.recordPath,

--- a/pkg/service/poller_watcher.go
+++ b/pkg/service/poller_watcher.go
@@ -2,16 +2,12 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
-	"github.com/jonboulle/clockwork"
-	"github.com/portpowered/infinite-you/pkg/factory"
-	"github.com/portpowered/infinite-you/pkg/hostedworkers"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
-	"github.com/portpowered/infinite-you/pkg/workers"
 	workersservice "github.com/portpowered/infinite-you/pkg/workers/service"
-	"go.uber.org/zap"
 )
 
 type workRequestSubmitter func(context.Context, interfaces.WorkRequest) error
@@ -23,12 +19,16 @@ func (fs *FactoryService) startSchedulerSidecarsForRuntime(
 	factoryCfg *interfaces.FactoryConfig,
 	runtimeCfg interfaces.RuntimeConfigLookup,
 	submitter workRequestSubmitter,
-) {
+) error {
 	if runtimeModeOrDefault(fs.coordinatorPolicy().runtimeMode) != interfaces.RuntimeModeService || factoryCfg == nil || runtimeCfg == nil || sidecars == nil || submitter == nil {
-		return
+		return nil
 	}
 
-	fs.requireWorkersScheduler().StartSchedulerSidecarsForRuntime(
+	workersScheduler, err := fs.requireWorkersScheduler()
+	if err != nil {
+		return err
+	}
+	workersScheduler.StartSchedulerSidecarsForRuntime(
 		ctx,
 		sidecars,
 		workersservice.RuntimeSidecarsInput{
@@ -38,41 +38,14 @@ func (fs *FactoryService) startSchedulerSidecarsForRuntime(
 			Submitter:  workersservice.WorkRequestSubmitter(submitter),
 		},
 	)
+	return nil
 }
 
-func (fs *FactoryService) requireWorkersScheduler() *workersservice.Service {
-	if fs == nil {
-		return workersservice.New(workersservice.Config{})
+func (fs *FactoryService) requireWorkersScheduler() (*workersservice.Service, error) {
+	if fs == nil || fs.workersScheduler == nil {
+		return nil, fmt.Errorf("worker sidecar owner is not initialized: construct FactoryService through the runtime initializer")
 	}
-	if fs.workersScheduler != nil {
-		return fs.workersScheduler
-	}
-	if fs.cfg != nil {
-		return NewWorkersSchedulerService(fs.cfg, fs.clock, fs.logger, fs.hostedWorkers)
-	}
-	clock := clockwork.NewRealClock()
-	if supervisorClock, ok := fs.clock.(clockwork.Clock); ok && supervisorClock != nil {
-		clock = supervisorClock
-	}
-	runner := workers.CommandRunner(workers.ExecCommandRunner{})
-	if fs.coordinatorPolicy().commandRunnerOverride != nil {
-		runner = fs.coordinatorPolicy().commandRunnerOverride
-	}
-	logger := zap.NewNop()
-	if fs.logger != nil {
-		logger = fs.logger
-	}
-	hosted := fs.hostedWorkers
-	return workersservice.New(workersservice.Config{
-		Logger:               logger,
-		Clock:                clock,
-		CommandRunner:        runner,
-		WorkflowID:           fs.coordinatorPolicy().workflowID,
-		DefaultFactoryDir:    fs.coordinatorPolicy().dir,
-		HostedHTTPClient:     hosted.HTTPClient,
-		HostedSecretResolver: hosted.SecretResolver,
-		HostedLinearEndpoint: hosted.LinearEndpoint,
-	})
+	return fs.workersScheduler, nil
 }
 
 func (fs *FactoryService) submitCronTick(
@@ -80,14 +53,18 @@ func (fs *FactoryService) submitCronTick(
 	ws interfaces.FactoryWorkstationConfig,
 	firedAt time.Time,
 ) error {
+	workersScheduler, err := fs.requireWorkersScheduler()
+	if err != nil {
+		return err
+	}
 	runtimeCfg := fs.currentRuntimeConfig()
 	workflowIdentity := ""
 	runtimeLookup := interfaces.FirstRuntimeWorkstationLookup(runtimeCfg)
 	submitter := fs.currentRuntimeSubmitter()
 	if runtimeCfg != nil {
-		workflowIdentity = fs.cronWorkflowIdentity(runtimeCfg.FactoryDir())
+		workflowIdentity = workersScheduler.WorkflowIdentityForFactoryDir(runtimeCfg.FactoryDir())
 	}
-	return fs.requireWorkersScheduler().SubmitCronTick(
+	return workersScheduler.SubmitCronTick(
 		ctx,
 		runtimeLookup,
 		workflowIdentity,
@@ -95,47 +72,4 @@ func (fs *FactoryService) submitCronTick(
 		ws,
 		firedAt,
 	)
-}
-
-func (fs *FactoryService) cronWorkflowIdentity(factoryDir string) string {
-	return fs.requireWorkersScheduler().WorkflowIdentityForFactoryDir(factoryDir)
-}
-
-// NewWorkersSchedulerService constructs the workers scheduling collaborator for
-// runtime-host poller and cron supervision.
-func NewWorkersSchedulerService(
-	cfg *FactoryServiceConfig,
-	clock factory.Clock,
-	logger *zap.Logger,
-	hostedWorkers hostedworkers.Config,
-) *workersservice.Service {
-	supervisorClock := clockwork.NewRealClock()
-	if clock != nil {
-		if clockworkClock, ok := clock.(clockwork.Clock); ok && clockworkClock != nil {
-			supervisorClock = clockworkClock
-		}
-	}
-	if logger == nil {
-		logger = zap.NewNop()
-	}
-	runner := workers.CommandRunner(workers.ExecCommandRunner{})
-	workflowID := ""
-	defaultFactoryDir := ""
-	if cfg != nil {
-		if cfg.CommandRunnerOverride != nil {
-			runner = cfg.CommandRunnerOverride
-		}
-		workflowID = cfg.WorkflowID
-		defaultFactoryDir = cfg.Dir
-	}
-	return workersservice.New(workersservice.Config{
-		Logger:               logger,
-		Clock:                supervisorClock,
-		CommandRunner:        runner,
-		WorkflowID:           workflowID,
-		DefaultFactoryDir:    defaultFactoryDir,
-		HostedHTTPClient:     hostedWorkers.HTTPClient,
-		HostedSecretResolver: hostedWorkers.SecretResolver,
-		HostedLinearEndpoint: hostedWorkers.LinearEndpoint,
-	})
 }

--- a/pkg/service/poller_watcher_test.go
+++ b/pkg/service/poller_watcher_test.go
@@ -34,6 +34,39 @@ const (
 	canonicalScriptPollerCommand         = "factory/scripts/poller.sh"
 )
 
+func initializeWorkersSchedulerForTest(svc *FactoryService) {
+	cfg := &FactoryServiceConfig{
+		Dir:                   svc.policy.dir,
+		WorkflowID:            svc.policy.workflowID,
+		CommandRunnerOverride: svc.policy.commandRunnerOverride,
+	}
+	svc.workersScheduler = NewWorkersSchedulerService(cfg, svc.clock, svc.logger, svc.hostedWorkers)
+}
+
+func TestFactoryService_StartLiveRuntimeSidecars_RequiresInitializedWorkerSidecarOwner(t *testing.T) {
+	svc := &FactoryService{
+		policy: serviceCoordinatorPolicyFromConfig(&FactoryServiceConfig{RuntimeMode: interfaces.RuntimeModeService}),
+		logger: zap.NewNop(),
+	}
+	runtimeCfg := newScriptPollerLoadedRuntimeConfigForServiceTest(
+		t,
+		t.TempDir(),
+		scriptPollerRuntimeConfigOptions{poller: newCanonicalScriptPollerWorkstation()},
+	)
+	handle := &liveRuntimeHandle{Bundle: &factoryRuntimeBundle{
+		Factory:    &aggregateSnapshotFactory{},
+		RuntimeCfg: runtimeCfg,
+	}}
+
+	err := svc.startLiveRuntimeSidecars(context.Background(), handle)
+	if err == nil || !strings.Contains(err.Error(), "worker sidecar owner is not initialized") {
+		t.Fatalf("startLiveRuntimeSidecars error = %v, want missing worker sidecar owner", err)
+	}
+	if handle.SidecarCancel != nil {
+		t.Fatal("failed sidecar attachment retained a cancellation function")
+	}
+}
+
 func TestFactoryService_StartLiveRuntimeSidecars_StartsScriptPollerForPollerRunWorkstationType(t *testing.T) {
 	start := time.Date(2026, time.June, 16, 9, 0, 0, 0, time.UTC)
 	fakeClock := clockwork.NewFakeClockAt(start)
@@ -47,6 +80,7 @@ func TestFactoryService_StartLiveRuntimeSidecars_StartsScriptPollerForPollerRunW
 		logger: zap.New(logCore),
 		clock:  fakeClock,
 	}
+	initializeWorkersSchedulerForTest(svc)
 	poller := interfaces.FactoryWorkstationConfig{
 		Name:           canonicalScriptPollerWorkstationName,
 		Type:           interfaces.WorkstationTypePoller,
@@ -66,9 +100,9 @@ func TestFactoryService_StartLiveRuntimeSidecars_StartsScriptPollerForPollerRunW
 		},
 	)
 	handle := &liveRuntimeHandle{Bundle: &factoryRuntimeBundle{
-			Factory:    &aggregateSnapshotFactory{},
-			RuntimeCfg: runtimeCfg,
-		},
+		Factory:    &aggregateSnapshotFactory{},
+		RuntimeCfg: runtimeCfg,
+	},
 	}
 	sidecarCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -97,6 +131,7 @@ func TestFactoryService_StartLiveRuntimeSidecars_StartsOnlyScriptPollersAndResta
 		logger: zap.New(logCore),
 		clock:  fakeClock,
 	}
+	initializeWorkersSchedulerForTest(svc)
 	poller := newCanonicalScriptPollerWorkstation()
 	standard := interfaces.FactoryWorkstationConfig{
 		Name:           "processor",
@@ -120,9 +155,9 @@ func TestFactoryService_StartLiveRuntimeSidecars_StartsOnlyScriptPollersAndResta
 		},
 	)
 	handle := &liveRuntimeHandle{Bundle: &factoryRuntimeBundle{
-			Factory:    &aggregateSnapshotFactory{},
-			RuntimeCfg: runtimeCfg,
-		},
+		Factory:    &aggregateSnapshotFactory{},
+		RuntimeCfg: runtimeCfg,
+	},
 	}
 	sidecarCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -167,6 +202,7 @@ func TestFactoryService_StartLiveRuntimeSidecars_BatchModeDoesNotStartScriptPoll
 		policy: serviceCoordinatorPolicyFromConfig(&FactoryServiceConfig{RuntimeMode: interfaces.RuntimeModeBatch, CommandRunnerOverride: runner}),
 		logger: zap.NewNop(),
 	}
+	initializeWorkersSchedulerForTest(svc)
 	poller := newCanonicalScriptPollerWorkstation()
 	runtimeCfg := newScriptPollerLoadedRuntimeConfigForServiceTest(
 		t,
@@ -176,9 +212,9 @@ func TestFactoryService_StartLiveRuntimeSidecars_BatchModeDoesNotStartScriptPoll
 		},
 	)
 	handle := &liveRuntimeHandle{Bundle: &factoryRuntimeBundle{
-			Factory:    &aggregateSnapshotFactory{},
-			RuntimeCfg: runtimeCfg,
-		},
+		Factory:    &aggregateSnapshotFactory{},
+		RuntimeCfg: runtimeCfg,
+	},
 	}
 
 	if err := svc.startLiveRuntimeSidecars(context.Background(), handle); err != nil {
@@ -237,6 +273,7 @@ func TestFactoryService_StartLiveRuntimeSidecars_StartsHostedLinearPoller(t *tes
 		logger:        zap.NewNop(),
 		hostedWorkers: buildHostedWorkersConfig(svcCfg, zap.NewNop(), nil),
 	}
+	initializeWorkersSchedulerForTest(svc)
 	poller := interfaces.FactoryWorkstationConfig{
 		Name:           "linear-ingress",
 		Kind:           interfaces.WorkstationKindPoller,
@@ -267,9 +304,9 @@ func TestFactoryService_StartLiveRuntimeSidecars_StartsHostedLinearPoller(t *tes
 		map[string]*interfaces.FactoryWorkstationConfig{poller.Name: &poller},
 	)
 	handle := &liveRuntimeHandle{Bundle: &factoryRuntimeBundle{
-			RuntimeCfg: runtimeCfg,
-			Factory:    submitted,
-		},
+		RuntimeCfg: runtimeCfg,
+		Factory:    submitted,
+	},
 	}
 	sidecarCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -360,6 +397,7 @@ func TestFactoryService_StopLiveRuntimeSidecars_StopsHostedLinearPollerAndLogsLi
 		logger:        zap.New(logCore),
 		hostedWorkers: buildHostedWorkersConfig(svcCfg, zap.New(logCore), nil),
 	}
+	initializeWorkersSchedulerForTest(svc)
 	poller := interfaces.FactoryWorkstationConfig{
 		Name:           "linear-ingress",
 		Kind:           interfaces.WorkstationKindPoller,
@@ -390,9 +428,9 @@ func TestFactoryService_StopLiveRuntimeSidecars_StopsHostedLinearPollerAndLogsLi
 		map[string]*interfaces.FactoryWorkstationConfig{poller.Name: &poller},
 	)
 	handle := &liveRuntimeHandle{Bundle: &factoryRuntimeBundle{
-			RuntimeCfg: runtimeCfg,
-			Factory:    &aggregateSnapshotFactory{},
-		},
+		RuntimeCfg: runtimeCfg,
+		Factory:    &aggregateSnapshotFactory{},
+	},
 	}
 
 	if err := svc.startLiveRuntimeSidecars(context.Background(), handle); err != nil {
@@ -419,6 +457,7 @@ func TestFactoryService_StartLiveRuntimeSidecars_DisablesUnsupportedHostedProvid
 		logger:        zap.New(logCore),
 		hostedWorkers: buildHostedWorkersConfig(svcCfg, zap.New(logCore), nil),
 	}
+	initializeWorkersSchedulerForTest(svc)
 	poller := interfaces.FactoryWorkstationConfig{
 		Name:           "custom-ingress",
 		Kind:           interfaces.WorkstationKindPoller,
@@ -441,9 +480,9 @@ func TestFactoryService_StartLiveRuntimeSidecars_DisablesUnsupportedHostedProvid
 		map[string]*interfaces.FactoryWorkstationConfig{poller.Name: &poller},
 	)
 	handle := &liveRuntimeHandle{Bundle: &factoryRuntimeBundle{
-			RuntimeCfg: runtimeCfg,
-			Factory:    &aggregateSnapshotFactory{},
-		},
+		RuntimeCfg: runtimeCfg,
+		Factory:    &aggregateSnapshotFactory{},
+	},
 	}
 	sidecarCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -484,6 +523,7 @@ func TestFactoryService_StartLiveRuntimeSidecars_RestartsScriptPollerOnMalformed
 		logger: zap.New(logCore),
 		clock:  fakeClock,
 	}
+	initializeWorkersSchedulerForTest(svc)
 	poller := newCanonicalScriptPollerWorkstation()
 	runtimeCfg := newScriptPollerLoadedRuntimeConfigForServiceTest(
 		t,
@@ -493,9 +533,9 @@ func TestFactoryService_StartLiveRuntimeSidecars_RestartsScriptPollerOnMalformed
 		},
 	)
 	handle := &liveRuntimeHandle{Bundle: &factoryRuntimeBundle{
-			Factory:    &aggregateSnapshotFactory{},
-			RuntimeCfg: runtimeCfg,
-		},
+		Factory:    &aggregateSnapshotFactory{},
+		RuntimeCfg: runtimeCfg,
+	},
 	}
 	sidecarCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -528,6 +568,7 @@ func TestFactoryService_StopLiveRuntimeSidecars_StopsScriptPollerAndLogsLifecycl
 		policy: serviceCoordinatorPolicyFromConfig(&FactoryServiceConfig{RuntimeMode: interfaces.RuntimeModeService, CommandRunnerOverride: runner}),
 		logger: zap.New(logCore),
 	}
+	initializeWorkersSchedulerForTest(svc)
 	poller := newCanonicalScriptPollerWorkstation()
 	runtimeCfg := newScriptPollerLoadedRuntimeConfigForServiceTest(
 		t,
@@ -537,9 +578,9 @@ func TestFactoryService_StopLiveRuntimeSidecars_StopsScriptPollerAndLogsLifecycl
 		},
 	)
 	handle := &liveRuntimeHandle{Bundle: &factoryRuntimeBundle{
-			Factory:    &aggregateSnapshotFactory{},
-			RuntimeCfg: runtimeCfg,
-		},
+		Factory:    &aggregateSnapshotFactory{},
+		RuntimeCfg: runtimeCfg,
+	},
 	}
 
 	if err := svc.startLiveRuntimeSidecars(context.Background(), handle); err != nil {
@@ -575,6 +616,7 @@ func TestFactoryService_StopLiveRuntimeSidecars_StopsPriorScriptPollerBeforeRepl
 		policy: serviceCoordinatorPolicyFromConfig(&FactoryServiceConfig{RuntimeMode: interfaces.RuntimeModeService, CommandRunnerOverride: runner}),
 		logger: zap.NewNop(),
 	}
+	initializeWorkersSchedulerForTest(svc)
 	oldPoller := interfaces.FactoryWorkstationConfig{
 		Name:           "linear-ingress-old",
 		Kind:           interfaces.WorkstationKindPoller,
@@ -639,6 +681,7 @@ func TestFactoryService_StopLiveRuntimeSidecars_WaitsForScriptPollerSubmitBefore
 		policy: serviceCoordinatorPolicyFromConfig(&FactoryServiceConfig{RuntimeMode: interfaces.RuntimeModeService, CommandRunnerOverride: runner}),
 		logger: zap.NewNop(),
 	}
+	initializeWorkersSchedulerForTest(svc)
 	oldHandle := newScriptPollerRuntimeHandle(t, "linear-ingress-old", oldFactory)
 	newHandle := newScriptPollerRuntimeHandle(t, "linear-ingress-new", newFactory)
 
@@ -709,15 +752,15 @@ func newScriptPollerRuntimeHandleForWorkstation(
 	t.Helper()
 
 	return &liveRuntimeHandle{Bundle: &factoryRuntimeBundle{
-			Factory: activeFactory,
-			RuntimeCfg: newScriptPollerLoadedRuntimeConfigForServiceTest(
-				t,
-				t.TempDir(),
-				scriptPollerRuntimeConfigOptions{
-					poller: poller,
-				},
-			),
-		},
+		Factory: activeFactory,
+		RuntimeCfg: newScriptPollerLoadedRuntimeConfigForServiceTest(
+			t,
+			t.TempDir(),
+			scriptPollerRuntimeConfigOptions{
+				poller: poller,
+			},
+		),
+	},
 	}
 }
 
@@ -969,12 +1012,14 @@ func newHostedLinearPollerServiceFixture(
 		},
 		map[string]*interfaces.FactoryWorkstationConfig{poller.Name: &poller},
 	)
+	svc := &FactoryService{
+		policy:        serviceCoordinatorPolicyFromConfig(svcCfg),
+		logger:        zap.NewNop(),
+		hostedWorkers: buildHostedWorkersConfig(svcCfg, zap.NewNop(), nil),
+	}
+	initializeWorkersSchedulerForTest(svc)
 	return hostedLinearPollerServiceFixture{
-		svc: &FactoryService{
-			policy:        serviceCoordinatorPolicyFromConfig(svcCfg),
-			logger:        zap.NewNop(),
-			hostedWorkers: buildHostedWorkersConfig(svcCfg, zap.NewNop(), nil),
-		},
+		svc:        svc,
 		submitted:  submitted,
 		runtimeCfg: runtimeCfg,
 	}
@@ -1041,13 +1086,15 @@ func newConcurrentHostedAndScriptPollerFixture(t *testing.T, server *httptest.Se
 			scriptPoller.Name: &scriptPoller,
 		},
 	)
+	svc := &FactoryService{
+		policy:        serviceCoordinatorPolicyFromConfig(svcCfg),
+		logger:        zap.NewNop(),
+		hostedWorkers: buildHostedWorkersConfig(svcCfg, zap.NewNop(), nil),
+	}
+	initializeWorkersSchedulerForTest(svc)
 	return concurrentHostedAndScriptPollerFixture{
 		hostedLinearPollerServiceFixture: hostedLinearPollerServiceFixture{
-			svc: &FactoryService{
-				policy:        serviceCoordinatorPolicyFromConfig(svcCfg),
-				logger:        zap.NewNop(),
-				hostedWorkers: buildHostedWorkersConfig(svcCfg, zap.NewNop(), nil),
-			},
+			svc:        svc,
 			submitted:  submitted,
 			runtimeCfg: runtimeCfg,
 		},
@@ -1057,9 +1104,9 @@ func newConcurrentHostedAndScriptPollerFixture(t *testing.T, server *httptest.Se
 func startHostedLinearPollerSidecars(t *testing.T, fixture hostedLinearPollerServiceFixture) func() {
 	t.Helper()
 	handle := &liveRuntimeHandle{Bundle: &factoryRuntimeBundle{
-			RuntimeCfg: fixture.runtimeCfg,
-			Factory:    fixture.submitted,
-		},
+		RuntimeCfg: fixture.runtimeCfg,
+		Factory:    fixture.submitted,
+	},
 	}
 	sidecarCtx, cancel := context.WithCancel(context.Background())
 	if err := fixture.svc.startLiveRuntimeSidecars(sidecarCtx, handle); err != nil {
@@ -1450,10 +1497,11 @@ func TestFactoryService_StartLiveRuntimeSidecars_SkipsNonCronAndTriggersOnlyCron
 		logger: zap.New(logCore),
 		clock:  fakeClock,
 	}
+	initializeWorkersSchedulerForTest(svc)
 	handle := &liveRuntimeHandle{Bundle: &factoryRuntimeBundle{
-			Factory:    replacementFactory,
-			RuntimeCfg: runtimeCfg,
-		},
+		Factory:    replacementFactory,
+		RuntimeCfg: runtimeCfg,
+	},
 	}
 	sidecarCtx, cancelSidecars := context.WithCancel(context.Background())
 	defer cancelSidecars()
@@ -1612,10 +1660,11 @@ func TestFactoryService_StartLiveRuntimeSidecars_BindsCronTriggerAtStartToReplac
 		logger: zap.NewNop(),
 		clock:  fakeClock,
 	}
+	initializeWorkersSchedulerForTest(svc)
 	handle := &liveRuntimeHandle{Bundle: &factoryRuntimeBundle{
-			Factory:    replacementFactory,
-			RuntimeCfg: cronLoadedFactoryConfigForServiceTest(t, "beta", true),
-		},
+		Factory:    replacementFactory,
+		RuntimeCfg: cronLoadedFactoryConfigForServiceTest(t, "beta", true),
+	},
 	}
 	sidecarCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/service/poller_watcher_test.go
+++ b/pkg/service/poller_watcher_test.go
@@ -317,10 +317,11 @@ func TestFactoryService_StartLiveRuntimeSidecars_StartsHostedLinearPoller(t *tes
 	defer svc.stopLiveRuntimeSidecars(handle)
 
 	waitForHostedPollerSubmission(t, submitted, 1, time.Second)
-	if submitted.submitCalls != 1 {
-		t.Fatalf("submit calls = %d, want 1", submitted.submitCalls)
+	calls, submissions := submitted.submissionSnapshot()
+	if calls != 1 {
+		t.Fatalf("submit calls = %d, want 1", calls)
 	}
-	if got := submitted.submissions[0].Works[0].WorkID; got != "linear:issue-new" {
+	if got := submissions[0].Works[0].WorkID; got != "linear:issue-new" {
 		t.Fatalf("submitted work id = %q, want linear:issue-new", got)
 	}
 }
@@ -1121,13 +1122,14 @@ func startHostedLinearPollerSidecars(t *testing.T, fixture hostedLinearPollerSer
 
 func assertHostedLinearBatchWorks(t *testing.T, submitted *aggregateSnapshotFactory, wantWorkIDs ...string) {
 	t.Helper()
-	if submitted.submitCalls != 1 {
-		t.Fatalf("submit calls = %d, want 1 batch submit for the poll cycle", submitted.submitCalls)
+	calls, submissions := submitted.submissionSnapshot()
+	if calls != 1 {
+		t.Fatalf("submit calls = %d, want 1 batch submit for the poll cycle", calls)
 	}
-	if len(submitted.submissions) != 1 {
-		t.Fatalf("submitted requests = %d, want 1", len(submitted.submissions))
+	if len(submissions) != 1 {
+		t.Fatalf("submitted requests = %d, want 1", len(submissions))
 	}
-	works := submitted.submissions[0].Works
+	works := submissions[0].Works
 	if len(works) != len(wantWorkIDs) {
 		t.Fatalf("submitted works = %d, want %d canonical outputs from one poll cycle", len(works), len(wantWorkIDs))
 	}
@@ -1136,18 +1138,19 @@ func assertHostedLinearBatchWorks(t *testing.T, submitted *aggregateSnapshotFact
 			t.Fatalf("submitted work ID[%d] = %q, want %q", i, works[i].WorkID, wantWorkID)
 		}
 	}
-	if submitted.submissions[0].RequestID == "" || works[0].RequestID != works[1].RequestID {
+	if submissions[0].RequestID == "" || works[0].RequestID != works[1].RequestID {
 		t.Fatalf("batch request IDs = [%q %q], want shared non-empty requestId", works[0].RequestID, works[1].RequestID)
 	}
 }
 
 func assertConcurrentHostedAndScriptPollerSubmissions(t *testing.T, submitted *aggregateSnapshotFactory) {
 	t.Helper()
-	if submitted.submitCalls < 2 {
-		t.Fatalf("submit calls = %d, want at least 2 from concurrent pollers", submitted.submitCalls)
+	calls, submissions := submitted.submissionSnapshot()
+	if calls < 2 {
+		t.Fatalf("submit calls = %d, want at least 2 from concurrent pollers", calls)
 	}
 	var hostedSubmitted, scriptSubmitted bool
-	for _, request := range submitted.submissions {
+	for _, request := range submissions {
 		for _, work := range request.Works {
 			if work.WorkID == "linear:issue-hosted" {
 				hostedSubmitted = true
@@ -1158,7 +1161,7 @@ func assertConcurrentHostedAndScriptPollerSubmissions(t *testing.T, submitted *a
 		}
 	}
 	if !hostedSubmitted || !scriptSubmitted {
-		t.Fatalf("submitted works = %#v, want both hosted linear:issue-hosted and script-issue outputs", submitted.submissions)
+		t.Fatalf("submitted works = %#v, want both hosted linear:issue-hosted and script-issue outputs", submissions)
 	}
 }
 
@@ -1166,12 +1169,14 @@ func waitForHostedPollerSubmission(t *testing.T, submitted *aggregateSnapshotFac
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		if submitted.submitCalls >= want {
+		calls, _ := submitted.submissionSnapshot()
+		if calls >= want {
 			return
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatalf("timed out waiting for %d hosted poller submission(s); got %d", want, submitted.submitCalls)
+	calls, _ := submitted.submissionSnapshot()
+	t.Fatalf("timed out waiting for %d hosted poller submission(s); got %d", want, calls)
 }
 
 func waitForObservedLogMessage(t *testing.T, logs *observer.ObservedLogs, message string, timeout time.Duration) {

--- a/pkg/service/runtime_session_runtime_test.go
+++ b/pkg/service/runtime_session_runtime_test.go
@@ -2595,9 +2595,10 @@ func TestObserveLiveLifecycleControl_LogsAcceptedPauseWithoutSensitiveFields(t *
 	core, observed := observer.New(zap.InfoLevel)
 	harness := startRunningSessionService(t, runningSessionServiceOptions{
 		rootConfig: minimalFactoryConfig(),
+		logger:     zap.New(core),
 	})
-	harness.svc.logger = zap.New(core)
 	defer harness.stop(t)
+	observed.TakeAll()
 
 	if _, err := harness.svc.PauseLiveFactorySession(
 		context.Background(),
@@ -2624,9 +2625,10 @@ func TestObserveLiveLifecycleControl_LogsNoOpRepeatPause(t *testing.T) {
 	core, observed := observer.New(zap.InfoLevel)
 	harness := startRunningSessionService(t, runningSessionServiceOptions{
 		rootConfig: minimalFactoryConfig(),
+		logger:     zap.New(core),
 	})
-	harness.svc.logger = zap.New(core)
 	defer harness.stop(t)
+	observed.TakeAll()
 
 	if _, err := harness.svc.PauseLiveFactorySession(
 		context.Background(),
@@ -2653,9 +2655,10 @@ func TestObserveLiveLifecycleControl_LogsNoOpResume(t *testing.T) {
 	core, observed := observer.New(zap.InfoLevel)
 	harness := startRunningSessionService(t, runningSessionServiceOptions{
 		rootConfig: minimalFactoryConfig(),
+		logger:     zap.New(core),
 	})
-	harness.svc.logger = zap.New(core)
 	defer harness.stop(t)
+	observed.TakeAll()
 
 	response, err := harness.svc.ResumeLiveFactorySession(
 		context.Background(),
@@ -2678,9 +2681,10 @@ func TestObserveLiveLifecycleControl_LogsNotFound(t *testing.T) {
 	core, observed := observer.New(zap.WarnLevel)
 	harness := startRunningSessionService(t, runningSessionServiceOptions{
 		rootConfig: minimalFactoryConfig(),
+		logger:     zap.New(core),
 	})
-	harness.svc.logger = zap.New(core)
 	defer harness.stop(t)
+	observed.TakeAll()
 
 	_, err := harness.svc.PauseLiveFactorySession(
 		context.Background(),
@@ -2694,7 +2698,7 @@ func TestObserveLiveLifecycleControl_LogsNotFound(t *testing.T) {
 		t.Fatalf("error = %v, want ErrFactorySessionNotFound", err)
 	}
 
-	entry := findLifecycleControlLog(t, observed, "factory session lifecycle control rejected")
+	entry := findLifecycleControlLogForSession(t, observed, "factory session lifecycle control rejected", "live-session-missing-001")
 	assertLogField(t, entry, "session_id", "live-session-missing-001")
 	assertLogField(t, entry, "outcome", "NOT_FOUND")
 }
@@ -2737,6 +2741,17 @@ func findLifecycleControlLog(t *testing.T, observed *observer.ObservedLogs, mess
 	return observer.LoggedEntry{}
 }
 
+func findLifecycleControlLogForSession(t *testing.T, observed *observer.ObservedLogs, message, sessionID string) observer.LoggedEntry {
+	t.Helper()
+	for _, entry := range observed.All() {
+		if entry.Message == message && entry.ContextMap()["session_id"] == sessionID {
+			return entry
+		}
+	}
+	t.Fatalf("lifecycle control log %q for session %q not found in %#v", message, sessionID, observed.All())
+	return observer.LoggedEntry{}
+}
+
 func findObservedLog(t *testing.T, observed *observer.ObservedLogs, message string) observer.LoggedEntry {
 	t.Helper()
 	for _, entry := range observed.All() {
@@ -2750,14 +2765,18 @@ func findObservedLog(t *testing.T, observed *observer.ObservedLogs, message stri
 
 func assertLogField(t *testing.T, entry observer.LoggedEntry, key, want string) {
 	t.Helper()
+	var values []string
 	for _, field := range entry.Context {
 		if field.Key != key {
 			continue
 		}
+		values = append(values, field.String)
 		if field.String == want {
 			return
 		}
-		t.Fatalf("log field %q = %q, want %q", key, field.String, want)
+	}
+	if len(values) > 0 {
+		t.Fatalf("log field %q values = %q, want one equal to %q", key, values, want)
 	}
 	t.Fatalf("log field %q missing from %#v", key, entry.Context)
 }

--- a/pkg/workers/service/hosted_poller_test.go
+++ b/pkg/workers/service/hosted_poller_test.go
@@ -71,8 +71,9 @@ func TestStartHostedLinearPoller_SubmitsIssuesThroughWorkersService(t *testing.T
 	svc.StartHostedLinearPoller(sidecarCtx, &sidecars, runtimeCfg, poller, worker, submitted.submit)
 
 	waitForPollerSubmission(t, submitted, 1, time.Second)
-	if submitted.calls != 1 {
-		t.Fatalf("submit calls = %d, want 1", submitted.calls)
+	calls, _ := submitted.snapshot()
+	if calls != 1 {
+		t.Fatalf("submit calls = %d, want 1", calls)
 	}
 }
 
@@ -206,8 +207,9 @@ func TestStartPollersForRuntime_StartsScriptAndHostedPollers(t *testing.T) {
 	svc.StartPollersForRuntime(sidecarCtx, &sidecars, factoryCfg, loaded, submitted.submit)
 
 	waitForPollerSubmission(t, submitted, 2, 2*time.Second)
-	if submitted.calls < 2 {
-		t.Fatalf("submit calls = %d, want at least 2 (script + hosted)", submitted.calls)
+	calls, _ := submitted.snapshot()
+	if calls < 2 {
+		t.Fatalf("submit calls = %d, want at least 2 (script + hosted)", calls)
 	}
 }
 
@@ -259,12 +261,14 @@ func waitForPollerSubmission(t *testing.T, submitted *recordingSubmitter, want i
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		if submitted.calls >= want {
+		calls, _ := submitted.snapshot()
+		if calls >= want {
 			return
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatalf("timed out waiting for %d poller submission(s); got %d", want, submitted.calls)
+	calls, _ := submitted.snapshot()
+	t.Fatalf("timed out waiting for %d poller submission(s); got %d", want, calls)
 }
 
 func waitForObservedLogMessage(t *testing.T, observed *observer.ObservedLogs, message string, timeout time.Duration) {

--- a/pkg/workers/service/runtime_sidecars_test.go
+++ b/pkg/workers/service/runtime_sidecars_test.go
@@ -38,7 +38,7 @@ func TestStartSchedulerSidecarsForRuntime_AttachesCronAndScriptPollerSupervision
 			scriptWorker.Name: scriptWorker,
 		},
 		Workstations: map[string]*interfaces.FactoryWorkstationConfig{
-			cronWS.Name:      &cronWS,
+			cronWS.Name:       &cronWS,
 			scriptPoller.Name: &scriptPoller,
 		},
 	})
@@ -80,7 +80,8 @@ func TestStartSchedulerSidecarsForRuntime_AttachesCronAndScriptPollerSupervision
 
 	var cronRequest interfaces.WorkRequest
 	var foundCron bool
-	for _, request := range submitted.submissions {
+	_, submissions := submitted.snapshot()
+	for _, request := range submissions {
 		if len(request.Works) > 0 && request.Works[0].Tags[interfaces.TimeWorkTagKeyCronWorkstation] == cronWS.Name {
 			cronRequest = request
 			foundCron = true

--- a/pkg/workers/service/script_poller_test.go
+++ b/pkg/workers/service/script_poller_test.go
@@ -27,18 +27,27 @@ const (
 )
 
 type recordingSubmitter struct {
+	mu             sync.Mutex
 	calls          int
 	submissions    []interfaces.WorkRequest
 	submitOverride func(context.Context, interfaces.WorkRequest) error
 }
 
 func (r *recordingSubmitter) submit(ctx context.Context, request interfaces.WorkRequest) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.calls++
 	r.submissions = append(r.submissions, request)
 	if r.submitOverride != nil {
 		return r.submitOverride(ctx, request)
 	}
 	return nil
+}
+
+func (r *recordingSubmitter) snapshot() (int, []interfaces.WorkRequest) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls, append([]interfaces.WorkRequest(nil), r.submissions...)
 }
 
 func TestRunScriptPoller_SubmitsCanonicalWorkRequestStdout(t *testing.T) {
@@ -436,12 +445,14 @@ type pollerRunOutcome struct {
 }
 
 type pollerSequenceCommandRunner struct {
+	mu       sync.Mutex
 	calls    int
 	reqs     []workers.CommandRequest
 	outcomes []pollerRunOutcome
 }
 
 func (r *pollerSequenceCommandRunner) Run(ctx context.Context, req workers.CommandRequest) (workers.CommandResult, error) {
+	r.mu.Lock()
 	r.calls++
 	r.reqs = append(r.reqs, req)
 	index := r.calls - 1
@@ -451,6 +462,7 @@ func (r *pollerSequenceCommandRunner) Run(ctx context.Context, req workers.Comma
 	} else if len(r.outcomes) > 0 {
 		outcome = r.outcomes[len(r.outcomes)-1]
 	}
+	r.mu.Unlock()
 
 	if outcome.waitForCancel {
 		<-ctx.Done()
@@ -459,14 +471,20 @@ func (r *pollerSequenceCommandRunner) Run(ctx context.Context, req workers.Comma
 	return outcome.result, outcome.err
 }
 
+func (r *pollerSequenceCommandRunner) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
 func waitForPollerRunnerCalls(t *testing.T, runner *pollerSequenceCommandRunner, want int, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		if runner.calls >= want {
+		if runner.callCount() >= want {
 			return
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
-	t.Fatalf("timed out waiting for %d poller runner call(s); got %d", want, runner.calls)
+	t.Fatalf("timed out waiting for %d poller runner call(s); got %d", want, runner.callCount())
 }


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "runtime-cleanup-worker-sidecar-owner",
  "description": "Make pkg/workers/service the single owner that constructs and supervises script pollers, hosted pollers, and cron workstation sidecars, while initialized runtime coordinators provide every dependency explicitly and Factory Session lifecycle controls deterministic startup and shutdown.",
  "context": {
    "customerAsk": "Make pkg/workers/service own script pollers, hosted pollers, and cron workstation sidecars while initializer and Factory Session lifecycle decide when to start and stop them.",
    "problem": "Service and runtime-host poller watcher paths can construct workersservice.Service on demand, duplicating dependency assembly and blurring responsibility for construction, sidecar supervision, and session lifecycle. Hidden fallback construction also makes injected behavior and shutdown cleanup harder to verify.",
    "solution": "Initialize one workers service per runtime coordinator with explicit config, logger, clock, command runner, workflow identity, default factory directory, hosted client, secret resolver, and endpoint dependencies; delegate all scheduler-sidecar construction to it; and retain cancellation and join ownership in Factory Session lifecycle paths."
  },
  "acceptanceCriteria": [
    "Service and runtime-host poller watcher paths never instantiate workersservice.Service; they use the instance supplied during initialization.",
    "Every initialized workersservice.Service receives explicit config, logger, clock, command runner, workflow identity, default factory directory, hosted client, secret resolver, and hosted endpoint dependencies.",
    "In service mode, each live Factory Session starts its configured script pollers, hosted pollers, and cron workstation sidecars through pkg/workers/service; non-service runtimes do not start them.",
    "Stopping, replacing, or failing to start a Factory Session cancels its worker sidecars and waits for them to exit without leaving poller, cron, or hosted-worker activity behind.",
    "Missing required worker-service wiring fails explicitly during initialization or sidecar attachment rather than silently creating a default service with production fallbacks.",
    "Existing work-request submission, cron workflow identity, logging, restart, and hosted dependency behavior remains unchanged for configured sidecars.",
    "Typecheck, lint, and focused tests pass, including go test ./pkg/workers/service/... and go test ./pkg/service/... ./pkg/runtimehost/...."
  ],
  "userStories": [
    {
      "id": "runtime-cleanup-worker-sidecar-owner-001",
      "title": "Initialize one explicit worker-sidecar owner",
      "description": "As a runtime maintainer, I want host and service initialization to provide one fully configured workers service so that worker-side scheduling never depends on watcher-local defaults.",
      "acceptanceCriteria": [
        "Both supported runtime coordinators initialize and retain one workersservice.Service before any Factory Session can attach worker sidecars.",
        "Construction explicitly supplies config, logger, clock, command runner, workflow identity, default factory directory, hosted HTTP client, hosted secret resolver, and hosted endpoint values, including intentional default implementations chosen at the initializer boundary.",
        "A configured fake clock, command runner, hosted client, secret resolver, or endpoint reaches worker-side behavior unchanged in focused initialization tests.",
        "Missing required initialized ownership is reported as an actionable error and does not create an empty or fallback workersservice.Service from a poller watcher path.",
        "Existing CLI/API construction paths that share these coordinators retain equivalent dependency selection.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "runtime-cleanup-worker-sidecar-owner-002",
      "title": "Attach all scheduler sidecars through the initialized workers service",
      "description": "As a Factory Session operator, I want service-mode sessions to attach script, hosted, and cron sidecars through one worker-side owner so that each configured scheduler behaves consistently regardless of the runtime coordinator in use.",
      "acceptanceCriteria": [
        "Starting a service-mode Factory Session delegates configured script pollers, hosted pollers, and cron workstations to the initialized workersservice.Service using the session's factory config, runtime config, factory directory, submitter, context, and lifecycle wait group.",
        "The service and runtime-host poller watcher paths contain no workersservice.Service construction or dependency-defaulting behavior.",
        "A runtime outside service mode starts none of these scheduler sidecars.",
        "Script and hosted poller work requests and cron ticks continue to use the active session submitter and the same workflow identity rules as before.",
        "Sidecar start, stop, restart, and dependency failures retain actionable structured logging without exposing resolved secrets.",
        "Focused behavior tests cover script, hosted, and cron attachment through the worker service for both runtime coordinator surfaces without asserting a source-file inventory.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "runtime-cleanup-worker-sidecar-owner-003",
      "title": "Stop session-owned worker sidecars deterministically",
      "description": "As an operator, I want Factory Session lifecycle transitions to cancel and join worker sidecars so that stopped, replaced, or failed sessions cannot continue polling or emitting cron work.",
      "acceptanceCriteria": [
        "Stopping a live Factory Session cancels its script poller, hosted poller, and cron sidecars and does not return until the attached sidecars have exited.",
        "Replacing a Factory Session stops and joins the outgoing session's worker sidecars before they can submit work against the replacement session.",
        "If runtime or sidecar startup fails, every sidecar already attached to that session is canceled and joined before the failure is returned.",
        "Cancellation is treated as normal shutdown, while non-cancellation failures remain observable through the existing logging/error boundary.",
        "Focused lifecycle tests use controllable sidecars or injected dependencies to prove exit and absence of post-stop submissions without timing-only sleeps.",
        "Repeated start/stop coverage completes without leaked goroutines, duplicate pollers, or wait-group misuse; race verification is run where supported.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}
