### PR TITLE
customer-factory-emulator-demos

### DIFF
--- a/docs/internal/processes/factory-replay-relevant-files.md
+++ b/docs/internal/processes/factory-replay-relevant-files.md
@@ -78,6 +78,10 @@ that consumes the replay kernel.
   intent, while pause, step, historical selection, and newly detected reduced
   motion must consume autoplay intent. Restart may renew the one-time autoplay
   opportunity only after the targeted emulator instance resets successfully.
+  For multi-demo hosts, verify disposal by removing one keyed mount while its
+  playback timer is active: its observer, motion listener, and timer must be
+  released, the sibling mount must retain its state, and re-adding the removed
+  key must construct a fresh deterministic instance.
 - `ui/packages/factory-visualizers/src/factory-emulator-controls.tsx` is a
   controlled host adapter for playback and the shared scrubber. It may request
   pause before historical selection and follow-latest before Play or Step, but

--- a/docs/internal/processes/factory-replay-relevant-files.md
+++ b/docs/internal/processes/factory-replay-relevant-files.md
@@ -150,6 +150,11 @@ that consumes the replay kernel.
   `ui/src/features/factory-emulator/components/factory-emulator-submission.tsx`
   connects that instance state to the transport-neutral simple composer; keep
   hosted HTTP submission and emulator submission as separate host adapters.
+  Customer-demo acceptance should exercise submission while a Dispatch is
+  active, history/current/closed availability, multiline keyboard input, draft
+  clearing or preservation, and sibling isolation through the mounted demo
+  composition; retain sink-rejection coverage at this adapter boundary so a
+  failed commit cannot clear controlled input or mutate accepted history.
 - `ui/src/features/factory-emulator/components/factory-emulator-adapter.stories.tsx`
   composes the instance adapter with controlled playback, replay inspection,
   and text submission for browser acceptance. Its required browser check lives

--- a/docs/internal/processes/factory-replay-relevant-files.md
+++ b/docs/internal/processes/factory-replay-relevant-files.md
@@ -71,6 +71,13 @@ that consumes the replay kernel.
   must replace only that instance's retained history, replay checkpoint,
   selection, playback, error, and draft state; sibling adapters and the hosted
   timeline store remain separate authorities.
+- `ui/src/features/factory-emulator/hooks/use-customer-demo-playback.ts` is the
+  customer-demo host policy for wall-clock advancement, viewport observation,
+  reduced-motion preference, and playback intent. Keep timers and observers
+  disposable per mount; visibility may resume only an explicitly retained play
+  intent, while pause, step, historical selection, and newly detected reduced
+  motion must consume autoplay intent. Restart may renew the one-time autoplay
+  opportunity only after the targeted emulator instance resets successfully.
 - `ui/packages/factory-visualizers/src/factory-emulator-controls.tsx` is a
   controlled host adapter for playback and the shared scrubber. It may request
   pause before historical selection and follow-latest before Play or Step, but

--- a/docs/internal/processes/factory-replay-relevant-files.md
+++ b/docs/internal/processes/factory-replay-relevant-files.md
@@ -166,6 +166,15 @@ that consumes the replay kernel.
   mobile and desktop browser contexts instead of Storybook viewport metadata,
   and runs in the required UI Browser Integration lane through
   `ui/scripts/run-storybook-ci.mjs`.
+- `ui/src/App.tsx` owns the shipped `/factory-emulator-demos` website surface.
+  Keep the route composition thin and import the two instance-scoped demos
+  through the Factory emulator feature's public boundary so local playback is
+  independent from hosted dashboard session and network state.
+- `ui/scripts/verify-customer-factory-emulator-demos-browser.mjs` owns direct
+  narrow/desktop browser acceptance for the paired customer demos. Its package
+  command must remain registered in `ui/scripts/run-storybook-ci.mjs` so the
+  required UI Browser Integration lane executes that evidence rather than
+  leaving it as a manual-only check.
 - `api/components/schemas/api/SubmitWorkRequest.yaml` permits a name-free
   single-work submission. The HTTP adapter leaves canonical identity assignment
   to `WorkRequestFromSubmitRequests`; do not synthesize a presentation name in

--- a/ui/package.json
+++ b/ui/package.json
@@ -35,6 +35,7 @@
     "storybook:factory-graph-toolbar-jitter-check": "bun run build-storybook && node scripts/run-factory-graph-toolbar-jitter-browser-check.mjs",
     "storybook:factory-graph-touch-check": "node scripts/verify-factory-graph-touch-browser.mjs",
     "storybook:factory-emulator-adapter-check": "node scripts/verify-factory-emulator-adapter-browser.mjs",
+    "storybook:customer-factory-emulator-demos-check": "node scripts/verify-customer-factory-emulator-demos-browser.mjs",
     "storybook:header-responsive-check": "node scripts/verify-dashboard-header-responsive-browser.mjs",
     "storybook:dashboard-viewport-check": "node scripts/verify-dashboard-viewport-browser.mjs",
     "storybook:factory-graph-visual-group-save-check": "bun run build-storybook && node scripts/run-factory-graph-visual-group-save-browser-check.mjs",

--- a/ui/scripts/run-storybook-ci.mjs
+++ b/ui/scripts/run-storybook-ci.mjs
@@ -363,6 +363,10 @@ export async function runStorybookCI({
       runCommand(["run", "storybook:factory-emulator-adapter-check"]),
       serverExit,
     ]);
+    await Promise.race([
+      runCommand(["run", "storybook:customer-factory-emulator-demos-check"]),
+      serverExit,
+    ]);
   } finally {
     shuttingDown = true;
     await stop(server);

--- a/ui/scripts/run-storybook-ci.test.mjs
+++ b/ui/scripts/run-storybook-ci.test.mjs
@@ -187,10 +187,6 @@ describe("runStorybookCI", () => {
       "run",
       "storybook:factory-emulator-adapter-check",
     ]);
-    expect(runCommand).toHaveBeenNthCalledWith(9, [
-      "run",
-      "storybook:customer-factory-emulator-demos-check",
-    ]);
     expect(stop).toHaveBeenCalledWith(server);
   });
 });
@@ -237,10 +233,6 @@ describe("runStorybookCI browser-check mode", () => {
     expect(runCommand).toHaveBeenNthCalledWith(4, [
       "run",
       "storybook:factory-emulator-adapter-check",
-    ]);
-    expect(runCommand).toHaveBeenNthCalledWith(5, [
-      "run",
-      "storybook:customer-factory-emulator-demos-check",
     ]);
     expect(settle).not.toHaveBeenCalled();
     expect(waitForStableIndex).not.toHaveBeenCalled();

--- a/ui/scripts/run-storybook-ci.test.mjs
+++ b/ui/scripts/run-storybook-ci.test.mjs
@@ -183,10 +183,6 @@ describe("runStorybookCI", () => {
       "run",
       "storybook:checkbox-consistency-check",
     ]);
-    expect(runCommand).toHaveBeenNthCalledWith(8, [
-      "run",
-      "storybook:factory-emulator-adapter-check",
-    ]);
     expect(stop).toHaveBeenCalledWith(server);
   });
 });
@@ -229,10 +225,6 @@ describe("runStorybookCI browser-check mode", () => {
     expect(runCommand).toHaveBeenNthCalledWith(3, [
       "run",
       "storybook:dashboard-viewport-check",
-    ]);
-    expect(runCommand).toHaveBeenNthCalledWith(4, [
-      "run",
-      "storybook:factory-emulator-adapter-check",
     ]);
     expect(settle).not.toHaveBeenCalled();
     expect(waitForStableIndex).not.toHaveBeenCalled();

--- a/ui/scripts/run-storybook-ci.test.mjs
+++ b/ui/scripts/run-storybook-ci.test.mjs
@@ -183,6 +183,14 @@ describe("runStorybookCI", () => {
       "run",
       "storybook:checkbox-consistency-check",
     ]);
+    expect(runCommand).toHaveBeenNthCalledWith(8, [
+      "run",
+      "storybook:factory-emulator-adapter-check",
+    ]);
+    expect(runCommand).toHaveBeenNthCalledWith(9, [
+      "run",
+      "storybook:customer-factory-emulator-demos-check",
+    ]);
     expect(stop).toHaveBeenCalledWith(server);
   });
 });
@@ -225,6 +233,14 @@ describe("runStorybookCI browser-check mode", () => {
     expect(runCommand).toHaveBeenNthCalledWith(3, [
       "run",
       "storybook:dashboard-viewport-check",
+    ]);
+    expect(runCommand).toHaveBeenNthCalledWith(4, [
+      "run",
+      "storybook:factory-emulator-adapter-check",
+    ]);
+    expect(runCommand).toHaveBeenNthCalledWith(5, [
+      "run",
+      "storybook:customer-factory-emulator-demos-check",
     ]);
     expect(settle).not.toHaveBeenCalled();
     expect(waitForStableIndex).not.toHaveBeenCalled();

--- a/ui/scripts/verify-customer-factory-emulator-demos-browser.mjs
+++ b/ui/scripts/verify-customer-factory-emulator-demos-browser.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+
+import { chromium } from "playwright";
+
+import {
+  storyUrl,
+  waitForStoryRender,
+} from "./storybook-responsive-helpers.mjs";
+
+const storybookUrl =
+  process.env.AGENT_FACTORY_STORYBOOK_URL ?? "http://127.0.0.1:6008";
+const interactiveStory = "agent-factory-emulator-customer-demos--interactive";
+const errorStory =
+  "agent-factory-emulator-customer-demos--setup-error-isolation";
+const viewports = [
+  { height: 844, width: 390 },
+  { height: 900, width: 1440 },
+];
+
+async function openStory(page, storyID) {
+  await page.goto(storyUrl(storybookUrl, storyID), {
+    timeout: 30_000,
+    waitUntil: "domcontentloaded",
+  });
+  await waitForStoryRender(page);
+}
+
+async function assertResponsiveLayout(page, viewport, storyID) {
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth > window.innerWidth + 1,
+  );
+  assert.equal(
+    overflow,
+    false,
+    `${storyID} has page-level overflow at ${viewport.width}px.`,
+  );
+  for (const control of await page.getByRole("button").all()) {
+    const box = await control.boundingBox();
+    if (!box) continue;
+    assert.ok(
+      box.x >= -1 && box.x + box.width <= viewport.width + 1,
+      `${storyID} has a clipped control at ${viewport.width}px.`,
+    );
+  }
+}
+
+async function step(demo) {
+  const button = demo.getByRole("button", { name: "Step" });
+  await button.focus();
+  await button.press("Enter");
+}
+
+async function verifyInteractive(page, viewport) {
+  await openStory(page, interactiveStory);
+  const success = page.getByRole("article", {
+    name: "Straightforward success",
+  });
+  const failure = page.getByRole("article", {
+    name: "Review, rework, and failure",
+  });
+  await success.getByText("1 Work total").waitFor();
+  await failure.getByText("1 Work total").waitFor();
+  await assertResponsiveLayout(page, viewport, interactiveStory);
+
+  await step(success);
+  await success
+    .getByText(
+      "Execute: Preparing the launch summary (1.5 seconds virtual time)",
+    )
+    .waitFor();
+  await step(success);
+  await success
+    .getByRole("region", { name: "Successful completion" })
+    .waitFor();
+  await failure
+    .getByRole("status", { name: "Runtime status" })
+    .getByText("Ready", { exact: true })
+    .waitFor();
+
+  for (let index = 0; index < 6; index += 1) await step(failure);
+  await step(failure);
+  await failure
+    .getByText(
+      "Execute: Polishing the revised launch plan (1.5 seconds virtual time)",
+    )
+    .waitFor();
+  for (let index = 0; index < 3; index += 1) await step(failure);
+  await failure.getByRole("region", { name: "Terminal failure" }).waitFor();
+  await failure.getByText("1 failed").waitFor();
+
+  const slider = failure.getByRole("slider", { name: "Select replay tick" });
+  await slider.focus();
+  await page.keyboard.press("ArrowLeft");
+  await failure
+    .getByText("Review: Working at Review (1 seconds virtual time)")
+    .waitFor();
+  assert.equal(
+    await failure.getByText(/Running final review/).count(),
+    0,
+    "Historical replay retained transient activity copy.",
+  );
+  await assertResponsiveLayout(page, viewport, interactiveStory);
+}
+
+async function verifySetupErrorIsolation(page, viewport) {
+  await openStory(page, errorStory);
+  await page.getByText("1 Work total").waitFor();
+  await page
+    .getByRole("alert")
+    .getByText(/This demo could not be prepared/)
+    .waitFor();
+  await page
+    .getByRole("article", { name: "Straightforward success" })
+    .getByRole("button", { name: "Step" })
+    .waitFor();
+  await assertResponsiveLayout(page, viewport, errorStory);
+}
+
+async function verifyCustomerFactoryEmulatorDemos() {
+  const browser = await chromium.launch({ headless: true });
+  try {
+    for (const viewport of viewports) {
+      const context = await browser.newContext({ viewport });
+      const page = await context.newPage();
+      await verifyInteractive(page, viewport);
+      await verifySetupErrorIsolation(page, viewport);
+      await context.close();
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+await verifyCustomerFactoryEmulatorDemos();
+console.log("Customer Factory emulator demo browser checks passed.");

--- a/ui/scripts/verify-customer-factory-emulator-demos-browser.mjs
+++ b/ui/scripts/verify-customer-factory-emulator-demos-browser.mjs
@@ -17,6 +17,70 @@ const viewports = [
   { height: 900, width: 1440 },
 ];
 
+async function installPlaybackControls(context) {
+  await context.addInitScript(() => {
+    const observers = [];
+    let reducedMotion = false;
+    const motionListeners = new Set();
+    window.matchMedia = (query) => ({
+      addEventListener: (_type, listener) => motionListeners.add(listener),
+      addListener: (listener) => motionListeners.add(listener),
+      dispatchEvent: () => true,
+      get matches() {
+        return query === "(prefers-reduced-motion: reduce)" && reducedMotion;
+      },
+      media: query,
+      onchange: null,
+      removeEventListener: (_type, listener) =>
+        motionListeners.delete(listener),
+      removeListener: (listener) => motionListeners.delete(listener),
+    });
+    window.IntersectionObserver = class {
+      constructor(callback) {
+        this.callback = callback;
+        this.targets = new Set();
+        observers.push(this);
+      }
+      disconnect() {
+        this.targets.clear();
+      }
+      observe(target) {
+        this.targets.add(target);
+      }
+      unobserve(target) {
+        this.targets.delete(target);
+      }
+    };
+    window.__setCustomerDemoVisibility = (demoID, isIntersecting) => {
+      for (const observer of observers) {
+        for (const target of observer.targets) {
+          if (target.dataset.demoId === demoID) {
+            observer.callback([{ isIntersecting, target }], observer);
+          }
+        }
+      }
+    };
+    window.__setCustomerDemoReducedMotion = (matches) => {
+      reducedMotion = matches;
+      for (const listener of motionListeners) listener({ matches });
+    };
+  });
+}
+
+async function setVisibility(page, demoID, isIntersecting) {
+  await page.evaluate(
+    ({ id, visible }) => window.__setCustomerDemoVisibility(id, visible),
+    { id: demoID, visible: isIntersecting },
+  );
+}
+
+async function setReducedMotion(page, matches) {
+  await page.evaluate(
+    (reduced) => window.__setCustomerDemoReducedMotion(reduced),
+    matches,
+  );
+}
+
 async function openStory(page, storyID) {
   await page.goto(storyUrl(storybookUrl, storyID), {
     timeout: 30_000,
@@ -116,14 +180,73 @@ async function verifySetupErrorIsolation(page, viewport) {
   await assertResponsiveLayout(page, viewport, errorStory);
 }
 
+async function verifyMotionSafePlayback(page) {
+  await openStory(page, interactiveStory);
+  await page.clock.install();
+  const success = page.getByRole("article", {
+    name: "Straightforward success",
+  });
+  await success.getByText("1 Work total").waitFor();
+
+  await setVisibility(page, "success", true);
+  await success.getByText("Playing", { exact: true }).waitFor();
+  await setVisibility(page, "success", false);
+  await success.getByText("Ready", { exact: true }).waitFor();
+  await setVisibility(page, "success", true);
+  await success.getByText("Playing", { exact: true }).waitFor();
+
+  await success.getByRole("button", { name: "Pause" }).click();
+  await setVisibility(page, "success", false);
+  await setVisibility(page, "success", true);
+  await success.getByText("Ready", { exact: true }).waitFor();
+
+  await success.getByRole("button", { name: "Play" }).click();
+  await setReducedMotion(page, true);
+  await success.getByText("Ready", { exact: true }).waitFor();
+  await setReducedMotion(page, false);
+  await setVisibility(page, "success", false);
+  await setVisibility(page, "success", true);
+  await success.getByText("Ready", { exact: true }).waitFor();
+
+  await success.getByRole("button", { name: "Play" }).click();
+  await page.clock.fastForward(2_000);
+  await success
+    .getByRole("region", { name: "Successful completion" })
+    .waitFor();
+  const completedTick = await success
+    .getByRole("slider", { name: "Select replay tick" })
+    .getAttribute("max");
+  await page.clock.fastForward(10_000);
+  assert.equal(
+    await success
+      .getByRole("slider", { name: "Select replay tick" })
+      .getAttribute("max"),
+    completedTick,
+    "Completed autoplay looped or scheduled more work.",
+  );
+
+  await success.getByRole("button", { name: "Restart" }).click();
+  await success.getByText("1 Work total").waitFor();
+  assert.equal(
+    await success
+      .getByRole("region", { name: "Successful completion" })
+      .count(),
+    0,
+    "Restart retained the terminal projection.",
+  );
+  await success.getByText("Playing", { exact: true }).waitFor();
+}
+
 async function verifyCustomerFactoryEmulatorDemos() {
   const browser = await chromium.launch({ headless: true });
   try {
     for (const viewport of viewports) {
       const context = await browser.newContext({ viewport });
+      await installPlaybackControls(context);
       const page = await context.newPage();
       await verifyInteractive(page, viewport);
       await verifySetupErrorIsolation(page, viewport);
+      await verifyMotionSafePlayback(page);
       await context.close();
     }
   } finally {

--- a/ui/scripts/verify-customer-factory-emulator-demos-browser.mjs
+++ b/ui/scripts/verify-customer-factory-emulator-demos-browser.mjs
@@ -106,6 +106,34 @@ async function assertResponsiveLayout(page, viewport, storyID) {
       `${storyID} has a clipped control at ${viewport.width}px.`,
     );
   }
+  for (const demo of await page.getByRole("article").all()) {
+    const controls = demo.locator(
+      'section[aria-label="Factory emulator controls"] button, section[aria-label="Factory emulator controls"] input, section[aria-label="Factory emulator controls"] select',
+    );
+    const boxes = (
+      await Promise.all(
+        (await controls.all()).map((control) => control.boundingBox()),
+      )
+    ).filter(Boolean);
+    for (let first = 0; first < boxes.length; first += 1) {
+      for (let second = first + 1; second < boxes.length; second += 1) {
+        const horizontalIntersection =
+          Math.min(
+            boxes[first].x + boxes[first].width,
+            boxes[second].x + boxes[second].width,
+          ) - Math.max(boxes[first].x, boxes[second].x);
+        const verticalIntersection =
+          Math.min(
+            boxes[first].y + boxes[first].height,
+            boxes[second].y + boxes[second].height,
+          ) - Math.max(boxes[first].y, boxes[second].y);
+        assert.ok(
+          horizontalIntersection <= 1 || verticalIntersection <= 1,
+          `${storyID} has overlapping controls at ${viewport.width}px.`,
+        );
+      }
+    }
+  }
 }
 
 async function step(demo) {
@@ -132,7 +160,35 @@ async function verifyInteractive(page, viewport) {
       "Execute: Preparing the launch summary (1.5 seconds virtual time)",
     )
     .waitFor();
-  await step(success);
+  const successSlider = success.getByRole("slider", {
+    name: "Select replay tick",
+  });
+  await successSlider.fill("0");
+  await success.getByText("Viewing history", { exact: true }).waitFor();
+  await setVisibility(page, "success", true);
+  await success.getByRole("button", { name: "Play" }).click();
+  await success.getByText("Playing", { exact: true }).waitFor();
+  await success.getByRole("button", { name: "Pause" }).click();
+  await successSlider.fill("0");
+  await success.getByRole("button", { name: "Step" }).focus();
+  await page.keyboard.press("Enter");
+  await success
+    .getByRole("region", { name: "Successful completion" })
+    .waitFor();
+  await success
+    .getByRole("combobox", { name: "Playback speed" })
+    .selectOption("2");
+  assert.equal(
+    await success
+      .getByRole("combobox", { name: "Playback speed" })
+      .inputValue(),
+    "2",
+    "Playback speed did not expose its controlled value.",
+  );
+  await successSlider.focus();
+  await page.keyboard.press("ArrowLeft");
+  await success.getByText("Viewing history", { exact: true }).waitFor();
+  await success.getByRole("button", { name: "Follow current" }).click();
   await success
     .getByRole("region", { name: "Successful completion" })
     .waitFor();
@@ -163,6 +219,8 @@ async function verifyInteractive(page, viewport) {
     0,
     "Historical replay retained transient activity copy.",
   );
+  await failure.getByRole("button", { name: "Follow current" }).click();
+  await failure.getByRole("region", { name: "Terminal failure" }).waitFor();
   await assertResponsiveLayout(page, viewport, interactiveStory);
 }
 

--- a/ui/scripts/verify-customer-factory-emulator-demos-browser.mjs
+++ b/ui/scripts/verify-customer-factory-emulator-demos-browser.mjs
@@ -12,6 +12,8 @@ const storybookUrl =
 const interactiveStory = "agent-factory-emulator-customer-demos--interactive";
 const errorStory =
   "agent-factory-emulator-customer-demos--setup-error-isolation";
+const lifecycleStory =
+  "agent-factory-emulator-customer-demos--lifecycle-isolation";
 const viewports = [
   { height: 844, width: 390 },
   { height: 900, width: 1440 },
@@ -64,6 +66,13 @@ async function installPlaybackControls(context) {
       reducedMotion = matches;
       for (const listener of motionListeners) listener({ matches });
     };
+    window.__customerDemoHostMetrics = () => ({
+      motionListeners: motionListeners.size,
+      observedTargets: observers.reduce(
+        (count, observer) => count + observer.targets.size,
+        0,
+      ),
+    });
   });
 }
 
@@ -289,6 +298,83 @@ async function verifySetupErrorIsolation(page, viewport) {
   await assertResponsiveLayout(page, viewport, errorStory);
 }
 
+async function verifyLifecycleIsolation(page, viewport) {
+  await openStory(page, lifecycleStory);
+  await page.clock.install();
+  const success = page.getByRole("article", {
+    name: "Straightforward success",
+  });
+  let failure = page.getByRole("article", {
+    name: "Review, rework, and failure",
+  });
+  await success.getByText("1 Work total").waitFor();
+  await failure.getByText("1 Work total").waitFor();
+  const mountedHostMetrics = await page.evaluate(() =>
+    window.__customerDemoHostMetrics(),
+  );
+  assert.equal(mountedHostMetrics.observedTargets, 2);
+  assert.ok(mountedHostMetrics.motionListeners > 0);
+
+  await setVisibility(page, "success", true);
+  await setVisibility(page, "repeat-review-failure", true);
+  await success.getByText("Playing", { exact: true }).waitFor();
+  await failure.getByText("Playing", { exact: true }).waitFor();
+  await success.getByRole("button", { name: "Pause" }).click();
+  await success
+    .getByRole("combobox", { name: "Playback speed" })
+    .selectOption("4");
+  const isolatedSubmission = success.getByRole("textbox", {
+    name: "Submit text",
+  });
+  await isolatedSubmission.fill("Isolated request");
+  await isolatedSubmission.press("Enter");
+  await success.getByText("2 Work total").waitFor();
+  await failure.getByText("1 Work total").waitFor();
+  await success.getByRole("slider", { name: "Select replay tick" }).fill("0");
+  await success.getByText("Viewing history", { exact: true }).waitFor();
+  await failure.getByText("Playing", { exact: true }).waitFor();
+  await success.getByRole("button", { name: "Restart" }).click();
+  await success.getByText("1 Work total").waitFor();
+  await failure.getByText("Playing", { exact: true }).waitFor();
+
+  await page.getByRole("button", { name: "Unmount failure demo" }).click();
+  await failure.waitFor({ state: "detached" });
+  const unmountedHostMetrics = await page.evaluate(() =>
+    window.__customerDemoHostMetrics(),
+  );
+  assert.equal(unmountedHostMetrics.observedTargets, 1);
+  assert.ok(
+    unmountedHostMetrics.motionListeners < mountedHostMetrics.motionListeners,
+    "Unmounting one demo did not release its motion-preference listener.",
+  );
+  assert.equal(
+    await success
+      .getByRole("combobox", { name: "Playback speed" })
+      .inputValue(),
+    "1",
+    "Restart did not reset the still-mounted success demo independently.",
+  );
+
+  await page.getByRole("button", { name: "Remount failure demo" }).click();
+  failure = page.getByRole("article", {
+    name: "Review, rework, and failure",
+  });
+  await failure.getByText("1 Work total").waitFor();
+  await failure.getByText("Ready", { exact: true }).waitFor();
+  assert.equal(
+    await failure
+      .getByRole("slider", { name: "Select replay tick" })
+      .inputValue(),
+    "0",
+    "Remounted failure demo retained its previous execution state.",
+  );
+  assert.deepEqual(
+    await page.evaluate(() => window.__customerDemoHostMetrics()),
+    mountedHostMetrics,
+  );
+  await assertResponsiveLayout(page, viewport, lifecycleStory);
+}
+
 async function verifyMotionSafePlayback(page) {
   await openStory(page, interactiveStory);
   await page.clock.install();
@@ -355,6 +441,7 @@ async function verifyCustomerFactoryEmulatorDemos() {
       const page = await context.newPage();
       await verifyInteractive(page, viewport);
       await verifySetupErrorIsolation(page, viewport);
+      await verifyLifecycleIsolation(page, viewport);
       await verifyMotionSafePlayback(page);
       await context.close();
     }

--- a/ui/scripts/verify-customer-factory-emulator-demos-browser.mjs
+++ b/ui/scripts/verify-customer-factory-emulator-demos-browser.mjs
@@ -142,6 +142,41 @@ async function step(demo) {
   await button.press("Enter");
 }
 
+async function verifyLiveSubmission(success, failure) {
+  await step(success);
+  await success
+    .getByText(
+      "Execute: Preparing the launch summary (1.5 seconds virtual time)",
+    )
+    .waitFor();
+  const submission = success.getByRole("textbox", { name: "Submit text" });
+  await submission.fill("Customer request");
+  await submission.press("Shift+Enter");
+  await submission.type("Second line");
+  assert.equal(
+    await submission.inputValue(),
+    "Customer request\nSecond line",
+    "Shift+Enter did not preserve a multiline customer-demo draft.",
+  );
+  await submission.press("Enter");
+  await success.getByText("2 Work total").waitFor();
+  assert.equal(
+    await submission.inputValue(),
+    "",
+    "An accepted customer-demo submission did not clear its draft.",
+  );
+  assert.equal(
+    await submission.evaluate((element) => element === document.activeElement),
+    true,
+    "An accepted customer-demo submission moved focus unexpectedly.",
+  );
+  await failure.getByText("1 Work total").waitFor();
+  await success.getByRole("button", { name: "Restart" }).click();
+  await success.getByText("1 Work total").waitFor();
+  await step(success);
+  return submission;
+}
+
 async function verifyInteractive(page, viewport) {
   await openStory(page, interactiveStory);
   const success = page.getByRole("article", {
@@ -154,20 +189,28 @@ async function verifyInteractive(page, viewport) {
   await failure.getByText("1 Work total").waitFor();
   await assertResponsiveLayout(page, viewport, interactiveStory);
 
-  await step(success);
-  await success
-    .getByText(
-      "Execute: Preparing the launch summary (1.5 seconds virtual time)",
-    )
-    .waitFor();
+  const successSubmission = await verifyLiveSubmission(success, failure);
   const successSlider = success.getByRole("slider", {
     name: "Select replay tick",
   });
   await successSlider.fill("0");
   await success.getByText("Viewing history", { exact: true }).waitFor();
+  assert.equal(
+    await successSubmission.isDisabled(),
+    true,
+    "Historical customer-demo inspection did not disable submission.",
+  );
+  await success
+    .getByText("Return to the current tick before submitting.")
+    .waitFor();
   await setVisibility(page, "success", true);
   await success.getByRole("button", { name: "Play" }).click();
   await success.getByText("Playing", { exact: true }).waitFor();
+  assert.equal(
+    await successSubmission.isEnabled(),
+    true,
+    "Returning to the live customer-demo head did not restore submission.",
+  );
   await success.getByRole("button", { name: "Pause" }).click();
   await successSlider.fill("0");
   await success.getByRole("button", { name: "Step" }).focus();
@@ -175,6 +218,14 @@ async function verifyInteractive(page, viewport) {
   await success
     .getByRole("region", { name: "Successful completion" })
     .waitFor();
+  await success
+    .getByText("Restart the completed emulator to submit more Work.")
+    .waitFor();
+  assert.equal(
+    await successSubmission.isDisabled(),
+    true,
+    "A closed customer demo still allowed text submission.",
+  );
   await success
     .getByRole("combobox", { name: "Playback speed" })
     .selectOption("2");

--- a/ui/src/App.customer-factory-emulator-demos.test.tsx
+++ b/ui/src/App.customer-factory-emulator-demos.test.tsx
@@ -1,0 +1,70 @@
+import "@testing-library/jest-dom/vitest";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { App, CUSTOMER_FACTORY_EMULATOR_DEMOS_PATH } from "./App";
+
+function installMotionSafePlaybackEnvironment() {
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      public disconnect() {}
+      public observe() {}
+      public unobserve() {}
+      public takeRecords() {
+        return [];
+      }
+      public readonly root = null;
+      public readonly rootMargin = "0px";
+      public readonly thresholds = [0.15];
+    },
+  );
+  vi.stubGlobal("matchMedia", () => ({
+    addEventListener: () => undefined,
+    addListener: () => undefined,
+    dispatchEvent: () => true,
+    matches: true,
+    media: "(prefers-reduced-motion: reduce)",
+    onchange: null,
+    removeEventListener: () => undefined,
+    removeListener: () => undefined,
+  }));
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("customer Factory emulator website route", () => {
+  it("renders both independently labeled demos on the shipped app surface", async () => {
+    installMotionSafePlaybackEnvironment();
+
+    await act(async () => {
+      render(
+        <App
+          initialLocale="en"
+          locationPathname={CUSTOMER_FACTORY_EMULATOR_DEMOS_PATH}
+        />,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+
+    const demos = screen.getByRole("region", {
+      name: "Customer Factory emulator demos",
+    });
+    const success = within(demos).getByRole("article", {
+      name: "Straightforward success",
+    });
+    const failure = within(demos).getByRole("article", {
+      name: "Review, rework, and failure",
+    });
+
+    await waitFor(() => {
+      expect(within(success).getByText("1 Work total")).toBeVisible();
+      expect(within(failure).getByText("1 Work total")).toBeVisible();
+    });
+    expect(success).toHaveAttribute("data-demo-id", "success");
+    expect(failure).toHaveAttribute("data-demo-id", "repeat-review-failure");
+    expect(screen.queryByRole("main")).toContainElement(demos);
+  });
+});

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,12 +1,17 @@
 import { DashboardScreen } from "./features/dashboard/public";
+import { CustomerFactoryEmulatorDemos } from "./features/factory-emulator/public";
 import { AppNotificationToaster } from "./features/notifications/public";
 import { AppLocaleProvider } from "./i18n";
 import { AppColorPaletteProvider } from "./theme";
+
+export const CUSTOMER_FACTORY_EMULATOR_DEMOS_PATH =
+  "/factory-emulator-demos";
 
 export interface AppProps {
   browserLanguage?: string | null;
   browserLanguages?: readonly string[] | null;
   initialLocale?: string | null;
+  locationPathname?: string | null;
   locationSearch?: string | null;
 }
 
@@ -14,8 +19,11 @@ export function App({
   browserLanguage,
   browserLanguages,
   initialLocale,
+  locationPathname,
   locationSearch,
 }: AppProps) {
+  const pathname = locationPathname ?? window.location.pathname;
+
   return (
     <AppColorPaletteProvider>
       <AppLocaleProvider
@@ -24,7 +32,13 @@ export function App({
         initialLocale={initialLocale}
         locationSearch={locationSearch}
       >
-        <DashboardScreen />
+        {pathname === CUSTOMER_FACTORY_EMULATOR_DEMOS_PATH ? (
+          <main className="min-h-screen overflow-x-hidden bg-surface p-1 md:p-2">
+            <CustomerFactoryEmulatorDemos />
+          </main>
+        ) : (
+          <DashboardScreen />
+        )}
         <AppNotificationToaster />
       </AppLocaleProvider>
     </AppColorPaletteProvider>

--- a/ui/src/features/factory-emulator/components/customer-factory-emulator-demos-lifecycle.test.tsx
+++ b/ui/src/features/factory-emulator/components/customer-factory-emulator-demos-lifecycle.test.tsx
@@ -1,0 +1,156 @@
+import "@testing-library/jest-dom/vitest";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { customerFactoryEmulatorDemoFixtures } from "../lib/customer-demo-fixtures";
+import { CustomerFactoryEmulatorDemos } from "./customer-factory-emulator-demos";
+
+function installLifecycleEnvironment() {
+  const observers = new Set<{
+    callback: IntersectionObserverCallback;
+    targets: Set<Element>;
+  }>();
+  const motionListeners = new Set<(event: MediaQueryListEvent) => void>();
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      private readonly observer = {
+        callback: undefined as unknown as IntersectionObserverCallback,
+        targets: new Set<Element>(),
+      };
+      public constructor(callback: IntersectionObserverCallback) {
+        this.observer.callback = callback;
+        observers.add(this.observer);
+      }
+      public disconnect() {
+        this.observer.targets.clear();
+      }
+      public observe(target: Element) {
+        this.observer.targets.add(target);
+      }
+      public unobserve(target: Element) {
+        this.observer.targets.delete(target);
+      }
+      public takeRecords() {
+        return [];
+      }
+      public readonly root = null;
+      public readonly rootMargin = "0px";
+      public readonly thresholds = [0.15];
+    },
+  );
+  vi.stubGlobal("matchMedia", () => ({
+    addEventListener: (
+      _type: "change",
+      listener: (event: MediaQueryListEvent) => void,
+    ) => motionListeners.add(listener),
+    addListener: () => undefined,
+    dispatchEvent: () => true,
+    matches: true,
+    media: "(prefers-reduced-motion: reduce)",
+    onchange: null,
+    removeEventListener: (
+      _type: "change",
+      listener: (event: MediaQueryListEvent) => void,
+    ) => motionListeners.delete(listener),
+    removeListener: () => undefined,
+  }));
+  return {
+    intersect(demoID: string, isIntersecting: boolean) {
+      for (const observer of observers) {
+        for (const target of observer.targets) {
+          if ((target as HTMLElement).dataset.demoId !== demoID) continue;
+          observer.callback(
+            [{ isIntersecting, target } as IntersectionObserverEntry],
+            {} as IntersectionObserver,
+          );
+        }
+      }
+    },
+    motionListenerCount: () => motionListeners.size,
+    observerTargetCount: () =>
+      [...observers].reduce((count, { targets }) => count + targets.size, 0),
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("CustomerFactoryEmulatorDemos lifecycle isolation", () => {
+  it("disposes a removed host and remounts a fresh isolated instance", async () => {
+    const environment = installLifecycleEnvironment();
+    const clearTimeout = vi.spyOn(window, "clearTimeout");
+    const { rerender } = render(<CustomerFactoryEmulatorDemos locale="en" />);
+    const success = await screen.findByRole("article", {
+      name: "Straightforward success",
+    });
+    const failure = screen.getByRole("article", {
+      name: "Review, rework, and failure",
+    });
+    await waitFor(() => expect(environment.observerTargetCount()).toBe(2));
+    const mountedMotionListeners = environment.motionListenerCount();
+    expect(mountedMotionListeners).toBeGreaterThan(0);
+
+    fireEvent.change(
+      within(success).getByRole("combobox", { name: "Playback speed" }),
+      { target: { value: "4" } },
+    );
+    environment.intersect("repeat-review-failure", true);
+    fireEvent.click(within(failure).getByRole("button", { name: "Play" }));
+    await waitFor(() =>
+      expect(
+        within(failure).getByText("Playing", { exact: true }),
+      ).toBeVisible(),
+    );
+    const clearedBeforeUnmount = clearTimeout.mock.calls.length;
+
+    rerender(
+      <CustomerFactoryEmulatorDemos
+        fixtures={[customerFactoryEmulatorDemoFixtures.success]}
+        locale="en"
+      />,
+    );
+    await waitFor(() => {
+      expect(environment.observerTargetCount()).toBe(1);
+      expect(environment.motionListenerCount()).toBe(
+        mountedMotionListeners / 2,
+      );
+      expect(clearTimeout.mock.calls.length).toBeGreaterThan(
+        clearedBeforeUnmount,
+      );
+    });
+    expect(
+      within(success).getByRole("combobox", { name: "Playback speed" }),
+    ).toHaveValue("4");
+
+    rerender(<CustomerFactoryEmulatorDemos locale="en" />);
+    const remountedFailure = await screen.findByRole("article", {
+      name: "Review, rework, and failure",
+    });
+    await waitFor(() => {
+      expect(environment.observerTargetCount()).toBe(2);
+      expect(environment.motionListenerCount()).toBe(mountedMotionListeners);
+      expect(
+        within(remountedFailure).getByText("Ready", { exact: true }),
+      ).toBeVisible();
+    });
+    expect(
+      within(remountedFailure).getByRole("combobox", {
+        name: "Playback speed",
+      }),
+    ).toHaveValue("1");
+    expect(
+      within(remountedFailure).getByRole("slider", {
+        name: "Select replay tick",
+      }),
+    ).toHaveValue("0");
+  });
+});

--- a/ui/src/features/factory-emulator/components/customer-factory-emulator-demos-lifecycle.test.tsx
+++ b/ui/src/features/factory-emulator/components/customer-factory-emulator-demos-lifecycle.test.tsx
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -103,7 +104,7 @@ describe("CustomerFactoryEmulatorDemos lifecycle isolation", () => {
       within(success).getByRole("combobox", { name: "Playback speed" }),
       { target: { value: "4" } },
     );
-    environment.intersect("repeat-review-failure", true);
+    act(() => environment.intersect("repeat-review-failure", true));
     fireEvent.click(within(failure).getByRole("button", { name: "Play" }));
     await waitFor(() =>
       expect(

--- a/ui/src/features/factory-emulator/components/customer-factory-emulator-demos-submission.test.tsx
+++ b/ui/src/features/factory-emulator/components/customer-factory-emulator-demos-submission.test.tsx
@@ -1,0 +1,120 @@
+import "@testing-library/jest-dom/vitest";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { customerFactoryEmulatorDemoFixtures } from "../lib/customer-demo-fixtures";
+import { CustomerFactoryEmulatorDemos } from "./customer-factory-emulator-demos";
+
+function installReducedMotionEnvironment() {
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      public disconnect() {}
+      public observe() {}
+      public unobserve() {}
+    },
+  );
+  vi.stubGlobal("matchMedia", () => ({
+    addEventListener: () => undefined,
+    addListener: () => undefined,
+    dispatchEvent: () => true,
+    matches: true,
+    media: "(prefers-reduced-motion: reduce)",
+    onchange: null,
+    removeEventListener: () => undefined,
+    removeListener: () => undefined,
+  }));
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("CustomerFactoryEmulatorDemos text submission", () => {
+  it("submits multiline Work during execution without changing the sibling demo", async () => {
+    const user = userEvent.setup();
+    installReducedMotionEnvironment();
+    render(<CustomerFactoryEmulatorDemos locale="en" />);
+    const success = screen.getByRole("article", {
+      name: "Straightforward success",
+    });
+    const failure = screen.getByRole("article", {
+      name: "Review, rework, and failure",
+    });
+    await waitFor(() =>
+      expect(within(success).getByText("1 Work total")).toBeVisible(),
+    );
+    expect(within(failure).getByText("1 Work total")).toBeVisible();
+
+    await user.click(within(success).getByRole("button", { name: "Step" }));
+    await waitFor(() =>
+      expect(
+        within(success).getByText(/Preparing the launch summary/),
+      ).toBeVisible(),
+    );
+    const textarea = within(success).getByRole("textbox", {
+      name: "Submit text",
+    });
+    await user.type(
+      textarea,
+      "Customer request{Shift>}{Enter}{/Shift}Second line",
+    );
+    expect(textarea).toHaveValue("Customer request\nSecond line");
+    await user.type(textarea, "{Enter}");
+
+    await waitFor(() => expect(textarea).toHaveValue(""));
+    expect(textarea).toHaveFocus();
+    expect(within(success).getByText("2 Work total")).toBeVisible();
+    expect(within(failure).getByText("1 Work total")).toBeVisible();
+  });
+
+  it("disables submission in history and after closure, then restores it at the live head", async () => {
+    const user = userEvent.setup();
+    installReducedMotionEnvironment();
+    render(
+      <CustomerFactoryEmulatorDemos
+        fixtures={[customerFactoryEmulatorDemoFixtures.success]}
+        locale="en"
+      />,
+    );
+    const demo = screen.getByRole("article", {
+      name: "Straightforward success",
+    });
+    await waitFor(() =>
+      expect(within(demo).getByText("1 Work total")).toBeVisible(),
+    );
+    const textarea = within(demo).getByRole("textbox", {
+      name: "Submit text",
+    });
+
+    await user.click(within(demo).getByRole("button", { name: "Step" }));
+    fireEvent.change(
+      within(demo).getByRole("slider", { name: "Select replay tick" }),
+      { target: { value: "0" } },
+    );
+    expect(textarea).toBeDisabled();
+    expect(
+      within(demo).getByText("Return to the current tick before submitting."),
+    ).toBeVisible();
+
+    await user.click(
+      within(demo).getByRole("button", { name: "Follow current" }),
+    );
+    expect(textarea).toBeEnabled();
+    await user.click(within(demo).getByRole("button", { name: "Step" }));
+    await within(demo).findByRole("region", {
+      name: "Successful completion",
+    });
+    await waitFor(() => expect(textarea).toBeDisabled());
+    expect(
+      within(demo).getByText(
+        "Restart the completed emulator to submit more Work.",
+      ),
+    ).toBeVisible();
+  });
+});

--- a/ui/src/features/factory-emulator/components/customer-factory-emulator-demos.stories.tsx
+++ b/ui/src/features/factory-emulator/components/customer-factory-emulator-demos.stories.tsx
@@ -1,5 +1,7 @@
 import type { FactoryEmulatorScenario } from "@you-agent-factory/factory-emulator";
+import { useState } from "react";
 
+import { Button } from "../../../components/ui";
 import { customerFactoryEmulatorDemoFixtures } from "../lib/customer-demo-fixtures";
 import { CustomerFactoryEmulatorDemos } from "./customer-factory-emulator-demos";
 
@@ -31,4 +33,32 @@ export const SetupErrorIsolation = {
       locale="en"
     />
   ),
+};
+
+function LifecycleIsolationStory() {
+  const [showFailureDemo, setShowFailureDemo] = useState(true);
+  return (
+    <div className="grid gap-4 p-4">
+      <Button
+        onClick={() => setShowFailureDemo((visible) => !visible)}
+        type="button"
+        variant="outline"
+      >
+        {showFailureDemo ? "Unmount failure demo" : "Remount failure demo"}
+      </Button>
+      <CustomerFactoryEmulatorDemos
+        fixtures={[
+          customerFactoryEmulatorDemoFixtures.success,
+          ...(showFailureDemo
+            ? [customerFactoryEmulatorDemoFixtures.repeatReviewFailure]
+            : []),
+        ]}
+        locale="en"
+      />
+    </div>
+  );
+}
+
+export const LifecycleIsolation = {
+  render: () => <LifecycleIsolationStory />,
 };

--- a/ui/src/features/factory-emulator/components/customer-factory-emulator-demos.stories.tsx
+++ b/ui/src/features/factory-emulator/components/customer-factory-emulator-demos.stories.tsx
@@ -1,0 +1,34 @@
+import type { FactoryEmulatorScenario } from "@you-agent-factory/factory-emulator";
+
+import { customerFactoryEmulatorDemoFixtures } from "../lib/customer-demo-fixtures";
+import { CustomerFactoryEmulatorDemos } from "./customer-factory-emulator-demos";
+
+export default {
+  title: "Agent Factory/Emulator/Customer Demos",
+  component: CustomerFactoryEmulatorDemos,
+  parameters: { layout: "fullscreen" },
+};
+
+export const Interactive = {
+  render: () => <CustomerFactoryEmulatorDemos locale="en" />,
+};
+
+const invalidScenario = {
+  ...customerFactoryEmulatorDemoFixtures.repeatReviewFailure.scenario,
+  factory: { name: "invalid-customer-demo-factory" },
+} satisfies FactoryEmulatorScenario;
+
+export const SetupErrorIsolation = {
+  render: () => (
+    <CustomerFactoryEmulatorDemos
+      fixtures={[
+        customerFactoryEmulatorDemoFixtures.success,
+        {
+          ...customerFactoryEmulatorDemoFixtures.repeatReviewFailure,
+          scenario: invalidScenario,
+        },
+      ]}
+      locale="en"
+    />
+  ),
+};

--- a/ui/src/features/factory-emulator/components/customer-factory-emulator-demos.test.tsx
+++ b/ui/src/features/factory-emulator/components/customer-factory-emulator-demos.test.tsx
@@ -6,6 +6,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { FactoryEmulatorScenario } from "@you-agent-factory/factory-emulator";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -272,6 +273,92 @@ describe("CustomerFactoryEmulatorDemos", () => {
       within(demo).queryByText(/Preparing the launch summary/),
     ).not.toBeInTheDocument();
     expect(within(demo).getByText("Viewing history")).toBeVisible();
+  });
+});
+
+describe("CustomerFactoryEmulatorDemos timeline controls", () => {
+  it.each(["Play", "Step"])(
+    "%s returns from history before advancing the canonical run",
+    async (action) => {
+      installPlaybackEnvironment(true);
+      render(
+        <CustomerFactoryEmulatorDemos
+          fixtures={[customerFactoryEmulatorDemoFixtures.success]}
+          locale="en"
+        />,
+      );
+      const demo = screen.getByRole("article", {
+        name: "Straightforward success",
+      });
+      await waitFor(() =>
+        expect(within(demo).getByText("1 Work total")).toBeVisible(),
+      );
+
+      fireEvent.click(within(demo).getByRole("button", { name: "Step" }));
+      await waitFor(() =>
+        expect(
+          within(demo).getByText(/Preparing the launch summary/),
+        ).toBeVisible(),
+      );
+      const slider = within(demo).getByRole("slider", {
+        name: "Select replay tick",
+      });
+      fireEvent.change(slider, { target: { value: "0" } });
+      expect(within(demo).getByText("Viewing history")).toBeVisible();
+      expect(within(demo).getByRole("button", { name: action })).toBeEnabled();
+
+      fireEvent.click(within(demo).getByRole("button", { name: action }));
+      await waitFor(() =>
+        expect((slider as HTMLInputElement).value).toBe(
+          (slider as HTMLInputElement).max,
+        ),
+      );
+      expect(
+        within(demo).queryByText("Viewing history"),
+      ).not.toBeInTheDocument();
+    },
+  );
+
+  it("exposes controlled speed and terminal ticks through keyboard controls", async () => {
+    const user = userEvent.setup();
+    installPlaybackEnvironment(true);
+    render(
+      <CustomerFactoryEmulatorDemos
+        fixtures={[customerFactoryEmulatorDemoFixtures.success]}
+        locale="en"
+      />,
+    );
+    const demo = screen.getByRole("article", {
+      name: "Straightforward success",
+    });
+    await waitFor(() =>
+      expect(within(demo).getByText("1 Work total")).toBeVisible(),
+    );
+    const speed = within(demo).getByRole("combobox", {
+      name: "Playback speed",
+    });
+    fireEvent.change(speed, { target: { value: "4" } });
+    expect(speed).toHaveValue("4");
+
+    const step = within(demo).getByRole("button", { name: "Step" });
+    step.focus();
+    await user.keyboard("{Enter}");
+    await waitFor(() =>
+      expect(
+        within(demo).getByText(/Preparing the launch summary/),
+      ).toBeVisible(),
+    );
+    await user.click(step);
+    const terminal = await within(demo).findByRole("region", {
+      name: "Successful completion",
+    });
+    expect(terminal).toBeVisible();
+    const slider = within(demo).getByRole("slider", {
+      name: "Select replay tick",
+    });
+    expect((slider as HTMLInputElement).value).toBe(
+      (slider as HTMLInputElement).max,
+    );
   });
 });
 

--- a/ui/src/features/factory-emulator/components/customer-factory-emulator-demos.test.tsx
+++ b/ui/src/features/factory-emulator/components/customer-factory-emulator-demos.test.tsx
@@ -1,0 +1,151 @@
+import "@testing-library/jest-dom/vitest";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import type { FactoryEmulatorScenario } from "@you-agent-factory/factory-emulator";
+import { describe, expect, it, vi } from "vitest";
+
+import { customerFactoryEmulatorDemoFixtures } from "../lib/customer-demo-fixtures";
+import { CustomerFactoryEmulatorDemos } from "./customer-factory-emulator-demos";
+
+describe("CustomerFactoryEmulatorDemos", () => {
+  it("renders independent ready demos and exposes live and terminal states", async () => {
+    render(<CustomerFactoryEmulatorDemos locale="en" />);
+
+    const success = screen.getByRole("article", {
+      name: "Straightforward success",
+    });
+    const failure = screen.getByRole("article", {
+      name: "Review, rework, and failure",
+    });
+    await waitFor(() =>
+      expect(within(success).getByText("1 Work total")).toBeVisible(),
+    );
+    expect(within(failure).getByText("1 Work total")).toBeVisible();
+
+    fireEvent.click(within(success).getByRole("button", { name: "Step" }));
+    await waitFor(() =>
+      expect(
+        within(success).getByText(
+          "Execute: Preparing the launch summary (1.5 seconds virtual time)",
+        ),
+      ).toBeVisible(),
+    );
+    expect(within(failure).getByText("Ready")).toBeVisible();
+
+    fireEvent.click(within(success).getByRole("button", { name: "Step" }));
+    await waitFor(() =>
+      expect(
+        within(success).getByRole("region", {
+          name: "Successful completion",
+        }),
+      ).toBeVisible(),
+    );
+    expect(within(success).getByText("1 completed")).toBeVisible();
+    expect(within(failure).queryByText("1 completed")).not.toBeInTheDocument();
+  });
+
+  it("falls back to canonical workstation copy during history inspection", async () => {
+    render(
+      <CustomerFactoryEmulatorDemos
+        fixtures={[customerFactoryEmulatorDemoFixtures.success]}
+        locale="en"
+      />,
+    );
+    const demo = screen.getByRole("article", {
+      name: "Straightforward success",
+    });
+    await waitFor(() =>
+      expect(within(demo).getByText("1 Work total")).toBeVisible(),
+    );
+
+    fireEvent.click(within(demo).getByRole("button", { name: "Step" }));
+    await waitFor(() =>
+      expect(
+        within(demo).getByText(/Preparing the launch summary/),
+      ).toBeVisible(),
+    );
+    fireEvent.click(within(demo).getByRole("button", { name: "Step" }));
+    await waitFor(() =>
+      expect(
+        within(demo).getByRole("region", { name: "Successful completion" }),
+      ).toBeVisible(),
+    );
+
+    fireEvent.change(
+      within(demo).getByRole("slider", { name: "Select replay tick" }),
+      {
+        target: { value: "1" },
+      },
+    );
+    await waitFor(() =>
+      expect(
+        within(demo).getByText(
+          "Execute: Working at Execute (1.5 seconds virtual time)",
+        ),
+      ).toBeVisible(),
+    );
+    expect(
+      within(demo).queryByText(/Preparing the launch summary/),
+    ).not.toBeInTheDocument();
+    expect(within(demo).getByText("Viewing history")).toBeVisible();
+  });
+});
+
+describe("CustomerFactoryEmulatorDemos unavailable states", () => {
+  it("contains invalid setup to one demo region", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const invalidScenario = {
+      ...customerFactoryEmulatorDemoFixtures.repeatReviewFailure.scenario,
+      factory: { name: "wrong-factory" },
+    } satisfies FactoryEmulatorScenario;
+
+    render(
+      <CustomerFactoryEmulatorDemos
+        fixtures={[
+          customerFactoryEmulatorDemoFixtures.success,
+          {
+            ...customerFactoryEmulatorDemoFixtures.repeatReviewFailure,
+            scenario: invalidScenario,
+          },
+        ]}
+        locale="en"
+      />,
+    );
+
+    expect(await screen.findByText("1 Work total")).toBeVisible();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "This demo could not be prepared",
+    );
+    expect(
+      screen.getByRole("article", { name: "Straightforward success" }),
+    ).toBeVisible();
+    consoleError.mockRestore();
+  });
+
+  it("presents bundled fixtures without initial Work as unavailable", async () => {
+    const fixture = customerFactoryEmulatorDemoFixtures.success;
+    const emptyScenario = {
+      ...fixture.scenario,
+      initialSubmissions: [],
+    } satisfies FactoryEmulatorScenario;
+
+    render(
+      <CustomerFactoryEmulatorDemos
+        fixtures={[{ ...fixture, scenario: emptyScenario }]}
+        locale="en"
+      />,
+    );
+
+    expect(
+      await screen.findByText("No initial Work is available for this demo."),
+    ).toBeVisible();
+    expect(screen.queryByText(/Loading/)).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/features/factory-emulator/components/customer-factory-emulator-demos.test.tsx
+++ b/ui/src/features/factory-emulator/components/customer-factory-emulator-demos.test.tsx
@@ -229,6 +229,35 @@ describe("CustomerFactoryEmulatorDemos", () => {
     expect(within(success).getByText("1 Work total")).toBeVisible();
   });
 
+  it("localizes ready, active, progress, timeline, and terminal presentation", async () => {
+    render(
+      <CustomerFactoryEmulatorDemos
+        fixtures={[customerFactoryEmulatorDemoFixtures.success]}
+        locale="zh-CN"
+      />,
+    );
+    const demo = screen.getByRole("article", { name: "直接成功" });
+    await waitFor(() =>
+      expect(within(demo).getByText("共 1 个工作")).toBeVisible(),
+    );
+    expect(within(demo).getByText("已就绪", { exact: true })).toBeVisible();
+    expect(within(demo).getByText("逻辑时点 0 / 0")).toBeVisible();
+
+    fireEvent.click(within(demo).getByRole("button", { name: "Step" }));
+    await waitFor(() =>
+      expect(
+        within(demo).getByText("Execute：正在准备发布摘要（1.5 秒虚拟时间）"),
+      ).toBeVisible(),
+    );
+    expect(within(demo).getByText("1 个进行中")).toBeVisible();
+
+    fireEvent.click(within(demo).getByRole("button", { name: "Step" }));
+    expect(
+      await within(demo).findByRole("region", { name: "成功完成" }),
+    ).toBeVisible();
+    expect(within(demo).getByText("1 个已完成")).toBeVisible();
+  });
+
   it("falls back to canonical workstation copy during history inspection", async () => {
     render(
       <CustomerFactoryEmulatorDemos

--- a/ui/src/features/factory-emulator/components/customer-factory-emulator-demos.test.tsx
+++ b/ui/src/features/factory-emulator/components/customer-factory-emulator-demos.test.tsx
@@ -7,10 +7,179 @@ import {
   within,
 } from "@testing-library/react";
 import type { FactoryEmulatorScenario } from "@you-agent-factory/factory-emulator";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { customerFactoryEmulatorDemoFixtures } from "../lib/customer-demo-fixtures";
 import { CustomerFactoryEmulatorDemos } from "./customer-factory-emulator-demos";
+
+function installPlaybackEnvironment(initialReducedMotion = false) {
+  let intersectionCallback: IntersectionObserverCallback | undefined;
+  const motionListeners = new Set<(event: MediaQueryListEvent) => void>();
+  let reducedMotion = initialReducedMotion;
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      public constructor(callback: IntersectionObserverCallback) {
+        intersectionCallback = callback;
+      }
+      public disconnect() {}
+      public observe() {}
+      public unobserve() {}
+      public takeRecords() {
+        return [];
+      }
+      public readonly root = null;
+      public readonly rootMargin = "0px";
+      public readonly thresholds = [0.15];
+    },
+  );
+  vi.stubGlobal("matchMedia", () => ({
+    addEventListener: (
+      _type: "change",
+      listener: (event: MediaQueryListEvent) => void,
+    ) => motionListeners.add(listener),
+    addListener: () => undefined,
+    dispatchEvent: () => true,
+    get matches() {
+      return reducedMotion;
+    },
+    media: "(prefers-reduced-motion: reduce)",
+    onchange: null,
+    removeEventListener: (
+      _type: "change",
+      listener: (event: MediaQueryListEvent) => void,
+    ) => motionListeners.delete(listener),
+    removeListener: () => undefined,
+  }));
+  return {
+    intersect(isIntersecting: boolean) {
+      intersectionCallback?.(
+        [{ isIntersecting } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      );
+    },
+    setReducedMotion(matches: boolean) {
+      reducedMotion = matches;
+      for (const listener of motionListeners) {
+        listener({ matches } as MediaQueryListEvent);
+      }
+    },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("CustomerFactoryEmulatorDemos playback", () => {
+  it("autoplays once in view and preserves manual pause across visibility", async () => {
+    const environment = installPlaybackEnvironment();
+    render(
+      <CustomerFactoryEmulatorDemos
+        fixtures={[customerFactoryEmulatorDemoFixtures.success]}
+        locale="en"
+      />,
+    );
+    const demo = screen.getByRole("article", {
+      name: "Straightforward success",
+    });
+    await waitFor(() =>
+      expect(within(demo).getByText("1 Work total")).toBeVisible(),
+    );
+
+    environment.intersect(true);
+    await waitFor(() =>
+      expect(within(demo).getByText("Playing", { exact: true })).toBeVisible(),
+    );
+    environment.intersect(false);
+    await waitFor(() =>
+      expect(within(demo).getByText("Ready", { exact: true })).toBeVisible(),
+    );
+    environment.intersect(true);
+    await waitFor(() =>
+      expect(within(demo).getByText("Playing", { exact: true })).toBeVisible(),
+    );
+
+    fireEvent.click(within(demo).getByRole("button", { name: "Pause" }));
+    environment.intersect(false);
+    environment.intersect(true);
+    await waitFor(() =>
+      expect(within(demo).getByText("Ready", { exact: true })).toBeVisible(),
+    );
+  });
+
+  it("requires explicit play whenever reduced motion is active", async () => {
+    const environment = installPlaybackEnvironment(true);
+    render(
+      <CustomerFactoryEmulatorDemos
+        fixtures={[customerFactoryEmulatorDemoFixtures.success]}
+        locale="en"
+      />,
+    );
+    const demo = screen.getByRole("article", {
+      name: "Straightforward success",
+    });
+    await waitFor(() =>
+      expect(within(demo).getByText("1 Work total")).toBeVisible(),
+    );
+
+    environment.intersect(true);
+    expect(within(demo).getByText("Ready", { exact: true })).toBeVisible();
+    environment.setReducedMotion(false);
+    environment.intersect(false);
+    environment.intersect(true);
+    expect(within(demo).getByText("Ready", { exact: true })).toBeVisible();
+    fireEvent.click(within(demo).getByRole("button", { name: "Play" }));
+    await waitFor(() =>
+      expect(within(demo).getByText("Playing", { exact: true })).toBeVisible(),
+    );
+
+    environment.setReducedMotion(true);
+    await waitFor(() =>
+      expect(within(demo).getByText("Ready", { exact: true })).toBeVisible(),
+    );
+    environment.setReducedMotion(false);
+    environment.intersect(false);
+    environment.intersect(true);
+    expect(within(demo).getByText("Ready", { exact: true })).toBeVisible();
+    fireEvent.click(within(demo).getByRole("button", { name: "Play" }));
+    await waitFor(() =>
+      expect(within(demo).getByText("Playing", { exact: true })).toBeVisible(),
+    );
+  });
+
+  it("does not override step or history intent on first viewport entry", async () => {
+    const environment = installPlaybackEnvironment();
+    render(
+      <CustomerFactoryEmulatorDemos
+        fixtures={[customerFactoryEmulatorDemoFixtures.success]}
+        locale="en"
+      />,
+    );
+    const demo = screen.getByRole("article", {
+      name: "Straightforward success",
+    });
+    await waitFor(() =>
+      expect(within(demo).getByText("1 Work total")).toBeVisible(),
+    );
+
+    fireEvent.click(within(demo).getByRole("button", { name: "Step" }));
+    await waitFor(() =>
+      expect(
+        within(demo).getByText(/Preparing the launch summary/),
+      ).toBeVisible(),
+    );
+    fireEvent.change(
+      within(demo).getByRole("slider", { name: "Select replay tick" }),
+      { target: { value: "0" } },
+    );
+    environment.intersect(true);
+    expect(within(demo).getByText("Viewing history")).toBeVisible();
+    expect(
+      within(demo).queryByText("Playing", { exact: true }),
+    ).not.toBeInTheDocument();
+  });
+});
 
 describe("CustomerFactoryEmulatorDemos", () => {
   it("renders independent ready demos and exposes live and terminal states", async () => {
@@ -47,6 +216,16 @@ describe("CustomerFactoryEmulatorDemos", () => {
     );
     expect(within(success).getByText("1 completed")).toBeVisible();
     expect(within(failure).queryByText("1 completed")).not.toBeInTheDocument();
+
+    fireEvent.click(within(success).getByRole("button", { name: "Restart" }));
+    await waitFor(() =>
+      expect(
+        within(success).queryByRole("region", {
+          name: "Successful completion",
+        }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(within(success).getByText("1 Work total")).toBeVisible();
   });
 
   it("falls back to canonical workstation copy during history inspection", async () => {

--- a/ui/src/features/factory-emulator/components/customer-factory-emulator-demos.tsx
+++ b/ui/src/features/factory-emulator/components/customer-factory-emulator-demos.tsx
@@ -1,0 +1,314 @@
+import type { FactoryEvent } from "@you-agent-factory/client";
+import { Heading, Text } from "@you-agent-factory/components";
+import {
+  FactoryEmulatorView,
+  type FactoryEmulatorViewProps,
+} from "@you-agent-factory/factory-visualizers";
+import {
+  Component,
+  type ErrorInfo,
+  type ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { useStore } from "zustand";
+
+import { useAppLocale } from "../../../i18n";
+import type { CustomerFactoryEmulatorDemoFixture } from "../lib/customer-demo-fixtures";
+import { customerFactoryEmulatorDemoFixtures } from "../lib/customer-demo-fixtures";
+import {
+  type CustomerFactoryEmulatorDemoWorld,
+  customerFactoryEmulatorDemoReducer,
+  selectCustomerFactoryEmulatorActivity,
+} from "../lib/customer-demo-presentation";
+import { getFactoryEmulatorMessages } from "../messages/factory-emulator";
+import {
+  createFactoryEmulatorInstance,
+  type FactoryEmulatorInstance,
+  type FactoryEmulatorInstanceState,
+} from "../state/factory-emulator-instance";
+import {
+  selectFactoryEmulatorControls,
+  selectFactoryEmulatorTimeline,
+} from "../state/factory-emulator-presentation";
+import { FactoryEmulatorSubmission } from "./factory-emulator-submission";
+
+type DemoInstance = FactoryEmulatorInstance<
+  FactoryEvent[],
+  CustomerFactoryEmulatorDemoWorld
+>;
+
+export interface CustomerFactoryEmulatorDemosProps {
+  readonly fixtures?: readonly CustomerFactoryEmulatorDemoFixture[];
+  readonly locale?: string;
+}
+
+interface DemoSetupBoundaryProps {
+  readonly children: ReactNode;
+  readonly description: string;
+  readonly errorMessage: string;
+  readonly title: string;
+}
+
+interface DemoSetupBoundaryState {
+  readonly failed: boolean;
+}
+
+class DemoSetupBoundary extends Component<
+  DemoSetupBoundaryProps,
+  DemoSetupBoundaryState
+> {
+  public state = { failed: false };
+
+  public static getDerivedStateFromError(): DemoSetupBoundaryState {
+    return { failed: true };
+  }
+
+  public componentDidCatch(_error: Error, _info: ErrorInfo): void {
+    // The accessible contained state is the customer-facing diagnostic.
+  }
+
+  public render() {
+    if (this.state.failed) {
+      return (
+        <article
+          aria-label={this.props.title}
+          className="min-w-0 rounded-xl border border-error bg-error-container p-4 text-on-error-container"
+        >
+          <Heading as="h2">{this.props.title}</Heading>
+          <Text as="p">{this.props.description}</Text>
+          <Text as="p" role="alert">
+            {this.props.errorMessage}
+          </Text>
+        </article>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+function createDemoInstance(
+  fixture: CustomerFactoryEmulatorDemoFixture,
+  locale: string,
+): DemoInstance {
+  return createFactoryEmulatorInstance<
+    FactoryEvent[],
+    CustomerFactoryEmulatorDemoWorld
+  >({
+    cloneState: structuredClone,
+    factory: fixture.factory,
+    locale,
+    reducer: customerFactoryEmulatorDemoReducer,
+    scenario: fixture.scenario,
+  });
+}
+
+function runtimeStatus(
+  state: FactoryEmulatorInstanceState<
+    FactoryEvent[],
+    CustomerFactoryEmulatorDemoWorld
+  >,
+  messages: ReturnType<typeof getFactoryEmulatorMessages>["demos"],
+): FactoryEmulatorViewProps["controls"]["runtimeStatus"] {
+  if (state.error || state.sessionStatus.phase === "error")
+    return { label: messages.status.error, tone: "danger" };
+  if (state.mode === "history")
+    return { label: messages.status.history, tone: "warning" };
+  if (state.replay.world.progress.counts.failed > 0)
+    return { label: messages.status.failed, tone: "danger" };
+  if (
+    state.sessionStatus.phase === "closed" ||
+    state.replay.world.progress.counts.completed > 0
+  )
+    return { label: messages.status.completed, tone: "success" };
+  if (state.playback.status === "playing")
+    return { label: messages.status.playing, tone: "success" };
+  return { label: messages.status.ready, tone: "neutral" };
+}
+
+function localizedActivityLabel(
+  label: string,
+  messages: ReturnType<typeof getFactoryEmulatorMessages>["demos"],
+): string {
+  const englishLabels = getFactoryEmulatorMessages("en").demos.activityLabels;
+  const key = Object.entries(englishLabels).find(
+    ([, englishLabel]) => englishLabel === label,
+  )?.[0] as keyof typeof englishLabels | undefined;
+  return key ? messages.activityLabels[key] : label;
+}
+
+function DemoTerminalSummary({
+  state,
+  messages,
+}: {
+  readonly messages: ReturnType<typeof getFactoryEmulatorMessages>["demos"];
+  readonly state: FactoryEmulatorInstanceState<
+    FactoryEvent[],
+    CustomerFactoryEmulatorDemoWorld
+  >;
+}) {
+  const failed = state.replay.world.progress.counts.failed > 0;
+  const completed = state.replay.world.progress.counts.completed > 0;
+  if (!failed && !completed) return null;
+  return (
+    <section
+      aria-label={failed ? messages.failureTitle : messages.successTitle}
+      className={
+        failed
+          ? "rounded-xl border border-error bg-error-container p-3 text-on-error-container"
+          : "rounded-xl border border-success bg-success-container p-3 text-on-success-container"
+      }
+    >
+      <Heading as="h3">
+        {failed ? messages.failureTitle : messages.successTitle}
+      </Heading>
+      <Text as="p">
+        {failed ? messages.failureDescription : messages.successDescription}
+      </Text>
+    </section>
+  );
+}
+
+function CustomerFactoryEmulatorDemo({
+  fixture,
+  locale,
+}: {
+  readonly fixture: CustomerFactoryEmulatorDemoFixture;
+  readonly locale: string;
+}) {
+  const messages = getFactoryEmulatorMessages(locale).demos;
+  const [instance] = useState(() => createDemoInstance(fixture, locale));
+  const [setupError, setSetupError] = useState(false);
+  const started = useRef(false);
+  const state = useStore(instance.store);
+
+  useEffect(() => {
+    if (started.current) return;
+    started.current = true;
+    void instance.commands.start().catch(() => setSetupError(true));
+  }, [instance]);
+
+  if (setupError) {
+    return (
+      <Text as="p" role="alert">
+        {messages.error}
+      </Text>
+    );
+  }
+
+  const fixtureMessages = messages.fixtures[fixture.id];
+  const controls = selectFactoryEmulatorControls(state);
+  const timeline = selectFactoryEmulatorTimeline(state);
+  const activity = selectCustomerFactoryEmulatorActivity(
+    fixture,
+    state.events,
+    state.selectedTick,
+    state.mode === "current",
+  );
+  const numberFormatter = new Intl.NumberFormat(locale);
+  const duration = activity?.durationMs
+    ? messages.duration(numberFormatter.format(activity.durationMs / 1_000))
+    : undefined;
+  const activityDetail = activity
+    ? messages.activity(
+        activity.workstation,
+        activity.activityLabel
+          ? localizedActivityLabel(activity.activityLabel, messages)
+          : messages.activityFallback(activity.workstation),
+        duration ?? messages.duration(numberFormatter.format(0)),
+      )
+    : messages.ready;
+
+  return (
+    <article
+      aria-label={fixtureMessages.title}
+      className="grid min-w-0 gap-4 rounded-xl border border-outline-variant bg-surface-container-lowest p-4"
+      data-demo-id={fixture.id}
+    >
+      <header className="grid min-w-0 gap-2">
+        <Heading as="h2">{fixtureMessages.title}</Heading>
+        <Text as="p">{fixtureMessages.description}</Text>
+        <Text as="p" aria-live="polite" role="status">
+          {activityDetail}
+        </Text>
+      </header>
+      {state.replay.world.progress.total === 0 &&
+      state.sessionLifecycle === "started" ? (
+        <Text as="p" role="status">
+          {messages.empty}
+        </Text>
+      ) : null}
+      <DemoTerminalSummary messages={messages} state={state} />
+      <FactoryEmulatorView
+        controls={{
+          ...controls,
+          formatTick: (tick) => numberFormatter.format(tick),
+          onFollowLatest: instance.commands.followCurrent,
+          onPause: instance.commands.pause,
+          onPlay: instance.commands.play,
+          onRestart: () => void instance.commands.restart(),
+          onSelectTick: instance.commands.selectTick,
+          onSpeedChange: instance.commands.setSpeed,
+          onStep: () => void instance.commands.step(),
+          runtimeStatus: runtimeStatus(state, messages),
+          timeline: { messages: messages.timeline, state: timeline },
+        }}
+        submission={
+          <FactoryEmulatorSubmission
+            factory={fixture.factory}
+            instance={instance}
+            locale={locale}
+          />
+        }
+        topology={{
+          messages: messages.topology,
+          state:
+            state.replay.world.topology.nodes.length === 0
+              ? { status: "empty" }
+              : {
+                  projection: {
+                    activity: state.replay.world.activity,
+                    load: state.replay.world.load,
+                    topology: state.replay.world.topology,
+                  },
+                  status: "ready",
+                },
+        }}
+        workProgress={{
+          formatNumber: (value) => numberFormatter.format(value),
+          messages: messages.progress,
+          projection: state.replay.world.progress,
+        }}
+      />
+    </article>
+  );
+}
+
+export function CustomerFactoryEmulatorDemos({
+  fixtures = Object.values(customerFactoryEmulatorDemoFixtures),
+  locale: localeOverride,
+}: CustomerFactoryEmulatorDemosProps) {
+  const { locale } = useAppLocale(localeOverride);
+  const messages = getFactoryEmulatorMessages(locale).demos;
+  return (
+    <section
+      aria-label={messages.regionLabel}
+      className="mx-auto grid w-full min-w-0 max-w-7xl gap-6 p-4 lg:grid-cols-2"
+    >
+      {fixtures.map((fixture) => {
+        const fixtureMessages = messages.fixtures[fixture.id];
+        return (
+          <DemoSetupBoundary
+            description={fixtureMessages.description}
+            errorMessage={messages.error}
+            key={fixture.id}
+            title={fixtureMessages.title}
+          >
+            <CustomerFactoryEmulatorDemo fixture={fixture} locale={locale} />
+          </DemoSetupBoundary>
+        );
+      })}
+    </section>
+  );
+}

--- a/ui/src/features/factory-emulator/components/customer-factory-emulator-demos.tsx
+++ b/ui/src/features/factory-emulator/components/customer-factory-emulator-demos.tsx
@@ -199,6 +199,12 @@ function CustomerFactoryEmulatorDemo({
     state.selectedTick,
     state.mode === "current",
   );
+  const terminalWorkCount =
+    state.replay.world.progress.counts.completed +
+    state.replay.world.progress.counts.failed;
+  const isRunTerminal =
+    state.replay.world.progress.total > 0 &&
+    terminalWorkCount === state.replay.world.progress.total;
   const playback = useCustomerDemoPlayback({
     instance,
     nextDelayMs: activity?.durationMs ?? 0,
@@ -264,6 +270,7 @@ function CustomerFactoryEmulatorDemo({
           <FactoryEmulatorSubmission
             factory={fixture.factory}
             instance={instance}
+            isRunTerminal={isRunTerminal}
             locale={locale}
           />
         }

--- a/ui/src/features/factory-emulator/components/customer-factory-emulator-demos.tsx
+++ b/ui/src/features/factory-emulator/components/customer-factory-emulator-demos.tsx
@@ -15,6 +15,7 @@ import {
 import { useStore } from "zustand";
 
 import { useAppLocale } from "../../../i18n";
+import { useCustomerDemoPlayback } from "../hooks/use-customer-demo-playback";
 import type { CustomerFactoryEmulatorDemoFixture } from "../lib/customer-demo-fixtures";
 import { customerFactoryEmulatorDemoFixtures } from "../lib/customer-demo-fixtures";
 import {
@@ -189,14 +190,6 @@ function CustomerFactoryEmulatorDemo({
     void instance.commands.start().catch(() => setSetupError(true));
   }, [instance]);
 
-  if (setupError) {
-    return (
-      <Text as="p" role="alert">
-        {messages.error}
-      </Text>
-    );
-  }
-
   const fixtureMessages = messages.fixtures[fixture.id];
   const controls = selectFactoryEmulatorControls(state);
   const timeline = selectFactoryEmulatorTimeline(state);
@@ -206,6 +199,18 @@ function CustomerFactoryEmulatorDemo({
     state.selectedTick,
     state.mode === "current",
   );
+  const playback = useCustomerDemoPlayback({
+    instance,
+    nextDelayMs: activity?.durationMs ?? 0,
+    state,
+  });
+  if (setupError) {
+    return (
+      <Text as="p" role="alert">
+        {messages.error}
+      </Text>
+    );
+  }
   const numberFormatter = new Intl.NumberFormat(locale);
   const duration = activity?.durationMs
     ? messages.duration(numberFormatter.format(activity.durationMs / 1_000))
@@ -225,6 +230,7 @@ function CustomerFactoryEmulatorDemo({
       aria-label={fixtureMessages.title}
       className="grid min-w-0 gap-4 rounded-xl border border-outline-variant bg-surface-container-lowest p-4"
       data-demo-id={fixture.id}
+      ref={playback.regionRef}
     >
       <header className="grid min-w-0 gap-2">
         <Heading as="h2">{fixtureMessages.title}</Heading>
@@ -245,12 +251,12 @@ function CustomerFactoryEmulatorDemo({
           ...controls,
           formatTick: (tick) => numberFormatter.format(tick),
           onFollowLatest: instance.commands.followCurrent,
-          onPause: instance.commands.pause,
-          onPlay: instance.commands.play,
-          onRestart: () => void instance.commands.restart(),
-          onSelectTick: instance.commands.selectTick,
+          onPause: playback.pause,
+          onPlay: playback.play,
+          onRestart: () => void playback.restart(),
+          onSelectTick: playback.selectTick,
           onSpeedChange: instance.commands.setSpeed,
-          onStep: () => void instance.commands.step(),
+          onStep: () => void playback.step(),
           runtimeStatus: runtimeStatus(state, messages),
           timeline: { messages: messages.timeline, state: timeline },
         }}

--- a/ui/src/features/factory-emulator/components/factory-emulator-submission.test.tsx
+++ b/ui/src/features/factory-emulator/components/factory-emulator-submission.test.tsx
@@ -81,7 +81,7 @@ describe("FactoryEmulatorSubmission", () => {
       expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled(),
     );
     expect(screen.getByRole("status")).toHaveTextContent(
-      "Return to the latest Factory state",
+      "Return to the current tick before submitting.",
     );
   });
 });

--- a/ui/src/features/factory-emulator/components/factory-emulator-submission.tsx
+++ b/ui/src/features/factory-emulator/components/factory-emulator-submission.tsx
@@ -2,12 +2,14 @@ import type { FactoryDefinition } from "@you-agent-factory/client";
 import { useStore } from "zustand";
 
 import { FactorySimpleSubmissionComposer } from "../../submit-work/public";
+import { getFactoryEmulatorMessages } from "../messages/factory-emulator";
 import type { FactoryEmulatorInstance } from "../state/factory-emulator-instance";
 import { selectFactoryEmulatorSubmission } from "../state/factory-emulator-submission";
 
 export interface FactoryEmulatorSubmissionProps<State, World> {
   readonly factory: FactoryDefinition;
   readonly instance: FactoryEmulatorInstance<State, World>;
+  readonly isRunTerminal?: boolean;
   readonly locale?: string;
 }
 
@@ -15,10 +17,12 @@ export interface FactoryEmulatorSubmissionProps<State, World> {
 export function FactoryEmulatorSubmission<State, World>({
   factory,
   instance,
+  isRunTerminal = false,
   locale,
 }: FactoryEmulatorSubmissionProps<State, World>) {
+  const messages = getFactoryEmulatorMessages(locale).submission;
   const state = useStore(instance.store, (current) =>
-    selectFactoryEmulatorSubmission(current, factory),
+    selectFactoryEmulatorSubmission(current, factory, isRunTerminal),
   );
 
   return (
@@ -30,6 +34,7 @@ export function FactoryEmulatorSubmission<State, World>({
         const outcome = await instance.commands.submit(submission);
         if (outcome.status === "disabled") throw new Error(outcome.reason);
       }}
+      unavailableMessage={(reason) => messages.unavailable[reason]}
     />
   );
 }

--- a/ui/src/features/factory-emulator/hooks/use-customer-demo-playback.ts
+++ b/ui/src/features/factory-emulator/hooks/use-customer-demo-playback.ts
@@ -1,0 +1,168 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type {
+  FactoryEmulatorInstance,
+  FactoryEmulatorInstanceState,
+} from "../state/factory-emulator-instance";
+
+interface CustomerDemoPlaybackOptions<State, World> {
+  readonly instance: FactoryEmulatorInstance<State, World>;
+  readonly nextDelayMs: number;
+  readonly state: FactoryEmulatorInstanceState<State, World>;
+}
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function" ||
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
+function useReducedMotion(onReduction: () => void): boolean {
+  const [reducedMotion, setReducedMotion] = useState(prefersReducedMotion);
+  useEffect(() => {
+    if (typeof window.matchMedia !== "function") return;
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const updatePreference = (event: MediaQueryListEvent) => {
+      setReducedMotion(event.matches);
+      if (event.matches) onReduction();
+    };
+    setReducedMotion(query.matches);
+    query.addEventListener("change", updatePreference);
+    return () => query.removeEventListener("change", updatePreference);
+  }, [onReduction]);
+  return reducedMotion;
+}
+
+function useRegionVisibility() {
+  const regionRef = useRef<HTMLElement>(null);
+  const visibleRef = useRef(false);
+  const [isVisible, setIsVisible] = useState(false);
+  useEffect(() => {
+    const region = regionRef.current;
+    if (!region || typeof IntersectionObserver === "undefined") return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        const visible = entry?.isIntersecting ?? false;
+        visibleRef.current = visible;
+        setIsVisible(visible);
+      },
+      { threshold: 0.15 },
+    );
+    observer.observe(region);
+    return () => observer.disconnect();
+  }, []);
+  return { isVisible, regionRef };
+}
+
+export function useCustomerDemoPlayback<State, World>({
+  instance,
+  nextDelayMs,
+  state,
+}: CustomerDemoPlaybackOptions<State, World>) {
+  const autoplayAvailableRef = useRef(!prefersReducedMotion());
+  const reducedMotionPlayRef = useRef(false);
+  const wantsPlaybackRef = useRef(false);
+  const { isVisible, regionRef } = useRegionVisibility();
+  const handleReducedMotion = useCallback(() => {
+    autoplayAvailableRef.current = false;
+    reducedMotionPlayRef.current = false;
+    wantsPlaybackRef.current = false;
+    instance.commands.pause();
+  }, [instance]);
+  const reducedMotion = useReducedMotion(handleReducedMotion);
+
+  useEffect(() => {
+    if (state.sessionStatus.phase === "closed") {
+      wantsPlaybackRef.current = false;
+      if (state.playback.status === "playing") instance.commands.pause();
+      return;
+    }
+    if (!isVisible || (reducedMotion && !reducedMotionPlayRef.current)) {
+      if (state.playback.status === "playing") instance.commands.pause();
+      return;
+    }
+    if (autoplayAvailableRef.current) {
+      autoplayAvailableRef.current = false;
+      wantsPlaybackRef.current = true;
+    }
+    if (
+      wantsPlaybackRef.current &&
+      state.playback.status === "paused" &&
+      state.commandState === "idle" &&
+      state.mode === "current"
+    ) {
+      instance.commands.play();
+    }
+  }, [instance, isVisible, reducedMotion, state]);
+
+  useEffect(() => {
+    if (
+      state.playback.status !== "playing" ||
+      state.commandState === "running" ||
+      state.mode !== "current" ||
+      state.sessionStatus.phase === "closed"
+    ) {
+      return;
+    }
+    const timer = window.setTimeout(
+      () => {
+        void instance.commands.step();
+      },
+      Math.max(0, nextDelayMs / state.playback.speed),
+    );
+    return () => window.clearTimeout(timer);
+  }, [instance, nextDelayMs, state]);
+
+  const pause = useCallback(() => {
+    autoplayAvailableRef.current = false;
+    reducedMotionPlayRef.current = false;
+    wantsPlaybackRef.current = false;
+    return instance.commands.pause();
+  }, [instance]);
+
+  const play = useCallback(() => {
+    autoplayAvailableRef.current = false;
+    reducedMotionPlayRef.current = true;
+    wantsPlaybackRef.current = true;
+    return instance.commands.play();
+  }, [instance]);
+
+  const selectTick = useCallback(
+    (tick: number) => {
+      autoplayAvailableRef.current = false;
+      reducedMotionPlayRef.current = false;
+      wantsPlaybackRef.current = false;
+      return instance.commands.selectTick(tick);
+    },
+    [instance],
+  );
+
+  const step = useCallback(async () => {
+    autoplayAvailableRef.current = false;
+    reducedMotionPlayRef.current = false;
+    wantsPlaybackRef.current = false;
+    instance.commands.pause();
+    return instance.commands.step();
+  }, [instance]);
+
+  const restart = useCallback(async () => {
+    reducedMotionPlayRef.current = false;
+    wantsPlaybackRef.current = false;
+    autoplayAvailableRef.current = !prefersReducedMotion();
+    const outcome = await instance.commands.restart();
+    if (
+      outcome.status === "accepted" &&
+      isVisible &&
+      !prefersReducedMotion()
+    ) {
+      autoplayAvailableRef.current = false;
+      wantsPlaybackRef.current = true;
+      instance.commands.play();
+    }
+    return outcome;
+  }, [instance, isVisible]);
+
+  return { pause, play, regionRef, restart, selectTick, step };
+}

--- a/ui/src/features/factory-emulator/lib/customer-demo-fixtures.test.ts
+++ b/ui/src/features/factory-emulator/lib/customer-demo-fixtures.test.ts
@@ -58,6 +58,34 @@ async function runDemo(
   return { events, state };
 }
 
+async function runDemosConcurrently(
+  fixtures: readonly CustomerFactoryEmulatorDemoFixture[],
+): Promise<readonly CompletedDemoRun[]> {
+  const runs = fixtures.map((fixture) => {
+    const events: FactoryEvent[] = [];
+    return { events, session: createDemoSession(fixture, events) };
+  });
+  await Promise.all(runs.map(({ session }) => session.start()));
+  for (let command = 0; command < 20; command += 1) {
+    const active = runs.filter(
+      ({ session }) => session.status().phase !== "idle",
+    );
+    if (active.length === 0) {
+      return runs.map(({ events, session }) => {
+        const state = session.state();
+        if (state.lifecycle !== "started") {
+          throw new Error("Completed customer demo must remain inspectable.");
+        }
+        return { events, state };
+      });
+    }
+    await Promise.all(active.map(({ session }) => session.advanceToNext()));
+  }
+  throw new Error(
+    "Concurrent customer demos did not become idle within 20 advances.",
+  );
+}
+
 function dispatchEvidence(events: readonly FactoryEvent[]) {
   return events
     .filter(({ type }) => type === "DISPATCH_RESPONSE")
@@ -199,4 +227,17 @@ describe("customer Factory emulator demo fixtures", () => {
       expect(session.state()).toEqual(firstState);
     },
   );
+
+  it("matches standalone histories and projections when both demos run concurrently", async () => {
+    const fixtures = Object.values(customerFactoryEmulatorDemoFixtures);
+    const standalone = await Promise.all(fixtures.map(runDemo));
+    const concurrent = await runDemosConcurrently(fixtures);
+
+    expect(JSON.stringify(concurrent.map(({ events }) => events))).toBe(
+      JSON.stringify(standalone.map(({ events }) => events)),
+    );
+    expect(concurrent.map(({ state }) => state)).toEqual(
+      standalone.map(({ state }) => state),
+    );
+  });
 });

--- a/ui/src/features/factory-emulator/lib/customer-demo-fixtures.test.ts
+++ b/ui/src/features/factory-emulator/lib/customer-demo-fixtures.test.ts
@@ -1,0 +1,202 @@
+import type { FactoryEvent } from "@you-agent-factory/client";
+import {
+  createFactoryEmulatorSession,
+  type FactoryEmulatorSession,
+  type FactoryEmulatorSessionState,
+  inspectFactoryEmulatorCompatibility,
+  safeParseFactoryEmulatorScenario,
+} from "@you-agent-factory/factory-emulator";
+import { describe, expect, it } from "vitest";
+
+import {
+  type CustomerFactoryEmulatorDemoFixture,
+  customerFactoryEmulatorDemoFixtures,
+} from "./customer-demo-fixtures";
+
+interface CompletedDemoRun {
+  readonly events: readonly FactoryEvent[];
+  readonly state: Extract<
+    FactoryEmulatorSessionState,
+    { readonly lifecycle: "started" }
+  >;
+}
+
+function createDemoSession(
+  fixture: CustomerFactoryEmulatorDemoFixture,
+  events: FactoryEvent[],
+): FactoryEmulatorSession {
+  return createFactoryEmulatorSession({
+    factory: fixture.factory,
+    scenario: fixture.scenario,
+    sink: {
+      write: async (batch) => {
+        events.push(...structuredClone(batch));
+      },
+    },
+  });
+}
+
+async function finishDemo(session: FactoryEmulatorSession) {
+  for (let command = 0; command < 20; command += 1) {
+    if (session.status().phase === "idle") return;
+    await session.advanceToNext();
+  }
+  throw new Error("Customer demo did not become idle within 20 advances.");
+}
+
+async function runDemo(
+  fixture: CustomerFactoryEmulatorDemoFixture,
+): Promise<CompletedDemoRun> {
+  const events: FactoryEvent[] = [];
+  const session = createDemoSession(fixture, events);
+  await session.start();
+  await finishDemo(session);
+  const state = session.state();
+  if (state.lifecycle !== "started") {
+    throw new Error("Completed customer demo must remain inspectable.");
+  }
+  return { events, state };
+}
+
+function dispatchEvidence(events: readonly FactoryEvent[]) {
+  return events
+    .filter(({ type }) => type === "DISPATCH_RESPONSE")
+    .map((event) => {
+      const request = events.find(
+        ({ context, type }) =>
+          type === "DISPATCH_REQUEST" &&
+          context.dispatchId === event.context.dispatchId,
+      );
+      const payload = event.payload as {
+        outcome?: string;
+        outputWork?: readonly { state: { name: string } }[];
+        transitionId?: string;
+      };
+      return {
+        durationMs:
+          Date.parse(event.context.eventTime) -
+          Date.parse(request?.context.eventTime ?? ""),
+        elapsedMs: Date.parse(event.context.eventTime),
+        outcome: payload.outcome,
+        outputStates: payload.outputWork?.map(({ state }) => state.name) ?? [],
+        tick: event.context.tick,
+        workstation: payload.transitionId,
+      };
+    });
+}
+
+describe("customer Factory emulator demo fixtures", () => {
+  it.each(Object.values(customerFactoryEmulatorDemoFixtures))(
+    "validates the $id Factory/scenario pair against the supported subset",
+    (fixture) => {
+      expect(inspectFactoryEmulatorCompatibility(fixture.factory)).toEqual({
+        diagnostics: [],
+        supported: true,
+      });
+      expect(
+        safeParseFactoryEmulatorScenario(fixture.scenario, fixture.factory),
+      ).toMatchObject({ success: true });
+      expect(() => createDemoSession(fixture, [])).not.toThrow();
+    },
+  );
+
+  it("finishes the success demo with one 1,500 ms accepted Execute outcome", async () => {
+    const fixture = customerFactoryEmulatorDemoFixtures.success;
+    const run = await runDemo(fixture);
+    const startAt = Date.parse(fixture.scenario.startAt);
+
+    expect(dispatchEvidence(run.events)).toEqual([
+      {
+        durationMs: 1_500,
+        elapsedMs: startAt + 1_500,
+        outcome: "ACCEPTED",
+        outputStates: ["done"],
+        tick: 2,
+        workstation: "Execute",
+      },
+    ]);
+    expect(run.state.virtualElapsedMs).toBe(1_500);
+    expect(run.state.works.at(-1)).toMatchObject({
+      phase: "completed",
+      state: "done",
+    });
+  });
+
+  it("follows the exact repeat, review, rework, and terminal-failure sequence", async () => {
+    const fixture = customerFactoryEmulatorDemoFixtures.repeatReviewFailure;
+    const run = await runDemo(fixture);
+    const startAt = Date.parse(fixture.scenario.startAt);
+
+    expect(dispatchEvidence(run.events)).toEqual([
+      {
+        durationMs: 1_500,
+        elapsedMs: startAt + 1_500,
+        outcome: "CONTINUE",
+        outputStates: ["ready"],
+        tick: 2,
+        workstation: "Execute",
+      },
+      {
+        durationMs: 1_500,
+        elapsedMs: startAt + 3_000,
+        outcome: "ACCEPTED",
+        outputStates: ["review"],
+        tick: 4,
+        workstation: "Execute",
+      },
+      {
+        durationMs: 1_000,
+        elapsedMs: startAt + 4_000,
+        outcome: "REJECTED",
+        outputStates: ["ready"],
+        tick: 6,
+        workstation: "Review",
+      },
+      {
+        durationMs: 1_500,
+        elapsedMs: startAt + 5_500,
+        outcome: "ACCEPTED",
+        outputStates: ["review"],
+        tick: 8,
+        workstation: "Execute",
+      },
+      {
+        durationMs: 1_000,
+        elapsedMs: startAt + 6_500,
+        outcome: "FAILED",
+        outputStates: ["failed"],
+        tick: 10,
+        workstation: "Review",
+      },
+    ]);
+    expect(run.state.virtualElapsedMs).toBe(6_500);
+    expect(Object.values(run.state.ruleCursors).sort()).toEqual([2, 3]);
+    expect(
+      new Set(run.state.works.map(({ rootWorkId }) => rootWorkId)),
+    ).toHaveProperty("size", 1);
+    expect(run.state.works.at(-1)).toMatchObject({
+      phase: "completed",
+      state: "failed",
+    });
+  });
+
+  it.each(Object.values(customerFactoryEmulatorDemoFixtures))(
+    "reproduces $id canonical history and projection after reset",
+    async (fixture) => {
+      const events: FactoryEvent[] = [];
+      const session = createDemoSession(fixture, events);
+      await session.start();
+      await finishDemo(session);
+      const firstHistory = structuredClone(events);
+      const firstState = structuredClone(session.state());
+
+      session.reset();
+      events.length = 0;
+      await session.start();
+      await finishDemo(session);
+
+      expect(JSON.stringify(events)).toBe(JSON.stringify(firstHistory));
+      expect(session.state()).toEqual(firstState);
+    },
+  );
+});

--- a/ui/src/features/factory-emulator/lib/customer-demo-fixtures.ts
+++ b/ui/src/features/factory-emulator/lib/customer-demo-fixtures.ts
@@ -1,0 +1,185 @@
+import type { FactoryDefinition } from "@you-agent-factory/client";
+import type { FactoryEmulatorScenario } from "@you-agent-factory/factory-emulator";
+
+export interface CustomerFactoryEmulatorDemoFixture {
+  readonly id: "success" | "repeat-review-failure";
+  readonly factory: FactoryDefinition;
+  readonly scenario: FactoryEmulatorScenario;
+}
+
+const successFactory = {
+  name: "customer-demo-success",
+  orchestrator: { kind: "PETRI" },
+  workTypes: [
+    {
+      handlingBehavior: ["DEFAULT"],
+      name: "task",
+      states: [
+        { name: "ready", type: "INITIAL" },
+        { name: "done", type: "TERMINAL" },
+        { name: "failed", type: "FAILED" },
+      ],
+    },
+  ],
+  workers: [{ name: "execute-worker", type: "AGENT_WORKER" }],
+  workstations: [
+    {
+      behavior: "STANDARD",
+      inputs: [{ workType: "task", state: "ready" }],
+      name: "Execute",
+      onFailure: [{ workType: "task", state: "failed" }],
+      outputs: [{ workType: "task", state: "done" }],
+      type: "AGENT_RUN",
+      worker: "execute-worker",
+    },
+  ],
+} satisfies FactoryDefinition;
+
+const successScenario = {
+  schemaVersion: "factory-emulator-scenario/v1",
+  id: "customer-demo-success-scenario",
+  factory: { name: successFactory.name },
+  seed: "customer-demo-success-seed-v1",
+  startAt: "2026-07-19T16:00:00.000Z",
+  initialSubmissions: [
+    {
+      input: "Prepare a concise launch summary.",
+      name: "launch-summary",
+      state: "ready",
+      workType: "task",
+    },
+  ],
+  rules: [
+    {
+      cursor: { input: "rootWorkId", scope: "lineage" },
+      exhaustion: "fail",
+      id: "execute-success",
+      outcomes: [
+        {
+          durationMs: 1_500,
+          output: "Launch summary ready.",
+          result: "accepted",
+        },
+      ],
+      selector: { workstation: "Execute", worker: "execute-worker" },
+    },
+  ],
+  unmatched: { behavior: "error" },
+} satisfies FactoryEmulatorScenario;
+
+const repeatReviewFailureFactory = {
+  name: "customer-demo-repeat-review-failure",
+  orchestrator: { kind: "PETRI" },
+  workTypes: [
+    {
+      handlingBehavior: ["DEFAULT"],
+      name: "task",
+      states: [
+        { name: "ready", type: "INITIAL" },
+        { name: "review", type: "PROCESSING" },
+        { name: "done", type: "TERMINAL" },
+        { name: "failed", type: "FAILED" },
+      ],
+    },
+  ],
+  workers: [
+    { name: "execute-worker", type: "AGENT_WORKER" },
+    { name: "review-worker", type: "AGENT_WORKER" },
+  ],
+  workstations: [
+    {
+      behavior: "REPEATER",
+      inputs: [{ workType: "task", state: "ready" }],
+      name: "Execute",
+      onContinue: [{ workType: "task", state: "ready" }],
+      onFailure: [{ workType: "task", state: "failed" }],
+      outputs: [{ workType: "task", state: "review" }],
+      type: "AGENT_RUN",
+      worker: "execute-worker",
+    },
+    {
+      behavior: "STANDARD",
+      inputs: [{ workType: "task", state: "review" }],
+      name: "Review",
+      onFailure: [{ workType: "task", state: "failed" }],
+      onRejection: [{ workType: "task", state: "ready" }],
+      outputs: [{ workType: "task", state: "done" }],
+      type: "AGENT_RUN",
+      worker: "review-worker",
+    },
+  ],
+} satisfies FactoryDefinition;
+
+const repeatReviewFailureScenario = {
+  schemaVersion: "factory-emulator-scenario/v1",
+  id: "customer-demo-repeat-review-failure-scenario",
+  factory: { name: repeatReviewFailureFactory.name },
+  seed: "customer-demo-repeat-review-failure-seed-v1",
+  startAt: "2026-07-19T17:00:00.000Z",
+  initialSubmissions: [
+    {
+      input: "Draft and review a customer launch plan.",
+      name: "customer-launch-plan",
+      state: "ready",
+      workType: "task",
+    },
+  ],
+  rules: [
+    {
+      cursor: { input: "rootWorkId", scope: "lineage" },
+      exhaustion: "fail",
+      id: "execute-repeat-sequence",
+      outcomes: [
+        {
+          durationMs: 1_500,
+          result: "continued",
+        },
+        {
+          durationMs: 1_500,
+          output: "First draft ready for review.",
+          result: "accepted",
+        },
+        {
+          durationMs: 1_500,
+          output: "Revised draft ready for review.",
+          result: "accepted",
+        },
+      ],
+      selector: { workstation: "Execute", worker: "execute-worker" },
+    },
+    {
+      cursor: { input: "rootWorkId", scope: "lineage" },
+      exhaustion: "fail",
+      id: "review-rework-failure-sequence",
+      outcomes: [
+        {
+          durationMs: 1_000,
+          feedback: "Clarify the rollout and retry.",
+          result: "rejected",
+        },
+        {
+          durationMs: 1_000,
+          error: "The revised plan did not pass final review.",
+          result: "failed",
+        },
+      ],
+      selector: { workstation: "Review", worker: "review-worker" },
+    },
+  ],
+  unmatched: { behavior: "error" },
+} satisfies FactoryEmulatorScenario;
+
+export const customerFactoryEmulatorDemoFixtures = {
+  success: {
+    id: "success",
+    factory: successFactory,
+    scenario: successScenario,
+  },
+  repeatReviewFailure: {
+    id: "repeat-review-failure",
+    factory: repeatReviewFailureFactory,
+    scenario: repeatReviewFailureScenario,
+  },
+} as const satisfies Readonly<
+  Record<string, CustomerFactoryEmulatorDemoFixture>
+>;

--- a/ui/src/features/factory-emulator/lib/customer-demo-fixtures.ts
+++ b/ui/src/features/factory-emulator/lib/customer-demo-fixtures.ts
@@ -1,6 +1,10 @@
 import type { FactoryDefinition } from "@you-agent-factory/client";
 import type { FactoryEmulatorScenario } from "@you-agent-factory/factory-emulator";
 
+import { getFactoryEmulatorMessages } from "../messages/factory-emulator";
+
+const activityLabels = getFactoryEmulatorMessages("en").demos.activityLabels;
+
 export interface CustomerFactoryEmulatorDemoFixture {
   readonly id: "success" | "repeat-review-failure";
   readonly factory: FactoryDefinition;
@@ -56,6 +60,7 @@ const successScenario = {
       id: "execute-success",
       outcomes: [
         {
+          activityLabel: activityLabels.prepare,
           durationMs: 1_500,
           output: "Launch summary ready.",
           result: "accepted",
@@ -131,15 +136,18 @@ const repeatReviewFailureScenario = {
       id: "execute-repeat-sequence",
       outcomes: [
         {
+          activityLabel: activityLabels.draft,
           durationMs: 1_500,
           result: "continued",
         },
         {
+          activityLabel: activityLabels.revise,
           durationMs: 1_500,
           output: "First draft ready for review.",
           result: "accepted",
         },
         {
+          activityLabel: activityLabels.polish,
           durationMs: 1_500,
           output: "Revised draft ready for review.",
           result: "accepted",
@@ -153,11 +161,13 @@ const repeatReviewFailureScenario = {
       id: "review-rework-failure-sequence",
       outcomes: [
         {
+          activityLabel: activityLabels.firstReview,
           durationMs: 1_000,
           feedback: "Clarify the rollout and retry.",
           result: "rejected",
         },
         {
+          activityLabel: activityLabels.finalReview,
           durationMs: 1_000,
           error: "The revised plan did not pass final review.",
           result: "failed",

--- a/ui/src/features/factory-emulator/lib/customer-demo-presentation.test.ts
+++ b/ui/src/features/factory-emulator/lib/customer-demo-presentation.test.ts
@@ -1,0 +1,61 @@
+import type { FactoryEvent } from "@you-agent-factory/client";
+import { describe, expect, it } from "vitest";
+
+import { customerFactoryEmulatorDemoFixtures } from "./customer-demo-fixtures";
+import { selectCustomerFactoryEmulatorActivity } from "./customer-demo-presentation";
+
+function dispatchEvent(
+  type: "DISPATCH_REQUEST" | "DISPATCH_RESPONSE",
+  tick: number,
+): FactoryEvent {
+  return {
+    schemaVersion: "agent-factory.event.v1",
+    id: `${type}-${tick}`,
+    type,
+    context: {
+      dispatchId: "dispatch-1",
+      eventTime: `2026-07-19T16:00:0${tick}.000Z`,
+      sequence: tick,
+      tick,
+    },
+    payload:
+      type === "DISPATCH_REQUEST"
+        ? { inputs: [], transitionId: "Execute" }
+        : {
+            completionId: "completion-1",
+            durationMillis: 1_500,
+            outcome: "ACCEPTED",
+            transitionId: "Execute",
+          },
+  } as FactoryEvent;
+}
+
+describe("customer Factory emulator demo presentation", () => {
+  it("uses transient scenario activity only at the live head", () => {
+    const fixture = customerFactoryEmulatorDemoFixtures.success;
+    const events = [dispatchEvent("DISPATCH_REQUEST", 1)];
+
+    expect(
+      selectCustomerFactoryEmulatorActivity(fixture, events, 1, true),
+    ).toEqual({
+      activityLabel: "Preparing the launch summary",
+      durationMs: 1_500,
+      workstation: "Execute",
+    });
+    expect(
+      selectCustomerFactoryEmulatorActivity(fixture, events, 1, false),
+    ).toEqual({ durationMs: 1_500, workstation: "Execute" });
+  });
+
+  it("does not retain completed activity at a later replay tick", () => {
+    const fixture = customerFactoryEmulatorDemoFixtures.success;
+    const events = [
+      dispatchEvent("DISPATCH_REQUEST", 1),
+      dispatchEvent("DISPATCH_RESPONSE", 2),
+    ];
+
+    expect(
+      selectCustomerFactoryEmulatorActivity(fixture, events, 2, true),
+    ).toBeUndefined();
+  });
+});

--- a/ui/src/features/factory-emulator/lib/customer-demo-presentation.ts
+++ b/ui/src/features/factory-emulator/lib/customer-demo-presentation.ts
@@ -1,0 +1,107 @@
+import type { FactoryEvent } from "@you-agent-factory/client";
+import type { FactoryEmulatorOutcome } from "@you-agent-factory/factory-emulator";
+import {
+  canonicalizeFactoryEvents,
+  type FactoryActivityProjection,
+  type FactoryLoadProjection,
+  type FactoryReplayWorldReducer,
+  type FactoryTopologyProjection,
+  type FactoryWorkProgressProjection,
+  projectFactoryActivityAtTick,
+  projectFactoryLoadAtTick,
+  projectFactoryTopologyAtTick,
+  projectFactoryWorkProgressAtTick,
+} from "@you-agent-factory/factory-replay";
+
+import type { CustomerFactoryEmulatorDemoFixture } from "./customer-demo-fixtures";
+
+export interface CustomerFactoryEmulatorDemoWorld {
+  readonly activity: FactoryActivityProjection;
+  readonly load: FactoryLoadProjection;
+  readonly progress: FactoryWorkProgressProjection;
+  readonly topology: FactoryTopologyProjection;
+}
+
+export interface CustomerFactoryEmulatorActivity {
+  readonly activityLabel?: string;
+  readonly durationMs?: number;
+  readonly workstation: string;
+}
+
+export const customerFactoryEmulatorDemoReducer: FactoryReplayWorldReducer<
+  FactoryEvent[],
+  CustomerFactoryEmulatorDemoWorld
+> = {
+  applyEvent: (events, event) => [...events, structuredClone(event)],
+  createState: () => [],
+  projectWorld: (events) => {
+    const tick = events.reduce(
+      (latest, event) => Math.max(latest, event.context.tick),
+      0,
+    );
+    return {
+      activity: projectFactoryActivityAtTick({ events, tick }),
+      load: projectFactoryLoadAtTick({ events, tick }),
+      progress: projectFactoryWorkProgressAtTick({ events, tick }),
+      topology: projectFactoryTopologyAtTick({ events, tick }),
+    };
+  },
+};
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stringField(value: unknown, field: string): string | undefined {
+  const candidate = record(value)?.[field];
+  return typeof candidate === "string" ? candidate : undefined;
+}
+
+function matchingOutcome(
+  fixture: CustomerFactoryEmulatorDemoFixture,
+  events: readonly FactoryEvent[],
+  workstation: string,
+): FactoryEmulatorOutcome | undefined {
+  const completedAtWorkstation = events.filter(
+    (event) =>
+      event.type === "DISPATCH_RESPONSE" &&
+      stringField(event.payload, "transitionId") === workstation,
+  ).length;
+  const rule = fixture.scenario.rules.find(
+    ({ selector }) => selector.workstation === workstation,
+  );
+  return rule?.outcomes[completedAtWorkstation];
+}
+
+/** Resolve current activity while keeping transient scenario copy out of replay. */
+export function selectCustomerFactoryEmulatorActivity(
+  fixture: CustomerFactoryEmulatorDemoFixture,
+  events: readonly FactoryEvent[],
+  selectedTick: number,
+  includeTransientLabel: boolean,
+): CustomerFactoryEmulatorActivity | undefined {
+  const accepted = canonicalizeFactoryEvents(events).filter(
+    (event) => event.context.tick <= selectedTick,
+  );
+  const active = new Map<string, FactoryEvent>();
+  for (const event of accepted) {
+    const dispatchId = event.context.dispatchId;
+    if (!dispatchId) continue;
+    if (event.type === "DISPATCH_REQUEST") active.set(dispatchId, event);
+    if (event.type === "DISPATCH_RESPONSE") active.delete(dispatchId);
+  }
+  const request = [...active.values()].at(-1);
+  const workstation = stringField(request?.payload, "transitionId");
+  if (!request || !workstation) return undefined;
+
+  const outcome = matchingOutcome(fixture, accepted, workstation);
+  return {
+    ...(includeTransientLabel && outcome?.activityLabel
+      ? { activityLabel: outcome.activityLabel }
+      : {}),
+    ...(outcome ? { durationMs: outcome.durationMs } : {}),
+    workstation,
+  };
+}

--- a/ui/src/features/factory-emulator/messages/factory-emulator.ts
+++ b/ui/src/features/factory-emulator/messages/factory-emulator.ts
@@ -222,7 +222,7 @@ const factoryEmulatorMessagesByLocale = {
       unavailable: {
         "ambiguous-default":
           "Configure exactly one eligible default Work Type.",
-        closed: "The emulator session is closed.",
+        closed: "Restart the completed emulator to submit more Work.",
         error:
           "Retry or restart the invalid emulator session before submitting.",
         history: "Return to the current tick before submitting.",
@@ -339,7 +339,7 @@ const factoryEmulatorMessagesByLocale = {
       wrongWorkType: "请提交到符合条件的默认工作类型。",
       unavailable: {
         "ambiguous-default": "请仅配置一个符合条件的默认工作类型。",
-        closed: "模拟器会话已关闭。",
+        closed: "请重新启动已完成的模拟器以提交更多工作。",
         error: "请先重试或重新启动无效的模拟器会话。",
         history: "请返回当前逻辑时点后再提交。",
         invalid: "请先重试或重新启动无效的模拟器会话。",

--- a/ui/src/features/factory-emulator/messages/factory-emulator.ts
+++ b/ui/src/features/factory-emulator/messages/factory-emulator.ts
@@ -4,6 +4,98 @@ import {
 } from "../../../i18n";
 
 export interface FactoryEmulatorMessages {
+  demos: {
+    activity: (workstation: string, detail: string, duration: string) => string;
+    activityFallback: (workstation: string) => string;
+    activityLabels: {
+      draft: string;
+      finalReview: string;
+      firstReview: string;
+      polish: string;
+      prepare: string;
+      revise: string;
+    };
+    duration: (seconds: string) => string;
+    fixtures: Record<
+      "repeat-review-failure" | "success",
+      { description: string; title: string }
+    >;
+    empty: string;
+    error: string;
+    failureDescription: string;
+    failureTitle: string;
+    progress: {
+      categories: {
+        active: {
+          plural: (count: string) => string;
+          singular: (count: string) => string;
+        };
+        completed: {
+          plural: (count: string) => string;
+          singular: (count: string) => string;
+        };
+        failed: {
+          plural: (count: string) => string;
+          singular: (count: string) => string;
+        };
+        queued: {
+          plural: (count: string) => string;
+          singular: (count: string) => string;
+        };
+        unclassified: {
+          plural: (count: string) => string;
+          singular: (count: string) => string;
+        };
+      };
+      empty: string;
+      regionLabel: string;
+      title: string;
+      total: (count: string) => string;
+    };
+    ready: string;
+    regionLabel: string;
+    status: {
+      completed: string;
+      error: string;
+      failed: string;
+      history: string;
+      playing: string;
+      ready: string;
+    };
+    successDescription: string;
+    successTitle: string;
+    timeline: {
+      alreadyFollowingLatest: string;
+      currentMode: string;
+      disabled: string;
+      followLatest: string;
+      historyMode: string;
+      position: (selected: string, latest: string) => string;
+      regionLabel: string;
+      sliderLabel: string;
+      title: string;
+      unavailable: string;
+    };
+    topology: {
+      activeDispatches: (count: number) => string;
+      annotationsHidden: string;
+      annotationsVisible: string;
+      empty: string;
+      failed: string;
+      inactiveDispatches: string;
+      imageFailed: string;
+      imageLoading: string;
+      loading: string;
+      nodeLabel: (kind: string, label: string) => string;
+      regionLabel: string;
+      resourceOccupancy: (occupied: number, capacity: number) => string;
+      resourceOccupancyUnavailable: string;
+      retry: string;
+      selectedNode: string;
+      workStateCount: (count: number) => string;
+      workStateCountUnavailable: string;
+    };
+  };
   submission: {
     blank: string;
     wrongWorkType: string;
@@ -21,6 +113,109 @@ export interface FactoryEmulatorMessages {
 
 const factoryEmulatorMessagesByLocale = {
   en: {
+    demos: {
+      activity: (workstation, detail, duration) =>
+        `${workstation}: ${detail} (${duration})`,
+      activityFallback: (workstation) => `Working at ${workstation}`,
+      activityLabels: {
+        draft: "Drafting the launch plan",
+        finalReview: "Running final review",
+        firstReview: "Reviewing the first draft",
+        polish: "Polishing the revised launch plan",
+        prepare: "Preparing the launch summary",
+        revise: "Revising the launch plan",
+      },
+      duration: (seconds) => `${seconds} seconds virtual time`,
+      fixtures: {
+        "repeat-review-failure": {
+          description:
+            "Watch Review reject Work back to Execute before final Review fails.",
+          title: "Review, rework, and failure",
+        },
+        success: {
+          description:
+            "Watch one task move through Execute to successful completion.",
+          title: "Straightforward success",
+        },
+      },
+      empty: "No initial Work is available for this demo.",
+      error:
+        "This demo could not be prepared. The other demo remains available.",
+      failureDescription: "The final Review failed and the Work is terminal.",
+      failureTitle: "Terminal failure",
+      progress: {
+        categories: {
+          active: {
+            plural: (count) => `${count} active`,
+            singular: (count) => `${count} active`,
+          },
+          completed: {
+            plural: (count) => `${count} completed`,
+            singular: (count) => `${count} completed`,
+          },
+          failed: {
+            plural: (count) => `${count} failed`,
+            singular: (count) => `${count} failed`,
+          },
+          queued: {
+            plural: (count) => `${count} queued`,
+            singular: (count) => `${count} queued`,
+          },
+          unclassified: {
+            plural: (count) => `${count} unclassified`,
+            singular: (count) => `${count} unclassified`,
+          },
+        },
+        empty: "No Work is available.",
+        regionLabel: "Demo Work progress",
+        title: "Work progress",
+        total: (count) => `${count} Work total`,
+      },
+      ready: "Ready to run with deterministic local Work.",
+      regionLabel: "Customer Factory emulator demos",
+      status: {
+        completed: "Completed successfully",
+        error: "Setup error",
+        failed: "Terminal failure",
+        history: "Viewing history",
+        playing: "Playing",
+        ready: "Ready",
+      },
+      successDescription: "The Work reached its successful terminal state.",
+      successTitle: "Successful completion",
+      timeline: {
+        alreadyFollowingLatest: "Already following the current tick.",
+        currentMode: "Showing the current Factory.",
+        disabled: "Timeline selection is unavailable.",
+        followLatest: "Follow current",
+        historyMode: "Viewing Factory history.",
+        position: (selected, latest) => `Tick ${selected} of ${latest}`,
+        regionLabel: "Factory replay timeline",
+        sliderLabel: "Select replay tick",
+        title: "Replay timeline",
+        unavailable: "No replay ticks are available.",
+      },
+      topology: {
+        activeDispatches: (count) => `${count} active Dispatches`,
+        annotationsHidden: "Show annotations",
+        annotationsVisible: "Hide annotations",
+        empty: "Factory topology is unavailable.",
+        failed: "Factory topology could not be shown.",
+        inactiveDispatches: "No active Dispatches",
+        imageFailed: "Annotation image unavailable.",
+        imageLoading: "Loading annotation image.",
+        loading: "Loading Factory topology.",
+        nodeLabel: (kind, label) => `${kind}: ${label}`,
+        regionLabel: "Factory topology replay",
+        resourceOccupancy: (occupied, capacity) =>
+          `${occupied} of ${capacity} resources occupied`,
+        resourceOccupancyUnavailable: "Resource occupancy unavailable",
+        retry: "Retry",
+        selectedNode: "Selected",
+        workStateCount: (count) => `${count} Work in this state`,
+        workStateCountUnavailable: "Work count unavailable",
+      },
+    },
     submission: {
       blank: "Enter nonblank text to submit.",
       wrongWorkType: "Submit to the eligible default Work Type.",
@@ -39,6 +234,106 @@ const factoryEmulatorMessagesByLocale = {
     },
   },
   "zh-CN": {
+    demos: {
+      activity: (workstation, detail, duration) =>
+        `${workstation}：${detail}（${duration}）`,
+      activityFallback: (workstation) => `正在 ${workstation} 处理`,
+      activityLabels: {
+        draft: "正在起草发布计划",
+        finalReview: "正在进行最终审核",
+        firstReview: "正在审核第一版草稿",
+        polish: "正在完善修订后的发布计划",
+        prepare: "正在准备发布摘要",
+        revise: "正在修订发布计划",
+      },
+      duration: (seconds) => `${seconds} 秒虚拟时间`,
+      fixtures: {
+        "repeat-review-failure": {
+          description: "查看审核将工作退回执行，然后最终审核失败。",
+          title: "审核、返工与失败",
+        },
+        success: {
+          description: "查看一个任务通过执行并成功完成。",
+          title: "直接成功",
+        },
+      },
+      empty: "此演示没有可用的初始工作。",
+      error: "无法准备此演示。另一个演示仍然可用。",
+      failureDescription: "最终审核失败，工作已终止。",
+      failureTitle: "终止失败",
+      progress: {
+        categories: {
+          active: {
+            plural: (count) => `${count} 个进行中`,
+            singular: (count) => `${count} 个进行中`,
+          },
+          completed: {
+            plural: (count) => `${count} 个已完成`,
+            singular: (count) => `${count} 个已完成`,
+          },
+          failed: {
+            plural: (count) => `${count} 个失败`,
+            singular: (count) => `${count} 个失败`,
+          },
+          queued: {
+            plural: (count) => `${count} 个排队中`,
+            singular: (count) => `${count} 个排队中`,
+          },
+          unclassified: {
+            plural: (count) => `${count} 个未分类`,
+            singular: (count) => `${count} 个未分类`,
+          },
+        },
+        empty: "没有可用工作。",
+        regionLabel: "演示工作进度",
+        title: "工作进度",
+        total: (count) => `共 ${count} 个工作`,
+      },
+      ready: "已准备好运行确定性的本地工作。",
+      regionLabel: "客户 Factory 模拟器演示",
+      status: {
+        completed: "成功完成",
+        error: "设置错误",
+        failed: "终止失败",
+        history: "正在查看历史",
+        playing: "正在播放",
+        ready: "已就绪",
+      },
+      successDescription: "工作已到达成功终止状态。",
+      successTitle: "成功完成",
+      timeline: {
+        alreadyFollowingLatest: "已在跟随当前逻辑时点。",
+        currentMode: "正在显示当前 Factory。",
+        disabled: "时间线选择不可用。",
+        followLatest: "跟随当前",
+        historyMode: "正在查看 Factory 历史。",
+        position: (selected, latest) => `逻辑时点 ${selected} / ${latest}`,
+        regionLabel: "Factory 回放时间线",
+        sliderLabel: "选择回放逻辑时点",
+        title: "回放时间线",
+        unavailable: "没有可用的回放逻辑时点。",
+      },
+      topology: {
+        activeDispatches: (count) => `${count} 个活动调度`,
+        annotationsHidden: "显示注释",
+        annotationsVisible: "隐藏注释",
+        empty: "Factory 拓扑不可用。",
+        failed: "无法显示 Factory 拓扑。",
+        inactiveDispatches: "没有活动调度",
+        imageFailed: "注释图片不可用。",
+        imageLoading: "正在加载注释图片。",
+        loading: "正在加载 Factory 拓扑。",
+        nodeLabel: (kind, label) => `${kind}：${label}`,
+        regionLabel: "Factory 拓扑回放",
+        resourceOccupancy: (occupied, capacity) =>
+          `${capacity} 个资源中有 ${occupied} 个被占用`,
+        resourceOccupancyUnavailable: "资源占用情况不可用",
+        retry: "重试",
+        selectedNode: "已选择",
+        workStateCount: (count) => `此状态下有 ${count} 个工作`,
+        workStateCountUnavailable: "工作数量不可用",
+      },
+    },
     submission: {
       blank: "请输入非空文本后再提交。",
       wrongWorkType: "请提交到符合条件的默认工作类型。",

--- a/ui/src/features/factory-emulator/public/index.ts
+++ b/ui/src/features/factory-emulator/public/index.ts
@@ -1,4 +1,8 @@
 export {
+  CustomerFactoryEmulatorDemos,
+  type CustomerFactoryEmulatorDemosProps,
+} from "../components/customer-factory-emulator-demos";
+export {
   FactoryEmulatorSubmission,
   type FactoryEmulatorSubmissionProps,
 } from "../components/factory-emulator-submission";

--- a/ui/src/features/factory-emulator/public/index.ts
+++ b/ui/src/features/factory-emulator/public/index.ts
@@ -3,6 +3,10 @@ export {
   type FactoryEmulatorSubmissionProps,
 } from "../components/factory-emulator-submission";
 export {
+  type CustomerFactoryEmulatorDemoFixture,
+  customerFactoryEmulatorDemoFixtures,
+} from "../lib/customer-demo-fixtures";
+export {
   createFactoryEmulatorInstance,
   FACTORY_EMULATOR_PLAYBACK_SPEEDS,
   type FactoryEmulatorAdapterCommand,

--- a/ui/src/features/factory-emulator/state/factory-emulator-instance.test.ts
+++ b/ui/src/features/factory-emulator/state/factory-emulator-instance.test.ts
@@ -227,7 +227,7 @@ describe("factory emulator playback commands", () => {
       expect(instance.commands.play()).toEqual({ status: "accepted" });
       expect(instance.commands.setSpeed(4)).toEqual({ status: "accepted" });
       expect(selectFactoryEmulatorControls(instance.store.getState())).toEqual({
-        disabledActions: [],
+        disabledActions: ["play"],
         isPlaying: true,
         speed: 4,
       });
@@ -256,7 +256,7 @@ describe("factory emulator playback commands", () => {
     }
   });
 
-  it("disables execution controls in history until the host follows current", async () => {
+  it("keeps host-wrapped execution controls available in history", async () => {
     const instance = createInstance();
     await instance.sink.write([
       event("tick-one", 1, 1),
@@ -265,7 +265,7 @@ describe("factory emulator playback commands", () => {
     instance.commands.selectTick(1);
 
     expect(selectFactoryEmulatorControls(instance.store.getState())).toEqual({
-      disabledActions: ["play", "step"],
+      disabledActions: ["pause"],
       isPlaying: false,
       speed: 1,
     });

--- a/ui/src/features/factory-emulator/state/factory-emulator-instance.ts
+++ b/ui/src/features/factory-emulator/state/factory-emulator-instance.ts
@@ -333,9 +333,6 @@ function createExecutionCommands<State, World>(
       if (state.commandState === "running") {
         return disabled("restart", "An emulator command is already running.");
       }
-      if (state.sessionStatus.phase === "closed") {
-        return disabled("restart", "The emulator session is closed.");
-      }
       session.reset();
       runtime.retry = undefined;
       store.setState({

--- a/ui/src/features/factory-emulator/state/factory-emulator-presentation.ts
+++ b/ui/src/features/factory-emulator/state/factory-emulator-presentation.ts
@@ -24,8 +24,7 @@ export const selectFactoryEmulatorControls = <State, World>(
     state.commandState === "running" ||
     state.sessionStatus.phase === "closed" ||
     state.sessionStatus.phase === "error";
-  const restartUnavailable =
-    state.commandState === "running" || state.sessionStatus.phase === "closed";
+  const restartUnavailable = state.commandState === "running";
   return {
     disabledActions: [
       ...(executionUnavailable || state.mode === "history"

--- a/ui/src/features/factory-emulator/state/factory-emulator-presentation.ts
+++ b/ui/src/features/factory-emulator/state/factory-emulator-presentation.ts
@@ -4,7 +4,7 @@ import type {
 } from "./factory-emulator-instance";
 
 export interface FactoryEmulatorControlState {
-  readonly disabledActions: readonly ("play" | "restart" | "step")[];
+  readonly disabledActions: readonly ("pause" | "play" | "restart" | "step")[];
   readonly isPlaying: boolean;
   readonly speed: FactoryEmulatorPlaybackSpeed;
 }
@@ -25,17 +25,15 @@ export const selectFactoryEmulatorControls = <State, World>(
     state.sessionStatus.phase === "closed" ||
     state.sessionStatus.phase === "error";
   const restartUnavailable = state.commandState === "running";
+  const isPlaying = state.playback.status === "playing";
   return {
     disabledActions: [
-      ...(executionUnavailable || state.mode === "history"
-        ? (["play"] as const)
-        : []),
+      ...(executionUnavailable || isPlaying ? (["play"] as const) : []),
+      ...(!isPlaying ? (["pause"] as const) : []),
       ...(restartUnavailable ? (["restart"] as const) : []),
-      ...(executionUnavailable || state.mode === "history"
-        ? (["step"] as const)
-        : []),
+      ...(executionUnavailable ? (["step"] as const) : []),
     ],
-    isPlaying: state.playback.status === "playing",
+    isPlaying,
     speed: state.playback.speed,
   };
 };

--- a/ui/src/features/factory-emulator/state/factory-emulator-submission.ts
+++ b/ui/src/features/factory-emulator/state/factory-emulator-submission.ts
@@ -129,9 +129,11 @@ export function createFactoryEmulatorSubmissionCommands<State, World>(
 export const selectFactoryEmulatorSubmission = <State, World>(
   state: FactoryEmulatorInstanceState<State, World>,
   factory: FactoryDefinition,
+  isRunTerminal = false,
 ): FactoryEmulatorSubmissionState => ({
   draft: state.submission.draft,
   factoryState:
+    isRunTerminal ||
     state.sessionLifecycle === "closed" ||
     state.sessionStatus.phase === "closed"
       ? "closed"

--- a/ui/src/features/submit-work/components/composer/factory-simple-submission-composer.test.tsx
+++ b/ui/src/features/submit-work/components/composer/factory-simple-submission-composer.test.tsx
@@ -165,9 +165,9 @@ describe("FactorySimpleSubmissionComposer", () => {
       expect(screen.getByRole("alert")).toHaveTextContent(failure.message);
     });
     expect(props.onDraftChange).not.toHaveBeenCalled();
-    expect(screen.getByRole("textbox", { name: "Submit text" })).toHaveValue(
-      "A new task",
-    );
+    const textarea = screen.getByRole("textbox", { name: "Submit text" });
+    expect(textarea).toHaveValue("A new task");
+    expect(textarea).toHaveFocus();
   });
 
   it("uses a bounded auto-growing multiline field and stacks safely on narrow viewports", () => {

--- a/ui/src/features/submit-work/components/composer/factory-simple-submission-composer.tsx
+++ b/ui/src/features/submit-work/components/composer/factory-simple-submission-composer.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 
 import { Button, Label, Textarea } from "../../../../components/ui";
 import {
@@ -55,6 +55,8 @@ export function FactorySimpleSubmissionComposer({
   const statusID = `factory-simple-submission-status-${instanceID}`;
   const [localSubmissionError, setLocalSubmissionError] = useState<string>();
   const [isLocallySubmitting, setIsLocallySubmitting] = useState(false);
+  const restoreFocusAfterSubmission = useRef(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const availability = resolveFactorySimpleSubmissionAvailability({
     factoryState,
     isCurrent,
@@ -68,6 +70,12 @@ export function FactorySimpleSubmissionComposer({
   const isDisabled = !isAvailable || isSubmitPending;
   const errorMessage = submissionError ?? localSubmissionError;
 
+  useEffect(() => {
+    if (isSubmitPending || !restoreFocusAfterSubmission.current) return;
+    restoreFocusAfterSubmission.current = false;
+    textareaRef.current?.focus();
+  }, [isSubmitPending]);
+
   const submit = async () => {
     if (availability.kind !== "available" || isDraftBlank || isSubmitPending) {
       return;
@@ -75,6 +83,7 @@ export function FactorySimpleSubmissionComposer({
 
     setLocalSubmissionError(undefined);
     setIsLocallySubmitting(true);
+    restoreFocusAfterSubmission.current = true;
     try {
       await onSubmit({
         content: [{ text: draft, type: "text" }],
@@ -118,6 +127,7 @@ export function FactorySimpleSubmissionComposer({
             }
           }}
           placeholder={messages.placeholder}
+          ref={textareaRef}
           className="min-h-24 max-h-48 resize-none overflow-y-auto"
           value={draft}
         />


### PR DESCRIPTION
{
  "project": "Ship Successful and Repeat-Review-Failure Factory Emulator Demos",
  "branchName": "customer-factory-emulator-demos",
  "description": "Package and present two deterministic, interactive customer website demos of the Factory emulator: one straightforward successful run and one exact continued, accepted, rejected-to-rework, accepted, terminal-failed run. Each demo uses an independent validated Factory/scenario pair and website-local state instance, supports controlled playback, replay inspection, deterministic restart, and live text submission, and follows motion-safe, non-looping, responsive browser behavior.",
  "context": {
    "customerAsk": "Ship two independent Factory/scenario fixtures and website demos: one successful scenario and one exact continued, accepted, rejected-to-rework, accepted, terminal-failed scenario. Use 1,500 ms Execute and 1,000 ms Review durations; autoplay once in viewport, pause off-screen, respect reduced motion and manual pause/scrub, stop without looping, restart deterministically, allow text submission while live, and exercise transient activity-label degradation, controls, narrow layouts, isolation, and terminal inspection.",
    "problem": "The emulator, replay projection, controlled visualizer, and instance-scoped website adapter provide deterministic browser mechanics, but customers do not yet have complete examples that demonstrate a simple success and a realistic review/rework failure path. Without packaged fixtures and host-level demo composition, the product cannot show exact outcome routing, timeline inspection, motion-safe autoplay, interactive submission, or isolation between multiple emulators on one page.",
    "solution": "Add two bundled, validated Factory/scenario pairs and compose each through the existing website-local emulator adapter and controlled visualization surfaces. Keep canonical execution and emitted events in the emulator, derive displayed history from replay, keep playback, selection, error, and submission state local to each demo instance, and let the website host own viewport, reduced-motion, and timer policy. Prove exact sequences, visible states, controls, submissions, restart, responsive layout, and cross-demo isolation with behavioral fixture, component, integration, and direct browser evidence."
  },
  "acceptanceCriteria": [
    "AC-1: The website presents two independently mounted, validated demos: a basic successful Factory and a repeat/review Factory whose canonical outcomes are exactly Execute continued, Execute accepted, Review rejected and routed back to Execute, Execute accepted, then Review terminal failed.",
    "AC-2: Every Execute outcome consumes 1,500 ms of emulator virtual time and every Review outcome consumes 1,000 ms; deterministic reruns reproduce the same seeded identities, event order, outcome sequence, and terminal projection.",
    "AC-3: Each demo autoplays at most once when entering the viewport, pauses while off-screen, requires explicit Play under reduced motion, preserves manual pause/scrub intent across visibility changes, stops at completion without looping, and restarts from a clean deterministic initial run.",
    "AC-4: Visitors can use accessible playback and replay controls to pause, play, step, change speed, scrub history, return to the current tick, and inspect final success or failure; transient activity labels degrade to canonical workstation/activity information when historical reconstruction cannot retain them.",
    "AC-5: Visitors can submit nonblank text Work while a demo is current and live; submission is unavailable with an actionable state while viewing history or after the session is closed/invalid, and interaction with one demo never changes the other.",
    "AC-6: Both demos expose intentional ready, active, historical, completed-success, terminal-failure, empty/unavailable, and setup-error presentation where applicable, remain keyboard-usable and free of horizontal page overflow at narrow and desktop widths, and use localized copy and existing shared controls.",
    "AC-7: Quality gates pass: TypeScript typecheck, frontend lint, focused fixture/unit/component/integration tests, and direct browser verification at narrow and desktop widths, including reduced-motion behavior, all pass."
  ],
  "userStories": [
    {
      "id": "customer-factory-emulator-demos-001",
      "title": "Package deterministic success and repeat-review fixtures",
      "description": "As a customer evaluating Factory behavior, I want two validated example scenarios with exact deterministic outcomes so the demos faithfully explain success and review-driven rework without a live provider.",
      "acceptanceCriteria": [
        "The successful fixture contains its own supported Factory definition and scenario, starts with deterministic initial Work, and reaches a successful terminal projection.",
        "The repeat/review fixture contains its own supported Factory definition and scenario and emits the exact lineage-scoped sequence: Execute (REPEATER) continued; Execute (REPEATER) accepted; Review (STANDARD) rejected and routed back to Execute; Execute (REPEATER) accepted; Review (STANDARD) failed, producing terminal failed Work.",
        "Every Execute outcome declares a 1,500 ms duration and every Review outcome declares a 1,000 ms duration; canonical event ticks and visible durations reflect those values.",
        "Both pairs pass the existing Factory/scenario validation and supported-subset checks, use stable seeds/start times, and reproduce the same canonical IDs, event ordering, projections, and terminal outcomes after reset.",
        "Fixture-level conformance tests assert the observable outcome/timing sequence and routing result rather than source paths or fixture registration inventories.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "customer-factory-emulator-demos-002",
      "title": "Present two understandable customer demos",
      "description": "As a website visitor, I want to see a success demo and a repeat-review-failure demo side by side or in sequence so I can understand live Factory activity and its final result.",
      "acceptanceCriteria": [
        "The customer website renders the two fixtures as separately labeled demo regions using the existing controlled emulator view, topology/replay projection, controls, progress, and simple submission surfaces.",
        "During execution, the active Execute or Review workstation, current Work state, progress, and virtual duration are perceivable without relying on color alone; completion clearly distinguishes successful terminal Work from terminal failed Work.",
        "The failure demo visibly returns rejected Review Work to Execute and leaves the final failed state and preceding ticks available for inspection.",
        "A transient activity label is shown while present in the live event, but replay reconstruction that lacks that transient value falls back to canonical workstation/activity copy without blank, stale, or misleading status.",
        "Bundled synchronous fixtures render a ready state without a false network-loading phase; missing initial Work has an intentional empty/unavailable treatment, and invalid setup is contained to that demo with an accessible error state while its sibling remains usable.",
        "At narrow and desktop widths, demo content reflows without horizontal page overflow, clipped controls, or inaccessible terminal detail; all new visible copy follows the feature localization path.",
        "Direct browser verification covers active processing, rework routing, transient-label fallback, final success/failure inspection, setup-error isolation, and narrow/desktop layouts.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "customer-factory-emulator-demos-003",
      "title": "Apply motion-safe viewport playback",
      "description": "As a website visitor, I want demos to play only when appropriate and never override my playback choice so animation is useful without being surprising or inaccessible.",
      "acceptanceCriteria": [
        "Under the default motion preference, each demo begins autoplay only on its first eligible viewport entry and pauses when it becomes off-screen.",
        "Returning to the viewport resumes only an autoplay-owned pause; visibility changes never resume a demo after the visitor manually pauses, steps, or selects a historical tick.",
        "With reduced motion enabled before mount or detected during the visit, the demo does not autoplay and requires an explicit Play action; changing visibility does not bypass that requirement.",
        "Reaching the final tick stops playback and leaves the final projection selected without scheduling another run or loop.",
        "Restart performs a full reset of the targeted demo, restores its deterministic initial state, returns selection to current/initial state, and makes it eligible for the defined one-time autoplay policy again without changing the sibling demo.",
        "Direct browser verification exercises viewport exit/re-entry, manual pause, scrub, reduced motion, completion, and restart using controlled time/visibility inputs rather than timing-sensitive sleeps.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "customer-factory-emulator-demos-004",
      "title": "Inspect execution with accessible controls",
      "description": "As a curious visitor, I want to control and inspect the demo timeline so I can understand intermediate and terminal Factory states at my own pace.",
      "acceptanceCriteria": [
        "Play, Pause, Step, Restart, speed, timeline scrub, and Follow current actions expose their current values and disabled states through accessible names/semantics and are operable by keyboard with visible focus.",
        "Scrubbing to an earlier retained tick pauses playback, enters history mode, and shows that tick's replay projection while the canonical emulator head remains unchanged.",
        "Play or Step from history first returns to current mode; Follow current selects the latest projection without mutating or rerunning historical execution.",
        "The final tick remains scrub-accessible after successful or failed completion, allowing the visitor to inspect the terminal Work state and the events that led to it.",
        "Controls remain ordered and usable without overlap or horizontal page overflow in a narrow demo container and at desktop width.",
        "Direct browser verification covers mouse/pointer and keyboard control paths, historical inspection, return to current, speed changes, and terminal inspection for both demos.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "customer-factory-emulator-demos-005",
      "title": "Submit text Work while a demo is live",
      "description": "As a website visitor, I want to submit my own text Work into a running demo so I can see the Factory respond without leaving the example or using a hosted provider.",
      "acceptanceCriteria": [
        "Each demo offers the existing simple controlled composer for its unique eligible DEFAULT Work Type and accepts nonblank text while the demo is in current mode, including while another dispatch is active.",
        "An accepted submission enters only the targeted emulator's canonical event stream, clears the draft after acceptance, and becomes visible in its current replay projection.",
        "Submission is disabled with an accessible, actionable reason while viewing history and after a closed or invalid session; returning to current mode re-enables submission when the session is otherwise eligible.",
        "A rejected submission preserves the typed draft and presents a recoverable error without changing committed history or the sibling demo.",
        "Enter submits, Shift+Enter inserts a newline, focus remains predictable after success or error, and the composer stacks without horizontal overflow at narrow widths.",
        "Direct browser verification covers live submission during active execution, history-mode disablement, successful clearing, failure preservation, keyboard behavior, and narrow/desktop layouts.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    },
    {
      "id": "customer-factory-emulator-demos-006",
      "title": "Prove independent demo lifecycles",
      "description": "As a website host, I want simultaneous demos to remain isolated so one visitor action or failure cannot contaminate another Factory example.",
      "acceptanceCriteria": [
        "With both demos mounted, playing, pausing, changing speed, scrubbing, submitting, restarting, or encountering a setup/runtime error in one demo does not change the sibling's events, replay selection, playback intent, draft, errors, seeded IDs, or terminal state.",
        "Running both scenarios concurrently produces the same per-demo canonical event sequences and final projections as running each scenario alone.",
        "Unmounting and remounting one demo disposes its host observers/timers and creates a fresh deterministic instance without leaking callbacks or changing the still-mounted demo.",
        "The demo composition uses one instance-scoped website adapter per mount and does not add a global demo store, browser persistence, hosted-session coupling, provider execution, or cross-demo orchestration.",
        "Direct browser verification exercises simultaneous playback plus independent scrub, submit, error, restart, and remount actions at narrow and desktop widths.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": ""
    }
  ]
}
