### PR TITLE
interfaces-b03-config-mock

### DIFF
--- a/pkg/config/mockworkers/encode.go
+++ b/pkg/config/mockworkers/encode.go
@@ -1,0 +1,20 @@
+package mockworkers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// MarshalCanonicalJSON renders inventory as stable, byte-comparable JSON.
+func MarshalCanonicalJSON(inventory Inventory) ([]byte, error) {
+	payload, err := json.MarshalIndent(inventory, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal mock workers topology inventory: %w", err)
+	}
+
+	var buffer bytes.Buffer
+	buffer.Write(payload)
+	buffer.WriteByte('\n')
+	return buffer.Bytes(), nil
+}

--- a/pkg/config/mockworkers/encode.go
+++ b/pkg/config/mockworkers/encode.go
@@ -6,6 +6,19 @@ import (
 	"fmt"
 )
 
+// MarshalInputInventoryJSON renders the mock-worker input inventory as stable JSON.
+func MarshalInputInventoryJSON(inventory InputInventory) ([]byte, error) {
+	payload, err := json.MarshalIndent(inventory, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal mock workers input inventory: %w", err)
+	}
+
+	var buffer bytes.Buffer
+	buffer.Write(payload)
+	buffer.WriteByte('\n')
+	return buffer.Bytes(), nil
+}
+
 // MarshalCanonicalJSON renders inventory as stable, byte-comparable JSON.
 func MarshalCanonicalJSON(inventory Inventory) ([]byte, error) {
 	payload, err := json.MarshalIndent(inventory, "", "  ")

--- a/pkg/config/mockworkers/fixture_text.go
+++ b/pkg/config/mockworkers/fixture_text.go
@@ -1,0 +1,10 @@
+package mockworkers
+
+import "bytes"
+
+// NormalizeFixtureBytes canonicalizes committed baseline fixture bytes so compares
+// stay stable when Git checks out files with CRLF on Windows.
+func NormalizeFixtureBytes(data []byte) []byte {
+	normalized := bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+	return bytes.ReplaceAll(normalized, []byte("\r"), []byte("\n"))
+}

--- a/pkg/config/mockworkers/fixture_text.go
+++ b/pkg/config/mockworkers/fixture_text.go
@@ -8,3 +8,8 @@ func NormalizeFixtureBytes(data []byte) []byte {
 	normalized := bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
 	return bytes.ReplaceAll(normalized, []byte("\r"), []byte("\n"))
 }
+
+// NormalizeSourceBytes canonicalizes production loader source bytes before hashing.
+func NormalizeSourceBytes(data []byte) []byte {
+	return NormalizeFixtureBytes(data)
+}

--- a/pkg/config/mockworkers/input_index.go
+++ b/pkg/config/mockworkers/input_index.go
@@ -3,8 +3,9 @@ package mockworkers
 // ProjectInputInventory builds the deterministic mock-worker input inventory
 // from committed fixtures, docs examples, and documented loader outcomes.
 func ProjectInputInventory() InputInventory {
-	cases := make([]InputCase, 0, 16)
+	cases := make([]InputCase, 0, 24)
 	cases = append(cases, parseValidInputCases()...)
+	cases = append(cases, parseInvalidInputCases()...)
 	cases = append(cases, loadValidInputCases()...)
 
 	return InputInventory{

--- a/pkg/config/mockworkers/input_index.go
+++ b/pkg/config/mockworkers/input_index.go
@@ -1,0 +1,20 @@
+package mockworkers
+
+// ProjectInputInventory builds the deterministic mock-worker input inventory
+// from committed fixtures, docs examples, and documented loader outcomes.
+func ProjectInputInventory() InputInventory {
+	cases := make([]InputCase, 0, 16)
+	cases = append(cases, parseValidInputCases()...)
+	cases = append(cases, loadValidInputCases()...)
+
+	return InputInventory{
+		FormatVersion: InputInventoryFormatVersion,
+		UnknownFieldPolicy: "ParseMockWorkersConfig uses json.Decoder.DisallowUnknownFields and rejects unknown top-level keys, " +
+			"unknown nested keys, and trailing JSON values",
+		LoaderEntrypoints: []string{
+			entrypointParseMockWorkersConfig,
+			entrypointLoadMockWorkersConfig,
+		},
+		Cases: cases,
+	}
+}

--- a/pkg/config/mockworkers/input_index_invalid_cases.go
+++ b/pkg/config/mockworkers/input_index_invalid_cases.go
@@ -1,0 +1,96 @@
+package mockworkers
+
+func parseInvalidInputCases() []InputCase {
+	return []InputCase{
+		{
+			ID:          "invalid-unknown-top-level",
+			Category:    categoryParseUnknownField,
+			Entrypoint:  entrypointParseMockWorkersConfig,
+			Outcome:     outcomeReject,
+			Fixture:     "pkg/config/mockworkers/testdata/fixtures/invalid/unknown-top-level.json",
+			Description: "unknown top-level keys are rejected under strict decode",
+			ErrorFragments: []string{
+				"decode mock workers JSON",
+				"unknown field",
+			},
+		},
+		{
+			ID:          "invalid-unknown-nested-mock-worker",
+			Category:    categoryParseUnknownField,
+			Entrypoint:  entrypointParseMockWorkersConfig,
+			Outcome:     outcomeReject,
+			Fixture:     "pkg/config/mockworkers/testdata/fixtures/invalid/unknown-nested-mock-worker.json",
+			Description: "unknown nested mockWorkers[] keys are rejected under strict decode",
+			ErrorFragments: []string{
+				"decode mock workers JSON",
+				"unknown field",
+			},
+		},
+		{
+			ID:          "invalid-trailing-json",
+			Category:    categoryParseUnknownField,
+			Entrypoint:  entrypointParseMockWorkersConfig,
+			Outcome:     outcomeReject,
+			Fixture:     "pkg/config/mockworkers/testdata/fixtures/invalid/trailing-json.json",
+			Description: "trailing JSON values after the root object are rejected",
+			ErrorFragments: []string{
+				"unexpected trailing JSON",
+			},
+		},
+		{
+			ID:          "invalid-unknown-run-type",
+			Category:    categoryParseAcceptEntry,
+			Entrypoint:  entrypointParseMockWorkersConfig,
+			Outcome:     outcomeReject,
+			Fixture:     "pkg/config/mockworkers/testdata/fixtures/invalid/unknown-run-type.json",
+			Description: "unknown runType values fail validation with actionable diagnostics",
+			ErrorFragments: []string{
+				`runType must be one of "accept", "script", or "reject"; got "maybe"`,
+			},
+		},
+		{
+			ID:          "invalid-unknown-unmatched-policy",
+			Category:    categoryParseUnmatchedPolicy,
+			Entrypoint:  entrypointParseMockWorkersConfig,
+			Outcome:     outcomeReject,
+			Fixture:     "pkg/config/mockworkers/testdata/fixtures/invalid/unknown-unmatched-policy.json",
+			Description: "unknown unmatchedDispatchPolicy values fail validation with actionable diagnostics",
+			ErrorFragments: []string{
+				`unmatchedDispatchPolicy must be one of "accept" or "passthrough"; got "maybe"`,
+			},
+		},
+		{
+			ID:          "invalid-script-without-script-config",
+			Category:    categoryParseScriptEntry,
+			Entrypoint:  entrypointParseMockWorkersConfig,
+			Outcome:     outcomeReject,
+			Fixture:     "pkg/config/mockworkers/testdata/fixtures/invalid/script-without-script-config.json",
+			Description: "script runType without scriptConfig fails validation",
+			ErrorFragments: []string{
+				"scriptConfig is required",
+			},
+		},
+		{
+			ID:          "invalid-script-without-command",
+			Category:    categoryParseScriptEntry,
+			Entrypoint:  entrypointParseMockWorkersConfig,
+			Outcome:     outcomeReject,
+			Fixture:     "pkg/config/mockworkers/testdata/fixtures/invalid/script-without-command.json",
+			Description: "script runType without scriptConfig.command fails validation",
+			ErrorFragments: []string{
+				"scriptConfig.command is required",
+			},
+		},
+		{
+			ID:          "invalid-reject-exit-code-out-of-range",
+			Category:    categoryParseRejectEntry,
+			Entrypoint:  entrypointParseMockWorkersConfig,
+			Outcome:     outcomeReject,
+			Fixture:     "pkg/config/mockworkers/testdata/fixtures/invalid/reject-exit-code-out-of-range.json",
+			Description: "rejectConfig.exitCode outside 1-255 fails validation",
+			ErrorFragments: []string{
+				"rejectConfig.exitCode must be between 1 and 255",
+			},
+		},
+	}
+}

--- a/pkg/config/mockworkers/input_index_valid_cases.go
+++ b/pkg/config/mockworkers/input_index_valid_cases.go
@@ -1,6 +1,13 @@
 package mockworkers
 
 func parseValidInputCases() []InputCase {
+	cases := make([]InputCase, 0, 9)
+	cases = append(cases, parseValidFixtureInputCases()...)
+	cases = append(cases, parseValidDocsExampleInputCases()...)
+	return cases
+}
+
+func parseValidFixtureInputCases() []InputCase {
 	return []InputCase{
 		{
 			ID:          "valid-empty-default",
@@ -71,61 +78,6 @@ func parseValidInputCases() []InputCase {
 			ExpectedConfig: &MockWorkersConfigExpectation{
 				UnmatchedDispatchPolicy: string(MockWorkerUnmatchedDispatchPolicyAccept),
 				MockWorkerCount:         0,
-			},
-		},
-		{
-			ID:          "docs-example-mock-workers",
-			Category:    categoryParseDocsExample,
-			Entrypoint:  entrypointParseMockWorkersConfig,
-			Outcome:     outcomeAccept,
-			Fixture:     "docs/examples/mock-workers.json",
-			Description: "checked-in reject-with-rejectConfig docs example parses via production loader",
-			ExpectedConfig: &MockWorkersConfigExpectation{
-				MockWorkerCount: 1,
-				MockWorkers: []MockWorkerExpectation{{
-					ID:              "reviewer-rejects-first-pass",
-					WorkerName:      "reviewer",
-					WorkstationName: "review-story",
-					RunType:         string(MockWorkerRunTypeReject),
-					RejectExitCode:  intPtr(42),
-				}},
-			},
-		},
-		{
-			ID:          "docs-example-mock-workers-script",
-			Category:    categoryParseDocsExample,
-			Entrypoint:  entrypointParseMockWorkersConfig,
-			Outcome:     outcomeAccept,
-			Fixture:     "docs/examples/mock-workers-script.json",
-			Description: "checked-in script docs example parses with required command and optional script fields",
-			ExpectedConfig: &MockWorkersConfigExpectation{
-				MockWorkerCount: 1,
-				MockWorkers: []MockWorkerExpectation{{
-					ID:              "executor-script-side-effect",
-					WorkerName:      "executor",
-					WorkstationName: "execute-story",
-					RunType:         string(MockWorkerRunTypeScript),
-					ScriptCommand:   "printf",
-				}},
-			},
-		},
-		{
-			ID:          "docs-example-mock-workers-mixed",
-			Category:    categoryParseDocsExample,
-			Entrypoint:  entrypointParseMockWorkersConfig,
-			Outcome:     outcomeAccept,
-			Fixture:     "docs/examples/mock-workers-mixed.json",
-			Description: "checked-in mixed docs example parses with unmatchedDispatchPolicy passthrough",
-			ExpectedConfig: &MockWorkersConfigExpectation{
-				UnmatchedDispatchPolicy: string(MockWorkerUnmatchedDispatchPolicyPassthrough),
-				MockWorkerCount:         1,
-				MockWorkers: []MockWorkerExpectation{{
-					ID:              "reviewer-rejects-first-pass",
-					WorkerName:      "reviewer",
-					WorkstationName: "review-story",
-					RunType:         string(MockWorkerRunTypeReject),
-					RejectExitCode:  intPtr(42),
-				}},
 			},
 		},
 	}

--- a/pkg/config/mockworkers/input_index_valid_cases.go
+++ b/pkg/config/mockworkers/input_index_valid_cases.go
@@ -1,0 +1,194 @@
+package mockworkers
+
+func parseValidInputCases() []InputCase {
+	return []InputCase{
+		{
+			ID:          "valid-empty-default",
+			Category:    categoryParseEmptyDefault,
+			Entrypoint:  entrypointParseMockWorkersConfig,
+			Outcome:     outcomeAccept,
+			Fixture:     "pkg/config/mockworkers/testdata/fixtures/valid/empty-accept.json",
+			Description: "empty mockWorkers array is the default accept config when unmatchedDispatchPolicy is omitted",
+			ExpectedConfig: &MockWorkersConfigExpectation{
+				MockWorkerCount: 0,
+			},
+		},
+		{
+			ID:          "valid-accept-entry-selectors",
+			Category:    categoryParseAcceptEntry,
+			Entrypoint:  entrypointParseMockWorkersConfig,
+			Outcome:     outcomeAccept,
+			Fixture:     "pkg/config/mockworkers/testdata/fixtures/valid/accept-entry-selectors.json",
+			Description: "accept runType preserves selector-bearing workInputs entries",
+			ExpectedConfig: &MockWorkersConfigExpectation{
+				MockWorkerCount: 1,
+				MockWorkers: []MockWorkerExpectation{{
+					ID:              "accept-reviewer",
+					WorkerName:      "reviewer",
+					WorkstationName: "review",
+					RunType:         string(MockWorkerRunTypeAccept),
+				}},
+			},
+		},
+		{
+			ID:          "valid-reject-without-reject-config",
+			Category:    categoryParseRejectEntry,
+			Entrypoint:  entrypointParseMockWorkersConfig,
+			Outcome:     outcomeAccept,
+			Fixture:     "pkg/config/mockworkers/testdata/fixtures/valid/reject-without-reject-config.json",
+			Description: "reject runType accepts omitted rejectConfig",
+			ExpectedConfig: &MockWorkersConfigExpectation{
+				MockWorkerCount: 1,
+				MockWorkers: []MockWorkerExpectation{{
+					ID:      "reject-minimal",
+					RunType: string(MockWorkerRunTypeReject),
+				}},
+			},
+		},
+		{
+			ID:          "valid-script-minimal-command",
+			Category:    categoryParseScriptEntry,
+			Entrypoint:  entrypointParseMockWorkersConfig,
+			Outcome:     outcomeAccept,
+			Fixture:     "pkg/config/mockworkers/testdata/fixtures/valid/script-minimal-command.json",
+			Description: "script runType requires only scriptConfig.command; optional script fields may be omitted",
+			ExpectedConfig: &MockWorkersConfigExpectation{
+				MockWorkerCount: 1,
+				MockWorkers: []MockWorkerExpectation{{
+					ID:            "script-minimal",
+					RunType:       string(MockWorkerRunTypeScript),
+					ScriptCommand: "echo",
+				}},
+			},
+		},
+		{
+			ID:          "valid-unmatched-policy-explicit-accept",
+			Category:    categoryParseUnmatchedPolicy,
+			Entrypoint:  entrypointParseMockWorkersConfig,
+			Outcome:     outcomeAccept,
+			Fixture:     "pkg/config/mockworkers/testdata/fixtures/valid/unmatched-policy-explicit-accept.json",
+			Description: "explicit unmatchedDispatchPolicy accept matches omitted-policy default behavior",
+			ExpectedConfig: &MockWorkersConfigExpectation{
+				UnmatchedDispatchPolicy: string(MockWorkerUnmatchedDispatchPolicyAccept),
+				MockWorkerCount:         0,
+			},
+		},
+		{
+			ID:          "docs-example-mock-workers",
+			Category:    categoryParseDocsExample,
+			Entrypoint:  entrypointParseMockWorkersConfig,
+			Outcome:     outcomeAccept,
+			Fixture:     "docs/examples/mock-workers.json",
+			Description: "checked-in reject-with-rejectConfig docs example parses via production loader",
+			ExpectedConfig: &MockWorkersConfigExpectation{
+				MockWorkerCount: 1,
+				MockWorkers: []MockWorkerExpectation{{
+					ID:              "reviewer-rejects-first-pass",
+					WorkerName:      "reviewer",
+					WorkstationName: "review-story",
+					RunType:         string(MockWorkerRunTypeReject),
+					RejectExitCode:  intPtr(42),
+				}},
+			},
+		},
+		{
+			ID:          "docs-example-mock-workers-script",
+			Category:    categoryParseDocsExample,
+			Entrypoint:  entrypointParseMockWorkersConfig,
+			Outcome:     outcomeAccept,
+			Fixture:     "docs/examples/mock-workers-script.json",
+			Description: "checked-in script docs example parses with required command and optional script fields",
+			ExpectedConfig: &MockWorkersConfigExpectation{
+				MockWorkerCount: 1,
+				MockWorkers: []MockWorkerExpectation{{
+					ID:              "executor-script-side-effect",
+					WorkerName:      "executor",
+					WorkstationName: "execute-story",
+					RunType:         string(MockWorkerRunTypeScript),
+					ScriptCommand:   "printf",
+				}},
+			},
+		},
+		{
+			ID:          "docs-example-mock-workers-mixed",
+			Category:    categoryParseDocsExample,
+			Entrypoint:  entrypointParseMockWorkersConfig,
+			Outcome:     outcomeAccept,
+			Fixture:     "docs/examples/mock-workers-mixed.json",
+			Description: "checked-in mixed docs example parses with unmatchedDispatchPolicy passthrough",
+			ExpectedConfig: &MockWorkersConfigExpectation{
+				UnmatchedDispatchPolicy: string(MockWorkerUnmatchedDispatchPolicyPassthrough),
+				MockWorkerCount:         1,
+				MockWorkers: []MockWorkerExpectation{{
+					ID:              "reviewer-rejects-first-pass",
+					WorkerName:      "reviewer",
+					WorkstationName: "review-story",
+					RunType:         string(MockWorkerRunTypeReject),
+					RejectExitCode:  intPtr(42),
+				}},
+			},
+		},
+	}
+}
+
+func loadValidInputCases() []InputCase {
+	return []InputCase{
+		{
+			ID:          "valid-load-empty-path",
+			Category:    categoryLoadEmptyPath,
+			Entrypoint:  entrypointLoadMockWorkersConfig,
+			Outcome:     outcomeAccept,
+			Description: "LoadMockWorkersConfig with empty path returns the default empty accept config",
+			ExpectedConfig: &MockWorkersConfigExpectation{
+				MockWorkerCount: 0,
+			},
+		},
+		{
+			ID:          "load-docs-example-mock-workers",
+			Category:    categoryLoadFile,
+			Entrypoint:  entrypointLoadMockWorkersConfig,
+			Outcome:     outcomeAccept,
+			Fixture:     "docs/examples/mock-workers.json",
+			Description: "LoadMockWorkersConfig loads the checked-in reject docs example from disk",
+			ExpectedConfig: &MockWorkersConfigExpectation{
+				MockWorkerCount: 1,
+				MockWorkers: []MockWorkerExpectation{{
+					ID:      "reviewer-rejects-first-pass",
+					RunType: string(MockWorkerRunTypeReject),
+				}},
+			},
+		},
+		{
+			ID:          "load-docs-example-mock-workers-script",
+			Category:    categoryLoadFile,
+			Entrypoint:  entrypointLoadMockWorkersConfig,
+			Outcome:     outcomeAccept,
+			Fixture:     "docs/examples/mock-workers-script.json",
+			Description: "LoadMockWorkersConfig loads the checked-in script docs example from disk",
+			ExpectedConfig: &MockWorkersConfigExpectation{
+				MockWorkerCount: 1,
+				MockWorkers: []MockWorkerExpectation{{
+					ID:            "executor-script-side-effect",
+					RunType:       string(MockWorkerRunTypeScript),
+					ScriptCommand: "printf",
+				}},
+			},
+		},
+		{
+			ID:          "load-docs-example-mock-workers-mixed",
+			Category:    categoryLoadFile,
+			Entrypoint:  entrypointLoadMockWorkersConfig,
+			Outcome:     outcomeAccept,
+			Fixture:     "docs/examples/mock-workers-mixed.json",
+			Description: "LoadMockWorkersConfig loads the checked-in passthrough-policy docs example from disk",
+			ExpectedConfig: &MockWorkersConfigExpectation{
+				UnmatchedDispatchPolicy: string(MockWorkerUnmatchedDispatchPolicyPassthrough),
+				MockWorkerCount:         1,
+			},
+		},
+	}
+}
+
+func intPtr(value int) *int {
+	return &value
+}

--- a/pkg/config/mockworkers/input_index_valid_docs_cases.go
+++ b/pkg/config/mockworkers/input_index_valid_docs_cases.go
@@ -1,0 +1,61 @@
+package mockworkers
+
+func parseValidDocsExampleInputCases() []InputCase {
+	return []InputCase{
+		{
+			ID:          "docs-example-mock-workers",
+			Category:    categoryParseDocsExample,
+			Entrypoint:  entrypointParseMockWorkersConfig,
+			Outcome:     outcomeAccept,
+			Fixture:     "docs/examples/mock-workers.json",
+			Description: "checked-in reject-with-rejectConfig docs example parses via production loader",
+			ExpectedConfig: &MockWorkersConfigExpectation{
+				MockWorkerCount: 1,
+				MockWorkers: []MockWorkerExpectation{{
+					ID:              "reviewer-rejects-first-pass",
+					WorkerName:      "reviewer",
+					WorkstationName: "review-story",
+					RunType:         string(MockWorkerRunTypeReject),
+					RejectExitCode:  intPtr(42),
+				}},
+			},
+		},
+		{
+			ID:          "docs-example-mock-workers-script",
+			Category:    categoryParseDocsExample,
+			Entrypoint:  entrypointParseMockWorkersConfig,
+			Outcome:     outcomeAccept,
+			Fixture:     "docs/examples/mock-workers-script.json",
+			Description: "checked-in script docs example parses with required command and optional script fields",
+			ExpectedConfig: &MockWorkersConfigExpectation{
+				MockWorkerCount: 1,
+				MockWorkers: []MockWorkerExpectation{{
+					ID:              "executor-script-side-effect",
+					WorkerName:      "executor",
+					WorkstationName: "execute-story",
+					RunType:         string(MockWorkerRunTypeScript),
+					ScriptCommand:   "printf",
+				}},
+			},
+		},
+		{
+			ID:          "docs-example-mock-workers-mixed",
+			Category:    categoryParseDocsExample,
+			Entrypoint:  entrypointParseMockWorkersConfig,
+			Outcome:     outcomeAccept,
+			Fixture:     "docs/examples/mock-workers-mixed.json",
+			Description: "checked-in mixed docs example parses with unmatchedDispatchPolicy passthrough",
+			ExpectedConfig: &MockWorkersConfigExpectation{
+				UnmatchedDispatchPolicy: string(MockWorkerUnmatchedDispatchPolicyPassthrough),
+				MockWorkerCount:         1,
+				MockWorkers: []MockWorkerExpectation{{
+					ID:              "reviewer-rejects-first-pass",
+					WorkerName:      "reviewer",
+					WorkstationName: "review-story",
+					RunType:         string(MockWorkerRunTypeReject),
+					RejectExitCode:  intPtr(42),
+				}},
+			},
+		},
+	}
+}

--- a/pkg/config/mockworkers/input_inventory.go
+++ b/pkg/config/mockworkers/input_inventory.go
@@ -22,6 +22,7 @@ const (
 	categoryParseScriptEntry     = "parse-script-entry"
 	categoryParseUnmatchedPolicy = "parse-unmatched-policy"
 	categoryParseDocsExample     = "parse-docs-example"
+	categoryParseUnknownField    = "parse-unknown-field"
 	categoryLoadFile             = "load-file"
 	categoryLoadEmptyPath        = "load-empty-path"
 )

--- a/pkg/config/mockworkers/input_inventory.go
+++ b/pkg/config/mockworkers/input_inventory.go
@@ -1,0 +1,65 @@
+// Package mockworkers loads and validates the mock-workers JSON contract. The
+// input inventory types in this file document accepted authoring variants and
+// loader outcomes without changing parse or validation behavior.
+package mockworkers
+
+// InputInventoryFormatVersion identifies the mock-worker input inventory shape.
+const InputInventoryFormatVersion = "mock-workers-input/v1"
+
+// InputIndexBaselineRelativePath is the committed mock-worker input index fixture.
+const InputIndexBaselineRelativePath = "pkg/config/mockworkers/testdata/baseline/mock-workers-input-index.json"
+
+const (
+	outcomeAccept = "accept"
+	outcomeReject = "reject"
+
+	entrypointParseMockWorkersConfig = "ParseMockWorkersConfig"
+	entrypointLoadMockWorkersConfig  = "LoadMockWorkersConfig"
+
+	categoryParseEmptyDefault    = "parse-empty-default"
+	categoryParseAcceptEntry     = "parse-accept-entry"
+	categoryParseRejectEntry     = "parse-reject-entry"
+	categoryParseScriptEntry     = "parse-script-entry"
+	categoryParseUnmatchedPolicy = "parse-unmatched-policy"
+	categoryParseDocsExample     = "parse-docs-example"
+	categoryLoadFile             = "load-file"
+	categoryLoadEmptyPath        = "load-empty-path"
+)
+
+// InputInventory indexes deterministic mock-worker inputs and expected loader outcomes.
+type InputInventory struct {
+	FormatVersion      string      `json:"formatVersion"`
+	UnknownFieldPolicy string      `json:"unknownFieldPolicy"`
+	LoaderEntrypoints  []string    `json:"loaderEntrypoints"`
+	Cases              []InputCase `json:"cases"`
+}
+
+// InputCase records one indexed input and the production loader outcome it documents.
+type InputCase struct {
+	ID          string `json:"id"`
+	Category    string `json:"category"`
+	Entrypoint  string `json:"entrypoint"`
+	Outcome     string `json:"outcome"`
+	Fixture     string `json:"fixture,omitempty"`
+	Description string `json:"description"`
+
+	ExpectedConfig *MockWorkersConfigExpectation `json:"expectedConfig,omitempty"`
+	ErrorFragments []string                      `json:"errorFragments,omitempty"`
+}
+
+// MockWorkersConfigExpectation records expected parse/load outputs for accepted inputs.
+type MockWorkersConfigExpectation struct {
+	UnmatchedDispatchPolicy string                  `json:"unmatchedDispatchPolicy,omitempty"`
+	MockWorkerCount         int                     `json:"mockWorkerCount,omitempty"`
+	MockWorkers             []MockWorkerExpectation `json:"mockWorkers,omitempty"`
+}
+
+// MockWorkerExpectation records selective mockWorkers[] fields asserted by inventory tests.
+type MockWorkerExpectation struct {
+	ID              string `json:"id,omitempty"`
+	WorkerName      string `json:"workerName,omitempty"`
+	WorkstationName string `json:"workstationName,omitempty"`
+	RunType         string `json:"runType,omitempty"`
+	ScriptCommand   string `json:"scriptCommand,omitempty"`
+	RejectExitCode  *int   `json:"rejectExitCode,omitempty"`
+}

--- a/pkg/config/mockworkers/input_inventory_test.go
+++ b/pkg/config/mockworkers/input_inventory_test.go
@@ -1,0 +1,291 @@
+package mockworkers_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/config/mockworkers"
+	"github.com/portpowered/infinite-you/pkg/testutil"
+)
+
+func TestProjectInputInventory_RecordsUnknownFieldPolicyAndEntrypoints(t *testing.T) {
+	t.Parallel()
+
+	inventory := mockworkers.ProjectInputInventory()
+	if inventory.FormatVersion != mockworkers.InputInventoryFormatVersion {
+		t.Fatalf("FormatVersion = %q, want %q", inventory.FormatVersion, mockworkers.InputInventoryFormatVersion)
+	}
+	if !strings.Contains(inventory.UnknownFieldPolicy, "DisallowUnknownFields") {
+		t.Fatalf("unknown field policy = %q, want DisallowUnknownFields reference", inventory.UnknownFieldPolicy)
+	}
+	if len(inventory.LoaderEntrypoints) != 2 {
+		t.Fatalf("loader entrypoints len = %d, want ParseMockWorkersConfig and LoadMockWorkersConfig", len(inventory.LoaderEntrypoints))
+	}
+}
+
+func TestProjectInputInventory_HasDocsExampleAndVariantCases(t *testing.T) {
+	t.Parallel()
+
+	inventory := mockworkers.ProjectInputInventory()
+	byID := indexInputCasesByID(t, inventory.Cases)
+
+	required := []string{
+		"valid-empty-default",
+		"valid-accept-entry-selectors",
+		"valid-reject-without-reject-config",
+		"valid-script-minimal-command",
+		"valid-unmatched-policy-explicit-accept",
+		"docs-example-mock-workers",
+		"docs-example-mock-workers-script",
+		"docs-example-mock-workers-mixed",
+		"valid-load-empty-path",
+		"load-docs-example-mock-workers",
+		"load-docs-example-mock-workers-script",
+		"load-docs-example-mock-workers-mixed",
+	}
+	for _, id := range required {
+		if _, ok := byID[id]; !ok {
+			t.Fatalf("missing indexed input case %q", id)
+		}
+	}
+}
+
+func TestIndexedInputCases_MatchProductionLoaders(t *testing.T) {
+	inventory := mockworkers.ProjectInputInventory()
+	seen := make(map[string]struct{}, len(inventory.Cases))
+	for _, inputCase := range inventory.Cases {
+		if inputCase.ID == "" {
+			t.Fatal("input case missing id")
+		}
+		if _, exists := seen[inputCase.ID]; exists {
+			t.Fatalf("duplicate input case id %q", inputCase.ID)
+		}
+		seen[inputCase.ID] = struct{}{}
+
+		t.Run(inputCase.ID, func(t *testing.T) {
+			runIndexedInputCase(t, inputCase)
+		})
+	}
+}
+
+func runIndexedInputCase(t *testing.T, inputCase mockworkers.InputCase) {
+	t.Helper()
+
+	switch inputCase.Entrypoint {
+	case "ParseMockWorkersConfig":
+		runParseMockWorkersConfigCase(t, inputCase)
+	case "LoadMockWorkersConfig":
+		runLoadMockWorkersConfigCase(t, inputCase)
+	default:
+		t.Fatalf("unsupported entrypoint %q", inputCase.Entrypoint)
+	}
+}
+
+func runParseMockWorkersConfigCase(t *testing.T, inputCase mockworkers.InputCase) {
+	t.Helper()
+
+	data := readRepoFixture(t, inputCase.Fixture)
+	cfg, err := mockworkers.ParseMockWorkersConfig(data)
+	if inputCase.Outcome == "accept" {
+		if err != nil {
+			t.Fatalf("ParseMockWorkersConfig() error = %v, want accept", err)
+		}
+		assertMockWorkersConfigExpectation(t, cfg, inputCase.ExpectedConfig)
+		return
+	}
+	if err == nil {
+		t.Fatal("ParseMockWorkersConfig() error = nil, want reject")
+	}
+	assertErrorFragments(t, err, inputCase.ErrorFragments)
+}
+
+func runLoadMockWorkersConfigCase(t *testing.T, inputCase mockworkers.InputCase) {
+	t.Helper()
+
+	var path string
+	if inputCase.ID == "valid-load-empty-path" {
+		path = ""
+	} else {
+		path = repoFixturePath(t, inputCase.Fixture)
+	}
+
+	cfg, err := mockworkers.LoadMockWorkersConfig(path)
+	if inputCase.Outcome == "accept" {
+		if err != nil {
+			t.Fatalf("LoadMockWorkersConfig() error = %v, want accept", err)
+		}
+		assertMockWorkersConfigExpectation(t, cfg, inputCase.ExpectedConfig)
+		return
+	}
+	if err == nil {
+		t.Fatal("LoadMockWorkersConfig() error = nil, want reject")
+	}
+	assertErrorFragments(t, err, inputCase.ErrorFragments)
+}
+
+func assertMockWorkersConfigExpectation(t *testing.T, cfg *mockworkers.MockWorkersConfig, want *mockworkers.MockWorkersConfigExpectation) {
+	t.Helper()
+
+	if want == nil {
+		t.Fatal("accept case missing expectedConfig")
+	}
+	if cfg == nil {
+		t.Fatal("loader returned nil config")
+	}
+	if want.UnmatchedDispatchPolicy != "" {
+		got := string(cfg.UnmatchedDispatchPolicy)
+		if got != want.UnmatchedDispatchPolicy {
+			t.Fatalf("unmatchedDispatchPolicy = %q, want %q", got, want.UnmatchedDispatchPolicy)
+		}
+	}
+	if len(cfg.MockWorkers) != want.MockWorkerCount {
+		t.Fatalf("mock worker count = %d, want %d", len(cfg.MockWorkers), want.MockWorkerCount)
+	}
+	for i, wantWorker := range want.MockWorkers {
+		if i >= len(cfg.MockWorkers) {
+			t.Fatalf("mockWorkers[%d] missing, want %#v", i, wantWorker)
+		}
+		gotWorker := cfg.MockWorkers[i]
+		if wantWorker.ID != "" && gotWorker.ID != wantWorker.ID {
+			t.Fatalf("mockWorkers[%d].id = %q, want %q", i, gotWorker.ID, wantWorker.ID)
+		}
+		if wantWorker.WorkerName != "" && gotWorker.WorkerName != wantWorker.WorkerName {
+			t.Fatalf("mockWorkers[%d].workerName = %q, want %q", i, gotWorker.WorkerName, wantWorker.WorkerName)
+		}
+		if wantWorker.WorkstationName != "" && gotWorker.WorkstationName != wantWorker.WorkstationName {
+			t.Fatalf("mockWorkers[%d].workstationName = %q, want %q", i, gotWorker.WorkstationName, wantWorker.WorkstationName)
+		}
+		if wantWorker.RunType != "" && string(gotWorker.RunType) != wantWorker.RunType {
+			t.Fatalf("mockWorkers[%d].runType = %q, want %q", i, gotWorker.RunType, wantWorker.RunType)
+		}
+		if wantWorker.ScriptCommand != "" {
+			if gotWorker.ScriptConfig == nil {
+				t.Fatalf("mockWorkers[%d].scriptConfig = nil, want command %q", i, wantWorker.ScriptCommand)
+			}
+			if gotWorker.ScriptConfig.Command != wantWorker.ScriptCommand {
+				t.Fatalf("mockWorkers[%d].scriptConfig.command = %q, want %q", i, gotWorker.ScriptConfig.Command, wantWorker.ScriptCommand)
+			}
+		}
+		if wantWorker.RejectExitCode != nil {
+			if gotWorker.RejectConfig == nil || gotWorker.RejectConfig.ExitCode == nil {
+				t.Fatalf("mockWorkers[%d].rejectConfig.exitCode = %#v, want %d", i, gotWorker.RejectConfig, *wantWorker.RejectExitCode)
+			}
+			if *gotWorker.RejectConfig.ExitCode != *wantWorker.RejectExitCode {
+				t.Fatalf("mockWorkers[%d].rejectConfig.exitCode = %d, want %d", i, *gotWorker.RejectConfig.ExitCode, *wantWorker.RejectExitCode)
+			}
+		}
+	}
+}
+
+func assertErrorFragments(t *testing.T, err error, fragments []string) {
+	t.Helper()
+
+	for _, fragment := range fragments {
+		if !strings.Contains(err.Error(), fragment) {
+			t.Fatalf("error = %q, want fragment %q", err.Error(), fragment)
+		}
+	}
+}
+
+func readRepoFixture(t *testing.T, rel string) []byte {
+	t.Helper()
+
+	path := repoFixturePath(t, rel)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", path, err)
+	}
+	return data
+}
+
+func repoFixturePath(t *testing.T, rel string) string {
+	t.Helper()
+
+	return testutil.MustRepoPath(t, filepath.ToSlash(rel))
+}
+
+func indexInputCasesByID(t *testing.T, cases []mockworkers.InputCase) map[string]mockworkers.InputCase {
+	t.Helper()
+
+	indexed := make(map[string]mockworkers.InputCase, len(cases))
+	for _, inputCase := range cases {
+		if inputCase.ID == "" {
+			t.Fatal("input case missing id")
+		}
+		if _, exists := indexed[inputCase.ID]; exists {
+			t.Fatalf("duplicate input case id %q", inputCase.ID)
+		}
+		indexed[inputCase.ID] = inputCase
+	}
+	return indexed
+}
+
+func TestMarshalInputInventoryJSON_IsByteIdenticalAcrossRepeatedProjections(t *testing.T) {
+	t.Parallel()
+
+	first := mockworkers.ProjectInputInventory()
+	second := mockworkers.ProjectInputInventory()
+
+	firstJSON, err := mockworkers.MarshalInputInventoryJSON(first)
+	if err != nil {
+		t.Fatalf("first MarshalInputInventoryJSON() error = %v", err)
+	}
+	secondJSON, err := mockworkers.MarshalInputInventoryJSON(second)
+	if err != nil {
+		t.Fatalf("second MarshalInputInventoryJSON() error = %v", err)
+	}
+	if !bytes.Equal(firstJSON, secondJSON) {
+		t.Fatalf("repeated mock workers input inventory json differs")
+	}
+	if firstJSON[len(firstJSON)-1] != '\n' {
+		t.Fatalf("mock workers input inventory json missing trailing newline")
+	}
+}
+
+func TestProjectInputInventory_MatchesCommittedBaseline(t *testing.T) {
+	inventory := mockworkers.ProjectInputInventory()
+	got, err := mockworkers.MarshalInputInventoryJSON(inventory)
+	if err != nil {
+		t.Fatalf("MarshalInputInventoryJSON() error = %v", err)
+	}
+
+	fixturePath := testutil.MustRepoPath(t, mockworkers.InputIndexBaselineRelativePath)
+	want, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("read baseline fixture %s: %v", fixturePath, err)
+	}
+	want = mockworkers.NormalizeFixtureBytes(want)
+	if bytes.Equal(got, want) {
+		return
+	}
+
+	t.Fatalf(
+		"mock workers input index baseline drift detected; update %s when intentional\nwant %d bytes, got %d bytes",
+		mockworkers.InputIndexBaselineRelativePath,
+		len(want),
+		len(got),
+	)
+}
+
+func TestWriteMockWorkersInputIndexBaseline(t *testing.T) {
+	if os.Getenv("UPDATE_MOCK_WORKERS_BASELINES") != "1" {
+		t.Skip("set UPDATE_MOCK_WORKERS_BASELINES=1 to rewrite fixtures")
+	}
+
+	inventory := mockworkers.ProjectInputInventory()
+	got, err := mockworkers.MarshalInputInventoryJSON(inventory)
+	if err != nil {
+		t.Fatalf("MarshalInputInventoryJSON() error = %v", err)
+	}
+
+	fixturePath := testutil.MustRepoPath(t, mockworkers.InputIndexBaselineRelativePath)
+	if err := os.MkdirAll(filepath.Dir(fixturePath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(fixturePath, got, 0o644); err != nil {
+		t.Fatalf("write baseline fixture %s: %v", fixturePath, err)
+	}
+}

--- a/pkg/config/mockworkers/input_inventory_test.go
+++ b/pkg/config/mockworkers/input_inventory_test.go
@@ -53,6 +53,51 @@ func TestProjectInputInventory_HasDocsExampleAndVariantCases(t *testing.T) {
 	}
 }
 
+func TestProjectInputInventory_HasUnknownFieldAndInvalidUnionRejectCases(t *testing.T) {
+	t.Parallel()
+
+	inventory := mockworkers.ProjectInputInventory()
+	byID := indexInputCasesByID(t, inventory.Cases)
+
+	required := []string{
+		"invalid-unknown-top-level",
+		"invalid-unknown-nested-mock-worker",
+		"invalid-trailing-json",
+		"invalid-unknown-run-type",
+		"invalid-unknown-unmatched-policy",
+		"invalid-script-without-script-config",
+		"invalid-script-without-command",
+		"invalid-reject-exit-code-out-of-range",
+	}
+	for _, id := range required {
+		inputCase, ok := byID[id]
+		if !ok {
+			t.Fatalf("missing indexed invalid input case %q", id)
+		}
+		if inputCase.Outcome != "reject" {
+			t.Fatalf("input case %q outcome = %q, want reject", id, inputCase.Outcome)
+		}
+		if len(inputCase.ErrorFragments) == 0 {
+			t.Fatalf("input case %q missing errorFragments", id)
+		}
+	}
+
+	var unknownFieldReject bool
+	for _, inputCase := range inventory.Cases {
+		if inputCase.Category != "parse-unknown-field" || inputCase.Outcome != "reject" {
+			continue
+		}
+		if inputCase.Fixture == "" {
+			t.Fatalf("unknown-field case %q missing fixture", inputCase.ID)
+		}
+		unknownFieldReject = true
+		break
+	}
+	if !unknownFieldReject {
+		t.Fatal("missing unknown-field reject case in input inventory")
+	}
+}
+
 func TestIndexedInputCases_MatchProductionLoaders(t *testing.T) {
 	inventory := mockworkers.ProjectInputInventory()
 	seen := make(map[string]struct{}, len(inventory.Cases))

--- a/pkg/config/mockworkers/input_inventory_test.go
+++ b/pkg/config/mockworkers/input_inventory_test.go
@@ -180,12 +180,7 @@ func assertMockWorkersConfigExpectation(t *testing.T, cfg *mockworkers.MockWorke
 	if cfg == nil {
 		t.Fatal("loader returned nil config")
 	}
-	if want.UnmatchedDispatchPolicy != "" {
-		got := string(cfg.UnmatchedDispatchPolicy)
-		if got != want.UnmatchedDispatchPolicy {
-			t.Fatalf("unmatchedDispatchPolicy = %q, want %q", got, want.UnmatchedDispatchPolicy)
-		}
-	}
+	assertUnmatchedDispatchPolicyExpectation(t, cfg, want)
 	if len(cfg.MockWorkers) != want.MockWorkerCount {
 		t.Fatalf("mock worker count = %d, want %d", len(cfg.MockWorkers), want.MockWorkerCount)
 	}
@@ -193,35 +188,66 @@ func assertMockWorkersConfigExpectation(t *testing.T, cfg *mockworkers.MockWorke
 		if i >= len(cfg.MockWorkers) {
 			t.Fatalf("mockWorkers[%d] missing, want %#v", i, wantWorker)
 		}
-		gotWorker := cfg.MockWorkers[i]
-		if wantWorker.ID != "" && gotWorker.ID != wantWorker.ID {
-			t.Fatalf("mockWorkers[%d].id = %q, want %q", i, gotWorker.ID, wantWorker.ID)
-		}
-		if wantWorker.WorkerName != "" && gotWorker.WorkerName != wantWorker.WorkerName {
-			t.Fatalf("mockWorkers[%d].workerName = %q, want %q", i, gotWorker.WorkerName, wantWorker.WorkerName)
-		}
-		if wantWorker.WorkstationName != "" && gotWorker.WorkstationName != wantWorker.WorkstationName {
-			t.Fatalf("mockWorkers[%d].workstationName = %q, want %q", i, gotWorker.WorkstationName, wantWorker.WorkstationName)
-		}
-		if wantWorker.RunType != "" && string(gotWorker.RunType) != wantWorker.RunType {
-			t.Fatalf("mockWorkers[%d].runType = %q, want %q", i, gotWorker.RunType, wantWorker.RunType)
-		}
-		if wantWorker.ScriptCommand != "" {
-			if gotWorker.ScriptConfig == nil {
-				t.Fatalf("mockWorkers[%d].scriptConfig = nil, want command %q", i, wantWorker.ScriptCommand)
-			}
-			if gotWorker.ScriptConfig.Command != wantWorker.ScriptCommand {
-				t.Fatalf("mockWorkers[%d].scriptConfig.command = %q, want %q", i, gotWorker.ScriptConfig.Command, wantWorker.ScriptCommand)
-			}
-		}
-		if wantWorker.RejectExitCode != nil {
-			if gotWorker.RejectConfig == nil || gotWorker.RejectConfig.ExitCode == nil {
-				t.Fatalf("mockWorkers[%d].rejectConfig.exitCode = %#v, want %d", i, gotWorker.RejectConfig, *wantWorker.RejectExitCode)
-			}
-			if *gotWorker.RejectConfig.ExitCode != *wantWorker.RejectExitCode {
-				t.Fatalf("mockWorkers[%d].rejectConfig.exitCode = %d, want %d", i, *gotWorker.RejectConfig.ExitCode, *wantWorker.RejectExitCode)
-			}
-		}
+		assertMockWorkerExpectation(t, i, cfg.MockWorkers[i], wantWorker)
+	}
+}
+
+func assertUnmatchedDispatchPolicyExpectation(t *testing.T, cfg *mockworkers.MockWorkersConfig, want *mockworkers.MockWorkersConfigExpectation) {
+	t.Helper()
+
+	if want.UnmatchedDispatchPolicy == "" {
+		return
+	}
+	got := string(cfg.UnmatchedDispatchPolicy)
+	if got != want.UnmatchedDispatchPolicy {
+		t.Fatalf("unmatchedDispatchPolicy = %q, want %q", got, want.UnmatchedDispatchPolicy)
+	}
+}
+
+func assertMockWorkerExpectation(t *testing.T, index int, got mockworkers.MockWorkerConfig, want mockworkers.MockWorkerExpectation) {
+	t.Helper()
+
+	if want.ID != "" && got.ID != want.ID {
+		t.Fatalf("mockWorkers[%d].id = %q, want %q", index, got.ID, want.ID)
+	}
+	if want.WorkerName != "" && got.WorkerName != want.WorkerName {
+		t.Fatalf("mockWorkers[%d].workerName = %q, want %q", index, got.WorkerName, want.WorkerName)
+	}
+	if want.WorkstationName != "" && got.WorkstationName != want.WorkstationName {
+		t.Fatalf("mockWorkers[%d].workstationName = %q, want %q", index, got.WorkstationName, want.WorkstationName)
+	}
+	if want.RunType != "" && string(got.RunType) != want.RunType {
+		t.Fatalf("mockWorkers[%d].runType = %q, want %q", index, got.RunType, want.RunType)
+	}
+	assertMockWorkerScriptExpectation(t, index, got, want)
+	assertMockWorkerRejectExpectation(t, index, got, want)
+}
+
+func assertMockWorkerScriptExpectation(t *testing.T, index int, got mockworkers.MockWorkerConfig, want mockworkers.MockWorkerExpectation) {
+	t.Helper()
+
+	if want.ScriptCommand == "" {
+		return
+	}
+	if got.ScriptConfig == nil {
+		t.Fatalf("mockWorkers[%d].scriptConfig = nil, want command %q", index, want.ScriptCommand)
+	}
+	if got.ScriptConfig.Command != want.ScriptCommand {
+		t.Fatalf("mockWorkers[%d].scriptConfig.command = %q, want %q", index, got.ScriptConfig.Command, want.ScriptCommand)
+	}
+}
+
+func assertMockWorkerRejectExpectation(t *testing.T, index int, got mockworkers.MockWorkerConfig, want mockworkers.MockWorkerExpectation) {
+	t.Helper()
+
+	if want.RejectExitCode == nil {
+		return
+	}
+	if got.RejectConfig == nil || got.RejectConfig.ExitCode == nil {
+		t.Fatalf("mockWorkers[%d].rejectConfig.exitCode = %#v, want %d", index, got.RejectConfig, *want.RejectExitCode)
+	}
+	if *got.RejectConfig.ExitCode != *want.RejectExitCode {
+		t.Fatalf("mockWorkers[%d].rejectConfig.exitCode = %d, want %d", index, *got.RejectConfig.ExitCode, *want.RejectExitCode)
 	}
 }
 

--- a/pkg/config/mockworkers/inventory.go
+++ b/pkg/config/mockworkers/inventory.go
@@ -1,0 +1,71 @@
+// Package mockworkers loads and validates the mock-workers JSON contract. The
+// inventory types in this file document current production-loader acceptance
+// without changing parse or validation behavior.
+package mockworkers
+
+// FormatVersion identifies the mock-worker topology inventory document shape.
+const FormatVersion = "mock-workers-topology/v1"
+
+const (
+	ownerDecode   = "decode"
+	ownerValidate = "validate"
+)
+
+// Inventory is the canonical mock-worker authoring topology document.
+type Inventory struct {
+	FormatVersion              string                    `json:"formatVersion"`
+	LoaderEntrypoints          []string                  `json:"loaderEntrypoints"`
+	UnknownFieldPolicy         string                    `json:"unknownFieldPolicy"`
+	EntrySelectionPolicy       string                    `json:"entrySelectionPolicy"`
+	RunTypeUnion               RunTypeUnion              `json:"runTypeUnion"`
+	UnmatchedDispatchPolicies []UnmatchedDispatchPolicy `json:"unmatchedDispatchPolicies"`
+	ValidationBoundaries       []ValidationBoundary      `json:"validationBoundaries"`
+	NotAcceptedCapabilities    []NotAcceptedCapability   `json:"notAcceptedCapabilities"`
+	Fields                     []FieldRecord             `json:"fields"`
+}
+
+// RunTypeUnion documents accepted runType values and nested config requirements.
+type RunTypeUnion struct {
+	Summary string          `json:"summary"`
+	Values  []RunTypeRecord `json:"values"`
+}
+
+// RunTypeRecord inventories one accepted runType variant.
+type RunTypeRecord struct {
+	Value              string `json:"value"`
+	NestedConfig       string `json:"nestedConfig,omitempty"`
+	NestedConfigPolicy string `json:"nestedConfigPolicy,omitempty"`
+}
+
+// UnmatchedDispatchPolicy inventories one accepted unmatched-dispatch value.
+type UnmatchedDispatchPolicy struct {
+	Value           string `json:"value"`
+	OmittedBehavior bool   `json:"omittedBehavior,omitempty"`
+	Summary         string `json:"summary"`
+}
+
+// ValidationBoundary records a strict rejection owned by decode or Validate.
+type ValidationBoundary struct {
+	Condition    string `json:"condition"`
+	Owner        string `json:"owner"`
+	ErrorPattern string `json:"errorPattern"`
+}
+
+// NotAcceptedCapability documents batch-language categories the loader does not accept.
+type NotAcceptedCapability struct {
+	Category string `json:"category"`
+	Reason   string `json:"reason"`
+}
+
+// FieldRecord inventories one accepted mock-worker JSON field.
+type FieldRecord struct {
+	ID                   string `json:"id"`
+	JSONPath             string `json:"jsonPath"`
+	JSONName             string `json:"jsonName"`
+	ValueType            string `json:"valueType"`
+	ParentField          string `json:"parentField,omitempty"`
+	Required             string `json:"required"`
+	DefaultEmptyBehavior string `json:"defaultEmptyBehavior"`
+	ValidationOwner      string `json:"validationOwner"`
+	Notes                string `json:"notes,omitempty"`
+}

--- a/pkg/config/mockworkers/inventory_test.go
+++ b/pkg/config/mockworkers/inventory_test.go
@@ -1,0 +1,232 @@
+package mockworkers_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/config/mockworkers"
+	"github.com/portpowered/infinite-you/pkg/testutil"
+)
+
+func TestProjectTopologyInventory_RecordsLoaderBoundariesAndRunTypes(t *testing.T) {
+	t.Parallel()
+
+	inventory := mockworkers.ProjectTopologyInventory()
+	if inventory.FormatVersion != mockworkers.FormatVersion {
+		t.Fatalf("FormatVersion = %q, want %q", inventory.FormatVersion, mockworkers.FormatVersion)
+	}
+	if !strings.Contains(inventory.UnknownFieldPolicy, "DisallowUnknownFields") {
+		t.Fatalf("unknown field policy = %q, want strict decode language", inventory.UnknownFieldPolicy)
+	}
+	if !strings.Contains(inventory.EntrySelectionPolicy, "first matching") {
+		t.Fatalf("entry selection policy = %q, want first-match language", inventory.EntrySelectionPolicy)
+	}
+
+	runTypes := make(map[string]mockworkers.RunTypeRecord, len(inventory.RunTypeUnion.Values))
+	for _, value := range inventory.RunTypeUnion.Values {
+		runTypes[value.Value] = value
+	}
+	for _, want := range []string{"accept", "script", "reject"} {
+		if _, ok := runTypes[want]; !ok {
+			t.Fatalf("missing runType union value %q", want)
+		}
+	}
+	if runTypes["script"].NestedConfig != "scriptConfig" {
+		t.Fatalf("script nested config = %q, want scriptConfig", runTypes["script"].NestedConfig)
+	}
+	if runTypes["reject"].NestedConfig != "rejectConfig" {
+		t.Fatalf("reject nested config = %q, want rejectConfig", runTypes["reject"].NestedConfig)
+	}
+}
+
+func TestProjectTopologyInventory_RecordsRequiredFieldsAndSelectors(t *testing.T) {
+	t.Parallel()
+
+	inventory := mockworkers.ProjectTopologyInventory()
+	byID := indexFieldsByID(t, inventory.Fields)
+
+	required := []string{
+		"mockWorkers",
+		"unmatchedDispatchPolicy",
+		"mockWorkers[].id",
+		"mockWorkers[].workerName",
+		"mockWorkers[].workstationName",
+		"mockWorkers[].workInputs",
+		"mockWorkers[].runType",
+		"mockWorkers[].scriptConfig",
+		"mockWorkers[].rejectConfig",
+		"mockWorkers[].workInputs[].workId",
+		"mockWorkers[].workInputs[].workType",
+		"mockWorkers[].workInputs[].state",
+		"mockWorkers[].workInputs[].inputName",
+		"mockWorkers[].workInputs[].traceId",
+		"mockWorkers[].workInputs[].channel",
+		"mockWorkers[].workInputs[].payloadHash",
+		"mockWorkers[].scriptConfig.command",
+		"mockWorkers[].scriptConfig.args",
+		"mockWorkers[].scriptConfig.env",
+		"mockWorkers[].scriptConfig.workingDirectory",
+		"mockWorkers[].scriptConfig.stdin",
+		"mockWorkers[].scriptConfig.timeout",
+		"mockWorkers[].rejectConfig.stdout",
+		"mockWorkers[].rejectConfig.stderr",
+		"mockWorkers[].rejectConfig.exitCode",
+	}
+	for _, id := range required {
+		if _, ok := byID[id]; !ok {
+			t.Fatalf("missing inventoried field %q", id)
+		}
+	}
+
+	runType := byID["mockWorkers[].runType"]
+	if runType.ValidationOwner != "validate" {
+		t.Fatalf("runType validation owner = %q, want validate", runType.ValidationOwner)
+	}
+	if runType.Required != "required" {
+		t.Fatalf("runType required = %q, want required", runType.Required)
+	}
+
+	command := byID["mockWorkers[].scriptConfig.command"]
+	if command.Required != "required when runType is script" {
+		t.Fatalf("script command required = %q, want required when runType is script", command.Required)
+	}
+
+	exitCode := byID["mockWorkers[].rejectConfig.exitCode"]
+	if exitCode.ValidationOwner != "validate" {
+		t.Fatalf("exitCode validation owner = %q, want validate", exitCode.ValidationOwner)
+	}
+
+	if len(inventory.UnmatchedDispatchPolicies) < 3 {
+		t.Fatalf("unmatched policy len = %d, want accept default plus explicit accept and passthrough", len(inventory.UnmatchedDispatchPolicies))
+	}
+}
+
+func TestProjectTopologyInventory_RecordsStrictBoundariesAndNonAcceptedCapabilities(t *testing.T) {
+	t.Parallel()
+
+	inventory := mockworkers.ProjectTopologyInventory()
+	if len(inventory.ValidationBoundaries) < 7 {
+		t.Fatalf("validation boundary len = %d, want decode and validate rejections", len(inventory.ValidationBoundaries))
+	}
+
+	patterns := make([]string, 0, len(inventory.ValidationBoundaries))
+	for _, boundary := range inventory.ValidationBoundaries {
+		patterns = append(patterns, boundary.ErrorPattern)
+	}
+	for _, want := range []string{
+		"unknown field",
+		`runType must be one of "accept", "script", or "reject"`,
+		`scriptConfig is required when runType is "script"`,
+		`scriptConfig.command is required when runType is "script"`,
+		"rejectConfig.exitCode must be between 1 and 255",
+	} {
+		if !containsSubstring(patterns, want) {
+			t.Fatalf("missing validation boundary pattern %q in %#v", want, patterns)
+		}
+	}
+
+	categories := make([]string, 0, len(inventory.NotAcceptedCapabilities))
+	for _, capability := range inventory.NotAcceptedCapabilities {
+		categories = append(categories, capability.Category)
+	}
+	for _, want := range []string{"media", "artifact payloads", "response sequences"} {
+		if !containsSubstring(categories, want) {
+			t.Fatalf("missing not-accepted capability category %q in %#v", want, categories)
+		}
+	}
+}
+
+func TestMarshalCanonicalJSON_IsByteIdenticalAcrossRepeatedProjections(t *testing.T) {
+	t.Parallel()
+
+	first := mockworkers.ProjectTopologyInventory()
+	second := mockworkers.ProjectTopologyInventory()
+
+	firstJSON, err := mockworkers.MarshalCanonicalJSON(first)
+	if err != nil {
+		t.Fatalf("first MarshalCanonicalJSON() error = %v", err)
+	}
+	secondJSON, err := mockworkers.MarshalCanonicalJSON(second)
+	if err != nil {
+		t.Fatalf("second MarshalCanonicalJSON() error = %v", err)
+	}
+	if !bytes.Equal(firstJSON, secondJSON) {
+		t.Fatalf("repeated topology inventory json differs")
+	}
+	if firstJSON[len(firstJSON)-1] != '\n' {
+		t.Fatalf("topology inventory json missing trailing newline")
+	}
+}
+
+func TestProjectTopologyInventory_MatchesCommittedBaseline(t *testing.T) {
+	inventory := mockworkers.ProjectTopologyInventory()
+	got, err := mockworkers.MarshalCanonicalJSON(inventory)
+	if err != nil {
+		t.Fatalf("MarshalCanonicalJSON() error = %v", err)
+	}
+
+	fixturePath := testutil.MustRepoPath(t, mockworkers.TopologyBaselineRelativePath)
+	want, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("read baseline fixture %s: %v", fixturePath, err)
+	}
+	want = mockworkers.NormalizeFixtureBytes(want)
+	if bytes.Equal(got, want) {
+		return
+	}
+
+	t.Fatalf(
+		"mock workers topology baseline drift detected; update %s when intentional\nwant %d bytes, got %d bytes",
+		mockworkers.TopologyBaselineRelativePath,
+		len(want),
+		len(got),
+	)
+}
+
+func TestWriteTopologyInventoryBaseline(t *testing.T) {
+	if os.Getenv("UPDATE_MOCK_WORKERS_BASELINES") != "1" {
+		t.Skip("set UPDATE_MOCK_WORKERS_BASELINES=1 to rewrite fixtures")
+	}
+
+	inventory := mockworkers.ProjectTopologyInventory()
+	got, err := mockworkers.MarshalCanonicalJSON(inventory)
+	if err != nil {
+		t.Fatalf("MarshalCanonicalJSON() error = %v", err)
+	}
+
+	fixturePath := testutil.MustRepoPath(t, mockworkers.TopologyBaselineRelativePath)
+	if err := os.MkdirAll(filepath.Dir(fixturePath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(fixturePath, got, 0o644); err != nil {
+		t.Fatalf("write baseline fixture %s: %v", fixturePath, err)
+	}
+}
+
+func indexFieldsByID(t *testing.T, fields []mockworkers.FieldRecord) map[string]mockworkers.FieldRecord {
+	t.Helper()
+
+	indexed := make(map[string]mockworkers.FieldRecord, len(fields))
+	for _, field := range fields {
+		if field.ID == "" {
+			t.Fatal("field record missing id")
+		}
+		if _, exists := indexed[field.ID]; exists {
+			t.Fatalf("duplicate field id %q", field.ID)
+		}
+		indexed[field.ID] = field
+	}
+	return indexed
+}
+
+func containsSubstring(values []string, want string) bool {
+	for _, value := range values {
+		if strings.Contains(value, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/config/mockworkers/lane_gate_test.go
+++ b/pkg/config/mockworkers/lane_gate_test.go
@@ -1,0 +1,139 @@
+package mockworkers_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/config/mockworkers"
+	"github.com/portpowered/infinite-you/pkg/testutil"
+)
+
+// productionLoaderSources records the loader implementation files this inventory
+// lane must not alter. Update hashes only when intentionally changing loader behavior
+// outside this lane.
+var productionLoaderSources = []struct {
+	relativePath string
+	sha256Hex    string
+}{
+	{
+		relativePath: "pkg/config/mockworkers/config.go",
+		sha256Hex:    "11c46cfb4827d64d7f20f5525a74eee58b589ca3ab61f206ad50173d0ba16985",
+	},
+}
+
+var inventoryLaneRoots = []string{
+	"pkg/config/mockworkers/testdata",
+}
+
+func TestProductionLoaderSources_UnchangedForInventoryLane(t *testing.T) {
+	t.Parallel()
+
+	for _, src := range productionLoaderSources {
+		src := src
+		t.Run(src.relativePath, func(t *testing.T) {
+			t.Parallel()
+
+			path := testutil.MustRepoPath(t, src.relativePath)
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read production loader source %s: %v", path, err)
+			}
+			data = mockworkers.NormalizeSourceBytes(data)
+
+			sum := sha256.Sum256(data)
+			got := hex.EncodeToString(sum[:])
+			if got != src.sha256Hex {
+				t.Fatalf(
+					"production loader source drift detected for %s; update lane gate hashes only when intentionally changing loader behavior\ngot %s, want %s",
+					src.relativePath,
+					got,
+					src.sha256Hex,
+				)
+			}
+		})
+	}
+}
+
+func TestInventoryLane_RepeatedSerializationIsByteIdenticalAcrossOwners(t *testing.T) {
+	t.Parallel()
+
+	topologyFirst, err := mockworkers.MarshalCanonicalJSON(mockworkers.ProjectTopologyInventory())
+	if err != nil {
+		t.Fatalf("topology first MarshalCanonicalJSON() error = %v", err)
+	}
+	topologySecond, err := mockworkers.MarshalCanonicalJSON(mockworkers.ProjectTopologyInventory())
+	if err != nil {
+		t.Fatalf("topology second MarshalCanonicalJSON() error = %v", err)
+	}
+	if !bytes.Equal(topologyFirst, topologySecond) {
+		t.Fatalf("repeated mock workers topology inventory json differs")
+	}
+
+	inputFirst, err := mockworkers.MarshalInputInventoryJSON(mockworkers.ProjectInputInventory())
+	if err != nil {
+		t.Fatalf("input first MarshalInputInventoryJSON() error = %v", err)
+	}
+	inputSecond, err := mockworkers.MarshalInputInventoryJSON(mockworkers.ProjectInputInventory())
+	if err != nil {
+		t.Fatalf("input second MarshalInputInventoryJSON() error = %v", err)
+	}
+	if !bytes.Equal(inputFirst, inputSecond) {
+		t.Fatalf("repeated mock workers input inventory json differs")
+	}
+}
+
+func TestInventoryLane_DoesNotAuthorDraft202012Schemas(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := testutil.MustRepoPath(t, ".")
+	for _, root := range inventoryLaneRoots {
+		root := root
+		t.Run(root, func(t *testing.T) {
+			t.Parallel()
+
+			scanRoot := filepath.Join(repoRoot, filepath.FromSlash(root))
+			err := filepath.WalkDir(scanRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+				if walkErr != nil {
+					return walkErr
+				}
+				if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+					return nil
+				}
+
+				data, err := os.ReadFile(path)
+				if err != nil {
+					return err
+				}
+				lower := strings.ToLower(string(data))
+				if strings.Contains(lower, `"$schema"`) && strings.Contains(lower, "draft-2020-12") {
+					t.Fatalf("draft-2020-12 schema document found in inventory lane: %s", path)
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("walk inventory lane root %s: %v", scanRoot, err)
+			}
+		})
+	}
+}
+
+func TestInventoryLane_DocumentsNonAcceptedCapabilitiesWithoutInventingThem(t *testing.T) {
+	t.Parallel()
+
+	inventory := mockworkers.ProjectTopologyInventory()
+	categories := make([]string, 0, len(inventory.NotAcceptedCapabilities))
+	for _, capability := range inventory.NotAcceptedCapabilities {
+		categories = append(categories, capability.Category)
+	}
+	for _, want := range []string{"media", "dispatch delay", "artifact payloads", "response sequences"} {
+		if !containsSubstring(categories, want) {
+			t.Fatalf("missing not-accepted capability category %q in %#v", want, categories)
+		}
+	}
+}

--- a/pkg/config/mockworkers/project.go
+++ b/pkg/config/mockworkers/project.go
@@ -1,0 +1,122 @@
+package mockworkers
+
+// TopologyBaselineRelativePath is the committed mock-worker topology inventory fixture.
+const TopologyBaselineRelativePath = "pkg/config/mockworkers/testdata/baseline/mock-workers-topology.json"
+
+// ProjectTopologyInventory builds the deterministic mock-worker topology inventory
+// from current ParseMockWorkersConfig / LoadMockWorkersConfig / Validate boundaries.
+func ProjectTopologyInventory() Inventory {
+	return Inventory{
+		FormatVersion: FormatVersion,
+		LoaderEntrypoints: []string{
+			"ParseMockWorkersConfig",
+			"LoadMockWorkersConfig",
+			"MockWorkersConfig.Validate",
+			"MockWorkerConfig.Validate",
+		},
+		UnknownFieldPolicy: "ParseMockWorkersConfig uses json.Decoder.DisallowUnknownFields and rejects unknown top-level keys, unknown nested keys, and trailing JSON values",
+		EntrySelectionPolicy: "first matching mockWorkers[] entry wins; there is no response-sequence or multi-hit authoring surface beyond that first-match selection",
+		RunTypeUnion:         topologyRunTypeUnion(),
+		UnmatchedDispatchPolicies: []UnmatchedDispatchPolicy{
+			{
+				Value:           string(MockWorkerUnmatchedDispatchPolicyAccept),
+				OmittedBehavior: true,
+				Summary:         "default when unmatchedDispatchPolicy is omitted; unmatched dispatches return the synthetic accepted mock result",
+			},
+			{
+				Value:   string(MockWorkerUnmatchedDispatchPolicyAccept),
+				Summary: "explicit accept policy; same default-accept behavior as omission",
+			},
+			{
+				Value:   string(MockWorkerUnmatchedDispatchPolicyPassthrough),
+				Summary: "unmatched dispatches execute through the normal worker runner/provider path",
+			},
+		},
+		ValidationBoundaries:    topologyValidationBoundaries(),
+		NotAcceptedCapabilities: topologyNotAcceptedCapabilities(),
+		Fields:                  topologyFieldRecords(),
+	}
+}
+
+func topologyRunTypeUnion() RunTypeUnion {
+	return RunTypeUnion{
+		Summary: "runType is required on every mockWorkers[] entry and selects which nested config shape Validate enforces",
+		Values: []RunTypeRecord{
+			{
+				Value:              string(MockWorkerRunTypeAccept),
+				NestedConfigPolicy: "no nested config required; scriptConfig and rejectConfig are ignored when present",
+			},
+			{
+				Value:              string(MockWorkerRunTypeScript),
+				NestedConfig:       "scriptConfig",
+				NestedConfigPolicy: "scriptConfig is required; scriptConfig.command is required non-empty",
+			},
+			{
+				Value:              string(MockWorkerRunTypeReject),
+				NestedConfig:       "rejectConfig",
+				NestedConfigPolicy: "rejectConfig is optional; rejectConfig.exitCode when set must be between 1 and 255",
+			},
+		},
+	}
+}
+
+func topologyValidationBoundaries() []ValidationBoundary {
+	return []ValidationBoundary{
+		{
+			Condition:    "unknown top-level or nested JSON field",
+			Owner:        ownerDecode,
+			ErrorPattern: "unknown field",
+		},
+		{
+			Condition:    "trailing JSON after the root object",
+			Owner:        ownerDecode,
+			ErrorPattern: "unexpected trailing JSON",
+		},
+		{
+			Condition:    "unknown unmatchedDispatchPolicy value",
+			Owner:        ownerValidate,
+			ErrorPattern: `unmatchedDispatchPolicy must be one of "accept" or "passthrough"`,
+		},
+		{
+			Condition:    "unknown runType value",
+			Owner:        ownerValidate,
+			ErrorPattern: `runType must be one of "accept", "script", or "reject"`,
+		},
+		{
+			Condition:    "runType script without scriptConfig",
+			Owner:        ownerValidate,
+			ErrorPattern: `scriptConfig is required when runType is "script"`,
+		},
+		{
+			Condition:    "runType script with scriptConfig missing command",
+			Owner:        ownerValidate,
+			ErrorPattern: `scriptConfig.command is required when runType is "script"`,
+		},
+		{
+			Condition:    "rejectConfig.exitCode outside 1-255 when set",
+			Owner:        ownerValidate,
+			ErrorPattern: "rejectConfig.exitCode must be between 1 and 255",
+		},
+	}
+}
+
+func topologyNotAcceptedCapabilities() []NotAcceptedCapability {
+	return []NotAcceptedCapability{
+		{
+			Category: "media",
+			Reason:   "no media payload or media-response authoring fields are accepted by ParseMockWorkersConfig",
+		},
+		{
+			Category: "dispatch delay or timing fields",
+			Reason:   "no per-entry delay, sleep, or dispatch-timing fields are accepted; scriptConfig.timeout only bounds local script execution",
+		},
+		{
+			Category: "artifact payloads",
+			Reason:   "no artifact upload/download or artifact payload fields are accepted on mockWorkers entries",
+		},
+		{
+			Category: "response sequences",
+			Reason:   "no multi-step response sequence authoring exists beyond first-match mockWorkers[] entry selection",
+		},
+	}
+}

--- a/pkg/config/mockworkers/project_fields.go
+++ b/pkg/config/mockworkers/project_fields.go
@@ -1,0 +1,242 @@
+package mockworkers
+
+func topologyFieldRecords() []FieldRecord {
+	fields := make([]FieldRecord, 0, 26)
+	fields = append(fields, topologyTopLevelFields()...)
+	fields = append(fields, topologyMockWorkerEntryFields()...)
+	fields = append(fields, topologyWorkInputSelectorFields()...)
+	fields = append(fields, topologyScriptConfigFields()...)
+	fields = append(fields, topologyRejectConfigFields()...)
+	return fields
+}
+
+func topologyTopLevelFields() []FieldRecord {
+	return []FieldRecord{
+		{
+			ID:                   "mockWorkers",
+			JSONPath:             "mockWorkers",
+			JSONName:             "mockWorkers",
+			ValueType:            "array",
+			Required:             "required",
+			DefaultEmptyBehavior: "missing mockWorkers decodes as an empty slice; nil after decode is normalized to []",
+			ValidationOwner:      ownerDecode,
+			Notes:                "LoadMockWorkersConfig with an empty path returns NewEmptyMockWorkersConfig without reading a file",
+		},
+		{
+			ID:                   "unmatchedDispatchPolicy",
+			JSONPath:             "unmatchedDispatchPolicy",
+			JSONName:             "unmatchedDispatchPolicy",
+			ValueType:            "string enum",
+			Required:             "optional",
+			DefaultEmptyBehavior: "omitted or empty string behaves as accept for unmatched dispatches",
+			ValidationOwner:      ownerValidate,
+			Notes:                `accepted values are "accept" and "passthrough"`,
+		},
+	}
+}
+
+func topologyMockWorkerEntryFields() []FieldRecord {
+	return []FieldRecord{
+		{
+			ID:                   "mockWorkers[].id",
+			JSONPath:             "mockWorkers[].id",
+			JSONName:             "id",
+			ValueType:            "string",
+			ParentField:          "mockWorkers[]",
+			Required:             "optional",
+			DefaultEmptyBehavior: "omitted id is allowed and leaves diagnostics matching unconstrained",
+			ValidationOwner:      ownerDecode,
+		},
+		{
+			ID:                   "mockWorkers[].workerName",
+			JSONPath:             "mockWorkers[].workerName",
+			JSONName:             "workerName",
+			ValueType:            "string",
+			ParentField:          "mockWorkers[]",
+			Required:             "optional",
+			DefaultEmptyBehavior: "omitted workerName does not constrain worker-name matching",
+			ValidationOwner:      ownerDecode,
+		},
+		{
+			ID:                   "mockWorkers[].workstationName",
+			JSONPath:             "mockWorkers[].workstationName",
+			JSONName:             "workstationName",
+			ValueType:            "string",
+			ParentField:          "mockWorkers[]",
+			Required:             "optional",
+			DefaultEmptyBehavior: "omitted workstationName does not constrain workstation matching",
+			ValidationOwner:      ownerDecode,
+		},
+		{
+			ID:                   "mockWorkers[].workInputs",
+			JSONPath:             "mockWorkers[].workInputs",
+			JSONName:             "workInputs",
+			ValueType:            "array",
+			ParentField:          "mockWorkers[]",
+			Required:             "optional",
+			DefaultEmptyBehavior: "omitted workInputs does not constrain consumed work-input selectors",
+			ValidationOwner:      ownerDecode,
+		},
+		{
+			ID:                   "mockWorkers[].runType",
+			JSONPath:             "mockWorkers[].runType",
+			JSONName:             "runType",
+			ValueType:            "string enum",
+			ParentField:          "mockWorkers[]",
+			Required:             "required",
+			DefaultEmptyBehavior: "missing runType fails Validate with actionable runType union message",
+			ValidationOwner:      ownerValidate,
+			Notes:                `accepted values are "accept", "script", and "reject"`,
+		},
+		{
+			ID:                   "mockWorkers[].scriptConfig",
+			JSONPath:             "mockWorkers[].scriptConfig",
+			JSONName:             "scriptConfig",
+			ValueType:            "object",
+			ParentField:          "mockWorkers[]",
+			Required:             "required when runType is script",
+			DefaultEmptyBehavior: "omitted scriptConfig is rejected when runType is script",
+			ValidationOwner:      ownerValidate,
+		},
+		{
+			ID:                   "mockWorkers[].rejectConfig",
+			JSONPath:             "mockWorkers[].rejectConfig",
+			JSONName:             "rejectConfig",
+			ValueType:            "object",
+			ParentField:          "mockWorkers[]",
+			Required:             "optional",
+			DefaultEmptyBehavior: "omitted rejectConfig is allowed when runType is reject",
+			ValidationOwner:      ownerValidate,
+		},
+	}
+}
+
+func topologyWorkInputSelectorFields() []FieldRecord {
+	selectors := []struct {
+		id       string
+		jsonName string
+	}{
+		{id: "mockWorkers[].workInputs[].workId", jsonName: "workId"},
+		{id: "mockWorkers[].workInputs[].workType", jsonName: "workType"},
+		{id: "mockWorkers[].workInputs[].state", jsonName: "state"},
+		{id: "mockWorkers[].workInputs[].inputName", jsonName: "inputName"},
+		{id: "mockWorkers[].workInputs[].traceId", jsonName: "traceId"},
+		{id: "mockWorkers[].workInputs[].channel", jsonName: "channel"},
+		{id: "mockWorkers[].workInputs[].payloadHash", jsonName: "payloadHash"},
+	}
+	fields := make([]FieldRecord, 0, len(selectors))
+	for _, selector := range selectors {
+		fields = append(fields, FieldRecord{
+			ID:                   selector.id,
+			JSONPath:             selector.id,
+			JSONName:             selector.jsonName,
+			ValueType:            "string",
+			ParentField:          "mockWorkers[].workInputs[]",
+			Required:             "optional",
+			DefaultEmptyBehavior: "omitted selector field does not constrain that dimension; all specified selector fields on an entry must match",
+			ValidationOwner:      ownerDecode,
+		})
+	}
+	return fields
+}
+
+func topologyScriptConfigFields() []FieldRecord {
+	return []FieldRecord{
+		{
+			ID:                   "mockWorkers[].scriptConfig.command",
+			JSONPath:             "mockWorkers[].scriptConfig.command",
+			JSONName:             "command",
+			ValueType:            "string",
+			ParentField:          "mockWorkers[].scriptConfig",
+			Required:             "required when runType is script",
+			DefaultEmptyBehavior: "missing or empty command fails Validate when runType is script",
+			ValidationOwner:      ownerValidate,
+		},
+		{
+			ID:                   "mockWorkers[].scriptConfig.args",
+			JSONPath:             "mockWorkers[].scriptConfig.args",
+			JSONName:             "args",
+			ValueType:            "array of string",
+			ParentField:          "mockWorkers[].scriptConfig",
+			Required:             "optional",
+			DefaultEmptyBehavior: "omitted args leaves command argument list empty",
+			ValidationOwner:      ownerDecode,
+		},
+		{
+			ID:                   "mockWorkers[].scriptConfig.env",
+			JSONPath:             "mockWorkers[].scriptConfig.env",
+			JSONName:             "env",
+			ValueType:            "object map string to string",
+			ParentField:          "mockWorkers[].scriptConfig",
+			Required:             "optional",
+			DefaultEmptyBehavior: "omitted env leaves script environment unchanged aside from runner defaults",
+			ValidationOwner:      ownerDecode,
+		},
+		{
+			ID:                   "mockWorkers[].scriptConfig.workingDirectory",
+			JSONPath:             "mockWorkers[].scriptConfig.workingDirectory",
+			JSONName:             "workingDirectory",
+			ValueType:            "string",
+			ParentField:          "mockWorkers[].scriptConfig",
+			Required:             "optional",
+			DefaultEmptyBehavior: "omitted workingDirectory uses runner default working directory",
+			ValidationOwner:      ownerDecode,
+		},
+		{
+			ID:                   "mockWorkers[].scriptConfig.stdin",
+			JSONPath:             "mockWorkers[].scriptConfig.stdin",
+			JSONName:             "stdin",
+			ValueType:            "string",
+			ParentField:          "mockWorkers[].scriptConfig",
+			Required:             "optional",
+			DefaultEmptyBehavior: "omitted stdin leaves script stdin empty",
+			ValidationOwner:      ownerDecode,
+		},
+		{
+			ID:                   "mockWorkers[].scriptConfig.timeout",
+			JSONPath:             "mockWorkers[].scriptConfig.timeout",
+			JSONName:             "timeout",
+			ValueType:            "string",
+			ParentField:          "mockWorkers[].scriptConfig",
+			Required:             "optional",
+			DefaultEmptyBehavior: "omitted timeout uses runner default script timeout; duration strings such as 30s are accepted when set",
+			ValidationOwner:      ownerDecode,
+			Notes:                "bounds local script execution only; not a dispatch-delay authoring field",
+		},
+	}
+}
+
+func topologyRejectConfigFields() []FieldRecord {
+	return []FieldRecord{
+		{
+			ID:                   "mockWorkers[].rejectConfig.stdout",
+			JSONPath:             "mockWorkers[].rejectConfig.stdout",
+			JSONName:             "stdout",
+			ValueType:            "string",
+			ParentField:          "mockWorkers[].rejectConfig",
+			Required:             "optional",
+			DefaultEmptyBehavior: "omitted stdout leaves rejected command stdout empty",
+			ValidationOwner:      ownerDecode,
+		},
+		{
+			ID:                   "mockWorkers[].rejectConfig.stderr",
+			JSONPath:             "mockWorkers[].rejectConfig.stderr",
+			JSONName:             "stderr",
+			ValueType:            "string",
+			ParentField:          "mockWorkers[].rejectConfig",
+			Required:             "optional",
+			DefaultEmptyBehavior: "omitted stderr leaves rejected command stderr empty",
+			ValidationOwner:      ownerDecode,
+		},
+		{
+			ID:                   "mockWorkers[].rejectConfig.exitCode",
+			JSONPath:             "mockWorkers[].rejectConfig.exitCode",
+			JSONName:             "exitCode",
+			ValueType:            "integer",
+			ParentField:          "mockWorkers[].rejectConfig",
+			Required:             "optional",
+			DefaultEmptyBehavior: "omitted exitCode leaves rejected exit code unset; when set must be between 1 and 255",
+			ValidationOwner:      ownerValidate,
+		},
+	}
+}

--- a/pkg/config/mockworkers/testdata/baseline/mock-workers-input-index.json
+++ b/pkg/config/mockworkers/testdata/baseline/mock-workers-input-index.json
@@ -142,6 +142,96 @@
       }
     },
     {
+      "id": "invalid-unknown-top-level",
+      "category": "parse-unknown-field",
+      "entrypoint": "ParseMockWorkersConfig",
+      "outcome": "reject",
+      "fixture": "pkg/config/mockworkers/testdata/fixtures/invalid/unknown-top-level.json",
+      "description": "unknown top-level keys are rejected under strict decode",
+      "errorFragments": [
+        "decode mock workers JSON",
+        "unknown field"
+      ]
+    },
+    {
+      "id": "invalid-unknown-nested-mock-worker",
+      "category": "parse-unknown-field",
+      "entrypoint": "ParseMockWorkersConfig",
+      "outcome": "reject",
+      "fixture": "pkg/config/mockworkers/testdata/fixtures/invalid/unknown-nested-mock-worker.json",
+      "description": "unknown nested mockWorkers[] keys are rejected under strict decode",
+      "errorFragments": [
+        "decode mock workers JSON",
+        "unknown field"
+      ]
+    },
+    {
+      "id": "invalid-trailing-json",
+      "category": "parse-unknown-field",
+      "entrypoint": "ParseMockWorkersConfig",
+      "outcome": "reject",
+      "fixture": "pkg/config/mockworkers/testdata/fixtures/invalid/trailing-json.json",
+      "description": "trailing JSON values after the root object are rejected",
+      "errorFragments": [
+        "unexpected trailing JSON"
+      ]
+    },
+    {
+      "id": "invalid-unknown-run-type",
+      "category": "parse-accept-entry",
+      "entrypoint": "ParseMockWorkersConfig",
+      "outcome": "reject",
+      "fixture": "pkg/config/mockworkers/testdata/fixtures/invalid/unknown-run-type.json",
+      "description": "unknown runType values fail validation with actionable diagnostics",
+      "errorFragments": [
+        "runType must be one of \"accept\", \"script\", or \"reject\"; got \"maybe\""
+      ]
+    },
+    {
+      "id": "invalid-unknown-unmatched-policy",
+      "category": "parse-unmatched-policy",
+      "entrypoint": "ParseMockWorkersConfig",
+      "outcome": "reject",
+      "fixture": "pkg/config/mockworkers/testdata/fixtures/invalid/unknown-unmatched-policy.json",
+      "description": "unknown unmatchedDispatchPolicy values fail validation with actionable diagnostics",
+      "errorFragments": [
+        "unmatchedDispatchPolicy must be one of \"accept\" or \"passthrough\"; got \"maybe\""
+      ]
+    },
+    {
+      "id": "invalid-script-without-script-config",
+      "category": "parse-script-entry",
+      "entrypoint": "ParseMockWorkersConfig",
+      "outcome": "reject",
+      "fixture": "pkg/config/mockworkers/testdata/fixtures/invalid/script-without-script-config.json",
+      "description": "script runType without scriptConfig fails validation",
+      "errorFragments": [
+        "scriptConfig is required"
+      ]
+    },
+    {
+      "id": "invalid-script-without-command",
+      "category": "parse-script-entry",
+      "entrypoint": "ParseMockWorkersConfig",
+      "outcome": "reject",
+      "fixture": "pkg/config/mockworkers/testdata/fixtures/invalid/script-without-command.json",
+      "description": "script runType without scriptConfig.command fails validation",
+      "errorFragments": [
+        "scriptConfig.command is required"
+      ]
+    },
+    {
+      "id": "invalid-reject-exit-code-out-of-range",
+      "category": "parse-reject-entry",
+      "entrypoint": "ParseMockWorkersConfig",
+      "outcome": "reject",
+      "fixture": "pkg/config/mockworkers/testdata/fixtures/invalid/reject-exit-code-out-of-range.json",
+      "description": "rejectConfig.exitCode outside 1-255 fails validation",
+      "errorFragments": [
+        "rejectConfig.exitCode must be between 1 and 255"
+      ]
+    },
+    {
       "id": "valid-load-empty-path",
       "category": "load-empty-path",
       "entrypoint": "LoadMockWorkersConfig",

--- a/pkg/config/mockworkers/testdata/baseline/mock-workers-input-index.json
+++ b/pkg/config/mockworkers/testdata/baseline/mock-workers-input-index.json
@@ -1,0 +1,200 @@
+{
+  "formatVersion": "mock-workers-input/v1",
+  "unknownFieldPolicy": "ParseMockWorkersConfig uses json.Decoder.DisallowUnknownFields and rejects unknown top-level keys, unknown nested keys, and trailing JSON values",
+  "loaderEntrypoints": [
+    "ParseMockWorkersConfig",
+    "LoadMockWorkersConfig"
+  ],
+  "cases": [
+    {
+      "id": "valid-empty-default",
+      "category": "parse-empty-default",
+      "entrypoint": "ParseMockWorkersConfig",
+      "outcome": "accept",
+      "fixture": "pkg/config/mockworkers/testdata/fixtures/valid/empty-accept.json",
+      "description": "empty mockWorkers array is the default accept config when unmatchedDispatchPolicy is omitted",
+      "expectedConfig": {}
+    },
+    {
+      "id": "valid-accept-entry-selectors",
+      "category": "parse-accept-entry",
+      "entrypoint": "ParseMockWorkersConfig",
+      "outcome": "accept",
+      "fixture": "pkg/config/mockworkers/testdata/fixtures/valid/accept-entry-selectors.json",
+      "description": "accept runType preserves selector-bearing workInputs entries",
+      "expectedConfig": {
+        "mockWorkerCount": 1,
+        "mockWorkers": [
+          {
+            "id": "accept-reviewer",
+            "workerName": "reviewer",
+            "workstationName": "review",
+            "runType": "accept"
+          }
+        ]
+      }
+    },
+    {
+      "id": "valid-reject-without-reject-config",
+      "category": "parse-reject-entry",
+      "entrypoint": "ParseMockWorkersConfig",
+      "outcome": "accept",
+      "fixture": "pkg/config/mockworkers/testdata/fixtures/valid/reject-without-reject-config.json",
+      "description": "reject runType accepts omitted rejectConfig",
+      "expectedConfig": {
+        "mockWorkerCount": 1,
+        "mockWorkers": [
+          {
+            "id": "reject-minimal",
+            "runType": "reject"
+          }
+        ]
+      }
+    },
+    {
+      "id": "valid-script-minimal-command",
+      "category": "parse-script-entry",
+      "entrypoint": "ParseMockWorkersConfig",
+      "outcome": "accept",
+      "fixture": "pkg/config/mockworkers/testdata/fixtures/valid/script-minimal-command.json",
+      "description": "script runType requires only scriptConfig.command; optional script fields may be omitted",
+      "expectedConfig": {
+        "mockWorkerCount": 1,
+        "mockWorkers": [
+          {
+            "id": "script-minimal",
+            "runType": "script",
+            "scriptCommand": "echo"
+          }
+        ]
+      }
+    },
+    {
+      "id": "valid-unmatched-policy-explicit-accept",
+      "category": "parse-unmatched-policy",
+      "entrypoint": "ParseMockWorkersConfig",
+      "outcome": "accept",
+      "fixture": "pkg/config/mockworkers/testdata/fixtures/valid/unmatched-policy-explicit-accept.json",
+      "description": "explicit unmatchedDispatchPolicy accept matches omitted-policy default behavior",
+      "expectedConfig": {
+        "unmatchedDispatchPolicy": "accept"
+      }
+    },
+    {
+      "id": "docs-example-mock-workers",
+      "category": "parse-docs-example",
+      "entrypoint": "ParseMockWorkersConfig",
+      "outcome": "accept",
+      "fixture": "docs/examples/mock-workers.json",
+      "description": "checked-in reject-with-rejectConfig docs example parses via production loader",
+      "expectedConfig": {
+        "mockWorkerCount": 1,
+        "mockWorkers": [
+          {
+            "id": "reviewer-rejects-first-pass",
+            "workerName": "reviewer",
+            "workstationName": "review-story",
+            "runType": "reject",
+            "rejectExitCode": 42
+          }
+        ]
+      }
+    },
+    {
+      "id": "docs-example-mock-workers-script",
+      "category": "parse-docs-example",
+      "entrypoint": "ParseMockWorkersConfig",
+      "outcome": "accept",
+      "fixture": "docs/examples/mock-workers-script.json",
+      "description": "checked-in script docs example parses with required command and optional script fields",
+      "expectedConfig": {
+        "mockWorkerCount": 1,
+        "mockWorkers": [
+          {
+            "id": "executor-script-side-effect",
+            "workerName": "executor",
+            "workstationName": "execute-story",
+            "runType": "script",
+            "scriptCommand": "printf"
+          }
+        ]
+      }
+    },
+    {
+      "id": "docs-example-mock-workers-mixed",
+      "category": "parse-docs-example",
+      "entrypoint": "ParseMockWorkersConfig",
+      "outcome": "accept",
+      "fixture": "docs/examples/mock-workers-mixed.json",
+      "description": "checked-in mixed docs example parses with unmatchedDispatchPolicy passthrough",
+      "expectedConfig": {
+        "unmatchedDispatchPolicy": "passthrough",
+        "mockWorkerCount": 1,
+        "mockWorkers": [
+          {
+            "id": "reviewer-rejects-first-pass",
+            "workerName": "reviewer",
+            "workstationName": "review-story",
+            "runType": "reject",
+            "rejectExitCode": 42
+          }
+        ]
+      }
+    },
+    {
+      "id": "valid-load-empty-path",
+      "category": "load-empty-path",
+      "entrypoint": "LoadMockWorkersConfig",
+      "outcome": "accept",
+      "description": "LoadMockWorkersConfig with empty path returns the default empty accept config",
+      "expectedConfig": {}
+    },
+    {
+      "id": "load-docs-example-mock-workers",
+      "category": "load-file",
+      "entrypoint": "LoadMockWorkersConfig",
+      "outcome": "accept",
+      "fixture": "docs/examples/mock-workers.json",
+      "description": "LoadMockWorkersConfig loads the checked-in reject docs example from disk",
+      "expectedConfig": {
+        "mockWorkerCount": 1,
+        "mockWorkers": [
+          {
+            "id": "reviewer-rejects-first-pass",
+            "runType": "reject"
+          }
+        ]
+      }
+    },
+    {
+      "id": "load-docs-example-mock-workers-script",
+      "category": "load-file",
+      "entrypoint": "LoadMockWorkersConfig",
+      "outcome": "accept",
+      "fixture": "docs/examples/mock-workers-script.json",
+      "description": "LoadMockWorkersConfig loads the checked-in script docs example from disk",
+      "expectedConfig": {
+        "mockWorkerCount": 1,
+        "mockWorkers": [
+          {
+            "id": "executor-script-side-effect",
+            "runType": "script",
+            "scriptCommand": "printf"
+          }
+        ]
+      }
+    },
+    {
+      "id": "load-docs-example-mock-workers-mixed",
+      "category": "load-file",
+      "entrypoint": "LoadMockWorkersConfig",
+      "outcome": "accept",
+      "fixture": "docs/examples/mock-workers-mixed.json",
+      "description": "LoadMockWorkersConfig loads the checked-in passthrough-policy docs example from disk",
+      "expectedConfig": {
+        "unmatchedDispatchPolicy": "passthrough",
+        "mockWorkerCount": 1
+      }
+    }
+  ]
+}

--- a/pkg/config/mockworkers/testdata/baseline/mock-workers-topology.json
+++ b/pkg/config/mockworkers/testdata/baseline/mock-workers-topology.json
@@ -1,0 +1,354 @@
+{
+  "formatVersion": "mock-workers-topology/v1",
+  "loaderEntrypoints": [
+    "ParseMockWorkersConfig",
+    "LoadMockWorkersConfig",
+    "MockWorkersConfig.Validate",
+    "MockWorkerConfig.Validate"
+  ],
+  "unknownFieldPolicy": "ParseMockWorkersConfig uses json.Decoder.DisallowUnknownFields and rejects unknown top-level keys, unknown nested keys, and trailing JSON values",
+  "entrySelectionPolicy": "first matching mockWorkers[] entry wins; there is no response-sequence or multi-hit authoring surface beyond that first-match selection",
+  "runTypeUnion": {
+    "summary": "runType is required on every mockWorkers[] entry and selects which nested config shape Validate enforces",
+    "values": [
+      {
+        "value": "accept",
+        "nestedConfigPolicy": "no nested config required; scriptConfig and rejectConfig are ignored when present"
+      },
+      {
+        "value": "script",
+        "nestedConfig": "scriptConfig",
+        "nestedConfigPolicy": "scriptConfig is required; scriptConfig.command is required non-empty"
+      },
+      {
+        "value": "reject",
+        "nestedConfig": "rejectConfig",
+        "nestedConfigPolicy": "rejectConfig is optional; rejectConfig.exitCode when set must be between 1 and 255"
+      }
+    ]
+  },
+  "unmatchedDispatchPolicies": [
+    {
+      "value": "accept",
+      "omittedBehavior": true,
+      "summary": "default when unmatchedDispatchPolicy is omitted; unmatched dispatches return the synthetic accepted mock result"
+    },
+    {
+      "value": "accept",
+      "summary": "explicit accept policy; same default-accept behavior as omission"
+    },
+    {
+      "value": "passthrough",
+      "summary": "unmatched dispatches execute through the normal worker runner/provider path"
+    }
+  ],
+  "validationBoundaries": [
+    {
+      "condition": "unknown top-level or nested JSON field",
+      "owner": "decode",
+      "errorPattern": "unknown field"
+    },
+    {
+      "condition": "trailing JSON after the root object",
+      "owner": "decode",
+      "errorPattern": "unexpected trailing JSON"
+    },
+    {
+      "condition": "unknown unmatchedDispatchPolicy value",
+      "owner": "validate",
+      "errorPattern": "unmatchedDispatchPolicy must be one of \"accept\" or \"passthrough\""
+    },
+    {
+      "condition": "unknown runType value",
+      "owner": "validate",
+      "errorPattern": "runType must be one of \"accept\", \"script\", or \"reject\""
+    },
+    {
+      "condition": "runType script without scriptConfig",
+      "owner": "validate",
+      "errorPattern": "scriptConfig is required when runType is \"script\""
+    },
+    {
+      "condition": "runType script with scriptConfig missing command",
+      "owner": "validate",
+      "errorPattern": "scriptConfig.command is required when runType is \"script\""
+    },
+    {
+      "condition": "rejectConfig.exitCode outside 1-255 when set",
+      "owner": "validate",
+      "errorPattern": "rejectConfig.exitCode must be between 1 and 255"
+    }
+  ],
+  "notAcceptedCapabilities": [
+    {
+      "category": "media",
+      "reason": "no media payload or media-response authoring fields are accepted by ParseMockWorkersConfig"
+    },
+    {
+      "category": "dispatch delay or timing fields",
+      "reason": "no per-entry delay, sleep, or dispatch-timing fields are accepted; scriptConfig.timeout only bounds local script execution"
+    },
+    {
+      "category": "artifact payloads",
+      "reason": "no artifact upload/download or artifact payload fields are accepted on mockWorkers entries"
+    },
+    {
+      "category": "response sequences",
+      "reason": "no multi-step response sequence authoring exists beyond first-match mockWorkers[] entry selection"
+    }
+  ],
+  "fields": [
+    {
+      "id": "mockWorkers",
+      "jsonPath": "mockWorkers",
+      "jsonName": "mockWorkers",
+      "valueType": "array",
+      "required": "required",
+      "defaultEmptyBehavior": "missing mockWorkers decodes as an empty slice; nil after decode is normalized to []",
+      "validationOwner": "decode",
+      "notes": "LoadMockWorkersConfig with an empty path returns NewEmptyMockWorkersConfig without reading a file"
+    },
+    {
+      "id": "unmatchedDispatchPolicy",
+      "jsonPath": "unmatchedDispatchPolicy",
+      "jsonName": "unmatchedDispatchPolicy",
+      "valueType": "string enum",
+      "required": "optional",
+      "defaultEmptyBehavior": "omitted or empty string behaves as accept for unmatched dispatches",
+      "validationOwner": "validate",
+      "notes": "accepted values are \"accept\" and \"passthrough\""
+    },
+    {
+      "id": "mockWorkers[].id",
+      "jsonPath": "mockWorkers[].id",
+      "jsonName": "id",
+      "valueType": "string",
+      "parentField": "mockWorkers[]",
+      "required": "optional",
+      "defaultEmptyBehavior": "omitted id is allowed and leaves diagnostics matching unconstrained",
+      "validationOwner": "decode"
+    },
+    {
+      "id": "mockWorkers[].workerName",
+      "jsonPath": "mockWorkers[].workerName",
+      "jsonName": "workerName",
+      "valueType": "string",
+      "parentField": "mockWorkers[]",
+      "required": "optional",
+      "defaultEmptyBehavior": "omitted workerName does not constrain worker-name matching",
+      "validationOwner": "decode"
+    },
+    {
+      "id": "mockWorkers[].workstationName",
+      "jsonPath": "mockWorkers[].workstationName",
+      "jsonName": "workstationName",
+      "valueType": "string",
+      "parentField": "mockWorkers[]",
+      "required": "optional",
+      "defaultEmptyBehavior": "omitted workstationName does not constrain workstation matching",
+      "validationOwner": "decode"
+    },
+    {
+      "id": "mockWorkers[].workInputs",
+      "jsonPath": "mockWorkers[].workInputs",
+      "jsonName": "workInputs",
+      "valueType": "array",
+      "parentField": "mockWorkers[]",
+      "required": "optional",
+      "defaultEmptyBehavior": "omitted workInputs does not constrain consumed work-input selectors",
+      "validationOwner": "decode"
+    },
+    {
+      "id": "mockWorkers[].runType",
+      "jsonPath": "mockWorkers[].runType",
+      "jsonName": "runType",
+      "valueType": "string enum",
+      "parentField": "mockWorkers[]",
+      "required": "required",
+      "defaultEmptyBehavior": "missing runType fails Validate with actionable runType union message",
+      "validationOwner": "validate",
+      "notes": "accepted values are \"accept\", \"script\", and \"reject\""
+    },
+    {
+      "id": "mockWorkers[].scriptConfig",
+      "jsonPath": "mockWorkers[].scriptConfig",
+      "jsonName": "scriptConfig",
+      "valueType": "object",
+      "parentField": "mockWorkers[]",
+      "required": "required when runType is script",
+      "defaultEmptyBehavior": "omitted scriptConfig is rejected when runType is script",
+      "validationOwner": "validate"
+    },
+    {
+      "id": "mockWorkers[].rejectConfig",
+      "jsonPath": "mockWorkers[].rejectConfig",
+      "jsonName": "rejectConfig",
+      "valueType": "object",
+      "parentField": "mockWorkers[]",
+      "required": "optional",
+      "defaultEmptyBehavior": "omitted rejectConfig is allowed when runType is reject",
+      "validationOwner": "validate"
+    },
+    {
+      "id": "mockWorkers[].workInputs[].workId",
+      "jsonPath": "mockWorkers[].workInputs[].workId",
+      "jsonName": "workId",
+      "valueType": "string",
+      "parentField": "mockWorkers[].workInputs[]",
+      "required": "optional",
+      "defaultEmptyBehavior": "omitted selector field does not constrain that dimension; all specified selector fields on an entry must match",
+      "validationOwner": "decode"
+    },
+    {
+      "id": "mockWorkers[].workInputs[].workType",
+      "jsonPath": "mockWorkers[].workInputs[].workType",
+      "jsonName": "workType",
+      "valueType": "string",
+      "parentField": "mockWorkers[].workInputs[]",
+      "required": "optional",
+      "defaultEmptyBehavior": "omitted selector field does not constrain that dimension; all specified selector fields on an entry must match",
+      "validationOwner": "decode"
+    },
+    {
+      "id": "mockWorkers[].workInputs[].state",
+      "jsonPath": "mockWorkers[].workInputs[].state",
+      "jsonName": "state",
+      "valueType": "string",
+      "parentField": "mockWorkers[].workInputs[]",
+      "required": "optional",
+      "defaultEmptyBehavior": "omitted selector field does not constrain that dimension; all specified selector fields on an entry must match",
+      "validationOwner": "decode"
+    },
+    {
+      "id": "mockWorkers[].workInputs[].inputName",
+      "jsonPath": "mockWorkers[].workInputs[].inputName",
+      "jsonName": "inputName",
+      "valueType": "string",
+      "parentField": "mockWorkers[].workInputs[]",
+      "required": "optional",
+      "defaultEmptyBehavior": "omitted selector field does not constrain that dimension; all specified selector fields on an entry must match",
+      "validationOwner": "decode"
+    },
+    {
+      "id": "mockWorkers[].workInputs[].traceId",
+      "jsonPath": "mockWorkers[].workInputs[].traceId",
+      "jsonName": "traceId",
+      "valueType": "string",
+      "parentField": "mockWorkers[].workInputs[]",
+      "required": "optional",
+      "defaultEmptyBehavior": "omitted selector field does not constrain that dimension; all specified selector fields on an entry must match",
+      "validationOwner": "decode"
+    },
+    {
+      "id": "mockWorkers[].workInputs[].channel",
+      "jsonPath": "mockWorkers[].workInputs[].channel",
+      "jsonName": "channel",
+      "valueType": "string",
+      "parentField": "mockWorkers[].workInputs[]",
+      "required": "optional",
+      "defaultEmptyBehavior": "omitted selector field does not constrain that dimension; all specified selector fields on an entry must match",
+      "validationOwner": "decode"
+    },
+    {
+      "id": "mockWorkers[].workInputs[].payloadHash",
+      "jsonPath": "mockWorkers[].workInputs[].payloadHash",
+      "jsonName": "payloadHash",
+      "valueType": "string",
+      "parentField": "mockWorkers[].workInputs[]",
+      "required": "optional",
+      "defaultEmptyBehavior": "omitted selector field does not constrain that dimension; all specified selector fields on an entry must match",
+      "validationOwner": "decode"
+    },
+    {
+      "id": "mockWorkers[].scriptConfig.command",
+      "jsonPath": "mockWorkers[].scriptConfig.command",
+      "jsonName": "command",
+      "valueType": "string",
+      "parentField": "mockWorkers[].scriptConfig",
+      "required": "required when runType is script",
+      "defaultEmptyBehavior": "missing or empty command fails Validate when runType is script",
+      "validationOwner": "validate"
+    },
+    {
+      "id": "mockWorkers[].scriptConfig.args",
+      "jsonPath": "mockWorkers[].scriptConfig.args",
+      "jsonName": "args",
+      "valueType": "array of string",
+      "parentField": "mockWorkers[].scriptConfig",
+      "required": "optional",
+      "defaultEmptyBehavior": "omitted args leaves command argument list empty",
+      "validationOwner": "decode"
+    },
+    {
+      "id": "mockWorkers[].scriptConfig.env",
+      "jsonPath": "mockWorkers[].scriptConfig.env",
+      "jsonName": "env",
+      "valueType": "object map string to string",
+      "parentField": "mockWorkers[].scriptConfig",
+      "required": "optional",
+      "defaultEmptyBehavior": "omitted env leaves script environment unchanged aside from runner defaults",
+      "validationOwner": "decode"
+    },
+    {
+      "id": "mockWorkers[].scriptConfig.workingDirectory",
+      "jsonPath": "mockWorkers[].scriptConfig.workingDirectory",
+      "jsonName": "workingDirectory",
+      "valueType": "string",
+      "parentField": "mockWorkers[].scriptConfig",
+      "required": "optional",
+      "defaultEmptyBehavior": "omitted workingDirectory uses runner default working directory",
+      "validationOwner": "decode"
+    },
+    {
+      "id": "mockWorkers[].scriptConfig.stdin",
+      "jsonPath": "mockWorkers[].scriptConfig.stdin",
+      "jsonName": "stdin",
+      "valueType": "string",
+      "parentField": "mockWorkers[].scriptConfig",
+      "required": "optional",
+      "defaultEmptyBehavior": "omitted stdin leaves script stdin empty",
+      "validationOwner": "decode"
+    },
+    {
+      "id": "mockWorkers[].scriptConfig.timeout",
+      "jsonPath": "mockWorkers[].scriptConfig.timeout",
+      "jsonName": "timeout",
+      "valueType": "string",
+      "parentField": "mockWorkers[].scriptConfig",
+      "required": "optional",
+      "defaultEmptyBehavior": "omitted timeout uses runner default script timeout; duration strings such as 30s are accepted when set",
+      "validationOwner": "decode",
+      "notes": "bounds local script execution only; not a dispatch-delay authoring field"
+    },
+    {
+      "id": "mockWorkers[].rejectConfig.stdout",
+      "jsonPath": "mockWorkers[].rejectConfig.stdout",
+      "jsonName": "stdout",
+      "valueType": "string",
+      "parentField": "mockWorkers[].rejectConfig",
+      "required": "optional",
+      "defaultEmptyBehavior": "omitted stdout leaves rejected command stdout empty",
+      "validationOwner": "decode"
+    },
+    {
+      "id": "mockWorkers[].rejectConfig.stderr",
+      "jsonPath": "mockWorkers[].rejectConfig.stderr",
+      "jsonName": "stderr",
+      "valueType": "string",
+      "parentField": "mockWorkers[].rejectConfig",
+      "required": "optional",
+      "defaultEmptyBehavior": "omitted stderr leaves rejected command stderr empty",
+      "validationOwner": "decode"
+    },
+    {
+      "id": "mockWorkers[].rejectConfig.exitCode",
+      "jsonPath": "mockWorkers[].rejectConfig.exitCode",
+      "jsonName": "exitCode",
+      "valueType": "integer",
+      "parentField": "mockWorkers[].rejectConfig",
+      "required": "optional",
+      "defaultEmptyBehavior": "omitted exitCode leaves rejected exit code unset; when set must be between 1 and 255",
+      "validationOwner": "validate"
+    }
+  ]
+}

--- a/pkg/config/mockworkers/testdata/fixtures/invalid/reject-exit-code-out-of-range.json
+++ b/pkg/config/mockworkers/testdata/fixtures/invalid/reject-exit-code-out-of-range.json
@@ -1,0 +1,11 @@
+{
+  "mockWorkers": [
+    {
+      "id": "reject",
+      "runType": "reject",
+      "rejectConfig": {
+        "exitCode": 0
+      }
+    }
+  ]
+}

--- a/pkg/config/mockworkers/testdata/fixtures/invalid/script-without-command.json
+++ b/pkg/config/mockworkers/testdata/fixtures/invalid/script-without-command.json
@@ -1,0 +1,11 @@
+{
+  "mockWorkers": [
+    {
+      "id": "script",
+      "runType": "script",
+      "scriptConfig": {
+        "args": ["ok"]
+      }
+    }
+  ]
+}

--- a/pkg/config/mockworkers/testdata/fixtures/invalid/script-without-script-config.json
+++ b/pkg/config/mockworkers/testdata/fixtures/invalid/script-without-script-config.json
@@ -1,0 +1,8 @@
+{
+  "mockWorkers": [
+    {
+      "id": "script",
+      "runType": "script"
+    }
+  ]
+}

--- a/pkg/config/mockworkers/testdata/fixtures/invalid/trailing-json.json
+++ b/pkg/config/mockworkers/testdata/fixtures/invalid/trailing-json.json
@@ -1,0 +1,4 @@
+{
+  "mockWorkers": []
+}
+{"trailing": true}

--- a/pkg/config/mockworkers/testdata/fixtures/invalid/unknown-nested-mock-worker.json
+++ b/pkg/config/mockworkers/testdata/fixtures/invalid/unknown-nested-mock-worker.json
@@ -1,0 +1,9 @@
+{
+  "mockWorkers": [
+    {
+      "id": "bad",
+      "runType": "accept",
+      "unexpectedNested": true
+    }
+  ]
+}

--- a/pkg/config/mockworkers/testdata/fixtures/invalid/unknown-run-type.json
+++ b/pkg/config/mockworkers/testdata/fixtures/invalid/unknown-run-type.json
@@ -1,0 +1,8 @@
+{
+  "mockWorkers": [
+    {
+      "id": "bad",
+      "runType": "maybe"
+    }
+  ]
+}

--- a/pkg/config/mockworkers/testdata/fixtures/invalid/unknown-top-level.json
+++ b/pkg/config/mockworkers/testdata/fixtures/invalid/unknown-top-level.json
@@ -1,0 +1,4 @@
+{
+  "mockWorkers": [],
+  "unexpectedTopLevel": true
+}

--- a/pkg/config/mockworkers/testdata/fixtures/invalid/unknown-unmatched-policy.json
+++ b/pkg/config/mockworkers/testdata/fixtures/invalid/unknown-unmatched-policy.json
@@ -1,0 +1,4 @@
+{
+  "mockWorkers": [],
+  "unmatchedDispatchPolicy": "maybe"
+}

--- a/pkg/config/mockworkers/testdata/fixtures/valid/accept-entry-selectors.json
+++ b/pkg/config/mockworkers/testdata/fixtures/valid/accept-entry-selectors.json
@@ -1,0 +1,21 @@
+{
+  "mockWorkers": [
+    {
+      "id": "accept-reviewer",
+      "workerName": "reviewer",
+      "workstationName": "review",
+      "workInputs": [
+        {
+          "workId": "work-1",
+          "workType": "story",
+          "state": "in-review",
+          "inputName": "story",
+          "traceId": "trace-1",
+          "channel": "default",
+          "payloadHash": "sha256:test"
+        }
+      ],
+      "runType": "accept"
+    }
+  ]
+}

--- a/pkg/config/mockworkers/testdata/fixtures/valid/empty-accept.json
+++ b/pkg/config/mockworkers/testdata/fixtures/valid/empty-accept.json
@@ -1,0 +1,3 @@
+{
+  "mockWorkers": []
+}

--- a/pkg/config/mockworkers/testdata/fixtures/valid/reject-without-reject-config.json
+++ b/pkg/config/mockworkers/testdata/fixtures/valid/reject-without-reject-config.json
@@ -1,0 +1,8 @@
+{
+  "mockWorkers": [
+    {
+      "id": "reject-minimal",
+      "runType": "reject"
+    }
+  ]
+}

--- a/pkg/config/mockworkers/testdata/fixtures/valid/script-minimal-command.json
+++ b/pkg/config/mockworkers/testdata/fixtures/valid/script-minimal-command.json
@@ -1,0 +1,11 @@
+{
+  "mockWorkers": [
+    {
+      "id": "script-minimal",
+      "runType": "script",
+      "scriptConfig": {
+        "command": "echo"
+      }
+    }
+  ]
+}

--- a/pkg/config/mockworkers/testdata/fixtures/valid/unmatched-policy-explicit-accept.json
+++ b/pkg/config/mockworkers/testdata/fixtures/valid/unmatched-policy-explicit-accept.json
@@ -1,0 +1,4 @@
+{
+  "mockWorkers": [],
+  "unmatchedDispatchPolicy": "accept"
+}


### PR DESCRIPTION
{
  "project": "Inventory Mock-Worker Authoring Variants Without Inventing Capabilities",
  "branchName": "interfaces-b03-config-mock",
  "description": "Produce a deterministic mock-worker authoring inventory under pkg/config/mockworkers that documents current production-loader acceptance for accept/reject/script variants, selectors, unmatched policy, and strict object boundaries—indexing docs examples and retaining existing invalid error paths—without inventing media or other non-accepted capabilities or changing loader behavior.",
  "context": {
    "customerAsk": "Inventory mock-worker authoring variants without inventing capabilities (B03-CONFIG-MOCK). Add an indexed baseline under pkg/config/mockworkers for current accept/reject/script variants, selectors, response sequences, delay/failure/artifact fields, repeat/selection behavior, and unmatched policy. Shape field topology plus fixture IDs/outcomes; record strict object boundaries. Index docs examples that already pass the production loader and retain matching paths for existing invalid cases.",
    "problem": "Batch 02 delivered global you configuration inventory, but mock-worker behavioral inventory was deferred. Maintainers lack a checked-in, deterministic record of which mock-worker JSON fields and authoring variants the production loader currently accepts or rejects—blocking later B15-CONFIG-MOCK schema work and risking checklist language around delay/media/artifact being mistaken for accepted capabilities.",
    "solution": "Add a deterministic authoring inventory baseline under pkg/config/mockworkers with field topology, fixture IDs/outcomes, docs-example indexing, and focused valid-per-variant plus unknown-field/invalid-union table tests against the production loader, remaining behavior-neutral and leaving loader acceptance unchanged."
  },
  "acceptanceCriteria": [
    "Docs examples under docs/examples/mock-workers*.json pass the production mock-worker loader and appear in the inventory index",
    "Existing invalid cases retain matching error paths (same actionable diagnostics / reject outcomes already owned by the loader)",
    "No media (or other non-accepted) capability is invented; the inventory remains behavior-neutral relative to current loader acceptance",
    "Focused valid-per-variant and unknown-field/invalid-union tests pass against production ParseMockWorkersConfig / LoadMockWorkersConfig",
    "Field topology, fixture IDs/outcomes, and strict object boundaries are recorded in a deterministic baseline under pkg/config/mockworkers",
    "Factory and global config inventories are untouched; mock-worker loader acceptance is unchanged",
    "Quality checks pass (typecheck, lint, tests)"
  ],
  "userStories": [
    {
      "id": "interfaces-b03-config-mock-001",
      "title": "Shape the mock-worker field topology and strict-boundary index",
      "description": "As a maintainer preparing interface contracts for mock-worker config, I want a checked-in inventory index under pkg/config/mockworkers that documents the current authoring topology—top-level object fields, per-entry selectors, run-type unions and nested configs, unmatched-dispatch policy, and strict object boundaries—so current acceptance is reviewable without changing the loader or inventing capabilities.",
      "acceptanceCriteria": [
        "An inventory index lives under pkg/config/mockworkers and records the top-level mock-worker JSON object (mockWorkers, unmatchedDispatchPolicy) plus per-entry fields (id, workerName, workstationName, workInputs, runType, scriptConfig, rejectConfig)",
        "Each inventoried field records JSON name, value type, required/optional behavior, default/empty behavior where relevant, and ownership of validation (decode vs Validate)",
        "Run-type union boundaries are explicit: accept needs no nested config; script requires scriptConfig.command; reject optionally carries rejectConfig with exitCode constrained to 1–255 when set",
        "Work-input selector fields (workId, workType, state, inputName, traceId, channel, payloadHash) and unmatched policy values (accept default / omitted, passthrough) appear in the index",
        "Strict object boundaries are recorded: unknown JSON fields are rejected at decode time; invalid run-type / policy / script / exit-code unions fail validation with the existing actionable messages",
        "Categories mentioned in batch language that the loader does not currently accept (for example media, delay/timing fields, artifact payloads, response sequences beyond first-match entry selection) are not invented as accepted capabilities; the inventory stays behavior-neutral",
        "Production mock-worker loader acceptance (ParseMockWorkersConfig / LoadMockWorkersConfig / Validate) is not modified by this story",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b03-config-mock-002",
      "title": "Index docs examples and one valid case per authoring variant",
      "description": "As a maintainer, I want docs examples and one valid fixture per currently accepted authoring variant indexed with stable fixture IDs and loader outcomes, exercised through the production mock-worker loader, so the inventory’s accept claims match runtime behavior.",
      "acceptanceCriteria": [
        "Checked-in docs examples docs/examples/mock-workers.json, docs/examples/mock-workers-script.json, and docs/examples/mock-workers-mixed.json are indexed and still parse successfully via production ParseMockWorkersConfig / LoadMockWorkersConfig",
        "At least one valid indexed case exists per currently accepted authoring variant needed for completeness: empty/default accept config, accept entry, reject entry (with and without optional rejectConfig fields as already supported), script entry with required command plus optional script fields, selector-bearing entry, and unmatchedDispatchPolicy omitted / accept / passthrough",
        "Each indexed valid case records a stable fixture ID and expected accept outcome; focused table tests drive the production loader and assert agreement with the inventory",
        "Only minimal new valid cases are added beyond docs examples and inputs that already exercise the production loader; fixtures contain no secrets",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b03-config-mock-003",
      "title": "Index unknown-field and invalid-union cases with matching error paths",
      "description": "As a maintainer, I want focused unknown-field and invalid-union fixtures indexed so existing reject diagnostics remain the source of truth and the inventory’s reject claims match production error paths.",
      "acceptanceCriteria": [
        "Invalid fixtures cover unknown top-level and/or nested JSON fields (strict decode rejection) and invalid unions already owned by validation: unknown runType, unknown unmatchedDispatchPolicy, script without scriptConfig, script without command, and rejectConfig.exitCode outside 1–255",
        "Each indexed invalid case records a stable fixture ID, reject outcome, and a matching error-path assertion (substring or equivalent) consistent with existing loader diagnostics",
        "Focused table tests drive production ParseMockWorkersConfig and assert that each indexed invalid input’s reject outcome and error path match the inventory",
        "Existing invalid cases retain matching error paths—diagnostics are not rewritten for style; this story documents current rejection behavior",
        "Fixtures are deterministic and secret-safe",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b03-config-mock-004",
      "title": "Prove baseline/index parity and leave loader acceptance unchanged",
      "description": "As a reviewer of Batch 03 inventories, I want deterministic baseline/index parity tests and an explicit no-behavior-change gate so repeat extractions stay byte-identical, no non-accepted capabilities are invented, and mock-worker runtime acceptance cannot drift under this lane.",
      "acceptanceCriteria": [
        "Deterministic baseline/index parity tests assert that regenerating or re-serializing the committed inventory/fixtures from the same sources yields byte-identical output",
        "Repeat runs of the inventory serialization path on unchanged inputs are byte-identical",
        "Diff for this lane does not alter mock-worker loader acceptance, config structs, parsing, or validation behavior (inventory fixtures/index and focused tests only, plus minimal helpers required for table-driven agreement)",
        "No media capability (or other non-accepted delay/artifact/response-sequence authoring surface) is invented; Factory and global config inventories are not modified; Batch 04+ work is not released from this item",
        "Focused go test ./pkg/config/mockworkers/... (or the narrowest owning package that holds the inventory suite) passes with -count=1",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}
