### PR TITLE
session-repair-materialized-state-timeline-integration

### DIFF
--- a/ui/integration/browser-test-harness.mjs
+++ b/ui/integration/browser-test-harness.mjs
@@ -26,7 +26,38 @@ export const defaultFactorySessionID = "~default";
 export const resolvedDefaultFactorySessionID =
   "019e0000-0000-7000-8000-000000000042";
 export const timelineCheckpointDBVersion = 3;
-export const timelineCheckpointSchemaVersion = 3;
+export const timelineCheckpointSchemaVersion = 4;
+
+export function emptyMaterializedWorkOutcomeState(cursor) {
+  return {
+    accumulator: {
+      activeDispatchesByID: {},
+      appliedEventCount: 0,
+      completedAcceptedCount: 0,
+      completedDispatchCount: 0,
+      failedWorkItemsByID: {},
+      initialPlaceIDs: [],
+      workItemsByID: {},
+    },
+    counts: {
+      completed: 0,
+      dispatched: 0,
+      failed: 0,
+      inFlight: 0,
+      queued: 0,
+    },
+    cursor: {
+      eventID: cursor.afterEventId,
+      eventTime: cursor.eventTime ?? "1970-01-01T00:00:00Z",
+      sequence: cursor.afterSequence,
+      tick: cursor.selectedTick,
+    },
+    failedByWorkType: {},
+    failedWorkLabels: [],
+    samples: [],
+    version: 1,
+  };
+}
 
 function isDefaultFactorySessionSelector(sessionID) {
   return (

--- a/ui/integration/dashboard-session-recovery-manual-scenarios-harness.mjs
+++ b/ui/integration/dashboard-session-recovery-manual-scenarios-harness.mjs
@@ -1,4 +1,5 @@
 import {
+  emptyMaterializedWorkOutcomeState,
   initialEditableFactoryDefinitionVersion,
   resolvedDefaultFactorySessionID,
   timelineCheckpointDBVersion,
@@ -205,6 +206,8 @@ export async function seedTimelineCheckpoint(page, identity, cursor) {
         checkpoint: {
           afterEventId: cursor.afterEventId,
           afterSequence: cursor.afterSequence,
+          materializedWorkOutcomeState:
+            emptyMaterializedWorkOutcomeState(cursor),
           replayState,
           selectedTick: cursor.selectedTick,
         },

--- a/ui/integration/dashboard-session-recovery.integration.test.mjs
+++ b/ui/integration/dashboard-session-recovery.integration.test.mjs
@@ -5,6 +5,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   browserScenarioTimeoutMs,
   buildTimeoutMs,
+  emptyMaterializedWorkOutcomeState,
   expectNoBrowserErrors,
   initialEditableFactoryDefinitionVersion,
   openBrowserPage,
@@ -159,6 +160,8 @@ async function seedTimelineCheckpoint(page, identity, cursor) {
         checkpoint: {
           afterEventId: cursor.afterEventId,
           afterSequence: cursor.afterSequence,
+          materializedWorkOutcomeState:
+            emptyMaterializedWorkOutcomeState(cursor),
           replayState: emptyReplayWorldState(cursor.selectedTick),
           selectedTick: cursor.selectedTick,
         },

--- a/ui/src/features/dashboard/hooks/event-stream/useFactoryEventStream.ts
+++ b/ui/src/features/dashboard/hooks/event-stream/useFactoryEventStream.ts
@@ -109,7 +109,9 @@ function reconnectCursorFromEvent(
   };
 }
 
-function clearReconnectTimeout(reconnectTimeoutRef: { current: number | null }) {
+function clearReconnectTimeout(reconnectTimeoutRef: {
+  current: number | null;
+}) {
   if (reconnectTimeoutRef.current != null) {
     window.clearTimeout(reconnectTimeoutRef.current);
     reconnectTimeoutRef.current = null;
@@ -232,7 +234,9 @@ function useDashboardStreamConnection({
             streamSessionID,
             reconnect,
           );
-          if (validationAttempt !== refs.reconnectValidationAttemptRef.current) {
+          if (
+            validationAttempt !== refs.reconnectValidationAttemptRef.current
+          ) {
             return;
           }
           if (!validation.ok) {
@@ -362,7 +366,17 @@ export function useFactoryEventStream({
   validateReconnectCursor = validateFactoryEventReconnectCursor,
 }: UseFactoryEventStreamOptions) {
   const queryClient = useQueryClient();
-  const resetTimeline = useFactoryTimelineStore((state) => state.reset);
+  const resetAllTimelines = useFactoryTimelineStore((state) => state.reset);
+  const resetTimelineEntry = useFactoryTimelineStore(
+    (state) => state.resetEntry,
+  );
+  const resetTimeline = useCallback(() => {
+    if (streamIdentity) {
+      resetTimelineEntry(streamIdentity);
+      return;
+    }
+    resetAllTimelines();
+  }, [resetAllTimelines, resetTimelineEntry, streamIdentity]);
   const setStreamState = useDashboardStreamStore(
     (state) => state.setStreamState,
   );

--- a/ui/src/features/dashboard/hooks/preflight/use-dashboard-checkpoint-preflight.identity-race.test.tsx
+++ b/ui/src/features/dashboard/hooks/preflight/use-dashboard-checkpoint-preflight.identity-race.test.tsx
@@ -9,6 +9,7 @@ import {
   createControlledIndexedDBTestDouble,
   flushPromiseContinuations,
 } from "../../../../testing/controlled-indexeddb-test-utils";
+import { createMaterializedWorkOutcomeState } from "../../../work-outcome/public/materializer";
 import { useDashboardCheckpointPreflight } from "./use-dashboard-checkpoint-preflight";
 
 vi.mock("../../session/dashboard-session-provider", () => ({
@@ -32,8 +33,12 @@ describe("useDashboardCheckpointPreflight exact deletion cancellation", () => {
   it("preserves persisted and runtime state when deletion is superseded", async () => {
     const sessionID = "session-delete-race";
     const persistedRecord = {
-      checkpoint: { replayState: {}, selectedTick: 11 },
-      schemaVersion: 3,
+      checkpoint: {
+        materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
+        replayState: {},
+        selectedTick: 11,
+      },
+      schemaVersion: 4,
       storageKey: `checkpoint-${sessionID}`,
       streamIdentity: {
         backendScopeID: `backend-${sessionID}`,

--- a/ui/src/features/dashboard/hooks/preflight/use-dashboard-checkpoint-preflight.test.tsx
+++ b/ui/src/features/dashboard/hooks/preflight/use-dashboard-checkpoint-preflight.test.tsx
@@ -327,6 +327,7 @@ describe("useDashboardCheckpointPreflight superseded session races", () => {
     expect(race.result.current.persistedCheckpoint?.selectedTick).toBe(22);
     expect(race.restoreCheckpoint).toHaveBeenCalledTimes(1);
     expect(race.restoreCheckpoint).toHaveBeenCalledWith(
+      expect.objectContaining({ factorySessionID: SESSION_B }),
       expect.objectContaining({ selectedTick: 22 }),
     );
     expect(race.readCheckpointSpy).toHaveBeenCalledTimes(1);

--- a/ui/src/features/dashboard/hooks/preflight/use-dashboard-checkpoint-preflight.ts
+++ b/ui/src/features/dashboard/hooks/preflight/use-dashboard-checkpoint-preflight.ts
@@ -69,7 +69,10 @@ export function useDashboardCheckpointPreflight({
   checkpointsDisabled: boolean;
   rawSessionID: string | null;
   refreshToken: number;
-  restoreCheckpoint: (checkpoint: FactoryTimelineCheckpoint) => void;
+  restoreCheckpoint: (
+    streamIdentity: TimelineCheckpointStreamIdentity,
+    checkpoint: FactoryTimelineCheckpoint,
+  ) => void;
 }): UseDashboardCheckpointPreflightResult {
   const queryClient = useQueryClient();
   const remapSelectedSessionID = useRemapDashboardSelectedSession();
@@ -209,7 +212,7 @@ export function useDashboardCheckpointPreflight({
         remapSelectedSessionID(resolution.resolvedSessionId);
       }
       if (resolution.kind === "resume" && resolution.checkpoint) {
-        restoreCheckpoint({
+        restoreCheckpoint(resolution.streamIdentity, {
           ...resolution.checkpoint,
           syncIdentity: checkpointSyncIdentityFromPreflight(
             resolution.streamIdentity,

--- a/ui/src/features/dashboard/hooks/useDashboardSnapshot.test.tsx
+++ b/ui/src/features/dashboard/hooks/useDashboardSnapshot.test.tsx
@@ -29,6 +29,7 @@ import {
 } from "../../timeline/state/factoryTimelineStore";
 import { emptyReplayWorldState } from "../../timeline/state/timeline/replayWorldStateSupport";
 import { readTimelineCheckpoint } from "../../timeline/state/timelineCheckpointPersistence";
+import { createMaterializedWorkOutcomeState } from "../../work-outcome/public/materializer";
 import { useDashboardSessionStore } from "../state/dashboardSessionStore";
 import {
   createDefaultDashboardStreamState,
@@ -285,10 +286,11 @@ describe("useDashboardSnapshot composer", () => {
       checkpoint: {
         afterEventId: "event-2",
         afterSequence: 2,
+        materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
         replayState: emptyReplayWorldState(17),
         selectedTick: 17,
       },
-      schemaVersion: 3,
+      schemaVersion: 4,
       storageKey: checkpointStorageKey(),
       streamIdentity: defaultStreamIdentity(),
     });
@@ -561,10 +563,11 @@ describe("useDashboardSnapshot composer", () => {
       checkpoint: {
         afterEventId: "checkpoint-event-7",
         afterSequence: 7,
+        materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
         replayState: emptyReplayWorldState(7),
         selectedTick: 7,
       },
-      schemaVersion: 3,
+      schemaVersion: 4,
       storageKey: checkpointStorageKey(),
       streamIdentity: defaultStreamIdentity(),
     });
@@ -637,6 +640,7 @@ describe("useDashboardSnapshot composer", () => {
       checkpoint: {
         afterEventId: "checkpoint-event-7",
         afterSequence: 7,
+        materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
         replayState: emptyReplayWorldState(7),
         selectedTick: 7,
         syncIdentity: {
@@ -646,7 +650,7 @@ describe("useDashboardSnapshot composer", () => {
           streamGenerationId: "2026-06-27T00:00:00Z",
         },
       },
-      schemaVersion: 3,
+      schemaVersion: 4,
       storageKey: checkpointStorageKey("session-stale-001"),
       streamIdentity: staleStreamIdentity,
     });
@@ -654,10 +658,11 @@ describe("useDashboardSnapshot composer", () => {
       checkpoint: {
         afterEventId: "beta-event-9",
         afterSequence: 9,
+        materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
         replayState: emptyReplayWorldState(9),
         selectedTick: 9,
       },
-      schemaVersion: 3,
+      schemaVersion: 4,
       storageKey: checkpointStorageKey("session-beta"),
       streamIdentity: defaultStreamIdentity("session-beta"),
     });
@@ -754,10 +759,11 @@ describe("useDashboardSnapshot composer", () => {
       checkpoint: {
         afterEventId: "checkpoint-event-7",
         afterSequence: 7,
+        materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
         replayState: emptyReplayWorldState(7),
         selectedTick: 7,
       },
-      schemaVersion: 3,
+      schemaVersion: 4,
       storageKey: checkpointStorageKey(staleSessionID),
       streamIdentity: staleStreamIdentity,
     });

--- a/ui/src/features/dashboard/hooks/useDashboardSnapshot.test.tsx
+++ b/ui/src/features/dashboard/hooks/useDashboardSnapshot.test.tsx
@@ -194,6 +194,7 @@ describe("useDashboardSnapshot composer", () => {
 
   beforeEach(() => {
     replayHarness.install();
+    window.history.replaceState({}, "", "/");
     indexedDBRecords = installIndexedDBTestDouble();
     getFactorySessionSyncPreflightSpy = vi
       .spyOn(factorySessionsAPI, "getFactorySessionSyncPreflight")
@@ -225,6 +226,7 @@ describe("useDashboardSnapshot composer", () => {
   });
 
   afterEach(() => {
+    window.history.replaceState({}, "", "/");
     vi.unstubAllGlobals();
     getFactorySessionSyncPreflightSpy.mockRestore();
     replayHarness.reset();
@@ -431,6 +433,72 @@ describe("useDashboardSnapshot composer", () => {
     expect(
       window.localStorage.getItem(FACTORY_TIMELINE_DEBUG_STORAGE_KEY),
     ).toBeNull();
+  });
+
+  it("advances replay and materialized outcomes when checkpoint persistence is disabled", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/?afDisableTimelineCheckpoint=1",
+    );
+    useFactoryTimelineStore.getState().reset();
+
+    const { result } = renderHook(() => useDashboardSnapshot(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(replayHarness.getStreams()).toHaveLength(1);
+    });
+    expect(getFactorySessionSyncPreflightSpy).not.toHaveBeenCalled();
+
+    await act(async () => {
+      replayHarness.getStreams()[0]?.emit("message", {
+        context: {
+          eventTime: "2026-07-13T10:00:01Z",
+          sequence: 1,
+          tick: 1,
+        },
+        id: "disabled-checkpoint-work-request",
+        payload: {
+          source: "api",
+          type: "FACTORY_REQUEST_BATCH",
+          works: [
+            {
+              name: "Diagnostic timeline story",
+              traceId: "trace-disabled-checkpoint",
+              workId: "work-disabled-checkpoint",
+              workTypeName: "story",
+            },
+          ],
+        },
+        type: FACTORY_EVENT_TYPES.workRequest,
+      });
+      await new Promise<void>((resolve) => {
+        window.setTimeout(() => resolve(), 20);
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.snapshot?.tick_count).toBe(1);
+    });
+    expect(useFactoryTimelineStore.getState()).toMatchObject({
+      currentReplayCheckpoint: {
+        afterEventId: "disabled-checkpoint-work-request",
+        afterSequence: 1,
+        selectedTick: 1,
+      },
+      events: [{ id: "disabled-checkpoint-work-request" }],
+      latestTick: 1,
+      materializedWorkOutcomeState: {
+        accumulator: { appliedEventCount: 1 },
+        cursor: {
+          eventID: "disabled-checkpoint-work-request",
+          sequence: 1,
+          tick: 1,
+        },
+      },
+    });
   });
 
   it("hydrates a persisted checkpoint and opens the stream after its cursor", async () => {

--- a/ui/src/features/dashboard/hooks/useDashboardSnapshot.ts
+++ b/ui/src/features/dashboard/hooks/useDashboardSnapshot.ts
@@ -67,15 +67,22 @@ export function useDashboardSnapshot({
   locale,
   refreshToken = 0,
 }: UseDashboardSnapshotOptions = {}) {
-  const appendEvents = useFactoryTimelineStore((state) => state.appendEvents);
+  const activateTimelineEntry = useFactoryTimelineStore(
+    (state) => state.activateEntry,
+  );
+  const appendEventsForEntry = useFactoryTimelineStore(
+    (state) => state.appendEventsForEntry,
+  );
   const currentReplayCheckpoint = useFactoryTimelineStore(
     (state) => state.currentReplayCheckpoint,
   );
   const eventCount = useFactoryTimelineStore((state) => state.events.length);
-  const restoreCheckpoint = useFactoryTimelineStore(
-    (state) => state.restoreCheckpoint,
+  const restoreCheckpointForEntry = useFactoryTimelineStore(
+    (state) => state.restoreCheckpointForEntry,
   );
-  const resetTimeline = useFactoryTimelineStore((state) => state.reset);
+  const resetTimelineEntry = useFactoryTimelineStore(
+    (state) => state.resetEntry,
+  );
   const { error, isInitialLoading, snapshot, streamState } =
     useDashboardWorldView();
   const { isPaused, rawSessionID } = useDashboardSession();
@@ -87,14 +94,10 @@ export function useDashboardSnapshot({
   const reconnectCursorInvalidatedRef = useRef(false);
   const [reconnectCursorRevision, setReconnectCursorRevision] = useState(0);
   const defaultRuntimeSessionIDRef = useRef<string | null>(null);
-  const lastPersistedCheckpointRef =
-    useRef<FactoryTimelineCheckpoint | null>(null);
+  const lastPersistedCheckpointRef = useRef<FactoryTimelineCheckpoint | null>(
+    null,
+  );
   const lastSessionIDRef = useRef<string | null>(null);
-  const queuedAppendRef =
-    useRef<(events: FactoryEvent[]) => void>(appendEvents);
-
-  queuedAppendRef.current = appendEvents;
-
   useDashboardSessionLifecycle({
     locale,
     refreshToken,
@@ -115,8 +118,14 @@ export function useDashboardSnapshot({
     checkpointsDisabled: debugOptions.disableTimelineCheckpoint,
     rawSessionID,
     refreshToken,
-    restoreCheckpoint,
+    restoreCheckpoint: restoreCheckpointForEntry,
   });
+
+  useEffect(() => {
+    if (streamIdentity) {
+      activateTimelineEntry(streamIdentity);
+    }
+  }, [activateTimelineEntry, streamIdentity]);
 
   const effectiveSessionID = resolvedSessionID ?? rawSessionID;
 
@@ -157,7 +166,12 @@ export function useDashboardSnapshot({
         ? undefined
         : (preflightReconnectCursor ??
           reconnectCursorFromCheckpoint(persistedCheckpoint)),
-    [persistedCheckpoint, preflightReconnectCursor, reconnectCursorRevision, refreshToken],
+    [
+      persistedCheckpoint,
+      preflightReconnectCursor,
+      reconnectCursorRevision,
+      refreshToken,
+    ],
   );
 
   const handleInvalidReconnectCursor = useCallback(() => {
@@ -174,9 +188,11 @@ export function useDashboardSnapshot({
         ),
       );
     }
-    resetTimeline();
+    if (streamIdentity) {
+      resetTimelineEntry(streamIdentity);
+    }
     void clearTimelineCheckpoint(window.indexedDB, streamIdentity);
-  }, [rawSessionID, resetTimeline, streamIdentity]);
+  }, [rawSessionID, resetTimelineEntry, streamIdentity]);
 
   const checkpointSyncIdentity = useMemo(() => {
     if (
@@ -206,13 +222,23 @@ export function useDashboardSnapshot({
     syncIdentity: checkpointSyncIdentity,
   });
 
-  const handleStreamEvent = useCallback((event: FactoryEvent) => {
-    queuedAppendRef.current([event]);
-  }, []);
+  const handleStreamEvent = useCallback(
+    (event: FactoryEvent) => {
+      if (streamIdentity) {
+        appendEventsForEntry(streamIdentity, [event]);
+      }
+    },
+    [appendEventsForEntry, streamIdentity],
+  );
 
-  const handleStreamEvents = useCallback((events: FactoryEvent[]) => {
-    queuedAppendRef.current(events);
-  }, []);
+  const handleStreamEvents = useCallback(
+    (events: FactoryEvent[]) => {
+      if (streamIdentity) {
+        appendEventsForEntry(streamIdentity, events);
+      }
+    },
+    [appendEventsForEntry, streamIdentity],
+  );
 
   useFactoryEventStream({
     enabled:
@@ -246,9 +272,7 @@ export function useDashboardSnapshot({
     () => ({
       error: preflightRecovery != null ? null : (preflightError ?? error),
       isInitialLoading:
-        preflightRecovery == null &&
-        preflightError == null &&
-        isInitialLoading,
+        preflightRecovery == null && preflightError == null && isInitialLoading,
       preflightRecovery,
       preflightStatus,
       snapshot: preflightRecovery ? null : snapshot,

--- a/ui/src/features/dashboard/hooks/useDashboardSnapshot.ts
+++ b/ui/src/features/dashboard/hooks/useDashboardSnapshot.ts
@@ -70,6 +70,7 @@ export function useDashboardSnapshot({
   const activateTimelineEntry = useFactoryTimelineStore(
     (state) => state.activateEntry,
   );
+  const appendEvents = useFactoryTimelineStore((state) => state.appendEvents);
   const appendEventsForEntry = useFactoryTimelineStore(
     (state) => state.appendEventsForEntry,
   );
@@ -222,22 +223,29 @@ export function useDashboardSnapshot({
     syncIdentity: checkpointSyncIdentity,
   });
 
-  const handleStreamEvent = useCallback(
-    (event: FactoryEvent) => {
-      if (streamIdentity) {
-        appendEventsForEntry(streamIdentity, [event]);
-      }
-    },
-    [appendEventsForEntry, streamIdentity],
-  );
-
-  const handleStreamEvents = useCallback(
+  const appendStreamEvents = useCallback(
     (events: FactoryEvent[]) => {
       if (streamIdentity) {
         appendEventsForEntry(streamIdentity, events);
+        return;
+      }
+      if (debugOptions.disableTimelineCheckpoint) {
+        appendEvents(events);
       }
     },
-    [appendEventsForEntry, streamIdentity],
+    [
+      appendEvents,
+      appendEventsForEntry,
+      debugOptions.disableTimelineCheckpoint,
+      streamIdentity,
+    ],
+  );
+
+  const handleStreamEvent = useCallback(
+    (event: FactoryEvent) => {
+      appendStreamEvents([event]);
+    },
+    [appendStreamEvents],
   );
 
   useFactoryEventStream({
@@ -250,7 +258,7 @@ export function useDashboardSnapshot({
     initialReconnectCursor,
     locale,
     onEvent: handleStreamEvent,
-    onEvents: handleStreamEvents,
+    onEvents: appendStreamEvents,
     onInvalidReconnectCursor: handleInvalidReconnectCursor,
     refreshToken,
     sessionID: effectiveSessionID,

--- a/ui/src/features/timeline/public/index.ts
+++ b/ui/src/features/timeline/public/index.ts
@@ -3,9 +3,14 @@ export {
   type StreamDerivedCacheIdentity,
   streamDerivedCacheKeyPrefix,
 } from "../lib/stream-derived-cache-identity";
+export {
+  factoryTimelineEntryKey,
+  type FactoryTimelineEntryKey,
+} from "../state/entries/factoryTimelineEntry";
 export { readFactoryTimelineDebugOptions } from "../state/factoryTimelineDebug";
 export {
   type FactoryTimelineCheckpoint,
+  type FactoryTimelineEntryState,
   type FactoryTimelineSyncIdentity,
   useFactoryTimelineStore,
 } from "../state/factoryTimelineStore";

--- a/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointCodec.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointCodec.ts
@@ -1,0 +1,75 @@
+import {
+  MATERIALIZED_WORK_OUTCOME_VERSION,
+  type MaterializedWorkOutcomeState,
+} from "../../../work-outcome/public/materializer";
+import type { FactoryTimelineCheckpoint } from "../timeline/storeState";
+import type { ReplayWorldState } from "../timeline/types";
+
+export const CHECKPOINT_SCHEMA_VERSION_GUARDED = 4;
+
+const MAX_COMPACT_TEXT_CHARS = 512;
+
+export interface PersistedTimelineCheckpoint {
+  afterEventId?: string;
+  afterSequence?: number;
+  materializedWorkOutcomeState: MaterializedWorkOutcomeState;
+  replayState: ReplayWorldState;
+  selectedTick: number;
+  syncIdentity?: FactoryTimelineCheckpoint["syncIdentity"];
+}
+
+export function isSupportedPersistedTimelineCheckpoint(
+  checkpoint: PersistedTimelineCheckpoint | null | undefined,
+): checkpoint is PersistedTimelineCheckpoint {
+  return (
+    checkpoint?.replayState !== undefined &&
+    checkpoint.materializedWorkOutcomeState?.version ===
+      MATERIALIZED_WORK_OUTCOME_VERSION
+  );
+}
+
+export function buildPersistedCheckpoint(
+  checkpoint: FactoryTimelineCheckpoint,
+): PersistedTimelineCheckpoint {
+  return {
+    afterEventId: checkpoint.afterEventId,
+    afterSequence: checkpoint.afterSequence,
+    materializedWorkOutcomeState: structuredClone(
+      checkpoint.materializedWorkOutcomeState,
+    ),
+    replayState: compactReplayState(checkpoint.replayState),
+    selectedTick: checkpoint.selectedTick,
+    syncIdentity: checkpoint.syncIdentity,
+  };
+}
+
+export function hydrateCheckpoint(
+  checkpoint: PersistedTimelineCheckpoint,
+): FactoryTimelineCheckpoint {
+  return {
+    afterEventId: checkpoint.afterEventId,
+    afterSequence: checkpoint.afterSequence,
+    materializedWorkOutcomeState: checkpoint.materializedWorkOutcomeState,
+    replayState: checkpoint.replayState,
+    selectedTick: checkpoint.selectedTick,
+    syncIdentity: checkpoint.syncIdentity,
+  };
+}
+
+function compactReplayState(state: ReplayWorldState): ReplayWorldState {
+  const compacted = structuredClone(state);
+
+  for (const [textBlobID, value] of Object.entries(compacted.textBlobsByID)) {
+    compacted.textBlobsByID[textBlobID] = compactText(value);
+  }
+
+  return compacted;
+}
+
+function compactText(value: string): string {
+  if (value.length <= MAX_COMPACT_TEXT_CHARS) {
+    return value;
+  }
+  // hardcoded-ui-copy-exception: non-product-diagnostic
+  return `${value.slice(0, MAX_COMPACT_TEXT_CHARS)}\n\n[checkpoint truncated ${value.length - MAX_COMPACT_TEXT_CHARS} chars]`;
+}

--- a/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.materialized-boundary.test.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.materialized-boundary.test.ts
@@ -1,0 +1,47 @@
+import { expect, it } from "vitest";
+import { createTimelineCheckpointIndexedDBTestDouble } from "../../../../testing/timeline-checkpoint-indexeddb-test-utils";
+import { emptyReplayWorldState } from "../timeline/replayWorldStateSupport";
+import {
+  readTimelineCheckpoint,
+  type TimelineCheckpointStreamIdentity,
+} from "../timelineCheckpointPersistence";
+
+interface ReplayOnlyCheckpointEnvelope {
+  checkpoint: {
+    afterEventId: string;
+    afterSequence: number;
+    replayState: ReturnType<typeof emptyReplayWorldState>;
+    selectedTick: number;
+  };
+  schemaVersion: number;
+  storageKey: string;
+  streamIdentity: TimelineCheckpointStreamIdentity;
+}
+
+it("deletes replay-only v3 checkpoints without a materialized boundary", async () => {
+  const fixture = createTimelineCheckpointIndexedDBTestDouble();
+  const records = fixture.records as Map<string, ReplayOnlyCheckpointEnvelope>;
+  const streamIdentity = {
+    backendScopeID: "backend-a",
+    factorySessionID: "a1b2c3d4-e5f6-4789-a012-3456789abcde",
+    logicalSessionKeyID: "logical-a",
+    streamGenerationID: "generation-a",
+  } satisfies TimelineCheckpointStreamIdentity;
+  const storageKey = Object.values(streamIdentity).join("::");
+  records.set(storageKey, {
+    checkpoint: {
+      afterEventId: "event-7",
+      afterSequence: 7,
+      replayState: emptyReplayWorldState(7),
+      selectedTick: 7,
+    },
+    schemaVersion: 3,
+    storageKey,
+    streamIdentity,
+  });
+
+  await expect(
+    readTimelineCheckpoint(fixture.indexedDB, streamIdentity),
+  ).resolves.toBeNull();
+  expect(records.has(storageKey)).toBe(false);
+});

--- a/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.replacement-failure.test.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.replacement-failure.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../dashboard/lib/session-persistence/diagnostics";
 import { emptyReplayWorldState } from "../timeline/replayWorldStateSupport";
 import type { FactoryTimelineCheckpoint } from "../timeline/storeState";
+import { createMaterializedWorkOutcomeState } from "../../../work-outcome/public/materializer";
 import {
   clearTimelineCheckpointsForSession,
   persistTimelineCheckpoint,
@@ -43,6 +44,7 @@ function checkpoint(
   return {
     afterEventId,
     afterSequence,
+    materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
     replayState: emptyReplayWorldState(selectedTick),
     selectedTick,
   };

--- a/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.test.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.test.ts
@@ -14,11 +14,15 @@ import {
   type TimelineCheckpointStreamIdentity,
 } from "../timelineCheckpointPersistence";
 import { reconnectCursorFromCheckpoint } from "../timelineCheckpointReconnect";
+import { createMaterializedWorkOutcomeState } from "../../../work-outcome/public/materializer";
 
 interface StoredCheckpointEnvelope {
   checkpoint?: {
     afterEventId?: string;
     afterSequence?: number;
+    materializedWorkOutcomeState?: ReturnType<
+      typeof createMaterializedWorkOutcomeState
+    >;
     replayState?: ReturnType<typeof emptyReplayWorldState>;
     selectedTick: number;
   };
@@ -138,6 +142,7 @@ function checkpointFixture(): FactoryTimelineCheckpoint {
   return {
     afterEventId: "event-7",
     afterSequence: 42,
+    materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
     replayState,
     selectedTick: 7,
     syncIdentity: {
@@ -238,7 +243,7 @@ describe("timeline checkpoint persistence diagnostics", () => {
 
     records.set(storageKey, {
       checkpoint: checkpointFixture(),
-      schemaVersion: 3,
+      schemaVersion: 4,
       storageKey,
       streamIdentity: {
         ...streamIdentity,
@@ -430,7 +435,7 @@ describe("timeline checkpoint guard migration", () => {
 
     records.set(affectedStorageKey, {
       checkpoint,
-      schemaVersion: 3,
+      schemaVersion: 4,
       storageKey: affectedStorageKey,
       streamIdentity: { ...expectedIdentity, ...mismatch },
     });
@@ -456,6 +461,7 @@ describe("timeline checkpoint reconnect cursors", () => {
     expect(reconnectCursorFromCheckpoint(null)).toBeUndefined();
     expect(
       reconnectCursorFromCheckpoint({
+        materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
         replayState: emptyReplayWorldState(1),
         selectedTick: 1,
       }),
@@ -468,6 +474,7 @@ describe("timeline checkpoint reconnect cursors", () => {
     expect(
       reconnectCursorFromCheckpoint({
         afterSequence: 9,
+        materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
         replayState: emptyReplayWorldState(9),
         selectedTick: 9,
       }),

--- a/ui/src/features/timeline/state/entries/factoryTimelineEntry.append.test.ts
+++ b/ui/src/features/timeline/state/entries/factoryTimelineEntry.append.test.ts
@@ -1,6 +1,11 @@
 import { FACTORY_EVENT_TYPES, type FactoryEvent } from "../../../../api/events";
 import type { StreamDerivedCacheIdentity } from "../../lib/stream-derived-cache-identity";
+import { createTimelineCheckpointIndexedDBTestDouble } from "../../../../testing/timeline-checkpoint-indexeddb-test-utils";
 import { useFactoryTimelineStore } from "../factoryTimelineStore";
+import {
+  persistTimelineCheckpoint,
+  readTimelineCheckpoint,
+} from "../timelineCheckpointPersistence";
 
 const identity: StreamDerivedCacheIdentity = {
   backendScopeID: "backend-a",
@@ -99,6 +104,25 @@ const dispatchResponse = event(
   "dispatch-1",
 );
 
+const reconnectSuffix = event(
+  "event-work-2",
+  5,
+  5,
+  FACTORY_EVENT_TYPES.workRequest,
+  {
+    source: "api",
+    type: "FACTORY_REQUEST_BATCH",
+    works: [
+      {
+        name: "Reconnect Suffix Story",
+        traceId: "trace-2",
+        workId: "work-2",
+        workTypeName: "story",
+      },
+    ],
+  },
+);
+
 function entry() {
   return useFactoryTimelineStore.getState().entryForIdentity(identity);
 }
@@ -174,6 +198,77 @@ describe("factory timeline ordered outcome append", () => {
 
     store.appendEventsForEntry(identity, [workRequest, initialStructure]);
     expect(entry()).toBe(before);
+  });
+});
+
+describe("factory timeline persisted append continuation", () => {
+  it("restores one persisted boundary and applies only a reconnect suffix", async () => {
+    const store = useFactoryTimelineStore.getState();
+    store.appendEventsForEntry(identity, [
+      initialStructure,
+      workRequest,
+      dispatchRequest,
+      dispatchResponse,
+    ]);
+    const checkpoint = entry()?.currentReplayCheckpoint;
+    if (!checkpoint) {
+      throw new Error("expected checkpoint after initial timeline append");
+    }
+    const { indexedDB } = createTimelineCheckpointIndexedDBTestDouble();
+    await persistTimelineCheckpoint(indexedDB, checkpoint, identity);
+
+    store.resetEntry(identity);
+    const restored = await readTimelineCheckpoint(indexedDB, identity);
+    if (!restored) {
+      throw new Error("expected persisted timeline checkpoint");
+    }
+    store.restoreCheckpointForEntry(identity, restored);
+    const beforeReconnect = entry();
+
+    store.appendEventsForEntry(identity, [
+      dispatchRequest,
+      dispatchResponse,
+      reconnectSuffix,
+    ]);
+
+    const current = entry();
+    expect(
+      beforeReconnect?.currentReplayCheckpoint?.replayState.completedDispatches,
+    ).toHaveLength(1);
+    expect(beforeReconnect?.materializedWorkOutcomeState).toMatchObject({
+      accumulator: { appliedEventCount: 4, completedDispatchCount: 1 },
+      counts: { completed: 1, dispatched: 1 },
+      cursor: { eventID: "event-response", sequence: 4, tick: 4 },
+    });
+    expect(current?.events.map(({ id }) => id)).toEqual(["event-work-2"]);
+    expect(current?.receivedEventIDs).toEqual(["event-work-2"]);
+    expect(
+      current?.currentReplayCheckpoint?.replayState.completedDispatches,
+    ).toHaveLength(1);
+    expect(current?.currentReplayCheckpoint).toMatchObject({
+      afterEventId: "event-work-2",
+      afterSequence: 5,
+      selectedTick: 5,
+    });
+    expect(current?.materializedWorkOutcomeState).toMatchObject({
+      accumulator: {
+        appliedEventCount: 5,
+        completedAcceptedCount: 1,
+        completedDispatchCount: 1,
+      },
+      counts: {
+        completed: 1,
+        dispatched: 1,
+        failed: 0,
+        inFlight: 0,
+        queued: 1,
+      },
+      cursor: { eventID: "event-work-2", sequence: 5, tick: 5 },
+    });
+    expect(current?.materializedWorkOutcomeState.samples).toHaveLength(5);
+    expect(current?.currentReplayCheckpoint?.afterEventId).toBe(
+      current?.materializedWorkOutcomeState.cursor?.eventID,
+    );
   });
 });
 

--- a/ui/src/features/timeline/state/entries/factoryTimelineEntry.append.test.ts
+++ b/ui/src/features/timeline/state/entries/factoryTimelineEntry.append.test.ts
@@ -1,0 +1,275 @@
+import { FACTORY_EVENT_TYPES, type FactoryEvent } from "../../../../api/events";
+import type { StreamDerivedCacheIdentity } from "../../lib/stream-derived-cache-identity";
+import { useFactoryTimelineStore } from "../factoryTimelineStore";
+
+const identity: StreamDerivedCacheIdentity = {
+  backendScopeID: "backend-a",
+  factorySessionID: "session-a-uuid",
+  logicalSessionKeyID: "logical-session-a",
+  streamGenerationID: "generation-1",
+};
+
+function event(
+  id: string,
+  tick: number,
+  sequence: number,
+  type: FactoryEvent["type"],
+  payload: FactoryEvent["payload"],
+  dispatchID?: string,
+): FactoryEvent {
+  return {
+    context: {
+      dispatchId: dispatchID,
+      eventTime: `2026-07-13T12:00:0${tick}.000Z`,
+      sequence,
+      tick,
+    },
+    id,
+    payload,
+    type,
+  };
+}
+
+const initialStructure = event(
+  "event-initial",
+  1,
+  1,
+  FACTORY_EVENT_TYPES.initialStructureRequest,
+  {
+    factory: {
+      workers: [],
+      workTypes: [
+        {
+          name: "story",
+          states: [
+            { name: "ready", type: "INITIAL" },
+            { name: "done", type: "TERMINAL" },
+          ],
+        },
+      ],
+      workstations: [],
+    },
+  },
+);
+
+const workRequest = event("event-work", 2, 2, FACTORY_EVENT_TYPES.workRequest, {
+  source: "api",
+  type: "FACTORY_REQUEST_BATCH",
+  works: [
+    {
+      name: "Timeline Story",
+      traceId: "trace-1",
+      workId: "work-1",
+      workTypeName: "story",
+    },
+  ],
+});
+
+const dispatchRequest = event(
+  "event-dispatch",
+  3,
+  3,
+  FACTORY_EVENT_TYPES.dispatchRequest,
+  {
+    inputs: [{ workId: "work-1" }],
+    transitionId: "review",
+  },
+  "dispatch-1",
+);
+
+const dispatchResponse = event(
+  "event-response",
+  4,
+  4,
+  FACTORY_EVENT_TYPES.dispatchResponse,
+  {
+    durationMillis: 10,
+    outcome: "ACCEPTED",
+    outputWork: [
+      {
+        name: "Timeline Story",
+        state: "done",
+        traceId: "trace-1",
+        workId: "work-1",
+        workTypeName: "story",
+      },
+    ],
+    transitionId: "review",
+  },
+  "dispatch-1",
+);
+
+function entry() {
+  return useFactoryTimelineStore.getState().entryForIdentity(identity);
+}
+
+afterEach(() => {
+  useFactoryTimelineStore.getState().reset();
+});
+
+describe("factory timeline ordered outcome append", () => {
+  it("publishes replay and outcomes from one ordered, deduplicated tail", () => {
+    const observedBoundaries: Array<[string | undefined, string | undefined]> =
+      [];
+    useFactoryTimelineStore.getState().activateEntry(identity);
+    const unsubscribe = useFactoryTimelineStore.subscribe((state) => {
+      observedBoundaries.push([
+        state.currentReplayCheckpoint?.afterEventId,
+        state.materializedWorkOutcomeState.cursor?.eventID,
+      ]);
+    });
+
+    useFactoryTimelineStore
+      .getState()
+      .appendEventsForEntry(identity, [
+        dispatchRequest,
+        workRequest,
+        initialStructure,
+        workRequest,
+      ]);
+    unsubscribe();
+
+    const current = entry();
+    expect(current?.events.map(({ id }) => id)).toEqual([
+      "event-initial",
+      "event-work",
+      "event-dispatch",
+    ]);
+    expect(current?.receivedEventIDs).toEqual([
+      "event-initial",
+      "event-work",
+      "event-dispatch",
+    ]);
+    expect(current?.currentReplayCheckpoint).toMatchObject({
+      afterEventId: "event-dispatch",
+      afterSequence: 3,
+      selectedTick: 3,
+    });
+    expect(
+      current?.currentReplayCheckpoint?.replayState.activeDispatches[
+        "dispatch-1"
+      ],
+    ).toBeDefined();
+    expect(current?.materializedWorkOutcomeState).toMatchObject({
+      accumulator: { appliedEventCount: 3 },
+      counts: {
+        completed: 0,
+        dispatched: 1,
+        failed: 0,
+        inFlight: 1,
+        queued: 0,
+      },
+      cursor: { eventID: "event-dispatch", sequence: 3, tick: 3 },
+    });
+    expect(observedBoundaries).toEqual([["event-dispatch", "event-dispatch"]]);
+  });
+
+  it("returns the existing entry for empty and duplicate-only batches", () => {
+    const store = useFactoryTimelineStore.getState();
+    store.appendEventsForEntry(identity, [initialStructure, workRequest]);
+    const before = entry();
+
+    store.appendEventsForEntry(identity, []);
+    expect(entry()).toBe(before);
+
+    store.appendEventsForEntry(identity, [workRequest, initialStructure]);
+    expect(entry()).toBe(before);
+  });
+});
+
+describe("factory timeline append continuation", () => {
+  it("applies only the new suffix from reconnect overlap", () => {
+    const store = useFactoryTimelineStore.getState();
+    store.appendEventsForEntry(identity, [
+      initialStructure,
+      workRequest,
+      dispatchRequest,
+    ]);
+
+    store.appendEventsForEntry(identity, [
+      workRequest,
+      dispatchRequest,
+      dispatchResponse,
+      dispatchResponse,
+    ]);
+
+    const current = entry();
+    expect(current?.events).toHaveLength(4);
+    expect(current?.currentReplayCheckpoint).toMatchObject({
+      afterEventId: "event-response",
+      afterSequence: 4,
+      selectedTick: 4,
+    });
+    expect(
+      current?.currentReplayCheckpoint?.replayState.completedDispatches,
+    ).toHaveLength(1);
+    expect(current?.materializedWorkOutcomeState).toMatchObject({
+      accumulator: {
+        appliedEventCount: 4,
+        completedAcceptedCount: 1,
+        completedDispatchCount: 1,
+      },
+      counts: {
+        completed: 1,
+        dispatched: 1,
+        failed: 0,
+        inFlight: 0,
+        queued: 0,
+      },
+      cursor: { eventID: "event-response", sequence: 4, tick: 4 },
+    });
+  });
+
+  it("keeps historical selection separate while live replay and outcomes advance", () => {
+    const store = useFactoryTimelineStore.getState();
+    store.appendEventsForEntry(identity, [initialStructure, workRequest]);
+    const materializedBeforeSelection = entry()?.materializedWorkOutcomeState;
+
+    store.selectTickForEntry(identity, 1);
+    expect(entry()?.materializedWorkOutcomeState).toBe(
+      materializedBeforeSelection,
+    );
+
+    store.appendEventForEntry(identity, dispatchRequest);
+    const fixed = entry();
+    expect(fixed).toMatchObject({ mode: "fixed", selectedTick: 1 });
+    expect(fixed?.currentReplayCheckpoint?.afterEventId).toBe("event-dispatch");
+    expect(fixed?.materializedWorkOutcomeState.cursor?.eventID).toBe(
+      "event-dispatch",
+    );
+    expect(fixed?.materializedWorkOutcomeState.counts.inFlight).toBe(1);
+
+    const liveMaterialized = fixed?.materializedWorkOutcomeState;
+    store.setCurrentModeForEntry(identity);
+    expect(entry()).toMatchObject({ mode: "current", selectedTick: 3 });
+    expect(entry()?.materializedWorkOutcomeState).toBe(liveMaterialized);
+  });
+
+  it("advances both projections for a later event at the current tick", () => {
+    const sameTickDispatch = {
+      ...dispatchRequest,
+      context: { ...dispatchRequest.context, tick: 2 },
+    };
+    const store = useFactoryTimelineStore.getState();
+    store.appendEventsForEntry(identity, [initialStructure, workRequest]);
+
+    store.appendEventForEntry(identity, sameTickDispatch);
+
+    const current = entry();
+    expect(
+      current?.currentReplayCheckpoint?.replayState.activeDispatches[
+        "dispatch-1"
+      ],
+    ).toBeDefined();
+    expect(current?.currentReplayCheckpoint).toMatchObject({
+      afterEventId: "event-dispatch",
+      afterSequence: 3,
+      selectedTick: 2,
+    });
+    expect(current?.materializedWorkOutcomeState.cursor).toMatchObject({
+      eventID: "event-dispatch",
+      sequence: 3,
+      tick: 2,
+    });
+  });
+});

--- a/ui/src/features/timeline/state/entries/factoryTimelineEntry.reset.test.ts
+++ b/ui/src/features/timeline/state/entries/factoryTimelineEntry.reset.test.ts
@@ -1,0 +1,253 @@
+import { FACTORY_EVENT_TYPES, type FactoryEvent } from "../../../../api/events";
+import type { StreamDerivedCacheIdentity } from "../../lib/stream-derived-cache-identity";
+import { useFactoryTimelineStore } from "../factoryTimelineStore";
+
+function identity(
+  factorySessionID: string,
+  streamGenerationID: string,
+): StreamDerivedCacheIdentity {
+  return {
+    backendScopeID: "backend-a",
+    factorySessionID,
+    logicalSessionKeyID: `logical-${factorySessionID}`,
+    streamGenerationID,
+  };
+}
+
+function event(
+  id: string,
+  tick: number,
+  type: FactoryEvent["type"],
+  payload: FactoryEvent["payload"],
+  dispatchID?: string,
+): FactoryEvent {
+  return {
+    context: {
+      dispatchId: dispatchID,
+      eventTime: `2026-07-13T15:00:0${tick}.000Z`,
+      sequence: tick,
+      tick,
+    },
+    id,
+    payload,
+    type,
+  };
+}
+
+const initialStructure = event(
+  "reset-initial",
+  1,
+  FACTORY_EVENT_TYPES.initialStructureRequest,
+  {
+    factory: {
+      workers: [],
+      workTypes: [
+        {
+          name: "story",
+          states: [
+            { name: "ready", type: "INITIAL" },
+            { name: "done", type: "TERMINAL" },
+          ],
+        },
+      ],
+      workstations: [],
+    },
+  },
+);
+
+const workRequest = event("reset-work", 2, FACTORY_EVENT_TYPES.workRequest, {
+  source: "api",
+  type: "FACTORY_REQUEST_BATCH",
+  works: [
+    {
+      name: "Reset Story",
+      traceId: "trace-reset",
+      workId: "work-reset",
+      workTypeName: "story",
+    },
+  ],
+});
+
+const dispatchRequest = event(
+  "reset-dispatch",
+  3,
+  FACTORY_EVENT_TYPES.dispatchRequest,
+  {
+    inputs: [{ workId: "work-reset" }],
+    transitionId: "review",
+  },
+  "dispatch-reset",
+);
+
+const fullHistory = [initialStructure, workRequest, dispatchRequest];
+
+function entry(streamIdentity: StreamDerivedCacheIdentity) {
+  return useFactoryTimelineStore.getState().entryForIdentity(streamIdentity);
+}
+
+afterEach(() => {
+  useFactoryTimelineStore.getState().reset();
+});
+
+describe("factory timeline entry reset", () => {
+  it("resets only the targeted entry to complete empty state", () => {
+    const sessionA = identity("session-a-uuid", "generation-1");
+    const sessionB = identity("session-b-uuid", "generation-1");
+    const store = useFactoryTimelineStore.getState();
+    store.appendEventsForEntry(sessionA, fullHistory);
+    store.selectTickForEntry(sessionA, 1);
+    store.activateEntry(sessionA);
+    store.appendEventsForEntry(sessionB, [initialStructure, workRequest]);
+    const sessionBBeforeReset = entry(sessionB);
+    const materializedBeforeReset =
+      entry(sessionA)?.materializedWorkOutcomeState;
+
+    store.resetEntry(sessionA);
+
+    const reset = entry(sessionA);
+    expect(reset).toMatchObject({
+      currentReplayCheckpoint: undefined,
+      events: [],
+      identity: sessionA,
+      latestTick: 0,
+      mode: "current",
+      receivedEventIDs: [],
+      selectedTick: 0,
+    });
+    expect(Object.keys(reset?.worldViewCache ?? {})).toEqual(["0"]);
+    expect(reset?.materializedWorkOutcomeState).toEqual({
+      accumulator: {
+        activeDispatchesByID: {},
+        appliedEventCount: 0,
+        completedAcceptedCount: 0,
+        completedDispatchCount: 0,
+        failedWorkItemsByID: {},
+        initialPlaceIDs: [],
+        workItemsByID: {},
+      },
+      counts: {
+        completed: 0,
+        dispatched: 0,
+        failed: 0,
+        inFlight: 0,
+        queued: 0,
+      },
+      cursor: null,
+      failedByWorkType: {},
+      failedWorkLabels: [],
+      samples: [],
+      version: 1,
+    });
+    expect(reset?.materializedWorkOutcomeState).not.toBe(
+      materializedBeforeReset,
+    );
+    expect(entry(sessionB)).toBe(sessionBBeforeReset);
+    expect(useFactoryTimelineStore.getState().events).toEqual([]);
+    expect(
+      useFactoryTimelineStore.getState().materializedWorkOutcomeState,
+    ).toBe(reset?.materializedWorkOutcomeState);
+  });
+});
+
+describe("factory timeline full-history replacement", () => {
+  it("rebuilds full history like uninterrupted append without inherited state", () => {
+    const stream = identity("session-a-uuid", "generation-1");
+    const reference = identity("session-reference-uuid", "generation-1");
+    const store = useFactoryTimelineStore.getState();
+    store.appendEventsForEntry(reference, fullHistory);
+    store.appendEventsForEntry(stream, [
+      initialStructure,
+      workRequest,
+      dispatchRequest,
+      event(
+        "old-response",
+        4,
+        FACTORY_EVENT_TYPES.dispatchResponse,
+        {
+          durationMillis: 10,
+          outcome: "ACCEPTED",
+          outputWork: [],
+          transitionId: "review",
+        },
+        "dispatch-reset",
+      ),
+    ]);
+    const inheritedAccumulator = entry(stream)?.materializedWorkOutcomeState;
+
+    store.replaceEventsForEntry(stream, [
+      dispatchRequest,
+      initialStructure,
+      workRequest,
+      workRequest,
+    ]);
+
+    const replaced = entry(stream);
+    const uninterrupted = entry(reference);
+    expect(replaced?.events.map(({ id }) => id)).toEqual(
+      uninterrupted?.events.map(({ id }) => id),
+    );
+    expect(replaced?.receivedEventIDs).toEqual(uninterrupted?.receivedEventIDs);
+    expect(replaced?.currentReplayCheckpoint).toEqual(
+      uninterrupted?.currentReplayCheckpoint,
+    );
+    expect(replaced?.materializedWorkOutcomeState).toEqual(
+      uninterrupted?.materializedWorkOutcomeState,
+    );
+    expect(replaced?.materializedWorkOutcomeState).not.toBe(
+      inheritedAccumulator,
+    );
+    expect(replaced).toMatchObject({
+      latestTick: 3,
+      mode: "current",
+      selectedTick: 3,
+    });
+  });
+});
+
+describe("factory timeline stream-generation replacement", () => {
+  it("keeps replacement generations empty under late old-generation callbacks", () => {
+    const oldGeneration = identity("session-a-uuid", "generation-1");
+    const newGeneration = identity("session-a-uuid", "generation-2");
+    const store = useFactoryTimelineStore.getState();
+    store.appendEventsForEntry(oldGeneration, fullHistory);
+    store.activateEntry(newGeneration);
+    const replacementBeforeLateCallback = entry(newGeneration);
+
+    store.appendEventForEntry(
+      oldGeneration,
+      event(
+        "late-old-generation",
+        4,
+        FACTORY_EVENT_TYPES.dispatchResponse,
+        {
+          durationMillis: 10,
+          outcome: "ACCEPTED",
+          outputWork: [],
+          transitionId: "review",
+        },
+        "dispatch-reset",
+      ),
+    );
+
+    expect(entry(newGeneration)).toBe(replacementBeforeLateCallback);
+    expect(entry(newGeneration)).toMatchObject({
+      currentReplayCheckpoint: undefined,
+      events: [],
+      latestTick: 0,
+      mode: "current",
+      receivedEventIDs: [],
+      selectedTick: 0,
+    });
+    expect(
+      entry(newGeneration)?.materializedWorkOutcomeState.cursor,
+    ).toBeNull();
+    expect(entry(newGeneration)?.materializedWorkOutcomeState.counts).toEqual({
+      completed: 0,
+      dispatched: 0,
+      failed: 0,
+      inFlight: 0,
+      queued: 0,
+    });
+    expect(entry(oldGeneration)?.events.at(-1)?.id).toBe("late-old-generation");
+  });
+});

--- a/ui/src/features/timeline/state/entries/factoryTimelineEntry.ts
+++ b/ui/src/features/timeline/state/entries/factoryTimelineEntry.ts
@@ -1,0 +1,42 @@
+import type { StreamDerivedCacheIdentity } from "../../lib/stream-derived-cache-identity";
+import { createMaterializedWorkOutcomeState } from "../../../work-outcome/public/materializer";
+import {
+  emptyTimelineState,
+  type FactoryTimelineEntryState,
+} from "../timeline/storeState";
+
+export type FactoryTimelineEntryKey = string;
+
+/**
+ * Logical session identity is remap metadata. It is intentionally absent from
+ * this key so aliases cannot create or select a different resolved stream.
+ */
+export function factoryTimelineEntryKey(
+  identity: StreamDerivedCacheIdentity,
+): FactoryTimelineEntryKey {
+  return JSON.stringify([
+    identity.backendScopeID,
+    identity.factorySessionID,
+    identity.streamGenerationID,
+  ]);
+}
+
+export function createFactoryTimelineEntry(
+  identity: StreamDerivedCacheIdentity,
+): FactoryTimelineEntryState {
+  return {
+    ...emptyTimelineState(),
+    identity: { ...identity },
+    materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
+  };
+}
+
+export function withEntryTimelineState(
+  entry: FactoryTimelineEntryState,
+  timeline: ReturnType<typeof emptyTimelineState>,
+): FactoryTimelineEntryState {
+  return {
+    ...entry,
+    ...timeline,
+  };
+}

--- a/ui/src/features/timeline/state/entries/factoryTimelineEntry.ts
+++ b/ui/src/features/timeline/state/entries/factoryTimelineEntry.ts
@@ -1,5 +1,4 @@
 import type { StreamDerivedCacheIdentity } from "../../lib/stream-derived-cache-identity";
-import { createMaterializedWorkOutcomeState } from "../../../work-outcome/public/materializer";
 import {
   emptyTimelineState,
   type FactoryTimelineEntryState,
@@ -27,14 +26,20 @@ export function createFactoryTimelineEntry(
   return {
     ...emptyTimelineState(),
     identity: { ...identity },
-    materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
   };
 }
 
 export function withEntryTimelineState(
   entry: FactoryTimelineEntryState,
-  timeline: ReturnType<typeof emptyTimelineState>,
+  timeline: Omit<
+    ReturnType<typeof emptyTimelineState>,
+    "materializedWorkOutcomeState"
+  > &
+    Partial<Pick<FactoryTimelineEntryState, "materializedWorkOutcomeState">>,
 ): FactoryTimelineEntryState {
+  if (timeline === entry) {
+    return entry;
+  }
   return {
     ...entry,
     ...timeline,

--- a/ui/src/features/timeline/state/factoryTimelineStore.entries.test.ts
+++ b/ui/src/features/timeline/state/factoryTimelineStore.entries.test.ts
@@ -1,0 +1,173 @@
+import type { FactoryEvent } from "../../../api/events";
+import { FACTORY_EVENT_TYPES } from "../../../api/events";
+import type { StreamDerivedCacheIdentity } from "../lib/stream-derived-cache-identity";
+import { useFactoryTimelineStore } from "./factoryTimelineStore";
+
+const eventTime = "2026-07-13T12:00:00.000Z";
+
+function streamIdentity(
+  factorySessionID: string,
+  streamGenerationID: string,
+): StreamDerivedCacheIdentity {
+  return {
+    backendScopeID: "backend-a",
+    factorySessionID,
+    logicalSessionKeyID: "shared-logical-alias",
+    streamGenerationID,
+  };
+}
+
+function event(id: string, tick: number): FactoryEvent {
+  return {
+    context: {
+      eventTime,
+      sequence: tick,
+      tick,
+    },
+    id,
+    payload: {
+      factory: {
+        workers: [],
+        workTypes: [],
+        workstations: [],
+      },
+    },
+    type: FACTORY_EVENT_TYPES.initialStructureRequest,
+  };
+}
+
+afterEach(() => {
+  useFactoryTimelineStore.getState().reset();
+});
+
+describe("factory timeline stream entries", () => {
+  it("isolates exact sessions even when their logical alias matches", () => {
+    const sessionA = streamIdentity("session-a-uuid", "generation-1");
+    const sessionB = streamIdentity("session-b-uuid", "generation-1");
+    const store = useFactoryTimelineStore.getState();
+
+    store.appendEventForEntry(sessionA, event("event-a", 1));
+    store.appendEventForEntry(sessionB, event("event-b", 4));
+    store.selectTickForEntry(sessionA, 1);
+    store.activateEntry(sessionB);
+
+    const entryA = useFactoryTimelineStore
+      .getState()
+      .entryForIdentity(sessionA);
+    const entryB = useFactoryTimelineStore
+      .getState()
+      .entryForIdentity(sessionB);
+    expect(entryA).toMatchObject({
+      latestTick: 1,
+      mode: "fixed",
+      receivedEventIDs: ["event-a"],
+      selectedTick: 1,
+    });
+    expect(entryB).toMatchObject({
+      latestTick: 4,
+      mode: "current",
+      receivedEventIDs: ["event-b"],
+      selectedTick: 4,
+    });
+    expect(entryA?.events.map(({ id }) => id)).toEqual(["event-a"]);
+    expect(entryB?.events.map(({ id }) => id)).toEqual(["event-b"]);
+    expect(entryA?.currentReplayCheckpoint?.afterEventId).toBe("event-a");
+    expect(entryB?.currentReplayCheckpoint?.afterEventId).toBe("event-b");
+    expect(entryA?.worldViewCache[4]).toBeUndefined();
+    expect(entryB?.worldViewCache[1]).toBeUndefined();
+    expect(entryA?.materializedWorkOutcomeState.cursor).toBeNull();
+    expect(entryB?.materializedWorkOutcomeState.cursor).toBeNull();
+    expect(entryA?.materializedWorkOutcomeState).not.toBe(
+      entryB?.materializedWorkOutcomeState,
+    );
+
+    const active = useFactoryTimelineStore.getState();
+    expect(active.activeEntryKey).not.toBeNull();
+    expect(active.events.map(({ id }) => id)).toEqual(["event-b"]);
+    expect(active.latestTick).toBe(4);
+  });
+
+  it("keeps generations of one resolved session in separate accumulators", () => {
+    const generationA = streamIdentity("session-a-uuid", "generation-1");
+    const generationB = streamIdentity("session-a-uuid", "generation-2");
+    const store = useFactoryTimelineStore.getState();
+
+    store.appendEventForEntry(generationA, event("old-generation", 3));
+    store.activateEntry(generationB);
+
+    const oldEntry = useFactoryTimelineStore
+      .getState()
+      .entryForIdentity(generationA);
+    const replacementEntry = useFactoryTimelineStore
+      .getState()
+      .entryForIdentity(generationB);
+    expect(oldEntry?.events.map(({ id }) => id)).toEqual(["old-generation"]);
+    expect(oldEntry?.currentReplayCheckpoint?.afterEventId).toBe(
+      "old-generation",
+    );
+    expect(replacementEntry).toMatchObject({
+      currentReplayCheckpoint: undefined,
+      events: [],
+      latestTick: 0,
+      mode: "current",
+      receivedEventIDs: [],
+      selectedTick: 0,
+    });
+    expect(replacementEntry?.materializedWorkOutcomeState).toMatchObject({
+      counts: {
+        completed: 0,
+        dispatched: 0,
+        failed: 0,
+        inFlight: 0,
+        queued: 0,
+      },
+      cursor: null,
+      version: 1,
+    });
+    expect(replacementEntry?.materializedWorkOutcomeState).not.toBe(
+      oldEntry?.materializedWorkOutcomeState,
+    );
+
+    store.appendEventForEntry(generationA, event("late-old-generation", 5));
+    const active = useFactoryTimelineStore.getState();
+    expect(active.events).toEqual([]);
+    expect(active.currentReplayCheckpoint).toBeUndefined();
+    expect(active.materializedWorkOutcomeState.cursor).toBeNull();
+    expect(
+      active.entryForIdentity(generationA)?.events.map(({ id }) => id),
+    ).toEqual(["old-generation", "late-old-generation"]);
+  });
+});
+
+describe("factory timeline entry binding", () => {
+  it("rejects unresolved identities before creating an entry", () => {
+    const unresolved = streamIdentity("~default", "generation-1");
+
+    expect(() =>
+      useFactoryTimelineStore
+        .getState()
+        .appendEventForEntry(unresolved, event("unresolved", 1)),
+    ).toThrow(/resolved Factory Session UUID/);
+    expect(useFactoryTimelineStore.getState().entriesByKey).toEqual({});
+  });
+
+  it("binds a preflight identity to an unowned compatibility seed", () => {
+    const identity = streamIdentity("session-a-uuid", "generation-1");
+    const seededEvent = event("seeded-before-preflight", 7);
+    useFactoryTimelineStore.setState({
+      events: [seededEvent],
+      latestTick: 7,
+      receivedEventIDs: [seededEvent.id],
+      selectedTick: 7,
+    });
+
+    useFactoryTimelineStore.getState().activateEntry(identity);
+
+    const entry = useFactoryTimelineStore.getState().entryForIdentity(identity);
+    expect(entry?.events.map(({ id }) => id)).toEqual([
+      "seeded-before-preflight",
+    ]);
+    expect(entry?.latestTick).toBe(7);
+    expect(entry?.selectedTick).toBe(7);
+  });
+});

--- a/ui/src/features/timeline/state/factoryTimelineStore.entries.test.ts
+++ b/ui/src/features/timeline/state/factoryTimelineStore.entries.test.ts
@@ -75,8 +75,12 @@ describe("factory timeline stream entries", () => {
     expect(entryB?.currentReplayCheckpoint?.afterEventId).toBe("event-b");
     expect(entryA?.worldViewCache[4]).toBeUndefined();
     expect(entryB?.worldViewCache[1]).toBeUndefined();
-    expect(entryA?.materializedWorkOutcomeState.cursor).toBeNull();
-    expect(entryB?.materializedWorkOutcomeState.cursor).toBeNull();
+    expect(entryA?.materializedWorkOutcomeState.cursor?.eventID).toBe(
+      "event-a",
+    );
+    expect(entryB?.materializedWorkOutcomeState.cursor?.eventID).toBe(
+      "event-b",
+    );
     expect(entryA?.materializedWorkOutcomeState).not.toBe(
       entryB?.materializedWorkOutcomeState,
     );

--- a/ui/src/features/timeline/state/factoryTimelineStore.ts
+++ b/ui/src/features/timeline/state/factoryTimelineStore.ts
@@ -1,6 +1,11 @@
-import { create } from "zustand";
+import { create, type StateCreator } from "zustand";
 
 import type { FactoryEvent } from "../../../api/events";
+import {
+  normalizeStreamDerivedCacheIdentity,
+  type StreamDerivedCacheIdentity,
+} from "../lib/stream-derived-cache-identity";
+import { createMaterializedWorkOutcomeState } from "../../work-outcome/public/materializer";
 import {
   buildFactoryTimelineProjection as buildProjectedTimelineProjection,
   buildFactoryTimelineSnapshot as buildProjectedTimelineSnapshot,
@@ -19,6 +24,7 @@ export type { WorldState } from "./timeline/types";
 import {
   appendTimelineEvents,
   emptyTimelineState,
+  type FactoryTimelineEntryState,
   type FactoryTimelineCheckpoint,
   type FactoryTimelineState,
   replaceTimelineEvents,
@@ -28,9 +34,15 @@ import {
   type TimelineStoreStateDeps,
 } from "./timeline/storeState";
 import type { WorldState } from "./timeline/types";
+import {
+  createFactoryTimelineEntry,
+  factoryTimelineEntryKey,
+  withEntryTimelineState,
+} from "./entries/factoryTimelineEntry";
 
 export type {
   FactoryTimelineCheckpoint,
+  FactoryTimelineEntryState,
   FactoryTimelineMode,
   FactoryTimelineSyncIdentity,
 } from "./timeline/storeState";
@@ -64,31 +76,281 @@ const timelineStoreStateDeps: TimelineStoreStateDeps = {
   orderedEvents,
 };
 
-export const useFactoryTimelineStore = create<FactoryTimelineState>((set) => ({
-  ...emptyTimelineState(),
-  appendEvent: (event) => {
-    set((current) =>
-      appendTimelineEvents(current, [event], timelineStoreStateDeps),
+function exactIdentity(
+  identity: StreamDerivedCacheIdentity,
+): StreamDerivedCacheIdentity {
+  const normalized = normalizeStreamDerivedCacheIdentity(identity);
+  if (!normalized) {
+    throw new Error(
+      "Timeline entries require backend scope, resolved Factory Session UUID, logical session metadata, and stream generation.",
     );
-  },
-  appendEvents: (events) => {
-    set((current) =>
-      appendTimelineEvents(current, events, timelineStoreStateDeps),
-    );
-  },
-  replaceEvents: (events) => {
-    set(replaceTimelineEvents(events, timelineStoreStateDeps));
-  },
-  reset: () => {
-    set(emptyTimelineState());
-  },
-  restoreCheckpoint: (checkpoint: FactoryTimelineCheckpoint) => {
-    set(restoreTimelineCheckpoint(checkpoint));
-  },
-  selectTick: (tick) => {
-    set((current) => selectTimelineTick(current, tick, timelineStoreStateDeps));
-  },
-  setCurrentMode: () => {
-    set((current) => setTimelineCurrentMode(current, timelineStoreStateDeps));
-  },
-}));
+  }
+  return normalized;
+}
+
+function entryStateForMutation(
+  state: FactoryTimelineState,
+  identity: StreamDerivedCacheIdentity,
+): {
+  entry: FactoryTimelineEntryState;
+  key: string;
+} {
+  const normalized = exactIdentity(identity);
+  const key = factoryTimelineEntryKey(normalized);
+  const existing = state.entriesByKey[key];
+  return {
+    entry: existing
+      ? { ...existing, identity: normalized }
+      : createFactoryTimelineEntry(normalized),
+    key,
+  };
+}
+
+function bindUnownedActiveState(
+  state: FactoryTimelineState,
+  entry: FactoryTimelineEntryState,
+): FactoryTimelineEntryState {
+  if (
+    state.activeEntryKey !== null ||
+    Object.keys(state.entriesByKey).length > 0
+  ) {
+    return entry;
+  }
+  return {
+    currentReplayCheckpoint: state.currentReplayCheckpoint,
+    events: state.events,
+    identity: entry.identity,
+    latestTick: state.latestTick,
+    materializedWorkOutcomeState: state.materializedWorkOutcomeState,
+    mode: state.mode,
+    receivedEventIDs: state.receivedEventIDs,
+    selectedTick: state.selectedTick,
+    worldViewCache: state.worldViewCache,
+  };
+}
+
+function entryMutation(
+  state: FactoryTimelineState,
+  identity: StreamDerivedCacheIdentity,
+  mutate: (entry: FactoryTimelineEntryState) => FactoryTimelineEntryState,
+): Partial<FactoryTimelineState> {
+  const { entry, key } = entryStateForMutation(state, identity);
+  const nextEntry = mutate(entry);
+  const registry = {
+    ...state.entriesByKey,
+    [key]: nextEntry,
+  };
+  return state.activeEntryKey === key
+    ? { ...nextEntry, entriesByKey: registry }
+    : { entriesByKey: registry };
+}
+
+function activeEntryMutation(
+  state: FactoryTimelineState,
+  mutate: (entry: FactoryTimelineEntryState) => FactoryTimelineEntryState,
+  mutateLegacy: () => Partial<FactoryTimelineState>,
+): Partial<FactoryTimelineState> {
+  const key = state.activeEntryKey;
+  const entry = key ? state.entriesByKey[key] : undefined;
+  if (!key || !entry) {
+    return mutateLegacy();
+  }
+  const nextEntry = mutate(entry);
+  return {
+    ...nextEntry,
+    entriesByKey: {
+      ...state.entriesByKey,
+      [key]: nextEntry,
+    },
+  };
+}
+
+const initialTimelineState = emptyTimelineState();
+
+type TimelineStoreInitializer = StateCreator<FactoryTimelineState>;
+type TimelineStoreSet = Parameters<TimelineStoreInitializer>[0];
+type TimelineStoreGet = Parameters<TimelineStoreInitializer>[1];
+
+function exactEntryActions(set: TimelineStoreSet, get: TimelineStoreGet) {
+  return {
+    activateEntry: (identity) => {
+      set((current) => {
+        const resolved = entryStateForMutation(current, identity);
+        const entry = bindUnownedActiveState(current, resolved.entry);
+        const { key } = resolved;
+        return {
+          ...entry,
+          activeEntryKey: key,
+          entriesByKey: {
+            ...current.entriesByKey,
+            [key]: entry,
+          },
+        };
+      });
+    },
+    appendEventForEntry: (identity, event) => {
+      set((current) =>
+        entryMutation(current, identity, (entry) =>
+          withEntryTimelineState(
+            entry,
+            appendTimelineEvents(entry, [event], timelineStoreStateDeps),
+          ),
+        ),
+      );
+    },
+    appendEventsForEntry: (identity, events) => {
+      set((current) =>
+        entryMutation(current, identity, (entry) =>
+          withEntryTimelineState(
+            entry,
+            appendTimelineEvents(entry, events, timelineStoreStateDeps),
+          ),
+        ),
+      );
+    },
+    entryForIdentity: (identity) => {
+      const normalized = exactIdentity(identity);
+      return get().entriesByKey[factoryTimelineEntryKey(normalized)];
+    },
+    replaceEventsForEntry: (identity, events) => {
+      set((current) =>
+        entryMutation(current, identity, (entry) =>
+          withEntryTimelineState(
+            entry,
+            replaceTimelineEvents(events, timelineStoreStateDeps),
+          ),
+        ),
+      );
+    },
+    resetEntry: (identity) => {
+      set((current) =>
+        entryMutation(current, identity, (entry) =>
+          createFactoryTimelineEntry(entry.identity),
+        ),
+      );
+    },
+    restoreCheckpointForEntry: (identity, checkpoint) => {
+      set((current) =>
+        entryMutation(current, identity, (entry) =>
+          withEntryTimelineState(entry, restoreTimelineCheckpoint(checkpoint)),
+        ),
+      );
+    },
+    selectTickForEntry: (identity, tick) => {
+      set((current) =>
+        entryMutation(current, identity, (entry) => ({
+          ...entry,
+          ...selectTimelineTick(entry, tick, timelineStoreStateDeps),
+        })),
+      );
+    },
+    setCurrentModeForEntry: (identity) => {
+      set((current) =>
+        entryMutation(current, identity, (entry) => ({
+          ...entry,
+          ...setTimelineCurrentMode(entry, timelineStoreStateDeps),
+        })),
+      );
+    },
+  } satisfies Partial<FactoryTimelineState>;
+}
+
+function activeEntryActions(set: TimelineStoreSet) {
+  return {
+    appendEvent: (event: FactoryEvent) => {
+      set((current) =>
+        activeEntryMutation(
+          current,
+          (entry) =>
+            withEntryTimelineState(
+              entry,
+              appendTimelineEvents(entry, [event], timelineStoreStateDeps),
+            ),
+          () => appendTimelineEvents(current, [event], timelineStoreStateDeps),
+        ),
+      );
+    },
+    appendEvents: (events: FactoryEvent[]) => {
+      set((current) =>
+        activeEntryMutation(
+          current,
+          (entry) =>
+            withEntryTimelineState(
+              entry,
+              appendTimelineEvents(entry, events, timelineStoreStateDeps),
+            ),
+          () => appendTimelineEvents(current, events, timelineStoreStateDeps),
+        ),
+      );
+    },
+    replaceEvents: (events: FactoryEvent[]) => {
+      set((current) =>
+        activeEntryMutation(
+          current,
+          (entry) =>
+            withEntryTimelineState(
+              entry,
+              replaceTimelineEvents(events, timelineStoreStateDeps),
+            ),
+          () => replaceTimelineEvents(events, timelineStoreStateDeps),
+        ),
+      );
+    },
+    reset: () => {
+      set({
+        activeEntryKey: null,
+        ...emptyTimelineState(),
+        entriesByKey: {},
+        materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
+      });
+    },
+    restoreCheckpoint: (checkpoint: FactoryTimelineCheckpoint) => {
+      set((current) =>
+        activeEntryMutation(
+          current,
+          (entry) =>
+            withEntryTimelineState(
+              entry,
+              restoreTimelineCheckpoint(checkpoint),
+            ),
+          () => restoreTimelineCheckpoint(checkpoint),
+        ),
+      );
+    },
+    selectTick: (tick: number) => {
+      set((current) =>
+        activeEntryMutation(
+          current,
+          (entry) => ({
+            ...entry,
+            ...selectTimelineTick(entry, tick, timelineStoreStateDeps),
+          }),
+          () => selectTimelineTick(current, tick, timelineStoreStateDeps),
+        ),
+      );
+    },
+    setCurrentMode: () => {
+      set((current) =>
+        activeEntryMutation(
+          current,
+          (entry) => ({
+            ...entry,
+            ...setTimelineCurrentMode(entry, timelineStoreStateDeps),
+          }),
+          () => setTimelineCurrentMode(current, timelineStoreStateDeps),
+        ),
+      );
+    },
+  } satisfies Partial<FactoryTimelineState>;
+}
+
+export const useFactoryTimelineStore = create<FactoryTimelineState>(
+  (set, get) => ({
+    activeEntryKey: null,
+    ...initialTimelineState,
+    entriesByKey: {},
+    materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
+    ...activeEntryActions(set),
+    ...exactEntryActions(set, get),
+  }),
+);

--- a/ui/src/features/timeline/state/factoryTimelineStore.ts
+++ b/ui/src/features/timeline/state/factoryTimelineStore.ts
@@ -5,7 +5,6 @@ import {
   normalizeStreamDerivedCacheIdentity,
   type StreamDerivedCacheIdentity,
 } from "../lib/stream-derived-cache-identity";
-import { createMaterializedWorkOutcomeState } from "../../work-outcome/public/materializer";
 import {
   buildFactoryTimelineProjection as buildProjectedTimelineProjection,
   buildFactoryTimelineSnapshot as buildProjectedTimelineSnapshot,
@@ -14,7 +13,7 @@ import {
 export { resolveConfiguredWorkTypeName } from "./timeline/projectTopology";
 
 import {
-  advanceWorldStateFromCheckpoint,
+  advanceWorldStateFromAcceptedTail,
   reconstructWorldState,
 } from "./timeline/replayWorldState";
 import { orderedEvents } from "./timeline/shared";
@@ -65,8 +64,8 @@ const timelineStoreStateDeps: TimelineStoreStateDeps = {
       selectedTick,
       checkpoint
         ? (nextEvents, nextSelectedTick) =>
-            advanceWorldStateFromCheckpoint(
-              checkpoint.replayState,
+            advanceWorldStateFromAcceptedTail(
+              structuredClone(checkpoint.replayState),
               nextEvents,
               nextSelectedTick,
             )
@@ -98,9 +97,16 @@ function entryStateForMutation(
   const normalized = exactIdentity(identity);
   const key = factoryTimelineEntryKey(normalized);
   const existing = state.entriesByKey[key];
+  const identityIsUnchanged =
+    existing?.identity.backendScopeID === normalized.backendScopeID &&
+    existing.identity.factorySessionID === normalized.factorySessionID &&
+    existing.identity.logicalSessionKeyID === normalized.logicalSessionKeyID &&
+    existing.identity.streamGenerationID === normalized.streamGenerationID;
   return {
     entry: existing
-      ? { ...existing, identity: normalized }
+      ? identityIsUnchanged
+        ? existing
+        : { ...existing, identity: normalized }
       : createFactoryTimelineEntry(normalized),
     key,
   };
@@ -301,7 +307,6 @@ function activeEntryActions(set: TimelineStoreSet) {
         activeEntryKey: null,
         ...emptyTimelineState(),
         entriesByKey: {},
-        materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
       });
     },
     restoreCheckpoint: (checkpoint: FactoryTimelineCheckpoint) => {
@@ -349,7 +354,6 @@ export const useFactoryTimelineStore = create<FactoryTimelineState>(
     activeEntryKey: null,
     ...initialTimelineState,
     entriesByKey: {},
-    materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
     ...activeEntryActions(set),
     ...exactEntryActions(set, get),
   }),

--- a/ui/src/features/timeline/state/timeline/replayWorldState.ts
+++ b/ui/src/features/timeline/state/timeline/replayWorldState.ts
@@ -102,14 +102,25 @@ export function advanceWorldStateFromCheckpoint(
   events: FactoryEvent[],
   selectedTick: number,
 ): ReplayWorldState {
-  const checkpointTick = checkpoint.tick_count;
   const state = checkpoint;
   state.tick_count = selectedTick;
   for (const event of orderedEvents(events)) {
-    if (
-      event.context.tick > checkpointTick &&
-      event.context.tick <= selectedTick
-    ) {
+    if (event.context.tick <= selectedTick) {
+      applyReplayEvent(state, event);
+    }
+  }
+  return state;
+}
+
+export function advanceWorldStateFromAcceptedTail(
+  checkpoint: ReplayWorldState,
+  acceptedTail: FactoryEvent[],
+  selectedTick: number,
+): ReplayWorldState {
+  const state = checkpoint;
+  state.tick_count = selectedTick;
+  for (const event of orderedEvents(acceptedTail)) {
+    if (event.context.tick <= selectedTick) {
       applyReplayEvent(state, event);
     }
   }

--- a/ui/src/features/timeline/state/timeline/storeState.test.ts
+++ b/ui/src/features/timeline/state/timeline/storeState.test.ts
@@ -157,7 +157,7 @@ describe("timeline storeState helpers", () => {
     const first = timelineEvent("replace-1", 1);
     const second = timelineEvent("replace-2", 2);
 
-    const next = replaceTimelineEvents([second, first], deps);
+    const next = replaceTimelineEvents([second, first, second], deps);
 
     expect(next.mode).toBe("current");
     expect(next.events.map((event) => event.id)).toEqual([
@@ -168,6 +168,16 @@ describe("timeline storeState helpers", () => {
     expect(next.selectedTick).toBe(2);
     expect(next.receivedEventIDs).toEqual(["replace-1", "replace-2"]);
     expect(next.worldViewCache[2]).toEqual(snapshotForTick(2));
+    expect(next.currentReplayCheckpoint).toMatchObject({
+      afterEventId: "replace-2",
+      afterSequence: 2,
+      selectedTick: 2,
+    });
+    expect(next.materializedWorkOutcomeState).toMatchObject({
+      accumulator: { appliedEventCount: 2 },
+      cursor: { eventID: "replace-2", sequence: 2, tick: 2 },
+      version: 1,
+    });
   });
 
   it("cacheWithSnapshot leaves cache unchanged when tick is already cached", () => {

--- a/ui/src/features/timeline/state/timeline/storeState.test.ts
+++ b/ui/src/features/timeline/state/timeline/storeState.test.ts
@@ -75,14 +75,7 @@ describe("timeline storeState helpers", () => {
 
     const next = appendTimelineEvents(current, [], deps);
 
-    expect(next).toEqual({
-      events: current.events,
-      latestTick: current.latestTick,
-      mode: current.mode,
-      receivedEventIDs: current.receivedEventIDs,
-      selectedTick: current.selectedTick,
-      worldViewCache: current.worldViewCache,
-    });
+    expect(next).toBe(current);
   });
 
   it("returns current state when all appended events are duplicates", () => {
@@ -98,14 +91,7 @@ describe("timeline storeState helpers", () => {
 
     const next = appendTimelineEvents(current, [event], deps);
 
-    expect(next).toEqual({
-      events: current.events,
-      latestTick: current.latestTick,
-      mode: current.mode,
-      receivedEventIDs: current.receivedEventIDs,
-      selectedTick: current.selectedTick,
-      worldViewCache: current.worldViewCache,
-    });
+    expect(next).toBe(current);
   });
 
   it("keeps selected tick in fixed mode when appending events", () => {

--- a/ui/src/features/timeline/state/timeline/storeState.ts
+++ b/ui/src/features/timeline/state/timeline/storeState.ts
@@ -2,7 +2,11 @@ import type { DashboardSnapshot } from "../../../../api/dashboard";
 import type { FactoryEvent } from "../../../../api/events";
 import type { FactoryTimelineProjection } from "./buildSnapshot";
 import type { StreamDerivedCacheIdentity } from "../../lib/stream-derived-cache-identity";
-import type { MaterializedWorkOutcomeState } from "../../../work-outcome/public/materializer";
+import {
+  createMaterializedWorkOutcomeState,
+  type MaterializedWorkOutcomeState,
+  reduceMaterializedWorkOutcomeEvents,
+} from "../../../work-outcome/public/materializer";
 import { projectSnapshot } from "./projectSnapshot";
 import {
   emptyWorldRuntime,
@@ -133,6 +137,7 @@ export function emptyTimelineState(): Pick<
   | "currentReplayCheckpoint"
   | "events"
   | "latestTick"
+  | "materializedWorkOutcomeState"
   | "mode"
   | "receivedEventIDs"
   | "selectedTick"
@@ -142,6 +147,7 @@ export function emptyTimelineState(): Pick<
     currentReplayCheckpoint: undefined,
     events: [],
     latestTick: 0,
+    materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
     mode: "current",
     receivedEventIDs: [],
     selectedTick: 0,
@@ -198,15 +204,17 @@ function projectCurrentTick(
   selectedTick: number,
   deps: TimelineStoreStateDeps,
   checkpoint?: FactoryTimelineCheckpoint,
+  acceptedTail?: FactoryEvent[],
 ): TimelineCheckpointProjection {
   const usableCheckpoint =
     checkpoint && checkpoint.selectedTick <= selectedTick
       ? checkpoint
       : undefined;
   const projectionEvents = usableCheckpoint
-    ? events.filter(
+    ? (acceptedTail ??
+      events.filter(
         (event) => event.context.tick > usableCheckpoint.selectedTick,
-      )
+      ))
     : events;
   return checkpointFromProjection(
     events,
@@ -225,6 +233,7 @@ export function appendTimelineEvents(
     | "events"
     | "currentReplayCheckpoint"
     | "latestTick"
+    | "materializedWorkOutcomeState"
     | "mode"
     | "receivedEventIDs"
     | "selectedTick"
@@ -237,64 +246,76 @@ export function appendTimelineEvents(
   | "events"
   | "currentReplayCheckpoint"
   | "latestTick"
+  | "materializedWorkOutcomeState"
   | "mode"
   | "receivedEventIDs"
   | "selectedTick"
   | "worldViewCache"
 > {
   const receivedEventIDs = new Set(current.receivedEventIDs);
-  const nextEvents = incomingEvents.filter(
-    (event) => !receivedEventIDs.has(event.id),
-  );
-
-  if (nextEvents.length === 0) {
-    return {
-      events: current.events,
-      currentReplayCheckpoint: current.currentReplayCheckpoint,
-      latestTick: current.latestTick,
-      mode: current.mode,
-      receivedEventIDs: current.receivedEventIDs,
-      selectedTick: current.selectedTick,
-      worldViewCache: current.worldViewCache,
-    };
+  const unorderedAcceptedEvents: FactoryEvent[] = [];
+  for (const event of incomingEvents) {
+    if (receivedEventIDs.has(event.id)) {
+      continue;
+    }
+    receivedEventIDs.add(event.id);
+    unorderedAcceptedEvents.push(event);
   }
 
-  const events = deps.orderedEvents([...current.events, ...nextEvents]);
-  const latestTick = nextEvents.reduce(
+  if (unorderedAcceptedEvents.length === 0) {
+    return current;
+  }
+
+  const acceptedEventIDs = new Set(
+    unorderedAcceptedEvents.map((event) => event.id),
+  );
+  const events = deps.orderedEvents([
+    ...current.events,
+    ...unorderedAcceptedEvents,
+  ]);
+  const acceptedTail = events.filter((event) => acceptedEventIDs.has(event.id));
+  const latestTick = acceptedTail.reduce(
     (maxTick, event) => Math.max(maxTick, event.context.tick),
     current.latestTick,
   );
   const selectedTick =
     current.mode === "current" ? latestTick : current.selectedTick;
-  const currentProjection =
-    current.mode === "current"
-      ? projectCurrentTick(
-          events,
-          selectedTick,
-          deps,
-          current.currentReplayCheckpoint,
-        )
-      : current.currentReplayCheckpoint;
+  const currentProjection = projectCurrentTick(
+    events,
+    latestTick,
+    deps,
+    current.currentReplayCheckpoint,
+    acceptedTail,
+  );
+  const materializedWorkOutcomeState = reduceMaterializedWorkOutcomeEvents(
+    current.materializedWorkOutcomeState,
+    acceptedTail,
+  );
+  const selectedWorldViewCache = cacheWithSnapshot(
+    events,
+    current.worldViewCache,
+    selectedTick,
+    deps,
+  );
 
   return {
     events,
-    currentReplayCheckpoint:
-      currentProjection && "checkpoint" in currentProjection
-        ? currentProjection.checkpoint
-        : currentProjection,
+    currentReplayCheckpoint: currentProjection.checkpoint,
     latestTick,
+    materializedWorkOutcomeState,
     mode: current.mode,
     receivedEventIDs: [
       ...current.receivedEventIDs,
-      ...nextEvents.map((event) => event.id),
+      ...acceptedTail.map((event) => event.id),
     ],
     selectedTick,
     worldViewCache:
-      current.mode === "current" &&
-      currentProjection &&
-      "worldState" in currentProjection
+      current.mode === "current"
         ? { [selectedTick]: currentProjection.worldState }
-        : cacheWithSnapshot(events, {}, selectedTick, deps),
+        : {
+            ...selectedWorldViewCache,
+            [latestTick]: currentProjection.worldState,
+          },
   };
 }
 

--- a/ui/src/features/timeline/state/timeline/storeState.ts
+++ b/ui/src/features/timeline/state/timeline/storeState.ts
@@ -1,6 +1,7 @@
 import type { DashboardSnapshot } from "../../../../api/dashboard";
 import type { FactoryEvent } from "../../../../api/events";
 import {
+  compareEventToTimelinePosition,
   createMaterializedWorkOutcomeState,
   type MaterializedWorkOutcomeState,
   reduceMaterializedWorkOutcomeEvents,
@@ -84,6 +85,7 @@ export interface FactoryTimelineSyncIdentity {
 export interface FactoryTimelineCheckpoint {
   afterEventId?: string;
   afterSequence?: number;
+  materializedWorkOutcomeState: MaterializedWorkOutcomeState;
   replayState: ReplayWorldState;
   selectedTick: number;
   syncIdentity?: FactoryTimelineSyncIdentity;
@@ -173,6 +175,7 @@ function latestAppliedEvent(
 function checkpointFromProjection(
   events: FactoryEvent[],
   selectedTick: number,
+  materializedWorkOutcomeState: MaterializedWorkOutcomeState,
   projection: FactoryTimelineProjection,
 ): TimelineCheckpointProjection {
   const latestEvent = latestAppliedEvent(events, selectedTick);
@@ -181,6 +184,7 @@ function checkpointFromProjection(
       afterEventId: latestEvent?.id,
       afterSequence:
         latestEvent?.context.sessionSequence ?? latestEvent?.context.sequence,
+      materializedWorkOutcomeState,
       replayState: projection.replayState,
       selectedTick,
     },
@@ -202,6 +206,7 @@ export function cacheWithSnapshot(
 function projectCurrentTick(
   events: FactoryEvent[],
   selectedTick: number,
+  materializedWorkOutcomeState: MaterializedWorkOutcomeState,
   deps: TimelineStoreStateDeps,
   checkpoint?: FactoryTimelineCheckpoint,
   acceptedTail?: FactoryEvent[],
@@ -219,6 +224,7 @@ function projectCurrentTick(
   return checkpointFromProjection(
     events,
     selectedTick,
+    materializedWorkOutcomeState,
     deps.buildFactoryTimelineProjection(
       projectionEvents,
       selectedTick,
@@ -254,8 +260,15 @@ export function appendTimelineEvents(
 > {
   const receivedEventIDs = new Set(current.receivedEventIDs);
   const unorderedAcceptedEvents: FactoryEvent[] = [];
-  for (const event of incomingEvents) {
-    if (receivedEventIDs.has(event.id)) {
+  for (const event of deps.orderedEvents(incomingEvents)) {
+    if (
+      receivedEventIDs.has(event.id) ||
+      (current.materializedWorkOutcomeState.cursor &&
+        compareEventToTimelinePosition(
+          event,
+          current.materializedWorkOutcomeState.cursor,
+        ) <= 0)
+    ) {
       continue;
     }
     receivedEventIDs.add(event.id);
@@ -280,15 +293,16 @@ export function appendTimelineEvents(
   );
   const selectedTick =
     current.mode === "current" ? latestTick : current.selectedTick;
+  const materializedWorkOutcomeState = reduceMaterializedWorkOutcomeEvents(
+    current.materializedWorkOutcomeState,
+    acceptedTail,
+  );
   const currentProjection = projectCurrentTick(
     events,
     latestTick,
+    materializedWorkOutcomeState,
     deps,
     current.currentReplayCheckpoint,
-    acceptedTail,
-  );
-  const materializedWorkOutcomeState = reduceMaterializedWorkOutcomeEvents(
-    current.materializedWorkOutcomeState,
     acceptedTail,
   );
   const selectedWorldViewCache = cacheWithSnapshot(
@@ -333,6 +347,7 @@ export function restoreTimelineCheckpoint(
   | "currentReplayCheckpoint"
   | "events"
   | "latestTick"
+  | "materializedWorkOutcomeState"
   | "mode"
   | "receivedEventIDs"
   | "selectedTick"
@@ -343,6 +358,7 @@ export function restoreTimelineCheckpoint(
     currentReplayCheckpoint: checkpoint,
     events: [],
     latestTick: checkpoint.selectedTick,
+    materializedWorkOutcomeState: checkpoint.materializedWorkOutcomeState,
     mode: "current",
     receivedEventIDs: [],
     selectedTick: checkpoint.selectedTick,
@@ -400,6 +416,8 @@ export function setTimelineCurrentMode(
   const currentProjection = projectCurrentTick(
     current.events,
     current.latestTick,
+    current.currentReplayCheckpoint?.materializedWorkOutcomeState ??
+      createMaterializedWorkOutcomeState(),
     deps,
     currentCheckpoint,
   );

--- a/ui/src/features/timeline/state/timeline/storeState.ts
+++ b/ui/src/features/timeline/state/timeline/storeState.ts
@@ -1,6 +1,8 @@
 import type { DashboardSnapshot } from "../../../../api/dashboard";
 import type { FactoryEvent } from "../../../../api/events";
 import type { FactoryTimelineProjection } from "./buildSnapshot";
+import type { StreamDerivedCacheIdentity } from "../../lib/stream-derived-cache-identity";
+import type { MaterializedWorkOutcomeState } from "../../../work-outcome/public/materializer";
 import { projectSnapshot } from "./projectSnapshot";
 import {
   emptyWorldRuntime,
@@ -10,21 +12,62 @@ import {
 
 export type FactoryTimelineMode = "current" | "fixed";
 
-export interface FactoryTimelineState {
+export interface FactoryTimelineEntryState {
   currentReplayCheckpoint?: FactoryTimelineCheckpoint;
   events: FactoryEvent[];
+  identity: StreamDerivedCacheIdentity;
   latestTick: number;
+  materializedWorkOutcomeState: MaterializedWorkOutcomeState;
   mode: FactoryTimelineMode;
   receivedEventIDs: string[];
   selectedTick: number;
   worldViewCache: Record<number, WorldState>;
+}
+
+export interface FactoryTimelineState {
+  activeEntryKey: string | null;
+  currentReplayCheckpoint?: FactoryTimelineCheckpoint;
+  entriesByKey: Record<string, FactoryTimelineEntryState>;
+  events: FactoryEvent[];
+  latestTick: number;
+  materializedWorkOutcomeState: MaterializedWorkOutcomeState;
+  mode: FactoryTimelineMode;
+  receivedEventIDs: string[];
+  selectedTick: number;
+  worldViewCache: Record<number, WorldState>;
+  activateEntry: (identity: StreamDerivedCacheIdentity) => void;
   appendEvent: (event: FactoryEvent) => void;
+  appendEventForEntry: (
+    identity: StreamDerivedCacheIdentity,
+    event: FactoryEvent,
+  ) => void;
   appendEvents: (events: FactoryEvent[]) => void;
+  appendEventsForEntry: (
+    identity: StreamDerivedCacheIdentity,
+    events: FactoryEvent[],
+  ) => void;
+  entryForIdentity: (
+    identity: StreamDerivedCacheIdentity,
+  ) => FactoryTimelineEntryState | undefined;
   replaceEvents: (events: FactoryEvent[]) => void;
+  replaceEventsForEntry: (
+    identity: StreamDerivedCacheIdentity,
+    events: FactoryEvent[],
+  ) => void;
   reset: () => void;
+  resetEntry: (identity: StreamDerivedCacheIdentity) => void;
   restoreCheckpoint: (checkpoint: FactoryTimelineCheckpoint) => void;
+  restoreCheckpointForEntry: (
+    identity: StreamDerivedCacheIdentity,
+    checkpoint: FactoryTimelineCheckpoint,
+  ) => void;
   selectTick: (tick: number) => void;
+  selectTickForEntry: (
+    identity: StreamDerivedCacheIdentity,
+    tick: number,
+  ) => void;
   setCurrentMode: () => void;
+  setCurrentModeForEntry: (identity: StreamDerivedCacheIdentity) => void;
 }
 
 export interface FactoryTimelineSyncIdentity {

--- a/ui/src/features/timeline/state/timeline/storeState.ts
+++ b/ui/src/features/timeline/state/timeline/storeState.ts
@@ -1,12 +1,12 @@
 import type { DashboardSnapshot } from "../../../../api/dashboard";
 import type { FactoryEvent } from "../../../../api/events";
-import type { FactoryTimelineProjection } from "./buildSnapshot";
-import type { StreamDerivedCacheIdentity } from "../../lib/stream-derived-cache-identity";
 import {
   createMaterializedWorkOutcomeState,
   type MaterializedWorkOutcomeState,
   reduceMaterializedWorkOutcomeEvents,
 } from "../../../work-outcome/public/materializer";
+import type { StreamDerivedCacheIdentity } from "../../lib/stream-derived-cache-identity";
+import type { FactoryTimelineProjection } from "./buildSnapshot";
 import { projectSnapshot } from "./projectSnapshot";
 import {
   emptyWorldRuntime,
@@ -322,31 +322,8 @@ export function appendTimelineEvents(
 export function replaceTimelineEvents(
   events: FactoryEvent[],
   deps: TimelineStoreStateDeps,
-): Pick<
-  FactoryTimelineState,
-  | "currentReplayCheckpoint"
-  | "events"
-  | "latestTick"
-  | "mode"
-  | "receivedEventIDs"
-  | "selectedTick"
-  | "worldViewCache"
-> {
-  const ordered = deps.orderedEvents(events);
-  const latestTick = Math.max(0, ...ordered.map((event) => event.context.tick));
-  const currentProjection = projectCurrentTick(ordered, latestTick, deps);
-
-  return {
-    currentReplayCheckpoint: currentProjection.checkpoint,
-    events: ordered,
-    latestTick,
-    mode: "current",
-    receivedEventIDs: ordered.map((event) => event.id),
-    selectedTick: latestTick,
-    worldViewCache: {
-      [latestTick]: currentProjection.worldState,
-    },
-  };
+): ReturnType<typeof emptyTimelineState> {
+  return appendTimelineEvents(emptyTimelineState(), events, deps);
 }
 
 export function restoreTimelineCheckpoint(

--- a/ui/src/features/timeline/state/timelineCheckpointPersistence.ts
+++ b/ui/src/features/timeline/state/timelineCheckpointPersistence.ts
@@ -18,12 +18,15 @@ import {
   indexedDBRequestToPromise,
   openCheckpointDatabase,
 } from "./checkpoint-persistence/indexedDBCheckpointRequests";
+import {
+  buildPersistedCheckpoint,
+  CHECKPOINT_SCHEMA_VERSION_GUARDED,
+  hydrateCheckpoint,
+  isSupportedPersistedTimelineCheckpoint,
+  type PersistedTimelineCheckpoint,
+} from "./checkpoint-persistence/timelineCheckpointCodec";
 import type { FactoryTimelineCheckpoint } from "./timeline/storeState";
-import type { ReplayWorldState } from "./timeline/types";
-
-const CHECKPOINT_SCHEMA_VERSION_GUARDED = 3;
 const CHECKPOINT_STORE_NAME = "checkpoints";
-const MAX_COMPACT_TEXT_CHARS = 512;
 
 export type TimelineCheckpointStreamIdentity = StreamDerivedCacheIdentity;
 
@@ -54,14 +57,6 @@ function matchesStoredCheckpointFactorySessionID(
   return (
     requestedSessionID !== "" && storedFactorySessionID === requestedSessionID
   );
-}
-
-interface PersistedTimelineCheckpoint {
-  afterEventId?: string;
-  afterSequence?: number;
-  replayState: ReplayWorldState;
-  selectedTick: number;
-  syncIdentity?: FactoryTimelineCheckpoint["syncIdentity"];
 }
 
 async function writeIndexedCheckpoint(
@@ -165,7 +160,7 @@ export async function peekPersistedTimelineCheckpoint(
     if (
       !envelope ||
       envelope.schemaVersion !== CHECKPOINT_SCHEMA_VERSION_GUARDED ||
-      !envelope.checkpoint?.replayState
+      !isSupportedPersistedTimelineCheckpoint(envelope.checkpoint)
     ) {
       return null;
     }
@@ -236,55 +231,13 @@ export async function clearTimelineCheckpoint(
   await deleteIndexedCheckpoint(indexedDB, storageKey).catch(() => {});
 }
 
-function compactText(value: string): string {
-  if (value.length <= MAX_COMPACT_TEXT_CHARS) {
-    return value;
-  }
-  // hardcoded-ui-copy-exception: non-product-diagnostic
-  return `${value.slice(0, MAX_COMPACT_TEXT_CHARS)}\n\n[checkpoint truncated ${value.length - MAX_COMPACT_TEXT_CHARS} chars]`;
-}
-
-function compactReplayState(state: ReplayWorldState): ReplayWorldState {
-  const compacted = structuredClone(state);
-
-  for (const [textBlobID, value] of Object.entries(compacted.textBlobsByID)) {
-    compacted.textBlobsByID[textBlobID] = compactText(value);
-  }
-
-  return compacted;
-}
-
-function buildPersistedCheckpoint(
-  checkpoint: FactoryTimelineCheckpoint,
-): PersistedTimelineCheckpoint {
-  return {
-    afterEventId: checkpoint.afterEventId,
-    afterSequence: checkpoint.afterSequence,
-    replayState: compactReplayState(checkpoint.replayState),
-    selectedTick: checkpoint.selectedTick,
-    syncIdentity: checkpoint.syncIdentity,
-  };
-}
-
-function hydrateCheckpoint(
-  checkpoint: PersistedTimelineCheckpoint,
-): FactoryTimelineCheckpoint {
-  return {
-    afterEventId: checkpoint.afterEventId,
-    afterSequence: checkpoint.afterSequence,
-    replayState: checkpoint.replayState,
-    selectedTick: checkpoint.selectedTick,
-    syncIdentity: checkpoint.syncIdentity,
-  };
-}
-
 function parseStoredCheckpoint(
   envelope: TimelineCheckpointEnvelope,
   expectedIdentity: TimelineCheckpointStreamIdentity | null,
 ): FactoryTimelineCheckpoint | null {
   if (
     envelope.schemaVersion !== CHECKPOINT_SCHEMA_VERSION_GUARDED ||
-    !envelope.checkpoint?.replayState
+    !isSupportedPersistedTimelineCheckpoint(envelope.checkpoint)
   ) {
     return null;
   }

--- a/ui/src/features/work-outcome/public/materializer.ts
+++ b/ui/src/features/work-outcome/public/materializer.ts
@@ -1,0 +1,4 @@
+export {
+  createMaterializedWorkOutcomeState,
+  type MaterializedWorkOutcomeState,
+} from "../lib/materializer/materialized-work-outcome";

--- a/ui/src/features/work-outcome/public/materializer.ts
+++ b/ui/src/features/work-outcome/public/materializer.ts
@@ -1,4 +1,5 @@
 export {
   createMaterializedWorkOutcomeState,
+  reduceMaterializedWorkOutcomeEvents,
   type MaterializedWorkOutcomeState,
 } from "../lib/materializer/materialized-work-outcome";

--- a/ui/src/features/work-outcome/public/materializer.ts
+++ b/ui/src/features/work-outcome/public/materializer.ts
@@ -1,5 +1,11 @@
 export {
+  compareEventToTimelinePosition,
+  type FactoryEventTimelinePosition,
+} from "../lib/materializer/factory-event-ordering";
+
+export {
   createMaterializedWorkOutcomeState,
+  MATERIALIZED_WORK_OUTCOME_VERSION,
   reduceMaterializedWorkOutcomeEvents,
   type MaterializedWorkOutcomeState,
 } from "../lib/materializer/materialized-work-outcome";

--- a/ui/src/testing/multi-session-timeline-checkpoint-scenario.ts
+++ b/ui/src/testing/multi-session-timeline-checkpoint-scenario.ts
@@ -3,6 +3,7 @@ import type {
   TimelineCheckpointStreamIdentity,
 } from "../features/timeline/public";
 import { emptyReplayWorldState } from "../features/timeline/state/timeline/replayWorldStateSupport";
+import { createMaterializedWorkOutcomeState } from "../features/work-outcome/public/materializer";
 
 export interface MultiSessionTimelineCheckpointFixture {
   checkpoint: FactoryTimelineCheckpoint;
@@ -46,6 +47,7 @@ function createSessionFixture({
     checkpoint: {
       afterEventId,
       afterSequence,
+      materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
       replayState,
       selectedTick,
       syncIdentity: {

--- a/ui/src/testing/quiet-checkpoint-reload-test-utils.ts
+++ b/ui/src/testing/quiet-checkpoint-reload-test-utils.ts
@@ -4,6 +4,7 @@ import { vi } from "vitest";
 import { useFactoryTimelineStore } from "../features/timeline/state/factoryTimelineStore";
 import { emptyReplayWorldState } from "../features/timeline/state/timeline/replayWorldStateSupport";
 import type { FactoryTimelineCheckpoint } from "../features/timeline/state/timeline/storeState";
+import { createMaterializedWorkOutcomeState } from "../features/work-outcome/public/materializer";
 import {
   persistTimelineCheckpoint,
   type TimelineCheckpointStreamIdentity,
@@ -137,6 +138,7 @@ export function createQuietCheckpointReloadFixture(
   const checkpoint: FactoryTimelineCheckpoint = {
     afterEventId: `quiet-checkpoint-event-${tick}`,
     afterSequence: tick,
+    materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
     replayState,
     selectedTick: tick,
     syncIdentity: {


### PR DESCRIPTION
{
  "project": "Integrate Materialized Work Outcomes Into Session Timelines",
  "branchName": "session-repair-materialized-state-timeline-integration",
  "description": "Advance each exact Factory Session stream's versioned MaterializedWorkOutcomeState in the same ordered timeline transition that advances replay state, while preserving historical selection, reconnect idempotency, reset semantics, and per-session isolation without depending on deferred Batch 004.",
  "context": {
    "customerAsk": "After confirming or establishing the minimal per-session timeline ownership needed by this batch, make each session-keyed timeline entry advance its MaterializedWorkOutcomeState in the same ordered append operation that advances replay state. Events must share one session identity and cursor boundary, fixed historical selection must not mutate the current accumulator, reconnect overlap must not double-count, and reset or stream-generation replacement must create empty versioned state without assuming deferred Batch 004 has landed.",
    "problem": "The current frontend timeline is a selected-session singleton, and its append, historical-selection, deduplication, and reset behavior do not yet own a resumable work-outcome accumulator under an exact session-stream identity. Adding materialized outcomes without a narrow ownership boundary could mix sessions or generations, diverge replay and outcome cursors, double-count reconnect overlap, or let a historical selection overwrite current outcome state. Depending on all of deferred Batch 004 would also pull unrelated selector, invalidation, and memory work into this focused repair.",
    "solution": "Establish only the minimal timeline-entry ownership keyed by backend scope, resolved Factory Session UUID, and stream generation; keep logical identity as remap metadata. Store replay and MaterializedWorkOutcomeState together, canonicalize and deduplicate each incoming batch once, apply the same accepted tail to both before publishing one next entry, keep historical view selection separate from current accumulators, and initialize targeted reset, full-history replacement, and replacement generations from the supported empty materialized state."
  },
  "acceptanceCriteria": [
    "Replay state and MaterializedWorkOutcomeState are owned by the same entry keyed to the exact backend scope, resolved Factory Session UUID, and stream generation; logical identity alone cannot reuse another entry.",
    "Each append canonicalizes and deduplicates incoming events once and applies the same accepted ordered tail to replay and materialized outcomes, leaving both at the same latest accepted event boundary.",
    "Selecting or leaving a fixed historical tick changes only view projection state and never rewinds, clips, or mutates the current materialized accumulator.",
    "Reconnect batches with already received or materialized overlap leave existing replay and outcome results unchanged for the overlap and apply each genuinely new event once.",
    "Targeted reset, full-history replacement, and replacement stream generation initialize from supported empty materialized state and cannot inherit another entry's accumulator.",
    "The implementation establishes only the narrow ownership prerequisite needed here and does not depend on or duplicate deferred Batch 004 selector migration, lifecycle invalidation, or inactive-entry eviction work.",
    "Quality gate: frontend typecheck, frontend lint, focused timeline append and reconnect tests, and focused per-session and stream-generation isolation tests pass."
  ],
  "userStories": [
    {
      "id": "session-repair-materialized-state-timeline-integration-001",
      "title": "Establish minimal stream-keyed timeline entry ownership",
      "description": "As a dashboard session maintainer, I want replay and materialized outcomes owned by one exact session-stream entry so that concurrent or reselected sessions cannot share mutable timeline state.",
      "acceptanceCriteria": [
        "A timeline entry is addressed by backend scope, resolved real Factory Session UUID, and stream generation; the logical session key may support remap metadata but cannot substitute for the resolved stream key.",
        "Each entry owns its events, received-event identities, replay checkpoint, selected tick and mode, world-view cache, and one supported-version MaterializedWorkOutcomeState initialized from the materializer's empty-state constructor.",
        "Timeline mutation operations require or are bound to an exact entry identity, so appending an event for session A cannot alter replay state, materialized state, cursor, selection, or cache for session B.",
        "Two entries with the same Factory Session UUID but different stream generations remain isolated and never share materialized accumulator objects.",
        "The ownership change is limited to the state and operation boundary needed by this project; dashboard-wide selector migration, lifecycle invalidation policy, and inactive-entry eviction remain out of scope.",
        "Focused state-operation tests prove A/B and same-session/different-generation isolation using observable entry values rather than meta-test inventories.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "session-repair-materialized-state-timeline-integration-002",
      "title": "Advance replay and outcomes through one ordered append",
      "description": "As a dashboard user, I want each live Factory Event to update replay and work outcomes once under the same session boundary so that reconnects and historical inspection cannot corrupt the current timeline.",
      "acceptanceCriteria": [
        "For an identified timeline entry, append uses canonical timeline ordering and event-identity deduplication once, then passes exactly the accepted ordered tail to both replay advancement and the materialized work-outcome reducer.",
        "After each accepted append, the replay checkpoint boundary and materialized cursor identify the same latest applied event by available event ID, sequence, and tick semantics; an empty or all-duplicate batch returns the existing entry without changing either projection.",
        "Selecting a fixed tick, appending while fixed, and returning to current mode preserve the current materialized accumulator: selection operations do not reduce or clip it, while genuinely new live events still advance current replay and outcome state once.",
        "A reconnect batch containing an already applied prefix plus a new suffix leaves the prefix's counts, breakdowns, samples, replay state, and cursors unchanged and applies every suffix event exactly once.",
        "Outcome reduction and replay advancement are published as one next entry value; no subscriber can observe a state where one has accepted an event and the other has not.",
        "Focused append tests cover ordered, shuffled, empty, duplicate-only, reconnect-overlap, fixed-mode append, and return-to-current cases with concrete replay and materialized outcome assertions.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "session-repair-materialized-state-timeline-integration-003",
      "title": "Reset and replace materialized stream state safely",
      "description": "As a dashboard user, I want reset and stream replacement to discard only the targeted stream's derived outcomes so that a new or rebuilt timeline never displays counts from an earlier stream.",
      "acceptanceCriteria": [
        "Resetting an identified entry restores empty events, deduplication state, replay state, selection and cache defaults, and a fresh supported-version empty MaterializedWorkOutcomeState without changing any other entry.",
        "Replacing an entry from a full event history starts replay and materialization from empty states and reduces the same canonical ordered history once, producing the same final results as uninterrupted append of that history.",
        "Replacing the stream generation creates or selects an empty entry for the new exact generation and does not copy the prior generation's cursor, accumulator, counts, breakdowns, samples, events, or replay checkpoint.",
        "Late callbacks addressed to an old stream-generation identity cannot mutate the replacement generation's entry.",
        "Focused reset, full-history replacement, late-old-generation callback, and per-session isolation tests assert complete observable state for affected and unaffected entries.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}
