### PR TITLE
ftest-b00-mcp-client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/wire v0.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/jonboulle/clockwork v0.5.0
+	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/portpowered/go-agent-harness/go-agent-loop v0.0.1
 	github.com/robfig/cron/v3 v3.0.1
@@ -34,7 +35,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/pprof v0.0.0-20230207041349-798e818bf904 // indirect
 	github.com/google/subcommands v1.2.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -49,12 +50,16 @@ require (
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/segmentio/asm v1.1.3 // indirect
+	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/speakeasy-api/jsonpath v0.6.0 // indirect
 	github.com/speakeasy-api/openapi-overlay v0.10.2 // indirect
 	github.com/vmware-labs/yaml-jsonpath v0.3.2 // indirect
 	github.com/woodsbury/decimal128 v1.3.0 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/mod v0.33.0 // indirect
+	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/text v0.20.0 // indirect
 	golang.org/x/tools v0.42.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/go-sourcemap/sourcemap v2.1.3+incompatible/go.mod h1:F8jJfvm2KbVjc5Nq
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
 github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
@@ -55,6 +57,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
+github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20230207041349-798e818bf904 h1:4/hN5RUoecvl+RmJRE2YxKWtnnQls6rQjjW5oV7qg2U=
 github.com/google/pprof v0.0.0-20230207041349-798e818bf904/go.mod h1:uglQLonpP8qtYCYyzA+8c/9qtqgA3qsXGYqCPKARAFg=
@@ -90,6 +94,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-sqlite3 v1.14.16 h1:yOQRA0RpS5PFz/oikGwBEqvAWhWg5ufRz4ETLjwpU1Y=
 github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
+github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=
+github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
@@ -130,6 +136,10 @@ github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
+github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
+github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
+github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/speakeasy-api/jsonpath v0.6.0 h1:IhtFOV9EbXplhyRqsVhHoBmmYjblIRh5D1/g8DHMXJ8=
@@ -157,6 +167,8 @@ github.com/vmware-labs/yaml-jsonpath v0.3.2 h1:/5QKeCBGdsInyDCyVNLbXyilb61MXGi9N
 github.com/vmware-labs/yaml-jsonpath v0.3.2/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN1BWz5V+51Ewf8k+rQ=
 github.com/woodsbury/decimal128 v1.3.0 h1:8pffMNWIlC0O5vbyHWFZAt5yWvWcrHA+3ovIIjVWss0=
 github.com/woodsbury/decimal128 v1.3.0/go.mod h1:C5UTmyTjW3JftjUFzOVhC20BEQa2a4ZKOB5I6Zjb+ds=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
@@ -194,6 +206,8 @@ golang.org/x/net v0.15.0/go.mod h1:idbUs1IY1+zTqbi8yxTbhexhEEk5ur9LInksu6HrEpk=
 golang.org/x/net v0.20.0/go.mod h1:z8BVo6PvndSri0LbOE3hAn0apkU+1YvI6E70E9jsnvY=
 golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
 golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
+golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
+golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/testutil/mcpclient/client.go
+++ b/pkg/testutil/mcpclient/client.go
@@ -104,6 +104,27 @@ func (c *Client) Ping(ctx context.Context) error {
 	return nil
 }
 
+// ListTools discovers the tools published by the attached MCP server.
+func (c *Client) ListTools(ctx context.Context) (*mcp.ListToolsResult, error) {
+	result, err := c.session.ListTools(ctx, nil)
+	if err != nil {
+		return nil, clientError(StageProtocolExchange, "list tools", err)
+	}
+	return result, nil
+}
+
+// CallTool invokes one discovered tool through the SDK session.
+func (c *Client) CallTool(ctx context.Context, name string, arguments any) (*mcp.CallToolResult, error) {
+	result, err := c.session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      name,
+		Arguments: arguments,
+	})
+	if err != nil {
+		return nil, clientError(StageProtocolExchange, "call tool", err)
+	}
+	return result, nil
+}
+
 // DecodeTextResult decodes the single text item used by the current server.
 func DecodeTextResult(result *mcp.CallToolResult, target any) error {
 	if result == nil {

--- a/pkg/testutil/mcpclient/client.go
+++ b/pkg/testutil/mcpclient/client.go
@@ -1,0 +1,149 @@
+// Package mcpclient provides an SDK-backed MCP client for functional tests.
+package mcpclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const (
+	defaultClientName    = "you-functional-test"
+	defaultClientVersion = "dev"
+)
+
+// Stage identifies the client lifecycle boundary at which an operation failed.
+type Stage string
+
+const (
+	StageSetup             Stage = "setup"
+	StageProtocolExchange  Stage = "protocol exchange"
+	StageTransportShutdown Stage = "transport shutdown"
+	StageToolDecoding      Stage = "tool decoding"
+)
+
+// Error preserves the lifecycle stage and operation for an SDK client failure.
+type Error struct {
+	Stage Stage
+	Op    string
+	Err   error
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("mcp client %s during %s: %v", e.Op, e.Stage, e.Err)
+}
+
+// Unwrap exposes the underlying SDK, transport, or decoding error.
+func (e *Error) Unwrap() error { return e.Err }
+
+// Pipes are caller-supplied endpoints connected to a newline-delimited MCP server.
+// Reader receives server stdout and Writer sends server stdin.
+type Pipes struct {
+	Reader io.ReadCloser
+	Writer io.WriteCloser
+}
+
+// Options identifies the functional-test client during MCP initialization.
+type Options struct {
+	Name    string
+	Version string
+}
+
+// Client is an initialized SDK client attached to caller-supplied pipes.
+type Client struct {
+	session *mcp.ClientSession
+}
+
+// Connect initializes an MCP session over pipes without constructing or owning
+// a process, application service, server handler, or graph host.
+func Connect(ctx context.Context, pipes Pipes, options Options) (*Client, error) {
+	if ctx == nil {
+		return nil, clientError(StageSetup, "connect", errors.New("context is required"))
+	}
+	if pipes.Reader == nil {
+		return nil, clientError(StageSetup, "connect", errors.New("server output reader is required"))
+	}
+	if pipes.Writer == nil {
+		return nil, clientError(StageSetup, "connect", errors.New("server input writer is required"))
+	}
+	if options.Name == "" {
+		options.Name = defaultClientName
+	}
+	if options.Version == "" {
+		options.Version = defaultClientVersion
+	}
+
+	sdkClient := mcp.NewClient(&mcp.Implementation{
+		Name:    options.Name,
+		Version: options.Version,
+	}, nil)
+	session, err := sdkClient.Connect(ctx, &mcp.IOTransport{
+		Reader: pipes.Reader,
+		Writer: pipes.Writer,
+	}, nil)
+	if err != nil {
+		return nil, clientError(StageProtocolExchange, "initialize", err)
+	}
+	return &Client{session: session}, nil
+}
+
+// InitializeResult returns the protocol negotiation result from Connect.
+func (c *Client) InitializeResult() *mcp.InitializeResult {
+	return c.session.InitializeResult()
+}
+
+// Ping performs one SDK-backed MCP protocol exchange.
+func (c *Client) Ping(ctx context.Context) error {
+	if err := c.session.Ping(ctx, nil); err != nil {
+		return clientError(StageProtocolExchange, "ping", err)
+	}
+	return nil
+}
+
+// DecodeTextResult decodes the single text item used by the current server.
+func DecodeTextResult(result *mcp.CallToolResult, target any) error {
+	if result == nil {
+		return clientError(StageToolDecoding, "decode result", errors.New("tool result is required"))
+	}
+	if len(result.Content) != 1 {
+		return clientError(StageToolDecoding, "decode result", fmt.Errorf("content item count = %d, want 1", len(result.Content)))
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		return clientError(StageToolDecoding, "decode result", fmt.Errorf("content type = %T, want *mcp.TextContent", result.Content[0]))
+	}
+	if target == nil {
+		return clientError(StageToolDecoding, "decode result", errors.New("decode target is required"))
+	}
+	if err := json.Unmarshal([]byte(text.Text), target); err != nil {
+		return clientError(StageToolDecoding, "decode result", err)
+	}
+	return nil
+}
+
+// Close shuts down the SDK session and its attached transport within the
+// caller's lifecycle bound.
+func (c *Client) Close(ctx context.Context) error {
+	if ctx == nil {
+		return clientError(StageTransportShutdown, "close", errors.New("context is required"))
+	}
+	closed := make(chan error, 1)
+	go func() { closed <- c.session.Close() }()
+	select {
+	case err := <-closed:
+		if err != nil {
+			return clientError(StageTransportShutdown, "close", err)
+		}
+		return nil
+	case <-ctx.Done():
+		return clientError(StageTransportShutdown, "close", ctx.Err())
+	}
+}
+
+func clientError(stage Stage, op string, err error) error {
+	return &Error{Stage: stage, Op: op, Err: err}
+}

--- a/pkg/testutil/mcpclient/client.go
+++ b/pkg/testutil/mcpclient/client.go
@@ -125,6 +125,14 @@ func (c *Client) CallTool(ctx context.Context, name string, arguments any) (*mcp
 	return result, nil
 }
 
+// SetLoggingLevel asks the attached server to change its MCP logging level.
+func (c *Client) SetLoggingLevel(ctx context.Context, level mcp.LoggingLevel) error {
+	if err := c.session.SetLoggingLevel(ctx, &mcp.SetLoggingLevelParams{Level: level}); err != nil {
+		return clientError(StageProtocolExchange, "set logging level", err)
+	}
+	return nil
+}
+
 // DecodeTextResult decodes the single text item used by the current server.
 func DecodeTextResult(result *mcp.CallToolResult, target any) error {
 	if result == nil {

--- a/pkg/testutil/mcpclient/client_test.go
+++ b/pkg/testutil/mcpclient/client_test.go
@@ -1,0 +1,114 @@
+package mcpclient
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	mcpfactorysession "github.com/portpowered/infinite-you/pkg/transports/mcp/factorysession"
+	mcpserver "github.com/portpowered/infinite-you/pkg/transports/mcp/server"
+)
+
+const testTimeout = 5 * time.Second
+
+func TestClientConnectsToRealServerThroughCallerSuppliedPipes(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	serverInput, clientWriter := io.Pipe()
+	clientReader, serverOutput := io.Pipe()
+	server := newRealServer(t)
+	serverErr := make(chan error, 1)
+	go func() {
+		serverErr <- server.ServeStdio(ctx, serverInput, serverOutput)
+	}()
+
+	client, err := Connect(ctx, Pipes{Reader: clientReader, Writer: clientWriter}, Options{
+		Name:    "sdk-client-test",
+		Version: "1.0.0",
+	})
+	if err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+	result := client.InitializeResult()
+	if result.ProtocolVersion != "2024-11-05" {
+		t.Fatalf("protocol version = %q, want 2024-11-05", result.ProtocolVersion)
+	}
+	if result.ServerInfo == nil || result.ServerInfo.Name != "pipe-test-server" {
+		t.Fatalf("server info = %#v, want pipe-test-server", result.ServerInfo)
+	}
+	if err := client.Ping(ctx); err != nil {
+		t.Fatalf("Ping() error = %v", err)
+	}
+	if err := client.Close(ctx); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	select {
+	case err := <-serverErr:
+		if err != nil {
+			t.Fatalf("ServeStdio() error = %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("ServeStdio() did not stop after client close: %v", ctx.Err())
+	}
+}
+
+func TestClientErrorsRetainLifecycleStage(t *testing.T) {
+	_, err := Connect(context.Background(), Pipes{}, Options{})
+	assertErrorStage(t, err, StageSetup)
+
+	result := &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "not-json"}}}
+	err = DecodeTextResult(result, &struct{}{})
+	assertErrorStage(t, err, StageToolDecoding)
+}
+
+func TestConnectClassifiesInitializationEOFAsProtocolExchange(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	serverInput, clientWriter := io.Pipe()
+	clientReader, serverOutput := io.Pipe()
+	go func() {
+		_, _ = io.Copy(io.Discard, io.LimitReader(serverInput, 1))
+		_ = serverOutput.Close()
+		_ = serverInput.Close()
+	}()
+
+	_, err := Connect(ctx, Pipes{Reader: clientReader, Writer: clientWriter}, Options{})
+	assertErrorStage(t, err, StageProtocolExchange)
+}
+
+func newRealServer(t *testing.T) *mcpserver.Server {
+	t.Helper()
+	server, err := mcpserver.New(mcpserver.Options{
+		Client:        mcpfactorysession.NewClient(),
+		ServerName:    "pipe-test-server",
+		ServerVersion: "1.0.0",
+	})
+	if err != nil {
+		t.Fatalf("server.New() error = %v", err)
+	}
+	return server
+}
+
+func assertErrorStage(t *testing.T, err error, want Stage) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("error = nil, want stage %q", want)
+	}
+	var clientErr *Error
+	if !errors.As(err, &clientErr) {
+		t.Fatalf("error = %T %v, want *Error", err, err)
+	}
+	if clientErr.Stage != want {
+		t.Fatalf("error stage = %q, want %q", clientErr.Stage, want)
+	}
+	if !strings.Contains(err.Error(), string(want)) {
+		t.Fatalf("error %q does not retain stage %q", err, want)
+	}
+}

--- a/pkg/testutil/mcpclient/client_test.go
+++ b/pkg/testutil/mcpclient/client_test.go
@@ -1,10 +1,14 @@
 package mcpclient
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -55,6 +59,102 @@ func TestClientConnectsToRealServerThroughCallerSuppliedPipes(t *testing.T) {
 		}
 	case <-ctx.Done():
 		t.Fatalf("ServeStdio() did not stop after client close: %v", ctx.Err())
+	}
+}
+
+func TestClientNegotiatesDiscoversAndCorrelatesToolTrafficOverRealStdio(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+	client, requests, responses, serverErr := connectRecordingClient(t, ctx)
+	assertInitializeResult(t, client.InitializeResult())
+	listResult, callResult := runConcurrentOperations(t, ctx, client)
+	assertDiscoveredTool(t, listResult, mcpfactorysession.ToolListSessions)
+	assertSuccessfulTextToolResult(t, callResult)
+	assertConversationFrames(t, requests.frames(), responses.frames())
+	if err := client.Close(ctx); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	select {
+	case err := <-serverErr:
+		if err != nil {
+			t.Fatalf("ServeStdio() error = %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("ServeStdio() did not stop after client close: %v", ctx.Err())
+	}
+}
+
+func connectRecordingClient(t *testing.T, ctx context.Context) (*Client, *frameRecorder, *frameRecorder, <-chan error) {
+	t.Helper()
+	serverInput, pipeWriter := io.Pipe()
+	pipeReader, serverOutput := io.Pipe()
+	requests := newFrameRecorder(2)
+	responses := newFrameRecorder(0)
+	serverErr := make(chan error, 1)
+	go func() {
+		serverErr <- newRealServer(t).ServeStdio(ctx, serverInput, serverOutput)
+	}()
+	client, err := Connect(ctx, Pipes{
+		Reader: &recordingReader{source: pipeReader, recorder: responses, gate: requests.ready},
+		Writer: &recordingWriter{destination: pipeWriter, recorder: requests},
+	}, Options{Name: "sdk-conversation-test", Version: "1.0.0"})
+	if err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+	return client, requests, responses, serverErr
+}
+
+func assertInitializeResult(t *testing.T, initialize *mcp.InitializeResult) {
+	t.Helper()
+	if initialize.ProtocolVersion != "2024-11-05" {
+		t.Fatalf("protocol version = %q, want 2024-11-05", initialize.ProtocolVersion)
+	}
+	if initialize.ServerInfo == nil || initialize.ServerInfo.Name != "pipe-test-server" || initialize.ServerInfo.Version != "1.0.0" {
+		t.Fatalf("server info = %#v, want pipe-test-server 1.0.0", initialize.ServerInfo)
+	}
+	if initialize.Capabilities == nil || initialize.Capabilities.Tools == nil {
+		t.Fatalf("server capabilities = %#v, want tools capability", initialize.Capabilities)
+	}
+}
+
+type operationResult struct {
+	list *mcp.ListToolsResult
+	call *mcp.CallToolResult
+	err  error
+}
+
+func runConcurrentOperations(t *testing.T, ctx context.Context, client *Client) (*mcp.ListToolsResult, *mcp.CallToolResult) {
+	t.Helper()
+	results := make(chan operationResult, 2)
+	go func() {
+		result, err := client.ListTools(ctx)
+		results <- operationResult{list: result, err: err}
+	}()
+	go func() {
+		result, err := client.CallTool(ctx, mcpfactorysession.ToolListSessions, map[string]any{})
+		results <- operationResult{call: result, err: err}
+	}()
+	first, second := <-results, <-results
+	if first.err != nil || second.err != nil {
+		t.Fatalf("concurrent SDK operation errors = %v, %v", first.err, second.err)
+	}
+	if first.list != nil {
+		return first.list, second.call
+	}
+	return second.list, first.call
+}
+
+func assertSuccessfulTextToolResult(t *testing.T, result *mcp.CallToolResult) {
+	t.Helper()
+	if result == nil || result.IsError {
+		t.Fatalf("CallTool() result = %#v, want isError false", result)
+	}
+	var toolResponse mcpfactorysession.ToolResponse[json.RawMessage]
+	if err := DecodeTextResult(result, &toolResponse); err != nil {
+		t.Fatalf("DecodeTextResult() error = %v", err)
+	}
+	if toolResponse.Error == nil || !strings.Contains(toolResponse.Error.Message, "unavailable") {
+		t.Fatalf("tool text payload = %#v, want current text-only Factory Session response", toolResponse)
 	}
 }
 
@@ -110,5 +210,153 @@ func assertErrorStage(t *testing.T, err error, want Stage) {
 	}
 	if !strings.Contains(err.Error(), string(want)) {
 		t.Fatalf("error %q does not retain stage %q", err, want)
+	}
+}
+
+type frameRecorder struct {
+	mu        sync.Mutex
+	buffer    bytes.Buffer
+	recorded  [][]byte
+	operation int
+	target    int
+	ready     chan struct{}
+	once      sync.Once
+}
+
+func newFrameRecorder(operationTarget int) *frameRecorder {
+	recorder := &frameRecorder{target: operationTarget, ready: make(chan struct{})}
+	if operationTarget == 0 {
+		close(recorder.ready)
+	}
+	return recorder
+}
+
+func (r *frameRecorder) record(data []byte) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, _ = r.buffer.Write(data)
+	for {
+		line, err := r.buffer.ReadBytes('\n')
+		if err != nil {
+			_, _ = r.buffer.Write(line)
+			return
+		}
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		r.recorded = append(r.recorded, bytes.Clone(line))
+		var frame rpcFrame
+		if json.Unmarshal(line, &frame) == nil && (frame.Method == "tools/list" || frame.Method == "tools/call") {
+			r.operation++
+			if r.operation == r.target {
+				r.once.Do(func() { close(r.ready) })
+			}
+		}
+	}
+}
+
+func (r *frameRecorder) frames() [][]byte {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([][]byte(nil), r.recorded...)
+}
+
+type recordingWriter struct {
+	destination io.WriteCloser
+	recorder    *frameRecorder
+}
+
+func (w *recordingWriter) Write(data []byte) (int, error) {
+	w.recorder.record(data)
+	return w.destination.Write(data)
+}
+
+func (w *recordingWriter) Close() error { return w.destination.Close() }
+
+type recordingReader struct {
+	source    io.ReadCloser
+	recorder  *frameRecorder
+	gate      <-chan struct{}
+	responses int
+}
+
+func (r *recordingReader) Read(data []byte) (int, error) {
+	n, err := r.source.Read(data)
+	if n > 0 {
+		r.recorder.record(data[:n])
+		var frame rpcFrame
+		if json.Unmarshal(bytes.TrimSpace(data[:n]), &frame) == nil && frame.ID != nil && frame.Method == "" {
+			r.responses++
+			if r.responses > 1 {
+				select {
+				case <-r.gate:
+				case <-time.After(testTimeout):
+					return 0, context.DeadlineExceeded
+				}
+			}
+		}
+	}
+	return n, err
+}
+
+func (r *recordingReader) Close() error { return r.source.Close() }
+
+type rpcFrame struct {
+	ID     any             `json:"id"`
+	Method string          `json:"method"`
+	Result json.RawMessage `json:"result"`
+}
+
+func assertDiscoveredTool(t *testing.T, result *mcp.ListToolsResult, name string) {
+	t.Helper()
+	if result == nil {
+		t.Fatal("ListTools() result = nil")
+	}
+	for _, tool := range result.Tools {
+		if tool.Name == name {
+			return
+		}
+	}
+	t.Fatalf("ListTools() missing canonical tool %q", name)
+}
+
+func assertConversationFrames(t *testing.T, requests, responses [][]byte) {
+	t.Helper()
+	requestIDs := map[string]string{}
+	initialized := 0
+	for _, encoded := range requests {
+		var frame rpcFrame
+		if err := json.Unmarshal(encoded, &frame); err != nil {
+			t.Fatalf("decode SDK request %q: %v", encoded, err)
+		}
+		if frame.Method == "notifications/initialized" {
+			initialized++
+		}
+		if frame.Method == "tools/list" || frame.Method == "tools/call" {
+			requestIDs[fmt.Sprint(frame.ID)] = frame.Method
+		}
+	}
+	if initialized != 1 {
+		t.Fatalf("initialized notification count = %d, want 1", initialized)
+	}
+	if len(requestIDs) != 2 {
+		t.Fatalf("operation request identities = %#v, want two distinct IDs", requestIDs)
+	}
+	responseIDs := map[string]bool{}
+	for _, encoded := range responses {
+		var frame rpcFrame
+		if err := json.Unmarshal(encoded, &frame); err != nil {
+			t.Fatalf("decode server response %q: %v", encoded, err)
+		}
+		responseIDs[fmt.Sprint(frame.ID)] = true
+	}
+	for id, method := range requestIDs {
+		if !responseIDs[id] {
+			t.Errorf("response missing request identity %s for %s", id, method)
+		}
+	}
+	if len(responses) != 3 {
+		t.Fatalf("server response count = %d, want initialize plus two operations and no notification response", len(responses))
 	}
 }

--- a/pkg/testutil/mcpclient/lifecycle_test.go
+++ b/pkg/testutil/mcpclient/lifecycle_test.go
@@ -1,0 +1,328 @@
+package mcpclient
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestClientPreservesProtocolAndToolErrorBoundariesOverRealStdio(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+	client, requests, responses, serverErr := connectUnblockedRecordingClient(t, ctx)
+
+	err := client.SetLoggingLevel(ctx, mcp.LoggingLevel("info"))
+	assertErrorStage(t, err, StageProtocolExchange)
+	var protocolErr *jsonrpc.Error
+	if !errors.As(err, &protocolErr) {
+		t.Fatalf("SetLoggingLevel() error = %T %v, want *jsonrpc.Error", err, err)
+	}
+	if protocolErr.Code != jsonrpc.CodeMethodNotFound {
+		t.Fatalf("SetLoggingLevel() protocol code = %d, want %d", protocolErr.Code, jsonrpc.CodeMethodNotFound)
+	}
+
+	toolResult, err := client.CallTool(ctx, "unsupported.tool", map[string]any{})
+	if err != nil {
+		t.Fatalf("CallTool(unsupported) error = %v, want normal tool result", err)
+	}
+	assertRejectedTextToolResult(t, toolResult, `unsupported tool "unsupported.tool"`)
+	assertErrorBoundaryFrames(t, requests.frames(), responses.frames())
+	closeClientAndWaitForServer(t, ctx, client, serverErr)
+}
+
+func TestClientCancellationReleasesPendingRequestAndTearsDownRealStdio(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+	serverInput, pipeWriter := io.Pipe()
+	proxyInput, serverOutput := io.Pipe()
+	pipeReader, proxyOutput := io.Pipe()
+	serverErr := make(chan error, 1)
+	go func() {
+		serverErr <- newRealServer(t).ServeStdio(ctx, serverInput, serverOutput)
+		_ = serverOutput.Close()
+	}()
+
+	responseGate := make(chan struct{})
+	defer func() {
+		select {
+		case <-responseGate:
+		default:
+			close(responseGate)
+		}
+	}()
+	go forwardResponsesAfterInitialize(proxyInput, proxyOutput, responseGate)
+	requests := newMethodObservingWriter(pipeWriter, "ping")
+	client, err := Connect(ctx, Pipes{
+		Reader: pipeReader,
+		Writer: requests,
+	}, Options{Name: "sdk-cancellation-test", Version: "1.0.0"})
+	if err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+
+	operationCtx, cancelOperation := context.WithCancel(ctx)
+	operationErr := make(chan error, 1)
+	go func() { operationErr <- client.Ping(operationCtx) }()
+	waitForSignal(t, ctx, requests.observed, "SDK ping request")
+	cancelOperation()
+	select {
+	case err := <-operationErr:
+		assertErrorStage(t, err, StageProtocolExchange)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Ping() error = %v, want context cancellation", err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("Ping() did not release its pending request: %v", ctx.Err())
+	}
+	assertCancellationTargetsRequest(t, requests.frames(), "ping")
+	close(responseGate)
+	closeClientAndWaitForServer(t, ctx, client, serverErr)
+}
+
+func TestCallerInputCloseEndsRealStdioWithoutPendingClientOperations(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+	serverInput, clientWriter := io.Pipe()
+	clientReader, serverOutput := io.Pipe()
+	serverErr := make(chan error, 1)
+	go func() { serverErr <- newRealServer(t).ServeStdio(ctx, serverInput, serverOutput) }()
+	client, err := Connect(ctx, Pipes{Reader: clientReader, Writer: clientWriter}, Options{})
+	if err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+
+	if err := clientWriter.Close(); err != nil {
+		t.Fatalf("close caller-owned client input: %v", err)
+	}
+	waitForServer(t, ctx, serverErr)
+	if err := client.Close(ctx); err != nil {
+		t.Fatalf("Close() after input EOF error = %v", err)
+	}
+}
+
+func TestMalformedProtocolRawFrameRetainsRequestIdentity(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+	serverInput, rawClientInput := io.Pipe()
+	rawClientOutput, serverOutput := io.Pipe()
+	serverErr := make(chan error, 1)
+	go func() { serverErr <- newRealServer(t).ServeStdio(ctx, serverInput, serverOutput) }()
+
+	const malformedProtocolFrame = `{"jsonrpc":"1.0","id":"malformed-1","method":"ping"}` + "\n"
+	if _, err := io.WriteString(rawClientInput, malformedProtocolFrame); err != nil {
+		t.Fatalf("write intentionally malformed raw frame: %v", err)
+	}
+	encoded, err := bufio.NewReader(rawClientOutput).ReadBytes('\n')
+	if err != nil {
+		t.Fatalf("read malformed-protocol response: %v", err)
+	}
+	var response boundaryFrame
+	if err := json.Unmarshal(bytes.TrimSpace(encoded), &response); err != nil {
+		t.Fatalf("decode malformed-protocol response: %v", err)
+	}
+	if fmt.Sprint(response.ID) != "malformed-1" || response.Error == nil || response.Error.Code != jsonrpc.CodeInvalidRequest {
+		t.Fatalf("malformed-protocol response = %#v, want correlated invalid-request error", response)
+	}
+	if err := rawClientInput.Close(); err != nil {
+		t.Fatalf("close malformed-protocol input: %v", err)
+	}
+	waitForServer(t, ctx, serverErr)
+	_ = rawClientOutput.Close()
+}
+
+func connectUnblockedRecordingClient(t *testing.T, ctx context.Context) (*Client, *frameRecorder, *frameRecorder, <-chan error) {
+	t.Helper()
+	serverInput, pipeWriter := io.Pipe()
+	pipeReader, serverOutput := io.Pipe()
+	requests := newFrameRecorder(0)
+	responses := newFrameRecorder(0)
+	serverErr := make(chan error, 1)
+	go func() { serverErr <- newRealServer(t).ServeStdio(ctx, serverInput, serverOutput) }()
+	client, err := Connect(ctx, Pipes{
+		Reader: &recordingReader{source: pipeReader, recorder: responses, gate: requests.ready},
+		Writer: &recordingWriter{destination: pipeWriter, recorder: requests},
+	}, Options{Name: "sdk-error-boundary-test", Version: "1.0.0"})
+	if err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+	return client, requests, responses, serverErr
+}
+
+func assertRejectedTextToolResult(t *testing.T, result *mcp.CallToolResult, wantText string) {
+	t.Helper()
+	if result == nil || !result.IsError || len(result.Content) != 1 {
+		t.Fatalf("CallTool() result = %#v, want one text item with isError true", result)
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok || !strings.Contains(text.Text, wantText) {
+		t.Fatalf("CallTool() content = %#v, want text containing %q", result.Content, wantText)
+	}
+}
+
+type boundaryFrame struct {
+	ID     any    `json:"id"`
+	Method string `json:"method"`
+	Params struct {
+		RequestID any `json:"requestId"`
+	} `json:"params"`
+	Error *struct {
+		Code int64 `json:"code"`
+	} `json:"error"`
+}
+
+func assertErrorBoundaryFrames(t *testing.T, requests, responses [][]byte) {
+	t.Helper()
+	requestIDs := make(map[string]any)
+	for _, encoded := range requests {
+		var frame boundaryFrame
+		if err := json.Unmarshal(encoded, &frame); err != nil {
+			t.Fatalf("decode SDK request %q: %v", encoded, err)
+		}
+		if frame.Method == "logging/setLevel" || frame.Method == "tools/call" {
+			requestIDs[frame.Method] = frame.ID
+		}
+	}
+	if len(requestIDs) != 2 || fmt.Sprint(requestIDs["logging/setLevel"]) == fmt.Sprint(requestIDs["tools/call"]) {
+		t.Fatalf("error-boundary request identities = %#v, want distinct logging and tool IDs", requestIDs)
+	}
+	responseErrors := make(map[string]*struct {
+		Code int64 `json:"code"`
+	})
+	for _, encoded := range responses {
+		var frame boundaryFrame
+		if err := json.Unmarshal(encoded, &frame); err != nil {
+			t.Fatalf("decode server response %q: %v", encoded, err)
+		}
+		responseErrors[fmt.Sprint(frame.ID)] = frame.Error
+	}
+	if rpcErr := responseErrors[fmt.Sprint(requestIDs["logging/setLevel"])]; rpcErr == nil || rpcErr.Code != jsonrpc.CodeMethodNotFound {
+		t.Fatalf("logging response error = %#v, want method-not-found", rpcErr)
+	}
+	if rpcErr := responseErrors[fmt.Sprint(requestIDs["tools/call"])]; rpcErr != nil {
+		t.Fatalf("tool/domain response error = %#v, want normal CallToolResult", rpcErr)
+	}
+}
+
+func forwardResponsesAfterInitialize(source io.ReadCloser, destination io.WriteCloser, gate <-chan struct{}) {
+	defer source.Close()
+	defer destination.Close()
+	scanner := bufio.NewScanner(source)
+	initialized := false
+	for scanner.Scan() {
+		if initialized {
+			<-gate
+		}
+		if _, err := destination.Write(append(bytes.Clone(scanner.Bytes()), '\n')); err != nil {
+			return
+		}
+		initialized = true
+	}
+}
+
+type methodObservingWriter struct {
+	destination io.WriteCloser
+	method      string
+	observed    chan struct{}
+	once        sync.Once
+	mu          sync.Mutex
+	buffer      bytes.Buffer
+	recorded    [][]byte
+}
+
+func newMethodObservingWriter(destination io.WriteCloser, method string) *methodObservingWriter {
+	return &methodObservingWriter{destination: destination, method: method, observed: make(chan struct{})}
+}
+
+func (w *methodObservingWriter) Write(data []byte) (int, error) {
+	w.record(data)
+	return w.destination.Write(data)
+}
+
+func (w *methodObservingWriter) Close() error { return w.destination.Close() }
+
+func (w *methodObservingWriter) record(data []byte) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	_, _ = w.buffer.Write(data)
+	for {
+		line, err := w.buffer.ReadBytes('\n')
+		if err != nil {
+			_, _ = w.buffer.Write(line)
+			return
+		}
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		w.recorded = append(w.recorded, bytes.Clone(line))
+		var frame boundaryFrame
+		if json.Unmarshal(line, &frame) == nil && frame.Method == w.method {
+			w.once.Do(func() { close(w.observed) })
+		}
+	}
+}
+
+func (w *methodObservingWriter) frames() [][]byte {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return append([][]byte(nil), w.recorded...)
+}
+
+func assertCancellationTargetsRequest(t *testing.T, frames [][]byte, method string) {
+	t.Helper()
+	var requestID, cancelledID any
+	for _, encoded := range frames {
+		var frame boundaryFrame
+		if err := json.Unmarshal(encoded, &frame); err != nil {
+			t.Fatalf("decode cancellation frame %q: %v", encoded, err)
+		}
+		switch frame.Method {
+		case method:
+			requestID = frame.ID
+		case "notifications/cancelled":
+			cancelledID = frame.Params.RequestID
+		}
+	}
+	if requestID == nil || fmt.Sprint(cancelledID) != fmt.Sprint(requestID) {
+		t.Fatalf("cancellation request ID = %v, want active %s request ID %v", cancelledID, method, requestID)
+	}
+}
+
+func closeClientAndWaitForServer(t *testing.T, ctx context.Context, client *Client, serverErr <-chan error) {
+	t.Helper()
+	if err := client.Close(ctx); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	waitForServer(t, ctx, serverErr)
+}
+
+func waitForServer(t *testing.T, ctx context.Context, serverErr <-chan error) {
+	t.Helper()
+	select {
+	case err := <-serverErr:
+		if err != nil {
+			t.Fatalf("ServeStdio() error = %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("ServeStdio() did not finish: %v", ctx.Err())
+	}
+}
+
+func waitForSignal(t *testing.T, ctx context.Context, signal <-chan struct{}, boundary string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for %s: %v", boundary, ctx.Err())
+	}
+}


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ftest-b00-mcp-client",
  "description": "Add a reviewed MCP Go SDK test dependency and a reusable client that attaches to caller-supplied pipes, then prove initialize/version negotiation, notification, discovery, request correlation, one tool call, error taxonomy, cancellation, and input close against the current real newline-delimited stdio server without direct handler calls; canonical root-built graph proof remains deferred to B01/FTQ-07B.",
  "context": {
    "customerAsk": "Add github.com/modelcontextprotocol/go-sdk as a reviewed test dependency and prepare a reusable client against the current real newline-delimited stdio server. Prove initialize/version negotiation, discovery, notification, request-id correlation, one tool call, cancellation, and input close. Keep protocol and tool/domain errors distinct, allow raw frames only for intentionally malformed protocol tests, and make the client attachable to pipes supplied by the later graph host. Canonical root-built graph proof belongs to B01/FTQ-07B.",
    "problem": "The repository has MCP server and Factory Session package tests, but it lacks a reusable standards-based Go SDK client that proves behavior through the actual stdio boundary. Later functional work could otherwise depend on direct handler calls, repository-specific valid-message framing, or transport ownership that cannot attach to canonical graph-host pipes. Current coverage also does not directly prove request correlation, error taxonomy, cancellation, and clean EOF behavior through one reusable client contract.",
    "solution": "Record the reviewed MCP Go SDK dependency for test support, wrap it in a small adapter over caller-owned stdio pipes, and drive the current real server exclusively through those pipes for valid traffic. Add focused deterministic coverage for negotiation, initialized notification, discovery, correlated requests, one canonical tool call, distinct protocol and tool/domain errors, cancellation, and input EOF. Restrict raw frames to deliberately malformed protocol cases and defer root-built graph proof to B01/FTQ-07B."
  },
  "acceptanceCriteria": [
    "AC-1: go.mod and go.sum contain a reviewed github.com/modelcontextprotocol/go-sdk dependency used by MCP functional test support, with module metadata remaining tidy.",
    "AC-2: The reusable SDK client attaches to caller-supplied stdio pipes and proves valid MCP traffic against the current real newline-delimited server without invoking MCP handlers directly.",
    "AC-3: A focused smoke proves supported protocol-version negotiation, initialized notification handling, tool discovery, request-id correlation, and one representative canonical tool call.",
    "AC-4: JSON-RPC protocol failures remain distinct from tools/call tool/domain failures, which retain the existing text-only result and isError semantics.",
    "AC-5: Cancellation and client-input close finish cleanly without hangs or pending requests, and the cancellation/close scenario passes repeatedly.",
    "AC-6: Raw JSON-RPC frames are used only by intentionally malformed-protocol tests; all valid scenarios use the SDK-backed client, and canonical root-built graph proof remains out of scope for this batch.",
    "AC-7: Quality checks pass: typecheck, lint, focused MCP SDK stdio tests, make mcp-contract-smoke, and the repeated cancellation/input-close test."
  ],
  "userStories": [
    {
      "id": "ftest-b00-mcp-client-001",
      "title": "Connect an SDK client to supplied stdio pipes",
      "description": "As a functional-test author, I want a reusable MCP Go SDK client that attaches to pipes owned by the test host so the same client can drive today's real stdio server and the later canonical graph host without calling handlers.",
      "acceptanceCriteria": [
        "The reviewed github.com/modelcontextprotocol/go-sdk dependency is recorded in go.mod and go.sum, is used by test support, and leaves module metadata tidy.",
        "The client accepts caller-supplied bidirectional stdio endpoints and does not require ownership of a CLI process, application service, MCP handler, or future graph host.",
        "Valid MCP messages are encoded, sent, received, and decoded through SDK client/protocol facilities over the supplied pipes rather than through direct handler or domain-client calls.",
        "Client setup and teardown expose bounded context cancellation and close behavior to callers, with errors retaining whether setup, protocol exchange, transport shutdown, or tool decoding failed.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented by commit 51d7b920d with an SDK-backed caller-pipe client, staged errors, bounded close, real ServeStdio initialize/ping coverage, and tidy module metadata."
    },
    {
      "id": "ftest-b00-mcp-client-002",
      "title": "Prove negotiated discovery and correlated tool traffic",
      "description": "As a maintainer, I want the SDK client to complete a representative MCP conversation against the current real stdio server so interoperability is proven at the customer protocol boundary.",
      "acceptanceCriteria": [
        "A focused smoke connects the reusable client to the real newline-delimited stdio server and completes initialize with the supported negotiated protocol version and expected server identity/capabilities.",
        "The client completes the initialized notification and tool discovery sequence without the server emitting a response to the notification.",
        "At least two distinguishable SDK requests use different request identities, and each decoded response is delivered to the originating request even when both are outstanding or their completion is observed independently.",
        "One discovered canonical tool is invoked through the SDK and its successful CallToolResult retains the server's text-only content and isError: false behavior.",
        "The smoke invokes and observes behavior only through stdio; it does not call MCP request handlers or Factory Session service methods as an alternate test path.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented by commit b1fd904df with SDK-backed discovery and tool-call methods plus a real-stdio smoke proving negotiation, initialized notification behavior, two simultaneously outstanding request identities, correlated typed responses, and text-only isError:false tool results."
    },
    {
      "id": "ftest-b00-mcp-client-003",
      "title": "Preserve protocol, tool-error, cancellation, and EOF boundaries",
      "description": "As a maintainer, I want failure and shutdown outcomes to remain distinguishable over real stdio so later functional scenarios can diagnose protocol defects, domain rejection, cancellation, and normal input closure correctly.",
      "acceptanceCriteria": [
        "An SDK-driven invalid request produces a JSON-RPC protocol error with its request identity and does not decode as a successful CallToolResult or tool/domain failure.",
        "An SDK-driven tool call that the domain rejects returns a normal correlated CallToolResult with isError: true and the existing text-only error payload, not a JSON-RPC protocol error.",
        "Canceling an active client operation releases its outstanding request and allows client/server teardown to complete within a bounded deadline without a hang.",
        "Closing the caller-owned client-input pipe causes the real stdio server to finish cleanly on EOF and leaves no pending client operation.",
        "The cancellation/input-close scenario passes in a repeat run, and failures report which lifecycle boundary failed rather than relying on timing sleeps.",
        "Raw frame injection appears only in an explicitly named malformed-protocol case; valid error, cancellation, and close scenarios use the SDK-backed client.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented by commit 4c628775f with SDK-driven correlated protocol and tool/domain error coverage, deterministic cancellation retirement, caller-input EOF shutdown, and an explicitly malformed raw-frame case."
    }
  ]
}
