### PR TITLE
interfaces-b05-generation-drift-and-staging-checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,10 @@ jobs:
         timeout-minutes: 10
         run: make deadcode
 
+      - name: Run contract validation and drift smoke verification
+        timeout-minutes: 10
+        run: make contracts-smoke
+
       - name: Run API smoke verification
         timeout-minutes: 10
         run: make api-smoke

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ define run_timed_step
 	exit $$status
 endef
 
-.PHONY: default build intall bundle-api generate-api generate-go-api generate-go-server-api generate-go-client-api generate-ui-api generate-wire wire-smoke api-smoke contracts-validate contracts-generate contracts-check docs-reference-check docs-reference-smoke test test-full test-functional test-functional-long verify-fast verify-pr verify-pr-inference verify-extended verify-build-contracts verify-tests run-concurrent-ui-verification-lanes run-sharded-ui-coverage verify test-ui-coverage test-ui-coverage-merge test-ui-browser-integration test-ui-durable-session-real-backend test-backend-coverage test-backend-functional test-backend-verification long-tests long-tests-managed-runtime long-tests-functional-runtime pr-inference-approval test-coverage-go script-timeout-companion-smoke-100 cron-time-work-smoke current-factory-watcher-switch-smoke release-surface-smoke artifact-contract-closeout lint backend-size pkg-maint pkg-file-count pkg-boundary durable-runtime-construction-check logging-boundary-check model-facade-check readme-check deadcode ui-deadcode test-race fmt vet deps deps-tidy init dashboard-verify typecheck release ci ci-typecheck ci-verify-build-contracts ci-verify-tests ui-deps ui-lint ui-build ui-test ui-integration-test ui-durable-session-real-backend-integration-test ui-test-coverage ui-replay-coverage-check ui-install-playwright ui-storybook ui-test-storybook ui-components-typecheck ui-components-test ui-components-storybook ui-components-boundary ui-components-dependency-direction ui-components-verify ui-verify-fresh-npm-install clean
+.PHONY: default build intall bundle-api generate-api generate-go-api generate-go-server-api generate-go-client-api generate-ui-api generate-wire wire-smoke api-smoke contracts-validate contracts-generate contracts-check contracts-smoke docs-reference-check docs-reference-smoke test test-full test-functional test-functional-long verify-fast verify-pr verify-pr-inference verify-extended verify-build-contracts verify-tests run-concurrent-ui-verification-lanes run-sharded-ui-coverage verify test-ui-coverage test-ui-coverage-merge test-ui-browser-integration test-ui-durable-session-real-backend test-backend-coverage test-backend-functional test-backend-verification long-tests long-tests-managed-runtime long-tests-functional-runtime pr-inference-approval test-coverage-go script-timeout-companion-smoke-100 cron-time-work-smoke current-factory-watcher-switch-smoke release-surface-smoke artifact-contract-closeout lint backend-size pkg-maint pkg-file-count pkg-boundary durable-runtime-construction-check logging-boundary-check model-facade-check readme-check deadcode ui-deadcode test-race fmt vet deps deps-tidy init dashboard-verify typecheck release ci ci-typecheck ci-verify-build-contracts ci-verify-tests ui-deps ui-lint ui-build ui-test ui-integration-test ui-durable-session-real-backend-integration-test ui-test-coverage ui-replay-coverage-check ui-install-playwright ui-storybook ui-test-storybook ui-components-typecheck ui-components-test ui-components-storybook ui-components-boundary ui-components-dependency-direction ui-components-verify ui-verify-fresh-npm-install clean
 
 default:
 	$(MAKE) generate-api
@@ -129,6 +129,15 @@ contracts-generate:
 
 contracts-check:
 	$(GO) run ./cmd/contractscheck -root .
+
+contracts-smoke:
+	$(GO) test ./internal/contract... ./cmd/contracts... -count=1 -timeout $(GO_TEST_TIMEOUT)
+	$(MAKE) contracts-validate
+	$(MAKE) contracts-check
+	$(MAKE) contracts-generate
+	$(MAKE) contracts-check
+	$(MAKE) contracts-generate
+	$(MAKE) contracts-check
 
 docs-reference-check:
 	$(GO) run ./cmd/markdown-linter docs/README.md docs/reference
@@ -270,6 +279,7 @@ verify-build-contracts:
 	$(MAKE) build
 	$(MAKE) lint
 	$(MAKE) ui-components-verify
+	$(MAKE) contracts-smoke
 	$(MAKE) api-smoke
 	$(MAKE) wire-smoke
 
@@ -308,6 +318,7 @@ ci-verify-build-contracts: ci-typecheck
 	$(MAKE) build
 	$(MAKE) lint
 	$(MAKE) ui-components-verify
+	$(MAKE) contracts-smoke
 	$(MAKE) api-smoke
 	$(MAKE) wire-smoke
 

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ define run_timed_step
 	exit $$status
 endef
 
-.PHONY: default build intall bundle-api generate-api generate-go-api generate-go-server-api generate-go-client-api generate-ui-api generate-wire wire-smoke api-smoke contracts-validate docs-reference-check docs-reference-smoke test test-full test-functional test-functional-long verify-fast verify-pr verify-pr-inference verify-extended verify-build-contracts verify-tests run-concurrent-ui-verification-lanes run-sharded-ui-coverage verify test-ui-coverage test-ui-coverage-merge test-ui-browser-integration test-ui-durable-session-real-backend test-backend-coverage test-backend-functional test-backend-verification long-tests long-tests-managed-runtime long-tests-functional-runtime pr-inference-approval test-coverage-go script-timeout-companion-smoke-100 cron-time-work-smoke current-factory-watcher-switch-smoke release-surface-smoke artifact-contract-closeout lint backend-size pkg-maint pkg-file-count pkg-boundary durable-runtime-construction-check logging-boundary-check model-facade-check readme-check deadcode ui-deadcode test-race fmt vet deps deps-tidy init dashboard-verify typecheck release ci ci-typecheck ci-verify-build-contracts ci-verify-tests ui-deps ui-lint ui-build ui-test ui-integration-test ui-durable-session-real-backend-integration-test ui-test-coverage ui-replay-coverage-check ui-install-playwright ui-storybook ui-test-storybook ui-components-typecheck ui-components-test ui-components-storybook ui-components-boundary ui-components-dependency-direction ui-components-verify ui-verify-fresh-npm-install clean
+.PHONY: default build intall bundle-api generate-api generate-go-api generate-go-server-api generate-go-client-api generate-ui-api generate-wire wire-smoke api-smoke contracts-validate contracts-generate docs-reference-check docs-reference-smoke test test-full test-functional test-functional-long verify-fast verify-pr verify-pr-inference verify-extended verify-build-contracts verify-tests run-concurrent-ui-verification-lanes run-sharded-ui-coverage verify test-ui-coverage test-ui-coverage-merge test-ui-browser-integration test-ui-durable-session-real-backend test-backend-coverage test-backend-functional test-backend-verification long-tests long-tests-managed-runtime long-tests-functional-runtime pr-inference-approval test-coverage-go script-timeout-companion-smoke-100 cron-time-work-smoke current-factory-watcher-switch-smoke release-surface-smoke artifact-contract-closeout lint backend-size pkg-maint pkg-file-count pkg-boundary durable-runtime-construction-check logging-boundary-check model-facade-check readme-check deadcode ui-deadcode test-race fmt vet deps deps-tidy init dashboard-verify typecheck release ci ci-typecheck ci-verify-build-contracts ci-verify-tests ui-deps ui-lint ui-build ui-test ui-integration-test ui-durable-session-real-backend-integration-test ui-test-coverage ui-replay-coverage-check ui-install-playwright ui-storybook ui-test-storybook ui-components-typecheck ui-components-test ui-components-storybook ui-components-boundary ui-components-dependency-direction ui-components-verify ui-verify-fresh-npm-install clean
 
 default:
 	$(MAKE) generate-api
@@ -123,6 +123,9 @@ api-smoke:
 
 contracts-validate:
 	$(GO) run ./cmd/contractsvalidate -root .
+
+contracts-generate:
+	$(GO) run ./cmd/contractsgenerate -root .
 
 docs-reference-check:
 	$(GO) run ./cmd/markdown-linter docs/README.md docs/reference

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ define run_timed_step
 	exit $$status
 endef
 
-.PHONY: default build intall bundle-api generate-api generate-go-api generate-go-server-api generate-go-client-api generate-ui-api generate-wire wire-smoke api-smoke contracts-validate contracts-generate docs-reference-check docs-reference-smoke test test-full test-functional test-functional-long verify-fast verify-pr verify-pr-inference verify-extended verify-build-contracts verify-tests run-concurrent-ui-verification-lanes run-sharded-ui-coverage verify test-ui-coverage test-ui-coverage-merge test-ui-browser-integration test-ui-durable-session-real-backend test-backend-coverage test-backend-functional test-backend-verification long-tests long-tests-managed-runtime long-tests-functional-runtime pr-inference-approval test-coverage-go script-timeout-companion-smoke-100 cron-time-work-smoke current-factory-watcher-switch-smoke release-surface-smoke artifact-contract-closeout lint backend-size pkg-maint pkg-file-count pkg-boundary durable-runtime-construction-check logging-boundary-check model-facade-check readme-check deadcode ui-deadcode test-race fmt vet deps deps-tidy init dashboard-verify typecheck release ci ci-typecheck ci-verify-build-contracts ci-verify-tests ui-deps ui-lint ui-build ui-test ui-integration-test ui-durable-session-real-backend-integration-test ui-test-coverage ui-replay-coverage-check ui-install-playwright ui-storybook ui-test-storybook ui-components-typecheck ui-components-test ui-components-storybook ui-components-boundary ui-components-dependency-direction ui-components-verify ui-verify-fresh-npm-install clean
+.PHONY: default build intall bundle-api generate-api generate-go-api generate-go-server-api generate-go-client-api generate-ui-api generate-wire wire-smoke api-smoke contracts-validate contracts-generate contracts-check docs-reference-check docs-reference-smoke test test-full test-functional test-functional-long verify-fast verify-pr verify-pr-inference verify-extended verify-build-contracts verify-tests run-concurrent-ui-verification-lanes run-sharded-ui-coverage verify test-ui-coverage test-ui-coverage-merge test-ui-browser-integration test-ui-durable-session-real-backend test-backend-coverage test-backend-functional test-backend-verification long-tests long-tests-managed-runtime long-tests-functional-runtime pr-inference-approval test-coverage-go script-timeout-companion-smoke-100 cron-time-work-smoke current-factory-watcher-switch-smoke release-surface-smoke artifact-contract-closeout lint backend-size pkg-maint pkg-file-count pkg-boundary durable-runtime-construction-check logging-boundary-check model-facade-check readme-check deadcode ui-deadcode test-race fmt vet deps deps-tidy init dashboard-verify typecheck release ci ci-typecheck ci-verify-build-contracts ci-verify-tests ui-deps ui-lint ui-build ui-test ui-integration-test ui-durable-session-real-backend-integration-test ui-test-coverage ui-replay-coverage-check ui-install-playwright ui-storybook ui-test-storybook ui-components-typecheck ui-components-test ui-components-storybook ui-components-boundary ui-components-dependency-direction ui-components-verify ui-verify-fresh-npm-install clean
 
 default:
 	$(MAKE) generate-api
@@ -126,6 +126,9 @@ contracts-validate:
 
 contracts-generate:
 	$(GO) run ./cmd/contractsgenerate -root .
+
+contracts-check:
+	$(GO) run ./cmd/contractscheck -root .
 
 docs-reference-check:
 	$(GO) run ./cmd/markdown-linter docs/README.md docs/reference

--- a/cmd/contractscheck/main.go
+++ b/cmd/contractscheck/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/portpowered/infinite-you/internal/contractstaging"
+)
+
+const successMessage = "[agent-factory:contracts-check] approved joined contracts are current"
+
+func main() {
+	root := flag.String("root", ".", "repository root")
+	flag.Parse()
+	os.Exit(run(*root, os.Stdout, os.Stderr))
+}
+
+func run(root string, stdout, stderr io.Writer) int {
+	drift, err := contractstaging.Check(root)
+	if err != nil {
+		fmt.Fprintf(stderr, "[agent-factory:contracts-check] check failed: %v\n", err)
+		return 1
+	}
+	if drift.Empty() {
+		fmt.Fprintln(stdout, successMessage)
+		return 0
+	}
+
+	writePaths(stderr, "stale", drift.Stale)
+	writePaths(stderr, "missing", drift.Missing)
+	writePaths(stderr, "unexpected", drift.Unexpected)
+	fmt.Fprintln(stderr, "[agent-factory:contracts-check] contract staging differs from canonical sources; run `make contracts-generate` and remove every unexpected file from staging")
+	return 1
+}
+
+func writePaths(writer io.Writer, category string, paths []string) {
+	if len(paths) == 0 {
+		return
+	}
+	fmt.Fprintf(writer, "[agent-factory:contracts-check] %s:\n", category)
+	for _, path := range paths {
+		fmt.Fprintf(writer, "  %s\n", path)
+	}
+}

--- a/cmd/contractscheck/main_test.go
+++ b/cmd/contractscheck/main_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/contractjoiner"
+	"github.com/portpowered/infinite-you/internal/contractstaging"
+)
+
+func TestRunPassesCleanStagingWithoutWriting(t *testing.T) {
+	root := commandFixture(t)
+	before := commandTree(t, root)
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+
+	if status := run(root, stdout, stderr); status != 0 {
+		t.Fatalf("run() status = %d, want 0; stderr = %q", status, stderr)
+	}
+	if got := stdout.String(); got != successMessage+"\n" || stderr.Len() != 0 {
+		t.Fatalf("run() stdout = %q, stderr = %q", got, stderr.String())
+	}
+	if after := commandTree(t, root); !reflect.DeepEqual(after, before) {
+		t.Fatal("run() changed repository bytes on success")
+	}
+}
+
+func TestRunReportsCombinedDriftDeterministicallyWithoutWriting(t *testing.T) {
+	root := commandFixture(t)
+	allowed := contractstaging.AllowedArtifacts()
+	writeCommandFixture(t, root, allowed[0], "stale-z")
+	writeCommandFixture(t, root, allowed[1], "stale-a")
+	if err := os.Remove(filepath.Join(root, filepath.FromSlash(allowed[2]))); err != nil {
+		t.Fatalf("remove expected artifact: %v", err)
+	}
+	for _, path := range []string{
+		"packages/api/generated/ui/openapi.ts",
+		"packages/api/generated/client.gen.go",
+		"packages/api/generated/bin/you.exe",
+		"packages/api/generated/.cache/contracts/data",
+		"packages/api/generated/unrelated.txt",
+	} {
+		writeCommandFixture(t, root, path, "unexpected")
+	}
+	before := commandTree(t, root)
+	want := strings.Join([]string{
+		"[agent-factory:contracts-check] stale:",
+		"  " + allowed[0],
+		"  " + allowed[1],
+		"[agent-factory:contracts-check] missing:",
+		"  " + allowed[2],
+		"[agent-factory:contracts-check] unexpected:",
+		"  packages/api/generated/.cache/contracts/data",
+		"  packages/api/generated/bin/you.exe",
+		"  packages/api/generated/client.gen.go",
+		"  packages/api/generated/ui/openapi.ts",
+		"  packages/api/generated/unrelated.txt",
+		"[agent-factory:contracts-check] contract staging differs from canonical sources; run `make contracts-generate` and remove every unexpected file from staging",
+		"",
+	}, "\n")
+
+	for runIndex := 0; runIndex < 2; runIndex++ {
+		stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+		if status := run(root, stdout, stderr); status != 1 {
+			t.Fatalf("run %d status = %d, want 1", runIndex, status)
+		}
+		if stdout.Len() != 0 || stderr.String() != want {
+			t.Fatalf("run %d stdout = %q, stderr = %q, want %q", runIndex, stdout, stderr, want)
+		}
+	}
+	if after := commandTree(t, root); !reflect.DeepEqual(after, before) {
+		t.Fatal("run() changed repository bytes on failure")
+	}
+}
+
+func commandFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeCommandFixture(t, root, "contracts/common/documentation.schema.json", `{"$id":"https://schemas.portpowered.com/you/contracts/common/documentation.schema.json","$defs":{"itemId":{"type":"string"}}}`)
+	writeCommandFixture(t, root, "contracts/common/deprecations.schema.json", `{"$id":"https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json","properties":{"itemId":{"$ref":"https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"}}}`)
+	writeCommandFixture(t, root, "contracts/manifest.schema.json", `{"$id":"https://schemas.portpowered.com/you/contracts/manifest.schema.json","properties":{"packageId":{"$ref":"https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"}}}`)
+	writeCommandFixture(t, root, "unrelated.txt", "unrelated")
+	if diagnostics := contractjoiner.Generate(contractstaging.JoinInput(root)); len(diagnostics) != 0 {
+		t.Fatalf("Generate() diagnostics = %#v", diagnostics)
+	}
+	return root
+}
+
+func commandTree(t *testing.T, root string) map[string]string {
+	t.Helper()
+	result := make(map[string]string)
+	if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil || entry.IsDir() {
+			return err
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		payload, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		result[filepath.ToSlash(relative)] = string(payload)
+		return nil
+	}); err != nil {
+		t.Fatalf("walk repository: %v", err)
+	}
+	return result
+}
+
+func writeCommandFixture(t *testing.T, root, path, contents string) {
+	t.Helper()
+	target := filepath.Join(root, filepath.FromSlash(path))
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("create fixture directory: %v", err)
+	}
+	if err := os.WriteFile(target, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+}

--- a/cmd/contractsgenerate/main.go
+++ b/cmd/contractsgenerate/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/portpowered/infinite-you/internal/contractjoiner"
+	"github.com/portpowered/infinite-you/internal/contractstaging"
+)
+
+const successMessage = "[agent-factory:contracts-generate] approved joined contracts generated"
+
+func main() {
+	root := flag.String("root", ".", "repository root")
+	flag.Parse()
+	os.Exit(run(*root, os.Stdout, os.Stderr))
+}
+
+func run(root string, stdout, stderr io.Writer) int {
+	diagnostics := contractjoiner.Generate(contractstaging.JoinInput(root))
+	if len(diagnostics) == 0 {
+		fmt.Fprintln(stdout, successMessage)
+		return 0
+	}
+
+	encoder := json.NewEncoder(stderr)
+	encoder.SetEscapeHTML(false)
+	for _, diagnostic := range diagnostics {
+		if err := encoder.Encode(diagnostic); err != nil {
+			fmt.Fprintln(stderr, "[agent-factory:contracts-generate] diagnostic output failed")
+			return 1
+		}
+	}
+	return 1
+}

--- a/cmd/contractsgenerate/main_test.go
+++ b/cmd/contractsgenerate/main_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/contractstaging"
+)
+
+func TestRunGeneratesApprovedArtifactsReproduciblyWithoutChangingOtherFiles(t *testing.T) {
+	root := t.TempDir()
+	writeFixture(t, root, "contracts/common/documentation.schema.json", `{"$id":"https://schemas.portpowered.com/you/contracts/common/documentation.schema.json","$defs":{"itemId":{"type":"string"}}}`)
+	writeFixture(t, root, "contracts/common/deprecations.schema.json", `{"$id":"https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json","properties":{"itemId":{"$ref":"https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"}}}`)
+	writeFixture(t, root, "contracts/manifest.schema.json", `{"$id":"https://schemas.portpowered.com/you/contracts/manifest.schema.json","properties":{"packageId":{"$ref":"https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"}}}`)
+	protected := []string{
+		"contracts/testdata/fixture.json",
+		"pkg/generatedclient/client.gen.go",
+		"ui/src/api/generated/openapi.ts",
+		"bin/you.exe",
+		".cache/contracts/data",
+		"unrelated.txt",
+	}
+	for _, path := range protected {
+		writeFixture(t, root, path, "protected:"+path)
+	}
+	before := fileDigests(t, root, protected)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if status := run(root, stdout, stderr); status != 0 || stderr.Len() != 0 {
+		t.Fatalf("first run() = %d, stdout %q, stderr %q", status, stdout, stderr)
+	}
+	first := fileDigests(t, root, contractstaging.AllowedArtifacts())
+	stdout.Reset()
+	if status := run(root, stdout, stderr); status != 0 || stderr.Len() != 0 {
+		t.Fatalf("second run() = %d, stdout %q, stderr %q", status, stdout, stderr)
+	}
+	second := fileDigests(t, root, contractstaging.AllowedArtifacts())
+
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("repeated generation changed artifact digests:\nfirst=%x\nsecond=%x", first, second)
+	}
+	if after := fileDigests(t, root, protected); !reflect.DeepEqual(before, after) {
+		t.Fatalf("generation changed protected files:\nbefore=%x\nafter=%x", before, after)
+	}
+	assertOnlyAllowedArtifacts(t, root)
+}
+
+func TestRunPropagatesAComponentChangeToEveryConsumer(t *testing.T) {
+	root := t.TempDir()
+	documentation := "contracts/common/documentation.schema.json"
+	writeFixture(t, root, documentation, `{"$id":"https://schemas.portpowered.com/you/contracts/common/documentation.schema.json","$defs":{"itemId":{"type":"string"}}}`)
+	writeFixture(t, root, "contracts/common/deprecations.schema.json", `{"properties":{"itemId":{"$ref":"https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"}}}`)
+	writeFixture(t, root, "contracts/manifest.schema.json", `{"properties":{"packageId":{"$ref":"https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"}}}`)
+	if status := run(root, &bytes.Buffer{}, &bytes.Buffer{}); status != 0 {
+		t.Fatalf("initial run() = %d", status)
+	}
+	before := fileDigests(t, root, contractstaging.AllowedArtifacts())
+
+	writeFixture(t, root, documentation, `{"$id":"https://schemas.portpowered.com/you/contracts/common/documentation.schema.json","$defs":{"itemId":{"type":"integer"}}}`)
+	if status := run(root, &bytes.Buffer{}, &bytes.Buffer{}); status != 0 {
+		t.Fatalf("changed run() = %d", status)
+	}
+	after := fileDigests(t, root, contractstaging.AllowedArtifacts())
+
+	for _, path := range contractstaging.AllowedArtifacts() {
+		if bytes.Contains([]byte(path), []byte("documentation.schema.json")) {
+			continue
+		}
+		if before[path] == after[path] {
+			t.Errorf("component change did not change joined consumer %s", path)
+		}
+	}
+}
+
+func assertOnlyAllowedArtifacts(t *testing.T, root string) {
+	t.Helper()
+	want := contractstaging.AllowedArtifacts()
+	var got []string
+	base := filepath.Join(root, "packages", "api", "generated", "joined")
+	if err := filepath.WalkDir(base, func(path string, entry os.DirEntry, err error) error {
+		if err != nil || entry.IsDir() {
+			return err
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		got = append(got, filepath.ToSlash(relative))
+		return nil
+	}); err != nil {
+		t.Fatalf("walk generated artifacts: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("generated paths = %q, want allowlist %q", got, want)
+	}
+}
+
+func fileDigests(t *testing.T, root string, paths []string) map[string][sha256.Size]byte {
+	t.Helper()
+	digests := make(map[string][sha256.Size]byte, len(paths))
+	for _, path := range paths {
+		content, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(path)))
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		digests[path] = sha256.Sum256(content)
+	}
+	return digests
+}
+
+func writeFixture(t *testing.T, root, path, contents string) {
+	t.Helper()
+	target := filepath.Join(root, filepath.FromSlash(path))
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("create fixture directory: %v", err)
+	}
+	if err := os.WriteFile(target, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+}

--- a/internal/contractjoiner/joiner_test.go
+++ b/internal/contractjoiner/joiner_test.go
@@ -62,6 +62,28 @@ func TestCanonicalJoinedJSONMatchesGoldenAcrossRepeatedAndShuffledInputs(t *test
 	compileJoinedSchema(t, joinDocuments(t, input)[0].Value)
 }
 
+func TestJoinResolvesAbsoluteReferenceMatchingExplicitAuthoredID(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "contracts/root.json", `{"value":{"$ref":"https://schemas.example.test/shared.json#/$defs/value"}}`)
+	writeFile(t, root, "contracts/shared.json", `{"$id":"https://schemas.example.test/shared.json","$defs":{"value":{"type":"string"}}}`)
+
+	documents, diagnostics := contractjoiner.Join(contractjoiner.Input{
+		RepositoryRoot: root,
+		Roots:          []string{"contracts/root.json"},
+		Components:     []string{"contracts/shared.json"},
+	})
+	if len(diagnostics) != 0 {
+		t.Fatalf("Join() diagnostics = %#v, want none", diagnostics)
+	}
+	canonical, err := contractjoiner.MarshalCanonicalJSON(documents[0].Value)
+	if err != nil {
+		t.Fatalf("MarshalCanonicalJSON(): %v", err)
+	}
+	if !bytes.Contains(canonical, []byte(`"type": "string"`)) {
+		t.Fatalf("joined document did not contain absolute-ID target: %s", canonical)
+	}
+}
+
 type serializedDocument struct {
 	Path string
 	JSON []byte

--- a/internal/contractstaging/check.go
+++ b/internal/contractstaging/check.go
@@ -1,0 +1,125 @@
+package contractstaging
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/portpowered/infinite-you/internal/contractjoiner"
+)
+
+const stagingDirectory = "packages/api/generated"
+
+// Drift describes every difference between canonical joined output and package
+// staging. Paths are repository-relative and sorted within each category.
+type Drift struct {
+	Stale      []string
+	Missing    []string
+	Unexpected []string
+}
+
+type stagedFile struct {
+	payload []byte
+	regular bool
+}
+
+// Empty reports whether package staging exactly matches canonical joined output.
+func (drift Drift) Empty() bool {
+	return len(drift.Stale) == 0 && len(drift.Missing) == 0 && len(drift.Unexpected) == 0
+}
+
+// Check computes expected artifacts in memory, then compares their path set and
+// bytes with package staging without changing either authored or staged files.
+func Check(repositoryRoot string) (Drift, error) {
+	expected, err := expectedArtifacts(repositoryRoot)
+	if err != nil {
+		return Drift{}, err
+	}
+	actual, err := stagedArtifacts(repositoryRoot)
+	if err != nil {
+		return Drift{}, err
+	}
+
+	drift := Drift{}
+	for path, expectedPayload := range expected {
+		actualFile, exists := actual[path]
+		if !exists {
+			drift.Missing = append(drift.Missing, path)
+			continue
+		}
+		if !actualFile.regular || !bytes.Equal(actualFile.payload, expectedPayload) {
+			drift.Stale = append(drift.Stale, path)
+		}
+		delete(actual, path)
+	}
+	for path := range actual {
+		drift.Unexpected = append(drift.Unexpected, path)
+	}
+	sort.Strings(drift.Stale)
+	sort.Strings(drift.Missing)
+	sort.Strings(drift.Unexpected)
+	return drift, nil
+}
+
+func expectedArtifacts(repositoryRoot string) (map[string][]byte, error) {
+	documents, diagnostics := contractjoiner.Join(JoinInput(repositoryRoot))
+	if len(diagnostics) != 0 {
+		payload, err := json.Marshal(diagnostics)
+		if err != nil {
+			return nil, fmt.Errorf("encode join diagnostics: %w", err)
+		}
+		return nil, fmt.Errorf("join canonical contracts: %s", payload)
+	}
+
+	expected := make(map[string][]byte, len(documents))
+	for _, document := range documents {
+		payload, err := contractjoiner.MarshalCanonicalJSON(document.Value)
+		if err != nil {
+			return nil, fmt.Errorf("serialize joined contract %s: %w", document.Path, err)
+		}
+		path := filepath.ToSlash(filepath.Join(joinedOutputDirectory, document.Path))
+		expected[path] = payload
+	}
+	return expected, nil
+}
+
+func stagedArtifacts(repositoryRoot string) (map[string]stagedFile, error) {
+	root, err := filepath.Abs(repositoryRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolve repository root: %w", err)
+	}
+	base := filepath.Join(root, filepath.FromSlash(stagingDirectory))
+	actual := make(map[string]stagedFile)
+	err = filepath.WalkDir(base, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			if path == base && os.IsNotExist(walkErr) {
+				return filepath.SkipDir
+			}
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if !entry.Type().IsRegular() {
+			actual[filepath.ToSlash(relative)] = stagedFile{}
+			return nil
+		}
+		payload, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		actual[filepath.ToSlash(relative)] = stagedFile{payload: payload, regular: true}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("read package staging: %w", err)
+	}
+	return actual, nil
+}

--- a/internal/contractstaging/check_test.go
+++ b/internal/contractstaging/check_test.go
@@ -1,0 +1,158 @@
+package contractstaging_test
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/contractjoiner"
+	"github.com/portpowered/infinite-you/internal/contractstaging"
+)
+
+func TestCheckReportsEveryDriftCategoryInDeterministicPathOrder(t *testing.T) {
+	root := checkFixture(t)
+	allowed := contractstaging.AllowedArtifacts()
+	writeCheckFixture(t, root, allowed[0], "stale-z")
+	writeCheckFixture(t, root, allowed[1], "stale-a")
+	if err := os.Remove(filepath.Join(root, filepath.FromSlash(allowed[2]))); err != nil {
+		t.Fatalf("remove expected artifact: %v", err)
+	}
+	unexpected := []string{
+		"packages/api/generated/ui/openapi.ts",
+		"packages/api/generated/client.gen.go",
+		"packages/api/generated/bin/you.exe",
+		"packages/api/generated/.cache/contracts/data",
+		"packages/api/generated/unrelated.txt",
+	}
+	for _, path := range unexpected {
+		writeCheckFixture(t, root, path, path)
+	}
+
+	want := contractstaging.Drift{
+		Stale:      []string{allowed[0], allowed[1]},
+		Missing:    []string{allowed[2]},
+		Unexpected: []string{unexpected[3], unexpected[2], unexpected[1], unexpected[0], unexpected[4]},
+	}
+	first, err := contractstaging.Check(root)
+	if err != nil {
+		t.Fatalf("first Check() error = %v", err)
+	}
+	second, err := contractstaging.Check(root)
+	if err != nil {
+		t.Fatalf("second Check() error = %v", err)
+	}
+	if !reflect.DeepEqual(first, want) || !reflect.DeepEqual(second, want) {
+		t.Fatalf("Check() drift = %#v then %#v, want %#v", first, second, want)
+	}
+}
+
+func TestCheckDistinguishesIndividualStaleMissingAndUnexpectedCases(t *testing.T) {
+	allowed := contractstaging.AllowedArtifacts()
+	tests := []struct {
+		name   string
+		mutate func(t *testing.T, root string)
+		want   contractstaging.Drift
+	}{
+		{
+			name: "stale",
+			mutate: func(t *testing.T, root string) {
+				writeCheckFixture(t, root, allowed[0], "stale")
+			},
+			want: contractstaging.Drift{Stale: []string{allowed[0]}},
+		},
+		{
+			name: "missing",
+			mutate: func(t *testing.T, root string) {
+				if err := os.Remove(filepath.Join(root, filepath.FromSlash(allowed[1]))); err != nil {
+					t.Fatalf("remove expected artifact: %v", err)
+				}
+			},
+			want: contractstaging.Drift{Missing: []string{allowed[1]}},
+		},
+		{
+			name: "unexpected",
+			mutate: func(t *testing.T, root string) {
+				writeCheckFixture(t, root, "packages/api/generated/forbidden.txt", "forbidden")
+			},
+			want: contractstaging.Drift{Unexpected: []string{"packages/api/generated/forbidden.txt"}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := checkFixture(t)
+			test.mutate(t, root)
+			got, err := contractstaging.Check(root)
+			if err != nil {
+				t.Fatalf("Check() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("Check() drift = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestCheckPassesCleanStagingAndDoesNotChangeRepositoryBytes(t *testing.T) {
+	root := checkFixture(t)
+	writeCheckFixture(t, root, "contracts/testdata/fixture.json", "fixture")
+	writeCheckFixture(t, root, "unrelated.txt", "unrelated")
+	before := checkTree(t, root)
+
+	drift, err := contractstaging.Check(root)
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if !drift.Empty() {
+		t.Fatalf("Check() drift = %#v, want none", drift)
+	}
+	if after := checkTree(t, root); !reflect.DeepEqual(after, before) {
+		t.Fatal("Check() changed repository bytes on success")
+	}
+}
+
+func checkFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeCheckFixture(t, root, "contracts/common/documentation.schema.json", `{"$id":"https://schemas.portpowered.com/you/contracts/common/documentation.schema.json","$defs":{"itemId":{"type":"string"}}}`)
+	writeCheckFixture(t, root, "contracts/common/deprecations.schema.json", `{"$id":"https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json","properties":{"itemId":{"$ref":"https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"}}}`)
+	writeCheckFixture(t, root, "contracts/manifest.schema.json", `{"$id":"https://schemas.portpowered.com/you/contracts/manifest.schema.json","properties":{"packageId":{"$ref":"https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"}}}`)
+	if diagnostics := contractjoiner.Generate(contractstaging.JoinInput(root)); len(diagnostics) != 0 {
+		t.Fatalf("Generate() diagnostics = %#v", diagnostics)
+	}
+	return root
+}
+
+func checkTree(t *testing.T, root string) map[string]string {
+	t.Helper()
+	result := make(map[string]string)
+	if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil || entry.IsDir() {
+			return err
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		payload, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		result[filepath.ToSlash(relative)] = string(payload)
+		return nil
+	}); err != nil {
+		t.Fatalf("walk repository: %v", err)
+	}
+	return result
+}
+
+func writeCheckFixture(t *testing.T, root, path, contents string) {
+	t.Helper()
+	target := filepath.Join(root, filepath.FromSlash(path))
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("create fixture directory: %v", err)
+	}
+	if err := os.WriteFile(target, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+}

--- a/internal/contractstaging/policy.go
+++ b/internal/contractstaging/policy.go
@@ -1,0 +1,43 @@
+// Package contractstaging defines the repository-owned contract package staging
+// policy. It is build tooling and must not be imported by runtime packages.
+package contractstaging
+
+import (
+	"path/filepath"
+
+	"github.com/portpowered/infinite-you/internal/contractjoiner"
+)
+
+const joinedOutputDirectory = "packages/api/generated/joined"
+
+var (
+	joinedRoots = []string{
+		"contracts/common/deprecations.schema.json",
+		"contracts/common/documentation.schema.json",
+		"contracts/manifest.schema.json",
+	}
+	joinedComponents = []string{
+		"contracts/common/deprecations.schema.json",
+		"contracts/common/documentation.schema.json",
+	}
+)
+
+// JoinInput returns the complete reviewed input set for contract package
+// generation. Returning copies keeps the package policy immutable to callers.
+func JoinInput(repositoryRoot string) contractjoiner.Input {
+	return contractjoiner.Input{
+		RepositoryRoot: repositoryRoot,
+		Roots:          append([]string(nil), joinedRoots...),
+		Components:     append([]string(nil), joinedComponents...),
+	}
+}
+
+// AllowedArtifacts returns the complete reviewed generated artifact set in
+// deterministic repository-relative path order.
+func AllowedArtifacts() []string {
+	artifacts := make([]string, len(joinedRoots))
+	for index, root := range joinedRoots {
+		artifacts[index] = filepath.ToSlash(filepath.Join(joinedOutputDirectory, root))
+	}
+	return artifacts
+}

--- a/internal/contractstaging/policy_test.go
+++ b/internal/contractstaging/policy_test.go
@@ -1,0 +1,30 @@
+package contractstaging_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/contractstaging"
+)
+
+func TestAllowedArtifactsAreTheReviewedJoinedContracts(t *testing.T) {
+	want := []string{
+		"packages/api/generated/joined/contracts/common/deprecations.schema.json",
+		"packages/api/generated/joined/contracts/common/documentation.schema.json",
+		"packages/api/generated/joined/contracts/manifest.schema.json",
+	}
+	if got := contractstaging.AllowedArtifacts(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("AllowedArtifacts() = %q, want %q", got, want)
+	}
+}
+
+func TestJoinInputReturnsIndependentPolicyCopies(t *testing.T) {
+	first := contractstaging.JoinInput("first")
+	first.Roots[0] = "changed"
+	first.Components[0] = "changed"
+
+	second := contractstaging.JoinInput("second")
+	if second.RepositoryRoot != "second" || second.Roots[0] == "changed" || second.Components[0] == "changed" {
+		t.Fatalf("JoinInput() shared mutable policy state: %#v", second)
+	}
+}

--- a/internal/contractvalidator/references.go
+++ b/internal/contractvalidator/references.go
@@ -22,6 +22,7 @@ func (disabledURLLoader) Load(resourceURL string) (any, error) {
 type referenceResolver struct {
 	root                               string
 	documents                          map[string]any
+	authoredResourceDocuments          map[string]string
 	active                             map[string]bool
 	allowed                            map[string]struct{}
 	deduplicateResources               bool
@@ -119,6 +120,7 @@ func resolveReferencesWithin(
 	resolver := referenceResolver{
 		root:                               root,
 		documents:                          map[string]any{document: value},
+		authoredResourceDocuments:          authoredResourceDocuments(root, document, value, allowed),
 		active:                             make(map[string]bool),
 		allowed:                            allowed,
 		deduplicateResources:               deduplicateResources,
@@ -142,6 +144,44 @@ func resolveReferencesWithin(
 		loaded = append(loaded, loadedDocument{path: path, value: resolver.documents[path]})
 	}
 	return resolved, loaded, nil
+}
+
+func authoredResourceDocuments(root, primaryDocument string, primaryValue any, allowed map[string]struct{}) map[string]string {
+	resources := make(map[string]string)
+	if allowed == nil {
+		return resources
+	}
+	paths := make([]string, 0, len(allowed))
+	for path := range allowed {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
+		value := primaryValue
+		if path != primaryDocument {
+			loaded, issue := loadJSON(root, path, "document")
+			if issue != nil {
+				continue
+			}
+			value = loaded
+		}
+		object, ok := value.(map[string]any)
+		if !ok {
+			continue
+		}
+		identifier, ok := object["$id"].(string)
+		if !ok {
+			continue
+		}
+		parsed, err := url.Parse(identifier)
+		if err != nil || !parsed.IsAbs() || parsed.Fragment != "" {
+			continue
+		}
+		if _, exists := resources[parsed.String()]; !exists {
+			resources[parsed.String()] = path
+		}
+	}
+	return resources
 }
 
 func (r *referenceResolver) resolveNode(value any, document string, segments, sourceSegments []string, scope resolutionScope) (any, []Diagnostic) {
@@ -468,6 +508,13 @@ func (r *referenceResolver) classifyReference(referringDocument, reference strin
 		return "", "", &issue
 	}
 	parsed, err := url.Parse(portable)
+	if err == nil && parsed.IsAbs() && parsed.RawQuery == "" {
+		resource := *parsed
+		resource.Fragment = ""
+		if target, ok := r.authoredResourceDocuments[resource.String()]; ok {
+			return target, parsed.Fragment, nil
+		}
+	}
 	if err != nil || parsed.Scheme != "" || parsed.Host != "" || parsed.RawQuery != "" {
 		issue := r.singleIssue("reference.unsupported", fmt.Sprintf("reference %q is not repository-relative", reference), referringDocument, segments)
 		return "", "", &issue

--- a/packages/api/generated/joined/contracts/common/deprecations.schema.json
+++ b/packages/api/generated/joined/contracts/common/deprecations.schema.json
@@ -1,0 +1,146 @@
+{
+  "$defs": {
+    "successor": {
+      "additionalProperties": false,
+      "description": "The replacement contract item and canonical English migration guidance.",
+      "properties": {
+        "canonicalEnglish": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "targetItemId": {
+          "description": "Stable lowercase item identity. Dot, underscore, and hyphen separators are allowed; display names and source locations are not encoded.",
+          "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "targetItemId",
+        "canonicalEnglish"
+      ],
+      "type": "object"
+    },
+    "version": {
+      "description": "A three-part stable semantic version without a leading v or leading zeroes.",
+      "pattern": "^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$",
+      "type": "string"
+    }
+  },
+  "$id": "https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Family-neutral lifecycle and migration metadata for one contract item. This metadata describes support history and does not control runtime callability.",
+  "oneOf": [
+    {
+      "properties": {
+        "deprecated": false,
+        "removed": false,
+        "state": {
+          "const": "active"
+        },
+        "successor": false
+      }
+    },
+    {
+      "properties": {
+        "removed": false,
+        "state": {
+          "const": "deprecated"
+        }
+      },
+      "required": [
+        "deprecated",
+        "successor"
+      ]
+    },
+    {
+      "properties": {
+        "state": {
+          "const": "removed"
+        }
+      },
+      "required": [
+        "deprecated",
+        "removed",
+        "successor"
+      ]
+    }
+  ],
+  "properties": {
+    "deprecated": {
+      "allOf": [
+        {
+          "description": "A three-part stable semantic version without a leading v or leading zeroes.",
+          "pattern": "^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$",
+          "type": "string"
+        }
+      ],
+      "description": "The first package version in which the item was deprecated."
+    },
+    "formatVersion": {
+      "const": "1.0.0",
+      "description": "The explicitly supported version of this lifecycle metadata format."
+    },
+    "itemId": {
+      "description": "Stable lowercase item identity. Dot, underscore, and hyphen separators are allowed; display names and source locations are not encoded.",
+      "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+      "type": "string"
+    },
+    "removed": {
+      "allOf": [
+        {
+          "description": "A three-part stable semantic version without a leading v or leading zeroes.",
+          "pattern": "^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$",
+          "type": "string"
+        }
+      ],
+      "description": "The first package version from which the item was absent."
+    },
+    "since": {
+      "allOf": [
+        {
+          "description": "A three-part stable semantic version without a leading v or leading zeroes.",
+          "pattern": "^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$",
+          "type": "string"
+        }
+      ],
+      "description": "The first package version containing the item."
+    },
+    "state": {
+      "description": "The item's publication lifecycle state.",
+      "enum": [
+        "active",
+        "deprecated",
+        "removed"
+      ]
+    },
+    "successor": {
+      "additionalProperties": false,
+      "description": "The replacement contract item and canonical English migration guidance.",
+      "properties": {
+        "canonicalEnglish": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "targetItemId": {
+          "description": "Stable lowercase item identity. Dot, underscore, and hyphen separators are allowed; display names and source locations are not encoded.",
+          "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "targetItemId",
+        "canonicalEnglish"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "formatVersion",
+    "itemId",
+    "state",
+    "since"
+  ],
+  "title": "You contract lifecycle metadata",
+  "type": "object"
+}

--- a/packages/api/generated/joined/contracts/common/documentation.schema.json
+++ b/packages/api/generated/joined/contracts/common/documentation.schema.json
@@ -1,0 +1,170 @@
+{
+  "$defs": {
+    "descriptionDocumentation": {
+      "additionalProperties": false,
+      "description": "The required description translation. The .description suffix makes its ID structurally distinct from the title ID.",
+      "properties": {
+        "canonicalEnglish": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "id": {
+          "allOf": [
+            {
+              "description": "Stable lowercase documentation identity independent of translated text and source location.",
+              "type": "string"
+            },
+            {
+              "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*[.]description$"
+            }
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "canonicalEnglish"
+      ],
+      "type": "object"
+    },
+    "documentationIdBase": {
+      "description": "Stable lowercase documentation identity independent of translated text and source location.",
+      "type": "string"
+    },
+    "itemId": {
+      "description": "Stable lowercase item identity. Dot, underscore, and hyphen separators are allowed; display names and source locations are not encoded.",
+      "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+      "type": "string"
+    },
+    "titleDocumentation": {
+      "additionalProperties": false,
+      "description": "The required title translation. The .title suffix makes its ID structurally distinct from the description ID.",
+      "properties": {
+        "canonicalEnglish": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "id": {
+          "allOf": [
+            {
+              "description": "Stable lowercase documentation identity independent of translated text and source location.",
+              "type": "string"
+            },
+            {
+              "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*[.]title$"
+            }
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "canonicalEnglish"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Family-neutral identity, canonical English documentation, examples, visibility, and source integrity metadata for one contract item.",
+  "properties": {
+    "documentation": {
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "additionalProperties": false,
+          "description": "The required description translation. The .description suffix makes its ID structurally distinct from the title ID.",
+          "properties": {
+            "canonicalEnglish": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "id": {
+              "allOf": [
+                {
+                  "description": "Stable lowercase documentation identity independent of translated text and source location.",
+                  "type": "string"
+                },
+                {
+                  "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*[.]description$"
+                }
+              ]
+            }
+          },
+          "required": [
+            "id",
+            "canonicalEnglish"
+          ],
+          "type": "object"
+        },
+        "title": {
+          "additionalProperties": false,
+          "description": "The required title translation. The .title suffix makes its ID structurally distinct from the description ID.",
+          "properties": {
+            "canonicalEnglish": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "id": {
+              "allOf": [
+                {
+                  "description": "Stable lowercase documentation identity independent of translated text and source location.",
+                  "type": "string"
+                },
+                {
+                  "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*[.]title$"
+                }
+              ]
+            }
+          },
+          "required": [
+            "id",
+            "canonicalEnglish"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "title",
+        "description"
+      ],
+      "type": "object"
+    },
+    "examples": {
+      "description": "Representative values in any JSON shape.",
+      "items": true,
+      "minItems": 1,
+      "type": "array"
+    },
+    "formatVersion": {
+      "const": "1.0.0",
+      "description": "The explicitly supported version of this documentation metadata format."
+    },
+    "itemId": {
+      "description": "Stable lowercase item identity. Dot, underscore, and hyphen separators are allowed; display names and source locations are not encoded.",
+      "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+      "type": "string"
+    },
+    "sourceHash": {
+      "description": "Lowercase hexadecimal SHA-256 of the source from which this metadata was produced.",
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "visibility": {
+      "description": "Whether the documented contract item is customer-facing or repository-internal.",
+      "enum": [
+        "public",
+        "internal"
+      ]
+    }
+  },
+  "required": [
+    "formatVersion",
+    "itemId",
+    "documentation",
+    "examples",
+    "visibility",
+    "sourceHash"
+  ],
+  "title": "You contract documentation metadata",
+  "type": "object"
+}

--- a/packages/api/generated/joined/contracts/manifest.schema.json
+++ b/packages/api/generated/joined/contracts/manifest.schema.json
@@ -1,0 +1,442 @@
+{
+  "$defs": {
+    "export": {
+      "additionalProperties": false,
+      "properties": {
+        "artifactHash": {
+          "description": "Lowercase hexadecimal SHA-256 of the exported artifact.",
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "documentation": {
+          "$defs": {
+            "descriptionDocumentation": {
+              "additionalProperties": false,
+              "description": "The required description translation. The .description suffix makes its ID structurally distinct from the title ID.",
+              "properties": {
+                "canonicalEnglish": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "id": {
+                  "allOf": [
+                    {
+                      "description": "Stable lowercase documentation identity independent of translated text and source location.",
+                      "type": "string"
+                    },
+                    {
+                      "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*[.]description$"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "canonicalEnglish"
+              ],
+              "type": "object"
+            },
+            "documentationIdBase": {
+              "description": "Stable lowercase documentation identity independent of translated text and source location.",
+              "type": "string"
+            },
+            "itemId": {
+              "description": "Stable lowercase item identity. Dot, underscore, and hyphen separators are allowed; display names and source locations are not encoded.",
+              "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+              "type": "string"
+            },
+            "titleDocumentation": {
+              "additionalProperties": false,
+              "description": "The required title translation. The .title suffix makes its ID structurally distinct from the description ID.",
+              "properties": {
+                "canonicalEnglish": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "id": {
+                  "allOf": [
+                    {
+                      "description": "Stable lowercase documentation identity independent of translated text and source location.",
+                      "type": "string"
+                    },
+                    {
+                      "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*[.]title$"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "canonicalEnglish"
+              ],
+              "type": "object"
+            }
+          },
+          "$id": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "additionalProperties": false,
+          "description": "Family-neutral identity, canonical English documentation, examples, visibility, and source integrity metadata for one contract item.",
+          "properties": {
+            "documentation": {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "additionalProperties": false,
+                  "description": "The required description translation. The .description suffix makes its ID structurally distinct from the title ID.",
+                  "properties": {
+                    "canonicalEnglish": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "id": {
+                      "allOf": [
+                        {
+                          "description": "Stable lowercase documentation identity independent of translated text and source location.",
+                          "type": "string"
+                        },
+                        {
+                          "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*[.]description$"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "canonicalEnglish"
+                  ],
+                  "type": "object"
+                },
+                "title": {
+                  "additionalProperties": false,
+                  "description": "The required title translation. The .title suffix makes its ID structurally distinct from the description ID.",
+                  "properties": {
+                    "canonicalEnglish": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "id": {
+                      "allOf": [
+                        {
+                          "description": "Stable lowercase documentation identity independent of translated text and source location.",
+                          "type": "string"
+                        },
+                        {
+                          "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*[.]title$"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "canonicalEnglish"
+                  ],
+                  "type": "object"
+                }
+              },
+              "required": [
+                "title",
+                "description"
+              ],
+              "type": "object"
+            },
+            "examples": {
+              "description": "Representative values in any JSON shape.",
+              "items": true,
+              "minItems": 1,
+              "type": "array"
+            },
+            "formatVersion": {
+              "const": "1.0.0",
+              "description": "The explicitly supported version of this documentation metadata format."
+            },
+            "itemId": {
+              "description": "Stable lowercase item identity. Dot, underscore, and hyphen separators are allowed; display names and source locations are not encoded.",
+              "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+              "type": "string"
+            },
+            "sourceHash": {
+              "description": "Lowercase hexadecimal SHA-256 of the source from which this metadata was produced.",
+              "pattern": "^[0-9a-f]{64}$",
+              "type": "string"
+            },
+            "visibility": {
+              "description": "Whether the documented contract item is customer-facing or repository-internal.",
+              "enum": [
+                "public",
+                "internal"
+              ]
+            }
+          },
+          "required": [
+            "formatVersion",
+            "itemId",
+            "documentation",
+            "examples",
+            "visibility",
+            "sourceHash"
+          ],
+          "title": "You contract documentation metadata",
+          "type": "object"
+        },
+        "family": {
+          "description": "Stable lowercase item identity. Dot, underscore, and hyphen separators are allowed; display names and source locations are not encoded.",
+          "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+          "type": "string"
+        },
+        "lifecycle": {
+          "$defs": {
+            "successor": {
+              "additionalProperties": false,
+              "description": "The replacement contract item and canonical English migration guidance.",
+              "properties": {
+                "canonicalEnglish": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "targetItemId": {
+                  "description": "Stable lowercase item identity. Dot, underscore, and hyphen separators are allowed; display names and source locations are not encoded.",
+                  "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "targetItemId",
+                "canonicalEnglish"
+              ],
+              "type": "object"
+            },
+            "version": {
+              "description": "A three-part stable semantic version without a leading v or leading zeroes.",
+              "pattern": "^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$",
+              "type": "string"
+            }
+          },
+          "$id": "https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "additionalProperties": false,
+          "description": "Family-neutral lifecycle and migration metadata for one contract item. This metadata describes support history and does not control runtime callability.",
+          "oneOf": [
+            {
+              "properties": {
+                "deprecated": false,
+                "removed": false,
+                "state": {
+                  "const": "active"
+                },
+                "successor": false
+              }
+            },
+            {
+              "properties": {
+                "removed": false,
+                "state": {
+                  "const": "deprecated"
+                }
+              },
+              "required": [
+                "deprecated",
+                "successor"
+              ]
+            },
+            {
+              "properties": {
+                "state": {
+                  "const": "removed"
+                }
+              },
+              "required": [
+                "deprecated",
+                "removed",
+                "successor"
+              ]
+            }
+          ],
+          "properties": {
+            "deprecated": {
+              "allOf": [
+                {
+                  "description": "A three-part stable semantic version without a leading v or leading zeroes.",
+                  "pattern": "^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$",
+                  "type": "string"
+                }
+              ],
+              "description": "The first package version in which the item was deprecated."
+            },
+            "formatVersion": {
+              "const": "1.0.0",
+              "description": "The explicitly supported version of this lifecycle metadata format."
+            },
+            "itemId": {
+              "description": "Stable lowercase item identity. Dot, underscore, and hyphen separators are allowed; display names and source locations are not encoded.",
+              "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+              "type": "string"
+            },
+            "removed": {
+              "allOf": [
+                {
+                  "description": "A three-part stable semantic version without a leading v or leading zeroes.",
+                  "pattern": "^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$",
+                  "type": "string"
+                }
+              ],
+              "description": "The first package version from which the item was absent."
+            },
+            "since": {
+              "allOf": [
+                {
+                  "description": "A three-part stable semantic version without a leading v or leading zeroes.",
+                  "pattern": "^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$",
+                  "type": "string"
+                }
+              ],
+              "description": "The first package version containing the item."
+            },
+            "state": {
+              "description": "The item's publication lifecycle state.",
+              "enum": [
+                "active",
+                "deprecated",
+                "removed"
+              ]
+            },
+            "successor": {
+              "additionalProperties": false,
+              "description": "The replacement contract item and canonical English migration guidance.",
+              "properties": {
+                "canonicalEnglish": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "targetItemId": {
+                  "description": "Stable lowercase item identity. Dot, underscore, and hyphen separators are allowed; display names and source locations are not encoded.",
+                  "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "targetItemId",
+                "canonicalEnglish"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "formatVersion",
+            "itemId",
+            "state",
+            "since"
+          ],
+          "title": "You contract lifecycle metadata",
+          "type": "object"
+        },
+        "path": {
+          "description": "Stable repository-relative artifact path with no empty, current-directory, or parent-directory segments.",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*(?:/[A-Za-z0-9][A-Za-z0-9._-]*)*$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "family",
+        "artifactHash",
+        "documentation",
+        "lifecycle"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://schemas.portpowered.com/you/contracts/manifest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Family-neutral package, source, export, and artifact integrity metadata for a published contract bundle.",
+  "properties": {
+    "exports": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "artifactHash": {
+            "description": "Lowercase hexadecimal SHA-256 of the exported artifact.",
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "documentation": {
+            "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json"
+          },
+          "family": {
+            "description": "Stable lowercase item identity. Dot, underscore, and hyphen separators are allowed; display names and source locations are not encoded.",
+            "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+            "type": "string"
+          },
+          "lifecycle": {
+            "$ref": "https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json"
+          },
+          "path": {
+            "description": "Stable repository-relative artifact path with no empty, current-directory, or parent-directory segments.",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*(?:/[A-Za-z0-9][A-Za-z0-9._-]*)*$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "family",
+          "artifactHash",
+          "documentation",
+          "lifecycle"
+        ],
+        "type": "object"
+      },
+      "description": "Published artifacts keyed by stable export identifiers. Object keys make duplicate export IDs structurally unrepresentable.",
+      "minProperties": 1,
+      "propertyNames": {
+        "description": "Stable lowercase item identity. Dot, underscore, and hyphen separators are allowed; display names and source locations are not encoded.",
+        "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "familyFormatVersions": {
+      "additionalProperties": {
+        "description": "A three-part stable semantic version without a leading v or leading zeroes.",
+        "pattern": "^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$",
+        "type": "string"
+      },
+      "description": "Supported contract-family format versions keyed by stable, family-neutral identifiers.",
+      "minProperties": 1,
+      "propertyNames": {
+        "description": "Stable lowercase item identity. Dot, underscore, and hyphen separators are allowed; display names and source locations are not encoded.",
+        "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "formatVersion": {
+      "const": "1.0.0",
+      "description": "The explicitly supported version of this manifest format."
+    },
+    "packageId": {
+      "description": "Stable lowercase item identity. Dot, underscore, and hyphen separators are allowed; display names and source locations are not encoded.",
+      "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+      "type": "string"
+    },
+    "packageVersion": {
+      "description": "A three-part stable semantic version without a leading v or leading zeroes.",
+      "pattern": "^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$",
+      "type": "string"
+    },
+    "sourceCommit": {
+      "description": "The lowercase full-length Git SHA-1 or SHA-256 commit identifying the package source.",
+      "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64})$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "formatVersion",
+    "packageId",
+    "packageVersion",
+    "sourceCommit",
+    "familyFormatVersions",
+    "exports"
+  ],
+  "title": "You contract package manifest",
+  "type": "object"
+}


### PR DESCRIPTION
{
  "project": "you-agent-factory deterministic contract generation drift and staging boundaries",
  "branchName": "interfaces-b05-generation-drift-and-staging-checks",
  "description": "Add deterministic contract generation and read-only drift checking after the reviewed B05 joiner, restrict package staging to reviewed contract artifacts, report stale, missing, and unexpected paths actionably, and enforce the same gate in focused build-contract CI without mutating canonical authored sources.",
  "context": {
    "customerAsk": "After the reviewed B05 joiner is merged, add `make contracts-generate`, `make contracts-check`, focused build-contract CI wiring, and a package-staging allowlist. Generation must create only reviewed joined contract artifacts reproducibly; checking must detect stale, missing, and forbidden staged files with deterministic remediation while proving canonical authored sources remain unchanged.",
    "problem": "The B05 joiner can derive self-contained contract documents, but generation alone does not prevent a stale or deleted projection from reaching downstream packaging and does not stop generated clients, UI artifacts, executables, caches, or unrelated files from contaminating package staging. A check that regenerates directly over the repository could also hide the original mismatch or mutate protected authored inputs.",
    "solution": "Provide one controlled generation command that invokes the reviewed joiner and owns only allowlisted contract staging outputs. Provide a read-only check that generates expected output in isolation, compares path sets and bytes, and deterministically reports all stale, missing, and unexpected repository-relative paths with `make contracts-generate` remediation. Prove clean and failing states, repeat-run stability, source immutability, and package-boundary fit through focused smoke tests and the existing build-contract CI lane."
  },
  "acceptanceCriteria": [
    "AC-1: `make contracts-generate` invokes the reviewed B05 joiner and reproducibly writes only reviewed joined contract artifacts allowed in package staging.",
    "AC-2: `make contracts-check` passes without modifying the repository when canonical sources and staged artifacts agree.",
    "AC-3: `make contracts-check` fails for stale generated content, a missing generated artifact, and any non-allowlisted staged file, including generated API clients, UI artifacts, executables, caches, and unrelated files.",
    "AC-4: Failure output groups stale, missing, and unexpected repository-relative paths, sorts every reported path deterministically, and identifies `make contracts-generate` as the corrective command.",
    "AC-5: Repeated validation, generation, and checking produce identical generated digests and no second-run diff while authored contracts, fixtures, executable inventory baselines, and unrelated files retain their original bytes.",
    "AC-6: Focused shell or Go smoke coverage proves clean, stale, missing, and forbidden fixture behavior, and the contract check runs in the existing focused build-contract CI path without broadening unrelated verification lanes.",
    "AC-7: Quality gates pass: typecheck, lint, tests, `make pkg-boundary`, and `make pkg-file-count`."
  ],
  "userStories": [
    {
      "id": "interfaces-b05-generation-drift-and-staging-checks-001",
      "title": "Generate only approved joined contract artifacts reproducibly",
      "description": "As a contract maintainer, I want one deterministic generation command so that package staging can be recreated from canonical sources without changing authored inputs or admitting unrelated output.",
      "acceptanceCriteria": [
        "`make contracts-generate` delegates joined-document construction to the reviewed B05 joiner rather than reimplementing reference resolution or canonicalization.",
        "Starting from the same canonical sources, two generation runs produce the same allowlisted path set and byte-identical artifact digests, with no second-run diff.",
        "Generation writes only within the owned package-staging boundary and leaves authored schemas, contract fixtures, executable inventory baselines, existing generated API clients, UI artifacts, and unrelated repository files byte-identical.",
        "The staging policy permits only explicitly reviewed raw/generated contract artifacts and does not permit generated clients, UI output, executables, caches, or unrelated files.",
        "A canonical component change is reflected in each affected joined consumer through the reviewed joiner on the next generation run.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b05-generation-drift-and-staging-checks-002",
      "title": "Report stale, missing, and unexpected staged artifacts without rewriting the tree",
      "description": "As a maintainer, I want contract checking to explain every staging mismatch without repairing it implicitly so that I can review the failure and regenerate intentionally.",
      "acceptanceCriteria": [
        "`make contracts-check` passes on a clean tree whose staged artifacts exactly match isolated expected output from the canonical sources.",
        "The check exits non-zero when an allowlisted artifact has stale bytes, when an expected artifact is missing, or when staging contains a non-allowlisted path.",
        "One run can report all present mismatch categories, using the labels `stale`, `missing`, and `unexpected`, without stopping after the first finding.",
        "Reported repository-relative paths are sorted deterministically within a stable category order, and repeated checks of the same fixture produce byte-identical diagnostics.",
        "Failure output identifies `make contracts-generate` as the corrective command and makes clear that unexpected files must not remain in staging.",
        "Checking computes expected output outside repository staging and does not change staged files, canonical sources, fixtures, inventory baselines, or unrelated repository files on either success or failure.",
        "Focused smoke cases directly exercise clean, stale, missing, and forbidden fixture directories, including representative rejected client, UI, executable, and cache paths.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b05-generation-drift-and-staging-checks-003",
      "title": "Enforce contract drift in the focused build-contract verification lane",
      "description": "As a repository maintainer, I want CI to run the same contract drift gate used locally so that stale or contaminated staging cannot merge while unrelated verification behavior remains unchanged.",
      "acceptanceCriteria": [
        "The existing focused build-contract CI path invokes the repository-owned contract validation and drift-check entrypoints using the same behavior available to local maintainers.",
        "CI fails when the focused drift smoke introduces a stale, missing, or unexpected staged artifact and passes for a clean deterministic generation state.",
        "CI wiring remains limited to contract validation/generation drift enforcement and does not change shared runtime, UI, API-client generation, or unrelated verification behavior.",
        "The focused contract smoke tests pass together with `make contracts-validate`, `make contracts-generate`, and `make contracts-check` run twice.",
        "`make pkg-boundary` and `make pkg-file-count` remain green, demonstrating that contract build tooling has not become a runtime dependency or created an unapproved package boundary.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}
