### PR TITLE
stream-b01-canonical-event-vocabulary

### DIFF
--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -171,6 +171,12 @@ primary-result behavior.
   compaction/backlog/stream-gap text and token-usage chatter while JSON mode
   keeps `compaction` / `stream_gap` records. Internal stream listing for
   `pkg/service/runtime_sessions.go` alongside `SubscribeSessionResponseStream`.
+  Provider-neutral `FactoryResponseEvent` vocabulary lives in
+  `pkg/factorysessions/responseevents` (distinct from internal
+  `pkg/factorysessions/responsestream` fragment kinds). Package docs in
+  `responseevents/doc.go` record resolved v1 transport, retention, and CLI JSON
+  decisions without implementing transports; `responseevents/boundary_test.go`
+  enforces isolation from CLI, HTTP, subprocess, and provider imports.
   `responsestream.StreamSet.CloseDispatch` retains completed dispatch streams so
   late CLI pollers can still subscribe and drain retained progress until the
   completed-dispatch retention window expires; `runResponseStreamAttachment` in

--- a/pkg/factorysessions/responseevents/boundary_test.go
+++ b/pkg/factorysessions/responseevents/boundary_test.go
@@ -1,0 +1,38 @@
+package responseevents_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestPackageBoundary_DoesNotImportForbiddenTransportOrProviderPackages(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.Command(
+		"go",
+		"list",
+		"-deps",
+		"-f",
+		"{{if not .Standard}}{{.ImportPath}}{{end}}",
+		"github.com/portpowered/infinite-you/pkg/factorysessions/responseevents",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list deps: %v\n%s", err, output)
+	}
+
+	forbiddenRoots := []string{
+		"github.com/portpowered/infinite-you/pkg/cli",
+		"github.com/portpowered/infinite-you/pkg/workers",
+		"net/http",
+		"os/exec",
+	}
+	for _, dep := range strings.Fields(string(output)) {
+		for _, forbidden := range forbiddenRoots {
+			if dep == forbidden || strings.HasPrefix(dep, forbidden+"/") {
+				t.Fatalf("pkg/factorysessions/responseevents must not import %s; found dependency %s", forbidden, dep)
+			}
+		}
+	}
+}

--- a/pkg/factorysessions/responseevents/capabilities.go
+++ b/pkg/factorysessions/responseevents/capabilities.go
@@ -1,0 +1,18 @@
+package responseevents
+
+// Capabilities declares which response-event features a provider session supports.
+// Adapters publish capability flags so consumers can interpret fidelity and phase
+// availability without depending on provider-native schemas.
+type Capabilities struct {
+	NativeStreaming    bool `json:"nativeStreaming"`
+	MessageDeltas      bool `json:"messageDeltas"`
+	MessageSnapshots   bool `json:"messageSnapshots"`
+	ReasoningSummaries bool `json:"reasoningSummaries"`
+	ToolLifecycle      bool `json:"toolLifecycle"`
+	ToolOutputDeltas   bool `json:"toolOutputDeltas"`
+	FileChanges        bool `json:"fileChanges"`
+	Plans              bool `json:"plans"`
+	Usage              bool `json:"usage"`
+	StableItemIDs      bool `json:"stableItemIds"`
+	ProviderReconnect  bool `json:"providerReconnect"`
+}

--- a/pkg/factorysessions/responseevents/doc.go
+++ b/pkg/factorysessions/responseevents/doc.go
@@ -3,6 +3,7 @@
 //
 // These records are intentionally separate from factoryapi.FactoryEvent and must
 // not be projected into canonical factory replay. Later transports, adapters,
-// and consumers share this envelope, kind, phase, provenance, and payload
-// contract without depending on provider-native schemas.
+// and consumers share this envelope, kind, phase, provenance, typed payload,
+// capability, and validation contract without depending on provider-native
+// schemas. Use ValidateEvent to reject invalid kind/phase/payload combinations.
 package responseevents

--- a/pkg/factorysessions/responseevents/doc.go
+++ b/pkg/factorysessions/responseevents/doc.go
@@ -1,9 +1,59 @@
 // Package responseevents defines the provider-neutral FactoryResponseEvent
 // vocabulary for transient agent activity observed during a Factory Session.
 //
-// These records are intentionally separate from factoryapi.FactoryEvent and must
-// not be projected into canonical factory replay. Later transports, adapters,
-// and consumers share this envelope, kind, phase, provenance, typed payload,
-// capability, and validation contract without depending on provider-native
-// schemas. Use ValidateEvent to reject invalid kind/phase/payload combinations.
+// # Ephemeral observation records
+//
+// FactoryResponseEvent records are ephemeral observation data. They capture
+// provider-neutral agent activity while a session is live or recently active.
+// They must not be projected into canonical factory replay and must not be used
+// to derive canonical work state after replay. Canonical lifecycle, dispatch,
+// and work outcomes remain owned by factoryapi.FactoryEvent and its projections.
+//
+// # Resolved public contract decisions (v1, documentation only)
+//
+// Later transport, storage, SSE, CLI, and adapter lanes implement these
+// decisions; this package owns the vocabulary types and validation only.
+//
+// Public HTTP endpoint:
+//
+//	GET /factory-sessions/{session_id}/response-events
+//
+// SSE reconnect cursor:
+//
+//	Clients resume with the after_sequence query parameter using
+//	FactoryResponseEvent.sequence as the monotonic session-scoped cursor.
+//
+// v1 retention:
+//
+//	Session-wide retention with global limits and snapshot priority when
+//	compaction is required. MESSAGE and TOOL snapshots are preferred over
+//	high-volume deltas when retention pressure forces drops.
+//
+// CLI response-stream JSON:
+//
+//	The you run --output response-stream JSON schema evolves in place on
+//	agent-factory.response-event.v1 without a temporary --response-stream-version
+//	flag.
+//
+// Tool argument and result publication:
+//
+//	Defaults to bounded redacted structured summaries (ToolPayload.argumentsSummary
+//	and ToolPayload.resultSummary) rather than raw provider protocol payloads.
+//
+// Service restart:
+//
+//	v1 does not imply durable replay of response events across service restart.
+//	Consumers treat the stream as live-session observation, not canonical history.
+//
+// # Vocabulary surface
+//
+// The envelope carries schemaVersion, eventId, sequence, recordedAt,
+// factorySessionId, runId, kind, phase, provenance, payload, and optional
+// correlation fields. ValidateEvent rejects invalid kind/phase/payload
+// combinations before publication. Raw provider payloads and internal compaction
+// types are not part of this public surface.
+//
+// # Isolation
+//
+// This package does not import CLI, HTTP, subprocess, or provider packages.
 package responseevents

--- a/pkg/factorysessions/responseevents/doc.go
+++ b/pkg/factorysessions/responseevents/doc.go
@@ -1,0 +1,8 @@
+// Package responseevents defines the provider-neutral FactoryResponseEvent
+// vocabulary for transient agent activity observed during a Factory Session.
+//
+// These records are intentionally separate from factoryapi.FactoryEvent and must
+// not be projected into canonical factory replay. Later transports, adapters,
+// and consumers share this envelope, kind, phase, provenance, and payload
+// contract without depending on provider-native schemas.
+package responseevents

--- a/pkg/factorysessions/responseevents/envelope.go
+++ b/pkg/factorysessions/responseevents/envelope.go
@@ -1,0 +1,29 @@
+package responseevents
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// FactoryResponseEvent is the provider-neutral envelope for transient agent
+// activity observed during one Factory Session run. Unlike canonical factory
+// events, these records are ephemeral observation records and must not derive
+// canonical work state after replay.
+type FactoryResponseEvent struct {
+	SchemaVersion    string          `json:"schemaVersion"`
+	EventID          string          `json:"eventId"`
+	Sequence         int64           `json:"sequence"`
+	RecordedAt       time.Time       `json:"recordedAt"`
+	FactorySessionID string          `json:"factorySessionId"`
+	RunID            string          `json:"runId"`
+	Kind             Kind            `json:"kind"`
+	Phase            Phase           `json:"phase"`
+	Provenance       Provenance      `json:"provenance"`
+	Payload          json.RawMessage `json:"payload"`
+
+	DispatchID         string `json:"dispatchId,omitempty"`
+	TurnID             string `json:"turnId,omitempty"`
+	ItemID             string `json:"itemId,omitempty"`
+	ParentItemID       string `json:"parentItemId,omitempty"`
+	ProviderSessionRef string `json:"providerSessionRef,omitempty"`
+}

--- a/pkg/factorysessions/responseevents/envelope_test.go
+++ b/pkg/factorysessions/responseevents/envelope_test.go
@@ -1,0 +1,171 @@
+package responseevents_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/pkg/factorysessions/responseevents"
+)
+
+func TestFactoryResponseEvent_MarshalEmitsDeclaredEnumStrings(t *testing.T) {
+	t.Parallel()
+
+	recordedAt := time.Date(2026, 7, 12, 23, 4, 5, 0, time.UTC)
+	event := responseevents.FactoryResponseEvent{
+		SchemaVersion:    responseevents.SchemaVersionV1,
+		EventID:          "evt-001",
+		Sequence:         7,
+		RecordedAt:       recordedAt,
+		FactorySessionID: "session-abc",
+		RunID:            "run-xyz",
+		Kind:             responseevents.KindMessage,
+		Phase:            responseevents.PhaseDelta,
+		Provenance: responseevents.Provenance{
+			Provider:        "example-provider",
+			NativeEventType: "response.output_text.delta",
+			Delivery:        responseevents.DeliveryNativeStream,
+			Representation:  responseevents.RepresentationDelta,
+			Fidelity:        responseevents.FidelityLossless,
+		},
+		Payload:            json.RawMessage(`{"text":"hello"}`),
+		DispatchID:         "dispatch-1",
+		TurnID:             "turn-1",
+		ItemID:             "item-1",
+		ParentItemID:       "parent-item-0",
+		ProviderSessionRef: "provider-session-ref-1",
+	}
+
+	payload, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+
+	encoded := string(payload)
+	for _, want := range []string{
+		`"schemaVersion":"agent-factory.response-event.v1"`,
+		`"eventId":"evt-001"`,
+		`"sequence":7`,
+		`"factorySessionId":"session-abc"`,
+		`"runId":"run-xyz"`,
+		`"kind":"MESSAGE"`,
+		`"phase":"DELTA"`,
+		`"delivery":"NATIVE_STREAM"`,
+		`"representation":"DELTA"`,
+		`"fidelity":"LOSSLESS"`,
+		`"dispatchId":"dispatch-1"`,
+		`"turnId":"turn-1"`,
+		`"itemId":"item-1"`,
+		`"parentItemId":"parent-item-0"`,
+		`"providerSessionRef":"provider-session-ref-1"`,
+	} {
+		if !strings.Contains(encoded, want) {
+			t.Fatalf("marshaled envelope missing %q in %s", want, encoded)
+		}
+	}
+}
+
+func TestDeclaredKindsAndPhasesAreDistinctFromLegacyFragmentKinds(t *testing.T) {
+	t.Parallel()
+
+	legacyKinds := []string{
+		"PROGRESS_FRAGMENT",
+		"RESPONSE_FRAGMENT",
+		"STREAM_COMPLETED",
+		"STREAM_FAILED",
+		"STREAM_COMPACTION_SIGNAL",
+	}
+	declaredKinds := []responseevents.Kind{
+		responseevents.KindSession,
+		responseevents.KindRun,
+		responseevents.KindTurn,
+		responseevents.KindMessage,
+		responseevents.KindReasoning,
+		responseevents.KindTool,
+		responseevents.KindFileChange,
+		responseevents.KindPlan,
+		responseevents.KindProgress,
+		responseevents.KindUsage,
+		responseevents.KindError,
+		responseevents.KindStreamGap,
+	}
+	for _, kind := range declaredKinds {
+		for _, legacy := range legacyKinds {
+			if string(kind) == legacy {
+				t.Fatalf("declared kind %q must not alias legacy fragment kind %q", kind, legacy)
+			}
+		}
+	}
+
+	declaredPhases := []responseevents.Phase{
+		responseevents.PhaseStarted,
+		responseevents.PhaseDelta,
+		responseevents.PhaseUpdated,
+		responseevents.PhaseCompleted,
+		responseevents.PhaseFailed,
+		responseevents.PhaseCanceled,
+	}
+	seen := make(map[responseevents.Phase]struct{}, len(declaredPhases))
+	for _, phase := range declaredPhases {
+		if _, ok := seen[phase]; ok {
+			t.Fatalf("duplicate declared phase %q", phase)
+		}
+		seen[phase] = struct{}{}
+	}
+}
+
+func TestProvenanceEnumsMarshalToDeclaredStrings(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body any
+		want string
+	}{
+		{
+			name: "delivery",
+			body: responseevents.DeliveryNativeFinal,
+			want: `"NATIVE_FINAL"`,
+		},
+		{
+			name: "representation snapshot",
+			body: responseevents.RepresentationSnapshot,
+			want: `"SNAPSHOT"`,
+		},
+		{
+			name: "representation notification",
+			body: responseevents.RepresentationNotification,
+			want: `"NOTIFICATION"`,
+		},
+		{
+			name: "fidelity normalized",
+			body: responseevents.FidelityNormalized,
+			want: `"NORMALIZED"`,
+		},
+		{
+			name: "fidelity final only",
+			body: responseevents.FidelityFinalOnly,
+			want: `"FINAL_ONLY"`,
+		},
+		{
+			name: "fidelity lifecycle only",
+			body: responseevents.FidelityLifecycleOnly,
+			want: `"LIFECYCLE_ONLY"`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			payload, err := json.Marshal(tc.body)
+			if err != nil {
+				t.Fatalf("marshal %s: %v", tc.name, err)
+			}
+			if string(payload) != tc.want {
+				t.Fatalf("marshal %s = %s, want %s", tc.name, payload, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/factorysessions/responseevents/fixtures_test.go
+++ b/pkg/factorysessions/responseevents/fixtures_test.go
@@ -1,0 +1,156 @@
+package responseevents_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/factorysessions/responseevents"
+)
+
+var responseEventFixtures = []struct {
+	name string
+}{
+	{name: "text_delta"},
+	{name: "message_snapshot"},
+	{name: "tool_lifecycle"},
+	{name: "retry"},
+	{name: "final_only_message"},
+	{name: "usage"},
+	{name: "stream_gap"},
+}
+
+func TestFixtureRoundTrip_PreservesDeclaredFields(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range responseEventFixtures {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			event := loadFixtureEvent(t, tc.name)
+			if err := responseevents.ValidateEvent(event); err != nil {
+				t.Fatalf("ValidateEvent() error = %v", err)
+			}
+
+			remarshaled, err := json.Marshal(event)
+			if err != nil {
+				t.Fatalf("json.Marshal() error = %v", err)
+			}
+
+			var roundTripped responseevents.FactoryResponseEvent
+			if err := json.Unmarshal(remarshaled, &roundTripped); err != nil {
+				t.Fatalf("json.Unmarshal(remarshaled) error = %v", err)
+			}
+
+			assertEventsSemanticallyEqual(t, event, roundTripped)
+		})
+	}
+}
+
+func TestFixtureRoundTrip_MarshalIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range responseEventFixtures {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			event := loadFixtureEvent(t, tc.name)
+
+			first, err := json.Marshal(event)
+			if err != nil {
+				t.Fatalf("first json.Marshal() error = %v", err)
+			}
+			second, err := json.Marshal(event)
+			if err != nil {
+				t.Fatalf("second json.Marshal() error = %v", err)
+			}
+			if !bytes.Equal(first, second) {
+				t.Fatalf("marshal is not deterministic:\nfirst=%s\nsecond=%s", first, second)
+			}
+		})
+	}
+}
+
+func TestFixtures_ContainNoProviderNativeProtocolFields(t *testing.T) {
+	t.Parallel()
+
+	forbidden := []string{
+		"openai",
+		"anthropic",
+		"cursor",
+		"compaction",
+		"rawProvider",
+		"providerPayload",
+	}
+	for _, tc := range responseEventFixtures {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw := readFixtureBytes(t, tc.name)
+			lower := strings.ToLower(string(raw))
+			for _, needle := range forbidden {
+				if strings.Contains(lower, needle) {
+					t.Fatalf("fixture %q contains forbidden provider-native marker %q", tc.name, needle)
+				}
+			}
+		})
+	}
+}
+
+func loadFixtureEvent(t *testing.T, name string) responseevents.FactoryResponseEvent {
+	t.Helper()
+
+	raw := readFixtureBytes(t, name)
+	var event responseevents.FactoryResponseEvent
+	if err := json.Unmarshal(raw, &event); err != nil {
+		t.Fatalf("json.Unmarshal(%s) error = %v", name, err)
+	}
+	return event
+}
+
+func readFixtureBytes(t *testing.T, name string) []byte {
+	t.Helper()
+
+	fixturePath := filepath.Join("testdata", "fixtures", name+".json")
+	raw, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("read fixture %q: %v", fixturePath, err)
+	}
+	return raw
+}
+
+func assertEventsSemanticallyEqual(t *testing.T, want, got responseevents.FactoryResponseEvent) {
+	t.Helper()
+
+	if !jsonValuesEqual(want.Payload, got.Payload) {
+		t.Fatalf("payload semantic mismatch:\nwant=%s\ngot=%s", want.Payload, got.Payload)
+	}
+
+	want.Payload = nil
+	got.Payload = nil
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("envelope field mismatch:\nwant=%#v\ngot=%#v", want, got)
+	}
+}
+
+func jsonValuesEqual(left, right json.RawMessage) bool {
+	if len(left) == 0 && len(right) == 0 {
+		return true
+	}
+	var leftValue any
+	var rightValue any
+	if err := json.Unmarshal(left, &leftValue); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(right, &rightValue); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(leftValue, rightValue)
+}

--- a/pkg/factorysessions/responseevents/kind.go
+++ b/pkg/factorysessions/responseevents/kind.go
@@ -1,0 +1,19 @@
+package responseevents
+
+// Kind identifies the semantic category of one FactoryResponseEvent.
+type Kind string
+
+const (
+	KindSession    Kind = "SESSION"
+	KindRun        Kind = "RUN"
+	KindTurn       Kind = "TURN"
+	KindMessage    Kind = "MESSAGE"
+	KindReasoning  Kind = "REASONING"
+	KindTool       Kind = "TOOL"
+	KindFileChange Kind = "FILE_CHANGE"
+	KindPlan       Kind = "PLAN"
+	KindProgress   Kind = "PROGRESS"
+	KindUsage      Kind = "USAGE"
+	KindError      Kind = "ERROR"
+	KindStreamGap  Kind = "STREAM_GAP"
+)

--- a/pkg/factorysessions/responseevents/payload.go
+++ b/pkg/factorysessions/responseevents/payload.go
@@ -1,0 +1,129 @@
+package responseevents
+
+import "encoding/json"
+
+// ContentBlockKind identifies one provider-neutral message content block.
+type ContentBlockKind string
+
+const (
+	ContentBlockText              ContentBlockKind = "TEXT"
+	ContentBlockReasoningSummary  ContentBlockKind = "REASONING_SUMMARY"
+	ContentBlockToolRequest       ContentBlockKind = "TOOL_REQUEST"
+	ContentBlockImageRef          ContentBlockKind = "IMAGE_REF"
+	ContentBlockResourceRef       ContentBlockKind = "RESOURCE_REF"
+	ContentBlockStructuredOutput  ContentBlockKind = "STRUCTURED_OUTPUT"
+)
+
+// ContentBlock carries one typed slice of assistant-visible message content.
+type ContentBlock struct {
+	Kind               ContentBlockKind `json:"kind"`
+	Text               string           `json:"text,omitempty"`
+	ToolCallID         string           `json:"toolCallId,omitempty"`
+	ToolName           string           `json:"toolName,omitempty"`
+	ArgumentsSummary   json.RawMessage  `json:"argumentsSummary,omitempty"`
+	ImageRef           string           `json:"imageRef,omitempty"`
+	ResourceRef        string           `json:"resourceRef,omitempty"`
+	StructuredOutput   json.RawMessage  `json:"structuredOutput,omitempty"`
+}
+
+// SessionPayload records session-scoped lifecycle and capability metadata.
+type SessionPayload struct {
+	Status       string        `json:"status,omitempty"`
+	Capabilities *Capabilities `json:"capabilities,omitempty"`
+}
+
+// RunPayload records run-scoped lifecycle metadata.
+type RunPayload struct {
+	Status string `json:"status,omitempty"`
+}
+
+// TurnPayload records turn-scoped lifecycle metadata.
+type TurnPayload struct {
+	TurnIndex int    `json:"turnIndex,omitempty"`
+	Status    string `json:"status,omitempty"`
+}
+
+// MessagePayload carries a message snapshot with typed content blocks.
+type MessagePayload struct {
+	Role          string         `json:"role"`
+	ContentBlocks []ContentBlock `json:"contentBlocks"`
+}
+
+// MessageDeltaPayload carries incremental message content for one block.
+type MessageDeltaPayload struct {
+	ContentBlockIndex int              `json:"contentBlockIndex"`
+	ContentBlockKind  ContentBlockKind `json:"contentBlockKind"`
+	TextDelta         string           `json:"textDelta,omitempty"`
+}
+
+// ReasoningPayload carries reasoning summary content or deltas.
+type ReasoningPayload struct {
+	Summary      string `json:"summary,omitempty"`
+	SummaryDelta string `json:"summaryDelta,omitempty"`
+}
+
+// ToolPayload carries tool lifecycle metadata and bounded summaries.
+type ToolPayload struct {
+	ToolCallID         string          `json:"toolCallId"`
+	ToolName           string          `json:"toolName"`
+	Status             string          `json:"status,omitempty"`
+	ArgumentsSummary   json.RawMessage `json:"argumentsSummary,omitempty"`
+	ResultSummary      json.RawMessage `json:"resultSummary,omitempty"`
+}
+
+// ToolDeltaPayload carries incremental tool output.
+type ToolDeltaPayload struct {
+	ToolCallID  string `json:"toolCallId"`
+	OutputDelta string `json:"outputDelta"`
+}
+
+// FileChangePayload records one observed file mutation.
+type FileChangePayload struct {
+	Path      string `json:"path"`
+	Operation string `json:"operation"`
+	Summary   string `json:"summary,omitempty"`
+}
+
+// PlanStep records one step in a published plan snapshot.
+type PlanStep struct {
+	ID          string `json:"id"`
+	Description string `json:"description"`
+	Status      string `json:"status,omitempty"`
+}
+
+// PlanPayload carries a plan update snapshot.
+type PlanPayload struct {
+	Steps   []PlanStep `json:"steps,omitempty"`
+	Summary string     `json:"summary,omitempty"`
+}
+
+// ProgressPayload carries a coarse progress notification.
+type ProgressPayload struct {
+	Label           string   `json:"label"`
+	Message         string   `json:"message,omitempty"`
+	PercentComplete *float64 `json:"percentComplete,omitempty"`
+}
+
+// UsagePayload carries token or model usage accounting.
+type UsagePayload struct {
+	InputTokens  int64  `json:"inputTokens,omitempty"`
+	OutputTokens int64  `json:"outputTokens,omitempty"`
+	TotalTokens  int64  `json:"totalTokens,omitempty"`
+	Model        string `json:"model,omitempty"`
+}
+
+// ErrorPayload carries a provider-neutral error with optional retry metadata.
+type ErrorPayload struct {
+	Code              string `json:"code"`
+	Message           string `json:"message"`
+	Retryable         bool   `json:"retryable,omitempty"`
+	RetryAfterSeconds *int64 `json:"retryAfterSeconds,omitempty"`
+	RetryAttempt      *int   `json:"retryAttempt,omitempty"`
+}
+
+// StreamGapPayload records a discontinuity in the retained response-event stream.
+type StreamGapPayload struct {
+	FromSequence int64  `json:"fromSequence"`
+	ToSequence   int64  `json:"toSequence"`
+	Reason       string `json:"reason,omitempty"`
+}

--- a/pkg/factorysessions/responseevents/phase.go
+++ b/pkg/factorysessions/responseevents/phase.go
@@ -1,0 +1,13 @@
+package responseevents
+
+// Phase identifies the lifecycle position of one FactoryResponseEvent within its kind.
+type Phase string
+
+const (
+	PhaseStarted   Phase = "STARTED"
+	PhaseDelta     Phase = "DELTA"
+	PhaseUpdated   Phase = "UPDATED"
+	PhaseCompleted Phase = "COMPLETED"
+	PhaseFailed    Phase = "FAILED"
+	PhaseCanceled  Phase = "CANCELED"
+)

--- a/pkg/factorysessions/responseevents/provenance.go
+++ b/pkg/factorysessions/responseevents/provenance.go
@@ -1,0 +1,43 @@
+package responseevents
+
+// Delivery describes how the response event entered the Factory vocabulary.
+type Delivery string
+
+const (
+	DeliveryNativeStream Delivery = "NATIVE_STREAM"
+	DeliveryNativeFinal  Delivery = "NATIVE_FINAL"
+	DeliverySynthesized  Delivery = "SYNTHESIZED"
+	DeliveryReplay         Delivery = "REPLAY"
+)
+
+// Representation describes the shape fidelity model used for the public payload.
+type Representation string
+
+const (
+	RepresentationDelta         Representation = "DELTA"
+	RepresentationSnapshot      Representation = "SNAPSHOT"
+	RepresentationNotification  Representation = "NOTIFICATION"
+)
+
+// Fidelity describes how closely the public payload preserves provider detail.
+type Fidelity string
+
+const (
+	FidelityLossless       Fidelity = "LOSSLESS"
+	FidelityNormalized     Fidelity = "NORMALIZED"
+	FidelityLossy          Fidelity = "LOSSY"
+	FidelityFinalOnly      Fidelity = "FINAL_ONLY"
+	FidelityLifecycleOnly  Fidelity = "LIFECYCLE_ONLY"
+)
+
+// Provenance records provider-neutral fidelity metadata for one response event.
+// It exposes diagnostic identity without promoting provider-native schemas into
+// the public vocabulary.
+type Provenance struct {
+	Provider           string         `json:"provider"`
+	NativeEventType    string         `json:"nativeEventType"`
+	NativeEventSubtype string         `json:"nativeEventSubtype,omitempty"`
+	Delivery           Delivery       `json:"delivery"`
+	Representation     Representation `json:"representation"`
+	Fidelity           Fidelity       `json:"fidelity"`
+}

--- a/pkg/factorysessions/responseevents/schema.go
+++ b/pkg/factorysessions/responseevents/schema.go
@@ -1,0 +1,4 @@
+package responseevents
+
+// SchemaVersionV1 is the schema version string for FactoryResponseEvent v1.
+const SchemaVersionV1 = "agent-factory.response-event.v1"

--- a/pkg/factorysessions/responseevents/testdata/fixtures/final_only_message.json
+++ b/pkg/factorysessions/responseevents/testdata/fixtures/final_only_message.json
@@ -1,0 +1,29 @@
+{
+  "schemaVersion": "agent-factory.response-event.v1",
+  "eventId": "evt-final-only-message-001",
+  "sequence": 46,
+  "recordedAt": "2026-07-13T12:00:04Z",
+  "factorySessionId": "session-fixture-001",
+  "runId": "run-fixture-001",
+  "kind": "MESSAGE",
+  "phase": "COMPLETED",
+  "provenance": {
+    "provider": "example-provider",
+    "nativeEventType": "message.final",
+    "delivery": "NATIVE_FINAL",
+    "representation": "SNAPSHOT",
+    "fidelity": "FINAL_ONLY"
+  },
+  "payload": {
+    "role": "assistant",
+    "contentBlocks": [
+      {
+        "kind": "TEXT",
+        "text": "Final answer delivered without intermediate streaming."
+      }
+    ]
+  },
+  "dispatchId": "dispatch-001",
+  "turnId": "turn-001",
+  "itemId": "item-msg-final-001"
+}

--- a/pkg/factorysessions/responseevents/testdata/fixtures/message_snapshot.json
+++ b/pkg/factorysessions/responseevents/testdata/fixtures/message_snapshot.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "agent-factory.response-event.v1",
+  "eventId": "evt-message-snapshot-001",
+  "sequence": 43,
+  "recordedAt": "2026-07-13T12:00:01Z",
+  "factorySessionId": "session-fixture-001",
+  "runId": "run-fixture-001",
+  "kind": "MESSAGE",
+  "phase": "COMPLETED",
+  "provenance": {
+    "provider": "example-provider",
+    "nativeEventType": "message.completed",
+    "delivery": "NATIVE_STREAM",
+    "representation": "SNAPSHOT",
+    "fidelity": "LOSSLESS"
+  },
+  "payload": {
+    "role": "assistant",
+    "contentBlocks": [
+      {
+        "kind": "TEXT",
+        "text": "Here is the completed assistant message."
+      },
+      {
+        "kind": "TOOL_REQUEST",
+        "toolCallId": "call-search-001",
+        "toolName": "search",
+        "argumentsSummary": {
+          "query": "factory response events"
+        }
+      }
+    ]
+  },
+  "dispatchId": "dispatch-001",
+  "turnId": "turn-001",
+  "itemId": "item-msg-002",
+  "parentItemId": "item-msg-001"
+}

--- a/pkg/factorysessions/responseevents/testdata/fixtures/retry.json
+++ b/pkg/factorysessions/responseevents/testdata/fixtures/retry.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "agent-factory.response-event.v1",
+  "eventId": "evt-retry-001",
+  "sequence": 45,
+  "recordedAt": "2026-07-13T12:00:03Z",
+  "factorySessionId": "session-fixture-001",
+  "runId": "run-fixture-001",
+  "kind": "ERROR",
+  "phase": "UPDATED",
+  "provenance": {
+    "provider": "example-provider",
+    "nativeEventType": "error.retryable",
+    "delivery": "SYNTHESIZED",
+    "representation": "NOTIFICATION",
+    "fidelity": "NORMALIZED"
+  },
+  "payload": {
+    "code": "rate_limited",
+    "message": "Provider rate limit exceeded; retrying",
+    "retryable": true,
+    "retryAfterSeconds": 30,
+    "retryAttempt": 2
+  },
+  "dispatchId": "dispatch-001",
+  "turnId": "turn-001"
+}

--- a/pkg/factorysessions/responseevents/testdata/fixtures/stream_gap.json
+++ b/pkg/factorysessions/responseevents/testdata/fixtures/stream_gap.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": "agent-factory.response-event.v1",
+  "eventId": "evt-stream-gap-001",
+  "sequence": 48,
+  "recordedAt": "2026-07-13T12:00:06Z",
+  "factorySessionId": "session-fixture-001",
+  "runId": "run-fixture-001",
+  "kind": "STREAM_GAP",
+  "phase": "UPDATED",
+  "provenance": {
+    "provider": "example-provider",
+    "nativeEventType": "stream.gap",
+    "delivery": "SYNTHESIZED",
+    "representation": "NOTIFICATION",
+    "fidelity": "LOSSY"
+  },
+  "payload": {
+    "fromSequence": 100,
+    "toSequence": 150,
+    "reason": "retention_window"
+  }
+}

--- a/pkg/factorysessions/responseevents/testdata/fixtures/text_delta.json
+++ b/pkg/factorysessions/responseevents/testdata/fixtures/text_delta.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "agent-factory.response-event.v1",
+  "eventId": "evt-text-delta-001",
+  "sequence": 42,
+  "recordedAt": "2026-07-13T12:00:00Z",
+  "factorySessionId": "session-fixture-001",
+  "runId": "run-fixture-001",
+  "kind": "MESSAGE",
+  "phase": "DELTA",
+  "provenance": {
+    "provider": "example-provider",
+    "nativeEventType": "message.delta",
+    "delivery": "NATIVE_STREAM",
+    "representation": "DELTA",
+    "fidelity": "LOSSLESS"
+  },
+  "payload": {
+    "contentBlockIndex": 0,
+    "contentBlockKind": "TEXT",
+    "textDelta": "Hello"
+  },
+  "dispatchId": "dispatch-001",
+  "turnId": "turn-001",
+  "itemId": "item-msg-001",
+  "providerSessionRef": "provider-session-001"
+}

--- a/pkg/factorysessions/responseevents/testdata/fixtures/tool_lifecycle.json
+++ b/pkg/factorysessions/responseevents/testdata/fixtures/tool_lifecycle.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": "agent-factory.response-event.v1",
+  "eventId": "evt-tool-lifecycle-001",
+  "sequence": 44,
+  "recordedAt": "2026-07-13T12:00:02Z",
+  "factorySessionId": "session-fixture-001",
+  "runId": "run-fixture-001",
+  "kind": "TOOL",
+  "phase": "STARTED",
+  "provenance": {
+    "provider": "example-provider",
+    "nativeEventType": "tool.started",
+    "delivery": "NATIVE_STREAM",
+    "representation": "NOTIFICATION",
+    "fidelity": "LIFECYCLE_ONLY"
+  },
+  "payload": {
+    "toolCallId": "call-read-001",
+    "toolName": "read_file",
+    "status": "started",
+    "argumentsSummary": {
+      "path": "README.md"
+    }
+  },
+  "dispatchId": "dispatch-001",
+  "turnId": "turn-001",
+  "itemId": "item-tool-001"
+}

--- a/pkg/factorysessions/responseevents/testdata/fixtures/usage.json
+++ b/pkg/factorysessions/responseevents/testdata/fixtures/usage.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": "agent-factory.response-event.v1",
+  "eventId": "evt-usage-001",
+  "sequence": 47,
+  "recordedAt": "2026-07-13T12:00:05Z",
+  "factorySessionId": "session-fixture-001",
+  "runId": "run-fixture-001",
+  "kind": "USAGE",
+  "phase": "UPDATED",
+  "provenance": {
+    "provider": "example-provider",
+    "nativeEventType": "usage.updated",
+    "delivery": "NATIVE_FINAL",
+    "representation": "NOTIFICATION",
+    "fidelity": "LOSSLESS"
+  },
+  "payload": {
+    "inputTokens": 1024,
+    "outputTokens": 256,
+    "totalTokens": 1280,
+    "model": "example-model-v1"
+  },
+  "dispatchId": "dispatch-001"
+}

--- a/pkg/factorysessions/responseevents/validation.go
+++ b/pkg/factorysessions/responseevents/validation.go
@@ -76,122 +76,144 @@ func validateKindPhase(kind Kind, phase Phase) error {
 }
 
 func validatePayload(kind Kind, phase Phase, payload json.RawMessage) error {
+	if err := validatePayloadBasics(kind, payload); err != nil {
+		return err
+	}
+
+	switch kind {
+	case KindSession:
+		var body SessionPayload
+		return decodePayload(payload, &body, "SessionPayload")
+	case KindRun:
+		var body RunPayload
+		return decodePayload(payload, &body, "RunPayload")
+	case KindTurn:
+		var body TurnPayload
+		return decodePayload(payload, &body, "TurnPayload")
+	case KindMessage:
+		return validateMessageKindPayload(phase, payload)
+	case KindReasoning:
+		var body ReasoningPayload
+		return decodePayload(payload, &body, "ReasoningPayload")
+	case KindTool:
+		return validateToolKindPayload(phase, payload)
+	case KindFileChange:
+		return validateFileChangeKindPayload(payload)
+	case KindPlan:
+		var body PlanPayload
+		return decodePayload(payload, &body, "PlanPayload")
+	case KindProgress:
+		return validateProgressKindPayload(payload)
+	case KindUsage:
+		var body UsagePayload
+		return decodePayload(payload, &body, "UsagePayload")
+	case KindError:
+		return validateErrorKindPayload(payload)
+	case KindStreamGap:
+		return validateStreamGapKindPayload(payload)
+	default:
+		return validationError("kind", fmt.Sprintf("kind %q has no declared payload validator", kind))
+	}
+}
+
+func validatePayloadBasics(kind Kind, payload json.RawMessage) error {
 	if len(payload) == 0 {
 		return validationError("payload", fmt.Sprintf("payload is required for kind %q", kind))
 	}
 	if !json.Valid(payload) {
 		return validationError("payload", "payload must contain valid JSON")
 	}
+	return nil
+}
 
-	switch kind {
-	case KindSession:
-		var body SessionPayload
-		if err := decodePayload(payload, &body, "SessionPayload"); err != nil {
+func validateMessageKindPayload(phase Phase, payload json.RawMessage) error {
+	if phase == PhaseDelta {
+		if err := rejectPayloadKeys(payload, "MessageDeltaPayload", "role", "contentBlocks"); err != nil {
 			return err
 		}
-	case KindRun:
-		var body RunPayload
-		if err := decodePayload(payload, &body, "RunPayload"); err != nil {
+		var body MessageDeltaPayload
+		if err := decodePayload(payload, &body, "MessageDeltaPayload"); err != nil {
 			return err
 		}
-	case KindTurn:
-		var body TurnPayload
-		if err := decodePayload(payload, &body, "TurnPayload"); err != nil {
+		return validateMessageDeltaPayload(body)
+	}
+	if err := rejectPayloadKeys(payload, "MessagePayload", "contentBlockIndex", "contentBlockKind", "textDelta"); err != nil {
+		return err
+	}
+	var body MessagePayload
+	if err := decodePayload(payload, &body, "MessagePayload"); err != nil {
+		return err
+	}
+	return validateMessagePayload(body)
+}
+
+func validateToolKindPayload(phase Phase, payload json.RawMessage) error {
+	if phase == PhaseDelta {
+		if err := rejectPayloadKeys(payload, "ToolDeltaPayload", "toolName", "status", "argumentsSummary", "resultSummary"); err != nil {
 			return err
 		}
-	case KindMessage:
-		if phase == PhaseDelta {
-			if err := rejectPayloadKeys(payload, "MessageDeltaPayload", "role", "contentBlocks"); err != nil {
-				return err
-			}
-			var body MessageDeltaPayload
-			if err := decodePayload(payload, &body, "MessageDeltaPayload"); err != nil {
-				return err
-			}
-			return validateMessageDeltaPayload(body)
-		}
-		if err := rejectPayloadKeys(payload, "MessagePayload", "contentBlockIndex", "contentBlockKind", "textDelta"); err != nil {
+		var body ToolDeltaPayload
+		if err := decodePayload(payload, &body, "ToolDeltaPayload"); err != nil {
 			return err
 		}
-		var body MessagePayload
-		if err := decodePayload(payload, &body, "MessagePayload"); err != nil {
-			return err
-		}
-		return validateMessagePayload(body)
-	case KindReasoning:
-		var body ReasoningPayload
-		if err := decodePayload(payload, &body, "ReasoningPayload"); err != nil {
-			return err
-		}
-	case KindTool:
-		if phase == PhaseDelta {
-			if err := rejectPayloadKeys(payload, "ToolDeltaPayload", "toolName", "status", "argumentsSummary", "resultSummary"); err != nil {
-				return err
-			}
-			var body ToolDeltaPayload
-			if err := decodePayload(payload, &body, "ToolDeltaPayload"); err != nil {
-				return err
-			}
-			return validateToolDeltaPayload(body)
-		}
-		if err := rejectPayloadKeys(payload, "ToolPayload", "outputDelta"); err != nil {
-			return err
-		}
-		var body ToolPayload
-		if err := decodePayload(payload, &body, "ToolPayload"); err != nil {
-			return err
-		}
-		return validateToolPayload(body)
-	case KindFileChange:
-		var body FileChangePayload
-		if err := decodePayload(payload, &body, "FileChangePayload"); err != nil {
-			return err
-		}
-		if strings.TrimSpace(body.Path) == "" {
-			return validationError("payload.path", "path is required for FileChangePayload")
-		}
-		if strings.TrimSpace(body.Operation) == "" {
-			return validationError("payload.operation", "operation is required for FileChangePayload")
-		}
-	case KindPlan:
-		var body PlanPayload
-		if err := decodePayload(payload, &body, "PlanPayload"); err != nil {
-			return err
-		}
-	case KindProgress:
-		var body ProgressPayload
-		if err := decodePayload(payload, &body, "ProgressPayload"); err != nil {
-			return err
-		}
-		if strings.TrimSpace(body.Label) == "" {
-			return validationError("payload.label", "label is required for ProgressPayload")
-		}
-	case KindUsage:
-		var body UsagePayload
-		if err := decodePayload(payload, &body, "UsagePayload"); err != nil {
-			return err
-		}
-	case KindError:
-		var body ErrorPayload
-		if err := decodePayload(payload, &body, "ErrorPayload"); err != nil {
-			return err
-		}
-		if strings.TrimSpace(body.Code) == "" {
-			return validationError("payload.code", "code is required for ErrorPayload")
-		}
-		if strings.TrimSpace(body.Message) == "" {
-			return validationError("payload.message", "message is required for ErrorPayload")
-		}
-	case KindStreamGap:
-		var body StreamGapPayload
-		if err := decodePayload(payload, &body, "StreamGapPayload"); err != nil {
-			return err
-		}
-		if body.FromSequence < 0 || body.ToSequence < 0 {
-			return validationError("payload.fromSequence", "fromSequence and toSequence must be non-negative for StreamGapPayload")
-		}
-	default:
-		return validationError("kind", fmt.Sprintf("kind %q has no declared payload validator", kind))
+		return validateToolDeltaPayload(body)
+	}
+	if err := rejectPayloadKeys(payload, "ToolPayload", "outputDelta"); err != nil {
+		return err
+	}
+	var body ToolPayload
+	if err := decodePayload(payload, &body, "ToolPayload"); err != nil {
+		return err
+	}
+	return validateToolPayload(body)
+}
+
+func validateFileChangeKindPayload(payload json.RawMessage) error {
+	var body FileChangePayload
+	if err := decodePayload(payload, &body, "FileChangePayload"); err != nil {
+		return err
+	}
+	if strings.TrimSpace(body.Path) == "" {
+		return validationError("payload.path", "path is required for FileChangePayload")
+	}
+	if strings.TrimSpace(body.Operation) == "" {
+		return validationError("payload.operation", "operation is required for FileChangePayload")
+	}
+	return nil
+}
+
+func validateProgressKindPayload(payload json.RawMessage) error {
+	var body ProgressPayload
+	if err := decodePayload(payload, &body, "ProgressPayload"); err != nil {
+		return err
+	}
+	if strings.TrimSpace(body.Label) == "" {
+		return validationError("payload.label", "label is required for ProgressPayload")
+	}
+	return nil
+}
+
+func validateErrorKindPayload(payload json.RawMessage) error {
+	var body ErrorPayload
+	if err := decodePayload(payload, &body, "ErrorPayload"); err != nil {
+		return err
+	}
+	if strings.TrimSpace(body.Code) == "" {
+		return validationError("payload.code", "code is required for ErrorPayload")
+	}
+	if strings.TrimSpace(body.Message) == "" {
+		return validationError("payload.message", "message is required for ErrorPayload")
+	}
+	return nil
+}
+
+func validateStreamGapKindPayload(payload json.RawMessage) error {
+	var body StreamGapPayload
+	if err := decodePayload(payload, &body, "StreamGapPayload"); err != nil {
+		return err
+	}
+	if body.FromSequence < 0 || body.ToSequence < 0 {
+		return validationError("payload.fromSequence", "fromSequence and toSequence must be non-negative for StreamGapPayload")
 	}
 	return nil
 }

--- a/pkg/factorysessions/responseevents/validation.go
+++ b/pkg/factorysessions/responseevents/validation.go
@@ -1,0 +1,344 @@
+package responseevents
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// ValidationError identifies the response-event field that failed validation.
+type ValidationError struct {
+	Field   string
+	message string
+}
+
+func (e *ValidationError) Error() string {
+	return e.message
+}
+
+func validationError(field, message string) error {
+	return &ValidationError{Field: field, message: message}
+}
+
+var allowedPhasesByKind = map[Kind][]Phase{
+	KindSession:    {PhaseStarted, PhaseCompleted, PhaseFailed, PhaseCanceled},
+	KindRun:        {PhaseStarted, PhaseCompleted, PhaseFailed, PhaseCanceled},
+	KindTurn:       {PhaseStarted, PhaseCompleted, PhaseFailed, PhaseCanceled},
+	KindMessage:    {PhaseStarted, PhaseDelta, PhaseCompleted},
+	KindReasoning:  {PhaseStarted, PhaseDelta, PhaseCompleted},
+	KindTool:       {PhaseStarted, PhaseDelta, PhaseCompleted, PhaseFailed, PhaseCanceled},
+	KindFileChange: {PhaseUpdated},
+	KindPlan:       {PhaseUpdated},
+	KindProgress:   {PhaseUpdated},
+	KindUsage:      {PhaseUpdated},
+	KindError:      {PhaseUpdated, PhaseFailed},
+	KindStreamGap:  {PhaseUpdated},
+}
+
+var knownContentBlockKinds = []ContentBlockKind{
+	ContentBlockText,
+	ContentBlockReasoningSummary,
+	ContentBlockToolRequest,
+	ContentBlockImageRef,
+	ContentBlockResourceRef,
+	ContentBlockStructuredOutput,
+}
+
+// ValidateEvent checks kind/phase allow-lists and kind-aligned payload shape.
+func ValidateEvent(event FactoryResponseEvent) error {
+	if !isKnownKind(event.Kind) {
+		return validationError("kind", fmt.Sprintf("kind %q is not a declared FactoryResponseEvent kind", event.Kind))
+	}
+	if err := validateKindPhase(event.Kind, event.Phase); err != nil {
+		return err
+	}
+	return validatePayload(event.Kind, event.Phase, event.Payload)
+}
+
+func validateKindPhase(kind Kind, phase Phase) error {
+	allowed, ok := allowedPhasesByKind[kind]
+	if !ok {
+		return validationError("kind", fmt.Sprintf("kind %q has no declared phase allow-list", kind))
+	}
+	if !slices.Contains(allowed, phase) {
+		return validationError(
+			"phase",
+			fmt.Sprintf(
+				"phase %q is not allowed for kind %q; allowed phases: %s",
+				phase,
+				kind,
+				formatPhaseList(allowed),
+			),
+		)
+	}
+	return nil
+}
+
+func validatePayload(kind Kind, phase Phase, payload json.RawMessage) error {
+	if len(payload) == 0 {
+		return validationError("payload", fmt.Sprintf("payload is required for kind %q", kind))
+	}
+	if !json.Valid(payload) {
+		return validationError("payload", "payload must contain valid JSON")
+	}
+
+	switch kind {
+	case KindSession:
+		var body SessionPayload
+		if err := decodePayload(payload, &body, "SessionPayload"); err != nil {
+			return err
+		}
+	case KindRun:
+		var body RunPayload
+		if err := decodePayload(payload, &body, "RunPayload"); err != nil {
+			return err
+		}
+	case KindTurn:
+		var body TurnPayload
+		if err := decodePayload(payload, &body, "TurnPayload"); err != nil {
+			return err
+		}
+	case KindMessage:
+		if phase == PhaseDelta {
+			if err := rejectPayloadKeys(payload, "MessageDeltaPayload", "role", "contentBlocks"); err != nil {
+				return err
+			}
+			var body MessageDeltaPayload
+			if err := decodePayload(payload, &body, "MessageDeltaPayload"); err != nil {
+				return err
+			}
+			return validateMessageDeltaPayload(body)
+		}
+		if err := rejectPayloadKeys(payload, "MessagePayload", "contentBlockIndex", "contentBlockKind", "textDelta"); err != nil {
+			return err
+		}
+		var body MessagePayload
+		if err := decodePayload(payload, &body, "MessagePayload"); err != nil {
+			return err
+		}
+		return validateMessagePayload(body)
+	case KindReasoning:
+		var body ReasoningPayload
+		if err := decodePayload(payload, &body, "ReasoningPayload"); err != nil {
+			return err
+		}
+	case KindTool:
+		if phase == PhaseDelta {
+			if err := rejectPayloadKeys(payload, "ToolDeltaPayload", "toolName", "status", "argumentsSummary", "resultSummary"); err != nil {
+				return err
+			}
+			var body ToolDeltaPayload
+			if err := decodePayload(payload, &body, "ToolDeltaPayload"); err != nil {
+				return err
+			}
+			return validateToolDeltaPayload(body)
+		}
+		if err := rejectPayloadKeys(payload, "ToolPayload", "outputDelta"); err != nil {
+			return err
+		}
+		var body ToolPayload
+		if err := decodePayload(payload, &body, "ToolPayload"); err != nil {
+			return err
+		}
+		return validateToolPayload(body)
+	case KindFileChange:
+		var body FileChangePayload
+		if err := decodePayload(payload, &body, "FileChangePayload"); err != nil {
+			return err
+		}
+		if strings.TrimSpace(body.Path) == "" {
+			return validationError("payload.path", "path is required for FileChangePayload")
+		}
+		if strings.TrimSpace(body.Operation) == "" {
+			return validationError("payload.operation", "operation is required for FileChangePayload")
+		}
+	case KindPlan:
+		var body PlanPayload
+		if err := decodePayload(payload, &body, "PlanPayload"); err != nil {
+			return err
+		}
+	case KindProgress:
+		var body ProgressPayload
+		if err := decodePayload(payload, &body, "ProgressPayload"); err != nil {
+			return err
+		}
+		if strings.TrimSpace(body.Label) == "" {
+			return validationError("payload.label", "label is required for ProgressPayload")
+		}
+	case KindUsage:
+		var body UsagePayload
+		if err := decodePayload(payload, &body, "UsagePayload"); err != nil {
+			return err
+		}
+	case KindError:
+		var body ErrorPayload
+		if err := decodePayload(payload, &body, "ErrorPayload"); err != nil {
+			return err
+		}
+		if strings.TrimSpace(body.Code) == "" {
+			return validationError("payload.code", "code is required for ErrorPayload")
+		}
+		if strings.TrimSpace(body.Message) == "" {
+			return validationError("payload.message", "message is required for ErrorPayload")
+		}
+	case KindStreamGap:
+		var body StreamGapPayload
+		if err := decodePayload(payload, &body, "StreamGapPayload"); err != nil {
+			return err
+		}
+		if body.FromSequence < 0 || body.ToSequence < 0 {
+			return validationError("payload.fromSequence", "fromSequence and toSequence must be non-negative for StreamGapPayload")
+		}
+	default:
+		return validationError("kind", fmt.Sprintf("kind %q has no declared payload validator", kind))
+	}
+	return nil
+}
+
+func decodePayload(payload json.RawMessage, target any, typeName string) error {
+	if err := json.Unmarshal(payload, target); err != nil {
+		return validationError(
+			"payload",
+			fmt.Sprintf("payload must decode as %s: %v", typeName, err),
+		)
+	}
+	return nil
+}
+
+func rejectPayloadKeys(payload json.RawMessage, typeName string, forbiddenKeys ...string) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &fields); err != nil {
+		return validationError("payload", fmt.Sprintf("payload must decode as %s: %v", typeName, err))
+	}
+	for _, key := range forbiddenKeys {
+		if _, ok := fields[key]; ok {
+			return validationError(
+				"payload",
+				fmt.Sprintf("payload shape is incompatible with %s; remove field %q", typeName, key),
+			)
+		}
+	}
+	return nil
+}
+
+func validateMessagePayload(payload MessagePayload) error {
+	if strings.TrimSpace(payload.Role) == "" {
+		return validationError("payload.role", "role is required for MessagePayload")
+	}
+	if len(payload.ContentBlocks) == 0 {
+		return validationError("payload.contentBlocks", "contentBlocks must contain at least one block for MessagePayload")
+	}
+	for index, block := range payload.ContentBlocks {
+		if err := validateContentBlock(block); err != nil {
+			if validationErr, ok := err.(*ValidationError); ok {
+				return validationError(
+					fmt.Sprintf("payload.contentBlocks[%d].%s", index, validationErr.Field),
+					validationErr.message,
+				)
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func validateMessageDeltaPayload(payload MessageDeltaPayload) error {
+	if payload.ContentBlockIndex < 0 {
+		return validationError("payload.contentBlockIndex", "contentBlockIndex must be non-negative for MessageDeltaPayload")
+	}
+	if err := validateContentBlockKind(payload.ContentBlockKind); err != nil {
+		if validationErr, ok := err.(*ValidationError); ok {
+			return validationError("payload."+validationErr.Field, validationErr.message)
+		}
+		return err
+	}
+	return nil
+}
+
+func validateToolPayload(payload ToolPayload) error {
+	if strings.TrimSpace(payload.ToolCallID) == "" {
+		return validationError("payload.toolCallId", "toolCallId is required for ToolPayload")
+	}
+	if strings.TrimSpace(payload.ToolName) == "" {
+		return validationError("payload.toolName", "toolName is required for ToolPayload")
+	}
+	return nil
+}
+
+func validateToolDeltaPayload(payload ToolDeltaPayload) error {
+	if strings.TrimSpace(payload.ToolCallID) == "" {
+		return validationError("payload.toolCallId", "toolCallId is required for ToolDeltaPayload")
+	}
+	if payload.OutputDelta == "" {
+		return validationError("payload.outputDelta", "outputDelta is required for ToolDeltaPayload")
+	}
+	return nil
+}
+
+func validateContentBlock(block ContentBlock) error {
+	if err := validateContentBlockKind(block.Kind); err != nil {
+		return validationError("kind", err.Error())
+	}
+	switch block.Kind {
+	case ContentBlockText, ContentBlockReasoningSummary:
+		if strings.TrimSpace(block.Text) == "" {
+			return validationError("text", fmt.Sprintf("text is required for content block kind %q", block.Kind))
+		}
+	case ContentBlockToolRequest:
+		if strings.TrimSpace(block.ToolCallID) == "" {
+			return validationError("toolCallId", "toolCallId is required for TOOL_REQUEST content blocks")
+		}
+		if strings.TrimSpace(block.ToolName) == "" {
+			return validationError("toolName", "toolName is required for TOOL_REQUEST content blocks")
+		}
+	case ContentBlockImageRef:
+		if strings.TrimSpace(block.ImageRef) == "" {
+			return validationError("imageRef", "imageRef is required for IMAGE_REF content blocks")
+		}
+	case ContentBlockResourceRef:
+		if strings.TrimSpace(block.ResourceRef) == "" {
+			return validationError("resourceRef", "resourceRef is required for RESOURCE_REF content blocks")
+		}
+	case ContentBlockStructuredOutput:
+		if len(block.StructuredOutput) == 0 || !json.Valid(block.StructuredOutput) {
+			return validationError("structuredOutput", "structuredOutput must contain valid JSON for STRUCTURED_OUTPUT content blocks")
+		}
+	}
+	return nil
+}
+
+func validateContentBlockKind(kind ContentBlockKind) error {
+	if !slices.Contains(knownContentBlockKinds, kind) {
+		return validationError(
+			"contentBlockKind",
+			fmt.Sprintf(
+				"contentBlockKind %q is not declared; allowed kinds: %s",
+				kind,
+				formatContentBlockKindList(knownContentBlockKinds),
+			),
+		)
+	}
+	return nil
+}
+
+func isKnownKind(kind Kind) bool {
+	_, ok := allowedPhasesByKind[kind]
+	return ok
+}
+
+func formatPhaseList(phases []Phase) string {
+	values := make([]string, len(phases))
+	for index, phase := range phases {
+		values[index] = string(phase)
+	}
+	return strings.Join(values, ", ")
+}
+
+func formatContentBlockKindList(kinds []ContentBlockKind) string {
+	values := make([]string, len(kinds))
+	for index, kind := range kinds {
+		values[index] = string(kind)
+	}
+	return strings.Join(values, ", ")
+}

--- a/pkg/factorysessions/responseevents/validation_test.go
+++ b/pkg/factorysessions/responseevents/validation_test.go
@@ -1,0 +1,235 @@
+package responseevents_test
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/pkg/factorysessions/responseevents"
+)
+
+func TestValidateEvent_AcceptsApprovedKindPhaseMatrix(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		kind  responseevents.Kind
+		phase responseevents.Phase
+	}{
+		{name: "message started", kind: responseevents.KindMessage, phase: responseevents.PhaseStarted},
+		{name: "message delta", kind: responseevents.KindMessage, phase: responseevents.PhaseDelta},
+		{name: "message completed", kind: responseevents.KindMessage, phase: responseevents.PhaseCompleted},
+		{name: "stream gap updated", kind: responseevents.KindStreamGap, phase: responseevents.PhaseUpdated},
+		{name: "error updated", kind: responseevents.KindError, phase: responseevents.PhaseUpdated},
+		{name: "error failed", kind: responseevents.KindError, phase: responseevents.PhaseFailed},
+		{name: "tool delta", kind: responseevents.KindTool, phase: responseevents.PhaseDelta},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			event := sampleEvent(t, tc.kind, tc.phase, samplePayload(t, tc.kind, tc.phase))
+			if err := responseevents.ValidateEvent(event); err != nil {
+				t.Fatalf("ValidateEvent() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateEvent_RejectsInvalidKindPhasePairsWithActionableErrors(t *testing.T) {
+	t.Parallel()
+
+	event := sampleEvent(t, responseevents.KindMessage, responseevents.PhaseUpdated, json.RawMessage(`{"role":"assistant","contentBlocks":[{"kind":"TEXT","text":"hi"}]}`))
+	err := responseevents.ValidateEvent(event)
+	assertValidationField(t, err, "phase")
+	if !strings.Contains(err.Error(), "allowed phases: STARTED, DELTA, COMPLETED") {
+		t.Fatalf("expected allowed phase list in error, got %v", err)
+	}
+
+	event = sampleEvent(t, responseevents.KindStreamGap, responseevents.PhaseDelta, json.RawMessage(`{"fromSequence":1,"toSequence":4}`))
+	err = responseevents.ValidateEvent(event)
+	assertValidationField(t, err, "phase")
+	if !strings.Contains(err.Error(), "allowed phases: UPDATED") {
+		t.Fatalf("expected STREAM_GAP phase constraint in error, got %v", err)
+	}
+
+	event = sampleEvent(t, responseevents.KindError, responseevents.PhaseCompleted, json.RawMessage(`{"code":"retry","message":"temporary"}`))
+	err = responseevents.ValidateEvent(event)
+	assertValidationField(t, err, "phase")
+	if !strings.Contains(err.Error(), "allowed phases: UPDATED, FAILED") {
+		t.Fatalf("expected ERROR phase constraint in error, got %v", err)
+	}
+}
+
+func TestValidateEvent_RejectsKindPayloadMismatchesWithActionableErrors(t *testing.T) {
+	t.Parallel()
+
+	event := sampleEvent(
+		t,
+		responseevents.KindMessage,
+		responseevents.PhaseDelta,
+		json.RawMessage(`{"role":"assistant","contentBlocks":[{"kind":"TEXT","text":"hi"}]}`),
+	)
+	err := responseevents.ValidateEvent(event)
+	assertValidationField(t, err, "payload")
+	if !strings.Contains(err.Error(), "MessageDeltaPayload") {
+		t.Fatalf("expected MessageDeltaPayload constraint in error, got %v", err)
+	}
+
+	event = sampleEvent(
+		t,
+		responseevents.KindTool,
+		responseevents.PhaseDelta,
+		json.RawMessage(`{"toolCallId":"call-1","toolName":"read_file"}`),
+	)
+	err = responseevents.ValidateEvent(event)
+	assertValidationField(t, err, "payload")
+	if !strings.Contains(err.Error(), "ToolDeltaPayload") {
+		t.Fatalf("expected ToolDeltaPayload constraint in error, got %v", err)
+	}
+
+	event = sampleEvent(
+		t,
+		responseevents.KindMessage,
+		responseevents.PhaseStarted,
+		json.RawMessage(`{"contentBlockIndex":0,"contentBlockKind":"TEXT","textDelta":"hi"}`),
+	)
+	err = responseevents.ValidateEvent(event)
+	assertValidationField(t, err, "payload")
+	if !strings.Contains(err.Error(), "MessagePayload") {
+		t.Fatalf("expected MessagePayload constraint in error, got %v", err)
+	}
+}
+
+func TestValidateEvent_ValidatesDeclaredContentBlockKinds(t *testing.T) {
+	t.Parallel()
+
+	event := sampleEvent(
+		t,
+		responseevents.KindMessage,
+		responseevents.PhaseCompleted,
+		json.RawMessage(`{"role":"assistant","contentBlocks":[{"kind":"UNKNOWN","text":"hi"}]}`),
+	)
+	err := responseevents.ValidateEvent(event)
+	assertValidationField(t, err, "payload.contentBlocks[0].kind")
+	if !strings.Contains(err.Error(), "TEXT, REASONING_SUMMARY, TOOL_REQUEST") {
+		t.Fatalf("expected declared content block kinds in error, got %v", err)
+	}
+}
+
+func TestCapabilities_MarshalDeclaredFlags(t *testing.T) {
+	t.Parallel()
+
+	capabilities := responseevents.Capabilities{
+		NativeStreaming:    true,
+		MessageDeltas:      true,
+		MessageSnapshots:   true,
+		ReasoningSummaries: true,
+		ToolLifecycle:      true,
+		ToolOutputDeltas:   true,
+		FileChanges:        true,
+		Plans:              true,
+		Usage:              true,
+		StableItemIDs:      true,
+		ProviderReconnect:  true,
+	}
+
+	payload, err := json.Marshal(capabilities)
+	if err != nil {
+		t.Fatalf("marshal capabilities: %v", err)
+	}
+	encoded := string(payload)
+	for _, want := range []string{
+		`"nativeStreaming":true`,
+		`"messageDeltas":true`,
+		`"messageSnapshots":true`,
+		`"reasoningSummaries":true`,
+		`"toolLifecycle":true`,
+		`"toolOutputDeltas":true`,
+		`"fileChanges":true`,
+		`"plans":true`,
+		`"usage":true`,
+		`"stableItemIds":true`,
+		`"providerReconnect":true`,
+	} {
+		if !strings.Contains(encoded, want) {
+			t.Fatalf("capabilities JSON missing %q in %s", want, encoded)
+		}
+	}
+}
+
+func sampleEvent(t *testing.T, kind responseevents.Kind, phase responseevents.Phase, payload json.RawMessage) responseevents.FactoryResponseEvent {
+	t.Helper()
+	return responseevents.FactoryResponseEvent{
+		SchemaVersion:    responseevents.SchemaVersionV1,
+		EventID:          "evt-test",
+		Sequence:         1,
+		RecordedAt:       time.Date(2026, 7, 13, 0, 0, 0, 0, time.UTC),
+		FactorySessionID: "session-test",
+		RunID:            "run-test",
+		Kind:             kind,
+		Phase:            phase,
+		Provenance: responseevents.Provenance{
+			Provider:        "example-provider",
+			NativeEventType: "example.event",
+			Delivery:        responseevents.DeliveryNativeStream,
+			Representation:  responseevents.RepresentationDelta,
+			Fidelity:        responseevents.FidelityLossless,
+		},
+		Payload: payload,
+	}
+}
+
+func samplePayload(t *testing.T, kind responseevents.Kind, phase responseevents.Phase) json.RawMessage {
+	t.Helper()
+
+	switch kind {
+	case responseevents.KindSession:
+		return json.RawMessage(`{"status":"active","capabilities":{"nativeStreaming":true}}`)
+	case responseevents.KindRun:
+		return json.RawMessage(`{"status":"running"}`)
+	case responseevents.KindTurn:
+		return json.RawMessage(`{"turnIndex":1,"status":"active"}`)
+	case responseevents.KindMessage:
+		if phase == responseevents.PhaseDelta {
+			return json.RawMessage(`{"contentBlockIndex":0,"contentBlockKind":"TEXT","textDelta":"hello"}`)
+		}
+		return json.RawMessage(`{"role":"assistant","contentBlocks":[{"kind":"TEXT","text":"hello"}]}`)
+	case responseevents.KindReasoning:
+		return json.RawMessage(`{"summaryDelta":"thinking"}`)
+	case responseevents.KindTool:
+		if phase == responseevents.PhaseDelta {
+			return json.RawMessage(`{"toolCallId":"call-1","outputDelta":"partial"}`)
+		}
+		return json.RawMessage(`{"toolCallId":"call-1","toolName":"read_file","status":"started"}`)
+	case responseevents.KindFileChange:
+		return json.RawMessage(`{"path":"README.md","operation":"MODIFY"}`)
+	case responseevents.KindPlan:
+		return json.RawMessage(`{"summary":"step plan","steps":[{"id":"1","description":"inspect"}]}`)
+	case responseevents.KindProgress:
+		return json.RawMessage(`{"label":"compile","message":"building"}`)
+	case responseevents.KindUsage:
+		return json.RawMessage(`{"inputTokens":10,"outputTokens":5,"totalTokens":15,"model":"example-model"}`)
+	case responseevents.KindError:
+		return json.RawMessage(`{"code":"temporary","message":"retry later","retryable":true,"retryAttempt":1}`)
+	case responseevents.KindStreamGap:
+		return json.RawMessage(`{"fromSequence":10,"toSequence":20,"reason":"retention"}`)
+	default:
+		t.Fatalf("unsupported sample kind %q", kind)
+		return nil
+	}
+}
+
+func assertValidationField(t *testing.T, err error, wantField string) {
+	t.Helper()
+	var validationErr *responseevents.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected ValidationError, got %T: %v", err, err)
+	}
+	if validationErr.Field != wantField {
+		t.Fatalf("ValidationError.Field = %q, want %q (message: %s)", validationErr.Field, wantField, validationErr.Error())
+	}
+}

--- a/pkg/factorysessions/responseevents/validation_test.go
+++ b/pkg/factorysessions/responseevents/validation_test.go
@@ -18,13 +18,22 @@ func TestValidateEvent_AcceptsApprovedKindPhaseMatrix(t *testing.T) {
 		kind  responseevents.Kind
 		phase responseevents.Phase
 	}{
+		{name: "session started", kind: responseevents.KindSession, phase: responseevents.PhaseStarted},
+		{name: "run started", kind: responseevents.KindRun, phase: responseevents.PhaseStarted},
+		{name: "turn started", kind: responseevents.KindTurn, phase: responseevents.PhaseStarted},
 		{name: "message started", kind: responseevents.KindMessage, phase: responseevents.PhaseStarted},
 		{name: "message delta", kind: responseevents.KindMessage, phase: responseevents.PhaseDelta},
 		{name: "message completed", kind: responseevents.KindMessage, phase: responseevents.PhaseCompleted},
+		{name: "reasoning delta", kind: responseevents.KindReasoning, phase: responseevents.PhaseDelta},
+		{name: "tool started", kind: responseevents.KindTool, phase: responseevents.PhaseStarted},
+		{name: "tool delta", kind: responseevents.KindTool, phase: responseevents.PhaseDelta},
+		{name: "file change updated", kind: responseevents.KindFileChange, phase: responseevents.PhaseUpdated},
+		{name: "plan updated", kind: responseevents.KindPlan, phase: responseevents.PhaseUpdated},
+		{name: "progress updated", kind: responseevents.KindProgress, phase: responseevents.PhaseUpdated},
+		{name: "usage updated", kind: responseevents.KindUsage, phase: responseevents.PhaseUpdated},
 		{name: "stream gap updated", kind: responseevents.KindStreamGap, phase: responseevents.PhaseUpdated},
 		{name: "error updated", kind: responseevents.KindError, phase: responseevents.PhaseUpdated},
 		{name: "error failed", kind: responseevents.KindError, phase: responseevents.PhaseFailed},
-		{name: "tool delta", kind: responseevents.KindTool, phase: responseevents.PhaseDelta},
 	}
 
 	for _, tc := range cases {
@@ -101,6 +110,141 @@ func TestValidateEvent_RejectsKindPayloadMismatchesWithActionableErrors(t *testi
 	assertValidationField(t, err, "payload")
 	if !strings.Contains(err.Error(), "MessagePayload") {
 		t.Fatalf("expected MessagePayload constraint in error, got %v", err)
+	}
+}
+
+func TestValidateEvent_RejectsInvalidPayloadBasics(t *testing.T) {
+	t.Parallel()
+
+	event := sampleEvent(t, responseevents.KindMessage, responseevents.PhaseStarted, nil)
+	err := responseevents.ValidateEvent(event)
+	assertValidationField(t, err, "payload")
+
+	event = sampleEvent(t, responseevents.KindMessage, responseevents.PhaseStarted, json.RawMessage(`not-json`))
+	err = responseevents.ValidateEvent(event)
+	assertValidationField(t, err, "payload")
+	if !strings.Contains(err.Error(), "valid JSON") {
+		t.Fatalf("expected valid JSON constraint in error, got %v", err)
+	}
+}
+
+func TestValidateEvent_RejectsRequiredPayloadFields(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		kind      responseevents.Kind
+		phase     responseevents.Phase
+		payload   json.RawMessage
+		wantField string
+	}{
+		{
+			name:      "file change missing path",
+			kind:      responseevents.KindFileChange,
+			phase:     responseevents.PhaseUpdated,
+			payload:   json.RawMessage(`{"operation":"MODIFY"}`),
+			wantField: "payload.path",
+		},
+		{
+			name:      "progress missing label",
+			kind:      responseevents.KindProgress,
+			phase:     responseevents.PhaseUpdated,
+			payload:   json.RawMessage(`{"message":"building"}`),
+			wantField: "payload.label",
+		},
+		{
+			name:      "error missing code",
+			kind:      responseevents.KindError,
+			phase:     responseevents.PhaseUpdated,
+			payload:   json.RawMessage(`{"message":"temporary"}`),
+			wantField: "payload.code",
+		},
+		{
+			name:      "stream gap negative sequence",
+			kind:      responseevents.KindStreamGap,
+			phase:     responseevents.PhaseUpdated,
+			payload:   json.RawMessage(`{"fromSequence":-1,"toSequence":4}`),
+			wantField: "payload.fromSequence",
+		},
+		{
+			name:      "message missing role",
+			kind:      responseevents.KindMessage,
+			phase:     responseevents.PhaseStarted,
+			payload:   json.RawMessage(`{"contentBlocks":[{"kind":"TEXT","text":"hi"}]}`),
+			wantField: "payload.role",
+		},
+		{
+			name:      "message delta negative index",
+			kind:      responseevents.KindMessage,
+			phase:     responseevents.PhaseDelta,
+			payload:   json.RawMessage(`{"contentBlockIndex":-1,"contentBlockKind":"TEXT","textDelta":"hi"}`),
+			wantField: "payload.contentBlockIndex",
+		},
+		{
+			name:      "tool missing tool call id",
+			kind:      responseevents.KindTool,
+			phase:     responseevents.PhaseStarted,
+			payload:   json.RawMessage(`{"toolName":"read_file","status":"started"}`),
+			wantField: "payload.toolCallId",
+		},
+		{
+			name:      "tool delta missing output",
+			kind:      responseevents.KindTool,
+			phase:     responseevents.PhaseDelta,
+			payload:   json.RawMessage(`{"toolCallId":"call-1"}`),
+			wantField: "payload.outputDelta",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			event := sampleEvent(t, tc.kind, tc.phase, tc.payload)
+			err := responseevents.ValidateEvent(event)
+			assertValidationField(t, err, tc.wantField)
+		})
+	}
+}
+
+func TestValidateEvent_AcceptsDeclaredContentBlockKinds(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		payload json.RawMessage
+	}{
+		{
+			name:    "reasoning summary",
+			payload: json.RawMessage(`{"role":"assistant","contentBlocks":[{"kind":"REASONING_SUMMARY","text":"thinking"}]}`),
+		},
+		{
+			name:    "tool request",
+			payload: json.RawMessage(`{"role":"assistant","contentBlocks":[{"kind":"TOOL_REQUEST","toolCallId":"call-1","toolName":"read_file"}]}`),
+		},
+		{
+			name:    "image ref",
+			payload: json.RawMessage(`{"role":"assistant","contentBlocks":[{"kind":"IMAGE_REF","imageRef":"img://1"}]}`),
+		},
+		{
+			name:    "resource ref",
+			payload: json.RawMessage(`{"role":"assistant","contentBlocks":[{"kind":"RESOURCE_REF","resourceRef":"res://1"}]}`),
+		},
+		{
+			name:    "structured output",
+			payload: json.RawMessage(`{"role":"assistant","contentBlocks":[{"kind":"STRUCTURED_OUTPUT","structuredOutput":{"status":"ok"}}]}`),
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			event := sampleEvent(t, responseevents.KindMessage, responseevents.PhaseCompleted, tc.payload)
+			if err := responseevents.ValidateEvent(event); err != nil {
+				t.Fatalf("ValidateEvent() error = %v", err)
+			}
+		})
 	}
 }
 

--- a/pkg/factorysessions/responseevents/validation_test.go
+++ b/pkg/factorysessions/responseevents/validation_test.go
@@ -187,24 +187,41 @@ func samplePayload(t *testing.T, kind responseevents.Kind, phase responseevents.
 	t.Helper()
 
 	switch kind {
+	case responseevents.KindMessage:
+		return sampleMessagePayload(phase)
+	case responseevents.KindTool:
+		return sampleToolPayload(phase)
+	default:
+		return sampleStaticKindPayload(t, kind)
+	}
+}
+
+func sampleMessagePayload(phase responseevents.Phase) json.RawMessage {
+	if phase == responseevents.PhaseDelta {
+		return json.RawMessage(`{"contentBlockIndex":0,"contentBlockKind":"TEXT","textDelta":"hello"}`)
+	}
+	return json.RawMessage(`{"role":"assistant","contentBlocks":[{"kind":"TEXT","text":"hello"}]}`)
+}
+
+func sampleToolPayload(phase responseevents.Phase) json.RawMessage {
+	if phase == responseevents.PhaseDelta {
+		return json.RawMessage(`{"toolCallId":"call-1","outputDelta":"partial"}`)
+	}
+	return json.RawMessage(`{"toolCallId":"call-1","toolName":"read_file","status":"started"}`)
+}
+
+func sampleStaticKindPayload(t *testing.T, kind responseevents.Kind) json.RawMessage {
+	t.Helper()
+
+	switch kind {
 	case responseevents.KindSession:
 		return json.RawMessage(`{"status":"active","capabilities":{"nativeStreaming":true}}`)
 	case responseevents.KindRun:
 		return json.RawMessage(`{"status":"running"}`)
 	case responseevents.KindTurn:
 		return json.RawMessage(`{"turnIndex":1,"status":"active"}`)
-	case responseevents.KindMessage:
-		if phase == responseevents.PhaseDelta {
-			return json.RawMessage(`{"contentBlockIndex":0,"contentBlockKind":"TEXT","textDelta":"hello"}`)
-		}
-		return json.RawMessage(`{"role":"assistant","contentBlocks":[{"kind":"TEXT","text":"hello"}]}`)
 	case responseevents.KindReasoning:
 		return json.RawMessage(`{"summaryDelta":"thinking"}`)
-	case responseevents.KindTool:
-		if phase == responseevents.PhaseDelta {
-			return json.RawMessage(`{"toolCallId":"call-1","outputDelta":"partial"}`)
-		}
-		return json.RawMessage(`{"toolCallId":"call-1","toolName":"read_file","status":"started"}`)
 	case responseevents.KindFileChange:
 		return json.RawMessage(`{"path":"README.md","operation":"MODIFY"}`)
 	case responseevents.KindPlan:


### PR DESCRIPTION
{
  "project": "Provider-Neutral Factory Response-Event Vocabulary",
  "branchName": "stream-b01-canonical-event-vocabulary",
  "description": "Publish the provider-neutral FactoryResponseEvent vocabulary—envelope, kinds, phases, typed payloads, provenance, capabilities, and validation—with fixtures and deterministic JSON round trips, and document resolved transport/retention/CLI decisions without implementing transports.",
  "context": {
    "customerAsk": "Publish the provider-neutral Factory response-event vocabulary. Define envelope, kind, phase, typed payload, provenance, capability, and validation types exactly as approved in the stream-response fix plan (sections 4–5 and Story 01). Resolve endpoint/cursor/retention/CLI-version/tool-summary contract decisions in package documentation without implementing transports. Keep the package free of CLI, HTTP, subprocess, and provider dependencies; do not modify FactoryEvent or place response events in canonical replay; keep raw provider payload and internal compaction types private. Prove behavior with pure validation and JSON round-trip table tests, fixtures covering text delta, message snapshot, tool lifecycle, retry, final-only message, usage, and stream gap, plus focused package tests, make pkg-boundary, and make pkg-file-count.",
    "problem": "Agent activity today is represented with legacy fragment kinds. Maintainers cannot express provider-neutral messages, tools, reasoning, errors, usage, retries, final-only results, or stream gaps with one validated vocabulary. Without a pure contract kernel, later OpenAPI, storage, SSE, CLI, and adapter work would each invent divergent shapes and cannot share fixtures or validation.",
    "solution": "Introduce a focused subpackage under an approved existing pkg family that owns the FactoryResponseEvent vocabulary: envelope fields, kinds, phases, typed payloads, provenance, capabilities, and central validation. Ship provider-neutral JSON fixtures and round-trip tests. Document the resolved public transport/retention/CLI decisions in package docs only—no transports, OpenAPI generation, stream store, or provider adapters in this lane."
  },
  "acceptanceCriteria": [
    "Go types define the FactoryResponseEvent envelope, kinds, phases, typed payloads, provenance, and capabilities from the approved plan",
    "Invalid kind/phase/payload combinations return actionable validation errors",
    "Provider-neutral JSON fixtures cover text delta, message snapshot, tool lifecycle, retry, final-only message, usage, and stream gap",
    "JSON round trips preserve every declared field and use deterministic serialization",
    "The vocabulary package has no dependency on CLI, HTTP, subprocess, or provider packages; raw provider payloads and internal compaction types stay private / out of the public vocabulary",
    "FactoryEvent and canonical replay surfaces are unchanged; response events are not placed in canonical replay",
    "Quality checks pass (typecheck, lint, tests), including focused package tests, make pkg-boundary, and make pkg-file-count"
  ],
  "userStories": [
    {
      "id": "stream-b01-canonical-event-vocabulary-001",
      "title": "Publish envelope, kinds, phases, and provenance",
      "description": "As a maintainer, I want the FactoryResponseEvent envelope with kinds, phases, and provenance so later adapters and consumers share one identity and fidelity model without provider-specific fields.",
      "acceptanceCriteria": [
        "Public types define the envelope required fields: schemaVersion, eventId, sequence, recordedAt, factorySessionId, runId, kind, phase, provenance, and payload, plus optional correlation fields (dispatchId, turnId, itemId, parentItemId, providerSessionRef)",
        "Declared kinds include SESSION, RUN, TURN, MESSAGE, REASONING, TOOL, FILE_CHANGE, PLAN, PROGRESS, USAGE, ERROR, and STREAM_GAP",
        "Declared phases include STARTED, DELTA, UPDATED, COMPLETED, FAILED, and CANCELED",
        "Provenance exposes provider, nativeEventType, nativeEventSubtype, delivery (NATIVE_STREAM | NATIVE_FINAL | SYNTHESIZED | REPLAY), representation (DELTA | SNAPSHOT | NOTIFICATION), and fidelity (LOSSLESS | NORMALIZED | LOSSY | FINAL_ONLY | LIFECYCLE_ONLY)",
        "Marshaling a representative envelope emits the declared string enum values for kind, phase, and provenance delivery/representation/fidelity (for example MESSAGE, DELTA, NATIVE_STREAM, DELTA, LOSSLESS)",
        "Types do not import CLI, HTTP, subprocess, or provider packages and do not modify FactoryEvent",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "stream-b01-canonical-event-vocabulary-002",
      "title": "Publish typed payloads, capabilities, and combination validation",
      "description": "As a publisher of response events, I want kind-aligned typed payloads, capability declarations, and central validation so invalid kind/phase/payload combinations are rejected with actionable errors before any transport exists.",
      "acceptanceCriteria": [
        "Typed payloads cover the plan’s first contract set (session, run, turn, message, message delta, reasoning, tool, tool delta, file change, plan, progress, usage, error, stream gap), including message content-block kinds TEXT, REASONING_SUMMARY, TOOL_REQUEST, IMAGE_REF, RESOURCE_REF, and STRUCTURED_OUTPUT",
        "Capability flags include nativeStreaming, messageDeltas, messageSnapshots, reasoningSummaries, toolLifecycle, toolOutputDeltas, fileChanges, plans, usage, stableItemIds, and providerReconnect",
        "Validation accepts only the approved kind/phase matrix (for example MESSAGE allows STARTED/DELTA/COMPLETED; STREAM_GAP allows UPDATED; ERROR allows UPDATED/FAILED)",
        "Invalid kind/phase pairs and kind/payload mismatches return actionable errors that name the offending fields and the expected constraint",
        "Raw provider payload types and internal compaction types are not part of the public vocabulary surface",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "stream-b01-canonical-event-vocabulary-003",
      "title": "Ship fixtures and deterministic JSON round trips",
      "description": "As a reviewer or later adapter author, I want provider-neutral JSON fixtures and round-trip table tests so representative event shapes serialize stably and preserve every declared field.",
      "acceptanceCriteria": [
        "Fixtures cover at least: text delta, message snapshot, tool lifecycle, retry (ERROR with retry metadata), final-only message, usage, and stream gap",
        "Round-trip table tests unmarshal each fixture into vocabulary types and remarshal without losing any declared field",
        "Serialization is deterministic for equal values (stable key ordering / identical bytes across repeated marshals of the same value)",
        "Fixtures contain no provider-native private protocol fields or compaction-internal types",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "stream-b01-canonical-event-vocabulary-004",
      "title": "Document resolved contract decisions and prove package isolation",
      "description": "As a later OpenAPI/API/CLI implementer, I want package documentation that records the resolved public decisions, and package-boundary evidence that the vocabulary stays isolated, so transports can be built without reopening Story 01 questions.",
      "acceptanceCriteria": [
        "Package documentation records these resolved decisions without implementing transports: public endpoint path /factory-sessions/{session_id}/response-events; SSE reconnect cursor/id uses sequence with after_sequence; v1 retention is session-wide with global limits and snapshot priority; CLI JSON response-stream schema changes in place (no temporary --response-stream-version); tool argument/result publication defaults to bounded redacted structured summaries; v1 contract does not imply durable replay across service restart",
        "Documentation states that response events are ephemeral observation records and must not derive canonical work state after replay",
        "Vocabulary package remains free of CLI, HTTP, subprocess, and provider imports; FactoryEvent is unchanged",
        "Focused package tests, make pkg-boundary, and make pkg-file-count pass",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}
