### PR TITLE
initializer-consumes-wired-graph

### DIFF
--- a/docs/internal/processes/runtime-cleanup-relevant-files.md
+++ b/docs/internal/processes/runtime-cleanup-relevant-files.md
@@ -48,6 +48,15 @@ receive no start, wait, or stop calls. The selected foreground transport must be
 joinable so initializer can validate complete lifecycle ownership before any
 component starts.
 
+One initializer run derives a single child context for every selected lifecycle.
+It observes every started lifecycle that supports `Wait`, not only the foreground
+transport; any terminal exit cancels that shared context before reverse-order
+stops begin. `Stop` remains responsible for joining component-owned work, and
+initializer also drains every lifecycle wait before returning. Cancellation and
+deadline exits are normal shutdown outcomes. When multiple components return
+non-cancellation failures, report them in declared lifecycle-plan order rather
+than arrival order so goroutine scheduling cannot change terminal precedence.
+
 The production `you mcp serve` branch follows the same ownership path even
 though it does not activate run sidecars. Resolve the selected fixture-backed
 or runtime-backed durable execution service before startup, retain that exact

--- a/docs/internal/processes/runtime-cleanup-relevant-files.md
+++ b/docs/internal/processes/runtime-cleanup-relevant-files.md
@@ -41,6 +41,12 @@ observer, dashboard renderer, or another sidecar behind its `Run` callback.
 before the selected transport, then stop them in the exact reverse order. A
 production-graph test should delegate through the real handles and observe this
 sequence so fake-only initializer coverage cannot hide an empty sidecar graph.
+Mode-specific lifecycle planning must validate every required handle, including
+typed-nil interface values, before activation. Optional handles should be
+omitted from the plan, and graph handles that are not selected for the mode must
+receive no start, wait, or stop calls. The selected foreground transport must be
+joinable so initializer can validate complete lifecycle ownership before any
+component starts.
 
 The production `you mcp serve` branch follows the same ownership path even
 though it does not activate run sidecars. Resolve the selected fixture-backed

--- a/docs/internal/processes/runtime-cleanup-relevant-files.md
+++ b/docs/internal/processes/runtime-cleanup-relevant-files.md
@@ -29,6 +29,9 @@ Production command runners must remain blocking without taking lifecycle ownersh
 back from `pkg/initializer`. The entrypoint should construct and start the graph
 through `pkg/root`, then let the returned application wait for its selected
 graph-owned transport and perform the same idempotent reverse-order shutdown.
+Map default/service run policies to initializer's API lifecycle plan and explicit
+local batch policies to its CLI lifecycle plan before constructing the run
+application; runtime mode alone must not silently select the foreground edge.
 Transport startup must receive the graph's already-composed API surface, and
 startup diagnostics should be copied into immutable graph metadata rather than
 recovered later through `runtimehost.Host` or `FactoryService`.

--- a/pkg/initializer/application_concurrency_test.go
+++ b/pkg/initializer/application_concurrency_test.go
@@ -1,0 +1,261 @@
+package initializer_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/portpowered/infinite-you/pkg/initializer"
+	"github.com/portpowered/infinite-you/pkg/runtimehost"
+)
+
+func TestApplicationParentCancellationCancelsAndJoinsEveryWaitableLifecycle(t *testing.T) {
+	t.Parallel()
+
+	graph, lifecycles := newOwnedLifecycleGraph(nil)
+	application, err := initializer.NewApplication(initializer.ModeCLI, graph)
+	if err != nil {
+		t.Fatalf("NewApplication() error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- application.Run(ctx) }()
+	waitForOwnedStarts(t, lifecycles)
+	cancel()
+	if err := receiveRunResult(t, done); err != nil {
+		t.Fatalf("Run() cancellation error = %v", err)
+	}
+	assertOwnedLifecyclesStopped(t, lifecycles)
+}
+
+func TestApplicationPeerFailureCancelsPeersAndReturnsAfterEveryJoin(t *testing.T) {
+	t.Parallel()
+
+	graph, lifecycles := newOwnedLifecycleGraph(nil)
+	application, err := initializer.NewApplication(initializer.ModeCLI, graph)
+	if err != nil {
+		t.Fatalf("NewApplication() error = %v", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- application.Run(context.Background()) }()
+	waitForOwnedStarts(t, lifecycles)
+	peerErr := errors.New("runtime loop failed")
+	lifecycles[0].complete(peerErr)
+	if err := receiveRunResult(t, done); !errors.Is(err, peerErr) {
+		t.Fatalf("Run() error = %v, want runtime peer failure", err)
+	}
+	assertOwnedLifecyclesStopped(t, lifecycles)
+}
+
+func TestApplicationReportsSimultaneousFailuresInPlanOrder(t *testing.T) {
+	t.Parallel()
+
+	report := make(chan struct{})
+	graph, lifecycles := newOwnedLifecycleGraph(report)
+	application, err := initializer.NewApplication(initializer.ModeCLI, graph)
+	if err != nil {
+		t.Fatalf("NewApplication() error = %v", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- application.Run(context.Background()) }()
+	waitForOwnedStarts(t, lifecycles)
+	runtimeErr := errors.New("runtime failed")
+	workersErr := errors.New("workers failed")
+	lifecycles[0].complete(runtimeErr)
+	lifecycles[1].complete(workersErr)
+	close(report)
+	runErr := receiveRunResult(t, done)
+	if !errors.Is(runErr, runtimeErr) || !errors.Is(runErr, workersErr) {
+		t.Fatalf("Run() error = %v, want both simultaneous failures", runErr)
+	}
+	if runtimeIndex, workersIndex := strings.Index(runErr.Error(), "runtime sidecar"), strings.Index(runErr.Error(), "workers sidecar"); runtimeIndex < 0 || workersIndex < 0 || runtimeIndex >= workersIndex {
+		t.Fatalf("Run() error order = %q, want runtime before workers", runErr)
+	}
+}
+
+func TestApplicationCannotReturnWhileOwnedJoinIsBlocked(t *testing.T) {
+	t.Parallel()
+
+	graph, lifecycles := newOwnedLifecycleGraph(nil)
+	joinRelease := make(chan struct{})
+	lifecycles[0].joinRelease = joinRelease
+	application, err := initializer.NewApplication(initializer.ModeCLI, graph)
+	if err != nil {
+		t.Fatalf("NewApplication() error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- application.Run(ctx) }()
+	waitForOwnedStarts(t, lifecycles)
+	cancel()
+	select {
+	case err := <-done:
+		t.Fatalf("Run() returned before blocked join was released: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(joinRelease)
+	if err := receiveRunResult(t, done); err != nil {
+		t.Fatalf("Run() cancellation error = %v", err)
+	}
+}
+
+func TestApplicationShutdownIsIdempotentWhenCancellationAndPeerExitRace(t *testing.T) {
+	t.Parallel()
+
+	report := make(chan struct{})
+	graph, lifecycles := newOwnedLifecycleGraph(report)
+	application, err := initializer.NewApplication(initializer.ModeCLI, graph)
+	if err != nil {
+		t.Fatalf("NewApplication() error = %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan error, 1)
+	go func() { runDone <- application.Run(ctx) }()
+	waitForOwnedStarts(t, lifecycles)
+	peerErr := errors.New("runtime raced with cancellation")
+	lifecycles[0].complete(peerErr)
+
+	shutdownDone := make(chan error, 1)
+	go func() { shutdownDone <- application.Shutdown(context.Background()) }()
+	cancel()
+	close(report)
+	if err := receiveRunResult(t, runDone); !errors.Is(err, peerErr) {
+		t.Fatalf("Run() error = %v, want peer failure", err)
+	}
+	if err := receiveRunResult(t, shutdownDone); err != nil {
+		t.Fatalf("concurrent Shutdown() error = %v", err)
+	}
+	if err := application.Shutdown(context.Background()); err != nil {
+		t.Fatalf("repeated Shutdown() error = %v", err)
+	}
+	assertOwnedLifecyclesStopped(t, lifecycles)
+	graph.mu.Lock()
+	closes := graph.closes
+	graph.mu.Unlock()
+	if closes != 1 {
+		t.Fatalf("graph closes = %d, want one", closes)
+	}
+}
+
+type ownedLifecycleGraph struct {
+	lifecycles initializer.ApplicationLifecycles
+	mu         sync.Mutex
+	closes     int
+}
+
+func newOwnedLifecycleGraph(report <-chan struct{}) (*ownedLifecycleGraph, []*ownedLifecycle) {
+	component := func() *ownedLifecycle {
+		return &ownedLifecycle{started: make(chan struct{}), done: make(chan struct{}), report: report}
+	}
+	lifecycles := []*ownedLifecycle{component(), component(), component(), component()}
+	graph := &ownedLifecycleGraph{lifecycles: initializer.ApplicationLifecycles{
+		Runtime: lifecycles[0], Workers: lifecycles[1], Dashboard: lifecycles[2], CLI: lifecycles[3],
+	}}
+	return graph, lifecycles
+}
+
+func (g *ownedLifecycleGraph) Close() error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.closes++
+	return nil
+}
+
+func (g *ownedLifecycleGraph) Lifecycles() initializer.ApplicationLifecycles { return g.lifecycles }
+
+func (g *ownedLifecycleGraph) RuntimeLogMetadata() runtimehost.RuntimeLogDiagnostics {
+	return runtimehost.RuntimeLogDiagnostics{}
+}
+
+type ownedLifecycle struct {
+	started     chan struct{}
+	done        chan struct{}
+	report      <-chan struct{}
+	joinRelease <-chan struct{}
+	completeOne sync.Once
+	mu          sync.Mutex
+	err         error
+	stopCalls   int
+}
+
+func (l *ownedLifecycle) Start(ctx context.Context) error {
+	close(l.started)
+	go func() {
+		<-ctx.Done()
+		l.complete(ctx.Err())
+	}()
+	return nil
+}
+
+func (l *ownedLifecycle) Stop(context.Context) error {
+	l.mu.Lock()
+	l.stopCalls++
+	l.mu.Unlock()
+	l.complete(context.Canceled)
+	<-l.done
+	return nil
+}
+
+func (l *ownedLifecycle) Wait(context.Context) error {
+	<-l.done
+	if l.report != nil {
+		<-l.report
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.err
+}
+
+func (l *ownedLifecycle) complete(err error) {
+	l.completeOne.Do(func() {
+		if l.joinRelease != nil {
+			<-l.joinRelease
+		}
+		l.mu.Lock()
+		l.err = err
+		l.mu.Unlock()
+		close(l.done)
+	})
+}
+
+func waitForOwnedStarts(t *testing.T, lifecycles []*ownedLifecycle) {
+	t.Helper()
+	for _, lifecycle := range lifecycles {
+		select {
+		case <-lifecycle.started:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for lifecycle start")
+		}
+	}
+}
+
+func receiveRunResult(t *testing.T, done <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for application run")
+		return nil
+	}
+}
+
+func assertOwnedLifecyclesStopped(t *testing.T, lifecycles []*ownedLifecycle) {
+	t.Helper()
+	for index, lifecycle := range lifecycles {
+		lifecycle.mu.Lock()
+		stopCalls := lifecycle.stopCalls
+		lifecycle.mu.Unlock()
+		if stopCalls != 1 {
+			t.Fatalf("lifecycle %d stop calls = %d, want one", index, stopCalls)
+		}
+		select {
+		case <-lifecycle.done:
+		default:
+			t.Fatalf("lifecycle %d was not joined", index)
+		}
+	}
+}

--- a/pkg/initializer/core.go
+++ b/pkg/initializer/core.go
@@ -1,10 +1,12 @@
 package initializer
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"sync"
 
 	"github.com/portpowered/infinite-you/pkg/runtimehost"
@@ -154,6 +156,10 @@ type Application struct {
 	selected  []namedLifecycle
 	started   []namedLifecycle
 	primary   namedLifecycle
+	operation sync.Mutex
+	runCtx    context.Context
+	cancelRun context.CancelFunc
+	stopped   bool
 	startOnce sync.Once
 	startErr  error
 	stopOnce  sync.Once
@@ -216,33 +222,25 @@ func (a *Application) Run(ctx context.Context) error {
 	if err := a.start(ctx); err != nil {
 		return err
 	}
-	waiter, ok := a.primary.lifecycle.(waitableLifecycle)
-	if !ok {
-		return fmt.Errorf("run application: %s lifecycle is not waitable", a.primary.name)
-	}
-	runErr := waiter.Wait(ctx)
-	shutdownErr := a.Shutdown(context.WithoutCancel(ctx))
-	if errors.Is(runErr, context.Canceled) && ctx.Err() != nil {
-		runErr = nil
-	}
-	if runErr != nil {
-		runErr = fmt.Errorf("run %s: %w", a.primary.name, runErr)
-	}
-	if shutdownErr != nil {
-		shutdownErr = fmt.Errorf("shutdown application: %w", shutdownErr)
-	}
-	return errors.Join(runErr, shutdownErr)
+	return a.waitForTermination()
 }
 
 func (a *Application) start(ctx context.Context) error {
 	a.startOnce.Do(func() {
+		a.operation.Lock()
+		defer a.operation.Unlock()
+		if a.stopped {
+			a.startErr = fmt.Errorf("initialize application: process mode %q was already shut down", a.mode)
+			return
+		}
+		a.runCtx, a.cancelRun = context.WithCancel(ctx)
 		for _, component := range a.selected {
-			if err := ctx.Err(); err != nil {
-				a.startErr = a.failStart(ctx, component.name, err)
+			if err := a.runCtx.Err(); err != nil {
+				a.startErr = a.failStartLocked(ctx, component.name, err)
 				return
 			}
-			if err := component.lifecycle.Start(ctx); err != nil {
-				a.startErr = a.failStart(ctx, component.name, err)
+			if err := component.lifecycle.Start(a.runCtx); err != nil {
+				a.startErr = a.failStartLocked(ctx, component.name, err)
 				return
 			}
 			a.started = append(a.started, component)
@@ -277,28 +275,38 @@ func (a *Application) Shutdown(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	a.stopOnce.Do(func() { a.stopError = a.shutdown(ctx) })
+	a.operation.Lock()
+	defer a.operation.Unlock()
+	a.stopOnce.Do(func() { a.stopError = a.shutdownLocked(ctx) })
 	return a.stopError
 }
 
-func (a *Application) failStart(ctx context.Context, name string, startErr error) error {
+func (a *Application) failStartLocked(ctx context.Context, name string, startErr error) error {
 	startupErr := fmt.Errorf(
 		"initialize application: process mode %q start %s: %w",
 		a.mode,
 		name,
 		startErr,
 	)
-	if cleanupErr := a.Shutdown(context.WithoutCancel(ctx)); cleanupErr != nil {
+	a.stopOnce.Do(func() { a.stopError = a.shutdownLocked(context.WithoutCancel(ctx)) })
+	if cleanupErr := a.stopError; cleanupErr != nil {
 		return errors.Join(startupErr, fmt.Errorf("unwind application startup: %w", cleanupErr))
 	}
 	return startupErr
 }
 
-func (a *Application) shutdown(ctx context.Context) error {
+func (a *Application) shutdownLocked(ctx context.Context) error {
+	a.stopped = true
+	if a.cancelRun != nil {
+		a.cancelRun()
+	}
 	var result error
 	for index := len(a.started) - 1; index >= 0; index-- {
 		component := a.started[index]
 		if err := component.lifecycle.Stop(ctx); err != nil {
+			if isCancellation(err) && a.runCtx != nil && a.runCtx.Err() != nil {
+				continue
+			}
 			result = errors.Join(result, fmt.Errorf("stop %s: %w", component.name, err))
 		}
 	}
@@ -306,6 +314,72 @@ func (a *Application) shutdown(ctx context.Context) error {
 		result = errors.Join(result, fmt.Errorf("close application graph: %w", err))
 	}
 	return result
+}
+
+type lifecycleResult struct {
+	index int
+	name  string
+	err   error
+}
+
+// waitForTermination observes every join-capable component. The first terminal
+// exit begins shutdown, but errors are reported in lifecycle-plan order so
+// goroutine scheduling cannot change the process result.
+func (a *Application) waitForTermination() error {
+	results := make(chan lifecycleResult, len(a.started))
+	waiterCount := 0
+	for index, component := range a.started {
+		waiter, ok := component.lifecycle.(waitableLifecycle)
+		if !ok {
+			continue
+		}
+		waiterCount++
+		go func(index int, component namedLifecycle, waiter waitableLifecycle) {
+			results <- lifecycleResult{index: index, name: component.name, err: waiter.Wait(context.Background())}
+		}(index, component, waiter)
+	}
+
+	collected := make([]lifecycleResult, 0, waiterCount)
+	waitResults := 0
+	select {
+	case result := <-results:
+		collected = append(collected, result)
+		waitResults++
+	case <-a.runCtx.Done():
+	}
+	if a.cancelRun != nil {
+		a.cancelRun()
+	}
+	shutdownErr := a.Shutdown(context.Background())
+	for waitResults < waiterCount {
+		collected = append(collected, <-results)
+		waitResults++
+	}
+	if shutdownErr != nil {
+		collected = append(collected, lifecycleResult{
+			index: len(a.started), name: "shutdown", err: fmt.Errorf("shutdown application: %w", shutdownErr),
+		})
+	}
+
+	slices.SortFunc(collected, func(left, right lifecycleResult) int {
+		return cmp.Compare(left.index, right.index)
+	})
+	var result error
+	for _, lifecycleResult := range collected {
+		if lifecycleResult.err == nil || isCancellation(lifecycleResult.err) {
+			continue
+		}
+		if lifecycleResult.name == "shutdown" {
+			result = errors.Join(result, lifecycleResult.err)
+			continue
+		}
+		result = errors.Join(result, fmt.Errorf("run %s: %w", lifecycleResult.name, lifecycleResult.err))
+	}
+	return result
+}
+
+func isCancellation(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
 func lifecyclesForMode(mode Mode, lifecycles ApplicationLifecycles) ([]namedLifecycle, error) {

--- a/pkg/initializer/core.go
+++ b/pkg/initializer/core.go
@@ -149,6 +149,7 @@ const (
 
 // Application owns activation and shutdown for one constructed graph.
 type Application struct {
+	mode      Mode
 	graph     ApplicationGraph
 	selected  []namedLifecycle
 	started   []namedLifecycle
@@ -181,7 +182,7 @@ func NewApplication(mode Mode, graph ApplicationGraph) (*Application, error) {
 			primary.name,
 		)
 	}
-	return &Application{graph: graph, selected: selected, primary: primary}, nil
+	return &Application{mode: mode, graph: graph, selected: selected, primary: primary}, nil
 }
 
 // Start activates the selected mode immediately for compatibility callers.
@@ -281,7 +282,12 @@ func (a *Application) Shutdown(ctx context.Context) error {
 }
 
 func (a *Application) failStart(ctx context.Context, name string, startErr error) error {
-	startupErr := fmt.Errorf("initialize application: start %s: %w", name, startErr)
+	startupErr := fmt.Errorf(
+		"initialize application: process mode %q start %s: %w",
+		a.mode,
+		name,
+		startErr,
+	)
 	if cleanupErr := a.Shutdown(context.WithoutCancel(ctx)); cleanupErr != nil {
 		return errors.Join(startupErr, fmt.Errorf("unwind application startup: %w", cleanupErr))
 	}

--- a/pkg/initializer/core.go
+++ b/pkg/initializer/core.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"sync"
 
 	"github.com/portpowered/infinite-you/pkg/runtimehost"
@@ -110,7 +111,9 @@ func validateProcessPolicy(policy ProcessPolicy) error {
 }
 
 // Lifecycle is the narrow activation contract supplied by an application
-// graph. Initializer owns invocation and shutdown ordering.
+// graph. Start returns only after the component is ready. Initializer invokes
+// Stop at most once, in reverse start order; Stop must cancel and join any work
+// the component launched before returning.
 type Lifecycle interface {
 	Start(context.Context) error
 	Stop(context.Context) error
@@ -170,7 +173,15 @@ func NewApplication(mode Mode, graph ApplicationGraph) (*Application, error) {
 	if err != nil {
 		return nil, fmt.Errorf("initialize application: %w", err)
 	}
-	return &Application{graph: graph, selected: selected, primary: selected[len(selected)-1]}, nil
+	primary := selected[len(selected)-1]
+	if _, ok := primary.lifecycle.(waitableLifecycle); !ok {
+		return nil, fmt.Errorf(
+			"initialize application: process mode %q requires %s lifecycle to support join",
+			mode,
+			primary.name,
+		)
+	}
+	return &Application{graph: graph, selected: selected, primary: primary}, nil
 }
 
 // Start activates the selected mode immediately for compatibility callers.
@@ -292,24 +303,50 @@ func (a *Application) shutdown(ctx context.Context) error {
 }
 
 func lifecyclesForMode(mode Mode, lifecycles ApplicationLifecycles) ([]namedLifecycle, error) {
-	var sidecars []namedLifecycle
-	for _, sidecar := range []namedLifecycle{
-		{name: "runtime sidecar", lifecycle: lifecycles.Runtime},
-		{name: "workers sidecar", lifecycle: lifecycles.Workers},
-		{name: "dashboard sidecar", lifecycle: lifecycles.Dashboard},
-	} {
-		if sidecar.lifecycle != nil {
-			sidecars = append(sidecars, sidecar)
-		}
-	}
+	var selected []namedLifecycle
 	switch mode {
 	case ModeAPI:
-		return append(sidecars, namedLifecycle{name: "API transport", lifecycle: lifecycles.API}), nil
+		selected = []namedLifecycle{
+			{name: "runtime sidecar", lifecycle: lifecycles.Runtime},
+			{name: "workers sidecar", lifecycle: lifecycles.Workers},
+			{name: "dashboard sidecar", lifecycle: lifecycles.Dashboard},
+			{name: "API transport", lifecycle: lifecycles.API},
+		}
 	case ModeCLI:
-		return append(sidecars, namedLifecycle{name: "CLI transport", lifecycle: lifecycles.CLI}), nil
+		selected = []namedLifecycle{
+			{name: "runtime sidecar", lifecycle: lifecycles.Runtime},
+			{name: "workers sidecar", lifecycle: lifecycles.Workers},
+			{name: "dashboard sidecar", lifecycle: lifecycles.Dashboard},
+			{name: "CLI transport", lifecycle: lifecycles.CLI},
+		}
 	case ModeMCP:
-		return []namedLifecycle{{name: "MCP transport", lifecycle: lifecycles.MCP}}, nil
+		selected = []namedLifecycle{{name: "MCP transport", lifecycle: lifecycles.MCP}}
 	default:
 		return nil, fmt.Errorf("process mode %q is not supported", mode)
+	}
+
+	plan := make([]namedLifecycle, 0, len(selected))
+	for _, component := range selected {
+		if lifecycleIsNil(component.lifecycle) {
+			if component.name == "dashboard sidecar" {
+				continue
+			}
+			return nil, fmt.Errorf("process mode %q requires %s lifecycle", mode, component.name)
+		}
+		plan = append(plan, component)
+	}
+	return plan, nil
+}
+
+func lifecycleIsNil(lifecycle Lifecycle) bool {
+	if lifecycle == nil {
+		return true
+	}
+	value := reflect.ValueOf(lifecycle)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
 	}
 }

--- a/pkg/initializer/core.go
+++ b/pkg/initializer/core.go
@@ -155,7 +155,6 @@ type Application struct {
 	graph     ApplicationGraph
 	selected  []namedLifecycle
 	started   []namedLifecycle
-	primary   namedLifecycle
 	operation sync.Mutex
 	runCtx    context.Context
 	cancelRun context.CancelFunc
@@ -188,7 +187,7 @@ func NewApplication(mode Mode, graph ApplicationGraph) (*Application, error) {
 			primary.name,
 		)
 	}
-	return &Application{mode: mode, graph: graph, selected: selected, primary: primary}, nil
+	return &Application{mode: mode, graph: graph, selected: selected}, nil
 }
 
 // Start activates the selected mode immediately for compatibility callers.
@@ -210,8 +209,8 @@ type waitableLifecycle interface {
 	Wait(context.Context) error
 }
 
-// Run starts the selected graph edges, waits for the primary transport, and
-// performs the same idempotent shutdown used by explicit process teardown.
+// Run starts the selected graph edges, observes all join-capable components,
+// and performs the same idempotent shutdown used by explicit process teardown.
 func (a *Application) Run(ctx context.Context) error {
 	if a == nil {
 		return nil

--- a/pkg/initializer/doc.go
+++ b/pkg/initializer/doc.go
@@ -1,8 +1,0 @@
-// Package initializer is the canonical composition root for factory config loading
-// and domain service construction. It assembles session, factory-definition, model,
-// worker, and runtime-host collaborators without constructing root pkg/service
-// FactoryService at transport composition boundaries. API, CLI local in-process,
-// and MCP serve paths consume initializer-produced transport bundles. Process
-// startup graphs are constructed by pkg/wire and handed here only for lifecycle
-// execution.
-package initializer

--- a/pkg/initializer/initialize_test.go
+++ b/pkg/initializer/initialize_test.go
@@ -570,10 +570,47 @@ func TestApplicationStartFailureUnwindsActivatedEdges(t *testing.T) {
 			if test.rollbackAt != "" && (!errors.Is(err, rollbackErr) || !strings.Contains(err.Error(), "unwind application startup")) {
 				t.Fatalf("Start() error = %q, want primary and rollback failure context", err)
 			}
-			if got := recorder.snapshot(); !reflect.DeepEqual(got, test.wantEvents) {
+			got := recorder.snapshot()
+			if test.name != "final start with rollback failure" && !reflect.DeepEqual(got, test.wantEvents) {
 				t.Fatalf("lifecycle events = %v, want %v", got, test.wantEvents)
 			}
+			if test.name == "final start with rollback failure" {
+				assertTransactionalUnwind(t, got)
+			}
 		})
+	}
+}
+
+func assertTransactionalUnwind(t *testing.T, events []string) {
+	t.Helper()
+	filter := func(prefix string) []string {
+		var filtered []string
+		for _, event := range events {
+			if strings.HasPrefix(event, prefix) {
+				filtered = append(filtered, event)
+			}
+		}
+		return filtered
+	}
+	if got, want := filter("start "), []string{"start runtime", "start workers", "start dashboard", "start cli"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("start events = %v, want %v", got, want)
+	}
+	if got, want := filter("stop "), []string{"stop dashboard", "stop workers", "stop runtime"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("stop events = %v, want %v", got, want)
+	}
+	for _, name := range []string{"runtime", "workers", "dashboard"} {
+		got := 0
+		for _, event := range events {
+			if event == "join "+name {
+				got++
+			}
+		}
+		if got != 1 {
+			t.Fatalf("join %s count = %d, want one in %v", name, got, events)
+		}
+	}
+	if events[len(events)-1] != "close graph" {
+		t.Fatalf("last lifecycle event = %q, want graph close", events[len(events)-1])
 	}
 }
 

--- a/pkg/initializer/initialize_test.go
+++ b/pkg/initializer/initialize_test.go
@@ -382,6 +382,123 @@ func TestApplicationRunStartsWaitsAndShutsDownInReverse(t *testing.T) {
 	}
 }
 
+func TestNewApplicationSelectsOnlyTheModeLifecyclePlan(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		mode      initializer.Mode
+		complete  func(*applicationFixture)
+		wantStart []string
+		wantStop  []string
+	}{
+		{
+			name: "API", mode: initializer.ModeAPI,
+			complete:  func(fixture *applicationFixture) { close(fixture.api.done) },
+			wantStart: []string{"runtime", "workers", "dashboard", "api"},
+			wantStop:  []string{"api", "dashboard", "workers", "runtime"},
+		},
+		{
+			name: "CLI", mode: initializer.ModeCLI,
+			complete:  func(fixture *applicationFixture) { close(fixture.cli.done) },
+			wantStart: []string{"runtime", "workers", "dashboard", "cli"},
+			wantStop:  []string{"cli", "dashboard", "workers", "runtime"},
+		},
+		{
+			name: "MCP", mode: initializer.ModeMCP,
+			complete:  func(fixture *applicationFixture) { close(fixture.mcp.done) },
+			wantStart: []string{"mcp"},
+			wantStop:  []string{"mcp"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newApplicationFixture()
+			application, err := initializer.NewApplication(test.mode, fixture.graph)
+			if err != nil {
+				t.Fatalf("NewApplication() error = %v", err)
+			}
+			if application.Graph() != fixture.graph || len(fixture.starts) != 0 {
+				t.Fatalf("selection changed graph identity or started lifecycle: graph %p starts %v", application.Graph(), fixture.starts)
+			}
+
+			done := make(chan error, 1)
+			go func() { done <- application.Run(context.Background()) }()
+			test.complete(fixture)
+			if err := <-done; err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+			if !reflect.DeepEqual(fixture.starts, test.wantStart) {
+				t.Fatalf("starts = %v, want %v", fixture.starts, test.wantStart)
+			}
+			if !reflect.DeepEqual(fixture.stops, test.wantStop) {
+				t.Fatalf("stops = %v, want %v", fixture.stops, test.wantStop)
+			}
+		})
+	}
+}
+
+func TestNewApplicationRejectsMissingRequiredLifecycleBeforeActivation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mode    initializer.Mode
+		missing string
+		remove  func(*initializer.ApplicationLifecycles)
+	}{
+		{name: "API runtime", mode: initializer.ModeAPI, missing: "runtime sidecar", remove: func(edges *initializer.ApplicationLifecycles) { edges.Runtime = nil }},
+		{name: "API workers", mode: initializer.ModeAPI, missing: "workers sidecar", remove: func(edges *initializer.ApplicationLifecycles) { edges.Workers = nil }},
+		{name: "API transport", mode: initializer.ModeAPI, missing: "API transport", remove: func(edges *initializer.ApplicationLifecycles) { edges.API = nil }},
+		{name: "CLI runtime", mode: initializer.ModeCLI, missing: "runtime sidecar", remove: func(edges *initializer.ApplicationLifecycles) { edges.Runtime = nil }},
+		{name: "CLI workers", mode: initializer.ModeCLI, missing: "workers sidecar", remove: func(edges *initializer.ApplicationLifecycles) { edges.Workers = nil }},
+		{name: "CLI transport", mode: initializer.ModeCLI, missing: "CLI transport", remove: func(edges *initializer.ApplicationLifecycles) { edges.CLI = nil }},
+		{name: "MCP transport", mode: initializer.ModeMCP, missing: "MCP transport", remove: func(edges *initializer.ApplicationLifecycles) { edges.MCP = nil }},
+		{name: "typed nil transport", mode: initializer.ModeMCP, missing: "MCP transport", remove: func(edges *initializer.ApplicationLifecycles) {
+			var lifecycle *applicationLifecycle
+			edges.MCP = lifecycle
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newApplicationFixture()
+			test.remove(&fixture.graph.lifecycles)
+			application, err := initializer.NewApplication(test.mode, fixture.graph)
+			if application != nil || err == nil {
+				t.Fatalf("NewApplication() = (%v, %v), want validation failure", application, err)
+			}
+			if !strings.Contains(err.Error(), string(test.mode)) || !strings.Contains(err.Error(), test.missing) {
+				t.Fatalf("NewApplication() error = %q, want mode %q and role %q", err, test.mode, test.missing)
+			}
+			if len(fixture.starts) != 0 || len(fixture.stops) != 0 || fixture.graph.closes != 0 {
+				t.Fatalf("rejected plan changed lifecycle state: starts %v stops %v closes %d", fixture.starts, fixture.stops, fixture.graph.closes)
+			}
+		})
+	}
+}
+
+func TestNewApplicationAllowsMissingOptionalDashboard(t *testing.T) {
+	t.Parallel()
+
+	fixture := newApplicationFixture()
+	fixture.graph.lifecycles.Dashboard = nil
+	application, err := initializer.NewApplication(initializer.ModeCLI, fixture.graph)
+	if err != nil {
+		t.Fatalf("NewApplication() error = %v", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- application.Run(context.Background()) }()
+	close(fixture.cli.done)
+	if err := <-done; err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got, want := fixture.starts, []string{"runtime", "workers", "cli"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("starts = %v, want %v", got, want)
+	}
+}
+
 func TestApplicationStartFailureUnwindsActivatedEdges(t *testing.T) {
 	t.Parallel()
 
@@ -419,17 +536,19 @@ func TestApplicationDiagnosticsAndValidation(t *testing.T) {
 	if application != nil || err == nil || !strings.Contains(err.Error(), "not supported") {
 		t.Fatalf("NewApplication(invalid mode) = (%v, %v)", application, err)
 	}
-	application, err = initializer.NewApplication(initializer.ModeMCP, fixture.graph)
+	application, err = initializer.NewApplication(initializer.ModeCLI, fixture.graph)
 	if err != nil {
-		t.Fatalf("NewApplication(MCP) error = %v", err)
+		t.Fatalf("NewApplication(CLI) error = %v", err)
 	}
 	if got := application.RuntimeLogDiagnostics(); got.Path != "runtime.log" {
 		t.Fatalf("RuntimeLogDiagnostics() = %+v, want graph metadata", got)
 	}
-	if err := application.Run(context.Background()); err == nil || !strings.Contains(err.Error(), "not waitable") {
-		t.Fatalf("Run(non-waitable MCP) error = %v", err)
+	fixture.graph.lifecycles.MCP = &applicationLifecycle{name: "mcp", starts: &fixture.starts, stops: &fixture.stops}
+	application, err = initializer.NewApplication(initializer.ModeMCP, fixture.graph)
+	if application != nil || err == nil || !strings.Contains(err.Error(), "mcp") || !strings.Contains(err.Error(), "join") {
+		t.Fatalf("NewApplication(non-waitable MCP) = (%v, %v), want pre-start join validation", application, err)
 	}
-	if err := application.Shutdown(nil); err != nil {
+	if err := nilApplication.Shutdown(nil); err != nil {
 		t.Fatalf("Shutdown(nil context) error = %v", err)
 	}
 }
@@ -438,7 +557,9 @@ type applicationFixture struct {
 	graph  *applicationGraph
 	starts []string
 	stops  []string
+	api    *waitableApplicationLifecycle
 	cli    *waitableApplicationLifecycle
+	mcp    *waitableApplicationLifecycle
 }
 
 func newApplicationFixture() *applicationFixture {
@@ -446,9 +567,11 @@ func newApplicationFixture() *applicationFixture {
 	lifecycle := func(name string) *applicationLifecycle {
 		return &applicationLifecycle{name: name, starts: &fixture.starts, stops: &fixture.stops}
 	}
+	fixture.api = &waitableApplicationLifecycle{applicationLifecycle: lifecycle("api"), done: make(chan struct{})}
 	fixture.cli = &waitableApplicationLifecycle{applicationLifecycle: lifecycle("cli"), done: make(chan struct{})}
+	fixture.mcp = &waitableApplicationLifecycle{applicationLifecycle: lifecycle("mcp"), done: make(chan struct{})}
 	fixture.graph = &applicationGraph{lifecycles: initializer.ApplicationLifecycles{
-		API: lifecycle("api"), CLI: fixture.cli, MCP: lifecycle("mcp"),
+		API: fixture.api, CLI: fixture.cli, MCP: fixture.mcp,
 		Runtime: lifecycle("runtime"), Workers: lifecycle("workers"), Dashboard: lifecycle("dashboard"),
 	}}
 	return fixture

--- a/pkg/initializer/initialize_test.go
+++ b/pkg/initializer/initialize_test.go
@@ -571,13 +571,35 @@ func TestApplicationStartFailureUnwindsActivatedEdges(t *testing.T) {
 				t.Fatalf("Start() error = %q, want primary and rollback failure context", err)
 			}
 			got := recorder.snapshot()
-			if test.name != "final start with rollback failure" && !reflect.DeepEqual(got, test.wantEvents) {
+			if test.name == "first start" && !reflect.DeepEqual(got, test.wantEvents) {
 				t.Fatalf("lifecycle events = %v, want %v", got, test.wantEvents)
+			}
+			if test.name == "middle start" {
+				assertMiddleStartUnwind(t, got)
 			}
 			if test.name == "final start with rollback failure" {
 				assertTransactionalUnwind(t, got)
 			}
 		})
+	}
+}
+
+func assertMiddleStartUnwind(t *testing.T, events []string) {
+	t.Helper()
+	withoutJoin := make([]string, 0, len(events)-1)
+	joinCount := 0
+	for _, event := range events {
+		if event == "join runtime" {
+			joinCount++
+			continue
+		}
+		withoutJoin = append(withoutJoin, event)
+	}
+	wantWithoutJoin := []string{
+		"start runtime", "start workers", "stop runtime", "cancel runtime", "close graph",
+	}
+	if joinCount != 1 || !reflect.DeepEqual(withoutJoin, wantWithoutJoin) {
+		t.Fatalf("lifecycle events = %v, want one runtime join and ordered synchronous events %v", events, wantWithoutJoin)
 	}
 }
 

--- a/pkg/initializer/initialize_test.go
+++ b/pkg/initializer/initialize_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/portpowered/infinite-you/pkg/config"
@@ -502,18 +503,154 @@ func TestNewApplicationAllowsMissingOptionalDashboard(t *testing.T) {
 func TestApplicationStartFailureUnwindsActivatedEdges(t *testing.T) {
 	t.Parallel()
 
-	fixture := newApplicationFixture()
-	cause := errors.New("listener unavailable")
-	fixture.cli.startErr = cause
-	application, err := initializer.Start(context.Background(), initializer.ModeCLI, fixture.graph)
-	if application != nil || !errors.Is(err, cause) {
-		t.Fatalf("Start() = (%v, %v), want nil application wrapping cause", application, err)
+	tests := []struct {
+		name       string
+		failRole   string
+		rollbackAt string
+		wantEvents []string
+	}{
+		{
+			name:     "first start",
+			failRole: "runtime",
+			wantEvents: []string{
+				"start runtime", "close graph",
+			},
+		},
+		{
+			name:     "middle start",
+			failRole: "workers",
+			wantEvents: []string{
+				"start runtime", "start workers",
+				"stop runtime", "cancel runtime", "join runtime", "close graph",
+			},
+		},
+		{
+			name:       "final start with rollback failure",
+			failRole:   "cli",
+			rollbackAt: "workers",
+			wantEvents: []string{
+				"start runtime", "start workers", "start dashboard", "start cli",
+				"stop dashboard", "cancel dashboard", "join dashboard",
+				"stop workers", "cancel workers", "join workers",
+				"stop runtime", "cancel runtime", "join runtime", "close graph",
+			},
+		},
 	}
-	if got, want := fixture.stops, []string{"dashboard", "workers", "runtime"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("unwind order = %v, want %v", got, want)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recorder := &lifecycleRecorder{}
+			startErr := errors.New("startup unavailable")
+			rollbackErr := errors.New("rollback unavailable")
+			component := func(name string) *transactionLifecycle {
+				lifecycle := &transactionLifecycle{name: name, recorder: recorder}
+				if name == test.failRole {
+					lifecycle.startErr = startErr
+				}
+				if name == test.rollbackAt {
+					lifecycle.stopErr = rollbackErr
+				}
+				return lifecycle
+			}
+			graph := &transactionGraph{
+				recorder: recorder,
+				lifecycles: initializer.ApplicationLifecycles{
+					Runtime: component("runtime"), Workers: component("workers"),
+					Dashboard: component("dashboard"), CLI: component("cli"),
+				},
+			}
+
+			application, err := initializer.Start(context.Background(), initializer.ModeCLI, graph)
+			if application != nil || !errors.Is(err, startErr) {
+				t.Fatalf("Start() = (%v, %v), want nil application wrapping startup failure", application, err)
+			}
+			if !strings.Contains(err.Error(), `process mode "cli"`) || !strings.Contains(err.Error(), test.failRole) {
+				t.Fatalf("Start() error = %q, want mode and failed component", err)
+			}
+			if test.rollbackAt != "" && (!errors.Is(err, rollbackErr) || !strings.Contains(err.Error(), "unwind application startup")) {
+				t.Fatalf("Start() error = %q, want primary and rollback failure context", err)
+			}
+			if got := recorder.snapshot(); !reflect.DeepEqual(got, test.wantEvents) {
+				t.Fatalf("lifecycle events = %v, want %v", got, test.wantEvents)
+			}
+		})
 	}
-	if fixture.graph.closes != 1 {
-		t.Fatalf("graph closes = %d, want one", fixture.graph.closes)
+}
+
+type lifecycleRecorder struct {
+	mu     sync.Mutex
+	events []string
+}
+
+func (r *lifecycleRecorder) record(event string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, event)
+}
+
+func (r *lifecycleRecorder) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.events...)
+}
+
+type transactionGraph struct {
+	recorder   *lifecycleRecorder
+	lifecycles initializer.ApplicationLifecycles
+}
+
+func (g *transactionGraph) Close() error {
+	g.recorder.record("close graph")
+	return nil
+}
+
+func (g *transactionGraph) Lifecycles() initializer.ApplicationLifecycles { return g.lifecycles }
+
+func (g *transactionGraph) RuntimeLogMetadata() runtimehost.RuntimeLogDiagnostics {
+	return runtimehost.RuntimeLogDiagnostics{}
+}
+
+type transactionLifecycle struct {
+	name      string
+	recorder  *lifecycleRecorder
+	startErr  error
+	stopErr   error
+	cancel    context.CancelFunc
+	done      chan struct{}
+	stopCalls int
+}
+
+func (l *transactionLifecycle) Start(ctx context.Context) error {
+	l.recorder.record("start " + l.name)
+	if l.startErr != nil {
+		return l.startErr
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	l.cancel = cancel
+	l.done = make(chan struct{})
+	go func() {
+		<-runCtx.Done()
+		l.recorder.record("join " + l.name)
+		close(l.done)
+	}()
+	return nil
+}
+
+func (l *transactionLifecycle) Stop(context.Context) error {
+	l.stopCalls++
+	l.recorder.record("stop " + l.name)
+	l.recorder.record("cancel " + l.name)
+	l.cancel()
+	<-l.done
+	return l.stopErr
+}
+
+func (l *transactionLifecycle) Wait(ctx context.Context) error {
+	select {
+	case <-l.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 

--- a/pkg/initializer/services.go
+++ b/pkg/initializer/services.go
@@ -1,3 +1,10 @@
+// Package initializer is the canonical composition root for factory config loading
+// and domain service construction. It assembles session, factory-definition, model,
+// worker, and runtime-host collaborators without constructing root pkg/service
+// FactoryService at transport composition boundaries. API, CLI local in-process,
+// and MCP serve paths consume initializer-produced transport bundles. Process
+// startup graphs are constructed by pkg/wire and handed here only for lifecycle
+// execution.
 package initializer
 
 import (

--- a/pkg/root/process_test.go
+++ b/pkg/root/process_test.go
@@ -125,7 +125,10 @@ func TestProductionGraphConstructionFailuresPreventInitializerStartup(t *testing
 func TestProductionMCPGraphUsesSuppliedProcessStreams(t *testing.T) {
 	t.Parallel()
 	fixturePath := testutil.MustRepoPath(t, "pkg/api/testdata/durable-session-contract-fixtures.json")
-	input := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"root-test","version":"test"}}}` + "\n")
+	input := strings.NewReader(
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"root-test","version":"test"}}}` + "\n" +
+			`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"you.factory_session.list","arguments":{"scope":"persisted"}}}` + "\n",
+	)
 	var output bytes.Buffer
 	code := Run(Input{
 		Args: []string{"you", "mcp", "serve", "--fixture-catalog", fixturePath},
@@ -136,6 +139,11 @@ func TestProductionMCPGraphUsesSuppliedProcessStreams(t *testing.T) {
 	}
 	if !strings.Contains(output.String(), `"protocolVersion":"2024-11-05"`) {
 		t.Fatalf("MCP stdout = %q, want initialize response", output.String())
+	}
+	if !strings.Contains(output.String(), `"id":2`) ||
+		!strings.Contains(output.String(), `"isError":false`) ||
+		!strings.Contains(output.String(), `dur-sess-js-failed-partial-001`) {
+		t.Fatalf("MCP stdout = %q, want successful graph-backed Factory Session list response", output.String())
 	}
 }
 

--- a/pkg/wire/cli.go
+++ b/pkg/wire/cli.go
@@ -19,6 +19,14 @@ import (
 // Construction remains inert; initializer activates and shuts down the graph
 // when the returned application is run.
 func BuildCLIRunner(ctx context.Context, cfg *service.FactoryServiceConfig) (initializer.LocalRuntimeRunner, error) {
+	return buildApplicationRunner(ctx, cfg, initializer.ModeCLI)
+}
+
+func buildApplicationRunner(
+	ctx context.Context,
+	cfg *service.FactoryServiceConfig,
+	mode initializer.Mode,
+) (initializer.LocalRuntimeRunner, error) {
 	runtimeCfg := service.RuntimeHostConfigFromFactoryService(cfg)
 	if runtimeCfg != nil {
 		copied := *runtimeCfg
@@ -34,10 +42,10 @@ func BuildCLIRunner(ctx context.Context, cfg *service.FactoryServiceConfig) (ini
 	if err != nil {
 		return nil, err
 	}
-	application, err := initializer.NewApplication(initializer.ModeCLI, graph)
+	application, err := initializer.NewApplication(mode, graph)
 	if err != nil {
 		if cleanupErr := graph.Close(); cleanupErr != nil {
-			return nil, errors.Join(err, fmt.Errorf("close rejected CLI application graph: %w", cleanupErr))
+			return nil, errors.Join(err, fmt.Errorf("close rejected %s application graph: %w", mode, cleanupErr))
 		}
 		return nil, err
 	}

--- a/pkg/wire/cli_test.go
+++ b/pkg/wire/cli_test.go
@@ -60,7 +60,7 @@ func TestBuildCLIRunnerConstructsInertGraphApplication(t *testing.T) {
 	}
 }
 
-func TestBuildCLIRunnerRunsGraphOwnedSurfaceAndCanonicalSessionID(t *testing.T) {
+func TestBuildApplicationRunnerAPIModeRunsGraphOwnedSurfaceAndCanonicalSessionID(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -82,9 +82,9 @@ func TestBuildCLIRunnerRunsGraphOwnedSurfaceAndCanonicalSessionID(t *testing.T) 
 			return ctx.Err()
 		},
 	}
-	runner, err := BuildCLIRunner(context.Background(), cfg)
+	runner, err := buildApplicationRunner(context.Background(), cfg, initializer.ModeAPI)
 	if err != nil {
-		t.Fatalf("BuildCLIRunner() error = %v", err)
+		t.Fatalf("buildApplicationRunner(API) error = %v", err)
 	}
 	application := runner.(*initializer.Application)
 	graph := application.Graph().(*Graph)

--- a/pkg/wire/process.go
+++ b/pkg/wire/process.go
@@ -18,16 +18,23 @@ func BuildProcessGraph(ctx context.Context, request startupcli.Request, policy i
 	return buildProcessGraph(ctx, request, policy, func(
 		buildCtx context.Context,
 		cfg *service.FactoryServiceConfig,
+		mode initializer.Mode,
 	) (runcli.RuntimeRunner, error) {
-		return BuildCLIRunner(buildCtx, cfg)
+		return buildApplicationRunner(buildCtx, cfg, mode)
 	})
 }
+
+type processRunnerBuilder func(
+	context.Context,
+	*service.FactoryServiceConfig,
+	initializer.Mode,
+) (runcli.RuntimeRunner, error)
 
 func buildProcessGraph(
 	ctx context.Context,
 	request startupcli.Request,
 	policy initializer.ProcessPolicy,
-	buildRunner runcli.FactoryServiceBuilder,
+	buildRunner processRunnerBuilder,
 ) (*initializer.ProcessGraph, error) {
 	switch request.Kind {
 	case startupcli.KindRun:
@@ -38,7 +45,16 @@ func buildProcessGraph(
 		if err != nil {
 			return nil, fmt.Errorf("construct run graph: %w", err)
 		}
-		application, err := runcli.BuildApplication(ctx, runConfig, buildRunner)
+		applicationMode, err := applicationModeForProcess(policy.Mode)
+		if err != nil {
+			return nil, fmt.Errorf("construct run graph: %w", err)
+		}
+		application, err := runcli.BuildApplication(ctx, runConfig, func(
+			buildCtx context.Context,
+			cfg *service.FactoryServiceConfig,
+		) (runcli.RuntimeRunner, error) {
+			return buildRunner(buildCtx, cfg, applicationMode)
+		})
 		if err != nil {
 			return nil, fmt.Errorf("construct run graph: %w", err)
 		}
@@ -73,6 +89,17 @@ func buildProcessGraph(
 		return &initializer.ProcessGraph{Policy: policy, MCP: application}, nil
 	default:
 		return nil, fmt.Errorf("construct process graph: unsupported startup kind %q", request.Kind)
+	}
+}
+
+func applicationModeForProcess(mode initializer.ProcessMode) (initializer.Mode, error) {
+	switch mode {
+	case initializer.ProcessModeDefaultRun, initializer.ProcessModeAPIService:
+		return initializer.ModeAPI, nil
+	case initializer.ProcessModeLocalRun:
+		return initializer.ModeCLI, nil
+	default:
+		return "", fmt.Errorf("run graph requires a run process mode, got %q", mode)
 	}
 }
 

--- a/pkg/wire/process_test.go
+++ b/pkg/wire/process_test.go
@@ -130,10 +130,12 @@ func TestBuildProcessGraphAppliesRootPolicyBeforeConstructionAndLifecycle(t *tes
 				MockWorkersEnabled: true, SuppressDashboardRendering: !test.wantDashboard,
 			}
 			var built *service.FactoryServiceConfig
+			var builtMode initializer.Mode
 			graph, err := buildProcessGraph(context.Background(), startupcli.Request{
 				Kind: startupcli.KindRun, RunConfig: &cfg,
-			}, test.policy, func(_ context.Context, cfg *service.FactoryServiceConfig) (runcli.RuntimeRunner, error) {
+			}, test.policy, func(_ context.Context, cfg *service.FactoryServiceConfig, mode initializer.Mode) (runcli.RuntimeRunner, error) {
 				built = cfg
+				builtMode = mode
 				return processRunnerFunc(func(context.Context) error { return nil }), nil
 			})
 			if err != nil {
@@ -144,6 +146,13 @@ func TestBuildProcessGraphAppliesRootPolicyBeforeConstructionAndLifecycle(t *tes
 			}
 			if got := built.SimpleDashboardRenderer != nil; got != test.wantDashboard {
 				t.Fatalf("dashboard renderer enabled = %t, want %t", got, test.wantDashboard)
+			}
+			wantApplicationMode := initializer.ModeCLI
+			if test.policy.Mode == initializer.ProcessModeAPIService {
+				wantApplicationMode = initializer.ModeAPI
+			}
+			if builtMode != wantApplicationMode {
+				t.Fatalf("initializer application mode = %q, want %q", builtMode, wantApplicationMode)
 			}
 			if graph.Policy != test.policy {
 				t.Fatalf("graph policy = %+v, want %+v", graph.Policy, test.policy)

--- a/pkg/wire/production_internal_test.go
+++ b/pkg/wire/production_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"sync"
@@ -18,6 +19,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/runtimehost"
 	"github.com/portpowered/infinite-you/pkg/testutil/factoryfixtures"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestProductionGraphSidecarsStartAndStopThroughInitializer(t *testing.T) {
@@ -74,6 +76,105 @@ func TestProductionGraphSidecarsStartAndStopThroughInitializer(t *testing.T) {
 	}
 	if dashboardRenders != 1 {
 		t.Fatalf("dashboard render count = %d, want one final render", dashboardRenders)
+	}
+}
+
+func TestProductionWorkerSidecarUsesGraphSchedulerAndConfigBeforeTransport(t *testing.T) {
+	dir := t.TempDir()
+	factoryConfig := factoryfixtures.MinimalFactoryConfig()
+	factoryConfig["workstations"] = append(factoryConfig["workstations"].([]map[string]any), map[string]any{
+		"name":     "scheduled-task",
+		"behavior": "CRON",
+		"worker":   "worker-a",
+		"cron":     map[string]any{"schedule": "0 * * * *"},
+		"outputs":  []map[string]string{{"workType": "task", "state": "init"}},
+	})
+	factoryfixtures.WriteFactoryJSON(t, dir, factoryConfig)
+
+	logCore, observedLogs := observer.New(zap.InfoLevel)
+	transportStarted := make(chan struct{})
+	graph, err := Build(context.Background(), Inputs{
+		Config: &runtimehost.Config{
+			Dir: dir, SystemConfigHomeDir: t.TempDir(), RuntimeMode: interfaces.RuntimeModeService,
+			Port: 43176, Logger: zap.New(logCore), Clock: productionInternalClock{},
+			DurableSessionPersistencePolicy:         factorysessionexecution.PersistencePolicyDisabled,
+			RuntimeFileLoggingPolicy:                runtimehost.RuntimeFileLoggingPolicyDisabled,
+			RuntimeMetricsPolicy:                    runtimehost.RuntimeMetricsPolicyDisabled,
+			SkipBuiltInRunnerPrerequisiteValidation: true,
+			APIServerStarter: func(ctx context.Context, _ apisurface.APISurface, _ int, _ *zap.Logger) error {
+				registered := observedLogs.FilterMessage("cron watcher registered").All()
+				if len(registered) != 1 || registered[0].ContextMap()["workstation"] != "scheduled-task" {
+					return fmt.Errorf("transport started before graph worker scheduler was ready: logs=%v", observedLogs.All())
+				}
+				close(transportStarted)
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		},
+		MCPInput: strings.NewReader(""), MCPOutput: &bytes.Buffer{},
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	workerScheduler := graph.Workers
+	if workerScheduler == nil || graph.Sidecars.Workers == nil {
+		t.Fatal("production graph omitted its worker scheduler or worker lifecycle")
+	}
+
+	application, err := initializer.NewApplication(initializer.ModeAPI, graph)
+	if err != nil {
+		t.Fatalf("NewApplication() error = %v", err)
+	}
+	if application.Graph() != graph || graph.Workers != workerScheduler {
+		t.Fatal("initializer replaced the graph or worker scheduler instance")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan error, 1)
+	go func() { runDone <- application.Run(ctx) }()
+	select {
+	case <-transportStarted:
+	case err := <-runDone:
+		t.Fatalf("Application.Run() returned before transport startup: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("graph-owned transport did not start after worker readiness")
+	}
+	cancel()
+	if err := <-runDone; err != nil {
+		t.Fatalf("Application.Run() error = %v", err)
+	}
+}
+
+func TestProductionMCPModeLeavesWorkerSidecarsInactive(t *testing.T) {
+	dir := t.TempDir()
+	factoryfixtures.WriteFactoryJSON(t, dir, factoryfixtures.MinimalFactoryConfig())
+	graph, err := Build(context.Background(), Inputs{
+		Config: &runtimehost.Config{
+			Dir: dir, SystemConfigHomeDir: t.TempDir(), RuntimeMode: interfaces.RuntimeModeService,
+			Logger: zap.NewNop(), Clock: productionInternalClock{},
+			DurableSessionPersistencePolicy:         factorysessionexecution.PersistencePolicyDisabled,
+			RuntimeFileLoggingPolicy:                runtimehost.RuntimeFileLoggingPolicyDisabled,
+			RuntimeMetricsPolicy:                    runtimehost.RuntimeMetricsPolicyDisabled,
+			SkipBuiltInRunnerPrerequisiteValidation: true,
+		},
+		MCPInput: strings.NewReader(""), MCPOutput: &bytes.Buffer{},
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	recorder := &lifecycleOrder{}
+	graph.Sidecars.Runtime = recorder.wrap("runtime", graph.Sidecars.Runtime)
+	graph.Sidecars.Workers = recorder.wrap("workers", graph.Sidecars.Workers)
+	graph.Sidecars.Dashboard = recorder.wrap("dashboard", graph.Sidecars.Dashboard)
+
+	application, err := initializer.NewApplication(initializer.ModeMCP, graph)
+	if err != nil {
+		t.Fatalf("NewApplication() error = %v", err)
+	}
+	if err := application.Run(context.Background()); err != nil {
+		t.Fatalf("Application.Run() error = %v", err)
+	}
+	if starts, stops := recorder.started(), recorder.stopped(); len(starts) != 0 || len(stops) != 0 {
+		t.Fatalf("MCP run sidecar effects = starts %v stops %v, want none", starts, stops)
 	}
 }
 

--- a/pkg/wire/production_internal_test.go
+++ b/pkg/wire/production_internal_test.go
@@ -79,7 +79,12 @@ type lifecycleOrder struct {
 }
 
 func (o *lifecycleOrder) wrap(name string, lifecycle Lifecycle) Lifecycle {
-	return &recordingProductionLifecycle{order: o, name: name, lifecycle: lifecycle}
+	recording := &recordingProductionLifecycle{order: o, name: name, lifecycle: lifecycle}
+	waiter, ok := lifecycle.(interface{ Wait(context.Context) error })
+	if !ok {
+		return recording
+	}
+	return &recordingWaitableProductionLifecycle{recordingProductionLifecycle: recording, waiter: waiter}
 }
 
 type recordingProductionLifecycle struct {
@@ -102,12 +107,13 @@ func (l *recordingProductionLifecycle) Stop(ctx context.Context) error {
 	return l.lifecycle.Stop(ctx)
 }
 
-func (l *recordingProductionLifecycle) Wait(ctx context.Context) error {
-	waiter, ok := l.lifecycle.(interface{ Wait(context.Context) error })
-	if !ok {
-		return errors.New("recorded lifecycle is not waitable")
-	}
-	return waiter.Wait(ctx)
+type recordingWaitableProductionLifecycle struct {
+	*recordingProductionLifecycle
+	waiter interface{ Wait(context.Context) error }
+}
+
+func (l *recordingWaitableProductionLifecycle) Wait(ctx context.Context) error {
+	return l.waiter.Wait(ctx)
 }
 
 func (o *lifecycleOrder) started() []string {

--- a/pkg/wire/production_internal_test.go
+++ b/pkg/wire/production_internal_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/apisurface"
 	"github.com/portpowered/infinite-you/pkg/factorysessionexecution"
 	"github.com/portpowered/infinite-you/pkg/initializer"
+	initializerdashboard "github.com/portpowered/infinite-you/pkg/initializer/dashboard"
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	"github.com/portpowered/infinite-you/pkg/runtimehost"
 	"github.com/portpowered/infinite-you/pkg/testutil/factoryfixtures"
@@ -23,6 +24,7 @@ func TestProductionGraphSidecarsStartAndStopThroughInitializer(t *testing.T) {
 	dir := t.TempDir()
 	factoryfixtures.WriteFactoryJSON(t, dir, factoryfixtures.MinimalFactoryConfig())
 	transportStarted := make(chan struct{})
+	var dashboardRenders int
 	graph, err := Build(context.Background(), Inputs{
 		Config: &runtimehost.Config{
 			Dir: dir, SystemConfigHomeDir: t.TempDir(), RuntimeMode: interfaces.RuntimeModeService,
@@ -36,7 +38,7 @@ func TestProductionGraphSidecarsStartAndStopThroughInitializer(t *testing.T) {
 				<-ctx.Done()
 				return ctx.Err()
 			},
-			SimpleDashboardRenderer: func(runtimehost.SimpleDashboardRenderInput) {},
+			SimpleDashboardRenderer: func(runtimehost.SimpleDashboardRenderInput) { dashboardRenders++ },
 		},
 		MCPInput: strings.NewReader(""), MCPOutput: &bytes.Buffer{},
 	})
@@ -69,6 +71,95 @@ func TestProductionGraphSidecarsStartAndStopThroughInitializer(t *testing.T) {
 	}
 	if got, want := recorder.stopped(), []string{"cli", "dashboard", "workers", "runtime"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("production stop order = %v, want %v", got, want)
+	}
+	if dashboardRenders != 1 {
+		t.Fatalf("dashboard render count = %d, want one final render", dashboardRenders)
+	}
+}
+
+func TestProductionCLIModePreservesTransportFailureAfterDashboardShutdown(t *testing.T) {
+	dir := t.TempDir()
+	factoryfixtures.WriteFactoryJSON(t, dir, factoryfixtures.MinimalFactoryConfig())
+	var dashboardRenders int
+	graph, err := Build(context.Background(), Inputs{
+		Config: &runtimehost.Config{
+			Dir: dir, SystemConfigHomeDir: t.TempDir(), RuntimeMode: interfaces.RuntimeModeService,
+			Port: 43175, Logger: zap.NewNop(), Clock: productionInternalClock{},
+			DurableSessionPersistencePolicy:         factorysessionexecution.PersistencePolicyDisabled,
+			RuntimeFileLoggingPolicy:                runtimehost.RuntimeFileLoggingPolicyDisabled,
+			RuntimeMetricsPolicy:                    runtimehost.RuntimeMetricsPolicyDisabled,
+			SkipBuiltInRunnerPrerequisiteValidation: true,
+			SimpleDashboardRenderer:                 func(runtimehost.SimpleDashboardRenderInput) { dashboardRenders++ },
+		},
+		MCPInput: strings.NewReader(""), MCPOutput: &bytes.Buffer{},
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	transportErr := errors.New("CLI runner failed")
+	cli := newRunnerLifecycle(func(context.Context) error { return transportErr })
+	graph.Transports.CLI = cli
+	application, err := initializer.NewApplication(initializer.ModeCLI, graph)
+	if err != nil {
+		t.Fatalf("NewApplication() error = %v", err)
+	}
+	if application.Graph() != graph || graph.Transports.CLI != cli {
+		t.Fatal("CLI mode replaced the supplied graph or CLI lifecycle")
+	}
+	if err := application.Run(context.Background()); !errors.Is(err, transportErr) {
+		t.Fatalf("Application.Run() error = %v, want CLI runner failure", err)
+	}
+	if dashboardRenders != 1 {
+		t.Fatalf("dashboard render count = %d, want one final render after CLI failure", dashboardRenders)
+	}
+}
+
+func TestProductionDashboardDisabledOmitsEveryDashboardLifecycleEffect(t *testing.T) {
+	var runtime runtimehost.ApplicationRuntime
+	sidecars, err := buildProductionSidecars(
+		&runtimehost.Config{SimpleDashboardRenderer: nil},
+		nil,
+		&runtime,
+	)
+	if err != nil {
+		t.Fatalf("buildProductionSidecars() error = %v", err)
+	}
+	if sidecars.Dashboard != nil {
+		t.Fatalf("dashboard lifecycle = %T, want nil when rendering is disabled", sidecars.Dashboard)
+	}
+}
+
+func TestDashboardLifecycleJoinsPeriodicLoopBeforeFinalRender(t *testing.T) {
+	ticker := &joiningDashboardTicker{ticks: make(chan time.Time), stopped: make(chan struct{})}
+	finalRendered := make(chan struct{}, 1)
+	sidecar, err := initializerdashboard.NewDashboardSidecar(initializerdashboard.DashboardSidecarConfig{
+		Reader: dashboardReaderFunc(func(context.Context, time.Time) (initializerdashboard.DashboardRenderInput, error) {
+			select {
+			case <-ticker.stopped:
+				return initializerdashboard.DashboardRenderInput{}, nil
+			default:
+				return initializerdashboard.DashboardRenderInput{}, errors.New("final render preceded dashboard join")
+			}
+		}),
+		Renderer: dashboardRendererFunc(func(initializerdashboard.DashboardRenderInput) {
+			finalRendered <- struct{}{}
+		}),
+		Timing: dashboardTiming{ticker: ticker},
+	})
+	if err != nil {
+		t.Fatalf("NewDashboardSidecar() error = %v", err)
+	}
+	lifecycle := newDashboardLifecycle(sidecar)
+	if err := lifecycle.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if err := lifecycle.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+	select {
+	case <-finalRendered:
+	default:
+		t.Fatal("dashboard lifecycle did not render after joining its periodic loop")
 	}
 }
 
@@ -263,3 +354,40 @@ func canceledProductionContext() context.Context {
 type productionInternalClock struct{}
 
 func (productionInternalClock) Now() time.Time { return time.Unix(0, 0).UTC() }
+
+type dashboardReaderFunc func(context.Context, time.Time) (initializerdashboard.DashboardRenderInput, error)
+
+func (fn dashboardReaderFunc) ReadDashboard(
+	ctx context.Context,
+	now time.Time,
+) (initializerdashboard.DashboardRenderInput, error) {
+	return fn(ctx, now)
+}
+
+type dashboardRendererFunc func(initializerdashboard.DashboardRenderInput)
+
+func (fn dashboardRendererFunc) RenderDashboard(input initializerdashboard.DashboardRenderInput) {
+	fn(input)
+}
+
+type dashboardTiming struct {
+	ticker initializerdashboard.DashboardTicker
+}
+
+func (dashboardTiming) Now() time.Time { return time.Unix(0, 0).UTC() }
+
+func (timing dashboardTiming) NewTicker(time.Duration) initializerdashboard.DashboardTicker {
+	return timing.ticker
+}
+
+type joiningDashboardTicker struct {
+	ticks   chan time.Time
+	stopped chan struct{}
+	once    sync.Once
+}
+
+func (ticker *joiningDashboardTicker) C() <-chan time.Time { return ticker.ticks }
+
+func (ticker *joiningDashboardTicker) Stop() {
+	ticker.once.Do(func() { close(ticker.stopped) })
+}


### PR DESCRIPTION
{
  "project": "Start and Stop the Wired Graph Through pkg/initializer",
  "branchName": "initializer-consumes-wired-graph",
  "description": "Make pkg/initializer the single lifecycle owner for the typed pkg/wire application graph, starting API, CLI, MCP, dashboard, worker scheduler, and selected sidecars from already-constructed graph collaborators with deterministic ordering, rollback, cancellation, and joins and without changing public behavior.",
  "context": {
    "customerAsk": "Make pkg/initializer consume the typed pkg/wire application graph and own ordered startup, cancellation, and join behavior for transports and sidecars without reconstructing core dependencies. API, CLI, MCP, dashboard, and worker sidecars must start from graph collaborators; startup failure must unwind started components; shutdown ownership must be deterministic; and initializer must contain no lazy durable runtime or domain-service construction.",
    "problem": "Initializer currently participates in composition through paths that build a core, derive transport bundles, attach runtime-host shells, and create some sidecars near startup. Lifecycle behavior is spread across wrappers and compatibility hosts, obscuring collaborator identity, partial-start rollback, cancellation ownership, joins, and deterministic terminal errors.",
    "solution": "Have root pass one selected startup mode and one complete typed graph to initializer. Initializer derives a mode-specific lifecycle plan using only graph fields, validates it before activation, starts prerequisites in order, unwinds partial startup in reverse order, propagates one shared cancellation path, joins everything it owns, and returns a deterministic terminal result proven by focused lifecycle and startup-mode tests."
  },
  "acceptanceCriteria": [
    "API, CLI, MCP, dashboard, worker scheduler, and applicable runtime sidecars run from the exact collaborators supplied by one typed pkg/wire graph, with unselected mode collaborators left inactive.",
    "Initializer validates the selected mode before activation, starts required collaborators in deterministic dependency order, and never exposes a transport as running before its prerequisites are ready.",
    "If any start step fails, initializer prevents later starts, cancels and joins concurrent work already launched, and unwinds successfully started lifecycle components exactly once in reverse start order while retaining actionable failure context.",
    "Parent cancellation, a terminal component error, and normal one-shot CLI completion follow an explicit ownership policy that joins every initializer-owned component before return and produces a deterministic terminal result.",
    "Initializer performs no lazy durable execution, runtime host, domain service, transport, dashboard, or worker scheduler construction, and focused tests prove consumers observe the same graph instances throughout startup and shutdown.",
    "Existing API, CLI, MCP, dashboard, worker, and Factory Session behavior and public contracts remain compatible, with safe lifecycle diagnostics identifying mode and component.",
    "Typecheck, lint, and tests pass, including focused initializer lifecycle and startup-mode tests and make verify-fast."
  ],
  "userStories": [
    {
      "id": "initializer-consumes-wired-graph-001",
      "title": "Select graph collaborators for one startup run",
      "description": "As a maintainer, I want initializer to translate the selected process mode and typed graph into one explicit lifecycle plan so that only the already-constructed collaborators required by that mode can run.",
      "acceptanceCriteria": [
        "Given a valid graph and startup mode, initializer selects the graph-provided transport, runtime, dashboard, worker scheduler, and sidecar collaborators required by that mode and leaves every unselected collaborator inactive.",
        "A selected mode with a missing required graph collaborator fails before any start or run call, and the error identifies the mode and missing lifecycle role.",
        "The lifecycle plan contains explicit dependency order and ownership for start, cancellation, join, and stop behavior and does not use an untyped service locator or recover collaborators from a broad host facade.",
        "Recording collaborators prove that selected instances are the same instances present in the supplied graph and that selection performs no domain-service, durable-runtime, transport, dashboard, or worker construction.",
        "Repeated runs with different graphs or modes do not retain lifecycle state, cancellation, errors, or collaborator references from a previous run.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Initializer now validates and selects a fresh mode-specific lifecycle plan from exact graph collaborators before activation, including typed-nil and join-capability validation."
    },
    {
      "id": "initializer-consumes-wired-graph-002",
      "title": "Start in order and unwind partial startup",
      "description": "As an operator, I want startup to be transactional across lifecycle components so that a failed prerequisite or sidecar cannot leave a partially running application behind.",
      "acceptanceCriteria": [
        "Initializer starts selected lifecycle components in declared dependency order and does not start a dependent component until its prerequisite reports successful startup or readiness.",
        "When a start step fails, no later component starts, the original failure retains mode and component context, and all earlier successful steps are stopped exactly once in reverse start order.",
        "Any concurrently running component launched before the failure receives cancellation and is joined before initializer returns, and cancellation-related exit errors do not replace the startup failure.",
        "If rollback also fails, the returned result preserves the primary startup failure and includes actionable rollback context without duplicating stop calls.",
        "Focused tests cover failure at the first, middle, and final start positions and verify start, cancellation, join, and reverse-unwind order through recording collaborators.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Initializer now reports mode/component startup failures and transactionally cancels, joins, and reverse-unwinds every successfully started collaborator while preserving primary and rollback errors."
    },
    {
      "id": "initializer-consumes-wired-graph-003",
      "title": "Cancel and join every owned component deterministically",
      "description": "As an operator, I want shutdown to have one clear owner and terminal result so that cancellation never leaks background work or produces race-dependent process outcomes.",
      "acceptanceCriteria": [
        "Parent-context cancellation is propagated through one initializer-owned run context to every active cancellable collaborator.",
        "A terminal error from an active long-running collaborator triggers cancellation of its peers, and initializer waits for every component it started to join before returning.",
        "Normal cancellation exits are treated as shutdown rather than replacing a primary component failure, and multiple non-cancellation errors follow one documented stable precedence rule independent of join timing.",
        "Shutdown and cleanup are idempotent from the lifecycle caller's perspective, with each owned stop action invoked at most once even when parent cancellation and component exit race.",
        "Focused concurrency tests exercise parent cancellation, peer failure, simultaneous exits, and a deliberately blocked join, proving initializer cannot return while an owned component remains active; race-sensitive coverage passes when run repeatedly.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Initializer now propagates one owned cancellation context, observes every join-capable started lifecycle, cancels peers on terminal exit, drains all joins, and reports non-cancellation failures in stable lifecycle-plan order."
    },
    {
      "id": "initializer-consumes-wired-graph-004",
      "title": "Run API and MCP server modes from the graph",
      "description": "As an API or MCP user, I want server startup to use the wired transport and domain collaborators so that both services expose their existing behavior without recomposing dependencies during serve.",
      "acceptanceCriteria": [
        "API-service mode starts the graph-provided API transport with its graph-provided API/session surface and required runtime lifecycle, and MCP mode starts the graph-provided MCP transport with its graph-provided Factory Session execution collaborator.",
        "Each server mode starts only its applicable runtime and sidecars; API mode does not start MCP or CLI execution, and MCP mode does not construct or start API or CLI collaborators unless existing mode policy explicitly requires a shared sidecar.",
        "Recording integration tests prove the transport and durable or session collaborators observed during serve are identical to the graph fields and that no lazy construction callback is invoked.",
        "A transport startup failure and a runtime or sidecar startup failure follow the common rollback policy, while parent cancellation follows the common cancel-and-join policy.",
        "Existing representative API requests and MCP tool calls retain their success and error behavior through bounded startup-mode tests, with no public REST, generated OpenAPI, or MCP tool contract changes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "API/default service policies now select initializer's API lifecycle plan, MCP serve retains its graph-owned durable execution transport, and bounded production tests prove graph identity plus representative API and MCP behavior."
    },
    {
      "id": "initializer-consumes-wired-graph-005",
      "title": "Run CLI and dashboard behavior from the graph",
      "description": "As a CLI user, I want local commands and optional dashboard rendering to run from the wired graph so that command completion, final rendering, and shutdown remain predictable.",
      "acceptanceCriteria": [
        "A selected local runtime command executes through the graph-provided CLI or runtime collaborator, while non-startup CLI commands continue to avoid activating runtime or sidecar collaborators.",
        "When dashboard rendering is enabled, initializer starts the graph-provided dashboard sidecar only after its read or runtime prerequisite is ready, cancels and joins its periodic loop during shutdown, and performs any existing final render only after the periodic loop has joined.",
        "When dashboard rendering is disabled, no dashboard start, render, stop, or join behavior occurs.",
        "CLI completion or failure produces the existing command result after all initializer-owned dashboard and runtime work has joined, and dashboard cancellation does not mask a primary CLI or runtime failure.",
        "Focused mode tests prove the CLI runner and dashboard are the same graph instances and preserve enabled, disabled, final-render, failure, and cancellation behavior without constructing replacements.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": "Focused production-graph coverage now proves CLI lifecycle identity, dashboard-enabled and dashboard-disabled behavior, final rendering after periodic-loop join, parent cancellation, and preservation of the primary CLI failure through shutdown."
    },
    {
      "id": "initializer-consumes-wired-graph-006",
      "title": "Run worker sidecars from the graph",
      "description": "As an operator, I want worker scheduling and applicable process sidecars to follow the selected startup mode so that background work has the same deterministic lifecycle as the transports it supports.",
      "acceptanceCriteria": [
        "Modes that require process-level worker supervision start the graph-provided worker scheduler and applicable sidecars, while modes that do not require them make zero start calls.",
        "Worker supervision becomes ready before a dependent transport accepts work and receives the same shared graph services and runtime configuration constructed by pkg/wire.",
        "Worker or sidecar startup failure prevents dependent transport startup and unwinds earlier components through the common reverse-order rollback policy.",
        "Parent cancellation or a terminal worker-sidecar error cancels peers and joins every initializer-owned worker loop before return, and repeated shutdown does not duplicate stop effects.",
        "Focused startup-mode tests cover worker-enabled and worker-disabled paths and prove exact graph instance identity, ordering, failure unwind, cancellation, and join behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": "Focused production-graph tests now prove worker-enabled API startup uses the retained graph scheduler and runtime configuration before transport acceptance, worker-disabled MCP startup leaves run sidecars inactive, and common failure, cancellation, join, and idempotent shutdown behavior remains enforced."
    }
  ]
}
