### PR TITLE
ftest-b00-rest-client

### DIFF
--- a/tests/functional/internal/restclient/adapter.go
+++ b/tests/functional/internal/restclient/adapter.go
@@ -1,0 +1,60 @@
+package restclient
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	generatedclient "github.com/portpowered/infinite-you/pkg/transports/http/client"
+)
+
+// Adapter delegates functional REST calls to the generated response client.
+// It owns no process, service, or endpoint-discovery state.
+type Adapter struct {
+	client *generatedclient.ClientWithResponses
+}
+
+// New constructs an adapter from dependencies owned by the caller.
+func New(baseURL string, httpClient *http.Client) (*Adapter, error) {
+	if err := validateBaseURL(baseURL); err != nil {
+		return nil, err
+	}
+	if httpClient == nil {
+		return nil, fmt.Errorf("create generated REST adapter: HTTP client is required")
+	}
+
+	client, err := generatedclient.NewClientWithResponses(
+		baseURL,
+		generatedclient.WithHTTPClient(httpClient),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create generated REST client: %w", err)
+	}
+
+	return &Adapter{client: client}, nil
+}
+
+// GetFactoryResponseEventsBySessionID executes the generated typed REST
+// operation without translating its request parameters or response.
+func (a *Adapter) GetFactoryResponseEventsBySessionID(
+	ctx context.Context,
+	sessionID generatedclient.SessionID,
+	params *generatedclient.GetFactoryResponseEventsBySessionIdParams,
+) (*generatedclient.GetFactoryResponseEventsBySessionIdClientResponse, error) {
+	return a.client.GetFactoryResponseEventsBySessionIdWithResponse(ctx, sessionID, params)
+}
+
+func validateBaseURL(baseURL string) error {
+	parsed, err := url.ParseRequestURI(baseURL)
+	if err != nil {
+		return fmt.Errorf("create generated REST adapter: invalid base URL: %w", err)
+	}
+	if (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+		return fmt.Errorf("create generated REST adapter: base URL must be an absolute HTTP(S) URL")
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return fmt.Errorf("create generated REST adapter: base URL must not contain a query or fragment")
+	}
+	return nil
+}

--- a/tests/functional/internal/restclient/adapter_test.go
+++ b/tests/functional/internal/restclient/adapter_test.go
@@ -1,0 +1,91 @@
+package restclient_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	generatedclient "github.com/portpowered/infinite-you/pkg/transports/http/client"
+	"github.com/portpowered/infinite-you/tests/functional/internal/restclient"
+)
+
+func TestAdapterUsesCallerBaseURLAndHTTPClient(t *testing.T) {
+	const clientMarker = "caller-owned-client"
+	var requestCount atomic.Int32
+
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		if r.URL.Path != "/factory-sessions/missing-session/response-events" {
+			t.Errorf("request path = %q, want generated response-events path", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Functional-Client"); got != clientMarker {
+			t.Errorf("X-Functional-Client = %q, want %q", got, clientMarker)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"family":"NOT_FOUND","code":"RESPONSE_EVENT_SESSION_NOT_FOUND","message":"session not found"}`))
+	}))
+	t.Cleanup(host.Close)
+
+	httpClient := &http.Client{Transport: markerTransport{
+		marker: clientMarker,
+		base:   http.DefaultTransport,
+	}}
+	adapter, err := restclient.New(host.URL, httpClient)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	response, err := adapter.GetFactoryResponseEventsBySessionID(context.Background(), "missing-session", nil)
+	if err != nil {
+		t.Fatalf("GetFactoryResponseEventsBySessionID() error = %v", err)
+	}
+	if requestCount.Load() != 1 {
+		t.Fatalf("request count = %d, want 1", requestCount.Load())
+	}
+	if response.StatusCode() != http.StatusNotFound || response.JSON404 == nil {
+		t.Fatalf("response = %#v, want generated typed 404 response", response)
+	}
+	if response.JSON404.Family != generatedclient.ErrorFamilyNotFound || response.JSON404.Code != generatedclient.RESPONSEEVENTSESSIONNOTFOUND {
+		t.Fatalf("typed error = %#v, want NOT_FOUND/RESPONSE_EVENT_SESSION_NOT_FOUND", response.JSON404)
+	}
+}
+
+func TestNewRejectsInvalidConfiguration(t *testing.T) {
+	tests := []struct {
+		name       string
+		baseURL    string
+		httpClient *http.Client
+	}{
+		{name: "missing base URL", httpClient: &http.Client{}},
+		{name: "relative base URL", baseURL: "/api", httpClient: &http.Client{}},
+		{name: "unsupported scheme", baseURL: "ftp://example.test", httpClient: &http.Client{}},
+		{name: "base URL query", baseURL: "https://example.test?scope=one", httpClient: &http.Client{}},
+		{name: "missing HTTP client", baseURL: "https://example.test"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter, err := restclient.New(tt.baseURL, tt.httpClient)
+			if err == nil {
+				t.Fatalf("New() = %#v, want configuration error", adapter)
+			}
+		})
+	}
+}
+
+type markerTransport struct {
+	marker string
+	base   http.RoundTripper
+}
+
+func (t markerTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	if request == nil {
+		return nil, errors.New("marker transport received nil request")
+	}
+	request.Header.Set("X-Functional-Client", t.marker)
+	return t.base.RoundTrip(request)
+}

--- a/tests/functional/internal/restclient/doc.go
+++ b/tests/functional/internal/restclient/doc.go
@@ -1,0 +1,5 @@
+// Package restclient provides the pre-DI functional adapter around the
+// generated REST response client. Callers retain ownership of the endpoint and
+// HTTP client; production-shaped dependency graph coverage belongs to later
+// functional graph tests.
+package restclient

--- a/tests/functional/runtime_api/api_generated_rest_client_smoke_test.go
+++ b/tests/functional/runtime_api/api_generated_rest_client_smoke_test.go
@@ -1,0 +1,55 @@
+package runtime_api
+
+import (
+	"context"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/factory"
+	generatedclient "github.com/portpowered/infinite-you/pkg/transports/http/client"
+	"github.com/portpowered/infinite-you/tests/functional/internal/restclient"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+// TestGeneratedRESTClientSmoke_ConfiguresCallerOwnedDependencies is a pre-DI
+// transport/client proof. Production-shaped graph equivalence belongs to the
+// functional graph coverage introduced after Wire DI.
+func TestGeneratedRESTClientSmoke_ConfiguresCallerOwnedDependencies(t *testing.T) {
+	dir := support.ScaffoldFactory(t, simplePipelineConfig())
+	host := startFunctionalServer(t, dir, true, factory.WithServiceMode())
+
+	var requests atomic.Int32
+	httpClient := &http.Client{Transport: countingRoundTripper{
+		count: &requests,
+		base:  http.DefaultTransport,
+	}}
+	adapter, err := restclient.New(host.URL(), httpClient)
+	if err != nil {
+		t.Fatalf("construct generated REST adapter: %v", err)
+	}
+
+	response, err := adapter.GetFactoryResponseEventsBySessionID(context.Background(), "missing-session", nil)
+	if err != nil {
+		t.Fatalf("request response events through generated REST adapter: %v", err)
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("caller-owned HTTP client request count = %d, want 1", requests.Load())
+	}
+	if response.StatusCode() != http.StatusNotFound || response.JSON404 == nil {
+		t.Fatalf("generated response = %#v, want typed 404 from functional HTTP host", response)
+	}
+	if response.JSON404.Code != generatedclient.RESPONSEEVENTSESSIONNOTFOUND {
+		t.Fatalf("generated error code = %q, want %q", response.JSON404.Code, generatedclient.RESPONSEEVENTSESSIONNOTFOUND)
+	}
+}
+
+type countingRoundTripper struct {
+	count *atomic.Int32
+	base  http.RoundTripper
+}
+
+func (t countingRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	t.count.Add(1)
+	return t.base.RoundTrip(request)
+}

--- a/tests/functional/runtime_api/api_generated_rest_client_smoke_test.go
+++ b/tests/functional/runtime_api/api_generated_rest_client_smoke_test.go
@@ -2,6 +2,7 @@ package runtime_api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -20,6 +21,8 @@ import (
 )
 
 const generatedRESTClientSmokeTimeout = 10 * time.Second
+
+const generatedRESTClientDeadline = 2 * time.Second
 
 // TestGeneratedRESTClientSmoke_ConfiguresCallerOwnedDependencies is a pre-DI
 // transport/client proof. Production-shaped graph equivalence belongs to the
@@ -127,6 +130,106 @@ func TestGeneratedRESTClientSmoke_RoundTripsTypedSuccessAndAPIFailure(t *testing
 	}
 	if failure.JSON404.Family != generatedclient.ErrorFamilyNotFound || failure.JSON404.Code != generatedclient.RESPONSEEVENTSESSIONNOTFOUND {
 		t.Fatalf("generated API error = %#v, want NOT_FOUND/RESPONSE_EVENT_SESSION_NOT_FOUND", failure.JSON404)
+	}
+}
+
+// TestGeneratedRESTClientSmoke_BoundsCancellationAndDeadline is a pre-DI
+// transport/client proof against the current functional HTTP host. It verifies
+// caller-owned context bounds without claiming production-graph equivalence.
+func TestGeneratedRESTClientSmoke_BoundsCancellationAndDeadline(t *testing.T) {
+	dir := support.ScaffoldFactory(t, simplePipelineConfig())
+	support.WriteAgentConfig(t, dir, "worker-a", support.BuildModelWorkerConfig(interfaces.ModelProviderCodex, "gpt-5-codex"))
+	host := startFunctionalServerWithConfig(t, dir, false, func(cfg *service.FactoryServiceConfig) {
+		cfg.RuntimeMode = interfaces.RuntimeModeService
+		cfg.ProviderCommandRunnerOverride = generatedRESTStreamingRunner{}
+	})
+
+	traceID := submitGeneratedWork(t, host.URL(), factoryapi.SubmitWorkRequest{
+		Name:         "generated-rest-client-context-bounds",
+		WorkTypeName: "task",
+		Payload:      map[string]string{"title": "generated REST client context bounds"},
+	})
+	waitForGeneratedWorkComplete(t, host.URL(), traceID, generatedRESTClientSmokeTimeout)
+
+	t.Run("cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		started, result := startOutstandingGeneratedRESTCall(t, host.URL(), ctx)
+		waitForGeneratedRESTResponseStart(t, started, result)
+
+		cancel()
+		assertGeneratedRESTContextError(t, result, context.Canceled)
+	})
+
+	t.Run("deadline", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), generatedRESTClientDeadline)
+		defer cancel()
+		started, result := startOutstandingGeneratedRESTCall(t, host.URL(), ctx)
+		waitForGeneratedRESTResponseStart(t, started, result)
+
+		assertGeneratedRESTContextError(t, result, context.DeadlineExceeded)
+	})
+}
+
+type generatedRESTCallResult struct {
+	response *generatedclient.GetFactoryResponseEventsBySessionIdClientResponse
+	err      error
+}
+
+func startOutstandingGeneratedRESTCall(
+	t *testing.T,
+	baseURL string,
+	ctx context.Context,
+) (<-chan struct{}, <-chan generatedRESTCallResult) {
+	t.Helper()
+	started := make(chan struct{}, 1)
+	adapter, err := restclient.New(baseURL, &http.Client{Transport: responseStartedRoundTripper{
+		started: started,
+		base:    http.DefaultTransport,
+	}})
+	if err != nil {
+		t.Fatalf("construct generated REST adapter: %v", err)
+	}
+
+	result := make(chan generatedRESTCallResult, 1)
+	go func() {
+		response, callErr := adapter.GetFactoryResponseEventsBySessionID(ctx, "~default", nil)
+		result <- generatedRESTCallResult{response: response, err: callErr}
+	}()
+	return started, result
+}
+
+func waitForGeneratedRESTResponseStart(
+	t *testing.T,
+	started <-chan struct{},
+	result <-chan generatedRESTCallResult,
+) {
+	t.Helper()
+	select {
+	case <-started:
+	case completed := <-result:
+		t.Fatalf("generated REST call completed before it was outstanding: response=%#v error=%v", completed.response, completed.err)
+	case <-time.After(generatedRESTClientSmokeTimeout):
+		t.Fatal("timed out waiting for generated REST response to start")
+	}
+}
+
+func assertGeneratedRESTContextError(
+	t *testing.T,
+	result <-chan generatedRESTCallResult,
+	want error,
+) {
+	t.Helper()
+	select {
+	case completed := <-result:
+		if completed.response != nil {
+			t.Fatalf("generated REST response = %#v, want no typed API response", completed.response)
+		}
+		if !errors.Is(completed.err, want) {
+			t.Fatalf("generated REST error = %v, want errors.Is(error, %v)", completed.err, want)
+		}
+	case <-time.After(generatedRESTClientSmokeTimeout):
+		t.Fatalf("generated REST call did not terminate within %s", generatedRESTClientSmokeTimeout)
 	}
 }
 

--- a/tests/functional/runtime_api/api_generated_rest_client_smoke_test.go
+++ b/tests/functional/runtime_api/api_generated_rest_client_smoke_test.go
@@ -2,15 +2,24 @@ package runtime_api
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/portpowered/infinite-you/pkg/factory"
+	"github.com/portpowered/infinite-you/pkg/interfaces"
+	"github.com/portpowered/infinite-you/pkg/service"
 	generatedclient "github.com/portpowered/infinite-you/pkg/transports/http/client"
+	factoryapi "github.com/portpowered/infinite-you/pkg/transports/http/generated"
+	"github.com/portpowered/infinite-you/pkg/workers"
 	"github.com/portpowered/infinite-you/tests/functional/internal/restclient"
 	"github.com/portpowered/infinite-you/tests/functional/internal/support"
 )
+
+const generatedRESTClientSmokeTimeout = 10 * time.Second
 
 // TestGeneratedRESTClientSmoke_ConfiguresCallerOwnedDependencies is a pre-DI
 // transport/client proof. Production-shaped graph equivalence belongs to the
@@ -44,6 +53,99 @@ func TestGeneratedRESTClientSmoke_ConfiguresCallerOwnedDependencies(t *testing.T
 	}
 }
 
+// TestGeneratedRESTClientSmoke_RoundTripsTypedSuccessAndAPIFailure is a
+// pre-DI transport/client proof against the current functional HTTP host. It
+// does not claim equivalence with the future Wire-composed production graph.
+func TestGeneratedRESTClientSmoke_RoundTripsTypedSuccessAndAPIFailure(t *testing.T) {
+	dir := support.ScaffoldFactory(t, simplePipelineConfig())
+	support.WriteAgentConfig(t, dir, "worker-a", support.BuildModelWorkerConfig(interfaces.ModelProviderCodex, "gpt-5-codex"))
+	host := startFunctionalServerWithConfig(t, dir, false, func(cfg *service.FactoryServiceConfig) {
+		cfg.RuntimeMode = interfaces.RuntimeModeService
+		cfg.ProviderCommandRunnerOverride = generatedRESTStreamingRunner{}
+	})
+
+	traceID := submitGeneratedWork(t, host.URL(), factoryapi.SubmitWorkRequest{
+		Name:         "generated-rest-client-success",
+		WorkTypeName: "task",
+		Payload:      map[string]string{"title": "generated REST client success"},
+	})
+	waitForGeneratedWorkComplete(t, host.URL(), traceID, generatedRESTClientSmokeTimeout)
+
+	responseStarted := make(chan struct{}, 1)
+	httpClient := &http.Client{Transport: responseStartedRoundTripper{
+		started: responseStarted,
+		base:    http.DefaultTransport,
+	}}
+	adapter, err := restclient.New(host.URL(), httpClient)
+	if err != nil {
+		t.Fatalf("construct generated REST adapter: %v", err)
+	}
+
+	type callResult struct {
+		response *generatedclient.GetFactoryResponseEventsBySessionIdClientResponse
+		err      error
+	}
+	result := make(chan callResult, 1)
+	go func() {
+		response, callErr := adapter.GetFactoryResponseEventsBySessionID(context.Background(), "~default", nil)
+		result <- callResult{response: response, err: callErr}
+	}()
+
+	select {
+	case <-responseStarted:
+	case <-time.After(generatedRESTClientSmokeTimeout):
+		t.Fatal("timed out waiting for generated REST success response to start")
+	}
+	closeDefaultFactorySession(t, host.URL())
+
+	var success callResult
+	select {
+	case success = <-result:
+	case <-time.After(generatedRESTClientSmokeTimeout):
+		t.Fatal("timed out waiting for generated REST success response to finish")
+	}
+	if success.err != nil {
+		t.Fatalf("request generated REST success response: %v", success.err)
+	}
+	if success.response.StatusCode() != http.StatusOK {
+		t.Fatalf("generated success status = %d, want 200", success.response.StatusCode())
+	}
+	if contentType := success.response.HTTPResponse.Header.Get("Content-Type"); !strings.Contains(contentType, "text/event-stream") {
+		t.Fatalf("generated success Content-Type = %q, want text/event-stream", contentType)
+	}
+	wantKind := fmt.Sprintf(`"kind":"%s"`, generatedclient.FactoryResponseEventKindMessage)
+	if body := string(success.response.Body); !strings.Contains(body, wantKind) || !strings.Contains(body, "generated client response COMPLETE") {
+		t.Fatalf("generated success body = %q, want typed MESSAGE event payload", body)
+	}
+
+	failure, err := adapter.GetFactoryResponseEventsBySessionID(context.Background(), "missing-session", nil)
+	if err != nil {
+		t.Fatalf("request generated REST API failure: %v", err)
+	}
+	if failure.StatusCode() != http.StatusNotFound || failure.JSON404 == nil {
+		t.Fatalf("generated failure response = %#v, want typed 404", failure)
+	}
+	if failure.JSON404.Family != generatedclient.ErrorFamilyNotFound || failure.JSON404.Code != generatedclient.RESPONSEEVENTSESSIONNOTFOUND {
+		t.Fatalf("generated API error = %#v, want NOT_FOUND/RESPONSE_EVENT_SESSION_NOT_FOUND", failure.JSON404)
+	}
+}
+
+func closeDefaultFactorySession(t *testing.T, baseURL string) {
+	t.Helper()
+	request, err := http.NewRequest(http.MethodDelete, strings.TrimSuffix(baseURL, "/")+"/factory-sessions/~default", nil)
+	if err != nil {
+		t.Fatalf("build close default Factory Session request: %v", err)
+	}
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("close default Factory Session: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("close default Factory Session status = %d, want 204", response.StatusCode)
+	}
+}
+
 type countingRoundTripper struct {
 	count *atomic.Int32
 	base  http.RoundTripper
@@ -53,3 +155,35 @@ func (t countingRoundTripper) RoundTrip(request *http.Request) (*http.Response, 
 	t.count.Add(1)
 	return t.base.RoundTrip(request)
 }
+
+type responseStartedRoundTripper struct {
+	started chan<- struct{}
+	base    http.RoundTripper
+}
+
+func (t responseStartedRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	response, err := t.base.RoundTrip(request)
+	if err == nil {
+		select {
+		case t.started <- struct{}{}:
+		default:
+		}
+	}
+	return response, err
+}
+
+type generatedRESTStreamingRunner struct{}
+
+func (generatedRESTStreamingRunner) Run(context.Context, workers.CommandRequest) (workers.CommandResult, error) {
+	output := strings.Join([]string{
+		`{"type":"thread.started","thread_id":"generated-rest-client-thread"}`,
+		`{"type":"turn.started"}`,
+		`{"type":"item.completed","item":{"id":"generated-rest-client-message","type":"agent_message","text":"generated client response COMPLETE"}}`,
+		`{"type":"turn.completed","usage":{"input_tokens":4,"output_tokens":3}}`,
+	}, "\n") + "\n"
+	return workers.CommandResult{Stdout: []byte(output)}, nil
+}
+
+func (generatedRESTStreamingRunner) SupportsResponseStreaming() bool { return true }
+
+var _ workers.CommandRunner = generatedRESTStreamingRunner{}


### PR DESCRIPTION
{
  "project": "FTQ-02A Generated REST Client Library Minimum",
  "branchName": "ftest-b00-rest-client",
  "description": "Prepare a reusable pre-DI functional REST adapter around the generated Go client, configured by a caller-supplied base URL and HTTP client, and prove typed success, typed API error, cancellation, and bounded timeout behavior against the current real HTTP transport test host without claiming production-graph equivalence.",
  "context": {
    "customerAsk": "Prepare the reusable functional adapter around pkg/transports/http/client and prove typed success, typed API error, cancellation, and bounded timeout behavior against the current real HTTP transport test host. The adapter must accept a base URL and HTTP client supplied later by the canonical functional graph. Do not add or mutate a legacy service composition to simulate the future DI graph, and do not claim production-graph equivalence before B01 after Wire DI.",
    "problem": "Functional REST coverage lacks a small reusable driver that preserves generated OpenAPI request and response types while allowing the future canonical composition root to supply transport dependencies. Without a focused pre-DI proof, later tests could introduce handwritten DTOs, leave calls unbounded, or mistake the existing transport test host for the future production-shaped graph.",
    "solution": "Add a stateless functional adapter configured with a caller-owned base URL and HTTP client that delegates typed calls to the generated Go response client. Prove deterministic typed success and API failure round trips through the current real HTTP transport test host, plus cancellation and bounded timeout behavior, while leaving composition-graph equivalence to B01/FTQ-07A."
  },
  "acceptanceCriteria": [
    "The reusable adapter accepts a caller-supplied base URL and HTTP client without constructing or mutating a service composition",
    "REST request, success, and error payloads use generated Go client types with no handwritten REST DTOs",
    "One deterministic typed success and one deterministic typed API failure complete through the current real HTTP transport test host",
    "Cancellation and a bounded timeout terminate outstanding adapter calls and return errors identifiable through standard Go context error semantics",
    "Evidence describes this as a pre-DI transport/client proof and does not claim equivalence with the future canonical functional or production graph",
    "make generate-api, the focused generated REST client smoke, and make api-smoke pass",
    "Typecheck, lint, and tests pass"
  ],
  "userStories": [
    {
      "id": "ftest-b00-rest-client-001",
      "title": "Configure a reusable generated REST adapter",
      "description": "As a functional-test author, I want to create the REST adapter from a supplied base URL and HTTP client so that the later canonical functional graph can provide those dependencies without replacing the adapter.",
      "acceptanceCriteria": [
        "A caller can construct the adapter with a real test-host base URL and a caller-owned HTTP client, then use it for generated typed REST operations",
        "Requests are executed by the supplied HTTP client and target the supplied base URL; the adapter does not discover endpoints or create hidden process/service state",
        "The adapter exposes generated request/response types from pkg/transports/http/client and introduces no handwritten REST DTOs",
        "Construction reports invalid configuration as an explicit error rather than panicking",
        "No legacy service configuration, composition root, or dependency graph is added or mutated to construct the adapter",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Implemented in 8cf8e7bd8: added a pre-DI generated REST adapter with explicit base URL and caller-owned HTTP client validation, plus focused and real functional-host transport coverage."
    },
    {
      "id": "ftest-b00-rest-client-002",
      "title": "Prove typed success and API failure round trips",
      "description": "As a functional-test author, I want successful and rejected calls to retain their generated response types so that functional assertions exercise the real REST contract without ad hoc decoding.",
      "acceptanceCriteria": [
        "A deterministic request through the adapter and current real HTTP transport test host completes successfully and exposes the expected status and payload through generated client response types",
        "A deterministic rejected request through the same adapter/host boundary exposes the documented non-2xx status and generated typed API error payload, including its stable error family and code",
        "Both scenarios traverse the real HTTP request/response transport boundary; neither invokes a handler, service, repository, or runtime method as the assertion path",
        "Test requests and assertions use generated Go client types with no handwritten REST request, response, or error DTOs",
        "The smoke is identified as current-host transport proof only and does not assert production-graph equivalence",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Implemented in e83dd385e: added a deterministic generated-client SSE success round trip and typed NOT_FOUND/RESPONSE_EVENT_SESSION_NOT_FOUND failure proof through the current functional HTTP host."
    },
    {
      "id": "ftest-b00-rest-client-003",
      "title": "Bound cancellation and timeout behavior",
      "description": "As a functional-test author, I want outstanding REST calls to honor cancellation and deadlines so that a stalled functional scenario fails promptly and diagnostically.",
      "acceptanceCriteria": [
        "Canceling the call context terminates an outstanding adapter request within a deterministic bound and returns an error for which errors.Is(err, context.Canceled) is true",
        "A caller-selected bounded deadline or supplied HTTP-client timeout terminates an outstanding adapter request within a deterministic bound and returns an error identifiable as a deadline/timeout rather than a typed API response",
        "Cancellation and timeout scenarios use the adapter against the current real HTTP transport test host, require no public network, and cannot block the test indefinitely",
        "The adapter does not swallow or translate context termination into a handwritten REST error DTO",
        "Cleanup closes outstanding responses and the test host without leaked or hanging work",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Implemented in 9fddcd632: proved outstanding generated REST calls terminate on caller cancellation and bounded deadlines with standard Go context error semantics against the current functional HTTP host."
    }
  ]
}
