### PR TITLE
you-goal-b01-provider-identities

### DIFF
--- a/pkg/workers/cli_provider_registry.go
+++ b/pkg/workers/cli_provider_registry.go
@@ -30,12 +30,20 @@ const (
 
 // CLIProviderRegistration describes one supported agent CLI provider in the
 // deterministic discovery catalog.
+//
+// PreferenceRank establishes a total order for discovery: lower rank means higher
+// preference. Ranks are fixed at registration time and do not depend on PATH
+// enumeration or host filesystem ordering.
 type CLIProviderRegistration struct {
 	Identity       CLIProviderIdentity
 	Command        string
 	PreferenceRank int
 }
 
+// registeredCLIProviders is the canonical CLI provider catalog. Preference ranks
+// are assigned in discovery priority order:
+//
+//	Codex (10) → Claude (20) → Cursor (30) → OpenCode (40) → Gemini (50) → Kiro (60)
 var registeredCLIProviders = []CLIProviderRegistration{
 	{
 		Identity:       CLIProviderIdentityCodex,

--- a/pkg/workers/cli_provider_registry.go
+++ b/pkg/workers/cli_provider_registry.go
@@ -155,3 +155,27 @@ func ProbeRegisteredCLIProviderAvailability() []CLIProviderAvailability {
 	}
 	return results
 }
+
+// CLIProviderDiscovery reports ranked availability probes and the first
+// available registered provider in preference order, if any.
+type CLIProviderDiscovery struct {
+	Selected     *CLIProviderRegistration
+	Availability []CLIProviderAvailability
+}
+
+// DiscoverRegisteredCLIProvider probes every registered CLI provider in rank
+// order and selects the first available registration. When no command is on
+// PATH, Selected is nil and every probe is classified unavailable.
+func DiscoverRegisteredCLIProvider() CLIProviderDiscovery {
+	availability := ProbeRegisteredCLIProviderAvailability()
+	discovery := CLIProviderDiscovery{Availability: availability}
+	for i := range availability {
+		if !availability[i].Available {
+			continue
+		}
+		selected := availability[i].Registration
+		discovery.Selected = &selected
+		break
+	}
+	return discovery
+}

--- a/pkg/workers/cli_provider_registry.go
+++ b/pkg/workers/cli_provider_registry.go
@@ -7,6 +7,14 @@ import (
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 )
 
+// CLIProviderAvailability reports whether one registered CLI provider command is
+// resolvable on PATH without executing the provider or customer work.
+type CLIProviderAvailability struct {
+	Registration      CLIProviderRegistration
+	Available         bool
+	UnavailableReason string
+}
+
 // CLIProviderIdentity is the stable registry identity for one supported agent CLI
 // provider. Values align with systemconfig provider-scope segments.
 type CLIProviderIdentity string
@@ -119,4 +127,31 @@ func NormalizeCLIProviderIdentity(id string) CLIProviderIdentity {
 // provider backend scope derivation for one registry identity.
 func CLIProviderScopeSegment(id CLIProviderIdentity) string {
 	return string(NormalizeCLIProviderIdentity(string(id)))
+}
+
+// ProbeCLIProviderAvailability checks whether one registered provider command
+// is resolvable on PATH. Probes perform only command-resolution checks.
+func ProbeCLIProviderAvailability(registration CLIProviderRegistration) CLIProviderAvailability {
+	if _, err := lookPath(registration.Command); err != nil {
+		return CLIProviderAvailability{
+			Registration:      registration,
+			Available:         false,
+			UnavailableReason: string(interfaces.WorkFailureTypeMissingExecutable),
+		}
+	}
+	return CLIProviderAvailability{
+		Registration: registration,
+		Available:    true,
+	}
+}
+
+// ProbeRegisteredCLIProviderAvailability probes every registered CLI provider in
+// deterministic preference-rank order.
+func ProbeRegisteredCLIProviderAvailability() []CLIProviderAvailability {
+	registrations := RegisteredCLIProviders()
+	results := make([]CLIProviderAvailability, 0, len(registrations))
+	for _, registration := range registrations {
+		results = append(results, ProbeCLIProviderAvailability(registration))
+	}
+	return results
 }

--- a/pkg/workers/cli_provider_registry.go
+++ b/pkg/workers/cli_provider_registry.go
@@ -1,0 +1,122 @@
+package workers
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+)
+
+// CLIProviderIdentity is the stable registry identity for one supported agent CLI
+// provider. Values align with systemconfig provider-scope segments.
+type CLIProviderIdentity string
+
+const (
+	CLIProviderIdentityCodex    CLIProviderIdentity = "codex"
+	CLIProviderIdentityClaude   CLIProviderIdentity = "claude"
+	CLIProviderIdentityCursor   CLIProviderIdentity = "cursor"
+	CLIProviderIdentityOpenCode CLIProviderIdentity = "opencode"
+	CLIProviderIdentityGemini   CLIProviderIdentity = "gemini"
+	CLIProviderIdentityKiro     CLIProviderIdentity = "kiro"
+)
+
+// CLIProviderRegistration describes one supported agent CLI provider in the
+// deterministic discovery catalog.
+type CLIProviderRegistration struct {
+	Identity       CLIProviderIdentity
+	Command        string
+	PreferenceRank int
+}
+
+var registeredCLIProviders = []CLIProviderRegistration{
+	{
+		Identity:       CLIProviderIdentityCodex,
+		Command:        string(interfaces.ModelProviderCodex),
+		PreferenceRank: 10,
+	},
+	{
+		Identity:       CLIProviderIdentityClaude,
+		Command:        string(interfaces.ModelProviderClaude),
+		PreferenceRank: 20,
+	},
+	{
+		Identity:       CLIProviderIdentityCursor,
+		Command:        string(interfaces.ModelProviderCursor),
+		PreferenceRank: 30,
+	},
+	{
+		Identity:       CLIProviderIdentityOpenCode,
+		Command:        string(interfaces.ModelProviderOpenCode),
+		PreferenceRank: 40,
+	},
+	{
+		Identity:       CLIProviderIdentityGemini,
+		Command:        string(interfaces.ModelProviderGemini),
+		PreferenceRank: 50,
+	},
+	{
+		Identity:       CLIProviderIdentityKiro,
+		Command:        string(interfaces.ModelProviderKiro),
+		PreferenceRank: 60,
+	},
+}
+
+var (
+	cliProvidersByIdentity = buildCLIProvidersByIdentity(registeredCLIProviders)
+	cliProvidersByCommand    = buildCLIProvidersByCommand(registeredCLIProviders)
+)
+
+func buildCLIProvidersByIdentity(registrations []CLIProviderRegistration) map[CLIProviderIdentity]CLIProviderRegistration {
+	byIdentity := make(map[CLIProviderIdentity]CLIProviderRegistration, len(registrations))
+	for _, registration := range registrations {
+		byIdentity[registration.Identity] = registration
+	}
+	return byIdentity
+}
+
+func buildCLIProvidersByCommand(registrations []CLIProviderRegistration) map[string]CLIProviderRegistration {
+	byCommand := make(map[string]CLIProviderRegistration, len(registrations))
+	for _, registration := range registrations {
+		byCommand[registration.Command] = registration
+	}
+	return byCommand
+}
+
+// RegisteredCLIProviders returns every supported agent CLI provider sorted by
+// deterministic preference rank.
+func RegisteredCLIProviders() []CLIProviderRegistration {
+	sorted := append([]CLIProviderRegistration(nil), registeredCLIProviders...)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].PreferenceRank != sorted[j].PreferenceRank {
+			return sorted[i].PreferenceRank < sorted[j].PreferenceRank
+		}
+		return sorted[i].Identity < sorted[j].Identity
+	})
+	return sorted
+}
+
+// CLIProviderRegistrationByIdentity returns one registry entry for a stable
+// provider identity.
+func CLIProviderRegistrationByIdentity(id CLIProviderIdentity) (CLIProviderRegistration, bool) {
+	registration, ok := cliProvidersByIdentity[NormalizeCLIProviderIdentity(string(id))]
+	return registration, ok
+}
+
+// CLIProviderRegistrationByCommand returns one registry entry for a canonical
+// CLI dispatch command name.
+func CLIProviderRegistrationByCommand(command string) (CLIProviderRegistration, bool) {
+	registration, ok := cliProvidersByCommand[strings.TrimSpace(command)]
+	return registration, ok
+}
+
+// NormalizeCLIProviderIdentity trims and lowercases operator-supplied provider
+// identity inputs into the registry vocabulary.
+func NormalizeCLIProviderIdentity(id string) CLIProviderIdentity {
+	return CLIProviderIdentity(strings.ToLower(strings.TrimSpace(id)))
+}
+
+// CLIProviderScopeSegment returns the provider segment used by systemconfig
+// provider backend scope derivation for one registry identity.
+func CLIProviderScopeSegment(id CLIProviderIdentity) string {
+	return string(NormalizeCLIProviderIdentity(string(id)))
+}

--- a/pkg/workers/cli_provider_registry_test.go
+++ b/pkg/workers/cli_provider_registry_test.go
@@ -238,6 +238,170 @@ func TestProbeCLIProviderAvailability_FakePATHPresentAndAbsentPerCommand(t *test
 	}
 }
 
+func TestDiscoverRegisteredCLIProvider_FakePATHDiscoveryTables(t *testing.T) {
+	originalLookPath := lookPath
+	defer func() {
+		lookPath = originalLookPath
+	}()
+
+	cases := []struct {
+		name              string
+		presentCommands   map[string]bool
+		wantSelected      *CLIProviderIdentity
+		wantUnavailable   []CLIProviderIdentity
+		wantProbeCommands []string
+	}{
+		{
+			name: "all providers present prefers highest rank codex",
+			presentCommands: map[string]bool{
+				string(interfaces.ModelProviderCodex):    true,
+				string(interfaces.ModelProviderClaude):   true,
+				string(interfaces.ModelProviderCursor):   true,
+				string(interfaces.ModelProviderOpenCode): true,
+				string(interfaces.ModelProviderGemini):   true,
+				string(interfaces.ModelProviderKiro):     true,
+			},
+			wantSelected: ptrCLIProviderIdentity(CLIProviderIdentityCodex),
+			wantProbeCommands: []string{
+				string(interfaces.ModelProviderCodex),
+				string(interfaces.ModelProviderClaude),
+				string(interfaces.ModelProviderCursor),
+				string(interfaces.ModelProviderOpenCode),
+				string(interfaces.ModelProviderGemini),
+				string(interfaces.ModelProviderKiro),
+			},
+		},
+		{
+			name: "codex absent falls through to claude",
+			presentCommands: map[string]bool{
+				string(interfaces.ModelProviderClaude):   true,
+				string(interfaces.ModelProviderCursor):   true,
+				string(interfaces.ModelProviderOpenCode):   true,
+				string(interfaces.ModelProviderGemini):     true,
+				string(interfaces.ModelProviderKiro):       true,
+			},
+			wantSelected: ptrCLIProviderIdentity(CLIProviderIdentityClaude),
+			wantUnavailable: []CLIProviderIdentity{
+				CLIProviderIdentityCodex,
+			},
+		},
+		{
+			name: "codex and claude absent falls through to cursor",
+			presentCommands: map[string]bool{
+				string(interfaces.ModelProviderCursor):   true,
+				string(interfaces.ModelProviderOpenCode): true,
+				string(interfaces.ModelProviderGemini):   true,
+			},
+			wantSelected: ptrCLIProviderIdentity(CLIProviderIdentityCursor),
+			wantUnavailable: []CLIProviderIdentity{
+				CLIProviderIdentityCodex,
+				CLIProviderIdentityClaude,
+			},
+		},
+		{
+			name: "only lower ranked providers present selects gemini before kiro",
+			presentCommands: map[string]bool{
+				string(interfaces.ModelProviderGemini): true,
+				string(interfaces.ModelProviderKiro):   true,
+			},
+			wantSelected: ptrCLIProviderIdentity(CLIProviderIdentityGemini),
+			wantUnavailable: []CLIProviderIdentity{
+				CLIProviderIdentityCodex,
+				CLIProviderIdentityClaude,
+				CLIProviderIdentityCursor,
+				CLIProviderIdentityOpenCode,
+			},
+		},
+		{
+			name:            "no providers on path selects none and classifies all missing",
+			presentCommands: map[string]bool{},
+			wantSelected:    nil,
+			wantUnavailable: []CLIProviderIdentity{
+				CLIProviderIdentityCodex,
+				CLIProviderIdentityClaude,
+				CLIProviderIdentityCursor,
+				CLIProviderIdentityOpenCode,
+				CLIProviderIdentityGemini,
+				CLIProviderIdentityKiro,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var probedCommands []string
+			lookPath = func(file string) (string, error) {
+				probedCommands = append(probedCommands, file)
+				if tc.presentCommands[file] {
+					return "/fake/bin/" + file, nil
+				}
+				return "", exec.ErrNotFound
+			}
+
+			got := DiscoverRegisteredCLIProvider()
+
+			if tc.wantSelected == nil {
+				if got.Selected != nil {
+					t.Fatalf("selected = %#v, want nil", got.Selected)
+				}
+			} else if got.Selected == nil {
+				t.Fatalf("selected = nil, want %q", *tc.wantSelected)
+			} else if got.Selected.Identity != *tc.wantSelected {
+				t.Fatalf("selected identity = %q, want %q", got.Selected.Identity, *tc.wantSelected)
+			}
+
+			if len(got.Availability) != len(RegisteredCLIProviders()) {
+				t.Fatalf("availability len = %d, want %d", len(got.Availability), len(RegisteredCLIProviders()))
+			}
+
+			unavailable := make(map[CLIProviderIdentity]struct{})
+			for _, availability := range got.Availability {
+				if availability.Available {
+					continue
+				}
+				if availability.UnavailableReason != string(interfaces.WorkFailureTypeMissingExecutable) {
+					t.Fatalf("identity %q unavailable reason = %q, want %q",
+						availability.Registration.Identity,
+						availability.UnavailableReason,
+						interfaces.WorkFailureTypeMissingExecutable,
+					)
+				}
+				unavailable[availability.Registration.Identity] = struct{}{}
+			}
+
+			for _, identity := range tc.wantUnavailable {
+				if _, ok := unavailable[identity]; !ok {
+					t.Fatalf("identity %q not classified unavailable", identity)
+				}
+			}
+
+			wantProbeCommands := tc.wantProbeCommands
+			if wantProbeCommands == nil {
+				wantProbeCommands = []string{
+					string(interfaces.ModelProviderCodex),
+					string(interfaces.ModelProviderClaude),
+					string(interfaces.ModelProviderCursor),
+					string(interfaces.ModelProviderOpenCode),
+					string(interfaces.ModelProviderGemini),
+					string(interfaces.ModelProviderKiro),
+				}
+			}
+			if len(probedCommands) != len(wantProbeCommands) {
+				t.Fatalf("lookPath commands = %#v, want %#v", probedCommands, wantProbeCommands)
+			}
+			for i, wantCommand := range wantProbeCommands {
+				if probedCommands[i] != wantCommand {
+					t.Fatalf("lookPath command[%d] = %q, want %q", i, probedCommands[i], wantCommand)
+				}
+			}
+		})
+	}
+}
+
+func ptrCLIProviderIdentity(id CLIProviderIdentity) *CLIProviderIdentity {
+	return &id
+}
+
 func TestProbeCLIProviderAvailability_IsDeterministicForFixedFakePATH(t *testing.T) {
 	originalLookPath := lookPath
 	defer func() {

--- a/pkg/workers/cli_provider_registry_test.go
+++ b/pkg/workers/cli_provider_registry_test.go
@@ -1,0 +1,114 @@
+package workers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/config/systemconfig"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+)
+
+func TestRegisteredCLIProviders_IncludeEverySupportedProvider(t *testing.T) {
+	wantCommands := map[CLIProviderIdentity]string{
+		CLIProviderIdentityClaude:   string(interfaces.ModelProviderClaude),
+		CLIProviderIdentityCodex:    string(interfaces.ModelProviderCodex),
+		CLIProviderIdentityGemini:   string(interfaces.ModelProviderGemini),
+		CLIProviderIdentityKiro:     string(interfaces.ModelProviderKiro),
+		CLIProviderIdentityCursor:   string(interfaces.ModelProviderCursor),
+		CLIProviderIdentityOpenCode: string(interfaces.ModelProviderOpenCode),
+	}
+
+	registrations := RegisteredCLIProviders()
+	if len(registrations) != len(wantCommands) {
+		t.Fatalf("RegisteredCLIProviders() len = %d, want %d", len(registrations), len(wantCommands))
+	}
+
+	seen := make(map[CLIProviderIdentity]struct{}, len(wantCommands))
+	for _, registration := range registrations {
+		wantCommand, ok := wantCommands[registration.Identity]
+		if !ok {
+			t.Fatalf("unexpected provider identity %q", registration.Identity)
+		}
+		if registration.Command != wantCommand {
+			t.Fatalf("identity %q command = %q, want %q", registration.Identity, registration.Command, wantCommand)
+		}
+		seen[registration.Identity] = struct{}{}
+	}
+
+	for identity := range wantCommands {
+		if _, ok := seen[identity]; !ok {
+			t.Fatalf("missing provider identity %q", identity)
+		}
+	}
+}
+
+func TestRegisteredCLIProviders_PreferenceRankOrder(t *testing.T) {
+	wantOrder := []CLIProviderIdentity{
+		CLIProviderIdentityCodex,
+		CLIProviderIdentityClaude,
+		CLIProviderIdentityCursor,
+		CLIProviderIdentityOpenCode,
+		CLIProviderIdentityGemini,
+		CLIProviderIdentityKiro,
+	}
+
+	registrations := RegisteredCLIProviders()
+	if len(registrations) != len(wantOrder) {
+		t.Fatalf("RegisteredCLIProviders() len = %d, want %d", len(registrations), len(wantOrder))
+	}
+
+	for i, wantIdentity := range wantOrder {
+		if registrations[i].Identity != wantIdentity {
+			t.Fatalf("rank[%d] identity = %q, want %q", i, registrations[i].Identity, wantIdentity)
+		}
+	}
+}
+
+func TestCLIProviderRegistrationLookups_AreStableAcrossRepeatedCalls(t *testing.T) {
+	first := RegisteredCLIProviders()
+	second := RegisteredCLIProviders()
+	if len(first) != len(second) {
+		t.Fatalf("registry length drift: first=%d second=%d", len(first), len(second))
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			t.Fatalf("registry entry[%d] drift: first=%#v second=%#v", i, first[i], second[i])
+		}
+	}
+
+	for _, registration := range first {
+		for attempt := 0; attempt < 3; attempt++ {
+			byIdentity, ok := CLIProviderRegistrationByIdentity(registration.Identity)
+			if !ok {
+				t.Fatalf("identity lookup miss for %q on attempt %d", registration.Identity, attempt)
+			}
+			if byIdentity != registration {
+				t.Fatalf("identity lookup drift for %q: got %#v want %#v", registration.Identity, byIdentity, registration)
+			}
+
+			byCommand, ok := CLIProviderRegistrationByCommand(registration.Command)
+			if !ok {
+				t.Fatalf("command lookup miss for %q on attempt %d", registration.Command, attempt)
+			}
+			if byCommand != registration {
+				t.Fatalf("command lookup drift for %q: got %#v want %#v", registration.Command, byCommand, registration)
+			}
+		}
+	}
+}
+
+func TestCLIProviderIdentity_CompatibleWithProviderBackendScopeNaming(t *testing.T) {
+	for _, registration := range RegisteredCLIProviders() {
+		scope := systemconfig.DeriveProviderBackendScopeID(
+			CLIProviderScopeSegment(registration.Identity),
+			"account",
+			"workspace",
+		)
+		if !strings.HasPrefix(scope, "provider-") {
+			t.Fatalf("identity %q scope = %q, want provider-* prefix", registration.Identity, scope)
+		}
+		if !strings.Contains(scope, string(registration.Identity)) {
+			t.Fatalf("identity %q scope = %q, want identity segment preserved", registration.Identity, scope)
+		}
+	}
+}

--- a/pkg/workers/cli_provider_registry_test.go
+++ b/pkg/workers/cli_provider_registry_test.go
@@ -293,6 +293,69 @@ func registeredCLIProviderProbeCommands() []string {
 	}
 }
 
+func assertCLIProviderDiscoverySelected(t *testing.T, got CLIProviderDiscovery, wantSelected *CLIProviderIdentity) {
+	t.Helper()
+
+	if wantSelected == nil {
+		if got.Selected != nil {
+			t.Fatalf("selected = %#v, want nil", got.Selected)
+		}
+		return
+	}
+	if got.Selected == nil {
+		t.Fatalf("selected = nil, want %q", *wantSelected)
+	}
+	if got.Selected.Identity != *wantSelected {
+		t.Fatalf("selected identity = %q, want %q", got.Selected.Identity, *wantSelected)
+	}
+}
+
+func assertCLIProviderDiscoveryUnavailable(
+	t *testing.T,
+	availability []CLIProviderAvailability,
+	wantUnavailable []CLIProviderIdentity,
+) {
+	t.Helper()
+
+	if len(availability) != len(RegisteredCLIProviders()) {
+		t.Fatalf("availability len = %d, want %d", len(availability), len(RegisteredCLIProviders()))
+	}
+
+	unavailable := make(map[CLIProviderIdentity]struct{})
+	for _, item := range availability {
+		if item.Available {
+			continue
+		}
+		if item.UnavailableReason != string(interfaces.WorkFailureTypeMissingExecutable) {
+			t.Fatalf("identity %q unavailable reason = %q, want %q",
+				item.Registration.Identity,
+				item.UnavailableReason,
+				interfaces.WorkFailureTypeMissingExecutable,
+			)
+		}
+		unavailable[item.Registration.Identity] = struct{}{}
+	}
+
+	for _, identity := range wantUnavailable {
+		if _, ok := unavailable[identity]; !ok {
+			t.Fatalf("identity %q not classified unavailable", identity)
+		}
+	}
+}
+
+func assertProbedCLIProviderCommands(t *testing.T, probedCommands, wantProbeCommands []string) {
+	t.Helper()
+
+	if len(probedCommands) != len(wantProbeCommands) {
+		t.Fatalf("lookPath commands = %#v, want %#v", probedCommands, wantProbeCommands)
+	}
+	for i, wantCommand := range wantProbeCommands {
+		if probedCommands[i] != wantCommand {
+			t.Fatalf("lookPath command[%d] = %q, want %q", i, probedCommands[i], wantCommand)
+		}
+	}
+}
+
 func assertCLIProviderDiscovery(t *testing.T, tc cliProviderDiscoveryCase) {
 	t.Helper()
 
@@ -306,54 +369,14 @@ func assertCLIProviderDiscovery(t *testing.T, tc cliProviderDiscoveryCase) {
 	}
 
 	got := DiscoverRegisteredCLIProvider()
-
-	if tc.wantSelected == nil {
-		if got.Selected != nil {
-			t.Fatalf("selected = %#v, want nil", got.Selected)
-		}
-	} else if got.Selected == nil {
-		t.Fatalf("selected = nil, want %q", *tc.wantSelected)
-	} else if got.Selected.Identity != *tc.wantSelected {
-		t.Fatalf("selected identity = %q, want %q", got.Selected.Identity, *tc.wantSelected)
-	}
-
-	if len(got.Availability) != len(RegisteredCLIProviders()) {
-		t.Fatalf("availability len = %d, want %d", len(got.Availability), len(RegisteredCLIProviders()))
-	}
-
-	unavailable := make(map[CLIProviderIdentity]struct{})
-	for _, availability := range got.Availability {
-		if availability.Available {
-			continue
-		}
-		if availability.UnavailableReason != string(interfaces.WorkFailureTypeMissingExecutable) {
-			t.Fatalf("identity %q unavailable reason = %q, want %q",
-				availability.Registration.Identity,
-				availability.UnavailableReason,
-				interfaces.WorkFailureTypeMissingExecutable,
-			)
-		}
-		unavailable[availability.Registration.Identity] = struct{}{}
-	}
-
-	for _, identity := range tc.wantUnavailable {
-		if _, ok := unavailable[identity]; !ok {
-			t.Fatalf("identity %q not classified unavailable", identity)
-		}
-	}
+	assertCLIProviderDiscoverySelected(t, got, tc.wantSelected)
+	assertCLIProviderDiscoveryUnavailable(t, got.Availability, tc.wantUnavailable)
 
 	wantProbeCommands := tc.wantProbeCommands
 	if wantProbeCommands == nil {
 		wantProbeCommands = registeredCLIProviderProbeCommands()
 	}
-	if len(probedCommands) != len(wantProbeCommands) {
-		t.Fatalf("lookPath commands = %#v, want %#v", probedCommands, wantProbeCommands)
-	}
-	for i, wantCommand := range wantProbeCommands {
-		if probedCommands[i] != wantCommand {
-			t.Fatalf("lookPath command[%d] = %q, want %q", i, probedCommands[i], wantCommand)
-		}
-	}
+	assertProbedCLIProviderCommands(t, probedCommands, wantProbeCommands)
 }
 
 func TestDiscoverRegisteredCLIProvider_FakePATHDiscoveryTables(t *testing.T) {

--- a/pkg/workers/cli_provider_registry_test.go
+++ b/pkg/workers/cli_provider_registry_test.go
@@ -115,142 +115,96 @@ func TestCLIProviderIdentity_CompatibleWithProviderBackendScopeNaming(t *testing
 	}
 }
 
+type cliProviderProbeCase struct {
+	name            string
+	command         string
+	presentCommands map[string]bool
+	wantAvailable   bool
+	wantReason      string
+}
+
+func fakeCLIProviderProbeCases() []cliProviderProbeCase {
+	commands := []string{
+		string(interfaces.ModelProviderClaude),
+		string(interfaces.ModelProviderCodex),
+		string(interfaces.ModelProviderCursor),
+		string(interfaces.ModelProviderOpenCode),
+		string(interfaces.ModelProviderGemini),
+		string(interfaces.ModelProviderKiro),
+	}
+	cases := make([]cliProviderProbeCase, 0, len(commands)*2)
+	for _, command := range commands {
+		cases = append(cases,
+			cliProviderProbeCase{
+				name:            command + " present",
+				command:         command,
+				presentCommands: map[string]bool{command: true},
+				wantAvailable:   true,
+			},
+			cliProviderProbeCase{
+				name:            command + " absent",
+				command:         command,
+				presentCommands: map[string]bool{},
+				wantAvailable:   false,
+				wantReason:      string(interfaces.WorkFailureTypeMissingExecutable),
+			},
+		)
+	}
+	return cases
+}
+
+func assertCLIProviderProbeAvailability(t *testing.T, tc cliProviderProbeCase) {
+	t.Helper()
+
+	var probedCommands []string
+	lookPath = func(file string) (string, error) {
+		probedCommands = append(probedCommands, file)
+		if tc.presentCommands[file] {
+			return "/fake/bin/" + file, nil
+		}
+		return "", exec.ErrNotFound
+	}
+
+	registration, ok := CLIProviderRegistrationByCommand(tc.command)
+	if !ok {
+		t.Fatalf("CLIProviderRegistrationByCommand(%q) miss", tc.command)
+	}
+
+	got := ProbeCLIProviderAvailability(registration)
+	if got.Available != tc.wantAvailable {
+		t.Fatalf("available = %v, want %v", got.Available, tc.wantAvailable)
+	}
+	if got.UnavailableReason != tc.wantReason {
+		t.Fatalf("unavailable reason = %q, want %q", got.UnavailableReason, tc.wantReason)
+	}
+	if len(probedCommands) != 1 || probedCommands[0] != tc.command {
+		t.Fatalf("lookPath commands = %#v, want [%q]", probedCommands, tc.command)
+	}
+}
+
 func TestProbeCLIProviderAvailability_FakePATHPresentAndAbsentPerCommand(t *testing.T) {
 	originalLookPath := lookPath
 	defer func() {
 		lookPath = originalLookPath
 	}()
 
-	cases := []struct {
-		name            string
-		command         string
-		presentCommands map[string]bool
-		wantAvailable   bool
-		wantReason      string
-	}{
-		{
-			name:            "claude present",
-			command:         string(interfaces.ModelProviderClaude),
-			presentCommands: map[string]bool{string(interfaces.ModelProviderClaude): true},
-			wantAvailable:   true,
-		},
-		{
-			name:            "claude absent",
-			command:         string(interfaces.ModelProviderClaude),
-			presentCommands: map[string]bool{},
-			wantAvailable:   false,
-			wantReason:      string(interfaces.WorkFailureTypeMissingExecutable),
-		},
-		{
-			name:            "codex present",
-			command:         string(interfaces.ModelProviderCodex),
-			presentCommands: map[string]bool{string(interfaces.ModelProviderCodex): true},
-			wantAvailable:   true,
-		},
-		{
-			name:            "codex absent",
-			command:         string(interfaces.ModelProviderCodex),
-			presentCommands: map[string]bool{},
-			wantAvailable:   false,
-			wantReason:      string(interfaces.WorkFailureTypeMissingExecutable),
-		},
-		{
-			name:            "cursor present",
-			command:         string(interfaces.ModelProviderCursor),
-			presentCommands: map[string]bool{string(interfaces.ModelProviderCursor): true},
-			wantAvailable:   true,
-		},
-		{
-			name:            "cursor absent",
-			command:         string(interfaces.ModelProviderCursor),
-			presentCommands: map[string]bool{},
-			wantAvailable:   false,
-			wantReason:      string(interfaces.WorkFailureTypeMissingExecutable),
-		},
-		{
-			name:            "opencode present",
-			command:         string(interfaces.ModelProviderOpenCode),
-			presentCommands: map[string]bool{string(interfaces.ModelProviderOpenCode): true},
-			wantAvailable:   true,
-		},
-		{
-			name:            "opencode absent",
-			command:         string(interfaces.ModelProviderOpenCode),
-			presentCommands: map[string]bool{},
-			wantAvailable:   false,
-			wantReason:      string(interfaces.WorkFailureTypeMissingExecutable),
-		},
-		{
-			name:            "gemini present",
-			command:         string(interfaces.ModelProviderGemini),
-			presentCommands: map[string]bool{string(interfaces.ModelProviderGemini): true},
-			wantAvailable:   true,
-		},
-		{
-			name:            "gemini absent",
-			command:         string(interfaces.ModelProviderGemini),
-			presentCommands: map[string]bool{},
-			wantAvailable:   false,
-			wantReason:      string(interfaces.WorkFailureTypeMissingExecutable),
-		},
-		{
-			name:            "kiro present",
-			command:         string(interfaces.ModelProviderKiro),
-			presentCommands: map[string]bool{string(interfaces.ModelProviderKiro): true},
-			wantAvailable:   true,
-		},
-		{
-			name:            "kiro absent",
-			command:         string(interfaces.ModelProviderKiro),
-			presentCommands: map[string]bool{},
-			wantAvailable:   false,
-			wantReason:      string(interfaces.WorkFailureTypeMissingExecutable),
-		},
-	}
-
-	for _, tc := range cases {
+	for _, tc := range fakeCLIProviderProbeCases() {
 		t.Run(tc.name, func(t *testing.T) {
-			var probedCommands []string
-			lookPath = func(file string) (string, error) {
-				probedCommands = append(probedCommands, file)
-				if tc.presentCommands[file] {
-					return "/fake/bin/" + file, nil
-				}
-				return "", exec.ErrNotFound
-			}
-
-			registration, ok := CLIProviderRegistrationByCommand(tc.command)
-			if !ok {
-				t.Fatalf("CLIProviderRegistrationByCommand(%q) miss", tc.command)
-			}
-
-			got := ProbeCLIProviderAvailability(registration)
-			if got.Available != tc.wantAvailable {
-				t.Fatalf("available = %v, want %v", got.Available, tc.wantAvailable)
-			}
-			if got.UnavailableReason != tc.wantReason {
-				t.Fatalf("unavailable reason = %q, want %q", got.UnavailableReason, tc.wantReason)
-			}
-			if len(probedCommands) != 1 || probedCommands[0] != tc.command {
-				t.Fatalf("lookPath commands = %#v, want [%q]", probedCommands, tc.command)
-			}
+			assertCLIProviderProbeAvailability(t, tc)
 		})
 	}
 }
 
-func TestDiscoverRegisteredCLIProvider_FakePATHDiscoveryTables(t *testing.T) {
-	originalLookPath := lookPath
-	defer func() {
-		lookPath = originalLookPath
-	}()
+type cliProviderDiscoveryCase struct {
+	name              string
+	presentCommands   map[string]bool
+	wantSelected      *CLIProviderIdentity
+	wantUnavailable   []CLIProviderIdentity
+	wantProbeCommands []string
+}
 
-	cases := []struct {
-		name              string
-		presentCommands   map[string]bool
-		wantSelected      *CLIProviderIdentity
-		wantUnavailable   []CLIProviderIdentity
-		wantProbeCommands []string
-	}{
+func fakeCLIProviderDiscoveryCases() []cliProviderDiscoveryCase {
+	return []cliProviderDiscoveryCase{
 		{
 			name: "all providers present prefers highest rank codex",
 			presentCommands: map[string]bool{
@@ -276,9 +230,9 @@ func TestDiscoverRegisteredCLIProvider_FakePATHDiscoveryTables(t *testing.T) {
 			presentCommands: map[string]bool{
 				string(interfaces.ModelProviderClaude):   true,
 				string(interfaces.ModelProviderCursor):   true,
-				string(interfaces.ModelProviderOpenCode):   true,
-				string(interfaces.ModelProviderGemini):     true,
-				string(interfaces.ModelProviderKiro):       true,
+				string(interfaces.ModelProviderOpenCode): true,
+				string(interfaces.ModelProviderGemini):   true,
+				string(interfaces.ModelProviderKiro):     true,
 			},
 			wantSelected: ptrCLIProviderIdentity(CLIProviderIdentityClaude),
 			wantUnavailable: []CLIProviderIdentity{
@@ -302,7 +256,7 @@ func TestDiscoverRegisteredCLIProvider_FakePATHDiscoveryTables(t *testing.T) {
 			name: "only lower ranked providers present selects gemini before kiro",
 			presentCommands: map[string]bool{
 				string(interfaces.ModelProviderGemini): true,
-				string(interfaces.ModelProviderKiro):   true,
+				string(interfaces.ModelProviderKiro): true,
 			},
 			wantSelected: ptrCLIProviderIdentity(CLIProviderIdentityGemini),
 			wantUnavailable: []CLIProviderIdentity{
@@ -326,74 +280,91 @@ func TestDiscoverRegisteredCLIProvider_FakePATHDiscoveryTables(t *testing.T) {
 			},
 		},
 	}
+}
 
-	for _, tc := range cases {
+func registeredCLIProviderProbeCommands() []string {
+	return []string{
+		string(interfaces.ModelProviderCodex),
+		string(interfaces.ModelProviderClaude),
+		string(interfaces.ModelProviderCursor),
+		string(interfaces.ModelProviderOpenCode),
+		string(interfaces.ModelProviderGemini),
+		string(interfaces.ModelProviderKiro),
+	}
+}
+
+func assertCLIProviderDiscovery(t *testing.T, tc cliProviderDiscoveryCase) {
+	t.Helper()
+
+	var probedCommands []string
+	lookPath = func(file string) (string, error) {
+		probedCommands = append(probedCommands, file)
+		if tc.presentCommands[file] {
+			return "/fake/bin/" + file, nil
+		}
+		return "", exec.ErrNotFound
+	}
+
+	got := DiscoverRegisteredCLIProvider()
+
+	if tc.wantSelected == nil {
+		if got.Selected != nil {
+			t.Fatalf("selected = %#v, want nil", got.Selected)
+		}
+	} else if got.Selected == nil {
+		t.Fatalf("selected = nil, want %q", *tc.wantSelected)
+	} else if got.Selected.Identity != *tc.wantSelected {
+		t.Fatalf("selected identity = %q, want %q", got.Selected.Identity, *tc.wantSelected)
+	}
+
+	if len(got.Availability) != len(RegisteredCLIProviders()) {
+		t.Fatalf("availability len = %d, want %d", len(got.Availability), len(RegisteredCLIProviders()))
+	}
+
+	unavailable := make(map[CLIProviderIdentity]struct{})
+	for _, availability := range got.Availability {
+		if availability.Available {
+			continue
+		}
+		if availability.UnavailableReason != string(interfaces.WorkFailureTypeMissingExecutable) {
+			t.Fatalf("identity %q unavailable reason = %q, want %q",
+				availability.Registration.Identity,
+				availability.UnavailableReason,
+				interfaces.WorkFailureTypeMissingExecutable,
+			)
+		}
+		unavailable[availability.Registration.Identity] = struct{}{}
+	}
+
+	for _, identity := range tc.wantUnavailable {
+		if _, ok := unavailable[identity]; !ok {
+			t.Fatalf("identity %q not classified unavailable", identity)
+		}
+	}
+
+	wantProbeCommands := tc.wantProbeCommands
+	if wantProbeCommands == nil {
+		wantProbeCommands = registeredCLIProviderProbeCommands()
+	}
+	if len(probedCommands) != len(wantProbeCommands) {
+		t.Fatalf("lookPath commands = %#v, want %#v", probedCommands, wantProbeCommands)
+	}
+	for i, wantCommand := range wantProbeCommands {
+		if probedCommands[i] != wantCommand {
+			t.Fatalf("lookPath command[%d] = %q, want %q", i, probedCommands[i], wantCommand)
+		}
+	}
+}
+
+func TestDiscoverRegisteredCLIProvider_FakePATHDiscoveryTables(t *testing.T) {
+	originalLookPath := lookPath
+	defer func() {
+		lookPath = originalLookPath
+	}()
+
+	for _, tc := range fakeCLIProviderDiscoveryCases() {
 		t.Run(tc.name, func(t *testing.T) {
-			var probedCommands []string
-			lookPath = func(file string) (string, error) {
-				probedCommands = append(probedCommands, file)
-				if tc.presentCommands[file] {
-					return "/fake/bin/" + file, nil
-				}
-				return "", exec.ErrNotFound
-			}
-
-			got := DiscoverRegisteredCLIProvider()
-
-			if tc.wantSelected == nil {
-				if got.Selected != nil {
-					t.Fatalf("selected = %#v, want nil", got.Selected)
-				}
-			} else if got.Selected == nil {
-				t.Fatalf("selected = nil, want %q", *tc.wantSelected)
-			} else if got.Selected.Identity != *tc.wantSelected {
-				t.Fatalf("selected identity = %q, want %q", got.Selected.Identity, *tc.wantSelected)
-			}
-
-			if len(got.Availability) != len(RegisteredCLIProviders()) {
-				t.Fatalf("availability len = %d, want %d", len(got.Availability), len(RegisteredCLIProviders()))
-			}
-
-			unavailable := make(map[CLIProviderIdentity]struct{})
-			for _, availability := range got.Availability {
-				if availability.Available {
-					continue
-				}
-				if availability.UnavailableReason != string(interfaces.WorkFailureTypeMissingExecutable) {
-					t.Fatalf("identity %q unavailable reason = %q, want %q",
-						availability.Registration.Identity,
-						availability.UnavailableReason,
-						interfaces.WorkFailureTypeMissingExecutable,
-					)
-				}
-				unavailable[availability.Registration.Identity] = struct{}{}
-			}
-
-			for _, identity := range tc.wantUnavailable {
-				if _, ok := unavailable[identity]; !ok {
-					t.Fatalf("identity %q not classified unavailable", identity)
-				}
-			}
-
-			wantProbeCommands := tc.wantProbeCommands
-			if wantProbeCommands == nil {
-				wantProbeCommands = []string{
-					string(interfaces.ModelProviderCodex),
-					string(interfaces.ModelProviderClaude),
-					string(interfaces.ModelProviderCursor),
-					string(interfaces.ModelProviderOpenCode),
-					string(interfaces.ModelProviderGemini),
-					string(interfaces.ModelProviderKiro),
-				}
-			}
-			if len(probedCommands) != len(wantProbeCommands) {
-				t.Fatalf("lookPath commands = %#v, want %#v", probedCommands, wantProbeCommands)
-			}
-			for i, wantCommand := range wantProbeCommands {
-				if probedCommands[i] != wantCommand {
-					t.Fatalf("lookPath command[%d] = %q, want %q", i, probedCommands[i], wantCommand)
-				}
-			}
+			assertCLIProviderDiscovery(t, tc)
 		})
 	}
 }

--- a/pkg/workers/cli_provider_registry_test.go
+++ b/pkg/workers/cli_provider_registry_test.go
@@ -186,6 +186,9 @@ func assertCLIProviderProbeAvailability(t *testing.T, tc cliProviderProbeCase) {
 	}
 
 	got := ProbeCLIProviderAvailability(registration)
+	if got.Registration != registration {
+		t.Fatalf("registration = %#v, want %#v (provider/command diagnostic)", got.Registration, registration)
+	}
 	if got.Available != tc.wantAvailable {
 		t.Fatalf("available = %v, want %v", got.Available, tc.wantAvailable)
 	}

--- a/pkg/workers/cli_provider_registry_test.go
+++ b/pkg/workers/cli_provider_registry_test.go
@@ -44,6 +44,21 @@ func TestRegisteredCLIProviders_IncludeEverySupportedProvider(t *testing.T) {
 	}
 }
 
+func TestRegisteredCLIProviders_PreferenceRanksAreUnique(t *testing.T) {
+	seen := make(map[int]CLIProviderIdentity)
+	for _, registration := range RegisteredCLIProviders() {
+		if previous, ok := seen[registration.PreferenceRank]; ok {
+			t.Fatalf(
+				"duplicate preference rank %d: %q and %q",
+				registration.PreferenceRank,
+				previous,
+				registration.Identity,
+			)
+		}
+		seen[registration.PreferenceRank] = registration.Identity
+	}
+}
+
 func TestRegisteredCLIProviders_PreferenceRankOrder(t *testing.T) {
 	wantOrder := []CLIProviderIdentity{
 		CLIProviderIdentityCodex,
@@ -394,6 +409,50 @@ func TestDiscoverRegisteredCLIProvider_FakePATHDiscoveryTables(t *testing.T) {
 
 func ptrCLIProviderIdentity(id CLIProviderIdentity) *CLIProviderIdentity {
 	return &id
+}
+
+func TestProbeRegisteredCLIProviderAvailability_FakePATHReturnsRankOrder(t *testing.T) {
+	originalLookPath := lookPath
+	defer func() {
+		lookPath = originalLookPath
+	}()
+
+	presentCommands := map[string]bool{
+		string(interfaces.ModelProviderCodex):    true,
+		string(interfaces.ModelProviderClaude):   true,
+		string(interfaces.ModelProviderCursor):   true,
+		string(interfaces.ModelProviderOpenCode): true,
+		string(interfaces.ModelProviderGemini):   true,
+		string(interfaces.ModelProviderKiro):     true,
+	}
+	lookPath = func(file string) (string, error) {
+		if presentCommands[file] {
+			return "/fake/bin/" + file, nil
+		}
+		return "", exec.ErrNotFound
+	}
+
+	wantOrder := []CLIProviderIdentity{
+		CLIProviderIdentityCodex,
+		CLIProviderIdentityClaude,
+		CLIProviderIdentityCursor,
+		CLIProviderIdentityOpenCode,
+		CLIProviderIdentityGemini,
+		CLIProviderIdentityKiro,
+	}
+
+	got := ProbeRegisteredCLIProviderAvailability()
+	if len(got) != len(wantOrder) {
+		t.Fatalf("availability len = %d, want %d", len(got), len(wantOrder))
+	}
+	for i, wantIdentity := range wantOrder {
+		if got[i].Registration.Identity != wantIdentity {
+			t.Fatalf("availability[%d] identity = %q, want %q", i, got[i].Registration.Identity, wantIdentity)
+		}
+		if !got[i].Available {
+			t.Fatalf("availability[%d] identity %q not available on Fake-PATH", i, wantIdentity)
+		}
+	}
 }
 
 func TestProbeCLIProviderAvailability_IsDeterministicForFixedFakePATH(t *testing.T) {

--- a/pkg/workers/cli_provider_registry_test.go
+++ b/pkg/workers/cli_provider_registry_test.go
@@ -1,6 +1,8 @@
 package workers
 
 import (
+	"errors"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -109,6 +111,163 @@ func TestCLIProviderIdentity_CompatibleWithProviderBackendScopeNaming(t *testing
 		}
 		if !strings.Contains(scope, string(registration.Identity)) {
 			t.Fatalf("identity %q scope = %q, want identity segment preserved", registration.Identity, scope)
+		}
+	}
+}
+
+func TestProbeCLIProviderAvailability_FakePATHPresentAndAbsentPerCommand(t *testing.T) {
+	originalLookPath := lookPath
+	defer func() {
+		lookPath = originalLookPath
+	}()
+
+	cases := []struct {
+		name            string
+		command         string
+		presentCommands map[string]bool
+		wantAvailable   bool
+		wantReason      string
+	}{
+		{
+			name:            "claude present",
+			command:         string(interfaces.ModelProviderClaude),
+			presentCommands: map[string]bool{string(interfaces.ModelProviderClaude): true},
+			wantAvailable:   true,
+		},
+		{
+			name:            "claude absent",
+			command:         string(interfaces.ModelProviderClaude),
+			presentCommands: map[string]bool{},
+			wantAvailable:   false,
+			wantReason:      string(interfaces.WorkFailureTypeMissingExecutable),
+		},
+		{
+			name:            "codex present",
+			command:         string(interfaces.ModelProviderCodex),
+			presentCommands: map[string]bool{string(interfaces.ModelProviderCodex): true},
+			wantAvailable:   true,
+		},
+		{
+			name:            "codex absent",
+			command:         string(interfaces.ModelProviderCodex),
+			presentCommands: map[string]bool{},
+			wantAvailable:   false,
+			wantReason:      string(interfaces.WorkFailureTypeMissingExecutable),
+		},
+		{
+			name:            "cursor present",
+			command:         string(interfaces.ModelProviderCursor),
+			presentCommands: map[string]bool{string(interfaces.ModelProviderCursor): true},
+			wantAvailable:   true,
+		},
+		{
+			name:            "cursor absent",
+			command:         string(interfaces.ModelProviderCursor),
+			presentCommands: map[string]bool{},
+			wantAvailable:   false,
+			wantReason:      string(interfaces.WorkFailureTypeMissingExecutable),
+		},
+		{
+			name:            "opencode present",
+			command:         string(interfaces.ModelProviderOpenCode),
+			presentCommands: map[string]bool{string(interfaces.ModelProviderOpenCode): true},
+			wantAvailable:   true,
+		},
+		{
+			name:            "opencode absent",
+			command:         string(interfaces.ModelProviderOpenCode),
+			presentCommands: map[string]bool{},
+			wantAvailable:   false,
+			wantReason:      string(interfaces.WorkFailureTypeMissingExecutable),
+		},
+		{
+			name:            "gemini present",
+			command:         string(interfaces.ModelProviderGemini),
+			presentCommands: map[string]bool{string(interfaces.ModelProviderGemini): true},
+			wantAvailable:   true,
+		},
+		{
+			name:            "gemini absent",
+			command:         string(interfaces.ModelProviderGemini),
+			presentCommands: map[string]bool{},
+			wantAvailable:   false,
+			wantReason:      string(interfaces.WorkFailureTypeMissingExecutable),
+		},
+		{
+			name:            "kiro present",
+			command:         string(interfaces.ModelProviderKiro),
+			presentCommands: map[string]bool{string(interfaces.ModelProviderKiro): true},
+			wantAvailable:   true,
+		},
+		{
+			name:            "kiro absent",
+			command:         string(interfaces.ModelProviderKiro),
+			presentCommands: map[string]bool{},
+			wantAvailable:   false,
+			wantReason:      string(interfaces.WorkFailureTypeMissingExecutable),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var probedCommands []string
+			lookPath = func(file string) (string, error) {
+				probedCommands = append(probedCommands, file)
+				if tc.presentCommands[file] {
+					return "/fake/bin/" + file, nil
+				}
+				return "", exec.ErrNotFound
+			}
+
+			registration, ok := CLIProviderRegistrationByCommand(tc.command)
+			if !ok {
+				t.Fatalf("CLIProviderRegistrationByCommand(%q) miss", tc.command)
+			}
+
+			got := ProbeCLIProviderAvailability(registration)
+			if got.Available != tc.wantAvailable {
+				t.Fatalf("available = %v, want %v", got.Available, tc.wantAvailable)
+			}
+			if got.UnavailableReason != tc.wantReason {
+				t.Fatalf("unavailable reason = %q, want %q", got.UnavailableReason, tc.wantReason)
+			}
+			if len(probedCommands) != 1 || probedCommands[0] != tc.command {
+				t.Fatalf("lookPath commands = %#v, want [%q]", probedCommands, tc.command)
+			}
+		})
+	}
+}
+
+func TestProbeCLIProviderAvailability_IsDeterministicForFixedFakePATH(t *testing.T) {
+	originalLookPath := lookPath
+	defer func() {
+		lookPath = originalLookPath
+	}()
+
+	presentCommands := map[string]bool{
+		string(interfaces.ModelProviderCodex):    true,
+		string(interfaces.ModelProviderClaude):   false,
+		string(interfaces.ModelProviderCursor):   true,
+		string(interfaces.ModelProviderOpenCode): false,
+		string(interfaces.ModelProviderGemini):   true,
+		string(interfaces.ModelProviderKiro):     false,
+	}
+
+	lookPath = func(file string) (string, error) {
+		if presentCommands[file] {
+			return "/fake/bin/" + file, nil
+		}
+		return "", errors.New("executable file not found in $PATH")
+	}
+
+	first := ProbeRegisteredCLIProviderAvailability()
+	second := ProbeRegisteredCLIProviderAvailability()
+	if len(first) != len(second) {
+		t.Fatalf("probe length drift: first=%d second=%d", len(first), len(second))
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			t.Fatalf("probe[%d] drift: first=%#v second=%#v", i, first[i], second[i])
 		}
 	}
 }


### PR DESCRIPTION
{
  "project": "you-agent-factory",
  "branchName": "you-goal-b01-provider-identities",
  "description": "Define supported CLI provider identity and availability probes so every currently supported agent CLI provider is registered with command, deterministic preference rank, and a side-effect-free PATH probe. The concrete change is a registry foundation that proves stable Codex→Claude→Cursor→OpenCode→remaining priority, missing-executable classification, and no work execution during discovery inside existing pkg/workers and pkg/config/systemconfig boundaries.",
  "context": {
    "customerAsk": "Register every currently supported agent CLI provider with command, deterministic preference rank, and side-effect-free availability probe. Stable priority and missing-executable classification must be proven. Do not execute customer work or add a new root package family. Prove with Fake-PATH discovery tables and make pkg-boundary.",
    "problem": "One-shot you goal invocation needs deterministic installed-harness discovery when no provider is configured, but provider identities, commands, ranks, and availability checks are incomplete and not owned by one registry policy. Without typed identity, command, preference rank, and side-effect-free probes, discovery can drift by filesystem order, miss supported providers such as Claude, fail to classify missing executables, or risk executing provider CLIs or customer work while probing.",
    "solution": "Extend the existing workers provider registry (and aligned systemconfig identity vocabulary) so every currently supported agent CLI provider exposes stable identity, CLI command, preference rank, and a PATH-only availability probe. Prove stable priority, fallback ordering, missing-executable classification, and zero work execution with Fake-PATH tables while keeping make pkg-boundary green."
  },
  "acceptanceCriteria": [
    "AC-1: Every currently supported agent CLI provider is registered with a stable identity, CLI command name, and deterministic preference rank.",
    "AC-2: Preference ranks produce the stable discovery order Codex, Claude, Cursor, OpenCode, then remaining registered CLI providers in deterministic registry order.",
    "AC-3: Availability probes classify a provider as available or missing-executable from PATH-visible command presence without executing the provider CLI or any customer work.",
    "AC-4: Fake-PATH discovery tables prove stable priority, deterministic fallback when higher-ranked providers are absent, and missing-executable classification.",
    "AC-5: No new root pkg/ package family is introduced; make pkg-boundary passes.",
    "AC-6: Quality checks pass (typecheck, lint, tests)"
  ],
  "userStories": [
    {
      "id": "you-goal-b01-provider-identities-001",
      "title": "Register supported CLI provider identities with commands and ranks",
      "description": "As a maintainer building deterministic harness discovery, I need every currently supported agent CLI provider registered with a stable identity, command name, and preference rank so discovery order does not depend on filesystem iteration or scattered conditionals.",
      "acceptanceCriteria": [
        "The registry enumerates every currently supported agent CLI provider (Claude, Codex, Gemini, Kiro, Cursor, OpenCode) with a stable identity and the canonical CLI command used for dispatch (claude, codex, gemini, kiro-cli, agent, opencode).",
        "Each registration carries a deterministic preference rank such that sorting by rank yields Codex, then Claude, then Cursor, then OpenCode, then the remaining registered providers in a fixed registry order.",
        "Querying the registry for identity or command returns the same values for a given provider across repeated calls (no environment-dependent identity drift).",
        "Provider identity vocabulary remains compatible with existing systemconfig provider-scope naming for the same providers.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "you-goal-b01-provider-identities-002",
      "title": "Probe availability without side effects and classify missing executables",
      "description": "As an invocation bootstrap caller, I want a side-effect-free availability probe per registered CLI provider so discovery can tell whether a harness is installed without running the provider or executing customer work.",
      "acceptanceCriteria": [
        "For each registered provider, a probe reports available when its command is resolvable on PATH and missing-executable (or equivalent classified unavailable outcome aligned with missing_executable) when it is not.",
        "Probes perform only PATH/command-resolution checks; they do not start the provider process, send prompts, touch customer work payloads, or otherwise execute customer work.",
        "Fake-PATH fixtures cover at least one present-command case and one absent-command case per registered provider command name.",
        "Probe results are deterministic for a fixed fake PATH and do not vary with unrelated environment noise.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "you-goal-b01-provider-identities-003",
      "title": "Prove stable priority and fallback ordering with Fake-PATH discovery tables",
      "description": "As a reviewer of the you-goal bootstrap foundation, I need Fake-PATH discovery tables that prove stable priority and deterministic fallback so later selection policy can rely on registry ordering without re-deriving it.",
      "acceptanceCriteria": [
        "Table-driven Fake-PATH fixtures prove that when multiple providers are present, discovery preference follows the registered rank order (Codex before Claude before Cursor before OpenCode before remaining providers).",
        "Table-driven fixtures prove that when higher-ranked providers are absent, discovery falls through to the next available registered provider in rank order.",
        "Table-driven fixtures prove that when no registered provider command is on PATH, every probed provider is classified as missing-executable / unavailable and no provider is treated as selected.",
        "Discovery evaluation in these fixtures never executes a real provider CLI or customer work.",
        "Work remains in existing package families; make pkg-boundary passes with no new root pkg/ family.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}
