### PR TITLE
session-repair-ordered-checkpoint-writer

### DIFF
--- a/ui/src/features/dashboard/components/dashboard-screen.recovery-retry.test.tsx
+++ b/ui/src/features/dashboard/components/dashboard-screen.recovery-retry.test.tsx
@@ -103,9 +103,16 @@ function installIndexedDBTestDouble() {
         oncomplete: null,
         objectStore: () => ({
           delete: (key: string) =>
-            indexedDBRequest(undefined, () => {
-              records.delete(key);
-            }),
+            indexedDBRequest(
+              undefined,
+              () => {
+                records.delete(key);
+              },
+              () =>
+                (transaction.oncomplete as ((event: Event) => void) | null)?.(
+                  {} as Event,
+                ),
+            ),
           get: (key: string) => indexedDBRequest(records.get(key)),
           getAll: () => indexedDBRequest([...records.values()]),
           put: (value: { sessionID: string; storageKey?: string }) =>
@@ -115,9 +122,9 @@ function installIndexedDBTestDouble() {
                 records.set(value.storageKey ?? value.sessionID, value);
               },
               () =>
-                (
-                  transaction.oncomplete as ((event: Event) => void) | null
-                )?.({} as Event),
+                (transaction.oncomplete as ((event: Event) => void) | null)?.(
+                  {} as Event,
+                ),
             ),
         }),
       };

--- a/ui/src/features/dashboard/components/dashboard-screen.recovery-retry.test.tsx
+++ b/ui/src/features/dashboard/components/dashboard-screen.recovery-retry.test.tsx
@@ -64,7 +64,11 @@ vi.mock("../../header/public", () => ({
   }) => <StatusPanelProbe detail={detail} title={title} />,
 }));
 
-function indexedDBRequest<T>(result: T, beforeSuccess?: () => void) {
+function indexedDBRequest<T>(
+  result: T,
+  beforeSuccess?: () => void,
+  afterSuccess?: () => void,
+) {
   const request = {
     error: null,
     onblocked: null,
@@ -80,6 +84,7 @@ function indexedDBRequest<T>(result: T, beforeSuccess?: () => void) {
   window.setTimeout(() => {
     beforeSuccess?.();
     request.onsuccess?.({} as Event);
+    afterSuccess?.();
   }, 0);
 
   return request;
@@ -93,20 +98,31 @@ function installIndexedDBTestDouble() {
     objectStoreNames: {
       contains: () => true,
     },
-    transaction: () => ({
-      objectStore: () => ({
-        delete: (key: string) =>
-          indexedDBRequest(undefined, () => {
-            records.delete(key);
-          }),
-        get: (key: string) => indexedDBRequest(records.get(key)),
-        getAll: () => indexedDBRequest([...records.values()]),
-        put: (value: { sessionID: string; storageKey?: string }) =>
-          indexedDBRequest(value.storageKey ?? value.sessionID, () => {
-            records.set(value.storageKey ?? value.sessionID, value);
-          }),
-      }),
-    }),
+    transaction: () => {
+      const transaction = {
+        oncomplete: null,
+        objectStore: () => ({
+          delete: (key: string) =>
+            indexedDBRequest(undefined, () => {
+              records.delete(key);
+            }),
+          get: (key: string) => indexedDBRequest(records.get(key)),
+          getAll: () => indexedDBRequest([...records.values()]),
+          put: (value: { sessionID: string; storageKey?: string }) =>
+            indexedDBRequest(
+              value.storageKey ?? value.sessionID,
+              () => {
+                records.set(value.storageKey ?? value.sessionID, value);
+              },
+              () =>
+                (
+                  transaction.oncomplete as ((event: Event) => void) | null
+                )?.({} as Event),
+            ),
+        }),
+      };
+      return transaction;
+    },
   };
   const indexedDB = {
     open: () => {

--- a/ui/src/features/dashboard/hooks/useDashboardSnapshot.test.tsx
+++ b/ui/src/features/dashboard/hooks/useDashboardSnapshot.test.tsx
@@ -114,20 +114,31 @@ function installIndexedDBTestDouble() {
     objectStoreNames: {
       contains: () => true,
     },
-    transaction: () => ({
-      objectStore: () => ({
-        delete: (key: string) =>
-          indexedDBRequest(undefined, () => {
-            records.delete(key);
-          }),
-        get: (key: string) => indexedDBRequest(records.get(key)),
-        getAll: () => indexedDBRequest([...records.values()]),
-        put: (value: { sessionID: string; storageKey?: string }) =>
-          indexedDBRequest(value.storageKey ?? value.sessionID, () => {
-            records.set(value.storageKey ?? value.sessionID, value);
-          }),
-      }),
-    }),
+    transaction: () => {
+      const transaction = {
+        oncomplete: null,
+        objectStore: () => ({
+          delete: (key: string) =>
+            indexedDBRequest(
+              undefined,
+              () => {
+                records.delete(key);
+              },
+              () =>
+                (transaction.oncomplete as ((event: Event) => void) | null)?.(
+                  {} as Event,
+                ),
+            ),
+          get: (key: string) => indexedDBRequest(records.get(key)),
+          getAll: () => indexedDBRequest([...records.values()]),
+          put: (value: { sessionID: string; storageKey?: string }) =>
+            indexedDBRequest(value.storageKey ?? value.sessionID, () => {
+              records.set(value.storageKey ?? value.sessionID, value);
+            }),
+        }),
+      };
+      return transaction;
+    },
   };
   const indexedDB = {
     open: () => {
@@ -148,7 +159,11 @@ function installIndexedDBTestDouble() {
   return records;
 }
 
-function indexedDBRequest<T>(result: T, beforeSuccess?: () => void) {
+function indexedDBRequest<T>(
+  result: T,
+  beforeSuccess?: () => void,
+  afterSuccess?: () => void,
+) {
   const request = {
     error: null,
     onblocked: null,
@@ -164,6 +179,7 @@ function indexedDBRequest<T>(result: T, beforeSuccess?: () => void) {
   window.setTimeout(() => {
     beforeSuccess?.();
     request.onsuccess?.({} as Event);
+    afterSuccess?.();
   }, 0);
 
   return request;

--- a/ui/src/features/timeline/state/checkpoint-persistence/durability/timelineCheckpointPersistence.durable-transaction.test.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/durability/timelineCheckpointPersistence.durable-transaction.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  createControlledIndexedDBTestDouble,
+  flushPromiseContinuations,
+} from "../../../../../testing/controlled-indexeddb-test-utils";
+import { createMaterializedWorkOutcomeState } from "../../../../work-outcome/public/materializer";
+import { emptyReplayWorldState } from "../../timeline/replayWorldStateSupport";
+import type { FactoryTimelineCheckpoint } from "../../timeline/storeState";
+import {
+  persistTimelineCheckpoint,
+  type TimelineCheckpointStreamIdentity,
+} from "../../timelineCheckpointPersistence";
+
+interface StoredCheckpointEnvelope {
+  checkpoint?: FactoryTimelineCheckpoint;
+  storageKey?: string;
+}
+
+const streamIdentity = {
+  backendScopeID: "backend-scope-a",
+  factorySessionID: "a1b2c3d4-e5f6-4789-a012-3456789abcde",
+  logicalSessionKeyID: "logical-default",
+  streamGenerationID: "2026-07-13T00:00:00Z",
+} satisfies TimelineCheckpointStreamIdentity;
+
+function checkpoint(): FactoryTimelineCheckpoint {
+  return {
+    afterEventId: "event-42",
+    afterSequence: 42,
+    materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
+    replayState: emptyReplayWorldState(7),
+    selectedTick: 7,
+  };
+}
+
+async function startWrite() {
+  const fixture =
+    createControlledIndexedDBTestDouble<StoredCheckpointEnvelope>();
+  let settled = false;
+  const write = persistTimelineCheckpoint(
+    fixture.indexedDB,
+    checkpoint(),
+    streamIdentity,
+  ).finally(() => {
+    settled = true;
+  });
+
+  fixture.controls.succeed("open");
+  await flushPromiseContinuations();
+  expect(fixture.controls.pendingOperations()).toEqual(["put"]);
+  expect(fixture.controls.pendingTransactionCount()).toBe(1);
+
+  fixture.controls.succeed("put");
+  await flushPromiseContinuations();
+  expect(settled).toBe(false);
+  expect(fixture.controls.closedDatabaseCount()).toBe(0);
+  expect(fixture.records.size).toBe(0);
+
+  return { ...fixture, isSettled: () => settled, write };
+}
+
+describe("timeline checkpoint durable transaction settlement", () => {
+  it("keeps the write and database connection pending until transaction completion", async () => {
+    const fixture = await startWrite();
+
+    fixture.controls.completeTransaction();
+    await fixture.write;
+
+    expect(fixture.isSettled()).toBe(true);
+    expect(fixture.controls.closedDatabaseCount()).toBe(1);
+    expect(fixture.records.size).toBe(1);
+  });
+
+  it("settles as a failed best-effort write when the transaction aborts after put success", async () => {
+    const fixture = await startWrite();
+
+    fixture.controls.abortTransaction(new Error("transaction aborted"));
+    await fixture.write;
+
+    expect(fixture.isSettled()).toBe(true);
+    expect(fixture.controls.closedDatabaseCount()).toBe(1);
+    expect(fixture.records.size).toBe(0);
+  });
+
+  it("settles as a failed best-effort write when the transaction errors after put success", async () => {
+    const fixture = await startWrite();
+
+    fixture.controls.failTransaction(new Error("transaction failed"));
+    await fixture.write;
+
+    expect(fixture.isSettled()).toBe(true);
+    expect(fixture.controls.closedDatabaseCount()).toBe(1);
+    expect(fixture.records.size).toBe(0);
+  });
+});

--- a/ui/src/features/timeline/state/checkpoint-persistence/durability/timelineCheckpointPersistence.durable-transaction.test.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/durability/timelineCheckpointPersistence.durable-transaction.test.ts
@@ -47,13 +47,19 @@ async function startWrite() {
 
   fixture.controls.succeed("open");
   await flushPromiseContinuations();
+  expect(fixture.controls.pendingOperations()).toEqual(["get"]);
+  fixture.controls.succeed("get");
+  await flushPromiseContinuations();
+  await flushPromiseContinuations();
+  fixture.controls.succeed("open");
+  await flushPromiseContinuations();
   expect(fixture.controls.pendingOperations()).toEqual(["put"]);
   expect(fixture.controls.pendingTransactionCount()).toBe(1);
 
   fixture.controls.succeed("put");
   await flushPromiseContinuations();
   expect(settled).toBe(false);
-  expect(fixture.controls.closedDatabaseCount()).toBe(0);
+  expect(fixture.controls.closedDatabaseCount()).toBe(1);
   expect(fixture.records.size).toBe(0);
 
   return { ...fixture, isSettled: () => settled, write };
@@ -67,7 +73,7 @@ describe("timeline checkpoint durable transaction settlement", () => {
     await fixture.write;
 
     expect(fixture.isSettled()).toBe(true);
-    expect(fixture.controls.closedDatabaseCount()).toBe(1);
+    expect(fixture.controls.closedDatabaseCount()).toBe(2);
     expect(fixture.records.size).toBe(1);
   });
 
@@ -78,7 +84,7 @@ describe("timeline checkpoint durable transaction settlement", () => {
     await fixture.write;
 
     expect(fixture.isSettled()).toBe(true);
-    expect(fixture.controls.closedDatabaseCount()).toBe(1);
+    expect(fixture.controls.closedDatabaseCount()).toBe(2);
     expect(fixture.records.size).toBe(0);
   });
 
@@ -89,7 +95,7 @@ describe("timeline checkpoint durable transaction settlement", () => {
     await fixture.write;
 
     expect(fixture.isSettled()).toBe(true);
-    expect(fixture.controls.closedDatabaseCount()).toBe(1);
+    expect(fixture.controls.closedDatabaseCount()).toBe(2);
     expect(fixture.records.size).toBe(0);
   });
 });

--- a/ui/src/features/timeline/state/checkpoint-persistence/indexedDBCheckpointRequests.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/indexedDBCheckpointRequests.ts
@@ -6,6 +6,27 @@ const CHECKPOINT_DB_NAME = "agentFactoryTimelineCheckpoints";
 const CHECKPOINT_DB_VERSION = 3;
 const CHECKPOINT_STORE_NAME = "checkpoints";
 
+export async function writeCheckpointDatabaseRecord(
+  indexedDB: IndexedDBLike,
+  value: unknown,
+): Promise<void> {
+  const database = await openCheckpointDatabase(indexedDB);
+  try {
+    const transaction = database.transaction(
+      CHECKPOINT_STORE_NAME,
+      "readwrite",
+    );
+    await Promise.all([
+      indexedDBRequestToPromise(
+        transaction.objectStore(CHECKPOINT_STORE_NAME).put(value),
+      ),
+      indexedDBTransactionToPromise(transaction),
+    ]);
+  } finally {
+    database.close();
+  }
+}
+
 export function openCheckpointDatabase(
   indexedDB: IndexedDBLike,
 ): Promise<IDBDatabase> {
@@ -61,5 +82,23 @@ export function indexedDBRequestToPromise<T>(
       return;
     }
     signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+export function indexedDBTransactionToPromise(
+  transaction: IDBTransaction,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onabort = () =>
+      reject(
+        transaction.error ??
+          new Error("timeline checkpoint IndexedDB transaction aborted"),
+      );
+    transaction.onerror = () =>
+      reject(
+        transaction.error ??
+          new Error("timeline checkpoint IndexedDB transaction failed"),
+      );
   });
 }

--- a/ui/src/features/timeline/state/checkpoint-persistence/indexedDBCheckpointRequests.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/indexedDBCheckpointRequests.ts
@@ -6,6 +6,59 @@ const CHECKPOINT_DB_NAME = "agentFactoryTimelineCheckpoints";
 const CHECKPOINT_DB_VERSION = 3;
 const CHECKPOINT_STORE_NAME = "checkpoints";
 
+export async function readCheckpointDatabaseRecord<T>(
+  indexedDB: IndexedDBLike,
+  storageKey: string,
+  signal?: AbortSignal,
+): Promise<T | null> {
+  const database = await openCheckpointDatabase(indexedDB);
+  try {
+    const transaction = database.transaction(CHECKPOINT_STORE_NAME, "readonly");
+    const result = await indexedDBRequestToPromise<T | undefined>(
+      transaction.objectStore(CHECKPOINT_STORE_NAME).get(storageKey),
+      transaction,
+      signal,
+    );
+    return result ?? null;
+  } finally {
+    database.close();
+  }
+}
+
+export async function deleteCheckpointDatabaseRecord(
+  indexedDB: IndexedDBLike,
+  storageKey: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const database = await openCheckpointDatabase(indexedDB);
+  try {
+    const transaction = database.transaction(
+      CHECKPOINT_STORE_NAME,
+      "readwrite",
+    );
+    const requestOutcome = indexedDBRequestToPromise(
+      transaction.objectStore(CHECKPOINT_STORE_NAME).delete(storageKey),
+      transaction,
+      signal,
+    ).then(
+      () => ({ succeeded: true }) as const,
+      (error: unknown) => ({ error, succeeded: false }) as const,
+    );
+    const transactionOutcome = indexedDBTransactionToPromise(transaction).then(
+      () => ({ succeeded: true }) as const,
+      (error: unknown) => ({ error, succeeded: false }) as const,
+    );
+    const [request, durableTransaction] = await Promise.all([
+      requestOutcome,
+      transactionOutcome,
+    ]);
+    if (!request.succeeded) throw request.error;
+    if (!durableTransaction.succeeded) throw durableTransaction.error;
+  } finally {
+    database.close();
+  }
+}
+
 export async function writeCheckpointDatabaseRecord(
   indexedDB: IndexedDBLike,
   value: unknown,

--- a/ui/src/features/timeline/state/checkpoint-persistence/indexedDBCheckpointRequests.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/indexedDBCheckpointRequests.ts
@@ -16,12 +16,22 @@ export async function writeCheckpointDatabaseRecord(
       CHECKPOINT_STORE_NAME,
       "readwrite",
     );
-    await Promise.all([
-      indexedDBRequestToPromise(
-        transaction.objectStore(CHECKPOINT_STORE_NAME).put(value),
-      ),
-      indexedDBTransactionToPromise(transaction),
+    const requestOutcome = indexedDBRequestToPromise(
+      transaction.objectStore(CHECKPOINT_STORE_NAME).put(value),
+    ).then(
+      () => ({ succeeded: true }) as const,
+      (error: unknown) => ({ error, succeeded: false }) as const,
+    );
+    const transactionOutcome = indexedDBTransactionToPromise(transaction).then(
+      () => ({ succeeded: true }) as const,
+      (error: unknown) => ({ error, succeeded: false }) as const,
+    );
+    const [request, durableTransaction] = await Promise.all([
+      requestOutcome,
+      transactionOutcome,
     ]);
+    if (!request.succeeded) throw request.error;
+    if (!durableTransaction.succeeded) throw durableTransaction.error;
   } finally {
     database.close();
   }

--- a/ui/src/features/timeline/state/checkpoint-persistence/ordering/orderedCheckpointWriter.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/ordering/orderedCheckpointWriter.ts
@@ -6,9 +6,14 @@ interface CheckpointWriteLane {
   tail: Promise<void>;
 }
 
-const writeLanesByDatabase = new WeakMap<
+interface CheckpointWriteCoordinator {
+  committedSequences: Map<string, number>;
+  lanes: Map<string, CheckpointWriteLane>;
+}
+
+const coordinatorsByDatabase = new WeakMap<
   IndexedDBLike,
-  Map<string, CheckpointWriteLane>
+  CheckpointWriteCoordinator
 >();
 
 function writeAdvancesLane(
@@ -33,14 +38,20 @@ export function enqueueOrderedCheckpointWrite(
     streamIdentity.logicalSessionKeyID,
     streamIdentity.streamGenerationID,
   ]);
-  let lanes = writeLanesByDatabase.get(indexedDB);
-  if (!lanes) {
-    lanes = new Map();
-    writeLanesByDatabase.set(indexedDB, lanes);
+  let coordinator = coordinatorsByDatabase.get(indexedDB);
+  if (!coordinator) {
+    coordinator = {
+      committedSequences: new Map(),
+      lanes: new Map(),
+    };
+    coordinatorsByDatabase.set(indexedDB, coordinator);
   }
 
+  const { committedSequences, lanes } = coordinator;
   let lane = lanes.get(laneKey);
-  if (lane && !writeAdvancesLane(lane.newestSequence, afterSequence)) {
+  const newestSequence =
+    lane?.newestSequence ?? committedSequences.get(laneKey);
+  if (!writeAdvancesLane(newestSequence, afterSequence)) {
     return Promise.resolve();
   }
   const startsLane = !lane;
@@ -57,21 +68,20 @@ export function enqueueOrderedCheckpointWrite(
     write = startsLane ? writeCheckpoint() : lane.tail.then(writeCheckpoint);
   } catch (error) {
     lanes.delete(laneKey);
-    if (lanes.size === 0) {
-      writeLanesByDatabase.delete(indexedDB);
-    }
     return Promise.reject(error);
   }
-  const settledTail = write.catch(() => {});
+  const committedWrite = write.then(() => {
+    if (afterSequence !== undefined) {
+      committedSequences.set(laneKey, afterSequence);
+    }
+  });
+  const settledTail = committedWrite.catch(() => {});
   lane.tail = settledTail;
   void settledTail.finally(() => {
     if (lanes.get(laneKey)?.tail !== settledTail) {
       return;
     }
     lanes.delete(laneKey);
-    if (lanes.size === 0) {
-      writeLanesByDatabase.delete(indexedDB);
-    }
   });
-  return write;
+  return committedWrite;
 }

--- a/ui/src/features/timeline/state/checkpoint-persistence/ordering/orderedCheckpointWriter.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/ordering/orderedCheckpointWriter.ts
@@ -1,0 +1,77 @@
+import type { StreamDerivedCacheIdentity } from "../../../lib/stream-derived-cache-identity";
+import type { IndexedDBLike } from "../indexedDBCheckpointRequests";
+
+interface CheckpointWriteLane {
+  newestSequence?: number;
+  tail: Promise<void>;
+}
+
+const writeLanesByDatabase = new WeakMap<
+  IndexedDBLike,
+  Map<string, CheckpointWriteLane>
+>();
+
+function writeAdvancesLane(
+  newestSequence: number | undefined,
+  candidateSequence: number | undefined,
+): boolean {
+  if (newestSequence === undefined) {
+    return true;
+  }
+  return candidateSequence !== undefined && candidateSequence > newestSequence;
+}
+
+export function enqueueOrderedCheckpointWrite(
+  indexedDB: IndexedDBLike,
+  streamIdentity: StreamDerivedCacheIdentity,
+  afterSequence: number | undefined,
+  writeCheckpoint: () => Promise<void>,
+): Promise<void> {
+  const laneKey = JSON.stringify([
+    streamIdentity.backendScopeID,
+    streamIdentity.factorySessionID,
+    streamIdentity.logicalSessionKeyID,
+    streamIdentity.streamGenerationID,
+  ]);
+  let lanes = writeLanesByDatabase.get(indexedDB);
+  if (!lanes) {
+    lanes = new Map();
+    writeLanesByDatabase.set(indexedDB, lanes);
+  }
+
+  let lane = lanes.get(laneKey);
+  if (lane && !writeAdvancesLane(lane.newestSequence, afterSequence)) {
+    return Promise.resolve();
+  }
+  const startsLane = !lane;
+  if (!lane) {
+    lane = { tail: Promise.resolve() };
+    lanes.set(laneKey, lane);
+  }
+  if (afterSequence !== undefined) {
+    lane.newestSequence = afterSequence;
+  }
+
+  let write: Promise<void>;
+  try {
+    write = startsLane ? writeCheckpoint() : lane.tail.then(writeCheckpoint);
+  } catch (error) {
+    lanes.delete(laneKey);
+    if (lanes.size === 0) {
+      writeLanesByDatabase.delete(indexedDB);
+    }
+    return Promise.reject(error);
+  }
+  const settledTail = write.catch(() => {});
+  lane.tail = settledTail;
+  void settledTail.finally(() => {
+    if (lanes.get(laneKey)?.tail !== settledTail) {
+      return;
+    }
+    lanes.delete(laneKey);
+    if (lanes.size === 0) {
+      writeLanesByDatabase.delete(indexedDB);
+    }
+  });
+  return write;
+}

--- a/ui/src/features/timeline/state/checkpoint-persistence/ordering/orderedCheckpointWriter.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/ordering/orderedCheckpointWriter.ts
@@ -2,12 +2,13 @@ import type { StreamDerivedCacheIdentity } from "../../../lib/stream-derived-cac
 import type { IndexedDBLike } from "../indexedDBCheckpointRequests";
 
 interface CheckpointWriteLane {
+  committedSequence?: number;
+  initialized: boolean;
   newestSequence?: number;
   tail: Promise<void>;
 }
 
 interface CheckpointWriteCoordinator {
-  committedSequences: Map<string, number>;
   lanes: Map<string, CheckpointWriteLane>;
 }
 
@@ -30,6 +31,7 @@ export function enqueueOrderedCheckpointWrite(
   indexedDB: IndexedDBLike,
   streamIdentity: StreamDerivedCacheIdentity,
   afterSequence: number | undefined,
+  readCommittedSequence: () => Promise<number | undefined>,
   writeCheckpoint: () => Promise<void>,
 ): Promise<void> {
   const laneKey = JSON.stringify([
@@ -41,22 +43,19 @@ export function enqueueOrderedCheckpointWrite(
   let coordinator = coordinatorsByDatabase.get(indexedDB);
   if (!coordinator) {
     coordinator = {
-      committedSequences: new Map(),
       lanes: new Map(),
     };
     coordinatorsByDatabase.set(indexedDB, coordinator);
   }
 
-  const { committedSequences, lanes } = coordinator;
+  const { lanes } = coordinator;
   let lane = lanes.get(laneKey);
-  const newestSequence =
-    lane?.newestSequence ?? committedSequences.get(laneKey);
-  if (!writeAdvancesLane(newestSequence, afterSequence)) {
+  if (lane && !writeAdvancesLane(lane.newestSequence, afterSequence)) {
     return Promise.resolve();
   }
   const startsLane = !lane;
   if (!lane) {
-    lane = { tail: Promise.resolve() };
+    lane = { initialized: false, tail: Promise.resolve() };
     lanes.set(laneKey, lane);
   }
   if (afterSequence !== undefined) {
@@ -65,17 +64,23 @@ export function enqueueOrderedCheckpointWrite(
 
   let write: Promise<void>;
   try {
-    write = startsLane ? writeCheckpoint() : lane.tail.then(writeCheckpoint);
+    const runWrite = async () => {
+      if (!lane.initialized) {
+        lane.committedSequence = await readCommittedSequence();
+        lane.initialized = true;
+      }
+      if (!writeAdvancesLane(lane.committedSequence, afterSequence)) {
+        return;
+      }
+      await writeCheckpoint();
+      lane.committedSequence = afterSequence;
+    };
+    write = startsLane ? runWrite() : lane.tail.then(runWrite);
   } catch (error) {
     lanes.delete(laneKey);
     return Promise.reject(error);
   }
-  const committedWrite = write.then(() => {
-    if (afterSequence !== undefined) {
-      committedSequences.set(laneKey, afterSequence);
-    }
-  });
-  const settledTail = committedWrite.catch(() => {});
+  const settledTail = write.catch(() => {});
   lane.tail = settledTail;
   void settledTail.finally(() => {
     if (lanes.get(laneKey)?.tail !== settledTail) {
@@ -83,5 +88,47 @@ export function enqueueOrderedCheckpointWrite(
     }
     lanes.delete(laneKey);
   });
-  return committedWrite;
+  return write;
+}
+
+export function enqueueOrderedCheckpointClear(
+  indexedDB: IndexedDBLike,
+  streamIdentity: StreamDerivedCacheIdentity,
+  clearCheckpoint: () => Promise<void>,
+): Promise<void> {
+  const laneKey = JSON.stringify([
+    streamIdentity.backendScopeID,
+    streamIdentity.factorySessionID,
+    streamIdentity.logicalSessionKeyID,
+    streamIdentity.streamGenerationID,
+  ]);
+  let coordinator = coordinatorsByDatabase.get(indexedDB);
+  if (!coordinator) {
+    coordinator = { lanes: new Map() };
+    coordinatorsByDatabase.set(indexedDB, coordinator);
+  }
+
+  const { lanes } = coordinator;
+  let lane = lanes.get(laneKey);
+  const startsLane = !lane;
+  if (!lane) {
+    lane = { initialized: false, tail: Promise.resolve() };
+    lanes.set(laneKey, lane);
+  }
+  lane.newestSequence = undefined;
+
+  const runClear = async () => {
+    await clearCheckpoint();
+    lane.committedSequence = undefined;
+    lane.initialized = true;
+  };
+  const clear = startsLane ? runClear() : lane.tail.then(runClear);
+  const settledTail = clear.catch(() => {});
+  lane.tail = settledTail;
+  void settledTail.finally(() => {
+    if (lanes.get(laneKey)?.tail === settledTail) {
+      lanes.delete(laneKey);
+    }
+  });
+  return clear;
 }

--- a/ui/src/features/timeline/state/checkpoint-persistence/ordering/timelineCheckpointPersistence.ordered-writes.test.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/ordering/timelineCheckpointPersistence.ordered-writes.test.ts
@@ -15,6 +15,7 @@ import {
 interface StoredCheckpointEnvelope {
   checkpoint?: FactoryTimelineCheckpoint;
   storageKey?: string;
+  streamIdentity?: TimelineCheckpointStreamIdentity;
 }
 
 const streamIdentity = {
@@ -28,6 +29,7 @@ function checkpoint(
   selectedTick: number,
   afterEventId: string,
   afterSequence: number,
+  identity: TimelineCheckpointStreamIdentity = streamIdentity,
 ): FactoryTimelineCheckpoint {
   const materializedWorkOutcomeState = createMaterializedWorkOutcomeState();
   materializedWorkOutcomeState.counts.completed = selectedTick;
@@ -38,10 +40,10 @@ function checkpoint(
     replayState: emptyReplayWorldState(selectedTick),
     selectedTick,
     syncIdentity: {
-      backendScopeId: streamIdentity.backendScopeID,
-      factorySessionId: streamIdentity.factorySessionID,
-      logicalSessionKeyId: streamIdentity.logicalSessionKeyID,
-      streamGenerationId: streamIdentity.streamGenerationID,
+      backendScopeId: identity.backendScopeID,
+      factorySessionId: identity.factorySessionID,
+      logicalSessionKeyId: identity.logicalSessionKeyID,
+      streamGenerationId: identity.streamGenerationID,
     },
   };
 }
@@ -161,5 +163,114 @@ describe("timeline checkpoint same-stream write ordering", () => {
       afterSequence: 52,
       selectedTick: 52,
     });
+  });
+});
+
+describe("timeline checkpoint independent stream writes", () => {
+  it.each([
+    ["backend scope", { backendScopeID: "backend-scope-b" }],
+    [
+      "Factory Session",
+      { factorySessionID: "b1b2c3d4-e5f6-4789-a012-3456789abcde" },
+    ],
+    ["logical session key", { logicalSessionKeyID: "logical-other" }],
+    ["stream generation", { streamGenerationID: "2026-07-14T00:00:00Z" }],
+  ] as const)("allows a stream with a different %s to reach IndexedDB concurrently", async (_label, identityDifference) => {
+    const fixture =
+      createControlledIndexedDBTestDouble<StoredCheckpointEnvelope>();
+    const otherIdentity = {
+      ...streamIdentity,
+      ...identityDifference,
+    } satisfies TimelineCheckpointStreamIdentity;
+    let firstSettled = false;
+    let otherSettled = false;
+
+    const first = persistTimelineCheckpoint(
+      fixture.indexedDB,
+      checkpoint(61, "event-61", 61),
+      streamIdentity,
+    ).then(() => {
+      firstSettled = true;
+    });
+    const other = persistTimelineCheckpoint(
+      fixture.indexedDB,
+      checkpoint(72, "event-72", 72, otherIdentity),
+      otherIdentity,
+    ).then(() => {
+      otherSettled = true;
+    });
+
+    expect(fixture.controls.pendingOperations()).toEqual(["open", "open"]);
+    fixture.controls.succeed("open");
+    fixture.controls.succeed("open");
+    await flushPromiseContinuations();
+    expect(fixture.controls.pendingOperations()).toEqual(["put", "put"]);
+
+    fixture.controls.succeed("put");
+    fixture.controls.succeed("put");
+    fixture.controls.completeTransaction(1);
+    await flushPromiseContinuations();
+    await flushPromiseContinuations();
+    await flushPromiseContinuations();
+    await flushPromiseContinuations();
+
+    expect(otherSettled).toBe(true);
+    expect(firstSettled).toBe(false);
+    expect([...fixture.records.values()]).toEqual([
+      expect.objectContaining({
+        checkpoint: expect.objectContaining({
+          afterEventId: "event-72",
+          afterSequence: 72,
+          materializedWorkOutcomeState: expect.objectContaining({
+            counts: expect.objectContaining({ completed: 72 }),
+          }),
+        }),
+        streamIdentity: otherIdentity,
+      }),
+    ]);
+
+    fixture.controls.failTransaction(new Error("first stream failed"));
+    await Promise.all([first, other]);
+
+    expect([...fixture.records.values()]).toHaveLength(1);
+  });
+
+  it("removes idle lane state after the last pending write settles", async () => {
+    const fixture =
+      createControlledIndexedDBTestDouble<StoredCheckpointEnvelope>();
+    const first = persistTimelineCheckpoint(
+      fixture.indexedDB,
+      checkpoint(81, "event-81", 81),
+      streamIdentity,
+    );
+
+    fixture.controls.succeed("open");
+    await flushPromiseContinuations();
+    fixture.controls.succeed("put");
+    fixture.controls.completeTransaction();
+    await first;
+    await flushPromiseContinuations();
+
+    const next = persistTimelineCheckpoint(
+      fixture.indexedDB,
+      checkpoint(82, "event-82", 82),
+      streamIdentity,
+    );
+
+    expect(fixture.controls.pendingOperations()).toEqual(["open"]);
+    fixture.controls.succeed("open");
+    await flushPromiseContinuations();
+    fixture.controls.succeed("put");
+    fixture.controls.completeTransaction();
+    await next;
+
+    expect([...fixture.records.values()]).toEqual([
+      expect.objectContaining({
+        checkpoint: expect.objectContaining({
+          afterEventId: "event-82",
+          afterSequence: 82,
+        }),
+      }),
+    ]);
   });
 });

--- a/ui/src/features/timeline/state/checkpoint-persistence/ordering/timelineCheckpointPersistence.ordered-writes.test.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/ordering/timelineCheckpointPersistence.ordered-writes.test.ts
@@ -7,6 +7,7 @@ import { createMaterializedWorkOutcomeState } from "../../../../work-outcome/pub
 import { emptyReplayWorldState } from "../../timeline/replayWorldStateSupport";
 import type { FactoryTimelineCheckpoint } from "../../timeline/storeState";
 import {
+  clearTimelineCheckpoint,
   persistTimelineCheckpoint,
   readTimelineCheckpoint,
   type TimelineCheckpointStreamIdentity,
@@ -14,6 +15,7 @@ import {
 
 interface StoredCheckpointEnvelope {
   checkpoint?: FactoryTimelineCheckpoint;
+  schemaVersion?: number;
   storageKey?: string;
   streamIdentity?: TimelineCheckpointStreamIdentity;
 }
@@ -24,6 +26,15 @@ const streamIdentity = {
   logicalSessionKeyID: "logical-default",
   streamGenerationID: "2026-07-13T00:00:00Z",
 } satisfies TimelineCheckpointStreamIdentity;
+
+function storageKey(identity: TimelineCheckpointStreamIdentity): string {
+  return [
+    identity.backendScopeID,
+    identity.factorySessionID,
+    identity.logicalSessionKeyID,
+    identity.streamGenerationID,
+  ].join("::");
+}
 
 function checkpoint(
   selectedTick: number,
@@ -60,6 +71,18 @@ async function readStoredCheckpoint(
   return read;
 }
 
+async function releaseCommittedSequenceRead(
+  fixture: ReturnType<
+    typeof createControlledIndexedDBTestDouble<StoredCheckpointEnvelope>
+  >,
+) {
+  fixture.controls.succeed("open");
+  await flushPromiseContinuations();
+  fixture.controls.succeed("get");
+  await flushPromiseContinuations();
+  await flushPromiseContinuations();
+}
+
 describe("timeline checkpoint same-stream write ordering", () => {
   it("serializes a strictly newer save behind the pending same-stream write", async () => {
     const fixture =
@@ -75,6 +98,8 @@ describe("timeline checkpoint same-stream write ordering", () => {
       streamIdentity,
     );
 
+    expect(fixture.controls.pendingOperations()).toEqual(["open"]);
+    await releaseCommittedSequenceRead(fixture);
     expect(fixture.controls.pendingOperations()).toEqual(["open"]);
     fixture.controls.succeed("open");
     await flushPromiseContinuations();
@@ -119,6 +144,8 @@ describe("timeline checkpoint same-stream write ordering", () => {
     await flushPromiseContinuations();
 
     expect(fixture.controls.pendingOperations()).toEqual(["open"]);
+    await releaseCommittedSequenceRead(fixture);
+    expect(fixture.controls.pendingOperations()).toEqual(["open"]);
     fixture.controls.succeed("open");
     await flushPromiseContinuations();
     expect(fixture.controls.pendingOperations()).toEqual(["put"]);
@@ -152,6 +179,7 @@ describe("timeline checkpoint same-stream write ordering", () => {
     await flushPromiseContinuations();
 
     expect(fixture.controls.pendingOperations()).toEqual(["open"]);
+    await releaseCommittedSequenceRead(fixture);
     fixture.controls.succeed("open");
     await flushPromiseContinuations();
     fixture.controls.succeed("put");
@@ -204,6 +232,14 @@ describe("timeline checkpoint independent stream writes", () => {
     fixture.controls.succeed("open");
     fixture.controls.succeed("open");
     await flushPromiseContinuations();
+    fixture.controls.succeed("get");
+    fixture.controls.succeed("get");
+    await flushPromiseContinuations();
+    await flushPromiseContinuations();
+    expect(fixture.controls.pendingOperations()).toEqual(["open", "open"]);
+    fixture.controls.succeed("open");
+    fixture.controls.succeed("open");
+    await flushPromiseContinuations();
     expect(fixture.controls.pendingOperations()).toEqual(["put", "put"]);
 
     fixture.controls.succeed("put");
@@ -246,6 +282,7 @@ describe("timeline checkpoint lane lifecycle", () => {
       streamIdentity,
     );
 
+    await releaseCommittedSequenceRead(fixture);
     fixture.controls.succeed("open");
     await flushPromiseContinuations();
     fixture.controls.succeed("put");
@@ -260,6 +297,7 @@ describe("timeline checkpoint lane lifecycle", () => {
     );
 
     expect(fixture.controls.pendingOperations()).toEqual(["open"]);
+    await releaseCommittedSequenceRead(fixture);
     fixture.controls.succeed("open");
     await flushPromiseContinuations();
     fixture.controls.succeed("put");
@@ -275,7 +313,9 @@ describe("timeline checkpoint lane lifecycle", () => {
       }),
     ]);
   });
+});
 
+describe("timeline checkpoint durable admission lifecycle", () => {
   it("rejects older and equal saves after a newer checkpoint is committed", async () => {
     const fixture =
       createControlledIndexedDBTestDouble<StoredCheckpointEnvelope>();
@@ -286,6 +326,7 @@ describe("timeline checkpoint lane lifecycle", () => {
       streamIdentity,
     );
 
+    await releaseCommittedSequenceRead(fixture);
     fixture.controls.succeed("open");
     await flushPromiseContinuations();
     fixture.controls.succeed("put");
@@ -303,6 +344,8 @@ describe("timeline checkpoint lane lifecycle", () => {
       checkpoint(83, "different-event-at-82", 82),
       streamIdentity,
     );
+    expect(fixture.controls.pendingOperations()).toEqual(["open"]);
+    await releaseCommittedSequenceRead(fixture);
     await Promise.all([older, equal]);
 
     expect(fixture.controls.pendingOperations()).toEqual([]);
@@ -317,6 +360,105 @@ describe("timeline checkpoint lane lifecycle", () => {
           replayState: expect.objectContaining({ tick_count: 82 }),
           selectedTick: 82,
           syncIdentity: committedCheckpoint.syncIdentity,
+        }),
+        streamIdentity,
+      }),
+    ]);
+  });
+
+  it("reconciles a fresh lane with a checkpoint committed by a prior realm", async () => {
+    const fixture =
+      createControlledIndexedDBTestDouble<StoredCheckpointEnvelope>();
+    const committedCheckpoint = checkpoint(82, "event-82", 82);
+    fixture.records.set(storageKey(streamIdentity), {
+      checkpoint: committedCheckpoint,
+      schemaVersion: 4,
+      storageKey: storageKey(streamIdentity),
+      streamIdentity,
+    });
+
+    const older = persistTimelineCheckpoint(
+      fixture.indexedDB,
+      checkpoint(81, "stale-event-81", 81),
+      streamIdentity,
+    );
+    const equal = persistTimelineCheckpoint(
+      fixture.indexedDB,
+      checkpoint(83, "different-event-at-82", 82),
+      streamIdentity,
+    );
+
+    await releaseCommittedSequenceRead(fixture);
+    await Promise.all([older, equal]);
+
+    expect(fixture.controls.pendingOperations()).toEqual([]);
+    expect([...fixture.records.values()]).toEqual([
+      expect.objectContaining({
+        checkpoint: expect.objectContaining({
+          afterEventId: "event-82",
+          afterSequence: 82,
+          materializedWorkOutcomeState: expect.objectContaining({
+            counts: expect.objectContaining({ completed: 82 }),
+          }),
+          replayState: expect.objectContaining({ tick_count: 82 }),
+          selectedTick: 82,
+          syncIdentity: committedCheckpoint.syncIdentity,
+        }),
+        streamIdentity,
+      }),
+    ]);
+  });
+});
+
+describe("timeline checkpoint clear lifecycle", () => {
+  it("allows a lower replay checkpoint after the durable checkpoint is cleared", async () => {
+    const fixture =
+      createControlledIndexedDBTestDouble<StoredCheckpointEnvelope>();
+    const committed = persistTimelineCheckpoint(
+      fixture.indexedDB,
+      checkpoint(82, "event-82", 82),
+      streamIdentity,
+    );
+    await releaseCommittedSequenceRead(fixture);
+    fixture.controls.succeed("open");
+    await flushPromiseContinuations();
+    fixture.controls.succeed("put");
+    fixture.controls.completeTransaction();
+    await committed;
+    await flushPromiseContinuations();
+
+    const cleared = clearTimelineCheckpoint(fixture.indexedDB, streamIdentity);
+    fixture.controls.succeed("open");
+    await flushPromiseContinuations();
+    fixture.controls.succeed("delete");
+    fixture.controls.completeTransaction();
+    await cleared;
+    await flushPromiseContinuations();
+
+    const replayCheckpoint = checkpoint(21, "replayed-event-21", 21);
+    const replayed = persistTimelineCheckpoint(
+      fixture.indexedDB,
+      replayCheckpoint,
+      streamIdentity,
+    );
+    await releaseCommittedSequenceRead(fixture);
+    fixture.controls.succeed("open");
+    await flushPromiseContinuations();
+    fixture.controls.succeed("put");
+    fixture.controls.completeTransaction();
+    await replayed;
+
+    expect([...fixture.records.values()]).toEqual([
+      expect.objectContaining({
+        checkpoint: expect.objectContaining({
+          afterEventId: "replayed-event-21",
+          afterSequence: 21,
+          materializedWorkOutcomeState: expect.objectContaining({
+            counts: expect.objectContaining({ completed: 21 }),
+          }),
+          replayState: expect.objectContaining({ tick_count: 21 }),
+          selectedTick: 21,
+          syncIdentity: replayCheckpoint.syncIdentity,
         }),
         streamIdentity,
       }),

--- a/ui/src/features/timeline/state/checkpoint-persistence/ordering/timelineCheckpointPersistence.ordered-writes.test.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/ordering/timelineCheckpointPersistence.ordered-writes.test.ts
@@ -234,7 +234,9 @@ describe("timeline checkpoint independent stream writes", () => {
 
     expect([...fixture.records.values()]).toHaveLength(1);
   });
+});
 
+describe("timeline checkpoint lane lifecycle", () => {
   it("removes idle lane state after the last pending write settles", async () => {
     const fixture =
       createControlledIndexedDBTestDouble<StoredCheckpointEnvelope>();
@@ -270,6 +272,53 @@ describe("timeline checkpoint independent stream writes", () => {
           afterEventId: "event-82",
           afterSequence: 82,
         }),
+      }),
+    ]);
+  });
+
+  it("rejects older and equal saves after a newer checkpoint is committed", async () => {
+    const fixture =
+      createControlledIndexedDBTestDouble<StoredCheckpointEnvelope>();
+    const committedCheckpoint = checkpoint(82, "event-82", 82);
+    const committed = persistTimelineCheckpoint(
+      fixture.indexedDB,
+      committedCheckpoint,
+      streamIdentity,
+    );
+
+    fixture.controls.succeed("open");
+    await flushPromiseContinuations();
+    fixture.controls.succeed("put");
+    fixture.controls.completeTransaction();
+    await committed;
+    await flushPromiseContinuations();
+
+    const older = persistTimelineCheckpoint(
+      fixture.indexedDB,
+      checkpoint(81, "stale-event-81", 81),
+      streamIdentity,
+    );
+    const equal = persistTimelineCheckpoint(
+      fixture.indexedDB,
+      checkpoint(83, "different-event-at-82", 82),
+      streamIdentity,
+    );
+    await Promise.all([older, equal]);
+
+    expect(fixture.controls.pendingOperations()).toEqual([]);
+    expect([...fixture.records.values()]).toEqual([
+      expect.objectContaining({
+        checkpoint: expect.objectContaining({
+          afterEventId: "event-82",
+          afterSequence: 82,
+          materializedWorkOutcomeState: expect.objectContaining({
+            counts: expect.objectContaining({ completed: 82 }),
+          }),
+          replayState: expect.objectContaining({ tick_count: 82 }),
+          selectedTick: 82,
+          syncIdentity: committedCheckpoint.syncIdentity,
+        }),
+        streamIdentity,
       }),
     ]);
   });

--- a/ui/src/features/timeline/state/checkpoint-persistence/ordering/timelineCheckpointPersistence.ordered-writes.test.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/ordering/timelineCheckpointPersistence.ordered-writes.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import {
+  createControlledIndexedDBTestDouble,
+  flushPromiseContinuations,
+} from "../../../../../testing/controlled-indexeddb-test-utils";
+import { createMaterializedWorkOutcomeState } from "../../../../work-outcome/public/materializer";
+import { emptyReplayWorldState } from "../../timeline/replayWorldStateSupport";
+import type { FactoryTimelineCheckpoint } from "../../timeline/storeState";
+import {
+  persistTimelineCheckpoint,
+  readTimelineCheckpoint,
+  type TimelineCheckpointStreamIdentity,
+} from "../../timelineCheckpointPersistence";
+
+interface StoredCheckpointEnvelope {
+  checkpoint?: FactoryTimelineCheckpoint;
+  storageKey?: string;
+}
+
+const streamIdentity = {
+  backendScopeID: "backend-scope-a",
+  factorySessionID: "a1b2c3d4-e5f6-4789-a012-3456789abcde",
+  logicalSessionKeyID: "logical-default",
+  streamGenerationID: "2026-07-13T00:00:00Z",
+} satisfies TimelineCheckpointStreamIdentity;
+
+function checkpoint(
+  selectedTick: number,
+  afterEventId: string,
+  afterSequence: number,
+): FactoryTimelineCheckpoint {
+  const materializedWorkOutcomeState = createMaterializedWorkOutcomeState();
+  materializedWorkOutcomeState.counts.completed = selectedTick;
+  return {
+    afterEventId,
+    afterSequence,
+    materializedWorkOutcomeState,
+    replayState: emptyReplayWorldState(selectedTick),
+    selectedTick,
+    syncIdentity: {
+      backendScopeId: streamIdentity.backendScopeID,
+      factorySessionId: streamIdentity.factorySessionID,
+      logicalSessionKeyId: streamIdentity.logicalSessionKeyID,
+      streamGenerationId: streamIdentity.streamGenerationID,
+    },
+  };
+}
+
+async function readStoredCheckpoint(
+  fixture: ReturnType<
+    typeof createControlledIndexedDBTestDouble<StoredCheckpointEnvelope>
+  >,
+) {
+  const read = readTimelineCheckpoint(fixture.indexedDB, streamIdentity);
+  fixture.controls.succeed("open");
+  await flushPromiseContinuations();
+  fixture.controls.succeed("get");
+  return read;
+}
+
+describe("timeline checkpoint same-stream write ordering", () => {
+  it("serializes a strictly newer save behind the pending same-stream write", async () => {
+    const fixture =
+      createControlledIndexedDBTestDouble<StoredCheckpointEnvelope>();
+    const first = persistTimelineCheckpoint(
+      fixture.indexedDB,
+      checkpoint(41, "event-41", 41),
+      streamIdentity,
+    );
+    const newer = persistTimelineCheckpoint(
+      fixture.indexedDB,
+      checkpoint(52, "event-52", 52),
+      streamIdentity,
+    );
+
+    expect(fixture.controls.pendingOperations()).toEqual(["open"]);
+    fixture.controls.succeed("open");
+    await flushPromiseContinuations();
+    fixture.controls.succeed("put");
+    expect(fixture.controls.pendingOperations()).toEqual([]);
+    fixture.controls.completeTransaction();
+    await flushPromiseContinuations();
+    await flushPromiseContinuations();
+
+    expect(fixture.controls.pendingOperations()).toEqual(["open"]);
+    fixture.controls.succeed("open");
+    await flushPromiseContinuations();
+    fixture.controls.succeed("put");
+    fixture.controls.completeTransaction();
+    await Promise.all([first, newer]);
+
+    await expect(readStoredCheckpoint(fixture)).resolves.toMatchObject({
+      afterEventId: "event-52",
+      afterSequence: 52,
+      selectedTick: 52,
+    });
+  });
+
+  it("keeps the newer complete envelope when an older save starts last", async () => {
+    const fixture =
+      createControlledIndexedDBTestDouble<StoredCheckpointEnvelope>();
+    const newer = checkpoint(52, "event-52", 52);
+    const older = checkpoint(41, "event-41", 41);
+
+    const newerWrite = persistTimelineCheckpoint(
+      fixture.indexedDB,
+      newer,
+      streamIdentity,
+    );
+    const olderWrite = persistTimelineCheckpoint(
+      fixture.indexedDB,
+      older,
+      streamIdentity,
+    );
+    await flushPromiseContinuations();
+
+    expect(fixture.controls.pendingOperations()).toEqual(["open"]);
+    fixture.controls.succeed("open");
+    await flushPromiseContinuations();
+    expect(fixture.controls.pendingOperations()).toEqual(["put"]);
+    fixture.controls.succeed("put");
+    fixture.controls.completeTransaction();
+    await Promise.all([newerWrite, olderWrite]);
+
+    await expect(readStoredCheckpoint(fixture)).resolves.toMatchObject({
+      afterEventId: "event-52",
+      afterSequence: 52,
+      materializedWorkOutcomeState: { counts: { completed: 52 } },
+      replayState: { tick_count: 52 },
+      selectedTick: 52,
+      syncIdentity: newer.syncIdentity,
+    });
+  });
+
+  it("does not admit an equal sequence while that sequence is pending", async () => {
+    const fixture =
+      createControlledIndexedDBTestDouble<StoredCheckpointEnvelope>();
+    const first = persistTimelineCheckpoint(
+      fixture.indexedDB,
+      checkpoint(52, "event-52", 52),
+      streamIdentity,
+    );
+    const equal = persistTimelineCheckpoint(
+      fixture.indexedDB,
+      checkpoint(53, "different-event-at-52", 52),
+      streamIdentity,
+    );
+    await flushPromiseContinuations();
+
+    expect(fixture.controls.pendingOperations()).toEqual(["open"]);
+    fixture.controls.succeed("open");
+    await flushPromiseContinuations();
+    fixture.controls.succeed("put");
+    fixture.controls.completeTransaction();
+    await Promise.all([first, equal]);
+
+    await expect(readStoredCheckpoint(fixture)).resolves.toMatchObject({
+      afterEventId: "event-52",
+      afterSequence: 52,
+      selectedTick: 52,
+    });
+  });
+});

--- a/ui/src/features/timeline/state/checkpoint-persistence/ordering/timelineCheckpointPersistence.ordered-writes.test.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/ordering/timelineCheckpointPersistence.ordered-writes.test.ts
@@ -81,6 +81,8 @@ describe("timeline checkpoint same-stream write ordering", () => {
     fixture.controls.completeTransaction();
     await flushPromiseContinuations();
     await flushPromiseContinuations();
+    await flushPromiseContinuations();
+    await flushPromiseContinuations();
 
     expect(fixture.controls.pendingOperations()).toEqual(["open"]);
     fixture.controls.succeed("open");

--- a/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.multi-session.test.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.multi-session.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { DEFAULT_FACTORY_SESSION_ID } from "../../../../api/session-routing";
 import { MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO } from "../../../../testing/multi-session-timeline-checkpoint-scenario";
 import { createTimelineCheckpointIndexedDBTestDouble } from "../../../../testing/timeline-checkpoint-indexeddb-test-utils";
+import { streamDerivedCheckpointStorageKey } from "../../lib/stream-derived-cache-identity";
 import type { FactoryTimelineCheckpoint } from "../timeline/storeState";
 import {
   clearTimelineCheckpointsForSession,
@@ -31,6 +32,32 @@ async function persistScenarioInOrder(
   }
 }
 
+async function seedCrossKeyIdentityMismatch(
+  indexedDB: IDBFactory,
+  records: Map<string, { storageKey?: string }>,
+  options: { includeLegacySessionID?: boolean } = {},
+): Promise<{ invalidStorageKey: string; validStorageKey: string }> {
+  const { A, B } = MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO;
+  const invalidStorageKey = streamDerivedCheckpointStorageKey(A.streamIdentity);
+  const validStorageKey = streamDerivedCheckpointStorageKey(B.streamIdentity);
+  await persistTimelineCheckpoint(indexedDB, B.checkpoint, B.streamIdentity);
+  const validEnvelope = records.get(validStorageKey);
+  if (!validEnvelope) {
+    throw new Error("expected persisted session B checkpoint fixture");
+  }
+
+  records.clear();
+  records.set(invalidStorageKey, {
+    ...validEnvelope,
+    ...(options.includeLegacySessionID
+      ? { sessionID: A.streamIdentity.factorySessionID }
+      : {}),
+    storageKey: invalidStorageKey,
+  });
+  records.set(validStorageKey, validEnvelope);
+  return { invalidStorageKey, validStorageKey };
+}
+
 function expectCheckpointToMatchScenario(
   checkpoint: FactoryTimelineCheckpoint | null | undefined,
   session: (typeof MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO)["A" | "B" | "C"],
@@ -47,6 +74,32 @@ function expectCheckpointToMatchScenario(
 }
 
 describe("multi-session timeline checkpoint identity regression", () => {
+  it("preflight deletes a key-mismatched envelope without deleting the valid derived-key checkpoint", async () => {
+    const { indexedDB, records } =
+      createTimelineCheckpointIndexedDBTestDouble();
+    const { B } = MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO;
+    const { invalidStorageKey, validStorageKey } =
+      await seedCrossKeyIdentityMismatch(indexedDB, records);
+
+    await expect(
+      peekPersistedTimelineCheckpoint(
+        indexedDB,
+        B.streamIdentity.factorySessionID,
+      ),
+    ).resolves.toBe(null);
+    expect(records.has(invalidStorageKey)).toBe(false);
+    expect(records.has(validStorageKey)).toBe(true);
+    expectCheckpointToMatchScenario(
+      (
+        await peekPersistedTimelineCheckpoint(
+          indexedDB,
+          B.streamIdentity.factorySessionID,
+        )
+      )?.checkpoint,
+      B,
+    );
+  });
+
   it.each(
     checkpointInsertionOrders,
   )("does not choose an arbitrary concrete checkpoint for ~default after %s then %s insertion", async (...order) => {
@@ -117,6 +170,35 @@ describe("multi-session timeline checkpoint identity regression", () => {
       )?.checkpoint,
       A,
     );
+    expectCheckpointToMatchScenario(
+      (
+        await peekPersistedTimelineCheckpoint(
+          indexedDB,
+          B.streamIdentity.factorySessionID,
+        )
+      )?.checkpoint,
+      B,
+    );
+  });
+});
+
+describe("multi-session timeline checkpoint targeted invalidation", () => {
+  it("session cleanup deletes a key-mismatched envelope without deleting the valid derived-key checkpoint", async () => {
+    const { indexedDB, records } =
+      createTimelineCheckpointIndexedDBTestDouble();
+    const { A, B } = MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO;
+    const { invalidStorageKey, validStorageKey } =
+      await seedCrossKeyIdentityMismatch(indexedDB, records, {
+        includeLegacySessionID: true,
+      });
+
+    await clearTimelineCheckpointsForSession(
+      indexedDB,
+      A.streamIdentity.factorySessionID,
+    );
+
+    expect(records.has(invalidStorageKey)).toBe(false);
+    expect(records.has(validStorageKey)).toBe(true);
     expectCheckpointToMatchScenario(
       (
         await peekPersistedTimelineCheckpoint(

--- a/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.replacement-failure.test.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.replacement-failure.test.ts
@@ -79,6 +79,7 @@ describe("timeline checkpoint replacement failure", () => {
     expect(records.size).toBe(0);
 
     controls.succeed("put");
+    controls.completeTransaction();
     await firstWrite;
     expect(controls.pendingOperations()).not.toContain("delete");
     expect([...records.values()][0]?.checkpoint).toMatchObject({
@@ -134,6 +135,7 @@ describe("timeline checkpoint replacement failure", () => {
     controls.succeed("open");
     await flushPromiseContinuations();
     controls.succeed("put");
+    controls.completeTransaction();
     await write;
     const stored = [...records.entries()][0];
     if (!stored) {

--- a/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.replacement-failure.test.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.replacement-failure.test.ts
@@ -68,6 +68,11 @@ async function commitCheckpoint(
   await flushPromiseContinuations();
   fixture.controls.succeed("open");
   await flushPromiseContinuations();
+  fixture.controls.succeed("get");
+  await flushPromiseContinuations();
+  await flushPromiseContinuations();
+  fixture.controls.succeed("open");
+  await flushPromiseContinuations();
   fixture.controls.succeed("put");
   fixture.controls.completeTransaction();
   await write;
@@ -78,7 +83,6 @@ async function readStoredCheckpoint(fixture: ControlledFixture) {
   fixture.controls.succeed("open");
   await flushPromiseContinuations();
   fixture.controls.succeed("get");
-  fixture.controls.completeTransaction();
   return read;
 }
 
@@ -105,6 +109,11 @@ async function expectFailedReplacementRecovery(
   ).finally(() => {
     replacementSettled = true;
   });
+  await flushPromiseContinuations();
+  await flushPromiseContinuations();
+  fixture.controls.succeed("open");
+  await flushPromiseContinuations();
+  fixture.controls.succeed("get");
   await flushPromiseContinuations();
   await flushPromiseContinuations();
   fixture.controls.succeed("open");
@@ -171,6 +180,11 @@ describe("timeline checkpoint replacement failure", () => {
       checkpoint(7, "event-7", 42),
       streamIdentity,
     );
+    controls.succeed("open");
+    await flushPromiseContinuations();
+    controls.succeed("get");
+    await flushPromiseContinuations();
+    await flushPromiseContinuations();
     controls.succeed("open");
     await flushPromiseContinuations();
     controls.succeed("put");

--- a/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.replacement-failure.test.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.replacement-failure.test.ts
@@ -11,7 +11,6 @@ import { createMaterializedWorkOutcomeState } from "../../../work-outcome/public
 import { emptyReplayWorldState } from "../timeline/replayWorldStateSupport";
 import type { FactoryTimelineCheckpoint } from "../timeline/storeState";
 import {
-  clearTimelineCheckpointsForSession,
   persistTimelineCheckpoint,
   readTimelineCheckpoint,
   type TimelineCheckpointStreamIdentity,
@@ -41,83 +40,126 @@ function checkpoint(
   afterEventId: string,
   afterSequence: number,
 ): FactoryTimelineCheckpoint {
+  const materializedWorkOutcomeState = createMaterializedWorkOutcomeState();
+  materializedWorkOutcomeState.counts.completed = selectedTick;
   return {
     afterEventId,
     afterSequence,
-    materializedWorkOutcomeState: createMaterializedWorkOutcomeState(),
+    materializedWorkOutcomeState,
     replayState: emptyReplayWorldState(selectedTick),
     selectedTick,
   };
 }
 
+type ControlledFixture = ReturnType<
+  typeof createControlledIndexedDBTestDouble<StoredCheckpointEnvelope>
+>;
+
+async function commitCheckpoint(
+  fixture: ControlledFixture,
+  value: FactoryTimelineCheckpoint,
+): Promise<void> {
+  const write = persistTimelineCheckpoint(
+    fixture.indexedDB,
+    value,
+    streamIdentity,
+  );
+  await flushPromiseContinuations();
+  await flushPromiseContinuations();
+  fixture.controls.succeed("open");
+  await flushPromiseContinuations();
+  fixture.controls.succeed("put");
+  fixture.controls.completeTransaction();
+  await write;
+}
+
+async function readStoredCheckpoint(fixture: ControlledFixture) {
+  const read = readTimelineCheckpoint(fixture.indexedDB, streamIdentity);
+  fixture.controls.succeed("open");
+  await flushPromiseContinuations();
+  fixture.controls.succeed("get");
+  fixture.controls.completeTransaction();
+  return read;
+}
+
+async function expectFailedReplacementRecovery(
+  failReplacement: (
+    fixture: ControlledFixture,
+    isReplacementSettled: () => boolean,
+  ) => Promise<void>,
+): Promise<void> {
+  const fixture =
+    createControlledIndexedDBTestDouble<StoredCheckpointEnvelope>();
+  const lastKnownGood = checkpoint(7, "event-7", 42);
+  const attemptedReplacement = checkpoint(11, "event-11", 51);
+  const staleCheckpoint = checkpoint(9, "event-9", 45);
+  const recoveredCheckpoint = checkpoint(15, "event-15", 60);
+
+  await commitCheckpoint(fixture, lastKnownGood);
+
+  let replacementSettled = false;
+  const replacementWrite = persistTimelineCheckpoint(
+    fixture.indexedDB,
+    attemptedReplacement,
+    streamIdentity,
+  ).finally(() => {
+    replacementSettled = true;
+  });
+  await flushPromiseContinuations();
+  await flushPromiseContinuations();
+  fixture.controls.succeed("open");
+  await flushPromiseContinuations();
+  expect(fixture.controls.pendingOperations()).toEqual(["put"]);
+
+  await persistTimelineCheckpoint(
+    fixture.indexedDB,
+    staleCheckpoint,
+    streamIdentity,
+  );
+  expect(fixture.controls.pendingOperations()).toEqual(["put"]);
+
+  await failReplacement(fixture, () => replacementSettled);
+  await replacementWrite;
+
+  await expect(readStoredCheckpoint(fixture)).resolves.toMatchObject({
+    afterEventId: "event-7",
+    afterSequence: 42,
+    materializedWorkOutcomeState: { counts: { completed: 7 } },
+    replayState: { tick_count: 7 },
+    selectedTick: 7,
+  });
+
+  await commitCheckpoint(fixture, recoveredCheckpoint);
+  await expect(readStoredCheckpoint(fixture)).resolves.toMatchObject({
+    afterEventId: "event-15",
+    afterSequence: 60,
+    materializedWorkOutcomeState: { counts: { completed: 15 } },
+    replayState: { tick_count: 15 },
+    selectedTick: 15,
+  });
+}
+
 describe("timeline checkpoint replacement failure", () => {
-  it("preserves the last committed checkpoint when a delayed replacement put fails", async () => {
-    const { controls, indexedDB, records } =
-      createControlledIndexedDBTestDouble<StoredCheckpointEnvelope>();
-    const lastKnownGood = checkpoint(7, "event-7", 42);
-    const attemptedReplacement = checkpoint(11, "event-11", 51);
-
-    const firstWrite = persistTimelineCheckpoint(
-      indexedDB,
-      lastKnownGood,
-      streamIdentity,
-    );
-    controls.succeed("open");
-    await flushPromiseContinuations();
-
-    controls.succeed("put");
-    controls.completeTransaction();
-    await firstWrite;
-    expect(controls.pendingOperations()).not.toContain("delete");
-    expect([...records.values()][0]?.checkpoint).toMatchObject({
-      afterEventId: "event-7",
-      afterSequence: 42,
-      selectedTick: 7,
+  it("recovers after a replacement request fails and its transaction aborts", async () => {
+    await expectFailedReplacementRecovery(async ({ controls }, isSettled) => {
+      controls.fail("put", new Error("replacement put failed"));
+      await flushPromiseContinuations();
+      expect(isSettled()).toBe(false);
+      controls.abortTransaction(new Error("replacement transaction aborted"));
     });
+  });
 
-    const replacementWrite = persistTimelineCheckpoint(
-      indexedDB,
-      attemptedReplacement,
-      streamIdentity,
-    );
-    controls.succeed("open");
-    await flushPromiseContinuations();
-    controls.fail("put", new Error("replacement put failed"));
-    await replacementWrite;
-
-    const restoredCheckpoint = readTimelineCheckpoint(
-      indexedDB,
-      streamIdentity,
-    );
-    controls.succeed("open");
-    await flushPromiseContinuations();
-    controls.succeed("get");
-
-    await expect(restoredCheckpoint).resolves.toMatchObject({
-      afterEventId: "event-7",
-      afterSequence: 42,
-      selectedTick: 7,
+  it("recovers after a replacement transaction fails following put success", async () => {
+    await expectFailedReplacementRecovery(async ({ controls, records }) => {
+      controls.succeed("put");
+      await flushPromiseContinuations();
+      expect([...records.values()][0]?.checkpoint).toMatchObject({
+        afterEventId: "event-7",
+        afterSequence: 42,
+        selectedTick: 7,
+      });
+      controls.failTransaction(new Error("replacement transaction failed"));
     });
-    expect(await restoredCheckpoint).not.toMatchObject({
-      afterEventId: "event-11",
-      afterSequence: 51,
-      selectedTick: 11,
-    });
-
-    const cleanup = clearTimelineCheckpointsForSession(
-      indexedDB,
-      streamIdentity.factorySessionID,
-    );
-    controls.succeed("open");
-    await flushPromiseContinuations();
-    controls.succeed("getAll");
-    await flushPromiseContinuations();
-    controls.succeed("open");
-    await flushPromiseContinuations();
-    controls.succeed("delete");
-    await cleanup;
-
-    expect(records.size).toBe(0);
   });
 
   it("does not diagnose or delete a held read after cancellation", async () => {

--- a/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.replacement-failure.test.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.replacement-failure.test.ts
@@ -7,9 +7,9 @@ import {
   readSessionPersistenceInvalidationRecords,
   resetSessionPersistenceInvalidationRecords,
 } from "../../../dashboard/lib/session-persistence/diagnostics";
+import { createMaterializedWorkOutcomeState } from "../../../work-outcome/public/materializer";
 import { emptyReplayWorldState } from "../timeline/replayWorldStateSupport";
 import type { FactoryTimelineCheckpoint } from "../timeline/storeState";
-import { createMaterializedWorkOutcomeState } from "../../../work-outcome/public/materializer";
 import {
   clearTimelineCheckpointsForSession,
   persistTimelineCheckpoint,
@@ -65,19 +65,6 @@ describe("timeline checkpoint replacement failure", () => {
     controls.succeed("open");
     await flushPromiseContinuations();
 
-    const replacementWrite = persistTimelineCheckpoint(
-      indexedDB,
-      attemptedReplacement,
-      streamIdentity,
-    );
-    controls.succeed("open");
-    await flushPromiseContinuations();
-    expect(controls.pendingOperations()).toEqual(["put", "put"]);
-
-    controls.fail("put", new Error("replacement put failed"), 1);
-    await replacementWrite;
-    expect(records.size).toBe(0);
-
     controls.succeed("put");
     controls.completeTransaction();
     await firstWrite;
@@ -87,6 +74,16 @@ describe("timeline checkpoint replacement failure", () => {
       afterSequence: 42,
       selectedTick: 7,
     });
+
+    const replacementWrite = persistTimelineCheckpoint(
+      indexedDB,
+      attemptedReplacement,
+      streamIdentity,
+    );
+    controls.succeed("open");
+    await flushPromiseContinuations();
+    controls.fail("put", new Error("replacement put failed"));
+    await replacementWrite;
 
     const restoredCheckpoint = readTimelineCheckpoint(
       indexedDB,

--- a/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.test.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_FACTORY_SESSION_ID } from "../../../../api/session-routing";
 import {
+  indexedDBErrorTestRequest,
+  indexedDBTestRequest,
+} from "../../../../testing/timeline-checkpoint-indexeddb-test-utils";
+import {
   readSessionPersistenceInvalidationRecords,
   resetSessionPersistenceInvalidationRecords,
 } from "../../../dashboard/public/session-persistence-diagnostics";
@@ -50,36 +54,51 @@ function createIndexedDBTestDouble(
     objectStoreNames: {
       contains: () => options.storeExists ?? true,
     },
-    transaction: () => ({
-      objectStore: () => ({
-        delete: (key: string) =>
-          indexedDBRequest(undefined, () => {
-            records.delete(key);
-          }),
-        get: (key: string) => indexedDBRequest(records.get(key)),
-        getAll: () => indexedDBRequest(Array.from(records.values())),
-        put: (value: StoredCheckpointEnvelope) =>
-          options.failPut
-            ? indexedDBErrorRequest<string>(new Error("put failed"))
-            : indexedDBRequest(value.storageKey ?? "", () => {
-                if (value.storageKey) {
-                  records.set(value.storageKey, value);
-                }
-              }),
-      }),
-    }),
+    transaction: () => {
+      const transaction = {
+        onabort: null,
+        oncomplete: null,
+        onerror: null,
+        objectStore: () => ({
+          delete: (key: string) =>
+            indexedDBTestRequest(undefined, () => {
+              records.delete(key);
+            }),
+          get: (key: string) => indexedDBTestRequest(records.get(key)),
+          getAll: () => indexedDBTestRequest(Array.from(records.values())),
+          put: (value: StoredCheckpointEnvelope) =>
+            options.failPut
+              ? indexedDBErrorTestRequest<string>(new Error("put failed"))
+              : indexedDBTestRequest(
+                  value.storageKey ?? "",
+                  () => {
+                    if (value.storageKey) {
+                      records.set(value.storageKey, value);
+                    }
+                  },
+                  () =>
+                    (
+                      transaction.oncomplete as
+                        | ((event: Event) => void)
+                        | null
+                    )?.({} as Event),
+                ),
+        }),
+      };
+      return transaction;
+    },
   };
 
   return {
     indexedDB: {
       open: () => {
         if (options.failOpen) {
-          return indexedDBErrorRequest<typeof database>(
+          return indexedDBErrorTestRequest<typeof database>(
             new Error("open failed"),
           );
         }
 
-        const request = indexedDBRequest(database);
+        const request = indexedDBTestRequest(database);
         queueMicrotask(() =>
           request.onupgradeneeded?.({} as IDBVersionChangeEvent),
         );
@@ -89,47 +108,6 @@ function createIndexedDBTestDouble(
     createObjectStore,
     records,
   };
-}
-
-function indexedDBRequest<T>(result: T, beforeSuccess?: () => void) {
-  const request = {
-    error: null,
-    onblocked: null,
-    onerror: null,
-    onsuccess: null,
-    onupgradeneeded: null,
-    result,
-  } as unknown as IDBRequest<T> & {
-    onblocked?: ((event: Event) => void) | null;
-    onupgradeneeded?: ((event: IDBVersionChangeEvent) => void) | null;
-  };
-
-  queueMicrotask(() => {
-    beforeSuccess?.();
-    request.onsuccess?.({} as Event);
-  });
-
-  return request;
-}
-
-function indexedDBErrorRequest<T>(error: Error) {
-  const request = {
-    error,
-    onblocked: null,
-    onerror: null,
-    onsuccess: null,
-    onupgradeneeded: null,
-    result: undefined,
-  } as unknown as IDBRequest<T> & {
-    onblocked?: ((event: Event) => void) | null;
-    onupgradeneeded?: ((event: IDBVersionChangeEvent) => void) | null;
-  };
-
-  queueMicrotask(() => {
-    request.onerror?.({} as Event);
-  });
-
-  return request;
 }
 
 function checkpointFixture(): FactoryTimelineCheckpoint {

--- a/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.test.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.test.ts
@@ -8,6 +8,7 @@ import {
   readSessionPersistenceInvalidationRecords,
   resetSessionPersistenceInvalidationRecords,
 } from "../../../dashboard/public/session-persistence-diagnostics";
+import { createMaterializedWorkOutcomeState } from "../../../work-outcome/public/materializer";
 import { emptyReplayWorldState } from "../timeline/replayWorldStateSupport";
 import type { FactoryTimelineCheckpoint } from "../timeline/storeState";
 import {
@@ -18,7 +19,6 @@ import {
   type TimelineCheckpointStreamIdentity,
 } from "../timelineCheckpointPersistence";
 import { reconnectCursorFromCheckpoint } from "../timelineCheckpointReconnect";
-import { createMaterializedWorkOutcomeState } from "../../../work-outcome/public/materializer";
 
 interface StoredCheckpointEnvelope {
   checkpoint?: {
@@ -68,7 +68,11 @@ function createIndexedDBTestDouble(
           getAll: () => indexedDBTestRequest(Array.from(records.values())),
           put: (value: StoredCheckpointEnvelope) =>
             options.failPut
-              ? indexedDBErrorTestRequest<string>(new Error("put failed"))
+              ? indexedDBErrorTestRequest<string>(new Error("put failed"), () =>
+                  (transaction.onabort as ((event: Event) => void) | null)?.(
+                    {} as Event,
+                  ),
+                )
               : indexedDBTestRequest(
                   value.storageKey ?? "",
                   () => {
@@ -78,9 +82,7 @@ function createIndexedDBTestDouble(
                   },
                   () =>
                     (
-                      transaction.oncomplete as
-                        | ((event: Event) => void)
-                        | null
+                      transaction.oncomplete as ((event: Event) => void) | null
                     )?.({} as Event),
                 ),
         }),

--- a/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.test.ts
+++ b/ui/src/features/timeline/state/checkpoint-persistence/timelineCheckpointPersistence.test.ts
@@ -61,9 +61,16 @@ function createIndexedDBTestDouble(
         onerror: null,
         objectStore: () => ({
           delete: (key: string) =>
-            indexedDBTestRequest(undefined, () => {
-              records.delete(key);
-            }),
+            indexedDBTestRequest(
+              undefined,
+              () => {
+                records.delete(key);
+              },
+              () =>
+                (transaction.oncomplete as ((event: Event) => void) | null)?.(
+                  {} as Event,
+                ),
+            ),
           get: (key: string) => indexedDBTestRequest(records.get(key)),
           getAll: () => indexedDBTestRequest(Array.from(records.values())),
           put: (value: StoredCheckpointEnvelope) =>

--- a/ui/src/features/timeline/state/timelineCheckpointPersistence.ts
+++ b/ui/src/features/timeline/state/timelineCheckpointPersistence.ts
@@ -13,6 +13,7 @@ import {
   type IndexedDBLike,
   indexedDBRequestToPromise,
   openCheckpointDatabase,
+  writeCheckpointDatabaseRecord,
 } from "./checkpoint-persistence/indexedDBCheckpointRequests";
 import {
   buildPersistedCheckpoint,
@@ -63,23 +64,6 @@ function matchesStoredCheckpointFactorySessionID(
     return storedFactorySessionID === requestedSessionID;
   }
   return normalizeFactorySessionUUID(envelope.sessionID) === requestedSessionID;
-}
-
-async function writeIndexedCheckpoint(
-  indexedDB: IndexedDBLike,
-  envelope: TimelineCheckpointEnvelope,
-): Promise<void> {
-  const database = await openCheckpointDatabase(indexedDB);
-  try {
-    const transaction = database.transaction(
-      CHECKPOINT_STORE_NAME,
-      "readwrite",
-    );
-    const store = transaction.objectStore(CHECKPOINT_STORE_NAME);
-    await indexedDBRequestToPromise(store.put(envelope));
-  } finally {
-    database.close();
-  }
 }
 
 async function readIndexedCheckpoint(
@@ -414,7 +398,7 @@ export async function persistTimelineCheckpoint(
   } satisfies TimelineCheckpointEnvelope;
 
   try {
-    await writeIndexedCheckpoint(indexedDB, envelope);
+    await writeCheckpointDatabaseRecord(indexedDB, envelope);
   } catch {
     // Preserve any previously committed checkpoint when its replacement fails.
   }

--- a/ui/src/features/timeline/state/timelineCheckpointPersistence.ts
+++ b/ui/src/features/timeline/state/timelineCheckpointPersistence.ts
@@ -60,16 +60,20 @@ function matchesStoredCheckpointFactorySessionID(
   factorySessionID: string,
 ): boolean {
   const requestedSessionID = normalizeFactorySessionUUID(factorySessionID);
+  const legacySessionID = normalizeFactorySessionUUID(envelope.sessionID);
   const storedFactorySessionID = normalizeFactorySessionUUID(
     envelope.streamIdentity?.factorySessionID,
   );
   if (!requestedSessionID) {
     return false;
   }
+  if (legacySessionID) {
+    return legacySessionID === requestedSessionID;
+  }
   if (storedFactorySessionID) {
     return storedFactorySessionID === requestedSessionID;
   }
-  return normalizeFactorySessionUUID(envelope.sessionID) === requestedSessionID;
+  return false;
 }
 
 export interface PersistedTimelineCheckpointPeek {
@@ -94,18 +98,19 @@ async function deleteRejectedEnvelope(
   signal?: AbortSignal,
 ): Promise<void> {
   const storageKey = envelope.storageKey?.trim() ?? "";
-  if (storageKey !== "") {
-    const streamIdentity = normalizeTimelineCheckpointIdentity(
-      envelope.streamIdentity,
-    );
-    if (streamIdentity) {
-      await clearTimelineCheckpoint(indexedDB, streamIdentity);
-      return;
-    }
-    await deleteCheckpointDatabaseRecord(indexedDB, storageKey, signal).catch(
-      () => {},
-    );
+  if (storageKey === "") {
+    return;
   }
+  const streamIdentity = normalizeTimelineCheckpointIdentity(
+    envelope.streamIdentity,
+  );
+  if (streamIdentity && checkpointStorageKey(streamIdentity) === storageKey) {
+    await clearTimelineCheckpoint(indexedDB, streamIdentity, { signal });
+    return;
+  }
+  await deleteCheckpointDatabaseRecord(indexedDB, storageKey, signal).catch(
+    () => {},
+  );
 }
 
 async function listIndexedCheckpoints(
@@ -191,22 +196,9 @@ export async function clearTimelineCheckpointsForSession(
     );
 
     await Promise.all(
-      matchingEnvelopes.map((envelope) => {
-        const streamIdentity = normalizeTimelineCheckpointIdentity(
-          envelope.streamIdentity,
-        );
-        if (streamIdentity) {
-          return clearTimelineCheckpoint(indexedDB, streamIdentity);
-        }
-        const storageKey = envelope.storageKey.trim();
-        return storageKey === ""
-          ? Promise.resolve()
-          : deleteCheckpointDatabaseRecord(
-              indexedDB,
-              storageKey,
-              options.signal,
-            ).catch(() => {});
-      }),
+      matchingEnvelopes.map((envelope) =>
+        deleteRejectedEnvelope(indexedDB, envelope, options.signal),
+      ),
     );
   } catch {
     // Best-effort cleanup for stale reconnect state.
@@ -216,7 +208,11 @@ export async function clearTimelineCheckpointsForSession(
 export async function clearTimelineCheckpoint(
   indexedDB: IndexedDBLike | undefined,
   streamIdentity: TimelineCheckpointStreamIdentity | null,
-  options: { requestedSessionID?: string; userInitiated?: boolean } = {},
+  options: {
+    requestedSessionID?: string;
+    signal?: AbortSignal;
+    userInitiated?: boolean;
+  } = {},
 ): Promise<void> {
   const normalizedStreamIdentity =
     normalizeTimelineCheckpointIdentity(streamIdentity);
@@ -233,7 +229,7 @@ export async function clearTimelineCheckpoint(
     );
   }
   await enqueueOrderedCheckpointClear(indexedDB, normalizedStreamIdentity, () =>
-    deleteCheckpointDatabaseRecord(indexedDB, storageKey),
+    deleteCheckpointDatabaseRecord(indexedDB, storageKey, options.signal),
   ).catch(() => {});
 }
 

--- a/ui/src/features/timeline/state/timelineCheckpointPersistence.ts
+++ b/ui/src/features/timeline/state/timelineCheckpointPersistence.ts
@@ -10,11 +10,19 @@ import {
   streamDerivedCheckpointStorageKey,
 } from "../lib/stream-derived-cache-identity";
 import {
+  checkpointSyncIdentityMatchesStreamIdentity,
+  normalizeFactorySessionUUID,
+  normalizeStoredTimelineCheckpointIdentity,
+  normalizeTimelineCheckpointIdentity,
+  timelineCheckpointIdentitiesMatch,
+} from "./checkpoint-persistence/identity/timelineCheckpointIdentity";
+import {
   type IndexedDBLike,
   indexedDBRequestToPromise,
   openCheckpointDatabase,
   writeCheckpointDatabaseRecord,
 } from "./checkpoint-persistence/indexedDBCheckpointRequests";
+import { enqueueOrderedCheckpointWrite } from "./checkpoint-persistence/ordering/orderedCheckpointWriter";
 import {
   buildPersistedCheckpoint,
   CHECKPOINT_SCHEMA_VERSION_GUARDED,
@@ -22,13 +30,6 @@ import {
   isSupportedPersistedTimelineCheckpoint,
   type PersistedTimelineCheckpoint,
 } from "./checkpoint-persistence/timelineCheckpointCodec";
-import {
-  checkpointSyncIdentityMatchesStreamIdentity,
-  normalizeFactorySessionUUID,
-  normalizeStoredTimelineCheckpointIdentity,
-  normalizeTimelineCheckpointIdentity,
-  timelineCheckpointIdentitiesMatch,
-} from "./checkpoint-persistence/identity/timelineCheckpointIdentity";
 import type { FactoryTimelineCheckpoint } from "./timeline/storeState";
 
 const CHECKPOINT_STORE_NAME = "checkpoints";
@@ -398,7 +399,12 @@ export async function persistTimelineCheckpoint(
   } satisfies TimelineCheckpointEnvelope;
 
   try {
-    await writeCheckpointDatabaseRecord(indexedDB, envelope);
+    await enqueueOrderedCheckpointWrite(
+      indexedDB,
+      normalizedStreamIdentity,
+      persistedCheckpoint.afterSequence,
+      () => writeCheckpointDatabaseRecord(indexedDB, envelope),
+    );
   } catch {
     // Preserve any previously committed checkpoint when its replacement fails.
   }

--- a/ui/src/features/timeline/state/timelineCheckpointPersistence.ts
+++ b/ui/src/features/timeline/state/timelineCheckpointPersistence.ts
@@ -17,12 +17,17 @@ import {
   timelineCheckpointIdentitiesMatch,
 } from "./checkpoint-persistence/identity/timelineCheckpointIdentity";
 import {
+  deleteCheckpointDatabaseRecord,
   type IndexedDBLike,
   indexedDBRequestToPromise,
   openCheckpointDatabase,
+  readCheckpointDatabaseRecord,
   writeCheckpointDatabaseRecord,
 } from "./checkpoint-persistence/indexedDBCheckpointRequests";
-import { enqueueOrderedCheckpointWrite } from "./checkpoint-persistence/ordering/orderedCheckpointWriter";
+import {
+  enqueueOrderedCheckpointClear,
+  enqueueOrderedCheckpointWrite,
+} from "./checkpoint-persistence/ordering/orderedCheckpointWriter";
 import {
   buildPersistedCheckpoint,
   CHECKPOINT_SCHEMA_VERSION_GUARDED,
@@ -67,46 +72,6 @@ function matchesStoredCheckpointFactorySessionID(
   return normalizeFactorySessionUUID(envelope.sessionID) === requestedSessionID;
 }
 
-async function readIndexedCheckpoint(
-  indexedDB: IndexedDBLike,
-  storageKey: string,
-  signal?: AbortSignal,
-): Promise<TimelineCheckpointEnvelope | null> {
-  const database = await openCheckpointDatabase(indexedDB);
-  try {
-    const transaction = database.transaction(CHECKPOINT_STORE_NAME, "readonly");
-    const store = transaction.objectStore(CHECKPOINT_STORE_NAME);
-    const result = await indexedDBRequestToPromise<
-      TimelineCheckpointEnvelope | undefined
-    >(store.get(storageKey), transaction, signal);
-    return result ?? null;
-  } finally {
-    database.close();
-  }
-}
-
-async function deleteIndexedCheckpoint(
-  indexedDB: IndexedDBLike,
-  storageKey: string,
-  signal?: AbortSignal,
-): Promise<void> {
-  const database = await openCheckpointDatabase(indexedDB);
-  try {
-    const transaction = database.transaction(
-      CHECKPOINT_STORE_NAME,
-      "readwrite",
-    );
-    const store = transaction.objectStore(CHECKPOINT_STORE_NAME);
-    await indexedDBRequestToPromise(
-      store.delete(storageKey),
-      transaction,
-      signal,
-    );
-  } finally {
-    database.close();
-  }
-}
-
 export interface PersistedTimelineCheckpointPeek {
   checkpoint: FactoryTimelineCheckpoint;
   storageKey: string;
@@ -130,7 +95,14 @@ async function deleteRejectedEnvelope(
 ): Promise<void> {
   const storageKey = envelope.storageKey?.trim() ?? "";
   if (storageKey !== "") {
-    await deleteIndexedCheckpoint(indexedDB, storageKey, signal).catch(
+    const streamIdentity = normalizeTimelineCheckpointIdentity(
+      envelope.streamIdentity,
+    );
+    if (streamIdentity) {
+      await clearTimelineCheckpoint(indexedDB, streamIdentity);
+      return;
+    }
+    await deleteCheckpointDatabaseRecord(indexedDB, storageKey, signal).catch(
       () => {},
     );
   }
@@ -214,19 +186,27 @@ export async function clearTimelineCheckpointsForSession(
     if (options.signal?.aborted) {
       return;
     }
-    const storageKeys = envelopes
-      .filter((envelope) =>
-        matchesStoredCheckpointFactorySessionID(envelope, normalizedSessionID),
-      )
-      .map((envelope) => envelope.storageKey)
-      .filter((storageKey) => storageKey.trim() !== "");
+    const matchingEnvelopes = envelopes.filter((envelope) =>
+      matchesStoredCheckpointFactorySessionID(envelope, normalizedSessionID),
+    );
 
     await Promise.all(
-      storageKeys.map((storageKey) =>
-        deleteIndexedCheckpoint(indexedDB, storageKey, options.signal).catch(
-          () => {},
-        ),
-      ),
+      matchingEnvelopes.map((envelope) => {
+        const streamIdentity = normalizeTimelineCheckpointIdentity(
+          envelope.streamIdentity,
+        );
+        if (streamIdentity) {
+          return clearTimelineCheckpoint(indexedDB, streamIdentity);
+        }
+        const storageKey = envelope.storageKey.trim();
+        return storageKey === ""
+          ? Promise.resolve()
+          : deleteCheckpointDatabaseRecord(
+              indexedDB,
+              storageKey,
+              options.signal,
+            ).catch(() => {});
+      }),
     );
   } catch {
     // Best-effort cleanup for stale reconnect state.
@@ -238,8 +218,10 @@ export async function clearTimelineCheckpoint(
   streamIdentity: TimelineCheckpointStreamIdentity | null,
   options: { requestedSessionID?: string; userInitiated?: boolean } = {},
 ): Promise<void> {
-  const storageKey = checkpointStorageKey(streamIdentity);
-  if (!indexedDB || !storageKey) {
+  const normalizedStreamIdentity =
+    normalizeTimelineCheckpointIdentity(streamIdentity);
+  const storageKey = checkpointStorageKey(normalizedStreamIdentity);
+  if (!indexedDB || !storageKey || !normalizedStreamIdentity) {
     return;
   }
   if (options.userInitiated && streamIdentity && options.requestedSessionID) {
@@ -250,7 +232,9 @@ export async function clearTimelineCheckpoint(
       ),
     );
   }
-  await deleteIndexedCheckpoint(indexedDB, storageKey).catch(() => {});
+  await enqueueOrderedCheckpointClear(indexedDB, normalizedStreamIdentity, () =>
+    deleteCheckpointDatabaseRecord(indexedDB, storageKey),
+  ).catch(() => {});
 }
 
 function parseStoredCheckpoint(
@@ -403,6 +387,20 @@ export async function persistTimelineCheckpoint(
       indexedDB,
       normalizedStreamIdentity,
       persistedCheckpoint.afterSequence,
+      async () => {
+        const committedEnvelope =
+          await readCheckpointDatabaseRecord<TimelineCheckpointEnvelope>(
+            indexedDB,
+            storageKey,
+          );
+        if (!committedEnvelope) {
+          return undefined;
+        }
+        return parseStoredCheckpoint(
+          committedEnvelope,
+          normalizedStreamIdentity,
+        )?.afterSequence;
+      },
       () => writeCheckpointDatabaseRecord(indexedDB, envelope),
     );
   } catch {
@@ -414,9 +412,10 @@ export async function purgeLegacyTimelineCheckpoints(
   indexedDB: IndexedDBLike | undefined,
 ): Promise<void> {
   if (!indexedDB) return;
-  await deleteIndexedCheckpoint(indexedDB, DEFAULT_FACTORY_SESSION_ID).catch(
-    () => {},
-  );
+  await deleteCheckpointDatabaseRecord(
+    indexedDB,
+    DEFAULT_FACTORY_SESSION_ID,
+  ).catch(() => {});
 }
 
 export async function readTimelineCheckpoint(
@@ -432,11 +431,12 @@ export async function readTimelineCheckpoint(
   }
 
   try {
-    const envelope = await readIndexedCheckpoint(
-      indexedDB,
-      storageKey,
-      options.signal,
-    );
+    const envelope =
+      await readCheckpointDatabaseRecord<TimelineCheckpointEnvelope>(
+        indexedDB,
+        storageKey,
+        options.signal,
+      );
     if (options.signal?.aborted) {
       return null;
     }
@@ -446,21 +446,13 @@ export async function readTimelineCheckpoint(
         normalizedStreamIdentity,
       );
       if (!checkpoint) {
-        await deleteIndexedCheckpoint(
-          indexedDB,
-          storageKey,
-          options.signal,
-        ).catch(() => {});
+        await clearTimelineCheckpoint(indexedDB, normalizedStreamIdentity);
       }
       return checkpoint;
     }
   } catch {
     if (!options.signal?.aborted) {
-      await deleteIndexedCheckpoint(
-        indexedDB,
-        storageKey,
-        options.signal,
-      ).catch(() => {});
+      await clearTimelineCheckpoint(indexedDB, normalizedStreamIdentity);
     }
   }
 

--- a/ui/src/features/work-outcome/hooks/useWorkOutcomeChart.test.ts
+++ b/ui/src/features/work-outcome/hooks/useWorkOutcomeChart.test.ts
@@ -549,17 +549,26 @@ function createIndexedDBTestDouble() {
     createObjectStore: () => {},
     deleteObjectStore: () => {},
     objectStoreNames: { contains: () => true },
-    transaction: () => ({
-      objectStore: () => ({
-        delete: (key: string) =>
-          indexedDBRequest(undefined, () => records.delete(key)),
-        get: (key: string) => indexedDBRequest(records.get(key)),
-        put: (value: { storageKey: string }) =>
-          indexedDBRequest(value.storageKey, () =>
-            records.set(value.storageKey, value),
-          ),
-      }),
-    }),
+    transaction: () => {
+      const transaction = {
+        oncomplete: null,
+        objectStore: () => ({
+          delete: (key: string) =>
+            indexedDBRequest(undefined, () => records.delete(key)),
+          get: (key: string) => indexedDBRequest(records.get(key)),
+          put: (value: { storageKey: string }) =>
+            indexedDBRequest(
+              value.storageKey,
+              () => records.set(value.storageKey, value),
+              () =>
+                (
+                  transaction.oncomplete as ((event: Event) => void) | null
+                )?.({} as Event),
+            ),
+        }),
+      };
+      return transaction;
+    },
   };
 
   return {
@@ -569,7 +578,11 @@ function createIndexedDBTestDouble() {
   };
 }
 
-function indexedDBRequest<T>(result: T, beforeSuccess?: () => void) {
+function indexedDBRequest<T>(
+  result: T,
+  beforeSuccess?: () => void,
+  afterSuccess?: () => void,
+) {
   const request = {
     error: null,
     onblocked: null,
@@ -581,6 +594,7 @@ function indexedDBRequest<T>(result: T, beforeSuccess?: () => void) {
   queueMicrotask(() => {
     beforeSuccess?.();
     request.onsuccess?.({} as Event);
+    afterSuccess?.();
   });
   return request;
 }

--- a/ui/src/testing/controlled-indexeddb-test-utils.ts
+++ b/ui/src/testing/controlled-indexeddb-test-utils.ts
@@ -17,11 +17,91 @@ interface ControlledRequest<T> {
   result: () => T;
 }
 
+interface ControlledTransaction {
+  commitActions: Array<() => void>;
+  transaction: IDBTransaction;
+}
+
+function createTransactionControls(pending: ControlledTransaction[]) {
+  function take(ordinal = 0): ControlledTransaction {
+    const controlled = pending[ordinal];
+    if (!controlled) throw new Error("no pending IndexedDB transaction");
+    pending.splice(ordinal, 1);
+    return controlled;
+  }
+
+  return {
+    abort(error?: Error, ordinal = 0): void {
+      const { transaction } = take(ordinal);
+      Object.defineProperty(transaction, "error", {
+        configurable: true,
+        value: error ?? null,
+      });
+      transaction.onabort?.({} as Event);
+    },
+    complete(ordinal = 0): void {
+      const controlled = take(ordinal);
+      for (const commit of controlled.commitActions) commit();
+      controlled.transaction.oncomplete?.({} as Event);
+    },
+    fail(error: Error, ordinal = 0): void {
+      const { transaction } = take(ordinal);
+      Object.defineProperty(transaction, "error", {
+        configurable: true,
+        value: error,
+      });
+      transaction.onerror?.({} as Event);
+    },
+  };
+}
+
+function createRequestControls(pending: ControlledRequest<unknown>[]) {
+  function take(
+    operation: ControlledIndexedDBOperation,
+    ordinal = 0,
+  ): ControlledRequest<unknown> {
+    const matchingIndexes = pending.flatMap((request, index) =>
+      request.operation === operation ? [index] : [],
+    );
+    const index = matchingIndexes[ordinal] ?? -1;
+    const controlled = pending[index];
+    if (index < 0 || !controlled) {
+      throw new Error(`no pending IndexedDB ${operation} request`);
+    }
+    pending.splice(index, 1);
+    return controlled;
+  }
+
+  return {
+    fail(operation: ControlledIndexedDBOperation, error: Error, ordinal = 0) {
+      const controlled = take(operation, ordinal);
+      Object.defineProperty(controlled.request, "error", {
+        configurable: true,
+        value: error,
+      });
+      controlled.request.onerror?.({} as Event);
+    },
+    succeed(operation: ControlledIndexedDBOperation, ordinal = 0): void {
+      const controlled = take(operation, ordinal);
+      if (!controlled.isAborted()) controlled.beforeSuccess?.();
+      Object.defineProperty(controlled.request, "result", {
+        configurable: true,
+        value: controlled.result(),
+      });
+      controlled.request.onsuccess?.({} as Event);
+    },
+  };
+}
+
 export function createControlledIndexedDBTestDouble<
   RecordType extends StoredRecord,
 >() {
   const records = new Map<string, RecordType>();
   const pending: ControlledRequest<unknown>[] = [];
+  const pendingTransactions: ControlledTransaction[] = [];
+  const requestControls = createRequestControls(pending);
+  const transactionControls = createTransactionControls(pendingTransactions);
+  let closedDatabaseCount = 0;
 
   function controlledRequest<T>(
     operation: ControlledIndexedDBOperation,
@@ -47,13 +127,20 @@ export function createControlledIndexedDBTestDouble<
   }
 
   const database = {
-    close: () => {},
+    close: () => {
+      closedDatabaseCount += 1;
+    },
     objectStoreNames: {
       contains: () => true,
     },
     transaction: () => {
       let aborted = false;
-      return {
+      const commitActions: Array<() => void> = [];
+      const transaction = {
+        error: null,
+        onabort: null,
+        oncomplete: null,
+        onerror: null,
         abort: () => {
           aborted = true;
         },
@@ -84,63 +171,31 @@ export function createControlledIndexedDBTestDouble<
               "put",
               () => value.storageKey ?? "",
               () => {
-                if (value.storageKey) {
-                  records.set(value.storageKey, value);
-                }
+                commitActions.push(() => {
+                  if (value.storageKey) {
+                    records.set(value.storageKey, value);
+                  }
+                });
               },
               () => aborted,
             ),
         }),
-      };
+      } as unknown as IDBTransaction;
+      pendingTransactions.push({ commitActions, transaction });
+      return transaction;
     },
   };
 
-  function take(
-    operation: ControlledIndexedDBOperation,
-    ordinal = 0,
-  ): ControlledRequest<unknown> {
-    const matchingIndexes = pending.flatMap((request, index) =>
-      request.operation === operation ? [index] : [],
-    );
-    const index = matchingIndexes[ordinal] ?? -1;
-    const controlled = pending[index];
-    if (index < 0 || !controlled) {
-      throw new Error(`no pending IndexedDB ${operation} request`);
-    }
-    pending.splice(index, 1);
-    return controlled;
-  }
-
-  function succeed(operation: ControlledIndexedDBOperation, ordinal = 0): void {
-    const controlled = take(operation, ordinal);
-    if (!controlled.isAborted()) {
-      controlled.beforeSuccess?.();
-    }
-    Object.defineProperty(controlled.request, "result", {
-      configurable: true,
-      value: controlled.result(),
-    });
-    controlled.request.onsuccess?.({} as Event);
-  }
-
-  function fail(
-    operation: ControlledIndexedDBOperation,
-    error: Error,
-    ordinal = 0,
-  ): void {
-    const controlled = take(operation, ordinal);
-    Object.defineProperty(controlled.request, "error", {
-      configurable: true,
-      value: error,
-    });
-    controlled.request.onerror?.({} as Event);
-  }
-
   return {
     controls: {
-      fail,
+      abortTransaction: transactionControls.abort,
+      closedDatabaseCount: () => closedDatabaseCount,
+      completeTransaction: transactionControls.complete,
+      fail: requestControls.fail,
+      failTransaction: transactionControls.fail,
       pendingOperations: () => pending.map(({ operation }) => operation),
-      succeed,
+      pendingTransactionCount: () => pendingTransactions.length,
+      succeed: requestControls.succeed,
     },
     indexedDB: {
       open: () => controlledRequest("open", () => database),

--- a/ui/src/testing/controlled-indexeddb-test-utils.ts
+++ b/ui/src/testing/controlled-indexeddb-test-utils.ts
@@ -133,7 +133,7 @@ export function createControlledIndexedDBTestDouble<
     objectStoreNames: {
       contains: () => true,
     },
-    transaction: () => {
+    transaction: (_storeName: string, mode?: IDBTransactionMode) => {
       let aborted = false;
       const commitActions: Array<() => void> = [];
       const transaction = {
@@ -181,7 +181,9 @@ export function createControlledIndexedDBTestDouble<
             ),
         }),
       } as unknown as IDBTransaction;
-      pendingTransactions.push({ commitActions, transaction });
+      if (mode === "readwrite") {
+        pendingTransactions.push({ commitActions, transaction });
+      }
       return transaction;
     },
   };

--- a/ui/src/testing/quiet-checkpoint-reload-test-utils.ts
+++ b/ui/src/testing/quiet-checkpoint-reload-test-utils.ts
@@ -82,7 +82,14 @@ function createIndexedDBTestDouble(): IDBFactory {
         onerror: null,
         objectStore: () => ({
           delete: (key: string) =>
-            indexedDBRequest(undefined, () => records.delete(key)),
+            indexedDBRequest(
+              undefined,
+              () => records.delete(key),
+              () =>
+                (transaction.oncomplete as ((event: Event) => void) | null)?.(
+                  {} as Event,
+                ),
+            ),
           get: (key: string) => indexedDBRequest(records.get(key)),
           getAll: () => indexedDBRequest([...records.values()]),
           put: (value: StoredCheckpointEnvelope) =>

--- a/ui/src/testing/quiet-checkpoint-reload-test-utils.ts
+++ b/ui/src/testing/quiet-checkpoint-reload-test-utils.ts
@@ -4,11 +4,11 @@ import { vi } from "vitest";
 import { useFactoryTimelineStore } from "../features/timeline/state/factoryTimelineStore";
 import { emptyReplayWorldState } from "../features/timeline/state/timeline/replayWorldStateSupport";
 import type { FactoryTimelineCheckpoint } from "../features/timeline/state/timeline/storeState";
-import { createMaterializedWorkOutcomeState } from "../features/work-outcome/public/materializer";
 import {
   persistTimelineCheckpoint,
   type TimelineCheckpointStreamIdentity,
 } from "../features/timeline/state/timelineCheckpointPersistence";
+import { createMaterializedWorkOutcomeState } from "../features/work-outcome/public/materializer";
 import type { RenderAppFetchOverride } from "./app-shell-fetch-test-utils";
 import { APP_SHELL_RESOLVED_DEFAULT_SESSION_UUID } from "./app-shell-session-preflight-test-utils";
 import { MockEventSource } from "./app-shell-session-stream-test-utils";
@@ -44,7 +44,11 @@ export interface QuietCheckpointReloadFixture {
   waitForStreamCreation: () => Promise<MockEventSource>;
 }
 
-function indexedDBRequest<T>(result: T, beforeSuccess?: () => void) {
+function indexedDBRequest<T>(
+  result: T,
+  beforeSuccess?: () => void,
+  afterSuccess?: () => void,
+) {
   const request = {
     error: null,
     onblocked: null,
@@ -59,6 +63,7 @@ function indexedDBRequest<T>(result: T, beforeSuccess?: () => void) {
   queueMicrotask(() => {
     beforeSuccess?.();
     request.onsuccess?.({} as Event);
+    afterSuccess?.();
   });
   return request;
 }
@@ -70,20 +75,33 @@ function createIndexedDBTestDouble(): IDBFactory {
     createObjectStore: () => undefined,
     deleteObjectStore: () => undefined,
     objectStoreNames: { contains: () => true },
-    transaction: () => ({
-      objectStore: () => ({
-        delete: (key: string) =>
-          indexedDBRequest(undefined, () => records.delete(key)),
-        get: (key: string) => indexedDBRequest(records.get(key)),
-        getAll: () => indexedDBRequest([...records.values()]),
-        put: (value: StoredCheckpointEnvelope) =>
-          indexedDBRequest(value.storageKey ?? "", () => {
-            if (value.storageKey) {
-              records.set(value.storageKey, value);
-            }
-          }),
-      }),
-    }),
+    transaction: () => {
+      const transaction = {
+        onabort: null,
+        oncomplete: null,
+        onerror: null,
+        objectStore: () => ({
+          delete: (key: string) =>
+            indexedDBRequest(undefined, () => records.delete(key)),
+          get: (key: string) => indexedDBRequest(records.get(key)),
+          getAll: () => indexedDBRequest([...records.values()]),
+          put: (value: StoredCheckpointEnvelope) =>
+            indexedDBRequest(
+              value.storageKey ?? "",
+              () => {
+                if (value.storageKey) {
+                  records.set(value.storageKey, value);
+                }
+              },
+              () =>
+                (transaction.oncomplete as ((event: Event) => void) | null)?.(
+                  {} as Event,
+                ),
+            ),
+        }),
+      };
+      return transaction;
+    },
   };
 
   return {

--- a/ui/src/testing/timeline-checkpoint-indexeddb-test-utils.ts
+++ b/ui/src/testing/timeline-checkpoint-indexeddb-test-utils.ts
@@ -35,9 +35,9 @@ export function createTimelineCheckpointIndexedDBTestDouble(): {
                 }
               },
               () =>
-                (
-                  transaction.oncomplete as ((event: Event) => void) | null
-                )?.({} as Event),
+                (transaction.oncomplete as ((event: Event) => void) | null)?.(
+                  {} as Event,
+                ),
             ),
         }),
       };
@@ -85,13 +85,19 @@ export function indexedDBTestRequest<T>(
   return request;
 }
 
-export function indexedDBErrorTestRequest<T>(error: Error): IDBRequest<T> {
+export function indexedDBErrorTestRequest<T>(
+  error: Error,
+  afterError?: () => void,
+): IDBRequest<T> {
   const request = {
     error,
     onerror: null,
     onsuccess: null,
     result: undefined,
   } as unknown as IDBRequest<T>;
-  queueMicrotask(() => request.onerror?.({} as Event));
+  queueMicrotask(() => {
+    request.onerror?.({} as Event);
+    afterError?.();
+  });
   return request;
 }

--- a/ui/src/testing/timeline-checkpoint-indexeddb-test-utils.ts
+++ b/ui/src/testing/timeline-checkpoint-indexeddb-test-utils.ts
@@ -21,9 +21,16 @@ export function createTimelineCheckpointIndexedDBTestDouble(): {
         onerror: null,
         objectStore: () => ({
           delete: (key: string) =>
-            indexedDBTestRequest(undefined, () => {
-              records.delete(key);
-            }),
+            indexedDBTestRequest(
+              undefined,
+              () => {
+                records.delete(key);
+              },
+              () =>
+                (transaction.oncomplete as ((event: Event) => void) | null)?.(
+                  {} as Event,
+                ),
+            ),
           get: (key: string) => indexedDBTestRequest(records.get(key)),
           getAll: () => indexedDBTestRequest([...records.values()]),
           put: (value: StoredCheckpointEnvelope) =>

--- a/ui/src/testing/timeline-checkpoint-indexeddb-test-utils.ts
+++ b/ui/src/testing/timeline-checkpoint-indexeddb-test-utils.ts
@@ -14,28 +14,41 @@ export function createTimelineCheckpointIndexedDBTestDouble(): {
     objectStoreNames: {
       contains: () => true,
     },
-    transaction: () => ({
-      objectStore: () => ({
-        delete: (key: string) =>
-          indexedDBRequest(undefined, () => {
-            records.delete(key);
-          }),
-        get: (key: string) => indexedDBRequest(records.get(key)),
-        getAll: () => indexedDBRequest([...records.values()]),
-        put: (value: StoredCheckpointEnvelope) =>
-          indexedDBRequest(value.storageKey ?? "", () => {
-            if (value.storageKey) {
-              records.set(value.storageKey, value);
-            }
-          }),
-      }),
-    }),
+    transaction: () => {
+      const transaction = {
+        onabort: null,
+        oncomplete: null,
+        onerror: null,
+        objectStore: () => ({
+          delete: (key: string) =>
+            indexedDBTestRequest(undefined, () => {
+              records.delete(key);
+            }),
+          get: (key: string) => indexedDBTestRequest(records.get(key)),
+          getAll: () => indexedDBTestRequest([...records.values()]),
+          put: (value: StoredCheckpointEnvelope) =>
+            indexedDBTestRequest(
+              value.storageKey ?? "",
+              () => {
+                if (value.storageKey) {
+                  records.set(value.storageKey, value);
+                }
+              },
+              () =>
+                (
+                  transaction.oncomplete as ((event: Event) => void) | null
+                )?.({} as Event),
+            ),
+        }),
+      };
+      return transaction;
+    },
   };
 
   return {
     indexedDB: {
       open: () => {
-        const request = indexedDBRequest(database);
+        const request = indexedDBTestRequest(database);
         queueMicrotask(() =>
           request.onupgradeneeded?.({} as IDBVersionChangeEvent),
         );
@@ -46,7 +59,11 @@ export function createTimelineCheckpointIndexedDBTestDouble(): {
   };
 }
 
-function indexedDBRequest<T>(result: T, beforeSuccess?: () => void) {
+export function indexedDBTestRequest<T>(
+  result: T,
+  beforeSuccess?: () => void,
+  afterSuccess?: () => void,
+) {
   const request = {
     error: null,
     onblocked: null,
@@ -62,7 +79,19 @@ function indexedDBRequest<T>(result: T, beforeSuccess?: () => void) {
   queueMicrotask(() => {
     beforeSuccess?.();
     request.onsuccess?.({} as Event);
+    afterSuccess?.();
   });
 
+  return request;
+}
+
+export function indexedDBErrorTestRequest<T>(error: Error): IDBRequest<T> {
+  const request = {
+    error,
+    onerror: null,
+    onsuccess: null,
+    result: undefined,
+  } as unknown as IDBRequest<T>;
+  queueMicrotask(() => request.onerror?.({} as Event));
   return request;
 }


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "session-repair-ordered-checkpoint-writer",
  "description": "Harden timeline checkpoint persistence with a per-stream ordered writer that admits only strictly newer checkpoint sequences, waits for the durable IndexedDB transaction outcome, preserves the last known-good checkpoint across failed replacements, and allows distinct four-part stream identities to write concurrently.",
  "context": {
    "customerAsk": "Serialize timeline checkpoint writes per four-part stream identity so same-stream writes remain monotonic, the persistence promise waits for durable IndexedDB transaction completion, distinct streams remain independent, failed replacements preserve the last known-good record, and invalid checkpoints retain targeted fail-closed invalidation.",
    "problem": "The current writer awaits the IndexedDB put request but does not coordinate overlapping same-stream writes or explicitly await transaction completion. An older asynchronous completion can therefore replace newer cursor and event metadata, callers can observe completion before durability is known, and failure handling must be hardened without losing the prior checkpoint or blocking recovery.",
    "solution": "Add a transient write coordinator keyed by the normalized four-part stream identity, admit only checkpoints with a strictly newer afterSequence than the newest pending or committed candidate, serialize only same-stream writes, and settle internal writes on IndexedDB transaction completion, abort, or error. Preserve best-effort caller behavior, last-known-good records, targeted invalidation, and existing bounded materialized checkpoint round trips."
  },
  "acceptanceCriteria": [
    "For one normalized four-part stream identity, only a checkpoint with a strictly newer afterSequence may supersede the newest pending or committed checkpoint; older or equal candidates cannot replace its cursor, event ID, or materialized payload even when request completions are forced into reverse order.",
    "A checkpoint persistence promise remains pending after put request success and settles only after the corresponding read-write transaction completes, aborts, or errors; the database is not treated as durably written before that outcome.",
    "Writes for different four-part stream identities can reach pending IndexedDB operations concurrently, and a delayed or failed write for one identity does not block another identity.",
    "A failed newer replacement leaves the last committed checkpoint readable, does not allow a previously rejected stale write to take its place, and does not prevent a later strictly newer checkpoint from committing.",
    "Schema-invalid and identity-invalid stored checkpoints continue to be rejected and deleted only at the targeted stream key, with existing persistence diagnostics retained where applicable; Batch 005 bounded materialized checkpoint round trips remain equivalent.",
    "UI typecheck, lint, focused checkpoint persistence tests, and affected existing tests pass."
  ],
  "userStories": [
    {
      "id": "session-repair-ordered-checkpoint-writer-001",
      "title": "Resolve writes at durable transaction completion",
      "description": "As a dashboard operator, I want a completed checkpoint save to represent the IndexedDB transaction's durable outcome so reconnect logic never relies on a write that merely reached request success.",
      "acceptanceCriteria": [
        "After the checkpoint put request succeeds, the persistence operation remains pending until the same read-write transaction emits completion.",
        "Transaction completion produces the successful persistence outcome; transaction abort or error produces a failed internal write outcome even when the put request previously succeeded.",
        "The database connection remains valid through transaction settlement and is closed after the durable outcome is known.",
        "Controlled IndexedDB tests independently release request success and transaction completion, abort, and error without timers or race-prone sleeps.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "session-repair-ordered-checkpoint-writer-002",
      "title": "Keep same-stream checkpoints monotonic",
      "description": "As a dashboard operator reconnecting to a Factory Session, I want overlapping saves for the same event stream to retain the newest checkpoint so delayed work cannot move my resumed timeline backward.",
      "acceptanceCriteria": [
        "The writer uses the normalized four-part stream identity as the coordination boundary and compares each candidate with the newest checkpoint already pending or committed on that lane.",
        "Only a strictly greater afterSequence is admitted after a stream has a sequenced pending or committed candidate; lower or equal candidates resolve without replacing the newer checkpoint.",
        "The complete admitted checkpoint envelope is written atomically, so afterSequence, afterEventId, selected tick, sync identity, and bounded materialized replay state always come from the same candidate.",
        "A deterministic older-last test starts a newer and an older same-stream save, controls IndexedDB progression, and proves the newer cursor and event metadata remain readable after both promises settle.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "session-repair-ordered-checkpoint-writer-003",
      "title": "Recover cleanly after a failed replacement",
      "description": "As a dashboard operator, I want checkpoint persistence to recover after a failed replacement so my last known-good resume point survives and later timeline progress can still be saved.",
      "acceptanceCriteria": [
        "If an admitted replacement transaction fails or aborts, the previously committed checkpoint remains readable and unchanged.",
        "Failure settles the attempted public persistence call according to the existing best-effort contract and does not leave a rejected coordinator tail that blocks later work.",
        "An older or equal candidate rejected while a newer replacement is pending is not replayed after that replacement fails.",
        "A later checkpoint with a strictly newer afterSequence can commit after the failure, and a subsequent read returns that later checkpoint's cursor, event metadata, and materialized state.",
        "Controlled failure-and-recovery tests cover request failure and a transaction failure after request success while preserving the existing replacement-failure regression.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "session-repair-ordered-checkpoint-writer-004",
      "title": "Preserve independent streams and validation safeguards",
      "description": "As an operator monitoring multiple Factory Session streams, I want each stream to persist independently while invalid stored data remains isolated so one stream cannot delay, collide with, or invalidate another.",
      "acceptanceCriteria": [
        "Two checkpoints whose normalized four-part identities differ in any identity component can both reach their IndexedDB write stages before either transaction is released.",
        "Delaying or failing one stream's request or transaction does not delay settlement or durable commit for the other stream, and each storage key retains only its own checkpoint metadata and materialized state.",
        "Coordinator bookkeeping is removed when an identity has no pending work, without a global lock or cross-stream queue.",
        "Existing schema-invalid and identity-invalid read cases still fail closed, delete only the targeted checkpoint, and retain existing identity-mismatch diagnostics where applicable.",
        "Existing Batch 005 bounded materialized projection and resume round-trip tests pass unchanged or with only durability-aware test-double progression.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}
