### PR TITLE
stream-b03-retention-and-gaps

### DIFF
--- a/api/components/schemas/response-events/FactoryResponseEvent.yaml
+++ b/api/components/schemas/response-events/FactoryResponseEvent.yaml
@@ -31,7 +31,10 @@ properties:
     type: integer
     format: int64
     minimum: 0
-    description: Monotonic session-scoped cursor for reconnect and ordering.
+    description: >-
+      Monotonic session-scoped cursor for published events. Sequence zero is
+      reserved for synthetic out-of-band read markers such as retention gaps;
+      those markers do not consume or reuse a published sequence.
   recordedAt:
     type: string
     format: date-time

--- a/api/components/schemas/response-events/payloads/FactoryResponseEventStreamGapPayload.yaml
+++ b/api/components/schemas/response-events/payloads/FactoryResponseEventStreamGapPayload.yaml
@@ -9,12 +9,14 @@ properties:
     type: integer
     format: int64
     minimum: 0
-    description: Last retained sequence before the gap.
+    description: >-
+      Lowest unavailable published sequence greater than the reader's cursor.
   toSequence:
     type: integer
     format: int64
     minimum: 0
-    description: First available sequence after the gap.
+    description: >-
+      Highest unavailable published sequence in the reader's catch-up window.
   reason:
     type: string
     description: Optional reason for the stream gap such as retention_window.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -7245,7 +7245,7 @@ components:
           type: integer
           format: int64
           minimum: 0
-          description: Monotonic session-scoped cursor for reconnect and ordering.
+          description: Monotonic session-scoped cursor for published events. Sequence zero is reserved for synthetic out-of-band read markers such as retention gaps; those markers do not consume or reuse a published sequence.
         recordedAt:
           type: string
           format: date-time
@@ -7883,12 +7883,12 @@ components:
           type: integer
           format: int64
           minimum: 0
-          description: Last retained sequence before the gap.
+          description: Lowest unavailable published sequence greater than the reader's cursor.
         toSequence:
           type: integer
           format: int64
           minimum: 0
-          description: First available sequence after the gap.
+          description: Highest unavailable published sequence in the reader's catch-up window.
         reason:
           type: string
           description: Optional reason for the stream gap such as retention_window.

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -218,7 +218,13 @@ primary-result behavior.
   store alongside legacy response streams; keep this lifecycle state on
   `LiveSession`, not `FactoryService`.
   `SessionResponseEventStore.Subscribe(afterSequence)` delivers retained events
-  after the cursor, then continues live via `Subscription.Next`; optional
+  after the cursor, then continues live via `Subscription.Next`. Retention keeps
+  ordered unavailable-sequence spans separate from immutable retained events;
+  stale reads receive one cursor-clipped `STREAM_GAP`/`UPDATED` marker with
+  `retention_window` reason and lossy provenance before catch-up. The marker is
+  out-of-band at sequence zero and advances only the private subscription
+  cursor, so it never consumes, reuses, or renumbers published identities;
+  optional
   `WithDispatchFilter(dispatchID)` omits non-matching events while preserving
   each delivered event's global session sequence and eventId. `Complete()` stops
   further publishes while retained events remain for catch-up; catch-up readers

--- a/pkg/api/generated/server.gen.go
+++ b/pkg/api/generated/server.gen.go
@@ -1979,7 +1979,7 @@ type FactoryResponseEvent struct {
 	// SchemaVersion Version of the FactoryResponseEvent envelope schema.
 	SchemaVersion FactoryResponseEventSchemaVersion `json:"schemaVersion"`
 
-	// Sequence Monotonic session-scoped cursor for reconnect and ordering.
+	// Sequence Monotonic session-scoped cursor for published events. Sequence zero is reserved for synthetic out-of-band read markers such as retention gaps; those markers do not consume or reuse a published sequence.
 	Sequence int64 `json:"sequence"`
 
 	// TurnId Optional turn correlation identifier.
@@ -2207,13 +2207,13 @@ type FactoryResponseEventSessionPayload struct {
 
 // FactoryResponseEventStreamGapPayload Discontinuity marker in the retained response-event stream.
 type FactoryResponseEventStreamGapPayload struct {
-	// FromSequence Last retained sequence before the gap.
+	// FromSequence Lowest unavailable published sequence greater than the reader's cursor.
 	FromSequence int64 `json:"fromSequence"`
 
 	// Reason Optional reason for the stream gap such as retention_window.
 	Reason *string `json:"reason,omitempty"`
 
-	// ToSequence First available sequence after the gap.
+	// ToSequence Highest unavailable published sequence in the reader's catch-up window.
 	ToSequence int64 `json:"toSequence"`
 }
 

--- a/pkg/config/openapitests/parity_inventory_test.go
+++ b/pkg/config/openapitests/parity_inventory_test.go
@@ -326,7 +326,7 @@ var productionBoundarySources = []struct {
 	},
 	{
 		relativePath: "pkg/api/generated/server.gen.go",
-		sha256Hex:    "31cb73f21474acb5903127fc46517f80a4009e23f5f545a8b16aebbdf1a040a4",
+		sha256Hex:    "e19e1c9af8f878ef11aede6f6604fb40e2ff58c95c87d956f09cf226c8889e12",
 	},
 	{
 		relativePath: "pkg/generatedclient/client.gen.go",

--- a/pkg/factorysessions/responseeventstore/doc.go
+++ b/pkg/factorysessions/responseeventstore/doc.go
@@ -9,7 +9,7 @@
 // coordinate session lifecycle, but the ordered event buffer itself is
 // session-runtime-local state rather than service-wide mutable configuration.
 //
-// Retention eviction is intentionally out of scope for the initial store lane;
-// published events remain in the retained buffer until a later story introduces
-// compaction policy.
+// Retention applies hard session-wide event-count and serialized-envelope byte
+// limits. It removes the oldest event in the lowest semantic tier first while
+// preserving every retained envelope and its published identity verbatim.
 package responseeventstore

--- a/pkg/factorysessions/responseeventstore/doc.go
+++ b/pkg/factorysessions/responseeventstore/doc.go
@@ -12,4 +12,8 @@
 // Retention applies hard session-wide event-count and serialized-envelope byte
 // limits. It removes the oldest event in the lowest semantic tier first while
 // preserving every retained envelope and its published identity verbatim.
+// Removed sequence spans are tracked separately. A stale subscription read
+// receives one cursor-relative STREAM_GAP before retained catch-up. Gap markers
+// are out-of-band (sequence zero), are never retained, and do not consume or
+// reuse the monotonically assigned identities of published events.
 package responseeventstore

--- a/pkg/factorysessions/responseeventstore/errors.go
+++ b/pkg/factorysessions/responseeventstore/errors.go
@@ -20,4 +20,7 @@ var ErrSubscriptionClosed = errors.New("session response event store subscriptio
 // ErrInvalidDispatchFilter indicates a dispatch filter was requested without a dispatch identity.
 var ErrInvalidDispatchFilter = errors.New("session response event store dispatch filter requires a dispatch identity")
 
+// ErrInvalidRetentionLimits indicates that one or both hard limits are not positive.
+var ErrInvalidRetentionLimits = errors.New("invalid session response event retention limits")
+
 var errInvalidDispatchFilter = ErrInvalidDispatchFilter

--- a/pkg/factorysessions/responseeventstore/gap_test.go
+++ b/pkg/factorysessions/responseeventstore/gap_test.go
@@ -1,0 +1,357 @@
+package responseeventstore_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/pkg/factorysessions/responseevents"
+	"github.com/portpowered/infinite-you/pkg/factorysessions/responseeventstore"
+)
+
+func decodeGap(t *testing.T, event responseevents.FactoryResponseEvent) responseevents.StreamGapPayload {
+	t.Helper()
+	if err := responseevents.ValidateEvent(event); err != nil {
+		t.Fatalf("gap event validation: %v", err)
+	}
+	if event.Kind != responseevents.KindStreamGap || event.Phase != responseevents.PhaseUpdated {
+		t.Fatalf("first event = %s/%s, want STREAM_GAP/UPDATED", event.Kind, event.Phase)
+	}
+	if event.Sequence != 0 {
+		t.Fatalf("gap sequence = %d, want out-of-band sequence 0", event.Sequence)
+	}
+	if event.EventID == "" {
+		t.Fatal("gap event ID is empty")
+	}
+	if event.Provenance.Fidelity != responseevents.FidelityLossy ||
+		event.Provenance.Delivery != responseevents.DeliverySynthesized {
+		t.Fatalf("gap provenance = %#v, want synthesized lossy", event.Provenance)
+	}
+	var payload responseevents.StreamGapPayload
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		t.Fatalf("decode gap payload: %v", err)
+	}
+	if payload.Reason != "retention_window" {
+		t.Fatalf("gap reason = %q, want retention_window", payload.Reason)
+	}
+	return payload
+}
+
+func TestSessionResponseEventStoreSubscription_StaleCursorGetsExactGapBeforeOrderedCatchUp(t *testing.T) {
+	t.Parallel()
+
+	store := newRetentionStore(t, responseeventstore.RetentionLimits{MaxEvents: 2, MaxBytes: generousByteLimit})
+	published := publishRetentionEvents(t, store,
+		retentionEvent(responseevents.KindMessage, responseevents.PhaseDelta, "dropped-1"),
+		retentionEvent(responseevents.KindMessage, responseevents.PhaseCompleted, "final-2"),
+		retentionEvent(responseevents.KindProgress, responseevents.PhaseUpdated, "dropped-3"),
+		retentionEvent(responseevents.KindTool, responseevents.PhaseFailed, "failure-4"),
+		retentionEvent(responseevents.KindMessage, responseevents.PhaseDelta, "dropped-5"),
+	)
+
+	subscription, err := store.Subscribe(0)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer subscription.Detach()
+	events, err := subscription.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("event count = %d, want gap plus two retained events", len(events))
+	}
+	gap := decodeGap(t, events[0])
+	if gap.FromSequence != 1 || gap.ToSequence != 5 {
+		t.Fatalf("gap = %#v, want dropped bounds [1,5]", gap)
+	}
+	if !reflect.DeepEqual(events[1:], []responseevents.FactoryResponseEvent{published[1], published[3]}) {
+		t.Fatalf("catch-up = %#v, want retained original envelopes", events[1:])
+	}
+}
+
+func TestSessionResponseEventStoreSubscription_GapBoundsClipToCursorAndCurrentCursorHasNoGap(t *testing.T) {
+	t.Parallel()
+
+	store := newRetentionStore(t, responseeventstore.RetentionLimits{MaxEvents: 2, MaxBytes: generousByteLimit})
+	publishRetentionEvents(t, store,
+		retentionEvent(responseevents.KindMessage, responseevents.PhaseDelta, "drop-1"),
+		retentionEvent(responseevents.KindMessage, responseevents.PhaseCompleted, "keep-2"),
+		retentionEvent(responseevents.KindProgress, responseevents.PhaseUpdated, "drop-3"),
+		retentionEvent(responseevents.KindTool, responseevents.PhaseFailed, "keep-4"),
+		retentionEvent(responseevents.KindMessage, responseevents.PhaseDelta, "drop-5"),
+	)
+	store.Complete()
+
+	for _, test := range []struct {
+		after    int64
+		wantFrom int64
+		wantTo   int64
+	}{
+		{after: 1, wantFrom: 3, wantTo: 5},
+		{after: 3, wantFrom: 5, wantTo: 5},
+	} {
+		subscription, err := store.Subscribe(test.after)
+		if err != nil {
+			t.Fatalf("Subscribe(%d): %v", test.after, err)
+		}
+		events, err := subscription.Next(context.Background())
+		if err != nil {
+			t.Fatalf("Next(%d): %v", test.after, err)
+		}
+		gap := decodeGap(t, events[0])
+		if gap.FromSequence != test.wantFrom || gap.ToSequence != test.wantTo {
+			t.Fatalf("after %d gap = %#v, want [%d,%d]", test.after, gap, test.wantFrom, test.wantTo)
+		}
+		subscription.Detach()
+	}
+
+	current, err := store.Subscribe(5)
+	if err != nil {
+		t.Fatalf("Subscribe(current): %v", err)
+	}
+	if _, err := current.Next(context.Background()); !errors.Is(err, responseeventstore.ErrSubscriptionClosed) {
+		t.Fatalf("current cursor Next error = %v, want closed without a gap", err)
+	}
+}
+
+func TestSessionResponseEventStoreSubscription_GapOnlyReadAdvancesThenContinuesLive(t *testing.T) {
+	t.Parallel()
+
+	store := newRetentionStore(t, responseeventstore.RetentionLimits{MaxEvents: 4, MaxBytes: generousByteLimit})
+	oversized := publishRetentionEvents(t, store,
+		retentionEvent(responseevents.KindMessage, responseevents.PhaseCompleted, "oversized"),
+	)[0]
+	size, err := responseeventstore.SerializedEventSize(oversized)
+	if err != nil {
+		t.Fatalf("SerializedEventSize: %v", err)
+	}
+	if err := store.SetRetentionLimits(responseeventstore.RetentionLimits{MaxEvents: 4, MaxBytes: size - 1}); err != nil {
+		t.Fatalf("SetRetentionLimits(drop): %v", err)
+	}
+
+	subscription, err := store.Subscribe(0)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer subscription.Detach()
+	first, err := subscription.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next(gap): %v", err)
+	}
+	if len(first) != 1 {
+		t.Fatalf("gap-only count = %d, want 1", len(first))
+	}
+	gap := decodeGap(t, first[0])
+	if gap.FromSequence != oversized.Sequence || gap.ToSequence != oversized.Sequence {
+		t.Fatalf("gap = %#v, want oversized sequence %d", gap, oversized.Sequence)
+	}
+
+	if err := store.SetRetentionLimits(responseeventstore.RetentionLimits{MaxEvents: 4, MaxBytes: generousByteLimit}); err != nil {
+		t.Fatalf("SetRetentionLimits(grow): %v", err)
+	}
+	live := publishRetentionEvents(t, store,
+		retentionEvent(responseevents.KindMessage, responseevents.PhaseCompleted, "live-final"),
+	)[0]
+	second, err := subscription.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next(live): %v", err)
+	}
+	if !reflect.DeepEqual(second, []responseevents.FactoryResponseEvent{live}) {
+		t.Fatalf("second read = %#v, want live event once without repeated gap", second)
+	}
+}
+
+func TestSessionResponseEventStoreSubscription_LateReaderReconstructsFinalSemanticState(t *testing.T) {
+	t.Parallel()
+
+	store := newRetentionStore(t, responseeventstore.RetentionLimits{MaxEvents: 3, MaxBytes: generousByteLimit})
+	finals := publishRetentionEvents(t, store,
+		retentionEvent(responseevents.KindMessage, responseevents.PhaseCompleted, "final answer"),
+		retentionEvent(responseevents.KindTool, responseevents.PhaseFailed, "failed tool"),
+		retentionEvent(responseevents.KindRun, responseevents.PhaseCompleted, "completed"),
+	)
+	for index := range 40 {
+		publishRetentionEvents(t, store, retentionEvent(
+			responseevents.KindMessage,
+			responseevents.PhaseDelta,
+			fmt.Sprintf("heavy-delta-%02d", index),
+		))
+	}
+
+	subscription, err := store.Subscribe(0)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer subscription.Detach()
+	events, err := subscription.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	decodeGap(t, events[0])
+	if !reflect.DeepEqual(events[1:], finals) {
+		t.Fatalf("final catch-up = %#v, want exact semantic snapshots %#v", events[1:], finals)
+	}
+}
+
+func TestSessionResponseEventStoreSubscription_RepeatedEvictionGapBoundsMatchRemovedLedger(t *testing.T) {
+	t.Parallel()
+
+	store := newRetentionStore(t, responseeventstore.RetentionLimits{MaxEvents: 7, MaxBytes: generousByteLimit})
+	all := make([]responseevents.FactoryResponseEvent, 0, 100)
+	for index := range 100 {
+		phase := responseevents.PhaseDelta
+		if index%11 == 0 {
+			phase = responseevents.PhaseCompleted
+		}
+		all = append(all, publishRetentionEvents(t, store,
+			retentionEvent(responseevents.KindMessage, phase, fmt.Sprintf("event-%03d", index)),
+		)[0])
+		if index == 50 {
+			if err := store.SetRetentionLimits(responseeventstore.RetentionLimits{MaxEvents: 4, MaxBytes: generousByteLimit}); err != nil {
+				t.Fatalf("SetRetentionLimits: %v", err)
+			}
+		}
+	}
+	store.Complete()
+	retained := make(map[int64]struct{})
+	for _, event := range store.Events() {
+		retained[event.Sequence] = struct{}{}
+	}
+
+	for after := int64(0); after <= store.LatestSequence(); after++ {
+		assertGapMatchesRemovedLedger(t, store, all, retained, after)
+	}
+}
+
+func assertGapMatchesRemovedLedger(
+	t *testing.T,
+	store *responseeventstore.SessionResponseEventStore,
+	all []responseevents.FactoryResponseEvent,
+	retained map[int64]struct{},
+	after int64,
+) {
+	t.Helper()
+	wantFrom, wantTo, found := removedBoundsAfter(all, retained, after)
+	subscription, err := store.Subscribe(after)
+	if err != nil {
+		t.Fatalf("Subscribe(%d): %v", after, err)
+	}
+	defer subscription.Detach()
+	events, err := subscription.Next(context.Background())
+	if !found {
+		if err == nil && len(events) > 0 && events[0].Kind == responseevents.KindStreamGap {
+			t.Fatalf("after %d received unexpected gap %#v", after, events[0])
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("Next(%d): %v", after, err)
+	}
+	gap := decodeGap(t, events[0])
+	if gap.FromSequence != wantFrom || gap.ToSequence != wantTo {
+		t.Fatalf("after %d gap = [%d,%d], actual removed bounds = [%d,%d]", after, gap.FromSequence, gap.ToSequence, wantFrom, wantTo)
+	}
+}
+
+func removedBoundsAfter(
+	all []responseevents.FactoryResponseEvent,
+	retained map[int64]struct{},
+	after int64,
+) (int64, int64, bool) {
+	from, to, found := int64(0), int64(0), false
+	for _, event := range all {
+		if event.Sequence <= after {
+			continue
+		}
+		if _, ok := retained[event.Sequence]; ok {
+			continue
+		}
+		if !found {
+			from = event.Sequence
+			found = true
+		}
+		to = event.Sequence
+	}
+	return from, to, found
+}
+
+func TestSessionResponseEventStoreSubscription_ConcurrentPublishEvictReadAndClose(t *testing.T) {
+	store := newRetentionStore(t, responseeventstore.RetentionLimits{MaxEvents: 8, MaxBytes: generousByteLimit})
+	const readerCount = 6
+	subscriptions := make([]*responseeventstore.Subscription, 0, readerCount)
+	for range readerCount {
+		subscription, err := store.Subscribe(0)
+		if err != nil {
+			t.Fatalf("Subscribe: %v", err)
+		}
+		subscriptions = append(subscriptions, subscription)
+	}
+
+	var readers sync.WaitGroup
+	readers.Add(len(subscriptions))
+	for _, subscription := range subscriptions {
+		go func(subscription *responseeventstore.Subscription) {
+			defer readers.Done()
+			lastSequence := int64(0)
+			for {
+				events, err := subscription.Next(context.Background())
+				if errors.Is(err, responseeventstore.ErrSubscriptionClosed) {
+					return
+				}
+				if err != nil {
+					t.Errorf("Next: %v", err)
+					return
+				}
+				for index, event := range events {
+					if event.Kind == responseevents.KindStreamGap {
+						if index != 0 {
+							t.Errorf("gap index = %d, want first", index)
+						}
+						continue
+					}
+					if event.Sequence <= lastSequence {
+						t.Errorf("sequence %d delivered after %d", event.Sequence, lastSequence)
+					}
+					lastSequence = event.Sequence
+				}
+			}
+		}(subscription)
+	}
+
+	var publishers sync.WaitGroup
+	for index := range 80 {
+		publishers.Add(1)
+		go func(index int) {
+			defer publishers.Done()
+			_, err := store.Publish(retentionEvent(
+				responseevents.KindMessage,
+				responseevents.PhaseDelta,
+				fmt.Sprintf("concurrent-%03d", index),
+			))
+			if err != nil {
+				t.Errorf("Publish(%d): %v", index, err)
+			}
+		}(index)
+	}
+	publishers.Wait()
+	store.Complete()
+	go store.Close()
+
+	done := make(chan struct{})
+	go func() {
+		readers.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for concurrent readers to drain")
+	}
+	assertExactRetentionAccounting(t, store)
+}

--- a/pkg/factorysessions/responseeventstore/retention.go
+++ b/pkg/factorysessions/responseeventstore/retention.go
@@ -3,9 +3,12 @@ package responseeventstore
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/portpowered/infinite-you/pkg/factorysessions/responseevents"
 )
+
+const retentionGapReason = "retention_window"
 
 const (
 	defaultMaxRetainedEvents = 10_000
@@ -35,6 +38,56 @@ func DefaultRetentionLimits() RetentionLimits {
 type RetentionAccounting struct {
 	EventCount int
 	TotalBytes int
+}
+
+// sequenceSpan is an inclusive range of unavailable published sequences.
+// Spans stay disjoint and ordered. Their count is bounded by the retained
+// records that separate them, so exact stale-cursor reporting does not create
+// another unbounded per-session event history.
+type sequenceSpan struct {
+	from int64
+	to   int64
+}
+
+func addDroppedSequence(spans []sequenceSpan, sequence int64) []sequenceSpan {
+	index := sort.Search(len(spans), func(index int) bool {
+		return spans[index].to >= sequence-1
+	})
+	if index == len(spans) {
+		return append(spans, sequenceSpan{from: sequence, to: sequence})
+	}
+	if sequence < spans[index].from-1 {
+		spans = append(spans, sequenceSpan{})
+		copy(spans[index+1:], spans[index:])
+		spans[index] = sequenceSpan{from: sequence, to: sequence}
+		return spans
+	}
+	if sequence < spans[index].from {
+		spans[index].from = sequence
+	}
+	if sequence > spans[index].to {
+		spans[index].to = sequence
+	}
+	if index+1 < len(spans) && spans[index].to+1 >= spans[index+1].from {
+		spans[index].to = spans[index+1].to
+		copy(spans[index+1:], spans[index+2:])
+		spans = spans[:len(spans)-1]
+	}
+	return spans
+}
+
+func droppedBoundsAfter(spans []sequenceSpan, afterSequence int64) (int64, int64, bool) {
+	index := sort.Search(len(spans), func(index int) bool {
+		return spans[index].to > afterSequence
+	})
+	if index == len(spans) {
+		return 0, 0, false
+	}
+	from := spans[index].from
+	if from <= afterSequence {
+		from = afterSequence + 1
+	}
+	return from, spans[len(spans)-1].to, true
 }
 
 // SerializedEventSize returns the production byte-accounting size for an

--- a/pkg/factorysessions/responseeventstore/retention.go
+++ b/pkg/factorysessions/responseeventstore/retention.go
@@ -1,0 +1,91 @@
+package responseeventstore
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/portpowered/infinite-you/pkg/factorysessions/responseevents"
+)
+
+const (
+	defaultMaxRetainedEvents = 10_000
+	defaultMaxRetainedBytes  = 16 * 1024 * 1024
+)
+
+// RetentionLimits are hard session-wide bounds for retained response events.
+// Both values must be positive. MaxBytes counts the JSON serialization of each
+// complete retained FactoryResponseEvent envelope, including identity,
+// provenance, correlation fields, and payload.
+type RetentionLimits struct {
+	MaxEvents int
+	MaxBytes  int
+}
+
+// DefaultRetentionLimits returns the bounded controls used by compatibility
+// constructors that do not accept explicit limits.
+func DefaultRetentionLimits() RetentionLimits {
+	return RetentionLimits{
+		MaxEvents: defaultMaxRetainedEvents,
+		MaxBytes:  defaultMaxRetainedBytes,
+	}
+}
+
+// RetentionAccounting reports the exact current retained count and serialized
+// envelope bytes.
+type RetentionAccounting struct {
+	EventCount int
+	TotalBytes int
+}
+
+// SerializedEventSize returns the production byte-accounting size for an
+// immutable retained event envelope.
+func SerializedEventSize(event responseevents.FactoryResponseEvent) (int, error) {
+	serialized, err := json.Marshal(event)
+	if err != nil {
+		return 0, fmt.Errorf("serialize response event for retention accounting: %w", err)
+	}
+	return len(serialized), nil
+}
+
+func validateRetentionLimits(limits RetentionLimits) error {
+	if limits.MaxEvents <= 0 {
+		return fmt.Errorf("%w: max retained events must be positive", ErrInvalidRetentionLimits)
+	}
+	if limits.MaxBytes <= 0 {
+		return fmt.Errorf("%w: max retained bytes must be positive", ErrInvalidRetentionLimits)
+	}
+	return nil
+}
+
+type retentionTier uint8
+
+const (
+	retentionTierTransient retentionTier = iota
+	retentionTierSnapshot
+	retentionTierFinalSemantic
+)
+
+func eventRetentionTier(event responseevents.FactoryResponseEvent) retentionTier {
+	if event.Phase == responseevents.PhaseDelta || event.Kind == responseevents.KindProgress {
+		return retentionTierTransient
+	}
+	if isFinalSemanticEvent(event) {
+		return retentionTierFinalSemantic
+	}
+	return retentionTierSnapshot
+}
+
+func isFinalSemanticEvent(event responseevents.FactoryResponseEvent) bool {
+	switch event.Kind {
+	case responseevents.KindMessage:
+		return event.Phase == responseevents.PhaseCompleted
+	case responseevents.KindTool:
+		return event.Phase == responseevents.PhaseFailed
+	case responseevents.KindRun:
+		return event.Phase == responseevents.PhaseCompleted ||
+			event.Phase == responseevents.PhaseFailed ||
+			event.Phase == responseevents.PhaseCanceled
+	default:
+		return false
+	}
+}

--- a/pkg/factorysessions/responseeventstore/retention_test.go
+++ b/pkg/factorysessions/responseeventstore/retention_test.go
@@ -1,0 +1,325 @@
+package responseeventstore_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/factorysessions/responseevents"
+	"github.com/portpowered/infinite-you/pkg/factorysessions/responseeventstore"
+)
+
+const generousByteLimit = 1 << 30
+
+func retentionEvent(kind responseevents.Kind, phase responseevents.Phase, label string) responseevents.FactoryResponseEvent {
+	event := samplePublishInput()
+	event.Kind = kind
+	event.Phase = phase
+	event.ItemID = label
+	switch kind {
+	case responseevents.KindMessage:
+		if phase == responseevents.PhaseDelta {
+			event.Payload = json.RawMessage(fmt.Sprintf(
+				`{"contentBlockIndex":0,"contentBlockKind":"TEXT","textDelta":%q}`,
+				label,
+			))
+		} else {
+			event.Payload = json.RawMessage(fmt.Sprintf(
+				`{"role":"assistant","contentBlocks":[{"kind":"TEXT","text":%q}]}`,
+				label,
+			))
+		}
+	case responseevents.KindTool:
+		event.Payload = json.RawMessage(fmt.Sprintf(
+			`{"toolCallId":%q,"toolName":"shell","status":%q}`,
+			label,
+			phase,
+		))
+	case responseevents.KindRun:
+		event.ItemID = ""
+		event.Payload = json.RawMessage(fmt.Sprintf(`{"status":%q}`, phase))
+	case responseevents.KindProgress:
+		event.Payload = json.RawMessage(fmt.Sprintf(`{"label":%q}`, label))
+	default:
+		panic("unsupported retention test event kind")
+	}
+	return event
+}
+
+func newRetentionStore(t *testing.T, limits responseeventstore.RetentionLimits) *responseeventstore.SessionResponseEventStore {
+	t.Helper()
+	store, err := responseeventstore.NewSessionResponseEventStoreWithLimits("session-abc", limits)
+	if err != nil {
+		t.Fatalf("NewSessionResponseEventStoreWithLimits: %v", err)
+	}
+	return store
+}
+
+func publishRetentionEvents(
+	t *testing.T,
+	store *responseeventstore.SessionResponseEventStore,
+	inputs ...responseevents.FactoryResponseEvent,
+) []responseevents.FactoryResponseEvent {
+	t.Helper()
+	published := make([]responseevents.FactoryResponseEvent, 0, len(inputs))
+	for _, input := range inputs {
+		event, err := store.Publish(input)
+		if err != nil {
+			t.Fatalf("Publish(%s/%s): %v", input.Kind, input.Phase, err)
+		}
+		published = append(published, event)
+	}
+	return published
+}
+
+func assertExactRetentionAccounting(t *testing.T, store *responseeventstore.SessionResponseEventStore) {
+	t.Helper()
+	events := store.Events()
+	wantBytes := 0
+	for _, event := range events {
+		size, err := responseeventstore.SerializedEventSize(event)
+		if err != nil {
+			t.Fatalf("SerializedEventSize: %v", err)
+		}
+		wantBytes += size
+	}
+	accounting := store.RetentionAccounting()
+	if accounting.EventCount != len(events) || accounting.TotalBytes != wantBytes {
+		t.Fatalf("accounting = %#v, want count=%d bytes=%d", accounting, len(events), wantBytes)
+	}
+	limits := store.RetentionLimits()
+	if accounting.EventCount > limits.MaxEvents || accounting.TotalBytes > limits.MaxBytes {
+		t.Fatalf("accounting %#v exceeds limits %#v", accounting, limits)
+	}
+}
+
+func TestSessionResponseEventStore_RejectsNonPositiveRetentionLimits(t *testing.T) {
+	t.Parallel()
+
+	for _, limits := range []responseeventstore.RetentionLimits{
+		{MaxEvents: 0, MaxBytes: 1},
+		{MaxEvents: 1, MaxBytes: 0},
+		{MaxEvents: -1, MaxBytes: 1},
+		{MaxEvents: 1, MaxBytes: -1},
+	} {
+		if _, err := responseeventstore.NewSessionResponseEventStoreWithLimits("session-abc", limits); !errors.Is(err, responseeventstore.ErrInvalidRetentionLimits) {
+			t.Fatalf("limits %#v error = %v, want ErrInvalidRetentionLimits", limits, err)
+		}
+	}
+
+	store := newRetentionStore(t, responseeventstore.RetentionLimits{MaxEvents: 3, MaxBytes: 3_000})
+	if err := store.SetRetentionLimits(responseeventstore.RetentionLimits{MaxEvents: 0, MaxBytes: 1}); !errors.Is(err, responseeventstore.ErrInvalidRetentionLimits) {
+		t.Fatalf("SetRetentionLimits error = %v, want ErrInvalidRetentionLimits", err)
+	}
+	if got := store.RetentionLimits(); got != (responseeventstore.RetentionLimits{MaxEvents: 3, MaxBytes: 3_000}) {
+		t.Fatalf("limits changed after rejected update: %#v", got)
+	}
+}
+
+func TestSessionResponseEventStore_CountRetentionUsesSemanticPriorityAndAge(t *testing.T) {
+	t.Parallel()
+
+	store := newRetentionStore(t, responseeventstore.RetentionLimits{MaxEvents: 8, MaxBytes: generousByteLimit})
+	published := publishRetentionEvents(t, store,
+		retentionEvent(responseevents.KindMessage, responseevents.PhaseCompleted, "final-message"),
+		retentionEvent(responseevents.KindTool, responseevents.PhaseStarted, "active-tool"),
+		retentionEvent(responseevents.KindMessage, responseevents.PhaseDelta, "old-delta"),
+		retentionEvent(responseevents.KindProgress, responseevents.PhaseUpdated, "new-progress"),
+		retentionEvent(responseevents.KindTool, responseevents.PhaseFailed, "failed-tool"),
+		retentionEvent(responseevents.KindRun, responseevents.PhaseCompleted, "run-outcome"),
+	)
+
+	if err := store.SetRetentionLimits(responseeventstore.RetentionLimits{MaxEvents: 3, MaxBytes: generousByteLimit}); err != nil {
+		t.Fatalf("SetRetentionLimits: %v", err)
+	}
+	got := store.Events()
+	want := []responseevents.FactoryResponseEvent{published[0], published[4], published[5]}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("retained events = %#v, want final semantic events %#v", got, want)
+	}
+	assertExactRetentionAccounting(t, store)
+}
+
+func TestSessionResponseEventStore_ByteRetentionUsesSerializedEnvelopeBoundary(t *testing.T) {
+	t.Parallel()
+
+	store := newRetentionStore(t, responseeventstore.RetentionLimits{MaxEvents: 8, MaxBytes: generousByteLimit})
+	published := publishRetentionEvents(t, store,
+		retentionEvent(responseevents.KindMessage, responseevents.PhaseDelta, "a large transient delta that should be removed first"),
+		retentionEvent(responseevents.KindMessage, responseevents.PhaseCompleted, "final"),
+		retentionEvent(responseevents.KindProgress, responseevents.PhaseUpdated, "transient-progress"),
+	)
+	finalBytes, err := responseeventstore.SerializedEventSize(published[1])
+	if err != nil {
+		t.Fatalf("SerializedEventSize(final): %v", err)
+	}
+
+	if err := store.SetRetentionLimits(responseeventstore.RetentionLimits{MaxEvents: 8, MaxBytes: finalBytes}); err != nil {
+		t.Fatalf("SetRetentionLimits: %v", err)
+	}
+	if got := store.Events(); !reflect.DeepEqual(got, []responseevents.FactoryResponseEvent{published[1]}) {
+		t.Fatalf("retained events = %#v, want final event only", got)
+	}
+	assertExactRetentionAccounting(t, store)
+}
+
+func TestSessionResponseEventStore_SimultaneousLimitsAndPriorityTiesAreDeterministic(t *testing.T) {
+	t.Parallel()
+
+	store := newRetentionStore(t, responseeventstore.RetentionLimits{MaxEvents: 8, MaxBytes: generousByteLimit})
+	published := publishRetentionEvents(t, store,
+		retentionEvent(responseevents.KindMessage, responseevents.PhaseDelta, "oldest"),
+		retentionEvent(responseevents.KindMessage, responseevents.PhaseDelta, "newest"),
+		retentionEvent(responseevents.KindMessage, responseevents.PhaseCompleted, "preferred"),
+	)
+	preferredBytes, err := responseeventstore.SerializedEventSize(published[2])
+	if err != nil {
+		t.Fatalf("SerializedEventSize(preferred): %v", err)
+	}
+	if err := store.SetRetentionLimits(responseeventstore.RetentionLimits{MaxEvents: 1, MaxBytes: preferredBytes}); err != nil {
+		t.Fatalf("SetRetentionLimits: %v", err)
+	}
+	if got := store.Events(); !reflect.DeepEqual(got, []responseevents.FactoryResponseEvent{published[2]}) {
+		t.Fatalf("retained events = %#v, want preferred event only", got)
+	}
+
+	tieStore := newRetentionStore(t, responseeventstore.RetentionLimits{MaxEvents: 1, MaxBytes: generousByteLimit})
+	tiePublished := publishRetentionEvents(t, tieStore,
+		retentionEvent(responseevents.KindMessage, responseevents.PhaseDelta, "oldest"),
+		retentionEvent(responseevents.KindMessage, responseevents.PhaseDelta, "newest"),
+	)
+	if got := tieStore.Events(); !reflect.DeepEqual(got, []responseevents.FactoryResponseEvent{tiePublished[1]}) {
+		t.Fatalf("tie retention = %#v, want newest event", got)
+	}
+
+	preferredTieStore := newRetentionStore(t, responseeventstore.RetentionLimits{MaxEvents: 1, MaxBytes: generousByteLimit})
+	preferredTiePublished := publishRetentionEvents(t, preferredTieStore,
+		retentionEvent(responseevents.KindMessage, responseevents.PhaseCompleted, "old-final"),
+		retentionEvent(responseevents.KindTool, responseevents.PhaseFailed, "new-failure"),
+	)
+	if got := preferredTieStore.Events(); !reflect.DeepEqual(got, []responseevents.FactoryResponseEvent{preferredTiePublished[1]}) {
+		t.Fatalf("preferred tie retention = %#v, want newest final semantic event", got)
+	}
+}
+
+func TestSessionResponseEventStore_OversizedEventIsDroppedWithoutSequenceReuse(t *testing.T) {
+	t.Parallel()
+
+	store := newRetentionStore(t, responseeventstore.RetentionLimits{MaxEvents: 8, MaxBytes: generousByteLimit})
+	first := publishRetentionEvents(t, store,
+		retentionEvent(responseevents.KindMessage, responseevents.PhaseCompleted, "oversized"),
+	)[0]
+	firstBytes, err := responseeventstore.SerializedEventSize(first)
+	if err != nil {
+		t.Fatalf("SerializedEventSize(first): %v", err)
+	}
+	if err := store.SetRetentionLimits(responseeventstore.RetentionLimits{MaxEvents: 8, MaxBytes: firstBytes - 1}); err != nil {
+		t.Fatalf("SetRetentionLimits: %v", err)
+	}
+	if got := store.Events(); len(got) != 0 {
+		t.Fatalf("oversized retained events = %#v, want none", got)
+	}
+
+	second, err := store.Publish(retentionEvent(responseevents.KindMessage, responseevents.PhaseCompleted, "also-oversized"))
+	if err != nil {
+		t.Fatalf("Publish(second): %v", err)
+	}
+	if second.Sequence != first.Sequence+1 || second.EventID == first.EventID {
+		t.Fatalf("second identity = (%d, %q), first = (%d, %q)", second.Sequence, second.EventID, first.Sequence, first.EventID)
+	}
+	if got := store.Events(); len(got) != 0 {
+		t.Fatalf("second oversized retained events = %#v, want none", got)
+	}
+	if latest := store.LatestSequence(); latest != second.Sequence {
+		t.Fatalf("LatestSequence = %d, want published sequence %d", latest, second.Sequence)
+	}
+	assertExactRetentionAccounting(t, store)
+}
+
+func TestSessionResponseEventStore_RepeatedRetentionKeepsExactCountersAndImmutableEvents(t *testing.T) {
+	t.Parallel()
+
+	limits := responseeventstore.RetentionLimits{MaxEvents: 7, MaxBytes: 3_200}
+	store := newRetentionStore(t, limits)
+	rng := rand.New(rand.NewSource(42))
+	publishedBytes := make(map[int64][]byte)
+	publishedIDs := make(map[string]struct{})
+
+	for index := 0; index < 250; index++ {
+		var input responseevents.FactoryResponseEvent
+		switch rng.Intn(6) {
+		case 0, 1:
+			input = retentionEvent(responseevents.KindMessage, responseevents.PhaseDelta, fmt.Sprintf("delta-%03d-%s", index, strings.Repeat("x", rng.Intn(24))))
+		case 2:
+			input = retentionEvent(responseevents.KindProgress, responseevents.PhaseUpdated, fmt.Sprintf("progress-%03d", index))
+		case 3:
+			input = retentionEvent(responseevents.KindMessage, responseevents.PhaseCompleted, fmt.Sprintf("final-%03d", index))
+		case 4:
+			input = retentionEvent(responseevents.KindTool, responseevents.PhaseFailed, fmt.Sprintf("tool-%03d", index))
+		default:
+			input = retentionEvent(responseevents.KindRun, responseevents.PhaseCompleted, fmt.Sprintf("run-%03d", index))
+		}
+		published, err := store.Publish(input)
+		if err != nil {
+			t.Fatalf("Publish(%d): %v", index, err)
+		}
+		if published.Sequence != int64(index+1) {
+			t.Fatalf("Publish(%d) sequence = %d, want %d", index, published.Sequence, index+1)
+		}
+		if _, exists := publishedIDs[published.EventID]; exists {
+			t.Fatalf("Publish(%d) reused event ID %q", index, published.EventID)
+		}
+		publishedIDs[published.EventID] = struct{}{}
+		serialized, err := json.Marshal(published)
+		if err != nil {
+			t.Fatalf("json.Marshal(published): %v", err)
+		}
+		publishedBytes[published.Sequence] = serialized
+		assertExactRetentionAccounting(t, store)
+
+		for _, retained := range store.Events() {
+			got, err := json.Marshal(retained)
+			if err != nil {
+				t.Fatalf("json.Marshal(retained): %v", err)
+			}
+			if !reflect.DeepEqual(got, publishedBytes[retained.Sequence]) {
+				t.Fatalf("retained sequence %d changed\ngot=%s\nwant=%s", retained.Sequence, got, publishedBytes[retained.Sequence])
+			}
+		}
+	}
+	if latest := store.LatestSequence(); latest != 250 {
+		t.Fatalf("LatestSequence = %d, want 250", latest)
+	}
+}
+
+func TestSessionResponseEventStore_ConcurrentPublishRetentionAccounting(t *testing.T) {
+	store := newRetentionStore(t, responseeventstore.RetentionLimits{MaxEvents: 9, MaxBytes: generousByteLimit})
+
+	const workers = 64
+	var wait sync.WaitGroup
+	wait.Add(workers)
+	for index := 0; index < workers; index++ {
+		go func(index int) {
+			defer wait.Done()
+			_, err := store.Publish(retentionEvent(
+				responseevents.KindMessage,
+				responseevents.PhaseDelta,
+				fmt.Sprintf("delta-%d", index),
+			))
+			if err != nil {
+				t.Errorf("Publish(%d): %v", index, err)
+			}
+		}(index)
+	}
+	wait.Wait()
+
+	if latest := store.LatestSequence(); latest != workers {
+		t.Fatalf("LatestSequence = %d, want %d", latest, workers)
+	}
+	assertExactRetentionAccounting(t, store)
+}

--- a/pkg/factorysessions/responseeventstore/store.go
+++ b/pkg/factorysessions/responseeventstore/store.go
@@ -22,6 +22,7 @@ type SessionResponseEventStore struct {
 	nextSequence     int64
 	events           []responseevents.FactoryResponseEvent
 	eventSizes       []int
+	droppedSequences []sequenceSpan
 	limits           RetentionLimits
 	retainedBytes    int
 	closed           bool
@@ -101,7 +102,9 @@ func (s *SessionResponseEventStore) SetRetentionLimits(limits RetentionLimits) e
 	s.mu.Lock()
 	s.limits = limits
 	s.enforceRetentionLocked()
+	subscribers := s.subscribersSnapshotLocked()
 	s.mu.Unlock()
+	notifyStoreSubscribers(subscribers)
 	return nil
 }
 
@@ -240,6 +243,7 @@ func (s *SessionResponseEventStore) enforceRetentionLocked() {
 			return
 		}
 		s.retainedBytes -= s.eventSizes[index]
+		s.droppedSequences = addDroppedSequence(s.droppedSequences, s.events[index].Sequence)
 		copy(s.events[index:], s.events[index+1:])
 		s.events = s.events[:len(s.events)-1]
 		copy(s.eventSizes[index:], s.eventSizes[index+1:])

--- a/pkg/factorysessions/responseeventstore/store.go
+++ b/pkg/factorysessions/responseeventstore/store.go
@@ -21,6 +21,9 @@ type SessionResponseEventStore struct {
 	factorySessionID string
 	nextSequence     int64
 	events           []responseevents.FactoryResponseEvent
+	eventSizes       []int
+	limits           RetentionLimits
+	retainedBytes    int
 	closed           bool
 	completed        bool
 	completedAt      time.Time
@@ -30,17 +33,86 @@ type SessionResponseEventStore struct {
 
 // NewSessionResponseEventStore allocates an empty store for one session runtime.
 func NewSessionResponseEventStore(factorySessionID string) *SessionResponseEventStore {
-	return NewSessionResponseEventStoreWithClock(factorySessionID, factory.RealClock{})
+	store, _ := NewSessionResponseEventStoreWithClockAndLimits(
+		factorySessionID,
+		factory.RealClock{},
+		DefaultRetentionLimits(),
+	)
+	return store
 }
 
 // NewSessionResponseEventStoreWithClock allocates an empty store using the
 // supplied clock.
 func NewSessionResponseEventStoreWithClock(factorySessionID string, clock factory.Clock) *SessionResponseEventStore {
+	store, _ := NewSessionResponseEventStoreWithClockAndLimits(
+		factorySessionID,
+		clock,
+		DefaultRetentionLimits(),
+	)
+	return store
+}
+
+// NewSessionResponseEventStoreWithLimits allocates an empty store with explicit
+// positive hard retention limits.
+func NewSessionResponseEventStoreWithLimits(
+	factorySessionID string,
+	limits RetentionLimits,
+) (*SessionResponseEventStore, error) {
+	return NewSessionResponseEventStoreWithClockAndLimits(factorySessionID, factory.RealClock{}, limits)
+}
+
+// NewSessionResponseEventStoreWithClockAndLimits allocates an empty store with
+// an explicit clock and positive hard retention limits.
+func NewSessionResponseEventStoreWithClockAndLimits(
+	factorySessionID string,
+	clock factory.Clock,
+	limits RetentionLimits,
+) (*SessionResponseEventStore, error) {
+	if err := validateRetentionLimits(limits); err != nil {
+		return nil, err
+	}
 	return &SessionResponseEventStore{
 		clock:            factory.EnsureClock(clock),
 		factorySessionID: strings.TrimSpace(factorySessionID),
+		limits:           limits,
 		subscribers:      make(map[int64]*storeSubscriber),
+	}, nil
+}
+
+// RetentionLimits returns the active session-wide hard limits.
+func (s *SessionResponseEventStore) RetentionLimits() RetentionLimits {
+	if s == nil {
+		return RetentionLimits{}
 	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.limits
+}
+
+// SetRetentionLimits applies positive hard limits and immediately evicts until
+// both are satisfied. Invalid limits leave the current policy unchanged.
+func (s *SessionResponseEventStore) SetRetentionLimits(limits RetentionLimits) error {
+	if s == nil {
+		return errNilStore
+	}
+	if err := validateRetentionLimits(limits); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.limits = limits
+	s.enforceRetentionLocked()
+	s.mu.Unlock()
+	return nil
+}
+
+// RetentionAccounting returns exact counters for the immutable retained events.
+func (s *SessionResponseEventStore) RetentionAccounting() RetentionAccounting {
+	if s == nil {
+		return RetentionAccounting{}
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return RetentionAccounting{EventCount: len(s.events), TotalBytes: s.retainedBytes}
 }
 
 // FactorySessionID returns the session identity bound to this store.
@@ -144,13 +216,51 @@ func (s *SessionResponseEventStore) Publish(input responseevents.FactoryResponse
 		return responseevents.FactoryResponseEvent{}, ErrStoreCompleted
 	}
 	stored := s.assignIdentityLocked(prepared)
+	storedBytes, err := SerializedEventSize(stored)
+	if err != nil {
+		s.mu.Unlock()
+		return responseevents.FactoryResponseEvent{}, err
+	}
 	s.events = append(s.events, stored)
+	s.eventSizes = append(s.eventSizes, storedBytes)
+	s.retainedBytes += storedBytes
+	s.enforceRetentionLocked()
 	subscribers := s.subscribersSnapshotLocked()
 	s.mu.Unlock()
 
 	notifyStoreSubscribers(subscribers)
 
 	return cloneEvent(stored), nil
+}
+
+func (s *SessionResponseEventStore) enforceRetentionLocked() {
+	for len(s.events) > s.limits.MaxEvents || s.retainedBytes > s.limits.MaxBytes {
+		index := s.evictionIndexLocked()
+		if index < 0 {
+			return
+		}
+		s.retainedBytes -= s.eventSizes[index]
+		copy(s.events[index:], s.events[index+1:])
+		s.events = s.events[:len(s.events)-1]
+		copy(s.eventSizes[index:], s.eventSizes[index+1:])
+		s.eventSizes = s.eventSizes[:len(s.eventSizes)-1]
+	}
+}
+
+func (s *SessionResponseEventStore) evictionIndexLocked() int {
+	if len(s.events) == 0 {
+		return -1
+	}
+	lowestTier := eventRetentionTier(s.events[0])
+	oldestIndex := 0
+	for index := 1; index < len(s.events); index++ {
+		tier := eventRetentionTier(s.events[index])
+		if tier < lowestTier {
+			lowestTier = tier
+			oldestIndex = index
+		}
+	}
+	return oldestIndex
 }
 
 func (s *SessionResponseEventStore) preparePublishInput(input responseevents.FactoryResponseEvent) responseevents.FactoryResponseEvent {

--- a/pkg/factorysessions/responseeventstore/subscription.go
+++ b/pkg/factorysessions/responseeventstore/subscription.go
@@ -2,9 +2,13 @@ package responseeventstore
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/portpowered/infinite-you/pkg/factorysessions/responseevents"
 )
@@ -221,13 +225,13 @@ func (s *Subscription) Next(ctx context.Context) ([]responseevents.FactoryRespon
 			return nil, ErrSubscriptionClosed
 		}
 
-		events, closed := s.store.readForSubscriber(afterSequence, dispatchID)
+		result, closed := s.store.readForSubscriber(afterSequence, dispatchID)
 		if closed {
 			return nil, ErrSubscriptionClosed
 		}
-		if len(events) > 0 {
-			s.advance(events)
-			return events, nil
+		if len(result.events) > 0 {
+			s.advance(result.nextSequence)
+			return result.events, nil
 		}
 
 		select {
@@ -248,30 +252,38 @@ func (s *Subscription) Next(ctx context.Context) ([]responseevents.FactoryRespon
 	}
 }
 
-func (s *Subscription) advance(events []responseevents.FactoryResponseEvent) {
+func (s *Subscription) advance(sequence int64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.afterSequence = events[len(events)-1].Sequence
+	if sequence > s.afterSequence {
+		s.afterSequence = sequence
+	}
 }
 
-func (s *SessionResponseEventStore) readForSubscriber(afterSequence int64, dispatchID string) ([]responseevents.FactoryResponseEvent, bool) {
+type subscriberRead struct {
+	events       []responseevents.FactoryResponseEvent
+	nextSequence int64
+}
+
+func (s *SessionResponseEventStore) readForSubscriber(afterSequence int64, dispatchID string) (subscriberRead, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.closed {
-		return nil, true
+		return subscriberRead{}, true
 	}
-	events := s.eventsAfterLocked(afterSequence, dispatchID)
-	if s.completed && len(events) == 0 {
-		return nil, true
+	result := s.eventsAfterLocked(afterSequence, dispatchID)
+	if s.completed && len(result.events) == 0 {
+		return subscriberRead{}, true
 	}
-	return events, false
+	return result, false
 }
 
-func (s *SessionResponseEventStore) eventsAfterLocked(afterSequence int64, dispatchID string) []responseevents.FactoryResponseEvent {
-	if len(s.events) == 0 {
-		return nil
+func (s *SessionResponseEventStore) eventsAfterLocked(afterSequence int64, dispatchID string) subscriberRead {
+	result := subscriberRead{nextSequence: afterSequence}
+	if from, to, ok := droppedBoundsAfter(s.droppedSequences, afterSequence); ok {
+		result.events = append(result.events, s.retentionGapEventLocked(from, to))
+		result.nextSequence = to
 	}
-	out := make([]responseevents.FactoryResponseEvent, 0)
 	for _, event := range s.events {
 		if event.Sequence <= afterSequence {
 			continue
@@ -279,12 +291,43 @@ func (s *SessionResponseEventStore) eventsAfterLocked(afterSequence int64, dispa
 		if dispatchID != "" && !dispatchMatches(event.DispatchID, dispatchID) {
 			continue
 		}
-		out = append(out, cloneEvent(event))
+		result.events = append(result.events, cloneEvent(event))
+		if event.Sequence > result.nextSequence {
+			result.nextSequence = event.Sequence
+		}
 	}
-	if len(out) == 0 {
-		return nil
+	return result
+}
+
+// retentionGapEventLocked creates an out-of-band marker. Sequence zero is
+// reserved for this synthetic read result: the marker is never stored, never
+// participates in retention, and never consumes or impersonates a published
+// sequence. Its deterministic event ID identifies the same cursor-relative gap
+// consistently without entering the session's published identity space.
+func (s *SessionResponseEventStore) retentionGapEventLocked(from, to int64) responseevents.FactoryResponseEvent {
+	payload, _ := json.Marshal(responseevents.StreamGapPayload{
+		FromSequence: from,
+		ToSequence:   to,
+		Reason:       retentionGapReason,
+	})
+	identity := fmt.Sprintf("%s:%d:%d:%s", s.factorySessionID, from, to, retentionGapReason)
+	return responseevents.FactoryResponseEvent{
+		SchemaVersion:    responseevents.SchemaVersionV1,
+		EventID:          uuid.NewSHA1(uuid.NameSpaceOID, []byte(identity)).String(),
+		Sequence:         0,
+		RecordedAt:       s.storeNowLocked(),
+		FactorySessionID: s.factorySessionID,
+		Kind:             responseevents.KindStreamGap,
+		Phase:            responseevents.PhaseUpdated,
+		Provenance: responseevents.Provenance{
+			Provider:        "you-agent-factory",
+			NativeEventType: "response.retention_gap",
+			Delivery:        responseevents.DeliverySynthesized,
+			Representation:  responseevents.RepresentationNotification,
+			Fidelity:        responseevents.FidelityLossy,
+		},
+		Payload: payload,
 	}
-	return out
 }
 
 func dispatchMatches(eventDispatchID, filterDispatchID string) bool {

--- a/ui/src/api/generated/openapi.ts
+++ b/ui/src/api/generated/openapi.ts
@@ -3558,7 +3558,7 @@ export interface components {
       eventId: string;
       /**
        * Format: int64
-       * @description Monotonic session-scoped cursor for reconnect and ordering.
+       * @description Monotonic session-scoped cursor for published events. Sequence zero is reserved for synthetic out-of-band read markers such as retention gaps; those markers do not consume or reuse a published sequence.
        */
       sequence: number;
       /**
@@ -3894,12 +3894,12 @@ export interface components {
     FactoryResponseEventStreamGapPayload: {
       /**
        * Format: int64
-       * @description Last retained sequence before the gap.
+       * @description Lowest unavailable published sequence greater than the reader's cursor.
        */
       fromSequence: number;
       /**
        * Format: int64
-       * @description First available sequence after the gap.
+       * @description Highest unavailable published sequence in the reader's catch-up window.
        */
       toSequence: number;
       /** @description Optional reason for the stream gap such as retention_window. */


### PR DESCRIPTION
{
  "project": "Retain Semantic Response Snapshots and Report Stream Gaps",
  "branchName": "stream-b03-retention-and-gaps",
  "description": "Bound each Factory Session response-event store by exact event-count and serialized-byte limits, preferentially retain final semantic snapshots, preserve immutable published event identities and sequences, and report exact cursor-relative dropped bounds before stale-reader catch-up.",
  "context": {
    "customerAsk": "Add session-wide event-count and byte limits with snapshot-priority retention. Prefer final messages, tool failures, and run outcomes, never mutate retained events or rewrite published sequences, and emit STREAM_GAP with exact dropped sequence bounds for stale reads. Prove repeated accounting, late-reader reconstruction, gap metadata, and concurrency behavior with deterministic eviction tables, property/repeat tests, and focused race tests.",
    "problem": "An unbounded response-event store can exhaust memory, while indiscriminate truncation can discard final semantic records and retain transient noise. Selective repeated eviction can also drift event/byte counters, and stale readers can silently miss removed events or receive inaccurate gap bounds. Concurrent publication and catch-up increase the risk of inconsistent accounting, rewritten identities, and incomplete final-state reconstruction.",
    "solution": "Enforce explicit session-wide retained-event and retained-byte budgets in the session-owned response-event store using one deterministic serialized-size rule. Evict the oldest lowest-priority records first, giving final messages, tool failures, and terminal run outcomes the strongest preference while treating both limits as hard. Preserve published envelopes and monotonic sequences verbatim, track unavailable sequence bounds separately, and emit one lossy cursor-relative STREAM_GAP before retained catch-up so late readers can identify loss and reconstruct the final semantic state that fits within the budgets."
  },
  "acceptanceCriteria": [
    "Each Factory Session response-event store enforces configured session-wide event-count and byte limits after every retention pass, using a documented deterministic serialized-size rule",
    "Retention evicts the oldest lowest-priority transient records first and preferentially preserves final message snapshots, tool failures, and terminal run outcomes when those records can fit within the configured budgets",
    "Repeated eviction keeps retained event count and retained byte count exactly equal to the retained immutable records, without duplicate removal or accounting drift",
    "Retention never changes a retained event's payload, event ID, or published sequence and never assigns an old sequence to a replacement or gap record",
    "A read whose afterSequence is behind removed history receives a lossy STREAM_GAP with exact dropped lower and upper sequence bounds before retained catch-up; a current cursor receives no gap",
    "After the gap, late readers receive retained events in original order and can reconstruct the final message, tool-failure, and run-outcome state when those snapshots fit the limits",
    "Quality checks pass (typecheck, lint, tests), including deterministic eviction tables, repeated/property-style accounting tests, and focused go test -race coverage for publish, eviction, subscribe, and read"
  ],
  "userStories": [
    {
      "id": "stream-b03-retention-and-gaps-001",
      "title": "Enforce exact session-wide retention budgets with semantic priority",
      "description": "As a Factory Session operator, I want response-event retention to stay within configured event and byte budgets while preferring final semantic snapshots so late inspection remains useful without unbounded memory growth.",
      "acceptanceCriteria": [
        "The store accepts explicit positive session-wide maximum retained-event and retained-byte limits, and retention runs after publication and when limits are applied or reduced until both limits are satisfied",
        "Retained byte size is computed by one documented deterministic rule based on the serialized retained event envelope; tests use the same production accounting boundary rather than an approximate payload-only counter",
        "When either limit is exceeded, deterministic eviction chooses the oldest record from the lowest available retention tier: transient deltas/progress before authoritative active-item snapshots, with final message snapshots, tool failures, and terminal run outcomes in the highest-preference tier",
        "If all preferred records cannot fit, eviction still satisfies both hard limits using deterministic age order within the remaining tier; preference does not permit budget overflow",
        "A single event larger than the byte budget is handled deterministically without leaving the store over budget or looping indefinitely, and its published sequence remains unavailable rather than being reused",
        "After every publish and every repeated eviction pass, reported retained count equals the number of retained events and reported retained bytes equal the sum of their accounted sizes",
        "Eviction removes records only; every retained event remains byte-for-byte equivalent to its published envelope, including unchanged eventId, sequence, kind, phase, provenance, and payload",
        "Deterministic table tests cover count-only pressure, byte-only pressure, simultaneous limits, priority ties, oversized events, limit reduction, and repeated eviction; property/repeat tests assert both limits, exact counters, stable retained identities, and monotonic unreused sequences across varied event mixes",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented in dbacbae14 with exact serialized-envelope accounting, hard count/byte limits, semantic-priority eviction, deterministic tie handling, and repeat/race coverage."
    },
    {
      "id": "stream-b03-retention-and-gaps-002",
      "title": "Report exact stale-cursor gaps and preserve final late-read state",
      "description": "As a late response-stream reader, I want an exact gap signal before retained catch-up so I know which published sequence bounds became unavailable and can still reconstruct the final semantic state from prioritized snapshots.",
      "acceptanceCriteria": [
        "When afterSequence precedes one or more sequences removed by retention, the read begins with exactly one synthetic STREAM_GAP/UPDATED event before any retained response events",
        "The gap payload's fromSequence is the lowest dropped sequence greater than the reader's cursor and its toSequence is the highest dropped sequence relevant to the catch-up window; the event uses lossy provenance and a stable retention reason",
        "The synthetic gap receives a new sequence/identity according to normal publication rules or is explicitly out-of-band from stored sequence identity; it never overwrites, renumbers, or impersonates a dropped or retained event",
        "A cursor at or beyond the applicable dropped bounds receives no gap, and a cursor inside a previously dropped span receives bounds clipped to the unavailable sequences after that cursor",
        "After the gap, retained events are delivered once in ascending original sequence order and the subscription continues live without duplicates",
        "In a stream containing heavy deltas plus a final message, a failed tool snapshot, and a terminal run outcome that fit the configured budgets, a late reader receives gap metadata and reconstructs those final semantic states exactly",
        "Repeated/property-style tests compare emitted gap bounds with the actual evicted sequence ledger across multiple retention cycles and cursor positions, including retained records whose sequences fall within the aggregate lower/upper bounds",
        "Focused go test -race coverage proves concurrent publish, eviction, subscribe, catch-up, and close produce internally consistent accounting, gap bounds, and immutable retained events without panics or data races",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented in 3a0128735 with bounded exact dropped-sequence spans, cursor-clipped out-of-band STREAM_GAP markers, semantic late-read reconstruction, generated contract alignment, repeated ledger tests, and focused race coverage."
    }
  ]
}
