### PR TITLE
interfaces-b17-javascript-close

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ CURRENT_FACTORY_WATCHER_SWITCH_SMOKE_COUNT ?= 1
 CURRENT_FACTORY_WATCHER_SWITCH_SMOKE_TIMEOUT ?= 120s
 CROSS_PROVIDER_PARITY_SMOKE_TEST := TestCrossProviderParity
 CROSS_PROVIDER_PARITY_SMOKE_TIMEOUT ?= 120s
+JAVASCRIPT_CONTRACT_SMOKE_TIMEOUT ?= 120s
 RESPONSE_STREAM_STRESS_SMOKE_TEST := TestSessionResponseEventStore_Backpressure
 RESPONSE_STREAM_STRESS_SMOKE_TIMEOUT ?= 120s
 BUILT_CLI_ACCEPTANCE_PACKAGES := ./tests/functional/acceptance
@@ -82,7 +83,7 @@ define run_timed_step
 	exit $$status
 endef
 
-.PHONY: default build intall bundle-api generate-api generate-go-api generate-go-server-api generate-go-client-api generate-ui-api generate-wire wire-smoke api-smoke api-package-pack-smoke contracts-validate contracts-generate contracts-check contracts-smoke cli-manifest-generate cli-manifest-check docs-reference-check docs-reference-smoke test test-full test-functional test-functional-long verify-fast verify-pr verify-pr-inference verify-extended verify-build-contracts verify-tests run-concurrent-ui-verification-lanes run-sharded-ui-coverage verify test-ui-coverage test-ui-coverage-merge test-ui-browser-integration test-ui-durable-session-real-backend test-backend-coverage test-backend-functional test-backend-verification test-built-cli-acceptance long-tests long-tests-managed-runtime long-tests-functional-runtime pr-inference-approval test-coverage-go script-timeout-companion-smoke-100 cron-time-work-smoke current-factory-watcher-switch-smoke provider-parity-smoke response-stream-stress-smoke release-surface-smoke artifact-contract-closeout lint backend-size pkg-maint pkg-file-count pkg-boundary durable-runtime-construction-check logging-boundary-check compatibility-alias-check retired-surface-check model-facade-check readme-check deadcode ui-deadcode test-race fmt vet deps deps-tidy init dashboard-verify typecheck release ci ci-typecheck ci-verify-build-contracts ci-verify-tests ui-deps ui-lint ui-build ui-test ui-integration-test ui-durable-session-real-backend-integration-test ui-test-coverage ui-replay-coverage-check ui-install-playwright ui-storybook ui-test-storybook ui-components-typecheck ui-components-test ui-components-storybook ui-components-boundary ui-components-dependency-direction ui-components-verify ui-verify-fresh-npm-install clean
+.PHONY: default build intall bundle-api generate-api generate-go-api generate-go-server-api generate-go-client-api generate-ui-api generate-wire wire-smoke api-smoke api-package-pack-smoke contracts-validate contracts-generate contracts-check contracts-smoke cli-manifest-generate cli-manifest-check docs-reference-check docs-reference-smoke test test-full test-functional test-functional-long verify-fast verify-pr verify-pr-inference verify-extended verify-build-contracts verify-tests run-concurrent-ui-verification-lanes run-sharded-ui-coverage verify test-ui-coverage test-ui-coverage-merge test-ui-browser-integration test-ui-durable-session-real-backend test-backend-coverage test-backend-functional test-backend-verification test-built-cli-acceptance long-tests long-tests-managed-runtime long-tests-functional-runtime pr-inference-approval test-coverage-go script-timeout-companion-smoke-100 cron-time-work-smoke current-factory-watcher-switch-smoke provider-parity-smoke javascript-contract-smoke response-stream-stress-smoke release-surface-smoke artifact-contract-closeout lint backend-size pkg-maint pkg-file-count pkg-boundary durable-runtime-construction-check logging-boundary-check compatibility-alias-check retired-surface-check model-facade-check readme-check deadcode ui-deadcode test-race fmt vet deps deps-tidy init dashboard-verify typecheck release ci ci-typecheck ci-verify-build-contracts ci-verify-tests ui-deps ui-lint ui-build ui-test ui-integration-test ui-durable-session-real-backend-integration-test ui-test-coverage ui-replay-coverage-check ui-install-playwright ui-storybook ui-test-storybook ui-components-typecheck ui-components-test ui-components-storybook ui-components-boundary ui-components-dependency-direction ui-components-verify ui-verify-fresh-npm-install clean
 
 default:
 	$(MAKE) generate-api
@@ -261,6 +262,11 @@ current-factory-watcher-switch-smoke:
 
 provider-parity-smoke:
 	$(GO) test ./pkg/workers/provider/parityfixtures ./tests/functional/providers -run $(CROSS_PROVIDER_PARITY_SMOKE_TEST) -count=1 -timeout $(CROSS_PROVIDER_PARITY_SMOKE_TIMEOUT)
+
+javascript-contract-smoke:
+	$(GO) run ./cmd/javascriptcontractsmoke -root .
+	$(GO) run ./cmd/javascriptcontractsmoke -root .
+	$(GO) test ./internal/javascriptcontractsmoke ./cmd/javascriptcontractsmoke -count=1 -timeout $(JAVASCRIPT_CONTRACT_SMOKE_TIMEOUT)
 
 response-stream-stress-smoke:
 	$(GO) test ./pkg/factory/sessions/responseeventstore -run $(RESPONSE_STREAM_STRESS_SMOKE_TEST) -count=1 -timeout $(RESPONSE_STREAM_STRESS_SMOKE_TIMEOUT)

--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ javascript-contract-smoke:
 	$(GO) run ./cmd/javascriptcontractsmoke -root .
 	$(GO) run ./cmd/javascriptcontractsmoke -root .
 	$(GO) test ./internal/javascriptcontractsmoke ./cmd/javascriptcontractsmoke -count=1 -timeout $(JAVASCRIPT_CONTRACT_SMOKE_TIMEOUT)
-	$(GO) test ./contracts -run '^TestJavaScriptRuntimePackagesDoNot(ImportContractTooling|LoadContractManifests)$$' -count=1 -timeout $(JAVASCRIPT_CONTRACT_SMOKE_TIMEOUT)
+	$(GO) test ./contracts -run '^TestJavaScriptRuntimeBehaviorDoesNotLoadContractManifests$$' -count=1 -timeout $(JAVASCRIPT_CONTRACT_SMOKE_TIMEOUT)
 	$(GO) test ./pkg/orchestrators/javascript/runtime -run '$(JAVASCRIPT_RUNTIME_REGRESSION_TESTS)' -count=1 -timeout $(JAVASCRIPT_CONTRACT_SMOKE_TIMEOUT)
 
 response-stream-stress-smoke:

--- a/Makefile
+++ b/Makefile
@@ -267,6 +267,7 @@ javascript-contract-smoke:
 	$(GO) run ./cmd/javascriptcontractsmoke -root .
 	$(GO) run ./cmd/javascriptcontractsmoke -root .
 	$(GO) test ./internal/javascriptcontractsmoke ./cmd/javascriptcontractsmoke -count=1 -timeout $(JAVASCRIPT_CONTRACT_SMOKE_TIMEOUT)
+	$(GO) test ./contracts -run '^TestJavaScriptRuntimePackagesDoNot(ImportContractTooling|LoadContractManifests)$$' -count=1 -timeout $(JAVASCRIPT_CONTRACT_SMOKE_TIMEOUT)
 
 response-stream-stress-smoke:
 	$(GO) test ./pkg/factory/sessions/responseeventstore -run $(RESPONSE_STREAM_STRESS_SMOKE_TEST) -count=1 -timeout $(RESPONSE_STREAM_STRESS_SMOKE_TIMEOUT)

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ CURRENT_FACTORY_WATCHER_SWITCH_SMOKE_TIMEOUT ?= 120s
 CROSS_PROVIDER_PARITY_SMOKE_TEST := TestCrossProviderParity
 CROSS_PROVIDER_PARITY_SMOKE_TIMEOUT ?= 120s
 JAVASCRIPT_CONTRACT_SMOKE_TIMEOUT ?= 120s
+JAVASCRIPT_RUNTIME_REGRESSION_TESTS ?= ^(TestCallBehavior_WorkflowFinalInventoryMatchesExecution|TestCallBehavior_AgentRunInventoryMatchesExecution|TestRun_ProgressPrimitives_EmitsOrderedRuntimeRecords|TestRun_PolicyDeniedChildOperations_ReturnStableDiagnostics|TestCallBehavior_WorkflowResumeStateInventoryMatchesExecution)$$
 RESPONSE_STREAM_STRESS_SMOKE_TEST := TestSessionResponseEventStore_Backpressure
 RESPONSE_STREAM_STRESS_SMOKE_TIMEOUT ?= 120s
 BUILT_CLI_ACCEPTANCE_PACKAGES := ./tests/functional/acceptance
@@ -268,6 +269,7 @@ javascript-contract-smoke:
 	$(GO) run ./cmd/javascriptcontractsmoke -root .
 	$(GO) test ./internal/javascriptcontractsmoke ./cmd/javascriptcontractsmoke -count=1 -timeout $(JAVASCRIPT_CONTRACT_SMOKE_TIMEOUT)
 	$(GO) test ./contracts -run '^TestJavaScriptRuntimePackagesDoNot(ImportContractTooling|LoadContractManifests)$$' -count=1 -timeout $(JAVASCRIPT_CONTRACT_SMOKE_TIMEOUT)
+	$(GO) test ./pkg/orchestrators/javascript/runtime -run '$(JAVASCRIPT_RUNTIME_REGRESSION_TESTS)' -count=1 -timeout $(JAVASCRIPT_CONTRACT_SMOKE_TIMEOUT)
 
 response-stream-stress-smoke:
 	$(GO) test ./pkg/factory/sessions/responseeventstore -run $(RESPONSE_STREAM_STRESS_SMOKE_TEST) -count=1 -timeout $(RESPONSE_STREAM_STRESS_SMOKE_TIMEOUT)

--- a/cmd/javascriptcontractsmoke/main.go
+++ b/cmd/javascriptcontractsmoke/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/portpowered/infinite-you/internal/javascriptcontractsmoke"
+)
+
+const successMessage = "[agent-factory:javascript-contract-smoke] catalog, projection, binding descriptor, and behavior baseline are aligned"
+
+func main() {
+	root := flag.String("root", ".", "repository root")
+	flag.Parse()
+	os.Exit(run(*root, os.Stdout, os.Stderr))
+}
+
+func run(root string, stdout, stderr io.Writer) int {
+	diagnostics, err := javascriptcontractsmoke.Check(root)
+	if err != nil {
+		fmt.Fprintf(stderr, "[agent-factory:javascript-contract-smoke] check failed: %v\n", err)
+		return 1
+	}
+	if len(diagnostics) > 0 {
+		for _, diagnostic := range diagnostics {
+			fmt.Fprintf(
+				stderr,
+				"[agent-factory:javascript-contract-smoke] %s (%s): %s\n",
+				diagnostic.Path,
+				diagnostic.Code,
+				diagnostic.Message,
+			)
+		}
+		fmt.Fprintln(stderr, "[agent-factory:javascript-contract-smoke] JavaScript contract parity failed; restore catalog, staging, binding descriptor, and call-behavior baseline alignment")
+		return 1
+	}
+
+	fmt.Fprintln(stdout, successMessage)
+	return 0
+}

--- a/cmd/javascriptcontractsmoke/main_test.go
+++ b/cmd/javascriptcontractsmoke/main_test.go
@@ -126,6 +126,43 @@ func TestRunReportsDuplicatePathDeterministicallyWithoutWriting(t *testing.T) {
 	assertRunPathFailureDeterministic(t, root, "phase", "javascript.path.duplicate")
 }
 
+func TestRunReportsIncompleteCallBehaviorDeterministicallyWithoutWriting(t *testing.T) {
+	root := mutationFixtureRoot(t)
+	mutateCatalogFixture(t, root, func(catalog map[string]any) {
+		symbols := catalog["symbols"].(map[string]any)
+		checkpoint := symbols["javascript.workflow.checkpoint"].(map[string]any)
+		delete(checkpoint, "emittedRecords")
+	})
+
+	before := repositoryTree(t, root)
+	wantSuffix := "[agent-factory:javascript-contract-smoke] JavaScript contract parity failed; restore catalog, staging, binding descriptor, and call-behavior baseline alignment\n"
+	for runIndex := 0; runIndex < 2; runIndex++ {
+		stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+		if status := run(root, stdout, stderr); status != 1 {
+			t.Fatalf("run %d status = %d, want 1", runIndex, status)
+		}
+		if stdout.Len() != 0 {
+			t.Fatalf("run %d stdout = %q, want empty", runIndex, stdout.String())
+		}
+		output := stderr.String()
+		if !strings.Contains(output, "workflow.checkpoint (javascript.call_behavior.mismatch):") {
+			t.Fatalf("run %d stderr = %q, want symbol path and behavior code", runIndex, output)
+		}
+		if !strings.Contains(output, "/symbols/javascript.workflow.checkpoint/emittedRecords") {
+			t.Fatalf("run %d stderr = %q, want incomplete field path", runIndex, output)
+		}
+		if !strings.Contains(output, "restore catalog call metadata parity with the installed call-behavior baseline") {
+			t.Fatalf("run %d stderr = %q, want actionable baseline remediation", runIndex, output)
+		}
+		if !strings.HasSuffix(output, wantSuffix) {
+			t.Fatalf("run %d stderr = %q, want parity failure suffix", runIndex, output)
+		}
+	}
+	if after := repositoryTree(t, root); !mapsEqual(after, before) {
+		t.Fatal("run() changed incomplete call-behavior fixture bytes")
+	}
+}
+
 func TestRunReportsStaleProjectionDeterministicallyWithoutWriting(t *testing.T) {
 	root := mutationFixtureRoot(t)
 	stagedPath := filepath.Join(root, filepath.FromSlash(javascriptcontractsmoke.StagedProjectionRelativePath))

--- a/cmd/javascriptcontractsmoke/main_test.go
+++ b/cmd/javascriptcontractsmoke/main_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/javascriptcontractsmoke"
+)
+
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(1)
+	if !ok {
+		t.Fatal("cannot determine test file path")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find module root from test file")
+		}
+		dir = parent
+	}
+}
+
+func TestRunPassesCleanRepositoryWithoutWriting(t *testing.T) {
+	root := moduleRoot(t)
+	before := repositoryTree(t, root)
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+
+	if status := run(root, stdout, stderr); status != 0 {
+		t.Fatalf("run() status = %d, want 0; stderr = %q", status, stderr)
+	}
+	if got := stdout.String(); got != successMessage+"\n" || stderr.Len() != 0 {
+		t.Fatalf("run() stdout = %q, stderr = %q", got, stderr.String())
+	}
+	if after := repositoryTree(t, root); !mapsEqual(after, before) {
+		t.Fatal("run() changed repository bytes on success")
+	}
+}
+
+func TestRunRepeatPassesAreDeterministicWithoutWriting(t *testing.T) {
+	root := moduleRoot(t)
+	before := repositoryTree(t, root)
+
+	for runIndex := 0; runIndex < 2; runIndex++ {
+		stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+		if status := run(root, stdout, stderr); status != 0 {
+			t.Fatalf("run %d status = %d, want 0; stderr = %q", runIndex, status, stderr)
+		}
+		if got := stdout.String(); got != successMessage+"\n" || stderr.Len() != 0 {
+			t.Fatalf("run %d stdout = %q, stderr = %q", runIndex, got, stderr.String())
+		}
+	}
+	if after := repositoryTree(t, root); !mapsEqual(after, before) {
+		t.Fatal("run() changed repository bytes across repeat passes")
+	}
+}
+
+func TestRunReportsStaleProjectionDeterministicallyWithoutWriting(t *testing.T) {
+	root := mutationFixtureRoot(t)
+	stagedPath := filepath.Join(root, filepath.FromSlash(javascriptcontractsmoke.StagedProjectionRelativePath))
+	original, err := os.ReadFile(stagedPath)
+	if err != nil {
+		t.Fatalf("read staged projection: %v", err)
+	}
+	if err := os.WriteFile(stagedPath, append(original, '\n'), 0o644); err != nil {
+		t.Fatalf("mutate staged projection: %v", err)
+	}
+
+	want := strings.Join([]string{
+		"[agent-factory:javascript-contract-smoke] packages/api/generated/javascript/runtime-api.json (javascript.projection.stale): staged JavaScript runtime projection diverges from the authored catalog; run `make contracts-generate` and `make contracts-check` to restore staging parity",
+		"[agent-factory:javascript-contract-smoke] JavaScript contract parity failed; restore catalog, staging, binding descriptor, and call-behavior baseline alignment",
+		"",
+	}, "\n")
+
+	for runIndex := 0; runIndex < 2; runIndex++ {
+		stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+		if status := run(root, stdout, stderr); status != 1 {
+			t.Fatalf("run %d status = %d, want 1", runIndex, status)
+		}
+		if stdout.Len() != 0 || stderr.String() != want {
+			t.Fatalf("run %d stdout = %q, stderr = %q, want %q", runIndex, stdout, stderr, want)
+		}
+	}
+}
+
+func mutationFixtureRoot(t *testing.T) string {
+	t.Helper()
+
+	repoRoot := moduleRoot(t)
+	root := t.TempDir()
+	for _, rel := range []string{
+		javascriptcontractsmoke.AuthoredCatalogRelativePath,
+		javascriptcontractsmoke.StagedProjectionRelativePath,
+	} {
+		source := filepath.Join(repoRoot, filepath.FromSlash(rel))
+		target := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			t.Fatalf("create fixture directory for %s: %v", rel, err)
+		}
+		data, err := os.ReadFile(source)
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		if err := os.WriteFile(target, data, 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	return root
+}
+
+func repositoryTree(t *testing.T, root string) map[string][]byte {
+	t.Helper()
+
+	paths := []string{
+		javascriptcontractsmoke.AuthoredCatalogRelativePath,
+		javascriptcontractsmoke.StagedProjectionRelativePath,
+	}
+	tree := make(map[string][]byte, len(paths))
+	for _, rel := range paths {
+		data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		tree[rel] = append([]byte(nil), data...)
+	}
+	return tree
+}
+
+func mapsEqual(left, right map[string][]byte) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for key, value := range left {
+		other, ok := right[key]
+		if !ok || !bytes.Equal(value, other) {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/javascriptcontractsmoke/main_test.go
+++ b/cmd/javascriptcontractsmoke/main_test.go
@@ -66,6 +66,32 @@ func TestRunRepeatPassesAreDeterministicWithoutWriting(t *testing.T) {
 	}
 }
 
+func TestRunReportsForbiddenRootDeterministicallyWithoutWriting(t *testing.T) {
+	root := mutationFixtureRoot(t)
+	mutateCatalogFixture(t, root, func(catalog map[string]any) {
+		symbols := catalog["symbols"].(map[string]any)
+		symbols["javascript.context"] = map[string]any{
+			"path": "context",
+			"kind": "value",
+		}
+	})
+
+	assertRunForbiddenFailureDeterministic(t, root, "context", "javascript.path.forbidden")
+}
+
+func TestRunReportsComparisonHelperDeterministicallyWithoutWriting(t *testing.T) {
+	root := mutationFixtureRoot(t)
+	mutateCatalogFixture(t, root, func(catalog map[string]any) {
+		symbols := catalog["symbols"].(map[string]any)
+		symbols["javascript.workflow.sleep"] = map[string]any{
+			"path": "workflow.sleep",
+			"kind": "method",
+		}
+	})
+
+	assertRunForbiddenFailureDeterministic(t, root, "workflow.sleep", "javascript.path.unsupported_helper")
+}
+
 func TestRunReportsMissingPathDeterministicallyWithoutWriting(t *testing.T) {
 	root := mutationFixtureRoot(t)
 	mutateCatalogFixture(t, root, func(catalog map[string]any) {
@@ -182,6 +208,32 @@ func mapsEqual(left, right map[string][]byte) bool {
 		}
 	}
 	return true
+}
+
+func assertRunForbiddenFailureDeterministic(t *testing.T, root, path, code string) {
+	t.Helper()
+
+	wantSuffix := "[agent-factory:javascript-contract-smoke] JavaScript contract parity failed; restore catalog, staging, binding descriptor, and call-behavior baseline alignment\n"
+
+	for runIndex := 0; runIndex < 2; runIndex++ {
+		stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+		if status := run(root, stdout, stderr); status != 1 {
+			t.Fatalf("run %d status = %d, want 1", runIndex, status)
+		}
+		if stdout.Len() != 0 {
+			t.Fatalf("run %d stdout = %q, want empty", runIndex, stdout.String())
+		}
+		output := stderr.String()
+		if !strings.Contains(output, path+" ("+code+"):") {
+			t.Fatalf("run %d stderr = %q, want path %q and code %q", runIndex, output, path, code)
+		}
+		if !strings.Contains(output, "remove the path from the contracted supported surface") {
+			t.Fatalf("run %d stderr = %q, want actionable remediation", runIndex, output)
+		}
+		if !strings.HasSuffix(output, wantSuffix) {
+			t.Fatalf("run %d stderr = %q, want parity failure suffix", runIndex, output)
+		}
+	}
 }
 
 func assertRunPathFailureDeterministic(t *testing.T, root, path, code string) {

--- a/cmd/javascriptcontractsmoke/main_test.go
+++ b/cmd/javascriptcontractsmoke/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -63,6 +64,40 @@ func TestRunRepeatPassesAreDeterministicWithoutWriting(t *testing.T) {
 	if after := repositoryTree(t, root); !mapsEqual(after, before) {
 		t.Fatal("run() changed repository bytes across repeat passes")
 	}
+}
+
+func TestRunReportsMissingPathDeterministicallyWithoutWriting(t *testing.T) {
+	root := mutationFixtureRoot(t)
+	mutateCatalogFixture(t, root, func(catalog map[string]any) {
+		symbols := catalog["symbols"].(map[string]any)
+		delete(symbols, "javascript.phase")
+	})
+
+	assertRunPathFailureDeterministic(t, root, "phase", "javascript.path.missing")
+}
+
+func TestRunReportsExtraPathDeterministicallyWithoutWriting(t *testing.T) {
+	root := mutationFixtureRoot(t)
+	mutateCatalogFixture(t, root, func(catalog map[string]any) {
+		symbols := catalog["symbols"].(map[string]any)
+		symbols["javascript.workflow.extra"] = map[string]any{
+			"path": "workflow.extra",
+		}
+	})
+
+	assertRunPathFailureDeterministic(t, root, "workflow.extra", "javascript.path.extra")
+}
+
+func TestRunReportsDuplicatePathDeterministicallyWithoutWriting(t *testing.T) {
+	root := mutationFixtureRoot(t)
+	mutateCatalogFixture(t, root, func(catalog map[string]any) {
+		symbols := catalog["symbols"].(map[string]any)
+		symbols["javascript.duplicate-phase"] = map[string]any{
+			"path": "phase",
+		}
+	})
+
+	assertRunPathFailureDeterministic(t, root, "phase", "javascript.path.duplicate")
 }
 
 func TestRunReportsStaleProjectionDeterministicallyWithoutWriting(t *testing.T) {
@@ -147,4 +182,62 @@ func mapsEqual(left, right map[string][]byte) bool {
 		}
 	}
 	return true
+}
+
+func assertRunPathFailureDeterministic(t *testing.T, root, path, code string) {
+	t.Helper()
+
+	wantSuffix := "[agent-factory:javascript-contract-smoke] JavaScript contract parity failed; restore catalog, staging, binding descriptor, and call-behavior baseline alignment\n"
+
+	for runIndex := 0; runIndex < 2; runIndex++ {
+		stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+		if status := run(root, stdout, stderr); status != 1 {
+			t.Fatalf("run %d status = %d, want 1", runIndex, status)
+		}
+		if stdout.Len() != 0 {
+			t.Fatalf("run %d stdout = %q, want empty", runIndex, stdout.String())
+		}
+		output := stderr.String()
+		if !strings.Contains(output, path+" ("+code+"):") {
+			t.Fatalf("run %d stderr = %q, want path %q and code %q", runIndex, output, path, code)
+		}
+		if !strings.Contains(output, "restore authored catalog and staging parity") {
+			t.Fatalf("run %d stderr = %q, want actionable remediation", runIndex, output)
+		}
+		if !strings.HasSuffix(output, wantSuffix) {
+			t.Fatalf("run %d stderr = %q, want parity failure suffix", runIndex, output)
+		}
+	}
+}
+
+func mutateCatalogFixture(t *testing.T, root string, mutate func(map[string]any)) {
+	t.Helper()
+
+	authoredPath := filepath.Join(root, filepath.FromSlash(javascriptcontractsmoke.AuthoredCatalogRelativePath))
+	data, err := os.ReadFile(authoredPath)
+	if err != nil {
+		t.Fatalf("read authored catalog: %v", err)
+	}
+
+	var catalog map[string]any
+	if err := json.Unmarshal(data, &catalog); err != nil {
+		t.Fatalf("decode authored catalog: %v", err)
+	}
+	mutate(catalog)
+
+	updated, err := json.MarshalIndent(catalog, "", "  ")
+	if err != nil {
+		t.Fatalf("encode catalog fixture: %v", err)
+	}
+	updated = append(updated, '\n')
+
+	for _, rel := range []string{
+		javascriptcontractsmoke.AuthoredCatalogRelativePath,
+		javascriptcontractsmoke.StagedProjectionRelativePath,
+	} {
+		target := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.WriteFile(target, updated, 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
 }

--- a/contracts/runtime_manifest_boundary_test.go
+++ b/contracts/runtime_manifest_boundary_test.go
@@ -1,153 +1,166 @@
 package contracts_test
 
 import (
+	"bytes"
 	"encoding/json"
-	"go/ast"
-	"go/parser"
-	"go/token"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"slices"
-	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/portpowered/infinite-you/internal/contractstaging"
 	"github.com/portpowered/infinite-you/internal/testpath"
+	workflowpolicy "github.com/portpowered/infinite-you/pkg/orchestrators/javascript/policy"
+	workflowruntime "github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime"
 )
-
-var forbiddenContractToolingImports = []string{
-	"github.com/portpowered/infinite-you/internal/contract",
-	"github.com/portpowered/infinite-you/internal/javascriptcontractsmoke",
-	"github.com/portpowered/infinite-you/contracts",
-}
 
 const (
-	repositoryImportPrefix          = "github.com/portpowered/infinite-you/"
-	javascriptRuntimePackagePattern = repositoryImportPrefix + "pkg/orchestrators/javascript/..."
+	runtimeWithoutManifestsHelper = "YOU_TEST_RUNTIME_WITHOUT_MANIFESTS"
+	runtimeBehaviorSnapshotPath   = "YOU_TEST_RUNTIME_BEHAVIOR_SNAPSHOT"
 )
 
-var forbiddenRuntimeManifestNames = []string{
-	"runtime-api.json",
-	"runtime-manifest.schema.json",
+type runtimeBehaviorSnapshot struct {
+	InvocationValue   string                          `json:"invocationValue"`
+	InvocationRecords []workflowruntime.RuntimeRecord `json:"invocationRecords"`
+	ResumeValue       string                          `json:"resumeValue"`
+	DeniedFailure     workflowruntime.Failure         `json:"deniedFailure"`
+	DeniedRecords     []workflowruntime.RuntimeRecord `json:"deniedRecords"`
 }
 
-type listedJavaScriptPackage struct {
-	Dir        string
-	ImportPath string
-	GoFiles    []string
-	CgoFiles   []string
-}
+func TestJavaScriptRuntimeBehaviorDoesNotLoadContractManifests(t *testing.T) {
+	if os.Getenv(runtimeWithoutManifestsHelper) == "1" {
+		writeRuntimeBehaviorSnapshot(t, captureRuntimeBehavior(t))
+		return
+	}
 
-func TestJavaScriptRuntimePackagesDoNotImportContractTooling(t *testing.T) {
-	t.Parallel()
+	baseline := marshalRuntimeBehaviorSnapshot(t, captureRuntimeBehavior(t))
+	root := t.TempDir()
+	for _, relativePath := range []string{
+		filepath.Join("contracts", "javascript", "runtime-api.json"),
+		filepath.Join("contracts", "javascript", "runtime-manifest.schema.json"),
+		filepath.Join("packages", "api", "generated", "javascript", "runtime-api.json"),
+	} {
+		writeUnusableManifest(t, root, relativePath)
+	}
 
-	cmd := exec.Command(
-		"go",
-		"list",
-		"-deps",
-		"-f",
-		"{{if not .Standard}}{{.ImportPath}}{{end}}",
-		javascriptRuntimePackagePattern,
+	cmd := exec.Command(os.Args[0], "-test.run=^TestJavaScriptRuntimeBehaviorDoesNotLoadContractManifests$")
+	cmd.Dir = root
+	snapshotPath := filepath.Join(root, "runtime-behavior.json")
+	cmd.Env = append(os.Environ(),
+		runtimeWithoutManifestsHelper+"=1",
+		runtimeBehaviorSnapshotPath+"="+snapshotPath,
 	)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("go list JavaScript runtime dependencies: %v\n%s", err, output)
+		t.Fatalf("execute JavaScript runtime with unusable contract manifests: %v\n%s", err, output)
 	}
-
-	for _, dependency := range strings.Fields(string(output)) {
-		for _, forbidden := range forbiddenContractToolingImports {
-			if dependency == forbidden || strings.HasPrefix(dependency, forbidden+"/") {
-				t.Fatalf(
-					"JavaScript runtime packages must not depend on contract tooling %s; found %s",
-					forbidden,
-					dependency,
-				)
-			}
-		}
+	withoutManifests, err := os.ReadFile(snapshotPath)
+	if err != nil {
+		t.Fatalf("read runtime behavior snapshot: %v", err)
+	}
+	if !bytes.Equal(withoutManifests, baseline) {
+		t.Fatalf("runtime behavior changed with unusable manifests:\nbaseline: %s\nunusable: %s", baseline, withoutManifests)
 	}
 }
 
-func TestJavaScriptRuntimePackagesDoNotLoadContractManifests(t *testing.T) {
-	t.Parallel()
-
-	for _, pkg := range listJavaScriptRuntimePackages(t) {
-		files := append(slices.Clone(pkg.GoFiles), pkg.CgoFiles...)
-		slices.Sort(files)
-		for _, file := range files {
-			path := filepath.Join(pkg.Dir, file)
-			repositoryPath := filepath.ToSlash(filepath.Join(strings.TrimPrefix(pkg.ImportPath, repositoryImportPrefix), file))
-			for _, reference := range runtimeManifestReferences(t, path) {
-				t.Errorf(
-					"JavaScript runtime package %s loads contract manifest %q in %s; remove the runtime dependency and keep contract comparison in structural tooling",
-					pkg.ImportPath,
-					reference,
-					repositoryPath,
-				)
-			}
-		}
+func writeUnusableManifest(t *testing.T, root, relativePath string) {
+	t.Helper()
+	path := filepath.Join(root, relativePath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create unusable manifest directory: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{not-valid-json"), 0o600); err != nil {
+		t.Fatalf("write unusable manifest %s: %v", filepath.ToSlash(relativePath), err)
 	}
 }
 
-func listJavaScriptRuntimePackages(t *testing.T) []listedJavaScriptPackage {
+func captureRuntimeBehavior(t *testing.T) runtimeBehaviorSnapshot {
 	t.Helper()
 
-	cmd := exec.Command("go", "list", "-json", javascriptRuntimePackagePattern)
-	output, err := cmd.Output()
-	if err != nil {
-		t.Fatalf("go list JavaScript runtime packages: %v", err)
+	invocation := runJavaScript(t, workflowruntime.Request{
+		Source: `
+workflow.checkpoint({ label: "manifest-independent", state: { step: 1 } });
+workflow.final({ status: "complete" });
+`,
+		SourceRef: "manifest-independent-invocation.js",
+		SessionID: "manifest-independent-invocation",
+		Policy:    workflowpolicy.DefaultEffectivePolicy(),
+	})
+	if !invocation.OK || string(invocation.Value.JSON) != `{"status":"complete"}` {
+		t.Fatalf("invocation outcome = %#v, want successful manifest-independent final", invocation)
+	}
+	if len(invocation.Records) != 1 || invocation.Records[0].Kind != workflowruntime.RecordKindCheckpoint {
+		t.Fatalf("invocation records = %#v, want one checkpoint record", invocation.Records)
 	}
 
-	decoder := json.NewDecoder(strings.NewReader(string(output)))
-	var packages []listedJavaScriptPackage
-	for {
-		var pkg listedJavaScriptPackage
-		err := decoder.Decode(&pkg)
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			t.Fatalf("decode listed JavaScript runtime package: %v", err)
-		}
-		packages = append(packages, pkg)
-	}
-	slices.SortFunc(packages, func(left, right listedJavaScriptPackage) int {
-		return strings.Compare(left.ImportPath, right.ImportPath)
+	resume := runJavaScript(t, workflowruntime.Request{
+		Source:    `return { resumedStep: workflow.resumeState().step };`,
+		SourceRef: "manifest-independent-resume.js",
+		SessionID: "manifest-independent-resume",
+		Policy:    workflowpolicy.DefaultEffectivePolicy(),
+		Resume: &workflowruntime.ResumeContext{CheckpointState: map[string]any{
+			"step": float64(2),
+		}},
 	})
-	return packages
+	if !resume.OK || string(resume.Value.JSON) != `{"resumedStep":2}` {
+		t.Fatalf("resume outcome = %#v, want restored checkpoint state", resume)
+	}
+
+	maxArtifactBytes := int64(1)
+	deniedPolicy := workflowpolicy.DefaultEffectivePolicy()
+	deniedPolicy.MaxArtifactBytes = &maxArtifactBytes
+	denied := runJavaScript(t, workflowruntime.Request{
+		Source:    `workflow.artifact({ kind: "report", label: "oversized", content: { body: "too large" } }); return { ok: true };`,
+		SourceRef: "manifest-independent-policy.js",
+		SessionID: "manifest-independent-policy",
+		Policy:    deniedPolicy,
+	})
+	if denied.OK || denied.Failure.Code != workflowruntime.CodeScriptError || !strings.Contains(denied.Failure.Message, "policy denied") {
+		t.Fatalf("policy outcome = %#v, want stable policy denial", denied)
+	}
+	for _, record := range denied.Records {
+		if record.Kind == workflowruntime.RecordKindArtifact {
+			t.Fatalf("policy denial emitted artifact record: %#v", denied.Records)
+		}
+	}
+
+	return runtimeBehaviorSnapshot{
+		InvocationValue:   string(invocation.Value.JSON),
+		InvocationRecords: invocation.Records,
+		ResumeValue:       string(resume.Value.JSON),
+		DeniedFailure:     denied.Failure,
+		DeniedRecords:     denied.Records,
+	}
 }
 
-func runtimeManifestReferences(t *testing.T, path string) []string {
+func writeRuntimeBehaviorSnapshot(t *testing.T, snapshot runtimeBehaviorSnapshot) {
 	t.Helper()
-
-	parsed, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
-	if err != nil {
-		t.Fatalf("parse JavaScript runtime source %s: %v", filepath.ToSlash(path), err)
+	path := os.Getenv(runtimeBehaviorSnapshotPath)
+	if path == "" {
+		t.Fatal("runtime behavior snapshot path is required in helper process")
 	}
+	if err := os.WriteFile(path, marshalRuntimeBehaviorSnapshot(t, snapshot), 0o600); err != nil {
+		t.Fatalf("write runtime behavior snapshot: %v", err)
+	}
+}
 
-	var references []string
-	ast.Inspect(parsed, func(node ast.Node) bool {
-		literal, ok := node.(*ast.BasicLit)
-		if !ok || literal.Kind != token.STRING {
-			return true
-		}
-		value, err := strconv.Unquote(literal.Value)
-		if err != nil {
-			return true
-		}
-		normalized := strings.ReplaceAll(value, `\`, "/")
-		for _, forbiddenName := range forbiddenRuntimeManifestNames {
-			if normalized == forbiddenName || strings.HasSuffix(normalized, "/"+forbiddenName) {
-				references = append(references, value)
-				break
-			}
-		}
-		return true
-	})
-	slices.Sort(references)
-	return references
+func marshalRuntimeBehaviorSnapshot(t *testing.T, snapshot runtimeBehaviorSnapshot) []byte {
+	t.Helper()
+	raw, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("marshal runtime behavior snapshot: %v", err)
+	}
+	return raw
+}
+
+func runJavaScript(t *testing.T, request workflowruntime.Request) workflowruntime.Outcome {
+	t.Helper()
+	outcome, err := workflowruntime.Run(t.Context(), request, workflowruntime.Hooks{})
+	if err != nil {
+		t.Fatalf("run JavaScript workflow: %v", err)
+	}
+	return outcome
 }
 
 func TestJavaScriptAuthoredCatalogBoundary(t *testing.T) {

--- a/contracts/runtime_manifest_boundary_test.go
+++ b/contracts/runtime_manifest_boundary_test.go
@@ -1,8 +1,16 @@
 package contracts_test
 
 import (
+	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -10,61 +18,136 @@ import (
 	"github.com/portpowered/infinite-you/internal/testpath"
 )
 
-var javascriptRuntimePackages = []string{
-	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/childcontract",
-	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/policy",
-	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/preview",
-	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/result",
-	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime",
-	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/callbehavior",
-	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/catalog",
-	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/symbolidentity",
-	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/source",
-	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/store",
-	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/validation",
+var forbiddenContractToolingImports = []string{
+	"github.com/portpowered/infinite-you/internal/contract",
+	"github.com/portpowered/infinite-you/internal/javascriptcontractsmoke",
+	"github.com/portpowered/infinite-you/contracts",
 }
 
-var forbiddenContractToolingImports = []string{
-	"github.com/portpowered/infinite-you/internal/contractvalidator",
-	"github.com/portpowered/infinite-you/internal/contractstaging",
-	"github.com/portpowered/infinite-you/contracts",
+const (
+	repositoryImportPrefix          = "github.com/portpowered/infinite-you/"
+	javascriptRuntimePackagePattern = repositoryImportPrefix + "pkg/orchestrators/javascript/..."
+)
+
+var forbiddenRuntimeManifestNames = []string{
+	"runtime-api.json",
+	"runtime-manifest.schema.json",
+}
+
+type listedJavaScriptPackage struct {
+	Dir        string
+	ImportPath string
+	GoFiles    []string
+	CgoFiles   []string
 }
 
 func TestJavaScriptRuntimePackagesDoNotImportContractTooling(t *testing.T) {
 	t.Parallel()
 
-	for _, pkg := range javascriptRuntimePackages {
-		pkg := pkg
-		t.Run(pkg, func(t *testing.T) {
-			t.Parallel()
-
-			cmd := exec.Command(
-				"go",
-				"list",
-				"-deps",
-				"-f",
-				"{{if not .Standard}}{{.ImportPath}}{{end}}",
-				pkg,
-			)
-			output, err := cmd.CombinedOutput()
-			if err != nil {
-				t.Fatalf("go list dependencies: %v\n%s", err, output)
-			}
-
-			for _, dependency := range strings.Fields(string(output)) {
-				for _, forbidden := range forbiddenContractToolingImports {
-					if dependency == forbidden || strings.HasPrefix(dependency, forbidden+"/") {
-						t.Fatalf(
-							"runtime package %s must not depend on contract tooling %s; found %s",
-							pkg,
-							forbidden,
-							dependency,
-						)
-					}
-				}
-			}
-		})
+	cmd := exec.Command(
+		"go",
+		"list",
+		"-deps",
+		"-f",
+		"{{if not .Standard}}{{.ImportPath}}{{end}}",
+		javascriptRuntimePackagePattern,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list JavaScript runtime dependencies: %v\n%s", err, output)
 	}
+
+	for _, dependency := range strings.Fields(string(output)) {
+		for _, forbidden := range forbiddenContractToolingImports {
+			if dependency == forbidden || strings.HasPrefix(dependency, forbidden+"/") {
+				t.Fatalf(
+					"JavaScript runtime packages must not depend on contract tooling %s; found %s",
+					forbidden,
+					dependency,
+				)
+			}
+		}
+	}
+}
+
+func TestJavaScriptRuntimePackagesDoNotLoadContractManifests(t *testing.T) {
+	t.Parallel()
+
+	for _, pkg := range listJavaScriptRuntimePackages(t) {
+		files := append(slices.Clone(pkg.GoFiles), pkg.CgoFiles...)
+		slices.Sort(files)
+		for _, file := range files {
+			path := filepath.Join(pkg.Dir, file)
+			repositoryPath := filepath.ToSlash(filepath.Join(strings.TrimPrefix(pkg.ImportPath, repositoryImportPrefix), file))
+			for _, reference := range runtimeManifestReferences(t, path) {
+				t.Errorf(
+					"JavaScript runtime package %s loads contract manifest %q in %s; remove the runtime dependency and keep contract comparison in structural tooling",
+					pkg.ImportPath,
+					reference,
+					repositoryPath,
+				)
+			}
+		}
+	}
+}
+
+func listJavaScriptRuntimePackages(t *testing.T) []listedJavaScriptPackage {
+	t.Helper()
+
+	cmd := exec.Command("go", "list", "-json", javascriptRuntimePackagePattern)
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("go list JavaScript runtime packages: %v", err)
+	}
+
+	decoder := json.NewDecoder(strings.NewReader(string(output)))
+	var packages []listedJavaScriptPackage
+	for {
+		var pkg listedJavaScriptPackage
+		err := decoder.Decode(&pkg)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("decode listed JavaScript runtime package: %v", err)
+		}
+		packages = append(packages, pkg)
+	}
+	slices.SortFunc(packages, func(left, right listedJavaScriptPackage) int {
+		return strings.Compare(left.ImportPath, right.ImportPath)
+	})
+	return packages
+}
+
+func runtimeManifestReferences(t *testing.T, path string) []string {
+	t.Helper()
+
+	parsed, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse JavaScript runtime source %s: %v", filepath.ToSlash(path), err)
+	}
+
+	var references []string
+	ast.Inspect(parsed, func(node ast.Node) bool {
+		literal, ok := node.(*ast.BasicLit)
+		if !ok || literal.Kind != token.STRING {
+			return true
+		}
+		value, err := strconv.Unquote(literal.Value)
+		if err != nil {
+			return true
+		}
+		normalized := strings.ReplaceAll(value, `\`, "/")
+		for _, forbiddenName := range forbiddenRuntimeManifestNames {
+			if normalized == forbiddenName || strings.HasSuffix(normalized, "/"+forbiddenName) {
+				references = append(references, value)
+				break
+			}
+		}
+		return true
+	})
+	slices.Sort(references)
+	return references
 }
 
 func TestJavaScriptAuthoredCatalogBoundary(t *testing.T) {

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -69,7 +69,10 @@ Use this map when changing the public REST contract.
   `cmd/javascriptcontractsmoke` and `make javascript-contract-smoke`; reuse
   `symbolidentity.ProjectInstalledBindings`, `callbehavior.ProjectInstalledCallBehavior`,
   `catalog.CatalogPathCompletenessIssues`, and `catalog.CatalogCallBehaviorParityIssues`
-  rather than inventing a second runtime descriptor.
+  rather than inventing a second runtime descriptor. Prove missing/extra/duplicate
+  symbol-path failures with temp-dir catalog copies that keep authored and staged
+  bytes aligned in `internal/javascriptcontractsmoke/check_test.go` and
+  `cmd/javascriptcontractsmoke/main_test.go`.
 - Staged OpenAPI byte policy lives in `internal/contractstaging/openapi.go`
   (`CanonicalOpenAPIPath`, `StagedOpenAPIPath`, `ReviewedOpenAPIBytePolicy`,
   `ProjectStagedOpenAPI`, `VerifyStagedOpenAPIParity`). The reviewed policy is

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -67,7 +67,8 @@ Use this map when changing the public REST contract.
   catalog/projection/binding/behavior parity closeout lives in
   `internal/javascriptcontractsmoke` with CLI entrypoint
   `cmd/javascriptcontractsmoke` and `make javascript-contract-smoke`; the same
-  target runs the production-package guards in
+  target runs focused installed-runtime regressions for signature, async result,
+  emitted records, policy rejection, and resume, plus the production-package guards in
   `contracts/runtime_manifest_boundary_test.go`, which discover every
   `pkg/orchestrators/javascript/...` package and reject transitive contract-tooling
   imports or production source literals that name the authored/staged runtime

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -74,7 +74,11 @@ Use this map when changing the public REST contract.
   symbol-path failures and forbidden/comparison-project helper failures with
   temp-dir catalog copies that keep authored and staged bytes aligned in
   `internal/javascriptcontractsmoke/check_test.go` and
-  `cmd/javascriptcontractsmoke/main_test.go`.
+  `cmd/javascriptcontractsmoke/main_test.go`. Stale staged-projection diagnostics
+  report the generated repository-relative file path and, when valid JSON differs
+  inside symbol records, the affected public symbol paths; the check remains
+  read-only and directs maintainers to `make contracts-generate` followed by
+  `make contracts-check`.
 - Staged OpenAPI byte policy lives in `internal/contractstaging/openapi.go`
   (`CanonicalOpenAPIPath`, `StagedOpenAPIPath`, `ReviewedOpenAPIBytePolicy`,
   `ProjectStagedOpenAPI`, `VerifyStagedOpenAPIParity`). The reviewed policy is

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -78,7 +78,11 @@ Use this map when changing the public REST contract.
   report the generated repository-relative file path and, when valid JSON differs
   inside symbol records, the affected public symbol paths; the check remains
   read-only and directs maintainers to `make contracts-generate` followed by
-  `make contracts-check`.
+  `make contracts-check`. Behavior-incomplete fixtures should delete or contradict
+  call metadata in synchronized authored/staged temp catalogs, then assert the
+  public symbol path, `/symbols/<key>/<field>` location, and call-behavior baseline
+  remediation for signature, async/result, emitted-record, policy, and resume
+  fields; this proves the smoke boundary without making the catalog executable.
 - Staged OpenAPI byte policy lives in `internal/contractstaging/openapi.go`
   (`CanonicalOpenAPIPath`, `StagedOpenAPIPath`, `ReviewedOpenAPIBytePolicy`,
   `ProjectStagedOpenAPI`, `VerifyStagedOpenAPIParity`). The reviewed policy is

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -66,7 +66,12 @@ Use this map when changing the public REST contract.
   `internal/contractstaging/policy.go#rawArtifacts`. Maintainer-facing
   catalog/projection/binding/behavior parity closeout lives in
   `internal/javascriptcontractsmoke` with CLI entrypoint
-  `cmd/javascriptcontractsmoke` and `make javascript-contract-smoke`; reuse
+  `cmd/javascriptcontractsmoke` and `make javascript-contract-smoke`; the same
+  target runs the production-package guards in
+  `contracts/runtime_manifest_boundary_test.go`, which discover every
+  `pkg/orchestrators/javascript/...` package and reject transitive contract-tooling
+  imports or production source literals that name the authored/staged runtime
+  manifest. Reuse
   `symbolidentity.ProjectInstalledBindings`, `callbehavior.ProjectInstalledCallBehavior`,
   `catalog.CatalogPathCompletenessIssues`, `catalog.CatalogForbiddenSymbolIssues`, and
   `catalog.CatalogCallBehaviorParityIssues`

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -63,7 +63,13 @@ Use this map when changing the public REST contract.
   `contracts/javascript_runtime_api_test.go`; staged
   `packages/api/generated/javascript/runtime-api.json` is a byte-identical copy
   of the authored catalog at `contracts/javascript/runtime-api.json` through
-  `internal/contractstaging/policy.go#rawArtifacts`.
+  `internal/contractstaging/policy.go#rawArtifacts`. Maintainer-facing
+  catalog/projection/binding/behavior parity closeout lives in
+  `internal/javascriptcontractsmoke` with CLI entrypoint
+  `cmd/javascriptcontractsmoke` and `make javascript-contract-smoke`; reuse
+  `symbolidentity.ProjectInstalledBindings`, `callbehavior.ProjectInstalledCallBehavior`,
+  `catalog.CatalogPathCompletenessIssues`, and `catalog.CatalogCallBehaviorParityIssues`
+  rather than inventing a second runtime descriptor.
 - Staged OpenAPI byte policy lives in `internal/contractstaging/openapi.go`
   (`CanonicalOpenAPIPath`, `StagedOpenAPIPath`, `ReviewedOpenAPIBytePolicy`,
   `ProjectStagedOpenAPI`, `VerifyStagedOpenAPIParity`). The reviewed policy is

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -68,10 +68,12 @@ Use this map when changing the public REST contract.
   `internal/javascriptcontractsmoke` with CLI entrypoint
   `cmd/javascriptcontractsmoke` and `make javascript-contract-smoke`; reuse
   `symbolidentity.ProjectInstalledBindings`, `callbehavior.ProjectInstalledCallBehavior`,
-  `catalog.CatalogPathCompletenessIssues`, and `catalog.CatalogCallBehaviorParityIssues`
+  `catalog.CatalogPathCompletenessIssues`, `catalog.CatalogForbiddenSymbolIssues`, and
+  `catalog.CatalogCallBehaviorParityIssues`
   rather than inventing a second runtime descriptor. Prove missing/extra/duplicate
-  symbol-path failures with temp-dir catalog copies that keep authored and staged
-  bytes aligned in `internal/javascriptcontractsmoke/check_test.go` and
+  symbol-path failures and forbidden/comparison-project helper failures with
+  temp-dir catalog copies that keep authored and staged bytes aligned in
+  `internal/javascriptcontractsmoke/check_test.go` and
   `cmd/javascriptcontractsmoke/main_test.go`.
 - Staged OpenAPI byte policy lives in `internal/contractstaging/openapi.go`
   (`CanonicalOpenAPIPath`, `StagedOpenAPIPath`, `ReviewedOpenAPIBytePolicy`,

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -59,7 +59,9 @@ Use this map when changing the public REST contract.
   `internal/contractvalidator/javascript_catalog_call_behavior_parity.go`.
   Focused runtime execution parity for the same representative symbols remains
   in `pkg/orchestrators/javascript/runtime/callbehavior_inventory_test.go`.
-  Prove runtime dependency isolation and catalog boundaries in `contracts/runtime_manifest_boundary_test.go` and
+  Prove runtime manifest independence behaviorally in `contracts/runtime_manifest_boundary_test.go` by
+  executing representative invocation, emitted-record, policy-denial, and resume behavior from a
+  subprocess whose authored and staged manifests are unusable. Catalog boundaries remain in
   `contracts/javascript_runtime_api_test.go`; staged
   `packages/api/generated/javascript/runtime-api.json` is a byte-identical copy
   of the authored catalog at `contracts/javascript/runtime-api.json` through
@@ -68,11 +70,11 @@ Use this map when changing the public REST contract.
   `internal/javascriptcontractsmoke` with CLI entrypoint
   `cmd/javascriptcontractsmoke` and `make javascript-contract-smoke`; the same
   target runs focused installed-runtime regressions for signature, async result,
-  emitted records, policy rejection, and resume, plus the production-package guards in
-  `contracts/runtime_manifest_boundary_test.go`, which discover every
-  `pkg/orchestrators/javascript/...` package and reject transitive contract-tooling
-  imports or production source literals that name the authored/staged runtime
-  manifest. Reuse
+  emitted records, policy rejection, and resume, plus the unusable-manifest behavioral
+  proof. Canonical forbidden host-global and comparison-project-helper classification
+  lives in `pkg/orchestrators/javascript/runtime/symbolidentity`; route both schema
+  validation and smoke/catalog checks through `symbolidentity.ClassifySurface` so the
+  supported-surface policy cannot drift. Reuse
   `symbolidentity.ProjectInstalledBindings`, `callbehavior.ProjectInstalledCallBehavior`,
   `catalog.CatalogPathCompletenessIssues`, `catalog.CatalogForbiddenSymbolIssues`, and
   `catalog.CatalogCallBehaviorParityIssues`

--- a/internal/contractvalidator/javascript_surface.go
+++ b/internal/contractvalidator/javascript_surface.go
@@ -3,19 +3,9 @@ package contractvalidator
 import (
 	"fmt"
 	"strconv"
-	"strings"
+
+	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/symbolidentity"
 )
-
-var forbiddenInstalledRootGlobals = []string{
-	"context",
-	"orchestrator",
-}
-
-var comparisonProjectHelperPaths = map[string]struct{}{
-	"workflow.sleep": {},
-	"agent.verify":   {},
-	"agent.parallel": {},
-}
 
 func runtimeManifestSupportedSurfaceDiagnostics(document string, keys []string, pathByKey map[string]string, symbolKindByKey map[string]string) []Diagnostic {
 	var diagnostics []Diagnostic
@@ -28,25 +18,22 @@ func runtimeManifestSupportedSurfaceDiagnostics(document string, keys []string, 
 		symbolPath := "/symbols/" + escapeJSONPointerToken(key) + "/path"
 		kind := symbolKindByKey[key]
 
-		if isForbiddenInstalledRootGlobalPath(path) {
+		switch symbolidentity.ClassifySurface(path, kind) {
+		case symbolidentity.SurfaceForbiddenHostGlobal:
 			diagnostics = append(diagnostics, newDiagnostic(
 				"javascript.surface.forbidden_global",
 				symbolPath,
 				fmt.Sprintf("symbol path %s documents a forbidden host-only global", strconv.Quote(path)),
 				document,
 			))
-			continue
-		}
-		if isComparisonProjectHelperPath(path) {
+		case symbolidentity.SurfaceComparisonProjectHelper:
 			diagnostics = append(diagnostics, newDiagnostic(
 				"javascript.surface.unsupported_helper",
 				symbolPath,
 				fmt.Sprintf("symbol path %s documents a comparison-project-only helper that is not part of the installed supported surface", strconv.Quote(path)),
 				document,
 			))
-			continue
-		}
-		if path == "agent" && kind == "function" {
+		case symbolidentity.SurfaceCallableAgentGlobal:
 			diagnostics = append(diagnostics, newDiagnostic(
 				"javascript.surface.unsupported_helper",
 				symbolPath,
@@ -57,18 +44,4 @@ func runtimeManifestSupportedSurfaceDiagnostics(document string, keys []string, 
 	}
 
 	return diagnostics
-}
-
-func isForbiddenInstalledRootGlobalPath(path string) bool {
-	for _, forbidden := range forbiddenInstalledRootGlobals {
-		if path == forbidden || strings.HasPrefix(path, forbidden+".") {
-			return true
-		}
-	}
-	return false
-}
-
-func isComparisonProjectHelperPath(path string) bool {
-	_, ok := comparisonProjectHelperPaths[path]
-	return ok
 }

--- a/internal/javascriptcontractsmoke/check.go
+++ b/internal/javascriptcontractsmoke/check.go
@@ -1,0 +1,161 @@
+// Package javascriptcontractsmoke compares the authored JavaScript runtime
+// catalog, staged package projection, installed binding descriptor, and
+// call-behavior baseline. It is build/verification tooling and must not be
+// imported by runtime packages.
+package javascriptcontractsmoke
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	jscatalog "github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/catalog"
+	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/callbehavior"
+	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/symbolidentity"
+)
+
+const (
+	AuthoredCatalogRelativePath  = "contracts/javascript/runtime-api.json"
+	StagedProjectionRelativePath = "packages/api/generated/javascript/runtime-api.json"
+)
+
+// Diagnostic records one deterministic repository-relative parity failure.
+type Diagnostic struct {
+	Code    string
+	Path    string
+	Message string
+}
+
+// Check compares the authored catalog, staged projection, installed binding
+// descriptor, and call-behavior baseline using the existing B02/B03 helpers.
+// It never mutates repository files.
+func Check(root string) ([]Diagnostic, error) {
+	repositoryRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolve repository root: %w", err)
+	}
+
+	authoredPath := filepath.Join(repositoryRoot, filepath.FromSlash(AuthoredCatalogRelativePath))
+	stagedPath := filepath.Join(repositoryRoot, filepath.FromSlash(StagedProjectionRelativePath))
+
+	authoredBytes, err := os.ReadFile(authoredPath)
+	if err != nil {
+		return nil, fmt.Errorf("read authored catalog %s: %w", AuthoredCatalogRelativePath, err)
+	}
+	stagedBytes, err := os.ReadFile(stagedPath)
+	if err != nil {
+		return nil, fmt.Errorf("read staged projection %s: %w", StagedProjectionRelativePath, err)
+	}
+
+	var diagnostics []Diagnostic
+	if !bytes.Equal(authoredBytes, stagedBytes) {
+		diagnostics = append(diagnostics, Diagnostic{
+			Code: "javascript.projection.stale",
+			Path: StagedProjectionRelativePath,
+			Message: "staged JavaScript runtime projection diverges from the authored catalog; " +
+				"run `make contracts-generate` and `make contracts-check` to restore staging parity",
+		})
+	}
+
+	var catalog map[string]any
+	if err := json.Unmarshal(authoredBytes, &catalog); err != nil {
+		return nil, fmt.Errorf("decode authored catalog %s: %w", AuthoredCatalogRelativePath, err)
+	}
+
+	identity := symbolidentity.ProjectInstalledBindings()
+	callInventory := callbehavior.ProjectInstalledCallBehavior()
+
+	if err := symbolidentity.VerifyProjectedInstalledBindings(); err != nil {
+		diagnostics = append(diagnostics, bindingDescriptorDiagnostic(err))
+	}
+
+	catalogPaths, err := jscatalog.CatalogSymbolPathsFromDocument(catalog)
+	if err != nil {
+		return nil, fmt.Errorf("extract catalog symbol paths: %w", err)
+	}
+	for _, issue := range jscatalog.CatalogPathCompletenessIssues(catalogPaths, identity, callInventory) {
+		diagnostics = append(diagnostics, pathCompletenessDiagnostic(issue))
+	}
+
+	callIssues, err := jscatalog.CatalogCallBehaviorParityIssues(catalog, callInventory)
+	if err != nil {
+		return nil, fmt.Errorf("compare catalog call-behavior parity: %w", err)
+	}
+	for _, issue := range callIssues {
+		diagnostics = append(diagnostics, callBehaviorDiagnostic(issue))
+	}
+
+	sortDiagnostics(diagnostics)
+	return diagnostics, nil
+}
+
+func bindingDescriptorDiagnostic(err error) Diagnostic {
+	message := strings.TrimSpace(err.Error())
+	path := AuthoredCatalogRelativePath
+	if quoted := firstQuotedString(message); quoted != "" {
+		path = quoted
+	}
+	return Diagnostic{
+		Code:    "javascript.binding.descriptor",
+		Path:    path,
+		Message: message + "; restore parity between the installed binding descriptor and authored catalog",
+	}
+}
+
+func pathCompletenessDiagnostic(issue jscatalog.PathCompletenessIssue) Diagnostic {
+	path := issue.Path
+	if path == "" || path == "/symbols" {
+		path = AuthoredCatalogRelativePath
+	}
+	return Diagnostic{
+		Code:    issue.Code,
+		Path:    path,
+		Message: issue.Message + "; restore authored catalog and staging parity with the installed binding descriptor",
+	}
+}
+
+func callBehaviorDiagnostic(issue jscatalog.CallBehaviorParityIssue) Diagnostic {
+	path := issue.Path
+	if path == "" {
+		path = AuthoredCatalogRelativePath
+	}
+	message := issue.Message
+	if issue.SymbolKey != "" && issue.Field != "" {
+		message = fmt.Sprintf("%s at /symbols/%s/%s", issue.Message, issue.SymbolKey, issue.Field)
+	}
+	return Diagnostic{
+		Code:    issue.Code,
+		Path:    path,
+		Message: message + "; restore catalog call metadata parity with the installed call-behavior baseline",
+	}
+}
+
+func sortDiagnostics(diagnostics []Diagnostic) {
+	sort.Slice(diagnostics, func(i, j int) bool {
+		left, right := diagnostics[i], diagnostics[j]
+		if left.Code != right.Code {
+			return left.Code < right.Code
+		}
+		if left.Path != right.Path {
+			return left.Path < right.Path
+		}
+		return left.Message < right.Message
+	})
+}
+
+func firstQuotedString(message string) string {
+	start := strings.Index(message, `"`)
+	if start < 0 {
+		return ""
+	}
+	rest := message[start+1:]
+	end := strings.Index(rest, `"`)
+	if end < 0 {
+		return ""
+	}
+	return rest[:end]
+}

--- a/internal/javascriptcontractsmoke/check.go
+++ b/internal/javascriptcontractsmoke/check.go
@@ -10,11 +10,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 
-	jscatalog "github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/catalog"
 	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/callbehavior"
+	jscatalog "github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/catalog"
 	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/symbolidentity"
 )
 
@@ -53,11 +54,14 @@ func Check(root string) ([]Diagnostic, error) {
 
 	var diagnostics []Diagnostic
 	if !bytes.Equal(authoredBytes, stagedBytes) {
+		message := "staged JavaScript runtime projection diverges from the authored catalog"
+		if paths := staleProjectionSymbolPaths(authoredBytes, stagedBytes); len(paths) > 0 {
+			message += "; divergent symbol paths: " + strings.Join(paths, ", ")
+		}
 		diagnostics = append(diagnostics, Diagnostic{
-			Code: "javascript.projection.stale",
-			Path: StagedProjectionRelativePath,
-			Message: "staged JavaScript runtime projection diverges from the authored catalog; " +
-				"run `make contracts-generate` and `make contracts-check` to restore staging parity",
+			Code:    "javascript.projection.stale",
+			Path:    StagedProjectionRelativePath,
+			Message: message + "; run `make contracts-generate` and `make contracts-check` to restore staging parity",
 		})
 	}
 
@@ -95,6 +99,42 @@ func Check(root string) ([]Diagnostic, error) {
 
 	sortDiagnostics(diagnostics)
 	return diagnostics, nil
+}
+
+func staleProjectionSymbolPaths(authoredBytes, stagedBytes []byte) []string {
+	var authored, staged struct {
+		Symbols map[string]map[string]any `json:"symbols"`
+	}
+	if json.Unmarshal(authoredBytes, &authored) != nil || json.Unmarshal(stagedBytes, &staged) != nil {
+		return nil
+	}
+
+	keys := make(map[string]struct{}, len(authored.Symbols)+len(staged.Symbols))
+	for key := range authored.Symbols {
+		keys[key] = struct{}{}
+	}
+	for key := range staged.Symbols {
+		keys[key] = struct{}{}
+	}
+
+	paths := make(map[string]struct{})
+	for key := range keys {
+		if reflect.DeepEqual(authored.Symbols[key], staged.Symbols[key]) {
+			continue
+		}
+		for _, record := range []map[string]any{authored.Symbols[key], staged.Symbols[key]} {
+			if path, ok := record["path"].(string); ok && path != "" {
+				paths[path] = struct{}{}
+			}
+		}
+	}
+
+	out := make([]string, 0, len(paths))
+	for path := range paths {
+		out = append(out, path)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func bindingDescriptorDiagnostic(err error) Diagnostic {

--- a/internal/javascriptcontractsmoke/check.go
+++ b/internal/javascriptcontractsmoke/check.go
@@ -77,6 +77,10 @@ func Check(root string) ([]Diagnostic, error) {
 	if err != nil {
 		return nil, fmt.Errorf("extract catalog symbol paths: %w", err)
 	}
+	symbols, _ := catalog["symbols"].(map[string]any)
+	for _, issue := range jscatalog.CatalogForbiddenSymbolIssues(catalogPaths, symbols) {
+		diagnostics = append(diagnostics, forbiddenSymbolDiagnostic(issue))
+	}
 	for _, issue := range jscatalog.CatalogPathCompletenessIssues(catalogPaths, identity, callInventory) {
 		diagnostics = append(diagnostics, pathCompletenessDiagnostic(issue))
 	}
@@ -103,6 +107,18 @@ func bindingDescriptorDiagnostic(err error) Diagnostic {
 		Code:    "javascript.binding.descriptor",
 		Path:    path,
 		Message: message + "; restore parity between the installed binding descriptor and authored catalog",
+	}
+}
+
+func forbiddenSymbolDiagnostic(issue jscatalog.PathCompletenessIssue) Diagnostic {
+	path := issue.Path
+	if path == "" || path == "/symbols" {
+		path = AuthoredCatalogRelativePath
+	}
+	return Diagnostic{
+		Code:    issue.Code,
+		Path:    path,
+		Message: issue.Message + "; remove the path from the contracted supported surface",
 	}
 }
 

--- a/internal/javascriptcontractsmoke/check_test.go
+++ b/internal/javascriptcontractsmoke/check_test.go
@@ -335,6 +335,53 @@ func TestCheck_PathCompletenessFailuresAreDeterministic(t *testing.T) {
 	}
 }
 
+func TestCheck_FailsWhenCatalogCallBehaviorIsIncomplete(t *testing.T) {
+	tests := []struct {
+		name      string
+		symbolKey string
+		path      string
+		field     string
+	}{
+		{name: "signature", symbolKey: "javascript.workflow.checkpoint", path: "workflow.checkpoint", field: "parameters"},
+		{name: "async", symbolKey: "javascript.agent.run", path: "agent.run", field: "async"},
+		{name: "result", symbolKey: "javascript.agent.run", path: "agent.run", field: "return"},
+		{name: "emitted record", symbolKey: "javascript.workflow.checkpoint", path: "workflow.checkpoint", field: "emittedRecords"},
+		{name: "policy", symbolKey: "javascript.agent.run", path: "agent.run", field: "policyChecks"},
+		{name: "resume", symbolKey: "javascript.workflow.checkpoint", path: "workflow.checkpoint", field: "resumeNotes"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := mutationFixtureRoot(t)
+			mutateCatalogFixture(t, root, func(catalog map[string]any) {
+				symbols := catalog["symbols"].(map[string]any)
+				symbol := symbols[test.symbolKey].(map[string]any)
+				delete(symbol, test.field)
+			})
+
+			first := runCheckDiagnostics(t, root)
+			second := runCheckDiagnostics(t, root)
+			if len(first) != 1 || len(second) != 1 || first[0] != second[0] {
+				t.Fatalf("call-behavior diagnostics are not deterministic: first=%+v second=%+v", first, second)
+			}
+			diagnostic := first[0]
+			if diagnostic.Code != "javascript.call_behavior.mismatch" {
+				t.Fatalf("diagnostic code = %q, want javascript.call_behavior.mismatch", diagnostic.Code)
+			}
+			if diagnostic.Path != test.path {
+				t.Fatalf("diagnostic path = %q, want repository-relative symbol path %q", diagnostic.Path, test.path)
+			}
+			wantFieldPath := "/symbols/" + test.symbolKey + "/" + test.field
+			if !strings.Contains(diagnostic.Message, wantFieldPath) {
+				t.Fatalf("diagnostic message = %q, want field path %q", diagnostic.Message, wantFieldPath)
+			}
+			if !strings.Contains(diagnostic.Message, "restore catalog call metadata parity with the installed call-behavior baseline") {
+				t.Fatalf("diagnostic message = %q, want actionable baseline remediation", diagnostic.Message)
+			}
+		})
+	}
+}
+
 type pathCompletenessExpectation struct {
 	wantCount int
 	code      string

--- a/internal/javascriptcontractsmoke/check_test.go
+++ b/internal/javascriptcontractsmoke/check_test.go
@@ -125,6 +125,100 @@ func mutationFixtureRoot(t *testing.T) string {
 	return root
 }
 
+func TestCheck_FailsWhenCatalogContainsForbiddenRootGlobal(t *testing.T) {
+	root := mutationFixtureRoot(t)
+	mutateCatalogFixture(t, root, func(catalog map[string]any) {
+		symbols := catalog["symbols"].(map[string]any)
+		symbols["javascript.context"] = map[string]any{
+			"path": "context",
+			"kind": "value",
+		}
+	})
+
+	assertForbiddenSymbolFailure(t, root, forbiddenSymbolExpectation{
+		code: "javascript.path.forbidden",
+		path: "context",
+	})
+}
+
+func TestCheck_FailsWhenCatalogContainsOrchestratorGlobal(t *testing.T) {
+	root := mutationFixtureRoot(t)
+	mutateCatalogFixture(t, root, func(catalog map[string]any) {
+		symbols := catalog["symbols"].(map[string]any)
+		symbols["javascript.orchestrator"] = map[string]any{
+			"path": "orchestrator",
+			"kind": "namespace",
+		}
+	})
+
+	assertForbiddenSymbolFailure(t, root, forbiddenSymbolExpectation{
+		code: "javascript.path.forbidden",
+		path: "orchestrator",
+	})
+}
+
+func TestCheck_FailsWhenCatalogContainsComparisonProjectHelper(t *testing.T) {
+	root := mutationFixtureRoot(t)
+	mutateCatalogFixture(t, root, func(catalog map[string]any) {
+		symbols := catalog["symbols"].(map[string]any)
+		symbols["javascript.workflow.sleep"] = map[string]any{
+			"path": "workflow.sleep",
+			"kind": "method",
+		}
+	})
+
+	assertForbiddenSymbolFailure(t, root, forbiddenSymbolExpectation{
+		code: "javascript.path.unsupported_helper",
+		path: "workflow.sleep",
+	})
+}
+
+func TestCheck_ForbiddenSymbolFailuresAreDeterministic(t *testing.T) {
+	root := mutationFixtureRoot(t)
+	mutateCatalogFixture(t, root, func(catalog map[string]any) {
+		symbols := catalog["symbols"].(map[string]any)
+		symbols["javascript.context"] = map[string]any{
+			"path": "context",
+			"kind": "value",
+		}
+	})
+
+	first := runCheckDiagnostics(t, root)
+	second := runCheckDiagnostics(t, root)
+	if len(first) != len(second) {
+		t.Fatalf("diagnostic count drift: first=%d second=%d", len(first), len(second))
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			t.Fatalf("diagnostic[%d] drift: first=%+v second=%+v", i, first[i], second[i])
+		}
+	}
+}
+
+type forbiddenSymbolExpectation struct {
+	code string
+	path string
+}
+
+func assertForbiddenSymbolFailure(t *testing.T, root string, want forbiddenSymbolExpectation) {
+	t.Helper()
+
+	diagnostics := runCheckDiagnostics(t, root)
+	if len(diagnostics) != 1 {
+		t.Fatalf("Check() diagnostics = %+v, want one forbidden-surface issue", diagnostics)
+	}
+	diagnostic := diagnostics[0]
+	if diagnostic.Code != want.code {
+		t.Fatalf("diagnostic code = %q, want %q (full=%+v)", diagnostic.Code, want.code, diagnostic)
+	}
+	if diagnostic.Path != want.path {
+		t.Fatalf("diagnostic path = %q, want repository-relative symbol path %q (full=%+v)", diagnostic.Path, want.path, diagnostic)
+	}
+	if !strings.Contains(diagnostic.Message, "remove the path from the contracted supported surface") {
+		t.Fatalf("diagnostic message = %q, want actionable remediation", diagnostic.Message)
+	}
+}
+
 func TestCheck_FailsWhenInstalledPathMissingFromCatalog(t *testing.T) {
 	root := mutationFixtureRoot(t)
 	mutateCatalogFixture(t, root, func(catalog map[string]any) {

--- a/internal/javascriptcontractsmoke/check_test.go
+++ b/internal/javascriptcontractsmoke/check_test.go
@@ -1,6 +1,7 @@
 package javascriptcontractsmoke_test
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -122,4 +123,140 @@ func mutationFixtureRoot(t *testing.T) string {
 		}
 	}
 	return root
+}
+
+func TestCheck_FailsWhenInstalledPathMissingFromCatalog(t *testing.T) {
+	root := mutationFixtureRoot(t)
+	mutateCatalogFixture(t, root, func(catalog map[string]any) {
+		symbols := catalog["symbols"].(map[string]any)
+		delete(symbols, "javascript.phase")
+	})
+
+	assertPathCompletenessFailure(t, root, pathCompletenessExpectation{
+		wantCount: 1,
+		code:      "javascript.path.missing",
+		path:      "phase",
+	})
+}
+
+func TestCheck_FailsWhenCatalogContainsExtraPath(t *testing.T) {
+	root := mutationFixtureRoot(t)
+	mutateCatalogFixture(t, root, func(catalog map[string]any) {
+		symbols := catalog["symbols"].(map[string]any)
+		symbols["javascript.workflow.extra"] = map[string]any{
+			"path": "workflow.extra",
+		}
+	})
+
+	assertPathCompletenessFailure(t, root, pathCompletenessExpectation{
+		wantCount: 1,
+		code:      "javascript.path.extra",
+		path:      "workflow.extra",
+	})
+}
+
+func TestCheck_FailsWhenCatalogPathDuplicated(t *testing.T) {
+	root := mutationFixtureRoot(t)
+	mutateCatalogFixture(t, root, func(catalog map[string]any) {
+		symbols := catalog["symbols"].(map[string]any)
+		symbols["javascript.duplicate-phase"] = map[string]any{
+			"path": "phase",
+		}
+	})
+
+	assertPathCompletenessFailure(t, root, pathCompletenessExpectation{
+		wantCount: 2,
+		code:      "javascript.path.duplicate",
+		path:      "phase",
+	})
+}
+
+func TestCheck_PathCompletenessFailuresAreDeterministic(t *testing.T) {
+	root := mutationFixtureRoot(t)
+	mutateCatalogFixture(t, root, func(catalog map[string]any) {
+		symbols := catalog["symbols"].(map[string]any)
+		delete(symbols, "javascript.phase")
+	})
+
+	first := runCheckDiagnostics(t, root)
+	second := runCheckDiagnostics(t, root)
+	if len(first) != len(second) {
+		t.Fatalf("diagnostic count drift: first=%d second=%d", len(first), len(second))
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			t.Fatalf("diagnostic[%d] drift: first=%+v second=%+v", i, first[i], second[i])
+		}
+	}
+}
+
+type pathCompletenessExpectation struct {
+	wantCount int
+	code      string
+	path      string
+}
+
+func assertPathCompletenessFailure(t *testing.T, root string, want pathCompletenessExpectation) {
+	t.Helper()
+
+	diagnostics := runCheckDiagnostics(t, root)
+	if len(diagnostics) != want.wantCount {
+		t.Fatalf("Check() diagnostics = %+v, want %d issue(s)", diagnostics, want.wantCount)
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Code != want.code {
+			t.Fatalf("diagnostic code = %q, want %q (full=%+v)", diagnostic.Code, want.code, diagnostic)
+		}
+		if diagnostic.Path != want.path {
+			t.Fatalf("diagnostic path = %q, want repository-relative symbol path %q (full=%+v)", diagnostic.Path, want.path, diagnostic)
+		}
+		if !strings.Contains(diagnostic.Message, "restore authored catalog and staging parity") {
+			t.Fatalf("diagnostic message = %q, want actionable remediation", diagnostic.Message)
+		}
+	}
+}
+
+func runCheckDiagnostics(t *testing.T, root string) []javascriptcontractsmoke.Diagnostic {
+	t.Helper()
+
+	diagnostics, err := javascriptcontractsmoke.Check(root)
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if len(diagnostics) == 0 {
+		t.Fatal("Check() diagnostics = none, want path completeness failure")
+	}
+	return diagnostics
+}
+
+func mutateCatalogFixture(t *testing.T, root string, mutate func(map[string]any)) {
+	t.Helper()
+
+	authoredPath := filepath.Join(root, filepath.FromSlash(javascriptcontractsmoke.AuthoredCatalogRelativePath))
+	data, err := os.ReadFile(authoredPath)
+	if err != nil {
+		t.Fatalf("read authored catalog: %v", err)
+	}
+
+	var catalog map[string]any
+	if err := json.Unmarshal(data, &catalog); err != nil {
+		t.Fatalf("decode authored catalog: %v", err)
+	}
+	mutate(catalog)
+
+	updated, err := json.MarshalIndent(catalog, "", "  ")
+	if err != nil {
+		t.Fatalf("encode catalog fixture: %v", err)
+	}
+	updated = append(updated, '\n')
+
+	for _, rel := range []string{
+		javascriptcontractsmoke.AuthoredCatalogRelativePath,
+		javascriptcontractsmoke.StagedProjectionRelativePath,
+	} {
+		target := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.WriteFile(target, updated, 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
 }

--- a/internal/javascriptcontractsmoke/check_test.go
+++ b/internal/javascriptcontractsmoke/check_test.go
@@ -1,0 +1,125 @@
+package javascriptcontractsmoke_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/internal/javascriptcontractsmoke"
+)
+
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(1)
+	if !ok {
+		t.Fatal("cannot determine test file path")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find module root from test file")
+		}
+		dir = parent
+	}
+}
+
+func TestCheck_PassesForCleanRepository(t *testing.T) {
+	root := moduleRoot(t)
+
+	diagnostics, err := javascriptcontractsmoke.Check(root)
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if len(diagnostics) != 0 {
+		t.Fatalf("Check() diagnostics = %+v, want none on clean repository", diagnostics)
+	}
+}
+
+func TestCheck_RepeatRunsAreDeterministic(t *testing.T) {
+	root := moduleRoot(t)
+
+	first, err := javascriptcontractsmoke.Check(root)
+	if err != nil {
+		t.Fatalf("first Check() error = %v", err)
+	}
+	second, err := javascriptcontractsmoke.Check(root)
+	if err != nil {
+		t.Fatalf("second Check() error = %v", err)
+	}
+	if len(first) != len(second) {
+		t.Fatalf("diagnostic count drift: first=%d second=%d", len(first), len(second))
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			t.Fatalf("diagnostic[%d] drift: first=%+v second=%+v", i, first[i], second[i])
+		}
+	}
+}
+
+func TestCheck_ReportsStaleProjectionWithoutWriting(t *testing.T) {
+	root := mutationFixtureRoot(t)
+
+	diagnostics, err := javascriptcontractsmoke.Check(root)
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if len(diagnostics) != 0 {
+		t.Fatalf("Check() diagnostics = %+v, want none before staging mutation", diagnostics)
+	}
+
+	stagedPath := filepath.Join(root, filepath.FromSlash(javascriptcontractsmoke.StagedProjectionRelativePath))
+	original, err := os.ReadFile(stagedPath)
+	if err != nil {
+		t.Fatalf("read staged projection: %v", err)
+	}
+	if err := os.WriteFile(stagedPath, append(original, '\n'), 0o644); err != nil {
+		t.Fatalf("mutate staged projection: %v", err)
+	}
+
+	diagnostics, err = javascriptcontractsmoke.Check(root)
+	if err != nil {
+		t.Fatalf("Check() after mutation error = %v", err)
+	}
+	if len(diagnostics) != 1 {
+		t.Fatalf("Check() diagnostics = %+v, want one stale projection failure", diagnostics)
+	}
+	diagnostic := diagnostics[0]
+	if diagnostic.Path != javascriptcontractsmoke.StagedProjectionRelativePath {
+		t.Fatalf("diagnostic path = %q, want %q", diagnostic.Path, javascriptcontractsmoke.StagedProjectionRelativePath)
+	}
+	if !strings.Contains(diagnostic.Message, "contracts-generate") {
+		t.Fatalf("diagnostic message = %q, want contracts-generate remediation", diagnostic.Message)
+	}
+}
+
+func mutationFixtureRoot(t *testing.T) string {
+	t.Helper()
+
+	repoRoot := moduleRoot(t)
+	root := t.TempDir()
+	for _, rel := range []string{
+		javascriptcontractsmoke.AuthoredCatalogRelativePath,
+		javascriptcontractsmoke.StagedProjectionRelativePath,
+	} {
+		source := filepath.Join(repoRoot, filepath.FromSlash(rel))
+		target := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			t.Fatalf("create fixture directory for %s: %v", rel, err)
+		}
+		data, err := os.ReadFile(source)
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		if err := os.WriteFile(target, data, 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	return root
+}

--- a/internal/javascriptcontractsmoke/check_test.go
+++ b/internal/javascriptcontractsmoke/check_test.go
@@ -100,6 +100,57 @@ func TestCheck_ReportsStaleProjectionWithoutWriting(t *testing.T) {
 	}
 }
 
+func TestCheck_ReportsStaleProjectionSymbolPathDeterministicallyWithoutWriting(t *testing.T) {
+	root := mutationFixtureRoot(t)
+	stagedPath := filepath.Join(root, filepath.FromSlash(javascriptcontractsmoke.StagedProjectionRelativePath))
+	original, err := os.ReadFile(stagedPath)
+	if err != nil {
+		t.Fatalf("read staged projection: %v", err)
+	}
+
+	var staged map[string]any
+	if err := json.Unmarshal(original, &staged); err != nil {
+		t.Fatalf("decode staged projection: %v", err)
+	}
+	symbols := staged["symbols"].(map[string]any)
+	phase := symbols["javascript.phase"].(map[string]any)
+	phase["kind"] = "method"
+	mutated, err := json.MarshalIndent(staged, "", "  ")
+	if err != nil {
+		t.Fatalf("encode staged projection: %v", err)
+	}
+	mutated = append(mutated, '\n')
+	if err := os.WriteFile(stagedPath, mutated, 0o644); err != nil {
+		t.Fatalf("write staged projection: %v", err)
+	}
+
+	first := runCheckDiagnostics(t, root)
+	second := runCheckDiagnostics(t, root)
+	if len(first) != 1 || len(second) != 1 || first[0] != second[0] {
+		t.Fatalf("stale diagnostics are not deterministic: first=%+v second=%+v", first, second)
+	}
+	diagnostic := first[0]
+	if diagnostic.Code != "javascript.projection.stale" {
+		t.Fatalf("diagnostic code = %q, want javascript.projection.stale", diagnostic.Code)
+	}
+	if diagnostic.Path != javascriptcontractsmoke.StagedProjectionRelativePath {
+		t.Fatalf("diagnostic path = %q, want %q", diagnostic.Path, javascriptcontractsmoke.StagedProjectionRelativePath)
+	}
+	if !strings.Contains(diagnostic.Message, "divergent symbol paths: phase") {
+		t.Fatalf("diagnostic message = %q, want divergent symbol path", diagnostic.Message)
+	}
+	if !strings.Contains(diagnostic.Message, "make contracts-generate") || !strings.Contains(diagnostic.Message, "make contracts-check") {
+		t.Fatalf("diagnostic message = %q, want generation/check remediation", diagnostic.Message)
+	}
+	after, err := os.ReadFile(stagedPath)
+	if err != nil {
+		t.Fatalf("read staged projection after checks: %v", err)
+	}
+	if string(after) != string(mutated) {
+		t.Fatal("Check() rewrote the stale staged projection")
+	}
+}
+
 func mutationFixtureRoot(t *testing.T) string {
 	t.Helper()
 

--- a/pkg/orchestrators/javascript/runtime/catalog/catalog_forbidden.go
+++ b/pkg/orchestrators/javascript/runtime/catalog/catalog_forbidden.go
@@ -1,0 +1,99 @@
+package catalog
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/symbolidentity"
+)
+
+var comparisonProjectHelperPaths = map[string]struct{}{
+	"workflow.sleep": {},
+	"agent.verify":   {},
+	"agent.parallel": {},
+}
+
+// CatalogForbiddenSymbolIssues reports catalog symbol paths that document
+// forbidden host-only globals or comparison-project-only helpers.
+func CatalogForbiddenSymbolIssues(catalog []CatalogSymbolPath, symbols map[string]any) []PathCompletenessIssue {
+	var issues []PathCompletenessIssue
+	for _, entry := range catalog {
+		path := entry.Path
+		if isForbiddenInstalledRootGlobalPath(path) {
+			issues = append(issues, PathCompletenessIssue{
+				Code:      "javascript.path.forbidden",
+				SymbolKey: entry.SymbolKey,
+				Path:      path,
+				Message: fmt.Sprintf(
+					"symbol path %s documents a forbidden host-only global",
+					strconv.Quote(path),
+				),
+			})
+			continue
+		}
+		if isComparisonProjectHelperPath(path) {
+			issues = append(issues, PathCompletenessIssue{
+				Code:      "javascript.path.unsupported_helper",
+				SymbolKey: entry.SymbolKey,
+				Path:      path,
+				Message: fmt.Sprintf(
+					"symbol path %s documents a comparison-project-only helper that is not part of the installed supported surface",
+					strconv.Quote(path),
+				),
+			})
+			continue
+		}
+		if path == "agent" && catalogSymbolKind(symbols, entry.SymbolKey) == "function" {
+			issues = append(issues, PathCompletenessIssue{
+				Code:      "javascript.path.unsupported_helper",
+				SymbolKey: entry.SymbolKey,
+				Path:      path,
+				Message: fmt.Sprintf(
+					"symbol path %s documents a comparison-project-only callable agent global; installed runtime exposes agent as a namespace with agent.run",
+					strconv.Quote(path),
+				),
+			})
+		}
+	}
+
+	sort.Slice(issues, func(i, j int) bool {
+		left, right := issues[i], issues[j]
+		if left.Code != right.Code {
+			return left.Code < right.Code
+		}
+		if left.Path != right.Path {
+			return left.Path < right.Path
+		}
+		return left.SymbolKey < right.SymbolKey
+	})
+	return issues
+}
+
+func isForbiddenInstalledRootGlobalPath(path string) bool {
+	for _, forbidden := range symbolidentity.ForbiddenRootGlobals {
+		if path == forbidden || strings.HasPrefix(path, forbidden+".") {
+			return true
+		}
+	}
+	return false
+}
+
+func isComparisonProjectHelperPath(path string) bool {
+	_, ok := comparisonProjectHelperPaths[path]
+	return ok
+}
+
+func isUnsupportedCatalogSurfacePath(path string) bool {
+	return isForbiddenInstalledRootGlobalPath(path) || isComparisonProjectHelperPath(path)
+}
+
+func catalogSymbolKind(symbols map[string]any, key string) string {
+	record, ok := symbols[key].(map[string]any)
+	if !ok {
+		return ""
+	}
+	kind, _ := record["kind"].(string)
+	return kind
+}

--- a/pkg/orchestrators/javascript/runtime/catalog/catalog_forbidden.go
+++ b/pkg/orchestrators/javascript/runtime/catalog/catalog_forbidden.go
@@ -4,16 +4,9 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/symbolidentity"
 )
-
-var comparisonProjectHelperPaths = map[string]struct{}{
-	"workflow.sleep": {},
-	"agent.verify":   {},
-	"agent.parallel": {},
-}
 
 // CatalogForbiddenSymbolIssues reports catalog symbol paths that document
 // forbidden host-only globals or comparison-project-only helpers.
@@ -21,7 +14,8 @@ func CatalogForbiddenSymbolIssues(catalog []CatalogSymbolPath, symbols map[strin
 	var issues []PathCompletenessIssue
 	for _, entry := range catalog {
 		path := entry.Path
-		if isForbiddenInstalledRootGlobalPath(path) {
+		switch symbolidentity.ClassifySurface(path, catalogSymbolKind(symbols, entry.SymbolKey)) {
+		case symbolidentity.SurfaceForbiddenHostGlobal:
 			issues = append(issues, PathCompletenessIssue{
 				Code:      "javascript.path.forbidden",
 				SymbolKey: entry.SymbolKey,
@@ -31,9 +25,7 @@ func CatalogForbiddenSymbolIssues(catalog []CatalogSymbolPath, symbols map[strin
 					strconv.Quote(path),
 				),
 			})
-			continue
-		}
-		if isComparisonProjectHelperPath(path) {
+		case symbolidentity.SurfaceComparisonProjectHelper:
 			issues = append(issues, PathCompletenessIssue{
 				Code:      "javascript.path.unsupported_helper",
 				SymbolKey: entry.SymbolKey,
@@ -43,9 +35,7 @@ func CatalogForbiddenSymbolIssues(catalog []CatalogSymbolPath, symbols map[strin
 					strconv.Quote(path),
 				),
 			})
-			continue
-		}
-		if path == "agent" && catalogSymbolKind(symbols, entry.SymbolKey) == "function" {
+		case symbolidentity.SurfaceCallableAgentGlobal:
 			issues = append(issues, PathCompletenessIssue{
 				Code:      "javascript.path.unsupported_helper",
 				SymbolKey: entry.SymbolKey,
@@ -71,22 +61,8 @@ func CatalogForbiddenSymbolIssues(catalog []CatalogSymbolPath, symbols map[strin
 	return issues
 }
 
-func isForbiddenInstalledRootGlobalPath(path string) bool {
-	for _, forbidden := range symbolidentity.ForbiddenRootGlobals {
-		if path == forbidden || strings.HasPrefix(path, forbidden+".") {
-			return true
-		}
-	}
-	return false
-}
-
-func isComparisonProjectHelperPath(path string) bool {
-	_, ok := comparisonProjectHelperPaths[path]
-	return ok
-}
-
 func isUnsupportedCatalogSurfacePath(path string) bool {
-	return isForbiddenInstalledRootGlobalPath(path) || isComparisonProjectHelperPath(path)
+	return symbolidentity.IsUnsupportedSurfacePath(path)
 }
 
 func catalogSymbolKind(symbols map[string]any, key string) string {

--- a/pkg/orchestrators/javascript/runtime/catalog/catalog_forbidden_test.go
+++ b/pkg/orchestrators/javascript/runtime/catalog/catalog_forbidden_test.go
@@ -1,0 +1,125 @@
+package catalog_test
+
+import (
+	"testing"
+
+	jscatalog "github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/catalog"
+	"github.com/portpowered/infinite-you/pkg/orchestrators/javascript/runtime/symbolidentity"
+)
+
+func TestCatalogForbiddenSymbolIssues_FailsForForbiddenRootGlobal(t *testing.T) {
+	catalog := []jscatalog.CatalogSymbolPath{
+		{SymbolKey: "javascript.context", Path: "context"},
+	}
+	symbols := map[string]any{
+		"javascript.context": map[string]any{
+			"path": "context",
+			"kind": "value",
+		},
+	}
+
+	issues := jscatalog.CatalogForbiddenSymbolIssues(catalog, symbols)
+	if len(issues) != 1 {
+		t.Fatalf("CatalogForbiddenSymbolIssues() = %+v, want one forbidden issue", issues)
+	}
+	issue := issues[0]
+	if issue.Code != "javascript.path.forbidden" || issue.Path != "context" {
+		t.Fatalf("issue = %+v, want forbidden path %q", issue, "context")
+	}
+}
+
+func TestCatalogForbiddenSymbolIssues_FailsForOrchestratorGlobal(t *testing.T) {
+	catalog := []jscatalog.CatalogSymbolPath{
+		{SymbolKey: "javascript.orchestrator", Path: "orchestrator"},
+	}
+	symbols := map[string]any{
+		"javascript.orchestrator": map[string]any{
+			"path": "orchestrator",
+			"kind": "namespace",
+		},
+	}
+
+	issues := jscatalog.CatalogForbiddenSymbolIssues(catalog, symbols)
+	if len(issues) != 1 {
+		t.Fatalf("CatalogForbiddenSymbolIssues() = %+v, want one forbidden issue", issues)
+	}
+	issue := issues[0]
+	if issue.Code != "javascript.path.forbidden" || issue.Path != "orchestrator" {
+		t.Fatalf("issue = %+v, want forbidden path %q", issue, "orchestrator")
+	}
+}
+
+func TestCatalogForbiddenSymbolIssues_FailsForComparisonProjectHelper(t *testing.T) {
+	catalog := []jscatalog.CatalogSymbolPath{
+		{SymbolKey: "javascript.workflow.sleep", Path: "workflow.sleep"},
+	}
+	symbols := map[string]any{
+		"javascript.workflow.sleep": map[string]any{
+			"path": "workflow.sleep",
+			"kind": "method",
+		},
+	}
+
+	issues := jscatalog.CatalogForbiddenSymbolIssues(catalog, symbols)
+	if len(issues) != 1 {
+		t.Fatalf("CatalogForbiddenSymbolIssues() = %+v, want one unsupported-helper issue", issues)
+	}
+	issue := issues[0]
+	if issue.Code != "javascript.path.unsupported_helper" || issue.Path != "workflow.sleep" {
+		t.Fatalf("issue = %+v, want unsupported helper path %q", issue, "workflow.sleep")
+	}
+}
+
+func TestCatalogForbiddenSymbolIssues_FailsForCallableAgentGlobal(t *testing.T) {
+	catalog := []jscatalog.CatalogSymbolPath{
+		{SymbolKey: "javascript.agent", Path: "agent"},
+	}
+	symbols := map[string]any{
+		"javascript.agent": map[string]any{
+			"path": "agent",
+			"kind": "function",
+		},
+	}
+
+	issues := jscatalog.CatalogForbiddenSymbolIssues(catalog, symbols)
+	if len(issues) != 1 {
+		t.Fatalf("CatalogForbiddenSymbolIssues() = %+v, want one unsupported-helper issue", issues)
+	}
+	issue := issues[0]
+	if issue.Code != "javascript.path.unsupported_helper" || issue.Path != "agent" {
+		t.Fatalf("issue = %+v, want unsupported helper path %q", issue, "agent")
+	}
+}
+
+func TestCatalogForbiddenSymbolIssues_PassesForInstalledSurface(t *testing.T) {
+	catalog := installedCatalogSymbolPaths(t)
+	symbols := installedCatalogSymbols(t)
+
+	issues := jscatalog.CatalogForbiddenSymbolIssues(catalog, symbols)
+	if len(issues) != 0 {
+		t.Fatalf("CatalogForbiddenSymbolIssues() = %+v, want none on installed surface", issues)
+	}
+}
+
+func installedCatalogSymbols(t *testing.T) map[string]any {
+	t.Helper()
+
+	symbols := make(map[string]any, len(symbolidentity.ExpectedInstalledPaths()))
+	for _, path := range symbolidentity.ExpectedInstalledPaths() {
+		key := catalogSymbolKeyForPath(path)
+		kind := "method"
+		switch path {
+		case "agent":
+			kind = "namespace"
+		case "workflow":
+			kind = "namespace"
+		case "phase", "log":
+			kind = "function"
+		}
+		symbols[key] = map[string]any{
+			"path": path,
+			"kind": kind,
+		}
+	}
+	return symbols
+}

--- a/pkg/orchestrators/javascript/runtime/catalog/catalog_identity.go
+++ b/pkg/orchestrators/javascript/runtime/catalog/catalog_identity.go
@@ -152,6 +152,9 @@ func catalogExtraPathIssues(
 	extraPaths := make([]string, 0)
 	for path := range catalogPaths {
 		if _, ok := expectedSet[path]; !ok {
+			if isUnsupportedCatalogSurfacePath(path) {
+				continue
+			}
 			extraPaths = append(extraPaths, path)
 		}
 	}

--- a/pkg/orchestrators/javascript/runtime/symbolidentity/verify.go
+++ b/pkg/orchestrators/javascript/runtime/symbolidentity/verify.go
@@ -10,6 +10,45 @@ import (
 // installed binding surface or symbol identity inventory.
 var ForbiddenRootGlobals = []string{"context", "orchestrator"}
 
+var comparisonProjectHelperPaths = map[string]struct{}{
+	"workflow.sleep": {},
+	"agent.verify":   {},
+	"agent.parallel": {},
+}
+
+// SurfaceClassification describes whether a documented JavaScript symbol is
+// part of the installed supported surface.
+type SurfaceClassification string
+
+const (
+	SurfaceSupported               SurfaceClassification = "supported"
+	SurfaceForbiddenHostGlobal     SurfaceClassification = "forbidden_host_global"
+	SurfaceComparisonProjectHelper SurfaceClassification = "comparison_project_helper"
+	SurfaceCallableAgentGlobal     SurfaceClassification = "callable_agent_global"
+)
+
+// ClassifySurface centralizes forbidden and comparison-project-only symbol
+// policy for contract validation and installed-catalog parity checks.
+func ClassifySurface(path, kind string) SurfaceClassification {
+	if isForbiddenSymbolPath(path) {
+		return SurfaceForbiddenHostGlobal
+	}
+	if _, ok := comparisonProjectHelperPaths[path]; ok {
+		return SurfaceComparisonProjectHelper
+	}
+	if path == "agent" && kind == "function" {
+		return SurfaceCallableAgentGlobal
+	}
+	return SurfaceSupported
+}
+
+// IsUnsupportedSurfacePath reports path-only unsupported surfaces. Callable
+// agent classification additionally requires the catalog symbol kind.
+func IsUnsupportedSurfacePath(path string) bool {
+	classification := ClassifySurface(path, "")
+	return classification != SurfaceSupported
+}
+
 // VerifyProjectedInstalledBindings projects the canonical inventory and fails
 // when paths are missing, duplicated, unexpected, unsorted, or forbidden.
 func VerifyProjectedInstalledBindings() error {

--- a/pkg/orchestrators/javascript/runtime/symbolidentity/verify_test.go
+++ b/pkg/orchestrators/javascript/runtime/symbolidentity/verify_test.go
@@ -15,6 +15,31 @@ func TestVerifyProjectedInstalledBindings_PassesForLiveDescriptor(t *testing.T) 
 	}
 }
 
+func TestClassifySurface_CentralizesUnsupportedSymbolPolicy(t *testing.T) {
+	tests := []struct {
+		path string
+		kind string
+		want symbolidentity.SurfaceClassification
+	}{
+		{path: "workflow.final", kind: "function", want: symbolidentity.SurfaceSupported},
+		{path: "context.session", kind: "property", want: symbolidentity.SurfaceForbiddenHostGlobal},
+		{path: "orchestrator", kind: "object", want: symbolidentity.SurfaceForbiddenHostGlobal},
+		{path: "workflow.sleep", kind: "function", want: symbolidentity.SurfaceComparisonProjectHelper},
+		{path: "agent.verify", kind: "function", want: symbolidentity.SurfaceComparisonProjectHelper},
+		{path: "agent.parallel", kind: "function", want: symbolidentity.SurfaceComparisonProjectHelper},
+		{path: "agent", kind: "function", want: symbolidentity.SurfaceCallableAgentGlobal},
+		{path: "agent", kind: "object", want: symbolidentity.SurfaceSupported},
+	}
+
+	for _, test := range tests {
+		t.Run(test.path+"/"+test.kind, func(t *testing.T) {
+			if got := symbolidentity.ClassifySurface(test.path, test.kind); got != test.want {
+				t.Fatalf("ClassifySurface(%q, %q) = %q, want %q", test.path, test.kind, got, test.want)
+			}
+		})
+	}
+}
+
 func TestVerifyInventory_FailsWhenExpectedPathMissing(t *testing.T) {
 	inventory := symbolidentity.ProjectInstalledBindings()
 	filtered := make([]symbolidentity.SymbolRecord, 0, len(inventory.Symbols)-1)


### PR DESCRIPTION
{
  "project": "B17-JS-CLOSE — Enforce JavaScript contract and binding parity",
  "branchName": "interfaces-b17-javascript-close",
  "description": "Add make javascript-contract-smoke and focused parity checks comparing the authored runtime catalog, generated package projection, installed binding descriptor, and behavior baseline. Reject stale projections and missing, extra, duplicate, forbidden, or behaviorally incomplete symbol records with deterministic stable paths while preserving runtime ownership and execution behavior.",
  "context": {
    "customerAsk": "Add make javascript-contract-smoke and focused parity checks comparing the authored runtime catalog, generated package projection, installed binding descriptor, and behavior baseline. Reject stale projections and missing, extra, duplicate, forbidden, or behaviorally incomplete symbol records with deterministic stable paths while preserving runtime ownership and execution behavior.",
    "problem": "After B17 schema and catalog land, maintainers still lack one deterministic closeout gate that proves the authored contracts/javascript/runtime-api.json, the staged packages/api/generated/javascript/runtime-api.json, the installed binding descriptor, and the call-behavior baseline stay aligned. Divergences can silently enter as stale projections or incomplete symbol records, and without path-stable failures plus a non-executable manifest boundary, Batch 17 cannot close with confidence that contracts stay structural while public JavaScript behavior remains unchanged.",
    "solution": "After the B17 schema and canonical catalog are merged, add make javascript-contract-smoke that reuses existing B02/B03 inventory and parity helpers to compare catalog, staged projection, installed bindings, and behavior baseline; fail deliberate missing, extra, duplicate, forbidden, stale-projection, and behaviorally incomplete fixtures with deterministic repository-relative symbol paths and remediation; keep the manifest non-executable for workflow logic; and prove representative runtime regressions remain green under the narrow applicable verification tier."
  },
  "acceptanceCriteria": [
    "A clean catalog/binding/staging set passes make javascript-contract-smoke deterministically (repeat runs are byte-stable and exit zero)",
    "Deliberate missing, extra, duplicate, forbidden, and stale-projection fixtures fail with the symbol path (repository-relative) and actionable remediation",
    "Behaviorally incomplete symbol records relative to the call-behavior baseline fail with the symbol path and actionable remediation",
    "Representative signature, async result, emitted-record, policy rejection, and resume regressions remain green",
    "No runtime package loads the manifest to execute workflow logic",
    "Contract checks, runtime-focused tests, package guards, and the narrow applicable verification tier pass",
    "Quality checks pass (typecheck, lint, tests)"
  ],
  "userStories": [
    {
      "id": "interfaces-b17-javascript-close-001",
      "title": "Add javascript-contract-smoke that passes on a clean catalog/binding/staging set",
      "description": "As a contracts maintainer, I want make javascript-contract-smoke so that a clean authored catalog, generated package projection, installed binding descriptor, and behavior baseline pass together in one deterministic gate.",
      "acceptanceCriteria": [
        "make javascript-contract-smoke exists and exits zero on the clean repository catalog/binding/staging set",
        "The smoke compares the authored runtime catalog, generated package projection, installed binding descriptor, and behavior baseline using existing inventory/parity helpers (no second runtime descriptor)",
        "Two consecutive smoke runs produce identical exit status and deterministic diagnostics (no second-run drift)",
        "The smoke does not alter public JavaScript runtime bindings or workflow execution behavior",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b17-javascript-close-002",
      "title": "Fail missing, extra, and duplicate symbol records by path with remediation",
      "description": "As a reviewer, I want deliberate missing, extra, and duplicate symbol-record fixtures to fail the smoke so that catalog/binding drift is diagnosed by stable symbol path with clear repair guidance.",
      "acceptanceCriteria": [
        "A fixture missing an expected installed symbol path fails non-zero and names that repository-relative symbol path",
        "A fixture with an extra unexpected symbol path fails non-zero and names that path",
        "A fixture with a duplicate symbol path fails non-zero and names that path",
        "Failure output includes actionable remediation (for example regenerate/check or restore the authored catalog/staging parity) rather than only a generic error",
        "Diagnostics are deterministic across repeated runs of the same fixture",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b17-javascript-close-003",
      "title": "Fail forbidden symbol records by path with remediation",
      "description": "As a reviewer, I want forbidden surfaces such as context, orchestrator, and comparison-project-only helpers rejected by the smoke so unsupported globals cannot pass as contracted symbols.",
      "acceptanceCriteria": [
        "A fixture that introduces a forbidden root or helper symbol fails non-zero and reports the forbidden symbol path",
        "Failure output includes actionable remediation stating the path must be removed from the contracted/supported surface",
        "Clean catalogs without forbidden symbols continue to pass",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b17-javascript-close-004",
      "title": "Fail stale package projections by path with remediation",
      "description": "As a maintainer, I want stale generated packages/api/generated/javascript/runtime-api.json content to fail the smoke so staging cannot drift from the authored catalog without a visible path-level failure.",
      "acceptanceCriteria": [
        "A fixture where the staged projection bytes diverge from the authored catalog (or expected generated projection) fails non-zero",
        "Failure names the stale repository-relative projection path (and symbol path when the divergence is symbol-scoped)",
        "Failure output identifies the corrective generation/check action maintainers must run",
        "Checking does not silently rewrite staging; the smoke reports and exits non-zero",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b17-javascript-close-005",
      "title": "Fail behaviorally incomplete symbol records against the behavior baseline",
      "description": "As a reviewer, I want symbol records that omit or contradict required call-behavior fields to fail the smoke so signature, async, emitted-record, policy, and resume documentation cannot silently lag the installed baseline.",
      "acceptanceCriteria": [
        "A fixture whose catalog/parity record is behaviorally incomplete relative to the B03 call-behavior baseline fails non-zero for the affected symbol path",
        "Incomplete coverage includes representative gaps such as missing/mismatched signature, async/result, emitted-record, policy, or resume fields that the baseline requires",
        "Failure output names the symbol path and provides actionable remediation to restore parity with the behavior baseline",
        "Complete records for the installed supported surface continue to pass",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b17-javascript-close-006",
      "title": "Prove runtime packages never load the manifest to execute workflow logic",
      "description": "As a runtime maintainer, I want package guards proving no JavaScript runtime package loads the contract manifest for execution so the closeout gate cannot turn documentation into executable workflow input.",
      "acceptanceCriteria": [
        "Focused package-boundary/guard evidence shows JavaScript runtime packages do not import contract tooling or load contracts/javascript/runtime-api.json (or the staged projection) to execute workflow logic",
        "The smoke/parity gate remains structural: it compares descriptors and catalogs; it does not become a runtime dependency of workflow execution",
        "Public JavaScript invocation, policy, and resume execution behavior remains unchanged by this lane",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": ""
    },
    {
      "id": "interfaces-b17-javascript-close-007",
      "title": "Keep representative runtime regressions green under the narrow verification tier",
      "description": "As a release reviewer, I want the closeout to re-run representative signature, async result, emitted-record, policy rejection, and resume regressions plus the narrow applicable verification tier so structural smoke work does not regress installed runtime behavior.",
      "acceptanceCriteria": [
        "Representative signature, async result, emitted-record, policy rejection, and resume focused runtime regressions remain green",
        "Contract checks, runtime-focused tests, package guards (pkg-boundary / related guards as applicable), and the narrow applicable verification tier for this lane pass",
        "make javascript-contract-smoke remains the maintainer-facing closeout entrypoint and stays green on the clean tree",
        "No public JavaScript behavior change is introduced beyond structural/documentation parity enforcement",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 7,
      "passes": true,
      "notes": ""
    }
  ]
}
