### PR TITLE
interfaces-b06-openapi-stage-resync

### DIFF
--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -37,7 +37,8 @@ Use this map when changing the public REST contract.
   prove accepted/rejected manifest schema fixtures in
   `contracts/manifest_schema_test.go`. `resolveSourceCommit` rejects shallow git
   history that would misattribute `sourceCommit` to `HEAD` when identity inputs
-  were last changed in an unreachable ancestor; CI jobs that run
+  were last changed in an unreachable ancestor, but accepts merge commits that
+  appear in `rev-list` without modifying source identity paths; CI jobs that run
   `make contracts-smoke` or contractstaging tests must use `fetch-depth: 0`.
 - Regeneration cleanliness for owned staging outputs lives in
   `internal/contractstaging/generate.go` (`Generate`) with repository evidence in

--- a/internal/contractstaging/manifest.go
+++ b/internal/contractstaging/manifest.go
@@ -134,6 +134,15 @@ func resolveSourceCommit(repositoryRoot string) (string, error) {
 	}
 	parentSource := strings.TrimSpace(string(parentOutput))
 	if parentSource != "" && parentSource != sourceCommit {
+		merge, mergeErr := isMergeCommit(repositoryRoot, head)
+		if mergeErr != nil {
+			return "", fmt.Errorf("resolve package source commit: %w", mergeErr)
+		}
+		if merge {
+			// Merge commits can appear in rev-list without modifying source identity
+			// paths; an empty diff-tree on HEAD is expected and not shallow history.
+			return sourceCommit, nil
+		}
 		return "", fmt.Errorf(
 			"resolve package source commit: git history is too shallow to determine the last change to package source inputs; fetch full history (for example fetch-depth: 0 in CI)",
 		)
@@ -170,4 +179,15 @@ func isShallowRepository(repositoryRoot string) (bool, error) {
 		return false, err
 	}
 	return output == "true", nil
+}
+
+func isMergeCommit(repositoryRoot, commit string) (bool, error) {
+	_, err := gitOutput(repositoryRoot, "rev-parse", "--verify", commit+"^2")
+	if err == nil {
+		return true, nil
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+		return false, nil
+	}
+	return false, err
 }

--- a/internal/contractstaging/manifest_test.go
+++ b/internal/contractstaging/manifest_test.go
@@ -151,6 +151,110 @@ func TestShallowGitHistoryRejectsFalseSourceCommit(t *testing.T) {
 	}
 }
 
+func TestMergeCommitTipResolvesSourceCommitWithoutFalseShallowFailure(t *testing.T) {
+	origin := t.TempDir()
+	writeCheckFixture(t, origin, "contracts/common/documentation.schema.json", `{"$id":"https://schemas.portpowered.com/you/contracts/common/documentation.schema.json","$defs":{"itemId":{"type":"string"}}}`)
+	writeCheckFixture(t, origin, "contracts/common/deprecations.schema.json", `{"$id":"https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json","properties":{"itemId":{"$ref":"https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"}}}`)
+	writeCheckFixture(t, origin, "contracts/manifest.schema.json", `{"$id":"https://schemas.portpowered.com/you/contracts/manifest.schema.json","properties":{"packageId":{"$ref":"https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"}}}`)
+	for _, artifact := range contractstaging.RawArtifacts() {
+		writeCheckFixture(t, origin, artifact.Source, canonicalFixture(artifact.Source))
+	}
+	initCheckGitRepo(t, origin)
+
+	runGit(t, origin, "checkout", "-b", "side")
+	writeCheckFixture(t, origin, "side-only.txt", "side")
+	runGit(t, origin, "add", "-A")
+	runGit(t, origin, "commit", "-m", "side branch")
+
+	runGit(t, origin, "checkout", "master")
+	writeCheckFixture(t, origin, "main-only.txt", "main")
+	runGit(t, origin, "add", "-A")
+	runGit(t, origin, "commit", "-m", "main branch")
+
+	runGit(t, origin, "merge", "--no-ff", "side", "-m", "merge package source identity paths unchanged")
+
+	artifacts, err := contractstaging.Artifacts(origin)
+	if err != nil {
+		t.Fatalf("Artifacts() on merge tip error = %v", err)
+	}
+	manifest := decodeManifestPayload(t, artifacts[manifestTarget])
+	sourceCommit, ok := manifest["sourceCommit"].(string)
+	if !ok || sourceCommit == "" {
+		t.Fatalf("manifest sourceCommit = %#v", manifest["sourceCommit"])
+	}
+	sourceArgs := append([]string{"-C", origin, "rev-list", "-1", "HEAD", "--"}, contractstaging.SourceIdentityPaths()...)
+	wantOutput, err := exec.Command("git", sourceArgs...).Output()
+	if err != nil {
+		t.Fatalf("resolve package source commit: %v", err)
+	}
+	wantSource := strings.TrimSpace(string(wantOutput))
+	if sourceCommit != wantSource {
+		t.Fatalf("manifest sourceCommit = %q, want package source commit %q", sourceCommit, wantSource)
+	}
+}
+
+func TestMergeCommitInRevListWithoutPathChangesResolvesSourceCommit(t *testing.T) {
+	origin := t.TempDir()
+	writeCheckFixture(t, origin, "contracts/common/documentation.schema.json", `{"$id":"https://schemas.portpowered.com/you/contracts/common/documentation.schema.json","$defs":{"itemId":{"type":"string"}}}`)
+	writeCheckFixture(t, origin, "contracts/common/deprecations.schema.json", `{"$id":"https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json","properties":{"itemId":{"$ref":"https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"}}}`)
+	writeCheckFixture(t, origin, "contracts/manifest.schema.json", `{"$id":"https://schemas.portpowered.com/you/contracts/manifest.schema.json","properties":{"packageId":{"$ref":"https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"}}}`)
+	for _, artifact := range contractstaging.RawArtifacts() {
+		writeCheckFixture(t, origin, artifact.Source, canonicalFixture(artifact.Source))
+	}
+	initCheckGitRepo(t, origin)
+
+	runGit(t, origin, "checkout", "-b", "feature")
+	writeCheckFixture(t, origin, "internal/contractstaging/openapi.go", "// feature branch openapi marker\n")
+	runGit(t, origin, "add", "-A")
+	runGit(t, origin, "commit", "-m", "feature source identity change")
+
+	runGit(t, origin, "checkout", "master")
+	writeCheckFixture(t, origin, "internal/contractstaging/policy.go", "// main branch policy marker\n")
+	runGit(t, origin, "add", "-A")
+	runGit(t, origin, "commit", "-m", "main source identity change")
+
+	runGit(t, origin, "merge", "--no-ff", "feature", "-m", "merge both source identity branches")
+
+	head := strings.TrimSpace(string(runGitOutput(t, origin, "rev-parse", "HEAD")))
+	revListArgs := append([]string{"rev-list", "-1", "HEAD", "--"}, contractstaging.SourceIdentityPaths()...)
+	revListHead := strings.TrimSpace(string(runGitOutput(t, origin, revListArgs...)))
+	if revListHead != head {
+		t.Fatalf("fixture rev-list = %q, want merge tip HEAD %q", revListHead, head)
+	}
+	diffArgs := append([]string{"diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD", "--"}, contractstaging.SourceIdentityPaths()...)
+	if diff := strings.TrimSpace(string(runGitOutput(t, origin, diffArgs...))); diff != "" {
+		t.Fatalf("fixture merge diff-tree = %q, want empty source identity diff", diff)
+	}
+
+	artifacts, err := contractstaging.Artifacts(origin)
+	if err != nil {
+		t.Fatalf("Artifacts() on merge-in-rev-list tip error = %v", err)
+	}
+	manifest := decodeManifestPayload(t, artifacts[manifestTarget])
+	sourceCommit, ok := manifest["sourceCommit"].(string)
+	if !ok || sourceCommit != head {
+		t.Fatalf("manifest sourceCommit = %#v, want merge tip HEAD %q", manifest["sourceCommit"], head)
+	}
+}
+
+func runGit(t *testing.T, root string, args ...string) {
+	t.Helper()
+	command := append([]string{"-C", root}, args...)
+	if output, err := exec.Command("git", command...).CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %s", args, output)
+	}
+}
+
+func runGitOutput(t *testing.T, root string, args ...string) []byte {
+	t.Helper()
+	command := append([]string{"-C", root}, args...)
+	output, err := exec.Command("git", command...).Output()
+	if err != nil {
+		t.Fatalf("git %v: %v", args, err)
+	}
+	return output
+}
+
 func TestMalformedManifestArtifactHashFailsJoinedManifestContract(t *testing.T) {
 	t.Parallel()
 

--- a/packages/api/generated/manifest.json
+++ b/packages/api/generated/manifest.json
@@ -312,5 +312,5 @@
   "formatVersion": "1.0.0",
   "packageId": "you-agent-factory.api",
   "packageVersion": "0.0.0",
-  "sourceCommit": "a3f26a1c3942dcf176e4adf4a6c7b6730d32b8ef"
+  "sourceCommit": "8b58aa90a00091af5db9c55b75efba938dec3153"
 }

--- a/packages/api/generated/manifest.json
+++ b/packages/api/generated/manifest.json
@@ -181,7 +181,7 @@
       "path": "generated/mcp/tools.json"
     },
     "generated.openapi.openapi": {
-      "artifactHash": "4b75e762b8f9bb656539db6343590acd690502963e70a20f71c4598aa28845eb",
+      "artifactHash": "bc50df588550c88e45fa74a3f3438b3994769b0823ce112bd9306c7d5f4e0e0b",
       "documentation": {
         "documentation": {
           "description": {
@@ -198,7 +198,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.openapi.openapi",
-        "sourceHash": "4b75e762b8f9bb656539db6343590acd690502963e70a20f71c4598aa28845eb",
+        "sourceHash": "bc50df588550c88e45fa74a3f3438b3994769b0823ce112bd9306c7d5f4e0e0b",
         "visibility": "public"
       },
       "family": "openapi",
@@ -211,7 +211,7 @@
       "path": "generated/openapi/openapi.yaml"
     },
     "generated.schemas.factory": {
-      "artifactHash": "64647d6931c0064190ed5b384d64a7ae9c5b22d532d89f532e42c1e9cf85ecbf",
+      "artifactHash": "4368e1e2b958de4a6e890463a4035dbb4218bafa4c4a607086d23db8d2c0276d",
       "documentation": {
         "documentation": {
           "description": {
@@ -228,7 +228,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.schemas.factory",
-        "sourceHash": "64647d6931c0064190ed5b384d64a7ae9c5b22d532d89f532e42c1e9cf85ecbf",
+        "sourceHash": "4368e1e2b958de4a6e890463a4035dbb4218bafa4c4a607086d23db8d2c0276d",
         "visibility": "public"
       },
       "family": "config",
@@ -312,5 +312,5 @@
   "formatVersion": "1.0.0",
   "packageId": "you-agent-factory.api",
   "packageVersion": "0.0.0",
-  "sourceCommit": "60782735e68d82dc3d28f0de04dcf2065c9207d0"
+  "sourceCommit": "a3f26a1c3942dcf176e4adf4a6c7b6730d32b8ef"
 }

--- a/packages/api/generated/openapi/openapi.yaml
+++ b/packages/api/generated/openapi/openapi.yaml
@@ -8941,6 +8941,7 @@ components:
         - WorkerModelProviderGemini
         - WorkerModelProviderKiro
         - WorkerModelProviderOpenCode
+        - WorkerModelProviderPi
       enum:
         - CLAUDE
         - CODEX
@@ -8948,6 +8949,7 @@ components:
         - GEMINI
         - KIRO
         - OPENCODE
+        - PI
       x-enum-descriptions:
         - Claude model execution routed through the `claude` provider command.
         - Codex model execution routed through the `codex` provider command.
@@ -8955,6 +8957,7 @@ components:
         - Gemini model execution routed through the `gemini` provider command.
         - Kiro model execution routed through the `kiro-cli` provider command.
         - OpenCode model execution routed through the `opencode` provider command.
+        - Pi model execution routed through the `pi` provider command.
     WorkerModelLocality:
       type: string
       description: Provider locality for a model worker capability declaration.
@@ -9045,18 +9048,21 @@ components:
         - RunnerIDKiro
         - RunnerIDCursorCLI
         - RunnerIDOpenCode
+        - RunnerIDPi
       enum:
         - codex
         - gemini
         - kiro
         - cursor-cli
         - opencode
+        - pi
       x-enum-descriptions:
         - Codex runner selected through the shared runner contract.
         - Gemini runner selected through the shared runner contract.
         - Kiro runner selected through the shared runner contract.
         - Cursor CLI runner selected through the shared runner contract.
         - OpenCode runner selected through the shared runner contract.
+        - Pi runner selected through the shared runner contract.
     RunnerSelectionSource:
       type: string
       description: Configuration layer that supplied the resolved built-in runner selection for a dispatch.

--- a/packages/api/generated/schemas/factory.schema.json
+++ b/packages/api/generated/schemas/factory.schema.json
@@ -1292,7 +1292,8 @@
         "gemini",
         "kiro",
         "cursor-cli",
-        "opencode"
+        "opencode",
+        "pi"
       ],
       "type": "string",
       "x-enum-descriptions": [
@@ -1300,14 +1301,16 @@
         "Gemini runner selected through the shared runner contract.",
         "Kiro runner selected through the shared runner contract.",
         "Cursor CLI runner selected through the shared runner contract.",
-        "OpenCode runner selected through the shared runner contract."
+        "OpenCode runner selected through the shared runner contract.",
+        "Pi runner selected through the shared runner contract."
       ],
       "x-enum-varnames": [
         "RunnerIDCodex",
         "RunnerIDGemini",
         "RunnerIDKiro",
         "RunnerIDCursorCLI",
-        "RunnerIDOpenCode"
+        "RunnerIDOpenCode",
+        "RunnerIDPi"
       ]
     },
     "StringMap": {
@@ -1828,7 +1831,8 @@
         "CURSOR",
         "GEMINI",
         "KIRO",
-        "OPENCODE"
+        "OPENCODE",
+        "PI"
       ],
       "type": "string",
       "x-enum-descriptions": [
@@ -1837,7 +1841,8 @@
         "Cursor model execution routed through the `agent` provider command.",
         "Gemini model execution routed through the `gemini` provider command.",
         "Kiro model execution routed through the `kiro-cli` provider command.",
-        "OpenCode model execution routed through the `opencode` provider command."
+        "OpenCode model execution routed through the `opencode` provider command.",
+        "Pi model execution routed through the `pi` provider command."
       ],
       "x-enum-varnames": [
         "WorkerModelProviderClaude",
@@ -1845,7 +1850,8 @@
         "WorkerModelProviderCursor",
         "WorkerModelProviderGemini",
         "WorkerModelProviderKiro",
-        "WorkerModelProviderOpenCode"
+        "WorkerModelProviderOpenCode",
+        "WorkerModelProviderPi"
       ]
     },
     "WorkerProvider": {


### PR DESCRIPTION
{
  "project": "Resync staged OpenAPI and derived package projections after #1104 main merge drift",
  "branchName": "interfaces-b06-openapi-stage-resync",
  "description": "On a tip based on current origin/main, restore B06 OpenAPI staging truthfulness after #1104 merge drift: regenerate packages/api/generated/openapi/openapi.yaml under ReviewedOpenAPIBytePolicy to match canonical api/openapi.yaml, regenerate OpenAPI-derived factory.schema.json, refresh generated/manifest.json with truthful hashes and sourceCommit, and fix resolveSourceCommit/Check so Artifacts() succeeds on ordinary and merge tips—without introducing or soft-completing npm package-scaffold surfaces.",
  "context": {
    "customerAsk": "On a branch based on current origin/main, restore B06 OpenAPI staging truthfulness without owning npm package surfaces. Regenerate packages/api/generated/openapi/openapi.yaml under the reviewed byte-identical policy so it matches canonical api/openapi.yaml; regenerate OpenAPI-derived packages/api/generated/schemas/factory.schema.json and refresh packages/api/generated/manifest.json so every staged artifact hash and sourceCommit are truthful for the resulting tip. Harden or otherwise fix resolveSourceCommit/Check so Artifacts() succeeds on ordinary branch tips and does not false-fail after merges the way main tip a3f26a1c3 currently does. Leave raw-matching CLI/MCP/config copies untouched unless regeneration requires them. Do not author packages/api/package.json, README/LICENSE, pack allowlist scripts, or api-package-pack-smoke. Do not soft-complete or re-stack package-scaffold in this item.",
    "problem": "After PR #1104 (interfaces-b06-openapi-stage) merged to origin/main as a3f26a1c3, staged OpenAPI drifted from canonical api/openapi.yaml (427451 vs 427666 bytes) because canonical advanced via Pi RunnerID enum fix 39af7ac38 after the staging branch last refreshed. OpenAPI-derived factory.schema.json is therefore stale; committed manifest sourceCommit is outdated (60782735e…); and Artifacts()/Check() on the merge tip false-fails resolveSourceCommit with a mislabeled shallow-history error even on a full clone. Raw CLI/MCP/config staged copies still match. Package-scaffold remains unmerged and must not be resumed in this lane.",
    "solution": "On a tip based on current origin/main, regenerate staged OpenAPI under ReviewedOpenAPIBytePolicy, regenerate the OpenAPI-derived factory schema, refresh the package manifest so hashes and sourceCommit are truthful for the resulting tip, and fix resolveSourceCommit/Check so ordinary and merge tips validate without the false shallow failure—without introducing any npm package-scaffold surfaces."
  },
  "acceptanceCriteria": [
    "On the resulting tip, packages/api/generated/openapi/openapi.yaml is byte-identical to api/openapi.yaml under ReviewedOpenAPIBytePolicy, and focused OpenAPI parity tests pass",
    "OpenAPI-derived packages/api/generated/schemas/factory.schema.json is regenerated and covered by existing staging projection checks; raw CLI/MCP/config staged copies that already matched remain matching",
    "packages/api/generated/manifest.json validates, hashes every AllowedArtifacts() path, and records a truthful sourceCommit for the package source identity on the resulting tip",
    "Artifacts()/Check() succeeds on ordinary branch tips and does not fail with the merge-tip resolveSourceCommit false shallow error observed on a3f26a1c3",
    "make contracts-smoke, make generate-api, make api-smoke, make pkg-boundary, and make pkg-file-count pass on the resulting tip",
    "No npm package.json/exports/tarball/pack-smoke surfaces are introduced; package-scaffold remains unmerged and un-soft-completed",
    "Quality checks pass (typecheck, lint, tests)"
  ],
  "userStories": [
    {
      "id": "interfaces-b06-openapi-stage-resync-001",
      "title": "Restore staged OpenAPI byte parity with canonical",
      "description": "As a maintainer of the Interfaces API package staging lane, I want the staged OpenAPI document to be byte-identical to canonical api/openapi.yaml under the reviewed byte policy so post-merge tip drift cannot silently ship a stale contract copy.",
      "acceptanceCriteria": [
        "On the resulting tip, packages/api/generated/openapi/openapi.yaml is byte-identical to api/openapi.yaml under ReviewedOpenAPIBytePolicy",
        "Focused internal/contractstaging OpenAPI parity tests pass for the restored copy",
        "No invented later-phase generated/components/* topology or npm export entries are introduced",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b06-openapi-stage-resync-002",
      "title": "Regenerate OpenAPI-derived factory schema; keep raw copies matching",
      "description": "As a maintainer, I want OpenAPI-derived factory.schema.json regenerated from the restored OpenAPI so derived package projections stay consistent, while raw CLI/MCP/config staged copies that already matched continue to match.",
      "acceptanceCriteria": [
        "packages/api/generated/schemas/factory.schema.json is regenerated from the restored staged/canonical OpenAPI and passes existing staging projection checks",
        "Raw staged copies for you-config, mock-workers, cli-commands, and mcp-tools that already matched remain matching unless regeneration explicitly requires a change (prefer leave untouched)",
        "Focused regeneration cleanliness / staging projection checks covering the schema projection pass",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b06-openapi-stage-resync-003",
      "title": "Refresh package manifest hashes and sourceCommit",
      "description": "As a maintainer, I want packages/api/generated/manifest.json to hash every allowed staged artifact and record a truthful sourceCommit for the resulting tip so package source identity is auditable after the resync.",
      "acceptanceCriteria": [
        "packages/api/generated/manifest.json validates successfully",
        "The manifest hashes every path returned by AllowedArtifacts()",
        "The manifest records a truthful sourceCommit for the package source identity on the resulting tip (not the stale 60782735e… value from the drifted merge tip)",
        "Focused manifest digest / regeneration cleanliness suite coverage for the refreshed manifest passes",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b06-openapi-stage-resync-004",
      "title": "Fix resolveSourceCommit so Artifacts/Check succeed on merge tips",
      "description": "As a maintainer running package artifact validation on ordinary branch tips (including merge commits), I want resolveSourceCommit/Check to succeed without mislabeling a full clone as shallow history the way tip a3f26a1c3 currently fails.",
      "acceptanceCriteria": [
        "Calling Artifacts()/Check() on an ordinary branch tip that includes a merge commit over SourceIdentityPaths does not fail with the false shallow-history resolveSourceCommit error observed on a3f26a1c3",
        "When history is genuinely insufficient, the failure remains truthful (no silent success that hides missing commit identity)",
        "Focused tests cover the merge-tip / empty-diff-tree resolve path that previously false-failed, and show success on a full clone with truthful source identity",
        "Runtime, API, CLI, service, worker, provider, and UI dependency paths are unchanged except test-only fixes required for mergeability",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b06-openapi-stage-resync-005",
      "title": "Pass smoke gates without introducing npm package surfaces",
      "description": "As a reviewer of the B06 resync tip, I want the required Make smoke/boundary gates to pass and confirmed absence of npm package-scaffold surfaces so this lane restores staging truthfulness without owning or soft-completing scaffold.",
      "acceptanceCriteria": [
        "make contracts-smoke, make generate-api, make api-smoke, make pkg-boundary, and make pkg-file-count pass on the resulting tip",
        "No packages/api/package.json, README/LICENSE pack surfaces, pack allowlist scripts, api-package-pack-smoke, npm exports, or tarball pack-smoke surfaces are introduced",
        "This item does not resume, terminal-complete, re-submit, or soft-complete interfaces-b06-package-scaffold, and does not release Interfaces B07",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    }
  ]
}
