### PR TITLE
update the reviewer behavior to not use the decision envelope structuring

### DIFF
--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -318,15 +318,15 @@ primary-result behavior.
   Goal routing envelopes with authored `classificationRoutes` map parsed
   `decision` labels onto `SelectedClassificationLabel` while preserving
   `Feedback`, optional `Output`, and `RecordedOutputWork`.
-- `pkg/workers/executor/agent.go` routes `review` workstation agent output through
+- `pkg/workers/executor/agent.go` routes workstations with
+  `outcomeFormat: decision-envelope` through
   `goal.WorkResultFromDecisionEnvelopeJSONOrFailed` instead of stop-token parsing.
-  Workstations with `outcomeFormat: decision-envelope` and authored
+  Those workstations with authored
   `classificationRoutes` use `goal.WorkResultFromGoalRoutingDecisionEnvelopeJSONOrFailed`.
 - `factory/docs/decision-envelope.md` is the packaged-authoring guide for the
   reviewer/checker envelope shape, the standard outcome vocabulary, the
   packaged-goal goal-routing decision vocabulary used when
-  `classificationRoutes` are present, and malformed-input behavior used by
-  `factory/workstations/review/AGENTS.md`.
+  `classificationRoutes` are present, and malformed-input behavior.
 - `pkg/factory/subsystems/subsystem_transitioner.go` applies packaged goal
   invocation summary shaping on `execute-goal` workstations alongside packaged
   TTS metadata shaping. `pkg/factory/subsystems/goalroutingtests/transitioner_goal_routing_test.go`

--- a/factory/docs/decision-envelope.md
+++ b/factory/docs/decision-envelope.md
@@ -110,7 +110,6 @@ mode.
 
 ## Where to author responses
 
-- Review workstation prompt: `factory/workstations/review/AGENTS.md`
 - Packaged `@you/goal` authored prompts: `pkg/config/builtingoal/prompts/`
 - Checker or review-style prompts in other packaged goal factories should use
   this envelope shape and the decision vocabulary that matches their routing

--- a/factory/factory.json
+++ b/factory/factory.json
@@ -768,7 +768,6 @@
         }
       ],
       "name": "review",
-      "outcomeFormat": "decision-envelope",
       "onFailure": [
         {
           "state": "failed",

--- a/factory/workstations/review/AGENTS.md
+++ b/factory/workstations/review/AGENTS.md
@@ -79,34 +79,22 @@ If the PR has merge conflicts, please tell the processor to fix the merge confli
 
 ### Step 7 - respond back
 
-Return one JSON decision envelope as your final output. See
-`factory/docs/decision-envelope.md` for the full shape, accepted decision
-values, routing-mode differences, and malformed-input behavior. This review
-workstation uses the standard outcome vocabulary below; packaged `@you/goal`
-structured review lanes use the goal-routing labels documented in the same
-file instead.
+End your final response with exactly one review routing marker:
 
-| Review outcome | `decision` value |
-| --- | --- |
-| PR is complete and merged | `ACCEPTED` |
-| More executor work is required | `CONTINUE` |
-| PR is not complete | `REJECTED` |
+- `<COMPLETE>` when the PR is complete, approved, and merged.
+- `<REJECTED>` when concrete executor work remains, required CI is still
+  running, or the change is otherwise not ready to approve.
 
-Put your review summary and acceptance-criteria checklist in `feedback`. Use
-optional `output` for a short final summary and optional `recorded_output_work`
-when you need to record work items that should advance with the decision.
-
-Example:
-
-```json
-{
-  "decision": "REJECTED",
-  "feedback": "BLOCKING: make test failed on pkg/foo. Acceptance criterion 2 is FAIL."
-}
-```
+Write the review summary and acceptance-criteria checklist before the marker.
+Do not return a JSON decision envelope. The runtime derives the review outcome
+from the worker's `<COMPLETE>` stop token; a response without that stop token
+follows the review rejection route. Do not use `<CONTINUE>` from this
+workstation because review rework belongs on the rejection route.
 
 If CI is still pending or in progress and you have no concrete independent
-review findings to report yet, respond with `{"decision":"REJECTED","feedback":"Waiting for required CI on the current PR head."}` without posting a new PR comment so the workflow waits silently instead of creating premature review noise.
+review findings to report yet, end with `<REJECTED>` without posting a new PR
+comment so the workflow waits silently instead of creating premature review
+noise.
 
   When starting local servers for verification:
   - Never use a shared default port such as 3000 without first checking whether it is already occupied.

--- a/pkg/config/openapitests/parity_inventory_test.go
+++ b/pkg/config/openapitests/parity_inventory_test.go
@@ -326,7 +326,7 @@ var productionBoundarySources = []struct {
 	},
 	{
 		relativePath: "pkg/api/generated/server.gen.go",
-		sha256Hex:    "5633f2946af845d4da706190305b79a3214de3aa1645c510369de0f5a8c51136",
+		sha256Hex:    "31cb73f21474acb5903127fc46517f80a4009e23f5f545a8b16aebbdf1a040a4",
 	},
 	{
 		relativePath: "pkg/generatedclient/client.gen.go",

--- a/pkg/workers/executor/agentrun/executor_test.go
+++ b/pkg/workers/executor/agentrun/executor_test.go
@@ -352,7 +352,7 @@ func TestEvaluateAgentRunOutcome_StopTokenAndContinueSemantics(t *testing.T) {
 	if got := evaluateAgentRunOutcome("still working <CONTINUE>", worker); got != interfaces.OutcomeContinue {
 		t.Fatalf("continue outcome = %s, want CONTINUE", got)
 	}
-	if got := evaluateAgentRunOutcome("needs revision", worker); got != interfaces.OutcomeRejected {
+	if got := evaluateAgentRunOutcome("review cannot proceed <REJECTED>", worker); got != interfaces.OutcomeRejected {
 		t.Fatalf("rejected outcome = %s, want REJECTED", got)
 	}
 	if got := evaluateAgentRunOutcome("plain output", nil); got != interfaces.OutcomeAccepted {


### PR DESCRIPTION
## Summary

- route the repository review workstation through `<COMPLETE>` / `<REJECTED>` stop-word outcomes
- remove the review workstation's `decision-envelope` outcome format
- align decision-envelope documentation with the packaged goal workstations that still use it
- refresh the generated API parity guard hash after verifying API generation is byte-clean

## Root cause

The review prompt emitted a structured decision envelope while the desired factory loop uses the planner worker's `<COMPLETE>` stop token and the review rejection arc. Concurrent generated API changes also left the parity lane's approved `server.gen.go` digest stale.

## Validation

- `go test ./pkg/workers/executor/... -count=1`
- `go test ./pkg/config/runtimetests ./pkg/config/openapitests -count=1`
- `go run ./cmd/gocoveragecheck -min 78.3 -timeout 10m` — 81.0%
- `go test -short ./... -timeout 300s`
- `make generate-api` — byte-clean
- `git diff --check`