### PR TITLE
stream-b09-cross-provider-parity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ CRON_TIME_WORK_SMOKE_TIMEOUT ?= 120s
 CURRENT_FACTORY_WATCHER_SWITCH_SMOKE_TEST := TestCurrentFactoryActivationFixture_ActivatesSecondPersistedFactoryAndResolvesCurrentFactory
 CURRENT_FACTORY_WATCHER_SWITCH_SMOKE_COUNT ?= 1
 CURRENT_FACTORY_WATCHER_SWITCH_SMOKE_TIMEOUT ?= 120s
+CROSS_PROVIDER_PARITY_SMOKE_TEST := TestCrossProviderParity
+CROSS_PROVIDER_PARITY_SMOKE_TIMEOUT ?= 120s
+RESPONSE_STREAM_STRESS_SMOKE_TEST := TestSessionResponseEventStore_Backpressure
+RESPONSE_STREAM_STRESS_SMOKE_TIMEOUT ?= 120s
 
 ifeq ($(OS),Windows_NT)
 	BINARY_NAME := you.exe
@@ -75,7 +79,7 @@ define run_timed_step
 	exit $$status
 endef
 
-.PHONY: default build intall bundle-api generate-api generate-go-api generate-go-server-api generate-go-client-api generate-ui-api generate-wire wire-smoke api-smoke api-package-pack-smoke contracts-validate contracts-generate contracts-check contracts-smoke docs-reference-check docs-reference-smoke test test-full test-functional test-functional-long verify-fast verify-pr verify-pr-inference verify-extended verify-build-contracts verify-tests run-concurrent-ui-verification-lanes run-sharded-ui-coverage verify test-ui-coverage test-ui-coverage-merge test-ui-browser-integration test-ui-durable-session-real-backend test-backend-coverage test-backend-functional test-backend-verification long-tests long-tests-managed-runtime long-tests-functional-runtime pr-inference-approval test-coverage-go script-timeout-companion-smoke-100 cron-time-work-smoke current-factory-watcher-switch-smoke release-surface-smoke artifact-contract-closeout lint backend-size pkg-maint pkg-file-count pkg-boundary durable-runtime-construction-check logging-boundary-check compatibility-alias-check model-facade-check readme-check deadcode ui-deadcode test-race fmt vet deps deps-tidy init dashboard-verify typecheck release ci ci-typecheck ci-verify-build-contracts ci-verify-tests ui-deps ui-lint ui-build ui-test ui-integration-test ui-durable-session-real-backend-integration-test ui-test-coverage ui-replay-coverage-check ui-install-playwright ui-storybook ui-test-storybook ui-components-typecheck ui-components-test ui-components-storybook ui-components-boundary ui-components-dependency-direction ui-components-verify ui-verify-fresh-npm-install clean
+.PHONY: default build intall bundle-api generate-api generate-go-api generate-go-server-api generate-go-client-api generate-ui-api generate-wire wire-smoke api-smoke api-package-pack-smoke contracts-validate contracts-generate contracts-check contracts-smoke docs-reference-check docs-reference-smoke test test-full test-functional test-functional-long verify-fast verify-pr verify-pr-inference verify-extended verify-build-contracts verify-tests run-concurrent-ui-verification-lanes run-sharded-ui-coverage verify test-ui-coverage test-ui-coverage-merge test-ui-browser-integration test-ui-durable-session-real-backend test-backend-coverage test-backend-functional test-backend-verification long-tests long-tests-managed-runtime long-tests-functional-runtime pr-inference-approval test-coverage-go script-timeout-companion-smoke-100 cron-time-work-smoke current-factory-watcher-switch-smoke provider-parity-smoke response-stream-stress-smoke release-surface-smoke artifact-contract-closeout lint backend-size pkg-maint pkg-file-count pkg-boundary durable-runtime-construction-check logging-boundary-check compatibility-alias-check model-facade-check readme-check deadcode ui-deadcode test-race fmt vet deps deps-tidy init dashboard-verify typecheck release ci ci-typecheck ci-verify-build-contracts ci-verify-tests ui-deps ui-lint ui-build ui-test ui-integration-test ui-durable-session-real-backend-integration-test ui-test-coverage ui-replay-coverage-check ui-install-playwright ui-storybook ui-test-storybook ui-components-typecheck ui-components-test ui-components-storybook ui-components-boundary ui-components-dependency-direction ui-components-verify ui-verify-fresh-npm-install clean
 
 default:
 	$(MAKE) generate-api
@@ -121,6 +125,7 @@ api-smoke:
 	node scripts/check-api-generated-drift.js
 	$(GO) test ./pkg/transports/http/contracttests -run TestOpenAPIContract_BundledFactoryEventSchemasRemainComplete -count=1 -timeout $(GO_TEST_TIMEOUT)
 	$(GO) test ./tests/functional/runtime_api -run TestGeneratedAPIIntegrationSmoke_OpenAPIGeneratedServerAndLiveRuntimeStayAligned -count=1 -timeout $(GO_TEST_TIMEOUT)
+	$(MAKE) provider-parity-smoke
 
 api-package-pack-smoke:
 	node --test scripts/api-package-contract.test.mjs scripts/api-package-pack.test.mjs scripts/api-package-consumer.test.mjs
@@ -241,6 +246,12 @@ cron-time-work-smoke:
 current-factory-watcher-switch-smoke:
 	$(GO) test -tags=$(FUNCTIONAL_LONG_TAGS) ./tests/functional/bootstrap_portability -run $(CURRENT_FACTORY_WATCHER_SWITCH_SMOKE_TEST) -count=$(CURRENT_FACTORY_WATCHER_SWITCH_SMOKE_COUNT) -timeout $(CURRENT_FACTORY_WATCHER_SWITCH_SMOKE_TIMEOUT)
 
+provider-parity-smoke:
+	$(GO) test ./pkg/workers/provider/parityfixtures ./tests/functional/providers -run $(CROSS_PROVIDER_PARITY_SMOKE_TEST) -count=1 -timeout $(CROSS_PROVIDER_PARITY_SMOKE_TIMEOUT)
+
+response-stream-stress-smoke:
+	$(GO) test ./pkg/factory/sessions/responseeventstore -run $(RESPONSE_STREAM_STRESS_SMOKE_TEST) -count=1 -timeout $(RESPONSE_STREAM_STRESS_SMOKE_TIMEOUT)
+
 artifact-contract-closeout:
 	$(GO) test ./pkg/testutil -run TestArtifactContractInventory_ -count=1 -timeout $(GO_TEST_TIMEOUT)
 	$(MAKE) release-surface-smoke
@@ -288,6 +299,7 @@ verify-build-contracts:
 	$(MAKE) ui-components-verify
 	$(MAKE) contracts-smoke
 	$(MAKE) api-smoke
+	$(MAKE) response-stream-stress-smoke
 	$(MAKE) api-package-pack-smoke
 	$(MAKE) wire-smoke
 
@@ -328,6 +340,7 @@ ci-verify-build-contracts: ci-typecheck
 	$(MAKE) ui-components-verify
 	$(MAKE) contracts-smoke
 	$(MAKE) api-smoke
+	$(MAKE) response-stream-stress-smoke
 	$(MAKE) api-package-pack-smoke
 	$(MAKE) wire-smoke
 

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -277,7 +277,10 @@ primary-result behavior.
   terminal `InvocationResponse` outcomes for every fidelity class (full-stream,
   partial-stream, snapshot-only, and final-only including Agy) plus the structured
   tool-lifecycle fixture via `AssertObservableToolLifecycle` before adding new
-  transport parity tests. While legacy response-stream
+  transport parity tests. Use `AssertPrimaryStreamModeParity` with
+  `ProjectPrimaryOnlyInvocation` and `ProjectResponseStreamInvocation` to prove
+  primary-only and response-stream observation modes agree on authoritative
+  terminal `InvocationResponse` outcomes for the same fixture run. While legacy response-stream
   consumers remain supported, carry an exact draft beside the compatibility
   fragment and let `pkg/factory/sessions/stream/manager.go` publish that draft
   directly; do not remap it through the lossy legacy fragment mapper. Keep the

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -275,7 +275,8 @@ primary-result behavior.
   plus `AssertCLIAPITransportParity` and `AssertTruthfulStreamingFidelity` to
   compare decoded CLI NDJSON and API SSE `FactoryResponseEvent` values and
   terminal `InvocationResponse` outcomes for every fidelity class (full-stream,
-  partial-stream, snapshot-only, and final-only including Agy) before adding new
+  partial-stream, snapshot-only, and final-only including Agy) plus the structured
+  tool-lifecycle fixture via `AssertObservableToolLifecycle` before adding new
   transport parity tests. While legacy response-stream
   consumers remain supported, carry an exact draft beside the compatibility
   fragment and let `pkg/factory/sessions/stream/manager.go` publish that draft

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -274,8 +274,9 @@ primary-result behavior.
   inventing parallel fixture trees. Use `parityfixtures.RunTransportParity`
   plus `AssertCLIAPITransportParity` and `AssertTruthfulStreamingFidelity` to
   compare decoded CLI NDJSON and API SSE `FactoryResponseEvent` values and
-  terminal `InvocationResponse` outcomes for streaming fidelity classes before
-  adding new transport parity tests. While legacy response-stream
+  terminal `InvocationResponse` outcomes for every fidelity class (full-stream,
+  partial-stream, snapshot-only, and final-only including Agy) before adding new
+  transport parity tests. While legacy response-stream
   consumers remain supported, carry an exact draft beside the compatibility
   fragment and let `pkg/factory/sessions/stream/manager.go` publish that draft
   directly; do not remap it through the lossy legacy fragment mapper. Keep the

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -280,8 +280,16 @@ primary-result behavior.
   transport parity tests. Use `AssertPrimaryStreamModeParity` with
   `ProjectPrimaryOnlyInvocation` and `ProjectResponseStreamInvocation` to prove
   primary-only and response-stream observation modes agree on authoritative
-  terminal `InvocationResponse` outcomes for the same fixture run. While legacy response-stream
-  consumers remain supported, carry an exact draft beside the compatibility
+  terminal `InvocationResponse` outcomes for the same fixture run. Consolidated
+  Batch 09 parity proofs live in `parityfixtures.AssertCrossProviderParityCatalog`
+  and `AssertCrossProviderParityForFixture`; run them from
+  `pkg/workers/provider/parityfixtures/suite_test.go`
+  (`TestCrossProviderParitySuite_Catalog`) and the provider-suite entrypoint
+  `tests/functional/providers/cross_provider_parity_smoke_test.go`
+  (`TestCrossProviderParitySmoke_ProviderSuiteEntrypoint`). Maintainer lanes:
+  `make provider-parity-smoke` (also invoked by `make api-smoke`) and
+  `make response-stream-stress-smoke` for response-event backpressure/race proofs.
+  While legacy response-stream consumers remain supported, carry an exact draft beside the compatibility
   fragment and let `pkg/factory/sessions/stream/manager.go` publish that draft
   directly; do not remap it through the lossy legacy fragment mapper. Keep the
   provider's final-result parser independent from decoder observation state so

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -271,7 +271,11 @@ primary-result behavior.
   parity transcripts and the adapter-neutral terminal harness live in
   `pkg/workers/provider/parityfixtures` with fidelity-class fixtures under
   `testdata/`; extend that catalog for CLI/API parity proofs instead of
-  inventing parallel fixture trees. While legacy response-stream
+  inventing parallel fixture trees. Use `parityfixtures.RunTransportParity`
+  plus `AssertCLIAPITransportParity` and `AssertTruthfulStreamingFidelity` to
+  compare decoded CLI NDJSON and API SSE `FactoryResponseEvent` values and
+  terminal `InvocationResponse` outcomes for streaming fidelity classes before
+  adding new transport parity tests. While legacy response-stream
   consumers remain supported, carry an exact draft beside the compatibility
   fragment and let `pkg/factory/sessions/stream/manager.go` publish that draft
   directly; do not remap it through the lossy legacy fragment mapper. Keep the

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -267,7 +267,11 @@ primary-result behavior.
   `compat/testdata/primary_result_regression/` and are asserted by
   `primary_result_regression_test.go` without wiring the mapper into selection.
   Provider-native typed adapters live under `pkg/workers/provider/<provider>`
-  and emit validated `responseevents.Draft` values. While legacy response-stream
+  and emit validated `responseevents.Draft` values. Sanitized cross-provider
+  parity transcripts and the adapter-neutral terminal harness live in
+  `pkg/workers/provider/parityfixtures` with fidelity-class fixtures under
+  `testdata/`; extend that catalog for CLI/API parity proofs instead of
+  inventing parallel fixture trees. While legacy response-stream
   consumers remain supported, carry an exact draft beside the compatibility
   fragment and let `pkg/factory/sessions/stream/manager.go` publish that draft
   directly; do not remap it through the lossy legacy fragment mapper. Keep the

--- a/pkg/workers/provider/parityfixtures/catalog.go
+++ b/pkg/workers/provider/parityfixtures/catalog.go
@@ -1,0 +1,145 @@
+// Package parityfixtures provides sanitized deterministic provider transcripts
+// for cross-provider CLI/API parity proofs across fidelity classes.
+package parityfixtures
+
+import (
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/workers/provider/adapter"
+)
+
+// FidelityClass names one adapter streaming fidelity lane exercised by parity proofs.
+type FidelityClass string
+
+const (
+	FidelityFullStream    FidelityClass = "full-stream"
+	FidelityPartialStream FidelityClass = "partial-stream"
+	FidelitySnapshotOnly  FidelityClass = "snapshot-only"
+	FidelityFinalOnly     FidelityClass = "final-only"
+)
+
+const (
+	FixtureFullStreamClaude      = "full-stream-claude"
+	FixturePartialStreamCodex    = "partial-stream-codex"
+	FixtureSnapshotOnlyOpenCode  = "snapshot-only-opencode"
+	FixtureFinalOnlyOpenCode     = "final-only-opencode"
+	FixtureToolLifecycleClaude   = "tool-lifecycle-claude"
+	FixtureAgyFinalOnly          = "agy-final-only"
+)
+
+// Fixture describes one sanitized parity transcript and its expected terminal outcome.
+type Fixture struct {
+	ID              string
+	FidelityClass   FidelityClass
+	Provider        adapter.Identity
+	TranscriptFile  string
+	Request         interfaces.ProviderInferenceRequest
+	WantContent     string
+	WantCapabilities adapter.Capabilities
+	ToolLifecycle   bool
+	AgyFinalOnly    bool
+}
+
+// Catalog returns the canonical parity fixture matrix for Batch 09 proofs.
+func Catalog() []Fixture {
+	return []Fixture{
+		{
+			ID:             FixtureFullStreamClaude,
+			FidelityClass:  FidelityFullStream,
+			Provider:       adapter.Identity(interfaces.ModelProviderClaude),
+			TranscriptFile: "testdata/full_stream_claude.jsonl",
+			Request: interfaces.ProviderInferenceRequest{
+				Dispatch: interfaces.WorkDispatch{DispatchID: "dispatch-parity-full-stream"},
+				Model:    "claude-sonnet-4", UserMessage: "parity fixture prompt",
+			},
+			WantContent: "Parity hello world",
+			WantCapabilities: adapter.Capabilities{
+				NativeStreaming: true, MessageDeltas: true, MessageSnapshots: true,
+				ToolLifecycle: true, ToolOutputDeltas: true, StableItemIDs: true,
+			},
+		},
+		{
+			ID:             FixturePartialStreamCodex,
+			FidelityClass:  FidelityPartialStream,
+			Provider:       adapter.Identity(interfaces.ModelProviderCodex),
+			TranscriptFile: "testdata/partial_stream_codex.jsonl",
+			Request: interfaces.ProviderInferenceRequest{
+				Dispatch: interfaces.WorkDispatch{DispatchID: "dispatch-parity-partial-stream"},
+				Model:    "gpt-test", UserMessage: "parity fixture prompt",
+			},
+			WantContent: "Parity codex answer",
+			WantCapabilities: adapter.Capabilities{
+				NativeStreaming: true, MessageSnapshots: true, ReasoningSummaries: true,
+				ToolLifecycle: true, ToolOutputDeltas: true, StableItemIDs: true,
+			},
+		},
+		{
+			ID:             FixtureSnapshotOnlyOpenCode,
+			FidelityClass:  FidelitySnapshotOnly,
+			Provider:       adapter.Identity(interfaces.ModelProviderOpenCode),
+			TranscriptFile: "testdata/snapshot_only_opencode.jsonl",
+			Request: interfaces.ProviderInferenceRequest{
+				Dispatch: interfaces.WorkDispatch{DispatchID: "dispatch-parity-snapshot-only"},
+				Model:    "openai/gpt-5", UserMessage: "parity fixture prompt",
+			},
+			WantContent: "Parity snapshot answer",
+			WantCapabilities: adapter.Capabilities{
+				NativeStreaming: true, MessageSnapshots: true, StableItemIDs: true,
+			},
+		},
+		{
+			ID:             FixtureFinalOnlyOpenCode,
+			FidelityClass:  FidelityFinalOnly,
+			Provider:       adapter.Identity(interfaces.ModelProviderOpenCode),
+			TranscriptFile: "testdata/final_only_opencode.txt",
+			Request: interfaces.ProviderInferenceRequest{
+				Dispatch: interfaces.WorkDispatch{DispatchID: "dispatch-parity-final-only"},
+				Model:    "openai/gpt-5", UserMessage: "parity fixture prompt",
+			},
+			WantContent: "Parity final-only answer",
+			WantCapabilities: adapter.Capabilities{
+				MessageSnapshots: true, FinalOnly: true,
+			},
+		},
+		{
+			ID:             FixtureToolLifecycleClaude,
+			FidelityClass:  FidelityFullStream,
+			Provider:       adapter.Identity(interfaces.ModelProviderClaude),
+			TranscriptFile: "testdata/tool_lifecycle_claude.jsonl",
+			Request: interfaces.ProviderInferenceRequest{
+				Dispatch: interfaces.WorkDispatch{DispatchID: "dispatch-parity-tool-lifecycle"},
+				Model:    "claude-sonnet-4", UserMessage: "parity fixture prompt",
+			},
+			WantContent: "Parity tool lifecycle complete",
+			WantCapabilities: adapter.Capabilities{
+				NativeStreaming: true, MessageDeltas: true, MessageSnapshots: true,
+				ToolLifecycle: true, ToolOutputDeltas: true, StableItemIDs: true,
+			},
+			ToolLifecycle: true,
+		},
+		{
+			ID:            FixtureAgyFinalOnly,
+			FidelityClass: FidelityFinalOnly,
+			Provider:      adapter.Identity(interfaces.ModelProviderAgy),
+			TranscriptFile: "testdata/agy_final_only.txt",
+			Request: interfaces.ProviderInferenceRequest{
+				Dispatch: interfaces.WorkDispatch{DispatchID: "dispatch-parity-agy-final-only"},
+				Model:    "gemini-pro", UserMessage: "parity fixture prompt",
+			},
+			WantContent: "Parity agy complete response",
+			WantCapabilities: adapter.Capabilities{
+				MessageSnapshots: true, FinalOnly: true,
+			},
+			AgyFinalOnly: true,
+		},
+	}
+}
+
+// FixtureByID returns one catalog fixture or false when id is unknown.
+func FixtureByID(id string) (Fixture, bool) {
+	for _, fixture := range Catalog() {
+		if fixture.ID == id {
+			return fixture, true
+		}
+	}
+	return Fixture{}, false
+}

--- a/pkg/workers/provider/parityfixtures/edge_cases_test.go
+++ b/pkg/workers/provider/parityfixtures/edge_cases_test.go
@@ -1,0 +1,414 @@
+package parityfixtures_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/interfaces/responseevents"
+	"github.com/portpowered/infinite-you/pkg/workers/provider/adapter"
+	apisurface "github.com/portpowered/infinite-you/pkg/transports/mapping"
+	"github.com/portpowered/infinite-you/pkg/workers/provider/parityfixtures"
+)
+
+func TestFixtureByID_Unknown(t *testing.T) {
+	t.Parallel()
+
+	if _, ok := parityfixtures.FixtureByID("missing-fixture"); ok {
+		t.Fatal("FixtureByID() = true, want false for unknown id")
+	}
+}
+
+func TestValidateSanitized_RejectsForbiddenContent(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		contents string
+	}{
+		{name: "forbidden token", contents: "contains sk-parity-secret-token in body"},
+		{name: "secret pattern", contents: `api_key: "leaked"`},
+		{name: "host path", contents: "/Users/alice/project/file.txt"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if err := parityfixtures.ValidateSanitized([]byte(tc.contents)); err == nil {
+				t.Fatalf("ValidateSanitized() = nil, want error for %q", tc.name)
+			}
+		})
+	}
+}
+
+func TestDecodeTransportCLINDJSON_RejectsInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		lines []string
+	}{
+		{name: "empty", lines: nil},
+		{name: "bad json", lines: []string{`{not-json`}},
+		{name: "wrong record type", lines: []string{
+			`{"recordType":"invocation_result","invocation":{}}`,
+			`{"recordType":"invocation_result","invocation":{}}`,
+		}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, _, err := parityfixtures.DecodeTransportCLINDJSON(tc.lines); err == nil {
+				t.Fatalf("DecodeTransportCLINDJSON() = nil, want error for %q", tc.name)
+			}
+		})
+	}
+}
+
+func TestDecodeTransportAPIRecords_RejectsInvalidPayload(t *testing.T) {
+	t.Parallel()
+
+	records := []apisurface.FactoryResponseEventRecord{{
+		Sequence: 1,
+		Kind:     string(responseevents.KindMessage),
+		Data:     []byte(`{`),
+	}}
+	if _, err := parityfixtures.DecodeTransportAPIRecords(records); err == nil {
+		t.Fatal("DecodeTransportAPIRecords() = nil, want error for invalid payload")
+	}
+}
+
+func TestDecodeTransportSSEFrame_RejectsInvalidFrame(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		frame string
+	}{
+		{name: "missing id", frame: "data: {}\n\n"},
+		{name: "bad json", frame: "id: 1\ndata: {bad\n\n"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := parityfixtures.DecodeTransportSSEFrame(tc.frame); err == nil {
+				t.Fatalf("DecodeTransportSSEFrame() = nil, want error for %q", tc.name)
+			}
+		})
+	}
+}
+
+func TestAssertObservableToolLifecycle_RejectsIncompleteLifecycle(t *testing.T) {
+	t.Parallel()
+
+	if err := parityfixtures.AssertObservableToolLifecycle(nil); err == nil {
+		t.Fatal("AssertObservableToolLifecycle() = nil, want error for missing lifecycle")
+	}
+}
+
+func TestAssertObservableToolLifecycle_RejectsInvalidPayload(t *testing.T) {
+	t.Parallel()
+
+	started := toolEvent(responseevents.PhaseStarted, responseevents.ToolPayload{
+		ToolCallID: "tool-1",
+		ToolName:   "lookup",
+	})
+	completedBadJSON := responseevents.FactoryResponseEvent{
+		Kind:    responseevents.KindTool,
+		Phase:   responseevents.PhaseCompleted,
+		Payload: json.RawMessage(`{`),
+	}
+	if err := parityfixtures.AssertObservableToolLifecycle([]responseevents.FactoryResponseEvent{started, completedBadJSON}); err == nil {
+		t.Fatal("AssertObservableToolLifecycle() = nil, want decode error")
+	}
+}
+
+func TestAssertObservableToolLifecycle_RejectsIdentityDrift(t *testing.T) {
+	t.Parallel()
+
+	events := []responseevents.FactoryResponseEvent{
+		toolEvent(responseevents.PhaseStarted, responseevents.ToolPayload{
+			ToolCallID: "tool-1",
+			ToolName:   "lookup",
+		}),
+		toolEvent(responseevents.PhaseStarted, responseevents.ToolPayload{
+			ToolCallID: "tool-2",
+			ToolName:   "lookup",
+		}),
+	}
+	if err := parityfixtures.AssertObservableToolLifecycle(events); err == nil {
+		t.Fatal("AssertObservableToolLifecycle() = nil, want identity drift error")
+	}
+}
+
+func TestAssertObservableToolLifecycle_RejectsMissingIdentity(t *testing.T) {
+	t.Parallel()
+
+	started := toolEvent(responseevents.PhaseStarted, responseevents.ToolPayload{ToolName: "lookup"})
+	if err := parityfixtures.AssertObservableToolLifecycle([]responseevents.FactoryResponseEvent{started}); err == nil {
+		t.Fatal("AssertObservableToolLifecycle() = nil, want missing identity error")
+	}
+}
+
+func TestAssertObservableToolLifecycle_RejectsCompletedMismatch(t *testing.T) {
+	t.Parallel()
+
+	events := []responseevents.FactoryResponseEvent{
+		toolEvent(responseevents.PhaseStarted, responseevents.ToolPayload{
+			ToolCallID: "tool-1",
+			ToolName:   "lookup",
+		}),
+		toolEvent(responseevents.PhaseCompleted, responseevents.ToolPayload{
+			ToolCallID: "tool-2",
+			ToolName:   "lookup",
+		}),
+	}
+	if err := parityfixtures.AssertObservableToolLifecycle(events); err == nil {
+		t.Fatal("AssertObservableToolLifecycle() = nil, want completed identity mismatch error")
+	}
+}
+
+func TestDecodeTransportSSEFrame_RejectsSequenceMismatch(t *testing.T) {
+	t.Parallel()
+
+	fixture, ok := parityfixtures.FixtureByID(parityfixtures.FixtureFullStreamClaude)
+	if !ok {
+		t.Fatal("missing full-stream fixture")
+	}
+	outcome, err := parityfixtures.RunTransportParity(context.Background(), fixture)
+	if err != nil {
+		t.Fatalf("RunTransportParity() error = %v", err)
+	}
+	frame, err := parityfixtures.EncodeTransportSSEFrame(outcome.Events[0])
+	if err != nil {
+		t.Fatalf("EncodeTransportSSEFrame() error = %v", err)
+	}
+	frame = strings.Replace(frame, "id: ", "id: 999", 1)
+	if _, err := parityfixtures.DecodeTransportSSEFrame(frame); err == nil {
+		t.Fatal("DecodeTransportSSEFrame() = nil, want sequence mismatch error")
+	}
+}
+
+func TestAssertPrimaryStreamModeParity_RejectsEmptyStreamEvents(t *testing.T) {
+	t.Parallel()
+
+	err := parityfixtures.AssertPrimaryStreamModeParity(parityfixtures.TransportParityOutcome{})
+	if err == nil || !strings.Contains(err.Error(), "no response events") {
+		t.Fatalf("AssertPrimaryStreamModeParity() = %v, want empty stream events error", err)
+	}
+}
+
+func TestAssertCLIAPITransportParity_RejectsEmptyEvents(t *testing.T) {
+	t.Parallel()
+
+	err := parityfixtures.AssertCLIAPITransportParity(parityfixtures.TransportParityOutcome{})
+	if err == nil || !strings.Contains(err.Error(), "no publishable response events") {
+		t.Fatalf("AssertCLIAPITransportParity() = %v, want empty-events error", err)
+	}
+}
+
+func TestProjectResponseStreamInvocation_RejectsEncodeFailure(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := parityfixtures.ProjectResponseStreamInvocation(parityfixtures.TransportParityOutcome{
+		Events: []responseevents.FactoryResponseEvent{{
+			Kind:  responseevents.KindMessage,
+			Phase: responseevents.PhaseCompleted,
+		}},
+	})
+	if err == nil {
+		t.Fatal("ProjectResponseStreamInvocation() = nil, want error for invalid event envelope")
+	}
+}
+
+func TestAssertCrossProviderParityCatalog(t *testing.T) {
+	t.Parallel()
+
+	if err := parityfixtures.AssertCrossProviderParityCatalog(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDecodeTransportCLINDJSON_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	fixture, ok := parityfixtures.FixtureByID(parityfixtures.FixtureFullStreamClaude)
+	if !ok {
+		t.Fatal("missing full-stream fixture")
+	}
+	outcome, err := parityfixtures.RunTransportParity(context.Background(), fixture)
+	if err != nil {
+		t.Fatalf("RunTransportParity() error = %v", err)
+	}
+	lines, err := parityfixtures.EncodeTransportCLINDJSON(outcome.Events, outcome.InvocationResult)
+	if err != nil {
+		t.Fatalf("EncodeTransportCLINDJSON() error = %v", err)
+	}
+	decodedEvents, decodedInvocation, err := parityfixtures.DecodeTransportCLINDJSON(lines)
+	if err != nil {
+		t.Fatalf("DecodeTransportCLINDJSON() error = %v", err)
+	}
+	if len(decodedEvents) != len(outcome.Events) {
+		t.Fatalf("decoded event count = %d, want %d", len(decodedEvents), len(outcome.Events))
+	}
+	if decodedInvocation.Status == "" {
+		t.Fatal("decoded invocation missing status")
+	}
+}
+
+func TestReadTranscript_MissingFile(t *testing.T) {
+	t.Parallel()
+
+	if _, err := parityfixtures.ReadTranscript("missing-transcript.ndjson"); err == nil {
+		t.Fatal("ReadTranscript() = nil, want error for missing file")
+	}
+}
+
+func TestRunTerminal_UnsupportedProvider(t *testing.T) {
+	t.Parallel()
+
+	_, err := parityfixtures.RunTerminal(context.Background(), parityfixtures.Fixture{
+		ID:             "unsupported-provider",
+		TranscriptFile: "testdata/full_stream_claude.jsonl",
+		Provider:       "unsupported-provider",
+		Request: interfaces.ProviderInferenceRequest{
+			Dispatch: interfaces.WorkDispatch{DispatchID: "dispatch-unsupported"},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "unsupported parity provider") {
+		t.Fatalf("RunTerminal() = %v, want unsupported provider error", err)
+	}
+}
+
+func TestAssertTruthfulStreamingFidelity_UnsupportedClass(t *testing.T) {
+	t.Parallel()
+
+	err := parityfixtures.AssertTruthfulStreamingFidelity(
+		parityfixtures.Fixture{FidelityClass: "unsupported"},
+		parityfixtures.TransportParityOutcome{},
+	)
+	if err == nil || !strings.Contains(err.Error(), "unsupported fidelity class") {
+		t.Fatalf("AssertTruthfulStreamingFidelity() = %v, want unsupported class error", err)
+	}
+}
+
+func TestAssertCrossProviderParityForFixture_RejectsTerminalContentMismatch(t *testing.T) {
+	t.Parallel()
+
+	fixture, ok := parityfixtures.FixtureByID(parityfixtures.FixtureFullStreamClaude)
+	if !ok {
+		t.Fatal("missing full-stream fixture")
+	}
+	fixture.WantContent = "intentionally-wrong-content"
+	if err := parityfixtures.AssertCrossProviderParityForFixture(context.Background(), fixture); err == nil {
+		t.Fatal("AssertCrossProviderParityForFixture() = nil, want terminal content mismatch error")
+	}
+}
+
+func TestValidateSanitized_RejectsAbsolutePath(t *testing.T) {
+	t.Parallel()
+
+	if err := parityfixtures.ValidateSanitized([]byte("C:\\Users\\alice\\secret.txt")); err == nil {
+		t.Fatal("ValidateSanitized() = nil, want absolute path error")
+	}
+}
+
+func TestRunTerminal_MissingTranscript(t *testing.T) {
+	t.Parallel()
+
+	_, err := parityfixtures.RunTerminal(context.Background(), parityfixtures.Fixture{
+		ID:             "missing-transcript",
+		TranscriptFile: "testdata/does-not-exist.jsonl",
+	})
+	if err == nil {
+		t.Fatal("RunTerminal() = nil, want missing transcript error")
+	}
+}
+
+func TestAssertTruthfulStreamingFidelity_RejectsInvalidOutcomes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		fixture parityfixtures.Fixture
+		outcome parityfixtures.TransportParityOutcome
+		want    string
+	}{
+		{
+			name:    "full-stream missing deltas",
+			fixture: parityfixtures.Fixture{FidelityClass: parityfixtures.FidelityFullStream},
+			outcome: parityfixtures.TransportParityOutcome{
+				Terminal: parityfixtures.TerminalResult{
+					Capabilities: adapter.Capabilities{NativeStreaming: true, MessageDeltas: true},
+				},
+			},
+			want: "no message delta events",
+		},
+		{
+			name:    "partial-stream missing snapshots",
+			fixture: parityfixtures.Fixture{FidelityClass: parityfixtures.FidelityPartialStream},
+			outcome: parityfixtures.TransportParityOutcome{
+				Terminal: parityfixtures.TerminalResult{
+					Capabilities: adapter.Capabilities{NativeStreaming: true, MessageSnapshots: true},
+				},
+			},
+			want: "no completed message snapshots",
+		},
+		{
+			name:    "snapshot-only claims deltas",
+			fixture: parityfixtures.Fixture{FidelityClass: parityfixtures.FidelitySnapshotOnly},
+			outcome: parityfixtures.TransportParityOutcome{
+				Terminal: parityfixtures.TerminalResult{
+					Capabilities: adapter.Capabilities{
+						NativeStreaming: true, MessageSnapshots: true, MessageDeltas: true,
+					},
+				},
+			},
+			want: "must not claim message deltas",
+		},
+		{
+			name:    "final-only missing completed message",
+			fixture: parityfixtures.Fixture{FidelityClass: parityfixtures.FidelityFinalOnly},
+			outcome: parityfixtures.TransportParityOutcome{
+				Terminal: parityfixtures.TerminalResult{
+					Capabilities: adapter.Capabilities{MessageSnapshots: true, FinalOnly: true},
+				},
+			},
+			want: "no completed message events",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := parityfixtures.AssertTruthfulStreamingFidelity(tc.fixture, tc.outcome)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("AssertTruthfulStreamingFidelity() = %v, want error containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestDefaultForbiddenTokens_NonEmpty(t *testing.T) {
+	t.Parallel()
+
+	if len(parityfixtures.DefaultForbiddenTokens()) == 0 {
+		t.Fatal("DefaultForbiddenTokens() is empty")
+	}
+}
+
+func toolEvent(phase responseevents.Phase, payload responseevents.ToolPayload) responseevents.FactoryResponseEvent {
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		panic(err)
+	}
+	return responseevents.FactoryResponseEvent{
+		Kind:    responseevents.KindTool,
+		Phase:   phase,
+		Payload: encoded,
+	}
+}

--- a/pkg/workers/provider/parityfixtures/harness.go
+++ b/pkg/workers/provider/parityfixtures/harness.go
@@ -1,0 +1,189 @@
+package parityfixtures
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/interfaces/responseevents"
+	workerprocess "github.com/portpowered/infinite-you/pkg/workers/process"
+	"github.com/portpowered/infinite-you/pkg/workers/provider/adapter"
+	opencodeadapter "github.com/portpowered/infinite-you/pkg/workers/provider/adapter/opencode"
+	"github.com/portpowered/infinite-you/pkg/workers/provider/agy"
+	"github.com/portpowered/infinite-you/pkg/workers/provider/claude"
+	"github.com/portpowered/infinite-you/pkg/workers/provider/codex"
+)
+
+// TerminalResult is the neutral terminal outcome produced by one parity fixture run.
+type TerminalResult struct {
+	Outcome      adapter.CommandOutcome
+	Response     interfaces.InferenceResponse
+	Capabilities adapter.Capabilities
+	Drafts       []responseevents.Draft
+}
+
+// RunTerminal executes one fixture through the adapter-neutral harness and returns
+// its terminal invocation outcome without live provider credentials.
+func RunTerminal(ctx context.Context, fixture Fixture) (TerminalResult, error) {
+	transcript, err := ReadTranscript(fixture.TranscriptFile)
+	if err != nil {
+		return TerminalResult{}, err
+	}
+	if err := ValidateSanitized(transcript); err != nil {
+		return TerminalResult{}, fmt.Errorf("fixture %q: %w", fixture.ID, err)
+	}
+	if fixture.AgyFinalOnly {
+		return runAgyTerminal(ctx, fixture, transcript)
+	}
+	providerAdapter, err := adapterForFixture(fixture)
+	if err != nil {
+		return TerminalResult{}, err
+	}
+	registry, err := adapter.NewRegistry(providerAdapter)
+	if err != nil {
+		return TerminalResult{}, fmt.Errorf("registry fixture %q: %w", fixture.ID, err)
+	}
+	runner := newTranscriptRunner(transcript)
+	result, err := adapter.Execute(ctx, registry, runner, adapter.ExecuteInput{
+		Provider: fixture.Provider,
+		Command:  adapter.CommandContext{Request: fixture.Request},
+		Decoder: adapter.DecoderContext{
+			RunID:      "run-parity-" + fixture.ID,
+			DispatchID: fixture.Request.Dispatch.DispatchID,
+		},
+	})
+	if err != nil {
+		return TerminalResult{}, fmt.Errorf("execute fixture %q: %w", fixture.ID, err)
+	}
+	return TerminalResult{
+		Outcome:      result.Outcome,
+		Response:     result.Response,
+		Capabilities: result.Capabilities,
+		Drafts:       result.Drafts,
+	}, nil
+}
+
+func runAgyTerminal(_ context.Context, fixture Fixture, transcript []byte) (TerminalResult, error) {
+	factoryRoot, err := os.MkdirTemp("", "parity-agy-*")
+	if err != nil {
+		return TerminalResult{}, fmt.Errorf("agy temp dir: %w", err)
+	}
+	defer os.RemoveAll(factoryRoot)
+
+	providerAdapter := agy.NewAdapter(factoryRoot, agy.WithExecutable("agy"))
+	reported, err := providerAdapter.Capabilities(context.Background(), adapter.CapabilityContext{Request: fixture.Request})
+	if err != nil {
+		return TerminalResult{}, fmt.Errorf("agy capabilities: %w", err)
+	}
+	parsed, err := providerAdapter.ParseFinal(context.Background(), adapter.FinalParseContext{
+		RunID:         "run-parity-" + fixture.ID,
+		DispatchID:    fixture.Request.Dispatch.DispatchID,
+		CommandResult: workerprocess.CommandResult{Stdout: transcript},
+		FlushReason:   adapter.FlushReasonCompleted,
+	})
+	if err != nil {
+		return TerminalResult{}, fmt.Errorf("agy parse final: %w", err)
+	}
+	return TerminalResult{
+		Outcome:      adapter.CommandOutcomeCompleted,
+		Response:     parsed.Response,
+		Capabilities: reported.Capabilities,
+		Drafts:       parsed.Drafts,
+	}, nil
+}
+
+func adapterForFixture(fixture Fixture) (adapter.Adapter, error) {
+	switch fixture.Provider {
+	case adapter.Identity(interfaces.ModelProviderClaude):
+		return claude.NewAdapter(), nil
+	case adapter.Identity(interfaces.ModelProviderCodex):
+		return codex.NewResponseAdapter(), nil
+	case adapter.Identity(interfaces.ModelProviderOpenCode):
+		return openCodeAdapterForFixture(fixture)
+	default:
+		return nil, fmt.Errorf("unsupported parity provider %q", fixture.Provider)
+	}
+}
+
+func openCodeAdapterForFixture(fixture Fixture) (adapter.Adapter, error) {
+	mode := opencodeadapter.ModeStructured
+	if fixture.FidelityClass == FidelityFinalOnly {
+		mode = opencodeadapter.ModeFinalOnly
+	}
+	negotiated, err := opencodeadapter.NewNegotiatedAdapter(opencodeadapter.Decision{
+		Installation: opencodeadapter.Installation{
+			Executable:  "/parity/opencode",
+			Fingerprint: "parity-fixture",
+		},
+		Version: "1.2.3",
+		Mode:    mode,
+	}, nil)
+	if err != nil {
+		return nil, err
+	}
+	return negotiated, nil
+}
+
+// ReadTranscript loads one fixture transcript from the package testdata directory.
+func ReadTranscript(relPath string) ([]byte, error) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return nil, fmt.Errorf("resolve parityfixtures package path")
+	}
+	path := filepath.Join(filepath.Dir(file), relPath)
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read transcript %s: %w", relPath, err)
+	}
+	return contents, nil
+}
+
+type transcriptRunner struct {
+	transcript []byte
+	chunks     []adapter.Observation
+}
+
+func newTranscriptRunner(transcript []byte) *transcriptRunner {
+	if len(transcript) == 0 {
+		return &transcriptRunner{}
+	}
+	middle := len(transcript) / 2
+	if middle < 1 {
+		middle = 1
+	}
+	return &transcriptRunner{
+		transcript: transcript,
+		chunks: []adapter.Observation{
+			{Stream: adapter.OutputStreamStdout, Chunk: transcript[:minInt(7, len(transcript))]},
+			{Stream: adapter.OutputStreamStdout, Chunk: transcript[minInt(7, len(transcript)):middle]},
+			{Stream: adapter.OutputStreamStdout, Chunk: transcript[middle:]},
+		},
+	}
+}
+
+func (r *transcriptRunner) Run(ctx context.Context, _ workerprocess.CommandRequest, observe func(adapter.Observation) error) (workerprocess.CommandResult, error) {
+	for _, chunk := range r.chunks {
+		if err := ctx.Err(); err != nil {
+			return workerprocess.CommandResult{}, err
+		}
+		if len(chunk.Chunk) == 0 {
+			continue
+		}
+		if err := observe(chunk); err != nil {
+			return workerprocess.CommandResult{}, err
+		}
+	}
+	return workerprocess.CommandResult{Stdout: r.transcript}, nil
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+var _ adapter.StreamingCommandRunner = (*transcriptRunner)(nil)

--- a/pkg/workers/provider/parityfixtures/harness_test.go
+++ b/pkg/workers/provider/parityfixtures/harness_test.go
@@ -1,0 +1,127 @@
+package parityfixtures_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/interfaces/responseevents"
+	"github.com/portpowered/infinite-you/pkg/workers/provider/adapter"
+	"github.com/portpowered/infinite-you/pkg/workers/provider/parityfixtures"
+)
+
+func TestCatalog_CoversAllFidelityClasses(t *testing.T) {
+	t.Parallel()
+
+	want := map[parityfixtures.FidelityClass]bool{
+		parityfixtures.FidelityFullStream:    false,
+		parityfixtures.FidelityPartialStream: false,
+		parityfixtures.FidelitySnapshotOnly:  false,
+		parityfixtures.FidelityFinalOnly:     false,
+	}
+	var toolLifecycle, agyFinalOnly bool
+	for _, fixture := range parityfixtures.Catalog() {
+		want[fixture.FidelityClass] = true
+		if fixture.ToolLifecycle {
+			toolLifecycle = true
+		}
+		if fixture.AgyFinalOnly {
+			agyFinalOnly = true
+		}
+		if fixture.ID == "" || fixture.TranscriptFile == "" || fixture.WantContent == "" {
+			t.Fatalf("incomplete fixture: %#v", fixture)
+		}
+	}
+	for class, covered := range want {
+		if !covered {
+			t.Fatalf("catalog missing fidelity class %q", class)
+		}
+	}
+	if !toolLifecycle {
+		t.Fatal("catalog missing structured tool lifecycle fixture")
+	}
+	if !agyFinalOnly {
+		t.Fatal("catalog missing Agy final-only fixture")
+	}
+}
+
+func TestSanitizedTranscripts_ExcludeForbiddenTokens(t *testing.T) {
+	t.Parallel()
+
+	for _, fixture := range parityfixtures.Catalog() {
+		fixture := fixture
+		t.Run(fixture.ID, func(t *testing.T) {
+			t.Parallel()
+			transcript, err := parityfixtures.ReadTranscript(fixture.TranscriptFile)
+			if err != nil {
+				t.Fatalf("ReadTranscript() error = %v", err)
+			}
+			if err := parityfixtures.ValidateSanitized(transcript); err != nil {
+				t.Fatalf("ValidateSanitized() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestHarness_ReachesTerminalOutcome(t *testing.T) {
+	t.Parallel()
+
+	for _, fixture := range parityfixtures.Catalog() {
+		fixture := fixture
+		t.Run(fixture.ID, func(t *testing.T) {
+			t.Parallel()
+			result, err := parityfixtures.RunTerminal(context.Background(), fixture)
+			if err != nil {
+				t.Fatalf("RunTerminal() error = %v", err)
+			}
+			if result.Outcome != adapter.CommandOutcomeCompleted {
+				t.Fatalf("outcome = %q, want %q", result.Outcome, adapter.CommandOutcomeCompleted)
+			}
+			if result.Response.Content != fixture.WantContent {
+				t.Fatalf("content = %q, want %q", result.Response.Content, fixture.WantContent)
+			}
+			if result.Capabilities != fixture.WantCapabilities {
+				t.Fatalf("capabilities = %#v, want %#v", result.Capabilities, fixture.WantCapabilities)
+			}
+			if fixture.ToolLifecycle && !hasToolLifecycleDrafts(result.Drafts) {
+				t.Fatalf("drafts = %#v, want observable tool lifecycle events", result.Drafts)
+			}
+			if fixture.FidelityClass == parityfixtures.FidelityFinalOnly {
+				assertFinalOnlyDrafts(t, result.Drafts)
+			}
+		})
+	}
+}
+
+func hasToolLifecycleDrafts(drafts []responseevents.Draft) bool {
+	var started, completed bool
+	for _, draft := range drafts {
+		if draft.Kind != responseevents.KindTool {
+			continue
+		}
+		switch draft.Phase {
+		case responseevents.PhaseStarted:
+			started = true
+		case responseevents.PhaseCompleted:
+			completed = true
+		}
+	}
+	return started && completed
+}
+
+func assertFinalOnlyDrafts(t *testing.T, drafts []responseevents.Draft) {
+	t.Helper()
+	var message *responseevents.Draft
+	for index := range drafts {
+		draft := drafts[index]
+		if draft.Kind == responseevents.KindMessage && draft.Phase == responseevents.PhaseCompleted {
+			message = &draft
+			break
+		}
+	}
+	if message == nil {
+		t.Fatalf("drafts = %#v, want final-only completed message", drafts)
+	}
+	if message.Provenance.Fidelity != responseevents.FidelityFinalOnly {
+		t.Fatalf("message fidelity = %q, want %q", message.Provenance.Fidelity, responseevents.FidelityFinalOnly)
+	}
+}

--- a/pkg/workers/provider/parityfixtures/mode_parity.go
+++ b/pkg/workers/provider/parityfixtures/mode_parity.go
@@ -1,0 +1,86 @@
+package parityfixtures
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/portpowered/infinite-you/pkg/factory/sessions/responseevents"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	apisurface "github.com/portpowered/infinite-you/pkg/transports/mapping"
+)
+
+// ObservationMode names one invocation stdout observation contract.
+type ObservationMode string
+
+const (
+	// ObservationPrimaryOnly is the default authoritative final without live
+	// response-stream progress on stdout.
+	ObservationPrimaryOnly ObservationMode = "primary"
+	// ObservationResponseStream enables live response events plus the terminal
+	// invocation result on stdout.
+	ObservationResponseStream ObservationMode = "response-stream"
+)
+
+// ModeParityOutcome captures authoritative finals for primary-only and
+// response-stream observation of one fixture run.
+type ModeParityOutcome struct {
+	PrimaryOnlyInvocation factoryapi.InvocationResponse
+	StreamEvents          []responseevents.FactoryResponseEvent
+	StreamInvocation      factoryapi.InvocationResponse
+}
+
+// RunModeParity executes one fixture once and projects both observation modes
+// from the same transport-neutral terminal outcome.
+func RunModeParity(outcome TransportParityOutcome) (ModeParityOutcome, error) {
+	primaryOnly := ProjectPrimaryOnlyInvocation(outcome)
+	streamEvents, streamInvocation, err := ProjectResponseStreamInvocation(outcome)
+	if err != nil {
+		return ModeParityOutcome{}, err
+	}
+	return ModeParityOutcome{
+		PrimaryOnlyInvocation: primaryOnly,
+		StreamEvents:          streamEvents,
+		StreamInvocation:      streamInvocation,
+	}, nil
+}
+
+// ProjectPrimaryOnlyInvocation maps the authoritative terminal invocation for
+// primary-only stdout mode.
+func ProjectPrimaryOnlyInvocation(outcome TransportParityOutcome) factoryapi.InvocationResponse {
+	return apisurface.InvocationResponseFromResult(outcome.InvocationResult)
+}
+
+// ProjectResponseStreamInvocation round-trips published events and the terminal
+// invocation through the CLI response-stream NDJSON envelope.
+func ProjectResponseStreamInvocation(outcome TransportParityOutcome) ([]responseevents.FactoryResponseEvent, factoryapi.InvocationResponse, error) {
+	lines, err := EncodeTransportCLINDJSON(outcome.Events, outcome.InvocationResult)
+	if err != nil {
+		return nil, factoryapi.InvocationResponse{}, fmt.Errorf("encode response-stream NDJSON: %w", err)
+	}
+	events, invocation, err := DecodeTransportCLINDJSON(lines)
+	if err != nil {
+		return nil, factoryapi.InvocationResponse{}, fmt.Errorf("decode response-stream NDJSON: %w", err)
+	}
+	return events, invocation, nil
+}
+
+// AssertPrimaryStreamModeParity proves primary-only and response-stream modes
+// agree on authoritative terminal InvocationResponse outcomes while response-stream
+// mode still delivers published response events.
+func AssertPrimaryStreamModeParity(outcome TransportParityOutcome) error {
+	modeOutcome, err := RunModeParity(outcome)
+	if err != nil {
+		return err
+	}
+	if len(modeOutcome.StreamEvents) == 0 {
+		return fmt.Errorf("response-stream mode produced no response events")
+	}
+	if !reflect.DeepEqual(modeOutcome.PrimaryOnlyInvocation, modeOutcome.StreamInvocation) {
+		return fmt.Errorf(
+			"mode parity mismatch: primary-only = %#v, response-stream = %#v",
+			modeOutcome.PrimaryOnlyInvocation,
+			modeOutcome.StreamInvocation,
+		)
+	}
+	return nil
+}

--- a/pkg/workers/provider/parityfixtures/mode_parity_test.go
+++ b/pkg/workers/provider/parityfixtures/mode_parity_test.go
@@ -1,0 +1,64 @@
+package parityfixtures_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/workers/provider/parityfixtures"
+)
+
+func TestModeParity_FullStreamPrimaryAndStreamAgree(t *testing.T) {
+	t.Parallel()
+	assertModeParityForFixture(t, parityfixtures.FixtureFullStreamClaude)
+}
+
+func TestModeParity_PartialStreamPrimaryAndStreamAgree(t *testing.T) {
+	t.Parallel()
+	assertModeParityForFixture(t, parityfixtures.FixturePartialStreamCodex)
+}
+
+func TestModeParity_SnapshotOnlyPrimaryAndStreamAgree(t *testing.T) {
+	t.Parallel()
+	assertModeParityForFixture(t, parityfixtures.FixtureSnapshotOnlyOpenCode)
+}
+
+func TestModeParity_FinalOnlyOpenCodePrimaryAndStreamAgree(t *testing.T) {
+	t.Parallel()
+	assertModeParityForFixture(t, parityfixtures.FixtureFinalOnlyOpenCode)
+}
+
+func TestModeParity_AgyFinalOnlyPrimaryAndStreamAgree(t *testing.T) {
+	t.Parallel()
+	assertModeParityForFixture(t, parityfixtures.FixtureAgyFinalOnly)
+}
+
+func TestModeParity_ToolLifecyclePrimaryAndStreamAgree(t *testing.T) {
+	t.Parallel()
+	assertModeParityForFixture(t, parityfixtures.FixtureToolLifecycleClaude)
+}
+
+func assertModeParityForFixture(t *testing.T, fixtureID string) {
+	t.Helper()
+
+	fixture, ok := parityfixtures.FixtureByID(fixtureID)
+	if !ok {
+		t.Fatalf("unknown fixture %q", fixtureID)
+	}
+	outcome, err := parityfixtures.RunTransportParity(context.Background(), fixture)
+	if err != nil {
+		t.Fatalf("RunTransportParity(%q) error = %v", fixtureID, err)
+	}
+	if err := parityfixtures.AssertPrimaryStreamModeParity(outcome); err != nil {
+		t.Fatalf("AssertPrimaryStreamModeParity(%q) error = %v", fixtureID, err)
+	}
+	modeOutcome, err := parityfixtures.RunModeParity(outcome)
+	if err != nil {
+		t.Fatalf("RunModeParity(%q) error = %v", fixtureID, err)
+	}
+	if modeOutcome.PrimaryOnlyInvocation.Status == "" {
+		t.Fatalf("primary-only invocation missing status for %q", fixtureID)
+	}
+	if modeOutcome.StreamInvocation.Status == "" {
+		t.Fatalf("response-stream invocation missing status for %q", fixtureID)
+	}
+}

--- a/pkg/workers/provider/parityfixtures/sanitize.go
+++ b/pkg/workers/provider/parityfixtures/sanitize.go
@@ -1,0 +1,59 @@
+package parityfixtures
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var (
+	forbiddenSecretPatterns = []*regexp.Regexp{
+		regexp.MustCompile(`(?i)sk-[A-Za-z0-9_-]{8,}`),
+		regexp.MustCompile(`(?i)(api[_-]?key|access[_-]?token|bearer)\s*[:=]`),
+	}
+	forbiddenPathPatterns = []*regexp.Regexp{
+		regexp.MustCompile(`(?i)[A-Za-z]:\\Users\\`),
+		regexp.MustCompile(`(?i)/Users/[^/\s]+/`),
+		regexp.MustCompile(`(?i)/home/[^/\s]+/`),
+	}
+)
+
+// DefaultForbiddenTokens are substrings parity fixtures must never require for assertions.
+func DefaultForbiddenTokens() []string {
+	return []string{
+		"sk-parity-secret-token",
+		"private submitted prompt",
+		"cursor-secret",
+		"secret-value",
+		"PRIVATE.md",
+		"private result",
+	}
+}
+
+// ValidateSanitized rejects fixture bytes that still carry secrets or host-specific paths.
+func ValidateSanitized(contents []byte, extraForbidden ...string) error {
+	text := string(contents)
+	for _, forbidden := range append(DefaultForbiddenTokens(), extraForbidden...) {
+		if forbidden == "" {
+			continue
+		}
+		if strings.Contains(text, forbidden) {
+			return fmt.Errorf("fixture contains forbidden token %q", forbidden)
+		}
+	}
+	for _, pattern := range forbiddenSecretPatterns {
+		if pattern.FindStringIndex(text) != nil {
+			return fmt.Errorf("fixture matches forbidden secret pattern %q", pattern.String())
+		}
+	}
+	for _, pattern := range forbiddenPathPatterns {
+		if pattern.FindStringIndex(text) != nil {
+			return fmt.Errorf("fixture matches forbidden path pattern %q", pattern.String())
+		}
+	}
+	if filepath.IsAbs(text) {
+		return fmt.Errorf("fixture must not be an absolute path")
+	}
+	return nil
+}

--- a/pkg/workers/provider/parityfixtures/suite.go
+++ b/pkg/workers/provider/parityfixtures/suite.go
@@ -1,0 +1,66 @@
+package parityfixtures
+
+import (
+	"context"
+	"fmt"
+
+	apisurface "github.com/portpowered/infinite-you/pkg/transports/mapping"
+)
+
+// AssertCrossProviderParityForFixture runs the consolidated Batch 09 parity proofs
+// for one catalog fixture: truthful fidelity, CLI/API transport parity, optional
+// tool lifecycle checks, and primary-only vs response-stream finals.
+func AssertCrossProviderParityForFixture(ctx context.Context, fixture Fixture) error {
+	outcome, err := RunTransportParity(ctx, fixture)
+	if err != nil {
+		return fmt.Errorf("fixture %q transport parity: %w", fixture.ID, err)
+	}
+	if err := AssertTruthfulStreamingFidelity(fixture, outcome); err != nil {
+		return fmt.Errorf("fixture %q fidelity: %w", fixture.ID, err)
+	}
+	if err := AssertCLIAPITransportParity(outcome); err != nil {
+		return fmt.Errorf("fixture %q CLI/API transport parity: %w", fixture.ID, err)
+	}
+	if fixture.ToolLifecycle {
+		if err := AssertObservableToolLifecycle(outcome.Events); err != nil {
+			return fmt.Errorf("fixture %q tool lifecycle: %w", fixture.ID, err)
+		}
+	}
+	if outcome.Terminal.Response.Content != fixture.WantContent {
+		return fmt.Errorf(
+			"fixture %q terminal content = %q, want %q",
+			fixture.ID,
+			outcome.Terminal.Response.Content,
+			fixture.WantContent,
+		)
+	}
+	apiInvocation := apisurface.InvocationResponseFromResult(outcome.InvocationResult)
+	if apiInvocation.Status == "" {
+		return fmt.Errorf("fixture %q API invocation projection missing status", fixture.ID)
+	}
+	if err := AssertPrimaryStreamModeParity(outcome); err != nil {
+		return fmt.Errorf("fixture %q mode parity: %w", fixture.ID, err)
+	}
+	modeOutcome, err := RunModeParity(outcome)
+	if err != nil {
+		return fmt.Errorf("fixture %q mode projection: %w", fixture.ID, err)
+	}
+	if modeOutcome.PrimaryOnlyInvocation.Status == "" {
+		return fmt.Errorf("fixture %q primary-only invocation missing status", fixture.ID)
+	}
+	if modeOutcome.StreamInvocation.Status == "" {
+		return fmt.Errorf("fixture %q response-stream invocation missing status", fixture.ID)
+	}
+	return nil
+}
+
+// AssertCrossProviderParityCatalog runs AssertCrossProviderParityForFixture for
+// every canonical catalog fixture.
+func AssertCrossProviderParityCatalog(ctx context.Context) error {
+	for _, fixture := range Catalog() {
+		if err := AssertCrossProviderParityForFixture(ctx, fixture); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/workers/provider/parityfixtures/suite_test.go
+++ b/pkg/workers/provider/parityfixtures/suite_test.go
@@ -1,0 +1,22 @@
+package parityfixtures_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/workers/provider/parityfixtures"
+)
+
+func TestCrossProviderParitySuite_Catalog(t *testing.T) {
+	t.Parallel()
+
+	for _, fixture := range parityfixtures.Catalog() {
+		fixture := fixture
+		t.Run(fixture.ID, func(t *testing.T) {
+			t.Parallel()
+			if err := parityfixtures.AssertCrossProviderParityForFixture(context.Background(), fixture); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/pkg/workers/provider/parityfixtures/testdata/agy_final_only.txt
+++ b/pkg/workers/provider/parityfixtures/testdata/agy_final_only.txt
@@ -1,0 +1,1 @@
+Parity agy complete response

--- a/pkg/workers/provider/parityfixtures/testdata/final_only_opencode.txt
+++ b/pkg/workers/provider/parityfixtures/testdata/final_only_opencode.txt
@@ -1,0 +1,1 @@
+Parity final-only answer

--- a/pkg/workers/provider/parityfixtures/testdata/full_stream_claude.jsonl
+++ b/pkg/workers/provider/parityfixtures/testdata/full_stream_claude.jsonl
@@ -1,0 +1,9 @@
+{"type":"system","subtype":"init","session_id":"parity-claude-session"}
+{"type":"stream_event","session_id":"parity-claude-session","event":{"type":"message_start","message":{"id":"parity-msg-full","role":"assistant","content":[]}}}
+{"type":"stream_event","session_id":"parity-claude-session","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}}
+{"type":"stream_event","session_id":"parity-claude-session","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Parity "}}}
+{"type":"stream_event","session_id":"parity-claude-session","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello "}}}
+{"type":"stream_event","session_id":"parity-claude-session","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"world"}}}
+{"type":"stream_event","session_id":"parity-claude-session","event":{"type":"message_stop"}}
+{"type":"assistant","session_id":"parity-claude-session","message":{"id":"parity-msg-full","role":"assistant","content":[{"type":"text","text":"Parity hello world"}]}}
+{"type":"result","subtype":"success","is_error":false,"result":"Parity hello world","session_id":"parity-claude-session"}

--- a/pkg/workers/provider/parityfixtures/testdata/partial_stream_codex.jsonl
+++ b/pkg/workers/provider/parityfixtures/testdata/partial_stream_codex.jsonl
@@ -1,0 +1,4 @@
+{"type":"thread.started","thread_id":"parity-codex-thread"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"parity-msg-1","type":"agent_message","text":"Parity codex answer"}}
+{"type":"turn.completed","usage":{"input_tokens":4,"output_tokens":2}}

--- a/pkg/workers/provider/parityfixtures/testdata/snapshot_only_opencode.jsonl
+++ b/pkg/workers/provider/parityfixtures/testdata/snapshot_only_opencode.jsonl
@@ -1,0 +1,3 @@
+{"type":"step_start","timestamp":1783962000000,"sessionID":"parity-opencode-session","part":{"id":"step_parity","sessionID":"parity-opencode-session","messageID":"msg_parity","type":"step-start"}}
+{"type":"text","timestamp":1783962000002,"sessionID":"parity-opencode-session","part":{"id":"part_text_parity","sessionID":"parity-opencode-session","messageID":"msg_parity","type":"text","text":"Parity snapshot answer","time":{"start":1783962000001,"end":1783962000002}}}
+{"type":"step_finish","timestamp":1783962000005,"sessionID":"parity-opencode-session","part":{"id":"step_parity","sessionID":"parity-opencode-session","messageID":"msg_parity","type":"step-finish","tokens":{"input":12,"output":7},"reason":"stop"}}

--- a/pkg/workers/provider/parityfixtures/testdata/tool_lifecycle_claude.jsonl
+++ b/pkg/workers/provider/parityfixtures/testdata/tool_lifecycle_claude.jsonl
@@ -1,0 +1,13 @@
+{"type":"system","subtype":"init","session_id":"parity-claude-tools"}
+{"type":"stream_event","session_id":"parity-claude-tools","event":{"type":"message_start","message":{"id":"parity-msg-tool","role":"assistant","content":[]}}}
+{"type":"stream_event","session_id":"parity-claude-tools","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}}
+{"type":"stream_event","session_id":"parity-claude-tools","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Parity tool "}}}
+{"type":"stream_event","session_id":"parity-claude-tools","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"lifecycle "}}}
+{"type":"stream_event","session_id":"parity-claude-tools","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"complete"}}}
+{"type":"stream_event","session_id":"parity-claude-tools","event":{"type":"message_stop"}}
+{"type":"stream_event","session_id":"parity-claude-tools","event":{"type":"message_start","message":{"id":"parity-msg-tool-block","role":"assistant","content":[]}}}
+{"type":"stream_event","session_id":"parity-claude-tools","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_parity","name":"lookup","input":{}}}}
+{"type":"stream_event","session_id":"parity-claude-tools","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"topic\":\"parity\"}"}}}
+{"type":"stream_event","session_id":"parity-claude-tools","event":{"type":"content_block_stop","index":0}}
+{"type":"assistant","session_id":"parity-claude-tools","message":{"id":"parity-msg-tool","role":"assistant","content":[{"type":"text","text":"Parity tool lifecycle complete"}]}}
+{"type":"result","subtype":"success","is_error":false,"result":"Parity tool lifecycle complete","session_id":"parity-claude-tools"}

--- a/pkg/workers/provider/parityfixtures/transport.go
+++ b/pkg/workers/provider/parityfixtures/transport.go
@@ -203,44 +203,87 @@ func DecodeTransportSSEFrame(frame string) (responseevents.FactoryResponseEvent,
 // AssertObservableToolLifecycle verifies published response events include a
 // correlated tool start and completion with stable tool identity fields.
 func AssertObservableToolLifecycle(events []responseevents.FactoryResponseEvent) error {
-	var started, completed bool
-	var toolCallID, toolName string
+	var tracker toolLifecycleTracker
 	for _, event := range events {
-		if event.Kind != responseevents.KindTool {
-			continue
-		}
-		switch event.Phase {
-		case responseevents.PhaseStarted:
-			var payload responseevents.ToolPayload
-			if err := json.Unmarshal(event.Payload, &payload); err != nil {
-				return fmt.Errorf("decode tool started payload: %w", err)
-			}
-			if payload.ToolCallID == "" || payload.ToolName == "" {
-				return fmt.Errorf("tool started missing identity: %#v", payload)
-			}
-			if toolCallID == "" {
-				toolCallID = payload.ToolCallID
-				toolName = payload.ToolName
-			} else if payload.ToolCallID != toolCallID || payload.ToolName != toolName {
-				return fmt.Errorf("tool started identity drift: %#v", payload)
-			}
-			started = true
-		case responseevents.PhaseCompleted:
-			var payload responseevents.ToolPayload
-			if err := json.Unmarshal(event.Payload, &payload); err != nil {
-				return fmt.Errorf("decode tool completed payload: %w", err)
-			}
-			if payload.ToolCallID == "" || payload.ToolName == "" {
-				return fmt.Errorf("tool completed missing identity: %#v", payload)
-			}
-			if toolCallID != "" && (payload.ToolCallID != toolCallID || payload.ToolName != toolName) {
-				return fmt.Errorf("tool completed identity mismatch: %#v", payload)
-			}
-			completed = true
+		if err := tracker.observe(event); err != nil {
+			return err
 		}
 	}
-	if !started || !completed {
-		return fmt.Errorf("tool lifecycle events = started %t completed %t, want both", started, completed)
+	return tracker.finalize()
+}
+
+type toolLifecycleTracker struct {
+	started    bool
+	completed  bool
+	toolCallID string
+	toolName   string
+}
+
+func (t *toolLifecycleTracker) observe(event responseevents.FactoryResponseEvent) error {
+	if event.Kind != responseevents.KindTool {
+		return nil
+	}
+	switch event.Phase {
+	case responseevents.PhaseStarted:
+		return t.observeStarted(event)
+	case responseevents.PhaseCompleted:
+		return t.observeCompleted(event)
+	default:
+		return nil
+	}
+}
+
+func (t *toolLifecycleTracker) finalize() error {
+	if !t.started || !t.completed {
+		return fmt.Errorf("tool lifecycle events = started %t completed %t, want both", t.started, t.completed)
+	}
+	return nil
+}
+
+func (t *toolLifecycleTracker) observeStarted(event responseevents.FactoryResponseEvent) error {
+	payload, err := decodeToolPayload(event, "started")
+	if err != nil {
+		return err
+	}
+	if err := requireToolIdentity(payload, "started"); err != nil {
+		return err
+	}
+	if t.toolCallID == "" {
+		t.toolCallID = payload.ToolCallID
+		t.toolName = payload.ToolName
+	} else if payload.ToolCallID != t.toolCallID || payload.ToolName != t.toolName {
+		return fmt.Errorf("tool started identity drift: %#v", payload)
+	}
+	t.started = true
+	return nil
+}
+
+func (t *toolLifecycleTracker) observeCompleted(event responseevents.FactoryResponseEvent) error {
+	payload, err := decodeToolPayload(event, "completed")
+	if err != nil {
+		return err
+	}
+	if err := requireToolIdentity(payload, "completed"); err != nil {
+		return err
+	}
+	if t.toolCallID != "" && (payload.ToolCallID != t.toolCallID || payload.ToolName != t.toolName) {
+		return fmt.Errorf("tool completed identity mismatch: %#v", payload)
+	}
+	t.completed = true
+	return nil
+}
+
+func decodeToolPayload(event responseevents.FactoryResponseEvent, label string) (responseevents.ToolPayload, error) {
+	var payload responseevents.ToolPayload
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		return payload, fmt.Errorf("decode tool %s payload: %w", label, err)
+	}
+	return payload, nil
+}
+
+func requireToolIdentity(payload responseevents.ToolPayload, label string) error {
+	if payload.ToolCallID == "" || payload.ToolName == "" {
+		return fmt.Errorf("tool %s missing identity: %#v", label, payload)
 	}
 	return nil
 }

--- a/pkg/workers/provider/parityfixtures/transport.go
+++ b/pkg/workers/provider/parityfixtures/transport.go
@@ -1,0 +1,380 @@
+package parityfixtures
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/portpowered/infinite-you/pkg/factory/sessions/responseevents"
+	"github.com/portpowered/infinite-you/pkg/factory/sessions/responseeventstore"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	apisurface "github.com/portpowered/infinite-you/pkg/transports/mapping"
+)
+
+const parityTransportSessionID = "session-parity-transport"
+
+const (
+	transportJSONRecordResponseEvent    = "response_event"
+	transportJSONRecordInvocationResult = "invocation_result"
+)
+
+// TransportParityOutcome is one fixture run with published response events and
+// the terminal invocation result used for CLI/API transport parity proofs.
+type TransportParityOutcome struct {
+	Events           []responseevents.FactoryResponseEvent
+	Terminal         TerminalResult
+	InvocationResult interfaces.FactoryInvocationResult
+}
+
+// RunTransportParity executes one fixture, publishes adapter drafts through the
+// session response-event store, and returns transport-neutral parity inputs.
+func RunTransportParity(ctx context.Context, fixture Fixture) (TransportParityOutcome, error) {
+	terminal, err := RunTerminal(ctx, fixture)
+	if err != nil {
+		return TransportParityOutcome{}, err
+	}
+	store := responseeventstore.NewSessionResponseEventStore(parityTransportSessionID)
+	events, err := publishDrafts(store, terminal.Drafts)
+	if err != nil {
+		return TransportParityOutcome{}, fmt.Errorf("publish fixture %q drafts: %w", fixture.ID, err)
+	}
+	return TransportParityOutcome{
+		Events:           events,
+		Terminal:         terminal,
+		InvocationResult: invocationResultFromTerminal(fixture, terminal),
+	}, nil
+}
+
+// AssertCLIAPITransportParity proves decoded CLI NDJSON and API SSE transports
+// agree on FactoryResponseEvent values and terminal InvocationResponse outcomes.
+func AssertCLIAPITransportParity(outcome TransportParityOutcome) error {
+	if len(outcome.Events) == 0 {
+		return fmt.Errorf("fixture produced no publishable response events")
+	}
+	apiRecords, err := EncodeTransportAPIRecords(outcome.Events)
+	if err != nil {
+		return fmt.Errorf("encode API records: %w", err)
+	}
+	cliLines, err := EncodeTransportCLINDJSON(outcome.Events, outcome.InvocationResult)
+	if err != nil {
+		return fmt.Errorf("encode CLI NDJSON: %w", err)
+	}
+	apiEvents, err := DecodeTransportAPIRecords(apiRecords)
+	if err != nil {
+		return fmt.Errorf("decode API records: %w", err)
+	}
+	cliEvents, cliInvocation, err := DecodeTransportCLINDJSON(cliLines)
+	if err != nil {
+		return fmt.Errorf("decode CLI NDJSON: %w", err)
+	}
+	if err := assertEventSequencesEqual(apiEvents, cliEvents); err != nil {
+		return fmt.Errorf("response-event transport parity: %w", err)
+	}
+	apiInvocation := apisurface.InvocationResponseFromResult(outcome.InvocationResult)
+	if !reflect.DeepEqual(cliInvocation, apiInvocation) {
+		return fmt.Errorf("invocation transport parity: CLI = %#v, API = %#v", cliInvocation, apiInvocation)
+	}
+	return nil
+}
+
+// EncodeTransportAPIRecords serializes events the same way runtime SSE consumers
+// receive them through FactoryResponseEventRecord payloads.
+func EncodeTransportAPIRecords(events []responseevents.FactoryResponseEvent) ([]apisurface.FactoryResponseEventRecord, error) {
+	records := make([]apisurface.FactoryResponseEventRecord, 0, len(events))
+	for _, event := range events {
+		data, err := json.Marshal(event)
+		if err != nil {
+			return nil, fmt.Errorf("marshal response event sequence %d: %w", event.Sequence, err)
+		}
+		records = append(records, apisurface.FactoryResponseEventRecord{
+			Sequence: event.Sequence,
+			Kind:     string(event.Kind),
+			Data:     data,
+		})
+	}
+	return records, nil
+}
+
+// DecodeTransportAPIRecords decodes API SSE data payloads back to response events.
+func DecodeTransportAPIRecords(records []apisurface.FactoryResponseEventRecord) ([]responseevents.FactoryResponseEvent, error) {
+	decoded := make([]responseevents.FactoryResponseEvent, 0, len(records))
+	for _, record := range records {
+		var event responseevents.FactoryResponseEvent
+		if err := json.Unmarshal(record.Data, &event); err != nil {
+			return nil, fmt.Errorf("decode API record sequence %d: %w", record.Sequence, err)
+		}
+		if err := responseevents.ValidateEvent(event); err != nil {
+			return nil, fmt.Errorf("validate API record sequence %d: %w", record.Sequence, err)
+		}
+		decoded = append(decoded, event)
+	}
+	return decoded, nil
+}
+
+// EncodeTransportCLINDJSON serializes response events and the terminal invocation
+// result using the CLI response-stream NDJSON record envelope.
+func EncodeTransportCLINDJSON(
+	events []responseevents.FactoryResponseEvent,
+	invocation interfaces.FactoryInvocationResult,
+) ([]string, error) {
+	lines := make([]string, 0, len(events)+1)
+	for _, event := range events {
+		encoded, err := json.Marshal(transportCLIResponseEventRecord{
+			RecordType: transportJSONRecordResponseEvent,
+			Event:      event,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("marshal CLI response_event sequence %d: %w", event.Sequence, err)
+		}
+		lines = append(lines, string(encoded))
+	}
+	finalEncoded, err := json.Marshal(transportCLIInvocationResultRecord{
+		RecordType: transportJSONRecordInvocationResult,
+		Invocation: apisurface.InvocationResponseFromResult(invocation),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal CLI invocation_result: %w", err)
+	}
+	lines = append(lines, string(finalEncoded))
+	return lines, nil
+}
+
+// DecodeTransportCLINDJSON decodes CLI response-stream NDJSON records.
+func DecodeTransportCLINDJSON(lines []string) ([]responseevents.FactoryResponseEvent, factoryapi.InvocationResponse, error) {
+	if len(lines) == 0 {
+		return nil, factoryapi.InvocationResponse{}, fmt.Errorf("CLI NDJSON is empty")
+	}
+	events := make([]responseevents.FactoryResponseEvent, 0, len(lines)-1)
+	for index, line := range lines[:len(lines)-1] {
+		var record transportCLIResponseEventRecord
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			return nil, factoryapi.InvocationResponse{}, fmt.Errorf("decode CLI response_event line %d: %w", index, err)
+		}
+		if record.RecordType != transportJSONRecordResponseEvent {
+			return nil, factoryapi.InvocationResponse{}, fmt.Errorf("CLI line %d recordType = %q, want %q", index, record.RecordType, transportJSONRecordResponseEvent)
+		}
+		if err := responseevents.ValidateEvent(record.Event); err != nil {
+			return nil, factoryapi.InvocationResponse{}, fmt.Errorf("validate CLI response_event line %d: %w", index, err)
+		}
+		events = append(events, record.Event)
+	}
+	var finalRecord transportCLIInvocationResultRecord
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &finalRecord); err != nil {
+		return nil, factoryapi.InvocationResponse{}, fmt.Errorf("decode CLI invocation_result: %w", err)
+	}
+	if finalRecord.RecordType != transportJSONRecordInvocationResult {
+		return nil, factoryapi.InvocationResponse{}, fmt.Errorf("final CLI recordType = %q, want %q", finalRecord.RecordType, transportJSONRecordInvocationResult)
+	}
+	return events, finalRecord.Invocation, nil
+}
+
+// EncodeTransportSSEFrame serializes one event using the HTTP SSE wire format.
+func EncodeTransportSSEFrame(event responseevents.FactoryResponseEvent) (string, error) {
+	data, err := json.Marshal(event)
+	if err != nil {
+		return "", fmt.Errorf("marshal SSE event: %w", err)
+	}
+	return fmt.Sprintf("id: %s\ndata: %s\n\n", strconv.FormatInt(event.Sequence, 10), data), nil
+}
+
+// DecodeTransportSSEFrame decodes one HTTP SSE response-event frame.
+func DecodeTransportSSEFrame(frame string) (responseevents.FactoryResponseEvent, error) {
+	idLine, dataLine, err := parseSSEFrame(frame)
+	if err != nil {
+		return responseevents.FactoryResponseEvent{}, err
+	}
+	var event responseevents.FactoryResponseEvent
+	if err := json.Unmarshal([]byte(dataLine), &event); err != nil {
+		return responseevents.FactoryResponseEvent{}, fmt.Errorf("decode SSE data: %w", err)
+	}
+	if idLine != strconv.FormatInt(event.Sequence, 10) {
+		return responseevents.FactoryResponseEvent{}, fmt.Errorf("SSE id = %q, want sequence %d", idLine, event.Sequence)
+	}
+	if err := responseevents.ValidateEvent(event); err != nil {
+		return responseevents.FactoryResponseEvent{}, fmt.Errorf("validate SSE event: %w", err)
+	}
+	return event, nil
+}
+
+// AssertTruthfulStreamingFidelity verifies adapter events claim only the fixture
+// fidelity class's truthful streaming capabilities.
+func AssertTruthfulStreamingFidelity(fixture Fixture, outcome TransportParityOutcome) error {
+	switch fixture.FidelityClass {
+	case FidelityFullStream:
+		return assertFullStreamFidelity(outcome)
+	case FidelityPartialStream:
+		return assertPartialStreamFidelity(outcome)
+	default:
+		return nil
+	}
+}
+
+func publishDrafts(
+	store *responseeventstore.SessionResponseEventStore,
+	drafts []responseevents.Draft,
+) ([]responseevents.FactoryResponseEvent, error) {
+	published := make([]responseevents.FactoryResponseEvent, 0, len(drafts))
+	for index, draft := range drafts {
+		if err := responseevents.ValidateDraft(draft); err != nil {
+			return nil, fmt.Errorf("draft[%d]: %w", index, err)
+		}
+		stored, err := store.Publish(responseevents.FactoryResponseEvent{
+			RunID:              draft.RunID,
+			Kind:               draft.Kind,
+			Phase:              draft.Phase,
+			Provenance:         draft.Provenance,
+			Payload:            append([]byte(nil), draft.Payload...),
+			DispatchID:         draft.DispatchID,
+			TurnID:             draft.TurnID,
+			ItemID:             draft.ItemID,
+			ParentItemID:       draft.ParentItemID,
+			ProviderSessionRef: draft.ProviderSessionRef,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("publish draft[%d]: %w", index, err)
+		}
+		published = append(published, stored)
+	}
+	return published, nil
+}
+
+func invocationResultFromTerminal(fixture Fixture, terminal TerminalResult) interfaces.FactoryInvocationResult {
+	return interfaces.FactoryInvocationResult{
+		RequestID: "req-parity-" + fixture.ID,
+		TraceID:   "trace-parity-" + fixture.ID,
+		Status:    factoryapi.InvocationTerminalStatusCompleted,
+		PrimaryResult: []interfaces.WorkContentPart{
+			{Type: interfaces.WorkContentPartTypeText, Text: terminal.Response.Content},
+		},
+		SessionID: parityTransportSessionID,
+	}
+}
+
+func assertEventSequencesEqual(left, right []responseevents.FactoryResponseEvent) error {
+	if len(left) != len(right) {
+		return fmt.Errorf("event count = %d, want %d", len(left), len(right))
+	}
+	for index := range left {
+		if err := assertEventsConsumerParityEqual(left[index], right[index]); err != nil {
+			return fmt.Errorf("event[%d]: %w", index, err)
+		}
+	}
+	return nil
+}
+
+func assertEventsConsumerParityEqual(want, got responseevents.FactoryResponseEvent) error {
+	if !jsonValuesEqual(want.Payload, got.Payload) {
+		return fmt.Errorf("payload mismatch:\nwant=%s\ngot=%s", want.Payload, got.Payload)
+	}
+	want.Payload = nil
+	got.Payload = nil
+	if !reflect.DeepEqual(want, got) {
+		return fmt.Errorf("envelope mismatch:\nwant=%#v\ngot=%#v", want, got)
+	}
+	return nil
+}
+
+func jsonValuesEqual(left, right json.RawMessage) bool {
+	if len(left) == 0 && len(right) == 0 {
+		return true
+	}
+	var leftValue any
+	var rightValue any
+	if err := json.Unmarshal(left, &leftValue); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(right, &rightValue); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(leftValue, rightValue)
+}
+
+func assertFullStreamFidelity(outcome TransportParityOutcome) error {
+	capabilities := outcome.Terminal.Capabilities
+	if !capabilities.NativeStreaming || !capabilities.MessageDeltas {
+		return fmt.Errorf("capabilities = %#v, want native streaming with message deltas", capabilities)
+	}
+	if capabilities.FinalOnly {
+		return fmt.Errorf("full-stream adapter must not claim final-only capabilities")
+	}
+	var messageDeltaCount int
+	for _, event := range outcome.Events {
+		if event.Kind != responseevents.KindMessage || event.Phase != responseevents.PhaseDelta {
+			continue
+		}
+		messageDeltaCount++
+		if event.Provenance.Fidelity == responseevents.FidelityFinalOnly {
+			return fmt.Errorf("message delta claims final-only fidelity: %#v", event)
+		}
+		if event.Provenance.Delivery != responseevents.DeliveryNativeStream {
+			return fmt.Errorf("message delta delivery = %q, want native stream", event.Provenance.Delivery)
+		}
+	}
+	if messageDeltaCount == 0 {
+		return fmt.Errorf("full-stream fixture produced no message delta events")
+	}
+	return nil
+}
+
+func assertPartialStreamFidelity(outcome TransportParityOutcome) error {
+	capabilities := outcome.Terminal.Capabilities
+	if !capabilities.NativeStreaming || capabilities.MessageDeltas {
+		return fmt.Errorf("capabilities = %#v, want native streaming without message deltas", capabilities)
+	}
+	if capabilities.FinalOnly {
+		return fmt.Errorf("partial-stream adapter must not claim final-only capabilities")
+	}
+	var messageSnapshotCount int
+	for _, event := range outcome.Events {
+		if event.Kind != responseevents.KindMessage {
+			continue
+		}
+		switch event.Phase {
+		case responseevents.PhaseDelta:
+			return fmt.Errorf("partial-stream fixture emitted message delta: %#v", event)
+		case responseevents.PhaseCompleted:
+			messageSnapshotCount++
+			if event.Provenance.Fidelity == responseevents.FidelityFinalOnly {
+				return fmt.Errorf("message snapshot claims final-only fidelity: %#v", event)
+			}
+		}
+	}
+	if messageSnapshotCount == 0 {
+		return fmt.Errorf("partial-stream fixture produced no completed message snapshots")
+	}
+	return nil
+}
+
+func parseSSEFrame(frame string) (idLine, dataLine string, err error) {
+	for _, line := range strings.Split(frame, "\n") {
+		line = strings.TrimRight(line, "\r")
+		switch {
+		case line == "":
+			continue
+		case strings.HasPrefix(line, "id: "):
+			idLine = strings.TrimPrefix(line, "id: ")
+		case strings.HasPrefix(line, "data: "):
+			dataLine = strings.TrimPrefix(line, "data: ")
+		default:
+			return "", "", fmt.Errorf("unexpected SSE line %q", line)
+		}
+	}
+	if idLine == "" || dataLine == "" {
+		return "", "", fmt.Errorf("SSE frame id=%q data=%q, want exactly one of each", idLine, dataLine)
+	}
+	return idLine, dataLine, nil
+}
+
+type transportCLIResponseEventRecord struct {
+	RecordType string                              `json:"recordType"`
+	Event      responseevents.FactoryResponseEvent `json:"event"`
+}
+
+type transportCLIInvocationResultRecord struct {
+	RecordType string                        `json:"recordType"`
+	Invocation factoryapi.InvocationResponse `json:"invocation"`
+}

--- a/pkg/workers/provider/parityfixtures/transport.go
+++ b/pkg/workers/provider/parityfixtures/transport.go
@@ -200,6 +200,51 @@ func DecodeTransportSSEFrame(frame string) (responseevents.FactoryResponseEvent,
 	return event, nil
 }
 
+// AssertObservableToolLifecycle verifies published response events include a
+// correlated tool start and completion with stable tool identity fields.
+func AssertObservableToolLifecycle(events []responseevents.FactoryResponseEvent) error {
+	var started, completed bool
+	var toolCallID, toolName string
+	for _, event := range events {
+		if event.Kind != responseevents.KindTool {
+			continue
+		}
+		switch event.Phase {
+		case responseevents.PhaseStarted:
+			var payload responseevents.ToolPayload
+			if err := json.Unmarshal(event.Payload, &payload); err != nil {
+				return fmt.Errorf("decode tool started payload: %w", err)
+			}
+			if payload.ToolCallID == "" || payload.ToolName == "" {
+				return fmt.Errorf("tool started missing identity: %#v", payload)
+			}
+			if toolCallID == "" {
+				toolCallID = payload.ToolCallID
+				toolName = payload.ToolName
+			} else if payload.ToolCallID != toolCallID || payload.ToolName != toolName {
+				return fmt.Errorf("tool started identity drift: %#v", payload)
+			}
+			started = true
+		case responseevents.PhaseCompleted:
+			var payload responseevents.ToolPayload
+			if err := json.Unmarshal(event.Payload, &payload); err != nil {
+				return fmt.Errorf("decode tool completed payload: %w", err)
+			}
+			if payload.ToolCallID == "" || payload.ToolName == "" {
+				return fmt.Errorf("tool completed missing identity: %#v", payload)
+			}
+			if toolCallID != "" && (payload.ToolCallID != toolCallID || payload.ToolName != toolName) {
+				return fmt.Errorf("tool completed identity mismatch: %#v", payload)
+			}
+			completed = true
+		}
+	}
+	if !started || !completed {
+		return fmt.Errorf("tool lifecycle events = started %t completed %t, want both", started, completed)
+	}
+	return nil
+}
+
 // AssertTruthfulStreamingFidelity verifies adapter events claim only the fixture
 // fidelity class's truthful streaming capabilities.
 func AssertTruthfulStreamingFidelity(fixture Fixture, outcome TransportParityOutcome) error {

--- a/pkg/workers/provider/parityfixtures/transport.go
+++ b/pkg/workers/provider/parityfixtures/transport.go
@@ -208,8 +208,12 @@ func AssertTruthfulStreamingFidelity(fixture Fixture, outcome TransportParityOut
 		return assertFullStreamFidelity(outcome)
 	case FidelityPartialStream:
 		return assertPartialStreamFidelity(outcome)
+	case FidelitySnapshotOnly:
+		return assertSnapshotOnlyFidelity(outcome)
+	case FidelityFinalOnly:
+		return assertFinalOnlyFidelity(outcome)
 	default:
-		return nil
+		return fmt.Errorf("unsupported fidelity class %q", fixture.FidelityClass)
 	}
 }
 
@@ -316,6 +320,67 @@ func assertFullStreamFidelity(outcome TransportParityOutcome) error {
 	}
 	if messageDeltaCount == 0 {
 		return fmt.Errorf("full-stream fixture produced no message delta events")
+	}
+	return nil
+}
+
+func assertSnapshotOnlyFidelity(outcome TransportParityOutcome) error {
+	capabilities := outcome.Terminal.Capabilities
+	if !capabilities.NativeStreaming || !capabilities.MessageSnapshots {
+		return fmt.Errorf("capabilities = %#v, want native streaming with message snapshots", capabilities)
+	}
+	if capabilities.MessageDeltas {
+		return fmt.Errorf("snapshot-only adapter must not claim message deltas")
+	}
+	if capabilities.FinalOnly {
+		return fmt.Errorf("snapshot-only adapter must not claim final-only capabilities")
+	}
+	var messageSnapshotCount int
+	for _, event := range outcome.Events {
+		if event.Kind != responseevents.KindMessage {
+			continue
+		}
+		switch event.Phase {
+		case responseevents.PhaseDelta:
+			return fmt.Errorf("snapshot-only fixture emitted message delta: %#v", event)
+		case responseevents.PhaseCompleted:
+			messageSnapshotCount++
+			if event.Provenance.Fidelity == responseevents.FidelityFinalOnly {
+				return fmt.Errorf("message snapshot claims final-only fidelity: %#v", event)
+			}
+		}
+	}
+	if messageSnapshotCount == 0 {
+		return fmt.Errorf("snapshot-only fixture produced no completed message snapshots")
+	}
+	return nil
+}
+
+func assertFinalOnlyFidelity(outcome TransportParityOutcome) error {
+	capabilities := outcome.Terminal.Capabilities
+	if capabilities.NativeStreaming || capabilities.MessageDeltas || !capabilities.MessageSnapshots || !capabilities.FinalOnly {
+		return fmt.Errorf("capabilities = %#v, want final-only without native streaming", capabilities)
+	}
+	var messageFinalCount int
+	for _, event := range outcome.Events {
+		if event.Kind != responseevents.KindMessage {
+			continue
+		}
+		switch event.Phase {
+		case responseevents.PhaseDelta:
+			return fmt.Errorf("final-only fixture emitted message delta: %#v", event)
+		case responseevents.PhaseCompleted:
+			messageFinalCount++
+			if event.Provenance.Fidelity != responseevents.FidelityFinalOnly {
+				return fmt.Errorf("completed message fidelity = %q, want %q: %#v", event.Provenance.Fidelity, responseevents.FidelityFinalOnly, event)
+			}
+			if event.Provenance.Delivery != responseevents.DeliveryNativeFinal {
+				return fmt.Errorf("completed message delivery = %q, want %q: %#v", event.Provenance.Delivery, responseevents.DeliveryNativeFinal, event)
+			}
+		}
+	}
+	if messageFinalCount == 0 {
+		return fmt.Errorf("final-only fixture produced no completed message events")
 	}
 	return nil
 }

--- a/pkg/workers/provider/parityfixtures/transport_parity_test.go
+++ b/pkg/workers/provider/parityfixtures/transport_parity_test.go
@@ -34,6 +34,11 @@ func TestTransportParity_AgyFinalOnlyCLIAndAPIAgree(t *testing.T) {
 	assertTransportParityForFixture(t, parityfixtures.FixtureAgyFinalOnly)
 }
 
+func TestTransportParity_ToolLifecycleCLIAndAPIAgree(t *testing.T) {
+	t.Parallel()
+	assertTransportParityForFixture(t, parityfixtures.FixtureToolLifecycleClaude)
+}
+
 func TestTransportParity_SSEFramesMatchAPIRecordDecoding(t *testing.T) {
 	t.Parallel()
 
@@ -84,6 +89,11 @@ func assertTransportParityForFixture(t *testing.T, fixtureID string) {
 	}
 	if err := parityfixtures.AssertCLIAPITransportParity(outcome); err != nil {
 		t.Fatalf("AssertCLIAPITransportParity(%q) error = %v", fixtureID, err)
+	}
+	if fixture.ToolLifecycle {
+		if err := parityfixtures.AssertObservableToolLifecycle(outcome.Events); err != nil {
+			t.Fatalf("AssertObservableToolLifecycle(%q) error = %v", fixtureID, err)
+		}
 	}
 	if outcome.Terminal.Response.Content != fixture.WantContent {
 		t.Fatalf("terminal content = %q, want %q", outcome.Terminal.Response.Content, fixture.WantContent)

--- a/pkg/workers/provider/parityfixtures/transport_parity_test.go
+++ b/pkg/workers/provider/parityfixtures/transport_parity_test.go
@@ -1,0 +1,80 @@
+package parityfixtures_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	apisurface "github.com/portpowered/infinite-you/pkg/transports/mapping"
+	"github.com/portpowered/infinite-you/pkg/workers/provider/parityfixtures"
+)
+
+func TestTransportParity_FullStreamCLIAndAPIAgree(t *testing.T) {
+	t.Parallel()
+	assertTransportParityForFixture(t, parityfixtures.FixtureFullStreamClaude)
+}
+
+func TestTransportParity_PartialStreamCLIAndAPIAgree(t *testing.T) {
+	t.Parallel()
+	assertTransportParityForFixture(t, parityfixtures.FixturePartialStreamCodex)
+}
+
+func TestTransportParity_SSEFramesMatchAPIRecordDecoding(t *testing.T) {
+	t.Parallel()
+
+	fixture, ok := parityfixtures.FixtureByID(parityfixtures.FixtureFullStreamClaude)
+	if !ok {
+		t.Fatal("missing full-stream fixture")
+	}
+	outcome, err := parityfixtures.RunTransportParity(context.Background(), fixture)
+	if err != nil {
+		t.Fatalf("RunTransportParity() error = %v", err)
+	}
+	records, err := parityfixtures.EncodeTransportAPIRecords(outcome.Events)
+	if err != nil {
+		t.Fatalf("EncodeTransportAPIRecords() error = %v", err)
+	}
+	recordEvents, err := parityfixtures.DecodeTransportAPIRecords(records)
+	if err != nil {
+		t.Fatalf("DecodeTransportAPIRecords() error = %v", err)
+	}
+	for index, event := range outcome.Events {
+		frame, err := parityfixtures.EncodeTransportSSEFrame(event)
+		if err != nil {
+			t.Fatalf("EncodeTransportSSEFrame(event[%d]) error = %v", index, err)
+		}
+		decodedFrame, err := parityfixtures.DecodeTransportSSEFrame(frame)
+		if err != nil {
+			t.Fatalf("DecodeTransportSSEFrame(event[%d]) error = %v", index, err)
+		}
+		if !reflect.DeepEqual(decodedFrame, recordEvents[index]) {
+			t.Fatalf("SSE decode mismatch for event[%d]: frame=%#v record=%#v", index, decodedFrame, recordEvents[index])
+		}
+	}
+}
+
+func assertTransportParityForFixture(t *testing.T, fixtureID string) {
+	t.Helper()
+
+	fixture, ok := parityfixtures.FixtureByID(fixtureID)
+	if !ok {
+		t.Fatalf("unknown fixture %q", fixtureID)
+	}
+	outcome, err := parityfixtures.RunTransportParity(context.Background(), fixture)
+	if err != nil {
+		t.Fatalf("RunTransportParity(%q) error = %v", fixtureID, err)
+	}
+	if err := parityfixtures.AssertTruthfulStreamingFidelity(fixture, outcome); err != nil {
+		t.Fatalf("AssertTruthfulStreamingFidelity(%q) error = %v", fixtureID, err)
+	}
+	if err := parityfixtures.AssertCLIAPITransportParity(outcome); err != nil {
+		t.Fatalf("AssertCLIAPITransportParity(%q) error = %v", fixtureID, err)
+	}
+	if outcome.Terminal.Response.Content != fixture.WantContent {
+		t.Fatalf("terminal content = %q, want %q", outcome.Terminal.Response.Content, fixture.WantContent)
+	}
+	apiInvocation := apisurface.InvocationResponseFromResult(outcome.InvocationResult)
+	if apiInvocation.Status == "" {
+		t.Fatalf("API invocation projection missing status")
+	}
+}

--- a/pkg/workers/provider/parityfixtures/transport_parity_test.go
+++ b/pkg/workers/provider/parityfixtures/transport_parity_test.go
@@ -19,6 +19,21 @@ func TestTransportParity_PartialStreamCLIAndAPIAgree(t *testing.T) {
 	assertTransportParityForFixture(t, parityfixtures.FixturePartialStreamCodex)
 }
 
+func TestTransportParity_SnapshotOnlyCLIAndAPIAgree(t *testing.T) {
+	t.Parallel()
+	assertTransportParityForFixture(t, parityfixtures.FixtureSnapshotOnlyOpenCode)
+}
+
+func TestTransportParity_FinalOnlyOpenCodeCLIAndAPIAgree(t *testing.T) {
+	t.Parallel()
+	assertTransportParityForFixture(t, parityfixtures.FixtureFinalOnlyOpenCode)
+}
+
+func TestTransportParity_AgyFinalOnlyCLIAndAPIAgree(t *testing.T) {
+	t.Parallel()
+	assertTransportParityForFixture(t, parityfixtures.FixtureAgyFinalOnly)
+}
+
 func TestTransportParity_SSEFramesMatchAPIRecordDecoding(t *testing.T) {
 	t.Parallel()
 

--- a/tests/functional/providers/cross_provider_parity_smoke_test.go
+++ b/tests/functional/providers/cross_provider_parity_smoke_test.go
@@ -1,0 +1,16 @@
+package providers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/workers/provider/parityfixtures"
+)
+
+// TestCrossProviderParitySmoke_ProviderSuiteEntrypoint is the maintained provider
+// suite entrypoint for Batch 09 cross-provider CLI/API and mode parity proofs.
+func TestCrossProviderParitySmoke_ProviderSuiteEntrypoint(t *testing.T) {
+	if err := parityfixtures.AssertCrossProviderParityCatalog(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
{
  "project": "Prove Cross-Provider CLI, API, and Primary-Result Parity",
  "branchName": "stream-b09-cross-provider-parity",
  "description": "Prove cross-provider CLI, API, and primary-result parity: cover full-stream, partial-stream, snapshot-only, and final-only adapters end to end; compare decoded CLI NDJSON and API SSE FactoryResponseEvent values and final InvocationResponse outcomes; ensure every provider yields a terminal result with only its truthful fidelity; and prove primary-only and stream modes share equivalent finals using sanitized deterministic fixtures.",
  "context": {
    "customerAsk": "Prove cross-provider CLI, API, and primary-result parity. Cover full-stream, partial-stream, snapshot-only, and final-only adapters end to end. Compare decoded CLI NDJSON and API SSE FactoryResponseEvent values and final InvocationResponse outcomes. Every supported provider must yield a terminal invocation result and only its truthful fidelity. Primary-only and stream modes must have equivalent final outcomes. Use sanitized deterministic fixtures so live credentials are not required for blocking CI. Include one structured tool lifecycle and one Agy final-only run. Verify with make api-smoke, provider suites, response-stream race/stress, and make verify-pr when feasible. (Source: stream-response-fix-plan.md Story 24 / checklist S24.)",
    "problem": "Provider adapters publish through a shared FactoryResponseEvent vocabulary with different native fidelities (full stream, partial stream, snapshot-only, final-only). Without an end-to-end parity suite, CLI NDJSON and API SSE consumers can diverge on event shape, ordering, fidelity claims, or terminal InvocationResponse / primaryResult outcomes. Primary-only invocation mode can also disagree with stream mode on the final authoritative result. That gap blocks Batch 09 closeout: operators cannot trust that every supported provider finishes with a truthful terminal result across transports.",
    "solution": "Add sanitized, deterministic functional fixtures that drive full-stream, partial-stream, snapshot-only, and final-only adapters (including one structured tool lifecycle and one Agy final-only run), then assert CLI NDJSON and API SSE decode to equivalent FactoryResponseEvent sequences and equivalent final InvocationResponse outcomes. Prove each provider emits only its truthful fidelity, and that primary-only and stream modes agree on final outcomes. Keep the suite hermetic for blocking CI and wire it into the existing smoke, provider, race/stress, and PR verification lanes."
  },
  "acceptanceCriteria": [
    "Every covered provider fidelity class (full-stream, partial-stream, snapshot-only, final-only) completes with a terminal InvocationResponse on both CLI and API paths",
    "Decoded CLI NDJSON and API SSE FactoryResponseEvent values match for the same fixture run (kind, phase, provenance/fidelity, and payload semantics required for consumer parity)",
    "Each provider publishes only its truthful fidelity (no inflated native-stream claims for snapshot-only or final-only adapters; Agy remains final-only)",
    "Primary-only and stream invocation modes produce equivalent final InvocationResponse / primaryResult outcomes for the same fixture inputs",
    "Coverage includes one structured tool lifecycle run and one Agy final-only run using sanitized deterministic fixtures without live provider credentials in blocking CI",
    "Quality checks pass (typecheck, lint, tests)"
  ],
  "userStories": [
    {
      "id": "stream-b09-cross-provider-parity-001",
      "title": "Add sanitized fixtures for all provider fidelity classes",
      "description": "As a maintainer writing parity proofs, I want sanitized deterministic fixtures for full-stream, partial-stream, snapshot-only, and final-only adapters—including one structured tool lifecycle and one Agy final-only run—so blocking CI can drive end-to-end parity without live provider credentials.",
      "acceptanceCriteria": [
        "Deterministic fixtures exist for full-stream, partial-stream, snapshot-only, and final-only adapter behaviors and can be exercised without live provider credentials",
        "Fixture set includes at least one structured tool lifecycle scenario (tool start/progress/result or equivalent observable tool events) and one Agy final-only scenario",
        "Fixture outputs are sanitized (no secrets, tokens, or host-specific absolute paths required for assertions)",
        "Running each fixture produces a completable invocation that reaches a terminal outcome under the test harness",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "stream-b09-cross-provider-parity-002",
      "title": "Prove CLI/API parity for full-stream and partial-stream adapters",
      "description": "As a CLI or API consumer of native-stream providers, I want decoded CLI NDJSON and API SSE FactoryResponseEvent sequences plus final InvocationResponse outcomes to match for full-stream and partial-stream adapters so transport choice does not change observed stream semantics or terminal results.",
      "acceptanceCriteria": [
        "For a full-stream fixture, CLI NDJSON and API SSE decode to equivalent FactoryResponseEvent sequences (same kinds/phases and matching provenance fidelity/delivery semantics for consumer-visible fields)",
        "For a partial-stream fixture, CLI NDJSON and API SSE likewise decode to equivalent event sequences",
        "Both transports yield the same terminal InvocationResponse outcome for each fixture, including matching primaryResult when success policy selects one",
        "Events claim only truthful streaming fidelity for these adapters (no final-only downgrade masquerading as lossless native stream unless that degradation is the fixture’s explicit expected outcome)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "stream-b09-cross-provider-parity-003",
      "title": "Prove CLI/API parity for snapshot-only and final-only adapters including Agy",
      "description": "As a CLI or API consumer of lower-fidelity providers, I want snapshot-only and final-only adapters—including Agy—to publish only their truthful fidelity and to agree across CLI NDJSON and API SSE on events and terminal InvocationResponse outcomes.",
      "acceptanceCriteria": [
        "A snapshot-only fixture completes with terminal InvocationResponse on both CLI and API, and decoded NDJSON/SSE events agree",
        "An Agy final-only fixture completes with terminal InvocationResponse on both CLI and API, and decoded NDJSON/SSE events agree",
        "Snapshot-only and final-only runs advertise truthful fidelity only (FINAL_ONLY / non-native-stream capabilities as applicable); they do not claim lossless native streaming deltas they did not produce",
        "Final InvocationResponse / primaryResult values match between CLI and API for each fixture",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "stream-b09-cross-provider-parity-004",
      "title": "Prove structured tool lifecycle parity across CLI and API",
      "description": "As a stream consumer that tracks tool use, I want one structured tool lifecycle fixture to emit equivalent tool lifecycle FactoryResponseEvent values on CLI NDJSON and API SSE so tool start/update/result observation does not depend on transport.",
      "acceptanceCriteria": [
        "A structured tool lifecycle fixture emits observable tool-related response events on both CLI NDJSON and API SSE paths",
        "Decoded tool lifecycle events match across transports for consumer-visible fields (kind/phase, tool identity/status, and final tool outcome payload semantics)",
        "The fixture still reaches a terminal InvocationResponse, and CLI/API final outcomes match",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "stream-b09-cross-provider-parity-005",
      "title": "Prove primary-only and stream modes share final outcomes",
      "description": "As an operator choosing between primary-only and stream observation modes, I want both modes to produce equivalent final InvocationResponse / primaryResult outcomes for the same fixture inputs so enabling the response stream cannot change the authoritative result.",
      "acceptanceCriteria": [
        "For each covered fidelity class fixture (at least one streaming and one final-only/Agy), primary-only mode and stream mode produce equivalent terminal InvocationResponse status and primaryResult (or equivalently absent primary on non-success)",
        "Stream mode still delivers response events, but those events do not alter the authoritative final outcome relative to primary-only mode for the same input",
        "Assertions are deterministic and do not require live provider credentials",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "stream-b09-cross-provider-parity-006",
      "title": "Wire parity proofs into smoke, provider, and PR verification",
      "description": "As a maintainer closing Batch 09, I want the cross-provider parity proofs exercised by make api-smoke, provider suites, response-stream race/stress coverage, and make verify-pr when feasible so regressions cannot silently reopen the Story 24 gate.",
      "acceptanceCriteria": [
        "Parity coverage is reachable from the provider test suites used for adapter conformance (or an explicitly documented provider-suite entrypoint that CI/maintainers run for this lane)",
        "make api-smoke remains green with the new or extended parity/smoke paths that touch public CLI/API stream consumers",
        "Existing response-stream race/stress suites still pass; this lane does not regress backpressure or race proofs while adding parity coverage",
        "When feasible in the implementation environment, make verify-pr (or the narrowest documented PR verification tier that includes these suites) passes",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": ""
    }
  ]
}
