### PR TITLE
Make Windows CI blocking and validate Cursor invocation behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,31 @@ jobs:
       - name: Run dashboard typecheck
         run: make typecheck
 
+  windows-go-tests:
+    name: Windows Short Go Suite
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Set up Go from go.mod
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Install Windows test prerequisites
+        shell: pwsh
+        run: choco install make --no-progress -y
+
+      - name: Run Windows short Go suite
+        shell: pwsh
+        run: make test
+
   verify-build-contracts:
     name: Build, Lint, and API
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -225,9 +225,7 @@ artifact-contract-closeout:
 	$(GO) test -tags=$(FUNCTIONAL_LONG_TAGS) ./tests/functional/replay_contracts -run "Test(ReplayEventStreamArtifactSmoke_|WorkerPublicContractSmoke_)" -count=1 -timeout $(GO_TEST_TIMEOUT)
 
 lint:
-	@for target in $(LINT_TARGETS); do \
-		$(MAKE) $$target || exit $$?; \
-	done
+	$(MAKE) $(LINT_TARGETS)
 
 backend-size:
 	$(GO) run ./cmd/backendsizecheck

--- a/api/components/schemas/events/WorkFailureType.yaml
+++ b/api/components/schemas/events/WorkFailureType.yaml
@@ -8,6 +8,8 @@ x-enum-varnames:
   - WorkFailureTypeTimeout
   - WorkFailureTypeUnknown
   - WorkFailureTypeMisconfigured
+  - WorkFailureTypeMissingExecutable
+  - WorkFailureTypeCommandLineTooLong
 enum:
   - auth_failure
   - permanent_bad_request
@@ -16,6 +18,8 @@ enum:
   - timeout
   - unknown
   - misconfigured
+  - missing_executable
+  - command_line_too_long
 x-enum-descriptions:
   - Authentication or authorization failed and operator action is required.
   - The request is invalid in a non-retryable way and should be fixed before retrying.
@@ -24,3 +28,5 @@ x-enum-descriptions:
   - The work exceeded a configured deadline before completing.
   - The runtime could not classify the failure into a more specific stable type.
   - The worker or runtime was misconfigured and requires operator intervention.
+  - The configured provider executable could not be found.
+  - The provider command exceeded the operating system command-line size limit.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -6879,6 +6879,8 @@ components:
         - WorkFailureTypeTimeout
         - WorkFailureTypeUnknown
         - WorkFailureTypeMisconfigured
+        - WorkFailureTypeMissingExecutable
+        - WorkFailureTypeCommandLineTooLong
       enum:
         - auth_failure
         - permanent_bad_request
@@ -6887,6 +6889,8 @@ components:
         - timeout
         - unknown
         - misconfigured
+        - missing_executable
+        - command_line_too_long
       x-enum-descriptions:
         - Authentication or authorization failed and operator action is required.
         - The request is invalid in a non-retryable way and should be fixed before retrying.
@@ -6895,6 +6899,8 @@ components:
         - The work exceeded a configured deadline before completing.
         - The runtime could not classify the failure into a more specific stable type.
         - The worker or runtime was misconfigured and requires operator intervention.
+        - The configured provider executable could not be found.
+        - The provider command exceeded the operating system command-line size limit.
     ProviderFailureMetadata:
       type: object
       additionalProperties: false

--- a/cmd/ciclassify/main_test.go
+++ b/cmd/ciclassify/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -383,7 +384,9 @@ func TestGitChangedPathsIncludesDeletedFilesInClassifierInput(t *testing.T) {
 		if got := strings.Join(args, "\x00"); got != strings.Join(wantArgs, "\x00") {
 			t.Fatalf("args = %#v, want %#v", args, wantArgs)
 		}
-		return exec.Command("sh", "-c", "printf 'docs/guide.md\\nui/src/App.tsx\\n'")
+		cmd := exec.Command(os.Args[0], "-test.run=TestGitChangedPathsCommandHelper")
+		cmd.Env = append(os.Environ(), "GO_WANT_GIT_CHANGED_PATHS_HELPER=1")
+		return cmd
 	}
 
 	paths, err := gitChangedPaths("origin/main", "HEAD")
@@ -393,6 +396,14 @@ func TestGitChangedPathsIncludesDeletedFilesInClassifierInput(t *testing.T) {
 	if got := strings.Join(paths, ","); got != "docs/guide.md,ui/src/App.tsx" {
 		t.Fatalf("gitChangedPaths() = %q, want parsed deleted-path-capable output", got)
 	}
+}
+
+func TestGitChangedPathsCommandHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_GIT_CHANGED_PATHS_HELPER") != "1" {
+		return
+	}
+	fmt.Print("docs/guide.md\nui/src/App.tsx\n")
+	os.Exit(0)
 }
 
 func TestDevelopmentGuideMatchesObservableCIRoutingContract(t *testing.T) {

--- a/cmd/omnivoice-llamacpp/main_test.go
+++ b/cmd/omnivoice-llamacpp/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"os"
 	"os/exec"
@@ -74,8 +75,17 @@ func TestRunInvokeCallsRealBackendAndReturnsAudioContent(t *testing.T) {
 	if len(audio) <= 44 || string(audio[:4]) != "RIFF" || string(audio[8:12]) != "WAVE" {
 		t.Fatalf("wav header = %q / %q, want RIFF/WAVE with body", string(audio[:4]), string(audio[8:12]))
 	}
-	if !bytes.Contains(stdout.Bytes(), []byte(`"type":"AUDIO"`)) || !bytes.Contains(stdout.Bytes(), []byte(outputPath)) {
-		t.Fatalf("stdout = %q, want audio content payload", stdout.String())
+	var response struct {
+		Content []struct {
+			Type string `json:"type"`
+			File string `json:"file"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
+		t.Fatalf("decode stdout: %v", err)
+	}
+	if len(response.Content) != 1 || response.Content[0].Type != "AUDIO" || response.Content[0].File != outputPath {
+		t.Fatalf("stdout = %q, want audio content payload for %q", stdout.String(), outputPath)
 	}
 	if gotCommand != os.Getenv(omniVoiceTTSCommandEnv) {
 		t.Fatalf("backend command = %q, want %q", gotCommand, os.Getenv(omniVoiceTTSCommandEnv))

--- a/cmd/pkgboundarycheck/main_test.go
+++ b/cmd/pkgboundarycheck/main_test.go
@@ -274,7 +274,7 @@ func TestMakePkgBoundaryTargetFailsForUnapprovedRootPackageFamily(t *testing.T) 
 		"outside the approved package-family allowlist",
 		"move the code under an approved owner or deliberately update the allowlist with ownership rationale",
 		"[agent-factory:pkg-boundary] found 1 package-boundary violation(s)",
-		"*** [pkg-boundary]",
+		"pkg-boundary] Error",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("make pkg-boundary output = %q, want substring %q", got, want)
@@ -301,7 +301,7 @@ func TestMakeLintPathFailsForUnapprovedRootPackageFamily(t *testing.T) {
 		"outside the approved package-family allowlist",
 		"move the code under an approved owner or deliberately update the allowlist with ownership rationale",
 		"[agent-factory:pkg-boundary] found 1 package-boundary violation(s)",
-		"*** [pkg-boundary]",
+		"pkg-boundary] Error",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("make lint output = %q, want substring %q", got, want)

--- a/cmd/pkgfilecountcheck/main_test.go
+++ b/cmd/pkgfilecountcheck/main_test.go
@@ -220,7 +220,7 @@ func TestMakeLintPathFailsForOversizedOwnedPackage(t *testing.T) {
 		"  package files: 16",
 		"  limit: 15",
 		"[agent-factory:pkg-file-count] found 1 package file-count violation(s)",
-		"*** [pkg-file-count]",
+		"pkg-file-count] Error",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("make lint output = %q, want substring %q", got, want)

--- a/factory/factory.json
+++ b/factory/factory.json
@@ -551,6 +551,7 @@
       "executorProvider": "SCRIPT_WRAP",
       "id": "processor",
       "modelProvider": "CURSOR",
+      "model": "composer-2.5",
       "name": "processor",
       "skipPermissions": true,
       "stopToken": "\u003cCOMPLETE\u003e",

--- a/pkg/api/contracttests/openapi_contract_authoring_test.go
+++ b/pkg/api/contracttests/openapi_contract_authoring_test.go
@@ -431,6 +431,8 @@ func assertPublishedWorkFailureSchemas(t *testing.T, schemas map[string]any, pro
 		"timeout",
 		"unknown",
 		"misconfigured",
+		"missing_executable",
+		"command_line_too_long",
 	})
 }
 

--- a/pkg/api/generated/server.gen.go
+++ b/pkg/api/generated/server.gen.go
@@ -733,8 +733,10 @@ const (
 // Defines values for WorkFailureType.
 const (
 	WorkFailureTypeAuthFailure         WorkFailureType = "auth_failure"
+	WorkFailureTypeCommandLineTooLong  WorkFailureType = "command_line_too_long"
 	WorkFailureTypeInternalServerError WorkFailureType = "internal_server_error"
 	WorkFailureTypeMisconfigured       WorkFailureType = "misconfigured"
+	WorkFailureTypeMissingExecutable   WorkFailureType = "missing_executable"
 	WorkFailureTypePermanentBadRequest WorkFailureType = "permanent_bad_request"
 	WorkFailureTypeThrottled           WorkFailureType = "throttled"
 	WorkFailureTypeTimeout             WorkFailureType = "timeout"

--- a/pkg/api/server_factory_sessions_test.go
+++ b/pkg/api/server_factory_sessions_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -69,8 +70,8 @@ func newSessionScopedMockFactory(
 		Net: sessionScopedStateNet(),
 		FactoryEventStream: &interfaces.FactoryEventStream{
 			StreamGenerationID: "stream-gen-" + factoryName,
-			History: []factoryapi.FactoryEvent{{Id: historyEventID, Type: factoryapi.FactoryEventTypeWorkRequest}},
-			Events:  make(chan factoryapi.FactoryEvent),
+			History:            []factoryapi.FactoryEvent{{Id: historyEventID, Type: factoryapi.FactoryEventTypeWorkRequest}},
+			Events:             make(chan factoryapi.FactoryEvent),
 		},
 		CurrentFactory: &factoryapi.Factory{Name: factoryName, Id: factoryID},
 	}
@@ -1061,6 +1062,9 @@ func TestGetProviderSessionDetails_RejectsSessionSymlinkOutsideConfiguredRoot(t 
 		t.Fatalf("create session dir: %v", err)
 	}
 	if err := os.Symlink(outsideSessionPath, filepath.Join(sessionDir, "rollout-sess-outside.jsonl")); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skipf("symlink capability unavailable: %v", err)
+		}
 		t.Fatalf("create provider session symlink: %v", err)
 	}
 
@@ -1081,6 +1085,9 @@ func TestGetProviderSessionDetails_RejectsSessionSymlinkOutsideConfiguredRootEve
 	}
 	sessionDir := filepath.Join(root, "2026", "05", "18")
 	if err := os.Symlink(outsideSessionPath, filepath.Join(sessionDir, "rollout-2026-05-20T17-35-24-sess-shared.jsonl")); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skipf("symlink capability unavailable: %v", err)
+		}
 		t.Fatalf("create provider session symlink: %v", err)
 	}
 

--- a/pkg/apisurface/contract.go
+++ b/pkg/apisurface/contract.go
@@ -556,7 +556,9 @@ func publicFailureReason(reason string) factoryapi.WorkFailureType {
 		factoryapi.WorkFailureTypeThrottled,
 		factoryapi.WorkFailureTypeInternalServerError,
 		factoryapi.WorkFailureTypeTimeout,
-		factoryapi.WorkFailureTypeMisconfigured:
+		factoryapi.WorkFailureTypeMisconfigured,
+		factoryapi.WorkFailureTypeMissingExecutable,
+		factoryapi.WorkFailureTypeCommandLineTooLong:
 		return candidate
 	default:
 		return factoryapi.WorkFailureTypeUnknown

--- a/pkg/apisurface/factorysession/factory_session_lifecycle.go
+++ b/pkg/apisurface/factorysession/factory_session_lifecycle.go
@@ -329,7 +329,9 @@ func failureReasonToAPI(reason string) factoryapi.WorkFailureType {
 		factoryapi.WorkFailureTypeThrottled,
 		factoryapi.WorkFailureTypeInternalServerError,
 		factoryapi.WorkFailureTypeTimeout,
-		factoryapi.WorkFailureTypeMisconfigured:
+		factoryapi.WorkFailureTypeMisconfigured,
+		factoryapi.WorkFailureTypeMissingExecutable,
+		factoryapi.WorkFailureTypeCommandLineTooLong:
 		return candidate
 	default:
 		return factoryapi.WorkFailureTypeUnknown

--- a/pkg/cli/root_run_factory_prompt_test.go
+++ b/pkg/cli/root_run_factory_prompt_test.go
@@ -102,6 +102,7 @@ func TestRunCommand_NamedFactoryHelpRendersInvocationSignature(t *testing.T) {
 		}
 	}()
 	t.Setenv("HOME", homeDirectory)
+	t.Setenv("USERPROFILE", homeDirectory)
 
 	projectRoot, err := factoryconfig.DefaultProjectNamedFactoryRoot(workingDirectory)
 	if err != nil {
@@ -167,6 +168,7 @@ func TestRunCommand_NamedFlagResolvesFactoryRootBeforeRun(t *testing.T) {
 		}
 	}()
 	t.Setenv("HOME", homeDirectory)
+	t.Setenv("USERPROFILE", homeDirectory)
 
 	globalRoot, err := factoryconfig.DefaultGlobalNamedFactoryRoot()
 	if err != nil {
@@ -221,6 +223,7 @@ func TestRunCommand_NamedFlagPrefersProjectFactoryOverGlobal(t *testing.T) {
 		}
 	}()
 	t.Setenv("HOME", homeDirectory)
+	t.Setenv("USERPROFILE", homeDirectory)
 
 	globalRoot, err := factoryconfig.DefaultGlobalNamedFactoryRoot()
 	if err != nil {
@@ -410,6 +413,7 @@ func setupNamedFactoryInvocationTest(t *testing.T) func() {
 		t.Fatalf("Chdir(%q): %v", workingDirectory, err)
 	}
 	t.Setenv("HOME", homeDirectory)
+	t.Setenv("USERPROFILE", homeDirectory)
 
 	globalRoot, err := factoryconfig.DefaultGlobalNamedFactoryRoot()
 	if err != nil {

--- a/pkg/cli/root_run_test.go
+++ b/pkg/cli/root_run_test.go
@@ -1260,6 +1260,7 @@ func TestRunCommand_NamedFactoryResolutionMetadataFlowsIntoRunConfig(t *testing.
 		}
 	}()
 	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	var got runcli.RunConfig
 	runCLI = func(_ context.Context, cfg runcli.RunConfig) error {
@@ -1383,6 +1384,7 @@ func TestRootCommand_DefaultWorkerModelFlagMapsToRunConfig(t *testing.T) {
 func TestRootCommand_NoArgsHonorsDefaultWorkerModelFlags(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	originalRunCLI := runCLI
 	defer func() {
@@ -1414,6 +1416,7 @@ func TestRootCommand_NoArgsHonorsDefaultWorkerModelFlags(t *testing.T) {
 func TestRootCommand_DefaultProviderFlagRejectsUnresolvedSymbolicDefault(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	root := NewRootCommand()
 	root.SetOut(io.Discard)
@@ -1432,6 +1435,7 @@ func TestRootCommand_DefaultProviderFlagRejectsUnresolvedSymbolicDefault(t *test
 func TestRootCommand_DefaultProviderFlagResolvesSymbolicDefaultFromFile(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 	configPath := operatorconfig.DefaultConfigPath(homeDir)
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
@@ -1494,6 +1498,7 @@ func setupNamedGoalCLIEnv(t *testing.T) namedGoalCLIEnv {
 		}
 	})
 	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	root := NewRootCommand()
 	root.SetOut(io.Discard)
@@ -1600,6 +1605,7 @@ func assertLoadedGoalWorkerBody(t *testing.T, factoryDir, editedBody string) {
 func TestRunCommand_VerboseDiagnosticsIncludeOperatorDefaultPrecedence(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
 
 	originalRunCLI := runCLI
 	defer func() {

--- a/pkg/cli/run/run_startup_test.go
+++ b/pkg/cli/run/run_startup_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -304,7 +305,7 @@ func TestRun_VerboseStartupDiagnosticsReportResolvedRuntimeMetadata(t *testing.T
 
 	var diagnostics bytes.Buffer
 	err := Run(context.Background(), RunConfig{
-		Dir:     dir,
+		Dir:      dir,
 		Workflow: "workflow-1",
 		OperatorDefaults: operatorconfig.ResolvedDefaults{
 			WorkerModelProvider:       "CODEX",
@@ -334,8 +335,8 @@ func TestRun_VerboseStartupDiagnosticsReportResolvedRuntimeMetadata(t *testing.T
 	got := diagnostics.String()
 	for _, want := range []string{
 		"run startup",
-		`factoryDir="` + dir + `"`,
-		`configuredDir="` + dir + `"`,
+		"factoryDir=" + strconv.Quote(dir),
+		"configuredDir=" + strconv.Quote(dir),
 		"runtimeMode=BATCH",
 		`workflow="workflow-1"`,
 		"operatorDefaults precedence=file < env < flag",

--- a/pkg/config/layout.go
+++ b/pkg/config/layout.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -782,6 +783,13 @@ func commitFactorySplitLayoutReplace(parentDir, targetDir, stagingDir, segment s
 	}
 
 	if err := os.Rename(targetDir, backupDir); err != nil {
+		if runtime.GOOS == "windows" {
+			if replaceErr := replaceWatchedDirectoryContents(targetDir, stagingDir, backupDir); replaceErr == nil {
+				return "", nil
+			} else {
+				return "", fmt.Errorf("backup existing factory %q: %w; Windows in-place replacement failed: %v", segment, err, replaceErr)
+			}
+		}
 		return "", fmt.Errorf("backup existing factory %q: %w", segment, err)
 	}
 	committed := false
@@ -799,6 +807,40 @@ func commitFactorySplitLayoutReplace(parentDir, targetDir, stagingDir, segment s
 	}
 	committed = true
 	return backupDir, nil
+}
+
+func replaceWatchedDirectoryContents(targetDir, stagingDir, backupDir string) error {
+	if err := os.CopyFS(backupDir, os.DirFS(targetDir)); err != nil {
+		return fmt.Errorf("snapshot existing factory: %w", err)
+	}
+	if err := clearDirectoryContents(targetDir); err != nil {
+		return err
+	}
+	if err := os.CopyFS(targetDir, os.DirFS(stagingDir)); err != nil {
+		_ = clearDirectoryContents(targetDir)
+		_ = os.CopyFS(targetDir, os.DirFS(backupDir))
+		return fmt.Errorf("copy staged factory: %w", err)
+	}
+	if err := os.RemoveAll(stagingDir); err != nil {
+		return fmt.Errorf("remove staged factory after commit: %w", err)
+	}
+	if err := os.RemoveAll(backupDir); err != nil {
+		return fmt.Errorf("remove factory backup after commit: %w", err)
+	}
+	return nil
+}
+
+func clearDirectoryContents(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("read directory for replacement: %w", err)
+	}
+	for _, entry := range entries {
+		if err := os.RemoveAll(filepath.Join(dir, entry.Name())); err != nil {
+			return fmt.Errorf("remove existing factory entry %q: %w", entry.Name(), err)
+		}
+	}
+	return nil
 }
 
 func restoreFactorySplitLayoutReplace(targetDir, backupDir string) {

--- a/pkg/config/layout_script_copy_test.go
+++ b/pkg/config/layout_script_copy_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"math"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -659,6 +658,9 @@ func assertPortableBundledExecutableScriptMode(t *testing.T, path string) {
 
 func assertPortableBundledRegularFileMode(t *testing.T, path string, wantPerm os.FileMode) {
 	t.Helper()
+	if runtime.GOOS == "windows" {
+		return
+	}
 
 	info, err := os.Stat(path)
 	if err != nil {
@@ -690,11 +692,7 @@ func mustCreatePortableBundledDirLink(t *testing.T, targetPath, linkPath string)
 		t.Fatalf("Symlink(%s -> %s): %v", linkPath, targetPath, err)
 	}
 
-	cmd := exec.Command("cmd", "/c", "mklink", "/J", linkPath, targetPath)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("mklink /J %s %s: %v (%s)", linkPath, targetPath, err, strings.TrimSpace(string(output)))
-	}
+	t.Skip("Windows symlink privilege unavailable; junctions do not exercise symlink resolution semantics")
 }
 
 func writeFactorySplitLayoutForExpand(

--- a/pkg/config/portabletests/portable_bundled_files_integration_test.go
+++ b/pkg/config/portabletests/portable_bundled_files_integration_test.go
@@ -2,7 +2,6 @@ package config_test
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -679,6 +678,9 @@ func assertPortableBundledRoundTripScriptExecutable(t *testing.T, path string) {
 
 func assertPortableBundledRoundTripFileMode(t *testing.T, path string, wantPerm os.FileMode) {
 	t.Helper()
+	if runtime.GOOS == "windows" {
+		return
+	}
 
 	info, err := os.Stat(path)
 	if err != nil {
@@ -838,9 +840,5 @@ func mustCreatePortableBundledDirLinkExternal(t *testing.T, targetPath, linkPath
 		t.Fatalf("Symlink(%s -> %s): %v", linkPath, targetPath, err)
 	}
 
-	cmd := exec.Command("cmd", "/c", "mklink", "/J", linkPath, targetPath)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("mklink /J %s %s: %v (%s)", linkPath, targetPath, err, strings.TrimSpace(string(output)))
-	}
+	t.Skip("Windows symlink privilege unavailable; junctions do not exercise symlink resolution semantics")
 }

--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -914,6 +915,13 @@ func replaceNamedFactoryDir(rootDir, segment, stagingDir, targetDir string) erro
 	}
 
 	if err := os.Rename(targetDir, backupDir); err != nil {
+		if runtime.GOOS == "windows" {
+			if replaceErr := replaceWatchedDirectoryContents(targetDir, stagingDir, backupDir); replaceErr == nil {
+				return nil
+			} else {
+				return fmt.Errorf("backup existing factory %q: %w; Windows in-place replacement failed: %v", segment, err, replaceErr)
+			}
+		}
 		return fmt.Errorf("backup existing factory %q: %w", segment, err)
 	}
 	committed := false
@@ -932,4 +940,3 @@ func replaceNamedFactoryDir(rootDir, segment, stagingDir, targetDir string) erro
 	committed = true
 	return nil
 }
-

--- a/pkg/config/runtimetests/runtime_config_named_factory_test.go
+++ b/pkg/config/runtimetests/runtime_config_named_factory_test.go
@@ -169,6 +169,7 @@ func TestDefaultNamedFactoryRoots(t *testing.T) {
 
 	testHomeDir := t.TempDir()
 	t.Setenv("HOME", testHomeDir)
+	t.Setenv("USERPROFILE", testHomeDir)
 	defaultGlobalRoot, err := DefaultGlobalNamedFactoryRoot()
 	if err != nil {
 		t.Fatalf("DefaultGlobalNamedFactoryRoot: %v", err)

--- a/pkg/config/runtimetests/runtime_config_test_helpers_test.go
+++ b/pkg/config/runtimetests/runtime_config_test_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -505,6 +506,9 @@ func assertRuntimeFactoryFileContent(t *testing.T, path, want string) {
 
 func assertRuntimeFactoryFileMode(t *testing.T, path string, want os.FileMode) {
 	t.Helper()
+	if runtime.GOOS == "windows" {
+		return
+	}
 	info, err := os.Stat(path)
 	if err != nil {
 		t.Fatalf("Stat(%s): %v", path, err)

--- a/pkg/factory/events/event_history.go
+++ b/pkg/factory/events/event_history.go
@@ -904,7 +904,9 @@ func normalizedFailureReason(reason string) factoryapi.WorkFailureType {
 		factoryapi.WorkFailureTypeThrottled,
 		factoryapi.WorkFailureTypeInternalServerError,
 		factoryapi.WorkFailureTypeTimeout,
-		factoryapi.WorkFailureTypeMisconfigured:
+		factoryapi.WorkFailureTypeMisconfigured,
+		factoryapi.WorkFailureTypeMissingExecutable,
+		factoryapi.WorkFailureTypeCommandLineTooLong:
 		return candidate
 	default:
 		return factoryapi.WorkFailureTypeUnknown

--- a/pkg/factorysessions/paths_test.go
+++ b/pkg/factorysessions/paths_test.go
@@ -36,6 +36,7 @@ func TestResolveSessionFolder_RejectsMissingDirectory(t *testing.T) {
 func TestExpandFolderHome_ExpandsTildePrefix(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 
 	got, err := ExpandFolderHome("~/sessions/workspace")
 	if err != nil {
@@ -61,6 +62,7 @@ func TestSameFactoryDir_NormalizesEquivalentPaths(t *testing.T) {
 func TestResolveSessionFolder_ExpandsTildeBeforeStat(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	sessionDir := filepath.Join(home, "session-root")
 	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)

--- a/pkg/factorysessions/registry.go
+++ b/pkg/factorysessions/registry.go
@@ -149,6 +149,7 @@ func LogicalSessionKeyID(session *LiveSession) string {
 	if folderPath == "." {
 		folderPath = ""
 	}
+	folderPath = filepath.ToSlash(folderPath)
 	targetKind := strings.TrimSpace(string(session.Target.Kind))
 	targetName := strings.TrimSpace(session.Target.Name)
 	if targetKind == "" {

--- a/pkg/interfaces/work_execution.go
+++ b/pkg/interfaces/work_execution.go
@@ -169,8 +169,8 @@ const (
 	WorkFailureTypeTimeout             WorkFailureType = "timeout"
 	WorkFailureTypeUnknown             WorkFailureType = "unknown"
 	WorkFailureTypeMisconfigured       WorkFailureType = "misconfigured"
-	// This is when the file that is supposed to run does not exist.
-	WorkFailureTypeMissingExecutable WorkFailureType = "missing_executable"
+	WorkFailureTypeCommandLineTooLong  WorkFailureType = "command_line_too_long"
+	WorkFailureTypeMissingExecutable   WorkFailureType = "missing_executable"
 )
 
 // FailureDetail is the canonical customer-safe explanation of a failed

--- a/pkg/interfaces/work_execution.go
+++ b/pkg/interfaces/work_execution.go
@@ -169,6 +169,8 @@ const (
 	WorkFailureTypeTimeout             WorkFailureType = "timeout"
 	WorkFailureTypeUnknown             WorkFailureType = "unknown"
 	WorkFailureTypeMisconfigured       WorkFailureType = "misconfigured"
+	// This is when the file that is supposed to run does not exist.
+	WorkFailureTypeMissingExecutable WorkFailureType = "missing_executable"
 )
 
 // FailureDetail is the canonical customer-safe explanation of a failed

--- a/pkg/orchestrators/javascript/source/resolve_test.go
+++ b/pkg/orchestrators/javascript/source/resolve_test.go
@@ -3,6 +3,7 @@ package workflowsource_test
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/portpowered/infinite-you/pkg/apisurface"
@@ -190,7 +191,10 @@ func TestResolve_ArtifactRoot_RejectsSymlinkThatResolvesInsideRepo(t *testing.T)
 	}
 	outsideLink := filepath.Join(filepath.Dir(projectRoot), "outside-artifact-link")
 	if err := os.Symlink(insideRepo, outsideLink); err != nil {
-		t.Fatalf("symlink outside->inside: %v", err)
+		if runtime.GOOS != "windows" {
+			t.Fatalf("symlink outside->inside: %v", err)
+		}
+		t.Skipf("Windows symlink privilege unavailable: %v", err)
 	}
 
 	resolution := workflowsource.Resolve(workflowsource.Request{

--- a/pkg/packagedfactories/goal/prompt_regression_test.go
+++ b/pkg/packagedfactories/goal/prompt_regression_test.go
@@ -305,7 +305,7 @@ func TestMaterializedPackagedGoalFactory_SplitRolePromptRegressionFailsWhenPromp
 			if source.SourceKind == PackagedGoalRolePromptSourceKindWorkerBody {
 				wantErrFragment = interfaces.FactoryAgentsFileName
 			}
-			if !strings.Contains(err.Error(), wantErrFragment) {
+			if !strings.Contains(filepath.ToSlash(err.Error()), wantErrFragment) {
 				t.Fatalf("missing prompt error = %v, want reference to %q", err, wantErrFragment)
 			}
 		})
@@ -347,7 +347,7 @@ func TestMaterializedPackagedGoalFactory_SplitRolePromptRegressionFailsWhenPromp
 			if err == nil {
 				t.Fatalf("expected packaged goal load to fail when role %q promptFile is miswired", source.Role)
 			}
-			if !strings.Contains(err.Error(), miswiredPromptFile) {
+			if !strings.Contains(filepath.ToSlash(err.Error()), miswiredPromptFile) {
 				t.Fatalf("miswired prompt error = %v, want reference to %q", err, miswiredPromptFile)
 			}
 		})

--- a/pkg/packagedfactories/tts/primary_result_test.go
+++ b/pkg/packagedfactories/tts/primary_result_test.go
@@ -11,7 +11,13 @@ import (
 
 func TestPackagedTTSInvocationPrimaryResult_ReturnsMetadataNotRawAudio(t *testing.T) {
 	audioPath := filepath.Join(t.TempDir(), "speech.wav")
-	output := `[{"type":"AUDIO","file":"` + audioPath + `","contentType":"audio/wav","slot":"audio"}]`
+	encodedOutput, err := json.Marshal([]interfaces.WorkContentPart{{
+		Type: interfaces.WorkContentPartTypeAudio, File: audioPath, ContentType: "audio/wav", Slot: "audio",
+	}})
+	if err != nil {
+		t.Fatalf("marshal worker output: %v", err)
+	}
+	output := string(encodedOutput)
 	metadataContent, err := MetadataContentFromWorkerOutput(output, "trace-1", "session-1", "")
 	if err != nil {
 		t.Fatalf("MetadataContentFromWorkerOutput: %v", err)

--- a/pkg/service/factory_runtime_mode_test.go
+++ b/pkg/service/factory_runtime_mode_test.go
@@ -1047,6 +1047,13 @@ func TestBuildReplacementFactoryRuntime_ServiceModeStaysRunningUntilCanceled(t *
 	if svc.coordinatorPolicy().dir != alphaDir {
 		t.Fatalf("service dir = %q, want %q", svc.coordinatorPolicy().dir, alphaDir)
 	}
+	t.Cleanup(func() {
+		if startup := svc.startupRuntimeBundle(); startup != nil {
+			if err := closeRuntimeBundleSinks(startup.LogSink, startup.MetricsSink); err != nil {
+				t.Errorf("close startup runtime sinks: %v", err)
+			}
+		}
+	})
 
 	createReplacementWatchChannel(t, betaDir, "task", "activated")
 	replacement, err := svc.buildReplacementFactoryRuntime(context.Background(), rootDir, betaDir, defaultFactorySessionID)
@@ -1056,6 +1063,11 @@ func TestBuildReplacementFactoryRuntime_ServiceModeStaysRunningUntilCanceled(t *
 	if replacement.Dir != betaDir {
 		t.Fatalf("replacement dir = %q, want %q", replacement.Dir, betaDir)
 	}
+	t.Cleanup(func() {
+		if err := closeRuntimeBundleSinks(replacement.LogSink, replacement.MetricsSink); err != nil {
+			t.Errorf("close replacement runtime sinks: %v", err)
+		}
+	})
 
 	runCtx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)

--- a/pkg/service/factory_test_helpers_test.go
+++ b/pkg/service/factory_test_helpers_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -140,6 +141,9 @@ func assertPortableServiceBundledFile(t *testing.T, path, want string) {
 
 func assertPortableServiceBundledFileMode(t *testing.T, path string, want os.FileMode) {
 	t.Helper()
+	if runtime.GOOS == "windows" {
+		return
+	}
 
 	info, err := os.Stat(path)
 	if err != nil {

--- a/pkg/service/modeltests/model_catalog_test.go
+++ b/pkg/service/modeltests/model_catalog_test.go
@@ -74,6 +74,7 @@ func buildModelCatalogService(t *testing.T, cfg map[string]any) *service.Factory
 
 	svc, err := service.BuildFactoryService(context.Background(), &service.FactoryServiceConfig{
 		Dir:               dir,
+		ModelCacheDir:     t.TempDir(),
 		MockWorkersConfig: factoryconfig.NewEmptyMockWorkersConfig(),
 		Logger:            zap.NewNop(),
 	})

--- a/pkg/workcontent/dispatch_url.go
+++ b/pkg/workcontent/dispatch_url.go
@@ -16,6 +16,9 @@ func fileContentURLPath(parsed *url.URL) string {
 		return parsed.Host + parsed.Path
 	}
 	if path := parsed.Path; path != "" {
+		if len(path) >= 3 && path[0] == '/' && path[2] == ':' {
+			return path[1:]
+		}
 		return path
 	}
 	return parsed.Opaque

--- a/pkg/workcontent/dispatch_url_test.go
+++ b/pkg/workcontent/dispatch_url_test.go
@@ -9,7 +9,10 @@ import (
 
 func TestResolveDispatchContentURL_AbsoluteFileURLUnchanged(t *testing.T) {
 	absPath := filepath.Join(t.TempDir(), "img.png")
-	rawURL := "file://" + absPath
+	rawURL, err := workcontent.FilesystemPathToContentURL(absPath)
+	if err != nil {
+		t.Fatalf("file URL: %v", err)
+	}
 
 	got, err := workcontent.ResolveDispatchContentURL("/tmp/workspace", rawURL)
 	if err != nil {
@@ -28,7 +31,10 @@ func TestResolveDispatchContentURL_RelativeFileURLJoinsWorkingDirectory(t *testi
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
-	want := "file://" + filepath.Join(workspace, "fixtures", "ui.png")
+	want, err := workcontent.FilesystemPathToContentURL(filepath.Join(workspace, "fixtures", "ui.png"))
+	if err != nil {
+		t.Fatalf("want file URL: %v", err)
+	}
 	if got != want {
 		t.Fatalf("url = %q, want %q", got, want)
 	}

--- a/pkg/workcontent/legacy_normalize.go
+++ b/pkg/workcontent/legacy_normalize.go
@@ -19,7 +19,11 @@ func FilesystemPathToContentURL(path string) (string, error) {
 	}
 	cleaned := filepath.Clean(trimmed)
 	if filepath.IsAbs(cleaned) {
-		return (&url.URL{Scheme: "file", Path: filepath.ToSlash(cleaned)}).String(), nil
+		urlPath := filepath.ToSlash(cleaned)
+		if volume := filepath.VolumeName(cleaned); volume != "" && !strings.HasPrefix(urlPath, "/") {
+			urlPath = "/" + urlPath
+		}
+		return (&url.URL{Scheme: "file", Path: urlPath}).String(), nil
 	}
 	return "file://" + filepath.ToSlash(cleaned), nil
 }

--- a/pkg/workcontent/legacy_normalize_test.go
+++ b/pkg/workcontent/legacy_normalize_test.go
@@ -1,6 +1,7 @@
 package workcontent_test
 
 import (
+	"net/url"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -14,6 +15,11 @@ func TestFilesystemPathToContentURL(t *testing.T) {
 
 	dir := t.TempDir()
 	absPath := filepath.Join(dir, "img.png")
+	absURLPath := filepath.ToSlash(absPath)
+	if volume := filepath.VolumeName(absPath); volume != "" && !strings.HasPrefix(absURLPath, "/") {
+		absURLPath = "/" + absURLPath
+	}
+	wantAbsoluteURL := (&url.URL{Scheme: "file", Path: absURLPath}).String()
 
 	tests := []struct {
 		name    string
@@ -21,7 +27,7 @@ func TestFilesystemPathToContentURL(t *testing.T) {
 		wantURL string
 	}{
 		{name: "relative", path: "fixtures/ui.png", wantURL: "file://fixtures/ui.png"},
-		{name: "absolute", path: absPath, wantURL: "file://" + absPath},
+		{name: "absolute", path: absPath, wantURL: wantAbsoluteURL},
 	}
 	for _, tc := range tests {
 		tc := tc

--- a/pkg/workcontent/materialize/fixture_corpus_test.go
+++ b/pkg/workcontent/materialize/fixture_corpus_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/portpowered/infinite-you/pkg/workcontent"
 	"github.com/portpowered/infinite-you/pkg/workcontent/materialize"
 )
 
@@ -71,7 +72,11 @@ func resolveURLMaterializationFixture(t *testing.T, tc materialize.URLMaterializ
 		if err := os.WriteFile(localPath, []byte(tc.FileContent), 0o644); err != nil {
 			t.Fatalf("write local file: %v", err)
 		}
-		return "file://" + localPath, nil, localPath
+		contentURL, err := workcontent.FilesystemPathToContentURL(localPath)
+		if err != nil {
+			t.Fatalf("local file URL: %v", err)
+		}
+		return contentURL, nil, localPath
 	case "httptest_server":
 		body := tc.ResponseBody
 		statusCode := tc.StatusCode

--- a/pkg/workcontent/materialize/local.go
+++ b/pkg/workcontent/materialize/local.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
+	"runtime"
 )
 
 func materializeFileURL(rawURL string, parsed *url.URL) (string, CleanupFunc, error) {
@@ -14,6 +16,10 @@ func materializeFileURL(rawURL string, parsed *url.URL) (string, CleanupFunc, er
 	if path == "" {
 		return "", noopCleanup, notReadableError(rawURL, "empty file path")
 	}
+	if runtime.GOOS == "windows" && len(path) >= 3 && path[0] == '/' && path[2] == ':' {
+		path = path[1:]
+	}
+	path = filepath.FromSlash(path)
 
 	info, err := os.Stat(path)
 	if err != nil {

--- a/pkg/workcontent/materialize/materialize_test.go
+++ b/pkg/workcontent/materialize/materialize_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/portpowered/infinite-you/pkg/workcontent"
 	"github.com/portpowered/infinite-you/pkg/workcontent/materialize"
 )
 
@@ -21,7 +22,10 @@ func TestMaterializeContentURL_LocalFileOK(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rawURL := "file://" + path
+	rawURL, err := workcontent.FilesystemPathToContentURL(path)
+	if err != nil {
+		t.Fatalf("file URL: %v", err)
+	}
 	got, cleanup, err := materialize.MaterializeContentURL(context.Background(), rawURL, nil)
 	if err != nil {
 		t.Fatalf("materialize: %v", err)
@@ -36,7 +40,10 @@ func TestMaterializeContentURL_LocalFileOK(t *testing.T) {
 }
 
 func TestMaterializeContentURL_LocalMissing(t *testing.T) {
-	rawURL := "file://" + filepath.Join(t.TempDir(), "missing.png")
+	rawURL, err := workcontent.FilesystemPathToContentURL(filepath.Join(t.TempDir(), "missing.png"))
+	if err != nil {
+		t.Fatalf("file URL: %v", err)
+	}
 	_, cleanup, err := materialize.MaterializeContentURL(context.Background(), rawURL, nil)
 	defer cleanup()
 	if err == nil {
@@ -177,7 +184,10 @@ func TestDispatchCache_ReusesURLAndCleansUpOnRelease(t *testing.T) {
 	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	rawURL := "file://" + path
+	rawURL, err := workcontent.FilesystemPathToContentURL(path)
+	if err != nil {
+		t.Fatalf("file URL: %v", err)
+	}
 
 	cache := materialize.NewDispatchCache()
 	p1, cleanup1, err := cache.MaterializeContentURL(context.Background(), rawURL, nil)

--- a/pkg/workers/executor/agentrun/tools.go
+++ b/pkg/workers/executor/agentrun/tools.go
@@ -143,7 +143,7 @@ func isSafeRelativePathForDiagnostics(path string) bool {
 	if trimmed == "" {
 		return false
 	}
-	if filepath.IsAbs(trimmed) {
+	if isAnyPlatformAbsolutePath(trimmed) {
 		return false
 	}
 	cleaned := filepath.Clean(trimmed)
@@ -153,14 +153,25 @@ func isSafeRelativePathForDiagnostics(path string) bool {
 	return true
 }
 
+func isAnyPlatformAbsolutePath(path string) bool {
+	if filepath.IsAbs(path) || strings.HasPrefix(path, "/") || strings.HasPrefix(path, `\\`) {
+		return true
+	}
+	return len(path) >= 3 && path[1] == ':' && (path[2] == '/' || path[2] == '\\') &&
+		((path[0] >= 'a' && path[0] <= 'z') || (path[0] >= 'A' && path[0] <= 'Z'))
+}
+
 func toolFailureReason(err error) string {
+	message := strings.ToLower(err.Error())
+	if strings.Contains(message, "write_file failed creating parent directories") {
+		return "operation_failed"
+	}
 	switch {
 	case errors.Is(err, fs.ErrNotExist):
 		return "not_found"
 	case errors.Is(err, fs.ErrPermission):
 		return "permission_denied"
 	}
-	message := strings.ToLower(err.Error())
 	switch {
 	case strings.Contains(message, "tool path is required"):
 		return "path_required"
@@ -238,9 +249,9 @@ func toolDefinitionsForPolicy(policy string) []messages.ToolDefinition {
 
 // PolicyToolExecutor enforces agent tool policy and records safe diagnostics.
 type PolicyToolExecutor struct {
-	policy    string
+	policy     string
 	workingDir string
-	recorder  *ToolDiagnosticRecorder
+	recorder   *ToolDiagnosticRecorder
 }
 
 func NewPolicyToolExecutor(policy, workingDir string, recorder *ToolDiagnosticRecorder) *PolicyToolExecutor {
@@ -370,7 +381,7 @@ func (executor *PolicyToolExecutor) resolveBoundedPath(relativePath string) (str
 	if trimmed == "" {
 		return "", errors.New("tool path is required")
 	}
-	if filepath.IsAbs(trimmed) {
+	if isAnyPlatformAbsolutePath(trimmed) {
 		return "", errors.New("tool path must be relative to the agent working directory")
 	}
 	base := executor.workingDir

--- a/pkg/workers/executor/workstation/workstation_runtime_path_test.go
+++ b/pkg/workers/executor/workstation/workstation_runtime_path_test.go
@@ -165,7 +165,7 @@ func TestWorkstationExecutor_ResolvesTemplatedWorkingDirectoryFromSessionContext
 	if mock.dispatch.FactorySessionID != sessionID {
 		t.Fatalf("FactorySessionID = %q, want %q", mock.dispatch.FactorySessionID, sessionID)
 	}
-	if mock.dispatch.EnvVars["SESSION_WORKDIR"] != wantDir {
+	if filepath.Clean(mock.dispatch.EnvVars["SESSION_WORKDIR"]) != wantDir {
 		t.Fatalf("env vars = %#v, want SESSION_WORKDIR=%q", mock.dispatch.EnvVars, wantDir)
 	}
 }

--- a/pkg/workers/mockworker/runner_test.go
+++ b/pkg/workers/mockworker/runner_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -348,7 +349,8 @@ func TestMockWorkerCommandRunner_RunNextUsesExecRunnerWhenNextMissing(t *testing
 	}
 
 	result, err := (&MockWorkerCommandRunner{}).runNext(context.Background(), workerprocess.CommandRequest{
-		Command: scriptPath,
+		Command: shellCommandForTest(scriptPath),
+		Args:    shellArgsForTest(scriptPath),
 		Env:     []string{"GREETING=hello"},
 		Stdin:   []byte("world"),
 		WorkDir: dir,
@@ -362,6 +364,25 @@ func TestMockWorkerCommandRunner_RunNextUsesExecRunnerWhenNextMissing(t *testing
 	if got := string(result.Stdout); !strings.HasPrefix(got, "cwd:") || !strings.Contains(got, " stdin:world env:hello") {
 		t.Fatalf("Stdout = %q, want exec runner output", got)
 	}
+}
+
+func shellCommandForTest(scriptPath string) string {
+	if runtime.GOOS == "windows" {
+		return "powershell.exe"
+	}
+	return scriptPath
+}
+
+func shellArgsForTest(scriptPath string) []string {
+	if runtime.GOOS == "windows" {
+		return []string{
+			"-NoProfile",
+			"-NonInteractive",
+			"-Command",
+			`$value = [Console]::In.ReadToEnd(); [Console]::Out.Write("cwd:{0} stdin:{1} env:{2}", (Get-Location).Path, $value, $env:GREETING)`,
+		}
+	}
+	return nil
 }
 
 func TestRejectResultNilConfigDefaultsToExitCodeOne(t *testing.T) {

--- a/pkg/workers/process/command_process_windows.go
+++ b/pkg/workers/process/command_process_windows.go
@@ -79,7 +79,10 @@ func terminateCommandJobGroup(job windows.Handle, grace time.Duration, logCtx co
 		return nil
 	}
 	supervisorID := int(job)
-	if commandJobActiveProcesses(job) == 0 {
+	// Windows can briefly report zero active processes for a newly assigned job
+	// even while its process is running. Cancellation must still terminate the
+	// job; otherwise the runner waits for the command to exit on its own.
+	if logCtx.reason != commandProcessCleanupReasonCancel && commandJobActiveProcesses(job) == 0 {
 		logCtx.logCompleted(commandProcessCleanupOutcomeNoOp, supervisorID, nil, "job has no active processes")
 		return nil
 	}
@@ -99,7 +102,7 @@ func terminateCommandJobGroup(job windows.Handle, grace time.Duration, logCtx co
 	}
 
 	logCtx.logForceKill(supervisorID)
-	if commandJobActiveProcesses(job) == 0 {
+	if logCtx.reason != commandProcessCleanupReasonCancel && commandJobActiveProcesses(job) == 0 {
 		logCtx.logCompleted(commandProcessCleanupOutcomeNoOp, supervisorID, nil, "job members exited before force kill")
 		return nil
 	}

--- a/pkg/workers/provider/cursor/failure.go
+++ b/pkg/workers/provider/cursor/failure.go
@@ -13,12 +13,13 @@ import (
 const FailureMessageLimit = 1024
 
 const (
-	cursorAuthFailureMessage       = "Cursor authentication failed. Sign in again or check the configured credentials."
-	cursorBadRequestFailureMessage = "Cursor rejected the request as invalid. Check the model and Cursor configuration."
-	cursorThrottleFailureMessage   = "Cursor is temporarily unavailable due to usage or capacity limits."
-	cursorTimeoutFailureMessage    = "Cursor request timed out."
-	cursorServerFailureMessage     = "Cursor encountered a temporary server error."
-	cursorUnknownFailureMessage    = "Cursor reported an unsuccessful result."
+	cursorAuthFailureMessage        = "Cursor authentication failed. Sign in again or check the configured credentials."
+	cursorBadRequestFailureMessage  = "Cursor rejected the request as invalid. Check the model and Cursor configuration."
+	cursorThrottleFailureMessage    = "Cursor is temporarily unavailable due to usage or capacity limits."
+	cursorTimeoutFailureMessage     = "Cursor request timed out."
+	cursorServerFailureMessage      = "Cursor encountered a temporary server error."
+	cursorCommandLineTooLongMessage = "Cursor could not start because the rendered command exceeded the operating system command-line limit."
+	cursorUnknownFailureMessage     = "Cursor reported an unsuccessful result."
 )
 
 var unsafeCursorFailureTextPattern = regexp.MustCompile(`(?i)(authorization\s*:|bearer\s+\S+|api[_ -]?key\s*[:=]\s*\S+|password\s*[:=]|secret\s*[:=]|token\s*[:=]|private prompt|user prompt|complete transcript|full transcript|cleanup noise|could not be terminated|failed to terminate process)`)
@@ -72,6 +73,7 @@ func failureResultFromText(output []byte, fallbackReason interfaces.WorkFailureT
 	}
 
 	for _, reason := range []interfaces.WorkFailureType{
+		interfaces.WorkFailureTypeCommandLineTooLong,
 		interfaces.WorkFailureTypeAuthFailure,
 		interfaces.WorkFailureTypePermanentBadRequest,
 		interfaces.WorkFailureTypeThrottled,
@@ -200,6 +202,8 @@ func classifyTerminalFailure(subtype, result string) interfaces.WorkFailureType 
 func classifyCursorFailureSignal(signal string) interfaces.WorkFailureType {
 	signal = strings.ToLower(signal)
 	switch {
+	case containsCursorSignal(signal, "the command line is too long", "command line too long", "command-line limit"):
+		return interfaces.WorkFailureTypeCommandLineTooLong
 	case containsCursorSignal(signal, "authentication_error", "authentication failed", "authorization", "login required", "sign in", "unauthorized", "forbidden", "invalid api key", "401", "403"):
 		return interfaces.WorkFailureTypeAuthFailure
 	case containsCursorSignal(signal, "invalid_request", "bad request", "invalid argument", "invalid configuration", "configuration error", "config error", "model not found", "unsupported model"):
@@ -259,6 +263,8 @@ func cursorFailureGuidance(reason interfaces.WorkFailureType) string {
 		return cursorTimeoutFailureMessage
 	case interfaces.WorkFailureTypeInternalServerError:
 		return cursorServerFailureMessage
+	case interfaces.WorkFailureTypeCommandLineTooLong:
+		return cursorCommandLineTooLongMessage
 	default:
 		return cursorUnknownFailureMessage
 	}

--- a/pkg/workers/provider/cursor/failure_test.go
+++ b/pkg/workers/provider/cursor/failure_test.go
@@ -126,6 +126,7 @@ func TestParseProviderFailure_ClassifiesCursorStderrWithDeterministicPrecedence(
 		{name: "Capacity", stderr: "Cursor model capacity is exhausted", wantReason: interfaces.WorkFailureTypeThrottled, wantMessage: "Cursor model capacity is exhausted"},
 		{name: "Timeout", stderr: "Cursor request timed out", wantReason: interfaces.WorkFailureTypeTimeout, wantMessage: "Cursor request timed out"},
 		{name: "Server", stderr: "Cursor provider unavailable with status 503", wantReason: interfaces.WorkFailureTypeInternalServerError, wantMessage: "Cursor provider unavailable with status 503"},
+		{name: "WindowsCommandLineTooLong", stderr: "The command line is too long.", wantReason: interfaces.WorkFailureTypeCommandLineTooLong, wantMessage: "The command line is too long."},
 		{
 			name:        "CategoryPrecedenceAndDuplicateNoise",
 			stderr:      "cleanup noise\nrate limit reached\nRATE LIMIT REACHED\nauthentication failed\nprocess already exited",

--- a/pkg/workers/provider/helpers.go
+++ b/pkg/workers/provider/helpers.go
@@ -165,6 +165,10 @@ func safeProviderFailureLogMessage(provider string, providerErr *ProviderError) 
 		return "Provider request timed out."
 	case interfaces.WorkFailureTypeMisconfigured:
 		return "Provider command could not be started."
+	case interfaces.WorkFailureTypeMissingExecutable:
+		return "Provider executable could not be found."
+	case interfaces.WorkFailureTypeCommandLineTooLong:
+		return "Provider command exceeded the operating system command-line limit."
 	default:
 		return "Provider execution failed."
 	}

--- a/pkg/workers/provider/helpers.go
+++ b/pkg/workers/provider/helpers.go
@@ -24,8 +24,7 @@ type ExecCommandRunner = workerprocess.ExecCommandRunner
 type LoggingCommandRunner = workerprocess.LoggingCommandRunner
 
 const (
-	omitZeroWorkerEventExitCode    = false
-	includeZeroWorkerEventExitCode = true
+	omitZeroWorkerEventExitCode = false
 )
 
 const (

--- a/pkg/workers/provider/inference_progress.go
+++ b/pkg/workers/provider/inference_progress.go
@@ -576,5 +576,10 @@ func NewInferenceProgressPublishingCommandRunner(
 }
 
 func isCodexCommand(command string) bool {
-	return strings.EqualFold(filepath.Base(strings.TrimSpace(command)), string(interfaces.ModelProviderCodex))
+	base := filepath.Base(strings.ReplaceAll(strings.TrimSpace(command), `\`, "/"))
+	extension := strings.ToLower(filepath.Ext(base))
+	if extension == ".exe" || extension == ".cmd" || extension == ".bat" {
+		base = strings.TrimSuffix(base, filepath.Ext(base))
+	}
+	return strings.EqualFold(base, string(interfaces.ModelProviderCodex))
 }

--- a/pkg/workers/provider/inference_provider.go
+++ b/pkg/workers/provider/inference_provider.go
@@ -198,6 +198,9 @@ func (p *ScriptWrapProvider) Execute(ctx context.Context, req interfaces.RunnerE
 	providerSession := effectiveProviderSession(req, result)
 	cursorProvider := req.ModelProvider == string(interfaces.ModelProviderCursor)
 	if err != nil {
+		logger.Error("inference dispatch failed with error",
+			"raw_error", err.Error(),
+		)
 		providerErr := normalizeProviderExecutionError(
 			req.ModelProvider, result, err, providerSession,
 			cursorInferenceFailureDiagnostics(cursorProvider, commandDiagnostics, result),
@@ -209,6 +212,11 @@ func (p *ScriptWrapProvider) Execute(ctx context.Context, req interfaces.RunnerE
 		return interfaces.InferenceResponse{}, providerErr
 	}
 	if result.ExitCode != 0 {
+		logger.Error("inference dispatch failed with non-zero exit code",
+			"exit_code", result.ExitCode,
+			"stderr", result.Stderr,
+			"stdout", result.Stdout,
+		)
 		providerErr := normalizeProviderExitFailure(
 			req.ModelProvider, result, providerSession,
 			cursorInferenceFailureDiagnostics(cursorProvider, commandDiagnostics, result),
@@ -293,7 +301,7 @@ func normalizeProviderExecutionError(provider string, result CommandResult, err 
 		)
 	case errors.Is(err, exec.ErrNotFound):
 		message := formatProviderCommandFailure(provider, result, err)
-		return newProviderErrorWithDiagnostics(interfaces.WorkFailureTypeMisconfigured, message, err, session, diagnostics)
+		return newProviderErrorWithDiagnostics(interfaces.WorkFailureTypeMissingExecutable, message, err, session, diagnostics)
 	default:
 		message := formatProviderCommandFailure(provider, result, err)
 		var execErr *exec.Error

--- a/pkg/workers/provider/inference_provider.go
+++ b/pkg/workers/provider/inference_provider.go
@@ -174,7 +174,7 @@ func (p *ScriptWrapProvider) Execute(ctx context.Context, req interfaces.RunnerE
 		ContentCache:    materialize.NewDispatchCache(),
 		MaterializeOpts: p.MaterializeOptions,
 	}
-	defer buildCtx.ContentCache.Release()
+	defer buildCtx.release()
 	args, err := behavior.BuildArgs(ctx, req, p.SkipPermissions, buildCtx)
 	if err != nil {
 		logger.Error("inferencer: request argument validation failed",

--- a/pkg/workers/provider/inference_provider_error_normalization_test.go
+++ b/pkg/workers/provider/inference_provider_error_normalization_test.go
@@ -859,9 +859,9 @@ func TestScriptWrapProvider_Infer_RunErrorsNormalizeTimeoutAndMisconfigured(t *t
 			rejectText:  "raw inference transcript",
 		},
 		{
-			name:       "ExecutableMissing_IsMisconfigured",
+			name:       "ExecutableMissing_HasExplicitType",
 			runErr:     exec.ErrNotFound,
-			wantType:   interfaces.WorkFailureTypeMisconfigured,
+			wantType:   interfaces.WorkFailureTypeMissingExecutable,
 			wantFamily: interfaces.WorkFailureFamilyTerminal,
 		},
 		{

--- a/pkg/workers/provider/inference_provider_exit_failure_test.go
+++ b/pkg/workers/provider/inference_provider_exit_failure_test.go
@@ -824,11 +824,9 @@ func TestNormalizeProviderExitFailure_CursorCommandLineTooLongHasExplicitType(t 
 	}, nil, nil)
 	if providerErr.Type != interfaces.WorkFailureTypeCommandLineTooLong {
 		t.Fatalf("Type = %q, want %q", providerErr.Type, interfaces.WorkFailureTypeCommandLineTooLong)
-	}
-	if providerErr.Family != interfaces.WorkFailureFamilyTerminal {
+	} else if providerErr.Family != interfaces.WorkFailureFamilyTerminal {
 		t.Fatalf("Family = %q, want terminal", providerErr.Family)
-	}
-	if providerErr.Message != "The command line is too long." {
+	} else if providerErr.Message != "The command line is too long." {
 		t.Fatalf("Message = %q, want bounded Cursor diagnostic", providerErr.Message)
 	}
 }

--- a/pkg/workers/provider/inference_provider_exit_failure_test.go
+++ b/pkg/workers/provider/inference_provider_exit_failure_test.go
@@ -163,7 +163,7 @@ func TestScriptWrapProvider_Infer_LogsNormalizedFailuresWithoutSyntheticExitCode
 		wantRetryable bool
 	}{
 		{name: "timeout", err: context.DeadlineExceeded, wantReason: interfaces.WorkFailureTypeTimeout, wantRetryable: true},
-		{name: "command start", err: exec.ErrNotFound, wantReason: interfaces.WorkFailureTypeMisconfigured},
+		{name: "command start", err: exec.ErrNotFound, wantReason: interfaces.WorkFailureTypeMissingExecutable},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			sequence := []string{}
@@ -202,7 +202,7 @@ func TestScriptWrapProvider_Infer_CodexExecutionFailureJSONLogsExcludeCommandOut
 		wantMessage string
 	}{
 		{name: "timeout", err: context.DeadlineExceeded, wantReason: interfaces.WorkFailureTypeTimeout, wantMessage: "Provider request timed out."},
-		{name: "command start", err: exec.ErrNotFound, wantReason: interfaces.WorkFailureTypeMisconfigured, wantMessage: "Provider command could not be started."},
+		{name: "command start", err: exec.ErrNotFound, wantReason: interfaces.WorkFailureTypeMissingExecutable, wantMessage: "Provider executable could not be found."},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var output bytes.Buffer
@@ -795,6 +795,8 @@ func TestNewProviderError_AssignsDeterministicFamilyFromType(t *testing.T) {
 		{name: "Timeout_IsRetryable", errorType: interfaces.WorkFailureTypeTimeout, wantFamily: interfaces.WorkFailureFamilyRetryable},
 		{name: "Unknown_IsTerminal", errorType: interfaces.WorkFailureTypeUnknown, wantFamily: interfaces.WorkFailureFamilyTerminal},
 		{name: "Misconfigured_IsTerminal", errorType: interfaces.WorkFailureTypeMisconfigured, wantFamily: interfaces.WorkFailureFamilyTerminal},
+		{name: "MissingExecutable_IsTerminal", errorType: interfaces.WorkFailureTypeMissingExecutable, wantFamily: interfaces.WorkFailureFamilyTerminal},
+		{name: "CommandLineTooLong_IsTerminal", errorType: interfaces.WorkFailureTypeCommandLineTooLong, wantFamily: interfaces.WorkFailureFamilyTerminal},
 	}
 
 	for _, tc := range testCases {
@@ -807,6 +809,22 @@ func TestNewProviderError_AssignsDeterministicFamilyFromType(t *testing.T) {
 				t.Fatalf("expected Family %q, got %q", tc.wantFamily, err.Family)
 			}
 		})
+	}
+}
+
+func TestNormalizeProviderExitFailure_CursorCommandLineTooLongHasExplicitType(t *testing.T) {
+	providerErr := normalizeProviderExitFailure(string(interfaces.ModelProviderCursor), CommandResult{
+		ExitCode: 1,
+		Stderr:   []byte("The command line is too long.\r\n"),
+	}, nil, nil)
+	if providerErr.Type != interfaces.WorkFailureTypeCommandLineTooLong {
+		t.Fatalf("Type = %q, want %q", providerErr.Type, interfaces.WorkFailureTypeCommandLineTooLong)
+	}
+	if providerErr.Family != interfaces.WorkFailureFamilyTerminal {
+		t.Fatalf("Family = %q, want terminal", providerErr.Family)
+	}
+	if providerErr.Message != "The command line is too long." {
+		t.Fatalf("Message = %q, want bounded Cursor diagnostic", providerErr.Message)
 	}
 }
 

--- a/pkg/workers/provider/inference_provider_exit_failure_test.go
+++ b/pkg/workers/provider/inference_provider_exit_failure_test.go
@@ -388,13 +388,11 @@ func assertInferenceExitFailure(t *testing.T, tc exitFailureInferenceTestCase) {
 }
 
 func TestInferenceProgressPublishingCommandRunner_NormalizesCodexStructuredEvents(t *testing.T) {
-	scriptPath := filepath.Join(t.TempDir(), "codex")
-	script := "#!/bin/sh\n" +
-		"printf '%s\\n' '{\"event\":\"session.created\",\"session_id\":\"sess-codex-1\"}'\n" +
-		"printf '%s\\n' '{\"type\":\"response.output_text.delta\",\"delta\":\"hello from delta\"}'\n" +
-		"printf '%s\\n' '{\"type\":\"response.completed\",\"response\":{\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"hello final\"}]}]}}'\n" +
-		"printf '%s\\n' 'planning update' 1>&2\n"
-	writeExecutableTestScript(t, scriptPath, script)
+	scriptPath := writeProviderOutputFixture(t, filepath.Join(t.TempDir(), "codex"), []byte(
+		"{\"event\":\"session.created\",\"session_id\":\"sess-codex-1\"}\n"+
+			"{\"type\":\"response.output_text.delta\",\"delta\":\"hello from delta\"}\n"+
+			"{\"type\":\"response.completed\",\"response\":{\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"hello final\"}]}]}}\n",
+	), []byte("planning update\n"), 0)
 
 	var published []InferenceProgressFragment
 	var publishedMu sync.Mutex
@@ -436,18 +434,26 @@ func TestInferenceProgressPublishingCommandRunner_NormalizesCodexStructuredEvent
 	}
 }
 
+func TestIsCodexCommand_AcceptsNativeExecutableShapes(t *testing.T) {
+	for _, command := range []string{"codex", "codex.exe", `C:\tools\codex.cmd`, "/usr/local/bin/codex"} {
+		if !isCodexCommand(command) {
+			t.Fatalf("isCodexCommand(%q) = false, want true", command)
+		}
+	}
+	if isCodexCommand("codex-helper.exe") {
+		t.Fatal("codex-helper.exe must not be classified as the Codex provider command")
+	}
+}
+
 func TestInferenceProgressPublishingCommandRunner_MapsUnknownAndMalformedCodexEventsToBoundedDiagnostics(t *testing.T) {
-	scriptPath := filepath.Join(t.TempDir(), "codex")
-	script := "#!/bin/sh\n" +
-		"printf '%s\\n' '{\"event\":\"session.created\",\"session_id\":\"sess-codex-2\"}'\n" +
-		"printf '%s\\n' '{\"type\":\"response.mystery\",\"message\":\"secret-token-123 should never be retained\"}'\n" +
-		"printf '%s\\n' '{\"type\":\"response.progress\"' \n" +
-		"printf 'event: response.output_text.delta\\n'\n" +
-		"printf '\\n'\n" +
-		"printf 'event: response.output_text.delta\\n'\n" +
-		"printf 'data: {\"delta\":\"hello after malformed frames\"}\\n'\n" +
-		"printf '\\n'\n"
-	writeExecutableTestScript(t, scriptPath, script)
+	scriptPath := writeProviderOutputFixture(t, filepath.Join(t.TempDir(), "codex"), []byte(
+		"{\"event\":\"session.created\",\"session_id\":\"sess-codex-2\"}\n"+
+			"{\"type\":\"response.mystery\",\"message\":\"secret-token-123 should never be retained\"}\n"+
+			"{\"type\":\"response.progress\"\n"+
+			"event: response.output_text.delta\n\n"+
+			"event: response.output_text.delta\n"+
+			"data: {\"delta\":\"hello after malformed frames\"}\n\n",
+	), nil, 0)
 
 	var published []InferenceProgressFragment
 	var publishedMu sync.Mutex
@@ -495,15 +501,14 @@ func TestInferenceProgressPublishingCommandRunner_MapsFailureCancelAndTruncation
 	failurePayload := strings.Repeat("e", codexRetainedProgressBytes+17)
 	cancelPayload := strings.Repeat("c", codexRetainedProgressBytes+9)
 
-	scriptPath := filepath.Join(t.TempDir(), "codex")
-	script := "#!/bin/sh\n" +
-		"printf '%s\\n' '{\"event\":\"session.created\",\"session_id\":\"sess-codex-3\"}'\n" +
-		"printf '%s\\n' '{\"type\":\"response.progress\",\"message\":\"" + progressPayload + "\"}'\n" +
-		"printf '%s\\n' '{\"type\":\"response.output_text.delta\",\"delta\":\"" + deltaPayload + "\"}'\n" +
-		"printf '%s\\n' '{\"type\":\"response.completed\",\"response\":{\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"" + finalPayload + "\"}]}]}}'\n" +
-		"printf '%s\\n' '{\"type\":\"response.failed\",\"error\":\"" + failurePayload + "\"}'\n" +
-		"printf '%s\\n' '{\"type\":\"response.canceled\",\"status\":\"" + cancelPayload + "\"}'\n"
-	writeExecutableTestScript(t, scriptPath, script)
+	scriptPath := writeProviderOutputFixture(t, filepath.Join(t.TempDir(), "codex"), []byte(
+		"{\"event\":\"session.created\",\"session_id\":\"sess-codex-3\"}\n"+
+			"{\"type\":\"response.progress\",\"message\":\""+progressPayload+"\"}\n"+
+			"{\"type\":\"response.output_text.delta\",\"delta\":\""+deltaPayload+"\"}\n"+
+			"{\"type\":\"response.completed\",\"response\":{\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\""+finalPayload+"\"}]}]}}\n"+
+			"{\"type\":\"response.failed\",\"error\":\""+failurePayload+"\"}\n"+
+			"{\"type\":\"response.canceled\",\"status\":\""+cancelPayload+"\"}\n",
+	), nil, 0)
 
 	var published []InferenceProgressFragment
 	var publishedMu sync.Mutex

--- a/pkg/workers/provider/inference_provider_streaming_test.go
+++ b/pkg/workers/provider/inference_provider_streaming_test.go
@@ -16,7 +16,7 @@ import (
 func TestScriptWrapProvider_Infer_CursorErrorFlaggedSuccessPublishesOnlyCanonicalFailure(t *testing.T) {
 	scriptDir := t.TempDir()
 	scriptPath := filepath.Join(scriptDir, string(interfaces.ModelProviderCursor))
-	writeExecutableTestScript(t, scriptPath, "#!/bin/sh\nprintf '%s\\n' '{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"result\":\"Request timed out\",\"session_id\":\"cursor-session-error\"}'\n")
+	writeProviderOutputFixture(t, scriptPath, []byte("{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"result\":\"Request timed out\",\"session_id\":\"cursor-session-error\"}\n"), nil, 0)
 	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	var publishedMu sync.Mutex

--- a/pkg/workers/provider/inference_provider_test_helpers_test.go
+++ b/pkg/workers/provider/inference_provider_test_helpers_test.go
@@ -210,6 +210,32 @@ func writeExecutableTestScript(t *testing.T, path string, content string) {
 	releaseExecutableWriteLock(t, path)
 }
 
+func writeProviderOutputFixture(t *testing.T, path string, stdout, stderr []byte, exitCode int) string {
+	t.Helper()
+	dir := filepath.Dir(path)
+	stdoutPath := filepath.Join(dir, "fixture.stdout")
+	stderrPath := filepath.Join(dir, "fixture.stderr")
+	if err := os.WriteFile(stdoutPath, stdout, 0o600); err != nil {
+		t.Fatalf("write fixture stdout: %v", err)
+	}
+	if err := os.WriteFile(stderrPath, stderr, 0o600); err != nil {
+		t.Fatalf("write fixture stderr: %v", err)
+	}
+
+	if runtime.GOOS == "windows" {
+		path += ".cmd"
+		body := fmt.Sprintf("@echo off\r\ntype %q\r\ntype %q 1>&2\r\nexit /b %d\r\n", stdoutPath, stderrPath, exitCode)
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("write Windows provider fixture: %v", err)
+		}
+		return path
+	}
+
+	body := fmt.Sprintf("#!/bin/sh\ncat %q\ncat %q 1>&2\nexit %d\n", stdoutPath, stderrPath, exitCode)
+	writeExecutableTestScript(t, path, body)
+	return path
+}
+
 func releaseExecutableWriteLock(t *testing.T, path string) {
 	t.Helper()
 
@@ -694,8 +720,7 @@ func (e *codexMixedImageAssertExec) Run(ctx context.Context, req CommandRequest)
 func TestInferenceProgressPublishingCommandRunner_PublishesOrderedFragments(t *testing.T) {
 	t.Parallel()
 
-	scriptPath := filepath.Join(t.TempDir(), "stream.sh")
-	writeExecutableTestScript(t, scriptPath, "#!/bin/sh\necho stdout-chunk\necho stderr-chunk 1>&2\n")
+	scriptPath := writeProviderOutputFixture(t, filepath.Join(t.TempDir(), "stream"), []byte("stdout-chunk\n"), []byte("stderr-chunk\n"), 0)
 
 	var publishedMu sync.Mutex
 	var published []InferenceProgressFragment
@@ -744,14 +769,12 @@ func TestInferenceProgressPublishingCommandRunner_PublishesOrderedFragments(t *t
 func TestInferenceProgressPublishingCommandRunner_CursorPublishesDiagnosticsAndLaterValidEventsInOrder(t *testing.T) {
 	scriptDir := t.TempDir()
 	scriptPath := filepath.Join(scriptDir, string(interfaces.ModelProviderCursor))
-	script := "#!/bin/sh\n" +
-		"printf '%s\\n' '{not json}'\n" +
-		"printf '%s\\n' '{\"type\":\"mystery\"}'\n" +
-		"printf '%s\\n' '{\"type\":\"assistant\",\"timestamp_ms\":1,\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Plan \"}]},\"session_id\":\"cursor-session-123\"}'\n" +
-		"printf '%s\\n' '{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"result\":\"Plan done\",\"session_id\":\"cursor-session-123\"}'\n"
-	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
-		t.Fatalf("write script: %v", err)
-	}
+	writeProviderOutputFixture(t, scriptPath, []byte(
+		"{not json}\n"+
+			"{\"type\":\"mystery\"}\n"+
+			"{\"type\":\"assistant\",\"timestamp_ms\":1,\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Plan \"}]},\"session_id\":\"cursor-session-123\"}\n"+
+			"{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"result\":\"Plan done\",\"session_id\":\"cursor-session-123\"}\n",
+	), nil, 0)
 	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	var publishedMu sync.Mutex
@@ -792,8 +815,7 @@ func TestInferenceProgressPublishingCommandRunner_CursorPublishesDiagnosticsAndL
 func TestInferenceProgressPublishingCommandRunner_WithoutPublisherPreservesExecBehavior(t *testing.T) {
 	t.Parallel()
 
-	scriptPath := filepath.Join(t.TempDir(), "nostream.sh")
-	writeExecutableTestScript(t, scriptPath, "#!/bin/sh\necho stdout-fallback\necho stderr-fallback 1>&2\nexit 7\n")
+	scriptPath := writeProviderOutputFixture(t, filepath.Join(t.TempDir(), "nostream"), []byte("stdout-fallback\n"), []byte("stderr-fallback\n"), 7)
 
 	runner := NewInferenceProgressPublishingCommandRunner(nil, nil)
 	result, err := runner.Run(context.Background(), CommandRequest{

--- a/pkg/workers/provider/provider_behavior.go
+++ b/pkg/workers/provider/provider_behavior.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"runtime"
 	"strings"
 
 	"github.com/portpowered/infinite-you/pkg/interfaces"
@@ -205,13 +207,49 @@ func (b cursorProviderBehavior) BuildArgs(_ context.Context, req interfaces.Prov
 	if req.WorkingDirectory != "" {
 		args = append(args, "--workspace", req.WorkingDirectory)
 	}
+
+	if req.Worktree != "" {
+		args = append(args, "--worktree", req.Worktree)
+	}
+
+	// Use to get a JSON stream response
 	args = append(args, "--output-format", cursorpkg.CursorOutputFormatStreamJSON, "--stream-partial-output")
-	prompt := strings.TrimSpace(req.UserMessage)
-	if systemPrompt := strings.TrimSpace(req.SystemPrompt); systemPrompt != "" {
-		prompt = buildKiroPrompt(req)
+
+	// if OS is windows, the prompt might be too long so we ask to pass it in via telling the agent to read a prompt from a temporary file.
+
+	prompt := ""
+	if runtime.GOOS == "windows" {
+
+		tempFile, err := b.writeTempFile(req.UserMessage, req.SystemPrompt)
+		if err != nil {
+			b.logger.Error("failed to write temporary prompt file", "error", err)
+			return nil, fmt.Errorf("failed to write temporary prompt file: %w", err)
+		}
+		defer tempFile.Close()
+		prompt = strings.Join([]string{"@", tempFile.Name()}, "")
+	} else {
+		prompt = strings.TrimSpace(req.UserMessage)
+		if systemPrompt := strings.TrimSpace(req.SystemPrompt); systemPrompt != "" {
+			prompt = buildKiroPrompt(req)
+		}
 	}
 	args = append(args, prompt)
 	return args, nil
+}
+
+func (b cursorProviderBehavior) writeTempFile(userPrompt string, systemPrompt string) (*os.File, error) {
+	f, err := os.CreateTemp("", "cursor_prompt_*.md")
+	if err != nil {
+		b.logger.Error("failed to create temporary prompt file", "error", err)
+		return nil, err
+	}
+	_, err = f.Write([]byte(strings.Join([]string{systemPrompt, userPrompt}, " ")))
+	if err != nil {
+		b.logger.Error("failed to write to temporary prompt file", "error", err)
+		f.Close()
+		return nil, err
+	}
+	return f, nil
 }
 
 func (b openCodeProviderBehavior) BuildArgs(_ context.Context, req interfaces.ProviderInferenceRequest, skipPermissions bool, _ *ProviderBuildContext) ([]string, error) {

--- a/pkg/workers/provider/provider_behavior.go
+++ b/pkg/workers/provider/provider_behavior.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"unicode/utf16"
 
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/logging"
@@ -23,10 +24,36 @@ const (
 
 const codexHighDemandTemporaryErrorsNeedle = "we're currently experiencing high demand, which may cause temporary errors."
 
+// Cursor is commonly installed through a Windows command shim whose practical
+// command-line limit is lower than CreateProcess' documented maximum. Keep the
+// prompt below the observed 8 KiB boundary and materialize larger prompts.
+const cursorWindowsPromptArgumentLimit = 7 * 1024
+
 // ProviderBuildContext carries dispatch-scoped resources for provider argument building.
 type ProviderBuildContext struct {
 	ContentCache    *materialize.DispatchCache
 	MaterializeOpts *materialize.Options
+	operatingSystem string
+	tempDir         string
+	cleanup         []func()
+}
+
+func (c *ProviderBuildContext) release() {
+	if c == nil {
+		return
+	}
+	for index := len(c.cleanup) - 1; index >= 0; index-- {
+		c.cleanup[index]()
+	}
+	if c.ContentCache != nil {
+		c.ContentCache.Release()
+	}
+}
+
+func (c *ProviderBuildContext) registerCleanup(cleanup func()) {
+	if c != nil && cleanup != nil {
+		c.cleanup = append(c.cleanup, cleanup)
+	}
 }
 
 type providerBehavior interface {
@@ -189,7 +216,7 @@ func (kiroProviderBehavior) BuildCommandRequest(req interfaces.ProviderInference
 	return buildBaseProviderCommandRequest(req, args)
 }
 
-func (b cursorProviderBehavior) BuildArgs(_ context.Context, req interfaces.ProviderInferenceRequest, skipPermissions bool, _ *ProviderBuildContext) ([]string, error) {
+func (b cursorProviderBehavior) BuildArgs(_ context.Context, req interfaces.ProviderInferenceRequest, skipPermissions bool, buildCtx *ProviderBuildContext) ([]string, error) {
 	if err := validateCursorOptionalCapabilities(req); err != nil {
 		return nil, err
 	}
@@ -212,44 +239,58 @@ func (b cursorProviderBehavior) BuildArgs(_ context.Context, req interfaces.Prov
 		args = append(args, "--worktree", req.Worktree)
 	}
 
-	// Use to get a JSON stream response
 	args = append(args, "--output-format", cursorpkg.CursorOutputFormatStreamJSON, "--stream-partial-output")
 
-	// if OS is windows, the prompt might be too long so we ask to pass it in via telling the agent to read a prompt from a temporary file.
-
-	prompt := ""
-	if runtime.GOOS == "windows" {
-
-		tempFile, err := b.writeTempFile(req.UserMessage, req.SystemPrompt)
+	prompt := buildCursorPrompt(req)
+	operatingSystem := runtime.GOOS
+	if buildCtx != nil && buildCtx.operatingSystem != "" {
+		operatingSystem = buildCtx.operatingSystem
+	}
+	if operatingSystem == "windows" && len(utf16.Encode([]rune(prompt))) > cursorWindowsPromptArgumentLimit {
+		tempDir := req.WorkingDirectory
+		if tempDir == "" {
+			tempDir = "."
+		}
+		if buildCtx != nil && buildCtx.tempDir != "" {
+			tempDir = buildCtx.tempDir
+		}
+		promptFile, err := b.writeTempFile(tempDir, prompt)
 		if err != nil {
-			b.logger.Error("failed to write temporary prompt file", "error", err)
 			return nil, fmt.Errorf("failed to write temporary prompt file: %w", err)
 		}
-		defer tempFile.Close()
-		prompt = strings.Join([]string{"@", tempFile.Name()}, "")
-	} else {
-		prompt = strings.TrimSpace(req.UserMessage)
-		if systemPrompt := strings.TrimSpace(req.SystemPrompt); systemPrompt != "" {
-			prompt = buildKiroPrompt(req)
-		}
+		buildCtx.registerCleanup(func() { _ = os.Remove(promptFile) })
+		prompt = "@" + promptFile
 	}
 	args = append(args, prompt)
 	return args, nil
 }
 
-func (b cursorProviderBehavior) writeTempFile(userPrompt string, systemPrompt string) (*os.File, error) {
-	f, err := os.CreateTemp("", "cursor_prompt_*.md")
+func buildCursorPrompt(req interfaces.ProviderInferenceRequest) string {
+	prompt := strings.TrimSpace(req.UserMessage)
+	if strings.TrimSpace(req.SystemPrompt) != "" {
+		prompt = buildKiroPrompt(req)
+	}
+	return prompt
+}
+
+func (b cursorProviderBehavior) writeTempFile(tempDir, prompt string) (string, error) {
+	f, err := os.CreateTemp(tempDir, "cursor_prompt_*.md")
 	if err != nil {
 		b.logger.Error("failed to create temporary prompt file", "error", err)
-		return nil, err
+		return "", err
 	}
-	_, err = f.Write([]byte(strings.Join([]string{systemPrompt, userPrompt}, " ")))
-	if err != nil {
+	path := f.Name()
+	if _, err = f.WriteString(prompt); err != nil {
 		b.logger.Error("failed to write to temporary prompt file", "error", err)
-		f.Close()
-		return nil, err
+		_ = f.Close()
+		_ = os.Remove(path)
+		return "", err
 	}
-	return f, nil
+	if err := f.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", err
+	}
+	return path, nil
 }
 
 func (b openCodeProviderBehavior) BuildArgs(_ context.Context, req interfaces.ProviderInferenceRequest, skipPermissions bool, _ *ProviderBuildContext) ([]string, error) {
@@ -525,7 +566,9 @@ func providerFailurePolicyForReason(reason interfaces.WorkFailureType) providerF
 	case interfaces.WorkFailureTypeAuthFailure,
 		interfaces.WorkFailureTypePermanentBadRequest,
 		interfaces.WorkFailureTypeUnknown,
-		interfaces.WorkFailureTypeMisconfigured:
+		interfaces.WorkFailureTypeMisconfigured,
+		interfaces.WorkFailureTypeMissingExecutable,
+		interfaces.WorkFailureTypeCommandLineTooLong:
 		return providerFailurePolicy{
 			Family:   interfaces.WorkFailureFamilyTerminal,
 			Decision: interfaces.WorkFailureDecision{Terminal: true},

--- a/pkg/workers/provider/provider_behavior_test.go
+++ b/pkg/workers/provider/provider_behavior_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/portpowered/infinite-you/pkg/interfaces"
@@ -371,6 +372,72 @@ func TestCursorProviderBehavior_BuildArgs(t *testing.T) {
 				t.Fatalf("BuildArgs returned error: %v", err)
 			}
 			assertStringSlicesEqual(t, tc.want, args)
+		})
+	}
+}
+
+func TestCursorProviderBehavior_BuildArgs_WindowsLongPromptUsesArgumentFile(t *testing.T) {
+	tempDir := t.TempDir()
+	buildCtx := &ProviderBuildContext{operatingSystem: "windows", tempDir: tempDir}
+	prompt := strings.Repeat("long cursor instruction ", cursorWindowsPromptArgumentLimit)
+	req := interfaces.ProviderInferenceRequest{
+		ModelProvider:    string(interfaces.ModelProviderCursor),
+		SystemPrompt:     "system guidance",
+		UserMessage:      prompt,
+		Model:            "composer-2.5",
+		SessionID:        "cursor-session-123",
+		WorkingDirectory: `C:\workspace`,
+		Worktree:         "feature-worktree",
+	}
+
+	args, err := (cursorProviderBehavior{logger: logging.NoopLogger{}}).BuildArgs(context.Background(), req, true, buildCtx)
+	if err != nil {
+		t.Fatalf("BuildArgs returned error: %v", err)
+	}
+	wantPrefix := []string{"-f", "-p", "--model", "composer-2.5", "--resume", "cursor-session-123", "--workspace", `C:\workspace`, "--worktree", "feature-worktree", "--output-format", "stream-json", "--stream-partial-output"}
+	if len(args) != len(wantPrefix)+1 {
+		t.Fatalf("args = %#v, want prefix plus prompt-file argument", args)
+	}
+	assertStringSlicesEqual(t, wantPrefix, args[:len(wantPrefix)])
+	promptArg := args[len(args)-1]
+	if !strings.HasPrefix(promptArg, "@") {
+		t.Fatalf("prompt argument = %q, want @file reference", promptArg)
+	}
+	promptPath := strings.TrimPrefix(promptArg, "@")
+	gotPrompt, err := os.ReadFile(promptPath)
+	if err != nil {
+		t.Fatalf("read prompt file: %v", err)
+	}
+	wantPrompt := buildKiroPrompt(req)
+	if string(gotPrompt) != wantPrompt {
+		t.Fatalf("prompt file content differs: got %d bytes, want %d", len(gotPrompt), len(wantPrompt))
+	}
+	buildCtx.release()
+	if _, err := os.Stat(promptPath); !os.IsNotExist(err) {
+		t.Fatalf("prompt file still exists after release: %v", err)
+	}
+}
+
+func TestCursorProviderBehavior_BuildArgs_DoesNotWrapShortOrNonWindowsPrompts(t *testing.T) {
+	testCases := []struct {
+		name            string
+		operatingSystem string
+		prompt          string
+	}{
+		{name: "ShortWindowsPrompt", operatingSystem: "windows", prompt: "inspect the repository"},
+		{name: "LongLinuxPrompt", operatingSystem: "linux", prompt: strings.Repeat("x", cursorWindowsPromptArgumentLimit+1)},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			args, err := (cursorProviderBehavior{logger: logging.NoopLogger{}}).BuildArgs(context.Background(), interfaces.ProviderInferenceRequest{
+				ModelProvider: string(interfaces.ModelProviderCursor), UserMessage: tc.prompt,
+			}, false, &ProviderBuildContext{operatingSystem: tc.operatingSystem, tempDir: t.TempDir()})
+			if err != nil {
+				t.Fatalf("BuildArgs returned error: %v", err)
+			}
+			if got := args[len(args)-1]; got != tc.prompt {
+				t.Fatalf("prompt argument = %q, want positional prompt", got)
+			}
 		})
 	}
 }

--- a/pkg/workers/service/coverage_gaps_test.go
+++ b/pkg/workers/service/coverage_gaps_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -117,7 +118,7 @@ func TestScriptPollerCommandRequest_ResolvesWorkstationEnvAndWorkerTimeout(t *te
 	if len(req.Env) != 1 || req.Env[0] != "POLLER_MODE=watch" {
 		t.Fatalf("poller env = %#v, want POLLER_MODE=watch", req.Env)
 	}
-	if !strings.Contains(req.WorkDir, "relative/workdir") {
+	if !strings.Contains(req.WorkDir, filepath.Join("relative", "workdir")) {
 		t.Fatalf("poller workdir = %q, want resolved relative path", req.WorkDir)
 	}
 }

--- a/tests/functional/runtime_api/api_generated_smoke_test.go
+++ b/tests/functional/runtime_api/api_generated_smoke_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -348,7 +349,15 @@ func TestGeneratedAPIIntegrationSmoke_SubmitWorkItemsAcceptMixedTextAndImageSubm
 	if imagePart.File != nil && string(*imagePart.File) != "" {
 		imagePath = string(*imagePart.File)
 	} else if strings.HasPrefix(imagePath, "file://") {
-		imagePath = strings.TrimPrefix(imagePath, "file://")
+		parsed, parseErr := url.Parse(imagePath)
+		if parseErr != nil {
+			t.Fatalf("parse staged image URL: %v", parseErr)
+		}
+		imagePath = parsed.Path
+		if runtime.GOOS == "windows" && len(imagePath) >= 3 && imagePath[0] == '/' && imagePath[2] == ':' {
+			imagePath = imagePath[1:]
+		}
+		imagePath = filepath.FromSlash(imagePath)
 	}
 	imageContent, err := os.ReadFile(imagePath)
 	if err != nil {

--- a/tests/functional/runtime_api/api_packaged_goal_invocation_test.go
+++ b/tests/functional/runtime_api/api_packaged_goal_invocation_test.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -631,6 +633,9 @@ func packagedGoalBuiltInTopologyOpenAPIJSON() string {
 
 func writePackagedGoalBuiltInTopologyFixtureFiles(t *testing.T, dir string, cfg *interfaces.FactoryConfig) {
 	t.Helper()
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skipf("packaged goal checker requires its configured POSIX shell: %v", err)
+	}
 
 	for _, workstation := range cfg.Workstations {
 		body := "---\ntype: MODEL_WORKSTATION\n---\nProcess packaged goal work.\n"
@@ -680,13 +685,14 @@ Review packaged goal work.
 func writePackagedGoalVerificationMakefile(t *testing.T, dir string) {
 	t.Helper()
 
-	const makefile = ".PHONY: test\n\ntest:\n\t@:\n"
+	const makefile = ".PHONY: test\n\ntest:\n\t@echo verification-ok\n"
 	if err := os.WriteFile(filepath.Join(dir, "Makefile"), []byte(makefile), 0o644); err != nil {
 		t.Fatalf("write packaged goal verification Makefile: %v", err)
 	}
 }
 
 func packagedGoalBuiltInTopologyMockWorkersConfigForRealChecker(reviewerWorkstation, reviewerOutput string) *factoryconfig.MockWorkersConfig {
+	command, args := echoCommand(reviewerOutput)
 	return &factoryconfig.MockWorkersConfig{
 		UnmatchedDispatchPolicy: factoryconfig.MockWorkerUnmatchedDispatchPolicyPassthrough,
 		MockWorkers: []factoryconfig.MockWorkerConfig{
@@ -705,8 +711,8 @@ func packagedGoalBuiltInTopologyMockWorkersConfigForRealChecker(reviewerWorkstat
 				WorkstationName: reviewerWorkstation,
 				RunType:         factoryconfig.MockWorkerRunTypeScript,
 				ScriptConfig: &factoryconfig.MockWorkerScriptConfig{
-					Command: "/bin/echo",
-					Args:    []string{reviewerOutput},
+					Command: command,
+					Args:    args,
 				},
 			},
 		},
@@ -746,6 +752,12 @@ func packagedGoalBuiltInTopologySequencedReviewerMockWorkersConfig(t *testing.T,
 }
 
 func packagedGoalBuiltInTopologyMockWorkersConfigForScript(reviewerWorkstation, scriptPath string) *factoryconfig.MockWorkersConfig {
+	command := scriptPath
+	var args []string
+	if runtime.GOOS == "windows" {
+		command = "sh"
+		args = []string{scriptPath}
+	}
 	return &factoryconfig.MockWorkersConfig{
 		UnmatchedDispatchPolicy: factoryconfig.MockWorkerUnmatchedDispatchPolicyPassthrough,
 		MockWorkers: []factoryconfig.MockWorkerConfig{
@@ -764,11 +776,20 @@ func packagedGoalBuiltInTopologyMockWorkersConfigForScript(reviewerWorkstation, 
 				WorkstationName: reviewerWorkstation,
 				RunType:         factoryconfig.MockWorkerRunTypeScript,
 				ScriptConfig: &factoryconfig.MockWorkerScriptConfig{
-					Command: scriptPath,
+					Command: command,
+					Args:    args,
 				},
 			},
 		},
 	}
+}
+
+func echoCommand(output string) (string, []string) {
+	if runtime.GOOS == "windows" {
+		literal := strings.ReplaceAll(output, "'", "''")
+		return "powershell.exe", []string{"-NoProfile", "-NonInteractive", "-Command", "[Console]::Out.Write('" + literal + "')"}
+	}
+	return "/bin/echo", []string{output}
 }
 
 func goalCheckerWorkerConfig(cfg *interfaces.FactoryConfig) *interfaces.WorkerConfig {
@@ -784,14 +805,15 @@ func goalCheckerWorkerConfig(cfg *interfaces.FactoryConfig) *interfaces.WorkerCo
 }
 
 func packagedGoalReviewClassifierMockWorkersConfig(label string) *factoryconfig.MockWorkersConfig {
+	command, args := echoCommand(label)
 	return &factoryconfig.MockWorkersConfig{
 		MockWorkers: []factoryconfig.MockWorkerConfig{{
 			WorkerName:      "goal-reviewer",
 			WorkstationName: goal.PackagedReviewWorkstationName,
 			RunType:         factoryconfig.MockWorkerRunTypeScript,
 			ScriptConfig: &factoryconfig.MockWorkerScriptConfig{
-				Command: "/bin/echo",
-				Args:    []string{label},
+				Command: command,
+				Args:    args,
 			},
 		}},
 	}

--- a/tests/functional/smoke/verify_fast_command_smoke_test.go
+++ b/tests/functional/smoke/verify_fast_command_smoke_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -74,13 +75,13 @@ func TestVerifyFastCommandSmoke_FailureReportsOwnedSuiteAndRerunCommand(t *testi
 func TestVerifyPRCommandSmoke_UsesRequiredLanesOnce(t *testing.T) {
 	repoRoot := testutil.MustRepoPath(t, ".")
 	makefilePath := writeVerifyFastWrapperMakefile(t, repoRoot, map[string]string{
-		"verify-build-contracts":             "@printf '%s\\n' 'stub:verify-build-contracts'\n",
-		"release-surface-smoke":              "@printf '%s\\n' 'stub:release-surface-smoke'\n",
+		"verify-build-contracts":               "@printf '%s\\n' 'stub:verify-build-contracts'\n",
+		"release-surface-smoke":                "@printf '%s\\n' 'stub:release-surface-smoke'\n",
 		"run-concurrent-ui-verification-lanes": "@printf '%s\\n' 'stub:run-concurrent-ui-verification-lanes'\n",
-		"test-backend-verification":          "@printf '%s\\n' 'stub:test-backend-verification'\n",
-		"verify":                             "@printf '%s\\n' 'unexpected:verify'\n\t@exit 99\n",
-		"test-backend-functional":            "@printf '%s\\n' 'unexpected:test-backend-functional'\n\t@exit 99\n",
-		"ui-test":                            "@printf '%s\\n' 'unexpected:ui-test'\n\t@exit 99\n",
+		"test-backend-verification":            "@printf '%s\\n' 'stub:test-backend-verification'\n",
+		"verify":                               "@printf '%s\\n' 'unexpected:verify'\n\t@exit 99\n",
+		"test-backend-functional":              "@printf '%s\\n' 'unexpected:test-backend-functional'\n\t@exit 99\n",
+		"ui-test":                              "@printf '%s\\n' 'unexpected:ui-test'\n\t@exit 99\n",
 	})
 
 	output, err := runMakefileTarget(repoRoot, makefilePath, "verify-pr")
@@ -127,10 +128,10 @@ func TestVerifyPRCommandSmoke_UsesRequiredLanesOnce(t *testing.T) {
 func TestVerifyPRCommandSmoke_FailureReportsExactLaneRerun(t *testing.T) {
 	repoRoot := testutil.MustRepoPath(t, ".")
 	makefilePath := writeVerifyFastWrapperMakefile(t, repoRoot, map[string]string{
-		"verify-build-contracts":             "@printf '%s\\n' 'stub:verify-build-contracts'\n",
-		"release-surface-smoke":              "@printf '%s\\n' 'stub:release-surface-smoke'\n",
+		"verify-build-contracts":               "@printf '%s\\n' 'stub:verify-build-contracts'\n",
+		"release-surface-smoke":                "@printf '%s\\n' 'stub:release-surface-smoke'\n",
 		"run-concurrent-ui-verification-lanes": "@printf '%s\\n' 'stub:run-concurrent-ui-verification-lanes'\n\t@exit 23\n",
-		"test-backend-verification":          "@printf '%s\\n' 'stub:test-backend-verification'\n",
+		"test-backend-verification":            "@printf '%s\\n' 'stub:test-backend-verification'\n",
 	})
 
 	output, err := runMakefileTarget(repoRoot, makefilePath, "verify-pr")
@@ -220,10 +221,10 @@ func TestUIPackageCoverageCommandSmoke_InvokesPackageOwnedCoverageScript(t *test
 func TestVerifyCompatibilityAliasSmoke_RedirectsToCanonicalPRTier(t *testing.T) {
 	repoRoot := testutil.MustRepoPath(t, ".")
 	makefilePath := writeVerifyFastWrapperMakefile(t, repoRoot, map[string]string{
-		"verify-build-contracts":             "@printf '%s\\n' 'stub:verify-build-contracts'\n",
-		"release-surface-smoke":              "@printf '%s\\n' 'stub:release-surface-smoke'\n",
+		"verify-build-contracts":               "@printf '%s\\n' 'stub:verify-build-contracts'\n",
+		"release-surface-smoke":                "@printf '%s\\n' 'stub:release-surface-smoke'\n",
 		"run-concurrent-ui-verification-lanes": "@printf '%s\\n' 'stub:run-concurrent-ui-verification-lanes'\n",
-		"test-backend-verification":          "@printf '%s\\n' 'stub:test-backend-verification'\n",
+		"test-backend-verification":            "@printf '%s\\n' 'stub:test-backend-verification'\n",
 	})
 
 	output, err := runMakefileTarget(repoRoot, makefilePath, "verify")
@@ -653,15 +654,15 @@ func TestVerifyPRInferenceCommandSmoke_FailureReportsOwnedRerunCommand(t *testin
 func TestVerifyPRInferenceCommandSmoke_StaysOutsideRequiredPRAndExtendedTiers(t *testing.T) {
 	repoRoot := testutil.MustRepoPath(t, ".")
 	makefilePath := writeVerifyFastWrapperMakefile(t, repoRoot, map[string]string{
-		"verify-build-contracts":    "@printf '%s\\n' 'stub:verify-build-contracts'\n",
-		"release-surface-smoke":     "@printf '%s\\n' 'stub:release-surface-smoke'\n",
-		"test-ui-coverage":          "@printf '%s\\n' 'stub:test-ui-coverage'\n",
-		"ui-integration-test":       "@printf '%s\\n' 'stub:ui-integration-test'\n",
-		"test-backend-verification": "@printf '%s\\n' 'stub:test-backend-verification'\n",
-		"verify-pr":                 "@printf '%s\\n' 'stub:verify-pr'\n",
+		"verify-build-contracts":        "@printf '%s\\n' 'stub:verify-build-contracts'\n",
+		"release-surface-smoke":         "@printf '%s\\n' 'stub:release-surface-smoke'\n",
+		"test-ui-coverage":              "@printf '%s\\n' 'stub:test-ui-coverage'\n",
+		"ui-integration-test":           "@printf '%s\\n' 'stub:ui-integration-test'\n",
+		"test-backend-verification":     "@printf '%s\\n' 'stub:test-backend-verification'\n",
+		"verify-pr":                     "@printf '%s\\n' 'stub:verify-pr'\n",
 		"long-tests-managed-runtime":    "@printf '%s\\n' 'stub:long-tests-managed-runtime'\n",
 		"long-tests-functional-runtime": "@printf '%s\\n' 'stub:long-tests-functional-runtime'\n",
-		"pr-inference-approval":     "@printf '%s\\n' 'unexpected:pr-inference-approval'\n\t@exit 99\n",
+		"pr-inference-approval":         "@printf '%s\\n' 'unexpected:pr-inference-approval'\n\t@exit 99\n",
 	})
 
 	for _, target := range []string{"verify-pr", "verify-extended", "long-tests"} {
@@ -677,8 +678,10 @@ func TestVerifyPRInferenceCommandSmoke_StaysOutsideRequiredPRAndExtendedTiers(t 
 
 func writeVerifyFastWrapperMakefile(t *testing.T, repoRoot string, overrides map[string]string) string {
 	t.Helper()
+	requirePOSIXShell(t)
 
 	var body strings.Builder
+	body.WriteString("SHELL := sh\n")
 	body.WriteString(fmt.Sprintf("include %s\n\n", filepath.Join(repoRoot, "Makefile")))
 	for target, recipe := range overrides {
 		body.WriteString(fmt.Sprintf("%s:\n", target))
@@ -694,7 +697,7 @@ func writeVerifyFastWrapperMakefile(t *testing.T, repoRoot string, overrides map
 	if err := os.WriteFile(path, []byte(body.String()), 0o644); err != nil {
 		t.Fatalf("write wrapper makefile: %v", err)
 	}
-	return path
+	return filepath.ToSlash(path)
 }
 
 func runMakefileTarget(repoRoot, makefilePath, target string) (string, error) {
@@ -709,7 +712,8 @@ func runMakefileTargetWithArgs(repoRoot, makefilePath, target string, args ...st
 
 	makeArgs := []string{
 		"-f", makefilePath,
-		fmt.Sprintf("MAKE=%s -f %s", makePath, makefilePath),
+		"SHELL=sh",
+		fmt.Sprintf("MAKE=%s -f %s", filepath.ToSlash(makePath), filepath.ToSlash(makefilePath)),
 	}
 	makeArgs = append(makeArgs, args...)
 	makeArgs = append(makeArgs, target)
@@ -727,27 +731,41 @@ func runMakefileTargetWithArgs(repoRoot, makefilePath, target string, args ...st
 
 func writeMakeEchoScript(t *testing.T, label string) string {
 	t.Helper()
+	requirePOSIXShell(t)
 
 	path := filepath.Join(t.TempDir(), label)
 	body := fmt.Sprintf("#!/bin/sh\nprintf '%%s:' %q\nprintf '%%s\\n' \"$*\"\n", label)
 	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
 		t.Fatalf("write echo script: %v", err)
 	}
-	return path
+	return filepath.ToSlash(path)
 }
 
 func writeExecutableScript(t *testing.T, label string, body string) string {
 	t.Helper()
+	requirePOSIXShell(t)
 
 	path := filepath.Join(t.TempDir(), label)
 	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
 		t.Fatalf("write executable script: %v", err)
 	}
-	return path
+	return filepath.ToSlash(path)
+}
+
+func requirePOSIXShell(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skipf("POSIX shell smoke test requires sh: %v", err)
+	}
 }
 
 func runScript(repoRoot string, scriptPath string, env ...string) (string, error) {
-	cmd := exec.Command(scriptPath)
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.Command("sh", filepath.ToSlash(scriptPath))
+	} else {
+		cmd = exec.Command(scriptPath)
+	}
 	cmd.Dir = repoRoot
 	cmd.Env = append(os.Environ(), env...)
 

--- a/ui/src/api/generated/openapi.ts
+++ b/ui/src/api/generated/openapi.ts
@@ -7055,6 +7055,10 @@ export const WorkFailureType = {
   WorkFailureTypeUnknown: "unknown",
   // The worker or runtime was misconfigured and requires operator intervention.
   WorkFailureTypeMisconfigured: "misconfigured",
+  // The configured provider executable could not be found.
+  WorkFailureTypeMissingExecutable: "missing_executable",
+  // The provider command exceeded the operating system command-line size limit.
+  WorkFailureTypeCommandLineTooLong: "command_line_too_long",
 } as const;
 export type WorkFailureType =
   (typeof WorkFailureType)[keyof typeof WorkFailureType];


### PR DESCRIPTION
## Summary

- add a blocking native Windows short-Go-suite CI job
- validate Cursor argument-file and long-prompt invocation behavior, including explicit command-size failure classification
- make path, file URL, process cleanup, test fixtures, and factory replacement behavior portable on Windows
- remove hidden POSIX-shell dependencies from platform-neutral tests and capability-gate tests that explicitly exercise POSIX shell scripts

## Root cause

The existing CI matrix did not run the complete short Go suite on a native Windows host. Several tests and runtime paths therefore assumed POSIX path, process, symlink, permission, or shell behavior. An earlier local pass also unintentionally depended on Git's `sh.exe` being added to `PATH`; this change removes that dependency from the native Windows lane.

## Impact

Windows compilation and the full short Go suite are now merge-blocking. Cursor receives the expected stdin/argument-file shapes for long prompts, and command-line-size failures are exposed with an explicit failure type.

## Validation

- `make test` on Windows with an unmodified `PATH`
- `git diff --check`
