### PR TITLE
ftest-di-root-run-foundation

### DIFF
--- a/docs/internal/processes/runtime-cleanup-relevant-files.md
+++ b/docs/internal/processes/runtime-cleanup-relevant-files.md
@@ -29,6 +29,11 @@ Production command runners must remain blocking without taking lifecycle ownersh
 back from `pkg/initializer`. The entrypoint should construct and start the graph
 through `pkg/root`, then let the returned application wait for its selected
 graph-owned transport and perform the same idempotent reverse-order shutdown.
+Production-shaped functional runs replace process side effects through the typed
+`pkg/wire.FunctionalEdges` input. Apply those edges to an invocation-local config
+copy before calling the shared application builders; do not add CLI flags,
+package globals, untyped dependency bags, or test-side service-config mutation.
+The zero-value edge input must retain production defaults.
 Map default/service run policies to initializer's API lifecycle plan and explicit
 local batch policies to its CLI lifecycle plan before constructing the run
 application; runtime mode alone must not silently select the foreground edge.

--- a/pkg/wire/process.go
+++ b/pkg/wire/process.go
@@ -10,7 +10,15 @@ import (
 	"github.com/portpowered/infinite-you/pkg/service"
 	runcli "github.com/portpowered/infinite-you/pkg/transports/cli/run"
 	startupcli "github.com/portpowered/infinite-you/pkg/transports/cli/startup"
+	"github.com/portpowered/infinite-you/pkg/workers"
 )
+
+// FunctionalEdges contains the process-owned side-effect boundaries that a
+// production-shaped functional graph may replace. Its zero value preserves
+// every production edge.
+type FunctionalEdges struct {
+	ProviderCommandRunner workers.CommandRunner
+}
 
 // MCPExecutionRequest contains the transport inputs that select the durable
 // Factory Session execution collaborator used by MCP serve.
@@ -63,7 +71,25 @@ func BuildMCPExecutionService(
 // BuildProcessGraph constructs the concrete application graph selected by the
 // process root without starting transports, sidecars, or runtime loops.
 func BuildProcessGraph(ctx context.Context, request startupcli.Request, policy initializer.ProcessPolicy) (*initializer.ProcessGraph, error) {
-	return BuildProcessGraphWithMCPBuilder(ctx, request, policy, BuildMCPExecutionService)
+	return buildProcessGraph(
+		ctx, request, policy, FunctionalEdges{}, buildProcessApplicationRunner,
+		BuildMCPExecutionService,
+	)
+}
+
+// BuildProcessGraphWithFunctionalEdges constructs the same application graph
+// as BuildProcessGraph while replacing only explicitly supplied process edges.
+// Functional edge selection is applied to a copy of invocation-local config.
+func BuildProcessGraphWithFunctionalEdges(
+	ctx context.Context,
+	request startupcli.Request,
+	policy initializer.ProcessPolicy,
+	edges FunctionalEdges,
+) (*initializer.ProcessGraph, error) {
+	return buildProcessGraph(
+		ctx, request, policy, edges, buildProcessApplicationRunner,
+		BuildMCPExecutionService,
+	)
 }
 
 // BuildProcessGraphWithMCPBuilder constructs a process graph with an explicit
@@ -75,13 +101,10 @@ func BuildProcessGraphWithMCPBuilder(
 	policy initializer.ProcessPolicy,
 	buildMCP MCPExecutionBuilder,
 ) (*initializer.ProcessGraph, error) {
-	return buildProcessGraph(ctx, request, policy, func(
-		buildCtx context.Context,
-		cfg *service.FactoryServiceConfig,
-		mode initializer.Mode,
-	) (runcli.RuntimeRunner, error) {
-		return buildApplicationRunner(buildCtx, cfg, mode)
-	}, buildMCP)
+	return buildProcessGraph(
+		ctx, request, policy, FunctionalEdges{}, buildProcessApplicationRunner,
+		buildMCP,
+	)
 }
 
 type processRunnerBuilder func(
@@ -90,10 +113,19 @@ type processRunnerBuilder func(
 	initializer.Mode,
 ) (runcli.RuntimeRunner, error)
 
+func buildProcessApplicationRunner(
+	ctx context.Context,
+	cfg *service.FactoryServiceConfig,
+	mode initializer.Mode,
+) (runcli.RuntimeRunner, error) {
+	return buildApplicationRunner(ctx, cfg, mode)
+}
+
 func buildProcessGraph(
 	ctx context.Context,
 	request startupcli.Request,
 	policy initializer.ProcessPolicy,
+	edges FunctionalEdges,
 	buildRunner processRunnerBuilder,
 	buildMCP MCPExecutionBuilder,
 	invocationBuilders ...runcli.InvocationBootstrapBuilder,
@@ -119,8 +151,10 @@ func buildProcessGraph(
 			buildCtx context.Context,
 			cfg *service.FactoryServiceConfig,
 		) (runcli.RuntimeRunner, error) {
-			return buildRunner(buildCtx, cfg, applicationMode)
-		}, invocationBuilder)
+			return buildRunner(buildCtx, configWithFunctionalEdges(cfg, edges), applicationMode)
+		}, func(buildCtx context.Context, cfg *service.FactoryServiceConfig) (runcli.InvocationRunner, error) {
+			return invocationBuilder(buildCtx, configWithFunctionalEdges(cfg, edges))
+		})
 		if err != nil {
 			return nil, fmt.Errorf("construct run graph: %w", err)
 		}
@@ -130,6 +164,18 @@ func buildProcessGraph(
 	default:
 		return nil, fmt.Errorf("construct process graph: unsupported startup kind %q", request.Kind)
 	}
+}
+
+func configWithFunctionalEdges(
+	cfg *service.FactoryServiceConfig,
+	edges FunctionalEdges,
+) *service.FactoryServiceConfig {
+	if cfg == nil || isNil(edges.ProviderCommandRunner) {
+		return cfg
+	}
+	copied := *cfg
+	copied.ProviderCommandRunnerOverride = edges.ProviderCommandRunner
+	return &copied
 }
 
 func buildMCPProcessGraph(

--- a/pkg/wire/process_test.go
+++ b/pkg/wire/process_test.go
@@ -17,11 +17,18 @@ import (
 	runcli "github.com/portpowered/infinite-you/pkg/transports/cli/run"
 	sessionexecutioncli "github.com/portpowered/infinite-you/pkg/transports/cli/sessionexecution"
 	startupcli "github.com/portpowered/infinite-you/pkg/transports/cli/startup"
+	"github.com/portpowered/infinite-you/pkg/workers"
 )
 
 type processRunnerFunc func(context.Context) error
 
 func (run processRunnerFunc) Run(ctx context.Context) error { return run(ctx) }
+
+type processCommandRunner struct{}
+
+func (*processCommandRunner) Run(context.Context, workers.CommandRequest) (workers.CommandResult, error) {
+	return workers.CommandResult{}, nil
+}
 
 func TestBuildProcessGraphConstructsRunBeforeLifecycle(t *testing.T) {
 	t.Parallel()
@@ -44,6 +51,30 @@ func TestBuildProcessGraphConstructsRunBeforeLifecycle(t *testing.T) {
 	}
 }
 
+func TestBuildProcessGraphWithFunctionalEdgesConstructsSharedRunGraph(t *testing.T) {
+	t.Parallel()
+	factoryDir := testutil.MustRepoPath(t, "tests/release/testdata/cli_smoke_factory")
+	graph, err := BuildProcessGraphWithFunctionalEdges(context.Background(), startupcli.Request{
+		Kind: startupcli.KindRun,
+		RunConfig: &runcli.RunConfig{
+			Dir: factoryDir, Port: 0, DisableDefaultRecording: true,
+			MockWorkersEnabled: true, SuppressDashboardRendering: true,
+		},
+	}, initializer.ProcessPolicy{
+		Mode:     initializer.ProcessModeLocalRun,
+		Sidecars: initializer.SidecarPolicy{WorkerScheduler: true},
+	}, FunctionalEdges{ProviderCommandRunner: &processCommandRunner{}})
+	if err != nil {
+		t.Fatalf("BuildProcessGraphWithFunctionalEdges() error = %v", err)
+	}
+	if graph == nil || graph.Run == nil || graph.MCP != nil {
+		t.Fatalf("functional run graph = %+v, want shared run application", graph)
+	}
+	if err := initializer.RunProcess(context.Background(), graph); err != nil {
+		t.Fatalf("RunProcess() error = %v", err)
+	}
+}
+
 func TestBuildProcessGraphUsesInjectedInvocationBuilder(t *testing.T) {
 	t.Parallel()
 	factoryDir := testutil.MustRepoPath(t, "tests/release/testdata/cli_smoke_factory")
@@ -57,6 +88,7 @@ func TestBuildProcessGraphUsesInjectedInvocationBuilder(t *testing.T) {
 	graph, err := buildProcessGraph(context.Background(), startupcli.Request{
 		Kind: startupcli.KindRun, RunConfig: &runConfig,
 	}, initializer.ProcessPolicy{Mode: initializer.ProcessModeLocalRun, Sidecars: initializer.SidecarPolicy{WorkerScheduler: true}},
+		FunctionalEdges{},
 		func(context.Context, *service.FactoryServiceConfig, initializer.Mode) (runcli.RuntimeRunner, error) {
 			t.Fatal("runtime builder called for one-shot invocation")
 			return nil, nil
@@ -72,6 +104,72 @@ func TestBuildProcessGraphUsesInjectedInvocationBuilder(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Fatalf("invocation builder calls = %d, want 1", calls)
+	}
+}
+
+func TestBuildProcessGraphSelectsOnlySuppliedFunctionalEdge(t *testing.T) {
+	t.Parallel()
+	factoryDir := testutil.MustRepoPath(t, "tests/release/testdata/cli_smoke_factory")
+	policy := initializer.ProcessPolicy{
+		Mode:     initializer.ProcessModeLocalRun,
+		Sidecars: initializer.SidecarPolicy{WorkerScheduler: true},
+	}
+	injected := &processCommandRunner{}
+
+	tests := []struct {
+		name     string
+		edges    FunctionalEdges
+		wantEdge workers.CommandRunner
+	}{
+		{name: "production defaults", edges: FunctionalEdges{}},
+		{name: "functional provider runner", edges: FunctionalEdges{ProviderCommandRunner: injected}, wantEdge: injected},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var built *service.FactoryServiceConfig
+			graph, err := buildProcessGraph(context.Background(), startupcli.Request{
+				Kind: startupcli.KindRun,
+				RunConfig: &runcli.RunConfig{
+					Dir: factoryDir, DisableDefaultRecording: true, SuppressDashboardRendering: true,
+				},
+			}, policy, test.edges, func(
+				_ context.Context,
+				cfg *service.FactoryServiceConfig,
+				_ initializer.Mode,
+			) (runcli.RuntimeRunner, error) {
+				built = cfg
+				return processRunnerFunc(func(context.Context) error { return nil }), nil
+			}, BuildMCPExecutionService)
+			if err != nil {
+				t.Fatalf("buildProcessGraph() error = %v", err)
+			}
+			if built == nil || built.ProviderCommandRunnerOverride != test.wantEdge {
+				t.Fatalf("provider command runner = %T, want %T", built.ProviderCommandRunnerOverride, test.wantEdge)
+			}
+			if graph == nil || graph.Run == nil {
+				t.Fatalf("run graph = %+v, want constructed application", graph)
+			}
+		})
+	}
+}
+
+func TestConfigWithFunctionalEdgesCopiesOnlyForReplacement(t *testing.T) {
+	t.Parallel()
+	configured := &processCommandRunner{}
+	injected := &processCommandRunner{}
+	cfg := &service.FactoryServiceConfig{ProviderCommandRunnerOverride: configured}
+
+	production := configWithFunctionalEdges(cfg, FunctionalEdges{})
+	if production != cfg || production.ProviderCommandRunnerOverride != configured {
+		t.Fatalf("production config = %+v, want original config and provider runner", production)
+	}
+
+	functional := configWithFunctionalEdges(cfg, FunctionalEdges{ProviderCommandRunner: injected})
+	if functional == cfg || functional.ProviderCommandRunnerOverride != injected {
+		t.Fatalf("functional config = %+v, want copied config with injected provider runner", functional)
+	}
+	if cfg.ProviderCommandRunnerOverride != configured {
+		t.Fatal("functional edge selection mutated the caller-owned config")
 	}
 }
 
@@ -284,7 +382,7 @@ func TestBuildProcessGraphAppliesRootPolicyBeforeConstructionAndLifecycle(t *tes
 			var builtMode initializer.Mode
 			graph, err := buildProcessGraph(context.Background(), startupcli.Request{
 				Kind: startupcli.KindRun, RunConfig: &cfg,
-			}, test.policy, func(_ context.Context, cfg *service.FactoryServiceConfig, mode initializer.Mode) (runcli.RuntimeRunner, error) {
+			}, test.policy, FunctionalEdges{}, func(_ context.Context, cfg *service.FactoryServiceConfig, mode initializer.Mode) (runcli.RuntimeRunner, error) {
 				built = cfg
 				builtMode = mode
 				return processRunnerFunc(func(context.Context) error { return nil }), nil

--- a/tests/functional/providers/cli_root_run_injected_provider_test.go
+++ b/tests/functional/providers/cli_root_run_injected_provider_test.go
@@ -1,0 +1,161 @@
+package providers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/root"
+	"github.com/portpowered/infinite-you/pkg/wire"
+	"github.com/portpowered/infinite-you/pkg/workers"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+const (
+	rootRunWorkType       = "root-run-task"
+	rootRunWorker         = "root-run-worker"
+	rootRunWorkstation    = "process-root-run-task"
+	rootRunModel          = "functional-cursor-model"
+	rootRunPrompt         = "prove the injected provider edge"
+	rootRunProviderResult = "root.Run injected provider result COMPLETE"
+)
+
+type functionalEdgeGraphBuilder struct {
+	edges wire.FunctionalEdges
+}
+
+func (builder functionalEdgeGraphBuilder) Build(
+	ctx context.Context,
+	request root.GraphRequest,
+) (*root.ApplicationGraph, error) {
+	return wire.BuildProcessGraphWithFunctionalEdges(ctx, request.Startup, request.Policy, builder.edges)
+}
+
+func TestRootRunInjectedProviderCommandRunner(t *testing.T) {
+	factoryDir, providerWorkDir := scaffoldRootRunProviderFactory(t)
+	runner := support.NewRecordingCommandRunner(string(support.CursorProviderSuccessStdout(rootRunProviderResult)))
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	input := root.Input{
+		Args: []string{
+			"you", "run", "--factory", filepath.Join(factoryDir, interfaces.FactoryConfigFile),
+			"--quiet", "--no-record", rootRunPrompt,
+		},
+		Env:     isolatedRootRunEnvironment(t.TempDir()),
+		Stdin:   strings.NewReader(""),
+		Stdout:  &stdout,
+		Stderr:  &stderr,
+		Context: context.Background(),
+	}
+	dependencies := root.Dependencies{GraphBuilder: functionalEdgeGraphBuilder{edges: wire.FunctionalEdges{
+		ProviderCommandRunner: runner,
+	}}}
+	exitCode := root.ExitFailure
+	support.WithWorkingDirectory(t, factoryDir, func() {
+		exitCode = root.Run(input, dependencies)
+	})
+
+	if exitCode != root.ExitSuccess {
+		t.Fatalf("root.Run() exit code = %d, want %d; stdout=%q stderr=%q", exitCode, root.ExitSuccess, stdout.String(), stderr.String())
+	}
+	if got := strings.TrimSpace(stdout.String()); got != rootRunProviderResult {
+		t.Fatalf("stdout = %q, want primary result %q", got, rootRunProviderResult)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty successful provider invocation diagnostics", got)
+	}
+	if runner.CallCount() != 1 {
+		t.Fatalf("provider runner call count = %d, want 1", runner.CallCount())
+	}
+	assertRootRunProviderRequest(t, providerWorkDir, runner.LastRequest())
+}
+
+func scaffoldRootRunProviderFactory(t *testing.T) (string, string) {
+	t.Helper()
+	providerWorkDir := t.TempDir()
+	dir := support.ScaffoldFactory(t, map[string]any{
+		"name": "root-run-injected-provider",
+		"workTypes": []map[string]any{{
+			"name":             rootRunWorkType,
+			"handlingBehavior": []string{"DEFAULT"},
+			"states": []map[string]string{
+				{"name": "init", "type": "INITIAL"},
+				{"name": "complete", "type": "TERMINAL"},
+				{"name": "failed", "type": "FAILED"},
+			},
+		}},
+		"workers": []map[string]string{{"name": rootRunWorker}},
+		"workstations": []map[string]any{{
+			"name":             rootRunWorkstation,
+			"worker":           rootRunWorker,
+			"workingDirectory": providerWorkDir,
+			"inputs":           []map[string]string{{"workType": rootRunWorkType, "state": "init"}},
+			"outputs":          []map[string]string{{"workType": rootRunWorkType, "state": "complete"}},
+			"onFailure":        []map[string]string{{"workType": rootRunWorkType, "state": "failed"}},
+		}},
+	})
+	support.WriteAgentConfig(t, dir, rootRunWorker, support.BuildModelWorkerConfig(
+		interfaces.ModelProviderCursor,
+		rootRunModel,
+	))
+	return dir, providerWorkDir
+}
+
+func isolatedRootRunEnvironment(home string) []string {
+	switch runtime.GOOS {
+	case "windows":
+		return []string{"USERPROFILE=" + home}
+	case "plan9":
+		return []string{"home=" + home}
+	default:
+		return []string{"HOME=" + home}
+	}
+}
+
+func assertRootRunProviderRequest(t *testing.T, providerWorkDir string, request workers.CommandRequest) {
+	t.Helper()
+	if request.Command != string(interfaces.ModelProviderCursor) {
+		t.Fatalf("provider command = %q, want %q", request.Command, interfaces.ModelProviderCursor)
+	}
+	support.AssertArgsContainSequence(t, request.Args, []string{"-p", "--model", rootRunModel})
+	support.AssertArgsContainSequence(t, request.Args, []string{"--output-format", "stream-json", "--stream-partial-output"})
+	if len(request.Args) == 0 {
+		t.Fatal("provider args are empty, want rendered prompt argument")
+	}
+	renderedInput := request.Args[len(request.Args)-1]
+	for _, want := range []string{"Process the input task.", "Do the work."} {
+		if !strings.Contains(renderedInput, want) {
+			t.Fatalf("rendered provider input = %q, want %q", renderedInput, want)
+		}
+	}
+	inputTokens, err := json.Marshal(request.InputTokens)
+	if err != nil {
+		t.Fatalf("marshal provider input tokens: %v", err)
+	}
+	if !bytes.Contains(inputTokens, []byte(rootRunPrompt)) {
+		t.Fatalf("provider input tokens = %s, want invocation prompt %q", inputTokens, rootRunPrompt)
+	}
+	if len(request.Stdin) != 0 {
+		t.Fatalf("provider stdin = %q, want Cursor prompt in command args", string(request.Stdin))
+	}
+	if got, want := filepath.Clean(request.WorkDir), filepath.Clean(providerWorkDir); got != want {
+		t.Fatalf("provider working directory = %q, want %q", got, want)
+	}
+	if request.DispatchID == "" || request.TransitionID == "" {
+		t.Fatalf("provider dispatch metadata = dispatch %q transition %q, want populated", request.DispatchID, request.TransitionID)
+	}
+	if request.WorkerType != rootRunWorker || request.WorkstationName != rootRunWorkstation {
+		t.Fatalf("provider routing metadata = worker %q workstation %q", request.WorkerType, request.WorkstationName)
+	}
+	if request.Execution.TraceID == "" || len(request.Execution.WorkIDs) != 1 {
+		t.Fatalf("provider execution metadata = %+v, want trace and one work ID", request.Execution)
+	}
+}
+
+var _ root.GraphBuilder = functionalEdgeGraphBuilder{}


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "ftest-di-root-run-foundation",
  "description": "Establish a canonical typed functional process-graph seam for provider command execution and prove through one required short functional scenario that `you run` can enter through `root.Run`, execute the real provider-backed worker path with an injected recording `CommandRunner`, and succeed without mock workers, internal service inspection, or a real provider binary.",
  "context": {
    "customerAsk": "Establish the canonical functional process-graph seam and add one required short functional scenario that invokes `you run` through `root.Run`, injects a recording provider `CommandRunner`, executes the real provider-backed worker path without mock workers or a real provider binary, and verifies success through CLI output and exit status plus recorded edge calls.",
    "problem": "`root.Run` already owns process-input normalization and CLI mode selection, and lower-level tests can inject a provider command runner, but the public Wire process-graph builder has no typed functional edge input. Existing CLI functional coverage therefore does not prove that a dependency supplied at the root graph boundary survives production-shaped composition and controls the provider subprocess edge; tests must otherwise bypass the process graph, mutate service configuration, expose internal handles, or depend on a real executable.",
    "solution": "Add the smallest typed functional edge contract needed to provide a provider `CommandRunner` through the public Wire graph builder while production and functional runs share the same non-edge application construction. Add a deterministic required short functional test that invokes `you run` through `root.Run`, uses an isolated real provider-backed fixture and a recording runner, and verifies behavior only through CLI stdout, stderr, exit status, and captured edge calls."
  },
  "acceptanceCriteria": [
    "AC-1: Production and functional run graphs use the same non-edge application construction path, differing only through an explicit typed edge input.",
    "AC-2: A functional graph replaces the provider `CommandRunner` without CLI flags, package globals, `ProviderOverride`, or ad hoc test-side `FactoryServiceConfig` mutation.",
    "AC-3: A required short functional scenario invokes `you run` through `root.Run`, executes a real configured provider-backed worker path, and requires neither mock workers nor a real provider executable.",
    "AC-4: The scenario verifies success through CLI stdout, stderr, exit status, and recorded provider edge calls without obtaining a `FactoryService`, runtime, registry, handler, repository/store, or projection object.",
    "AC-5: The regression fails if composition discards the injected runner and falls back to `os/exec`; focused root and Wire tests plus the short functional lane pass.",
    "AC-6: Quality checks pass (typecheck, lint, tests)."
  ],
  "userStories": [
    {
      "id": "ftest-di-root-run-foundation-001",
      "title": "Select the provider command edge through canonical graph composition",
      "description": "As a maintainer, I want production and functional runs to share the same application construction while functional runs can explicitly replace the provider command edge, so tests exercise the production-shaped process graph without hidden configuration mutation.",
      "acceptanceCriteria": [
        "The public process-graph construction boundary accepts a typed functional edge input that can supply a provider `CommandRunner`.",
        "Production and functional graph construction reuse the same non-edge application providers; the functional path replaces only the approved provider command edge required by this project.",
        "Omitting the functional replacement preserves the existing production provider command behavior.",
        "The edge is selected without a customer CLI flag, package-global mutable state, `ProviderOverride`, or test-side mutation of `FactoryServiceConfig`.",
        "Focused composition coverage proves that the supplied provider runner reaches the constructed run graph and that production defaults remain intact when no functional replacement is supplied.",
        "Duplicate or missing graph providers fail generation or compilation rather than being selected at runtime through an untyped service locator.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ftest-di-root-run-foundation-002",
      "title": "Prove injected provider execution through root.Run",
      "description": "As a maintainer, I want a short functional `you run` scenario to enter through `root.Run` and complete through an injected recording provider runner, so the CLI process path is proven without an external provider binary or internal service inspection.",
      "acceptanceCriteria": [
        "The scenario supplies explicit arguments, environment, context, streams, and isolated home/config paths, then invokes `you run` through `root.Run` using the typed functional graph edge from the preceding story.",
        "The scenario uses a real configured provider-backed worker and does not enable mock workers, replace the provider service, or require the provider executable on `PATH`.",
        "The recording runner returns deterministic provider output containing the fixture's completion result, and `root.Run` returns the documented success exit code.",
        "CLI stdout contains the documented primary or terminal result, while stderr contains no missing-executable or provider-launch failure.",
        "Recorded calls prove the expected invocation count and provider request details, including command, arguments, working directory, rendered input, and available trace or dispatch metadata.",
        "The test obtains no `FactoryService`, runtime, registry, handler, repository/store, or projection object and determines success only from public process outputs plus the injected edge recording.",
        "The scenario fails if graph composition drops the injected runner and falls back to `os/exec`, and it is included in the required short functional lane.",
        "Focused root and Wire verification and the short functional scenario pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
