### PR TITLE
runtime-visit-count-sibling-isolation

### DIFF
--- a/pkg/factory/runtime/factory_modes_test.go
+++ b/pkg/factory/runtime/factory_modes_test.go
@@ -604,6 +604,140 @@ func TestRuntimeVisitCountRoutesSharedTraceSiblingsIndependentlyAtThreshold(t *t
 	assertReviewDispatch(t, independent, maxReviews, "work-unaffected")
 }
 
+func TestRuntimeVisitCountReplayPreservesSharedTraceSiblingRouting(t *testing.T) {
+	const maxReviews = 3
+	live := runVisitCountSiblingIsolationScenario(t, maxReviews)
+	replayed := replayVisitCountSiblingIsolationScenario(t, maxReviews, runtimeGeneratedEvents(t, live))
+
+	liveSnapshot := runtimeSnapshot(t, live)
+	replaySnapshot := runtimeSnapshot(t, replayed)
+	assertWorkVisitState(t, replaySnapshot, "work-repeated", "task:failed", maxReviews)
+	assertWorkVisitState(t, replaySnapshot, "work-unaffected", "task:review", 1)
+	if len(replaySnapshot.DispatchHistory) != len(liveSnapshot.DispatchHistory) {
+		t.Fatalf("replayed dispatch count = %d, want live count %d", len(replaySnapshot.DispatchHistory), len(liveSnapshot.DispatchHistory))
+	}
+	for index := range liveSnapshot.DispatchHistory {
+		liveDispatch := liveSnapshot.DispatchHistory[index]
+		replayDispatch := replaySnapshot.DispatchHistory[index]
+		if liveDispatch.TransitionID != replayDispatch.TransitionID {
+			t.Fatalf("replayed dispatch[%d] transition = %q, want live %q", index, replayDispatch.TransitionID, liveDispatch.TransitionID)
+		}
+		assertReviewDispatch(t, replaySnapshot, index, workIDForCompletedDispatch(t, liveDispatch))
+	}
+}
+
+func runVisitCountSiblingIsolationScenario(t *testing.T, maxReviews int) factory.Factory {
+	t.Helper()
+	f, err := New(
+		factory.WithNet(buildVisitCountSiblingIsolationNet(maxReviews)),
+		factory.WithServiceMode(),
+		factory.WithWorkerExecutor("mock", &passExecutor{}),
+		factory.WithCompletionDeliveryPlanner(nextTickCompletionPlanner{}),
+		factory.WithLogger(logging.NoopLogger{}),
+	)
+	if err != nil {
+		t.Fatalf("New live factory: %v", err)
+	}
+
+	ctx := context.Background()
+	if _, err := submitWorkRequests(ctx, f, sharedTraceSiblingSubmissions("trace-shared-siblings-replay")); err != nil {
+		t.Fatalf("SubmitWorkRequest: %v", err)
+	}
+	tickable := tickableFactory(t, f)
+	for completedReviews := 1; completedReviews <= maxReviews; completedReviews++ {
+		for phase := 0; phase < 2; phase++ {
+			if err := tickable.Tick(ctx); err != nil {
+				t.Fatalf("Tick live review cycle %d phase %d: %v", completedReviews, phase+1, err)
+			}
+		}
+		snapshot := runtimeSnapshot(t, f)
+		assertWorkVisitState(t, snapshot, "work-repeated", "task:review", completedReviews)
+		assertWorkVisitState(t, snapshot, "work-unaffected", "task:held", 0)
+	}
+	if err := tickable.Tick(ctx); err != nil {
+		t.Fatalf("Tick live loop breaker: %v", err)
+	}
+	if _, err := f.MoveWork(ctx, "work-unaffected", "review", interfaces.WorkStateChangeSourceCLI, ""); err != nil {
+		t.Fatalf("MoveWork live unaffected sibling: %v", err)
+	}
+	for phase := 0; phase < 2; phase++ {
+		if err := tickable.Tick(ctx); err != nil {
+			t.Fatalf("Tick live unaffected sibling phase %d: %v", phase+1, err)
+		}
+	}
+	return f
+}
+
+func replayVisitCountSiblingIsolationScenario(t *testing.T, maxReviews int, events []factoryapi.FactoryEvent) factory.Factory {
+	t.Helper()
+	artifact := &interfaces.ReplayArtifact{
+		SchemaVersion: replay.CurrentSchemaVersion,
+		RecordedAt:    time.Date(2026, time.July, 13, 0, 0, 0, 0, time.UTC),
+		Events:        append([]factoryapi.FactoryEvent(nil), events...),
+	}
+	submissions, err := replay.NewSubmissionHook(artifact)
+	if err != nil {
+		t.Fatalf("NewSubmissionHook: %v", err)
+	}
+	workMoves, err := replay.NewWorkStateChangeHook(artifact)
+	if err != nil {
+		t.Fatalf("NewWorkStateChangeHook: %v", err)
+	}
+	completions, err := replay.NewCompletionDeliveryPlan(artifact)
+	if err != nil {
+		t.Fatalf("NewCompletionDeliveryPlan: %v", err)
+	}
+
+	f, err := New(
+		factory.WithNet(buildVisitCountSiblingIsolationNet(maxReviews)),
+		factory.WithServiceMode(),
+		factory.WithWorkerExecutor("mock", &passExecutor{}),
+		factory.WithSubmissionHook(submissions),
+		factory.WithSubmissionHook(workMoves),
+		factory.WithCompletionDeliveryPlanner(completions),
+		factory.WithLogger(logging.NoopLogger{}),
+	)
+	if err != nil {
+		t.Fatalf("New replay factory: %v", err)
+	}
+
+	tickable := tickableFactory(t, f)
+	completedReviews := 0
+	for attempt := 0; attempt < (maxReviews+1)*2+2; attempt++ {
+		if err := tickable.Tick(context.Background()); err != nil {
+			t.Fatalf("Tick replay attempt %d: %v", attempt+1, err)
+		}
+		snapshot := runtimeSnapshot(t, f)
+		if len(snapshot.DispatchHistory) > completedReviews && len(snapshot.DispatchHistory) <= maxReviews {
+			completedReviews = len(snapshot.DispatchHistory)
+			assertWorkVisitState(t, snapshot, "work-repeated", "task:review", completedReviews)
+			assertWorkVisitState(t, snapshot, "work-unaffected", "task:held", 0)
+		}
+		if len(snapshot.DispatchHistory) == maxReviews+1 {
+			return f
+		}
+	}
+	t.Fatalf("replay did not complete %d repeated reviews and one unaffected review", maxReviews)
+	return nil
+}
+
+type nextTickCompletionPlanner struct{}
+
+func (nextTickCompletionPlanner) DeliveryTickForDispatch(dispatch interfaces.WorkDispatch) (int, bool, error) {
+	return dispatch.Execution.DispatchCreatedTick + 1, true, nil
+}
+
+func workIDForCompletedDispatch(t *testing.T, dispatch interfaces.CompletedDispatch) string {
+	t.Helper()
+	for _, token := range dispatch.ConsumedTokens {
+		if token.Color.DataType != interfaces.DataTypeResource && token.Color.WorkID != "" {
+			return token.Color.WorkID
+		}
+	}
+	t.Fatalf("completed dispatch %q has no work input", dispatch.DispatchID)
+	return ""
+}
+
 func buildVisitCountSiblingIsolationNet(maxReviews int) *state.Net {
 	workType := &state.WorkType{
 		ID:   "task",

--- a/pkg/factory/runtime/factory_modes_test.go
+++ b/pkg/factory/runtime/factory_modes_test.go
@@ -551,3 +551,146 @@ func TestGetEngineStateSnapshot_AggregatesRuntimeLifecycleUptimeAndTopology(t *t
 		t.Fatal("timed out waiting for factory run to stop")
 	}
 }
+
+func TestRuntimeVisitCountRoutesSharedTraceSiblingsIndependentlyAtThreshold(t *testing.T) {
+	const (
+		maxReviews  = 3
+		sharedTrace = "trace-shared-siblings"
+	)
+	f, err := New(
+		factory.WithNet(buildVisitCountSiblingIsolationNet(maxReviews)),
+		factory.WithServiceMode(),
+		factory.WithInlineDispatch(),
+		factory.WithWorkerExecutor("mock", &passExecutor{}),
+		factory.WithLogger(logging.NoopLogger{}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx := context.Background()
+	if _, err := submitWorkRequests(ctx, f, sharedTraceSiblingSubmissions(sharedTrace)); err != nil {
+		t.Fatalf("SubmitWorkRequest: %v", err)
+	}
+	tickable := tickableFactory(t, f)
+	for completedReviews := 1; completedReviews <= maxReviews; completedReviews++ {
+		if err := tickable.Tick(ctx); err != nil {
+			t.Fatalf("Tick review cycle %d: %v", completedReviews, err)
+		}
+		snapshot := runtimeSnapshot(t, f)
+		assertWorkVisitState(t, snapshot, "work-repeated", "task:review", completedReviews)
+		assertWorkVisitState(t, snapshot, "work-unaffected", "task:held", 0)
+		assertReviewDispatch(t, snapshot, completedReviews-1, "work-repeated")
+	}
+
+	if err := tickable.Tick(ctx); err != nil {
+		t.Fatalf("Tick loop breaker: %v", err)
+	}
+	exhausted := runtimeSnapshot(t, f)
+	assertWorkVisitState(t, exhausted, "work-repeated", "task:failed", maxReviews)
+	assertWorkVisitState(t, exhausted, "work-unaffected", "task:held", 0)
+	if len(exhausted.DispatchHistory) != maxReviews {
+		t.Fatalf("dispatch count after exhaustion = %d, want %d", len(exhausted.DispatchHistory), maxReviews)
+	}
+
+	if _, err := f.MoveWork(ctx, "work-unaffected", "review", interfaces.WorkStateChangeSourceCLI, ""); err != nil {
+		t.Fatalf("MoveWork unaffected sibling to review: %v", err)
+	}
+	if err := tickable.Tick(ctx); err != nil {
+		t.Fatalf("Tick unaffected sibling first review: %v", err)
+	}
+	independent := runtimeSnapshot(t, f)
+	assertWorkVisitState(t, independent, "work-unaffected", "task:review", 1)
+	assertReviewDispatch(t, independent, maxReviews, "work-unaffected")
+}
+
+func buildVisitCountSiblingIsolationNet(maxReviews int) *state.Net {
+	workType := &state.WorkType{
+		ID:   "task",
+		Name: "Task",
+		States: []state.StateDefinition{
+			{Value: "held", Category: state.StateCategoryInitial},
+			{Value: "review", Category: state.StateCategoryProcessing},
+			{Value: "done", Category: state.StateCategoryTerminal},
+			{Value: "failed", Category: state.StateCategoryFailed},
+		},
+	}
+	places := make(map[string]*petri.Place)
+	for _, place := range workType.GeneratePlaces() {
+		places[place.ID] = place
+	}
+	reviewInput := petri.Arc{
+		ID: "review-in", Name: "work", PlaceID: "task:review", Direction: petri.ArcInput,
+		Cardinality: petri.ArcCardinality{Mode: petri.CardinalityOne},
+	}
+	return &state.Net{
+		ID: "visit-count-sibling-isolation", Places: places,
+		WorkTypes: map[string]*state.WorkType{"task": workType}, Resources: make(map[string]*state.ResourceDef),
+		Transitions: map[string]*petri.Transition{
+			"quality-check": {
+				ID: "quality-check", Name: "quality-check", Type: petri.TransitionNormal, WorkerType: "mock",
+				InputArcs:  []petri.Arc{reviewInput},
+				OutputArcs: []petri.Arc{{ID: "review-again", PlaceID: "task:review", Direction: petri.ArcOutput}},
+			},
+			"review-loop-breaker": {
+				ID: "review-loop-breaker", Name: "review-loop-breaker", Type: petri.TransitionExhaustion,
+				InputArcs: []petri.Arc{{
+					ID: "exhausted-review", Name: "work", PlaceID: "task:review", Direction: petri.ArcInput,
+					Cardinality: petri.ArcCardinality{Mode: petri.CardinalityOne},
+					Guard:       &petri.VisitCountGuard{TransitionID: "quality-check", MaxVisits: maxReviews},
+				}},
+				OutputArcs: []petri.Arc{{ID: "review-failed", PlaceID: "task:failed", Direction: petri.ArcOutput}},
+			},
+		},
+	}
+}
+
+func sharedTraceSiblingSubmissions(sharedTrace string) []interfaces.SubmitRequest {
+	return []interfaces.SubmitRequest{
+		{RequestID: "request-shared-siblings", WorkID: "work-repeated", Name: "repeated", WorkTypeID: "task", TargetState: "review", CurrentChainingTraceID: sharedTrace, TraceID: sharedTrace},
+		{RequestID: "request-shared-siblings", WorkID: "work-unaffected", Name: "unaffected", WorkTypeID: "task", TargetState: "held", CurrentChainingTraceID: sharedTrace, TraceID: sharedTrace},
+	}
+}
+
+func runtimeSnapshot(t *testing.T, f factory.Factory) *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net] {
+	t.Helper()
+	snapshot, err := f.GetEngineStateSnapshot(context.Background())
+	if err != nil {
+		t.Fatalf("GetEngineStateSnapshot: %v", err)
+	}
+	return snapshot
+}
+
+func assertWorkVisitState(t *testing.T, snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], workID, placeID string, visits int) {
+	t.Helper()
+	for _, token := range snapshot.Marking.Tokens {
+		if token.Color.WorkID != workID {
+			continue
+		}
+		if token.PlaceID != placeID {
+			t.Fatalf("work %s place = %q, want %q", workID, token.PlaceID, placeID)
+		}
+		if got := token.History.TotalVisits["quality-check"]; got != visits {
+			t.Fatalf("work %s quality-check visits = %d, want %d", workID, got, visits)
+		}
+		return
+	}
+	t.Fatalf("work %s missing from marking", workID)
+}
+
+func assertReviewDispatch(t *testing.T, snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], index int, workID string) {
+	t.Helper()
+	if len(snapshot.DispatchHistory) <= index {
+		t.Fatalf("dispatch history count = %d, want index %d", len(snapshot.DispatchHistory), index)
+	}
+	dispatch := snapshot.DispatchHistory[index]
+	if dispatch.TransitionID != "quality-check" {
+		t.Fatalf("dispatch[%d] transition = %q, want quality-check", index, dispatch.TransitionID)
+	}
+	for _, token := range dispatch.ConsumedTokens {
+		if token.Color.WorkID == workID {
+			return
+		}
+	}
+	t.Fatalf("dispatch[%d] did not consume work %s", index, workID)
+}

--- a/pkg/factory/subsystems/subsystem_history.go
+++ b/pkg/factory/subsystems/subsystem_history.go
@@ -46,7 +46,9 @@ func (h *HistorySubsystem) Execute(_ context.Context, snapshot *interfaces.Engin
 
 	histories := make([]interfaces.TokenHistory, len(snapshot.Results))
 	for i := range snapshot.Results {
-		histories[i] = buildHistory(consumedTokensForResult(snapshot, &snapshot.Results[i]), &snapshot.Results[i])
+		result := &snapshot.Results[i]
+		consumedTokens := consumedTokensForResult(snapshot, result)
+		histories[i] = buildHistory(consumedTokens, result, candidateWorkID(snapshot.Topology, result.TransitionID, consumedTokens))
 	}
 
 	h.logger.Debug("history: computed token histories", "count", len(histories))
@@ -54,8 +56,9 @@ func (h *HistorySubsystem) Execute(_ context.Context, snapshot *interfaces.Engin
 }
 
 // buildHistory creates a TokenHistory with updated TotalVisits and ConsecutiveFailures.
-// Consumed token histories are merged from the runtime dispatch snapshot.
-func buildHistory(consumedTokens []interfaces.Token, result *interfaces.WorkResult) interfaces.TokenHistory {
+// Consumed token histories are merged from the candidate work lineage stored in
+// the runtime dispatch snapshot.
+func buildHistory(consumedTokens []interfaces.Token, result *interfaces.WorkResult, candidateID string) interfaces.TokenHistory {
 	history := interfaces.TokenHistory{
 		TotalVisits:         make(map[string]int),
 		ConsecutiveFailures: make(map[string]int),
@@ -66,7 +69,7 @@ func buildHistory(consumedTokens []interfaces.Token, result *interfaces.WorkResu
 	// carry copies of the same lineage visit counts (for example task + review
 	// companions in executor/review loops). Use max per key so visit counts reflect
 	// one work lineage instead of summing duplicate counters.
-	for _, consumed := range consumedTokens {
+	for _, consumed := range candidateLineageTokens(consumedTokens, candidateID) {
 		ih := consumed.History
 		for tid, v := range ih.TotalVisits {
 			if v > history.TotalVisits[tid] {
@@ -102,6 +105,45 @@ func buildHistory(consumedTokens []interfaces.Token, result *interfaces.WorkResu
 	}
 
 	return history
+}
+
+// candidateWorkID identifies the durable work item whose history should be
+// propagated by a transition. Authored input order is canonical, so the first
+// non-resource input arc is the candidate while later inputs may be generated
+// companions or other supporting work.
+func candidateWorkID(net *state.Net, transitionID string, consumedTokens []interfaces.Token) string {
+	if net != nil {
+		if transition := net.Transitions[transitionID]; transition != nil {
+			for _, arc := range transition.InputArcs {
+				for _, token := range consumedTokens {
+					if token.PlaceID == arc.PlaceID && token.Color.DataType != interfaces.DataTypeResource && token.Color.WorkID != "" {
+						return token.Color.WorkID
+					}
+				}
+			}
+		}
+	}
+
+	for _, token := range consumedTokens {
+		if token.Color.DataType != interfaces.DataTypeResource && token.Color.WorkID != "" {
+			return token.Color.WorkID
+		}
+	}
+	return ""
+}
+
+func candidateLineageTokens(consumedTokens []interfaces.Token, candidateID string) []interfaces.Token {
+	if candidateID == "" {
+		return consumedTokens
+	}
+
+	lineage := make([]interfaces.Token, 0, len(consumedTokens))
+	for _, token := range consumedTokens {
+		if token.Color.WorkID == candidateID || token.Color.ParentID == candidateID {
+			lineage = append(lineage, token)
+		}
+	}
+	return lineage
 }
 
 func consumedTokensForResult(snapshot *interfaces.EngineStateSnapshot[petri.MarkingSnapshot, *state.Net], result *interfaces.WorkResult) []interfaces.Token {

--- a/pkg/factory/subsystems/subsystem_history_test.go
+++ b/pkg/factory/subsystems/subsystem_history_test.go
@@ -92,11 +92,13 @@ func TestHistorySubsystem_Execute_MergesHistoryFromDispatchConsumedTokens(t *tes
 func TestBuildHistory_MergesSharedLineageVisitCountsWithMaxNotSum(t *testing.T) {
 	consumed := []interfaces.Token{
 		{
+			Color: interfaces.TokenColor{WorkID: "task-1", WorkTypeID: "task"},
 			History: interfaces.TokenHistory{
 				TotalVisits: map[string]int{"process": 3, "review": 2},
 			},
 		},
 		{
+			Color: interfaces.TokenColor{WorkID: "review-1", WorkTypeID: "review", ParentID: "task-1"},
 			History: interfaces.TokenHistory{
 				TotalVisits: map[string]int{"process": 3, "review": 1},
 			},
@@ -106,7 +108,7 @@ func TestBuildHistory_MergesSharedLineageVisitCountsWithMaxNotSum(t *testing.T) 
 	history := buildHistory(consumed, &interfaces.WorkResult{
 		TransitionID: "review",
 		Outcome:      interfaces.OutcomeContinue,
-	})
+	}, "task-1")
 
 	if got := history.TotalVisits["process"]; got != 3 {
 		t.Fatalf("TotalVisits[process] = %d, want 3", got)
@@ -116,12 +118,77 @@ func TestBuildHistory_MergesSharedLineageVisitCountsWithMaxNotSum(t *testing.T) 
 	}
 }
 
+func TestBuildHistory_ExcludesDifferentWorkOnSharedTrace(t *testing.T) {
+	const sharedTrace = "batch-trace"
+	consumed := []interfaces.Token{
+		{
+			Color:   interfaces.TokenColor{WorkID: "task-a", WorkTypeID: "task", CurrentChainingTraceID: sharedTrace},
+			History: interfaces.TokenHistory{TotalVisits: map[string]int{"process": 1, "review": 0}},
+		},
+		{
+			Color:   interfaces.TokenColor{WorkID: "review-b", WorkTypeID: "review", ParentID: "task-b", CurrentChainingTraceID: sharedTrace},
+			History: interfaces.TokenHistory{TotalVisits: map[string]int{"process": 7, "review": 6}},
+		},
+	}
+
+	history := buildHistory(consumed, &interfaces.WorkResult{
+		TransitionID: "review",
+		Outcome:      interfaces.OutcomeRejected,
+	}, "task-a")
+
+	if got := history.TotalVisits["process"]; got != 1 {
+		t.Fatalf("TotalVisits[process] = %d, want 1 from task-a only", got)
+	}
+	if got := history.TotalVisits["review"]; got != 1 {
+		t.Fatalf("TotalVisits[review] = %d, want first review visit for task-a", got)
+	}
+}
+
+func TestBuildHistory_AccumulatesRepeatedCandidateCycles(t *testing.T) {
+	consumed := []interfaces.Token{{
+		Color:   interfaces.TokenColor{WorkID: "task-a", WorkTypeID: "task"},
+		History: interfaces.TokenHistory{TotalVisits: map[string]int{"process": 2, "review": 3}},
+	}}
+
+	history := buildHistory(consumed, &interfaces.WorkResult{
+		TransitionID: "review",
+		Outcome:      interfaces.OutcomeRejected,
+	}, "task-a")
+
+	if got := history.TotalVisits["process"]; got != 2 {
+		t.Fatalf("TotalVisits[process] = %d, want 2", got)
+	}
+	if got := history.TotalVisits["review"]; got != 4 {
+		t.Fatalf("TotalVisits[review] = %d, want 4", got)
+	}
+}
+
+func TestCandidateWorkID_UsesAuthoredInputOrderInsteadOfDispatchTokenOrder(t *testing.T) {
+	net := &state.Net{Transitions: map[string]*petri.Transition{
+		"review": {
+			ID: "review",
+			InputArcs: []petri.Arc{
+				{PlaceID: "task:in-review"},
+				{PlaceID: "review:init"},
+			},
+		},
+	}}
+	consumed := []interfaces.Token{
+		{PlaceID: "review:init", Color: interfaces.TokenColor{WorkID: "review-b", ParentID: "task-b"}},
+		{PlaceID: "task:in-review", Color: interfaces.TokenColor{WorkID: "task-a"}},
+	}
+
+	if got := candidateWorkID(net, "review", consumed); got != "task-a" {
+		t.Fatalf("candidateWorkID() = %q, want task-a", got)
+	}
+}
+
 func TestBuildHistory_WhenDispatchLookupMissing_UsesOnlyCurrentResult(t *testing.T) {
 	history := buildHistory(nil, &interfaces.WorkResult{
 		DispatchID:   "dispatch-missing",
 		TransitionID: "transition-review",
 		Outcome:      interfaces.OutcomeAccepted,
-	})
+	}, "")
 
 	if got := history.TotalVisits["transition-review"]; got != 1 {
 		t.Fatalf("TotalVisits[transition-review] = %d, want 1", got)

--- a/pkg/factory/subsystems/subsystem_transitioner.go
+++ b/pkg/factory/subsystems/subsystem_transitioner.go
@@ -171,7 +171,7 @@ func (t *TransitionerSubsystem) mapToCorrespondingTokenMutations(snapshot *inter
 
 	resolved := resolveWorkResult(currentTransition, result, t.runtimeConfig)
 	consumedTokens := consumedTokensForResult(snapshot, result)
-	history := buildHistory(consumedTokens, result)
+	history := buildHistory(consumedTokens, result, candidateWorkID(t.netDefinition, result.TransitionID, consumedTokens))
 	now := t.now()
 	inputColors := tokenColorsFromTokens(consumedTokens)
 	//TODO: the intermittent failure arc should be denoted as a preconstructed output, teh calculate arcs function should be a mapping of arcs for a current workstation/transition, and one such mapping would be the intermitten failure arc.


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "runtime-visit-count-sibling-isolation",
  "description": "Correct factory-runtime VISIT_COUNT accounting so each candidate work item uses its own retry lineage, paired task/review companion histories are deduplicated without summing, unrelated shared-trace siblings do not consume one another's retry budget, and live execution and replay make the same threshold and routing decisions.",
  "context": {
    "customerAsk": "Make VISIT_COUNT guard accounting follow the candidate work item's own retry lineage, including its paired task/review companion tokens, without inheriting visits from unrelated sibling work merely because a batch shares one request or chaining trace.",
    "problem": "Two completed Stream B05 provider tasks were moved from task:in-review to task:failed by review-loop-breaker before an independent review could run. Their siblings had accumulated correction and review visits on the shared batch chaining trace, and each retained task succeeded when resubmitted on a fresh trace. This shows that request-wide trace history can incorrectly exhaust a valid sibling's guard.",
    "solution": "Derive visit history from canonical dispatch/result evidence scoped to the candidate work item's retry lineage. Merge duplicate counts carried by its co-consumed task/review companion tokens using maximum-per-transition semantics, exclude histories that belong only to different work IDs despite a shared trace, preserve exact same-lineage accumulation to the authored threshold, and use the same deterministic derivation for live execution and replay."
  },
  "acceptanceCriteria": [
    "AC-1: In a runtime scenario with at least two sibling work items on one shared request/chaining trace, repeated review cycles for one sibling do not make the other sibling's first review eligible for the loop breaker; the unaffected sibling remains eligible for the review workstation.",
    "AC-2: Repeated process or review cycles for the same work lineage accumulate, and a VISIT_COUNT guard passes exactly when that lineage reaches the configured maxVisits value.",
    "AC-3: Co-consumed companion tokens for one logical work cycle merge duplicate transition counts without summing, while history belonging to a different work ID is not imported merely because it shares a trace.",
    "AC-4: Live execution and replay derive equal visit counts and equal review-versus-loop-breaker routing decisions from the same canonical dispatch/result evidence.",
    "AC-5: Retry semantics are not keyed solely by request-wide trace, configured maxVisits values and comparison semantics are unchanged, and the correction has no Stream B05 or provider-specific branch.",
    "AC-6: Public OpenAPI contracts, provider adapters, and authored factory thresholds remain unchanged.",
    "AC-7: Quality checks pass (typecheck, lint, tests), including focused race/repeat coverage for the affected factory subsystem and the repository's applicable backend package gates."
  ],
  "userStories": [
    {
      "id": "runtime-visit-count-sibling-isolation-001",
      "title": "Derive visit counts from the candidate work lineage",
      "description": "As a factory operator, I want each work item's visit count to reflect only its own retry lineage so unrelated batch siblings cannot exhaust its process or review guard.",
      "acceptanceCriteria": [
        "Visit history propagation identifies the candidate work lineage from work-specific canonical dispatch/result data and does not use a shared request or chaining trace as the sole retry-lineage key.",
        "Histories carried by co-consumed task/review companion tokens for one work cycle merge duplicate per-transition counts by maximum rather than sum.",
        "A co-consumed or previously recorded history belonging only to a different work ID does not increase the candidate work item's process or review count, even when both work items share request and chaining-trace metadata.",
        "Each completed process or review result increments the applicable transition count once for the candidate lineage, preserving consecutive same-lineage cycles.",
        "Focused unit tests cover companion-token deduplication, different-work isolation on a shared trace, and accumulation across repeated same-lineage cycles.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented in 72cbb183f. Candidate history is selected from authored primary input order, direct generated companions merge by maximum, and unrelated shared-trace work is excluded. Verified with focused repeat/race tests, make lint, make test, and package gates."
    },
    {
      "id": "runtime-visit-count-sibling-isolation-002",
      "title": "Route shared-trace siblings independently while preserving exhaustion",
      "description": "As a factory operator, I want siblings submitted in one batch to receive independent review budgets while still having genuine repeated cycles stopped at the configured limit.",
      "acceptanceCriteria": [
        "A package-level runtime regression creates at least two sibling work items with distinct work IDs and one shared request/chaining trace.",
        "After one sibling is driven through repeated review or correction cycles, the other sibling's first review remains eligible for the normal review workstation and is not selected by the review loop breaker.",
        "The same regression proves that repeated cycles for one work lineage make its loop breaker eligible exactly at the configured maxVisits threshold, not before or after it.",
        "Workstation scheduling remains generic across work names and executor providers; the fixture does not depend on Stream B05 names or provider-adapter behavior.",
        "Focused package tests pass repeatedly and under the race detector for the affected factory subsystem.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Added a package-level runtime regression using real submission, scheduling, dispatch/result, history, transitioner, and circuit-breaker paths. It proves a repeated sibling routes through review three times and breaks exactly at maxVisits=3 while an unaffected sibling on the same request/chaining trace retains an independent first review. Verified with focused repeat/race coverage, make lint, and make test."
    },
    {
      "id": "runtime-visit-count-sibling-isolation-003",
      "title": "Preserve visit-count routing across replay",
      "description": "As a factory operator, I want a restored or historically replayed factory session to make the same retry-limit decisions as live execution so restart and inspection cannot change work routing.",
      "acceptanceCriteria": [
        "Canonical dispatch and result evidence for the sibling-isolation scenario can be replayed to reconstruct the same per-work transition counts observed during live execution.",
        "Before the configured threshold, both live and replay keep the unaffected sibling eligible for the review workstation and ineligible for the loop breaker.",
        "At the configured threshold for the repeatedly reviewed lineage, both live and replay make that lineage eligible for the loop breaker.",
        "Replay does not require a parallel visit-count store, provider-specific evidence, or non-canonical trace-only reconstruction.",
        "Focused replay regression tests compare the live and replayed visit counts and routing outcomes for both siblings.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Added a canonical event-log replay regression that compares live and replayed visit counts and dispatch routing at every pre-threshold checkpoint and after exhaustion. The repeated sibling exhausts exactly at maxVisits=3 while the shared-trace sibling retains an independent first review. Verified with focused repeat/race coverage, make test, make lint, typecheck, and package gates."
    }
  ]
}
