### PR TITLE
runtime-cleanup-durable-persistence-composition

### DIFF
--- a/cmd/durableruntimeconstructioncheck/main.go
+++ b/cmd/durableruntimeconstructioncheck/main.go
@@ -13,13 +13,26 @@ import (
 	"strings"
 )
 
-const constructorName = "NewJavaScriptRuntimeService"
+const (
+	runtimeConstructorName = "NewJavaScriptRuntimeService"
+	storeConstructorName   = "NewDirectoryStore"
+	storeDirectoryName     = "DirForProjectRoot"
+	persistenceBooleanName = "PersistSessions"
+)
 
-var approvedCompositionFiles = map[string]struct{}{
-	"pkg/composebridge/core.go":                          {},
+var approvedRuntimeConstructorFiles = map[string]struct{}{
 	"pkg/factorysessionexecution/service.go":             {},
 	"pkg/factorysessionexecution/testharness/harness.go": {},
-	"pkg/service/factory_editable_definition.go":         {},
+}
+
+var approvedPersistenceCompositionFiles = map[string]struct{}{
+	"pkg/api/servertests/server_durable_session_execution_test.go": {},
+	"pkg/cli/mcp/serve_runtime_resume_smoke_test.go":               {},
+	"pkg/cli/session/smoke/resume_smoke_test.go":                   {},
+	"pkg/factorysessionexecution/service.go":                       {},
+	"pkg/factorysessionexecution/runtimepersist/store.go":          {},
+	"pkg/factorysessionexecution/testharness/harness.go":           {},
+	"pkg/mcp/factorysession/execution_test.go":                     {},
 }
 
 type config struct{ root string }
@@ -76,9 +89,6 @@ func scan(root string) ([]string, error) {
 		if strings.HasSuffix(entry.Name(), "_test.go") && !isTransportTest(relative) {
 			return nil
 		}
-		if _, approved := approvedCompositionFiles[relative]; approved {
-			return nil
-		}
 		fileSet := token.NewFileSet()
 		file, err := parser.ParseFile(fileSet, path, nil, parser.ParseComments)
 		if err != nil {
@@ -88,12 +98,29 @@ func scan(root string) ([]string, error) {
 			return nil
 		}
 		ast.Inspect(file, func(node ast.Node) bool {
-			call, ok := node.(*ast.CallExpr)
-			if !ok || calledName(call.Fun) != constructorName {
-				return true
+			switch value := node.(type) {
+			case *ast.CallExpr:
+				name := calledName(value.Fun)
+				if name == runtimeConstructorName && !approved(relative, approvedRuntimeConstructorFiles) {
+					appendFinding(&findings, fileSet, value.Pos(), relative, name,
+						"construct durable execution in an approved composition owner")
+				}
+				if (name == storeConstructorName || name == storeDirectoryName) &&
+					!approved(relative, approvedPersistenceCompositionFiles) {
+					appendFinding(&findings, fileSet, value.Pos(), relative, name,
+						"resolve and construct durable persistence at the approved application composition boundary")
+				}
+			case *ast.KeyValueExpr:
+				if identifierName(value.Key) == persistenceBooleanName {
+					appendFinding(&findings, fileSet, value.Pos(), relative, persistenceBooleanName,
+						"inject a persistence store or explicit disabled policy instead of a boolean")
+				}
+			case *ast.CompositeLit:
+				if calledName(value.Type) == "DirectoryStore" && !approved(relative, approvedPersistenceCompositionFiles) {
+					appendFinding(&findings, fileSet, value.Pos(), relative, "DirectoryStore literal",
+						"construct durable persistence at the approved application composition boundary")
+				}
 			}
-			position := fileSet.Position(call.Pos())
-			findings = append(findings, fmt.Sprintf("[agent-factory:durable-runtime-construction] %s:%d calls %s; construct durable execution in an approved composition owner", relative, position.Line, constructorName))
 			return true
 		})
 		return nil
@@ -103,6 +130,22 @@ func scan(root string) ([]string, error) {
 	}
 	sort.Strings(findings)
 	return findings, nil
+}
+
+func approved(relative string, files map[string]struct{}) bool {
+	_, ok := files[relative]
+	return ok
+}
+
+func appendFinding(findings *[]string, fileSet *token.FileSet, position token.Pos, relative, name, guidance string) {
+	line := fileSet.Position(position).Line
+	*findings = append(*findings, fmt.Sprintf(
+		"[agent-factory:durable-runtime-construction] %s:%d uses %s; %s",
+		relative,
+		line,
+		name,
+		guidance,
+	))
 }
 
 func isTransportTest(relative string) bool {
@@ -123,6 +166,14 @@ func calledName(expression ast.Expr) string {
 	default:
 		return ""
 	}
+}
+
+func identifierName(expression ast.Expr) string {
+	identifier, ok := expression.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+	return identifier.Name
 }
 
 func ignoredDirectory(name string) bool {

--- a/cmd/durableruntimeconstructioncheck/main_test.go
+++ b/cmd/durableruntimeconstructioncheck/main_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestScanRejectsImplicitPersistenceConstruction(t *testing.T) {
+	root := fixtureRepository(t, map[string]string{
+		"pkg/runtime/implicit.go": "testdata/prohibited_implicit.go.txt",
+	})
+
+	findings, err := scan(root)
+	if err != nil {
+		t.Fatalf("scan fixture: %v", err)
+	}
+
+	for _, prohibited := range []string{
+		"NewJavaScriptRuntimeService",
+		"PersistSessions",
+		"DirForProjectRoot",
+		"NewDirectoryStore",
+		"DirectoryStore literal",
+	} {
+		if !containsFinding(findings, prohibited) {
+			t.Errorf("findings %#v do not report %s", findings, prohibited)
+		}
+	}
+}
+
+func TestScanAcceptsApplicationCompositionAndApprovedHarness(t *testing.T) {
+	root := fixtureRepository(t, map[string]string{
+		"pkg/factorysessionexecution/service.go":             "testdata/approved_composition.go.txt",
+		"pkg/factorysessionexecution/testharness/harness.go": "testdata/approved_harness.go.txt",
+		"pkg/api/transport_test.go":                          "testdata/approved_transport_test.go.txt",
+	})
+
+	findings, err := scan(root)
+	if err != nil {
+		t.Fatalf("scan fixture: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("approved ownership produced findings: %v", findings)
+	}
+}
+
+func fixtureRepository(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for destination, source := range files {
+		contents, err := os.ReadFile(source)
+		if err != nil {
+			t.Fatalf("read fixture %s: %v", source, err)
+		}
+		path := filepath.Join(root, filepath.FromSlash(destination))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("create fixture directory: %v", err)
+		}
+		if err := os.WriteFile(path, contents, 0o600); err != nil {
+			t.Fatalf("write fixture %s: %v", destination, err)
+		}
+	}
+	return root
+}
+
+func containsFinding(findings []string, expected string) bool {
+	for _, finding := range findings {
+		if strings.Contains(finding, expected) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/durableruntimeconstructioncheck/testdata/approved_composition.go.txt
+++ b/cmd/durableruntimeconstructioncheck/testdata/approved_composition.go.txt
@@ -1,0 +1,6 @@
+package factorysessionexecution
+
+func build(root string) {
+	store := NewDirectoryStore(DirForProjectRoot(root))
+	NewJavaScriptRuntimeService(Config{Persistence: store})
+}

--- a/cmd/durableruntimeconstructioncheck/testdata/approved_harness.go.txt
+++ b/cmd/durableruntimeconstructioncheck/testdata/approved_harness.go.txt
@@ -1,0 +1,5 @@
+package testharness
+
+func build(store Store) {
+	NewJavaScriptRuntimeService(Config{Persistence: store})
+}

--- a/cmd/durableruntimeconstructioncheck/testdata/approved_transport_test.go.txt
+++ b/cmd/durableruntimeconstructioncheck/testdata/approved_transport_test.go.txt
@@ -1,0 +1,5 @@
+package api
+
+func testRuntime(config Config) {
+	testharness.New(config)
+}

--- a/cmd/durableruntimeconstructioncheck/testdata/prohibited_implicit.go.txt
+++ b/cmd/durableruntimeconstructioncheck/testdata/prohibited_implicit.go.txt
@@ -1,0 +1,7 @@
+package runtime
+
+func build(root string) {
+	NewJavaScriptRuntimeService(Config{PersistSessions: true})
+	NewDirectoryStore(DirForProjectRoot(root))
+	_ = DirectoryStore{Dir: root}
+}

--- a/docs/internal/processes/runtime-cleanup-relevant-files.md
+++ b/docs/internal/processes/runtime-cleanup-relevant-files.md
@@ -82,7 +82,11 @@ and `make typecheck`. Add `make docs-reference-smoke` only when packaged
 
 When changing durable Factory Session execution construction, run
 `make durable-runtime-construction-check`. The guard permits direct
-`NewJavaScriptRuntimeService` calls only in the application composition owners
-and the package-local execution-provider factory; package tests, `testdata`
+`NewJavaScriptRuntimeService` calls only in the package-local execution-provider
+factory and approved deterministic test harness. Project-local persistence path
+resolution and directory-store construction belong at the fallible application
+composition boundary in `pkg/factorysessionexecution/service.go`; production
+runtime code must receive either that injected store or an explicit disabled
+policy and must not use a persistence boolean. Package tests, `testdata`
 fixtures, generated code, dependencies, coverage, and build artifacts are not
 production construction sites.

--- a/pkg/cli/mcp/serve.go
+++ b/pkg/cli/mcp/serve.go
@@ -62,9 +62,13 @@ func resolveServeService(cfg ServeConfig) (factorysessionexecution.Service, erro
 		if err != nil {
 			return nil, err
 		}
+		persistence, err := factorysessionexecution.ProjectPersistence(projectRoot)
+		if err != nil {
+			return nil, fmt.Errorf("initialize runtime-backed persistence: %w", err)
+		}
 		service, err := factorysessionexecution.NewExecutionService(
 			factorysessionexecution.ExecutionProviderJavaScriptRuntime,
-			factorysessionexecution.ServiceConfig{ProjectRoot: projectRoot},
+			factorysessionexecution.ServiceConfig{ProjectRoot: projectRoot, Persistence: persistence},
 		)
 		if err != nil {
 			return nil, fmt.Errorf("initialize runtime-backed execution service: %w", err)

--- a/pkg/cli/sessionexecution/live_provider_test.go
+++ b/pkg/cli/sessionexecution/live_provider_test.go
@@ -170,7 +170,7 @@ func TestRunSync_JavaScriptRuntimeFakeChildCLIInspectionRegression(t *testing.T)
 	projectRoot := setupCLIAgentRunWorkflowFixture(t)
 	service, err := fse.NewExecutionService(
 		fse.ExecutionProviderJavaScriptRuntime,
-		fse.ServiceConfig{ProjectRoot: projectRoot},
+		fse.ServiceConfig{ProjectRoot: projectRoot, Persistence: fse.DisabledPersistence()},
 	)
 	if err != nil {
 		t.Fatalf("NewExecutionService: %v", err)
@@ -436,6 +436,7 @@ func newLiveChildCLIJavaScriptRuntimeService(t *testing.T) (fse.Service, string)
 			ProjectRoot:       projectRoot,
 			ChildExecutorMode: fse.ChildExecutorModeLive,
 			Provider:          fse.SmokeLiveChildProvider(),
+			Persistence:       fse.DisabledPersistence(),
 		},
 	)
 	if err != nil {

--- a/pkg/cli/sessionexecution/run.go
+++ b/pkg/cli/sessionexecution/run.go
@@ -99,9 +99,14 @@ func resolveExecutionService(cfg RunConfig) (factorysessionexecution.Service, er
 		if err != nil {
 			return nil, err
 		}
+		persistence, err := factorysessionexecution.ProjectPersistence(projectRoot)
+		if err != nil {
+			return nil, err
+		}
 		return factorysessionexecution.NewExecutionService(provider, factorysessionexecution.ServiceConfig{
 			ProjectRoot:       projectRoot,
 			ChildExecutorMode: cfg.StartConfig.ChildExecutorMode,
+			Persistence:       persistence,
 		})
 	}
 	catalogPath, err := resolveFixtureCatalogPath(cfg.FixtureCatalogPath)

--- a/pkg/composebridge/core.go
+++ b/pkg/composebridge/core.go
@@ -10,7 +10,6 @@ import (
 	"github.com/portpowered/infinite-you/pkg/factory"
 	factoryservice "github.com/portpowered/infinite-you/pkg/factory/service"
 	"github.com/portpowered/infinite-you/pkg/factorysessionexecution"
-	"github.com/portpowered/infinite-you/pkg/factorysessionexecution/runtimepersist"
 	"github.com/portpowered/infinite-you/pkg/factorysessions"
 	"github.com/portpowered/infinite-you/pkg/hostedworkers"
 	"github.com/portpowered/infinite-you/pkg/runtimehost"
@@ -81,6 +80,10 @@ func ComposeCore(
 		}
 		cfg.Dir = resolvedDir
 	}
+	durableExecution, err := composeDurableExecution(cfg, root, clock)
+	if err != nil {
+		return nil, err
+	}
 
 	replaySideEffects, replayFactoryOpts, err := ReplayFactoryModeOptions(load.ReplayArtifact)
 	if err != nil {
@@ -136,12 +139,7 @@ func ComposeCore(
 		runtimeBundle,
 		runtimeBundle.Logger,
 		WireModelAssetPuller(cfg, collaborators.LocalModels),
-		factorysessionexecution.NewJavaScriptRuntimeService(factorysessionexecution.JavaScriptRuntimeServiceConfig{
-			ProjectRoot: durableProjectRoot(cfg.ExecutionBaseDir, cfg.Dir, root.FactoryRootDir),
-			Provider:    cfg.ProviderOverride,
-			Persistence: durablePersistence(cfg.ExecutionBaseDir, cfg.Dir, root.FactoryRootDir),
-			Clock:       clock,
-		}),
+		durableExecution,
 	), nil
 }
 
@@ -154,10 +152,28 @@ func durableProjectRoot(executionBaseDir, configuredDir, factoryRootDir string) 
 	return ""
 }
 
-func durablePersistence(executionBaseDir, configuredDir, factoryRootDir string) runtimepersist.Store {
-	return runtimepersist.DirectoryStore{Dir: runtimepersist.DirForProjectRoot(
-		durableProjectRoot(executionBaseDir, configuredDir, factoryRootDir),
-	)}
+func composeDurableExecution(
+	cfg *runtimehost.Config,
+	root Root,
+	clock factory.Clock,
+) (factorysessionexecution.Service, error) {
+	projectRoot := durableProjectRoot(cfg.ExecutionBaseDir, cfg.Dir, root.FactoryRootDir)
+	persistence, err := factorysessionexecution.PersistenceChoiceForPolicy(
+		cfg.DurableSessionPersistencePolicy,
+		projectRoot,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("compose durable session persistence: %w", err)
+	}
+	return factorysessionexecution.NewExecutionService(
+		factorysessionexecution.ExecutionProviderJavaScriptRuntime,
+		factorysessionexecution.ServiceConfig{
+			ProjectRoot: projectRoot,
+			Provider:    cfg.ProviderOverride,
+			Persistence: persistence,
+			Clock:       clock,
+		},
+	)
 }
 
 // BuildCore constructs the normalized runtime graph without attaching a transport host.

--- a/pkg/composebridge/core.go
+++ b/pkg/composebridge/core.go
@@ -10,6 +10,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/factory"
 	factoryservice "github.com/portpowered/infinite-you/pkg/factory/service"
 	"github.com/portpowered/infinite-you/pkg/factorysessionexecution"
+	"github.com/portpowered/infinite-you/pkg/factorysessionexecution/runtimepersist"
 	"github.com/portpowered/infinite-you/pkg/factorysessions"
 	"github.com/portpowered/infinite-you/pkg/hostedworkers"
 	"github.com/portpowered/infinite-you/pkg/runtimehost"
@@ -136,10 +137,10 @@ func ComposeCore(
 		runtimeBundle.Logger,
 		WireModelAssetPuller(cfg, collaborators.LocalModels),
 		factorysessionexecution.NewJavaScriptRuntimeService(factorysessionexecution.JavaScriptRuntimeServiceConfig{
-			ProjectRoot:     durableProjectRoot(cfg.ExecutionBaseDir, cfg.Dir, root.FactoryRootDir),
-			Provider:        cfg.ProviderOverride,
-			PersistSessions: true,
-			Clock:           clock,
+			ProjectRoot: durableProjectRoot(cfg.ExecutionBaseDir, cfg.Dir, root.FactoryRootDir),
+			Provider:    cfg.ProviderOverride,
+			Persistence: durablePersistence(cfg.ExecutionBaseDir, cfg.Dir, root.FactoryRootDir),
+			Clock:       clock,
 		}),
 	), nil
 }
@@ -151,6 +152,12 @@ func durableProjectRoot(executionBaseDir, configuredDir, factoryRootDir string) 
 		}
 	}
 	return ""
+}
+
+func durablePersistence(executionBaseDir, configuredDir, factoryRootDir string) runtimepersist.Store {
+	return runtimepersist.DirectoryStore{Dir: runtimepersist.DirForProjectRoot(
+		durableProjectRoot(executionBaseDir, configuredDir, factoryRootDir),
+	)}
 }
 
 // BuildCore constructs the normalized runtime graph without attaching a transport host.

--- a/pkg/composebridge/core_test.go
+++ b/pkg/composebridge/core_test.go
@@ -2,6 +2,9 @@ package composebridge_test
 
 import (
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
@@ -130,5 +133,51 @@ func TestBuildCore_ComposesCoreForValidFactoryConfig(t *testing.T) {
 	}
 	if err := composebridge.CloseRuntimeBundleSinks(nil, nil); err != nil {
 		t.Fatalf("CloseRuntimeBundleSinks(nil): %v", err)
+	}
+}
+
+func TestBuildCore_ComposesExplicitlyDisabledPersistence(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	factoryfixtures.WriteFactoryJSON(t, dir, factoryfixtures.MinimalFactoryConfig())
+	core, err := composebridge.BuildCore(context.Background(), &runtimehost.Config{
+		Dir:                                     dir,
+		Logger:                                  zap.NewNop(),
+		DurableSessionPersistencePolicy:         factorysessionexecution.PersistencePolicyDisabled,
+		SkipBuiltInRunnerPrerequisiteValidation: true,
+	})
+	if err != nil {
+		t.Fatalf("BuildCore: %v", err)
+	}
+	if core.DurableExecution() == nil {
+		t.Fatal("disabled persistence did not compose in-memory durable execution")
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".you-agent-factory", "durable-sessions")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("disabled persistence path stat error = %v, want not-exist", err)
+	}
+}
+
+func TestBuildCore_RejectsUnavailablePersistenceLocation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	factoryfixtures.WriteFactoryJSON(t, dir, factoryfixtures.MinimalFactoryConfig())
+	blockedRoot := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blockedRoot, []byte("blocked"), 0o600); err != nil {
+		t.Fatalf("write blocked root: %v", err)
+	}
+	core, err := composebridge.BuildCore(context.Background(), &runtimehost.Config{
+		Dir:                                     dir,
+		ExecutionBaseDir:                        blockedRoot,
+		Logger:                                  zap.NewNop(),
+		SkipBuiltInRunnerPrerequisiteValidation: true,
+	})
+	if core != nil {
+		t.Fatal("BuildCore returned a core for unavailable persistence")
+	}
+	var validation *factorysessionexecution.ValidationError
+	if !errors.As(err, &validation) || validation.Field != "persistence" {
+		t.Fatalf("BuildCore error = %#v, want wrapped persistence ValidationError", err)
 	}
 }

--- a/pkg/factorysessionexecution/fake_service_runtime_test.go
+++ b/pkg/factorysessionexecution/fake_service_runtime_test.go
@@ -919,6 +919,7 @@ func testExecutionServiceProviders(t *testing.T) {
 func testExecutionServicePersistenceChoices(t *testing.T) {
 	t.Helper()
 	projectRoot := t.TempDir()
+	testApplicationPersistencePolicies(t, projectRoot)
 	if _, err := NewExecutionService(ExecutionProviderJavaScriptRuntime, ServiceConfig{ProjectRoot: projectRoot}); err == nil {
 		t.Fatal("NewExecutionService(runtime without persistence choice) error = nil, want validation error")
 	}
@@ -950,6 +951,38 @@ func testExecutionServicePersistenceChoices(t *testing.T) {
 		t.Fatal("ProjectPersistence(unavailable root) error = nil, want validation error")
 	} else if validation, ok := err.(*ValidationError); !ok || validation.Field != "persistence" {
 		t.Fatalf("unavailable persistence error = %#v, want persistence ValidationError", err)
+	}
+}
+
+func testApplicationPersistencePolicies(t *testing.T, projectRoot string) {
+	t.Helper()
+	for _, tc := range []struct {
+		name     string
+		policy   PersistencePolicy
+		disabled bool
+	}{
+		{name: "default enabled"},
+		{name: "enabled", policy: PersistencePolicyEnabled},
+		{name: "disabled", policy: PersistencePolicyDisabled, disabled: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			choice, err := PersistenceChoiceForPolicy(tc.policy, projectRoot)
+			if err != nil {
+				t.Fatalf("PersistenceChoiceForPolicy: %v", err)
+			}
+			store, err := choice.resolve()
+			if err != nil {
+				t.Fatalf("resolve policy choice: %v", err)
+			}
+			if (store == nil) != tc.disabled {
+				t.Fatalf("store nil = %t, want disabled = %t", store == nil, tc.disabled)
+			}
+		})
+	}
+	if _, err := PersistenceChoiceForPolicy(PersistencePolicy("invalid"), projectRoot); err == nil {
+		t.Fatal("PersistenceChoiceForPolicy(invalid) error = nil, want validation error")
+	} else if validation, ok := err.(*ValidationError); !ok || validation.Field != "persistence.policy" {
+		t.Fatalf("invalid policy error = %#v, want persistence.policy ValidationError", err)
 	}
 }
 

--- a/pkg/factorysessionexecution/fake_service_runtime_test.go
+++ b/pkg/factorysessionexecution/fake_service_runtime_test.go
@@ -652,8 +652,9 @@ func (c durableFixedClock) Now() time.Time { return c.now }
 
 func TestJavaScriptRuntimeService_StartSync_UsesInjectedClock(t *testing.T) {
 	want := time.Date(2031, time.April, 5, 6, 7, 8, 0, time.FixedZone("offset", -7*60*60))
+	projectRoot := t.TempDir()
 	service := NewJavaScriptRuntimeService(JavaScriptRuntimeServiceConfig{
-		ProjectRoot: t.TempDir(),
+		ProjectRoot: projectRoot,
 		Clock:       durableFixedClock{now: want},
 	})
 
@@ -1093,8 +1094,8 @@ func testNormalizationIdempotencyHashBranches(t *testing.T) {
 func TestPrepareStartAndPersistenceHelpers(t *testing.T) {
 	projectRoot := writeSimpleFinalWorkflowProject(t)
 	service := NewJavaScriptRuntimeService(JavaScriptRuntimeServiceConfig{
-		ProjectRoot:     projectRoot,
-		PersistSessions: true,
+		ProjectRoot: projectRoot,
+		Persistence: runtimepersist.DirectoryStore{Dir: runtimepersist.DirForProjectRoot(projectRoot)},
 	})
 
 	prepared, err := service.prepareStart(StartRequest{
@@ -1139,6 +1140,25 @@ func TestPrepareStartAndPersistenceHelpers(t *testing.T) {
 	}
 	if loaded.result.ResultStatus != ResultStatusFinal {
 		t.Fatalf("loaded result status = %q, want FINAL", loaded.result.ResultStatus)
+	}
+}
+
+func TestJavaScriptRuntimeService_ProjectRootAloneDoesNotEnablePersistence(t *testing.T) {
+	projectRoot := writeSimpleFinalWorkflowProject(t)
+	service := NewJavaScriptRuntimeService(JavaScriptRuntimeServiceConfig{ProjectRoot: projectRoot})
+
+	if _, err := service.StartSync(context.Background(), StartRequest{
+		RequestID: "req-runtime-no-implicit-persistence-001",
+		Source: Source{
+			Kind:         workflowsource.KindWorkflowName,
+			WorkflowName: "simple-final",
+		},
+	}); err != nil {
+		t.Fatalf("StartSync: %v", err)
+	}
+
+	if _, err := os.Stat(runtimepersist.DirForProjectRoot(projectRoot)); !os.IsNotExist(err) {
+		t.Fatalf("durable persistence path stat error = %v, want not exist", err)
 	}
 }
 
@@ -1694,9 +1714,10 @@ func TestPersistAndMetadataNoOpBranches(t *testing.T) {
 		t.Fatalf("persistTerminalSessionState(no dir) = %v, want nil", err)
 	}
 
+	projectRoot := t.TempDir()
 	service := NewJavaScriptRuntimeService(JavaScriptRuntimeServiceConfig{
-		ProjectRoot:     t.TempDir(),
-		PersistSessions: true,
+		ProjectRoot: projectRoot,
+		Persistence: runtimepersist.DirectoryStore{Dir: runtimepersist.DirForProjectRoot(projectRoot)},
 	})
 	if err := service.persistTerminalSessionState(runtimeSessionState{
 		session: SessionReadResult{SessionID: "dur-sess-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", Status: LifecycleStatusRunning},
@@ -2570,7 +2591,7 @@ func TestJavaScriptRuntimeService_ResumeInterruptedSession_PackageLocalCoverage(
 		ProjectRoot:       projectRoot,
 		ChildExecutorMode: ChildExecutorModeLive,
 		Provider:          provider,
-		PersistSessions:   true,
+		Persistence:       runtimepersist.DirectoryStore{Dir: runtimepersist.DirForProjectRoot(projectRoot)},
 	})
 
 	started, err := initial.StartAsync(context.Background(), StartRequest{
@@ -2606,7 +2627,7 @@ func TestJavaScriptRuntimeService_ResumeInterruptedSession_PackageLocalCoverage(
 		ProjectRoot:       projectRoot,
 		ChildExecutorMode: ChildExecutorModeLive,
 		Provider:          provider,
-		PersistSessions:   true,
+		Persistence:       runtimepersist.DirectoryStore{Dir: runtimepersist.DirForProjectRoot(projectRoot)},
 	})
 	resumed, err := resumedService.ResumeInterruptedSession(context.Background(), started.SessionID, ResumeSessionRequest{
 		RequestID: "req-package-resume-resume-001",

--- a/pkg/factorysessionexecution/fake_service_runtime_test.go
+++ b/pkg/factorysessionexecution/fake_service_runtime_test.go
@@ -874,6 +874,7 @@ func TestJavaScriptRuntimeService_StartSync_WaitTimeoutWithoutCancelKeepsSession
 
 func TestExecutionServiceAndHelperNormalization(t *testing.T) {
 	t.Run("execution service providers", testExecutionServiceProviders)
+	t.Run("explicit persistence choices", testExecutionServicePersistenceChoices)
 	t.Run("child executor and smoke provider", testExecutionServiceChildExecutorHelpers)
 	t.Run("source request helpers", testExecutionServiceSourceRequestHelpers)
 }
@@ -890,7 +891,11 @@ func testExecutionServiceProviders(t *testing.T) {
 	}
 
 	projectRoot := t.TempDir()
-	runtimeService, err := NewExecutionService(ExecutionProviderJavaScriptRuntime, ServiceConfig{ProjectRoot: projectRoot})
+	persistence, err := ProjectPersistence(projectRoot)
+	if err != nil {
+		t.Fatalf("ProjectPersistence: %v", err)
+	}
+	runtimeService, err := NewExecutionService(ExecutionProviderJavaScriptRuntime, ServiceConfig{ProjectRoot: projectRoot, Persistence: persistence})
 	if err != nil {
 		t.Fatalf("NewExecutionService(runtime): %v", err)
 	}
@@ -898,8 +903,8 @@ func testExecutionServiceProviders(t *testing.T) {
 	if !ok {
 		t.Fatalf("runtime provider type = %T, want *JavaScriptRuntimeService", runtimeService)
 	}
-	if jsService.sessionPersistDir == "" {
-		t.Fatal("expected runtime service to enable persisted session dir when project root is set")
+	if jsService.persistence == nil {
+		t.Fatal("expected runtime service to use the injected persisted session store")
 	}
 
 	if _, err := NewExecutionService(ExecutionProviderJavaScriptRuntime, ServiceConfig{}); err == nil {
@@ -907,6 +912,43 @@ func testExecutionServiceProviders(t *testing.T) {
 	}
 	if _, err := NewExecutionService(ExecutionProvider("unknown"), ServiceConfig{}); err == nil {
 		t.Fatal("NewExecutionService(unknown) error = nil, want validation error")
+	}
+}
+
+func testExecutionServicePersistenceChoices(t *testing.T) {
+	t.Helper()
+	projectRoot := t.TempDir()
+	if _, err := NewExecutionService(ExecutionProviderJavaScriptRuntime, ServiceConfig{ProjectRoot: projectRoot}); err == nil {
+		t.Fatal("NewExecutionService(runtime without persistence choice) error = nil, want validation error")
+	}
+	disabled, err := NewExecutionService(ExecutionProviderJavaScriptRuntime, ServiceConfig{
+		ProjectRoot: projectRoot,
+		Persistence: DisabledPersistence(),
+	})
+	if err != nil {
+		t.Fatalf("NewExecutionService(runtime with disabled persistence): %v", err)
+	}
+	if disabled.(*JavaScriptRuntimeService).persistence != nil {
+		t.Fatal("disabled persistence unexpectedly configured a store")
+	}
+	contradictory := PersistenceChoice{store: runtimepersist.DirectoryStore{Dir: t.TempDir()}, disabled: true}
+	if _, err := NewExecutionService(ExecutionProviderJavaScriptRuntime, ServiceConfig{
+		ProjectRoot: projectRoot,
+		Persistence: contradictory,
+	}); err == nil {
+		t.Fatal("NewExecutionService(runtime with contradictory persistence) error = nil, want validation error")
+	} else if validation, ok := err.(*ValidationError); !ok || validation.Field != "persistence" {
+		t.Fatalf("contradictory persistence error = %#v, want persistence ValidationError", err)
+	}
+
+	blockedRoot := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blockedRoot, []byte("blocked"), 0o600); err != nil {
+		t.Fatalf("write blocked persistence root: %v", err)
+	}
+	if _, err := ProjectPersistence(blockedRoot); err == nil {
+		t.Fatal("ProjectPersistence(unavailable root) error = nil, want validation error")
+	} else if validation, ok := err.(*ValidationError); !ok || validation.Field != "persistence" {
+		t.Fatalf("unavailable persistence error = %#v, want persistence ValidationError", err)
 	}
 }
 
@@ -1105,7 +1147,7 @@ func newJavaScriptRuntimeService(t *testing.T) *JavaScriptRuntimeService {
 
 	service, err := NewExecutionService(
 		ExecutionProviderJavaScriptRuntime,
-		ServiceConfig{ProjectRoot: t.TempDir()},
+		ServiceConfig{ProjectRoot: t.TempDir(), Persistence: DisabledPersistence()},
 	)
 	if err != nil {
 		t.Fatalf("NewExecutionService: %v", err)

--- a/pkg/factorysessionexecution/fixtures/helpers_test.go
+++ b/pkg/factorysessionexecution/fixtures/helpers_test.go
@@ -11,11 +11,16 @@ import (
 
 	fse "github.com/portpowered/infinite-you/pkg/factorysessionexecution"
 	"github.com/portpowered/infinite-you/pkg/factorysessionexecution/fixtures"
+	"github.com/portpowered/infinite-you/pkg/factorysessionexecution/runtimepersist"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	workflowsource "github.com/portpowered/infinite-you/pkg/orchestrators/javascript/source"
 )
 
 const runtimeEventSource = "runtime-service"
+
+func runtimePersistence(projectRoot string) runtimepersist.Store {
+	return runtimepersist.DirectoryStore{Dir: runtimepersist.DirForProjectRoot(projectRoot)}
+}
 
 func contractFixtureCatalogPath(t *testing.T) string {
 	t.Helper()
@@ -463,6 +468,7 @@ func assertReplayProjectionStable(
 		t.Fatalf("resultStatus drift = %q vs %q", firstResult.ResultStatus, secondResult.ResultStatus)
 	}
 }
+
 type interruptedResumableHarness struct {
 	projectRoot string
 	provider    *sequentialBlockingProvider
@@ -505,7 +511,7 @@ func startInterruptedResumableSessionForWorkflow(
 		ProjectRoot:       projectRoot,
 		ChildExecutorMode: fse.ChildExecutorModeLive,
 		Provider:          provider,
-		PersistSessions:   true,
+		Persistence:       runtimePersistence(projectRoot),
 	})
 
 	started, err := initial.StartAsync(context.Background(), fse.StartRequest{
@@ -559,7 +565,7 @@ func newResumedRuntimeService(harness interruptedResumableHarness) *fse.JavaScri
 		ProjectRoot:       harness.projectRoot,
 		ChildExecutorMode: fse.ChildExecutorModeLive,
 		Provider:          harness.provider,
-		PersistSessions:   true,
+		Persistence:       runtimePersistence(harness.projectRoot),
 	})
 }
 

--- a/pkg/factorysessionexecution/fixtures/runtime_boundary_test.go
+++ b/pkg/factorysessionexecution/fixtures/runtime_boundary_test.go
@@ -349,7 +349,7 @@ func TestJavaScriptRuntimeService_TypedFailures_MissingSessionMissingSourceBadSo
 
 		runtimeService, err := fse.NewExecutionService(
 			fse.ExecutionProviderJavaScriptRuntime,
-			fse.ServiceConfig{ProjectRoot: projectRoot},
+			fse.ServiceConfig{ProjectRoot: projectRoot, Persistence: fse.DisabledPersistence()},
 		)
 		if err != nil {
 			t.Fatalf("NewExecutionService: %v", err)

--- a/pkg/factorysessionexecution/fixtures/runtime_execution_test.go
+++ b/pkg/factorysessionexecution/fixtures/runtime_execution_test.go
@@ -40,7 +40,7 @@ func TestJavaScriptRuntimeService_StartSync_SimpleWorkflowCompletesWithPrimaryRe
 	projectRoot := writeSimpleFinalWorkflowProject(t)
 	service, err := fse.NewExecutionService(
 		fse.ExecutionProviderJavaScriptRuntime,
-		fse.ServiceConfig{ProjectRoot: projectRoot},
+		fse.ServiceConfig{ProjectRoot: projectRoot, Persistence: fse.DisabledPersistence()},
 	)
 	if err != nil {
 		t.Fatalf("NewExecutionService: %v", err)
@@ -408,7 +408,7 @@ func TestNewExecutionService_SelectsFakeAndJavaScriptRuntimeProviders(t *testing
 	projectRoot := t.TempDir()
 	runtimeService, err := fse.NewExecutionService(
 		fse.ExecutionProviderJavaScriptRuntime,
-		fse.ServiceConfig{ProjectRoot: projectRoot},
+		fse.ServiceConfig{ProjectRoot: projectRoot, Persistence: fse.DisabledPersistence()},
 	)
 	if err != nil {
 		t.Fatalf("NewExecutionService(runtime): %v", err)
@@ -462,7 +462,7 @@ func newJavaScriptRuntimeService(t *testing.T) fse.Service {
 	}
 	service, err := fse.NewExecutionService(
 		fse.ExecutionProviderJavaScriptRuntime,
-		fse.ServiceConfig{ProjectRoot: projectRoot},
+		fse.ServiceConfig{ProjectRoot: projectRoot, Persistence: fse.DisabledPersistence()},
 	)
 	if err != nil {
 		t.Fatalf("NewExecutionService: %v", err)

--- a/pkg/factorysessionexecution/fixtures/runtime_record_projection_test.go
+++ b/pkg/factorysessionexecution/fixtures/runtime_record_projection_test.go
@@ -106,8 +106,7 @@ func newJavaScriptRuntimeServiceWithFixture(t *testing.T, fixtureName, workflowN
 	t.Helper()
 	projectRoot := setupRuntimeWorkflowFixture(t, fixtureName, workflowName)
 	return fse.NewJavaScriptRuntimeService(fse.JavaScriptRuntimeServiceConfig{
-		ProjectRoot:     projectRoot,
-		PersistSessions: false,
+		ProjectRoot: projectRoot,
 	})
 }
 

--- a/pkg/factorysessionexecution/fixtures/runtime_restart_resume_test.go
+++ b/pkg/factorysessionexecution/fixtures/runtime_restart_resume_test.go
@@ -281,8 +281,8 @@ func TestJavaScriptRuntimeService_ResumeInterruptedSession_MissingCheckpointRetu
 	})
 
 	service := fse.NewJavaScriptRuntimeService(fse.JavaScriptRuntimeServiceConfig{
-		ProjectRoot:     projectRoot,
-		PersistSessions: true,
+		ProjectRoot: projectRoot,
+		Persistence: runtimePersistence(projectRoot),
 	})
 
 	before, err := service.GetSession(context.Background(), sessionID)
@@ -327,8 +327,8 @@ func TestJavaScriptRuntimeService_ResumeInterruptedSession_CorruptedPersistenceR
 	}
 
 	service := fse.NewJavaScriptRuntimeService(fse.JavaScriptRuntimeServiceConfig{
-		ProjectRoot:     projectRoot,
-		PersistSessions: true,
+		ProjectRoot: projectRoot,
+		Persistence: runtimePersistence(projectRoot),
 	})
 	_, err := service.ResumeInterruptedSession(context.Background(), sessionID, fse.ResumeSessionRequest{
 		RequestID: "req-runtime-resume-corrupted-persistence-001",
@@ -345,8 +345,8 @@ func TestJavaScriptRuntimeService_ResumeInterruptedSession_InvalidCheckpointSumm
 	})
 
 	service := fse.NewJavaScriptRuntimeService(fse.JavaScriptRuntimeServiceConfig{
-		ProjectRoot:     projectRoot,
-		PersistSessions: true,
+		ProjectRoot: projectRoot,
+		Persistence: runtimePersistence(projectRoot),
 	})
 	_, err := service.ResumeInterruptedSession(context.Background(), sessionID, fse.ResumeSessionRequest{
 		RequestID: "req-runtime-resume-invalid-checkpoint-001",
@@ -361,8 +361,8 @@ func TestJavaScriptRuntimeService_ResumeInterruptedSession_NonInterruptedSession
 		"simple-final",
 	)
 	service := fse.NewJavaScriptRuntimeService(fse.JavaScriptRuntimeServiceConfig{
-		ProjectRoot:     projectRoot,
-		PersistSessions: true,
+		ProjectRoot: projectRoot,
+		Persistence: runtimePersistence(projectRoot),
 	})
 	started, err := service.StartSync(context.Background(), fse.StartRequest{
 		RequestID: "req-runtime-resume-non-interrupted-001",
@@ -393,7 +393,7 @@ func seedInterruptedCheckpointedSession(t *testing.T) (string, string) {
 		ProjectRoot:       projectRoot,
 		ChildExecutorMode: fse.ChildExecutorModeLive,
 		Provider:          provider,
-		PersistSessions:   true,
+		Persistence:       runtimePersistence(projectRoot),
 	})
 	started, err := initial.StartAsync(context.Background(), fse.StartRequest{
 		RequestID: "req-runtime-resume-failure-seed-001",
@@ -500,8 +500,8 @@ func waitForPersistedInterruptedSnapshot(t *testing.T, projectRoot, sessionID st
 func TestJavaScriptRuntimeService_NonResumedFakeChild_PreservesShippedTransportSemantics(t *testing.T) {
 	projectRoot := setupRuntimeWorkflowFixture(t, "agent-run-fake-child.workflow.js", "agent-run-fake-child")
 	service := fse.NewJavaScriptRuntimeService(fse.JavaScriptRuntimeServiceConfig{
-		ProjectRoot:     projectRoot,
-		PersistSessions: true,
+		ProjectRoot: projectRoot,
+		Persistence: runtimePersistence(projectRoot),
 	})
 
 	completed, err := service.StartSync(context.Background(), fse.StartRequest{
@@ -558,8 +558,8 @@ func TestJavaScriptRuntimeService_NonResumedFakeChild_PreservesShippedTransportS
 func TestJavaScriptRuntimeService_NonResumedSimpleFinal_PreservesReplayReconnectAndTerminalResult(t *testing.T) {
 	projectRoot := setupRuntimeWorkflowFixture(t, "simple-final.workflow.js", "simple-final")
 	service := fse.NewJavaScriptRuntimeService(fse.JavaScriptRuntimeServiceConfig{
-		ProjectRoot:     projectRoot,
-		PersistSessions: true,
+		ProjectRoot: projectRoot,
+		Persistence: runtimePersistence(projectRoot),
 	})
 
 	completed, err := service.StartSync(context.Background(), fse.StartRequest{
@@ -622,8 +622,8 @@ func TestJavaScriptRuntimeService_NonResumedSimpleFinal_PreservesReplayReconnect
 func TestJavaScriptRuntimeService_NonResumedTerminalSnapshot_OmitsCheckpointSummaryAndReloadsAcrossFreshServices(t *testing.T) {
 	projectRoot := setupRuntimeWorkflowFixture(t, "agent-run-fake-child.workflow.js", "agent-run-fake-child")
 	initial := fse.NewJavaScriptRuntimeService(fse.JavaScriptRuntimeServiceConfig{
-		ProjectRoot:     projectRoot,
-		PersistSessions: true,
+		ProjectRoot: projectRoot,
+		Persistence: runtimePersistence(projectRoot),
 	})
 
 	completed, err := initial.StartSync(context.Background(), fse.StartRequest{
@@ -650,8 +650,8 @@ func TestJavaScriptRuntimeService_NonResumedTerminalSnapshot_OmitsCheckpointSumm
 	}
 
 	reloaded := fse.NewJavaScriptRuntimeService(fse.JavaScriptRuntimeServiceConfig{
-		ProjectRoot:     projectRoot,
-		PersistSessions: true,
+		ProjectRoot: projectRoot,
+		Persistence: runtimePersistence(projectRoot),
 	})
 	read, err := reloaded.GetSession(context.Background(), completed.SessionID)
 	if err != nil {

--- a/pkg/factorysessionexecution/runtime_service.go
+++ b/pkg/factorysessionexecution/runtime_service.go
@@ -200,7 +200,6 @@ type JavaScriptRuntimeServiceConfig struct {
 	ProjectRoot       string
 	ChildExecutorMode string
 	Provider          workers.Provider
-	PersistSessions   bool
 	Persistence       runtimepersist.Store
 	Clock             factory.Clock
 }
@@ -211,7 +210,6 @@ type JavaScriptRuntimeService struct {
 	projectRoot       string
 	childExecutorMode string
 	provider          workers.Provider
-	sessionPersistDir string
 	persistence       runtimepersist.Store
 	clock             factory.Clock
 
@@ -237,12 +235,6 @@ func NewJavaScriptRuntimeService(config JavaScriptRuntimeServiceConfig) *JavaScr
 		startReplay:       make(map[string]startReplayRecord),
 		startInflight:     make(map[string]*startInflightFlight),
 		controlReplay:     make(map[string]controlReplayRecord),
-	}
-	if config.PersistSessions && projectRoot != "" {
-		service.sessionPersistDir = runtimepersist.DirForProjectRoot(projectRoot)
-		if service.persistence == nil {
-			service.persistence = runtimepersist.DirectoryStore{Dir: service.sessionPersistDir}
-		}
 	}
 	return service
 }

--- a/pkg/factorysessionexecution/runtimepersist/store.go
+++ b/pkg/factorysessionexecution/runtimepersist/store.go
@@ -24,6 +24,18 @@ type Store interface {
 // DirectoryStore persists snapshots beneath one explicit directory.
 type DirectoryStore struct{ Dir string }
 
+// NewDirectoryStore validates and initializes an explicit snapshot directory.
+func NewDirectoryStore(dir string) (DirectoryStore, error) {
+	trimmed := strings.TrimSpace(dir)
+	if trimmed == "" {
+		return DirectoryStore{}, errors.New("durable session persistence directory is required")
+	}
+	if err := os.MkdirAll(trimmed, 0o700); err != nil {
+		return DirectoryStore{}, fmt.Errorf("initialize durable session persistence directory: %w", err)
+	}
+	return DirectoryStore{Dir: trimmed}, nil
+}
+
 // Save writes a snapshot to the configured directory.
 func (s DirectoryStore) Save(sessionID string, encoded []byte) error {
 	return SaveBytes(s.Dir, sessionID, encoded)

--- a/pkg/factorysessionexecution/service.go
+++ b/pkg/factorysessionexecution/service.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/portpowered/infinite-you/pkg/factory"
+	"github.com/portpowered/infinite-you/pkg/factorysessionexecution/runtimepersist"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	workflowresult "github.com/portpowered/infinite-you/pkg/orchestrators/javascript/result"
 	workflowruntime "github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime"
@@ -150,8 +151,51 @@ type ServiceConfig struct {
 	ChildExecutorMode string
 	Provider          workers.Provider
 	FakeOptions       []FakeServiceOption
-	PersistSessions   bool
+	Persistence       PersistenceChoice
 	Clock             factory.Clock
+}
+
+// PersistenceChoice makes durable snapshot ownership explicit at composition.
+// Construct it with EnabledPersistence or DisabledPersistence.
+type PersistenceChoice struct {
+	store    runtimepersist.Store
+	disabled bool
+}
+
+// EnabledPersistence selects durable snapshots through the injected store.
+func EnabledPersistence(store runtimepersist.Store) PersistenceChoice {
+	return PersistenceChoice{store: store}
+}
+
+// DisabledPersistence explicitly selects in-memory-only session execution.
+func DisabledPersistence() PersistenceChoice {
+	return PersistenceChoice{disabled: true}
+}
+
+// ProjectPersistence initializes the established project-local snapshot store.
+func ProjectPersistence(projectRoot string) (PersistenceChoice, error) {
+	root := strings.TrimSpace(projectRoot)
+	if root == "" {
+		return PersistenceChoice{}, NewValidationError("persistence.projectRoot", "project root is required for persistence")
+	}
+	store, err := runtimepersist.NewDirectoryStore(runtimepersist.DirForProjectRoot(root))
+	if err != nil {
+		return PersistenceChoice{}, NewValidationError("persistence", "initialize durable session persistence: "+err.Error())
+	}
+	return EnabledPersistence(store), nil
+}
+
+func (choice PersistenceChoice) resolve() (runtimepersist.Store, error) {
+	switch {
+	case choice.disabled && choice.store != nil:
+		return nil, NewValidationError("persistence", "persistence cannot be both enabled and disabled")
+	case choice.disabled:
+		return nil, nil
+	case choice.store == nil:
+		return nil, NewValidationError("persistence", "persistence must be explicitly enabled with a store or disabled")
+	default:
+		return choice.store, nil
+	}
 }
 
 // NewExecutionService constructs one shared Factory Session execution service for
@@ -173,11 +217,15 @@ func NewExecutionService(provider ExecutionProvider, config ServiceConfig) (Serv
 		if err := validateLiveChildExecutorConfig(childExecutorMode, provider); err != nil {
 			return nil, err
 		}
+		persistence, err := config.Persistence.resolve()
+		if err != nil {
+			return nil, err
+		}
 		return NewJavaScriptRuntimeService(JavaScriptRuntimeServiceConfig{
 			ProjectRoot:       projectRoot,
 			ChildExecutorMode: childExecutorMode,
 			Provider:          provider,
-			PersistSessions:   config.PersistSessions || projectRoot != "",
+			Persistence:       persistence,
 			Clock:             config.Clock,
 		}), nil
 	default:

--- a/pkg/factorysessionexecution/service.go
+++ b/pkg/factorysessionexecution/service.go
@@ -162,6 +162,32 @@ type PersistenceChoice struct {
 	disabled bool
 }
 
+// PersistencePolicy is the application-level durable snapshot policy. The
+// zero value preserves production persistence; callers must select Disabled
+// explicitly when durable snapshots are not wanted.
+type PersistencePolicy string
+
+const (
+	PersistencePolicyEnabled  PersistencePolicy = "enabled"
+	PersistencePolicyDisabled PersistencePolicy = "disabled"
+)
+
+// PersistenceChoiceForPolicy resolves application policy into the closed
+// persistence choice consumed by durable execution composition.
+func PersistenceChoiceForPolicy(policy PersistencePolicy, projectRoot string) (PersistenceChoice, error) {
+	switch policy {
+	case "", PersistencePolicyEnabled:
+		return ProjectPersistence(projectRoot)
+	case PersistencePolicyDisabled:
+		return DisabledPersistence(), nil
+	default:
+		return PersistenceChoice{}, NewValidationError(
+			"persistence.policy",
+			fmt.Sprintf("unsupported durable session persistence policy %q", policy),
+		)
+	}
+}
+
 // EnabledPersistence selects durable snapshots through the injected store.
 func EnabledPersistence(store runtimepersist.Store) PersistenceChoice {
 	return PersistenceChoice{store: store}

--- a/pkg/runtimehost/host.go
+++ b/pkg/runtimehost/host.go
@@ -205,6 +205,10 @@ type Config struct {
 	// runtime execution paths such as workstation workingDirectory values.
 	// Empty defaults to the loaded factory directory.
 	ExecutionBaseDir string
+	// DurableSessionPersistencePolicy selects enabled project-local snapshots
+	// or explicitly disabled in-memory-only durable execution. Empty defaults
+	// to enabled for production-facing behavior.
+	DurableSessionPersistencePolicy factorysessionexecution.PersistencePolicy
 	// RuntimeMode controls whether the runtime exits on idle completion or
 	// stays alive until its context is canceled. Empty defaults to batch mode.
 	RuntimeMode interfaces.RuntimeMode

--- a/pkg/service/factory.go
+++ b/pkg/service/factory.go
@@ -19,6 +19,7 @@ import (
 	factoryservice "github.com/portpowered/infinite-you/pkg/factory/service"
 	"github.com/portpowered/infinite-you/pkg/factory/state"
 	"github.com/portpowered/infinite-you/pkg/factorysessionexecution"
+	"github.com/portpowered/infinite-you/pkg/factorysessionexecution/runtimepersist"
 	"github.com/portpowered/infinite-you/pkg/factorysessions"
 	"github.com/portpowered/infinite-you/pkg/hostedworkers"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
@@ -137,6 +138,12 @@ func composedDurableProjectRoot(executionBaseDir, configuredDir, factoryRootDir 
 		}
 	}
 	return ""
+}
+
+func composedDurablePersistence(executionBaseDir, configuredDir, factoryRootDir string) runtimepersist.Store {
+	return runtimepersist.DirectoryStore{Dir: runtimepersist.DirForProjectRoot(
+		composedDurableProjectRoot(executionBaseDir, configuredDir, factoryRootDir),
+	)}
 }
 
 var _ factory.APIFactory = (*FactoryService)(nil)

--- a/pkg/service/factory.go
+++ b/pkg/service/factory.go
@@ -19,7 +19,6 @@ import (
 	factoryservice "github.com/portpowered/infinite-you/pkg/factory/service"
 	"github.com/portpowered/infinite-you/pkg/factory/state"
 	"github.com/portpowered/infinite-you/pkg/factorysessionexecution"
-	"github.com/portpowered/infinite-you/pkg/factorysessionexecution/runtimepersist"
 	"github.com/portpowered/infinite-you/pkg/factorysessions"
 	"github.com/portpowered/infinite-you/pkg/hostedworkers"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
@@ -140,10 +139,28 @@ func composedDurableProjectRoot(executionBaseDir, configuredDir, factoryRootDir 
 	return ""
 }
 
-func composedDurablePersistence(executionBaseDir, configuredDir, factoryRootDir string) runtimepersist.Store {
-	return runtimepersist.DirectoryStore{Dir: runtimepersist.DirForProjectRoot(
-		composedDurableProjectRoot(executionBaseDir, configuredDir, factoryRootDir),
-	)}
+func composeDurableExecution(
+	cfg *FactoryServiceConfig,
+	root FactoryServiceRoot,
+	clock factory.Clock,
+) (factorysessionexecution.Service, error) {
+	projectRoot := composedDurableProjectRoot(cfg.ExecutionBaseDir, cfg.Dir, root.FactoryRootDir)
+	persistence, err := factorysessionexecution.PersistenceChoiceForPolicy(
+		cfg.DurableSessionPersistencePolicy,
+		projectRoot,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("compose durable session persistence: %w", err)
+	}
+	return factorysessionexecution.NewExecutionService(
+		factorysessionexecution.ExecutionProviderJavaScriptRuntime,
+		factorysessionexecution.ServiceConfig{
+			ProjectRoot: projectRoot,
+			Provider:    cfg.ProviderOverride,
+			Persistence: persistence,
+			Clock:       clock,
+		},
+	)
 }
 
 var _ factory.APIFactory = (*FactoryService)(nil)
@@ -192,6 +209,10 @@ type FactoryServiceConfig struct {
 	// runtime execution paths such as workstation workingDirectory values.
 	// Empty defaults to the loaded factory directory.
 	ExecutionBaseDir string
+	// DurableSessionPersistencePolicy selects enabled project-local snapshots
+	// or explicitly disabled in-memory-only durable execution. Empty defaults
+	// to enabled for production-facing behavior.
+	DurableSessionPersistencePolicy factorysessionexecution.PersistencePolicy
 	// RuntimeMode controls whether the runtime exits on idle completion or
 	// stays alive until its context is canceled. Empty defaults to batch mode.
 	RuntimeMode interfaces.RuntimeMode

--- a/pkg/service/factory_editable_definition.go
+++ b/pkg/service/factory_editable_definition.go
@@ -962,10 +962,10 @@ func ComposeFactoryCore(
 		modelAssets:   wireModelAssetPuller(cfg, collaborators.LocalModels.Assets),
 		durableExecution: factorysessionexecution.NewJavaScriptRuntimeService(
 			factorysessionexecution.JavaScriptRuntimeServiceConfig{
-				ProjectRoot:     composedDurableProjectRoot(cfg.ExecutionBaseDir, cfg.Dir, root.FactoryRootDir),
-				Provider:        cfg.ProviderOverride,
-				PersistSessions: true,
-				Clock:           clock,
+				ProjectRoot: composedDurableProjectRoot(cfg.ExecutionBaseDir, cfg.Dir, root.FactoryRootDir),
+				Provider:    cfg.ProviderOverride,
+				Persistence: composedDurablePersistence(cfg.ExecutionBaseDir, cfg.Dir, root.FactoryRootDir),
+				Clock:       clock,
 			},
 		),
 	}, nil

--- a/pkg/service/factory_editable_definition.go
+++ b/pkg/service/factory_editable_definition.go
@@ -910,6 +910,10 @@ func ComposeFactoryCore(
 		}
 		cfg.Dir = resolvedDir
 	}
+	durableExecution, err := composeDurableExecution(cfg, root, clock)
+	if err != nil {
+		return nil, err
+	}
 
 	replaySideEffects, replayFactoryOpts, err := replayFactoryModeOptions(load.ReplayArtifact)
 	if err != nil {
@@ -952,22 +956,15 @@ func ComposeFactoryCore(
 
 	coreBuilt = true
 	return &FactoryCore{
-		cfg:           cfg,
-		root:          root,
-		collaborators: collaborators,
-		hostedWorkers: hostedWorkers,
-		clock:         clock,
-		startupBundle: runtimeBundle,
-		logger:        runtimeBundle.Logger,
-		modelAssets:   wireModelAssetPuller(cfg, collaborators.LocalModels.Assets),
-		durableExecution: factorysessionexecution.NewJavaScriptRuntimeService(
-			factorysessionexecution.JavaScriptRuntimeServiceConfig{
-				ProjectRoot: composedDurableProjectRoot(cfg.ExecutionBaseDir, cfg.Dir, root.FactoryRootDir),
-				Provider:    cfg.ProviderOverride,
-				Persistence: composedDurablePersistence(cfg.ExecutionBaseDir, cfg.Dir, root.FactoryRootDir),
-				Clock:       clock,
-			},
-		),
+		cfg:              cfg,
+		root:             root,
+		collaborators:    collaborators,
+		hostedWorkers:    hostedWorkers,
+		clock:            clock,
+		startupBundle:    runtimeBundle,
+		logger:           runtimeBundle.Logger,
+		modelAssets:      wireModelAssetPuller(cfg, collaborators.LocalModels.Assets),
+		durableExecution: durableExecution,
 	}, nil
 }
 

--- a/pkg/service/runtime_session_runtime_test.go
+++ b/pkg/service/runtime_session_runtime_test.go
@@ -2148,7 +2148,7 @@ func newFactoryServiceForDurableLifecycleTest(t *testing.T, fixtureName, workflo
 	projectRoot := setupDurableLifecycleWorkflowFixture(t, fixtureName, workflowName)
 	execution, err := factorysessionexecution.NewExecutionService(
 		factorysessionexecution.ExecutionProviderJavaScriptRuntime,
-		factorysessionexecution.ServiceConfig{ProjectRoot: projectRoot},
+		factorysessionexecution.ServiceConfig{ProjectRoot: projectRoot, Persistence: factorysessionexecution.DisabledPersistence()},
 	)
 	if err != nil {
 		t.Fatalf("compose durable execution: %v", err)


### PR DESCRIPTION
{
  "project": "Compose Durable JavaScript Session Persistence Explicitly",
  "branchName": "runtime-cleanup-durable-persistence-composition",
  "description": "Make durable JavaScript Factory Session persistence an explicit application-composition dependency by injecting either a store at the established project-local location or an explicit disabled policy, while preserving persisted start/read, restart/resume, deterministic runtime selection, injected clocks, and transport behavior.",
  "context": {
    "customerAsk": "Complete the remaining Phase 3 durable-execution composition gap by making JavaScript Factory Session persistence an explicit application dependency. Production composition must resolve and inject either a persistence store rooted at the existing project-local durable-session path or an explicit disabled-persistence policy while preserving restart/resume behavior, facade equivalence, deterministic fake/live selection, injected clocks, and public behavior.",
    "problem": "Production composition still expresses JavaScript session persistence as PersistSessions: true, allowing NewJavaScriptRuntimeService to derive a project-local directory and construct filesystem persistence internally. This hides an operational dependency, weakens composition ownership, and prevents invalid or unavailable storage from failing at the boundary that owns configuration.",
    "solution": "Represent persistence as an explicit store-enabled or disabled choice, construct and validate the existing project-local directory store at application composition, inject it into the single durable collaborator shared by FactoryService and runtimehost.Host, route runtime persistence only through the injected store, and enforce the ownership boundary mechanically."
  },
  "acceptanceCriteria": [
    "Every production JavaScript durable-execution graph injects either a configured store at the existing project-local durable-session location or an explicit disabled-persistence policy; no persistence boolean triggers runtime-owned store derivation",
    "Enabled persistence preserves durable start/read and application-reconstruction/resume behavior without changing session identity, checkpoint progress, completed-work execution, terminal results, stored path, or snapshot compatibility",
    "Disabled persistence keeps in-memory execution usable, writes no durable snapshot, and never silently enables persistence",
    "Invalid or unavailable persistence configuration fails at the earliest fallible composition boundary with a typed, actionable, payload-safe error",
    "FactoryService and runtimehost.Host return equivalent persistence outcomes through the same durable collaborator while fake/live selection, injected clocks, and public transport contracts remain unchanged",
    "A mechanical boundary check rejects implicit production persistence construction while allowing package-local tests and the approved deterministic harness",
    "Typecheck, lint, focused factorysessionexecution/service/runtimehost/composebridge/composition tests, the persistence boundary check, and verify-fast when warranted all pass"
  ],
  "userStories": [
    {
      "id": "runtime-cleanup-durable-persistence-composition-001",
      "title": "Express persistence as an explicit composition choice",
      "description": "As an application composer, I want to supply either a durable-session store or an explicit disabled policy so that runtime persistence behavior cannot be inferred from a boolean or project root.",
      "acceptanceCriteria": [
        "Durable execution composition accepts exactly one intentional persistence choice: an injected store or disabled persistence",
        "Missing, contradictory, or invalid persistence choices return a typed validation error at a fallible construction boundary instead of silently selecting a store or disabled mode",
        "The enabled choice can be created for the established project-local durable-session location, while the disabled choice performs no filesystem initialization",
        "Fake/JavaScript execution selection, provider selection, child-executor mode, logger, and injected clock remain independent explicit inputs and retain their existing outcomes",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "runtime-cleanup-durable-persistence-composition-002",
      "title": "Preserve persisted runtime behavior through the injected store",
      "description": "As a customer running durable JavaScript Factory Sessions, I want injected persistence to preserve session snapshots and restart/resume behavior so that explicit composition does not change recovery semantics.",
      "acceptanceCriteria": [
        "The JavaScript runtime saves and loads durable session state only through the injected store and does not derive a directory or construct a filesystem store from ProjectRoot or a persistence boolean",
        "A session started with persistence enabled can be read through the original runtime and through a newly constructed runtime using a store for the same project-local location",
        "Restart/resume preserves the durable session ID, completed dispatch/checkpoint progress, lifecycle state, and terminal result behavior without rerunning already completed work",
        "Existing snapshots at the established project-local durable-session path remain readable without migration or path changes",
        "Store read/write failures retain typed runtime outcomes and actionable operation context without leaking workflow payloads",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "runtime-cleanup-durable-persistence-composition-003",
      "title": "Compose enabled and disabled persistence across production facades",
      "description": "As a CLI, API, or MCP caller, I want production composition to inject the same persistence-configured durable collaborator into both compatibility facades so that all transports observe equivalent recovery behavior.",
      "acceptanceCriteria": [
        "Production composition resolves the current project-local durable-session path, constructs the store once, and injects it through the shared durable execution collaborator used by FactoryService and runtimehost.Host",
        "If the configured persistence location is invalid or unavailable where composition can validate it, composition returns a typed, actionable error and does not start with an in-memory fallback",
        "With persistence enabled, representative start/read and application-reconstruction/resume flows return equivalent session, lifecycle, checkpoint, and result outcomes through FactoryService and runtimehost.Host",
        "With persistence disabled, representative starts remain available during that runtime, produce no persisted snapshot, and cannot be recovered by a reconstructed runtime unless persistence is separately supplied with existing data",
        "Deterministic fake/live selection and JavaScript timestamps from the injected clock remain equivalent through both facades",
        "Existing CLI, API, and MCP request/response shapes, status/error mappings, commands, routes, and tools remain unchanged",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "runtime-cleanup-durable-persistence-composition-004",
      "title": "Enforce explicit persistence ownership and regression evidence",
      "description": "As a maintainer, I want automated enforcement and focused behavioral verification so that production runtime code cannot reintroduce hidden persistence-store construction.",
      "acceptanceCriteria": [
        "The durable-runtime boundary check rejects production code that passes a persistence boolean, derives a durable-session persistence root inside runtime construction, or directly constructs the persistence store outside the approved application composition owner",
        "The check permits package-local runtime tests and the approved deterministic transport test harness to construct stores or runtimes explicitly",
        "Checker fixtures prove prohibited implicit production construction is rejected and approved composition/test ownership is accepted without asserting inventories of routes, commands, registrations, tests, or source files",
        "Focused factorysessionexecution, service, runtimehost, composebridge, and composition tests directly cover enabled persistence, disabled persistence, invalid/unavailable configuration, restart/resume, cross-facade equivalence, fake/live selection, and injected-clock behavior",
        "The relevant static check is included in the pull-request lint path, and verify-fast passes when shared composition changes warrant it",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}
