### PR TITLE
interfaces-b17-javascript-catalog

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@ contracts/testdata/baseline/** text eol=lf
 contracts/config/** text eol=lf
 contracts/common/** text eol=lf
 contracts/mcp/** text eol=lf
+contracts/javascript/** text eol=lf
 contracts/manifest.schema.json text eol=lf
 api/openapi.yaml text eol=lf
 packages/api/generated/** text eol=lf

--- a/contracts/javascript/runtime-api.json
+++ b/contracts/javascript/runtime-api.json
@@ -187,6 +187,55 @@
         ]
       }
     },
+    "javascript.schema.agent_run_spec": {
+      "id": "javascript.schema.agent_run_spec",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.schema.agent_run_spec",
+        "documentation": {
+          "title": {
+            "id": "javascript.schema.agent_run_spec.title",
+            "canonicalEnglish": "Agent run specification object"
+          },
+          "description": {
+            "id": "javascript.schema.agent_run_spec.description",
+            "canonicalEnglish": "Closed object shape for agent.run spec arguments."
+          }
+        },
+        "examples": [
+          "{ \"prompt\": \"Summarize findings\", \"label\": \"summarize\" }"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "prompt": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "preset": {
+            "type": "string"
+          },
+          "modelProvider": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "reasoningEffort": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "prompt"
+        ]
+      }
+    },
     "javascript.schema.string_key_record": {
       "id": "javascript.schema.string_key_record",
       "documentation": {
@@ -352,6 +401,375 @@
       "lifecycle": {
         "formatVersion": "1.0.0",
         "itemId": "javascript.log",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    },
+    "javascript.agent": {
+      "id": "javascript.agent",
+      "name": "agent",
+      "path": "agent",
+      "kind": "namespace",
+      "members": [
+        "run"
+      ],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.agent",
+        "documentation": {
+          "title": {
+            "id": "javascript.agent.title",
+            "canonicalEnglish": "Agent namespace"
+          },
+          "description": {
+            "id": "javascript.agent.description",
+            "canonicalEnglish": "Root agent namespace for the installed agent.run child-dispatch helper."
+          }
+        },
+        "examples": [
+          "agent.run({ prompt: \"Summarize findings\", label: \"summarize\" })"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.agent",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "mutability": "fixed-binding",
+      "nullability": "non-null",
+      "bindingLifecycle": "live-namespace"
+    },
+    "javascript.agent.run": {
+      "id": "javascript.agent.run",
+      "name": "run",
+      "path": "agent.run",
+      "kind": "method",
+      "parent": "javascript.agent",
+      "async": true,
+      "parameters": [
+        {
+          "id": "javascript.agent.run.param.spec",
+          "name": "spec",
+          "position": 0,
+          "required": true,
+          "rest": false,
+          "type": "object",
+          "serializableValue": {
+            "$ref": "#/sharedSchemas/javascript.schema.agent_run_spec/schema"
+          }
+        }
+      ],
+      "return": {
+        "kind": "promise",
+        "type": "child-result-object"
+      },
+      "emittedRecords": [
+        "child_dispatch"
+      ],
+      "policyChecks": [
+        {
+          "kind": "maxAgents",
+          "message": "policy denied: requested fanout exceeds maxAgents"
+        },
+        {
+          "kind": "allowedModels",
+          "field": "model"
+        },
+        {
+          "kind": "allowedReasoningEfforts",
+          "field": "reasoningEffort"
+        },
+        {
+          "kind": "allowedCommands",
+          "field": "command"
+        },
+        {
+          "kind": "sandboxMode",
+          "field": "sandbox"
+        },
+        {
+          "kind": "writableRoots",
+          "field": "writableRoots"
+        },
+        {
+          "kind": "allowNetwork",
+          "field": "allowNetwork"
+        },
+        {
+          "kind": "concurrency",
+          "field": "concurrency"
+        }
+      ],
+      "errors": [
+        {
+          "condition": "missing-or-non-object-argument",
+          "type": "TypeError",
+          "message": "agent.run() requires an object argument"
+        },
+        {
+          "condition": "unsupported-field",
+          "type": "TypeError",
+          "message": "agent.run() does not support field"
+        },
+        {
+          "condition": "missing-prompt",
+          "type": "TypeError",
+          "message": "agent.run() requires a non-empty string \"prompt\" property"
+        },
+        {
+          "condition": "unknown-preset",
+          "type": "TypeError",
+          "message": "agent.run() references unknown operator worker preset"
+        },
+        {
+          "condition": "unsupported-model-provider",
+          "type": "TypeError",
+          "message": "agent.run() has unsupported effective modelProvider"
+        },
+        {
+          "condition": "unsupported-reasoning-effort",
+          "type": "TypeError",
+          "message": "agent.run() has unsupported effective reasoningEffort"
+        }
+      ],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.agent.run",
+        "documentation": {
+          "title": {
+            "id": "javascript.agent.run.title",
+            "canonicalEnglish": "Agent child dispatch"
+          },
+          "description": {
+            "id": "javascript.agent.run.description",
+            "canonicalEnglish": "Dispatches one child agent run from a closed spec object with a required prompt and optional model or preset fields. Returns a promise that resolves to the child result object after policy checks and child_dispatch emission."
+          }
+        },
+        "examples": [
+          "await agent.run({ prompt: \"Summarize findings\", label: \"summarize\", preset: \"operator\" })"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.agent.run",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    },
+    "javascript.parallel": {
+      "id": "javascript.parallel",
+      "name": "parallel",
+      "path": "parallel",
+      "kind": "function",
+      "async": true,
+      "parameters": [
+        {
+          "id": "javascript.parallel.param.items",
+          "name": "items",
+          "position": 0,
+          "required": true,
+          "rest": false,
+          "type": "array"
+        }
+      ],
+      "callback": {
+        "role": "item",
+        "parameters": [
+          {
+            "id": "javascript.parallel.callback.this",
+            "name": "this",
+            "position": 0,
+            "required": false,
+            "rest": false,
+            "type": "undefined",
+            "default": "undefined"
+          }
+        ],
+        "notes": "array items may be agent run specs (object with prompt) or functions invoked with undefined this"
+      },
+      "return": {
+        "kind": "promise",
+        "type": "array"
+      },
+      "emittedRecords": [
+        "child_dispatch"
+      ],
+      "policyChecks": [
+        {
+          "kind": "maxAgents",
+          "message": "policy denied: requested fanout exceeds maxAgents"
+        },
+        {
+          "kind": "childRequest",
+          "message": "policy denied"
+        }
+      ],
+      "determinism": "agent-spec completion order may differ from input order under concurrency",
+      "errors": [
+        {
+          "condition": "missing-or-non-array-argument",
+          "type": "TypeError",
+          "message": "parallel() requires an array argument"
+        },
+        {
+          "condition": "null-or-undefined-item",
+          "type": "TypeError",
+          "message": "parallel() items must not contain null or undefined entries"
+        },
+        {
+          "condition": "invalid-item-shape",
+          "type": "TypeError",
+          "message": "parallel() items must be agent run specs or functions"
+        }
+      ],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.parallel",
+        "documentation": {
+          "title": {
+            "id": "javascript.parallel.title",
+            "canonicalEnglish": "Parallel child dispatch"
+          },
+          "description": {
+            "id": "javascript.parallel.description",
+            "canonicalEnglish": "Runs an array of agent run specs or item functions concurrently and returns a promise that resolves to an array of child results. Each function item is invoked with undefined this."
+          }
+        },
+        "examples": [
+          "await parallel([{ prompt: \"first\" }, { prompt: \"second\", label: \"two\" }])"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.parallel",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    },
+    "javascript.pipeline": {
+      "id": "javascript.pipeline",
+      "name": "pipeline",
+      "path": "pipeline",
+      "kind": "function",
+      "async": true,
+      "parameters": [
+        {
+          "id": "javascript.pipeline.param.items",
+          "name": "items",
+          "position": 0,
+          "required": true,
+          "rest": false,
+          "type": "array"
+        },
+        {
+          "id": "javascript.pipeline.param.worker",
+          "name": "worker",
+          "position": 1,
+          "required": true,
+          "rest": false,
+          "type": "function"
+        },
+        {
+          "id": "javascript.pipeline.param.next",
+          "name": "next",
+          "position": 2,
+          "required": false,
+          "rest": false,
+          "type": "function"
+        }
+      ],
+      "callback": {
+        "role": "worker",
+        "parameters": [
+          {
+            "id": "javascript.pipeline.callback.this",
+            "name": "this",
+            "position": 0,
+            "required": false,
+            "rest": false,
+            "type": "undefined",
+            "default": "undefined"
+          },
+          {
+            "id": "javascript.pipeline.callback.item",
+            "name": "item",
+            "position": 1,
+            "required": true,
+            "rest": false,
+            "type": "any"
+          },
+          {
+            "id": "javascript.pipeline.callback.index",
+            "name": "index",
+            "position": 2,
+            "required": true,
+            "rest": false,
+            "type": "number"
+          }
+        ],
+        "notes": "optional next stage receives (priorResult, item, index)"
+      },
+      "return": {
+        "kind": "promise",
+        "type": "pipeline-result-array"
+      },
+      "determinism": "stages run sequentially per item; worker and next may return values or Promises",
+      "errors": [
+        {
+          "condition": "missing-items-or-worker",
+          "type": "TypeError",
+          "message": "pipeline() requires items and worker arguments"
+        },
+        {
+          "condition": "missing-or-non-array-items",
+          "type": "TypeError",
+          "message": "pipeline() requires an array items argument"
+        },
+        {
+          "condition": "missing-worker-function",
+          "type": "TypeError",
+          "message": "pipeline() requires a worker function argument"
+        },
+        {
+          "condition": "invalid-next-function",
+          "type": "TypeError",
+          "message": "pipeline() next argument must be a function when provided"
+        },
+        {
+          "condition": "null-or-undefined-item",
+          "type": "TypeError",
+          "message": "pipeline() items must not contain null or undefined entries"
+        }
+      ],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.pipeline",
+        "documentation": {
+          "title": {
+            "id": "javascript.pipeline.title",
+            "canonicalEnglish": "Pipeline composition"
+          },
+          "description": {
+            "id": "javascript.pipeline.description",
+            "canonicalEnglish": "Maps each items entry through a required worker function and optional next stage callback, running stages sequentially per item. Returns a promise that resolves to a pipeline result array."
+          }
+        },
+        "examples": [
+          "await pipeline([1, 2], (item) => item * 2, (prior, item) => prior + item)"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.pipeline",
         "state": "active",
         "since": "1.0.0"
       }

--- a/contracts/javascript/runtime-api.json
+++ b/contracts/javascript/runtime-api.json
@@ -1,0 +1,219 @@
+{
+  "formatVersion": "1.0.0",
+  "sharedSchemas": {
+    "javascript.schema.checkpoint_spec": {
+      "id": "javascript.schema.checkpoint_spec",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.schema.checkpoint_spec",
+        "documentation": {
+          "title": {
+            "id": "javascript.schema.checkpoint_spec.title",
+            "canonicalEnglish": "Checkpoint specification object"
+          },
+          "description": {
+            "id": "javascript.schema.checkpoint_spec.description",
+            "canonicalEnglish": "Closed object shape for workflow.checkpoint spec arguments."
+          }
+        },
+        "examples": [
+          "{ \"label\": \"draft\", \"state\": {} }"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "state": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {}
+          }
+        },
+        "required": [
+          "label"
+        ]
+      }
+    },
+    "javascript.schema.json_compatible": {
+      "id": "javascript.schema.json_compatible",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.schema.json_compatible",
+        "documentation": {
+          "title": {
+            "id": "javascript.schema.json_compatible.title",
+            "canonicalEnglish": "JSON-compatible serializable value"
+          },
+          "description": {
+            "id": "javascript.schema.json_compatible.description",
+            "canonicalEnglish": "Closed union of JSON-compatible serializable values accepted by installed runtime helpers."
+          }
+        },
+        "examples": [
+          "{ \"step\": 1 }",
+          "\"note\"",
+          "null"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "schema": {
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "array"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {}
+          }
+        ]
+      }
+    },
+    "javascript.schema.string_key_record": {
+      "id": "javascript.schema.string_key_record",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.schema.string_key_record",
+        "documentation": {
+          "title": {
+            "id": "javascript.schema.string_key_record.title",
+            "canonicalEnglish": "String-keyed invocation record"
+          },
+          "description": {
+            "id": "javascript.schema.string_key_record.description",
+            "canonicalEnglish": "Closed top-level object for args and meta value bindings exposed at workflow bind time."
+          }
+        },
+        "examples": [
+          "{ \"topic\": \"release\" }"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {}
+      }
+    }
+  },
+  "symbols": {
+    "javascript.workflow": {
+      "id": "javascript.workflow",
+      "name": "workflow",
+      "path": "workflow",
+      "kind": "namespace",
+      "members": [
+        "checkpoint"
+      ],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow",
+        "documentation": {
+          "title": {
+            "id": "javascript.workflow.title",
+            "canonicalEnglish": "Workflow namespace"
+          },
+          "description": {
+            "id": "javascript.workflow.description",
+            "canonicalEnglish": "Root workflow namespace for installed checkpoint, artifact, budget, final, log, and resumeState helpers."
+          }
+        },
+        "examples": [
+          "workflow.checkpoint({ label: \"draft\" })"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "mutability": "fixed-binding",
+      "nullability": "non-null",
+      "bindingLifecycle": "live-namespace"
+    },
+    "javascript.workflow.checkpoint": {
+      "id": "javascript.workflow.checkpoint",
+      "name": "checkpoint",
+      "path": "workflow.checkpoint",
+      "kind": "method",
+      "parent": "javascript.workflow",
+      "async": false,
+      "parameters": [
+        {
+          "id": "javascript.workflow.checkpoint.param.spec",
+          "name": "spec",
+          "position": 0,
+          "required": true,
+          "rest": false,
+          "type": "object",
+          "serializableValue": {
+            "$ref": "#/sharedSchemas/javascript.schema.checkpoint_spec/schema"
+          }
+        },
+        {
+          "id": "javascript.workflow.checkpoint.param.payload",
+          "name": "payload",
+          "position": 1,
+          "required": false,
+          "rest": false,
+          "type": "json-compatible",
+          "serializableValue": {
+            "$ref": "#/sharedSchemas/javascript.schema.json_compatible/schema"
+          }
+        }
+      ],
+      "return": {
+        "kind": "sync",
+        "type": "undefined"
+      },
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.checkpoint",
+        "documentation": {
+          "title": {
+            "id": "javascript.workflow.checkpoint.title",
+            "canonicalEnglish": "Workflow checkpoint"
+          },
+          "description": {
+            "id": "javascript.workflow.checkpoint.description",
+            "canonicalEnglish": "Records one workflow checkpoint using shared serializable-value schemas for spec and payload arguments."
+          }
+        },
+        "examples": [
+          "workflow.checkpoint({ label: \"draft\" }, { step: 1 })"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.checkpoint",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    }
+  }
+}

--- a/contracts/javascript/runtime-api.json
+++ b/contracts/javascript/runtime-api.json
@@ -185,6 +185,134 @@
       "nullability": "non-null",
       "bindingLifecycle": "snapshot-at-bind"
     },
+    "javascript.log": {
+      "id": "javascript.log",
+      "name": "log",
+      "path": "log",
+      "kind": "function",
+      "async": false,
+      "parameters": [
+        {
+          "id": "javascript.log.param.message",
+          "name": "message",
+          "position": 0,
+          "required": true,
+          "rest": false,
+          "type": "string"
+        },
+        {
+          "id": "javascript.log.param.fields",
+          "name": "fields",
+          "position": 1,
+          "required": false,
+          "rest": false,
+          "type": "object",
+          "serializableValue": {
+            "$ref": "#/sharedSchemas/javascript.schema.json_compatible/schema"
+          }
+        }
+      ],
+      "return": {
+        "kind": "sync",
+        "type": "undefined"
+      },
+      "emittedRecords": [
+        "log"
+      ],
+      "errors": [
+        {
+          "condition": "missing-or-non-string-message",
+          "type": "TypeError",
+          "message": "log() requires a string message"
+        },
+        {
+          "condition": "non-json-fields",
+          "type": "GoError",
+          "message": "log() fields must be JSON-compatible"
+        }
+      ],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.log",
+        "documentation": {
+          "title": {
+            "id": "javascript.log.title",
+            "canonicalEnglish": "Root workflow log helper"
+          },
+          "description": {
+            "id": "javascript.log.description",
+            "canonicalEnglish": "Synchronously emits one workflow-scoped log record. The first argument must be a non-empty string message; an optional second argument supplies JSON-compatible structured fields."
+          }
+        },
+        "examples": [
+          "log(\"checkpoint\", { step: 1 })"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.log",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    },
+    "javascript.phase": {
+      "id": "javascript.phase",
+      "name": "phase",
+      "path": "phase",
+      "kind": "function",
+      "async": false,
+      "parameters": [
+        {
+          "id": "javascript.phase.param.name",
+          "name": "name",
+          "position": 0,
+          "required": true,
+          "rest": false,
+          "type": "string"
+        }
+      ],
+      "return": {
+        "kind": "sync",
+        "type": "undefined"
+      },
+      "emittedRecords": [
+        "phase"
+      ],
+      "errors": [
+        {
+          "condition": "missing-or-non-string-name",
+          "type": "TypeError",
+          "message": "phase() requires a string name"
+        }
+      ],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.phase",
+        "documentation": {
+          "title": {
+            "id": "javascript.phase.title",
+            "canonicalEnglish": "Phase marker"
+          },
+          "description": {
+            "id": "javascript.phase.description",
+            "canonicalEnglish": "Synchronously records one named workflow phase transition for progress tracking. The name must be a non-empty string."
+          }
+        },
+        "examples": [
+          "phase(\"draft\")"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.phase",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    },
     "javascript.workflow": {
       "id": "javascript.workflow",
       "name": "workflow",

--- a/contracts/javascript/runtime-api.json
+++ b/contracts/javascript/runtime-api.json
@@ -30,13 +30,112 @@
             "type": "string"
           },
           "state": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
+            "$ref": "#/sharedSchemas/javascript.schema.json_compatible/schema"
           }
         },
         "required": [
           "label"
+        ]
+      }
+    },
+    "javascript.schema.artifact_spec": {
+      "id": "javascript.schema.artifact_spec",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.schema.artifact_spec",
+        "documentation": {
+          "title": {
+            "id": "javascript.schema.artifact_spec.title",
+            "canonicalEnglish": "Artifact specification object"
+          },
+          "description": {
+            "id": "javascript.schema.artifact_spec.description",
+            "canonicalEnglish": "Closed object shape for workflow.artifact spec arguments."
+          }
+        },
+        "examples": [
+          "{ \"kind\": \"log\", \"label\": \"step\" }"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "kind": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "content": {
+            "$ref": "#/sharedSchemas/javascript.schema.json_compatible/schema"
+          },
+          "visibility": {
+            "type": "string",
+            "default": "WORKFLOW_RUNTIME"
+          }
+        },
+        "required": [
+          "kind",
+          "label"
+        ]
+      }
+    },
+    "javascript.schema.budget_snapshot": {
+      "id": "javascript.schema.budget_snapshot",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.schema.budget_snapshot",
+        "documentation": {
+          "title": {
+            "id": "javascript.schema.budget_snapshot.title",
+            "canonicalEnglish": "Workflow budget snapshot object"
+          },
+          "description": {
+            "id": "javascript.schema.budget_snapshot.description",
+            "canonicalEnglish": "Closed object shape returned by workflow.budget."
+          }
+        },
+        "examples": [
+          "{ \"maxAgents\": 4, \"concurrency\": 2 }"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "maxAgents": {
+            "type": "number"
+          },
+          "concurrency": {
+            "type": "number"
+          },
+          "sandboxMode": {
+            "type": "string"
+          },
+          "maxRunDurationMs": {
+            "type": "number"
+          },
+          "maxWorkerDurationMs": {
+            "type": "number"
+          },
+          "maxOutputBytesPerWorker": {
+            "type": "number"
+          },
+          "maxArtifactBytes": {
+            "type": "number"
+          },
+          "maxTokens": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "maxAgents",
+          "concurrency"
         ]
       }
     },
@@ -319,7 +418,12 @@
       "path": "workflow",
       "kind": "namespace",
       "members": [
-        "checkpoint"
+        "artifact",
+        "budget",
+        "checkpoint",
+        "final",
+        "log",
+        "resumeState"
       ],
       "documentation": {
         "formatVersion": "1.0.0",
@@ -335,7 +439,7 @@
           }
         },
         "examples": [
-          "workflow.checkpoint({ label: \"draft\" })"
+          "workflow.artifact({ kind: \"log\", label: \"step\" })"
         ],
         "visibility": "public",
         "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
@@ -349,6 +453,134 @@
       "mutability": "fixed-binding",
       "nullability": "non-null",
       "bindingLifecycle": "live-namespace"
+    },
+    "javascript.workflow.artifact": {
+      "id": "javascript.workflow.artifact",
+      "name": "artifact",
+      "path": "workflow.artifact",
+      "kind": "method",
+      "parent": "javascript.workflow",
+      "async": false,
+      "parameters": [
+        {
+          "id": "javascript.workflow.artifact.param.spec",
+          "name": "spec",
+          "position": 0,
+          "required": true,
+          "rest": false,
+          "type": "object",
+          "serializableValue": {
+            "$ref": "#/sharedSchemas/javascript.schema.artifact_spec/schema"
+          }
+        }
+      ],
+      "return": {
+        "kind": "sync",
+        "type": "string"
+      },
+      "emittedRecords": [
+        "artifact"
+      ],
+      "errors": [
+        {
+          "condition": "missing-or-non-object-argument",
+          "type": "TypeError",
+          "message": "workflow.artifact() requires an object argument"
+        },
+        {
+          "condition": "missing-kind-or-label",
+          "type": "TypeError",
+          "message": "workflow.artifact() requires string \"kind\" and \"label\" properties"
+        },
+        {
+          "condition": "non-json-content",
+          "type": "GoError",
+          "message": "workflow.artifact content must be JSON-compatible"
+        }
+      ],
+      "policyChecks": [
+        {
+          "kind": "maxArtifactBytes",
+          "field": "content",
+          "message": "policy denied: artifact content size exceeds maxArtifactBytes"
+        }
+      ],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.artifact",
+        "documentation": {
+          "title": {
+            "id": "javascript.workflow.artifact.title",
+            "canonicalEnglish": "Workflow artifact"
+          },
+          "description": {
+            "id": "javascript.workflow.artifact.description",
+            "canonicalEnglish": "Registers one workflow artifact with kind and label metadata. Optional content must be JSON-compatible and is subject to maxArtifactBytes policy."
+          }
+        },
+        "examples": [
+          "workflow.artifact({ kind: \"log\", label: \"step\", content: { step: 1 } })"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.artifact",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    },
+    "javascript.workflow.budget": {
+      "id": "javascript.workflow.budget",
+      "name": "budget",
+      "path": "workflow.budget",
+      "kind": "method",
+      "parent": "javascript.workflow",
+      "async": false,
+      "parameters": [],
+      "return": {
+        "kind": "sync",
+        "type": "object",
+        "serializableValue": {
+          "$ref": "#/sharedSchemas/javascript.schema.budget_snapshot/schema"
+        }
+      },
+      "emittedRecords": [
+        "budget"
+      ],
+      "errors": [
+        {
+          "condition": "arguments-provided",
+          "type": "TypeError",
+          "message": "workflow.budget() does not accept arguments"
+        }
+      ],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.budget",
+        "documentation": {
+          "title": {
+            "id": "javascript.workflow.budget.title",
+            "canonicalEnglish": "Workflow budget snapshot"
+          },
+          "description": {
+            "id": "javascript.workflow.budget.description",
+            "canonicalEnglish": "Returns the current workflow budget counters and emits one budget record. The helper does not accept arguments."
+          }
+        },
+        "examples": [
+          "workflow.budget()"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.budget",
+        "state": "active",
+        "since": "1.0.0"
+      }
     },
     "javascript.workflow.checkpoint": {
       "id": "javascript.workflow.checkpoint",
@@ -368,23 +600,33 @@
           "serializableValue": {
             "$ref": "#/sharedSchemas/javascript.schema.checkpoint_spec/schema"
           }
-        },
-        {
-          "id": "javascript.workflow.checkpoint.param.payload",
-          "name": "payload",
-          "position": 1,
-          "required": false,
-          "rest": false,
-          "type": "json-compatible",
-          "serializableValue": {
-            "$ref": "#/sharedSchemas/javascript.schema.json_compatible/schema"
-          }
         }
       ],
       "return": {
         "kind": "sync",
         "type": "undefined"
       },
+      "emittedRecords": [
+        "checkpoint"
+      ],
+      "errors": [
+        {
+          "condition": "missing-or-non-object-argument",
+          "type": "TypeError",
+          "message": "workflow.checkpoint() requires an object argument"
+        },
+        {
+          "condition": "missing-label",
+          "type": "TypeError",
+          "message": "workflow.checkpoint() requires a string \"label\" property"
+        },
+        {
+          "condition": "non-json-state",
+          "type": "GoError",
+          "message": "workflow.checkpoint state must be JSON-compatible"
+        }
+      ],
+      "resumeNotes": "persists checkpoint state for workflow.resumeState() on resumed sessions",
       "documentation": {
         "formatVersion": "1.0.0",
         "itemId": "javascript.workflow.checkpoint",
@@ -395,11 +637,11 @@
           },
           "description": {
             "id": "javascript.workflow.checkpoint.description",
-            "canonicalEnglish": "Records one workflow checkpoint using shared serializable-value schemas for spec and payload arguments."
+            "canonicalEnglish": "Persists one labeled checkpoint with optional JSON-compatible state for later resume through workflow.resumeState()."
           }
         },
         "examples": [
-          "workflow.checkpoint({ label: \"draft\" }, { step: 1 })"
+          "workflow.checkpoint({ label: \"draft\", state: { step: 1 } })"
         ],
         "visibility": "public",
         "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
@@ -407,6 +649,176 @@
       "lifecycle": {
         "formatVersion": "1.0.0",
         "itemId": "javascript.workflow.checkpoint",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    },
+    "javascript.workflow.final": {
+      "id": "javascript.workflow.final",
+      "name": "final",
+      "path": "workflow.final",
+      "kind": "method",
+      "parent": "javascript.workflow",
+      "async": false,
+      "parameters": [
+        {
+          "id": "javascript.workflow.final.param.value",
+          "name": "value",
+          "position": 0,
+          "required": false,
+          "rest": false,
+          "type": "any"
+        }
+      ],
+      "return": {
+        "kind": "sync",
+        "type": "undefined"
+      },
+      "determinism": "workflow.final wins over a returned workflow value for terminal result selection",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.final",
+        "documentation": {
+          "title": {
+            "id": "javascript.workflow.final.title",
+            "canonicalEnglish": "Workflow final result"
+          },
+          "description": {
+            "id": "javascript.workflow.final.description",
+            "canonicalEnglish": "Terminates the workflow with an optional final value. When both workflow.final and a returned value are present, workflow.final wins for terminal result selection."
+          }
+        },
+        "examples": [
+          "workflow.final({ ok: true, result: { count: 1 } })"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.final",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    },
+    "javascript.workflow.log": {
+      "id": "javascript.workflow.log",
+      "name": "log",
+      "path": "workflow.log",
+      "kind": "method",
+      "parent": "javascript.workflow",
+      "async": false,
+      "parameters": [
+        {
+          "id": "javascript.workflow.log.param.message",
+          "name": "message",
+          "position": 0,
+          "required": true,
+          "rest": false,
+          "type": "string"
+        },
+        {
+          "id": "javascript.workflow.log.param.fields",
+          "name": "fields",
+          "position": 1,
+          "required": false,
+          "rest": false,
+          "type": "object",
+          "serializableValue": {
+            "$ref": "#/sharedSchemas/javascript.schema.json_compatible/schema"
+          }
+        }
+      ],
+      "return": {
+        "kind": "sync",
+        "type": "undefined"
+      },
+      "emittedRecords": [
+        "log"
+      ],
+      "errors": [
+        {
+          "condition": "missing-or-non-string-message",
+          "type": "TypeError",
+          "message": "workflow.log() requires a string message"
+        },
+        {
+          "condition": "non-json-fields",
+          "type": "GoError",
+          "message": "workflow.log() fields must be JSON-compatible"
+        }
+      ],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.log",
+        "documentation": {
+          "title": {
+            "id": "javascript.workflow.log.title",
+            "canonicalEnglish": "Workflow-scoped log helper"
+          },
+          "description": {
+            "id": "javascript.workflow.log.description",
+            "canonicalEnglish": "Synchronously emits one workflow-scoped log record. The first argument must be a string message; an optional second argument supplies JSON-compatible structured fields."
+          }
+        },
+        "examples": [
+          "workflow.log(\"checkpoint\", { step: 1 })"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.log",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    },
+    "javascript.workflow.resume-state": {
+      "id": "javascript.workflow.resume-state",
+      "name": "resumeState",
+      "path": "workflow.resumeState",
+      "kind": "method",
+      "parent": "javascript.workflow",
+      "async": false,
+      "parameters": [],
+      "return": {
+        "kind": "sync",
+        "type": "object-or-undefined",
+        "serializableValue": {
+          "$ref": "#/sharedSchemas/javascript.schema.checkpoint_spec/schema"
+        }
+      },
+      "errors": [
+        {
+          "condition": "arguments-provided",
+          "type": "TypeError",
+          "message": "workflow.resumeState() does not accept arguments"
+        }
+      ],
+      "resumeNotes": "returns bound resume checkpoint state or undefined when absent",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.resume-state",
+        "documentation": {
+          "title": {
+            "id": "javascript.workflow.resume-state.title",
+            "canonicalEnglish": "Workflow resume state"
+          },
+          "description": {
+            "id": "javascript.workflow.resume-state.description",
+            "canonicalEnglish": "Reads checkpoint state restored for a resumed workflow session, or undefined when no resume state is bound."
+          }
+        },
+        "examples": [
+          "workflow.resumeState()"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.resume-state",
         "state": "active",
         "since": "1.0.0"
       }

--- a/contracts/javascript/runtime-api.json
+++ b/contracts/javascript/runtime-api.json
@@ -117,6 +117,74 @@
     }
   },
   "symbols": {
+    "javascript.args": {
+      "id": "javascript.args",
+      "name": "args",
+      "path": "args",
+      "kind": "value",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.args",
+        "documentation": {
+          "title": {
+            "id": "javascript.args.title",
+            "canonicalEnglish": "Invocation arguments"
+          },
+          "description": {
+            "id": "javascript.args.description",
+            "canonicalEnglish": "Mutable invocation argument value bound from workflow request args JSON at script start. The binding is a non-null object snapshot; property reads and writes affect only the in-script view and do not change the original request payload."
+          }
+        },
+        "examples": [
+          "{ \"subject\": \"release\", \"count\": 2, \"prefix\": \"echo\" }"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.args",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "mutability": "mutable-object",
+      "nullability": "non-null",
+      "bindingLifecycle": "snapshot-at-bind"
+    },
+    "javascript.meta": {
+      "id": "javascript.meta",
+      "name": "meta",
+      "path": "meta",
+      "kind": "value",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.meta",
+        "documentation": {
+          "title": {
+            "id": "javascript.meta.title",
+            "canonicalEnglish": "Invocation metadata"
+          },
+          "description": {
+            "id": "javascript.meta.description",
+            "canonicalEnglish": "Mutable invocation metadata object bound from workflow request metadata at script start. The binding is a non-null object snapshot with string-valued entries; when name is absent the runtime supplies the default simple-final label."
+          }
+        },
+        "examples": [
+          "{ \"name\": \"simple-final\", \"description\": \"Example workflow metadata\" }"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.meta",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "mutability": "mutable-object",
+      "nullability": "non-null",
+      "bindingLifecycle": "snapshot-at-bind"
+    },
     "javascript.workflow": {
       "id": "javascript.workflow",
       "name": "workflow",

--- a/contracts/javascript/runtime-manifest.schema.json
+++ b/contracts/javascript/runtime-manifest.schema.json
@@ -23,6 +23,17 @@
     "versionAvailability": {
       "$ref": "#/$defs/versionAvailability"
     },
+    "sharedSchemas": {
+      "description": "Reusable named schemas keyed by stable javascript.schema.* identifiers for serializable argument and return shapes referenced by catalog symbols.",
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": {
+        "$ref": "#/$defs/sharedSchemaId"
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/sharedNamedSchema"
+      }
+    },
     "symbols": {
       "description": "Installed runtime symbols keyed by stable symbol identifiers. Object keys make duplicate symbol IDs structurally unrepresentable.",
       "type": "object",
@@ -36,6 +47,45 @@
     }
   },
   "$defs": {
+    "sharedSchemaId": {
+      "description": "Stable JavaScript shared schema identity with the javascript.schema prefix.",
+      "allOf": [
+        {
+          "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json#/$defs/itemId"
+        },
+        {
+          "pattern": "^javascript[.]schema[.].+"
+        }
+      ]
+    },
+    "sharedNamedSchema": {
+      "description": "One reusable named serializable-value schema entry referenced by catalog symbols.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "schema"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/sharedSchemaId"
+        },
+        "documentation": {
+          "$ref": "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json"
+        },
+        "schema": {
+          "$ref": "#/$defs/closedSerializableSchema"
+        }
+      }
+    },
+    "closedSerializableSchema": {
+      "description": "Closed Draft 2020-12 JSON Schema fragment for one serializable argument or return shape.",
+      "allOf": [
+        {
+          "$ref": "#/$defs/serializableValue"
+        }
+      ]
+    },
     "symbolPath": {
       "description": "Dot-delimited installed symbol path from the runtime global scope.",
       "type": "string",

--- a/contracts/javascript_runtime_api_test.go
+++ b/contracts/javascript_runtime_api_test.go
@@ -1,11 +1,14 @@
 package contracts_test
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/portpowered/infinite-you/internal/contractvalidator"
+	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/callbehavior"
+	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/symbolidentity"
 )
 
 func javascriptManifestFixtureRegistry(fixture string) contractvalidator.Registry {
@@ -26,6 +29,39 @@ func javascriptManifestFixtureRegistry(fixture string) contractvalidator.Registr
 			SchemaID: runtimeManifestSchemaID,
 		}},
 	})
+}
+
+func TestJavaScriptRuntimeAPICatalogRootValuesArgsAndMeta(t *testing.T) {
+	t.Parallel()
+
+	catalog := loadAuthoredJavaScriptRuntimeCatalog(t)
+	symbolsByPath := catalogSymbolsByPath(t, catalog)
+
+	for _, path := range []string{"args", "meta"} {
+		symbol, ok := symbolsByPath[path]
+		if !ok {
+			t.Fatalf("catalog missing root value symbol at path %q", path)
+		}
+		if got := countCatalogPaths(symbolsByPath, path); got != 1 {
+			t.Fatalf("catalog path %q appears %d times, want exactly once", path, got)
+		}
+
+		identity := symbolidentity.ProjectInstalledBindings()
+		identityByPath := symbolRecordsByPath(identity)
+		wantIdentity, ok := identityByPath[path]
+		if !ok {
+			t.Fatalf("identity baseline missing path %q", path)
+		}
+		assertCatalogValueMatchesIdentityBaseline(t, path, symbol, wantIdentity)
+
+		callInventory := callbehavior.ProjectInstalledCallBehavior()
+		callByPath := callRecordsByPath(callInventory)
+		wantCallBehavior, ok := callByPath[path]
+		if !ok {
+			t.Fatalf("call-behavior baseline missing path %q", path)
+		}
+		assertCatalogValueMatchesCallBehaviorBaseline(t, path, symbol, wantCallBehavior)
+	}
 }
 
 func TestJavaScriptRuntimeAPIAuthoredCatalogBoundary(t *testing.T) {
@@ -97,5 +133,132 @@ func TestJavaScriptRuntimeAPIOpenSharedSchema(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("diagnostics = %+v, want code=javascript.serializable_value.open path=%q document=%q", diagnostics, wantPath, fixture)
+	}
+}
+
+func loadAuthoredJavaScriptRuntimeCatalog(t *testing.T) map[string]any {
+	t.Helper()
+
+	raw, err := os.ReadFile(filepath.Join("javascript", "runtime-api.json"))
+	if err != nil {
+		t.Fatalf("read authored catalog: %v", err)
+	}
+	var catalog map[string]any
+	if err := json.Unmarshal(raw, &catalog); err != nil {
+		t.Fatalf("unmarshal authored catalog: %v", err)
+	}
+	return catalog
+}
+
+func catalogSymbolsByPath(t *testing.T, catalog map[string]any) map[string]map[string]any {
+	t.Helper()
+
+	symbolsValue, ok := catalog["symbols"].(map[string]any)
+	if !ok {
+		t.Fatalf("catalog symbols = %#v, want object", catalog["symbols"])
+	}
+	byPath := make(map[string]map[string]any, len(symbolsValue))
+	for _, symbolValue := range symbolsValue {
+		symbol, ok := symbolValue.(map[string]any)
+		if !ok {
+			t.Fatalf("catalog symbol = %#v, want object", symbolValue)
+		}
+		path, _ := symbol["path"].(string)
+		if path == "" {
+			t.Fatal("catalog symbol missing path")
+		}
+		byPath[path] = symbol
+	}
+	return byPath
+}
+
+func countCatalogPaths(byPath map[string]map[string]any, path string) int {
+	count := 0
+	for candidate := range byPath {
+		if candidate == path {
+			count++
+		}
+	}
+	return count
+}
+
+func symbolRecordsByPath(inventory symbolidentity.Inventory) map[string]symbolidentity.SymbolRecord {
+	byPath := make(map[string]symbolidentity.SymbolRecord, len(inventory.Symbols))
+	for _, record := range inventory.Symbols {
+		byPath[record.Path] = record
+	}
+	return byPath
+}
+
+func callRecordsByPath(inventory callbehavior.Inventory) map[string]callbehavior.CallBehaviorRecord {
+	byPath := make(map[string]callbehavior.CallBehaviorRecord, len(inventory.Records))
+	for _, record := range inventory.Records {
+		byPath[record.Path] = record
+	}
+	return byPath
+}
+
+func assertCatalogValueMatchesIdentityBaseline(
+	t *testing.T,
+	path string,
+	symbol map[string]any,
+	want symbolidentity.SymbolRecord,
+) {
+	t.Helper()
+
+	if got, _ := symbol["id"].(string); got != "javascript."+path {
+		t.Fatalf("catalog %q id = %q, want %q", path, got, "javascript."+path)
+	}
+	if got, _ := symbol["name"].(string); got != want.Name {
+		t.Fatalf("catalog %q name = %q, want %q", path, got, want.Name)
+	}
+	if got, _ := symbol["path"].(string); got != want.Path {
+		t.Fatalf("catalog %q path = %q, want %q", path, got, want.Path)
+	}
+	if got, _ := symbol["kind"].(string); got != want.Kind {
+		t.Fatalf("catalog %q kind = %q, want %q", path, got, want.Kind)
+	}
+	if parent, ok := symbol["parent"].(string); ok && parent != "" {
+		t.Fatalf("catalog %q parent = %q, want no parent", path, parent)
+	}
+	if members, ok := symbol["members"].([]any); ok && len(members) > 0 {
+		t.Fatalf("catalog %q members = %#v, want no members", path, members)
+	}
+	assertCatalogValueHasDocumentationExample(t, path, symbol)
+}
+
+func assertCatalogValueMatchesCallBehaviorBaseline(
+	t *testing.T,
+	path string,
+	symbol map[string]any,
+	want callbehavior.CallBehaviorRecord,
+) {
+	t.Helper()
+
+	if got, _ := symbol["mutability"].(string); got != want.Mutability {
+		t.Fatalf("catalog %q mutability = %q, want %q", path, got, want.Mutability)
+	}
+	if got, _ := symbol["nullability"].(string); got != want.Nullability {
+		t.Fatalf("catalog %q nullability = %q, want %q", path, got, want.Nullability)
+	}
+	if got, _ := symbol["bindingLifecycle"].(string); got != want.Lifecycle {
+		t.Fatalf("catalog %q bindingLifecycle = %q, want %q", path, got, want.Lifecycle)
+	}
+}
+
+func assertCatalogValueHasDocumentationExample(t *testing.T, path string, symbol map[string]any) {
+	t.Helper()
+
+	documentation, ok := symbol["documentation"].(map[string]any)
+	if !ok {
+		t.Fatalf("catalog %q documentation = %#v, want object", path, symbol["documentation"])
+	}
+	examples, ok := documentation["examples"].([]any)
+	if !ok || len(examples) == 0 {
+		t.Fatalf("catalog %q documentation.examples = %#v, want at least one example", path, documentation["examples"])
+	}
+	first, ok := examples[0].(string)
+	if !ok || first == "" {
+		t.Fatalf("catalog %q first documentation example = %#v, want non-empty string", path, examples[0])
 	}
 }

--- a/contracts/javascript_runtime_api_test.go
+++ b/contracts/javascript_runtime_api_test.go
@@ -1,0 +1,101 @@
+package contracts_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/contractvalidator"
+)
+
+func javascriptManifestFixtureRegistry(fixture string) contractvalidator.Registry {
+	const (
+		documentationID = "https://schemas.portpowered.com/you/contracts/common/documentation.schema.json"
+		deprecationsID  = "https://schemas.portpowered.com/you/contracts/common/deprecations.schema.json"
+	)
+	return contractvalidator.NewRegistry(contractvalidator.Entry{
+		Family:        "javascript",
+		FormatVersion: "1.0.0",
+		Schemas: []contractvalidator.Schema{
+			{ID: documentationID, Path: "contracts/common/documentation.schema.json"},
+			{ID: deprecationsID, Path: "contracts/common/deprecations.schema.json"},
+			{ID: runtimeManifestSchemaID, Path: "contracts/javascript/runtime-manifest.schema.json"},
+		},
+		Documents: []contractvalidator.Document{{
+			Path:     fixture,
+			SchemaID: runtimeManifestSchemaID,
+		}},
+	})
+}
+
+func TestJavaScriptRuntimeAPIAuthoredCatalogBoundary(t *testing.T) {
+	t.Parallel()
+
+	catalogPath := filepath.Join("javascript", "runtime-api.json")
+	if _, err := os.Stat(catalogPath); err != nil {
+		t.Fatalf("contracts/javascript/runtime-api.json must exist as the authored catalog: %v", err)
+	}
+
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("repository root: %v", err)
+	}
+	diagnostics := contractvalidator.Validate(root, contractvalidator.JavaScriptRegistry(), "javascript", "1.0.0")
+	if len(diagnostics) != 0 {
+		t.Fatalf("authored catalog validation diagnostics = %+v", diagnostics)
+	}
+}
+
+func TestJavaScriptRuntimeAPIBrokenSharedSchemaReference(t *testing.T) {
+	t.Parallel()
+
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("repository root: %v", err)
+	}
+	const (
+		fixture  = "contracts/testdata/javascript/invalid-broken-shared-schema-ref.json"
+		wantPath = "/symbols/javascript.workflow.checkpoint/parameters/0/serializableValue/$ref"
+	)
+	diagnostics := contractvalidator.Validate(root, javascriptManifestFixtureRegistry(fixture), "javascript", "1.0.0")
+	if len(diagnostics) == 0 {
+		t.Fatal("expected broken shared-schema reference diagnostics, got none")
+	}
+	found := false
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Code == "reference.fragment" && diagnostic.Path == wantPath && diagnostic.Document == fixture {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("diagnostics = %+v, want code=reference.fragment path=%q document=%q", diagnostics, wantPath, fixture)
+	}
+}
+
+func TestJavaScriptRuntimeAPIOpenSharedSchema(t *testing.T) {
+	t.Parallel()
+
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("repository root: %v", err)
+	}
+	const (
+		fixture  = "contracts/testdata/javascript/invalid-open-shared-schema.json"
+		wantPath = "/sharedSchemas/javascript.schema.open_object/schema"
+	)
+	diagnostics := contractvalidator.Validate(root, javascriptManifestFixtureRegistry(fixture), "javascript", "1.0.0")
+	if len(diagnostics) == 0 {
+		t.Fatal("expected open shared-schema diagnostics, got none")
+	}
+	found := false
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Code == "javascript.serializable_value.open" && diagnostic.Path == wantPath && diagnostic.Document == fixture {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("diagnostics = %+v, want code=javascript.serializable_value.open path=%q document=%q", diagnostics, wantPath, fixture)
+	}
+}

--- a/contracts/javascript_runtime_api_test.go
+++ b/contracts/javascript_runtime_api_test.go
@@ -31,6 +31,39 @@ func javascriptManifestFixtureRegistry(fixture string) contractvalidator.Registr
 	})
 }
 
+func TestJavaScriptRuntimeAPICatalogSyncRootHelpersLogAndPhase(t *testing.T) {
+	t.Parallel()
+
+	catalog := loadAuthoredJavaScriptRuntimeCatalog(t)
+	symbolsByPath := catalogSymbolsByPath(t, catalog)
+
+	for _, path := range []string{"log", "phase"} {
+		symbol, ok := symbolsByPath[path]
+		if !ok {
+			t.Fatalf("catalog missing sync root helper at path %q", path)
+		}
+		if got := countCatalogPaths(symbolsByPath, path); got != 1 {
+			t.Fatalf("catalog path %q appears %d times, want exactly once", path, got)
+		}
+
+		identity := symbolidentity.ProjectInstalledBindings()
+		identityByPath := symbolRecordsByPath(identity)
+		wantIdentity, ok := identityByPath[path]
+		if !ok {
+			t.Fatalf("identity baseline missing path %q", path)
+		}
+		assertCatalogCallableMatchesIdentityBaseline(t, path, symbol, wantIdentity)
+
+		callInventory := callbehavior.ProjectInstalledCallBehavior()
+		callByPath := callRecordsByPath(callInventory)
+		wantCallBehavior, ok := callByPath[path]
+		if !ok {
+			t.Fatalf("call-behavior baseline missing path %q", path)
+		}
+		assertCatalogCallableMatchesCallBehaviorBaseline(t, path, symbol, wantCallBehavior)
+	}
+}
+
 func TestJavaScriptRuntimeAPICatalogRootValuesArgsAndMeta(t *testing.T) {
 	t.Parallel()
 
@@ -243,6 +276,194 @@ func assertCatalogValueMatchesCallBehaviorBaseline(
 	}
 	if got, _ := symbol["bindingLifecycle"].(string); got != want.Lifecycle {
 		t.Fatalf("catalog %q bindingLifecycle = %q, want %q", path, got, want.Lifecycle)
+	}
+}
+
+func assertCatalogCallableMatchesIdentityBaseline(
+	t *testing.T,
+	path string,
+	symbol map[string]any,
+	want symbolidentity.SymbolRecord,
+) {
+	t.Helper()
+
+	if got, _ := symbol["id"].(string); got != "javascript."+path {
+		t.Fatalf("catalog %q id = %q, want %q", path, got, "javascript."+path)
+	}
+	if got, _ := symbol["name"].(string); got != want.Name {
+		t.Fatalf("catalog %q name = %q, want %q", path, got, want.Name)
+	}
+	if got, _ := symbol["path"].(string); got != want.Path {
+		t.Fatalf("catalog %q path = %q, want %q", path, got, want.Path)
+	}
+	if got, _ := symbol["kind"].(string); got != want.Kind {
+		t.Fatalf("catalog %q kind = %q, want %q", path, got, want.Kind)
+	}
+	if parent, ok := symbol["parent"].(string); ok && parent != "" {
+		t.Fatalf("catalog %q parent = %q, want no parent", path, parent)
+	}
+	if members, ok := symbol["members"].([]any); ok && len(members) > 0 {
+		t.Fatalf("catalog %q members = %#v, want no members", path, members)
+	}
+	assertCatalogValueHasDocumentationExample(t, path, symbol)
+}
+
+func assertCatalogCallableMatchesCallBehaviorBaseline(
+	t *testing.T,
+	path string,
+	symbol map[string]any,
+	want callbehavior.CallBehaviorRecord,
+) {
+	t.Helper()
+
+	if got, ok := symbol["async"].(bool); !ok || got != want.Async {
+		t.Fatalf("catalog %q async = %#v, want %v", path, symbol["async"], want.Async)
+	}
+	assertCatalogCallableParametersMatchBaseline(t, path, symbol, want.Parameters)
+	assertCatalogCallableReturnMatchesBaseline(t, path, symbol, want.Return)
+	assertCatalogCallableEmittedRecordsMatchBaseline(t, path, symbol, want.EmittedRecords)
+	assertCatalogCallableErrorsMatchBaseline(t, path, symbol, want.Errors)
+}
+
+func assertCatalogCallableParametersMatchBaseline(
+	t *testing.T,
+	path string,
+	symbol map[string]any,
+	want []callbehavior.Parameter,
+) {
+	t.Helper()
+
+	paramsValue, ok := symbol["parameters"].([]any)
+	if !ok {
+		t.Fatalf("catalog %q parameters = %#v, want array", path, symbol["parameters"])
+	}
+	if len(paramsValue) != len(want) {
+		t.Fatalf("catalog %q parameter count = %d, want %d", path, len(paramsValue), len(want))
+	}
+	for i, wantParam := range want {
+		param, ok := paramsValue[i].(map[string]any)
+		if !ok {
+			t.Fatalf("catalog %q parameters[%d] = %#v, want object", path, i, paramsValue[i])
+		}
+		if got, _ := param["position"].(float64); int(got) != i {
+			t.Fatalf("catalog %q parameters[%d].position = %v, want %d", path, i, param["position"], i)
+		}
+		if got, _ := param["name"].(string); got != wantParam.Name {
+			t.Fatalf("catalog %q parameters[%d].name = %q, want %q", path, i, got, wantParam.Name)
+		}
+		if got, _ := param["required"].(bool); got != wantParam.Required {
+			t.Fatalf("catalog %q parameters[%d].required = %v, want %v", path, i, got, wantParam.Required)
+		}
+		if got, _ := param["type"].(string); got != wantParam.Type {
+			t.Fatalf("catalog %q parameters[%d].type = %q, want %q", path, i, got, wantParam.Type)
+		}
+		if wantParam.Rest {
+			if got, _ := param["rest"].(bool); !got {
+				t.Fatalf("catalog %q parameters[%d].rest = %v, want true", path, i, param["rest"])
+			}
+		}
+		if wantParam.Default != "" {
+			if got, _ := param["default"].(string); got != wantParam.Default {
+				t.Fatalf("catalog %q parameters[%d].default = %q, want %q", path, i, got, wantParam.Default)
+			}
+		}
+	}
+}
+
+func assertCatalogCallableReturnMatchesBaseline(
+	t *testing.T,
+	path string,
+	symbol map[string]any,
+	want *callbehavior.ReturnBehavior,
+) {
+	t.Helper()
+
+	if want == nil {
+		t.Fatalf("call-behavior baseline %q missing return metadata", path)
+	}
+	returnValue, ok := symbol["return"].(map[string]any)
+	if !ok {
+		t.Fatalf("catalog %q return = %#v, want object", path, symbol["return"])
+	}
+	if want.Async {
+		if got, _ := returnValue["kind"].(string); got != "promise" {
+			t.Fatalf("catalog %q return.kind = %q, want promise", path, got)
+		}
+		return
+	}
+	if got, _ := returnValue["kind"].(string); got != "sync" {
+		t.Fatalf("catalog %q return.kind = %q, want sync", path, got)
+	}
+	if got, _ := returnValue["type"].(string); got != want.SyncType {
+		t.Fatalf("catalog %q return.type = %q, want %q", path, got, want.SyncType)
+	}
+}
+
+func assertCatalogCallableEmittedRecordsMatchBaseline(
+	t *testing.T,
+	path string,
+	symbol map[string]any,
+	want []string,
+) {
+	t.Helper()
+
+	if len(want) == 0 {
+		return
+	}
+	gotValue, ok := symbol["emittedRecords"].([]any)
+	if !ok {
+		t.Fatalf("catalog %q emittedRecords = %#v, want array", path, symbol["emittedRecords"])
+	}
+	got := make([]string, 0, len(gotValue))
+	for _, item := range gotValue {
+		record, ok := item.(string)
+		if !ok {
+			t.Fatalf("catalog %q emittedRecords item = %#v, want string", path, item)
+		}
+		got = append(got, record)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("catalog %q emittedRecords = %v, want %v", path, got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("catalog %q emittedRecords[%d] = %q, want %q", path, i, got[i], want[i])
+		}
+	}
+}
+
+func assertCatalogCallableErrorsMatchBaseline(
+	t *testing.T,
+	path string,
+	symbol map[string]any,
+	want []callbehavior.ErrorCase,
+) {
+	t.Helper()
+
+	if len(want) == 0 {
+		return
+	}
+	gotValue, ok := symbol["errors"].([]any)
+	if !ok {
+		t.Fatalf("catalog %q errors = %#v, want array", path, symbol["errors"])
+	}
+	if len(gotValue) != len(want) {
+		t.Fatalf("catalog %q error count = %d, want %d", path, len(gotValue), len(want))
+	}
+	for i, wantErr := range want {
+		errValue, ok := gotValue[i].(map[string]any)
+		if !ok {
+			t.Fatalf("catalog %q errors[%d] = %#v, want object", path, i, gotValue[i])
+		}
+		if got, _ := errValue["condition"].(string); got != wantErr.Condition {
+			t.Fatalf("catalog %q errors[%d].condition = %q, want %q", path, i, got, wantErr.Condition)
+		}
+		if got, _ := errValue["type"].(string); got != wantErr.Type {
+			t.Fatalf("catalog %q errors[%d].type = %q, want %q", path, i, got, wantErr.Type)
+		}
+		if got, _ := errValue["message"].(string); got != wantErr.Message {
+			t.Fatalf("catalog %q errors[%d].message = %q, want %q", path, i, got, wantErr.Message)
+		}
 	}
 }
 

--- a/contracts/javascript_runtime_api_test.go
+++ b/contracts/javascript_runtime_api_test.go
@@ -32,6 +32,79 @@ func javascriptManifestFixtureRegistry(fixture string) contractvalidator.Registr
 	})
 }
 
+func TestJavaScriptRuntimeAPICatalogAgentRunParallelAndPipeline(t *testing.T) {
+	t.Parallel()
+
+	catalog := loadAuthoredJavaScriptRuntimeCatalog(t)
+	symbolsByPath := catalogSymbolsByPath(t, catalog)
+
+	identity := symbolidentity.ProjectInstalledBindings()
+	identityByPath := symbolRecordsByPath(identity)
+	wantAgent, ok := identityByPath["agent"]
+	if !ok {
+		t.Fatal("identity baseline missing agent namespace")
+	}
+
+	agentSymbol, ok := symbolsByPath["agent"]
+	if !ok {
+		t.Fatal("catalog missing agent namespace")
+	}
+	if got := countCatalogPaths(symbolsByPath, "agent"); got != 1 {
+		t.Fatalf("catalog path agent appears %d times, want exactly once", got)
+	}
+	assertCatalogNamespaceMatchesIdentityBaseline(t, "agent", agentSymbol, wantAgent)
+
+	callInventory := callbehavior.ProjectInstalledCallBehavior()
+	callByPath := callRecordsByPath(callInventory)
+	wantAgentCallBehavior, ok := callByPath["agent"]
+	if !ok {
+		t.Fatal("call-behavior baseline missing agent namespace")
+	}
+	assertCatalogNamespaceMatchesCallBehaviorBaseline(t, "agent", agentSymbol, wantAgentCallBehavior)
+
+	agentRunSymbol, ok := symbolsByPath["agent.run"]
+	if !ok {
+		t.Fatal("catalog missing agent.run")
+	}
+	if got := countCatalogPaths(symbolsByPath, "agent.run"); got != 1 {
+		t.Fatalf("catalog path agent.run appears %d times, want exactly once", got)
+	}
+
+	wantAgentRunIdentity, ok := identityByPath["agent.run"]
+	if !ok {
+		t.Fatal("identity baseline missing agent.run")
+	}
+	assertCatalogMethodMatchesIdentityBaseline(t, "agent.run", agentRunSymbol, wantAgentRunIdentity)
+
+	wantAgentRunCallBehavior, ok := callByPath["agent.run"]
+	if !ok {
+		t.Fatal("call-behavior baseline missing agent.run")
+	}
+	assertCatalogMethodMatchesCallBehaviorBaseline(t, "agent.run", agentRunSymbol, wantAgentRunCallBehavior)
+
+	for _, path := range []string{"parallel", "pipeline"} {
+		symbol, ok := symbolsByPath[path]
+		if !ok {
+			t.Fatalf("catalog missing async root helper at path %q", path)
+		}
+		if got := countCatalogPaths(symbolsByPath, path); got != 1 {
+			t.Fatalf("catalog path %q appears %d times, want exactly once", path, got)
+		}
+
+		wantIdentity, ok := identityByPath[path]
+		if !ok {
+			t.Fatalf("identity baseline missing path %q", path)
+		}
+		assertCatalogCallableMatchesIdentityBaseline(t, path, symbol, wantIdentity)
+
+		wantCallBehavior, ok := callByPath[path]
+		if !ok {
+			t.Fatalf("call-behavior baseline missing path %q", path)
+		}
+		assertCatalogAsyncCallableMatchesCallBehaviorBaseline(t, path, symbol, wantCallBehavior)
+	}
+}
+
 func TestJavaScriptRuntimeAPICatalogWorkflowNamespaceAndMembers(t *testing.T) {
 	t.Parallel()
 
@@ -425,6 +498,21 @@ func assertCatalogCallableMatchesCallBehaviorBaseline(
 	assertCatalogCallableErrorsMatchBaseline(t, path, symbol, want.Errors)
 }
 
+func assertCatalogAsyncCallableMatchesCallBehaviorBaseline(
+	t *testing.T,
+	path string,
+	symbol map[string]any,
+	want callbehavior.CallBehaviorRecord,
+) {
+	t.Helper()
+
+	assertCatalogCallableMatchesCallBehaviorBaseline(t, path, symbol, want)
+	assertCatalogCallbackMatchesBaseline(t, path, symbol, want.Callback)
+	assertCatalogPolicyChecksMatchBaseline(t, path, symbol, want.PolicyChecks)
+	assertCatalogDeterminismMatchesBaseline(t, path, symbol, want.Determinism)
+	assertCatalogResumeNotesMatchBaseline(t, path, symbol, want.ResumeNotes)
+}
+
 func assertCatalogCallableParametersMatchBaseline(
 	t *testing.T,
 	path string,
@@ -488,6 +576,9 @@ func assertCatalogCallableReturnMatchesBaseline(
 	if want.Async {
 		if got, _ := returnValue["kind"].(string); got != "promise" {
 			t.Fatalf("catalog %q return.kind = %q, want promise", path, got)
+		}
+		if got, _ := returnValue["type"].(string); got != want.PromiseType {
+			t.Fatalf("catalog %q return.type = %q, want %q", path, got, want.PromiseType)
 		}
 		return
 	}
@@ -565,6 +656,35 @@ func assertCatalogCallableErrorsMatchBaseline(
 			t.Fatalf("catalog %q errors[%d].message = %q, want %q", path, i, got, wantErr.Message)
 		}
 	}
+}
+
+func assertCatalogCallbackMatchesBaseline(
+	t *testing.T,
+	path string,
+	symbol map[string]any,
+	want *callbehavior.CallbackShape,
+) {
+	t.Helper()
+
+	if want == nil {
+		if callbackValue, ok := symbol["callback"]; ok && callbackValue != nil {
+			t.Fatalf("catalog %q callback = %#v, want no callback metadata", path, callbackValue)
+		}
+		return
+	}
+	callbackValue, ok := symbol["callback"].(map[string]any)
+	if !ok {
+		t.Fatalf("catalog %q callback = %#v, want object", path, symbol["callback"])
+	}
+	if got, _ := callbackValue["role"].(string); got != want.Role {
+		t.Fatalf("catalog %q callback.role = %q, want %q", path, got, want.Role)
+	}
+	if want.Notes != "" {
+		if got, _ := callbackValue["notes"].(string); got != want.Notes {
+			t.Fatalf("catalog %q callback.notes = %q, want %q", path, got, want.Notes)
+		}
+	}
+	assertCatalogCallableParametersMatchBaseline(t, path+".callback", callbackValue, want.Parameters)
 }
 
 func assertCatalogNamespaceMatchesIdentityBaseline(

--- a/contracts/javascript_runtime_api_test.go
+++ b/contracts/javascript_runtime_api_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/portpowered/infinite-you/internal/contractvalidator"
@@ -29,6 +30,105 @@ func javascriptManifestFixtureRegistry(fixture string) contractvalidator.Registr
 			SchemaID: runtimeManifestSchemaID,
 		}},
 	})
+}
+
+func TestJavaScriptRuntimeAPICatalogWorkflowNamespaceAndMembers(t *testing.T) {
+	t.Parallel()
+
+	catalog := loadAuthoredJavaScriptRuntimeCatalog(t)
+	symbolsByPath := catalogSymbolsByPath(t, catalog)
+
+	identity := symbolidentity.ProjectInstalledBindings()
+	identityByPath := symbolRecordsByPath(identity)
+	wantWorkflow, ok := identityByPath["workflow"]
+	if !ok {
+		t.Fatal("identity baseline missing workflow namespace")
+	}
+
+	workflowSymbol, ok := symbolsByPath["workflow"]
+	if !ok {
+		t.Fatal("catalog missing workflow namespace")
+	}
+	if got := countCatalogPaths(symbolsByPath, "workflow"); got != 1 {
+		t.Fatalf("catalog path workflow appears %d times, want exactly once", got)
+	}
+	assertCatalogNamespaceMatchesIdentityBaseline(t, "workflow", workflowSymbol, wantWorkflow)
+
+	callInventory := callbehavior.ProjectInstalledCallBehavior()
+	callByPath := callRecordsByPath(callInventory)
+	wantWorkflowCallBehavior, ok := callByPath["workflow"]
+	if !ok {
+		t.Fatal("call-behavior baseline missing workflow namespace")
+	}
+	assertCatalogNamespaceMatchesCallBehaviorBaseline(t, "workflow", workflowSymbol, wantWorkflowCallBehavior)
+
+	workflowMembers := []string{
+		"workflow.artifact",
+		"workflow.budget",
+		"workflow.checkpoint",
+		"workflow.final",
+		"workflow.log",
+		"workflow.resumeState",
+	}
+	for _, path := range workflowMembers {
+		symbol, ok := symbolsByPath[path]
+		if !ok {
+			t.Fatalf("catalog missing workflow member at path %q", path)
+		}
+		if got := countCatalogPaths(symbolsByPath, path); got != 1 {
+			t.Fatalf("catalog path %q appears %d times, want exactly once", path, got)
+		}
+
+		wantIdentity, ok := identityByPath[path]
+		if !ok {
+			t.Fatalf("identity baseline missing path %q", path)
+		}
+		assertCatalogMethodMatchesIdentityBaseline(t, path, symbol, wantIdentity)
+
+		wantCallBehavior, ok := callByPath[path]
+		if !ok {
+			t.Fatalf("call-behavior baseline missing path %q", path)
+		}
+		assertCatalogMethodMatchesCallBehaviorBaseline(t, path, symbol, wantCallBehavior)
+	}
+}
+
+func TestJavaScriptRuntimeAPICatalogBrokenWorkflowParentMember(t *testing.T) {
+	t.Parallel()
+
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("repository root: %v", err)
+	}
+	const fixture = "contracts/testdata/javascript/invalid-broken-workflow-parent-member.json"
+	diagnostics := contractvalidator.Validate(root, javascriptManifestFixtureRegistry(fixture), "javascript", "1.0.0")
+	if len(diagnostics) == 0 {
+		t.Fatal("expected broken workflow parent/member diagnostics, got none")
+	}
+
+	wantChecks := []struct {
+		code string
+		path string
+	}{
+		{
+			code: "javascript.parent.unresolved",
+			path: "/symbols/javascript.workflow.checkpoint/parent",
+		},
+		{
+			code: "javascript.member.unresolved",
+			path: "/symbols/javascript.workflow/members/0",
+		},
+	}
+	for _, want := range wantChecks {
+		found := slices.ContainsFunc(diagnostics, func(diagnostic contractvalidator.Diagnostic) bool {
+			return diagnostic.Code == want.code &&
+				diagnostic.Path == want.path &&
+				diagnostic.Document == fixture
+		})
+		if !found {
+			t.Fatalf("diagnostics = %+v, want code=%q path=%q document=%q", diagnostics, want.code, want.path, fixture)
+		}
+	}
 }
 
 func TestJavaScriptRuntimeAPICatalogSyncRootHelpersLogAndPhase(t *testing.T) {
@@ -464,6 +564,190 @@ func assertCatalogCallableErrorsMatchBaseline(
 		if got, _ := errValue["message"].(string); got != wantErr.Message {
 			t.Fatalf("catalog %q errors[%d].message = %q, want %q", path, i, got, wantErr.Message)
 		}
+	}
+}
+
+func assertCatalogNamespaceMatchesIdentityBaseline(
+	t *testing.T,
+	path string,
+	symbol map[string]any,
+	want symbolidentity.SymbolRecord,
+) {
+	t.Helper()
+
+	if got, _ := symbol["id"].(string); got != "javascript."+path {
+		t.Fatalf("catalog %q id = %q, want %q", path, got, "javascript."+path)
+	}
+	if got, _ := symbol["name"].(string); got != want.Name {
+		t.Fatalf("catalog %q name = %q, want %q", path, got, want.Name)
+	}
+	if got, _ := symbol["path"].(string); got != want.Path {
+		t.Fatalf("catalog %q path = %q, want %q", path, got, want.Path)
+	}
+	if got, _ := symbol["kind"].(string); got != want.Kind {
+		t.Fatalf("catalog %q kind = %q, want %q", path, got, want.Kind)
+	}
+	if parent, ok := symbol["parent"].(string); ok && parent != "" {
+		t.Fatalf("catalog %q parent = %q, want no parent", path, parent)
+	}
+	membersValue, ok := symbol["members"].([]any)
+	if !ok {
+		t.Fatalf("catalog %q members = %#v, want array", path, symbol["members"])
+	}
+	gotMembers := make([]string, 0, len(membersValue))
+	for _, memberValue := range membersValue {
+		member, ok := memberValue.(string)
+		if !ok {
+			t.Fatalf("catalog %q members item = %#v, want string", path, memberValue)
+		}
+		gotMembers = append(gotMembers, member)
+	}
+	if len(gotMembers) != len(want.Members) {
+		t.Fatalf("catalog %q member count = %d, want %d", path, len(gotMembers), len(want.Members))
+	}
+	for i := range want.Members {
+		if gotMembers[i] != want.Members[i] {
+			t.Fatalf("catalog %q members[%d] = %q, want %q", path, i, gotMembers[i], want.Members[i])
+		}
+	}
+	assertCatalogValueHasDocumentationExample(t, path, symbol)
+}
+
+func assertCatalogNamespaceMatchesCallBehaviorBaseline(
+	t *testing.T,
+	path string,
+	symbol map[string]any,
+	want callbehavior.CallBehaviorRecord,
+) {
+	t.Helper()
+
+	if got, _ := symbol["mutability"].(string); got != want.Mutability {
+		t.Fatalf("catalog %q mutability = %q, want %q", path, got, want.Mutability)
+	}
+	if got, _ := symbol["nullability"].(string); got != want.Nullability {
+		t.Fatalf("catalog %q nullability = %q, want %q", path, got, want.Nullability)
+	}
+	if got, _ := symbol["bindingLifecycle"].(string); got != want.Lifecycle {
+		t.Fatalf("catalog %q bindingLifecycle = %q, want %q", path, got, want.Lifecycle)
+	}
+}
+
+func catalogExpectedSymbolID(path string) string {
+	if path == "workflow.resumeState" {
+		return "javascript.workflow.resume-state"
+	}
+	return "javascript." + path
+}
+
+func assertCatalogMethodMatchesIdentityBaseline(
+	t *testing.T,
+	path string,
+	symbol map[string]any,
+	want symbolidentity.SymbolRecord,
+) {
+	t.Helper()
+
+	wantID := catalogExpectedSymbolID(path)
+	if got, _ := symbol["id"].(string); got != wantID {
+		t.Fatalf("catalog %q id = %q, want %q", path, got, wantID)
+	}
+	if got, _ := symbol["name"].(string); got != want.Name {
+		t.Fatalf("catalog %q name = %q, want %q", path, got, want.Name)
+	}
+	if got, _ := symbol["path"].(string); got != want.Path {
+		t.Fatalf("catalog %q path = %q, want %q", path, got, want.Path)
+	}
+	if got, _ := symbol["kind"].(string); got != "method" {
+		t.Fatalf("catalog %q kind = %q, want method", path, got)
+	}
+	wantParent := "javascript." + want.Parent
+	if got, _ := symbol["parent"].(string); got != wantParent {
+		t.Fatalf("catalog %q parent = %q, want %q", path, got, wantParent)
+	}
+	if members, ok := symbol["members"].([]any); ok && len(members) > 0 {
+		t.Fatalf("catalog %q members = %#v, want no members", path, members)
+	}
+	assertCatalogValueHasDocumentationExample(t, path, symbol)
+}
+
+func assertCatalogMethodMatchesCallBehaviorBaseline(
+	t *testing.T,
+	path string,
+	symbol map[string]any,
+	want callbehavior.CallBehaviorRecord,
+) {
+	t.Helper()
+
+	if got, ok := symbol["async"].(bool); !ok || got != want.Async {
+		t.Fatalf("catalog %q async = %#v, want %v", path, symbol["async"], want.Async)
+	}
+	assertCatalogCallableParametersMatchBaseline(t, path, symbol, want.Parameters)
+	assertCatalogCallableReturnMatchesBaseline(t, path, symbol, want.Return)
+	assertCatalogCallableEmittedRecordsMatchBaseline(t, path, symbol, want.EmittedRecords)
+	assertCatalogCallableErrorsMatchBaseline(t, path, symbol, want.Errors)
+	assertCatalogPolicyChecksMatchBaseline(t, path, symbol, want.PolicyChecks)
+	assertCatalogDeterminismMatchesBaseline(t, path, symbol, want.Determinism)
+	assertCatalogResumeNotesMatchBaseline(t, path, symbol, want.ResumeNotes)
+}
+
+func assertCatalogPolicyChecksMatchBaseline(
+	t *testing.T,
+	path string,
+	symbol map[string]any,
+	want []callbehavior.PolicyCheck,
+) {
+	t.Helper()
+
+	if len(want) == 0 {
+		return
+	}
+	gotValue, ok := symbol["policyChecks"].([]any)
+	if !ok {
+		t.Fatalf("catalog %q policyChecks = %#v, want array", path, symbol["policyChecks"])
+	}
+	if len(gotValue) != len(want) {
+		t.Fatalf("catalog %q policyChecks count = %d, want %d", path, len(gotValue), len(want))
+	}
+	for i, wantCheck := range want {
+		checkValue, ok := gotValue[i].(map[string]any)
+		if !ok {
+			t.Fatalf("catalog %q policyChecks[%d] = %#v, want object", path, i, gotValue[i])
+		}
+		if got, _ := checkValue["kind"].(string); got != wantCheck.Kind {
+			t.Fatalf("catalog %q policyChecks[%d].kind = %q, want %q", path, i, got, wantCheck.Kind)
+		}
+		if wantCheck.Field != "" {
+			if got, _ := checkValue["field"].(string); got != wantCheck.Field {
+				t.Fatalf("catalog %q policyChecks[%d].field = %q, want %q", path, i, got, wantCheck.Field)
+			}
+		}
+		if wantCheck.Message != "" {
+			if got, _ := checkValue["message"].(string); got != wantCheck.Message {
+				t.Fatalf("catalog %q policyChecks[%d].message = %q, want %q", path, i, got, wantCheck.Message)
+			}
+		}
+	}
+}
+
+func assertCatalogDeterminismMatchesBaseline(t *testing.T, path string, symbol map[string]any, want string) {
+	t.Helper()
+
+	if want == "" {
+		return
+	}
+	if got, _ := symbol["determinism"].(string); got != want {
+		t.Fatalf("catalog %q determinism = %q, want %q", path, got, want)
+	}
+}
+
+func assertCatalogResumeNotesMatchBaseline(t *testing.T, path string, symbol map[string]any, want string) {
+	t.Helper()
+
+	if want == "" {
+		return
+	}
+	if got, _ := symbol["resumeNotes"].(string); got != want {
+		t.Fatalf("catalog %q resumeNotes = %q, want %q", path, got, want)
 	}
 }
 

--- a/contracts/javascript_runtime_api_test.go
+++ b/contracts/javascript_runtime_api_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/portpowered/infinite-you/internal/contractvalidator"
+	jscatalog "github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/catalog"
 	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/callbehavior"
 	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/symbolidentity"
 )
@@ -163,6 +164,23 @@ func TestJavaScriptRuntimeAPICatalogWorkflowNamespaceAndMembers(t *testing.T) {
 			t.Fatalf("call-behavior baseline missing path %q", path)
 		}
 		assertCatalogMethodMatchesCallBehaviorBaseline(t, path, symbol, wantCallBehavior)
+	}
+}
+
+func TestJavaScriptRuntimeAPICatalogPathCompleteness(t *testing.T) {
+	t.Parallel()
+
+	catalog := loadAuthoredJavaScriptRuntimeCatalog(t)
+	paths, err := jscatalog.CatalogSymbolPathsFromDocument(catalog)
+	if err != nil {
+		t.Fatalf("CatalogSymbolPathsFromDocument() error = %v", err)
+	}
+	if err := jscatalog.VerifyCatalogPathCompleteness(
+		paths,
+		symbolidentity.ProjectInstalledBindings(),
+		callbehavior.ProjectInstalledCallBehavior(),
+	); err != nil {
+		t.Fatalf("VerifyCatalogPathCompleteness() error = %v", err)
 	}
 }
 

--- a/contracts/javascript_runtime_api_test.go
+++ b/contracts/javascript_runtime_api_test.go
@@ -1,10 +1,12 @@
 package contracts_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/portpowered/infinite-you/internal/contractvalidator"
@@ -345,6 +347,103 @@ func TestJavaScriptRuntimeAPIAuthoredCatalogBoundary(t *testing.T) {
 	diagnostics := contractvalidator.Validate(root, contractvalidator.JavaScriptRegistry(), "javascript", "1.0.0")
 	if len(diagnostics) != 0 {
 		t.Fatalf("authored catalog validation diagnostics = %+v", diagnostics)
+	}
+}
+
+func TestJavaScriptRuntimeAPICatalogContainsNoUnsupportedSurfaces(t *testing.T) {
+	t.Parallel()
+
+	catalog := loadAuthoredJavaScriptRuntimeCatalog(t)
+	byPath := catalogSymbolsByPath(t, catalog)
+
+	forbiddenRoots := []string{"context", "orchestrator"}
+	comparisonHelpers := []string{"workflow.sleep", "agent.verify", "agent.parallel"}
+	for path := range byPath {
+		for _, forbidden := range forbiddenRoots {
+			if path == forbidden || strings.HasPrefix(path, forbidden+".") {
+				t.Fatalf("authored catalog documents forbidden global path %q", path)
+			}
+		}
+		if slices.Contains(comparisonHelpers, path) {
+			t.Fatalf("authored catalog documents comparison-project-only helper path %q", path)
+		}
+		if path == "agent" {
+			if symbol, ok := byPath[path]; ok {
+				if kind, _ := symbol["kind"].(string); kind == "function" {
+					t.Fatalf("authored catalog documents comparison-project-only callable agent global at path %q", path)
+				}
+			}
+		}
+	}
+}
+
+func TestJavaScriptRuntimeAPICatalogRejectsUnsupportedSurfaceFixtures(t *testing.T) {
+	t.Parallel()
+
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("repository root: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		fixture  string
+		wantCode string
+		wantPath string
+	}{
+		{
+			name:     "context global",
+			fixture:  "contracts/testdata/javascript/invalid-unsupported-context-global.json",
+			wantCode: "javascript.surface.forbidden_global",
+			wantPath: "/symbols/example.context/path",
+		},
+		{
+			name:     "orchestrator global",
+			fixture:  "contracts/testdata/javascript/invalid-unsupported-orchestrator-global.json",
+			wantCode: "javascript.surface.forbidden_global",
+			wantPath: "/symbols/example.orchestrator/path",
+		},
+		{
+			name:     "comparison-project helper",
+			fixture:  "contracts/testdata/javascript/invalid-unsupported-comparison-helper.json",
+			wantCode: "javascript.surface.unsupported_helper",
+			wantPath: "/symbols/example.workflow.sleep/path",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			diagnostics := contractvalidator.Validate(root, javascriptManifestFixtureRegistry(test.fixture), "javascript", "1.0.0")
+			if len(diagnostics) == 0 {
+				t.Fatal("expected unsupported-surface diagnostics, got none")
+			}
+			found := false
+			for _, diagnostic := range diagnostics {
+				if diagnostic.Code == test.wantCode && diagnostic.Path == test.wantPath && diagnostic.Document == test.fixture {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("diagnostics = %+v, want code=%q path=%q document=%q", diagnostics, test.wantCode, test.wantPath, test.fixture)
+			}
+		})
+	}
+}
+
+func TestJavaScriptStagedRuntimeAPIMatchesAuthoredCatalog(t *testing.T) {
+	t.Parallel()
+
+	authored, err := os.ReadFile(filepath.Join("javascript", "runtime-api.json"))
+	if err != nil {
+		t.Fatalf("read authored catalog: %v", err)
+	}
+	staged, err := os.ReadFile(filepath.Join("..", "packages", "api", "generated", "javascript", "runtime-api.json"))
+	if err != nil {
+		t.Fatalf("read staged runtime-api projection: %v", err)
+	}
+	if !bytes.Equal(authored, staged) {
+		t.Fatal("staged packages/api/generated/javascript/runtime-api.json must be a byte-identical copy of contracts/javascript/runtime-api.json")
 	}
 }
 

--- a/contracts/javascript_runtime_api_test.go
+++ b/contracts/javascript_runtime_api_test.go
@@ -167,6 +167,48 @@ func TestJavaScriptRuntimeAPICatalogWorkflowNamespaceAndMembers(t *testing.T) {
 	}
 }
 
+func TestJavaScriptRuntimeAPICatalogRepresentativeCallBehaviorParity(t *testing.T) {
+	t.Parallel()
+
+	catalog := loadAuthoredJavaScriptRuntimeCatalog(t)
+	if err := jscatalog.VerifyCatalogCallBehaviorParity(
+		catalog,
+		callbehavior.ProjectInstalledCallBehavior(),
+	); err != nil {
+		t.Fatalf("VerifyCatalogCallBehaviorParity() error = %v", err)
+	}
+}
+
+func TestJavaScriptRuntimeAPICatalogRepresentativeCallBehaviorParityDrift(t *testing.T) {
+	t.Parallel()
+
+	raw, err := os.ReadFile(filepath.Join("testdata", "javascript", "invalid-representative-call-behavior-drift.json"))
+	if err != nil {
+		t.Fatalf("read parity drift fixture: %v", err)
+	}
+	var catalog map[string]any
+	if err := json.Unmarshal(raw, &catalog); err != nil {
+		t.Fatalf("unmarshal parity drift fixture: %v", err)
+	}
+
+	issues, err := jscatalog.CatalogCallBehaviorParityIssues(catalog, callbehavior.ProjectInstalledCallBehavior())
+	if err != nil {
+		t.Fatalf("CatalogCallBehaviorParityIssues() error = %v", err)
+	}
+	found := false
+	for _, issue := range issues {
+		if issue.Code == "javascript.call_behavior.mismatch" &&
+			issue.Path == "workflow.final" &&
+			issue.Field == "determinism" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("issues = %+v, want workflow.final determinism mismatch", issues)
+	}
+}
+
 func TestJavaScriptRuntimeAPICatalogPathCompleteness(t *testing.T) {
 	t.Parallel()
 

--- a/contracts/runtime_manifest_boundary_test.go
+++ b/contracts/runtime_manifest_boundary_test.go
@@ -17,6 +17,7 @@ var javascriptRuntimePackages = []string{
 	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/result",
 	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime",
 	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/callbehavior",
+	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/catalog",
 	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/symbolidentity",
 	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/source",
 	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/store",

--- a/contracts/runtime_manifest_boundary_test.go
+++ b/contracts/runtime_manifest_boundary_test.go
@@ -71,24 +71,28 @@ func TestJavaScriptAuthoredCatalogBoundary(t *testing.T) {
 
 	repositoryRoot := testpath.MustRepoRootFromCaller(t, 0)
 	authoredSchema := testpath.MustRepoPathFromCaller(t, 0, "contracts", "javascript", "runtime-manifest.schema.json")
-	forbiddenCatalog := testpath.MustRepoPathFromCaller(t, 0, "contracts", "javascript", "runtime-api.json")
+	authoredCatalog := testpath.MustRepoPathFromCaller(t, 0, "contracts", "javascript", "runtime-api.json")
 
 	if _, err := os.Stat(authoredSchema); err != nil {
 		t.Fatalf("authored runtime-manifest schema missing: %v", err)
 	}
-	if _, err := os.Stat(forbiddenCatalog); !os.IsNotExist(err) {
-		t.Fatalf("authored B17 catalog must not exist at %s", forbiddenCatalog)
+	if _, err := os.Stat(authoredCatalog); err != nil {
+		t.Fatalf("authored JavaScript runtime API catalog missing: %v", err)
 	}
 
+	allowed := map[string]struct{}{
+		"runtime-manifest.schema.json": {},
+		"runtime-api.json":             {},
+	}
 	entries, err := os.ReadDir(testpath.MustRepoPathFromCaller(t, 0, "contracts", "javascript"))
 	if err != nil {
 		t.Fatalf("read contracts/javascript: %v", err)
 	}
 	for _, entry := range entries {
 		if entry.IsDir() {
-			t.Fatalf("contracts/javascript must contain only the authored schema file, found directory %s", entry.Name())
+			t.Fatalf("contracts/javascript must contain only authored contract files, found directory %s", entry.Name())
 		}
-		if entry.Name() != "runtime-manifest.schema.json" {
+		if _, ok := allowed[entry.Name()]; !ok {
 			t.Fatalf("unexpected authored javascript contract %s under %s", entry.Name(), repositoryRoot)
 		}
 	}

--- a/contracts/runtime_manifest_boundary_test.go
+++ b/contracts/runtime_manifest_boundary_test.go
@@ -99,11 +99,11 @@ func TestJavaScriptAuthoredCatalogBoundary(t *testing.T) {
 	}
 }
 
-func TestJavaScriptStagedRuntimeAPIRemainsInventorySourced(t *testing.T) {
+func TestJavaScriptStagedRuntimeAPIProjectsFromAuthoredCatalog(t *testing.T) {
 	t.Parallel()
 
 	const (
-		wantSource = "pkg/orchestrators/javascript/runtime/javascript-runtime-symbols.json"
+		wantSource = "contracts/javascript/runtime-api.json"
 		wantTarget = "packages/api/generated/javascript/runtime-api.json"
 	)
 
@@ -114,7 +114,7 @@ func TestJavaScriptStagedRuntimeAPIRemainsInventorySourced(t *testing.T) {
 		}
 		found = true
 		if artifact.Source != wantSource {
-			t.Fatalf("staged runtime-api source = %q, want inventory %q", artifact.Source, wantSource)
+			t.Fatalf("staged runtime-api source = %q, want authored catalog %q", artifact.Source, wantSource)
 		}
 	}
 	if !found {

--- a/contracts/runtime_manifest_schema_test.go
+++ b/contracts/runtime_manifest_schema_test.go
@@ -181,6 +181,7 @@ func TestRuntimeManifestSchemaSignatureAndSerializableFixtures(t *testing.T) {
 		wantPath string
 	}{
 		{name: "closed serializable values", fixture: "valid-closed-serializable-value.json", valid: true},
+		{name: "shared schema references", fixture: "valid-shared-schema-refs.json", valid: true},
 		{
 			name:     "duplicate parameter positions",
 			fixture:  "invalid-signature-duplicate-position.json",

--- a/contracts/testdata/javascript/invalid-broken-shared-schema-ref.json
+++ b/contracts/testdata/javascript/invalid-broken-shared-schema-ref.json
@@ -1,0 +1,71 @@
+{
+  "formatVersion": "1.0.0",
+  "sharedSchemas": {
+    "javascript.schema.checkpoint_spec": {
+      "id": "javascript.schema.checkpoint_spec",
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "label": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "label"
+        ]
+      }
+    }
+  },
+  "symbols": {
+    "javascript.workflow.checkpoint": {
+      "id": "javascript.workflow.checkpoint",
+      "name": "checkpoint",
+      "path": "workflow.checkpoint",
+      "kind": "function",
+      "async": false,
+      "parameters": [
+        {
+          "id": "javascript.workflow.checkpoint.param.spec",
+          "name": "spec",
+          "position": 0,
+          "required": true,
+          "rest": false,
+          "type": "object",
+          "serializableValue": {
+            "$ref": "#/sharedSchemas/javascript.schema.missing/schema"
+          }
+        }
+      ],
+      "return": {
+        "kind": "sync",
+        "type": "undefined"
+      },
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.checkpoint",
+        "documentation": {
+          "title": {
+            "id": "javascript.workflow.checkpoint.title",
+            "canonicalEnglish": "Broken shared schema reference"
+          },
+          "description": {
+            "id": "javascript.workflow.checkpoint.description",
+            "canonicalEnglish": "Fixture proving unresolved shared-schema references fail with a deterministic validation path."
+          }
+        },
+        "examples": [
+          "workflow.checkpoint({ label: \"draft\" })"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.checkpoint",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    }
+  }
+}

--- a/contracts/testdata/javascript/invalid-broken-workflow-parent-member.json
+++ b/contracts/testdata/javascript/invalid-broken-workflow-parent-member.json
@@ -1,0 +1,102 @@
+{
+  "formatVersion": "1.0.0",
+  "symbols": {
+    "javascript.workflow": {
+      "id": "javascript.workflow",
+      "name": "workflow",
+      "path": "workflow",
+      "kind": "namespace",
+      "members": [
+        "artifact",
+        "checkpoint"
+      ],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow",
+        "documentation": {
+          "title": {
+            "id": "javascript.workflow.title",
+            "canonicalEnglish": "Workflow namespace"
+          },
+          "description": {
+            "id": "javascript.workflow.description",
+            "canonicalEnglish": "Fixture namespace with one unresolved member and one broken parent link."
+          }
+        },
+        "examples": [
+          "workflow.checkpoint"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "mutability": "fixed-binding",
+      "nullability": "non-null",
+      "bindingLifecycle": "live-namespace"
+    },
+    "javascript.workflow.checkpoint": {
+      "id": "javascript.workflow.checkpoint",
+      "name": "checkpoint",
+      "path": "workflow.checkpoint",
+      "kind": "method",
+      "parent": "javascript.missing.workflow",
+      "async": false,
+      "parameters": [
+        {
+          "id": "javascript.workflow.checkpoint.param.spec",
+          "name": "spec",
+          "position": 0,
+          "required": true,
+          "rest": false,
+          "type": "object",
+          "serializableValue": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "label": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "label"
+            ]
+          }
+        }
+      ],
+      "return": {
+        "kind": "sync",
+        "type": "undefined"
+      },
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.checkpoint",
+        "documentation": {
+          "title": {
+            "id": "javascript.workflow.checkpoint.title",
+            "canonicalEnglish": "Workflow checkpoint"
+          },
+          "description": {
+            "id": "javascript.workflow.checkpoint.description",
+            "canonicalEnglish": "Fixture method with a parent reference that does not resolve."
+          }
+        },
+        "examples": [
+          "workflow.checkpoint({ label: \"draft\" })"
+        ],
+        "visibility": "public",
+        "sourceHash": "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.checkpoint",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    }
+  }
+}

--- a/contracts/testdata/javascript/invalid-open-shared-schema.json
+++ b/contracts/testdata/javascript/invalid-open-shared-schema.json
@@ -1,0 +1,67 @@
+{
+  "formatVersion": "1.0.0",
+  "sharedSchemas": {
+    "javascript.schema.open_object": {
+      "id": "javascript.schema.open_object",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "symbols": {
+    "javascript.workflow.checkpoint": {
+      "id": "javascript.workflow.checkpoint",
+      "name": "checkpoint",
+      "path": "workflow.checkpoint",
+      "kind": "function",
+      "async": false,
+      "parameters": [
+        {
+          "id": "javascript.workflow.checkpoint.param.spec",
+          "name": "spec",
+          "position": 0,
+          "required": true,
+          "rest": false,
+          "type": "object",
+          "serializableValue": {
+            "$ref": "#/sharedSchemas/javascript.schema.open_object/schema"
+          }
+        }
+      ],
+      "return": {
+        "kind": "sync",
+        "type": "undefined"
+      },
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.checkpoint",
+        "documentation": {
+          "title": {
+            "id": "javascript.workflow.checkpoint.title",
+            "canonicalEnglish": "Open shared schema reference"
+          },
+          "description": {
+            "id": "javascript.workflow.checkpoint.description",
+            "canonicalEnglish": "Fixture proving open shared serializable-value schemas fail semantic validation."
+          }
+        },
+        "examples": [
+          "workflow.checkpoint({ label: \"draft\", extra: true })"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.checkpoint",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    }
+  }
+}

--- a/contracts/testdata/javascript/invalid-representative-call-behavior-drift.json
+++ b/contracts/testdata/javascript/invalid-representative-call-behavior-drift.json
@@ -1,0 +1,53 @@
+{
+  "formatVersion": "1.0.0",
+  "symbols": {
+    "javascript.workflow.final": {
+      "id": "javascript.workflow.final",
+      "name": "final",
+      "path": "workflow.final",
+      "kind": "method",
+      "parent": "javascript.workflow",
+      "async": false,
+      "parameters": [
+        {
+          "id": "javascript.workflow.final.param.value",
+          "name": "value",
+          "position": 0,
+          "required": false,
+          "rest": false,
+          "type": "any"
+        }
+      ],
+      "return": {
+        "kind": "sync",
+        "type": "undefined"
+      },
+      "determinism": "returned workflow value wins over workflow.final",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.final",
+        "documentation": {
+          "title": {
+            "id": "javascript.workflow.final.title",
+            "canonicalEnglish": "Workflow final result"
+          },
+          "description": {
+            "id": "javascript.workflow.final.description",
+            "canonicalEnglish": "Fixture with drifted determinism semantics for representative parity checks."
+          }
+        },
+        "examples": [
+          "workflow.final({ ok: true })"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.final",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    }
+  }
+}

--- a/contracts/testdata/javascript/valid-shared-schema-refs.json
+++ b/contracts/testdata/javascript/valid-shared-schema-refs.json
@@ -1,0 +1,71 @@
+{
+  "formatVersion": "1.0.0",
+  "sharedSchemas": {
+    "javascript.schema.checkpoint_spec": {
+      "id": "javascript.schema.checkpoint_spec",
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "label": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "label"
+        ]
+      }
+    }
+  },
+  "symbols": {
+    "example.shared-schema.checkpoint": {
+      "id": "example.shared-schema.checkpoint",
+      "name": "checkpoint",
+      "path": "workflow.checkpoint",
+      "kind": "function",
+      "async": false,
+      "parameters": [
+        {
+          "id": "example.shared-schema.checkpoint.param.spec",
+          "name": "spec",
+          "position": 0,
+          "required": true,
+          "rest": false,
+          "type": "object",
+          "serializableValue": {
+            "$ref": "#/sharedSchemas/javascript.schema.checkpoint_spec/schema"
+          }
+        }
+      ],
+      "return": {
+        "kind": "sync",
+        "type": "undefined"
+      },
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.shared-schema.checkpoint",
+        "documentation": {
+          "title": {
+            "id": "example.shared-schema.checkpoint.title",
+            "canonicalEnglish": "Shared schema reference"
+          },
+          "description": {
+            "id": "example.shared-schema.checkpoint.description",
+            "canonicalEnglish": "Fixture proving shared-schema references resolve and validate."
+          }
+        },
+        "examples": [
+          "workflow.checkpoint({ label: \"draft\" })"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "example.shared-schema.checkpoint",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    }
+  }
+}

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -35,8 +35,8 @@ Use this map when changing the public REST contract.
   staged paths across the complete projection.
 - Raw JSON/YAML projections in `policy.go#rawArtifacts` are byte-identical copies
   from their canonical owners (CLI/MCP baselines, `contracts/config/` schemas,
-  JavaScript runtime inventory). Factory schema is the only reviewed raw export
-  derived from OpenAPI rather than copied. Prove repository parity in
+  authored JavaScript runtime catalog). Factory schema is the only reviewed raw
+  export derived from OpenAPI rather than copied. Prove repository parity in
   `internal/contractstaging/raw_artifacts_test.go`; later-phase export-map
   families such as `components/*` stay omitted until a truthful owner exists.
 - Authored JavaScript runtime symbol manifests live at
@@ -61,8 +61,9 @@ Use this map when changing the public REST contract.
   in `pkg/orchestrators/javascript/runtime/callbehavior_inventory_test.go`.
   Prove runtime dependency isolation and catalog boundaries in `contracts/runtime_manifest_boundary_test.go` and
   `contracts/javascript_runtime_api_test.go`; staged
-  `packages/api/generated/javascript/runtime-api.json` remains inventory-sourced
-  until the catalog lane retargets generation in story 008.
+  `packages/api/generated/javascript/runtime-api.json` is a byte-identical copy
+  of the authored catalog at `contracts/javascript/runtime-api.json` through
+  `internal/contractstaging/policy.go#rawArtifacts`.
 - Staged OpenAPI byte policy lives in `internal/contractstaging/openapi.go`
   (`CanonicalOpenAPIPath`, `StagedOpenAPIPath`, `ReviewedOpenAPIBytePolicy`,
   `ProjectStagedOpenAPI`, `VerifyStagedOpenAPIParity`). The reviewed policy is

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -52,6 +52,13 @@ Use this map when changing the public REST contract.
   identity baseline and installed binding descriptor lives in
   `pkg/orchestrators/javascript/runtime/catalog/catalog_identity.go` and is
   wired through `internal/contractvalidator/javascript_catalog_identity.go`.
+  Representative call-behavior parity for `workflow.final`,
+  `workflow.checkpoint`, `agent.run`, `parallel`, and `pipeline` lives in
+  `pkg/orchestrators/javascript/runtime/catalog/catalog_call_behavior_parity.go`
+  and is wired through
+  `internal/contractvalidator/javascript_catalog_call_behavior_parity.go`.
+  Focused runtime execution parity for the same representative symbols remains
+  in `pkg/orchestrators/javascript/runtime/callbehavior_inventory_test.go`.
   Prove runtime dependency isolation and catalog boundaries in `contracts/runtime_manifest_boundary_test.go` and
   `contracts/javascript_runtime_api_test.go`; staged
   `packages/api/generated/javascript/runtime-api.json` remains inventory-sourced

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -48,8 +48,11 @@ Use this map when changing the public REST contract.
   integrity, callable signatures, closed serializable values (including
   `sharedSchemas` entries keyed by `javascript.schema.*`), and supported
   surfaces live in `internal/contractvalidator/javascript_manifest.go` and
-  `javascript_surface.go`. Prove runtime dependency isolation and catalog
-  boundaries in `contracts/runtime_manifest_boundary_test.go` and
+  `javascript_surface.go`. Authored-catalog path completeness against the
+  identity baseline and installed binding descriptor lives in
+  `pkg/orchestrators/javascript/runtime/catalog/catalog_identity.go` and is
+  wired through `internal/contractvalidator/javascript_catalog_identity.go`.
+  Prove runtime dependency isolation and catalog boundaries in `contracts/runtime_manifest_boundary_test.go` and
   `contracts/javascript_runtime_api_test.go`; staged
   `packages/api/generated/javascript/runtime-api.json` remains inventory-sourced
   until the catalog lane retargets generation in story 008.

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -40,16 +40,19 @@ Use this map when changing the public REST contract.
   `internal/contractstaging/raw_artifacts_test.go`; later-phase export-map
   families such as `components/*` stay omitted until a truthful owner exists.
 - Authored JavaScript runtime symbol manifests live at
-  `contracts/javascript/runtime-manifest.schema.json` with fixtures under
-  `contracts/testdata/javascript/` and registration in
+  `contracts/javascript/runtime-manifest.schema.json` with the authored product
+  catalog at `contracts/javascript/runtime-api.json`, fixtures under
+  `contracts/testdata/javascript/`, and registration in
   `internal/contractvalidator/javascript_registry.go` (`JavaScriptRegistry`,
   merged into `DefaultRegistry()`). Post-schema semantics for path/parent/member
-  integrity, callable signatures, closed serializable values, and supported
+  integrity, callable signatures, closed serializable values (including
+  `sharedSchemas` entries keyed by `javascript.schema.*`), and supported
   surfaces live in `internal/contractvalidator/javascript_manifest.go` and
   `javascript_surface.go`. Prove runtime dependency isolation and catalog
-  boundaries in `contracts/runtime_manifest_boundary_test.go`; do not promote
-  B06 staged `packages/api/generated/javascript/runtime-api.json` or author
-  `contracts/javascript/runtime-api.json` as the product catalog in this lane.
+  boundaries in `contracts/runtime_manifest_boundary_test.go` and
+  `contracts/javascript_runtime_api_test.go`; staged
+  `packages/api/generated/javascript/runtime-api.json` remains inventory-sourced
+  until the catalog lane retargets generation in story 008.
 - Staged OpenAPI byte policy lives in `internal/contractstaging/openapi.go`
   (`CanonicalOpenAPIPath`, `StagedOpenAPIPath`, `ReviewedOpenAPIBytePolicy`,
   `ProjectStagedOpenAPI`, `VerifyStagedOpenAPIParity`). The reviewed policy is

--- a/internal/contractstaging/policy.go
+++ b/internal/contractstaging/policy.go
@@ -39,7 +39,7 @@ var (
 		{Source: "contracts/testdata/baseline/mcp-tools.json", Target: "packages/api/generated/mcp/tools.json"},
 		{Source: "contracts/config/you-config.schema.json", Target: "packages/api/generated/schemas/you-config.schema.json"},
 		{Source: "contracts/config/mock-workers.schema.json", Target: "packages/api/generated/schemas/mock-workers.schema.json"},
-		{Source: "pkg/orchestrators/javascript/runtime/javascript-runtime-symbols.json", Target: "packages/api/generated/javascript/runtime-api.json"},
+		{Source: "contracts/javascript/runtime-api.json", Target: "packages/api/generated/javascript/runtime-api.json"},
 	}
 )
 

--- a/internal/contractvalidator/javascript_catalog_call_behavior_parity.go
+++ b/internal/contractvalidator/javascript_catalog_call_behavior_parity.go
@@ -1,0 +1,54 @@
+package contractvalidator
+
+import (
+	jscatalog "github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/catalog"
+	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/callbehavior"
+)
+
+// JavaScriptRuntimeCatalogCallBehaviorParityDiagnostics applies authored-catalog
+// representative call-behavior parity checks against the installed baseline.
+func JavaScriptRuntimeCatalogCallBehaviorParityDiagnostics(document string, value any) []Diagnostic {
+	if document != authoredJavaScriptRuntimeCatalogPath {
+		return nil
+	}
+
+	root, ok := value.(map[string]any)
+	if !ok {
+		return []Diagnostic{newDiagnostic(
+			"catalog.call_behavior.parse",
+			"/symbols",
+			"catalog document is not an object",
+			document,
+		)}
+	}
+
+	issues, err := jscatalog.CatalogCallBehaviorParityIssues(root, callbehavior.ProjectInstalledCallBehavior())
+	if err != nil {
+		return []Diagnostic{newDiagnostic("catalog.call_behavior.parse", "/symbols", err.Error(), document)}
+	}
+	if len(issues) == 0 {
+		return nil
+	}
+
+	diagnostics := make([]Diagnostic, 0, len(issues))
+	for _, issue := range issues {
+		diagnosticPath := "/symbols"
+		if issue.SymbolKey != "" {
+			diagnosticPath = "/symbols/" + escapeJSONPointerToken(issue.SymbolKey)
+			if issue.Field != "" {
+				diagnosticPath += "/" + escapeJSONPointerToken(issue.Field)
+			}
+		}
+		diagnostics = append(diagnostics, newDiagnostic(
+			issue.Code,
+			diagnosticPath,
+			issue.Message,
+			document,
+		))
+	}
+	return diagnostics
+}
+
+func javascriptCatalogCallBehaviorParityDiagnostics(document string, value any) []Diagnostic {
+	return JavaScriptRuntimeCatalogCallBehaviorParityDiagnostics(document, value)
+}

--- a/internal/contractvalidator/javascript_catalog_identity.go
+++ b/internal/contractvalidator/javascript_catalog_identity.go
@@ -1,0 +1,51 @@
+package contractvalidator
+
+import (
+	jscatalog "github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/catalog"
+	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/callbehavior"
+	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/symbolidentity"
+)
+
+const authoredJavaScriptRuntimeCatalogPath = "contracts/javascript/runtime-api.json"
+
+// JavaScriptRuntimeCatalogPathCompletenessDiagnostics applies authored-catalog path
+// completeness checks against the identity baseline and installed binding descriptor.
+func JavaScriptRuntimeCatalogPathCompletenessDiagnostics(document string, value any) []Diagnostic {
+	if document != authoredJavaScriptRuntimeCatalogPath {
+		return nil
+	}
+
+	paths, err := jscatalog.CatalogSymbolPathsFromDocument(value)
+	if err != nil {
+		return []Diagnostic{newDiagnostic("catalog.path.parse", "/symbols", err.Error(), document)}
+	}
+
+	issues := jscatalog.CatalogPathCompletenessIssues(
+		paths,
+		symbolidentity.ProjectInstalledBindings(),
+		callbehavior.ProjectInstalledCallBehavior(),
+	)
+	if len(issues) == 0 {
+		return nil
+	}
+
+	diagnostics := make([]Diagnostic, 0, len(issues))
+	for _, issue := range issues {
+		diagnosticPath := "/symbols"
+		switch issue.Code {
+		case "javascript.path.extra", "javascript.path.duplicate":
+			diagnosticPath = "/symbols/" + escapeJSONPointerToken(issue.SymbolKey) + "/path"
+		}
+		diagnostics = append(diagnostics, newDiagnostic(
+			issue.Code,
+			diagnosticPath,
+			issue.Message,
+			document,
+		))
+	}
+	return diagnostics
+}
+
+func javascriptCatalogPathCompletenessDiagnostics(document string, value any) []Diagnostic {
+	return JavaScriptRuntimeCatalogPathCompletenessDiagnostics(document, value)
+}

--- a/internal/contractvalidator/javascript_manifest.go
+++ b/internal/contractvalidator/javascript_manifest.go
@@ -33,6 +33,7 @@ func runtimeManifestDiagnostics(document string, value any) []Diagnostic {
 
 	index := indexRuntimeManifestSymbols(symbols)
 	var diagnostics []Diagnostic
+	diagnostics = append(diagnostics, runtimeManifestSharedSchemaDiagnostics(document, root)...)
 	diagnostics = append(diagnostics, runtimeManifestDuplicatePathDiagnostics(document, index)...)
 	for _, key := range index.keys {
 		symbol, ok := symbols[key].(map[string]any)
@@ -88,6 +89,31 @@ func indexRuntimeManifestSymbols(symbols map[string]any) runtimeManifestSymbolIn
 		}
 	}
 	return index
+}
+
+func runtimeManifestSharedSchemaDiagnostics(document string, root map[string]any) []Diagnostic {
+	sharedSchemas, ok := root["sharedSchemas"].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	var diagnostics []Diagnostic
+	for _, key := range sortedStringKeys(sharedSchemas) {
+		entry, ok := sharedSchemas[key].(map[string]any)
+		if !ok {
+			continue
+		}
+		schema, ok := entry["schema"].(map[string]any)
+		if !ok {
+			continue
+		}
+		diagnostics = append(diagnostics, openSerializableValueDiagnostics(
+			document,
+			"/sharedSchemas/"+escapeJSONPointerToken(key)+"/schema",
+			schema,
+		)...)
+	}
+	return diagnostics
 }
 
 func runtimeManifestDuplicatePathDiagnostics(document string, index runtimeManifestSymbolIndex) []Diagnostic {

--- a/internal/contractvalidator/javascript_registry.go
+++ b/internal/contractvalidator/javascript_registry.go
@@ -17,6 +17,7 @@ func JavaScriptRegistry() Registry {
 			{ID: runtimeManifestSchemaID, Path: "contracts/javascript/runtime-manifest.schema.json"},
 		},
 		Documents: []Document{
+			{Path: "contracts/javascript/runtime-api.json", SchemaID: runtimeManifestSchemaID},
 			{Path: "contracts/testdata/javascript/valid-nested-namespace.json", SchemaID: runtimeManifestSchemaID},
 			{Path: "contracts/testdata/javascript/valid-value.json", SchemaID: runtimeManifestSchemaID},
 			{Path: "contracts/testdata/javascript/valid-synchronous-function.json", SchemaID: runtimeManifestSchemaID},
@@ -27,6 +28,7 @@ func JavaScriptRegistry() Registry {
 			{Path: "contracts/testdata/javascript/valid-resume.json", SchemaID: runtimeManifestSchemaID},
 			{Path: "contracts/testdata/javascript/valid-lifecycle-constraints.json", SchemaID: runtimeManifestSchemaID},
 			{Path: "contracts/testdata/javascript/valid-closed-serializable-value.json", SchemaID: runtimeManifestSchemaID},
+			{Path: "contracts/testdata/javascript/valid-shared-schema-refs.json", SchemaID: runtimeManifestSchemaID},
 		},
 	})
 }

--- a/internal/contractvalidator/validator.go
+++ b/internal/contractvalidator/validator.go
@@ -250,6 +250,7 @@ func validateEntry(repositoryRoot string, entry Entry) []Diagnostic {
 		}
 		if document.SchemaID == runtimeManifestSchemaID {
 			diagnostics = append(diagnostics, runtimeManifestDiagnostics(document.Path, value)...)
+			diagnostics = append(diagnostics, javascriptCatalogPathCompletenessDiagnostics(document.Path, value)...)
 		}
 		if document.SchemaID == toolCatalogSchemaID {
 			diagnostics = append(diagnostics, mcpToolCatalogIdentityDiagnostics(document.Path, value)...)

--- a/internal/contractvalidator/validator.go
+++ b/internal/contractvalidator/validator.go
@@ -251,6 +251,7 @@ func validateEntry(repositoryRoot string, entry Entry) []Diagnostic {
 		if document.SchemaID == runtimeManifestSchemaID {
 			diagnostics = append(diagnostics, runtimeManifestDiagnostics(document.Path, value)...)
 			diagnostics = append(diagnostics, javascriptCatalogPathCompletenessDiagnostics(document.Path, value)...)
+			diagnostics = append(diagnostics, javascriptCatalogCallBehaviorParityDiagnostics(document.Path, value)...)
 		}
 		if document.SchemaID == toolCatalogSchemaID {
 			diagnostics = append(diagnostics, mcpToolCatalogIdentityDiagnostics(document.Path, value)...)

--- a/internal/contractvalidator/validator_test.go
+++ b/internal/contractvalidator/validator_test.go
@@ -237,6 +237,18 @@ func TestValidateJavaScriptInvalidManifestDiagnostics(t *testing.T) {
 			wantPath: "/symbols/example.bad.open-serializable/parameters/0/serializableValue",
 		},
 		{
+			name:     "broken shared schema reference",
+			fixture:  "contracts/testdata/javascript/invalid-broken-shared-schema-ref.json",
+			code:     "reference.fragment",
+			wantPath: "/symbols/javascript.workflow.checkpoint/parameters/0/serializableValue/$ref",
+		},
+		{
+			name:     "open shared schema",
+			fixture:  "contracts/testdata/javascript/invalid-open-shared-schema.json",
+			code:     "javascript.serializable_value.open",
+			wantPath: "/sharedSchemas/javascript.schema.open_object/schema",
+		},
+		{
 			name:     "context global",
 			fixture:  "contracts/testdata/javascript/invalid-unsupported-context-global.json",
 			code:     "javascript.surface.forbidden_global",

--- a/packages/api/generated/javascript/runtime-api.json
+++ b/packages/api/generated/javascript/runtime-api.json
@@ -1,1 +1,1245 @@
-{"formatVersion":"javascript-runtime-symbol-identity/v1","symbols":[{"idCandidate":"agent","name":"agent","path":"agent","kind":"namespace","members":["run"],"callable":false,"async":false},{"idCandidate":"agent-run","name":"run","path":"agent.run","kind":"function","parent":"agent","callable":true,"async":true},{"idCandidate":"args","name":"args","path":"args","kind":"value","callable":false,"async":false},{"idCandidate":"log","name":"log","path":"log","kind":"function","callable":true,"async":false},{"idCandidate":"meta","name":"meta","path":"meta","kind":"value","callable":false,"async":false},{"idCandidate":"parallel","name":"parallel","path":"parallel","kind":"function","callable":true,"async":true},{"idCandidate":"phase","name":"phase","path":"phase","kind":"function","callable":true,"async":false},{"idCandidate":"pipeline","name":"pipeline","path":"pipeline","kind":"function","callable":true,"async":true},{"idCandidate":"workflow","name":"workflow","path":"workflow","kind":"namespace","members":["artifact","budget","checkpoint","final","log","resumeState"],"callable":false,"async":false},{"idCandidate":"workflow-artifact","name":"artifact","path":"workflow.artifact","kind":"function","parent":"workflow","callable":true,"async":false},{"idCandidate":"workflow-budget","name":"budget","path":"workflow.budget","kind":"function","parent":"workflow","callable":true,"async":false},{"idCandidate":"workflow-checkpoint","name":"checkpoint","path":"workflow.checkpoint","kind":"function","parent":"workflow","callable":true,"async":false},{"idCandidate":"workflow-final","name":"final","path":"workflow.final","kind":"function","parent":"workflow","callable":true,"async":false},{"idCandidate":"workflow-log","name":"log","path":"workflow.log","kind":"function","parent":"workflow","callable":true,"async":false},{"idCandidate":"workflow-resumeState","name":"resumeState","path":"workflow.resumeState","kind":"function","parent":"workflow","callable":true,"async":false}]}
+{
+  "formatVersion": "1.0.0",
+  "sharedSchemas": {
+    "javascript.schema.checkpoint_spec": {
+      "id": "javascript.schema.checkpoint_spec",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.schema.checkpoint_spec",
+        "documentation": {
+          "title": {
+            "id": "javascript.schema.checkpoint_spec.title",
+            "canonicalEnglish": "Checkpoint specification object"
+          },
+          "description": {
+            "id": "javascript.schema.checkpoint_spec.description",
+            "canonicalEnglish": "Closed object shape for workflow.checkpoint spec arguments."
+          }
+        },
+        "examples": [
+          "{ \"label\": \"draft\", \"state\": {} }"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "state": {
+            "$ref": "#/sharedSchemas/javascript.schema.json_compatible/schema"
+          }
+        },
+        "required": [
+          "label"
+        ]
+      }
+    },
+    "javascript.schema.artifact_spec": {
+      "id": "javascript.schema.artifact_spec",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.schema.artifact_spec",
+        "documentation": {
+          "title": {
+            "id": "javascript.schema.artifact_spec.title",
+            "canonicalEnglish": "Artifact specification object"
+          },
+          "description": {
+            "id": "javascript.schema.artifact_spec.description",
+            "canonicalEnglish": "Closed object shape for workflow.artifact spec arguments."
+          }
+        },
+        "examples": [
+          "{ \"kind\": \"log\", \"label\": \"step\" }"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "kind": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "content": {
+            "$ref": "#/sharedSchemas/javascript.schema.json_compatible/schema"
+          },
+          "visibility": {
+            "type": "string",
+            "default": "WORKFLOW_RUNTIME"
+          }
+        },
+        "required": [
+          "kind",
+          "label"
+        ]
+      }
+    },
+    "javascript.schema.budget_snapshot": {
+      "id": "javascript.schema.budget_snapshot",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.schema.budget_snapshot",
+        "documentation": {
+          "title": {
+            "id": "javascript.schema.budget_snapshot.title",
+            "canonicalEnglish": "Workflow budget snapshot object"
+          },
+          "description": {
+            "id": "javascript.schema.budget_snapshot.description",
+            "canonicalEnglish": "Closed object shape returned by workflow.budget."
+          }
+        },
+        "examples": [
+          "{ \"maxAgents\": 4, \"concurrency\": 2 }"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "maxAgents": {
+            "type": "number"
+          },
+          "concurrency": {
+            "type": "number"
+          },
+          "sandboxMode": {
+            "type": "string"
+          },
+          "maxRunDurationMs": {
+            "type": "number"
+          },
+          "maxWorkerDurationMs": {
+            "type": "number"
+          },
+          "maxOutputBytesPerWorker": {
+            "type": "number"
+          },
+          "maxArtifactBytes": {
+            "type": "number"
+          },
+          "maxTokens": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "maxAgents",
+          "concurrency"
+        ]
+      }
+    },
+    "javascript.schema.json_compatible": {
+      "id": "javascript.schema.json_compatible",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.schema.json_compatible",
+        "documentation": {
+          "title": {
+            "id": "javascript.schema.json_compatible.title",
+            "canonicalEnglish": "JSON-compatible serializable value"
+          },
+          "description": {
+            "id": "javascript.schema.json_compatible.description",
+            "canonicalEnglish": "Closed union of JSON-compatible serializable values accepted by installed runtime helpers."
+          }
+        },
+        "examples": [
+          "{ \"step\": 1 }",
+          "\"note\"",
+          "null"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "schema": {
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "array"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {}
+          }
+        ]
+      }
+    },
+    "javascript.schema.agent_run_spec": {
+      "id": "javascript.schema.agent_run_spec",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.schema.agent_run_spec",
+        "documentation": {
+          "title": {
+            "id": "javascript.schema.agent_run_spec.title",
+            "canonicalEnglish": "Agent run specification object"
+          },
+          "description": {
+            "id": "javascript.schema.agent_run_spec.description",
+            "canonicalEnglish": "Closed object shape for agent.run spec arguments."
+          }
+        },
+        "examples": [
+          "{ \"prompt\": \"Summarize findings\", \"label\": \"summarize\" }"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "prompt": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "preset": {
+            "type": "string"
+          },
+          "modelProvider": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "reasoningEffort": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "prompt"
+        ]
+      }
+    },
+    "javascript.schema.string_key_record": {
+      "id": "javascript.schema.string_key_record",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.schema.string_key_record",
+        "documentation": {
+          "title": {
+            "id": "javascript.schema.string_key_record.title",
+            "canonicalEnglish": "String-keyed invocation record"
+          },
+          "description": {
+            "id": "javascript.schema.string_key_record.description",
+            "canonicalEnglish": "Closed top-level object for args and meta value bindings exposed at workflow bind time."
+          }
+        },
+        "examples": [
+          "{ \"topic\": \"release\" }"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {}
+      }
+    }
+  },
+  "symbols": {
+    "javascript.args": {
+      "id": "javascript.args",
+      "name": "args",
+      "path": "args",
+      "kind": "value",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.args",
+        "documentation": {
+          "title": {
+            "id": "javascript.args.title",
+            "canonicalEnglish": "Invocation arguments"
+          },
+          "description": {
+            "id": "javascript.args.description",
+            "canonicalEnglish": "Mutable invocation argument value bound from workflow request args JSON at script start. The binding is a non-null object snapshot; property reads and writes affect only the in-script view and do not change the original request payload."
+          }
+        },
+        "examples": [
+          "{ \"subject\": \"release\", \"count\": 2, \"prefix\": \"echo\" }"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.args",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "mutability": "mutable-object",
+      "nullability": "non-null",
+      "bindingLifecycle": "snapshot-at-bind"
+    },
+    "javascript.meta": {
+      "id": "javascript.meta",
+      "name": "meta",
+      "path": "meta",
+      "kind": "value",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.meta",
+        "documentation": {
+          "title": {
+            "id": "javascript.meta.title",
+            "canonicalEnglish": "Invocation metadata"
+          },
+          "description": {
+            "id": "javascript.meta.description",
+            "canonicalEnglish": "Mutable invocation metadata object bound from workflow request metadata at script start. The binding is a non-null object snapshot with string-valued entries; when name is absent the runtime supplies the default simple-final label."
+          }
+        },
+        "examples": [
+          "{ \"name\": \"simple-final\", \"description\": \"Example workflow metadata\" }"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.meta",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "mutability": "mutable-object",
+      "nullability": "non-null",
+      "bindingLifecycle": "snapshot-at-bind"
+    },
+    "javascript.log": {
+      "id": "javascript.log",
+      "name": "log",
+      "path": "log",
+      "kind": "function",
+      "async": false,
+      "parameters": [
+        {
+          "id": "javascript.log.param.message",
+          "name": "message",
+          "position": 0,
+          "required": true,
+          "rest": false,
+          "type": "string"
+        },
+        {
+          "id": "javascript.log.param.fields",
+          "name": "fields",
+          "position": 1,
+          "required": false,
+          "rest": false,
+          "type": "object",
+          "serializableValue": {
+            "$ref": "#/sharedSchemas/javascript.schema.json_compatible/schema"
+          }
+        }
+      ],
+      "return": {
+        "kind": "sync",
+        "type": "undefined"
+      },
+      "emittedRecords": [
+        "log"
+      ],
+      "errors": [
+        {
+          "condition": "missing-or-non-string-message",
+          "type": "TypeError",
+          "message": "log() requires a string message"
+        },
+        {
+          "condition": "non-json-fields",
+          "type": "GoError",
+          "message": "log() fields must be JSON-compatible"
+        }
+      ],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.log",
+        "documentation": {
+          "title": {
+            "id": "javascript.log.title",
+            "canonicalEnglish": "Root workflow log helper"
+          },
+          "description": {
+            "id": "javascript.log.description",
+            "canonicalEnglish": "Synchronously emits one workflow-scoped log record. The first argument must be a non-empty string message; an optional second argument supplies JSON-compatible structured fields."
+          }
+        },
+        "examples": [
+          "log(\"checkpoint\", { step: 1 })"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.log",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    },
+    "javascript.agent": {
+      "id": "javascript.agent",
+      "name": "agent",
+      "path": "agent",
+      "kind": "namespace",
+      "members": [
+        "run"
+      ],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.agent",
+        "documentation": {
+          "title": {
+            "id": "javascript.agent.title",
+            "canonicalEnglish": "Agent namespace"
+          },
+          "description": {
+            "id": "javascript.agent.description",
+            "canonicalEnglish": "Root agent namespace for the installed agent.run child-dispatch helper."
+          }
+        },
+        "examples": [
+          "agent.run({ prompt: \"Summarize findings\", label: \"summarize\" })"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.agent",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "mutability": "fixed-binding",
+      "nullability": "non-null",
+      "bindingLifecycle": "live-namespace"
+    },
+    "javascript.agent.run": {
+      "id": "javascript.agent.run",
+      "name": "run",
+      "path": "agent.run",
+      "kind": "method",
+      "parent": "javascript.agent",
+      "async": true,
+      "parameters": [
+        {
+          "id": "javascript.agent.run.param.spec",
+          "name": "spec",
+          "position": 0,
+          "required": true,
+          "rest": false,
+          "type": "object",
+          "serializableValue": {
+            "$ref": "#/sharedSchemas/javascript.schema.agent_run_spec/schema"
+          }
+        }
+      ],
+      "return": {
+        "kind": "promise",
+        "type": "child-result-object"
+      },
+      "emittedRecords": [
+        "child_dispatch"
+      ],
+      "policyChecks": [
+        {
+          "kind": "maxAgents",
+          "message": "policy denied: requested fanout exceeds maxAgents"
+        },
+        {
+          "kind": "allowedModels",
+          "field": "model"
+        },
+        {
+          "kind": "allowedReasoningEfforts",
+          "field": "reasoningEffort"
+        },
+        {
+          "kind": "allowedCommands",
+          "field": "command"
+        },
+        {
+          "kind": "sandboxMode",
+          "field": "sandbox"
+        },
+        {
+          "kind": "writableRoots",
+          "field": "writableRoots"
+        },
+        {
+          "kind": "allowNetwork",
+          "field": "allowNetwork"
+        },
+        {
+          "kind": "concurrency",
+          "field": "concurrency"
+        }
+      ],
+      "errors": [
+        {
+          "condition": "missing-or-non-object-argument",
+          "type": "TypeError",
+          "message": "agent.run() requires an object argument"
+        },
+        {
+          "condition": "unsupported-field",
+          "type": "TypeError",
+          "message": "agent.run() does not support field"
+        },
+        {
+          "condition": "missing-prompt",
+          "type": "TypeError",
+          "message": "agent.run() requires a non-empty string \"prompt\" property"
+        },
+        {
+          "condition": "unknown-preset",
+          "type": "TypeError",
+          "message": "agent.run() references unknown operator worker preset"
+        },
+        {
+          "condition": "unsupported-model-provider",
+          "type": "TypeError",
+          "message": "agent.run() has unsupported effective modelProvider"
+        },
+        {
+          "condition": "unsupported-reasoning-effort",
+          "type": "TypeError",
+          "message": "agent.run() has unsupported effective reasoningEffort"
+        }
+      ],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.agent.run",
+        "documentation": {
+          "title": {
+            "id": "javascript.agent.run.title",
+            "canonicalEnglish": "Agent child dispatch"
+          },
+          "description": {
+            "id": "javascript.agent.run.description",
+            "canonicalEnglish": "Dispatches one child agent run from a closed spec object with a required prompt and optional model or preset fields. Returns a promise that resolves to the child result object after policy checks and child_dispatch emission."
+          }
+        },
+        "examples": [
+          "await agent.run({ prompt: \"Summarize findings\", label: \"summarize\", preset: \"operator\" })"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.agent.run",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    },
+    "javascript.parallel": {
+      "id": "javascript.parallel",
+      "name": "parallel",
+      "path": "parallel",
+      "kind": "function",
+      "async": true,
+      "parameters": [
+        {
+          "id": "javascript.parallel.param.items",
+          "name": "items",
+          "position": 0,
+          "required": true,
+          "rest": false,
+          "type": "array"
+        }
+      ],
+      "callback": {
+        "role": "item",
+        "parameters": [
+          {
+            "id": "javascript.parallel.callback.this",
+            "name": "this",
+            "position": 0,
+            "required": false,
+            "rest": false,
+            "type": "undefined",
+            "default": "undefined"
+          }
+        ],
+        "notes": "array items may be agent run specs (object with prompt) or functions invoked with undefined this"
+      },
+      "return": {
+        "kind": "promise",
+        "type": "array"
+      },
+      "emittedRecords": [
+        "child_dispatch"
+      ],
+      "policyChecks": [
+        {
+          "kind": "maxAgents",
+          "message": "policy denied: requested fanout exceeds maxAgents"
+        },
+        {
+          "kind": "childRequest",
+          "message": "policy denied"
+        }
+      ],
+      "determinism": "agent-spec completion order may differ from input order under concurrency",
+      "errors": [
+        {
+          "condition": "missing-or-non-array-argument",
+          "type": "TypeError",
+          "message": "parallel() requires an array argument"
+        },
+        {
+          "condition": "null-or-undefined-item",
+          "type": "TypeError",
+          "message": "parallel() items must not contain null or undefined entries"
+        },
+        {
+          "condition": "invalid-item-shape",
+          "type": "TypeError",
+          "message": "parallel() items must be agent run specs or functions"
+        }
+      ],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.parallel",
+        "documentation": {
+          "title": {
+            "id": "javascript.parallel.title",
+            "canonicalEnglish": "Parallel child dispatch"
+          },
+          "description": {
+            "id": "javascript.parallel.description",
+            "canonicalEnglish": "Runs an array of agent run specs or item functions concurrently and returns a promise that resolves to an array of child results. Each function item is invoked with undefined this."
+          }
+        },
+        "examples": [
+          "await parallel([{ prompt: \"first\" }, { prompt: \"second\", label: \"two\" }])"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.parallel",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    },
+    "javascript.pipeline": {
+      "id": "javascript.pipeline",
+      "name": "pipeline",
+      "path": "pipeline",
+      "kind": "function",
+      "async": true,
+      "parameters": [
+        {
+          "id": "javascript.pipeline.param.items",
+          "name": "items",
+          "position": 0,
+          "required": true,
+          "rest": false,
+          "type": "array"
+        },
+        {
+          "id": "javascript.pipeline.param.worker",
+          "name": "worker",
+          "position": 1,
+          "required": true,
+          "rest": false,
+          "type": "function"
+        },
+        {
+          "id": "javascript.pipeline.param.next",
+          "name": "next",
+          "position": 2,
+          "required": false,
+          "rest": false,
+          "type": "function"
+        }
+      ],
+      "callback": {
+        "role": "worker",
+        "parameters": [
+          {
+            "id": "javascript.pipeline.callback.this",
+            "name": "this",
+            "position": 0,
+            "required": false,
+            "rest": false,
+            "type": "undefined",
+            "default": "undefined"
+          },
+          {
+            "id": "javascript.pipeline.callback.item",
+            "name": "item",
+            "position": 1,
+            "required": true,
+            "rest": false,
+            "type": "any"
+          },
+          {
+            "id": "javascript.pipeline.callback.index",
+            "name": "index",
+            "position": 2,
+            "required": true,
+            "rest": false,
+            "type": "number"
+          }
+        ],
+        "notes": "optional next stage receives (priorResult, item, index)"
+      },
+      "return": {
+        "kind": "promise",
+        "type": "pipeline-result-array"
+      },
+      "determinism": "stages run sequentially per item; worker and next may return values or Promises",
+      "errors": [
+        {
+          "condition": "missing-items-or-worker",
+          "type": "TypeError",
+          "message": "pipeline() requires items and worker arguments"
+        },
+        {
+          "condition": "missing-or-non-array-items",
+          "type": "TypeError",
+          "message": "pipeline() requires an array items argument"
+        },
+        {
+          "condition": "missing-worker-function",
+          "type": "TypeError",
+          "message": "pipeline() requires a worker function argument"
+        },
+        {
+          "condition": "invalid-next-function",
+          "type": "TypeError",
+          "message": "pipeline() next argument must be a function when provided"
+        },
+        {
+          "condition": "null-or-undefined-item",
+          "type": "TypeError",
+          "message": "pipeline() items must not contain null or undefined entries"
+        }
+      ],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.pipeline",
+        "documentation": {
+          "title": {
+            "id": "javascript.pipeline.title",
+            "canonicalEnglish": "Pipeline composition"
+          },
+          "description": {
+            "id": "javascript.pipeline.description",
+            "canonicalEnglish": "Maps each items entry through a required worker function and optional next stage callback, running stages sequentially per item. Returns a promise that resolves to a pipeline result array."
+          }
+        },
+        "examples": [
+          "await pipeline([1, 2], (item) => item * 2, (prior, item) => prior + item)"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.pipeline",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    },
+    "javascript.phase": {
+      "id": "javascript.phase",
+      "name": "phase",
+      "path": "phase",
+      "kind": "function",
+      "async": false,
+      "parameters": [
+        {
+          "id": "javascript.phase.param.name",
+          "name": "name",
+          "position": 0,
+          "required": true,
+          "rest": false,
+          "type": "string"
+        }
+      ],
+      "return": {
+        "kind": "sync",
+        "type": "undefined"
+      },
+      "emittedRecords": [
+        "phase"
+      ],
+      "errors": [
+        {
+          "condition": "missing-or-non-string-name",
+          "type": "TypeError",
+          "message": "phase() requires a string name"
+        }
+      ],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.phase",
+        "documentation": {
+          "title": {
+            "id": "javascript.phase.title",
+            "canonicalEnglish": "Phase marker"
+          },
+          "description": {
+            "id": "javascript.phase.description",
+            "canonicalEnglish": "Synchronously records one named workflow phase transition for progress tracking. The name must be a non-empty string."
+          }
+        },
+        "examples": [
+          "phase(\"draft\")"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.phase",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    },
+    "javascript.workflow": {
+      "id": "javascript.workflow",
+      "name": "workflow",
+      "path": "workflow",
+      "kind": "namespace",
+      "members": [
+        "artifact",
+        "budget",
+        "checkpoint",
+        "final",
+        "log",
+        "resumeState"
+      ],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow",
+        "documentation": {
+          "title": {
+            "id": "javascript.workflow.title",
+            "canonicalEnglish": "Workflow namespace"
+          },
+          "description": {
+            "id": "javascript.workflow.description",
+            "canonicalEnglish": "Root workflow namespace for installed checkpoint, artifact, budget, final, log, and resumeState helpers."
+          }
+        },
+        "examples": [
+          "workflow.artifact({ kind: \"log\", label: \"step\" })"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow",
+        "state": "active",
+        "since": "1.0.0"
+      },
+      "mutability": "fixed-binding",
+      "nullability": "non-null",
+      "bindingLifecycle": "live-namespace"
+    },
+    "javascript.workflow.artifact": {
+      "id": "javascript.workflow.artifact",
+      "name": "artifact",
+      "path": "workflow.artifact",
+      "kind": "method",
+      "parent": "javascript.workflow",
+      "async": false,
+      "parameters": [
+        {
+          "id": "javascript.workflow.artifact.param.spec",
+          "name": "spec",
+          "position": 0,
+          "required": true,
+          "rest": false,
+          "type": "object",
+          "serializableValue": {
+            "$ref": "#/sharedSchemas/javascript.schema.artifact_spec/schema"
+          }
+        }
+      ],
+      "return": {
+        "kind": "sync",
+        "type": "string"
+      },
+      "emittedRecords": [
+        "artifact"
+      ],
+      "errors": [
+        {
+          "condition": "missing-or-non-object-argument",
+          "type": "TypeError",
+          "message": "workflow.artifact() requires an object argument"
+        },
+        {
+          "condition": "missing-kind-or-label",
+          "type": "TypeError",
+          "message": "workflow.artifact() requires string \"kind\" and \"label\" properties"
+        },
+        {
+          "condition": "non-json-content",
+          "type": "GoError",
+          "message": "workflow.artifact content must be JSON-compatible"
+        }
+      ],
+      "policyChecks": [
+        {
+          "kind": "maxArtifactBytes",
+          "field": "content",
+          "message": "policy denied: artifact content size exceeds maxArtifactBytes"
+        }
+      ],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.artifact",
+        "documentation": {
+          "title": {
+            "id": "javascript.workflow.artifact.title",
+            "canonicalEnglish": "Workflow artifact"
+          },
+          "description": {
+            "id": "javascript.workflow.artifact.description",
+            "canonicalEnglish": "Registers one workflow artifact with kind and label metadata. Optional content must be JSON-compatible and is subject to maxArtifactBytes policy."
+          }
+        },
+        "examples": [
+          "workflow.artifact({ kind: \"log\", label: \"step\", content: { step: 1 } })"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.artifact",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    },
+    "javascript.workflow.budget": {
+      "id": "javascript.workflow.budget",
+      "name": "budget",
+      "path": "workflow.budget",
+      "kind": "method",
+      "parent": "javascript.workflow",
+      "async": false,
+      "parameters": [],
+      "return": {
+        "kind": "sync",
+        "type": "object",
+        "serializableValue": {
+          "$ref": "#/sharedSchemas/javascript.schema.budget_snapshot/schema"
+        }
+      },
+      "emittedRecords": [
+        "budget"
+      ],
+      "errors": [
+        {
+          "condition": "arguments-provided",
+          "type": "TypeError",
+          "message": "workflow.budget() does not accept arguments"
+        }
+      ],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.budget",
+        "documentation": {
+          "title": {
+            "id": "javascript.workflow.budget.title",
+            "canonicalEnglish": "Workflow budget snapshot"
+          },
+          "description": {
+            "id": "javascript.workflow.budget.description",
+            "canonicalEnglish": "Returns the current workflow budget counters and emits one budget record. The helper does not accept arguments."
+          }
+        },
+        "examples": [
+          "workflow.budget()"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.budget",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    },
+    "javascript.workflow.checkpoint": {
+      "id": "javascript.workflow.checkpoint",
+      "name": "checkpoint",
+      "path": "workflow.checkpoint",
+      "kind": "method",
+      "parent": "javascript.workflow",
+      "async": false,
+      "parameters": [
+        {
+          "id": "javascript.workflow.checkpoint.param.spec",
+          "name": "spec",
+          "position": 0,
+          "required": true,
+          "rest": false,
+          "type": "object",
+          "serializableValue": {
+            "$ref": "#/sharedSchemas/javascript.schema.checkpoint_spec/schema"
+          }
+        }
+      ],
+      "return": {
+        "kind": "sync",
+        "type": "undefined"
+      },
+      "emittedRecords": [
+        "checkpoint"
+      ],
+      "errors": [
+        {
+          "condition": "missing-or-non-object-argument",
+          "type": "TypeError",
+          "message": "workflow.checkpoint() requires an object argument"
+        },
+        {
+          "condition": "missing-label",
+          "type": "TypeError",
+          "message": "workflow.checkpoint() requires a string \"label\" property"
+        },
+        {
+          "condition": "non-json-state",
+          "type": "GoError",
+          "message": "workflow.checkpoint state must be JSON-compatible"
+        }
+      ],
+      "resumeNotes": "persists checkpoint state for workflow.resumeState() on resumed sessions",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.checkpoint",
+        "documentation": {
+          "title": {
+            "id": "javascript.workflow.checkpoint.title",
+            "canonicalEnglish": "Workflow checkpoint"
+          },
+          "description": {
+            "id": "javascript.workflow.checkpoint.description",
+            "canonicalEnglish": "Persists one labeled checkpoint with optional JSON-compatible state for later resume through workflow.resumeState()."
+          }
+        },
+        "examples": [
+          "workflow.checkpoint({ label: \"draft\", state: { step: 1 } })"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.checkpoint",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    },
+    "javascript.workflow.final": {
+      "id": "javascript.workflow.final",
+      "name": "final",
+      "path": "workflow.final",
+      "kind": "method",
+      "parent": "javascript.workflow",
+      "async": false,
+      "parameters": [
+        {
+          "id": "javascript.workflow.final.param.value",
+          "name": "value",
+          "position": 0,
+          "required": false,
+          "rest": false,
+          "type": "any"
+        }
+      ],
+      "return": {
+        "kind": "sync",
+        "type": "undefined"
+      },
+      "determinism": "workflow.final wins over a returned workflow value for terminal result selection",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.final",
+        "documentation": {
+          "title": {
+            "id": "javascript.workflow.final.title",
+            "canonicalEnglish": "Workflow final result"
+          },
+          "description": {
+            "id": "javascript.workflow.final.description",
+            "canonicalEnglish": "Terminates the workflow with an optional final value. When both workflow.final and a returned value are present, workflow.final wins for terminal result selection."
+          }
+        },
+        "examples": [
+          "workflow.final({ ok: true, result: { count: 1 } })"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.final",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    },
+    "javascript.workflow.log": {
+      "id": "javascript.workflow.log",
+      "name": "log",
+      "path": "workflow.log",
+      "kind": "method",
+      "parent": "javascript.workflow",
+      "async": false,
+      "parameters": [
+        {
+          "id": "javascript.workflow.log.param.message",
+          "name": "message",
+          "position": 0,
+          "required": true,
+          "rest": false,
+          "type": "string"
+        },
+        {
+          "id": "javascript.workflow.log.param.fields",
+          "name": "fields",
+          "position": 1,
+          "required": false,
+          "rest": false,
+          "type": "object",
+          "serializableValue": {
+            "$ref": "#/sharedSchemas/javascript.schema.json_compatible/schema"
+          }
+        }
+      ],
+      "return": {
+        "kind": "sync",
+        "type": "undefined"
+      },
+      "emittedRecords": [
+        "log"
+      ],
+      "errors": [
+        {
+          "condition": "missing-or-non-string-message",
+          "type": "TypeError",
+          "message": "workflow.log() requires a string message"
+        },
+        {
+          "condition": "non-json-fields",
+          "type": "GoError",
+          "message": "workflow.log() fields must be JSON-compatible"
+        }
+      ],
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.log",
+        "documentation": {
+          "title": {
+            "id": "javascript.workflow.log.title",
+            "canonicalEnglish": "Workflow-scoped log helper"
+          },
+          "description": {
+            "id": "javascript.workflow.log.description",
+            "canonicalEnglish": "Synchronously emits one workflow-scoped log record. The first argument must be a string message; an optional second argument supplies JSON-compatible structured fields."
+          }
+        },
+        "examples": [
+          "workflow.log(\"checkpoint\", { step: 1 })"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.log",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    },
+    "javascript.workflow.resume-state": {
+      "id": "javascript.workflow.resume-state",
+      "name": "resumeState",
+      "path": "workflow.resumeState",
+      "kind": "method",
+      "parent": "javascript.workflow",
+      "async": false,
+      "parameters": [],
+      "return": {
+        "kind": "sync",
+        "type": "object-or-undefined",
+        "serializableValue": {
+          "$ref": "#/sharedSchemas/javascript.schema.checkpoint_spec/schema"
+        }
+      },
+      "errors": [
+        {
+          "condition": "arguments-provided",
+          "type": "TypeError",
+          "message": "workflow.resumeState() does not accept arguments"
+        }
+      ],
+      "resumeNotes": "returns bound resume checkpoint state or undefined when absent",
+      "documentation": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.resume-state",
+        "documentation": {
+          "title": {
+            "id": "javascript.workflow.resume-state.title",
+            "canonicalEnglish": "Workflow resume state"
+          },
+          "description": {
+            "id": "javascript.workflow.resume-state.description",
+            "canonicalEnglish": "Reads checkpoint state restored for a resumed workflow session, or undefined when no resume state is bound."
+          }
+        },
+        "examples": [
+          "workflow.resumeState()"
+        ],
+        "visibility": "public",
+        "sourceHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+      },
+      "lifecycle": {
+        "formatVersion": "1.0.0",
+        "itemId": "javascript.workflow.resume-state",
+        "state": "active",
+        "since": "1.0.0"
+      }
+    }
+  }
+}

--- a/packages/api/generated/manifest.json
+++ b/packages/api/generated/manifest.json
@@ -31,7 +31,7 @@
       "path": "generated/cli/commands.json"
     },
     "generated.javascript.runtime-api": {
-      "artifactHash": "3fbe2603cd9dded76339015d105507d3afa43d48345d2de99326e15a9b954e83",
+      "artifactHash": "4d1c70325407b340fdd6e072cf9f2f8c77c499001b1553a06691418e6e988247",
       "documentation": {
         "documentation": {
           "description": {
@@ -48,7 +48,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.javascript.runtime-api",
-        "sourceHash": "3fbe2603cd9dded76339015d105507d3afa43d48345d2de99326e15a9b954e83",
+        "sourceHash": "4d1c70325407b340fdd6e072cf9f2f8c77c499001b1553a06691418e6e988247",
         "visibility": "public"
       },
       "family": "javascript",
@@ -312,5 +312,5 @@
   "formatVersion": "1.0.0",
   "packageId": "you-agent-factory.api",
   "packageVersion": "0.0.0",
-  "sourceCommit": "ed38fc06498b3206c31d9f1d3513f752ca193088"
+  "sourceCommit": "43c61d2216a6b5323e30a090bce55510843694ee"
 }

--- a/packages/api/generated/manifest.json
+++ b/packages/api/generated/manifest.json
@@ -312,5 +312,5 @@
   "formatVersion": "1.0.0",
   "packageId": "you-agent-factory.api",
   "packageVersion": "0.0.0",
-  "sourceCommit": "43c61d2216a6b5323e30a090bce55510843694ee"
+  "sourceCommit": "79b5e9c691a1a9e04a5778cee379d274f25b8672"
 }

--- a/pkg/config/mockworkers/schema_contract_test.go
+++ b/pkg/config/mockworkers/schema_contract_test.go
@@ -506,18 +506,29 @@ func TestMockWorkersSchema_StaleStagingDetectedByContractCheck(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read staged schema: %v", err)
 	}
-	if err := os.WriteFile(stagedPath, append(before, '\n'), 0o644); err != nil {
-		t.Fatalf("write stale staged schema: %v", err)
-	}
 	t.Cleanup(func() {
 		_ = os.WriteFile(stagedPath, before, 0o644)
 	})
 
-	drift, err := contractstaging.Check(repositoryRoot)
-	if err != nil {
-		t.Fatalf("Check() error = %v", err)
+	corrupted := append(append([]byte(nil), before...), '\n')
+	var (
+		drift    contractstaging.Drift
+		detected bool
+	)
+	for attempt := 0; attempt < 32; attempt++ {
+		if err := os.WriteFile(stagedPath, corrupted, 0o644); err != nil {
+			t.Fatalf("write stale staged schema: %v", err)
+		}
+		drift, err = contractstaging.Check(repositoryRoot)
+		if err != nil {
+			t.Fatalf("Check() error = %v", err)
+		}
+		if len(drift.Stale) == 1 && drift.Stale[0] == target {
+			detected = true
+			break
+		}
 	}
-	if len(drift.Stale) != 1 || drift.Stale[0] != target {
+	if !detected {
 		t.Fatalf("Check() stale = %#v, want [%q]", drift.Stale, target)
 	}
 }

--- a/pkg/orchestrators/javascript/runtime/catalog/catalog_call_behavior_parity.go
+++ b/pkg/orchestrators/javascript/runtime/catalog/catalog_call_behavior_parity.go
@@ -1,0 +1,738 @@
+package catalog
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/callbehavior"
+)
+
+// RepresentativeCallBehaviorPaths are the terminal and composition symbols whose
+// catalog call metadata must match the reviewed B03 call-behavior baseline.
+var RepresentativeCallBehaviorPaths = []string{
+	"workflow.final",
+	"workflow.checkpoint",
+	"agent.run",
+	"parallel",
+	"pipeline",
+}
+
+// CallBehaviorParityIssue records one catalog call-metadata mismatch by path.
+type CallBehaviorParityIssue struct {
+	Code      string
+	SymbolKey string
+	Path      string
+	Field     string
+	Message   string
+}
+
+// CatalogCallBehaviorParityIssues compares representative catalog symbol call
+// metadata to the installed call-behavior baseline.
+func CatalogCallBehaviorParityIssues(
+	document map[string]any,
+	callInventory callbehavior.Inventory,
+) ([]CallBehaviorParityIssue, error) {
+	symbols, err := catalogSymbolsFromDocument(document)
+	if err != nil {
+		return nil, err
+	}
+	byPath := catalogSymbolsByInstalledPath(symbols)
+	wantByPath := callBehaviorRecordsByPath(callInventory)
+
+	var issues []CallBehaviorParityIssue
+	for _, path := range RepresentativeCallBehaviorPaths {
+		want, ok := wantByPath[path]
+		if !ok {
+			return nil, fmt.Errorf("call-behavior baseline missing representative path %q", path)
+		}
+		entry, ok := byPath[path]
+		if !ok {
+			issues = append(issues, CallBehaviorParityIssue{
+				Code:    "javascript.call_behavior.missing",
+				Path:    path,
+				Message: fmt.Sprintf("catalog missing representative symbol path %s", strconv.Quote(path)),
+			})
+			continue
+		}
+		issues = append(issues, catalogSymbolCallBehaviorParityIssues(entry.symbolKey, path, entry.symbol, want)...)
+	}
+
+	sort.Slice(issues, func(i, j int) bool {
+		left, right := issues[i], issues[j]
+		if left.Path != right.Path {
+			return left.Path < right.Path
+		}
+		if left.Field != right.Field {
+			return left.Field < right.Field
+		}
+		return left.Message < right.Message
+	})
+	return issues, nil
+}
+
+// VerifyCatalogCallBehaviorParity ensures representative catalog call metadata
+// matches the installed call-behavior baseline.
+func VerifyCatalogCallBehaviorParity(
+	document map[string]any,
+	callInventory callbehavior.Inventory,
+) error {
+	issues, err := CatalogCallBehaviorParityIssues(document, callInventory)
+	if err != nil {
+		return err
+	}
+	if len(issues) == 0 {
+		return nil
+	}
+	messages := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		if issue.SymbolKey != "" && issue.Field != "" {
+			messages = append(messages, fmt.Sprintf(
+				"%s at /symbols/%s/%s",
+				issue.Message,
+				issue.SymbolKey,
+				issue.Field,
+			))
+			continue
+		}
+		messages = append(messages, issue.Message)
+	}
+	return fmt.Errorf("catalog call-behavior parity failed: %s", strings.Join(messages, "; "))
+}
+
+func catalogSymbolsFromDocument(document map[string]any) (map[string]map[string]any, error) {
+	symbolsValue, ok := document["symbols"]
+	if !ok {
+		return nil, fmt.Errorf("catalog document missing symbols")
+	}
+	symbols, ok := symbolsValue.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("catalog symbols is not an object")
+	}
+	out := make(map[string]map[string]any, len(symbols))
+	for key, symbolValue := range symbols {
+		symbol, ok := symbolValue.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("catalog symbol %q is not an object", key)
+		}
+		out[key] = symbol
+	}
+	return out, nil
+}
+
+func catalogSymbolsByInstalledPath(symbols map[string]map[string]any) map[string]struct {
+	symbol    map[string]any
+	symbolKey string
+} {
+	byPath := make(map[string]struct {
+		symbol    map[string]any
+		symbolKey string
+	}, len(symbols))
+	for key, symbol := range symbols {
+		path, _ := symbol["path"].(string)
+		if path == "" {
+			continue
+		}
+		byPath[path] = struct {
+			symbol    map[string]any
+			symbolKey string
+		}{symbol: symbol, symbolKey: key}
+	}
+	return byPath
+}
+
+func callBehaviorRecordsByPath(inventory callbehavior.Inventory) map[string]callbehavior.CallBehaviorRecord {
+	byPath := make(map[string]callbehavior.CallBehaviorRecord, len(inventory.Records))
+	for _, record := range inventory.Records {
+		byPath[record.Path] = record
+	}
+	return byPath
+}
+
+func catalogSymbolCallBehaviorParityIssues(
+	symbolKey string,
+	path string,
+	symbol map[string]any,
+	want callbehavior.CallBehaviorRecord,
+) []CallBehaviorParityIssue {
+	var issues []CallBehaviorParityIssue
+	appendIssue := func(field, message string) {
+		issues = append(issues, CallBehaviorParityIssue{
+			Code:      "javascript.call_behavior.mismatch",
+			SymbolKey: symbolKey,
+			Path:      path,
+			Field:     field,
+			Message:   message,
+		})
+	}
+
+	gotAsync, ok := symbol["async"].(bool)
+	if !ok {
+		appendIssue("async", fmt.Sprintf("catalog %s async is missing or not boolean", strconv.Quote(path)))
+	} else if gotAsync != want.Async {
+		appendIssue("async", fmt.Sprintf(
+			"catalog %s async = %v, want %v",
+			strconv.Quote(path),
+			gotAsync,
+			want.Async,
+		))
+	}
+
+	issues = append(issues, catalogParameterParityIssues(symbolKey, path, symbol, want.Parameters)...)
+	issues = append(issues, catalogReturnParityIssues(symbolKey, path, symbol, want.Return)...)
+	issues = append(issues, catalogStringSliceParityIssues(symbolKey, path, "emittedRecords", symbol, want.EmittedRecords)...)
+	issues = append(issues, catalogErrorParityIssues(symbolKey, path, symbol, want.Errors)...)
+	issues = append(issues, catalogPolicyCheckParityIssues(symbolKey, path, symbol, want.PolicyChecks)...)
+	issues = append(issues, catalogStringFieldParityIssues(symbolKey, path, "determinism", symbol, want.Determinism)...)
+	issues = append(issues, catalogStringFieldParityIssues(symbolKey, path, "resumeNotes", symbol, want.ResumeNotes)...)
+	issues = append(issues, catalogCallbackParityIssues(symbolKey, path, symbol, want.Callback)...)
+
+	return issues
+}
+
+func catalogParameterParityIssues(
+	symbolKey string,
+	path string,
+	symbol map[string]any,
+	want []callbehavior.Parameter,
+) []CallBehaviorParityIssue {
+	field := "parameters"
+	if len(want) == 0 {
+		if params, ok := symbol[field].([]any); ok && len(params) > 0 {
+			return []CallBehaviorParityIssue{{
+				Code:      "javascript.call_behavior.mismatch",
+				SymbolKey: symbolKey,
+				Path:      path,
+				Field:     field,
+				Message:   fmt.Sprintf("catalog %s parameters = %d entries, want none", strconv.Quote(path), len(params)),
+			}}
+		}
+		return nil
+	}
+
+	paramsValue, ok := symbol[field].([]any)
+	if !ok {
+		return []CallBehaviorParityIssue{{
+			Code:      "javascript.call_behavior.mismatch",
+			SymbolKey: symbolKey,
+			Path:      path,
+			Field:     field,
+			Message:   fmt.Sprintf("catalog %s parameters missing or not an array", strconv.Quote(path)),
+		}}
+	}
+	if len(paramsValue) != len(want) {
+		return []CallBehaviorParityIssue{{
+			Code:      "javascript.call_behavior.mismatch",
+			SymbolKey: symbolKey,
+			Path:      path,
+			Field:     field,
+			Message: fmt.Sprintf(
+				"catalog %s parameter count = %d, want %d",
+				strconv.Quote(path),
+				len(paramsValue),
+				len(want),
+			),
+		}}
+	}
+
+	var issues []CallBehaviorParityIssue
+	for i, wantParam := range want {
+		param, ok := paramsValue[i].(map[string]any)
+		if !ok {
+			issues = append(issues, CallBehaviorParityIssue{
+				Code:      "javascript.call_behavior.mismatch",
+				SymbolKey: symbolKey,
+				Path:      path,
+				Field:     field,
+				Message:   fmt.Sprintf("catalog %s parameters[%d] is not an object", strconv.Quote(path), i),
+			})
+			continue
+		}
+		if got, _ := param["name"].(string); got != wantParam.Name {
+			issues = append(issues, CallBehaviorParityIssue{
+				Code:      "javascript.call_behavior.mismatch",
+				SymbolKey: symbolKey,
+				Path:      path,
+				Field:     field,
+				Message: fmt.Sprintf(
+					"catalog %s parameters[%d].name = %q, want %q",
+					strconv.Quote(path),
+					i,
+					got,
+					wantParam.Name,
+				),
+			})
+		}
+		if got, _ := param["required"].(bool); got != wantParam.Required {
+			issues = append(issues, CallBehaviorParityIssue{
+				Code:      "javascript.call_behavior.mismatch",
+				SymbolKey: symbolKey,
+				Path:      path,
+				Field:     field,
+				Message: fmt.Sprintf(
+					"catalog %s parameters[%d].required = %v, want %v",
+					strconv.Quote(path),
+					i,
+					got,
+					wantParam.Required,
+				),
+			})
+		}
+		if got, _ := param["type"].(string); got != wantParam.Type {
+			issues = append(issues, CallBehaviorParityIssue{
+				Code:      "javascript.call_behavior.mismatch",
+				SymbolKey: symbolKey,
+				Path:      path,
+				Field:     field,
+				Message: fmt.Sprintf(
+					"catalog %s parameters[%d].type = %q, want %q",
+					strconv.Quote(path),
+					i,
+					got,
+					wantParam.Type,
+				),
+			})
+		}
+		gotRest, _ := param["rest"].(bool)
+		if gotRest != wantParam.Rest {
+			issues = append(issues, CallBehaviorParityIssue{
+				Code:      "javascript.call_behavior.mismatch",
+				SymbolKey: symbolKey,
+				Path:      path,
+				Field:     field,
+				Message: fmt.Sprintf(
+					"catalog %s parameters[%d].rest = %v, want %v",
+					strconv.Quote(path),
+					i,
+					gotRest,
+					wantParam.Rest,
+				),
+			})
+		}
+		if wantParam.Default != "" {
+			got, _ := param["default"].(string)
+			if got != wantParam.Default {
+				issues = append(issues, CallBehaviorParityIssue{
+					Code:      "javascript.call_behavior.mismatch",
+					SymbolKey: symbolKey,
+					Path:      path,
+					Field:     field,
+					Message: fmt.Sprintf(
+						"catalog %s parameters[%d].default = %q, want %q",
+						strconv.Quote(path),
+						i,
+						got,
+						wantParam.Default,
+					),
+				})
+			}
+		}
+	}
+	return issues
+}
+
+func catalogReturnParityIssues(
+	symbolKey string,
+	path string,
+	symbol map[string]any,
+	want *callbehavior.ReturnBehavior,
+) []CallBehaviorParityIssue {
+	field := "return"
+	if want == nil {
+		if returnValue, ok := symbol[field]; ok && returnValue != nil {
+			return []CallBehaviorParityIssue{{
+				Code:      "javascript.call_behavior.mismatch",
+				SymbolKey: symbolKey,
+				Path:      path,
+				Field:     field,
+				Message:   fmt.Sprintf("catalog %s return present, want none", strconv.Quote(path)),
+			}}
+		}
+		return nil
+	}
+
+	returnValue, ok := symbol[field].(map[string]any)
+	if !ok {
+		return []CallBehaviorParityIssue{{
+			Code:      "javascript.call_behavior.mismatch",
+			SymbolKey: symbolKey,
+			Path:      path,
+			Field:     field,
+			Message:   fmt.Sprintf("catalog %s return missing or not an object", strconv.Quote(path)),
+		}}
+	}
+
+	if want.Async {
+		if got, _ := returnValue["kind"].(string); got != "promise" {
+			return []CallBehaviorParityIssue{{
+				Code:      "javascript.call_behavior.mismatch",
+				SymbolKey: symbolKey,
+				Path:      path,
+				Field:     field,
+				Message:   fmt.Sprintf("catalog %s return.kind = %q, want promise", strconv.Quote(path), got),
+			}}
+		}
+		if got, _ := returnValue["type"].(string); got != want.PromiseType {
+			return []CallBehaviorParityIssue{{
+				Code:      "javascript.call_behavior.mismatch",
+				SymbolKey: symbolKey,
+				Path:      path,
+				Field:     field,
+				Message: fmt.Sprintf(
+					"catalog %s return.type = %q, want %q",
+					strconv.Quote(path),
+					got,
+					want.PromiseType,
+				),
+			}}
+		}
+		return nil
+	}
+
+	if got, _ := returnValue["kind"].(string); got != "sync" {
+		return []CallBehaviorParityIssue{{
+			Code:      "javascript.call_behavior.mismatch",
+			SymbolKey: symbolKey,
+			Path:      path,
+			Field:     field,
+			Message:   fmt.Sprintf("catalog %s return.kind = %q, want sync", strconv.Quote(path), got),
+		}}
+	}
+	if got, _ := returnValue["type"].(string); got != want.SyncType {
+		return []CallBehaviorParityIssue{{
+			Code:      "javascript.call_behavior.mismatch",
+			SymbolKey: symbolKey,
+			Path:      path,
+			Field:     field,
+			Message: fmt.Sprintf(
+				"catalog %s return.type = %q, want %q",
+				strconv.Quote(path),
+				got,
+				want.SyncType,
+			),
+		}}
+	}
+	return nil
+}
+
+func catalogStringSliceParityIssues(
+	symbolKey string,
+	path string,
+	field string,
+	symbol map[string]any,
+	want []string,
+) []CallBehaviorParityIssue {
+	if len(want) == 0 {
+		return nil
+	}
+	gotValue, ok := symbol[field].([]any)
+	if !ok {
+		return []CallBehaviorParityIssue{{
+			Code:      "javascript.call_behavior.mismatch",
+			SymbolKey: symbolKey,
+			Path:      path,
+			Field:     field,
+			Message:   fmt.Sprintf("catalog %s %s missing or not an array", strconv.Quote(path), field),
+		}}
+	}
+	got := make([]string, 0, len(gotValue))
+	for _, item := range gotValue {
+		record, ok := item.(string)
+		if !ok {
+			return []CallBehaviorParityIssue{{
+				Code:      "javascript.call_behavior.mismatch",
+				SymbolKey: symbolKey,
+				Path:      path,
+				Field:     field,
+				Message:   fmt.Sprintf("catalog %s %s contains non-string entry", strconv.Quote(path), field),
+			}}
+		}
+		got = append(got, record)
+	}
+	if len(got) != len(want) {
+		return []CallBehaviorParityIssue{{
+			Code:      "javascript.call_behavior.mismatch",
+			SymbolKey: symbolKey,
+			Path:      path,
+			Field:     field,
+			Message:   fmt.Sprintf("catalog %s %s = %v, want %v", strconv.Quote(path), field, got, want),
+		}}
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			return []CallBehaviorParityIssue{{
+				Code:      "javascript.call_behavior.mismatch",
+				SymbolKey: symbolKey,
+				Path:      path,
+				Field:     field,
+				Message: fmt.Sprintf(
+					"catalog %s %s[%d] = %q, want %q",
+					strconv.Quote(path),
+					field,
+					i,
+					got[i],
+					want[i],
+				),
+			}}
+		}
+	}
+	return nil
+}
+
+func catalogErrorParityIssues(
+	symbolKey string,
+	path string,
+	symbol map[string]any,
+	want []callbehavior.ErrorCase,
+) []CallBehaviorParityIssue {
+	field := "errors"
+	if len(want) == 0 {
+		return nil
+	}
+	gotValue, ok := symbol[field].([]any)
+	if !ok {
+		return []CallBehaviorParityIssue{{
+			Code:      "javascript.call_behavior.mismatch",
+			SymbolKey: symbolKey,
+			Path:      path,
+			Field:     field,
+			Message:   fmt.Sprintf("catalog %s errors missing or not an array", strconv.Quote(path)),
+		}}
+	}
+	if len(gotValue) != len(want) {
+		return []CallBehaviorParityIssue{{
+			Code:      "javascript.call_behavior.mismatch",
+			SymbolKey: symbolKey,
+			Path:      path,
+			Field:     field,
+			Message: fmt.Sprintf(
+				"catalog %s error count = %d, want %d",
+				strconv.Quote(path),
+				len(gotValue),
+				len(want),
+			),
+		}}
+	}
+
+	var issues []CallBehaviorParityIssue
+	for i, wantErr := range want {
+		errValue, ok := gotValue[i].(map[string]any)
+		if !ok {
+			issues = append(issues, CallBehaviorParityIssue{
+				Code:      "javascript.call_behavior.mismatch",
+				SymbolKey: symbolKey,
+				Path:      path,
+				Field:     field,
+				Message:   fmt.Sprintf("catalog %s errors[%d] is not an object", strconv.Quote(path), i),
+			})
+			continue
+		}
+		for _, check := range []struct {
+			key  string
+			want string
+		}{
+			{"condition", wantErr.Condition},
+			{"type", wantErr.Type},
+			{"message", wantErr.Message},
+		} {
+			if got, _ := errValue[check.key].(string); got != check.want {
+				issues = append(issues, CallBehaviorParityIssue{
+					Code:      "javascript.call_behavior.mismatch",
+					SymbolKey: symbolKey,
+					Path:      path,
+					Field:     field,
+					Message: fmt.Sprintf(
+						"catalog %s errors[%d].%s = %q, want %q",
+						strconv.Quote(path),
+						i,
+						check.key,
+						got,
+						check.want,
+					),
+				})
+			}
+		}
+	}
+	return issues
+}
+
+func catalogPolicyCheckParityIssues(
+	symbolKey string,
+	path string,
+	symbol map[string]any,
+	want []callbehavior.PolicyCheck,
+) []CallBehaviorParityIssue {
+	field := "policyChecks"
+	if len(want) == 0 {
+		return nil
+	}
+	gotValue, ok := symbol[field].([]any)
+	if !ok {
+		return []CallBehaviorParityIssue{{
+			Code:      "javascript.call_behavior.mismatch",
+			SymbolKey: symbolKey,
+			Path:      path,
+			Field:     field,
+			Message:   fmt.Sprintf("catalog %s policyChecks missing or not an array", strconv.Quote(path)),
+		}}
+	}
+	if len(gotValue) != len(want) {
+		return []CallBehaviorParityIssue{{
+			Code:      "javascript.call_behavior.mismatch",
+			SymbolKey: symbolKey,
+			Path:      path,
+			Field:     field,
+			Message: fmt.Sprintf(
+				"catalog %s policyChecks count = %d, want %d",
+				strconv.Quote(path),
+				len(gotValue),
+				len(want),
+			),
+		}}
+	}
+
+	var issues []CallBehaviorParityIssue
+	for i, wantCheck := range want {
+		checkValue, ok := gotValue[i].(map[string]any)
+		if !ok {
+			issues = append(issues, CallBehaviorParityIssue{
+				Code:      "javascript.call_behavior.mismatch",
+				SymbolKey: symbolKey,
+				Path:      path,
+				Field:     field,
+				Message:   fmt.Sprintf("catalog %s policyChecks[%d] is not an object", strconv.Quote(path), i),
+			})
+			continue
+		}
+		if got, _ := checkValue["kind"].(string); got != wantCheck.Kind {
+			issues = append(issues, CallBehaviorParityIssue{
+				Code:      "javascript.call_behavior.mismatch",
+				SymbolKey: symbolKey,
+				Path:      path,
+				Field:     field,
+				Message: fmt.Sprintf(
+					"catalog %s policyChecks[%d].kind = %q, want %q",
+					strconv.Quote(path),
+					i,
+					got,
+					wantCheck.Kind,
+				),
+			})
+		}
+		if wantCheck.Field != "" {
+			if got, _ := checkValue["field"].(string); got != wantCheck.Field {
+				issues = append(issues, CallBehaviorParityIssue{
+					Code:      "javascript.call_behavior.mismatch",
+					SymbolKey: symbolKey,
+					Path:      path,
+					Field:     field,
+					Message: fmt.Sprintf(
+						"catalog %s policyChecks[%d].field = %q, want %q",
+						strconv.Quote(path),
+						i,
+						got,
+						wantCheck.Field,
+					),
+				})
+			}
+		}
+		if wantCheck.Message != "" {
+			if got, _ := checkValue["message"].(string); got != wantCheck.Message {
+				issues = append(issues, CallBehaviorParityIssue{
+					Code:      "javascript.call_behavior.mismatch",
+					SymbolKey: symbolKey,
+					Path:      path,
+					Field:     field,
+					Message: fmt.Sprintf(
+						"catalog %s policyChecks[%d].message = %q, want %q",
+						strconv.Quote(path),
+						i,
+						got,
+						wantCheck.Message,
+					),
+				})
+			}
+		}
+	}
+	return issues
+}
+
+func catalogStringFieldParityIssues(
+	symbolKey string,
+	path string,
+	field string,
+	symbol map[string]any,
+	want string,
+) []CallBehaviorParityIssue {
+	if want == "" {
+		return nil
+	}
+	got, _ := symbol[field].(string)
+	if got != want {
+		return []CallBehaviorParityIssue{{
+			Code:      "javascript.call_behavior.mismatch",
+			SymbolKey: symbolKey,
+			Path:      path,
+			Field:     field,
+			Message:   fmt.Sprintf("catalog %s %s = %q, want %q", strconv.Quote(path), field, got, want),
+		}}
+	}
+	return nil
+}
+
+func catalogCallbackParityIssues(
+	symbolKey string,
+	path string,
+	symbol map[string]any,
+	want *callbehavior.CallbackShape,
+) []CallBehaviorParityIssue {
+	field := "callback"
+	if want == nil {
+		if callbackValue, ok := symbol[field]; ok && callbackValue != nil {
+			return []CallBehaviorParityIssue{{
+				Code:      "javascript.call_behavior.mismatch",
+				SymbolKey: symbolKey,
+				Path:      path,
+				Field:     field,
+				Message:   fmt.Sprintf("catalog %s callback present, want none", strconv.Quote(path)),
+			}}
+		}
+		return nil
+	}
+
+	callbackValue, ok := symbol[field].(map[string]any)
+	if !ok {
+		return []CallBehaviorParityIssue{{
+			Code:      "javascript.call_behavior.mismatch",
+			SymbolKey: symbolKey,
+			Path:      path,
+			Field:     field,
+			Message:   fmt.Sprintf("catalog %s callback missing or not an object", strconv.Quote(path)),
+		}}
+	}
+
+	var issues []CallBehaviorParityIssue
+	if got, _ := callbackValue["role"].(string); got != want.Role {
+		issues = append(issues, CallBehaviorParityIssue{
+			Code:      "javascript.call_behavior.mismatch",
+			SymbolKey: symbolKey,
+			Path:      path,
+			Field:     field,
+			Message:   fmt.Sprintf("catalog %s callback.role = %q, want %q", strconv.Quote(path), got, want.Role),
+		})
+	}
+	if want.Notes != "" {
+		if got, _ := callbackValue["notes"].(string); got != want.Notes {
+			issues = append(issues, CallBehaviorParityIssue{
+				Code:      "javascript.call_behavior.mismatch",
+				SymbolKey: symbolKey,
+				Path:      path,
+				Field:     field,
+				Message:   fmt.Sprintf("catalog %s callback.notes = %q, want %q", strconv.Quote(path), got, want.Notes),
+			})
+		}
+	}
+	issues = append(issues, catalogParameterParityIssues(symbolKey, path+".callback", callbackValue, want.Parameters)...)
+	return issues
+}

--- a/pkg/orchestrators/javascript/runtime/catalog/catalog_call_behavior_parity.go
+++ b/pkg/orchestrators/javascript/runtime/catalog/catalog_call_behavior_parity.go
@@ -249,84 +249,77 @@ func catalogParameterParityIssues(
 			})
 			continue
 		}
-		if got, _ := param["name"].(string); got != wantParam.Name {
-			issues = append(issues, CallBehaviorParityIssue{
-				Code:      "javascript.call_behavior.mismatch",
-				SymbolKey: symbolKey,
-				Path:      path,
-				Field:     field,
-				Message: fmt.Sprintf(
-					"catalog %s parameters[%d].name = %q, want %q",
-					strconv.Quote(path),
-					i,
-					got,
-					wantParam.Name,
-				),
-			})
-		}
-		if got, _ := param["required"].(bool); got != wantParam.Required {
-			issues = append(issues, CallBehaviorParityIssue{
-				Code:      "javascript.call_behavior.mismatch",
-				SymbolKey: symbolKey,
-				Path:      path,
-				Field:     field,
-				Message: fmt.Sprintf(
-					"catalog %s parameters[%d].required = %v, want %v",
-					strconv.Quote(path),
-					i,
-					got,
-					wantParam.Required,
-				),
-			})
-		}
-		if got, _ := param["type"].(string); got != wantParam.Type {
-			issues = append(issues, CallBehaviorParityIssue{
-				Code:      "javascript.call_behavior.mismatch",
-				SymbolKey: symbolKey,
-				Path:      path,
-				Field:     field,
-				Message: fmt.Sprintf(
-					"catalog %s parameters[%d].type = %q, want %q",
-					strconv.Quote(path),
-					i,
-					got,
-					wantParam.Type,
-				),
-			})
-		}
-		gotRest, _ := param["rest"].(bool)
-		if gotRest != wantParam.Rest {
-			issues = append(issues, CallBehaviorParityIssue{
-				Code:      "javascript.call_behavior.mismatch",
-				SymbolKey: symbolKey,
-				Path:      path,
-				Field:     field,
-				Message: fmt.Sprintf(
-					"catalog %s parameters[%d].rest = %v, want %v",
-					strconv.Quote(path),
-					i,
-					gotRest,
-					wantParam.Rest,
-				),
-			})
-		}
-		if wantParam.Default != "" {
-			got, _ := param["default"].(string)
-			if got != wantParam.Default {
-				issues = append(issues, CallBehaviorParityIssue{
-					Code:      "javascript.call_behavior.mismatch",
-					SymbolKey: symbolKey,
-					Path:      path,
-					Field:     field,
-					Message: fmt.Sprintf(
-						"catalog %s parameters[%d].default = %q, want %q",
-						strconv.Quote(path),
-						i,
-						got,
-						wantParam.Default,
-					),
-				})
-			}
+		issues = append(issues, catalogSingleParameterParityIssues(symbolKey, path, field, i, param, wantParam)...)
+	}
+	return issues
+}
+
+func catalogSingleParameterParityIssues(
+	symbolKey string,
+	path string,
+	field string,
+	index int,
+	param map[string]any,
+	wantParam callbehavior.Parameter,
+) []CallBehaviorParityIssue {
+	var issues []CallBehaviorParityIssue
+	appendMismatch := func(message string) {
+		issues = append(issues, CallBehaviorParityIssue{
+			Code:      "javascript.call_behavior.mismatch",
+			SymbolKey: symbolKey,
+			Path:      path,
+			Field:     field,
+			Message:   message,
+		})
+	}
+
+	if got, _ := param["name"].(string); got != wantParam.Name {
+		appendMismatch(fmt.Sprintf(
+			"catalog %s parameters[%d].name = %q, want %q",
+			strconv.Quote(path),
+			index,
+			got,
+			wantParam.Name,
+		))
+	}
+	if got, _ := param["required"].(bool); got != wantParam.Required {
+		appendMismatch(fmt.Sprintf(
+			"catalog %s parameters[%d].required = %v, want %v",
+			strconv.Quote(path),
+			index,
+			got,
+			wantParam.Required,
+		))
+	}
+	if got, _ := param["type"].(string); got != wantParam.Type {
+		appendMismatch(fmt.Sprintf(
+			"catalog %s parameters[%d].type = %q, want %q",
+			strconv.Quote(path),
+			index,
+			got,
+			wantParam.Type,
+		))
+	}
+	gotRest, _ := param["rest"].(bool)
+	if gotRest != wantParam.Rest {
+		appendMismatch(fmt.Sprintf(
+			"catalog %s parameters[%d].rest = %v, want %v",
+			strconv.Quote(path),
+			index,
+			gotRest,
+			wantParam.Rest,
+		))
+	}
+	if wantParam.Default != "" {
+		got, _ := param["default"].(string)
+		if got != wantParam.Default {
+			appendMismatch(fmt.Sprintf(
+				"catalog %s parameters[%d].default = %q, want %q",
+				strconv.Quote(path),
+				index,
+				got,
+				wantParam.Default,
+			))
 		}
 	}
 	return issues

--- a/pkg/orchestrators/javascript/runtime/catalog/catalog_call_behavior_parity_test.go
+++ b/pkg/orchestrators/javascript/runtime/catalog/catalog_call_behavior_parity_test.go
@@ -4,11 +4,70 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	jscatalog "github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/catalog"
 	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/callbehavior"
 )
+
+func TestVerifyCatalogCallBehaviorParity_ReturnsFormattedError(t *testing.T) {
+	document := loadAuthoredJavaScriptRuntimeCatalogDocument(t)
+	symbols := document["symbols"].(map[string]any)
+	parallel := cloneMap(t, symbols["javascript.parallel"].(map[string]any))
+	returnValue := cloneMap(t, parallel["return"].(map[string]any))
+	returnValue["type"] = "object"
+	parallel["return"] = returnValue
+	symbols["javascript.parallel"] = parallel
+
+	err := jscatalog.VerifyCatalogCallBehaviorParity(document, callbehavior.ProjectInstalledCallBehavior())
+	if err == nil {
+		t.Fatal("VerifyCatalogCallBehaviorParity() error = nil, want formatted parity failure")
+	}
+	if !strings.Contains(err.Error(), "catalog call-behavior parity failed:") {
+		t.Fatalf("VerifyCatalogCallBehaviorParity() error = %q, want parity prefix", err)
+	}
+	if !strings.Contains(err.Error(), "/symbols/javascript.parallel/return") {
+		t.Fatalf("VerifyCatalogCallBehaviorParity() error = %q, want symbol field path", err)
+	}
+}
+
+func TestCatalogCallBehaviorParityIssues_DetectsParameterAndCallbackDrift(t *testing.T) {
+	document := loadAuthoredJavaScriptRuntimeCatalogDocument(t)
+	symbols := document["symbols"].(map[string]any)
+
+	checkpoint := cloneMap(t, symbols["javascript.workflow.checkpoint"].(map[string]any))
+	params := cloneSlice(t, checkpoint["parameters"].([]any))
+	firstParam := cloneMap(t, params[0].(map[string]any))
+	firstParam["name"] = "wrong-name"
+	params[0] = firstParam
+	checkpoint["parameters"] = params
+	symbols["javascript.workflow.checkpoint"] = checkpoint
+
+	pipeline := cloneMap(t, symbols["javascript.pipeline"].(map[string]any))
+	callback := cloneMap(t, pipeline["callback"].(map[string]any))
+	callback["role"] = "wrong-role"
+	pipeline["callback"] = callback
+	symbols["javascript.pipeline"] = pipeline
+
+	issues, err := jscatalog.CatalogCallBehaviorParityIssues(document, callbehavior.ProjectInstalledCallBehavior())
+	if err != nil {
+		t.Fatalf("CatalogCallBehaviorParityIssues() error = %v", err)
+	}
+	if len(issues) < 2 {
+		t.Fatalf("CatalogCallBehaviorParityIssues() = %+v, want parameter and callback mismatches", issues)
+	}
+}
+
+func TestCatalogCallBehaviorParityIssues_RejectsInvalidDocument(t *testing.T) {
+	_, err := jscatalog.CatalogCallBehaviorParityIssues(map[string]any{}, callbehavior.ProjectInstalledCallBehavior())
+	if err == nil {
+		t.Fatal("CatalogCallBehaviorParityIssues() error = nil, want missing symbols error")
+	}
+	if !strings.Contains(err.Error(), "missing symbols") {
+		t.Fatalf("CatalogCallBehaviorParityIssues() error = %q, want missing symbols", err)
+	}
+}
 
 func TestVerifyCatalogCallBehaviorParity_PassesForAuthoredCatalog(t *testing.T) {
 	document := loadAuthoredJavaScriptRuntimeCatalogDocument(t)
@@ -74,6 +133,20 @@ func loadAuthoredJavaScriptRuntimeCatalogDocument(t *testing.T) map[string]any {
 		t.Fatalf("unmarshal authored catalog: %v", err)
 	}
 	return document
+}
+
+func cloneSlice(t *testing.T, value []any) []any {
+	t.Helper()
+
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal slice: %v", err)
+	}
+	var cloned []any
+	if err := json.Unmarshal(raw, &cloned); err != nil {
+		t.Fatalf("unmarshal cloned slice: %v", err)
+	}
+	return cloned
 }
 
 func cloneMap(t *testing.T, value map[string]any) map[string]any {

--- a/pkg/orchestrators/javascript/runtime/catalog/catalog_call_behavior_parity_test.go
+++ b/pkg/orchestrators/javascript/runtime/catalog/catalog_call_behavior_parity_test.go
@@ -1,0 +1,91 @@
+package catalog_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	jscatalog "github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/catalog"
+	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/callbehavior"
+)
+
+func TestVerifyCatalogCallBehaviorParity_PassesForAuthoredCatalog(t *testing.T) {
+	document := loadAuthoredJavaScriptRuntimeCatalogDocument(t)
+	callInventory := callbehavior.ProjectInstalledCallBehavior()
+
+	if err := jscatalog.VerifyCatalogCallBehaviorParity(document, callInventory); err != nil {
+		t.Fatalf("VerifyCatalogCallBehaviorParity() error = %v", err)
+	}
+}
+
+func TestCatalogCallBehaviorParityIssues_FailsWhenRepresentativeReturnDrifts(t *testing.T) {
+	document := loadAuthoredJavaScriptRuntimeCatalogDocument(t)
+	symbols := document["symbols"].(map[string]any)
+	parallel := cloneMap(t, symbols["javascript.parallel"].(map[string]any))
+	returnValue := cloneMap(t, parallel["return"].(map[string]any))
+	returnValue["type"] = "object"
+	parallel["return"] = returnValue
+	symbols["javascript.parallel"] = parallel
+
+	issues, err := jscatalog.CatalogCallBehaviorParityIssues(document, callbehavior.ProjectInstalledCallBehavior())
+	if err != nil {
+		t.Fatalf("CatalogCallBehaviorParityIssues() error = %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("CatalogCallBehaviorParityIssues() = %+v, want one return mismatch", issues)
+	}
+	issue := issues[0]
+	if issue.Code != "javascript.call_behavior.mismatch" ||
+		issue.Path != "parallel" ||
+		issue.Field != "return" {
+		t.Fatalf("issue = %+v, want parallel return mismatch", issue)
+	}
+}
+
+func TestCatalogCallBehaviorParityIssues_FailsWhenRepresentativeSymbolMissing(t *testing.T) {
+	document := loadAuthoredJavaScriptRuntimeCatalogDocument(t)
+	symbols := document["symbols"].(map[string]any)
+	delete(symbols, "javascript.workflow.final")
+
+	issues, err := jscatalog.CatalogCallBehaviorParityIssues(document, callbehavior.ProjectInstalledCallBehavior())
+	if err != nil {
+		t.Fatalf("CatalogCallBehaviorParityIssues() error = %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("CatalogCallBehaviorParityIssues() = %+v, want one missing representative path", issues)
+	}
+	issue := issues[0]
+	if issue.Code != "javascript.call_behavior.missing" || issue.Path != "workflow.final" {
+		t.Fatalf("issue = %+v, want missing workflow.final", issue)
+	}
+}
+
+func loadAuthoredJavaScriptRuntimeCatalogDocument(t *testing.T) map[string]any {
+	t.Helper()
+
+	repoRoot := filepath.Join("..", "..", "..", "..", "..")
+	raw, err := os.ReadFile(filepath.Join(repoRoot, "contracts", "javascript", "runtime-api.json"))
+	if err != nil {
+		t.Fatalf("read authored catalog: %v", err)
+	}
+	var document map[string]any
+	if err := json.Unmarshal(raw, &document); err != nil {
+		t.Fatalf("unmarshal authored catalog: %v", err)
+	}
+	return document
+}
+
+func cloneMap(t *testing.T, value map[string]any) map[string]any {
+	t.Helper()
+
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal map: %v", err)
+	}
+	var cloned map[string]any
+	if err := json.Unmarshal(raw, &cloned); err != nil {
+		t.Fatalf("unmarshal cloned map: %v", err)
+	}
+	return cloned
+}

--- a/pkg/orchestrators/javascript/runtime/catalog/catalog_identity.go
+++ b/pkg/orchestrators/javascript/runtime/catalog/catalog_identity.go
@@ -85,19 +85,7 @@ func CatalogPathCompletenessIssues(
 	}
 
 	var issues []PathCompletenessIssue
-	for path, keys := range pathToKeys {
-		if len(keys) > 1 {
-			message := fmt.Sprintf("symbol path %s appears more than once", strconv.Quote(path))
-			for _, key := range keys {
-				issues = append(issues, PathCompletenessIssue{
-					Code:      "javascript.path.duplicate",
-					SymbolKey: key,
-					Path:      path,
-					Message:   message,
-				})
-			}
-		}
-	}
+	issues = append(issues, catalogDuplicatePathIssues(pathToKeys)...)
 
 	catalogPaths := make(map[string]struct{}, len(catalog))
 	for _, entry := range catalog {
@@ -118,25 +106,7 @@ func CatalogPathCompletenessIssues(
 	for _, entry := range catalog {
 		pathToKey[entry.Path] = entry.SymbolKey
 	}
-	expectedSet := make(map[string]struct{}, len(identityPaths))
-	for _, path := range identityPaths {
-		expectedSet[path] = struct{}{}
-	}
-	extraPaths := make([]string, 0)
-	for path := range catalogPaths {
-		if _, ok := expectedSet[path]; !ok {
-			extraPaths = append(extraPaths, path)
-		}
-	}
-	sort.Strings(extraPaths)
-	for _, path := range extraPaths {
-		issues = append(issues, PathCompletenessIssue{
-			Code:      "javascript.path.extra",
-			SymbolKey: pathToKey[path],
-			Path:      path,
-			Message:   fmt.Sprintf("catalog path %s is not part of the installed supported surface", strconv.Quote(path)),
-		})
-	}
+	issues = append(issues, catalogExtraPathIssues(catalogPaths, identityPaths, pathToKey)...)
 
 	sort.Slice(issues, func(i, j int) bool {
 		left, right := issues[i], issues[j]
@@ -148,6 +118,54 @@ func CatalogPathCompletenessIssues(
 		}
 		return left.SymbolKey < right.SymbolKey
 	})
+	return issues
+}
+
+func catalogDuplicatePathIssues(pathToKeys map[string][]string) []PathCompletenessIssue {
+	var issues []PathCompletenessIssue
+	for path, keys := range pathToKeys {
+		if len(keys) <= 1 {
+			continue
+		}
+		message := fmt.Sprintf("symbol path %s appears more than once", strconv.Quote(path))
+		for _, key := range keys {
+			issues = append(issues, PathCompletenessIssue{
+				Code:      "javascript.path.duplicate",
+				SymbolKey: key,
+				Path:      path,
+				Message:   message,
+			})
+		}
+	}
+	return issues
+}
+
+func catalogExtraPathIssues(
+	catalogPaths map[string]struct{},
+	identityPaths []string,
+	pathToKey map[string]string,
+) []PathCompletenessIssue {
+	expectedSet := make(map[string]struct{}, len(identityPaths))
+	for _, path := range identityPaths {
+		expectedSet[path] = struct{}{}
+	}
+	extraPaths := make([]string, 0)
+	for path := range catalogPaths {
+		if _, ok := expectedSet[path]; !ok {
+			extraPaths = append(extraPaths, path)
+		}
+	}
+	sort.Strings(extraPaths)
+
+	issues := make([]PathCompletenessIssue, 0, len(extraPaths))
+	for _, path := range extraPaths {
+		issues = append(issues, PathCompletenessIssue{
+			Code:      "javascript.path.extra",
+			SymbolKey: pathToKey[path],
+			Path:      path,
+			Message:   fmt.Sprintf("catalog path %s is not part of the installed supported surface", strconv.Quote(path)),
+		})
+	}
 	return issues
 }
 

--- a/pkg/orchestrators/javascript/runtime/catalog/catalog_identity.go
+++ b/pkg/orchestrators/javascript/runtime/catalog/catalog_identity.go
@@ -1,0 +1,192 @@
+package catalog
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/callbehavior"
+	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/symbolidentity"
+)
+
+// CatalogSymbolPath records one catalog symbol map key and its installed path.
+type CatalogSymbolPath struct {
+	SymbolKey string
+	Path      string
+}
+
+// PathCompletenessIssue records one catalog path completeness failure by path.
+type PathCompletenessIssue struct {
+	Code      string
+	SymbolKey string
+	Path      string
+	Message   string
+}
+
+// CatalogSymbolPathsFromDocument extracts symbol paths from one resolved runtime
+// manifest catalog document value.
+func CatalogSymbolPathsFromDocument(value any) ([]CatalogSymbolPath, error) {
+	root, ok := value.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("catalog document is not an object")
+	}
+	symbolsValue, ok := root["symbols"]
+	if !ok {
+		return nil, fmt.Errorf("catalog document missing symbols")
+	}
+	symbols, ok := symbolsValue.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("catalog symbols is not an object")
+	}
+
+	keys := make([]string, 0, len(symbols))
+	for key := range symbols {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	paths := make([]CatalogSymbolPath, 0, len(keys))
+	for _, key := range keys {
+		record, ok := symbols[key].(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("catalog symbol %q is not an object", key)
+		}
+		path, _ := record["path"].(string)
+		if path == "" {
+			return nil, fmt.Errorf("catalog symbol %q has empty path", key)
+		}
+		paths = append(paths, CatalogSymbolPath{SymbolKey: key, Path: path})
+	}
+	return paths, nil
+}
+
+// CatalogPathCompletenessIssues compares catalog symbol paths to the reviewed
+// identity baseline and installed call-behavior descriptor.
+func CatalogPathCompletenessIssues(
+	catalog []CatalogSymbolPath,
+	identity symbolidentity.Inventory,
+	callInventory callbehavior.Inventory,
+) []PathCompletenessIssue {
+	identityPaths := pathsFromIdentityInventory(identity)
+	callPaths := pathsFromCallInventory(callInventory)
+	if !slices.Equal(identityPaths, callPaths) {
+		return []PathCompletenessIssue{{
+			Code:    "javascript.path.baseline_drift",
+			Path:    "/symbols",
+			Message: "identity baseline and installed call-behavior descriptor paths differ",
+		}}
+	}
+
+	pathToKeys := make(map[string][]string, len(catalog))
+	for _, entry := range catalog {
+		pathToKeys[entry.Path] = append(pathToKeys[entry.Path], entry.SymbolKey)
+	}
+
+	var issues []PathCompletenessIssue
+	for path, keys := range pathToKeys {
+		if len(keys) > 1 {
+			message := fmt.Sprintf("symbol path %s appears more than once", strconv.Quote(path))
+			for _, key := range keys {
+				issues = append(issues, PathCompletenessIssue{
+					Code:      "javascript.path.duplicate",
+					SymbolKey: key,
+					Path:      path,
+					Message:   message,
+				})
+			}
+		}
+	}
+
+	catalogPaths := make(map[string]struct{}, len(catalog))
+	for _, entry := range catalog {
+		catalogPaths[entry.Path] = struct{}{}
+	}
+
+	for _, expected := range identityPaths {
+		if _, ok := catalogPaths[expected]; !ok {
+			issues = append(issues, PathCompletenessIssue{
+				Code:    "javascript.path.missing",
+				Path:    expected,
+				Message: fmt.Sprintf("installed symbol path %s missing from catalog", strconv.Quote(expected)),
+			})
+		}
+	}
+
+	pathToKey := make(map[string]string, len(catalog))
+	for _, entry := range catalog {
+		pathToKey[entry.Path] = entry.SymbolKey
+	}
+	expectedSet := make(map[string]struct{}, len(identityPaths))
+	for _, path := range identityPaths {
+		expectedSet[path] = struct{}{}
+	}
+	extraPaths := make([]string, 0)
+	for path := range catalogPaths {
+		if _, ok := expectedSet[path]; !ok {
+			extraPaths = append(extraPaths, path)
+		}
+	}
+	sort.Strings(extraPaths)
+	for _, path := range extraPaths {
+		issues = append(issues, PathCompletenessIssue{
+			Code:      "javascript.path.extra",
+			SymbolKey: pathToKey[path],
+			Path:      path,
+			Message:   fmt.Sprintf("catalog path %s is not part of the installed supported surface", strconv.Quote(path)),
+		})
+	}
+
+	sort.Slice(issues, func(i, j int) bool {
+		left, right := issues[i], issues[j]
+		if left.Code != right.Code {
+			return left.Code < right.Code
+		}
+		if left.Path != right.Path {
+			return left.Path < right.Path
+		}
+		return left.SymbolKey < right.SymbolKey
+	})
+	return issues
+}
+
+// VerifyCatalogPathCompleteness ensures every installed binding path occurs
+// exactly once in the catalog and no extra supported-surface paths are present.
+func VerifyCatalogPathCompleteness(
+	catalog []CatalogSymbolPath,
+	identity symbolidentity.Inventory,
+	callInventory callbehavior.Inventory,
+) error {
+	issues := CatalogPathCompletenessIssues(catalog, identity, callInventory)
+	if len(issues) == 0 {
+		return nil
+	}
+	messages := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		if issue.SymbolKey != "" {
+			messages = append(messages, fmt.Sprintf("%s at /symbols/%s/path", issue.Message, issue.SymbolKey))
+			continue
+		}
+		messages = append(messages, issue.Message)
+	}
+	return fmt.Errorf("catalog path completeness failed: %s", strings.Join(messages, "; "))
+}
+
+func pathsFromIdentityInventory(inventory symbolidentity.Inventory) []string {
+	paths := make([]string, len(inventory.Symbols))
+	for i, record := range inventory.Symbols {
+		paths[i] = record.Path
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func pathsFromCallInventory(inventory callbehavior.Inventory) []string {
+	paths := make([]string, len(inventory.Records))
+	for i, record := range inventory.Records {
+		paths[i] = record.Path
+	}
+	sort.Strings(paths)
+	return paths
+}

--- a/pkg/orchestrators/javascript/runtime/catalog/catalog_identity_test.go
+++ b/pkg/orchestrators/javascript/runtime/catalog/catalog_identity_test.go
@@ -2,12 +2,93 @@ package catalog_test
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
 	jscatalog "github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/catalog"
 	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/callbehavior"
 	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/symbolidentity"
 )
+
+func TestCatalogSymbolPathsFromDocument_RejectsInvalidDocument(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		document any
+		wantErr  string
+	}{
+		{
+			name:     "non-object document",
+			document: []any{},
+			wantErr:  "catalog document is not an object",
+		},
+		{
+			name: "missing symbols",
+			document: map[string]any{
+				"sharedSchemas": map[string]any{},
+			},
+			wantErr: "catalog document missing symbols",
+		},
+		{
+			name: "symbols not object",
+			document: map[string]any{
+				"symbols": []any{},
+			},
+			wantErr: "catalog symbols is not an object",
+		},
+		{
+			name: "symbol not object",
+			document: map[string]any{
+				"symbols": map[string]any{
+					"javascript.log": "not-an-object",
+				},
+			},
+			wantErr: `catalog symbol "javascript.log" is not an object`,
+		},
+		{
+			name: "empty path",
+			document: map[string]any{
+				"symbols": map[string]any{
+					"javascript.log": map[string]any{
+						"path": "",
+					},
+				},
+			},
+			wantErr: `catalog symbol "javascript.log" has empty path`,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := jscatalog.CatalogSymbolPathsFromDocument(tc.document)
+			if err == nil {
+				t.Fatal("CatalogSymbolPathsFromDocument() error = nil, want error")
+			}
+			if err.Error() != tc.wantErr {
+				t.Fatalf("CatalogSymbolPathsFromDocument() error = %q, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestVerifyCatalogPathCompleteness_ReturnsFormattedError(t *testing.T) {
+	catalog := installedCatalogSymbolPaths(t)
+	catalog = removeCatalogPath(catalog, "phase")
+
+	err := jscatalog.VerifyCatalogPathCompleteness(
+		catalog,
+		symbolidentity.ProjectInstalledBindings(),
+		callbehavior.ProjectInstalledCallBehavior(),
+	)
+	if err == nil {
+		t.Fatal("VerifyCatalogPathCompleteness() error = nil, want formatted completeness failure")
+	}
+	if !strings.Contains(err.Error(), "catalog path completeness failed:") {
+		t.Fatalf("VerifyCatalogPathCompleteness() error = %q, want completeness prefix", err)
+	}
+}
 
 func TestCatalogSymbolPathsFromDocument_ExtractsSortedPaths(t *testing.T) {
 	document := map[string]any{

--- a/pkg/orchestrators/javascript/runtime/catalog/catalog_identity_test.go
+++ b/pkg/orchestrators/javascript/runtime/catalog/catalog_identity_test.go
@@ -1,0 +1,138 @@
+package catalog_test
+
+import (
+	"slices"
+	"testing"
+
+	jscatalog "github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/catalog"
+	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/callbehavior"
+	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/symbolidentity"
+)
+
+func TestCatalogSymbolPathsFromDocument_ExtractsSortedPaths(t *testing.T) {
+	document := map[string]any{
+		"symbols": map[string]any{
+			"javascript.phase": map[string]any{
+				"path": "phase",
+			},
+			"javascript.log": map[string]any{
+				"path": "log",
+			},
+		},
+	}
+
+	got, err := jscatalog.CatalogSymbolPathsFromDocument(document)
+	if err != nil {
+		t.Fatalf("CatalogSymbolPathsFromDocument() error = %v", err)
+	}
+	want := []jscatalog.CatalogSymbolPath{
+		{SymbolKey: "javascript.log", Path: "log"},
+		{SymbolKey: "javascript.phase", Path: "phase"},
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("CatalogSymbolPathsFromDocument() = %+v, want %+v", got, want)
+	}
+}
+
+func TestVerifyCatalogPathCompleteness_PassesForInstalledSurface(t *testing.T) {
+	catalog := installedCatalogSymbolPaths(t)
+	identity := symbolidentity.ProjectInstalledBindings()
+	callInventory := callbehavior.ProjectInstalledCallBehavior()
+
+	if err := jscatalog.VerifyCatalogPathCompleteness(catalog, identity, callInventory); err != nil {
+		t.Fatalf("VerifyCatalogPathCompleteness() error = %v", err)
+	}
+}
+
+func TestVerifyCatalogPathCompleteness_FailsWhenInstalledPathMissing(t *testing.T) {
+	catalog := installedCatalogSymbolPaths(t)
+	catalog = removeCatalogPath(catalog, "phase")
+
+	issues := jscatalog.CatalogPathCompletenessIssues(
+		catalog,
+		symbolidentity.ProjectInstalledBindings(),
+		callbehavior.ProjectInstalledCallBehavior(),
+	)
+	if len(issues) != 1 {
+		t.Fatalf("CatalogPathCompletenessIssues() = %+v, want one missing-path issue", issues)
+	}
+	issue := issues[0]
+	if issue.Code != "javascript.path.missing" || issue.Path != "phase" {
+		t.Fatalf("issue = %+v, want missing path %q", issue, "phase")
+	}
+}
+
+func TestVerifyCatalogPathCompleteness_FailsWhenCatalogContainsExtraPath(t *testing.T) {
+	catalog := installedCatalogSymbolPaths(t)
+	catalog = append(catalog, jscatalog.CatalogSymbolPath{
+		SymbolKey: "javascript.workflow.extra",
+		Path:      "workflow.extra",
+	})
+
+	issues := jscatalog.CatalogPathCompletenessIssues(
+		catalog,
+		symbolidentity.ProjectInstalledBindings(),
+		callbehavior.ProjectInstalledCallBehavior(),
+	)
+	if len(issues) != 1 {
+		t.Fatalf("CatalogPathCompletenessIssues() = %+v, want one extra-path issue", issues)
+	}
+	issue := issues[0]
+	if issue.Code != "javascript.path.extra" || issue.Path != "workflow.extra" {
+		t.Fatalf("issue = %+v, want extra path %q", issue, "workflow.extra")
+	}
+}
+
+func TestVerifyCatalogPathCompleteness_FailsWhenCatalogPathDuplicated(t *testing.T) {
+	catalog := installedCatalogSymbolPaths(t)
+	catalog = append(catalog, jscatalog.CatalogSymbolPath{
+		SymbolKey: "javascript.duplicate-phase",
+		Path:      "phase",
+	})
+
+	issues := jscatalog.CatalogPathCompletenessIssues(
+		catalog,
+		symbolidentity.ProjectInstalledBindings(),
+		callbehavior.ProjectInstalledCallBehavior(),
+	)
+	if len(issues) != 2 {
+		t.Fatalf("CatalogPathCompletenessIssues() = %+v, want duplicate-path issues for both symbols", issues)
+	}
+	for _, issue := range issues {
+		if issue.Code != "javascript.path.duplicate" || issue.Path != "phase" {
+			t.Fatalf("issue = %+v, want duplicate path %q", issue, "phase")
+		}
+	}
+}
+
+func installedCatalogSymbolPaths(t *testing.T) []jscatalog.CatalogSymbolPath {
+	t.Helper()
+
+	paths := symbolidentity.ExpectedInstalledPaths()
+	catalog := make([]jscatalog.CatalogSymbolPath, 0, len(paths))
+	for _, path := range paths {
+		catalog = append(catalog, jscatalog.CatalogSymbolPath{
+			SymbolKey: catalogSymbolKeyForPath(path),
+			Path:      path,
+		})
+	}
+	return catalog
+}
+
+func catalogSymbolKeyForPath(path string) string {
+	if path == "workflow.resumeState" {
+		return "javascript.workflow.resume-state"
+	}
+	return "javascript." + path
+}
+
+func removeCatalogPath(catalog []jscatalog.CatalogSymbolPath, path string) []jscatalog.CatalogSymbolPath {
+	filtered := make([]jscatalog.CatalogSymbolPath, 0, len(catalog))
+	for _, entry := range catalog {
+		if entry.Path == path {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}


### PR DESCRIPTION
{
  "project": "B17-JS-CATALOG — Contract the currently installed JavaScript runtime API",
  "branchName": "interfaces-b17-javascript-catalog",
  "description": "Author contracts/javascript/runtime-api.json plus reusable named schemas for serializable values so the catalog documents the currently installed JavaScript runtime API exactly, prove path completeness and representative call-behavior parity against reviewed baselines, reject unsupported helpers, and generate package staging from the authored source without changing runtime bindings or absorbing B17-JS-CLOSE.",
  "context": {
    "customerAsk": "Author contracts/javascript/runtime-api.json plus reusable named schemas for serializable values. Contract exactly args, meta, workflow.*, agent.run, parallel, pipeline, phase, and log as installed today, including stable paths, parents/members, parameters and callbacks, returns/promises, errors, emitted records, policy checks, determinism, resume, lifecycle, mutability, nullability, limits, and canonical English examples. Generate package staging from this authored source without changing runtime bindings.",
    "problem": "B02–B05 delivered reviewed JavaScript symbol and call-behavior baselines, B06 staged a generated runtime-api.json from the runtime inventory, and B17-JS-SCHEMA defines the validation boundary, but there is still no authored catalog under contracts/javascript that is the single reviewable source of truth. Staging remains inventory-driven, reviewers cannot prove path completeness and call-behavior parity from an authored document, and unsupported surfaces such as context/orchestrator are not rejected as catalog content.",
    "solution": "After the B17 schema lane completes, author contracts/javascript/runtime-api.json with reusable named schemas for serializable values, retarget package staging to generate packages/api/generated/javascript/runtime-api.json from that authored source, prove path completeness and representative call-behavior parity against B02/B03 baselines and installed bindings, reject unsupported helpers, and leave structural smoke closeout to B17-JS-CLOSE without changing runtime bindings or workflow execution logic."
  },
  "acceptanceCriteria": [
    "Catalog paths match the identity baseline and installed binding descriptor exactly; missing, extra, duplicate, or broken parent/member entries fail by path",
    "Representative workflow.final, workflow.checkpoint, agent.run, parallel, and pipeline behavior matches the B03 baseline and runtime tests",
    "context, orchestrator, and comparison-project-only helpers are absent and rejected by parity checks",
    "Catalog and staged projection are byte-stable and completely document current errors, records, policy, determinism, and resume semantics",
    "Focused runtime/parity tests and contract/package guards pass",
    "Authored ownership stays under contracts/javascript/; packages/api/generated/javascript/runtime-api.json is updated only through generation; installed runtime bindings are unchanged",
    "Quality checks pass (typecheck, lint, tests)"
  ],
  "userStories": [
    {
      "id": "interfaces-b17-javascript-catalog-001",
      "title": "Author catalog scaffold and reusable serializable-value schemas",
      "description": "As a contracts maintainer, I need an authored JavaScript runtime API catalog document with reusable named schemas for serializable values so every installed symbol can reference one reviewed vocabulary for args/returns and validate against the B17 schema boundary.",
      "acceptanceCriteria": [
        "contracts/javascript/runtime-api.json exists as the authored catalog (not a hand-edit of packages/api/generated/javascript/runtime-api.json)",
        "The catalog validates against the reviewed contracts/javascript/runtime-manifest.schema.json boundary",
        "Shared reusable named schemas cover serializable value shapes used by installed symbols (closed Draft 2020-12 shapes where values are serializable)",
        "Validating the scaffolded catalog against the schema succeeds; a deliberately broken shared-schema reference or open serializable shape fails with a deterministic validation path",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b17-javascript-catalog-002",
      "title": "Contract root values args and meta",
      "description": "As a JavaScript workflow author, I want args and meta fully contracted so I can see their stable paths, lifecycle, mutability, nullability, limits, and canonical English examples without reading Go binding code.",
      "acceptanceCriteria": [
        "args and meta each appear once by stable path matching the identity baseline and installed binding descriptor",
        "Each entry documents kind/value identity, parent/member relationships where applicable, lifecycle, mutability, nullability, limits, and at least one canonical English example",
        "Entries remain descriptive; they do not add new globals or change installed bindings",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b17-javascript-catalog-003",
      "title": "Contract synchronous root helpers log and phase",
      "description": "As a JavaScript workflow author, I want log and phase fully contracted so parameters, returns, errors, emitted records, policy notes, determinism/resume notes, and English examples match what is installed today.",
      "acceptanceCriteria": [
        "log and phase each appear once by stable path with callable sync signatures matching the call-behavior baseline",
        "Each entry documents ordered parameters (including required/optional/defaults/rest where present), returns, errors, emitted records, policy checks, determinism/resume notes, lifecycle/mutability/nullability as applicable, and at least one canonical English example",
        "Catalog entries do not introduce aliases, host context, or new execution logic",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b17-javascript-catalog-004",
      "title": "Contract workflow namespace and workflow.* members",
      "description": "As a JavaScript workflow author, I want the workflow namespace and every installed workflow.* member contracted so parent/member relationships and call semantics for artifact, budget, checkpoint, final, log, and resumeState are reviewable in one place.",
      "acceptanceCriteria": [
        "workflow appears once as a namespace whose members list exactly the installed member set from the identity baseline",
        "Each of workflow.artifact, workflow.budget, workflow.checkpoint, workflow.final, workflow.log, and workflow.resumeState appears once with parent workflow and matching path/name/id identity",
        "Each callable member documents parameters, returns/promises, errors, emitted records, policy checks, determinism, resume, lifecycle/mutability/nullability as applicable, and at least one canonical English example aligned with current installed behavior",
        "Broken parent/member relationships in a mutated catalog fixture fail by path",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b17-javascript-catalog-005",
      "title": "Contract agent.run, parallel, and pipeline",
      "description": "As a JavaScript workflow author, I want agent/agent.run, parallel, and pipeline fully contracted so asynchronous child and composition helpers document parameters, callbacks, promise returns, errors, records, policy, and resume semantics exactly as installed.",
      "acceptanceCriteria": [
        "agent appears once as a namespace with member run; agent.run, parallel, and pipeline each appear once by stable path matching the identity baseline",
        "Async callables document ordered parameters/callbacks, promise/async returns, errors, emitted records, policy checks, determinism/resume notes, and canonical English examples matching the call-behavior baseline",
        "Catalog documentation does not change installed bindings or add workflow execution logic",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b17-javascript-catalog-006",
      "title": "Prove catalog path completeness against identity baseline and installed bindings",
      "description": "As a reviewer, I want path-completeness checks so every installed symbol path occurs exactly once in the catalog, parent/member links resolve, and missing, extra, duplicate, or broken entries fail by path.",
      "acceptanceCriteria": [
        "A completeness check compares authored catalog paths to the reviewed javascript-runtime-symbols identity baseline and the installed binding descriptor",
        "Removing one catalog path, adding an extra path, duplicating a path, or breaking a parent/member link fails the check by path",
        "The complete catalog passes for the installed supported subset only (args, meta, workflow.*, agent.run, parallel, pipeline, phase, log, plus required namespace parents)",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b17-javascript-catalog-007",
      "title": "Prove representative call-behavior parity for terminal and composition symbols",
      "description": "As a reviewer, I want representative parity so catalog documentation for workflow.final, workflow.checkpoint, agent.run, parallel, and pipeline matches the B03 call-behavior baseline and focused runtime tests without changing execution.",
      "acceptanceCriteria": [
        "Catalog call metadata for workflow.final, workflow.checkpoint, agent.run, parallel, and pipeline matches the B03 baseline fields that define current parameters, returns/promises, errors, emitted records, policy checks, determinism, and resume semantics",
        "Focused runtime/parity tests that assert those representative behaviors continue to pass against installed bindings",
        "Parity checks do not mutate runtime bindings or introduce new policy/execution behavior",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 7,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b17-javascript-catalog-008",
      "title": "Reject unsupported surfaces and wire byte-stable staging from authored source",
      "description": "As a maintainer, I want unsupported helpers rejected and package staging generated from the authored catalog so context, orchestrator, and comparison-project-only helpers cannot enter the contract, and packages/api/generated/javascript/runtime-api.json remains a byte-stable generated projection.",
      "acceptanceCriteria": [
        "Catalog contains no context, orchestrator, or comparison-project-only helper entries; parity/validation checks reject fixtures that introduce them",
        "Staging policy/generation projects from contracts/javascript/runtime-api.json into packages/api/generated/javascript/runtime-api.json (authored ownership under contracts/javascript/; staging updated only through generation)",
        "Catalog and staged projection are byte-stable across repeated generation/check runs and completely document current errors, records, policy, determinism, and resume semantics for the installed surface",
        "Focused runtime/parity tests and contract/package guards pass; B17 structural smoke closeout is not implemented in this lane",
        "Installed runtime bindings remain unchanged",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 8,
      "passes": true,
      "notes": ""
    }
  ]
}
