### PR TITLE
you-goal-b07-subagent-factory

### DIFF
--- a/contracts/testdata/baseline/rest-operations.json
+++ b/contracts/testdata/baseline/rest-operations.json
@@ -410,6 +410,12 @@
           ]
         },
         {
+          "status": "400",
+          "mediaTypes": [
+            "application/json"
+          ]
+        },
+        {
           "status": "404",
           "mediaTypes": [
             "application/json"

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -208,8 +208,11 @@ primary-result behavior.
   exported from `pkg/config/layout.go`. The topology uses exactly one `AGENT_WORKER`
   with explicit `agentTools.policy` and one `AGENT_RUN` workstation that interpolates
   `${input}` from the invocation signature into the workstation prompt body.
-- `pkg/packagedfactories/subagent/` owns packaged subagent factory metadata constants
-  and topology validation coverage for the one-pass built-in factory JSON.
+  `@you/subagent` is registered in `builtInNamedFactoryCatalog` so first named
+  resolution materializes the split-layout factory under the global named-factory root.
+- `pkg/packagedfactories/subagent/` owns packaged subagent factory metadata constants,
+  topology validation coverage, and materialization/edit-safe identity tests for the
+  one-pass built-in factory JSON.
 - `pkg/cli/run/factory_invocation_help.go` owns the factory-aware help renderer
   for `you run --named <factory> --help` and `you run --factory <factory.json> --help`.
   Keep usage lines, parameter descriptions, defaults, accepted values, output

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -211,8 +211,18 @@ primary-result behavior.
   `@you/subagent` is registered in `builtInNamedFactoryCatalog` so first named
   resolution materializes the split-layout factory under the global named-factory root.
 - `pkg/packagedfactories/subagent/` owns packaged subagent factory metadata constants,
-  topology validation coverage, and materialization/edit-safe identity tests for the
-  one-pass built-in factory JSON.
+  topology validation coverage, materialization/edit-safe identity tests, response
+  shaping helpers for terminal `task:complete` work content, and primary-result
+  selection tests for the one-pass built-in factory JSON.
+- Hermetic no-server named `@you/subagent` package proof lives in
+  `pkg/cli/run/run_invocation_test.go`
+  (`TestRun_NamedSubagentHermeticInvocationSucceedsWithoutListeningServer`,
+  `TestRun_NamedSubagentNoServerBootstrap_TextPrimaryResultIsAgentResponse`,
+  `TestRun_NamedSubagentNoServerBootstrap_SuccessJSONMatchesAPIProjection`,
+  `TestNoServerNamedSubagentInvocationIntegrationAndEquivalenceProof`), using the
+  real shared bootstrap path with mock workers and a TCP probe port to assert no
+  factory API/dashboard listener is bound and exactly one agent-response
+  `primaryResult` is returned.
 - `pkg/cli/run/factory_invocation_help.go` owns the factory-aware help renderer
   for `you run --named <factory> --help` and `you run --factory <factory.json> --help`.
   Keep usage lines, parameter descriptions, defaults, accepted values, output

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -203,6 +203,13 @@ primary-result behavior.
   directory so customer edits survive later `you run --named` reuse.
   `@you/fusion` factory JSON (`BuiltInFusionFactoryJSON`) is also registered from
   `builtInNamedFactoryCatalog`.
+- `pkg/config/builtinsubagent/` owns the authored `@you/subagent` one-pass factory
+  scaffold (`factory.json`, prompt files) assembled into `BuiltInSubagentFactoryJSON`
+  exported from `pkg/config/layout.go`. The topology uses exactly one `AGENT_WORKER`
+  with explicit `agentTools.policy` and one `AGENT_RUN` workstation that interpolates
+  `${input}` from the invocation signature into the workstation prompt body.
+- `pkg/packagedfactories/subagent/` owns packaged subagent factory metadata constants
+  and topology validation coverage for the one-pass built-in factory JSON.
 - `pkg/cli/run/factory_invocation_help.go` owns the factory-aware help renderer
   for `you run --named <factory> --help` and `you run --factory <factory.json> --help`.
   Keep usage lines, parameter descriptions, defaults, accepted values, output

--- a/pkg/cli/run/run_invocation_test.go
+++ b/pkg/cli/run/run_invocation_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/invocations"
 	"github.com/portpowered/infinite-you/pkg/packagedfactories/goal"
+	"github.com/portpowered/infinite-you/pkg/packagedfactories/subagent"
 	"github.com/portpowered/infinite-you/pkg/packagedfactories/tts"
 	"github.com/portpowered/infinite-you/pkg/service"
 	"go.uber.org/zap"
@@ -1605,6 +1606,225 @@ func TestNoServerNamedInvocationIntegrationAndEquivalenceProof(t *testing.T) {
 			cfg.JSONOutput = true
 		})
 		assertCapturedRequestMatchesLogicalAPIText(t, capture, goalText)
+		assertCapturedResultMatchesCLIJSONOutput(t, capture, output)
+	})
+}
+
+func namedSubagentNoServerInvocationRunConfig(t *testing.T, requestText string) RunConfig {
+	t.Helper()
+
+	homeDir := t.TempDir()
+	setUserHomeForTest(t, homeDir)
+	globalRoot, err := factoryconfig.DefaultGlobalNamedFactoryRoot()
+	if err != nil {
+		t.Fatalf("DefaultGlobalNamedFactoryRoot: %v", err)
+	}
+	resolution, err := factoryconfig.ResolveNamedFactoryAcrossRoots(t.TempDir(), globalRoot, subagent.PackagedFactoryName)
+	if err != nil {
+		t.Fatalf("ResolveNamedFactoryAcrossRoots: %v", err)
+	}
+
+	return RunConfig{
+		Dir:                        resolution.FactoryDir,
+		NamedFactoryName:           subagent.PackagedFactoryName,
+		NamedFactoryResolution:     resolution,
+		InvocationPositionalText:   &requestText,
+		StdinIsTTY:                 func() bool { return true },
+		SuppressDashboardRendering: true,
+		MockWorkersEnabled:         true,
+		MockWorkersConfigPath:      writePackagedSubagentNoServerMockWorkersConfig(t),
+		DisableDefaultRecording:    true,
+		Port:                       reserveNoServerInvocationProbePort(t),
+		AutoPort:                   true,
+		Logger:                     zap.NewNop(),
+	}
+}
+
+func runNoServerSubagentBootstrapEquivalenceCase(
+	t *testing.T,
+	requestText string,
+	mutate func(*RunConfig),
+) (*capturingBootstrapRunner, *bytes.Buffer) {
+	t.Helper()
+
+	preserveRunGlobals(t)
+	capture := installCapturingRealInvocationBootstrap(t)
+	cfg := namedSubagentNoServerInvocationRunConfig(t, requestText)
+	if mutate != nil {
+		mutate(&cfg)
+	}
+	var output bytes.Buffer
+	cfg.Output = &output
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	if err := Run(ctx, cfg); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	return capture, &output
+}
+
+func TestRun_NamedSubagentHermeticInvocationSucceedsWithoutListeningServer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test for hermetic named subagent no-server invocation")
+	}
+
+	preserveRunGlobals(t)
+
+	homeDir := t.TempDir()
+	setUserHomeForTest(t, homeDir)
+	globalRoot, err := factoryconfig.DefaultGlobalNamedFactoryRoot()
+	if err != nil {
+		t.Fatalf("DefaultGlobalNamedFactoryRoot: %v", err)
+	}
+	resolution, err := factoryconfig.ResolveNamedFactoryAcrossRoots(t.TempDir(), globalRoot, subagent.PackagedFactoryName)
+	if err != nil {
+		t.Fatalf("ResolveNamedFactoryAcrossRoots: %v", err)
+	}
+
+	mockWorkersPath := writePackagedSubagentNoServerMockWorkersConfig(t)
+	probePort := reserveNoServerInvocationProbePort(t)
+	requestText := "hermetic no-server named subagent prompt"
+
+	var output bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	err = Run(ctx, RunConfig{
+		Dir:                        resolution.FactoryDir,
+		NamedFactoryName:           subagent.PackagedFactoryName,
+		NamedFactoryResolution:     resolution,
+		InvocationPositionalText:   &requestText,
+		StdinIsTTY:                 func() bool { return true },
+		SuppressDashboardRendering: true,
+		MockWorkersEnabled:         true,
+		MockWorkersConfigPath:      mockWorkersPath,
+		DisableDefaultRecording:    true,
+		Output:                     &output,
+		Port:                       probePort,
+		AutoPort:                   true,
+		Logger:                     zap.NewNop(),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := output.String(); got != "mock worker accepted" {
+		t.Fatalf("stdout = %q, want agent response mock worker accepted", got)
+	}
+	if got := output.String(); got == requestText {
+		t.Fatalf("stdout echoed submitted request text instead of agent response")
+	}
+	assertNoServerInvocationProbePortFree(t, probePort)
+}
+
+func TestRun_NamedSubagentNoServerBootstrap_TextPrimaryResultIsAgentResponse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test for no-server bootstrap subagent primary-result selection")
+	}
+
+	requestText := "no-server bootstrap subagent primary-result prompt"
+	_, output := runNoServerSubagentBootstrapEquivalenceCase(t, requestText, nil)
+	if got := output.String(); got != "mock worker accepted" {
+		t.Fatalf("stdout = %q, want agent response mock worker accepted", got)
+	}
+	if got := output.String(); got == requestText {
+		t.Fatalf("stdout echoed submitted request text instead of agent response")
+	}
+}
+
+func TestRun_NamedSubagentNoServerBootstrap_SuccessJSONMatchesAPIProjection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test for no-server bootstrap subagent CLI/API projection")
+	}
+
+	requestText := "no-server bootstrap subagent json parity prompt"
+	capture, output := runNoServerSubagentBootstrapEquivalenceCase(t, requestText, func(cfg *RunConfig) {
+		cfg.JSONOutput = true
+	})
+	assertCapturedRequestMatchesLogicalAPIText(t, capture, requestText)
+	assertCapturedResultMatchesCLIJSONOutput(t, capture, output)
+	if capture.lastResult == nil || len(capture.lastResult.PrimaryResult) == 0 {
+		t.Fatalf("capture result = %#v, want primary result", capture.lastResult)
+	}
+	if got := capture.lastResult.PrimaryResult[0].Text; got != "mock worker accepted" {
+		t.Fatalf("primaryResult text = %q, want agent response mock worker accepted", got)
+	}
+	if got := capture.lastResult.PrimaryResult[0].Text; got == requestText {
+		t.Fatalf("primaryResult echoed submitted request text instead of agent response")
+	}
+	if !strings.Contains(output.String(), `"primaryResult"`) {
+		t.Fatalf("json output = %s, want primaryResult field", output.String())
+	}
+	if strings.Count(output.String(), `"primaryResult"`) != 1 {
+		t.Fatalf("json output = %s, want exactly one primaryResult field", output.String())
+	}
+}
+
+func writePackagedSubagentNoServerMockWorkersConfig(t *testing.T) string {
+	t.Helper()
+
+	cfg := factoryconfig.MockWorkersConfig{
+		UnmatchedDispatchPolicy: factoryconfig.MockWorkerUnmatchedDispatchPolicyPassthrough,
+		MockWorkers: []factoryconfig.MockWorkerConfig{
+			{
+				WorkerName:      subagent.PackagedWorkerName,
+				WorkstationName: subagent.PackagedRunWorkstationName,
+				RunType:         factoryconfig.MockWorkerRunTypeAccept,
+			},
+		},
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal mock workers config: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "mock-workers-packaged-subagent-no-server.json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write mock workers config: %v", err)
+	}
+	return path
+}
+
+// TestNoServerNamedSubagentInvocationIntegrationAndEquivalenceProof is the
+// consolidated package integration and invocation-equivalence proof for hermetic
+// named one-shot @you/subagent invocation on the shared no-server bootstrap path.
+func TestNoServerNamedSubagentInvocationIntegrationAndEquivalenceProof(t *testing.T) {
+	if testing.Short() {
+		t.Skip("consolidated package integration and invocation-equivalence proof for no-server named subagent invocation")
+	}
+
+	t.Run("hermetic named success without listener", func(t *testing.T) {
+		preserveRunGlobals(t)
+
+		requestText := "consolidated no-server named subagent integration proof"
+		probePort := reserveNoServerInvocationProbePort(t)
+		cfg := namedSubagentNoServerInvocationRunConfig(t, requestText)
+		cfg.Port = probePort
+		cfg.AutoPort = true
+		var output bytes.Buffer
+		cfg.Output = &output
+
+		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+		defer cancel()
+
+		if err := Run(ctx, cfg); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if got := output.String(); got != "mock worker accepted" {
+			t.Fatalf("stdout = %q, want agent response mock worker accepted", got)
+		}
+		if got := output.String(); got == requestText {
+			t.Fatalf("stdout echoed submitted request text instead of agent response")
+		}
+		assertNoServerInvocationProbePortFree(t, probePort)
+	})
+
+	t.Run("shared input resolution and primary-result equivalence", func(t *testing.T) {
+		requestText := "consolidated no-server subagent equivalence proof"
+		capture, output := runNoServerSubagentBootstrapEquivalenceCase(t, requestText, func(cfg *RunConfig) {
+			cfg.JSONOutput = true
+		})
+		assertCapturedRequestMatchesLogicalAPIText(t, capture, requestText)
 		assertCapturedResultMatchesCLIJSONOutput(t, capture, output)
 	})
 }

--- a/pkg/config/builtinsubagent/assembly_test.go
+++ b/pkg/config/builtinsubagent/assembly_test.go
@@ -1,0 +1,57 @@
+package builtinsubagent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAssembleBuiltInSubagentFactoryJSON_RejectsMalformedFactoryJSON(t *testing.T) {
+	t.Run("workers not array", func(t *testing.T) {
+		root := map[string]any{
+			"workers": "not-an-array",
+		}
+		_, err := assembleBuiltInSubagentFactoryJSONFromRoot(root)
+		if err == nil || !strings.Contains(err.Error(), "workers must be an array") {
+			t.Fatalf("assemble error = %v, want workers array validation", err)
+		}
+	})
+
+	t.Run("worker entry not object", func(t *testing.T) {
+		root := map[string]any{
+			"workers": []any{"not-an-object"},
+		}
+		_, err := assembleBuiltInSubagentFactoryJSONFromRoot(root)
+		if err == nil || !strings.Contains(err.Error(), "worker entry must be an object") {
+			t.Fatalf("assemble error = %v, want worker object validation", err)
+		}
+	})
+
+	t.Run("workstations not array", func(t *testing.T) {
+		root := map[string]any{
+			"workers":      []any{},
+			"workstations": "not-an-array",
+		}
+		_, err := assembleBuiltInSubagentFactoryJSONFromRoot(root)
+		if err == nil || !strings.Contains(err.Error(), "workstations must be an array") {
+			t.Fatalf("assemble error = %v, want workstations array validation", err)
+		}
+	})
+
+	t.Run("workstation entry not object", func(t *testing.T) {
+		root := map[string]any{
+			"workers":      []any{},
+			"workstations": []any{"not-an-object"},
+		}
+		_, err := assembleBuiltInSubagentFactoryJSONFromRoot(root)
+		if err == nil || !strings.Contains(err.Error(), "workstation entry must be an object") {
+			t.Fatalf("assemble error = %v, want workstation object validation", err)
+		}
+	})
+}
+
+func TestAssembleBuiltInSubagentFactoryJSON_RejectsInvalidFactoryJSON(t *testing.T) {
+	_, err := assembleBuiltInSubagentFactoryJSONFromRoot(map[string]any{"workers": []any{}})
+	if err == nil || !strings.Contains(err.Error(), "workstations must be an array") {
+		t.Fatalf("assemble error = %v, want workstations array validation", err)
+	}
+}

--- a/pkg/config/builtinsubagent/builtin.go
+++ b/pkg/config/builtinsubagent/builtin.go
@@ -1,0 +1,94 @@
+package builtinsubagent
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+//go:embed factory.json
+var factoryJSON []byte
+
+//go:embed prompts/worker.md
+var workerPrompt string
+
+//go:embed prompts/run-subagent.md
+var runSubagentPrompt string
+
+var workerPromptBodies = map[string]string{
+	"subagent-worker": workerPrompt,
+}
+
+var workstationPromptBodies = map[string]string{
+	"run-subagent": runSubagentPrompt,
+}
+
+// BuiltInSubagentFactoryJSON is the canonical runnable @you/subagent packaged
+// factory payload assembled from authored factory.json and prompt files.
+var BuiltInSubagentFactoryJSON = mustAssembleBuiltInSubagentFactoryJSON()
+
+// FactoryJSON returns the authored factory scaffold without assembled prompt bodies.
+func FactoryJSON() []byte {
+	return append([]byte(nil), factoryJSON...)
+}
+
+func mustAssembleBuiltInSubagentFactoryJSON() []byte {
+	payload, err := assembleBuiltInSubagentFactoryJSON()
+	if err != nil {
+		panic(fmt.Sprintf("assemble built-in @you/subagent factory json: %v", err))
+	}
+	return payload
+}
+
+func assembleBuiltInSubagentFactoryJSON() ([]byte, error) {
+	var root map[string]any
+	if err := json.Unmarshal(factoryJSON, &root); err != nil {
+		return nil, fmt.Errorf("unmarshal factory.json: %w", err)
+	}
+	return assembleBuiltInSubagentFactoryJSONFromRoot(root)
+}
+
+func assembleBuiltInSubagentFactoryJSONFromRoot(root map[string]any) ([]byte, error) {
+	workers, ok := root["workers"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("factory.json workers must be an array")
+	}
+	for _, entry := range workers {
+		worker, ok := entry.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("factory.json worker entry must be an object")
+		}
+		name, _ := worker["name"].(string)
+		promptBody, ok := workerPromptBodies[name]
+		if !ok {
+			continue
+		}
+		worker["body"] = strings.TrimSpace(promptBody)
+		delete(worker, "promptFile")
+	}
+
+	workstations, ok := root["workstations"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("factory.json workstations must be an array")
+	}
+	for _, entry := range workstations {
+		workstation, ok := entry.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("factory.json workstation entry must be an object")
+		}
+		name, _ := workstation["name"].(string)
+		promptBody, ok := workstationPromptBodies[name]
+		if !ok {
+			continue
+		}
+		workstation["body"] = strings.TrimSpace(promptBody)
+		delete(workstation, "promptFile")
+	}
+
+	payload, err := json.Marshal(root)
+	if err != nil {
+		return nil, fmt.Errorf("marshal assembled factory json: %w", err)
+	}
+	return payload, nil
+}

--- a/pkg/config/builtinsubagent/builtin_test.go
+++ b/pkg/config/builtinsubagent/builtin_test.go
@@ -1,0 +1,78 @@
+package builtinsubagent_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	factoryconfig "github.com/portpowered/infinite-you/pkg/config"
+	"github.com/portpowered/infinite-you/pkg/config/builtinsubagent"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+)
+
+func TestBuiltInSubagentFactoryJSON_AssemblesFromAuthoredPromptFiles(t *testing.T) {
+	cfg, err := factoryconfig.FactoryConfigFromOpenAPIJSON(builtinsubagent.BuiltInSubagentFactoryJSON)
+	if err != nil {
+		t.Fatalf("FactoryConfigFromOpenAPIJSON: %v", err)
+	}
+
+	assertWorkerBodiesMatchAuthoredPrompts(t, cfg)
+	assertWorkstationBodiesMatchAuthoredPrompts(t, cfg)
+	assertFactoryJSONWorkstationsHaveNoInlineBodies(t)
+}
+
+func assertWorkstationBodiesMatchAuthoredPrompts(t *testing.T, cfg *interfaces.FactoryConfig) {
+	t.Helper()
+	for _, workstation := range cfg.Workstations {
+		if workstation.Name != "run-subagent" {
+			continue
+		}
+		body := strings.TrimSpace(workstation.Body)
+		if !strings.Contains(body, "${input}") {
+			t.Fatalf("run-subagent body = %q, want invocation request interpolation", body)
+		}
+		if !strings.Contains(body, "(index .Inputs 0).WorkID") {
+			t.Fatalf("run-subagent body = %q, want canonical work input binding", body)
+		}
+		return
+	}
+	t.Fatal("run-subagent workstation not found")
+}
+
+func assertWorkerBodiesMatchAuthoredPrompts(t *testing.T, cfg *interfaces.FactoryConfig) {
+	t.Helper()
+	for _, worker := range cfg.Workers {
+		if worker.Name != "subagent-worker" {
+			continue
+		}
+		if strings.TrimSpace(worker.Body) == "" {
+			t.Fatal("subagent-worker body is empty")
+		}
+		if worker.AgentTools == nil || worker.AgentTools.Policy != interfaces.AgentWorkerToolPolicyReadOnly {
+			t.Fatalf("subagent-worker agentTools = %#v, want READ_ONLY policy", worker.AgentTools)
+		}
+		return
+	}
+	t.Fatal("subagent-worker not found")
+}
+
+func assertFactoryJSONWorkstationsHaveNoInlineBodies(t *testing.T) {
+	t.Helper()
+	var raw map[string]any
+	if err := json.Unmarshal(builtinsubagent.FactoryJSON(), &raw); err != nil {
+		t.Fatalf("unmarshal authored factory.json: %v", err)
+	}
+	workstations, ok := raw["workstations"].([]any)
+	if !ok {
+		t.Fatal("authored factory.json workstations must be an array")
+	}
+	for _, entry := range workstations {
+		workstation, ok := entry.(map[string]any)
+		if !ok {
+			t.Fatal("authored workstation entry must be an object")
+		}
+		if _, hasBody := workstation["body"]; hasBody {
+			t.Fatalf("authored workstation %q must not inline prompt body in factory.json", workstation["name"])
+		}
+	}
+}

--- a/pkg/config/builtinsubagent/factory.json
+++ b/pkg/config/builtinsubagent/factory.json
@@ -1,0 +1,67 @@
+{
+  "name": "@you/subagent",
+  "id": "builtin-subagent",
+  "invocationSignature": {
+    "parameters": [
+      {
+        "name": "input",
+        "description": "Text request for the one-pass subagent.",
+        "required": true,
+        "bindings": [
+          {"kind": "POSITIONAL", "position": 1},
+          {"kind": "STDIN"}
+        ]
+      }
+    ],
+    "examples": [
+      {
+        "name": "positional-input",
+        "argv": ["Summarize this release"]
+      },
+      {
+        "name": "stdin-input",
+        "argv": [],
+        "stdin": "Summarize this release"
+      }
+    ]
+  },
+  "workTypes": [
+    {
+      "name": "task",
+      "handlingBehavior": ["DEFAULT"],
+      "states": [
+        {"name": "init", "type": "INITIAL"},
+        {"name": "complete", "type": "TERMINAL"},
+        {"name": "failed", "type": "FAILED"}
+      ]
+    }
+  ],
+  "resources": [],
+  "workers": [
+    {
+      "name": "subagent-worker",
+      "type": "AGENT_WORKER",
+      "agentTools": {
+        "policy": "READ_ONLY"
+      },
+      "promptFile": "prompts/worker.md"
+    }
+  ],
+  "workstations": [
+    {
+      "name": "run-subagent",
+      "type": "AGENT_RUN",
+      "worker": "subagent-worker",
+      "inputs": [
+        {"workType": "task", "state": "init"}
+      ],
+      "outputs": [
+        {"workType": "task", "state": "complete"}
+      ],
+      "onFailure": [
+        {"workType": "task", "state": "failed"}
+      ],
+      "promptFile": "prompts/run-subagent.md"
+    }
+  ]
+}

--- a/pkg/config/builtinsubagent/prompts/run-subagent.md
+++ b/pkg/config/builtinsubagent/prompts/run-subagent.md
@@ -1,0 +1,4 @@
+Respond to the submitted request in one pass for work {{ (index .Inputs 0).WorkID }}.
+
+Request:
+${input}

--- a/pkg/config/builtinsubagent/prompts/worker.md
+++ b/pkg/config/builtinsubagent/prompts/worker.md
@@ -1,0 +1,3 @@
+You are the one-pass subagent worker for @you/subagent.
+
+Respond directly to the submitted request in a single bounded pass. Do not plan multi-stage work or defer follow-up actions.

--- a/pkg/config/layout.go
+++ b/pkg/config/layout.go
@@ -15,6 +15,7 @@ import (
 
 	factoryapi "github.com/portpowered/infinite-you/pkg/api/generated"
 	"github.com/portpowered/infinite-you/pkg/config/builtingoal"
+	"github.com/portpowered/infinite-you/pkg/config/builtinsubagent"
 	factoryvalidation "github.com/portpowered/infinite-you/pkg/factory/validation"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 )
@@ -1091,6 +1092,9 @@ func resolveBuiltInNamedFactory(globalRoot, canonicalName string) (string, bool,
 }
 
 var BuiltInGoalFactoryJSON = builtingoal.BuiltInGoalFactoryJSON
+
+// BuiltInSubagentFactoryJSON is the canonical runnable @you/subagent packaged factory payload.
+var BuiltInSubagentFactoryJSON = builtinsubagent.BuiltInSubagentFactoryJSON
 
 // BuiltInFusionFactoryJSON is the canonical runnable @you/fusion packaged factory payload.
 var BuiltInFusionFactoryJSON = []byte(`{

--- a/pkg/config/layout.go
+++ b/pkg/config/layout.go
@@ -874,9 +874,10 @@ func restoreFactorySplitLayoutReplace(targetDir, backupDir string) {
 }
 
 var builtInNamedFactoryCatalog = map[string][]byte{
-	"@you/fusion": BuiltInFusionFactoryJSON,
-	"@you/goal":   BuiltInGoalFactoryJSON,
-	"@you/tts":    BuiltInTTSFactoryJSON,
+	"@you/fusion":    BuiltInFusionFactoryJSON,
+	"@you/goal":      BuiltInGoalFactoryJSON,
+	"@you/subagent":  BuiltInSubagentFactoryJSON,
+	"@you/tts":       BuiltInTTSFactoryJSON,
 }
 
 // ResolveNamedFactoryDirAcrossRoots returns the runnable factory directory for

--- a/pkg/factory/subsystems/subsystem_history.go
+++ b/pkg/factory/subsystems/subsystem_history.go
@@ -9,6 +9,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/logging"
 	"github.com/portpowered/infinite-you/pkg/packagedfactories/goal"
+	"github.com/portpowered/infinite-you/pkg/packagedfactories/subagent"
 	"github.com/portpowered/infinite-you/pkg/packagedfactories/tts"
 	"github.com/portpowered/infinite-you/pkg/petri"
 )
@@ -204,6 +205,38 @@ func applyPackagedGoalInvocationSummary(
 	}
 
 	token.Color.Content = summaryContent
+	token.Color.Payload = nil
+	return nil
+}
+
+func applyPackagedSubagentInvocationResponse(
+	token *interfaces.Token,
+	workstation *interfaces.FactoryWorkstationConfig,
+	workerOutput string,
+	runtimeConfig interfaces.RuntimeWorkstationLookup,
+) error {
+	if token == nil || !subagent.ShouldFormatInvocationResponse(workstation) {
+		return nil
+	}
+	if strings.TrimSpace(workerOutput) == "" {
+		return nil
+	}
+
+	stopToken := ""
+	if workstation != nil && runtimeConfig != nil {
+		if lookup, ok := runtimeConfig.(interfaces.RuntimeDefinitionLookup); ok {
+			if worker, ok := lookup.Worker(strings.TrimSpace(workstation.WorkerTypeName)); ok && worker != nil {
+				stopToken = strings.TrimSpace(worker.StopToken)
+			}
+		}
+	}
+
+	responseContent, err := subagent.ResponseContentFromWorkerOutput(workerOutput, stopToken)
+	if err != nil {
+		return fmt.Errorf("shape packaged subagent invocation response: %w", err)
+	}
+
+	token.Color.Content = responseContent
 	token.Color.Payload = nil
 	return nil
 }

--- a/pkg/factory/subsystems/subsystem_transitioner.go
+++ b/pkg/factory/subsystems/subsystem_transitioner.go
@@ -750,6 +750,9 @@ func calculateMutations(in mutationCalculationInput) ([]interfaces.MarkingMutati
 			if err := applyPackagedGoalInvocationSummary(newToken, in.workstation, in.result.output, in.runtimeConfig); err != nil {
 				return nil, err
 			}
+			if err := applyPackagedSubagentInvocationResponse(newToken, in.workstation, in.result.output, in.runtimeConfig); err != nil {
+				return nil, err
+			}
 			if newToken.Color.DataType != interfaces.DataTypeResource {
 				if workOutputIndex < len(in.result.recordedOutputWork) {
 					applyRecordedOutputWorkIdentity(newToken, in.result.recordedOutputWork[workOutputIndex])

--- a/pkg/factory/subsystems/subsystem_transitioner_mutations_test.go
+++ b/pkg/factory/subsystems/subsystem_transitioner_mutations_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/factory/token_transformer"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/packagedfactories/goal"
+	"github.com/portpowered/infinite-you/pkg/packagedfactories/subagent"
 	"github.com/portpowered/infinite-you/pkg/packagedfactories/tts"
 	"github.com/portpowered/infinite-you/pkg/petri"
 	"github.com/portpowered/infinite-you/pkg/testutil/runtimefixtures"
@@ -699,6 +700,55 @@ func TestCalculateMutations_PackagedGoalReplacesTerminalContentWithSummary(t *te
 	}
 	if token.Color.Content[0].Text != "Final goal summary." {
 		t.Fatalf("terminal content = %q, want worker summary without stop token", token.Color.Content[0].Text)
+	}
+	if len(token.Color.Payload) != 0 {
+		t.Fatalf("terminal payload = %q, want cleared so submitted input does not leak", string(token.Color.Payload))
+	}
+}
+
+func TestCalculateMutations_PackagedSubagentReplacesTerminalContentWithAgentResponse(t *testing.T) {
+	fixture := newCalculateMutationsFixture()
+	workstation := &interfaces.FactoryWorkstationConfig{
+		Name:           subagent.PackagedRunWorkstationName,
+		Type:           interfaces.WorkstationTypeAgent,
+		WorkerTypeName: subagent.PackagedWorkerName,
+	}
+	workerOutput := "mock worker accepted\nCOMPLETE"
+
+	mutations, err := calculateMutations(mutationCalculationInput{
+		transition:  fixture.transition,
+		workstation: workstation,
+		arcs: []petri.Arc{{
+			PlaceID: subagent.PackagedWorkTypeName + ":complete",
+		}},
+		consumed:    fixture.consumed,
+		result:      resolvedWorkResult{outcome: interfaces.OutcomeAccepted, output: workerOutput},
+		now:         fixture.now,
+		history:     fixture.baseHistory,
+		inputColors: fixture.inputColors,
+		transformer: fixture.transformer,
+		runtimeConfig: runtimefixtures.RuntimeDefinitionLookupFixture{
+			Workers: map[string]*interfaces.WorkerConfig{
+				subagent.PackagedWorkerName: {
+					Name:      subagent.PackagedWorkerName,
+					StopToken: "COMPLETE",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("calculateMutations: %v", err)
+	}
+	if len(mutations) != 1 {
+		t.Fatalf("mutation count = %d, want 1", len(mutations))
+	}
+
+	token := mutations[0].NewToken
+	if len(token.Color.Content) != 1 || token.Color.Content[0].Type != interfaces.WorkContentPartTypeText {
+		t.Fatalf("terminal content = %#v, want one text agent response part", token.Color.Content)
+	}
+	if token.Color.Content[0].Text != "mock worker accepted" {
+		t.Fatalf("terminal content = %q, want worker response without stop token", token.Color.Content[0].Text)
 	}
 	if len(token.Color.Payload) != 0 {
 		t.Fatalf("terminal payload = %q, want cleared so submitted input does not leak", string(token.Color.Payload))

--- a/pkg/packagedfactories/subagent/factory_test.go
+++ b/pkg/packagedfactories/subagent/factory_test.go
@@ -1,0 +1,176 @@
+package subagent
+
+import (
+	"strings"
+	"testing"
+
+	factoryconfig "github.com/portpowered/infinite-you/pkg/config"
+	factoryvalidation "github.com/portpowered/infinite-you/pkg/factory/validation"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+)
+
+func TestBuiltInFactoryJSON_LoadsRunnablePackagedSubagentFactory(t *testing.T) {
+	cfg, err := factoryconfig.FactoryConfigFromOpenAPIJSON(factoryconfig.BuiltInSubagentFactoryJSON)
+	if err != nil {
+		t.Fatalf("FactoryConfigFromOpenAPIJSON: %v", err)
+	}
+	if cfg.Name != PackagedFactoryName {
+		t.Fatalf("factory name = %q, want %s", cfg.Name, PackagedFactoryName)
+	}
+	if cfg.Project != PackagedFactoryProject {
+		t.Fatalf("factory project = %q, want %s", cfg.Project, PackagedFactoryProject)
+	}
+	if cfg.InvocationSignature == nil {
+		t.Fatal("InvocationSignature = nil, want packaged signature with request input")
+	}
+
+	assertOnePassWorkType(t, cfg)
+	assertOnePassTopology(t, cfg)
+	assertRequestContentPropagation(t, cfg)
+	assertSharedAgentToolsPolicy(t, cfg)
+	assertTopologyValidationPasses(t, cfg)
+}
+
+func assertOnePassWorkType(t *testing.T, cfg *interfaces.FactoryConfig) {
+	t.Helper()
+	if len(cfg.WorkTypes) != 1 {
+		t.Fatalf("workTypes = %#v, want one DEFAULT-handled work type", cfg.WorkTypes)
+	}
+	workType := cfg.WorkTypes[0]
+	if workType.Name != PackagedWorkTypeName {
+		t.Fatalf("work type name = %q, want %s", workType.Name, PackagedWorkTypeName)
+	}
+	if len(workType.HandlingBehavior) != 1 || workType.HandlingBehavior[0] != interfaces.WorkTypeHandlingBehaviorDefault {
+		t.Fatalf("handlingBehavior = %#v, want [DEFAULT]", workType.HandlingBehavior)
+	}
+
+	stateNames := make([]string, 0, len(workType.States))
+	stateTypes := map[string]interfaces.StateType{}
+	for _, state := range workType.States {
+		stateNames = append(stateNames, state.Name)
+		stateTypes[state.Name] = state.Type
+	}
+	for _, want := range []string{"init", "complete", "failed"} {
+		if !containsString(stateNames, want) {
+			t.Fatalf("states = %#v, want lifecycle state %q", stateNames, want)
+		}
+	}
+	if stateTypes["init"] != interfaces.StateTypeInitial {
+		t.Fatalf("init state type = %q, want %s", stateTypes["init"], interfaces.StateTypeInitial)
+	}
+	if stateTypes["complete"] != interfaces.StateTypeTerminal {
+		t.Fatalf("complete state type = %q, want %s", stateTypes["complete"], interfaces.StateTypeTerminal)
+	}
+	if stateTypes["failed"] != interfaces.StateTypeFailed {
+		t.Fatalf("failed state type = %q, want %s", stateTypes["failed"], interfaces.StateTypeFailed)
+	}
+}
+
+func assertOnePassTopology(t *testing.T, cfg *interfaces.FactoryConfig) {
+	t.Helper()
+	if len(cfg.Workers) != 1 {
+		t.Fatalf("workers = %#v, want exactly one AGENT_WORKER", cfg.Workers)
+	}
+	worker := cfg.Workers[0]
+	if worker.Name != PackagedWorkerName {
+		t.Fatalf("worker name = %q, want %s", worker.Name, PackagedWorkerName)
+	}
+	publicWorkerType := interfaces.PublicWorkerTypeFromInternalRuntime(worker.Type)
+	if publicWorkerType != interfaces.WorkerTypeAgent {
+		t.Fatalf("worker %q public type = %q, want %s", worker.Name, publicWorkerType, interfaces.WorkerTypeAgent)
+	}
+
+	if len(cfg.Workstations) != 1 {
+		t.Fatalf("workstations = %#v, want exactly one AGENT_RUN workstation", cfg.Workstations)
+	}
+	workstation := cfg.Workstations[0]
+	if workstation.Name != PackagedRunWorkstationName {
+		t.Fatalf("workstation name = %q, want %s", workstation.Name, PackagedRunWorkstationName)
+	}
+	publicWorkstationType := interfaces.PublicWorkstationTypeFromInternalRuntime(workstation.Type, worker.Type, workstation.Kind)
+	if publicWorkstationType != interfaces.WorkstationTypeAgent {
+		t.Fatalf("workstation %q public type = %q, want %s", workstation.Name, publicWorkstationType, interfaces.WorkstationTypeAgent)
+	}
+	if workstation.WorkerTypeName != PackagedWorkerName {
+		t.Fatalf("workstation worker = %q, want %s", workstation.WorkerTypeName, PackagedWorkerName)
+	}
+	assertIORoute(t, workstation.Inputs, PackagedWorkTypeName, "init")
+	assertIORoute(t, workstation.Outputs, PackagedWorkTypeName, "complete")
+	assertIORoute(t, workstation.OnFailure, PackagedWorkTypeName, "failed")
+}
+
+func assertRequestContentPropagation(t *testing.T, cfg *interfaces.FactoryConfig) {
+	t.Helper()
+	for _, workstation := range cfg.Workstations {
+		if workstation.Name != PackagedRunWorkstationName {
+			continue
+		}
+		if !strings.Contains(workstation.Body, "${input}") {
+			t.Fatalf("run-subagent body = %q, want submitted invocation request interpolation", workstation.Body)
+		}
+		return
+	}
+	t.Fatal("run-subagent workstation not found")
+}
+
+func assertSharedAgentToolsPolicy(t *testing.T, cfg *interfaces.FactoryConfig) {
+	t.Helper()
+	for _, worker := range cfg.Workers {
+		if worker.Name != PackagedWorkerName {
+			continue
+		}
+		if worker.AgentTools == nil {
+			t.Fatal("subagent-worker agentTools = nil, want explicit shared policy")
+		}
+		if worker.AgentTools.Policy != interfaces.AgentWorkerToolPolicyReadOnly {
+			t.Fatalf("agentTools.policy = %q, want %s", worker.AgentTools.Policy, interfaces.AgentWorkerToolPolicyReadOnly)
+		}
+		return
+	}
+	t.Fatal("subagent-worker not found")
+}
+
+func assertTopologyValidationPasses(t *testing.T, cfg *interfaces.FactoryConfig) {
+	t.Helper()
+	for _, target := range factoryvalidation.Validate(cfg).Targets {
+		t.Fatalf("validation target = %#v, want valid one-pass subagent topology", target)
+	}
+	findings := factoryconfig.CanonicalStructuralFindings(cfg)
+	if len(findings) != 0 {
+		t.Fatalf("canonical structural findings = %#v, want none", findings)
+	}
+}
+
+func assertIORoute(t *testing.T, routes []interfaces.IOConfig, workTypeName, stateName string) {
+	t.Helper()
+	for _, route := range routes {
+		if route.WorkTypeName == workTypeName && route.StateName == stateName {
+			return
+		}
+	}
+	t.Fatalf("routes = %#v, want %s:%s", routes, workTypeName, stateName)
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func TestIsPackagedFactory_MatchesBuiltInSubagentIdentity(t *testing.T) {
+	if !IsPackagedFactory(&interfaces.FactoryConfig{Name: PackagedFactoryName}) {
+		t.Fatal("expected packaged factory name match")
+	}
+	if !IsPackagedFactory(&interfaces.FactoryConfig{Project: PackagedFactoryProject}) {
+		t.Fatal("expected packaged factory project match")
+	}
+	if IsPackagedFactory(&interfaces.FactoryConfig{Name: "customer-subagent"}) {
+		t.Fatal("unexpected packaged factory match for unrelated factory")
+	}
+	if IsPackagedFactory(nil) {
+		t.Fatal("expected nil factory config not to match")
+	}
+}

--- a/pkg/packagedfactories/subagent/materialize_edit_test.go
+++ b/pkg/packagedfactories/subagent/materialize_edit_test.go
@@ -1,0 +1,138 @@
+package subagent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	factoryconfig "github.com/portpowered/infinite-you/pkg/config"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+)
+
+func TestEditedMaterializedPackagedSubagentFactoryChangesNextLoad(t *testing.T) {
+	factoryDir := materializePackagedSubagentFactory(t, t.TempDir())
+	initialWorker := loadPackagedSubagentWorker(t, factoryDir)
+	if initialWorker.Body == "" {
+		t.Fatal("expected initial materialized subagent worker body")
+	}
+
+	editedBody := "You are the customer-edited @you/subagent built-in.\n"
+	editMaterializedWorkerBody(t, factoryDir, PackagedWorkerName, editedBody)
+
+	editedWorker := loadPackagedSubagentWorker(t, factoryDir)
+	if editedWorker.Body != strings.TrimSpace(editedBody) {
+		t.Fatalf("edited worker body = %q, want %q", editedWorker.Body, strings.TrimSpace(editedBody))
+	}
+	if editedWorker.Body == initialWorker.Body {
+		t.Fatalf("edited worker body = %q, want change from initial materialized content", editedWorker.Body)
+	}
+}
+
+func TestEditedMaterializedPackagedSubagentFactoryWorkstationChangesNextLoad(t *testing.T) {
+	factoryDir := materializePackagedSubagentFactory(t, t.TempDir())
+	initialWorkstation := loadPackagedSubagentWorkstation(t, factoryDir)
+	if initialWorkstation.Body == "" {
+		t.Fatal("expected initial materialized subagent workstation body")
+	}
+
+	editedBody := "Respond to the customer-edited request for work {{ (index .Inputs 0).WorkID }}.\n"
+	editMaterializedWorkstationBody(t, factoryDir, PackagedRunWorkstationName, editedBody)
+
+	editedWorkstation := loadPackagedSubagentWorkstation(t, factoryDir)
+	if editedWorkstation.Body != strings.TrimSpace(editedBody) {
+		t.Fatalf("edited workstation body = %q, want %q", editedWorkstation.Body, strings.TrimSpace(editedBody))
+	}
+	if editedWorkstation.Body == initialWorkstation.Body {
+		t.Fatalf("edited workstation body = %q, want change from initial materialized content", editedWorkstation.Body)
+	}
+}
+
+func TestEditedMaterializedPackagedSubagentFactoryJSONChangesNextLoad(t *testing.T) {
+	const editedProject = "customer-edited-subagent"
+	factoryDir := materializePackagedSubagentFactory(t, t.TempDir())
+	initialLoaded := loadPackagedSubagentRuntimeConfig(t, factoryDir)
+	if initialLoaded.FactoryConfig().Project != PackagedFactoryProject {
+		t.Fatalf("initial project = %q, want %s", initialLoaded.FactoryConfig().Project, PackagedFactoryProject)
+	}
+
+	editMaterializedFactoryProject(t, factoryDir, editedProject)
+
+	editedLoaded := loadPackagedSubagentRuntimeConfig(t, factoryDir)
+	if editedLoaded.FactoryConfig().Project != editedProject {
+		t.Fatalf("edited project = %q, want %q", editedLoaded.FactoryConfig().Project, editedProject)
+	}
+	if editedLoaded.FactoryConfig().Project == initialLoaded.FactoryConfig().Project {
+		t.Fatalf("edited project = %q, want change from initial materialized content", editedLoaded.FactoryConfig().Project)
+	}
+}
+
+func loadPackagedSubagentRuntimeConfig(t *testing.T, factoryDir string) *factoryconfig.LoadedFactoryConfig {
+	t.Helper()
+	loaded, err := factoryconfig.LoadRuntimeConfigFromFactoryDir(factoryDir, nil)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfigFromFactoryDir(%q): %v", factoryDir, err)
+	}
+	return loaded
+}
+
+func loadPackagedSubagentWorker(t *testing.T, factoryDir string) *interfaces.WorkerConfig {
+	t.Helper()
+	loaded := loadPackagedSubagentRuntimeConfig(t, factoryDir)
+	worker, ok := loaded.Worker(PackagedWorkerName)
+	if !ok {
+		t.Fatal("expected materialized subagent-worker")
+	}
+	return worker
+}
+
+func loadPackagedSubagentWorkstation(t *testing.T, factoryDir string) *interfaces.FactoryWorkstationConfig {
+	t.Helper()
+	loaded := loadPackagedSubagentRuntimeConfig(t, factoryDir)
+	workstation, ok := loaded.Workstation(PackagedRunWorkstationName)
+	if !ok {
+		t.Fatal("expected materialized run-subagent workstation")
+	}
+	return workstation
+}
+
+func editMaterializedWorkerBody(t *testing.T, factoryDir, workerName, body string) {
+	t.Helper()
+	workerPath := filepath.Join(factoryDir, interfaces.WorkersDir, workerName, interfaces.FactoryAgentsFileName)
+	if err := os.WriteFile(workerPath, []byte(body), 0o644); err != nil {
+		t.Fatalf("WriteFile(materialized worker body): %v", err)
+	}
+}
+
+func editMaterializedWorkstationBody(t *testing.T, factoryDir, workstationName, body string) {
+	t.Helper()
+	workstationPath := filepath.Join(factoryDir, interfaces.WorkstationsDir, workstationName, interfaces.FactoryAgentsFileName)
+	if err := os.WriteFile(workstationPath, []byte(body), 0o644); err != nil {
+		t.Fatalf("WriteFile(materialized workstation body): %v", err)
+	}
+}
+
+func editMaterializedFactoryProject(t *testing.T, factoryDir, project string) {
+	t.Helper()
+	factoryJSONPath := filepath.Join(factoryDir, interfaces.FactoryConfigFile)
+	factoryJSON, err := os.ReadFile(factoryJSONPath)
+	if err != nil {
+		t.Fatalf("ReadFile(factory.json): %v", err)
+	}
+	var factoryDoc map[string]any
+	if err := json.Unmarshal(factoryJSON, &factoryDoc); err != nil {
+		t.Fatalf("Unmarshal(factory.json): %v", err)
+	}
+	factoryDoc["id"] = project
+	editedJSON, err := json.MarshalIndent(factoryDoc, "", "  ")
+	if err != nil {
+		t.Fatalf("Marshal(edited factory.json): %v", err)
+	}
+	if string(editedJSON) == string(factoryJSON) {
+		t.Fatal("expected edited factory.json to differ from initial materialized content")
+	}
+	if err := os.WriteFile(factoryJSONPath, editedJSON, 0o644); err != nil {
+		t.Fatalf("WriteFile(edited factory.json): %v", err)
+	}
+}

--- a/pkg/packagedfactories/subagent/materialize_test.go
+++ b/pkg/packagedfactories/subagent/materialize_test.go
@@ -1,0 +1,101 @@
+package subagent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	factoryconfig "github.com/portpowered/infinite-you/pkg/config"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+)
+
+func TestMaterializePackagedSubagentFactory_WritesEditableSplitLayout(t *testing.T) {
+	factoryDir := materializePackagedSubagentFactory(t, t.TempDir())
+	assertMaterializedSplitLayout(t, factoryDir)
+
+	loaded, err := factoryconfig.LoadRuntimeConfigFromFactoryDir(factoryDir, nil)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfigFromFactoryDir: %v", err)
+	}
+	if loaded.FactoryConfig().Name != PackagedFactoryName {
+		t.Fatalf("factory name = %q, want %s", loaded.FactoryConfig().Name, PackagedFactoryName)
+	}
+	if loaded.FactoryConfig().Project != PackagedFactoryProject {
+		t.Fatalf("project = %q, want %s", loaded.FactoryConfig().Project, PackagedFactoryProject)
+	}
+	worker, ok := loaded.Worker(PackagedWorkerName)
+	if !ok {
+		t.Fatal("expected materialized subagent-worker")
+	}
+	if worker.Body == "" {
+		t.Fatal("expected worker body loaded from split-layout workers/ directory")
+	}
+	workstation, ok := loaded.Workstation(PackagedRunWorkstationName)
+	if !ok {
+		t.Fatal("expected materialized run-subagent workstation")
+	}
+	if workstation.Body == "" {
+		t.Fatal("expected workstation body loaded from split-layout workstations/ directory")
+	}
+}
+
+func TestResolveNamedFactoryAcrossRoots_MaterializesBuiltInSubagentIntoGlobalRoot(t *testing.T) {
+	projectRoot := t.TempDir()
+	globalRoot := t.TempDir()
+
+	resolution, err := factoryconfig.ResolveNamedFactoryAcrossRoots(projectRoot, globalRoot, PackagedFactoryName)
+	if err != nil {
+		t.Fatalf("ResolveNamedFactoryAcrossRoots(builtin subagent): %v", err)
+	}
+	if resolution.Name != PackagedFactoryName {
+		t.Fatalf("resolution name = %q, want %s", resolution.Name, PackagedFactoryName)
+	}
+	if resolution.Source != factoryconfig.NamedFactoryResolutionSourceBuiltin {
+		t.Fatalf("resolution source = %q, want builtin materialization", resolution.Source)
+	}
+
+	wantDir := filepath.Join(globalRoot, "@you%2Fsubagent")
+	if resolution.FactoryDir != wantDir {
+		t.Fatalf("factory dir = %q, want %q", resolution.FactoryDir, wantDir)
+	}
+	assertMaterializedSplitLayout(t, wantDir)
+
+	loaded, err := factoryconfig.LoadRuntimeConfigFromFactoryDir(resolution.FactoryDir, nil)
+	if err != nil {
+		t.Fatalf("LoadRuntimeConfigFromFactoryDir(materialized builtin subagent): %v", err)
+	}
+	if loaded.FactoryConfig().Project != PackagedFactoryProject {
+		t.Fatalf("materialized builtin project = %q, want %s", loaded.FactoryConfig().Project, PackagedFactoryProject)
+	}
+}
+
+func materializePackagedSubagentFactory(t *testing.T, globalRoot string) string {
+	t.Helper()
+	factoryDir, err := factoryconfig.PersistNamedFactory(globalRoot, PackagedFactoryName, factoryconfig.BuiltInSubagentFactoryJSON)
+	if err != nil {
+		t.Fatalf("PersistNamedFactory: %v", err)
+	}
+	return factoryDir
+}
+
+func assertMaterializedSplitLayout(t *testing.T, factoryDir string) {
+	t.Helper()
+	for _, dirName := range []string{interfaces.WorkersDir, interfaces.WorkstationsDir} {
+		info, err := os.Stat(filepath.Join(factoryDir, dirName))
+		if err != nil {
+			t.Fatalf("stat %s: %v", dirName, err)
+		}
+		if !info.IsDir() {
+			t.Fatalf("%s is not a directory", dirName)
+		}
+	}
+	for _, path := range []string{
+		filepath.Join(factoryDir, interfaces.FactoryConfigFile),
+		filepath.Join(factoryDir, interfaces.WorkersDir, PackagedWorkerName, interfaces.FactoryAgentsFileName),
+		filepath.Join(factoryDir, interfaces.WorkstationsDir, PackagedRunWorkstationName, interfaces.FactoryAgentsFileName),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected materialized path %s: %v", path, err)
+		}
+	}
+}

--- a/pkg/packagedfactories/subagent/metadata.go
+++ b/pkg/packagedfactories/subagent/metadata.go
@@ -1,0 +1,31 @@
+package subagent
+
+import (
+	"strings"
+
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+)
+
+const (
+	// PackagedFactoryName is the canonical named factory identifier for @you/subagent.
+	PackagedFactoryName = "@you/subagent"
+	// PackagedFactoryProject is the stable project id for the built-in subagent factory.
+	PackagedFactoryProject = "builtin-subagent"
+	// PackagedWorkTypeName is the DEFAULT-handled work type for one-pass subagent runs.
+	PackagedWorkTypeName = "task"
+	// PackagedRunWorkstationName is the single AGENT_RUN workstation name.
+	PackagedRunWorkstationName = "run-subagent"
+	// PackagedWorkerName is the single AGENT_WORKER name.
+	PackagedWorkerName = "subagent-worker"
+)
+
+// IsPackagedFactory reports whether cfg identifies the built-in @you/subagent factory.
+func IsPackagedFactory(cfg *interfaces.FactoryConfig) bool {
+	if cfg == nil {
+		return false
+	}
+	if strings.TrimSpace(cfg.Name) == PackagedFactoryName {
+		return true
+	}
+	return strings.TrimSpace(cfg.Project) == PackagedFactoryProject
+}

--- a/pkg/packagedfactories/subagent/metadata_test.go
+++ b/pkg/packagedfactories/subagent/metadata_test.go
@@ -1,0 +1,22 @@
+package subagent
+
+import (
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+)
+
+func TestIsPackagedFactory_MatchesNameOrProject(t *testing.T) {
+	if !IsPackagedFactory(&interfaces.FactoryConfig{Name: PackagedFactoryName}) {
+		t.Fatal("expected factory name match")
+	}
+	if !IsPackagedFactory(&interfaces.FactoryConfig{Project: PackagedFactoryProject}) {
+		t.Fatal("expected factory project match")
+	}
+	if IsPackagedFactory(&interfaces.FactoryConfig{Name: "@you/other"}) {
+		t.Fatal("expected unrelated factory name to be rejected")
+	}
+	if IsPackagedFactory(nil) {
+		t.Fatal("expected nil factory config to be rejected")
+	}
+}

--- a/pkg/packagedfactories/subagent/primary_result_config_test.go
+++ b/pkg/packagedfactories/subagent/primary_result_config_test.go
@@ -1,0 +1,17 @@
+package subagent
+
+import (
+	"testing"
+
+	factoryconfig "github.com/portpowered/infinite-you/pkg/config"
+)
+
+func TestBuiltInFactoryJSON_UsesSubmittedWorkTerminalInvocationReturnDefault(t *testing.T) {
+	cfg, err := factoryconfig.FactoryConfigFromOpenAPIJSON(factoryconfig.BuiltInSubagentFactoryJSON)
+	if err != nil {
+		t.Fatalf("FactoryConfigFromOpenAPIJSON: %v", err)
+	}
+	if cfg.InvocationReturn != nil {
+		t.Fatalf("InvocationReturn = %#v, want nil so shared resolver uses SUBMITTED_WORK_TERMINAL", cfg.InvocationReturn)
+	}
+}

--- a/pkg/packagedfactories/subagent/primary_result_test.go
+++ b/pkg/packagedfactories/subagent/primary_result_test.go
@@ -1,0 +1,68 @@
+package subagent
+
+import (
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/invocations"
+)
+
+func TestPackagedSubagentInvocationPrimaryResult_ReturnsAgentResponseNotSubmittedInput(t *testing.T) {
+	const agentResponse = "mock worker accepted"
+
+	requestID := "req-subagent"
+	workID := "work-subagent"
+	submitted := interfaces.FactoryWorkItem{
+		ID:         workID,
+		WorkTypeID: PackagedWorkTypeName,
+		State:      "init",
+		TraceID:    requestID,
+		Content: []interfaces.WorkContentPart{{
+			Type: interfaces.WorkContentPartTypeText,
+			Text: "customer subagent request text",
+		}},
+	}
+	terminal := interfaces.FactoryWorkItem{
+		ID:         workID,
+		WorkTypeID: PackagedWorkTypeName,
+		State:      "complete",
+		TraceID:    requestID,
+		PlaceID:    PackagedWorkTypeName + ":complete",
+		Content: []interfaces.WorkContentPart{{
+			Type: interfaces.WorkContentPartTypeText,
+			Text: agentResponse,
+		}},
+	}
+
+	state := interfaces.FactoryWorldState{
+		PayloadLineage:   interfaces.WorkPayloadLineageProjection{},
+		WorkRequestsByID: make(map[string]interfaces.WorkRequestPayload),
+		TerminalWorkByID: make(map[string]interfaces.FactoryTerminalWork),
+	}
+	state.WorkRequestsByID[requestID] = interfaces.WorkRequestPayload{
+		RequestID: requestID,
+		Type:      interfaces.WorkRequestTypeFactoryRequestBatch,
+		WorkItems: []interfaces.FactoryWorkItem{submitted},
+	}
+	state.PayloadLineage.RecordWorkRequestSnapshot(1, requestID, submitted)
+	state.PayloadLineage.RecordConsumedInputSnapshot("dispatch-subagent", submitted)
+	state.PayloadLineage.RecordDispatchOutputSnapshot(2, "dispatch-subagent", []interfaces.FactoryWorkItem{submitted}, terminal, 0)
+	state.TerminalWorkByID[workID] = interfaces.FactoryTerminalWork{WorkItem: terminal, Status: "TERMINAL"}
+
+	selection, err := invocations.ResolvePrimaryResult(invocations.PrimaryResultSelectionInput{
+		RequestID:  requestID,
+		WorldState: state,
+	})
+	if err != nil {
+		t.Fatalf("ResolvePrimaryResult: %v", err)
+	}
+	if len(selection.PrimaryResult) != 1 || selection.PrimaryResult[0].Type != interfaces.WorkContentPartTypeText {
+		t.Fatalf("primary result = %#v, want one text agent response part", selection.PrimaryResult)
+	}
+	if selection.PrimaryResult[0].Text != agentResponse {
+		t.Fatalf("primary result text = %q, want agent response %q", selection.PrimaryResult[0].Text, agentResponse)
+	}
+	if selection.PrimaryResult[0].Text == submitted.Content[0].Text {
+		t.Fatalf("primary result echoed submitted request text")
+	}
+}

--- a/pkg/packagedfactories/subagent/response.go
+++ b/pkg/packagedfactories/subagent/response.go
@@ -1,0 +1,54 @@
+package subagent
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+)
+
+// ShouldFormatInvocationResponse reports whether workstation output should be
+// shaped into packaged subagent response work content for terminal
+// primary-result selection.
+func ShouldFormatInvocationResponse(workstation *interfaces.FactoryWorkstationConfig) bool {
+	if workstation == nil {
+		return false
+	}
+	if strings.TrimSpace(workstation.Name) != PackagedRunWorkstationName {
+		return false
+	}
+	switch interfaces.EffectiveWorkstationTypeForCompatibility(*workstation) {
+	case interfaces.WorkstationTypeModel, interfaces.WorkstationTypeAgent:
+		return true
+	default:
+		return false
+	}
+}
+
+// ResponseContentFromWorkerOutput converts subagent worker output into canonical
+// text work content for invocation primary-result selection.
+func ResponseContentFromWorkerOutput(output, stopToken string) ([]interfaces.WorkContentPart, error) {
+	response := normalizeSubagentResponseText(output, stopToken)
+	if response == "" {
+		return nil, fmt.Errorf("subagent worker output is empty after normalization")
+	}
+	return []interfaces.WorkContentPart{{
+		Type: interfaces.WorkContentPartTypeText,
+		Text: response,
+	}}, nil
+}
+
+func normalizeSubagentResponseText(output, stopToken string) string {
+	trimmed := strings.TrimSpace(output)
+	stopToken = strings.TrimSpace(stopToken)
+	if stopToken == "" {
+		return trimmed
+	}
+	if strings.HasSuffix(trimmed, stopToken) {
+		return strings.TrimSpace(strings.TrimSuffix(trimmed, stopToken))
+	}
+	if idx := strings.LastIndex(trimmed, "\n"+stopToken); idx >= 0 {
+		return strings.TrimSpace(trimmed[:idx])
+	}
+	return trimmed
+}

--- a/pkg/packagedfactories/subagent/response_test.go
+++ b/pkg/packagedfactories/subagent/response_test.go
@@ -28,6 +28,19 @@ func TestShouldFormatInvocationResponse_RejectsUnrelatedWorkstations(t *testing.
 	}
 }
 
+func TestShouldFormatInvocationResponse_RejectsNilAndNonAgentTypes(t *testing.T) {
+	if ShouldFormatInvocationResponse(nil) {
+		t.Fatal("expected nil workstation to be rejected")
+	}
+	workstation := &interfaces.FactoryWorkstationConfig{
+		Name: PackagedRunWorkstationName,
+		Type: interfaces.WorkstationTypeLogical,
+	}
+	if ShouldFormatInvocationResponse(workstation) {
+		t.Fatal("expected logical workstation type to be rejected")
+	}
+}
+
 func TestResponseContentFromWorkerOutput_NormalizesStopToken(t *testing.T) {
 	content, err := ResponseContentFromWorkerOutput("mock worker accepted\nCOMPLETE", "COMPLETE")
 	if err != nil {
@@ -35,5 +48,31 @@ func TestResponseContentFromWorkerOutput_NormalizesStopToken(t *testing.T) {
 	}
 	if len(content) != 1 || content[0].Text != "mock worker accepted" {
 		t.Fatalf("content = %#v, want normalized agent response text", content)
+	}
+}
+
+func TestResponseContentFromWorkerOutput_PreservesTextWithoutStopToken(t *testing.T) {
+	content, err := ResponseContentFromWorkerOutput("  agent response  ", "")
+	if err != nil {
+		t.Fatalf("ResponseContentFromWorkerOutput: %v", err)
+	}
+	if len(content) != 1 || content[0].Text != "agent response" {
+		t.Fatalf("content = %#v, want trimmed response without stop token", content)
+	}
+}
+
+func TestResponseContentFromWorkerOutput_StripsNewlineStopToken(t *testing.T) {
+	content, err := ResponseContentFromWorkerOutput("agent response\nSTOP", "STOP")
+	if err != nil {
+		t.Fatalf("ResponseContentFromWorkerOutput: %v", err)
+	}
+	if len(content) != 1 || content[0].Text != "agent response" {
+		t.Fatalf("content = %#v, want response before newline stop token", content)
+	}
+}
+
+func TestResponseContentFromWorkerOutput_RejectsEmptyResponse(t *testing.T) {
+	if _, err := ResponseContentFromWorkerOutput("   \nSTOP", "STOP"); err == nil {
+		t.Fatal("expected empty normalized response to fail")
 	}
 }

--- a/pkg/packagedfactories/subagent/response_test.go
+++ b/pkg/packagedfactories/subagent/response_test.go
@@ -1,0 +1,39 @@
+package subagent
+
+import (
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+)
+
+func TestShouldFormatInvocationResponse_MatchesPackagedRunSubagentWorkstation(t *testing.T) {
+	workstation := &interfaces.FactoryWorkstationConfig{
+		Name:           PackagedRunWorkstationName,
+		Type:           interfaces.WorkstationTypeAgent,
+		WorkerTypeName: PackagedWorkerName,
+	}
+	if !ShouldFormatInvocationResponse(workstation) {
+		t.Fatal("expected packaged run-subagent workstation to format invocation response")
+	}
+}
+
+func TestShouldFormatInvocationResponse_RejectsUnrelatedWorkstations(t *testing.T) {
+	workstation := &interfaces.FactoryWorkstationConfig{
+		Name:           "other-workstation",
+		Type:           interfaces.WorkstationTypeAgent,
+		WorkerTypeName: PackagedWorkerName,
+	}
+	if ShouldFormatInvocationResponse(workstation) {
+		t.Fatal("expected unrelated workstation not to format invocation response")
+	}
+}
+
+func TestResponseContentFromWorkerOutput_NormalizesStopToken(t *testing.T) {
+	content, err := ResponseContentFromWorkerOutput("mock worker accepted\nCOMPLETE", "COMPLETE")
+	if err != nil {
+		t.Fatalf("ResponseContentFromWorkerOutput: %v", err)
+	}
+	if len(content) != 1 || content[0].Text != "mock worker accepted" {
+		t.Fatalf("content = %#v, want normalized agent response text", content)
+	}
+}


### PR DESCRIPTION
{
  "project": "you-goal-b07-subagent-factory",
  "branchName": "you-goal-b07-subagent-factory",
  "description": "Add the one-pass @you/subagent packaged factory with a single agent workstation that propagates request content and returns exactly one response via shared no-server named invocation, bootstrap, provider selection, permission policy, and primary-result contracts.",
  "context": {
    "customerAsk": "Add the one-pass @you/subagent packaged factory. Add one agent workstation that propagates request content and returns its response. Named invocation must work without a server and return exactly one response. Reuse shared bootstrap, provider selection, permission policy, and primary-result contract. Prove with packaged validation/materialization and no-server invocation tests (systematic-fix-plan.md S22).",
    "problem": "Customers need a first-party named factory that runs a single agent pass over the submitted request and returns that agent's response as the invocation result, but the packaged catalog has multi-stage or non-agent built-ins and no one-pass agent subagent factory for hermetic no-server named invocation.",
    "solution": "Add packaged @you/subagent with exactly one AGENT_WORKER and one AGENT_RUN workstation that propagates request content, completes with the agent response as the single primaryResult, registers in the packaged catalog with the same materialization and shared bootstrap/provider/permission/primary-result contracts, and prove with validation, materialization, and hermetic no-server named invocation tests."
  },
  "acceptanceCriteria": [
    "Named factory @you/subagent is resolvable from the packaged/built-in catalog and materializes to an editable on-disk factory layout",
    "Built-in topology has exactly one agent workstation that propagates submitted request content into the agent pass",
    "Successful named invocation returns exactly one primary response (the agent response), not multiple or empty primary results",
    "Named invocation completes without a listening HTTP server via the shared in-process bootstrap",
    "Shared provider selection, agent permission/agentTools policy, and primary-result contracts are reused (no parallel subagent-only invocation stack)",
    "Packaged validation/materialization and no-server invocation tests cover the above behaviors",
    "Quality checks pass (typecheck, lint, tests)"
  ],
  "userStories": [
    {
      "id": "you-goal-b07-subagent-factory-001",
      "title": "Author the one-pass validating subagent topology",
      "description": "As an operator, I want @you/subagent to be a small one-pass agent factory so a submitted request runs through one agent workstation and can complete with that workstation's response.",
      "acceptanceCriteria": [
        "Built-in @you/subagent defines a DEFAULT-handled work type with init (INITIAL), complete (TERMINAL), and failed (FAILED) states suitable for one-pass success/failure",
        "Built-in factory includes exactly one AGENT_WORKER and exactly one AGENT_RUN workstation that consumes work from init and routes accept to complete and failure to failed",
        "The agent workstation prompt/bindings propagate the submitted invocation request content into the agent pass (request text/content is visible to the worker, not dropped)",
        "The agent worker declares an explicit shared-style permission/agentTools policy (not an ad hoc subagent-only permissions path)",
        "Assembled built-in factory JSON loads and passes factory topology validation",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "you-goal-b07-subagent-factory-002",
      "title": "Register, materialize, and expose packaged @you/subagent",
      "description": "As an operator resolving named factories, I want @you/subagent registered in the packaged catalog so first use materializes an editable factory under the global named-factory root like other @you/* built-ins.",
      "acceptanceCriteria": [
        "Resolving named factory @you/subagent from empty project/global roots materializes the built-in into the global named-factory layout without requiring a pre-existing on-disk copy",
        "Materialized factory identity matches packaged constants (canonical name @you/subagent and a stable builtin project id such as builtin-subagent)",
        "Packagedfactories support for @you/subagent exposes identity/metadata needed by validation and materialization tests in the existing packaged-factories family pattern",
        "Packaged validation and materialization tests prove load/validate and materialize-edit-safe identity for @you/subagent",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "you-goal-b07-subagent-factory-003",
      "title": "Return exactly one response via no-server named invocation",
      "description": "As a customer running hermetic or headless one-shot work, I want you run --named @you/subagent to complete without a listening HTTP server and return exactly one primary response so the subagent result is immediately usable.",
      "acceptanceCriteria": [
        "Hermetic named invocation of @you/subagent completes successfully through the shared in-process no-server bootstrap (no listening HTTP API/dashboard server required)",
        "Successful invocation returns exactly one primaryResult containing the agent response for the completed work (not the raw submitted prompt alone, and not multiple primary results)",
        "Invocation reuses shared provider selection and primary-result selection contracts (same shared path used by other packaged named factories; no parallel subagent-only resolver)",
        "No-server invocation tests assert observable success: no listener requirement, exactly one primary response, shared bootstrap path",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}
