### PR TITLE
projection-replay-parity

### DIFF
--- a/pkg/factorysessionexecution/fake_service_test.go
+++ b/pkg/factorysessionexecution/fake_service_test.go
@@ -1308,6 +1308,111 @@ func TestReplaySessionProjection_IgnoresUnknownEventTypes(t *testing.T) {
 	}
 }
 
+func TestReplaySessionProjection_EquivalentOrchestratorsSharePublicSessionProjection(t *testing.T) {
+	startedAt := time.Date(2026, 7, 11, 18, 30, 0, 0, time.UTC)
+	sessionID := "dur-sess-orchestrator-parity-001"
+	baseSession := SessionReadResult{
+		SessionID:      sessionID,
+		Status:         LifecycleStatusRunning,
+		SourceHash:     "sha256:equivalent-source",
+		Policy:         PolicyProjection{EffectiveHash: "sha256:equivalent-policy"},
+		ResolvedSource: ResolvedSource{SourceHash: "sha256:equivalent-source"},
+		Lifecycle:      &LifecycleTimestamps{StartedAt: &startedAt},
+		Phase:          "execute",
+	}
+	result := ResultReadResult{SessionID: sessionID, ResultStatus: ResultStatusNotReady}
+
+	petriSession := baseSession
+	petriSession.OrchestratorKind = "PETRI"
+	petriEvents := BuildCanonicalRuntimeSessionEvents(petriSession, result)
+	petriPayload := factoryapi.DispatchRequestEventPayload{
+		Inputs:       []factoryapi.DispatchConsumedWorkRef{},
+		TransitionId: "transition-review",
+	}
+	petriEvents = append(petriEvents, canonicalTypedInternalEvent(t, "DISPATCH_REQUEST", sessionID, petriPayload))
+
+	javascriptSession := baseSession
+	javascriptSession.OrchestratorKind = "JAVASCRIPT"
+	javascriptSession.Dialect = "you-workflow-v1"
+	javascriptEvents := BuildCanonicalRuntimeSessionEvents(javascriptSession, result)
+	javascriptPayload := factoryapi.OrchestratorCheckpointWrittenEventPayload{
+		Label:              "after-review",
+		ResumabilityStatus: factoryapi.RESUMABLE,
+		Timestamp:          &startedAt,
+	}
+	javascriptEvents = append(javascriptEvents, canonicalTypedInternalEvent(t, "ORCHESTRATOR_CHECKPOINT_WRITTEN", sessionID, javascriptPayload))
+
+	petriProjection, _, err := ReplaySessionProjection(petriEvents)
+	if err != nil {
+		t.Fatalf("ReplaySessionProjection(PETRI): %v", err)
+	}
+	javascriptProjection, _, err := ReplaySessionProjection(javascriptEvents)
+	if err != nil {
+		t.Fatalf("ReplaySessionProjection(JAVASCRIPT): %v", err)
+	}
+
+	type sharedPublicSession struct {
+		SessionID     string
+		Status        LifecycleStatus
+		SourceHash    string
+		PolicyHash    string
+		Phase         string
+		StartedAt     time.Time
+		ResultStatus  string
+		ArtifactCount int
+		Links         InspectionLinks
+	}
+	sharedProjection := func(session SessionReadResult) sharedPublicSession {
+		t.Helper()
+		if session.Lifecycle == nil || session.Lifecycle.StartedAt == nil {
+			t.Fatalf("lifecycle = %#v, want startedAt", session.Lifecycle)
+		}
+		if session.ResultSummary == nil {
+			t.Fatal("resultSummary missing")
+		}
+		return sharedPublicSession{
+			SessionID:     session.SessionID,
+			Status:        session.Status,
+			SourceHash:    session.SourceHash,
+			PolicyHash:    session.Policy.EffectiveHash,
+			Phase:         session.Phase,
+			StartedAt:     session.Lifecycle.StartedAt.UTC(),
+			ResultStatus:  session.ResultSummary.ResultStatus,
+			ArtifactCount: session.ArtifactCount,
+			Links:         session.Links,
+		}
+	}
+	petriPublic := sharedProjection(petriProjection)
+	javascriptPublic := sharedProjection(javascriptProjection)
+	if petriPublic != javascriptPublic {
+		t.Fatalf("shared public session projection differs by orchestrator:\nPETRI: %#v\nJAVASCRIPT: %#v", petriPublic, javascriptPublic)
+	}
+	if petriProjection.OrchestratorKind != "PETRI" || javascriptProjection.OrchestratorKind != "JAVASCRIPT" {
+		t.Fatalf("orchestrator identity lost: PETRI=%q JAVASCRIPT=%q", petriProjection.OrchestratorKind, javascriptProjection.OrchestratorKind)
+	}
+	if petriPayload.TransitionId == "" || javascriptPayload.Label == "" {
+		t.Fatal("typed orchestrator-specific facts missing")
+	}
+}
+
+func canonicalTypedInternalEvent(t *testing.T, eventType, sessionID string, payload any) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{
+		"schemaVersion": canonicalFactoryEventSchemaVersion,
+		"id":            "internal/" + eventType,
+		"type":          eventType,
+		"context": map[string]any{
+			"sequence":  99,
+			"sessionId": sessionID,
+		},
+		"payload": payload,
+	})
+	if err != nil {
+		t.Fatalf("marshal %s event: %v", eventType, err)
+	}
+	return raw
+}
+
 func TestAppendDispatchInterruptedEvent_RecordsCanonicalMetadata(t *testing.T) {
 	startedAt := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
 	session := SessionReadResult{

--- a/pkg/factorysessionexecution/fake_service_test.go
+++ b/pkg/factorysessionexecution/fake_service_test.go
@@ -1531,6 +1531,100 @@ func TestReplaySessionProjection_EquivalentOrchestratorsRestoreArtifactsAndLates
 	}
 }
 
+func TestReplaySessionProjection_EquivalentOrchestratorsPreserveResultAvailability(t *testing.T) {
+	startedAt := time.Date(2026, 7, 11, 22, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name             string
+		sessionStatus    LifecycleStatus
+		resultStatus     ResultStatus
+		primaryResult    json.RawMessage
+		precedingPartial bool
+	}{
+		{
+			name:          "partial result without terminal result",
+			sessionStatus: LifecycleStatusRunning,
+			resultStatus:  ResultStatusPartial,
+			primaryResult: json.RawMessage(`[{"type":"text","text":"partial output"}]`),
+		},
+		{
+			name:          "terminal result",
+			sessionStatus: LifecycleStatusSucceeded,
+			resultStatus:  ResultStatusFinal,
+			primaryResult: json.RawMessage(`[{"type":"text","text":"final output"}]`),
+		},
+		{
+			name:             "terminal result supersedes partial result",
+			sessionStatus:    LifecycleStatusSucceeded,
+			resultStatus:     ResultStatusFinal,
+			primaryResult:    json.RawMessage(`[{"type":"text","text":"final output after partial"}]`),
+			precedingPartial: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var sharedResult *ResultReadResult
+			for _, orchestratorKind := range []string{"PETRI", "JAVASCRIPT"} {
+				sessionID := "result-parity-" + strings.ToLower(orchestratorKind)
+				session := SessionReadResult{
+					SessionID:        sessionID,
+					Status:           test.sessionStatus,
+					OrchestratorKind: orchestratorKind,
+					Lifecycle:        &LifecycleTimestamps{StartedAt: &startedAt},
+				}
+				if IsTerminalLifecycleStatus(test.sessionStatus) {
+					finishedAt := startedAt.Add(time.Minute)
+					session.Lifecycle.FinishedAt = &finishedAt
+				}
+				live := ResultReadResult{
+					SessionID:     sessionID,
+					SessionStatus: test.sessionStatus,
+					ResultStatus:  test.resultStatus,
+					PrimaryResult: test.primaryResult,
+				}
+				events := BuildCanonicalRuntimeSessionEvents(session, live)
+				if test.precedingPartial {
+					partialEvent := canonicalTypedInternalEvent(t, "SESSION_RESULT_UPDATED", sessionID, map[string]any{
+						"resultStatus":  "PARTIAL",
+						"resultSummary": []map[string]any{{"type": "text", "text": "earlier partial output"}},
+					})
+					events = append(events[:1], append([]json.RawMessage{partialEvent}, events[1:]...)...)
+				}
+
+				replayedSession, replayedResult, err := ReplaySessionProjection(events)
+				if err != nil {
+					t.Fatalf("ReplaySessionProjection(%s): %v", orchestratorKind, err)
+				}
+				if replayedResult.ResultStatus != test.resultStatus || replayedResult.SessionStatus != test.sessionStatus {
+					t.Fatalf("%s result availability = (%q, %q), want (%q, %q)", orchestratorKind, replayedResult.ResultStatus, replayedResult.SessionStatus, test.resultStatus, test.sessionStatus)
+				}
+				if !jsonEqual(replayedResult.PrimaryResult, test.primaryResult) {
+					t.Fatalf("%s primary result = %s, want %s", orchestratorKind, replayedResult.PrimaryResult, test.primaryResult)
+				}
+				if replayedSession.ResultSummary == nil || replayedSession.ResultSummary.ResultStatus != string(test.resultStatus) {
+					t.Fatalf("%s session result summary = %#v, want %q", orchestratorKind, replayedSession.ResultSummary, test.resultStatus)
+				}
+
+				comparable := replayedResult
+				comparable.SessionID = ""
+				if sharedResult == nil {
+					sharedResult = &comparable
+				} else if !reflect.DeepEqual(*sharedResult, comparable) {
+					t.Fatalf("shared result projection differs by orchestrator:\nfirst: %#v\n%s: %#v", *sharedResult, orchestratorKind, comparable)
+				}
+			}
+		})
+	}
+}
+
+func jsonEqual(left, right json.RawMessage) bool {
+	var leftValue any
+	var rightValue any
+	return json.Unmarshal(left, &leftValue) == nil &&
+		json.Unmarshal(right, &rightValue) == nil &&
+		reflect.DeepEqual(leftValue, rightValue)
+}
+
 func canonicalTypedInternalEvent(t *testing.T, eventType, sessionID string, payload any) json.RawMessage {
 	t.Helper()
 	raw, err := json.Marshal(map[string]any{

--- a/pkg/factorysessionexecution/fake_service_test.go
+++ b/pkg/factorysessionexecution/fake_service_test.go
@@ -1466,6 +1466,71 @@ func TestReplayDispatchProjection_EquivalentOrchestratorsPreserveAbsentProviderS
 	}
 }
 
+func TestReplaySessionProjection_EquivalentOrchestratorsRestoreArtifactsAndLatestLifecycle(t *testing.T) {
+	startedAt := time.Date(2026, 7, 11, 21, 0, 0, 0, time.UTC)
+	pausedAt := startedAt.Add(time.Minute)
+	resumedAt := pausedAt.Add(time.Minute)
+	artifact := map[string]any{
+		"id":          "artifact-parity-1",
+		"kind":        "FINAL_RESULT",
+		"visibility":  "PUBLIC",
+		"contentHash": "sha256:artifact-parity",
+		"sizeBytes":   128,
+	}
+
+	for _, orchestratorKind := range []string{"PETRI", "JAVASCRIPT"} {
+		t.Run(orchestratorKind, func(t *testing.T) {
+			sessionID := "artifact-parity-" + strings.ToLower(orchestratorKind)
+			session := SessionReadResult{
+				SessionID:        sessionID,
+				Status:           LifecycleStatusRunning,
+				OrchestratorKind: orchestratorKind,
+				Lifecycle: &LifecycleTimestamps{
+					StartedAt: &startedAt,
+					PausedAt:  &pausedAt,
+					ResumedAt: &resumedAt,
+				},
+			}
+			events := BuildCanonicalRuntimeSessionEvents(session, ResultReadResult{
+				SessionID:    sessionID,
+				ResultStatus: ResultStatusPartial,
+				ArtifactIDs:  []string{"artifact-parity-1"},
+			})
+			artifactEvent := canonicalTypedInternalEvent(t, "ARTIFACT_CREATED", sessionID, map[string]any{
+				"artifact":   artifact,
+				"capturedAt": resumedAt.Format(time.RFC3339),
+			})
+			var artifactEnvelope map[string]any
+			if err := json.Unmarshal(artifactEvent, &artifactEnvelope); err != nil {
+				t.Fatalf("unmarshal artifact envelope: %v", err)
+			}
+			context := artifactEnvelope["context"].(map[string]any)
+			context["orchestratorKind"] = orchestratorKind
+			artifactEvent, _ = json.Marshal(artifactEnvelope)
+
+			internalType := "DISPATCH_REQUESTED"
+			internalPayload := map[string]any{"transitionId": "transition-1"}
+			if orchestratorKind == "JAVASCRIPT" {
+				internalType = "ORCHESTRATOR_CHECKPOINT_WRITTEN"
+				internalPayload = map[string]any{"checkpointId": "checkpoint-1"}
+			}
+			events = append(events, artifactEvent, canonicalTypedInternalEvent(t, internalType, sessionID, internalPayload))
+
+			replayed, _, err := ReplaySessionProjection(events)
+			if err != nil {
+				t.Fatalf("ReplaySessionProjection: %v", err)
+			}
+			wantRef := ArtifactRefSummary{ID: "artifact-parity-1", Kind: "FINAL_RESULT", Visibility: "PUBLIC", ContentHash: "sha256:artifact-parity", SizeBytes: 128}
+			if replayed.ArtifactCount != 1 || !reflect.DeepEqual(replayed.ArtifactRefs, []ArtifactRefSummary{wantRef}) {
+				t.Fatalf("artifact projection = count %d refs %#v, want %#v", replayed.ArtifactCount, replayed.ArtifactRefs, wantRef)
+			}
+			if replayed.Status != LifecycleStatusRunning || replayed.Lifecycle == nil || !replayed.Lifecycle.ResumedAt.Equal(resumedAt) {
+				t.Fatalf("lifecycle = status %q timestamps %#v, want latest RUNNING at %s", replayed.Status, replayed.Lifecycle, resumedAt)
+			}
+		})
+	}
+}
+
 func canonicalTypedInternalEvent(t *testing.T, eventType, sessionID string, payload any) json.RawMessage {
 	t.Helper()
 	raw, err := json.Marshal(map[string]any{

--- a/pkg/factorysessionexecution/fake_service_test.go
+++ b/pkg/factorysessionexecution/fake_service_test.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"errors"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1392,6 +1394,75 @@ func TestReplaySessionProjection_EquivalentOrchestratorsSharePublicSessionProjec
 	}
 	if petriPayload.TransitionId == "" || javascriptPayload.Label == "" {
 		t.Fatal("typed orchestrator-specific facts missing")
+	}
+}
+
+func TestReplayDispatchProjection_EquivalentOrchestratorsMatchLiveDispatchSummary(t *testing.T) {
+	startedAt := time.Date(2026, 7, 11, 20, 0, 0, 0, time.UTC)
+	providerRef := ProviderSessionRef{Provider: "mock", Kind: "session_id", ID: "provider-session-parity-1"}
+
+	for _, orchestratorKind := range []string{"PETRI", "JAVASCRIPT"} {
+		t.Run(orchestratorKind, func(t *testing.T) {
+			session := SessionReadResult{
+				SessionID:        "dispatch-parity-" + strings.ToLower(orchestratorKind),
+				Status:           LifecycleStatusSucceeded,
+				OrchestratorKind: orchestratorKind,
+				Phase:            "execute",
+				Lifecycle:        &LifecycleTimestamps{StartedAt: &startedAt},
+			}
+			live := DispatchSummary{
+				ID:                  "dispatch-equivalent-1",
+				Status:              DispatchStatusCompleted,
+				DispatchKind:        "AGENT",
+				Phase:               "execute",
+				Label:               "summarize findings",
+				RunnerID:            "worker-summary",
+				Model:               "mock-model",
+				Provider:            "mock",
+				ProviderSessionRefs: []ProviderSessionRef{providerRef},
+				OutputArtifactIDs:   []string{"artifact-equivalent-1"},
+			}
+			events := BuildCanonicalRuntimeSessionEvents(
+				session,
+				ResultReadResult{SessionID: session.SessionID, ResultStatus: ResultStatusFinal},
+				RuntimeDispatchEventInput{Dispatches: []DispatchSummary{live}},
+			)
+
+			replayed, err := ReplayDispatchProjection(events)
+			if err != nil {
+				t.Fatalf("ReplayDispatchProjection: %v", err)
+			}
+			if len(replayed) != 1 || !reflect.DeepEqual(replayed[0], live) {
+				t.Fatalf("replayed dispatch = %#v, want live projection %#v", replayed, live)
+			}
+		})
+	}
+}
+
+func TestReplayDispatchProjection_EquivalentOrchestratorsPreserveAbsentProviderSession(t *testing.T) {
+	startedAt := time.Date(2026, 7, 11, 20, 5, 0, 0, time.UTC)
+	for _, orchestratorKind := range []string{"PETRI", "JAVASCRIPT"} {
+		t.Run(orchestratorKind, func(t *testing.T) {
+			session := SessionReadResult{
+				SessionID:        "dispatch-no-provider-" + strings.ToLower(orchestratorKind),
+				Status:           LifecycleStatusFailed,
+				OrchestratorKind: orchestratorKind,
+				Lifecycle:        &LifecycleTimestamps{StartedAt: &startedAt},
+			}
+			live := DispatchSummary{ID: "dispatch-no-provider", Status: DispatchStatusFailed, DispatchKind: "AGENT"}
+			events := BuildCanonicalRuntimeSessionEvents(
+				session,
+				ResultReadResult{SessionID: session.SessionID, ResultStatus: ResultStatusUnavailable},
+				RuntimeDispatchEventInput{Dispatches: []DispatchSummary{live}},
+			)
+			replayed, err := ReplayDispatchProjection(events)
+			if err != nil {
+				t.Fatalf("ReplayDispatchProjection: %v", err)
+			}
+			if len(replayed) != 1 || len(replayed[0].ProviderSessionRefs) != 0 {
+				t.Fatalf("replayed dispatch = %#v, want absent provider session refs", replayed)
+			}
+		})
 	}
 }
 

--- a/pkg/factorysessionexecution/lifecycle.go
+++ b/pkg/factorysessionexecution/lifecycle.go
@@ -463,11 +463,61 @@ func applyDispatchProjectionEvent(dispatches map[string]DispatchSummary, raw jso
 		return fmt.Errorf("unmarshal event envelope: %w", err)
 	}
 	switch strings.TrimSpace(envelope.Type) {
+	case "DISPATCH_QUEUED":
+		return applyDispatchQueuedProjection(dispatches, envelope)
+	case "DISPATCH_RECONCILED":
+		return applyDispatchReconciledProjection(dispatches, envelope)
 	case "DISPATCH_INTERRUPTED":
 		return applyDispatchInterruptedProjection(dispatches, envelope)
 	default:
 		return nil
 	}
+}
+
+func applyDispatchQueuedProjection(dispatches map[string]DispatchSummary, envelope canonicalFactoryEvent) error {
+	dispatchID := stringValuePtr(envelope.Context.DispatchID)
+	if dispatchID == "" {
+		return fmt.Errorf("DISPATCH_QUEUED missing dispatchId")
+	}
+	var payload dispatchQueuedEventPayload
+	if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
+		return fmt.Errorf("unmarshal DISPATCH_QUEUED payload: %w", err)
+	}
+	dispatches[dispatchID] = DispatchSummary{
+		ID:           dispatchID,
+		Status:       DispatchStatusQueued,
+		DispatchKind: strings.TrimSpace(payload.DispatchKind),
+		Phase:        stringValuePtr(envelope.Context.PhaseID),
+		Label:        strings.TrimSpace(payload.Label),
+		RunnerID:     strings.TrimSpace(payload.RunnerID),
+		Model:        strings.TrimSpace(payload.Model),
+		Provider:     strings.TrimSpace(payload.Provider),
+	}
+	return nil
+}
+
+func applyDispatchReconciledProjection(dispatches map[string]DispatchSummary, envelope canonicalFactoryEvent) error {
+	dispatchID := stringValuePtr(envelope.Context.DispatchID)
+	if dispatchID == "" {
+		return fmt.Errorf("DISPATCH_RECONCILED missing dispatchId")
+	}
+	var payload dispatchReconciledEventPayload
+	if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
+		return fmt.Errorf("unmarshal DISPATCH_RECONCILED payload: %w", err)
+	}
+	dispatch := dispatches[dispatchID]
+	dispatch.ID = dispatchID
+	dispatch.Status = DispatchStatus(strings.TrimSpace(payload.ReconciledStatus))
+	dispatch.ProviderSessionRefs = cloneProviderSessionRefs(payload.ProviderSessionRefs)
+	dispatch.OutputArtifactIDs = append([]string(nil), payload.ArtifactIDs...)
+	if payload.FailureDetail != nil {
+		dispatch.FailureDetail = &DispatchFailureDetail{
+			Reason:  strings.TrimSpace(payload.FailureDetail.Reason),
+			Message: strings.TrimSpace(payload.FailureDetail.Message),
+		}
+	}
+	dispatches[dispatchID] = dispatch
+	return nil
 }
 
 func applyDispatchInterruptedProjection(dispatches map[string]DispatchSummary, envelope canonicalFactoryEvent) error {

--- a/pkg/factorysessionexecution/listing.go
+++ b/pkg/factorysessionexecution/listing.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/portpowered/infinite-you/pkg/interfaces"
 	workflowsource "github.com/portpowered/infinite-you/pkg/orchestrators/javascript/source"
 )
 
@@ -594,7 +595,9 @@ func canonicalSessionResultUpdatedPayload(session SessionReadResult, result Resu
 	payload := map[string]any{
 		"resultStatus": string(result.ResultStatus),
 	}
-	if session.ResultSummary != nil {
+	if primaryResult := canonicalPrimaryResultPayload(result.PrimaryResult); primaryResult != nil {
+		payload["resultSummary"] = primaryResult
+	} else if session.ResultSummary != nil {
 		if summary := strings.TrimSpace(session.ResultSummary.Summary); summary != "" {
 			payload["resultSummary"] = []map[string]any{
 				{"type": "text", "text": summary},
@@ -608,6 +611,17 @@ func canonicalSessionResultUpdatedPayload(session SessionReadResult, result Resu
 		payload["availability"] = availability
 	}
 	return payload
+}
+
+func canonicalPrimaryResultPayload(primaryResult json.RawMessage) any {
+	if len(primaryResult) == 0 {
+		return nil
+	}
+	var payload []interfaces.WorkContentPart
+	if err := json.Unmarshal(primaryResult, &payload); err != nil || payload == nil {
+		return nil
+	}
+	return append(json.RawMessage(nil), primaryResult...)
 }
 
 func canonicalResultAvailabilityPayload(availability *ResultAvailabilityDetail) map[string]any {

--- a/pkg/factorysessionexecution/prepare_start.go
+++ b/pkg/factorysessionexecution/prepare_start.go
@@ -385,6 +385,7 @@ type dispatchReconciledEventPayload struct {
 	ReconciledStatus     string                       `json:"reconciledStatus"`
 	ReconciliationSource string                       `json:"reconciliationSource"`
 	Replayed             bool                         `json:"replayed"`
+	ProviderSessionRefs  []ProviderSessionRef         `json:"providerSessionRefs,omitempty"`
 	ArtifactIDs          []string                     `json:"artifactIds,omitempty"`
 	FailureDetail        *dispatchFailureEventPayload `json:"failureDetail,omitempty"`
 }
@@ -477,6 +478,9 @@ func buildDispatchReconciledEvent(
 		ReconciledStatus:     string(dispatch.Status),
 		ReconciliationSource: dispatchReconciliationSource(dispatch),
 		Replayed:             false,
+	}
+	if len(dispatch.ProviderSessionRefs) > 0 {
+		payload.ProviderSessionRefs = cloneProviderSessionRefs(dispatch.ProviderSessionRefs)
 	}
 	if len(dispatch.OutputArtifactIDs) > 0 {
 		payload.ArtifactIDs = append([]string(nil), dispatch.OutputArtifactIDs...)

--- a/pkg/factorysessionexecution/projection_consistency.go
+++ b/pkg/factorysessionexecution/projection_consistency.go
@@ -499,6 +499,9 @@ func (r *sessionProjectionReducer) applySessionResultUpdated(envelope canonicalF
 	}
 	r.mergeSessionIdentity(envelope.Context)
 	r.applyResultStatus(payload.ResultStatus, summaryTextFromWorkContent(payload.ResultSummary))
+	if len(payload.ResultSummary) > 0 {
+		r.result.PrimaryResult = append(json.RawMessage(nil), payload.ResultSummary...)
+	}
 	r.replaceArtifactStubs(payload.ArtifactIDs)
 	if payload.Availability != nil {
 		r.resultAvailability = &ResultAvailabilityDetail{
@@ -697,6 +700,7 @@ func (r *sessionProjectionReducer) finalize() {
 	r.result = ResultReadResult{
 		SessionID:     r.session.SessionID,
 		SessionStatus: r.session.Status,
+		PrimaryResult: append(json.RawMessage(nil), r.result.PrimaryResult...),
 		ArtifactIDs:   artifactIDsFromRefSummaries(r.session.ArtifactRefs),
 	}
 	if r.session.ResultSummary != nil {

--- a/pkg/factorysessionexecution/projection_consistency.go
+++ b/pkg/factorysessionexecution/projection_consistency.go
@@ -379,6 +379,8 @@ func (r *sessionProjectionReducer) apply(raw json.RawMessage) error {
 		return r.applySessionLifecycleControl(envelope)
 	case "SESSION_COMPLETED":
 		return r.applySessionCompleted(envelope)
+	case "ARTIFACT_CREATED":
+		return r.applyArtifactCreated(envelope)
 	default:
 		return nil
 	}
@@ -590,6 +592,34 @@ func (r *sessionProjectionReducer) applySessionCompleted(envelope canonicalFacto
 	return nil
 }
 
+func (r *sessionProjectionReducer) applyArtifactCreated(envelope canonicalFactoryEvent) error {
+	var payload struct {
+		Artifact struct {
+			ID          string `json:"id"`
+			Kind        string `json:"kind"`
+			Visibility  string `json:"visibility"`
+			ContentHash string `json:"contentHash"`
+			SizeBytes   int64  `json:"sizeBytes"`
+		} `json:"artifact"`
+	}
+	if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
+		return fmt.Errorf("unmarshal ARTIFACT_CREATED payload: %w", err)
+	}
+	artifactID := strings.TrimSpace(payload.Artifact.ID)
+	if artifactID == "" {
+		return fmt.Errorf("ARTIFACT_CREATED missing artifact id")
+	}
+	r.mergeSessionIdentity(envelope.Context)
+	r.upsertArtifactRef(ArtifactRefSummary{
+		ID:          artifactID,
+		Kind:        strings.TrimSpace(payload.Artifact.Kind),
+		Visibility:  strings.TrimSpace(payload.Artifact.Visibility),
+		ContentHash: strings.TrimSpace(payload.Artifact.ContentHash),
+		SizeBytes:   payload.Artifact.SizeBytes,
+	})
+	return nil
+}
+
 func (r *sessionProjectionReducer) mergeSessionIdentity(context canonicalFactoryEventContext) {
 	if sessionID := stringValuePtr(context.SessionID); sessionID != "" && r.session.SessionID == "" {
 		r.session.SessionID = sessionID
@@ -626,11 +656,30 @@ func (r *sessionProjectionReducer) replaceArtifactStubs(artifactIDs []string) {
 	refs := make([]ArtifactRefSummary, 0, len(artifactIDs))
 	for _, artifactID := range artifactIDs {
 		if id := strings.TrimSpace(artifactID); id != "" {
-			refs = append(refs, ArtifactRefSummary{ID: id})
+			ref := ArtifactRefSummary{ID: id}
+			for _, existing := range r.session.ArtifactRefs {
+				if existing.ID == id {
+					ref = existing
+					break
+				}
+			}
+			refs = append(refs, ref)
 		}
 	}
 	r.session.ArtifactRefs = refs
 	r.session.ArtifactCount = len(refs)
+}
+
+func (r *sessionProjectionReducer) upsertArtifactRef(ref ArtifactRefSummary) {
+	for index := range r.session.ArtifactRefs {
+		if r.session.ArtifactRefs[index].ID == ref.ID {
+			r.session.ArtifactRefs[index] = ref
+			r.session.ArtifactCount = len(r.session.ArtifactRefs)
+			return
+		}
+	}
+	r.session.ArtifactRefs = append(r.session.ArtifactRefs, ref)
+	r.session.ArtifactCount = len(r.session.ArtifactRefs)
 }
 
 func (r *sessionProjectionReducer) finalize() {


### PR DESCRIPTION
{
  "project": "Projection and Replay Parity Across Orchestrators",
  "branchName": "projection-replay-parity",
  "description": "Prove that equivalent Petri and JavaScript execution facts reconstruct the same public Factory Session, Dispatch, Provider Session, artifact, lifecycle, and result views during live projection and persisted replay while orchestrator-specific internal facts remain typed and separate.",
  "context": {
    "customerAsk": "Add projection and replay evidence that equivalent Petri and JavaScript facts reconstruct the same public Factory Session, Dispatch, Provider Session, artifact, lifecycle, and result views. Keep orchestrator-specific internal facts typed and separate.",
    "problem": "Equivalent execution facts can be recorded differently by Petri and JavaScript orchestration, and existing evidence does not fully prove that live projection and persisted replay restore identical dashboard-facing summaries, Provider Session lineage, artifacts, lifecycle state, and partial or final result availability.",
    "solution": "Create paired Petri and JavaScript event histories for equivalent public facts, reduce and replay them through canonical Factory Session ownership, compare the shared public read models, and preserve Petri-only transition facts and JavaScript-only checkpoint facts as separate typed internals."
  },
  "acceptanceCriteria": [
    "Projection and persisted replay regressions exercise both Petri and JavaScript orchestrator kinds with equivalent shared facts.",
    "Replay reconstructs the same public Factory Session and Dispatch summaries produced by live reduction, including Provider Session references.",
    "Replay preserves artifact references, lifecycle status, and partial or final result availability for both orchestrator kinds.",
    "Equivalent facts produce orchestrator-independent dashboard-facing public shapes while Petri-only transition facts and JavaScript-only checkpoint facts remain separately typed.",
    "The work remains limited to event recording, projection, replay, and directly affected public mappings without unrelated runtime cleanup or a new public runtime noun.",
    "Quality gate: typecheck, lint, go test ./pkg/factory/... ./pkg/factorysessionexecution/... ./pkg/replay/..., and focused API/UI projection tests when mappings change all pass."
  ],
  "userStories": [
    {
      "id": "projection-replay-parity-001",
      "title": "Project equivalent shared facts into one public session shape",
      "description": "As a dashboard and API consumer, I want equivalent Petri and JavaScript execution facts to produce the same public Factory Session shape so that inspection does not depend on the internal orchestration model.",
      "acceptanceCriteria": [
        "Paired Petri and JavaScript histories representing the same session start and shared execution facts project equivalent public Factory Session identity, semantically shared timestamps, and current summary fields.",
        "Shared public event and projection fields use the canonical Factory Session vocabulary and shape for both histories.",
        "Petri transition details and JavaScript checkpoint details remain separately typed internal facts and are not flattened into a fabricated shared fact.",
        "A projection regression fails if an equivalent shared fact requires an orchestrator-specific dashboard-facing field or produces a different public value.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "projection-replay-parity-002",
      "title": "Restore dispatch summaries and Provider Session references on replay",
      "description": "As an operator inspecting a reconstructed Factory Session, I want dispatch summaries and their Provider Session references restored after replay so that provider-backed work remains traceable after restart or historical loading.",
      "acceptanceCriteria": [
        "Persisted Petri and JavaScript histories containing equivalent dispatch start and completion facts replay into equivalent public Dispatch summaries.",
        "Each replayed Dispatch retains the Provider Session reference associated with the recorded provider-backed execution.",
        "Dispatch identity, status, workstation or worker association when present, and completion summary match the corresponding live projection for each orchestrator.",
        "Missing optional Provider Session data remains absent in the same public form for both orchestrators and does not cause replay failure or a fabricated reference.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "projection-replay-parity-003",
      "title": "Restore artifacts and lifecycle status on replay",
      "description": "As an operator reopening a Factory Session, I want its artifacts and lifecycle status reconstructed from history so that inspection reflects the same state and recorded outputs seen before reconstruction.",
      "acceptanceCriteria": [
        "Equivalent Petri and JavaScript artifact facts replay into equivalent public artifact references, including stable identity, kind, and availability metadata carried by the canonical contract.",
        "Accepted lifecycle facts replay into the same current public lifecycle status as live reduction for both orchestrator kinds.",
        "A later lifecycle fact supersedes an earlier status consistently for Petri and JavaScript histories.",
        "Orchestrator-specific internal facts interleaved with shared artifact or lifecycle facts do not erase, duplicate, or reorder the public artifact and lifecycle views.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "projection-replay-parity-004",
      "title": "Preserve partial and final result availability across replay",
      "description": "As a caller waiting for or inspecting Factory Session output, I want replay to preserve whether a partial or final result is available so that reconstructed sessions expose the same usable result state as live sessions.",
      "acceptanceCriteria": [
        "A history with a partial result and no terminal result replays as partial-result-available without incorrectly reporting a final result for either orchestrator.",
        "A history with a terminal result replays with equivalent final-result availability and lifecycle outcome for Petri and JavaScript execution.",
        "When a final result follows partial results, replay selects the same public result state and availability reported by live reduction without losing partial lineage required by the contract.",
        "Focused public mapping tests prove affected API or UI projections consume the shared result fields without branching on orchestrator kind when those mappings change.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}
