### PR TITLE
session-repair-checkpoint-lifecycle-flush

### DIFF
--- a/ui/src/App.multi-session-checkpoint-debounce.test.tsx
+++ b/ui/src/App.multi-session-checkpoint-debounce.test.tsx
@@ -20,6 +20,10 @@ import {
   renderAppWithDashboardShell,
 } from "./testing/app-shell-test-utils";
 import {
+  createControlledIndexedDBTestDouble,
+  flushPromiseContinuations,
+} from "./testing/controlled-indexeddb-test-utils";
+import {
   MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO,
   type MultiSessionTimelineCheckpointFixture,
 } from "./testing/multi-session-timeline-checkpoint-scenario";
@@ -27,6 +31,13 @@ import { createTimelineCheckpointIndexedDBTestDouble } from "./testing/timeline-
 
 const CHECKPOINT_DEBOUNCE_MS = 750;
 const { A, B } = MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO;
+
+interface StoredCheckpointEnvelope {
+  checkpoint?: MultiSessionTimelineCheckpointFixture["checkpoint"];
+  schemaVersion?: number;
+  storageKey?: string;
+  streamIdentity?: MultiSessionTimelineCheckpointFixture["streamIdentity"];
+}
 
 function previousCheckpointFor(
   fixture: MultiSessionTimelineCheckpointFixture,
@@ -165,6 +176,40 @@ async function settleCheckpointPersistence(): Promise<void> {
       await Promise.resolve();
     }
   });
+}
+
+async function advanceControlledWrite(
+  fixture: ReturnType<
+    typeof createControlledIndexedDBTestDouble<StoredCheckpointEnvelope>
+  >,
+  openOrdinal = 0,
+): Promise<void> {
+  fixture.controls.succeed("open", openOrdinal);
+  await flushPromiseContinuations();
+  fixture.controls.succeed("get");
+  await flushPromiseContinuations();
+  await flushPromiseContinuations();
+  fixture.controls.succeed("open", openOrdinal);
+  await flushPromiseContinuations();
+  fixture.controls.succeed("put");
+  fixture.controls.completeTransaction();
+  for (let turn = 0; turn < 4; turn += 1) {
+    await flushPromiseContinuations();
+  }
+}
+
+async function advanceQueuedControlledWrite(
+  fixture: ReturnType<
+    typeof createControlledIndexedDBTestDouble<StoredCheckpointEnvelope>
+  >,
+): Promise<void> {
+  fixture.controls.succeed("open");
+  await flushPromiseContinuations();
+  fixture.controls.succeed("put");
+  fixture.controls.completeTransaction();
+  for (let turn = 0; turn < 4; turn += 1) {
+    await flushPromiseContinuations();
+  }
 }
 
 async function renderSessionA(options: { writeError?: Error } = {}) {
@@ -360,5 +405,64 @@ describe("App checkpoint lifecycle safety", () => {
     ).resolves.toBeNull();
     expect(pageHide.defaultPrevented).toBe(false);
     expect(writeAttempts()).toBe(1);
+  });
+
+  it("keeps newer same-stream state authoritative while A and B lifecycle writes overlap", async () => {
+    const { indexedDB: preflightIndexedDB, unmount } = await renderSessionA();
+    const controlled =
+      createControlledIndexedDBTestDouble<StoredCheckpointEnvelope>();
+    vi.stubGlobal("indexedDB", controlled.indexedDB);
+
+    await scheduleCheckpoint(previousCheckpointFor(A));
+    window.dispatchEvent(new Event("pagehide"));
+    await flushPromiseContinuations();
+    await scheduleCheckpoint(A);
+    await advanceCheckpointTimer(CHECKPOINT_DEBOUNCE_MS);
+
+    vi.stubGlobal("indexedDB", preflightIndexedDB);
+    await selectSession("beta", B);
+    vi.stubGlobal("indexedDB", controlled.indexedDB);
+    await scheduleCheckpoint(B);
+    window.dispatchEvent(new Event("pagehide"));
+    await flushPromiseContinuations();
+
+    expect(controlled.controls.pendingOperations()).toEqual(["open", "open"]);
+
+    // B owns an independent identity lane and may finish before the older A
+    // lifecycle write even though A was admitted first.
+    await advanceControlledWrite(controlled, 1);
+    await advanceControlledWrite(controlled);
+    expect(controlled.controls.pendingOperations()).toEqual(["open"]);
+    await advanceQueuedControlledWrite(controlled);
+
+    const stored = [...controlled.records.values()];
+    expect(stored).toHaveLength(2);
+    expect(
+      stored.find(
+        ({ streamIdentity }) =>
+          streamIdentity?.factorySessionID ===
+          A.streamIdentity.factorySessionID,
+      ),
+    ).toEqual({
+      checkpoint: A.checkpoint,
+      schemaVersion: expect.any(Number),
+      storageKey: expect.any(String),
+      streamIdentity: A.streamIdentity,
+    });
+    expect(
+      stored.find(
+        ({ streamIdentity }) =>
+          streamIdentity?.factorySessionID ===
+          B.streamIdentity.factorySessionID,
+      ),
+    ).toEqual({
+      checkpoint: B.checkpoint,
+      schemaVersion: expect.any(Number),
+      storageKey: expect.any(String),
+      streamIdentity: B.streamIdentity,
+    });
+
+    unmount();
+    expect(controlled.controls.pendingOperations()).toEqual([]);
   });
 });

--- a/ui/src/App.multi-session-checkpoint-debounce.test.tsx
+++ b/ui/src/App.multi-session-checkpoint-debounce.test.tsx
@@ -28,6 +28,25 @@ import { createTimelineCheckpointIndexedDBTestDouble } from "./testing/timeline-
 const CHECKPOINT_DEBOUNCE_MS = 750;
 const { A, B } = MULTI_SESSION_TIMELINE_CHECKPOINT_SCENARIO;
 
+function previousCheckpointFor(
+  fixture: MultiSessionTimelineCheckpointFixture,
+): MultiSessionTimelineCheckpointFixture {
+  const previous = structuredClone(fixture);
+  previous.checkpoint.afterEventId = `session-${fixture.label.toLowerCase()}-event-previous`;
+  previous.checkpoint.afterSequence -= 1;
+  previous.checkpoint.selectedTick -= 1;
+  previous.checkpoint.replayState.tick_count -= 1;
+  if (previous.checkpoint.materializedWorkOutcomeState.cursor) {
+    previous.checkpoint.materializedWorkOutcomeState.cursor.eventID =
+      previous.checkpoint.afterEventId;
+    previous.checkpoint.materializedWorkOutcomeState.cursor.sequence =
+      previous.checkpoint.afterSequence;
+    previous.checkpoint.materializedWorkOutcomeState.cursor.tick =
+      previous.checkpoint.selectedTick;
+  }
+  return previous;
+}
+
 const factorySessions: FactorySessionSummary[] = [
   sessionSummary(A, "alpha"),
   sessionSummary(B, "beta"),
@@ -169,28 +188,21 @@ describe("App multi-session checkpoint debounce regression", () => {
     return indexedDB;
   }
 
-  it.fails("retains checkpoints that become due after A to B to A switching just before 750 ms", async () => {
+  it("flushes each stream's latest checkpoint during rapid A to B to A switching", async () => {
     const indexedDB = await renderSessionA();
 
+    await scheduleCheckpoint(previousCheckpointFor(A));
     await scheduleCheckpoint(A);
     await advanceCheckpointTimer(CHECKPOINT_DEBOUNCE_MS - 1);
     await selectSession("beta", B);
+
+    await expect(
+      readTimelineCheckpoint(indexedDB, A.streamIdentity),
+    ).resolves.toEqual(A.checkpoint);
+
     await scheduleCheckpoint(B);
     await selectSession("alpha", A);
-    await advanceCheckpointTimer(1);
 
-    const aAtOriginalDueBoundary = await readTimelineCheckpoint(
-      indexedDB,
-      A.streamIdentity,
-    );
-
-    await scheduleCheckpoint(A);
-    await advanceCheckpointTimer(CHECKPOINT_DEBOUNCE_MS);
-    await selectSession("beta", B);
-    await scheduleCheckpoint(B);
-    await advanceCheckpointTimer(CHECKPOINT_DEBOUNCE_MS);
-
-    expect.soft(aAtOriginalDueBoundary).toEqual(A.checkpoint);
     await expect(
       readTimelineCheckpoint(indexedDB, A.streamIdentity),
     ).resolves.toEqual(A.checkpoint);

--- a/ui/src/App.multi-session-checkpoint-debounce.test.tsx
+++ b/ui/src/App.multi-session-checkpoint-debounce.test.tsx
@@ -159,6 +159,38 @@ async function advanceCheckpointTimer(milliseconds: number): Promise<void> {
   });
 }
 
+async function settleCheckpointPersistence(): Promise<void> {
+  await act(async () => {
+    for (let turn = 0; turn < 8; turn += 1) {
+      await Promise.resolve();
+    }
+  });
+}
+
+async function renderSessionA(options: { writeError?: Error } = {}) {
+  const checkpointDatabase =
+    createTimelineCheckpointIndexedDBTestDouble(options);
+  const { indexedDB } = checkpointDatabase;
+  vi.stubGlobal("indexedDB", indexedDB);
+  useDashboardSessionStore.setState({
+    pausedSessionIDs: [],
+    selectedSessionID: A.streamIdentity.factorySessionID,
+  });
+  const view = await renderAppWithDashboardShell({
+    factorySessions,
+    fetchOverride: multiSessionPreflightFetch(),
+    seedTimelineFromSnapshot: false,
+    snapshot: snapshotFor(A),
+  });
+  await waitFor(() => {
+    expect(requireEventStream(MockEventSource.instances).url).toBe(
+      expectedStreamURL(A),
+    );
+  });
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  return { ...checkpointDatabase, ...view };
+}
+
 describe("App multi-session checkpoint debounce regression", () => {
   registerAppDashboardTestLifecycle();
 
@@ -166,30 +198,8 @@ describe("App multi-session checkpoint debounce regression", () => {
     vi.useRealTimers();
   });
 
-  async function renderSessionA(): Promise<IDBFactory> {
-    const { indexedDB } = createTimelineCheckpointIndexedDBTestDouble();
-    vi.stubGlobal("indexedDB", indexedDB);
-    useDashboardSessionStore.setState({
-      pausedSessionIDs: [],
-      selectedSessionID: A.streamIdentity.factorySessionID,
-    });
-    await renderAppWithDashboardShell({
-      factorySessions,
-      fetchOverride: multiSessionPreflightFetch(),
-      seedTimelineFromSnapshot: false,
-      snapshot: snapshotFor(A),
-    });
-    await waitFor(() => {
-      expect(requireEventStream(MockEventSource.instances).url).toBe(
-        expectedStreamURL(A),
-      );
-    });
-    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
-    return indexedDB;
-  }
-
   it("flushes each stream's latest checkpoint during rapid A to B to A switching", async () => {
-    const indexedDB = await renderSessionA();
+    const { indexedDB } = await renderSessionA();
 
     await scheduleCheckpoint(previousCheckpointFor(A));
     await scheduleCheckpoint(A);
@@ -212,7 +222,7 @@ describe("App multi-session checkpoint debounce regression", () => {
   });
 
   it("keeps A durable when switching A to B to A after its 750 ms boundary", async () => {
-    const indexedDB = await renderSessionA();
+    const { indexedDB } = await renderSessionA();
 
     await scheduleCheckpoint(A);
     await advanceCheckpointTimer(CHECKPOINT_DEBOUNCE_MS);
@@ -237,5 +247,118 @@ describe("App multi-session checkpoint debounce regression", () => {
     await expect(
       readTimelineCheckpoint(indexedDB, B.streamIdentity),
     ).resolves.toEqual(B.checkpoint);
+  });
+});
+
+describe("App checkpoint lifecycle handoff", () => {
+  registerAppDashboardTestLifecycle();
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("flushes the latest pending checkpoint on unmount", async () => {
+    const { indexedDB, unmount, writeAttempts } = await renderSessionA();
+
+    await scheduleCheckpoint(previousCheckpointFor(A));
+    await scheduleCheckpoint(A);
+    unmount();
+    await settleCheckpointPersistence();
+
+    await expect(
+      readTimelineCheckpoint(indexedDB, A.streamIdentity),
+    ).resolves.toEqual(A.checkpoint);
+    expect(writeAttempts()).toBe(1);
+  });
+
+  it("flushes on pagehide without blocking navigation or repeating the handoff", async () => {
+    const { indexedDB, writeAttempts } = await renderSessionA();
+    await scheduleCheckpoint(A);
+    const pageHide = new Event("pagehide", { cancelable: true });
+
+    expect(window.dispatchEvent(pageHide)).toBe(true);
+    expect(pageHide.defaultPrevented).toBe(false);
+    window.dispatchEvent(new Event("pagehide"));
+    await advanceCheckpointTimer(CHECKPOINT_DEBOUNCE_MS);
+
+    await expect(
+      readTimelineCheckpoint(indexedDB, A.streamIdentity),
+    ).resolves.toEqual(A.checkpoint);
+    expect(writeAttempts()).toBe(1);
+  });
+
+  it("flushes only when visibility changes to hidden", async () => {
+    const { indexedDB, writeAttempts } = await renderSessionA();
+    await scheduleCheckpoint(A);
+    const visibilityState = vi.spyOn(document, "visibilityState", "get");
+
+    visibilityState.mockReturnValue("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+    visibilityState.mockReturnValue("prerender");
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(writeAttempts()).toBe(0);
+
+    visibilityState.mockReturnValue("hidden");
+    document.dispatchEvent(new Event("visibilitychange"));
+    document.dispatchEvent(new Event("visibilitychange"));
+    await settleCheckpointPersistence();
+
+    await expect(
+      readTimelineCheckpoint(indexedDB, A.streamIdentity),
+    ).resolves.toEqual(A.checkpoint);
+    expect(writeAttempts()).toBe(1);
+  });
+});
+
+describe("App checkpoint lifecycle safety", () => {
+  registerAppDashboardTestLifecycle();
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("installs lifecycle listeners once and removes them on unmount", async () => {
+    const addWindowListener = vi.spyOn(window, "addEventListener");
+    const removeWindowListener = vi.spyOn(window, "removeEventListener");
+    const addDocumentListener = vi.spyOn(document, "addEventListener");
+    const removeDocumentListener = vi.spyOn(document, "removeEventListener");
+    const { unmount } = await renderSessionA();
+
+    expect(
+      addWindowListener.mock.calls.filter(([type]) => type === "pagehide"),
+    ).toHaveLength(1);
+    expect(
+      addDocumentListener.mock.calls.filter(
+        ([type]) => type === "visibilitychange",
+      ),
+    ).toHaveLength(1);
+
+    unmount();
+
+    expect(
+      removeWindowListener.mock.calls.filter(([type]) => type === "pagehide"),
+    ).toHaveLength(1);
+    expect(
+      removeDocumentListener.mock.calls.filter(
+        ([type]) => type === "visibilitychange",
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("contains a lifecycle-time persistence rejection", async () => {
+    const { indexedDB, writeAttempts } = await renderSessionA({
+      writeError: new Error("storage refused"),
+    });
+    await scheduleCheckpoint(A);
+    const pageHide = new Event("pagehide", { cancelable: true });
+
+    expect(window.dispatchEvent(pageHide)).toBe(true);
+    await settleCheckpointPersistence();
+
+    await expect(
+      readTimelineCheckpoint(indexedDB, A.streamIdentity),
+    ).resolves.toBeNull();
+    expect(pageHide.defaultPrevented).toBe(false);
+    expect(writeAttempts()).toBe(1);
   });
 });

--- a/ui/src/features/dashboard/hooks/useDashboardSnapshot.ts
+++ b/ui/src/features/dashboard/hooks/useDashboardSnapshot.ts
@@ -172,6 +172,29 @@ function usePersistedTimelineCheckpoint({
       flushPendingCheckpoint(streamKey);
     };
   }, [flushPendingCheckpoint, streamKey]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof document === "undefined") {
+      return;
+    }
+
+    const handlePageHide = () => {
+      flushPendingCheckpoint();
+    };
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        flushPendingCheckpoint();
+      }
+    };
+
+    window.addEventListener("pagehide", handlePageHide);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      window.removeEventListener("pagehide", handlePageHide);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      flushPendingCheckpoint();
+    };
+  }, [flushPendingCheckpoint]);
 }
 
 // biome-ignore lint/complexity/noExcessiveLinesPerFunction: snapshot composition keeps preflight, checkpoint hydration, and stream wiring in one hook.

--- a/ui/src/features/dashboard/hooks/useDashboardSnapshot.ts
+++ b/ui/src/features/dashboard/hooks/useDashboardSnapshot.ts
@@ -5,6 +5,7 @@ import { DEFAULT_FACTORY_SESSION_ID } from "../../../api/session-routing";
 import {
   clearTimelineCheckpoint,
   type FactoryTimelineCheckpoint,
+  normalizeStreamDerivedCacheIdentity,
   persistTimelineCheckpoint,
   readFactoryTimelineDebugOptions,
   reconnectCursorFromCheckpoint,
@@ -41,6 +42,24 @@ export interface DashboardSnapshotResult {
 
 type DashboardPreflightStatus = "loading" | "non-recoverable" | "success";
 
+interface PendingTimelineCheckpoint {
+  checkpoint: FactoryTimelineCheckpoint;
+  indexedDB: IDBFactory;
+  streamIdentity: TimelineCheckpointStreamIdentity;
+  streamKey: string;
+}
+
+function timelineCheckpointStreamKey(
+  identity: TimelineCheckpointStreamIdentity,
+): string {
+  return JSON.stringify([
+    identity.backendScopeID,
+    identity.factorySessionID,
+    identity.logicalSessionKeyID,
+    identity.streamGenerationID,
+  ]);
+}
+
 function usePersistedTimelineCheckpoint({
   checkpoint,
   checkpointsDisabled,
@@ -52,26 +71,107 @@ function usePersistedTimelineCheckpoint({
   streamIdentity: TimelineCheckpointStreamIdentity | null;
   syncIdentity?: FactoryTimelineCheckpoint["syncIdentity"];
 }) {
+  const pendingCheckpointRef = useRef<PendingTimelineCheckpoint | null>(null);
+  const persistHandleRef = useRef<number | null>(null);
+  const backendScopeID = streamIdentity?.backendScopeID;
+  const factorySessionID = streamIdentity?.factorySessionID;
+  const logicalSessionKeyID = streamIdentity?.logicalSessionKeyID;
+  const streamGenerationID = streamIdentity?.streamGenerationID;
+  const normalizedStreamIdentity = useMemo(
+    () =>
+      normalizeStreamDerivedCacheIdentity({
+        backendScopeID,
+        factorySessionID,
+        logicalSessionKeyID,
+        streamGenerationID,
+      }),
+    [backendScopeID, factorySessionID, logicalSessionKeyID, streamGenerationID],
+  );
+  const streamKey = normalizedStreamIdentity
+    ? timelineCheckpointStreamKey(normalizedStreamIdentity)
+    : null;
+
+  const detachPendingCheckpoint = useCallback(
+    (expectedStreamKey?: string): PendingTimelineCheckpoint | null => {
+      const pending = pendingCheckpointRef.current;
+      if (
+        !pending ||
+        (expectedStreamKey && pending.streamKey !== expectedStreamKey)
+      ) {
+        return null;
+      }
+      pendingCheckpointRef.current = null;
+      if (persistHandleRef.current !== null) {
+        window.clearTimeout(persistHandleRef.current);
+        persistHandleRef.current = null;
+      }
+      return pending;
+    },
+    [],
+  );
+
+  const flushPendingCheckpoint = useCallback(
+    (expectedStreamKey?: string) => {
+      const pending = detachPendingCheckpoint(expectedStreamKey);
+      if (!pending) {
+        return;
+      }
+      void persistTimelineCheckpoint(
+        pending.indexedDB,
+        pending.checkpoint,
+        pending.streamIdentity,
+      );
+    },
+    [detachPendingCheckpoint],
+  );
+
   useEffect(() => {
-    if (typeof window === "undefined" || checkpointsDisabled) {
+    if (
+      typeof window === "undefined" ||
+      checkpointsDisabled ||
+      !checkpoint ||
+      !normalizedStreamIdentity ||
+      !streamKey
+    ) {
+      detachPendingCheckpoint();
       return;
     }
-    const persistHandle = window.setTimeout(() => {
-      void persistTimelineCheckpoint(
-        window.indexedDB,
-        checkpoint
-          ? {
-              ...checkpoint,
-              ...(syncIdentity ? { syncIdentity } : {}),
-            }
-          : undefined,
-        streamIdentity,
-      );
+
+    detachPendingCheckpoint();
+    const pending = {
+      checkpoint: {
+        ...checkpoint,
+        ...(syncIdentity ? { syncIdentity } : {}),
+      },
+      indexedDB: window.indexedDB,
+      streamIdentity: normalizedStreamIdentity,
+      streamKey,
+    } satisfies PendingTimelineCheckpoint;
+    pendingCheckpointRef.current = pending;
+    persistHandleRef.current = window.setTimeout(() => {
+      if (pendingCheckpointRef.current !== pending) {
+        return;
+      }
+      flushPendingCheckpoint(pending.streamKey);
     }, 750);
+  }, [
+    checkpoint,
+    checkpointsDisabled,
+    detachPendingCheckpoint,
+    flushPendingCheckpoint,
+    normalizedStreamIdentity,
+    streamKey,
+    syncIdentity,
+  ]);
+
+  useEffect(() => {
+    if (!streamKey) {
+      return;
+    }
     return () => {
-      window.clearTimeout(persistHandle);
+      flushPendingCheckpoint(streamKey);
     };
-  }, [checkpoint, checkpointsDisabled, streamIdentity, syncIdentity]);
+  }, [flushPendingCheckpoint, streamKey]);
 }
 
 // biome-ignore lint/complexity/noExcessiveLinesPerFunction: snapshot composition keeps preflight, checkpoint hydration, and stream wiring in one hook.

--- a/ui/src/testing/timeline-checkpoint-indexeddb-test-utils.ts
+++ b/ui/src/testing/timeline-checkpoint-indexeddb-test-utils.ts
@@ -2,11 +2,15 @@ interface StoredCheckpointEnvelope {
   storageKey?: string;
 }
 
-export function createTimelineCheckpointIndexedDBTestDouble(): {
+export function createTimelineCheckpointIndexedDBTestDouble(
+  options: { writeError?: Error } = {},
+): {
   indexedDB: IDBFactory;
   records: Map<string, StoredCheckpointEnvelope>;
+  writeAttempts: () => number;
 } {
   const records = new Map<string, StoredCheckpointEnvelope>();
+  let attemptedWrites = 0;
   const database = {
     close: () => {},
     createObjectStore: () => undefined,
@@ -33,8 +37,16 @@ export function createTimelineCheckpointIndexedDBTestDouble(): {
             ),
           get: (key: string) => indexedDBTestRequest(records.get(key)),
           getAll: () => indexedDBTestRequest([...records.values()]),
-          put: (value: StoredCheckpointEnvelope) =>
-            indexedDBTestRequest(
+          put: (value: StoredCheckpointEnvelope) => {
+            attemptedWrites += 1;
+            if (options.writeError) {
+              return indexedDBErrorTestRequest(options.writeError, () => {
+                (transaction.onerror as ((event: Event) => void) | null)?.(
+                  {} as Event,
+                );
+              });
+            }
+            return indexedDBTestRequest(
               value.storageKey ?? "",
               () => {
                 if (value.storageKey) {
@@ -45,7 +57,8 @@ export function createTimelineCheckpointIndexedDBTestDouble(): {
                 (transaction.oncomplete as ((event: Event) => void) | null)?.(
                   {} as Event,
                 ),
-            ),
+            );
+          },
         }),
       };
       return transaction;
@@ -63,6 +76,7 @@ export function createTimelineCheckpointIndexedDBTestDouble(): {
       },
     } as unknown as IDBFactory,
     records,
+    writeAttempts: () => attemptedWrites,
   };
 }
 


### PR DESCRIPTION
{
  "project": "Preserve Checkpoints Across Session and Page Lifecycle Boundaries",
  "branchName": "session-repair-checkpoint-lifecycle-flush",
  "description": "Preserve the latest safe bounded dashboard timeline checkpoint across rapid Factory Session switches, unmount, pagehide, and supported hidden-visibility transitions by replacing cancellation-only debounce cleanup with an identity-safe, stream-scoped best-effort flush that uses the existing ordered checkpoint writer.",
  "context": {
    "customerAsk": "Replace cancellation-only debounce cleanup with a stream-scoped flush or supersession policy for session switch, unmount, pagehide, and supported visibility transitions so the latest safe bounded checkpoint is not lost.",
    "problem": "The dashboard delays checkpoint persistence by 750 ms, but effect cleanup only cancels the timer. Rapid session switching or page lifecycle teardown can therefore discard the newest pending checkpoint, while a naive shared flush could mix one session's projection with another session's identity or allow a delayed older write to regress durable state.",
    "solution": "Capture each pending bounded checkpoint together with its normalized four-part stream identity, flush the prior record on stream change, and use stable lifecycle listeners to hand off the current record on unmount, pagehide, and transition to hidden visibility. Detach handed-off state synchronously and route every write through the existing ordered per-identity writer so duplicate signals stay bounded, stale writes are superseded safely, and storage failure remains non-fatal."
  },
  "acceptanceCriteria": [
    "Switching from session A to session B before the 750 ms debounce expires hands session A's latest bounded checkpoint to persistence with session A's original normalized backend scope, real Factory Session ID, logical session key, and stream generation.",
    "Hook unmount and pagehide each independently hand off the latest pending checkpoint without requiring the debounce timer or a later browser event to run.",
    "A transition to document.visibilityState hidden independently hands off the latest pending checkpoint; unsupported or non-hidden visibility changes do not create extra writes.",
    "Lifecycle listeners are installed once per mounted hook owner, use current pending state without stale captured session values, are removed on unmount, and release handed-off candidates so pending memory remains bounded.",
    "Overlapping debounce and lifecycle flushes cannot mix checkpoint payloads and identities, write one stream beneath another stream's storage identity, or allow an older checkpoint to replace a newer same-stream checkpoint.",
    "Browser storage refusal, abort, or incomplete lifecycle-time completion remains best effort and non-fatal: the dashboard does not throw, block navigation, call preventDefault, or display a false durability guarantee.",
    "Quality gates pass: UI typecheck, UI lint, focused fake-timer and lifecycle hook tests, existing rapid-switch and materialized checkpoint regressions, and affected checkpoint persistence tests."
  ],
  "userStories": [
    {
      "id": "session-repair-checkpoint-lifecycle-flush-001",
      "title": "Flush the Previous Stream During Rapid Session Switching",
      "description": "As a dashboard user switching Factory Sessions, I want the previous stream's latest checkpoint handed off before its debounce is canceled so returning to that session can resume from the newest safe projection.",
      "acceptanceCriteria": [
        "When session A has a pending checkpoint and the active stream changes to session B before 750 ms, cleanup immediately submits A's latest candidate without waiting for A's timer.",
        "The submitted record keeps A's bounded checkpoint together with A's captured normalized backend scope, real Factory Session ID, logical session key, and stream generation; B's values cannot alter that record.",
        "If A produces multiple checkpoints inside the debounce window, only A's latest eligible candidate is handed off by the switch cleanup.",
        "After the switch, B owns a separate pending candidate and debounce schedule; completing A's handoff cannot clear, replace, or relabel B's candidate.",
        "Fake-timer hook coverage performs rapid A-to-B switching before 750 ms and verifies the persisted cursor, materialized projection, and complete stream identity for both streams where applicable.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "session-repair-checkpoint-lifecycle-flush-002",
      "title": "Flush Pending Checkpoints at Browser Lifecycle Boundaries",
      "description": "As a dashboard user leaving or backgrounding the page, I want the latest checkpoint handed to persistence immediately so ordinary browser lifecycle transitions do not silently discard the debounce window.",
      "acceptanceCriteria": [
        "Hook unmount clears the active debounce and immediately hands off the latest unflushed candidate under its captured identity.",
        "A pagehide event immediately hands off the latest unflushed candidate without waiting for another event, blocking the lifecycle, or prompting the user.",
        "A visibilitychange event flushes only when the document has become hidden; visible and unsupported visibility states do not enqueue an additional persistence attempt.",
        "Lifecycle listeners are installed once for the mounted hook owner, read the latest candidate through stable state ownership rather than captured render values, and are removed cleanly on unmount.",
        "Once a candidate is handed off it no longer remains pending, and repeated pagehide, hidden-visibility, timer, or cleanup signals do not retain or repeatedly submit unbounded copies of it.",
        "Storage refusal, transaction failure, or inability to finish before browser termination is contained by the existing best-effort persistence contract and causes no uncaught error or navigation-blocking behavior.",
        "Fake-timer lifecycle tests independently cover unmount, pagehide, hidden visibility, ignored visible visibility, duplicate signals, listener cleanup, and a rejected persistence attempt.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "session-repair-checkpoint-lifecycle-flush-003",
      "title": "Preserve Identity and Monotonicity Across Superseded Flushes",
      "description": "As a dashboard user receiving events while lifecycle writes overlap, I want a newer checkpoint to remain authoritative so a delayed flush cannot restore stale progress or another session's projection.",
      "acceptanceCriteria": [
        "Every timer, switch, unmount, and lifecycle flush passes one indivisible checkpoint-and-four-part-identity record to the ordered checkpoint writer.",
        "If a lifecycle flush for an older same-stream checkpoint overlaps a newer admitted checkpoint, the older flush cannot replace the newer cursor, event ID, selected tick, sync identity, or bounded materialized replay state.",
        "If lifecycle handling for session A overlaps active work for session B, persisted reads for each four-part identity return only that stream's checkpoint fields and materialized projection.",
        "A superseded or failed flush settles without deleting a newer committed checkpoint, poisoning subsequent writes, or recreating cleared pending state.",
        "Deterministic controlled-write and fake-timer tests cover a superseded lifecycle flush, reverse completion order, and overlapping A/B candidates, and verify final persisted records rather than implementation topology.",
        "Existing rapid-switch, ordered-writer, replacement-failure, and bounded materialized checkpoint regressions pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}
