### PR TITLE
session-repair-chart-materialized-consumer

### DIFF
--- a/ui/scripts/check-work-outcome-memory.ts
+++ b/ui/scripts/check-work-outcome-memory.ts
@@ -4,7 +4,11 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 
 import type { FactoryEvent } from "../src/api/events";
-import { buildWorkOutcomeTimelineSamplesFromEvents } from "../src/features/work-outcome/useWorkOutcomeChart";
+import {
+  createMaterializedWorkOutcomeState,
+  reduceMaterializedWorkOutcomeEvents,
+  selectMaterializedWorkOutcomeSamples,
+} from "../src/features/work-outcome/lib/materializer/materialized-work-outcome";
 
 type FixtureName =
   | "baseline"
@@ -168,8 +172,11 @@ function main(): void {
   gcIfAvailable();
   const heapBeforeMB = sampleHeapUsedMB();
   const startedAt = performance.now();
-  const samples = buildWorkOutcomeTimelineSamplesFromEvents(
-    events,
+  const samples = selectMaterializedWorkOutcomeSamples(
+    reduceMaterializedWorkOutcomeEvents(
+      createMaterializedWorkOutcomeState(),
+      events,
+    ),
     selectedTick,
   );
   const durationMs = Number((performance.now() - startedAt).toFixed(1));

--- a/ui/scripts/feature-cross-import-allowlist.mjs
+++ b/ui/scripts/feature-cross-import-allowlist.mjs
@@ -1354,12 +1354,6 @@ export const allowlistedCrossFeatureBoundaryViolations = [
       "Legacy cross-feature internal import. Route reuse through the target feature public/ boundary or relocate shared behavior.",
   },
   {
-    relativeFilePath: "src/features/work-outcome/hooks/useWorkOutcomeChart.ts",
-    importSpecifiers: ["../../timeline/state/factoryTimelineStore"],
-    reason:
-      "Legacy cross-feature internal import. Route reuse through the target feature public/ boundary or relocate shared behavior.",
-  },
-  {
     relativeFilePath:
       "src/features/workflow-activity/components/dashboard-flow-axis-legend.tsx",
     importSpecifiers: [

--- a/ui/scripts/feature-cross-import-allowlist.mjs
+++ b/ui/scripts/feature-cross-import-allowlist.mjs
@@ -55,10 +55,7 @@ export const allowlistedCrossFeatureBoundaryViolations = [
   {
     relativeFilePath:
       "src/features/bento/hooks/use-dashboard-bento-snapshot.ts",
-    importSpecifiers: [
-      "../../current-selection/hooks/core/useCurrentSelection",
-      "../../timeline/state/factoryTimelineStore",
-    ],
+    importSpecifiers: ["../../current-selection/hooks/core/useCurrentSelection"],
     reason:
       "Legacy cross-feature internal import. Route reuse through the target feature public/ boundary or relocate shared behavior.",
   },

--- a/ui/src/App.current-selection.test.tsx
+++ b/ui/src/App.current-selection.test.tsx
@@ -563,7 +563,7 @@ describe("App current selection", () => {
       act(() => {
         seedTimelineSnapshot(
           {
-          ...semanticWorkflowDashboardSnapshot,
+            ...semanticWorkflowDashboardSnapshot,
             tick_count: semanticWorkflowDashboardSnapshot.tick_count + 1,
           } satisfies DashboardSnapshot,
           activeStoryTraceFixtures,
@@ -665,10 +665,15 @@ describe("App current selection", () => {
         within(dashboardGrid).getByRole("article", { name: "Submit work" }),
       ).toBeTruthy();
       expect(
-        within(dashboardGrid).getByRole("img", {
-          name: "Work outcome chart for Session",
+        within(dashboardGrid).getByRole("heading", {
+          name: "No work outcome samples",
         }),
       ).toBeTruthy();
+      expect(
+        within(dashboardGrid).queryByRole("img", {
+          name: "Work outcome chart for Session",
+        }),
+      ).toBeNull();
       expect(
         within(dashboardGrid).getByRole("article", {
           name: "Trace drill-down",

--- a/ui/src/features/bento/components/dashboard-bento-cards.tsx
+++ b/ui/src/features/bento/components/dashboard-bento-cards.tsx
@@ -344,6 +344,7 @@ function buildDuplicateCapableWidgetCard({
         widgetType: layoutItem.widgetType,
         children: (
           <WorkOutcomeWidget
+            chartState={workChartModel.chartState}
             headerAction={headerAction}
             locale={locale}
             model={workChartModel}

--- a/ui/src/features/bento/components/dashboard-bento.test.tsx
+++ b/ui/src/features/bento/components/dashboard-bento.test.tsx
@@ -206,7 +206,10 @@ vi.mock("../../trace-drilldown/public", () => ({
 }));
 
 vi.mock("../../work-outcome/hooks/useWorkOutcomeChart", () => ({
-  useWorkOutcomeChart: () => ({ status: "empty" }),
+  useWorkOutcomeChart: () => ({
+    chartState: { status: "ready" },
+    status: "empty",
+  }),
 }));
 
 vi.mock("../../work-outcome/public", () => ({

--- a/ui/src/features/bento/components/dashboard-bento.test.tsx
+++ b/ui/src/features/bento/components/dashboard-bento.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import * as React from "react";
 import type { LoadableProviderSessionRef } from "../../provider-session-detail/lib/provider-session-ref";
+import { createMaterializedWorkOutcomeState } from "../../work-outcome/public/materializer";
 
 import { DEFAULT_DASHBOARD_LAYOUT } from "../hooks/dashboardLayoutSchema";
 
@@ -152,6 +153,7 @@ vi.mock("../../dashboard/session/dashboard-session-provider", () => ({
 
 const defaultTimelineStoreState = {
   events: [] as [],
+  materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
   selectedTick: 1,
   worldViewCache: {
     1: {
@@ -357,6 +359,7 @@ describe("DashboardBento", () => {
   it("renders nothing while the selected timeline snapshot is unavailable", () => {
     timelineStoreState = {
       events: [],
+      materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
       selectedTick: 99,
       worldViewCache: {},
     };

--- a/ui/src/features/bento/components/dashboard-bento.tsx
+++ b/ui/src/features/bento/components/dashboard-bento.tsx
@@ -59,11 +59,10 @@ export function DashboardBento({ locale }: DashboardBentoProps = {}) {
   const { rawSessionID, sessionID } = useDashboardSession();
   const {
     currentSelection,
+    materializedWorkOutcomeState,
     selectedSnapshot,
     selectedTimelineTick,
     snapshot,
-    timelineEvents,
-    worldViewCache,
   } = useDashboardBentoSnapshot(sessionID);
   const importController = useCurrentActivityImportController({
     currentFactoryDefinition: snapshot.factory,
@@ -93,9 +92,8 @@ export function DashboardBento({ locale }: DashboardBentoProps = {}) {
     });
   const workChartModel = useWorkOutcomeChart({
     locale: resolvedLocale,
+    materializedWorkOutcomeState,
     selectedTimelineTick,
-    timelineEvents,
-    worldViewCache,
   });
   const cards = buildDashboardCardLayouts({
     addDashboardWidget,

--- a/ui/src/features/bento/components/dashboard-bento.tsx
+++ b/ui/src/features/bento/components/dashboard-bento.tsx
@@ -9,7 +9,10 @@ import { DashboardImportPreviewDialog } from "../../import/public";
 import { useTraceDrilldown } from "../../trace-drilldown/hooks/useTraceDrilldown";
 import { useWorkOutcomeChart } from "../../work-outcome/hooks/useWorkOutcomeChart";
 import { useCurrentActivityImportController } from "../../workflow-activity/hooks/current-activity-import-controller";
-import { useDashboardBentoSnapshot } from "../hooks/use-dashboard-bento-snapshot";
+import {
+  type DashboardWorkOutcomeStream,
+  useDashboardBentoSnapshot,
+} from "../hooks/use-dashboard-bento-snapshot";
 import {
   getRenderableDashboardLayout,
   useDashboardLayout,
@@ -39,9 +42,13 @@ function useDashboardBentoSelectionState() {
 
 export interface DashboardBentoProps {
   locale?: string;
+  workOutcomeStream?: DashboardWorkOutcomeStream;
 }
 
-export function DashboardBento({ locale }: DashboardBentoProps = {}) {
+export function DashboardBento({
+  locale,
+  workOutcomeStream,
+}: DashboardBentoProps = {}) {
   const { locale: resolvedLocale } = useAppLocale(locale);
   const {
     addDashboardWidget,
@@ -63,7 +70,8 @@ export function DashboardBento({ locale }: DashboardBentoProps = {}) {
     selectedSnapshot,
     selectedTimelineTick,
     snapshot,
-  } = useDashboardBentoSnapshot(sessionID);
+    workOutcomeHydrationStatus,
+  } = useDashboardBentoSnapshot(sessionID, workOutcomeStream);
   const importController = useCurrentActivityImportController({
     currentFactoryDefinition: snapshot.factory,
     locale: resolvedLocale,
@@ -91,6 +99,7 @@ export function DashboardBento({ locale }: DashboardBentoProps = {}) {
         snapshot.runtime.workstation_requests_by_dispatch_id,
     });
   const workChartModel = useWorkOutcomeChart({
+    hydrationStatus: workOutcomeHydrationStatus,
     locale: resolvedLocale,
     materializedWorkOutcomeState,
     selectedTimelineTick,

--- a/ui/src/features/bento/hooks/use-dashboard-bento-snapshot.test.ts
+++ b/ui/src/features/bento/hooks/use-dashboard-bento-snapshot.test.ts
@@ -1,0 +1,70 @@
+import { createMaterializedWorkOutcomeState } from "../../work-outcome/public/materializer";
+import {
+  type DashboardWorkOutcomeStream,
+  selectDashboardWorkOutcomeInput,
+} from "./use-dashboard-bento-snapshot";
+
+const resolvedStream: DashboardWorkOutcomeStream = {
+  identity: {
+    backendScopeID: "backend-a",
+    factorySessionID: "session-a",
+    logicalSessionKeyID: "logical-a",
+    streamGenerationID: "generation-b",
+  },
+  status: "ready",
+};
+
+describe("dashboard work outcome stream selection", () => {
+  it("keeps stale active outcomes hidden until the resolved entry is published", () => {
+    const staleState = createMaterializedWorkOutcomeState();
+
+    expect(
+      selectDashboardWorkOutcomeInput(
+        {
+          entriesByKey: {},
+          materializedWorkOutcomeState: staleState,
+          selectedTick: 99,
+        },
+        resolvedStream,
+      ),
+    ).toEqual({
+      hydrationStatus: "loading",
+      materializedWorkOutcomeState: undefined,
+      selectedTimelineTick: 0,
+    });
+  });
+
+  it("selects materialized outcomes from the exact resolved generation", () => {
+    const staleState = createMaterializedWorkOutcomeState();
+    const resolvedState = {
+      ...createMaterializedWorkOutcomeState(),
+      counts: {
+        completed: 4,
+        dispatched: 4,
+        failed: 0,
+        inFlight: 0,
+        queued: 0,
+      },
+    };
+
+    expect(
+      selectDashboardWorkOutcomeInput(
+        {
+          entriesByKey: {
+            [JSON.stringify(["backend-a", "session-a", "generation-b"])]: {
+              materializedWorkOutcomeState: resolvedState,
+              selectedTick: 42,
+            },
+          },
+          materializedWorkOutcomeState: staleState,
+          selectedTick: 99,
+        },
+        resolvedStream,
+      ),
+    ).toEqual({
+      hydrationStatus: "ready",
+      materializedWorkOutcomeState: resolvedState,
+      selectedTimelineTick: 42,
+    });
+  });
+});

--- a/ui/src/features/bento/hooks/use-dashboard-bento-snapshot.ts
+++ b/ui/src/features/bento/hooks/use-dashboard-bento-snapshot.ts
@@ -1,7 +1,56 @@
 import type { DashboardSnapshot } from "../../../api/dashboard/types";
 import { DEFAULT_FACTORY_SESSION_ID } from "../../../api/session-routing";
 import { useCurrentSelection } from "../../current-selection/hooks/core/useCurrentSelection";
-import { useFactoryTimelineStore } from "../../timeline/state/factoryTimelineStore";
+import {
+  factoryTimelineEntryKey,
+  type StreamDerivedCacheIdentity,
+  useFactoryTimelineStore,
+} from "../../timeline/public";
+
+export interface DashboardWorkOutcomeStream {
+  identity: StreamDerivedCacheIdentity | null;
+  status: "loading" | "ready";
+}
+
+interface WorkOutcomeTimelineSelectionState {
+  entriesByKey?: Record<
+    string,
+    | {
+        materializedWorkOutcomeState: unknown;
+        selectedTick: number;
+      }
+    | undefined
+  >;
+  materializedWorkOutcomeState: unknown;
+  selectedTick: number;
+}
+
+export function selectDashboardWorkOutcomeInput(
+  state: WorkOutcomeTimelineSelectionState,
+  stream?: DashboardWorkOutcomeStream,
+): {
+  hydrationStatus: DashboardWorkOutcomeStream["status"];
+  materializedWorkOutcomeState: unknown;
+  selectedTimelineTick: number;
+} {
+  const exactEntryKey = stream?.identity
+    ? factoryTimelineEntryKey(stream.identity)
+    : null;
+  const exactEntry = exactEntryKey ? state.entriesByKey?.[exactEntryKey] : null;
+  const exactEntryPending =
+    stream?.status === "ready" && exactEntryKey !== null && !exactEntry;
+
+  return {
+    hydrationStatus:
+      stream?.status === "loading" || exactEntryPending ? "loading" : "ready",
+    materializedWorkOutcomeState: exactEntryKey
+      ? exactEntry?.materializedWorkOutcomeState
+      : state.materializedWorkOutcomeState,
+    selectedTimelineTick: exactEntryKey
+      ? (exactEntry?.selectedTick ?? 0)
+      : state.selectedTick,
+  };
+}
 
 const EMPTY_DASHBOARD_SNAPSHOT: DashboardSnapshot = {
   factory_state: "IDLE",
@@ -26,12 +75,21 @@ const EMPTY_DASHBOARD_SNAPSHOT: DashboardSnapshot = {
 
 export function useDashboardBentoSnapshot(
   sessionID: string | null | undefined,
+  workOutcomeStream?: DashboardWorkOutcomeStream,
 ) {
   const materializedWorkOutcomeState = useFactoryTimelineStore(
-    (state) => state.materializedWorkOutcomeState,
+    (state) =>
+      selectDashboardWorkOutcomeInput(state, workOutcomeStream)
+        .materializedWorkOutcomeState,
   );
   const selectedTimelineTick = useFactoryTimelineStore(
-    (state) => state.selectedTick,
+    (state) =>
+      selectDashboardWorkOutcomeInput(state, workOutcomeStream)
+        .selectedTimelineTick,
+  );
+  const workOutcomeHydrationStatus = useFactoryTimelineStore(
+    (state) =>
+      selectDashboardWorkOutcomeInput(state, workOutcomeStream).hydrationStatus,
   );
   const workstationRequestsByDispatchID = useFactoryTimelineStore(
     (state) =>
@@ -46,12 +104,12 @@ export function useDashboardBentoSnapshot(
     snapshot,
     workstationRequestsByDispatchID,
   });
-
   return {
     currentSelection,
     materializedWorkOutcomeState,
     selectedSnapshot,
     selectedTimelineTick,
     snapshot,
+    workOutcomeHydrationStatus,
   };
 }

--- a/ui/src/features/bento/hooks/use-dashboard-bento-snapshot.ts
+++ b/ui/src/features/bento/hooks/use-dashboard-bento-snapshot.ts
@@ -27,12 +27,11 @@ const EMPTY_DASHBOARD_SNAPSHOT: DashboardSnapshot = {
 export function useDashboardBentoSnapshot(
   sessionID: string | null | undefined,
 ) {
-  const timelineEvents = useFactoryTimelineStore((state) => state.events);
+  const materializedWorkOutcomeState = useFactoryTimelineStore(
+    (state) => state.materializedWorkOutcomeState,
+  );
   const selectedTimelineTick = useFactoryTimelineStore(
     (state) => state.selectedTick,
-  );
-  const worldViewCache = useFactoryTimelineStore(
-    (state) => state.worldViewCache,
   );
   const workstationRequestsByDispatchID = useFactoryTimelineStore(
     (state) =>
@@ -50,10 +49,9 @@ export function useDashboardBentoSnapshot(
 
   return {
     currentSelection,
+    materializedWorkOutcomeState,
     selectedSnapshot,
     selectedTimelineTick,
     snapshot,
-    timelineEvents,
-    worldViewCache,
   };
 }

--- a/ui/src/features/dashboard/components/dashboard-screen.single-scroll.test.tsx
+++ b/ui/src/features/dashboard/components/dashboard-screen.single-scroll.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach } from "vitest";
 import type { DashboardSnapshot } from "../../../api/dashboard/types";
 import { dashboardSemanticSnapshotFixtures } from "../../../components/dashboard/fixtures";
 import { installDashboardBrowserTestShims } from "../../../components/dashboard/test-browser-shims";
+import { createMaterializedWorkOutcomeState } from "../../work-outcome/public/materializer";
 import { DashboardScreen } from "./dashboard-screen";
 
 const VIEWPORT_HEIGHT = 768;
@@ -88,13 +89,10 @@ vi.mock("../../bento/hooks/use-dashboard-bento-snapshot", () => ({
         terminalWorkDetail: null,
         undoSelection: vi.fn(),
       },
+      materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
       selectedSnapshot: snapshot,
       selectedTimelineTick: snapshot.tick_count,
       snapshot,
-      timelineEvents: [],
-      worldViewCache: {
-        [snapshot.tick_count]: snapshot,
-      },
     };
   }),
 }));

--- a/ui/src/features/dashboard/components/dashboard-screen.test.tsx
+++ b/ui/src/features/dashboard/components/dashboard-screen.test.tsx
@@ -43,10 +43,23 @@ function StatusPanelProbe({
 }
 
 vi.mock("../../bento/public", () => ({
-  DashboardBento: ({ locale }: { locale?: string }) => {
+  DashboardBento: ({
+    locale,
+    workOutcomeStream,
+  }: {
+    locale?: string;
+    workOutcomeStream?: {
+      identity: { streamGenerationID: string } | null;
+      status: "loading" | "ready";
+    };
+  }) => {
     const { locale: resolvedLocale } = useAppLocale(locale);
     return (
-      <section data-testid="dashboard-bento-probe">
+      <section
+        data-stream-generation={workOutcomeStream?.identity?.streamGenerationID}
+        data-stream-status={workOutcomeStream?.status}
+        data-testid="dashboard-bento-probe"
+      >
         Dashboard bento {resolvedLocale}
       </section>
     );
@@ -272,6 +285,12 @@ describe("DashboardScreen content states", () => {
         message: "Factory event stream connected.",
         status: "live",
       },
+      workOutcomeStreamIdentity: {
+        backendScopeID: "backend-a",
+        factorySessionID: "session-a",
+        logicalSessionKeyID: "logical-a",
+        streamGenerationID: "generation-a",
+      },
     };
 
     render(
@@ -284,6 +303,30 @@ describe("DashboardScreen content states", () => {
     expect(screen.getByText("Dashboard header zh-CN")).toBeTruthy();
     expect(screen.getByText("Dashboard bento zh-CN")).toBeTruthy();
     expect(screen.getByText("Dashboard export dialog zh-CN")).toBeTruthy();
+    expect(screen.getByTestId("dashboard-bento-probe").dataset).toMatchObject({
+      streamGeneration: "generation-a",
+      streamStatus: "ready",
+    });
+  });
+
+  it("keeps the work outcome card in hydration mode while preflight is pending", () => {
+    dashboardSnapshotState = {
+      error: null,
+      isInitialLoading: false,
+      preflightRecovery: null,
+      preflightStatus: "loading",
+      snapshot: {} as never,
+      streamState: {
+        message: "Validating retained history.",
+        status: "connecting",
+      },
+    };
+
+    render(<DashboardScreen />);
+
+    expect(screen.getByTestId("dashboard-bento-probe").dataset).toMatchObject({
+      streamStatus: "loading",
+    });
   });
 
   it("does not introduce a nested vertical scroll owner on the success path", () => {

--- a/ui/src/features/dashboard/components/dashboard-screen.tsx
+++ b/ui/src/features/dashboard/components/dashboard-screen.tsx
@@ -92,11 +92,18 @@ function DashboardScreenContent({ locale }: DashboardScreenProps = {}) {
     (state) => state.incrementRefreshToken,
   );
   const refreshToken = useDashboardBentoStore((state) => state.refreshToken);
-  const { snapshot, isInitialLoading, error, preflightRecovery, streamState } =
-    useDashboardSnapshot({
-      locale: resolvedLocale,
-      refreshToken,
-    });
+  const {
+    snapshot,
+    isInitialLoading,
+    error,
+    preflightRecovery,
+    preflightStatus,
+    streamState,
+    workOutcomeStreamIdentity,
+  } = useDashboardSnapshot({
+    locale: resolvedLocale,
+    refreshToken,
+  });
   useDashboardWorldView();
   const messages = getHeaderControlsMessages(resolvedLocale);
   const recoveryMessages = getDashboardRecoveryMessages(resolvedLocale);
@@ -194,7 +201,13 @@ function DashboardScreenContent({ locale }: DashboardScreenProps = {}) {
     <main className={DASHBOARD_SHELL_CLASS}>
       <DashboardHeader locale={locale} />
 
-      <DashboardBento locale={locale} />
+      <DashboardBento
+        locale={locale}
+        workOutcomeStream={{
+          identity: workOutcomeStreamIdentity ?? null,
+          status: preflightStatus === "success" ? "ready" : "loading",
+        }}
+      />
       <DashboardExportDialog locale={locale} />
     </main>
   );

--- a/ui/src/features/dashboard/hooks/useDashboardSnapshot.ts
+++ b/ui/src/features/dashboard/hooks/useDashboardSnapshot.ts
@@ -1,10 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { FactoryEvent } from "../../../api/events";
-import {
-  recordSessionPersistenceInvalidation,
-  silentReplayRecoveryDiagnostic,
-} from "../public";
+import { DEFAULT_FACTORY_SESSION_ID } from "../../../api/session-routing";
 import {
   clearTimelineCheckpoint,
   type FactoryTimelineCheckpoint,
@@ -14,10 +11,13 @@ import {
   type TimelineCheckpointStreamIdentity,
   useFactoryTimelineStore,
 } from "../../timeline/public";
-import { DEFAULT_FACTORY_SESSION_ID } from "../../../api/session-routing";
+import {
+  recordSessionPersistenceInvalidation,
+  silentReplayRecoveryDiagnostic,
+} from "../public";
 import { useDashboardSession } from "../session/dashboard-session-provider";
-import { useDashboardCheckpointPreflight } from "./preflight/use-dashboard-checkpoint-preflight";
 import { useFactoryEventStream } from "./event-stream/useFactoryEventStream";
+import { useDashboardCheckpointPreflight } from "./preflight/use-dashboard-checkpoint-preflight";
 import { useDashboardSessionLifecycle } from "./useDashboardSessionLifecycle";
 import { useDashboardTimelineMemoryDebug } from "./useDashboardTimelineMemoryDebug";
 import { useDashboardWorldView } from "./useDashboardWorldView";
@@ -25,6 +25,18 @@ import { useDashboardWorldView } from "./useDashboardWorldView";
 export interface UseDashboardSnapshotOptions {
   locale?: string | null;
   refreshToken?: number;
+}
+
+export interface DashboardSnapshotResult {
+  error: Error | null;
+  isInitialLoading: boolean;
+  preflightRecovery: ReturnType<
+    typeof useDashboardCheckpointPreflight
+  >["preflightRecovery"];
+  preflightStatus: DashboardPreflightStatus;
+  snapshot: ReturnType<typeof useDashboardWorldView>["snapshot"] | null;
+  streamState: ReturnType<typeof useDashboardWorldView>["streamState"];
+  workOutcomeStreamIdentity?: TimelineCheckpointStreamIdentity | null;
 }
 
 type DashboardPreflightStatus = "loading" | "non-recoverable" | "success";
@@ -66,7 +78,7 @@ function usePersistedTimelineCheckpoint({
 export function useDashboardSnapshot({
   locale,
   refreshToken = 0,
-}: UseDashboardSnapshotOptions = {}) {
+}: UseDashboardSnapshotOptions = {}): DashboardSnapshotResult {
   const activateTimelineEntry = useFactoryTimelineStore(
     (state) => state.activateEntry,
   );
@@ -285,6 +297,7 @@ export function useDashboardSnapshot({
       preflightStatus,
       snapshot: preflightRecovery ? null : snapshot,
       streamState,
+      workOutcomeStreamIdentity: streamIdentity,
     }),
     [
       error,
@@ -294,6 +307,7 @@ export function useDashboardSnapshot({
       preflightStatus,
       snapshot,
       streamState,
+      streamIdentity,
     ],
   );
 }

--- a/ui/src/features/work-outcome/components/work-chart.test.tsx
+++ b/ui/src/features/work-outcome/components/work-chart.test.tsx
@@ -2,8 +2,12 @@ import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FACTORY_EVENT_TYPES, type FactoryEvent } from "../../../api/events";
 import { installDashboardBrowserTestShims } from "../../../components/dashboard/test-browser-shims";
-import { buildWorkOutcomeTimelineSamplesFromEvents } from "../hooks/useWorkOutcomeChart";
 import { getDashboardWorkChartSeriesStyle } from "../lib/chart-contract";
+import {
+  createMaterializedWorkOutcomeState,
+  reduceMaterializedWorkOutcomeEvents,
+  selectMaterializedWorkOutcomeSamples,
+} from "../lib/materializer/materialized-work-outcome";
 import { buildWorkChartModel, type WorkChartModel } from "../lib/trends";
 import { getWorkOutcomeMessages } from "../messages/work-outcome";
 import { WorkChartCard } from "./d3-information-card";
@@ -195,8 +199,8 @@ const edgeZoomWorkChartModel: WorkChartModel = {
 };
 
 const liveSessionLikeModel = buildWorkChartModel(
-  buildWorkOutcomeTimelineSamplesFromEvents(
-    [
+  selectMaterializedWorkOutcomeSamples(
+    reduceMaterializedWorkOutcomeEvents(createMaterializedWorkOutcomeState(), [
       workOutcomeEvent("run-started", 0, FACTORY_EVENT_TYPES.runRequest, {
         factory: {
           resources: [{ capacity: 10, name: "executor-slot" }],
@@ -335,7 +339,7 @@ const liveSessionLikeModel = buildWorkChartModel(
         },
         { dispatchId: "dispatch-plan-c" },
       ),
-    ],
+    ]),
     12,
   ),
   "session",

--- a/ui/src/features/work-outcome/hooks/useWorkOutcomeChart.test.ts
+++ b/ui/src/features/work-outcome/hooks/useWorkOutcomeChart.test.ts
@@ -11,13 +11,11 @@ import {
 import {
   createMaterializedWorkOutcomeState,
   reduceMaterializedWorkOutcomeEvents,
+  selectMaterializedWorkOutcomeSamples,
 } from "../lib/materializer/materialized-work-outcome";
-import {
-  buildWorkOutcomeTimelineSamplesFromEvents,
-  useWorkOutcomeChart,
-} from "./useWorkOutcomeChart";
+import { useWorkOutcomeChart } from "./useWorkOutcomeChart";
 
-describe("buildWorkOutcomeTimelineSamplesFromEvents", () => {
+describe("materialized work outcome chart projection", () => {
   const baselineEvents = [
     event("run-started", 0, FACTORY_EVENT_TYPES.runRequest, {
       factory: {
@@ -205,8 +203,11 @@ describe("buildWorkOutcomeTimelineSamplesFromEvents", () => {
   });
 
   it("projects the exact uninterrupted customer work-outcome series", () => {
-    const samples = buildWorkOutcomeTimelineSamplesFromEvents(
-      baselineEvents,
+    const samples = selectMaterializedWorkOutcomeSamples(
+      reduceMaterializedWorkOutcomeEvents(
+        createMaterializedWorkOutcomeState(),
+        baselineEvents,
+      ),
       6,
     );
 
@@ -291,7 +292,7 @@ describe("buildWorkOutcomeTimelineSamplesFromEvents", () => {
     ]);
   });
 
-  it("adapts selected events from the materialized state", () => {
+  it("clips the retained materialized samples without rebuilding from events", () => {
     const selectedEvents = baselineEvents.filter(
       (timelineEvent) => timelineEvent.context.tick <= 4,
     );
@@ -301,15 +302,23 @@ describe("buildWorkOutcomeTimelineSamplesFromEvents", () => {
     );
 
     expect(
-      buildWorkOutcomeTimelineSamplesFromEvents(
-        [...baselineEvents, tailEvent],
+      selectMaterializedWorkOutcomeSamples(
+        reduceMaterializedWorkOutcomeEvents(
+          createMaterializedWorkOutcomeState(),
+          [...baselineEvents, tailEvent],
+        ),
         4,
       ),
     ).toEqual(materialized.samples);
-    expect(buildWorkOutcomeTimelineSamplesFromEvents([], 4)).toEqual([]);
+    expect(
+      selectMaterializedWorkOutcomeSamples(
+        createMaterializedWorkOutcomeState(),
+        4,
+      ),
+    ).toEqual([]);
   });
 
-  it("characterizes checkpoint restore, tail replacement, and duplicate delivery", async () => {
+  it("preserves the restored baseline and extends it with one accepted live event", async () => {
     const { indexedDB } = createIndexedDBTestDouble();
     const streamIdentity = streamIdentityFixture();
 
@@ -318,6 +327,7 @@ describe("buildWorkOutcomeTimelineSamplesFromEvents", () => {
     expect(
       uninterrupted.result.current.samples.map((sample) => sample.tick),
     ).toEqual([0, 1, 2, 3, 4, 5, 6]);
+    const uninterruptedBaseline = uninterrupted.result.current.samples;
 
     const baselineCheckpoint =
       useFactoryTimelineStore.getState().currentReplayCheckpoint;
@@ -343,42 +353,24 @@ describe("buildWorkOutcomeTimelineSamplesFromEvents", () => {
     });
 
     const restored = renderHook(() => useTimelineWorkOutcomeChart());
-    expect(restored.result.current.samples).toEqual([
-      {
-        completedCount: 1,
-        dispatchedCount: 2,
-        failedByWorkType: { story: 1 },
-        failedCount: 1,
-        failedWorkLabels: ["Story Two"],
-        inFlightCount: 0,
-        observedAt: 0,
-        queuedCount: 0,
-        tick: 6,
-      },
-    ]);
+    expect(restored.result.current.samples).toEqual(uninterruptedBaseline);
+    expect(
+      restored.result.current.samples.map((sample) => sample.tick),
+    ).toEqual([0, 1, 2, 3, 4, 5, 6]);
+    expect(restored.result.current.samples.at(-1)).toMatchObject({
+      completedCount: 1,
+      dispatchedCount: 2,
+      failedByWorkType: { story: 1 },
+      failedCount: 1,
+      failedWorkLabels: ["Story Two"],
+      tick: 6,
+    });
 
     act(() => useFactoryTimelineStore.getState().appendEvent(tailEvent));
     expect(restored.result.current.samples).toEqual([
-      {
-        completedCount: 0,
-        dispatchedCount: 0,
-        failedByWorkType: {},
-        failedCount: 0,
-        failedWorkLabels: [],
-        inFlightCount: 0,
-        observedAt: 1777464007000,
-        queuedCount: 0,
-        tick: 7,
-      },
+      ...uninterruptedBaseline,
+      expect.objectContaining({ queuedCount: 1, tick: 7 }),
     ]);
-    expect(
-      [0, 1, 2, 3, 4, 5, 6].filter(
-        (tick) =>
-          !restored.result.current.samples.some(
-            (sample) => sample.tick === tick,
-          ),
-      ),
-    ).toEqual([0, 1, 2, 3, 4, 5, 6]);
 
     const samplesAfterFirstTail = restored.result.current.samples;
     act(() => useFactoryTimelineStore.getState().appendEvent(tailEvent));
@@ -388,19 +380,19 @@ describe("buildWorkOutcomeTimelineSamplesFromEvents", () => {
         .getState()
         .events.filter((timelineEvent) => timelineEvent.id === tailEvent.id),
     ).toHaveLength(1);
+    uninterrupted.unmount();
+    restored.unmount();
   });
 });
 
 function useTimelineWorkOutcomeChart() {
-  const events = useFactoryTimelineStore((state) => state.events);
-  const selectedTick = useFactoryTimelineStore((state) => state.selectedTick);
-  const worldViewCache = useFactoryTimelineStore(
-    (state) => state.worldViewCache,
+  const materializedWorkOutcomeState = useFactoryTimelineStore(
+    (state) => state.materializedWorkOutcomeState,
   );
+  const selectedTick = useFactoryTimelineStore((state) => state.selectedTick);
   return useWorkOutcomeChart({
+    materializedWorkOutcomeState,
     selectedTimelineTick: selectedTick,
-    timelineEvents: events,
-    worldViewCache,
   });
 }
 

--- a/ui/src/features/work-outcome/hooks/useWorkOutcomeChart.test.ts
+++ b/ui/src/features/work-outcome/hooks/useWorkOutcomeChart.test.ts
@@ -292,30 +292,79 @@ describe("materialized work outcome chart projection", () => {
     ]);
   });
 
-  it("clips the retained materialized samples without rebuilding from events", () => {
-    const selectedEvents = baselineEvents.filter(
-      (timelineEvent) => timelineEvent.context.tick <= 4,
-    );
+  it("clips exact, between-sample, and before-history ticks without mutating materialized state", () => {
     const materialized = reduceMaterializedWorkOutcomeEvents(
       createMaterializedWorkOutcomeState(),
-      selectedEvents,
+      baselineEvents,
+    );
+    const materializedBeforeSelection = structuredClone(materialized);
+    const samplesThroughTickFour = materialized.samples.filter(
+      (sample) => sample.tick <= 4,
     );
 
+    expect(selectMaterializedWorkOutcomeSamples(materialized, 4)).toEqual(
+      samplesThroughTickFour,
+    );
+    expect(selectMaterializedWorkOutcomeSamples(materialized, 4.5)).toEqual(
+      samplesThroughTickFour,
+    );
+    expect(selectMaterializedWorkOutcomeSamples(materialized, -1)).toEqual([]);
+    expect(materialized).toEqual(materializedBeforeSelection);
+  });
+
+  it("keeps a historical chart pinned while live outcomes advance and restores current history", () => {
+    const store = useFactoryTimelineStore.getState();
+    act(() => store.appendEvents(baselineEvents));
+    const chart = renderHook(() => useTimelineWorkOutcomeChart());
+    const materializedBeforeSelection =
+      useFactoryTimelineStore.getState().materializedWorkOutcomeState;
+    const baselineBeforeSelection = structuredClone(
+      materializedBeforeSelection,
+    );
+
+    act(() => store.selectTick(-1));
+    expect(chart.result.current.samples).toEqual([]);
+    expect(chart.result.current.points).toEqual([]);
+
+    act(() => store.selectTick(4));
+    expect(chart.result.current.samples.map((sample) => sample.tick)).toEqual([
+      0, 1, 2, 3, 4,
+    ]);
+    expect(chart.result.current.samples.at(-1)).toMatchObject({
+      completedCount: 1,
+      failedCount: 0,
+      queuedCount: 1,
+      tick: 4,
+    });
     expect(
-      selectMaterializedWorkOutcomeSamples(
-        reduceMaterializedWorkOutcomeEvents(
-          createMaterializedWorkOutcomeState(),
-          [...baselineEvents, tailEvent],
-        ),
-        4,
-      ),
-    ).toEqual(materialized.samples);
+      useFactoryTimelineStore.getState().materializedWorkOutcomeState,
+    ).toBe(materializedBeforeSelection);
+    expect(materializedBeforeSelection).toEqual(baselineBeforeSelection);
+
+    act(() => store.appendEvent(tailEvent));
+    expect(chart.result.current.samples.map((sample) => sample.tick)).toEqual([
+      0, 1, 2, 3, 4,
+    ]);
+    const materializedAfterTail =
+      useFactoryTimelineStore.getState().materializedWorkOutcomeState;
+    const baselineAfterTail = structuredClone(materializedAfterTail);
+    expect(materializedAfterTail.samples.map((sample) => sample.tick)).toEqual([
+      0, 1, 2, 3, 4, 5, 6, 7,
+    ]);
+    expect(materializedAfterTail).toMatchObject({
+      counts: { completed: 1, failed: 1, queued: 1 },
+      cursor: { eventID: tailEvent.id, tick: 7 },
+    });
+
+    act(() => store.setCurrentMode());
+    expect(chart.result.current.samples.map((sample) => sample.tick)).toEqual([
+      0, 1, 2, 3, 4, 5, 6, 7,
+    ]);
     expect(
-      selectMaterializedWorkOutcomeSamples(
-        createMaterializedWorkOutcomeState(),
-        4,
-      ),
-    ).toEqual([]);
+      useFactoryTimelineStore.getState().materializedWorkOutcomeState,
+    ).toBe(materializedAfterTail);
+    expect(materializedAfterTail).toEqual(baselineAfterTail);
+    chart.unmount();
   });
 
   it("preserves the restored baseline and extends it with one accepted live event", async () => {

--- a/ui/src/features/work-outcome/hooks/useWorkOutcomeChart.test.ts
+++ b/ui/src/features/work-outcome/hooks/useWorkOutcomeChart.test.ts
@@ -16,6 +16,74 @@ import {
 import { useWorkOutcomeChart } from "./useWorkOutcomeChart";
 
 describe("materialized work outcome chart projection", () => {
+  it("maps hydration, valid empty, malformed, and zero-valued history to explicit states", () => {
+    const emptyState = createMaterializedWorkOutcomeState();
+    const zeroSampleState = {
+      ...emptyState,
+      samples: [
+        {
+          completedCount: 0,
+          dispatchedCount: 0,
+          failedByWorkType: {},
+          failedCount: 0,
+          failedWorkLabels: [],
+          inFlightCount: 0,
+          observedAt: 0,
+          queuedCount: 0,
+          tick: 0,
+        },
+      ],
+    };
+    const { result, rerender } = renderHook(
+      ({ hydrationStatus, materializedWorkOutcomeState }) =>
+        useWorkOutcomeChart({
+          hydrationStatus,
+          materializedWorkOutcomeState,
+          selectedTimelineTick: 10,
+        }),
+      {
+        initialProps: {
+          hydrationStatus: "loading" as "loading" | "ready",
+          materializedWorkOutcomeState: zeroSampleState as unknown,
+        },
+      },
+    );
+
+    expect(result.current.chartState).toEqual({ status: "loading" });
+    expect(result.current.samples).toEqual([]);
+
+    rerender({
+      hydrationStatus: "ready",
+      materializedWorkOutcomeState: emptyState,
+    });
+    expect(result.current.chartState).toEqual({ status: "ready" });
+    expect(result.current.samples).toEqual([]);
+
+    rerender({
+      hydrationStatus: "ready",
+      materializedWorkOutcomeState: { ...zeroSampleState, version: 999 },
+    });
+    expect(result.current.chartState).toEqual({ status: "error" });
+    expect(result.current.samples).toEqual([]);
+
+    rerender({
+      hydrationStatus: "ready",
+      materializedWorkOutcomeState: {
+        ...zeroSampleState,
+        samples: [{ tick: 0 }],
+      },
+    });
+    expect(result.current.chartState).toEqual({ status: "error" });
+    expect(result.current.samples).toEqual([]);
+
+    rerender({
+      hydrationStatus: "ready",
+      materializedWorkOutcomeState: zeroSampleState,
+    });
+    expect(result.current.chartState).toEqual({ status: "ready" });
+    expect(result.current.samples).toEqual(zeroSampleState.samples);
+  });
+
   const baselineEvents = [
     event("run-started", 0, FACTORY_EVENT_TYPES.runRequest, {
       factory: {

--- a/ui/src/features/work-outcome/hooks/useWorkOutcomeChart.ts
+++ b/ui/src/features/work-outcome/hooks/useWorkOutcomeChart.ts
@@ -1,44 +1,31 @@
 import { useMemo } from "react";
 
-import type { DashboardSnapshot } from "../../../api/dashboard/types";
-import type { FactoryEvent } from "../../../api/events";
-import type { WorldState } from "../../timeline/state/factoryTimelineStore";
 import {
-  createMaterializedWorkOutcomeState,
-  reduceMaterializedWorkOutcomeEvents,
+  type MaterializedWorkOutcomeState,
+  selectMaterializedWorkOutcomeSamples,
 } from "../lib/materializer/materialized-work-outcome";
-import {
-  buildWorkChartModel,
-  recordThroughputSample,
-  type ThroughputSample,
-} from "../lib/trends";
+import { buildWorkChartModel } from "../lib/trends";
 
 const WORK_OUTCOME_RANGE_ID = "session";
 const SESSION_WORK_CHART_NOW = 0;
 
 export function useWorkOutcomeChart({
   locale,
+  materializedWorkOutcomeState,
   selectedTimelineTick,
-  timelineEvents,
-  worldViewCache,
 }: {
   locale?: string | null;
+  materializedWorkOutcomeState: MaterializedWorkOutcomeState;
   selectedTimelineTick: number;
-  timelineEvents: FactoryEvent[];
-  worldViewCache: Record<number, WorldState | DashboardSnapshot | unknown>;
 }) {
-  const workOutcomeSamples = useMemo(() => {
-    if (timelineEvents.length > 0) {
-      return buildWorkOutcomeTimelineSamplesFromEvents(
-        timelineEvents,
+  const workOutcomeSamples = useMemo(
+    () =>
+      selectMaterializedWorkOutcomeSamples(
+        materializedWorkOutcomeState,
         selectedTimelineTick,
-      );
-    }
-    return buildWorkOutcomeTimelineSamplesFromCachedSnapshots(
-      worldViewCache,
-      selectedTimelineTick,
-    );
-  }, [selectedTimelineTick, timelineEvents, worldViewCache]);
+      ),
+    [materializedWorkOutcomeState, selectedTimelineTick],
+  );
 
   return useMemo(
     () =>
@@ -50,39 +37,4 @@ export function useWorkOutcomeChart({
       ),
     [locale, workOutcomeSamples],
   );
-}
-
-export function buildWorkOutcomeTimelineSamplesFromEvents(
-  events: FactoryEvent[],
-  selectedTick: number,
-): ThroughputSample[] {
-  const selectedEvents = events.filter(
-    (event) => event.context.tick <= selectedTick,
-  );
-  if (selectedEvents.length === 0) {
-    return [];
-  }
-
-  return reduceMaterializedWorkOutcomeEvents(
-    createMaterializedWorkOutcomeState(),
-    selectedEvents,
-  ).samples;
-}
-
-function buildWorkOutcomeTimelineSamplesFromCachedSnapshots(
-  worldViewCache: Record<number, WorldState | DashboardSnapshot | unknown>,
-  selectedTick: number,
-): ThroughputSample[] {
-  const ticks = Object.keys(worldViewCache)
-    .map((value) => Number(value))
-    .filter((tick) => Number.isFinite(tick) && tick <= selectedTick)
-    .sort((left, right) => left - right);
-
-  return ticks.reduce<ThroughputSample[]>((samples, tick, index) => {
-    const snapshot = worldViewCache[tick] as DashboardSnapshot | undefined;
-    if (!snapshot) {
-      return samples;
-    }
-    return recordThroughputSample(samples, snapshot, index);
-  }, []);
 }

--- a/ui/src/features/work-outcome/hooks/useWorkOutcomeChart.ts
+++ b/ui/src/features/work-outcome/hooks/useWorkOutcomeChart.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
-
+import type { WorkChartState } from "../components/work-chart";
 import {
-  type MaterializedWorkOutcomeState,
+  isSupportedMaterializedWorkOutcomeState,
   selectMaterializedWorkOutcomeSamples,
 } from "../lib/materializer/materialized-work-outcome";
 import { buildWorkChartModel } from "../lib/trends";
@@ -10,31 +10,57 @@ const WORK_OUTCOME_RANGE_ID = "session";
 const SESSION_WORK_CHART_NOW = 0;
 
 export function useWorkOutcomeChart({
+  hydrationStatus = "ready",
   locale,
   materializedWorkOutcomeState,
   selectedTimelineTick,
 }: {
+  hydrationStatus?: "loading" | "ready";
   locale?: string | null;
-  materializedWorkOutcomeState: MaterializedWorkOutcomeState;
+  materializedWorkOutcomeState: unknown;
   selectedTimelineTick: number;
 }) {
-  const workOutcomeSamples = useMemo(
-    () =>
-      selectMaterializedWorkOutcomeSamples(
-        materializedWorkOutcomeState,
-        selectedTimelineTick,
-      ),
-    [materializedWorkOutcomeState, selectedTimelineTick],
-  );
+  const workOutcomeSamples = useMemo(() => {
+    if (
+      hydrationStatus !== "ready" ||
+      !isSupportedMaterializedWorkOutcomeState(materializedWorkOutcomeState)
+    ) {
+      return [];
+    }
+    return selectMaterializedWorkOutcomeSamples(
+      materializedWorkOutcomeState,
+      selectedTimelineTick,
+    );
+  }, [hydrationStatus, materializedWorkOutcomeState, selectedTimelineTick]);
+
+  const chartStatus: WorkChartState["status"] =
+    hydrationStatus === "loading"
+      ? "loading"
+      : isSupportedMaterializedWorkOutcomeState(materializedWorkOutcomeState)
+        ? "ready"
+        : "error";
 
   return useMemo(
-    () =>
-      buildWorkChartModel(
+    () => ({
+      ...buildWorkChartModel(
         workOutcomeSamples,
         WORK_OUTCOME_RANGE_ID,
         SESSION_WORK_CHART_NOW,
         locale,
       ),
-    [locale, workOutcomeSamples],
+      chartState: workChartState(chartStatus),
+    }),
+    [chartStatus, locale, workOutcomeSamples],
   );
+}
+
+function workChartState(status: WorkChartState["status"]): WorkChartState {
+  switch (status) {
+    case "loading":
+      return { status: "loading" };
+    case "error":
+      return { status: "error" };
+    default:
+      return { status: "ready" };
+  }
 }

--- a/ui/src/features/work-outcome/lib/materializer/materialized-work-outcome-state.ts
+++ b/ui/src/features/work-outcome/lib/materializer/materialized-work-outcome-state.ts
@@ -82,3 +82,10 @@ export function createMaterializedWorkOutcomeState(): MaterializedWorkOutcomeSta
     version: MATERIALIZED_WORK_OUTCOME_VERSION,
   };
 }
+
+export function selectMaterializedWorkOutcomeSamples(
+  state: MaterializedWorkOutcomeState,
+  selectedTick: number,
+): ThroughputSample[] {
+  return state.samples.filter((sample) => sample.tick <= selectedTick);
+}

--- a/ui/src/features/work-outcome/lib/materializer/materialized-work-outcome-validation.ts
+++ b/ui/src/features/work-outcome/lib/materializer/materialized-work-outcome-validation.ts
@@ -1,0 +1,134 @@
+import type { ThroughputSample } from "../trends";
+import {
+  MATERIALIZED_WORK_OUTCOME_VERSION,
+  type MaterializedWorkOutcomeState,
+} from "./materialized-work-outcome-state";
+
+export function isSupportedMaterializedWorkOutcomeState(
+  value: unknown,
+): value is MaterializedWorkOutcomeState {
+  if (!isRecord(value) || value.version !== MATERIALIZED_WORK_OUTCOME_VERSION) {
+    return false;
+  }
+
+  return (
+    isAccumulator(value.accumulator) &&
+    isCounts(value.counts) &&
+    isCursor(value.cursor) &&
+    isCountRecord(value.failedByWorkType) &&
+    isStringArray(value.failedWorkLabels) &&
+    isOrderedSampleArray(value.samples)
+  );
+}
+
+function isAccumulator(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    isActiveDispatchRecord(value.activeDispatchesByID) &&
+    isNonNegativeInteger(value.appliedEventCount) &&
+    isNonNegativeInteger(value.completedAcceptedCount) &&
+    isNonNegativeInteger(value.completedDispatchCount) &&
+    isWorkItemRecord(value.failedWorkItemsByID) &&
+    isStringArray(value.initialPlaceIDs) &&
+    isWorkItemRecord(value.workItemsByID)
+  );
+}
+
+function isActiveDispatchRecord(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    Object.values(value).every(
+      (dispatch) =>
+        isRecord(dispatch) &&
+        isStringArray(dispatch.inputWorkIDs) &&
+        typeof dispatch.systemOnly === "boolean",
+    )
+  );
+}
+
+function isWorkItemRecord(value: unknown): boolean {
+  return isRecord(value) && Object.values(value).every(isWorkItem);
+}
+
+function isWorkItem(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.workTypeID === "string" &&
+    isOptionalString(value.displayName) &&
+    isOptionalString(value.placeID) &&
+    isOptionalString(value.traceID)
+  );
+}
+
+function isCounts(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    isNonNegativeInteger(value.completed) &&
+    isNonNegativeInteger(value.dispatched) &&
+    isNonNegativeInteger(value.failed) &&
+    isNonNegativeInteger(value.inFlight) &&
+    isNonNegativeInteger(value.queued)
+  );
+}
+
+function isCursor(value: unknown): boolean {
+  return (
+    value === null ||
+    (isRecord(value) &&
+      typeof value.eventID === "string" &&
+      typeof value.eventTime === "string" &&
+      isNonNegativeInteger(value.sequence) &&
+      isNonNegativeInteger(value.tick))
+  );
+}
+
+function isOrderedSampleArray(value: unknown): value is ThroughputSample[] {
+  if (!Array.isArray(value) || !value.every(isSample)) {
+    return false;
+  }
+  return value.every(
+    (sample, index) => index === 0 || value[index - 1].tick <= sample.tick,
+  );
+}
+
+function isSample(value: unknown): value is ThroughputSample {
+  return (
+    isRecord(value) &&
+    isNonNegativeInteger(value.completedCount) &&
+    isNonNegativeInteger(value.dispatchedCount) &&
+    isCountRecord(value.failedByWorkType) &&
+    isNonNegativeInteger(value.failedCount) &&
+    isStringArray(value.failedWorkLabels) &&
+    isNonNegativeInteger(value.inFlightCount) &&
+    isFiniteNumber(value.observedAt) &&
+    isNonNegativeInteger(value.queuedCount) &&
+    isNonNegativeInteger(value.tick)
+  );
+}
+
+function isCountRecord(value: unknown): boolean {
+  return isRecord(value) && Object.values(value).every(isNonNegativeInteger);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === "string")
+  );
+}
+
+function isOptionalString(value: unknown): boolean {
+  return value === undefined || typeof value === "string";
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/ui/src/features/work-outcome/lib/materializer/materialized-work-outcome.ts
+++ b/ui/src/features/work-outcome/lib/materializer/materialized-work-outcome.ts
@@ -32,6 +32,7 @@ export {
   type MaterializedWorkOutcomeCounts,
   type MaterializedWorkOutcomeEventCursor,
   type MaterializedWorkOutcomeState,
+  selectMaterializedWorkOutcomeSamples,
 } from "./materialized-work-outcome-state";
 
 const SYSTEM_TIME_WORK_TYPE_ID = "__system_time";

--- a/ui/src/features/work-outcome/lib/materializer/materialized-work-outcome.ts
+++ b/ui/src/features/work-outcome/lib/materializer/materialized-work-outcome.ts
@@ -34,6 +34,7 @@ export {
   type MaterializedWorkOutcomeState,
   selectMaterializedWorkOutcomeSamples,
 } from "./materialized-work-outcome-state";
+export { isSupportedMaterializedWorkOutcomeState } from "./materialized-work-outcome-validation";
 
 const SYSTEM_TIME_WORK_TYPE_ID = "__system_time";
 const SYSTEM_TIME_EXPIRY_TRANSITION_ID = `${SYSTEM_TIME_WORK_TYPE_ID}:expire`;

--- a/ui/src/features/work-outcome/public/materializer.ts
+++ b/ui/src/features/work-outcome/public/materializer.ts
@@ -6,6 +6,7 @@ export {
 export {
   createMaterializedWorkOutcomeState,
   MATERIALIZED_WORK_OUTCOME_VERSION,
-  reduceMaterializedWorkOutcomeEvents,
   type MaterializedWorkOutcomeState,
+  reduceMaterializedWorkOutcomeEvents,
+  selectMaterializedWorkOutcomeSamples,
 } from "../lib/materializer/materialized-work-outcome";

--- a/ui/src/features/work-outcome/public/materializer.ts
+++ b/ui/src/features/work-outcome/public/materializer.ts
@@ -5,6 +5,7 @@ export {
 
 export {
   createMaterializedWorkOutcomeState,
+  isSupportedMaterializedWorkOutcomeState,
   MATERIALIZED_WORK_OUTCOME_VERSION,
   type MaterializedWorkOutcomeState,
   reduceMaterializedWorkOutcomeEvents,


### PR DESCRIPTION
{
  "project": "Render Work Summaries And Chart History From Materialized State",
  "branchName": "session-repair-chart-materialized-consumer",
  "description": "Render current work-outcome summaries and retained chart history from the selected session stream's MaterializedWorkOutcomeState so quiet checkpoint reloads preserve every retained point, live tail events extend that baseline, historical tick selection remains non-destructive, and chart data states stay explicit and accessible.",
  "context": {
    "customerAsk": "Replace the raw-events versus worldViewCache fallback in the work-outcome chart consumer with projections from MaterializedWorkOutcomeState for current summaries, retained historical chart samples, and selected-tick clipping. A quiet reload must render the complete retained baseline, one post-checkpoint event must append to that baseline, historical selection must not mutate the current accumulator, and loading, empty, invalid, and ready chart states must remain explicit and accessible.",
    "problem": "The existing chart consumer switches between cached world snapshots and whatever raw Factory Events are currently present. Checkpoint restore can therefore expose only one cached point, and the first tail event can switch the chart to a tail-only event series. Summary values follow the same unstable source decision, while destructive historical clipping could corrupt the current materialized accumulator.",
    "solution": "Use the exact selected session-stream entry's supported MaterializedWorkOutcomeState as the sole work-outcome source. Project current summaries and retained samples from that immutable state, clip only a derived sample view for historical selection, and map hydration and state validity explicitly to accessible loading, empty, invalid/error, and ready chart presentations."
  },
  "acceptanceCriteria": [
    "Reloading a checkpoint with no newly received Factory Events renders every retained materialized work-outcome sample in deterministic order, and current summaries come from the restored materialized outcome.",
    "The first event accepted after checkpoint restore adds exactly one new materialized sample to the restored baseline without replacing or duplicating retained points.",
    "Selecting a retained historical tick shows only samples at or before that tick while leaving the current materialized cursor, accumulator, counts, breakdowns, and retained samples unchanged.",
    "Returning to current mode reveals the full retained baseline plus every accepted live tail sample without replaying unavailable pre-checkpoint events.",
    "Loading, empty, invalid, and ready outcomes use explicit accessible chart presentations, with hydration distinct from valid empty history and invalid state announced as an error.",
    "Raw timeline events and worldViewCache no longer control work-outcome summaries or chart history, while unrelated timeline and snapshot consumers remain unchanged.",
    "Quality gate: frontend typecheck, frontend lint, the Batch 001 multi-point history regression, focused work-chart component tests, and relevant dashboard integration tests pass."
  ],
  "userStories": [
    {
      "id": "session-repair-chart-materialized-consumer-001",
      "title": "Render restored and live outcomes from one materialized baseline",
      "description": "As a dashboard user, I want restored work summaries and chart history to come from the session's materialized outcome so that reloading and receiving a new event never collapses my historical series.",
      "acceptanceCriteria": [
        "With the Batch 001 fixture restored from a checkpoint and no new Factory Events received, the chart model contains every retained baseline sample in tick order, including queued, in-flight, completed, failed, and failure-breakdown values.",
        "The chart's current summary values and failure groups are derived from the materialized state's current outcome/latest retained sample and agree with the restored baseline's latest tick.",
        "After one post-checkpoint event is accepted into the same resolved session and stream generation, the chart contains the complete restored baseline followed by exactly one new tail sample; no retained point is removed or duplicated.",
        "Empty or non-empty raw timeline-event arrays and populated or empty worldViewCache values do not change the work-outcome model when the same materialized state is supplied.",
        "Focused hook or projection tests compare quiet restore and one-live-tail results with the uninterrupted Batch 001 multi-point outcome and fail on latest-only or tail-only series.",
        "Direct browser verification reloads the retained multi-point session, confirms the historical baseline before new activity, submits or receives one live tail event, and confirms that the new point extends the visible series.",
        "Tests pass",
        "Verify in browser using dev-browser skill",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "session-repair-chart-materialized-consumer-002",
      "title": "Clip historical chart views without mutating current outcomes",
      "description": "As a dashboard user, I want selecting an earlier timeline tick to show the work-outcome history through that tick while my session's current outcome continues accumulating independently.",
      "acceptanceCriteria": [
        "Selecting a retained tick produces a chart model containing all and only materialized samples whose tick is less than or equal to the selection, in deterministic sample order.",
        "Selecting a tick before the first retained sample produces the established explicit empty presentation rather than substituting the latest current sample or cached world data.",
        "Entering historical mode, accepting a new live event, and leaving historical mode does not change the selected historical projection until the user returns to current mode; current mode then shows the retained baseline plus the new tail exactly once.",
        "Historical selection and deselection leave the stored materialized version, cursor, accumulator, current counts, failure breakdowns, and retained samples deeply unchanged; only the derived chart model is clipped.",
        "Focused state/projection tests cover an exact retained tick, a between-sample tick, a tick before retained history, append while fixed, and return to current mode without relying on source-file or registration inventories.",
        "Direct browser verification selects an earlier retained tick, confirms later samples are hidden, returns to current mode, and confirms the full current history is restored without a reload.",
        "Tests pass",
        "Verify in browser using dev-browser skill",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "session-repair-chart-materialized-consumer-003",
      "title": "Preserve explicit accessible chart states during hydration",
      "description": "As a dashboard user, I want the work-outcome card to communicate whether history is loading, empty, invalid, or ready so that checkpoint recovery never presents missing or unusable data as a valid chart.",
      "acceptanceCriteria": [
        "Before checkpoint hydration resolves for the selected session stream, the work-outcome card renders its loading status with aria-busy=true and does not render stale samples from another session or stream generation.",
        "A supported materialized state with no retained samples renders the localized empty status and no chart graphic; zero-valued retained samples remain valid ready data rather than being mistaken for empty history.",
        "An unsupported version or malformed materialized outcome renders the localized error treatment with role=alert, does not fall back to raw events or cached snapshots, and does not expose a partially valid chart.",
        "A supported materialized state with valid retained samples renders the ready chart with its accessible chart label, keyboard-operable chart interactions, current summaries, and deterministic series.",
        "Loading, empty, invalid, and ready presentations retain the existing responsive layout without unintended horizontal scrolling at small, medium, and large supported viewports.",
        "Focused component and dashboard wiring tests assert the semantic loading, empty, invalid, and ready outcomes and prove that one selected session stream cannot display another stream's materialized state.",
        "Direct browser verification covers the restored loading-to-ready transition and confirms the ready chart remains usable at narrow and wide viewport sizes.",
        "Tests pass",
        "Verify in browser using dev-browser skill",
        "Typecheck passes"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}
