### PR TITLE
interfaces-b07-openapi-diff

### DIFF
--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -72,6 +72,22 @@ Use this map when changing the public REST contract.
   `make api-smoke`; this inventory lane must not modify authored OpenAPI,
   generated clients, or `pkg/transports/http` handlers.
 
+## OpenAPI contract semver comparator
+
+- `internal/contractopenapidiff` owns the build-time OpenAPI comparator that
+  classifies supported semantic deltas between two loaded documents as
+  `major`, `minor`, or `patch` with stable change codes and operation/schema
+  paths. Use `CompareYAML` or `CompareDocuments`; keep runtime packages from
+  importing it.
+- Documentation-only differences (description, summary, externalDocs, schema
+  title) classify as `patch` when structural surfaces match. Non-documentation
+  differences currently fail closed until later comparator stories extend
+  classification.
+- Focused fixtures live under
+  `internal/contractopenapidiff/testdata/`; prove end-to-end outcomes in
+  `internal/contractopenapidiff/compare_test.go` and include the package in
+  `make contracts-smoke`.
+
 ## Compatibility Alias Inventory
 
 This inventory is the maintainer source of truth for retained public aliases.

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -84,7 +84,9 @@ Use this map when changing the public REST contract.
   additions (new operations, optional parameters, optional schema properties,
   widened enums) classify as `minor` with `openapi.add.*` change codes.
   Removals and narrowing classify as `major` with `openapi.remove.*` and
-  `openapi.narrow.*` change codes; major wins over minor and patch.
+  `openapi.narrow.*` change codes; major wins over minor and patch. Unsupported
+  or ambiguous structural deltas fail closed via `UnsupportedDiffError` with an
+  operation or schema path instead of returning a guessed classification.
 - Focused fixtures live under
   `internal/contractopenapidiff/testdata/`; prove end-to-end outcomes in
   `internal/contractopenapidiff/compare_test.go` and include the package in

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -83,8 +83,8 @@ Use this map when changing the public REST contract.
   title) classify as `patch` when structural surfaces match. Compatible
   additions (new operations, optional parameters, optional schema properties,
   widened enums) classify as `minor` with `openapi.add.*` change codes.
-  Removals and narrowing still fail closed until later comparator stories
-  extend classification.
+  Removals and narrowing classify as `major` with `openapi.remove.*` and
+  `openapi.narrow.*` change codes; major wins over minor and patch.
 - Focused fixtures live under
   `internal/contractopenapidiff/testdata/`; prove end-to-end outcomes in
   `internal/contractopenapidiff/compare_test.go` and include the package in

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -87,7 +87,9 @@ Use this map when changing the public REST contract.
   removing a name from `schema.required`) classify as `minor` with
   `openapi.relax.*` change codes. Removals and narrowing classify as `major`
   with `openapi.remove.*` and `openapi.narrow.*` change codes; major wins over
-  minor and patch. Unsupported
+  minor and patch. Inline request/response content schemas use the same
+  `collectSchemaRefChanges` path as component schemas (for example
+  `{operation}.responses.{status}.content.{mediaType}.schema`). Unsupported
   or ambiguous structural deltas fail closed via `UnsupportedDiffError` with an
   operation or schema path instead of returning a guessed classification.
 - Focused fixtures live under

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -80,9 +80,11 @@ Use this map when changing the public REST contract.
   paths. Use `CompareYAML` or `CompareDocuments`; keep runtime packages from
   importing it.
 - Documentation-only differences (description, summary, externalDocs, schema
-  title) classify as `patch` when structural surfaces match. Non-documentation
-  differences currently fail closed until later comparator stories extend
-  classification.
+  title) classify as `patch` when structural surfaces match. Compatible
+  additions (new operations, optional parameters, optional schema properties,
+  widened enums) classify as `minor` with `openapi.add.*` change codes.
+  Removals and narrowing still fail closed until later comparator stories
+  extend classification.
 - Focused fixtures live under
   `internal/contractopenapidiff/testdata/`; prove end-to-end outcomes in
   `internal/contractopenapidiff/compare_test.go` and include the package in

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -102,7 +102,10 @@ Use this map when changing the public REST contract.
   `variables` (`default`/`enum`), media-type `encoding`/`example`, response
   `links`, and operation `callbacks` must also fail closed or classify
   explicitly; path-item parameter removal reuses `collectParameterChanges` as
-  major with `openapi.remove.parameter`.
+  major with `openapi.remove.parameter`. Vendor extensions (`x-*` /
+  kin-openapi `Extensions` maps on info, operation, parameter, requestBody,
+  response, mediaType, schema, server, tag, and components) must fail closed via
+  shared `checkUnsupportedExtensions` instead of silently classifying as `patch`.
 - Focused fixtures live under
   `internal/contractopenapidiff/testdata/`; prove end-to-end outcomes in
   `internal/contractopenapidiff/compare_test.go` and the consolidated matrix in

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -89,7 +89,8 @@ Use this map when changing the public REST contract.
   operation or schema path instead of returning a guessed classification.
 - Focused fixtures live under
   `internal/contractopenapidiff/testdata/`; prove end-to-end outcomes in
-  `internal/contractopenapidiff/compare_test.go` and include the package in
+  `internal/contractopenapidiff/compare_test.go` and the consolidated matrix in
+  `internal/contractopenapidiff/fixture_matrix_test.go`; include the package in
   `make contracts-smoke`.
 
 ## Compatibility Alias Inventory

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -92,6 +92,9 @@ Use this map when changing the public REST contract.
   `{operation}.responses.{status}.content.{mediaType}.schema`). Unsupported
   or ambiguous structural deltas fail closed via `UnsupportedDiffError` with an
   operation or schema path instead of returning a guessed classification.
+  Residual schema keywords outside the supported comparison surface (for example
+  `nullable`, `additionalProperties`, `oneOf`, constraints, and `default`) also
+  fail closed instead of silently classifying as `patch`.
 - Focused fixtures live under
   `internal/contractopenapidiff/testdata/`; prove end-to-end outcomes in
   `internal/contractopenapidiff/compare_test.go` and the consolidated matrix in

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -97,7 +97,11 @@ Use this map when changing the public REST contract.
   fail closed instead of silently classifying as `patch`. Unhandled parameter
   serialization fields (`style`, `explode`, `allowReserved`), response `headers`,
   and non-schema `components` maps (`parameters`, `securitySchemes`, etc.) also
-  fail closed with path-aware `UnsupportedDiffError` outcomes.
+  fail closed with path-aware `UnsupportedDiffError` outcomes. Operation
+  `security`, path-item `parameters`/`servers`, media-type `encoding`/`example`,
+  response `links`, and operation `callbacks` must also fail closed or classify
+  explicitly; path-item parameter removal reuses `collectParameterChanges` as
+  major with `openapi.remove.parameter`.
 - Focused fixtures live under
   `internal/contractopenapidiff/testdata/`; prove end-to-end outcomes in
   `internal/contractopenapidiff/compare_test.go` and the consolidated matrix in

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -94,7 +94,10 @@ Use this map when changing the public REST contract.
   operation or schema path instead of returning a guessed classification.
   Residual schema keywords outside the supported comparison surface (for example
   `nullable`, `additionalProperties`, `oneOf`, constraints, and `default`) also
-  fail closed instead of silently classifying as `patch`.
+  fail closed instead of silently classifying as `patch`. Unhandled parameter
+  serialization fields (`style`, `explode`, `allowReserved`), response `headers`,
+  and non-schema `components` maps (`parameters`, `securitySchemes`, etc.) also
+  fail closed with path-aware `UnsupportedDiffError` outcomes.
 - Focused fixtures live under
   `internal/contractopenapidiff/testdata/`; prove end-to-end outcomes in
   `internal/contractopenapidiff/compare_test.go` and the consolidated matrix in

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -83,8 +83,11 @@ Use this map when changing the public REST contract.
   title) classify as `patch` when structural surfaces match. Compatible
   additions (new operations, optional parameters, optional schema properties,
   widened enums) classify as `minor` with `openapi.add.*` change codes.
-  Removals and narrowing classify as `major` with `openapi.remove.*` and
-  `openapi.narrow.*` change codes; major wins over minor and patch. Unsupported
+  Compatible requiredness relaxations (parameter `required: true` to `false`,
+  removing a name from `schema.required`) classify as `minor` with
+  `openapi.relax.*` change codes. Removals and narrowing classify as `major`
+  with `openapi.remove.*` and `openapi.narrow.*` change codes; major wins over
+  minor and patch. Unsupported
   or ambiguous structural deltas fail closed via `UnsupportedDiffError` with an
   operation or schema path instead of returning a guessed classification.
 - Focused fixtures live under

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -98,8 +98,9 @@ Use this map when changing the public REST contract.
   serialization fields (`style`, `explode`, `allowReserved`), response `headers`,
   and non-schema `components` maps (`parameters`, `securitySchemes`, etc.) also
   fail closed with path-aware `UnsupportedDiffError` outcomes. Operation
-  `security`, path-item `parameters`/`servers`, media-type `encoding`/`example`,
-  response `links`, and operation `callbacks` must also fail closed or classify
+  `security`, path-item `parameters`/`servers`, operation `servers`, server
+  `variables` (`default`/`enum`), media-type `encoding`/`example`, response
+  `links`, and operation `callbacks` must also fail closed or classify
   explicitly; path-item parameter removal reuses `collectParameterChanges` as
   major with `openapi.remove.parameter`.
 - Focused fixtures live under

--- a/internal/contractopenapidiff/compare.go
+++ b/internal/contractopenapidiff/compare.go
@@ -34,10 +34,7 @@ func CompareDocuments(before, after *openapi3.T) (Result, error) {
 	changes := append(structuralChanges, collectDocumentationChanges(before, after)...)
 	sortChanges(changes)
 
-	classification := ClassificationPatch
-	if len(structuralChanges) > 0 {
-		classification = ClassificationMinor
-	}
+	classification := classifyStructuralChanges(structuralChanges)
 
 	return Result{
 		Classification: classification,
@@ -73,6 +70,26 @@ func appendDocChange(changes []Change, code, path string) []Change {
 
 func appendMinorChange(changes []Change, code, path string) []Change {
 	return append(changes, Change{Code: code, Path: path})
+}
+
+func appendMajorChange(changes []Change, code, path string) []Change {
+	return append(changes, Change{Code: code, Path: path})
+}
+
+func classifyStructuralChanges(structuralChanges []Change) Classification {
+	for _, change := range structuralChanges {
+		if isMajorChangeCode(change.Code) {
+			return ClassificationMajor
+		}
+	}
+	if len(structuralChanges) > 0 {
+		return ClassificationMinor
+	}
+	return ClassificationPatch
+}
+
+func isMajorChangeCode(code string) bool {
+	return strings.HasPrefix(code, "openapi.remove.") || strings.HasPrefix(code, "openapi.narrow.")
 }
 
 func stringPtrEqual(before, after *string) bool {

--- a/internal/contractopenapidiff/compare.go
+++ b/internal/contractopenapidiff/compare.go
@@ -26,15 +26,21 @@ func CompareDocuments(before, after *openapi3.T) (Result, error) {
 	if before == nil || after == nil {
 		return Result{}, fmt.Errorf("openapi document is nil")
 	}
-	if err := compareStructural(before, after); err != nil {
+	structuralChanges, err := collectStructuralChanges(before, after)
+	if err != nil {
 		return Result{}, err
 	}
 
-	changes := collectDocumentationChanges(before, after)
+	changes := append(structuralChanges, collectDocumentationChanges(before, after)...)
 	sortChanges(changes)
 
+	classification := ClassificationPatch
+	if len(structuralChanges) > 0 {
+		classification = ClassificationMinor
+	}
+
 	return Result{
-		Classification: ClassificationPatch,
+		Classification: classification,
 		Changes:        changes,
 	}, nil
 }
@@ -63,6 +69,20 @@ func operationPath(method, path string) string {
 
 func appendDocChange(changes []Change, code, path string) []Change {
 	return append(changes, Change{Code: code, Path: path})
+}
+
+func appendMinorChange(changes []Change, code, path string) []Change {
+	return append(changes, Change{Code: code, Path: path})
+}
+
+func stringPtrEqual(before, after *string) bool {
+	if before == nil && after == nil {
+		return true
+	}
+	if before == nil || after == nil {
+		return false
+	}
+	return *before == *after
 }
 
 func externalDocsEqual(before, after *openapi3.ExternalDocs) bool {

--- a/internal/contractopenapidiff/compare.go
+++ b/internal/contractopenapidiff/compare.go
@@ -1,0 +1,83 @@
+package contractopenapidiff
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// CompareYAML loads two OpenAPI YAML documents and classifies their differences.
+func CompareYAML(before, after []byte) (Result, error) {
+	beforeDoc, err := loadDocument(before)
+	if err != nil {
+		return Result{}, fmt.Errorf("load before openapi document: %w", err)
+	}
+	afterDoc, err := loadDocument(after)
+	if err != nil {
+		return Result{}, fmt.Errorf("load after openapi document: %w", err)
+	}
+	return CompareDocuments(beforeDoc, afterDoc)
+}
+
+// CompareDocuments classifies supported differences between loaded OpenAPI documents.
+func CompareDocuments(before, after *openapi3.T) (Result, error) {
+	if before == nil || after == nil {
+		return Result{}, fmt.Errorf("openapi document is nil")
+	}
+	if err := compareStructural(before, after); err != nil {
+		return Result{}, err
+	}
+
+	changes := collectDocumentationChanges(before, after)
+	sortChanges(changes)
+
+	return Result{
+		Classification: ClassificationPatch,
+		Changes:        changes,
+	}, nil
+}
+
+func loadDocument(data []byte) (*openapi3.T, error) {
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData(data)
+	if err != nil {
+		return nil, err
+	}
+	return doc, nil
+}
+
+func sortChanges(changes []Change) {
+	sort.Slice(changes, func(i, j int) bool {
+		if changes[i].Path != changes[j].Path {
+			return changes[i].Path < changes[j].Path
+		}
+		return changes[i].Code < changes[j].Code
+	})
+}
+
+func operationPath(method, path string) string {
+	return strings.ToUpper(method) + " " + path
+}
+
+func appendDocChange(changes []Change, code, path string) []Change {
+	return append(changes, Change{Code: code, Path: path})
+}
+
+func externalDocsEqual(before, after *openapi3.ExternalDocs) bool {
+	if before == nil && after == nil {
+		return true
+	}
+	if before == nil || after == nil {
+		return false
+	}
+	return before.URL == after.URL && before.Description == after.Description
+}
+
+func appendExternalDocsChange(changes []Change, code, path string, before, after *openapi3.ExternalDocs) []Change {
+	if externalDocsEqual(before, after) {
+		return changes
+	}
+	return appendDocChange(changes, code, path)
+}

--- a/internal/contractopenapidiff/compare_test.go
+++ b/internal/contractopenapidiff/compare_test.go
@@ -308,6 +308,50 @@ func TestCompareYAML_NarrowTypeFixture_ClassifiesMajor(t *testing.T) {
 	}
 }
 
+func TestCompareYAML_NarrowInlineResponseSchemaFixture_ClassifiesMajor(t *testing.T) {
+	t.Parallel()
+
+	before := readFixture(t, "narrow-inline-response-schema", "before.yaml")
+	after := readFixture(t, "narrow-inline-response-schema", "after.yaml")
+
+	result, err := contractopenapidiff.CompareYAML(before, after)
+	if err != nil {
+		t.Fatalf("CompareYAML() error = %v", err)
+	}
+	if result.Classification != contractopenapidiff.ClassificationMajor {
+		t.Fatalf("Classification = %q, want %q", result.Classification, contractopenapidiff.ClassificationMajor)
+	}
+
+	wantChanges := []contractopenapidiff.Change{
+		{Code: contractopenapidiff.CodeSchemaTypeNarrowed, Path: "GET /pets.responses.200.content.application/json.schema.properties.age.type"},
+	}
+	if !slices.Equal(result.Changes, wantChanges) {
+		t.Fatalf("Changes = %#v, want %#v", result.Changes, wantChanges)
+	}
+}
+
+func TestCompareYAML_AddInlineResponseSchemaPropertyFixture_ClassifiesMinor(t *testing.T) {
+	t.Parallel()
+
+	before := readFixture(t, "add-inline-response-schema-property", "before.yaml")
+	after := readFixture(t, "add-inline-response-schema-property", "after.yaml")
+
+	result, err := contractopenapidiff.CompareYAML(before, after)
+	if err != nil {
+		t.Fatalf("CompareYAML() error = %v", err)
+	}
+	if result.Classification != contractopenapidiff.ClassificationMinor {
+		t.Fatalf("Classification = %q, want %q", result.Classification, contractopenapidiff.ClassificationMinor)
+	}
+
+	wantChanges := []contractopenapidiff.Change{
+		{Code: contractopenapidiff.CodeSchemaPropertyAdded, Path: "GET /pets.responses.200.content.application/json.schema.properties.name"},
+	}
+	if !slices.Equal(result.Changes, wantChanges) {
+		t.Fatalf("Changes = %#v, want %#v", result.Changes, wantChanges)
+	}
+}
+
 func TestCompareYAML_MajorWinsMixedFixture_ClassifiesMajor(t *testing.T) {
 	t.Parallel()
 

--- a/internal/contractopenapidiff/compare_test.go
+++ b/internal/contractopenapidiff/compare_test.go
@@ -449,6 +449,62 @@ func TestCompareYAML_UnsupportedSchemaKeywordFixtures_FailClosed(t *testing.T) {
 	}
 }
 
+func TestCompareYAML_UnsupportedStructuralSurfaceFixtures_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		fixture  string
+		wantPath string
+	}{
+		{
+			name:     "parameter-style",
+			fixture:  "unsupported-parameter-style",
+			wantPath: "GET /pets.parameters[query:tags].style",
+		},
+		{
+			name:     "response-header-remove",
+			fixture:  "unsupported-response-header-remove",
+			wantPath: "GET /pets.responses.200.headers.X-RateLimit",
+		},
+		{
+			name:     "security-scheme",
+			fixture:  "unsupported-security-scheme",
+			wantPath: "components.securitySchemes.bearerAuth",
+		},
+		{
+			name:     "component-parameter-remove",
+			fixture:  "unsupported-component-parameter-remove",
+			wantPath: "components.parameters.Limit",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			before := readFixture(t, tc.fixture, "before.yaml")
+			after := readFixture(t, tc.fixture, "after.yaml")
+
+			result, err := contractopenapidiff.CompareYAML(before, after)
+			if err == nil {
+				t.Fatalf("CompareYAML() = %#v, want unsupported diff error", result)
+			}
+			if !contractopenapidiff.IsUnsupportedDiff(err) {
+				t.Fatalf("CompareYAML() error = %v, want unsupported diff refusal", err)
+			}
+
+			var unsupported *contractopenapidiff.UnsupportedDiffError
+			if !errors.As(err, &unsupported) {
+				t.Fatalf("errors.As() = false, want *UnsupportedDiffError")
+			}
+			if unsupported.Path != tc.wantPath {
+				t.Fatalf("unsupported.Path = %q, want %q", unsupported.Path, tc.wantPath)
+			}
+		})
+	}
+}
+
 func TestCompareYAML_SupportedFixtures_StillClassifySuccessfully(t *testing.T) {
 	t.Parallel()
 

--- a/internal/contractopenapidiff/compare_test.go
+++ b/internal/contractopenapidiff/compare_test.go
@@ -524,6 +524,16 @@ func TestCompareYAML_UnsupportedStructuralSurfaceFixtures_FailClosed(t *testing.
 			fixture:  "unsupported-operation-callbacks",
 			wantPath: "POST /pets.callbacks.onData",
 		},
+		{
+			name:     "operation-servers",
+			fixture:  "unsupported-operation-servers",
+			wantPath: "GET /pets.servers",
+		},
+		{
+			name:     "server-variables",
+			fixture:  "unsupported-server-variables",
+			wantPath: "servers[0].variables.env.enum",
+		},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/internal/contractopenapidiff/compare_test.go
+++ b/internal/contractopenapidiff/compare_test.go
@@ -375,6 +375,28 @@ func TestCompareYAML_MajorWinsMixedFixture_ClassifiesMajor(t *testing.T) {
 	}
 }
 
+func TestCompareYAML_RemovePathParameterFixture_ClassifiesMajor(t *testing.T) {
+	t.Parallel()
+
+	before := readFixture(t, "remove-path-parameter", "before.yaml")
+	after := readFixture(t, "remove-path-parameter", "after.yaml")
+
+	result, err := contractopenapidiff.CompareYAML(before, after)
+	if err != nil {
+		t.Fatalf("CompareYAML() error = %v", err)
+	}
+	if result.Classification != contractopenapidiff.ClassificationMajor {
+		t.Fatalf("Classification = %q, want %q", result.Classification, contractopenapidiff.ClassificationMajor)
+	}
+
+	wantChanges := []contractopenapidiff.Change{
+		{Code: contractopenapidiff.CodeParameterRemoved, Path: "/pets.parameters[query:limit]"},
+	}
+	if !slices.Equal(result.Changes, wantChanges) {
+		t.Fatalf("Changes = %#v, want %#v", result.Changes, wantChanges)
+	}
+}
+
 func TestCompareYAML_UnsupportedOperationIDFixture_FailsClosed(t *testing.T) {
 	t.Parallel()
 
@@ -476,6 +498,31 @@ func TestCompareYAML_UnsupportedStructuralSurfaceFixtures_FailClosed(t *testing.
 			name:     "component-parameter-remove",
 			fixture:  "unsupported-component-parameter-remove",
 			wantPath: "components.parameters.Limit",
+		},
+		{
+			name:     "operation-security",
+			fixture:  "unsupported-operation-security",
+			wantPath: "GET /pets.security",
+		},
+		{
+			name:     "path-servers",
+			fixture:  "unsupported-path-servers",
+			wantPath: "/pets.servers",
+		},
+		{
+			name:     "media-type-encoding",
+			fixture:  "unsupported-media-type-encoding",
+			wantPath: "POST /pets.requestBody.content.multipart/form-data.encoding.file",
+		},
+		{
+			name:     "response-links",
+			fixture:  "unsupported-response-links",
+			wantPath: "GET /pets.responses.200.links.GetPet",
+		},
+		{
+			name:     "operation-callbacks",
+			fixture:  "unsupported-operation-callbacks",
+			wantPath: "POST /pets.callbacks.onData",
 		},
 	}
 	for _, tc := range cases {

--- a/internal/contractopenapidiff/compare_test.go
+++ b/internal/contractopenapidiff/compare_test.go
@@ -65,15 +65,103 @@ func TestCompareYAML_DocsOnlyFixture_IsDeterministic(t *testing.T) {
 	}
 }
 
-func TestCompareYAML_StructuralDifferenceFailsClosed(t *testing.T) {
+func TestCompareYAML_AddRouteFixture_ClassifiesMinor(t *testing.T) {
 	t.Parallel()
 
-	before := readFixture(t, "docs-only", "before.yaml")
-	after := readFixture(t, "structural-add-route", "after.yaml")
+	before := readFixture(t, "add-route", "before.yaml")
+	after := readFixture(t, "add-route", "after.yaml")
+
+	result, err := contractopenapidiff.CompareYAML(before, after)
+	if err != nil {
+		t.Fatalf("CompareYAML() error = %v", err)
+	}
+	if result.Classification != contractopenapidiff.ClassificationMinor {
+		t.Fatalf("Classification = %q, want %q", result.Classification, contractopenapidiff.ClassificationMinor)
+	}
+
+	wantChanges := []contractopenapidiff.Change{
+		{Code: contractopenapidiff.CodeOperationAdded, Path: "POST /pets"},
+	}
+	if !slices.Equal(result.Changes, wantChanges) {
+		t.Fatalf("Changes = %#v, want %#v", result.Changes, wantChanges)
+	}
+}
+
+func TestCompareYAML_AddParameterFixture_ClassifiesMinor(t *testing.T) {
+	t.Parallel()
+
+	before := readFixture(t, "add-parameter", "before.yaml")
+	after := readFixture(t, "add-parameter", "after.yaml")
+
+	result, err := contractopenapidiff.CompareYAML(before, after)
+	if err != nil {
+		t.Fatalf("CompareYAML() error = %v", err)
+	}
+	if result.Classification != contractopenapidiff.ClassificationMinor {
+		t.Fatalf("Classification = %q, want %q", result.Classification, contractopenapidiff.ClassificationMinor)
+	}
+
+	wantChanges := []contractopenapidiff.Change{
+		{Code: contractopenapidiff.CodeParameterAdded, Path: "GET /pets.parameters[query:offset]"},
+	}
+	if !slices.Equal(result.Changes, wantChanges) {
+		t.Fatalf("Changes = %#v, want %#v", result.Changes, wantChanges)
+	}
+}
+
+func TestCompareYAML_AddSchemaPropertyFixture_ClassifiesMinor(t *testing.T) {
+	t.Parallel()
+
+	before := readFixture(t, "add-schema-property", "before.yaml")
+	after := readFixture(t, "add-schema-property", "after.yaml")
+
+	result, err := contractopenapidiff.CompareYAML(before, after)
+	if err != nil {
+		t.Fatalf("CompareYAML() error = %v", err)
+	}
+	if result.Classification != contractopenapidiff.ClassificationMinor {
+		t.Fatalf("Classification = %q, want %q", result.Classification, contractopenapidiff.ClassificationMinor)
+	}
+
+	wantChanges := []contractopenapidiff.Change{
+		{Code: contractopenapidiff.CodeSchemaPropertyAdded, Path: "components.schemas.Pet.properties.nickname"},
+	}
+	if !slices.Equal(result.Changes, wantChanges) {
+		t.Fatalf("Changes = %#v, want %#v", result.Changes, wantChanges)
+	}
+}
+
+func TestCompareYAML_WidenEnumFixture_ClassifiesMinor(t *testing.T) {
+	t.Parallel()
+
+	before := readFixture(t, "widen-enum", "before.yaml")
+	after := readFixture(t, "widen-enum", "after.yaml")
+
+	result, err := contractopenapidiff.CompareYAML(before, after)
+	if err != nil {
+		t.Fatalf("CompareYAML() error = %v", err)
+	}
+	if result.Classification != contractopenapidiff.ClassificationMinor {
+		t.Fatalf("Classification = %q, want %q", result.Classification, contractopenapidiff.ClassificationMinor)
+	}
+
+	wantChanges := []contractopenapidiff.Change{
+		{Code: contractopenapidiff.CodeEnumValueAdded, Path: "components.schemas.Pet.properties.status.enum.pending"},
+	}
+	if !slices.Equal(result.Changes, wantChanges) {
+		t.Fatalf("Changes = %#v, want %#v", result.Changes, wantChanges)
+	}
+}
+
+func TestCompareYAML_RemovedOperationFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	before := readFixture(t, "add-route", "after.yaml")
+	after := readFixture(t, "add-route", "before.yaml")
 
 	_, err := contractopenapidiff.CompareYAML(before, after)
 	if err == nil {
-		t.Fatal("expected structural difference to fail closed")
+		t.Fatal("expected removed operation to fail closed")
 	}
 }
 

--- a/internal/contractopenapidiff/compare_test.go
+++ b/internal/contractopenapidiff/compare_test.go
@@ -154,6 +154,50 @@ func TestCompareYAML_WidenEnumFixture_ClassifiesMinor(t *testing.T) {
 	}
 }
 
+func TestCompareYAML_RelaxParameterRequiredFixture_ClassifiesMinor(t *testing.T) {
+	t.Parallel()
+
+	before := readFixture(t, "relax-parameter-required", "before.yaml")
+	after := readFixture(t, "relax-parameter-required", "after.yaml")
+
+	result, err := contractopenapidiff.CompareYAML(before, after)
+	if err != nil {
+		t.Fatalf("CompareYAML() error = %v", err)
+	}
+	if result.Classification != contractopenapidiff.ClassificationMinor {
+		t.Fatalf("Classification = %q, want %q", result.Classification, contractopenapidiff.ClassificationMinor)
+	}
+
+	wantChanges := []contractopenapidiff.Change{
+		{Code: contractopenapidiff.CodeParameterRequiredRelaxed, Path: "GET /pets.parameters[query:limit]"},
+	}
+	if !slices.Equal(result.Changes, wantChanges) {
+		t.Fatalf("Changes = %#v, want %#v", result.Changes, wantChanges)
+	}
+}
+
+func TestCompareYAML_RelaxSchemaRequiredFixture_ClassifiesMinor(t *testing.T) {
+	t.Parallel()
+
+	before := readFixture(t, "relax-schema-required", "before.yaml")
+	after := readFixture(t, "relax-schema-required", "after.yaml")
+
+	result, err := contractopenapidiff.CompareYAML(before, after)
+	if err != nil {
+		t.Fatalf("CompareYAML() error = %v", err)
+	}
+	if result.Classification != contractopenapidiff.ClassificationMinor {
+		t.Fatalf("Classification = %q, want %q", result.Classification, contractopenapidiff.ClassificationMinor)
+	}
+
+	wantChanges := []contractopenapidiff.Change{
+		{Code: contractopenapidiff.CodeSchemaRequiredRelaxed, Path: "components.schemas.Pet.required.name"},
+	}
+	if !slices.Equal(result.Changes, wantChanges) {
+		t.Fatalf("Changes = %#v, want %#v", result.Changes, wantChanges)
+	}
+}
+
 func TestCompareYAML_RemoveRouteFixture_ClassifiesMajor(t *testing.T) {
 	t.Parallel()
 

--- a/internal/contractopenapidiff/compare_test.go
+++ b/internal/contractopenapidiff/compare_test.go
@@ -534,6 +534,21 @@ func TestCompareYAML_UnsupportedStructuralSurfaceFixtures_FailClosed(t *testing.
 			fixture:  "unsupported-server-variables",
 			wantPath: "servers[0].variables.env.enum",
 		},
+		{
+			name:     "schema-extension",
+			fixture:  "unsupported-schema-extension",
+			wantPath: "components.schemas.Pet.x-internal",
+		},
+		{
+			name:     "operation-extension",
+			fixture:  "unsupported-operation-extension",
+			wantPath: "GET /pets.x-internal",
+		},
+		{
+			name:     "parameter-extension",
+			fixture:  "unsupported-parameter-extension",
+			wantPath: "GET /pets.parameters[query:tags].x-codegen-name",
+		},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/internal/contractopenapidiff/compare_test.go
+++ b/internal/contractopenapidiff/compare_test.go
@@ -398,6 +398,57 @@ func TestCompareYAML_UnsupportedOperationIDFixture_FailsClosed(t *testing.T) {
 	}
 }
 
+func TestCompareYAML_UnsupportedSchemaKeywordFixtures_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		fixture    string
+		wantPath   string
+	}{
+		{
+			name:     "nullable-narrow",
+			fixture:  "unsupported-nullable-narrow",
+			wantPath: "GET /pets.responses.200.content.application/json.schema.nullable",
+		},
+		{
+			name:     "additional-properties-narrow",
+			fixture:  "unsupported-additional-properties-narrow",
+			wantPath: "GET /pets.responses.200.content.application/json.schema.additionalProperties",
+		},
+		{
+			name:     "oneof-narrow",
+			fixture:  "unsupported-oneof-narrow",
+			wantPath: "GET /pets.responses.200.content.application/json.schema.oneOf",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			before := readFixture(t, tc.fixture, "before.yaml")
+			after := readFixture(t, tc.fixture, "after.yaml")
+
+			result, err := contractopenapidiff.CompareYAML(before, after)
+			if err == nil {
+				t.Fatalf("CompareYAML() = %#v, want unsupported diff error", result)
+			}
+			if !contractopenapidiff.IsUnsupportedDiff(err) {
+				t.Fatalf("CompareYAML() error = %v, want unsupported diff refusal", err)
+			}
+
+			var unsupported *contractopenapidiff.UnsupportedDiffError
+			if !errors.As(err, &unsupported) {
+				t.Fatalf("errors.As() = false, want *UnsupportedDiffError")
+			}
+			if unsupported.Path != tc.wantPath {
+				t.Fatalf("unsupported.Path = %q, want %q", unsupported.Path, tc.wantPath)
+			}
+		})
+	}
+}
+
 func TestCompareYAML_SupportedFixtures_StillClassifySuccessfully(t *testing.T) {
 	t.Parallel()
 

--- a/internal/contractopenapidiff/compare_test.go
+++ b/internal/contractopenapidiff/compare_test.go
@@ -1,6 +1,7 @@
 package contractopenapidiff_test
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -283,6 +284,60 @@ func TestCompareYAML_MajorWinsMixedFixture_ClassifiesMajor(t *testing.T) {
 	}
 	if !slices.Equal(result.Changes, wantChanges) {
 		t.Fatalf("Changes = %#v, want %#v", result.Changes, wantChanges)
+	}
+}
+
+func TestCompareYAML_UnsupportedOperationIDFixture_FailsClosed(t *testing.T) {
+	t.Parallel()
+
+	before := readFixture(t, "unsupported-operation-id", "before.yaml")
+	after := readFixture(t, "unsupported-operation-id", "after.yaml")
+
+	result, err := contractopenapidiff.CompareYAML(before, after)
+	if err == nil {
+		t.Fatalf("CompareYAML() = %#v, want unsupported diff error", result)
+	}
+	if !contractopenapidiff.IsUnsupportedDiff(err) {
+		t.Fatalf("CompareYAML() error = %v, want unsupported diff refusal", err)
+	}
+
+	var unsupported *contractopenapidiff.UnsupportedDiffError
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("errors.As() = false, want *UnsupportedDiffError")
+	}
+	if unsupported.Path != "GET /pets.operationId" {
+		t.Fatalf("unsupported.Path = %q, want %q", unsupported.Path, "GET /pets.operationId")
+	}
+}
+
+func TestCompareYAML_SupportedFixtures_StillClassifySuccessfully(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name           string
+		fixture        string
+		classification contractopenapidiff.Classification
+	}{
+		{name: "docs-only", fixture: "docs-only", classification: contractopenapidiff.ClassificationPatch},
+		{name: "add-route", fixture: "add-route", classification: contractopenapidiff.ClassificationMinor},
+		{name: "remove-route", fixture: "remove-route", classification: contractopenapidiff.ClassificationMajor},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			before := readFixture(t, tc.fixture, "before.yaml")
+			after := readFixture(t, tc.fixture, "after.yaml")
+
+			result, err := contractopenapidiff.CompareYAML(before, after)
+			if err != nil {
+				t.Fatalf("CompareYAML() error = %v", err)
+			}
+			if result.Classification != tc.classification {
+				t.Fatalf("Classification = %q, want %q", result.Classification, tc.classification)
+			}
+		})
 	}
 }
 

--- a/internal/contractopenapidiff/compare_test.go
+++ b/internal/contractopenapidiff/compare_test.go
@@ -448,25 +448,7 @@ func TestCompareYAML_UnsupportedSchemaKeywordFixtures_FailClosed(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-
-			before := readFixture(t, tc.fixture, "before.yaml")
-			after := readFixture(t, tc.fixture, "after.yaml")
-
-			result, err := contractopenapidiff.CompareYAML(before, after)
-			if err == nil {
-				t.Fatalf("CompareYAML() = %#v, want unsupported diff error", result)
-			}
-			if !contractopenapidiff.IsUnsupportedDiff(err) {
-				t.Fatalf("CompareYAML() error = %v, want unsupported diff refusal", err)
-			}
-
-			var unsupported *contractopenapidiff.UnsupportedDiffError
-			if !errors.As(err, &unsupported) {
-				t.Fatalf("errors.As() = false, want *UnsupportedDiffError")
-			}
-			if unsupported.Path != tc.wantPath {
-				t.Fatalf("unsupported.Path = %q, want %q", unsupported.Path, tc.wantPath)
-			}
+			assertCompareYAMLFailsClosedAtPath(t, tc.fixture, tc.wantPath)
 		})
 	}
 }
@@ -534,6 +516,24 @@ func TestCompareYAML_UnsupportedStructuralSurfaceFixtures_FailClosed(t *testing.
 			fixture:  "unsupported-server-variables",
 			wantPath: "servers[0].variables.env.enum",
 		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assertCompareYAMLFailsClosedAtPath(t, tc.fixture, tc.wantPath)
+		})
+	}
+}
+
+func TestCompareYAML_UnsupportedExtensionFixtures_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		fixture  string
+		wantPath string
+	}{
 		{
 			name:     "schema-extension",
 			fixture:  "unsupported-schema-extension",
@@ -554,25 +554,7 @@ func TestCompareYAML_UnsupportedStructuralSurfaceFixtures_FailClosed(t *testing.
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-
-			before := readFixture(t, tc.fixture, "before.yaml")
-			after := readFixture(t, tc.fixture, "after.yaml")
-
-			result, err := contractopenapidiff.CompareYAML(before, after)
-			if err == nil {
-				t.Fatalf("CompareYAML() = %#v, want unsupported diff error", result)
-			}
-			if !contractopenapidiff.IsUnsupportedDiff(err) {
-				t.Fatalf("CompareYAML() error = %v, want unsupported diff refusal", err)
-			}
-
-			var unsupported *contractopenapidiff.UnsupportedDiffError
-			if !errors.As(err, &unsupported) {
-				t.Fatalf("errors.As() = false, want *UnsupportedDiffError")
-			}
-			if unsupported.Path != tc.wantPath {
-				t.Fatalf("unsupported.Path = %q, want %q", unsupported.Path, tc.wantPath)
-			}
+			assertCompareYAMLFailsClosedAtPath(t, tc.fixture, tc.wantPath)
 		})
 	}
 }
@@ -621,4 +603,27 @@ func readFixture(t *testing.T, parts ...string) []byte {
 		t.Fatalf("read fixture %s: %v", path, err)
 	}
 	return data
+}
+
+func assertCompareYAMLFailsClosedAtPath(t *testing.T, fixture, wantPath string) {
+	t.Helper()
+
+	before := readFixture(t, fixture, "before.yaml")
+	after := readFixture(t, fixture, "after.yaml")
+
+	result, err := contractopenapidiff.CompareYAML(before, after)
+	if err == nil {
+		t.Fatalf("CompareYAML() = %#v, want unsupported diff error", result)
+	}
+	if !contractopenapidiff.IsUnsupportedDiff(err) {
+		t.Fatalf("CompareYAML() error = %v, want unsupported diff refusal", err)
+	}
+
+	var unsupported *contractopenapidiff.UnsupportedDiffError
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("errors.As() = false, want *UnsupportedDiffError")
+	}
+	if unsupported.Path != wantPath {
+		t.Fatalf("unsupported.Path = %q, want %q", unsupported.Path, wantPath)
+	}
 }

--- a/internal/contractopenapidiff/compare_test.go
+++ b/internal/contractopenapidiff/compare_test.go
@@ -153,15 +153,136 @@ func TestCompareYAML_WidenEnumFixture_ClassifiesMinor(t *testing.T) {
 	}
 }
 
-func TestCompareYAML_RemovedOperationFailsClosed(t *testing.T) {
+func TestCompareYAML_RemoveRouteFixture_ClassifiesMajor(t *testing.T) {
 	t.Parallel()
 
-	before := readFixture(t, "add-route", "after.yaml")
-	after := readFixture(t, "add-route", "before.yaml")
+	before := readFixture(t, "remove-route", "before.yaml")
+	after := readFixture(t, "remove-route", "after.yaml")
 
-	_, err := contractopenapidiff.CompareYAML(before, after)
-	if err == nil {
-		t.Fatal("expected removed operation to fail closed")
+	result, err := contractopenapidiff.CompareYAML(before, after)
+	if err != nil {
+		t.Fatalf("CompareYAML() error = %v", err)
+	}
+	if result.Classification != contractopenapidiff.ClassificationMajor {
+		t.Fatalf("Classification = %q, want %q", result.Classification, contractopenapidiff.ClassificationMajor)
+	}
+
+	wantChanges := []contractopenapidiff.Change{
+		{Code: contractopenapidiff.CodeOperationRemoved, Path: "POST /pets"},
+	}
+	if !slices.Equal(result.Changes, wantChanges) {
+		t.Fatalf("Changes = %#v, want %#v", result.Changes, wantChanges)
+	}
+}
+
+func TestCompareYAML_RemoveParameterFixture_ClassifiesMajor(t *testing.T) {
+	t.Parallel()
+
+	before := readFixture(t, "remove-parameter", "before.yaml")
+	after := readFixture(t, "remove-parameter", "after.yaml")
+
+	result, err := contractopenapidiff.CompareYAML(before, after)
+	if err != nil {
+		t.Fatalf("CompareYAML() error = %v", err)
+	}
+	if result.Classification != contractopenapidiff.ClassificationMajor {
+		t.Fatalf("Classification = %q, want %q", result.Classification, contractopenapidiff.ClassificationMajor)
+	}
+
+	wantChanges := []contractopenapidiff.Change{
+		{Code: contractopenapidiff.CodeParameterRemoved, Path: "GET /pets.parameters[query:offset]"},
+	}
+	if !slices.Equal(result.Changes, wantChanges) {
+		t.Fatalf("Changes = %#v, want %#v", result.Changes, wantChanges)
+	}
+}
+
+func TestCompareYAML_RemoveSchemaPropertyFixture_ClassifiesMajor(t *testing.T) {
+	t.Parallel()
+
+	before := readFixture(t, "remove-schema-property", "before.yaml")
+	after := readFixture(t, "remove-schema-property", "after.yaml")
+
+	result, err := contractopenapidiff.CompareYAML(before, after)
+	if err != nil {
+		t.Fatalf("CompareYAML() error = %v", err)
+	}
+	if result.Classification != contractopenapidiff.ClassificationMajor {
+		t.Fatalf("Classification = %q, want %q", result.Classification, contractopenapidiff.ClassificationMajor)
+	}
+
+	wantChanges := []contractopenapidiff.Change{
+		{Code: contractopenapidiff.CodeSchemaPropertyRemoved, Path: "components.schemas.Pet.properties.nickname"},
+	}
+	if !slices.Equal(result.Changes, wantChanges) {
+		t.Fatalf("Changes = %#v, want %#v", result.Changes, wantChanges)
+	}
+}
+
+func TestCompareYAML_NarrowEnumFixture_ClassifiesMajor(t *testing.T) {
+	t.Parallel()
+
+	before := readFixture(t, "narrow-enum", "before.yaml")
+	after := readFixture(t, "narrow-enum", "after.yaml")
+
+	result, err := contractopenapidiff.CompareYAML(before, after)
+	if err != nil {
+		t.Fatalf("CompareYAML() error = %v", err)
+	}
+	if result.Classification != contractopenapidiff.ClassificationMajor {
+		t.Fatalf("Classification = %q, want %q", result.Classification, contractopenapidiff.ClassificationMajor)
+	}
+
+	wantChanges := []contractopenapidiff.Change{
+		{Code: contractopenapidiff.CodeEnumValueRemoved, Path: "components.schemas.Pet.properties.status.enum.pending"},
+	}
+	if !slices.Equal(result.Changes, wantChanges) {
+		t.Fatalf("Changes = %#v, want %#v", result.Changes, wantChanges)
+	}
+}
+
+func TestCompareYAML_NarrowTypeFixture_ClassifiesMajor(t *testing.T) {
+	t.Parallel()
+
+	before := readFixture(t, "narrow-type", "before.yaml")
+	after := readFixture(t, "narrow-type", "after.yaml")
+
+	result, err := contractopenapidiff.CompareYAML(before, after)
+	if err != nil {
+		t.Fatalf("CompareYAML() error = %v", err)
+	}
+	if result.Classification != contractopenapidiff.ClassificationMajor {
+		t.Fatalf("Classification = %q, want %q", result.Classification, contractopenapidiff.ClassificationMajor)
+	}
+
+	wantChanges := []contractopenapidiff.Change{
+		{Code: contractopenapidiff.CodeSchemaTypeNarrowed, Path: "components.schemas.Pet.properties.age.type"},
+	}
+	if !slices.Equal(result.Changes, wantChanges) {
+		t.Fatalf("Changes = %#v, want %#v", result.Changes, wantChanges)
+	}
+}
+
+func TestCompareYAML_MajorWinsMixedFixture_ClassifiesMajor(t *testing.T) {
+	t.Parallel()
+
+	before := readFixture(t, "major-wins-mixed", "before.yaml")
+	after := readFixture(t, "major-wins-mixed", "after.yaml")
+
+	result, err := contractopenapidiff.CompareYAML(before, after)
+	if err != nil {
+		t.Fatalf("CompareYAML() error = %v", err)
+	}
+	if result.Classification != contractopenapidiff.ClassificationMajor {
+		t.Fatalf("Classification = %q, want %q", result.Classification, contractopenapidiff.ClassificationMajor)
+	}
+
+	wantChanges := []contractopenapidiff.Change{
+		{Code: contractopenapidiff.CodeParameterAdded, Path: "GET /pets.parameters[query:offset]"},
+		{Code: contractopenapidiff.CodeOperationRemoved, Path: "POST /pets"},
+	}
+	if !slices.Equal(result.Changes, wantChanges) {
+		t.Fatalf("Changes = %#v, want %#v", result.Changes, wantChanges)
 	}
 }
 

--- a/internal/contractopenapidiff/compare_test.go
+++ b/internal/contractopenapidiff/compare_test.go
@@ -1,0 +1,93 @@
+package contractopenapidiff_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/contractopenapidiff"
+)
+
+func TestCompareYAML_DocsOnlyFixture_ClassifiesPatchWithStableChanges(t *testing.T) {
+	t.Parallel()
+
+	before := readFixture(t, "docs-only", "before.yaml")
+	after := readFixture(t, "docs-only", "after.yaml")
+
+	result, err := contractopenapidiff.CompareYAML(before, after)
+	if err != nil {
+		t.Fatalf("CompareYAML() error = %v", err)
+	}
+	if result.Classification != contractopenapidiff.ClassificationPatch {
+		t.Fatalf("Classification = %q, want %q", result.Classification, contractopenapidiff.ClassificationPatch)
+	}
+
+	wantChanges := []contractopenapidiff.Change{
+		{Code: contractopenapidiff.CodeOperationDescriptionChanged, Path: "GET /pets"},
+		{Code: contractopenapidiff.CodeOperationSummaryChanged, Path: "GET /pets"},
+		{Code: contractopenapidiff.CodeParameterDescriptionChanged, Path: "GET /pets.parameters[query:limit]"},
+		{Code: contractopenapidiff.CodeRequestBodyDescriptionChanged, Path: "GET /pets.requestBody"},
+		{Code: contractopenapidiff.CodeResponseDescriptionChanged, Path: "GET /pets.responses.200"},
+		{Code: contractopenapidiff.CodeSchemaDescriptionChanged, Path: "components.schemas.Pet"},
+		{Code: contractopenapidiff.CodeSchemaTitleChanged, Path: "components.schemas.Pet"},
+		{Code: contractopenapidiff.CodeSchemaDescriptionChanged, Path: "components.schemas.Pet.properties.id"},
+		{Code: contractopenapidiff.CodeSchemaDescriptionChanged, Path: "components.schemas.Pet.properties.name"},
+		{Code: contractopenapidiff.CodeSchemaDescriptionChanged, Path: "components.schemas.PetFilter.properties.name"},
+		{Code: contractopenapidiff.CodeInfoDescriptionChanged, Path: "info"},
+		{Code: contractopenapidiff.CodeTagDescriptionChanged, Path: "tags.pets"},
+	}
+	if !slices.Equal(result.Changes, wantChanges) {
+		t.Fatalf("Changes = %#v, want %#v", result.Changes, wantChanges)
+	}
+}
+
+func TestCompareYAML_DocsOnlyFixture_IsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	before := readFixture(t, "docs-only", "before.yaml")
+	after := readFixture(t, "docs-only", "after.yaml")
+
+	first, err := contractopenapidiff.CompareYAML(before, after)
+	if err != nil {
+		t.Fatalf("first CompareYAML() error = %v", err)
+	}
+	second, err := contractopenapidiff.CompareYAML(before, after)
+	if err != nil {
+		t.Fatalf("second CompareYAML() error = %v", err)
+	}
+	if !slices.Equal(first.Changes, second.Changes) {
+		t.Fatalf("changes differ across runs: first=%#v second=%#v", first.Changes, second.Changes)
+	}
+	if first.Classification != second.Classification {
+		t.Fatalf("classification differ across runs: first=%q second=%q", first.Classification, second.Classification)
+	}
+}
+
+func TestCompareYAML_StructuralDifferenceFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	before := readFixture(t, "docs-only", "before.yaml")
+	after := readFixture(t, "structural-add-route", "after.yaml")
+
+	_, err := contractopenapidiff.CompareYAML(before, after)
+	if err == nil {
+		t.Fatal("expected structural difference to fail closed")
+	}
+}
+
+func readFixture(t *testing.T, parts ...string) []byte {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	path := filepath.Join(append([]string{filepath.Dir(file), "testdata"}, parts...)...)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", path, err)
+	}
+	return data
+}

--- a/internal/contractopenapidiff/docs.go
+++ b/internal/contractopenapidiff/docs.go
@@ -1,8 +1,6 @@
 package contractopenapidiff
 
 import (
-	"fmt"
-
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
@@ -237,5 +235,5 @@ func schemaValue(ref *openapi3.SchemaRef) *openapi3.Schema {
 }
 
 func unsupportedStructuralDiff(path string) error {
-	return fmt.Errorf("unsupported openapi diff: non-documentation change at %s", path)
+	return &UnsupportedDiffError{Path: path}
 }

--- a/internal/contractopenapidiff/docs.go
+++ b/internal/contractopenapidiff/docs.go
@@ -168,7 +168,7 @@ func appendResponseDocChanges(changes []Change, opPath string, before, after *op
 		if beforeResponse == nil || afterResponse == nil {
 			continue
 		}
-		if beforeResponse.Description != afterResponse.Description {
+		if !stringPtrEqual(beforeResponse.Description, afterResponse.Description) {
 			changes = appendDocChange(changes, CodeResponseDescriptionChanged, opPath+".responses."+status)
 		}
 	}

--- a/internal/contractopenapidiff/docs.go
+++ b/internal/contractopenapidiff/docs.go
@@ -1,0 +1,241 @@
+package contractopenapidiff
+
+import (
+	"fmt"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+func collectDocumentationChanges(before, after *openapi3.T) []Change {
+	var changes []Change
+	changes = appendInfoDocChanges(changes, before.Info, after.Info)
+	changes = appendRootExternalDocsChanges(changes, before.ExternalDocs, after.ExternalDocs)
+	changes = appendTagDocChanges(changes, before.Tags, after.Tags)
+	changes = appendPathDocChanges(changes, before.Paths, after.Paths)
+	changes = appendComponentDocChanges(changes, before.Components, after.Components)
+	return changes
+}
+
+func appendInfoDocChanges(changes []Change, before, after *openapi3.Info) []Change {
+	if before == nil && after == nil {
+		return changes
+	}
+	if before == nil || after == nil {
+		return changes
+	}
+	if before.Description != after.Description {
+		changes = appendDocChange(changes, CodeInfoDescriptionChanged, "info")
+	}
+	return changes
+}
+
+func appendRootExternalDocsChanges(changes []Change, before, after *openapi3.ExternalDocs) []Change {
+	return appendExternalDocsChange(changes, CodeInfoExternalDocsChanged, "externalDocs", before, after)
+}
+
+func appendTagDocChanges(changes []Change, before, after openapi3.Tags) []Change {
+	beforeByName := tagsByName(before)
+	afterByName := tagsByName(after)
+	for name := range beforeByName {
+		beforeTag := beforeByName[name]
+		afterTag, ok := afterByName[name]
+		if !ok {
+			continue
+		}
+		if beforeTag.Description != afterTag.Description {
+			changes = appendDocChange(changes, CodeTagDescriptionChanged, "tags."+name)
+		}
+		changes = appendExternalDocsChange(
+			changes,
+			CodeTagExternalDocsChanged,
+			"tags."+name+".externalDocs",
+			beforeTag.ExternalDocs,
+			afterTag.ExternalDocs,
+		)
+	}
+	return changes
+}
+
+func tagsByName(tags openapi3.Tags) map[string]*openapi3.Tag {
+	out := make(map[string]*openapi3.Tag, len(tags))
+	for _, tag := range tags {
+		if tag == nil {
+			continue
+		}
+		out[tag.Name] = tag
+	}
+	return out
+}
+
+func appendPathDocChanges(changes []Change, before, after *openapi3.Paths) []Change {
+	if before == nil && after == nil {
+		return changes
+	}
+	if before == nil || after == nil {
+		return changes
+	}
+
+	beforePaths := before.Map()
+	afterPaths := after.Map()
+	for path := range beforePaths {
+		beforeItem := beforePaths[path]
+		afterItem := afterPaths[path]
+		if beforeItem == nil || afterItem == nil {
+			continue
+		}
+		for method, beforeOperation := range beforeItem.Operations() {
+			afterOperation := afterItem.GetOperation(method)
+			if beforeOperation == nil || afterOperation == nil {
+				continue
+			}
+			changes = appendOperationDocChanges(changes, method, path, beforeOperation, afterOperation)
+		}
+	}
+	return changes
+}
+
+func appendOperationDocChanges(changes []Change, method, path string, before, after *openapi3.Operation) []Change {
+	opPath := operationPath(method, path)
+	if before.Summary != after.Summary {
+		changes = appendDocChange(changes, CodeOperationSummaryChanged, opPath)
+	}
+	if before.Description != after.Description {
+		changes = appendDocChange(changes, CodeOperationDescriptionChanged, opPath)
+	}
+	changes = appendExternalDocsChange(changes, CodeOperationExternalDocsChanged, opPath, before.ExternalDocs, after.ExternalDocs)
+
+	changes = appendParameterDocChanges(changes, opPath, before.Parameters, after.Parameters)
+	changes = appendRequestBodyDocChanges(changes, opPath, before.RequestBody, after.RequestBody)
+	changes = appendResponseDocChanges(changes, opPath, before.Responses, after.Responses)
+	return changes
+}
+
+func appendParameterDocChanges(changes []Change, opPath string, before, after openapi3.Parameters) []Change {
+	beforeByKey := parametersByKey(before)
+	afterByKey := parametersByKey(after)
+	for key, beforeParameter := range beforeByKey {
+		afterParameter, ok := afterByKey[key]
+		if !ok || beforeParameter == nil || afterParameter == nil {
+			continue
+		}
+		if beforeParameter.Description != afterParameter.Description {
+			changes = appendDocChange(changes, CodeParameterDescriptionChanged, opPath+".parameters["+key+"]")
+		}
+	}
+	return changes
+}
+
+func parametersByKey(parameters openapi3.Parameters) map[string]*openapi3.Parameter {
+	out := make(map[string]*openapi3.Parameter, len(parameters))
+	for _, parameterRef := range parameters {
+		if parameterRef == nil || parameterRef.Value == nil {
+			continue
+		}
+		parameter := parameterRef.Value
+		key := parameter.In + ":" + parameter.Name
+		out[key] = parameter
+	}
+	return out
+}
+
+func appendRequestBodyDocChanges(changes []Change, opPath string, before, after *openapi3.RequestBodyRef) []Change {
+	beforeBody := requestBodyValue(before)
+	afterBody := requestBodyValue(after)
+	if beforeBody == nil || afterBody == nil {
+		return changes
+	}
+	if beforeBody.Description != afterBody.Description {
+		changes = appendDocChange(changes, CodeRequestBodyDescriptionChanged, opPath+".requestBody")
+	}
+	return changes
+}
+
+func requestBodyValue(ref *openapi3.RequestBodyRef) *openapi3.RequestBody {
+	if ref == nil || ref.Value == nil {
+		return nil
+	}
+	return ref.Value
+}
+
+func appendResponseDocChanges(changes []Change, opPath string, before, after *openapi3.Responses) []Change {
+	if before == nil || after == nil {
+		return changes
+	}
+	for status, beforeResponseRef := range before.Map() {
+		afterResponseRef := after.Value(status)
+		beforeResponse := responseValue(beforeResponseRef)
+		afterResponse := responseValue(afterResponseRef)
+		if beforeResponse == nil || afterResponse == nil {
+			continue
+		}
+		if beforeResponse.Description != afterResponse.Description {
+			changes = appendDocChange(changes, CodeResponseDescriptionChanged, opPath+".responses."+status)
+		}
+	}
+	return changes
+}
+
+func responseValue(ref *openapi3.ResponseRef) *openapi3.Response {
+	if ref == nil || ref.Value == nil {
+		return nil
+	}
+	return ref.Value
+}
+
+func appendComponentDocChanges(changes []Change, before, after *openapi3.Components) []Change {
+	if before == nil && after == nil {
+		return changes
+	}
+	if before == nil || after == nil {
+		return changes
+	}
+	if before.Schemas != nil {
+		for name, beforeSchemaRef := range before.Schemas {
+			afterSchemaRef := after.Schemas[name]
+			changes = appendSchemaDocChanges(changes, "components.schemas."+name, beforeSchemaRef, afterSchemaRef)
+		}
+	}
+	return changes
+}
+
+func appendSchemaDocChanges(changes []Change, schemaPath string, beforeRef, afterRef *openapi3.SchemaRef) []Change {
+	beforeSchema := schemaValue(beforeRef)
+	afterSchema := schemaValue(afterRef)
+	if beforeSchema == nil || afterSchema == nil {
+		return changes
+	}
+	if beforeSchema.Title != afterSchema.Title {
+		changes = appendDocChange(changes, CodeSchemaTitleChanged, schemaPath)
+	}
+	if beforeSchema.Description != afterSchema.Description {
+		changes = appendDocChange(changes, CodeSchemaDescriptionChanged, schemaPath)
+	}
+	changes = appendExternalDocsChange(changes, CodeSchemaExternalDocsChanged, schemaPath, beforeSchema.ExternalDocs, afterSchema.ExternalDocs)
+	changes = appendPropertySchemaDocChanges(changes, schemaPath, beforeSchema, afterSchema)
+	return changes
+}
+
+func appendPropertySchemaDocChanges(changes []Change, schemaPath string, before, after *openapi3.Schema) []Change {
+	if before == nil || after == nil || before.Properties == nil {
+		return changes
+	}
+	for propertyName, beforePropertyRef := range before.Properties {
+		afterPropertyRef := after.Properties[propertyName]
+		changes = appendSchemaDocChanges(changes, schemaPath+".properties."+propertyName, beforePropertyRef, afterPropertyRef)
+	}
+	if before.Items != nil && after.Items != nil {
+		changes = appendSchemaDocChanges(changes, schemaPath+".items", before.Items, after.Items)
+	}
+	return changes
+}
+
+func schemaValue(ref *openapi3.SchemaRef) *openapi3.Schema {
+	if ref == nil || ref.Value == nil {
+		return nil
+	}
+	return ref.Value
+}
+
+func unsupportedStructuralDiff(path string) error {
+	return fmt.Errorf("unsupported openapi diff: non-documentation change at %s", path)
+}

--- a/internal/contractopenapidiff/fixture_matrix_test.go
+++ b/internal/contractopenapidiff/fixture_matrix_test.go
@@ -1,0 +1,163 @@
+package contractopenapidiff_test
+
+import (
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/contractopenapidiff"
+)
+
+type fixtureCategory string
+
+const (
+	categoryRoute              fixtureCategory = "route"
+	categoryParameter          fixtureCategory = "parameter"
+	categoryRequestResponse    fixtureCategory = "request_response_schema"
+	categoryEnum               fixtureCategory = "enum"
+	categoryDocsOnly           fixtureCategory = "docs_only"
+	categoryFailClosed         fixtureCategory = "fail_closed"
+)
+
+var openAPIDiffFixtureMatrix = []struct {
+	name           string
+	fixture        string
+	category       fixtureCategory
+	classification contractopenapidiff.Classification
+	failClosed     bool
+}{
+	{
+		name:           "docs-only",
+		fixture:        "docs-only",
+		category:       categoryDocsOnly,
+		classification: contractopenapidiff.ClassificationPatch,
+	},
+	{
+		name:           "add-route",
+		fixture:        "add-route",
+		category:       categoryRoute,
+		classification: contractopenapidiff.ClassificationMinor,
+	},
+	{
+		name:           "add-parameter",
+		fixture:        "add-parameter",
+		category:       categoryParameter,
+		classification: contractopenapidiff.ClassificationMinor,
+	},
+	{
+		name:           "add-schema-property",
+		fixture:        "add-schema-property",
+		category:       categoryRequestResponse,
+		classification: contractopenapidiff.ClassificationMinor,
+	},
+	{
+		name:           "widen-enum",
+		fixture:        "widen-enum",
+		category:       categoryEnum,
+		classification: contractopenapidiff.ClassificationMinor,
+	},
+	{
+		name:           "remove-route",
+		fixture:        "remove-route",
+		category:       categoryRoute,
+		classification: contractopenapidiff.ClassificationMajor,
+	},
+	{
+		name:           "remove-parameter",
+		fixture:        "remove-parameter",
+		category:       categoryParameter,
+		classification: contractopenapidiff.ClassificationMajor,
+	},
+	{
+		name:           "remove-schema-property",
+		fixture:        "remove-schema-property",
+		category:       categoryRequestResponse,
+		classification: contractopenapidiff.ClassificationMajor,
+	},
+	{
+		name:           "narrow-enum",
+		fixture:        "narrow-enum",
+		category:       categoryEnum,
+		classification: contractopenapidiff.ClassificationMajor,
+	},
+	{
+		name:           "narrow-type",
+		fixture:        "narrow-type",
+		category:       categoryRequestResponse,
+		classification: contractopenapidiff.ClassificationMajor,
+	},
+	{
+		name:           "major-wins-mixed",
+		fixture:        "major-wins-mixed",
+		category:       categoryRoute,
+		classification: contractopenapidiff.ClassificationMajor,
+	},
+	{
+		name:       "unsupported-operation-id",
+		fixture:    "unsupported-operation-id",
+		category:   categoryFailClosed,
+		failClosed: true,
+	},
+}
+
+func TestCompareYAML_FixtureMatrix_ClassifiesRepresentativeCases(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range openAPIDiffFixtureMatrix {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			before := readFixture(t, tc.fixture, "before.yaml")
+			after := readFixture(t, tc.fixture, "after.yaml")
+
+			result, err := contractopenapidiff.CompareYAML(before, after)
+			if tc.failClosed {
+				if err == nil {
+					t.Fatalf("CompareYAML() = %#v, want unsupported diff error", result)
+				}
+				if !contractopenapidiff.IsUnsupportedDiff(err) {
+					t.Fatalf("CompareYAML() error = %v, want unsupported diff refusal", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CompareYAML() error = %v", err)
+			}
+			if result.Classification != tc.classification {
+				t.Fatalf("Classification = %q, want %q", result.Classification, tc.classification)
+			}
+			if len(result.Changes) == 0 {
+				t.Fatalf("Changes is empty, want at least one classified change")
+			}
+			for _, change := range result.Changes {
+				if change.Code == "" {
+					t.Fatalf("change missing code: %#v", change)
+				}
+				if change.Path == "" {
+					t.Fatalf("change missing path: %#v", change)
+				}
+			}
+		})
+	}
+}
+
+func TestCompareYAML_FixtureMatrix_CoversRequiredCategories(t *testing.T) {
+	t.Parallel()
+
+	required := []fixtureCategory{
+		categoryRoute,
+		categoryParameter,
+		categoryRequestResponse,
+		categoryEnum,
+		categoryDocsOnly,
+		categoryFailClosed,
+	}
+	covered := make(map[fixtureCategory]struct{}, len(required))
+	for _, tc := range openAPIDiffFixtureMatrix {
+		covered[tc.category] = struct{}{}
+	}
+	for _, category := range required {
+		if _, ok := covered[category]; !ok {
+			t.Fatalf("fixture matrix missing category %q", category)
+		}
+	}
+}

--- a/internal/contractopenapidiff/fixture_matrix_test.go
+++ b/internal/contractopenapidiff/fixture_matrix_test.go
@@ -138,6 +138,30 @@ var openAPIDiffFixtureMatrix = []struct {
 		category:   categoryFailClosed,
 		failClosed: true,
 	},
+	{
+		name:       "unsupported-parameter-style",
+		fixture:    "unsupported-parameter-style",
+		category:   categoryFailClosed,
+		failClosed: true,
+	},
+	{
+		name:       "unsupported-response-header-remove",
+		fixture:    "unsupported-response-header-remove",
+		category:   categoryFailClosed,
+		failClosed: true,
+	},
+	{
+		name:       "unsupported-security-scheme",
+		fixture:    "unsupported-security-scheme",
+		category:   categoryFailClosed,
+		failClosed: true,
+	},
+	{
+		name:       "unsupported-component-parameter-remove",
+		fixture:    "unsupported-component-parameter-remove",
+		category:   categoryFailClosed,
+		failClosed: true,
+	},
 }
 
 func TestCompareYAML_FixtureMatrix_ClassifiesRepresentativeCases(t *testing.T) {

--- a/internal/contractopenapidiff/fixture_matrix_test.go
+++ b/internal/contractopenapidiff/fixture_matrix_test.go
@@ -120,6 +120,24 @@ var openAPIDiffFixtureMatrix = []struct {
 		category:   categoryFailClosed,
 		failClosed: true,
 	},
+	{
+		name:       "unsupported-nullable-narrow",
+		fixture:    "unsupported-nullable-narrow",
+		category:   categoryFailClosed,
+		failClosed: true,
+	},
+	{
+		name:       "unsupported-additional-properties-narrow",
+		fixture:    "unsupported-additional-properties-narrow",
+		category:   categoryFailClosed,
+		failClosed: true,
+	},
+	{
+		name:       "unsupported-oneof-narrow",
+		fixture:    "unsupported-oneof-narrow",
+		category:   categoryFailClosed,
+		failClosed: true,
+	},
 }
 
 func TestCompareYAML_FixtureMatrix_ClassifiesRepresentativeCases(t *testing.T) {

--- a/internal/contractopenapidiff/fixture_matrix_test.go
+++ b/internal/contractopenapidiff/fixture_matrix_test.go
@@ -55,6 +55,18 @@ var openAPIDiffFixtureMatrix = []struct {
 		classification: contractopenapidiff.ClassificationMinor,
 	},
 	{
+		name:           "relax-parameter-required",
+		fixture:        "relax-parameter-required",
+		category:       categoryParameter,
+		classification: contractopenapidiff.ClassificationMinor,
+	},
+	{
+		name:           "relax-schema-required",
+		fixture:        "relax-schema-required",
+		category:       categoryRequestResponse,
+		classification: contractopenapidiff.ClassificationMinor,
+	},
+	{
 		name:           "remove-route",
 		fixture:        "remove-route",
 		category:       categoryRoute,
@@ -137,27 +149,5 @@ func TestCompareYAML_FixtureMatrix_ClassifiesRepresentativeCases(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-func TestCompareYAML_FixtureMatrix_CoversRequiredCategories(t *testing.T) {
-	t.Parallel()
-
-	required := []fixtureCategory{
-		categoryRoute,
-		categoryParameter,
-		categoryRequestResponse,
-		categoryEnum,
-		categoryDocsOnly,
-		categoryFailClosed,
-	}
-	covered := make(map[fixtureCategory]struct{}, len(required))
-	for _, tc := range openAPIDiffFixtureMatrix {
-		covered[tc.category] = struct{}{}
-	}
-	for _, category := range required {
-		if _, ok := covered[category]; !ok {
-			t.Fatalf("fixture matrix missing category %q", category)
-		}
 	}
 }

--- a/internal/contractopenapidiff/fixture_matrix_test.go
+++ b/internal/contractopenapidiff/fixture_matrix_test.go
@@ -157,6 +157,42 @@ var openAPIDiffFixtureMatrix = []struct {
 		failClosed: true,
 	},
 	{
+		name:           "remove-path-parameter",
+		fixture:        "remove-path-parameter",
+		category:       categoryParameter,
+		classification: contractopenapidiff.ClassificationMajor,
+	},
+	{
+		name:       "unsupported-operation-security",
+		fixture:    "unsupported-operation-security",
+		category:   categoryFailClosed,
+		failClosed: true,
+	},
+	{
+		name:       "unsupported-path-servers",
+		fixture:    "unsupported-path-servers",
+		category:   categoryFailClosed,
+		failClosed: true,
+	},
+	{
+		name:       "unsupported-media-type-encoding",
+		fixture:    "unsupported-media-type-encoding",
+		category:   categoryFailClosed,
+		failClosed: true,
+	},
+	{
+		name:       "unsupported-response-links",
+		fixture:    "unsupported-response-links",
+		category:   categoryFailClosed,
+		failClosed: true,
+	},
+	{
+		name:       "unsupported-operation-callbacks",
+		fixture:    "unsupported-operation-callbacks",
+		category:   categoryFailClosed,
+		failClosed: true,
+	},
+	{
 		name:       "unsupported-component-parameter-remove",
 		fixture:    "unsupported-component-parameter-remove",
 		category:   categoryFailClosed,

--- a/internal/contractopenapidiff/fixture_matrix_test.go
+++ b/internal/contractopenapidiff/fixture_matrix_test.go
@@ -193,6 +193,18 @@ var openAPIDiffFixtureMatrix = []struct {
 		failClosed: true,
 	},
 	{
+		name:       "unsupported-operation-servers",
+		fixture:    "unsupported-operation-servers",
+		category:   categoryFailClosed,
+		failClosed: true,
+	},
+	{
+		name:       "unsupported-server-variables",
+		fixture:    "unsupported-server-variables",
+		category:   categoryFailClosed,
+		failClosed: true,
+	},
+	{
 		name:       "unsupported-component-parameter-remove",
 		fixture:    "unsupported-component-parameter-remove",
 		category:   categoryFailClosed,

--- a/internal/contractopenapidiff/fixture_matrix_test.go
+++ b/internal/contractopenapidiff/fixture_matrix_test.go
@@ -97,6 +97,18 @@ var openAPIDiffFixtureMatrix = []struct {
 		classification: contractopenapidiff.ClassificationMajor,
 	},
 	{
+		name:           "narrow-inline-response-schema",
+		fixture:        "narrow-inline-response-schema",
+		category:       categoryRequestResponse,
+		classification: contractopenapidiff.ClassificationMajor,
+	},
+	{
+		name:           "add-inline-response-schema-property",
+		fixture:        "add-inline-response-schema-property",
+		category:       categoryRequestResponse,
+		classification: contractopenapidiff.ClassificationMinor,
+	},
+	{
 		name:           "major-wins-mixed",
 		fixture:        "major-wins-mixed",
 		category:       categoryRoute,

--- a/internal/contractopenapidiff/fixture_matrix_test.go
+++ b/internal/contractopenapidiff/fixture_matrix_test.go
@@ -205,6 +205,24 @@ var openAPIDiffFixtureMatrix = []struct {
 		failClosed: true,
 	},
 	{
+		name:       "unsupported-schema-extension",
+		fixture:    "unsupported-schema-extension",
+		category:   categoryFailClosed,
+		failClosed: true,
+	},
+	{
+		name:       "unsupported-operation-extension",
+		fixture:    "unsupported-operation-extension",
+		category:   categoryFailClosed,
+		failClosed: true,
+	},
+	{
+		name:       "unsupported-parameter-extension",
+		fixture:    "unsupported-parameter-extension",
+		category:   categoryFailClosed,
+		failClosed: true,
+	},
+	{
 		name:       "unsupported-component-parameter-remove",
 		fixture:    "unsupported-component-parameter-remove",
 		category:   categoryFailClosed,

--- a/internal/contractopenapidiff/structural.go
+++ b/internal/contractopenapidiff/structural.go
@@ -213,12 +213,17 @@ func collectOperationChanges(opPath string, before, after *openapi3.Operation) (
 	}
 	changes = append(changes, paramChanges...)
 
-	if err := compareRequestBodyStructural(opPath, before.RequestBody, after.RequestBody); err != nil {
+	requestBodyChanges, err := collectRequestBodyChanges(opPath, before.RequestBody, after.RequestBody)
+	if err != nil {
 		return nil, err
 	}
-	if err := compareResponsesStructural(opPath, before.Responses, after.Responses); err != nil {
+	changes = append(changes, requestBodyChanges...)
+
+	responseChanges, err := collectResponsesChanges(opPath, before.Responses, after.Responses)
+	if err != nil {
 		return nil, err
 	}
+	changes = append(changes, responseChanges...)
 	return changes, nil
 }
 
@@ -275,58 +280,64 @@ func collectParameterPairChanges(path string, before, after *openapi3.Parameter)
 	return append(changes, schemaChanges...), nil
 }
 
-func compareRequestBodyStructural(opPath string, before, after *openapi3.RequestBodyRef) error {
+func collectRequestBodyChanges(opPath string, before, after *openapi3.RequestBodyRef) ([]Change, error) {
 	beforeBody := requestBodyValue(before)
 	afterBody := requestBodyValue(after)
 	if beforeBody == nil && afterBody == nil {
-		return nil
+		return nil, nil
 	}
 	if beforeBody == nil || afterBody == nil {
-		return unsupportedStructuralDiff(opPath + ".requestBody")
+		return nil, unsupportedStructuralDiff(opPath + ".requestBody")
 	}
 	if beforeBody.Required != afterBody.Required {
-		return unsupportedStructuralDiff(opPath + ".requestBody.required")
+		return nil, unsupportedStructuralDiff(opPath + ".requestBody.required")
 	}
-	return compareMediaTypesStructural(opPath+".requestBody.content", beforeBody.Content, afterBody.Content)
+	return collectMediaTypeChanges(opPath+".requestBody.content", beforeBody.Content, afterBody.Content)
 }
 
-func compareResponsesStructural(opPath string, before, after *openapi3.Responses) error {
+func collectResponsesChanges(opPath string, before, after *openapi3.Responses) ([]Change, error) {
 	if before == nil || after == nil {
-		return unsupportedStructuralDiff(opPath + ".responses")
+		return nil, unsupportedStructuralDiff(opPath + ".responses")
 	}
 	beforeResponses := before.Map()
 	afterResponses := after.Map()
 	if len(beforeResponses) != len(afterResponses) {
-		return unsupportedStructuralDiff(opPath + ".responses")
+		return nil, unsupportedStructuralDiff(opPath + ".responses")
 	}
+	var changes []Change
 	for status, beforeResponseRef := range beforeResponses {
 		afterResponseRef := afterResponses[status]
 		beforeResponse := responseValue(beforeResponseRef)
 		afterResponse := responseValue(afterResponseRef)
 		if beforeResponse == nil || afterResponse == nil {
-			return unsupportedStructuralDiff(opPath + ".responses." + status)
+			return nil, unsupportedStructuralDiff(opPath + ".responses." + status)
 		}
-		if err := compareMediaTypesStructural(opPath+".responses."+status+".content", beforeResponse.Content, afterResponse.Content); err != nil {
-			return err
+		responseChanges, err := collectMediaTypeChanges(opPath+".responses."+status+".content", beforeResponse.Content, afterResponse.Content)
+		if err != nil {
+			return nil, err
 		}
+		changes = append(changes, responseChanges...)
 	}
-	return nil
+	return changes, nil
 }
 
-func compareMediaTypesStructural(path string, before, after openapi3.Content) error {
+func collectMediaTypeChanges(path string, before, after openapi3.Content) ([]Change, error) {
 	if len(before) != len(after) {
-		return unsupportedStructuralDiff(path)
+		return nil, unsupportedStructuralDiff(path)
 	}
+	var changes []Change
 	for mediaType, beforeMedia := range before {
 		afterMedia, ok := after[mediaType]
 		if !ok {
-			return unsupportedStructuralDiff(path + "." + mediaType)
+			return nil, unsupportedStructuralDiff(path + "." + mediaType)
 		}
-		if err := compareSchemaRefStructural(path+"."+mediaType+".schema", beforeMedia.Schema, afterMedia.Schema); err != nil {
-			return err
+		schemaChanges, err := collectSchemaRefChanges(path+"."+mediaType+".schema", beforeMedia.Schema, afterMedia.Schema)
+		if err != nil {
+			return nil, err
 		}
+		changes = append(changes, schemaChanges...)
 	}
-	return nil
+	return changes, nil
 }
 
 func collectComponentChanges(before, after *openapi3.Components) ([]Change, error) {
@@ -373,11 +384,6 @@ func collectSchemaRefChanges(path string, before, after *openapi3.SchemaRef) ([]
 		return nil, nil
 	}
 	return collectSchemaChanges(path, before.Value, after.Value)
-}
-
-func compareSchemaRefStructural(path string, before, after *openapi3.SchemaRef) error {
-	_, err := collectSchemaRefChanges(path, before, after)
-	return err
 }
 
 func collectSchemaChanges(path string, before, after *openapi3.Schema) ([]Change, error) {

--- a/internal/contractopenapidiff/structural.go
+++ b/internal/contractopenapidiff/structural.go
@@ -1,0 +1,364 @@
+package contractopenapidiff
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+func compareStructural(before, after *openapi3.T) error {
+	if before.OpenAPI != after.OpenAPI {
+		return unsupportedStructuralDiff("openapi")
+	}
+	if err := compareInfoStructural(before.Info, after.Info); err != nil {
+		return err
+	}
+	if err := compareServersStructural(before.Servers, after.Servers); err != nil {
+		return err
+	}
+	if err := compareSecurityStructural(before.Security, after.Security); err != nil {
+		return err
+	}
+	if err := compareTagsStructural(before.Tags, after.Tags); err != nil {
+		return err
+	}
+	if err := comparePathsStructural(before.Paths, after.Paths); err != nil {
+		return err
+	}
+	if err := compareComponentsStructural(before.Components, after.Components); err != nil {
+		return err
+	}
+	return nil
+}
+
+func compareInfoStructural(before, after *openapi3.Info) error {
+	if before == nil || after == nil {
+		return unsupportedStructuralDiff("info")
+	}
+	if before.Title != after.Title || before.Version != after.Version {
+		return unsupportedStructuralDiff("info")
+	}
+	if before.TermsOfService != after.TermsOfService {
+		return unsupportedStructuralDiff("info.termsOfService")
+	}
+	if !contactStructuralEqual(before.Contact, after.Contact) {
+		return unsupportedStructuralDiff("info.contact")
+	}
+	if !licenseStructuralEqual(before.License, after.License) {
+		return unsupportedStructuralDiff("info.license")
+	}
+	return nil
+}
+
+func contactStructuralEqual(before, after *openapi3.Contact) bool {
+	if before == nil && after == nil {
+		return true
+	}
+	if before == nil || after == nil {
+		return false
+	}
+	return before.Name == after.Name && before.URL == after.URL && before.Email == after.Email
+}
+
+func licenseStructuralEqual(before, after *openapi3.License) bool {
+	if before == nil && after == nil {
+		return true
+	}
+	if before == nil || after == nil {
+		return false
+	}
+	return before.Name == after.Name && before.URL == after.URL
+}
+
+func externalDocsStructuralEqual(before, after *openapi3.ExternalDocs) bool {
+	if before == nil && after == nil {
+		return true
+	}
+	if before == nil || after == nil {
+		return false
+	}
+	return before.URL == after.URL
+}
+
+func compareServersStructural(before, after openapi3.Servers) error {
+	if len(before) != len(after) {
+		return unsupportedStructuralDiff("servers")
+	}
+	for i := range before {
+		if before[i] == nil || after[i] == nil {
+			return unsupportedStructuralDiff("servers")
+		}
+		if before[i].URL != after[i].URL {
+			return unsupportedStructuralDiff("servers[" + fmt.Sprint(i) + "].url")
+		}
+	}
+	return nil
+}
+
+func compareSecurityStructural(before, after openapi3.SecurityRequirements) error {
+	if !reflect.DeepEqual(before, after) {
+		return unsupportedStructuralDiff("security")
+	}
+	return nil
+}
+
+func compareTagsStructural(before, after openapi3.Tags) error {
+	beforeByName := tagsByName(before)
+	afterByName := tagsByName(after)
+	if len(beforeByName) != len(afterByName) {
+		return unsupportedStructuralDiff("tags")
+	}
+	for name, beforeTag := range beforeByName {
+		afterTag, ok := afterByName[name]
+		if !ok {
+			return unsupportedStructuralDiff("tags." + name)
+		}
+		if beforeTag.Name != afterTag.Name {
+			return unsupportedStructuralDiff("tags." + name)
+		}
+		if !externalDocsStructuralEqual(beforeTag.ExternalDocs, afterTag.ExternalDocs) {
+			return unsupportedStructuralDiff("tags." + name + ".externalDocs")
+		}
+	}
+	return nil
+}
+
+func comparePathsStructural(before, after *openapi3.Paths) error {
+	if before == nil || after == nil {
+		return unsupportedStructuralDiff("paths")
+	}
+	beforePaths := before.Map()
+	afterPaths := after.Map()
+	if len(beforePaths) != len(afterPaths) {
+		return unsupportedStructuralDiff("paths")
+	}
+	for path := range beforePaths {
+		afterItem, ok := afterPaths[path]
+		if !ok {
+			return unsupportedStructuralDiff("paths." + path)
+		}
+		if err := comparePathItemStructural(path, beforePaths[path], afterItem); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func comparePathItemStructural(path string, before, after *openapi3.PathItem) error {
+	if before == nil || after == nil {
+		return unsupportedStructuralDiff("paths." + path)
+	}
+	beforeOps := before.Operations()
+	afterOps := after.Operations()
+	if len(beforeOps) != len(afterOps) {
+		return unsupportedStructuralDiff("paths." + path)
+	}
+	for method, beforeOperation := range beforeOps {
+		afterOperation := after.GetOperation(method)
+		if err := compareOperationStructural(operationPath(method, path), beforeOperation, afterOperation); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func compareOperationStructural(opPath string, before, after *openapi3.Operation) error {
+	if before == nil || after == nil {
+		return unsupportedStructuralDiff(opPath)
+	}
+	if before.OperationID != after.OperationID {
+		return unsupportedStructuralDiff(opPath + ".operationId")
+	}
+	if !reflect.DeepEqual(before.Tags, after.Tags) {
+		return unsupportedStructuralDiff(opPath + ".tags")
+	}
+	if before.Deprecated != after.Deprecated {
+		return unsupportedStructuralDiff(opPath + ".deprecated")
+	}
+	if err := compareParametersStructural(opPath, before.Parameters, after.Parameters); err != nil {
+		return err
+	}
+	if err := compareRequestBodyStructural(opPath, before.RequestBody, after.RequestBody); err != nil {
+		return err
+	}
+	if err := compareResponsesStructural(opPath, before.Responses, after.Responses); err != nil {
+		return err
+	}
+	return nil
+}
+
+func compareParametersStructural(opPath string, before, after openapi3.Parameters) error {
+	beforeByKey := parametersByKey(before)
+	afterByKey := parametersByKey(after)
+	if len(beforeByKey) != len(afterByKey) {
+		return unsupportedStructuralDiff(opPath + ".parameters")
+	}
+	for key, beforeParameter := range beforeByKey {
+		afterParameter, ok := afterByKey[key]
+		if !ok {
+			return unsupportedStructuralDiff(opPath + ".parameters[" + key + "]")
+		}
+		if err := compareParameterStructural(opPath+".parameters["+key+"]", beforeParameter, afterParameter); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func compareParameterStructural(path string, before, after *openapi3.Parameter) error {
+	if before == nil || after == nil {
+		return unsupportedStructuralDiff(path)
+	}
+	if before.Name != after.Name || before.In != after.In || before.Required != after.Required {
+		return unsupportedStructuralDiff(path)
+	}
+	if err := compareSchemaRefStructural(path+".schema", before.Schema, after.Schema); err != nil {
+		return err
+	}
+	return nil
+}
+
+func compareRequestBodyStructural(opPath string, before, after *openapi3.RequestBodyRef) error {
+	beforeBody := requestBodyValue(before)
+	afterBody := requestBodyValue(after)
+	if beforeBody == nil && afterBody == nil {
+		return nil
+	}
+	if beforeBody == nil || afterBody == nil {
+		return unsupportedStructuralDiff(opPath + ".requestBody")
+	}
+	if beforeBody.Required != afterBody.Required {
+		return unsupportedStructuralDiff(opPath + ".requestBody.required")
+	}
+	return compareMediaTypesStructural(opPath+".requestBody.content", beforeBody.Content, afterBody.Content)
+}
+
+func compareResponsesStructural(opPath string, before, after *openapi3.Responses) error {
+	if before == nil || after == nil {
+		return unsupportedStructuralDiff(opPath + ".responses")
+	}
+	beforeResponses := before.Map()
+	afterResponses := after.Map()
+	if len(beforeResponses) != len(afterResponses) {
+		return unsupportedStructuralDiff(opPath + ".responses")
+	}
+	for status, beforeResponseRef := range beforeResponses {
+		afterResponseRef := afterResponses[status]
+		beforeResponse := responseValue(beforeResponseRef)
+		afterResponse := responseValue(afterResponseRef)
+		if beforeResponse == nil || afterResponse == nil {
+			return unsupportedStructuralDiff(opPath + ".responses." + status)
+		}
+		if err := compareMediaTypesStructural(opPath+".responses."+status+".content", beforeResponse.Content, afterResponse.Content); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func compareMediaTypesStructural(path string, before, after openapi3.Content) error {
+	if len(before) != len(after) {
+		return unsupportedStructuralDiff(path)
+	}
+	for mediaType, beforeMedia := range before {
+		afterMedia, ok := after[mediaType]
+		if !ok {
+			return unsupportedStructuralDiff(path + "." + mediaType)
+		}
+		if err := compareSchemaRefStructural(path+"."+mediaType+".schema", beforeMedia.Schema, afterMedia.Schema); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func compareComponentsStructural(before, after *openapi3.Components) error {
+	if before == nil && after == nil {
+		return nil
+	}
+	if before == nil || after == nil {
+		return unsupportedStructuralDiff("components")
+	}
+	if len(before.Schemas) != len(after.Schemas) {
+		return unsupportedStructuralDiff("components.schemas")
+	}
+	for name, beforeSchemaRef := range before.Schemas {
+		afterSchemaRef, ok := after.Schemas[name]
+		if !ok {
+			return unsupportedStructuralDiff("components.schemas." + name)
+		}
+		if err := compareSchemaRefStructural("components.schemas."+name, beforeSchemaRef, afterSchemaRef); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func compareSchemaRefStructural(path string, before, after *openapi3.SchemaRef) error {
+	if before == nil && after == nil {
+		return nil
+	}
+	if before == nil || after == nil {
+		return unsupportedStructuralDiff(path)
+	}
+	if before.Ref != after.Ref {
+		return unsupportedStructuralDiff(path + ".ref")
+	}
+	if before.Ref != "" {
+		return nil
+	}
+	return compareSchemaStructural(path, before.Value, after.Value)
+}
+
+func compareSchemaStructural(path string, before, after *openapi3.Schema) error {
+	if before == nil || after == nil {
+		return unsupportedStructuralDiff(path)
+	}
+	if !typesEqual(before.Type, after.Type) {
+		return unsupportedStructuralDiff(path + ".type")
+	}
+	if before.Format != after.Format {
+		return unsupportedStructuralDiff(path + ".format")
+	}
+	if !reflect.DeepEqual(before.Enum, after.Enum) {
+		return unsupportedStructuralDiff(path + ".enum")
+	}
+	if !reflect.DeepEqual(before.Required, after.Required) {
+		return unsupportedStructuralDiff(path + ".required")
+	}
+	if !externalDocsStructuralEqual(before.ExternalDocs, after.ExternalDocs) {
+		return unsupportedStructuralDiff(path + ".externalDocs")
+	}
+	if len(before.Properties) != len(after.Properties) {
+		return unsupportedStructuralDiff(path + ".properties")
+	}
+	for propertyName, beforePropertyRef := range before.Properties {
+		afterPropertyRef, ok := after.Properties[propertyName]
+		if !ok {
+			return unsupportedStructuralDiff(path + ".properties." + propertyName)
+		}
+		if err := compareSchemaRefStructural(path+".properties."+propertyName, beforePropertyRef, afterPropertyRef); err != nil {
+			return err
+		}
+	}
+	if (before.Items == nil) != (after.Items == nil) {
+		return unsupportedStructuralDiff(path + ".items")
+	}
+	if before.Items != nil {
+		if err := compareSchemaRefStructural(path+".items", before.Items, after.Items); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func typesEqual(before, after *openapi3.Types) bool {
+	if before == nil && after == nil {
+		return true
+	}
+	if before == nil || after == nil {
+		return false
+	}
+	return reflect.DeepEqual(before.Slice(), after.Slice())
+}

--- a/internal/contractopenapidiff/structural.go
+++ b/internal/contractopenapidiff/structural.go
@@ -438,7 +438,149 @@ func collectSchemaChanges(path string, before, after *openapi3.Schema) ([]Change
 		}
 		changes = append(changes, itemChanges...)
 	}
+	if err := checkUnsupportedSchemaResiduals(path, before, after); err != nil {
+		return nil, err
+	}
 	return changes, nil
+}
+
+func checkUnsupportedSchemaResiduals(path string, before, after *openapi3.Schema) error {
+	if before.Nullable != after.Nullable {
+		return unsupportedStructuralDiff(path + ".nullable")
+	}
+	if !additionalPropertiesEqual(before.AdditionalProperties, after.AdditionalProperties) {
+		return unsupportedStructuralDiff(path + ".additionalProperties")
+	}
+	if before.MinLength != after.MinLength {
+		return unsupportedStructuralDiff(path + ".minLength")
+	}
+	if !uint64PtrEqual(before.MaxLength, after.MaxLength) {
+		return unsupportedStructuralDiff(path + ".maxLength")
+	}
+	if before.Pattern != after.Pattern {
+		return unsupportedStructuralDiff(path + ".pattern")
+	}
+	if !schemaRefsEqual(before.OneOf, after.OneOf) {
+		return unsupportedStructuralDiff(path + ".oneOf")
+	}
+	if !schemaRefsEqual(before.AnyOf, after.AnyOf) {
+		return unsupportedStructuralDiff(path + ".anyOf")
+	}
+	if !schemaRefsEqual(before.AllOf, after.AllOf) {
+		return unsupportedStructuralDiff(path + ".allOf")
+	}
+	if !schemaRefStructuralEqual(before.Not, after.Not) {
+		return unsupportedStructuralDiff(path + ".not")
+	}
+	if !anyEqual(before.Default, after.Default) {
+		return unsupportedStructuralDiff(path + ".default")
+	}
+	if !anyEqual(before.Example, after.Example) {
+		return unsupportedStructuralDiff(path + ".example")
+	}
+	if before.UniqueItems != after.UniqueItems {
+		return unsupportedStructuralDiff(path + ".uniqueItems")
+	}
+	if before.ExclusiveMin != after.ExclusiveMin {
+		return unsupportedStructuralDiff(path + ".exclusiveMinimum")
+	}
+	if before.ExclusiveMax != after.ExclusiveMax {
+		return unsupportedStructuralDiff(path + ".exclusiveMaximum")
+	}
+	if before.ReadOnly != after.ReadOnly {
+		return unsupportedStructuralDiff(path + ".readOnly")
+	}
+	if before.WriteOnly != after.WriteOnly {
+		return unsupportedStructuralDiff(path + ".writeOnly")
+	}
+	if before.AllowEmptyValue != after.AllowEmptyValue {
+		return unsupportedStructuralDiff(path + ".allowEmptyValue")
+	}
+	if before.Deprecated != after.Deprecated {
+		return unsupportedStructuralDiff(path + ".deprecated")
+	}
+	if !float64PtrEqual(before.Min, after.Min) {
+		return unsupportedStructuralDiff(path + ".minimum")
+	}
+	if !float64PtrEqual(before.Max, after.Max) {
+		return unsupportedStructuralDiff(path + ".maximum")
+	}
+	if !float64PtrEqual(before.MultipleOf, after.MultipleOf) {
+		return unsupportedStructuralDiff(path + ".multipleOf")
+	}
+	if before.MinItems != after.MinItems {
+		return unsupportedStructuralDiff(path + ".minItems")
+	}
+	if !uint64PtrEqual(before.MaxItems, after.MaxItems) {
+		return unsupportedStructuralDiff(path + ".maxItems")
+	}
+	if before.MinProps != after.MinProps {
+		return unsupportedStructuralDiff(path + ".minProperties")
+	}
+	if !uint64PtrEqual(before.MaxProps, after.MaxProps) {
+		return unsupportedStructuralDiff(path + ".maxProperties")
+	}
+	if !reflect.DeepEqual(before.XML, after.XML) {
+		return unsupportedStructuralDiff(path + ".xml")
+	}
+	if !reflect.DeepEqual(before.Discriminator, after.Discriminator) {
+		return unsupportedStructuralDiff(path + ".discriminator")
+	}
+	return nil
+}
+
+func additionalPropertiesEqual(before, after openapi3.AdditionalProperties) bool {
+	if (before.Has == nil) != (after.Has == nil) {
+		return false
+	}
+	if before.Has != nil && after.Has != nil && *before.Has != *after.Has {
+		return false
+	}
+	return schemaRefStructuralEqual(before.Schema, after.Schema)
+}
+
+func schemaRefsEqual(before, after openapi3.SchemaRefs) bool {
+	return reflect.DeepEqual(before, after)
+}
+
+func schemaRefStructuralEqual(before, after *openapi3.SchemaRef) bool {
+	if before == nil && after == nil {
+		return true
+	}
+	if before == nil || after == nil {
+		return false
+	}
+	if before.Ref != after.Ref {
+		return false
+	}
+	if before.Ref != "" {
+		return true
+	}
+	return reflect.DeepEqual(before.Value, after.Value)
+}
+
+func float64PtrEqual(before, after *float64) bool {
+	if before == nil && after == nil {
+		return true
+	}
+	if before == nil || after == nil {
+		return false
+	}
+	return *before == *after
+}
+
+func uint64PtrEqual(before, after *uint64) bool {
+	if before == nil && after == nil {
+		return true
+	}
+	if before == nil || after == nil {
+		return false
+	}
+	return *before == *after
+}
+
+func anyEqual(before, after any) bool {
+	return reflect.DeepEqual(before, after)
 }
 
 func collectEnumChanges(path string, before, after []any) ([]Change, error) {

--- a/internal/contractopenapidiff/structural.go
+++ b/internal/contractopenapidiff/structural.go
@@ -261,8 +261,11 @@ func collectParameterPairChanges(path string, before, after *openapi3.Parameter)
 	}
 	var changes []Change
 	if before.Required != after.Required {
-		if after.Required && !before.Required {
+		switch {
+		case after.Required && !before.Required:
 			changes = appendMajorChange(changes, CodeParameterRequiredNarrowed, path)
+		case before.Required && !after.Required:
+			changes = appendMinorChange(changes, CodeParameterRequiredRelaxed, path)
 		}
 	}
 	schemaChanges, err := collectSchemaRefChanges(path+".schema", before.Schema, after.Schema)
@@ -270,11 +273,6 @@ func collectParameterPairChanges(path string, before, after *openapi3.Parameter)
 		return nil, err
 	}
 	return append(changes, schemaChanges...), nil
-}
-
-func compareParameterStructural(path string, before, after *openapi3.Parameter) error {
-	_, err := collectParameterPairChanges(path, before, after)
-	return err
 }
 
 func compareRequestBodyStructural(opPath string, before, after *openapi3.RequestBodyRef) error {
@@ -393,7 +391,7 @@ func collectSchemaChanges(path string, before, after *openapi3.Schema) ([]Change
 	if before.Format != after.Format {
 		changes = appendMajorChange(changes, CodeSchemaTypeNarrowed, path+".format")
 	}
-	changes = append(changes, collectRequiredNarrowingChanges(path, before.Required, after.Required)...)
+	changes = append(changes, collectRequiredChanges(path, before.Required, after.Required)...)
 	if !externalDocsStructuralEqual(before.ExternalDocs, after.ExternalDocs) {
 		return nil, unsupportedStructuralDiff(path + ".externalDocs")
 	}
@@ -437,11 +435,6 @@ func collectSchemaChanges(path string, before, after *openapi3.Schema) ([]Change
 	return changes, nil
 }
 
-func compareSchemaStructural(path string, before, after *openapi3.Schema) error {
-	_, err := collectSchemaChanges(path, before, after)
-	return err
-}
-
 func collectEnumChanges(path string, before, after []any) ([]Change, error) {
 	beforeValues := enumValueSet(before)
 	afterValues := enumValueSet(after)
@@ -460,14 +453,21 @@ func collectEnumChanges(path string, before, after []any) ([]Change, error) {
 	return changes, nil
 }
 
-func collectRequiredNarrowingChanges(path string, beforeRequired, afterRequired []string) []Change {
+func collectRequiredChanges(path string, beforeRequired, afterRequired []string) []Change {
 	beforeSet := stringSet(beforeRequired)
+	afterSet := stringSet(afterRequired)
 	var changes []Change
 	for _, name := range afterRequired {
 		if _, ok := beforeSet[name]; ok {
 			continue
 		}
 		changes = appendMajorChange(changes, CodeSchemaRequiredNarrowed, path+".required."+name)
+	}
+	for _, name := range beforeRequired {
+		if _, ok := afterSet[name]; ok {
+			continue
+		}
+		changes = appendMinorChange(changes, CodeSchemaRequiredRelaxed, path+".required."+name)
 	}
 	return changes
 }

--- a/internal/contractopenapidiff/structural.go
+++ b/internal/contractopenapidiff/structural.go
@@ -134,13 +134,18 @@ func collectPathChanges(before, after *openapi3.Paths) ([]Change, error) {
 	beforePaths := before.Map()
 	afterPaths := after.Map()
 
+	var changes []Change
 	for path := range beforePaths {
-		if _, ok := afterPaths[path]; !ok {
+		if afterItem, ok := afterPaths[path]; !ok {
+			for method := range beforePaths[path].Operations() {
+				changes = appendMajorChange(changes, CodeOperationRemoved, operationPath(method, path))
+			}
+			continue
+		} else if beforePaths[path] == nil || afterItem == nil {
 			return nil, unsupportedStructuralDiff("paths." + path)
 		}
 	}
 
-	var changes []Change
 	for path, afterItem := range afterPaths {
 		beforeItem, ok := beforePaths[path]
 		if !ok {
@@ -165,13 +170,13 @@ func collectPathItemChanges(path string, before, after *openapi3.PathItem) ([]Ch
 	beforeOps := before.Operations()
 	afterOps := after.Operations()
 
+	var changes []Change
 	for method := range beforeOps {
 		if after.GetOperation(method) == nil {
-			return nil, unsupportedStructuralDiff(operationPath(method, path))
+			changes = appendMajorChange(changes, CodeOperationRemoved, operationPath(method, path))
 		}
 	}
 
-	var changes []Change
 	for method, afterOperation := range afterOps {
 		beforeOperation := before.GetOperation(method)
 		if beforeOperation == nil {
@@ -221,37 +226,55 @@ func collectParameterChanges(opPath string, before, after openapi3.Parameters) (
 	beforeByKey := parametersByKey(before)
 	afterByKey := parametersByKey(after)
 
+	var changes []Change
 	for key := range beforeByKey {
 		if _, ok := afterByKey[key]; !ok {
-			return nil, unsupportedStructuralDiff(opPath + ".parameters[" + key + "]")
+			changes = appendMajorChange(changes, CodeParameterRemoved, opPath+".parameters["+key+"]")
 		}
 	}
 
-	var changes []Change
 	for key, afterParameter := range afterByKey {
 		beforeParameter, ok := beforeByKey[key]
 		if !ok {
 			if afterParameter.Required {
-				return nil, unsupportedStructuralDiff(opPath + ".parameters[" + key + "]")
+				changes = appendMajorChange(changes, CodeParameterRequiredNarrowed, opPath+".parameters["+key+"]")
+			} else {
+				changes = appendMinorChange(changes, CodeParameterAdded, opPath+".parameters["+key+"]")
 			}
-			changes = appendMinorChange(changes, CodeParameterAdded, opPath+".parameters["+key+"]")
 			continue
 		}
-		if err := compareParameterStructural(opPath+".parameters["+key+"]", beforeParameter, afterParameter); err != nil {
+		paramChanges, err := collectParameterPairChanges(opPath+".parameters["+key+"]", beforeParameter, afterParameter)
+		if err != nil {
 			return nil, err
 		}
+		changes = append(changes, paramChanges...)
 	}
 	return changes, nil
 }
 
-func compareParameterStructural(path string, before, after *openapi3.Parameter) error {
+func collectParameterPairChanges(path string, before, after *openapi3.Parameter) ([]Change, error) {
 	if before == nil || after == nil {
-		return unsupportedStructuralDiff(path)
+		return nil, unsupportedStructuralDiff(path)
 	}
-	if before.Name != after.Name || before.In != after.In || before.Required != after.Required {
-		return unsupportedStructuralDiff(path)
+	if before.Name != after.Name || before.In != after.In {
+		return nil, unsupportedStructuralDiff(path)
 	}
-	return compareSchemaRefStructural(path+".schema", before.Schema, after.Schema)
+	var changes []Change
+	if before.Required != after.Required {
+		if after.Required && !before.Required {
+			changes = appendMajorChange(changes, CodeParameterRequiredNarrowed, path)
+		}
+	}
+	schemaChanges, err := collectSchemaRefChanges(path+".schema", before.Schema, after.Schema)
+	if err != nil {
+		return nil, err
+	}
+	return append(changes, schemaChanges...), nil
+}
+
+func compareParameterStructural(path string, before, after *openapi3.Parameter) error {
+	_, err := collectParameterPairChanges(path, before, after)
+	return err
 }
 
 func compareRequestBodyStructural(opPath string, before, after *openapi3.RequestBodyRef) error {
@@ -316,13 +339,13 @@ func collectComponentChanges(before, after *openapi3.Components) ([]Change, erro
 		return nil, unsupportedStructuralDiff("components")
 	}
 
+	var changes []Change
 	for name := range before.Schemas {
 		if _, ok := after.Schemas[name]; !ok {
-			return nil, unsupportedStructuralDiff("components.schemas." + name)
+			changes = appendMajorChange(changes, CodeSchemaRemoved, "components.schemas."+name)
 		}
 	}
 
-	var changes []Change
 	for name, afterSchemaRef := range after.Schemas {
 		beforeSchemaRef, ok := before.Schemas[name]
 		if !ok {
@@ -363,20 +386,17 @@ func collectSchemaChanges(path string, before, after *openapi3.Schema) ([]Change
 	if before == nil || after == nil {
 		return nil, unsupportedStructuralDiff(path)
 	}
+	var changes []Change
 	if !typesEqual(before.Type, after.Type) {
-		return nil, unsupportedStructuralDiff(path + ".type")
+		changes = appendMajorChange(changes, CodeSchemaTypeNarrowed, path+".type")
 	}
 	if before.Format != after.Format {
-		return nil, unsupportedStructuralDiff(path + ".format")
+		changes = appendMajorChange(changes, CodeSchemaTypeNarrowed, path+".format")
 	}
-	if !reflect.DeepEqual(before.Required, after.Required) {
-		return nil, unsupportedStructuralDiff(path + ".required")
-	}
+	changes = append(changes, collectRequiredNarrowingChanges(path, before.Required, after.Required)...)
 	if !externalDocsStructuralEqual(before.ExternalDocs, after.ExternalDocs) {
 		return nil, unsupportedStructuralDiff(path + ".externalDocs")
 	}
-
-	var changes []Change
 	enumChanges, err := collectEnumChanges(path, before.Enum, after.Enum)
 	if err != nil {
 		return nil, err
@@ -385,16 +405,17 @@ func collectSchemaChanges(path string, before, after *openapi3.Schema) ([]Change
 
 	for propertyName := range before.Properties {
 		if _, ok := after.Properties[propertyName]; !ok {
-			return nil, unsupportedStructuralDiff(path + ".properties." + propertyName)
+			changes = appendMajorChange(changes, CodeSchemaPropertyRemoved, path+".properties."+propertyName)
 		}
 	}
 	for propertyName, afterPropertyRef := range after.Properties {
 		beforePropertyRef, ok := before.Properties[propertyName]
 		if !ok {
 			if slices.Contains(after.Required, propertyName) {
-				return nil, unsupportedStructuralDiff(path + ".properties." + propertyName)
+				changes = appendMajorChange(changes, CodeSchemaRequiredNarrowed, path+".properties."+propertyName)
+			} else {
+				changes = appendMinorChange(changes, CodeSchemaPropertyAdded, path+".properties."+propertyName)
 			}
-			changes = appendMinorChange(changes, CodeSchemaPropertyAdded, path+".properties."+propertyName)
 			continue
 		}
 		propertyChanges, err := collectSchemaRefChanges(path+".properties."+propertyName, beforePropertyRef, afterPropertyRef)
@@ -424,12 +445,12 @@ func compareSchemaStructural(path string, before, after *openapi3.Schema) error 
 func collectEnumChanges(path string, before, after []any) ([]Change, error) {
 	beforeValues := enumValueSet(before)
 	afterValues := enumValueSet(after)
+	var changes []Change
 	for value := range beforeValues {
 		if _, ok := afterValues[value]; !ok {
-			return nil, unsupportedStructuralDiff(path + ".enum")
+			changes = appendMajorChange(changes, CodeEnumValueRemoved, path+".enum."+enumValuePath(value))
 		}
 	}
-	var changes []Change
 	for value := range afterValues {
 		if _, ok := beforeValues[value]; ok {
 			continue
@@ -437,6 +458,26 @@ func collectEnumChanges(path string, before, after []any) ([]Change, error) {
 		changes = appendMinorChange(changes, CodeEnumValueAdded, path+".enum."+enumValuePath(value))
 	}
 	return changes, nil
+}
+
+func collectRequiredNarrowingChanges(path string, beforeRequired, afterRequired []string) []Change {
+	beforeSet := stringSet(beforeRequired)
+	var changes []Change
+	for _, name := range afterRequired {
+		if _, ok := beforeSet[name]; ok {
+			continue
+		}
+		changes = appendMajorChange(changes, CodeSchemaRequiredNarrowed, path+".required."+name)
+	}
+	return changes
+}
+
+func stringSet(values []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		out[value] = struct{}{}
+	}
+	return out
 }
 
 func enumValueSet(values []any) map[string]struct{} {

--- a/internal/contractopenapidiff/structural.go
+++ b/internal/contractopenapidiff/structural.go
@@ -85,15 +85,19 @@ func externalDocsStructuralEqual(before, after *openapi3.ExternalDocs) bool {
 }
 
 func compareServersStructural(before, after openapi3.Servers) error {
+	return compareServersAt("servers", before, after)
+}
+
+func compareServersAt(path string, before, after openapi3.Servers) error {
 	if len(before) != len(after) {
-		return unsupportedStructuralDiff("servers")
+		return unsupportedStructuralDiff(path)
 	}
 	for i := range before {
 		if before[i] == nil || after[i] == nil {
-			return unsupportedStructuralDiff("servers")
+			return unsupportedStructuralDiff(path)
 		}
 		if before[i].URL != after[i].URL {
-			return unsupportedStructuralDiff("servers[" + fmt.Sprint(i) + "].url")
+			return unsupportedStructuralDiff(path + "[" + fmt.Sprint(i) + "].url")
 		}
 	}
 	return nil
@@ -167,10 +171,18 @@ func collectPathItemChanges(path string, before, after *openapi3.PathItem) ([]Ch
 	if before == nil || after == nil {
 		return nil, unsupportedStructuralDiff("paths." + path)
 	}
+	var changes []Change
+	pathParamChanges, err := collectParameterChanges(path, before.Parameters, after.Parameters)
+	if err != nil {
+		return nil, err
+	}
+	changes = append(changes, pathParamChanges...)
+	if err := compareServersAt(path+".servers", before.Servers, after.Servers); err != nil {
+		return nil, err
+	}
+
 	beforeOps := before.Operations()
 	afterOps := after.Operations()
-
-	var changes []Change
 	for method := range beforeOps {
 		if after.GetOperation(method) == nil {
 			changes = appendMajorChange(changes, CodeOperationRemoved, operationPath(method, path))
@@ -204,6 +216,12 @@ func collectOperationChanges(opPath string, before, after *openapi3.Operation) (
 	}
 	if before.Deprecated != after.Deprecated {
 		return nil, unsupportedStructuralDiff(opPath + ".deprecated")
+	}
+	if err := checkUnsupportedOperationSecurity(opPath, before, after); err != nil {
+		return nil, err
+	}
+	if err := checkUnsupportedOperationCallbacks(opPath, before, after); err != nil {
+		return nil, err
 	}
 
 	var changes []Change
@@ -319,6 +337,9 @@ func collectResponsesChanges(opPath string, before, after *openapi3.Responses) (
 		if err := checkUnsupportedResponseHeaders(opPath+".responses."+status+".headers", beforeResponse.Headers, afterResponse.Headers); err != nil {
 			return nil, err
 		}
+		if err := checkUnsupportedResponseLinks(opPath+".responses."+status+".links", beforeResponse.Links, afterResponse.Links); err != nil {
+			return nil, err
+		}
 		responseChanges, err := collectMediaTypeChanges(opPath+".responses."+status+".content", beforeResponse.Content, afterResponse.Content)
 		if err != nil {
 			return nil, err
@@ -338,11 +359,15 @@ func collectMediaTypeChanges(path string, before, after openapi3.Content) ([]Cha
 		if !ok {
 			return nil, unsupportedStructuralDiff(path + "." + mediaType)
 		}
-		schemaChanges, err := collectSchemaRefChanges(path+"."+mediaType+".schema", beforeMedia.Schema, afterMedia.Schema)
+		mediaPath := path + "." + mediaType
+		schemaChanges, err := collectSchemaRefChanges(mediaPath+".schema", beforeMedia.Schema, afterMedia.Schema)
 		if err != nil {
 			return nil, err
 		}
 		changes = append(changes, schemaChanges...)
+		if err := checkUnsupportedMediaTypeResiduals(mediaPath, beforeMedia, afterMedia); err != nil {
+			return nil, err
+		}
 	}
 	return changes, nil
 }
@@ -378,6 +403,70 @@ func collectComponentChanges(before, after *openapi3.Components) ([]Change, erro
 		return nil, err
 	}
 	return changes, nil
+}
+
+func checkUnsupportedOperationSecurity(opPath string, before, after *openapi3.Operation) error {
+	if securityRequirementsEqual(before.Security, after.Security) {
+		return nil
+	}
+	return unsupportedStructuralDiff(opPath + ".security")
+}
+
+func securityRequirementsEqual(before, after *openapi3.SecurityRequirements) bool {
+	if before == nil && after == nil {
+		return true
+	}
+	if before == nil || after == nil {
+		return false
+	}
+	return reflect.DeepEqual(*before, *after)
+}
+
+func checkUnsupportedOperationCallbacks(opPath string, before, after *openapi3.Operation) error {
+	return checkNamedMapResidual(opPath+".callbacks", before.Callbacks, after.Callbacks)
+}
+
+func checkUnsupportedMediaTypeResiduals(path string, before, after *openapi3.MediaType) error {
+	if !anyEqual(before.Example, after.Example) {
+		return unsupportedStructuralDiff(path + ".example")
+	}
+	if !reflect.DeepEqual(before.Examples, after.Examples) {
+		return unsupportedStructuralDiff(path + ".examples")
+	}
+	return checkNamedMapResidual(path+".encoding", before.Encoding, after.Encoding)
+}
+
+func checkUnsupportedResponseLinks(path string, before, after openapi3.Links) error {
+	return checkNamedMapResidual(path, before, after)
+}
+
+func checkNamedMapResidual[T any](path string, before, after map[string]T) error {
+	if reflect.DeepEqual(before, after) {
+		return nil
+	}
+	allNames := make(map[string]struct{})
+	for name := range before {
+		allNames[name] = struct{}{}
+	}
+	for name := range after {
+		allNames[name] = struct{}{}
+	}
+	names := make([]string, 0, len(allNames))
+	for name := range allNames {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	for _, name := range names {
+		beforeValue, beforeOK := before[name]
+		afterValue, afterOK := after[name]
+		if !beforeOK || !afterOK {
+			return unsupportedStructuralDiff(path + "." + name)
+		}
+		if !reflect.DeepEqual(beforeValue, afterValue) {
+			return unsupportedStructuralDiff(path + "." + name)
+		}
+	}
+	return unsupportedStructuralDiff(path)
 }
 
 func checkUnsupportedParameterResiduals(path string, before, after *openapi3.Parameter) error {
@@ -466,32 +555,7 @@ func checkUnsupportedComponentResiduals(before, after *openapi3.Components) erro
 }
 
 func checkComponentMapResidual[T any](path string, before, after map[string]T) error {
-	if reflect.DeepEqual(before, after) {
-		return nil
-	}
-	allNames := make(map[string]struct{})
-	for name := range before {
-		allNames[name] = struct{}{}
-	}
-	for name := range after {
-		allNames[name] = struct{}{}
-	}
-	names := make([]string, 0, len(allNames))
-	for name := range allNames {
-		names = append(names, name)
-	}
-	slices.Sort(names)
-	for _, name := range names {
-		beforeValue, beforeOK := before[name]
-		afterValue, afterOK := after[name]
-		if !beforeOK || !afterOK {
-			return unsupportedStructuralDiff(path + "." + name)
-		}
-		if !reflect.DeepEqual(beforeValue, afterValue) {
-			return unsupportedStructuralDiff(path + "." + name)
-		}
-	}
-	return unsupportedStructuralDiff(path)
+	return checkNamedMapResidual(path, before, after)
 }
 
 func boolPtrEqual(before, after *bool) bool {

--- a/internal/contractopenapidiff/structural.go
+++ b/internal/contractopenapidiff/structural.go
@@ -12,6 +12,9 @@ func collectStructuralChanges(before, after *openapi3.T) ([]Change, error) {
 	if before.OpenAPI != after.OpenAPI {
 		return nil, unsupportedStructuralDiff("openapi")
 	}
+	if err := checkUnsupportedExtensions("openapi", before.Extensions, after.Extensions); err != nil {
+		return nil, err
+	}
 	if err := compareInfoStructural(before.Info, after.Info); err != nil {
 		return nil, err
 	}
@@ -38,6 +41,9 @@ func collectStructuralChanges(before, after *openapi3.T) ([]Change, error) {
 func compareInfoStructural(before, after *openapi3.Info) error {
 	if before == nil || after == nil {
 		return unsupportedStructuralDiff("info")
+	}
+	if err := checkUnsupportedExtensions("info", before.Extensions, after.Extensions); err != nil {
+		return err
 	}
 	if before.Title != after.Title || before.Version != after.Version {
 		return unsupportedStructuralDiff("info")
@@ -99,6 +105,9 @@ func compareServersAt(path string, before, after openapi3.Servers) error {
 		if before[i].URL != after[i].URL {
 			return unsupportedStructuralDiff(path + "[" + fmt.Sprint(i) + "].url")
 		}
+		if err := checkUnsupportedExtensions(path+"["+fmt.Sprint(i)+"]", before[i].Extensions, after[i].Extensions); err != nil {
+			return err
+		}
 		if err := compareServerVariablesAt(path+"["+fmt.Sprint(i)+"].variables", before[i].Variables, after[i].Variables); err != nil {
 			return err
 		}
@@ -125,6 +134,9 @@ func compareServerVariablesAt(path string, before, after map[string]*openapi3.Se
 		}
 		if beforeVariable == nil || afterVariable == nil {
 			return unsupportedStructuralDiff(path + "." + name)
+		}
+		if err := checkUnsupportedExtensions(path+"."+name, beforeVariable.Extensions, afterVariable.Extensions); err != nil {
+			return err
 		}
 		if beforeVariable.Default != afterVariable.Default {
 			return unsupportedStructuralDiff(path + "." + name + ".default")
@@ -159,6 +171,9 @@ func compareTagsStructural(before, after openapi3.Tags) error {
 		}
 		if !externalDocsStructuralEqual(beforeTag.ExternalDocs, afterTag.ExternalDocs) {
 			return unsupportedStructuralDiff("tags." + name + ".externalDocs")
+		}
+		if err := checkUnsupportedExtensions("tags."+name, beforeTag.Extensions, afterTag.Extensions); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -203,6 +218,9 @@ func collectPathChanges(before, after *openapi3.Paths) ([]Change, error) {
 func collectPathItemChanges(path string, before, after *openapi3.PathItem) ([]Change, error) {
 	if before == nil || after == nil {
 		return nil, unsupportedStructuralDiff("paths." + path)
+	}
+	if err := checkUnsupportedExtensions(path, before.Extensions, after.Extensions); err != nil {
+		return nil, err
 	}
 	var changes []Change
 	pathParamChanges, err := collectParameterChanges(path, before.Parameters, after.Parameters)
@@ -250,6 +268,9 @@ func collectOperationChanges(opPath string, before, after *openapi3.Operation) (
 	if before.Deprecated != after.Deprecated {
 		return nil, unsupportedStructuralDiff(opPath + ".deprecated")
 	}
+	if err := checkUnsupportedExtensions(opPath, before.Extensions, after.Extensions); err != nil {
+		return nil, err
+	}
 	if err := checkUnsupportedOperationSecurity(opPath, before, after); err != nil {
 		return nil, err
 	}
@@ -295,6 +316,9 @@ func collectParameterChanges(opPath string, before, after openapi3.Parameters) (
 	for key, afterParameter := range afterByKey {
 		beforeParameter, ok := beforeByKey[key]
 		if !ok {
+			if err := checkUnsupportedExtensions(opPath+".parameters["+key+"]", nil, afterParameter.Extensions); err != nil {
+				return nil, err
+			}
 			if afterParameter.Required {
 				changes = appendMajorChange(changes, CodeParameterRequiredNarrowed, opPath+".parameters["+key+"]")
 			} else {
@@ -317,6 +341,9 @@ func collectParameterPairChanges(path string, before, after *openapi3.Parameter)
 	}
 	if before.Name != after.Name || before.In != after.In {
 		return nil, unsupportedStructuralDiff(path)
+	}
+	if err := checkUnsupportedExtensions(path, before.Extensions, after.Extensions); err != nil {
+		return nil, err
 	}
 	var changes []Change
 	if before.Required != after.Required {
@@ -347,6 +374,12 @@ func collectRequestBodyChanges(opPath string, before, after *openapi3.RequestBod
 	if beforeBody == nil || afterBody == nil {
 		return nil, unsupportedStructuralDiff(opPath + ".requestBody")
 	}
+	if err := checkUnsupportedRefExtensions(opPath+".requestBody", before.Extensions, after.Extensions); err != nil {
+		return nil, err
+	}
+	if err := checkUnsupportedExtensions(opPath+".requestBody", beforeBody.Extensions, afterBody.Extensions); err != nil {
+		return nil, err
+	}
 	if beforeBody.Required != afterBody.Required {
 		return nil, unsupportedStructuralDiff(opPath + ".requestBody.required")
 	}
@@ -376,6 +409,12 @@ func collectResponsesChanges(opPath string, before, after *openapi3.Responses) (
 		if err := checkUnsupportedResponseLinks(opPath+".responses."+status+".links", beforeResponse.Links, afterResponse.Links); err != nil {
 			return nil, err
 		}
+		if err := checkUnsupportedRefExtensions(opPath+".responses."+status, beforeResponseRef.Extensions, afterResponseRef.Extensions); err != nil {
+			return nil, err
+		}
+		if err := checkUnsupportedExtensions(opPath+".responses."+status, beforeResponse.Extensions, afterResponse.Extensions); err != nil {
+			return nil, err
+		}
 		responseChanges, err := collectMediaTypeChanges(opPath+".responses."+status+".content", beforeResponse.Content, afterResponse.Content)
 		if err != nil {
 			return nil, err
@@ -401,6 +440,9 @@ func collectMediaTypeChanges(path string, before, after openapi3.Content) ([]Cha
 			return nil, err
 		}
 		changes = append(changes, schemaChanges...)
+		if err := checkUnsupportedExtensions(mediaPath, beforeMedia.Extensions, afterMedia.Extensions); err != nil {
+			return nil, err
+		}
 		if err := checkUnsupportedMediaTypeResiduals(mediaPath, beforeMedia, afterMedia); err != nil {
 			return nil, err
 		}
@@ -434,6 +476,9 @@ func collectComponentChanges(before, after *openapi3.Components) ([]Change, erro
 			return nil, err
 		}
 		changes = append(changes, schemaChanges...)
+	}
+	if err := checkUnsupportedExtensions("components", before.Extensions, after.Extensions); err != nil {
+		return nil, err
 	}
 	if err := checkUnsupportedComponentResiduals(before, after); err != nil {
 		return nil, err
@@ -484,6 +529,39 @@ func checkUnsupportedMediaTypeResiduals(path string, before, after *openapi3.Med
 
 func checkUnsupportedResponseLinks(path string, before, after openapi3.Links) error {
 	return checkNamedMapResidual(path, before, after)
+}
+
+func checkUnsupportedRefExtensions(path string, before, after map[string]any) error {
+	return checkUnsupportedExtensions(path, before, after)
+}
+
+func checkUnsupportedExtensions(path string, before, after map[string]any) error {
+	if len(before) == 0 && len(after) == 0 {
+		return nil
+	}
+	allKeys := make(map[string]struct{})
+	for key := range before {
+		allKeys[key] = struct{}{}
+	}
+	for key := range after {
+		allKeys[key] = struct{}{}
+	}
+	keys := make([]string, 0, len(allKeys))
+	for key := range allKeys {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	for _, key := range keys {
+		beforeValue, beforeOK := before[key]
+		afterValue, afterOK := after[key]
+		if !beforeOK || !afterOK {
+			return unsupportedStructuralDiff(path + "." + key)
+		}
+		if !reflect.DeepEqual(beforeValue, afterValue) {
+			return unsupportedStructuralDiff(path + "." + key)
+		}
+	}
+	return nil
 }
 
 func checkNamedMapResidual[T any](path string, before, after map[string]T) error {
@@ -621,6 +699,9 @@ func collectSchemaRefChanges(path string, before, after *openapi3.SchemaRef) ([]
 	if before == nil || after == nil {
 		return nil, unsupportedStructuralDiff(path)
 	}
+	if err := checkUnsupportedExtensions(path, before.Extensions, after.Extensions); err != nil {
+		return nil, err
+	}
 	if before.Ref != after.Ref {
 		return nil, unsupportedStructuralDiff(path + ".ref")
 	}
@@ -633,6 +714,9 @@ func collectSchemaRefChanges(path string, before, after *openapi3.SchemaRef) ([]
 func collectSchemaChanges(path string, before, after *openapi3.Schema) ([]Change, error) {
 	if before == nil || after == nil {
 		return nil, unsupportedStructuralDiff(path)
+	}
+	if err := checkUnsupportedExtensions(path, before.Extensions, after.Extensions); err != nil {
+		return nil, err
 	}
 	var changes []Change
 	if !typesEqual(before.Type, after.Type) {

--- a/internal/contractopenapidiff/structural.go
+++ b/internal/contractopenapidiff/structural.go
@@ -99,6 +99,39 @@ func compareServersAt(path string, before, after openapi3.Servers) error {
 		if before[i].URL != after[i].URL {
 			return unsupportedStructuralDiff(path + "[" + fmt.Sprint(i) + "].url")
 		}
+		if err := compareServerVariablesAt(path+"["+fmt.Sprint(i)+"].variables", before[i].Variables, after[i].Variables); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func compareServerVariablesAt(path string, before, after map[string]*openapi3.ServerVariable) error {
+	if len(before) == 0 && len(after) == 0 {
+		return nil
+	}
+	allNames := make(map[string]struct{})
+	for name := range before {
+		allNames[name] = struct{}{}
+	}
+	for name := range after {
+		allNames[name] = struct{}{}
+	}
+	for name := range allNames {
+		beforeVariable := before[name]
+		afterVariable := after[name]
+		if beforeVariable == nil && afterVariable == nil {
+			continue
+		}
+		if beforeVariable == nil || afterVariable == nil {
+			return unsupportedStructuralDiff(path + "." + name)
+		}
+		if beforeVariable.Default != afterVariable.Default {
+			return unsupportedStructuralDiff(path + "." + name + ".default")
+		}
+		if !slices.Equal(beforeVariable.Enum, afterVariable.Enum) {
+			return unsupportedStructuralDiff(path + "." + name + ".enum")
+		}
 	}
 	return nil
 }
@@ -218,6 +251,9 @@ func collectOperationChanges(opPath string, before, after *openapi3.Operation) (
 		return nil, unsupportedStructuralDiff(opPath + ".deprecated")
 	}
 	if err := checkUnsupportedOperationSecurity(opPath, before, after); err != nil {
+		return nil, err
+	}
+	if err := checkUnsupportedOperationServers(opPath, before, after); err != nil {
 		return nil, err
 	}
 	if err := checkUnsupportedOperationCallbacks(opPath, before, after); err != nil {
@@ -410,6 +446,16 @@ func checkUnsupportedOperationSecurity(opPath string, before, after *openapi3.Op
 		return nil
 	}
 	return unsupportedStructuralDiff(opPath + ".security")
+}
+
+func checkUnsupportedOperationServers(opPath string, before, after *openapi3.Operation) error {
+	if before.Servers == nil && after.Servers == nil {
+		return nil
+	}
+	if before.Servers == nil || after.Servers == nil {
+		return unsupportedStructuralDiff(opPath + ".servers")
+	}
+	return compareServersAt(opPath+".servers", *before.Servers, *after.Servers)
 }
 
 func securityRequirementsEqual(before, after *openapi3.SecurityRequirements) bool {

--- a/internal/contractopenapidiff/structural.go
+++ b/internal/contractopenapidiff/structural.go
@@ -3,33 +3,36 @@ package contractopenapidiff
 import (
 	"fmt"
 	"reflect"
+	"slices"
 
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
-func compareStructural(before, after *openapi3.T) error {
+func collectStructuralChanges(before, after *openapi3.T) ([]Change, error) {
 	if before.OpenAPI != after.OpenAPI {
-		return unsupportedStructuralDiff("openapi")
+		return nil, unsupportedStructuralDiff("openapi")
 	}
 	if err := compareInfoStructural(before.Info, after.Info); err != nil {
-		return err
+		return nil, err
 	}
 	if err := compareServersStructural(before.Servers, after.Servers); err != nil {
-		return err
+		return nil, err
 	}
 	if err := compareSecurityStructural(before.Security, after.Security); err != nil {
-		return err
+		return nil, err
 	}
 	if err := compareTagsStructural(before.Tags, after.Tags); err != nil {
-		return err
+		return nil, err
 	}
-	if err := comparePathsStructural(before.Paths, after.Paths); err != nil {
-		return err
+	pathChanges, err := collectPathChanges(before.Paths, after.Paths)
+	if err != nil {
+		return nil, err
 	}
-	if err := compareComponentsStructural(before.Components, after.Components); err != nil {
-		return err
+	componentChanges, err := collectComponentChanges(before.Components, after.Components)
+	if err != nil {
+		return nil, err
 	}
-	return nil
+	return append(pathChanges, componentChanges...), nil
 }
 
 func compareInfoStructural(before, after *openapi3.Info) error {
@@ -124,86 +127,121 @@ func compareTagsStructural(before, after openapi3.Tags) error {
 	return nil
 }
 
-func comparePathsStructural(before, after *openapi3.Paths) error {
+func collectPathChanges(before, after *openapi3.Paths) ([]Change, error) {
 	if before == nil || after == nil {
-		return unsupportedStructuralDiff("paths")
+		return nil, unsupportedStructuralDiff("paths")
 	}
 	beforePaths := before.Map()
 	afterPaths := after.Map()
-	if len(beforePaths) != len(afterPaths) {
-		return unsupportedStructuralDiff("paths")
-	}
+
 	for path := range beforePaths {
-		afterItem, ok := afterPaths[path]
-		if !ok {
-			return unsupportedStructuralDiff("paths." + path)
-		}
-		if err := comparePathItemStructural(path, beforePaths[path], afterItem); err != nil {
-			return err
+		if _, ok := afterPaths[path]; !ok {
+			return nil, unsupportedStructuralDiff("paths." + path)
 		}
 	}
-	return nil
+
+	var changes []Change
+	for path, afterItem := range afterPaths {
+		beforeItem, ok := beforePaths[path]
+		if !ok {
+			for method := range afterItem.Operations() {
+				changes = appendMinorChange(changes, CodeOperationAdded, operationPath(method, path))
+			}
+			continue
+		}
+		pathChanges, err := collectPathItemChanges(path, beforeItem, afterItem)
+		if err != nil {
+			return nil, err
+		}
+		changes = append(changes, pathChanges...)
+	}
+	return changes, nil
 }
 
-func comparePathItemStructural(path string, before, after *openapi3.PathItem) error {
+func collectPathItemChanges(path string, before, after *openapi3.PathItem) ([]Change, error) {
 	if before == nil || after == nil {
-		return unsupportedStructuralDiff("paths." + path)
+		return nil, unsupportedStructuralDiff("paths." + path)
 	}
 	beforeOps := before.Operations()
 	afterOps := after.Operations()
-	if len(beforeOps) != len(afterOps) {
-		return unsupportedStructuralDiff("paths." + path)
-	}
-	for method, beforeOperation := range beforeOps {
-		afterOperation := after.GetOperation(method)
-		if err := compareOperationStructural(operationPath(method, path), beforeOperation, afterOperation); err != nil {
-			return err
+
+	for method := range beforeOps {
+		if after.GetOperation(method) == nil {
+			return nil, unsupportedStructuralDiff(operationPath(method, path))
 		}
 	}
-	return nil
+
+	var changes []Change
+	for method, afterOperation := range afterOps {
+		beforeOperation := before.GetOperation(method)
+		if beforeOperation == nil {
+			changes = appendMinorChange(changes, CodeOperationAdded, operationPath(method, path))
+			continue
+		}
+		opChanges, err := collectOperationChanges(operationPath(method, path), beforeOperation, afterOperation)
+		if err != nil {
+			return nil, err
+		}
+		changes = append(changes, opChanges...)
+	}
+	return changes, nil
 }
 
-func compareOperationStructural(opPath string, before, after *openapi3.Operation) error {
+func collectOperationChanges(opPath string, before, after *openapi3.Operation) ([]Change, error) {
 	if before == nil || after == nil {
-		return unsupportedStructuralDiff(opPath)
+		return nil, unsupportedStructuralDiff(opPath)
 	}
 	if before.OperationID != after.OperationID {
-		return unsupportedStructuralDiff(opPath + ".operationId")
+		return nil, unsupportedStructuralDiff(opPath + ".operationId")
 	}
 	if !reflect.DeepEqual(before.Tags, after.Tags) {
-		return unsupportedStructuralDiff(opPath + ".tags")
+		return nil, unsupportedStructuralDiff(opPath + ".tags")
 	}
 	if before.Deprecated != after.Deprecated {
-		return unsupportedStructuralDiff(opPath + ".deprecated")
+		return nil, unsupportedStructuralDiff(opPath + ".deprecated")
 	}
-	if err := compareParametersStructural(opPath, before.Parameters, after.Parameters); err != nil {
-		return err
+
+	var changes []Change
+	paramChanges, err := collectParameterChanges(opPath, before.Parameters, after.Parameters)
+	if err != nil {
+		return nil, err
 	}
+	changes = append(changes, paramChanges...)
+
 	if err := compareRequestBodyStructural(opPath, before.RequestBody, after.RequestBody); err != nil {
-		return err
+		return nil, err
 	}
 	if err := compareResponsesStructural(opPath, before.Responses, after.Responses); err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return changes, nil
 }
 
-func compareParametersStructural(opPath string, before, after openapi3.Parameters) error {
+func collectParameterChanges(opPath string, before, after openapi3.Parameters) ([]Change, error) {
 	beforeByKey := parametersByKey(before)
 	afterByKey := parametersByKey(after)
-	if len(beforeByKey) != len(afterByKey) {
-		return unsupportedStructuralDiff(opPath + ".parameters")
+
+	for key := range beforeByKey {
+		if _, ok := afterByKey[key]; !ok {
+			return nil, unsupportedStructuralDiff(opPath + ".parameters[" + key + "]")
+		}
 	}
-	for key, beforeParameter := range beforeByKey {
-		afterParameter, ok := afterByKey[key]
+
+	var changes []Change
+	for key, afterParameter := range afterByKey {
+		beforeParameter, ok := beforeByKey[key]
 		if !ok {
-			return unsupportedStructuralDiff(opPath + ".parameters[" + key + "]")
+			if afterParameter.Required {
+				return nil, unsupportedStructuralDiff(opPath + ".parameters[" + key + "]")
+			}
+			changes = appendMinorChange(changes, CodeParameterAdded, opPath+".parameters["+key+"]")
+			continue
 		}
 		if err := compareParameterStructural(opPath+".parameters["+key+"]", beforeParameter, afterParameter); err != nil {
-			return err
+			return nil, err
 		}
 	}
-	return nil
+	return changes, nil
 }
 
 func compareParameterStructural(path string, before, after *openapi3.Parameter) error {
@@ -213,10 +251,7 @@ func compareParameterStructural(path string, before, after *openapi3.Parameter) 
 	if before.Name != after.Name || before.In != after.In || before.Required != after.Required {
 		return unsupportedStructuralDiff(path)
 	}
-	if err := compareSchemaRefStructural(path+".schema", before.Schema, after.Schema); err != nil {
-		return err
-	}
-	return nil
+	return compareSchemaRefStructural(path+".schema", before.Schema, after.Schema)
 }
 
 func compareRequestBodyStructural(opPath string, before, after *openapi3.RequestBodyRef) error {
@@ -273,84 +308,151 @@ func compareMediaTypesStructural(path string, before, after openapi3.Content) er
 	return nil
 }
 
-func compareComponentsStructural(before, after *openapi3.Components) error {
+func collectComponentChanges(before, after *openapi3.Components) ([]Change, error) {
 	if before == nil && after == nil {
-		return nil
+		return nil, nil
 	}
 	if before == nil || after == nil {
-		return unsupportedStructuralDiff("components")
+		return nil, unsupportedStructuralDiff("components")
 	}
-	if len(before.Schemas) != len(after.Schemas) {
-		return unsupportedStructuralDiff("components.schemas")
+
+	for name := range before.Schemas {
+		if _, ok := after.Schemas[name]; !ok {
+			return nil, unsupportedStructuralDiff("components.schemas." + name)
+		}
 	}
-	for name, beforeSchemaRef := range before.Schemas {
-		afterSchemaRef, ok := after.Schemas[name]
+
+	var changes []Change
+	for name, afterSchemaRef := range after.Schemas {
+		beforeSchemaRef, ok := before.Schemas[name]
 		if !ok {
-			return unsupportedStructuralDiff("components.schemas." + name)
+			changes = appendMinorChange(changes, CodeSchemaAdded, "components.schemas."+name)
+			continue
 		}
-		if err := compareSchemaRefStructural("components.schemas."+name, beforeSchemaRef, afterSchemaRef); err != nil {
-			return err
+		schemaChanges, err := collectSchemaRefChanges("components.schemas."+name, beforeSchemaRef, afterSchemaRef)
+		if err != nil {
+			return nil, err
 		}
+		changes = append(changes, schemaChanges...)
 	}
-	return nil
+	return changes, nil
+}
+
+func collectSchemaRefChanges(path string, before, after *openapi3.SchemaRef) ([]Change, error) {
+	if before == nil && after == nil {
+		return nil, nil
+	}
+	if before == nil || after == nil {
+		return nil, unsupportedStructuralDiff(path)
+	}
+	if before.Ref != after.Ref {
+		return nil, unsupportedStructuralDiff(path + ".ref")
+	}
+	if before.Ref != "" {
+		return nil, nil
+	}
+	return collectSchemaChanges(path, before.Value, after.Value)
 }
 
 func compareSchemaRefStructural(path string, before, after *openapi3.SchemaRef) error {
-	if before == nil && after == nil {
-		return nil
-	}
+	_, err := collectSchemaRefChanges(path, before, after)
+	return err
+}
+
+func collectSchemaChanges(path string, before, after *openapi3.Schema) ([]Change, error) {
 	if before == nil || after == nil {
-		return unsupportedStructuralDiff(path)
+		return nil, unsupportedStructuralDiff(path)
 	}
-	if before.Ref != after.Ref {
-		return unsupportedStructuralDiff(path + ".ref")
+	if !typesEqual(before.Type, after.Type) {
+		return nil, unsupportedStructuralDiff(path + ".type")
 	}
-	if before.Ref != "" {
-		return nil
+	if before.Format != after.Format {
+		return nil, unsupportedStructuralDiff(path + ".format")
 	}
-	return compareSchemaStructural(path, before.Value, after.Value)
+	if !reflect.DeepEqual(before.Required, after.Required) {
+		return nil, unsupportedStructuralDiff(path + ".required")
+	}
+	if !externalDocsStructuralEqual(before.ExternalDocs, after.ExternalDocs) {
+		return nil, unsupportedStructuralDiff(path + ".externalDocs")
+	}
+
+	var changes []Change
+	enumChanges, err := collectEnumChanges(path, before.Enum, after.Enum)
+	if err != nil {
+		return nil, err
+	}
+	changes = append(changes, enumChanges...)
+
+	for propertyName := range before.Properties {
+		if _, ok := after.Properties[propertyName]; !ok {
+			return nil, unsupportedStructuralDiff(path + ".properties." + propertyName)
+		}
+	}
+	for propertyName, afterPropertyRef := range after.Properties {
+		beforePropertyRef, ok := before.Properties[propertyName]
+		if !ok {
+			if slices.Contains(after.Required, propertyName) {
+				return nil, unsupportedStructuralDiff(path + ".properties." + propertyName)
+			}
+			changes = appendMinorChange(changes, CodeSchemaPropertyAdded, path+".properties."+propertyName)
+			continue
+		}
+		propertyChanges, err := collectSchemaRefChanges(path+".properties."+propertyName, beforePropertyRef, afterPropertyRef)
+		if err != nil {
+			return nil, err
+		}
+		changes = append(changes, propertyChanges...)
+	}
+	if (before.Items == nil) != (after.Items == nil) {
+		return nil, unsupportedStructuralDiff(path + ".items")
+	}
+	if before.Items != nil {
+		itemChanges, err := collectSchemaRefChanges(path+".items", before.Items, after.Items)
+		if err != nil {
+			return nil, err
+		}
+		changes = append(changes, itemChanges...)
+	}
+	return changes, nil
 }
 
 func compareSchemaStructural(path string, before, after *openapi3.Schema) error {
-	if before == nil || after == nil {
-		return unsupportedStructuralDiff(path)
-	}
-	if !typesEqual(before.Type, after.Type) {
-		return unsupportedStructuralDiff(path + ".type")
-	}
-	if before.Format != after.Format {
-		return unsupportedStructuralDiff(path + ".format")
-	}
-	if !reflect.DeepEqual(before.Enum, after.Enum) {
-		return unsupportedStructuralDiff(path + ".enum")
-	}
-	if !reflect.DeepEqual(before.Required, after.Required) {
-		return unsupportedStructuralDiff(path + ".required")
-	}
-	if !externalDocsStructuralEqual(before.ExternalDocs, after.ExternalDocs) {
-		return unsupportedStructuralDiff(path + ".externalDocs")
-	}
-	if len(before.Properties) != len(after.Properties) {
-		return unsupportedStructuralDiff(path + ".properties")
-	}
-	for propertyName, beforePropertyRef := range before.Properties {
-		afterPropertyRef, ok := after.Properties[propertyName]
-		if !ok {
-			return unsupportedStructuralDiff(path + ".properties." + propertyName)
-		}
-		if err := compareSchemaRefStructural(path+".properties."+propertyName, beforePropertyRef, afterPropertyRef); err != nil {
-			return err
+	_, err := collectSchemaChanges(path, before, after)
+	return err
+}
+
+func collectEnumChanges(path string, before, after []any) ([]Change, error) {
+	beforeValues := enumValueSet(before)
+	afterValues := enumValueSet(after)
+	for value := range beforeValues {
+		if _, ok := afterValues[value]; !ok {
+			return nil, unsupportedStructuralDiff(path + ".enum")
 		}
 	}
-	if (before.Items == nil) != (after.Items == nil) {
-		return unsupportedStructuralDiff(path + ".items")
-	}
-	if before.Items != nil {
-		if err := compareSchemaRefStructural(path+".items", before.Items, after.Items); err != nil {
-			return err
+	var changes []Change
+	for value := range afterValues {
+		if _, ok := beforeValues[value]; ok {
+			continue
 		}
+		changes = appendMinorChange(changes, CodeEnumValueAdded, path+".enum."+enumValuePath(value))
 	}
-	return nil
+	return changes, nil
+}
+
+func enumValueSet(values []any) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		out[enumValueKey(value)] = struct{}{}
+	}
+	return out
+}
+
+func enumValueKey(value any) string {
+	return fmt.Sprint(value)
+}
+
+func enumValuePath(value any) string {
+	return enumValueKey(value)
 }
 
 func typesEqual(before, after *openapi3.Types) bool {

--- a/internal/contractopenapidiff/structural.go
+++ b/internal/contractopenapidiff/structural.go
@@ -277,7 +277,11 @@ func collectParameterPairChanges(path string, before, after *openapi3.Parameter)
 	if err != nil {
 		return nil, err
 	}
-	return append(changes, schemaChanges...), nil
+	changes = append(changes, schemaChanges...)
+	if err := checkUnsupportedParameterResiduals(path, before, after); err != nil {
+		return nil, err
+	}
+	return changes, nil
 }
 
 func collectRequestBodyChanges(opPath string, before, after *openapi3.RequestBodyRef) ([]Change, error) {
@@ -311,6 +315,9 @@ func collectResponsesChanges(opPath string, before, after *openapi3.Responses) (
 		afterResponse := responseValue(afterResponseRef)
 		if beforeResponse == nil || afterResponse == nil {
 			return nil, unsupportedStructuralDiff(opPath + ".responses." + status)
+		}
+		if err := checkUnsupportedResponseHeaders(opPath+".responses."+status+".headers", beforeResponse.Headers, afterResponse.Headers); err != nil {
+			return nil, err
 		}
 		responseChanges, err := collectMediaTypeChanges(opPath+".responses."+status+".content", beforeResponse.Content, afterResponse.Content)
 		if err != nil {
@@ -367,7 +374,134 @@ func collectComponentChanges(before, after *openapi3.Components) ([]Change, erro
 		}
 		changes = append(changes, schemaChanges...)
 	}
+	if err := checkUnsupportedComponentResiduals(before, after); err != nil {
+		return nil, err
+	}
 	return changes, nil
+}
+
+func checkUnsupportedParameterResiduals(path string, before, after *openapi3.Parameter) error {
+	if before.Style != after.Style {
+		return unsupportedStructuralDiff(path + ".style")
+	}
+	if !boolPtrEqual(before.Explode, after.Explode) {
+		return unsupportedStructuralDiff(path + ".explode")
+	}
+	if before.AllowEmptyValue != after.AllowEmptyValue {
+		return unsupportedStructuralDiff(path + ".allowEmptyValue")
+	}
+	if before.AllowReserved != after.AllowReserved {
+		return unsupportedStructuralDiff(path + ".allowReserved")
+	}
+	if before.Deprecated != after.Deprecated {
+		return unsupportedStructuralDiff(path + ".deprecated")
+	}
+	if !anyEqual(before.Example, after.Example) {
+		return unsupportedStructuralDiff(path + ".example")
+	}
+	if !reflect.DeepEqual(before.Examples, after.Examples) {
+		return unsupportedStructuralDiff(path + ".examples")
+	}
+	if !reflect.DeepEqual(before.Content, after.Content) {
+		return unsupportedStructuralDiff(path + ".content")
+	}
+	return nil
+}
+
+func checkUnsupportedResponseHeaders(path string, before, after openapi3.Headers) error {
+	if len(before) == 0 && len(after) == 0 {
+		return nil
+	}
+	allNames := make(map[string]struct{})
+	for name := range before {
+		allNames[name] = struct{}{}
+	}
+	for name := range after {
+		allNames[name] = struct{}{}
+	}
+	names := make([]string, 0, len(allNames))
+	for name := range allNames {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	for _, name := range names {
+		beforeHeader, beforeOK := before[name]
+		afterHeader, afterOK := after[name]
+		if !beforeOK || !afterOK {
+			return unsupportedStructuralDiff(path + "." + name)
+		}
+		if !reflect.DeepEqual(beforeHeader, afterHeader) {
+			return unsupportedStructuralDiff(path + "." + name)
+		}
+	}
+	return nil
+}
+
+func checkUnsupportedComponentResiduals(before, after *openapi3.Components) error {
+	if err := checkComponentMapResidual("components.parameters", before.Parameters, after.Parameters); err != nil {
+		return err
+	}
+	if err := checkComponentMapResidual("components.headers", before.Headers, after.Headers); err != nil {
+		return err
+	}
+	if err := checkComponentMapResidual("components.requestBodies", before.RequestBodies, after.RequestBodies); err != nil {
+		return err
+	}
+	if err := checkComponentMapResidual("components.responses", before.Responses, after.Responses); err != nil {
+		return err
+	}
+	if err := checkComponentMapResidual("components.securitySchemes", before.SecuritySchemes, after.SecuritySchemes); err != nil {
+		return err
+	}
+	if err := checkComponentMapResidual("components.examples", before.Examples, after.Examples); err != nil {
+		return err
+	}
+	if err := checkComponentMapResidual("components.links", before.Links, after.Links); err != nil {
+		return err
+	}
+	if err := checkComponentMapResidual("components.callbacks", before.Callbacks, after.Callbacks); err != nil {
+		return err
+	}
+	return nil
+}
+
+func checkComponentMapResidual[T any](path string, before, after map[string]T) error {
+	if reflect.DeepEqual(before, after) {
+		return nil
+	}
+	allNames := make(map[string]struct{})
+	for name := range before {
+		allNames[name] = struct{}{}
+	}
+	for name := range after {
+		allNames[name] = struct{}{}
+	}
+	names := make([]string, 0, len(allNames))
+	for name := range allNames {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	for _, name := range names {
+		beforeValue, beforeOK := before[name]
+		afterValue, afterOK := after[name]
+		if !beforeOK || !afterOK {
+			return unsupportedStructuralDiff(path + "." + name)
+		}
+		if !reflect.DeepEqual(beforeValue, afterValue) {
+			return unsupportedStructuralDiff(path + "." + name)
+		}
+	}
+	return unsupportedStructuralDiff(path)
+}
+
+func boolPtrEqual(before, after *bool) bool {
+	if before == nil && after == nil {
+		return true
+	}
+	if before == nil || after == nil {
+		return false
+	}
+	return *before == *after
 }
 
 func collectSchemaRefChanges(path string, before, after *openapi3.SchemaRef) ([]Change, error) {

--- a/internal/contractopenapidiff/testdata/add-inline-response-schema-property/after.yaml
+++ b/internal/contractopenapidiff/testdata/add-inline-response-schema-property/after.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.3
+info:
+  title: Add Inline Response Schema Property Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string

--- a/internal/contractopenapidiff/testdata/add-inline-response-schema-property/before.yaml
+++ b/internal/contractopenapidiff/testdata/add-inline-response-schema-property/before.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.3
+info:
+  title: Add Inline Response Schema Property Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: string

--- a/internal/contractopenapidiff/testdata/add-parameter/after.yaml
+++ b/internal/contractopenapidiff/testdata/add-parameter/after.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.3
+info:
+  title: Add Parameter Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/add-parameter/before.yaml
+++ b/internal/contractopenapidiff/testdata/add-parameter/before.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.3
+info:
+  title: Add Parameter Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/add-route/after.yaml
+++ b/internal/contractopenapidiff/testdata/add-route/after.yaml
@@ -1,15 +1,14 @@
 openapi: 3.0.3
 info:
-  title: Docs Only Fixture
+  title: Add Route Fixture
   version: 1.0.0
-  description: Before API description.
 paths:
   /pets:
     get:
       operationId: listPets
       responses:
         '200':
-          description: ok
+          description: Pet list.
     post:
       operationId: createPet
       responses:

--- a/internal/contractopenapidiff/testdata/add-route/before.yaml
+++ b/internal/contractopenapidiff/testdata/add-route/before.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.3
+info:
+  title: Add Route Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/add-schema-property/after.yaml
+++ b/internal/contractopenapidiff/testdata/add-schema-property/after.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.3
+info:
+  title: Add Schema Property Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        nickname:
+          type: string

--- a/internal/contractopenapidiff/testdata/add-schema-property/before.yaml
+++ b/internal/contractopenapidiff/testdata/add-schema-property/before.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.3
+info:
+  title: Add Schema Property Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+        name:
+          type: string

--- a/internal/contractopenapidiff/testdata/docs-only/after.yaml
+++ b/internal/contractopenapidiff/testdata/docs-only/after.yaml
@@ -1,0 +1,60 @@
+openapi: 3.0.3
+info:
+  title: Docs Only Fixture
+  version: 1.0.0
+  description: After API description.
+tags:
+  - name: pets
+    description: Pet operations after.
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      summary: List pets after
+      description: Returns pets after.
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: Page size after.
+          schema:
+            type: integer
+      requestBody:
+        required: false
+        description: Optional filter body after.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PetFilter'
+      responses:
+        '200':
+          description: Pet list after.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      title: Pet after
+      description: A pet after.
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          description: Pet identifier after.
+        name:
+          type: string
+          description: Pet name after.
+    PetFilter:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Filter by name after.

--- a/internal/contractopenapidiff/testdata/docs-only/before.yaml
+++ b/internal/contractopenapidiff/testdata/docs-only/before.yaml
@@ -1,0 +1,60 @@
+openapi: 3.0.3
+info:
+  title: Docs Only Fixture
+  version: 1.0.0
+  description: Before API description.
+tags:
+  - name: pets
+    description: Pet operations before.
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      summary: List pets before
+      description: Returns pets before.
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: Page size before.
+          schema:
+            type: integer
+      requestBody:
+        required: false
+        description: Optional filter body before.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PetFilter'
+      responses:
+        '200':
+          description: Pet list before.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      title: Pet before
+      description: A pet before.
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          description: Pet identifier before.
+        name:
+          type: string
+          description: Pet name before.
+    PetFilter:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Filter by name before.

--- a/internal/contractopenapidiff/testdata/major-wins-mixed/after.yaml
+++ b/internal/contractopenapidiff/testdata/major-wins-mixed/after.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.3
+info:
+  title: Major Wins Mixed Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      parameters:
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/major-wins-mixed/before.yaml
+++ b/internal/contractopenapidiff/testdata/major-wins-mixed/before.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+info:
+  title: Major Wins Mixed Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+    post:
+      operationId: createPet
+      responses:
+        '201':
+          description: created

--- a/internal/contractopenapidiff/testdata/narrow-enum/after.yaml
+++ b/internal/contractopenapidiff/testdata/narrow-enum/after.yaml
@@ -1,0 +1,30 @@
+openapi: 3.0.3
+info:
+  title: Narrow Enum Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - status
+      properties:
+        id:
+          type: string
+        status:
+          type: string
+          enum:
+            - active
+            - inactive

--- a/internal/contractopenapidiff/testdata/narrow-enum/before.yaml
+++ b/internal/contractopenapidiff/testdata/narrow-enum/before.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.3
+info:
+  title: Narrow Enum Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - status
+      properties:
+        id:
+          type: string
+        status:
+          type: string
+          enum:
+            - active
+            - inactive
+            - pending

--- a/internal/contractopenapidiff/testdata/narrow-inline-response-schema/after.yaml
+++ b/internal/contractopenapidiff/testdata/narrow-inline-response-schema/after.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.3
+info:
+  title: Narrow Inline Response Schema Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: string
+                  age:
+                    type: string

--- a/internal/contractopenapidiff/testdata/narrow-inline-response-schema/before.yaml
+++ b/internal/contractopenapidiff/testdata/narrow-inline-response-schema/before.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.3
+info:
+  title: Narrow Inline Response Schema Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: string
+                  age:
+                    type: integer

--- a/internal/contractopenapidiff/testdata/narrow-type/after.yaml
+++ b/internal/contractopenapidiff/testdata/narrow-type/after.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.3
+info:
+  title: Narrow Type Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+        age:
+          type: integer

--- a/internal/contractopenapidiff/testdata/narrow-type/before.yaml
+++ b/internal/contractopenapidiff/testdata/narrow-type/before.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.3
+info:
+  title: Narrow Type Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+        age:
+          type: string

--- a/internal/contractopenapidiff/testdata/relax-parameter-required/after.yaml
+++ b/internal/contractopenapidiff/testdata/relax-parameter-required/after.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.3
+info:
+  title: Relax Parameter Required Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/relax-parameter-required/before.yaml
+++ b/internal/contractopenapidiff/testdata/relax-parameter-required/before.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.3
+info:
+  title: Relax Parameter Required Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      parameters:
+        - name: limit
+          in: query
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/relax-schema-required/after.yaml
+++ b/internal/contractopenapidiff/testdata/relax-schema-required/after.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.3
+info:
+  title: Relax Schema Required Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+        name:
+          type: string

--- a/internal/contractopenapidiff/testdata/relax-schema-required/before.yaml
+++ b/internal/contractopenapidiff/testdata/relax-schema-required/before.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.3
+info:
+  title: Relax Schema Required Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+        name:
+          type: string

--- a/internal/contractopenapidiff/testdata/remove-parameter/after.yaml
+++ b/internal/contractopenapidiff/testdata/remove-parameter/after.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.3
+info:
+  title: Remove Parameter Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/remove-parameter/before.yaml
+++ b/internal/contractopenapidiff/testdata/remove-parameter/before.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.3
+info:
+  title: Remove Parameter Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/remove-path-parameter/after.yaml
+++ b/internal/contractopenapidiff/testdata/remove-path-parameter/after.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.3
+info:
+  title: Remove Path Parameter Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/remove-path-parameter/before.yaml
+++ b/internal/contractopenapidiff/testdata/remove-path-parameter/before.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+info:
+  title: Remove Path Parameter Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    parameters:
+      - name: limit
+        in: query
+        schema:
+          type: integer
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/remove-route/after.yaml
+++ b/internal/contractopenapidiff/testdata/remove-route/after.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.3
+info:
+  title: Remove Route Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/remove-route/before.yaml
+++ b/internal/contractopenapidiff/testdata/remove-route/before.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+info:
+  title: Remove Route Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+    post:
+      operationId: createPet
+      responses:
+        '201':
+          description: created

--- a/internal/contractopenapidiff/testdata/remove-schema-property/after.yaml
+++ b/internal/contractopenapidiff/testdata/remove-schema-property/after.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.3
+info:
+  title: Remove Schema Property Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+        name:
+          type: string

--- a/internal/contractopenapidiff/testdata/remove-schema-property/before.yaml
+++ b/internal/contractopenapidiff/testdata/remove-schema-property/before.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.3
+info:
+  title: Remove Schema Property Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        nickname:
+          type: string

--- a/internal/contractopenapidiff/testdata/structural-add-route/after.yaml
+++ b/internal/contractopenapidiff/testdata/structural-add-route/after.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.3
+info:
+  title: Docs Only Fixture
+  version: 1.0.0
+  description: Before API description.
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: ok
+    post:
+      operationId: createPet
+      responses:
+        '201':
+          description: created

--- a/internal/contractopenapidiff/testdata/unsupported-additional-properties-narrow/after.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-additional-properties-narrow/after.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Additional Properties Narrow Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                properties:
+                  id:
+                    type: string

--- a/internal/contractopenapidiff/testdata/unsupported-additional-properties-narrow/before.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-additional-properties-narrow/before.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Additional Properties Narrow Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                properties:
+                  id:
+                    type: string

--- a/internal/contractopenapidiff/testdata/unsupported-component-parameter-remove/after.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-component-parameter-remove/after.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Component Parameter Remove Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+components: {}

--- a/internal/contractopenapidiff/testdata/unsupported-component-parameter-remove/before.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-component-parameter-remove/before.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Component Parameter Remove Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+components:
+  parameters:
+    Limit:
+      name: limit
+      in: query
+      schema:
+        type: integer

--- a/internal/contractopenapidiff/testdata/unsupported-media-type-encoding/after.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-media-type-encoding/after.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Media Type Encoding Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    post:
+      operationId: uploadPet
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+            encoding:
+              file:
+                contentType: image/jpeg
+      responses:
+        '200':
+          description: Uploaded.

--- a/internal/contractopenapidiff/testdata/unsupported-media-type-encoding/before.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-media-type-encoding/before.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Media Type Encoding Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    post:
+      operationId: uploadPet
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+            encoding:
+              file:
+                contentType: image/png
+      responses:
+        '200':
+          description: Uploaded.

--- a/internal/contractopenapidiff/testdata/unsupported-nullable-narrow/after.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-nullable-narrow/after.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Nullable Narrow Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                type: object
+                nullable: false
+                properties:
+                  id:
+                    type: string

--- a/internal/contractopenapidiff/testdata/unsupported-nullable-narrow/before.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-nullable-narrow/before.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Nullable Narrow Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                type: object
+                nullable: true
+                properties:
+                  id:
+                    type: string

--- a/internal/contractopenapidiff/testdata/unsupported-oneof-narrow/after.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-oneof-narrow/after.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+info:
+  title: Unsupported OneOf Narrow Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: string

--- a/internal/contractopenapidiff/testdata/unsupported-oneof-narrow/before.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-oneof-narrow/before.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.3
+info:
+  title: Unsupported OneOf Narrow Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: string
+                  - type: integer

--- a/internal/contractopenapidiff/testdata/unsupported-operation-callbacks/after.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-operation-callbacks/after.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Operation Callbacks Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    post:
+      operationId: createPet
+      responses:
+        '200':
+          description: Created.

--- a/internal/contractopenapidiff/testdata/unsupported-operation-callbacks/before.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-operation-callbacks/before.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Operation Callbacks Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    post:
+      operationId: createPet
+      callbacks:
+        onData:
+          '{$request.body#/callbackUrl}':
+            post:
+              responses:
+                '200':
+                  description: Callback accepted.
+      responses:
+        '200':
+          description: Created.

--- a/internal/contractopenapidiff/testdata/unsupported-operation-extension/after.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-operation-extension/after.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Operation Extension Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      x-internal: true
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/unsupported-operation-extension/before.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-operation-extension/before.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Operation Extension Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/unsupported-operation-id/after.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-operation-id/after.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Operation ID Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listAllPets
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/unsupported-operation-id/before.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-operation-id/before.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Operation ID Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/unsupported-operation-security/after.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-operation-security/after.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Operation Security Fixture
+  version: 1.0.0
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/unsupported-operation-security/before.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-operation-security/before.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Operation Security Fixture
+  version: 1.0.0
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/unsupported-operation-servers/after.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-operation-servers/after.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Operation Servers Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/unsupported-operation-servers/before.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-operation-servers/before.yaml
@@ -1,0 +1,13 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Operation Servers Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      servers:
+        - url: https://api.example.com
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/unsupported-parameter-extension/after.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-parameter-extension/after.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Parameter Extension Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      parameters:
+        - name: tags
+          in: query
+          x-codegen-name: tagFilter
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/unsupported-parameter-extension/before.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-parameter-extension/before.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Parameter Extension Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      parameters:
+        - name: tags
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/unsupported-parameter-style/after.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-parameter-style/after.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Parameter Style Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      parameters:
+        - name: tags
+          in: query
+          style: pipeDelimited
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/unsupported-parameter-style/before.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-parameter-style/before.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Parameter Style Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      parameters:
+        - name: tags
+          in: query
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/unsupported-path-servers/after.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-path-servers/after.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Path Servers Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/unsupported-path-servers/before.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-path-servers/before.yaml
@@ -1,0 +1,13 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Path Servers Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    servers:
+      - url: https://api.example.com/v1
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/unsupported-response-header-remove/after.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-response-header-remove/after.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Response Header Remove Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string

--- a/internal/contractopenapidiff/testdata/unsupported-response-header-remove/before.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-response-header-remove/before.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Response Header Remove Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          headers:
+            X-RateLimit:
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string

--- a/internal/contractopenapidiff/testdata/unsupported-response-links/after.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-response-links/after.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Response Links Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/unsupported-response-links/before.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-response-links/before.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Response Links Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          links:
+            GetPet:
+              operationId: getPet
+              parameters:
+                petId: '$response.body#/id'

--- a/internal/contractopenapidiff/testdata/unsupported-schema-extension/after.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-schema-extension/after.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Schema Extension Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      x-internal: true
+      properties:
+        id:
+          type: string

--- a/internal/contractopenapidiff/testdata/unsupported-schema-extension/before.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-schema-extension/before.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Schema Extension Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: string

--- a/internal/contractopenapidiff/testdata/unsupported-security-scheme/after.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-security-scheme/after.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Security Scheme Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: basic

--- a/internal/contractopenapidiff/testdata/unsupported-security-scheme/before.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-security-scheme/before.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Security Scheme Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer

--- a/internal/contractopenapidiff/testdata/unsupported-server-variables/after.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-server-variables/after.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Server Variables Fixture
+  version: 1.0.0
+servers:
+  - url: https://{env}.example.com
+    variables:
+      env:
+        default: prod
+        enum:
+          - prod
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/unsupported-server-variables/before.yaml
+++ b/internal/contractopenapidiff/testdata/unsupported-server-variables/before.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.3
+info:
+  title: Unsupported Server Variables Fixture
+  version: 1.0.0
+servers:
+  - url: https://{env}.example.com
+    variables:
+      env:
+        default: prod
+        enum:
+          - prod
+          - staging
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.

--- a/internal/contractopenapidiff/testdata/widen-enum/after.yaml
+++ b/internal/contractopenapidiff/testdata/widen-enum/after.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.3
+info:
+  title: Widen Enum Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - status
+      properties:
+        id:
+          type: string
+        status:
+          type: string
+          enum:
+            - active
+            - inactive
+            - pending

--- a/internal/contractopenapidiff/testdata/widen-enum/before.yaml
+++ b/internal/contractopenapidiff/testdata/widen-enum/before.yaml
@@ -1,0 +1,30 @@
+openapi: 3.0.3
+info:
+  title: Widen Enum Fixture
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: Pet list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - status
+      properties:
+        id:
+          type: string
+        status:
+          type: string
+          enum:
+            - active
+            - inactive

--- a/internal/contractopenapidiff/types.go
+++ b/internal/contractopenapidiff/types.go
@@ -3,6 +3,8 @@
 // It is build tooling and must not be imported by runtime packages.
 package contractopenapidiff
 
+import "errors"
+
 // Classification is the aggregate semver signal for a compared document pair.
 type Classification string
 
@@ -22,6 +24,21 @@ type Change struct {
 type Result struct {
 	Classification Classification `json:"classification"`
 	Changes        []Change       `json:"changes"`
+}
+
+// UnsupportedDiffError means the comparator refused to classify a difference.
+type UnsupportedDiffError struct {
+	Path string
+}
+
+func (e *UnsupportedDiffError) Error() string {
+	return "openapi classification refused: unsupported diff at " + e.Path
+}
+
+// IsUnsupportedDiff reports whether err is an unsupported-diff refusal.
+func IsUnsupportedDiff(err error) bool {
+	var unsupported *UnsupportedDiffError
+	return errors.As(err, &unsupported)
 }
 
 // Stable documentation-only change codes.

--- a/internal/contractopenapidiff/types.go
+++ b/internal/contractopenapidiff/types.go
@@ -41,3 +41,12 @@ const (
 	CodeTagDescriptionChanged         = "openapi.doc.tag.description"
 	CodeTagExternalDocsChanged        = "openapi.doc.tag.external_docs"
 )
+
+// Stable compatible-addition change codes.
+const (
+	CodeOperationAdded      = "openapi.add.operation"
+	CodeParameterAdded      = "openapi.add.parameter"
+	CodeSchemaAdded         = "openapi.add.schema"
+	CodeSchemaPropertyAdded = "openapi.add.schema.property"
+	CodeEnumValueAdded      = "openapi.add.enum.value"
+)

--- a/internal/contractopenapidiff/types.go
+++ b/internal/contractopenapidiff/types.go
@@ -50,3 +50,15 @@ const (
 	CodeSchemaPropertyAdded = "openapi.add.schema.property"
 	CodeEnumValueAdded      = "openapi.add.enum.value"
 )
+
+// Stable removal and narrowing change codes.
+const (
+	CodeOperationRemoved        = "openapi.remove.operation"
+	CodeParameterRemoved        = "openapi.remove.parameter"
+	CodeSchemaRemoved           = "openapi.remove.schema"
+	CodeSchemaPropertyRemoved   = "openapi.remove.schema.property"
+	CodeEnumValueRemoved        = "openapi.remove.enum.value"
+	CodeSchemaTypeNarrowed      = "openapi.narrow.schema.type"
+	CodeSchemaRequiredNarrowed  = "openapi.narrow.schema.required"
+	CodeParameterRequiredNarrowed = "openapi.narrow.parameter.required"
+)

--- a/internal/contractopenapidiff/types.go
+++ b/internal/contractopenapidiff/types.go
@@ -1,0 +1,43 @@
+// Package contractopenapidiff compares OpenAPI documents and classifies
+// supported semantic differences for independent package semver decisions.
+// It is build tooling and must not be imported by runtime packages.
+package contractopenapidiff
+
+// Classification is the aggregate semver signal for a compared document pair.
+type Classification string
+
+const (
+	ClassificationMajor Classification = "major"
+	ClassificationMinor Classification = "minor"
+	ClassificationPatch Classification = "patch"
+)
+
+// Change is one classified OpenAPI difference with a stable code and location.
+type Change struct {
+	Code string `json:"code"`
+	Path string `json:"path"`
+}
+
+// Result is the comparator output for a successfully classified comparison.
+type Result struct {
+	Classification Classification `json:"classification"`
+	Changes        []Change       `json:"changes"`
+}
+
+// Stable documentation-only change codes.
+const (
+	CodeInfoDescriptionChanged        = "openapi.doc.info.description"
+	CodeInfoSummaryChanged            = "openapi.doc.info.summary"
+	CodeInfoExternalDocsChanged       = "openapi.doc.info.external_docs"
+	CodeOperationSummaryChanged       = "openapi.doc.operation.summary"
+	CodeOperationDescriptionChanged   = "openapi.doc.operation.description"
+	CodeOperationExternalDocsChanged  = "openapi.doc.operation.external_docs"
+	CodeParameterDescriptionChanged   = "openapi.doc.parameter.description"
+	CodeRequestBodyDescriptionChanged = "openapi.doc.request_body.description"
+	CodeResponseDescriptionChanged    = "openapi.doc.response.description"
+	CodeSchemaTitleChanged            = "openapi.doc.schema.title"
+	CodeSchemaDescriptionChanged      = "openapi.doc.schema.description"
+	CodeSchemaExternalDocsChanged     = "openapi.doc.schema.external_docs"
+	CodeTagDescriptionChanged         = "openapi.doc.tag.description"
+	CodeTagExternalDocsChanged        = "openapi.doc.tag.external_docs"
+)

--- a/internal/contractopenapidiff/types.go
+++ b/internal/contractopenapidiff/types.go
@@ -44,7 +44,6 @@ func IsUnsupportedDiff(err error) bool {
 // Stable documentation-only change codes.
 const (
 	CodeInfoDescriptionChanged        = "openapi.doc.info.description"
-	CodeInfoSummaryChanged            = "openapi.doc.info.summary"
 	CodeInfoExternalDocsChanged       = "openapi.doc.info.external_docs"
 	CodeOperationSummaryChanged       = "openapi.doc.operation.summary"
 	CodeOperationDescriptionChanged   = "openapi.doc.operation.description"
@@ -78,4 +77,10 @@ const (
 	CodeSchemaTypeNarrowed      = "openapi.narrow.schema.type"
 	CodeSchemaRequiredNarrowed  = "openapi.narrow.schema.required"
 	CodeParameterRequiredNarrowed = "openapi.narrow.parameter.required"
+)
+
+// Stable compatible-relaxation change codes.
+const (
+	CodeParameterRequiredRelaxed = "openapi.relax.parameter.required"
+	CodeSchemaRequiredRelaxed    = "openapi.relax.schema.required"
 )


### PR DESCRIPTION
{
  "project": "you-agent-factory OpenAPI contract change classification for independent package semver",
  "branchName": "interfaces-b07-openapi-diff",
  "description": "Add a focused OpenAPI contract comparator with fixtures that classifies contract changes as major, minor, or patch using stable change codes and operation/schema paths, so maintainers can decide independent package semver without inventing release, publish, or npm export automation.",
  "context": {
    "customerAsk": "Implement only B07-OPENAPI-DIFF. Add a focused OpenAPI contract comparator with fixtures that classifies changes as major|minor|patch with stable change codes and operation/schema paths. Removal and type narrowing must be major; compatible additions minor; documentation-only changes patch; unsupported ambiguity fails closed. Do not invent a release workflow, npm publish path, or package-version bump automation. Do not change runtime handlers, CLI, MCP, UI clients, or staged package.json exports.",
    "problem": "Batch 06 staged OpenAPI and an AllowedArtifacts-only packages/api surface, but no OpenAPI semantic-diff comparator exists under contracts tooling. Byte identity and staging parity do not tell maintainers whether a REST contract edit is breaking, additive, or documentation-only, so independent package semver cannot be decided from observable contract deltas.",
    "solution": "Add a contracts/build-tooling OpenAPI comparator that compares two documents and returns { classification: major|minor|patch, changes[] } with stable codes and operation/schema paths. Cover route, parameter, request/response schema, enum, and docs-only fixtures with expected classifications; fail closed on unsupported ambiguity; leave release, npm exports, runtime clients, and B08 SSE out of scope."
  },
  "acceptanceCriteria": [
    "AC-1: Comparator result shape is { classification: major|minor|patch, changes[] } with stable change codes and operation/schema paths on every reported change.",
    "AC-2: Representative fixtures cover route, parameter, request/response schema, enum, and docs-only cases with expected classifications.",
    "AC-3: Removal or type narrowing is classified major; compatible addition is minor; documentation-only change is patch; ambiguous unsupported diffs fail closed.",
    "AC-4: Focused comparator tests pass; make contracts-smoke, make pkg-boundary, and make pkg-file-count still pass.",
    "AC-5: The change does not alter the packages/api package.json export map or invent a generated/components topology.",
    "AC-6: Quality checks pass (typecheck, lint, tests)."
  ],
  "userStories": [
    {
      "id": "interfaces-b07-openapi-diff-001",
      "title": "Return a stable comparator result for documentation-only OpenAPI edits",
      "description": "As a contract maintainer, I want comparing two OpenAPI documents that differ only in documentation to yield a patch classification with stable change codes and operation/schema paths so that non-breaking docs edits are distinguishable from additive or breaking contract changes.",
      "acceptanceCriteria": [
        "Comparing a before/after OpenAPI pair that differs only in documentation fields (for example description, summary, or externalDocs text) returns { classification: \"patch\", changes: [...] }.",
        "Every reported change includes a stable machine-readable code and an operation or schema path that identifies the affected location.",
        "Repeated comparisons of the same inputs produce the same classification, change codes, and paths (deterministic ordering of changes).",
        "Focused tests assert the docs-only fixture outcome end-to-end through the comparator result shape.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b07-openapi-diff-002",
      "title": "Classify compatible OpenAPI additions as minor",
      "description": "As a package maintainer, I want compatible additions such as new routes, optional parameters, additive request/response schema fields, and widened enums classified as minor so that additive REST contract growth maps to a minor semver signal.",
      "acceptanceCriteria": [
        "Adding a route/operation that did not exist in the before document classifies as minor with a stable change code and operation path.",
        "Adding an optional parameter or an additive compatible request/response schema field classifies as minor with stable codes and paths.",
        "Widening an enum with new values (without removing existing values) classifies as minor.",
        "When only compatible additions are present, overall classification is minor (not major or patch).",
        "Focused fixture coverage asserts route, parameter, schema, and enum addition cases.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b07-openapi-diff-003",
      "title": "Classify removals and type narrowing as major",
      "description": "As a package maintainer, I want removals and type-narrowing OpenAPI changes classified as major so that breaking REST contract edits cannot be mistaken for minor or patch bumps.",
      "acceptanceCriteria": [
        "Removing a route/operation, required parameter, or previously present schema property classifies as major with stable change codes and paths.",
        "Narrowing a type or enum (for example removing an enum value or changing a field to a stricter incompatible type) classifies as major.",
        "When any major change is present alongside minor or patch changes, overall classification is major.",
        "Focused fixture coverage asserts removal and type-narrowing cases for route, parameter, schema, and enum surfaces.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b07-openapi-diff-004",
      "title": "Fail closed on unsupported or ambiguous OpenAPI diffs",
      "description": "As a contract reviewer, I want ambiguous or unsupported OpenAPI differences to fail closed rather than receive a guessed softer classification so that unknown semantic cases cannot silently under-report breaking risk.",
      "acceptanceCriteria": [
        "When the comparator encounters an unsupported or ambiguous diff it cannot classify confidently, the comparison fails closed (non-success / explicit failure outcome) instead of returning minor or patch.",
        "Failure diagnostics identify the affected operation or schema path and make clear that classification was refused.",
        "Supported classified cases from stories 001–003 continue to succeed with their expected classifications.",
        "Focused tests cover at least one representative unsupported/ambiguous fixture that fails closed.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b07-openapi-diff-005",
      "title": "Prove the fixture matrix and preserve contract/package quality gates",
      "description": "As a repository maintainer, I want the representative OpenAPI diff fixture matrix and existing contract/package gates to pass so that B07 remains comparator-and-fixtures only and does not disturb publication exports, runtime clients, or package boundaries.",
      "acceptanceCriteria": [
        "The focused fixture matrix includes route, parameter, request/response schema, enum, and docs-only cases with expected major / minor / patch (and fail-closed) outcomes.",
        "Focused comparator tests pass.",
        "make contracts-smoke, make pkg-boundary, and make pkg-file-count pass.",
        "The change does not alter the packages/api package.json export map and does not invent a generated/components topology.",
        "Runtime API handlers, generated Go/TS clients (as a product change), CLI, MCP, UI clients, release workflow, trusted publishing, and B08 SSE surfaces remain out of scope and unchanged by this lane.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    }
  ]
}
