### PR TITLE
interfaces-b09-cli-schema

### DIFF
--- a/cmd/contractsvalidate/main.go
+++ b/cmd/contractsvalidate/main.go
@@ -15,7 +15,7 @@ const successMessage = "[agent-factory:contracts-validate] registered contracts 
 func main() {
 	root := flag.String("root", ".", "repository root")
 	flag.Parse()
-	os.Exit(run(*root, contractvalidator.CommonRegistry(), os.Stdout, os.Stderr))
+	os.Exit(run(*root, contractvalidator.DefaultRegistry(), os.Stdout, os.Stderr))
 }
 
 func run(root string, registry contractvalidator.Registry, stdout, stderr io.Writer) int {

--- a/contracts/cli/command-manifest.schema.json
+++ b/contracts/cli/command-manifest.schema.json
@@ -116,6 +116,16 @@
           "additionalProperties": {
             "$ref": "#/$defs/flag"
           }
+        },
+        "relationships": {
+          "description": "Parse-constraint relationship records keyed by stable relationship identifiers. Object keys make duplicate relationship IDs structurally unrepresentable.",
+          "type": "object",
+          "propertyNames": {
+            "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/relationship"
+          }
         }
       }
     },
@@ -446,6 +456,112 @@
             "properties": {
               "valueType": {
                 "const": "stringArray"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "participantRef": {
+      "description": "Stable reference to one flag or argument participant in a relationship group.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "id"
+      ],
+      "properties": {
+        "type": {
+          "description": "Whether the participant is a flag or positional argument on the same command.",
+          "enum": [
+            "flag",
+            "argument"
+          ]
+        },
+        "id": {
+          "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"
+        }
+      }
+    },
+    "relationship": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind",
+        "participants"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"
+        },
+        "kind": {
+          "description": "The parse-constraint relationship expressed by this record.",
+          "enum": [
+            "mutually-exclusive",
+            "required-together",
+            "at-least-one",
+            "conditional",
+            "conflict"
+          ]
+        },
+        "participants": {
+          "description": "Ordered participant references constrained by this relationship.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/participantRef"
+          },
+          "uniqueItems": true
+        },
+        "when": {
+          "description": "Trigger participant for conditional relationships. Required when kind is conditional.",
+          "$ref": "#/$defs/participantRef"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "enum": [
+                  "mutually-exclusive",
+                  "required-together",
+                  "at-least-one",
+                  "conflict"
+                ]
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
+          "then": {
+            "properties": {
+              "participants": {
+                "minItems": 2
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "conditional"
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
+          "then": {
+            "required": [
+              "when"
+            ],
+            "properties": {
+              "participants": {
+                "minItems": 2
               }
             }
           }

--- a/contracts/cli/command-manifest.schema.json
+++ b/contracts/cli/command-manifest.schema.json
@@ -106,6 +106,16 @@
           "additionalProperties": {
             "$ref": "#/$defs/argument"
           }
+        },
+        "flags": {
+          "description": "Flag records keyed by stable flag identifiers. Object keys make duplicate flag IDs structurally unrepresentable.",
+          "type": "object",
+          "propertyNames": {
+            "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/flag"
+          }
         }
       }
     },
@@ -275,6 +285,168 @@
               "required": [
                 "maxCardinality"
               ]
+            }
+          }
+        }
+      ]
+    },
+    "flag": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "long",
+        "shorthand",
+        "aliases",
+        "scope",
+        "valueType",
+        "required",
+        "default",
+        "changedDefault",
+        "noOptionDefault",
+        "repeatable",
+        "normalization",
+        "completion",
+        "binding",
+        "visibility",
+        "lifecycle"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"
+        },
+        "long": {
+          "description": "The primary long flag name without leading dashes.",
+          "type": "string",
+          "minLength": 1
+        },
+        "shorthand": {
+          "description": "Optional single-character shorthand. Use an empty string when no shorthand is exposed.",
+          "type": "string",
+          "maxLength": 1
+        },
+        "aliases": {
+          "description": "Alternate long flag spellings accepted for this flag.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "scope": {
+          "description": "Whether the flag is local to one command, persistent on a subtree, or inherited from an ancestor.",
+          "enum": [
+            "local",
+            "persistent",
+            "inherited"
+          ]
+        },
+        "valueType": {
+          "description": "The scalar or collection type accepted for one flag value.",
+          "enum": [
+            "bool",
+            "string",
+            "int",
+            "int64",
+            "stringArray"
+          ]
+        },
+        "required": {
+          "description": "Whether the flag must be supplied before invocation proceeds.",
+          "type": "boolean"
+        },
+        "default": {
+          "description": "Serialized default value for the flag when it is omitted.",
+          "type": "string"
+        },
+        "changedDefault": {
+          "description": "Whether the effective default differs from the originally authored default.",
+          "type": "boolean"
+        },
+        "noOptionDefault": {
+          "description": "Serialized value applied when a boolean flag is present without an explicit option value. Use an empty string when no-option defaults are unsupported.",
+          "type": "string"
+        },
+        "repeatable": {
+          "description": "Whether the flag may be supplied multiple times on one invocation line.",
+          "type": "boolean"
+        },
+        "normalization": {
+          "description": "Optional value normalization applied after parsing. Use an empty string when no normalization is configured.",
+          "type": "string",
+          "enum": [
+            "",
+            "lowercase",
+            "trim",
+            "lowercase-trim"
+          ]
+        },
+        "completion": {
+          "description": "How shell completion values are sourced for this flag.",
+          "enum": [
+            "none",
+            "static",
+            "dynamic"
+          ]
+        },
+        "binding": {
+          "description": "Optional binding target for this flag. Use an empty string when the flag is not bound to another input surface.",
+          "type": "string"
+        },
+        "visibility": {
+          "description": "Whether the flag is shown in default help output.",
+          "enum": [
+            "visible",
+            "hidden"
+          ]
+        },
+        "lifecycle": {
+          "$ref": "https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "noOptionDefault": {
+                "minLength": 1
+              }
+            },
+            "required": [
+              "noOptionDefault"
+            ]
+          },
+          "then": {
+            "properties": {
+              "valueType": {
+                "const": "bool"
+              },
+              "noOptionDefault": {
+                "enum": [
+                  "true",
+                  "false"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "repeatable": {
+                "const": true
+              }
+            },
+            "required": [
+              "repeatable"
+            ]
+          },
+          "then": {
+            "properties": {
+              "valueType": {
+                "const": "stringArray"
+              }
             }
           }
         }

--- a/contracts/cli/command-manifest.schema.json
+++ b/contracts/cli/command-manifest.schema.json
@@ -126,6 +126,48 @@
           "additionalProperties": {
             "$ref": "#/$defs/relationship"
           }
+        },
+        "precedence": {
+          "$ref": "#/$defs/precedence"
+        },
+        "channels": {
+          "$ref": "#/$defs/channels"
+        },
+        "outputs": {
+          "description": "Declared command output records keyed by stable output identifiers. Object keys make duplicate output IDs structurally unrepresentable.",
+          "type": "object",
+          "propertyNames": {
+            "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/output"
+          }
+        },
+        "exits": {
+          "description": "Declared exit-code records keyed by stable exit identifiers. Object keys make duplicate exit IDs structurally unrepresentable.",
+          "type": "object",
+          "propertyNames": {
+            "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/exit"
+          }
+        },
+        "sideEffects": {
+          "description": "Declared side-effect records keyed by stable side-effect identifiers. Object keys make duplicate side-effect IDs structurally unrepresentable.",
+          "type": "object",
+          "propertyNames": {
+            "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/sideEffect"
+          }
+        },
+        "constraints": {
+          "$ref": "#/$defs/constraints"
+        },
+        "handler": {
+          "$ref": "#/$defs/handler"
         }
       }
     },
@@ -609,6 +651,208 @@
         "example": {
           "description": "Optional multi-line example block rendered after the usage line.",
           "type": "string"
+        }
+      }
+    },
+    "precedence": {
+      "description": "Relative precedence of input sources when resolving one command invocation.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "order"
+      ],
+      "properties": {
+        "order": {
+          "description": "Ordered input sources from highest to lowest precedence. Each source appears exactly once.",
+          "type": "array",
+          "minItems": 6,
+          "maxItems": 6,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "flags",
+              "args",
+              "env",
+              "config",
+              "stdin",
+              "defaults"
+            ]
+          }
+        }
+      }
+    },
+    "channels": {
+      "description": "Invocation input and output channels exposed by one command.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "input",
+        "output"
+      ],
+      "properties": {
+        "input": {
+          "description": "Input channels that may supply values for this command.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "cli",
+              "env",
+              "config",
+              "stdin"
+            ]
+          }
+        },
+        "output": {
+          "description": "Output channels that may receive values from this command.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "stdout",
+              "stderr",
+              "file"
+            ]
+          }
+        }
+      }
+    },
+    "output": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "channel",
+        "format"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"
+        },
+        "channel": {
+          "description": "The output channel that carries this payload.",
+          "enum": [
+            "stdout",
+            "stderr",
+            "file"
+          ]
+        },
+        "format": {
+          "description": "The serialized payload format emitted on the channel.",
+          "enum": [
+            "text",
+            "json",
+            "yaml",
+            "binary"
+          ]
+        }
+      }
+    },
+    "exit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "code",
+        "kind"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"
+        },
+        "code": {
+          "description": "Process exit code returned for this outcome.",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "kind": {
+          "description": "Semantic classification of the exit outcome.",
+          "enum": [
+            "success",
+            "failure",
+            "usage",
+            "cancel"
+          ]
+        }
+      }
+    },
+    "sideEffect": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"
+        },
+        "kind": {
+          "description": "The external surface touched by this side effect.",
+          "enum": [
+            "filesystem",
+            "network",
+            "process",
+            "config"
+          ]
+        }
+      }
+    },
+    "constraints": {
+      "description": "Runtime and platform constraints governing command execution.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "runtime",
+        "platforms"
+      ],
+      "properties": {
+        "runtime": {
+          "description": "Supported runtime environments for this command.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "local",
+              "hosted",
+              "container"
+            ]
+          }
+        },
+        "platforms": {
+          "description": "Supported host platforms for this command.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "linux",
+              "darwin",
+              "windows"
+            ]
+          }
+        }
+      }
+    },
+    "handler": {
+      "description": "Stable handler identity and optional OpenAPI operation binding for one runnable command.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"
+        },
+        "operationId": {
+          "description": "Optional OpenAPI operationId bound to this handler.",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9]*$"
         }
       }
     }

--- a/contracts/cli/command-manifest.schema.json
+++ b/contracts/cli/command-manifest.schema.json
@@ -96,8 +96,189 @@
         },
         "usage": {
           "$ref": "#/$defs/usage"
+        },
+        "arguments": {
+          "description": "Positional argument records keyed by stable argument identifiers. Object keys make duplicate argument IDs structurally unrepresentable.",
+          "type": "object",
+          "propertyNames": {
+            "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/argument"
+          }
         }
       }
+    },
+    "argument": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "position",
+        "kind",
+        "valueType",
+        "required",
+        "minCardinality",
+        "maxCardinality",
+        "variadic",
+        "enum",
+        "pattern",
+        "completion",
+        "channels",
+        "doubleDash"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"
+        },
+        "name": {
+          "description": "The positional argument name rendered in usage templates.",
+          "type": "string",
+          "minLength": 1
+        },
+        "position": {
+          "description": "Zero-based positional index within the command argument list.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "kind": {
+          "description": "How the argument is consumed during parsing.",
+          "enum": [
+            "positional"
+          ]
+        },
+        "valueType": {
+          "description": "The scalar type accepted for one positional value.",
+          "enum": [
+            "string"
+          ]
+        },
+        "required": {
+          "description": "Whether the argument must receive at least one value before invocation proceeds.",
+          "type": "boolean"
+        },
+        "minCardinality": {
+          "description": "Minimum number of values accepted for this argument.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "maxCardinality": {
+          "description": "Maximum number of values accepted for this argument. Use -1 for unbounded variadic overflow.",
+          "type": "integer",
+          "minimum": -1
+        },
+        "variadic": {
+          "description": "Whether the argument consumes all remaining positional values.",
+          "type": "boolean"
+        },
+        "enum": {
+          "description": "Closed set of accepted values when the argument is restricted to enumerated strings.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "pattern": {
+          "description": "Optional regular expression restricting accepted string values.",
+          "type": "string"
+        },
+        "completion": {
+          "description": "How shell completion values are sourced for this argument.",
+          "enum": [
+            "none",
+            "static",
+            "dynamic"
+          ]
+        },
+        "channels": {
+          "description": "Input channels that may supply values for this argument.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "enum": [
+              "cli",
+              "env",
+              "config",
+              "stdin"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "doubleDash": {
+          "description": "How a bare -- token is interpreted relative to this command's positional arguments.",
+          "enum": [
+            "none",
+            "terminates-flags"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "required": {
+                "const": true
+              }
+            },
+            "required": [
+              "required"
+            ]
+          },
+          "then": {
+            "properties": {
+              "minCardinality": {
+                "minimum": 1
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "variadic": {
+                "const": true
+              }
+            },
+            "required": [
+              "variadic"
+            ]
+          },
+          "then": {
+            "properties": {
+              "maxCardinality": {
+                "const": -1
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "variadic": {
+                "const": false
+              }
+            },
+            "required": [
+              "variadic"
+            ]
+          },
+          "then": {
+            "not": {
+              "properties": {
+                "maxCardinality": {
+                  "const": -1
+                }
+              },
+              "required": [
+                "maxCardinality"
+              ]
+            }
+          }
+        }
+      ]
     },
     "suggestion": {
       "description": "Shell-completion and argument-suggestion metadata for one command.",

--- a/contracts/cli/command-manifest.schema.json
+++ b/contracts/cli/command-manifest.schema.json
@@ -1,0 +1,147 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.portpowered.com/you/contracts/cli/command-manifest.schema.json",
+  "title": "You CLI command manifest",
+  "description": "Authored CLI command metadata, inputs, relationships, execution metadata, and handler bindings for one command tree.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "formatVersion",
+    "rootPath",
+    "commands"
+  ],
+  "properties": {
+    "formatVersion": {
+      "description": "The explicitly supported version of this command-manifest format.",
+      "const": "1.0.0"
+    },
+    "rootPath": {
+      "description": "The space-delimited command path of the manifest root command.",
+      "type": "string",
+      "minLength": 1
+    },
+    "commands": {
+      "description": "Command records keyed by stable command identifiers. Object keys make duplicate command IDs structurally unrepresentable.",
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": {
+        "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/command"
+      }
+    }
+  },
+  "$defs": {
+    "command": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "path",
+        "aliases",
+        "documentation",
+        "lifecycle",
+        "visibility",
+        "runnable",
+        "usage"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"
+        },
+        "name": {
+          "description": "The final command segment name exposed to users.",
+          "type": "string",
+          "minLength": 1
+        },
+        "path": {
+          "description": "The full space-delimited command path from the manifest root.",
+          "type": "string",
+          "minLength": 1
+        },
+        "aliases": {
+          "description": "Alternate spellings accepted for the final command segment.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "groupId": {
+          "description": "Optional Cobra command-group identifier for help grouping.",
+          "type": "string"
+        },
+        "documentation": {
+          "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json"
+        },
+        "lifecycle": {
+          "$ref": "https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json"
+        },
+        "visibility": {
+          "description": "Whether the command is shown in default help output.",
+          "enum": [
+            "visible",
+            "hidden"
+          ]
+        },
+        "runnable": {
+          "description": "Whether the command exposes a runnable handler.",
+          "type": "boolean"
+        },
+        "suggestion": {
+          "$ref": "#/$defs/suggestion"
+        },
+        "usage": {
+          "$ref": "#/$defs/usage"
+        }
+      }
+    },
+    "suggestion": {
+      "description": "Shell-completion and argument-suggestion metadata for one command.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "minimumDistance": {
+          "description": "Minimum Levenshtein distance accepted when matching misspelled subcommands.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "disableDefaultCmd": {
+          "description": "Whether the default help subcommand suggestion is suppressed.",
+          "type": "boolean"
+        },
+        "validArgs": {
+          "description": "Static positional values accepted by the command when no dynamic completion is configured.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "usage": {
+      "description": "Invocation-line and example metadata rendered in help output.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "line"
+      ],
+      "properties": {
+        "line": {
+          "description": "The canonical usage template for the command.",
+          "type": "string",
+          "minLength": 1
+        },
+        "example": {
+          "description": "Optional multi-line example block rendered after the usage line.",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/contracts/command_manifest_schema_test.go
+++ b/contracts/command_manifest_schema_test.go
@@ -116,3 +116,42 @@ func TestCommandManifestSchemaFlagFixtures(t *testing.T) {
 		})
 	}
 }
+
+func TestCommandManifestSchemaRelationshipFixtures(t *testing.T) {
+	schema := commandManifestSchema(t)
+
+	tests := []struct {
+		name     string
+		fixture  string
+		valid    bool
+		wantPath string
+	}{
+		{name: "valid mutex relationship", fixture: "valid-mutex-relationship.json", valid: true},
+		{name: "valid required-together relationship", fixture: "valid-required-together-relationship.json", valid: true},
+		{name: "valid conditional relationship", fixture: "valid-conditional-relationship.json", valid: true},
+		{
+			name:     "mutex relationship with one participant",
+			fixture:  "invalid-relationship-impossible.json",
+			wantPath: "/commands/example.factory.export/relationships/example.factory.export.rel.mutex.archive/participants",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			instance := readJSON(t, filepath.Join("testdata", "cli", test.fixture))
+			err := schema.Validate(instance)
+			if test.valid {
+				if err != nil {
+					t.Fatalf("validate valid fixture: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected fixture validation to fail")
+			}
+			if paths := validationPaths(t, err); !slices.Contains(paths, test.wantPath) {
+				t.Fatalf("validation paths = %v, want %q", paths, test.wantPath)
+			}
+		})
+	}
+}

--- a/contracts/command_manifest_schema_test.go
+++ b/contracts/command_manifest_schema_test.go
@@ -156,6 +156,85 @@ func TestCommandManifestSchemaRelationshipFixtures(t *testing.T) {
 	}
 }
 
+func TestCommandManifestSchemaValidFixtureMatrix(t *testing.T) {
+	schema := commandManifestSchema(t)
+
+	tests := []struct {
+		name    string
+		fixture string
+	}{
+		{name: "identity metadata", fixture: "valid-identity.json"},
+		{name: "optional positional argument", fixture: "valid-optional-argument.json"},
+		{name: "variadic argument", fixture: "valid-variadic-argument.json"},
+		{name: "persistent flag", fixture: "valid-persistent-flag.json"},
+		{name: "inherited flag", fixture: "valid-inherited-flag.json"},
+		{name: "no-option flag", fixture: "valid-no-option-flag.json"},
+		{name: "mutex relationship", fixture: "valid-mutex-relationship.json"},
+		{name: "required-together relationship", fixture: "valid-required-together-relationship.json"},
+		{name: "conditional relationship", fixture: "valid-conditional-relationship.json"},
+		{name: "precedence and execution metadata", fixture: "valid-precedence.json"},
+		{name: "handler binding", fixture: "valid-handler-binding.json"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			instance := readJSON(t, filepath.Join("testdata", "cli", test.fixture))
+			if err := schema.Validate(instance); err != nil {
+				t.Fatalf("validate valid fixture %s: %v", test.fixture, err)
+			}
+		})
+	}
+}
+
+func TestCommandManifestSchemaInvalidFixtureMatrix(t *testing.T) {
+	schema := commandManifestSchema(t)
+
+	tests := []struct {
+		name     string
+		fixture  string
+		wantPath string
+	}{
+		{
+			name:     "invalid argument cardinality",
+			fixture:  "invalid-argument-cardinality.json",
+			wantPath: "/commands/example.factory.collect/arguments/example.factory.collect.arg.items/maxCardinality",
+		},
+		{
+			name:     "unknown flag property",
+			fixture:  "invalid-flag-unknown-property.json",
+			wantPath: "/commands/example.factory.inspect/flags/example.factory.inspect.flag.output",
+		},
+		{
+			name:     "no-option default on string flag",
+			fixture:  "invalid-flag-scope-value.json",
+			wantPath: "/commands/example.factory.publish/flags/example.factory.publish.flag.channel/valueType",
+		},
+		{
+			name:     "impossible mutex relationship",
+			fixture:  "invalid-relationship-impossible.json",
+			wantPath: "/commands/example.factory.export/relationships/example.factory.export.rel.mutex.archive/participants",
+		},
+		{
+			name:     "invalid handler id",
+			fixture:  "invalid-handler-id.json",
+			wantPath: "/commands/example.factory.dispatch/handler/id",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			instance := readJSON(t, filepath.Join("testdata", "cli", test.fixture))
+			err := schema.Validate(instance)
+			if err == nil {
+				t.Fatal("expected fixture validation to fail")
+			}
+			if paths := validationPaths(t, err); !slices.Contains(paths, test.wantPath) {
+				t.Fatalf("validation paths = %v, want %q", paths, test.wantPath)
+			}
+		})
+	}
+}
+
 func TestCommandManifestSchemaExecutionMetadataFixtures(t *testing.T) {
 	schema := commandManifestSchema(t)
 

--- a/contracts/command_manifest_schema_test.go
+++ b/contracts/command_manifest_schema_test.go
@@ -1,0 +1,29 @@
+package contracts_test
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+const commandManifestSchemaID = "https://schemas.portpowered.com/you/contracts/cli/command-manifest.schema.json"
+
+func TestCommandManifestSchemaValidIdentityFixture(t *testing.T) {
+	schema := compileSchema(
+		t,
+		filepath.Join("cli", "command-manifest.schema.json"),
+		commandManifestSchemaID,
+		schemaResource{
+			path: filepath.Join("common", "documentation.schema.json"),
+			id:   documentationSchemaID,
+		},
+		schemaResource{
+			path: filepath.Join("common", "deprecations.schema.json"),
+			id:   deprecationsSchemaID,
+		},
+	)
+
+	instance := readJSON(t, filepath.Join("testdata", "cli", "valid-identity.json"))
+	if err := schema.Validate(instance); err != nil {
+		t.Fatalf("validate valid identity fixture: %v", err)
+	}
+}

--- a/contracts/command_manifest_schema_test.go
+++ b/contracts/command_manifest_schema_test.go
@@ -155,3 +155,41 @@ func TestCommandManifestSchemaRelationshipFixtures(t *testing.T) {
 		})
 	}
 }
+
+func TestCommandManifestSchemaExecutionMetadataFixtures(t *testing.T) {
+	schema := commandManifestSchema(t)
+
+	tests := []struct {
+		name     string
+		fixture  string
+		valid    bool
+		wantPath string
+	}{
+		{name: "valid precedence and execution metadata", fixture: "valid-precedence.json", valid: true},
+		{name: "valid handler binding", fixture: "valid-handler-binding.json", valid: true},
+		{
+			name:     "invalid handler id",
+			fixture:  "invalid-handler-id.json",
+			wantPath: "/commands/example.factory.dispatch/handler/id",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			instance := readJSON(t, filepath.Join("testdata", "cli", test.fixture))
+			err := schema.Validate(instance)
+			if test.valid {
+				if err != nil {
+					t.Fatalf("validate valid fixture: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected fixture validation to fail")
+			}
+			if paths := validationPaths(t, err); !slices.Contains(paths, test.wantPath) {
+				t.Fatalf("validation paths = %v, want %q", paths, test.wantPath)
+			}
+		})
+	}
+}

--- a/contracts/command_manifest_schema_test.go
+++ b/contracts/command_manifest_schema_test.go
@@ -72,3 +72,47 @@ func TestCommandManifestSchemaArgumentFixtures(t *testing.T) {
 		})
 	}
 }
+
+func TestCommandManifestSchemaFlagFixtures(t *testing.T) {
+	schema := commandManifestSchema(t)
+
+	tests := []struct {
+		name     string
+		fixture  string
+		valid    bool
+		wantPath string
+	}{
+		{name: "valid persistent flag", fixture: "valid-persistent-flag.json", valid: true},
+		{name: "valid inherited flag", fixture: "valid-inherited-flag.json", valid: true},
+		{name: "valid no-option flag", fixture: "valid-no-option-flag.json", valid: true},
+		{
+			name:     "unknown flag property",
+			fixture:  "invalid-flag-unknown-property.json",
+			wantPath: "/commands/example.factory.inspect/flags/example.factory.inspect.flag.output",
+		},
+		{
+			name:     "no-option default on string flag",
+			fixture:  "invalid-flag-scope-value.json",
+			wantPath: "/commands/example.factory.publish/flags/example.factory.publish.flag.channel/valueType",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			instance := readJSON(t, filepath.Join("testdata", "cli", test.fixture))
+			err := schema.Validate(instance)
+			if test.valid {
+				if err != nil {
+					t.Fatalf("validate valid fixture: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected fixture validation to fail")
+			}
+			if paths := validationPaths(t, err); !slices.Contains(paths, test.wantPath) {
+				t.Fatalf("validation paths = %v, want %q", paths, test.wantPath)
+			}
+		})
+	}
+}

--- a/contracts/command_manifest_schema_test.go
+++ b/contracts/command_manifest_schema_test.go
@@ -2,13 +2,17 @@ package contracts_test
 
 import (
 	"path/filepath"
+	"slices"
 	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
 const commandManifestSchemaID = "https://schemas.portpowered.com/you/contracts/cli/command-manifest.schema.json"
 
-func TestCommandManifestSchemaValidIdentityFixture(t *testing.T) {
-	schema := compileSchema(
+func commandManifestSchema(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+	return compileSchema(
 		t,
 		filepath.Join("cli", "command-manifest.schema.json"),
 		commandManifestSchemaID,
@@ -21,9 +25,50 @@ func TestCommandManifestSchemaValidIdentityFixture(t *testing.T) {
 			id:   deprecationsSchemaID,
 		},
 	)
+}
 
+func TestCommandManifestSchemaValidIdentityFixture(t *testing.T) {
+	schema := commandManifestSchema(t)
 	instance := readJSON(t, filepath.Join("testdata", "cli", "valid-identity.json"))
 	if err := schema.Validate(instance); err != nil {
 		t.Fatalf("validate valid identity fixture: %v", err)
+	}
+}
+
+func TestCommandManifestSchemaArgumentFixtures(t *testing.T) {
+	schema := commandManifestSchema(t)
+
+	tests := []struct {
+		name     string
+		fixture  string
+		valid    bool
+		wantPath string
+	}{
+		{name: "valid optional positional argument", fixture: "valid-optional-argument.json", valid: true},
+		{name: "valid variadic argument", fixture: "valid-variadic-argument.json", valid: true},
+		{
+			name:     "variadic argument with bounded max cardinality",
+			fixture:  "invalid-argument-cardinality.json",
+			wantPath: "/commands/example.factory.collect/arguments/example.factory.collect.arg.items/maxCardinality",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			instance := readJSON(t, filepath.Join("testdata", "cli", test.fixture))
+			err := schema.Validate(instance)
+			if test.valid {
+				if err != nil {
+					t.Fatalf("validate valid fixture: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected fixture validation to fail")
+			}
+			if paths := validationPaths(t, err); !slices.Contains(paths, test.wantPath) {
+				t.Fatalf("validation paths = %v, want %q", paths, test.wantPath)
+			}
+		})
 	}
 }

--- a/contracts/testdata/cli/invalid-ambiguous-flag-argument.json
+++ b/contracts/testdata/cli/invalid-ambiguous-flag-argument.json
@@ -1,0 +1,89 @@
+{
+  "formatVersion": "1.0.0",
+  "rootPath": "example",
+  "commands": {
+    "example.factory.sync": {
+      "id": "example.factory.sync",
+      "name": "sync",
+      "path": "example factory sync",
+      "aliases": [],
+      "groupId": "factory",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.sync",
+        "documentation": {
+          "title": {
+            "id": "example.factory.sync.title",
+            "canonicalEnglish": "Synchronize factory state"
+          },
+          "description": {
+            "id": "example.factory.sync.description",
+            "canonicalEnglish": "Claims the same stable identity for one flag and one positional argument."
+          }
+        },
+        "examples": [
+          "example factory sync target"
+        ],
+        "visibility": "public",
+        "sourceHash": "3333444455556666777788889999000011112222aaaabbbbccccddddeeeeffff"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.sync",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "visibility": "visible",
+      "runnable": true,
+      "usage": {
+        "line": "sync [target]",
+        "example": "  example factory sync target --target other"
+      },
+      "arguments": {
+        "example.factory.sync.target": {
+          "id": "example.factory.sync.target",
+          "name": "target",
+          "position": 0,
+          "kind": "positional",
+          "valueType": "string",
+          "required": false,
+          "minCardinality": 0,
+          "maxCardinality": 1,
+          "variadic": false,
+          "enum": [],
+          "pattern": "",
+          "completion": "none",
+          "channels": [
+            "cli"
+          ],
+          "doubleDash": "terminates-flags"
+        }
+      },
+      "flags": {
+        "example.factory.sync.target": {
+          "id": "example.factory.sync.target",
+          "long": "target",
+          "shorthand": "",
+          "aliases": [],
+          "scope": "local",
+          "valueType": "string",
+          "required": false,
+          "default": "",
+          "changedDefault": false,
+          "noOptionDefault": "",
+          "repeatable": false,
+          "normalization": "",
+          "completion": "none",
+          "binding": "",
+          "visibility": "visible",
+          "lifecycle": {
+            "formatVersion": "1.0.0",
+            "itemId": "example.factory.sync.target",
+            "state": "active",
+            "since": "1.0.0"
+          }
+        }
+      }
+    }
+  }
+}

--- a/contracts/testdata/cli/invalid-argument-cardinality.json
+++ b/contracts/testdata/cli/invalid-argument-cardinality.json
@@ -1,0 +1,63 @@
+{
+  "formatVersion": "1.0.0",
+  "rootPath": "example",
+  "commands": {
+    "example.factory.collect": {
+      "id": "example.factory.collect",
+      "name": "collect",
+      "path": "example factory collect",
+      "aliases": [],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.collect",
+        "documentation": {
+          "title": {
+            "id": "example.factory.collect.title",
+            "canonicalEnglish": "Collect factory artifacts"
+          },
+          "description": {
+            "id": "example.factory.collect.description",
+            "canonicalEnglish": "Collects one or more artifacts from a factory session."
+          }
+        },
+        "examples": [
+          "example factory collect"
+        ],
+        "visibility": "public",
+        "sourceHash": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.collect",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "visibility": "visible",
+      "runnable": true,
+      "usage": {
+        "line": "collect [items...]",
+        "example": "  example factory collect"
+      },
+      "arguments": {
+        "example.factory.collect.arg.items": {
+          "id": "example.factory.collect.arg.items",
+          "name": "items",
+          "position": 0,
+          "kind": "positional",
+          "valueType": "string",
+          "required": false,
+          "minCardinality": 0,
+          "maxCardinality": 1,
+          "variadic": true,
+          "enum": [],
+          "pattern": "",
+          "completion": "none",
+          "channels": [
+            "cli"
+          ],
+          "doubleDash": "terminates-flags"
+        }
+      }
+    }
+  }
+}

--- a/contracts/testdata/cli/invalid-duplicate-stable-id.json
+++ b/contracts/testdata/cli/invalid-duplicate-stable-id.json
@@ -1,0 +1,82 @@
+{
+  "formatVersion": "1.0.0",
+  "rootPath": "example",
+  "commands": {
+    "example.factory.alpha": {
+      "id": "example.factory.alpha",
+      "name": "alpha",
+      "path": "example factory alpha",
+      "aliases": [],
+      "groupId": "factory",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.alpha",
+        "documentation": {
+          "title": {
+            "id": "example.factory.shared.title",
+            "canonicalEnglish": "Alpha factory command"
+          },
+          "description": {
+            "id": "example.factory.alpha.description",
+            "canonicalEnglish": "First command that reuses a documentation title identity."
+          }
+        },
+        "examples": [
+          "example factory alpha"
+        ],
+        "visibility": "public",
+        "sourceHash": "1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.alpha",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "visibility": "visible",
+      "runnable": true,
+      "usage": {
+        "line": "alpha",
+        "example": "  example factory alpha"
+      }
+    },
+    "example.factory.beta": {
+      "id": "example.factory.beta",
+      "name": "beta",
+      "path": "example factory beta",
+      "aliases": [],
+      "groupId": "factory",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.beta",
+        "documentation": {
+          "title": {
+            "id": "example.factory.shared.title",
+            "canonicalEnglish": "Beta factory command"
+          },
+          "description": {
+            "id": "example.factory.beta.description",
+            "canonicalEnglish": "Second command that reuses the same documentation title identity."
+          }
+        },
+        "examples": [
+          "example factory beta"
+        ],
+        "visibility": "public",
+        "sourceHash": "2222333344445555666677778888999900001111aaaabbbbccccddddeeeeffff"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.beta",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "visibility": "visible",
+      "runnable": true,
+      "usage": {
+        "line": "beta",
+        "example": "  example factory beta"
+      }
+    }
+  }
+}

--- a/contracts/testdata/cli/invalid-flag-scope-value.json
+++ b/contracts/testdata/cli/invalid-flag-scope-value.json
@@ -1,0 +1,68 @@
+{
+  "formatVersion": "1.0.0",
+  "rootPath": "example",
+  "commands": {
+    "example.factory.publish": {
+      "id": "example.factory.publish",
+      "name": "publish",
+      "path": "example factory publish",
+      "aliases": [],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.publish",
+        "documentation": {
+          "title": {
+            "id": "example.factory.publish.title",
+            "canonicalEnglish": "Publish factory artifacts"
+          },
+          "description": {
+            "id": "example.factory.publish.description",
+            "canonicalEnglish": "Publishes factory artifacts with an invalid no-option default on a string flag."
+          }
+        },
+        "examples": [
+          "example factory publish"
+        ],
+        "visibility": "public",
+        "sourceHash": "5555666677778888999900001111222233334444aaaabbbbccccddddeeeeffff"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.publish",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "visibility": "visible",
+      "runnable": true,
+      "usage": {
+        "line": "publish",
+        "example": "  example factory publish"
+      },
+      "flags": {
+        "example.factory.publish.flag.channel": {
+          "id": "example.factory.publish.flag.channel",
+          "long": "channel",
+          "shorthand": "",
+          "aliases": [],
+          "scope": "local",
+          "valueType": "string",
+          "required": false,
+          "default": "",
+          "changedDefault": false,
+          "noOptionDefault": "true",
+          "repeatable": false,
+          "normalization": "",
+          "completion": "none",
+          "binding": "",
+          "visibility": "visible",
+          "lifecycle": {
+            "formatVersion": "1.0.0",
+            "itemId": "example.factory.publish.flag.channel",
+            "state": "active",
+            "since": "1.0.0"
+          }
+        }
+      }
+    }
+  }
+}

--- a/contracts/testdata/cli/invalid-flag-unknown-property.json
+++ b/contracts/testdata/cli/invalid-flag-unknown-property.json
@@ -1,0 +1,69 @@
+{
+  "formatVersion": "1.0.0",
+  "rootPath": "example",
+  "commands": {
+    "example.factory.inspect": {
+      "id": "example.factory.inspect",
+      "name": "inspect",
+      "path": "example factory inspect",
+      "aliases": [],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.inspect",
+        "documentation": {
+          "title": {
+            "id": "example.factory.inspect.title",
+            "canonicalEnglish": "Inspect factory state"
+          },
+          "description": {
+            "id": "example.factory.inspect.description",
+            "canonicalEnglish": "Inspects factory state with an invalid unknown flag property."
+          }
+        },
+        "examples": [
+          "example factory inspect"
+        ],
+        "visibility": "public",
+        "sourceHash": "4444555566667777888899990000111122223333aaaabbbbccccddddeeeeffff"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.inspect",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "visibility": "visible",
+      "runnable": true,
+      "usage": {
+        "line": "inspect",
+        "example": "  example factory inspect"
+      },
+      "flags": {
+        "example.factory.inspect.flag.output": {
+          "id": "example.factory.inspect.flag.output",
+          "long": "output",
+          "shorthand": "o",
+          "aliases": [],
+          "scope": "local",
+          "valueType": "string",
+          "required": false,
+          "default": "",
+          "changedDefault": false,
+          "noOptionDefault": "",
+          "repeatable": false,
+          "normalization": "",
+          "completion": "none",
+          "binding": "",
+          "visibility": "visible",
+          "lifecycle": {
+            "formatVersion": "1.0.0",
+            "itemId": "example.factory.inspect.flag.output",
+            "state": "active",
+            "since": "1.0.0"
+          },
+          "unknownField": "not-allowed"
+        }
+      }
+    }
+  }
+}

--- a/contracts/testdata/cli/invalid-handler-id.json
+++ b/contracts/testdata/cli/invalid-handler-id.json
@@ -1,0 +1,48 @@
+{
+  "formatVersion": "1.0.0",
+  "rootPath": "example",
+  "commands": {
+    "example.factory.dispatch": {
+      "id": "example.factory.dispatch",
+      "name": "dispatch",
+      "path": "example factory dispatch",
+      "aliases": [],
+      "groupId": "factory",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.dispatch",
+        "documentation": {
+          "title": {
+            "id": "example.factory.dispatch.title",
+            "canonicalEnglish": "Dispatch factory work"
+          },
+          "description": {
+            "id": "example.factory.dispatch.description",
+            "canonicalEnglish": "Dispatches work through a handler with an invalid stable identity."
+          }
+        },
+        "examples": [
+          "example factory dispatch"
+        ],
+        "visibility": "public",
+        "sourceHash": "cccc3333dddd4444eeee5555ffff66667777888899990000aaaa1111bbbb2222"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.dispatch",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "visibility": "visible",
+      "runnable": true,
+      "usage": {
+        "line": "dispatch",
+        "example": "  example factory dispatch"
+      },
+      "handler": {
+        "id": "Invalid_Handler",
+        "operationId": "submitWorkBySessionId"
+      }
+    }
+  }
+}

--- a/contracts/testdata/cli/invalid-relationship-impossible.json
+++ b/contracts/testdata/cli/invalid-relationship-impossible.json
@@ -1,0 +1,80 @@
+{
+  "formatVersion": "1.0.0",
+  "rootPath": "example",
+  "commands": {
+    "example.factory.export": {
+      "id": "example.factory.export",
+      "name": "export",
+      "path": "example factory export",
+      "aliases": [],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.export",
+        "documentation": {
+          "title": {
+            "id": "example.factory.export.title",
+            "canonicalEnglish": "Export factory artifacts"
+          },
+          "description": {
+            "id": "example.factory.export.description",
+            "canonicalEnglish": "Exports factory artifacts with an impossible mutex relationship that names only one participant."
+          }
+        },
+        "examples": [
+          "example factory export"
+        ],
+        "visibility": "public",
+        "sourceHash": "9999000011112222333344445555666677778888aaaabbbbccccddddeeeeffff"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.export",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "visibility": "visible",
+      "runnable": true,
+      "usage": {
+        "line": "export",
+        "example": "  example factory export"
+      },
+      "flags": {
+        "example.factory.export.flag.archive": {
+          "id": "example.factory.export.flag.archive",
+          "long": "archive",
+          "shorthand": "",
+          "aliases": [],
+          "scope": "local",
+          "valueType": "bool",
+          "required": false,
+          "default": "false",
+          "changedDefault": false,
+          "noOptionDefault": "true",
+          "repeatable": false,
+          "normalization": "",
+          "completion": "none",
+          "binding": "",
+          "visibility": "visible",
+          "lifecycle": {
+            "formatVersion": "1.0.0",
+            "itemId": "example.factory.export.flag.archive",
+            "state": "active",
+            "since": "1.0.0"
+          }
+        }
+      },
+      "relationships": {
+        "example.factory.export.rel.mutex.archive": {
+          "id": "example.factory.export.rel.mutex.archive",
+          "kind": "mutually-exclusive",
+          "participants": [
+            {
+              "type": "flag",
+              "id": "example.factory.export.flag.archive"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/contracts/testdata/cli/valid-conditional-relationship.json
+++ b/contracts/testdata/cli/valid-conditional-relationship.json
@@ -1,0 +1,139 @@
+{
+  "formatVersion": "1.0.0",
+  "rootPath": "example",
+  "commands": {
+    "example.factory.trace": {
+      "id": "example.factory.trace",
+      "name": "trace",
+      "path": "example factory trace",
+      "aliases": [],
+      "groupId": "factory",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.trace",
+        "documentation": {
+          "title": {
+            "id": "example.factory.trace.title",
+            "canonicalEnglish": "Trace factory execution"
+          },
+          "description": {
+            "id": "example.factory.trace.description",
+            "canonicalEnglish": "Enables verbose tracing and requires output controls when the verbose trigger is set."
+          }
+        },
+        "examples": [
+          "example factory trace --verbose --log-level debug --output trace.log"
+        ],
+        "visibility": "public",
+        "sourceHash": "8888999900001111222233334444555566667777aaaabbbbccccddddeeeeffff"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.trace",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "visibility": "visible",
+      "runnable": true,
+      "usage": {
+        "line": "trace",
+        "example": "  example factory trace --verbose --log-level debug --output trace.log"
+      },
+      "flags": {
+        "example.factory.trace.flag.verbose": {
+          "id": "example.factory.trace.flag.verbose",
+          "long": "verbose",
+          "shorthand": "v",
+          "aliases": [],
+          "scope": "local",
+          "valueType": "bool",
+          "required": false,
+          "default": "false",
+          "changedDefault": false,
+          "noOptionDefault": "true",
+          "repeatable": false,
+          "normalization": "",
+          "completion": "none",
+          "binding": "",
+          "visibility": "visible",
+          "lifecycle": {
+            "formatVersion": "1.0.0",
+            "itemId": "example.factory.trace.flag.verbose",
+            "state": "active",
+            "since": "1.0.0"
+          }
+        },
+        "example.factory.trace.flag.log-level": {
+          "id": "example.factory.trace.flag.log-level",
+          "long": "log-level",
+          "shorthand": "",
+          "aliases": [],
+          "scope": "local",
+          "valueType": "string",
+          "required": false,
+          "default": "",
+          "changedDefault": false,
+          "noOptionDefault": "",
+          "repeatable": false,
+          "normalization": "",
+          "completion": "static",
+          "binding": "",
+          "visibility": "visible",
+          "lifecycle": {
+            "formatVersion": "1.0.0",
+            "itemId": "example.factory.trace.flag.log-level",
+            "state": "active",
+            "since": "1.0.0"
+          }
+        },
+        "example.factory.trace.flag.output": {
+          "id": "example.factory.trace.flag.output",
+          "long": "output",
+          "shorthand": "o",
+          "aliases": [],
+          "scope": "local",
+          "valueType": "string",
+          "required": false,
+          "default": "",
+          "changedDefault": false,
+          "noOptionDefault": "",
+          "repeatable": false,
+          "normalization": "",
+          "completion": "none",
+          "binding": "",
+          "visibility": "visible",
+          "lifecycle": {
+            "formatVersion": "1.0.0",
+            "itemId": "example.factory.trace.flag.output",
+            "state": "active",
+            "since": "1.0.0"
+          }
+        }
+      },
+      "relationships": {
+        "example.factory.trace.rel.conditional.verbose-log-level-output": {
+          "id": "example.factory.trace.rel.conditional.verbose-log-level-output",
+          "kind": "conditional",
+          "when": {
+            "type": "flag",
+            "id": "example.factory.trace.flag.verbose"
+          },
+          "participants": [
+            {
+              "type": "flag",
+              "id": "example.factory.trace.flag.verbose"
+            },
+            {
+              "type": "flag",
+              "id": "example.factory.trace.flag.log-level"
+            },
+            {
+              "type": "flag",
+              "id": "example.factory.trace.flag.output"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/contracts/testdata/cli/valid-handler-binding.json
+++ b/contracts/testdata/cli/valid-handler-binding.json
@@ -1,0 +1,48 @@
+{
+  "formatVersion": "1.0.0",
+  "rootPath": "example",
+  "commands": {
+    "example.factory.invoke": {
+      "id": "example.factory.invoke",
+      "name": "invoke",
+      "path": "example factory invoke",
+      "aliases": [],
+      "groupId": "factory",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.invoke",
+        "documentation": {
+          "title": {
+            "id": "example.factory.invoke.title",
+            "canonicalEnglish": "Invoke a factory session"
+          },
+          "description": {
+            "id": "example.factory.invoke.description",
+            "canonicalEnglish": "Invokes one factory session through a bound handler and optional OpenAPI operation."
+          }
+        },
+        "examples": [
+          "example factory invoke --session-id sess-123"
+        ],
+        "visibility": "public",
+        "sourceHash": "bbbb2222cccc3333dddd4444eeee5555ffff66667777888899990000aaaa1111"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.invoke",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "visibility": "visible",
+      "runnable": true,
+      "usage": {
+        "line": "invoke",
+        "example": "  example factory invoke --session-id sess-123"
+      },
+      "handler": {
+        "id": "example.factory.invoke.handler",
+        "operationId": "invokeFactorySessionBySessionId"
+      }
+    }
+  }
+}

--- a/contracts/testdata/cli/valid-identity.json
+++ b/contracts/testdata/cli/valid-identity.json
@@ -1,0 +1,51 @@
+{
+  "formatVersion": "1.0.0",
+  "rootPath": "example",
+  "commands": {
+    "example.factory.list": {
+      "id": "example.factory.list",
+      "name": "list",
+      "path": "example factory list",
+      "aliases": [
+        "ls"
+      ],
+      "groupId": "factory",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.list",
+        "documentation": {
+          "title": {
+            "id": "example.factory.list.title",
+            "canonicalEnglish": "List named factories"
+          },
+          "description": {
+            "id": "example.factory.list.description",
+            "canonicalEnglish": "Lists persisted named factories under a factory root."
+          }
+        },
+        "examples": [
+          "example factory list"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.list",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "visibility": "visible",
+      "runnable": true,
+      "suggestion": {
+        "minimumDistance": 2,
+        "disableDefaultCmd": false,
+        "validArgs": []
+      },
+      "usage": {
+        "line": "list",
+        "example": "  example factory list"
+      }
+    }
+  }
+}

--- a/contracts/testdata/cli/valid-inherited-flag.json
+++ b/contracts/testdata/cli/valid-inherited-flag.json
@@ -1,0 +1,69 @@
+{
+  "formatVersion": "1.0.0",
+  "rootPath": "example",
+  "commands": {
+    "example.factory.watch": {
+      "id": "example.factory.watch",
+      "name": "watch",
+      "path": "example factory watch",
+      "aliases": [],
+      "groupId": "factory",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.watch",
+        "documentation": {
+          "title": {
+            "id": "example.factory.watch.title",
+            "canonicalEnglish": "Watch factory session output"
+          },
+          "description": {
+            "id": "example.factory.watch.description",
+            "canonicalEnglish": "Streams factory session events with inherited verbose diagnostics."
+          }
+        },
+        "examples": [
+          "example factory watch --verbose"
+        ],
+        "visibility": "public",
+        "sourceHash": "2222333344445555666677778888999900001111aaaabbbbccccddddeeeeffff"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.watch",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "visibility": "visible",
+      "runnable": true,
+      "usage": {
+        "line": "watch",
+        "example": "  example factory watch --verbose"
+      },
+      "flags": {
+        "example.factory.watch.flag.verbose": {
+          "id": "example.factory.watch.flag.verbose",
+          "long": "verbose",
+          "shorthand": "v",
+          "aliases": [],
+          "scope": "inherited",
+          "valueType": "bool",
+          "required": false,
+          "default": "false",
+          "changedDefault": false,
+          "noOptionDefault": "true",
+          "repeatable": false,
+          "normalization": "",
+          "completion": "none",
+          "binding": "",
+          "visibility": "visible",
+          "lifecycle": {
+            "formatVersion": "1.0.0",
+            "itemId": "example.factory.watch.flag.verbose",
+            "state": "active",
+            "since": "1.0.0"
+          }
+        }
+      }
+    }
+  }
+}

--- a/contracts/testdata/cli/valid-mutex-relationship.json
+++ b/contracts/testdata/cli/valid-mutex-relationship.json
@@ -1,0 +1,108 @@
+{
+  "formatVersion": "1.0.0",
+  "rootPath": "example",
+  "commands": {
+    "example.factory.format": {
+      "id": "example.factory.format",
+      "name": "format",
+      "path": "example factory format",
+      "aliases": [],
+      "groupId": "factory",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.format",
+        "documentation": {
+          "title": {
+            "id": "example.factory.format.title",
+            "canonicalEnglish": "Select an output format"
+          },
+          "description": {
+            "id": "example.factory.format.description",
+            "canonicalEnglish": "Selects one mutually exclusive output format for factory results."
+          }
+        },
+        "examples": [
+          "example factory format --json"
+        ],
+        "visibility": "public",
+        "sourceHash": "6666777788889999000011112222333344445555aaaabbbbccccddddeeeeffff"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.format",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "visibility": "visible",
+      "runnable": true,
+      "usage": {
+        "line": "format",
+        "example": "  example factory format --json"
+      },
+      "flags": {
+        "example.factory.format.flag.json": {
+          "id": "example.factory.format.flag.json",
+          "long": "json",
+          "shorthand": "",
+          "aliases": [],
+          "scope": "local",
+          "valueType": "bool",
+          "required": false,
+          "default": "false",
+          "changedDefault": false,
+          "noOptionDefault": "true",
+          "repeatable": false,
+          "normalization": "",
+          "completion": "none",
+          "binding": "",
+          "visibility": "visible",
+          "lifecycle": {
+            "formatVersion": "1.0.0",
+            "itemId": "example.factory.format.flag.json",
+            "state": "active",
+            "since": "1.0.0"
+          }
+        },
+        "example.factory.format.flag.yaml": {
+          "id": "example.factory.format.flag.yaml",
+          "long": "yaml",
+          "shorthand": "",
+          "aliases": [],
+          "scope": "local",
+          "valueType": "bool",
+          "required": false,
+          "default": "false",
+          "changedDefault": false,
+          "noOptionDefault": "true",
+          "repeatable": false,
+          "normalization": "",
+          "completion": "none",
+          "binding": "",
+          "visibility": "visible",
+          "lifecycle": {
+            "formatVersion": "1.0.0",
+            "itemId": "example.factory.format.flag.yaml",
+            "state": "active",
+            "since": "1.0.0"
+          }
+        }
+      },
+      "relationships": {
+        "example.factory.format.rel.mutex.json-yaml": {
+          "id": "example.factory.format.rel.mutex.json-yaml",
+          "kind": "mutually-exclusive",
+          "participants": [
+            {
+              "type": "flag",
+              "id": "example.factory.format.flag.json"
+            },
+            {
+              "type": "flag",
+              "id": "example.factory.format.flag.yaml"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/contracts/testdata/cli/valid-no-option-flag.json
+++ b/contracts/testdata/cli/valid-no-option-flag.json
@@ -1,0 +1,69 @@
+{
+  "formatVersion": "1.0.0",
+  "rootPath": "example",
+  "commands": {
+    "example.factory.enable": {
+      "id": "example.factory.enable",
+      "name": "enable",
+      "path": "example factory enable",
+      "aliases": [],
+      "groupId": "factory",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.enable",
+        "documentation": {
+          "title": {
+            "id": "example.factory.enable.title",
+            "canonicalEnglish": "Enable a factory feature"
+          },
+          "description": {
+            "id": "example.factory.enable.description",
+            "canonicalEnglish": "Enables a factory feature using a boolean flag that accepts no explicit option value."
+          }
+        },
+        "examples": [
+          "example factory enable --force"
+        ],
+        "visibility": "public",
+        "sourceHash": "3333444455556666777788889999000011112222aaaabbbbccccddddeeeeffff"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.enable",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "visibility": "visible",
+      "runnable": true,
+      "usage": {
+        "line": "enable",
+        "example": "  example factory enable --force"
+      },
+      "flags": {
+        "example.factory.enable.flag.force": {
+          "id": "example.factory.enable.flag.force",
+          "long": "force",
+          "shorthand": "",
+          "aliases": [],
+          "scope": "local",
+          "valueType": "bool",
+          "required": false,
+          "default": "false",
+          "changedDefault": false,
+          "noOptionDefault": "true",
+          "repeatable": false,
+          "normalization": "",
+          "completion": "none",
+          "binding": "",
+          "visibility": "visible",
+          "lifecycle": {
+            "formatVersion": "1.0.0",
+            "itemId": "example.factory.enable.flag.force",
+            "state": "active",
+            "since": "1.0.0"
+          }
+        }
+      }
+    }
+  }
+}

--- a/contracts/testdata/cli/valid-optional-argument.json
+++ b/contracts/testdata/cli/valid-optional-argument.json
@@ -1,0 +1,72 @@
+{
+  "formatVersion": "1.0.0",
+  "rootPath": "example",
+  "commands": {
+    "example.factory.docs": {
+      "id": "example.factory.docs",
+      "name": "docs",
+      "path": "example factory docs",
+      "aliases": [],
+      "groupId": "factory",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.docs",
+        "documentation": {
+          "title": {
+            "id": "example.factory.docs.title",
+            "canonicalEnglish": "Show factory documentation topics"
+          },
+          "description": {
+            "id": "example.factory.docs.description",
+            "canonicalEnglish": "Shows packaged documentation topics for the factory CLI."
+          }
+        },
+        "examples": [
+          "example factory docs"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.docs",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "visibility": "visible",
+      "runnable": true,
+      "suggestion": {
+        "minimumDistance": 2,
+        "disableDefaultCmd": false,
+        "validArgs": []
+      },
+      "usage": {
+        "line": "docs [topic]",
+        "example": "  example factory docs agents"
+      },
+      "arguments": {
+        "example.factory.docs.arg.topic": {
+          "id": "example.factory.docs.arg.topic",
+          "name": "topic",
+          "position": 0,
+          "kind": "positional",
+          "valueType": "string",
+          "required": false,
+          "minCardinality": 0,
+          "maxCardinality": 1,
+          "variadic": false,
+          "enum": [
+            "agents",
+            "run"
+          ],
+          "pattern": "",
+          "completion": "static",
+          "channels": [
+            "cli"
+          ],
+          "doubleDash": "terminates-flags"
+        }
+      }
+    }
+  }
+}

--- a/contracts/testdata/cli/valid-persistent-flag.json
+++ b/contracts/testdata/cli/valid-persistent-flag.json
@@ -1,0 +1,69 @@
+{
+  "formatVersion": "1.0.0",
+  "rootPath": "example",
+  "commands": {
+    "example.factory.debug": {
+      "id": "example.factory.debug",
+      "name": "debug",
+      "path": "example factory debug",
+      "aliases": [],
+      "groupId": "factory",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.debug",
+        "documentation": {
+          "title": {
+            "id": "example.factory.debug.title",
+            "canonicalEnglish": "Enable factory debug output"
+          },
+          "description": {
+            "id": "example.factory.debug.description",
+            "canonicalEnglish": "Runs a factory command with persistent debug diagnostics enabled."
+          }
+        },
+        "examples": [
+          "example factory debug --debug"
+        ],
+        "visibility": "public",
+        "sourceHash": "1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.debug",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "visibility": "visible",
+      "runnable": true,
+      "usage": {
+        "line": "debug",
+        "example": "  example factory debug --debug"
+      },
+      "flags": {
+        "example.factory.debug.flag.debug": {
+          "id": "example.factory.debug.flag.debug",
+          "long": "debug",
+          "shorthand": "d",
+          "aliases": [],
+          "scope": "persistent",
+          "valueType": "bool",
+          "required": false,
+          "default": "false",
+          "changedDefault": false,
+          "noOptionDefault": "true",
+          "repeatable": false,
+          "normalization": "",
+          "completion": "none",
+          "binding": "",
+          "visibility": "visible",
+          "lifecycle": {
+            "formatVersion": "1.0.0",
+            "itemId": "example.factory.debug.flag.debug",
+            "state": "active",
+            "since": "1.0.0"
+          }
+        }
+      }
+    }
+  }
+}

--- a/contracts/testdata/cli/valid-precedence.json
+++ b/contracts/testdata/cli/valid-precedence.json
@@ -1,0 +1,101 @@
+{
+  "formatVersion": "1.0.0",
+  "rootPath": "example",
+  "commands": {
+    "example.factory.resolve": {
+      "id": "example.factory.resolve",
+      "name": "resolve",
+      "path": "example factory resolve",
+      "aliases": [],
+      "groupId": "factory",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.resolve",
+        "documentation": {
+          "title": {
+            "id": "example.factory.resolve.title",
+            "canonicalEnglish": "Resolve factory inputs"
+          },
+          "description": {
+            "id": "example.factory.resolve.description",
+            "canonicalEnglish": "Resolves factory invocation inputs using an explicit precedence order."
+          }
+        },
+        "examples": [
+          "example factory resolve --config ./factory.json"
+        ],
+        "visibility": "public",
+        "sourceHash": "aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff66667777888899990000"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.resolve",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "visibility": "visible",
+      "runnable": true,
+      "usage": {
+        "line": "resolve",
+        "example": "  example factory resolve --config ./factory.json"
+      },
+      "precedence": {
+        "order": [
+          "flags",
+          "args",
+          "env",
+          "config",
+          "stdin",
+          "defaults"
+        ]
+      },
+      "channels": {
+        "input": [
+          "cli",
+          "env",
+          "config",
+          "stdin"
+        ],
+        "output": [
+          "stdout",
+          "stderr"
+        ]
+      },
+      "outputs": {
+        "example.factory.resolve.output.result": {
+          "id": "example.factory.resolve.output.result",
+          "channel": "stdout",
+          "format": "json"
+        }
+      },
+      "exits": {
+        "example.factory.resolve.exit.success": {
+          "id": "example.factory.resolve.exit.success",
+          "code": 0,
+          "kind": "success"
+        },
+        "example.factory.resolve.exit.usage": {
+          "id": "example.factory.resolve.exit.usage",
+          "code": 2,
+          "kind": "usage"
+        }
+      },
+      "sideEffects": {
+        "example.factory.resolve.side-effect.config": {
+          "id": "example.factory.resolve.side-effect.config",
+          "kind": "config"
+        }
+      },
+      "constraints": {
+        "runtime": [
+          "local"
+        ],
+        "platforms": [
+          "linux",
+          "darwin",
+          "windows"
+        ]
+      }
+    }
+  }
+}

--- a/contracts/testdata/cli/valid-required-together-relationship.json
+++ b/contracts/testdata/cli/valid-required-together-relationship.json
@@ -1,0 +1,108 @@
+{
+  "formatVersion": "1.0.0",
+  "rootPath": "example",
+  "commands": {
+    "example.factory.authenticate": {
+      "id": "example.factory.authenticate",
+      "name": "authenticate",
+      "path": "example factory authenticate",
+      "aliases": [],
+      "groupId": "factory",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.authenticate",
+        "documentation": {
+          "title": {
+            "id": "example.factory.authenticate.title",
+            "canonicalEnglish": "Authenticate to a factory endpoint"
+          },
+          "description": {
+            "id": "example.factory.authenticate.description",
+            "canonicalEnglish": "Supplies credentials that must be provided together before authentication proceeds."
+          }
+        },
+        "examples": [
+          "example factory authenticate --user alice --pass secret"
+        ],
+        "visibility": "public",
+        "sourceHash": "7777888899990000111122223333444455556666aaaabbbbccccddddeeeeffff"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.authenticate",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "visibility": "visible",
+      "runnable": true,
+      "usage": {
+        "line": "authenticate",
+        "example": "  example factory authenticate --user alice --pass secret"
+      },
+      "flags": {
+        "example.factory.authenticate.flag.user": {
+          "id": "example.factory.authenticate.flag.user",
+          "long": "user",
+          "shorthand": "u",
+          "aliases": [],
+          "scope": "local",
+          "valueType": "string",
+          "required": false,
+          "default": "",
+          "changedDefault": false,
+          "noOptionDefault": "",
+          "repeatable": false,
+          "normalization": "",
+          "completion": "none",
+          "binding": "",
+          "visibility": "visible",
+          "lifecycle": {
+            "formatVersion": "1.0.0",
+            "itemId": "example.factory.authenticate.flag.user",
+            "state": "active",
+            "since": "1.0.0"
+          }
+        },
+        "example.factory.authenticate.flag.pass": {
+          "id": "example.factory.authenticate.flag.pass",
+          "long": "pass",
+          "shorthand": "p",
+          "aliases": [],
+          "scope": "local",
+          "valueType": "string",
+          "required": false,
+          "default": "",
+          "changedDefault": false,
+          "noOptionDefault": "",
+          "repeatable": false,
+          "normalization": "",
+          "completion": "none",
+          "binding": "",
+          "visibility": "visible",
+          "lifecycle": {
+            "formatVersion": "1.0.0",
+            "itemId": "example.factory.authenticate.flag.pass",
+            "state": "active",
+            "since": "1.0.0"
+          }
+        }
+      },
+      "relationships": {
+        "example.factory.authenticate.rel.required-together.pass-user": {
+          "id": "example.factory.authenticate.rel.required-together.pass-user",
+          "kind": "required-together",
+          "participants": [
+            {
+              "type": "flag",
+              "id": "example.factory.authenticate.flag.pass"
+            },
+            {
+              "type": "flag",
+              "id": "example.factory.authenticate.flag.user"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/contracts/testdata/cli/valid-variadic-argument.json
+++ b/contracts/testdata/cli/valid-variadic-argument.json
@@ -1,0 +1,63 @@
+{
+  "formatVersion": "1.0.0",
+  "rootPath": "example",
+  "commands": {
+    "example.factory.run": {
+      "id": "example.factory.run",
+      "name": "run",
+      "path": "example factory run",
+      "aliases": [],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.run",
+        "documentation": {
+          "title": {
+            "id": "example.factory.run.title",
+            "canonicalEnglish": "Run a factory"
+          },
+          "description": {
+            "id": "example.factory.run.description",
+            "canonicalEnglish": "Runs a factory with one or more work paths."
+          }
+        },
+        "examples": [
+          "example factory run ./work.json"
+        ],
+        "visibility": "public",
+        "sourceHash": "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.factory.run",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "visibility": "visible",
+      "runnable": true,
+      "usage": {
+        "line": "run [paths...]",
+        "example": "  example factory run ./work-a.json ./work-b.json"
+      },
+      "arguments": {
+        "example.factory.run.arg.paths": {
+          "id": "example.factory.run.arg.paths",
+          "name": "paths",
+          "position": 0,
+          "kind": "positional",
+          "valueType": "string",
+          "required": false,
+          "minCardinality": 0,
+          "maxCardinality": -1,
+          "variadic": true,
+          "enum": [],
+          "pattern": "",
+          "completion": "none",
+          "channels": [
+            "cli"
+          ],
+          "doubleDash": "terminates-flags"
+        }
+      }
+    }
+  }
+}

--- a/internal/contractvalidator/cli_manifest.go
+++ b/internal/contractvalidator/cli_manifest.go
@@ -1,0 +1,82 @@
+package contractvalidator
+
+import (
+	"fmt"
+	"sort"
+)
+
+const commandManifestSchemaID = "https://schemas.portpowered.com/you/contracts/cli/command-manifest.schema.json"
+
+func cliManifestDiagnostics(document string, value any) []Diagnostic {
+	root, ok := value.(map[string]any)
+	if !ok {
+		return nil
+	}
+	commands, ok := root["commands"].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	var diagnostics []Diagnostic
+	for _, commandKey := range sortedStringKeys(commands) {
+		command, ok := commands[commandKey].(map[string]any)
+		if !ok {
+			continue
+		}
+		diagnostics = append(diagnostics, cliCommandInputAmbiguityDiagnostics(document, commandKey, command)...)
+	}
+	return diagnostics
+}
+
+func cliCommandInputAmbiguityDiagnostics(document, commandKey string, command map[string]any) []Diagnostic {
+	argumentIDs := collectCLIRecordIDPaths(commandKey, command, "arguments")
+	flagIDs := collectCLIRecordIDPaths(commandKey, command, "flags")
+
+	var diagnostics []Diagnostic
+	sharedIDs := make([]string, 0)
+	for id := range argumentIDs {
+		if _, ok := flagIDs[id]; ok {
+			sharedIDs = append(sharedIDs, id)
+		}
+	}
+	sort.Strings(sharedIDs)
+
+	for _, id := range sharedIDs {
+		message := fmt.Sprintf("stable ID %q is claimed by both a flag and an argument", id)
+		diagnostics = append(diagnostics,
+			newDiagnostic("cli.input.ambiguous", argumentIDs[id], message, document),
+			newDiagnostic("cli.input.ambiguous", flagIDs[id], message, document),
+		)
+	}
+	return diagnostics
+}
+
+func collectCLIRecordIDPaths(commandKey string, command map[string]any, field string) map[string]string {
+	records, ok := command[field].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	ids := make(map[string]string, len(records))
+	for _, recordKey := range sortedStringKeys(records) {
+		record, ok := records[recordKey].(map[string]any)
+		if !ok {
+			continue
+		}
+		id, ok := record["id"].(string)
+		if !ok || id == "" {
+			continue
+		}
+		ids[id] = instancePath([]string{"commands", commandKey, field, recordKey, "id"})
+	}
+	return ids
+}
+
+func sortedStringKeys(values map[string]any) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/contractvalidator/validator.go
+++ b/internal/contractvalidator/validator.go
@@ -120,6 +120,9 @@ func CLIRegistry() Registry {
 			{Path: "contracts/testdata/cli/valid-persistent-flag.json", SchemaID: commandManifestID},
 			{Path: "contracts/testdata/cli/valid-inherited-flag.json", SchemaID: commandManifestID},
 			{Path: "contracts/testdata/cli/valid-no-option-flag.json", SchemaID: commandManifestID},
+			{Path: "contracts/testdata/cli/valid-mutex-relationship.json", SchemaID: commandManifestID},
+			{Path: "contracts/testdata/cli/valid-required-together-relationship.json", SchemaID: commandManifestID},
+			{Path: "contracts/testdata/cli/valid-conditional-relationship.json", SchemaID: commandManifestID},
 		},
 	})
 }

--- a/internal/contractvalidator/validator.go
+++ b/internal/contractvalidator/validator.go
@@ -117,6 +117,9 @@ func CLIRegistry() Registry {
 			{Path: "contracts/testdata/cli/valid-identity.json", SchemaID: commandManifestID},
 			{Path: "contracts/testdata/cli/valid-optional-argument.json", SchemaID: commandManifestID},
 			{Path: "contracts/testdata/cli/valid-variadic-argument.json", SchemaID: commandManifestID},
+			{Path: "contracts/testdata/cli/valid-persistent-flag.json", SchemaID: commandManifestID},
+			{Path: "contracts/testdata/cli/valid-inherited-flag.json", SchemaID: commandManifestID},
+			{Path: "contracts/testdata/cli/valid-no-option-flag.json", SchemaID: commandManifestID},
 		},
 	})
 }

--- a/internal/contractvalidator/validator.go
+++ b/internal/contractvalidator/validator.go
@@ -123,6 +123,8 @@ func CLIRegistry() Registry {
 			{Path: "contracts/testdata/cli/valid-mutex-relationship.json", SchemaID: commandManifestID},
 			{Path: "contracts/testdata/cli/valid-required-together-relationship.json", SchemaID: commandManifestID},
 			{Path: "contracts/testdata/cli/valid-conditional-relationship.json", SchemaID: commandManifestID},
+			{Path: "contracts/testdata/cli/valid-precedence.json", SchemaID: commandManifestID},
+			{Path: "contracts/testdata/cli/valid-handler-binding.json", SchemaID: commandManifestID},
 		},
 	})
 }

--- a/internal/contractvalidator/validator.go
+++ b/internal/contractvalidator/validator.go
@@ -61,6 +61,20 @@ func NewRegistry(entries ...Entry) Registry {
 	return Registry{entries: copied}
 }
 
+// MergeRegistries combines multiple registries without mutating the inputs.
+func MergeRegistries(registries ...Registry) Registry {
+	var entries []Entry
+	for _, registry := range registries {
+		entries = append(entries, registry.entries...)
+	}
+	return Registry{entries: entries}
+}
+
+// DefaultRegistry registers every contract family validated by make contracts-validate.
+func DefaultRegistry() Registry {
+	return MergeRegistries(CommonRegistry(), CLIRegistry())
+}
+
 // CommonRegistry registers the common schemas and their merged valid fixtures.
 func CommonRegistry() Registry {
 	const (
@@ -80,6 +94,27 @@ func CommonRegistry() Registry {
 			{Path: "contracts/testdata/common/deprecations/valid-active.json", SchemaID: deprecationsID},
 			{Path: "contracts/testdata/common/deprecations/valid-deprecated.json", SchemaID: deprecationsID},
 			{Path: "contracts/testdata/common/deprecations/valid-removed.json", SchemaID: deprecationsID},
+		},
+	})
+}
+
+// CLIRegistry registers the CLI command-manifest schema and its valid fixtures.
+func CLIRegistry() Registry {
+	const (
+		commandManifestID = "https://schemas.portpowered.com/you/contracts/cli/command-manifest.schema.json"
+		documentationID   = "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json"
+		deprecationsID    = "https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json"
+	)
+	return NewRegistry(Entry{
+		Family:        "cli",
+		FormatVersion: "1.0.0",
+		Schemas: []Schema{
+			{ID: documentationID, Path: "contracts/common/documentation.schema.json"},
+			{ID: deprecationsID, Path: "contracts/common/deprecations.schema.json"},
+			{ID: commandManifestID, Path: "contracts/cli/command-manifest.schema.json"},
+		},
+		Documents: []Document{
+			{Path: "contracts/testdata/cli/valid-identity.json", SchemaID: commandManifestID},
 		},
 	})
 }

--- a/internal/contractvalidator/validator.go
+++ b/internal/contractvalidator/validator.go
@@ -196,6 +196,9 @@ func validateEntry(repositoryRoot string, entry Entry) []Diagnostic {
 			diagnostics = append(diagnostics, validationDiagnostics(document.Path, err)...)
 			continue
 		}
+		if document.SchemaID == commandManifestSchemaID {
+			diagnostics = append(diagnostics, cliManifestDiagnostics(document.Path, value)...)
+		}
 		for _, source := range sourceDocuments {
 			loadedDocuments[source.path] = source
 		}

--- a/internal/contractvalidator/validator.go
+++ b/internal/contractvalidator/validator.go
@@ -115,6 +115,8 @@ func CLIRegistry() Registry {
 		},
 		Documents: []Document{
 			{Path: "contracts/testdata/cli/valid-identity.json", SchemaID: commandManifestID},
+			{Path: "contracts/testdata/cli/valid-optional-argument.json", SchemaID: commandManifestID},
+			{Path: "contracts/testdata/cli/valid-variadic-argument.json", SchemaID: commandManifestID},
 		},
 	})
 }

--- a/internal/contractvalidator/validator_test.go
+++ b/internal/contractvalidator/validator_test.go
@@ -26,6 +26,67 @@ func TestCLIRegistryValidFixtures(t *testing.T) {
 	}
 }
 
+func TestValidateCLIInvalidManifestDiagnostics(t *testing.T) {
+	root := repositoryRoot(t)
+
+	tests := []struct {
+		name     string
+		fixture  string
+		code     string
+		wantPath string
+	}{
+		{
+			name:     "duplicate stable documentation IDs",
+			fixture:  "contracts/testdata/cli/invalid-duplicate-stable-id.json",
+			code:     "identity.duplicate",
+			wantPath: "/commands/example.factory.alpha/documentation/documentation/title/id",
+		},
+		{
+			name:     "ambiguous flag and argument stable ID",
+			fixture:  "contracts/testdata/cli/invalid-ambiguous-flag-argument.json",
+			code:     "cli.input.ambiguous",
+			wantPath: "/commands/example.factory.sync/arguments/example.factory.sync.target/id",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			diagnostics := contractvalidator.Validate(root, cliManifestFixtureRegistry(test.fixture), "cli", "1.0.0")
+			if len(diagnostics) == 0 {
+				t.Fatal("expected diagnostics, got none")
+			}
+			found := false
+			for _, diagnostic := range diagnostics {
+				if diagnostic.Code == test.code && diagnostic.Path == test.wantPath && diagnostic.Document == test.fixture {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("diagnostics = %+v, want code=%q path=%q document=%q", diagnostics, test.code, test.wantPath, test.fixture)
+			}
+		})
+	}
+}
+
+func cliManifestFixtureRegistry(fixture string) contractvalidator.Registry {
+	const (
+		commandManifestID = "https://schemas.portpowered.com/you/contracts/cli/command-manifest.schema.json"
+		documentationID   = "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json"
+		deprecationsID    = "https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json"
+	)
+	return contractvalidator.NewRegistry(contractvalidator.Entry{
+		Family:        "cli",
+		FormatVersion: "1.0.0",
+		Schemas: []contractvalidator.Schema{
+			{ID: documentationID, Path: "contracts/common/documentation.schema.json"},
+			{ID: deprecationsID, Path: "contracts/common/deprecations.schema.json"},
+			{ID: commandManifestID, Path: "contracts/cli/command-manifest.schema.json"},
+		},
+		Documents: []contractvalidator.Document{{Path: fixture, SchemaID: commandManifestID}},
+	})
+}
+
 func TestDefaultRegistryValidFixtures(t *testing.T) {
 	root := repositoryRoot(t)
 	diagnostics := contractvalidator.ValidateAll(root, contractvalidator.DefaultRegistry())

--- a/internal/contractvalidator/validator_test.go
+++ b/internal/contractvalidator/validator_test.go
@@ -18,6 +18,22 @@ func TestCommonRegistryValidFixtures(t *testing.T) {
 	}
 }
 
+func TestCLIRegistryValidFixtures(t *testing.T) {
+	root := repositoryRoot(t)
+	diagnostics := contractvalidator.Validate(root, contractvalidator.CLIRegistry(), "cli", "1.0.0")
+	if len(diagnostics) != 0 {
+		t.Fatalf("Validate() diagnostics = %+v, want none", diagnostics)
+	}
+}
+
+func TestDefaultRegistryValidFixtures(t *testing.T) {
+	root := repositoryRoot(t)
+	diagnostics := contractvalidator.ValidateAll(root, contractvalidator.DefaultRegistry())
+	if len(diagnostics) != 0 {
+		t.Fatalf("ValidateAll() diagnostics = %+v, want none", diagnostics)
+	}
+}
+
 func TestValidateRejectsUnknownRegistrySelection(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
{
  "project": "Define Draft-2020-12 CLI Command Manifest Schema",
  "branchName": "interfaces-b09-cli-schema",
  "description": "Create contracts/cli/command-manifest.schema.json (JSON Schema Draft 2020-12) plus valid/invalid fixtures covering the full §4.3 CLI command-manifest surface—command metadata, arguments, flags, relationships, precedence, channels, outputs, exits, side-effects, runtime/platform constraints, and handler-ID / optional OpenAPI operationId binding—wired through make contracts-validate without production commands.json cutover or Cobra generator changes.",
  "context": {
    "customerAsk": "Create contracts/cli/command-manifest.schema.json (Draft 2020-12) plus valid/invalid fixtures covering the full §4.3 surface: command identity/path/aliases/group/docs/lifecycle/visibility/runnable/suggestion/usage metadata; arguments; flags; relationships; precedence; channels; outputs; exits; side-effects; runtime/platform constraints; and handler-ID / optional OpenAPI operationId binding. Valid fixtures for optional/variadic/inherited/no-option/mutex/conditional/precedence cases must pass make contracts-validate. Invalid fixtures for duplicate IDs, ambiguous flag+argument, invalid cardinality, broken handler IDs, and impossible relationships must fail with actionable JSON paths. Do not author production commands.json or change Cobra constructors/generators; keep the schema build-time-only with no new pkg/ runtime dependency.",
    "problem": "Interfaces B01–B02 produced CLI baselines and B04 delivered a reusable contract validator plus common schemas, but B10 still lacks a Draft 2020-12 CLI command-manifest schema and fixture matrix. Without that schema, authors cannot prove optional/variadic args, inherited/no-option flags, relationship groups, precedence, outputs/exits, or handler bindings before production commands.json authoring, and invalid manifests would fail without actionable JSON paths.",
    "solution": "Author one closed Draft 2020-12 CLI command-manifest schema under contracts/cli/, add a narrowly named valid/invalid fixture matrix, and register the CLI family with the existing build-time contractvalidator so valid fixtures pass make contracts-validate and invalid fixtures fail with deterministic actionable instance paths—without production commands.json, Cobra constructor/generator changes, or a new pkg/ runtime dependency."
  },
  "acceptanceCriteria": [
    "AC-1: contracts/cli/command-manifest.schema.json declares JSON Schema Draft 2020-12, has a stable $id, defines an explicit initial format version, closes authored objects against unknown properties, and covers every §4.3 field group listed in the requested outcome.",
    "AC-2: Valid fixtures for optional positional, variadic, persistent/inherited flags, no-option defaults, mutex/required-together/conditional groups, and precedence cases pass make contracts-validate.",
    "AC-3: Invalid fixtures for duplicate IDs, ambiguous flag+argument claims, invalid cardinality, broken handler IDs, and impossible relationships fail with actionable JSON paths.",
    "AC-4: No production contracts/cli/commands.json cutover and no Cobra constructor/generator changes land in this item.",
    "AC-5: The schema and validation remain build-time-only; no new pkg/ runtime dependency is introduced.",
    "AC-6: Focused contractvalidator / CLI schema fixture tests prove the valid and invalid matrix with stable path diagnostics.",
    "AC-7: Quality checks pass (typecheck, lint, and tests), including make contracts-validate and applicable package-boundary checks."
  ],
  "userStories": [
    {
      "id": "interfaces-b09-cli-schema-001",
      "title": "Author command identity and metadata schema foundation",
      "description": "As a CLI contract author, I want a Draft 2020-12 command-manifest schema root that accepts command identity, path, aliases, group, docs, lifecycle, visibility, runnable, suggestion, and usage metadata so later argument/flag/relationship groups have a stable document home.",
      "acceptanceCriteria": [
        "contracts/cli/command-manifest.schema.json declares Draft 2020-12, a stable $id under the repository schema namespace, an explicit initial format version, and additionalProperties false at authored object boundaries.",
        "The schema accepts command identity/path/aliases/group/docs/lifecycle/visibility/runnable/suggestion/usage metadata for at least one valid command document fixture.",
        "Common documentation and/or deprecation shapes are composed by $ref where reusable rather than redefining incompatible identity/lifecycle rules.",
        "The CLI schema is registered with the build-time contract validator family/version registry so a minimal valid identity fixture is included in repository validation.",
        "Running make contracts-validate succeeds for the registered valid identity fixture set after this story.",
        "No production commands.json and no Cobra constructor/generator changes are introduced.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b09-cli-schema-002",
      "title": "Validate argument shapes including optional and variadic cases",
      "description": "As a CLI contract reviewer, I want argument metadata for stable ID, position, kind, value type, required/min/max cardinality, variadic, enum/pattern, completion, channels, and -- handling so optional and variadic positionals validate and invalid cardinality fails at an actionable path.",
      "acceptanceCriteria": [
        "The schema accepts argument records covering stable ID, position, kind, value type, required/min/max cardinality, variadic, enum/pattern, completion, channels, and -- handling.",
        "At least one valid fixture documents an optional positional argument and at least one valid fixture documents a variadic argument; both pass make contracts-validate / focused schema validation.",
        "An invalid cardinality fixture fails validation with an actionable JSON path identifying the offending argument field.",
        "Argument validation does not invent production command catalogs or change Cobra Args behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b09-cli-schema-003",
      "title": "Validate flag shapes including inherited and no-option defaults",
      "description": "As a CLI contract reviewer, I want flag metadata for long/shorthand/aliases, scope, value type, default/changed/no-option, repeatability, normalization, completion, binding, and visibility/deprecation so persistent/inherited and no-option flags validate before generators consume the schema.",
      "acceptanceCriteria": [
        "The schema accepts flag records covering long/shorthand/aliases, scope including local/persistent/inherited, value type, default/changed/no-option, repeatability, normalization, completion, binding, and visibility/deprecation.",
        "At least one valid fixture documents a persistent or inherited flag, and at least one valid fixture documents a no-option default; both pass focused validation / make contracts-validate.",
        "Unknown flag properties and unsupported scope/value combinations that the schema deliberately closes are rejected at actionable JSON paths.",
        "Flag schema work does not modify Cobra flag constructors, help text, or completion wiring.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b09-cli-schema-004",
      "title": "Validate relationship groups and reject impossible relationships",
      "description": "As a maintainer documenting parse constraints, I want mutex, required-together, at-least-one, conditional, and conflict relationship groups expressible in the schema, with impossible relationship documents rejected at actionable JSON paths.",
      "acceptanceCriteria": [
        "The schema accepts relationship records for mutually exclusive, required-together, at-least-one, conditional, and conflict kinds with stable IDs and participant references.",
        "Valid fixtures cover mutex, required-together, and conditional groups and pass focused validation / make contracts-validate.",
        "An impossible-relationship fixture fails with an actionable JSON path.",
        "Relationship validation remains metadata-only and does not change Cobra MarkFlags wiring or runtime parse rejection behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b09-cli-schema-005",
      "title": "Validate precedence, channels, outputs, exits, side-effects, constraints, and handler binding",
      "description": "As a CLI contract author preparing for B10 cutover, I want precedence across flags/args/env/config/stdin/defaults, plus channels, outputs, exits, side-effects, runtime/platform constraints, and handler-ID / optional OpenAPI operationId binding represented in the schema so those §4.3 groups are fixture-proven before production authoring.",
      "acceptanceCriteria": [
        "The schema accepts precedence metadata covering the relative order of flags, args, env, config, stdin, and defaults for a command document.",
        "The schema accepts channels, outputs, exits, side-effects, and runtime/platform constraints as closed §4.3 field groups on the command manifest.",
        "The schema accepts a handler ID and optional OpenAPI operationId binding fields with documented identity patterns.",
        "At least one valid precedence fixture and at least one valid handler-binding fixture pass focused validation / make contracts-validate.",
        "A broken handler-ID fixture fails validation with an actionable JSON path to the handler identity field.",
        "No production commands.json cutover and no generator/Cobra constructor changes are introduced.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b09-cli-schema-006",
      "title": "Complete invalid fixture matrix and prove contracts-validate closure",
      "description": "As a reviewer, I want the remaining cross-cutting invalid cases and the full CLI fixture matrix wired through the build-time validator so duplicate IDs and ambiguous flag+argument claims fail with actionable JSON paths and make contracts-validate stays green for valid fixtures only.",
      "acceptanceCriteria": [
        "Invalid fixtures exist for duplicate stable IDs and ambiguous flag+argument claims; each fails with an actionable JSON path identifying the conflicting identity or claim location.",
        "The focused CLI schema / contractvalidator fixture matrix covers every customer-named valid class and every customer-named invalid class.",
        "make contracts-validate passes when only registered valid CLI fixtures are validated; invalid fixtures are asserted by focused tests that check path-bearing diagnostics rather than third-party error prose snapshots.",
        "Diff review confirms no production contracts/cli/commands.json, no Cobra constructor/generator changes, and no new pkg/ runtime import of the schema or validator.",
        "Applicable make contracts-smoke / package-boundary checks remain green when generation or registry wiring is touched.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": ""
    }
  ]
}
