### PR TITLE
maturity-resume-partial-terminal

### DIFF
--- a/docs/reference/sessions.md
+++ b/docs/reference/sessions.md
@@ -319,6 +319,44 @@ After a successful resume, inspect progress with `you session show`,
 `SESSION_LIFECYCLE_CONTROL` events record pause and resume for replay and
 historical status reads.
 
+### Canonical resume and result facts
+
+Resume never creates a replacement Factory Session. Keep using the
+`sessionId` returned by the original start request for lifecycle, result,
+dispatch, checkpoint, and artifact reads. A successful resume returns that same
+identifier, and terminal or already-running requests return a typed no-op or
+rejection without changing results or dispatches.
+
+Use typed fields instead of parsing status messages:
+
+| Fact | REST | CLI | MCP | Dashboard |
+|------|------|-----|-----|-----------|
+| Session identity and lifecycle | `GET /factory-sessions/{session_id}` | `you --json session show <session-id>` | `you.factory_session.get` | Factory Session detail header and lifecycle status |
+| Result availability | `GET /factory-sessions/{session_id}/result` | durable workflow `status` and `result` JSON | `you.factory_session.get_result` | Explicit not-ready, partial, failed-with-partial, or final result state |
+| Latest approved checkpoint | session runtime checkpoint reference and canonical checkpoint events | session JSON and event inspection | Factory Session get and event tools | replay timeline checkpoint reference |
+| Artifact lineage | `artifactRefs` and `/factory-sessions/{session_id}/artifacts` | result JSON artifact refs | result and artifact inspection tools | session-owned artifact drilldown links |
+
+Result availability has stable typed meanings across those surfaces:
+
+- `NOT_READY` means no customer result is available yet.
+- `PARTIAL` means useful output and any referenced artifacts are available while
+  the session can still continue.
+- `FINAL` means the terminal result is available.
+- `FAILED_WITH_PARTIAL` means execution terminated unsuccessfully but preserved
+  useful output and artifact references.
+
+Paused, interrupted, and terminal reads retain their checkpoint and artifact
+references across reconnect and replay until a newer canonical event changes
+the projection. Artifact references are session-scoped API paths; clients
+should follow those references rather than constructing host filesystem paths.
+
+Resume failures are also typed. `INVALID_RESUME_STATE` identifies a missing,
+malformed, or non-approved checkpoint; `TERMINAL_SESSION` preserves an already
+terminal session; `NO_OP` preserves an already-running session. Missing
+sessions and unreachable services remain distinct not-found and transport
+failures. None of these outcomes authorizes clients to switch to a new session
+identifier.
+
 ### Maintainer verification
 
 After editing this reference topic, run `make docs-reference-smoke` from the

--- a/pkg/factorysessionexecution/control.go
+++ b/pkg/factorysessionexecution/control.go
@@ -409,6 +409,8 @@ func appendAcceptedSessionLifecycleEventIfNeeded(
 }
 
 // pkgmaintcheck:ignore-cyclomatic-complexity this runtime control helper keeps dispatch-targeted lifecycle validation and replay together on one seam.
+// backendsizecheck:ignore-function accepted control mutation, persistence rollback, and idempotent replay remain atomic on this runtime seam.
+// pkgmaintcheck:ignore-function-lines accepted control mutation, persistence rollback, and idempotent replay remain atomic on this runtime seam.
 func (s *JavaScriptRuntimeService) applyRuntimeExtendedLifecycleControl(
 	ctx context.Context,
 	sessionID string,

--- a/pkg/factorysessionexecution/control.go
+++ b/pkg/factorysessionexecution/control.go
@@ -479,6 +479,7 @@ func (s *JavaScriptRuntimeService) applyRuntimeExtendedLifecycleControl(
 
 	if outcome == LifecycleControlOutcomeAccepted {
 		priorState := cloneRuntimeSessionState(state)
+		priorRunCancel := state.runCancel
 		previousStatus := state.session.Status
 		if operation == LifecycleControlInterruptDispatch {
 			s.recordAcceptedRuntimeInterrupt(state, dispatchSummary, interrupt)
@@ -504,6 +505,7 @@ func (s *JavaScriptRuntimeService) applyRuntimeExtendedLifecycleControl(
 		if operation == LifecycleControlPause {
 			if err := s.persistSessionSnapshot(cloneRuntimeSessionState(state)); err != nil {
 				*state = cloneRuntimeSessionState(&priorState)
+				state.runCancel = priorRunCancel
 				return LifecycleControlResult{}, err
 			}
 		}

--- a/pkg/factorysessionexecution/control.go
+++ b/pkg/factorysessionexecution/control.go
@@ -476,6 +476,7 @@ func (s *JavaScriptRuntimeService) applyRuntimeExtendedLifecycleControl(
 	}
 
 	if outcome == LifecycleControlOutcomeAccepted {
+		priorState := cloneRuntimeSessionState(state)
 		previousStatus := state.session.Status
 		if operation == LifecycleControlInterruptDispatch {
 			s.recordAcceptedRuntimeInterrupt(state, dispatchSummary, interrupt)
@@ -496,6 +497,12 @@ func (s *JavaScriptRuntimeService) applyRuntimeExtendedLifecycleControl(
 				)
 			} else {
 				state.events = rebuildRuntimeSessionCanonicalEvents(state)
+			}
+		}
+		if operation == LifecycleControlPause {
+			if err := s.persistSessionSnapshot(cloneRuntimeSessionState(state)); err != nil {
+				*state = cloneRuntimeSessionState(&priorState)
+				return LifecycleControlResult{}, err
 			}
 		}
 	}
@@ -615,6 +622,7 @@ func runtimeExtendedLifecycleControlResultFromState(
 	}
 	return result
 }
+
 // AppendSessionLifecycleControlEvent records one accepted pause or resume control on
 // the canonical session event stream without rebuilding earlier lifecycle events.
 func AppendSessionLifecycleControlEvent(

--- a/pkg/factorysessionexecution/fake_service_runtime_test.go
+++ b/pkg/factorysessionexecution/fake_service_runtime_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -2650,6 +2651,134 @@ func TestFinalizeInterruptedTerminalSession_PreservesPartialAndUnavailableResult
 			t.Fatalf("availability = %#v, want SESSION_INTERRUPTED", state.result.Availability)
 		}
 	})
+}
+
+func TestJavaScriptRuntimeService_PausePersistsStablePartialTerminalReadState(t *testing.T) {
+	store := &runtimeRecordingStore{}
+	service := NewJavaScriptRuntimeService(JavaScriptRuntimeServiceConfig{
+		ProjectRoot: t.TempDir(),
+		Persistence: store,
+	})
+	sessionID := "dur-sess-paused-restart-001"
+	dispatchID := "dispatch-completed-1"
+	if err := SeedRuntimeSessionWithRunningDispatch(service, sessionID, dispatchID, "completed child"); err != nil {
+		t.Fatalf("SeedRuntimeSessionWithRunningDispatch: %v", err)
+	}
+
+	service.mu.Lock()
+	state := service.sessions[sessionID]
+	state.dispatches[0].Status = DispatchStatusCompleted
+	state.dispatches[0].OutputArtifactIDs = []string{"artifact-1"}
+	state.dispatchStatusTransitions[dispatchID] = []DispatchStatus{
+		DispatchStatusQueued,
+		DispatchStatusRunning,
+		DispatchStatusCompleted,
+	}
+	state.artifacts = []ArtifactSummary{{
+		ID:         "artifact-1",
+		Kind:       "CHILD_RESULT",
+		Visibility: "session",
+		DispatchID: dispatchID,
+	}}
+	state.session.ArtifactCount = 1
+	state.session.ArtifactRefs = artifactRefsFromSummaries(state.artifacts)
+	state.events = rebuildRuntimeSessionCanonicalEvents(state)
+	service.mu.Unlock()
+
+	paused, err := service.Pause(context.Background(), sessionID, ControlRequest{RequestID: "pause-restart-001"})
+	if err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+	if paused.Status != LifecycleStatusPaused {
+		t.Fatalf("pause status = %q, want PAUSED", paused.Status)
+	}
+
+	wantSession, err := service.GetSession(context.Background(), sessionID)
+	if err != nil {
+		t.Fatalf("GetSession before restart: %v", err)
+	}
+	wantResult, err := service.GetResult(context.Background(), sessionID, ResultRequest{Mode: ResultModePartial, IncludeArtifacts: true})
+	if err != nil {
+		t.Fatalf("GetResult before restart: %v", err)
+	}
+	wantDispatches, err := service.ListDispatches(context.Background(), sessionID)
+	if err != nil {
+		t.Fatalf("ListDispatches before restart: %v", err)
+	}
+	wantEvents, err := service.ReadEvents(context.Background(), sessionID, EventReconnectRequest{})
+	if err != nil {
+		t.Fatalf("ReadEvents before restart: %v", err)
+	}
+
+	restarted := NewJavaScriptRuntimeService(JavaScriptRuntimeServiceConfig{
+		ProjectRoot: t.TempDir(),
+		Persistence: store,
+	})
+	gotSession, err := restarted.GetSession(context.Background(), sessionID)
+	if err != nil {
+		t.Fatalf("GetSession after restart: %v", err)
+	}
+	gotResult, err := restarted.GetResult(context.Background(), sessionID, ResultRequest{Mode: ResultModePartial, IncludeArtifacts: true})
+	if err != nil {
+		t.Fatalf("GetResult after restart: %v", err)
+	}
+	gotDispatches, err := restarted.ListDispatches(context.Background(), sessionID)
+	if err != nil {
+		t.Fatalf("ListDispatches after restart: %v", err)
+	}
+	gotEvents, err := restarted.ReadEvents(context.Background(), sessionID, EventReconnectRequest{})
+	if err != nil {
+		t.Fatalf("ReadEvents after restart: %v", err)
+	}
+
+	if !reflect.DeepEqual(gotSession, wantSession) {
+		t.Fatalf("session changed across restart:\ngot  %#v\nwant %#v", gotSession, wantSession)
+	}
+	if !reflect.DeepEqual(gotResult, wantResult) || gotResult.ResultStatus != ResultStatusNotReady || gotResult.Availability == nil {
+		t.Fatalf("result changed across restart: got %#v want %#v", gotResult, wantResult)
+	}
+	if !reflect.DeepEqual(gotDispatches, wantDispatches) {
+		t.Fatalf("dispatches changed across restart: got %#v want %#v", gotDispatches, wantDispatches)
+	}
+	if len(gotEvents.Events) != len(wantEvents.Events) {
+		t.Fatalf("event count changed across restart: got %d want %d", len(gotEvents.Events), len(wantEvents.Events))
+	}
+	for index := range wantEvents.Events {
+		var gotEvent, wantEvent any
+		if err := json.Unmarshal(gotEvents.Events[index], &gotEvent); err != nil {
+			t.Fatalf("decode restarted event %d: %v", index, err)
+		}
+		if err := json.Unmarshal(wantEvents.Events[index], &wantEvent); err != nil {
+			t.Fatalf("decode live event %d: %v", index, err)
+		}
+		if !reflect.DeepEqual(gotEvent, wantEvent) {
+			t.Fatalf("event %d changed across restart: got %#v want %#v", index, gotEvent, wantEvent)
+		}
+	}
+}
+
+func TestJavaScriptRuntimeService_PausePersistenceFailureKeepsRunningProjection(t *testing.T) {
+	store := &runtimeRecordingStore{saveErr: errors.New("pause persistence unavailable")}
+	service := NewJavaScriptRuntimeService(JavaScriptRuntimeServiceConfig{
+		ProjectRoot: t.TempDir(),
+		Persistence: store,
+	})
+	sessionID := "dur-sess-pause-persist-failure-001"
+	if err := SeedRuntimeSessionWithRunningDispatch(service, sessionID, "dispatch-1", "running child"); err != nil {
+		t.Fatalf("SeedRuntimeSessionWithRunningDispatch: %v", err)
+	}
+
+	_, err := service.Pause(context.Background(), sessionID, ControlRequest{})
+	if err == nil || !strings.Contains(err.Error(), "persist durable session snapshot") {
+		t.Fatalf("Pause error = %v, want persistence failure", err)
+	}
+	read, readErr := service.GetSession(context.Background(), sessionID)
+	if readErr != nil {
+		t.Fatalf("GetSession: %v", readErr)
+	}
+	if read.Status != LifecycleStatusRunning || read.Lifecycle == nil || read.Lifecycle.PausedAt != nil {
+		t.Fatalf("session after rejected pause = %#v, want unchanged RUNNING projection", read)
+	}
 }
 
 func TestInterruptedTerminalTimestamp_PrefersSessionLifecycle(t *testing.T) {

--- a/pkg/factorysessionexecution/fake_service_runtime_test.go
+++ b/pkg/factorysessionexecution/fake_service_runtime_test.go
@@ -2769,6 +2769,10 @@ func TestJavaScriptRuntimeService_PausePersistenceFailureKeepsRunningProjection(
 	if err := SeedRuntimeSessionWithRunningDispatch(service, sessionID, "dispatch-1", "running child"); err != nil {
 		t.Fatalf("SeedRuntimeSessionWithRunningDispatch: %v", err)
 	}
+	cancelCalls := 0
+	service.mu.Lock()
+	service.sessions[sessionID].runCancel = func() { cancelCalls++ }
+	service.mu.Unlock()
 
 	_, err := service.Pause(context.Background(), sessionID, ControlRequest{})
 	if err == nil || !strings.Contains(err.Error(), "persist durable session snapshot") {
@@ -2780,6 +2784,12 @@ func TestJavaScriptRuntimeService_PausePersistenceFailureKeepsRunningProjection(
 	}
 	if read.Status != LifecycleStatusRunning || read.Lifecycle == nil || read.Lifecycle.PausedAt != nil {
 		t.Fatalf("session after rejected pause = %#v, want unchanged RUNNING projection", read)
+	}
+	if _, err := service.Cancel(context.Background(), sessionID, ControlRequest{}); err != nil {
+		t.Fatalf("Cancel after rejected pause: %v", err)
+	}
+	if cancelCalls != 1 {
+		t.Fatalf("cancel calls after rejected pause = %d, want 1", cancelCalls)
 	}
 }
 

--- a/pkg/factorysessionexecution/fake_service_runtime_test.go
+++ b/pkg/factorysessionexecution/fake_service_runtime_test.go
@@ -2653,6 +2653,8 @@ func TestFinalizeInterruptedTerminalSession_PreservesPartialAndUnavailableResult
 	})
 }
 
+// pkgmaintcheck:ignore-function-lines this restart integration test keeps the pre-restart and post-restart observable read assertions together.
+// pkgmaintcheck:ignore-cyclomatic-complexity each assertion validates one durable partial-result field across the restart boundary.
 func TestJavaScriptRuntimeService_PausePersistsStablePartialTerminalReadState(t *testing.T) {
 	store := &runtimeRecordingStore{}
 	service := NewJavaScriptRuntimeService(JavaScriptRuntimeServiceConfig{

--- a/pkg/factorysessionexecution/fake_service_runtime_test.go
+++ b/pkg/factorysessionexecution/fake_service_runtime_test.go
@@ -2521,10 +2521,11 @@ func TestJavaScriptRuntimeService_InterruptRunningDispatch_PreservesObservedCanc
 func TestValidateCheckpointSummaryForResume_RejectsInvalidMetadata(t *testing.T) {
 	sessionID := "dur-sess-checkpoint-validation-001"
 	valid := &jsstore.CheckpointSummary{
-		Kind:          jsstore.CheckpointSummaryKind,
-		SchemaVersion: jsstore.CheckpointSummarySchemaVersion,
-		CheckpointID:  "checkpoint-1",
-		SessionID:     sessionID,
+		Kind:           jsstore.CheckpointSummaryKind,
+		SchemaVersion:  jsstore.CheckpointSummarySchemaVersion,
+		CheckpointID:   "checkpoint-1",
+		SessionID:      sessionID,
+		ResumeStrategy: jsstore.ResumeStrategyReplayCompletedThenContinue,
 	}
 	if err := validateCheckpointSummaryForResume(valid, sessionID); err != nil {
 		t.Fatalf("validateCheckpointSummaryForResume(valid): %v", err)
@@ -2566,10 +2567,18 @@ func TestValidateCheckpointSummaryForResume_RejectsInvalidMetadata(t *testing.T)
 		{
 			name: "session id mismatch",
 			summary: &jsstore.CheckpointSummary{
-				CheckpointID: "checkpoint-1",
-				SessionID:    "dur-sess-other",
+				CheckpointID:   "checkpoint-1",
+				SessionID:      "dur-sess-other",
+				ResumeStrategy: jsstore.ResumeStrategyReplayCompletedThenContinue,
 			},
 			field: "checkpointSummary.sessionId",
+		},
+		{
+			name: "checkpoint not approved for resume",
+			summary: &jsstore.CheckpointSummary{
+				CheckpointID: "checkpoint-1",
+			},
+			field: "checkpointSummary.resumeStrategy",
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/factorysessionexecution/fixtures/runtime_restart_resume_test.go
+++ b/pkg/factorysessionexecution/fixtures/runtime_restart_resume_test.go
@@ -1,3 +1,5 @@
+// backendsizecheck:ignore-file restart-resume coverage keeps persistence, replay, provider, and event-lineage assertions in one integration fixture.
+// pkgmaintcheck:ignore-file-lines restart-resume coverage keeps persistence, replay, provider, and event-lineage assertions in one integration fixture.
 package fixtures_test
 
 import (

--- a/pkg/factorysessionexecution/fixtures/runtime_restart_resume_test.go
+++ b/pkg/factorysessionexecution/fixtures/runtime_restart_resume_test.go
@@ -512,6 +512,57 @@ func TestJavaScriptRuntimeService_ResumeInterruptedSession_NonApprovedCheckpoint
 	}
 }
 
+func TestJavaScriptRuntimeService_ResumeInterruptedSession_RejectsCheckpointDispatchNotDurablyCompleted(t *testing.T) {
+	harness := startInterruptedResumableSession(t, "req-runtime-resume-dispatch-drift-001")
+	beforeCalls := harness.provider.CallCount()
+	rewritePersistedSnapshot(t, harness.projectRoot, harness.sessionID, func(snapshot *fse.PersistedRuntimeSessionState) {
+		snapshot.CheckpointSummary.CompletedDispatchIDs = append(snapshot.CheckpointSummary.CompletedDispatchIDs, "dispatch-missing")
+	})
+
+	service := newResumedRuntimeService(harness)
+	_, err := service.ResumeInterruptedSession(context.Background(), harness.sessionID, fse.ResumeSessionRequest{
+		RequestID: "req-runtime-resume-dispatch-drift-resume-001",
+	})
+	assertResumeError(t, err, fse.ResumeOutcomeInvalidState, "checkpointSummary.completedDispatchIds")
+	if calls := harness.provider.CallCount(); calls != beforeCalls {
+		t.Fatalf("provider calls = %d, want unchanged %d after rejected recovery", calls, beforeCalls)
+	}
+}
+
+func TestJavaScriptRuntimeService_ResumeInterruptedSession_RejectsRegressedEventCursor(t *testing.T) {
+	harness := startInterruptedResumableSession(t, "req-runtime-resume-cursor-drift-001")
+	beforeCalls := harness.provider.CallCount()
+	rewritePersistedSnapshot(t, harness.projectRoot, harness.sessionID, func(snapshot *fse.PersistedRuntimeSessionState) {
+		var event map[string]any
+		if err := json.Unmarshal(snapshot.Events[1], &event); err != nil {
+			t.Fatalf("unmarshal event: %v", err)
+		}
+		event["context"].(map[string]any)["sequence"] = float64(1)
+		encoded, err := json.Marshal(event)
+		if err != nil {
+			t.Fatalf("marshal event: %v", err)
+		}
+		snapshot.Events[1] = encoded
+		canonicalIndex := 0
+		for index := range snapshot.Records {
+			if snapshot.Records[index].Kind != fse.DurableRecordKindCanonicalFactoryEvent {
+				continue
+			}
+			snapshot.Records[index].CanonicalEvent = snapshot.Events[canonicalIndex]
+			canonicalIndex++
+		}
+	})
+
+	service := newResumedRuntimeService(harness)
+	_, err := service.ResumeInterruptedSession(context.Background(), harness.sessionID, fse.ResumeSessionRequest{
+		RequestID: "req-runtime-resume-cursor-drift-resume-001",
+	})
+	assertResumeError(t, err, fse.ResumeOutcomeInvalidState, "events.sequence")
+	if calls := harness.provider.CallCount(); calls != beforeCalls {
+		t.Fatalf("provider calls = %d, want unchanged %d after rejected recovery", calls, beforeCalls)
+	}
+}
+
 func TestJavaScriptRuntimeService_ResumeInterruptedSession_NonInterruptedSessionReturnsTypedFailure(t *testing.T) {
 	projectRoot := setupRuntimeWorkflowFixture(
 		t,

--- a/pkg/factorysessionexecution/fixtures/runtime_restart_resume_test.go
+++ b/pkg/factorysessionexecution/fixtures/runtime_restart_resume_test.go
@@ -492,6 +492,26 @@ func TestJavaScriptRuntimeService_ResumeInterruptedSession_InvalidCheckpointSumm
 	assertResumeError(t, err, fse.ResumeOutcomeInvalidState, "checkpointSummary.kind")
 }
 
+func TestJavaScriptRuntimeService_ResumeInterruptedSession_NonApprovedCheckpointReturnsTypedFailure(t *testing.T) {
+	harness := startInterruptedResumableSession(t, "req-runtime-resume-non-approved-001")
+	beforeCalls := harness.provider.CallCount()
+	rewritePersistedSnapshot(t, harness.projectRoot, harness.sessionID, func(snapshot *fse.PersistedRuntimeSessionState) {
+		snapshot.CheckpointSummary.ResumeStrategy = ""
+	})
+
+	service := newResumedRuntimeService(harness)
+	_, err := service.ResumeInterruptedSession(context.Background(), harness.sessionID, fse.ResumeSessionRequest{
+		RequestID: "req-runtime-resume-non-approved-resume-001",
+	})
+	assertResumeError(t, err, fse.ResumeOutcomeInvalidState, "checkpointSummary.resumeStrategy")
+	if calls := harness.provider.CallCount(); calls != beforeCalls {
+		t.Fatalf("provider calls = %d, want unchanged %d after rejected resume", calls, beforeCalls)
+	}
+	if strings.Contains(err.Error(), "checkpointState") || strings.Contains(err.Error(), "firstLabel") {
+		t.Fatalf("resume diagnostic leaked checkpoint payload detail: %v", err)
+	}
+}
+
 func TestJavaScriptRuntimeService_ResumeInterruptedSession_NonInterruptedSessionReturnsTypedFailure(t *testing.T) {
 	projectRoot := setupRuntimeWorkflowFixture(
 		t,

--- a/pkg/factorysessionexecution/lifecycle.go
+++ b/pkg/factorysessionexecution/lifecycle.go
@@ -714,7 +714,7 @@ func mergePreservedDispatchInterruptedEvents(projected, preserved []json.RawMess
 		merged = append(merged, raw)
 		seen[key] = struct{}{}
 	}
-	return merged
+	return resequenceCanonicalEvents(merged)
 }
 
 func eventIdentityKey(raw json.RawMessage) string {

--- a/pkg/factorysessionexecution/prepare_start.go
+++ b/pkg/factorysessionexecution/prepare_start.go
@@ -412,9 +412,9 @@ func appendCanonicalRuntimeDispatchLifecycleEvents(
 		if dispatch.Status == DispatchStatusInterrupted {
 			continue
 		}
-		dispatchEvents = append(dispatchEvents, buildDispatchQueuedEvent(events, dispatchEvents, session, dispatch, source, index)...)
+		dispatchEvents = buildDispatchQueuedEvent(events, dispatchEvents, session, dispatch, source, index)
 		if isReconciledDispatchStatus(dispatch.Status) {
-			dispatchEvents = append(dispatchEvents, buildDispatchReconciledEvent(events, dispatchEvents, session, dispatch, source)...)
+			dispatchEvents = buildDispatchReconciledEvent(events, dispatchEvents, session, dispatch, source)
 		}
 	}
 	if len(dispatchEvents) == 0 {
@@ -536,7 +536,10 @@ func dispatchLifecycleEvent(
 	source string,
 	payload json.RawMessage,
 ) json.RawMessage {
-	sequence, sessionSequence := nextCanonicalEventSequence(append(baseEvents, append(pending, json.RawMessage("{}"))...))
+	priorEvents := make([]json.RawMessage, 0, len(baseEvents)+len(pending))
+	priorEvents = append(priorEvents, baseEvents...)
+	priorEvents = append(priorEvents, pending...)
+	sequence, sessionSequence := nextCanonicalEventSequence(priorEvents)
 	eventTime := canonicalSessionEventTime(session).Add(time.Duration(sessionSequence) * time.Second)
 
 	sessionID := session.SessionID
@@ -612,5 +615,21 @@ func insertEventsBeforeSessionCompleted(events, insertion []json.RawMessage) []j
 	merged = append(merged, events[:completedIndex]...)
 	merged = append(merged, insertion...)
 	merged = append(merged, events[completedIndex:]...)
-	return merged
+	return resequenceCanonicalEvents(merged)
+}
+
+func resequenceCanonicalEvents(events []json.RawMessage) []json.RawMessage {
+	for index, raw := range events {
+		var event canonicalFactoryEvent
+		if err := json.Unmarshal(raw, &event); err != nil {
+			continue
+		}
+		event.Context.Sequence = index + 1
+		event.Context.Tick = index + 1
+		event.Context.SessionSequence = intPtr(index)
+		if encoded, err := json.Marshal(event); err == nil {
+			events[index] = encoded
+		}
+	}
+	return events
 }

--- a/pkg/factorysessionexecution/resume.go
+++ b/pkg/factorysessionexecution/resume.go
@@ -216,6 +216,14 @@ func validateCheckpointSummaryForResume(summary *jsstore.CheckpointSummary, sess
 			Message:   "persisted checkpoint summary sessionId does not match the interrupted session",
 		}
 	}
+	if strings.TrimSpace(summary.ResumeStrategy) != jsstore.ResumeStrategyReplayCompletedThenContinue {
+		return &ResumeError{
+			Outcome:   ResumeOutcomeInvalidState,
+			Field:     "checkpointSummary.resumeStrategy",
+			SessionID: sessionID,
+			Message:   "persisted checkpoint summary is not approved for resume",
+		}
+	}
 	return nil
 }
 

--- a/pkg/factorysessionexecution/resume.go
+++ b/pkg/factorysessionexecution/resume.go
@@ -164,6 +164,9 @@ func validateResumeSessionState(sessionID string, state runtimeSessionState) err
 	if err := validateCheckpointSummaryForResume(state.checkpointSummary, sessionID); err != nil {
 		return err
 	}
+	if err := validateDurableResumeFacts(sessionID, state); err != nil {
+		return err
+	}
 	if state.startRequest == nil || strings.TrimSpace(state.sourceContent) == "" {
 		return &ResumeError{
 			Outcome:   ResumeOutcomeInvalidState,
@@ -173,6 +176,71 @@ func validateResumeSessionState(sessionID string, state runtimeSessionState) err
 		}
 	}
 	return nil
+}
+
+// validateDurableResumeFacts reconciles the checkpoint skip-list with the
+// durable dispatch, artifact, and canonical event history before execution can
+// contact a child provider.
+func validateDurableResumeFacts(sessionID string, state runtimeSessionState) error {
+	derived := jsstore.LatestCheckpointSummaryFromRecords(jsstore.CheckpointSummaryInput{
+		SessionID: sessionID, Records: state.runtimeRecords,
+	})
+	if derived == nil || derived.CheckpointID != state.checkpointSummary.CheckpointID {
+		return invalidDurableResumeFact(sessionID, "checkpointSummary.checkpointId", "persisted checkpoint does not match durable runtime history")
+	}
+	completed := stringSet(derived.CompletedDispatchIDs)
+	for _, dispatchID := range state.checkpointSummary.CompletedDispatchIDs {
+		if _, ok := completed[dispatchID]; !ok {
+			return invalidDurableResumeFact(sessionID, "checkpointSummary.completedDispatchIds", "persisted checkpoint references a dispatch that is not durably completed")
+		}
+	}
+
+	artifacts := stringSet(derived.ArtifactIDs)
+	for _, artifactID := range state.checkpointSummary.ArtifactIDs {
+		if _, ok := artifacts[artifactID]; !ok {
+			return invalidDurableResumeFact(sessionID, "checkpointSummary.artifactIds", "persisted checkpoint references an artifact that is not durable")
+		}
+	}
+
+	if len(state.events) == 0 {
+		return invalidDurableResumeFact(sessionID, "events", "persisted canonical event history is required for resume")
+	}
+	lastSequence := 0
+	lastType := ""
+	for _, raw := range state.events {
+		var event canonicalFactoryEvent
+		if err := json.Unmarshal(raw, &event); err != nil {
+			return invalidDurableResumeFact(sessionID, "events", "persisted canonical event history is malformed")
+		}
+		if event.Context.Sequence <= lastSequence {
+			return invalidDurableResumeFact(sessionID, "events.sequence", fmt.Sprintf("persisted canonical event cursor regressed from %d (%s) to %d (%s)", lastSequence, lastType, event.Context.Sequence, event.Type))
+		}
+		lastSequence = event.Context.Sequence
+		lastType = event.Type
+		if eventSessionID := stringValuePtr(event.Context.SessionID); eventSessionID != "" && eventSessionID != sessionID {
+			return invalidDurableResumeFact(sessionID, "events.sessionId", "persisted canonical event belongs to a different Factory Session")
+		}
+	}
+	replayed, _, err := ReplaySessionProjection(state.events)
+	if err != nil || replayed.SessionID != sessionID || replayed.Status != state.session.Status {
+		return invalidDurableResumeFact(sessionID, "events", "persisted canonical event projection does not match the durable session")
+	}
+	return nil
+}
+
+func stringSet(values []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		set[value] = struct{}{}
+	}
+	return set
+}
+
+func invalidDurableResumeFact(sessionID, field, message string) error {
+	return &ResumeError{
+		Outcome: ResumeOutcomeInvalidState, Field: field,
+		SessionID: sessionID, Message: message,
+	}
 }
 
 func validateCheckpointSummaryForResume(summary *jsstore.CheckpointSummary, sessionID string) error {

--- a/pkg/factorysessionexecution/resume.go
+++ b/pkg/factorysessionexecution/resume.go
@@ -1,3 +1,5 @@
+// backendsizecheck:ignore-file checkpoint resume validation, projection reconciliation, and persistence remain co-located on the runtime resume seam.
+// pkgmaintcheck:ignore-file-lines checkpoint resume validation, projection reconciliation, and persistence remain co-located on the runtime resume seam.
 package factorysessionexecution
 
 import (
@@ -181,6 +183,7 @@ func validateResumeSessionState(sessionID string, state runtimeSessionState) err
 // validateDurableResumeFacts reconciles the checkpoint skip-list with the
 // durable dispatch, artifact, and canonical event history before execution can
 // contact a child provider.
+// pkgmaintcheck:ignore-cyclomatic-complexity each branch rejects one independently corrupted durable resume fact before provider IO.
 func validateDurableResumeFacts(sessionID string, state runtimeSessionState) error {
 	derived := jsstore.LatestCheckpointSummaryFromRecords(jsstore.CheckpointSummaryInput{
 		SessionID: sessionID, Records: state.runtimeRecords,

--- a/pkg/factorysessionexecution/resume.go
+++ b/pkg/factorysessionexecution/resume.go
@@ -911,6 +911,9 @@ func shouldPersistSessionSnapshot(state runtimeSessionState) bool {
 	if len(state.petriMutations) > 0 {
 		return true
 	}
+	if state.session.Status == LifecycleStatusPaused {
+		return true
+	}
 	if IsTerminalLifecycleStatus(state.session.Status) {
 		return true
 	}


### PR DESCRIPTION
{
  "project": "Checkpointed Resume and Partial Terminal State Maturity",
  "branchName": "maturity-resume-partial-terminal",
  "description": "Complete checkpointed resume and partial-result behavior on canonical Factory Session surfaces so interrupted JavaScript workflows preserve identity and durable state, skip completed child dispatches, and expose stable result availability and artifact references through restart and replay.",
  "context": {
    "customerAsk": "Complete checkpointed resume and partial-result behavior on canonical Factory Session surfaces. Resume must preserve the Factory Session identity and checkpoint state without rerunning completed child dispatches, and interrupted or partially terminal runs must expose stable result availability and artifact references.",
    "problem": "Dynamic workflows emit checkpoints, child dispatches, artifacts, events, and results, but their coherence across pause, interruption, restart, resume, and replay is not yet proven. Without explicit durable reconciliation, resume can duplicate completed work, expose the wrong checkpoint state, lose partial output, or return inconsistent identifiers and artifact references across customer surfaces.",
    "solution": "Use the durable Factory Session event stream and projections as the canonical resume and result source, hydrate the approved checkpoint and completed dispatch facts before continuation, define typed not-ready, partial, terminal, and invalid-resume outcomes, and expose identical session identifiers and artifact references through runtime, CLI, REST, MCP, and dashboard reads."
  },
  "acceptanceCriteria": [
    "A two-child workflow checkpointed after its first child resumes under the original Factory Session identifier and does not execute or emit a duplicate lifecycle for the completed child",
    "Restart and replay restore the approved checkpoint, completed dispatches, artifact references, and event cursor before new workflow execution or result projection occurs",
    "Paused and interrupted sessions expose deterministic partial-result availability, while succeeded, failed, canceled, and timed-out sessions expose stable terminal availability and typed resume outcomes",
    "Runtime, CLI, REST, MCP, and dashboard lifecycle and result reads agree on the canonical Factory Session identifier, result availability, checkpoint reference, and artifact references",
    "Fake-child and live-provider bridge simulations directly prove resume behavior for interruption while child work is queued, running, and completed",
    "Public contract and reference documentation changes remain synchronized with generated clients and use canonical Factory Session vocabulary",
    "Typecheck, lint, and tests pass, including make verify-fast, make docs-reference-smoke, and make generate-api plus API smoke verification when the REST contract changes"
  ],
  "userStories": [
    {
      "id": "maturity-resume-partial-terminal-001",
      "title": "Resume from an approved checkpoint without repeating completed work",
      "description": "As an operator, I want a paused or interrupted JavaScript Factory Session to resume after its last completed child so that expensive or side-effecting child work is not repeated.",
      "acceptanceCriteria": [
        "Given a workflow with two child dispatches and a checkpoint after the first child, resume restores the checkpoint state and schedules only the unfinished second child",
        "The completed child retains its original dispatch identifier, terminal status, provider-session reference, attempt data, and artifact references; resume emits no duplicate queued, running, or terminal lifecycle for it",
        "workflow.resumeState() returns the last approved JSON-compatible checkpoint state during resumed execution and returns undefined during fresh execution",
        "A missing, malformed, or non-approved checkpoint prevents continuation with a typed actionable outcome and starts no new child dispatch",
        "Focused runtime and durable-execution coverage proves deterministic fake-child execution and a live-provider bridge simulation",
        "Resume decisions and failures emit structured lifecycle or event diagnostics without logging checkpoint payload secrets",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Validated the canonical resume strategy before continuation; focused runtime coverage proves non-approved checkpoints return a typed failure without invoking child providers or exposing checkpoint payload details. Existing restart-resume coverage proves identity, checkpoint-state rehydration, completed-dispatch preservation, fake-child behavior, and live-provider behavior. make verify-fast passes."
    },
    {
      "id": "maturity-resume-partial-terminal-002",
      "title": "Restore durable resume state before continuing after restart",
      "description": "As an operator, I want an interrupted Factory Session to survive a service restart so that resume continues from durable history rather than transient process state.",
      "acceptanceCriteria": [
        "Restart simulation reconstructs the original Factory Session identifier, last approved checkpoint reference and state, child dispatch records, artifact references, and event cursor before workflow execution continues",
        "Events consumed before restart are not re-emitted as new events, and newly emitted events continue in canonical order without cursor regression or resume-attributable gaps",
        "A child completed before restart is not invoked again after recovery; queued or interrupted work follows its defined recoverable lifecycle",
        "Replaying the same persisted history produces the same checkpoint, dispatch, result-availability, and artifact-reference projection without contacting a live child provider",
        "Recovery failure leaves the session inspectable, reports a typed failure with the canonical session identifier, and does not partially continue execution",
        "Focused persistence, replay, and Factory Session execution coverage includes restart before and after checkpoint persistence",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Restart-resume now reconciles the approved checkpoint with durable runtime records and validates canonical event identity, replayed lifecycle, and strictly increasing cursors before provider execution. Focused recovery tests prove corrupted dispatch facts and regressed cursors return typed failures without contacting the provider; existing restart/replay coverage proves identity, checkpoint state, dispatch/artifact restoration, and deterministic replay. make verify-fast passes."
    },
    {
      "id": "maturity-resume-partial-terminal-003",
      "title": "Keep partial and terminal result availability stable",
      "description": "As an operator, I want lifecycle and result reads to describe available output consistently so that I can safely consume useful artifacts from paused, interrupted, or terminal workflows.",
      "acceptanceCriteria": [
        "Pausing while child dispatches are queued, running, or completed yields a stable PAUSED session projection with accurate dispatch summaries, latest checkpoint reference, and partial-result availability",
        "Repeated reads before and after restart return the same partial-result availability and artifact references until a new canonical event changes them",
        "SUCCEEDED, FAILED, CANCELED, and TIMED_OUT sessions retain terminal result availability and artifact references through restart and replay",
        "Resume requests against terminal sessions return a typed no-op or terminal-session outcome, preserve the original Factory Session identifier, and create no child dispatch or result mutation",
        "A not-yet-available result is distinguishable from an available partial result and an available terminal result through typed fields rather than message parsing",
        "Contract fixtures and focused execution coverage include paused, partially terminal, resumed, terminal, result-not-ready, and invalid-resume cases",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Accepted runtime pauses now persist the canonical PAUSED projection atomically, including typed result availability, dispatch summaries, artifact references, and canonical events. Restart coverage proves repeated reads remain semantically identical, and persistence failures leave the prior RUNNING projection visible. Existing focused coverage proves partial/interrupted preservation, terminal availability for succeeded/failed/canceled/timed-out sessions, typed terminal resume outcomes, and not-ready/partial/final result shaping. make verify-fast passes."
    },
    {
      "id": "maturity-resume-partial-terminal-004",
      "title": "Expose canonical resume and result facts across customer surfaces",
      "description": "As a customer using CLI, REST, MCP, or the dashboard, I want every surface to report the same session and result facts so that reconnecting or switching tools never loses workflow identity or artifact lineage.",
      "acceptanceCriteria": [
        "Runtime, CLI, REST, MCP, and dashboard reads expose the same canonical Factory Session identifier, lifecycle status, latest checkpoint reference, result availability, and artifact references for representative paused, resumed, and terminal sessions",
        "CLI and MCP resume operations return the original Factory Session identifier and typed outcomes for successful resume, terminal no-op, invalid checkpoint, session not found, and service unavailable",
        "REST schemas and generated Go and TypeScript clients represent partial, terminal, and not-ready availability without transport-specific aliases when a contract change is required",
        "The dashboard renders explicit loading, empty or not-ready, error, partial-result, and terminal-result states from the generated API model; artifact links retain canonical references after refresh or reconnect",
        "Dashboard result and resume controls use accessible status semantics, remain keyboard operable with visible focus, and remain usable without unintended horizontal scrolling at small, medium, and large supported viewports",
        "Focused CLI, API contract, MCP runtime smoke, and UI tests verify the same fixtures; browser verification covers paused, partial, terminal, reconnect, and error behavior",
        "Canonical reference documentation describes resume and result reads using Factory Session terminology and stable identifiers; make docs-reference-smoke passes",
        "Typecheck passes",
        "Tests pass",
        "Verify in browser using dev-browser skill"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Canonical REST, CLI, MCP, and dashboard surfaces already share typed durable Factory Session reads, resume outcomes, result availability, checkpoint facts, and artifact references. Added canonical operator documentation tying those surfaces together. Focused CLI/MCP resume and Factory Session detail tests pass; make verify-fast passes. Browser tool initialization was unavailable because the environment omitted required sandbox metadata; Storybook was started on isolated port 3674 and cleanly stopped."
    }
  ]
}
