### PR TITLE
interfaces-b09-compat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,8 @@ BACKEND_SIZE_ROOT ?= .
 PACKAGE_MAINT_ROOT ?= .
 PACKAGE_FILE_COUNT_ROOT ?= .
 PACKAGE_BOUNDARY_ROOT ?= .
-LINT_TARGETS ?= ui-lint ui-deadcode vet backend-size pkg-maint pkg-file-count pkg-boundary durable-runtime-construction-check logging-boundary-check model-facade-check deadcode
+COMPATIBILITY_ALIAS_CHECK_ROOT ?= .
+LINT_TARGETS ?= ui-lint ui-deadcode vet backend-size pkg-maint pkg-file-count pkg-boundary durable-runtime-construction-check logging-boundary-check model-facade-check compatibility-alias-check deadcode
 
 define run_verification_step
 	@printf '%s\n' "==> $(2) [make $(1)]"
@@ -74,7 +75,7 @@ define run_timed_step
 	exit $$status
 endef
 
-.PHONY: default build intall bundle-api generate-api generate-go-api generate-go-server-api generate-go-client-api generate-ui-api generate-wire wire-smoke api-smoke api-package-pack-smoke contracts-validate contracts-generate contracts-check contracts-smoke docs-reference-check docs-reference-smoke test test-full test-functional test-functional-long verify-fast verify-pr verify-pr-inference verify-extended verify-build-contracts verify-tests run-concurrent-ui-verification-lanes run-sharded-ui-coverage verify test-ui-coverage test-ui-coverage-merge test-ui-browser-integration test-ui-durable-session-real-backend test-backend-coverage test-backend-functional test-backend-verification long-tests long-tests-managed-runtime long-tests-functional-runtime pr-inference-approval test-coverage-go script-timeout-companion-smoke-100 cron-time-work-smoke current-factory-watcher-switch-smoke release-surface-smoke artifact-contract-closeout lint backend-size pkg-maint pkg-file-count pkg-boundary durable-runtime-construction-check logging-boundary-check model-facade-check readme-check deadcode ui-deadcode test-race fmt vet deps deps-tidy init dashboard-verify typecheck release ci ci-typecheck ci-verify-build-contracts ci-verify-tests ui-deps ui-lint ui-build ui-test ui-integration-test ui-durable-session-real-backend-integration-test ui-test-coverage ui-replay-coverage-check ui-install-playwright ui-storybook ui-test-storybook ui-components-typecheck ui-components-test ui-components-storybook ui-components-boundary ui-components-dependency-direction ui-components-verify ui-verify-fresh-npm-install clean
+.PHONY: default build intall bundle-api generate-api generate-go-api generate-go-server-api generate-go-client-api generate-ui-api generate-wire wire-smoke api-smoke api-package-pack-smoke contracts-validate contracts-generate contracts-check contracts-smoke docs-reference-check docs-reference-smoke test test-full test-functional test-functional-long verify-fast verify-pr verify-pr-inference verify-extended verify-build-contracts verify-tests run-concurrent-ui-verification-lanes run-sharded-ui-coverage verify test-ui-coverage test-ui-coverage-merge test-ui-browser-integration test-ui-durable-session-real-backend test-backend-coverage test-backend-functional test-backend-verification long-tests long-tests-managed-runtime long-tests-functional-runtime pr-inference-approval test-coverage-go script-timeout-companion-smoke-100 cron-time-work-smoke current-factory-watcher-switch-smoke release-surface-smoke artifact-contract-closeout lint backend-size pkg-maint pkg-file-count pkg-boundary durable-runtime-construction-check logging-boundary-check compatibility-alias-check model-facade-check readme-check deadcode ui-deadcode test-race fmt vet deps deps-tidy init dashboard-verify typecheck release ci ci-typecheck ci-verify-build-contracts ci-verify-tests ui-deps ui-lint ui-build ui-test ui-integration-test ui-durable-session-real-backend-integration-test ui-test-coverage ui-replay-coverage-check ui-install-playwright ui-storybook ui-test-storybook ui-components-typecheck ui-components-test ui-components-storybook ui-components-boundary ui-components-dependency-direction ui-components-verify ui-verify-fresh-npm-install clean
 
 default:
 	$(MAKE) generate-api
@@ -266,6 +267,9 @@ durable-runtime-construction-check:
 
 logging-boundary-check:
 	$(GO) run ./cmd/loggingboundarycheck -root .
+
+compatibility-alias-check:
+	$(GO) run ./cmd/compatibilityaliascheck -root $(COMPATIBILITY_ALIAS_CHECK_ROOT)
 
 model-facade-check:
 	$(GO) run ./cmd/modelfacadecheck

--- a/cmd/compatibilityaliascheck/main.go
+++ b/cmd/compatibilityaliascheck/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/portpowered/infinite-you/internal/contractguard"
+)
+
+type config struct {
+	root string
+}
+
+func main() {
+	cfg := config{}
+	flag.StringVar(&cfg.root, "root", ".", "repository root to scan")
+	flag.Parse()
+	if err := run(cfg, os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(cfg config, stdout, stderr io.Writer) error {
+	terms, err := contractguard.LoadCompatibilityAliasTerms(cfg.root)
+	if err != nil {
+		return err
+	}
+	violations, err := contractguard.ScanCompatibilityAliasViolations(cfg.root, terms, contractguard.DefaultCompatibilityAliasBoundaryPrefixes)
+	if err != nil {
+		return err
+	}
+	if len(violations) == 0 {
+		fmt.Fprintln(stdout, "[agent-factory:compatibility-alias] inventoried compatibility aliases are not adopted outside approved boundaries")
+		return nil
+	}
+	for _, violation := range violations {
+		fmt.Fprintf(
+			stderr,
+			"%s:%d:%d: compatibility alias %q (%s) must not be adopted in new internal code; use the canonical successor instead\n",
+			violation.FilePath,
+			violation.Line,
+			violation.Column,
+			violation.Term,
+			violation.ItemID,
+		)
+	}
+	return fmt.Errorf("[agent-factory:compatibility-alias] found %d prohibited compatibility alias adoption(s)", len(violations))
+}

--- a/cmd/compatibilityaliascheck/main_test.go
+++ b/cmd/compatibilityaliascheck/main_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunRejectsDeliberateCompatibilityAliasAdoption(t *testing.T) {
+	root := filepath.Join(repositoryRoot(t), "cmd", "compatibilityaliascheck", "testdata", "violation-repo")
+
+	var stdout, stderr bytes.Buffer
+	err := run(config{root: root}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("run() error = nil, want deliberate adoption failure")
+	}
+	output := err.Error() + stderr.String()
+	for _, want := range []string{
+		"[agent-factory:compatibility-alias] found 1 prohibited compatibility alias adoption(s)",
+		"pkg/work/adopter.go",
+		"you.workflow.validate",
+		"mcp.alias.you.workflow.validate",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("stderr = %q, want substring %q", output, want)
+		}
+	}
+}
+
+func TestRunPassesOnCleanCompatibilityBoundaryFixture(t *testing.T) {
+	root := filepath.Join(repositoryRoot(t), "cmd", "compatibilityaliascheck", "testdata", "clean-repo")
+	var stdout, stderr bytes.Buffer
+	if err := run(config{root: root}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v, stderr:\n%s", err, stderr.String())
+	}
+	if got := stdout.String(); !strings.Contains(got, "[agent-factory:compatibility-alias] inventoried compatibility aliases are not adopted outside approved boundaries") {
+		t.Fatalf("stdout = %q, want clean compatibility alias scan summary", got)
+	}
+}
+
+func TestRunPassesOnRepositoryRoot(t *testing.T) {
+	root := repositoryRoot(t)
+	var stdout, stderr bytes.Buffer
+	if err := run(config{root: root}, &stdout, &stderr); err != nil {
+		t.Fatalf("run() error = %v, stderr:\n%s", err, stderr.String())
+	}
+	if got := stdout.String(); !strings.Contains(got, "[agent-factory:compatibility-alias] inventoried compatibility aliases are not adopted outside approved boundaries") {
+		t.Fatalf("stdout = %q, want clean compatibility alias scan summary", got)
+	}
+}
+
+func TestMakeCompatibilityAliasCheckTargetPassesOnRepositoryRoot(t *testing.T) {
+	repoRoot := repositoryRoot(t)
+	cmd := exec.Command("make", "compatibility-alias-check", "COMPATIBILITY_ALIAS_CHECK_ROOT="+repoRoot)
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("make compatibility-alias-check failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "[agent-factory:compatibility-alias] inventoried compatibility aliases are not adopted outside approved boundaries") {
+		t.Fatalf("make output = %q, want clean compatibility alias scan summary", output)
+	}
+}
+
+func repositoryRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("repository root: %v", err)
+	}
+	return root
+}
+
+func fixtureRepository(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for relative, contents := range files {
+		path := filepath.Join(root, filepath.FromSlash(relative))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("create fixture directory: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+			t.Fatalf("write fixture %s: %v", relative, err)
+		}
+	}
+	return root
+}

--- a/cmd/compatibilityaliascheck/testdata/clean-repo/contracts/api/deprecated.json
+++ b/cmd/compatibilityaliascheck/testdata/clean-repo/contracts/api/deprecated.json
@@ -1,0 +1,1 @@
+{"formatVersion":"1.0.0","family":"api","records":{}}

--- a/cmd/compatibilityaliascheck/testdata/clean-repo/contracts/cli/deprecated.json
+++ b/cmd/compatibilityaliascheck/testdata/clean-repo/contracts/cli/deprecated.json
@@ -1,0 +1,1 @@
+{"formatVersion":"1.0.0","family":"cli","records":{}}

--- a/cmd/compatibilityaliascheck/testdata/clean-repo/contracts/mcp/deprecated.json
+++ b/cmd/compatibilityaliascheck/testdata/clean-repo/contracts/mcp/deprecated.json
@@ -1,0 +1,28 @@
+{
+  "formatVersion": "1.0.0",
+  "family": "mcp",
+  "records": {
+    "mcp.alias.you.workflow.validate": {
+      "itemId": "mcp.alias.you.workflow.validate",
+      "family": "mcp",
+      "publicName": "you.workflow.validate",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.alias.you.workflow.validate",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "mcp.tool.you.factory_session.validate_source",
+          "canonicalEnglish": "Use you.factory_session.validate_source."
+        }
+      },
+      "evidence": {
+        "summary": "Fixture inventory for compatibility alias lint tests."
+      },
+      "removalGates": [],
+      "approvalStatus": "approved"
+    }
+  }
+}

--- a/cmd/compatibilityaliascheck/testdata/clean-repo/pkg/transports/mcp/factorysession/tool.go
+++ b/cmd/compatibilityaliascheck/testdata/clean-repo/pkg/transports/mcp/factorysession/tool.go
@@ -1,0 +1,4 @@
+package factorysession
+
+// Approved compatibility boundary fixture: alias names may appear here.
+const ToolWorkflowValidate = "you.workflow.validate"

--- a/cmd/compatibilityaliascheck/testdata/violation-repo/contracts/api/deprecated.json
+++ b/cmd/compatibilityaliascheck/testdata/violation-repo/contracts/api/deprecated.json
@@ -1,0 +1,1 @@
+{"formatVersion":"1.0.0","family":"api","records":{}}

--- a/cmd/compatibilityaliascheck/testdata/violation-repo/contracts/cli/deprecated.json
+++ b/cmd/compatibilityaliascheck/testdata/violation-repo/contracts/cli/deprecated.json
@@ -1,0 +1,1 @@
+{"formatVersion":"1.0.0","family":"cli","records":{}}

--- a/cmd/compatibilityaliascheck/testdata/violation-repo/contracts/mcp/deprecated.json
+++ b/cmd/compatibilityaliascheck/testdata/violation-repo/contracts/mcp/deprecated.json
@@ -1,0 +1,28 @@
+{
+  "formatVersion": "1.0.0",
+  "family": "mcp",
+  "records": {
+    "mcp.alias.you.workflow.validate": {
+      "itemId": "mcp.alias.you.workflow.validate",
+      "family": "mcp",
+      "publicName": "you.workflow.validate",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.alias.you.workflow.validate",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "mcp.tool.you.factory_session.validate_source",
+          "canonicalEnglish": "Use you.factory_session.validate_source."
+        }
+      },
+      "evidence": {
+        "summary": "Fixture inventory for compatibility alias lint tests."
+      },
+      "removalGates": [],
+      "approvalStatus": "approved"
+    }
+  }
+}

--- a/cmd/compatibilityaliascheck/testdata/violation-repo/pkg/work/adopter.go
+++ b/cmd/compatibilityaliascheck/testdata/violation-repo/pkg/work/adopter.go
@@ -1,0 +1,4 @@
+package work
+
+// Deliberate compatibility alias adoption used to prove the lint rejects new internal use.
+const adoptedAlias = "you.workflow.validate"

--- a/cmd/contractsvalidate/main.go
+++ b/cmd/contractsvalidate/main.go
@@ -15,11 +15,26 @@ const successMessage = "[agent-factory:contracts-validate] registered contracts 
 func main() {
 	root := flag.String("root", ".", "repository root")
 	flag.Parse()
-	os.Exit(run(*root, contractvalidator.CommonRegistry(), os.Stdout, os.Stderr))
+	os.Exit(run(*root, os.Stdout, os.Stderr))
 }
 
-func run(root string, registry contractvalidator.Registry, stdout, stderr io.Writer) int {
-	diagnostics := contractvalidator.ValidateAll(root, registry)
+func run(root string, stdout, stderr io.Writer) int {
+	var diagnostics []contractvalidator.Diagnostic
+	for _, registry := range []contractvalidator.Registry{
+		contractvalidator.CommonRegistry(),
+		contractvalidator.CompatibilityInventoryRegistry(),
+	} {
+		diagnostics = append(diagnostics, contractvalidator.ValidateAll(root, registry)...)
+	}
+	return emitDiagnostics(diagnostics, stdout, stderr)
+}
+
+func runForRegistry(root string, registry contractvalidator.Registry, stdout, stderr io.Writer) int {
+	return emitDiagnostics(contractvalidator.ValidateAll(root, registry), stdout, stderr)
+}
+
+func emitDiagnostics(diagnostics []contractvalidator.Diagnostic, stdout, stderr io.Writer) int {
+	contractvalidator.SortDiagnostics(diagnostics)
 	if len(diagnostics) == 0 {
 		fmt.Fprintln(stdout, successMessage)
 		return 0

--- a/cmd/contractsvalidate/main_test.go
+++ b/cmd/contractsvalidate/main_test.go
@@ -29,7 +29,7 @@ func TestRunEmitsDeterministicDiagnosticsAndFailureStatus(t *testing.T) {
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
-	if status := run(root, registry, stdout, stderr); status != 1 {
+	if status := runForRegistry(root, registry, stdout, stderr); status != 1 {
 		t.Fatalf("run() status = %d, want 1", status)
 	}
 	if stdout.Len() != 0 {

--- a/contracts/api/deprecated.json
+++ b/contracts/api/deprecated.json
@@ -1,0 +1,440 @@
+{
+  "formatVersion": "1.0.0",
+  "family": "api",
+  "records": {
+    "api.route.post.workflow-previews": {
+      "itemId": "api.route.post.workflow-previews",
+      "family": "api",
+      "publicName": "POST /workflow-previews",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "api.route.post.workflow-previews",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "api.route.post.factories.preview",
+          "canonicalEnglish": "Use POST /factories/preview (previewFactory) for canonical Factory preview validation and diagnostics."
+        }
+      },
+      "evidence": {
+        "summary": "Obsolete workflow-preview REST route is compatibility-only and emits Deprecation plus Link successor headers while forwarding to Factory preview behavior.",
+        "references": [
+          "contracts/testdata/baseline/api-compatibility-surfaces.json",
+          "contracts/testdata/baseline/rest-operations.json",
+          "docs/internal/processes/api-relevant-files.md",
+          "pkg/transports/http/handlers_factory.go"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "api.route.post.workflow-previews.no-external-callers",
+          "description": "No supported external REST or generated-client consumers rely on POST /workflow-previews.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "api.schema.workflow-preview-request": {
+      "itemId": "api.schema.workflow-preview-request",
+      "family": "api",
+      "publicName": "WorkflowPreviewRequest",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "api.schema.workflow-preview-request",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "api.schema.factory-preview-request",
+          "canonicalEnglish": "Use FactoryPreviewRequest for canonical Factory preview request contracts."
+        }
+      },
+      "evidence": {
+        "summary": "WorkflowPreviewRequest is a deprecated OpenAPI schema alias of FactoryPreviewRequest.",
+        "references": [
+          "contracts/testdata/baseline/api-compatibility-surfaces.json",
+          "api/components/schemas/api/WorkflowPreviewRequest.yaml",
+          "pkg/transports/http/contracttests/openapi_contract_factory_validation_test.go"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "api.schema.workflow-preview-request.no-external-callers",
+          "description": "No supported Go or TypeScript consumers compile against WorkflowPreviewRequest.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "api.schema.workflow-preview-result": {
+      "itemId": "api.schema.workflow-preview-result",
+      "family": "api",
+      "publicName": "WorkflowPreviewResult",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "api.schema.workflow-preview-result",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "api.schema.factory-preview-result",
+          "canonicalEnglish": "Use FactoryPreviewResult for canonical Factory preview response contracts."
+        }
+      },
+      "evidence": {
+        "summary": "WorkflowPreviewResult is a deprecated OpenAPI schema alias of FactoryPreviewResult.",
+        "references": [
+          "contracts/testdata/baseline/api-compatibility-surfaces.json",
+          "api/components/schemas/api/WorkflowPreviewResult.yaml",
+          "pkg/transports/http/contracttests/openapi_contract_factory_validation_test.go"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "api.schema.workflow-preview-result.no-external-callers",
+          "description": "No supported Go or TypeScript consumers compile against WorkflowPreviewResult.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "api.generated.go.preview-workflow-json-request-body": {
+      "itemId": "api.generated.go.preview-workflow-json-request-body",
+      "family": "api",
+      "publicName": "PreviewWorkflowJSONRequestBody",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "api.generated.go.preview-workflow-json-request-body",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "api.generated.go.preview-factory-json-request-body",
+          "canonicalEnglish": "Use PreviewFactoryJSONRequestBody for canonical generated Go Factory preview request bodies."
+        }
+      },
+      "evidence": {
+        "summary": "Generated Go PreviewWorkflowJSONRequestBody aliases FactoryPreviewRequest for the obsolete previewWorkflow operation.",
+        "references": [
+          "contracts/testdata/baseline/api-compatibility-surfaces.json",
+          "pkg/transports/http/generated/server.gen.go"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "api.generated.go.preview-workflow-json-request-body.no-external-callers",
+          "description": "No supported Go consumers invoke PreviewWorkflowJSONRequestBody.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "api.operation.preview-workflow": {
+      "itemId": "api.operation.preview-workflow",
+      "family": "api",
+      "publicName": "previewWorkflow",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "api.operation.preview-workflow",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "api.operation.preview-factory",
+          "canonicalEnglish": "Use previewFactory for canonical Factory preview server operations."
+        }
+      },
+      "evidence": {
+        "summary": "previewWorkflow is a deprecated OpenAPI operationId for the obsolete POST /workflow-previews route.",
+        "references": [
+          "contracts/testdata/baseline/api-compatibility-surfaces.json",
+          "contracts/testdata/baseline/rest-operations.json",
+          "api/openapi-main.yaml"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "api.operation.preview-workflow.no-external-callers",
+          "description": "No supported generated clients or handlers rely on previewWorkflow operation names.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "api.generated.ts.operation.preview-workflow": {
+      "itemId": "api.generated.ts.operation.preview-workflow",
+      "family": "api",
+      "publicName": "operations[\"previewWorkflow\"]",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "api.generated.ts.operation.preview-workflow",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "api.generated.ts.operation.preview-factory",
+          "canonicalEnglish": "Use operations[\"previewFactory\"] for canonical generated TypeScript Factory preview clients."
+        }
+      },
+      "evidence": {
+        "summary": "Generated TypeScript operations previewWorkflow entry aliases the canonical previewFactory operation.",
+        "references": [
+          "contracts/testdata/baseline/api-compatibility-surfaces.json",
+          "ui/src/api/generated/openapi.ts"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "api.generated.ts.operation.preview-workflow.no-external-callers",
+          "description": "No supported TypeScript consumers invoke operations previewWorkflow.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "api.route.get.events": {
+      "itemId": "api.route.get.events",
+      "family": "api",
+      "publicName": "GET /events",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "api.route.get.events",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "api.route.get.factory-sessions.session-id.events",
+          "canonicalEnglish": "Use GET /factory-sessions/{session_id}/events with a resolved Factory Session UUID for session-scoped live and durable event streams."
+        }
+      },
+      "evidence": {
+        "summary": "Process-global GET /events is compatibility-only for retained legacy tooling and operator diagnostics.",
+        "references": [
+          "contracts/testdata/baseline/api-compatibility-surfaces.json",
+          "contracts/testdata/baseline/rest-operations.json",
+          "docs/internal/processes/api-relevant-files.md",
+          "pkg/api/handlers_events.go"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "api.route.get.events.no-external-callers",
+          "description": "No supported legacy tools or operator diagnostics rely on process-global GET /events.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "api.selector.default-session": {
+      "itemId": "api.selector.default-session",
+      "family": "api",
+      "publicName": "~default",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "api.selector.default-session",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "api.identity.resolved-factory-session-uuid",
+          "canonicalEnglish": "Resolve and persist the canonical Factory Session UUID from list runtime stream identity, sync preflight, session read, or event-stream handshake instead of ~default."
+        }
+      },
+      "evidence": {
+        "summary": "~default is a compatibility-only Factory Session selector accepted at API and CLI boundaries and resolved to the current default live session.",
+        "references": [
+          "contracts/testdata/baseline/api-compatibility-surfaces.json",
+          "docs/internal/processes/api-relevant-files.md",
+          "pkg/factorysessions/registry.go",
+          "pkg/factorysessions/types.go",
+          "pkg/service/runtime_sessions.go"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "api.selector.default-session.no-external-callers",
+          "description": "No supported CLI, API, or UI callers submit or persist ~default as Factory Session identity.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "api.ui.export.workflow-preview-request": {
+      "itemId": "api.ui.export.workflow-preview-request",
+      "family": "api",
+      "publicName": "WorkflowPreviewRequest",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "api.ui.export.workflow-preview-request",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "api.ui.export.factory-preview-request",
+          "canonicalEnglish": "Import FactoryPreviewRequest from ui/src/api/factory-preview instead of workflow-preview re-exports."
+        }
+      },
+      "evidence": {
+        "summary": "Dashboard workflow-preview module re-exports WorkflowPreviewRequest as a TypeScript import compatibility boundary.",
+        "references": [
+          "contracts/testdata/baseline/api-compatibility-surfaces.json",
+          "docs/internal/processes/api-relevant-files.md",
+          "ui/src/api/workflow-preview/index.ts",
+          "ui/src/api/workflow-preview/index.test.ts"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "api.ui.export.workflow-preview-request.no-external-callers",
+          "description": "No supported first-party dashboard code imports WorkflowPreviewRequest from workflow-preview.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "api.ui.export.workflow-preview-result": {
+      "itemId": "api.ui.export.workflow-preview-result",
+      "family": "api",
+      "publicName": "WorkflowPreviewResult",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "api.ui.export.workflow-preview-result",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "api.ui.export.factory-preview-result",
+          "canonicalEnglish": "Import FactoryPreviewResult from ui/src/api/factory-preview instead of workflow-preview re-exports."
+        }
+      },
+      "evidence": {
+        "summary": "Dashboard workflow-preview module re-exports WorkflowPreviewResult as a TypeScript import compatibility boundary.",
+        "references": [
+          "contracts/testdata/baseline/api-compatibility-surfaces.json",
+          "docs/internal/processes/api-relevant-files.md",
+          "ui/src/api/workflow-preview/index.ts",
+          "ui/src/api/workflow-preview/index.test.ts"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "api.ui.export.workflow-preview-result.no-external-callers",
+          "description": "No supported first-party dashboard code imports WorkflowPreviewResult from workflow-preview.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "api.ui.export.workflow-preview-api-error": {
+      "itemId": "api.ui.export.workflow-preview-api-error",
+      "family": "api",
+      "publicName": "WorkflowPreviewAPIError",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "api.ui.export.workflow-preview-api-error",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "api.ui.export.factory-preview-api-error",
+          "canonicalEnglish": "Import FactoryPreviewAPIError from ui/src/api/factory-preview instead of workflow-preview re-exports."
+        }
+      },
+      "evidence": {
+        "summary": "Dashboard workflow-preview module re-exports WorkflowPreviewAPIError as a TypeScript import compatibility boundary.",
+        "references": [
+          "contracts/testdata/baseline/api-compatibility-surfaces.json",
+          "docs/internal/processes/api-relevant-files.md",
+          "ui/src/api/workflow-preview/messages.ts"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "api.ui.export.workflow-preview-api-error.no-external-callers",
+          "description": "No supported first-party dashboard code imports WorkflowPreviewAPIError from workflow-preview.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "api.ui.export.workflow-preview-api-error-messages": {
+      "itemId": "api.ui.export.workflow-preview-api-error-messages",
+      "family": "api",
+      "publicName": "workflowPreviewAPIErrorMessages",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "api.ui.export.workflow-preview-api-error-messages",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "api.ui.export.factory-preview-api-error-messages",
+          "canonicalEnglish": "Import factoryPreviewAPIErrorMessages from ui/src/api/factory-preview instead of workflow-preview re-exports."
+        }
+      },
+      "evidence": {
+        "summary": "Dashboard workflow-preview module re-exports workflowPreviewAPIErrorMessages as a TypeScript import compatibility boundary.",
+        "references": [
+          "contracts/testdata/baseline/api-compatibility-surfaces.json",
+          "docs/internal/processes/api-relevant-files.md",
+          "ui/src/api/workflow-preview/messages.ts"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "api.ui.export.workflow-preview-api-error-messages.no-external-callers",
+          "description": "No supported first-party dashboard code imports workflowPreviewAPIErrorMessages from workflow-preview.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "api.ui.export.preview-workflow": {
+      "itemId": "api.ui.export.preview-workflow",
+      "family": "api",
+      "publicName": "previewWorkflow",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "api.ui.export.preview-workflow",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "api.ui.export.preview-factory",
+          "canonicalEnglish": "Import previewFactory from ui/src/api/factory-preview instead of the workflow-preview transport adapter."
+        }
+      },
+      "evidence": {
+        "summary": "Dashboard workflow-preview module exports previewWorkflow as a delegation adapter to the canonical Factory preview transport.",
+        "references": [
+          "contracts/testdata/baseline/api-compatibility-surfaces.json",
+          "docs/internal/processes/api-relevant-files.md",
+          "ui/src/api/workflow-preview/api.ts",
+          "ui/src/api/workflow-preview/api.test.ts"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "api.ui.export.preview-workflow.no-external-callers",
+          "description": "No supported first-party dashboard code invokes previewWorkflow from workflow-preview.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    }
+  }
+}

--- a/contracts/api_deprecated_inventory_test.go
+++ b/contracts/api_deprecated_inventory_test.go
@@ -1,0 +1,135 @@
+package contracts_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/contractvalidator"
+)
+
+const apiDeprecatedInventoryPath = "api/deprecated.json"
+
+func TestAPIDeprecatedInventoryValidatesAgainstSchema(t *testing.T) {
+	schema := compileSchema(
+		t,
+		"compatibility-inventory.schema.json",
+		compatibilityInventorySchemaID,
+		schemaResource{
+			path: filepath.Join("common", "compatibility-inventory.schema.json"),
+			id:   compatibilityVocabularySchemaID,
+		},
+		schemaResource{
+			path: filepath.Join("common", "documentation.schema.json"),
+			id:   documentationSchemaID,
+		},
+		schemaResource{
+			path: filepath.Join("common", "deprecations.schema.json"),
+			id:   deprecationsSchemaID,
+		},
+	)
+
+	instance := readJSON(t, apiDeprecatedInventoryPath)
+	if err := schema.Validate(instance); err != nil {
+		t.Fatalf("validate API deprecated inventory: %v", err)
+	}
+	diagnostics := contractvalidator.CompatibilityInventorySemanticsDiagnostics(apiDeprecatedInventoryPath, instance)
+	if len(diagnostics) != 0 {
+		t.Fatalf("semantic diagnostics = %#v, want none", diagnostics)
+	}
+}
+
+func TestAPIDeprecatedInventoryClassifiesEveryBaselineCompatibilitySurface(t *testing.T) {
+	baseline := readAPICompatibilitySurfacesBaseline(t)
+	inventory := readAPIDeprecatedInventory(t)
+
+	if inventory.Family != "api" {
+		t.Fatalf("inventory family = %q, want api", inventory.Family)
+	}
+
+	for _, surface := range baseline.Surfaces {
+		if !surface.CompatibilityOnly {
+			t.Fatalf("baseline surface %q is not marked compatibility-only", surface.ItemID)
+		}
+		record, ok := inventory.Records[surface.ItemID]
+		if !ok {
+			t.Fatalf("missing inventory record for baseline surface %q", surface.ItemID)
+		}
+		if record.PublicName != surface.PublicName {
+			t.Fatalf("record publicName = %q, want %q", record.PublicName, surface.PublicName)
+		}
+		if record.Classification == "" {
+			t.Fatalf("record for %q missing classification", surface.ItemID)
+		}
+		if record.Lifecycle.Successor.TargetItemID != surface.CanonicalSuccessorItemID {
+			t.Fatalf(
+				"record successor targetItemId = %q, want %q",
+				record.Lifecycle.Successor.TargetItemID,
+				surface.CanonicalSuccessorItemID,
+			)
+		}
+		if record.Lifecycle.Successor.CanonicalEnglish == "" {
+			t.Fatalf("record for %q missing successor migration guidance", surface.ItemID)
+		}
+		if record.Evidence.Summary == "" {
+			t.Fatalf("record for %q missing evidence summary", surface.ItemID)
+		}
+		if len(record.RemovalGates) == 0 {
+			t.Fatalf("record for %q missing removal gates", surface.ItemID)
+		}
+		if record.ApprovalStatus == "" {
+			t.Fatalf("record for %q missing approval status", surface.ItemID)
+		}
+	}
+
+	if len(inventory.Records) != len(baseline.Surfaces) {
+		t.Fatalf(
+			"inventory record count = %d, want %d baseline compatibility surfaces",
+			len(inventory.Records),
+			len(baseline.Surfaces),
+		)
+	}
+}
+
+type apiCompatibilitySurfacesBaselineDocument struct {
+	Surfaces []apiCompatibilitySurfaceRecord `json:"surfaces"`
+}
+
+type apiCompatibilitySurfaceRecord struct {
+	ItemID                     string `json:"itemId"`
+	PublicName                 string `json:"publicName"`
+	CanonicalSuccessorItemID   string `json:"canonicalSuccessorItemId"`
+	CompatibilityOnly          bool   `json:"compatibilityOnly"`
+}
+
+type apiDeprecatedInventoryDocument struct {
+	Family  string                         `json:"family"`
+	Records map[string]apiCompatibilityRecord `json:"records"`
+}
+
+type apiCompatibilityRecord struct {
+	PublicName     string `json:"publicName"`
+	Classification string `json:"classification"`
+	ApprovalStatus string `json:"approvalStatus"`
+	Lifecycle      struct {
+		Successor struct {
+			TargetItemID     string `json:"targetItemId"`
+			CanonicalEnglish string `json:"canonicalEnglish"`
+		} `json:"successor"`
+	} `json:"lifecycle"`
+	Evidence struct {
+		Summary string `json:"summary"`
+	} `json:"evidence"`
+	RemovalGates []struct {
+		ID string `json:"id"`
+	} `json:"removalGates"`
+}
+
+func readAPICompatibilitySurfacesBaseline(t *testing.T) apiCompatibilitySurfacesBaselineDocument {
+	t.Helper()
+	return decodeContractJSON[apiCompatibilitySurfacesBaselineDocument](t, filepath.Join("testdata", "baseline", "api-compatibility-surfaces.json"))
+}
+
+func readAPIDeprecatedInventory(t *testing.T) apiDeprecatedInventoryDocument {
+	t.Helper()
+	return decodeContractJSON[apiDeprecatedInventoryDocument](t, apiDeprecatedInventoryPath)
+}

--- a/contracts/api_deprecated_inventory_test.go
+++ b/contracts/api_deprecated_inventory_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/portpowered/infinite-you/internal/contractvalidator"
 )
 
-const apiDeprecatedInventoryPath = "api/deprecated.json"
-
 func TestAPIDeprecatedInventoryValidatesAgainstSchema(t *testing.T) {
 	schema := compileSchema(
 		t,
@@ -36,100 +34,4 @@ func TestAPIDeprecatedInventoryValidatesAgainstSchema(t *testing.T) {
 	if len(diagnostics) != 0 {
 		t.Fatalf("semantic diagnostics = %#v, want none", diagnostics)
 	}
-}
-
-func TestAPIDeprecatedInventoryClassifiesEveryBaselineCompatibilitySurface(t *testing.T) {
-	baseline := readAPICompatibilitySurfacesBaseline(t)
-	inventory := readAPIDeprecatedInventory(t)
-
-	if inventory.Family != "api" {
-		t.Fatalf("inventory family = %q, want api", inventory.Family)
-	}
-
-	for _, surface := range baseline.Surfaces {
-		if !surface.CompatibilityOnly {
-			t.Fatalf("baseline surface %q is not marked compatibility-only", surface.ItemID)
-		}
-		record, ok := inventory.Records[surface.ItemID]
-		if !ok {
-			t.Fatalf("missing inventory record for baseline surface %q", surface.ItemID)
-		}
-		if record.PublicName != surface.PublicName {
-			t.Fatalf("record publicName = %q, want %q", record.PublicName, surface.PublicName)
-		}
-		if record.Classification == "" {
-			t.Fatalf("record for %q missing classification", surface.ItemID)
-		}
-		if record.Lifecycle.Successor.TargetItemID != surface.CanonicalSuccessorItemID {
-			t.Fatalf(
-				"record successor targetItemId = %q, want %q",
-				record.Lifecycle.Successor.TargetItemID,
-				surface.CanonicalSuccessorItemID,
-			)
-		}
-		if record.Lifecycle.Successor.CanonicalEnglish == "" {
-			t.Fatalf("record for %q missing successor migration guidance", surface.ItemID)
-		}
-		if record.Evidence.Summary == "" {
-			t.Fatalf("record for %q missing evidence summary", surface.ItemID)
-		}
-		if len(record.RemovalGates) == 0 {
-			t.Fatalf("record for %q missing removal gates", surface.ItemID)
-		}
-		if record.ApprovalStatus == "" {
-			t.Fatalf("record for %q missing approval status", surface.ItemID)
-		}
-	}
-
-	if len(inventory.Records) != len(baseline.Surfaces) {
-		t.Fatalf(
-			"inventory record count = %d, want %d baseline compatibility surfaces",
-			len(inventory.Records),
-			len(baseline.Surfaces),
-		)
-	}
-}
-
-type apiCompatibilitySurfacesBaselineDocument struct {
-	Surfaces []apiCompatibilitySurfaceRecord `json:"surfaces"`
-}
-
-type apiCompatibilitySurfaceRecord struct {
-	ItemID                     string `json:"itemId"`
-	PublicName                 string `json:"publicName"`
-	CanonicalSuccessorItemID   string `json:"canonicalSuccessorItemId"`
-	CompatibilityOnly          bool   `json:"compatibilityOnly"`
-}
-
-type apiDeprecatedInventoryDocument struct {
-	Family  string                         `json:"family"`
-	Records map[string]apiCompatibilityRecord `json:"records"`
-}
-
-type apiCompatibilityRecord struct {
-	PublicName     string `json:"publicName"`
-	Classification string `json:"classification"`
-	ApprovalStatus string `json:"approvalStatus"`
-	Lifecycle      struct {
-		Successor struct {
-			TargetItemID     string `json:"targetItemId"`
-			CanonicalEnglish string `json:"canonicalEnglish"`
-		} `json:"successor"`
-	} `json:"lifecycle"`
-	Evidence struct {
-		Summary string `json:"summary"`
-	} `json:"evidence"`
-	RemovalGates []struct {
-		ID string `json:"id"`
-	} `json:"removalGates"`
-}
-
-func readAPICompatibilitySurfacesBaseline(t *testing.T) apiCompatibilitySurfacesBaselineDocument {
-	t.Helper()
-	return decodeContractJSON[apiCompatibilitySurfacesBaselineDocument](t, filepath.Join("testdata", "baseline", "api-compatibility-surfaces.json"))
-}
-
-func readAPIDeprecatedInventory(t *testing.T) apiDeprecatedInventoryDocument {
-	t.Helper()
-	return decodeContractJSON[apiDeprecatedInventoryDocument](t, apiDeprecatedInventoryPath)
 }

--- a/contracts/cli/deprecated.json
+++ b/contracts/cli/deprecated.json
@@ -1,0 +1,303 @@
+{
+  "formatVersion": "1.0.0",
+  "family": "cli",
+  "records": {
+    "cli.command.workflow.preview": {
+      "itemId": "cli.command.workflow.preview",
+      "family": "cli",
+      "publicName": "you workflow preview",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "cli.command.workflow.preview",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "api.route.post.factories.preview",
+          "canonicalEnglish": "Use POST /factories/preview for canonical Factory preview validation and diagnostics."
+        }
+      },
+      "evidence": {
+        "summary": "Workflow-named CLI preview command is compatibility-only and forwards to Factory preview output.",
+        "references": [
+          "contracts/testdata/baseline/cli-commands.json",
+          "docs/internal/processes/api-relevant-files.md",
+          "pkg/transports/cli/workflow/preview.go"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "cli.command.workflow.preview.no-external-callers",
+          "description": "No supported external operators rely on the workflow-named preview command.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "cli.command.workflow.validate": {
+      "itemId": "cli.command.workflow.validate",
+      "family": "cli",
+      "publicName": "you workflow validate",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "cli.command.workflow.validate",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "api.route.post.factories.preview",
+          "canonicalEnglish": "Use POST /factories/preview or MCP you.factory_session.validate_source for canonical Factory preview validation."
+        }
+      },
+      "evidence": {
+        "summary": "Workflow-named CLI validate command is compatibility-only and matches Factory preview validation without creating a Factory Session.",
+        "references": [
+          "contracts/testdata/baseline/cli-commands.json",
+          "docs/internal/processes/api-relevant-files.md",
+          "pkg/transports/cli/workflow/validate.go"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "cli.command.workflow.validate.no-external-callers",
+          "description": "No supported external operators rely on the workflow-named validate command.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "cli.command.workflow.run": {
+      "itemId": "cli.command.workflow.run",
+      "family": "cli",
+      "publicName": "you workflow run",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "cli.command.workflow.run",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "api.route.post.factory-sessions.sync",
+          "canonicalEnglish": "Use POST /factory-sessions/sync for synchronous Factory Session execution."
+        }
+      },
+      "evidence": {
+        "summary": "Workflow-named CLI run command is compatibility-only and uses the shared sync Factory Session execution contract.",
+        "references": [
+          "contracts/testdata/baseline/cli-commands.json",
+          "docs/internal/processes/api-relevant-files.md",
+          "pkg/transports/cli/sessionexecution/run.go"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "cli.command.workflow.run.no-external-callers",
+          "description": "No supported external operators rely on the workflow-named run command.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "cli.command.workflow.start": {
+      "itemId": "cli.command.workflow.start",
+      "family": "cli",
+      "publicName": "you workflow start",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "cli.command.workflow.start",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "api.route.post.factory-sessions.async",
+          "canonicalEnglish": "Use POST /factory-sessions/async for asynchronous Factory Session execution."
+        }
+      },
+      "evidence": {
+        "summary": "Workflow-named CLI start command is compatibility-only and uses the shared async Factory Session execution contract.",
+        "references": [
+          "contracts/testdata/baseline/cli-commands.json",
+          "docs/internal/processes/api-relevant-files.md",
+          "pkg/transports/cli/sessionexecution/async.go"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "cli.command.workflow.start.no-external-callers",
+          "description": "No supported external operators rely on the workflow-named start command.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "cli.command.workflow.status": {
+      "itemId": "cli.command.workflow.status",
+      "family": "cli",
+      "publicName": "you workflow status",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "cli.command.workflow.status",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "api.route.get.factory-sessions.session-id",
+          "canonicalEnglish": "Use GET /factory-sessions/{session_id} or you session show {session_id} for Factory Session status reads."
+        }
+      },
+      "evidence": {
+        "summary": "Workflow-named CLI status command is compatibility-only and normalizes durable Factory Session status for CLI output.",
+        "references": [
+          "contracts/testdata/baseline/cli-commands.json",
+          "docs/internal/processes/api-relevant-files.md",
+          "pkg/transports/cli/sessionexecution/status.go"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "cli.command.workflow.status.no-external-callers",
+          "description": "No supported external operators rely on the workflow-named status command.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "cli.command.workflow.result": {
+      "itemId": "cli.command.workflow.result",
+      "family": "cli",
+      "publicName": "you workflow result",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "cli.command.workflow.result",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "api.route.get.factory-sessions.session-id.results",
+          "canonicalEnglish": "Use GET /factory-sessions/{session_id}/results for durable Factory Session result reads."
+        }
+      },
+      "evidence": {
+        "summary": "Workflow-named CLI result command is compatibility-only and normalizes durable Factory Session results for CLI output.",
+        "references": [
+          "contracts/testdata/baseline/cli-commands.json",
+          "docs/internal/processes/api-relevant-files.md",
+          "pkg/transports/cli/sessionexecution/result.go"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "cli.command.workflow.result.no-external-callers",
+          "description": "No supported external operators rely on the workflow-named result command.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "cli.command.workflow.dispatches": {
+      "itemId": "cli.command.workflow.dispatches",
+      "family": "cli",
+      "publicName": "you workflow dispatches",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "cli.command.workflow.dispatches",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "api.route.get.factory-sessions.session-id.dispatches",
+          "canonicalEnglish": "Use GET /factory-sessions/{session_id}/dispatches or you session dispatches {session_id} for dispatch inspection."
+        }
+      },
+      "evidence": {
+        "summary": "Workflow-named CLI dispatches command is compatibility-only and normalizes durable Factory Session dispatch records for CLI output.",
+        "references": [
+          "contracts/testdata/baseline/cli-commands.json",
+          "docs/internal/processes/api-relevant-files.md",
+          "pkg/transports/cli/sessionexecution/inspection.go"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "cli.command.workflow.dispatches.no-external-callers",
+          "description": "No supported external operators rely on the workflow-named dispatches command.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "cli.command.workflow.artifacts": {
+      "itemId": "cli.command.workflow.artifacts",
+      "family": "cli",
+      "publicName": "you workflow artifacts",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "cli.command.workflow.artifacts",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "api.route.get.factory-sessions.session-id.artifacts",
+          "canonicalEnglish": "Use GET /factory-sessions/{session_id}/artifacts for FactoryArtifact inspection."
+        }
+      },
+      "evidence": {
+        "summary": "Workflow-named CLI artifacts command is compatibility-only and normalizes durable FactoryArtifact records for CLI output.",
+        "references": [
+          "contracts/testdata/baseline/cli-commands.json",
+          "docs/internal/processes/api-relevant-files.md",
+          "pkg/transports/cli/sessionexecution/inspection.go"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "cli.command.workflow.artifacts.no-external-callers",
+          "description": "No supported external operators rely on the workflow-named artifacts command.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "cli.command.workflow.events": {
+      "itemId": "cli.command.workflow.events",
+      "family": "cli",
+      "publicName": "you workflow events",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "cli.command.workflow.events",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "api.route.get.factory-sessions.session-id.events",
+          "canonicalEnglish": "Use GET /factory-sessions/{session_id}/events for ordered FactoryEvent inspection and reconnect cursors."
+        }
+      },
+      "evidence": {
+        "summary": "Workflow-named CLI events command is compatibility-only and normalizes durable FactoryEvent reads for CLI output.",
+        "references": [
+          "contracts/testdata/baseline/cli-commands.json",
+          "docs/internal/processes/api-relevant-files.md",
+          "pkg/transports/cli/sessionexecution/inspection.go"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "cli.command.workflow.events.no-external-callers",
+          "description": "No supported external operators rely on the workflow-named events command.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    }
+  }
+}

--- a/contracts/cli_deprecated_inventory_test.go
+++ b/contracts/cli_deprecated_inventory_test.go
@@ -2,25 +2,10 @@ package contracts_test
 
 import (
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/portpowered/infinite-you/internal/contractvalidator"
 )
-
-const cliDeprecatedInventoryPath = "cli/deprecated.json"
-
-var cliCompatibilitySuccessorByIDCandidate = map[string]string{
-	"you.workflow.preview":    "api.route.post.factories.preview",
-	"you.workflow.validate":   "api.route.post.factories.preview",
-	"you.workflow.run":        "api.route.post.factory-sessions.sync",
-	"you.workflow.start":      "api.route.post.factory-sessions.async",
-	"you.workflow.status":     "api.route.get.factory-sessions.session-id",
-	"you.workflow.result":     "api.route.get.factory-sessions.session-id.results",
-	"you.workflow.dispatches": "api.route.get.factory-sessions.session-id.dispatches",
-	"you.workflow.artifacts":  "api.route.get.factory-sessions.session-id.artifacts",
-	"you.workflow.events":     "api.route.get.factory-sessions.session-id.events",
-}
 
 func TestCLIDeprecatedInventoryValidatesAgainstSchema(t *testing.T) {
 	schema := compileSchema(
@@ -49,124 +34,4 @@ func TestCLIDeprecatedInventoryValidatesAgainstSchema(t *testing.T) {
 	if len(diagnostics) != 0 {
 		t.Fatalf("semantic diagnostics = %#v, want none", diagnostics)
 	}
-}
-
-func TestCLIDeprecatedInventoryClassifiesEveryBaselineCompatibilityCommand(t *testing.T) {
-	baseline := readCLICommandIdentityBaseline(t)
-	inventory := readCLIDeprecatedInventory(t)
-
-	if inventory.Family != "cli" {
-		t.Fatalf("inventory family = %q, want cli", inventory.Family)
-	}
-
-	compatibilityCommands := baselineCompatibilityCommands(baseline)
-	if len(compatibilityCommands) == 0 {
-		t.Fatal("expected at least one baseline CLI compatibility command")
-	}
-
-	for _, command := range compatibilityCommands {
-		recordKey := cliCompatibilityRecordKey(command.IDCandidate)
-		record, ok := inventory.Records[recordKey]
-		if !ok {
-			t.Fatalf("missing inventory record for baseline command %q", command.Path)
-		}
-		if record.PublicName != command.Path {
-			t.Fatalf("record publicName = %q, want %q", record.PublicName, command.Path)
-		}
-		if record.Classification == "" {
-			t.Fatalf("record for %q missing classification", command.Path)
-		}
-		wantSuccessor, ok := cliCompatibilitySuccessorByIDCandidate[command.IDCandidate]
-		if !ok {
-			t.Fatalf("missing successor mapping for baseline command idCandidate %q", command.IDCandidate)
-		}
-		if record.Lifecycle.Successor.TargetItemID != wantSuccessor {
-			t.Fatalf(
-				"record successor targetItemId = %q, want %q",
-				record.Lifecycle.Successor.TargetItemID,
-				wantSuccessor,
-			)
-		}
-		if record.Lifecycle.Successor.CanonicalEnglish == "" {
-			t.Fatalf("record for %q missing successor migration guidance", command.Path)
-		}
-		if record.Evidence.Summary == "" {
-			t.Fatalf("record for %q missing evidence summary", command.Path)
-		}
-		if len(record.RemovalGates) == 0 {
-			t.Fatalf("record for %q missing removal gates", command.Path)
-		}
-		if record.ApprovalStatus == "" {
-			t.Fatalf("record for %q missing approval status", command.Path)
-		}
-	}
-
-	if len(inventory.Records) != len(compatibilityCommands) {
-		t.Fatalf(
-			"inventory record count = %d, want %d baseline compatibility commands",
-			len(inventory.Records),
-			len(compatibilityCommands),
-		)
-	}
-}
-
-type cliCommandIdentityBaselineDocument struct {
-	Commands []cliCommandIdentityRecord `json:"commands"`
-}
-
-type cliCommandIdentityRecord struct {
-	Path        string `json:"path"`
-	IDCandidate string `json:"idCandidate"`
-}
-
-type cliDeprecatedInventoryDocument struct {
-	Family  string                          `json:"family"`
-	Records map[string]cliCompatibilityRecord `json:"records"`
-}
-
-type cliCompatibilityRecord struct {
-	PublicName     string `json:"publicName"`
-	Classification string `json:"classification"`
-	ApprovalStatus string `json:"approvalStatus"`
-	Lifecycle      struct {
-		Successor struct {
-			TargetItemID     string `json:"targetItemId"`
-			CanonicalEnglish string `json:"canonicalEnglish"`
-		} `json:"successor"`
-	} `json:"lifecycle"`
-	Evidence struct {
-		Summary string `json:"summary"`
-	} `json:"evidence"`
-	RemovalGates []struct {
-		ID string `json:"id"`
-	} `json:"removalGates"`
-}
-
-func readCLICommandIdentityBaseline(t *testing.T) cliCommandIdentityBaselineDocument {
-	t.Helper()
-	return decodeContractJSON[cliCommandIdentityBaselineDocument](t, filepath.Join("testdata", "baseline", "cli-commands.json"))
-}
-
-func readCLIDeprecatedInventory(t *testing.T) cliDeprecatedInventoryDocument {
-	t.Helper()
-	return decodeContractJSON[cliDeprecatedInventoryDocument](t, cliDeprecatedInventoryPath)
-}
-
-func baselineCompatibilityCommands(baseline cliCommandIdentityBaselineDocument) []cliCommandIdentityRecord {
-	var commands []cliCommandIdentityRecord
-	for _, command := range baseline.Commands {
-		if !isCLICompatibilityCommandIDCandidate(command.IDCandidate) {
-			continue
-		}
-		commands = append(commands, command)
-	}
-	return commands
-}
-
-func isCLICompatibilityCommandIDCandidate(idCandidate string) bool {
-	return strings.HasPrefix(idCandidate, "you.workflow.") && idCandidate != "you.workflow"
-}
-
-func cliCompatibilityRecordKey(idCandidate string) string {
-	return "cli.command." + strings.TrimPrefix(idCandidate, "you.")
 }

--- a/contracts/cli_deprecated_inventory_test.go
+++ b/contracts/cli_deprecated_inventory_test.go
@@ -1,0 +1,172 @@
+package contracts_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/contractvalidator"
+)
+
+const cliDeprecatedInventoryPath = "cli/deprecated.json"
+
+var cliCompatibilitySuccessorByIDCandidate = map[string]string{
+	"you.workflow.preview":    "api.route.post.factories.preview",
+	"you.workflow.validate":   "api.route.post.factories.preview",
+	"you.workflow.run":        "api.route.post.factory-sessions.sync",
+	"you.workflow.start":      "api.route.post.factory-sessions.async",
+	"you.workflow.status":     "api.route.get.factory-sessions.session-id",
+	"you.workflow.result":     "api.route.get.factory-sessions.session-id.results",
+	"you.workflow.dispatches": "api.route.get.factory-sessions.session-id.dispatches",
+	"you.workflow.artifacts":  "api.route.get.factory-sessions.session-id.artifacts",
+	"you.workflow.events":     "api.route.get.factory-sessions.session-id.events",
+}
+
+func TestCLIDeprecatedInventoryValidatesAgainstSchema(t *testing.T) {
+	schema := compileSchema(
+		t,
+		"compatibility-inventory.schema.json",
+		compatibilityInventorySchemaID,
+		schemaResource{
+			path: filepath.Join("common", "compatibility-inventory.schema.json"),
+			id:   compatibilityVocabularySchemaID,
+		},
+		schemaResource{
+			path: filepath.Join("common", "documentation.schema.json"),
+			id:   documentationSchemaID,
+		},
+		schemaResource{
+			path: filepath.Join("common", "deprecations.schema.json"),
+			id:   deprecationsSchemaID,
+		},
+	)
+
+	instance := readJSON(t, cliDeprecatedInventoryPath)
+	if err := schema.Validate(instance); err != nil {
+		t.Fatalf("validate CLI deprecated inventory: %v", err)
+	}
+	diagnostics := contractvalidator.CompatibilityInventorySemanticsDiagnostics(cliDeprecatedInventoryPath, instance)
+	if len(diagnostics) != 0 {
+		t.Fatalf("semantic diagnostics = %#v, want none", diagnostics)
+	}
+}
+
+func TestCLIDeprecatedInventoryClassifiesEveryBaselineCompatibilityCommand(t *testing.T) {
+	baseline := readCLICommandIdentityBaseline(t)
+	inventory := readCLIDeprecatedInventory(t)
+
+	if inventory.Family != "cli" {
+		t.Fatalf("inventory family = %q, want cli", inventory.Family)
+	}
+
+	compatibilityCommands := baselineCompatibilityCommands(baseline)
+	if len(compatibilityCommands) == 0 {
+		t.Fatal("expected at least one baseline CLI compatibility command")
+	}
+
+	for _, command := range compatibilityCommands {
+		recordKey := cliCompatibilityRecordKey(command.IDCandidate)
+		record, ok := inventory.Records[recordKey]
+		if !ok {
+			t.Fatalf("missing inventory record for baseline command %q", command.Path)
+		}
+		if record.PublicName != command.Path {
+			t.Fatalf("record publicName = %q, want %q", record.PublicName, command.Path)
+		}
+		if record.Classification == "" {
+			t.Fatalf("record for %q missing classification", command.Path)
+		}
+		wantSuccessor, ok := cliCompatibilitySuccessorByIDCandidate[command.IDCandidate]
+		if !ok {
+			t.Fatalf("missing successor mapping for baseline command idCandidate %q", command.IDCandidate)
+		}
+		if record.Lifecycle.Successor.TargetItemID != wantSuccessor {
+			t.Fatalf(
+				"record successor targetItemId = %q, want %q",
+				record.Lifecycle.Successor.TargetItemID,
+				wantSuccessor,
+			)
+		}
+		if record.Lifecycle.Successor.CanonicalEnglish == "" {
+			t.Fatalf("record for %q missing successor migration guidance", command.Path)
+		}
+		if record.Evidence.Summary == "" {
+			t.Fatalf("record for %q missing evidence summary", command.Path)
+		}
+		if len(record.RemovalGates) == 0 {
+			t.Fatalf("record for %q missing removal gates", command.Path)
+		}
+		if record.ApprovalStatus == "" {
+			t.Fatalf("record for %q missing approval status", command.Path)
+		}
+	}
+
+	if len(inventory.Records) != len(compatibilityCommands) {
+		t.Fatalf(
+			"inventory record count = %d, want %d baseline compatibility commands",
+			len(inventory.Records),
+			len(compatibilityCommands),
+		)
+	}
+}
+
+type cliCommandIdentityBaselineDocument struct {
+	Commands []cliCommandIdentityRecord `json:"commands"`
+}
+
+type cliCommandIdentityRecord struct {
+	Path        string `json:"path"`
+	IDCandidate string `json:"idCandidate"`
+}
+
+type cliDeprecatedInventoryDocument struct {
+	Family  string                          `json:"family"`
+	Records map[string]cliCompatibilityRecord `json:"records"`
+}
+
+type cliCompatibilityRecord struct {
+	PublicName     string `json:"publicName"`
+	Classification string `json:"classification"`
+	ApprovalStatus string `json:"approvalStatus"`
+	Lifecycle      struct {
+		Successor struct {
+			TargetItemID     string `json:"targetItemId"`
+			CanonicalEnglish string `json:"canonicalEnglish"`
+		} `json:"successor"`
+	} `json:"lifecycle"`
+	Evidence struct {
+		Summary string `json:"summary"`
+	} `json:"evidence"`
+	RemovalGates []struct {
+		ID string `json:"id"`
+	} `json:"removalGates"`
+}
+
+func readCLICommandIdentityBaseline(t *testing.T) cliCommandIdentityBaselineDocument {
+	t.Helper()
+	return decodeContractJSON[cliCommandIdentityBaselineDocument](t, filepath.Join("testdata", "baseline", "cli-commands.json"))
+}
+
+func readCLIDeprecatedInventory(t *testing.T) cliDeprecatedInventoryDocument {
+	t.Helper()
+	return decodeContractJSON[cliDeprecatedInventoryDocument](t, cliDeprecatedInventoryPath)
+}
+
+func baselineCompatibilityCommands(baseline cliCommandIdentityBaselineDocument) []cliCommandIdentityRecord {
+	var commands []cliCommandIdentityRecord
+	for _, command := range baseline.Commands {
+		if !isCLICompatibilityCommandIDCandidate(command.IDCandidate) {
+			continue
+		}
+		commands = append(commands, command)
+	}
+	return commands
+}
+
+func isCLICompatibilityCommandIDCandidate(idCandidate string) bool {
+	return strings.HasPrefix(idCandidate, "you.workflow.") && idCandidate != "you.workflow"
+}
+
+func cliCompatibilityRecordKey(idCandidate string) string {
+	return "cli.command." + strings.TrimPrefix(idCandidate, "you.")
+}

--- a/contracts/common/compatibility-inventory.schema.json
+++ b/contracts/common/compatibility-inventory.schema.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.portpowered.com/you/contracts/common/compatibility-inventory.schema.json",
+  "title": "You compatibility inventory vocabulary",
+  "description": "Shared vocabulary for family compatibility inventories that classify baseline aliases and compatibility-only public surfaces. Classification metadata does not control runtime callability.",
+  "$defs": {
+    "family": {
+      "description": "The transport family owning one compatibility inventory record.",
+      "enum": ["api", "cli", "mcp"]
+    },
+    "classification": {
+      "description": "Maintainer classification for one compatibility surface. remove-now means removal-ready for a later approved removal story, not physically removed in the inventory item.",
+      "enum": ["retain-temporarily", "remove-now", "separately-approved"]
+    },
+    "approvalStatus": {
+      "description": "Maintainer approval status for the recorded classification and removal gates.",
+      "enum": ["approved", "pending", "rejected"]
+    },
+    "evidence": {
+      "description": "Reviewed evidence that the public name is compatibility-only or otherwise inventoried for migration.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["summary"],
+      "properties": {
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "references": {
+          "description": "Optional repository-relative paths or stable evidence identifiers supporting the summary.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "removalGate": {
+      "description": "One objective gate that must be satisfied before a compatibility surface may be removed in a later approved change.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "description", "status"],
+      "properties": {
+        "id": {
+          "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "enum": ["open", "satisfied"]
+        }
+      }
+    },
+    "record": {
+      "description": "One classified compatibility alias or compatibility-only public surface.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "itemId",
+        "family",
+        "publicName",
+        "classification",
+        "lifecycle",
+        "evidence",
+        "removalGates",
+        "approvalStatus"
+      ],
+      "properties": {
+        "itemId": {
+          "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"
+        },
+        "family": {
+          "$ref": "#/$defs/family"
+        },
+        "publicName": {
+          "description": "The compatibility-facing public name callers may still use while the surface remains callable.",
+          "type": "string",
+          "minLength": 1
+        },
+        "classification": {
+          "$ref": "#/$defs/classification"
+        },
+        "lifecycle": {
+          "$ref": "https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json"
+        },
+        "evidence": {
+          "$ref": "#/$defs/evidence"
+        },
+        "removalGates": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/removalGate"
+          }
+        },
+        "approvalStatus": {
+          "$ref": "#/$defs/approvalStatus"
+        }
+      },
+      "allOf": [
+        {
+          "properties": {
+            "lifecycle": {
+              "required": ["state", "since", "successor", "deprecated"],
+              "properties": {
+                "state": {
+                  "const": "deprecated"
+                },
+                "removed": false
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/contracts/compatibility-inventory.schema.json
+++ b/contracts/compatibility-inventory.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.portpowered.com/you/contracts/compatibility-inventory.schema.json",
+  "title": "You family compatibility inventory",
+  "description": "Machine-readable inventory of classified compatibility aliases and compatibility-only public surfaces for one transport family. Inventory metadata does not control runtime callability.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["formatVersion", "family", "records"],
+  "properties": {
+    "formatVersion": {
+      "description": "The explicitly supported version of this compatibility inventory format.",
+      "const": "1.0.0"
+    },
+    "family": {
+      "$ref": "https://schemas.portpowered.com/you/contracts/common/compatibility-inventory.schema.json#/$defs/family"
+    },
+    "records": {
+      "description": "Classified compatibility surfaces keyed by stable item ID. Object keys make duplicate stable IDs structurally unrepresentable.",
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": {
+        "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"
+      },
+      "additionalProperties": {
+        "$ref": "https://schemas.portpowered.com/you/contracts/common/compatibility-inventory.schema.json#/$defs/record"
+      }
+    }
+  }
+}

--- a/contracts/compatibility_inventory_coverage_test.go
+++ b/contracts/compatibility_inventory_coverage_test.go
@@ -1,0 +1,344 @@
+package contracts_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	mcpDeprecatedInventoryPath  = "mcp/deprecated.json"
+	cliDeprecatedInventoryPath  = "cli/deprecated.json"
+	apiDeprecatedInventoryPath  = "api/deprecated.json"
+)
+
+var supportedCompatibilityClassifications = map[string]struct{}{
+	"retain-temporarily":  {},
+	"remove-now":          {},
+	"separately-approved": {},
+}
+
+var cliCompatibilitySuccessorByIDCandidate = map[string]string{
+	"you.workflow.preview":    "api.route.post.factories.preview",
+	"you.workflow.validate":   "api.route.post.factories.preview",
+	"you.workflow.run":        "api.route.post.factory-sessions.sync",
+	"you.workflow.start":      "api.route.post.factory-sessions.async",
+	"you.workflow.status":     "api.route.get.factory-sessions.session-id",
+	"you.workflow.result":     "api.route.get.factory-sessions.session-id.results",
+	"you.workflow.dispatches": "api.route.get.factory-sessions.session-id.dispatches",
+	"you.workflow.artifacts":  "api.route.get.factory-sessions.session-id.artifacts",
+	"you.workflow.events":     "api.route.get.factory-sessions.session-id.events",
+}
+
+func TestCompatibilityInventoryBaselineCoverage(t *testing.T) {
+	t.Run("mcp", func(t *testing.T) {
+		assertMCPCompatibilityInventoryBaselineCoverage(t)
+	})
+	t.Run("cli", func(t *testing.T) {
+		assertCLICompatibilityInventoryBaselineCoverage(t)
+	})
+	t.Run("api", func(t *testing.T) {
+		assertAPICompatibilityInventoryBaselineCoverage(t)
+	})
+}
+
+func assertMCPCompatibilityInventoryBaselineCoverage(t *testing.T) {
+	t.Helper()
+
+	baseline := readMCPBaselineAliases(t)
+	inventory := readCompatibilityInventoryDocument(t, mcpDeprecatedInventoryPath)
+
+	if inventory.Family != "mcp" {
+		t.Fatalf("inventory family = %q, want mcp", inventory.Family)
+	}
+	if len(baseline.Aliases) == 0 {
+		t.Fatal("expected at least one baseline MCP compatibility alias")
+	}
+
+	for _, alias := range baseline.Aliases {
+		if !alias.CompatibilityOnly {
+			t.Fatalf("baseline alias %q is not marked compatibility-only", alias.Name)
+		}
+		recordKey := "mcp.alias." + alias.Name
+		record, ok := inventory.Records[recordKey]
+		if !ok {
+			t.Fatalf("missing inventory record for baseline alias %q", alias.Name)
+		}
+		assertClassifiedCompatibilityRecord(t, inventory.Family, recordKey, record, classifiedRecordExpectation{
+			publicName:           alias.Name,
+			successorTargetItemID: "mcp.tool." + alias.CanonicalName,
+		})
+	}
+
+	if len(inventory.Records) != len(baseline.Aliases) {
+		t.Fatalf("inventory record count = %d, want %d baseline aliases", len(inventory.Records), len(baseline.Aliases))
+	}
+}
+
+func assertCLICompatibilityInventoryBaselineCoverage(t *testing.T) {
+	t.Helper()
+
+	baseline := readCLICommandIdentityBaseline(t)
+	inventory := readCompatibilityInventoryDocument(t, cliDeprecatedInventoryPath)
+
+	if inventory.Family != "cli" {
+		t.Fatalf("inventory family = %q, want cli", inventory.Family)
+	}
+
+	compatibilityCommands := baselineCompatibilityCommands(baseline)
+	if len(compatibilityCommands) == 0 {
+		t.Fatal("expected at least one baseline CLI compatibility command")
+	}
+
+	for _, command := range compatibilityCommands {
+		recordKey := cliCompatibilityRecordKey(command.IDCandidate)
+		record, ok := inventory.Records[recordKey]
+		if !ok {
+			t.Fatalf("missing inventory record for baseline command %q", command.Path)
+		}
+		wantSuccessor, ok := cliCompatibilitySuccessorByIDCandidate[command.IDCandidate]
+		if !ok {
+			t.Fatalf("missing successor mapping for baseline command idCandidate %q", command.IDCandidate)
+		}
+		assertClassifiedCompatibilityRecord(t, inventory.Family, recordKey, record, classifiedRecordExpectation{
+			publicName:            command.Path,
+			successorTargetItemID: wantSuccessor,
+		})
+	}
+
+	if len(inventory.Records) != len(compatibilityCommands) {
+		t.Fatalf(
+			"inventory record count = %d, want %d baseline compatibility commands",
+			len(inventory.Records),
+			len(compatibilityCommands),
+		)
+	}
+}
+
+func assertAPICompatibilityInventoryBaselineCoverage(t *testing.T) {
+	t.Helper()
+
+	baseline := readAPICompatibilitySurfacesBaseline(t)
+	inventory := readCompatibilityInventoryDocument(t, apiDeprecatedInventoryPath)
+
+	if inventory.Family != "api" {
+		t.Fatalf("inventory family = %q, want api", inventory.Family)
+	}
+	if len(baseline.Surfaces) == 0 {
+		t.Fatal("expected at least one baseline API compatibility surface")
+	}
+
+	for _, surface := range baseline.Surfaces {
+		if !surface.CompatibilityOnly {
+			t.Fatalf("baseline surface %q is not marked compatibility-only", surface.ItemID)
+		}
+		record, ok := inventory.Records[surface.ItemID]
+		if !ok {
+			t.Fatalf("missing inventory record for baseline surface %q", surface.ItemID)
+		}
+		assertClassifiedCompatibilityRecord(t, inventory.Family, surface.ItemID, record, classifiedRecordExpectation{
+			publicName:            surface.PublicName,
+			successorTargetItemID: surface.CanonicalSuccessorItemID,
+		})
+	}
+
+	if len(inventory.Records) != len(baseline.Surfaces) {
+		t.Fatalf(
+			"inventory record count = %d, want %d baseline compatibility surfaces",
+			len(inventory.Records),
+			len(baseline.Surfaces),
+		)
+	}
+}
+
+type classifiedRecordExpectation struct {
+	publicName            string
+	successorTargetItemID string
+}
+
+func assertClassifiedCompatibilityRecord(
+	t *testing.T,
+	inventoryFamily string,
+	recordKey string,
+	record compatibilityInventoryRecord,
+	expectation classifiedRecordExpectation,
+) {
+	t.Helper()
+
+	if record.ItemID == "" {
+		t.Fatalf("record %q missing stable itemId", recordKey)
+	}
+	if record.ItemID != recordKey {
+		t.Fatalf("record itemId = %q, want %q", record.ItemID, recordKey)
+	}
+	if record.Family == "" {
+		t.Fatalf("record %q missing family", recordKey)
+	}
+	if record.Family != inventoryFamily {
+		t.Fatalf("record family = %q, want %q", record.Family, inventoryFamily)
+	}
+	if record.PublicName == "" {
+		t.Fatalf("record %q missing publicName", recordKey)
+	}
+	if record.PublicName != expectation.publicName {
+		t.Fatalf("record publicName = %q, want %q", record.PublicName, expectation.publicName)
+	}
+	if record.Classification == "" {
+		t.Fatalf("record %q missing classification", recordKey)
+	}
+	if _, ok := supportedCompatibilityClassifications[record.Classification]; !ok {
+		t.Fatalf("record %q classification = %q, want one of retain-temporarily, remove-now, separately-approved", recordKey, record.Classification)
+	}
+	if record.Lifecycle.Since == "" {
+		t.Fatalf("record %q missing lifecycle.since version", recordKey)
+	}
+	if record.Lifecycle.Deprecated == "" {
+		t.Fatalf("record %q missing lifecycle.deprecated version", recordKey)
+	}
+	if record.Lifecycle.Successor.TargetItemID == "" {
+		t.Fatalf("record %q missing successor targetItemId", recordKey)
+	}
+	if record.Lifecycle.Successor.TargetItemID != expectation.successorTargetItemID {
+		t.Fatalf(
+			"record successor targetItemId = %q, want %q",
+			record.Lifecycle.Successor.TargetItemID,
+			expectation.successorTargetItemID,
+		)
+	}
+	if record.Lifecycle.Successor.CanonicalEnglish == "" {
+		t.Fatalf("record %q missing successor migration guidance", recordKey)
+	}
+	if record.Evidence.Summary == "" {
+		t.Fatalf("record %q missing evidence summary", recordKey)
+	}
+	if len(record.RemovalGates) == 0 {
+		t.Fatalf("record %q missing removal gates", recordKey)
+	}
+	for _, gate := range record.RemovalGates {
+		if gate.ID == "" {
+			t.Fatalf("record %q has a removal gate missing id", recordKey)
+		}
+		if gate.Description == "" {
+			t.Fatalf("record %q removal gate %q missing description", recordKey, gate.ID)
+		}
+		if gate.Status == "" {
+			t.Fatalf("record %q removal gate %q missing status", recordKey, gate.ID)
+		}
+	}
+	if record.ApprovalStatus == "" {
+		t.Fatalf("record %q missing approval status", recordKey)
+	}
+}
+
+type compatibilityInventoryDocument struct {
+	Family  string                              `json:"family"`
+	Records map[string]compatibilityInventoryRecord `json:"records"`
+}
+
+type compatibilityInventoryRecord struct {
+	ItemID         string `json:"itemId"`
+	Family         string `json:"family"`
+	PublicName     string `json:"publicName"`
+	Classification string `json:"classification"`
+	ApprovalStatus string `json:"approvalStatus"`
+	Lifecycle      struct {
+		Since      string `json:"since"`
+		Deprecated string `json:"deprecated"`
+		Successor  struct {
+			TargetItemID     string `json:"targetItemId"`
+			CanonicalEnglish string `json:"canonicalEnglish"`
+		} `json:"successor"`
+	} `json:"lifecycle"`
+	Evidence struct {
+		Summary string `json:"summary"`
+	} `json:"evidence"`
+	RemovalGates []struct {
+		ID          string `json:"id"`
+		Description string `json:"description"`
+		Status      string `json:"status"`
+	} `json:"removalGates"`
+}
+
+type mcpBaselineAliasesDocument struct {
+	Aliases []mcpBaselineAlias `json:"aliases"`
+}
+
+type mcpBaselineAlias struct {
+	Name              string `json:"name"`
+	CanonicalName     string `json:"canonicalName"`
+	CompatibilityOnly bool   `json:"compatibilityOnly"`
+}
+
+type cliCommandIdentityBaselineDocument struct {
+	Commands []cliCommandIdentityRecord `json:"commands"`
+}
+
+type cliCommandIdentityRecord struct {
+	Path        string `json:"path"`
+	IDCandidate string `json:"idCandidate"`
+}
+
+type apiCompatibilitySurfacesBaselineDocument struct {
+	Surfaces []apiCompatibilitySurfaceRecord `json:"surfaces"`
+}
+
+type apiCompatibilitySurfaceRecord struct {
+	ItemID                   string `json:"itemId"`
+	PublicName               string `json:"publicName"`
+	CanonicalSuccessorItemID string `json:"canonicalSuccessorItemId"`
+	CompatibilityOnly        bool   `json:"compatibilityOnly"`
+}
+
+func readCompatibilityInventoryDocument(t *testing.T, path string) compatibilityInventoryDocument {
+	t.Helper()
+	return decodeContractJSON[compatibilityInventoryDocument](t, path)
+}
+
+func readMCPBaselineAliases(t *testing.T) mcpBaselineAliasesDocument {
+	t.Helper()
+	return decodeContractJSON[mcpBaselineAliasesDocument](t, filepath.Join("testdata", "baseline", "mcp-aliases.json"))
+}
+
+func readCLICommandIdentityBaseline(t *testing.T) cliCommandIdentityBaselineDocument {
+	t.Helper()
+	return decodeContractJSON[cliCommandIdentityBaselineDocument](t, filepath.Join("testdata", "baseline", "cli-commands.json"))
+}
+
+func readAPICompatibilitySurfacesBaseline(t *testing.T) apiCompatibilitySurfacesBaselineDocument {
+	t.Helper()
+	return decodeContractJSON[apiCompatibilitySurfacesBaselineDocument](t, filepath.Join("testdata", "baseline", "api-compatibility-surfaces.json"))
+}
+
+func baselineCompatibilityCommands(baseline cliCommandIdentityBaselineDocument) []cliCommandIdentityRecord {
+	var commands []cliCommandIdentityRecord
+	for _, command := range baseline.Commands {
+		if !isCLICompatibilityCommandIDCandidate(command.IDCandidate) {
+			continue
+		}
+		commands = append(commands, command)
+	}
+	return commands
+}
+
+func isCLICompatibilityCommandIDCandidate(idCandidate string) bool {
+	return strings.HasPrefix(idCandidate, "you.workflow.") && idCandidate != "you.workflow"
+}
+
+func cliCompatibilityRecordKey(idCandidate string) string {
+	return "cli.command." + strings.TrimPrefix(idCandidate, "you.")
+}
+
+func decodeContractJSON[T any](t *testing.T, path string) T {
+	t.Helper()
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var value T
+	if err := json.Unmarshal(contents, &value); err != nil {
+		t.Fatalf("decode %s: %v", path, err)
+	}
+	return value
+}

--- a/contracts/compatibility_inventory_schema_test.go
+++ b/contracts/compatibility_inventory_schema_test.go
@@ -1,0 +1,107 @@
+package contracts_test
+
+import (
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/contractvalidator"
+)
+
+const (
+	compatibilityInventorySchemaID      = "https://schemas.portpowered.com/you/contracts/compatibility-inventory.schema.json"
+	compatibilityVocabularySchemaID     = "https://schemas.portpowered.com/you/contracts/common/compatibility-inventory.schema.json"
+	compatibilityInventoryFixtureRoot   = "compatibility-inventory"
+)
+
+func TestCompatibilityInventorySchemaFixtures(t *testing.T) {
+	schema := compileSchema(
+		t,
+		"compatibility-inventory.schema.json",
+		compatibilityInventorySchemaID,
+		schemaResource{
+			path: filepath.Join("common", "compatibility-inventory.schema.json"),
+			id:   compatibilityVocabularySchemaID,
+		},
+		schemaResource{
+			path: filepath.Join("common", "documentation.schema.json"),
+			id:   documentationSchemaID,
+		},
+		schemaResource{
+			path: filepath.Join("common", "deprecations.schema.json"),
+			id:   deprecationsSchemaID,
+		},
+	)
+
+	tests := []struct {
+		name           string
+		fixture        string
+		valid          bool
+		wantPath       string
+		semanticOnly   bool
+	}{
+		{name: "valid mcp retain-temporarily", fixture: "valid-mcp-retain.json", valid: true},
+		{name: "valid api remove-now", fixture: "valid-api-remove-now.json", valid: true},
+		{name: "valid cli separately-approved", fixture: "valid-cli-separately-approved.json", valid: true},
+		{name: "missing classification", fixture: "invalid-missing-classification.json", wantPath: "/records/mcp.alias.you.workflow.validate"},
+		{name: "missing successor", fixture: "invalid-missing-successor.json", wantPath: "/records/mcp.alias.you.workflow.validate/lifecycle"},
+		{name: "unknown family", fixture: "invalid-unknown-family.json", wantPath: "/family"},
+		{name: "unknown classification", fixture: "invalid-unknown-classification.json", wantPath: "/records/mcp.alias.you.workflow.validate/classification"},
+		{name: "unknown property", fixture: "invalid-unknown-property.json", wantPath: "/records/mcp.alias.you.workflow.validate"},
+		{name: "unknown format version", fixture: "invalid-format-version.json", wantPath: "/formatVersion"},
+		{name: "record family mismatch", fixture: "invalid-record-family-mismatch.json", semanticOnly: true, wantPath: "/records/mcp.alias.you.workflow.validate/family"},
+		{name: "duplicate stable IDs", fixture: "invalid-duplicate-stable-ids.json", semanticOnly: true, wantPath: "/records/mcp.alias.you.workflow.run/itemId"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			instance := readJSON(t, filepath.Join("testdata", compatibilityInventoryFixtureRoot, test.fixture))
+			err := schema.Validate(instance)
+			if test.semanticOnly {
+				if err != nil {
+					t.Fatalf("schema validation should pass before semantics: %v", err)
+				}
+				diagnostics := contractvalidator.CompatibilityInventorySemanticsDiagnostics(test.fixture, instance)
+				if test.valid {
+					if len(diagnostics) != 0 {
+						t.Fatalf("semantic diagnostics = %#v, want none", diagnostics)
+					}
+					return
+				}
+				if len(diagnostics) == 0 {
+					t.Fatal("expected semantic validation to fail")
+				}
+				paths := semanticDiagnosticPaths(diagnostics)
+				if !slices.Contains(paths, test.wantPath) {
+					t.Fatalf("semantic paths = %v, want %q", paths, test.wantPath)
+				}
+				return
+			}
+
+			if test.valid {
+				if err != nil {
+					t.Fatalf("validate valid fixture: %v", err)
+				}
+				diagnostics := contractvalidator.CompatibilityInventorySemanticsDiagnostics(test.fixture, instance)
+				if len(diagnostics) != 0 {
+					t.Fatalf("semantic diagnostics = %#v, want none", diagnostics)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected fixture validation to fail")
+			}
+			if paths := validationPaths(t, err); !slices.Contains(paths, test.wantPath) {
+				t.Fatalf("validation paths = %v, want %q", paths, test.wantPath)
+			}
+		})
+	}
+}
+
+func semanticDiagnosticPaths(diagnostics []contractvalidator.Diagnostic) []string {
+	paths := make([]string, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		paths = append(paths, diagnostic.Path)
+	}
+	return paths
+}

--- a/contracts/mcp/deprecated.json
+++ b/contracts/mcp/deprecated.json
@@ -1,0 +1,166 @@
+{
+  "formatVersion": "1.0.0",
+  "family": "mcp",
+  "records": {
+    "mcp.alias.you.workflow.validate": {
+      "itemId": "mcp.alias.you.workflow.validate",
+      "family": "mcp",
+      "publicName": "you.workflow.validate",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.alias.you.workflow.validate",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "mcp.tool.you.factory_session.validate_source",
+          "canonicalEnglish": "Use you.factory_session.validate_source for Factory preview validation."
+        }
+      },
+      "evidence": {
+        "summary": "Workflow-named MCP alias resolves to the canonical Factory Session validate_source tool.",
+        "references": [
+          "contracts/testdata/baseline/mcp-aliases.json",
+          "pkg/transports/mcp/factorysession/tool.go"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "mcp.alias.you.workflow.validate.no-external-callers",
+          "description": "No supported external integrations rely on the workflow-named alias.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "mcp.alias.you.workflow.run": {
+      "itemId": "mcp.alias.you.workflow.run",
+      "family": "mcp",
+      "publicName": "you.workflow.run",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.alias.you.workflow.run",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "mcp.tool.you.factory_session.start_sync",
+          "canonicalEnglish": "Use you.factory_session.start_sync for sync Factory Session start."
+        }
+      },
+      "evidence": {
+        "summary": "Workflow-named MCP alias resolves to the canonical Factory Session start_sync tool.",
+        "references": [
+          "contracts/testdata/baseline/mcp-aliases.json",
+          "pkg/transports/mcp/factorysession/tool.go"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "mcp.alias.you.workflow.run.no-external-callers",
+          "description": "No supported external integrations rely on the workflow-named alias.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "mcp.alias.you.workflow.status": {
+      "itemId": "mcp.alias.you.workflow.status",
+      "family": "mcp",
+      "publicName": "you.workflow.status",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.alias.you.workflow.status",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "mcp.tool.you.factory_session.get",
+          "canonicalEnglish": "Use you.factory_session.get for durable Factory Session status reads."
+        }
+      },
+      "evidence": {
+        "summary": "Workflow-named MCP alias resolves to the canonical Factory Session get tool.",
+        "references": [
+          "contracts/testdata/baseline/mcp-aliases.json",
+          "pkg/transports/mcp/factorysession/tool.go"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "mcp.alias.you.workflow.status.no-external-callers",
+          "description": "No supported external integrations rely on the workflow-named alias.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "mcp.alias.you.workflow.result": {
+      "itemId": "mcp.alias.you.workflow.result",
+      "family": "mcp",
+      "publicName": "you.workflow.result",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.alias.you.workflow.result",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "mcp.tool.you.factory_session.get_result",
+          "canonicalEnglish": "Use you.factory_session.get_result for durable Factory Session result reads."
+        }
+      },
+      "evidence": {
+        "summary": "Workflow-named MCP alias resolves to the canonical Factory Session get_result tool.",
+        "references": [
+          "contracts/testdata/baseline/mcp-aliases.json",
+          "pkg/transports/mcp/factorysession/tool.go"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "mcp.alias.you.workflow.result.no-external-callers",
+          "description": "No supported external integrations rely on the workflow-named alias.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "mcp.alias.you.workflow.artifacts": {
+      "itemId": "mcp.alias.you.workflow.artifacts",
+      "family": "mcp",
+      "publicName": "you.workflow.artifacts",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.alias.you.workflow.artifacts",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "mcp.tool.you.factory_session.list_artifacts",
+          "canonicalEnglish": "Use you.factory_session.list_artifacts for FactoryArtifact listing."
+        }
+      },
+      "evidence": {
+        "summary": "Workflow-named MCP alias resolves to the canonical Factory Session list_artifacts tool.",
+        "references": [
+          "contracts/testdata/baseline/mcp-aliases.json",
+          "pkg/transports/mcp/factorysession/tool.go"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "mcp.alias.you.workflow.artifacts.no-external-callers",
+          "description": "No supported external integrations rely on the workflow-named alias.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    }
+  }
+}

--- a/contracts/mcp_deprecated_inventory_test.go
+++ b/contracts/mcp_deprecated_inventory_test.go
@@ -1,0 +1,145 @@
+package contracts_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/contractvalidator"
+)
+
+const mcpDeprecatedInventoryPath = "mcp/deprecated.json"
+
+func TestMCPDeprecatedInventoryValidatesAgainstSchema(t *testing.T) {
+	schema := compileSchema(
+		t,
+		"compatibility-inventory.schema.json",
+		compatibilityInventorySchemaID,
+		schemaResource{
+			path: filepath.Join("common", "compatibility-inventory.schema.json"),
+			id:   compatibilityVocabularySchemaID,
+		},
+		schemaResource{
+			path: filepath.Join("common", "documentation.schema.json"),
+			id:   documentationSchemaID,
+		},
+		schemaResource{
+			path: filepath.Join("common", "deprecations.schema.json"),
+			id:   deprecationsSchemaID,
+		},
+	)
+
+	instance := readJSON(t, mcpDeprecatedInventoryPath)
+	if err := schema.Validate(instance); err != nil {
+		t.Fatalf("validate MCP deprecated inventory: %v", err)
+	}
+	diagnostics := contractvalidator.CompatibilityInventorySemanticsDiagnostics(mcpDeprecatedInventoryPath, instance)
+	if len(diagnostics) != 0 {
+		t.Fatalf("semantic diagnostics = %#v, want none", diagnostics)
+	}
+}
+
+func TestMCPDeprecatedInventoryClassifiesEveryBaselineAlias(t *testing.T) {
+	baseline := readMCPBaselineAliases(t)
+	inventory := readMCPDeprecatedInventory(t)
+
+	if inventory.Family != "mcp" {
+		t.Fatalf("inventory family = %q, want mcp", inventory.Family)
+	}
+
+	for _, alias := range baseline.Aliases {
+		if !alias.CompatibilityOnly {
+			t.Fatalf("baseline alias %q is not marked compatibility-only", alias.Name)
+		}
+		record, ok := inventory.Records["mcp.alias."+alias.Name]
+		if !ok {
+			t.Fatalf("missing inventory record for baseline alias %q", alias.Name)
+		}
+		if record.PublicName != alias.Name {
+			t.Fatalf("record publicName = %q, want %q", record.PublicName, alias.Name)
+		}
+		if record.Classification == "" {
+			t.Fatalf("record for %q missing classification", alias.Name)
+		}
+		if record.Lifecycle.Successor.TargetItemID != "mcp.tool."+alias.CanonicalName {
+			t.Fatalf(
+				"record successor targetItemId = %q, want %q",
+				record.Lifecycle.Successor.TargetItemID,
+				"mcp.tool."+alias.CanonicalName,
+			)
+		}
+		if record.Lifecycle.Successor.CanonicalEnglish == "" {
+			t.Fatalf("record for %q missing successor migration guidance", alias.Name)
+		}
+		if record.Evidence.Summary == "" {
+			t.Fatalf("record for %q missing evidence summary", alias.Name)
+		}
+		if len(record.RemovalGates) == 0 {
+			t.Fatalf("record for %q missing removal gates", alias.Name)
+		}
+		if record.ApprovalStatus == "" {
+			t.Fatalf("record for %q missing approval status", alias.Name)
+		}
+	}
+
+	if len(inventory.Records) != len(baseline.Aliases) {
+		t.Fatalf("inventory record count = %d, want %d baseline aliases", len(inventory.Records), len(baseline.Aliases))
+	}
+}
+
+type mcpBaselineAliasesDocument struct {
+	Aliases []mcpBaselineAlias `json:"aliases"`
+}
+
+type mcpBaselineAlias struct {
+	Name              string `json:"name"`
+	CanonicalName     string `json:"canonicalName"`
+	CompatibilityOnly bool   `json:"compatibilityOnly"`
+}
+
+type mcpDeprecatedInventoryDocument struct {
+	Family  string                           `json:"family"`
+	Records map[string]mcpCompatibilityRecord `json:"records"`
+}
+
+type mcpCompatibilityRecord struct {
+	PublicName     string `json:"publicName"`
+	Classification string `json:"classification"`
+	ApprovalStatus string `json:"approvalStatus"`
+	Lifecycle      struct {
+		Successor struct {
+			TargetItemID     string `json:"targetItemId"`
+			CanonicalEnglish string `json:"canonicalEnglish"`
+		} `json:"successor"`
+	} `json:"lifecycle"`
+	Evidence struct {
+		Summary string `json:"summary"`
+	} `json:"evidence"`
+	RemovalGates []struct {
+		ID string `json:"id"`
+	} `json:"removalGates"`
+}
+
+func readMCPBaselineAliases(t *testing.T) mcpBaselineAliasesDocument {
+	t.Helper()
+	return decodeContractJSON[mcpBaselineAliasesDocument](t, filepath.Join("testdata", "baseline", "mcp-aliases.json"))
+}
+
+func readMCPDeprecatedInventory(t *testing.T) mcpDeprecatedInventoryDocument {
+	t.Helper()
+	return decodeContractJSON[mcpDeprecatedInventoryDocument](t, mcpDeprecatedInventoryPath)
+}
+
+func decodeContractJSON[T any](t *testing.T, path string) T {
+	t.Helper()
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var value T
+	if err := json.Unmarshal(contents, &value); err != nil {
+		t.Fatalf("decode %s: %v", path, err)
+	}
+	return value
+}

--- a/contracts/mcp_deprecated_inventory_test.go
+++ b/contracts/mcp_deprecated_inventory_test.go
@@ -1,15 +1,11 @@
 package contracts_test
 
 import (
-	"encoding/json"
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/portpowered/infinite-you/internal/contractvalidator"
 )
-
-const mcpDeprecatedInventoryPath = "mcp/deprecated.json"
 
 func TestMCPDeprecatedInventoryValidatesAgainstSchema(t *testing.T) {
 	schema := compileSchema(
@@ -38,108 +34,4 @@ func TestMCPDeprecatedInventoryValidatesAgainstSchema(t *testing.T) {
 	if len(diagnostics) != 0 {
 		t.Fatalf("semantic diagnostics = %#v, want none", diagnostics)
 	}
-}
-
-func TestMCPDeprecatedInventoryClassifiesEveryBaselineAlias(t *testing.T) {
-	baseline := readMCPBaselineAliases(t)
-	inventory := readMCPDeprecatedInventory(t)
-
-	if inventory.Family != "mcp" {
-		t.Fatalf("inventory family = %q, want mcp", inventory.Family)
-	}
-
-	for _, alias := range baseline.Aliases {
-		if !alias.CompatibilityOnly {
-			t.Fatalf("baseline alias %q is not marked compatibility-only", alias.Name)
-		}
-		record, ok := inventory.Records["mcp.alias."+alias.Name]
-		if !ok {
-			t.Fatalf("missing inventory record for baseline alias %q", alias.Name)
-		}
-		if record.PublicName != alias.Name {
-			t.Fatalf("record publicName = %q, want %q", record.PublicName, alias.Name)
-		}
-		if record.Classification == "" {
-			t.Fatalf("record for %q missing classification", alias.Name)
-		}
-		if record.Lifecycle.Successor.TargetItemID != "mcp.tool."+alias.CanonicalName {
-			t.Fatalf(
-				"record successor targetItemId = %q, want %q",
-				record.Lifecycle.Successor.TargetItemID,
-				"mcp.tool."+alias.CanonicalName,
-			)
-		}
-		if record.Lifecycle.Successor.CanonicalEnglish == "" {
-			t.Fatalf("record for %q missing successor migration guidance", alias.Name)
-		}
-		if record.Evidence.Summary == "" {
-			t.Fatalf("record for %q missing evidence summary", alias.Name)
-		}
-		if len(record.RemovalGates) == 0 {
-			t.Fatalf("record for %q missing removal gates", alias.Name)
-		}
-		if record.ApprovalStatus == "" {
-			t.Fatalf("record for %q missing approval status", alias.Name)
-		}
-	}
-
-	if len(inventory.Records) != len(baseline.Aliases) {
-		t.Fatalf("inventory record count = %d, want %d baseline aliases", len(inventory.Records), len(baseline.Aliases))
-	}
-}
-
-type mcpBaselineAliasesDocument struct {
-	Aliases []mcpBaselineAlias `json:"aliases"`
-}
-
-type mcpBaselineAlias struct {
-	Name              string `json:"name"`
-	CanonicalName     string `json:"canonicalName"`
-	CompatibilityOnly bool   `json:"compatibilityOnly"`
-}
-
-type mcpDeprecatedInventoryDocument struct {
-	Family  string                           `json:"family"`
-	Records map[string]mcpCompatibilityRecord `json:"records"`
-}
-
-type mcpCompatibilityRecord struct {
-	PublicName     string `json:"publicName"`
-	Classification string `json:"classification"`
-	ApprovalStatus string `json:"approvalStatus"`
-	Lifecycle      struct {
-		Successor struct {
-			TargetItemID     string `json:"targetItemId"`
-			CanonicalEnglish string `json:"canonicalEnglish"`
-		} `json:"successor"`
-	} `json:"lifecycle"`
-	Evidence struct {
-		Summary string `json:"summary"`
-	} `json:"evidence"`
-	RemovalGates []struct {
-		ID string `json:"id"`
-	} `json:"removalGates"`
-}
-
-func readMCPBaselineAliases(t *testing.T) mcpBaselineAliasesDocument {
-	t.Helper()
-	return decodeContractJSON[mcpBaselineAliasesDocument](t, filepath.Join("testdata", "baseline", "mcp-aliases.json"))
-}
-
-func readMCPDeprecatedInventory(t *testing.T) mcpDeprecatedInventoryDocument {
-	t.Helper()
-	return decodeContractJSON[mcpDeprecatedInventoryDocument](t, mcpDeprecatedInventoryPath)
-}
-
-func decodeContractJSON[T any](t *testing.T, path string) T {
-	t.Helper()
-	contents, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read %s: %v", path, err)
-	}
-	var value T
-	if err := json.Unmarshal(contents, &value); err != nil {
-		t.Fatalf("decode %s: %v", path, err)
-	}
-	return value
 }

--- a/contracts/testdata/baseline/api-compatibility-surfaces.json
+++ b/contracts/testdata/baseline/api-compatibility-surfaces.json
@@ -1,0 +1,83 @@
+{
+  "formatVersion": "api-compatibility-surfaces/v1",
+  "surfaces": [
+    {
+      "itemId": "api.route.post.workflow-previews",
+      "publicName": "POST /workflow-previews",
+      "canonicalSuccessorItemId": "api.route.post.factories.preview",
+      "compatibilityOnly": true
+    },
+    {
+      "itemId": "api.schema.workflow-preview-request",
+      "publicName": "WorkflowPreviewRequest",
+      "canonicalSuccessorItemId": "api.schema.factory-preview-request",
+      "compatibilityOnly": true
+    },
+    {
+      "itemId": "api.schema.workflow-preview-result",
+      "publicName": "WorkflowPreviewResult",
+      "canonicalSuccessorItemId": "api.schema.factory-preview-result",
+      "compatibilityOnly": true
+    },
+    {
+      "itemId": "api.generated.go.preview-workflow-json-request-body",
+      "publicName": "PreviewWorkflowJSONRequestBody",
+      "canonicalSuccessorItemId": "api.generated.go.preview-factory-json-request-body",
+      "compatibilityOnly": true
+    },
+    {
+      "itemId": "api.operation.preview-workflow",
+      "publicName": "previewWorkflow",
+      "canonicalSuccessorItemId": "api.operation.preview-factory",
+      "compatibilityOnly": true
+    },
+    {
+      "itemId": "api.generated.ts.operation.preview-workflow",
+      "publicName": "operations[\"previewWorkflow\"]",
+      "canonicalSuccessorItemId": "api.generated.ts.operation.preview-factory",
+      "compatibilityOnly": true
+    },
+    {
+      "itemId": "api.route.get.events",
+      "publicName": "GET /events",
+      "canonicalSuccessorItemId": "api.route.get.factory-sessions.session-id.events",
+      "compatibilityOnly": true
+    },
+    {
+      "itemId": "api.selector.default-session",
+      "publicName": "~default",
+      "canonicalSuccessorItemId": "api.identity.resolved-factory-session-uuid",
+      "compatibilityOnly": true
+    },
+    {
+      "itemId": "api.ui.export.workflow-preview-request",
+      "publicName": "WorkflowPreviewRequest",
+      "canonicalSuccessorItemId": "api.ui.export.factory-preview-request",
+      "compatibilityOnly": true
+    },
+    {
+      "itemId": "api.ui.export.workflow-preview-result",
+      "publicName": "WorkflowPreviewResult",
+      "canonicalSuccessorItemId": "api.ui.export.factory-preview-result",
+      "compatibilityOnly": true
+    },
+    {
+      "itemId": "api.ui.export.workflow-preview-api-error",
+      "publicName": "WorkflowPreviewAPIError",
+      "canonicalSuccessorItemId": "api.ui.export.factory-preview-api-error",
+      "compatibilityOnly": true
+    },
+    {
+      "itemId": "api.ui.export.workflow-preview-api-error-messages",
+      "publicName": "workflowPreviewAPIErrorMessages",
+      "canonicalSuccessorItemId": "api.ui.export.factory-preview-api-error-messages",
+      "compatibilityOnly": true
+    },
+    {
+      "itemId": "api.ui.export.preview-workflow",
+      "publicName": "previewWorkflow",
+      "canonicalSuccessorItemId": "api.ui.export.preview-factory",
+      "compatibilityOnly": true
+    }
+  ]
+}

--- a/contracts/testdata/compatibility-inventory/invalid-duplicate-stable-ids.json
+++ b/contracts/testdata/compatibility-inventory/invalid-duplicate-stable-ids.json
@@ -1,0 +1,62 @@
+{
+  "formatVersion": "1.0.0",
+  "family": "mcp",
+  "records": {
+    "mcp.alias.you.workflow.validate": {
+      "itemId": "mcp.alias.shared.duplicate",
+      "family": "mcp",
+      "publicName": "you.workflow.validate",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.alias.shared.duplicate",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "mcp.tool.you.factory_session.validate_source",
+          "canonicalEnglish": "Use you.factory_session.validate_source."
+        }
+      },
+      "evidence": {
+        "summary": "Compatibility-only MCP alias."
+      },
+      "removalGates": [
+        {
+          "id": "mcp.alias.you.workflow.validate.no-external-callers",
+          "description": "No supported external integrations rely on the workflow-named alias.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    },
+    "mcp.alias.you.workflow.run": {
+      "itemId": "mcp.alias.shared.duplicate",
+      "family": "mcp",
+      "publicName": "you.workflow.run",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.alias.shared.duplicate",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "mcp.tool.you.factory_session.start_sync",
+          "canonicalEnglish": "Use you.factory_session.start_sync."
+        }
+      },
+      "evidence": {
+        "summary": "Compatibility-only MCP alias."
+      },
+      "removalGates": [
+        {
+          "id": "mcp.alias.you.workflow.run.no-external-callers",
+          "description": "No supported external integrations rely on the workflow-named alias.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    }
+  }
+}

--- a/contracts/testdata/compatibility-inventory/invalid-format-version.json
+++ b/contracts/testdata/compatibility-inventory/invalid-format-version.json
@@ -1,0 +1,34 @@
+{
+  "formatVersion": "9.9.9",
+  "family": "mcp",
+  "records": {
+    "mcp.alias.you.workflow.validate": {
+      "itemId": "mcp.alias.you.workflow.validate",
+      "family": "mcp",
+      "publicName": "you.workflow.validate",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.alias.you.workflow.validate",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "mcp.tool.you.factory_session.validate_source",
+          "canonicalEnglish": "Use you.factory_session.validate_source."
+        }
+      },
+      "evidence": {
+        "summary": "Compatibility-only MCP alias."
+      },
+      "removalGates": [
+        {
+          "id": "mcp.alias.you.workflow.validate.no-external-callers",
+          "description": "No supported external integrations rely on the workflow-named alias.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    }
+  }
+}

--- a/contracts/testdata/compatibility-inventory/invalid-missing-classification.json
+++ b/contracts/testdata/compatibility-inventory/invalid-missing-classification.json
@@ -1,0 +1,33 @@
+{
+  "formatVersion": "1.0.0",
+  "family": "mcp",
+  "records": {
+    "mcp.alias.you.workflow.validate": {
+      "itemId": "mcp.alias.you.workflow.validate",
+      "family": "mcp",
+      "publicName": "you.workflow.validate",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.alias.you.workflow.validate",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "mcp.tool.you.factory_session.validate_source",
+          "canonicalEnglish": "Use you.factory_session.validate_source."
+        }
+      },
+      "evidence": {
+        "summary": "Compatibility-only MCP alias."
+      },
+      "removalGates": [
+        {
+          "id": "mcp.alias.you.workflow.validate.no-external-callers",
+          "description": "No supported external integrations rely on the workflow-named alias.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    }
+  }
+}

--- a/contracts/testdata/compatibility-inventory/invalid-missing-successor.json
+++ b/contracts/testdata/compatibility-inventory/invalid-missing-successor.json
@@ -1,0 +1,30 @@
+{
+  "formatVersion": "1.0.0",
+  "family": "mcp",
+  "records": {
+    "mcp.alias.you.workflow.validate": {
+      "itemId": "mcp.alias.you.workflow.validate",
+      "family": "mcp",
+      "publicName": "you.workflow.validate",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.alias.you.workflow.validate",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0"
+      },
+      "evidence": {
+        "summary": "Compatibility-only MCP alias."
+      },
+      "removalGates": [
+        {
+          "id": "mcp.alias.you.workflow.validate.no-external-callers",
+          "description": "No supported external integrations rely on the workflow-named alias.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    }
+  }
+}

--- a/contracts/testdata/compatibility-inventory/invalid-record-family-mismatch.json
+++ b/contracts/testdata/compatibility-inventory/invalid-record-family-mismatch.json
@@ -1,0 +1,34 @@
+{
+  "formatVersion": "1.0.0",
+  "family": "mcp",
+  "records": {
+    "mcp.alias.you.workflow.validate": {
+      "itemId": "mcp.alias.you.workflow.validate",
+      "family": "api",
+      "publicName": "you.workflow.validate",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.alias.you.workflow.validate",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "mcp.tool.you.factory_session.validate_source",
+          "canonicalEnglish": "Use you.factory_session.validate_source."
+        }
+      },
+      "evidence": {
+        "summary": "Compatibility-only MCP alias."
+      },
+      "removalGates": [
+        {
+          "id": "mcp.alias.you.workflow.validate.no-external-callers",
+          "description": "No supported external integrations rely on the workflow-named alias.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    }
+  }
+}

--- a/contracts/testdata/compatibility-inventory/invalid-unknown-classification.json
+++ b/contracts/testdata/compatibility-inventory/invalid-unknown-classification.json
@@ -1,0 +1,34 @@
+{
+  "formatVersion": "1.0.0",
+  "family": "mcp",
+  "records": {
+    "mcp.alias.you.workflow.validate": {
+      "itemId": "mcp.alias.you.workflow.validate",
+      "family": "mcp",
+      "publicName": "you.workflow.validate",
+      "classification": "retain-forever",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.alias.you.workflow.validate",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "mcp.tool.you.factory_session.validate_source",
+          "canonicalEnglish": "Use you.factory_session.validate_source."
+        }
+      },
+      "evidence": {
+        "summary": "Compatibility-only MCP alias."
+      },
+      "removalGates": [
+        {
+          "id": "mcp.alias.you.workflow.validate.no-external-callers",
+          "description": "No supported external integrations rely on the workflow-named alias.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    }
+  }
+}

--- a/contracts/testdata/compatibility-inventory/invalid-unknown-family.json
+++ b/contracts/testdata/compatibility-inventory/invalid-unknown-family.json
@@ -1,0 +1,34 @@
+{
+  "formatVersion": "1.0.0",
+  "family": "transport",
+  "records": {
+    "mcp.alias.you.workflow.validate": {
+      "itemId": "mcp.alias.you.workflow.validate",
+      "family": "mcp",
+      "publicName": "you.workflow.validate",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.alias.you.workflow.validate",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "mcp.tool.you.factory_session.validate_source",
+          "canonicalEnglish": "Use you.factory_session.validate_source."
+        }
+      },
+      "evidence": {
+        "summary": "Compatibility-only MCP alias."
+      },
+      "removalGates": [
+        {
+          "id": "mcp.alias.you.workflow.validate.no-external-callers",
+          "description": "No supported external integrations rely on the workflow-named alias.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    }
+  }
+}

--- a/contracts/testdata/compatibility-inventory/invalid-unknown-property.json
+++ b/contracts/testdata/compatibility-inventory/invalid-unknown-property.json
@@ -1,0 +1,35 @@
+{
+  "formatVersion": "1.0.0",
+  "family": "mcp",
+  "records": {
+    "mcp.alias.you.workflow.validate": {
+      "itemId": "mcp.alias.you.workflow.validate",
+      "family": "mcp",
+      "publicName": "you.workflow.validate",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.alias.you.workflow.validate",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "mcp.tool.you.factory_session.validate_source",
+          "canonicalEnglish": "Use you.factory_session.validate_source."
+        }
+      },
+      "evidence": {
+        "summary": "Compatibility-only MCP alias."
+      },
+      "removalGates": [
+        {
+          "id": "mcp.alias.you.workflow.validate.no-external-callers",
+          "description": "No supported external integrations rely on the workflow-named alias.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved",
+      "unexpected": true
+    }
+  }
+}

--- a/contracts/testdata/compatibility-inventory/valid-api-remove-now.json
+++ b/contracts/testdata/compatibility-inventory/valid-api-remove-now.json
@@ -1,0 +1,34 @@
+{
+  "formatVersion": "1.0.0",
+  "family": "api",
+  "records": {
+    "api.route.post.workflow-previews": {
+      "itemId": "api.route.post.workflow-previews",
+      "family": "api",
+      "publicName": "POST /workflow-previews",
+      "classification": "remove-now",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "api.route.post.workflow-previews",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.2.0",
+        "successor": {
+          "targetItemId": "api.route.post.factories.preview",
+          "canonicalEnglish": "Use POST /factories/preview with FactoryPreviewRequest and FactoryPreviewResult."
+        }
+      },
+      "evidence": {
+        "summary": "Obsolete workflow-preview REST alias retained for compatibility-only callers."
+      },
+      "removalGates": [
+        {
+          "id": "api.route.post.workflow-previews.dashboard-migrated",
+          "description": "Dashboard and packaged reference guidance route preview through POST /factories/preview only.",
+          "status": "satisfied"
+        }
+      ],
+      "approvalStatus": "approved"
+    }
+  }
+}

--- a/contracts/testdata/compatibility-inventory/valid-cli-separately-approved.json
+++ b/contracts/testdata/compatibility-inventory/valid-cli-separately-approved.json
@@ -1,0 +1,34 @@
+{
+  "formatVersion": "1.0.0",
+  "family": "cli",
+  "records": {
+    "cli.command.workflow.preview": {
+      "itemId": "cli.command.workflow.preview",
+      "family": "cli",
+      "publicName": "you workflow preview",
+      "classification": "separately-approved",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "cli.command.workflow.preview",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "cli.command.factory.preview",
+          "canonicalEnglish": "Use you factory preview for canonical Factory preview."
+        }
+      },
+      "evidence": {
+        "summary": "Workflow-named CLI preview command is compatibility-only and forwards to Factory preview."
+      },
+      "removalGates": [
+        {
+          "id": "cli.command.workflow.preview.approval-recorded",
+          "description": "A separately approved work item records the retention or removal decision.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "pending"
+    }
+  }
+}

--- a/contracts/testdata/compatibility-inventory/valid-mcp-retain.json
+++ b/contracts/testdata/compatibility-inventory/valid-mcp-retain.json
@@ -1,0 +1,38 @@
+{
+  "formatVersion": "1.0.0",
+  "family": "mcp",
+  "records": {
+    "mcp.alias.you.workflow.validate": {
+      "itemId": "mcp.alias.you.workflow.validate",
+      "family": "mcp",
+      "publicName": "you.workflow.validate",
+      "classification": "retain-temporarily",
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.alias.you.workflow.validate",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "1.1.0",
+        "successor": {
+          "targetItemId": "mcp.tool.you.factory_session.validate_source",
+          "canonicalEnglish": "Use you.factory_session.validate_source for Factory preview validation."
+        }
+      },
+      "evidence": {
+        "summary": "Workflow-named MCP alias resolves to the canonical Factory Session validate_source tool.",
+        "references": [
+          "contracts/testdata/baseline/mcp-aliases.json",
+          "pkg/transports/mcp/factorysession/tool.go"
+        ]
+      },
+      "removalGates": [
+        {
+          "id": "mcp.alias.you.workflow.validate.no-external-callers",
+          "description": "No supported external integrations rely on the workflow-named alias.",
+          "status": "open"
+        }
+      ],
+      "approvalStatus": "approved"
+    }
+  }
+}

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -72,12 +72,31 @@ Use this map when changing the public REST contract.
   `make api-smoke`; this inventory lane must not modify authored OpenAPI,
   generated clients, or `pkg/transports/http` handlers.
 
-## Family compatibility inventory coverage
+## Family compatibility inventory ownership
 
 - Machine-readable API, CLI, and MCP compatibility classifications live in
   `contracts/api/deprecated.json`, `contracts/cli/deprecated.json`, and
   `contracts/mcp/deprecated.json` against
-  `contracts/compatibility-inventory.schema.json`.
+  `contracts/compatibility-inventory.schema.json` and the shared vocabulary in
+  `contracts/common/compatibility-inventory.schema.json`.
+- These family inventories are the **machine-readable source of truth** for
+  classification status, successor `targetItemId`, evidence, lifecycle
+  versions, removal-gate status, and maintainer `approvalStatus`. Update the
+  JSON records first when classification changes; the human-readable appendix
+  tables in [Compatibility Alias Inventory](#compatibility-alias-inventory)
+  document boundary ownership and runtime evidence and must stay aligned.
+- Supported `classification` values (see schema `$defs/classification`):
+  - `retain-temporarily`: the alias remains callable; removal requires satisfying
+    every recorded removal gate in a separate approved removal change.
+  - `remove-now`: classified as removal-ready for a later approved removal
+    story; inventory classification does not unregister or delete runtime
+    aliases.
+  - `separately-approved`: retained under explicit maintainer approval outside
+    the default retain/remove posture.
+- Supported `approvalStatus` values are `approved`, `pending`, and `rejected`.
+  Inventory records compose lifecycle fields from
+  `contracts/common/deprecations.schema.json`; classification metadata does not
+  control runtime callability.
 - Baseline scope for coverage assertions lives under
   `contracts/testdata/baseline/` (`api-compatibility-surfaces.json`,
   `cli-commands.json`, `mcp-aliases.json`). Add new compatibility-only surfaces
@@ -109,6 +128,29 @@ Use this map when changing the public REST contract.
   (`~default`, `GET /events`) stay inventoried for classification but are
   excluded from this focused lint because they are accepted at many transport
   boundaries rather than workflow-preview alias names.
+- Retained aliases remain callable until objective removal gates are satisfied
+  in a separate approved removal change; the lint gate blocks new first-party
+  internal adoption only.
+
+## Primary navigation and reference guidance
+
+- Packaged CLI reference (`docs/reference/`, `you docs <topic>`), dashboard
+  navigation, OpenAPI primary discovery, and new first-party examples must
+  present canonical successors rather than promoting compatibility aliases as
+  primary entry points.
+- Compatibility aliases belong only in the family compatibility inventories
+  above and the maintainer appendix tables in
+  [Compatibility Alias Inventory](#compatibility-alias-inventory); they are
+  excluded from primary discovery and must not appear as recommended routes,
+  nav labels, packaged topic names, or first-party examples in customer guides.
+- When documenting public entry points, name the canonical successor (for
+  example `POST /factories/preview`, Factory Session REST routes, and
+  `you.factory_session.*` MCP tools). Mention retained workflow-named aliases
+  only in explicit migration or compatibility appendix lanes.
+- Reference topics may acknowledge long-lived CLI topic aliases (for example
+  `batch-work` → `batch-inputs`) at the edges of canonical topic lists in
+  `docs/reference/README.md`; workflow-named API/CLI/MCP aliases are not primary
+  and must not be added to primary navigation or reference tables.
 
 ## OpenAPI contract semver comparator
 
@@ -152,7 +194,13 @@ Use this map when changing the public REST contract.
 
 ## Compatibility Alias Inventory
 
-This inventory is the maintainer source of truth for retained public aliases.
+This section is the human-readable maintainer appendix for alias-accepting
+boundaries, canonical successors, runtime evidence, and objective removal gates.
+Classification status, approval posture, and removal-gate satisfaction are
+owned by the machine-readable family inventories documented in
+[Family compatibility inventory ownership](#family-compatibility-inventory-ownership);
+update those JSON records first when classification changes.
+
 An alias-accepting boundary may parse, route, or re-export an obsolete name, but
 it does not own the behavior. The canonical owner and its tests remain the final
 specification; compatibility-only tests prove deprecation signals and parity

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -72,6 +72,25 @@ Use this map when changing the public REST contract.
   `make api-smoke`; this inventory lane must not modify authored OpenAPI,
   generated clients, or `pkg/transports/http` handlers.
 
+## Family compatibility inventory coverage
+
+- Machine-readable API, CLI, and MCP compatibility classifications live in
+  `contracts/api/deprecated.json`, `contracts/cli/deprecated.json`, and
+  `contracts/mcp/deprecated.json` against
+  `contracts/compatibility-inventory.schema.json`.
+- Baseline scope for coverage assertions lives under
+  `contracts/testdata/baseline/` (`api-compatibility-surfaces.json`,
+  `cli-commands.json`, `mcp-aliases.json`). Add new compatibility-only surfaces
+  to the relevant baseline file and the matching family inventory in the same
+  change.
+- `contracts/compatibility_inventory_coverage_test.go`
+  (`TestCompatibilityInventoryBaselineCoverage`) loads each family inventory plus
+  its baseline and fails when any in-scope compatibility surface lacks exactly
+  one classified record or required fields (stable `itemId`, `family`,
+  `publicName`, supported `classification`, successor, evidence, lifecycle
+  versions, removal gates, approval status). Per-family schema validation stays
+  in `contracts/*_deprecated_inventory_test.go`.
+
 ## OpenAPI contract semver comparator
 
 - `internal/contractopenapidiff` owns the build-time OpenAPI comparator that

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -91,6 +91,25 @@ Use this map when changing the public REST contract.
   versions, removal gates, approval status). Per-family schema validation stays
   in `contracts/*_deprecated_inventory_test.go`.
 
+## Focused compatibility alias internal-use lint
+
+- `internal/contractguard` loads inventoried compatibility alias match values from
+  `contracts/mcp/deprecated.json`, `contracts/cli/deprecated.json`, and
+  `contracts/api/deprecated.json`, then scans handwritten `cmd/`, `internal/`,
+  `pkg/`, and `ui/src` sources for deliberate new adoption outside approved
+  compatibility boundaries.
+- `cmd/compatibilityaliascheck` is wired through `make compatibility-alias-check`
+  and the default `make lint` target. Checked-in violation and clean fixtures
+  live under `cmd/compatibilityaliascheck/testdata/{violation-repo,clean-repo}/`.
+- Retained aliases remain callable at existing CLI/MCP/REST compatibility
+  boundaries (`pkg/transports/`, `pkg/factory/`, `ui/src/api/workflow-preview/`,
+  and related owners documented above). New first-party internal code must use
+  canonical successors instead of inventoried compatibility alias names.
+- Session-selector and process-global event compatibility surfaces
+  (`~default`, `GET /events`) stay inventoried for classification but are
+  excluded from this focused lint because they are accepted at many transport
+  boundaries rather than workflow-preview alias names.
+
 ## OpenAPI contract semver comparator
 
 - `internal/contractopenapidiff` owns the build-time OpenAPI comparator that

--- a/internal/contractguard/compatibility_alias_inventory.go
+++ b/internal/contractguard/compatibility_alias_inventory.go
@@ -1,0 +1,143 @@
+package contractguard
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	mcpDeprecatedInventoryPath = "contracts/mcp/deprecated.json"
+	cliDeprecatedInventoryPath = "contracts/cli/deprecated.json"
+	apiDeprecatedInventoryPath = "contracts/api/deprecated.json"
+)
+
+// CompatibilityAliasTerm is one inventoried compatibility alias surface that new
+// first-party internal code must not adopt outside approved boundaries.
+type CompatibilityAliasTerm struct {
+	ItemID      string
+	Family      string
+	PublicName  string
+	MatchValues []string
+}
+
+type compatibilityInventoryDocument struct {
+	Family  string                       `json:"family"`
+	Records map[string]compatibilityRecord `json:"records"`
+}
+
+type compatibilityRecord struct {
+	ItemID     string `json:"itemId"`
+	Family     string `json:"family"`
+	PublicName string `json:"publicName"`
+}
+
+var compatibilityAliasLintExcludedItemIDs = map[string]struct{}{
+	"api.selector.default-session": {},
+	"api.route.get.events":         {},
+}
+
+// LoadCompatibilityAliasTerms reads the family compatibility inventories and
+// returns deduplicated match values for each inventoried compatibility surface
+// that must not be adopted in new first-party internal code.
+func LoadCompatibilityAliasTerms(repoRoot string) ([]CompatibilityAliasTerm, error) {
+	repoRoot, err := filepath.Abs(repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolve repository root: %w", err)
+	}
+
+	termsByItemID := make(map[string]CompatibilityAliasTerm)
+	for _, inventoryPath := range []string{
+		mcpDeprecatedInventoryPath,
+		cliDeprecatedInventoryPath,
+		apiDeprecatedInventoryPath,
+	} {
+		document, err := readCompatibilityInventoryDocument(filepath.Join(repoRoot, filepath.FromSlash(inventoryPath)))
+		if err != nil {
+			return nil, err
+		}
+		for recordKey, record := range document.Records {
+			itemID := strings.TrimSpace(record.ItemID)
+			if itemID == "" {
+				itemID = recordKey
+			}
+			family := strings.TrimSpace(record.Family)
+			if family == "" {
+				family = document.Family
+			}
+			publicName := strings.TrimSpace(record.PublicName)
+			if publicName == "" {
+				return nil, fmt.Errorf("%s: record %q is missing publicName", inventoryPath, recordKey)
+			}
+			if _, excluded := compatibilityAliasLintExcludedItemIDs[itemID]; excluded {
+				continue
+			}
+			termsByItemID[itemID] = CompatibilityAliasTerm{
+				ItemID:      itemID,
+				Family:      family,
+				PublicName:  publicName,
+				MatchValues: derivedCompatibilityAliasMatchValues(itemID, family, publicName),
+			}
+		}
+	}
+
+	terms := make([]CompatibilityAliasTerm, 0, len(termsByItemID))
+	for _, term := range termsByItemID {
+		terms = append(terms, term)
+	}
+	sort.Slice(terms, func(i, j int) bool {
+		if terms[i].ItemID == terms[j].ItemID {
+			return terms[i].PublicName < terms[j].PublicName
+		}
+		return terms[i].ItemID < terms[j].ItemID
+	})
+	return terms, nil
+}
+
+func readCompatibilityInventoryDocument(path string) (compatibilityInventoryDocument, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return compatibilityInventoryDocument{}, fmt.Errorf("read compatibility inventory %s: %w", filepath.ToSlash(path), err)
+	}
+	var document compatibilityInventoryDocument
+	if err := json.Unmarshal(raw, &document); err != nil {
+		return compatibilityInventoryDocument{}, fmt.Errorf("decode compatibility inventory %s: %w", filepath.ToSlash(path), err)
+	}
+	if document.Records == nil {
+		document.Records = map[string]compatibilityRecord{}
+	}
+	return document, nil
+}
+
+func derivedCompatibilityAliasMatchValues(itemID, family, publicName string) []string {
+	seen := make(map[string]struct{})
+	add := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		seen[value] = struct{}{}
+	}
+
+	add(publicName)
+	switch family {
+	case "mcp":
+		if strings.HasPrefix(itemID, "mcp.alias.") {
+			add(strings.TrimPrefix(itemID, "mcp.alias."))
+		}
+	case "cli":
+		if strings.HasPrefix(itemID, "cli.command.") {
+			add("you." + strings.TrimPrefix(itemID, "cli.command."))
+		}
+	}
+
+	values := make([]string, 0, len(seen))
+	for value := range seen {
+		values = append(values, value)
+	}
+	sort.Strings(values)
+	return values
+}

--- a/internal/contractguard/compatibility_alias_lint.go
+++ b/internal/contractguard/compatibility_alias_lint.go
@@ -1,0 +1,353 @@
+package contractguard
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+const compatibilityAliasBoundaryMarker = "compatibility-alias-boundary:"
+
+// DefaultCompatibilityAliasBoundaryPrefixes are repository paths where retained
+// compatibility alias surfaces may be referenced while external callability
+// remains unchanged.
+var DefaultCompatibilityAliasBoundaryPrefixes = []string{
+	"api/",
+	"contracts/",
+	"packages/",
+	"pkg/transports/",
+	"pkg/factory/",
+	"pkg/service/",
+	"pkg/testutil/",
+	"ui/src/api/workflow-preview/",
+	"ui/src/api/generated/",
+	"ui/src/api/session-routing.ts",
+	"ui/src/api/session-factory/",
+	"ui/src/features/workflow-preview/",
+}
+
+var compatibilityAliasScanRoots = []string{"cmd", "internal", "pkg", "ui/src"}
+
+// CompatibilityAliasViolation records one deliberate compatibility alias
+// adoption outside an approved boundary.
+type CompatibilityAliasViolation struct {
+	FilePath   string
+	Line       int
+	Column     int
+	Term       string
+	ItemID     string
+	PublicName string
+}
+
+// ScanCompatibilityAliasViolations scans handwritten first-party sources for new
+// internal adoption of inventoried compatibility alias names.
+func ScanCompatibilityAliasViolations(repoRoot string, terms []CompatibilityAliasTerm, boundaryPrefixes []string) ([]CompatibilityAliasViolation, error) {
+	repoRoot, err := filepath.Abs(repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolve repository root: %w", err)
+	}
+	if len(boundaryPrefixes) == 0 {
+		boundaryPrefixes = DefaultCompatibilityAliasBoundaryPrefixes
+	}
+
+	matchIndex := buildCompatibilityAliasMatchIndex(terms)
+	var violations []CompatibilityAliasViolation
+	for _, sourceRoot := range compatibilityAliasScanRoots {
+		rootPath := filepath.Join(repoRoot, filepath.FromSlash(sourceRoot))
+		if _, statErr := os.Stat(rootPath); os.IsNotExist(statErr) {
+			continue
+		} else if statErr != nil {
+			return nil, fmt.Errorf("inspect %s: %w", sourceRoot, statErr)
+		}
+		err = filepath.WalkDir(rootPath, func(path string, entry os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() {
+				if shouldSkipCompatibilityAliasDir(repoRoot, path) {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			relative, relErr := filepath.Rel(repoRoot, path)
+			if relErr != nil {
+				return relErr
+			}
+			relative = filepath.ToSlash(relative)
+			if shouldSkipCompatibilityAliasFile(relative) {
+				return nil
+			}
+			if isCompatibilityAliasBoundary(relative, boundaryPrefixes) {
+				return nil
+			}
+			fileViolations, scanErr := scanCompatibilityAliasFile(path, relative, matchIndex)
+			if scanErr != nil {
+				return scanErr
+			}
+			violations = append(violations, fileViolations...)
+			return nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("scan %s: %w", sourceRoot, err)
+		}
+	}
+
+	sort.Slice(violations, func(i, j int) bool {
+		if violations[i].FilePath == violations[j].FilePath {
+			if violations[i].Line == violations[j].Line {
+				if violations[i].Column == violations[j].Column {
+					return violations[i].Term < violations[j].Term
+				}
+				return violations[i].Column < violations[j].Column
+			}
+			return violations[i].Line < violations[j].Line
+		}
+		return violations[i].FilePath < violations[j].FilePath
+	})
+	return violations, nil
+}
+
+type compatibilityAliasMatch struct {
+	term       string
+	itemID     string
+	publicName string
+}
+
+func buildCompatibilityAliasMatchIndex(terms []CompatibilityAliasTerm) []compatibilityAliasMatch {
+	seen := make(map[string]compatibilityAliasMatch)
+	for _, term := range terms {
+		for _, matchValue := range term.MatchValues {
+			if _, exists := seen[matchValue]; exists {
+				continue
+			}
+			seen[matchValue] = compatibilityAliasMatch{
+				term:       matchValue,
+				itemID:     term.ItemID,
+				publicName: term.PublicName,
+			}
+		}
+	}
+	matches := make([]compatibilityAliasMatch, 0, len(seen))
+	for _, match := range seen {
+		matches = append(matches, match)
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		if len(matches[i].term) == len(matches[j].term) {
+			return matches[i].term < matches[j].term
+		}
+		return len(matches[i].term) > len(matches[j].term)
+	})
+	return matches
+}
+
+func shouldSkipCompatibilityAliasDir(repoRoot, path string) bool {
+	return ShouldSkipDir(repoRoot, path, "vendor", "node_modules", "testdata", "generated", ".git")
+}
+
+func shouldSkipCompatibilityAliasFile(relative string) bool {
+	if strings.Contains(relative, "/testdata/") {
+		return true
+	}
+	if strings.HasSuffix(relative, "_test.go") {
+		return true
+	}
+	switch filepath.Ext(relative) {
+	case ".go":
+		return false
+	case ".ts", ".tsx":
+		return strings.HasSuffix(relative, ".test.ts") ||
+			strings.HasSuffix(relative, ".test.tsx") ||
+			strings.HasSuffix(relative, ".stories.tsx")
+	default:
+		return true
+	}
+}
+
+func isCompatibilityAliasBoundary(relative string, boundaryPrefixes []string) bool {
+	for _, prefix := range boundaryPrefixes {
+		if relative == strings.TrimSuffix(prefix, "/") || strings.HasPrefix(relative, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func scanCompatibilityAliasFile(path, relative string, matches []compatibilityAliasMatch) ([]CompatibilityAliasViolation, error) {
+	switch filepath.Ext(relative) {
+	case ".go":
+		return scanGoCompatibilityAliasFile(path, relative, matches)
+	case ".ts", ".tsx":
+		return scanTypeScriptCompatibilityAliasFile(path, relative, matches)
+	default:
+		return nil, nil
+	}
+}
+
+func scanGoCompatibilityAliasFile(path, relative string, matches []compatibilityAliasMatch) ([]CompatibilityAliasViolation, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", relative, err)
+	}
+	if strings.Contains(string(raw), compatibilityAliasBoundaryMarker) {
+		return nil, nil
+	}
+
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, path, raw, parser.ParseComments)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", relative, err)
+	}
+	if ast.IsGenerated(file) {
+		return nil, nil
+	}
+
+	seen := make(map[string]struct{})
+	var violations []CompatibilityAliasViolation
+	record := func(position token.Pos, match compatibilityAliasMatch) {
+		if position == token.NoPos {
+			return
+		}
+		line, column := fileSet.Position(position).Line, fileSet.Position(position).Column
+		key := fmt.Sprintf("%s:%d:%d:%s", relative, line, column, match.term)
+		if _, exists := seen[key]; exists {
+			return
+		}
+		seen[key] = struct{}{}
+		violations = append(violations, CompatibilityAliasViolation{
+			FilePath:   relative,
+			Line:       line,
+			Column:     column,
+			Term:       match.term,
+			ItemID:     match.itemID,
+			PublicName: match.publicName,
+		})
+	}
+
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch typed := node.(type) {
+		case *ast.ImportSpec:
+			if typed.Path != nil {
+				for _, match := range matches {
+					if containsCompatibilityAliasTerm(unquoteGoString(typed.Path.Value), match.term) ||
+						containsCompatibilityAliasTerm(typed.Path.Value, match.term) {
+						record(typed.Path.ValuePos, match)
+					}
+				}
+			}
+		case *ast.BasicLit:
+			if typed.Kind != token.STRING {
+				return true
+			}
+			literal := unquoteGoString(typed.Value)
+			for _, match := range matches {
+				if containsCompatibilityAliasTerm(literal, match.term) {
+					record(typed.ValuePos, match)
+				}
+			}
+		case *ast.Ident:
+			for _, match := range matches {
+				if typed.Name == match.term {
+					record(typed.NamePos, match)
+				}
+			}
+		}
+		return true
+	})
+	return violations, nil
+}
+
+func scanTypeScriptCompatibilityAliasFile(path, relative string, matches []compatibilityAliasMatch) ([]CompatibilityAliasViolation, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", relative, err)
+	}
+	content := string(raw)
+	if strings.Contains(content, compatibilityAliasBoundaryMarker) {
+		return nil, nil
+	}
+
+	seen := make(map[string]struct{})
+	var violations []CompatibilityAliasViolation
+	lines := strings.Split(content, "\n")
+	for lineIndex, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "/*") || strings.HasPrefix(trimmed, "*") {
+			continue
+		}
+		for _, match := range matches {
+			column := strings.Index(line, match.term)
+			if column < 0 || !hasCompatibilityAliasTermBoundary(line, column, len(match.term)) {
+				continue
+			}
+			key := fmt.Sprintf("%s:%d:%d:%s", relative, lineIndex+1, column+1, match.term)
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			violations = append(violations, CompatibilityAliasViolation{
+				FilePath:   relative,
+				Line:       lineIndex + 1,
+				Column:     column + 1,
+				Term:       match.term,
+				ItemID:     match.itemID,
+				PublicName: match.publicName,
+			})
+		}
+	}
+	return violations, nil
+}
+
+func unquoteGoString(value string) string {
+	if len(value) >= 2 {
+		if (value[0] == '"' && value[len(value)-1] == '"') || (value[0] == '`' && value[len(value)-1] == '`') {
+			if unquoted, err := strconv.Unquote(value); err == nil {
+				return unquoted
+			}
+		}
+	}
+	return value
+}
+
+func containsCompatibilityAliasTerm(content, term string) bool {
+	if term == "" {
+		return false
+	}
+	start := 0
+	for {
+		index := strings.Index(content[start:], term)
+		if index < 0 {
+			return false
+		}
+		position := start + index
+		if hasCompatibilityAliasTermBoundary(content, position, len(term)) {
+			return true
+		}
+		start = position + 1
+	}
+}
+
+func hasCompatibilityAliasTermBoundary(content string, start, length int) bool {
+	if start > 0 {
+		if previous := rune(content[start-1]); isCompatibilityAliasTermChar(previous) {
+			return false
+		}
+	}
+	end := start + length
+	if end < len(content) {
+		if next := rune(content[end]); isCompatibilityAliasTermChar(next) {
+			return false
+		}
+	}
+	return true
+}
+
+func isCompatibilityAliasTermChar(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '.'
+}

--- a/internal/contractguard/compatibility_alias_test.go
+++ b/internal/contractguard/compatibility_alias_test.go
@@ -1,0 +1,160 @@
+package contractguard_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/contractguard"
+)
+
+func TestLoadCompatibilityAliasTerms_IncludesDerivedMCPAndCLIForms(t *testing.T) {
+	root := repositoryRoot(t)
+	terms, err := contractguard.LoadCompatibilityAliasTerms(root)
+	if err != nil {
+		t.Fatalf("LoadCompatibilityAliasTerms() error = %v", err)
+	}
+	if len(terms) == 0 {
+		t.Fatal("expected inventoried compatibility alias terms")
+	}
+
+	termByItemID := make(map[string]contractguard.CompatibilityAliasTerm, len(terms))
+	for _, term := range terms {
+		termByItemID[term.ItemID] = term
+	}
+
+	mcpTerm, ok := termByItemID["mcp.alias.you.workflow.validate"]
+	if !ok {
+		t.Fatal("missing MCP workflow validate inventory term")
+	}
+	if !containsString(mcpTerm.MatchValues, "you.workflow.validate") {
+		t.Fatalf("MCP match values = %#v, want you.workflow.validate", mcpTerm.MatchValues)
+	}
+
+	cliTerm, ok := termByItemID["cli.command.workflow.preview"]
+	if !ok {
+		t.Fatal("missing CLI workflow preview inventory term")
+	}
+	if !containsString(cliTerm.MatchValues, "you.workflow.preview") || !containsString(cliTerm.MatchValues, "you workflow preview") {
+		t.Fatalf("CLI match values = %#v, want dotted and spaced workflow preview forms", cliTerm.MatchValues)
+	}
+}
+
+func TestScanCompatibilityAliasViolations_RejectsDeliberateAdoption(t *testing.T) {
+	root := fixtureRepository(t, map[string]string{
+		"contracts/mcp/deprecated.json": `{
+  "formatVersion": "1.0.0",
+  "family": "mcp",
+  "records": {
+    "mcp.alias.you.workflow.validate": {
+      "itemId": "mcp.alias.you.workflow.validate",
+      "family": "mcp",
+      "publicName": "you.workflow.validate"
+    }
+  }
+}`,
+		"contracts/cli/deprecated.json": `{"formatVersion":"1.0.0","family":"cli","records":{}}`,
+		"contracts/api/deprecated.json":   `{"formatVersion":"1.0.0","family":"api","records":{}}`,
+		"pkg/work/adopter.go": `package work
+
+const adoptedAlias = "you.workflow.validate"
+`,
+	})
+
+	terms, err := contractguard.LoadCompatibilityAliasTerms(root)
+	if err != nil {
+		t.Fatalf("LoadCompatibilityAliasTerms() error = %v", err)
+	}
+	violations, err := contractguard.ScanCompatibilityAliasViolations(root, terms, contractguard.DefaultCompatibilityAliasBoundaryPrefixes)
+	if err != nil {
+		t.Fatalf("ScanCompatibilityAliasViolations() error = %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("violations = %#v, want one deliberate adoption", violations)
+	}
+	if violations[0].FilePath != "pkg/work/adopter.go" || violations[0].Term != "you.workflow.validate" {
+		t.Fatalf("violations[0] = %#v, want pkg/work/adopter.go you.workflow.validate", violations[0])
+	}
+}
+
+func TestScanCompatibilityAliasViolations_AllowsApprovedBoundary(t *testing.T) {
+	root := fixtureRepository(t, map[string]string{
+		"contracts/mcp/deprecated.json": `{
+  "formatVersion": "1.0.0",
+  "family": "mcp",
+  "records": {
+    "mcp.alias.you.workflow.validate": {
+      "itemId": "mcp.alias.you.workflow.validate",
+      "family": "mcp",
+      "publicName": "you.workflow.validate"
+    }
+  }
+}`,
+		"contracts/cli/deprecated.json": `{"formatVersion":"1.0.0","family":"cli","records":{}}`,
+		"contracts/api/deprecated.json":   `{"formatVersion":"1.0.0","family":"api","records":{}}`,
+		"pkg/transports/mcp/factorysession/tool.go": `package factorysession
+
+const ToolWorkflowValidate = "you.workflow.validate"
+`,
+	})
+
+	terms, err := contractguard.LoadCompatibilityAliasTerms(root)
+	if err != nil {
+		t.Fatalf("LoadCompatibilityAliasTerms() error = %v", err)
+	}
+	violations, err := contractguard.ScanCompatibilityAliasViolations(root, terms, contractguard.DefaultCompatibilityAliasBoundaryPrefixes)
+	if err != nil {
+		t.Fatalf("ScanCompatibilityAliasViolations() error = %v", err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("approved boundary produced violations: %#v", violations)
+	}
+}
+
+func TestScanCompatibilityAliasViolations_PassesOnRepositoryRoot(t *testing.T) {
+	root := repositoryRoot(t)
+	terms, err := contractguard.LoadCompatibilityAliasTerms(root)
+	if err != nil {
+		t.Fatalf("LoadCompatibilityAliasTerms() error = %v", err)
+	}
+	violations, err := contractguard.ScanCompatibilityAliasViolations(root, terms, contractguard.DefaultCompatibilityAliasBoundaryPrefixes)
+	if err != nil {
+		t.Fatalf("ScanCompatibilityAliasViolations() error = %v", err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("repository scan produced violations: %#v", violations)
+	}
+}
+
+func repositoryRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("repository root: %v", err)
+	}
+	return root
+}
+
+func fixtureRepository(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for relative, contents := range files {
+		path := filepath.Join(root, filepath.FromSlash(relative))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("create fixture directory: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+			t.Fatalf("write fixture %s: %v", relative, err)
+		}
+	}
+	return root
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/contractvalidator/compatibility_inventory.go
+++ b/internal/contractvalidator/compatibility_inventory.go
@@ -31,6 +31,7 @@ func CompatibilityInventoryRegistry() Registry {
 			{Path: "contracts/testdata/compatibility-inventory/valid-mcp-retain.json", SchemaID: compatibilityInventorySchemaID},
 			{Path: "contracts/testdata/compatibility-inventory/valid-api-remove-now.json", SchemaID: compatibilityInventorySchemaID},
 			{Path: "contracts/testdata/compatibility-inventory/valid-cli-separately-approved.json", SchemaID: compatibilityInventorySchemaID},
+			{Path: "contracts/mcp/deprecated.json", SchemaID: compatibilityInventorySchemaID},
 		},
 	})
 }

--- a/internal/contractvalidator/compatibility_inventory.go
+++ b/internal/contractvalidator/compatibility_inventory.go
@@ -32,6 +32,7 @@ func CompatibilityInventoryRegistry() Registry {
 			{Path: "contracts/testdata/compatibility-inventory/valid-api-remove-now.json", SchemaID: compatibilityInventorySchemaID},
 			{Path: "contracts/testdata/compatibility-inventory/valid-cli-separately-approved.json", SchemaID: compatibilityInventorySchemaID},
 			{Path: "contracts/mcp/deprecated.json", SchemaID: compatibilityInventorySchemaID},
+			{Path: "contracts/cli/deprecated.json", SchemaID: compatibilityInventorySchemaID},
 		},
 	})
 }

--- a/internal/contractvalidator/compatibility_inventory.go
+++ b/internal/contractvalidator/compatibility_inventory.go
@@ -33,6 +33,7 @@ func CompatibilityInventoryRegistry() Registry {
 			{Path: "contracts/testdata/compatibility-inventory/valid-cli-separately-approved.json", SchemaID: compatibilityInventorySchemaID},
 			{Path: "contracts/mcp/deprecated.json", SchemaID: compatibilityInventorySchemaID},
 			{Path: "contracts/cli/deprecated.json", SchemaID: compatibilityInventorySchemaID},
+			{Path: "contracts/api/deprecated.json", SchemaID: compatibilityInventorySchemaID},
 		},
 	})
 }

--- a/internal/contractvalidator/compatibility_inventory.go
+++ b/internal/contractvalidator/compatibility_inventory.go
@@ -1,0 +1,114 @@
+package contractvalidator
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const compatibilityInventorySchemaID = "https://schemas.portpowered.com/you/contracts/compatibility-inventory.schema.json"
+
+const (
+	compatibilityDocumentationSchemaID = "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json"
+	compatibilityDeprecationsSchemaID  = "https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json"
+	compatibilityVocabularySchemaID    = "https://schemas.portpowered.com/you/contracts/common/compatibility-inventory.schema.json"
+)
+
+// CompatibilityInventoryRegistry registers compatibility inventory schemas and
+// reviewed valid fixtures.
+func CompatibilityInventoryRegistry() Registry {
+	return NewRegistry(Entry{
+		Family:        "compatibility-inventory",
+		FormatVersion: "1.0.0",
+		Schemas: []Schema{
+			{ID: compatibilityDocumentationSchemaID, Path: "contracts/common/documentation.schema.json"},
+			{ID: compatibilityDeprecationsSchemaID, Path: "contracts/common/deprecations.schema.json"},
+			{ID: compatibilityVocabularySchemaID, Path: "contracts/common/compatibility-inventory.schema.json"},
+			{ID: compatibilityInventorySchemaID, Path: "contracts/compatibility-inventory.schema.json"},
+		},
+		Documents: []Document{
+			{Path: "contracts/testdata/compatibility-inventory/valid-mcp-retain.json", SchemaID: compatibilityInventorySchemaID},
+			{Path: "contracts/testdata/compatibility-inventory/valid-api-remove-now.json", SchemaID: compatibilityInventorySchemaID},
+			{Path: "contracts/testdata/compatibility-inventory/valid-cli-separately-approved.json", SchemaID: compatibilityInventorySchemaID},
+		},
+	})
+}
+
+// CompatibilityInventorySemanticsDiagnostics applies inventory-specific semantic
+// checks after schema validation succeeds.
+func CompatibilityInventorySemanticsDiagnostics(document string, value any) []Diagnostic {
+	return compatibilityInventorySemanticsDiagnostics(document, value)
+}
+
+func compatibilityInventorySemanticsDiagnostics(document string, value any) []Diagnostic {
+	root, ok := value.(map[string]any)
+	if !ok {
+		return nil
+	}
+	family, _ := root["family"].(string)
+	records, ok := root["records"].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	keys := make([]string, 0, len(records))
+	for key := range records {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	seenItemIDs := make(map[string]string)
+	var diagnostics []Diagnostic
+	for _, key := range keys {
+		recordValue, ok := records[key].(map[string]any)
+		if !ok {
+			continue
+		}
+		recordPath := "/records/" + escapeJSONPointerToken(key)
+		itemID, _ := recordValue["itemId"].(string)
+		if itemID != key {
+			diagnostics = append(diagnostics, newDiagnostic(
+				"inventory.record_key_mismatch",
+				recordPath+"/itemId",
+				fmt.Sprintf("record itemId %s must match records key %s", strconv.Quote(itemID), strconv.Quote(key)),
+				document,
+			))
+		}
+		if previousKey, exists := seenItemIDs[itemID]; exists {
+			message := fmt.Sprintf("stable ID %s appears more than once", strconv.Quote(itemID))
+			diagnostics = append(diagnostics,
+				newDiagnostic("identity.duplicate", recordPath+"/itemId", message, document),
+				newDiagnostic("identity.duplicate", "/records/"+escapeJSONPointerToken(previousKey)+"/itemId", message, document),
+			)
+		} else {
+			seenItemIDs[itemID] = key
+		}
+		recordFamily, _ := recordValue["family"].(string)
+		if family != "" && recordFamily != family {
+			diagnostics = append(diagnostics, newDiagnostic(
+				"inventory.family_mismatch",
+				recordPath+"/family",
+				fmt.Sprintf("record family %q must match inventory family %q", recordFamily, family),
+				document,
+			))
+		}
+		if lifecycle, ok := recordValue["lifecycle"].(map[string]any); ok {
+			lifecycleItemID, _ := lifecycle["itemId"].(string)
+			if itemID != "" && lifecycleItemID != itemID {
+				diagnostics = append(diagnostics, newDiagnostic(
+					"inventory.lifecycle_item_mismatch",
+					recordPath+"/lifecycle/itemId",
+					fmt.Sprintf("lifecycle itemId %s must match record itemId %s", strconv.Quote(lifecycleItemID), strconv.Quote(itemID)),
+					document,
+				))
+			}
+		}
+	}
+	sortDiagnostics(diagnostics)
+	return diagnostics
+}
+
+func escapeJSONPointerToken(token string) string {
+	return strings.NewReplacer("~", "~0", "/", "~1").Replace(token)
+}

--- a/internal/contractvalidator/validator.go
+++ b/internal/contractvalidator/validator.go
@@ -151,6 +151,9 @@ func validateEntry(repositoryRoot string, entry Entry) []Diagnostic {
 			diagnostics = append(diagnostics, validationDiagnostics(document.Path, err)...)
 			continue
 		}
+		if document.SchemaID == compatibilityInventorySchemaID {
+			diagnostics = append(diagnostics, compatibilityInventorySemanticsDiagnostics(document.Path, value)...)
+		}
 		for _, source := range sourceDocuments {
 			loadedDocuments[source.path] = source
 		}

--- a/internal/contractvalidator/validator_test.go
+++ b/internal/contractvalidator/validator_test.go
@@ -18,6 +18,14 @@ func TestCommonRegistryValidFixtures(t *testing.T) {
 	}
 }
 
+func TestCompatibilityInventoryRegistryValidFixtures(t *testing.T) {
+	root := repositoryRoot(t)
+	diagnostics := contractvalidator.Validate(root, contractvalidator.CompatibilityInventoryRegistry(), "compatibility-inventory", "1.0.0")
+	if len(diagnostics) != 0 {
+		t.Fatalf("Validate() diagnostics = %+v, want none", diagnostics)
+	}
+}
+
 func TestValidateRejectsUnknownRegistrySelection(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
{
  "project": "B09-COMPAT — Classify API/CLI/MCP Retained and Removal-Ready Surfaces",
  "branchName": "interfaces-b09-compat",
  "description": "Author API/CLI/MCP compatibility inventories that classify every baseline alias and compatibility-only public surface as retain-temporarily, remove-now, or separately-approved, with stable identity, successor, evidence, versions, removal gates, and approval status; add inventory coverage tests and a focused lint against new internal alias use; document ownership in api-relevant-files.md; keep retained aliases callable with no runtime removal or constructor cutover.",
  "context": {
    "customerAsk": "Author deprecation/compatibility inventories that classify every baseline alias and compatibility-only public surface as retain-temporarily, remove-now, or separately-approved, with stable ID, family, public name, classification, successor, evidence, since/deprecated versions, removal gates, and maintainer approval status. Update docs/internal/processes/api-relevant-files.md to point maintainers at the inventories. Do not remove runtime aliases or change primary discovery beyond documenting that new internal alias use should fail lint. Acceptance: every baseline alias/surface is classified; deliberate new internal alias use fails a focused lint; retained aliases remain callable and stay out of primary navigation.",
    "problem": "Executable baselines and the common deprecations schema exist, but family deprecation inventories and api-relevant-files classification lanes are not yet authored. Maintainers cannot tell which aliases are temporarily retained, removal-ready, or separately approved; unclassified surfaces risk silent promotion into primary contracts; and there is no focused lint preventing new internal adoption of compatibility names.",
    "solution": "Author machine-readable API, CLI, and MCP compatibility inventories that compose common lifecycle metadata with classification, evidence, removal gates, and approval status; prove every baseline alias is classified; add a focused lint that rejects deliberate new internal alias use while leaving runtime callability unchanged; and document inventory ownership plus the lint gate in api-relevant-files.md without removing aliases or cutting over constructors/handlers."
  },
  "acceptanceCriteria": [
    "AC-1: Every baseline API/CLI/MCP compatibility alias or compatibility-only surface has one inventory record with stable ID, family, public name, classification, successor, evidence, versions, removal gates, and approval status.",
    "AC-2: No unclassified baseline alias remains.",
    "AC-3: Focused lint rejects new internal alias use while retained aliases remain callable at runtime.",
    "AC-4: Primary navigation/reference guidance excludes compatibility aliases.",
    "AC-5: docs/internal/processes/api-relevant-files.md documents the inventory ownership and lint gate.",
    "AC-6: No runtime alias removal and no constructor/handler cutover in this item.",
    "AC-7: Quality checks pass (typecheck, lint, and tests), including inventory/lint package tests, make contracts-validate when inventory schemas apply, and make verify-fast if shared lint wiring changes."
  ],
  "userStories": [
    {
      "id": "interfaces-b09-compat-001",
      "title": "Define family compatibility inventory schema and fixtures",
      "description": "As a contract author, I want a versioned inventory document shape for API, CLI, and MCP compatibility surfaces so every alias can be recorded with stable identity, classification, successor, evidence, versions, removal gates, and approval status before family inventories are filled in.",
      "acceptanceCriteria": [
        "A Draft 2020-12 inventory schema (or family-root schemas sharing one vocabulary) accepts explicit format version and records with stable ID, family (api | cli | mcp), public name, classification (retain-temporarily | remove-now | separately-approved), successor target and migration guidance, evidence, since/deprecated versions, removal gates, and maintainer approval status",
        "Inventory records compose or align with contracts/common/deprecations.schema.json lifecycle fields without inventing a conflicting state machine",
        "Valid fixtures pass and invalid fixtures (missing classification, missing successor for deprecated/compat entries, unknown family, unknown classification, duplicate stable IDs, unknown properties) fail at deterministic JSON paths",
        "Schema validation does not change whether any alias is callable at runtime",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b09-compat-002",
      "title": "Classify every MCP baseline compatibility alias",
      "description": "As a maintainer, I want every MCP alias in contracts/testdata/baseline/mcp-aliases.json recorded in the MCP compatibility inventory so workflow-named tools are explicitly classified with successors and removal gates instead of remaining unclassified.",
      "acceptanceCriteria": [
        "contracts/mcp/deprecated.json (or the MCP family inventory path agreed by the schema) contains one record for each baseline MCP alias, including at least you.workflow.validate, you.workflow.run, you.workflow.status, you.workflow.result, and you.workflow.artifacts",
        "Each MCP record names the canonical you.factory_session.* successor, evidence of compatibility-only status, since/deprecated versions when known, objective removal gates, classification, and maintainer approval status",
        "Classification values are only retain-temporarily, remove-now, or separately-approved; remove-now means classified as removal-ready for a later story, not physically removed in this item",
        "Inventory documents validate against the family schema from story 001",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b09-compat-003",
      "title": "Classify every CLI baseline compatibility surface",
      "description": "As a maintainer, I want every CLI compatibility command and alias surface from the reviewed baselines and existing maintainer inventory recorded in the CLI compatibility inventory so workflow-named CLI entry points are classified with successors and removal gates.",
      "acceptanceCriteria": [
        "contracts/cli/deprecated.json (or the CLI family inventory path agreed by the schema) contains one record for each CLI compatibility surface covered by the baseline/compatibility inventory scope, including the workflow-named CLI commands already tracked as compatibility aliases (preview, validate, run, start, status, result, dispatches, artifacts, events)",
        "Each CLI record names the exact canonical successor (Factory preview, Factory Session REST/CLI, or equivalent), evidence, versions, removal gates, classification, and approval status",
        "No CLI compatibility surface in scope remains unclassified; classification does not unregister or delete any command constructor",
        "Inventory documents validate against the family schema from story 001",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b09-compat-004",
      "title": "Classify every API and related compatibility-only surface",
      "description": "As a maintainer, I want every REST and related compatibility-only public surface from the reviewed baselines and maintainer inventory recorded in the API compatibility inventory so obsolete routes, schemas, selectors, and transport aliases are classified with successors and removal gates.",
      "acceptanceCriteria": [
        "The API compatibility inventory contains one record for each in-scope compatibility-only surface, including at least POST /workflow-previews (previewWorkflow), WorkflowPreview request/result and generated PreviewWorkflow names, process-global GET /events, and the ~default session selector (plus UI import compatibility boundaries already treated as compatibility-only when in scope)",
        "Each API record names the exact canonical successor, evidence, versions, removal gates, classification, and approval status",
        "No in-scope API compatibility surface remains unclassified; classification does not remove routes, schemas, or handlers",
        "Inventory documents validate against the family schema from story 001",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b09-compat-005",
      "title": "Prove inventory coverage over baseline aliases",
      "description": "As a reviewer, I want focused inventory coverage tests that fail when a baseline alias or in-scope compatibility-only surface lacks a classified inventory record so unclassified aliases cannot merge silently.",
      "acceptanceCriteria": [
        "Focused Go tests load the MCP, CLI, and API compatibility inventories and the relevant baseline inventories under contracts/testdata/baseline/",
        "Coverage assertions fail when any baseline MCP alias, in-scope CLI compatibility surface, or in-scope API compatibility-only surface lacks exactly one inventory record with a supported classification",
        "Coverage assertions fail when required fields (stable ID, family, public name, classification, successor, evidence, versions, removal gates, approval status) are missing or empty where required",
        "Tests assert behavioral coverage outcomes and do not rely on meta-tests such as source-file scans, docs link topology, or route-registration inventories unrelated to the product behavior under test",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b09-compat-006",
      "title": "Reject new internal alias use with a focused lint fixture",
      "description": "As a maintainer, I want a focused lint that fails when new internal code deliberately adopts a compatibility alias name so retained aliases stay callable for external callers while new first-party internal use is blocked.",
      "acceptanceCriteria": [
        "A focused lint or lint-backed check rejects deliberate new internal use of inventoried compatibility alias names (for example a checked-in violation fixture that fails until fixed, plus a clean case that passes)",
        "Retained aliases remain callable at runtime: existing alias-accepting CLI/MCP/REST boundaries still resolve compatibility names to their successors without this story removing registrations",
        "Primary navigation and packaged/reference guidance continue to present canonical successors rather than promoting compatibility aliases as primary entry points; any lint/docs wording states that new internal alias use must fail",
        "If shared lint wiring changes, make verify-fast remains green; otherwise focused lint/inventory package tests prove the gate",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b09-compat-007",
      "title": "Document inventory ownership and lint gate for maintainers",
      "description": "As a maintainer changing public contracts, I want docs/internal/processes/api-relevant-files.md to point at the family compatibility inventories and the focused alias lint so classification ownership and removal process stay discoverable beside the existing human-readable alias tables.",
      "acceptanceCriteria": [
        "docs/internal/processes/api-relevant-files.md documents where API, CLI, and MCP compatibility inventories live, what classification values mean, and that inventory ownership is the machine-readable source of truth for classification status",
        "The same doc documents the focused lint gate: new internal alias use must fail; retained aliases remain callable until objective removal gates are satisfied in a separate change",
        "Primary navigation/reference guidance language states that compatibility aliases are excluded from primary discovery and belong only in the compatibility inventory/appendix lane",
        "Documentation changes do not remove runtime aliases or rewrite handler ownership beyond inventory/lint pointers",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 7,
      "passes": true,
      "notes": ""
    }
  ]
}
