### PR TITLE
runtime-cleanup-dashboard-sidecar-owner

### DIFF
--- a/cmd/factory/compose/cli_transport.go
+++ b/cmd/factory/compose/cli_transport.go
@@ -4,10 +4,25 @@ import (
 	"context"
 
 	"github.com/portpowered/infinite-you/pkg/initializer"
+	"github.com/portpowered/infinite-you/pkg/service"
 )
 
 // InjectCLITransport composes local CLI runtime dependencies through
 // pkg/initializer without using the wire FactoryService composition root.
 func InjectCLITransport(ctx context.Context, cfg *initializer.Config) (*initializer.CLITransport, error) {
 	return initializer.InitializeCLITransport(ctx, cfg)
+}
+
+// InjectCLIRunner transfers dashboard-enabled process composition to the
+// initializer. Dashboard-suppressed invocation paths retain their existing
+// service compatibility runner while that broader migration remains separate.
+func InjectCLIRunner(ctx context.Context, cfg *service.FactoryServiceConfig) (initializer.LocalRuntimeRunner, error) {
+	if cfg == nil || cfg.SimpleDashboardRenderer == nil {
+		return service.BuildFactoryService(ctx, cfg)
+	}
+	transport, err := initializer.InitializeCLITransport(ctx, service.RuntimeHostConfigFromFactoryService(cfg))
+	if err != nil {
+		return nil, err
+	}
+	return transport.Runner(), nil
 }

--- a/cmd/factory/compose/compose_test.go
+++ b/cmd/factory/compose/compose_test.go
@@ -13,8 +13,40 @@ import (
 	"github.com/portpowered/infinite-you/pkg/config/operatorconfig"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/service"
+	"github.com/portpowered/infinite-you/pkg/testutil/factoryfixtures"
 	"go.uber.org/zap"
 )
+
+func TestInjectCLIRunner_ComposesDashboardEnabledRunsOutsideFactoryService(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	factoryfixtures.WriteFactoryJSON(t, dir, factoryfixtures.MinimalFactoryConfig())
+	runner, err := compose.InjectCLIRunner(context.Background(), &service.FactoryServiceConfig{
+		Dir:                     dir,
+		SimpleDashboardRenderer: func(service.SimpleDashboardRenderInput) {},
+	})
+	if err != nil {
+		t.Fatalf("InjectCLIRunner: %v", err)
+	}
+	if _, legacy := runner.(*service.FactoryService); legacy {
+		t.Fatal("dashboard-enabled runner used legacy FactoryService composition")
+	}
+}
+
+func TestInjectCLIRunner_KeepsDashboardSuppressedRunsInactive(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	factoryfixtures.WriteFactoryJSON(t, dir, factoryfixtures.MinimalFactoryConfig())
+	runner, err := compose.InjectCLIRunner(context.Background(), &service.FactoryServiceConfig{Dir: dir})
+	if err != nil {
+		t.Fatalf("InjectCLIRunner: %v", err)
+	}
+	if _, legacy := runner.(*service.FactoryService); !legacy {
+		t.Fatalf("dashboard-suppressed runner type = %T, want compatibility service runner", runner)
+	}
+}
 
 func TestInjectFactoryService_RejectsMissingFactoryDir(t *testing.T) {
 	t.Parallel()

--- a/cmd/factory/main.go
+++ b/cmd/factory/main.go
@@ -2,14 +2,19 @@
 package main
 
 import (
+	"context"
+
 	"github.com/portpowered/infinite-you/cmd/factory/compose"
 	"github.com/portpowered/infinite-you/pkg/cli"
 	"github.com/portpowered/infinite-you/pkg/cli/run"
+	"github.com/portpowered/infinite-you/pkg/service"
 )
 
 var executeCLI = cli.Execute
 
 func main() {
-	run.SetBuildFactoryService(run.FactoryServiceBuilderFromService(compose.InjectFactoryService))
+	run.SetBuildFactoryService(func(ctx context.Context, cfg *service.FactoryServiceConfig) (run.RuntimeRunner, error) {
+		return compose.InjectCLIRunner(ctx, cfg)
+	})
 	executeCLI()
 }

--- a/cmd/factory/main.go
+++ b/cmd/factory/main.go
@@ -13,8 +13,10 @@ import (
 var executeCLI = cli.Execute
 
 func main() {
-	run.SetBuildFactoryService(func(ctx context.Context, cfg *service.FactoryServiceConfig) (run.RuntimeRunner, error) {
-		return compose.InjectCLIRunner(ctx, cfg)
-	})
+	run.SetBuildFactoryService(buildCLIRunner)
 	executeCLI()
+}
+
+func buildCLIRunner(ctx context.Context, cfg *service.FactoryServiceConfig) (run.RuntimeRunner, error) {
+	return compose.InjectCLIRunner(ctx, cfg)
 }

--- a/cmd/factory/main_test.go
+++ b/cmd/factory/main_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"context"
 	"os"
 	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/service"
+	"github.com/portpowered/infinite-you/pkg/testutil/factoryfixtures"
 )
 
 func TestMainExecutesCLI(t *testing.T) {
@@ -22,6 +26,20 @@ func TestMainExecutesCLI(t *testing.T) {
 
 	if !called {
 		t.Fatal("main() did not execute the CLI entrypoint")
+	}
+}
+
+func TestBuildCLIRunnerComposesConfiguredRuntime(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	factoryfixtures.WriteFactoryJSON(t, dir, factoryfixtures.MinimalFactoryConfig())
+	runner, err := buildCLIRunner(context.Background(), &service.FactoryServiceConfig{Dir: dir})
+	if err != nil {
+		t.Fatalf("buildCLIRunner() error = %v", err)
+	}
+	if runner == nil {
+		t.Fatal("buildCLIRunner() returned nil runner")
 	}
 }
 

--- a/pkg/initializer/cli_transport.go
+++ b/pkg/initializer/cli_transport.go
@@ -2,6 +2,12 @@ package initializer
 
 import (
 	"context"
+	"fmt"
+
+	"github.com/portpowered/infinite-you/pkg/factory"
+	initializerdashboard "github.com/portpowered/infinite-you/pkg/initializer/dashboard"
+	"github.com/portpowered/infinite-you/pkg/runtimehost"
+	"go.uber.org/zap"
 )
 
 // CLITransport bundles initializer-produced domain services with the session
@@ -15,11 +21,37 @@ type CLITransport struct {
 // InitializeCLITransport loads factory configuration, composes domain services,
 // and returns the transport bundle used by local in-process CLI startup.
 func InitializeCLITransport(ctx context.Context, cfg *Config) (*CLITransport, error) {
-	core, err := BuildCore(ctx, cfg)
+	if cfg == nil {
+		return nil, fmt.Errorf("initialize CLI transport: config is required")
+	}
+	hostCfg := *cfg
+	renderer := hostCfg.SimpleDashboardRenderer
+	hostCfg.SimpleDashboardRenderer = nil
+	core, err := BuildCore(ctx, &hostCfg)
 	if err != nil {
 		return nil, err
 	}
 	host := NewSessionRuntimeHostFromCore(core, cfg)
+	if renderer != nil {
+		sidecar, sidecarErr := initializerdashboard.NewDashboardSidecar(initializerdashboard.DashboardSidecarConfig{
+			Reader: initializerdashboard.NewRuntimeDashboardReader(host.host),
+			Renderer: initializerdashboard.DashboardRendererFunc(func(input initializerdashboard.DashboardRenderInput) {
+				renderer(runtimehost.SimpleDashboardRenderInput{EngineState: input.EngineState, RenderData: input.RenderData, Now: input.Now})
+			}),
+			Timing: initializerdashboard.ClockTiming{Clock: factory.EnsureClock(cfg.Clock)},
+			ReportError: func(err error) {
+				logger := cfg.Logger
+				if logger == nil {
+					logger = zap.NewNop()
+				}
+				logger.Error("simple dashboard render failed", zap.Error(err))
+			},
+		})
+		if sidecarErr != nil {
+			return nil, sidecarErr
+		}
+		host.dashboard = sidecar
+	}
 	return &CLITransport{
 		Services: servicesFromCoreWithModels(core, host.ModelService()),
 		Host:     host,
@@ -31,5 +63,5 @@ func (t *CLITransport) Runner() LocalRuntimeRunner {
 	if t == nil || t.Host == nil {
 		return nil
 	}
-	return t.Host.LocalRuntimeRunner()
+	return t.Host
 }

--- a/pkg/initializer/cli_transport_test.go
+++ b/pkg/initializer/cli_transport_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/portpowered/infinite-you/cmd/factory/compose"
 	"github.com/portpowered/infinite-you/pkg/initializer"
+	"github.com/portpowered/infinite-you/pkg/runtimehost"
 	"github.com/portpowered/infinite-you/pkg/service"
 	"github.com/portpowered/infinite-you/pkg/testutil/factoryfixtures"
 )
@@ -27,6 +28,23 @@ func TestInitializeCLITransport_RejectsMissingFactoryConfig(t *testing.T) {
 	}
 	if errService.Error() != errInit.Error() {
 		t.Fatalf("InitializeCLITransport error = %q, want %q", errInit, errService)
+	}
+}
+
+func TestInitializeCLITransportComposesConfiguredDashboard(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	factoryfixtures.WriteFactoryJSON(t, dir, factoryfixtures.MinimalFactoryConfig())
+	transport, err := initializer.InitializeCLITransport(context.Background(), &initializer.Config{
+		Dir:                     dir,
+		SimpleDashboardRenderer: func(runtimehost.SimpleDashboardRenderInput) {},
+	})
+	if err != nil {
+		t.Fatalf("InitializeCLITransport() error = %v", err)
+	}
+	if transport.Runner() == nil {
+		t.Fatal("InitializeCLITransport() returned no runtime runner")
 	}
 }
 

--- a/pkg/initializer/dashboard/adapters.go
+++ b/pkg/initializer/dashboard/adapters.go
@@ -1,0 +1,64 @@
+package dashboard
+
+import (
+	"context"
+	"time"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
+	"github.com/portpowered/infinite-you/pkg/cli/dashboardrender"
+	"github.com/portpowered/infinite-you/pkg/factory/projections"
+	"github.com/portpowered/infinite-you/pkg/factory/state"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/petri"
+)
+
+// RuntimeDashboardReads is the bounded read surface needed to project a
+// dashboard view from the active runtime.
+type RuntimeDashboardReads interface {
+	GetEngineStateSnapshot(context.Context) (*interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], error)
+	GetFactoryEvents(context.Context) ([]factoryapi.FactoryEvent, error)
+}
+
+// NewRuntimeDashboardReader adapts runtime reads without exposing mutation or
+// lifecycle operations to the dashboard sidecar.
+func NewRuntimeDashboardReader(reads RuntimeDashboardReads) DashboardReader {
+	return runtimeDashboardReader{reads: reads}
+}
+
+type runtimeDashboardReader struct {
+	reads RuntimeDashboardReads
+}
+
+func (r runtimeDashboardReader) ReadDashboard(ctx context.Context, now time.Time) (DashboardRenderInput, error) {
+	es, err := r.reads.GetEngineStateSnapshot(ctx)
+	if err != nil {
+		return DashboardRenderInput{}, err
+	}
+	events, err := r.reads.GetFactoryEvents(ctx)
+	if err != nil {
+		return DashboardRenderInput{}, err
+	}
+	worldState, err := projections.ReconstructFactoryWorldState(events, es.TickCount)
+	if err != nil {
+		return DashboardRenderInput{}, err
+	}
+	renderData := dashboardrender.SimpleDashboardRenderDataFromWorldState(worldState)
+	renderData.ActiveThrottlePauses = projections.ProjectActiveThrottlePauses(worldState.Topology, es.ActiveThrottlePauses)
+	return DashboardRenderInput{EngineState: *es, RenderData: renderData, Now: now}, nil
+}
+
+// DashboardRendererFunc adapts an existing render callback to the bounded
+// renderer dependency.
+type DashboardRendererFunc func(DashboardRenderInput)
+
+func (f DashboardRendererFunc) RenderDashboard(input DashboardRenderInput) { f(input) }
+
+// ClockTiming preserves the configured runtime clock while using real
+// cancellable tickers for process scheduling.
+type ClockTiming struct{ Clock interface{ Now() time.Time } }
+
+func (t ClockTiming) Now() time.Time { return t.Clock.Now() }
+
+func (ClockTiming) NewTicker(interval time.Duration) DashboardTicker {
+	return realDashboardTicker{Ticker: time.NewTicker(interval)}
+}

--- a/pkg/initializer/dashboard/adapters_test.go
+++ b/pkg/initializer/dashboard/adapters_test.go
@@ -1,0 +1,88 @@
+package dashboard
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
+	"github.com/portpowered/infinite-you/pkg/factory/state"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/petri"
+)
+
+func TestRuntimeDashboardReaderBuildsBoundedRenderInput(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.July, 10, 23, 0, 0, 0, time.UTC)
+	snapshot := &interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{TickCount: 7}
+	reader := NewRuntimeDashboardReader(fakeRuntimeDashboardReads{snapshot: snapshot})
+
+	input, err := reader.ReadDashboard(context.Background(), now)
+	if err != nil {
+		t.Fatalf("ReadDashboard() error = %v", err)
+	}
+	if input.EngineState.TickCount != 7 || input.RenderData.ActiveExecutionsByDispatchID == nil || !input.Now.Equal(now) {
+		t.Fatalf("ReadDashboard() input = %+v, want tick 7 at %s", input, now)
+	}
+}
+
+func TestRuntimeDashboardReaderPropagatesReadFailures(t *testing.T) {
+	t.Parallel()
+
+	snapshotFailure := errors.New("snapshot unavailable")
+	reader := NewRuntimeDashboardReader(fakeRuntimeDashboardReads{snapshotErr: snapshotFailure})
+	if _, err := reader.ReadDashboard(context.Background(), time.Time{}); !errors.Is(err, snapshotFailure) {
+		t.Fatalf("ReadDashboard() error = %v, want %v", err, snapshotFailure)
+	}
+
+	eventsFailure := errors.New("events unavailable")
+	reader = NewRuntimeDashboardReader(fakeRuntimeDashboardReads{
+		snapshot:  &interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]{},
+		eventsErr: eventsFailure,
+	})
+	if _, err := reader.ReadDashboard(context.Background(), time.Time{}); !errors.Is(err, eventsFailure) {
+		t.Fatalf("ReadDashboard() error = %v, want %v", err, eventsFailure)
+	}
+}
+
+func TestDashboardRendererFuncAndClockTimingAdaptDependencies(t *testing.T) {
+	t.Parallel()
+
+	want := DashboardRenderInput{Now: time.Date(2026, time.July, 10, 23, 1, 0, 0, time.UTC)}
+	var got DashboardRenderInput
+	DashboardRendererFunc(func(input DashboardRenderInput) { got = input }).RenderDashboard(want)
+	if got.Now != want.Now {
+		t.Fatalf("rendered time = %s, want %s", got.Now, want.Now)
+	}
+
+	timing := ClockTiming{Clock: fixedClock{now: want.Now}}
+	if now := timing.Now(); now != want.Now {
+		t.Fatalf("Now() = %s, want %s", now, want.Now)
+	}
+	ticker := timing.NewTicker(time.Hour)
+	if ticker == nil || ticker.C() == nil {
+		t.Fatal("NewTicker() returned unusable ticker")
+	}
+	ticker.Stop()
+}
+
+type fakeRuntimeDashboardReads struct {
+	snapshot    *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]
+	snapshotErr error
+	events      []factoryapi.FactoryEvent
+	eventsErr   error
+}
+
+func (f fakeRuntimeDashboardReads) GetEngineStateSnapshot(context.Context) (*interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], error) {
+	return f.snapshot, f.snapshotErr
+}
+
+func (f fakeRuntimeDashboardReads) GetFactoryEvents(context.Context) ([]factoryapi.FactoryEvent, error) {
+	return f.events, f.eventsErr
+}
+
+type fixedClock struct{ now time.Time }
+
+func (f fixedClock) Now() time.Time { return f.now }

--- a/pkg/initializer/dashboard/boundary_test.go
+++ b/pkg/initializer/dashboard/boundary_test.go
@@ -1,0 +1,57 @@
+package dashboard_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestDashboardPackageDoesNotDependOnBroadRuntimeCarriers(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.Command(
+		"go",
+		"list",
+		"-deps",
+		"-f",
+		"{{if not .Standard}}{{.ImportPath}}{{end}}",
+		"github.com/portpowered/infinite-you/pkg/initializer/dashboard",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list dashboard dependencies: %v\n%s", err, output)
+	}
+
+	for _, dependency := range strings.Fields(string(output)) {
+		for _, forbidden := range []string{
+			"github.com/portpowered/infinite-you/pkg/runtimehost",
+			"github.com/portpowered/infinite-you/pkg/service",
+		} {
+			if dependency == forbidden || strings.HasPrefix(dependency, forbidden+"/") {
+				t.Fatalf("bounded dashboard package must not depend on broad carrier %s; found %s", forbidden, dependency)
+			}
+		}
+	}
+}
+
+func TestRuntimeHostDoesNotDependOnProcessDashboard(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.Command(
+		"go",
+		"list",
+		"-f",
+		"{{join .Imports \"\\n\"}}",
+		"github.com/portpowered/infinite-you/pkg/runtimehost",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list runtimehost imports: %v\n%s", err, output)
+	}
+	const processDashboard = "github.com/portpowered/infinite-you/pkg/initializer/dashboard"
+	for _, dependency := range strings.Fields(string(output)) {
+		if dependency == processDashboard {
+			t.Fatalf("runtimehost must not construct or start the process dashboard; found dependency %s", dependency)
+		}
+	}
+}

--- a/pkg/initializer/dashboard/sidecar.go
+++ b/pkg/initializer/dashboard/sidecar.go
@@ -1,0 +1,146 @@
+// Package dashboard owns the bounded process-level simple dashboard sidecar.
+package dashboard
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/portpowered/infinite-you/pkg/cli/dashboardrender"
+	"github.com/portpowered/infinite-you/pkg/factory/state"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/petri"
+)
+
+const defaultDashboardRenderInterval = 30 * time.Second
+
+// DashboardRenderInput is the bounded snapshot passed to the process dashboard
+// renderer. It contains presentation data only and does not expose runtime
+// mutation or process-host operations.
+type DashboardRenderInput struct {
+	EngineState interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net]
+	RenderData  dashboardrender.SimpleDashboardRenderData
+	Now         time.Time
+}
+
+// DashboardReader supplies one consistent dashboard view from the active
+// runtime. Composition adapters should implement only this read operation.
+type DashboardReader interface {
+	ReadDashboard(context.Context, time.Time) (DashboardRenderInput, error)
+}
+
+// DashboardRenderer emits one dashboard view to the configured output.
+type DashboardRenderer interface {
+	RenderDashboard(DashboardRenderInput)
+}
+
+// DashboardTicker is the cancellable timing primitive used by the sidecar.
+type DashboardTicker interface {
+	C() <-chan time.Time
+	Stop()
+}
+
+// DashboardTiming supplies wall-clock reads and render ticks. Keeping timing
+// behind this narrow seam makes lifecycle tests deterministic.
+type DashboardTiming interface {
+	Now() time.Time
+	NewTicker(time.Duration) DashboardTicker
+}
+
+// DashboardSidecarConfig contains only process-dashboard dependencies.
+type DashboardSidecarConfig struct {
+	Reader         DashboardReader
+	Renderer       DashboardRenderer
+	Timing         DashboardTiming
+	RenderInterval time.Duration
+	Ready          func()
+	ReportError    func(error)
+}
+
+// DashboardSidecar owns the periodic rendering loop independently of the
+// runtime host. Construct it at the process-composition boundary.
+type DashboardSidecar struct {
+	reader         DashboardReader
+	renderer       DashboardRenderer
+	timing         DashboardTiming
+	renderInterval time.Duration
+	ready          func()
+	reportError    func(error)
+}
+
+// NewDashboardSidecar validates and constructs a bounded dashboard lifecycle
+// collaborator. Required inputs are rejected here instead of being recovered
+// lazily from a runtime host or service facade.
+func NewDashboardSidecar(cfg DashboardSidecarConfig) (*DashboardSidecar, error) {
+	if cfg.Reader == nil {
+		return nil, errors.New("initialize dashboard sidecar: dashboard reader is required")
+	}
+	if cfg.Renderer == nil {
+		return nil, errors.New("initialize dashboard sidecar: dashboard renderer is required")
+	}
+	if cfg.Timing == nil {
+		cfg.Timing = realDashboardTiming{}
+	}
+	if cfg.RenderInterval < 0 {
+		return nil, fmt.Errorf("initialize dashboard sidecar: render interval must not be negative: %s", cfg.RenderInterval)
+	}
+	if cfg.RenderInterval == 0 {
+		cfg.RenderInterval = defaultDashboardRenderInterval
+	}
+	return &DashboardSidecar{
+		reader:         cfg.Reader,
+		renderer:       cfg.Renderer,
+		timing:         cfg.Timing,
+		renderInterval: cfg.RenderInterval,
+		ready:          cfg.Ready,
+		reportError:    cfg.ReportError,
+	}, nil
+}
+
+// Run renders on each configured tick until the owning process context is
+// cancelled. Cancellation is normal shutdown.
+func (s *DashboardSidecar) Run(ctx context.Context) error {
+	if s == nil {
+		return errors.New("run dashboard sidecar: sidecar is nil")
+	}
+	ticker := s.timing.NewTicker(s.renderInterval)
+	if ticker == nil {
+		return errors.New("run dashboard sidecar: timing source returned a nil ticker")
+	}
+	defer ticker.Stop()
+	if s.ready != nil {
+		s.ready()
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C():
+			s.render(ctx)
+		}
+	}
+}
+
+func (s *DashboardSidecar) render(ctx context.Context) {
+	input, err := s.reader.ReadDashboard(ctx, s.timing.Now())
+	if err != nil {
+		if s.reportError != nil {
+			s.reportError(fmt.Errorf("simple dashboard render failed: %w", err))
+		}
+		return
+	}
+	s.renderer.RenderDashboard(input)
+}
+
+type realDashboardTiming struct{}
+
+func (realDashboardTiming) Now() time.Time { return time.Now() }
+
+func (realDashboardTiming) NewTicker(interval time.Duration) DashboardTicker {
+	return realDashboardTicker{Ticker: time.NewTicker(interval)}
+}
+
+type realDashboardTicker struct{ *time.Ticker }
+
+func (t realDashboardTicker) C() <-chan time.Time { return t.Ticker.C }

--- a/pkg/initializer/dashboard/sidecar.go
+++ b/pkg/initializer/dashboard/sidecar.go
@@ -122,6 +122,16 @@ func (s *DashboardSidecar) Run(ctx context.Context) error {
 	}
 }
 
+// RenderFinal emits the shutdown snapshot after the periodic loop has exited.
+// The process owner calls this synchronously so shutdown cannot return before
+// the final operator-visible dashboard output is complete.
+func (s *DashboardSidecar) RenderFinal(ctx context.Context) {
+	if s == nil {
+		return
+	}
+	s.render(ctx)
+}
+
 func (s *DashboardSidecar) render(ctx context.Context) {
 	input, err := s.reader.ReadDashboard(ctx, s.timing.Now())
 	if err != nil {

--- a/pkg/initializer/dashboard/sidecar_test.go
+++ b/pkg/initializer/dashboard/sidecar_test.go
@@ -1,0 +1,151 @@
+package dashboard
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNewDashboardSidecarRejectsMissingRequiredInputs(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewDashboardSidecar(DashboardSidecarConfig{})
+	if err == nil || !strings.Contains(err.Error(), "dashboard reader is required") {
+		t.Fatalf("NewDashboardSidecar() error = %v, want missing reader", err)
+	}
+
+	_, err = NewDashboardSidecar(DashboardSidecarConfig{Reader: dashboardReaderFunc(func(context.Context, time.Time) (DashboardRenderInput, error) {
+		return DashboardRenderInput{}, nil
+	})})
+	if err == nil || !strings.Contains(err.Error(), "dashboard renderer is required") {
+		t.Fatalf("NewDashboardSidecar() error = %v, want missing renderer", err)
+	}
+}
+
+func TestDashboardSidecarReportsReadinessRendersAndObservesCancellation(t *testing.T) {
+	t.Parallel()
+
+	tick := make(chan time.Time)
+	ticker := &fakeDashboardTicker{ticks: tick, stopped: make(chan struct{})}
+	now := time.Date(2026, time.July, 10, 20, 0, 0, 0, time.UTC)
+	read := make(chan time.Time, 1)
+	rendered := make(chan DashboardRenderInput, 1)
+	ready := make(chan struct{})
+	timing := &fakeDashboardTiming{now: now, ticker: ticker}
+	sidecar, err := NewDashboardSidecar(DashboardSidecarConfig{
+		Reader: dashboardReaderFunc(func(_ context.Context, got time.Time) (DashboardRenderInput, error) {
+			read <- got
+			return DashboardRenderInput{Now: got}, nil
+		}),
+		Renderer: dashboardRendererFunc(func(input DashboardRenderInput) { rendered <- input }),
+		Timing:   timing,
+		Ready:    func() { close(ready) },
+	})
+	if err != nil {
+		t.Fatalf("NewDashboardSidecar() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	exited := make(chan error, 1)
+	go func() { exited <- sidecar.Run(ctx) }()
+
+	<-ready
+	if timing.interval != defaultDashboardRenderInterval {
+		t.Fatalf("ticker interval = %s, want %s", timing.interval, defaultDashboardRenderInterval)
+	}
+	tick <- now
+	if got := <-read; !got.Equal(now) {
+		t.Fatalf("reader time = %s, want %s", got, now)
+	}
+	if got := <-rendered; !got.Now.Equal(now) {
+		t.Fatalf("render input time = %s, want %s", got.Now, now)
+	}
+
+	cancel()
+	if err := <-exited; err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	<-ticker.stopped
+}
+
+func TestDashboardSidecarReportsReadFailureAndContinues(t *testing.T) {
+	t.Parallel()
+
+	tick := make(chan time.Time)
+	reported := make(chan error, 1)
+	rendered := make(chan struct{}, 1)
+	ready := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sidecar, err := NewDashboardSidecar(DashboardSidecarConfig{
+		Reader: dashboardReaderFunc(func(context.Context, time.Time) (DashboardRenderInput, error) {
+			return DashboardRenderInput{}, errors.New("snapshot unavailable")
+		}),
+		Renderer: dashboardRendererFunc(func(DashboardRenderInput) { rendered <- struct{}{} }),
+		Timing: &fakeDashboardTiming{
+			now:    time.Now(),
+			ticker: &fakeDashboardTicker{ticks: tick, stopped: make(chan struct{})},
+		},
+		Ready:       func() { close(ready) },
+		ReportError: func(err error) { reported <- err },
+	})
+	if err != nil {
+		t.Fatalf("NewDashboardSidecar() error = %v", err)
+	}
+	exited := make(chan error, 1)
+	go func() { exited <- sidecar.Run(ctx) }()
+	<-ready
+	tick <- time.Now()
+	if got := <-reported; !strings.Contains(got.Error(), "snapshot unavailable") {
+		t.Fatalf("reported error = %v", got)
+	}
+	select {
+	case <-rendered:
+		t.Fatal("renderer called after read failure")
+	default:
+	}
+	cancel()
+	if err := <-exited; err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+}
+
+type dashboardReaderFunc func(context.Context, time.Time) (DashboardRenderInput, error)
+
+func (f dashboardReaderFunc) ReadDashboard(ctx context.Context, now time.Time) (DashboardRenderInput, error) {
+	return f(ctx, now)
+}
+
+type dashboardRendererFunc func(DashboardRenderInput)
+
+func (f dashboardRendererFunc) RenderDashboard(input DashboardRenderInput) { f(input) }
+
+type fakeDashboardTiming struct {
+	now      time.Time
+	ticker   DashboardTicker
+	mu       sync.Mutex
+	interval time.Duration
+}
+
+func (f *fakeDashboardTiming) Now() time.Time { return f.now }
+
+func (f *fakeDashboardTiming) NewTicker(interval time.Duration) DashboardTicker {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.interval = interval
+	return f.ticker
+}
+
+type fakeDashboardTicker struct {
+	ticks   <-chan time.Time
+	stop    sync.Once
+	stopped chan struct{}
+}
+
+func (f *fakeDashboardTicker) C() <-chan time.Time { return f.ticks }
+func (f *fakeDashboardTicker) Stop() {
+	f.stop.Do(func() { close(f.stopped) })
+}

--- a/pkg/initializer/dashboard/sidecar_test.go
+++ b/pkg/initializer/dashboard/sidecar_test.go
@@ -23,6 +23,36 @@ func TestNewDashboardSidecarRejectsMissingRequiredInputs(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "dashboard renderer is required") {
 		t.Fatalf("NewDashboardSidecar() error = %v, want missing renderer", err)
 	}
+
+	_, err = NewDashboardSidecar(DashboardSidecarConfig{
+		Reader:         dashboardReaderFunc(func(context.Context, time.Time) (DashboardRenderInput, error) { return DashboardRenderInput{}, nil }),
+		Renderer:       dashboardRendererFunc(func(DashboardRenderInput) {}),
+		RenderInterval: -time.Second,
+	})
+	if err == nil || !strings.Contains(err.Error(), "render interval must not be negative") {
+		t.Fatalf("NewDashboardSidecar() error = %v, want invalid interval", err)
+	}
+}
+
+func TestDashboardSidecarRejectsInvalidRuntimeState(t *testing.T) {
+	t.Parallel()
+
+	var sidecar *DashboardSidecar
+	if err := sidecar.Run(context.Background()); err == nil || !strings.Contains(err.Error(), "sidecar is nil") {
+		t.Fatalf("Run() error = %v, want nil sidecar", err)
+	}
+
+	sidecar, err := NewDashboardSidecar(DashboardSidecarConfig{
+		Reader:   dashboardReaderFunc(func(context.Context, time.Time) (DashboardRenderInput, error) { return DashboardRenderInput{}, nil }),
+		Renderer: dashboardRendererFunc(func(DashboardRenderInput) {}),
+		Timing:   &fakeDashboardTiming{},
+	})
+	if err != nil {
+		t.Fatalf("NewDashboardSidecar() error = %v", err)
+	}
+	if err := sidecar.Run(context.Background()); err == nil || !strings.Contains(err.Error(), "nil ticker") {
+		t.Fatalf("Run() error = %v, want nil ticker", err)
+	}
 }
 
 func TestDashboardSidecarReportsReadinessRendersAndObservesCancellation(t *testing.T) {

--- a/pkg/initializer/runtime_host.go
+++ b/pkg/initializer/runtime_host.go
@@ -2,8 +2,10 @@ package initializer
 
 import (
 	"context"
+	"errors"
 
 	"github.com/portpowered/infinite-you/pkg/apisurface"
+	initializerdashboard "github.com/portpowered/infinite-you/pkg/initializer/dashboard"
 	"github.com/portpowered/infinite-you/pkg/runtimehost"
 )
 
@@ -16,7 +18,8 @@ type LocalRuntimeRunner interface {
 // SessionRuntimeHost is the transport-facing session/runtime shell composed from
 // a Core without exposing root FactoryService at transport boundaries.
 type SessionRuntimeHost struct {
-	host *runtimehost.Host
+	host      *runtimehost.Host
+	dashboard *initializerdashboard.DashboardSidecar
 }
 
 // NewSessionRuntimeHostFromCore composes the API/CLI session runtime host from a
@@ -78,7 +81,37 @@ func (h *SessionRuntimeHost) Run(ctx context.Context) error {
 	if h == nil || h.host == nil {
 		return nil
 	}
-	return h.host.Run(ctx)
+	return h.runWithDashboard(ctx, h.host.Run)
+}
+
+func (h *SessionRuntimeHost) runWithDashboard(ctx context.Context, runHost func(context.Context) error) error {
+	if h.dashboard == nil {
+		return runHost(ctx)
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	dashboardErr := make(chan error, 1)
+	hostErr := make(chan error, 1)
+	go func() { dashboardErr <- h.dashboard.Run(runCtx) }()
+	go func() { hostErr <- runHost(runCtx) }()
+	select {
+	case err := <-hostErr:
+		cancel()
+		sidecarErr := <-dashboardErr
+		if err != nil {
+			return err
+		}
+		if sidecarErr != nil && !errors.Is(sidecarErr, context.Canceled) {
+			return sidecarErr
+		}
+		return nil
+	case err := <-dashboardErr:
+		cancel()
+		runtimeErr := <-hostErr
+		if err != nil && !errors.Is(err, context.Canceled) {
+			return err
+		}
+		return runtimeErr
+	}
 }
 
 // RunWithAPISurface starts lifecycle-owned runtime work while providing the

--- a/pkg/initializer/runtime_host.go
+++ b/pkg/initializer/runtime_host.go
@@ -97,6 +97,7 @@ func (h *SessionRuntimeHost) runWithDashboard(ctx context.Context, runHost func(
 	case err := <-hostErr:
 		cancel()
 		sidecarErr := <-dashboardErr
+		h.dashboard.RenderFinal(ctx)
 		if err != nil {
 			return err
 		}

--- a/pkg/initializer/runtime_host.go
+++ b/pkg/initializer/runtime_host.go
@@ -93,26 +93,31 @@ func (h *SessionRuntimeHost) runWithDashboard(ctx context.Context, runHost func(
 	hostErr := make(chan error, 1)
 	go func() { dashboardErr <- h.dashboard.Run(runCtx) }()
 	go func() { hostErr <- runHost(runCtx) }()
+	var runtimeErr, sidecarErr error
+	renderFinal := false
 	select {
-	case err := <-hostErr:
+	case runtimeErr = <-hostErr:
+		renderFinal = true
 		cancel()
-		sidecarErr := <-dashboardErr
+		sidecarErr = <-dashboardErr
+	case sidecarErr = <-dashboardErr:
+		// A sidecar exit caused by the owning context is normal process
+		// shutdown. Preserve the final snapshot after both collaborators join,
+		// regardless of which cancellation observer exits first.
+		renderFinal = ctx.Err() != nil
+		cancel()
+		runtimeErr = <-hostErr
+	}
+	if renderFinal {
 		h.dashboard.RenderFinal(ctx)
-		if err != nil {
-			return err
-		}
-		if sidecarErr != nil && !errors.Is(sidecarErr, context.Canceled) {
-			return sidecarErr
-		}
-		return nil
-	case err := <-dashboardErr:
-		cancel()
-		runtimeErr := <-hostErr
-		if err != nil && !errors.Is(err, context.Canceled) {
-			return err
-		}
+	}
+	if runtimeErr != nil {
 		return runtimeErr
 	}
+	if sidecarErr != nil && !errors.Is(sidecarErr, context.Canceled) {
+		return sidecarErr
+	}
+	return nil
 }
 
 // RunWithAPISurface starts lifecycle-owned runtime work while providing the

--- a/pkg/initializer/runtime_host_internal_test.go
+++ b/pkg/initializer/runtime_host_internal_test.go
@@ -3,6 +3,7 @@ package initializer
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -33,6 +34,60 @@ func TestSessionRuntimeHostPropagatesDashboardStartupFailureAndCancelsRuntime(t 
 	<-runtimeCanceled
 }
 
+func TestSessionRuntimeHostCancelsAndJoinsDashboardBeforeReturning(t *testing.T) {
+	t.Parallel()
+
+	ticks := make(chan time.Time)
+	timing := &lifecycleDashboardTiming{
+		started: make(chan struct{}),
+		ticker:  &lifecycleDashboardTicker{ticks: ticks, stopped: make(chan struct{})},
+	}
+	renderStarted := make(chan struct{})
+	releaseRender := make(chan struct{})
+	sidecar, err := initializerdashboard.NewDashboardSidecar(initializerdashboard.DashboardSidecarConfig{
+		Reader: testDashboardReader{},
+		Renderer: blockingDashboardRenderer{
+			started: renderStarted,
+			release: releaseRender,
+		},
+		Timing: timing,
+	})
+	if err != nil {
+		t.Fatalf("NewDashboardSidecar: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runtimeCanceled := make(chan struct{})
+	runReturned := make(chan error, 1)
+	host := &SessionRuntimeHost{dashboard: sidecar}
+	go func() {
+		runReturned <- host.runWithDashboard(ctx, func(ctx context.Context) error {
+			<-ctx.Done()
+			close(runtimeCanceled)
+			return nil
+		})
+	}()
+
+	<-timing.started
+	ticks <- time.Now()
+	<-renderStarted
+	cancel()
+	<-runtimeCanceled
+	select {
+	case err := <-runReturned:
+		t.Fatalf("runWithDashboard returned before dashboard exit: %v", err)
+	default:
+	}
+	close(releaseRender)
+	if err := <-runReturned; err != nil {
+		t.Fatalf("runWithDashboard: %v", err)
+	}
+	<-timing.ticker.stopped
+	if got := timing.startCount(); got != 1 {
+		t.Fatalf("dashboard start count = %d, want 1", got)
+	}
+}
+
 type testDashboardReader struct{}
 
 func (testDashboardReader) ReadDashboard(context.Context, time.Time) (initializerdashboard.DashboardRenderInput, error) {
@@ -48,3 +103,48 @@ type nilTickerTiming struct{}
 func (nilTickerTiming) Now() time.Time { return time.Time{} }
 
 func (nilTickerTiming) NewTicker(time.Duration) initializerdashboard.DashboardTicker { return nil }
+
+type blockingDashboardRenderer struct {
+	started chan<- struct{}
+	release <-chan struct{}
+}
+
+func (r blockingDashboardRenderer) RenderDashboard(initializerdashboard.DashboardRenderInput) {
+	close(r.started)
+	<-r.release
+}
+
+type lifecycleDashboardTiming struct {
+	mu      sync.Mutex
+	starts  int
+	started chan struct{}
+	ticker  *lifecycleDashboardTicker
+}
+
+func (t *lifecycleDashboardTiming) Now() time.Time { return time.Now() }
+
+func (t *lifecycleDashboardTiming) NewTicker(time.Duration) initializerdashboard.DashboardTicker {
+	t.mu.Lock()
+	t.starts++
+	close(t.started)
+	t.mu.Unlock()
+	return t.ticker
+}
+
+func (t *lifecycleDashboardTiming) startCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.starts
+}
+
+type lifecycleDashboardTicker struct {
+	ticks   <-chan time.Time
+	stop    sync.Once
+	stopped chan struct{}
+}
+
+func (t *lifecycleDashboardTicker) C() <-chan time.Time { return t.ticks }
+
+func (t *lifecycleDashboardTicker) Stop() {
+	t.stop.Do(func() { close(t.stopped) })
+}

--- a/pkg/initializer/runtime_host_internal_test.go
+++ b/pkg/initializer/runtime_host_internal_test.go
@@ -1,0 +1,50 @@
+package initializer
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	initializerdashboard "github.com/portpowered/infinite-you/pkg/initializer/dashboard"
+)
+
+func TestSessionRuntimeHostPropagatesDashboardStartupFailureAndCancelsRuntime(t *testing.T) {
+	t.Parallel()
+
+	sidecar, err := initializerdashboard.NewDashboardSidecar(initializerdashboard.DashboardSidecarConfig{
+		Reader:   testDashboardReader{},
+		Renderer: testDashboardRenderer{},
+		Timing:   nilTickerTiming{},
+	})
+	if err != nil {
+		t.Fatalf("NewDashboardSidecar: %v", err)
+	}
+	runtimeCanceled := make(chan struct{})
+	host := &SessionRuntimeHost{dashboard: sidecar}
+	err = host.runWithDashboard(context.Background(), func(ctx context.Context) error {
+		<-ctx.Done()
+		close(runtimeCanceled)
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "nil ticker") {
+		t.Fatalf("runWithDashboard() error = %v, want dashboard startup failure", err)
+	}
+	<-runtimeCanceled
+}
+
+type testDashboardReader struct{}
+
+func (testDashboardReader) ReadDashboard(context.Context, time.Time) (initializerdashboard.DashboardRenderInput, error) {
+	return initializerdashboard.DashboardRenderInput{}, nil
+}
+
+type testDashboardRenderer struct{}
+
+func (testDashboardRenderer) RenderDashboard(initializerdashboard.DashboardRenderInput) {}
+
+type nilTickerTiming struct{}
+
+func (nilTickerTiming) Now() time.Time { return time.Time{} }
+
+func (nilTickerTiming) NewTicker(time.Duration) initializerdashboard.DashboardTicker { return nil }

--- a/pkg/initializer/runtime_host_internal_test.go
+++ b/pkg/initializer/runtime_host_internal_test.go
@@ -46,7 +46,7 @@ func TestSessionRuntimeHostCancelsAndJoinsDashboardBeforeReturning(t *testing.T)
 	releaseRender := make(chan struct{})
 	sidecar, err := initializerdashboard.NewDashboardSidecar(initializerdashboard.DashboardSidecarConfig{
 		Reader: testDashboardReader{},
-		Renderer: blockingDashboardRenderer{
+		Renderer: &blockingDashboardRenderer{
 			started: renderStarted,
 			release: releaseRender,
 		},
@@ -88,6 +88,59 @@ func TestSessionRuntimeHostCancelsAndJoinsDashboardBeforeReturning(t *testing.T)
 	}
 }
 
+func TestSessionRuntimeHostRendersFinalDashboardAfterJoiningPeriodicLoop(t *testing.T) {
+	t.Parallel()
+
+	ready := make(chan struct{})
+	tickerStopped := make(chan struct{})
+	finalRenderStarted := make(chan struct{})
+	releaseFinalRender := make(chan struct{})
+	timing := &lifecycleDashboardTiming{
+		started: make(chan struct{}),
+		ticker: &lifecycleDashboardTicker{
+			ticks:   make(chan time.Time),
+			stopped: tickerStopped,
+		},
+	}
+	sidecar, err := initializerdashboard.NewDashboardSidecar(initializerdashboard.DashboardSidecarConfig{
+		Reader: testDashboardReader{},
+		Renderer: &blockingDashboardRenderer{
+			started: finalRenderStarted,
+			release: releaseFinalRender,
+		},
+		Timing: timing,
+		Ready:  func() { close(ready) },
+	})
+	if err != nil {
+		t.Fatalf("NewDashboardSidecar: %v", err)
+	}
+
+	runReturned := make(chan error, 1)
+	host := &SessionRuntimeHost{dashboard: sidecar}
+	go func() {
+		runReturned <- host.runWithDashboard(context.Background(), func(context.Context) error {
+			<-ready
+			return nil
+		})
+	}()
+
+	<-finalRenderStarted
+	select {
+	case <-tickerStopped:
+	default:
+		t.Fatal("final dashboard render started before periodic loop was joined")
+	}
+	select {
+	case err := <-runReturned:
+		t.Fatalf("runWithDashboard returned before final render completed: %v", err)
+	default:
+	}
+	close(releaseFinalRender)
+	if err := <-runReturned; err != nil {
+		t.Fatalf("runWithDashboard: %v", err)
+	}
+}
+
 type testDashboardReader struct{}
 
 func (testDashboardReader) ReadDashboard(context.Context, time.Time) (initializerdashboard.DashboardRenderInput, error) {
@@ -107,11 +160,14 @@ func (nilTickerTiming) NewTicker(time.Duration) initializerdashboard.DashboardTi
 type blockingDashboardRenderer struct {
 	started chan<- struct{}
 	release <-chan struct{}
+	once    sync.Once
 }
 
-func (r blockingDashboardRenderer) RenderDashboard(initializerdashboard.DashboardRenderInput) {
-	close(r.started)
-	<-r.release
+func (r *blockingDashboardRenderer) RenderDashboard(initializerdashboard.DashboardRenderInput) {
+	r.once.Do(func() {
+		close(r.started)
+		<-r.release
+	})
 }
 
 type lifecycleDashboardTiming struct {

--- a/pkg/initializer/runtime_host_internal_test.go
+++ b/pkg/initializer/runtime_host_internal_test.go
@@ -141,6 +141,76 @@ func TestSessionRuntimeHostRendersFinalDashboardAfterJoiningPeriodicLoop(t *test
 	}
 }
 
+func TestSessionRuntimeHostRendersFinalDashboardAfterDashboardExitsFirst(t *testing.T) {
+	t.Parallel()
+
+	ready := make(chan struct{})
+	tickerStopped := make(chan struct{})
+	hostCanceled := make(chan struct{})
+	releaseHost := make(chan struct{})
+	hostExited := make(chan struct{})
+	finalRenderStarted := make(chan struct{})
+	releaseFinalRender := make(chan struct{})
+	timing := &lifecycleDashboardTiming{
+		started: make(chan struct{}),
+		ticker: &lifecycleDashboardTicker{
+			ticks:   make(chan time.Time),
+			stopped: tickerStopped,
+		},
+	}
+	renderer := &countingBlockingDashboardRenderer{
+		started: finalRenderStarted,
+		release: releaseFinalRender,
+	}
+	sidecar, err := initializerdashboard.NewDashboardSidecar(initializerdashboard.DashboardSidecarConfig{
+		Reader:   testDashboardReader{},
+		Renderer: renderer,
+		Timing:   timing,
+		Ready:    func() { close(ready) },
+	})
+	if err != nil {
+		t.Fatalf("NewDashboardSidecar: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runReturned := make(chan error, 1)
+	host := &SessionRuntimeHost{dashboard: sidecar}
+	go func() {
+		runReturned <- host.runWithDashboard(ctx, func(ctx context.Context) error {
+			<-ctx.Done()
+			close(hostCanceled)
+			<-releaseHost
+			close(hostExited)
+			return nil
+		})
+	}()
+
+	<-ready
+	cancel()
+	<-tickerStopped
+	<-hostCanceled
+	select {
+	case <-finalRenderStarted:
+		t.Fatal("final dashboard render started before runtime host joined")
+	default:
+	}
+	close(releaseHost)
+	<-hostExited
+	<-finalRenderStarted
+	if got := renderer.renderCount(); got != 1 {
+		t.Fatalf("dashboard render count = %d, want exactly one final render", got)
+	}
+	select {
+	case err := <-runReturned:
+		t.Fatalf("runWithDashboard returned before final render completed: %v", err)
+	default:
+	}
+	close(releaseFinalRender)
+	if err := <-runReturned; err != nil {
+		t.Fatalf("runWithDashboard: %v", err)
+	}
+}
+
 type testDashboardReader struct{}
 
 func (testDashboardReader) ReadDashboard(context.Context, time.Time) (initializerdashboard.DashboardRenderInput, error) {
@@ -161,6 +231,27 @@ type blockingDashboardRenderer struct {
 	started chan<- struct{}
 	release <-chan struct{}
 	once    sync.Once
+}
+
+type countingBlockingDashboardRenderer struct {
+	mu      sync.Mutex
+	renders int
+	started chan<- struct{}
+	release <-chan struct{}
+}
+
+func (r *countingBlockingDashboardRenderer) RenderDashboard(initializerdashboard.DashboardRenderInput) {
+	r.mu.Lock()
+	r.renders++
+	r.mu.Unlock()
+	close(r.started)
+	<-r.release
+}
+
+func (r *countingBlockingDashboardRenderer) renderCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.renders
 }
 
 func (r *blockingDashboardRenderer) RenderDashboard(initializerdashboard.DashboardRenderInput) {

--- a/pkg/runtimehost/host.go
+++ b/pkg/runtimehost/host.go
@@ -472,6 +472,7 @@ func (fs *Host) RunWithAPISurface(ctx context.Context, surface apisurface.APISur
 }
 
 func (fs *Host) run(ctx context.Context, surface apisurface.APISurface) error {
+	fs.startTime = fs.clock.Now()
 	runCtx, cancelRunSidecars := context.WithCancel(ctx)
 	var sidecars sync.WaitGroup
 	var currentRuntime *liveRuntimeHandle
@@ -512,11 +513,6 @@ func (fs *Host) run(ctx context.Context, surface apisurface.APISurface) error {
 	fs.clearRunState()
 	cancelRunSidecars()
 	sidecars.Wait()
-	// Print final dashboard.
-	if fs.cfg.SimpleDashboardRenderer != nil {
-		fs.renderDashboard(ctx)
-	}
-
 	if err != nil && !errors.Is(err, context.Canceled) {
 		return fmt.Errorf("factory run: %w", err)
 	}
@@ -553,7 +549,6 @@ func (fs *Host) startRunSidecars(runCtx context.Context, sidecars *sync.WaitGrou
 		}
 		fs.startListenerSidecar(runCtx, sidecars, listener, fs.logger)
 	}
-	fs.startDashboardSidecar(runCtx, sidecars)
 }
 
 func (fs *Host) startListenerSidecar(
@@ -571,18 +566,6 @@ func (fs *Host) startListenerSidecar(
 		if err := listener.Watch(runCtx); err != nil && !errors.Is(err, context.Canceled) {
 			logger.Error("file watcher error", zap.Error(err))
 		}
-	}()
-}
-
-func (fs *Host) startDashboardSidecar(runCtx context.Context, sidecars *sync.WaitGroup) {
-	fs.startTime = fs.clock.Now()
-	if fs.cfg.SimpleDashboardRenderer == nil {
-		return
-	}
-	sidecars.Add(1)
-	go func() {
-		defer sidecars.Done()
-		fs.dashboardLoop(runCtx)
 	}()
 }
 

--- a/pkg/runtimehost/host.go
+++ b/pkg/runtimehost/host.go
@@ -458,7 +458,8 @@ func (fs *Host) replacementExecutionBaseDir(folderPath string, factoryDir string
 	return ""
 }
 
-// Run starts the file watcher, dashboard, API server, and factory engine.
+// Run starts runtime-owned sidecars and the factory engine. Process-level
+// presentation sidecars are composed and owned outside Host.
 // It blocks until ctx is cancelled or the factory reaches a terminal state.
 // portos:func-length-exception owner=agent-factory reason=legacy-service-run-loop review=2026-07-18 removal=split-sidecar-startup-recording-and-engine-shutdown-before-next-service-run-change
 func (fs *Host) Run(ctx context.Context) error {

--- a/pkg/runtimehost/session_state.go
+++ b/pkg/runtimehost/session_state.go
@@ -7,16 +7,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/portpowered/infinite-you/pkg/cli/dashboardrender"
 	factoryconfig "github.com/portpowered/infinite-you/pkg/config"
-	"github.com/portpowered/infinite-you/pkg/factory"
-	"github.com/portpowered/infinite-you/pkg/factory/projections"
 	"github.com/portpowered/infinite-you/pkg/factorysessions"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/logging"
 	"github.com/portpowered/infinite-you/pkg/service/runtimebuild"
 	"github.com/portpowered/infinite-you/pkg/workers"
-	"go.uber.org/zap"
 )
 
 // LiveSessionState tracks per-session runtime state attached to live session handles.
@@ -127,52 +123,6 @@ func CoordinatorPolicyFromConfig(cfg *Config) hostCoordinatorPolicy {
 		providerCommandRunnerOverride: cfg.ProviderCommandRunnerOverride,
 		commandRunnerOverride:         cfg.CommandRunnerOverride,
 	}
-}
-
-func (h *Host) renderDashboard(ctx context.Context) {
-	now := factory.EnsureClock(h.clock).Now()
-	input, err := h.buildSimpleDashboardRenderInput(ctx, now)
-	if err != nil {
-		if h.logger != nil {
-			h.logger.Error("simple dashboard render failed", zap.Error(err))
-		}
-		return
-	}
-	h.cfg.SimpleDashboardRenderer(input)
-}
-
-func (h *Host) buildSimpleDashboardRenderInput(ctx context.Context, now time.Time) (SimpleDashboardRenderInput, error) {
-	es, err := h.GetEngineStateSnapshot(ctx)
-	if err != nil {
-		return SimpleDashboardRenderInput{}, err
-	}
-	renderData, err := h.simpleDashboardRenderData(ctx, es.TickCount, es.ActiveThrottlePauses)
-	if err != nil {
-		return SimpleDashboardRenderInput{}, err
-	}
-	return SimpleDashboardRenderInput{
-		EngineState: *es,
-		RenderData:  renderData,
-		Now:         now,
-	}, nil
-}
-
-func (h *Host) simpleDashboardRenderData(
-	ctx context.Context,
-	selectedTick int,
-	activeThrottlePauses []interfaces.ActiveThrottlePause,
-) (dashboardrender.SimpleDashboardRenderData, error) {
-	events, err := h.GetFactoryEvents(ctx)
-	if err != nil {
-		return dashboardrender.SimpleDashboardRenderData{}, err
-	}
-	worldState, err := projections.ReconstructFactoryWorldState(events, selectedTick)
-	if err != nil {
-		return dashboardrender.SimpleDashboardRenderData{}, err
-	}
-	renderData := dashboardrender.SimpleDashboardRenderDataFromWorldState(worldState)
-	renderData.ActiveThrottlePauses = projections.ProjectActiveThrottlePauses(worldState.Topology, activeThrottlePauses)
-	return renderData, nil
 }
 
 // RuntimeLogDiagnostics describes the active runtime log selected during host construction.

--- a/pkg/runtimehost/session_state.go
+++ b/pkg/runtimehost/session_state.go
@@ -129,20 +129,6 @@ func CoordinatorPolicyFromConfig(cfg *Config) hostCoordinatorPolicy {
 	}
 }
 
-func (h *Host) dashboardLoop(ctx context.Context) {
-	ticker := time.NewTicker(30 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			h.renderDashboard(ctx)
-		}
-	}
-}
-
 func (h *Host) renderDashboard(ctx context.Context) {
 	now := factory.EnsureClock(h.clock).Now()
 	input, err := h.buildSimpleDashboardRenderInput(ctx, now)

--- a/pkg/service/factory_build.go
+++ b/pkg/service/factory_build.go
@@ -1306,6 +1306,16 @@ func FactoryServiceConfigFromRuntimeHost(cfg *runtimehost.Config) *FactoryServic
 	return (*FactoryServiceConfig)(unsafe.Pointer(cfg))
 }
 
+// RuntimeHostConfigFromFactoryService maps the legacy CLI composition config
+// onto initializer-owned runtime composition while both migration structs are
+// kept layout-compatible.
+func RuntimeHostConfigFromFactoryService(cfg *FactoryServiceConfig) *runtimehost.Config {
+	if cfg == nil {
+		return nil
+	}
+	return (*runtimehost.Config)(unsafe.Pointer(cfg))
+}
+
 // EnsureBackendScopeForCompose resolves backend scope before core composition.
 func EnsureBackendScopeForCompose(cfg *runtimehost.Config, logger *zap.Logger) error {
 	return ensureServiceBackendScope(FactoryServiceConfigFromRuntimeHost(cfg), logger)


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "runtime-cleanup-dashboard-sidecar-owner",
  "description": "Move dashboard rendering into an explicitly composed process sidecar that uses bounded read and configuration dependencies, preserves existing availability and mode behavior, and has startup, cancellation, and joining owned outside runtimehost.Host.",
  "context": {
    "customerAsk": "Make dashboard rendering an explicitly composed initializer or CLI process sidecar with bounded dependencies and lifecycle ownership outside runtimehost.Host, without beginning durable execution composition or broad host-port cleanup.",
    "problem": "The production runtimehost.Host run loop directly decides whether to start the dashboard goroutine and owns its lifecycle alongside runtime sidecars. This mixes presentation and runtime-host responsibilities, obscures cancellation and join ownership, and creates pressure to recover dashboard inputs from a broad host or service dependency carrier.",
    "solution": "Compose a bounded dashboard collaborator at the existing initializer or CLI process boundary, preserve current mode, enablement, address, readiness, and error behavior, and make that process owner responsible for startup, cancellation, and joining while prohibiting runtimehost.Host, FactoryService, and broad host ports as dashboard dependencies."
  },
  "acceptanceCriteria": [
    "Production runtimehost.Host run-loop behavior neither constructs the dashboard sidecar nor directly starts its goroutine.",
    "The existing initializer or CLI process-composition boundary supplies a bounded dashboard collaborator and owns its enablement decision, startup, cancellation, and join semantics.",
    "No new dashboard constructor or adapter accepts runtimehost.Host, FactoryService, or a broad host port that exposes unrelated session, persistence, runtime activation, model, or transport operations.",
    "Service-mode, batch-mode, configured enablement/address, readiness, and startup-error behavior remains equivalent to the behavior before the ownership transfer.",
    "Focused lifecycle tests prove that the sidecar starts exactly when configured, remains inactive when disabled, observes cancellation, and is joined before shutdown returns.",
    "Durable session execution construction, API server and listener ownership, worker scheduling, Factory Session runtime behavior, and wide factory-domain host ports remain outside this work item except for minimal composition wiring.",
    "Typecheck, lint, and focused tests pass for initializer, runtimehost, CLI/root composition, and any dashboard serving or rendering package changed."
  ],
  "userStories": [
    {
      "id": "runtime-cleanup-dashboard-sidecar-owner-001",
      "title": "Define a bounded dashboard sidecar collaborator",
      "description": "As a runtime maintainer, I want dashboard rendering represented by a bounded process collaborator so that it can be composed without depending on the runtime host or service facade.",
      "acceptanceCriteria": [
        "The dashboard collaborator exposes only the lifecycle operation and the read, render, timing, output, readiness, and configuration inputs needed by existing dashboard behavior.",
        "Its constructor and adapters do not accept runtimehost.Host, FactoryService, or an interface that carries unrelated session mutation, persistence, runtime activation, model, API server, listener, or worker-scheduling capabilities.",
        "Missing required dashboard inputs fail explicitly at composition time or startup with an actionable error; the collaborator does not lazily recover them from a broad host object.",
        "The collaborator can be tested with bounded fakes that report start, readiness, cancellation, exit, and rendering observations without starting a full Factory Session runtime.",
        "No public API, OpenAPI schema, CLI flag, emitted event, or generated client contract changes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented in 3f7315e9f: added a bounded process dashboard sidecar with explicit read, render, timing, readiness, and error-reporting dependencies plus deterministic lifecycle tests."
    },
    {
      "id": "runtime-cleanup-dashboard-sidecar-owner-002",
      "title": "Compose dashboard startup with preserved mode and configuration behavior",
      "description": "As an operator, I want eligible runs to retain the same dashboard availability and configuration behavior after ownership moves so that service and batch workflows remain predictable.",
      "acceptanceCriteria": [
        "The initializer or CLI process-composition path constructs and supplies the bounded dashboard collaborator before the production run loop begins; runtimehost.Host does not construct it or directly launch its goroutine.",
        "Runs that currently enable dashboard rendering start exactly one dashboard sidecar with the resolved address, render interval, output, clock, readiness signaling, and bounded read inputs selected by existing configuration rules.",
        "Batch, invocation, quiet, or other modes that currently suppress dashboard rendering do not start the sidecar and do not emit dashboard output.",
        "Configured dashboard enablement and address resolution produce the same operator-visible URL/output and readiness behavior as before the ownership transfer.",
        "Dashboard startup or readiness failure is propagated through the existing process startup/error boundary with actionable diagnostics and without leaving a background dashboard loop running.",
        "API server, listener, worker scheduler, Factory Session runtime, and durable execution behavior remain unchanged apart from the minimum wiring needed to transfer dashboard ownership.",
        "Focused initializer and CLI/root composition tests cover enabled service mode, configured address behavior, and every existing disabled-mode class without relying on source inventories.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented in d9c190ade: production dashboard-enabled CLI runs now compose the bounded sidecar in the initializer, runtimehost no longer launches dashboard rendering, suppressed invocation modes remain inactive, and startup failures cancel and join runtime startup."
    },
    {
      "id": "runtime-cleanup-dashboard-sidecar-owner-003",
      "title": "Cancel and join the dashboard sidecar during process shutdown",
      "description": "As an operator, I want process shutdown to cancel and join dashboard rendering so that shutdown cannot return while the sidecar is still rendering or serving.",
      "acceptanceCriteria": [
        "Cancelling the owning process context is observed by the running dashboard collaborator and stops subsequent renders or serves.",
        "Normal process shutdown waits for the dashboard collaborator to exit before returning, including shutdown initiated after successful readiness and shutdown during startup.",
        "Context cancellation is treated as normal shutdown; non-cancellation sidecar failures retain the existing error or logging behavior and remain diagnosable without exposing sensitive runtime payloads.",
        "Focused lifecycle tests use explicit synchronization signals rather than timing-only sleeps to prove exactly-once startup, cancellation observation, and join-before-return behavior.",
        "Repeated lifecycle verification completes without duplicate dashboard loops, leaked goroutines, or wait-group misuse; race-oriented verification is run where supported.",
        "A narrow mechanical architecture rule, preferably an existing dependency or lint boundary check, rejects production dashboard startup from runtimehost.Host and rejects dashboard construction from broad host/service dependency carriers without enforcing an unrelated file or registration inventory.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented in c52d719b8: process shutdown now has deterministic cancellation/join coverage, runtimehost's dead dashboard rendering path is removed, and dependency-boundary tests reject host-owned startup and broad dashboard carriers."
    }
  ]
}
