### PR TITLE
interfaces-b05-deterministic-schema-joiner

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@ contracts/testdata/baseline/** text eol=lf
 pkg/config/globalconfiginventory/testdata/** text eol=lf
 pkg/config/operatorconfig/testdata/** text eol=lf
 pkg/config/systemconfig/testdata/** text eol=lf
+internal/contractjoiner/testdata/canonical/golden/** text eol=lf

--- a/cmd/contractsjoin/main.go
+++ b/cmd/contractsjoin/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/portpowered/infinite-you/internal/contractjoiner"
+)
+
+const successMessage = "[agent-factory:contracts-join] joined contracts generated"
+
+type stringList []string
+
+func (values *stringList) String() string { return fmt.Sprint([]string(*values)) }
+func (values *stringList) Set(value string) error {
+	*values = append(*values, value)
+	return nil
+}
+
+func main() {
+	input := contractjoiner.Input{}
+	flag.StringVar(&input.RepositoryRoot, "repository-root", ".", "repository root")
+	flag.Var((*stringList)(&input.Roots), "root", "repository-relative authored root (repeatable)")
+	flag.Var((*stringList)(&input.Components), "component", "repository-relative authored component (repeatable)")
+	flag.Parse()
+	os.Exit(run(input, os.Stdout, os.Stderr))
+}
+
+func run(input contractjoiner.Input, stdout, stderr io.Writer) int {
+	diagnostics := contractjoiner.Generate(input)
+	if len(diagnostics) == 0 {
+		fmt.Fprintln(stdout, successMessage)
+		return 0
+	}
+
+	encoder := json.NewEncoder(stderr)
+	encoder.SetEscapeHTML(false)
+	for _, diagnostic := range diagnostics {
+		if err := encoder.Encode(diagnostic); err != nil {
+			fmt.Fprintln(stderr, "[agent-factory:contracts-join] diagnostic output failed")
+			return 1
+		}
+	}
+	return 1
+}

--- a/cmd/contractsjoin/main_test.go
+++ b/cmd/contractsjoin/main_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/contractjoiner"
+)
+
+func TestRunGeneratesJoinedOutput(t *testing.T) {
+	root := t.TempDir()
+	writeCommandFixture(t, root, "contracts/root.json", `{"$id":"root","type":"object"}`)
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	status := run(contractjoiner.Input{RepositoryRoot: root, Roots: []string{"contracts/root.json"}}, stdout, stderr)
+
+	if status != 0 || stdout.String() != successMessage+"\n" || stderr.Len() != 0 {
+		t.Fatalf("run() = status %d, stdout %q, stderr %q", status, stdout, stderr)
+	}
+	if _, err := os.Stat(filepath.Join(root, "packages", "api", "generated", "joined", "contracts", "root.json")); err != nil {
+		t.Fatalf("generated output: %v", err)
+	}
+}
+
+func TestRunReportsStableJoinDiagnosticAndFailure(t *testing.T) {
+	root := t.TempDir()
+	writeCommandFixture(t, root, "contracts/root.json", `{"$ref":"missing.json"}`)
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	status := run(contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"contracts/root.json"},
+		Components:     []string{"contracts/missing.json"},
+	}, stdout, stderr)
+
+	if status != 1 || stdout.Len() != 0 {
+		t.Fatalf("run() = status %d, stdout %q; want failure and empty stdout", status, stdout)
+	}
+	want := "{\"code\":\"reference.missing\",\"path\":\"/$ref\",\"message\":\"referenced document does not exist\",\"document\":\"contracts/root.json\"}\n"
+	if stderr.String() != want {
+		t.Fatalf("run() stderr = %q, want %q", stderr, want)
+	}
+	if _, err := os.Stat(filepath.Join(root, "packages", "api", "generated", "joined")); !os.IsNotExist(err) {
+		t.Fatalf("failed command created joined output: %v", err)
+	}
+}
+
+func writeCommandFixture(t *testing.T, root, path, contents string) {
+	t.Helper()
+	target := filepath.Join(root, filepath.FromSlash(path))
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("create fixture directory: %v", err)
+	}
+	if err := os.WriteFile(target, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+}

--- a/internal/contractjoiner/canonical.go
+++ b/internal/contractjoiner/canonical.go
@@ -1,0 +1,24 @@
+package contractjoiner
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// MarshalCanonicalJSON serializes a joined JSON value with recursively sorted
+// object keys, two-space indentation, and exactly one trailing newline. The
+// encoding/json package guarantees sorted map keys; array order and scalar
+// values are preserved.
+func MarshalCanonicalJSON(value any) ([]byte, error) {
+	payload, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal joined contract: %w", err)
+	}
+
+	var result bytes.Buffer
+	result.Grow(len(payload) + 1)
+	result.Write(payload)
+	result.WriteByte('\n')
+	return result.Bytes(), nil
+}

--- a/internal/contractjoiner/diagnostics_test.go
+++ b/internal/contractjoiner/diagnostics_test.go
@@ -97,6 +97,46 @@ func TestJoinDiagnosticsUseTotalOrderIndependentOfInputOrder(t *testing.T) {
 	}
 }
 
+func TestJoinRejectsDistinctResourcesWithTheSameResolvedIDDeterministically(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "roots/root.json", `{
+  "$id":"https://schemas.example.test/root.json",
+  "properties":{
+    "a":{"$ref":"../components/a.json"},
+    "b":{"$ref":"../components/b.json"}
+  }
+}`)
+	writeFile(t, root, "components/a.json", `{"$id":"https://schemas.example.test/item.json","type":"string"}`)
+	writeFile(t, root, "components/b.json", `{"$id":"https://schemas.example.test/item.json","type":"integer"}`)
+	input := contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"roots/root.json"},
+		Components:     []string{"components/a.json", "components/b.json"},
+	}
+
+	documents, forward := contractjoiner.Join(input)
+	shuffledDocuments, shuffled := contractjoiner.Join(contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          input.Roots,
+		Components:     reversed(input.Components),
+	})
+	if documents != nil || shuffledDocuments != nil {
+		t.Fatalf("Join() returned partial documents: forward=%+v shuffled=%+v", documents, shuffledDocuments)
+	}
+	if !reflect.DeepEqual(forward, shuffled) {
+		t.Fatalf("input order changed collision diagnostics:\nforward: %+v\nshuffled: %+v", forward, shuffled)
+	}
+	want := []contractvalidator.Diagnostic{{
+		Code:     "reference.resource_collision",
+		Path:     "/$id",
+		Message:  `stable resource URI "https://schemas.example.test/item.json" is declared by multiple authored resources`,
+		Document: "components/b.json",
+	}}
+	if !reflect.DeepEqual(forward, want) {
+		t.Fatalf("Join() diagnostics = %+v, want %+v", forward, want)
+	}
+}
+
 func TestJoinRejectsAuthoredInputsInsideGeneratedOutput(t *testing.T) {
 	root := t.TempDir()
 	generated := "packages/api/generated/joined/contract.json"

--- a/internal/contractjoiner/diagnostics_test.go
+++ b/internal/contractjoiner/diagnostics_test.go
@@ -1,0 +1,179 @@
+package contractjoiner_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/contractjoiner"
+	"github.com/portpowered/infinite-you/internal/contractvalidator"
+)
+
+func TestJoinRejectsUnsafeReferenceGraphsWithoutPartialDocuments(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "repository")
+	writeFile(t, root, "roots/direct-cycle.json", `{"node":{"$ref":"#"}}`)
+	writeFile(t, root, "roots/indirect-cycle.json", `{"$ref":"../components/first.json"}`)
+	writeFile(t, root, "components/first.json", `{"$ref":"second.json"}`)
+	writeFile(t, root, "components/second.json", `{"$ref":"first.json"}`)
+	writeFile(t, root, "components/target.json", `{"type":"string"}`)
+	writeFile(t, parent, "outside.json", `{}`)
+	writeFile(t, parent, "repository-copy/outside.json", `{}`)
+	absPath := filepath.Join(parent, "outside.json")
+
+	tests := []struct {
+		name       string
+		rootPath   string
+		contents   string
+		components []string
+		code       string
+		document   string
+		path       string
+	}{
+		{name: "direct cycle", rootPath: "roots/direct-cycle.json", components: nil, code: "reference.cycle", document: "roots/direct-cycle.json", path: "/node/$ref"},
+		{name: "indirect cycle", rootPath: "roots/indirect-cycle.json", components: []string{"components/first.json", "components/second.json"}, code: "reference.cycle", document: "components/second.json", path: "/$ref"},
+		{name: "network URL", rootPath: "roots/network.json", contents: `{"value":{"$ref":"https://example.test/schema.json"}}`, code: "reference.unsupported", document: "roots/network.json", path: "/value/$ref"},
+		{name: "file URL", rootPath: "roots/file-url.json", contents: `{"value":{"$ref":"file:///tmp/schema.json"}}`, code: "reference.unsupported", document: "roots/file-url.json", path: "/value/$ref"},
+		{name: "absolute path", rootPath: "roots/absolute.json", contents: fmt.Sprintf(`{"value":{"$ref":%q}}`, absPath), code: "reference.unsupported", document: "roots/absolute.json", path: "/value/$ref"},
+		{name: "empty reference", rootPath: "roots/empty.json", contents: `{"value":{"$ref":""}}`, code: "reference.invalid", document: "roots/empty.json", path: "/value/$ref"},
+		{name: "non-string reference", rootPath: "roots/non-string.json", contents: `{"value":{"$ref":42}}`, code: "reference.invalid", document: "roots/non-string.json", path: "/value/$ref"},
+		{name: "query", rootPath: "roots/query.json", contents: `{"value":{"$ref":"../components/target.json?version=1"}}`, components: []string{"components/target.json"}, code: "reference.unsupported", document: "roots/query.json", path: "/value/$ref"},
+		{name: "unsupported fragment", rootPath: "roots/fragment.json", contents: `{"value":{"$ref":"../components/target.json#anchor"}}`, components: []string{"components/target.json"}, code: "reference.fragment", document: "roots/fragment.json", path: "/value/$ref"},
+		{name: "missing target", rootPath: "roots/missing.json", contents: `{"value":{"$ref":"../components/missing.json"}}`, components: []string{"components/missing.json"}, code: "reference.missing", document: "roots/missing.json", path: "/value/$ref"},
+		{name: "repository escape", rootPath: "roots/escape.json", contents: `{"value":{"$ref":"../../outside.json"}}`, code: "reference.escape", document: "roots/escape.json", path: "/value/$ref"},
+		{name: "sibling prefix escape", rootPath: "roots/sibling.json", contents: `{"value":{"$ref":"../../repository-copy/outside.json"}}`, code: "reference.escape", document: "roots/sibling.json", path: "/value/$ref"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.contents != "" {
+				writeFile(t, root, test.rootPath, test.contents)
+			}
+			documents, diagnostics := contractjoiner.Join(contractjoiner.Input{
+				RepositoryRoot: root,
+				Roots:          []string{test.rootPath},
+				Components:     test.components,
+			})
+			if documents != nil {
+				t.Fatalf("Join() documents = %+v, want no partial output", documents)
+			}
+			assertJoinDiagnostic(t, diagnostics, test.code, test.document, test.path, root)
+		})
+	}
+}
+
+func TestJoinDiagnosticsUseTotalOrderIndependentOfInputOrder(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "roots/a.json", `{"$ref":"../z-components/first.json"}`)
+	writeFile(t, root, "roots/b.json", `{"value":{"$ref":"https://example.test/external.json"}}`)
+	writeFile(t, root, "z-components/first.json", `{"$ref":"second.json"}`)
+	writeFile(t, root, "z-components/second.json", `{"$ref":"first.json"}`)
+	input := contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"roots/a.json", "roots/b.json"},
+		Components:     []string{"z-components/first.json", "z-components/second.json"},
+	}
+
+	_, forward := contractjoiner.Join(input)
+	_, shuffled := contractjoiner.Join(contractjoiner.Input{
+		RepositoryRoot: input.RepositoryRoot,
+		Roots:          reversed(input.Roots),
+		Components:     reversed(input.Components),
+	})
+	if !reflect.DeepEqual(forward, shuffled) {
+		t.Fatalf("input order changed diagnostics:\nforward: %+v\nshuffled: %+v", forward, shuffled)
+	}
+	want := []contractvalidator.Diagnostic{
+		{Code: "reference.unsupported", Path: "/value/$ref", Message: `reference "https://example.test/external.json" is not repository-relative`, Document: "roots/b.json"},
+		{Code: "reference.cycle", Path: "/$ref", Message: `reference "first.json" forms a cycle`, Document: "z-components/second.json"},
+	}
+	if !reflect.DeepEqual(forward, want) {
+		t.Fatalf("Join() diagnostics = %+v, want %+v", forward, want)
+	}
+}
+
+func TestJoinRejectsAuthoredInputsInsideGeneratedOutput(t *testing.T) {
+	root := t.TempDir()
+	generated := "packages/api/generated/joined/contract.json"
+	writeFile(t, root, generated, `{}`)
+	writeFile(t, root, "roots/safe.json", `{}`)
+
+	for _, inputPath := range []string{
+		generated,
+		`packages\api\generated\joined\contract.json`,
+		"packages/api/components/../generated/joined/contract.json",
+	} {
+		t.Run(inputPath, func(t *testing.T) {
+			documents, diagnostics := contractjoiner.Join(contractjoiner.Input{RepositoryRoot: root, Roots: []string{inputPath}})
+			if documents != nil {
+				t.Fatalf("Join() documents = %+v, want none", documents)
+			}
+			assertJoinDiagnostic(t, diagnostics, "join.input.generated", generated, "/", root)
+		})
+	}
+
+	_, diagnostics := contractjoiner.Join(contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"roots/safe.json"},
+		Components:     []string{generated},
+	})
+	assertJoinDiagnostic(t, diagnostics, "join.input.generated", generated, "/", root)
+}
+
+func TestJoinRejectsSymlinkAliasIntoGeneratedOutput(t *testing.T) {
+	root := t.TempDir()
+	generatedDirectory := filepath.Join(root, "packages", "api", "generated", "joined")
+	writeFile(t, root, "packages/api/generated/joined/contract.json", `{}`)
+	if err := os.MkdirAll(filepath.Join(root, "aliases"), 0o700); err != nil {
+		t.Fatalf("create aliases directory: %v", err)
+	}
+	if err := os.Symlink(generatedDirectory, filepath.Join(root, "aliases", "joined")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	documents, diagnostics := contractjoiner.Join(contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"aliases/joined/contract.json"},
+	})
+	if documents != nil {
+		t.Fatalf("Join() documents = %+v, want none", documents)
+	}
+	assertJoinDiagnostic(t, diagnostics, "join.input.generated", "aliases/joined/contract.json", "/", root)
+}
+
+func TestJoinRejectsAuthoredSymlinkOutsideRepository(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "repository")
+	writeFile(t, parent, "outside/contract.json", `{}`)
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("create repository: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(parent, "outside"), filepath.Join(root, "linked")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	documents, diagnostics := contractjoiner.Join(contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"linked/contract.json"},
+	})
+	if documents != nil {
+		t.Fatalf("Join() documents = %+v, want none", documents)
+	}
+	assertJoinDiagnostic(t, diagnostics, "join.input.escape", "linked/contract.json", "/", root)
+}
+
+func assertJoinDiagnostic(t *testing.T, diagnostics []contractvalidator.Diagnostic, code, document, path, repositoryRoot string) {
+	t.Helper()
+	if len(diagnostics) != 1 {
+		t.Fatalf("diagnostics = %+v, want one", diagnostics)
+	}
+	diagnostic := diagnostics[0]
+	if diagnostic.Code != code || diagnostic.Document != document || diagnostic.Path != path || diagnostic.Message == "" {
+		t.Fatalf("diagnostic = %+v, want code=%q document=%q path=%q and a message", diagnostic, code, document, path)
+	}
+	if strings.Contains(diagnostic.Message, repositoryRoot) || strings.Contains(diagnostic.Document, `\`) {
+		t.Fatalf("diagnostic leaks an absolute path or uses platform separators: %+v", diagnostic)
+	}
+}

--- a/internal/contractjoiner/diagnostics_test.go
+++ b/internal/contractjoiner/diagnostics_test.go
@@ -20,6 +20,7 @@ func TestJoinRejectsUnsafeReferenceGraphsWithoutPartialDocuments(t *testing.T) {
 	writeFile(t, root, "components/first.json", `{"$ref":"second.json"}`)
 	writeFile(t, root, "components/second.json", `{"$ref":"first.json"}`)
 	writeFile(t, root, "components/target.json", `{"type":"string"}`)
+	writeFile(t, root, "components/pointers.json", `{"foo~bar":{"type":"number"},"foo~2bar":{"type":"string"}}`)
 	writeFile(t, parent, "outside.json", `{}`)
 	writeFile(t, parent, "repository-copy/outside.json", `{}`)
 	absPath := filepath.Join(parent, "outside.json")
@@ -42,6 +43,8 @@ func TestJoinRejectsUnsafeReferenceGraphsWithoutPartialDocuments(t *testing.T) {
 		{name: "non-string reference", rootPath: "roots/non-string.json", contents: `{"value":{"$ref":42}}`, code: "reference.invalid", document: "roots/non-string.json", path: "/value/$ref"},
 		{name: "query", rootPath: "roots/query.json", contents: `{"value":{"$ref":"../components/target.json?version=1"}}`, components: []string{"components/target.json"}, code: "reference.unsupported", document: "roots/query.json", path: "/value/$ref"},
 		{name: "unsupported fragment", rootPath: "roots/fragment.json", contents: `{"value":{"$ref":"../components/target.json#anchor"}}`, components: []string{"components/target.json"}, code: "reference.fragment", document: "roots/fragment.json", path: "/value/$ref"},
+		{name: "bare JSON Pointer escape", rootPath: "roots/bare-pointer-escape.json", contents: `{"value":{"$ref":"../components/pointers.json#/foo~bar"}}`, components: []string{"components/pointers.json"}, code: "reference.fragment", document: "roots/bare-pointer-escape.json", path: "/value/$ref"},
+		{name: "invalid JSON Pointer escape with matching key", rootPath: "roots/invalid-pointer-escape.json", contents: `{"value":{"$ref":"../components/pointers.json#/foo~2bar"}}`, components: []string{"components/pointers.json"}, code: "reference.fragment", document: "roots/invalid-pointer-escape.json", path: "/value/$ref"},
 		{name: "external dynamic reference", rootPath: "roots/dynamic-external.json", contents: `{"nested":{"$dynamicRef":"https://example.test/external.json#node"}}`, code: "reference.unsupported", document: "roots/dynamic-external.json", path: "/nested/$dynamicRef"},
 		{name: "repository-relative dynamic reference", rootPath: "roots/dynamic-relative.json", contents: `{"nested":{"$dynamicRef":"../components/target.json#node"}}`, components: []string{"components/target.json"}, code: "reference.unsupported", document: "roots/dynamic-relative.json", path: "/nested/$dynamicRef"},
 		{name: "legacy recursive reference", rootPath: "roots/recursive.json", contents: `{"nested":{"$recursiveRef":"#"}}`, code: "reference.unsupported", document: "roots/recursive.json", path: "/nested/$recursiveRef"},
@@ -64,6 +67,69 @@ func TestJoinRejectsUnsafeReferenceGraphsWithoutPartialDocuments(t *testing.T) {
 			}
 			assertJoinDiagnostic(t, diagnostics, test.code, test.document, test.path, root)
 		})
+	}
+}
+
+func TestJoinRejectsMalformedJSONPointerEscapesDeterministically(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "roots/a.json", `{"value":{"$ref":"../components/pointers.json#/foo~2bar"}}`)
+	writeFile(t, root, "roots/b.json", `{"value":{"$ref":"../components/pointers.json#/foo~bar"}}`)
+	writeFile(t, root, "components/pointers.json", `{"foo~bar":{"type":"number"},"foo~2bar":{"type":"string"}}`)
+	input := contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"roots/a.json", "roots/b.json"},
+		Components:     []string{"components/pointers.json"},
+	}
+
+	documents, forward := contractjoiner.Join(input)
+	shuffledDocuments, shuffled := contractjoiner.Join(contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          reversed(input.Roots),
+		Components:     reversed(input.Components),
+	})
+	if documents != nil || shuffledDocuments != nil {
+		t.Fatalf("Join() returned partial documents: forward=%+v shuffled=%+v", documents, shuffledDocuments)
+	}
+	if !reflect.DeepEqual(forward, shuffled) {
+		t.Fatalf("input order changed malformed-pointer diagnostics:\nforward: %+v\nshuffled: %+v", forward, shuffled)
+	}
+	want := []contractvalidator.Diagnostic{
+		{Code: "reference.fragment", Path: "/value/$ref", Message: `reference "../components/pointers.json#/foo~2bar" has an unresolved fragment`, Document: "roots/a.json"},
+		{Code: "reference.fragment", Path: "/value/$ref", Message: `reference "../components/pointers.json#/foo~bar" has an unresolved fragment`, Document: "roots/b.json"},
+	}
+	if !reflect.DeepEqual(forward, want) {
+		t.Fatalf("Join() diagnostics = %+v, want %+v", forward, want)
+	}
+}
+
+func TestJoinResolvesValidJSONPointerEscapes(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "roots/root.json", `{
+  "properties":{
+    "tilde":{"$ref":"../components/pointers.json#/foo~0bar"},
+    "slash":{"$ref":"../components/pointers.json#/foo~1bar"}
+  }
+}`)
+	writeFile(t, root, "components/pointers.json", `{"foo~bar":{"type":"number"},"foo/bar":{"type":"string"}}`)
+
+	documents, diagnostics := contractjoiner.Join(contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"roots/root.json"},
+		Components:     []string{"components/pointers.json"},
+	})
+	if len(diagnostics) != 0 {
+		t.Fatalf("Join() diagnostics = %+v, want none", diagnostics)
+	}
+	if len(documents) != 1 {
+		t.Fatalf("Join() documents = %+v, want one", documents)
+	}
+	rootObject := documents[0].Value.(map[string]any)
+	properties := rootObject["properties"].(map[string]any)
+	if got := properties["tilde"].(map[string]any)["type"]; got != "number" {
+		t.Fatalf("escaped tilde target type = %v, want number", got)
+	}
+	if got := properties["slash"].(map[string]any)["type"]; got != "string" {
+		t.Fatalf("escaped slash target type = %v, want string", got)
 	}
 }
 

--- a/internal/contractjoiner/diagnostics_test.go
+++ b/internal/contractjoiner/diagnostics_test.go
@@ -42,6 +42,9 @@ func TestJoinRejectsUnsafeReferenceGraphsWithoutPartialDocuments(t *testing.T) {
 		{name: "non-string reference", rootPath: "roots/non-string.json", contents: `{"value":{"$ref":42}}`, code: "reference.invalid", document: "roots/non-string.json", path: "/value/$ref"},
 		{name: "query", rootPath: "roots/query.json", contents: `{"value":{"$ref":"../components/target.json?version=1"}}`, components: []string{"components/target.json"}, code: "reference.unsupported", document: "roots/query.json", path: "/value/$ref"},
 		{name: "unsupported fragment", rootPath: "roots/fragment.json", contents: `{"value":{"$ref":"../components/target.json#anchor"}}`, components: []string{"components/target.json"}, code: "reference.fragment", document: "roots/fragment.json", path: "/value/$ref"},
+		{name: "external dynamic reference", rootPath: "roots/dynamic-external.json", contents: `{"nested":{"$dynamicRef":"https://example.test/external.json#node"}}`, code: "reference.unsupported", document: "roots/dynamic-external.json", path: "/nested/$dynamicRef"},
+		{name: "repository-relative dynamic reference", rootPath: "roots/dynamic-relative.json", contents: `{"nested":{"$dynamicRef":"../components/target.json#node"}}`, components: []string{"components/target.json"}, code: "reference.unsupported", document: "roots/dynamic-relative.json", path: "/nested/$dynamicRef"},
+		{name: "legacy recursive reference", rootPath: "roots/recursive.json", contents: `{"nested":{"$recursiveRef":"#"}}`, code: "reference.unsupported", document: "roots/recursive.json", path: "/nested/$recursiveRef"},
 		{name: "missing target", rootPath: "roots/missing.json", contents: `{"value":{"$ref":"../components/missing.json"}}`, components: []string{"components/missing.json"}, code: "reference.missing", document: "roots/missing.json", path: "/value/$ref"},
 		{name: "repository escape", rootPath: "roots/escape.json", contents: `{"value":{"$ref":"../../outside.json"}}`, code: "reference.escape", document: "roots/escape.json", path: "/value/$ref"},
 		{name: "sibling prefix escape", rootPath: "roots/sibling.json", contents: `{"value":{"$ref":"../../repository-copy/outside.json"}}`, code: "reference.escape", document: "roots/sibling.json", path: "/value/$ref"},
@@ -67,7 +70,7 @@ func TestJoinRejectsUnsafeReferenceGraphsWithoutPartialDocuments(t *testing.T) {
 func TestJoinDiagnosticsUseTotalOrderIndependentOfInputOrder(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, root, "roots/a.json", `{"$ref":"../z-components/first.json"}`)
-	writeFile(t, root, "roots/b.json", `{"value":{"$ref":"https://example.test/external.json"}}`)
+	writeFile(t, root, "roots/b.json", `{"value":{"$dynamicRef":"https://example.test/external.json#node"}}`)
 	writeFile(t, root, "z-components/first.json", `{"$ref":"second.json"}`)
 	writeFile(t, root, "z-components/second.json", `{"$ref":"first.json"}`)
 	input := contractjoiner.Input{
@@ -86,7 +89,7 @@ func TestJoinDiagnosticsUseTotalOrderIndependentOfInputOrder(t *testing.T) {
 		t.Fatalf("input order changed diagnostics:\nforward: %+v\nshuffled: %+v", forward, shuffled)
 	}
 	want := []contractvalidator.Diagnostic{
-		{Code: "reference.unsupported", Path: "/value/$ref", Message: `reference "https://example.test/external.json" is not repository-relative`, Document: "roots/b.json"},
+		{Code: "reference.unsupported", Path: "/value/$dynamicRef", Message: `reference keyword "$dynamicRef" is not supported`, Document: "roots/b.json"},
 		{Code: "reference.cycle", Path: "/$ref", Message: `reference "first.json" forms a cycle`, Document: "z-components/second.json"},
 	}
 	if !reflect.DeepEqual(forward, want) {

--- a/internal/contractjoiner/generate.go
+++ b/internal/contractjoiner/generate.go
@@ -1,0 +1,162 @@
+package contractjoiner
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/portpowered/infinite-you/internal/contractvalidator"
+)
+
+const diagnosticRootPath = "/"
+
+type stagedDocument struct {
+	path    string
+	payload []byte
+}
+
+// Generate joins and canonicalizes the complete input set before replacing the
+// joined staging directory as one prepared set. It never publishes a partial set.
+func Generate(input Input) []contractvalidator.Diagnostic {
+	if len(input.Roots) == 0 {
+		return []contractvalidator.Diagnostic{*generationDiagnostic(
+			"generation.input", "at least one authored root is required", "roots",
+		)}
+	}
+	documents, diagnostics := Join(input)
+	if len(diagnostics) != 0 {
+		return diagnostics
+	}
+
+	staged, diagnostic := canonicalDocuments(documents)
+	if diagnostic != nil {
+		return []contractvalidator.Diagnostic{*diagnostic}
+	}
+	if diagnostic := publish(input.RepositoryRoot, staged); diagnostic != nil {
+		return []contractvalidator.Diagnostic{*diagnostic}
+	}
+	return nil
+}
+
+func canonicalDocuments(documents []Document) ([]stagedDocument, *contractvalidator.Diagnostic) {
+	staged := make([]stagedDocument, 0, len(documents))
+	for _, document := range documents {
+		payload, err := MarshalCanonicalJSON(document.Value)
+		if err != nil {
+			return nil, generationDiagnostic("generation.serialize", "joined document could not be serialized", document.Path)
+		}
+		staged = append(staged, stagedDocument{path: document.Path, payload: payload})
+	}
+	return staged, nil
+}
+
+func publish(repositoryRoot string, documents []stagedDocument) *contractvalidator.Diagnostic {
+	root, err := filepath.Abs(repositoryRoot)
+	if err != nil {
+		return generationDiagnostic("generation.root", "repository root could not be resolved", "repository")
+	}
+	root, err = filepath.EvalSymlinks(root)
+	if err != nil {
+		return generationDiagnostic("generation.root", "repository root could not be resolved", "repository")
+	}
+
+	output := filepath.Join(root, filepath.FromSlash(joinedOutputDirectory))
+	parent := filepath.Dir(output)
+	if !safeExistingAncestor(root, parent) {
+		return generationDiagnostic("generation.boundary", "joined output boundary is outside the repository", joinedOutputDirectory)
+	}
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return generationDiagnostic("generation.stage", "joined output could not be staged", joinedOutputDirectory)
+	}
+	canonicalParent, err := filepath.EvalSymlinks(parent)
+	if err != nil || !pathContainedBy(root, canonicalParent) {
+		return generationDiagnostic("generation.boundary", "joined output boundary is outside the repository", joinedOutputDirectory)
+	}
+	if canonicalOutput, err := filepath.EvalSymlinks(output); err == nil && !pathContainedBy(root, canonicalOutput) {
+		return generationDiagnostic("generation.boundary", "joined output boundary is outside the repository", joinedOutputDirectory)
+	} else if err != nil && !os.IsNotExist(err) {
+		return generationDiagnostic("generation.boundary", "joined output boundary could not be resolved", joinedOutputDirectory)
+	}
+	staging, err := os.MkdirTemp(parent, ".joined-stage-")
+	if err != nil {
+		return generationDiagnostic("generation.stage", "joined output could not be staged", joinedOutputDirectory)
+	}
+	defer os.RemoveAll(staging)
+
+	for _, document := range documents {
+		target := filepath.Join(staging, filepath.FromSlash(document.path))
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return generationDiagnostic("generation.stage", "joined output could not be staged", document.path)
+		}
+		if err := os.WriteFile(target, document.payload, 0o644); err != nil {
+			return generationDiagnostic("generation.stage", "joined output could not be staged", document.path)
+		}
+	}
+
+	return replaceDirectory(output, staging)
+}
+
+func safeExistingAncestor(root, path string) bool {
+	current := path
+	for {
+		_, err := os.Lstat(current)
+		if err == nil {
+			canonical, err := filepath.EvalSymlinks(current)
+			return err == nil && pathContainedBy(root, canonical)
+		}
+		if !os.IsNotExist(err) {
+			return false
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return false
+		}
+		current = parent
+	}
+}
+
+func pathContainedBy(root, candidate string) bool {
+	relative, err := filepath.Rel(root, candidate)
+	if err != nil || filepath.IsAbs(relative) {
+		return false
+	}
+	return relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}
+
+func replaceDirectory(output, staging string) *contractvalidator.Diagnostic {
+	backup, err := os.MkdirTemp(filepath.Dir(output), ".joined-backup-")
+	if err != nil {
+		return generationDiagnostic("generation.publish", "joined output could not be published", joinedOutputDirectory)
+	}
+	if err := os.Remove(backup); err != nil {
+		return generationDiagnostic("generation.publish", "joined output could not be published", joinedOutputDirectory)
+	}
+
+	hadOutput := false
+	if _, err := os.Stat(output); err == nil {
+		hadOutput = true
+		if err := os.Rename(output, backup); err != nil {
+			return generationDiagnostic("generation.publish", "joined output could not be published", joinedOutputDirectory)
+		}
+	} else if !os.IsNotExist(err) {
+		return generationDiagnostic("generation.publish", "joined output could not be published", joinedOutputDirectory)
+	}
+
+	if err := os.Rename(staging, output); err != nil {
+		if hadOutput {
+			_ = os.Rename(backup, output)
+		}
+		return generationDiagnostic("generation.publish", "joined output could not be published", joinedOutputDirectory)
+	}
+	if hadOutput {
+		_ = os.RemoveAll(backup)
+	}
+	return nil
+}
+
+func generationDiagnostic(code, message, document string) *contractvalidator.Diagnostic {
+	diagnostic := contractvalidator.Diagnostic{
+		Code: code, Path: diagnosticRootPath, Message: message, Document: filepath.ToSlash(document),
+	}
+	return &diagnostic
+}

--- a/internal/contractjoiner/generate_test.go
+++ b/internal/contractjoiner/generate_test.go
@@ -1,0 +1,192 @@
+package contractjoiner_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/contractjoiner"
+)
+
+const joinedDirectory = "packages/api/generated/joined"
+
+func TestGeneratePublishesCompleteDeterministicSetInsideJoinedBoundary(t *testing.T) {
+	root := t.TempDir()
+	writeGenerationFixture(t, root, "contracts/components/shared.json", `{"$id":"shared","type":"string"}`)
+	writeGenerationFixture(t, root, "contracts/roots/z.json", `{"$id":"z","properties":{"value":{"$ref":"../components/shared.json"}}}`)
+	writeGenerationFixture(t, root, "contracts/roots/a.json", `{"$id":"a","type":"object"}`)
+	input := contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"contracts/roots/z.json", "contracts/roots/a.json"},
+		Components:     []string{"contracts/components/shared.json"},
+	}
+
+	before := authoredGenerationBytes(t, root)
+	if diagnostics := contractjoiner.Generate(input); len(diagnostics) != 0 {
+		t.Fatalf("Generate() diagnostics = %#v, want none", diagnostics)
+	}
+	first := generatedTree(t, root)
+	if diagnostics := contractjoiner.Generate(contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"contracts/roots/a.json", "contracts/roots/z.json"},
+		Components:     []string{"contracts/components/shared.json"},
+	}); len(diagnostics) != 0 {
+		t.Fatalf("Generate(shuffled) diagnostics = %#v, want none", diagnostics)
+	}
+	second := generatedTree(t, root)
+
+	if !equalByteTrees(first, second) {
+		t.Fatalf("repeated generated tree changed:\nfirst=%q\nsecond=%q", first, second)
+	}
+	if len(second) != 2 {
+		t.Fatalf("generated file count = %d, want 2", len(second))
+	}
+	joinedZ := filepath.ToSlash(filepath.Join(joinedDirectory, "contracts/roots/z.json"))
+	if !bytes.Contains(second[joinedZ], []byte(`"$id": "shared"`)) {
+		t.Fatalf("generated %s does not contain joined component: %s", joinedZ, second[joinedZ])
+	}
+	if after := authoredGenerationBytes(t, root); !equalByteTrees(before, after) {
+		t.Fatalf("authored inputs changed:\nbefore=%q\nafter=%q", before, after)
+	}
+	if _, err := os.Stat(filepath.Join(root, "contracts", "roots", "joined")); !os.IsNotExist(err) {
+		t.Fatalf("unexpected write outside generated boundary: %v", err)
+	}
+}
+
+func TestGenerateFailurePreservesPreviousCompleteSet(t *testing.T) {
+	root := t.TempDir()
+	writeGenerationFixture(t, root, "contracts/root.json", `{"$id":"root","type":"object"}`)
+	input := contractjoiner.Input{RepositoryRoot: root, Roots: []string{"contracts/root.json"}}
+	if diagnostics := contractjoiner.Generate(input); len(diagnostics) != 0 {
+		t.Fatalf("initial Generate() diagnostics = %#v, want none", diagnostics)
+	}
+	before := generatedTree(t, root)
+
+	writeGenerationFixture(t, root, "contracts/broken.json", `{"$ref":"missing.json"}`)
+	diagnostics := contractjoiner.Generate(contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"contracts/root.json", "contracts/broken.json"},
+		Components:     []string{"contracts/missing.json"},
+	})
+	if len(diagnostics) != 1 || diagnostics[0].Code != "reference.missing" {
+		t.Fatalf("Generate(failure) diagnostics = %#v, want stable missing-reference diagnostic", diagnostics)
+	}
+	if after := generatedTree(t, root); !equalByteTrees(before, after) {
+		t.Fatalf("failed generation changed prior output:\nbefore=%q\nafter=%q", before, after)
+	}
+}
+
+func TestGenerateRequiresAtLeastOneRootWithoutChangingPreviousOutput(t *testing.T) {
+	root := t.TempDir()
+	writeGenerationFixture(t, root, "packages/api/generated/joined/existing.json", `{"existing":true}`)
+	before := generatedTree(t, root)
+
+	diagnostics := contractjoiner.Generate(contractjoiner.Input{RepositoryRoot: root})
+	if len(diagnostics) != 1 || diagnostics[0].Code != "generation.input" {
+		t.Fatalf("Generate(no roots) diagnostics = %#v, want generation.input", diagnostics)
+	}
+	if after := generatedTree(t, root); !equalByteTrees(before, after) {
+		t.Fatalf("empty generation changed prior output:\nbefore=%q\nafter=%q", before, after)
+	}
+}
+
+func TestGenerateRejectsSymlinkedOutputBoundaryOutsideRepository(t *testing.T) {
+	root := t.TempDir()
+	external := t.TempDir()
+	writeGenerationFixture(t, root, "contracts/root.json", `{"type":"object"}`)
+	packages := filepath.Join(root, "packages")
+	if err := os.Symlink(external, packages); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	diagnostics := contractjoiner.Generate(contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"contracts/root.json"},
+	})
+	if len(diagnostics) != 1 || diagnostics[0].Code != "generation.boundary" {
+		t.Fatalf("Generate(external output) diagnostics = %#v, want generation.boundary", diagnostics)
+	}
+	entries, err := os.ReadDir(external)
+	if err != nil {
+		t.Fatalf("read external directory: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("generation wrote outside repository: %v", entries)
+	}
+}
+
+func generatedTree(t *testing.T, root string) map[string][]byte {
+	t.Helper()
+	result := map[string][]byte{}
+	base := filepath.Join(root, filepath.FromSlash(joinedDirectory))
+	err := filepath.WalkDir(base, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		result[filepath.ToSlash(relative)] = content
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk generated tree: %v", err)
+	}
+	return result
+}
+
+func authoredGenerationBytes(t *testing.T, root string) map[string][]byte {
+	t.Helper()
+	result := map[string][]byte{}
+	err := filepath.WalkDir(filepath.Join(root, "contracts"), func(path string, entry os.DirEntry, err error) error {
+		if err != nil || entry.IsDir() {
+			return err
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		result[filepath.ToSlash(relative)] = content
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("read authored inputs: %v", err)
+	}
+	return result
+}
+
+func equalByteTrees(left, right map[string][]byte) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for path, leftContent := range left {
+		if !bytes.Equal(leftContent, right[path]) {
+			return false
+		}
+	}
+	return true
+}
+
+func writeGenerationFixture(t *testing.T, root, path, contents string) {
+	t.Helper()
+	target := filepath.Join(root, filepath.FromSlash(path))
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("create fixture directory: %v", err)
+	}
+	if err := os.WriteFile(target, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+}

--- a/internal/contractjoiner/generate_test.go
+++ b/internal/contractjoiner/generate_test.go
@@ -99,6 +99,32 @@ func TestGenerateUnsupportedReferenceKeywordPreservesPreviousCompleteSet(t *test
 	}
 }
 
+func TestGenerateMalformedJSONPointerPreservesPreviousCompleteSet(t *testing.T) {
+	root := t.TempDir()
+	writeGenerationFixture(t, root, "contracts/root.json", `{"$id":"root","type":"object"}`)
+	if diagnostics := contractjoiner.Generate(contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"contracts/root.json"},
+	}); len(diagnostics) != 0 {
+		t.Fatalf("initial Generate() diagnostics = %#v, want none", diagnostics)
+	}
+	before := generatedTree(t, root)
+
+	writeGenerationFixture(t, root, "contracts/broken.json", `{"value":{"$ref":"pointers.json#/foo~2bar"}}`)
+	writeGenerationFixture(t, root, "contracts/pointers.json", `{"foo~2bar":{"type":"string"}}`)
+	diagnostics := contractjoiner.Generate(contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"contracts/root.json", "contracts/broken.json"},
+		Components:     []string{"contracts/pointers.json"},
+	})
+	if len(diagnostics) != 1 || diagnostics[0].Code != "reference.fragment" || diagnostics[0].Path != "/value/$ref" {
+		t.Fatalf("Generate(malformed pointer) diagnostics = %#v, want stable fragment diagnostic", diagnostics)
+	}
+	if after := generatedTree(t, root); !equalByteTrees(before, after) {
+		t.Fatalf("malformed-pointer generation changed prior output:\nbefore=%q\nafter=%q", before, after)
+	}
+}
+
 func TestGenerateResourceCollisionPreservesPreviousCompleteSet(t *testing.T) {
 	root := t.TempDir()
 	writeGenerationFixture(t, root, "contracts/root.json", `{"$id":"root","type":"object"}`)

--- a/internal/contractjoiner/generate_test.go
+++ b/internal/contractjoiner/generate_test.go
@@ -99,6 +99,38 @@ func TestGenerateUnsupportedReferenceKeywordPreservesPreviousCompleteSet(t *test
 	}
 }
 
+func TestGenerateResourceCollisionPreservesPreviousCompleteSet(t *testing.T) {
+	root := t.TempDir()
+	writeGenerationFixture(t, root, "contracts/root.json", `{"$id":"root","type":"object"}`)
+	if diagnostics := contractjoiner.Generate(contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"contracts/root.json"},
+	}); len(diagnostics) != 0 {
+		t.Fatalf("initial Generate() diagnostics = %#v, want none", diagnostics)
+	}
+	before := generatedTree(t, root)
+
+	writeGenerationFixture(t, root, "contracts/collision.json", `{
+  "properties":{
+    "a":{"$ref":"a.json"},
+    "b":{"$ref":"b.json"}
+  }
+}`)
+	writeGenerationFixture(t, root, "contracts/a.json", `{"$id":"https://schemas.example.test/item.json","type":"string"}`)
+	writeGenerationFixture(t, root, "contracts/b.json", `{"$id":"https://schemas.example.test/item.json","type":"integer"}`)
+	diagnostics := contractjoiner.Generate(contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"contracts/collision.json"},
+		Components:     []string{"contracts/a.json", "contracts/b.json"},
+	})
+	if len(diagnostics) != 1 || diagnostics[0].Code != "reference.resource_collision" || diagnostics[0].Document != "contracts/b.json" || diagnostics[0].Path != "/$id" {
+		t.Fatalf("Generate(resource collision) diagnostics = %#v, want stable resource-collision diagnostic", diagnostics)
+	}
+	if after := generatedTree(t, root); !equalByteTrees(before, after) {
+		t.Fatalf("resource-collision generation changed prior output:\nbefore=%q\nafter=%q", before, after)
+	}
+}
+
 func TestGenerateRequiresAtLeastOneRootWithoutChangingPreviousOutput(t *testing.T) {
 	root := t.TempDir()
 	writeGenerationFixture(t, root, "packages/api/generated/joined/existing.json", `{"existing":true}`)

--- a/internal/contractjoiner/generate_test.go
+++ b/internal/contractjoiner/generate_test.go
@@ -77,6 +77,28 @@ func TestGenerateFailurePreservesPreviousCompleteSet(t *testing.T) {
 	}
 }
 
+func TestGenerateUnsupportedReferenceKeywordPreservesPreviousCompleteSet(t *testing.T) {
+	root := t.TempDir()
+	writeGenerationFixture(t, root, "contracts/root.json", `{"$id":"root","type":"object"}`)
+	input := contractjoiner.Input{RepositoryRoot: root, Roots: []string{"contracts/root.json"}}
+	if diagnostics := contractjoiner.Generate(input); len(diagnostics) != 0 {
+		t.Fatalf("initial Generate() diagnostics = %#v, want none", diagnostics)
+	}
+	before := generatedTree(t, root)
+
+	writeGenerationFixture(t, root, "contracts/dynamic.json", `{"nested":{"$dynamicRef":"https://example.test/external.json#node"}}`)
+	diagnostics := contractjoiner.Generate(contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"contracts/root.json", "contracts/dynamic.json"},
+	})
+	if len(diagnostics) != 1 || diagnostics[0].Code != "reference.unsupported" || diagnostics[0].Path != "/nested/$dynamicRef" {
+		t.Fatalf("Generate(dynamic reference) diagnostics = %#v, want stable unsupported-reference diagnostic", diagnostics)
+	}
+	if after := generatedTree(t, root); !equalByteTrees(before, after) {
+		t.Fatalf("failed generation changed prior output:\nbefore=%q\nafter=%q", before, after)
+	}
+}
+
 func TestGenerateRequiresAtLeastOneRootWithoutChangingPreviousOutput(t *testing.T) {
 	root := t.TempDir()
 	writeGenerationFixture(t, root, "packages/api/generated/joined/existing.json", `{"existing":true}`)

--- a/internal/contractjoiner/joiner.go
+++ b/internal/contractjoiner/joiner.go
@@ -1,0 +1,62 @@
+// Package contractjoiner builds portable contract documents from explicit
+// repository-authored roots and components. It is build tooling and must not be
+// imported by runtime packages.
+package contractjoiner
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/portpowered/infinite-you/internal/contractvalidator"
+)
+
+// Input identifies the repository boundary and the complete authored set for
+// one join operation. Roots become joined documents; Components are permitted
+// reference targets but do not produce independent outputs.
+type Input struct {
+	RepositoryRoot string
+	Roots          []string
+	Components     []string
+}
+
+// Document is one in-memory, self-contained joined contract document.
+type Document struct {
+	Path  string
+	Value any
+}
+
+// Join resolves every root against only the explicit authored input set. The
+// operation performs no writes and returns documents in repository-path order.
+func Join(input Input) ([]Document, []contractvalidator.Diagnostic) {
+	authored := normalizedUniquePaths(append(append([]string(nil), input.Roots...), input.Components...))
+	roots := normalizedUniquePaths(input.Roots)
+	documents := make([]Document, 0, len(roots))
+	var diagnostics []contractvalidator.Diagnostic
+	for _, root := range roots {
+		value, issues := contractvalidator.LoadAndResolve(input.RepositoryRoot, root, authored)
+		if len(issues) != 0 {
+			diagnostics = append(diagnostics, issues...)
+			continue
+		}
+		documents = append(documents, Document{Path: root, Value: value})
+	}
+	if len(diagnostics) != 0 {
+		return nil, diagnostics
+	}
+	return documents, nil
+}
+
+func normalizedUniquePaths(paths []string) []string {
+	unique := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		normalized := filepath.ToSlash(filepath.Clean(filepath.FromSlash(strings.ReplaceAll(path, `\`, "/"))))
+		unique[normalized] = struct{}{}
+	}
+	result := make([]string, 0, len(unique))
+	for path := range unique {
+		result = append(result, path)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/internal/contractjoiner/joiner.go
+++ b/internal/contractjoiner/joiner.go
@@ -11,6 +11,8 @@ import (
 	"github.com/portpowered/infinite-you/internal/contractvalidator"
 )
 
+const joinedOutputDirectory = "packages/api/generated/joined"
+
 // Input identifies the repository boundary and the complete authored set for
 // one join operation. Roots become joined documents; Components are permitted
 // reference targets but do not produce independent outputs.
@@ -31,6 +33,9 @@ type Document struct {
 func Join(input Input) ([]Document, []contractvalidator.Diagnostic) {
 	authored := normalizedUniquePaths(append(append([]string(nil), input.Roots...), input.Components...))
 	roots := normalizedUniquePaths(input.Roots)
+	if diagnostics := contractvalidator.ValidateAuthoredPaths(input.RepositoryRoot, authored, joinedOutputDirectory); len(diagnostics) != 0 {
+		return nil, diagnostics
+	}
 	documents := make([]Document, 0, len(roots))
 	var diagnostics []contractvalidator.Diagnostic
 	for _, root := range roots {
@@ -42,6 +47,7 @@ func Join(input Input) ([]Document, []contractvalidator.Diagnostic) {
 		documents = append(documents, Document{Path: root, Value: value})
 	}
 	if len(diagnostics) != 0 {
+		contractvalidator.SortDiagnostics(diagnostics)
 		return nil, diagnostics
 	}
 	return documents, nil

--- a/internal/contractjoiner/joiner_test.go
+++ b/internal/contractjoiner/joiner_test.go
@@ -180,6 +180,118 @@ func TestJoinDeduplicatesSharedStableIDResourceAndPreservesValidation(t *testing
 	}
 }
 
+func TestJoinDistinguishesRelativeResourceIDsUnderDifferentBases(t *testing.T) {
+	root := t.TempDir()
+	paths := []string{
+		"contracts/root.json",
+		"contracts/a/base.json",
+		"contracts/a/item.json",
+		"contracts/b/base.json",
+		"contracts/b/item.json",
+	}
+	writeFile(t, root, paths[0], `{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://schemas.example.test/root.json",
+  "type":"object",
+  "required":["a","b"],
+  "properties":{
+    "a":{"$ref":"a/base.json"},
+    "b":{"$ref":"b/base.json"}
+  }
+}`)
+	writeFile(t, root, paths[1], `{
+  "$id":"https://schemas.example.test/a/",
+  "type":"object",
+  "required":["first","second"],
+  "properties":{"first":{"$ref":"item.json"},"second":{"$ref":"item.json"}}
+}`)
+	writeFile(t, root, paths[2], `{"$id":"item.json","type":"string","minLength":2}`)
+	writeFile(t, root, paths[3], `{
+  "$id":"https://schemas.example.test/b/",
+  "type":"object",
+  "required":["first","second"],
+  "properties":{"first":{"$ref":"item.json"},"second":{"$ref":"item.json"}}
+}`)
+	writeFile(t, root, paths[4], `{"$id":"item.json","type":"integer","minimum":10}`)
+
+	input := contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          paths[:1],
+		Components:     paths[1:],
+	}
+	before := joinDocuments(t, input)[0].Value
+	if got := countResourceID(before, "item.json"); got != 2 {
+		t.Fatalf("distinct relative item resource count = %d, want 2", got)
+	}
+	joinedProperties := object(t, object(t, before)["properties"])
+	for property, want := range map[string]string{
+		"a": "https://schemas.example.test/a/item.json",
+		"b": "https://schemas.example.test/b/item.json",
+	} {
+		baseProperties := object(t, object(t, joinedProperties[property])["properties"])
+		if got := object(t, baseProperties["second"])["$ref"]; got != want {
+			t.Fatalf("joined %s repeated resource reference = %v, want %s", property, got, want)
+		}
+	}
+	assertDistinctRelativeResourcesValidate(t, before)
+
+	beforeProperties := joinedProperties
+	beforeA := canonicalValue(t, beforeProperties["a"])
+	beforeB := canonicalValue(t, beforeProperties["b"])
+
+	writeFile(t, root, paths[2], `{"$id":"item.json","type":"string","minLength":3}`)
+	aEdited := joinDocuments(t, input)[0].Value
+	aProperties := object(t, object(t, aEdited)["properties"])
+	if bytes.Equal(beforeA, canonicalValue(t, aProperties["a"])) {
+		t.Fatal("editing a/item.json did not change its consumer")
+	}
+	if !bytes.Equal(beforeB, canonicalValue(t, aProperties["b"])) {
+		t.Fatal("editing a/item.json changed the distinct b resource")
+	}
+
+	writeFile(t, root, paths[4], `{"$id":"item.json","type":"integer","minimum":20}`)
+	bEdited := joinDocuments(t, input)[0].Value
+	bProperties := object(t, object(t, bEdited)["properties"])
+	if !bytes.Equal(canonicalValue(t, aProperties["a"]), canonicalValue(t, bProperties["a"])) {
+		t.Fatal("editing b/item.json changed the distinct a resource")
+	}
+	if bytes.Equal(canonicalValue(t, aProperties["b"]), canonicalValue(t, bProperties["b"])) {
+		t.Fatal("editing b/item.json did not change its consumer")
+	}
+}
+
+func assertDistinctRelativeResourcesValidate(t *testing.T, value any) {
+	t.Helper()
+	schema := compileJoinedSchema(t, value)
+	for _, test := range []struct {
+		name  string
+		value any
+		valid bool
+	}{
+		{name: "both resources pass", value: map[string]any{"a": map[string]any{"first": "aa", "second": "bb"}, "b": map[string]any{"first": 10, "second": 11}}, valid: true},
+		{name: "a first fails", value: map[string]any{"a": map[string]any{"first": "a", "second": "bb"}, "b": map[string]any{"first": 10, "second": 11}}, valid: false},
+		{name: "a repeated use fails", value: map[string]any{"a": map[string]any{"first": "aa", "second": 2}, "b": map[string]any{"first": 10, "second": 11}}, valid: false},
+		{name: "b first fails", value: map[string]any{"a": map[string]any{"first": "aa", "second": "bb"}, "b": map[string]any{"first": 9, "second": 11}}, valid: false},
+		{name: "b repeated use fails", value: map[string]any{"a": map[string]any{"first": "aa", "second": "bb"}, "b": map[string]any{"first": 10, "second": "wrong"}}, valid: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := schema.Validate(test.value)
+			if (err == nil) != test.valid {
+				t.Fatalf("Validate(%v) error = %v, want valid %t", test.value, err, test.valid)
+			}
+		})
+	}
+}
+
+func canonicalValue(t *testing.T, value any) []byte {
+	t.Helper()
+	contents, err := contractjoiner.MarshalCanonicalJSON(value)
+	if err != nil {
+		t.Fatalf("MarshalCanonicalJSON() error = %v", err)
+	}
+	return contents
+}
+
 func TestJoinPreservesAdjacentReferenceKeywordsAndTheirSemantics(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, root, "contracts/root.json", `{

--- a/internal/contractjoiner/joiner_test.go
+++ b/internal/contractjoiner/joiner_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -58,6 +59,7 @@ func TestCanonicalJoinedJSONMatchesGoldenAcrossRepeatedAndShuffledInputs(t *test
 	if got := first[0].JSON; !bytes.Equal(got, golden) {
 		t.Fatalf("canonical catalog differs from golden:\ngot:\n%s\nwant:\n%s", got, golden)
 	}
+	compileJoinedSchema(t, joinDocuments(t, input)[0].Value)
 }
 
 type serializedDocument struct {
@@ -112,16 +114,70 @@ func TestJoinBuildsPortableDocumentsFromNestedSharedComponents(t *testing.T) {
 	primary := object(t, properties["primary"])
 	secondary := object(t, properties["secondary"])
 	assertPortableWidget(t, primary)
-	assertPortableWidget(t, secondary)
-	if !reflect.DeepEqual(primary, secondary) {
-		t.Fatalf("shared component joined inconsistently:\nprimary=%v\nsecondary=%v", primary, secondary)
+	if got := secondary["$ref"]; got != "https://schemas.example.test/widget.json" {
+		t.Fatalf("repeated shared component reference = %v, want stable internal resource ID", got)
 	}
 	if got := primary["$id"]; got != "https://schemas.example.test/widget.json" {
 		t.Fatalf("joined component $id = %v", got)
 	}
+	if got := countResourceID(alpha, "https://schemas.example.test/widget.json"); got != 1 {
+		t.Fatalf("joined widget resource count = %d, want 1", got)
+	}
 	beta := object(t, documents[1].Value)
 	assertPortableWidget(t, object(t, beta["items"]))
-	assertNoReferences(t, documents)
+	compileJoinedSchema(t, alpha)
+	compileJoinedSchema(t, beta)
+}
+
+func TestJoinDeduplicatesSharedStableIDResourceAndPreservesValidation(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "contracts/root.json", `{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://schemas.example.test/root.json",
+  "type":"object",
+  "required":["a","b"],
+  "properties":{
+    "a":{"$ref":"component.json"},
+    "b":{"$ref":"component.json"}
+  }
+}`)
+	writeFile(t, root, "contracts/component.json", `{
+  "$id":"https://schemas.example.test/component.json",
+  "type":"string",
+  "minLength":2
+}`)
+
+	documents, diagnostics := contractjoiner.Join(contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"contracts/root.json"},
+		Components:     []string{"contracts/component.json"},
+	})
+	if len(diagnostics) != 0 {
+		t.Fatalf("Join() diagnostics = %+v, want none", diagnostics)
+	}
+	joined := documents[0].Value
+	if got := countResourceID(joined, "https://schemas.example.test/component.json"); got != 1 {
+		t.Fatalf("joined component resource count = %d, want 1", got)
+	}
+
+	schema := compileJoinedSchema(t, joined)
+	for _, test := range []struct {
+		name  string
+		value any
+		valid bool
+	}{
+		{name: "both shared uses pass", value: map[string]any{"a": "aa", "b": "bb"}, valid: true},
+		{name: "first use fails", value: map[string]any{"a": "a", "b": "bb"}, valid: false},
+		{name: "second use fails", value: map[string]any{"a": "aa", "b": 2}, valid: false},
+		{name: "required use fails", value: map[string]any{"a": "aa"}, valid: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := schema.Validate(test.value)
+			if (err == nil) != test.valid {
+				t.Fatalf("Validate(%v) error = %v, want valid %t", test.value, err, test.valid)
+			}
+		})
+	}
 }
 
 func TestJoinPreservesAdjacentReferenceKeywordsAndTheirSemantics(t *testing.T) {
@@ -154,17 +210,7 @@ func TestJoinPreservesAdjacentReferenceKeywordsAndTheirSemantics(t *testing.T) {
 	if got := joined["maxProperties"]; got != json.Number("1") {
 		t.Fatalf("joined adjacent assertion = %v, want maxProperties 1", got)
 	}
-	assertNoReferences(t, documents)
-
-	compiler := jsonschema.NewCompiler()
-	compiler.DefaultDraft(jsonschema.Draft2020)
-	if err := compiler.AddResource("joined.json", joined); err != nil {
-		t.Fatalf("add joined schema: %v", err)
-	}
-	schema, err := compiler.Compile("joined.json")
-	if err != nil {
-		t.Fatalf("compile joined schema: %v", err)
-	}
+	schema := compileJoinedSchema(t, joined)
 	for _, test := range []struct {
 		name  string
 		value any
@@ -242,17 +288,6 @@ func assertPortableWidget(t *testing.T, value map[string]any) {
 	}
 }
 
-func assertNoReferences(t *testing.T, documents []contractjoiner.Document) {
-	t.Helper()
-	for _, document := range documents {
-		walkJSON(document.Value, func(value map[string]any) {
-			if reference, ok := value["$ref"]; ok {
-				t.Fatalf("joined document %s retained $ref %v", document.Path, reference)
-			}
-		})
-	}
-}
-
 func walkJSON(value any, visit func(map[string]any)) {
 	switch typed := value.(type) {
 	case map[string]any:
@@ -265,6 +300,37 @@ func walkJSON(value any, visit func(map[string]any)) {
 			walkJSON(child, visit)
 		}
 	}
+}
+
+func countResourceID(value any, identifier string) int {
+	count := 0
+	walkJSON(value, func(object map[string]any) {
+		if object["$id"] == identifier {
+			count++
+		}
+	})
+	return count
+}
+
+type rejectingLoader struct{}
+
+func (rejectingLoader) Load(resourceURL string) (any, error) {
+	return nil, fmt.Errorf("unexpected external schema load: %s", resourceURL)
+}
+
+func compileJoinedSchema(t *testing.T, value any) *jsonschema.Schema {
+	t.Helper()
+	compiler := jsonschema.NewCompiler()
+	compiler.DefaultDraft(jsonschema.Draft2020)
+	compiler.UseLoader(rejectingLoader{})
+	if err := compiler.AddResource("joined.json", value); err != nil {
+		t.Fatalf("add joined schema: %v", err)
+	}
+	schema, err := compiler.Compile("joined.json")
+	if err != nil {
+		t.Fatalf("compile joined schema without external loading: %v", err)
+	}
+	return schema
 }
 
 func object(t *testing.T, value any) map[string]any {
@@ -299,10 +365,7 @@ func documentJSON(t *testing.T, documents []contractjoiner.Document) map[string]
 
 func joinAndMarshal(t *testing.T, input contractjoiner.Input) []serializedDocument {
 	t.Helper()
-	documents, diagnostics := contractjoiner.Join(input)
-	if len(diagnostics) != 0 {
-		t.Fatalf("Join() diagnostics = %+v, want none", diagnostics)
-	}
+	documents := joinDocuments(t, input)
 	result := make([]serializedDocument, 0, len(documents))
 	for _, document := range documents {
 		contents, err := contractjoiner.MarshalCanonicalJSON(document.Value)
@@ -312,6 +375,15 @@ func joinAndMarshal(t *testing.T, input contractjoiner.Input) []serializedDocume
 		result = append(result, serializedDocument{Path: document.Path, JSON: contents})
 	}
 	return result
+}
+
+func joinDocuments(t *testing.T, input contractjoiner.Input) []contractjoiner.Document {
+	t.Helper()
+	documents, diagnostics := contractjoiner.Join(input)
+	if len(diagnostics) != 0 {
+		t.Fatalf("Join() diagnostics = %+v, want none", diagnostics)
+	}
+	return documents
 }
 
 func serializedDocumentPaths(documents []serializedDocument) []string {

--- a/internal/contractjoiner/joiner_test.go
+++ b/internal/contractjoiner/joiner_test.go
@@ -299,6 +299,65 @@ func TestJoinPreservesRetrievalBaseForNestedRelativeResourceID(t *testing.T) {
 	}
 }
 
+func TestJoinDeduplicatesRelocatedIDLessResourceWithNestedRelativeID(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "contracts/roots/root.json", `{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://schemas.example.test/roots/root.json",
+  "type":"object",
+  "required":["first","second"],
+  "properties":{
+    "first":{"$ref":"../components/container.json"},
+    "second":{"$ref":"../components/container.json"}
+  }
+}`)
+	writeFile(t, root, "contracts/components/container.json", `{
+  "type":"object",
+  "required":["value"],
+  "$defs":{"item":{"$id":"item.json","type":"string","minLength":2}},
+  "properties":{"value":{"$ref":"#/$defs/item"}}
+}`)
+
+	documents, diagnostics := contractjoiner.Join(contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"contracts/roots/root.json"},
+		Components:     []string{"contracts/components/container.json"},
+	})
+	if len(diagnostics) != 0 {
+		t.Fatalf("Join() diagnostics = %+v, want none", diagnostics)
+	}
+	joined := documents[0].Value
+	relocationID := "https://schemas.example.test/components/container.json?you-join-source=contracts%2Fcomponents%2Fcontainer.json%23"
+	if got := countResourceID(joined, relocationID); got != 1 {
+		t.Fatalf("joined synthetic relocation resource count = %d, want 1", got)
+	}
+	if got := countResourceID(joined, "item.json"); got != 1 {
+		t.Fatalf("joined authored nested resource count = %d, want 1", got)
+	}
+	properties := object(t, object(t, joined)["properties"])
+	if got := object(t, properties["second"])["$ref"]; got != relocationID {
+		t.Fatalf("repeated relocated resource reference = %v, want %s", got, relocationID)
+	}
+
+	schema := compileJoinedSchema(t, joined)
+	for _, test := range []struct {
+		name  string
+		value any
+		valid bool
+	}{
+		{name: "both relocated uses pass", value: map[string]any{"first": map[string]any{"value": "aa"}, "second": map[string]any{"value": "bb"}}, valid: true},
+		{name: "first relocated use fails", value: map[string]any{"first": map[string]any{"value": "a"}, "second": map[string]any{"value": "bb"}}, valid: false},
+		{name: "second relocated use fails", value: map[string]any{"first": map[string]any{"value": "aa"}, "second": map[string]any{"value": 2}}, valid: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := schema.Validate(test.value)
+			if (err == nil) != test.valid {
+				t.Fatalf("Validate(%v) error = %v, want valid %t", test.value, err, test.valid)
+			}
+		})
+	}
+}
+
 func TestJoinResolvesFragmentsWithinSelectedSchemaResourceScope(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, root, "contracts/roots/root.json", `{

--- a/internal/contractjoiner/joiner_test.go
+++ b/internal/contractjoiner/joiner_test.go
@@ -1,0 +1,207 @@
+package contractjoiner_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/contractjoiner"
+)
+
+func TestJoinBuildsPortableDocumentsFromNestedSharedComponents(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "contracts/roots/alpha.json", `{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://schemas.example.test/alpha.json",
+  "properties":{
+    "primary":{"$ref":"../components/collection.json#/$defs/widget"},
+    "secondary":{"$ref":"../components/widget.json"}
+  }
+}`)
+	writeFile(t, root, "contracts/roots/beta.json", `{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://schemas.example.test/beta.json",
+  "items":{"$ref":"../components/widget.json"}
+}`)
+	writeFile(t, root, "contracts/components/collection.json", `{
+  "$id":"https://schemas.example.test/collection.json",
+  "$defs":{"widget":{"$ref":"widget.json"}}
+}`)
+	writeFile(t, root, "contracts/components/widget.json", `{
+  "$id":"https://schemas.example.test/widget.json",
+  "type":"object",
+  "properties":{"name":{"type":"string"}}
+}`)
+
+	documents, diagnostics := contractjoiner.Join(contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"contracts/roots/beta.json", "contracts/roots/alpha.json"},
+		Components: []string{
+			"contracts/components/widget.json",
+			"contracts/components/collection.json",
+		},
+	})
+	if len(diagnostics) != 0 {
+		t.Fatalf("Join() diagnostics = %+v, want none", diagnostics)
+	}
+	if got, want := documentPaths(documents), []string{"contracts/roots/alpha.json", "contracts/roots/beta.json"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Join() document paths = %v, want %v", got, want)
+	}
+	alpha := object(t, documents[0].Value)
+	if got := alpha["$id"]; got != "https://schemas.example.test/alpha.json" {
+		t.Fatalf("joined root $id = %v", got)
+	}
+	properties := object(t, alpha["properties"])
+	primary := object(t, properties["primary"])
+	secondary := object(t, properties["secondary"])
+	assertPortableWidget(t, primary)
+	assertPortableWidget(t, secondary)
+	if !reflect.DeepEqual(primary, secondary) {
+		t.Fatalf("shared component joined inconsistently:\nprimary=%v\nsecondary=%v", primary, secondary)
+	}
+	if got := primary["$id"]; got != "https://schemas.example.test/widget.json" {
+		t.Fatalf("joined component $id = %v", got)
+	}
+	beta := object(t, documents[1].Value)
+	assertPortableWidget(t, object(t, beta["items"]))
+	assertNoReferences(t, documents)
+}
+
+func TestJoinPropagatesComponentEditsOnlyToConsumersAndPreservesInputs(t *testing.T) {
+	root := t.TempDir()
+	paths := []string{
+		"contracts/roots/consumer-a.json",
+		"contracts/roots/consumer-b.json",
+		"contracts/roots/unaffected.json",
+		"contracts/components/shared.json",
+	}
+	writeFile(t, root, paths[0], `{"value":{"$ref":"../components/shared.json"}}`)
+	writeFile(t, root, paths[1], `{"nested":{"value":{"$ref":"../components/shared.json"}}}`)
+	writeFile(t, root, paths[2], `{"type":"boolean"}`)
+	writeFile(t, root, paths[3], `{"$id":"https://schemas.example.test/shared.json","type":"string"}`)
+	beforeInputs := readFiles(t, root, paths)
+
+	input := contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          paths[:3],
+		Components:     paths[3:],
+	}
+	before, diagnostics := contractjoiner.Join(input)
+	if len(diagnostics) != 0 {
+		t.Fatalf("first Join() diagnostics = %+v", diagnostics)
+	}
+	if got := readFiles(t, root, paths); !reflect.DeepEqual(got, beforeInputs) {
+		t.Fatal("Join() mutated authored inputs")
+	}
+
+	writeFile(t, root, paths[3], `{"$id":"https://schemas.example.test/shared.json","type":"number"}`)
+	after, diagnostics := contractjoiner.Join(input)
+	if len(diagnostics) != 0 {
+		t.Fatalf("second Join() diagnostics = %+v", diagnostics)
+	}
+	beforeJSON := documentJSON(t, before)
+	afterJSON := documentJSON(t, after)
+	for _, consumer := range paths[:2] {
+		if reflect.DeepEqual(beforeJSON[consumer], afterJSON[consumer]) {
+			t.Fatalf("component edit did not change consumer %s", consumer)
+		}
+	}
+	if !reflect.DeepEqual(beforeJSON[paths[2]], afterJSON[paths[2]]) {
+		t.Fatalf("component edit changed unaffected document %s", paths[2])
+	}
+	if got := readFiles(t, root, paths[:3]); !reflect.DeepEqual(got, beforeInputs[:3]) {
+		t.Fatal("regeneration mutated authored roots")
+	}
+}
+
+func assertPortableWidget(t *testing.T, value map[string]any) {
+	t.Helper()
+	if got := value["type"]; got != "object" {
+		t.Fatalf("joined component type = %v, want object", got)
+	}
+	name := object(t, object(t, value["properties"])["name"])
+	if got := name["type"]; got != "string" {
+		t.Fatalf("nested property type = %v, want string", got)
+	}
+}
+
+func assertNoReferences(t *testing.T, documents []contractjoiner.Document) {
+	t.Helper()
+	for _, document := range documents {
+		walkJSON(document.Value, func(value map[string]any) {
+			if reference, ok := value["$ref"]; ok {
+				t.Fatalf("joined document %s retained $ref %v", document.Path, reference)
+			}
+		})
+	}
+}
+
+func walkJSON(value any, visit func(map[string]any)) {
+	switch typed := value.(type) {
+	case map[string]any:
+		visit(typed)
+		for _, child := range typed {
+			walkJSON(child, visit)
+		}
+	case []any:
+		for _, child := range typed {
+			walkJSON(child, visit)
+		}
+	}
+}
+
+func object(t *testing.T, value any) map[string]any {
+	t.Helper()
+	result, ok := value.(map[string]any)
+	if !ok {
+		t.Fatalf("value = %T, want JSON object", value)
+	}
+	return result
+}
+
+func documentPaths(documents []contractjoiner.Document) []string {
+	paths := make([]string, len(documents))
+	for i, document := range documents {
+		paths[i] = document.Path
+	}
+	return paths
+}
+
+func documentJSON(t *testing.T, documents []contractjoiner.Document) map[string][]byte {
+	t.Helper()
+	result := make(map[string][]byte, len(documents))
+	for _, document := range documents {
+		value, err := json.Marshal(document.Value)
+		if err != nil {
+			t.Fatalf("marshal %s: %v", document.Path, err)
+		}
+		result[document.Path] = value
+	}
+	return result
+}
+
+func readFiles(t *testing.T, root string, paths []string) [][]byte {
+	t.Helper()
+	result := make([][]byte, len(paths))
+	for i, path := range paths {
+		value, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(path)))
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		result[i] = value
+	}
+	return result
+}
+
+func writeFile(t *testing.T, root, path, contents string) {
+	t.Helper()
+	absolute := filepath.Join(root, filepath.FromSlash(path))
+	if err := os.MkdirAll(filepath.Dir(absolute), 0o700); err != nil {
+		t.Fatalf("create parent for %s: %v", path, err)
+	}
+	if err := os.WriteFile(absolute, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/contractjoiner/joiner_test.go
+++ b/internal/contractjoiner/joiner_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/portpowered/infinite-you/internal/contractjoiner"
+	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
 func TestCanonicalJoinedJSONMatchesGoldenAcrossRepeatedAndShuffledInputs(t *testing.T) {
@@ -121,6 +122,66 @@ func TestJoinBuildsPortableDocumentsFromNestedSharedComponents(t *testing.T) {
 	beta := object(t, documents[1].Value)
 	assertPortableWidget(t, object(t, beta["items"]))
 	assertNoReferences(t, documents)
+}
+
+func TestJoinPreservesAdjacentReferenceKeywordsAndTheirSemantics(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "contracts/root.json", `{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://schemas.example.test/stable-root.json",
+  "$ref":"component.json",
+  "maxProperties":1,
+  "allOf":[{"required":["name"]}]
+}`)
+	writeFile(t, root, "contracts/component.json", `{
+  "$id":"https://schemas.example.test/component.json",
+  "type":"object",
+  "properties":{"name":{"type":"string"}}
+}`)
+
+	documents, diagnostics := contractjoiner.Join(contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"contracts/root.json"},
+		Components:     []string{"contracts/component.json"},
+	})
+	if len(diagnostics) != 0 {
+		t.Fatalf("Join() diagnostics = %+v, want none", diagnostics)
+	}
+	joined := object(t, documents[0].Value)
+	if got := joined["$id"]; got != "https://schemas.example.test/stable-root.json" {
+		t.Fatalf("joined adjacent $id = %v, want stable root ID", got)
+	}
+	if got := joined["maxProperties"]; got != json.Number("1") {
+		t.Fatalf("joined adjacent assertion = %v, want maxProperties 1", got)
+	}
+	assertNoReferences(t, documents)
+
+	compiler := jsonschema.NewCompiler()
+	compiler.DefaultDraft(jsonschema.Draft2020)
+	if err := compiler.AddResource("joined.json", joined); err != nil {
+		t.Fatalf("add joined schema: %v", err)
+	}
+	schema, err := compiler.Compile("joined.json")
+	if err != nil {
+		t.Fatalf("compile joined schema: %v", err)
+	}
+	for _, test := range []struct {
+		name  string
+		value any
+		valid bool
+	}{
+		{name: "both conjuncts pass", value: map[string]any{"name": "widget"}, valid: true},
+		{name: "referenced type fails", value: "widget", valid: false},
+		{name: "adjacent required fails", value: map[string]any{}, valid: false},
+		{name: "adjacent maximum fails", value: map[string]any{"name": "widget", "extra": true}, valid: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := schema.Validate(test.value)
+			if (err == nil) != test.valid {
+				t.Fatalf("Validate(%v) error = %v, want valid %t", test.value, err, test.valid)
+			}
+		})
+	}
 }
 
 func TestJoinPropagatesComponentEditsOnlyToConsumersAndPreservesInputs(t *testing.T) {

--- a/internal/contractjoiner/joiner_test.go
+++ b/internal/contractjoiner/joiner_test.go
@@ -1,6 +1,8 @@
 package contractjoiner_test
 
 import (
+	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -9,6 +11,58 @@ import (
 
 	"github.com/portpowered/infinite-you/internal/contractjoiner"
 )
+
+func TestCanonicalJoinedJSONMatchesGoldenAcrossRepeatedAndShuffledInputs(t *testing.T) {
+	input := contractjoiner.Input{
+		RepositoryRoot: ".",
+		Roots: []string{
+			"testdata/canonical/roots/standalone.json",
+			"testdata/canonical/roots/catalog.json",
+		},
+		Components: []string{
+			"testdata/canonical/components/scalar.json",
+			"testdata/canonical/components/shared.json",
+		},
+	}
+
+	first := joinAndMarshal(t, input)
+	second := joinAndMarshal(t, input)
+	shuffled := joinAndMarshal(t, contractjoiner.Input{
+		RepositoryRoot: input.RepositoryRoot,
+		Roots:          reversed(input.Roots),
+		Components:     reversed(input.Components),
+	})
+	if !reflect.DeepEqual(first, second) {
+		t.Fatal("repeated generation produced different paths or bytes")
+	}
+	if !reflect.DeepEqual(first, shuffled) {
+		t.Fatal("shuffled inputs produced different paths or bytes")
+	}
+	if got, want := serializedDocumentPaths(first), []string{
+		"testdata/canonical/roots/catalog.json",
+		"testdata/canonical/roots/standalone.json",
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("canonical document paths = %v, want %v", got, want)
+	}
+	for index, document := range first {
+		if sha256.Sum256(document.JSON) != sha256.Sum256(second[index].JSON) {
+			t.Fatalf("repeated generation digest differs for %s", document.Path)
+		}
+	}
+
+	golden, err := os.ReadFile("testdata/canonical/golden/catalog.json")
+	if err != nil {
+		t.Fatalf("read golden file: %v", err)
+	}
+	if got := first[0].JSON; !bytes.Equal(got, golden) {
+		t.Fatalf("canonical catalog differs from golden:\ngot:\n%s\nwant:\n%s", got, golden)
+	}
+}
+
+type serializedDocument struct {
+	Path string
+	JSON []byte
+}
 
 func TestJoinBuildsPortableDocumentsFromNestedSharedComponents(t *testing.T) {
 	root := t.TempDir()
@@ -178,6 +232,39 @@ func documentJSON(t *testing.T, documents []contractjoiner.Document) map[string]
 			t.Fatalf("marshal %s: %v", document.Path, err)
 		}
 		result[document.Path] = value
+	}
+	return result
+}
+
+func joinAndMarshal(t *testing.T, input contractjoiner.Input) []serializedDocument {
+	t.Helper()
+	documents, diagnostics := contractjoiner.Join(input)
+	if len(diagnostics) != 0 {
+		t.Fatalf("Join() diagnostics = %+v, want none", diagnostics)
+	}
+	result := make([]serializedDocument, 0, len(documents))
+	for _, document := range documents {
+		contents, err := contractjoiner.MarshalCanonicalJSON(document.Value)
+		if err != nil {
+			t.Fatalf("MarshalCanonicalJSON(%s): %v", document.Path, err)
+		}
+		result = append(result, serializedDocument{Path: document.Path, JSON: contents})
+	}
+	return result
+}
+
+func serializedDocumentPaths(documents []serializedDocument) []string {
+	paths := make([]string, len(documents))
+	for index, document := range documents {
+		paths[index] = document.Path
+	}
+	return paths
+}
+
+func reversed(values []string) []string {
+	result := append([]string(nil), values...)
+	for left, right := 0, len(result)-1; left < right; left, right = left+1, right-1 {
+		result[left], result[right] = result[right], result[left]
 	}
 	return result
 }

--- a/internal/contractjoiner/joiner_test.go
+++ b/internal/contractjoiner/joiner_test.go
@@ -234,6 +234,71 @@ func TestJoinPreservesRelativeResourceIDWhenInliningAcrossBases(t *testing.T) {
 	}
 }
 
+func TestJoinPreservesRetrievalBaseForNestedRelativeResourceID(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "contracts/roots/root.json", `{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://schemas.example.test/roots/root.json",
+  "type":"object",
+  "required":["container"],
+  "properties":{"container":{"$ref":"../components/container.json"}}
+}`)
+	writeFile(t, root, "contracts/components/container.json", `{
+  "type":"object",
+  "required":["first","second"],
+  "$defs":{"item":{"$id":"item.json","type":"string","minLength":2}},
+  "properties":{
+    "first":{"$ref":"#/$defs/item"},
+    "second":{"$ref":"#/$defs/item"}
+  }
+}`)
+
+	documents, diagnostics := contractjoiner.Join(contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"contracts/roots/root.json"},
+		Components:     []string{"contracts/components/container.json"},
+	})
+	if len(diagnostics) != 0 {
+		t.Fatalf("Join() diagnostics = %+v, want none", diagnostics)
+	}
+	joined := documents[0].Value
+	if got := countResourceID(joined, "item.json"); got != 1 {
+		t.Fatalf("joined nested relative resource count = %d, want 1", got)
+	}
+	referenceCount := 0
+	walkJSON(joined, func(value map[string]any) {
+		reference, ok := value["$ref"]
+		if !ok {
+			return
+		}
+		referenceCount++
+		if reference != "https://schemas.example.test/components/item.json" {
+			t.Fatalf("joined nested resource reference = %v, want canonical embedded resource URI", reference)
+		}
+	})
+	if referenceCount != 2 {
+		t.Fatalf("joined nested resource reference count = %d, want 2", referenceCount)
+	}
+
+	schema := compileJoinedSchema(t, joined)
+	for _, test := range []struct {
+		name  string
+		value any
+		valid bool
+	}{
+		{name: "both uses pass", value: map[string]any{"container": map[string]any{"first": "aa", "second": "bb"}}, valid: true},
+		{name: "first use fails", value: map[string]any{"container": map[string]any{"first": "a", "second": "bb"}}, valid: false},
+		{name: "second use fails", value: map[string]any{"container": map[string]any{"first": "aa", "second": 2}}, valid: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := schema.Validate(test.value)
+			if (err == nil) != test.valid {
+				t.Fatalf("Validate(%v) error = %v, want valid %t", test.value, err, test.valid)
+			}
+		})
+	}
+}
+
 func TestJoinDistinguishesRelativeResourceIDsUnderDifferentBases(t *testing.T) {
 	root := t.TempDir()
 	paths := []string{

--- a/internal/contractjoiner/joiner_test.go
+++ b/internal/contractjoiner/joiner_test.go
@@ -299,6 +299,76 @@ func TestJoinPreservesRetrievalBaseForNestedRelativeResourceID(t *testing.T) {
 	}
 }
 
+func TestJoinResolvesFragmentsWithinSelectedSchemaResourceScope(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "contracts/roots/root.json", `{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://schemas.example.test/roots/root.json",
+  "type":"object",
+  "required":["group"],
+  "properties":{"group":{"$ref":"../components/component.json#/$defs/group"}}
+}`)
+	writeFile(t, root, "contracts/components/component.json", `{
+  "$id":"https://schemas.example.test/catalog/component.json",
+  "$defs":{
+    "group":{
+      "$id":"groups/group.json",
+      "type":"object",
+      "required":["first","second"],
+      "$defs":{"item":{"$id":"item.json","type":"string","minLength":2}},
+      "properties":{
+        "first":{"$ref":"#/$defs/item"},
+        "second":{"$ref":"#/$defs/item"}
+      }
+    }
+  }
+}`)
+
+	documents, diagnostics := contractjoiner.Join(contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"contracts/roots/root.json"},
+		Components:     []string{"contracts/components/component.json"},
+	})
+	if len(diagnostics) != 0 {
+		t.Fatalf("Join() diagnostics = %+v, want none", diagnostics)
+	}
+	joined := documents[0].Value
+	if got := countResourceID(joined, "groups/group.json"); got != 1 {
+		t.Fatalf("joined selected resource count = %d, want 1", got)
+	}
+	if got := countResourceID(joined, "item.json"); got != 1 {
+		t.Fatalf("joined selected descendant resource count = %d, want 1", got)
+	}
+	wantItemURI := "https://schemas.example.test/catalog/groups/item.json"
+	itemReferenceCount := 0
+	walkJSON(joined, func(value map[string]any) {
+		if value["$ref"] == wantItemURI {
+			itemReferenceCount++
+		}
+	})
+	if itemReferenceCount != 2 {
+		t.Fatalf("joined selected descendant reference count = %d, want 2 references to %s", itemReferenceCount, wantItemURI)
+	}
+
+	schema := compileJoinedSchema(t, joined)
+	for _, test := range []struct {
+		name  string
+		value any
+		valid bool
+	}{
+		{name: "both scoped fragment uses pass", value: map[string]any{"group": map[string]any{"first": "aa", "second": "bb"}}, valid: true},
+		{name: "first scoped fragment use fails", value: map[string]any{"group": map[string]any{"first": "a", "second": "bb"}}, valid: false},
+		{name: "second scoped fragment use fails", value: map[string]any{"group": map[string]any{"first": "aa", "second": 2}}, valid: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := schema.Validate(test.value)
+			if (err == nil) != test.valid {
+				t.Fatalf("Validate(%v) error = %v, want valid %t", test.value, err, test.valid)
+			}
+		})
+	}
+}
+
 func TestJoinDistinguishesRelativeResourceIDsUnderDifferentBases(t *testing.T) {
 	root := t.TempDir()
 	paths := []string{

--- a/internal/contractjoiner/joiner_test.go
+++ b/internal/contractjoiner/joiner_test.go
@@ -180,6 +180,60 @@ func TestJoinDeduplicatesSharedStableIDResourceAndPreservesValidation(t *testing
 	}
 }
 
+func TestJoinPreservesRelativeResourceIDWhenInliningAcrossBases(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "contracts/roots/root.json", `{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://schemas.example.test/roots/root.json",
+  "type":"object",
+  "required":["first","second"],
+  "properties":{
+    "first":{"$ref":"../components/component.json"},
+    "second":{"$ref":"../components/component.json"}
+  }
+}`)
+	writeFile(t, root, "contracts/components/component.json", `{
+  "$id":"component.json",
+  "type":"string",
+  "minLength":2
+}`)
+
+	documents, diagnostics := contractjoiner.Join(contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"contracts/roots/root.json"},
+		Components:     []string{"contracts/components/component.json"},
+	})
+	if len(diagnostics) != 0 {
+		t.Fatalf("Join() diagnostics = %+v, want none", diagnostics)
+	}
+	joined := documents[0].Value
+	if got := countResourceID(joined, "component.json"); got != 1 {
+		t.Fatalf("joined authored relative resource count = %d, want 1", got)
+	}
+	properties := object(t, object(t, joined)["properties"])
+	if got := object(t, properties["second"])["$ref"]; got != "https://schemas.example.test/components/component.json" {
+		t.Fatalf("repeated relative resource reference = %v, want canonical embedded resource URI", got)
+	}
+
+	schema := compileJoinedSchema(t, joined)
+	for _, test := range []struct {
+		name  string
+		value any
+		valid bool
+	}{
+		{name: "both uses pass", value: map[string]any{"first": "aa", "second": "bb"}, valid: true},
+		{name: "first use fails", value: map[string]any{"first": "a", "second": "bb"}, valid: false},
+		{name: "repeated use fails", value: map[string]any{"first": "aa", "second": 2}, valid: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := schema.Validate(test.value)
+			if (err == nil) != test.valid {
+				t.Fatalf("Validate(%v) error = %v, want valid %t", test.value, err, test.valid)
+			}
+		})
+	}
+}
+
 func TestJoinDistinguishesRelativeResourceIDsUnderDifferentBases(t *testing.T) {
 	root := t.TempDir()
 	paths := []string{

--- a/internal/contractjoiner/testdata/canonical/components/scalar.json
+++ b/internal/contractjoiner/testdata/canonical/components/scalar.json
@@ -1,0 +1,1 @@
+{"type":"string","$id":"https://schemas.example.test/scalar.json"}

--- a/internal/contractjoiner/testdata/canonical/components/shared.json
+++ b/internal/contractjoiner/testdata/canonical/components/shared.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "$id": "https://schemas.example.test/shared.json",
+  "$defs": {
+    "entry": {
+      "$id": "https://schemas.example.test/entry.json",
+      "required": ["z", "a"],
+      "properties": {
+        "z": {"type": "integer"},
+        "a": {"$ref": "scalar.json"}
+      },
+      "type": "object"
+    }
+  }
+}

--- a/internal/contractjoiner/testdata/canonical/golden/catalog.json
+++ b/internal/contractjoiner/testdata/canonical/golden/catalog.json
@@ -1,13 +1,7 @@
 {
   "$id": "https://schemas.example.test/catalog.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "alpha": {
-    "nested": {
-      "a": false,
-      "z": true
-    }
-  },
-  "items": [
+  "prefixItems": [
     {
       "$id": "https://schemas.example.test/entry.json",
       "properties": {
@@ -30,30 +24,26 @@
       "description": "array order stays authored"
     }
   ],
-  "numeric": {
-    "const": 9007199254740993
-  },
-  "zeta": {
-    "$defs": {
-      "entry": {
-        "$id": "https://schemas.example.test/entry.json",
-        "properties": {
-          "a": {
-            "$id": "https://schemas.example.test/scalar.json",
-            "type": "string"
-          },
-          "z": {
-            "type": "integer"
-          }
-        },
-        "required": [
-          "z",
-          "a"
-        ],
-        "type": "object"
+  "properties": {
+    "alpha": {
+      "const": {
+        "nested": {
+          "a": false,
+          "z": true
+        }
       }
     },
-    "$id": "https://schemas.example.test/shared.json",
-    "type": "object"
+    "numeric": {
+      "const": 9007199254740993
+    },
+    "zeta": {
+      "$defs": {
+        "entry": {
+          "$ref": "https://schemas.example.test/entry.json"
+        }
+      },
+      "$id": "https://schemas.example.test/shared.json",
+      "type": "object"
+    }
   }
 }

--- a/internal/contractjoiner/testdata/canonical/golden/catalog.json
+++ b/internal/contractjoiner/testdata/canonical/golden/catalog.json
@@ -1,0 +1,59 @@
+{
+  "$id": "https://schemas.example.test/catalog.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "alpha": {
+    "nested": {
+      "a": false,
+      "z": true
+    }
+  },
+  "items": [
+    {
+      "$id": "https://schemas.example.test/entry.json",
+      "properties": {
+        "a": {
+          "$id": "https://schemas.example.test/scalar.json",
+          "type": "string"
+        },
+        "z": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "z",
+        "a"
+      ],
+      "type": "object"
+    },
+    {
+      "const": "second",
+      "description": "array order stays authored"
+    }
+  ],
+  "numeric": {
+    "const": 9007199254740993
+  },
+  "zeta": {
+    "$defs": {
+      "entry": {
+        "$id": "https://schemas.example.test/entry.json",
+        "properties": {
+          "a": {
+            "$id": "https://schemas.example.test/scalar.json",
+            "type": "string"
+          },
+          "z": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "z",
+          "a"
+        ],
+        "type": "object"
+      }
+    },
+    "$id": "https://schemas.example.test/shared.json",
+    "type": "object"
+  }
+}

--- a/internal/contractjoiner/testdata/canonical/roots/catalog.json
+++ b/internal/contractjoiner/testdata/canonical/roots/catalog.json
@@ -1,11 +1,13 @@
 {
-  "zeta": {"$ref": "../components/shared.json"},
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "items": [
+  "prefixItems": [
     {"$ref": "../components/shared.json#/$defs/entry"},
     {"const": "second", "description": "array order stays authored"}
   ],
   "$id": "https://schemas.example.test/catalog.json",
-  "alpha": {"nested": {"z": true, "a": false}},
-  "numeric": {"const": 9007199254740993}
+  "properties": {
+    "zeta": {"$ref": "../components/shared.json"},
+    "alpha": {"const": {"nested": {"z": true, "a": false}}},
+    "numeric": {"const": 9007199254740993}
+  }
 }

--- a/internal/contractjoiner/testdata/canonical/roots/catalog.json
+++ b/internal/contractjoiner/testdata/canonical/roots/catalog.json
@@ -1,0 +1,11 @@
+{
+  "zeta": {"$ref": "../components/shared.json"},
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "items": [
+    {"$ref": "../components/shared.json#/$defs/entry"},
+    {"const": "second", "description": "array order stays authored"}
+  ],
+  "$id": "https://schemas.example.test/catalog.json",
+  "alpha": {"nested": {"z": true, "a": false}},
+  "numeric": {"const": 9007199254740993}
+}

--- a/internal/contractjoiner/testdata/canonical/roots/standalone.json
+++ b/internal/contractjoiner/testdata/canonical/roots/standalone.json
@@ -1,0 +1,1 @@
+{"type":"boolean","$id":"https://schemas.example.test/standalone.json"}

--- a/internal/contractvalidator/references.go
+++ b/internal/contractvalidator/references.go
@@ -34,6 +34,12 @@ type resourceLocation struct {
 	segments []string
 }
 
+type resolutionScope struct {
+	baseURI          *url.URL
+	resourceRoot     any
+	resourceSegments []string
+}
+
 // LoadAndResolve loads one authored document through the validator's reviewed
 // repository boundary and resolves references only to the explicitly supplied
 // authored documents. It is intended for repository build tooling such as the
@@ -119,7 +125,10 @@ func resolveReferencesWithin(
 		rejectUnsupportedReferenceKeywords: allowed != nil,
 		resolvedResourceIDs:                make(map[string]resourceLocation),
 	}
-	resolved, diagnostics := resolver.resolveNode(value, document, nil, nil, documentBaseURI(document))
+	resolved, diagnostics := resolver.resolveNode(value, document, nil, nil, resolutionScope{
+		baseURI:      documentBaseURI(document),
+		resourceRoot: value,
+	})
 	if len(diagnostics) != 0 {
 		return nil, nil, diagnostics
 	}
@@ -135,7 +144,7 @@ func resolveReferencesWithin(
 	return resolved, loaded, nil
 }
 
-func (r *referenceResolver) resolveNode(value any, document string, segments, sourceSegments []string, baseURI *url.URL) (any, []Diagnostic) {
+func (r *referenceResolver) resolveNode(value any, document string, segments, sourceSegments []string, scope resolutionScope) (any, []Diagnostic) {
 	switch typed := value.(type) {
 	case map[string]any:
 		if r.rejectUnsupportedReferenceKeywords {
@@ -143,7 +152,7 @@ func (r *referenceResolver) resolveNode(value any, document string, segments, so
 				return nil, diagnostics
 			}
 		}
-		resourceID, resourceURI, hasResourceID := stableResourceID(typed, baseURI)
+		resourceID, resourceURI, hasResourceID := stableResourceID(typed, scope.baseURI)
 		if r.deduplicateResources && hasResourceID {
 			location := resourceLocation{document: document, segments: append([]string(nil), sourceSegments...)}
 			if previous, resolved := r.resolvedResourceIDs[resourceURI.String()]; resolved {
@@ -157,15 +166,21 @@ func (r *referenceResolver) resolveNode(value any, document string, segments, so
 				}
 				return map[string]any{"$ref": reusableResourceReference(resourceID, resourceURI)}, nil
 			}
-			baseURI = resourceURI
+		}
+		if hasResourceID {
+			scope = resolutionScope{
+				baseURI:          resourceURI,
+				resourceRoot:     typed,
+				resourceSegments: append([]string(nil), sourceSegments...),
+			}
 		}
 
 		var resolved any
 		var diagnostics []Diagnostic
 		if reference, ok := typed["$ref"]; ok {
-			resolved, diagnostics = r.resolveReferenceObject(typed, reference, document, segments, sourceSegments, baseURI)
+			resolved, diagnostics = r.resolveReferenceObject(typed, reference, document, segments, sourceSegments, scope)
 		} else {
-			resolved, diagnostics = r.resolveObject(typed, document, segments, sourceSegments, baseURI)
+			resolved, diagnostics = r.resolveObject(typed, document, segments, sourceSegments, scope)
 		}
 		if len(diagnostics) == 0 && r.deduplicateResources && hasResourceID {
 			r.resolvedResourceIDs[resourceURI.String()] = resourceLocation{
@@ -184,7 +199,7 @@ func (r *referenceResolver) resolveNode(value any, document string, segments, so
 				document,
 				appendPath(segments, strconv.Itoa(index)),
 				appendPath(sourceSegments, strconv.Itoa(index)),
-				baseURI,
+				scope,
 			)
 			diagnostics = append(diagnostics, issues...)
 		}
@@ -245,7 +260,7 @@ func documentBaseURI(document string) *url.URL {
 	return &url.URL{Path: "/" + normalizeRepositoryPath(document)}
 }
 
-func (r *referenceResolver) resolveObject(value map[string]any, document string, segments, sourceSegments []string, baseURI *url.URL) (map[string]any, []Diagnostic) {
+func (r *referenceResolver) resolveObject(value map[string]any, document string, segments, sourceSegments []string, scope resolutionScope) (map[string]any, []Diagnostic) {
 	keys := make([]string, 0, len(value))
 	for key := range value {
 		keys = append(keys, key)
@@ -254,15 +269,15 @@ func (r *referenceResolver) resolveObject(value map[string]any, document string,
 	resolved := make(map[string]any, len(value))
 	var diagnostics []Diagnostic
 	for _, key := range keys {
-		child, issues := r.resolveNode(value[key], document, appendPath(segments, key), appendPath(sourceSegments, key), baseURI)
+		child, issues := r.resolveNode(value[key], document, appendPath(segments, key), appendPath(sourceSegments, key), scope)
 		resolved[key] = child
 		diagnostics = append(diagnostics, issues...)
 	}
 	return resolved, diagnostics
 }
 
-func (r *referenceResolver) resolveReferenceObject(value map[string]any, reference any, document string, segments, sourceSegments []string, baseURI *url.URL) (any, []Diagnostic) {
-	resolvedReference, diagnostics := r.resolveReference(reference, document, appendPath(segments, "$ref"), baseURI)
+func (r *referenceResolver) resolveReferenceObject(value map[string]any, reference any, document string, segments, sourceSegments []string, scope resolutionScope) (any, []Diagnostic) {
+	resolvedReference, diagnostics := r.resolveReference(reference, document, appendPath(segments, "$ref"), scope)
 	if len(diagnostics) != 0 {
 		return nil, diagnostics
 	}
@@ -276,7 +291,7 @@ func (r *referenceResolver) resolveReferenceObject(value map[string]any, referen
 			siblings[key] = child
 		}
 	}
-	resolvedSiblings, diagnostics := r.resolveObject(siblings, document, segments, sourceSegments, baseURI)
+	resolvedSiblings, diagnostics := r.resolveObject(siblings, document, segments, sourceSegments, scope)
 	if len(diagnostics) != 0 {
 		return nil, diagnostics
 	}
@@ -288,7 +303,7 @@ func (r *referenceResolver) resolveReferenceObject(value map[string]any, referen
 	return resolvedSiblings, nil
 }
 
-func (r *referenceResolver) resolveReference(value any, referringDocument string, segments []string, baseURI *url.URL) (any, []Diagnostic) {
+func (r *referenceResolver) resolveReference(value any, referringDocument string, segments []string, scope resolutionScope) (any, []Diagnostic) {
 	reference, ok := value.(string)
 	if !ok || reference == "" {
 		return nil, r.issue("reference.invalid", "reference must be a non-empty string", referringDocument, segments)
@@ -297,29 +312,50 @@ func (r *referenceResolver) resolveReference(value any, referringDocument string
 	if issue != nil {
 		return nil, []Diagnostic{*issue}
 	}
-	key := targetDocument + "#" + fragment
+
+	var target any
+	var targetScope resolutionScope
+	var sourceSegments []string
+	if strings.HasPrefix(reference, "#") {
+		target = scope.resourceRoot
+		targetScope = scope
+		sourceSegments = scope.resourceSegments
+	} else {
+		target, issue = r.loadTarget(targetDocument, referringDocument, segments)
+		if issue != nil {
+			return nil, []Diagnostic{*issue}
+		}
+		parsedReference, _ := url.Parse(reference)
+		resolvedBaseURI := scope.baseURI.ResolveReference(parsedReference)
+		resolvedBaseURI.Fragment = ""
+		targetScope = resolutionScope{
+			baseURI:      resolvedBaseURI,
+			resourceRoot: target,
+		}
+	}
+
+	selected, selectedScope, selectedSegments, err := selectFragmentInScope(
+		target,
+		fragment,
+		targetScope,
+		sourceSegments,
+		!strings.HasPrefix(reference, "#"),
+	)
+	if err != nil {
+		return nil, r.issue("reference.fragment", fmt.Sprintf("reference %q has an unresolved fragment", reference), referringDocument, segments)
+	}
+	key := targetDocument + "#" + instancePath(selectedSegments)
 	if r.active[key] {
 		return nil, r.issue("reference.cycle", fmt.Sprintf("reference %q forms a cycle", reference), referringDocument, segments)
 	}
 	r.active[key] = true
 	defer delete(r.active, key)
 
-	target, issue := r.loadTarget(targetDocument, referringDocument, segments)
-	if issue != nil {
-		return nil, []Diagnostic{*issue}
-	}
-	selected, err := selectFragment(target, fragment)
-	if err != nil {
-		return nil, r.issue("reference.fragment", fmt.Sprintf("reference %q has an unresolved fragment", reference), referringDocument, segments)
-	}
-	parsedReference, _ := url.Parse(reference)
-	resolvedBaseURI := baseURI.ResolveReference(parsedReference)
-	resolvedBaseURI.Fragment = ""
-	resolved, diagnostics := r.resolveNode(selected, targetDocument, nil, fragmentSegments(fragment), resolvedBaseURI)
+	resolved, diagnostics := r.resolveNode(selected, targetDocument, nil, selectedSegments, selectedScope)
 	if len(diagnostics) != 0 {
 		return nil, diagnostics
 	}
-	return preserveReferencedResourceBase(resolved, selected, resolvedBaseURI, referringDocument, targetDocument, fragment), nil
+	return preserveReferencedResourceBase(resolved, selected, selectedScope.baseURI, referringDocument, targetDocument, fragment), nil
 }
 
 func preserveReferencedResourceBase(resolved, authored any, baseURI *url.URL, referringDocument, document, fragment string) any {
@@ -374,18 +410,6 @@ func containsOuterBaseDependentResource(value any) bool {
 		}
 	}
 	return false
-}
-
-func fragmentSegments(fragment string) []string {
-	if fragment == "" {
-		return nil
-	}
-	encoded := strings.Split(strings.TrimPrefix(fragment, "/"), "/")
-	segments := make([]string, len(encoded))
-	for index, segment := range encoded {
-		segments[index] = strings.NewReplacer("~1", "/", "~0", "~").Replace(segment)
-	}
-	return segments
 }
 
 func (r *referenceResolver) classifyReference(referringDocument, reference string, segments []string) (string, string, *Diagnostic) {
@@ -463,34 +487,53 @@ func containedBy(root, candidate string) bool {
 	return err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
 }
 
-func selectFragment(value any, fragment string) (any, error) {
+func selectFragmentInScope(
+	value any,
+	fragment string,
+	scope resolutionScope,
+	sourceSegments []string,
+	applyRootID bool,
+) (any, resolutionScope, []string, error) {
 	if fragment == "" {
-		return value, nil
+		return value, scope, sourceSegments, nil
 	}
 	if !strings.HasPrefix(fragment, "/") {
-		return nil, errors.New("fragment is not a JSON Pointer")
+		return nil, resolutionScope{}, nil, errors.New("fragment is not a JSON Pointer")
 	}
 	current := value
+	currentSegments := append([]string(nil), sourceSegments...)
+	applyCurrentID := applyRootID
 	for _, encoded := range strings.Split(strings.TrimPrefix(fragment, "/"), "/") {
+		if object, ok := current.(map[string]any); ok && applyCurrentID {
+			if _, resourceURI, hasResourceID := stableResourceID(object, scope.baseURI); hasResourceID {
+				scope = resolutionScope{
+					baseURI:          resourceURI,
+					resourceRoot:     object,
+					resourceSegments: append([]string(nil), currentSegments...),
+				}
+			}
+		}
 		segment := strings.NewReplacer("~1", "/", "~0", "~").Replace(encoded)
 		switch typed := current.(type) {
 		case map[string]any:
 			var ok bool
 			current, ok = typed[segment]
 			if !ok {
-				return nil, errors.New("object member does not exist")
+				return nil, resolutionScope{}, nil, errors.New("object member does not exist")
 			}
 		case []any:
 			index, err := strconv.Atoi(segment)
 			if err != nil || index < 0 || index >= len(typed) {
-				return nil, errors.New("array element does not exist")
+				return nil, resolutionScope{}, nil, errors.New("array element does not exist")
 			}
 			current = typed[index]
 		default:
-			return nil, errors.New("fragment traverses a scalar")
+			return nil, resolutionScope{}, nil, errors.New("fragment traverses a scalar")
 		}
+		currentSegments = appendPath(currentSegments, segment)
+		applyCurrentID = true
 	}
-	return current, nil
+	return current, scope, currentSegments, nil
 }
 
 func normalizeRepositoryPath(value string) string {

--- a/internal/contractvalidator/references.go
+++ b/internal/contractvalidator/references.go
@@ -26,7 +26,12 @@ type referenceResolver struct {
 	allowed                            map[string]struct{}
 	deduplicateResources               bool
 	rejectUnsupportedReferenceKeywords bool
-	resolvedResourceIDs                map[string]struct{}
+	resolvedResourceIDs                map[string]resourceLocation
+}
+
+type resourceLocation struct {
+	document string
+	segments []string
 }
 
 // LoadAndResolve loads one authored document through the validator's reviewed
@@ -112,9 +117,9 @@ func resolveReferencesWithin(
 		allowed:                            allowed,
 		deduplicateResources:               deduplicateResources,
 		rejectUnsupportedReferenceKeywords: allowed != nil,
-		resolvedResourceIDs:                make(map[string]struct{}),
+		resolvedResourceIDs:                make(map[string]resourceLocation),
 	}
-	resolved, diagnostics := resolver.resolveNode(value, document, nil, documentBaseURI(document))
+	resolved, diagnostics := resolver.resolveNode(value, document, nil, nil, documentBaseURI(document))
 	if len(diagnostics) != 0 {
 		return nil, nil, diagnostics
 	}
@@ -130,7 +135,7 @@ func resolveReferencesWithin(
 	return resolved, loaded, nil
 }
 
-func (r *referenceResolver) resolveNode(value any, document string, segments []string, baseURI *url.URL) (any, []Diagnostic) {
+func (r *referenceResolver) resolveNode(value any, document string, segments, sourceSegments []string, baseURI *url.URL) (any, []Diagnostic) {
 	switch typed := value.(type) {
 	case map[string]any:
 		if r.rejectUnsupportedReferenceKeywords {
@@ -140,7 +145,16 @@ func (r *referenceResolver) resolveNode(value any, document string, segments []s
 		}
 		resourceID, resourceURI, hasResourceID := stableResourceID(typed, baseURI)
 		if r.deduplicateResources && hasResourceID {
-			if _, resolved := r.resolvedResourceIDs[resourceURI.String()]; resolved {
+			location := resourceLocation{document: document, segments: append([]string(nil), sourceSegments...)}
+			if previous, resolved := r.resolvedResourceIDs[resourceURI.String()]; resolved {
+				if !sameResourceLocation(previous, location) {
+					return nil, r.issue(
+						"reference.resource_collision",
+						fmt.Sprintf("stable resource URI %q is declared by multiple authored resources", resourceURI.String()),
+						document,
+						appendPath(sourceSegments, "$id"),
+					)
+				}
 				return map[string]any{"$ref": reusableResourceReference(resourceID, resourceURI)}, nil
 			}
 			baseURI = resourceURI
@@ -149,12 +163,15 @@ func (r *referenceResolver) resolveNode(value any, document string, segments []s
 		var resolved any
 		var diagnostics []Diagnostic
 		if reference, ok := typed["$ref"]; ok {
-			resolved, diagnostics = r.resolveReferenceObject(typed, reference, document, segments, baseURI)
+			resolved, diagnostics = r.resolveReferenceObject(typed, reference, document, segments, sourceSegments, baseURI)
 		} else {
-			resolved, diagnostics = r.resolveObject(typed, document, segments, baseURI)
+			resolved, diagnostics = r.resolveObject(typed, document, segments, sourceSegments, baseURI)
 		}
 		if len(diagnostics) == 0 && r.deduplicateResources && hasResourceID {
-			r.resolvedResourceIDs[resourceURI.String()] = struct{}{}
+			r.resolvedResourceIDs[resourceURI.String()] = resourceLocation{
+				document: document,
+				segments: append([]string(nil), sourceSegments...),
+			}
 		}
 		return resolved, diagnostics
 	case []any:
@@ -162,13 +179,31 @@ func (r *referenceResolver) resolveNode(value any, document string, segments []s
 		var diagnostics []Diagnostic
 		for index, child := range typed {
 			var issues []Diagnostic
-			resolved[index], issues = r.resolveNode(child, document, appendPath(segments, strconv.Itoa(index)), baseURI)
+			resolved[index], issues = r.resolveNode(
+				child,
+				document,
+				appendPath(segments, strconv.Itoa(index)),
+				appendPath(sourceSegments, strconv.Itoa(index)),
+				baseURI,
+			)
 			diagnostics = append(diagnostics, issues...)
 		}
 		return resolved, diagnostics
 	default:
 		return value, nil
 	}
+}
+
+func sameResourceLocation(first, second resourceLocation) bool {
+	if first.document != second.document || len(first.segments) != len(second.segments) {
+		return false
+	}
+	for index := range first.segments {
+		if first.segments[index] != second.segments[index] {
+			return false
+		}
+	}
+	return true
 }
 
 func (r *referenceResolver) unsupportedReferenceKeywordDiagnostics(value map[string]any, document string, segments []string) []Diagnostic {
@@ -210,7 +245,7 @@ func documentBaseURI(document string) *url.URL {
 	return &url.URL{Path: "/" + normalizeRepositoryPath(document)}
 }
 
-func (r *referenceResolver) resolveObject(value map[string]any, document string, segments []string, baseURI *url.URL) (map[string]any, []Diagnostic) {
+func (r *referenceResolver) resolveObject(value map[string]any, document string, segments, sourceSegments []string, baseURI *url.URL) (map[string]any, []Diagnostic) {
 	keys := make([]string, 0, len(value))
 	for key := range value {
 		keys = append(keys, key)
@@ -219,14 +254,14 @@ func (r *referenceResolver) resolveObject(value map[string]any, document string,
 	resolved := make(map[string]any, len(value))
 	var diagnostics []Diagnostic
 	for _, key := range keys {
-		child, issues := r.resolveNode(value[key], document, appendPath(segments, key), baseURI)
+		child, issues := r.resolveNode(value[key], document, appendPath(segments, key), appendPath(sourceSegments, key), baseURI)
 		resolved[key] = child
 		diagnostics = append(diagnostics, issues...)
 	}
 	return resolved, diagnostics
 }
 
-func (r *referenceResolver) resolveReferenceObject(value map[string]any, reference any, document string, segments []string, baseURI *url.URL) (any, []Diagnostic) {
+func (r *referenceResolver) resolveReferenceObject(value map[string]any, reference any, document string, segments, sourceSegments []string, baseURI *url.URL) (any, []Diagnostic) {
 	resolvedReference, diagnostics := r.resolveReference(reference, document, appendPath(segments, "$ref"), baseURI)
 	if len(diagnostics) != 0 {
 		return nil, diagnostics
@@ -241,7 +276,7 @@ func (r *referenceResolver) resolveReferenceObject(value map[string]any, referen
 			siblings[key] = child
 		}
 	}
-	resolvedSiblings, diagnostics := r.resolveObject(siblings, document, segments, baseURI)
+	resolvedSiblings, diagnostics := r.resolveObject(siblings, document, segments, sourceSegments, baseURI)
 	if len(diagnostics) != 0 {
 		return nil, diagnostics
 	}
@@ -280,7 +315,19 @@ func (r *referenceResolver) resolveReference(value any, referringDocument string
 	parsedReference, _ := url.Parse(reference)
 	resolvedBaseURI := baseURI.ResolveReference(parsedReference)
 	resolvedBaseURI.Fragment = ""
-	return r.resolveNode(selected, targetDocument, nil, resolvedBaseURI)
+	return r.resolveNode(selected, targetDocument, nil, fragmentSegments(fragment), resolvedBaseURI)
+}
+
+func fragmentSegments(fragment string) []string {
+	if fragment == "" {
+		return nil
+	}
+	encoded := strings.Split(strings.TrimPrefix(fragment, "/"), "/")
+	segments := make([]string, len(encoded))
+	for index, segment := range encoded {
+		segments[index] = strings.NewReplacer("~1", "/", "~0", "~").Replace(segment)
+	}
+	return segments
 }
 
 func (r *referenceResolver) classifyReference(referringDocument, reference string, segments []string) (string, string, *Diagnostic) {

--- a/internal/contractvalidator/references.go
+++ b/internal/contractvalidator/references.go
@@ -319,24 +319,25 @@ func (r *referenceResolver) resolveReference(value any, referringDocument string
 	if len(diagnostics) != 0 {
 		return nil, diagnostics
 	}
-	return preserveReferencedResourceBase(resolved, selected, resolvedBaseURI, targetDocument, fragment), nil
+	return preserveReferencedResourceBase(resolved, selected, resolvedBaseURI, referringDocument, targetDocument, fragment), nil
 }
 
-func preserveReferencedResourceBase(resolved, authored any, baseURI *url.URL, document, fragment string) any {
+func preserveReferencedResourceBase(resolved, authored any, baseURI *url.URL, referringDocument, document, fragment string) any {
 	authoredObject, ok := authored.(map[string]any)
 	if !ok {
 		return resolved
 	}
 	identifier, ok := authoredObject["$id"].(string)
-	if !ok || identifier == "" {
-		return resolved
-	}
-	parsedIdentifier, err := url.Parse(identifier)
-	if err != nil || parsedIdentifier.IsAbs() {
-		return resolved
-	}
-	resolvedObject, ok := resolved.(map[string]any)
-	if !ok || resolvedObject["$id"] != identifier {
+	if ok && identifier != "" {
+		parsedIdentifier, err := url.Parse(identifier)
+		if err != nil || parsedIdentifier.IsAbs() {
+			return resolved
+		}
+		resolvedObject, resolvedIsObject := resolved.(map[string]any)
+		if !resolvedIsObject || resolvedObject["$id"] != identifier {
+			return resolved
+		}
+	} else if referringDocument == document || !containsOuterBaseDependentResource(authoredObject) {
 		return resolved
 	}
 
@@ -348,6 +349,31 @@ func preserveReferencedResourceBase(resolved, authored any, baseURI *url.URL, do
 		"$id":   relocationBase.String(),
 		"allOf": []any{resolved},
 	}
+}
+
+func containsOuterBaseDependentResource(value any) bool {
+	switch typed := value.(type) {
+	case map[string]any:
+		if identifier, ok := typed["$id"].(string); ok && identifier != "" {
+			parsed, err := url.Parse(identifier)
+			if err != nil || parsed.IsAbs() {
+				return false
+			}
+			return true
+		}
+		for _, child := range typed {
+			if containsOuterBaseDependentResource(child) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range typed {
+			if containsOuterBaseDependentResource(child) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func fragmentSegments(fragment string) []string {

--- a/internal/contractvalidator/references.go
+++ b/internal/contractvalidator/references.go
@@ -20,10 +20,12 @@ func (disabledURLLoader) Load(resourceURL string) (any, error) {
 }
 
 type referenceResolver struct {
-	root      string
-	documents map[string]any
-	active    map[string]bool
-	allowed   map[string]struct{}
+	root                 string
+	documents            map[string]any
+	active               map[string]bool
+	allowed              map[string]struct{}
+	deduplicateResources bool
+	resolvedResourceIDs  map[string]struct{}
 }
 
 // LoadAndResolve loads one authored document through the validator's reviewed
@@ -40,7 +42,7 @@ func LoadAndResolve(repositoryRoot, document string, authoredDocuments []string)
 	for _, path := range authoredDocuments {
 		allowed[normalizeRepositoryPath(path)] = struct{}{}
 	}
-	resolved, _, diagnostics := resolveReferencesWithin(repositoryRoot, document, value, allowed)
+	resolved, _, diagnostics := resolveReferencesWithin(repositoryRoot, document, value, allowed, true)
 	sortDiagnostics(diagnostics)
 	return resolved, diagnostics
 }
@@ -88,20 +90,27 @@ func ValidateAuthoredPaths(repositoryRoot string, documents []string, generatedD
 }
 
 func resolveReferences(repositoryRoot, document string, value any) (any, []loadedDocument, []Diagnostic) {
-	return resolveReferencesWithin(repositoryRoot, document, value, nil)
+	return resolveReferencesWithin(repositoryRoot, document, value, nil, false)
 }
 
-func resolveReferencesWithin(repositoryRoot, document string, value any, allowed map[string]struct{}) (any, []loadedDocument, []Diagnostic) {
+func resolveReferencesWithin(
+	repositoryRoot, document string,
+	value any,
+	allowed map[string]struct{},
+	deduplicateResources bool,
+) (any, []loadedDocument, []Diagnostic) {
 	root, err := canonicalRoot(repositoryRoot)
 	if err != nil {
 		return nil, nil, []Diagnostic{newDiagnostic("reference.root", rootPath, "repository root could not be resolved", document)}
 	}
 	document = normalizeRepositoryPath(document)
 	resolver := referenceResolver{
-		root:      root,
-		documents: map[string]any{document: value},
-		active:    make(map[string]bool),
-		allowed:   allowed,
+		root:                 root,
+		documents:            map[string]any{document: value},
+		active:               make(map[string]bool),
+		allowed:              allowed,
+		deduplicateResources: deduplicateResources,
+		resolvedResourceIDs:  make(map[string]struct{}),
 	}
 	resolved, diagnostics := resolver.resolveNode(value, document, nil)
 	if len(diagnostics) != 0 {
@@ -122,10 +131,24 @@ func resolveReferencesWithin(repositoryRoot, document string, value any, allowed
 func (r *referenceResolver) resolveNode(value any, document string, segments []string) (any, []Diagnostic) {
 	switch typed := value.(type) {
 	case map[string]any:
-		if reference, ok := typed["$ref"]; ok {
-			return r.resolveReferenceObject(typed, reference, document, segments)
+		resourceID, hasResourceID := stableResourceID(typed)
+		if r.deduplicateResources && hasResourceID {
+			if _, resolved := r.resolvedResourceIDs[resourceID]; resolved {
+				return map[string]any{"$ref": resourceID}, nil
+			}
 		}
-		return r.resolveObject(typed, document, segments)
+
+		var resolved any
+		var diagnostics []Diagnostic
+		if reference, ok := typed["$ref"]; ok {
+			resolved, diagnostics = r.resolveReferenceObject(typed, reference, document, segments)
+		} else {
+			resolved, diagnostics = r.resolveObject(typed, document, segments)
+		}
+		if len(diagnostics) == 0 && r.deduplicateResources && hasResourceID {
+			r.resolvedResourceIDs[resourceID] = struct{}{}
+		}
+		return resolved, diagnostics
 	case []any:
 		resolved := make([]any, len(typed))
 		var diagnostics []Diagnostic
@@ -138,6 +161,11 @@ func (r *referenceResolver) resolveNode(value any, document string, segments []s
 	default:
 		return value, nil
 	}
+}
+
+func stableResourceID(value map[string]any) (string, bool) {
+	identifier, ok := value["$id"].(string)
+	return identifier, ok && identifier != ""
 }
 
 func (r *referenceResolver) resolveObject(value map[string]any, document string, segments []string) (map[string]any, []Diagnostic) {

--- a/internal/contractvalidator/references.go
+++ b/internal/contractvalidator/references.go
@@ -315,7 +315,39 @@ func (r *referenceResolver) resolveReference(value any, referringDocument string
 	parsedReference, _ := url.Parse(reference)
 	resolvedBaseURI := baseURI.ResolveReference(parsedReference)
 	resolvedBaseURI.Fragment = ""
-	return r.resolveNode(selected, targetDocument, nil, fragmentSegments(fragment), resolvedBaseURI)
+	resolved, diagnostics := r.resolveNode(selected, targetDocument, nil, fragmentSegments(fragment), resolvedBaseURI)
+	if len(diagnostics) != 0 {
+		return nil, diagnostics
+	}
+	return preserveReferencedResourceBase(resolved, selected, resolvedBaseURI, targetDocument, fragment), nil
+}
+
+func preserveReferencedResourceBase(resolved, authored any, baseURI *url.URL, document, fragment string) any {
+	authoredObject, ok := authored.(map[string]any)
+	if !ok {
+		return resolved
+	}
+	identifier, ok := authoredObject["$id"].(string)
+	if !ok || identifier == "" {
+		return resolved
+	}
+	parsedIdentifier, err := url.Parse(identifier)
+	if err != nil || parsedIdentifier.IsAbs() {
+		return resolved
+	}
+	resolvedObject, ok := resolved.(map[string]any)
+	if !ok || resolvedObject["$id"] != identifier {
+		return resolved
+	}
+
+	relocationBase := *baseURI
+	query := relocationBase.Query()
+	query.Set("you-join-source", normalizeRepositoryPath(document)+"#"+fragment)
+	relocationBase.RawQuery = query.Encode()
+	return map[string]any{
+		"$id":   relocationBase.String(),
+		"allOf": []any{resolved},
+	}
 }
 
 func fragmentSegments(fragment string) []string {

--- a/internal/contractvalidator/references.go
+++ b/internal/contractvalidator/references.go
@@ -114,7 +114,7 @@ func resolveReferencesWithin(
 		rejectUnsupportedReferenceKeywords: allowed != nil,
 		resolvedResourceIDs:                make(map[string]struct{}),
 	}
-	resolved, diagnostics := resolver.resolveNode(value, document, nil)
+	resolved, diagnostics := resolver.resolveNode(value, document, nil, documentBaseURI(document))
 	if len(diagnostics) != 0 {
 		return nil, nil, diagnostics
 	}
@@ -130,7 +130,7 @@ func resolveReferencesWithin(
 	return resolved, loaded, nil
 }
 
-func (r *referenceResolver) resolveNode(value any, document string, segments []string) (any, []Diagnostic) {
+func (r *referenceResolver) resolveNode(value any, document string, segments []string, baseURI *url.URL) (any, []Diagnostic) {
 	switch typed := value.(type) {
 	case map[string]any:
 		if r.rejectUnsupportedReferenceKeywords {
@@ -138,22 +138,23 @@ func (r *referenceResolver) resolveNode(value any, document string, segments []s
 				return nil, diagnostics
 			}
 		}
-		resourceID, hasResourceID := stableResourceID(typed)
+		resourceID, resourceURI, hasResourceID := stableResourceID(typed, baseURI)
 		if r.deduplicateResources && hasResourceID {
-			if _, resolved := r.resolvedResourceIDs[resourceID]; resolved {
-				return map[string]any{"$ref": resourceID}, nil
+			if _, resolved := r.resolvedResourceIDs[resourceURI.String()]; resolved {
+				return map[string]any{"$ref": reusableResourceReference(resourceID, resourceURI)}, nil
 			}
+			baseURI = resourceURI
 		}
 
 		var resolved any
 		var diagnostics []Diagnostic
 		if reference, ok := typed["$ref"]; ok {
-			resolved, diagnostics = r.resolveReferenceObject(typed, reference, document, segments)
+			resolved, diagnostics = r.resolveReferenceObject(typed, reference, document, segments, baseURI)
 		} else {
-			resolved, diagnostics = r.resolveObject(typed, document, segments)
+			resolved, diagnostics = r.resolveObject(typed, document, segments, baseURI)
 		}
 		if len(diagnostics) == 0 && r.deduplicateResources && hasResourceID {
-			r.resolvedResourceIDs[resourceID] = struct{}{}
+			r.resolvedResourceIDs[resourceURI.String()] = struct{}{}
 		}
 		return resolved, diagnostics
 	case []any:
@@ -161,7 +162,7 @@ func (r *referenceResolver) resolveNode(value any, document string, segments []s
 		var diagnostics []Diagnostic
 		for index, child := range typed {
 			var issues []Diagnostic
-			resolved[index], issues = r.resolveNode(child, document, appendPath(segments, strconv.Itoa(index)))
+			resolved[index], issues = r.resolveNode(child, document, appendPath(segments, strconv.Itoa(index)), baseURI)
 			diagnostics = append(diagnostics, issues...)
 		}
 		return resolved, diagnostics
@@ -186,12 +187,30 @@ func (r *referenceResolver) unsupportedReferenceKeywordDiagnostics(value map[str
 	return diagnostics
 }
 
-func stableResourceID(value map[string]any) (string, bool) {
+func stableResourceID(value map[string]any, baseURI *url.URL) (string, *url.URL, bool) {
 	identifier, ok := value["$id"].(string)
-	return identifier, ok && identifier != ""
+	if !ok || identifier == "" {
+		return "", baseURI, false
+	}
+	parsed, err := url.Parse(identifier)
+	if err != nil {
+		return identifier, baseURI, false
+	}
+	return identifier, baseURI.ResolveReference(parsed), true
 }
 
-func (r *referenceResolver) resolveObject(value map[string]any, document string, segments []string) (map[string]any, []Diagnostic) {
+func reusableResourceReference(identifier string, resourceURI *url.URL) string {
+	if resourceURI.IsAbs() {
+		return resourceURI.String()
+	}
+	return identifier
+}
+
+func documentBaseURI(document string) *url.URL {
+	return &url.URL{Path: "/" + normalizeRepositoryPath(document)}
+}
+
+func (r *referenceResolver) resolveObject(value map[string]any, document string, segments []string, baseURI *url.URL) (map[string]any, []Diagnostic) {
 	keys := make([]string, 0, len(value))
 	for key := range value {
 		keys = append(keys, key)
@@ -200,15 +219,15 @@ func (r *referenceResolver) resolveObject(value map[string]any, document string,
 	resolved := make(map[string]any, len(value))
 	var diagnostics []Diagnostic
 	for _, key := range keys {
-		child, issues := r.resolveNode(value[key], document, appendPath(segments, key))
+		child, issues := r.resolveNode(value[key], document, appendPath(segments, key), baseURI)
 		resolved[key] = child
 		diagnostics = append(diagnostics, issues...)
 	}
 	return resolved, diagnostics
 }
 
-func (r *referenceResolver) resolveReferenceObject(value map[string]any, reference any, document string, segments []string) (any, []Diagnostic) {
-	resolvedReference, diagnostics := r.resolveReference(reference, document, appendPath(segments, "$ref"))
+func (r *referenceResolver) resolveReferenceObject(value map[string]any, reference any, document string, segments []string, baseURI *url.URL) (any, []Diagnostic) {
+	resolvedReference, diagnostics := r.resolveReference(reference, document, appendPath(segments, "$ref"), baseURI)
 	if len(diagnostics) != 0 {
 		return nil, diagnostics
 	}
@@ -222,7 +241,7 @@ func (r *referenceResolver) resolveReferenceObject(value map[string]any, referen
 			siblings[key] = child
 		}
 	}
-	resolvedSiblings, diagnostics := r.resolveObject(siblings, document, segments)
+	resolvedSiblings, diagnostics := r.resolveObject(siblings, document, segments, baseURI)
 	if len(diagnostics) != 0 {
 		return nil, diagnostics
 	}
@@ -234,7 +253,7 @@ func (r *referenceResolver) resolveReferenceObject(value map[string]any, referen
 	return resolvedSiblings, nil
 }
 
-func (r *referenceResolver) resolveReference(value any, referringDocument string, segments []string) (any, []Diagnostic) {
+func (r *referenceResolver) resolveReference(value any, referringDocument string, segments []string, baseURI *url.URL) (any, []Diagnostic) {
 	reference, ok := value.(string)
 	if !ok || reference == "" {
 		return nil, r.issue("reference.invalid", "reference must be a non-empty string", referringDocument, segments)
@@ -258,7 +277,10 @@ func (r *referenceResolver) resolveReference(value any, referringDocument string
 	if err != nil {
 		return nil, r.issue("reference.fragment", fmt.Sprintf("reference %q has an unresolved fragment", reference), referringDocument, segments)
 	}
-	return r.resolveNode(selected, targetDocument, nil)
+	parsedReference, _ := url.Parse(reference)
+	resolvedBaseURI := baseURI.ResolveReference(parsedReference)
+	resolvedBaseURI.Fragment = ""
+	return r.resolveNode(selected, targetDocument, nil, resolvedBaseURI)
 }
 
 func (r *referenceResolver) classifyReference(referringDocument, reference string, segments []string) (string, string, *Diagnostic) {

--- a/internal/contractvalidator/references.go
+++ b/internal/contractvalidator/references.go
@@ -344,6 +344,27 @@ func (r *referenceResolver) resolveReference(value any, referringDocument string
 	if err != nil {
 		return nil, r.issue("reference.fragment", fmt.Sprintf("reference %q has an unresolved fragment", reference), referringDocument, segments)
 	}
+	relocationURI, relocatesIDLessResource := referencedResourceRelocationURI(
+		selected,
+		selectedScope.baseURI,
+		referringDocument,
+		targetDocument,
+		fragment,
+	)
+	location := resourceLocation{document: targetDocument, segments: append([]string(nil), selectedSegments...)}
+	if r.deduplicateResources && relocatesIDLessResource {
+		if previous, exists := r.resolvedResourceIDs[relocationURI.String()]; exists {
+			if !sameResourceLocation(previous, location) {
+				return nil, r.issue(
+					"reference.resource_collision",
+					fmt.Sprintf("stable resource URI %q is declared by multiple authored resources", relocationURI.String()),
+					targetDocument,
+					selectedSegments,
+				)
+			}
+			return map[string]any{"$ref": relocationURI.String()}, nil
+		}
+	}
 	key := targetDocument + "#" + instancePath(selectedSegments)
 	if r.active[key] {
 		return nil, r.issue("reference.cycle", fmt.Sprintf("reference %q forms a cycle", reference), referringDocument, segments)
@@ -355,7 +376,11 @@ func (r *referenceResolver) resolveReference(value any, referringDocument string
 	if len(diagnostics) != 0 {
 		return nil, diagnostics
 	}
-	return preserveReferencedResourceBase(resolved, selected, selectedScope.baseURI, referringDocument, targetDocument, fragment), nil
+	resolved = preserveReferencedResourceBase(resolved, selected, selectedScope.baseURI, referringDocument, targetDocument, fragment)
+	if r.deduplicateResources && relocatesIDLessResource {
+		r.resolvedResourceIDs[relocationURI.String()] = location
+	}
+	return resolved, nil
 }
 
 func preserveReferencedResourceBase(resolved, authored any, baseURI *url.URL, referringDocument, document, fragment string) any {
@@ -373,18 +398,39 @@ func preserveReferencedResourceBase(resolved, authored any, baseURI *url.URL, re
 		if !resolvedIsObject || resolvedObject["$id"] != identifier {
 			return resolved
 		}
-	} else if referringDocument == document || !containsOuterBaseDependentResource(authoredObject) {
-		return resolved
+	} else {
+		if _, relocates := referencedResourceRelocationURI(authored, baseURI, referringDocument, document, fragment); !relocates {
+			return resolved
+		}
 	}
 
+	return map[string]any{
+		"$id":   resourceRelocationURI(baseURI, document, fragment).String(),
+		"allOf": []any{resolved},
+	}
+}
+
+func referencedResourceRelocationURI(authored any, baseURI *url.URL, referringDocument, document, fragment string) (*url.URL, bool) {
+	authoredObject, ok := authored.(map[string]any)
+	if !ok {
+		return baseURI, false
+	}
+	if identifier, hasIdentifier := authoredObject["$id"].(string); hasIdentifier && identifier != "" {
+		return baseURI, false
+	}
+	if referringDocument == document || !containsOuterBaseDependentResource(authoredObject) {
+		return baseURI, false
+	}
+
+	return resourceRelocationURI(baseURI, document, fragment), true
+}
+
+func resourceRelocationURI(baseURI *url.URL, document, fragment string) *url.URL {
 	relocationBase := *baseURI
 	query := relocationBase.Query()
 	query.Set("you-join-source", normalizeRepositoryPath(document)+"#"+fragment)
 	relocationBase.RawQuery = query.Encode()
-	return map[string]any{
-		"$id":   relocationBase.String(),
-		"allOf": []any{resolved},
-	}
+	return &relocationBase
 }
 
 func containsOuterBaseDependentResource(value any) bool {

--- a/internal/contractvalidator/references.go
+++ b/internal/contractvalidator/references.go
@@ -123,21 +123,9 @@ func (r *referenceResolver) resolveNode(value any, document string, segments []s
 	switch typed := value.(type) {
 	case map[string]any:
 		if reference, ok := typed["$ref"]; ok {
-			return r.resolveReference(reference, document, appendPath(segments, "$ref"))
+			return r.resolveReferenceObject(typed, reference, document, segments)
 		}
-		keys := make([]string, 0, len(typed))
-		for key := range typed {
-			keys = append(keys, key)
-		}
-		sort.Strings(keys)
-		resolved := make(map[string]any, len(typed))
-		var diagnostics []Diagnostic
-		for _, key := range keys {
-			child, issues := r.resolveNode(typed[key], document, appendPath(segments, key))
-			resolved[key] = child
-			diagnostics = append(diagnostics, issues...)
-		}
-		return resolved, diagnostics
+		return r.resolveObject(typed, document, segments)
 	case []any:
 		resolved := make([]any, len(typed))
 		var diagnostics []Diagnostic
@@ -150,6 +138,49 @@ func (r *referenceResolver) resolveNode(value any, document string, segments []s
 	default:
 		return value, nil
 	}
+}
+
+func (r *referenceResolver) resolveObject(value map[string]any, document string, segments []string) (map[string]any, []Diagnostic) {
+	keys := make([]string, 0, len(value))
+	for key := range value {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	resolved := make(map[string]any, len(value))
+	var diagnostics []Diagnostic
+	for _, key := range keys {
+		child, issues := r.resolveNode(value[key], document, appendPath(segments, key))
+		resolved[key] = child
+		diagnostics = append(diagnostics, issues...)
+	}
+	return resolved, diagnostics
+}
+
+func (r *referenceResolver) resolveReferenceObject(value map[string]any, reference any, document string, segments []string) (any, []Diagnostic) {
+	resolvedReference, diagnostics := r.resolveReference(reference, document, appendPath(segments, "$ref"))
+	if len(diagnostics) != 0 {
+		return nil, diagnostics
+	}
+	if len(value) == 1 {
+		return resolvedReference, nil
+	}
+
+	siblings := make(map[string]any, len(value)-1)
+	for key, child := range value {
+		if key != "$ref" {
+			siblings[key] = child
+		}
+	}
+	resolvedSiblings, diagnostics := r.resolveObject(siblings, document, segments)
+	if len(diagnostics) != 0 {
+		return nil, diagnostics
+	}
+	if authoredAllOf, ok := resolvedSiblings["allOf"]; ok {
+		resolvedSiblings["allOf"] = []any{resolvedReference, map[string]any{"allOf": authoredAllOf}}
+	} else {
+		resolvedSiblings["allOf"] = []any{resolvedReference}
+	}
+	return resolvedSiblings, nil
 }
 
 func (r *referenceResolver) resolveReference(value any, referringDocument string, segments []string) (any, []Diagnostic) {

--- a/internal/contractvalidator/references.go
+++ b/internal/contractvalidator/references.go
@@ -513,7 +513,10 @@ func selectFragmentInScope(
 				}
 			}
 		}
-		segment := strings.NewReplacer("~1", "/", "~0", "~").Replace(encoded)
+		segment, err := decodeJSONPointerToken(encoded)
+		if err != nil {
+			return nil, resolutionScope{}, nil, err
+		}
 		switch typed := current.(type) {
 		case map[string]any:
 			var ok bool
@@ -534,6 +537,19 @@ func selectFragmentInScope(
 		applyCurrentID = true
 	}
 	return current, scope, currentSegments, nil
+}
+
+func decodeJSONPointerToken(encoded string) (string, error) {
+	for index := 0; index < len(encoded); index++ {
+		if encoded[index] != '~' {
+			continue
+		}
+		if index+1 >= len(encoded) || (encoded[index+1] != '0' && encoded[index+1] != '1') {
+			return "", errors.New("fragment contains an invalid JSON Pointer escape")
+		}
+		index++
+	}
+	return strings.NewReplacer("~1", "/", "~0", "~").Replace(encoded), nil
 }
 
 func normalizeRepositoryPath(value string) string {

--- a/internal/contractvalidator/references.go
+++ b/internal/contractvalidator/references.go
@@ -20,12 +20,13 @@ func (disabledURLLoader) Load(resourceURL string) (any, error) {
 }
 
 type referenceResolver struct {
-	root                 string
-	documents            map[string]any
-	active               map[string]bool
-	allowed              map[string]struct{}
-	deduplicateResources bool
-	resolvedResourceIDs  map[string]struct{}
+	root                               string
+	documents                          map[string]any
+	active                             map[string]bool
+	allowed                            map[string]struct{}
+	deduplicateResources               bool
+	rejectUnsupportedReferenceKeywords bool
+	resolvedResourceIDs                map[string]struct{}
 }
 
 // LoadAndResolve loads one authored document through the validator's reviewed
@@ -105,12 +106,13 @@ func resolveReferencesWithin(
 	}
 	document = normalizeRepositoryPath(document)
 	resolver := referenceResolver{
-		root:                 root,
-		documents:            map[string]any{document: value},
-		active:               make(map[string]bool),
-		allowed:              allowed,
-		deduplicateResources: deduplicateResources,
-		resolvedResourceIDs:  make(map[string]struct{}),
+		root:                               root,
+		documents:                          map[string]any{document: value},
+		active:                             make(map[string]bool),
+		allowed:                            allowed,
+		deduplicateResources:               deduplicateResources,
+		rejectUnsupportedReferenceKeywords: allowed != nil,
+		resolvedResourceIDs:                make(map[string]struct{}),
 	}
 	resolved, diagnostics := resolver.resolveNode(value, document, nil)
 	if len(diagnostics) != 0 {
@@ -131,6 +133,11 @@ func resolveReferencesWithin(
 func (r *referenceResolver) resolveNode(value any, document string, segments []string) (any, []Diagnostic) {
 	switch typed := value.(type) {
 	case map[string]any:
+		if r.rejectUnsupportedReferenceKeywords {
+			if diagnostics := r.unsupportedReferenceKeywordDiagnostics(typed, document, segments); len(diagnostics) != 0 {
+				return nil, diagnostics
+			}
+		}
 		resourceID, hasResourceID := stableResourceID(typed)
 		if r.deduplicateResources && hasResourceID {
 			if _, resolved := r.resolvedResourceIDs[resourceID]; resolved {
@@ -161,6 +168,22 @@ func (r *referenceResolver) resolveNode(value any, document string, segments []s
 	default:
 		return value, nil
 	}
+}
+
+func (r *referenceResolver) unsupportedReferenceKeywordDiagnostics(value map[string]any, document string, segments []string) []Diagnostic {
+	var diagnostics []Diagnostic
+	for _, keyword := range []string{"$dynamicRef", "$recursiveRef"} {
+		if _, exists := value[keyword]; !exists {
+			continue
+		}
+		diagnostics = append(diagnostics, r.singleIssue(
+			"reference.unsupported",
+			fmt.Sprintf("reference keyword %q is not supported", keyword),
+			document,
+			appendPath(segments, keyword),
+		))
+	}
+	return diagnostics
 }
 
 func stableResourceID(value map[string]any) (string, bool) {

--- a/internal/contractvalidator/references.go
+++ b/internal/contractvalidator/references.go
@@ -45,6 +45,48 @@ func LoadAndResolve(repositoryRoot, document string, authoredDocuments []string)
 	return resolved, diagnostics
 }
 
+// ValidateAuthoredPaths rejects authored inputs that escape the repository or
+// resolve into a generated directory. Missing paths remain the responsibility
+// of the loader so roots and referenced components retain their specific read
+// diagnostics.
+func ValidateAuthoredPaths(repositoryRoot string, documents []string, generatedDirectory string) []Diagnostic {
+	root, err := canonicalRoot(repositoryRoot)
+	if err != nil {
+		return []Diagnostic{newDiagnostic("reference.root", rootPath, "repository root could not be resolved", "repository")}
+	}
+	generated := filepath.Join(root, filepath.FromSlash(normalizeRepositoryPath(generatedDirectory)))
+	canonicalGenerated := generated
+	if resolved, resolveErr := filepath.EvalSymlinks(generated); resolveErr == nil {
+		canonicalGenerated = resolved
+	}
+	var diagnostics []Diagnostic
+	for _, document := range documents {
+		document = normalizeRepositoryPath(document)
+		candidate := filepath.Join(root, filepath.FromSlash(document))
+		if !containedBy(root, candidate) {
+			diagnostics = append(diagnostics, newDiagnostic("join.input.escape", rootPath, "authored input escapes the repository root", document))
+			continue
+		}
+		if containedBy(generated, candidate) {
+			diagnostics = append(diagnostics, newDiagnostic("join.input.generated", rootPath, "authored input is inside generated joined output", document))
+			continue
+		}
+		canonical, resolveErr := filepath.EvalSymlinks(candidate)
+		if resolveErr != nil {
+			continue
+		}
+		if !containedBy(root, canonical) {
+			diagnostics = append(diagnostics, newDiagnostic("join.input.escape", rootPath, "authored input resolves outside the repository root", document))
+			continue
+		}
+		if containedBy(canonicalGenerated, canonical) {
+			diagnostics = append(diagnostics, newDiagnostic("join.input.generated", rootPath, "authored input resolves inside generated joined output", document))
+		}
+	}
+	sortDiagnostics(diagnostics)
+	return diagnostics
+}
+
 func resolveReferences(repositoryRoot, document string, value any) (any, []loadedDocument, []Diagnostic) {
 	return resolveReferencesWithin(repositoryRoot, document, value, nil)
 }

--- a/internal/contractvalidator/references.go
+++ b/internal/contractvalidator/references.go
@@ -23,9 +23,33 @@ type referenceResolver struct {
 	root      string
 	documents map[string]any
 	active    map[string]bool
+	allowed   map[string]struct{}
+}
+
+// LoadAndResolve loads one authored document through the validator's reviewed
+// repository boundary and resolves references only to the explicitly supplied
+// authored documents. It is intended for repository build tooling such as the
+// contract joiner, not runtime consumers.
+func LoadAndResolve(repositoryRoot, document string, authoredDocuments []string) (any, []Diagnostic) {
+	value, issue := loadJSON(repositoryRoot, document, "document")
+	if issue != nil {
+		return nil, []Diagnostic{*issue}
+	}
+	allowed := make(map[string]struct{}, len(authoredDocuments)+1)
+	allowed[normalizeRepositoryPath(document)] = struct{}{}
+	for _, path := range authoredDocuments {
+		allowed[normalizeRepositoryPath(path)] = struct{}{}
+	}
+	resolved, _, diagnostics := resolveReferencesWithin(repositoryRoot, document, value, allowed)
+	sortDiagnostics(diagnostics)
+	return resolved, diagnostics
 }
 
 func resolveReferences(repositoryRoot, document string, value any) (any, []loadedDocument, []Diagnostic) {
+	return resolveReferencesWithin(repositoryRoot, document, value, nil)
+}
+
+func resolveReferencesWithin(repositoryRoot, document string, value any, allowed map[string]struct{}) (any, []loadedDocument, []Diagnostic) {
 	root, err := canonicalRoot(repositoryRoot)
 	if err != nil {
 		return nil, nil, []Diagnostic{newDiagnostic("reference.root", rootPath, "repository root could not be resolved", document)}
@@ -35,6 +59,7 @@ func resolveReferences(repositoryRoot, document string, value any) (any, []loade
 		root:      root,
 		documents: map[string]any{document: value},
 		active:    make(map[string]bool),
+		allowed:   allowed,
 	}
 	resolved, diagnostics := resolver.resolveNode(value, document, nil)
 	if len(diagnostics) != 0 {
@@ -138,6 +163,12 @@ func (r *referenceResolver) classifyReference(referringDocument, reference strin
 func (r *referenceResolver) loadTarget(targetDocument, referringDocument string, segments []string) (any, *Diagnostic) {
 	if value, ok := r.documents[targetDocument]; ok {
 		return value, nil
+	}
+	if r.allowed != nil {
+		if _, ok := r.allowed[targetDocument]; !ok {
+			issue := r.singleIssue("reference.unsupported", "reference target is not an explicit authored input", referringDocument, segments)
+			return nil, &issue
+		}
 	}
 	candidate := filepath.Join(r.root, filepath.FromSlash(targetDocument))
 	canonical, err := filepath.EvalSymlinks(candidate)

--- a/internal/contractvalidator/validator.go
+++ b/internal/contractvalidator/validator.go
@@ -265,6 +265,13 @@ func sortDiagnostics(diagnostics []Diagnostic) {
 	})
 }
 
+// SortDiagnostics applies the validator's documented total order in place.
+// Build tooling that aggregates diagnostics from multiple validation runs uses
+// this to preserve one stable error contract.
+func SortDiagnostics(diagnostics []Diagnostic) {
+	sortDiagnostics(diagnostics)
+}
+
 func cloneEntry(entry Entry) Entry {
 	entry.Schemas = append([]Schema(nil), entry.Schemas...)
 	entry.Documents = append([]Document(nil), entry.Documents...)

--- a/pkg/service/runtimelogtests/factory_runtime_log_test.go
+++ b/pkg/service/runtimelogtests/factory_runtime_log_test.go
@@ -259,7 +259,7 @@ func TestFactoryService_RunWritesCorrelationFieldsToRuntimeLog(t *testing.T) {
 		t.Fatalf("service.BuildFactoryService: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := svc.Run(ctx); err != nil {
 		t.Fatalf("Run: %v", err)

--- a/pkg/workers/process/command_test.go
+++ b/pkg/workers/process/command_test.go
@@ -271,7 +271,7 @@ func TestExecCommandRunner_ContextCancelTerminatesSpawnedChildProcess(t *testing
 	go func() {
 		deadline := time.Now().Add(3 * time.Second)
 		for time.Now().Before(deadline) {
-			if _, err := os.Stat(pidFile); err == nil {
+			if _, err := readCommandHelperPIDFile(pidFile); err == nil {
 				cancel()
 				return
 			}
@@ -897,16 +897,11 @@ func waitForCommandHelperPID(t *testing.T, pidFile string, timeout time.Duration
 	deadline := time.Now().Add(timeout)
 	var lastErr error
 	for timeout <= 0 || time.Now().Before(deadline) {
-		raw, err := os.ReadFile(pidFile)
+		pid, err := readCommandHelperPIDFile(pidFile)
 		if err == nil {
-			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(raw)))
-			if parseErr == nil && pid > 0 {
-				return pid
-			}
-			lastErr = parseErr
-		} else {
-			lastErr = err
+			return pid
 		}
+		lastErr = err
 		if timeout <= 0 {
 			break
 		}
@@ -917,6 +912,21 @@ func waitForCommandHelperPID(t *testing.T, pidFile string, timeout time.Duration
 	}
 	t.Fatalf("parse child pid from %s: %v", pidFile, lastErr)
 	return 0
+}
+
+func readCommandHelperPIDFile(pidFile string) (int, error) {
+	raw, err := os.ReadFile(pidFile)
+	if err != nil {
+		return 0, err
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil {
+		return 0, err
+	}
+	if pid <= 0 {
+		return 0, fmt.Errorf("child pid must be positive, got %d", pid)
+	}
+	return pid, nil
 }
 
 func waitForCommandHelperProcessExit(pid int, timeout time.Duration) bool {


### PR DESCRIPTION
{
  "project": "Generate Deterministic Self-Contained Draft 2020-12 Contract Documents",
  "branchName": "interfaces-b05-deterministic-schema-joiner",
  "description": "Add a build-time-only contract joiner that generates portable self-contained Draft 2020-12 documents under packages/api/generated/joined from canonical authored roots and components, resolves only supported repository-internal references, retains stable $id values, emits canonical byte-identical JSON, propagates component edits to every consumer, preserves authored inputs, and fails unsafe or invalid graphs with deterministic diagnostics without changing runtime behavior or generated OpenAPI clients.",
  "context": {
    "customerAsk": "After the B04 common contract schema and validator boundary are verified, add a build-time-only contract joiner that turns canonical authored Draft 2020-12 roots and components into self-contained documents under packages/api/generated/joined. Resolve only supported repository-internal $ref forms, retain stable $id values, canonicalize object-key ordering, propagate component edits to every joined consumer, and leave authored inputs unchanged. Make repeated and shuffled-input generation byte-identical. Reject cycles, external URLs, repository escapes, missing targets, unsupported reference forms, and authored inputs placed in generated joined output with stable code/path/message/document diagnostics. Keep the joiner out of runtime dependency paths and do not change generated OpenAPI clients or unrelated public behavior.",
    "problem": "Canonical contract roots reuse shared repository components, while downstream consumers need portable documents that do not depend on the authored file layout. Independent copying or resolution can create stale projections, fail to propagate component edits, vary output bytes with traversal or platform ordering, allow unsafe external access, treat generated output as a competing source of truth, or couple build policy into production packages.",
    "solution": "Add a stateless join operation in repository contract tooling, optionally behind a thin generation command. Accept an explicit repository root and authored root/component set, reuse the reviewed B04 loading and reference boundary, reject generated output as authored input, construct and validate each reference graph in memory without network access, preserve stable $id values, recursively sort JSON object keys, and publish the complete successful set only beneath packages/api/generated/joined. Normalize failures to the established deterministic code/path/message/document contract and keep all production packages independent of the joiner."
  },
  "acceptanceCriteria": [
    "AC-1: Nested and shared repository-internal reference fixtures generate self-contained Draft 2020-12 documents beneath packages/api/generated/joined, preserve every authored stable $id, and contain no reference that requires a file outside the generated document.",
    "AC-2: Canonical JSON recursively orders object keys and is byte-identical across repeated generation and shuffled root/component input order; focused golden generation tests pass on at least two consecutive runs.",
    "AC-3: Editing one canonical component changes every generated consumer that references it, while generation leaves all authored roots and components byte-for-byte unchanged.",
    "AC-4: Reference cycles, external URLs, repository escapes, missing targets, unsupported reference forms, and inputs beneath the generated joined-output directory fail closed without network or out-of-bound reads or partial generated output.",
    "AC-5: Every failure has stable non-empty code, path, message, and document fields, slash-normalized repository-relative document locations, and deterministic ordering independent of traversal or input order.",
    "AC-6: The joiner remains build-time-only: runtime, API, service, worker, provider, runtime CLI, and UI packages do not import it; generated OpenAPI clients and unrelated public behavior remain unchanged.",
    "AC-7: Quality gates pass: typecheck, lint, and tests, including focused joiner unit and golden tests run at least twice, make contracts-validate, make pkg-boundary, make pkg-file-count, and the narrow applicable repository verification tier."
  ],
  "userStories": [
    {
      "id": "interfaces-b05-deterministic-schema-joiner-001",
      "title": "Join supported internal references into portable documents",
      "description": "As a contract consumer, I want each authored root and its shared components joined into a self-contained Draft 2020-12 document so I can use the contract without access to the repository's component layout.",
      "acceptanceCriteria": [
        "An authored Draft 2020-12 root with nested and shared supported repository-internal $ref values generates a valid self-contained document whose remaining references, if any, resolve entirely within that document.",
        "Shared components have consistent joined content at every consuming location, and all stable $id values present in the authored root or resolved components are retained without synthetic replacement.",
        "Editing a canonical shared component and regenerating changes every joined document that consumes it; documents that do not consume it remain byte-identical.",
        "Joining is read-only with respect to authored roots and components: success does not rewrite, normalize, or otherwise mutate canonical inputs.",
        "Focused package tests cover nested references, one component shared by multiple consumers, transitive component reuse, component-edit propagation, unaffected consumers, stable $id retention, and authored-input immutability.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b05-deterministic-schema-joiner-002",
      "title": "Emit canonical byte-identical JSON",
      "description": "As a contract maintainer, I want joined documents serialized canonically so identical authored content always produces identical bytes and trustworthy review diffs.",
      "acceptanceCriteria": [
        "Joined JSON recursively sorts object keys at every depth while preserving JSON array order and value semantics required by the authored schema.",
        "Running generation at least twice with unchanged inputs produces byte-identical output and matching digests.",
        "Reversing or otherwise shuffling authored root and component input order produces the same output paths, bytes, and document order as the unshuffled run.",
        "A deterministic golden fixture covering nested objects, arrays, shared components, and stable $id values matches the generated bytes exactly.",
        "Canonicalization is derived only from explicit inputs and introduces no timestamp, absolute checkout path, random value, environment-specific separator, or map/filesystem iteration order into output.",
        "Focused canonicalization and golden tests are executed successfully on at least two consecutive runs.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b05-deterministic-schema-joiner-003",
      "title": "Fail closed with stable join diagnostics",
      "description": "As a contract author, I want invalid or unsafe reference graphs rejected consistently so I can correct the exact authored location without risking external access or ambiguous output.",
      "acceptanceCriteria": [
        "A direct or transitive reference cycle fails with a stable cycle code and identifies the authored document and $ref instance path involved; generation terminates without recursion overflow or partial joined output.",
        "HTTP(S) URLs, file URLs, absolute paths, repository escapes, missing targets, unsupported fragments, and every other unsupported reference form fail before network access or reads outside the reviewed repository boundary.",
        "Any purported authored root or component whose canonical path is inside packages/api/generated/joined is rejected, including separator, dot-segment, traversal, and symlink-equivalent path representations that resolve into that directory.",
        "Every rejection contains non-empty code, path, message, and document; document is slash-normalized and repository-relative, path uses the B04 instance-path convention, and messages contain no absolute checkout path or unstable third-party prose.",
        "Repeated runs and shuffled root/component order return identical diagnostics in the documented total order.",
        "Focused tests cover direct and indirect cycles, each unsupported or external form, missing targets, root escape and sibling-prefix cases, authored joined-output inputs, diagnostic values, ordering, and absence of partial writes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b05-deterministic-schema-joiner-004",
      "title": "Generate joined staging output through a build-only boundary",
      "description": "As a maintainer, I want a narrow generation entrypoint that writes successful joined documents only to the generated staging directory so build workflows can consume them without coupling production code to the joiner.",
      "acceptanceCriteria": [
        "The build-tool entrypoint generates selected canonical authored roots into deterministic repository-relative paths beneath packages/api/generated/joined and does not write outside that boundary.",
        "The command or function validates and joins the complete requested set before publishing output, so a failure leaves no newly partial set and preserves previously authored inputs.",
        "The entrypoint delegates parsing, reference resolution, joining, canonicalization, and diagnostics to the focused tooling owner; any command wrapper remains thin and contains no duplicate join policy.",
        "Focused integration or command tests prove successful staging, deterministic repeated output, non-zero failure with stable diagnostics, and no writes outside the generated boundary.",
        "Package-direction evidence proves runtime, API, service, worker, provider, runtime CLI, and UI packages do not import the joiner; make pkg-boundary and make pkg-file-count pass without adding a production package-family exception.",
        "make contracts-validate and the narrow applicable repository verification tier pass; generated OpenAPI clients are not modified, and unrelated failures are recorded rather than addressed through broad cleanup.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}
