### PR TITLE
interfaces-b13-mcp-schema

### DIFF
--- a/contracts/mcp/protocol/call-tool-result.schema.json
+++ b/contracts/mcp/protocol/call-tool-result.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.portpowered.com/you/contracts/mcp/protocol/call-tool-result.schema.json",
+  "title": "MCP CallToolResult transport envelope",
+  "description": "Reusable MCP 2024-11-05 tools/call result envelope with pinned text-only catalog policy.",
+  "$defs": {
+    "callToolResult": {
+      "description": "The MCP tools/call result envelope across the documented protocol surface.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "content",
+        "isError"
+      ],
+      "properties": {
+        "content": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "https://schemas.portpowered.com/you/contracts/mcp/protocol/content.schema.json#/$defs/content"
+          }
+        },
+        "isError": {
+          "type": "boolean"
+        },
+        "structuredContent": true,
+        "outputSchema": true
+      }
+    },
+    "pinnedTextCallToolResult": {
+      "description": "Pinned catalog policy: text-only content, no structuredContent or outputSchema.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "content",
+        "isError"
+      ],
+      "properties": {
+        "content": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "https://schemas.portpowered.com/you/contracts/mcp/protocol/content.schema.json#/$defs/textContent"
+          }
+        },
+        "isError": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/contracts/mcp/protocol/content.schema.json
+++ b/contracts/mcp/protocol/content.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.portpowered.com/you/contracts/mcp/protocol/content.schema.json",
+  "title": "MCP protocol content items",
+  "description": "Reusable MCP 2024-11-05 content item shapes. Broader protocol kinds are documented for reference; the pinned tool-catalog result policy admits only text.",
+  "$defs": {
+    "textContent": {
+      "description": "Text content carried in one CallToolResult content item.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "text"
+      ],
+      "properties": {
+        "type": {
+          "const": "text"
+        },
+        "text": {
+          "type": "string"
+        }
+      }
+    },
+    "imageContent": {
+      "description": "Image content documented for the broader MCP protocol surface.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "data",
+        "mimeType"
+      ],
+      "properties": {
+        "type": {
+          "const": "image"
+        },
+        "data": {
+          "type": "string",
+          "minLength": 1
+        },
+        "mimeType": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "audioContent": {
+      "description": "Audio content documented for the broader MCP protocol surface.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "data",
+        "mimeType"
+      ],
+      "properties": {
+        "type": {
+          "const": "audio"
+        },
+        "data": {
+          "type": "string",
+          "minLength": 1
+        },
+        "mimeType": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "embeddedResourceContent": {
+      "description": "Embedded resource content documented for the broader MCP protocol surface.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "resource"
+      ],
+      "properties": {
+        "type": {
+          "const": "resource"
+        },
+        "resource": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "uri"
+          ],
+          "properties": {
+            "uri": {
+              "type": "string",
+              "minLength": 1
+            },
+            "mimeType": {
+              "type": "string",
+              "minLength": 1
+            },
+            "text": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "content": {
+      "description": "One MCP CallToolResult content item across the documented protocol surface.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/textContent"
+        },
+        {
+          "$ref": "#/$defs/imageContent"
+        },
+        {
+          "$ref": "#/$defs/audioContent"
+        },
+        {
+          "$ref": "#/$defs/embeddedResourceContent"
+        }
+      ]
+    }
+  }
+}

--- a/contracts/mcp/protocol/domain-tool-response.schema.json
+++ b/contracts/mcp/protocol/domain-tool-response.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.portpowered.com/you/contracts/mcp/protocol/domain-tool-response.schema.json",
+  "title": "MCP domain tool response payloads",
+  "description": "Typed domain success and failure payloads serialized into CallToolResult text content, distinct from the transport envelope and JSON-RPC protocol errors.",
+  "$defs": {
+    "domainErrorEnvelope": {
+      "description": "Typed tool/domain failure payload carried inside serialized tools/call text content.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "message",
+        "retryable"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        },
+        "retryable": {
+          "type": "boolean"
+        },
+        "sessionId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "details": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    },
+    "domainSuccessPayload": {
+      "description": "One domain success payload serialized into tools/call text content.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "result"
+      ],
+      "properties": {
+        "result": true
+      }
+    },
+    "domainFailurePayload": {
+      "description": "One domain/tool failure payload serialized into tools/call text content.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "error"
+      ],
+      "properties": {
+        "error": {
+          "$ref": "#/$defs/domainErrorEnvelope"
+        }
+      }
+    }
+  }
+}

--- a/contracts/mcp/protocol/json-rpc-error.schema.json
+++ b/contracts/mcp/protocol/json-rpc-error.schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.portpowered.com/you/contracts/mcp/protocol/json-rpc-error.schema.json",
+  "title": "MCP JSON-RPC protocol error responses",
+  "description": "JSON-RPC protocol failure documentation distinct from tools/call domain payloads and CallToolResult envelopes.",
+  "$defs": {
+    "jsonRpcErrorObject": {
+      "description": "One JSON-RPC error object returned outside CallToolResult payloads.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        },
+        "data": true
+      }
+    },
+    "jsonRpcErrorResponse": {
+      "description": "One top-level JSON-RPC error response for invalid params or unknown method failures.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "jsonrpc",
+        "id",
+        "error"
+      ],
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0"
+        },
+        "id": {
+          "type": [
+            "integer",
+            "string",
+            "null"
+          ]
+        },
+        "error": {
+          "$ref": "#/$defs/jsonRpcErrorObject"
+        }
+      },
+      "not": {
+        "required": [
+          "result"
+        ]
+      }
+    },
+    "protocolFailureExample": {
+      "description": "One documented JSON-RPC protocol failure distinct from tool domain failures.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "description",
+        "request",
+        "response"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "request": {
+          "description": "Representative JSON-RPC request that triggers the protocol failure.",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "jsonrpc",
+            "id",
+            "method"
+          ],
+          "properties": {
+            "jsonrpc": {
+              "const": "2.0"
+            },
+            "id": {
+              "type": [
+                "integer",
+                "string",
+                "null"
+              ]
+            },
+            "method": {
+              "type": "string",
+              "minLength": 1
+            },
+            "params": true
+          }
+        },
+        "response": {
+          "$ref": "#/$defs/jsonRpcErrorResponse"
+        }
+      }
+    }
+  }
+}

--- a/contracts/mcp/tool-catalog.schema.json
+++ b/contracts/mcp/tool-catalog.schema.json
@@ -361,6 +361,67 @@
         },
         "input": {
           "$ref": "#/$defs/toolInput"
+        },
+        "result": {
+          "$ref": "#/$defs/toolResult"
+        }
+      }
+    },
+    "toolResultTransport": {
+      "description": "Pinned tools/call transport policy for one tool under MCP 2024-11-05.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contentTypes",
+        "textEncoding",
+        "allowsStructuredContent",
+        "allowsOutputSchema"
+      ],
+      "properties": {
+        "contentTypes": {
+          "description": "Supported CallToolResult content kinds for this tool. The pinned initial cut admits only text.",
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "const": "text"
+          }
+        },
+        "textEncoding": {
+          "description": "How serialized tool payloads are encoded in text content items.",
+          "enum": [
+            "serialized-json",
+            "plain-text"
+          ]
+        },
+        "allowsStructuredContent": {
+          "const": false
+        },
+        "allowsOutputSchema": {
+          "const": false
+        }
+      }
+    },
+    "toolResult": {
+      "description": "Authored tools/call result transport policy and representative CallToolResult examples.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "transport",
+        "examples"
+      ],
+      "properties": {
+        "transport": {
+          "$ref": "#/$defs/toolResultTransport"
+        },
+        "examples": {
+          "description": "Representative pinned text-only CallToolResult envelopes for this tool.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "https://schemas.portpowered.com/you/contracts/mcp/protocol/call-tool-result.schema.json#/$defs/pinnedTextCallToolResult"
+          }
         }
       }
     }

--- a/contracts/mcp/tool-catalog.schema.json
+++ b/contracts/mcp/tool-catalog.schema.json
@@ -43,11 +43,274 @@
         }
       ]
     },
+    "argumentId": {
+      "description": "Stable MCP tool argument identity with the mcp.arg prefix.",
+      "allOf": [
+        {
+          "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"
+        },
+        {
+          "pattern": "^mcp[.]arg[.].+"
+        }
+      ]
+    },
     "canonicalToolName": {
       "description": "The canonical MCP protocol tool name exposed to clients.",
       "type": "string",
       "minLength": 1,
       "pattern": "^you[.][a-z0-9_]+(?:[.][a-z0-9_]+)*$"
+    },
+    "transport": {
+      "description": "One supported MCP transport surface for tool discovery and invocation.",
+      "enum": [
+        "stdio-json-rpc"
+      ]
+    },
+    "executionMode": {
+      "description": "The supported execution model for one tool under the pinned protocol.",
+      "enum": [
+        "tools-call"
+      ]
+    },
+    "toolAnnotations": {
+      "description": "Closed behavioral hints advertised with one MCP tool.",
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "readOnlyHint": {
+          "type": "boolean"
+        },
+        "destructiveHint": {
+          "type": "boolean"
+        },
+        "idempotentHint": {
+          "type": "boolean"
+        },
+        "openWorldHint": {
+          "type": "boolean"
+        }
+      }
+    },
+    "argumentConstraints": {
+      "description": "Optional scalar constraints represented alongside one argument record.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enum": {
+          "type": "array",
+          "minItems": 1,
+          "items": true,
+          "uniqueItems": true
+        },
+        "pattern": {
+          "type": "string",
+          "minLength": 1
+        },
+        "minimum": {
+          "type": "number"
+        },
+        "maximum": {
+          "type": "number"
+        },
+        "minLength": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "maxLength": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "inputArgument": {
+      "description": "One authored MCP tool argument with stable identity and Draft input metadata.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "required"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/argumentId"
+        },
+        "name": {
+          "description": "The JSON property name accepted by tools/call arguments.",
+          "type": "string",
+          "minLength": 1
+        },
+        "required": {
+          "description": "Whether the argument must be present in tools/call arguments.",
+          "type": "boolean"
+        },
+        "documentation": {
+          "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json"
+        },
+        "sensitivity": {
+          "description": "How sensitive the argument value is when documented or exemplified.",
+          "enum": [
+            "public",
+            "internal",
+            "secret"
+          ]
+        },
+        "default": true,
+        "examples": {
+          "description": "Representative argument values in any JSON shape.",
+          "type": "array",
+          "minItems": 1,
+          "items": true
+        },
+        "constraints": {
+          "$ref": "#/$defs/argumentConstraints"
+        }
+      }
+    },
+    "closedSchemaNode": {
+      "description": "Recursive Draft schema node requiring closed objects and closed array items.",
+      "type": "object",
+      "allOf": [
+        {
+          "if": {
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "const": "object"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "additionalProperties"
+            ],
+            "properties": {
+              "additionalProperties": {
+                "const": false
+              },
+              "properties": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/$defs/closedSchemaNode"
+                }
+              },
+              "patternProperties": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/$defs/closedSchemaNode"
+                }
+              },
+              "propertyNames": {
+                "$ref": "#/$defs/closedSchemaNode"
+              },
+              "$defs": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/$defs/closedSchemaNode"
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "const": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "items": {
+                "$ref": "#/$defs/closedSchemaNode"
+              },
+              "prefixItems": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/$defs/closedSchemaNode"
+                }
+              },
+              "contains": {
+                "$ref": "#/$defs/closedSchemaNode"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "closedDraftSchema": {
+      "description": "Draft 2020-12 tools/call input object schema with closed nested object and array shapes.",
+      "allOf": [
+        {
+          "$ref": "#/$defs/closedSchemaNode"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "$schema",
+            "type",
+            "additionalProperties"
+          ],
+          "properties": {
+            "$schema": {
+              "const": "https://json-schema.org/draft/2020-12/schema"
+            },
+            "type": {
+              "const": "object"
+            },
+            "additionalProperties": {
+              "const": false
+            },
+            "required": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "uniqueItems": true
+            },
+            "properties": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/closedSchemaNode"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "toolInput": {
+      "description": "Authored tools/call input schema and stable argument metadata for one tool.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "arguments"
+      ],
+      "properties": {
+        "schema": {
+          "$ref": "#/$defs/closedDraftSchema"
+        },
+        "arguments": {
+          "description": "Argument records keyed by stable argument identifiers. Object keys make duplicate argument IDs structurally unrepresentable.",
+          "type": "object",
+          "minProperties": 1,
+          "propertyNames": {
+            "$ref": "#/$defs/argumentId"
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/inputArgument"
+          }
+        }
+      }
     },
     "tool": {
       "type": "object",
@@ -70,6 +333,34 @@
         },
         "lifecycle": {
           "$ref": "https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json"
+        },
+        "transports": {
+          "description": "Supported MCP transports for discovery and tools/call invocation.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/transport"
+          }
+        },
+        "execution": {
+          "description": "Execution and task-support metadata limited to currently supported behavior.",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "mode"
+          ],
+          "properties": {
+            "mode": {
+              "$ref": "#/$defs/executionMode"
+            }
+          }
+        },
+        "annotations": {
+          "$ref": "#/$defs/toolAnnotations"
+        },
+        "input": {
+          "$ref": "#/$defs/toolInput"
         }
       }
     }

--- a/contracts/mcp/tool-catalog.schema.json
+++ b/contracts/mcp/tool-catalog.schema.json
@@ -69,6 +69,30 @@
         }
       ]
     },
+    "handlerId": {
+      "description": "Stable MCP tool handler identity with the mcp.handler prefix.",
+      "allOf": [
+        {
+          "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"
+        },
+        {
+          "pattern": "^mcp[.]handler[.].+"
+        }
+      ]
+    },
+    "handler": {
+      "description": "Stable handler identity binding one canonical MCP tool to its handwritten implementation.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/handlerId"
+        }
+      }
+    },
     "canonicalToolName": {
       "description": "The canonical MCP protocol tool name exposed to clients.",
       "type": "string",
@@ -379,6 +403,9 @@
         },
         "result": {
           "$ref": "#/$defs/toolResult"
+        },
+        "handler": {
+          "$ref": "#/$defs/handler"
         }
       }
     },

--- a/contracts/mcp/tool-catalog.schema.json
+++ b/contracts/mcp/tool-catalog.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.portpowered.com/you/contracts/mcp/tool-catalog.schema.json",
+  "title": "You MCP tool catalog",
+  "description": "Authored MCP tool metadata, documentation, and lifecycle records for one protocol-pinned tool catalog.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "formatVersion",
+    "protocolVersion",
+    "tools"
+  ],
+  "properties": {
+    "formatVersion": {
+      "description": "The explicitly supported version of this tool-catalog format.",
+      "const": "1.0.0"
+    },
+    "protocolVersion": {
+      "description": "The MCP protocol revision pinned by this catalog.",
+      "const": "2024-11-05"
+    },
+    "tools": {
+      "description": "Tool records keyed by stable tool identifiers. Object keys make duplicate tool IDs structurally unrepresentable.",
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": {
+        "$ref": "#/$defs/toolId"
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/tool"
+      }
+    }
+  },
+  "$defs": {
+    "toolId": {
+      "description": "Stable MCP tool identity with the mcp.tool prefix.",
+      "allOf": [
+        {
+          "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"
+        },
+        {
+          "pattern": "^mcp[.]tool[.].+"
+        }
+      ]
+    },
+    "canonicalToolName": {
+      "description": "The canonical MCP protocol tool name exposed to clients.",
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^you[.][a-z0-9_]+(?:[.][a-z0-9_]+)*$"
+    },
+    "tool": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "documentation",
+        "lifecycle"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/toolId"
+        },
+        "name": {
+          "$ref": "#/$defs/canonicalToolName"
+        },
+        "documentation": {
+          "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json"
+        },
+        "lifecycle": {
+          "$ref": "https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json"
+        }
+      }
+    }
+  }
+}

--- a/contracts/mcp/tool-catalog.schema.json
+++ b/contracts/mcp/tool-catalog.schema.json
@@ -29,6 +29,10 @@
       "additionalProperties": {
         "$ref": "#/$defs/tool"
       }
+    },
+    "protocolFailures": {
+      "description": "JSON-RPC protocol failure documentation distinct from tool domain failures.",
+      "$ref": "#/$defs/protocolFailureDocumentation"
     }
   },
   "$defs": {
@@ -51,6 +55,17 @@
         },
         {
           "pattern": "^mcp[.]arg[.].+"
+        }
+      ]
+    },
+    "failureId": {
+      "description": "Stable MCP domain failure identity with the mcp.failure prefix.",
+      "allOf": [
+        {
+          "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"
+        },
+        {
+          "pattern": "^mcp[.]failure[.].+"
         }
       ]
     },
@@ -367,6 +382,93 @@
         }
       }
     },
+    "domainSuccessDocumentation": {
+      "description": "Typed domain success payload documentation serialized into CallToolResult text content.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "examples"
+      ],
+      "properties": {
+        "schema": {
+          "$ref": "#/$defs/closedDraftSchema"
+        },
+        "examples": {
+          "description": "Representative domain success payloads distinct from the CallToolResult transport envelope.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "https://schemas.portpowered.com/you/contracts/mcp/protocol/domain-tool-response.schema.json#/$defs/domainSuccessPayload"
+          }
+        }
+      }
+    },
+    "domainFailureDocumentation": {
+      "description": "One typed tool/domain failure record distinct from transport isError and JSON-RPC protocol errors.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "schema",
+        "examples"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/failureId"
+        },
+        "schema": {
+          "$ref": "#/$defs/closedDraftSchema"
+        },
+        "examples": {
+          "description": "Representative domain/tool failure payloads distinct from CallToolResult and JSON-RPC protocol errors.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "https://schemas.portpowered.com/you/contracts/mcp/protocol/domain-tool-response.schema.json#/$defs/domainFailurePayload"
+          }
+        }
+      }
+    },
+    "toolResultDomain": {
+      "description": "Domain output and failure documentation distinct from the CallToolResult transport envelope.",
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "success": {
+          "$ref": "#/$defs/domainSuccessDocumentation"
+        },
+        "failures": {
+          "description": "Typed domain failure records keyed by stable failure identifiers.",
+          "type": "object",
+          "minProperties": 1,
+          "propertyNames": {
+            "$ref": "#/$defs/failureId"
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/domainFailureDocumentation"
+          }
+        }
+      }
+    },
+    "protocolFailureDocumentation": {
+      "description": "Catalog-level JSON-RPC protocol failure examples distinct from tool domain failures.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "examples"
+      ],
+      "properties": {
+        "examples": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "https://schemas.portpowered.com/you/contracts/mcp/protocol/json-rpc-error.schema.json#/$defs/protocolFailureExample"
+          }
+        }
+      }
+    },
     "toolResultTransport": {
       "description": "Pinned tools/call transport policy for one tool under MCP 2024-11-05.",
       "type": "object",
@@ -404,7 +506,7 @@
       }
     },
     "toolResult": {
-      "description": "Authored tools/call result transport policy and representative CallToolResult examples.",
+      "description": "Authored tools/call result transport policy, domain documentation, and representative CallToolResult examples.",
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -414,6 +516,9 @@
       "properties": {
         "transport": {
           "$ref": "#/$defs/toolResultTransport"
+        },
+        "domain": {
+          "$ref": "#/$defs/toolResultDomain"
         },
         "examples": {
           "description": "Representative pinned text-only CallToolResult envelopes for this tool.",

--- a/contracts/mcp_tool_catalog_fixture_matrix_test.go
+++ b/contracts/mcp_tool_catalog_fixture_matrix_test.go
@@ -1,0 +1,286 @@
+package contracts_test
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/contractvalidator"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+var mcpRegistryValidFixturePaths = []string{
+	"contracts/testdata/mcp/valid-minimal.json",
+	"contracts/testdata/mcp/valid-input-closed-nested.json",
+	"contracts/testdata/mcp/valid-text-success-result.json",
+	"contracts/testdata/mcp/valid-text-error-result.json",
+	"contracts/testdata/mcp/valid-domain-failure-result.json",
+	"contracts/testdata/mcp/valid-protocol-failures.json",
+	"contracts/testdata/mcp/valid-handler-binding.json",
+}
+
+const (
+	toolCatalogSchemaID        = "https://schemas.portpowered.com/you/contracts/mcp/tool-catalog.schema.json"
+	mcpContentSchemaID         = "https://schemas.portpowered.com/you/contracts/mcp/protocol/content.schema.json"
+	mcpCallToolResultSchemaID  = "https://schemas.portpowered.com/you/contracts/mcp/protocol/call-tool-result.schema.json"
+	mcpDomainToolResponseID    = "https://schemas.portpowered.com/you/contracts/mcp/protocol/domain-tool-response.schema.json"
+	mcpJSONRPCErrorSchemaID    = "https://schemas.portpowered.com/you/contracts/mcp/protocol/json-rpc-error.schema.json"
+)
+
+var mcpValidCatalogFixtures = []struct {
+	name    string
+	fixture string
+}{
+	{name: "minimal tool metadata", fixture: "valid-minimal.json"},
+	{name: "closed nested input object", fixture: "valid-input-closed-nested.json"},
+	{name: "canonical text success result", fixture: "valid-text-success-result.json"},
+	{name: "canonical text error result", fixture: "valid-text-error-result.json"},
+	{name: "domain failure paired with text error envelope", fixture: "valid-domain-failure-result.json"},
+	{name: "JSON-RPC protocol failures", fixture: "valid-protocol-failures.json"},
+	{name: "handler binding", fixture: "valid-handler-binding.json"},
+}
+
+var mcpInvalidCatalogSchemaFixtures = []struct {
+	name     string
+	fixture  string
+	wantPath string
+}{
+	{
+		name:     "open nested input object",
+		fixture:  "invalid-open-nested-input.json",
+		wantPath: "/tools/mcp.tool.you.factory_session.start_async/input/schema/properties/source/additionalProperties",
+	},
+	{
+		name:     "unsupported task behavior",
+		fixture:  "invalid-unsupported-task.json",
+		wantPath: "/tools/mcp.tool.you.factory_session.list/execution/mode",
+	},
+	{
+		name:     "result image content",
+		fixture:  "invalid-result-image.json",
+		wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0/content/0/type",
+	},
+	{
+		name:     "result audio content",
+		fixture:  "invalid-result-audio.json",
+		wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0/content/0/type",
+	},
+	{
+		name:     "result embedded resource content",
+		fixture:  "invalid-result-embedded-resource.json",
+		wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0/content/0/type",
+	},
+	{
+		name:     "result structured content field",
+		fixture:  "invalid-result-structured-content.json",
+		wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0",
+	},
+	{
+		name:     "result output schema field",
+		fixture:  "invalid-result-output-schema.json",
+		wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0",
+	},
+	{
+		name:     "domain failure confused with protocol error",
+		fixture:  "invalid-domain-confused-with-protocol-error.json",
+		wantPath: "/tools/mcp.tool.you.factory_session.get/result/domain/failures/mcp.failure.you.factory_session.get.protocol_confusion/examples/0",
+	},
+	{
+		name:     "broken handler ID",
+		fixture:  "invalid-handler-id.json",
+		wantPath: "/tools/mcp.tool.you.factory_session.read_events/handler/id",
+	},
+	{
+		name:     "unknown protocol version",
+		fixture:  "invalid-unknown-protocol-version.json",
+		wantPath: "/protocolVersion",
+	},
+	{
+		name:     "malformed lifecycle record",
+		fixture:  "invalid-malformed-lifecycle.json",
+		wantPath: "/tools/mcp.tool.you.factory_session.start_sync/lifecycle",
+	},
+	{
+		name:     "malformed documentation record",
+		fixture:  "invalid-malformed-documentation.json",
+		wantPath: "/tools/mcp.tool.you.factory_session.get/documentation/documentation/title/id",
+	},
+}
+
+func toolCatalogSchema(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+	return compileSchema(
+		t,
+		filepath.Join("mcp", "tool-catalog.schema.json"),
+		toolCatalogSchemaID,
+		schemaResource{path: filepath.Join("common", "documentation.schema.json"), id: documentationSchemaID},
+		schemaResource{path: filepath.Join("common", "deprecations.schema.json"), id: deprecationsSchemaID},
+		schemaResource{path: filepath.Join("mcp", "protocol", "content.schema.json"), id: mcpContentSchemaID},
+		schemaResource{path: filepath.Join("mcp", "protocol", "call-tool-result.schema.json"), id: mcpCallToolResultSchemaID},
+		schemaResource{path: filepath.Join("mcp", "protocol", "domain-tool-response.schema.json"), id: mcpDomainToolResponseID},
+		schemaResource{path: filepath.Join("mcp", "protocol", "json-rpc-error.schema.json"), id: mcpJSONRPCErrorSchemaID},
+	)
+}
+
+func TestMCPToolCatalogSchemaValidFixtureMatrix(t *testing.T) {
+	schema := toolCatalogSchema(t)
+
+	for _, test := range mcpValidCatalogFixtures {
+		t.Run(test.name, func(t *testing.T) {
+			instance := readJSON(t, filepath.Join("testdata", "mcp", test.fixture))
+			if err := schema.Validate(instance); err != nil {
+				t.Fatalf("validate valid fixture %s: %v", test.fixture, err)
+			}
+		})
+	}
+}
+
+func TestMCPToolCatalogSchemaInvalidFixtureMatrix(t *testing.T) {
+	schema := toolCatalogSchema(t)
+
+	for _, test := range mcpInvalidCatalogSchemaFixtures {
+		t.Run(test.name, func(t *testing.T) {
+			instance := readJSON(t, filepath.Join("testdata", "mcp", test.fixture))
+			err := schema.Validate(instance)
+			if err == nil {
+				t.Fatal("expected fixture validation to fail")
+			}
+			if paths := validationPaths(t, err); !slices.Contains(paths, test.wantPath) {
+				t.Fatalf("validation paths = %v, want %q", paths, test.wantPath)
+			}
+		})
+	}
+}
+
+func TestMCPToolCatalogContractValidatorInvalidFixtureMatrix(t *testing.T) {
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("repository root: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		fixture  string
+		code     string
+		wantPath string
+	}{
+		{
+			name:     "duplicate stable documentation IDs",
+			fixture:  "invalid-duplicate-stable-id.json",
+			code:     "identity.duplicate",
+			wantPath: "/tools/mcp.tool.you.factory_session.list_dispatches/documentation/documentation/title/id",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			diagnostics := contractvalidator.Validate(root, mcpCatalogFixtureRegistry(test.fixture), "mcp", "1.0.0")
+			if len(diagnostics) == 0 {
+				t.Fatal("expected diagnostics, got none")
+			}
+			found := false
+			document := filepath.ToSlash(filepath.Join("contracts", "testdata", "mcp", test.fixture))
+			for _, diagnostic := range diagnostics {
+				if diagnostic.Code == test.code && diagnostic.Path == test.wantPath && diagnostic.Document == document {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("diagnostics = %+v, want code=%q path=%q document=%q", diagnostics, test.code, test.wantPath, document)
+			}
+		})
+	}
+}
+
+func TestMCPToolCatalogFixtureDirectoryCoverage(t *testing.T) {
+	entries, err := os.ReadDir(filepath.Join("testdata", "mcp"))
+	if err != nil {
+		t.Fatalf("read fixture directory: %v", err)
+	}
+
+	classified := make(map[string]struct{})
+	for _, fixture := range mcpValidCatalogFixtures {
+		classified[fixture.fixture] = struct{}{}
+	}
+	for _, fixture := range mcpInvalidCatalogSchemaFixtures {
+		classified[fixture.fixture] = struct{}{}
+	}
+	classified["invalid-duplicate-stable-id.json"] = struct{}{}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".json") {
+			t.Fatalf("unexpected non-json fixture %q", name)
+		}
+		if _, ok := classified[name]; !ok {
+			t.Fatalf("fixture %q is not covered by the MCP tool-catalog fixture matrix", name)
+		}
+	}
+	if len(classified) != len(entries) {
+		t.Fatalf("classified fixture count = %d, want %d files on disk", len(classified), len(entries))
+	}
+}
+
+func TestMCPToolCatalogRegistryMatchesValidFixtureMatrix(t *testing.T) {
+	want := make([]string, 0, len(mcpValidCatalogFixtures))
+	for _, fixture := range mcpValidCatalogFixtures {
+		want = append(want, fixture.fixture)
+	}
+	slices.Sort(want)
+
+	registered := make([]string, 0, len(mcpRegistryValidFixturePaths))
+	for _, path := range mcpRegistryValidFixturePaths {
+		registered = append(registered, filepath.Base(path))
+		if _, err := os.Stat(strings.TrimPrefix(path, "contracts/")); err != nil {
+			t.Fatalf("registered fixture %s missing on disk: %v", path, err)
+		}
+	}
+	slices.Sort(registered)
+
+	if !slices.Equal(registered, want) {
+		t.Fatalf("registered valid fixtures = %v, want %v", registered, want)
+	}
+}
+
+func TestMCPToolCatalogBoundaryNoProductionCutover(t *testing.T) {
+	if _, err := os.Stat(filepath.Join("mcp", "tools.json")); err == nil {
+		t.Fatal("contracts/mcp/tools.json must not exist before B14 production catalog cutover")
+	}
+	if _, err := os.Stat(filepath.Join("mcp", "deprecated.json")); err != nil {
+		t.Fatalf("contracts/mcp/deprecated.json must remain the compatibility alias inventory: %v", err)
+	}
+}
+
+func mcpCatalogFixtureRegistry(fixture string) contractvalidator.Registry {
+	const (
+		contentID            = "https://schemas.portpowered.com/you/contracts/mcp/protocol/content.schema.json"
+		callToolResultID     = "https://schemas.portpowered.com/you/contracts/mcp/protocol/call-tool-result.schema.json"
+		domainToolResponseID = "https://schemas.portpowered.com/you/contracts/mcp/protocol/domain-tool-response.schema.json"
+		jsonRPCErrorID       = "https://schemas.portpowered.com/you/contracts/mcp/protocol/json-rpc-error.schema.json"
+		documentationID      = "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json"
+		deprecationsID       = "https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json"
+	)
+	return contractvalidator.NewRegistry(contractvalidator.Entry{
+		Family:        "mcp",
+		FormatVersion: "1.0.0",
+		Schemas: []contractvalidator.Schema{
+			{ID: documentationID, Path: "contracts/common/documentation.schema.json"},
+			{ID: deprecationsID, Path: "contracts/common/deprecations.schema.json"},
+			{ID: contentID, Path: "contracts/mcp/protocol/content.schema.json"},
+			{ID: callToolResultID, Path: "contracts/mcp/protocol/call-tool-result.schema.json"},
+			{ID: domainToolResponseID, Path: "contracts/mcp/protocol/domain-tool-response.schema.json"},
+			{ID: jsonRPCErrorID, Path: "contracts/mcp/protocol/json-rpc-error.schema.json"},
+			{ID: toolCatalogSchemaID, Path: "contracts/mcp/tool-catalog.schema.json"},
+		},
+		Documents: []contractvalidator.Document{{
+			Path:     filepath.ToSlash(filepath.Join("contracts", "testdata", "mcp", fixture)),
+			SchemaID: toolCatalogSchemaID,
+		}},
+	})
+}

--- a/contracts/testdata/mcp/invalid-domain-confused-with-protocol-error.json
+++ b/contracts/testdata/mcp/invalid-domain-confused-with-protocol-error.json
@@ -1,0 +1,93 @@
+{
+  "formatVersion": "1.0.0",
+  "protocolVersion": "2024-11-05",
+  "tools": {
+    "mcp.tool.you.factory_session.get": {
+      "id": "mcp.tool.you.factory_session.get",
+      "name": "you.factory_session.get",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.get",
+        "documentation": {
+          "title": {
+            "id": "mcp.tool.you.factory_session.get.title",
+            "canonicalEnglish": "Get Factory Session"
+          },
+          "description": {
+            "id": "mcp.tool.you.factory_session.get.description",
+            "canonicalEnglish": "Reads one durable Factory Session by id."
+          }
+        },
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.get",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "result": {
+        "transport": {
+          "contentTypes": [
+            "text"
+          ],
+          "textEncoding": "serialized-json",
+          "allowsStructuredContent": false,
+          "allowsOutputSchema": false
+        },
+        "domain": {
+          "failures": {
+            "mcp.failure.you.factory_session.get.protocol_confusion": {
+              "id": "mcp.failure.you.factory_session.get.protocol_confusion",
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "code",
+                  "message",
+                  "retryable"
+                ],
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "message": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "retryable": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              "examples": [
+                {
+                  "jsonrpc": "2.0",
+                  "id": 1,
+                  "error": {
+                    "code": -32602,
+                    "message": "tool name is required"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "examples": [
+          {
+            "content": [
+              {
+                "type": "text",
+                "text": "{\"error\":{\"code\":\"factory_session.session.not_found\",\"message\":\"factory session not found\",\"retryable\":false}}"
+              }
+            ],
+            "isError": false
+          }
+        ]
+      }
+    }
+  }
+}

--- a/contracts/testdata/mcp/invalid-duplicate-stable-id.json
+++ b/contracts/testdata/mcp/invalid-duplicate-stable-id.json
@@ -1,0 +1,68 @@
+{
+  "formatVersion": "1.0.0",
+  "protocolVersion": "2024-11-05",
+  "tools": {
+    "mcp.tool.you.factory_session.list_dispatches": {
+      "id": "mcp.tool.you.factory_session.list_dispatches",
+      "name": "you.factory_session.list_dispatches",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.list_dispatches",
+        "documentation": {
+          "title": {
+            "id": "mcp.tool.you.factory_session.shared.title",
+            "canonicalEnglish": "List Factory Session Dispatches"
+          },
+          "description": {
+            "id": "mcp.tool.you.factory_session.list_dispatches.description",
+            "canonicalEnglish": "Lists dispatches for one durable Factory Session."
+          }
+        },
+        "examples": [
+          {
+            "sessionId": "dur-sess-disp-001"
+          }
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.list_dispatches",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    },
+    "mcp.tool.you.factory_session.list_artifacts": {
+      "id": "mcp.tool.you.factory_session.list_artifacts",
+      "name": "you.factory_session.list_artifacts",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.list_artifacts",
+        "documentation": {
+          "title": {
+            "id": "mcp.tool.you.factory_session.shared.title",
+            "canonicalEnglish": "List Factory Session Artifacts"
+          },
+          "description": {
+            "id": "mcp.tool.you.factory_session.list_artifacts.description",
+            "canonicalEnglish": "Lists artifacts for one durable Factory Session."
+          }
+        },
+        "examples": [
+          {
+            "sessionId": "dur-sess-art-001"
+          }
+        ],
+        "visibility": "public",
+        "sourceHash": "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.list_artifacts",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    }
+  }
+}

--- a/contracts/testdata/mcp/invalid-handler-id.json
+++ b/contracts/testdata/mcp/invalid-handler-id.json
@@ -1,0 +1,40 @@
+{
+  "formatVersion": "1.0.0",
+  "protocolVersion": "2024-11-05",
+  "tools": {
+    "mcp.tool.you.factory_session.read_events": {
+      "id": "mcp.tool.you.factory_session.read_events",
+      "name": "you.factory_session.read_events",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.read_events",
+        "documentation": {
+          "title": {
+            "id": "mcp.tool.you.factory_session.read_events.title",
+            "canonicalEnglish": "Read Factory Session Events"
+          },
+          "description": {
+            "id": "mcp.tool.you.factory_session.read_events.description",
+            "canonicalEnglish": "Reads canonical Factory Session events with a broken handler identity."
+          }
+        },
+        "examples": [
+          {
+            "sessionId": "dur-sess-evt-001"
+          }
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.read_events",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "handler": {
+        "id": "Invalid_Handler"
+      }
+    }
+  }
+}

--- a/contracts/testdata/mcp/invalid-malformed-documentation.json
+++ b/contracts/testdata/mcp/invalid-malformed-documentation.json
@@ -1,0 +1,37 @@
+{
+  "formatVersion": "1.0.0",
+  "protocolVersion": "2024-11-05",
+  "tools": {
+    "mcp.tool.you.factory_session.get": {
+      "id": "mcp.tool.you.factory_session.get",
+      "name": "you.factory_session.get",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.get",
+        "documentation": {
+          "title": {
+            "id": "docs/FactorySessionGet",
+            "canonicalEnglish": "Get Factory Session"
+          },
+          "description": {
+            "id": "mcp.tool.you.factory_session.get.description",
+            "canonicalEnglish": "Reads one durable Factory Session status."
+          }
+        },
+        "examples": [
+          {
+            "sessionId": "dur-sess-get-001"
+          }
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.get",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    }
+  }
+}

--- a/contracts/testdata/mcp/invalid-malformed-lifecycle.json
+++ b/contracts/testdata/mcp/invalid-malformed-lifecycle.json
@@ -1,0 +1,38 @@
+{
+  "formatVersion": "1.0.0",
+  "protocolVersion": "2024-11-05",
+  "tools": {
+    "mcp.tool.you.factory_session.start_sync": {
+      "id": "mcp.tool.you.factory_session.start_sync",
+      "name": "you.factory_session.start_sync",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.start_sync",
+        "documentation": {
+          "title": {
+            "id": "mcp.tool.you.factory_session.start_sync.title",
+            "canonicalEnglish": "Start Factory Session Sync"
+          },
+          "description": {
+            "id": "mcp.tool.you.factory_session.start_sync.description",
+            "canonicalEnglish": "Starts one synchronous Factory Session."
+          }
+        },
+        "examples": [
+          {
+            "requestId": "req-sync-001"
+          }
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.start_sync",
+        "state": "deprecated",
+        "since": "1.0.0",
+        "deprecated": "2.0.0"
+      }
+    }
+  }
+}

--- a/contracts/testdata/mcp/invalid-open-nested-input.json
+++ b/contracts/testdata/mcp/invalid-open-nested-input.json
@@ -1,0 +1,104 @@
+{
+  "formatVersion": "1.0.0",
+  "protocolVersion": "2024-11-05",
+  "tools": {
+    "mcp.tool.you.factory_session.start_async": {
+      "id": "mcp.tool.you.factory_session.start_async",
+      "name": "you.factory_session.start_async",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.start_async",
+        "documentation": {
+          "title": {
+            "id": "mcp.tool.you.factory_session.start_async.title",
+            "canonicalEnglish": "Start Factory Session Async"
+          },
+          "description": {
+            "id": "mcp.tool.you.factory_session.start_async.description",
+            "canonicalEnglish": "Starts one async Factory Session and returns an accepted or running summary for polling."
+          }
+        },
+        "examples": [
+          {
+            "requestId": "req-001",
+            "source": {
+              "kind": "WORKFLOW_NAME",
+              "workflowName": "example.workflow"
+            }
+          }
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.start_async",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "transports": [
+        "stdio-json-rpc"
+      ],
+      "execution": {
+        "mode": "tools-call"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "input": {
+        "schema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "requestId",
+            "source"
+          ],
+          "properties": {
+            "requestId": {
+              "type": "string",
+              "minLength": 1
+            },
+            "source": {
+              "type": "object",
+              "additionalProperties": true,
+              "required": [
+                "kind"
+              ],
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "enum": [
+                    "FACTORY_ID",
+                    "FACTORY_INLINE",
+                    "WORKFLOW_FILE",
+                    "WORKFLOW_NAME",
+                    "INLINE_WORKFLOW"
+                  ]
+                },
+                "workflowName": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "arguments": {
+          "mcp.arg.you.factory_session.start_async.request_id": {
+            "id": "mcp.arg.you.factory_session.start_async.request_id",
+            "name": "requestId",
+            "required": true
+          },
+          "mcp.arg.you.factory_session.start_async.source": {
+            "id": "mcp.arg.you.factory_session.start_async.source",
+            "name": "source",
+            "required": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/contracts/testdata/mcp/invalid-result-audio.json
+++ b/contracts/testdata/mcp/invalid-result-audio.json
@@ -1,0 +1,59 @@
+{
+  "formatVersion": "1.0.0",
+  "protocolVersion": "2024-11-05",
+  "tools": {
+    "mcp.tool.you.factory_session.list": {
+      "id": "mcp.tool.you.factory_session.list",
+      "name": "you.factory_session.list",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.list",
+        "documentation": {
+          "title": {
+            "id": "mcp.tool.you.factory_session.list.title",
+            "canonicalEnglish": "List Factory Sessions"
+          },
+          "description": {
+            "id": "mcp.tool.you.factory_session.list.description",
+            "canonicalEnglish": "Lists Factory Sessions for one scope using durable Factory Session listing vocabulary."
+          }
+        },
+        "examples": [
+          {
+            "scope": "live"
+          }
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.list",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "result": {
+        "transport": {
+          "contentTypes": [
+            "text"
+          ],
+          "textEncoding": "serialized-json",
+          "allowsStructuredContent": false,
+          "allowsOutputSchema": false
+        },
+        "examples": [
+          {
+            "content": [
+              {
+                "type": "audio",
+                "data": "aGVsbG8=",
+                "mimeType": "audio/wav"
+              }
+            ],
+            "isError": false
+          }
+        ]
+      }
+    }
+  }
+}

--- a/contracts/testdata/mcp/invalid-result-embedded-resource.json
+++ b/contracts/testdata/mcp/invalid-result-embedded-resource.json
@@ -1,0 +1,62 @@
+{
+  "formatVersion": "1.0.0",
+  "protocolVersion": "2024-11-05",
+  "tools": {
+    "mcp.tool.you.factory_session.list": {
+      "id": "mcp.tool.you.factory_session.list",
+      "name": "you.factory_session.list",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.list",
+        "documentation": {
+          "title": {
+            "id": "mcp.tool.you.factory_session.list.title",
+            "canonicalEnglish": "List Factory Sessions"
+          },
+          "description": {
+            "id": "mcp.tool.you.factory_session.list.description",
+            "canonicalEnglish": "Lists Factory Sessions for one scope using durable Factory Session listing vocabulary."
+          }
+        },
+        "examples": [
+          {
+            "scope": "live"
+          }
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.list",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "result": {
+        "transport": {
+          "contentTypes": [
+            "text"
+          ],
+          "textEncoding": "serialized-json",
+          "allowsStructuredContent": false,
+          "allowsOutputSchema": false
+        },
+        "examples": [
+          {
+            "content": [
+              {
+                "type": "resource",
+                "resource": {
+                  "uri": "file:///tmp/example.txt",
+                  "mimeType": "text/plain",
+                  "text": "embedded resource payload"
+                }
+              }
+            ],
+            "isError": false
+          }
+        ]
+      }
+    }
+  }
+}

--- a/contracts/testdata/mcp/invalid-result-image.json
+++ b/contracts/testdata/mcp/invalid-result-image.json
@@ -1,0 +1,59 @@
+{
+  "formatVersion": "1.0.0",
+  "protocolVersion": "2024-11-05",
+  "tools": {
+    "mcp.tool.you.factory_session.list": {
+      "id": "mcp.tool.you.factory_session.list",
+      "name": "you.factory_session.list",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.list",
+        "documentation": {
+          "title": {
+            "id": "mcp.tool.you.factory_session.list.title",
+            "canonicalEnglish": "List Factory Sessions"
+          },
+          "description": {
+            "id": "mcp.tool.you.factory_session.list.description",
+            "canonicalEnglish": "Lists Factory Sessions for one scope using durable Factory Session listing vocabulary."
+          }
+        },
+        "examples": [
+          {
+            "scope": "live"
+          }
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.list",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "result": {
+        "transport": {
+          "contentTypes": [
+            "text"
+          ],
+          "textEncoding": "serialized-json",
+          "allowsStructuredContent": false,
+          "allowsOutputSchema": false
+        },
+        "examples": [
+          {
+            "content": [
+              {
+                "type": "image",
+                "data": "aGVsbG8=",
+                "mimeType": "image/png"
+              }
+            ],
+            "isError": false
+          }
+        ]
+      }
+    }
+  }
+}

--- a/contracts/testdata/mcp/invalid-result-output-schema.json
+++ b/contracts/testdata/mcp/invalid-result-output-schema.json
@@ -1,0 +1,61 @@
+{
+  "formatVersion": "1.0.0",
+  "protocolVersion": "2024-11-05",
+  "tools": {
+    "mcp.tool.you.factory_session.list": {
+      "id": "mcp.tool.you.factory_session.list",
+      "name": "you.factory_session.list",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.list",
+        "documentation": {
+          "title": {
+            "id": "mcp.tool.you.factory_session.list.title",
+            "canonicalEnglish": "List Factory Sessions"
+          },
+          "description": {
+            "id": "mcp.tool.you.factory_session.list.description",
+            "canonicalEnglish": "Lists Factory Sessions for one scope using durable Factory Session listing vocabulary."
+          }
+        },
+        "examples": [
+          {
+            "scope": "live"
+          }
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.list",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "result": {
+        "transport": {
+          "contentTypes": [
+            "text"
+          ],
+          "textEncoding": "serialized-json",
+          "allowsStructuredContent": false,
+          "allowsOutputSchema": false
+        },
+        "examples": [
+          {
+            "content": [
+              {
+                "type": "text",
+                "text": "{\"result\":{\"scope\":\"live\",\"sessions\":[]}}"
+              }
+            ],
+            "isError": false,
+            "outputSchema": {
+              "type": "object"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/contracts/testdata/mcp/invalid-result-structured-content.json
+++ b/contracts/testdata/mcp/invalid-result-structured-content.json
@@ -1,0 +1,64 @@
+{
+  "formatVersion": "1.0.0",
+  "protocolVersion": "2024-11-05",
+  "tools": {
+    "mcp.tool.you.factory_session.list": {
+      "id": "mcp.tool.you.factory_session.list",
+      "name": "you.factory_session.list",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.list",
+        "documentation": {
+          "title": {
+            "id": "mcp.tool.you.factory_session.list.title",
+            "canonicalEnglish": "List Factory Sessions"
+          },
+          "description": {
+            "id": "mcp.tool.you.factory_session.list.description",
+            "canonicalEnglish": "Lists Factory Sessions for one scope using durable Factory Session listing vocabulary."
+          }
+        },
+        "examples": [
+          {
+            "scope": "live"
+          }
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.list",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "result": {
+        "transport": {
+          "contentTypes": [
+            "text"
+          ],
+          "textEncoding": "serialized-json",
+          "allowsStructuredContent": false,
+          "allowsOutputSchema": false
+        },
+        "examples": [
+          {
+            "content": [
+              {
+                "type": "text",
+                "text": "{\"result\":{\"scope\":\"live\",\"sessions\":[]}}"
+              }
+            ],
+            "isError": false,
+            "structuredContent": {
+              "result": {
+                "scope": "live",
+                "sessions": []
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/contracts/testdata/mcp/invalid-unknown-protocol-version.json
+++ b/contracts/testdata/mcp/invalid-unknown-protocol-version.json
@@ -1,0 +1,40 @@
+{
+  "formatVersion": "1.0.0",
+  "protocolVersion": "2025-03-26",
+  "tools": {
+    "mcp.tool.you.factory_session.validate_source": {
+      "id": "mcp.tool.you.factory_session.validate_source",
+      "name": "you.factory_session.validate_source",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.validate_source",
+        "documentation": {
+          "title": {
+            "id": "mcp.tool.you.factory_session.validate_source.title",
+            "canonicalEnglish": "Validate Factory Session Source"
+          },
+          "description": {
+            "id": "mcp.tool.you.factory_session.validate_source.description",
+            "canonicalEnglish": "Validates one Factory Session source before durable execution."
+          }
+        },
+        "examples": [
+          {
+            "source": {
+              "kind": "WORKFLOW_NAME",
+              "workflowName": "example.workflow"
+            }
+          }
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.validate_source",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    }
+  }
+}

--- a/contracts/testdata/mcp/invalid-unsupported-task.json
+++ b/contracts/testdata/mcp/invalid-unsupported-task.json
@@ -1,0 +1,49 @@
+{
+  "formatVersion": "1.0.0",
+  "protocolVersion": "2024-11-05",
+  "tools": {
+    "mcp.tool.you.factory_session.list": {
+      "id": "mcp.tool.you.factory_session.list",
+      "name": "you.factory_session.list",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.list",
+        "documentation": {
+          "title": {
+            "id": "mcp.tool.you.factory_session.list.title",
+            "canonicalEnglish": "List Factory Sessions"
+          },
+          "description": {
+            "id": "mcp.tool.you.factory_session.list.description",
+            "canonicalEnglish": "Lists Factory Sessions for one scope using durable Factory Session listing vocabulary."
+          }
+        },
+        "examples": [
+          {
+            "scope": "live"
+          }
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.list",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "transports": [
+        "stdio-json-rpc"
+      ],
+      "execution": {
+        "mode": "task-polling"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    }
+  }
+}

--- a/contracts/testdata/mcp/valid-domain-failure-result.json
+++ b/contracts/testdata/mcp/valid-domain-failure-result.json
@@ -1,0 +1,108 @@
+{
+  "formatVersion": "1.0.0",
+  "protocolVersion": "2024-11-05",
+  "tools": {
+    "mcp.tool.you.factory_session.start_sync": {
+      "id": "mcp.tool.you.factory_session.start_sync",
+      "name": "you.factory_session.start_sync",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.start_sync",
+        "documentation": {
+          "title": {
+            "id": "mcp.tool.you.factory_session.start_sync.title",
+            "canonicalEnglish": "Start Factory Session Sync"
+          },
+          "description": {
+            "id": "mcp.tool.you.factory_session.start_sync.description",
+            "canonicalEnglish": "Starts one durable Factory Session synchronously."
+          }
+        },
+        "examples": [
+          {
+            "sessionId": "dur-sess-pending-001"
+          }
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.start_sync",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "transports": [
+        "stdio-json-rpc"
+      ],
+      "execution": {
+        "mode": "tools-call"
+      },
+      "result": {
+        "transport": {
+          "contentTypes": [
+            "text"
+          ],
+          "textEncoding": "serialized-json",
+          "allowsStructuredContent": false,
+          "allowsOutputSchema": false
+        },
+        "domain": {
+          "failures": {
+            "mcp.failure.you.factory_session.start_sync.validation_failed": {
+              "id": "mcp.failure.you.factory_session.start_sync.validation_failed",
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "code",
+                  "message",
+                  "retryable"
+                ],
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "message": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "retryable": {
+                    "type": "boolean"
+                  },
+                  "sessionId": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              },
+              "examples": [
+                {
+                  "error": {
+                    "code": "factory_session.start.validation_failed",
+                    "message": "factory session source validation failed",
+                    "retryable": false,
+                    "sessionId": "dur-sess-pending-001"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "examples": [
+          {
+            "content": [
+              {
+                "type": "text",
+                "text": "{\"error\":{\"code\":\"factory_session.start.validation_failed\",\"message\":\"factory session source validation failed\",\"retryable\":false,\"sessionId\":\"dur-sess-pending-001\"}}"
+              }
+            ],
+            "isError": false
+          }
+        ]
+      }
+    }
+  }
+}

--- a/contracts/testdata/mcp/valid-domain-failure-result.json
+++ b/contracts/testdata/mcp/valid-domain-failure-result.json
@@ -99,7 +99,7 @@
                 "text": "{\"error\":{\"code\":\"factory_session.start.validation_failed\",\"message\":\"factory session source validation failed\",\"retryable\":false,\"sessionId\":\"dur-sess-pending-001\"}}"
               }
             ],
-            "isError": false
+            "isError": true
           }
         ]
       }

--- a/contracts/testdata/mcp/valid-handler-binding.json
+++ b/contracts/testdata/mcp/valid-handler-binding.json
@@ -1,0 +1,47 @@
+{
+  "formatVersion": "1.0.0",
+  "protocolVersion": "2024-11-05",
+  "tools": {
+    "mcp.tool.you.factory_session.control": {
+      "id": "mcp.tool.you.factory_session.control",
+      "name": "you.factory_session.control",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.control",
+        "documentation": {
+          "title": {
+            "id": "mcp.tool.you.factory_session.control.title",
+            "canonicalEnglish": "Control Factory Session"
+          },
+          "description": {
+            "id": "mcp.tool.you.factory_session.control.description",
+            "canonicalEnglish": "Applies one durable Factory Session lifecycle control through a bound handwritten handler."
+          }
+        },
+        "examples": [
+          {
+            "sessionId": "dur-sess-ctl-001",
+            "operation": "PAUSE"
+          }
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.control",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "transports": [
+        "stdio-json-rpc"
+      ],
+      "execution": {
+        "mode": "tools-call"
+      },
+      "handler": {
+        "id": "mcp.handler.you.factory_session.control"
+      }
+    }
+  }
+}

--- a/contracts/testdata/mcp/valid-input-closed-nested.json
+++ b/contracts/testdata/mcp/valid-input-closed-nested.json
@@ -1,0 +1,159 @@
+{
+  "formatVersion": "1.0.0",
+  "protocolVersion": "2024-11-05",
+  "tools": {
+    "mcp.tool.you.factory_session.start_async": {
+      "id": "mcp.tool.you.factory_session.start_async",
+      "name": "you.factory_session.start_async",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.start_async",
+        "documentation": {
+          "title": {
+            "id": "mcp.tool.you.factory_session.start_async.title",
+            "canonicalEnglish": "Start Factory Session Async"
+          },
+          "description": {
+            "id": "mcp.tool.you.factory_session.start_async.description",
+            "canonicalEnglish": "Starts one async Factory Session and returns an accepted or running summary for polling."
+          }
+        },
+        "examples": [
+          {
+            "requestId": "req-001",
+            "source": {
+              "kind": "WORKFLOW_NAME",
+              "workflowName": "example.workflow"
+            }
+          }
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.start_async",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "transports": [
+        "stdio-json-rpc"
+      ],
+      "execution": {
+        "mode": "tools-call"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "input": {
+        "schema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "requestId",
+            "source"
+          ],
+          "properties": {
+            "requestId": {
+              "type": "string",
+              "minLength": 1
+            },
+            "source": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "kind"
+              ],
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "enum": [
+                    "FACTORY_ID",
+                    "FACTORY_INLINE",
+                    "WORKFLOW_FILE",
+                    "WORKFLOW_NAME",
+                    "INLINE_WORKFLOW"
+                  ]
+                },
+                "workflowName": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "arguments": {
+          "mcp.arg.you.factory_session.start_async.request_id": {
+            "id": "mcp.arg.you.factory_session.start_async.request_id",
+            "name": "requestId",
+            "required": true,
+            "documentation": {
+              "formatVersion": "1.0.0",
+              "itemId": "mcp.arg.you.factory_session.start_async.request_id",
+              "documentation": {
+                "title": {
+                  "id": "mcp.arg.you.factory_session.start_async.request_id.title",
+                  "canonicalEnglish": "Request ID"
+                },
+                "description": {
+                  "id": "mcp.arg.you.factory_session.start_async.request_id.description",
+                  "canonicalEnglish": "Caller-supplied idempotency key for durable Factory Session start."
+                }
+              },
+              "examples": [
+                "req-001"
+              ],
+              "visibility": "public",
+              "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            },
+            "sensitivity": "internal",
+            "examples": [
+              "req-001"
+            ],
+            "constraints": {
+              "minLength": 1
+            }
+          },
+          "mcp.arg.you.factory_session.start_async.source": {
+            "id": "mcp.arg.you.factory_session.start_async.source",
+            "name": "source",
+            "required": true,
+            "documentation": {
+              "formatVersion": "1.0.0",
+              "itemId": "mcp.arg.you.factory_session.start_async.source",
+              "documentation": {
+                "title": {
+                  "id": "mcp.arg.you.factory_session.start_async.source.title",
+                  "canonicalEnglish": "Source"
+                },
+                "description": {
+                  "id": "mcp.arg.you.factory_session.start_async.source.description",
+                  "canonicalEnglish": "Durable execution source with a closed nested object shape."
+                }
+              },
+              "examples": [
+                {
+                  "kind": "WORKFLOW_NAME",
+                  "workflowName": "example.workflow"
+                }
+              ],
+              "visibility": "public",
+              "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            },
+            "sensitivity": "public",
+            "examples": [
+              {
+                "kind": "WORKFLOW_NAME",
+                "workflowName": "example.workflow"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/contracts/testdata/mcp/valid-minimal.json
+++ b/contracts/testdata/mcp/valid-minimal.json
@@ -1,0 +1,37 @@
+{
+  "formatVersion": "1.0.0",
+  "protocolVersion": "2024-11-05",
+  "tools": {
+    "mcp.tool.you.factory_session.list": {
+      "id": "mcp.tool.you.factory_session.list",
+      "name": "you.factory_session.list",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.list",
+        "documentation": {
+          "title": {
+            "id": "mcp.tool.you.factory_session.list.title",
+            "canonicalEnglish": "List Factory Sessions"
+          },
+          "description": {
+            "id": "mcp.tool.you.factory_session.list.description",
+            "canonicalEnglish": "Lists Factory Sessions for one scope using durable Factory Session listing vocabulary."
+          }
+        },
+        "examples": [
+          {
+            "scope": "live"
+          }
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.list",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    }
+  }
+}

--- a/contracts/testdata/mcp/valid-protocol-failures.json
+++ b/contracts/testdata/mcp/valid-protocol-failures.json
@@ -1,0 +1,76 @@
+{
+  "formatVersion": "1.0.0",
+  "protocolVersion": "2024-11-05",
+  "protocolFailures": {
+    "examples": [
+      {
+        "name": "tools_call_missing_tool_name",
+        "description": "Representative invalid-params JSON-RPC error for tools/call with a missing tool name.",
+        "request": {
+          "jsonrpc": "2.0",
+          "id": 1,
+          "method": "tools/call",
+          "params": {}
+        },
+        "response": {
+          "jsonrpc": "2.0",
+          "id": 1,
+          "error": {
+            "code": -32602,
+            "message": "tool name is required"
+          }
+        }
+      },
+      {
+        "name": "unknown_method",
+        "description": "Representative unknown-method JSON-RPC error for an unsupported MCP method.",
+        "request": {
+          "jsonrpc": "2.0",
+          "id": 3,
+          "method": "nope"
+        },
+        "response": {
+          "jsonrpc": "2.0",
+          "id": 3,
+          "error": {
+            "code": -32601,
+            "message": "method not found: nope"
+          }
+        }
+      }
+    ]
+  },
+  "tools": {
+    "mcp.tool.you.factory_session.validate_source": {
+      "id": "mcp.tool.you.factory_session.validate_source",
+      "name": "you.factory_session.validate_source",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.validate_source",
+        "documentation": {
+          "title": {
+            "id": "mcp.tool.you.factory_session.validate_source.title",
+            "canonicalEnglish": "Validate Factory Session Source"
+          },
+          "description": {
+            "id": "mcp.tool.you.factory_session.validate_source.description",
+            "canonicalEnglish": "Validates one Factory Session source before execution."
+          }
+        },
+        "examples": [
+          {
+            "sourcePath": "factory/session.json"
+          }
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.validate_source",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    }
+  }
+}

--- a/contracts/testdata/mcp/valid-text-error-result.json
+++ b/contracts/testdata/mcp/valid-text-error-result.json
@@ -1,0 +1,64 @@
+{
+  "formatVersion": "1.0.0",
+  "protocolVersion": "2024-11-05",
+  "tools": {
+    "mcp.tool.you.factory_session.get": {
+      "id": "mcp.tool.you.factory_session.get",
+      "name": "you.factory_session.get",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.get",
+        "documentation": {
+          "title": {
+            "id": "mcp.tool.you.factory_session.get.title",
+            "canonicalEnglish": "Get Factory Session"
+          },
+          "description": {
+            "id": "mcp.tool.you.factory_session.get.description",
+            "canonicalEnglish": "Reads one durable Factory Session by id."
+          }
+        },
+        "examples": [
+          {
+            "sessionId": "dur-sess-missing-999"
+          }
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.get",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "transports": [
+        "stdio-json-rpc"
+      ],
+      "execution": {
+        "mode": "tools-call"
+      },
+      "result": {
+        "transport": {
+          "contentTypes": [
+            "text"
+          ],
+          "textEncoding": "plain-text",
+          "allowsStructuredContent": false,
+          "allowsOutputSchema": false
+        },
+        "examples": [
+          {
+            "content": [
+              {
+                "type": "text",
+                "text": "factory session not found"
+              }
+            ],
+            "isError": true
+          }
+        ]
+      }
+    }
+  }
+}

--- a/contracts/testdata/mcp/valid-text-success-result.json
+++ b/contracts/testdata/mcp/valid-text-success-result.json
@@ -47,6 +47,37 @@
           "allowsStructuredContent": false,
           "allowsOutputSchema": false
         },
+        "domain": {
+          "success": {
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "sessionId",
+                "status"
+              ],
+              "properties": {
+                "sessionId": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "status": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            },
+            "examples": [
+              {
+                "result": {
+                  "sessionId": "dur-sess-001",
+                  "status": "SUCCEEDED"
+                }
+              }
+            ]
+          }
+        },
         "examples": [
           {
             "content": [

--- a/contracts/testdata/mcp/valid-text-success-result.json
+++ b/contracts/testdata/mcp/valid-text-success-result.json
@@ -1,0 +1,64 @@
+{
+  "formatVersion": "1.0.0",
+  "protocolVersion": "2024-11-05",
+  "tools": {
+    "mcp.tool.you.factory_session.get_result": {
+      "id": "mcp.tool.you.factory_session.get_result",
+      "name": "you.factory_session.get_result",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.get_result",
+        "documentation": {
+          "title": {
+            "id": "mcp.tool.you.factory_session.get_result.title",
+            "canonicalEnglish": "Get Factory Session Result"
+          },
+          "description": {
+            "id": "mcp.tool.you.factory_session.get_result.description",
+            "canonicalEnglish": "Reads the terminal or partial result for one durable Factory Session."
+          }
+        },
+        "examples": [
+          {
+            "sessionId": "dur-sess-001"
+          }
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "mcp.tool.you.factory_session.get_result",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "transports": [
+        "stdio-json-rpc"
+      ],
+      "execution": {
+        "mode": "tools-call"
+      },
+      "result": {
+        "transport": {
+          "contentTypes": [
+            "text"
+          ],
+          "textEncoding": "serialized-json",
+          "allowsStructuredContent": false,
+          "allowsOutputSchema": false
+        },
+        "examples": [
+          {
+            "content": [
+              {
+                "type": "text",
+                "text": "{\"result\":{\"sessionId\":\"dur-sess-001\",\"status\":\"SUCCEEDED\"}}"
+              }
+            ],
+            "isError": false
+          }
+        ]
+      }
+    }
+  }
+}

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -122,6 +122,10 @@ Use this map when changing the public REST contract.
   `make contracts-validate`. Invalid fixtures are asserted in focused
   `internal/contractvalidator` tests with path-bearing diagnostics, not in the
   default valid-only registry pass.
+- Tool `input` combines a closed Draft `schema` (`#/$defs/closedDraftSchema`)
+  with object-keyed `arguments` using `mcp.arg.*` stable IDs; `execution.mode`
+  is pinned to `tools-call` and `transports` to `stdio-json-rpc` for the
+  supported protocol surface.
 - Compatibility aliases remain only in `contracts/mcp/deprecated.json`; the
   tool-catalog schema is build-time contract validation only and does not cut
   over `packages/api/generated/mcp/tools.json` or runtime discovery.

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -110,6 +110,22 @@ Use this map when changing the public REST contract.
   versions, removal gates, approval status). Per-family schema validation stays
   in `contracts/*_deprecated_inventory_test.go`.
 
+## MCP tool catalog contract ownership
+
+- Authored MCP tool catalog schema lives at
+  `contracts/mcp/tool-catalog.schema.json` (Draft 2020-12, protocol pin
+  `2024-11-05`, format version `1.0.0`). Tool records compose B04 documentation
+  and lifecycle shapes via `$ref` to `contracts/common/documentation.schema.json`
+  and `contracts/common/deprecations.schema.json`.
+- Valid MCP catalog fixtures live under `contracts/testdata/mcp/` and register
+  through `internal/contractvalidator.MCPRegistry()` into
+  `make contracts-validate`. Invalid fixtures are asserted in focused
+  `internal/contractvalidator` tests with path-bearing diagnostics, not in the
+  default valid-only registry pass.
+- Compatibility aliases remain only in `contracts/mcp/deprecated.json`; the
+  tool-catalog schema is build-time contract validation only and does not cut
+  over `packages/api/generated/mcp/tools.json` or runtime discovery.
+
 ## Focused compatibility alias internal-use lint
 
 - `internal/contractguard` loads inventoried compatibility alias match values from

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -121,7 +121,9 @@ Use this map when changing the public REST contract.
   through `internal/contractvalidator.MCPRegistry()` into
   `make contracts-validate`. Invalid fixtures are asserted in focused
   `internal/contractvalidator` tests with path-bearing diagnostics, not in the
-  default valid-only registry pass.
+  default valid-only registry pass. Consolidated fixture-matrix closure lives in
+  `contracts/mcp_tool_catalog_fixture_matrix_test.go` (valid/invalid classes,
+  directory coverage, registry alignment, and no-production-cutover boundary).
 - Tool `input` combines a closed Draft `schema` (`#/$defs/closedDraftSchema`)
   with object-keyed `arguments` using `mcp.arg.*` stable IDs; `execution.mode`
   is pinned to `tools-call` and `transports` to `stdio-json-rpc` for the

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -128,9 +128,12 @@ Use this map when changing the public REST contract.
   supported protocol surface.
 - Reusable MCP protocol components live under `contracts/mcp/protocol/`
   (`content.schema.json` documents broader MCP content kinds; `call-tool-result.schema.json`
-  defines the `pinnedTextCallToolResult` envelope used by tool `result.examples`).
-  Tool `result.transport` pins text-only content types and rejects
-  `structuredContent` / `outputSchema` advertising.
+  defines the `pinnedTextCallToolResult` envelope used by tool `result.examples`;
+  `domain-tool-response.schema.json` documents typed domain success/failure payloads
+  serialized into text; `json-rpc-error.schema.json` documents protocol failures
+  distinct from domain errors). Tool `result.domain` groups domain success/failure
+  documentation separately from `result.transport` and `result.examples`; catalog-level
+  `protocolFailures` documents JSON-RPC invalid-params/unknown-method failures.
 - Compatibility aliases remain only in `contracts/mcp/deprecated.json`; the
   tool-catalog schema is build-time contract validation only and does not cut
   over `packages/api/generated/mcp/tools.json` or runtime discovery.

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -137,6 +137,11 @@ Use this map when changing the public REST contract.
 - Compatibility aliases remain only in `contracts/mcp/deprecated.json`; the
   tool-catalog schema is build-time contract validation only and does not cut
   over `packages/api/generated/mcp/tools.json` or runtime discovery.
+- Tool `handler` binds handwritten implementations with `mcp.handler.*` stable
+  IDs (`#/$defs/handler`). Duplicate documentation IDs, broken handler IDs,
+  unknown `protocolVersion`, and malformed lifecycle/documentation records fail
+  through schema validation or family-neutral `identity.duplicate` diagnostics in
+  focused `validator_test.go` cases.
 
 ## Focused compatibility alias internal-use lint
 

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -126,6 +126,11 @@ Use this map when changing the public REST contract.
   with object-keyed `arguments` using `mcp.arg.*` stable IDs; `execution.mode`
   is pinned to `tools-call` and `transports` to `stdio-json-rpc` for the
   supported protocol surface.
+- Reusable MCP protocol components live under `contracts/mcp/protocol/`
+  (`content.schema.json` documents broader MCP content kinds; `call-tool-result.schema.json`
+  defines the `pinnedTextCallToolResult` envelope used by tool `result.examples`).
+  Tool `result.transport` pins text-only content types and rejects
+  `structuredContent` / `outputSchema` advertising.
 - Compatibility aliases remain only in `contracts/mcp/deprecated.json`; the
   tool-catalog schema is build-time contract validation only and does not cut
   over `packages/api/generated/mcp/tools.json` or runtime discovery.

--- a/internal/contractvalidator/validator.go
+++ b/internal/contractvalidator/validator.go
@@ -102,6 +102,8 @@ func CommonRegistry() Registry {
 func MCPRegistry() Registry {
 	const (
 		toolCatalogID   = "https://schemas.portpowered.com/you/contracts/mcp/tool-catalog.schema.json"
+		contentID       = "https://schemas.portpowered.com/you/contracts/mcp/protocol/content.schema.json"
+		callToolResultID = "https://schemas.portpowered.com/you/contracts/mcp/protocol/call-tool-result.schema.json"
 		documentationID = "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json"
 		deprecationsID  = "https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json"
 	)
@@ -111,11 +113,15 @@ func MCPRegistry() Registry {
 		Schemas: []Schema{
 			{ID: documentationID, Path: "contracts/common/documentation.schema.json"},
 			{ID: deprecationsID, Path: "contracts/common/deprecations.schema.json"},
+			{ID: contentID, Path: "contracts/mcp/protocol/content.schema.json"},
+			{ID: callToolResultID, Path: "contracts/mcp/protocol/call-tool-result.schema.json"},
 			{ID: toolCatalogID, Path: "contracts/mcp/tool-catalog.schema.json"},
 		},
 		Documents: []Document{
 			{Path: "contracts/testdata/mcp/valid-minimal.json", SchemaID: toolCatalogID},
 			{Path: "contracts/testdata/mcp/valid-input-closed-nested.json", SchemaID: toolCatalogID},
+			{Path: "contracts/testdata/mcp/valid-text-success-result.json", SchemaID: toolCatalogID},
+			{Path: "contracts/testdata/mcp/valid-text-error-result.json", SchemaID: toolCatalogID},
 		},
 	})
 }

--- a/internal/contractvalidator/validator.go
+++ b/internal/contractvalidator/validator.go
@@ -115,6 +115,7 @@ func MCPRegistry() Registry {
 		},
 		Documents: []Document{
 			{Path: "contracts/testdata/mcp/valid-minimal.json", SchemaID: toolCatalogID},
+			{Path: "contracts/testdata/mcp/valid-input-closed-nested.json", SchemaID: toolCatalogID},
 		},
 	})
 }

--- a/internal/contractvalidator/validator.go
+++ b/internal/contractvalidator/validator.go
@@ -72,7 +72,7 @@ func MergeRegistries(registries ...Registry) Registry {
 
 // DefaultRegistry registers every contract family validated by make contracts-validate.
 func DefaultRegistry() Registry {
-	return MergeRegistries(CommonRegistry(), CLIRegistry(), CompatibilityInventoryRegistry())
+	return MergeRegistries(CommonRegistry(), CLIRegistry(), CompatibilityInventoryRegistry(), MCPRegistry())
 }
 
 // CommonRegistry registers the common schemas and their merged valid fixtures.
@@ -94,6 +94,27 @@ func CommonRegistry() Registry {
 			{Path: "contracts/testdata/common/deprecations/valid-active.json", SchemaID: deprecationsID},
 			{Path: "contracts/testdata/common/deprecations/valid-deprecated.json", SchemaID: deprecationsID},
 			{Path: "contracts/testdata/common/deprecations/valid-removed.json", SchemaID: deprecationsID},
+		},
+	})
+}
+
+// MCPRegistry registers the MCP tool-catalog schema and its valid fixtures.
+func MCPRegistry() Registry {
+	const (
+		toolCatalogID   = "https://schemas.portpowered.com/you/contracts/mcp/tool-catalog.schema.json"
+		documentationID = "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json"
+		deprecationsID  = "https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json"
+	)
+	return NewRegistry(Entry{
+		Family:        "mcp",
+		FormatVersion: "1.0.0",
+		Schemas: []Schema{
+			{ID: documentationID, Path: "contracts/common/documentation.schema.json"},
+			{ID: deprecationsID, Path: "contracts/common/deprecations.schema.json"},
+			{ID: toolCatalogID, Path: "contracts/mcp/tool-catalog.schema.json"},
+		},
+		Documents: []Document{
+			{Path: "contracts/testdata/mcp/valid-minimal.json", SchemaID: toolCatalogID},
 		},
 	})
 }

--- a/internal/contractvalidator/validator.go
+++ b/internal/contractvalidator/validator.go
@@ -128,6 +128,7 @@ func MCPRegistry() Registry {
 			{Path: "contracts/testdata/mcp/valid-text-error-result.json", SchemaID: toolCatalogID},
 			{Path: "contracts/testdata/mcp/valid-domain-failure-result.json", SchemaID: toolCatalogID},
 			{Path: "contracts/testdata/mcp/valid-protocol-failures.json", SchemaID: toolCatalogID},
+			{Path: "contracts/testdata/mcp/valid-handler-binding.json", SchemaID: toolCatalogID},
 		},
 	})
 }

--- a/internal/contractvalidator/validator.go
+++ b/internal/contractvalidator/validator.go
@@ -101,11 +101,13 @@ func CommonRegistry() Registry {
 // MCPRegistry registers the MCP tool-catalog schema and its valid fixtures.
 func MCPRegistry() Registry {
 	const (
-		toolCatalogID   = "https://schemas.portpowered.com/you/contracts/mcp/tool-catalog.schema.json"
-		contentID       = "https://schemas.portpowered.com/you/contracts/mcp/protocol/content.schema.json"
-		callToolResultID = "https://schemas.portpowered.com/you/contracts/mcp/protocol/call-tool-result.schema.json"
-		documentationID = "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json"
-		deprecationsID  = "https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json"
+		toolCatalogID        = "https://schemas.portpowered.com/you/contracts/mcp/tool-catalog.schema.json"
+		contentID            = "https://schemas.portpowered.com/you/contracts/mcp/protocol/content.schema.json"
+		callToolResultID     = "https://schemas.portpowered.com/you/contracts/mcp/protocol/call-tool-result.schema.json"
+		domainToolResponseID = "https://schemas.portpowered.com/you/contracts/mcp/protocol/domain-tool-response.schema.json"
+		jsonRPCErrorID       = "https://schemas.portpowered.com/you/contracts/mcp/protocol/json-rpc-error.schema.json"
+		documentationID      = "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json"
+		deprecationsID       = "https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json"
 	)
 	return NewRegistry(Entry{
 		Family:        "mcp",
@@ -115,6 +117,8 @@ func MCPRegistry() Registry {
 			{ID: deprecationsID, Path: "contracts/common/deprecations.schema.json"},
 			{ID: contentID, Path: "contracts/mcp/protocol/content.schema.json"},
 			{ID: callToolResultID, Path: "contracts/mcp/protocol/call-tool-result.schema.json"},
+			{ID: domainToolResponseID, Path: "contracts/mcp/protocol/domain-tool-response.schema.json"},
+			{ID: jsonRPCErrorID, Path: "contracts/mcp/protocol/json-rpc-error.schema.json"},
 			{ID: toolCatalogID, Path: "contracts/mcp/tool-catalog.schema.json"},
 		},
 		Documents: []Document{
@@ -122,6 +126,8 @@ func MCPRegistry() Registry {
 			{Path: "contracts/testdata/mcp/valid-input-closed-nested.json", SchemaID: toolCatalogID},
 			{Path: "contracts/testdata/mcp/valid-text-success-result.json", SchemaID: toolCatalogID},
 			{Path: "contracts/testdata/mcp/valid-text-error-result.json", SchemaID: toolCatalogID},
+			{Path: "contracts/testdata/mcp/valid-domain-failure-result.json", SchemaID: toolCatalogID},
+			{Path: "contracts/testdata/mcp/valid-protocol-failures.json", SchemaID: toolCatalogID},
 		},
 	})
 }

--- a/internal/contractvalidator/validator_test.go
+++ b/internal/contractvalidator/validator_test.go
@@ -48,47 +48,86 @@ func TestValidateMCPInvalidCatalogDiagnostics(t *testing.T) {
 	tests := []struct {
 		name     string
 		fixture  string
+		code     string
 		wantPath string
 	}{
 		{
 			name:     "open nested input object",
 			fixture:  "contracts/testdata/mcp/invalid-open-nested-input.json",
+			code:     "schema.validation",
 			wantPath: "/tools/mcp.tool.you.factory_session.start_async/input/schema/properties/source/additionalProperties",
 		},
 		{
 			name:     "unsupported task behavior",
 			fixture:  "contracts/testdata/mcp/invalid-unsupported-task.json",
+			code:     "schema.validation",
 			wantPath: "/tools/mcp.tool.you.factory_session.list/execution/mode",
 		},
 		{
 			name:     "result image content",
 			fixture:  "contracts/testdata/mcp/invalid-result-image.json",
+			code:     "schema.validation",
 			wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0/content/0/type",
 		},
 		{
 			name:     "result audio content",
 			fixture:  "contracts/testdata/mcp/invalid-result-audio.json",
+			code:     "schema.validation",
 			wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0/content/0/type",
 		},
 		{
 			name:     "result embedded resource content",
 			fixture:  "contracts/testdata/mcp/invalid-result-embedded-resource.json",
+			code:     "schema.validation",
 			wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0/content/0/type",
 		},
 		{
 			name:     "result structured content field",
 			fixture:  "contracts/testdata/mcp/invalid-result-structured-content.json",
+			code:     "schema.validation",
 			wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0",
 		},
 		{
 			name:     "result output schema field",
 			fixture:  "contracts/testdata/mcp/invalid-result-output-schema.json",
+			code:     "schema.validation",
 			wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0",
 		},
 		{
 			name:     "domain failure confused with protocol error",
 			fixture:  "contracts/testdata/mcp/invalid-domain-confused-with-protocol-error.json",
+			code:     "schema.validation",
 			wantPath: "/tools/mcp.tool.you.factory_session.get/result/domain/failures/mcp.failure.you.factory_session.get.protocol_confusion/examples/0",
+		},
+		{
+			name:     "duplicate stable documentation IDs",
+			fixture:  "contracts/testdata/mcp/invalid-duplicate-stable-id.json",
+			code:     "identity.duplicate",
+			wantPath: "/tools/mcp.tool.you.factory_session.list_dispatches/documentation/documentation/title/id",
+		},
+		{
+			name:     "broken handler ID",
+			fixture:  "contracts/testdata/mcp/invalid-handler-id.json",
+			code:     "schema.validation",
+			wantPath: "/tools/mcp.tool.you.factory_session.read_events/handler/id",
+		},
+		{
+			name:     "unknown protocol version",
+			fixture:  "contracts/testdata/mcp/invalid-unknown-protocol-version.json",
+			code:     "schema.validation",
+			wantPath: "/protocolVersion",
+		},
+		{
+			name:     "malformed lifecycle record",
+			fixture:  "contracts/testdata/mcp/invalid-malformed-lifecycle.json",
+			code:     "schema.validation",
+			wantPath: "/tools/mcp.tool.you.factory_session.start_sync/lifecycle",
+		},
+		{
+			name:     "malformed documentation record",
+			fixture:  "contracts/testdata/mcp/invalid-malformed-documentation.json",
+			code:     "schema.validation",
+			wantPath: "/tools/mcp.tool.you.factory_session.get/documentation/documentation/title/id",
 		},
 	}
 
@@ -99,14 +138,18 @@ func TestValidateMCPInvalidCatalogDiagnostics(t *testing.T) {
 				t.Fatal("expected diagnostics, got none")
 			}
 			found := false
+			wantCode := test.code
+			if wantCode == "" {
+				wantCode = "schema.validation"
+			}
 			for _, diagnostic := range diagnostics {
-				if diagnostic.Code == "schema.validation" && diagnostic.Path == test.wantPath && diagnostic.Document == test.fixture {
+				if diagnostic.Code == wantCode && diagnostic.Path == test.wantPath && diagnostic.Document == test.fixture {
 					found = true
 					break
 				}
 			}
 			if !found {
-				t.Fatalf("diagnostics = %+v, want code=%q path=%q document=%q", diagnostics, "schema.validation", test.wantPath, test.fixture)
+				t.Fatalf("diagnostics = %+v, want code=%q path=%q document=%q", diagnostics, wantCode, test.wantPath, test.fixture)
 			}
 		})
 	}

--- a/internal/contractvalidator/validator_test.go
+++ b/internal/contractvalidator/validator_test.go
@@ -42,117 +42,119 @@ func TestMCPRegistryValidFixtures(t *testing.T) {
 	}
 }
 
+var mcpInvalidCatalogDiagnosticCases = []struct {
+	name     string
+	fixture  string
+	code     string
+	wantPath string
+}{
+	{
+		name:     "open nested input object",
+		fixture:  "contracts/testdata/mcp/invalid-open-nested-input.json",
+		code:     "schema.validation",
+		wantPath: "/tools/mcp.tool.you.factory_session.start_async/input/schema/properties/source/additionalProperties",
+	},
+	{
+		name:     "unsupported task behavior",
+		fixture:  "contracts/testdata/mcp/invalid-unsupported-task.json",
+		code:     "schema.validation",
+		wantPath: "/tools/mcp.tool.you.factory_session.list/execution/mode",
+	},
+	{
+		name:     "result image content",
+		fixture:  "contracts/testdata/mcp/invalid-result-image.json",
+		code:     "schema.validation",
+		wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0/content/0/type",
+	},
+	{
+		name:     "result audio content",
+		fixture:  "contracts/testdata/mcp/invalid-result-audio.json",
+		code:     "schema.validation",
+		wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0/content/0/type",
+	},
+	{
+		name:     "result embedded resource content",
+		fixture:  "contracts/testdata/mcp/invalid-result-embedded-resource.json",
+		code:     "schema.validation",
+		wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0/content/0/type",
+	},
+	{
+		name:     "result structured content field",
+		fixture:  "contracts/testdata/mcp/invalid-result-structured-content.json",
+		code:     "schema.validation",
+		wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0",
+	},
+	{
+		name:     "result output schema field",
+		fixture:  "contracts/testdata/mcp/invalid-result-output-schema.json",
+		code:     "schema.validation",
+		wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0",
+	},
+	{
+		name:     "domain failure confused with protocol error",
+		fixture:  "contracts/testdata/mcp/invalid-domain-confused-with-protocol-error.json",
+		code:     "schema.validation",
+		wantPath: "/tools/mcp.tool.you.factory_session.get/result/domain/failures/mcp.failure.you.factory_session.get.protocol_confusion/examples/0",
+	},
+	{
+		name:     "duplicate stable documentation IDs",
+		fixture:  "contracts/testdata/mcp/invalid-duplicate-stable-id.json",
+		code:     "identity.duplicate",
+		wantPath: "/tools/mcp.tool.you.factory_session.list_dispatches/documentation/documentation/title/id",
+	},
+	{
+		name:     "broken handler ID",
+		fixture:  "contracts/testdata/mcp/invalid-handler-id.json",
+		code:     "schema.validation",
+		wantPath: "/tools/mcp.tool.you.factory_session.read_events/handler/id",
+	},
+	{
+		name:     "unknown protocol version",
+		fixture:  "contracts/testdata/mcp/invalid-unknown-protocol-version.json",
+		code:     "schema.validation",
+		wantPath: "/protocolVersion",
+	},
+	{
+		name:     "malformed lifecycle record",
+		fixture:  "contracts/testdata/mcp/invalid-malformed-lifecycle.json",
+		code:     "schema.validation",
+		wantPath: "/tools/mcp.tool.you.factory_session.start_sync/lifecycle",
+	},
+	{
+		name:     "malformed documentation record",
+		fixture:  "contracts/testdata/mcp/invalid-malformed-documentation.json",
+		code:     "schema.validation",
+		wantPath: "/tools/mcp.tool.you.factory_session.get/documentation/documentation/title/id",
+	},
+}
+
 func TestValidateMCPInvalidCatalogDiagnostics(t *testing.T) {
 	root := repositoryRoot(t)
 
-	tests := []struct {
-		name     string
-		fixture  string
-		code     string
-		wantPath string
-	}{
-		{
-			name:     "open nested input object",
-			fixture:  "contracts/testdata/mcp/invalid-open-nested-input.json",
-			code:     "schema.validation",
-			wantPath: "/tools/mcp.tool.you.factory_session.start_async/input/schema/properties/source/additionalProperties",
-		},
-		{
-			name:     "unsupported task behavior",
-			fixture:  "contracts/testdata/mcp/invalid-unsupported-task.json",
-			code:     "schema.validation",
-			wantPath: "/tools/mcp.tool.you.factory_session.list/execution/mode",
-		},
-		{
-			name:     "result image content",
-			fixture:  "contracts/testdata/mcp/invalid-result-image.json",
-			code:     "schema.validation",
-			wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0/content/0/type",
-		},
-		{
-			name:     "result audio content",
-			fixture:  "contracts/testdata/mcp/invalid-result-audio.json",
-			code:     "schema.validation",
-			wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0/content/0/type",
-		},
-		{
-			name:     "result embedded resource content",
-			fixture:  "contracts/testdata/mcp/invalid-result-embedded-resource.json",
-			code:     "schema.validation",
-			wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0/content/0/type",
-		},
-		{
-			name:     "result structured content field",
-			fixture:  "contracts/testdata/mcp/invalid-result-structured-content.json",
-			code:     "schema.validation",
-			wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0",
-		},
-		{
-			name:     "result output schema field",
-			fixture:  "contracts/testdata/mcp/invalid-result-output-schema.json",
-			code:     "schema.validation",
-			wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0",
-		},
-		{
-			name:     "domain failure confused with protocol error",
-			fixture:  "contracts/testdata/mcp/invalid-domain-confused-with-protocol-error.json",
-			code:     "schema.validation",
-			wantPath: "/tools/mcp.tool.you.factory_session.get/result/domain/failures/mcp.failure.you.factory_session.get.protocol_confusion/examples/0",
-		},
-		{
-			name:     "duplicate stable documentation IDs",
-			fixture:  "contracts/testdata/mcp/invalid-duplicate-stable-id.json",
-			code:     "identity.duplicate",
-			wantPath: "/tools/mcp.tool.you.factory_session.list_dispatches/documentation/documentation/title/id",
-		},
-		{
-			name:     "broken handler ID",
-			fixture:  "contracts/testdata/mcp/invalid-handler-id.json",
-			code:     "schema.validation",
-			wantPath: "/tools/mcp.tool.you.factory_session.read_events/handler/id",
-		},
-		{
-			name:     "unknown protocol version",
-			fixture:  "contracts/testdata/mcp/invalid-unknown-protocol-version.json",
-			code:     "schema.validation",
-			wantPath: "/protocolVersion",
-		},
-		{
-			name:     "malformed lifecycle record",
-			fixture:  "contracts/testdata/mcp/invalid-malformed-lifecycle.json",
-			code:     "schema.validation",
-			wantPath: "/tools/mcp.tool.you.factory_session.start_sync/lifecycle",
-		},
-		{
-			name:     "malformed documentation record",
-			fixture:  "contracts/testdata/mcp/invalid-malformed-documentation.json",
-			code:     "schema.validation",
-			wantPath: "/tools/mcp.tool.you.factory_session.get/documentation/documentation/title/id",
-		},
-	}
-
-	for _, test := range tests {
+	for _, test := range mcpInvalidCatalogDiagnosticCases {
 		t.Run(test.name, func(t *testing.T) {
-			diagnostics := contractvalidator.Validate(root, mcpCatalogFixtureRegistry(test.fixture), "mcp", "1.0.0")
-			if len(diagnostics) == 0 {
-				t.Fatal("expected diagnostics, got none")
-			}
-			found := false
-			wantCode := test.code
-			if wantCode == "" {
-				wantCode = "schema.validation"
-			}
-			for _, diagnostic := range diagnostics {
-				if diagnostic.Code == wantCode && diagnostic.Path == test.wantPath && diagnostic.Document == test.fixture {
-					found = true
-					break
-				}
-			}
-			if !found {
-				t.Fatalf("diagnostics = %+v, want code=%q path=%q document=%q", diagnostics, wantCode, test.wantPath, test.fixture)
-			}
+			assertMCPInvalidCatalogDiagnostic(t, root, test.fixture, test.code, test.wantPath)
 		})
 	}
+}
+
+func assertMCPInvalidCatalogDiagnostic(t *testing.T, root, fixture, code, wantPath string) {
+	t.Helper()
+
+	diagnostics := contractvalidator.Validate(root, mcpCatalogFixtureRegistry(fixture), "mcp", "1.0.0")
+	if len(diagnostics) == 0 {
+		t.Fatal("expected diagnostics, got none")
+	}
+	wantCode := code
+	if wantCode == "" {
+		wantCode = "schema.validation"
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Code == wantCode && diagnostic.Path == wantPath && diagnostic.Document == fixture {
+			return
+		}
+	}
+	t.Fatalf("diagnostics = %+v, want code=%q path=%q document=%q", diagnostics, wantCode, wantPath, fixture)
 }
 
 func mcpCatalogFixtureRegistry(fixture string) contractvalidator.Registry {

--- a/internal/contractvalidator/validator_test.go
+++ b/internal/contractvalidator/validator_test.go
@@ -42,6 +42,64 @@ func TestMCPRegistryValidFixtures(t *testing.T) {
 	}
 }
 
+func TestValidateMCPInvalidCatalogDiagnostics(t *testing.T) {
+	root := repositoryRoot(t)
+
+	tests := []struct {
+		name     string
+		fixture  string
+		wantPath string
+	}{
+		{
+			name:     "open nested input object",
+			fixture:  "contracts/testdata/mcp/invalid-open-nested-input.json",
+			wantPath: "/tools/mcp.tool.you.factory_session.start_async/input/schema/properties/source/additionalProperties",
+		},
+		{
+			name:     "unsupported task behavior",
+			fixture:  "contracts/testdata/mcp/invalid-unsupported-task.json",
+			wantPath: "/tools/mcp.tool.you.factory_session.list/execution/mode",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			diagnostics := contractvalidator.Validate(root, mcpCatalogFixtureRegistry(test.fixture), "mcp", "1.0.0")
+			if len(diagnostics) == 0 {
+				t.Fatal("expected diagnostics, got none")
+			}
+			found := false
+			for _, diagnostic := range diagnostics {
+				if diagnostic.Code == "schema.validation" && diagnostic.Path == test.wantPath && diagnostic.Document == test.fixture {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("diagnostics = %+v, want code=%q path=%q document=%q", diagnostics, "schema.validation", test.wantPath, test.fixture)
+			}
+		})
+	}
+}
+
+func mcpCatalogFixtureRegistry(fixture string) contractvalidator.Registry {
+	const (
+		toolCatalogID   = "https://schemas.portpowered.com/you/contracts/mcp/tool-catalog.schema.json"
+		documentationID = "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json"
+		deprecationsID  = "https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json"
+	)
+	return contractvalidator.NewRegistry(contractvalidator.Entry{
+		Family:        "mcp",
+		FormatVersion: "1.0.0",
+		Schemas: []contractvalidator.Schema{
+			{ID: documentationID, Path: "contracts/common/documentation.schema.json"},
+			{ID: deprecationsID, Path: "contracts/common/deprecations.schema.json"},
+			{ID: toolCatalogID, Path: "contracts/mcp/tool-catalog.schema.json"},
+		},
+		Documents: []contractvalidator.Document{{Path: fixture, SchemaID: toolCatalogID}},
+	})
+}
+
 func TestValidateCLIInvalidManifestDiagnostics(t *testing.T) {
 	root := repositoryRoot(t)
 

--- a/internal/contractvalidator/validator_test.go
+++ b/internal/contractvalidator/validator_test.go
@@ -34,6 +34,14 @@ func TestCLIRegistryValidFixtures(t *testing.T) {
 	}
 }
 
+func TestMCPRegistryValidFixtures(t *testing.T) {
+	root := repositoryRoot(t)
+	diagnostics := contractvalidator.Validate(root, contractvalidator.MCPRegistry(), "mcp", "1.0.0")
+	if len(diagnostics) != 0 {
+		t.Fatalf("Validate() diagnostics = %+v, want none", diagnostics)
+	}
+}
+
 func TestValidateCLIInvalidManifestDiagnostics(t *testing.T) {
 	root := repositoryRoot(t)
 

--- a/internal/contractvalidator/validator_test.go
+++ b/internal/contractvalidator/validator_test.go
@@ -60,6 +60,31 @@ func TestValidateMCPInvalidCatalogDiagnostics(t *testing.T) {
 			fixture:  "contracts/testdata/mcp/invalid-unsupported-task.json",
 			wantPath: "/tools/mcp.tool.you.factory_session.list/execution/mode",
 		},
+		{
+			name:     "result image content",
+			fixture:  "contracts/testdata/mcp/invalid-result-image.json",
+			wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0/content/0/type",
+		},
+		{
+			name:     "result audio content",
+			fixture:  "contracts/testdata/mcp/invalid-result-audio.json",
+			wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0/content/0/type",
+		},
+		{
+			name:     "result embedded resource content",
+			fixture:  "contracts/testdata/mcp/invalid-result-embedded-resource.json",
+			wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0/content/0/type",
+		},
+		{
+			name:     "result structured content field",
+			fixture:  "contracts/testdata/mcp/invalid-result-structured-content.json",
+			wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0",
+		},
+		{
+			name:     "result output schema field",
+			fixture:  "contracts/testdata/mcp/invalid-result-output-schema.json",
+			wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0",
+		},
 	}
 
 	for _, test := range tests {
@@ -84,9 +109,11 @@ func TestValidateMCPInvalidCatalogDiagnostics(t *testing.T) {
 
 func mcpCatalogFixtureRegistry(fixture string) contractvalidator.Registry {
 	const (
-		toolCatalogID   = "https://schemas.portpowered.com/you/contracts/mcp/tool-catalog.schema.json"
-		documentationID = "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json"
-		deprecationsID  = "https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json"
+		toolCatalogID    = "https://schemas.portpowered.com/you/contracts/mcp/tool-catalog.schema.json"
+		contentID        = "https://schemas.portpowered.com/you/contracts/mcp/protocol/content.schema.json"
+		callToolResultID = "https://schemas.portpowered.com/you/contracts/mcp/protocol/call-tool-result.schema.json"
+		documentationID  = "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json"
+		deprecationsID   = "https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json"
 	)
 	return contractvalidator.NewRegistry(contractvalidator.Entry{
 		Family:        "mcp",
@@ -94,6 +121,8 @@ func mcpCatalogFixtureRegistry(fixture string) contractvalidator.Registry {
 		Schemas: []contractvalidator.Schema{
 			{ID: documentationID, Path: "contracts/common/documentation.schema.json"},
 			{ID: deprecationsID, Path: "contracts/common/deprecations.schema.json"},
+			{ID: contentID, Path: "contracts/mcp/protocol/content.schema.json"},
+			{ID: callToolResultID, Path: "contracts/mcp/protocol/call-tool-result.schema.json"},
 			{ID: toolCatalogID, Path: "contracts/mcp/tool-catalog.schema.json"},
 		},
 		Documents: []contractvalidator.Document{{Path: fixture, SchemaID: toolCatalogID}},

--- a/internal/contractvalidator/validator_test.go
+++ b/internal/contractvalidator/validator_test.go
@@ -85,6 +85,11 @@ func TestValidateMCPInvalidCatalogDiagnostics(t *testing.T) {
 			fixture:  "contracts/testdata/mcp/invalid-result-output-schema.json",
 			wantPath: "/tools/mcp.tool.you.factory_session.list/result/examples/0",
 		},
+		{
+			name:     "domain failure confused with protocol error",
+			fixture:  "contracts/testdata/mcp/invalid-domain-confused-with-protocol-error.json",
+			wantPath: "/tools/mcp.tool.you.factory_session.get/result/domain/failures/mcp.failure.you.factory_session.get.protocol_confusion/examples/0",
+		},
 	}
 
 	for _, test := range tests {
@@ -109,11 +114,13 @@ func TestValidateMCPInvalidCatalogDiagnostics(t *testing.T) {
 
 func mcpCatalogFixtureRegistry(fixture string) contractvalidator.Registry {
 	const (
-		toolCatalogID    = "https://schemas.portpowered.com/you/contracts/mcp/tool-catalog.schema.json"
-		contentID        = "https://schemas.portpowered.com/you/contracts/mcp/protocol/content.schema.json"
-		callToolResultID = "https://schemas.portpowered.com/you/contracts/mcp/protocol/call-tool-result.schema.json"
-		documentationID  = "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json"
-		deprecationsID   = "https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json"
+		toolCatalogID        = "https://schemas.portpowered.com/you/contracts/mcp/tool-catalog.schema.json"
+		contentID            = "https://schemas.portpowered.com/you/contracts/mcp/protocol/content.schema.json"
+		callToolResultID     = "https://schemas.portpowered.com/you/contracts/mcp/protocol/call-tool-result.schema.json"
+		domainToolResponseID = "https://schemas.portpowered.com/you/contracts/mcp/protocol/domain-tool-response.schema.json"
+		jsonRPCErrorID       = "https://schemas.portpowered.com/you/contracts/mcp/protocol/json-rpc-error.schema.json"
+		documentationID      = "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json"
+		deprecationsID       = "https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json"
 	)
 	return contractvalidator.NewRegistry(contractvalidator.Entry{
 		Family:        "mcp",
@@ -123,6 +130,8 @@ func mcpCatalogFixtureRegistry(fixture string) contractvalidator.Registry {
 			{ID: deprecationsID, Path: "contracts/common/deprecations.schema.json"},
 			{ID: contentID, Path: "contracts/mcp/protocol/content.schema.json"},
 			{ID: callToolResultID, Path: "contracts/mcp/protocol/call-tool-result.schema.json"},
+			{ID: domainToolResponseID, Path: "contracts/mcp/protocol/domain-tool-response.schema.json"},
+			{ID: jsonRPCErrorID, Path: "contracts/mcp/protocol/json-rpc-error.schema.json"},
 			{ID: toolCatalogID, Path: "contracts/mcp/tool-catalog.schema.json"},
 		},
 		Documents: []contractvalidator.Document{{Path: fixture, SchemaID: toolCatalogID}},


### PR DESCRIPTION
{
  "project": "Define the Pinned MCP 2024-11-05 Tool-Catalog Contract",
  "branchName": "interfaces-b13-mcp-schema",
  "description": "Author contracts/mcp/tool-catalog.schema.json plus narrowly reusable protocol content/result components and a complete valid/invalid fixture matrix for MCP protocol version 2024-11-05—covering stable tool/documentation IDs, canonical names, transports, task support, annotations, Draft input schemas, domain output documentation, text-only CallToolResult with isError, typed tool/domain failures, JSON-RPC protocol failures, examples, lifecycle, and handwritten handler IDs—wired through make contracts-validate without production tools.json cutover, runtime MCP changes, or B14 generation.",
  "context": {
    "customerAsk": "Author contracts/mcp/tool-catalog.schema.json plus narrowly reusable protocol content/result components and a complete valid/invalid fixture matrix for MCP protocol version 2024-11-05. Represent stable tool and documentation IDs, canonical names, transports, task support, annotations, Draft input schemas, domain output documentation, the current text-only CallToolResult envelope, isError behavior, typed tool/domain failures, JSON-RPC protocol failures, examples, lifecycle, and handwritten handler IDs. Keep aliases in deprecated.json and do not add tools, result modalities, outputSchema, or runtime behavior. Build-time contract only: do not change DiscoverTools, tools/list, tools/call, handlers, aliases, service behavior, or runtime dependencies. Reuse B04 common documentation/deprecation vocabulary and B09 compatibility decisions. Do not begin B14 discovery generation or structural closure.",
    "problem": "Interfaces B04 common validation and B09 compatibility classification are merged, and canonical MCP discovery/alias/text-result baselines exist, but contracts/mcp has no canonical tool-catalog schema so packages/api/generated/mcp/tools.json remains an inventory projection. Without a pinned Draft 2020-12 schema and fixture matrix, later catalog authoring and B14 generation cannot prove valid text success/error shapes, cannot reject advertised image/audio/resource/structuredContent/outputSchema/unsupported-task capabilities with deterministic paths, and cannot keep typed domain results/errors distinct from the CallToolResult envelope and JSON-RPC protocol errors.",
    "solution": "Author one closed Draft 2020-12 MCP tool-catalog schema under contracts/mcp/, add narrowly reusable protocol content/result components for the pinned 2024-11-05 text-only envelope, and add a complete valid/invalid fixture matrix registered with the existing build-time contractvalidator—so valid text fixtures pass make contracts-validate while unsupported modalities and structural invalid cases fail with deterministic actionable paths—without production tools.json cutover, runtime MCP changes, alias moves out of deprecated.json, or B14 generation/closure."
  },
  "acceptanceCriteria": [
    "AC-1: Valid canonical text success and text error fixtures validate through the common contract validator.",
    "AC-2: Fixtures advertising image, audio, embedded resources, structuredContent, outputSchema, or unsupported task behavior fail with deterministic paths.",
    "AC-3: Typed domain results/errors remain distinct from the MCP CallToolResult envelope and JSON-RPC protocol errors.",
    "AC-4: Duplicate stable IDs, broken handler IDs, open nested input objects, unknown protocol versions, and malformed lifecycle/documentation records fail deterministically.",
    "AC-5: No production MCP tool catalog cutover and no changes to DiscoverTools, tools/list, tools/call, handlers, aliases, service behavior, or runtime dependencies land in this item; aliases stay in deprecated.json; B14 is not started.",
    "AC-6: The schema and validation remain build-time-only with no new pkg/ runtime dependency.",
    "AC-7: Quality checks pass (typecheck, lint, and tests), including make contracts-validate, make contracts-smoke, make pkg-boundary, and make pkg-file-count."
  ],
  "userStories": [
    {
      "id": "interfaces-b13-mcp-schema-001",
      "title": "Author tool-catalog schema foundation and register validation",
      "description": "As an MCP contract author, I want a Draft 2020-12 tool-catalog schema root pinned to protocol version 2024-11-05 that accepts stable tool IDs, canonical names, documentation IDs, and lifecycle metadata so later input, result, and error groups have a stable document home.",
      "acceptanceCriteria": [
        "contracts/mcp/tool-catalog.schema.json declares Draft 2020-12, a stable $id under the repository schema namespace, an explicit initial format/schema version, and additionalProperties false at authored object boundaries.",
        "The schema accepts stable tool ID, canonical protocol name, title/description documentation IDs, and lifecycle metadata for at least one valid minimal tool-catalog fixture.",
        "Common documentation and/or deprecation shapes are composed by $ref from B04 vocabulary where reusable rather than redefining incompatible identity/lifecycle rules.",
        "The MCP tool-catalog schema is registered with the build-time contract validator family/version registry so a minimal valid fixture is included in repository validation.",
        "Running make contracts-validate succeeds for the registered valid MCP fixture set after this story.",
        "No production contracts/mcp/tools.json cutover and no DiscoverTools / handler / alias / runtime changes are introduced.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b13-mcp-schema-002",
      "title": "Validate transports, task support, annotations, and Draft input schemas",
      "description": "As an MCP contract reviewer, I want transports, task-support declarations, behavioral annotations, and Draft 2020-12 input schemas with stable argument/documentation IDs so canonical tool inputs validate and open nested objects fail at actionable paths.",
      "acceptanceCriteria": [
        "The schema accepts transports, execution/task support metadata, and behavioral annotations (readOnlyHint, destructiveHint, idempotentHint, openWorldHint or the repository-equivalent closed set) on tool records.",
        "The schema accepts Draft-compatible input object schemas with stable argument IDs, documentation IDs, JSON names, requiredness, defaults/examples/constraints/sensitivity where represented, and closed nested object/array shapes.",
        "At least one valid fixture documents a closed nested input object and passes focused validation / make contracts-validate.",
        "An open nested input object fixture fails validation with a deterministic actionable JSON path.",
        "An unsupported task-behavior fixture fails with a deterministic actionable JSON path.",
        "Input/annotation schema work does not change live discovery inputSchema emission or handler argument parsing.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b13-mcp-schema-003",
      "title": "Pin text-only CallToolResult envelope and reject unsupported modalities",
      "description": "As a maintainer pinning MCP 2024-11-05 behavior, I want reusable protocol content/result components that accept text success and text error CallToolResult shapes with isError, while fixtures advertising image, audio, embedded resources, structuredContent, or outputSchema fail with deterministic paths.",
      "acceptanceCriteria": [
        "Narrowly reusable protocol content/result component schemas describe the pinned CallToolResult transport envelope for text content and isError.",
        "Valid canonical text success and text error fixtures validate through the common contract validator / focused schema validation.",
        "Fixtures advertising image, audio, embedded resources, structuredContent, or outputSchema fail with deterministic actionable JSON paths.",
        "Protocol component schemas may describe broader MCP content kinds for documentation of the protocol surface, but tool-catalog result policy for the pinned initial cut admits only text.",
        "No new result modalities, outputSchema advertising, or runtime tools/call envelope changes are introduced.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b13-mcp-schema-004",
      "title": "Keep domain results/errors distinct from envelope and JSON-RPC failures",
      "description": "As an MCP contract author preparing for catalog cutover, I want typed domain result and domain/tool failure documentation represented separately from the MCP CallToolResult envelope and from JSON-RPC protocol failures so serializers and future protocol upgrades do not conflate those layers.",
      "acceptanceCriteria": [
        "The schema accepts domain output documentation (typed success payload shape serialized into text) as a distinct field group from the protocol CallToolResult envelope.",
        "The schema accepts typed tool/domain failure documentation as a distinct field group from both the text isError transport shape and JSON-RPC protocol error shapes.",
        "The schema accepts JSON-RPC protocol failure documentation (invalid params / unknown method class) as a distinct field group from tool/domain failures.",
        "At least one valid fixture demonstrates domain success documentation paired with a text success envelope, and at least one valid fixture demonstrates domain/tool failure documentation paired with a text error envelope; both pass focused validation / make contracts-validate.",
        "Fixtures or schema structure make it impossible to treat a JSON-RPC protocol error document as a tool CallToolResult domain failure without failing validation at a deterministic path.",
        "Domain/result documentation work does not change runtime error mapping in MCP handlers or the JSON-RPC server.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b13-mcp-schema-005",
      "title": "Validate handler IDs, examples, and cross-cutting invalid identity cases",
      "description": "As a reviewer, I want handwritten handler IDs and examples expressible in the catalog schema, and I want duplicate stable IDs, broken handler IDs, unknown protocol versions, and malformed lifecycle/documentation records to fail deterministically with actionable paths.",
      "acceptanceCriteria": [
        "The schema accepts handwritten handler ID binding fields with documented identity patterns and accepts example records for tools and/or arguments where the §4.4 surface requires them.",
        "At least one valid handler-binding fixture and at least one valid examples fixture pass focused validation / make contracts-validate.",
        "Invalid fixtures exist for duplicate stable IDs, broken handler IDs, unknown protocol versions, and malformed lifecycle/documentation records; each fails with a deterministic actionable JSON path.",
        "Alias tool names are not authored as canonical catalog entries in this lane; retained aliases remain only in contracts/mcp/deprecated.json per B09 decisions.",
        "No B14 generator, handler-registry remapping, or structural-closure lint work is introduced.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b13-mcp-schema-006",
      "title": "Complete fixture matrix and prove contracts validation closure",
      "description": "As a maintainer, I want the full MCP schema fixture matrix wired through repository validation gates so valid text success/error fixtures stay green and every customer-named invalid class fails with path-bearing diagnostics while boundary Make targets remain green.",
      "acceptanceCriteria": [
        "The focused MCP schema / contractvalidator fixture matrix covers every customer-named valid class (canonical text success, canonical text error) and every customer-named invalid class (image, audio, embedded resources, structuredContent, outputSchema, unsupported task behavior, duplicate stable IDs, broken handler IDs, open nested input objects, unknown protocol versions, malformed lifecycle/documentation records).",
        "make contracts-validate passes when only registered valid MCP fixtures are validated; invalid fixtures are asserted by focused tests that check path-bearing diagnostics rather than third-party error prose snapshots.",
        "Diff review confirms no production MCP tools catalog cutover, no DiscoverTools / tools/list / tools/call / handler / alias / service changes, no new pkg/ runtime dependency, and no B14 generation or structural closure.",
        "make contracts-smoke, make pkg-boundary, and make pkg-file-count pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": ""
    }
  ]
}
