### PR TITLE
interfaces-b01-cli-logging-import-fix

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -29,6 +29,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/config/factoryrun"
 	"github.com/portpowered/infinite-you/pkg/config/operatorconfig"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/logging"
 	"github.com/spf13/cobra"
 )
 


### PR DESCRIPTION
{
  "project": "Restore missing logging import so CLI identity inventory tests compile",
  "branchName": "interfaces-b01-cli-logging-import-fix",
  "description": "Add the missing github.com/portpowered/infinite-you/pkg/logging import to pkg/cli/root.go so the existing models invoke logging.BuildLogger call compiles, restoring a compiling pkg/cli so interfaces B01 can re-verify the CLI command identity inventory against the committed baseline without changing public CLI behavior.",
  "context": {
    "customerAsk": "Restore a compiling pkg/cli on main so the interfaces B01 loopback can re-verify the CLI command identity inventory together with the already-green REST and MCP inventories. Add the missing import github.com/portpowered/infinite-you/pkg/logging to pkg/cli/root.go so the existing models invoke logging.BuildLogger call compiles. Keep the diff minimal; do not change models invoke behavior, diagnostics flags, walker logic, baseline fixtures, handlers, aliases, parsing, or help text unless a compile-only import fix is insufficient.",
    "problem": "After PR #1034 merged, pkg/cli/root.go calls logging.BuildLogger without importing github.com/portpowered/infinite-you/pkg/logging. go test ./pkg/cli/commandidentity/ fails at build with undefined: logging, blocking B01-CLI-COMMANDS re-verification even though the CLI baseline fixture is regenerated and REST/MCP B01 suites are green.",
    "solution": "Add the single missing pkg/logging import to pkg/cli/root.go so the already-authored logger wire-up compiles, then re-run commandidentity inventory tests against the committed cli-commands.json baseline. No intentional public CLI behavior change beyond restoring the logger wire-up that #1034 intended."
  },
  "acceptanceCriteria": [
    "go test ./pkg/cli/commandidentity/ -count=1 compiles and runs (no undefined: logging build failure)",
    "TestWalk_ProductionInventoryMatchesCommittedBaseline passes against the committed cli-commands.json on current main",
    "Non-baseline commandidentity coverage continues to pass (deterministic walk/marshal; immutable tree)",
    "No intentional public CLI behavior change beyond restoring the already-authored logger wire-up that #1034 intended",
    "Diff scope stays limited to the missing import (and at most a trivial compile-adjacent fix if required)",
    "Quality checks pass (typecheck, lint, tests)"
  ],
  "userStories": [
    {
      "id": "interfaces-b01-cli-logging-import-fix-001",
      "title": "Restore pkg/logging import in CLI root",
      "description": "As a maintainer running interfaces B01 loopback, I need pkg/cli/root.go to import github.com/portpowered/infinite-you/pkg/logging so the existing models invoke logging.BuildLogger call compiles and commandidentity inventory tests can execute against the committed baseline.",
      "acceptanceCriteria": [
        "pkg/cli/root.go imports github.com/portpowered/infinite-you/pkg/logging",
        "Models invoke command path still constructs its logger via logging.BuildLogger(diagnostics.verboseEnabled(), diagnostics.debug) and passes that logger into invoke config (restoring the #1034-intended wire-up, not inventing new logging behavior)",
        "go test ./pkg/cli/commandidentity/ -count=1 compiles and completes successfully",
        "TestWalk_ProductionInventoryMatchesCommittedBaseline passes against the committed cli-commands.json",
        "Non-baseline commandidentity tests in the same package continue to pass (deterministic walk/marshal; immutable tree)",
        "Diff does not change walker logic, baseline fixtures, handlers, aliases, parsing, help text, diagnostics flags, REST/MCP baselines, or Batch 02 / you-goal bootstrap redesign work",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    }
  ]
}
