### PR TITLE
ftest-javascript-parallel-real-cli-boundary

### DIFF
--- a/contracts/functional-scenario-evidence.json
+++ b/contracts/functional-scenario-evidence.json
@@ -29,7 +29,7 @@
       ]
     },
     {
-      "test": "tests/functional/smoke/cli_javascript_factory_run_smoke_test.go::TestJavaScriptFactoryRun_RealCLIProvesOrderedTwoStagePipeline",
+      "test": "tests/functional/smoke/cli_javascript_factory_run_smoke_test.go::TestJavaScriptFactoryRun_RealCLIParallelFanoutCorrelatesChildren",
       "stableIds": [
         "cli/you.run"
       ]

--- a/contracts/functional-scenarios.json
+++ b/contracts/functional-scenarios.json
@@ -246,7 +246,7 @@
       "executionClass": "deterministic",
       "evidence": [
         {
-          "test": "tests/functional/smoke/cli_javascript_factory_run_smoke_test.go::TestJavaScriptFactoryRun_RealCLIProvesOrderedTwoStagePipeline",
+          "test": "tests/functional/smoke/cli_javascript_factory_run_smoke_test.go::TestJavaScriptFactoryRun_RealCLIParallelFanoutCorrelatesChildren",
           "boundary": "cli"
         }
       ]

--- a/tests/functional/smoke/cli_javascript_factory_run_smoke_test.go
+++ b/tests/functional/smoke/cli_javascript_factory_run_smoke_test.go
@@ -20,7 +20,115 @@ import (
 
 const javascriptFactoryRunTimeout = 30 * time.Second
 
+const parallelJavaScriptFanoutResult = "alpha=ALPHA_RESULT;beta=BETA_RESULT"
 const orderedJavaScriptPipelineResult = "ordered-pipeline-complete"
+
+func TestJavaScriptFactoryRun_RealCLIParallelFanoutCorrelatesChildren(t *testing.T) {
+	t.Parallel()
+
+	isolatedRoot := testutil.CopyFixtureDir(t, support.LegacyFixtureDir(t, "dynamic"))
+	binaryPath := buildYouCLIBinary(t)
+	mockWorkersPath := writeDefaultMockWorkersConfig(t)
+	isolatedHome := t.TempDir()
+	port, err := reserveLocalTCPPort()
+	if err != nil {
+		t.Fatalf("reserve loopback port: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), javascriptFactoryRunTimeout)
+	t.Cleanup(cancel)
+	cmd := exec.CommandContext(ctx, binaryPath,
+		"--json", "run",
+		"--factory", "./parallel_fanout.js",
+		"--with-mock-workers="+mockWorkersPath,
+		"--output", "primary",
+		"--no-record",
+		"--server", fmt.Sprintf("http://127.0.0.1:%d", port),
+		"--quiet",
+	)
+	cmd.Dir = isolatedRoot
+	cmd.Env = javascriptFactoryRunEnvironmentForHome(isolatedHome)
+	cmd.WaitDelay = 2 * time.Second
+
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+	assertParallelFanoutProcessResult(t, ctx, runErr, stdout.String(), stderr.String())
+	assertParallelFanoutResult(t, decodeSingleJavaScriptFactoryRunResult(t, stdout.String()))
+}
+
+func assertParallelFanoutProcessResult(t *testing.T, ctx context.Context, runErr error, stdout, stderr string) {
+	t.Helper()
+	if ctx.Err() != nil {
+		t.Fatalf("you run parallel fanout timed out after %s: %v\nstdout:\n%s\nstderr:\n%s", javascriptFactoryRunTimeout, ctx.Err(), stdout, stderr)
+	}
+	if runErr != nil {
+		t.Fatalf("you run parallel fanout exited non-zero: %v\nstdout:\n%s\nstderr:\n%s", runErr, stdout, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty stderr on successful quiet JSON invocation", stderr)
+	}
+}
+
+type parallelFanoutEvidence struct {
+	FinalValue string `json:"finalValue"`
+	Children   []struct {
+		Name         string `json:"name"`
+		DispatchID   string `json:"dispatchId"`
+		ResultStatus string `json:"resultStatus"`
+		Response     string `json:"response"`
+		RawResponse  string `json:"rawResponse"`
+	} `json:"children"`
+}
+
+func assertParallelFanoutResult(t *testing.T, result factoryapi.FactorySessionSyncExecutionResponse) {
+	t.Helper()
+	if result.SyncOutcome != factoryapi.FactorySessionSyncExecutionOutcomeCompleted || result.Status != factoryapi.FactorySessionDurableLifecycleStatusSucceeded {
+		t.Fatalf("terminal outcome = %s (%s), want COMPLETED (SUCCEEDED)", result.SyncOutcome, result.Status)
+	}
+	if result.EffectivePolicy == nil || result.EffectivePolicy.AdditionalProperties["allowNetwork"] != false {
+		t.Fatalf("effective policy = %#v, want public network disabled", result.EffectivePolicy)
+	}
+	if result.Result == nil || result.Result.ResultStatus != factoryapi.FactorySessionResultStatusFinal || result.Result.PrimaryResult == nil || len(*result.Result.PrimaryResult) != 1 {
+		t.Fatalf("result = %#v, want exactly one FINAL Factory Session result with one content part", result.Result)
+	}
+	part, err := (*result.Result.PrimaryResult)[0].AsWorkJsonContentPart()
+	if err != nil {
+		t.Fatalf("decode parallel fanout result content part: %v", err)
+	}
+	encoded, err := json.Marshal(part.Json)
+	if err != nil {
+		t.Fatalf("encode parallel fanout evidence: %v", err)
+	}
+	var evidence parallelFanoutEvidence
+	if err := json.Unmarshal(encoded, &evidence); err != nil {
+		t.Fatalf("decode parallel fanout evidence: %v", err)
+	}
+	assertParallelFanoutEvidence(t, evidence)
+}
+
+func assertParallelFanoutEvidence(t *testing.T, evidence parallelFanoutEvidence) {
+	t.Helper()
+	if evidence.FinalValue != parallelJavaScriptFanoutResult || len(evidence.Children) != 2 {
+		t.Fatalf("parallel fanout evidence = %#v, want final %q and exactly 2 children", evidence, parallelJavaScriptFanoutResult)
+	}
+	wantResponses := map[string]string{"alpha": "ALPHA_RESULT", "beta": "BETA_RESULT"}
+	seenNames, seenDispatches := map[string]bool{}, map[string]bool{}
+	for _, child := range evidence.Children {
+		wantResponse, expected := wantResponses[child.Name]
+		responseMarker := ":" + child.Name + ":" + wantResponse + ":"
+		if !expected || seenNames[child.Name] || child.DispatchID == "" || seenDispatches[child.DispatchID] || child.ResultStatus != "COMPLETED" || child.Response != wantResponse || !strings.Contains(child.RawResponse, responseMarker) {
+			t.Fatalf("child evidence = %#v, want one distinct completed dispatch correlated to %q", child, wantResponse)
+		}
+		seenNames[child.Name], seenDispatches[child.DispatchID] = true, true
+	}
+	for name := range wantResponses {
+		if !seenNames[name] {
+			t.Fatalf("missing child evidence for %q", name)
+		}
+	}
+}
 
 func TestJavaScriptFactoryRun_RealCLIProvesOrderedTwoStagePipeline(t *testing.T) {
 	t.Parallel()
@@ -234,13 +342,15 @@ func javascriptFactoryRunEnvironment(t *testing.T) []string {
 }
 
 func javascriptFactoryRunEnvironmentForHome(isolatedHome string) []string {
-	environment := make([]string, 0, len(os.Environ())+3)
+	environment := make([]string, 0, len(os.Environ())+6)
 	for _, entry := range os.Environ() {
 		name, _, _ := strings.Cut(entry, "=")
 		upperName := strings.ToUpper(name)
-		if strings.EqualFold(name, "HOME") || strings.EqualFold(name, "USERPROFILE") ||
-			strings.HasSuffix(upperName, "_API_KEY") || strings.HasSuffix(upperName, "_AUTH_TOKEN") ||
-			strings.HasPrefix(upperName, "AWS_") {
+		if upperName == "HOME" || upperName == "USERPROFILE" || upperName == "APPDATA" ||
+			upperName == "LOCALAPPDATA" || upperName == "XDG_CONFIG_HOME" || upperName == "XDG_CACHE_HOME" ||
+			strings.HasPrefix(upperName, "YOU_") || strings.Contains(upperName, "API_KEY") ||
+			strings.Contains(upperName, "TOKEN") || strings.Contains(upperName, "SECRET") ||
+			strings.Contains(upperName, "CREDENTIAL") || strings.HasPrefix(upperName, "AWS_") {
 			continue
 		}
 		environment = append(environment, entry)
@@ -248,6 +358,9 @@ func javascriptFactoryRunEnvironmentForHome(isolatedHome string) []string {
 	return append(environment,
 		"HOME="+isolatedHome,
 		"USERPROFILE="+isolatedHome,
+		"APPDATA="+filepath.Join(isolatedHome, "AppData", "Roaming"),
+		"LOCALAPPDATA="+filepath.Join(isolatedHome, "AppData", "Local"),
 		"XDG_CONFIG_HOME="+filepath.Join(isolatedHome, ".config"),
+		"XDG_CACHE_HOME="+filepath.Join(isolatedHome, ".cache"),
 	)
 }

--- a/tests/functional/smoke/cli_javascript_factory_run_smoke_test.go
+++ b/tests/functional/smoke/cli_javascript_factory_run_smoke_test.go
@@ -56,6 +56,7 @@ func TestJavaScriptFactoryRun_RealCLIParallelFanoutCorrelatesChildren(t *testing
 	runErr := cmd.Run()
 	assertParallelFanoutProcessResult(t, ctx, runErr, stdout.String(), stderr.String())
 	assertParallelFanoutResult(t, decodeSingleJavaScriptFactoryRunResult(t, stdout.String()))
+	functionalevidence.Covers(t, "cli/you.run")
 }
 
 func assertParallelFanoutProcessResult(t *testing.T, ctx context.Context, runErr error, stdout, stderr string) {
@@ -169,7 +170,6 @@ func TestJavaScriptFactoryRun_RealCLIProvesOrderedTwoStagePipeline(t *testing.T)
 	assertJavaScriptPipelineProcessResult(t, ctx, runErr, stdout.String(), stderr.String())
 	result := decodeSingleJavaScriptFactoryRunResult(t, stdout.String())
 	assertOrderedJavaScriptPipelineResult(t, result)
-	functionalevidence.Covers(t, "cli/you.run")
 }
 
 func assertJavaScriptPipelineProcessResult(t *testing.T, ctx context.Context, runErr error, stdout, stderr string) {

--- a/tests/functional_test/testdata/dynamic/parallel_fanout.js
+++ b/tests/functional_test/testdata/dynamic/parallel_fanout.js
@@ -1,0 +1,45 @@
+return (async function () {
+  const childResults = await parallel([
+    {
+      label: "alpha",
+      prompt: "ALPHA_RESULT",
+    },
+    {
+      label: "beta",
+      prompt: "BETA_RESULT",
+    },
+  ]);
+
+  const alpha = childResults[0];
+  const beta = childResults[1];
+  if (childResults.length !== 2 || alpha.label !== "alpha" || beta.label !== "beta") {
+    throw new Error("parallel fanout returned missing, duplicate, or unexpected children");
+  }
+  if (
+    alpha.output.text.indexOf(":alpha:ALPHA_RESULT:") === -1 ||
+    beta.output.text.indexOf(":beta:BETA_RESULT:") === -1
+  ) {
+    throw new Error("parallel fanout cross-correlated deterministic child results");
+  }
+
+  const finalValue = "alpha=ALPHA_RESULT;beta=BETA_RESULT";
+  return {
+    finalValue: finalValue,
+    children: [
+      {
+        name: alpha.label,
+        dispatchId: alpha.dispatchId,
+        resultStatus: alpha.status,
+        response: "ALPHA_RESULT",
+        rawResponse: alpha.output.text,
+      },
+      {
+        name: beta.label,
+        dispatchId: beta.dispatchId,
+        resultStatus: beta.status,
+        response: "BETA_RESULT",
+        rawResponse: beta.output.text,
+      },
+    ],
+  };
+})();


### PR DESCRIPTION
{
  "project": "Prove Authored JavaScript Parallel Fan-Out Through the Real CLI",
  "branchName": "ftest-javascript-parallel-real-cli-boundary",
  "description": "Add one deterministic FT-CLI-RUN-009 functional smoke scenario that runs a bounded authored JavaScript Factory through a repository-built `you` subprocess, fans out the named children `alpha` and `beta` through the supported parallel primitive, proves distinct dispatch-to-result correlation from public evidence, and returns exactly `alpha=ALPHA_RESULT;beta=BETA_RESULT` as one successful terminal customer result.",
  "context": {
    "customerAsk": "Add one deterministic authored JavaScript fixture that uses the supported parallel fan-out primitive and execute it through a repository-built `you` subprocess with documented CLI arguments and explicit mock workers. Prove that a bounded set of named child dispatches and results remains individually correlated and produces one stable aggregate customer result using only public CLI output or a documented CLI-produced artifact. Register only the exact new test as `cli/you.run` evidence for FT-CLI-RUN-009.",
    "problem": "The merged basic and ordered-pipeline real-CLI scenarios do not prove multi-child JavaScript fan-out, distinct child dispatch identities, or correct result correlation at the customer executable boundary. Lower-layer JavaScript tests and deep-research smokes either bypass that boundary or prove different behavior and cannot qualify as FT-CLI-RUN-009 evidence.",
    "solution": "Add a bounded fixture that submits `alpha` and `beta` through the supported JavaScript parallel primitive, uses explicit mock responses `ALPHA_RESULT` and `BETA_RESULT`, and returns the stable aggregate `alpha=ALPHA_RESULT;beta=BETA_RESULT`. Execute it through a repository-built `you` child process with isolated roots, collision-safe local resources, stripped credentials, a deadline, and cleanup; parse only documented public evidence to prove one terminal success and exact one-to-one child correlation; then replace both `cli/you.run` evidence entries with only the exact new test."
  },
  "acceptanceCriteria": [
    "AC-1: A repository-built `you` subprocess invokes a bounded authored JavaScript Factory that fans out the named children `alpha` and `beta` through the supported parallel primitive and aggregates their results without calling `root.Run`, constructing `root.Dependencies`, importing `pkg/wire`, invoking a handler/service/runtime directly, or inspecting internal state.",
    "AC-2: The scenario uses explicit deterministic mock-worker responses, isolated temporary roots, a bounded context timeout, collision-safe loopback ports and files, no live provider credentials or public network, and cleanup of the child process and artifacts on success or failure.",
    "AC-3: Assertions prove exit zero, documented clean stdout/stderr semantics, exactly one successful terminal Factory Session result, and the exact aggregate customer result `alpha=ALPHA_RESULT;beta=BETA_RESULT` through public CLI or CLI-produced evidence.",
    "AC-4: Public evidence identifies `alpha` and `beta` exactly once, gives each a distinct dispatch identity, and correlates each identity to its matching deterministic result while rejecting missing, duplicate, reused, unexpected, or cross-correlated child facts.",
    "AC-5: The proof remains limited to bounded fan-out and correlation and does not infer behavior from source layout, helper order, internal projections, or incidental logs; assert a non-public scheduler concurrency limit; or claim deep-research behavior, FT-CLI-RUN-010, FT-JS-003, or FT-JS-004.",
    "AC-6: `contracts/functional-scenarios.json` and `contracts/functional-scenario-evidence.json` name only `tests/functional/smoke/cli_javascript_factory_run_smoke_test.go::TestJavaScriptFactoryRun_RealCLIParallelFanoutCorrelatesChildren` under `cli/you.run`, and the change stays within the owned smoke, fixture, and contract files.",
    "AC-7: Quality gates pass: typecheck, lint, the exact smoke test, manifest/evidence validation tests, `make test-functional`, and `make verify-fast`; any intentionally narrower verification is recorded with the command and reason."
  ],
  "userStories": [
    {
      "id": "ftest-javascript-parallel-real-cli-boundary-001",
      "title": "Prove bounded parallel fan-out and child correlation through you run",
      "description": "As a CLI customer, I want a bounded authored JavaScript Factory to fan out named child work through the supported parallel primitive and correlate each result correctly, so I can trust the real command to return a stable aggregate without losing or mixing child identities.",
      "acceptanceCriteria": [
        "The authored fixture uses the supported JavaScript parallel primitive to fan out exactly two named children, `alpha` and `beta`, rather than simulating fan-out with a sequential loop.",
        "Explicit deterministic mock-worker inputs return `ALPHA_RESULT` for `alpha` and `BETA_RESULT` for `beta`, and the Factory returns exactly `alpha=ALPHA_RESULT;beta=BETA_RESULT` independent of child completion order.",
        "`TestJavaScriptFactoryRun_RealCLIParallelFanoutCorrelatesChildren` builds and launches the repository `you` executable as a subprocess with documented Factory, mock-worker, output, server, and recording arguments and does not call `root.Run`, construct `root.Dependencies`, import `pkg/wire`, invoke a handler/service/runtime directly, or inspect an internal projection.",
        "The subprocess uses isolated temporary home, configuration, fixture, and recording roots; collision-safe loopback ports and files; no live-provider credentials or public-network dependency; a bounded context deadline; and cleanup on every exit path.",
        "The command exits zero, successful stderr satisfies the documented clean contract, and every non-empty stdout record satisfies the selected documented CLI output format.",
        "Parsed public CLI or documented CLI-produced evidence contains exactly one successful terminal Factory Session result whose customer value is exactly `alpha=ALPHA_RESULT;beta=BETA_RESULT`.",
        "Parsed public evidence contains exactly one fact for `alpha` and one for `beta`, gives each a non-empty distinct dispatch identity, and correlates each identity with its matching deterministic result.",
        "Assertions reject missing, duplicate, unexpected, identity-reused, or cross-correlated child facts without depending on sibling record order, incidental logs, source position, helper order, internal state, or a scheduler concurrency limit.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "ftest-javascript-parallel-real-cli-boundary-002",
      "title": "Register exact cli/you.run evidence and validate the functional lane",
      "description": "As a functional-test maintainer, I want the coverage contracts to point only to the qualifying real-CLI fan-out test, so FT-CLI-RUN-009 has precise evidence without overstating adjacent JavaScript or deep-research coverage.",
      "acceptanceCriteria": [
        "The `cli/you.run` entry in `contracts/functional-scenarios.json` names only `tests/functional/smoke/cli_javascript_factory_run_smoke_test.go::TestJavaScriptFactoryRun_RealCLIParallelFanoutCorrelatesChildren` as evidence.",
        "`contracts/functional-scenario-evidence.json` maps only that same exact test to `cli/you.run`, and the replaced pipeline test is not also claimed under that stable ID.",
        "The evidence claim remains limited to FT-CLI-RUN-009 bounded fan-out and child correlation and does not claim FT-CLI-RUN-010, FT-JS-003, FT-JS-004, scheduler concurrency limits, deep-research progress/artifacts/synthesis, failure, retry, cancellation, restart, or cross-interface behavior.",
        "The exact smoke test and the functional scenario manifest/evidence validation tests pass.",
        "`make test-functional` and `make verify-fast` pass when feasible; any intentionally narrower verification is recorded with the attempted command, narrower evidence, and concrete reason.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    }
  ]
}
