### PR TITLE
runtime-cleanup-model-host-adapter-retirement

### DIFF
--- a/cmd/modelfacadecheck/main.go
+++ b/cmd/modelfacadecheck/main.go
@@ -70,7 +70,7 @@ func run(cfg config, stdout io.Writer, stderr io.Writer) error {
 		return err
 	}
 	if len(findings) == 0 {
-		fmt.Fprintln(stdout, "[agent-factory:model-facade] model facade methods are thin delegates")
+		fmt.Fprintln(stdout, "[agent-factory:model-facade] model facade methods are thin delegates with explicit construction dependencies")
 		return nil
 	}
 	for _, finding := range findings {
@@ -97,8 +97,147 @@ func scanFacades(root string) ([]string, error) {
 				findings = append(findings, finding)
 			}
 		}
+		constructionFindings, err := scanModelServiceConstruction(repoRoot, target)
+		if err != nil {
+			return nil, err
+		}
+		findings = append(findings, constructionFindings...)
 	}
 	return findings, nil
+}
+
+func scanModelServiceConstruction(repoRoot string, target facadeTarget) ([]string, error) {
+	packageDir := filepath.Join(repoRoot, filepath.FromSlash(target.packagePath))
+	entries, err := os.ReadDir(packageDir)
+	if err != nil {
+		return nil, fmt.Errorf("read facade package %s: %w", target.packagePath, err)
+	}
+
+	broadAdapters := map[string]struct{}{}
+	for _, entry := range entries {
+		if entry.IsDir() || !isProductionGoFile(entry.Name()) {
+			continue
+		}
+		filePath := filepath.Join(packageDir, entry.Name())
+		file, err := parser.ParseFile(token.NewFileSet(), filePath, nil, 0)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", filepath.ToSlash(filePath), err)
+		}
+		for typeName := range broadAdapterTypes(file, target.receiver) {
+			broadAdapters[typeName] = struct{}{}
+		}
+	}
+
+	var findings []string
+	for _, entry := range entries {
+		if entry.IsDir() || !isProductionGoFile(entry.Name()) {
+			continue
+		}
+		filePath := filepath.Join(packageDir, entry.Name())
+		file, err := parser.ParseFile(token.NewFileSet(), filePath, nil, 0)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", filepath.ToSlash(filePath), err)
+		}
+		aliases := modelServiceImportAliases(file)
+		if len(aliases) == 0 {
+			continue
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			constructor := modelServiceConstructor(call.Fun, aliases)
+			if constructor == "NewFromHost" {
+				findings = append(findings, fmt.Sprintf("%s | %s calls retired models service NewFromHost; use New(Dependencies)", filepath.ToSlash(filePath), target.packagePath))
+				return true
+			}
+			if constructor == "New" && callCarriesBroadAdapter(call, broadAdapters) {
+				findings = append(findings, fmt.Sprintf("%s | %s passes a broad %s carrier into models service construction; use explicit Dependencies", filepath.ToSlash(filePath), target.packagePath, target.receiver))
+			}
+			return true
+		})
+	}
+	return findings, nil
+}
+
+func modelServiceImportAliases(file *ast.File) map[string]struct{} {
+	aliases := map[string]struct{}{}
+	for _, imported := range file.Imports {
+		if strings.Trim(imported.Path.Value, `"`) != "github.com/portpowered/infinite-you/pkg/models/service" {
+			continue
+		}
+		alias := "service"
+		if imported.Name != nil {
+			alias = imported.Name.Name
+		}
+		if alias != "." && alias != "_" {
+			aliases[alias] = struct{}{}
+		}
+	}
+	return aliases
+}
+
+func broadAdapterTypes(file *ast.File, receiverType string) map[string]struct{} {
+	types := map[string]struct{}{}
+	for _, declaration := range file.Decls {
+		general, ok := declaration.(*ast.GenDecl)
+		if !ok || general.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range general.Specs {
+			typeSpec, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			structure, ok := typeSpec.Type.(*ast.StructType)
+			if !ok {
+				continue
+			}
+			for _, field := range structure.Fields.List {
+				if receiverBaseType(field.Type) == receiverType {
+					types[typeSpec.Name.Name] = struct{}{}
+					break
+				}
+			}
+		}
+	}
+	return types
+}
+
+func modelServiceConstructor(expression ast.Expr, aliases map[string]struct{}) string {
+	selector, ok := expression.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+	identifier, ok := selector.X.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+	if _, ok := aliases[identifier.Name]; !ok {
+		return ""
+	}
+	return selector.Sel.Name
+}
+
+func callCarriesBroadAdapter(call *ast.CallExpr, broadAdapters map[string]struct{}) bool {
+	for _, argument := range call.Args {
+		if unary, ok := argument.(*ast.UnaryExpr); ok && unary.Op == token.AND {
+			argument = unary.X
+		}
+		literal, ok := argument.(*ast.CompositeLit)
+		if !ok {
+			continue
+		}
+		identifier, ok := literal.Type.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		if _, ok := broadAdapters[identifier.Name]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func findTargetMethods(repoRoot string, target facadeTarget) (map[string][]locatedMethod, error) {

--- a/cmd/modelfacadecheck/main_test.go
+++ b/cmd/modelfacadecheck/main_test.go
@@ -49,6 +49,54 @@ func TestRunRejectsCopiedPullPolicy(t *testing.T) {
 	}
 }
 
+func TestRunRejectsRetiredNewFromHostConstruction(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFacadeFixture(t, root, "pkg/service/catalog.go", thinDelegateFixture("service", "FactoryService"))
+	writeFacadeFixture(t, root, "pkg/runtimehost/catalog.go", thinDelegateFixture("runtimehost", "Host"))
+	writeFacadeFixture(t, root, "pkg/service/construction.go", `package service
+
+import modelsservice "github.com/portpowered/infinite-you/pkg/models/service"
+
+func construct(fs *FactoryService) any { return modelsservice.NewFromHost(fs) }
+`)
+
+	assertRunRejected(t, root, "NewFromHost")
+}
+
+func TestRunRejectsBroadFacadeCarrierConstruction(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeFacadeFixture(t, root, "pkg/service/catalog.go", thinDelegateFixture("service", "FactoryService"))
+	writeFacadeFixture(t, root, "pkg/runtimehost/catalog.go", thinDelegateFixture("runtimehost", "Host"))
+	writeFacadeFixture(t, root, "pkg/runtimehost/construction.go", `package runtimehost
+
+import modelsservice "github.com/portpowered/infinite-you/pkg/models/service"
+
+	func construct(host *Host) any { return modelsservice.New(&modelServiceHost{host: host}) }
+`)
+	writeFacadeFixture(t, root, "pkg/runtimehost/adapter.go", `package runtimehost
+
+type modelServiceHost struct { host *Host }
+`)
+
+	assertRunRejected(t, root, "broad Host carrier")
+}
+
+func assertRunRejected(t *testing.T, root string, finding string) {
+	t.Helper()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if err := run(config{root: root}, stdout, stderr); err == nil {
+		t.Fatalf("run() error = nil, want %q rejection", finding)
+	}
+	if got := stderr.String(); !strings.Contains(got, finding) {
+		t.Fatalf("run() stderr = %q, want %q", got, finding)
+	}
+}
+
 func thinDelegateFixture(packageName string, receiverType string) string {
 	return "package " + packageName + `
 

--- a/pkg/runtimehost/model_catalog_test.go
+++ b/pkg/runtimehost/model_catalog_test.go
@@ -5,12 +5,19 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/jonboulle/clockwork"
 	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
 	"github.com/portpowered/infinite-you/pkg/apisurface"
+	factoryconfig "github.com/portpowered/infinite-you/pkg/config"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/localmodels"
+	"github.com/portpowered/infinite-you/pkg/modelhost"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestHostModelServiceClockUsesCompositionClock(t *testing.T) {
@@ -20,6 +27,221 @@ func TestHostModelServiceClockUsesCompositionClock(t *testing.T) {
 	if got := host.modelServiceClock(); !got.Equal(want) {
 		t.Fatalf("modelServiceClock() = %s, want %s", got, want)
 	}
+}
+
+func TestWireModelServiceCollaboratorPreservesOverrideAndNilHostBehavior(t *testing.T) {
+	override := &catalogModelServiceStub{}
+	if got := wireModelServiceCollaborator(&Host{}, &Config{ModelAPI: override}); got != override {
+		t.Fatalf("wireModelServiceCollaborator override = %T, want configured ModelAPI", got)
+	}
+
+	var host *Host
+	_, err := host.ListModels(context.Background())
+	if err == nil || err.Error() != "factory service runtime is not available" {
+		t.Fatalf("nil Host ListModels error = %v, want unavailable runtime", err)
+	}
+}
+
+func TestRuntimeHostModelServicePreservesCatalogPullObservabilityAndErrors(t *testing.T) {
+	runtimeCfg := runtimeHostModelConfig(t)
+	modelHost := &runtimeHostModelHost{readiness: modelhost.ReadinessSnapshot{
+		Identity:       modelhost.Identity{Name: "voice-model", Locality: factoryapi.WorkerModelLocalityLocal},
+		ReadinessState: factoryapi.ManagedRuntimeReadinessStateREADY,
+		LifecycleState: factoryapi.ManagedRuntimeLifecycleStateLOADED,
+	}, pull: modelhost.PullSnapshot{
+		ReadinessSnapshot: modelhost.ReadinessSnapshot{
+			Identity:       modelhost.Identity{Name: "voice-model", Locality: factoryapi.WorkerModelLocalityLocal},
+			ReadinessState: factoryapi.ManagedRuntimeReadinessStateREADY,
+			LifecycleState: factoryapi.ManagedRuntimeLifecycleStateLOADED,
+		},
+		PullOutcome:   factoryapi.ManagedRuntimePullOutcomeALREADYREADY,
+		LegacyOutcome: "ALREADY_PRESENT",
+		CachePath:     "/tmp/model",
+		Revision:      "rev-1",
+	}}
+	puller := &runtimeHostModelPuller{result: apisurface.ModelPullResult{
+		ModelName: "voice-model", Outcome: "ALREADY_PRESENT", CachePath: "/tmp/model", Revision: "rev-1",
+	}, inspection: localmodels.RuntimeCacheInspection{
+		Supported: true, Installed: true, CachePath: "/tmp/model", Revision: "rev-1",
+	}}
+	recorder := &runtimeHostPullMetricsRecorder{}
+	logCore, logs := observer.New(zap.InfoLevel)
+	host := runtimeHostModelFacade(runtimeCfg, modelHost, puller, &Config{ModelPullMetricsRecorder: recorder})
+	host.logger = zap.New(logCore)
+
+	listed, err := host.ListModels(context.Background())
+	if err != nil || len(listed.Results) != 1 || listed.Results[0].ManagedRuntime.ReadinessState != factoryapi.ManagedRuntimeReadinessStateREADY {
+		t.Fatalf("ListModels = (%#v, %v), want one ready model", listed, err)
+	}
+	pulled, err := host.PullModel(context.Background(), "voice-model")
+	if err != nil || pulled.ReadinessState != "READY" {
+		t.Fatalf("PullModel = (%#v, %v), want ready result", pulled, err)
+	}
+	if got := recorder.names(); !reflect.DeepEqual(got, []string{modelPullMetricAttempts, modelPullMetricSuccess}) {
+		t.Fatalf("pull metrics = %#v, want one attempt and one success", got)
+	}
+	if got := logs.FilterMessage("managed runtime pull completed").Len(); got != 1 {
+		t.Fatalf("pull completion log count = %d, want 1", got)
+	}
+
+	sentinel := errors.New("readiness failed")
+	modelHost.readinessErr = sentinel
+	_, err = host.GetModel(context.Background(), "voice-model")
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("GetModel error = %v, want readiness sentinel", err)
+	}
+}
+
+func TestRuntimeHostModelServicePreservesPullFailureSignals(t *testing.T) {
+	runtimeCfg := runtimeHostModelConfig(t)
+	recorder := &runtimeHostPullMetricsRecorder{}
+	logCore, logs := observer.New(zap.WarnLevel)
+	puller := &runtimeHostModelPuller{}
+	modelHost := &runtimeHostModelHost{pullErr: apisurface.ErrManagedRuntimeSourceFetchFailed}
+	host := runtimeHostModelFacade(runtimeCfg, modelHost, puller, &Config{ModelPullMetricsRecorder: recorder})
+	host.logger = zap.New(logCore)
+
+	_, err := host.PullModel(context.Background(), "voice-model")
+	if !errors.Is(err, apisurface.ErrManagedRuntimeSourceFetchFailed) {
+		t.Fatalf("PullModel error = %v, want source fetch failure", err)
+	}
+	if got := recorder.names(); !reflect.DeepEqual(got, []string{modelPullMetricAttempts, modelPullMetricFailure, modelPullMetricSourceFailure}) {
+		t.Fatalf("pull metrics = %#v, want attempt, failure, and source failure", got)
+	}
+	if got := logs.FilterMessage("managed runtime pull failed").Len(); got != 1 {
+		t.Fatalf("pull failure log count = %d, want 1", got)
+	}
+}
+
+func TestRuntimeHostModelServicePreservesFactoryRunnerIdentityForInvocation(t *testing.T) {
+	runtimeCfg := runtimeHostModelConfig(t)
+	provider := &runtimeHostInvocationProvider{}
+	cfg := &Config{RunnerID: "factory-runner", ProviderOverride: provider}
+	host := runtimeHostModelFacade(runtimeCfg, &runtimeHostModelHost{readiness: modelhost.ReadinessSnapshot{
+		Identity:       modelhost.Identity{Name: "voice-model", Locality: factoryapi.WorkerModelLocalityLocal},
+		ReadinessState: factoryapi.ManagedRuntimeReadinessStateREADY,
+		LifecycleState: factoryapi.ManagedRuntimeLifecycleStateLOADED,
+	}}, &runtimeHostModelPuller{}, cfg)
+
+	result, err := host.InvokeModel(context.Background(), "voice-model", factoryapi.ModelInvocationRequest{Operation: "TTS"})
+	if err != nil {
+		t.Fatalf("InvokeModel: %v", err)
+	}
+	if result.ModelName != "voice-model" || result.Worker != "voice-worker" {
+		t.Fatalf("InvokeModel result = %#v, want voice-model/voice-worker", result)
+	}
+	if got := provider.runnerIDs(); !reflect.DeepEqual(got, []string{"factory-runner"}) {
+		t.Fatalf("provider runner IDs = %#v, want factory-runner", got)
+	}
+}
+
+func runtimeHostModelConfig(t *testing.T) *factoryconfig.LoadedFactoryConfig {
+	t.Helper()
+	cfg, err := factoryconfig.NewLoadedFactoryConfig(t.TempDir(), &interfaces.FactoryConfig{
+		Name: "runtime-host-models",
+		Workers: []interfaces.WorkerConfig{{
+			Name: "voice-worker", Type: interfaces.WorkerTypeModel, Model: "voice-model",
+			ModelLocality: interfaces.ModelLocalityLocal,
+			Operations:    []interfaces.ModelOperation{{Name: "TTS"}},
+		}},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewLoadedFactoryConfig: %v", err)
+	}
+	return cfg
+}
+
+func runtimeHostModelFacade(runtimeCfg *factoryconfig.LoadedFactoryConfig, host modelhost.Host, puller modelAssetPuller, cfg *Config) *Host {
+	facade := &Host{
+		cfg: cfg, policy: CoordinatorPolicyFromConfig(cfg), modelAssets: puller,
+		startupBundle: &factoryRuntimeBundle{RuntimeCfg: runtimeCfg, ModelHost: host, ModelAssets: puller},
+	}
+	facade.modelService = wireModelServiceCollaborator(facade, cfg)
+	return facade
+}
+
+type runtimeHostModelPuller struct {
+	result     apisurface.ModelPullResult
+	inspection localmodels.RuntimeCacheInspection
+	err        error
+}
+
+func (p *runtimeHostModelPuller) PullModel(context.Context, *factoryconfig.LoadedFactoryConfig, string) (apisurface.ModelPullResult, error) {
+	return p.result, p.err
+}
+func (p *runtimeHostModelPuller) EnsureModelAvailable(context.Context, *factoryconfig.LoadedFactoryConfig, *interfaces.WorkerConfig) error {
+	return nil
+}
+func (p *runtimeHostModelPuller) ResolveModelCache(context.Context, *factoryconfig.LoadedFactoryConfig, *interfaces.WorkerConfig) (localmodels.CacheLayout, error) {
+	return localmodels.CacheLayout{}, nil
+}
+func (p *runtimeHostModelPuller) InspectRuntimeCache(context.Context, *factoryconfig.LoadedFactoryConfig, string) (localmodels.RuntimeCacheInspection, error) {
+	return p.inspection, nil
+}
+
+type runtimeHostModelHost struct {
+	readiness    modelhost.ReadinessSnapshot
+	readinessErr error
+	pull         modelhost.PullSnapshot
+	pullErr      error
+}
+
+func (h *runtimeHostModelHost) ResolveIdentity(context.Context, *factoryconfig.LoadedFactoryConfig, string) (modelhost.Identity, error) {
+	return h.readiness.Identity, nil
+}
+func (h *runtimeHostModelHost) InspectReadiness(context.Context, *factoryconfig.LoadedFactoryConfig, string) (modelhost.ReadinessSnapshot, error) {
+	return h.readiness, h.readinessErr
+}
+func (h *runtimeHostModelHost) Pull(context.Context, *factoryconfig.LoadedFactoryConfig, string) (modelhost.PullSnapshot, error) {
+	return h.pull, h.pullErr
+}
+func (*runtimeHostModelHost) AcquireLease(context.Context, *factoryconfig.LoadedFactoryConfig, string, modelhost.LeaseOptions) (modelhost.Lease, error) {
+	return modelhost.Lease{}, nil
+}
+func (*runtimeHostModelHost) ReleaseLease(context.Context, string) error { return nil }
+func (*runtimeHostModelHost) Unload(context.Context, *factoryconfig.LoadedFactoryConfig, string) error {
+	return nil
+}
+
+type runtimeHostPullMetricsRecorder struct {
+	mu      sync.Mutex
+	metrics []InvocationMetric
+}
+
+func (r *runtimeHostPullMetricsRecorder) RecordModelPullMetric(metric InvocationMetric) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.metrics = append(r.metrics, metric)
+}
+func (r *runtimeHostPullMetricsRecorder) names() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	names := make([]string, len(r.metrics))
+	for i := range r.metrics {
+		names[i] = r.metrics[i].Name
+	}
+	return names
+}
+
+type runtimeHostInvocationProvider struct {
+	mu       sync.Mutex
+	requests []interfaces.ProviderInferenceRequest
+}
+
+func (p *runtimeHostInvocationProvider) Infer(_ context.Context, request interfaces.ProviderInferenceRequest) (interfaces.InferenceResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.requests = append(p.requests, request)
+	return interfaces.InferenceResponse{Content: "spoken response"}, nil
+}
+func (p *runtimeHostInvocationProvider) runnerIDs() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	ids := make([]string, len(p.requests))
+	for i := range p.requests {
+		ids[i] = p.requests[i].RunnerID
+	}
+	return ids
 }
 
 func TestHostModelMethodsForwardContextResultsAndErrorsUnchanged(t *testing.T) {

--- a/pkg/service/factory_test.go
+++ b/pkg/service/factory_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/localmodels"
 	"github.com/portpowered/infinite-you/pkg/logging"
-	modelsservice "github.com/portpowered/infinite-you/pkg/models/service"
 	"github.com/portpowered/infinite-you/pkg/petri"
 	"github.com/portpowered/infinite-you/pkg/replay"
 	"github.com/portpowered/infinite-you/pkg/service/runtimebuild"
@@ -4052,6 +4051,7 @@ func TestRuntimeModelService_PullThenInvoke_UsesManagedRuntimeReadiness(t *testi
 
 func TestRuntimeModelService_PullModel_RecordsManagedRuntimeMetrics(t *testing.T) {
 	recorder := &capturingModelPullMetricsRecorder{}
+	logCore, observedLogs := observer.New(zap.InfoLevel)
 	runtimeCfg, err := factoryconfig.NewLoadedFactoryConfig(t.TempDir(), &interfaces.FactoryConfig{
 		Name: "factory",
 		Workers: []interfaces.WorkerConfig{{
@@ -4072,28 +4072,24 @@ func TestRuntimeModelService_PullModel_RecordsManagedRuntimeMetrics(t *testing.T
 		t.Fatalf("NewLoadedFactoryConfig: %v", err)
 	}
 
-	svc := modelsservice.New(modelsservice.Dependencies{
-		RuntimeConfig: func() *factoryconfig.LoadedFactoryConfig { return runtimeCfg },
-		ModelAssetPuller: func() localmodels.AssetPuller {
-			return &managedPullMetricsAssetPuller{
-				result: apisurface.ModelPullResult{
-					ModelName: "OMNIVOICE_Q4_K_M",
-					Outcome:   "ALREADY_PRESENT",
-					CachePath: "/tmp/cache",
-					Revision:  "rev1",
-				},
-				inspection: localmodels.RuntimeCacheInspection{
-					Supported: true,
-					Installed: true,
-					CachePath: "/tmp/cache",
-					Revision:  "rev1",
-				},
-			}
+	svc := newModelCatalogServiceForTest(runtimeCfg, &managedPullMetricsAssetPuller{
+		result: apisurface.ModelPullResult{
+			ModelName: "OMNIVOICE_Q4_K_M",
+			Outcome:   "ALREADY_PRESENT",
+			CachePath: "/tmp/cache",
+			Revision:  "rev1",
 		},
-		ModelPullMetrics: func() modelsservice.PullMetricsRecorder {
-			return modelPullMetricsTestAdapter{inner: recorder}
+		inspection: localmodels.RuntimeCacheInspection{
+			Supported: true,
+			Installed: true,
+			CachePath: "/tmp/cache",
+			Revision:  "rev1",
 		},
 	})
+	svc.logger = zap.New(logCore)
+	svc.cfg = &FactoryServiceConfig{
+		ModelPullMetricsRecorder: recorder,
+	}
 
 	if _, err := svc.PullModel(context.Background(), "OMNIVOICE_Q4_K_M"); err != nil {
 		t.Fatalf("PullModel: %v", err)
@@ -4104,10 +4100,17 @@ func TestRuntimeModelService_PullModel_RecordsManagedRuntimeMetrics(t *testing.T
 		"pull_outcome":    "ALREADY_READY",
 		"readiness_state": "READY",
 	})
+	if got := recorder.count(); got != 2 {
+		t.Fatalf("model pull metric count = %d, want one attempt and one success", got)
+	}
+	if got := observedLogs.FilterMessage("managed runtime pull completed").Len(); got != 1 {
+		t.Fatalf("managed runtime pull completion log count = %d, want 1", got)
+	}
 }
 
 func TestRuntimeModelService_PullModel_RecordsSourceFailureMetric(t *testing.T) {
 	recorder := &capturingModelPullMetricsRecorder{}
+	logCore, observedLogs := observer.New(zap.WarnLevel)
 	runtimeCfg, err := factoryconfig.NewLoadedFactoryConfig(t.TempDir(), &interfaces.FactoryConfig{
 		Name: "factory",
 		Workers: []interfaces.WorkerConfig{{
@@ -4128,17 +4131,13 @@ func TestRuntimeModelService_PullModel_RecordsSourceFailureMetric(t *testing.T) 
 		t.Fatalf("NewLoadedFactoryConfig: %v", err)
 	}
 
-	svc := modelsservice.New(modelsservice.Dependencies{
-		RuntimeConfig: func() *factoryconfig.LoadedFactoryConfig { return runtimeCfg },
-		ModelAssetPuller: func() localmodels.AssetPuller {
-			return &managedPullMetricsAssetPuller{
-				err: apisurface.ErrManagedRuntimeSourceFetchFailed,
-			}
-		},
-		ModelPullMetrics: func() modelsservice.PullMetricsRecorder {
-			return modelPullMetricsTestAdapter{inner: recorder}
-		},
+	svc := newModelCatalogServiceForTest(runtimeCfg, &managedPullMetricsAssetPuller{
+		err: apisurface.ErrManagedRuntimeSourceFetchFailed,
 	})
+	svc.logger = zap.New(logCore)
+	svc.cfg = &FactoryServiceConfig{
+		ModelPullMetricsRecorder: recorder,
+	}
 
 	_, err = svc.PullModel(context.Background(), "OMNIVOICE_Q4_K_M")
 	pullErr, ok := apisurface.AsManagedRuntimePullError(err)
@@ -4159,6 +4158,12 @@ func TestRuntimeModelService_PullModel_RecordsSourceFailureMetric(t *testing.T) 
 	recorder.assertContainsMetric(t, modelPullMetricSourceFailure, map[string]string{
 		"model_name": "OMNIVOICE_Q4_K_M",
 	})
+	if got := recorder.count(); got != 3 {
+		t.Fatalf("model pull metric count = %d, want one attempt, failure, and source failure", got)
+	}
+	if got := observedLogs.FilterMessage("managed runtime pull failed").Len(); got != 1 {
+		t.Fatalf("managed runtime pull failure log count = %d, want 1", got)
+	}
 }
 
 type capturingModelPullMetricsRecorder struct {
@@ -4170,14 +4175,6 @@ func (r *capturingModelPullMetricsRecorder) RecordModelPullMetric(metric Invocat
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.metrics = append(r.metrics, metric)
-}
-
-type modelPullMetricsTestAdapter struct {
-	inner *capturingModelPullMetricsRecorder
-}
-
-func (a modelPullMetricsTestAdapter) RecordModelPullMetric(metric modelsservice.PullMetric) {
-	a.inner.RecordModelPullMetric(InvocationMetric{Name: metric.Name, Labels: metric.Labels})
 }
 
 func (r *capturingModelPullMetricsRecorder) assertContainsMetric(t *testing.T, name string, labels map[string]string) {
@@ -4200,6 +4197,12 @@ func (r *capturingModelPullMetricsRecorder) assertContainsMetric(t *testing.T, n
 		}
 	}
 	t.Fatalf("metrics %#v do not contain %q with labels %#v", r.metrics, name, labels)
+}
+
+func (r *capturingModelPullMetricsRecorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.metrics)
 }
 
 type managedPullMetricsAssetPuller struct {


### PR DESCRIPTION
{
  "project": "Retire the Remaining Production Model-Service Host Adapter",
  "branchName": "runtime-cleanup-model-host-adapter-retirement",
  "description": "Close the remaining Phase 2 model-service dependency-injection gap by moving the two production callers to New(Dependencies), preserving all model behavior and operational signals, deleting the obsolete broad host adapter, and narrowly preventing its return.",
  "context": {
    "customerAsk": "Move pkg/service and pkg/runtimehost from modelsservice.NewFromHost to modelsservice.New(Dependencies), explicitly pass every existing model-scoped dependency, delete the unused host migration adapter, and mechanically prevent equivalent production host-object construction from returning.",
    "problem": "Two production composition paths still hide model-service inputs behind adapters around FactoryService and runtimehost.Host, contrary to the Phase 2 acceptance criterion. The obsolete seam obscures dependency ownership and permits broad coordinator coupling to return.",
    "solution": "Translate each caller's existing runtime configuration, model host, asset puller, logger, pull metrics, invocation executor, and factory-runner identity directly into modelsservice.Dependencies; preserve observable behavior and overrides; then delete NewFromHost and add narrow static enforcement against host-based construction."
  },
  "acceptanceCriteria": [
    "pkg/service and pkg/runtimehost construct the canonical model service with modelsservice.New(modelsservice.Dependencies{...}) and explicitly supply every existing model-scoped runtime dependency",
    "Model catalog, pull, readiness, direct invocation, logging, metrics, dependency-error propagation, and factory-runner identity outcomes remain unchanged through both production facades",
    "Production code does not call modelsservice.NewFromHost or pass FactoryService, runtimehost.Host, or an equivalent broad adapter as a model-service dependency carrier",
    "pkg/models/service/host.go, its host-adapter tests, and both production modelServiceHost adapters are deleted when no compatibility caller remains, with no dead migration shim retained",
    "A narrow mechanical check rejects production NewFromHost usage and equivalent broad model-service host adapters without enforcing unrelated source inventories",
    "Public API, OpenAPI, CLI, events, generated clients, durable execution, factory save or definition, Factory Sessions, worker scheduling, and dashboard behavior remain unchanged",
    "Typecheck, lint and the relevant static boundary check, go test ./pkg/models/service/..., and go test ./pkg/service/... ./pkg/runtimehost/... pass"
  ],
  "userStories": [
    {
      "id": "runtime-cleanup-model-host-adapter-retirement-001",
      "title": "Preserve FactoryService model behavior with direct construction",
      "description": "As an API or CLI user, I want FactoryService model operations to keep their current results and operational signals while the canonical model service is constructed from explicit dependencies.",
      "acceptanceCriteria": [
        "Default FactoryService composition calls modelsservice.New(modelsservice.Dependencies{...}) with its existing live runtime configuration reader, model host reader, asset puller, logger, pull-metrics recorder, invocation executor, and factory-runner identity dependency supplied explicitly",
        "An explicitly configured ModelAPI continues to take precedence over default construction and nil-shell construction retains its current safe behavior",
        "Focused facade tests prove representative catalog and readiness, pull, and direct-invocation results and errors remain unchanged, including the same runner identity passed to invocation execution",
        "Focused tests prove pull logging and metrics retain their existing values and emission count after direct construction",
        "No FactoryService object or adapter around it is passed into pkg/models/service as a dependency carrier",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "runtime-cleanup-model-host-adapter-retirement-002",
      "title": "Preserve runtimehost model behavior with direct construction",
      "description": "As a runtime user, I want runtimehost.Host model operations to keep their current results and operational signals while the canonical model service is constructed from explicit dependencies.",
      "acceptanceCriteria": [
        "Default runtimehost.Host composition calls modelsservice.New(modelsservice.Dependencies{...}) with its existing live runtime configuration reader, model host reader, asset puller, logger, pull-metrics recorder, invocation executor, and factory-runner identity dependency supplied explicitly",
        "An explicitly configured ModelAPI continues to take precedence over default construction and nil-host construction retains its current safe behavior",
        "Focused facade tests prove representative catalog and readiness, pull, and direct-invocation results and errors remain unchanged, including the same runner identity passed to invocation execution",
        "Focused tests prove pull logging and metrics retain their existing values and emission count after direct construction",
        "No runtimehost.Host object or adapter around it is passed into pkg/models/service as a dependency carrier",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "runtime-cleanup-model-host-adapter-retirement-003",
      "title": "Remove and prohibit broad model-service host construction",
      "description": "As a maintainer, I want the obsolete host-based construction seam removed and narrowly prohibited so that model-service dependencies remain explicit after Phase 2 closes.",
      "acceptanceCriteria": [
        "After confirming no compatibility caller remains, delete pkg/models/service/host.go, its host-adapter tests, both production modelServiceHost adapter types, and their compile-time host assertions",
        "No production code calls NewFromHost and no dead alias, wrapper, or migration shim preserves equivalent host-object construction",
        "A focused static boundary check rejects a fixture containing production NewFromHost usage and a fixture containing an equivalent broad adapter that carries FactoryService or runtimehost.Host into model-service construction",
        "The same check accepts the repository's direct New(Dependencies) composition and does not enforce unrelated files, routes, commands, registrations, generated assets, or documentation topology",
        "Focused model-service, service, and runtimehost tests still prove catalog, readiness, pull, invocation, logging, metrics, and runner-identity behavior after adapter deletion",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}
