### PR TITLE
system-consolidation-dispatcher-assertion-exemption-burn-down

### DIFF
--- a/backend-exemption-budget.json
+++ b/backend-exemption-budget.json
@@ -483,12 +483,6 @@
     },
     {
       "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
-      "target": "pkg/factory/subsystems/dispatchertests/dispatcher_test.go#assertSingleTransitionDispatchResult",
-      "owner": "backend-maintainers",
-      "removalReason": "Refactor the target to satisfy the pkgmaintcheck:ignore-cyclomatic-complexity threshold. Current rationale: this helper keeps the full dispatch mutation contract together for transition-level assertions."
-    },
-    {
-      "rule": "pkgmaintcheck:ignore-cyclomatic-complexity",
       "target": "pkg/factory/subsystems/history_transitioner_pipeline_test.go#TestHistoryTransitionerPipeline_CodexWindowsExitCode4294967295RequeuesAndPreservesRetryableProviderMetadata",
       "owner": "backend-maintainers",
       "removalReason": "Refactor the target to satisfy the pkgmaintcheck:ignore-cyclomatic-complexity threshold. Current rationale: this failure-pipeline regression keeps the retryable Windows exit corpus and metadata assertions inline."

--- a/pkg/factory/subsystems/dispatchertests/dispatcher_test.go
+++ b/pkg/factory/subsystems/dispatchertests/dispatcher_test.go
@@ -641,24 +641,33 @@ func newSingleTransitionDispatchFixture() (*subsystems.DispatcherSubsystem, *int
 	return dispatcher, snapshot
 }
 
-// pkgmaintcheck:ignore-cyclomatic-complexity this helper keeps the full dispatch mutation contract together for transition-level assertions.
 func assertSingleTransitionDispatchResult(t *testing.T, result *interfaces.TickResult) {
 	t.Helper()
 	if result == nil {
 		t.Fatal("expected non-nil result")
 	}
-	if len(result.Mutations) != 1 {
-		t.Fatalf("expected 1 mutation, got %d", len(result.Mutations))
+	assertSingleTransitionMutation(t, result.Mutations)
+	assertSingleTransitionDispatchRecord(t, result.Dispatches)
+}
+
+func assertSingleTransitionMutation(t *testing.T, mutations []interfaces.MarkingMutation) {
+	t.Helper()
+	if len(mutations) != 1 {
+		t.Fatalf("expected 1 mutation, got %d", len(mutations))
 	}
-	mutation := result.Mutations[0]
+	mutation := mutations[0]
 	if mutation.Type != interfaces.MutationConsume || mutation.TokenID != "tok1" || mutation.FromPlace != "p-init" {
 		t.Fatalf("consume mutation = %#v, want tok1 from p-init", mutation)
 	}
-	if len(result.Dispatches) != 1 {
-		t.Fatalf("expected 1 dispatch record, got %d", len(result.Dispatches))
+}
+
+func assertSingleTransitionDispatchRecord(t *testing.T, records []interfaces.DispatchRecord) {
+	t.Helper()
+	if len(records) != 1 {
+		t.Fatalf("expected 1 dispatch record, got %d", len(records))
 	}
 
-	record := result.Dispatches[0]
+	record := records[0]
 	dispatch := record.Dispatch
 	input := firstInputToken(dispatch.InputTokens)
 	if dispatch.DispatchID == "" || dispatch.TransitionID != "t1" || len(dispatch.InputTokens) != 1 || input.ID != "tok1" {
@@ -676,8 +685,13 @@ func assertSingleTransitionDispatchResult(t *testing.T, result *interfaces.TickR
 	if strings.Join(dispatch.Execution.WorkIDs, ",") != "w1" || dispatch.Execution.ReplayKey != "t1/trace-1/w1" {
 		t.Fatalf("dispatch execution IDs = %#v, want work ID w1 and stable replay key", dispatch.Execution)
 	}
-	if len(record.Mutations) != 1 || record.Mutations[0].Type != interfaces.MutationConsume || record.Mutations[0].TokenID != "tok1" {
-		t.Fatalf("dispatch record mutations = %#v, want paired consume for tok1", record.Mutations)
+	assertSingleTransitionRecordMutation(t, record.Mutations)
+}
+
+func assertSingleTransitionRecordMutation(t *testing.T, mutations []interfaces.MarkingMutation) {
+	t.Helper()
+	if len(mutations) != 1 || mutations[0].Type != interfaces.MutationConsume || mutations[0].TokenID != "tok1" {
+		t.Fatalf("dispatch record mutations = %#v, want paired consume for tok1", mutations)
 	}
 }
 


### PR DESCRIPTION
{
  "project": "System Consolidation Dispatcher Assertion Exemption Burn-Down",
  "branchName": "system-consolidation-dispatcher-assertion-exemption-burn-down",
  "description": "Preserve the observable single-transition dispatcher mutation, routing, lineage, work identity, and replay-key evidence while simplifying the selected assertion helper enough to remove its cyclomatic-complexity directive and exactly its matching checked exemption-budget entry.",
  "context": {
    "customerAsk": "Preserve the observable single-transition dispatcher mutation, routing, lineage, and replay-key evidence while removing the selected pkgmaintcheck cyclomatic-complexity directive on assertSingleTransitionDispatchResult and exactly its matching backend exemption entry.",
    "problem": "The selected dispatcher assertion protects one consume mutation, its paired dispatch record, input-token metadata, routing, execution lineage, work identity, and deterministic replay identity, but currently requires a cyclomatic-complexity exemption. Removing the debt without equivalent behavioral evidence could weaken regression protection, while editing a newly overlapping file could conflict with another active lane.",
    "solution": "Refresh open-PR and active-worktree file sets immediately before edits and stop with concrete collision evidence if the target overlaps. Otherwise, simplify only the selected assertion structure, preserve every focused dispatcher outcome, remove only the directive and exact registry entry, and verify the existing quality gates with no production, adjacent portos-policy, or public-contract changes."
  },
  "acceptanceCriteria": [
    "Immediately before editing, refreshed open-PR and active-worktree file sets show no collision on pkg/factory/subsystems/dispatchertests/dispatcher_test.go; if a collision exists, leave the file and its budget entry unchanged and return concrete PR or worktree evidence to the planner",
    "The focused single-transition scenario proves exactly one consume mutation for tok1 from p-init and exactly one dispatch record whose paired mutation consumes tok1",
    "The dispatch preserves the single input token and its work metadata, routes through do-work in analytics-platform, preserves request-1, trace-1, tick 3, and work ID w1, and emits replay key t1/trace-1/w1 for transition t1",
    "Remove the selected pkgmaintcheck:ignore-cyclomatic-complexity directive on assertSingleTransitionDispatchResult and exactly its matching backend-exemption-budget.json entry with no replacement suppression, checker-threshold increase, lint-policy weakening, or coverage-baseline change",
    "The separate portos exception on TestDispatcher_SingleTransitionFires remains unchanged, and production dispatcher, CLI, API, event, persistence, runtime, UI, logging, and metrics behavior remain unchanged",
    "The checked exemption budget decreases from 174 to exactly 173 entries while every unrelated entry, owner, and removal reason remains unchanged",
    "Quality gates pass for typecheck, lint, and tests: go test ./pkg/factory/subsystems/dispatchertests -run TestDispatcher_SingleTransitionFires -count=1; go test ./pkg/factory/subsystems/dispatchertests; make backend-size; make pkg-maint; go run ./cmd/gocoveragecheck; make lint; make test"
  ],
  "userStories": [
    {
      "id": "system-consolidation-dispatcher-assertion-exemption-burn-down-001",
      "title": "Preserve single-transition dispatch evidence while retiring its exemption",
      "description": "As a backend maintainer, I want the single-transition dispatcher contract to remain directly proven without a complexity exemption so that checked technical debt decreases without weakening confidence in mutation, routing, lineage, or replay behavior.",
      "acceptanceCriteria": [
        "Immediately before editing, refresh every open-PR and active-worktree file set; if pkg/factory/subsystems/dispatchertests/dispatcher_test.go collides, leave that file and its budget entry unchanged and return the colliding PR number and branch or worktree branch and path to the planner",
        "With no collision, TestDispatcher_SingleTransitionFires produces a non-nil result containing exactly one consume mutation for token tok1 from place p-init",
        "The result contains exactly one dispatch record for transition t1 with exactly one input token, and the record contains exactly one paired consume mutation for tok1",
        "The dispatched input remains tok1, retains a non-zero creation time and work ID w1, and the dispatch routes to workstation do-work in project analytics-platform",
        "Dispatch execution preserves current tick 3, request ID request-1, trace ID trace-1, work IDs containing w1, and replay key t1/trace-1/w1",
        "The selected assertion satisfies the existing cyclomatic-complexity threshold without a replacement suppression, threshold increase, lint-policy weakening, coverage-baseline change, or meta-test substituted for dispatcher behavior",
        "Remove only the selected pkgmaintcheck directive and its exact backend-exemption-budget.json entry; the registry decreases from 174 to 173 entries and all unrelated entry fields remain unchanged",
        "The portos exception on TestDispatcher_SingleTransitionFires remains unchanged, and no production dispatcher, CLI, API, event, persistence, runtime, UI, logging, metrics, generated contract, or unrelated test behavior changes",
        "Typecheck passes",
        "Tests pass",
        "All project verification commands pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    }
  ]
}
