### PR TITLE
stream-b05-claude-content-block-adapter

### DIFF
--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -550,6 +550,14 @@ primary-result behavior.
   instead of submitted input text or raw audio payload bytes.
 - `docs/architecture/invocation-contract.md` documents CLI/API equivalence and
   invocation-return policy ownership.
+- Production provider mode selection lives at the `pkg/workers/provider`
+  execution boundary: a configured Factory Session response-stream publisher
+  selects a registered structured adapter, while final-only invocations retain
+  the established provider behavior. Provider-native `responseevents.Draft`
+  values must be published directly by `pkg/factorysessions/stream` so the
+  session store assigns event ID, sequence, recorded time, and Factory Session
+  identity without flattening stable message or tool identity through the
+  legacy fragment compatibility mapper.
 - `docs/reference/run.md` is the customer-facing owner for packaged `@you/goal`
   invocation behavior. Operator-visible blocked, needs-human, paused,
   interrupted, failed, timed-out, and unresolved-primary-result outcomes plus

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -210,6 +210,12 @@ primary-result behavior.
   explicitly opts into response streaming. Native JSONL fixture tests should
   fragment reads and flush an unterminated final record so command selection,
   decoder buffering, and final-result parsing are proven independently.
+  Provider retry and compaction records should publish only bounded typed facts
+  with static safe messages; adapters may classify those facts but must not
+  sleep, rerun commands, choose backoff, or expose raw provider payloads.
+  Preserve optional provider attribution only from an explicit native field on
+  the supported record, and omit malformed or absent attribution instead of
+  inferring it from neighboring stream activity.
 
   Legacy fragment
   compatibility mapping lives in `pkg/factorysessions/responsestream/compat`

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -207,7 +207,11 @@ primary-result behavior.
   publication to the session owner. Adapter `BuildCommand` selects structured
   output only for the response-adapter execution path; the established
   final-only provider command path must remain unchanged until its caller
-  explicitly opts into response streaming. Native JSONL fixture tests should
+  explicitly opts into response streaming. Both command paths must use
+  `pkg/workers/provider/commandenv` so provider variables retain the established
+  non-interactive Git/editor safeguards, and the production mode-selection
+  boundary must preserve provider input validation before starting either
+  runner. Native JSONL fixture tests should
   fragment reads and flush an unterminated final record so command selection,
   decoder buffering, and final-result parsing are proven independently.
   Provider retry and compaction records should publish only bounded typed facts

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -197,7 +197,21 @@ primary-result behavior.
   presentation fallback.
   Provider-neutral `FactoryResponseEvent` vocabulary lives in
   `pkg/factorysessions/responseevents` (distinct from internal
-  `pkg/factorysessions/responsestream` fragment kinds). Legacy fragment
+  `pkg/factorysessions/responsestream` fragment kinds).
+
+  Provider-native structured response adapters live in provider-owned
+  subpackages under `pkg/workers/provider/` and implement the neutral lifecycle
+  in `pkg/workers/provider/adapter`. Keep each decoder invocation-local and
+  stateful, return only canonical `responseevents.Draft` values plus bounded
+  diagnostics, and leave event ID, sequence, recorded time, and Factory Session
+  publication to the session owner. Adapter `BuildCommand` selects structured
+  output only for the response-adapter execution path; the established
+  final-only provider command path must remain unchanged until its caller
+  explicitly opts into response streaming. Native JSONL fixture tests should
+  fragment reads and flush an unterminated final record so command selection,
+  decoder buffering, and final-result parsing are proven independently.
+
+  Legacy fragment
   compatibility mapping lives in `pkg/factorysessions/responsestream/compat`
   (`MapFragment` over `responsestream.Event` with session/run `Context`); keep
   the mapper pure, table-tested, and free of CLI/HTTP/provider imports while

--- a/pkg/factorysessions/stream/manager.go
+++ b/pkg/factorysessions/stream/manager.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/portpowered/infinite-you/pkg/factorysessions"
+	"github.com/portpowered/infinite-you/pkg/factorysessions/responseevents"
 	"github.com/portpowered/infinite-you/pkg/factorysessions/responsestream"
 	"github.com/portpowered/infinite-you/pkg/factorysessions/responsestream/compat"
 	workerprovider "github.com/portpowered/infinite-you/pkg/workers/provider"
@@ -138,6 +139,17 @@ func (m *Manager) inferenceProgressPublisher(
 		if session == nil && normalizedSessionID == factorysessions.DefaultSessionID {
 			session = m.host.GetLiveSession(factorysessions.DefaultSessionID)
 		}
+		if fragment.CanonicalDraft != nil {
+			draft, ok := fragment.CanonicalDraft.(responseevents.Draft)
+			if !ok {
+				m.host.ObserveResponseStreamDegraded(session, normalizedSessionID, dispatchID, "CANONICAL_EVENT_PUBLISH_FAILED", logger, fmt.Errorf("canonical response draft has type %T", fragment.CanonicalDraft))
+				return
+			}
+			if err := publishCanonicalDraft(session, draft); err != nil {
+				m.host.ObserveResponseStreamDegraded(session, normalizedSessionID, dispatchID, "CANONICAL_EVENT_PUBLISH_FAILED", logger, err)
+			}
+			return
+		}
 		streams := m.host.ResponseStreams(session)
 		if streams == nil {
 			m.host.ObserveResponseStreamDegraded(session, normalizedSessionID, dispatchID, "STREAM_UNAVAILABLE", logger, nil)
@@ -165,6 +177,24 @@ func (m *Manager) inferenceProgressPublisher(
 		}
 		m.host.ObserveResponseStreamPublished(session, normalizedSessionID, stored)
 	}
+}
+
+func publishCanonicalDraft(session *factorysessions.LiveSession, draft responseevents.Draft) error {
+	if session == nil || session.ResponseEvents == nil {
+		return fmt.Errorf("session response-event store is unavailable")
+	}
+	if err := responseevents.ValidateDraft(draft); err != nil {
+		return fmt.Errorf("validate canonical response draft: %w", err)
+	}
+	_, err := session.ResponseEvents.Publish(responseevents.FactoryResponseEvent{
+		RunID: draft.RunID, Kind: draft.Kind, Phase: draft.Phase, Provenance: draft.Provenance,
+		Payload: append([]byte(nil), draft.Payload...), DispatchID: draft.DispatchID, TurnID: draft.TurnID,
+		ItemID: draft.ItemID, ParentItemID: draft.ParentItemID, ProviderSessionRef: draft.ProviderSessionRef,
+	})
+	if err != nil {
+		return fmt.Errorf("publish canonical response draft: %w", err)
+	}
+	return nil
 }
 
 func publishCanonicalResponseEvents(session *factorysessions.LiveSession, fragment responsestream.Event) error {

--- a/pkg/factorysessions/stream/manager_test.go
+++ b/pkg/factorysessions/stream/manager_test.go
@@ -2,10 +2,12 @@ package stream_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
 	"github.com/portpowered/infinite-you/pkg/factorysessions"
+	"github.com/portpowered/infinite-you/pkg/factorysessions/responseevents"
 	"github.com/portpowered/infinite-you/pkg/factorysessions/responsestream"
 	"github.com/portpowered/infinite-you/pkg/factorysessions/stream"
 	workerprovider "github.com/portpowered/infinite-you/pkg/workers/provider"
@@ -153,6 +155,44 @@ func TestManager_PublishesCanonicalResponseEventsToSessionStore(t *testing.T) {
 	}
 	if events[0].DispatchID != "dispatch-1" {
 		t.Fatalf("dispatchId = %q, want dispatch-1", events[0].DispatchID)
+	}
+}
+
+func TestManager_PublishesProviderCanonicalDraftWithoutLegacyRemapping(t *testing.T) {
+	t.Parallel()
+
+	session := factorysessions.NewLiveSession(
+		"sess-native-draft", "/factory", "/workspace", "/workspace",
+		factorysessions.TargetRef{Kind: factorysessions.TargetKindDefault}, nil, false, "factory",
+	)
+	host := &streamTestHost{session: session}
+	publisher := stream.NewManager(host).InferenceProgressPublisherFactory(nil)(session.ID)
+	payload, err := json.Marshal(responseevents.MessageDeltaPayload{
+		ContentBlockIndex: 2, ContentBlockKind: responseevents.ContentBlockText, TextDelta: "native delta",
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	publisher(workerprovider.CanonicalDraftFragment("dispatch-native", responseevents.Draft{
+		RunID: "dispatch-native", DispatchID: "dispatch-native", ItemID: "claude-message-7",
+		Kind: responseevents.KindMessage, Phase: responseevents.PhaseDelta,
+		Provenance: responseevents.Provenance{
+			Provider: "claude", NativeEventType: "content_block_delta",
+			Delivery: responseevents.DeliveryNativeStream, Representation: responseevents.RepresentationDelta,
+			Fidelity: responseevents.FidelityLossless,
+		},
+		Payload: payload,
+	}))
+
+	events := session.ResponseEvents.Events()
+	if len(events) != 1 || events[0].ItemID != "claude-message-7" || events[0].Provenance.Delivery != responseevents.DeliveryNativeStream {
+		t.Fatalf("canonical events = %#v, want unchanged provider-native identity and provenance", events)
+	}
+	if events[0].Sequence != 1 || events[0].EventID == "" || events[0].RecordedAt.IsZero() {
+		t.Fatalf("publication metadata = %#v, want session-owned identity, sequence, and time", events[0])
+	}
+	if host.published != 0 {
+		t.Fatalf("legacy response-stream publications = %d, want no lossy remapping", host.published)
 	}
 }
 

--- a/pkg/runtimehost/build_workers.go
+++ b/pkg/runtimehost/build_workers.go
@@ -13,6 +13,7 @@ import (
 	workeragentrun "github.com/portpowered/infinite-you/pkg/workers/executor/agentrun"
 	workerprompting "github.com/portpowered/infinite-you/pkg/workers/prompting"
 	workerprovider "github.com/portpowered/infinite-you/pkg/workers/provider"
+	providerstructured "github.com/portpowered/infinite-you/pkg/workers/provider/structured"
 )
 
 func wrapLocalModelRunner(
@@ -207,7 +208,10 @@ func providerRunnerOptions(
 		workerprovider.WithProviderLogger(logger),
 	}
 	if inferenceProgressPublisher != nil {
-		opts = append(opts, workerprovider.WithInferenceProgressPublisher(inferenceProgressPublisher))
+		opts = append(opts,
+			workerprovider.WithInferenceProgressPublisher(inferenceProgressPublisher),
+			workerprovider.WithResponseStreamExecutor(providerstructured.NewExecutor()),
+		)
 	}
 	if providerCommandRunner != nil {
 		opts = append(opts, workerprovider.WithProviderCommandRunner(providerCommandRunner))

--- a/pkg/service/factory_build.go
+++ b/pkg/service/factory_build.go
@@ -46,6 +46,7 @@ import (
 	workeragentrun "github.com/portpowered/infinite-you/pkg/workers/executor/agentrun"
 	workerprompting "github.com/portpowered/infinite-you/pkg/workers/prompting"
 	workerprovider "github.com/portpowered/infinite-you/pkg/workers/provider"
+	providerstructured "github.com/portpowered/infinite-you/pkg/workers/provider/structured"
 	workersservice "github.com/portpowered/infinite-you/pkg/workers/service"
 	"go.uber.org/zap"
 )
@@ -980,7 +981,10 @@ func providerRunnerOptions(
 		workerprovider.WithProviderLogger(logger),
 	}
 	if inferenceProgressPublisher != nil {
-		opts = append(opts, workerprovider.WithInferenceProgressPublisher(inferenceProgressPublisher))
+		opts = append(opts,
+			workerprovider.WithInferenceProgressPublisher(inferenceProgressPublisher),
+			workerprovider.WithResponseStreamExecutor(providerstructured.NewExecutor()),
+		)
 	}
 	if providerCommandRunner != nil {
 		opts = append(opts, workerprovider.WithProviderCommandRunner(providerCommandRunner))

--- a/pkg/service/factory_runtime_mode_test.go
+++ b/pkg/service/factory_runtime_mode_test.go
@@ -2417,6 +2417,10 @@ func waitForSnapshotMatch(
 	for time.Now().Before(deadline) {
 		snap, err := svc.GetEngineStateSnapshot(context.Background())
 		if err != nil {
+			if strings.Contains(err.Error(), "runtime is not available") {
+				time.Sleep(10 * time.Millisecond)
+				continue
+			}
 			t.Fatalf("GetEngineStateSnapshot during %s: %v", phase, err)
 		}
 		last = snap

--- a/pkg/workers/provider/adapter/orchestration.go
+++ b/pkg/workers/provider/adapter/orchestration.go
@@ -31,6 +31,9 @@ type ExecuteInput struct {
 	Provider Identity
 	Command  CommandContext
 	Decoder  DecoderContext
+	// ObserveDraft receives correlated drafts as decoding progresses. Session
+	// publication metadata remains owned by the caller.
+	ObserveDraft func(responseevents.Draft)
 }
 
 // ExecuteResult contains neutral adapter outputs from one subprocess attempt.
@@ -39,6 +42,7 @@ type ExecuteInput struct {
 type ExecuteResult struct {
 	Outcome      CommandOutcome
 	Capabilities Capabilities
+	Request      workerprocess.CommandRequest
 	Response     interfaces.InferenceResponse
 	Drafts       []responseevents.Draft
 	Diagnostics  []Diagnostic
@@ -75,10 +79,11 @@ func Execute(ctx context.Context, registry *Registry, runner StreamingCommandRun
 		return ExecuteResult{}, fmt.Errorf("create provider adapter decoder: %w", err)
 	}
 
-	result := ExecuteResult{Capabilities: capabilityResult.Capabilities}
+	result := ExecuteResult{Capabilities: capabilityResult.Capabilities, Request: built.Request}
 	commandResult, commandErr := runner.Run(ctx, built.Request, func(observation Observation) error {
 		decoded, observeErr := decoder.Observe(ctx, observation)
-		result.appendDecoded(decoded)
+		correlateDrafts(decoded.Drafts, input.Decoder)
+		result.appendDecoded(decoded, input.ObserveDraft)
 		if observeErr != nil && result.DecodeError == nil {
 			result.DecodeError = observeErr
 		}
@@ -89,7 +94,8 @@ func Execute(ctx context.Context, registry *Registry, runner StreamingCommandRun
 	result.Outcome = outcome
 
 	flushed, flushErr := decoder.Flush(ctx, FlushContext{Reason: flushReason})
-	result.appendDecoded(flushed)
+	correlateDrafts(flushed.Drafts, input.Decoder)
+	result.appendDecoded(flushed, input.ObserveDraft)
 	result.FlushError = flushErr
 
 	final, parseErr := selected.ParseFinal(ctx, FinalParseContext{
@@ -97,7 +103,9 @@ func Execute(ctx context.Context, registry *Registry, runner StreamingCommandRun
 		RunID: input.Decoder.RunID, DispatchID: input.Decoder.DispatchID,
 	})
 	result.Response, result.ParseError = final.Response, parseErr
+	correlateDrafts(final.Drafts, input.Decoder)
 	result.Drafts = append(result.Drafts, final.Drafts...)
+	observeDrafts(final.Drafts, input.ObserveDraft)
 	classified := selected.ClassifyFailure(ctx, FailureContext{
 		CommandResult: commandResult, CommandError: commandErr, DecodeError: result.DecodeError,
 		FlushError: flushErr, ParseError: parseErr, FlushReason: flushReason,
@@ -106,9 +114,30 @@ func Execute(ctx context.Context, registry *Registry, runner StreamingCommandRun
 	return result, errors.Join(result.DecodeError, flushErr, parseErr)
 }
 
-func (r *ExecuteResult) appendDecoded(decoded DecodeResult) {
+func correlateDrafts(drafts []responseevents.Draft, correlation DecoderContext) {
+	for index := range drafts {
+		if drafts[index].RunID == "" {
+			drafts[index].RunID = correlation.RunID
+		}
+		if drafts[index].DispatchID == "" {
+			drafts[index].DispatchID = correlation.DispatchID
+		}
+	}
+}
+
+func (r *ExecuteResult) appendDecoded(decoded DecodeResult, observe func(responseevents.Draft)) {
 	r.Drafts = append(r.Drafts, decoded.Drafts...)
 	r.Diagnostics = append(r.Diagnostics, decoded.Diagnostics...)
+	observeDrafts(decoded.Drafts, observe)
+}
+
+func observeDrafts(drafts []responseevents.Draft, observe func(responseevents.Draft)) {
+	if observe == nil {
+		return
+	}
+	for _, draft := range drafts {
+		observe(draft)
+	}
 }
 
 func commandOutcome(ctx context.Context, result workerprocess.CommandResult, commandErr error) (CommandOutcome, FlushReason) {

--- a/pkg/workers/provider/claude/adapter.go
+++ b/pkg/workers/provider/claude/adapter.go
@@ -1,0 +1,137 @@
+// Package claude implements Claude's structured subprocess response adapter.
+package claude
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	workerprocess "github.com/portpowered/infinite-you/pkg/workers/process"
+	"github.com/portpowered/infinite-you/pkg/workers/provider/adapter"
+)
+
+const (
+	outputFormatStreamJSON = "stream-json"
+	providerSessionKind    = "session_id"
+)
+
+// Adapter translates Claude CLI structured output into canonical drafts.
+type Adapter struct{}
+
+// NewAdapter constructs the stateless Claude adapter. Decoder state is
+// allocated separately for every invocation.
+func NewAdapter() *Adapter { return &Adapter{} }
+
+func (*Adapter) Identity() adapter.Identity { return adapter.Identity(interfaces.ModelProviderClaude) }
+
+func (*Adapter) BuildCommand(_ context.Context, input adapter.CommandContext) (adapter.CommandBuildResult, error) {
+	req := input.Request
+	args := []string{"-p"}
+	if input.SkipPermissions {
+		args = append(args, "--dangerously-skip-permissions")
+	}
+	if req.Worktree != "" {
+		args = append(args, "--worktree", req.Worktree)
+	}
+	if req.SystemPrompt != "" {
+		args = append(args, "--system-prompt", req.SystemPrompt)
+	}
+	if req.Model != "" {
+		args = append(args, "--model", req.Model)
+	}
+	if req.SessionID != "" {
+		args = append(args, "--resume", req.SessionID)
+	}
+	args = append(args, "--output-format", outputFormatStreamJSON, "--include-partial-messages", req.UserMessage)
+
+	command := workerprocess.SubprocessRequestBase(req.Dispatch)
+	command.Command = string(interfaces.ModelProviderClaude)
+	command.Args = args
+	command.Env = workerprocess.MergeCommandEnv(os.Environ(), workerprocess.CommandEnvEntriesFromMap(req.EnvVars))
+	command.WorkDir = req.WorkingDirectory
+	command.InputTokens = append([]any(nil), req.InputTokens...)
+	if req.WorkerType != "" {
+		command.WorkerType = req.WorkerType
+	}
+	if req.WorkstationType != "" {
+		command.WorkstationName = req.WorkstationType
+	}
+	if req.ProjectID != "" {
+		command.ProjectID = req.ProjectID
+	}
+	return adapter.CommandBuildResult{Request: command}, nil
+}
+
+func (*Adapter) NewDecoder(_ context.Context, input adapter.DecoderContext) (adapter.Decoder, error) {
+	return newDecoder(input), nil
+}
+
+func (*Adapter) ParseFinal(_ context.Context, input adapter.FinalParseContext) (adapter.FinalParseResult, error) {
+	if input.CommandError != nil || input.CommandResult.ExitCode != 0 {
+		return adapter.FinalParseResult{}, errors.New("Claude command did not complete successfully")
+	}
+	lines := bytes.Split(bytes.ReplaceAll(input.CommandResult.Stdout, []byte("\r\n"), []byte("\n")), []byte("\n"))
+	for index := len(lines) - 1; index >= 0; index-- {
+		var record struct {
+			Type      string `json:"type"`
+			Subtype   string `json:"subtype"`
+			IsError   bool   `json:"is_error"`
+			Result    string `json:"result"`
+			SessionID string `json:"session_id"`
+		}
+		if json.Unmarshal(bytes.TrimSpace(lines[index]), &record) != nil || record.Type != "result" {
+			continue
+		}
+		if record.Subtype != "success" || record.IsError {
+			return adapter.FinalParseResult{}, errors.New("Claude returned a terminal failure")
+		}
+		return adapter.FinalParseResult{Response: interfaces.InferenceResponse{
+			Content:         record.Result,
+			ProviderSession: providerSession(record.SessionID),
+		}}, nil
+	}
+	return adapter.FinalParseResult{}, errors.New("Claude stream did not contain a terminal result")
+}
+
+func (*Adapter) Capabilities(context.Context, adapter.CapabilityContext) (adapter.CapabilityResult, error) {
+	return adapter.CapabilityResult{Capabilities: adapter.Capabilities{
+		NativeStreaming: true, MessageDeltas: true, MessageSnapshots: true,
+		ToolLifecycle: true, ToolOutputDeltas: true, StableItemIDs: true,
+	}}, nil
+}
+
+func (*Adapter) ClassifyFailure(_ context.Context, input adapter.FailureContext) adapter.FailureResult {
+	if input.CommandError == nil && input.CommandResult.ExitCode == 0 && input.DecodeError == nil && input.FlushError == nil && input.ParseError == nil {
+		return adapter.FailureResult{}
+	}
+	return adapter.FailureResult{Failure: &adapter.FailureFacts{
+		Family:  interfaces.WorkFailureFamilyTerminal,
+		Type:    interfaces.WorkFailureTypeUnknown,
+		Message: "Claude invocation failed.",
+	}}
+}
+
+func providerSession(sessionID string) *interfaces.ProviderSessionMetadata {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return nil
+	}
+	return &interfaces.ProviderSessionMetadata{
+		Provider: string(interfaces.ModelProviderClaude), Kind: providerSessionKind, ID: sessionID,
+	}
+}
+
+func marshalPayload(value any) (json.RawMessage, error) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("marshal Claude canonical payload: %w", err)
+	}
+	return payload, nil
+}
+
+var _ adapter.Adapter = (*Adapter)(nil)

--- a/pkg/workers/provider/claude/adapter.go
+++ b/pkg/workers/provider/claude/adapter.go
@@ -73,6 +73,9 @@ func (*Adapter) NewDecoder(_ context.Context, input adapter.DecoderContext) (ada
 
 func (*Adapter) ParseFinal(_ context.Context, input adapter.FinalParseContext) (adapter.FinalParseResult, error) {
 	if input.CommandError != nil || input.CommandResult.ExitCode != 0 {
+		if failure := claudeRetryFailure(input.CommandResult.Stdout); failure != nil {
+			return adapter.FinalParseResult{}, &claudeRetryError{failure: *failure}
+		}
 		return adapter.FinalParseResult{}, errors.New("Claude command did not complete successfully")
 	}
 	lines := bytes.Split(bytes.ReplaceAll(input.CommandResult.Stdout, []byte("\r\n"), []byte("\n")), []byte("\n"))
@@ -108,6 +111,14 @@ func (*Adapter) Capabilities(context.Context, adapter.CapabilityContext) (adapte
 func (*Adapter) ClassifyFailure(_ context.Context, input adapter.FailureContext) adapter.FailureResult {
 	if input.CommandError == nil && input.CommandResult.ExitCode == 0 && input.DecodeError == nil && input.FlushError == nil && input.ParseError == nil {
 		return adapter.FailureResult{}
+	}
+	if failure := claudeRetryFailure(input.CommandResult.Stdout); failure != nil {
+		return adapter.FailureResult{Failure: failure}
+	}
+	var retryErr *claudeRetryError
+	if errors.As(input.ParseError, &retryErr) {
+		failure := retryErr.failure
+		return adapter.FailureResult{Failure: &failure}
 	}
 	return adapter.FailureResult{Failure: &adapter.FailureFacts{
 		Family:  interfaces.WorkFailureFamilyTerminal,

--- a/pkg/workers/provider/claude/adapter.go
+++ b/pkg/workers/provider/claude/adapter.go
@@ -7,12 +7,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	workerprocess "github.com/portpowered/infinite-you/pkg/workers/process"
 	"github.com/portpowered/infinite-you/pkg/workers/provider/adapter"
+	"github.com/portpowered/infinite-you/pkg/workers/provider/commandenv"
 )
 
 const (
@@ -52,7 +52,7 @@ func (*Adapter) BuildCommand(_ context.Context, input adapter.CommandContext) (a
 	command := workerprocess.SubprocessRequestBase(req.Dispatch)
 	command.Command = string(interfaces.ModelProviderClaude)
 	command.Args = args
-	command.Env = workerprocess.MergeCommandEnv(os.Environ(), workerprocess.CommandEnvEntriesFromMap(req.EnvVars))
+	command.Env = commandenv.Build(req.EnvVars)
 	command.WorkDir = req.WorkingDirectory
 	command.InputTokens = append([]any(nil), req.InputTokens...)
 	if req.WorkerType != "" {

--- a/pkg/workers/provider/claude/adapter_test.go
+++ b/pkg/workers/provider/claude/adapter_test.go
@@ -13,7 +13,13 @@ import (
 	"github.com/portpowered/infinite-you/pkg/interfaces"
 	workerprocess "github.com/portpowered/infinite-you/pkg/workers/process"
 	"github.com/portpowered/infinite-you/pkg/workers/provider/adapter"
+	"github.com/portpowered/infinite-you/pkg/workers/provider/adapter/testkit"
 	"github.com/portpowered/infinite-you/pkg/workers/provider/claude"
+)
+
+const (
+	privateConformancePrompt = "private Claude prompt must not escape"
+	privateConformanceToken  = "sk-claude-fixture-secret"
 )
 
 func TestAdapterBuildCommandRequestsStructuredPartialMessages(t *testing.T) {
@@ -58,6 +64,54 @@ func TestAdapterReportsClaudeStreamingCapabilitiesAndFailureFacts(t *testing.T) 
 	}
 }
 
+func TestAdapterFullStreamConformance(t *testing.T) {
+	t.Parallel()
+
+	testkit.RunFullStream(t, testkit.FullStreamFixture{
+		NewAdapter: func() adapter.Adapter { return claude.NewAdapter() },
+		Request: interfaces.ProviderInferenceRequest{
+			Dispatch: interfaces.WorkDispatch{DispatchID: "dispatch-conformance"},
+			Model:    "claude-sonnet-4", UserMessage: privateConformancePrompt,
+		},
+		ContentAndTools: claudeObservations(
+			`{"type":"system","subtype":"init","session_id":"claude-session-conformance"}`,
+			`{"type":"stream_event","session_id":"claude-session-conformance","event":{"type":"message_start","message":{"id":"msg_conformance","role":"assistant","content":[]}}}`,
+			`{"type":"stream_event","session_id":"claude-session-conformance","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}}`,
+			`{"type":"stream_event","session_id":"claude-session-conformance","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello "}}}`,
+			`{"type":"stream_event","session_id":"claude-session-conformance","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"world"}}}`,
+			`{"type":"stream_event","session_id":"claude-session-conformance","event":{"type":"message_stop"}}`,
+			`{"type":"assistant","session_id":"claude-session-conformance","message":{"id":"msg_conformance","role":"assistant","content":[{"type":"text","text":"Hello world"}]}}`,
+			`{"type":"stream_event","session_id":"claude-session-conformance","event":{"type":"message_start","message":{"id":"msg_tool","role":"assistant","content":[]}}}`,
+			`{"type":"stream_event","session_id":"claude-session-conformance","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_conformance","name":"weather","input":{}}}}`,
+			`{"type":"stream_event","session_id":"claude-session-conformance","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"city\":\"Oslo\"}"}}}`,
+			`{"type":"stream_event","session_id":"claude-session-conformance","event":{"type":"content_block_stop","index":0}}`,
+		),
+		RetryableFailure: claudeObservations(
+			`{"type":"system","subtype":"api_retry","session_id":"claude-session-conformance","attempt":2,"retry_delay_ms":2000,"error_status":429}`,
+		),
+		UnsafeAndRecovering: claudeObservations(
+			`{"type":"system","subtype":"init","session_id":"claude-session-conformance"}`,
+			`{"type":`+privateConformancePrompt+`,"token":"`+privateConformanceToken+`"}`,
+			`{"type":"future_shape","prompt":"`+privateConformancePrompt+`","token":"`+privateConformanceToken+`"}`,
+			`{"type":"assistant","session_id":"claude-session-conformance","message":{"id":"msg_conformance","role":"assistant","content":[{"type":"text","text":"Hello world"}]}}`,
+		),
+		UnterminatedFinal: []adapter.Observation{{Stream: adapter.OutputStreamStdout, Chunk: []byte(
+			`{"type":"assistant","session_id":"claude-session-conformance","message":{"id":"msg_conformance","role":"assistant","content":[{"type":"text","text":"Hello world"}]}}`,
+		)}},
+		FinalResult: workerprocess.CommandResult{Stdout: []byte(
+			`{"type":"result","subtype":"success","is_error":false,"result":"Hello world","session_id":"claude-session-conformance"}`,
+		)},
+		Expected: testkit.FullStreamExpected{
+			ProviderSession: interfaces.ProviderSessionMetadata{Provider: "claude", Kind: "session_id", ID: "claude-session-conformance"},
+			ProviderRef:     "claude-session-conformance", MessageItemID: "msg_conformance",
+			ToolItemID: "msg_tool/content-block/0", ToolCallID: "toolu_conformance",
+			MessageDeltas: []string{"Hello ", "world"}, FinalContent: "Hello world",
+			ToolOutputDelta: `{"city":"Oslo"}`, RetryAfter: 2,
+		},
+		ForbiddenDiagnostic: []string{privateConformancePrompt, privateConformanceToken},
+	})
+}
+
 func TestDecoderMapsChunkedTextAndToolInputWithStableIdentity(t *testing.T) {
 	t.Parallel()
 
@@ -99,6 +153,103 @@ func TestDecoderInvalidToolInputDoesNotLeakOrStopLaterMessage(t *testing.T) {
 	completed := findDraft(drafts, responseevents.KindMessage, responseevents.PhaseCompleted)
 	if completed == nil || completed.ItemID != "msg_recovery" {
 		t.Fatalf("later completed message missing: %#v", drafts)
+	}
+}
+
+func TestDecoderNormalizesControlRecordsAndExplicitSubagentAttribution(t *testing.T) {
+	t.Parallel()
+
+	drafts, diagnostics := decodeFixture(t, "testdata/control_records.jsonl", true)
+	assertControlDiagnostics(t, diagnostics)
+	assertCanonicalDrafts(t, drafts)
+	assertControlObservations(t, drafts)
+	assertControlAttribution(t, drafts)
+	assertControlOutputSafe(t, drafts, diagnostics)
+}
+
+func assertControlDiagnostics(t *testing.T, diagnostics []adapter.Diagnostic) {
+	t.Helper()
+	if len(diagnostics) != 2 || diagnostics[0].Code != "claude_unknown_record" || diagnostics[1].Code != "claude_malformed_record" {
+		t.Fatalf("diagnostics = %#v", diagnostics)
+	}
+}
+
+func assertCanonicalDrafts(t *testing.T, drafts []responseevents.Draft) {
+	t.Helper()
+	for index, draft := range drafts {
+		if err := responseevents.ValidateDraft(draft); err != nil {
+			t.Fatalf("draft[%d] invalid: %v", index, err)
+		}
+	}
+}
+
+func assertControlObservations(t *testing.T, drafts []responseevents.Draft) {
+	t.Helper()
+	retry := findDraft(drafts, responseevents.KindError, responseevents.PhaseUpdated)
+	if retry == nil {
+		t.Fatalf("retry observation missing: %#v", drafts)
+	}
+	var retryPayload responseevents.ErrorPayload
+	decodePayload(t, *retry, &retryPayload)
+	if !retryPayload.Retryable || retryPayload.RetryAttempt == nil || *retryPayload.RetryAttempt != 2 || retryPayload.RetryAfterSeconds == nil || *retryPayload.RetryAfterSeconds != 2 {
+		t.Fatalf("retry payload = %#v", retryPayload)
+	}
+	compaction := findDraft(drafts, responseevents.KindProgress, responseevents.PhaseUpdated)
+	if compaction == nil {
+		t.Fatalf("compaction observation missing: %#v", drafts)
+	}
+}
+
+func assertControlAttribution(t *testing.T, drafts []responseevents.Draft) {
+	t.Helper()
+	completed := draftsByKindAndPhase(drafts, responseevents.KindMessage, responseevents.PhaseCompleted)
+	if len(completed) != 3 || completed[0].ParentItemID != "toolu_parent" || completed[1].ParentItemID != "" || completed[2].ParentItemID != "" {
+		t.Fatalf("completed message attribution = %#v", completed)
+	}
+	delta := findDraft(drafts, responseevents.KindMessage, responseevents.PhaseDelta)
+	if delta == nil || delta.ParentItemID != "toolu_parent" || delta.ItemID != completed[0].ItemID {
+		t.Fatalf("partial attribution or identity = %#v", delta)
+	}
+}
+
+func assertControlOutputSafe(t *testing.T, drafts []responseevents.Draft, diagnostics []adapter.Diagnostic) {
+	t.Helper()
+	encoded, err := json.Marshal(struct {
+		Drafts      []responseevents.Draft
+		Diagnostics []adapter.Diagnostic
+	}{drafts, diagnostics})
+	if err != nil {
+		t.Fatalf("marshal decoded controls: %v", err)
+	}
+	for _, forbidden := range []string{"private compacted transcript", "private future prompt", privateConformanceToken} {
+		if bytes.Contains(encoded, []byte(forbidden)) {
+			t.Fatalf("normalized controls leaked %q: %s", forbidden, encoded)
+		}
+	}
+}
+
+func TestDecoderOmitsOutOfRangeRetryMetadata(t *testing.T) {
+	t.Parallel()
+
+	decoder, err := claude.NewAdapter().NewDecoder(context.Background(), adapter.DecoderContext{RunID: "run-bounds"})
+	if err != nil {
+		t.Fatalf("NewDecoder() error = %v", err)
+	}
+	result, err := decoder.Observe(context.Background(), adapter.Observation{
+		Stream: adapter.OutputStreamStdout,
+		Chunk:  []byte(`{"type":"system","subtype":"api_retry","attempt":1000001,"retry_delay_ms":86400001}` + "\n"),
+	})
+	if err != nil {
+		t.Fatalf("Observe() error = %v", err)
+	}
+	retry := findDraft(result.Drafts, responseevents.KindError, responseevents.PhaseUpdated)
+	if retry == nil {
+		t.Fatalf("retry observation missing: %#v", result)
+	}
+	var payload responseevents.ErrorPayload
+	decodePayload(t, *retry, &payload)
+	if payload.RetryAttempt != nil || payload.RetryAfterSeconds != nil {
+		t.Fatalf("out-of-range retry metadata was retained: %#v", payload)
 	}
 }
 
@@ -219,16 +370,28 @@ func decodeFixture(t *testing.T, path string, keepFinalRecordUnterminated bool) 
 	return append(drafts, flushed.Drafts...), append(diagnostics, flushed.Diagnostics...)
 }
 
+func claudeObservations(records ...string) []adapter.Observation {
+	observations := make([]adapter.Observation, 0, len(records)+1)
+	for index, record := range records {
+		chunk := []byte(strings.TrimSpace(record) + "\n")
+		if index == 1 && len(chunk) > 7 {
+			observations = append(observations,
+				adapter.Observation{Stream: adapter.OutputStreamStdout, Chunk: chunk[:7]},
+				adapter.Observation{Stream: adapter.OutputStreamStdout, Chunk: chunk[7:]},
+			)
+			continue
+		}
+		observations = append(observations, adapter.Observation{Stream: adapter.OutputStreamStdout, Chunk: chunk})
+	}
+	return observations
+}
+
 func assertValidDrafts(t *testing.T, drafts []responseevents.Draft, diagnostics []adapter.Diagnostic) {
 	t.Helper()
 	if len(diagnostics) != 0 {
 		t.Fatalf("diagnostics = %#v, want none", diagnostics)
 	}
-	for index, draft := range drafts {
-		if err := responseevents.ValidateDraft(draft); err != nil {
-			t.Fatalf("draft[%d] invalid: %v", index, err)
-		}
-	}
+	assertCanonicalDrafts(t, drafts)
 }
 
 func draftsByKindAndPhase(drafts []responseevents.Draft, kind responseevents.Kind, phase responseevents.Phase) []responseevents.Draft {

--- a/pkg/workers/provider/claude/adapter_test.go
+++ b/pkg/workers/provider/claude/adapter_test.go
@@ -102,6 +102,69 @@ func TestDecoderInvalidToolInputDoesNotLeakOrStopLaterMessage(t *testing.T) {
 	}
 }
 
+func TestDecoderCompleteTextSnapshotSupersedesDeltasAndIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	drafts, diagnostics := decodeFixture(t, "testdata/snapshot_text.jsonl", true)
+	assertValidDrafts(t, drafts, diagnostics)
+	completed := draftsByKindAndPhase(drafts, responseevents.KindMessage, responseevents.PhaseCompleted)
+	if len(completed) != 2 {
+		t.Fatalf("completed messages = %d, want authoritative and distinct later message: %#v", len(completed), drafts)
+	}
+	assertMessageContent(t, completed[0], "msg_text", []string{"authoritative text"})
+	assertMessageContent(t, completed[1], "msg_text_2", []string{"later message"})
+	if encoded, err := json.Marshal(completed); err != nil || bytes.Contains(encoded, []byte("draft text")) {
+		t.Fatalf("completed snapshots retained accumulated draft text: %s (err=%v)", encoded, err)
+	}
+}
+
+func TestDecoderCompleteToolSnapshotReusesLogicalToolIdentity(t *testing.T) {
+	t.Parallel()
+
+	drafts, diagnostics := decodeFixture(t, "testdata/snapshot_tool.jsonl", false)
+	assertValidDrafts(t, drafts, diagnostics)
+	completedTools := draftsByKindAndPhase(drafts, responseevents.KindTool, responseevents.PhaseCompleted)
+	if len(completedTools) != 2 {
+		t.Fatalf("completed tools = %d, want partial completion and authoritative update: %#v", len(completedTools), drafts)
+	}
+	for _, draft := range completedTools {
+		if draft.ItemID != "msg_tool/content-block/0" || draft.ParentItemID != "msg_tool" {
+			t.Fatalf("tool snapshot allocated a second logical identity: %#v", draft)
+		}
+	}
+	var authoritative responseevents.ToolPayload
+	decodePayload(t, completedTools[1], &authoritative)
+	var summary map[string]any
+	if err := json.Unmarshal(authoritative.ArgumentsSummary, &summary); err != nil {
+		t.Fatalf("decode authoritative tool summary: %v", err)
+	}
+	if authoritative.ToolCallID != "toolu_snapshot" || summary["city"] != "Bergen" || summary["api_token"] != "<redacted>" {
+		t.Fatalf("authoritative tool snapshot = %#v", authoritative)
+	}
+	if bytes.Contains(authoritative.ArgumentsSummary, []byte("snapshot-secret")) {
+		t.Fatalf("authoritative tool summary leaked provider input: %s", authoritative.ArgumentsSummary)
+	}
+	if got := len(draftsByKindAndPhase(drafts, responseevents.KindMessage, responseevents.PhaseCompleted)); got != 1 {
+		t.Fatalf("completed messages = %d, want one authoritative snapshot", got)
+	}
+}
+
+func TestDecoderCompleteMixedSnapshotPreservesProviderBlockOrder(t *testing.T) {
+	t.Parallel()
+
+	drafts, diagnostics := decodeFixture(t, "testdata/snapshot_mixed.jsonl", true)
+	assertValidDrafts(t, drafts, diagnostics)
+	completed := draftsByKindAndPhase(drafts, responseevents.KindMessage, responseevents.PhaseCompleted)
+	if len(completed) != 1 {
+		t.Fatalf("completed messages = %d, want one: %#v", len(completed), drafts)
+	}
+	var payload responseevents.MessagePayload
+	decodePayload(t, completed[0], &payload)
+	if len(payload.ContentBlocks) != 3 || payload.ContentBlocks[0].Text != "final first" || payload.ContentBlocks[1].ToolCallID != "toolu_mixed" || payload.ContentBlocks[2].Text != "final last" {
+		t.Fatalf("mixed snapshot order = %#v", payload.ContentBlocks)
+	}
+}
+
 func TestParseFinalKeepsTerminalResultAuthoritative(t *testing.T) {
 	t.Parallel()
 
@@ -154,6 +217,45 @@ func decodeFixture(t *testing.T, path string, keepFinalRecordUnterminated bool) 
 		t.Fatalf("Flush() error = %v", err)
 	}
 	return append(drafts, flushed.Drafts...), append(diagnostics, flushed.Diagnostics...)
+}
+
+func assertValidDrafts(t *testing.T, drafts []responseevents.Draft, diagnostics []adapter.Diagnostic) {
+	t.Helper()
+	if len(diagnostics) != 0 {
+		t.Fatalf("diagnostics = %#v, want none", diagnostics)
+	}
+	for index, draft := range drafts {
+		if err := responseevents.ValidateDraft(draft); err != nil {
+			t.Fatalf("draft[%d] invalid: %v", index, err)
+		}
+	}
+}
+
+func draftsByKindAndPhase(drafts []responseevents.Draft, kind responseevents.Kind, phase responseevents.Phase) []responseevents.Draft {
+	var matched []responseevents.Draft
+	for _, draft := range drafts {
+		if draft.Kind == kind && draft.Phase == phase {
+			matched = append(matched, draft)
+		}
+	}
+	return matched
+}
+
+func assertMessageContent(t *testing.T, draft responseevents.Draft, itemID string, texts []string) {
+	t.Helper()
+	if draft.ItemID != itemID {
+		t.Fatalf("message item ID = %q, want %q", draft.ItemID, itemID)
+	}
+	var payload responseevents.MessagePayload
+	decodePayload(t, draft, &payload)
+	if len(payload.ContentBlocks) != len(texts) {
+		t.Fatalf("message blocks = %#v, want text count %d", payload.ContentBlocks, len(texts))
+	}
+	for index, text := range texts {
+		if payload.ContentBlocks[index].Text != text {
+			t.Fatalf("message block[%d] = %#v, want text %q", index, payload.ContentBlocks[index], text)
+		}
+	}
 }
 
 func assertMessageDrafts(t *testing.T, drafts []responseevents.Draft) {

--- a/pkg/workers/provider/claude/adapter_test.go
+++ b/pkg/workers/provider/claude/adapter_test.go
@@ -1,0 +1,214 @@
+package claude_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/factorysessions/responseevents"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	workerprocess "github.com/portpowered/infinite-you/pkg/workers/process"
+	"github.com/portpowered/infinite-you/pkg/workers/provider/adapter"
+	"github.com/portpowered/infinite-you/pkg/workers/provider/claude"
+)
+
+func TestAdapterBuildCommandRequestsStructuredPartialMessages(t *testing.T) {
+	t.Parallel()
+
+	built, err := claude.NewAdapter().BuildCommand(context.Background(), adapter.CommandContext{
+		Request: interfaces.ProviderInferenceRequest{
+			ModelProvider: string(interfaces.ModelProviderClaude), Model: "claude-sonnet-4",
+			SessionID: "session-1", UserMessage: "inspect the workspace",
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildCommand() error = %v", err)
+	}
+	want := []string{"-p", "--model", "claude-sonnet-4", "--resume", "session-1", "--output-format", "stream-json", "--include-partial-messages", "inspect the workspace"}
+	if !reflect.DeepEqual(built.Request.Args, want) {
+		t.Fatalf("args = %#v, want %#v", built.Request.Args, want)
+	}
+}
+
+func TestAdapterReportsClaudeStreamingCapabilitiesAndFailureFacts(t *testing.T) {
+	t.Parallel()
+
+	providerAdapter := claude.NewAdapter()
+	if providerAdapter.Identity() != "claude" {
+		t.Fatalf("Identity() = %q", providerAdapter.Identity())
+	}
+	reported, err := providerAdapter.Capabilities(context.Background(), adapter.CapabilityContext{})
+	if err != nil {
+		t.Fatalf("Capabilities() error = %v", err)
+	}
+	capabilities := reported.Capabilities
+	if !capabilities.NativeStreaming || !capabilities.MessageDeltas || !capabilities.MessageSnapshots || !capabilities.ToolLifecycle || !capabilities.StableItemIDs || capabilities.FinalOnly {
+		t.Fatalf("Capabilities() = %#v", capabilities)
+	}
+	if failure := providerAdapter.ClassifyFailure(context.Background(), adapter.FailureContext{}); failure.Failure != nil {
+		t.Fatalf("successful failure classification = %#v", failure)
+	}
+	failure := providerAdapter.ClassifyFailure(context.Background(), adapter.FailureContext{CommandResult: workerprocess.CommandResult{ExitCode: 1}})
+	if failure.Failure == nil || failure.Failure.Message != "Claude invocation failed." || failure.Failure.Retry.Retryable {
+		t.Fatalf("failed classification = %#v", failure)
+	}
+}
+
+func TestDecoderMapsChunkedTextAndToolInputWithStableIdentity(t *testing.T) {
+	t.Parallel()
+
+	drafts, diagnostics := decodeFixture(t, "testdata/content_blocks.jsonl", true)
+	if len(diagnostics) != 0 {
+		t.Fatalf("diagnostics = %#v, want none", diagnostics)
+	}
+	if len(drafts) != 7 {
+		t.Fatalf("draft count = %d, want 7: %#v", len(drafts), drafts)
+	}
+	for index, draft := range drafts {
+		if err := responseevents.ValidateDraft(draft); err != nil {
+			t.Fatalf("draft[%d] invalid: %v", index, err)
+		}
+	}
+	assertMessageDrafts(t, drafts)
+	assertToolDrafts(t, drafts)
+}
+
+func TestDecoderInvalidToolInputDoesNotLeakOrStopLaterMessage(t *testing.T) {
+	t.Parallel()
+
+	drafts, diagnostics := decodeFixture(t, "testdata/invalid_tool_input.jsonl", false)
+	if len(diagnostics) != 1 || diagnostics[0].Code != "claude_invalid_tool_input" {
+		t.Fatalf("diagnostics = %#v", diagnostics)
+	}
+	encoded, err := json.Marshal(struct {
+		Drafts      []responseevents.Draft `json:"drafts"`
+		Diagnostics []adapter.Diagnostic   `json:"diagnostics"`
+	}{drafts, diagnostics})
+	if err != nil {
+		t.Fatalf("marshal decoded output: %v", err)
+	}
+	for _, forbidden := range []string{"private prompt", "credential", "{invalid"} {
+		if bytes.Contains(encoded, []byte(forbidden)) {
+			t.Fatalf("decoded output leaked %q: %s", forbidden, encoded)
+		}
+	}
+	completed := findDraft(drafts, responseevents.KindMessage, responseevents.PhaseCompleted)
+	if completed == nil || completed.ItemID != "msg_recovery" {
+		t.Fatalf("later completed message missing: %#v", drafts)
+	}
+}
+
+func TestParseFinalKeepsTerminalResultAuthoritative(t *testing.T) {
+	t.Parallel()
+
+	stdout := []byte("{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"partial\"}]}}\n" +
+		"{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"result\":\"authoritative final\",\"session_id\":\"claude-session-42\"}\n")
+	result, err := claude.NewAdapter().ParseFinal(context.Background(), adapter.FinalParseContext{
+		CommandResult: workerprocess.CommandResult{Stdout: stdout},
+	})
+	if err != nil {
+		t.Fatalf("ParseFinal() error = %v", err)
+	}
+	if result.Response.Content != "authoritative final" || result.Response.ProviderSession == nil || result.Response.ProviderSession.ID != "claude-session-42" {
+		t.Fatalf("ParseFinal() = %#v", result)
+	}
+	if len(result.Drafts) != 0 {
+		t.Fatalf("ParseFinal() emitted semantic drafts: %#v", result.Drafts)
+	}
+}
+
+func decodeFixture(t *testing.T, path string, keepFinalRecordUnterminated bool) ([]responseevents.Draft, []adapter.Diagnostic) {
+	t.Helper()
+	fixture, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if keepFinalRecordUnterminated {
+		fixture = bytes.TrimSuffix(fixture, []byte("\n"))
+	}
+	decoder, err := claude.NewAdapter().NewDecoder(context.Background(), adapter.DecoderContext{RunID: "run-1", DispatchID: "dispatch-1"})
+	if err != nil {
+		t.Fatalf("NewDecoder() error = %v", err)
+	}
+	var drafts []responseevents.Draft
+	var diagnostics []adapter.Diagnostic
+	for offset := 0; offset < len(fixture); {
+		size := 17
+		if remaining := len(fixture) - offset; remaining < size {
+			size = remaining
+		}
+		decoded, observeErr := decoder.Observe(context.Background(), adapter.Observation{Stream: adapter.OutputStreamStdout, Chunk: fixture[offset : offset+size]})
+		if observeErr != nil {
+			t.Fatalf("Observe() error = %v", observeErr)
+		}
+		drafts = append(drafts, decoded.Drafts...)
+		diagnostics = append(diagnostics, decoded.Diagnostics...)
+		offset += size
+	}
+	flushed, err := decoder.Flush(context.Background(), adapter.FlushContext{Reason: adapter.FlushReasonCompleted})
+	if err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	return append(drafts, flushed.Drafts...), append(diagnostics, flushed.Diagnostics...)
+}
+
+func assertMessageDrafts(t *testing.T, drafts []responseevents.Draft) {
+	t.Helper()
+	for _, index := range []int{1, 2, 6} {
+		if drafts[index].ItemID != "msg_01" || drafts[index].ProviderSessionRef != "claude-session-42" {
+			t.Fatalf("message draft[%d] lost identity: %#v", index, drafts[index])
+		}
+	}
+	for index, want := range []string{"Hello ", "world"} {
+		var payload responseevents.MessageDeltaPayload
+		decodePayload(t, drafts[index+1], &payload)
+		if payload.TextDelta != want || payload.ContentBlockIndex != 0 {
+			t.Fatalf("message delta[%d] = %#v", index, payload)
+		}
+	}
+	var completed responseevents.MessagePayload
+	decodePayload(t, drafts[6], &completed)
+	if len(completed.ContentBlocks) != 2 || completed.ContentBlocks[0].Text != "Hello world" || completed.ContentBlocks[1].ToolCallID != "toolu_42" {
+		t.Fatalf("completed message = %#v", completed)
+	}
+}
+
+func assertToolDrafts(t *testing.T, drafts []responseevents.Draft) {
+	t.Helper()
+	for _, index := range []int{3, 4, 5} {
+		if drafts[index].ItemID != "msg_01/content-block/1" || drafts[index].ParentItemID != "msg_01" {
+			t.Fatalf("tool draft[%d] lost identity: %#v", index, drafts[index])
+		}
+	}
+	var started, completed responseevents.ToolPayload
+	decodePayload(t, drafts[3], &started)
+	decodePayload(t, drafts[5], &completed)
+	var delta responseevents.ToolDeltaPayload
+	decodePayload(t, drafts[4], &delta)
+	if started.ToolCallID != "toolu_42" || delta.ToolCallID != "toolu_42" || completed.ToolCallID != "toolu_42" {
+		t.Fatalf("tool call identity changed: start=%#v delta=%#v completed=%#v", started, delta, completed)
+	}
+	if !strings.Contains(delta.OutputDelta, `"city":"Oslo"`) || !strings.Contains(delta.OutputDelta, `"api_token":"<redacted>"`) || strings.Contains(delta.OutputDelta, "fixture-secret") {
+		t.Fatalf("tool summary was not safely normalized: %q", delta.OutputDelta)
+	}
+}
+
+func findDraft(drafts []responseevents.Draft, kind responseevents.Kind, phase responseevents.Phase) *responseevents.Draft {
+	for index := range drafts {
+		if drafts[index].Kind == kind && drafts[index].Phase == phase {
+			return &drafts[index]
+		}
+	}
+	return nil
+}
+
+func decodePayload(t *testing.T, draft responseevents.Draft, target any) {
+	t.Helper()
+	if err := json.Unmarshal(draft.Payload, target); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+}

--- a/pkg/workers/provider/claude/adapter_test.go
+++ b/pkg/workers/provider/claude/adapter_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -37,6 +38,48 @@ func TestAdapterBuildCommandRequestsStructuredPartialMessages(t *testing.T) {
 	want := []string{"-p", "--model", "claude-sonnet-4", "--resume", "session-1", "--output-format", "stream-json", "--include-partial-messages", "inspect the workspace"}
 	if !reflect.DeepEqual(built.Request.Args, want) {
 		t.Fatalf("args = %#v, want %#v", built.Request.Args, want)
+	}
+}
+
+func TestAdapterBuildCommandPreservesOptionalExecutionContext(t *testing.T) {
+	t.Parallel()
+
+	built, err := claude.NewAdapter().BuildCommand(context.Background(), adapter.CommandContext{
+		SkipPermissions: true,
+		Request: interfaces.ProviderInferenceRequest{
+			Dispatch:         interfaces.WorkDispatch{DispatchID: "dispatch-options"},
+			WorkerType:       "agent-worker",
+			WorkstationType:  "review-work",
+			ProjectID:        "project-options",
+			InputTokens:      []any{"input-token"},
+			SystemPrompt:     "safe system prompt",
+			UserMessage:      "review the workspace",
+			EnvVars:          map[string]string{"CLAUDE_TEST_BOUNDARY": "value"},
+			Worktree:         "story-worktree",
+			WorkingDirectory: "workspace",
+			Model:            "claude-sonnet-4",
+			SessionID:        "session-options",
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildCommand() error = %v", err)
+	}
+	wantArgs := []string{
+		"-p", "--dangerously-skip-permissions", "--worktree", "story-worktree",
+		"--system-prompt", "safe system prompt", "--model", "claude-sonnet-4",
+		"--resume", "session-options", "--output-format", "stream-json",
+		"--include-partial-messages", "review the workspace",
+	}
+	if !reflect.DeepEqual(built.Request.Args, wantArgs) {
+		t.Fatalf("args = %#v, want %#v", built.Request.Args, wantArgs)
+	}
+	if built.Request.DispatchID != "dispatch-options" || built.Request.WorkerType != "agent-worker" ||
+		built.Request.WorkstationName != "review-work" || built.Request.ProjectID != "project-options" ||
+		built.Request.WorkDir != "workspace" || !reflect.DeepEqual(built.Request.InputTokens, []any{"input-token"}) {
+		t.Fatalf("execution context = %#v", built.Request)
+	}
+	if !slices.Contains(built.Request.Env, "CLAUDE_TEST_BOUNDARY=value") {
+		t.Fatalf("command env omitted explicit provider value: %#v", built.Request.Env)
 	}
 }
 
@@ -250,6 +293,33 @@ func TestDecoderOmitsOutOfRangeRetryMetadata(t *testing.T) {
 	decodePayload(t, *retry, &payload)
 	if payload.RetryAttempt != nil || payload.RetryAfterSeconds != nil {
 		t.Fatalf("out-of-range retry metadata was retained: %#v", payload)
+	}
+}
+
+func TestDecoderBoundsNonSemanticStreamDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	decoder, err := claude.NewAdapter().NewDecoder(context.Background(), adapter.DecoderContext{})
+	if err != nil {
+		t.Fatalf("NewDecoder() error = %v", err)
+	}
+	stderr, err := decoder.Observe(context.Background(), adapter.Observation{
+		Stream: adapter.OutputStreamStderr, Chunk: []byte("private provider stderr"),
+	})
+	if err != nil || len(stderr.Diagnostics) != 1 || stderr.Diagnostics[0].Code != "claude_stderr_ignored" {
+		t.Fatalf("stderr result = %#v, err=%v", stderr, err)
+	}
+	ignored, err := decoder.Observe(context.Background(), adapter.Observation{
+		Stream: adapter.OutputStream("future-stream"), Chunk: []byte("ignored"),
+	})
+	if err != nil || len(ignored.Drafts) != 0 || len(ignored.Diagnostics) != 0 {
+		t.Fatalf("unknown stream result = %#v, err=%v", ignored, err)
+	}
+	oversized, err := decoder.Observe(context.Background(), adapter.Observation{
+		Stream: adapter.OutputStreamStdout, Chunk: bytes.Repeat([]byte("x"), 256*1024+1),
+	})
+	if err != nil || len(oversized.Diagnostics) != 1 || oversized.Diagnostics[0].Code != "claude_record_too_large" {
+		t.Fatalf("oversized result = %#v, err=%v", oversized, err)
 	}
 }
 

--- a/pkg/workers/provider/claude/control_records.go
+++ b/pkg/workers/provider/claude/control_records.go
@@ -1,0 +1,118 @@
+package claude
+
+import (
+	"bytes"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/portpowered/infinite-you/pkg/factorysessions/responseevents"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/workers/provider/adapter"
+)
+
+const (
+	maximumRetryAttempt = 1_000_000
+	maximumRetryDelayMS = int64((24 * time.Hour) / time.Millisecond)
+)
+
+type claudeRetryError struct {
+	failure adapter.FailureFacts
+}
+
+func (*claudeRetryError) Error() string {
+	return "Claude reported a retryable provider API failure"
+}
+
+func (d *decoder) retryObservation(envelope nativeEnvelope) (adapter.DecodeResult, error) {
+	payload := responseevents.ErrorPayload{
+		Code: "claude_api_retry", Message: "Claude reported a provider API retry.", Retryable: true,
+		RetryAttempt: boundedRetryAttempt(envelope.Attempt),
+	}
+	if delay := boundedRetryDelay(envelope.RetryDelayMS); delay != nil {
+		seconds := int64((*delay + time.Second - 1) / time.Second)
+		payload.RetryAfterSeconds = &seconds
+	}
+	encoded, err := marshalPayload(payload)
+	if err != nil {
+		return adapter.DecodeResult{}, err
+	}
+	return d.withRunStart(adapter.DecodeResult{Drafts: []responseevents.Draft{{
+		Kind: responseevents.KindError, Phase: responseevents.PhaseUpdated, ProviderSessionRef: d.sessionRef,
+		Provenance: provenance("api_retry", responseevents.RepresentationNotification), Payload: encoded,
+	}}}), nil
+}
+
+func (d *decoder) compactionObservation() (adapter.DecodeResult, error) {
+	payload, err := marshalPayload(responseevents.ProgressPayload{
+		Label: "context_compaction", Message: "Claude compacted the conversation context.",
+	})
+	if err != nil {
+		return adapter.DecodeResult{}, err
+	}
+	return d.withRunStart(adapter.DecodeResult{Drafts: []responseevents.Draft{{
+		Kind: responseevents.KindProgress, Phase: responseevents.PhaseUpdated, ProviderSessionRef: d.sessionRef,
+		Provenance: provenance("compact_boundary", responseevents.RepresentationNotification), Payload: payload,
+	}}}), nil
+}
+
+func claudeRetryFailure(stdout []byte) *adapter.FailureFacts {
+	var latest *nativeEnvelope
+	for _, line := range bytes.Split(bytes.ReplaceAll(stdout, []byte("\r\n"), []byte("\n")), []byte("\n")) {
+		var envelope nativeEnvelope
+		if json.Unmarshal(bytes.TrimSpace(line), &envelope) == nil && envelope.Type == "system" && envelope.Subtype == "api_retry" {
+			copy := envelope
+			latest = &copy
+		}
+	}
+	if latest == nil {
+		return nil
+	}
+	family, failureType := interfaces.WorkFailureFamilyRetryable, interfaces.WorkFailureTypeInternalServerError
+	if status, ok := boundedStatus(latest.ErrorStatus); ok && status == 429 {
+		family, failureType = interfaces.WorkFailureFamilyThrottle, interfaces.WorkFailureTypeThrottled
+	}
+	return &adapter.FailureFacts{
+		Family: family, Type: failureType, Message: "Claude reported a retryable provider API failure.",
+		Retry:           adapter.RetryGuidance{Retryable: true, RetryAfter: boundedRetryDelay(latest.RetryDelayMS)},
+		ProviderSession: providerSession(latest.SessionID),
+	}
+}
+
+func boundedRetryAttempt(value *int) *int {
+	if value == nil || *value < 0 || *value > maximumRetryAttempt {
+		return nil
+	}
+	result := *value
+	return &result
+}
+
+func boundedRetryDelay(value *int64) *time.Duration {
+	if value == nil || *value < 0 || *value > maximumRetryDelayMS {
+		return nil
+	}
+	delay := time.Duration(*value) * time.Millisecond
+	return &delay
+}
+
+func boundedStatus(raw json.RawMessage) (int, bool) {
+	var number int
+	if json.Unmarshal(raw, &number) == nil && number >= 100 && number <= 599 {
+		return number, true
+	}
+	var text string
+	if json.Unmarshal(raw, &text) != nil {
+		return 0, false
+	}
+	number, err := strconv.Atoi(strings.TrimSpace(text))
+	return number, err == nil && number >= 100 && number <= 599
+}
+
+func optionalString(raw json.RawMessage) string {
+	var value string
+	if json.Unmarshal(raw, &value) != nil {
+		return ""
+	}
+	return strings.TrimSpace(value)
+}

--- a/pkg/workers/provider/claude/decoder.go
+++ b/pkg/workers/provider/claude/decoder.go
@@ -1,0 +1,464 @@
+package claude
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/portpowered/infinite-you/pkg/factorysessions/responseevents"
+	"github.com/portpowered/infinite-you/pkg/workers/provider/adapter"
+)
+
+const (
+	maximumBufferedRecordBytes = 256 * 1024
+	maximumToolInputBytes      = 64 * 1024
+	maximumSummaryBytes        = 256
+)
+
+type decoder struct {
+	context adapter.DecoderContext
+	pending []byte
+
+	runStarted bool
+	messageID  string
+	sessionRef string
+	blocks     map[int]*contentBlock
+}
+
+type contentBlock struct {
+	kind        string
+	text        strings.Builder
+	toolID      string
+	toolName    string
+	toolInput   []byte
+	lastSummary string
+}
+
+type nativeEnvelope struct {
+	Type      string          `json:"type"`
+	SessionID string          `json:"session_id"`
+	Event     json.RawMessage `json:"event"`
+	Message   *nativeMessage  `json:"message"`
+}
+
+type nativeEvent struct {
+	Type         string         `json:"type"`
+	Index        int            `json:"index"`
+	Message      *nativeMessage `json:"message"`
+	ContentBlock *nativeBlock   `json:"content_block"`
+	Delta        *nativeDelta   `json:"delta"`
+}
+
+type nativeMessage struct {
+	ID   string `json:"id"`
+	Role string `json:"role"`
+}
+
+type nativeBlock struct {
+	Type  string          `json:"type"`
+	Text  string          `json:"text"`
+	ID    string          `json:"id"`
+	Name  string          `json:"name"`
+	Input json.RawMessage `json:"input"`
+}
+
+type nativeDelta struct {
+	Type        string `json:"type"`
+	Text        string `json:"text"`
+	PartialJSON string `json:"partial_json"`
+}
+
+func newDecoder(input adapter.DecoderContext) *decoder {
+	return &decoder{context: input, blocks: make(map[int]*contentBlock)}
+}
+
+func (d *decoder) Observe(_ context.Context, observation adapter.Observation) (adapter.DecodeResult, error) {
+	if observation.Stream == adapter.OutputStreamStderr {
+		return adapter.DecodeResult{Diagnostics: []adapter.Diagnostic{{Code: "claude_stderr_ignored", Message: "Claude stderr output was omitted"}}}, nil
+	}
+	if observation.Stream != adapter.OutputStreamStdout || len(observation.Chunk) == 0 {
+		return adapter.DecodeResult{}, nil
+	}
+	if len(d.pending)+len(observation.Chunk) > maximumBufferedRecordBytes {
+		d.pending = nil
+		return safeDiagnostic("claude_record_too_large", "Claude emitted an oversized structured record"), nil
+	}
+	d.pending = append(d.pending, observation.Chunk...)
+	return d.drain(false)
+}
+
+func (d *decoder) Flush(_ context.Context, _ adapter.FlushContext) (adapter.DecodeResult, error) {
+	return d.drain(true)
+}
+
+func (d *decoder) drain(flush bool) (adapter.DecodeResult, error) {
+	var result adapter.DecodeResult
+	for {
+		newline := bytes.IndexByte(d.pending, '\n')
+		if newline < 0 {
+			if !flush || len(bytes.TrimSpace(d.pending)) == 0 {
+				return result, nil
+			}
+			record := append([]byte(nil), d.pending...)
+			d.pending = nil
+			decoded, err := d.decodeRecord(record)
+			return appendResult(result, decoded), err
+		}
+		record := append([]byte(nil), d.pending[:newline]...)
+		d.pending = d.pending[newline+1:]
+		if len(bytes.TrimSpace(record)) == 0 {
+			continue
+		}
+		decoded, err := d.decodeRecord(record)
+		result = appendResult(result, decoded)
+		if err != nil {
+			return result, err
+		}
+	}
+}
+
+func (d *decoder) decodeRecord(raw []byte) (adapter.DecodeResult, error) {
+	var envelope nativeEnvelope
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return safeDiagnostic("claude_malformed_record", "Claude emitted a malformed structured record"), nil
+	}
+	if session := providerSession(envelope.SessionID); session != nil {
+		d.sessionRef = session.ID
+	}
+	if envelope.Type == "assistant" && envelope.Message != nil {
+		return adapter.DecodeResult{}, nil
+	}
+	if envelope.Type != "stream_event" {
+		return adapter.DecodeResult{}, nil
+	}
+	var event nativeEvent
+	if err := json.Unmarshal(envelope.Event, &event); err != nil {
+		return safeDiagnostic("claude_malformed_event", "Claude emitted a malformed stream event"), nil
+	}
+	switch event.Type {
+	case "message_start":
+		if event.Message != nil {
+			d.messageID = strings.TrimSpace(event.Message.ID)
+		}
+		if d.messageID == "" {
+			d.messageID = fallbackMessageID(d.context)
+		}
+		d.blocks = make(map[int]*contentBlock)
+		return d.withRunStart(adapter.DecodeResult{}), nil
+	case "content_block_start":
+		return d.startBlock(event)
+	case "content_block_delta":
+		return d.updateBlock(event)
+	case "content_block_stop":
+		return d.stopBlock(event)
+	case "message_stop":
+		return d.completeMessage()
+	default:
+		return adapter.DecodeResult{}, nil
+	}
+}
+
+func (d *decoder) startBlock(event nativeEvent) (adapter.DecodeResult, error) {
+	if event.ContentBlock == nil || event.Index < 0 {
+		return safeDiagnostic("claude_invalid_block_start", "Claude emitted an invalid content-block start"), nil
+	}
+	block := &contentBlock{kind: event.ContentBlock.Type, toolID: strings.TrimSpace(event.ContentBlock.ID), toolName: strings.TrimSpace(event.ContentBlock.Name)}
+	d.blocks[event.Index] = block
+	switch block.kind {
+	case "text":
+		if event.ContentBlock.Text == "" {
+			return adapter.DecodeResult{}, nil
+		}
+		block.text.WriteString(event.ContentBlock.Text)
+		return d.messageDelta(event.Index, event.ContentBlock.Text)
+	case "tool_use":
+		if block.toolID == "" || block.toolName == "" {
+			return safeDiagnostic("claude_invalid_tool_start", "Claude emitted a tool block without stable identity"), nil
+		}
+		if len(event.ContentBlock.Input) > 0 && string(event.ContentBlock.Input) != "{}" {
+			block.toolInput = append(block.toolInput, event.ContentBlock.Input...)
+		}
+		return d.toolSnapshot(event.Index, responseevents.PhaseStarted)
+	default:
+		return adapter.DecodeResult{}, nil
+	}
+}
+
+func (d *decoder) updateBlock(event nativeEvent) (adapter.DecodeResult, error) {
+	block := d.blocks[event.Index]
+	if block == nil || event.Delta == nil {
+		return safeDiagnostic("claude_unmatched_block_delta", "Claude emitted an update for an unopened content block"), nil
+	}
+	switch event.Delta.Type {
+	case "text_delta":
+		if block.kind != "text" || event.Delta.Text == "" {
+			return adapter.DecodeResult{}, nil
+		}
+		block.text.WriteString(event.Delta.Text)
+		return d.messageDelta(event.Index, event.Delta.Text)
+	case "input_json_delta":
+		if block.kind != "tool_use" || event.Delta.PartialJSON == "" {
+			return adapter.DecodeResult{}, nil
+		}
+		if len(block.toolInput)+len(event.Delta.PartialJSON) > maximumToolInputBytes {
+			block.toolInput = nil
+			return safeDiagnostic("claude_tool_input_too_large", "Claude tool input exceeded the safe summary boundary"), nil
+		}
+		block.toolInput = append(block.toolInput, event.Delta.PartialJSON...)
+		summary, ok := safeJSONSummary(block.toolInput)
+		if !ok || summary == block.lastSummary {
+			return adapter.DecodeResult{}, nil
+		}
+		block.lastSummary = summary
+		return d.toolDelta(event.Index, summary)
+	default:
+		return adapter.DecodeResult{}, nil
+	}
+}
+
+func (d *decoder) stopBlock(event nativeEvent) (adapter.DecodeResult, error) {
+	block := d.blocks[event.Index]
+	if block == nil || block.kind != "tool_use" {
+		return adapter.DecodeResult{}, nil
+	}
+	result, err := d.toolSnapshot(event.Index, responseevents.PhaseCompleted)
+	if err != nil {
+		return result, err
+	}
+	if len(block.toolInput) > 0 {
+		if _, ok := safeJSONSummary(block.toolInput); !ok {
+			result.Diagnostics = append(result.Diagnostics, adapter.Diagnostic{Code: "claude_invalid_tool_input", Message: "Claude tool input did not form a valid safe summary"})
+		}
+	}
+	return result, nil
+}
+
+func (d *decoder) completeMessage() (adapter.DecodeResult, error) {
+	indexes := make([]int, 0, len(d.blocks))
+	for index := range d.blocks {
+		indexes = append(indexes, index)
+	}
+	sort.Ints(indexes)
+	blocks := make([]responseevents.ContentBlock, 0, len(indexes))
+	for _, index := range indexes {
+		block := d.blocks[index]
+		switch block.kind {
+		case "text":
+			if block.text.Len() > 0 {
+				blocks = append(blocks, responseevents.ContentBlock{Kind: responseevents.ContentBlockText, Text: block.text.String()})
+			}
+		case "tool_use":
+			content := responseevents.ContentBlock{Kind: responseevents.ContentBlockToolRequest, ToolCallID: block.toolID, ToolName: block.toolName}
+			if summary, ok := safeJSONSummary(block.toolInput); ok {
+				content.ArgumentsSummary = json.RawMessage(summary)
+			}
+			blocks = append(blocks, content)
+		}
+	}
+	if len(blocks) == 0 {
+		return adapter.DecodeResult{}, nil
+	}
+	payload, err := marshalPayload(responseevents.MessagePayload{Role: "assistant", ContentBlocks: blocks})
+	if err != nil {
+		return adapter.DecodeResult{}, err
+	}
+	return d.withRunStart(adapter.DecodeResult{Drafts: []responseevents.Draft{{
+		Kind: responseevents.KindMessage, Phase: responseevents.PhaseCompleted, ItemID: d.stableMessageID(), ProviderSessionRef: d.sessionRef,
+		Provenance: provenance("message_stop", responseevents.RepresentationSnapshot), Payload: payload,
+	}}}), nil
+}
+
+func (d *decoder) messageDelta(index int, text string) (adapter.DecodeResult, error) {
+	payload, err := marshalPayload(responseevents.MessageDeltaPayload{ContentBlockIndex: index, ContentBlockKind: responseevents.ContentBlockText, TextDelta: text})
+	if err != nil {
+		return adapter.DecodeResult{}, err
+	}
+	return d.withRunStart(adapter.DecodeResult{Drafts: []responseevents.Draft{{
+		Kind: responseevents.KindMessage, Phase: responseevents.PhaseDelta, ItemID: d.stableMessageID(), ProviderSessionRef: d.sessionRef,
+		Provenance: provenance("content_block_delta", responseevents.RepresentationDelta), Payload: payload,
+	}}}), nil
+}
+
+func (d *decoder) toolDelta(index int, summary string) (adapter.DecodeResult, error) {
+	block := d.blocks[index]
+	payload, err := marshalPayload(responseevents.ToolDeltaPayload{ToolCallID: block.toolID, OutputDelta: summary})
+	if err != nil {
+		return adapter.DecodeResult{}, err
+	}
+	return d.withRunStart(adapter.DecodeResult{Drafts: []responseevents.Draft{{
+		Kind: responseevents.KindTool, Phase: responseevents.PhaseDelta, ItemID: d.toolItemID(index), ParentItemID: d.stableMessageID(), ProviderSessionRef: d.sessionRef,
+		Provenance: provenance("input_json_delta", responseevents.RepresentationDelta), Payload: payload,
+	}}}), nil
+}
+
+func (d *decoder) toolSnapshot(index int, phase responseevents.Phase) (adapter.DecodeResult, error) {
+	block := d.blocks[index]
+	body := responseevents.ToolPayload{ToolCallID: block.toolID, ToolName: block.toolName, Status: "running"}
+	if phase == responseevents.PhaseCompleted {
+		body.Status = "completed"
+		if summary, ok := safeJSONSummary(block.toolInput); ok {
+			body.ArgumentsSummary = json.RawMessage(summary)
+		}
+	}
+	payload, err := marshalPayload(body)
+	if err != nil {
+		return adapter.DecodeResult{}, err
+	}
+	return d.withRunStart(adapter.DecodeResult{Drafts: []responseevents.Draft{{
+		Kind: responseevents.KindTool, Phase: phase, ItemID: d.toolItemID(index), ParentItemID: d.stableMessageID(), ProviderSessionRef: d.sessionRef,
+		Provenance: provenance("content_block_"+phaseName(phase), responseevents.RepresentationSnapshot), Payload: payload,
+	}}}), nil
+}
+
+func (d *decoder) withRunStart(result adapter.DecodeResult) adapter.DecodeResult {
+	if d.runStarted {
+		return result
+	}
+	payload, err := marshalPayload(responseevents.RunPayload{Status: "started"})
+	if err != nil {
+		result.Diagnostics = append(result.Diagnostics, adapter.Diagnostic{Code: "claude_run_start_failed", Message: "Claude run metadata could not be normalized"})
+		return result
+	}
+	d.runStarted = true
+	started := responseevents.Draft{RunID: d.context.RunID, DispatchID: d.context.DispatchID, Kind: responseevents.KindRun, Phase: responseevents.PhaseStarted,
+		Provenance: responseevents.Provenance{Provider: "claude", NativeEventType: "message_start", Delivery: responseevents.DeliverySynthesized, Representation: responseevents.RepresentationNotification, Fidelity: responseevents.FidelityNormalized}, Payload: payload}
+	result.Drafts = append([]responseevents.Draft{started}, result.Drafts...)
+	return result
+}
+
+func (d *decoder) stableMessageID() string {
+	if strings.TrimSpace(d.messageID) != "" {
+		return d.messageID
+	}
+	d.messageID = fallbackMessageID(d.context)
+	return d.messageID
+}
+
+func (d *decoder) toolItemID(index int) string {
+	return d.stableMessageID() + "/content-block/" + strconv.Itoa(index)
+}
+
+func fallbackMessageID(input adapter.DecoderContext) string {
+	identity := strings.TrimSpace(input.DispatchID)
+	if identity == "" {
+		identity = strings.TrimSpace(input.RunID)
+	}
+	if identity == "" {
+		identity = "invocation"
+	}
+	return "claude-message/" + identity
+}
+
+func provenance(nativeType string, representation responseevents.Representation) responseevents.Provenance {
+	return responseevents.Provenance{Provider: "claude", NativeEventType: nativeType, Delivery: responseevents.DeliveryNativeStream, Representation: representation, Fidelity: responseevents.FidelityNormalized}
+}
+
+func phaseName(phase responseevents.Phase) string {
+	if phase == responseevents.PhaseStarted {
+		return "start"
+	}
+	return "stop"
+}
+
+func safeJSONSummary(raw []byte) (string, bool) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return "", false
+	}
+	var value any
+	if json.Unmarshal(raw, &value) != nil {
+		return "", false
+	}
+	summarized := summarizeJSON(value, 0)
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(summarized)
+	encoded := bytes.TrimSuffix(buffer.Bytes(), []byte("\n"))
+	if err != nil {
+		return "", false
+	}
+	if len(encoded) > maximumSummaryBytes {
+		encoded = boundedJSONShapeSummary(value)
+	}
+	return string(encoded), true
+}
+
+func boundedJSONShapeSummary(value any) []byte {
+	switch typed := value.(type) {
+	case map[string]any:
+		return []byte(fmt.Sprintf(`{"summary":"valid tool input omitted","fieldCount":%d}`, len(typed)))
+	case []any:
+		return []byte(fmt.Sprintf(`{"summary":"valid tool input omitted","itemCount":%d}`, len(typed)))
+	default:
+		return []byte(`{"summary":"valid tool input omitted"}`)
+	}
+}
+
+func summarizeJSON(value any, depth int) any {
+	if depth >= 3 {
+		return "<omitted>"
+	}
+	switch typed := value.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		if len(keys) > 12 {
+			keys = keys[:12]
+		}
+		result := make(map[string]any, len(keys))
+		for _, key := range keys {
+			if sensitiveKey(key) {
+				result[key] = "<redacted>"
+			} else {
+				result[key] = summarizeJSON(typed[key], depth+1)
+			}
+		}
+		return result
+	case []any:
+		if len(typed) > 8 {
+			typed = typed[:8]
+		}
+		result := make([]any, len(typed))
+		for index := range typed {
+			result[index] = summarizeJSON(typed[index], depth+1)
+		}
+		return result
+	case string:
+		runes := []rune(typed)
+		if len(runes) > 48 {
+			return string(runes[:48]) + "…"
+		}
+		return typed
+	default:
+		return typed
+	}
+}
+
+func sensitiveKey(key string) bool {
+	normalized := strings.ToLower(key)
+	for _, marker := range []string{"token", "secret", "password", "credential", "api_key", "apikey", "authorization"} {
+		if strings.Contains(normalized, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func safeDiagnostic(code, message string) adapter.DecodeResult {
+	return adapter.DecodeResult{Diagnostics: []adapter.Diagnostic{{Code: code, Message: message}}}
+}
+
+func appendResult(target, next adapter.DecodeResult) adapter.DecodeResult {
+	target.Drafts = append(target.Drafts, next.Drafts...)
+	target.Diagnostics = append(target.Diagnostics, next.Diagnostics...)
+	return target
+}
+
+var _ adapter.Decoder = (*decoder)(nil)

--- a/pkg/workers/provider/claude/decoder.go
+++ b/pkg/workers/provider/claude/decoder.go
@@ -25,6 +25,7 @@ type decoder struct {
 
 	runStarted        bool
 	messageID         string
+	parentItemID      string
 	sessionRef        string
 	blocks            map[int]*contentBlock
 	pendingCompletion *messageCompletion
@@ -34,6 +35,7 @@ type decoder struct {
 
 type messageCompletion struct {
 	messageID     string
+	parentItemID  string
 	nativeType    string
 	contentBlocks []responseevents.ContentBlock
 	toolSnapshots []indexedToolSnapshot
@@ -54,10 +56,15 @@ type contentBlock struct {
 }
 
 type nativeEnvelope struct {
-	Type      string          `json:"type"`
-	SessionID string          `json:"session_id"`
-	Event     json.RawMessage `json:"event"`
-	Message   *nativeMessage  `json:"message"`
+	Type            string          `json:"type"`
+	Subtype         string          `json:"subtype"`
+	SessionID       string          `json:"session_id"`
+	ParentToolUseID json.RawMessage `json:"parent_tool_use_id"`
+	Event           json.RawMessage `json:"event"`
+	Message         *nativeMessage  `json:"message"`
+	Attempt         *int            `json:"attempt"`
+	RetryDelayMS    *int64          `json:"retry_delay_ms"`
+	ErrorStatus     json.RawMessage `json:"error_status"`
 }
 
 type nativeEvent struct {
@@ -154,15 +161,37 @@ func (d *decoder) decodeRecord(raw []byte) (adapter.DecodeResult, error) {
 		d.sessionRef = session.ID
 	}
 	if envelope.Type == "assistant" && envelope.Message != nil {
-		return d.completeNativeMessage(*envelope.Message)
+		return d.completeNativeMessage(*envelope.Message, optionalString(envelope.ParentToolUseID))
+	}
+	if envelope.Type == "system" {
+		return d.decodeSystemRecord(envelope)
 	}
 	if envelope.Type != "stream_event" {
-		return adapter.DecodeResult{}, nil
+		if envelope.Type == "result" || envelope.Type == "user" {
+			return adapter.DecodeResult{}, nil
+		}
+		return safeDiagnostic("claude_unknown_record", "Claude emitted an unsupported additive record"), nil
 	}
-	return d.decodeStreamEvent(envelope.Event)
+	if len(envelope.Event) == 0 {
+		return safeDiagnostic("claude_malformed_event", "Claude emitted a malformed stream event"), nil
+	}
+	return d.decodeStreamEvent(envelope.Event, optionalString(envelope.ParentToolUseID))
 }
 
-func (d *decoder) decodeStreamEvent(raw json.RawMessage) (adapter.DecodeResult, error) {
+func (d *decoder) decodeSystemRecord(envelope nativeEnvelope) (adapter.DecodeResult, error) {
+	switch envelope.Subtype {
+	case "init", "status":
+		return adapter.DecodeResult{}, nil
+	case "api_retry":
+		return d.retryObservation(envelope)
+	case "compact_boundary":
+		return d.compactionObservation()
+	default:
+		return safeDiagnostic("claude_unknown_system_record", "Claude emitted an unsupported additive system record"), nil
+	}
+}
+
+func (d *decoder) decodeStreamEvent(raw json.RawMessage, parentItemID string) (adapter.DecodeResult, error) {
 	var event nativeEvent
 	if err := json.Unmarshal(raw, &event); err != nil {
 		return safeDiagnostic("claude_malformed_event", "Claude emitted a malformed stream event"), nil
@@ -179,18 +208,23 @@ func (d *decoder) decodeStreamEvent(raw json.RawMessage) (adapter.DecodeResult, 
 		if d.messageID == "" {
 			d.messageID = fallbackMessageID(d.context)
 		}
+		d.parentItemID = parentItemID
 		d.blocks = make(map[int]*contentBlock)
 		return appendResult(result, d.withRunStart(adapter.DecodeResult{})), nil
 	case "content_block_start":
+		d.retainExplicitParent(parentItemID)
 		return d.startBlock(event)
 	case "content_block_delta":
+		d.retainExplicitParent(parentItemID)
 		return d.updateBlock(event)
 	case "content_block_stop":
+		d.retainExplicitParent(parentItemID)
 		return d.stopBlock(event)
 	case "message_stop":
+		d.retainExplicitParent(parentItemID)
 		return d.deferAccumulatedMessage()
 	default:
-		return adapter.DecodeResult{}, nil
+		return safeDiagnostic("claude_unknown_stream_event", "Claude emitted an unsupported additive stream event"), nil
 	}
 }
 
@@ -216,7 +250,7 @@ func (d *decoder) startBlock(event nativeEvent) (adapter.DecodeResult, error) {
 		}
 		return d.toolSnapshot(event.Index, responseevents.PhaseStarted)
 	default:
-		return adapter.DecodeResult{}, nil
+		return safeDiagnostic("claude_unknown_block", "Claude emitted an unsupported additive content block"), nil
 	}
 }
 
@@ -248,7 +282,7 @@ func (d *decoder) updateBlock(event nativeEvent) (adapter.DecodeResult, error) {
 		block.lastSummary = summary
 		return d.toolDelta(event.Index, summary)
 	default:
-		return adapter.DecodeResult{}, nil
+		return safeDiagnostic("claude_unknown_block_delta", "Claude emitted an unsupported additive content-block update"), nil
 	}
 }
 
@@ -292,12 +326,12 @@ func (d *decoder) deferAccumulatedMessage() (adapter.DecodeResult, error) {
 		}
 	}
 	if len(blocks) > 0 {
-		d.pendingCompletion = &messageCompletion{messageID: d.stableMessageID(), nativeType: "message_stop", contentBlocks: blocks}
+		d.pendingCompletion = &messageCompletion{messageID: d.stableMessageID(), parentItemID: d.parentItemID, nativeType: "message_stop", contentBlocks: blocks}
 	}
 	return adapter.DecodeResult{}, nil
 }
 
-func (d *decoder) completeNativeMessage(message nativeMessage) (adapter.DecodeResult, error) {
+func (d *decoder) completeNativeMessage(message nativeMessage, parentItemID string) (adapter.DecodeResult, error) {
 	if strings.TrimSpace(message.Role) != "assistant" {
 		return adapter.DecodeResult{}, nil
 	}
@@ -322,8 +356,9 @@ func (d *decoder) completeNativeMessage(message nativeMessage) (adapter.DecodeRe
 		d.pendingCompletion = nil
 	}
 	d.messageID = messageID
+	d.parentItemID = parentItemID
 	completed, err := d.publishCompletion(messageCompletion{
-		messageID: messageID, nativeType: "assistant", contentBlocks: blocks, toolSnapshots: tools,
+		messageID: messageID, parentItemID: parentItemID, nativeType: "assistant", contentBlocks: blocks, toolSnapshots: tools,
 	})
 	completed.Diagnostics = append(completed.Diagnostics, diagnostics...)
 	return appendResult(result, completed), err
@@ -385,16 +420,17 @@ func (d *decoder) publishCompletion(completion messageCompletion) (adapter.Decod
 	if err != nil {
 		return adapter.DecodeResult{}, err
 	}
-	if d.completedMessages[completion.messageID] == string(payload) {
+	fingerprint := completion.parentItemID + "\x00" + string(payload)
+	if d.completedMessages[completion.messageID] == fingerprint {
 		return adapter.DecodeResult{}, nil
 	}
 	result, err := d.publishToolSnapshots(completion)
 	if err != nil {
 		return result, err
 	}
-	d.completedMessages[completion.messageID] = string(payload)
+	d.completedMessages[completion.messageID] = fingerprint
 	result.Drafts = append(result.Drafts, responseevents.Draft{
-		Kind: responseevents.KindMessage, Phase: responseevents.PhaseCompleted, ItemID: completion.messageID, ProviderSessionRef: d.sessionRef,
+		Kind: responseevents.KindMessage, Phase: responseevents.PhaseCompleted, ItemID: completion.messageID, ParentItemID: completion.parentItemID, ProviderSessionRef: d.sessionRef,
 		Provenance: provenance(completion.nativeType, responseevents.RepresentationSnapshot), Payload: payload,
 	})
 	return d.withRunStart(result), nil
@@ -427,7 +463,7 @@ func (d *decoder) messageDelta(index int, text string) (adapter.DecodeResult, er
 		return adapter.DecodeResult{}, err
 	}
 	return d.withRunStart(adapter.DecodeResult{Drafts: []responseevents.Draft{{
-		Kind: responseevents.KindMessage, Phase: responseevents.PhaseDelta, ItemID: d.stableMessageID(), ProviderSessionRef: d.sessionRef,
+		Kind: responseevents.KindMessage, Phase: responseevents.PhaseDelta, ItemID: d.stableMessageID(), ParentItemID: d.parentItemID, ProviderSessionRef: d.sessionRef,
 		Provenance: provenance("content_block_delta", responseevents.RepresentationDelta), Payload: payload,
 	}}}), nil
 }
@@ -488,6 +524,12 @@ func (d *decoder) stableMessageID() string {
 	}
 	d.messageID = fallbackMessageID(d.context)
 	return d.messageID
+}
+
+func (d *decoder) retainExplicitParent(parentItemID string) {
+	if parentItemID != "" {
+		d.parentItemID = parentItemID
+	}
 }
 
 func (d *decoder) toolItemID(index int) string {

--- a/pkg/workers/provider/claude/decoder.go
+++ b/pkg/workers/provider/claude/decoder.go
@@ -23,10 +23,25 @@ type decoder struct {
 	context adapter.DecoderContext
 	pending []byte
 
-	runStarted bool
-	messageID  string
-	sessionRef string
-	blocks     map[int]*contentBlock
+	runStarted        bool
+	messageID         string
+	sessionRef        string
+	blocks            map[int]*contentBlock
+	pendingCompletion *messageCompletion
+	completedMessages map[string]string
+	completedTools    map[string]string
+}
+
+type messageCompletion struct {
+	messageID     string
+	nativeType    string
+	contentBlocks []responseevents.ContentBlock
+	toolSnapshots []indexedToolSnapshot
+}
+
+type indexedToolSnapshot struct {
+	index int
+	block responseevents.ContentBlock
 }
 
 type contentBlock struct {
@@ -54,8 +69,9 @@ type nativeEvent struct {
 }
 
 type nativeMessage struct {
-	ID   string `json:"id"`
-	Role string `json:"role"`
+	ID      string        `json:"id"`
+	Role    string        `json:"role"`
+	Content []nativeBlock `json:"content"`
 }
 
 type nativeBlock struct {
@@ -73,7 +89,10 @@ type nativeDelta struct {
 }
 
 func newDecoder(input adapter.DecoderContext) *decoder {
-	return &decoder{context: input, blocks: make(map[int]*contentBlock)}
+	return &decoder{
+		context: input, blocks: make(map[int]*contentBlock),
+		completedMessages: make(map[string]string), completedTools: make(map[string]string),
+	}
 }
 
 func (d *decoder) Observe(_ context.Context, observation adapter.Observation) (adapter.DecodeResult, error) {
@@ -92,7 +111,12 @@ func (d *decoder) Observe(_ context.Context, observation adapter.Observation) (a
 }
 
 func (d *decoder) Flush(_ context.Context, _ adapter.FlushContext) (adapter.DecodeResult, error) {
-	return d.drain(true)
+	result, err := d.drain(true)
+	if err != nil {
+		return result, err
+	}
+	completed, completeErr := d.publishPendingCompletion()
+	return appendResult(result, completed), completeErr
 }
 
 func (d *decoder) drain(flush bool) (adapter.DecodeResult, error) {
@@ -130,17 +154,25 @@ func (d *decoder) decodeRecord(raw []byte) (adapter.DecodeResult, error) {
 		d.sessionRef = session.ID
 	}
 	if envelope.Type == "assistant" && envelope.Message != nil {
-		return adapter.DecodeResult{}, nil
+		return d.completeNativeMessage(*envelope.Message)
 	}
 	if envelope.Type != "stream_event" {
 		return adapter.DecodeResult{}, nil
 	}
+	return d.decodeStreamEvent(envelope.Event)
+}
+
+func (d *decoder) decodeStreamEvent(raw json.RawMessage) (adapter.DecodeResult, error) {
 	var event nativeEvent
-	if err := json.Unmarshal(envelope.Event, &event); err != nil {
+	if err := json.Unmarshal(raw, &event); err != nil {
 		return safeDiagnostic("claude_malformed_event", "Claude emitted a malformed stream event"), nil
 	}
 	switch event.Type {
 	case "message_start":
+		result, err := d.publishPendingCompletion()
+		if err != nil {
+			return result, err
+		}
 		if event.Message != nil {
 			d.messageID = strings.TrimSpace(event.Message.ID)
 		}
@@ -148,7 +180,7 @@ func (d *decoder) decodeRecord(raw []byte) (adapter.DecodeResult, error) {
 			d.messageID = fallbackMessageID(d.context)
 		}
 		d.blocks = make(map[int]*contentBlock)
-		return d.withRunStart(adapter.DecodeResult{}), nil
+		return appendResult(result, d.withRunStart(adapter.DecodeResult{})), nil
 	case "content_block_start":
 		return d.startBlock(event)
 	case "content_block_delta":
@@ -156,7 +188,7 @@ func (d *decoder) decodeRecord(raw []byte) (adapter.DecodeResult, error) {
 	case "content_block_stop":
 		return d.stopBlock(event)
 	case "message_stop":
-		return d.completeMessage()
+		return d.deferAccumulatedMessage()
 	default:
 		return adapter.DecodeResult{}, nil
 	}
@@ -237,7 +269,7 @@ func (d *decoder) stopBlock(event nativeEvent) (adapter.DecodeResult, error) {
 	return result, nil
 }
 
-func (d *decoder) completeMessage() (adapter.DecodeResult, error) {
+func (d *decoder) deferAccumulatedMessage() (adapter.DecodeResult, error) {
 	indexes := make([]int, 0, len(d.blocks))
 	for index := range d.blocks {
 		indexes = append(indexes, index)
@@ -259,17 +291,134 @@ func (d *decoder) completeMessage() (adapter.DecodeResult, error) {
 			blocks = append(blocks, content)
 		}
 	}
-	if len(blocks) == 0 {
+	if len(blocks) > 0 {
+		d.pendingCompletion = &messageCompletion{messageID: d.stableMessageID(), nativeType: "message_stop", contentBlocks: blocks}
+	}
+	return adapter.DecodeResult{}, nil
+}
+
+func (d *decoder) completeNativeMessage(message nativeMessage) (adapter.DecodeResult, error) {
+	if strings.TrimSpace(message.Role) != "assistant" {
 		return adapter.DecodeResult{}, nil
 	}
-	payload, err := marshalPayload(responseevents.MessagePayload{Role: "assistant", ContentBlocks: blocks})
+	messageID := strings.TrimSpace(message.ID)
+	if messageID == "" {
+		messageID = d.stableMessageID()
+	}
+	var result adapter.DecodeResult
+	if d.pendingCompletion != nil && d.pendingCompletion.messageID != messageID {
+		pending, err := d.publishPendingCompletion()
+		if err != nil {
+			return pending, err
+		}
+		result = appendResult(result, pending)
+	}
+	blocks, tools, diagnostics := canonicalNativeBlocks(message.Content)
+	if len(blocks) == 0 {
+		result.Diagnostics = append(result.Diagnostics, diagnostics...)
+		return result, nil
+	}
+	if d.pendingCompletion != nil && d.pendingCompletion.messageID == messageID {
+		d.pendingCompletion = nil
+	}
+	d.messageID = messageID
+	completed, err := d.publishCompletion(messageCompletion{
+		messageID: messageID, nativeType: "assistant", contentBlocks: blocks, toolSnapshots: tools,
+	})
+	completed.Diagnostics = append(completed.Diagnostics, diagnostics...)
+	return appendResult(result, completed), err
+}
+
+func canonicalNativeBlocks(native []nativeBlock) ([]responseevents.ContentBlock, []indexedToolSnapshot, []adapter.Diagnostic) {
+	blocks := make([]responseevents.ContentBlock, 0, len(native))
+	tools := make([]indexedToolSnapshot, 0, len(native))
+	var diagnostics []adapter.Diagnostic
+	for index, block := range native {
+		switch block.Type {
+		case "text":
+			if block.Text != "" {
+				blocks = append(blocks, responseevents.ContentBlock{Kind: responseevents.ContentBlockText, Text: block.Text})
+			}
+		case "tool_use":
+			canonical, diagnostic := canonicalNativeTool(block)
+			if diagnostic != nil {
+				diagnostics = append(diagnostics, *diagnostic)
+				continue
+			}
+			blocks = append(blocks, canonical)
+			tools = append(tools, indexedToolSnapshot{index: index, block: canonical})
+		}
+	}
+	return blocks, tools, diagnostics
+}
+
+func canonicalNativeTool(block nativeBlock) (responseevents.ContentBlock, *adapter.Diagnostic) {
+	toolID, toolName := strings.TrimSpace(block.ID), strings.TrimSpace(block.Name)
+	if toolID == "" || toolName == "" {
+		return responseevents.ContentBlock{}, &adapter.Diagnostic{Code: "claude_invalid_tool_snapshot", Message: "Claude emitted a complete tool block without stable identity"}
+	}
+	canonical := responseevents.ContentBlock{Kind: responseevents.ContentBlockToolRequest, ToolCallID: toolID, ToolName: toolName}
+	if len(block.Input) == 0 {
+		return canonical, nil
+	}
+	if len(block.Input) > maximumToolInputBytes {
+		return canonical, &adapter.Diagnostic{Code: "claude_tool_input_too_large", Message: "Claude tool input exceeded the safe summary boundary"}
+	}
+	if summary, ok := safeJSONSummary(block.Input); ok {
+		canonical.ArgumentsSummary = json.RawMessage(summary)
+		return canonical, nil
+	}
+	return canonical, &adapter.Diagnostic{Code: "claude_invalid_tool_input", Message: "Claude tool input did not form a valid safe summary"}
+}
+
+func (d *decoder) publishPendingCompletion() (adapter.DecodeResult, error) {
+	if d.pendingCompletion == nil {
+		return adapter.DecodeResult{}, nil
+	}
+	completion := *d.pendingCompletion
+	d.pendingCompletion = nil
+	return d.publishCompletion(completion)
+}
+
+func (d *decoder) publishCompletion(completion messageCompletion) (adapter.DecodeResult, error) {
+	payload, err := marshalPayload(responseevents.MessagePayload{Role: "assistant", ContentBlocks: completion.contentBlocks})
 	if err != nil {
 		return adapter.DecodeResult{}, err
 	}
-	return d.withRunStart(adapter.DecodeResult{Drafts: []responseevents.Draft{{
-		Kind: responseevents.KindMessage, Phase: responseevents.PhaseCompleted, ItemID: d.stableMessageID(), ProviderSessionRef: d.sessionRef,
-		Provenance: provenance("message_stop", responseevents.RepresentationSnapshot), Payload: payload,
-	}}}), nil
+	if d.completedMessages[completion.messageID] == string(payload) {
+		return adapter.DecodeResult{}, nil
+	}
+	result, err := d.publishToolSnapshots(completion)
+	if err != nil {
+		return result, err
+	}
+	d.completedMessages[completion.messageID] = string(payload)
+	result.Drafts = append(result.Drafts, responseevents.Draft{
+		Kind: responseevents.KindMessage, Phase: responseevents.PhaseCompleted, ItemID: completion.messageID, ProviderSessionRef: d.sessionRef,
+		Provenance: provenance(completion.nativeType, responseevents.RepresentationSnapshot), Payload: payload,
+	})
+	return d.withRunStart(result), nil
+}
+
+func (d *decoder) publishToolSnapshots(completion messageCompletion) (adapter.DecodeResult, error) {
+	var result adapter.DecodeResult
+	for _, tool := range completion.toolSnapshots {
+		body := responseevents.ToolPayload{ToolCallID: tool.block.ToolCallID, ToolName: tool.block.ToolName, Status: "completed", ArgumentsSummary: tool.block.ArgumentsSummary}
+		payload, err := marshalPayload(body)
+		if err != nil {
+			return result, err
+		}
+		itemID := toolItemID(completion.messageID, tool.index)
+		if d.completedTools[itemID] == string(payload) {
+			continue
+		}
+		d.completedTools[itemID] = string(payload)
+		result.Drafts = append(result.Drafts, responseevents.Draft{
+			Kind: responseevents.KindTool, Phase: responseevents.PhaseCompleted, ItemID: itemID, ParentItemID: completion.messageID, ProviderSessionRef: d.sessionRef,
+			Provenance: provenance(completion.nativeType, responseevents.RepresentationSnapshot), Payload: payload,
+		})
+	}
+	return result, nil
 }
 
 func (d *decoder) messageDelta(index int, text string) (adapter.DecodeResult, error) {
@@ -308,6 +457,9 @@ func (d *decoder) toolSnapshot(index int, phase responseevents.Phase) (adapter.D
 	if err != nil {
 		return adapter.DecodeResult{}, err
 	}
+	if phase == responseevents.PhaseCompleted {
+		d.completedTools[d.toolItemID(index)] = string(payload)
+	}
 	return d.withRunStart(adapter.DecodeResult{Drafts: []responseevents.Draft{{
 		Kind: responseevents.KindTool, Phase: phase, ItemID: d.toolItemID(index), ParentItemID: d.stableMessageID(), ProviderSessionRef: d.sessionRef,
 		Provenance: provenance("content_block_"+phaseName(phase), responseevents.RepresentationSnapshot), Payload: payload,
@@ -339,7 +491,11 @@ func (d *decoder) stableMessageID() string {
 }
 
 func (d *decoder) toolItemID(index int) string {
-	return d.stableMessageID() + "/content-block/" + strconv.Itoa(index)
+	return toolItemID(d.stableMessageID(), index)
+}
+
+func toolItemID(messageID string, index int) string {
+	return messageID + "/content-block/" + strconv.Itoa(index)
 }
 
 func fallbackMessageID(input adapter.DecoderContext) string {

--- a/pkg/workers/provider/claude/testdata/content_blocks.jsonl
+++ b/pkg/workers/provider/claude/testdata/content_blocks.jsonl
@@ -1,0 +1,11 @@
+{"type":"system","subtype":"init","session_id":"claude-session-42"}
+{"type":"stream_event","session_id":"claude-session-42","event":{"type":"message_start","message":{"id":"msg_01","role":"assistant","content":[]}}}
+{"type":"stream_event","session_id":"claude-session-42","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}}
+{"type":"stream_event","session_id":"claude-session-42","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello "}}}
+{"type":"stream_event","session_id":"claude-session-42","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"world"}}}
+{"type":"stream_event","session_id":"claude-session-42","event":{"type":"content_block_stop","index":0}}
+{"type":"stream_event","session_id":"claude-session-42","event":{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_42","name":"weather","input":{}}}}
+{"type":"stream_event","session_id":"claude-session-42","event":{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"city\":"}}}
+{"type":"stream_event","session_id":"claude-session-42","event":{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"Oslo\",\"api_token\":\"fixture-secret\"}"}}}
+{"type":"stream_event","session_id":"claude-session-42","event":{"type":"content_block_stop","index":1}}
+{"type":"stream_event","session_id":"claude-session-42","event":{"type":"message_stop"}}

--- a/pkg/workers/provider/claude/testdata/control_records.jsonl
+++ b/pkg/workers/provider/claude/testdata/control_records.jsonl
@@ -1,0 +1,13 @@
+{"type":"system","subtype":"init","session_id":"claude-session-controls"}
+{"type":"system","subtype":"api_retry","session_id":"claude-session-controls","attempt":2,"retry_delay_ms":1500,"error_status":"429","error":{"message":"sk-claude-fixture-secret"}}
+{"type":"stream_event","session_id":"claude-session-controls","parent_tool_use_id":"toolu_parent","event":{"type":"message_start","message":{"id":"msg_subagent","role":"assistant","content":[]}}}
+{"type":"stream_event","session_id":"claude-session-controls","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}}
+{"type":"stream_event","session_id":"claude-session-controls","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"stable preview"}}}
+{"type":"system","subtype":"compact_boundary","session_id":"claude-session-controls","compact_metadata":{"trigger":"auto","pre_tokens":1234,"transcript":"private compacted transcript"}}
+{"type":"stream_event","session_id":"claude-session-controls","event":{"type":"content_block_stop","index":0}}
+{"type":"stream_event","session_id":"claude-session-controls","event":{"type":"message_stop"}}
+{"type":"assistant","session_id":"claude-session-controls","parent_tool_use_id":"toolu_parent","message":{"id":"msg_subagent","role":"assistant","content":[{"type":"text","text":"stable final"}]}}
+{"type":"future_shape","prompt":"private future prompt","token":"sk-claude-fixture-secret"}
+{"type":"future_shape","prompt":"private future prompt"
+{"type":"assistant","session_id":"claude-session-controls","message":{"id":"msg_without_parent","role":"assistant","content":[{"type":"text","text":"later valid completion"}]}}
+{"type":"assistant","session_id":"claude-session-controls","parent_tool_use_id":42,"message":{"id":"msg_malformed_parent","role":"assistant","content":[{"type":"text","text":"malformed attribution omitted"}]}}

--- a/pkg/workers/provider/claude/testdata/invalid_tool_input.jsonl
+++ b/pkg/workers/provider/claude/testdata/invalid_tool_input.jsonl
@@ -1,0 +1,8 @@
+{"type":"stream_event","session_id":"claude-session-42","event":{"type":"message_start","message":{"id":"msg_recovery","role":"assistant","content":[]}}}
+{"type":"stream_event","session_id":"claude-session-42","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_bad","name":"lookup","input":{}}}}
+{"type":"stream_event","session_id":"claude-session-42","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{invalid private prompt and credential"}}}
+{"type":"stream_event","session_id":"claude-session-42","event":{"type":"content_block_stop","index":0}}
+{"type":"stream_event","session_id":"claude-session-42","event":{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}}
+{"type":"stream_event","session_id":"claude-session-42","event":{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Recovered"}}}
+{"type":"stream_event","session_id":"claude-session-42","event":{"type":"content_block_stop","index":1}}
+{"type":"stream_event","session_id":"claude-session-42","event":{"type":"message_stop"}}

--- a/pkg/workers/provider/claude/testdata/snapshot_mixed.jsonl
+++ b/pkg/workers/provider/claude/testdata/snapshot_mixed.jsonl
@@ -1,0 +1,10 @@
+{"type":"stream_event","session_id":"claude-session-snapshot","event":{"type":"message_start","message":{"id":"msg_mixed","role":"assistant","content":[]}}}
+{"type":"stream_event","session_id":"claude-session-snapshot","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}}
+{"type":"stream_event","session_id":"claude-session-snapshot","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"draft first"}}}
+{"type":"stream_event","session_id":"claude-session-snapshot","event":{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_mixed","name":"lookup","input":{}}}}
+{"type":"stream_event","session_id":"claude-session-snapshot","event":{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\"safe\"}"}}}
+{"type":"stream_event","session_id":"claude-session-snapshot","event":{"type":"content_block_stop","index":1}}
+{"type":"stream_event","session_id":"claude-session-snapshot","event":{"type":"content_block_start","index":2,"content_block":{"type":"text","text":""}}}
+{"type":"stream_event","session_id":"claude-session-snapshot","event":{"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"draft last"}}}
+{"type":"stream_event","session_id":"claude-session-snapshot","event":{"type":"message_stop"}}
+{"type":"assistant","session_id":"claude-session-snapshot","message":{"id":"msg_mixed","role":"assistant","content":[{"type":"text","text":"final first"},{"type":"tool_use","id":"toolu_mixed","name":"lookup","input":{"query":"safe"}},{"type":"text","text":"final last"}]}}

--- a/pkg/workers/provider/claude/testdata/snapshot_text.jsonl
+++ b/pkg/workers/provider/claude/testdata/snapshot_text.jsonl
@@ -1,0 +1,9 @@
+{"type":"system","subtype":"init","session_id":"claude-session-snapshot"}
+{"type":"stream_event","session_id":"claude-session-snapshot","event":{"type":"message_start","message":{"id":"msg_text","role":"assistant","content":[]}}}
+{"type":"stream_event","session_id":"claude-session-snapshot","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}}
+{"type":"stream_event","session_id":"claude-session-snapshot","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"draft text"}}}
+{"type":"stream_event","session_id":"claude-session-snapshot","event":{"type":"content_block_stop","index":0}}
+{"type":"stream_event","session_id":"claude-session-snapshot","event":{"type":"message_stop"}}
+{"type":"assistant","session_id":"claude-session-snapshot","message":{"id":"msg_text","role":"assistant","content":[{"type":"text","text":"authoritative text"}]}}
+{"type":"assistant","session_id":"claude-session-snapshot","message":{"id":"msg_text","role":"assistant","content":[{"type":"text","text":"authoritative text"}]}}
+{"type":"assistant","session_id":"claude-session-snapshot","message":{"id":"msg_text_2","role":"assistant","content":[{"type":"text","text":"later message"}]}}

--- a/pkg/workers/provider/claude/testdata/snapshot_tool.jsonl
+++ b/pkg/workers/provider/claude/testdata/snapshot_tool.jsonl
@@ -1,0 +1,7 @@
+{"type":"stream_event","session_id":"claude-session-snapshot","event":{"type":"message_start","message":{"id":"msg_tool","role":"assistant","content":[]}}}
+{"type":"stream_event","session_id":"claude-session-snapshot","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_snapshot","name":"weather","input":{}}}}
+{"type":"stream_event","session_id":"claude-session-snapshot","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"city\":\"Oslo\"}"}}}
+{"type":"stream_event","session_id":"claude-session-snapshot","event":{"type":"content_block_stop","index":0}}
+{"type":"stream_event","session_id":"claude-session-snapshot","event":{"type":"message_stop"}}
+{"type":"assistant","session_id":"claude-session-snapshot","message":{"id":"msg_tool","role":"assistant","content":[{"type":"tool_use","id":"toolu_snapshot","name":"weather","input":{"city":"Bergen","api_token":"snapshot-secret"}}]}}
+{"type":"assistant","session_id":"claude-session-snapshot","message":{"id":"msg_tool","role":"assistant","content":[{"type":"tool_use","id":"toolu_snapshot","name":"weather","input":{"city":"Bergen","api_token":"snapshot-secret"}}]}}

--- a/pkg/workers/provider/commandenv/environment.go
+++ b/pkg/workers/provider/commandenv/environment.go
@@ -1,0 +1,32 @@
+// Package commandenv owns the shared subprocess environment policy for CLI providers.
+package commandenv
+
+import (
+	"os"
+
+	workerprocess "github.com/portpowered/infinite-you/pkg/workers/process"
+)
+
+var automationDefaults = []workerprocess.CommandEnvEntry{
+	{Name: "GIT_EDITOR", Value: "true"},
+	{Name: "GIT_SEQUENCE_EDITOR", Value: "true"},
+	{Name: "GIT_MERGE_AUTOEDIT", Value: "no"},
+	{Name: "GIT_TERMINAL_PROMPT", Value: "0"},
+	{Name: "EDITOR", Value: "true"},
+	{Name: "VISUAL", Value: "true"},
+}
+
+// Build merges environment sources with deterministic precedence: process
+// environment, provider variables, then non-interactive automation defaults.
+func Build(envVars map[string]string) []string {
+	return workerprocess.MergeCommandEnv(
+		os.Environ(),
+		workerprocess.CommandEnvEntriesFromMap(envVars),
+		automationDefaults,
+	)
+}
+
+// AutomationDefaults returns a copy of the enforced non-interactive defaults.
+func AutomationDefaults() []workerprocess.CommandEnvEntry {
+	return append([]workerprocess.CommandEnvEntry(nil), automationDefaults...)
+}

--- a/pkg/workers/provider/commandenv/environment_test.go
+++ b/pkg/workers/provider/commandenv/environment_test.go
@@ -1,0 +1,39 @@
+package commandenv_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/workers/provider/commandenv"
+)
+
+func TestBuildEnforcesAutomationDefaultsAfterProviderOverrides(t *testing.T) {
+	t.Setenv("GIT_EDITOR", "vim")
+	env := commandenv.Build(map[string]string{
+		"GIT_EDITOR":               "nano",
+		"GIT_TERMINAL_PROMPT":      "1",
+		"AGENT_FACTORY_CUSTOM_ENV": "present",
+	})
+
+	assertEnvValue(t, env, "GIT_EDITOR", "true")
+	assertEnvValue(t, env, "GIT_SEQUENCE_EDITOR", "true")
+	assertEnvValue(t, env, "GIT_TERMINAL_PROMPT", "0")
+	assertEnvValue(t, env, "AGENT_FACTORY_CUSTOM_ENV", "present")
+	if len(commandenv.AutomationDefaults()) == 0 {
+		t.Fatal("AutomationDefaults() returned no defaults")
+	}
+}
+
+func assertEnvValue(t *testing.T, env []string, name, want string) {
+	t.Helper()
+	prefix := name + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			if got := strings.TrimPrefix(entry, prefix); got != want {
+				t.Fatalf("%s = %q, want %q", name, got, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("environment does not contain %s", name)
+}

--- a/pkg/workers/provider/inference_progress.go
+++ b/pkg/workers/provider/inference_progress.go
@@ -58,6 +58,16 @@ type InferenceProgressFragment struct {
 	ProviderSessionRef *interfaces.ProviderSessionMetadata
 	ExternalEventType  string
 	Metadata           map[string]string
+	CanonicalDraft     any
+}
+
+// CanonicalDraftFragment carries one provider-native canonical response draft
+// to the session-owned publisher without flattening it into a legacy fragment.
+func CanonicalDraftFragment(dispatchID string, draft any) InferenceProgressFragment {
+	return InferenceProgressFragment{
+		DispatchID:     strings.TrimSpace(dispatchID),
+		CanonicalDraft: draft,
+	}
 }
 
 // InferenceProgressPublisher receives provider progress fragments for one live

--- a/pkg/workers/provider/inference_provider.go
+++ b/pkg/workers/provider/inference_provider.go
@@ -100,6 +100,32 @@ func WithInferenceProgressPublisher(publisher InferenceProgressPublisher) Script
 	}
 }
 
+// ResponseStreamExecutor runs a provider-owned structured response lifecycle
+// without making the core provider package depend on Factory Session types.
+type ResponseStreamExecutor interface {
+	Supports(provider string) bool
+	Execute(context.Context, interfaces.ProviderInferenceRequest, bool, CommandRunner, InferenceProgressPublisher, logging.Logger) ResponseStreamExecutionResult
+}
+
+// ResponseStreamExecutionResult carries the structured execution outcome back
+// to the provider boundary for existing diagnostics and failure publication.
+type ResponseStreamExecutionResult struct {
+	Response       interfaces.InferenceResponse
+	Request        CommandRequest
+	Command        CommandResult
+	FailureType    interfaces.WorkFailureType
+	FailureMessage string
+	FailureSession *interfaces.ProviderSessionMetadata
+	Err            error
+}
+
+// WithResponseStreamExecutor injects structured provider mode selection.
+func WithResponseStreamExecutor(executor ResponseStreamExecutor) ScriptWrapProviderOption {
+	return func(p *ScriptWrapProvider) {
+		p.responseStreamExecutor = executor
+	}
+}
+
 // WithMaterializeOptions configures dispatch-time content URL materialization (used by Codex image args).
 func WithMaterializeOptions(opts *materialize.Options) ScriptWrapProviderOption {
 	return func(p *ScriptWrapProvider) {
@@ -120,7 +146,8 @@ type ScriptWrapProvider struct {
 	Logger logging.Logger
 	exec   CommandRunner
 
-	progressPublisher InferenceProgressPublisher
+	progressPublisher      InferenceProgressPublisher
+	responseStreamExecutor ResponseStreamExecutor
 }
 
 func (p *ScriptWrapProvider) commandExec() CommandRunner {
@@ -166,6 +193,9 @@ func (p *ScriptWrapProvider) Execute(ctx context.Context, req interfaces.RunnerE
 
 	logger.Info("inferencer: request starting",
 		providerLogFields(req, "model", req.Model)...)
+	if p.progressPublisher != nil && p.responseStreamExecutor != nil && p.responseStreamExecutor.Supports(req.ModelProvider) {
+		return p.executeStructuredResponseStream(ctx, req, logger)
+	}
 
 	behavior := providerBehaviorFor(req.ModelProvider, logger)
 	buildCtx := &ProviderBuildContext{
@@ -238,6 +268,35 @@ func (p *ScriptWrapProvider) Execute(ctx context.Context, req interfaces.RunnerE
 		ProviderSession: providerSession,
 		Diagnostics:     commandDiagnostics,
 	}, nil
+}
+
+func (p *ScriptWrapProvider) executeStructuredResponseStream(
+	ctx context.Context,
+	req interfaces.ProviderInferenceRequest,
+	logger logging.Logger,
+) (interfaces.InferenceResponse, error) {
+	started := time.Now()
+	result := p.responseStreamExecutor.Execute(ctx, req, p.SkipPermissions, p.exec, p.progressPublisher, logger)
+	duration := time.Since(started)
+	diagnostics := commandDiagnostics(result.Request, result.Command, duration, false)
+	if result.Err != nil || result.FailureType != "" {
+		failureType := result.FailureType
+		if failureType == "" {
+			failureType = interfaces.WorkFailureTypeUnknown
+		}
+		message := strings.TrimSpace(result.FailureMessage)
+		if message == "" {
+			message = "Provider invocation failed."
+		}
+		providerErr := newProviderErrorWithDiagnostics(failureType, message, result.Err, result.FailureSession, diagnostics)
+		p.publishFailureFragment(req.Dispatch.DispatchID, result.FailureSession, providerErr)
+		return interfaces.InferenceResponse{}, providerErr
+	}
+	result.Response.Diagnostics = diagnostics
+	logger.Info("inferencer: request completed",
+		appendProviderSessionLogFields(providerLogFields(req, "output_len", len(result.Response.Content)), result.Response.ProviderSession)...)
+	p.publishCompletedFragment(req.Dispatch.DispatchID, result.Response.ProviderSession)
+	return result.Response, nil
 }
 
 // ContainsStopToken checks whether the output text contains the given stop token.

--- a/pkg/workers/provider/inference_provider.go
+++ b/pkg/workers/provider/inference_provider.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -14,6 +13,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/logging"
 	"github.com/portpowered/infinite-you/pkg/workcontent/materialize"
 	workerprocess "github.com/portpowered/infinite-you/pkg/workers/process"
+	"github.com/portpowered/infinite-you/pkg/workers/provider/commandenv"
 	cursorpkg "github.com/portpowered/infinite-you/pkg/workers/provider/cursor"
 )
 
@@ -45,14 +45,7 @@ const (
 	providerSessionKindResponseID     = "response_id"
 )
 
-var providerAutomationEnvDefaults = []workerprocess.CommandEnvEntry{
-	{Name: "GIT_EDITOR", Value: "true"},
-	{Name: "GIT_SEQUENCE_EDITOR", Value: "true"},
-	{Name: "GIT_MERGE_AUTOEDIT", Value: "no"},
-	{Name: "GIT_TERMINAL_PROMPT", Value: "0"},
-	{Name: "EDITOR", Value: "true"},
-	{Name: "VISUAL", Value: "true"},
-}
+var providerAutomationEnvDefaults = commandenv.AutomationDefaults()
 
 var providerSessionPatterns = []struct {
 	kind    string
@@ -194,6 +187,11 @@ func (p *ScriptWrapProvider) Execute(ctx context.Context, req interfaces.RunnerE
 	logger.Info("inferencer: request starting",
 		providerLogFields(req, "model", req.Model)...)
 	if p.progressPublisher != nil && p.responseStreamExecutor != nil && p.responseStreamExecutor.Supports(req.ModelProvider) {
+		if strings.EqualFold(strings.TrimSpace(req.ModelProvider), string(interfaces.ModelProviderClaude)) {
+			if err := unsupportedImageContentError(req.InputTokens, "model provider claude"); err != nil {
+				return providerRequestValidationFailure(req, err, logger)
+			}
+		}
 		return p.executeStructuredResponseStream(ctx, req, logger)
 	}
 
@@ -205,15 +203,7 @@ func (p *ScriptWrapProvider) Execute(ctx context.Context, req interfaces.RunnerE
 	defer buildCtx.release()
 	args, err := behavior.BuildArgs(ctx, req, p.SkipPermissions, buildCtx)
 	if err != nil {
-		logger.Error("inferencer: request argument validation failed",
-			providerLogFields(req, "error", err.Error())...)
-		return interfaces.InferenceResponse{}, newProviderErrorWithDiagnostics(
-			interfaces.WorkFailureTypePermanentBadRequest,
-			err.Error(),
-			err,
-			nil,
-			workDiagnosticsForInferenceRequest(req),
-		)
+		return providerRequestValidationFailure(req, err, logger)
 	}
 	execReq := behavior.BuildCommandRequest(req, args)
 	logger.Info("provider invocation prepared", providerPreparedLogFields(ctx, req, execReq)...)
@@ -312,7 +302,23 @@ func ContainsStopToken(output, stopToken string) bool {
 // buildProviderEnv merges subprocess environment sources with deterministic
 // precedence: process environment, provider env vars, then automation defaults.
 func buildProviderEnv(envVars map[string]string) []string {
-	return workerprocess.MergeCommandEnv(os.Environ(), workerprocess.CommandEnvEntriesFromMap(envVars), providerAutomationEnvDefaults)
+	return commandenv.Build(envVars)
+}
+
+func providerRequestValidationFailure(
+	req interfaces.ProviderInferenceRequest,
+	err error,
+	logger logging.Logger,
+) (interfaces.InferenceResponse, error) {
+	logger.Error("inferencer: request argument validation failed",
+		providerLogFields(req, "error", err.Error())...)
+	return interfaces.InferenceResponse{}, newProviderErrorWithDiagnostics(
+		interfaces.WorkFailureTypePermanentBadRequest,
+		err.Error(),
+		err,
+		nil,
+		workDiagnosticsForInferenceRequest(req),
+	)
 }
 
 // TODO: right now the stderr/stdout for the print prints out the entire response log for the stdout....

--- a/pkg/workers/provider/structured/executor.go
+++ b/pkg/workers/provider/structured/executor.go
@@ -1,0 +1,135 @@
+// Package structured wires provider-owned response adapters into subprocess execution.
+package structured
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/portpowered/infinite-you/pkg/factorysessions/responseevents"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/logging"
+	workerprocess "github.com/portpowered/infinite-you/pkg/workers/process"
+	workerprovider "github.com/portpowered/infinite-you/pkg/workers/provider"
+	"github.com/portpowered/infinite-you/pkg/workers/provider/adapter"
+	claudeadapter "github.com/portpowered/infinite-you/pkg/workers/provider/claude"
+)
+
+// Executor owns the registered structured provider adapters.
+type Executor struct {
+	registry *adapter.Registry
+}
+
+// NewExecutor constructs the production structured adapter registry.
+func NewExecutor() *Executor {
+	registry, err := adapter.NewRegistry(claudeadapter.NewAdapter())
+	if err != nil {
+		panic(fmt.Sprintf("register structured provider adapters: %v", err))
+	}
+	return &Executor{registry: registry}
+}
+
+// Supports reports whether provider has a registered structured adapter.
+func (e *Executor) Supports(provider string) bool {
+	if e == nil || e.registry == nil {
+		return false
+	}
+	_, err := e.registry.Lookup(adapter.Identity(provider))
+	return err == nil
+}
+
+// Execute runs the selected structured adapter and publishes correlated drafts
+// while leaving terminal failure policy at the parent provider boundary.
+func (e *Executor) Execute(
+	ctx context.Context,
+	req interfaces.ProviderInferenceRequest,
+	skipPermissions bool,
+	runner workerprovider.CommandRunner,
+	publisher workerprovider.InferenceProgressPublisher,
+	logger logging.Logger,
+) workerprovider.ResponseStreamExecutionResult {
+	result, executeErr := adapter.Execute(ctx, e.registry, commandRunner{runner: runner, logger: logger}, adapter.ExecuteInput{
+		Provider: adapter.Identity(req.ModelProvider),
+		Command:  adapter.CommandContext{Request: req, SkipPermissions: skipPermissions},
+		Decoder:  adapter.DecoderContext{RunID: req.Dispatch.DispatchID, DispatchID: req.Dispatch.DispatchID},
+		ObserveDraft: func(draft responseevents.Draft) {
+			if publisher != nil {
+				publisher(workerprovider.CanonicalDraftFragment(draft.DispatchID, draft))
+			}
+		},
+	})
+	output := workerprovider.ResponseStreamExecutionResult{
+		Response: result.Response, Request: result.Request, Command: result.Command, Err: executeErr,
+	}
+	if result.Failure != nil {
+		output.FailureType = result.Failure.Type
+		output.FailureMessage = result.Failure.Message
+		output.FailureSession = result.Failure.ProviderSession
+	}
+	return output
+}
+
+type commandRunner struct {
+	runner workerprovider.CommandRunner
+	logger logging.Logger
+}
+
+func (r commandRunner) Run(
+	ctx context.Context,
+	req workerprocess.CommandRequest,
+	observe func(adapter.Observation) error,
+) (workerprocess.CommandResult, error) {
+	switch r.runner.(type) {
+	case workerprovider.InferenceProgressPublishingCommandRunner, *workerprovider.InferenceProgressPublishingCommandRunner,
+		workerprocess.ExecCommandRunner, *workerprocess.ExecCommandRunner:
+		return runObservedCommand(ctx, req, observe, r.logger)
+	}
+	runner := r.runner
+	if runner == nil {
+		return runObservedCommand(ctx, req, observe, r.logger)
+	}
+	result, err := runner.Run(ctx, req)
+	if len(result.Stdout) > 0 {
+		err = observeResult(adapter.OutputStreamStdout, result.Stdout, observe, err)
+	}
+	if len(result.Stderr) > 0 {
+		err = observeResult(adapter.OutputStreamStderr, result.Stderr, observe, err)
+	}
+	return result, err
+}
+
+func observeResult(stream adapter.OutputStream, chunk []byte, observe func(adapter.Observation) error, runErr error) error {
+	observeErr := observe(adapter.Observation{Stream: stream, Chunk: chunk})
+	if runErr != nil {
+		return runErr
+	}
+	return observeErr
+}
+
+func runObservedCommand(
+	ctx context.Context,
+	req workerprocess.CommandRequest,
+	observe func(adapter.Observation) error,
+	logger logging.Logger,
+) (workerprocess.CommandResult, error) {
+	var mu sync.Mutex
+	var observeErr error
+	runner := workerprocess.StreamingExecCommandRunner{Logger: logger, Observer: func(stream string, chunk []byte) {
+		mu.Lock()
+		defer mu.Unlock()
+		if observeErr == nil {
+			observeErr = observe(adapter.Observation{Stream: adapter.OutputStream(strings.TrimSpace(stream)), Chunk: chunk})
+		}
+	}}
+	result, err := runner.Run(ctx, req)
+	mu.Lock()
+	defer mu.Unlock()
+	if err == nil {
+		err = observeErr
+	}
+	return result, err
+}
+
+var _ workerprovider.ResponseStreamExecutor = (*Executor)(nil)
+var _ adapter.StreamingCommandRunner = commandRunner{}

--- a/pkg/workers/provider/structured/executor_test.go
+++ b/pkg/workers/provider/structured/executor_test.go
@@ -1,0 +1,161 @@
+package structured_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/factorysessions/responseevents"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	workerprovider "github.com/portpowered/infinite-you/pkg/workers/provider"
+	"github.com/portpowered/infinite-you/pkg/workers/provider/structured"
+)
+
+func TestProductionProviderBoundarySelectsStructuredClaudeOnlyForResponseStream(t *testing.T) {
+	req := interfaces.ProviderInferenceRequest{
+		Dispatch:      interfaces.WorkDispatch{DispatchID: "dispatch-claude-production"},
+		ModelProvider: string(interfaces.ModelProviderClaude), Model: "claude-sonnet",
+		SessionID: "claude-session-123", UserMessage: "private prompt",
+	}
+
+	finalRunner := &recordingRunner{result: workerprovider.CommandResult{Stdout: []byte("authoritative answer")}}
+	finalProvider := workerprovider.NewScriptWrapProvider(workerprovider.WithProviderCommandRunner(finalRunner))
+	finalResponse, err := finalProvider.Infer(context.Background(), req)
+	if err != nil {
+		t.Fatalf("final-only Infer: %v", err)
+	}
+	if finalResponse.Content != "authoritative answer" || slices.Contains(finalRunner.request.Args, "--include-partial-messages") {
+		t.Fatalf("final-only response/request = %#v / %#v", finalResponse, finalRunner.request)
+	}
+
+	streamRunner := &recordingRunner{result: workerprovider.CommandResult{Stdout: []byte(structuredClaudeOutput())}}
+	var published []workerprovider.InferenceProgressFragment
+	streamProvider := workerprovider.NewScriptWrapProvider(
+		workerprovider.WithProviderCommandRunner(streamRunner),
+		workerprovider.WithInferenceProgressPublisher(func(fragment workerprovider.InferenceProgressFragment) {
+			published = append(published, fragment)
+		}),
+		workerprovider.WithResponseStreamExecutor(structured.NewExecutor()),
+	)
+	streamResponse, err := streamProvider.Infer(context.Background(), req)
+	if err != nil {
+		t.Fatalf("response-stream Infer: %v", err)
+	}
+	if streamResponse.Content != finalResponse.Content || streamResponse.ProviderSession == nil || streamResponse.ProviderSession.ID != "claude-session-123" {
+		t.Fatalf("response-stream final response = %#v", streamResponse)
+	}
+	if !slices.Contains(streamRunner.request.Args, "stream-json") || !slices.Contains(streamRunner.request.Args, "--include-partial-messages") {
+		t.Fatalf("response-stream args = %#v", streamRunner.request.Args)
+	}
+	assertStablePublishedMessage(t, published)
+}
+
+func TestExecutorStreamsRealCommandAndReportsSupport(t *testing.T) {
+	executor := structured.NewExecutor()
+	if !executor.Supports(" CLAUDE ") || executor.Supports("unknown-provider") {
+		t.Fatalf("Supports() did not use normalized registered identities")
+	}
+	var nilExecutor *structured.Executor
+	if nilExecutor.Supports("claude") {
+		t.Fatal("nil executor unexpectedly supports Claude")
+	}
+
+	fixturePath := filepath.Join(t.TempDir(), "claude-output.jsonl")
+	if err := os.WriteFile(fixturePath, []byte(structuredClaudeOutput()), 0o600); err != nil {
+		t.Fatalf("write Claude fixture: %v", err)
+	}
+	commandDir := t.TempDir()
+	writeClaudeFixtureCommand(t, commandDir)
+	t.Setenv("PATH", commandDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	var published []workerprovider.InferenceProgressFragment
+	result := executor.Execute(context.Background(), interfaces.ProviderInferenceRequest{
+		Dispatch:      interfaces.WorkDispatch{DispatchID: "dispatch-real-command"},
+		ModelProvider: string(interfaces.ModelProviderClaude), UserMessage: "private prompt",
+		EnvVars: map[string]string{"CLAUDE_FIXTURE": fixturePath},
+	}, false, nil, func(fragment workerprovider.InferenceProgressFragment) {
+		published = append(published, fragment)
+	}, nil)
+	if result.Err != nil || result.FailureType != "" || result.Response.Content != "authoritative answer" {
+		t.Fatalf("real command result = %#v", result)
+	}
+	if len(published) == 0 {
+		t.Fatal("real streaming command published no canonical drafts")
+	}
+}
+
+func TestExecutorReturnsStructuredFailureFromBufferedRunner(t *testing.T) {
+	executor := structured.NewExecutor()
+	result := executor.Execute(context.Background(), interfaces.ProviderInferenceRequest{
+		Dispatch:      interfaces.WorkDispatch{DispatchID: "dispatch-failure"},
+		ModelProvider: string(interfaces.ModelProviderClaude), UserMessage: "private prompt",
+	}, false, &recordingRunner{result: workerprovider.CommandResult{
+		Stdout: []byte(`{"type":"system","subtype":"api_retry","attempt":2,"retry_delay_ms":1000}` + "\n"),
+		Stderr: []byte("private provider warning"), ExitCode: 1,
+	}}, nil, nil)
+	if result.FailureType == "" || result.FailureMessage == "" {
+		t.Fatalf("failure result = %#v", result)
+	}
+}
+
+func writeClaudeFixtureCommand(t *testing.T, dir string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		path := filepath.Join(dir, "claude.cmd")
+		if err := os.WriteFile(path, []byte("@type \"%CLAUDE_FIXTURE%\"\r\n"), 0o600); err != nil {
+			t.Fatalf("write Claude command: %v", err)
+		}
+		return
+	}
+	path := filepath.Join(dir, "claude")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\ncat \"$CLAUDE_FIXTURE\"\n"), 0o700); err != nil {
+		t.Fatalf("write Claude command: %v", err)
+	}
+}
+
+func assertStablePublishedMessage(t *testing.T, fragments []workerprovider.InferenceProgressFragment) {
+	t.Helper()
+	var delta, completed *responseevents.Draft
+	for _, fragment := range fragments {
+		draft, ok := fragment.CanonicalDraft.(responseevents.Draft)
+		if !ok || draft.ItemID != "msg-production" {
+			continue
+		}
+		if draft.Phase == responseevents.PhaseDelta {
+			delta = &draft
+		}
+		if draft.Phase == responseevents.PhaseCompleted {
+			completed = &draft
+		}
+	}
+	if delta == nil || completed == nil || delta.ItemID != completed.ItemID || delta.DispatchID != "dispatch-claude-production" {
+		t.Fatalf("published fragments = %#v, want correlated stable message lifecycle", fragments)
+	}
+}
+
+func structuredClaudeOutput() string {
+	return strings.Join([]string{
+		`{"type":"system","subtype":"init","session_id":"claude-session-123"}`,
+		`{"type":"stream_event","session_id":"claude-session-123","event":{"type":"message_start","message":{"id":"msg-production","role":"assistant","content":[]}}}`,
+		`{"type":"stream_event","session_id":"claude-session-123","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}}`,
+		`{"type":"stream_event","session_id":"claude-session-123","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"authoritative answer"}}}`,
+		`{"type":"stream_event","session_id":"claude-session-123","event":{"type":"content_block_stop","index":0}}`,
+		`{"type":"stream_event","session_id":"claude-session-123","event":{"type":"message_stop"}}`,
+		`{"type":"assistant","session_id":"claude-session-123","message":{"id":"msg-production","role":"assistant","content":[{"type":"text","text":"authoritative answer"}]}}`,
+		`{"type":"result","subtype":"success","is_error":false,"result":"authoritative answer","session_id":"claude-session-123"}`,
+	}, "\n") + "\n"
+}
+
+type recordingRunner struct {
+	request workerprovider.CommandRequest
+	result  workerprovider.CommandResult
+}
+
+func (r *recordingRunner) Run(_ context.Context, req workerprovider.CommandRequest) (workerprovider.CommandResult, error) {
+	r.request = req
+	return r.result, nil
+}

--- a/pkg/workers/provider/structured/executor_test.go
+++ b/pkg/workers/provider/structured/executor_test.go
@@ -2,6 +2,7 @@ package structured_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -20,6 +21,7 @@ func TestProductionProviderBoundarySelectsStructuredClaudeOnlyForResponseStream(
 		Dispatch:      interfaces.WorkDispatch{DispatchID: "dispatch-claude-production"},
 		ModelProvider: string(interfaces.ModelProviderClaude), Model: "claude-sonnet",
 		SessionID: "claude-session-123", UserMessage: "private prompt",
+		EnvVars: map[string]string{"GIT_EDITOR": "vim", "GIT_TERMINAL_PROMPT": "1"},
 	}
 
 	finalRunner := &recordingRunner{result: workerprovider.CommandResult{Stdout: []byte("authoritative answer")}}
@@ -51,7 +53,44 @@ func TestProductionProviderBoundarySelectsStructuredClaudeOnlyForResponseStream(
 	if !slices.Contains(streamRunner.request.Args, "stream-json") || !slices.Contains(streamRunner.request.Args, "--include-partial-messages") {
 		t.Fatalf("response-stream args = %#v", streamRunner.request.Args)
 	}
+	assertCommandEnv(t, streamRunner.request.Env, "GIT_EDITOR", "true")
+	assertCommandEnv(t, streamRunner.request.Env, "GIT_SEQUENCE_EDITOR", "true")
+	assertCommandEnv(t, streamRunner.request.Env, "GIT_TERMINAL_PROMPT", "0")
 	assertStablePublishedMessage(t, published)
+}
+
+func TestProductionResponseStreamClaudeRejectsImageBeforeRunner(t *testing.T) {
+	runner := &recordingRunner{result: workerprovider.CommandResult{Stdout: []byte(structuredClaudeOutput())}}
+	provider := workerprovider.NewScriptWrapProvider(
+		workerprovider.WithProviderCommandRunner(runner),
+		workerprovider.WithInferenceProgressPublisher(func(workerprovider.InferenceProgressFragment) {}),
+		workerprovider.WithResponseStreamExecutor(structured.NewExecutor()),
+	)
+
+	_, err := provider.Infer(context.Background(), interfaces.ProviderInferenceRequest{
+		Dispatch:      interfaces.WorkDispatch{DispatchID: "dispatch-claude-image"},
+		ModelProvider: string(interfaces.ModelProviderClaude),
+		UserMessage:   "inspect",
+		InputTokens: []any{interfaces.Token{ID: "token-1", Color: interfaces.TokenColor{Content: []interfaces.WorkContentPart{
+			{Type: interfaces.WorkContentPartTypeText, Text: "caption"},
+			{Type: interfaces.WorkContentPartTypeImage, File: "fixtures/mockup.png"},
+		}}}},
+	})
+	if err == nil {
+		t.Fatal("expected response-stream Claude image content to fail")
+	}
+	var providerErr *workerprovider.ProviderError
+	if !errors.As(err, &providerErr) {
+		t.Fatalf("expected ProviderError, got %T: %v", err, err)
+	}
+	if providerErr.Type != interfaces.WorkFailureTypePermanentBadRequest ||
+		!strings.Contains(providerErr.Message, "input_tokens[0].color.content[1].file") ||
+		!strings.Contains(providerErr.Message, "model provider claude") {
+		t.Fatalf("provider error = %#v", providerErr)
+	}
+	if runner.calls != 0 {
+		t.Fatalf("runner calls = %d, want 0", runner.calls)
+	}
 }
 
 func TestExecutorStreamsRealCommandAndReportsSupport(t *testing.T) {
@@ -153,9 +192,25 @@ func structuredClaudeOutput() string {
 type recordingRunner struct {
 	request workerprovider.CommandRequest
 	result  workerprovider.CommandResult
+	calls   int
 }
 
 func (r *recordingRunner) Run(_ context.Context, req workerprovider.CommandRequest) (workerprovider.CommandResult, error) {
+	r.calls++
 	r.request = req
 	return r.result, nil
+}
+
+func assertCommandEnv(t *testing.T, env []string, name, want string) {
+	t.Helper()
+	prefix := name + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			if got := strings.TrimPrefix(entry, prefix); got != want {
+				t.Fatalf("%s = %q, want %q", name, got, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("environment does not contain %s", name)
 }

--- a/tests/functional/providers/cli_worktree_passthrough_test.go
+++ b/tests/functional/providers/cli_worktree_passthrough_test.go
@@ -40,7 +40,15 @@ stopToken: COMPLETE
 Process the input task.
 `)
 	runner := testutil.NewProviderCommandRunner(
-		workers.CommandResult{Stdout: []byte("Done. COMPLETE")},
+		workers.CommandResult{Stdout: []byte(
+			`{"type":"stream_event","session_id":"session-worktree","event":{"type":"message_start","message":{"id":"msg-worktree","role":"assistant","content":[]}}}` + "\n" +
+				`{"type":"stream_event","session_id":"session-worktree","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}}` + "\n" +
+				`{"type":"stream_event","session_id":"session-worktree","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Done. COMPLETE"}}}` + "\n" +
+				`{"type":"stream_event","session_id":"session-worktree","event":{"type":"content_block_stop","index":0}}` + "\n" +
+				`{"type":"stream_event","session_id":"session-worktree","event":{"type":"message_stop"}}` + "\n" +
+				`{"type":"assistant","session_id":"session-worktree","message":{"id":"msg-worktree","role":"assistant","content":[{"type":"text","text":"Done. COMPLETE"}]}}` + "\n" +
+				`{"type":"result","subtype":"success","is_error":false,"result":"Done. COMPLETE","session_id":"session-worktree"}` + "\n",
+		)},
 	)
 
 	h := testutil.NewServiceTestHarness(t, dir,
@@ -67,6 +75,7 @@ Process the input task.
 	}
 	support.AssertArgsContainSequence(t, call.Args, []string{"--worktree", "my-feature-branch"})
 	support.AssertArgsContainSequence(t, call.Args, []string{"--model", "test-model"})
+	support.AssertArgsContainSequence(t, call.Args, []string{"--output-format", "stream-json", "--include-partial-messages"})
 	if len(call.Stdin) != 0 {
 		t.Fatalf("expected Claude prompt to stay in args, got stdin %q", string(call.Stdin))
 	}


### PR DESCRIPTION
{
  "project": "Claude Message and Content-Block Streaming Adapter",
  "branchName": "stream-b05-claude-content-block-adapter",
  "description": "Migrate Claude response-stream execution to structured partial messages and map native message/content-block records into stable canonical message and tool items. Complete assistant snapshots supersede accumulated deltas without duplication, retry and compaction boundaries normalize safely, and subagent attribution is retained only when Claude explicitly supplies it. The intent is to give consumers a coherent live Claude transcript while preserving the existing authoritative final invocation result.",
  "context": {
    "customerAsk": "Enable structured partial messages for Claude in response-stream mode, map content blocks to stable message and tool items, let complete assistant snapshots supersede accumulated deltas, normalize retry and compact boundaries safely, and retain subagent attribution only when supplied.",
    "problem": "Claude response-stream runs do not yet expose the provider's structured message lifecycle through the canonical response-event contract. Text and tool input can be flattened into generic fragments, identity can change across content-block updates, and complete messages can duplicate accumulated deltas. Retry, compaction, and optional subagent fields also lack a deliberate safe translation.",
    "solution": "Make response-stream-mode Claude invocations request structured stream JSON with partial messages, and add a Claude-owned stateful decoder that maps indexed text and tool-use blocks into canonical drafts with stable identities. Reconcile complete messages as authoritative snapshots, normalize retry and compact-boundary facts without owning policy, preserve only explicit subagent attribution, and prove the behavior with sanitized fixtures plus the shared adapter conformance suite."
  },
  "acceptanceCriteria": [
    "AC-1: A Claude invocation in response-stream mode requests structured stream output and partial messages; a non-response-stream invocation retains its existing final-response behavior.",
    "AC-2: Structured text and tool-input content-block updates map to canonical message/tool events with stable item and call identity across start, delta, completion, and final snapshot records.",
    "AC-3: A complete assistant snapshot is authoritative for its message and supersedes accumulated partial content without duplicated assistant text or a second logical tool request.",
    "AC-4: Claude retry and compact-boundary records map to schema-valid, bounded, safe normalized records without leaking raw provider payloads or moving retry/backoff policy into the adapter.",
    "AC-5: Subagent attribution is retained when explicitly supplied by Claude and omitted when absent; unknown or malformed additive records do not invent attribution or abort an otherwise successful stream.",
    "AC-6: Quality gates pass: typecheck/compile validation, lint, focused Claude adapter tests, provider adapter conformance tests, and the applicable short Go test suite."
  ],
  "userStories": [
    {
      "id": "stream-b05-claude-content-block-adapter-001",
      "title": "Stream structured Claude text and tool-input updates with stable identity",
      "description": "As a response-stream consumer, I want Claude text and tool input to arrive as correlated structured updates so that I can render live work without replacing items on every content-block event.",
      "acceptanceCriteria": [
        "Response-stream-mode Claude command construction requests structured stream JSON and partial messages, while the same invocation outside response-stream mode keeps the established final-output command behavior.",
        "Sanitized fixtures covering a message start and interleaved content-block start, delta, and stop records produce ordered, schema-valid canonical message and tool event drafts.",
        "Text deltas identify the same assistant message and content-block index from start through stop; repeated updates never allocate a new logical message item.",
        "A tool-use block retains Claude's supplied tool-use ID as the canonical tool call ID across block start, partial input updates, block completion, and the containing message.",
        "Chunked tool-input JSON is accumulated in order and exposed only as a bounded safe summary when valid; incomplete or invalid partial JSON never leaks the raw provider record and does not terminate later decoding.",
        "Provider session identity is preserved when supplied, and session-owned event ID, sequence, and recorded time remain outside the Claude decoder.",
        "Focused structured partial-message fixtures pass through chunked reads and explicit decoder flush.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented in 055fbd7c7 with structured Claude stream command selection, invocation-local content-block decoding, stable message/tool identity, bounded redacted tool-input summaries, chunk/flush fixtures, and authoritative final-result regression coverage."
    },
    {
      "id": "stream-b05-claude-content-block-adapter-002",
      "title": "Reconcile complete assistant snapshots without duplicate content",
      "description": "As a response-stream consumer, I want Claude's complete assistant message to supersede its partial preview so that the final transcript is authoritative and does not repeat text or tool requests.",
      "acceptanceCriteria": [
        "A fixture containing partial text deltas followed by the corresponding complete assistant message produces one stable message identity and one authoritative completed message snapshot with the provider's final ordered content blocks.",
        "Text already observed in deltas is not re-emitted as a new delta, appended twice to the snapshot, or returned as a second logical assistant message.",
        "A complete tool-use block reconciles with the earlier partial tool-input block by tool-use ID and content-block index, producing one logical tool request with the final bounded argument summary.",
        "When the complete snapshot differs from accumulated partial content, the snapshot wins without emitting corrective synthetic deltas; consumers that ignore all deltas still receive the complete assistant message.",
        "Repeated identical complete snapshots are idempotent, and a later complete message with a distinct provider message identity remains a distinct canonical item.",
        "The authoritative final inference response remains unchanged by response-event publication and is not reconstructed from partial deltas.",
        "Partial-plus-snapshot regression fixtures cover text-only, tool-only, and mixed ordered content blocks.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented in 5ee523cb7 with deferred message-stop fallback, authoritative native assistant snapshot reconciliation, idempotent message/tool snapshot publication, stable distinct-message identity, bounded final tool summaries, and text/tool/mixed regression fixtures."
    },
    {
      "id": "stream-b05-claude-content-block-adapter-003",
      "title": "Normalize Claude retry, compaction, and optional subagent context safely",
      "description": "As an operator consuming Claude streams, I want retry, compaction, and subagent context represented accurately and safely so that I can understand execution boundaries without seeing fabricated or sensitive provider details.",
      "acceptanceCriteria": [
        "Sanitized API retry fixtures map to schema-valid normalized retry/error or progress records with bounded public messages and only provider-supplied retry attempt or delay metadata.",
        "The Claude adapter reports retry facts but does not sleep, rerun the command, choose backoff, or change caller-owned terminal/retry policy.",
        "A compact-boundary fixture emits a safe normalized compaction observation and preserves subsequent message/content-block decoding and stable item identity; it does not expose the raw compacted transcript or provider payload.",
        "Explicit subagent identity or attribution supplied on a supported Claude message is retained on the corresponding normalized records; when the field is absent, empty, malformed, or on an unsupported record, attribution is omitted rather than inferred from surrounding events.",
        "Unknown additive event types and malformed records yield at most bounded safe diagnostics, do not disclose prompt text, tool arguments, credentials, or raw JSON, and do not abort a later valid completion.",
        "The Claude implementation passes the shared adapter conformance cases for command selection, chunking and flush, stable identities, authoritative snapshots, retry facts, malformed/unknown input, safe diagnostics, final success, and terminal failure.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented in 1c29c3700 with bounded API retry facts and failure classification, safe compaction observations, explicit parent-tool subagent attribution, malformed/unknown recovery, sanitized fixtures, and shared full-stream adapter conformance coverage."
    }
  ]
}
