### PR TITLE
system-consolidation-ingest-exemption-burn-down

### DIFF
--- a/backend-exemption-budget.json
+++ b/backend-exemption-budget.json
@@ -399,12 +399,6 @@
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
-      "target": "pkg/factory/ingest/filewatcher_test.go#TestFileWatcher_JSONFactoryRequestBatchAcceptsParentChildByWorkName",
-      "owner": "backend-maintainers",
-      "removalReason": "Refactor the target to satisfy the pkgmaintcheck:ignore-cyclomatic-complexity threshold. Current rationale: this watcher batch-contract test keeps parent-child mapping and canonical submit assertions in one scenario."
-    },
-    {
-      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
       "target": "pkg/factory/projections/projectiontests/dispatch_lifecycle_event_replay_test.go#assertJavaScriptDispatchLifecycleReplay",
       "owner": "backend-maintainers",
       "removalReason": "Refactor the target to satisfy the pkgmaintcheck:ignore-cyclomatic-complexity threshold. Current rationale: this replay assertion keeps JavaScript dispatch lifecycle counts, metadata, and artifacts visible in one scenario."

--- a/pkg/factory/ingest/filewatcher_test.go
+++ b/pkg/factory/ingest/filewatcher_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -393,7 +394,6 @@ func TestFileWatcher_JSONFactoryRequestBatchMapsWorkTypeName(t *testing.T) {
 	}
 }
 
-// pkgmaintcheck:ignore-cyclomatic-complexity this watcher batch-contract test keeps parent-child mapping and canonical submit assertions in one scenario.
 func TestFileWatcher_JSONFactoryRequestBatchAcceptsParentChildByWorkName(t *testing.T) {
 	dir := setupWatchDir(t)
 	data := []byte(`{
@@ -441,29 +441,23 @@ func TestFileWatcher_JSONFactoryRequestBatchAcceptsParentChildByWorkName(t *test
 		t.Fatalf("child relations = %d, want 2", len(child.Relations))
 	}
 
-	var foundParentChild bool
-	var foundDependsOn bool
+	relationsByType := make(map[interfaces.RelationType]interfaces.Relation, len(child.Relations))
 	for _, relation := range child.Relations {
-		switch relation.Type {
-		case interfaces.RelationParentChild:
-			foundParentChild = true
-			if relation.TargetWorkID != "batch-request-batch-parent-child-parent" {
-				t.Fatalf("parent-child target = %q, want batch-request-batch-parent-child-parent", relation.TargetWorkID)
-			}
-		case interfaces.RelationDependsOn:
-			foundDependsOn = true
-			if relation.TargetWorkID != "batch-request-batch-parent-child-prerequisite" {
-				t.Fatalf("depends_on target = %q, want batch-request-batch-parent-child-prerequisite", relation.TargetWorkID)
-			}
-		default:
-			t.Fatalf("unexpected relation = %#v", relation)
-		}
+		relationsByType[relation.Type] = relation
 	}
-	if !foundParentChild {
-		t.Fatal("missing parent-child relation")
+	wantRelations := map[interfaces.RelationType]interfaces.Relation{
+		interfaces.RelationParentChild: {
+			Type:         interfaces.RelationParentChild,
+			TargetWorkID: "batch-request-batch-parent-child-parent",
+		},
+		interfaces.RelationDependsOn: {
+			Type:          interfaces.RelationDependsOn,
+			TargetWorkID:  "batch-request-batch-parent-child-prerequisite",
+			RequiredState: "complete",
+		},
 	}
-	if !foundDependsOn {
-		t.Fatal("missing depends_on relation")
+	if !reflect.DeepEqual(relationsByType, wantRelations) {
+		t.Fatalf("child relations = %#v, want %#v", relationsByType, wantRelations)
 	}
 }
 


### PR DESCRIPTION
{
  "project": "System Consolidation Ingest Exemption Burn-Down",
  "branchName": "system-consolidation-ingest-exemption-burn-down",
  "description": "Preserve the observable watched JSON FACTORY_REQUEST_BATCH parent-child-by-work-name ingestion contract while simplifying its focused regression test enough to remove one cyclomatic-complexity directive and exactly its matching checked exemption-budget entry.",
  "context": {
    "customerAsk": "Preserve successful watched-file ingestion of the canonical parent-child batch, including resolved work identity and relation semantics, while removing the selected pkgmaintcheck cyclomatic-complexity directive and exactly its matching backend exemption entry.",
    "problem": "The selected pkg/factory/ingest regression protects canonical batch identity and relation behavior but currently needs a cyclomatic-complexity exemption. Removing debt without equivalent behavioral evidence could weaken coverage, while editing a newly overlapping file could duplicate another active lane.",
    "solution": "Refresh open-PR and active-worktree file sets immediately before edits and stop with concrete collision evidence if the target overlaps. Otherwise, simplify only the selected test, preserve its success and neighboring invalid-input evidence, remove only the directive and exact registry entry, and verify the existing quality gates with no product-contract changes."
  },
  "acceptanceCriteria": [
    "Immediately before editing, refreshed open-PR and active-worktree file sets show no collision on pkg/factory/ingest/filewatcher_test.go; if a collision exists, leave the selected test and budget entry unchanged and return concrete PR or worktree evidence to the planner",
    "The canonical watched FACTORY_REQUEST_BATCH succeeds with three resolved submissions, the expected shared trace identity, and child PARENT_CHILD and DEPENDS_ON relations targeting the canonical parent and prerequisite work IDs",
    "Relevant package-owned malformed and invalid batch rejection coverage remains present and passing",
    "Remove the selected pkgmaintcheck:ignore-cyclomatic-complexity directive and exactly the backend-exemption-budget.json entry targeting pkg/factory/ingest/filewatcher_test.go#TestFileWatcher_JSONFactoryRequestBatchAcceptsParentChildByWorkName, with no replacement suppression, threshold increase, or coverage-baseline weakening",
    "The exemption budget decreases from 175 to exactly 174 entries while all unrelated rules, targets, owners, and removal reasons remain unchanged",
    "Observable CLI, API, event, persistence, runtime, UI, logging, and metrics contracts remain unchanged and no unrelated cleanup is included",
    "Quality gates pass: go test ./pkg/factory/ingest -run TestFileWatcher_JSONFactoryRequestBatchAcceptsParentChildByWorkName -count=1; go test ./pkg/factory/ingest; make backend-size; make pkg-maint; go run ./cmd/gocoveragecheck; make lint; make test"
  ],
  "userStories": [
    {
      "id": "system-consolidation-ingest-exemption-burn-down-001",
      "title": "Preserve batch relation ingestion while retiring its exemption",
      "description": "As a backend maintainer, I want the watched parent-child batch contract to remain directly proven without a complexity exemption so that checked technical debt decreases without weakening customer-visible ingestion behavior.",
      "acceptanceCriteria": [
        "Immediately before editing, refresh every open-PR and active-worktree file set; if pkg/factory/ingest/filewatcher_test.go collides, leave the selected test and budget entry unchanged and return the colliding PR number and branch or worktree branch and path to the planner",
        "With no collision, the focused test ingests the canonical three-work FACTORY_REQUEST_BATCH through FileWatcher.PreseedInputs and verifies exactly three accepted submissions",
        "The focused evidence identifies the child by work name, verifies the expected shared trace identity, and verifies exactly one PARENT_CHILD relation to batch-request-batch-parent-child-parent and one DEPENDS_ON relation to batch-request-batch-parent-child-prerequisite without accepting unexpected relation semantics",
        "The selected test satisfies the existing cyclomatic-complexity threshold without any replacement suppression or threshold change",
        "Existing pkg/factory/ingest invalid alias and conflicting trace or work-type batch rejection tests remain present and pass, with no meta-test or source-inventory assertion added as behavioral evidence",
        "Remove only the selected directive and its exact backend-exemption-budget.json entry; the registry decreases from 175 to 174 entries and all unrelated entry fields remain unchanged",
        "No production code, public or generated contract, CLI, API, event, persistence, runtime, UI, observability behavior, coverage baseline, or unrelated exemption changes",
        "Typecheck passes",
        "Tests pass",
        "All project verification commands pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    }
  ]
}
