### PR TITLE
factory-emulator-event-sink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ define run_timed_step
 endef
 
 .PHONY: test-unit test-functional functional-boundary-check test-stress test-release test-unit-coverage test-functional-coverage
-.PHONY: mcp-contract-check generate-client client-generated-check client-deps client-typecheck client-test
+.PHONY: mcp-contract-check generate-client client-generated-check client-deps client-typecheck client-test factory-emulator-deps factory-emulator-typecheck factory-emulator-test
 .PHONY: backend-dependency-graph
 .PHONY: default build intall bundle-api generate-api generate-go-api generate-go-server-api generate-go-client-api generate-ui-api generate-wire wire-smoke api-smoke api-package-pack-smoke contracts-validate contracts-generate contracts-check contracts-smoke cli-contract-smoke cli-manifest-generate cli-manifest-check docs-reference-check docs-reference-smoke test test-full test-functional test-functional-long verify-fast verify-pr verify-pr-inference verify-extended verify-build verify-lint verify-api verify-build-contracts verify-tests run-concurrent-ui-verification-lanes run-sharded-ui-coverage verify test-ui-coverage test-ui-coverage-merge test-ui-browser-integration test-ui-durable-session-real-backend test-backend-coverage test-backend-functional test-backend-verification test-built-cli-acceptance long-tests long-tests-managed-runtime long-tests-functional-runtime pr-inference-approval test-coverage-go script-timeout-companion-smoke-100 cron-time-work-smoke current-factory-watcher-switch-smoke provider-parity-smoke javascript-contract-smoke config-contract-smoke response-stream-stress-smoke release-surface-smoke artifact-contract-closeout lint backend-size pkg-maint pkg-file-count pkg-boundary durable-runtime-construction-check logging-boundary-check compatibility-alias-check retired-surface-check model-facade-check readme-check deadcode ui-deadcode test-race fmt vet deps deps-tidy init dashboard-verify typecheck release ci ci-typecheck ci-verify-build-contracts ci-verify-tests ui-deps ui-lint ui-build ui-test ui-integration-test ui-durable-session-real-backend-integration-test ui-test-coverage ui-replay-coverage-check ui-install-playwright ui-test-storybook ui-components-typecheck ui-components-test ui-components-storybook ui-components-boundary ui-components-dependency-direction ui-components-verify ui-verify-fresh-npm-install clean
 
@@ -150,6 +150,15 @@ client-typecheck: client-deps
 
 client-test: client-typecheck client-generated-check
 	node --test --test-concurrency=1 scripts/client-generated-freshness.test.mjs scripts/client-packed-consumer.test.mjs packages/client/test/recording-parser.test.mjs
+
+factory-emulator-deps:
+	cd packages/factory-emulator && $(NPM) ci --ignore-scripts
+
+factory-emulator-typecheck: factory-emulator-deps
+	cd packages/factory-emulator && $(NPM) run typecheck
+
+factory-emulator-test: factory-emulator-typecheck
+	cd packages/factory-emulator && $(NPM) test
 
 generate-wire:
 	$(GO) generate ./pkg/...
@@ -232,6 +241,7 @@ readme-check:
 
 test:
 	$(MAKE) test-unit
+	$(MAKE) factory-emulator-test
 
 test-full:
 	$(GO) test ./... -timeout $(GO_TEST_TIMEOUT)
@@ -449,6 +459,7 @@ dashboard-verify:
 	$(MAKE) test
 
 typecheck:
+	$(MAKE) factory-emulator-typecheck
 	cd ui && $(UI_SCRIPT) tsc
 
 ci: ci-typecheck ci-verify-build-contracts ci-verify-tests

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -2,6 +2,13 @@
 
 ## Pull-request verification workflow
 
+- Public standalone package checks belong in explicit root Make targets and in
+  the gates that already execute those targets. For `packages/factory-emulator`,
+  `make factory-emulator-typecheck` installs and typechecks the package, while
+  `make factory-emulator-test` runs its behavioral and packed isolated-consumer
+  tests; root `make typecheck` and `make test` compose those targets so the
+  Development Package workflow exercises the same contract.
+
 - `.github/workflows/ci.yml` owns pull-request and `main` CI lane scheduling.
   Build, Lint, and API are independent Ubuntu jobs, respectively rerunnable
   with `make verify-build`, `make verify-lint`, and `make verify-api`. Keep

--- a/packages/api/generated/manifest.json
+++ b/packages/api/generated/manifest.json
@@ -372,5 +372,5 @@
   "formatVersion": "1.0.0",
   "packageId": "you-agent-factory.api",
   "packageVersion": "0.0.0",
-  "sourceCommit": "693faee8a5cc3cbbd7493711ce72af9951d272c2"
+  "sourceCommit": "6d27e0ffbbb3dc97bede5dfafad01f99d75cbcdf"
 }

--- a/packages/factory-emulator/LICENSE.md
+++ b/packages/factory-emulator/LICENSE.md
@@ -1,0 +1,3 @@
+MIT License
+
+Copyright (c) you-agent-factory contributors

--- a/packages/factory-emulator/README.md
+++ b/packages/factory-emulator/README.md
@@ -26,3 +26,14 @@ batch from a detached committed-state snapshot, waits for `sink.write`, and
 only then commits the calculated next state. A concurrent `advance` rejects
 while the write is unresolved, ensuring no later tick is calculated or
 committed ahead of an unaccepted batch.
+
+If a sink rejects a tick, the emulator retains that detached batch and its
+calculated state as the only pending transaction. The next `advance` retries it
+with the same IDs, timestamps, contents, and order; `reset` explicitly
+discards it. `pending` and `status` expose detached recovery state and the last
+write or close error. An idle emulator remains open. When configured with
+`calculateClose`, `close` writes that caller-supplied terminal lifecycle batch,
+waits for it to be accepted, and then closes the sink. A pending rejected tick
+blocks close so canonical history cannot be skipped. A rejected terminal batch
+is likewise retained unchanged for the next close attempt; after its acceptance
+a failed sink close retries only `sink.close`, never the terminal write.

--- a/packages/factory-emulator/README.md
+++ b/packages/factory-emulator/README.md
@@ -20,6 +20,10 @@ event bound.
 This package intentionally does not own replay history or depend on browser
 timers, React, Zustand, dashboard state, or transport code.
 
+`@you-agent-factory/client` is a peer dependency because it supplies the
+canonical Factory event and recording types. Consumers install both published
+packages; the emulator package does not embed a checkout-relative dependency.
+
 `createFactoryEmulator({ initialState, calculateTick, sink })` provides the
 small logical-tick boundary used by an emulator host. It calculates a complete
 batch from a detached committed-state snapshot, waits for `sink.write`, and

--- a/packages/factory-emulator/README.md
+++ b/packages/factory-emulator/README.md
@@ -23,6 +23,8 @@ timers, React, Zustand, dashboard state, or transport code.
 `@you-agent-factory/client` is a peer dependency because it supplies the
 canonical Factory event and recording types. Consumers install both published
 packages; the emulator package does not embed a checkout-relative dependency.
+The peer range remains unconstrained while this dependency is type-only and no
+minimum compatible client release has been established.
 
 `createFactoryEmulator({ initialState, calculateTick, sink })` provides the
 small logical-tick boundary used by an emulator host. It calculates a complete

--- a/packages/factory-emulator/README.md
+++ b/packages/factory-emulator/README.md
@@ -1,0 +1,14 @@
+# Factory emulator event sink
+
+`@you-agent-factory/factory-emulator` provides the transport-neutral,
+caller-owned `FactoryEventSink` contract used by Factory emulator hosts.
+
+`write` accepts one ordered canonical `FactoryEventBatch` asynchronously. Its
+only successful receipt means every event in the supplied order was accepted;
+partial success must reject. `close` is a separate asynchronous operation and
+does not implicitly accept a pending write. The values crossing the contract
+are data-only, structured-cloneable Factory event and receipt shapes, making
+the contract suitable for a future worker or process boundary.
+
+This package intentionally does not own replay history or depend on browser
+timers, React, Zustand, dashboard state, or transport code.

--- a/packages/factory-emulator/README.md
+++ b/packages/factory-emulator/README.md
@@ -10,5 +10,12 @@ does not implicitly accept a pending write. The values crossing the contract
 are data-only, structured-cloneable Factory event and receipt shapes, making
 the contract suitable for a future worker or process boundary.
 
+`createMemoryFactoryEventSink({ maxEvents })` retains only the newest complete
+batches that fit its event limit. `createFactoryRecordingSink({ sessionId,
+maxEvents })` produces one finite recording for that session. Both helpers
+structured-clone accepted batches and returned history, reject writes after
+`close`, and preserve each batch atomically when a recording would exceed its
+event bound.
+
 This package intentionally does not own replay history or depend on browser
 timers, React, Zustand, dashboard state, or transport code.

--- a/packages/factory-emulator/README.md
+++ b/packages/factory-emulator/README.md
@@ -19,3 +19,10 @@ event bound.
 
 This package intentionally does not own replay history or depend on browser
 timers, React, Zustand, dashboard state, or transport code.
+
+`createFactoryEmulator({ initialState, calculateTick, sink })` provides the
+small logical-tick boundary used by an emulator host. It calculates a complete
+batch from a detached committed-state snapshot, waits for `sink.write`, and
+only then commits the calculated next state. A concurrent `advance` rejects
+while the write is unresolved, ensuring no later tick is calculated or
+committed ahead of an unaccepted batch.

--- a/packages/factory-emulator/package-lock.json
+++ b/packages/factory-emulator/package-lock.json
@@ -8,16 +8,18 @@
       "name": "@you-agent-factory/factory-emulator",
       "version": "0.0.0",
       "license": "MIT",
-      "dependencies": {
-        "@you-agent-factory/client": "file:../client"
-      },
       "devDependencies": {
+        "@you-agent-factory/client": "file:../client",
         "typescript": "~5.9.3"
+      },
+      "peerDependencies": {
+        "@you-agent-factory/client": "^0.0.0"
       }
     },
     "../client": {
       "name": "@you-agent-factory/client",
       "version": "0.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/packages/factory-emulator/package-lock.json
+++ b/packages/factory-emulator/package-lock.json
@@ -10,6 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@you-agent-factory/client": "file:../client"
+      },
+      "devDependencies": {
+        "typescript": "~5.9.3"
       }
     },
     "../client": {
@@ -24,6 +27,20 @@
     "node_modules/@you-agent-factory/client": {
       "resolved": "../client",
       "link": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     }
   }
 }

--- a/packages/factory-emulator/package-lock.json
+++ b/packages/factory-emulator/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "@you-agent-factory/factory-emulator",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@you-agent-factory/factory-emulator",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@you-agent-factory/client": "file:../client"
+      }
+    },
+    "../client": {
+      "name": "@you-agent-factory/client",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1"
+      }
+    },
+    "node_modules/@you-agent-factory/client": {
+      "resolved": "../client",
+      "link": true
+    }
+  }
+}

--- a/packages/factory-emulator/package-lock.json
+++ b/packages/factory-emulator/package-lock.json
@@ -13,7 +13,7 @@
         "typescript": "~5.9.3"
       },
       "peerDependencies": {
-        "@you-agent-factory/client": "^0.0.0"
+        "@you-agent-factory/client": "*"
       }
     },
     "../client": {

--- a/packages/factory-emulator/package.json
+++ b/packages/factory-emulator/package.json
@@ -16,10 +16,18 @@
   "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts"
+      "types": "./src/index.ts",
+      "import": "./src/index.js"
     }
   },
   "dependencies": {
     "@you-agent-factory/client": "file:../client"
+  },
+  "devDependencies": {
+    "typescript": "~5.9.3"
+  },
+  "scripts": {
+    "test": "node --test --test-concurrency=1 test/*.test.mjs",
+    "typecheck": "tsc --project tsconfig.json"
   }
 }

--- a/packages/factory-emulator/package.json
+++ b/packages/factory-emulator/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@you-agent-factory/factory-emulator",
+  "version": "0.0.0",
+  "description": "Transport-neutral event sink contracts for Factory emulator hosts.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/portpowered/you-agent-factory.git"
+  },
+  "type": "module",
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "src"
+  ],
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts"
+    }
+  },
+  "dependencies": {
+    "@you-agent-factory/client": "file:../client"
+  }
+}

--- a/packages/factory-emulator/package.json
+++ b/packages/factory-emulator/package.json
@@ -20,10 +20,11 @@
       "import": "./src/index.js"
     }
   },
-  "dependencies": {
-    "@you-agent-factory/client": "file:../client"
+  "peerDependencies": {
+    "@you-agent-factory/client": "^0.0.0"
   },
   "devDependencies": {
+    "@you-agent-factory/client": "file:../client",
     "typescript": "~5.9.3"
   },
   "scripts": {

--- a/packages/factory-emulator/package.json
+++ b/packages/factory-emulator/package.json
@@ -21,7 +21,7 @@
     }
   },
   "peerDependencies": {
-    "@you-agent-factory/client": "^0.0.0"
+    "@you-agent-factory/client": "*"
   },
   "devDependencies": {
     "@you-agent-factory/client": "file:../client",

--- a/packages/factory-emulator/src/contracts.ts
+++ b/packages/factory-emulator/src/contracts.ts
@@ -1,0 +1,41 @@
+import type { FactoryEvent } from "@you-agent-factory/client";
+
+/**
+ * One ordered canonical Factory event batch submitted by an emulator logical
+ * tick. This value contains data only, so hosts can structured-clone it across
+ * process or worker boundaries.
+ */
+export interface FactoryEventBatch {
+  readonly events: readonly FactoryEvent[];
+}
+
+/**
+ * The only successful result of a batch write. A receipt is returned only when
+ * every supplied event was accepted in its supplied order; partial acceptance
+ * must reject the write instead of returning this receipt.
+ */
+export interface FactoryEventSinkWriteReceipt {
+  readonly status: "accepted";
+}
+
+/**
+ * The only successful result of an explicit sink close. Closing does not
+ * implicitly accept a pending batch; callers must await its write first.
+ */
+export interface FactoryEventSinkCloseReceipt {
+  readonly status: "closed";
+}
+
+/**
+ * Caller-owned asynchronous destination for canonical Factory events.
+ *
+ * `write` is the backpressure boundary: resolution means the entire ordered
+ * batch was accepted, while rejection means none of the batch was accepted.
+ * `close` is explicit and asynchronous so a host can observe either its
+ * successful completion or rejection. The contract deliberately has no
+ * subscription, replay, transport, browser, or dashboard dependency.
+ */
+export interface FactoryEventSink {
+  write(batch: FactoryEventBatch): Promise<FactoryEventSinkWriteReceipt>;
+  close(): Promise<FactoryEventSinkCloseReceipt>;
+}

--- a/packages/factory-emulator/src/emulator.js
+++ b/packages/factory-emulator/src/emulator.js
@@ -7,6 +7,20 @@ export class FactoryEmulatorAdvanceInProgressError extends Error {
   }
 }
 
+export class FactoryEmulatorPendingTransactionError extends Error {
+  constructor() {
+    super("Factory emulator has a rejected logical tick that must be retried or reset");
+    this.name = "FactoryEmulatorPendingTransactionError";
+  }
+}
+
+export class FactoryEmulatorClosedError extends Error {
+  constructor() {
+    super("Factory emulator is closed");
+    this.name = "FactoryEmulatorClosedError";
+  }
+}
+
 /**
  * Creates a transport-neutral logical-tick emulator.
  *
@@ -14,7 +28,7 @@ export class FactoryEmulatorAdvanceInProgressError extends Error {
  * keeps the sink write and the eventual commit paired to one immutable
  * calculation, even when the host retains or mutates its original values.
  */
-export function createFactoryEmulator({ calculateTick, initialState, sink }) {
+export function createFactoryEmulator({ calculateClose, calculateTick, initialState, sink }) {
   if (typeof calculateTick !== "function") {
     throw new TypeError("calculateTick must be a function");
   }
@@ -24,28 +38,131 @@ export function createFactoryEmulator({ calculateTick, initialState, sink }) {
 
   let committedState = copy(initialState);
   let advanceInProgress = false;
+  let closed = false;
+  let pendingTick;
+  let pendingCloseBatch;
+  let pendingCloseBatchAccepted = false;
+  let lastError;
 
   return Object.freeze({
     async advance() {
       if (advanceInProgress) {
         throw new FactoryEmulatorAdvanceInProgressError();
       }
+      assertOpen(closed);
+      if (pendingCloseBatch) {
+        throw new FactoryEmulatorPendingTransactionError();
+      }
 
-      const calculation = copy(calculateTick(copy(committedState)));
-      assertCalculation(calculation);
+      const calculation = pendingTick ?? calculateCalculation(calculateTick, committedState);
+      return writeAndCommitTick(calculation);
+    },
+    async close() {
+      if (advanceInProgress) {
+        throw new FactoryEmulatorAdvanceInProgressError();
+      }
+      if (closed) {
+        throw new FactoryEmulatorClosedError();
+      }
+      if (pendingTick) {
+        throw new FactoryEmulatorPendingTransactionError();
+      }
+
+      if (!pendingCloseBatch) {
+        if (typeof calculateClose !== "function") {
+          throw new TypeError("calculateClose must be a function before closing the emulator");
+        }
+        pendingCloseBatch = calculateCloseBatch(calculateClose, committedState);
+      }
+      if (!pendingCloseBatchAccepted) {
+        advanceInProgress = true;
+        try {
+          await sink.write(copy(pendingCloseBatch));
+          pendingCloseBatchAccepted = true;
+          lastError = undefined;
+        } catch (error) {
+          lastError = errorStatus("write", error);
+          throw error;
+        } finally {
+          advanceInProgress = false;
+        }
+      }
+
       advanceInProgress = true;
       try {
-        await sink.write(copy(calculation.batch));
-        committedState = calculation.state;
-        return copy({ ...committedReceipt, batch: calculation.batch });
+        await sink.close();
+        closed = true;
+        lastError = undefined;
+        return copy({ status: "closed", batch: pendingCloseBatch });
+      } catch (error) {
+        lastError = errorStatus("close", error);
+        throw error;
       } finally {
         advanceInProgress = false;
       }
+    },
+    reset() {
+      if (advanceInProgress) {
+        throw new FactoryEmulatorAdvanceInProgressError();
+      }
+      if (closed) {
+        throw new FactoryEmulatorClosedError();
+      }
+      if (pendingCloseBatch) {
+        if (pendingCloseBatchAccepted) {
+          throw new FactoryEmulatorPendingTransactionError();
+        }
+        pendingCloseBatch = undefined;
+        lastError = undefined;
+        return;
+      }
+      pendingTick = undefined;
+      lastError = undefined;
+    },
+    pending() {
+      return pendingTick ? copy(pendingTick.batch) : undefined;
+    },
+    status() {
+      return copy({
+        phase: closed ? "closed" : pendingCloseBatch ? "closing" : pendingTick ? "pending" : "open",
+        lastError,
+      });
     },
     state() {
       return copy(committedState);
     },
   });
+
+  async function writeAndCommitTick(calculation) {
+    advanceInProgress = true;
+    try {
+      await sink.write(copy(calculation.batch));
+      committedState = calculation.state;
+      pendingTick = undefined;
+      lastError = undefined;
+      return copy({ ...committedReceipt, batch: calculation.batch });
+    } catch (error) {
+      pendingTick = calculation;
+      lastError = errorStatus("write", error);
+      throw error;
+    } finally {
+      advanceInProgress = false;
+    }
+  }
+}
+
+function calculateCalculation(calculateTick, committedState) {
+  const calculation = copy(calculateTick(copy(committedState)));
+  assertCalculation(calculation);
+  return calculation;
+}
+
+function calculateCloseBatch(calculateClose, committedState) {
+  const batch = copy(calculateClose(copy(committedState)));
+  if (!batch || !Array.isArray(batch.events)) {
+    throw new TypeError("calculateClose must return a terminal lifecycle event batch");
+  }
+  return batch;
 }
 
 function assertCalculation(calculation) {
@@ -58,6 +175,19 @@ function assertCalculation(calculation) {
   if (!("state" in calculation)) {
     throw new TypeError("logical tick calculation must contain the calculated state");
   }
+}
+
+function assertOpen(closed) {
+  if (closed) {
+    throw new FactoryEmulatorClosedError();
+  }
+}
+
+function errorStatus(operation, error) {
+  return {
+    operation,
+    message: error instanceof Error ? error.message : String(error),
+  };
 }
 
 function copy(value) {

--- a/packages/factory-emulator/src/emulator.js
+++ b/packages/factory-emulator/src/emulator.js
@@ -1,0 +1,65 @@
+const committedReceipt = Object.freeze({ status: "committed" });
+
+export class FactoryEmulatorAdvanceInProgressError extends Error {
+  constructor() {
+    super("Factory emulator is waiting for the current logical tick to be accepted");
+    this.name = "FactoryEmulatorAdvanceInProgressError";
+  }
+}
+
+/**
+ * Creates a transport-neutral logical-tick emulator.
+ *
+ * State and calculated tick values are copied at the emulator boundary. This
+ * keeps the sink write and the eventual commit paired to one immutable
+ * calculation, even when the host retains or mutates its original values.
+ */
+export function createFactoryEmulator({ calculateTick, initialState, sink }) {
+  if (typeof calculateTick !== "function") {
+    throw new TypeError("calculateTick must be a function");
+  }
+  if (!sink || typeof sink.write !== "function") {
+    throw new TypeError("sink must provide a write function");
+  }
+
+  let committedState = copy(initialState);
+  let advanceInProgress = false;
+
+  return Object.freeze({
+    async advance() {
+      if (advanceInProgress) {
+        throw new FactoryEmulatorAdvanceInProgressError();
+      }
+
+      const calculation = copy(calculateTick(copy(committedState)));
+      assertCalculation(calculation);
+      advanceInProgress = true;
+      try {
+        await sink.write(copy(calculation.batch));
+        committedState = calculation.state;
+        return copy({ ...committedReceipt, batch: calculation.batch });
+      } finally {
+        advanceInProgress = false;
+      }
+    },
+    state() {
+      return copy(committedState);
+    },
+  });
+}
+
+function assertCalculation(calculation) {
+  if (!calculation || typeof calculation !== "object") {
+    throw new TypeError("calculateTick must return a logical tick calculation");
+  }
+  if (!calculation.batch || !Array.isArray(calculation.batch.events)) {
+    throw new TypeError("logical tick calculation batch must contain an events array");
+  }
+  if (!("state" in calculation)) {
+    throw new TypeError("logical tick calculation must contain the calculated state");
+  }
+}
+
+function copy(value) {
+  return structuredClone(value);
+}

--- a/packages/factory-emulator/src/emulator.ts
+++ b/packages/factory-emulator/src/emulator.ts
@@ -1,0 +1,50 @@
+import type { FactoryEventBatch, FactoryEventSink } from "./contracts.js";
+
+/** Raised when an advancing command arrives before the prior tick is accepted. */
+export declare class FactoryEmulatorAdvanceInProgressError extends Error {}
+
+/**
+ * The complete result of calculating one logical scheduler step. The emulator
+ * writes `batch` before it makes `state` visible as its next committed state.
+ */
+export interface FactoryEmulatorTick<State> {
+  readonly batch: FactoryEventBatch;
+  readonly state: State;
+}
+
+/** Computes one complete logical tick from a detached committed-state snapshot. */
+export type FactoryEmulatorTickCalculator<State> = (
+  state: State,
+) => FactoryEmulatorTick<State>;
+
+/** Dependencies and initial state for one caller-owned emulator session. */
+export interface FactoryEmulatorOptions<State> {
+  readonly calculateTick: FactoryEmulatorTickCalculator<State>;
+  readonly initialState: State;
+  readonly sink: FactoryEventSink;
+}
+
+/** Returned only after the matching sink write accepts the entire batch. */
+export interface FactoryEmulatorAdvanceReceipt {
+  readonly status: "committed";
+  readonly batch: FactoryEventBatch;
+}
+
+/**
+ * A caller-owned logical-tick runtime.
+ *
+ * `advance` computes one full batch, awaits the asynchronous sink write, and
+ * commits the calculated state only after that write resolves. A second
+ * advancing command while the write is unresolved rejects explicitly, so it
+ * cannot calculate or commit a later tick ahead of the pending batch.
+ * `state` returns a detached snapshot of the latest committed state.
+ */
+export interface FactoryEmulator<State> {
+  advance(): Promise<FactoryEmulatorAdvanceReceipt>;
+  state(): State;
+}
+
+/** Creates an emulator with explicit state, scheduling, and sink ownership. */
+export declare function createFactoryEmulator<State>(
+  options: FactoryEmulatorOptions<State>,
+): FactoryEmulator<State>;

--- a/packages/factory-emulator/src/emulator.ts
+++ b/packages/factory-emulator/src/emulator.ts
@@ -3,6 +3,12 @@ import type { FactoryEventBatch, FactoryEventSink } from "./contracts.js";
 /** Raised when an advancing command arrives before the prior tick is accepted. */
 export declare class FactoryEmulatorAdvanceInProgressError extends Error {}
 
+/** Raised when a rejected tick must be retried or explicitly reset first. */
+export declare class FactoryEmulatorPendingTransactionError extends Error {}
+
+/** Raised when a command is issued after the emulator has closed. */
+export declare class FactoryEmulatorClosedError extends Error {}
+
 /**
  * The complete result of calculating one logical scheduler step. The emulator
  * writes `batch` before it makes `state` visible as its next committed state.
@@ -17,8 +23,15 @@ export type FactoryEmulatorTickCalculator<State> = (
   state: State,
 ) => FactoryEmulatorTick<State>;
 
+/** Builds the terminal lifecycle event batch written before the sink closes. */
+export type FactoryEmulatorCloseCalculator<State> = (
+  state: State,
+) => FactoryEventBatch;
+
 /** Dependencies and initial state for one caller-owned emulator session. */
 export interface FactoryEmulatorOptions<State> {
+  /** Required when callers use `close`; returns the terminal lifecycle batch. */
+  readonly calculateClose?: FactoryEmulatorCloseCalculator<State>;
   readonly calculateTick: FactoryEmulatorTickCalculator<State>;
   readonly initialState: State;
   readonly sink: FactoryEventSink;
@@ -30,6 +43,21 @@ export interface FactoryEmulatorAdvanceReceipt {
   readonly batch: FactoryEventBatch;
 }
 
+/** The result returned after a terminal batch and sink close both succeed. */
+export interface FactoryEmulatorCloseReceipt {
+  readonly status: "closed";
+  readonly batch: FactoryEventBatch;
+}
+
+/** Observable retry and lifecycle status for one emulator session. */
+export interface FactoryEmulatorStatus {
+  readonly phase: "open" | "pending" | "closing" | "closed";
+  readonly lastError?: {
+    readonly operation: "write" | "close";
+    readonly message: string;
+  };
+}
+
 /**
  * A caller-owned logical-tick runtime.
  *
@@ -37,10 +65,18 @@ export interface FactoryEmulatorAdvanceReceipt {
  * commits the calculated state only after that write resolves. A second
  * advancing command while the write is unresolved rejects explicitly, so it
  * cannot calculate or commit a later tick ahead of the pending batch.
+ * A rejected write retains the calculated batch unchanged; the next `advance`
+ * retries it before new work is calculated, while `reset` explicitly discards
+ * it. `close` retries its caller-calculated terminal lifecycle batch unchanged
+ * after rejection, then closes the sink. It cannot bypass a rejected tick.
  * `state` returns a detached snapshot of the latest committed state.
  */
 export interface FactoryEmulator<State> {
   advance(): Promise<FactoryEmulatorAdvanceReceipt>;
+  close(): Promise<FactoryEmulatorCloseReceipt>;
+  reset(): void;
+  pending(): FactoryEventBatch | undefined;
+  status(): FactoryEmulatorStatus;
   state(): State;
 }
 

--- a/packages/factory-emulator/src/index.js
+++ b/packages/factory-emulator/src/index.js
@@ -1,0 +1,6 @@
+export {
+  FactoryEventSinkCapacityError,
+  FactoryEventSinkClosedError,
+  createFactoryRecordingSink,
+  createMemoryFactoryEventSink,
+} from "./sinks.js";

--- a/packages/factory-emulator/src/index.js
+++ b/packages/factory-emulator/src/index.js
@@ -6,5 +6,7 @@ export {
 } from "./sinks.js";
 export {
   FactoryEmulatorAdvanceInProgressError,
+  FactoryEmulatorClosedError,
+  FactoryEmulatorPendingTransactionError,
   createFactoryEmulator,
 } from "./emulator.js";

--- a/packages/factory-emulator/src/index.js
+++ b/packages/factory-emulator/src/index.js
@@ -4,3 +4,7 @@ export {
   createFactoryRecordingSink,
   createMemoryFactoryEventSink,
 } from "./sinks.js";
+export {
+  FactoryEmulatorAdvanceInProgressError,
+  createFactoryEmulator,
+} from "./emulator.js";

--- a/packages/factory-emulator/src/index.ts
+++ b/packages/factory-emulator/src/index.ts
@@ -16,3 +16,14 @@ export type {
   MemoryFactoryEventSink,
   MemoryFactoryEventSinkOptions,
 } from "./sinks.js";
+export {
+  FactoryEmulatorAdvanceInProgressError,
+  createFactoryEmulator,
+} from "./emulator.js";
+export type {
+  FactoryEmulator,
+  FactoryEmulatorAdvanceReceipt,
+  FactoryEmulatorOptions,
+  FactoryEmulatorTick,
+  FactoryEmulatorTickCalculator,
+} from "./emulator.js";

--- a/packages/factory-emulator/src/index.ts
+++ b/packages/factory-emulator/src/index.ts
@@ -1,0 +1,6 @@
+export type {
+  FactoryEventBatch,
+  FactoryEventSink,
+  FactoryEventSinkCloseReceipt,
+  FactoryEventSinkWriteReceipt,
+} from "./contracts.js";

--- a/packages/factory-emulator/src/index.ts
+++ b/packages/factory-emulator/src/index.ts
@@ -4,3 +4,15 @@ export type {
   FactoryEventSinkCloseReceipt,
   FactoryEventSinkWriteReceipt,
 } from "./contracts.js";
+export {
+  FactoryEventSinkCapacityError,
+  FactoryEventSinkClosedError,
+  createFactoryRecordingSink,
+  createMemoryFactoryEventSink,
+} from "./sinks.js";
+export type {
+  FactoryRecordingSink,
+  FactoryRecordingSinkOptions,
+  MemoryFactoryEventSink,
+  MemoryFactoryEventSinkOptions,
+} from "./sinks.js";

--- a/packages/factory-emulator/src/index.ts
+++ b/packages/factory-emulator/src/index.ts
@@ -18,12 +18,17 @@ export type {
 } from "./sinks.js";
 export {
   FactoryEmulatorAdvanceInProgressError,
+  FactoryEmulatorClosedError,
+  FactoryEmulatorPendingTransactionError,
   createFactoryEmulator,
 } from "./emulator.js";
 export type {
   FactoryEmulator,
   FactoryEmulatorAdvanceReceipt,
+  FactoryEmulatorCloseCalculator,
+  FactoryEmulatorCloseReceipt,
   FactoryEmulatorOptions,
+  FactoryEmulatorStatus,
   FactoryEmulatorTick,
   FactoryEmulatorTickCalculator,
 } from "./emulator.js";

--- a/packages/factory-emulator/src/sinks.js
+++ b/packages/factory-emulator/src/sinks.js
@@ -1,0 +1,118 @@
+const acceptedReceipt = Object.freeze({ status: "accepted" });
+const closedReceipt = Object.freeze({ status: "closed" });
+
+export class FactoryEventSinkClosedError extends Error {
+  constructor() {
+    super("Factory event sink is closed");
+    this.name = "FactoryEventSinkClosedError";
+  }
+}
+
+export class FactoryEventSinkCapacityError extends Error {
+  constructor(limit, attempted) {
+    super(
+      `Factory event sink capacity ${limit} cannot accept ${attempted} more event${attempted === 1 ? "" : "s"}`,
+    );
+    this.name = "FactoryEventSinkCapacityError";
+  }
+}
+
+export function createMemoryFactoryEventSink({ maxEvents }) {
+  assertPositiveInteger(maxEvents, "maxEvents");
+  const retainedBatches = [];
+  let retainedEventCount = 0;
+  let isClosed = false;
+
+  return Object.freeze({
+    maxEvents,
+    async write(batch) {
+      assertOpen(isClosed);
+      const copiedBatch = copyBatch(batch);
+      if (copiedBatch.events.length === 0) {
+        return acceptedReceipt;
+      }
+      if (copiedBatch.events.length > maxEvents) {
+        throw new FactoryEventSinkCapacityError(maxEvents, copiedBatch.events.length);
+      }
+      while (
+        retainedBatches.length > 0 &&
+        retainedEventCount + copiedBatch.events.length > maxEvents
+      ) {
+        retainedEventCount -= retainedBatches.shift().events.length;
+      }
+      retainedBatches.push(copiedBatch);
+      retainedEventCount += copiedBatch.events.length;
+      return acceptedReceipt;
+    },
+    async close() {
+      isClosed = true;
+      return closedReceipt;
+    },
+    batches() {
+      return copyBatches(retainedBatches);
+    },
+  });
+}
+
+export function createFactoryRecordingSink({ sessionId, maxEvents }) {
+  if (typeof sessionId !== "string" || sessionId.length === 0) {
+    throw new TypeError("sessionId must be a non-empty string");
+  }
+  assertPositiveInteger(maxEvents, "maxEvents");
+
+  const retainedEvents = [];
+  let isClosed = false;
+
+  return Object.freeze({
+    sessionId,
+    maxEvents,
+    async write(batch) {
+      assertOpen(isClosed);
+      const copiedBatch = copyBatch(batch);
+      assertRecordingSession(copiedBatch.events, sessionId);
+      const attemptedCount = retainedEvents.length + copiedBatch.events.length;
+      if (attemptedCount > maxEvents) {
+        throw new FactoryEventSinkCapacityError(maxEvents, copiedBatch.events.length);
+      }
+      retainedEvents.push(...copiedBatch.events);
+      return acceptedReceipt;
+    },
+    async close() {
+      isClosed = true;
+      return closedReceipt;
+    },
+    recording() {
+      return structuredClone({
+        schemaVersion: "agent-factory.recording.v1",
+        sessionId,
+        events: retainedEvents,
+      });
+    },
+  });
+}
+
+function assertPositiveInteger(value, name) {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new RangeError(`${name} must be a positive safe integer`);
+  }
+}
+
+function assertOpen(isClosed) {
+  if (isClosed) {
+    throw new FactoryEventSinkClosedError();
+  }
+}
+
+function assertRecordingSession(events, sessionId) {
+  if (events.some((event) => event.context.sessionId !== sessionId)) {
+    throw new TypeError("recording sink batch has an event for another session");
+  }
+}
+
+function copyBatch(batch) {
+  return structuredClone(batch);
+}
+
+function copyBatches(batches) {
+  return structuredClone(batches);
+}

--- a/packages/factory-emulator/src/sinks.ts
+++ b/packages/factory-emulator/src/sinks.ts
@@ -1,0 +1,56 @@
+import type { FactoryRecording } from "@you-agent-factory/client";
+
+import type {
+  FactoryEventBatch,
+  FactoryEventSink,
+} from "./contracts.js";
+
+/** Raised when a caller writes to a helper after it has closed. */
+export declare class FactoryEventSinkClosedError extends Error {}
+
+/** Raised when a batch cannot fit without exceeding a helper's declared bound. */
+export declare class FactoryEventSinkCapacityError extends Error {}
+
+/**
+ * The maximum number of events a memory sink retains. Batches remain atomic:
+ * an oversized batch is rejected and older complete batches are discarded
+ * before a later accepted batch is retained.
+ */
+export interface MemoryFactoryEventSinkOptions {
+  readonly maxEvents: number;
+}
+
+/**
+ * A bounded in-memory sink. `batches` returns a detached snapshot, not the
+ * values retained by the sink.
+ */
+export interface MemoryFactoryEventSink extends FactoryEventSink {
+  readonly maxEvents: number;
+  batches(): readonly FactoryEventBatch[];
+}
+
+/** Creates a bounded, detached in-memory event sink. */
+export declare function createMemoryFactoryEventSink(
+  options: MemoryFactoryEventSinkOptions,
+): MemoryFactoryEventSink;
+
+/** The fixed metadata and capacity of one finite Factory recording. */
+export interface FactoryRecordingSinkOptions {
+  readonly sessionId: string;
+  readonly maxEvents: number;
+}
+
+/**
+ * A bounded sink that produces one finite recording. `recording` returns a
+ * detached snapshot and remains readable after close.
+ */
+export interface FactoryRecordingSink extends FactoryEventSink {
+  readonly sessionId: string;
+  readonly maxEvents: number;
+  recording(): FactoryRecording;
+}
+
+/** Creates a bounded sink for one caller-owned Factory recording. */
+export declare function createFactoryRecordingSink(
+  options: FactoryRecordingSinkOptions,
+): FactoryRecordingSink;

--- a/packages/factory-emulator/test/packed-consumer.test.mjs
+++ b/packages/factory-emulator/test/packed-consumer.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { cp, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -11,6 +11,7 @@ const repositoryRoot = fileURLToPath(new URL("../../../", import.meta.url));
 const clientPackage = join(repositoryRoot, "packages", "client");
 const typescript = join(packageDirectory, "node_modules", "typescript", "bin", "tsc");
 const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+const compatibleClientVersion = "0.1.0";
 
 function run(command, arguments_, { cwd, capture = false } = {}) {
   return new Promise((resolvePromise, rejectPromise) => {
@@ -66,11 +67,25 @@ test("packed emulator resolves its canonical contract from a clean consumer", as
   t.after(() => rm(temporaryRoot, { recursive: true, force: true }));
   const packedDirectory = join(temporaryRoot, "packed");
   const consumerDirectory = join(temporaryRoot, "consumer");
+  const stagedClientDirectory = join(temporaryRoot, "client");
   await mkdir(packedDirectory);
   await mkdir(consumerDirectory);
+  await cp(clientPackage, stagedClientDirectory, {
+    recursive: true,
+    filter: (source) => source !== join(clientPackage, "node_modules"),
+  });
+  const stagedClientManifestPath = join(stagedClientDirectory, "package.json");
+  const stagedClientManifest = JSON.parse(
+    await readFile(stagedClientManifestPath, "utf8"),
+  );
+  stagedClientManifest.version = compatibleClientVersion;
+  await writeFile(
+    stagedClientManifestPath,
+    `${JSON.stringify(stagedClientManifest, null, 2)}\n`,
+  );
 
   const [clientTarball, emulatorTarball] = await Promise.all([
-    pack(clientPackage, packedDirectory),
+    pack(stagedClientDirectory, packedDirectory),
     pack(packageDirectory, packedDirectory),
   ]);
   await writeFile(
@@ -143,7 +158,20 @@ void createMemoryFactoryEventSink({ maxEvents: 1 });
     ),
   );
   assert.equal(installedManifest.dependencies, undefined);
-  assert.equal(installedManifest.peerDependencies["@you-agent-factory/client"], "^0.0.0");
+  assert.equal(installedManifest.peerDependencies["@you-agent-factory/client"], "*");
+  const installedClientManifest = JSON.parse(
+    await readFile(
+      join(
+        consumerDirectory,
+        "node_modules",
+        "@you-agent-factory",
+        "client",
+        "package.json",
+      ),
+      "utf8",
+    ),
+  );
+  assert.equal(installedClientManifest.version, compatibleClientVersion);
   const dependencyTree = JSON.parse(
     await run(npmCommand, ["ls", "--all", "--json"], {
       capture: true,

--- a/packages/factory-emulator/test/packed-consumer.test.mjs
+++ b/packages/factory-emulator/test/packed-consumer.test.mjs
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const packageDirectory = fileURLToPath(new URL("../", import.meta.url));
+const repositoryRoot = fileURLToPath(new URL("../../../", import.meta.url));
+const clientPackage = join(repositoryRoot, "packages", "client");
+const typescript = join(packageDirectory, "node_modules", "typescript", "bin", "tsc");
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+
+function run(command, arguments_, { cwd, capture = false } = {}) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(command, arguments_, {
+      cwd,
+      shell: process.platform === "win32" && command === npmCommand,
+      stdio: capture ? ["ignore", "pipe", "pipe"] : "inherit",
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", rejectPromise);
+    child.on("close", (status) => {
+      if (status !== 0) {
+        rejectPromise(
+          new Error(`${command} ${arguments_.join(" ")} failed with status ${status}\n${stderr}`),
+        );
+        return;
+      }
+      resolvePromise(stdout);
+    });
+  });
+}
+
+async function pack(source, destination) {
+  const output = await run(
+    npmCommand,
+    [
+      "pack",
+      "--json",
+      "--ignore-scripts",
+      "--pack-destination",
+      destination,
+      source,
+    ],
+    { capture: true },
+  );
+  const [report] = JSON.parse(output);
+  return join(destination, report.filename);
+}
+
+test("packed emulator resolves its canonical contract from a clean consumer", async (t) => {
+  const temporaryRoot = await mkdtemp(
+    join(tmpdir(), "you-factory-emulator-consumer-"),
+  );
+  t.after(() => rm(temporaryRoot, { recursive: true, force: true }));
+  const packedDirectory = join(temporaryRoot, "packed");
+  const consumerDirectory = join(temporaryRoot, "consumer");
+  await mkdir(packedDirectory);
+  await mkdir(consumerDirectory);
+
+  const [clientTarball, emulatorTarball] = await Promise.all([
+    pack(clientPackage, packedDirectory),
+    pack(packageDirectory, packedDirectory),
+  ]);
+  await writeFile(
+    join(consumerDirectory, "package.json"),
+    `${JSON.stringify(
+      {
+        private: true,
+        type: "module",
+        dependencies: {
+          "@you-agent-factory/client": `file:${clientTarball}`,
+          "@you-agent-factory/factory-emulator": `file:${emulatorTarball}`,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await run(npmCommand, ["install", "--ignore-scripts", "--no-audit", "--no-fund"], {
+    cwd: consumerDirectory,
+  });
+
+  await writeFile(
+    join(consumerDirectory, "consumer.ts"),
+    `import type { FactoryEvent } from "@you-agent-factory/client";
+import { createMemoryFactoryEventSink } from "@you-agent-factory/factory-emulator";
+import type {
+  FactoryEventBatch,
+  FactoryEventSink,
+} from "@you-agent-factory/factory-emulator";
+
+declare const event: FactoryEvent;
+const batch: FactoryEventBatch = { events: [event] };
+declare const sink: FactoryEventSink;
+void sink.write(batch);
+void createMemoryFactoryEventSink({ maxEvents: 1 });
+`,
+  );
+  await writeFile(
+    join(consumerDirectory, "tsconfig.json"),
+    `${JSON.stringify(
+      {
+        compilerOptions: {
+          exactOptionalPropertyTypes: true,
+          module: "NodeNext",
+          moduleResolution: "NodeNext",
+          noEmit: true,
+          strict: true,
+          target: "ES2022",
+        },
+        include: ["consumer.ts"],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await run(process.execPath, [typescript, "--project", "tsconfig.json"], {
+    cwd: consumerDirectory,
+  });
+
+  const installedManifest = JSON.parse(
+    await readFile(
+      join(
+        consumerDirectory,
+        "node_modules",
+        "@you-agent-factory",
+        "factory-emulator",
+        "package.json",
+      ),
+      "utf8",
+    ),
+  );
+  assert.equal(installedManifest.dependencies, undefined);
+  assert.equal(installedManifest.peerDependencies["@you-agent-factory/client"], "^0.0.0");
+  const dependencyTree = JSON.parse(
+    await run(npmCommand, ["ls", "--all", "--json"], {
+      capture: true,
+      cwd: consumerDirectory,
+    }),
+  );
+  assert.equal(dependencyTree.problems, undefined);
+});

--- a/packages/factory-emulator/test/public-contract.test.ts
+++ b/packages/factory-emulator/test/public-contract.test.ts
@@ -3,6 +3,12 @@ import type {
   FactoryEventSink,
   FactoryEventSinkCloseReceipt,
   FactoryEventSinkWriteReceipt,
+  FactoryRecordingSink,
+  MemoryFactoryEventSink,
+} from "@you-agent-factory/factory-emulator";
+import {
+  createFactoryRecordingSink,
+  createMemoryFactoryEventSink,
 } from "@you-agent-factory/factory-emulator";
 import type { FactoryEvent } from "@you-agent-factory/client";
 
@@ -35,3 +41,16 @@ void closedReceipt;
 // @ts-expect-error The contract exposes no partial-success receipt.
 const partialReceipt: FactoryEventSinkWriteReceipt = { status: "partial" };
 void partialReceipt;
+
+const memorySink: MemoryFactoryEventSink = createMemoryFactoryEventSink({
+  maxEvents: 1,
+});
+const memoryHistory: readonly FactoryEventBatch[] = memorySink.batches();
+void memoryHistory;
+
+const recordingSink: FactoryRecordingSink = createFactoryRecordingSink({
+  maxEvents: 1,
+  sessionId: "session-1",
+});
+const recordingEvents: readonly FactoryEvent[] = recordingSink.recording().events;
+void recordingEvents;

--- a/packages/factory-emulator/test/public-contract.test.ts
+++ b/packages/factory-emulator/test/public-contract.test.ts
@@ -1,4 +1,7 @@
 import type {
+  FactoryEmulator,
+  FactoryEmulatorAdvanceReceipt,
+  FactoryEmulatorTick,
   FactoryEventBatch,
   FactoryEventSink,
   FactoryEventSinkCloseReceipt,
@@ -7,6 +10,7 @@ import type {
   MemoryFactoryEventSink,
 } from "@you-agent-factory/factory-emulator";
 import {
+  createFactoryEmulator,
   createFactoryRecordingSink,
   createMemoryFactoryEventSink,
 } from "@you-agent-factory/factory-emulator";
@@ -54,3 +58,13 @@ const recordingSink: FactoryRecordingSink = createFactoryRecordingSink({
 });
 const recordingEvents: readonly FactoryEvent[] = recordingSink.recording().events;
 void recordingEvents;
+
+const emulator: FactoryEmulator<{ readonly count: number }> = createFactoryEmulator({
+  initialState: { count: 0 },
+  sink,
+  calculateTick(state): FactoryEmulatorTick<{ readonly count: number }> {
+    return { batch, state: { count: state.count + 1 } };
+  },
+});
+const advanceReceipt: Promise<FactoryEmulatorAdvanceReceipt> = emulator.advance();
+void advanceReceipt;

--- a/packages/factory-emulator/test/public-contract.test.ts
+++ b/packages/factory-emulator/test/public-contract.test.ts
@@ -1,6 +1,8 @@
 import type {
   FactoryEmulator,
   FactoryEmulatorAdvanceReceipt,
+  FactoryEmulatorCloseReceipt,
+  FactoryEmulatorStatus,
   FactoryEmulatorTick,
   FactoryEventBatch,
   FactoryEventSink,
@@ -68,3 +70,10 @@ const emulator: FactoryEmulator<{ readonly count: number }> = createFactoryEmula
 });
 const advanceReceipt: Promise<FactoryEmulatorAdvanceReceipt> = emulator.advance();
 void advanceReceipt;
+
+const emulatorStatus: FactoryEmulatorStatus = emulator.status();
+const pendingBatch: FactoryEventBatch | undefined = emulator.pending();
+const emulatorCloseReceipt: Promise<FactoryEmulatorCloseReceipt> = emulator.close();
+void emulatorStatus;
+void pendingBatch;
+void emulatorCloseReceipt;

--- a/packages/factory-emulator/test/public-contract.test.ts
+++ b/packages/factory-emulator/test/public-contract.test.ts
@@ -1,0 +1,37 @@
+import type {
+  FactoryEventBatch,
+  FactoryEventSink,
+  FactoryEventSinkCloseReceipt,
+  FactoryEventSinkWriteReceipt,
+} from "@you-agent-factory/factory-emulator";
+import type { FactoryEvent } from "@you-agent-factory/client";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <
+    Value,
+  >() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type Assert<Value extends true> = Value;
+
+type _BatchUsesCanonicalEvents = Assert<
+  Equal<FactoryEventBatch["events"][number], FactoryEvent>
+>;
+
+declare const sink: FactoryEventSink;
+declare const batch: FactoryEventBatch;
+
+const writeReceipt: Promise<FactoryEventSinkWriteReceipt> = sink.write(batch);
+const closeReceipt: Promise<FactoryEventSinkCloseReceipt> = sink.close();
+void writeReceipt;
+void closeReceipt;
+
+const acceptedReceipt: FactoryEventSinkWriteReceipt = { status: "accepted" };
+const closedReceipt: FactoryEventSinkCloseReceipt = { status: "closed" };
+void acceptedReceipt;
+void closedReceipt;
+
+// A successful batch receipt cannot describe partial acceptance.
+// @ts-expect-error The contract exposes no partial-success receipt.
+const partialReceipt: FactoryEventSinkWriteReceipt = { status: "partial" };
+void partialReceipt;

--- a/packages/factory-emulator/test/sinks.test.mjs
+++ b/packages/factory-emulator/test/sinks.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   FactoryEmulatorAdvanceInProgressError,
+  FactoryEmulatorClosedError,
+  FactoryEmulatorPendingTransactionError,
   FactoryEventSinkCapacityError,
   FactoryEventSinkClosedError,
   createFactoryEmulator,
@@ -141,6 +143,198 @@ test("emulator commits its calculated state only after the logical-tick batch is
     batch: { events: [event("event-1", 1)] },
   });
   assert.deepEqual(emulator.state(), { count: 1 });
+});
+
+test("emulator retries a rejected tick unchanged before calculating later work", async () => {
+  const attempts = [];
+  let calculations = 0;
+  let rejectNextWrite = true;
+  const emulator = createFactoryEmulator({
+    initialState: { count: 0 },
+    sink: {
+      async close() {
+        return { status: "closed" };
+      },
+      async write(batch) {
+        attempts.push(structuredClone(batch));
+        if (rejectNextWrite) {
+          rejectNextWrite = false;
+          throw new Error("persistence unavailable");
+        }
+        return { status: "accepted" };
+      },
+    },
+    calculateTick(state) {
+      calculations += 1;
+      return {
+        batch: { events: [event(`event-${state.count + 1}`, state.count + 1)] },
+        state: { count: state.count + 1 },
+      };
+    },
+  });
+
+  await assert.rejects(emulator.advance(), /persistence unavailable/);
+  assert.deepEqual(emulator.state(), { count: 0 });
+  assert.equal(calculations, 1);
+  assert.deepEqual(emulator.status(), {
+    phase: "pending",
+    lastError: { operation: "write", message: "persistence unavailable" },
+  });
+  const inspectedPending = emulator.pending();
+  inspectedPending.events[0].payload.nested.value = "mutated inspected pending";
+  assert.equal(emulator.pending().events[0].payload.nested.value, "event-1");
+
+  await assert.rejects(emulator.close(), FactoryEmulatorPendingTransactionError);
+  const retryReceipt = await emulator.advance();
+  assert.equal(calculations, 1);
+  assert.deepEqual(retryReceipt.batch, attempts[0]);
+  assert.deepEqual(attempts, [retryReceipt.batch, retryReceipt.batch]);
+  assert.deepEqual(emulator.state(), { count: 1 });
+  assert.deepEqual(emulator.status(), { phase: "open", lastError: undefined });
+
+  await emulator.advance();
+  assert.equal(calculations, 2);
+  assert.deepEqual(
+    attempts.map((batch) => batch.events[0].id),
+    ["event-1", "event-1", "event-2"],
+  );
+});
+
+test("reset explicitly discards a rejected batch and repeated recoveries commit once", async () => {
+  let rejectNextWrite = true;
+  let calculations = 0;
+  const emulator = createFactoryEmulator({
+    initialState: { count: 0 },
+    sink: {
+      async close() {
+        return { status: "closed" };
+      },
+      async write() {
+        if (rejectNextWrite) {
+          rejectNextWrite = false;
+          throw new Error("write rejected");
+        }
+        return { status: "accepted" };
+      },
+    },
+    calculateTick(state) {
+      calculations += 1;
+      return {
+        batch: { events: [event(`event-${calculations}`, state.count + 1)] },
+        state: { count: state.count + 1 },
+      };
+    },
+  });
+
+  await assert.rejects(emulator.advance(), /write rejected/);
+  emulator.reset();
+  assert.equal(emulator.pending(), undefined);
+  assert.deepEqual(emulator.status(), { phase: "open", lastError: undefined });
+  await emulator.advance();
+  assert.equal(calculations, 2);
+
+  for (const expectedCount of [2, 3]) {
+    rejectNextWrite = true;
+    await assert.rejects(emulator.advance(), /write rejected/);
+    assert.deepEqual(emulator.state(), { count: expectedCount - 1 });
+    await emulator.advance();
+    assert.deepEqual(emulator.state(), { count: expectedCount });
+  }
+  assert.equal(calculations, 4);
+});
+
+test("an idle emulator accepts later work, then writes terminal lifecycle events before closing", async () => {
+  const operations = [];
+  const emulator = createFactoryEmulator({
+    initialState: { count: 0 },
+    sink: {
+      async close() {
+        operations.push("close");
+        return { status: "closed" };
+      },
+      async write(batch) {
+        operations.push(structuredClone(batch));
+        return { status: "accepted" };
+      },
+    },
+    calculateClose(state) {
+      return { events: [event("session-closed", state.count + 1)] };
+    },
+    calculateTick(state) {
+      return {
+        batch: { events: [event(`event-${state.count + 1}`, state.count + 1)] },
+        state: { count: state.count + 1 },
+      };
+    },
+  });
+
+  assert.deepEqual(emulator.status(), { phase: "open", lastError: undefined });
+  await emulator.advance();
+  const closeReceipt = await emulator.close();
+  assert.deepEqual(closeReceipt, {
+    status: "closed",
+    batch: { events: [event("session-closed", 2)] },
+  });
+  assert.deepEqual(operations, [
+    { events: [event("event-1", 1)] },
+    { events: [event("session-closed", 2)] },
+    "close",
+  ]);
+  assert.deepEqual(emulator.status(), { phase: "closed", lastError: undefined });
+  await assert.rejects(emulator.advance(), FactoryEmulatorClosedError);
+});
+
+test("emulator retains terminal lifecycle writes across close failures", async () => {
+  const terminalAttempts = [];
+  let closeCalculations = 0;
+  let rejectTerminalWrite = true;
+  let rejectSinkClose = true;
+  const emulator = createFactoryEmulator({
+    initialState: { count: 0 },
+    sink: {
+      async close() {
+        if (rejectSinkClose) {
+          rejectSinkClose = false;
+          throw new Error("sink close unavailable");
+        }
+        return { status: "closed" };
+      },
+      async write(batch) {
+        terminalAttempts.push(structuredClone(batch));
+        if (rejectTerminalWrite) {
+          rejectTerminalWrite = false;
+          throw new Error("terminal write unavailable");
+        }
+        return { status: "accepted" };
+      },
+    },
+    calculateClose(state) {
+      closeCalculations += 1;
+      return { events: [event("session-closed", state.count + 1)] };
+    },
+    calculateTick() {
+      throw new Error("advance is not used by this test");
+    },
+  });
+
+  await assert.rejects(emulator.close(), /terminal write unavailable/);
+  assert.deepEqual(emulator.status(), {
+    phase: "closing",
+    lastError: { operation: "write", message: "terminal write unavailable" },
+  });
+  await assert.rejects(emulator.advance(), FactoryEmulatorPendingTransactionError);
+  await assert.rejects(emulator.close(), /sink close unavailable/);
+  assert.deepEqual(emulator.status(), {
+    phase: "closing",
+    lastError: { operation: "close", message: "sink close unavailable" },
+  });
+  await emulator.close();
+
+  assert.equal(closeCalculations, 1);
+  assert.deepEqual(terminalAttempts, [
+    { events: [event("session-closed", 1)] },
+    { events: [event("session-closed", 1)] },
+  ]);
 });
 
 function deferred() {

--- a/packages/factory-emulator/test/sinks.test.mjs
+++ b/packages/factory-emulator/test/sinks.test.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  FactoryEventSinkCapacityError,
+  FactoryEventSinkClosedError,
+  createFactoryRecordingSink,
+  createMemoryFactoryEventSink,
+} from "@you-agent-factory/factory-emulator";
+
+function event(id, sequence, payload = { nested: { value: id } }) {
+  return {
+    schemaVersion: "agent-factory.event.v1",
+    id,
+    type: "INITIAL_STRUCTURE_REQUEST",
+    context: {
+      sequence,
+      tick: sequence,
+      eventTime: `2026-07-18T05:00:0${sequence}Z`,
+      sessionId: "session-1",
+    },
+    payload,
+  };
+}
+
+test("memory sink retains only complete newest batches and isolates snapshots", async () => {
+  const sink = createMemoryFactoryEventSink({ maxEvents: 2 });
+  const first = event("event-1", 1);
+  await sink.write({ events: [first] });
+  first.payload.nested.value = "mutated after write";
+  assert.equal(sink.batches()[0].events[0].payload.nested.value, "event-1");
+
+  await sink.write({ events: [event("event-2", 2)] });
+  await sink.write({ events: [event("event-3", 3)] });
+
+  const history = sink.batches();
+  assert.deepEqual(
+    history.map((batch) => batch.events.map((accepted) => accepted.id)),
+    [["event-2"], ["event-3"]],
+  );
+  history[0].events[0].payload.nested.value = "mutated returned history";
+  assert.equal(
+    sink.batches()[0].events[0].payload.nested.value,
+    "event-2",
+  );
+
+  await assert.rejects(
+    sink.write({
+      events: [event("event-4", 4), event("event-5", 5), event("event-6", 6)],
+    }),
+    FactoryEventSinkCapacityError,
+  );
+  assert.deepEqual(
+    sink.batches().map((batch) => batch.events.map((accepted) => accepted.id)),
+    [["event-2"], ["event-3"]],
+  );
+});
+
+test("recording sink keeps whole accepted batches, produces detached recordings, and closes", async () => {
+  const sink = createFactoryRecordingSink({
+    sessionId: "session-1",
+    maxEvents: 3,
+  });
+  const first = event("event-1", 1);
+  const second = event("event-2", 2);
+  await sink.write({ events: [first, second] });
+  first.payload.nested.value = "mutated after write";
+
+  await assert.rejects(
+    sink.write({ events: [event("event-3", 3), event("event-4", 4)] }),
+    FactoryEventSinkCapacityError,
+  );
+  const recording = sink.recording();
+  assert.deepEqual(
+    recording.events.map((accepted) => accepted.id),
+    ["event-1", "event-2"],
+  );
+  assert.equal(recording.events[0].payload.nested.value, "event-1");
+  recording.events[0].payload.nested.value = "mutated returned recording";
+  assert.equal(
+    sink.recording().events[0].payload.nested.value,
+    "event-1",
+  );
+
+  await sink.close();
+  await assert.rejects(
+    sink.write({ events: [event("event-3", 3)] }),
+    FactoryEventSinkClosedError,
+  );
+  assert.deepEqual(
+    sink.recording().events.map((accepted) => accepted.id),
+    ["event-1", "event-2"],
+  );
+});
+
+test("memory sink rejects writes after close", async () => {
+  const sink = createMemoryFactoryEventSink({ maxEvents: 1 });
+  await sink.close();
+  await assert.rejects(
+    sink.write({ events: [event("event-1", 1)] }),
+    FactoryEventSinkClosedError,
+  );
+});

--- a/packages/factory-emulator/test/sinks.test.mjs
+++ b/packages/factory-emulator/test/sinks.test.mjs
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  FactoryEmulatorAdvanceInProgressError,
   FactoryEventSinkCapacityError,
   FactoryEventSinkClosedError,
+  createFactoryEmulator,
   createFactoryRecordingSink,
   createMemoryFactoryEventSink,
 } from "@you-agent-factory/factory-emulator";
@@ -100,3 +102,51 @@ test("memory sink rejects writes after close", async () => {
     FactoryEventSinkClosedError,
   );
 });
+
+test("emulator commits its calculated state only after the logical-tick batch is accepted", async () => {
+  const pendingWrite = deferred();
+  const batches = [];
+  const sink = {
+    async close() {
+      return { status: "closed" };
+    },
+    async write(batch) {
+      batches.push(structuredClone(batch));
+      await pendingWrite.promise;
+      return { status: "accepted" };
+    },
+  };
+  const emulator = createFactoryEmulator({
+    initialState: { count: 0 },
+    sink,
+    calculateTick(state) {
+      return {
+        batch: { events: [event("event-1", 1)] },
+        state: { count: state.count + 1 },
+      };
+    },
+  });
+
+  const advance = emulator.advance();
+  assert.deepEqual(emulator.state(), { count: 0 });
+  assert.deepEqual(batches.map((batch) => batch.events.map((accepted) => accepted.id)), [
+    ["event-1"],
+  ]);
+  await assert.rejects(emulator.advance(), FactoryEmulatorAdvanceInProgressError);
+
+  pendingWrite.resolve();
+  const receipt = await advance;
+  assert.deepEqual(receipt, {
+    status: "committed",
+    batch: { events: [event("event-1", 1)] },
+  });
+  assert.deepEqual(emulator.state(), { count: 1 });
+});
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}

--- a/packages/factory-emulator/tsconfig.json
+++ b/packages/factory-emulator/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
{
  "project": "Factory Replay and Emulator Visualization",
  "branchName": "factory-emulator-event-sink",
  "description": "Define a caller-owned, structured-cloneable FactoryEventSink and safe memory and recording helpers for the Factory emulator. The change makes canonical event publication atomic at logical-tick boundaries: the emulator honors async backpressure, commits only after acceptance, retains rejected batches for deterministic retry, closes explicitly, and never owns unbounded replay history.",
  "context": {
    "customerAsk": "Publish structured-cloneable FactoryEventSink plus memory and recording helpers with atomic logical-tick batches, async backpressure, write-before-commit, retained pending writes, deterministic retry, explicit close, and bounded ownership.",
    "problem": "The emulator must publish canonical history without owning an unbounded replay buffer or committing state after a rejected asynchronous write. Without an atomic sink boundary, a failed write can leave history inconsistent with emulator state, and shared event references can corrupt retained history after acceptance.",
    "solution": "Provide a small caller-owned asynchronous FactoryEventSink contract and bounded memory and recording helpers. Each logical-tick event batch is all-or-nothing; the emulator awaits acceptance before committing state, preserves a rejected batch unchanged for same-ID and same-timestamp retry, keeps idle distinct from close, and isolates caller-owned event values."
  },
  "acceptanceCriteria": [
    "A structured-cloneable FactoryEventSink accepts one ordered canonical Factory event batch asynchronously and requires all-or-nothing batch acceptance.",
    "Logical-tick writes apply backpressure and the emulator does not commit calculated state until the matching sink write succeeds.",
    "A rejected write leaves prior state unchanged and retains the identical pending batch so retry uses the same event IDs and timestamps before new work advances.",
    "Memory and recording helpers retain only their declared bounded history or finite recording lifecycle and isolate both submitted and returned event values from mutation.",
    "An idle emulator session remains open for later work, while explicit close publishes terminal lifecycle events before closing the sink and finite recording closure remains distinct.",
    "Quality gate: Typecheck, lint, and relevant unit/integration tests pass."
  ],
  "userStories": [
    {
      "id": "factory-emulator-event-sink-001",
      "title": "Publish the atomic, structured-cloneable sink contract",
      "description": "As an emulator host, I want to supply an asynchronous Factory event sink with explicit batch and close semantics so that I can own canonical history without coupling the emulator to a particular replay or transport implementation.",
      "acceptanceCriteria": [
        "The public sink input and result shapes are structured-cloneable and contain only the information needed to write one ordered canonical Factory event batch and close the sink.",
        "The contract states that accepting a batch means accepting every event in its supplied order; partial acceptance is not a valid success outcome.",
        "The contract makes asynchronous completion, rejection, and explicit closure observable without introducing a generic observable API.",
        "Public package dependencies remain transport-neutral and exclude React, Zustand, replay, browser timer, and dashboard code.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "factory-emulator-event-sink-002",
      "title": "Provide isolated bounded memory and recording helpers",
      "description": "As a package consumer, I want ready-to-use memory and recording sinks so that I can capture canonical batches safely without giving either helper ownership of mutable caller events or unbounded emulator state.",
      "acceptanceCriteria": [
        "The memory helper exposes only its documented bounded retained history and preserves the accepted batch ordering.",
        "The recording helper can produce a finite recording through the same atomic sink contract without becoming a long-lived emulator-session owner.",
        "Mutating an event or nested payload after a caller submits it does not alter events retained by either helper.",
        "Mutating values returned or inspected from either helper does not alter the helper's retained canonical history.",
        "The helpers reject writes after their explicit close behavior takes effect and do not retain an unbounded replay buffer.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "factory-emulator-event-sink-003",
      "title": "Commit emulator state only after an accepted logical-tick batch",
      "description": "As an emulator host, I want an advancing command to wait for sink acceptance before state changes become committed so that slow persistence and backpressure cannot make canonical history diverge from execution state.",
      "acceptanceCriteria": [
        "Each advancing logical scheduler step calculates one complete ordered canonical event batch and submits it through one awaited sink write.",
        "While that write is unresolved, no later logical-tick batch is generated or committed.",
        "A successful write commits exactly the calculated state associated with that batch, and emitted history retains the batch ordering.",
        "Tests use a controllable delayed sink to prove that state remains at the pre-step snapshot until the matching write resolves.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "factory-emulator-event-sink-004",
      "title": "Preserve rejected batches for deterministic recovery and explicit close",
      "description": "As an emulator host recovering from a failed persistence write, I want the failed logical-tick transaction retained exactly until resolution so that retry is deterministic and lifecycle commands cannot silently lose canonical history.",
      "acceptanceCriteria": [
        "On write rejection, the emulator leaves the pre-step state unchanged, records an actionable error status, and retains the complete rejected batch as the only pending transaction.",
        "The next advancing command retries that pending batch before calculating new work and preserves its event IDs, timestamps, contents, and order.",
        "State-changing commands that could bypass the pending transaction, including submission and close, fail clearly until retry succeeds or reset explicitly discards the pending batch.",
        "A successful retry commits the original calculated state once and permits subsequent work without duplicating the accepted batch.",
        "An open idle session accepts later work, while explicit emulator close emits its terminal lifecycle batch, waits for acceptance, then closes the sink; a recording helper may instead close at its declared idle completion point.",
        "Focused failure, retry, close, and repeated-run tests prove the behavior without relying on timers or shared mutable event references.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}
