### PR TITLE
you-goal-b01-cli-doc-baseline

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+pkg/cli/baseline/testdata/** text eol=lf

--- a/pkg/cli/baseline/command_tree.go
+++ b/pkg/cli/baseline/command_tree.go
@@ -1,0 +1,40 @@
+package baseline
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// SerializeCommandTree records the production Cobra command tree in a
+// deterministic textual form. Each line is "<commandPath>\t<use>\t<parentPath>".
+// Lines are sorted by command path so repeated runs stay stable.
+func SerializeCommandTree(root *cobra.Command) string {
+	lines := collectCommandTreeLines(root)
+	sort.Strings(lines)
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func collectCommandTreeLines(cmd *cobra.Command) []string {
+	path := cmd.CommandPath()
+	parent := ""
+	if cmd.Parent() != nil {
+		parent = cmd.Parent().CommandPath()
+	}
+	lines := []string{path + "\t" + cmd.Use + "\t" + parent}
+
+	children := cmd.Commands()
+	sort.Slice(children, func(i, j int) bool {
+		left := children[i].CommandPath()
+		right := children[j].CommandPath()
+		if left == right {
+			return children[i].Use < children[j].Use
+		}
+		return left < right
+	})
+	for _, child := range children {
+		lines = append(lines, collectCommandTreeLines(child)...)
+	}
+	return lines
+}

--- a/pkg/cli/baseline/command_tree_test.go
+++ b/pkg/cli/baseline/command_tree_test.go
@@ -1,7 +1,6 @@
 package baseline_test
 
 import (
-	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -16,11 +15,10 @@ func TestCommandTreeBaseline_MatchesFixture(t *testing.T) {
 	root := cli.NewRootCommand()
 	got := baseline.SerializeCommandTree(root)
 
-	wantBytes, err := os.ReadFile(commandTreeFixture)
+	want, err := baseline.ReadFixtureText(commandTreeFixture)
 	if err != nil {
 		t.Fatalf("read command tree baseline fixture: %v", err)
 	}
-	want := string(wantBytes)
 
 	if got == want {
 		return

--- a/pkg/cli/baseline/command_tree_test.go
+++ b/pkg/cli/baseline/command_tree_test.go
@@ -1,0 +1,103 @@
+package baseline_test
+
+import (
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/cli"
+	"github.com/portpowered/infinite-you/pkg/cli/baseline"
+)
+
+const commandTreeFixture = "testdata/command_tree.txt"
+
+func TestCommandTreeBaseline_MatchesFixture(t *testing.T) {
+	root := cli.NewRootCommand()
+	got := baseline.SerializeCommandTree(root)
+
+	wantBytes, err := os.ReadFile(commandTreeFixture)
+	if err != nil {
+		t.Fatalf("read command tree baseline fixture: %v", err)
+	}
+	want := string(wantBytes)
+
+	if got == want {
+		return
+	}
+
+	t.Fatalf(
+		"command tree baseline drift detected; update %s when intentional\n%s",
+		commandTreeFixture,
+		formatCommandTreeDiff(want, got),
+	)
+}
+
+func TestCommandTreeBaseline_IsStableAcrossRuns(t *testing.T) {
+	root := cli.NewRootCommand()
+
+	first := baseline.SerializeCommandTree(root)
+	second := baseline.SerializeCommandTree(root)
+	if first != second {
+		t.Fatalf("command tree serialization is not stable across repeated runs\n%s", formatCommandTreeDiff(first, second))
+	}
+}
+
+func formatCommandTreeDiff(want, got string) string {
+	wantLines := strings.Split(strings.TrimSuffix(want, "\n"), "\n")
+	gotLines := strings.Split(strings.TrimSuffix(got, "\n"), "\n")
+
+	wantSet := make(map[string]struct{}, len(wantLines))
+	for _, line := range wantLines {
+		if line == "" {
+			continue
+		}
+		wantSet[line] = struct{}{}
+	}
+	gotSet := make(map[string]struct{}, len(gotLines))
+	for _, line := range gotLines {
+		if line == "" {
+			continue
+		}
+		gotSet[line] = struct{}{}
+	}
+
+	var removed []string
+	for line := range wantSet {
+		if _, ok := gotSet[line]; !ok {
+			removed = append(removed, line)
+		}
+	}
+	sort.Strings(removed)
+
+	var added []string
+	for line := range gotSet {
+		if _, ok := wantSet[line]; !ok {
+			added = append(added, line)
+		}
+	}
+	sort.Strings(added)
+
+	var b strings.Builder
+	b.WriteString("removed commands:\n")
+	if len(removed) == 0 {
+		b.WriteString("  (none)\n")
+	} else {
+		for _, line := range removed {
+			b.WriteString("  - ")
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
+	}
+	b.WriteString("added commands:\n")
+	if len(added) == 0 {
+		b.WriteString("  (none)\n")
+	} else {
+		for _, line := range added {
+			b.WriteString("  + ")
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}

--- a/pkg/cli/baseline/docs_topics.go
+++ b/pkg/cli/baseline/docs_topics.go
@@ -1,0 +1,26 @@
+package baseline
+
+import (
+	"strings"
+
+	docscli "github.com/portpowered/infinite-you/pkg/cli/docs"
+)
+
+// SerializeDocsTopicIndex records the production packaged docs topic index in
+// a deterministic textual form. Each line is
+// "<name>\t<description>\t<aliases>" where aliases are comma-separated and
+// sorted. Lines follow the production display order from TopicIndexEntries.
+func SerializeDocsTopicIndex() string {
+	entries := docscli.TopicIndexEntries()
+	lines := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		lines = append(lines, formatDocsTopicLine(entry))
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func formatDocsTopicLine(entry docscli.TopicIndexEntry) string {
+	description := strings.ReplaceAll(entry.Description, "\t", " ")
+	description = strings.ReplaceAll(description, "\n", " ")
+	return entry.Name + "\t" + description + "\t" + strings.Join(entry.Aliases, ",")
+}

--- a/pkg/cli/baseline/docs_topics_test.go
+++ b/pkg/cli/baseline/docs_topics_test.go
@@ -1,7 +1,6 @@
 package baseline_test
 
 import (
-	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -14,11 +13,10 @@ const docsTopicIndexFixture = "testdata/docs_topic_index.txt"
 func TestDocsTopicIndexBaseline_MatchesFixture(t *testing.T) {
 	got := baseline.SerializeDocsTopicIndex()
 
-	wantBytes, err := os.ReadFile(docsTopicIndexFixture)
+	want, err := baseline.ReadFixtureText(docsTopicIndexFixture)
 	if err != nil {
 		t.Fatalf("read docs topic index baseline fixture: %v", err)
 	}
-	want := string(wantBytes)
 
 	if got == want {
 		return

--- a/pkg/cli/baseline/docs_topics_test.go
+++ b/pkg/cli/baseline/docs_topics_test.go
@@ -1,0 +1,96 @@
+package baseline_test
+
+import (
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/cli/baseline"
+)
+
+const docsTopicIndexFixture = "testdata/docs_topic_index.txt"
+
+func TestDocsTopicIndexBaseline_MatchesFixture(t *testing.T) {
+	got := baseline.SerializeDocsTopicIndex()
+
+	wantBytes, err := os.ReadFile(docsTopicIndexFixture)
+	if err != nil {
+		t.Fatalf("read docs topic index baseline fixture: %v", err)
+	}
+	want := string(wantBytes)
+
+	if got == want {
+		return
+	}
+
+	t.Fatalf(
+		"docs topic index baseline drift detected; update %s when intentional\n%s",
+		docsTopicIndexFixture,
+		formatDocsTopicIndexDiff(want, got),
+	)
+}
+
+func TestDocsTopicIndexBaseline_IsStableAcrossRuns(t *testing.T) {
+	first := baseline.SerializeDocsTopicIndex()
+	second := baseline.SerializeDocsTopicIndex()
+	if first != second {
+		t.Fatalf(
+			"docs topic index serialization is not stable across repeated runs\n%s",
+			formatDocsTopicIndexDiff(first, second),
+		)
+	}
+}
+
+func formatDocsTopicIndexDiff(want, got string) string {
+	wantLines := nonEmptyLines(want)
+	gotLines := nonEmptyLines(got)
+
+	wantSet := make(map[string]struct{}, len(wantLines))
+	for _, line := range wantLines {
+		wantSet[line] = struct{}{}
+	}
+	gotSet := make(map[string]struct{}, len(gotLines))
+	for _, line := range gotLines {
+		gotSet[line] = struct{}{}
+	}
+
+	var removed []string
+	for line := range wantSet {
+		if _, ok := gotSet[line]; !ok {
+			removed = append(removed, line)
+		}
+	}
+	sort.Strings(removed)
+
+	var added []string
+	for line := range gotSet {
+		if _, ok := wantSet[line]; !ok {
+			added = append(added, line)
+		}
+	}
+	sort.Strings(added)
+
+	var b strings.Builder
+	b.WriteString("removed topics:\n")
+	if len(removed) == 0 {
+		b.WriteString("  (none)\n")
+	} else {
+		for _, line := range removed {
+			b.WriteString("  - ")
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
+	}
+	b.WriteString("added topics:\n")
+	if len(added) == 0 {
+		b.WriteString("  (none)\n")
+	} else {
+		for _, line := range added {
+			b.WriteString("  + ")
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}

--- a/pkg/cli/baseline/fixture_text.go
+++ b/pkg/cli/baseline/fixture_text.go
@@ -1,0 +1,26 @@
+package baseline
+
+import (
+	"os"
+	"strings"
+)
+
+// NormalizeFixtureText canonicalizes committed baseline fixture text so compares
+// stay stable when Git checks out files with CRLF on Windows.
+func NormalizeFixtureText(text string) string {
+	normalized := strings.ReplaceAll(text, "\r\n", "\n")
+	normalized = strings.ReplaceAll(normalized, "\r", "\n")
+	if normalized != "" && !strings.HasSuffix(normalized, "\n") {
+		normalized += "\n"
+	}
+	return normalized
+}
+
+// ReadFixtureText reads a committed baseline fixture and normalizes line endings.
+func ReadFixtureText(path string) (string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return NormalizeFixtureText(string(raw)), nil
+}

--- a/pkg/cli/baseline/fixture_text_test.go
+++ b/pkg/cli/baseline/fixture_text_test.go
@@ -1,0 +1,27 @@
+package baseline
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeFixtureText_StripsCRLF(t *testing.T) {
+	const want = "alpha\tbeta\n"
+	got := NormalizeFixtureText("alpha\tbeta\r\n")
+	if got != want {
+		t.Fatalf("NormalizeFixtureText() = %q, want %q", got, want)
+	}
+}
+
+func TestReadFixtureText_NormalizesLineEndings(t *testing.T) {
+	got, err := ReadFixtureText("testdata/command_tree.txt")
+	if err != nil {
+		t.Fatalf("ReadFixtureText: %v", err)
+	}
+	if got == "" {
+		t.Fatal("expected non-empty fixture text")
+	}
+	if strings.Contains(got, "\r") {
+		t.Fatalf("ReadFixtureText() still contains carriage returns")
+	}
+}

--- a/pkg/cli/baseline/help_output.go
+++ b/pkg/cli/baseline/help_output.go
@@ -1,0 +1,34 @@
+package baseline
+
+import (
+	"bytes"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// CaptureHelpOutput runs a production Cobra help invocation against root using
+// args and returns normalized stdout. stderr is discarded.
+func CaptureHelpOutput(root *cobra.Command, args []string) (string, error) {
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(io.Discard)
+	root.SetArgs(args)
+
+	if err := root.Execute(); err != nil {
+		return "", err
+	}
+	return NormalizeHelpOutput(out.String()), nil
+}
+
+// NormalizeHelpOutput canonicalizes help text so fixtures stay stable across
+// platforms and repeated runs.
+func NormalizeHelpOutput(output string) string {
+	normalized := strings.ReplaceAll(output, "\r\n", "\n")
+	normalized = strings.ReplaceAll(normalized, "\r", "\n")
+	if normalized != "" && !strings.HasSuffix(normalized, "\n") {
+		normalized += "\n"
+	}
+	return normalized
+}

--- a/pkg/cli/baseline/help_output.go
+++ b/pkg/cli/baseline/help_output.go
@@ -3,7 +3,6 @@ package baseline
 import (
 	"bytes"
 	"io"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -25,10 +24,5 @@ func CaptureHelpOutput(root *cobra.Command, args []string) (string, error) {
 // NormalizeHelpOutput canonicalizes help text so fixtures stay stable across
 // platforms and repeated runs.
 func NormalizeHelpOutput(output string) string {
-	normalized := strings.ReplaceAll(output, "\r\n", "\n")
-	normalized = strings.ReplaceAll(normalized, "\r", "\n")
-	if normalized != "" && !strings.HasSuffix(normalized, "\n") {
-		normalized += "\n"
-	}
-	return normalized
+	return NormalizeFixtureText(output)
 }

--- a/pkg/cli/baseline/help_output_test.go
+++ b/pkg/cli/baseline/help_output_test.go
@@ -1,7 +1,6 @@
 package baseline_test
 
 import (
-	"os"
 	"strings"
 	"testing"
 
@@ -65,11 +64,10 @@ func assertHelpMatchesFixture(t *testing.T, fixture string, args []string) {
 		t.Fatalf("capture help output: %v", err)
 	}
 
-	wantBytes, err := os.ReadFile(fixture)
+	want, err := baseline.ReadFixtureText(fixture)
 	if err != nil {
 		t.Fatalf("read help baseline fixture: %v", err)
 	}
-	want := baseline.NormalizeHelpOutput(string(wantBytes))
 
 	if got == want {
 		return

--- a/pkg/cli/baseline/help_output_test.go
+++ b/pkg/cli/baseline/help_output_test.go
@@ -1,0 +1,103 @@
+package baseline_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/cli"
+	"github.com/portpowered/infinite-you/pkg/cli/baseline"
+)
+
+const (
+	rootHelpFixture = "testdata/root_help.txt"
+	runHelpFixture  = "testdata/run_help.txt"
+	docsHelpFixture = "testdata/docs_help.txt"
+)
+
+func TestRootHelpBaseline_MatchesFixture(t *testing.T) {
+	assertHelpMatchesFixture(t, rootHelpFixture, []string{"--help"})
+}
+
+func TestRunHelpBaseline_MatchesFixture(t *testing.T) {
+	assertHelpMatchesFixture(t, runHelpFixture, []string{"run", "--help"})
+}
+
+func TestDocsHelpBaseline_MatchesFixture(t *testing.T) {
+	assertHelpMatchesFixture(t, docsHelpFixture, []string{"docs", "--help"})
+}
+
+func TestHelpBaselines_AreStableAcrossRuns(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{name: "root", args: []string{"--help"}},
+		{name: "run", args: []string{"run", "--help"}},
+		{name: "docs", args: []string{"docs", "--help"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			first, err := captureProductionHelp(tc.args)
+			if err != nil {
+				t.Fatalf("capture first help output: %v", err)
+			}
+			second, err := captureProductionHelp(tc.args)
+			if err != nil {
+				t.Fatalf("capture second help output: %v", err)
+			}
+			if first != second {
+				t.Fatalf(
+					"help output is not stable across repeated runs\n%s",
+					formatHelpDiff(first, second),
+				)
+			}
+		})
+	}
+}
+
+func assertHelpMatchesFixture(t *testing.T, fixture string, args []string) {
+	t.Helper()
+
+	got, err := captureProductionHelp(args)
+	if err != nil {
+		t.Fatalf("capture help output: %v", err)
+	}
+
+	wantBytes, err := os.ReadFile(fixture)
+	if err != nil {
+		t.Fatalf("read help baseline fixture: %v", err)
+	}
+	want := baseline.NormalizeHelpOutput(string(wantBytes))
+
+	if got == want {
+		return
+	}
+
+	t.Fatalf(
+		"help baseline drift detected; update %s when intentional\n%s",
+		fixture,
+		formatHelpDiff(want, got),
+	)
+}
+
+func captureProductionHelp(args []string) (string, error) {
+	root := cli.NewRootCommand()
+	return baseline.CaptureHelpOutput(root, args)
+}
+
+func formatHelpDiff(want, got string) string {
+	var b strings.Builder
+	b.WriteString("--- want ---\n")
+	b.WriteString(want)
+	if !strings.HasSuffix(want, "\n") {
+		b.WriteByte('\n')
+	}
+	b.WriteString("--- got ---\n")
+	b.WriteString(got)
+	if !strings.HasSuffix(got, "\n") {
+		b.WriteByte('\n')
+	}
+	return b.String()
+}

--- a/pkg/cli/baseline/intentional_changes.go
+++ b/pkg/cli/baseline/intentional_changes.go
@@ -1,0 +1,136 @@
+package baseline
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/portpowered/infinite-you/pkg/cli"
+	"github.com/spf13/cobra"
+)
+
+const intentionalChangesLedgerFixture = "testdata/intentional_changes.json"
+
+// IntentionalChangesLedger records commands and flags deliberately planned for
+// removal or relocation during upcoming CLI migrations.
+type IntentionalChangesLedger struct {
+	PlannedRemovals []PlannedRemoval `json:"planned_removals"`
+	PlannedMoves    []PlannedMove    `json:"planned_moves"`
+}
+
+// PlannedRemoval names a production command or run flag slated for removal.
+type PlannedRemoval struct {
+	Surface     string `json:"surface"`
+	Name        string `json:"name,omitempty"`
+	CommandPath string `json:"command_path,omitempty"`
+	Rationale   string `json:"rationale"`
+}
+
+// PlannedMove names a production command slated for relocation.
+type PlannedMove struct {
+	Surface         string `json:"surface"`
+	FromCommandPath string `json:"from_command_path"`
+	ToCommandPath   string `json:"to_command_path"`
+	Rationale       string `json:"rationale"`
+}
+
+// LoadIntentionalChangesLedger reads the committed intentional-change ledger.
+func LoadIntentionalChangesLedger() (IntentionalChangesLedger, error) {
+	raw, err := ReadFixtureText(intentionalChangesLedgerFixture)
+	if err != nil {
+		return IntentionalChangesLedger{}, err
+	}
+
+	var ledger IntentionalChangesLedger
+	if err := json.Unmarshal([]byte(raw), &ledger); err != nil {
+		return IntentionalChangesLedger{}, fmt.Errorf("decode intentional changes ledger: %w", err)
+	}
+	return ledger, nil
+}
+
+// ValidateIntentionalChangesLedger asserts each ledger entry still appears in
+// today's production command-tree and/or run-flag baselines.
+func ValidateIntentionalChangesLedger(root *cobra.Command, runCmd *cobra.Command) error {
+	ledger, err := LoadIntentionalChangesLedger()
+	if err != nil {
+		return err
+	}
+
+	commandTree := SerializeCommandTree(root)
+	runFlags := SerializeRunFlags(runCmd)
+
+	for _, removal := range ledger.PlannedRemovals {
+		switch removal.Surface {
+		case "run_flag":
+			if removal.Name == "" {
+				return fmt.Errorf("planned removal run_flag is missing name")
+			}
+			if !runFlagPresent(runFlags, removal.Name) {
+				return fmt.Errorf("planned removal run_flag %q is not present in the run-flag baseline", removal.Name)
+			}
+		case "command":
+			if removal.CommandPath == "" {
+				return fmt.Errorf("planned removal command is missing command_path")
+			}
+			if !commandPathPresent(commandTree, removal.CommandPath) {
+				return fmt.Errorf("planned removal command %q is not present in the command-tree baseline", removal.CommandPath)
+			}
+		default:
+			return fmt.Errorf("unsupported planned removal surface %q", removal.Surface)
+		}
+	}
+
+	for _, move := range ledger.PlannedMoves {
+		if move.Surface != "command" {
+			return fmt.Errorf("unsupported planned move surface %q", move.Surface)
+		}
+		if move.FromCommandPath == "" {
+			return fmt.Errorf("planned move command is missing from_command_path")
+		}
+		if !commandPathPresent(commandTree, move.FromCommandPath) {
+			return fmt.Errorf("planned move source command %q is not present in the command-tree baseline", move.FromCommandPath)
+		}
+	}
+
+	return nil
+}
+
+func commandPathPresent(commandTree, commandPath string) bool {
+	prefix := commandPath + "\t"
+	for _, line := range strings.Split(commandTree, "\n") {
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func runFlagPresent(runFlags, name string) bool {
+	prefix := name + "\t"
+	for _, line := range strings.Split(runFlags, "\n") {
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// ProductionRootCommand returns the canonical production CLI root command.
+func ProductionRootCommand() *cobra.Command {
+	return cli.NewRootCommand()
+}
+
+// ProductionRunCommand resolves the production you run command from root.
+func ProductionRunCommand(root *cobra.Command) (*cobra.Command, error) {
+	runCmd, _, err := root.Find([]string{"run"})
+	if err != nil {
+		return nil, fmt.Errorf("find run command: %w", err)
+	}
+	return runCmd, nil
+}

--- a/pkg/cli/baseline/intentional_changes_test.go
+++ b/pkg/cli/baseline/intentional_changes_test.go
@@ -1,0 +1,33 @@
+package baseline_test
+
+import (
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/cli/baseline"
+)
+
+func TestIntentionalChangesLedger_MatchesProductionBaselines(t *testing.T) {
+	root := baseline.ProductionRootCommand()
+	runCmd, err := baseline.ProductionRunCommand(root)
+	if err != nil {
+		t.Fatalf("resolve run command: %v", err)
+	}
+
+	if err := baseline.ValidateIntentionalChangesLedger(root, runCmd); err != nil {
+		t.Fatalf("intentional changes ledger drift detected; update testdata/intentional_changes.json when intentional\n%v", err)
+	}
+}
+
+func TestIntentionalChangesLedger_IsDistinctFromExecutableSnapshots(t *testing.T) {
+	ledger, err := baseline.LoadIntentionalChangesLedger()
+	if err != nil {
+		t.Fatalf("load intentional changes ledger: %v", err)
+	}
+
+	if len(ledger.PlannedRemovals) == 0 {
+		t.Fatal("expected planned removals in intentional changes ledger")
+	}
+	if len(ledger.PlannedMoves) == 0 {
+		t.Fatal("expected planned moves in intentional changes ledger")
+	}
+}

--- a/pkg/cli/baseline/run_flags.go
+++ b/pkg/cli/baseline/run_flags.go
@@ -1,0 +1,60 @@
+package baseline
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// SerializeRunFlags records the production you run flag contract in a
+// deterministic textual form. Each line is
+// "<name>\t<shorthand>\t<default>\t<usage>" for local and inherited flags.
+// Lines are sorted by flag name so repeated runs stay stable.
+func SerializeRunFlags(runCmd *cobra.Command) string {
+	lines := collectRunFlagLines(runCmd)
+	sort.Strings(lines)
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func collectRunFlagLines(runCmd *cobra.Command) []string {
+	flags := collectRunFlags(runCmd)
+	lines := make([]string, 0, len(flags))
+	for _, flag := range flags {
+		lines = append(lines, formatRunFlagLine(flag))
+	}
+	return lines
+}
+
+func collectRunFlags(runCmd *cobra.Command) []*pflag.Flag {
+	byName := map[string]*pflag.Flag{}
+	visit := func(flagSet *pflag.FlagSet) {
+		if flagSet == nil {
+			return
+		}
+		flagSet.VisitAll(func(flag *pflag.Flag) {
+			byName[flag.Name] = flag
+		})
+	}
+	visit(runCmd.InheritedFlags())
+	visit(runCmd.Flags())
+
+	names := make([]string, 0, len(byName))
+	for name := range byName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	flags := make([]*pflag.Flag, 0, len(names))
+	for _, name := range names {
+		flags = append(flags, byName[name])
+	}
+	return flags
+}
+
+func formatRunFlagLine(flag *pflag.Flag) string {
+	usage := strings.ReplaceAll(flag.Usage, "\t", " ")
+	usage = strings.ReplaceAll(usage, "\n", " ")
+	return flag.Name + "\t" + flag.Shorthand + "\t" + flag.DefValue + "\t" + usage
+}

--- a/pkg/cli/baseline/run_flags_test.go
+++ b/pkg/cli/baseline/run_flags_test.go
@@ -1,0 +1,121 @@
+package baseline_test
+
+import (
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/cli"
+	"github.com/portpowered/infinite-you/pkg/cli/baseline"
+	"github.com/spf13/cobra"
+)
+
+const runFlagsFixture = "testdata/run_flags.txt"
+
+func TestRunFlagsBaseline_MatchesFixture(t *testing.T) {
+	runCmd := productionRunCommand(t)
+	got := baseline.SerializeRunFlags(runCmd)
+
+	wantBytes, err := os.ReadFile(runFlagsFixture)
+	if err != nil {
+		t.Fatalf("read run flags baseline fixture: %v", err)
+	}
+	want := string(wantBytes)
+
+	if got == want {
+		return
+	}
+
+	t.Fatalf(
+		"run flags baseline drift detected; update %s when intentional\n%s",
+		runFlagsFixture,
+		formatLineDiff(want, got),
+	)
+}
+
+func TestRunFlagsBaseline_IsStableAcrossRuns(t *testing.T) {
+	runCmd := productionRunCommand(t)
+
+	first := baseline.SerializeRunFlags(runCmd)
+	second := baseline.SerializeRunFlags(runCmd)
+	if first != second {
+		t.Fatalf("run flags serialization is not stable across repeated runs\n%s", formatLineDiff(first, second))
+	}
+}
+
+func productionRunCommand(t *testing.T) *cobra.Command {
+	t.Helper()
+
+	root := cli.NewRootCommand()
+	runCmd, _, err := root.Find([]string{"run"})
+	if err != nil {
+		t.Fatalf("find run command: %v", err)
+	}
+	return runCmd
+}
+
+func formatLineDiff(want, got string) string {
+	wantLines := nonEmptyLines(want)
+	gotLines := nonEmptyLines(got)
+
+	wantSet := make(map[string]struct{}, len(wantLines))
+	for _, line := range wantLines {
+		wantSet[line] = struct{}{}
+	}
+	gotSet := make(map[string]struct{}, len(gotLines))
+	for _, line := range gotLines {
+		gotSet[line] = struct{}{}
+	}
+
+	var removed []string
+	for line := range wantSet {
+		if _, ok := gotSet[line]; !ok {
+			removed = append(removed, line)
+		}
+	}
+	sort.Strings(removed)
+
+	var added []string
+	for line := range gotSet {
+		if _, ok := wantSet[line]; !ok {
+			added = append(added, line)
+		}
+	}
+	sort.Strings(added)
+
+	var b strings.Builder
+	b.WriteString("removed flags:\n")
+	if len(removed) == 0 {
+		b.WriteString("  (none)\n")
+	} else {
+		for _, line := range removed {
+			b.WriteString("  - ")
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
+	}
+	b.WriteString("added flags:\n")
+	if len(added) == 0 {
+		b.WriteString("  (none)\n")
+	} else {
+		for _, line := range added {
+			b.WriteString("  + ")
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+func nonEmptyLines(text string) []string {
+	lines := strings.Split(strings.TrimSuffix(text, "\n"), "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
+}

--- a/pkg/cli/baseline/run_flags_test.go
+++ b/pkg/cli/baseline/run_flags_test.go
@@ -1,7 +1,6 @@
 package baseline_test
 
 import (
-	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -17,11 +16,10 @@ func TestRunFlagsBaseline_MatchesFixture(t *testing.T) {
 	runCmd := productionRunCommand(t)
 	got := baseline.SerializeRunFlags(runCmd)
 
-	wantBytes, err := os.ReadFile(runFlagsFixture)
+	want, err := baseline.ReadFixtureText(runFlagsFixture)
 	if err != nil {
 		t.Fatalf("read run flags baseline fixture: %v", err)
 	}
-	want := string(wantBytes)
 
 	if got == want {
 		return

--- a/pkg/cli/baseline/testdata/command_tree.txt
+++ b/pkg/cli/baseline/testdata/command_tree.txt
@@ -1,0 +1,46 @@
+you	you	
+you config	config	you
+you config expand	expand <factory.json>	you config
+you config flatten	flatten <factory-path>	you config
+you docs	docs [topic]	you
+you factory	factory	you
+you factory delete	delete <name>	you factory
+you factory list	list	you factory
+you factory query	query	you factory
+you factory save	save [name]	you factory
+you factory update	update <name>	you factory
+you factory validate	validate <factory-path>	you factory
+you init	init	you
+you mcp	mcp	you
+you mcp serve	serve	you mcp
+you models	models	you
+you models inspect	inspect <model-name>	you models
+you models invoke	invoke <model-name>	you models
+you models list	list	you models
+you models pull	pull <model-name>	you models
+you run	run	you
+you session	session	you
+you session create	create	you session
+you session delete	delete <session-id>	you session
+you session dispatches	dispatches [session-id]	you session
+you session list	list	you session
+you session pause	pause [session-id]	you session
+you session resume	resume [session-id]	you session
+you session show	show [session-id]	you session
+you submit	submit	you
+you submit batch	batch [path|-|<inline-json>]	you submit
+you work	work	you
+you work list	list	you work
+you work move	move <work-id> <state-name>	you work
+you work show	show <work-id>	you work
+you work visualize	visualize <batch-file.json>	you work
+you workflow	workflow	you
+you workflow artifacts	artifacts [session-id]	you workflow
+you workflow dispatches	dispatches [session-id]	you workflow
+you workflow events	events [session-id]	you workflow
+you workflow preview	preview	you workflow
+you workflow result	result [session-id]	you workflow
+you workflow run	run	you workflow
+you workflow start	start	you workflow
+you workflow status	status [session-id]	you workflow
+you workflow validate	validate	you workflow

--- a/pkg/cli/baseline/testdata/docs_help.txt
+++ b/pkg/cli/baseline/testdata/docs_help.txt
@@ -1,0 +1,17 @@
+Print packaged markdown reference topics from the installed binary.
+
+Run without a topic to print the quick-start blurb and packaged docs index. Use one supported topic argument to print the authored markdown page with no wrapper formatting.
+
+Usage:
+  you docs [topic] [flags]
+
+Flags:
+  -h, --help   help for docs
+
+Global Flags:
+  -d, --debug                                  emit lower-level command diagnostics where supported (implies --verbose)
+      --default-worker-model string            default worker model for model workers with omitted model
+      --default-worker-model-provider string   default worker model provider for model workers with omitted modelProvider (accepted canonical providers: CLAUDE, CODEX, CURSOR, GEMINI, KIRO, OPENCODE; accepted aliases include codex, claude, gemini, kiro-cli, opencode, agent, cursor, and anthropic; DEFAULT resolves through lower-precedence concrete provider)
+      --json                                   emit structured JSON on stdout for supported commands; diagnostics remain on stderr
+      --server string                          factory API base URI (http:// or https://); HTTP client commands target this URI and you run binds locally to its host and port (default "http://localhost:7437")
+  -v, --verbose                                emit concise command diagnostics to stderr

--- a/pkg/cli/baseline/testdata/docs_topic_index.txt
+++ b/pkg/cli/baseline/testdata/docs_topic_index.txt
@@ -1,0 +1,21 @@
+agents	Agent orientation: read order, work submission, command matrix, planner vs executor, and topic router.	
+authoring-factories	Practical factory authoring workflow, runnable examples, mock workers, and replay.	
+config	factory.json topology, operator model defaults, work types, states, workers, workstations, resources, and portability.	
+mock-workers	Mock-worker runs, JSON selection contract, and deterministic accept, reject, and script outcomes.	
+record-replay	Record and replay run modes, artifact paths, sensitivity, and incompatible flag combinations.	
+guards	Workstation, input, and factory guards, guarded LOGICAL_MOVE loop breakers, and guard attachment levels.	
+relationships	Batch DEPENDS_ON and PARENT_CHILD relations, runtime SPAWNED_BY lineage, and parent-aware guard linkage.	
+work	Submitted work: session-scoped work routes, tags, batch cross-links, and submission contracts.	
+sessions	Live factory sessions: session list, session show, pause and resume, factory query, status API, dashboard URL, and run modes.	
+mcp-hosts	Dynamic workflow MCP host setup: you mcp serve, stdio transport, tool catalog, and practical host examples.	
+orchestrators	Factory, FactoryOrchestrator, FactorySession, Dispatch, FactoryArtifact, FactoryEvent, and dynamic workflow aliases.	
+mcp	Canonical you mcp serve install path, preview tool catalog, scope boundaries, and automation-backed checks.	
+workstations	Workstation kinds, route fields, runtime step behavior, and scoped execution settings.	workstation
+workers	Worker types, model providers, script workers, and worker configuration.	
+resources	Resource capacity, bounded concurrency, and workstation resource requirements.	
+models	Local and hosted model setup for workers and CLI model commands.	
+packaged-fusion	Packaged @you/fusion invocation, signature-aware help, materialization path, and editability.	
+packaged-goal	Packaged @you/goal batch invocation, stdout primary result, materialization path, and headless operator-interaction scope.	
+packaged-tts	Packaged @you/tts invocation, materialization path, metadata result, and on-disk editability.	
+batch-inputs	Batch input files, request shape, dependencies, and validation.	batch-work
+templates	Prompt template variables, context fields, and Go template behavior.	

--- a/pkg/cli/baseline/testdata/intentional_changes.json
+++ b/pkg/cli/baseline/testdata/intentional_changes.json
@@ -1,0 +1,34 @@
+{
+  "planned_removals": [
+    {
+      "surface": "run_flag",
+      "name": "workflow",
+      "rationale": "Remove you run --workflow; workflow selection uses dedicated workflow commands."
+    },
+    {
+      "surface": "command",
+      "command_path": "you factory save",
+      "rationale": "Remove you factory save from the production CLI."
+    }
+  ],
+  "planned_moves": [
+    {
+      "surface": "command",
+      "from_command_path": "you config expand",
+      "to_command_path": "you factory config expand",
+      "rationale": "Relocate you config expand under you factory config."
+    },
+    {
+      "surface": "command",
+      "from_command_path": "you config flatten",
+      "to_command_path": "you factory config flatten",
+      "rationale": "Relocate you config flatten under you factory config."
+    },
+    {
+      "surface": "command",
+      "from_command_path": "you factory validate",
+      "to_command_path": "you factory config validate",
+      "rationale": "Reparent you factory validate under you factory config. you config validate is not registered today; this entry covers the planned validate relocation from the systematic CLI plan."
+    }
+  ]
+}

--- a/pkg/cli/baseline/testdata/intentional_changes.md
+++ b/pkg/cli/baseline/testdata/intentional_changes.md
@@ -1,0 +1,25 @@
+# Planned intentional CLI removals and moves
+
+This ledger records production commands and `you run` flags deliberately planned
+for removal or relocation during upcoming CLI migrations. It is distinct from the
+executable baseline fixtures in this directory; later migration stories should
+update those fixtures while citing the matching ledger entry.
+
+Each entry must still exist in today's production command-tree and/or run-flag
+baselines. The hermetic ledger test fails if an entry drifts away from the live
+contract without an intentional ledger update.
+
+## Planned removals
+
+| Surface | Identifier | Rationale |
+| --- | --- | --- |
+| `you run` flag | `workflow` | Remove `you run --workflow`; workflow selection uses dedicated workflow commands. |
+| command | `you factory save` | Remove `you factory save` from the production CLI. |
+
+## Planned moves
+
+| From | To | Rationale |
+| --- | --- | --- |
+| `you config expand` | `you factory config expand` | Relocate config expand under factory config. |
+| `you config flatten` | `you factory config flatten` | Relocate config flatten under factory config. |
+| `you factory validate` | `you factory config validate` | Reparent factory validate under factory config. `you config validate` is not registered today; this entry covers the planned validate relocation from the systematic CLI plan. |

--- a/pkg/cli/baseline/testdata/root_help.txt
+++ b/pkg/cli/baseline/testdata/root_help.txt
@@ -1,0 +1,49 @@
+Run and manage CPN-based workflow factories.
+
+What:
+CPN-based workflow factory CLI for running factories, submitting work, and inspecting live sessions.
+
+How to use:
+Running you with no args starts the out-of-the-box continuous factory and local dashboard (http://localhost:7437/dashboard/ui).
+Use you run --dir factory for explicit runs. See you <cmd> --help for subcommand details.
+
+Agents:
+Start with you docs agents for orientation, you submit or you submit batch to enqueue work, and you session list to confirm a live factory.
+Run you docs for all packaged reference topics. Use --verbose or --debug for stderr diagnostics; full policy in you docs.
+
+Usage:
+  you [flags]
+  you [command]
+
+Examples:
+  # Start the default Codex-backed factory in the current project.
+  you
+
+  # Agent orientation and command matrix.
+  you docs agents
+
+Available Commands:
+  completion  Generate the autocompletion script for the specified shell
+  config      Inspect and transform factory configuration
+  docs        Print packaged markdown reference topics
+  factory     Inspect and manage factory definitions
+  help        Help about any command
+  init        Create factory directory structure
+  mcp         Model Context Protocol servers for Factory Session tools
+  models      Inspect discovered models from a running service
+  run         Load workflow and run the factory engine
+  session     List, open, and close factory sessions on a running host
+  submit      Submit work to a running factory
+  work        Inspect work from a running factory
+  workflow    Validate JavaScript workflow sources for Factory Session execution
+
+Flags:
+  -d, --debug                                  emit lower-level command diagnostics where supported (implies --verbose)
+      --default-worker-model string            default worker model for model workers with omitted model
+      --default-worker-model-provider string   default worker model provider for model workers with omitted modelProvider (accepted canonical providers: CLAUDE, CODEX, CURSOR, GEMINI, KIRO, OPENCODE; accepted aliases include codex, claude, gemini, kiro-cli, opencode, agent, cursor, and anthropic; DEFAULT resolves through lower-precedence concrete provider)
+  -h, --help                                   help for you
+      --json                                   emit structured JSON on stdout for supported commands; diagnostics remain on stderr
+      --server string                          factory API base URI (http:// or https://); HTTP client commands target this URI and you run binds locally to its host and port (default "http://localhost:7437")
+  -v, --verbose                                emit concise command diagnostics to stderr
+
+Use "you [command] --help" for more information about a command.

--- a/pkg/cli/baseline/testdata/run_flags.txt
+++ b/pkg/cli/baseline/testdata/run_flags.txt
@@ -1,0 +1,29 @@
+continuously		false	keep the factory alive while idle until cancelled
+debug	d	false	emit lower-level command diagnostics where supported (implies --verbose)
+default-worker-model			default worker model for model workers with omitted model
+default-worker-model-provider			default worker model provider for model workers with omitted modelProvider (accepted canonical providers: CLAUDE, CODEX, CURSOR, GEMINI, KIRO, OPENCODE; accepted aliases include codex, claude, gemini, kiro-cli, opencode, agent, cursor, and anthropic; DEFAULT resolves through lower-precedence concrete provider)
+dir		factory	factory base directory
+factory			path to factory.json for portable one-shot runs; use positional text or piped stdin for the invocation input
+json		false	emit structured JSON on stdout for supported commands; diagnostics remain on stderr
+named			canonical persisted factory name resolved from ./factory before ~/.you-agent-factory/factories; built-ins materialize there on first use and remain editable
+no-record		false	disable the default replay artifact for this invocation
+output			invocation stdout mode: primary (default) or response-stream for live internal session progress on supported one-shot factory runs
+port		0	deprecated; use --server
+quiet		false	suppress dashboard output for quiet or CI-oriented runs
+record			path to write a replay artifact for this run; replay artifacts are sensitive, and default live runs record automatically unless --no-record is used
+replay			path to replay an existing sensitive replay artifact
+runtime-log-compress		false	compress rotated runtime log files
+runtime-log-dir			root directory for structured runtime log files grouped by UTC start date (default: ~/.you-agent-factory/logs)
+runtime-log-max-age-days		30	maximum days to retain rotated runtime log files
+runtime-log-max-backups		20	maximum rotated runtime log files to retain
+runtime-log-max-size-mb		100	rotate each runtime log file after this many megabytes
+runtime-metrics-compress		false	compress rotated runtime metrics files
+runtime-metrics-dir			root directory for structured runtime metrics JSONL files grouped by UTC start date (default: ~/.you-agent-factory/metrics)
+runtime-metrics-max-age-days		30	maximum days to retain rotated runtime metrics files
+runtime-metrics-max-backups		20	maximum rotated runtime metrics files to retain
+runtime-metrics-max-size-mb		100	rotate each runtime metrics file after this many megabytes
+server		http://localhost:7437	factory API base URI (http:// or https://); HTTP client commands target this URI and you run binds locally to its host and port
+verbose	v	false	emit concise command diagnostics to stderr
+with-mock-workers			enable mock-worker execution with an optional mock-workers JSON config path
+work			path to initial FACTORY_REQUEST_BATCH JSON file to submit
+workflow			workflow ID to run (default: all)

--- a/pkg/cli/baseline/testdata/run_help.txt
+++ b/pkg/cli/baseline/testdata/run_help.txt
@@ -1,0 +1,58 @@
+Load workflow and run the factory engine.
+
+For the quickest local setup, run you with no arguments. That default flow bootstraps ./factory, watches factory/inputs/task/default, keeps the runtime alive, and reports the first available dashboard URL, preferring http://localhost:7437/dashboard/ui. Default execution uses batch mode and exits after idle completion. Normal live runs record by default unless you pass --no-record. Replay artifacts are sensitive and can contain prompts, payloads, stdout, stderr, and diagnostic metadata. Use global --default-worker-model-provider and --default-worker-model to set operator-level model defaults for omitted model-worker fields. Use --continuously to keep the factory alive while idle until you cancel it. Use --with-mock-workers with an optional JSON config path to test workflows with deterministic mock worker outcomes. Use --quiet to suppress dashboard output for scripted or CI-oriented runs. Use --named with a persisted canonical factory name to resolve project-local factories before global built-ins under ~/.you-agent-factory/factories. Built-ins such as @you/tts and @you/goal materialize lazily into that global root on first use and stay editable on disk for later runs. Use --factory with a factory.json file path to run a portable factory config without guessing --dir. Selected factories can define custom invocation arguments; run you run --named <factory> --help or you run --factory <factory.json> --help to inspect signature-backed usage while keeping existing run-level flags available. In factory invocation mode, provide either trailing positional text or piped stdin text; supplying both is rejected with INVOCATION_INPUT_SOURCE_CONFLICT. Packaged @you/fusion, @you/goal, and @you/tts invocation details live in you docs packaged-fusion, you docs packaged-goal, and you docs packaged-tts. Full invocation input and return-policy details live in you docs config and you docs sessions. Use --output response-stream on supported one-shot factory invocations to render live internal session response-stream progress while the CLI owns the runtime; unsupported run shapes fall back to primary-result-only output or return INVOCATION_OUTPUT_UNSUPPORTED. Runtime logs are structured JSON rolling files grouped by UTC start date under the selected log root. Runtime metrics are a separate structured JSONL operational channel with their own rolling files and do not replace runtime logs. Environment details are record-channel diagnostics only, and system logs include command stdout/stderr only on command failures.
+
+Usage:
+  you run [flags]
+
+Examples:
+  # Start the out-of-the-box continuous factory.
+  you
+
+  # Submit a Markdown task to the default scaffold.
+  printf "Fix the lint issues\n" > factory/inputs/task/default/fix-lint.md
+
+  # Run an existing factory once in explicit batch mode.
+  you run --dir factory
+
+  # Run a persisted named factory from any working directory.
+  you run --named @you/tts
+
+  # Run a portable factory.json with a one-shot prompt (see handlingBehavior DEFAULT).
+  you run --factory ./factory.json "Fix the lint issues"
+
+  # Render live internal response-stream progress for a named goal invocation.
+  you run --named @you/goal --output response-stream "Ship the login bugfix"
+
+Flags:
+      --continuously                                                                 keep the factory alive while idle until cancelled
+      --dir string                                                                   factory base directory (default "factory")
+      --factory string                                                               path to factory.json for portable one-shot runs; use positional text or piped stdin for the invocation input
+  -h, --help                                                                         help for run
+      --named string                                                                 canonical persisted factory name resolved from ./factory before ~/.you-agent-factory/factories; built-ins materialize there on first use and remain editable
+      --no-record                                                                    disable the default replay artifact for this invocation
+      --output string                                                                invocation stdout mode: primary (default) or response-stream for live internal session progress on supported one-shot factory runs
+      --quiet                                                                        suppress dashboard output for quiet or CI-oriented runs
+      --record string                                                                path to write a replay artifact for this run; replay artifacts are sensitive, and default live runs record automatically unless --no-record is used
+      --replay string                                                                path to replay an existing sensitive replay artifact
+      --runtime-log-compress                                                         compress rotated runtime log files
+      --runtime-log-dir string                                                       root directory for structured runtime log files grouped by UTC start date (default: ~/.you-agent-factory/logs)
+      --runtime-log-max-age-days int                                                 maximum days to retain rotated runtime log files (default 30)
+      --runtime-log-max-backups int                                                  maximum rotated runtime log files to retain (default 20)
+      --runtime-log-max-size-mb int                                                  rotate each runtime log file after this many megabytes (default 100)
+      --runtime-metrics-compress                                                     compress rotated runtime metrics files
+      --runtime-metrics-dir string                                                   root directory for structured runtime metrics JSONL files grouped by UTC start date (default: ~/.you-agent-factory/metrics)
+      --runtime-metrics-max-age-days int                                             maximum days to retain rotated runtime metrics files (default 30)
+      --runtime-metrics-max-backups int                                              maximum rotated runtime metrics files to retain (default 20)
+      --runtime-metrics-max-size-mb int                                              rotate each runtime metrics file after this many megabytes (default 100)
+      --with-mock-workers string[="__agent_factory_default_mock_workers_config__"]   enable mock-worker execution with an optional mock-workers JSON config path
+      --work string                                                                  path to initial FACTORY_REQUEST_BATCH JSON file to submit
+      --workflow string                                                              workflow ID to run (default: all)
+
+Global Flags:
+  -d, --debug                                  emit lower-level command diagnostics where supported (implies --verbose)
+      --default-worker-model string            default worker model for model workers with omitted model
+      --default-worker-model-provider string   default worker model provider for model workers with omitted modelProvider (accepted canonical providers: CLAUDE, CODEX, CURSOR, GEMINI, KIRO, OPENCODE; accepted aliases include codex, claude, gemini, kiro-cli, opencode, agent, cursor, and anthropic; DEFAULT resolves through lower-precedence concrete provider)
+      --json                                   emit structured JSON on stdout for supported commands; diagnostics remain on stderr
+      --server string                          factory API base URI (http:// or https://); HTTP client commands target this URI and you run binds locally to its host and port (default "http://localhost:7437")
+  -v, --verbose                                emit concise command diagnostics to stderr

--- a/pkg/cli/docs/docs.go
+++ b/pkg/cli/docs/docs.go
@@ -116,6 +116,13 @@ type TopicSummary struct {
 	Description string
 }
 
+// TopicIndexEntry describes one canonical packaged docs topic plus CLI aliases.
+type TopicIndexEntry struct {
+	Name        string
+	Description string
+	Aliases     []string
+}
+
 // SupportedTopics returns the fixed docs topics exposed by the packaged CLI
 // docs surface in display order.
 func SupportedTopics() []string {
@@ -149,6 +156,25 @@ func TopicSummaries() []TopicSummary {
 		})
 	}
 	return summaries
+}
+
+// TopicIndexEntries returns canonical packaged docs topic metadata and CLI
+// aliases in display order.
+func TopicIndexEntries() []TopicIndexEntry {
+	entries := make([]TopicIndexEntry, 0, len(topicRegistry.ordered))
+	for _, doc := range topicRegistry.ordered {
+		aliases := make([]string, 0, len(doc.aliases))
+		for _, alias := range doc.aliases {
+			aliases = append(aliases, string(alias))
+		}
+		sort.Strings(aliases)
+		entries = append(entries, TopicIndexEntry{
+			Name:        string(doc.topic),
+			Description: doc.description,
+			Aliases:     aliases,
+		})
+	}
+	return entries
 }
 
 // QuickStartMarkdown returns the quick-start blurb printed before the docs index.


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "you-goal-b01-cli-doc-baseline",
  "description": "Capture executable CLI and documentation baselines before migrations by recording deterministic snapshots of the production Cobra command tree, you run flags, key help outputs, and the packaged docs topic index so intentional removals and moves are distinguishable from accidental drift, with no production behavior change.",
  "context": {
    "customerAsk": "Capture executable CLI and documentation baselines before migrations: record the production Cobra tree, run flags, help, and packaged topic index so intentional removals and moves are distinguishable from accidental drift. No production behavior change. Source: docs/temp/projects/you-goal-fixes/systematic-fix-plan.md S01.",
    "problem": "Upcoming CLI and docs migrations will rename, move, or remove commands, flags, help text, and packaged reference topics, but those surfaces are only partially covered by ad hoc assertions today. Without a committed deterministic baseline of the live production command tree, run flags, help, and packaged docs topic index, maintainers cannot tell whether a migration failure is an intentional contract update or accidental drift.",
    "solution": "Add hermetic deterministic snapshot/contract tests that record the current production CLI command tree, you run flag contract, key help outputs, and packaged docs topic index as committed reviewable fixtures. Failures show a clear diff so intentional baseline updates are explicit and accidental drift fails the suite, without changing production CLI or docs behavior."
  },
  "acceptanceCriteria": [
    "AC-1: Deterministic snapshots exist for the production Cobra command tree, you run flags, key help outputs, and the packaged docs topic index.",
    "AC-2: A change that removes, renames, or reorders a captured command, flag, help string, or topic causes the corresponding snapshot test to fail with a reviewer-visible diff.",
    "AC-3: Updating a committed baseline fixture is the only approved way to accept an intentional contract change; accidental drift without a fixture update fails tests.",
    "AC-4: Production CLI help, command routing, run flags, and you docs topic resolution remain observably unchanged by this lane.",
    "AC-5: Snapshot tests are hermetic (no live network, no provider, no filesystem factory setup beyond reading committed fixtures).",
    "AC-6: Quality checks pass (typecheck, lint, tests)."
  ],
  "userStories": [
    {
      "id": "you-goal-b01-cli-doc-baseline-001",
      "title": "Capture production Cobra command tree baseline",
      "description": "As a maintainer, I want a deterministic snapshot of the production Cobra command tree so later migrations cannot silently drop, rename, or reparent a command without an explicit baseline update.",
      "acceptanceCriteria": [
        "A package-local test builds the production root command and records a deterministic serialization of the command tree (stable command paths / use names and parent-child relationships for registered commands).",
        "The recorded tree is compared against a committed baseline fixture; mismatch fails the test with a clear diff of added, removed, or moved commands.",
        "Re-running the test with no CLI registration changes produces a stable pass (ordering and content are deterministic).",
        "No production CLI registration or help text is changed by this story.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "you-goal-b01-cli-doc-baseline-002",
      "title": "Capture you run flag contract baseline",
      "description": "As a maintainer, I want a deterministic snapshot of the production you run flag contract so flag removals, renames, default changes, and usage-text drift require an intentional baseline update.",
      "acceptanceCriteria": [
        "A package-local test records the production you run flags in a deterministic form that includes each flag's name, shorthand (if any), default value, and usage text.",
        "The recorded flag contract is compared against a committed baseline fixture; mismatch fails with a reviewer-visible diff.",
        "Re-running with no flag-definition changes produces a stable pass.",
        "No production you run flag definitions or defaults are changed by this story.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "you-goal-b01-cli-doc-baseline-003",
      "title": "Capture root, run, and docs help baselines",
      "description": "As a maintainer, I want deterministic help-output snapshots for the root command, you run, and you docs so user-facing help drift is caught before migrations rewrite those surfaces.",
      "acceptanceCriteria": [
        "Package-local tests capture deterministic help output for you --help, you run --help, and you docs --help (or the equivalent Cobra help invocation against the production root command).",
        "Each help capture is compared against a committed baseline fixture; mismatch fails with a clear textual diff.",
        "Help snapshots remain stable across repeated runs with no command-text changes.",
        "No production help strings, command short/long descriptions, or usage templates are changed by this story.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "you-goal-b01-cli-doc-baseline-004",
      "title": "Capture packaged docs topic index baseline",
      "description": "As a maintainer, I want a deterministic snapshot of the packaged docs topic index so topic adds, removals, renames, description changes, and alias moves are distinguishable from accidental drift during docs migrations.",
      "acceptanceCriteria": [
        "A package-local test records the production packaged topic index in deterministic form, including topic names, descriptions, and aliases as exposed by the docs command surface / pkg/cli/docs topic summaries used by you docs.",
        "The recorded index is compared against a committed baseline fixture; mismatch fails with a reviewer-visible diff of topic or alias changes.",
        "The baseline reflects the topics customers can reach through you docs / you docs <topic> and stays aligned with the packaged docs/reference topic set without asserting embed-FS internals.",
        "No production topic registration, descriptions, aliases, or packaged markdown content are changed by this story.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}
