### PR TITLE
you-goal-b01-failure-baseline

### DIFF
--- a/pkg/cli/goal_failure_baseline_test.go
+++ b/pkg/cli/goal_failure_baseline_test.go
@@ -437,6 +437,61 @@ func TestFailureBaseline_NamedPath_RunNamedMissingLocalFactoryRejectsBeforeInvoc
 	}
 }
 
+func TestFailureBaseline_NamedPath_RunNamedGoalSurfacesPercentEncodedFactoryDir(t *testing.T) {
+	originalRunCLI := runCLI
+	defer func() {
+		runCLI = originalRunCLI
+	}()
+
+	restore := withNamedPackagedFactoryRunRoot(t)
+	defer restore()
+
+	var got runcli.RunConfig
+	runCLI = func(_ context.Context, cfg runcli.RunConfig) error {
+		got = cfg
+		return nil
+	}
+
+	root := NewRootCommand()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{
+		"run",
+		"--named", goal.PackagedFactoryName,
+		"--no-record",
+		"--quiet",
+		"percent-encoded-path baseline probe",
+	})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute run --named %s: %v", goal.PackagedFactoryName, err)
+	}
+	if got.NamedFactoryName != goal.PackagedFactoryName {
+		t.Fatalf("named factory = %q, want %q", got.NamedFactoryName, goal.PackagedFactoryName)
+	}
+	if got.Dir == "" {
+		t.Fatal("expected resolved factory directory on run config")
+	}
+	if !strings.Contains(got.Dir, "@you%2Fgoal") {
+		t.Fatalf("run dir = %q, want customer-visible @you%%2Fgoal segment", got.Dir)
+	}
+	if got.NamedFactoryResolution == nil {
+		t.Fatal("expected named-factory resolution metadata")
+	}
+	if got.Dir != got.NamedFactoryResolution.FactoryDir {
+		t.Fatalf("run dir = %q, want resolved factory dir %q", got.Dir, got.NamedFactoryResolution.FactoryDir)
+	}
+	if !strings.Contains(got.NamedFactoryResolution.FactoryDir, "@you%2Fgoal") {
+		t.Fatalf("resolution factory dir = %q, want @you%%2Fgoal segment", got.NamedFactoryResolution.FactoryDir)
+	}
+	if filepath.Base(got.Dir) != "@you%2Fgoal" {
+		t.Fatalf("run dir base = %q, want @you%%2Fgoal layout segment", filepath.Base(got.Dir))
+	}
+	if !strings.Contains(got.Dir, filepath.Join(".you-agent-factory", "factories")) {
+		t.Fatalf("run dir = %q, want global named-factory root layout", got.Dir)
+	}
+}
+
 func TestFailureBaseline_NamedPath_RunNamedUnknownBuiltInGoalStyleNameRejectsBeforeInvocation(t *testing.T) {
 	originalRunCLI := runCLI
 	defer func() {

--- a/pkg/cli/goal_failure_baseline_test.go
+++ b/pkg/cli/goal_failure_baseline_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -58,6 +59,49 @@ func assertGoalQuietLeakContractForbidden(t *testing.T, output string) {
 		if strings.Contains(output, forbidden) {
 			t.Fatalf("output = %q, want no quiet-leak marker %q", output, forbidden)
 		}
+	}
+}
+
+func TestFailureBaseline_NoServer_RunNamedGoalCommandReportsSessionStoppedBeforeReady(t *testing.T) {
+	originalRunCLI := runCLI
+	defer func() {
+		runCLI = originalRunCLI
+	}()
+	restore := withNamedPackagedFactoryRunRoot(t)
+	defer restore()
+
+	runCLI = func(_ context.Context, cfg runcli.RunConfig) error {
+		if cfg.NamedFactoryName != goal.PackagedFactoryName {
+			t.Fatalf("named factory = %q, want %q", cfg.NamedFactoryName, goal.PackagedFactoryName)
+		}
+		if cfg.InvocationPositionalText == nil || *cfg.InvocationPositionalText != "no-server baseline probe" {
+			t.Fatalf("invocation text = %#v, want no-server baseline probe", cfg.InvocationPositionalText)
+		}
+		return errors.New("factory invocation session stopped before it became ready")
+	}
+
+	var output bytes.Buffer
+	root := NewRootCommand()
+	root.SetOut(&output)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{
+		"run",
+		"--named", goal.PackagedFactoryName,
+		"--no-record",
+		"--quiet",
+		"no-server baseline probe",
+	})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected named goal run to fail when factory session never becomes ready")
+	}
+	want := "factory invocation session stopped before it became ready"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %q, want %q", err.Error(), want)
+	}
+	if output.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty before invocation starts", output.String())
 	}
 }
 

--- a/pkg/cli/goal_failure_baseline_test.go
+++ b/pkg/cli/goal_failure_baseline_test.go
@@ -162,6 +162,45 @@ func TestFailureBaseline_AbsentDefault_RunCommandRejectsUnresolvedDefaultProvide
 	}
 }
 
+func TestFailureBaseline_AbsentDefault_RunNamedGoalLeavesOperatorDefaultsEmptyWithoutConfig(t *testing.T) {
+	originalRunCLI := runCLI
+	defer func() {
+		runCLI = originalRunCLI
+	}()
+	restore := withNamedPackagedFactoryRunRoot(t)
+	defer restore()
+
+	var got runcli.RunConfig
+	runCLI = func(_ context.Context, cfg runcli.RunConfig) error {
+		got = cfg
+		return nil
+	}
+
+	root := NewRootCommand()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{
+		"run",
+		"--named", goal.PackagedFactoryName,
+		"--no-record",
+		"--quiet",
+		"absent-default baseline probe",
+	})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute run --named %s: %v", goal.PackagedFactoryName, err)
+	}
+	if got.NamedFactoryName != goal.PackagedFactoryName {
+		t.Fatalf("named factory = %q, want %q", got.NamedFactoryName, goal.PackagedFactoryName)
+	}
+	if got.OperatorDefaults.WorkerModelProvider != "" {
+		t.Fatalf("operator provider = %q, want empty without configured defaults", got.OperatorDefaults.WorkerModelProvider)
+	}
+	if got.OperatorDefaults.WorkerModel != "" {
+		t.Fatalf("operator model = %q, want empty without configured defaults", got.OperatorDefaults.WorkerModel)
+	}
+}
+
 func TestFailureBaseline_InvalidTopology_RunFactoryCommandRejectsGoalShapedGraphReferences(t *testing.T) {
 	dir := t.TempDir()
 	factoryPath := filepath.Join(dir, "factory.json")

--- a/pkg/cli/goal_failure_baseline_test.go
+++ b/pkg/cli/goal_failure_baseline_test.go
@@ -52,6 +52,13 @@ var goalQuietLeakForbiddenMarkers = []string{
 	"Recording saved",
 }
 
+var goalQuietLeakExpectedMarkers = []string{
+	"Factory initiated",
+	"Dashboard URL",
+	"Runtime log",
+	"Recording saved",
+}
+
 func assertGoalQuietLeakContractForbidden(t *testing.T, output string) {
 	t.Helper()
 
@@ -60,6 +67,20 @@ func assertGoalQuietLeakContractForbidden(t *testing.T, output string) {
 			t.Fatalf("output = %q, want no quiet-leak marker %q", output, forbidden)
 		}
 	}
+}
+
+func assertGoalQuietLeakContractPresent(t *testing.T, output string) {
+	t.Helper()
+
+	if strings.TrimSpace(output) == "" {
+		t.Fatal("output is empty, want non-empty quiet-leak terminal chatter documenting today's contract")
+	}
+	for _, marker := range goalQuietLeakExpectedMarkers {
+		if strings.Contains(output, marker) {
+			return
+		}
+	}
+	t.Fatalf("output = %q, want at least one quiet-leak marker among %v", output, goalQuietLeakExpectedMarkers)
 }
 
 func TestFailureBaseline_NoServer_RunNamedGoalCommandReportsSessionStoppedBeforeReady(t *testing.T) {
@@ -229,6 +250,55 @@ func TestFailureBaseline_InvalidTopology_RunFactoryCommandRejectsGoalShapedGraph
 	if !strings.Contains(err.Error(), "blocking validation targets") {
 		t.Fatalf("error = %q, want blocking validation target count", err.Error())
 	}
+}
+
+func TestFailureBaseline_QuietLeak_RunBatchQuietStillEmitsStartupChatter(t *testing.T) {
+	originalRunCLI := runCLI
+	defer func() {
+		runCLI = originalRunCLI
+	}()
+
+	dir := t.TempDir()
+	workPath := filepath.Join(dir, "work.json")
+	if err := os.WriteFile(workPath, []byte(`{"type":"FACTORY_REQUEST_BATCH","works":[]}`), 0o644); err != nil {
+		t.Fatalf("write work file: %v", err)
+	}
+
+	var got runcli.RunConfig
+	runCLI = func(_ context.Context, cfg runcli.RunConfig) error {
+		got = cfg
+		if cfg.StartupOutput != nil {
+			io.WriteString(cfg.StartupOutput, "Factory initiated: "+cfg.Dir+"\n")
+			io.WriteString(cfg.StartupOutput, "Dashboard URL: http://127.0.0.1:7437/\n")
+		}
+		return nil
+	}
+
+	var stdout bytes.Buffer
+	root := NewRootCommand()
+	root.SetOut(&stdout)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{
+		"run",
+		"--dir", dir,
+		"--work", workPath,
+		"--no-record",
+		"--quiet",
+	})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute run --dir --work --quiet: %v", err)
+	}
+	if !got.SuppressDashboardRendering {
+		t.Fatal("expected --quiet to suppress dashboard rendering")
+	}
+	if got.StartupOutput == nil {
+		t.Fatal("expected batch quiet run to keep startup output wired to terminal stdout")
+	}
+	if got.CleanInvocation {
+		t.Fatal("expected dir/work batch quiet run to keep operator startup output mode")
+	}
+	assertGoalQuietLeakContractPresent(t, stdout.String())
 }
 
 func TestFailureBaseline_QuietLeak_RunFactoryQuietPromptKeepsStartupOutputSuppressed(t *testing.T) {

--- a/pkg/cli/run/failure_baseline_quiet_leak_test.go
+++ b/pkg/cli/run/failure_baseline_quiet_leak_test.go
@@ -14,9 +14,9 @@ import (
 	"go.uber.org/zap"
 )
 
-// Hermetic S02 failure-baseline fixtures for one-shot run paths with quiet or
-// CI-oriented suppression enabled. These lock the customer-visible contract
-// that dashboard and operator startup chatter must not leak on stdout.
+// Hermetic S02 failure-baseline fixtures for one-shot run paths: quiet/CI
+// suppression contracts and named @you/goal invocation when the factory session
+// never becomes ready (no listening Factory Session server).
 
 var quietLeakForbiddenMarkers = []string{
 	"Factory initiated",
@@ -122,4 +122,54 @@ func TestFailureBaseline_QuietLeak_OneShotNamedGoalInvocationSuppressesOperatorC
 		t.Fatalf("stdout = %q, want primary invocation result only", got)
 	}
 	assertQuietLeakContractForbidden(t, output.String())
+}
+
+type failureBaselineNoServerInvocationService struct {
+	run func(context.Context) error
+}
+
+func (s failureBaselineNoServerInvocationService) Run(ctx context.Context) error {
+	return s.run(ctx)
+}
+
+func (s failureBaselineNoServerInvocationService) GetCurrentFactoryForSession(context.Context, string) (factoryapi.Factory, error) {
+	return factoryapi.Factory{}, apisurface.ErrFactorySessionNotFound
+}
+
+func (s failureBaselineNoServerInvocationService) InvokeFactorySession(context.Context, string, factoryapi.InvocationRequest) (apisurface.FactoryInvocationResult, error) {
+	return apisurface.FactoryInvocationResult{}, apisurface.ErrFactorySessionNotFound
+}
+
+func TestFailureBaseline_NoServer_RunNamedGoalInvocationReportsSessionStoppedBeforeReady(t *testing.T) {
+	preserveRunGlobals(t)
+
+	text := "no-server baseline goal prompt"
+	var output bytes.Buffer
+	buildFactoryService = func(_ context.Context, _ *service.FactoryServiceConfig) (factoryServiceRunner, error) {
+		return failureBaselineNoServerInvocationService{
+			run: func(context.Context) error {
+				return nil
+			},
+		}, nil
+	}
+
+	err := Run(context.Background(), RunConfig{
+		Dir:                      "/tmp/builtin-goal",
+		NamedFactoryName:         goal.PackagedFactoryName,
+		InvocationPositionalText: &text,
+		StdinIsTTY:               func() bool { return true },
+		Output:                   &output,
+		Port:                     7437,
+		Logger:                   zap.NewNop(),
+	})
+	if err == nil {
+		t.Fatal("expected named goal invocation to fail before session became ready")
+	}
+	want := "factory invocation session stopped before it became ready"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %q, want %q", err.Error(), want)
+	}
+	if output.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty before invocation starts", output.String())
+	}
 }

--- a/pkg/cli/run/failure_baseline_quiet_leak_test.go
+++ b/pkg/cli/run/failure_baseline_quiet_leak_test.go
@@ -27,6 +27,13 @@ var quietLeakForbiddenMarkers = []string{
 	"Recording saved",
 }
 
+var quietLeakExpectedMarkers = []string{
+	"Factory initiated",
+	"Dashboard URL",
+	"Runtime log",
+	"Recording saved",
+}
+
 func assertQuietLeakContractForbidden(t *testing.T, output string) {
 	t.Helper()
 
@@ -35,6 +42,42 @@ func assertQuietLeakContractForbidden(t *testing.T, output string) {
 			t.Fatalf("output = %q, want no quiet-leak marker %q", output, forbidden)
 		}
 	}
+}
+
+func assertQuietLeakContractPresent(t *testing.T, output string) {
+	t.Helper()
+
+	if strings.TrimSpace(output) == "" {
+		t.Fatal("output is empty, want non-empty quiet-leak terminal chatter documenting today's contract")
+	}
+	for _, marker := range quietLeakExpectedMarkers {
+		if strings.Contains(output, marker) {
+			return
+		}
+	}
+	t.Fatalf("output = %q, want at least one quiet-leak marker among %v", output, quietLeakExpectedMarkers)
+}
+
+func TestFailureBaseline_QuietLeak_OneShotBatchQuietStillEmitsStartupChatter(t *testing.T) {
+	dir, workFile := writeDashboardRunFixture(t)
+	port := unusedTCPPort(t)
+
+	var startupOut bytes.Buffer
+	err := Run(context.Background(), RunConfig{
+		Dir:                        dir,
+		Port:                       port,
+		WorkFile:                   workFile,
+		MockWorkersEnabled:         true,
+		SuppressDashboardRendering: true,
+		StartupOutput:              &startupOut,
+		OpenDashboard:              false,
+		DisableDefaultRecording:    true,
+		Logger:                     zap.NewNop(),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	assertQuietLeakContractPresent(t, startupOut.String())
 }
 
 func TestFailureBaseline_QuietLeak_OneShotBatchRunSuppressesDashboardMarkers(t *testing.T) {

--- a/pkg/config/runtimetests/failure_baseline_named_path_test.go
+++ b/pkg/config/runtimetests/failure_baseline_named_path_test.go
@@ -3,6 +3,8 @@ package runtimetests
 import (
 	"errors"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	. "github.com/portpowered/infinite-you/pkg/config"
@@ -64,4 +66,41 @@ func TestFailureBaseline_NamedPath_UnknownBuiltInGoalStyleNameReportsNotFound(t 
 
 func stringsContainsMaterializeBuiltIn(value string) bool {
 	return containsAll(value, "materialize built-in named factory")
+}
+
+func TestFailureBaseline_NamedPath_GoalLayoutSegmentEncodesSlash(t *testing.T) {
+	segment, err := NamedFactoryNameToLayoutSegment("@you/goal")
+	if err != nil {
+		t.Fatalf("NamedFactoryNameToLayoutSegment(@you/goal): %v", err)
+	}
+	if segment != "@you%2Fgoal" {
+		t.Fatalf("layout segment = %q, want @you%%2Fgoal", segment)
+	}
+	if strings.Contains(segment, "/") {
+		t.Fatalf("layout segment = %q, want slash encoded instead of path separator", segment)
+	}
+}
+
+func TestFailureBaseline_NamedPath_GoalMaterializationUsesPercentEncodedLayoutSegment(t *testing.T) {
+	projectRoot := t.TempDir()
+	globalRoot := t.TempDir()
+
+	resolution, err := ResolveNamedFactoryAcrossRoots(projectRoot, globalRoot, "@you/goal")
+	if err != nil {
+		t.Fatalf("ResolveNamedFactoryAcrossRoots(@you/goal): %v", err)
+	}
+	if resolution.Name != "@you/goal" {
+		t.Fatalf("resolution name = %q, want @you/goal", resolution.Name)
+	}
+
+	wantDir := filepath.Join(globalRoot, "@you%2Fgoal")
+	if resolution.FactoryDir != wantDir {
+		t.Fatalf("factory dir = %q, want percent-encoded layout %q", resolution.FactoryDir, wantDir)
+	}
+	if !strings.Contains(resolution.FactoryDir, "@you%2Fgoal") {
+		t.Fatalf("factory dir = %q, want customer-visible @you%%2Fgoal segment", resolution.FactoryDir)
+	}
+	if _, statErr := os.Stat(wantDir); statErr != nil {
+		t.Fatalf("materialized factory dir %q: %v", wantDir, statErr)
+	}
 }

--- a/pkg/orchestrators/javascript/runtime/host_children_test.go
+++ b/pkg/orchestrators/javascript/runtime/host_children_test.go
@@ -61,6 +61,31 @@ func TestResolveChildWorkerSettings_UnknownPresetNamesSource(t *testing.T) {
 	}
 }
 
+func TestFailureBaseline_AbsentDefault_GoalAgentRunLeavesEmptyModelProviderWithoutOperatorDefaults(t *testing.T) {
+	got, err := workflowruntime.ResolveChildWorkerSettings(
+		workflowruntime.ChildExecutionRequest{
+			AgentID: "goal-planner",
+			Prompt:  "plan the goal",
+		},
+		map[string]interfaces.FactoryOrchestratorJavaScriptAgent{
+			"goal-planner": {},
+		},
+		workflowruntime.WorkerSettingsConfig{},
+	)
+	if err != nil {
+		t.Fatalf("ResolveChildWorkerSettings() error = %v", err)
+	}
+	if got.ModelProvider != "" {
+		t.Fatalf("modelProvider = %q, want empty when operator defaults are absent", got.ModelProvider)
+	}
+	if got.Model != "" {
+		t.Fatalf("model = %q, want empty when operator defaults are absent", got.Model)
+	}
+	if got.Command != "" {
+		t.Fatalf("command = %q, want empty provider command when operator defaults are absent", got.Command)
+	}
+}
+
 func TestAgentRun_InheritsFactoryNamedAgentPreset(t *testing.T) {
 	req := workflowruntime.Request{
 		Source:    `return (async function () { return agent.run({agentId: "reviewer", prompt: "review"}); })();`,

--- a/pkg/workers/provider/provider_behavior_test.go
+++ b/pkg/workers/provider/provider_behavior_test.go
@@ -558,6 +558,16 @@ func TestNonCodexProviderBehavior_BuildCommandRequest(t *testing.T) {
 	}
 }
 
+func TestFailureBaseline_AbsentDefault_BuildCommandRequestUsesEmptyProviderCommandWhenModelProviderUnset(t *testing.T) {
+	req := interfaces.ProviderInferenceRequest{
+		UserMessage: "plan the goal",
+	}
+	request := providerBehaviorFor("", logging.NoopLogger{}).BuildCommandRequest(req, []string{"-p", "plan the goal"})
+	if request.Command != "" {
+		t.Fatalf("command = %q, want empty provider command when modelProvider is unset", request.Command)
+	}
+}
+
 type nonCodexCommandRequestTestCase struct {
 	name    string
 	req     interfaces.ProviderInferenceRequest


### PR DESCRIPTION
{
  "project": "you-goal-b01-failure-baseline",
  "branchName": "you-goal-b01-failure-baseline",
  "description": "Capture failing one-shot goal and model invocation behavior as hermetic regression fixtures for no-server, absent-default, invalid-topology, quiet-leak, and named-path cases—without changing production behavior or depending on live providers/network.",
  "context": {
    "customerAsk": "Capture failing one-shot goal and model invocation behavior by reproducing the no-server, absent-default, invalid-topology, quiet-leak, and named-path cases as focused hermetic regression fixtures. Every reported failure must have a customer-visible assertion, with no live provider or network dependency (systematic-fix-plan.md S02).",
    "problem": "The you goal experiments exposed concrete one-shot failures—commands that need a live server, empty provider/model construction, invalid built-in topology materialization, --quiet terminal leakage, and percent-encoded named-factory paths—but those failures are not locked down as hermetic, customer-visible regressions. Without executable baselines, later bootstrap, path, quiet-policy, and goal-topology fixes cannot prove they fixed the reported symptoms.",
    "solution": "Add focused hermetic CLI/command fixtures that reproduce each reported failure case and assert the customer-visible outcome as it exists today. This lane captures baselines only; it does not fix the product behavior."
  },
  "acceptanceCriteria": [
    "Hermetic fixtures reproduce the no-server one-shot you run --named failure without a live HTTP server, provider, or network",
    "Hermetic fixtures reproduce the no-server / server-required you models invoke failure without a live provider or network",
    "Hermetic fixtures reproduce the absent provider/model default failure with a customer-visible assertion on the constructed empty invocation symptom",
    "Hermetic fixtures reproduce invalid built-in @you/goal topology materialization failure with a customer-visible assertion",
    "Hermetic fixtures prove --quiet still emits customer-visible terminal output on the reported leak case",
    "Hermetic fixtures prove named-factory resolution exposes the percent-encoded @you%2F... path shape to the customer-visible surface under test",
    "Quality checks pass (typecheck, lint, tests)"
  ],
  "userStories": [
    {
      "id": "you-goal-b01-failure-baseline-001",
      "title": "Capture no-server you run --named failure",
      "description": "As a maintainer, I want a hermetic fixture that reproduces one-shot you run --named @you/goal when no Factory Session server is running so later bootstrap work can prove the server prerequisite is gone.",
      "acceptanceCriteria": [
        "A hermetic command fixture invokes one-shot you run --named @you/goal (or the equivalent in-process CLI entry used by existing CLI tests) with an isolated home and no listening Factory Session server",
        "The fixture asserts the current customer-visible failure outcome (non-zero exit and/or classified error text the operator sees), not an internal function name",
        "The fixture does not call a live agent provider or open a real network dependency to an external service",
        "Production CLI behavior is unchanged by this story",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "you-goal-b01-failure-baseline-002",
      "title": "Capture no-server you models invoke failure",
      "description": "As a maintainer, I want a hermetic fixture that reproduces you models invoke when no server/runtime bootstrap is available so later shared-bootstrap work can prove invoke no longer depends on a pre-started server.",
      "acceptanceCriteria": [
        "A hermetic command or package fixture runs you models invoke (or the equivalent models CLI entry) against a local fixture without a pre-started Factory Session server",
        "The fixture asserts the current customer-visible failure outcome when invoke cannot proceed without that server/bootstrap",
        "The fixture does not depend on a live provider or external network",
        "Production models-invoke behavior is unchanged by this story",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "you-goal-b01-failure-baseline-003",
      "title": "Capture absent provider/model default failure",
      "description": "As a maintainer, I want a hermetic fixture that reproduces one-shot goal invocation with no configured provider, model, or command so later provider-selection work can prove empty invocations are replaced by discovery or an actionable harness error.",
      "acceptanceCriteria": [
        "A hermetic fixture runs a one-shot named/goal invocation with absent system/factory provider and model defaults",
        "The fixture asserts the current customer-visible failure symptom of an empty or unusable provider invocation (for example empty provider/command fields or the resulting operator-facing error)",
        "The fixture does not install or execute a real agent harness and does not use live network discovery",
        "Production selection behavior is unchanged by this story",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "you-goal-b01-failure-baseline-004",
      "title": "Capture invalid built-in topology materialization failure",
      "description": "As a maintainer, I want a hermetic fixture that reproduces materializing or upgrading an invalid built-in @you/goal topology so later validation-diagnostics work can prove the customer receives actionable recovery guidance.",
      "acceptanceCriteria": [
        "A hermetic fixture uses an invalid built-in/builtingoal topology fixture that triggers blocking graph/topology validation during named-factory materialization or upgrade",
        "The fixture asserts the current customer-visible failure text or classified error the operator sees for that invalid topology",
        "The fixture does not require a live provider, network, or externally running server",
        "Production validation/materialization behavior is unchanged by this story",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "you-goal-b01-failure-baseline-005",
      "title": "Capture --quiet terminal output leak",
      "description": "As a maintainer, I want a hermetic fixture that proves you run --quiet still emits terminal output on the reported leak path so later terminal-policy work can prove absolute quiet mute.",
      "acceptanceCriteria": [
        "A hermetic subprocess or CLI stdout/stderr capture runs a one-shot you run --quiet path that currently leaks warn/diagnostic/progress text",
        "The fixture asserts that customer-visible terminal bytes are non-empty on the leak case (documenting today's broken quiet contract)",
        "File diagnostics may still exist; the asserted surface is terminal stdout/stderr leakage",
        "The fixture does not depend on a live provider or network",
        "Production quiet behavior is unchanged by this story",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "you-goal-b01-failure-baseline-006",
      "title": "Capture percent-encoded named-factory path shape",
      "description": "As a maintainer, I want a hermetic fixture that proves named @you/goal resolution still surfaces the percent-encoded @you%2Fgoal path shape so later hierarchical path work can prove the customer-visible path contract changed.",
      "acceptanceCriteria": [
        "A hermetic fixture resolves or runs a named @you/goal (or equivalent @you/...) factory under an isolated home",
        "The fixture asserts the current customer-visible path symptom includes the percent-encoded segment form such as @you%2Fgoal (in resolved factory directory text, operator-facing error/log fields, or other documented customer-visible surface used by existing named-factory resolution)",
        "The fixture does not migrate, delete, or rewrite legacy directories; it only captures today's path shape",
        "The fixture does not depend on a live provider or network",
        "Production path mapping is unchanged by this story",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": ""
    }
  ]
}
