### PR TITLE
provider-failure-obsolete-path-cleanup

### DIFF
--- a/pkg/workers/executor_compat_test.go
+++ b/pkg/workers/executor_compat_test.go
@@ -2,6 +2,8 @@ package workers
 
 import (
 	"context"
+	"errors"
+	"reflect"
 	"testing"
 	"time"
 
@@ -28,6 +30,33 @@ func TestRunnerFromProviderUsesProviderInference(t *testing.T) {
 	}
 	if result.Content != provider.response.Content {
 		t.Fatalf("runner returned content %q, want %q", result.Content, provider.response.Content)
+	}
+}
+
+func TestRunnerFromProviderPreservesProviderFailureAndRequest(t *testing.T) {
+	providerErr := errors.New("canonical provider failure")
+	provider := &stubProvider{err: providerErr}
+	request := interfaces.RunnerExecutionRequest{
+		SystemPrompt:     "system",
+		UserMessage:      "user",
+		ModelProvider:    string(interfaces.ModelProviderCursor),
+		Model:            "cursor-model",
+		WorkingDirectory: "/tmp/runtime-worktree",
+		SessionID:        "session-1",
+	}
+
+	result, err := RunnerFromProvider(provider).Execute(context.Background(), request)
+	if !errors.Is(err, providerErr) {
+		t.Fatalf("runner error = %v, want provider error %v", err, providerErr)
+	}
+	if provider.calls != 1 {
+		t.Fatalf("provider calls = %d, want 1", provider.calls)
+	}
+	if !reflect.DeepEqual(provider.lastRequest, request) {
+		t.Fatalf("provider request = %#v, want %#v", provider.lastRequest, request)
+	}
+	if !reflect.DeepEqual(result, (interfaces.RunnerExecutionResult{})) {
+		t.Fatalf("runner result = %#v, want zero result on provider failure", result)
 	}
 }
 
@@ -152,11 +181,14 @@ var _ Runner = stubRunner{}
 type stubProvider struct {
 	lastRequest interfaces.ProviderInferenceRequest
 	response    interfaces.InferenceResponse
+	err         error
+	calls       int
 }
 
 func (s *stubProvider) Infer(_ context.Context, req interfaces.ProviderInferenceRequest) (interfaces.InferenceResponse, error) {
+	s.calls++
 	s.lastRequest = req
-	return s.response, nil
+	return s.response, s.err
 }
 
 type stubWorkerExecutor struct {

--- a/pkg/workers/provider/inference_provider.go
+++ b/pkg/workers/provider/inference_provider.go
@@ -261,7 +261,8 @@ func buildProviderEnv(envVars map[string]string) []string {
 //--------
 
 func normalizeProviderExecutionError(provider string, result CommandResult, err error, session *interfaces.ProviderSessionMetadata, diagnostics *interfaces.WorkDiagnostics) *ProviderError {
-	if provider == string(interfaces.ModelProviderCursor) {
+	normalizedProvider := strings.ToLower(strings.TrimSpace(provider))
+	if normalizedProvider == string(interfaces.ModelProviderCursor) {
 		fallbackReason := interfaces.WorkFailureTypeUnknown
 		switch {
 		case isProviderExecutionTimeout(err, result):
@@ -425,10 +426,21 @@ func providerOutputContainsTimeout(result CommandResult) bool {
 }
 
 func parseProviderTimeoutFailure(provider string, result CommandResult) ProviderFailureResult {
-	behavior := providerBehaviorForErrorClassification(strings.ToLower(strings.TrimSpace(provider)))
+	normalizedProvider := strings.ToLower(strings.TrimSpace(provider))
+	message := formatProviderOutputOrDefault(result, "execution timeout")
+	switch normalizedProvider {
+	case string(interfaces.ModelProviderCodex):
+		if codexError, ok := extractCodexErrorLine(result); ok {
+			message = codexError
+		}
+	case string(interfaces.ModelProviderGemini):
+		message = geminiTimeoutFailureMessage
+	case string(interfaces.ModelProviderKiro):
+		message = kiroTimeoutFailureMessage
+	}
 	return ProviderFailureResult{
 		Reason:  interfaces.WorkFailureTypeTimeout,
-		Message: behavior.FormatTimeoutFailure(result),
+		Message: message,
 	}
 }
 

--- a/pkg/workers/provider/inference_provider.go
+++ b/pkg/workers/provider/inference_provider.go
@@ -260,10 +260,6 @@ func buildProviderEnv(envVars map[string]string) []string {
 //Failed     process              14:03:20   14:06:29   3m8s     prd-endpoint-state-panels prd-endpoint-state-panels provider error: codex exited with code 4294967295: stderr: OpenAI Codex v0.118.0 (research preview)
 //--------
 
-func formatProviderExitFailure(provider string, result CommandResult) string {
-	return providerBehaviorForErrorClassification(provider).FormatExitFailure(provider, result)
-}
-
 func normalizeProviderExecutionError(provider string, result CommandResult, err error, session *interfaces.ProviderSessionMetadata, diagnostics *interfaces.WorkDiagnostics) *ProviderError {
 	if provider == string(interfaces.ModelProviderCursor) {
 		fallbackReason := interfaces.WorkFailureTypeUnknown
@@ -288,8 +284,12 @@ func normalizeProviderExecutionError(provider string, result CommandResult, err 
 		if diagnostics != nil && diagnostics.Command != nil {
 			diagnostics.Command.TimedOut = true
 		}
-		message := formatProviderTimeoutFailure(provider, result)
-		return newProviderErrorWithDiagnostics(interfaces.WorkFailureTypeTimeout, message, err, session, diagnostics)
+		return newProviderErrorFromResultWithDiagnostics(
+			parseProviderTimeoutFailure(provider, result),
+			err,
+			session,
+			diagnostics,
+		)
 	case errors.Is(err, exec.ErrNotFound):
 		message := formatProviderCommandFailure(provider, result, err)
 		return newProviderErrorWithDiagnostics(interfaces.WorkFailureTypeMisconfigured, message, err, session, diagnostics)
@@ -304,46 +304,63 @@ func normalizeProviderExecutionError(provider string, result CommandResult, err 
 }
 
 func normalizeProviderExitFailure(provider string, result CommandResult, session *interfaces.ProviderSessionMetadata, diagnostics *interfaces.WorkDiagnostics) *ProviderError {
+	parsed := parseProviderExitFailure(provider, result)
+	if parsed.providerSession != nil {
+		session = parsed.providerSession
+	}
+	return newProviderErrorFromResultWithDiagnostics(parsed.failure, nil, session, diagnostics)
+}
+
+type parsedProviderFailure struct {
+	failure         ProviderFailureResult
+	providerSession *interfaces.ProviderSessionMetadata
+}
+
+func parseProviderExitFailure(provider string, result CommandResult) parsedProviderFailure {
 	normalizedProvider := strings.ToLower(strings.TrimSpace(provider))
 	switch normalizedProvider {
 	case string(interfaces.ModelProviderClaude):
-		return newProviderErrorFromResultWithDiagnostics(ParseClaudeProviderFailure(result), nil, session, diagnostics)
+		return parsedProviderFailure{failure: ParseClaudeProviderFailure(result)}
 	case string(interfaces.ModelProviderCodex):
-		return newProviderErrorFromResultWithDiagnostics(
-			ParseCodexProviderFailure(result),
-			nil,
-			session,
-			diagnostics,
-		)
+		return parsedProviderFailure{failure: ParseCodexProviderFailure(result)}
 	case string(interfaces.ModelProviderKiro):
-		return newProviderErrorFromResultWithDiagnostics(
-			ParseKiroProviderFailure(result),
-			nil,
-			session,
-			diagnostics,
-		)
+		return parsedProviderFailure{failure: ParseKiroProviderFailure(result)}
 	case string(interfaces.ModelProviderOpenCode):
-		return newProviderErrorFromResultWithDiagnostics(
-			ParseOpenCodeProviderFailure(result),
-			nil,
-			session,
-			diagnostics,
-		)
+		return parsedProviderFailure{failure: ParseOpenCodeProviderFailure(result)}
+	case string(interfaces.ModelProviderGemini):
+		return parsedProviderFailure{failure: ParseGeminiProviderFailure(result)}
+	case string(interfaces.ModelProviderCursor):
+		failure := cursorpkg.ParseProviderFailure(cursorpkg.FailureInput{
+			Stdout: result.Stdout, Stderr: result.Stderr, ExitCode: result.ExitCode,
+		})
+		return parsedProviderFailure{
+			failure:         ProviderFailureResult{Reason: failure.Reason, Message: failure.Message},
+			providerSession: failure.ProviderSession,
+		}
+	default:
+		return parsedProviderFailure{failure: parseUnknownProviderFailure(normalizedProvider, result)}
 	}
-	if provider == string(interfaces.ModelProviderGemini) {
-		return newProviderErrorFromResultWithDiagnostics(
-			ParseGeminiProviderFailure(result),
-			nil,
-			session,
-			diagnostics,
-		)
+}
+
+func parseUnknownProviderFailure(provider string, result CommandResult) ProviderFailureResult {
+	normalizedOutput := strings.ToLower(formatCombinedProviderOutput(result))
+	reason := interfaces.WorkFailureTypeUnknown
+	switch {
+	case containsAny(normalizedOutput, "api key", "authentication", "unauthorized", "forbidden", "login required", "not authenticated"):
+		reason = interfaces.WorkFailureTypeAuthFailure
+	case containsAny(normalizedOutput, "invalid argument", "bad request", "invalid request"):
+		reason = interfaces.WorkFailureTypePermanentBadRequest
+	case containsAny(normalizedOutput, "rate limit", "too many requests", "resource exhausted", "429"):
+		reason = interfaces.WorkFailureTypeThrottled
+	case containsAny(normalizedOutput, "internal server error", "unexpected status 500", "unexpected status 502", "unexpected status 503", "unexpected status 504"):
+		reason = interfaces.WorkFailureTypeInternalServerError
+	case result.ExitCode == 124 || containsAny(normalizedOutput, "deadline exceeded", "timed out", "timeout"):
+		reason = interfaces.WorkFailureTypeTimeout
 	}
-	if provider == string(interfaces.ModelProviderCursor) {
-		return cursorProviderError(result, "", "", nil, session, diagnostics)
+	return ProviderFailureResult{
+		Reason:  reason,
+		Message: formatProviderOutputOrDefault(result, fmt.Sprintf("%s exited with code %d", provider, result.ExitCode)),
 	}
-	message := formatProviderExitFailure(provider, result)
-	errorType := classifyProviderExitFailure(provider, result)
-	return newProviderErrorWithDiagnostics(errorType, message, nil, session, diagnostics)
 }
 
 func cursorProviderError(
@@ -378,10 +395,6 @@ func NormalizeProviderExitFailure(provider string, result CommandResult, session
 	return normalizeProviderExitFailure(provider, result, session, diagnostics)
 }
 
-func classifyProviderExitFailure(provider string, result CommandResult) interfaces.WorkFailureType {
-	return providerBehaviorForErrorClassification(provider).ClassifyExitFailure(result)
-}
-
 func isProviderExecutionTimeout(err error, result CommandResult) bool {
 	if errors.Is(err, context.DeadlineExceeded) {
 		return true
@@ -411,8 +424,12 @@ func providerOutputContainsTimeout(result CommandResult) bool {
 	)
 }
 
-func formatProviderTimeoutFailure(provider string, result CommandResult) string {
-	return providerBehaviorForErrorClassification(provider).FormatTimeoutFailure(result)
+func parseProviderTimeoutFailure(provider string, result CommandResult) ProviderFailureResult {
+	behavior := providerBehaviorForErrorClassification(strings.ToLower(strings.TrimSpace(provider)))
+	return ProviderFailureResult{
+		Reason:  interfaces.WorkFailureTypeTimeout,
+		Message: behavior.FormatTimeoutFailure(result),
+	}
 }
 
 func cursorFailureLogFields(req interfaces.RunnerExecutionRequest, cursorProvider bool, result CommandResult, extra ...any) []any {

--- a/pkg/workers/provider/inference_provider_exit_failure_test.go
+++ b/pkg/workers/provider/inference_provider_exit_failure_test.go
@@ -25,6 +25,46 @@ func TestScriptWrapProvider_Infer_GenericNonCodexExitFailuresPreserveMessageAndC
 	}
 }
 
+func TestScriptWrapProvider_Infer_NormalizedIdentitySelectsOneCanonicalFailureResult(t *testing.T) {
+	testCases := []struct {
+		provider    string
+		result      CommandResult
+		runErr      error
+		wantReason  interfaces.WorkFailureType
+		wantFamily  interfaces.WorkFailureFamily
+		wantMessage string
+	}{
+		{
+			provider:    "  GEMINI  ",
+			result:      CommandResult{ExitCode: 1, Stderr: []byte(`{"error":{"status":"RESOURCE_EXHAUSTED","message":"private quota details"}}`)},
+			wantReason:  interfaces.WorkFailureTypeThrottled,
+			wantFamily:  interfaces.WorkFailureFamilyThrottle,
+			wantMessage: geminiThrottleFailureMessage,
+		},
+		{
+			provider:    "  GEMINI  ",
+			result:      CommandResult{Stderr: []byte("private timeout transcript")},
+			runErr:      context.DeadlineExceeded,
+			wantReason:  interfaces.WorkFailureTypeTimeout,
+			wantFamily:  interfaces.WorkFailureFamilyRetryable,
+			wantMessage: geminiTimeoutFailureMessage,
+		},
+	}
+
+	for _, tc := range testCases {
+		provider := NewScriptWrapProvider(WithProviderCommandRunner(&recordingProviderExec{result: tc.result, err: tc.runErr}))
+		_, err := provider.Infer(context.Background(), interfaces.ProviderInferenceRequest{ModelProvider: tc.provider, UserMessage: "private prompt"})
+		assertNormalizedProviderFailure(t, err, normalizedProviderFailureExpectation{
+			wantType:          tc.wantReason,
+			wantFamily:        tc.wantFamily,
+			wantMessage:       tc.wantMessage,
+			wantRetryable:     tc.wantReason == interfaces.WorkFailureTypeTimeout || tc.wantReason == interfaces.WorkFailureTypeThrottled,
+			wantTerminal:      tc.wantReason == interfaces.WorkFailureTypeUnknown,
+			wantThrottlePause: tc.wantReason == interfaces.WorkFailureTypeThrottled,
+		})
+	}
+}
+
 func TestScriptWrapProvider_Infer_CursorAndCodexExitFailuresKeepCodexDerivedBehavior(t *testing.T) {
 	for _, tc := range codexDerivedExitFailureTestCases() {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/workers/provider/inference_provider_exit_failure_test.go
+++ b/pkg/workers/provider/inference_provider_exit_failure_test.go
@@ -65,8 +65,8 @@ func TestScriptWrapProvider_Infer_NormalizedIdentitySelectsOneCanonicalFailureRe
 	}
 }
 
-func TestScriptWrapProvider_Infer_CursorAndCodexExitFailuresKeepCodexDerivedBehavior(t *testing.T) {
-	for _, tc := range codexDerivedExitFailureTestCases() {
+func TestScriptWrapProvider_Infer_CursorAndCodexUseProviderOwnedFailureParsers(t *testing.T) {
+	for _, tc := range providerOwnedCursorAndCodexFailureTestCases() {
 		t.Run(tc.name, func(t *testing.T) {
 			assertInferenceExitFailure(t, tc)
 		})
@@ -358,25 +358,6 @@ func genericNonCodexExitFailureTestCases() []exitFailureInferenceTestCase {
 			)},
 			wantMessage: "Authentication required. Run opencode auth login.",
 			wantType:    interfaces.WorkFailureTypeAuthFailure,
-		},
-	}
-}
-
-func codexDerivedExitFailureTestCases() []exitFailureInferenceTestCase {
-	return []exitFailureInferenceTestCase{
-		{
-			name:        "CursorUsesCodexErrorExtraction",
-			provider:    string(interfaces.ModelProviderCursor),
-			result:      CommandResult{ExitCode: 1, Stderr: []byte("noise before\nERROR: unexpected status 500 from cursor upstream")},
-			wantMessage: "ERROR: unexpected status 500 from cursor upstream",
-			wantType:    interfaces.WorkFailureTypeInternalServerError,
-		},
-		{
-			name:        "CodexUsesCodexErrorExtraction",
-			provider:    string(interfaces.ModelProviderCodex),
-			result:      CommandResult{ExitCode: 1, Stderr: []byte("noise before\nERROR: unexpected status 500 from codex upstream")},
-			wantMessage: codexServerFailureMessage,
-			wantType:    interfaces.WorkFailureTypeInternalServerError,
 		},
 	}
 }

--- a/pkg/workers/provider/provider_behavior.go
+++ b/pkg/workers/provider/provider_behavior.go
@@ -21,30 +21,6 @@ const (
 
 const codexHighDemandTemporaryErrorsNeedle = "we're currently experiencing high demand, which may cause temporary errors."
 
-var codexThrottledFailureNeedles = []string{
-	"rate limit",
-	"too many requests",
-	"429",
-	"throttl",
-	"at capacity",
-	"model capacity",
-	"try a different model",
-	"usage limit",
-}
-
-var codexTemporaryServerFailureNeedles = []string{
-	"unexpected status 500",
-	"unexpected status 502",
-	"unexpected status 503",
-	"unexpected status 504",
-	"server_error",
-	"internal server error",
-	"overloaded",
-	"server had an error",
-	"connection reset by peer",
-	codexHighDemandTemporaryErrorsNeedle,
-}
-
 // ProviderBuildContext carries dispatch-scoped resources for provider argument building.
 type ProviderBuildContext struct {
 	ContentCache    *materialize.DispatchCache
@@ -54,9 +30,6 @@ type ProviderBuildContext struct {
 type providerBehavior interface {
 	BuildArgs(ctx context.Context, req interfaces.ProviderInferenceRequest, skipPermissions bool, buildCtx *ProviderBuildContext) ([]string, error)
 	BuildCommandRequest(req interfaces.ProviderInferenceRequest, args []string) CommandRequest
-	FormatExitFailure(provider string, result CommandResult) string
-	ClassifyExitFailure(result CommandResult) interfaces.WorkFailureType
-	FormatTimeoutFailure(result CommandResult) string
 }
 
 type sharedNonCodexProviderBehavior struct{}
@@ -106,51 +79,8 @@ func providerBehaviorFor(provider string, logger logging.Logger) providerBehavio
 	}
 }
 
-func providerBehaviorForErrorClassification(provider string) providerBehavior {
-	switch provider {
-	case string(interfaces.ModelProviderClaude):
-		return claudeProviderBehavior{}
-	case string(interfaces.ModelProviderGemini):
-		return geminiProviderBehavior{}
-	case string(interfaces.ModelProviderKiro):
-		return kiroProviderBehavior{}
-	case string(interfaces.ModelProviderCursor):
-		return cursorProviderBehavior{}
-	case string(interfaces.ModelProviderOpenCode):
-		return openCodeProviderBehavior{}
-	default:
-		return codexProviderBehavior{}
-	}
-}
-
 func (sharedNonCodexProviderBehavior) BuildCommandRequest(req interfaces.ProviderInferenceRequest, args []string) CommandRequest {
 	return buildBaseProviderCommandRequest(req, args)
-}
-
-func (sharedNonCodexProviderBehavior) FormatTimeoutFailure(result CommandResult) string {
-	return formatProviderOutputOrDefault(result, "execution timeout")
-}
-
-func (sharedNonCodexProviderBehavior) FormatExitFailure(provider string, result CommandResult) string {
-	return formatProviderOutputOrDefault(result, fmt.Sprintf("%s exited with code %d", provider, result.ExitCode))
-}
-
-func (sharedNonCodexProviderBehavior) ClassifyExitFailure(result CommandResult) interfaces.WorkFailureType {
-	normalizedOutput := strings.ToLower(formatCombinedProviderOutput(result))
-	switch {
-	case containsAny(normalizedOutput, "api key", "authentication", "unauthorized", "forbidden", "login required", "not authenticated"):
-		return interfaces.WorkFailureTypeAuthFailure
-	case containsAny(normalizedOutput, "invalid argument", "bad request", "invalid request"):
-		return interfaces.WorkFailureTypePermanentBadRequest
-	case containsAny(normalizedOutput, "rate limit", "too many requests", "resource exhausted", "429"):
-		return interfaces.WorkFailureTypeThrottled
-	case containsAny(normalizedOutput, "internal server error", "unexpected status 500", "unexpected status 502", "unexpected status 503", "unexpected status 504"):
-		return interfaces.WorkFailureTypeInternalServerError
-	case result.ExitCode == 124 || containsAny(normalizedOutput, "deadline exceeded", "timed out", "timeout"):
-		return interfaces.WorkFailureTypeTimeout
-	default:
-		return interfaces.WorkFailureTypeUnknown
-	}
 }
 
 func (b claudeProviderBehavior) BuildArgs(_ context.Context, req interfaces.ProviderInferenceRequest, skipPermissions bool, _ *ProviderBuildContext) ([]string, error) {
@@ -180,28 +110,6 @@ func (b claudeProviderBehavior) BuildArgs(_ context.Context, req interfaces.Prov
 	}
 	args = append(args, req.UserMessage)
 	return args, nil
-}
-
-func (b claudeProviderBehavior) FormatExitFailure(provider string, result CommandResult) string {
-	return fmt.Sprintf("%s exited with code %d", provider, result.ExitCode)
-}
-
-func (b claudeProviderBehavior) ClassifyExitFailure(result CommandResult) interfaces.WorkFailureType {
-	normalizedOutput := strings.ToLower(formatCombinedProviderOutput(result))
-	switch {
-	case containsAny(normalizedOutput, `"type":"authentication_error"`, `"type":"permission_error"`, "api key", "authentication error", "permission error", "unauthorized", "forbidden"):
-		return interfaces.WorkFailureTypeAuthFailure
-	case containsAny(normalizedOutput, `"type":"invalid_request_error"`, "invalid_request_error", "bad request", "invalid request", "request_too_large"):
-		return interfaces.WorkFailureTypePermanentBadRequest
-	case containsAny(normalizedOutput, `"type":"rate_limit_error"`, `"type":"overloaded_error"`, "rate limit", "too many requests", "overloaded", "529"):
-		return interfaces.WorkFailureTypeThrottled
-	case containsAny(normalizedOutput, `"type":"api_error"`, "internal server error", "unexpected status 500", "unexpected status 502", "unexpected status 503", "unexpected status 504"):
-		return interfaces.WorkFailureTypeInternalServerError
-	case result.ExitCode == 124 || containsAny(normalizedOutput, "deadline exceeded", "timed out", "timeout"):
-		return interfaces.WorkFailureTypeTimeout
-	default:
-		return interfaces.WorkFailureTypeUnknown
-	}
 }
 
 func (b codexProviderBehavior) BuildArgs(ctx context.Context, req interfaces.ProviderInferenceRequest, skipPermissions bool, buildCtx *ProviderBuildContext) ([]string, error) {
@@ -241,44 +149,6 @@ func (b codexProviderBehavior) BuildCommandRequest(req interfaces.ProviderInfere
 	return commandReq
 }
 
-func (b codexProviderBehavior) FormatExitFailure(provider string, result CommandResult) string {
-	if codexError, ok := extractCodexErrorLine(result); ok {
-		return codexError
-	}
-	return fmt.Sprintf("%s exited with code %d", provider, result.ExitCode)
-}
-
-func (b codexProviderBehavior) ClassifyExitFailure(result CommandResult) interfaces.WorkFailureType {
-	normalizedOutput := strings.ToLower(formatCodexOutputForClassification(result))
-	switch {
-	case containsAny(normalizedOutput, `"type":"authentication_error"`, "authentication_error", "api key", "unauthorized", "forbidden", "401 unauthorized", "403 forbidden"):
-		return interfaces.WorkFailureTypeAuthFailure
-	case containsAny(normalizedOutput, `"type":"invalid_request_error"`, "invalid_request_error", "bad request", "400 item", "400 previous response", "400 ") && !containsAny(normalizedOutput, "timeout"):
-		return interfaces.WorkFailureTypePermanentBadRequest
-	case containsAny(normalizedOutput, codexThrottledFailureNeedles...):
-		return interfaces.WorkFailureTypeThrottled
-	case containsAny(normalizedOutput, codexTemporaryServerFailureNeedles...):
-		return interfaces.WorkFailureTypeInternalServerError
-	case result.ExitCode == 124 || containsAny(normalizedOutput, "deadline exceeded", "timed out", "timeout"):
-		return interfaces.WorkFailureTypeTimeout
-	case result.ExitCode == codexWindowsProcessFailureExitCode:
-		// Windows sometimes reports interrupted Codex subprocess failures as
-		// 4294967295 without any audited provider signal. Keep that path on the
-		// shared retryable provider/process-failure class instead of falling
-		// through to a terminal bucket.
-		return interfaces.WorkFailureTypeInternalServerError
-	default:
-		return interfaces.WorkFailureTypeUnknown
-	}
-}
-
-func (b codexProviderBehavior) FormatTimeoutFailure(result CommandResult) string {
-	if codexError, ok := extractCodexErrorLine(result); ok {
-		return codexError
-	}
-	return formatProviderOutputOrDefault(result, "execution timeout")
-}
-
 func (b geminiProviderBehavior) BuildArgs(_ context.Context, req interfaces.ProviderInferenceRequest, skipPermissions bool, _ *ProviderBuildContext) ([]string, error) {
 	if err := validateGeminiOptionalCapabilities(req); err != nil {
 		return nil, err
@@ -294,18 +164,6 @@ func (b geminiProviderBehavior) BuildArgs(_ context.Context, req interfaces.Prov
 		args = append(args, "--approval-mode", "yolo", "--sandbox", "false")
 	}
 	return args, nil
-}
-
-func (b geminiProviderBehavior) FormatExitFailure(provider string, result CommandResult) string {
-	return ParseGeminiProviderFailure(result).Message
-}
-
-func (b geminiProviderBehavior) ClassifyExitFailure(result CommandResult) interfaces.WorkFailureType {
-	return ParseGeminiProviderFailure(result).Reason
-}
-
-func (b geminiProviderBehavior) FormatTimeoutFailure(_ CommandResult) string {
-	return geminiTimeoutFailureMessage
 }
 
 func (b kiroProviderBehavior) BuildArgs(_ context.Context, req interfaces.ProviderInferenceRequest, skipPermissions bool, _ *ProviderBuildContext) ([]string, error) {
@@ -327,18 +185,6 @@ func (b kiroProviderBehavior) BuildArgs(_ context.Context, req interfaces.Provid
 
 func (kiroProviderBehavior) BuildCommandRequest(req interfaces.ProviderInferenceRequest, args []string) CommandRequest {
 	return buildBaseProviderCommandRequest(req, args)
-}
-
-func (b kiroProviderBehavior) FormatExitFailure(provider string, result CommandResult) string {
-	return ParseKiroProviderFailure(result).Message
-}
-
-func (b kiroProviderBehavior) ClassifyExitFailure(result CommandResult) interfaces.WorkFailureType {
-	return ParseKiroProviderFailure(result).Reason
-}
-
-func (kiroProviderBehavior) FormatTimeoutFailure(CommandResult) string {
-	return kiroTimeoutFailureMessage
 }
 
 func (b cursorProviderBehavior) BuildArgs(_ context.Context, req interfaces.ProviderInferenceRequest, skipPermissions bool, _ *ProviderBuildContext) ([]string, error) {
@@ -368,19 +214,6 @@ func (b cursorProviderBehavior) BuildArgs(_ context.Context, req interfaces.Prov
 	return args, nil
 }
 
-func (b cursorProviderBehavior) FormatExitFailure(provider string, result CommandResult) string {
-	_ = provider
-	return cursorpkg.ParseProviderFailure(cursorpkg.FailureInput{
-		Stdout: result.Stdout, Stderr: result.Stderr, ExitCode: result.ExitCode,
-	}).Message
-}
-
-func (b cursorProviderBehavior) ClassifyExitFailure(result CommandResult) interfaces.WorkFailureType {
-	return cursorpkg.ParseProviderFailure(cursorpkg.FailureInput{
-		Stdout: result.Stdout, Stderr: result.Stderr, ExitCode: result.ExitCode,
-	}).Reason
-}
-
 func (b openCodeProviderBehavior) BuildArgs(_ context.Context, req interfaces.ProviderInferenceRequest, skipPermissions bool, _ *ProviderBuildContext) ([]string, error) {
 	if err := validateOpenCodeOptionalCapabilities(req); err != nil {
 		return nil, err
@@ -403,14 +236,6 @@ func (b openCodeProviderBehavior) BuildArgs(_ context.Context, req interfaces.Pr
 	}
 	args = append(args, req.UserMessage)
 	return args, nil
-}
-
-func (b openCodeProviderBehavior) FormatExitFailure(provider string, result CommandResult) string {
-	return b.sharedNonCodexProviderBehavior.FormatExitFailure(provider, result)
-}
-
-func (b openCodeProviderBehavior) ClassifyExitFailure(result CommandResult) interfaces.WorkFailureType {
-	return b.sharedNonCodexProviderBehavior.ClassifyExitFailure(result)
 }
 
 func validateGeminiOptionalCapabilities(req interfaces.ProviderInferenceRequest) error {
@@ -524,13 +349,6 @@ func formatCombinedProviderOutput(result CommandResult) string {
 		strings.TrimSpace(string(result.Stderr)),
 		strings.TrimSpace(string(result.Stdout)),
 	}, "\n")
-}
-
-func formatCodexOutputForClassification(result CommandResult) string {
-	if codexError, ok := extractCodexErrorLine(result); ok {
-		return codexError
-	}
-	return formatCombinedProviderOutput(result)
 }
 
 func extractCodexErrorLine(result CommandResult) (string, bool) {

--- a/pkg/workers/provider/provider_behavior_test.go
+++ b/pkg/workers/provider/provider_behavior_test.go
@@ -578,68 +578,6 @@ func nonCodexCommandRequestTestCases() []nonCodexCommandRequestTestCase {
 	}
 }
 
-func TestNonCodexProviderBehavior_FormatTimeoutFailure(t *testing.T) {
-	behaviors := map[string]providerBehavior{
-		string(interfaces.ModelProviderClaude):   claudeProviderBehavior{logger: logging.NoopLogger{}},
-		string(interfaces.ModelProviderCursor):   cursorProviderBehavior{logger: logging.NoopLogger{}},
-		string(interfaces.ModelProviderOpenCode): openCodeProviderBehavior{logger: logging.NoopLogger{}},
-	}
-
-	testCases := []struct {
-		name   string
-		result CommandResult
-		want   string
-	}{
-		{
-			name: "PrefersTrimmedStderr",
-			result: CommandResult{
-				Stderr: []byte("  provider timed out waiting for upstream  \n"),
-				Stdout: []byte("stdout fallback"),
-			},
-			want: "provider timed out waiting for upstream",
-		},
-		{
-			name: "FallsBackToStdout",
-			result: CommandResult{
-				Stdout: []byte("provider timeout echoed on stdout"),
-			},
-			want: "provider timeout echoed on stdout",
-		},
-		{
-			name:   "UsesDefaultMessageWhenNoOutputExists",
-			result: CommandResult{},
-			want:   "execution timeout",
-		},
-	}
-
-	for providerName, behavior := range behaviors {
-		t.Run(providerName, func(t *testing.T) {
-			for _, tc := range testCases {
-				t.Run(tc.name, func(t *testing.T) {
-					if got := behavior.FormatTimeoutFailure(tc.result); got != tc.want {
-						t.Fatalf("FormatTimeoutFailure() = %q, want %q", got, tc.want)
-					}
-				})
-			}
-		})
-	}
-}
-
-func TestKiroProviderBehavior_UsesSafeCanonicalFailureMessages(t *testing.T) {
-	behavior := kiroProviderBehavior{logger: logging.NoopLogger{}}
-	authResult := providerErrorCorpusEntryForTest(t, "kiro_structured_authentication_error").CommandResult()
-
-	if got := behavior.FormatExitFailure(string(interfaces.ModelProviderKiro), authResult); got != kiroAuthFailureMessage {
-		t.Fatalf("FormatExitFailure() = %q, want %q", got, kiroAuthFailureMessage)
-	}
-	if got := behavior.ClassifyExitFailure(authResult); got != interfaces.WorkFailureTypeAuthFailure {
-		t.Fatalf("ClassifyExitFailure() = %q, want %q", got, interfaces.WorkFailureTypeAuthFailure)
-	}
-	if got := behavior.FormatTimeoutFailure(CommandResult{Stderr: []byte("private transcript")}); got != kiroTimeoutFailureMessage {
-		t.Fatalf("FormatTimeoutFailure() = %q, want %q", got, kiroTimeoutFailureMessage)
-	}
-}
-
 func TestScriptWrapProvider_Infer_KiroKnownFailuresUseCanonicalParserAndPolicy(t *testing.T) {
 	fixtureNames := []string{
 		"kiro_structured_authentication_error",
@@ -694,208 +632,36 @@ func TestScriptWrapProvider_Infer_KiroUnknownFailuresUseBoundedParserMessages(t 
 	}
 }
 
-func TestCodexProviderBehavior_FormatTimeoutFailure(t *testing.T) {
-	behavior := codexProviderBehavior{logger: logging.NoopLogger{}}
-
-	testCases := []struct {
-		name   string
-		result CommandResult
-		want   string
-	}{
+func providerOwnedCursorAndCodexFailureTestCases() []exitFailureInferenceTestCase {
+	return []exitFailureInferenceTestCase{
 		{
-			name: "PrefersTrimmedStderr",
-			result: CommandResult{
-				Stderr: []byte("  provider timed out waiting for upstream  \n"),
-				Stdout: []byte("stdout fallback"),
-			},
-			want: "provider timed out waiting for upstream",
+			name:        "CursorUsesItsOwnErrorExtraction",
+			provider:    string(interfaces.ModelProviderCursor),
+			result:      CommandResult{ExitCode: 1, Stderr: []byte("noise before\nERROR: unexpected status 500 from cursor upstream")},
+			wantMessage: "ERROR: unexpected status 500 from cursor upstream",
+			wantType:    interfaces.WorkFailureTypeInternalServerError,
 		},
 		{
-			name: "FallsBackToStdout",
-			result: CommandResult{
-				Stdout: []byte("provider timeout echoed on stdout"),
-			},
-			want: "provider timeout echoed on stdout",
+			name:        "CursorDoesNotInheritCodexHighDemandClassification",
+			provider:    string(interfaces.ModelProviderCursor),
+			result:      CommandResult{ExitCode: 1, Stderr: []byte(codexHighDemandTemporaryErrorsNeedle)},
+			wantMessage: codexHighDemandTemporaryErrorsNeedle,
+			wantType:    interfaces.WorkFailureTypeUnknown,
 		},
 		{
-			name:   "UsesDefaultMessageWhenNoOutputExists",
-			result: CommandResult{},
-			want:   "execution timeout",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := behavior.FormatTimeoutFailure(tc.result); got != tc.want {
-				t.Fatalf("FormatTimeoutFailure() = %q, want %q", got, tc.want)
-			}
-		})
-	}
-}
-
-func TestGenericNonCodexProviderBehavior_ExitFailureBehavior(t *testing.T) {
-	for _, providerName := range []string{
-		string(interfaces.ModelProviderOpenCode),
-	} {
-		behavior := providerBehaviorForErrorClassification(providerName)
-		t.Run(providerName, func(t *testing.T) {
-			assertProviderExitFailureFormatting(t, behavior, providerName)
-			assertProviderExitFailureClassification(t, behavior)
-		})
-	}
-}
-
-func TestGeminiProviderBehavior_UsesCanonicalFailureParser(t *testing.T) {
-	behavior := providerBehaviorForErrorClassification(string(interfaces.ModelProviderGemini))
-	result := CommandResult{
-		ExitCode: 1,
-		Stderr:   []byte(`{"error":{"status":"RESOURCE_EXHAUSTED","message":"private quota details"}}`),
-	}
-	if got := behavior.ClassifyExitFailure(result); got != interfaces.WorkFailureTypeThrottled {
-		t.Fatalf("ClassifyExitFailure() = %q, want %q", got, interfaces.WorkFailureTypeThrottled)
-	}
-	if got := behavior.FormatExitFailure("ignored", result); got != geminiThrottleFailureMessage {
-		t.Fatalf("FormatExitFailure() = %q, want %q", got, geminiThrottleFailureMessage)
-	}
-	if got := behavior.FormatTimeoutFailure(CommandResult{Stderr: []byte("private transcript")}); got != geminiTimeoutFailureMessage {
-		t.Fatalf("FormatTimeoutFailure() = %q, want %q", got, geminiTimeoutFailureMessage)
-	}
-}
-
-func TestCursorAndCodexProviderBehavior_ExitFailureBehavior(t *testing.T) {
-	cursorBehavior := providerBehaviorForErrorClassification(string(interfaces.ModelProviderCursor))
-	codexBehavior := providerBehaviorForErrorClassification(string(interfaces.ModelProviderCodex))
-
-	assertCodexDerivedExitFailureFormatting(t, codexBehavior, string(interfaces.ModelProviderCodex))
-
-	result := CommandResult{
-		ExitCode: 1,
-		Stderr:   []byte(codexHighDemandTemporaryErrorsNeedle),
-	}
-	if got := cursorBehavior.ClassifyExitFailure(result); got != interfaces.WorkFailureTypeUnknown {
-		t.Fatalf("cursor ClassifyExitFailure() = %q, want Cursor-owned unknown classification", got)
-	}
-	if got := codexBehavior.ClassifyExitFailure(result); got != interfaces.WorkFailureTypeInternalServerError {
-		t.Fatalf("codex ClassifyExitFailure() = %q, want %q", got, interfaces.WorkFailureTypeInternalServerError)
-	}
-}
-
-func assertCodexDerivedExitFailureFormatting(t *testing.T, behavior providerBehavior, providerName string) {
-	t.Helper()
-
-	testCases := []struct {
-		name   string
-		result CommandResult
-		want   string
-	}{
-		{
-			name:   "ExtractsCodexErrorLine",
-			result: CommandResult{ExitCode: 17, Stderr: []byte("noise before\nERROR: upstream rejected the request")},
-			want:   "ERROR: upstream rejected the request",
+			name:        "CodexUsesItsOwnSafeServerResult",
+			provider:    string(interfaces.ModelProviderCodex),
+			result:      CommandResult{ExitCode: 1, Stderr: []byte("noise before\nERROR: unexpected status 500 from codex upstream")},
+			wantMessage: codexServerFailureMessage,
+			wantType:    interfaces.WorkFailureTypeInternalServerError,
 		},
 		{
-			name:   "FallsBackToProviderExitCode",
-			result: CommandResult{ExitCode: 17, Stderr: []byte("stderr detail"), Stdout: []byte("stdout detail")},
-			want:   providerName + " exited with code 17",
+			name:        "UnsupportedProviderDoesNotFallBackToCodexParser",
+			provider:    "custom-provider",
+			result:      CommandResult{ExitCode: 1, Stderr: []byte(codexHighDemandTemporaryErrorsNeedle)},
+			wantMessage: codexHighDemandTemporaryErrorsNeedle,
+			wantType:    interfaces.WorkFailureTypeUnknown,
 		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := behavior.FormatExitFailure(providerName, tc.result); got != tc.want {
-				t.Fatalf("FormatExitFailure() = %q, want %q", got, tc.want)
-			}
-		})
-	}
-}
-
-func assertProviderExitFailureFormatting(t *testing.T, behavior providerBehavior, providerName string) {
-	t.Helper()
-
-	testCases := []struct {
-		name   string
-		result CommandResult
-		want   string
-	}{
-		{
-			name: "PrefersTrimmedStderr",
-			result: CommandResult{
-				ExitCode: 17,
-				Stderr:   []byte("  stderr detail  \n"),
-				Stdout:   []byte("stdout fallback"),
-			},
-			want: "stderr detail",
-		},
-		{
-			name: "FallsBackToStdout",
-			result: CommandResult{
-				ExitCode: 17,
-				Stdout:   []byte("stdout detail"),
-			},
-			want: "stdout detail",
-		},
-		{
-			name:   "UsesProviderSpecificFallback",
-			result: CommandResult{ExitCode: 17},
-			want:   providerName + " exited with code 17",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := behavior.FormatExitFailure(providerName, tc.result); got != tc.want {
-				t.Fatalf("FormatExitFailure() = %q, want %q", got, tc.want)
-			}
-		})
-	}
-}
-
-func assertProviderExitFailureClassification(t *testing.T, behavior providerBehavior) {
-	t.Helper()
-
-	testCases := []struct {
-		name   string
-		result CommandResult
-		want   interfaces.WorkFailureType
-	}{
-		{
-			name:   "AuthFailure",
-			result: CommandResult{ExitCode: 1, Stderr: []byte("login required for this API key")},
-			want:   interfaces.WorkFailureTypeAuthFailure,
-		},
-		{
-			name:   "PermanentBadRequest",
-			result: CommandResult{ExitCode: 1, Stderr: []byte("invalid argument in request payload")},
-			want:   interfaces.WorkFailureTypePermanentBadRequest,
-		},
-		{
-			name:   "Throttled",
-			result: CommandResult{ExitCode: 1, Stderr: []byte("resource exhausted by 429 quota")},
-			want:   interfaces.WorkFailureTypeThrottled,
-		},
-		{
-			name:   "InternalServerError",
-			result: CommandResult{ExitCode: 1, Stderr: []byte("unexpected status 503 from upstream")},
-			want:   interfaces.WorkFailureTypeInternalServerError,
-		},
-		{
-			name:   "Timeout",
-			result: CommandResult{ExitCode: 124},
-			want:   interfaces.WorkFailureTypeTimeout,
-		},
-		{
-			name:   "Unknown",
-			result: CommandResult{ExitCode: 1, Stderr: []byte("provider stopped without classification markers")},
-			want:   interfaces.WorkFailureTypeUnknown,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := behavior.ClassifyExitFailure(tc.result); got != tc.want {
-				t.Fatalf("ClassifyExitFailure() = %q, want %q", got, tc.want)
-			}
-		})
 	}
 }
 


### PR DESCRIPTION
{
  "project": "Remove Obsolete Split Provider Failure Paths",
  "branchName": "provider-failure-obsolete-path-cleanup",
  "description": "Route every failed or timed-out provider invocation through one provider-owned canonical parser result, remove obsolete split formatting and classification paths and cross-provider inheritance, and preserve the existing provider, runner, executor, recording, session, progress, materialization, and command-construction boundaries.",
  "context": {
    "customerAsk": "Remove FormatExitFailure, ClassifyExitFailure, FormatTimeoutFailure, providerBehaviorForErrorClassification, shared classification inheritance, and compatibility-only tests after every provider uses the canonical parser, while preserving Provider.Infer and the runner/executor boundaries.",
    "problem": "Legacy provider behavior can format and classify the same subprocess output independently, allowing inconsistent failure outcomes and letting Cursor or other providers inherit another provider's interpretation. The obsolete compatibility surface also obscures the intended separation of execution responsibilities.",
    "solution": "Use one canonical provider-selected parse result for every exit and timeout, remove split and cross-provider compatibility paths after migration, and retain direct behavioral coverage proving that inference, execution, recording, session, progress, materialization, and command construction remain intact."
  },
  "acceptanceCriteria": [
    "Every production provider subprocess failure and timeout obtains its normalized reason and customer-visible message from one canonical parse result; formatting and classification cannot be selected or computed independently.",
    "Cursor, Codex, Claude, Gemini, Kiro, and OpenCode select their own canonical parser by normalized provider identity and never borrow another provider's parser through embedding or fallback behavior selection.",
    "The obsolete split failure methods, error-classification selector, shared classification inheritance, and compatibility-only tests for those paths are removed without replacement compatibility shims.",
    "Provider.Infer, Runner.Execute, WorkstationRequestExecutor.Execute, and WorkerExecutor.Execute retain their distinct observable responsibilities and composition seams.",
    "Provider command construction, recording, provider-session handling, progress publication, content/image materialization, working-directory behavior, and execution result propagation remain behaviorally unchanged.",
    "Focused failure-path and composition tests pass, including go test ./pkg/workers/... ./pkg/service/... -short.",
    "Final quality gates pass: typecheck/compile checks, make verify-fast, make lint, and relevant tests."
  ],
  "userStories": [
    {
      "id": "provider-failure-obsolete-path-cleanup-001",
      "title": "Use one canonical result for each provider failure",
      "description": "As a factory user, I want each failed or timed-out provider invocation to publish one internally consistent reason and message so that retry behavior and diagnostics cannot be based on conflicting interpretations of the same process output.",
      "acceptanceCriteria": [
        "A non-successful provider process, including a timeout, is parsed exactly once through the canonical parser selected for the normalized provider identity.",
        "The failure reason and customer-visible message returned from inference are taken from the same parsed result; no production path independently formats or classifies the process output.",
        "Existing retry, terminal, and timeout behavior continues to derive from the canonical normalized reason rather than a second classification pass.",
        "Representative exit, timeout, malformed-output, and unknown-failure tests demonstrate consistent reason/message outcomes through Provider.Infer.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "provider-failure-obsolete-path-cleanup-002",
      "title": "Remove cross-provider and split failure compatibility paths",
      "description": "As a runtime maintainer, I want each provider to own its failure interpretation and obsolete compatibility paths removed so that future provider changes cannot silently affect another provider.",
      "acceptanceCriteria": [
        "Cursor, Codex, Claude, Gemini, Kiro, and OpenCode each resolve directly to their own canonical parser; Cursor does not invoke Codex failure parsing and no provider obtains classification through shared behavior embedding or a fallback provider selector.",
        "The production provider behavior contract no longer exposes FormatExitFailure, ClassifyExitFailure, or FormatTimeoutFailure, and providerBehaviorForErrorClassification no longer exists.",
        "Shared classification inheritance and compatibility-only tests for the removed split methods and fallback selector are deleted; behavioral parser and inference tests remain as regression evidence.",
        "Unknown or unsupported provider handling remains deterministic and does not silently select another provider's parser.",
        "No replacement shim or parallel failure-classification route is introduced.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "provider-failure-obsolete-path-cleanup-003",
      "title": "Preserve runner and executor behavior after cleanup",
      "description": "As a factory operator, I want provider invocations to retain their existing execution, session, recording, progress, and materialization behavior after failure cleanup so that the architectural simplification causes no workflow regression.",
      "acceptanceCriteria": [
        "Provider.Infer, Runner.Execute, WorkstationRequestExecutor.Execute, and WorkerExecutor.Execute remain distinct boundaries with their existing inputs, outputs, and delegation responsibilities.",
        "Provider-specific command and argument construction, working directory, environment and permission handling, session resume/extraction, and timeout propagation behave as before for successful and failed invocations.",
        "Recording wrappers and provider-to-runner composition continue to observe the same invocation and result without independently parsing or reclassifying provider output.",
        "Progress publication and work-content/image materialization retain their existing success, failure, and cleanup behavior.",
        "Focused service composition, provider-session, streaming/progress, materialization, and functional workflow tests demonstrate the preserved behavior.",
        "go test ./pkg/workers/... ./pkg/service/... -short passes",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}
