### PR TITLE
interfaces-b01-cli-unused-logging-import-fix

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -29,7 +29,6 @@ import (
 	"github.com/portpowered/infinite-you/pkg/config/factoryrun"
 	"github.com/portpowered/infinite-you/pkg/config/operatorconfig"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
-	"github.com/portpowered/infinite-you/pkg/logging"
 	"github.com/spf13/cobra"
 )
 


### PR DESCRIPTION
{
  "project": "Remove Unused CLI Logging Import",
  "branchName": "interfaces-b01-cli-unused-logging-import-fix",
  "description": "Remove the unused pkg/logging import from pkg/cli/root.go so pkg/cli compiles and the interfaces B01 CLI command-identity inventory can re-verify on main, with no intentional public CLI behavior change.",
  "context": {
    "customerAsk": "Remove the unused github.com/portpowered/infinite-you/pkg/logging import from pkg/cli/root.go so pkg/cli compiles again and the interfaces B01 CLI command-identity inventory can re-verify on main. Keep the diff minimal: prefer a one-line unused-import removal. Do not change terminal-policy logger wiring, diagnostics flags, walker logic, baseline fixtures, handlers, aliases, parsing, or help text unless that one-line fix is insufficient.",
    "problem": "After #1039 restored logging wiring and #1038 switched models invoke / runFactory to terminalpolicy.Policy.BuildLogger, pkg/cli/root.go still imports pkg/logging but no longer uses it. go test ./pkg/cli/commandidentity/ -count=1 fails at build with imported and not used (pkg/logging). REST and MCP B01 inventories are already green; CLI inventory re-verification is blocked solely by this compile error.",
    "solution": "Delete the unused pkg/logging import from pkg/cli/root.go (and at most a trivial compile-adjacent fix if required). Confirm pkg/cli builds and the committed CLI command-identity baseline suite passes with no intentional public CLI behavior change."
  },
  "acceptanceCriteria": [
    "go test ./pkg/cli/commandidentity/ -count=1 compiles and runs",
    "TestWalk_ProductionInventoryMatchesCommittedBaseline passes against the committed cli-commands.json on current main",
    "Non-baseline commandidentity coverage continues to pass (deterministic walk/marshal; immutable tree)",
    "No intentional public CLI behavior change beyond removing the unused import left by #1038 atop #1039",
    "Diff scope stays limited to the unused import (and at most a trivial compile-adjacent fix if required)",
    "Quality checks pass (typecheck, lint, tests)"
  ],
  "userStories": [
    {
      "id": "interfaces-b01-cli-unused-logging-import-fix-001",
      "title": "Remove unused pkg/logging import from CLI root",
      "description": "As a maintainer running the interfaces B01 loopback, I need pkg/cli to compile so the CLI command-identity inventory suite can re-verify against the committed baseline without changing CLI behavior.",
      "acceptanceCriteria": [
        "github.com/portpowered/infinite-you/pkg/logging is no longer imported in pkg/cli/root.go",
        "Terminal-policy logger wiring (policy.BuildLogger() / related call sites) remains unchanged",
        "go test ./pkg/cli/commandidentity/ -count=1 compiles and exits successfully",
        "TestWalk_ProductionInventoryMatchesCommittedBaseline passes against committed cli-commands.json",
        "Non-baseline commandidentity tests (deterministic walk/marshal; immutable tree) continue to pass",
        "Diff does not modify walker logic, baseline fixtures, handlers, aliases, parsing, help text, REST/MCP baselines, or terminal-policy redesign surfaces",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    }
  ]
}
