### PR TITLE
stream-b07-agypty-capture-race-fix

### DIFF
--- a/pkg/workers/agypty/session_run.go
+++ b/pkg/workers/agypty/session_run.go
@@ -152,19 +152,19 @@ func executeSessionRun(
 		select {
 		case waitErr = <-waitDone:
 			timer.Stop()
-			return finishSessionRun(reader, readDone, &mu, buf, capacityHit, timedOut, waitErr, proc, runErr)
+			return finishSessionRun(reader, readDone, &mu, &buf, &capacityHit, timedOut, waitErr, proc, runErr)
 		case <-ctx.Done():
 			timer.Stop()
 			_ = proc.Terminate()
 			waitErr = <-waitDone
-			return finishSessionRun(reader, readDone, &mu, buf, capacityHit, timedOut, waitErr, proc, ctx.Err())
+			return finishSessionRun(reader, readDone, &mu, &buf, &capacityHit, timedOut, waitErr, proc, ctx.Err())
 		case <-timer.C:
 			lastByte := readLastByteAt(&mu, &lastByteAt)
 			if sessionRunTimedOut(time.Now(), hardDeadline, cfg, lastByte) {
 				timedOut = true
 				_ = proc.Terminate()
 				waitErr = <-waitDone
-				return finishSessionRun(reader, readDone, &mu, buf, capacityHit, timedOut, waitErr, proc, nil)
+				return finishSessionRun(reader, readDone, &mu, &buf, &capacityHit, timedOut, waitErr, proc, nil)
 			}
 			timer.Reset(timeUntilTimeout(lastByte, hardDeadline, cfg))
 		}
@@ -229,8 +229,8 @@ func finishSessionRun(
 	reader io.ReadCloser,
 	readDone <-chan struct{},
 	mu *sync.Mutex,
-	buf []byte,
-	capacityHit bool,
+	buf *[]byte,
+	capacityHit *bool,
 	timedOut bool,
 	waitErr error,
 	proc *sessionProcess,
@@ -239,8 +239,8 @@ func finishSessionRun(
 	closePTYReader(reader)
 	<-readDone
 	mu.Lock()
-	resultBuf := append([]byte(nil), buf...)
-	hit := capacityHit
+	resultBuf := append([]byte(nil), (*buf)...)
+	hit := *capacityHit
 	mu.Unlock()
 	return finalizeSessionResult(resultBuf, hit, timedOut, waitErr, proc), runErr
 }

--- a/pkg/workers/agypty/session_run.go
+++ b/pkg/workers/agypty/session_run.go
@@ -139,7 +139,7 @@ func executeSessionRun(
 
 	readDone := startPTYCapture(reader, cfg, &mu, &buf, &capacityHit, &lastByteAt)
 
-	timer := time.NewTimer(timeUntilTimeout(lastByteAt, hardDeadline, cfg))
+	timer := time.NewTimer(timeUntilTimeout(readLastByteAt(&mu, &lastByteAt), hardDeadline, cfg))
 	defer timer.Stop()
 
 	var (
@@ -159,13 +159,14 @@ func executeSessionRun(
 			waitErr = <-waitDone
 			return finishSessionRun(reader, readDone, &mu, buf, capacityHit, timedOut, waitErr, proc, ctx.Err())
 		case <-timer.C:
-			if sessionRunTimedOut(time.Now(), hardDeadline, cfg, lastByteAt) {
+			lastByte := readLastByteAt(&mu, &lastByteAt)
+			if sessionRunTimedOut(time.Now(), hardDeadline, cfg, lastByte) {
 				timedOut = true
 				_ = proc.Terminate()
 				waitErr = <-waitDone
 				return finishSessionRun(reader, readDone, &mu, buf, capacityHit, timedOut, waitErr, proc, nil)
 			}
-			timer.Reset(timeUntilTimeout(lastByteAt, hardDeadline, cfg))
+			timer.Reset(timeUntilTimeout(lastByte, hardDeadline, cfg))
 		}
 	}
 }
@@ -209,6 +210,12 @@ func startPTYCapture(
 		}
 	}()
 	return readDone
+}
+
+func readLastByteAt(mu *sync.Mutex, lastByteAt *time.Time) time.Time {
+	mu.Lock()
+	defer mu.Unlock()
+	return *lastByteAt
 }
 
 func sessionRunTimedOut(now, hardDeadline time.Time, cfg SessionConfig, lastByteAt time.Time) bool {


### PR DESCRIPTION
{
  "project": "Fix agypty session-run capture races before Batch 08",
  "branchName": "stream-b07-agypty-capture-race-fix",
  "description": "Make agypty PTY capture and idle/hard timeout scheduling race-clean so SessionResult observes the post-capture buffer, without regressing S17/S18 timeout ordering or primary-result safety.",
  "context": {
    "customerAsk": "Make agypty PTY capture/timeout scheduling race-clean without regressing S17/S18 timeout ordering or primary-result safety. Protect lastByteAt reads used by idle/hard timeout scheduling with the same mutex as the capture writer (or an equivalent race-clean atomic/time source). Pass buf and capacityHit by pointer into finishSessionRun (or copy under lock after <-readDone) so the finalized SessionResult observes the post-capture buffer. Keep cleanup/cancel/timeout process termination behavior unchanged aside from synchronization. Do not weaken partial-timeout semantics, introduce shell strings/Python bridge, change argv validation, or start Stream Batch 08 ownership/resilience work.",
    "problem": "After S17 (#1115) and S18 (#1116) merged, behavioral tests pass without -race, but go test -race ./pkg/workers/agypty/... fails with data races on lastByteAt and the capture buffer between startPTYCapture and executeSessionRun. finishSessionRun also receives buf/capacityHit by value before <-readDone, so a reallocating append can drop capture bytes from the finalized SessionResult.",
    "solution": "Synchronize timeout-scheduling reads of lastByteAt with the capture writer, and finalize SessionResult from the live capture buffer/capacityHit after capture completes (pointer args or copy under lock after <-readDone), without changing cancel/timeout/capacity termination behavior or partial-timeout primary-result rules."
  },
  "acceptanceCriteria": [
    "go test -race ./pkg/workers/agypty/... PASS on Windows (and POSIX where CI runs it)",
    "Idle/hard timeout scheduling no longer races on lastByteAt against the PTY capture writer",
    "Finalized SessionResult observes the post-capture buffer and capacityHit after capture completes (no dropped bytes from stale by-value slice headers)",
    "Existing cancel, hard-timeout, capacity-cap, and cleaning session-run tests still PASS",
    "Partial-timeout semantics unchanged: nonempty cleaned partial may emit Partial=true message, then timeout error, then failed run; Response.Content stays empty on timeout",
    "go test ./pkg/workers/provider/agy/... PASS, including primary-result negatives proving partial timeout cannot become a successful primary result",
    "Quality checks pass (typecheck, lint, tests)"
  ],
  "userStories": [
    {
      "id": "stream-b07-agypty-capture-race-fix-001",
      "title": "Race-clean lastByteAt for idle/hard timeout scheduling",
      "description": "As a maintainer running the agypty worker under the Go race detector, I want idle and hard timeout scheduling to read lastByteAt without racing the PTY capture writer so timeout decisions stay correct and -race is clean.",
      "acceptanceCriteria": [
        "Every read of lastByteAt used by idle/hard timeout scheduling (sessionRunTimedOut, timeUntilTimeout, and the timer-select path) is synchronized with the capture writer via the same mutex, or via an equivalent race-clean atomic/time source",
        "Capture-writer updates to lastByteAt remain consistent with that same synchronization strategy",
        "Cancel, hard-timeout, and idle-timeout process termination behavior is unchanged aside from synchronization",
        "go test -race ./pkg/workers/agypty/... no longer reports a data race on lastByteAt",
        "Existing cancel, hard-timeout, and idle-timeout session-run tests still PASS",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "stream-b07-agypty-capture-race-fix-002",
      "title": "Finalize SessionResult from post-capture buffer under lock",
      "description": "As a runtime consumer of agypty SessionResult, I want the finalized capture buffer and capacityHit to reflect all bytes written before capture completes so reallocating appends cannot drop output from the result.",
      "acceptanceCriteria": [
        "finishSessionRun observes buf and capacityHit by pointer, or copies them under the capture mutex only after <-readDone",
        "When capture reallocates via append, the finalized SessionResult.RawBytes / cleaned text include the post-capture contents rather than a stale pre-wait slice header",
        "Capacity-cap behavior still sets CapacityHit from the synchronized post-capture value",
        "Cleanup/cancel/timeout process termination behavior is unchanged aside from this synchronization",
        "Existing capacity-cap and cleaning session-run tests still PASS",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "stream-b07-agypty-capture-race-fix-003",
      "title": "Prove race-clean capture without weakening partial-timeout primary-result safety",
      "description": "As a reviewer of the S17/S18 correction, I want full package race coverage plus provider-agy primary-result negatives to prove the sync fix did not weaken timeout ordering or allow partial timeout output to become a successful primary result.",
      "acceptanceCriteria": [
        "go test -race ./pkg/workers/agypty/... PASS on Windows (and POSIX where CI runs it)",
        "go test ./pkg/workers/agypty/... PASS, including cancel, hard-timeout, capacity-cap, and cleaning session-run coverage",
        "Partial-timeout semantics remain: nonempty cleaned partial may emit Partial=true message, then timeout error, then failed run; Response.Content stays empty on timeout",
        "go test ./pkg/workers/provider/agy/... PASS, including primary-result negatives proving partial timeout cannot become a successful primary result",
        "No shell strings, Python bridge, argv-validation changes, or Stream Batch 08 ownership/resilience work introduced by this correction",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    }
  ]
}
