### PR TITLE
stream-b06-agy-integration-decision

### DIFF
--- a/docs/architecture/agy-pty-boundary.md
+++ b/docs/architecture/agy-pty-boundary.md
@@ -1,0 +1,230 @@
+# ADR: Minimal native Go Agy PTY boundary
+
+| Field | Value |
+| --- | --- |
+| Status | Accepted |
+| Story | S16 / `stream-b06-agy-integration-decision-001` |
+| Date | 2026-07-14 (UTC) |
+| Gates | Story 17+ Agy execution (`stream-response-fix-plan.md` §8.6, Story 17) |
+
+This architecture decision record fixes the native Go boundary for Agy headless
+provider support. It is the authoritative scope contract for later execution
+work. Customer-facing vocabulary remains `Provider Session` and response events;
+see `docs/architecture/data-model.md`.
+
+## Context
+
+Agy (Antigravity CLI) gates useful output on TTY detection. Ordinary piped
+subprocess IO is insufficient for headless factory execution. The upstream
+reference implementation [`rhishi99/agy-headless-bridge`](https://github.com/rhishi99/agy-headless-bridge)
+is a Python package that allocates a PTY (Windows ConPTY or POSIX `pty`),
+captures bounded raw terminal output, cleans ANSI/TUI noise, enforces idle and
+hard timeouts, and tears down the process tree.
+
+The stream-response program (`docs/temp/projects/stream-responses/stream-response-fix-plan.md`
+§8.6) requires a **minimum native Go port** of that behavior for final-only Agy
+provider integration. Maintainers need a fixed build-vs-adapt decision,
+supported-platform scope, license posture, and explicit exclusions before
+Story 17 lands production execution code.
+
+## Decision
+
+**Build:** infinite-you owns a minimal native Go implementation of the Agy
+headless PTY boundary inside the worker/provider stack.
+
+**Do not:**
+
+- vendor or submodule the full upstream repository,
+- invoke the upstream Python package at runtime,
+- embed CPython or ship the Python bridge as a runtime dependency, or
+- shell out to a shell interpreter with a concatenated command string.
+
+The Go boundary adapts **only** the behaviors listed under [Maintained behavior
+scope](#maintained-behavior-scope). Upstream Python sources are reference
+material for behavioral equivalence, not a code-import source of truth.
+
+Implementation ownership:
+
+| Concern | Owner |
+| --- | --- |
+| PTY allocation, capture, cleaning, timeout, cleanup | new Agy-owned Go package under `pkg/workers/` (exact path chosen in Story 17; interface proposal in Story 003) |
+| Typed argv construction and workspace attachment | Agy provider adapter (Story 17) |
+| Process-tree supervision semantics | align with `pkg/workers/process` job-object (Windows) and process-group (POSIX) patterns |
+| Final-only response events and failure classification | `pkg/workers/provider` adapter kernel (Story 17+) |
+
+## Maintained behavior scope
+
+The approved native Go port maintains **only** these headless-bridge behaviors:
+
+1. **Binary discovery** — resolve the configured Agy executable path; surface
+   distinct missing-executable failures (execution detail in Story 17).
+2. **PTY allocation** — allocate an interactive terminal for the child process:
+   - **Windows:** ConPTY pseudo-console pair (not plain pipe redirection).
+   - **POSIX:** openpty/master-slave pair with the child attached to the slave
+     TTY (not plain pipe redirection).
+3. **Bounded capture** — read raw PTY output into an internal buffer with a
+   documented maximum byte bound; never publish unbounded terminal streams as
+   public response events.
+4. **Terminal cleaning** — pure functions that strip ANSI CSI/OSC sequences,
+   carriage-return repaint lines, spinner glyphs, and box-drawing noise from
+   captured bytes before any public message payload (cleaner corpus in Story
+   18).
+5. **Idle and hard timeout** — enforce configured idle (no new PTY bytes) and
+   overall hard limits; cancel the supervised process tree on breach.
+6. **Process cleanup** — on success, failure, cancel, or timeout, terminate the
+   supervised child process tree using the same ownership model as
+   `pkg/workers/process` (Windows job object with `KILL_ON_JOB_CLOSE`, POSIX
+   process-group SIGTERM then SIGKILL grace).
+
+**Out of scope for this boundary** (upstream or adjacent behaviors that must
+not be imported as part of the minimal port):
+
+- MCP server wiring, Gemini model routing, or Antigravity auth flows beyond
+  what the Agy CLI already exposes through argv and environment,
+- Python packaging, `pip install`, or PyPI distribution mechanics,
+- Interactive resize/input forwarding beyond what headless execution requires,
+- Publishing spinner/repaint chunks as incremental response events (Agy remains
+  `nativeStreaming=false`, final-only fidelity),
+- Partial-timeout public output policy (Story 18).
+
+## Supported operating systems
+
+Supported platforms match the repository's backend matrix: **Linux, macOS, and
+Windows** on amd64 and arm64 where the factory already builds and tests.
+
+| Platform | PTY mechanism | Support posture |
+| --- | --- | --- |
+| Windows | ConPTY via Go `x/sys/windows` or a maintained ConPTY helper | **Supported** — primary reference platform for upstream headless bridge |
+| Linux | POSIX `openpty` / `pty` master-slave | **Supported** — same class as existing `pkg/workers/process` POSIX builds |
+| macOS | POSIX `openpty` / `pty` master-slave | **Supported** — same class as Linux POSIX path |
+
+**Unsupported platforms** (BSD variants, 32-bit targets, or OS builds without
+ConPTY/POSIX PTY APIs) must fail closed with an explicit `UNSUPPORTED`
+capability or classified setup failure. They must not silently fall back to pipe
+IO for Agy execution.
+
+Upstream marks POSIX as beta; infinite-you still documents POSIX as supported
+because the factory already ships POSIX worker process supervision. Story 17
+must prove POSIX PTY allocation with mocked and targeted integration tests
+before release.
+
+## Windows ConPTY vs POSIX PTY responsibilities
+
+### Windows (ConPTY)
+
+- Create a pseudo-console and attach the Agy child to it so `isatty` checks
+  succeed.
+- Read stdout-equivalent PTY output from the pseudo-console input pipe (ConPTY
+  host side).
+- Supervise the child through a Windows job object consistent with
+  `pkg/workers/process/command_process_windows.go`.
+- On cleanup, terminate active job processes before closing the job handle.
+- Security assumption: argv is passed as a Windows command line built from typed
+  `[]string` fields (`exec.Command(name, arg...)`), never a shell string passed
+  to `cmd.exe` or PowerShell.
+
+### POSIX (Linux and macOS)
+
+- Allocate master/slave pair; set slave as controlling terminal for the child
+  session when required by the platform PTY contract.
+- Read captured bytes from the master fd with non-blocking or polled reads
+  bounded by the capture limit.
+- Supervise the child through a dedicated process group consistent with
+  `pkg/workers/process/command_process_unix.go`.
+- On cleanup, signal the process group (SIGTERM, grace, SIGKILL) before closing
+  PTY fds.
+- Security assumption: argv is passed as `exec.Command(name, arg...)` with no
+  `/bin/sh -c` wrapper.
+
+Detailed threat controls (argv injection, workspace paths, environment
+inheritance, escape sequences, bounds, timeouts, cleanup edge cases) are
+specified in the companion threat review (Story 002). Mock seams and interface
+types are specified in the Go PTY/process interface proposal (Story 003).
+
+## Upstream license and required notices
+
+| Item | Finding |
+| --- | --- |
+| Upstream repository | `https://github.com/rhishi99/agy-headless-bridge` |
+| Upstream license | **MIT License** (Copyright (c) 2026 agy-headless-bridge contributors) |
+| Compatibility with infinite-you | **Compatible** — MIT permits use, modification, and distribution in this repository subject to notice preservation |
+| Required notices | Retain the upstream MIT copyright and permission notice in `NOTICE` or `THIRD_PARTY_NOTICES` (or equivalent repository notices location) when Story 17 lands adapted behavior; cite upstream as the behavioral reference for the minimal port |
+| Upgrade ownership | infinite-you maintainers own the Go implementation lifecycle, security fixes, and platform updates; upstream version bumps inform behavioral parity reviews but do not auto-import code |
+
+No copyleft obligations apply to the adapted minimal port. Do not remove upstream
+attribution when documenting adapted algorithms or test corpora derived from
+upstream examples.
+
+## Explicit exclusions
+
+This lane and the approved boundary **exclude**:
+
+| Exclusion | Rationale |
+| --- | --- |
+| Production Agy execution | Story 001–003 are specification only; Story 17+ implements execution |
+| Python-bridge invocation or embedding | Runtime must not depend on CPython or `agy-headless-bridge` PyPI package |
+| Shell-string command construction | Commands are `[]string` argv only; no `sh -c`, `cmd /C`, or PowerShell `-Command` string assembly |
+| Unrelated upstream behavior | MCP tooling, packaging scripts, CLI UX unrelated to PTY capture/cleaning, and full-repo vendoring stay out of scope |
+| Incremental native streaming | Agy adapter declares final-only fidelity; PTY bytes are internal until cleaned final text is emitted |
+| Pipe-only fallback for Agy | Defeats TTY gating; classified as unsupported setup, not a silent fallback |
+
+## Gating Story 17 and later work
+
+Story 17 (**Execute Agy headlessly through the approved PTY/cleaning boundary**)
+and Story 18 (**Preserve bounded partial output on timeout**) **must not** merge
+until all of the following are true:
+
+1. This ADR is merged and marked Accepted.
+2. The Windows/POSIX threat review (Story 002) is published and reviewed
+   against `docs/internal/standards/code/general-backend-standards.md`.
+3. The Go PTY/process interface proposal with hermetic argv and path fixtures
+   (Story 003) is published and tests pass without an installed Agy binary or
+   Python bridge.
+4. Batch B06 loopback (`stream-b06-boundary-loopback`) accepts both the Pi
+   readiness gate and this Agy decision gate.
+
+Story 17 implementation checklist (derived from this ADR):
+
+- [ ] Implement only the [maintained behavior scope](#maintained-behavior-scope).
+- [ ] Use typed argv and documented workspace-path normalization rules from the
+  Story 003 interface proposal.
+- [ ] Allocate ConPTY on Windows and POSIX PTY on Linux/macOS — no pipe
+  fallback.
+- [ ] Reuse or extend `pkg/workers/process` supervision semantics; do not
+  duplicate ad hoc kill logic in the adapter.
+- [ ] Add `NOTICE` / third-party attribution for upstream MIT material when code
+  lands.
+- [ ] Emit final-only response events per `stream-response-fix-plan.md` §8.6.
+
+Story 18 may add partial-timeout public output only after Story 17 final-only
+execution is approved.
+
+## Consequences
+
+### Positive
+
+- Maintainers can implement and review Agy execution without reading Python
+  sources or debating scope ad hoc.
+- Windows and POSIX responsibilities are fixed before code lands.
+- License posture is explicit before attribution-bearing code merges.
+- Mock seams (Story 003) can be tested hermetically in CI without external
+  binaries.
+
+### Negative / costs
+
+- infinite-you maintains PTY platform code and must track OS API changes
+  (ConPTY availability, POSIX `openpty` behavior).
+- Behavioral parity with upstream is a maintainer responsibility, not a
+  package upgrade.
+- POSIX PTY support requires explicit test investment even though upstream
+  labels POSIX beta.
+
+## Related documents
+
+| Document | Story | Status |
+| --- | --- | --- |
+| Windows/POSIX threat review | `stream-b06-agy-integration-decision-002` | Pending |
+| Go PTY/process interface proposal and fixtures | `stream-b06-agy-integration-decision-003` | Pending |
+| Stream-response program plan | `docs/temp/projects/stream-responses/stream-response-fix-plan.md` §8.6 | Reference |
+| Worker process supervision | `pkg/workers/process/doc.go` | Existing |
+| Provider subprocess environment policy | `pkg/workers/provider/commandenv/environment.go` | Existing |

--- a/docs/architecture/agy-pty-boundary.md
+++ b/docs/architecture/agy-pty-boundary.md
@@ -225,7 +225,7 @@ execution is approved.
 | Document | Story | Status |
 | --- | --- | --- |
 | Windows/POSIX threat review (`agy-pty-threat-review.md`) | `stream-b06-agy-integration-decision-002` | Accepted |
-| Go PTY/process interface proposal and fixtures | `stream-b06-agy-integration-decision-003` | Pending |
+| Go PTY/process interface proposal and fixtures (`agy-pty-interface.md`) | `stream-b06-agy-integration-decision-003` | Accepted |
 | Stream-response program plan | `docs/temp/projects/stream-responses/stream-response-fix-plan.md` §8.6 | Reference |
 | Worker process supervision | `pkg/workers/process/doc.go` | Existing |
 | Provider subprocess environment policy | `pkg/workers/provider/commandenv/environment.go` | Existing |

--- a/docs/architecture/agy-pty-boundary.md
+++ b/docs/architecture/agy-pty-boundary.md
@@ -138,8 +138,9 @@ before release.
 
 Detailed threat controls (argv injection, workspace paths, environment
 inheritance, escape sequences, bounds, timeouts, cleanup edge cases) are
-specified in the companion threat review (Story 002). Mock seams and interface
-types are specified in the Go PTY/process interface proposal (Story 003).
+specified in `docs/architecture/agy-pty-threat-review.md` (Story 002). Mock
+seams and interface types are specified in the Go PTY/process interface proposal
+(Story 003).
 
 ## Upstream license and required notices
 
@@ -223,7 +224,7 @@ execution is approved.
 
 | Document | Story | Status |
 | --- | --- | --- |
-| Windows/POSIX threat review | `stream-b06-agy-integration-decision-002` | Pending |
+| Windows/POSIX threat review (`agy-pty-threat-review.md`) | `stream-b06-agy-integration-decision-002` | Accepted |
 | Go PTY/process interface proposal and fixtures | `stream-b06-agy-integration-decision-003` | Pending |
 | Stream-response program plan | `docs/temp/projects/stream-responses/stream-response-fix-plan.md` §8.6 | Reference |
 | Worker process supervision | `pkg/workers/process/doc.go` | Existing |

--- a/docs/architecture/agy-pty-interface.md
+++ b/docs/architecture/agy-pty-interface.md
@@ -1,0 +1,199 @@
+# Go PTY/process interface proposal: Agy headless boundary
+
+| Field | Value |
+| --- | --- |
+| Status | Accepted |
+| Story | S16 / `stream-b06-agy-integration-decision-003` |
+| Date | 2026-07-14 (UTC) |
+| Companion ADR | `docs/architecture/agy-pty-boundary.md` |
+| Threat review | `docs/architecture/agy-pty-threat-review.md` |
+| Package | `pkg/workers/agypty` |
+| Gates | Story 17+ Agy execution |
+
+This document proposes the mockable Go PTY/process seams for the minimal native
+Agy headless boundary. It is specification only: **production Agy headless
+execution remains out of scope until Story 17** consumes these interfaces. This
+lane does not invoke or embed the upstream Python bridge and does not require an
+installed Agy binary for hermetic unit tests.
+
+## Package layout
+
+| File / path | Responsibility |
+| --- | --- |
+| `types.go` | `PTYAllocator`, `PTYSession`, `ProcessLaunch`, `SessionConfig`, `SessionResult` |
+| `limits.go` | `DefaultMaxCaptureBytes`, `MaxMaxCaptureBytes`, idle/hard timeout defaults |
+| `argv.go` | Typed `BuildArgv`, `ValidateArgv`, `RejectShellWrapper` (T1) |
+| `workspace.go` | `ResolveWorkspaceDir` containment normalization (T2) |
+| `cleaner.go` | Pure `CleanTerminal` seam for Story 17/18 cleaning |
+| `mock.go` | `MockAllocator`, `MockSession` for hermetic tests |
+| `testdata/argv_fixtures.json` | Hermetic argv corpus |
+| `testdata/workspace_fixtures.json` | Hermetic workspace path corpus |
+
+Story 17 adds platform files:
+
+| Build tag | Implementation |
+| --- | --- |
+| `windows` | `WindowsConPTYAllocator` — ConPTY pseudo-console allocation |
+| `linux,darwin` | `POSIXPTYAllocator` — `openpty` master/slave allocation |
+| unsupported | `ErrUnsupportedPlatform` — fail closed, no pipe fallback |
+
+## Core interfaces
+
+### `PTYAllocator`
+
+Allocates one platform PTY for a supervised Agy child:
+
+```go
+type PTYAllocator interface {
+    Allocate(ctx context.Context, launch ProcessLaunch, cfg SessionConfig) (PTYSession, error)
+}
+```
+
+- **Windows:** `WindowsConPTYAllocator` creates a pseudo-console pair and
+  attaches the child so TTY checks succeed (`agy-pty-boundary.md` §Windows).
+- **POSIX:** `POSIXPTYAllocator` opens a master/slave pair and attaches the
+  child to the slave TTY (`agy-pty-boundary.md` §POSIX).
+- **Tests:** `MockAllocator` records `ProcessLaunch` and returns
+  `MockSession` without real ConPTY/PTY syscalls.
+
+### `PTYSession`
+
+Mockable seam for bounded capture, timeout signaling, and cleanup:
+
+```go
+type PTYSession interface {
+    Run(ctx context.Context) (SessionResult, error)
+    Close() error
+}
+```
+
+Story 17 `Run` responsibilities:
+
+1. Spawn the child with typed `ProcessLaunch.Argv` (no shell wrapper).
+2. Read PTY bytes into an internal buffer capped by `SessionConfig.MaxCaptureBytes`.
+3. Enforce `IdleTimeout` (no new bytes) and `HardTimeout` (wall clock).
+4. On exit, timeout, or cancel, terminate the supervised process tree through
+   `pkg/workers/process` semantics, then close PTY handles.
+5. Return `SessionResult` with raw bytes and `CleanTerminal` output.
+
+`MockSession` lets unit tests assert launch metadata, config limits, and
+predetermined capture without an Agy binary.
+
+### `ProcessLaunch`
+
+Typed subprocess description passed to allocation:
+
+| Field | Rule |
+| --- | --- |
+| `Executable` | Resolved Agy binary path after `filepath.Clean` |
+| `Argv` | Full argv slice from `BuildArgv`; passed to `exec.Command` directly |
+| `WorkDir` | Output of `ResolveWorkspaceDir` |
+| `Env` | Output of `commandenv.Build`; no parallel env builder |
+
+### `SessionConfig`
+
+| Field | Default | Ceiling |
+| --- | --- | --- |
+| `MaxCaptureBytes` | 4 MiB (`DefaultMaxCaptureBytes`) | 16 MiB (`MaxMaxCaptureBytes`) |
+| `IdleTimeout` | 30s | Story 17 factory config |
+| `HardTimeout` | 10m | Story 17 factory config |
+
+## Pure seams (T1 / T2)
+
+### Typed argv (`argv.go`)
+
+`ArgvSpec` carries executable, subcommand, flags, and prompt as **separate
+fields**. `BuildArgv` returns a `[]string` slice suitable for
+`exec.Command(executable, args...)`.
+
+Controls (threat review T1):
+
+- Prompt is always a distinct argv element, including when it contains shell
+  metacharacters (`;`, `|`, `` ` ``).
+- `RejectShellWrapper` forbids `sh -c`, `cmd /C`, `powershell -Command`, and
+  equivalent shell-string indirection.
+- `ValidateArgv` is the single entry point Story 17 calls before spawn.
+
+Hermetic corpus: `testdata/argv_fixtures.json`, loaded by `LoadArgvFixtures()`.
+
+### Workspace paths (`workspace.go`)
+
+`ResolveWorkspaceDir(factoryRoot, rawPath)`:
+
+1. Applies `filepath.Clean` and `filepath.FromSlash`.
+2. Rejects `..` traversal for relative inputs.
+3. Joins relative paths under `factoryRoot`.
+4. Verifies containment with `filepath.Rel` (same pattern as
+   `pkg/config/portable_bundled_files.go`).
+
+Controls (threat review T2):
+
+- One normalized path is used for both `cmd.Dir` and argv path fields.
+- Absolute paths outside `factoryRoot` are rejected.
+
+Hermetic corpus: `testdata/workspace_fixtures.json`, loaded by
+`LoadWorkspaceFixtures()`. Tests substitute `t.TempDir()` for
+`FACTORY_ROOT` placeholders.
+
+## Terminal cleaning seam
+
+`CleanTerminal(raw []byte) string` is a pure function over captured PTY bytes.
+Story 17 calls it before any public response emit. Story 18 may extend the
+cleaning corpus for partial-timeout policy.
+
+Current scope (proposal baseline):
+
+- Strip ANSI CSI (`ESC [` …) and OSC (`ESC ]` … BEL) sequences.
+- Collapse carriage-return repaint lines to the final visible segment.
+- Drop blank lines after stripping.
+
+Raw PTY bytes remain internal (T4, T10).
+
+## Mock substitution matrix
+
+| Seam | Production (Story 17) | Hermetic test |
+| --- | --- | --- |
+| PTY allocation | `WindowsConPTYAllocator` / `POSIXPTYAllocator` | `MockAllocator` |
+| Capture / timeout / cleanup | Real `PTYSession.Run` | `MockSession` with fixed `SessionResult` |
+| argv construction | `BuildArgv` + `ValidateArgv` | `testdata/argv_fixtures.json` |
+| Workspace attachment | `ResolveWorkspaceDir` | `testdata/workspace_fixtures.json` |
+| Terminal cleaning | `CleanTerminal` | Direct unit tests on byte corpora |
+| Process supervision | `pkg/workers/process.ExecCommandRunner` | Existing process package tests |
+
+## Story 17 consumption checklist
+
+Story 17 **must**:
+
+- [ ] Implement `PTYAllocator` / `PTYSession` for Windows ConPTY and POSIX PTY.
+- [ ] Call `BuildArgv`, `ValidateArgv`, and `ResolveWorkspaceDir` before spawn.
+- [ ] Honor `DefaultMaxCaptureBytes` and timeout defaults unless config overrides
+      within `MaxMaxCaptureBytes`.
+- [ ] Reuse `pkg/workers/process` for process-tree cleanup (T7).
+- [ ] Build environment through `commandenv.Build` (T3).
+- [ ] Keep `MockAllocator` / fixture tests passing in CI without an Agy binary.
+
+Story 17 **must not**:
+
+- Invoke or embed the Python bridge (T9).
+- Use shell-string command construction (T1).
+- Fall back to pipe IO on unsupported platforms (T8).
+- Publish raw PTY bytes as public response content (T4, T10).
+
+## Explicit exclusions
+
+Same exclusions as `agy-pty-boundary.md`:
+
+- Production Agy execution in this lane (Story 001–003 are specification only).
+- Python-bridge invocation or embedding.
+- Shell-string command construction.
+- Incremental native streaming of spinner/repaint frames.
+
+## Related documents
+
+| Document | Role |
+| --- | --- |
+| `agy-pty-boundary.md` | ADR — scope, platforms, gating |
+| `agy-pty-threat-review.md` | T1–T10 controls and Story 17 security checklist |
+| `pkg/workers/process/doc.go` | Supervision and cleanup escape documentation |
+| `pkg/workers/provider/commandenv/environment.go` | Environment merge policy |
+| `pkg/workers/worktree/paths.go` | Relative name normalization reference |

--- a/docs/architecture/agy-pty-threat-review.md
+++ b/docs/architecture/agy-pty-threat-review.md
@@ -319,7 +319,7 @@ Checked against `docs/internal/standards/code/general-backend-standards.md`:
 | Document | Role |
 | --- | --- |
 | `docs/architecture/agy-pty-boundary.md` | ADR — scope, platforms, exclusions |
-| Story 003 interface proposal | Mock seams, `maxCaptureBytes`, fixture locations |
+| Story 003 interface proposal (`agy-pty-interface.md`, `pkg/workers/agypty`) | Mock seams, `maxCaptureBytes`, fixture locations |
 | `pkg/workers/process/doc.go` | Supervision and cleanup escape documentation |
 | `pkg/workers/provider/commandenv/environment.go` | Environment merge policy |
 | `pkg/workers/worktree/paths.go` | Path normalization reference for workspace containment |

--- a/docs/architecture/agy-pty-threat-review.md
+++ b/docs/architecture/agy-pty-threat-review.md
@@ -1,0 +1,325 @@
+# Threat review: Agy PTY boundary (Windows and POSIX)
+
+| Field | Value |
+| --- | --- |
+| Status | Accepted |
+| Story | S16 / `stream-b06-agy-integration-decision-002` |
+| Date | 2026-07-14 (UTC) |
+| Companion ADR | `docs/architecture/agy-pty-boundary.md` |
+| Gates | Story 17+ Agy execution (`agy-pty-boundary.md` §Gating Story 17) |
+
+This document is the security threat review for the minimal native Go Agy PTY
+boundary approved in `agy-pty-boundary.md`. It constrains Story 17
+implementation choices. This lane does **not** invoke or embed the upstream
+Python bridge and does **not** add production Agy execution.
+
+## Scope and trust boundaries
+
+| Boundary | Trusted side | Untrusted side |
+| --- | --- | --- |
+| Factory configuration | Maintainer-authored factory config, worker definitions, orchestration policy | — |
+| Work payload | Factory runtime validation and work-content policy | User-supplied prompt text passed through to the Agy CLI as an argv element or documented stdin attachment |
+| Agy CLI child | Typed argv, supervised process group/job, bounded PTY capture | Agy binary behavior, terminal output content, auth prompts, and any child processes Agy spawns |
+| Public response events | Cleaned final text after terminal cleaning (Story 17+) | Raw PTY bytes, ANSI/OSC sequences, spinner/repaint noise |
+
+The PTY boundary runs inside the worker process. It must treat Agy argv fields,
+workspace paths, inherited environment values, and captured terminal bytes as
+**untrusted input** once they originate from work payloads or the child process.
+
+## Threat catalog
+
+| ID | Threat | Primary controls | Story 17 owner |
+| --- | --- | --- | --- |
+| T1 | Shell / argv injection via metacharacters or shell wrappers | Typed `[]string` argv only; no `sh -c`, `cmd /C`, or PowerShell `-Command` | Agy provider adapter + Story 003 fixtures |
+| T2 | Workspace path traversal or attachment outside factory root | Normalize, clean, and validate paths before `Dir` or argv attachment; reject `..` escapes | Agy provider adapter + Story 003 fixtures |
+| T3 | Environment inheritance leaking secrets or re-enabling interactive prompts | `commandenv.Build` precedence; explicit denylist for PTY-sensitive vars | Agy provider adapter |
+| T4 | Terminal escape sequences in PTY output affecting downstream consumers | Bounded capture; terminal cleaning before any public payload; no raw PTY publish | PTY package + Story 18 cleaning corpus |
+| T5 | Unbounded PTY capture exhausting memory or event buffers | Hard byte cap on internal capture buffer; truncate or fail closed per policy | PTY package |
+| T6 | Hung or runaway child processes after idle/hard timeout | Idle and hard timers; supervised tree termination via `pkg/workers/process` | PTY package + process runner |
+| T7 | Orphaned child processes after cancel, crash, or adapter failure | Job object (Windows) / process group (POSIX) cleanup; documented escape limits | `pkg/workers/process` |
+| T8 | Unsupported platform silently using pipe IO | Fail closed with `UNSUPPORTED` or classified setup failure | PTY allocator |
+| T9 | Python bridge invocation or embedding at runtime | ADR exclusion; no CPython dependency; hermetic tests without bridge | All layers |
+| T10 | Publishing incremental spinner/repaint noise as response events | Final-only fidelity (`nativeStreaming=false`); internal PTY bytes only | Agy adapter kernel |
+
+## T1 — Shell and argv injection
+
+### Risk
+
+Concatenating user or configuration values into a shell command string allows
+shell metacharacter injection (`;`, `|`, `` ` ``, `$()`, newlines). Wrapping
+argv in `/bin/sh -c`, `cmd.exe /C`, or `powershell -Command` reintroduces a
+shell parser between the factory and the Agy binary.
+
+### Required controls
+
+1. **Typed argv only.** Build commands with `exec.Command(executable, args...)`
+   where `executable` is the resolved Agy binary path and each `args[i]` is an
+   independent string field. Never pass a single assembled command line to a
+   shell interpreter.
+2. **No shell indirection.** Forbidden patterns include:
+   - `exec.Command("sh", "-c", joined)`
+   - `exec.Command("bash", "-c", joined)`
+   - `exec.Command("cmd", "/C", joined)`
+   - `exec.Command("powershell", "-Command", joined)`
+3. **Executable path resolution.** Resolve the configured Agy executable with
+   `filepath.Clean` / `filepath.EvalSymlinks` where appropriate; reject directory
+   paths and empty strings before spawn.
+4. **Prompt and flag separation.** User prompt text must be a distinct argv
+   element (or documented stdin attachment), not concatenated into a flag value
+   that is later split on whitespace.
+5. **Hermetic validation.** Story 003 fixtures must prove representative argv
+   shapes are `[]string` slices with no shell wrapper (see
+   `agy-pty-boundary.md` §Gating Story 17).
+
+### Platform notes
+
+| Platform | argv mechanism | Injection surface |
+| --- | --- | --- |
+| Windows | `CreateProcess` argv vector via Go `exec.Command` | Avoid `cmd.exe` parsing rules by not invoking `cmd.exe` |
+| POSIX | `execve` argv array | Avoid `/bin/sh` by not invoking a shell |
+
+## T2 — Workspace path attachment and normalization
+
+### Risk
+
+Attaching a workspace directory with `..` segments, absolute paths outside the
+factory root, or symlink escapes can cause the Agy child to read or write files
+outside the intended factory worktree.
+
+### Required controls
+
+1. **Normalize before use.** Apply `filepath.Clean` and `filepath.FromSlash` to
+   configured workspace paths. Reject empty paths.
+2. **Containment checks.** When the factory designates a workspace root, resolved
+   paths must remain under that root (same pattern as
+   `pkg/workers/worktree/paths.go` `cleanWorktreeName` — reject `..` traversal,
+   reject absolute names where relative names are required).
+3. **Process working directory.** Set `cmd.Dir` only after normalization and
+   containment validation; never pass raw user strings.
+4. **Argv path fields.** Any workspace path passed as an Agy flag value must be
+   the same normalized absolute or root-relative path used for `cmd.Dir`, not a
+   separate unvalidated copy.
+5. **Hermetic fixtures.** Story 003 must include fixtures for valid paths,
+   `..` rejection, and separator normalization on Windows and POSIX.
+
+### Platform notes
+
+| Platform | Consideration |
+| --- | --- |
+| Windows | `\\?\` prefixes, drive-relative paths, and case-insensitive comparison when checking root containment |
+| POSIX | Symlink components under the workspace root; prefer `EvalSymlinks` on the resolved root before containment checks when feasible |
+
+## T3 — Environment inheritance
+
+### Risk
+
+Inheriting the full process environment can propagate secrets (`AWS_*`,
+`OPENAI_*`, provider tokens) to the Agy child, re-enable interactive prompts
+(`GIT_TERMINAL_PROMPT`, `EDITOR`), or alter Agy behavior unpredictably.
+
+### Required controls
+
+1. **Centralized merge policy.** Use `pkg/workers/provider/commandenv.Build`
+   for provider subprocess environment assembly. Precedence: process environment,
+   provider variables, then automation defaults (`GIT_TERMINAL_PROMPT=0`, etc.).
+2. **No duplicate env builders.** The Agy adapter must not fork a parallel
+   environment-merge path that bypasses `commandenv`.
+3. **PTY-specific posture.** Story 17 must document any Agy-specific
+   environment denylists or required vars (for example non-interactive flags)
+   in the adapter; changes require threat-review update.
+4. **No Python bridge env.** Do not set `PYTHONPATH`, `VIRTUAL_ENV`, or invoke
+   `python -m agy_headless_bridge` to populate environment for the child.
+
+## T4 — Terminal escape sequences
+
+### Risk
+
+PTY output can contain ANSI CSI/OSC sequences, title changes, alternate-screen
+switches, or escape-driven repaints. Publishing raw bytes can corrupt dashboards,
+log pipelines, or terminal emulators used by operators. Some sequences are
+historically abused for social-engineering overlays (less relevant in headless
+capture but still noise).
+
+### Required controls
+
+1. **Internal-only raw bytes.** PTY capture buffers are implementation-private
+   until terminal cleaning runs.
+2. **Cleaning before public emit.** Story 17 must not emit response events
+   containing raw PTY bytes. Cleaned final text only (Story 18 may extend
+   partial-timeout policy later).
+3. **Cleaner scope.** Strip CSI/OSC, carriage-return repaint lines, spinner
+   glyphs, and box-drawing noise per `agy-pty-boundary.md` maintained scope.
+4. **No echo of control bytes in errors.** Failure messages must not include
+   unfiltered capture snippets that contain escape sequences; truncate and strip
+   when surfacing diagnostics.
+
+## T5 — Output bounds
+
+### Risk
+
+A verbose or runaway TUI can produce unbounded PTY output, causing memory
+pressure in the worker or oversized internal buffers.
+
+### Required controls
+
+1. **Hard byte cap.** Maintain a documented `maxCaptureBytes` on the internal
+   PTY read buffer. Default and maximum values are fixed in Story 17
+   implementation and recorded in the interface proposal (Story 003).
+2. **Bounded reads.** Read loops must respect the cap; do not grow slices
+   without limit.
+3. **No unbounded public streaming.** Agy adapter declares final-only fidelity;
+   incremental publish of PTY chunks is forbidden in Story 17.
+4. **Policy on cap breach.** Classify as timeout or capacity failure per adapter
+   kernel rules; do not publish partial raw capture.
+
+## T6 — Timeouts
+
+### Risk
+
+Without idle and hard limits, a stuck Agy session holds PTY fds, worker slots,
+and child processes indefinitely.
+
+### Required controls
+
+1. **Idle timeout.** Reset on new PTY bytes; cancel supervised tree on breach.
+2. **Hard timeout.** Absolute wall-clock limit from spawn; cancel regardless of
+   byte activity.
+3. **Context propagation.** Timeouts must flow through `context.Context`
+   cancellation into `pkg/workers/process` runner semantics.
+4. **No partial public output on timeout in Story 17.** Partial-timeout publish
+   is Story 18 scope only.
+
+## T7 — Process-tree cleanup
+
+### Risk
+
+After success, failure, cancel, or timeout, remaining child processes can leak
+workers, hold files, or continue consuming credentials.
+
+### Required controls
+
+1. **Reuse supervision semantics.** Align with `pkg/workers/process`:
+   - **Windows:** job object with `KILL_ON_JOB_CLOSE`; terminate active
+     processes before closing the handle.
+   - **POSIX:** dedicated process group; SIGTERM, grace period, then SIGKILL.
+2. **PTY fd lifecycle.** Close master/slave or ConPTY handles after cleanup
+   starts; do not leak fds on error paths.
+3. **Documented escape limits.** Cleanup targets the supervised group only.
+   Detached children (`setsid`, `CREATE_BREAKAWAY_FROM_JOB`) may survive — same
+   limits as `pkg/workers/process/doc.go`. Operators must not rely on cleanup
+   to stop intentionally detached daemons.
+4. **Cancel vs. exit ordering.** Capture exit metadata before cleanup mutates
+   the process tree, consistent with existing runner behavior.
+
+### Windows ConPTY-specific cleanup
+
+| Step | Requirement |
+| --- | --- |
+| Cancel/timeout | Cancel context; signal job termination |
+| ConPTY handles | Close pseudo-console and pipe handles after child termination attempt |
+| Job object | Terminate active processes; close job handle to enforce `KILL_ON_JOB_CLOSE` |
+| Failure mode | If ConPTY allocation fails at startup, fail closed before spawning Agy |
+
+### POSIX PTY-specific cleanup
+
+| Step | Requirement |
+| --- | --- |
+| Cancel/timeout | Cancel context; SIGTERM to process group, grace, SIGKILL |
+| PTY fds | Close master and slave fds after child termination attempt |
+| Controlling terminal | Follow platform PTY contract when setting controlling tty; avoid leaking session state to unrelated children |
+| Failure mode | If `openpty` fails, fail closed with `UNSUPPORTED` or setup failure — no pipe fallback |
+
+## T8 — Unsupported platforms
+
+### Risk
+
+Platforms without ConPTY or POSIX PTY APIs might tempt implementers to fall back
+to pipe IO, defeating Agy TTY gating and hiding capability gaps.
+
+### Required controls
+
+1. **Fail closed.** Return explicit `UNSUPPORTED` capability or classified setup
+   failure at allocation time.
+2. **No silent pipe fallback.** Pipe redirection is not an approved degradation
+   path (`agy-pty-boundary.md`).
+3. **Build tags.** Platform files must compile only supported paths; unsupported
+   OS builds return a typed error from allocator entry points.
+
+## T9 — Python bridge and production execution exclusions
+
+This threat review lane is specification only.
+
+| Exclusion | Threat if violated |
+| --- | --- |
+| No Python bridge invocation | Supply-chain and runtime dependency on CPython; behavior drift from approved Go boundary |
+| No Python embedding | Same as above; larger attack surface |
+| No production Agy execution in S16 | Unreviewed execution code bypassing argv, bounds, and cleaning controls |
+
+Story 17 may add execution only after this review, the ADR, and Story 003
+interface fixtures are merged.
+
+## T10 — Public response content policy
+
+### Risk
+
+Publishing raw terminal repaint or spinner frames as incremental response events
+leaks noise, destabilizes client rendering, and bypasses cleaning.
+
+### Required controls
+
+1. **Final-only fidelity.** Agy adapter sets `nativeStreaming=false` per
+   `stream-response-fix-plan.md` §8.6 (when present in tree).
+2. **Cleaned text only.** Public `Content` fields contain terminal-cleaned text
+   after Story 17 execution lands.
+3. **Diagnostics.** Internal logs may record capture metrics (byte counts,
+   duration) but must not log full prompt text or unfiltered PTY payloads at
+   default verbosity.
+
+## Windows vs POSIX security assumptions (summary)
+
+| Topic | Windows (ConPTY) | POSIX (Linux/macOS) |
+| --- | --- | --- |
+| PTY allocation | Pseudo-console via ConPTY APIs | `openpty` master/slave pair |
+| argv delivery | `CreateProcess` argv vector; no `cmd.exe` | `execve` argv array; no `/bin/sh` |
+| Supervision | Job object | Process group |
+| Cleanup | `TerminateJobObject`, close job handle | SIGTERM → grace → SIGKILL |
+| Detached child escape | `CREATE_BREAKAWAY_FROM_JOB` | `setsid`, double-fork |
+| Unsupported OS | Fail closed at allocator | Fail closed at allocator |
+| Pipe fallback | **Forbidden** | **Forbidden** |
+
+## Story 17 implementation checklist (security)
+
+Story 17 **must** satisfy every item before merge:
+
+- [ ] Spawn Agy with typed `[]string` argv and no shell wrapper (T1).
+- [ ] Normalize and validate workspace paths before `cmd.Dir` and argv attachment (T2).
+- [ ] Build environment through `commandenv.Build` (T3).
+- [ ] Keep raw PTY bytes internal; emit cleaned final text only (T4, T10).
+- [ ] Enforce `maxCaptureBytes` on capture loops (T5).
+- [ ] Implement idle and hard timeouts with context cancellation (T6).
+- [ ] Reuse `pkg/workers/process` supervision and cleanup semantics (T7).
+- [ ] Fail closed on unsupported platforms; no pipe fallback (T8).
+- [ ] Do not invoke or embed the Python bridge (T9).
+- [ ] Prove argv and path fixtures from Story 003 in CI without an Agy binary.
+
+## Review against backend standards
+
+Checked against `docs/internal/standards/code/general-backend-standards.md`:
+
+| Standard theme | How this review constrains implementation |
+| --- | --- |
+| Package boundaries | PTY allocation in dedicated `pkg/workers/` package; adapter owns argv/paths; `process` owns tree cleanup |
+| Pure vs IO logic | Terminal cleaning and argv/path normalization are pure and unit-testable (Story 003) |
+| Explicit timeouts and cancellation | T6 requires context-driven idle/hard limits |
+| Observable failure handling | Unsupported platform, cap breach, and timeout failures are classified, not silent |
+| Test evidence | Hermetic fixtures without live Agy or Python bridge |
+
+## Related documents
+
+| Document | Role |
+| --- | --- |
+| `docs/architecture/agy-pty-boundary.md` | ADR — scope, platforms, exclusions |
+| Story 003 interface proposal | Mock seams, `maxCaptureBytes`, fixture locations |
+| `pkg/workers/process/doc.go` | Supervision and cleanup escape documentation |
+| `pkg/workers/provider/commandenv/environment.go` | Environment merge policy |
+| `pkg/workers/worktree/paths.go` | Path normalization reference for workspace containment |

--- a/pkg/factory/sessions/execution/fixtures/helpers_test.go
+++ b/pkg/factory/sessions/execution/fixtures/helpers_test.go
@@ -594,8 +594,9 @@ func startInterruptedResumableSessionForWorkflow(
 		t.Fatalf("StartAsync: %v", err)
 	}
 
-	waitForDispatchStatus(t, initial, started.SessionID, "dispatch-1", fse.DispatchStatusCompleted, 3*time.Second)
-	waitForDispatchStatus(t, initial, started.SessionID, "dispatch-2", fse.DispatchStatusRunning, 3*time.Second)
+	waitForDispatchStatus(t, initial, started.SessionID, "dispatch-1", fse.DispatchStatusCompleted, 10*time.Second)
+	waitForDispatchStatus(t, initial, started.SessionID, "dispatch-2", fse.DispatchStatusRunning, 10*time.Second)
+	provider.waitUntilBlockedOnInfer(t, 10*time.Second)
 
 	interruptResult, err := initial.InterruptDispatch(context.Background(), started.SessionID, fse.InterruptDispatchRequest{
 		ControlRequest: fse.ControlRequest{Reason: "process restart simulation"},
@@ -608,7 +609,7 @@ func startInterruptedResumableSessionForWorkflow(
 		t.Fatalf("interrupt outcome = %q, want ACCEPTED", interruptResult.Outcome)
 	}
 
-	provider.waitForCanceledInfer(t, 3*time.Second)
+	provider.waitForCanceledInfer(t, 10*time.Second)
 	interrupted := waitUntilSessionStatus(t, initial, started.SessionID, fse.LifecycleStatusInterrupted, 5*time.Second)
 	if interrupted.Status != fse.LifecycleStatusInterrupted {
 		t.Fatalf("session status = %q, want INTERRUPTED", interrupted.Status)
@@ -733,14 +734,19 @@ type sequentialBlockingProvider struct {
 	blockedOnce     bool
 	contextCanceled int
 	workflowName    string
+	blockedOnCtx    chan struct{}
+	blockSignal     sync.Once
 }
 
 func newSequentialBlockingProvider() *sequentialBlockingProvider {
-	return &sequentialBlockingProvider{workflowName: "resumable-two-step-fake-children"}
+	return newSequentialBlockingProviderForWorkflow("resumable-two-step-fake-children")
 }
 
 func newSequentialBlockingProviderForWorkflow(workflowName string) *sequentialBlockingProvider {
-	return &sequentialBlockingProvider{workflowName: workflowName}
+	return &sequentialBlockingProvider{
+		workflowName: workflowName,
+		blockedOnCtx: make(chan struct{}),
+	}
 }
 
 func (p *sequentialBlockingProvider) Infer(ctx context.Context, _ interfaces.ProviderInferenceRequest) (interfaces.InferenceResponse, error) {
@@ -766,6 +772,7 @@ func (p *sequentialBlockingProvider) Infer(ctx context.Context, _ interfaces.Pro
 		p.blockedOnce = true
 		p.mu.Unlock()
 
+		p.blockSignal.Do(func() { close(p.blockedOnCtx) })
 		<-ctx.Done()
 		p.mu.Lock()
 		p.contextCanceled++
@@ -787,6 +794,16 @@ func (p *sequentialBlockingProvider) CallCount() int {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.calls
+}
+
+func (p *sequentialBlockingProvider) waitUntilBlockedOnInfer(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	select {
+	case <-p.blockedOnCtx:
+		return
+	case <-time.After(timeout):
+		t.Fatal("provider Infer did not block on workflow context")
+	}
 }
 
 func (p *sequentialBlockingProvider) waitForCanceledInfer(t *testing.T, timeout time.Duration) {

--- a/pkg/factory/sessions/execution/fixtures/runtime_restart_resume_test.go
+++ b/pkg/factory/sessions/execution/fixtures/runtime_restart_resume_test.go
@@ -620,15 +620,16 @@ func seedInterruptedCheckpointedSession(t *testing.T) (string, string) {
 	if err != nil {
 		t.Fatalf("StartAsync: %v", err)
 	}
-	waitForDispatchStatus(t, initial, started.SessionID, "dispatch-1", fse.DispatchStatusCompleted, 3*time.Second)
-	waitForDispatchStatus(t, initial, started.SessionID, "dispatch-2", fse.DispatchStatusRunning, 3*time.Second)
+	waitForDispatchStatus(t, initial, started.SessionID, "dispatch-1", fse.DispatchStatusCompleted, 10*time.Second)
+	waitForDispatchStatus(t, initial, started.SessionID, "dispatch-2", fse.DispatchStatusRunning, 10*time.Second)
+	provider.waitUntilBlockedOnInfer(t, 10*time.Second)
 	if _, err := initial.InterruptDispatch(context.Background(), started.SessionID, fse.InterruptDispatchRequest{
 		ControlRequest: fse.ControlRequest{Reason: "resume failure seed"},
 		DispatchID:     "dispatch-2",
 	}); err != nil {
 		t.Fatalf("InterruptDispatch: %v", err)
 	}
-	provider.waitForCanceledInfer(t, 3*time.Second)
+	provider.waitForCanceledInfer(t, 10*time.Second)
 	interrupted := waitUntilSessionStatus(t, initial, started.SessionID, fse.LifecycleStatusInterrupted, 5*time.Second)
 	if interrupted.Status != fse.LifecycleStatusInterrupted {
 		t.Fatalf("seed status = %q, want INTERRUPTED", interrupted.Status)

--- a/pkg/workers/agypty/argv.go
+++ b/pkg/workers/agypty/argv.go
@@ -1,0 +1,91 @@
+package agypty
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// ArgvSpec describes typed argv fields for one Agy headless invocation.
+// Prompt is always emitted as a separate argv element, never concatenated into
+// a shell command string (T1 control in agy-pty-threat-review.md).
+type ArgvSpec struct {
+	Executable string
+	Subcommand []string
+	Flags      []string
+	Prompt     string
+}
+
+// BuildArgv constructs a typed argv slice for exec.Command(executable, args...).
+// The returned slice never includes a shell interpreter wrapper.
+func BuildArgv(spec ArgvSpec) ([]string, error) {
+	executable := strings.TrimSpace(spec.Executable)
+	if executable == "" {
+		return nil, fmt.Errorf("agypty: executable is required")
+	}
+
+	argv := make([]string, 0, 1+len(spec.Subcommand)+len(spec.Flags)+1)
+	argv = append(argv, executable)
+	argv = append(argv, spec.Subcommand...)
+	argv = append(argv, spec.Flags...)
+	if strings.TrimSpace(spec.Prompt) != "" {
+		argv = append(argv, spec.Prompt)
+	}
+	return argv, nil
+}
+
+// ValidateArgv enforces the T1 argv contract: non-empty typed argv with no shell wrapper.
+func ValidateArgv(argv []string) error {
+	if len(argv) == 0 {
+		return fmt.Errorf("agypty: argv is empty")
+	}
+	if strings.TrimSpace(argv[0]) == "" {
+		return fmt.Errorf("agypty: executable is required")
+	}
+	return RejectShellWrapper(argv)
+}
+
+// RejectShellWrapper returns an error when argv would invoke a shell interpreter
+// with a command-string flag such as sh -c, cmd /C, or powershell -Command.
+func RejectShellWrapper(argv []string) error {
+	if len(argv) == 0 {
+		return fmt.Errorf("agypty: argv is empty")
+	}
+
+	program := normalizeProgramName(argv[0])
+	if !isShellInterpreter(program) {
+		return nil
+	}
+
+	for i := 1; i < len(argv); i++ {
+		if isShellWrapperFlag(argv[i]) {
+			return fmt.Errorf("agypty: shell wrapper %q with %q is forbidden", argv[0], argv[i])
+		}
+	}
+	return nil
+}
+
+func normalizeProgramName(program string) string {
+	program = strings.TrimSpace(program)
+	program = filepath.Base(program)
+	program = strings.ToLower(program)
+	return strings.TrimSuffix(program, ".exe")
+}
+
+func isShellInterpreter(program string) bool {
+	switch program {
+	case "sh", "bash", "zsh", "dash", "ksh", "cmd", "powershell", "pwsh":
+		return true
+	default:
+		return false
+	}
+}
+
+func isShellWrapperFlag(flag string) bool {
+	switch strings.ToLower(strings.TrimSpace(flag)) {
+	case "-c", "/c", "-command":
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/workers/agypty/argv_test.go
+++ b/pkg/workers/agypty/argv_test.go
@@ -1,0 +1,72 @@
+package agypty_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/workers/agypty"
+)
+
+func TestArgvFixtures(t *testing.T) {
+	t.Parallel()
+
+	fixtures, err := agypty.LoadArgvFixtures()
+	if err != nil {
+		t.Fatalf("LoadArgvFixtures() error = %v", err)
+	}
+
+	for _, fixture := range fixtures {
+		fixture := fixture
+		t.Run(fixture.Name, func(t *testing.T) {
+			t.Parallel()
+
+			switch {
+			case fixture.Spec != nil:
+				argv, err := agypty.BuildArgv(*fixture.Spec)
+				if err != nil {
+					t.Fatalf("BuildArgv() error = %v", err)
+				}
+				if err := agypty.ValidateArgv(argv); err != nil {
+					t.Fatalf("ValidateArgv() error = %v", err)
+				}
+				assertStringSliceEqual(t, argv, fixture.WantArgv)
+			case len(fixture.Argv) > 0:
+				err := agypty.ValidateArgv(fixture.Argv)
+				if fixture.WantError == "" {
+					if err != nil {
+						t.Fatalf("ValidateArgv() error = %v, want nil", err)
+					}
+					return
+				}
+				if err == nil {
+					t.Fatal("ValidateArgv() error = nil, want error")
+				}
+				if !strings.Contains(err.Error(), fixture.WantError) {
+					t.Fatalf("ValidateArgv() error = %v, want substring %q", err, fixture.WantError)
+				}
+			default:
+				t.Fatal("fixture must set spec or argv")
+			}
+		})
+	}
+}
+
+func TestBuildArgv_RejectsEmptyExecutable(t *testing.T) {
+	t.Parallel()
+
+	if _, err := agypty.BuildArgv(agypty.ArgvSpec{}); err == nil {
+		t.Fatal("BuildArgv() error = nil, want error")
+	}
+}
+
+func assertStringSliceEqual(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("argv = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("argv[%d] = %q, want %q (full %#v)", i, got[i], want[i], got)
+		}
+	}
+}

--- a/pkg/workers/agypty/cleaner.go
+++ b/pkg/workers/agypty/cleaner.go
@@ -1,0 +1,68 @@
+package agypty
+
+import (
+	"bytes"
+	"strings"
+)
+
+// CleanTerminal strips common ANSI CSI and OSC sequences plus carriage-return
+// repaint lines from raw PTY capture bytes. Story 18 may extend the cleaning
+// corpus; this function is the pure seam Story 17 calls before public emit.
+func CleanTerminal(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	stripped := stripANSISequences(raw)
+	normalized := strings.ReplaceAll(string(stripped), "\r\n", "\n")
+	lines := strings.Split(normalized, "\n")
+	filtered := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if idx := strings.LastIndex(line, "\r"); idx >= 0 {
+			line = line[idx+1:]
+		}
+		line = strings.TrimRight(line, "\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		filtered = append(filtered, line)
+	}
+	return strings.TrimSpace(strings.Join(filtered, "\n"))
+}
+
+func stripANSISequences(raw []byte) []byte {
+	var out bytes.Buffer
+	for i := 0; i < len(raw); {
+		if raw[i] != 0x1b {
+			out.WriteByte(raw[i])
+			i++
+			continue
+		}
+		if i+1 >= len(raw) {
+			break
+		}
+		switch raw[i+1] {
+		case '[':
+			end := i + 2
+			for end < len(raw) && !isCSITerminator(raw[end]) {
+				end++
+			}
+			if end < len(raw) {
+				i = end + 1
+				continue
+			}
+		case ']':
+			end := bytes.IndexByte(raw[i+2:], 0x07)
+			if end >= 0 {
+				i = i + 2 + end + 1
+				continue
+			}
+		}
+		i++
+	}
+	return out.Bytes()
+}
+
+func isCSITerminator(b byte) bool {
+	return (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z')
+}

--- a/pkg/workers/agypty/doc.go
+++ b/pkg/workers/agypty/doc.go
@@ -1,0 +1,16 @@
+// Package agypty defines the minimal native Go Agy PTY boundary interfaces,
+// pure argv/path helpers, and mock seams approved in
+// docs/architecture/agy-pty-interface.md.
+//
+// This package is specification-only for Story 16 (stream-b06-agy-integration-decision).
+// Production Agy headless execution remains out of scope until Story 17 consumes
+// these interfaces. The package does not invoke or embed the upstream Python bridge
+// and does not require an installed Agy binary for unit tests.
+//
+// Platform PTY allocation (Windows ConPTY, POSIX openpty) is implemented in Story 17.
+// Tests substitute MockAllocator for real ConPTY/PTY allocation.
+//
+// Related documents:
+//   - docs/architecture/agy-pty-boundary.md — ADR scope and gating
+//   - docs/architecture/agy-pty-threat-review.md — T1/T2 security controls
+package agypty

--- a/pkg/workers/agypty/fixtures.go
+++ b/pkg/workers/agypty/fixtures.go
@@ -1,0 +1,55 @@
+package agypty
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+)
+
+//go:embed testdata/argv_fixtures.json
+var argvFixturesJSON []byte
+
+//go:embed testdata/workspace_fixtures.json
+var workspaceFixturesJSON []byte
+
+type argvFixtureFile struct {
+	Fixtures []argvFixture `json:"fixtures"`
+}
+
+type argvFixture struct {
+	Name     string   `json:"name"`
+	Spec     *ArgvSpec `json:"spec,omitempty"`
+	Argv     []string `json:"argv,omitempty"`
+	WantArgv []string `json:"want_argv,omitempty"`
+	WantError string  `json:"want_error,omitempty"`
+}
+
+type workspaceFixtureFile struct {
+	Fixtures []workspaceFixture `json:"fixtures"`
+}
+
+type workspaceFixture struct {
+	Name        string   `json:"name"`
+	FactoryRoot string   `json:"factory_root"`
+	RawPath     string   `json:"raw_path"`
+	WantSuffix  []string `json:"want_suffix,omitempty"`
+	WantError   string   `json:"want_error,omitempty"`
+}
+
+// LoadArgvFixtures returns hermetic argv corpus entries for unit tests.
+func LoadArgvFixtures() ([]argvFixture, error) {
+	var file argvFixtureFile
+	if err := json.Unmarshal(argvFixturesJSON, &file); err != nil {
+		return nil, fmt.Errorf("agypty: decode argv fixtures: %w", err)
+	}
+	return file.Fixtures, nil
+}
+
+// LoadWorkspaceFixtures returns hermetic workspace path corpus entries for unit tests.
+func LoadWorkspaceFixtures() ([]workspaceFixture, error) {
+	var file workspaceFixtureFile
+	if err := json.Unmarshal(workspaceFixturesJSON, &file); err != nil {
+		return nil, fmt.Errorf("agypty: decode workspace fixtures: %w", err)
+	}
+	return file.Fixtures, nil
+}

--- a/pkg/workers/agypty/limits.go
+++ b/pkg/workers/agypty/limits.go
@@ -1,0 +1,13 @@
+package agypty
+
+import "time"
+
+// Default capture and timeout limits for the approved Agy PTY boundary.
+// Story 17 implementation must honor these defaults unless factory config
+// documents an explicit override within MaxMaxCaptureBytes.
+const (
+	DefaultMaxCaptureBytes = 4 * 1024 * 1024  // 4 MiB
+	MaxMaxCaptureBytes     = 16 * 1024 * 1024 // 16 MiB hard ceiling
+	DefaultIdleTimeout     = 30 * time.Second
+	DefaultHardTimeout     = 10 * time.Minute
+)

--- a/pkg/workers/agypty/mock.go
+++ b/pkg/workers/agypty/mock.go
@@ -1,0 +1,52 @@
+package agypty
+
+import "context"
+
+// MockAllocator records Allocate calls and returns MockSession values for
+// hermetic unit tests without ConPTY, POSIX PTY, or an installed Agy binary.
+type MockAllocator struct {
+	Sessions []*MockSession
+	Err      error
+}
+
+// Allocate implements PTYAllocator.
+func (m *MockAllocator) Allocate(_ context.Context, launch ProcessLaunch, cfg SessionConfig) (PTYSession, error) {
+	if m.Err != nil {
+		return nil, m.Err
+	}
+	session := &MockSession{
+		Launch: launch,
+		Config: cfg,
+	}
+	m.Sessions = append(m.Sessions, session)
+	return session, nil
+}
+
+// MockSession implements PTYSession with predetermined capture for tests.
+type MockSession struct {
+	Launch  ProcessLaunch
+	Config  SessionConfig
+	Result  SessionResult
+	RunErr  error
+	Closed  bool
+	RunCall int
+}
+
+// Run implements PTYSession.
+func (s *MockSession) Run(_ context.Context) (SessionResult, error) {
+	s.RunCall++
+	if s.RunErr != nil {
+		return SessionResult{}, s.RunErr
+	}
+	result := s.Result
+	if result.CleanedText == "" && len(result.RawBytes) > 0 {
+		result.CleanedText = CleanTerminal(result.RawBytes)
+	}
+	return result, nil
+}
+
+// Close implements PTYSession.
+func (s *MockSession) Close() error {
+	s.Closed = true
+	return nil
+}

--- a/pkg/workers/agypty/mock_test.go
+++ b/pkg/workers/agypty/mock_test.go
@@ -1,0 +1,69 @@
+package agypty_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/workers/agypty"
+)
+
+func TestMockAllocatorRecordsLaunchAndCapture(t *testing.T) {
+	t.Parallel()
+
+	allocator := &agypty.MockAllocator{}
+	launch := agypty.ProcessLaunch{
+		Executable: "/bin/agy",
+		Argv:       []string{"/bin/agy", "chat", "--headless", "hello"},
+		WorkDir:    "/factory/workspaces/a",
+		Env:        []string{"GIT_TERMINAL_PROMPT=0"},
+	}
+	cfg := agypty.DefaultSessionConfig()
+
+	session, err := allocator.Allocate(context.Background(), launch, cfg)
+	if err != nil {
+		t.Fatalf("Allocate() error = %v", err)
+	}
+
+	mockSession, ok := session.(*agypty.MockSession)
+	if !ok {
+		t.Fatalf("session type = %T, want *agypty.MockSession", session)
+	}
+	mockSession.Result = agypty.SessionResult{
+		ExitCode: 0,
+		RawBytes: []byte("answer\r\n\x1b[2K"),
+	}
+
+	result, err := session.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.CleanedText != "answer" {
+		t.Fatalf("CleanedText = %q, want %q", result.CleanedText, "answer")
+	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if !mockSession.Closed {
+		t.Fatal("MockSession.Closed = false, want true")
+	}
+	if len(allocator.Sessions) != 1 {
+		t.Fatalf("len(Sessions) = %d, want 1", len(allocator.Sessions))
+	}
+	if allocator.Sessions[0].Launch.Executable != launch.Executable {
+		t.Fatalf("recorded executable = %q, want %q", allocator.Sessions[0].Launch.Executable, launch.Executable)
+	}
+	if allocator.Sessions[0].Config.MaxCaptureBytes != cfg.MaxCaptureBytes {
+		t.Fatalf("recorded MaxCaptureBytes = %d, want %d", allocator.Sessions[0].Config.MaxCaptureBytes, cfg.MaxCaptureBytes)
+	}
+}
+
+func TestCleanTerminal_StripsANSICarriageReturnNoise(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte("spinning\ranswer\x1b[2K\nignored blank\n")
+	got := agypty.CleanTerminal(raw)
+	want := "answer\nignored blank"
+	if got != want {
+		t.Fatalf("CleanTerminal() = %q, want %q", got, want)
+	}
+}

--- a/pkg/workers/agypty/testdata/argv_fixtures.json
+++ b/pkg/workers/agypty/testdata/argv_fixtures.json
@@ -1,0 +1,49 @@
+{
+  "fixtures": [
+    {
+      "name": "headless_prompt_separate_element",
+      "spec": {
+        "executable": "/usr/local/bin/agy",
+        "subcommand": ["chat"],
+        "flags": ["--headless"],
+        "prompt": "explain foo"
+      },
+      "want_argv": ["/usr/local/bin/agy", "chat", "--headless", "explain foo"]
+    },
+    {
+      "name": "metacharacters_preserved_in_argv",
+      "spec": {
+        "executable": "/bin/agy",
+        "subcommand": [],
+        "flags": [],
+        "prompt": "run; rm -rf / | cat"
+      },
+      "want_argv": ["/bin/agy", "run; rm -rf / | cat"]
+    },
+    {
+      "name": "flags_without_prompt",
+      "spec": {
+        "executable": "C:\\Program Files\\Agy\\agy.exe",
+        "subcommand": ["version"],
+        "flags": ["--json"],
+        "prompt": ""
+      },
+      "want_argv": ["C:\\Program Files\\Agy\\agy.exe", "version", "--json"]
+    },
+    {
+      "name": "reject_sh_c_wrapper",
+      "argv": ["/bin/sh", "-c", "agy chat"],
+      "want_error": "shell wrapper"
+    },
+    {
+      "name": "reject_cmd_c_wrapper",
+      "argv": ["cmd.exe", "/C", "agy chat"],
+      "want_error": "shell wrapper"
+    },
+    {
+      "name": "reject_powershell_command_wrapper",
+      "argv": ["powershell", "-Command", "agy chat"],
+      "want_error": "shell wrapper"
+    }
+  ]
+}

--- a/pkg/workers/agypty/testdata/workspace_fixtures.json
+++ b/pkg/workers/agypty/testdata/workspace_fixtures.json
@@ -1,0 +1,34 @@
+{
+  "fixtures": [
+    {
+      "name": "relative_workspace_under_root",
+      "factory_root": "FACTORY_ROOT",
+      "raw_path": "workspaces/feature-a",
+      "want_suffix": ["workspaces", "feature-a"]
+    },
+    {
+      "name": "slash_normalized_relative_path",
+      "factory_root": "FACTORY_ROOT",
+      "raw_path": "workspaces/feature-b/nested",
+      "want_suffix": ["workspaces", "feature-b", "nested"]
+    },
+    {
+      "name": "reject_parent_traversal",
+      "factory_root": "FACTORY_ROOT",
+      "raw_path": "../escape",
+      "want_error": "traverse outside"
+    },
+    {
+      "name": "reject_empty_path",
+      "factory_root": "FACTORY_ROOT",
+      "raw_path": "",
+      "want_error": "workspace path is required"
+    },
+    {
+      "name": "reject_dotdot_only",
+      "factory_root": "FACTORY_ROOT",
+      "raw_path": "..",
+      "want_error": "traverse outside"
+    }
+  ]
+}

--- a/pkg/workers/agypty/types.go
+++ b/pkg/workers/agypty/types.go
@@ -1,0 +1,69 @@
+package agypty
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrUnsupportedPlatform reports that the current OS build cannot allocate ConPTY
+// or POSIX PTY APIs. Callers must fail closed; pipe IO is not a fallback.
+var ErrUnsupportedPlatform = errors.New("agypty: platform PTY allocation is not supported")
+
+// SessionConfig carries bounded capture and timeout policy for one PTY session.
+type SessionConfig struct {
+	MaxCaptureBytes int
+	IdleTimeout     time.Duration
+	HardTimeout     time.Duration
+}
+
+// DefaultSessionConfig returns the documented default session limits.
+func DefaultSessionConfig() SessionConfig {
+	return SessionConfig{
+		MaxCaptureBytes: DefaultMaxCaptureBytes,
+		IdleTimeout:     DefaultIdleTimeout,
+		HardTimeout:     DefaultHardTimeout,
+	}
+}
+
+// ProcessLaunch is the typed subprocess description for one Agy headless run.
+// Argv is passed directly to exec.Command without shell indirection.
+type ProcessLaunch struct {
+	Executable string
+	Argv       []string
+	WorkDir    string
+	Env        []string
+}
+
+// SessionResult is the observable outcome of one PTY session after cleanup.
+type SessionResult struct {
+	ExitCode    int
+	RawBytes    []byte
+	CleanedText string
+	TimedOut    bool
+	CapacityHit bool
+}
+
+// PTYAllocator opens a platform PTY for one supervised child process.
+//
+// Production implementations:
+//   - WindowsConPTYAllocator (windows build tag) — ConPTY pseudo-console pair
+//   - POSIXPTYAllocator (linux,darwin build tags) — openpty master/slave pair
+//
+// Unit tests inject MockAllocator to avoid real ConPTY/PTY allocation.
+type PTYAllocator interface {
+	Allocate(ctx context.Context, launch ProcessLaunch, cfg SessionConfig) (PTYSession, error)
+}
+
+// PTYSession is the mockable seam for bounded capture, timeout signaling, and cleanup.
+// Story 17 wires real capture loops; tests use MockSession with predetermined bytes.
+type PTYSession interface {
+	Run(ctx context.Context) (SessionResult, error)
+	Close() error
+}
+
+// PlatformAllocatorFactory selects the platform PTY allocator at runtime.
+// Story 17 provides a real factory; tests return MockAllocator directly.
+type PlatformAllocatorFactory interface {
+	NewAllocator() (PTYAllocator, error)
+}

--- a/pkg/workers/agypty/workspace.go
+++ b/pkg/workers/agypty/workspace.go
@@ -1,0 +1,62 @@
+package agypty
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// ResolveWorkspaceDir normalizes and validates a workspace directory under
+// factoryRoot (T2 control in agy-pty-threat-review.md). The returned path is
+// suitable for cmd.Dir and argv path fields after Story 17 lands execution.
+func ResolveWorkspaceDir(factoryRoot, rawPath string) (string, error) {
+	factoryRoot = strings.TrimSpace(factoryRoot)
+	if factoryRoot == "" {
+		return "", fmt.Errorf("agypty: factory root is required")
+	}
+	rawPath = strings.TrimSpace(rawPath)
+	if rawPath == "" {
+		return "", fmt.Errorf("agypty: workspace path is required")
+	}
+
+	factoryRoot = filepath.Clean(factoryRoot)
+	normalized := filepath.Clean(filepath.FromSlash(rawPath))
+
+	var resolved string
+	if filepath.IsAbs(normalized) {
+		resolved = normalized
+	} else {
+		if err := rejectRelativeTraversal(normalized); err != nil {
+			return "", err
+		}
+		resolved = filepath.Clean(filepath.Join(factoryRoot, normalized))
+	}
+
+	if !pathContainedIn(factoryRoot, resolved) {
+		return "", fmt.Errorf("agypty: workspace path must remain under factory root")
+	}
+	return resolved, nil
+}
+
+func rejectRelativeTraversal(normalized string) error {
+	if normalized == ".." {
+		return fmt.Errorf("agypty: workspace path must not traverse outside factory root")
+	}
+	if strings.HasPrefix(normalized, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("agypty: workspace path must not traverse outside factory root")
+	}
+	return nil
+}
+
+func pathContainedIn(root, candidate string) bool {
+	root = filepath.Clean(root)
+	candidate = filepath.Clean(candidate)
+
+	rel, err := filepath.Rel(root, candidate)
+	if err != nil {
+		return false
+	}
+	return rel != ".." &&
+		!strings.HasPrefix(rel, ".."+string(filepath.Separator)) &&
+		!filepath.IsAbs(rel)
+}

--- a/pkg/workers/agypty/workspace_test.go
+++ b/pkg/workers/agypty/workspace_test.go
@@ -1,0 +1,72 @@
+package agypty_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/workers/agypty"
+)
+
+func TestWorkspaceFixtures(t *testing.T) {
+	t.Parallel()
+
+	factoryRoot := t.TempDir()
+	fixtures, err := agypty.LoadWorkspaceFixtures()
+	if err != nil {
+		t.Fatalf("LoadWorkspaceFixtures() error = %v", err)
+	}
+
+	for _, fixture := range fixtures {
+		fixture := fixture
+		t.Run(fixture.Name, func(t *testing.T) {
+			t.Parallel()
+
+			root := factoryRoot
+			if fixture.FactoryRoot != "FACTORY_ROOT" {
+				root = fixture.FactoryRoot
+			}
+
+			got, err := agypty.ResolveWorkspaceDir(root, fixture.RawPath)
+			if fixture.WantError != "" {
+				if err == nil {
+					t.Fatal("ResolveWorkspaceDir() error = nil, want error")
+				}
+				if !strings.Contains(err.Error(), fixture.WantError) {
+					t.Fatalf("ResolveWorkspaceDir() error = %v, want substring %q", err, fixture.WantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveWorkspaceDir() error = %v", err)
+			}
+
+			want := filepath.Join(append([]string{root}, fixture.WantSuffix...)...)
+			if got != want {
+				t.Fatalf("ResolveWorkspaceDir() = %q, want %q", got, want)
+			}
+			if !strings.HasPrefix(got, root+string(filepath.Separator)) && got != root {
+				t.Fatalf("resolved path %q is not under factory root %q", got, root)
+			}
+		})
+	}
+}
+
+func TestResolveWorkspaceDir_RejectsEmptyFactoryRoot(t *testing.T) {
+	t.Parallel()
+
+	if _, err := agypty.ResolveWorkspaceDir("", "workspaces/a"); err == nil {
+		t.Fatal("ResolveWorkspaceDir() error = nil, want error")
+	}
+}
+
+func TestResolveWorkspaceDir_RejectsAbsoluteOutsideRoot(t *testing.T) {
+	t.Parallel()
+
+	factoryRoot := t.TempDir()
+	outside := filepath.Join(filepath.Dir(factoryRoot), "outside-agypty-workspace")
+
+	if _, err := agypty.ResolveWorkspaceDir(factoryRoot, outside); err == nil {
+		t.Fatal("ResolveWorkspaceDir() error = nil, want error for path outside factory root")
+	}
+}


### PR DESCRIPTION
{
  "project": "Minimal Native Go Agy PTY and Security Boundary",
  "branchName": "stream-b06-agy-integration-decision",
  "description": "Specify the minimal native Go Agy PTY and security boundary through an approved ADR, Windows/POSIX threat model, and mockable Go process/PTY interface proposal. The change records license/notices, supported OS scope, argv/path/environment/escape/cleanup security controls, and hermetic mock fixtures, while explicitly excluding production Agy execution, Python-bridge use, shell-string command construction, and unrelated upstream behavior.",
  "context": {
    "customerAsk": "Specify the minimal native Go Agy PTY and security boundary. Produce an ADR that fixes the native Go boundary and explicitly excludes unrelated upstream behavior; make Windows/POSIX security and mock seams explicit; specify the minimum Go port for PTY allocation, terminal cleaning, bounded capture, timeout, and cleanup across supported OSes; and record upstream license/notices plus a threat model covering argv, paths, environment, escapes, and cleanup. Do not add production Agy execution, do not invoke or embed the Python bridge, and do not use shell-string execution. Validate argv/path normalization and mock interface fixtures, and review against architecture/backend standards.",
    "problem": "Agy headless support depends on PTY allocation, terminal cleaning, bounded capture, timeouts, and cleanup, but maintainers lack an approved native Go boundary decision, supported-platform scope, license/notice record, threat model, and mockable process interface. Without those, later execution work risks importing unrelated upstream behavior, embedding the Python bridge, constructing shell strings, or shipping an untestable cross-platform PTY path.",
    "solution": "Publish a reviewer-approved ADR and accompanying security/interface specification for the minimal native Go Agy PTY boundary. Document build-vs-adapt scope, supported OSes, license/notices, exclusions, and Story 17 gating; publish a Windows/POSIX threat model for argv, paths, environment, escapes, bounds, timeouts, and cleanup; and propose mockable Go PTY/process seams with hermetic argv and path-normalization fixtures that do not require an Agy binary or Python bridge."
  },
  "acceptanceCriteria": [
    "An architecture decision record documents the selected minimal native Go port, supported OSes, license/notices, maintained behavior scope, upgrade ownership, and security model, and explicitly excludes unrelated upstream behavior, Python-bridge invocation/embedding, shell-string execution, and production Agy execution in this lane.",
    "A threat review covers shell/argv injection, workspace path attachment, environment inheritance, terminal escape handling, output bounds, timeouts, and process-tree cleanup for both Windows and POSIX.",
    "Windows ConPTY and POSIX PTY responsibilities, security assumptions, and mock seams are explicit and distinguishable in the decision/interface materials.",
    "A Go PTY/process interface proposal defines mockable allocation, bounded capture, terminal cleaning, timeout, and cleanup seams that ordinary unit tests can exercise without an installed Agy binary or Python bridge.",
    "Hermetic fixtures validate argv construction and workspace-path normalization against the proposed interface contract.",
    "The ADR and threat/interface materials are reviewable against architecture and backend standards and gate later Agy execution work (Story 17+) on the documented build-vs-adapt and platform decisions.",
    "Quality checks pass (typecheck, lint, tests)"
  ],
  "userStories": [
    {
      "id": "stream-b06-agy-integration-decision-001",
      "title": "Record the minimal native Go Agy boundary decision",
      "description": "As a maintainer preparing Agy provider support, I want an approved architecture decision record for the minimal native Go PTY boundary so later execution work has a fixed scope, license posture, and platform contract.",
      "acceptanceCriteria": [
        "An ADR under docs/architecture/ (or the repository's established architecture-decision location) records the build-vs-adapt decision to own a minimal native Go port of the required Agy headless-bridge behaviors rather than vendoring the full upstream repository or invoking the Python bridge.",
        "The ADR names the maintained behavior scope as PTY allocation, bounded capture, terminal cleaning, idle/hard timeout, and process cleanup across the documented supported OSes, and states which Windows ConPTY and POSIX PTY responsibilities are in scope.",
        "The ADR records upstream license compatibility findings and required notices for any adapted behavior or referenced upstream material.",
        "The ADR explicitly excludes unrelated upstream behavior, production Agy execution in this lane, Python-bridge invocation or embedding, and shell-string command construction.",
        "The ADR states how later Agy execution (Story 17+) is gated on this decision and the documented supported-platform scope.",
        "A maintainer reading the ADR can determine the approved boundary without reading upstream Python sources or inventing platform scope.",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "stream-b06-agy-integration-decision-002",
      "title": "Publish Windows/POSIX threat model for the Agy PTY boundary",
      "description": "As a security reviewer, I want an explicit Windows/POSIX threat model for the proposed Agy PTY boundary so argv, path, environment, escape, bound, timeout, and cleanup risks are decided before execution code lands.",
      "acceptanceCriteria": [
        "A threat-review document (standalone or ADR section) covers shell/argv injection, workspace path attachment and normalization, environment inheritance, terminal escape sequences, output bounds, timeouts, and process-tree cleanup.",
        "Windows ConPTY and POSIX PTY security assumptions are stated separately where they differ, including cleanup and unsupported-platform behavior.",
        "The threat model requires typed argv construction (no shell-string concatenation) and forbids publishing raw terminal control/repaint noise as public response content once execution exists.",
        "The threat model states that this lane does not invoke or embed the Python bridge and does not add production Agy execution.",
        "Review against architecture and backend standards confirms the threat model is specific enough to constrain Story 17 implementation choices.",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "stream-b06-agy-integration-decision-003",
      "title": "Propose mockable Go PTY/process seams with argv and path fixtures",
      "description": "As an implementer of later Agy execution, I want a Go PTY/process interface proposal with mock seams and hermetic fixtures so I can validate argv and path normalization without an Agy binary or Python bridge.",
      "acceptanceCriteria": [
        "A Go interface proposal defines mockable seams for PTY/process allocation, bounded capture, terminal cleaning inputs/outputs, timeout signaling, and cleanup without requiring production Agy execution.",
        "Windows and POSIX platform seams are named explicitly in the proposal, including how unit tests substitute mocks for real ConPTY/PTY allocation.",
        "Hermetic fixtures or focused tests validate that command arguments are represented as argv slices (not a shell string) and that workspace paths are normalized according to the documented rules.",
        "The fixtures pass without an installed Agy binary and without invoking or embedding the Python bridge.",
        "The proposal states that production Agy headless execution remains out of scope until Story 17 consumes this approved boundary.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}
