### PR TITLE
interfaces-b19-dev-publish

### DIFF
--- a/.github/workflows/development-package.yml
+++ b/.github/workflows/development-package.yml
@@ -1,0 +1,107 @@
+name: Development Package
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: development-package-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+env:
+  BUN_VERSION: 1.3.12
+  NODE_VERSION: 22
+  GO_VERSION: 1.24.2
+
+jobs:
+  validate:
+    name: Validate Development Package Prerequisites
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - name: Check out the reviewed pull request commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install dashboard dependencies
+        run: make ui-deps
+
+      - name: Run typecheck
+        run: make typecheck
+
+      - name: Run lint and package boundary gates
+        run: make lint
+
+      - name: Run relevant repository tests
+        run: make test
+
+      - name: Validate repeated contract generation and drift
+        run: make contracts-smoke
+
+      - name: Validate generated API parity
+        run: make api-smoke
+
+      - name: Validate package allowlist, packing, and isolated consumption
+        run: make api-package-pack-smoke
+
+  dry-run-candidate:
+    name: Build and Smoke Exact Candidate (No Publish)
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Check out the reviewed pull request commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Prepare and smoke the exact candidate without publishing
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .artifacts/api-development-candidate
+          node scripts/api-package-pr-dry-run.mjs \
+            --event-name "${{ github.event_name }}" \
+            --package-directory packages/api \
+            --output-directory .artifacts/api-development-candidate/package \
+            --run-id "${{ github.run_id }}" \
+            --source-commit "${{ github.event.pull_request.head.sha }}" \
+            --workspace-directory "${{ github.workspace }}" \
+            | tee .artifacts/api-development-candidate/dry-run-outcome.json
+
+      - name: Upload the preserved candidate and evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-development-candidate-${{ github.run_id }}
+          path: .artifacts/api-development-candidate/
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/development-package.yml
+++ b/.github/workflows/development-package.yml
@@ -2,17 +2,21 @@ name: Development Package
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read
 
 concurrency:
-  group: development-package-${{ github.event.pull_request.number }}
+  group: development-package-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
 env:
   BUN_VERSION: 1.3.12
-  NODE_VERSION: 22
+  NODE_VERSION: 24
+  NPM_VERSION: 11.15.0
   GO_VERSION: 1.24.2
 
 jobs:
@@ -21,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
-      - name: Check out the reviewed pull request commit
+      - name: Check out the candidate commit
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Set up Go
@@ -67,6 +71,7 @@ jobs:
 
   dry-run-candidate:
     name: Build and Smoke Exact Candidate (No Publish)
+    if: github.event_name == 'pull_request'
     needs: validate
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -105,3 +110,84 @@ jobs:
           path: .artifacts/api-development-candidate/
           if-no-files-found: error
           retention-days: 7
+
+  prepare-main-candidate:
+    name: Prepare Protected Main Candidate
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'portpowered/you-agent-factory'
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Check out the protected main commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Prepare the exact protected-main candidate
+        run: >-
+          node scripts/api-package-candidate.mjs
+          --package-directory packages/api
+          --output-directory .artifacts/api-development-candidate
+          --run-id "${{ github.run_id }}"
+          --source-commit "${{ github.sha }}"
+
+      - name: Upload the preserved candidate and evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-development-main-candidate-${{ github.run_id }}
+          path: .artifacts/api-development-candidate/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-main-candidate:
+    name: Publish and Verify Protected Main Candidate
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'portpowered/you-agent-factory'
+    needs:
+      - validate
+      - prepare-main-candidate
+    environment: development-publishing
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out the verified protected main helper
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: Set up trusted-publishing-compatible Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Pin trusted-publishing-compatible npm
+        run: npm install --global npm@${{ env.NPM_VERSION }}
+
+      - name: Download the preserved candidate
+        uses: actions/download-artifact@v4
+        with:
+          name: api-development-main-candidate-${{ github.run_id }}
+          path: .artifacts/api-development-candidate
+
+      - name: Reconcile, publish once when absent, and verify exact consumption
+        run: >-
+          node scripts/api-package-publish.mjs
+          --candidate-directory .artifacts/api-development-candidate
+          --workspace-directory "${{ github.workspace }}"

--- a/.github/workflows/development-package.yml
+++ b/.github/workflows/development-package.yml
@@ -89,6 +89,17 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Authorize the read-only pull request path
+        run: >-
+          node scripts/api-package-development-policy.mjs
+          --event-name "${{ github.event_name }}"
+          --expected-action dry-run
+          --prerequisite-result "${{ needs.validate.result }}"
+          --pull-request-head-sha "${{ github.event.pull_request.head.sha }}"
+          --ref "${{ github.ref }}"
+          --repository "${{ github.repository }}"
+          --source-commit "${{ github.event.pull_request.head.sha }}"
+
       - name: Prepare and smoke the exact candidate without publishing
         shell: bash
         run: |
@@ -133,6 +144,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+
+      - name: Authorize protected-main candidate preparation
+        run: >-
+          node scripts/api-package-development-policy.mjs
+          --event-name "${{ github.event_name }}"
+          --expected-action prepare-main
+          --prerequisite-result "${{ needs.validate.result }}"
+          --ref "${{ github.ref }}"
+          --repository "${{ github.repository }}"
+          --source-commit "${{ github.sha }}"
 
       - name: Prepare the exact protected-main candidate
         run: >-
@@ -185,6 +206,16 @@ jobs:
         with:
           name: api-development-main-candidate-${{ github.run_id }}
           path: .artifacts/api-development-candidate
+
+      - name: Authorize protected-main publication
+        run: >-
+          node scripts/api-package-development-policy.mjs
+          --event-name "${{ github.event_name }}"
+          --expected-action publish-main
+          --prerequisite-result "${{ needs.validate.result }}"
+          --ref "${{ github.ref }}"
+          --repository "${{ github.repository }}"
+          --source-commit "${{ github.sha }}"
 
       - name: Reconcile, publish once when absent, and verify exact consumption
         run: >-

--- a/.github/workflows/development-package.yml
+++ b/.github/workflows/development-package.yml
@@ -89,26 +89,20 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Authorize the read-only pull request path
-        run: >-
-          node scripts/api-package-development-policy.mjs
-          --event-name "${{ github.event_name }}"
-          --expected-action dry-run
-          --prerequisite-result "${{ needs.validate.result }}"
-          --pull-request-head-sha "${{ github.event.pull_request.head.sha }}"
-          --ref "${{ github.ref }}"
-          --repository "${{ github.repository }}"
-          --source-commit "${{ github.event.pull_request.head.sha }}"
-
-      - name: Prepare and smoke the exact candidate without publishing
+      - name: Authorize, prepare, and smoke the exact candidate without publishing
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p .artifacts/api-development-candidate
-          node scripts/api-package-pr-dry-run.mjs \
+          node scripts/api-package-development-command.mjs \
+            --action dry-run \
             --event-name "${{ github.event_name }}" \
-            --package-directory packages/api \
             --output-directory .artifacts/api-development-candidate/package \
+            --package-directory packages/api \
+            --prerequisite-result "${{ needs.validate.result }}" \
+            --pull-request-head-sha "${{ github.event.pull_request.head.sha }}" \
+            --ref "${{ github.ref }}" \
+            --repository "${{ github.repository }}" \
             --run-id "${{ github.run_id }}" \
             --source-commit "${{ github.event.pull_request.head.sha }}" \
             --workspace-directory "${{ github.workspace }}" \
@@ -145,21 +139,16 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Authorize protected-main candidate preparation
+      - name: Authorize and prepare the exact protected-main candidate
         run: >-
-          node scripts/api-package-development-policy.mjs
+          node scripts/api-package-development-command.mjs
+          --action prepare-main
           --event-name "${{ github.event_name }}"
-          --expected-action prepare-main
+          --output-directory .artifacts/api-development-candidate
+          --package-directory packages/api
           --prerequisite-result "${{ needs.validate.result }}"
           --ref "${{ github.ref }}"
           --repository "${{ github.repository }}"
-          --source-commit "${{ github.sha }}"
-
-      - name: Prepare the exact protected-main candidate
-        run: >-
-          node scripts/api-package-candidate.mjs
-          --package-directory packages/api
-          --output-directory .artifacts/api-development-candidate
           --run-id "${{ github.run_id }}"
           --source-commit "${{ github.sha }}"
 
@@ -207,18 +196,14 @@ jobs:
           name: api-development-main-candidate-${{ github.run_id }}
           path: .artifacts/api-development-candidate
 
-      - name: Authorize protected-main publication
+      - name: Authorize, reconcile, publish once when absent, and verify exact consumption
         run: >-
-          node scripts/api-package-development-policy.mjs
+          node scripts/api-package-development-command.mjs
+          --action publish-main
+          --candidate-directory .artifacts/api-development-candidate
           --event-name "${{ github.event_name }}"
-          --expected-action publish-main
           --prerequisite-result "${{ needs.validate.result }}"
           --ref "${{ github.ref }}"
           --repository "${{ github.repository }}"
           --source-commit "${{ github.sha }}"
-
-      - name: Reconcile, publish once when absent, and verify exact consumption
-        run: >-
-          node scripts/api-package-publish.mjs
-          --candidate-directory .artifacts/api-development-candidate
           --workspace-directory "${{ github.workspace }}"

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ api-smoke:
 	$(MAKE) provider-parity-smoke
 
 api-package-pack-smoke:
-	node --test scripts/api-package-contract.test.mjs scripts/api-package-pack.test.mjs scripts/api-package-candidate.test.mjs scripts/api-package-consumer.test.mjs
+	node --test scripts/api-package-contract.test.mjs scripts/api-package-pack.test.mjs scripts/api-package-candidate.test.mjs scripts/api-package-registry.test.mjs scripts/api-package-consumer.test.mjs
 
 contracts-validate:
 	$(GO) run ./cmd/contractsvalidate -root .

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ api-smoke:
 	$(MAKE) provider-parity-smoke
 
 api-package-pack-smoke:
-	node --test scripts/api-package-contract.test.mjs scripts/api-package-pack.test.mjs scripts/api-package-candidate.test.mjs scripts/api-package-registry.test.mjs scripts/api-package-consumer.test.mjs
+	node --test scripts/api-package-contract.test.mjs scripts/api-package-pack.test.mjs scripts/api-package-candidate.test.mjs scripts/api-package-registry.test.mjs scripts/api-package-consumer.test.mjs scripts/api-package-pr-dry-run.test.mjs scripts/api-package-development-workflow.test.mjs
 
 contracts-validate:
 	$(GO) run ./cmd/contractsvalidate -root .

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ api-smoke:
 	$(MAKE) provider-parity-smoke
 
 api-package-pack-smoke:
-	node --test scripts/api-package-contract.test.mjs scripts/api-package-pack.test.mjs scripts/api-package-candidate.test.mjs scripts/api-package-registry.test.mjs scripts/api-package-consumer.test.mjs scripts/api-package-pr-dry-run.test.mjs scripts/api-package-development-workflow.test.mjs
+	node --test scripts/api-package-contract.test.mjs scripts/api-package-pack.test.mjs scripts/api-package-candidate.test.mjs scripts/api-package-registry.test.mjs scripts/api-package-consumer.test.mjs scripts/api-package-pr-dry-run.test.mjs scripts/api-package-publish.test.mjs scripts/api-package-development-workflow.test.mjs
 
 contracts-validate:
 	$(GO) run ./cmd/contractsvalidate -root .

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ api-smoke:
 	$(MAKE) provider-parity-smoke
 
 api-package-pack-smoke:
-	node --test scripts/api-package-contract.test.mjs scripts/api-package-pack.test.mjs scripts/api-package-consumer.test.mjs
+	node --test scripts/api-package-contract.test.mjs scripts/api-package-pack.test.mjs scripts/api-package-candidate.test.mjs scripts/api-package-consumer.test.mjs
 
 contracts-validate:
 	$(GO) run ./cmd/contractsvalidate -root .

--- a/docs/internal/development/go-functional-coverage-package-baseline.txt
+++ b/docs/internal/development/go-functional-coverage-package-baseline.txt
@@ -101,6 +101,7 @@ github.com/portpowered/infinite-you/pkg/sessionpersistence
 github.com/portpowered/infinite-you/pkg/transports/cli
 github.com/portpowered/infinite-you/pkg/transports/cli/baseline
 github.com/portpowered/infinite-you/pkg/transports/cli/batchload
+github.com/portpowered/infinite-you/pkg/transports/cli/clicontract
 github.com/portpowered/infinite-you/pkg/transports/cli/clidiag
 github.com/portpowered/infinite-you/pkg/transports/cli/clihttp
 github.com/portpowered/infinite-you/pkg/transports/cli/cliinputs

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -171,7 +171,11 @@ Use this map when changing the public REST contract.
   pack, and isolated-consumer gates in its read-only `validate` job. The
   dependent dry-run job must pass the reviewed head SHA and one preserved
   candidate directly through `scripts/api-package-pr-dry-run.mjs`; it must not
-  receive registry mutation credentials or OIDC permission. Protected-main
+  receive registry mutation credentials or OIDC permission.
+  `scripts/api-package-development-policy.mjs` is the executable event,
+  prerequisite, and exact-head policy used by every candidate/publication job;
+  its injected orchestration harness supplies behavioral coverage without
+  treating workflow source text as runtime evidence. Protected-main
   publication prepares and uploads its candidate in a read-only job, then the
   separately environment-protected `id-token: write` job downloads that exact
   artifact and calls `scripts/api-package-publish.mjs`. That boundary reconciles

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -172,10 +172,12 @@ Use this map when changing the public REST contract.
   dependent dry-run job must pass the reviewed head SHA and one preserved
   candidate directly through `scripts/api-package-pr-dry-run.mjs`; it must not
   receive registry mutation credentials or OIDC permission.
-  `scripts/api-package-development-policy.mjs` is the executable event,
-  prerequisite, and exact-head policy used by every candidate/publication job;
-  its injected orchestration harness supplies behavioral coverage without
-  treating workflow source text as runtime evidence. Protected-main
+  `scripts/api-package-development-policy.mjs` owns the pure event,
+  prerequisite, and exact-head policy. Every candidate/publication job invokes
+  `scripts/api-package-development-command.mjs`, which enforces that policy and
+  calls the real mode-specific dry-run, preparation, or publication boundary;
+  inject dependencies into that same production command for behavioral coverage
+  without treating workflow source text as runtime evidence. Protected-main
   publication prepares and uploads its candidate in a read-only job, then the
   separately environment-protected `id-token: write` job downloads that exact
   artifact and calls `scripts/api-package-publish.mjs`. That boundary reconciles

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -165,8 +165,16 @@ Use this map when changing the public REST contract.
   treat an absent exact version as a publish decision, digest-check an existing
   registry tarball for idempotent success, and fail authentication, permission,
   dependency, or immutable-conflict outcomes without publishing or changing a
-  dist-tag. Run `make api-package-pack-smoke` after contract, candidate, or
-  registry guard changes and in `verify-build-contracts`/CI.
+  dist-tag. Pull-request development-package validation lives in
+  `.github/workflows/development-package.yml`: keep prerequisite contract,
+  generation/drift, API parity, package-boundary, repository-test, allowlist,
+  pack, and isolated-consumer gates in its read-only `validate` job. The
+  dependent dry-run job must pass the reviewed head SHA and one preserved
+  candidate directly through `scripts/api-package-pr-dry-run.mjs`; it must not
+  receive registry mutation credentials or OIDC permission. Run `make
+  api-package-pack-smoke` after contract, candidate, registry, dry-run, or
+  development-package workflow guard changes and in
+  `verify-build-contracts`/CI.
 
 ## REST operation identity inventory
 

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -160,8 +160,13 @@ Use this map when changing the public REST contract.
   `scripts/api-package-candidate.mjs`: derive their version from a stable base,
   immutable run ID, and fixed 12-character commit prefix; stage the manifest
   change outside the source package; and retain exactly one reviewed tarball
-  plus digest/inventory evidence. Run `make api-package-pack-smoke` after
-  contract or candidate guard changes and in `verify-build-contracts`/CI.
+  plus digest/inventory evidence. Immutable registry reconciliation lives in
+  `scripts/api-package-registry.mjs`: verify the preserved local tarball first,
+  treat an absent exact version as a publish decision, digest-check an existing
+  registry tarball for idempotent success, and fail authentication, permission,
+  dependency, or immutable-conflict outcomes without publishing or changing a
+  dist-tag. Run `make api-package-pack-smoke` after contract, candidate, or
+  registry guard changes and in `verify-build-contracts`/CI.
 
 ## REST operation identity inventory
 

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -171,7 +171,13 @@ Use this map when changing the public REST contract.
   pack, and isolated-consumer gates in its read-only `validate` job. The
   dependent dry-run job must pass the reviewed head SHA and one preserved
   candidate directly through `scripts/api-package-pr-dry-run.mjs`; it must not
-  receive registry mutation credentials or OIDC permission. Run `make
+  receive registry mutation credentials or OIDC permission. Protected-main
+  publication prepares and uploads its candidate in a read-only job, then the
+  separately environment-protected `id-token: write` job downloads that exact
+  artifact and calls `scripts/api-package-publish.mjs`. That boundary reconciles
+  before mutation, publishes an absent version at most once with public access,
+  provenance, and the `dev` tag, digest-verifies the registry result, and installs
+  the exact registry version in a clean external consumer. Run `make
   api-package-pack-smoke` after contract, candidate, registry, dry-run, or
   development-package workflow guard changes and in
   `verify-build-contracts`/CI.

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -155,9 +155,13 @@ Use this map when changing the public REST contract.
   paths under `packages/api/generated/` plus docs/license packaging; omit
   later-phase families such as `./components/*` until a truthful owner exists.
   `scripts/api-package-{pack,consumer,contract}.mjs` prove `npm pack` inventory
-  and isolated export resolution without mutating staged artifact bytes; run
-  `make api-package-pack-smoke` after contract guard changes and in
-  `verify-build-contracts`/CI.
+  and isolated export resolution without mutating staged artifact bytes.
+  Development candidates are prepared by
+  `scripts/api-package-candidate.mjs`: derive their version from a stable base,
+  immutable run ID, and fixed 12-character commit prefix; stage the manifest
+  change outside the source package; and retain exactly one reviewed tarball
+  plus digest/inventory evidence. Run `make api-package-pack-smoke` after
+  contract or candidate guard changes and in `verify-build-contracts`/CI.
 
 ## REST operation identity inventory
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.0",
   "description": "Raw JSON and YAML contract artifacts for you-agent-factory consumers.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/portpowered/you-agent-factory.git"
+  },
   "files": [
     "README.md",
     "LICENSE.md",

--- a/scripts/api-package-candidate.mjs
+++ b/scripts/api-package-candidate.mjs
@@ -1,0 +1,180 @@
+import { createHash } from "node:crypto";
+import {
+	cp,
+	mkdir,
+	mkdtemp,
+	readFile,
+	readdir,
+	rm,
+	writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+
+import { packAndVerify } from "./api-package-pack.mjs";
+
+export const API_PACKAGE_NAME = "@you-agent-factory/api";
+export const DEVELOPMENT_DIST_TAG = "dev";
+export const SHORT_SHA_LENGTH = 12;
+
+const STABLE_SEMVER_PATTERN =
+	/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const SOURCE_COMMIT_PATTERN = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
+const RUN_ID_PATTERN = /^[1-9]\d*$/;
+
+function requireString(value, name) {
+	if (typeof value !== "string" || value.length === 0) {
+		throw new Error(`[api-package-candidate] ${name} is required`);
+	}
+	return value;
+}
+
+export function deriveCandidateVersion({ baseVersion, runId, sourceCommit }) {
+	const validatedBaseVersion = requireString(baseVersion, "base version");
+	const validatedRunId = requireString(runId, "run ID");
+	const validatedSourceCommit = requireString(sourceCommit, "source commit");
+
+	if (!STABLE_SEMVER_PATTERN.test(validatedBaseVersion)) {
+		throw new Error(
+			"[api-package-candidate] base version must be a stable semantic version",
+		);
+	}
+	if (!RUN_ID_PATTERN.test(validatedRunId)) {
+		throw new Error(
+			"[api-package-candidate] run ID must be a canonical positive integer",
+		);
+	}
+	if (!SOURCE_COMMIT_PATTERN.test(validatedSourceCommit)) {
+		throw new Error(
+			"[api-package-candidate] source commit must be a full lowercase Git object ID",
+		);
+	}
+
+	return `${validatedBaseVersion}-dev.${validatedRunId}.${validatedSourceCommit.slice(0, SHORT_SHA_LENGTH)}`;
+}
+
+async function sha256(path) {
+	return `sha256:${createHash("sha256").update(await readFile(path)).digest("hex")}`;
+}
+
+async function readPackageManifest(packageRoot) {
+	const manifestPath = join(packageRoot, "package.json");
+	let manifest;
+	try {
+		manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+	} catch (error) {
+		throw new Error(
+			"[api-package-candidate] package manifest is not readable JSON",
+			{ cause: error },
+		);
+	}
+	if (manifest.name !== API_PACKAGE_NAME) {
+		throw new Error(
+			`[api-package-candidate] package name must be ${API_PACKAGE_NAME}`,
+		);
+	}
+	return { manifest, manifestPath };
+}
+
+async function requireEmptyOutputDirectory(outputRoot) {
+	await mkdir(outputRoot, { recursive: true });
+	if ((await readdir(outputRoot)).length !== 0) {
+		throw new Error(
+			"[api-package-candidate] output directory must be empty",
+		);
+	}
+}
+
+export async function prepareCandidate({
+	packageDirectory,
+	outputDirectory,
+	runId,
+	sourceCommit,
+}) {
+	const packageRoot = resolve(requireString(packageDirectory, "package directory"));
+	const outputRoot = resolve(requireString(outputDirectory, "output directory"));
+	const { manifest } = await readPackageManifest(packageRoot);
+	const candidateVersion = deriveCandidateVersion({
+		baseVersion: manifest.version,
+		runId,
+		sourceCommit,
+	});
+
+	await requireEmptyOutputDirectory(outputRoot);
+	const stagingRoot = await mkdtemp(join(tmpdir(), "you-api-candidate-"));
+	const stagedPackage = join(stagingRoot, "package");
+	try {
+		await cp(packageRoot, stagedPackage, { recursive: true });
+		const stagedManifestPath = join(stagedPackage, "package.json");
+		await writeFile(
+			stagedManifestPath,
+			`${JSON.stringify({ ...manifest, version: candidateVersion }, null, 2)}\n`,
+		);
+
+		const packed = await packAndVerify({
+			packageDirectory: stagedPackage,
+			packDestination: outputRoot,
+		});
+		if (
+			packed.packageName !== API_PACKAGE_NAME ||
+			packed.packageVersion !== candidateVersion
+		) {
+			throw new Error(
+				"[api-package-candidate] packed identity does not match the candidate",
+			);
+		}
+
+		const evidence = {
+			packageName: packed.packageName,
+			candidateVersion,
+			sourceCommit,
+			contractDigest: await sha256(
+				join(stagedPackage, "generated", "manifest.json"),
+			),
+			artifactDigest: await sha256(packed.tarballPath),
+			inventory: packed.files,
+			distTag: DEVELOPMENT_DIST_TAG,
+		};
+		const evidencePath = join(outputRoot, "candidate-evidence.json");
+		await writeFile(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`);
+
+		return {
+			evidence,
+			evidencePath,
+			tarballPath: packed.tarballPath,
+		};
+	} finally {
+		await rm(stagingRoot, { recursive: true, force: true });
+	}
+}
+
+async function main() {
+	const { values } = parseArgs({
+		options: {
+			"output-directory": { type: "string" },
+			"package-directory": { type: "string" },
+			"run-id": { type: "string" },
+			"source-commit": { type: "string" },
+		},
+		strict: true,
+	});
+	const result = await prepareCandidate({
+		packageDirectory: values["package-directory"],
+		outputDirectory: values["output-directory"],
+		runId: values["run-id"],
+		sourceCommit: values["source-commit"],
+	});
+	process.stdout.write(`${JSON.stringify(result.evidence)}\n`);
+}
+
+if (
+	process.argv[1] &&
+	import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+	main().catch((error) => {
+		process.stderr.write(`${error.message}\n`);
+		process.exitCode = 1;
+	});
+}

--- a/scripts/api-package-candidate.test.mjs
+++ b/scripts/api-package-candidate.test.mjs
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+	DEVELOPMENT_DIST_TAG,
+	SHORT_SHA_LENGTH,
+	deriveCandidateVersion,
+	prepareCandidate,
+} from "./api-package-candidate.mjs";
+import { REVIEWED_PACK_FILES } from "./api-package-pack.mjs";
+
+const packageDirectory = fileURLToPath(
+	new URL("../packages/api", import.meta.url),
+);
+const sourceCommit = "0123456789abcdef0123456789abcdef01234567";
+
+async function temporaryDirectory(t, name) {
+	const directory = await mkdtemp(join(tmpdir(), name));
+	t.after(() => rm(directory, { recursive: true, force: true }));
+	return directory;
+}
+
+function digest(contents) {
+	return `sha256:${createHash("sha256").update(contents).digest("hex")}`;
+}
+
+test("candidate version uses the immutable run ID and fixed commit prefix", () => {
+	assert.equal(SHORT_SHA_LENGTH, 12);
+	assert.equal(
+		deriveCandidateVersion({
+			baseVersion: "1.2.3",
+			runId: "9876543210",
+			sourceCommit,
+		}),
+		"1.2.3-dev.9876543210.0123456789ab",
+	);
+});
+
+test("candidate identity rejects incomplete or non-canonical inputs", () => {
+	const valid = { baseVersion: "1.2.3", runId: "42", sourceCommit };
+	for (const replacement of [
+		{ baseVersion: undefined },
+		{ baseVersion: "1.2.3-beta.1" },
+		{ baseVersion: "01.2.3" },
+		{ runId: undefined },
+		{ runId: "0" },
+		{ runId: "042" },
+		{ sourceCommit: undefined },
+		{ sourceCommit: sourceCommit.slice(0, -1) },
+		{ sourceCommit: sourceCommit.toUpperCase() },
+	]) {
+		assert.throws(() => deriveCandidateVersion({ ...valid, ...replacement }));
+	}
+});
+
+test("preparation packs one attributable candidate without mutating package sources", async (t) => {
+	const outputDirectory = await temporaryDirectory(t, "you-api-candidate-output-");
+	const packageManifestPath = join(packageDirectory, "package.json");
+	const contractManifestPath = join(
+		packageDirectory,
+		"generated",
+		"manifest.json",
+	);
+	const packageManifestBefore = await readFile(packageManifestPath);
+	const contractManifestBefore = await readFile(contractManifestPath);
+
+	const result = await prepareCandidate({
+		packageDirectory,
+		outputDirectory,
+		runId: "9876543210",
+		sourceCommit,
+	});
+
+	assert.deepEqual(await readFile(packageManifestPath), packageManifestBefore);
+	assert.deepEqual(await readFile(contractManifestPath), contractManifestBefore);
+	assert.deepEqual(result.evidence, {
+		packageName: "@you-agent-factory/api",
+		candidateVersion: "0.0.0-dev.9876543210.0123456789ab",
+		sourceCommit,
+		contractDigest: digest(contractManifestBefore),
+		artifactDigest: digest(await readFile(result.tarballPath)),
+		inventory: [...REVIEWED_PACK_FILES].sort((left, right) =>
+			left.localeCompare(right),
+		),
+		distTag: DEVELOPMENT_DIST_TAG,
+	});
+	assert.equal(
+		await readFile(result.evidencePath, "utf8"),
+		`${JSON.stringify(result.evidence, null, 2)}\n`,
+	);
+	assert.deepEqual(
+		(await readdir(outputDirectory)).sort(),
+		[basename(result.tarballPath), "candidate-evidence.json"].sort(),
+	);
+});
+
+test("repeated preparation preserves identity, inventory, and artifact digest", async (t) => {
+	const firstOutput = await temporaryDirectory(t, "you-api-candidate-first-");
+	const secondOutput = await temporaryDirectory(t, "you-api-candidate-second-");
+	const input = {
+		packageDirectory,
+		runId: "123456789",
+		sourceCommit,
+	};
+
+	const first = await prepareCandidate({
+		...input,
+		outputDirectory: firstOutput,
+	});
+	const second = await prepareCandidate({
+		...input,
+		outputDirectory: secondOutput,
+	});
+
+	assert.deepEqual(second.evidence, first.evidence);
+	assert.notEqual(second.tarballPath, first.tarballPath);
+});
+
+test("invalid identity fails before creating candidate output", async (t) => {
+	const parent = await temporaryDirectory(t, "you-api-candidate-invalid-");
+	const outputDirectory = join(parent, "candidate");
+
+	await assert.rejects(
+		prepareCandidate({
+			packageDirectory,
+			outputDirectory,
+			runId: "not-a-run-id",
+			sourceCommit,
+		}),
+		/run ID must be a canonical positive integer/,
+	);
+	await assert.rejects(readdir(outputDirectory), { code: "ENOENT" });
+});
+
+test("candidate evidence contains only the approved non-sensitive fields", async (t) => {
+	const outputDirectory = await temporaryDirectory(t, "you-api-candidate-safe-");
+	const secret = "never-include-this-npm-token";
+	const previousNpmToken = process.env.NPM_TOKEN;
+	process.env.NPM_TOKEN = secret;
+	t.after(() => {
+		if (previousNpmToken === undefined) {
+			delete process.env.NPM_TOKEN;
+			return;
+		}
+		process.env.NPM_TOKEN = previousNpmToken;
+	});
+
+	const result = await prepareCandidate({
+		packageDirectory,
+		outputDirectory,
+		runId: "7",
+		sourceCommit,
+	});
+	const serialized = JSON.stringify(result.evidence);
+
+	assert.deepEqual(Object.keys(result.evidence), [
+		"packageName",
+		"candidateVersion",
+		"sourceCommit",
+		"contractDigest",
+		"artifactDigest",
+		"inventory",
+		"distTag",
+	]);
+	assert.equal(serialized.includes(secret), false);
+	assert.equal(serialized.includes("authorization"), false);
+});

--- a/scripts/api-package-consumer.mjs
+++ b/scripts/api-package-consumer.mjs
@@ -277,17 +277,19 @@ async function verifyJSONArtifactSemantics({ document, packageRoot, specifier })
 	}
 }
 
-function runNpmInstall(consumerDirectory, tarballPath) {
+function runNpmInstall(consumerDirectory, packageTarget, { offline = false } = {}) {
 	const arguments_ = [
 		"install",
-		"--offline",
 		"--ignore-scripts",
 		"--no-audit",
 		"--no-fund",
 		"--no-save",
 		"--package-lock=false",
-		resolve(tarballPath),
 	];
+	if (offline) {
+		arguments_.push("--offline");
+	}
+	arguments_.push(packageTarget);
 
 	return new Promise((resolvePromise, rejectPromise) => {
 		const child = spawn("npm", arguments_, {
@@ -315,12 +317,12 @@ function runNpmInstall(consumerDirectory, tarballPath) {
 	});
 }
 
-export async function installAndVerifyTarball({
+export async function verifyInstalledPackage({
 	consumerDirectory,
 	packageName,
 	packedFiles,
-	tarballPath,
 	workspaceDirectory,
+	expectedVersion,
 }) {
 	const consumerRoot = resolve(consumerDirectory);
 	const workspaceRoot = resolve(workspaceDirectory);
@@ -330,7 +332,6 @@ export async function installAndVerifyTarball({
 		);
 	}
 
-	await runNpmInstall(consumerRoot, tarballPath);
 	const packageRoot = join(
 		consumerRoot,
 		"node_modules",
@@ -346,6 +347,14 @@ export async function installAndVerifyTarball({
 	const installedManifest = JSON.parse(
 		await readFile(join(packageRoot, "package.json"), "utf8"),
 	);
+	if (
+		typeof expectedVersion === "string" &&
+		installedManifest.version !== expectedVersion
+	) {
+		throw new Error(
+			`[api-package-consumer] installed version ${installedManifest.version}, want ${expectedVersion}`,
+		);
+	}
 	const exportCases = concreteExportCases(installedManifest, packedFiles);
 	const resolveFromConsumer = createRequire(
 		join(consumerRoot, "verify.cjs"),
@@ -359,4 +368,20 @@ export async function installAndVerifyTarball({
 	}
 
 	return exportCases;
+}
+
+export async function installAndVerifyTarball(input) {
+	await runNpmInstall(input.consumerDirectory, resolve(input.tarballPath), {
+		offline: true,
+	});
+	return verifyInstalledPackage(input);
+}
+
+export async function installAndVerifyRegistryPackage(input) {
+	const packageTarget = `${input.packageName}@${input.candidateVersion}`;
+	await runNpmInstall(input.consumerDirectory, packageTarget);
+	return verifyInstalledPackage({
+		...input,
+		expectedVersion: input.candidateVersion,
+	});
 }

--- a/scripts/api-package-development-command.mjs
+++ b/scripts/api-package-development-command.mjs
@@ -1,0 +1,96 @@
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+
+import { prepareCandidate } from "./api-package-candidate.mjs";
+import {
+	DEVELOPMENT_PACKAGE_ACTIONS,
+	assertDevelopmentPackageAction,
+} from "./api-package-development-policy.mjs";
+import { validatePullRequestCandidate } from "./api-package-pr-dry-run.mjs";
+import { publishCandidateDirectory } from "./api-package-publish.mjs";
+
+const productionDependencies = Object.freeze({
+	prepareCandidate,
+	publishCandidateDirectory,
+	validatePullRequestCandidate,
+});
+
+export async function executeDevelopmentPackageCommand(
+	input,
+	dependencies = productionDependencies,
+) {
+	const plan = assertDevelopmentPackageAction(input, input.action);
+	switch (input.action) {
+		case DEVELOPMENT_PACKAGE_ACTIONS.DRY_RUN:
+			return dependencies.validatePullRequestCandidate({
+				eventName: input.eventName,
+				outputDirectory: input.outputDirectory,
+				packageDirectory: input.packageDirectory,
+				runId: input.runId,
+				sourceCommit: plan.sourceCommit,
+				workspaceDirectory: input.workspaceDirectory,
+			});
+		case DEVELOPMENT_PACKAGE_ACTIONS.PREPARE_MAIN:
+			return dependencies.prepareCandidate({
+				outputDirectory: input.outputDirectory,
+				packageDirectory: input.packageDirectory,
+				runId: input.runId,
+				sourceCommit: plan.sourceCommit,
+			});
+		case DEVELOPMENT_PACKAGE_ACTIONS.PUBLISH_MAIN:
+			return dependencies.publishCandidateDirectory({
+				candidateDirectory: input.candidateDirectory,
+				workspaceDirectory: input.workspaceDirectory,
+			});
+		default:
+			throw new Error(
+				`[api-package-development-command] unsupported action ${input.action}`,
+			);
+	}
+}
+
+async function main() {
+	const { values } = parseArgs({
+		options: {
+			action: { type: "string" },
+			"candidate-directory": { type: "string" },
+			"event-name": { type: "string" },
+			"output-directory": { type: "string" },
+			"package-directory": { type: "string" },
+			"prerequisite-result": { type: "string" },
+			"pull-request-head-sha": { type: "string" },
+			ref: { type: "string" },
+			repository: { type: "string" },
+			"run-id": { type: "string" },
+			"source-commit": { type: "string" },
+			"workspace-directory": { type: "string" },
+		},
+		strict: true,
+	});
+	const result = await executeDevelopmentPackageCommand({
+		action: values.action,
+		candidateDirectory: values["candidate-directory"],
+		eventName: values["event-name"],
+		outputDirectory: values["output-directory"],
+		packageDirectory: values["package-directory"],
+		prerequisiteResult: values["prerequisite-result"],
+		pullRequestHeadSha: values["pull-request-head-sha"],
+		ref: values.ref,
+		repository: values.repository,
+		runId: values["run-id"],
+		sourceCommit: values["source-commit"],
+		workspaceDirectory: values["workspace-directory"],
+	});
+	process.stdout.write(`${JSON.stringify(result.evidence ?? result)}\n`);
+}
+
+if (
+	process.argv[1] &&
+	import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+	main().catch((error) => {
+		process.stderr.write(`${error.message}\n`);
+		process.exitCode = 1;
+	});
+}

--- a/scripts/api-package-development-policy.mjs
+++ b/scripts/api-package-development-policy.mjs
@@ -1,0 +1,148 @@
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+
+export const DEVELOPMENT_PACKAGE_ACTIONS = Object.freeze({
+	DRY_RUN: "dry-run",
+	PREPARE_MAIN: "prepare-main",
+	PUBLISH_MAIN: "publish-main",
+});
+
+export const DEVELOPMENT_PACKAGE_OUTCOMES = Object.freeze({
+	BLOCKED: "PREREQUISITES_BLOCKED",
+	INELIGIBLE: "EVENT_INELIGIBLE",
+	PR_DRY_RUN: "PR_DRY_RUN",
+	PROTECTED_MAIN: "PROTECTED_MAIN",
+});
+
+const PROTECTED_REPOSITORY = "portpowered/you-agent-factory";
+const PROTECTED_MAIN_REF = "refs/heads/main";
+
+function requiredString(value, name) {
+	if (typeof value !== "string" || value.length === 0) {
+		throw new Error(`[api-package-development-policy] ${name} is required`);
+	}
+	return value;
+}
+
+export function planDevelopmentPackage(context) {
+	if (context.prerequisiteResult !== "success") {
+		return { outcome: DEVELOPMENT_PACKAGE_OUTCOMES.BLOCKED, allowedActions: [] };
+	}
+
+	if (context.eventName === "pull_request") {
+		const sourceCommit = requiredString(context.sourceCommit, "source commit");
+		const pullRequestHeadSha = requiredString(
+			context.pullRequestHeadSha,
+			"pull request head SHA",
+		);
+		if (sourceCommit !== pullRequestHeadSha) {
+			throw new Error(
+				"[api-package-development-policy] pull request candidate must use the reviewed head SHA",
+			);
+		}
+		return {
+			outcome: DEVELOPMENT_PACKAGE_OUTCOMES.PR_DRY_RUN,
+			allowedActions: [DEVELOPMENT_PACKAGE_ACTIONS.DRY_RUN],
+			sourceCommit,
+		};
+	}
+
+	if (
+		context.eventName === "push" &&
+		context.ref === PROTECTED_MAIN_REF &&
+		context.repository === PROTECTED_REPOSITORY
+	) {
+		return {
+			outcome: DEVELOPMENT_PACKAGE_OUTCOMES.PROTECTED_MAIN,
+			allowedActions: [
+				DEVELOPMENT_PACKAGE_ACTIONS.PREPARE_MAIN,
+				DEVELOPMENT_PACKAGE_ACTIONS.PUBLISH_MAIN,
+			],
+			sourceCommit: requiredString(context.sourceCommit, "source commit"),
+		};
+	}
+
+	return { outcome: DEVELOPMENT_PACKAGE_OUTCOMES.INELIGIBLE, allowedActions: [] };
+}
+
+export function assertDevelopmentPackageAction(context, expectedAction) {
+	const action = requiredString(expectedAction, "expected action");
+	const plan = planDevelopmentPackage(context);
+	if (!plan.allowedActions.includes(action)) {
+		throw new Error(
+			`[api-package-development-policy] ${action} is not allowed for outcome ${plan.outcome}`,
+		);
+	}
+	return plan;
+}
+
+export async function executeDevelopmentPackagePolicy(input, dependencies) {
+	const prerequisiteResult = await dependencies.runPrerequisites();
+	const plan = planDevelopmentPackage({ ...input, prerequisiteResult });
+	if (
+		plan.outcome === DEVELOPMENT_PACKAGE_OUTCOMES.BLOCKED ||
+		plan.outcome === DEVELOPMENT_PACKAGE_OUTCOMES.INELIGIBLE
+	) {
+		return plan;
+	}
+
+	if (plan.outcome === DEVELOPMENT_PACKAGE_OUTCOMES.PR_DRY_RUN) {
+		return dependencies.validatePullRequestCandidate({
+			eventName: input.eventName,
+			outputDirectory: input.outputDirectory,
+			packageDirectory: input.packageDirectory,
+			runId: input.runId,
+			sourceCommit: plan.sourceCommit,
+			workspaceDirectory: input.workspaceDirectory,
+		});
+	}
+
+	const candidate = await dependencies.prepareCandidate({
+		outputDirectory: input.outputDirectory,
+		packageDirectory: input.packageDirectory,
+		runId: input.runId,
+		sourceCommit: plan.sourceCommit,
+	});
+	return dependencies.publishAndVerifyCandidate({
+		...candidate,
+		workspaceDirectory: input.workspaceDirectory,
+	});
+}
+
+async function main() {
+	const { values } = parseArgs({
+		options: {
+			"event-name": { type: "string" },
+			"expected-action": { type: "string" },
+			"prerequisite-result": { type: "string" },
+			"pull-request-head-sha": { type: "string" },
+			ref: { type: "string" },
+			repository: { type: "string" },
+			"source-commit": { type: "string" },
+		},
+		strict: true,
+	});
+	const plan = assertDevelopmentPackageAction(
+		{
+			eventName: values["event-name"],
+			prerequisiteResult: values["prerequisite-result"],
+			pullRequestHeadSha: values["pull-request-head-sha"],
+			ref: values.ref,
+			repository: values.repository,
+			sourceCommit: values["source-commit"],
+		},
+		values["expected-action"],
+	);
+	process.stdout.write(`${JSON.stringify(plan)}\n`);
+}
+
+if (
+	process.argv[1] &&
+	import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+	main().catch((error) => {
+		process.stderr.write(`${error.message}\n`);
+		process.exitCode = 1;
+	});
+}

--- a/scripts/api-package-development-policy.mjs
+++ b/scripts/api-package-development-policy.mjs
@@ -1,7 +1,3 @@
-import { resolve } from "node:path";
-import { pathToFileURL } from "node:url";
-import { parseArgs } from "node:util";
-
 export const DEVELOPMENT_PACKAGE_ACTIONS = Object.freeze({
 	DRY_RUN: "dry-run",
 	PREPARE_MAIN: "prepare-main",
@@ -75,74 +71,4 @@ export function assertDevelopmentPackageAction(context, expectedAction) {
 		);
 	}
 	return plan;
-}
-
-export async function executeDevelopmentPackagePolicy(input, dependencies) {
-	const prerequisiteResult = await dependencies.runPrerequisites();
-	const plan = planDevelopmentPackage({ ...input, prerequisiteResult });
-	if (
-		plan.outcome === DEVELOPMENT_PACKAGE_OUTCOMES.BLOCKED ||
-		plan.outcome === DEVELOPMENT_PACKAGE_OUTCOMES.INELIGIBLE
-	) {
-		return plan;
-	}
-
-	if (plan.outcome === DEVELOPMENT_PACKAGE_OUTCOMES.PR_DRY_RUN) {
-		return dependencies.validatePullRequestCandidate({
-			eventName: input.eventName,
-			outputDirectory: input.outputDirectory,
-			packageDirectory: input.packageDirectory,
-			runId: input.runId,
-			sourceCommit: plan.sourceCommit,
-			workspaceDirectory: input.workspaceDirectory,
-		});
-	}
-
-	const candidate = await dependencies.prepareCandidate({
-		outputDirectory: input.outputDirectory,
-		packageDirectory: input.packageDirectory,
-		runId: input.runId,
-		sourceCommit: plan.sourceCommit,
-	});
-	return dependencies.publishAndVerifyCandidate({
-		...candidate,
-		workspaceDirectory: input.workspaceDirectory,
-	});
-}
-
-async function main() {
-	const { values } = parseArgs({
-		options: {
-			"event-name": { type: "string" },
-			"expected-action": { type: "string" },
-			"prerequisite-result": { type: "string" },
-			"pull-request-head-sha": { type: "string" },
-			ref: { type: "string" },
-			repository: { type: "string" },
-			"source-commit": { type: "string" },
-		},
-		strict: true,
-	});
-	const plan = assertDevelopmentPackageAction(
-		{
-			eventName: values["event-name"],
-			prerequisiteResult: values["prerequisite-result"],
-			pullRequestHeadSha: values["pull-request-head-sha"],
-			ref: values.ref,
-			repository: values.repository,
-			sourceCommit: values["source-commit"],
-		},
-		values["expected-action"],
-	);
-	process.stdout.write(`${JSON.stringify(plan)}\n`);
-}
-
-if (
-	process.argv[1] &&
-	import.meta.url === pathToFileURL(resolve(process.argv[1])).href
-) {
-	main().catch((error) => {
-		process.stderr.write(`${error.message}\n`);
-		process.exitCode = 1;
-	});
 }

--- a/scripts/api-package-development-workflow.test.mjs
+++ b/scripts/api-package-development-workflow.test.mjs
@@ -7,21 +7,27 @@ const workflow = await readFile(
 	"utf8",
 );
 
-test("development package workflow grants pull requests read-only authority", () => {
-	assert.match(workflow, /^on:\n  pull_request:\s*$/m);
+function job(name, nextName) {
+	const start = workflow.indexOf(`  ${name}:`);
+	assert.notEqual(start, -1, `missing ${name} job`);
+	const end = nextName ? workflow.indexOf(`  ${nextName}:`, start) : workflow.length;
+	return workflow.slice(start, end);
+}
+
+test("pull requests retain a read-only dry-run path", () => {
+	assert.match(workflow, /^on:\n  pull_request:\s*\n  push:/m);
 	assert.match(workflow, /^permissions:\n  contents: read\s*$/m);
-	assert.doesNotMatch(workflow, /id-token\s*:\s*write/);
-	assert.doesNotMatch(
-		workflow,
-		/NPM_TOKEN|NODE_AUTH_TOKEN|registry-url|npm publish|npm dist-tag/i,
-	);
+	const dryRun = job("dry-run-candidate", "prepare-main-candidate");
+	assert.match(dryRun, /if: github\.event_name == 'pull_request'/);
+	assert.match(dryRun, /permissions:\n      contents: read/);
+	assert.doesNotMatch(dryRun, /id-token\s*:\s*write|npm publish|npm dist-tag/i);
+	assert.doesNotMatch(workflow, /NPM_TOKEN|NODE_AUTH_TOKEN/);
 });
 
-test("candidate dry run is blocked on every prerequisite gate", () => {
-	assert.match(
-		workflow,
-		/dry-run-candidate:\n(?:.|\n)*?    needs: validate\n/,
-	);
+test("candidate work is blocked on every prerequisite gate", () => {
+	for (const name of ["dry-run-candidate", "prepare-main-candidate"]) {
+		assert.match(job(name), /needs: validate/);
+	}
 	for (const command of [
 		"make typecheck",
 		"make lint",
@@ -34,20 +40,52 @@ test("candidate dry run is blocked on every prerequisite gate", () => {
 	}
 });
 
-test("workflow hands the reviewed commit to one preserved candidate smoke path", () => {
+test("workflow hands each reviewed commit to one preserved candidate path", () => {
+	const dryRun = job("dry-run-candidate", "prepare-main-candidate");
 	assert.match(
-		workflow,
+		dryRun,
 		/--source-commit "\$\{\{ github\.event\.pull_request\.head\.sha \}\}"/,
 	);
-	assert.match(workflow, /node scripts\/api-package-pr-dry-run\.mjs/);
-	assert.match(
-		workflow,
-		/--output-directory \.artifacts\/api-development-candidate\/package/,
-	);
-	assert.match(workflow, /path: \.artifacts\/api-development-candidate\//);
-	assert.match(workflow, /if-no-files-found: error/);
+	assert.match(dryRun, /node scripts\/api-package-pr-dry-run\.mjs/);
+	assert.match(dryRun, /if-no-files-found: error/);
+
+	const prepare = job("prepare-main-candidate", "publish-main-candidate");
+	assert.match(prepare, /--source-commit "\$\{\{ github\.sha \}\}"/);
+	assert.match(prepare, /node scripts\/api-package-candidate\.mjs/);
+	assert.match(prepare, /api-development-main-candidate-/);
 	assert.equal(
-		workflow.match(/node scripts\/api-package-pr-dry-run\.mjs/g)?.length,
+		workflow.match(/node scripts\/api-package-candidate\.mjs/g)?.length,
 		1,
 	);
+});
+
+test("publication is protected-main-only and separately permissioned", () => {
+	assert.match(workflow, /push:\n    branches:\n      - main/);
+	const publish = job("publish-main-candidate");
+	for (const eligibility of [
+		"github.event_name == 'push'",
+		"github.ref == 'refs/heads/main'",
+		"github.repository == 'portpowered/you-agent-factory'",
+	]) {
+		assert.equal(publish.includes(eligibility), true, eligibility);
+	}
+	assert.match(publish, /needs:\n      - validate\n      - prepare-main-candidate/);
+	assert.match(publish, /environment: development-publishing/);
+	assert.match(publish, /runs-on: ubuntu-latest/);
+	assert.match(
+		publish,
+		/permissions:\n      contents: read\n      id-token: write/,
+	);
+	assert.doesNotMatch(publish, /permissions:\n(?:      (?!contents: read|id-token: write).+\n)+/);
+});
+
+test("publish job uses the preserved candidate with trusted npm and exact verification", () => {
+	const publish = job("publish-main-candidate");
+	assert.match(workflow, /NODE_VERSION: 24/);
+	assert.match(workflow, /NPM_VERSION: 11\.15\.0/);
+	assert.match(publish, /ref: \$\{\{ github\.sha \}\}/);
+	assert.match(publish, /actions\/download-artifact@v4/);
+	assert.match(publish, /api-development-main-candidate-/);
+	assert.match(publish, /node scripts\/api-package-publish\.mjs/);
+	assert.doesNotMatch(publish, /--tag\s+latest|npm dist-tag/i);
 });

--- a/scripts/api-package-development-workflow.test.mjs
+++ b/scripts/api-package-development-workflow.test.mjs
@@ -1,91 +1,135 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
 import test from "node:test";
 
-const workflow = await readFile(
-	new URL("../.github/workflows/development-package.yml", import.meta.url),
-	"utf8",
-);
+import {
+	DEVELOPMENT_PACKAGE_OUTCOMES,
+	executeDevelopmentPackagePolicy,
+} from "./api-package-development-policy.mjs";
 
-function job(name, nextName) {
-	const start = workflow.indexOf(`  ${name}:`);
-	assert.notEqual(start, -1, `missing ${name} job`);
-	const end = nextName ? workflow.indexOf(`  ${nextName}:`, start) : workflow.length;
-	return workflow.slice(start, end);
+const sourceCommit = "0123456789abcdef0123456789abcdef01234567";
+
+function fixture(context = {}, prerequisiteResult = "success") {
+	const calls = { dryRun: [], prepare: [], publish: [], prerequisites: 0 };
+	const candidate = {
+		evidence: { sourceCommit, distTag: "dev" },
+		tarballPath: "/preserved/candidate.tgz",
+	};
+	return {
+		calls,
+		input: {
+			eventName: "pull_request",
+			outputDirectory: "/preserved",
+			packageDirectory: "packages/api",
+			pullRequestHeadSha: sourceCommit,
+			ref: "refs/pull/1160/merge",
+			repository: "portpowered/you-agent-factory",
+			runId: "42",
+			sourceCommit,
+			workspaceDirectory: "/workspace",
+			...context,
+		},
+		dependencies: {
+			async runPrerequisites() {
+				calls.prerequisites += 1;
+				return prerequisiteResult;
+			},
+			async validatePullRequestCandidate(input) {
+				calls.dryRun.push(input);
+				return { outcome: "DRY_RUN_NO_PUBLISH" };
+			},
+			async prepareCandidate(input) {
+				calls.prepare.push(input);
+				return candidate;
+			},
+			async publishAndVerifyCandidate(input) {
+				calls.publish.push(input);
+				return { outcome: "PUBLISHED_AND_VERIFIED" };
+			},
+		},
+	};
 }
 
-test("pull requests retain a read-only dry-run path", () => {
-	assert.match(workflow, /^on:\n  pull_request:\s*\n  push:/m);
-	assert.match(workflow, /^permissions:\n  contents: read\s*$/m);
-	const dryRun = job("dry-run-candidate", "prepare-main-candidate");
-	assert.match(dryRun, /if: github\.event_name == 'pull_request'/);
-	assert.match(dryRun, /permissions:\n      contents: read/);
-	assert.doesNotMatch(dryRun, /id-token\s*:\s*write|npm publish|npm dist-tag/i);
-	assert.doesNotMatch(workflow, /NPM_TOKEN|NODE_AUTH_TOKEN/);
+test("pull request success reaches only the exact-head dry-run boundary", async () => {
+	const subject = fixture();
+	const result = await executeDevelopmentPackagePolicy(
+		subject.input,
+		subject.dependencies,
+	);
+
+	assert.equal(result.outcome, "DRY_RUN_NO_PUBLISH");
+	assert.equal(subject.calls.prerequisites, 1);
+	assert.equal(subject.calls.dryRun.length, 1);
+	assert.equal(subject.calls.dryRun[0].sourceCommit, sourceCommit);
+	assert.equal(subject.calls.dryRun[0].outputDirectory, "/preserved");
+	assert.deepEqual(subject.calls.prepare, []);
+	assert.deepEqual(subject.calls.publish, []);
 });
 
-test("candidate work is blocked on every prerequisite gate", () => {
-	for (const name of ["dry-run-candidate", "prepare-main-candidate"]) {
-		assert.match(job(name), /needs: validate/);
-	}
-	for (const command of [
-		"make typecheck",
-		"make lint",
-		"make test",
-		"make contracts-smoke",
-		"make api-smoke",
-		"make api-package-pack-smoke",
+test("failed prerequisites block every candidate and publication boundary", async () => {
+	const subject = fixture({}, "failure");
+	const result = await executeDevelopmentPackagePolicy(
+		subject.input,
+		subject.dependencies,
+	);
+
+	assert.equal(result.outcome, DEVELOPMENT_PACKAGE_OUTCOMES.BLOCKED);
+	assert.deepEqual(subject.calls.dryRun, []);
+	assert.deepEqual(subject.calls.prepare, []);
+	assert.deepEqual(subject.calls.publish, []);
+});
+
+test("protected main prepares once and hands that preserved candidate to publish and verify", async () => {
+	const subject = fixture({
+		eventName: "push",
+		pullRequestHeadSha: undefined,
+		ref: "refs/heads/main",
+	});
+	const result = await executeDevelopmentPackagePolicy(
+		subject.input,
+		subject.dependencies,
+	);
+
+	assert.equal(result.outcome, "PUBLISHED_AND_VERIFIED");
+	assert.equal(subject.calls.prepare.length, 1);
+	assert.deepEqual(subject.calls.prepare[0], {
+		outputDirectory: "/preserved",
+		packageDirectory: "packages/api",
+		runId: "42",
+		sourceCommit,
+	});
+	assert.equal(subject.calls.publish.length, 1);
+	assert.equal(subject.calls.publish[0].tarballPath, "/preserved/candidate.tgz");
+	assert.equal(subject.calls.publish[0].evidence.distTag, "dev");
+	assert.equal(subject.calls.publish[0].evidence.sourceCommit, sourceCommit);
+	assert.equal(subject.calls.publish[0].workspaceDirectory, "/workspace");
+	assert.deepEqual(subject.calls.dryRun, []);
+});
+
+test("fork pushes, other branches, and tags never reach OIDC-authorized publication", async () => {
+	for (const context of [
+		{ eventName: "push", ref: "refs/heads/main", repository: "fork/factory" },
+		{ eventName: "push", ref: "refs/heads/feature" },
+		{ eventName: "push", ref: "refs/tags/v1.0.0" },
 	]) {
-		assert.equal(workflow.includes(`run: ${command}`), true, command);
+		const subject = fixture({ ...context, pullRequestHeadSha: undefined });
+		const result = await executeDevelopmentPackagePolicy(
+			subject.input,
+			subject.dependencies,
+		);
+
+		assert.equal(result.outcome, DEVELOPMENT_PACKAGE_OUTCOMES.INELIGIBLE);
+		assert.deepEqual(subject.calls.dryRun, []);
+		assert.deepEqual(subject.calls.prepare, []);
+		assert.deepEqual(subject.calls.publish, []);
 	}
 });
 
-test("workflow hands each reviewed commit to one preserved candidate path", () => {
-	const dryRun = job("dry-run-candidate", "prepare-main-candidate");
-	assert.match(
-		dryRun,
-		/--source-commit "\$\{\{ github\.event\.pull_request\.head\.sha \}\}"/,
+test("pull request candidate handoff rejects a commit other than the reviewed head", async () => {
+	const subject = fixture({ sourceCommit: "f".repeat(40) });
+	await assert.rejects(
+		executeDevelopmentPackagePolicy(subject.input, subject.dependencies),
+		/reviewed head SHA/,
 	);
-	assert.match(dryRun, /node scripts\/api-package-pr-dry-run\.mjs/);
-	assert.match(dryRun, /if-no-files-found: error/);
-
-	const prepare = job("prepare-main-candidate", "publish-main-candidate");
-	assert.match(prepare, /--source-commit "\$\{\{ github\.sha \}\}"/);
-	assert.match(prepare, /node scripts\/api-package-candidate\.mjs/);
-	assert.match(prepare, /api-development-main-candidate-/);
-	assert.equal(
-		workflow.match(/node scripts\/api-package-candidate\.mjs/g)?.length,
-		1,
-	);
-});
-
-test("publication is protected-main-only and separately permissioned", () => {
-	assert.match(workflow, /push:\n    branches:\n      - main/);
-	const publish = job("publish-main-candidate");
-	for (const eligibility of [
-		"github.event_name == 'push'",
-		"github.ref == 'refs/heads/main'",
-		"github.repository == 'portpowered/you-agent-factory'",
-	]) {
-		assert.equal(publish.includes(eligibility), true, eligibility);
-	}
-	assert.match(publish, /needs:\n      - validate\n      - prepare-main-candidate/);
-	assert.match(publish, /environment: development-publishing/);
-	assert.match(publish, /runs-on: ubuntu-latest/);
-	assert.match(
-		publish,
-		/permissions:\n      contents: read\n      id-token: write/,
-	);
-	assert.doesNotMatch(publish, /permissions:\n(?:      (?!contents: read|id-token: write).+\n)+/);
-});
-
-test("publish job uses the preserved candidate with trusted npm and exact verification", () => {
-	const publish = job("publish-main-candidate");
-	assert.match(workflow, /NODE_VERSION: 24/);
-	assert.match(workflow, /NPM_VERSION: 11\.15\.0/);
-	assert.match(publish, /ref: \$\{\{ github\.sha \}\}/);
-	assert.match(publish, /actions\/download-artifact@v4/);
-	assert.match(publish, /api-development-main-candidate-/);
-	assert.match(publish, /node scripts\/api-package-publish\.mjs/);
-	assert.doesNotMatch(publish, /--tag\s+latest|npm dist-tag/i);
+	assert.deepEqual(subject.calls.dryRun, []);
+	assert.deepEqual(subject.calls.publish, []);
 });

--- a/scripts/api-package-development-workflow.test.mjs
+++ b/scripts/api-package-development-workflow.test.mjs
@@ -1,25 +1,27 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import {
-	DEVELOPMENT_PACKAGE_OUTCOMES,
-	executeDevelopmentPackagePolicy,
-} from "./api-package-development-policy.mjs";
+import { executeDevelopmentPackageCommand } from "./api-package-development-command.mjs";
+import { DEVELOPMENT_PACKAGE_ACTIONS } from "./api-package-development-policy.mjs";
 
 const sourceCommit = "0123456789abcdef0123456789abcdef01234567";
 
-function fixture(context = {}, prerequisiteResult = "success") {
-	const calls = { dryRun: [], prepare: [], publish: [], prerequisites: 0 };
+function fixture(context = {}) {
+	const calls = { dryRun: [], prepare: [], publish: [] };
 	const candidate = {
 		evidence: { sourceCommit, distTag: "dev" },
+		evidencePath: "/preserved/candidate-evidence.json",
 		tarballPath: "/preserved/candidate.tgz",
 	};
 	return {
 		calls,
 		input: {
+			action: DEVELOPMENT_PACKAGE_ACTIONS.DRY_RUN,
+			candidateDirectory: "/preserved",
 			eventName: "pull_request",
 			outputDirectory: "/preserved",
 			packageDirectory: "packages/api",
+			prerequisiteResult: "success",
 			pullRequestHeadSha: sourceCommit,
 			ref: "refs/pull/1160/merge",
 			repository: "portpowered/you-agent-factory",
@@ -29,10 +31,6 @@ function fixture(context = {}, prerequisiteResult = "success") {
 			...context,
 		},
 		dependencies: {
-			async runPrerequisites() {
-				calls.prerequisites += 1;
-				return prerequisiteResult;
-			},
 			async validatePullRequestCandidate(input) {
 				calls.dryRun.push(input);
 				return { outcome: "DRY_RUN_NO_PUBLISH" };
@@ -41,7 +39,7 @@ function fixture(context = {}, prerequisiteResult = "success") {
 				calls.prepare.push(input);
 				return candidate;
 			},
-			async publishAndVerifyCandidate(input) {
+			async publishCandidateDirectory(input) {
 				calls.publish.push(input);
 				return { outcome: "PUBLISHED_AND_VERIFIED" };
 			},
@@ -49,87 +47,109 @@ function fixture(context = {}, prerequisiteResult = "success") {
 	};
 }
 
-test("pull request success reaches only the exact-head dry-run boundary", async () => {
+test("production pull request command reaches only exact-head dry-run", async () => {
 	const subject = fixture();
-	const result = await executeDevelopmentPackagePolicy(
+	const result = await executeDevelopmentPackageCommand(
 		subject.input,
 		subject.dependencies,
 	);
 
 	assert.equal(result.outcome, "DRY_RUN_NO_PUBLISH");
-	assert.equal(subject.calls.prerequisites, 1);
-	assert.equal(subject.calls.dryRun.length, 1);
-	assert.equal(subject.calls.dryRun[0].sourceCommit, sourceCommit);
-	assert.equal(subject.calls.dryRun[0].outputDirectory, "/preserved");
+	assert.deepEqual(subject.calls.dryRun, [
+		{
+			eventName: "pull_request",
+			outputDirectory: "/preserved",
+			packageDirectory: "packages/api",
+			runId: "42",
+			sourceCommit,
+			workspaceDirectory: "/workspace",
+		},
+	]);
 	assert.deepEqual(subject.calls.prepare, []);
 	assert.deepEqual(subject.calls.publish, []);
 });
 
-test("failed prerequisites block every candidate and publication boundary", async () => {
-	const subject = fixture({}, "failure");
-	const result = await executeDevelopmentPackagePolicy(
-		subject.input,
-		subject.dependencies,
-	);
-
-	assert.equal(result.outcome, DEVELOPMENT_PACKAGE_OUTCOMES.BLOCKED);
-	assert.deepEqual(subject.calls.dryRun, []);
-	assert.deepEqual(subject.calls.prepare, []);
-	assert.deepEqual(subject.calls.publish, []);
+test("failed prerequisites block every production action before side effects", async () => {
+	for (const action of Object.values(DEVELOPMENT_PACKAGE_ACTIONS)) {
+		const subject = fixture({
+			action,
+			eventName: action === DEVELOPMENT_PACKAGE_ACTIONS.DRY_RUN ? "pull_request" : "push",
+			prerequisiteResult: "failure",
+			pullRequestHeadSha:
+				action === DEVELOPMENT_PACKAGE_ACTIONS.DRY_RUN ? sourceCommit : undefined,
+			ref:
+				action === DEVELOPMENT_PACKAGE_ACTIONS.DRY_RUN
+					? "refs/pull/1160/merge"
+					: "refs/heads/main",
+		});
+		await assert.rejects(
+			executeDevelopmentPackageCommand(subject.input, subject.dependencies),
+			/not allowed for outcome PREREQUISITES_BLOCKED/,
+		);
+		assert.deepEqual(subject.calls, { dryRun: [], prepare: [], publish: [] });
+	}
 });
 
-test("protected main prepares once and hands that preserved candidate to publish and verify", async () => {
+test("production protected-main commands prepare once and publish the preserved directory", async () => {
 	const subject = fixture({
+		action: DEVELOPMENT_PACKAGE_ACTIONS.PREPARE_MAIN,
 		eventName: "push",
 		pullRequestHeadSha: undefined,
 		ref: "refs/heads/main",
 	});
-	const result = await executeDevelopmentPackagePolicy(
+	const prepared = await executeDevelopmentPackageCommand(
 		subject.input,
 		subject.dependencies,
 	);
 
-	assert.equal(result.outcome, "PUBLISHED_AND_VERIFIED");
-	assert.equal(subject.calls.prepare.length, 1);
-	assert.deepEqual(subject.calls.prepare[0], {
-		outputDirectory: "/preserved",
-		packageDirectory: "packages/api",
-		runId: "42",
-		sourceCommit,
-	});
-	assert.equal(subject.calls.publish.length, 1);
-	assert.equal(subject.calls.publish[0].tarballPath, "/preserved/candidate.tgz");
-	assert.equal(subject.calls.publish[0].evidence.distTag, "dev");
-	assert.equal(subject.calls.publish[0].evidence.sourceCommit, sourceCommit);
-	assert.equal(subject.calls.publish[0].workspaceDirectory, "/workspace");
+	assert.equal(prepared.tarballPath, "/preserved/candidate.tgz");
+	assert.deepEqual(subject.calls.prepare, [
+		{
+			outputDirectory: "/preserved",
+			packageDirectory: "packages/api",
+			runId: "42",
+			sourceCommit,
+		},
+	]);
+	const published = await executeDevelopmentPackageCommand(
+		{ ...subject.input, action: DEVELOPMENT_PACKAGE_ACTIONS.PUBLISH_MAIN },
+		subject.dependencies,
+	);
+
+	assert.equal(published.outcome, "PUBLISHED_AND_VERIFIED");
+	assert.deepEqual(subject.calls.publish, [
+		{
+			candidateDirectory: "/preserved",
+			workspaceDirectory: "/workspace",
+		},
+	]);
 	assert.deepEqual(subject.calls.dryRun, []);
 });
 
-test("fork pushes, other branches, and tags never reach OIDC-authorized publication", async () => {
+test("ineligible production publish commands cannot reach publication", async () => {
 	for (const context of [
 		{ eventName: "push", ref: "refs/heads/main", repository: "fork/factory" },
 		{ eventName: "push", ref: "refs/heads/feature" },
 		{ eventName: "push", ref: "refs/tags/v1.0.0" },
 	]) {
-		const subject = fixture({ ...context, pullRequestHeadSha: undefined });
-		const result = await executeDevelopmentPackagePolicy(
-			subject.input,
-			subject.dependencies,
+		const subject = fixture({
+			...context,
+			action: DEVELOPMENT_PACKAGE_ACTIONS.PUBLISH_MAIN,
+			pullRequestHeadSha: undefined,
+		});
+		await assert.rejects(
+			executeDevelopmentPackageCommand(subject.input, subject.dependencies),
+			/not allowed for outcome EVENT_INELIGIBLE/,
 		);
-
-		assert.equal(result.outcome, DEVELOPMENT_PACKAGE_OUTCOMES.INELIGIBLE);
-		assert.deepEqual(subject.calls.dryRun, []);
-		assert.deepEqual(subject.calls.prepare, []);
-		assert.deepEqual(subject.calls.publish, []);
+		assert.deepEqual(subject.calls, { dryRun: [], prepare: [], publish: [] });
 	}
 });
 
-test("pull request candidate handoff rejects a commit other than the reviewed head", async () => {
+test("production pull request command rejects a commit other than the reviewed head", async () => {
 	const subject = fixture({ sourceCommit: "f".repeat(40) });
 	await assert.rejects(
-		executeDevelopmentPackagePolicy(subject.input, subject.dependencies),
+		executeDevelopmentPackageCommand(subject.input, subject.dependencies),
 		/reviewed head SHA/,
 	);
-	assert.deepEqual(subject.calls.dryRun, []);
-	assert.deepEqual(subject.calls.publish, []);
+	assert.deepEqual(subject.calls, { dryRun: [], prepare: [], publish: [] });
 });

--- a/scripts/api-package-development-workflow.test.mjs
+++ b/scripts/api-package-development-workflow.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const workflow = await readFile(
+	new URL("../.github/workflows/development-package.yml", import.meta.url),
+	"utf8",
+);
+
+test("development package workflow grants pull requests read-only authority", () => {
+	assert.match(workflow, /^on:\n  pull_request:\s*$/m);
+	assert.match(workflow, /^permissions:\n  contents: read\s*$/m);
+	assert.doesNotMatch(workflow, /id-token\s*:\s*write/);
+	assert.doesNotMatch(
+		workflow,
+		/NPM_TOKEN|NODE_AUTH_TOKEN|registry-url|npm publish|npm dist-tag/i,
+	);
+});
+
+test("candidate dry run is blocked on every prerequisite gate", () => {
+	assert.match(
+		workflow,
+		/dry-run-candidate:\n(?:.|\n)*?    needs: validate\n/,
+	);
+	for (const command of [
+		"make typecheck",
+		"make lint",
+		"make test",
+		"make contracts-smoke",
+		"make api-smoke",
+		"make api-package-pack-smoke",
+	]) {
+		assert.equal(workflow.includes(`run: ${command}`), true, command);
+	}
+});
+
+test("workflow hands the reviewed commit to one preserved candidate smoke path", () => {
+	assert.match(
+		workflow,
+		/--source-commit "\$\{\{ github\.event\.pull_request\.head\.sha \}\}"/,
+	);
+	assert.match(workflow, /node scripts\/api-package-pr-dry-run\.mjs/);
+	assert.match(
+		workflow,
+		/--output-directory \.artifacts\/api-development-candidate\/package/,
+	);
+	assert.match(workflow, /path: \.artifacts\/api-development-candidate\//);
+	assert.match(workflow, /if-no-files-found: error/);
+	assert.equal(
+		workflow.match(/node scripts\/api-package-pr-dry-run\.mjs/g)?.length,
+		1,
+	);
+});

--- a/scripts/api-package-pack.mjs
+++ b/scripts/api-package-pack.mjs
@@ -128,6 +128,11 @@ export async function packAndVerify({ packageDirectory, packDestination }) {
 			"[api-package-pack] npm pack report has no valid package name",
 		);
 	}
+	if (typeof report.version !== "string" || report.version.length === 0) {
+		throw new Error(
+			"[api-package-pack] npm pack report has no valid package version",
+		);
+	}
 	const files = report.files?.map((file) => file.path);
 	if (!Array.isArray(files) || files.some((path) => typeof path !== "string")) {
 		throw new Error(
@@ -141,6 +146,7 @@ export async function packAndVerify({ packageDirectory, packDestination }) {
 	return {
 		files: sortedUnique(files),
 		packageName: report.name,
+		packageVersion: report.version,
 		tarballPath,
 	};
 }

--- a/scripts/api-package-pr-dry-run.mjs
+++ b/scripts/api-package-pr-dry-run.mjs
@@ -1,0 +1,102 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+
+import { prepareCandidate } from "./api-package-candidate.mjs";
+import { installAndVerifyTarball } from "./api-package-consumer.mjs";
+
+export const PULL_REQUEST_EVENT = "pull_request";
+export const DRY_RUN_OUTCOME = "DRY_RUN_NO_PUBLISH";
+
+function requireString(value, name) {
+	if (typeof value !== "string" || value.length === 0) {
+		throw new Error(`[api-package-pr-dry-run] ${name} is required`);
+	}
+	return value;
+}
+
+export async function validatePullRequestCandidate(
+	{
+		eventName,
+		outputDirectory,
+		packageDirectory,
+		runId,
+		sourceCommit,
+		workspaceDirectory,
+	},
+	dependencies = {},
+) {
+	if (eventName !== PULL_REQUEST_EVENT) {
+		throw new Error(
+			"[api-package-pr-dry-run] only pull_request events may use the dry-run path",
+		);
+	}
+
+	const prepare = dependencies.prepareCandidate ?? prepareCandidate;
+	const verify = dependencies.installAndVerifyTarball ?? installAndVerifyTarball;
+	const workspaceRoot = resolve(
+		requireString(workspaceDirectory, "workspace directory"),
+	);
+	const prepared = await prepare({
+		packageDirectory: requireString(packageDirectory, "package directory"),
+		outputDirectory: requireString(outputDirectory, "output directory"),
+		runId: requireString(runId, "run ID"),
+		sourceCommit: requireString(sourceCommit, "source commit"),
+	});
+
+	const consumerDirectory = await mkdtemp(
+		join(tmpdir(), "you-api-pr-candidate-consumer-"),
+	);
+	try {
+		await writeFile(
+			join(consumerDirectory, "package.json"),
+			'{"name":"api-pr-candidate-consumer","private":true}\n',
+		);
+		await verify({
+			consumerDirectory,
+			packageName: prepared.evidence.packageName,
+			packedFiles: prepared.evidence.inventory,
+			tarballPath: prepared.tarballPath,
+			workspaceDirectory: workspaceRoot,
+		});
+	} finally {
+		await rm(consumerDirectory, { recursive: true, force: true });
+	}
+
+	return { ...prepared.evidence, outcome: DRY_RUN_OUTCOME };
+}
+
+async function main() {
+	const { values } = parseArgs({
+		options: {
+			"event-name": { type: "string" },
+			"output-directory": { type: "string" },
+			"package-directory": { type: "string" },
+			"run-id": { type: "string" },
+			"source-commit": { type: "string" },
+			"workspace-directory": { type: "string" },
+		},
+		strict: true,
+	});
+	const result = await validatePullRequestCandidate({
+		eventName: values["event-name"],
+		outputDirectory: values["output-directory"],
+		packageDirectory: values["package-directory"],
+		runId: values["run-id"],
+		sourceCommit: values["source-commit"],
+		workspaceDirectory: values["workspace-directory"],
+	});
+	process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (
+	process.argv[1] &&
+	import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+	main().catch((error) => {
+		process.stderr.write(`${error.message}\n`);
+		process.exitCode = 1;
+	});
+}

--- a/scripts/api-package-pr-dry-run.test.mjs
+++ b/scripts/api-package-pr-dry-run.test.mjs
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+	DRY_RUN_OUTCOME,
+	validatePullRequestCandidate,
+} from "./api-package-pr-dry-run.mjs";
+
+const sourceCommit = "0123456789abcdef0123456789abcdef01234567";
+
+async function temporaryDirectory(t, name) {
+	const directory = await mkdtemp(join(tmpdir(), name));
+	t.after(() => rm(directory, { recursive: true, force: true }));
+	return directory;
+}
+
+test("pull request dry run verifies the exact prepared candidate without a registry boundary", async (t) => {
+	const outputDirectory = await temporaryDirectory(t, "you-api-pr-output-");
+	const tarballPath = join(outputDirectory, "candidate.tgz");
+	const evidence = {
+		packageName: "@you-agent-factory/api",
+		candidateVersion: "0.0.0-dev.42.0123456789ab",
+		sourceCommit,
+		contractDigest: `sha256:${"a".repeat(64)}`,
+		artifactDigest: `sha256:${"b".repeat(64)}`,
+		inventory: ["generated/manifest.json", "package.json"],
+		distTag: "dev",
+	};
+	let receivedCandidate;
+
+	const result = await validatePullRequestCandidate(
+		{
+			eventName: "pull_request",
+			outputDirectory,
+			packageDirectory: "packages/api",
+			runId: "42",
+			sourceCommit,
+			workspaceDirectory: process.cwd(),
+		},
+		{
+			prepareCandidate: async (input) => {
+				assert.equal(input.outputDirectory, outputDirectory);
+				return { evidence, tarballPath };
+			},
+			installAndVerifyTarball: async (input) => {
+				receivedCandidate = input;
+			},
+		},
+	);
+
+	assert.equal(receivedCandidate.tarballPath, tarballPath);
+	assert.equal(receivedCandidate.packageName, evidence.packageName);
+	assert.deepEqual(receivedCandidate.packedFiles, evidence.inventory);
+	assert.equal(receivedCandidate.workspaceDirectory, process.cwd());
+	assert.deepEqual(result, { ...evidence, outcome: DRY_RUN_OUTCOME });
+});
+
+test("non-pull-request events fail before candidate preparation", async (t) => {
+	const outputDirectory = await temporaryDirectory(t, "you-api-pr-rejected-");
+	let prepared = false;
+
+	await assert.rejects(
+		validatePullRequestCandidate(
+			{
+				eventName: "push",
+				outputDirectory,
+				packageDirectory: "packages/api",
+				runId: "42",
+				sourceCommit,
+				workspaceDirectory: process.cwd(),
+			},
+			{
+				prepareCandidate: async () => {
+					prepared = true;
+				},
+			},
+		),
+		/only pull_request events may use the dry-run path/,
+	);
+	assert.equal(prepared, false);
+});
+
+test("consumer failure prevents a dry-run success outcome", async (t) => {
+	const outputDirectory = await temporaryDirectory(t, "you-api-pr-failure-");
+
+	await assert.rejects(
+		validatePullRequestCandidate(
+			{
+				eventName: "pull_request",
+				outputDirectory,
+				packageDirectory: "packages/api",
+				runId: "42",
+				sourceCommit,
+				workspaceDirectory: process.cwd(),
+			},
+			{
+				prepareCandidate: async () => ({
+					evidence: {
+						packageName: "@you-agent-factory/api",
+						inventory: ["package.json"],
+					},
+					tarballPath: join(outputDirectory, "candidate.tgz"),
+				}),
+				installAndVerifyTarball: async () => {
+					throw new Error("semantic export verification failed");
+				},
+			},
+		),
+		/semantic export verification failed/,
+	);
+});

--- a/scripts/api-package-publish.mjs
+++ b/scripts/api-package-publish.mjs
@@ -230,6 +230,29 @@ async function candidateFiles(candidateDirectory) {
 	return { evidence, tarballPath: join(directory, tarballs[0]) };
 }
 
+export async function publishCandidateDirectory(
+	{ candidateDirectory, workspaceDirectory },
+	dependencies = {},
+) {
+	const loadCandidate = dependencies.candidateFiles ?? candidateFiles;
+	const publishAndVerify =
+		dependencies.publishAndVerifyCandidate ?? publishAndVerifyCandidate;
+	const registryClient =
+		dependencies.registryClient ?? createNpmRegistryClient();
+	const candidate = await loadCandidate(candidateDirectory);
+	const consumerDirectory = await mkdtemp(join(tmpdir(), "you-api-registry-consumer-"));
+	try {
+		return await publishAndVerify({
+			...candidate,
+			consumerDirectory,
+			registryClient,
+			workspaceDirectory,
+		});
+	} finally {
+		await rm(consumerDirectory, { recursive: true, force: true });
+	}
+}
+
 async function main() {
 	const { values } = parseArgs({
 		options: {
@@ -238,19 +261,11 @@ async function main() {
 		},
 		strict: true,
 	});
-	const candidate = await candidateFiles(values["candidate-directory"]);
-	const consumerDirectory = await mkdtemp(join(tmpdir(), "you-api-registry-consumer-"));
-	try {
-		const result = await publishAndVerifyCandidate({
-			...candidate,
-			consumerDirectory,
-			registryClient: createNpmRegistryClient(),
-			workspaceDirectory: values["workspace-directory"],
-		});
-		process.stdout.write(`${JSON.stringify(result)}\n`);
-	} finally {
-		await rm(consumerDirectory, { recursive: true, force: true });
-	}
+	const result = await publishCandidateDirectory({
+		candidateDirectory: values["candidate-directory"],
+		workspaceDirectory: values["workspace-directory"],
+	});
+	process.stdout.write(`${JSON.stringify(result)}\n`);
 }
 
 if (

--- a/scripts/api-package-publish.mjs
+++ b/scripts/api-package-publish.mjs
@@ -1,0 +1,265 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+
+import { installAndVerifyRegistryPackage } from "./api-package-consumer.mjs";
+import {
+	RECONCILIATION_OUTCOMES,
+	createNpmRegistryClient,
+	reconcileCandidate,
+} from "./api-package-registry.mjs";
+
+export const PUBLICATION_OUTCOMES = Object.freeze({
+	PUBLISHED_AND_VERIFIED: "PUBLISHED_AND_VERIFIED",
+	VERIFIED_EXISTING: "VERIFIED_EXISTING",
+});
+
+export const PUBLICATION_FAILURES = Object.freeze({
+	AUTHENTICATION_FAILED: "PUBLICATION_AUTHENTICATION_FAILED",
+	PERMISSION_FAILED: "PUBLICATION_PERMISSION_FAILED",
+	PUBLISH_FAILED: "PUBLICATION_FAILED",
+	REGISTRY_VERIFICATION_FAILED: "REGISTRY_VERIFICATION_FAILED",
+});
+
+const DEFAULT_VERIFICATION_ATTEMPTS = 6;
+const DEFAULT_VERIFICATION_DELAY_MS = 5_000;
+const DEFAULT_PUBLISH_TIMEOUT_MS = 120_000;
+
+export class PackagePublicationError extends Error {
+	constructor(code, message, options = {}) {
+		super(`[api-package-publish] ${message}`, options);
+		this.name = "PackagePublicationError";
+		this.code = code;
+	}
+}
+
+function publicationFailure(code, message, cause) {
+	return new PackagePublicationError(code, message, { cause });
+}
+
+function approvedDiagnostic(evidence, outcome) {
+	return {
+		packageName: evidence.packageName,
+		candidateVersion: evidence.candidateVersion,
+		sourceCommit: evidence.sourceCommit,
+		contractDigest: evidence.contractDigest,
+		artifactDigest: evidence.artifactDigest,
+		inventory: evidence.inventory,
+		distTag: evidence.distTag,
+		outcome,
+	};
+}
+
+function classifyPublishFailure(output) {
+	if (/\b(?:E401|ENEEDAUTH)\b|\b401\b/.test(output)) {
+		return publicationFailure(
+			PUBLICATION_FAILURES.AUTHENTICATION_FAILED,
+			"npm trusted-publishing authentication failed",
+		);
+	}
+	if (/\bE403\b|\b403\b/.test(output)) {
+		return publicationFailure(
+			PUBLICATION_FAILURES.PERMISSION_FAILED,
+			"npm trusted-publishing permission denied",
+		);
+	}
+	return publicationFailure(
+		PUBLICATION_FAILURES.PUBLISH_FAILED,
+		"npm publish failed",
+	);
+}
+
+export function publishCandidateTarball({
+	tarballPath,
+	distTag,
+	timeoutMs = DEFAULT_PUBLISH_TIMEOUT_MS,
+}) {
+	return new Promise((resolvePromise, rejectPromise) => {
+		const child = spawn(
+			"npm",
+			[
+				"publish",
+				resolve(tarballPath),
+				"--access",
+				"public",
+				"--provenance",
+				"--tag",
+				distTag,
+			],
+			{ shell: process.platform === "win32", stdio: ["ignore", "pipe", "pipe"] },
+		);
+		let output = "";
+		const timeout = setTimeout(() => child.kill(), timeoutMs);
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk) => {
+			output += chunk;
+		});
+		child.stderr.on("data", (chunk) => {
+			output += chunk;
+		});
+		child.on("error", () => {
+			clearTimeout(timeout);
+			rejectPromise(
+				publicationFailure(
+					PUBLICATION_FAILURES.PUBLISH_FAILED,
+					"npm publish could not start",
+				),
+			);
+		});
+		child.on("close", (status) => {
+			clearTimeout(timeout);
+			if (status === 0) {
+				resolvePromise();
+				return;
+			}
+			rejectPromise(classifyPublishFailure(output));
+		});
+	});
+}
+
+function wait(delayMs) {
+	return new Promise((resolvePromise) => setTimeout(resolvePromise, delayMs));
+}
+
+async function verifyPublishedRegistryState({
+	evidence,
+	tarballPath,
+	registryClient,
+	reconcile,
+	verificationAttempts,
+	verificationDelayMs,
+	sleep,
+}) {
+	for (let attempt = 1; attempt <= verificationAttempts; attempt += 1) {
+		const result = await reconcile({ evidence, tarballPath, registryClient });
+		if (result.outcome === RECONCILIATION_OUTCOMES.VERIFIED_EXISTING) {
+			return;
+		}
+		if (attempt < verificationAttempts) {
+			await sleep(verificationDelayMs);
+		}
+	}
+	throw publicationFailure(
+		PUBLICATION_FAILURES.REGISTRY_VERIFICATION_FAILED,
+		"published version did not become digest-verifiable within the bounded verification window",
+	);
+}
+
+export async function publishAndVerifyCandidate(
+	{
+		consumerDirectory,
+		evidence,
+		registryClient,
+		tarballPath,
+		workspaceDirectory,
+		verificationAttempts = DEFAULT_VERIFICATION_ATTEMPTS,
+		verificationDelayMs = DEFAULT_VERIFICATION_DELAY_MS,
+	},
+	dependencies = {},
+) {
+	const reconcile = dependencies.reconcileCandidate ?? reconcileCandidate;
+	const publish = dependencies.publishCandidateTarball ?? publishCandidateTarball;
+	const install =
+		dependencies.installAndVerifyRegistryPackage ??
+		installAndVerifyRegistryPackage;
+	const sleep = dependencies.sleep ?? wait;
+	const initial = await reconcile({ evidence, tarballPath, registryClient });
+	let outcome = PUBLICATION_OUTCOMES.VERIFIED_EXISTING;
+
+	if (initial.outcome === RECONCILIATION_OUTCOMES.PUBLISH_REQUIRED) {
+		let publishError;
+		try {
+			await publish({ tarballPath, distTag: evidence.distTag });
+		} catch (error) {
+			if (
+				error?.code === PUBLICATION_FAILURES.AUTHENTICATION_FAILED ||
+				error?.code === PUBLICATION_FAILURES.PERMISSION_FAILED
+			) {
+				throw error;
+			}
+			publishError = error;
+		}
+		outcome = PUBLICATION_OUTCOMES.PUBLISHED_AND_VERIFIED;
+		try {
+			await verifyPublishedRegistryState({
+				evidence,
+				tarballPath,
+				registryClient,
+				reconcile,
+				verificationAttempts,
+				verificationDelayMs,
+				sleep,
+			});
+		} catch (error) {
+			if (
+				publishError &&
+				error?.code === PUBLICATION_FAILURES.REGISTRY_VERIFICATION_FAILED
+			) {
+				throw publishError;
+			}
+			throw error;
+		}
+	}
+
+	await install({
+		candidateVersion: evidence.candidateVersion,
+		consumerDirectory,
+		packageName: evidence.packageName,
+		packedFiles: evidence.inventory,
+		workspaceDirectory,
+	});
+	return approvedDiagnostic(evidence, outcome);
+}
+
+async function candidateFiles(candidateDirectory) {
+	const directory = resolve(candidateDirectory);
+	const evidence = JSON.parse(
+		await readFile(join(directory, "candidate-evidence.json"), "utf8"),
+	);
+	const tarballs = (await readdir(directory)).filter((name) => name.endsWith(".tgz"));
+	if (tarballs.length !== 1) {
+		throw publicationFailure(
+			PUBLICATION_FAILURES.REGISTRY_VERIFICATION_FAILED,
+			"candidate directory must contain exactly one tarball",
+		);
+	}
+	return { evidence, tarballPath: join(directory, tarballs[0]) };
+}
+
+async function main() {
+	const { values } = parseArgs({
+		options: {
+			"candidate-directory": { type: "string" },
+			"workspace-directory": { type: "string" },
+		},
+		strict: true,
+	});
+	const candidate = await candidateFiles(values["candidate-directory"]);
+	const consumerDirectory = await mkdtemp(join(tmpdir(), "you-api-registry-consumer-"));
+	try {
+		const result = await publishAndVerifyCandidate({
+			...candidate,
+			consumerDirectory,
+			registryClient: createNpmRegistryClient(),
+			workspaceDirectory: values["workspace-directory"],
+		});
+		process.stdout.write(`${JSON.stringify(result)}\n`);
+	} finally {
+		await rm(consumerDirectory, { recursive: true, force: true });
+	}
+}
+
+if (
+	process.argv[1] &&
+	import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+	main().catch((error) => {
+		const code = error?.code ?? PUBLICATION_FAILURES.PUBLISH_FAILED;
+		process.stderr.write(`${code}: ${error.message}\n`);
+		process.exitCode = 1;
+	});
+}

--- a/scripts/api-package-publish.test.mjs
+++ b/scripts/api-package-publish.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { access } from "node:fs/promises";
 import test from "node:test";
 
 import {
@@ -6,6 +7,7 @@ import {
 	PUBLICATION_OUTCOMES,
 	PackagePublicationError,
 	publishAndVerifyCandidate,
+	publishCandidateDirectory,
 } from "./api-package-publish.mjs";
 import { RECONCILIATION_OUTCOMES } from "./api-package-registry.mjs";
 
@@ -206,4 +208,34 @@ test("success diagnostics contain only approved evidence and outcome", async () 
 		"distTag",
 		"outcome",
 	]);
+});
+
+test("publish directory loads the preserved candidate and cleans its external consumer", async () => {
+	const registryClient = {};
+	let consumerDirectory;
+	const result = await publishCandidateDirectory(
+		{
+			candidateDirectory: "/preserved",
+			workspaceDirectory: "/workspace",
+		},
+		{
+			async candidateFiles(candidateDirectory) {
+				assert.equal(candidateDirectory, "/preserved");
+				return { evidence, tarballPath: "/preserved/candidate.tgz" };
+			},
+			async publishAndVerifyCandidate(input) {
+				consumerDirectory = input.consumerDirectory;
+				await access(consumerDirectory);
+				assert.equal(input.evidence, evidence);
+				assert.equal(input.registryClient, registryClient);
+				assert.equal(input.tarballPath, "/preserved/candidate.tgz");
+				assert.equal(input.workspaceDirectory, "/workspace");
+				return { outcome: PUBLICATION_OUTCOMES.VERIFIED_EXISTING };
+			},
+			registryClient,
+		},
+	);
+
+	assert.equal(result.outcome, PUBLICATION_OUTCOMES.VERIFIED_EXISTING);
+	await assert.rejects(access(consumerDirectory));
 });

--- a/scripts/api-package-publish.test.mjs
+++ b/scripts/api-package-publish.test.mjs
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	PUBLICATION_FAILURES,
+	PUBLICATION_OUTCOMES,
+	PackagePublicationError,
+	publishAndVerifyCandidate,
+} from "./api-package-publish.mjs";
+import { RECONCILIATION_OUTCOMES } from "./api-package-registry.mjs";
+
+const evidence = {
+	packageName: "@you-agent-factory/api",
+	candidateVersion: "0.0.0-dev.42.0123456789ab",
+	sourceCommit: "0123456789abcdef0123456789abcdef01234567",
+	contractDigest: `sha256:${"a".repeat(64)}`,
+	artifactDigest: `sha256:${"b".repeat(64)}`,
+	inventory: ["generated/manifest.json", "package.json"],
+	distTag: "dev",
+};
+
+function fixture(overrides = {}) {
+	const calls = { install: 0, publish: 0, reconcile: 0, sleep: 0 };
+	return {
+		calls,
+		input: {
+			consumerDirectory: "/external/consumer",
+			evidence,
+			registryClient: {},
+			tarballPath: "/candidate/package.tgz",
+			workspaceDirectory: "/workspace",
+			verificationDelayMs: 1,
+		},
+		dependencies: {
+			async installAndVerifyRegistryPackage(input) {
+				calls.install += 1;
+				assert.equal(input.candidateVersion, evidence.candidateVersion);
+				assert.equal(input.packageName, evidence.packageName);
+			},
+			async publishCandidateTarball(input) {
+				calls.publish += 1;
+				assert.equal(input.distTag, "dev");
+			},
+			async reconcileCandidate() {
+				calls.reconcile += 1;
+				return { outcome: RECONCILIATION_OUTCOMES.VERIFIED_EXISTING };
+			},
+			async sleep() {
+				calls.sleep += 1;
+			},
+			...overrides,
+		},
+	};
+}
+
+test("matching retry verifies exact clean consumption without publishing", async () => {
+	const subject = fixture();
+	const result = await publishAndVerifyCandidate(
+		subject.input,
+		subject.dependencies,
+	);
+
+	assert.equal(result.outcome, PUBLICATION_OUTCOMES.VERIFIED_EXISTING);
+	assert.deepEqual(subject.calls, {
+		install: 1,
+		publish: 0,
+		reconcile: 1,
+		sleep: 0,
+	});
+});
+
+test("absent candidate publishes once, digest-verifies, and installs exact version", async () => {
+	const outcomes = [
+		RECONCILIATION_OUTCOMES.PUBLISH_REQUIRED,
+		RECONCILIATION_OUTCOMES.PUBLISH_REQUIRED,
+		RECONCILIATION_OUTCOMES.VERIFIED_EXISTING,
+	];
+	const subject = fixture({
+		async reconcileCandidate() {
+			subject.calls.reconcile += 1;
+			return { outcome: outcomes.shift() };
+		},
+	});
+	const result = await publishAndVerifyCandidate(
+		subject.input,
+		subject.dependencies,
+	);
+
+	assert.equal(result.outcome, PUBLICATION_OUTCOMES.PUBLISHED_AND_VERIFIED);
+	assert.deepEqual(subject.calls, {
+		install: 1,
+		publish: 1,
+		reconcile: 3,
+		sleep: 1,
+	});
+});
+
+test("immutable conflicts and permission failures stop without publish or install", async () => {
+	for (const code of [
+		"IMMUTABLE_VERSION_CONFLICT",
+		"REGISTRY_PERMISSION_FAILED",
+	]) {
+		const subject = fixture({
+			async reconcileCandidate() {
+				subject.calls.reconcile += 1;
+				throw new PackagePublicationError(code, "controlled failure");
+			},
+		});
+		await assert.rejects(
+			publishAndVerifyCandidate(subject.input, subject.dependencies),
+			(error) => error.code === code,
+		);
+		assert.equal(subject.calls.publish, 0);
+		assert.equal(subject.calls.install, 0);
+	}
+});
+
+test("post-publish verification is bounded and never republishes", async () => {
+	const subject = fixture({
+		async reconcileCandidate() {
+			subject.calls.reconcile += 1;
+			return { outcome: RECONCILIATION_OUTCOMES.PUBLISH_REQUIRED };
+		},
+	});
+	subject.input.verificationAttempts = 3;
+
+	await assert.rejects(
+		publishAndVerifyCandidate(subject.input, subject.dependencies),
+		(error) =>
+			error.code === PUBLICATION_FAILURES.REGISTRY_VERIFICATION_FAILED,
+	);
+	assert.deepEqual(subject.calls, {
+		install: 0,
+		publish: 1,
+		reconcile: 4,
+		sleep: 2,
+	});
+});
+
+test("ambiguous publish failure succeeds only after matching digest verification", async () => {
+	const outcomes = [
+		RECONCILIATION_OUTCOMES.PUBLISH_REQUIRED,
+		RECONCILIATION_OUTCOMES.VERIFIED_EXISTING,
+	];
+	const subject = fixture({
+		async publishCandidateTarball() {
+			subject.calls.publish += 1;
+			throw new PackagePublicationError(
+				PUBLICATION_FAILURES.PUBLISH_FAILED,
+				"controlled connection loss",
+			);
+		},
+		async reconcileCandidate() {
+			subject.calls.reconcile += 1;
+			return { outcome: outcomes.shift() };
+		},
+	});
+
+	const result = await publishAndVerifyCandidate(
+		subject.input,
+		subject.dependencies,
+	);
+	assert.equal(result.outcome, PUBLICATION_OUTCOMES.PUBLISHED_AND_VERIFIED);
+	assert.equal(subject.calls.publish, 1);
+	assert.equal(subject.calls.reconcile, 2);
+	assert.equal(subject.calls.install, 1);
+});
+
+test("trusted-publishing permission failure does not retry or verify consumption", async () => {
+	const subject = fixture({
+		async reconcileCandidate() {
+			subject.calls.reconcile += 1;
+			return { outcome: RECONCILIATION_OUTCOMES.PUBLISH_REQUIRED };
+		},
+		async publishCandidateTarball() {
+			subject.calls.publish += 1;
+			throw new PackagePublicationError(
+				PUBLICATION_FAILURES.PERMISSION_FAILED,
+				"controlled OIDC permission failure",
+			);
+		},
+	});
+
+	await assert.rejects(
+		publishAndVerifyCandidate(subject.input, subject.dependencies),
+		(error) => error.code === PUBLICATION_FAILURES.PERMISSION_FAILED,
+	);
+	assert.equal(subject.calls.publish, 1);
+	assert.equal(subject.calls.reconcile, 1);
+	assert.equal(subject.calls.install, 0);
+});
+
+test("success diagnostics contain only approved evidence and outcome", async () => {
+	const subject = fixture();
+	const result = await publishAndVerifyCandidate(
+		subject.input,
+		subject.dependencies,
+	);
+	assert.deepEqual(Object.keys(result), [
+		"packageName",
+		"candidateVersion",
+		"sourceCommit",
+		"contractDigest",
+		"artifactDigest",
+		"inventory",
+		"distTag",
+		"outcome",
+	]);
+});

--- a/scripts/api-package-registry.mjs
+++ b/scripts/api-package-registry.mjs
@@ -1,0 +1,331 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+
+import {
+	API_PACKAGE_NAME,
+	DEVELOPMENT_DIST_TAG,
+} from "./api-package-candidate.mjs";
+
+export const RECONCILIATION_OUTCOMES = Object.freeze({
+	PUBLISH_REQUIRED: "PUBLISH_REQUIRED",
+	VERIFIED_EXISTING: "VERIFIED_EXISTING",
+});
+
+export const RECONCILIATION_FAILURES = Object.freeze({
+	CANDIDATE_INVALID: "CANDIDATE_INVALID",
+	CANDIDATE_DIGEST_VERIFICATION_FAILED:
+		"CANDIDATE_DIGEST_VERIFICATION_FAILED",
+	REGISTRY_LOOKUP_FAILED: "REGISTRY_LOOKUP_FAILED",
+	REGISTRY_DOWNLOAD_FAILED: "REGISTRY_DOWNLOAD_FAILED",
+	REGISTRY_AUTHENTICATION_FAILED: "REGISTRY_AUTHENTICATION_FAILED",
+	REGISTRY_PERMISSION_FAILED: "REGISTRY_PERMISSION_FAILED",
+	IMMUTABLE_VERSION_CONFLICT: "IMMUTABLE_VERSION_CONFLICT",
+});
+
+const SHA256_PATTERN = /^sha256:[0-9a-f]{64}$/;
+const SOURCE_COMMIT_PATTERN = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
+const CANDIDATE_VERSION_PATTERN =
+	/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-dev\.([1-9]\d*)\.([0-9a-f]{12})$/;
+const DEFAULT_REGISTRY_TIMEOUT_MS = 30_000;
+
+export class RegistryReconciliationError extends Error {
+	constructor(code, message, options = {}) {
+		super(`[api-package-registry] ${message}`, options);
+		this.name = "RegistryReconciliationError";
+		this.code = code;
+	}
+}
+
+function failure(code, message, cause) {
+	return new RegistryReconciliationError(code, message, { cause });
+}
+
+function requireCandidateEvidence(evidence) {
+	if (!evidence || typeof evidence !== "object" || Array.isArray(evidence)) {
+		throw failure(
+			RECONCILIATION_FAILURES.CANDIDATE_INVALID,
+			"candidate evidence must be an object",
+		);
+	}
+	const versionMatch = CANDIDATE_VERSION_PATTERN.exec(evidence.candidateVersion);
+	if (
+		evidence.packageName !== API_PACKAGE_NAME ||
+		!versionMatch ||
+		!SOURCE_COMMIT_PATTERN.test(evidence.sourceCommit ?? "") ||
+		versionMatch[5] !== evidence.sourceCommit.slice(0, 12) ||
+		!SHA256_PATTERN.test(evidence.contractDigest ?? "") ||
+		!SHA256_PATTERN.test(evidence.artifactDigest ?? "") ||
+		!Array.isArray(evidence.inventory) ||
+		evidence.inventory.some((path) => typeof path !== "string") ||
+		evidence.distTag !== DEVELOPMENT_DIST_TAG
+	) {
+		throw failure(
+			RECONCILIATION_FAILURES.CANDIDATE_INVALID,
+			"candidate evidence has invalid or inconsistent identity fields",
+		);
+	}
+	return evidence;
+}
+
+function sha256(contents) {
+	return `sha256:${createHash("sha256").update(contents).digest("hex")}`;
+}
+
+function diagnostic(evidence, outcome) {
+	return {
+		packageName: evidence.packageName,
+		candidateVersion: evidence.candidateVersion,
+		sourceCommit: evidence.sourceCommit,
+		contractDigest: evidence.contractDigest,
+		artifactDigest: evidence.artifactDigest,
+		inventory: evidence.inventory,
+		distTag: evidence.distTag,
+		outcome,
+	};
+}
+
+function dependencyFailure(error, fallbackCode, fallbackMessage) {
+	if (error instanceof RegistryReconciliationError) {
+		return error;
+	}
+	return failure(fallbackCode, fallbackMessage, error);
+}
+
+export async function reconcileCandidate({
+	evidence,
+	tarballPath,
+	registryClient,
+}) {
+	const candidate = requireCandidateEvidence(evidence);
+	if (
+		!registryClient ||
+		typeof registryClient.lookupVersion !== "function" ||
+		typeof registryClient.downloadTarball !== "function"
+	) {
+		throw failure(
+			RECONCILIATION_FAILURES.CANDIDATE_INVALID,
+			"registry client must provide lookupVersion and downloadTarball",
+		);
+	}
+
+	let localContents;
+	try {
+		localContents = await readFile(resolve(tarballPath));
+	} catch (error) {
+		throw failure(
+			RECONCILIATION_FAILURES.CANDIDATE_DIGEST_VERIFICATION_FAILED,
+			"candidate tarball could not be read for digest verification",
+			error,
+		);
+	}
+	if (sha256(localContents) !== candidate.artifactDigest) {
+		throw failure(
+			RECONCILIATION_FAILURES.CANDIDATE_DIGEST_VERIFICATION_FAILED,
+			"candidate tarball digest does not match candidate evidence",
+		);
+	}
+
+	let registryVersion;
+	try {
+		registryVersion = await registryClient.lookupVersion({
+			packageName: candidate.packageName,
+			version: candidate.candidateVersion,
+		});
+	} catch (error) {
+		throw dependencyFailure(
+			error,
+			RECONCILIATION_FAILURES.REGISTRY_LOOKUP_FAILED,
+			"registry version lookup failed",
+		);
+	}
+	if (registryVersion?.status === "absent") {
+		return diagnostic(candidate, RECONCILIATION_OUTCOMES.PUBLISH_REQUIRED);
+	}
+	if (
+		registryVersion?.status !== "present" ||
+		typeof registryVersion.tarballUrl !== "string" ||
+		registryVersion.tarballUrl.length === 0
+	) {
+		throw failure(
+			RECONCILIATION_FAILURES.REGISTRY_LOOKUP_FAILED,
+			"registry version lookup returned an invalid response",
+		);
+	}
+
+	let registryContents;
+	try {
+		registryContents = await registryClient.downloadTarball(
+			registryVersion.tarballUrl,
+		);
+	} catch (error) {
+		throw dependencyFailure(
+			error,
+			RECONCILIATION_FAILURES.REGISTRY_DOWNLOAD_FAILED,
+			"registry tarball download failed",
+		);
+	}
+	if (sha256(registryContents) !== candidate.artifactDigest) {
+		throw failure(
+			RECONCILIATION_FAILURES.IMMUTABLE_VERSION_CONFLICT,
+			"existing registry version has a different immutable tarball digest",
+		);
+	}
+
+	return diagnostic(candidate, RECONCILIATION_OUTCOMES.VERIFIED_EXISTING);
+}
+
+function classifyNpmFailure(output) {
+	if (/\b(?:E401|ENEEDAUTH)\b|\b401\b/.test(output)) {
+		return failure(
+			RECONCILIATION_FAILURES.REGISTRY_AUTHENTICATION_FAILED,
+			"registry authentication failed",
+		);
+	}
+	if (/\bE403\b|\b403\b/.test(output)) {
+		return failure(
+			RECONCILIATION_FAILURES.REGISTRY_PERMISSION_FAILED,
+			"registry permission denied",
+		);
+	}
+	if (/\bE404\b|\b404\b/.test(output)) {
+		return { status: "absent" };
+	}
+	return failure(
+		RECONCILIATION_FAILURES.REGISTRY_LOOKUP_FAILED,
+		"registry version lookup failed",
+	);
+}
+
+function runNpmView(packageName, version, timeoutMs) {
+	return new Promise((resolvePromise, rejectPromise) => {
+		const child = spawn(
+			"npm",
+			["view", `${packageName}@${version}`, "dist.tarball", "--json"],
+			{
+				shell: process.platform === "win32",
+				stdio: ["ignore", "pipe", "pipe"],
+			},
+		);
+		let stdout = "";
+		let stderr = "";
+		const timeout = setTimeout(() => child.kill(), timeoutMs);
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk) => {
+			stdout += chunk;
+		});
+		child.stderr.on("data", (chunk) => {
+			stderr += chunk;
+		});
+		child.on("error", (error) => {
+			clearTimeout(timeout);
+			rejectPromise(error);
+		});
+		child.on("close", (status) => {
+			clearTimeout(timeout);
+			if (status !== 0) {
+				resolvePromise(classifyNpmFailure(`${stdout}\n${stderr}`));
+				return;
+			}
+			try {
+				const tarballUrl = JSON.parse(stdout);
+				if (typeof tarballUrl !== "string" || tarballUrl.length === 0) {
+					throw new Error("invalid tarball URL");
+				}
+				resolvePromise({ status: "present", tarballUrl });
+			} catch (error) {
+				rejectPromise(
+					failure(
+						RECONCILIATION_FAILURES.REGISTRY_LOOKUP_FAILED,
+						"registry version lookup returned invalid JSON",
+						error,
+					),
+				);
+			}
+		});
+	});
+}
+
+function downloadRegistryTarball(url, timeoutMs) {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), timeoutMs);
+	return fetch(url, { signal: controller.signal })
+		.then(async (response) => {
+			if (response.status === 401) {
+				throw failure(
+					RECONCILIATION_FAILURES.REGISTRY_AUTHENTICATION_FAILED,
+					"registry authentication failed while downloading tarball",
+				);
+			}
+			if (response.status === 403) {
+				throw failure(
+					RECONCILIATION_FAILURES.REGISTRY_PERMISSION_FAILED,
+					"registry permission denied while downloading tarball",
+				);
+			}
+			if (!response.ok) {
+				throw failure(
+					RECONCILIATION_FAILURES.REGISTRY_DOWNLOAD_FAILED,
+					"registry tarball download failed",
+				);
+			}
+			return new Uint8Array(await response.arrayBuffer());
+		})
+		.catch((error) => {
+			throw dependencyFailure(
+				error,
+				RECONCILIATION_FAILURES.REGISTRY_DOWNLOAD_FAILED,
+				"registry tarball download failed",
+			);
+		})
+		.finally(() => clearTimeout(timeout));
+}
+
+export function createNpmRegistryClient({
+	timeoutMs = DEFAULT_REGISTRY_TIMEOUT_MS,
+} = {}) {
+	return {
+		async lookupVersion({ packageName, version }) {
+			const result = await runNpmView(packageName, version, timeoutMs);
+			if (result instanceof RegistryReconciliationError) {
+				throw result;
+			}
+			return result;
+		},
+		downloadTarball(url) {
+			return downloadRegistryTarball(url, timeoutMs);
+		},
+	};
+}
+
+async function main() {
+	const { values } = parseArgs({
+		options: {
+			"evidence-file": { type: "string" },
+			"tarball-file": { type: "string" },
+		},
+		strict: true,
+	});
+	const evidence = JSON.parse(await readFile(values["evidence-file"], "utf8"));
+	const result = await reconcileCandidate({
+		evidence,
+		tarballPath: values["tarball-file"],
+		registryClient: createNpmRegistryClient(),
+	});
+	process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (
+	process.argv[1] &&
+	import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+	main().catch((error) => {
+		const code = error?.code ?? RECONCILIATION_FAILURES.CANDIDATE_INVALID;
+		process.stderr.write(`${code}: ${error.message}\n`);
+		process.exitCode = 1;
+	});
+}

--- a/scripts/api-package-registry.test.mjs
+++ b/scripts/api-package-registry.test.mjs
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+	RECONCILIATION_FAILURES,
+	RECONCILIATION_OUTCOMES,
+	RegistryReconciliationError,
+	reconcileCandidate,
+} from "./api-package-registry.mjs";
+
+const sourceCommit = "0123456789abcdef0123456789abcdef01234567";
+
+function digest(contents) {
+	return `sha256:${createHash("sha256").update(contents).digest("hex")}`;
+}
+
+async function candidateFixture(t) {
+	const directory = await mkdtemp(join(tmpdir(), "you-api-registry-"));
+	t.after(() => rm(directory, { recursive: true, force: true }));
+	const tarballPath = join(directory, "candidate.tgz");
+	const contents = Buffer.from("reviewed immutable candidate");
+	await writeFile(tarballPath, contents);
+	return {
+		contents,
+		tarballPath,
+		evidence: {
+			packageName: "@you-agent-factory/api",
+			candidateVersion: "0.0.0-dev.42.0123456789ab",
+			sourceCommit,
+			contractDigest: digest("contract manifest"),
+			artifactDigest: digest(contents),
+			inventory: ["LICENSE.md", "package.json"],
+			distTag: "dev",
+		},
+	};
+}
+
+function registrySpy({ lookup, download }) {
+	const calls = { lookup: 0, download: 0, publish: 0 };
+	return {
+		calls,
+		async lookupVersion(input) {
+			calls.lookup += 1;
+			return lookup(input);
+		},
+		async downloadTarball(url) {
+			calls.download += 1;
+			return download(url);
+		},
+		async publish() {
+			calls.publish += 1;
+		},
+	};
+}
+
+test("absent version returns one publish decision without mutating registry state", async (t) => {
+	const candidate = await candidateFixture(t);
+	const registryClient = registrySpy({
+		lookup: async () => ({ status: "absent" }),
+		download: async () => assert.fail("absent versions must not be downloaded"),
+	});
+
+	const result = await reconcileCandidate({ ...candidate, registryClient });
+
+	assert.equal(result.outcome, RECONCILIATION_OUTCOMES.PUBLISH_REQUIRED);
+	assert.deepEqual(registryClient.calls, { lookup: 1, download: 0, publish: 0 });
+});
+
+test("matching existing version is verified without publish or tag mutation", async (t) => {
+	const candidate = await candidateFixture(t);
+	const registryClient = registrySpy({
+		lookup: async () => ({
+			status: "present",
+			tarballUrl: "https://registry.example.test/candidate.tgz",
+		}),
+		download: async () => candidate.contents,
+	});
+
+	const result = await reconcileCandidate({ ...candidate, registryClient });
+
+	assert.equal(result.outcome, RECONCILIATION_OUTCOMES.VERIFIED_EXISTING);
+	assert.deepEqual(registryClient.calls, { lookup: 1, download: 1, publish: 0 });
+});
+
+test("different existing tarball fails as an immutable conflict", async (t) => {
+	const candidate = await candidateFixture(t);
+	const registryClient = registrySpy({
+		lookup: async () => ({ status: "present", tarballUrl: "controlled" }),
+		download: async () => Buffer.from("different registry tarball"),
+	});
+
+	await assert.rejects(
+		reconcileCandidate({ ...candidate, registryClient }),
+		(error) =>
+			error.code === RECONCILIATION_FAILURES.IMMUTABLE_VERSION_CONFLICT,
+	);
+	assert.deepEqual(registryClient.calls, { lookup: 1, download: 1, publish: 0 });
+});
+
+test("permission failure stays distinct and cannot fall through to publish", async (t) => {
+	const candidate = await candidateFixture(t);
+	const registryClient = registrySpy({
+		lookup: async () => {
+			throw new RegistryReconciliationError(
+				RECONCILIATION_FAILURES.REGISTRY_PERMISSION_FAILED,
+				"registry permission denied",
+			);
+		},
+		download: async () => assert.fail("permission failures must stop lookup"),
+	});
+
+	await assert.rejects(
+		reconcileCandidate({ ...candidate, registryClient }),
+		(error) => error.code === RECONCILIATION_FAILURES.REGISTRY_PERMISSION_FAILED,
+	);
+	assert.deepEqual(registryClient.calls, { lookup: 1, download: 0, publish: 0 });
+});
+
+test("lookup, download, authentication, and candidate digest failures stay distinct", async (t) => {
+	const candidate = await candidateFixture(t);
+	const cases = [
+		{
+			expected: RECONCILIATION_FAILURES.REGISTRY_LOOKUP_FAILED,
+			registryClient: registrySpy({
+				lookup: async () => {
+					throw new Error("controlled lookup outage");
+				},
+				download: async () => undefined,
+			}),
+		},
+		{
+			expected: RECONCILIATION_FAILURES.REGISTRY_DOWNLOAD_FAILED,
+			registryClient: registrySpy({
+				lookup: async () => ({ status: "present", tarballUrl: "controlled" }),
+				download: async () => {
+					throw new Error("controlled download outage");
+				},
+			}),
+		},
+		{
+			expected: RECONCILIATION_FAILURES.REGISTRY_AUTHENTICATION_FAILED,
+			registryClient: registrySpy({
+				lookup: async () => {
+					throw new RegistryReconciliationError(
+						RECONCILIATION_FAILURES.REGISTRY_AUTHENTICATION_FAILED,
+						"registry authentication failed",
+					);
+				},
+				download: async () => undefined,
+			}),
+		},
+	];
+
+	for (const { expected, registryClient } of cases) {
+		await assert.rejects(
+			reconcileCandidate({ ...candidate, registryClient }),
+			(error) => error.code === expected,
+		);
+		assert.equal(registryClient.calls.publish, 0);
+	}
+
+	await writeFile(candidate.tarballPath, "locally modified candidate");
+	const unusedRegistry = registrySpy({
+		lookup: async () => assert.fail("invalid candidates must fail locally"),
+		download: async () => undefined,
+	});
+	await assert.rejects(
+		reconcileCandidate({ ...candidate, registryClient: unusedRegistry }),
+		(error) =>
+			error.code ===
+			RECONCILIATION_FAILURES.CANDIDATE_DIGEST_VERIFICATION_FAILED,
+	);
+	assert.deepEqual(unusedRegistry.calls, { lookup: 0, download: 0, publish: 0 });
+});
+
+test("reconciliation diagnostics expose only approved candidate fields and outcome", async (t) => {
+	const candidate = await candidateFixture(t);
+	const registryClient = registrySpy({
+		lookup: async () => ({ status: "absent" }),
+		download: async () => undefined,
+	});
+	const result = await reconcileCandidate({ ...candidate, registryClient });
+
+	assert.deepEqual(Object.keys(result), [
+		"packageName",
+		"candidateVersion",
+		"sourceCommit",
+		"contractDigest",
+		"artifactDigest",
+		"inventory",
+		"distTag",
+		"outcome",
+	]);
+});


### PR DESCRIPTION
{
  "project": "Trusted immutable development publication for the contract package",
  "branchName": "interfaces-b19-dev-publish",
  "description": "Add a dedicated development-publication workflow for @you-agent-factory/api so pull requests validate and smoke-test the exact candidate tarball without publishing, while successful protected-main runs publish a unique immutable <base>-dev.<run>.<short-sha> version under the dev dist-tag through npm trusted publishing, OIDC, provenance, and deterministic digest-verified retry handling.",
  "context": {
    "customerAsk": "Add a dedicated package-development workflow that validates the exact @you-agent-factory/api tarball on pull requests without publishing and publishes eligible protected-main candidates as <base>-dev.<run>.<short-sha> under the dev dist-tag through npm trusted publishing, GitHub Actions OIDC, provenance, public access, and no long-lived npm token. Make retries idempotent only for matching registry tarballs, fail immutable conflicts and permission errors without mutation, verify clean consumption, emit only approved non-sensitive diagnostics, and leave stable release and downstream documentation work unchanged.",
    "problem": "The repository already proves contract generation, parity, reviewed package inventory, and isolated local consumption, but it has no dedicated trusted path for publishing that exact artifact as an immutable development package. Pull requests need publication-equivalent evidence without registry authority, and protected-main retries need an explicit fail-closed contract so a partial success cannot cause an overwrite, accept a mismatched artifact, or hide an authentication failure.",
    "solution": "Add a small deterministic helper surface for candidate versioning, evidence, digest comparison, and registry reconciliation, then use it from a separate GitHub Actions workflow. Validation jobs build one candidate after all prerequisite gates and stop at dry-run for pull requests. A separately permissioned protected-main job uses OIDC to publish an absent candidate once with public access, provenance, and the dev tag; verifies a matching existing version idempotently; rejects conflicts and dependency failures; and confirms the exact registry version in a clean consumer."
  },
  "acceptanceCriteria": [
    "AC-1: Every pull request run completes the required contract, repeated generation/drift, package allowlist, isolated-consumer, and relevant repository verification gates against one identified @you-agent-factory/api candidate tarball and performs no registry write.",
    "AC-2: A successful eligible run for the protected main branch derives exactly <base>-dev.<run>.<short-sha>, publishes the reviewed tarball once under the dev dist-tag with public access and provenance, and never uses a long-lived npm token.",
    "AC-3: Publication cannot begin until all prerequisite validation jobs succeed, and the publishing job has only contents: read and id-token: write permissions on a GitHub-hosted runner with the configured protected deployment environment.",
    "AC-4: An absent version is publishable; an existing version with the same verified registry tarball digest succeeds without republishing; and an existing version with a different digest fails as an immutable conflict without changing the version or dist-tag.",
    "AC-5: Permission/OIDC failures and all publish decisions emit actionable diagnostics limited to package name, candidate version, source commit, contract digest, artifact digest and inventory, dist-tag, and outcome.",
    "AC-6: A newly published or matching existing version installs by exact version in a clean external consumer and exposes the reviewed raw contract exports with their existing semantic checks.",
    "AC-7: Quality gates pass: typecheck, lint, focused workflow/helper tests, contract/package checks, and the relevant repository test suite."
  ],
  "userStories": [
    {
      "id": "interfaces-b19-dev-publish-001",
      "title": "Produce an attributable immutable package candidate",
      "description": "As a maintainer, I want one deterministic publication candidate and evidence record so the artifact validated by CI is exactly the artifact considered for publication.",
      "acceptanceCriteria": [
        "Given base package version, GitHub run identity, and source commit, the candidate version is exactly <base>-dev.<run>.<short-sha> and invalid or incomplete inputs fail before any registry operation.",
        "Candidate preparation changes the packed package version without leaving generated or source contract files modified after the run.",
        "The resulting evidence identifies the package name, candidate version, full source commit, digest of the contract manifest, digest of the candidate tarball, sorted reviewed tarball inventory, and dev dist-tag.",
        "Repeated candidate preparation from the same inputs produces the same version and reviewed inventory, and the tarball used by later checks is preserved as the single candidate artifact.",
        "Diagnostics contain no npm token, OIDC token, registry authorization header, secret, or contract payload content.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented in commit 399d7598c with deterministic candidate identity, isolated staging, reviewed single-tarball evidence, and focused behavioral coverage."
    },
    {
      "id": "interfaces-b19-dev-publish-002",
      "title": "Reconcile immutable registry state safely",
      "description": "As a release maintainer, I want retries to distinguish an absent version, an identical prior publication, and an immutable conflict so reruns cannot overwrite or silently accept the wrong package.",
      "acceptanceCriteria": [
        "When the exact candidate version is absent from npm, reconciliation returns one explicit publish outcome without changing registry state itself.",
        "When the exact version exists, reconciliation obtains and verifies the registry tarball digest against the local candidate; a match returns a verified idempotent-success outcome and does not call publish.",
        "When the exact version exists with a different tarball digest, reconciliation fails with an immutable-version conflict and performs no publish or dist-tag mutation.",
        "Registry lookup, download, digest-verification, authentication, and permission failures remain distinct actionable outcomes and do not fall through to publishing.",
        "Tests use controlled registry responses and publish spies to prove absent, matching retry, digest mismatch, and permission-failure behavior without requiring live npm writes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented in commit 36ec5a5ae with fail-closed exact-version lookup, local and registry tarball digest verification, explicit publish/idempotent outcomes, distinct dependency failures, and controlled no-publish coverage."
    },
    {
      "id": "interfaces-b19-dev-publish-003",
      "title": "Validate the exact candidate on pull requests without publishing",
      "description": "As a contributor, I want pull requests to exercise the complete development-package path in dry-run mode so publication problems are caught before merge without giving untrusted code registry write authority.",
      "acceptanceCriteria": [
        "The dedicated workflow runs for pull requests, builds one candidate tarball, and reports a dry-run/no-publish outcome regardless of whether the candidate version is absent from npm.",
        "Pull request jobs do not execute npm publish, request an OIDC token, receive id-token: write, use an npm write token, or mutate an npm dist-tag.",
        "Before dry-run success, the workflow completes contract validation, repeated contract generation and drift checks, generated/production parity, package boundary and file-count checks, the exact package allowlist/pack checks, isolated clean-consumer smoke, and the relevant repository verification gates.",
        "The isolated consumer installs the candidate tarball outside the workspace and verifies every reviewed raw contract export and its existing semantic checks.",
        "Behavior-focused workflow tests prove pull-request dry-run/no-publish behavior, prerequisite failure blocking, least-privilege permissions, exact candidate handoff, and clean-consumer verification.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented in commit c53f8f507 with a read-only prerequisite-gated pull-request workflow, exact reviewed-head candidate handoff, isolated clean-consumer verification, preserved candidate evidence, and behavior-focused workflow coverage."
    },
    {
      "id": "interfaces-b19-dev-publish-004",
      "title": "Publish and verify eligible protected-main candidates through OIDC",
      "description": "As a release maintainer, I want successful protected-main runs to publish and verify the candidate with short-lived trusted credentials so development consumers receive an attributable artifact without weakening stable release controls.",
      "acceptanceCriteria": [
        "The publish job is eligible only for a successful run on the repository's protected main ref and configured development-publishing environment; pull requests, forks, other branches, tags, and failed prerequisite runs cannot reach it.",
        "The job runs on a GitHub-hosted runner with explicit contents: read and id-token: write permissions, a trusted-publishing-compatible Node/npm version, no long-lived npm credential, and no broader repository write permission.",
        "For an absent version, the job publishes the preserved candidate tarball exactly once with --access public, provenance enabled, and --tag dev; it never uses latest.",
        "For a matching existing version, the job reports verified idempotent success without publishing again; immutable conflict, digest mismatch, OIDC/permission failure, or registry verification failure ends the job unsuccessfully without overwriting or retagging anything.",
        "After publish or matching-version success, a clean external consumer installs @you-agent-factory/api@<exact-version> from the registry, verifies its received tarball digest, and passes the existing export and contract-semantic smoke checks.",
        "Behavior-focused tests prove protected-main eligibility, OIDC/provenance/public-access/dist-tag configuration, lack of npm token use, successful publish, matching retry, immutable conflict, permission failure, and post-publication clean consumption.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Implemented in commit db49e985a with protected-main/environment eligibility, separately scoped OIDC trusted publishing, publish-once immutable reconciliation, digest-verified ambiguous-failure handling, and exact-version clean registry consumption."
    }
  ]
}
