### PR TITLE
provider-functional-test-topology

### DIFF
--- a/cmd/functionalboundarycheck/main.go
+++ b/cmd/functionalboundarycheck/main.go
@@ -75,6 +75,32 @@ var forbiddenFunctionalConfigFields = map[string]struct{}{
 	"ConfigureRuntime": {},
 }
 
+// grandfatheredAggregateProviderTestFiles is deletion-only: existing aggregate
+// tests may remain runnable while they migrate, but new tests belong in a
+// dedicated provider or provider-domain package.
+var grandfatheredAggregateProviderTestFiles = map[string]struct{}{
+	"cli_script_executor_test.go":                        {},
+	"cli_script_executor_timeout_long_test.go":           {},
+	"cli_template_resolution_long_test.go":               {},
+	"cli_timeout_cleanup_process_unix_test.go":           {},
+	"cli_timeout_cleanup_process_windows_test.go":        {},
+	"cli_timeout_cleanup_smoke_test.go":                  {},
+	"cli_timeout_companion_smoke_long_test.go":           {},
+	"cli_worktree_passthrough_test.go":                   {},
+	"codex_content_test.go":                              {},
+	"codex_worktree_workstation_test.go":                 {},
+	"cursor_provider_command_test.go":                    {},
+	"helpers_long_test.go":                               {},
+	"helpers_test.go":                                    {},
+	"mock_workers_agent_test.go":                         {},
+	"mock_workers_cli_http_stability_smoke_long_test.go": {},
+	"mock_workers_end_to_end_smoke_test.go":              {},
+	"mock_workers_script_test.go":                        {},
+	"mock_workers_service_runner_test.go":                {},
+	"packaged_script_runtime_test.go":                    {},
+	"runtime_logging_smoke_test.go":                      {},
+}
+
 type config struct {
 	root string
 	path string
@@ -95,7 +121,31 @@ func run(args []string, stderr io.Writer) error {
 	if err := checkSource(cfg.root, cfg.path); err != nil {
 		return err
 	}
+	if err := checkAggregateProviderTests(cfg.root); err != nil {
+		return err
+	}
 	return checkFunctionalCompositionTree(cfg.root)
+}
+
+func checkAggregateProviderTests(root string) error {
+	providerRoot := filepath.Join(root, filepath.FromSlash(providerTestRoot))
+	entries, err := os.ReadDir(providerRoot)
+	if err != nil {
+		return fmt.Errorf("%s read aggregate provider tests: %w", diagnosticPrefix, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		if _, grandfathered := grandfatheredAggregateProviderTestFiles[entry.Name()]; grandfathered {
+			continue
+		}
+		return fmt.Errorf(
+			"%s new aggregate provider test prohibited: %s%s; place the test in the dedicated provider or domain subpackage",
+			diagnosticPrefix, providerTestRoot, entry.Name(),
+		)
+	}
+	return nil
 }
 
 func checkFunctionalCompositionTree(root string) error {

--- a/cmd/functionalboundarycheck/main.go
+++ b/cmd/functionalboundarycheck/main.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -128,21 +129,39 @@ func run(args []string, stderr io.Writer) error {
 }
 
 func checkAggregateProviderTests(root string) error {
+	return checkAggregateProviderTestsAgainst(root, grandfatheredAggregateProviderTestFiles)
+}
+
+func checkAggregateProviderTestsAgainst(root string, grandfathered map[string]struct{}) error {
 	providerRoot := filepath.Join(root, filepath.FromSlash(providerTestRoot))
 	entries, err := os.ReadDir(providerRoot)
 	if err != nil {
 		return fmt.Errorf("%s read aggregate provider tests: %w", diagnosticPrefix, err)
 	}
+	active := make(map[string]struct{}, len(grandfathered))
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), "_test.go") {
 			continue
 		}
-		if _, grandfathered := grandfatheredAggregateProviderTestFiles[entry.Name()]; grandfathered {
-			continue
+		if _, recorded := grandfathered[entry.Name()]; !recorded {
+			return fmt.Errorf(
+				"%s new aggregate provider test prohibited: %s%s; place the test in the dedicated provider or domain subpackage",
+				diagnosticPrefix, providerTestRoot, entry.Name(),
+			)
 		}
+		active[entry.Name()] = struct{}{}
+	}
+	stale := make([]string, 0)
+	for name := range grandfathered {
+		if _, exists := active[name]; !exists {
+			stale = append(stale, name)
+		}
+	}
+	if len(stale) > 0 {
+		slices.Sort(stale)
 		return fmt.Errorf(
-			"%s new aggregate provider test prohibited: %s%s; place the test in the dedicated provider or domain subpackage",
-			diagnosticPrefix, providerTestRoot, entry.Name(),
+			"%s stale grandfathered aggregate provider test entry: %s%s; remove the migrated filename from grandfatheredAggregateProviderTestFiles so it cannot be reintroduced",
+			diagnosticPrefix, providerTestRoot, stale[0],
 		)
 	}
 	return nil

--- a/cmd/functionalboundarycheck/main.go
+++ b/cmd/functionalboundarycheck/main.go
@@ -18,6 +18,7 @@ import (
 const (
 	defaultScenarioPath = "tests/functional/runtime_api/api_request_batch_boundary_smoke_test.go"
 	diagnosticPrefix    = "[agent-factory:functional-boundary]"
+	providerTestRoot    = "tests/functional/providers/"
 )
 
 var forbiddenRequestBatchImports = []string{
@@ -37,6 +38,17 @@ var forbiddenCompositionImports = []string{
 	"github.com/portpowered/infinite-you/pkg/services/workers/executor",
 	"github.com/portpowered/infinite-you/pkg/transports/mapping/factoryeventprojection",
 	"github.com/portpowered/infinite-you/pkg/wire",
+}
+
+var forbiddenProviderImplementationImports = []string{
+	"github.com/portpowered/infinite-you/pkg/services/workers/provider/agy",
+	"github.com/portpowered/infinite-you/pkg/services/workers/provider/claude",
+	"github.com/portpowered/infinite-you/pkg/services/workers/provider/codex",
+	"github.com/portpowered/infinite-you/pkg/services/workers/provider/cursor",
+	"github.com/portpowered/infinite-you/pkg/services/workers/provider/gemini",
+	"github.com/portpowered/infinite-you/pkg/services/workers/provider/kiro",
+	"github.com/portpowered/infinite-you/pkg/services/workers/provider/adapter/opencode",
+	"github.com/portpowered/infinite-you/pkg/services/workers/provider/pi",
 }
 
 var forbiddenCompositionCalls = map[string]struct{}{
@@ -104,6 +116,13 @@ func checkFunctionalCompositionTree(root string) error {
 			return err
 		}
 		relative = filepath.ToSlash(relative)
+		providerSource := isDedicatedProviderSource(relative)
+		if providerSource && isProviderSharedSupportSource(relative) {
+			return fmt.Errorf(
+				"%s prohibited provider-local shared support (%s); keep reusable process composition in tests/functional/internal/support",
+				diagnosticPrefix, relative,
+			)
+		}
 		fileSet := token.NewFileSet()
 		file, err := parser.ParseFile(fileSet, path, nil, parser.ImportsOnly)
 		if err != nil {
@@ -113,6 +132,18 @@ func checkFunctionalCompositionTree(root string) error {
 			importPath, err := strconv.Unquote(spec.Path.Value)
 			if err != nil {
 				return fmt.Errorf("%s read import in %s: %w", diagnosticPrefix, relative, err)
+			}
+			if providerSource && importPath == "github.com/portpowered/infinite-you/pkg/root" {
+				return fmt.Errorf(
+					"%s prohibited provider functional composition import: %s (%s); use tests/functional/internal/support.BuildProcess with exact edges.Edges replacements",
+					diagnosticPrefix, importPath, relative,
+				)
+			}
+			if providerSource && matchesImportPrefix(importPath, forbiddenProviderImplementationImports) {
+				return fmt.Errorf(
+					"%s prohibited concrete provider implementation import: %s (%s); exercise provider behavior through tests/functional/internal/support.BuildProcess with exact edges.Edges replacements",
+					diagnosticPrefix, importPath, relative,
+				)
 			}
 			for _, forbidden := range forbiddenCompositionImports {
 				if importPath == forbidden || strings.HasPrefix(importPath, forbidden+"/") {
@@ -156,6 +187,29 @@ func checkFunctionalCompositionTree(root string) error {
 		}
 		return nil
 	})
+}
+
+func isDedicatedProviderSource(relative string) bool {
+	if !strings.HasPrefix(relative, providerTestRoot) {
+		return false
+	}
+	remainder := strings.TrimPrefix(relative, providerTestRoot)
+	return strings.Contains(remainder, "/")
+}
+
+func isProviderSharedSupportSource(relative string) bool {
+	remainder := strings.TrimPrefix(relative, providerTestRoot)
+	return strings.HasPrefix(remainder, "support/") ||
+		strings.HasPrefix(remainder, "internal/support/")
+}
+
+func matchesImportPrefix(importPath string, forbiddenImports []string) bool {
+	for _, forbidden := range forbiddenImports {
+		if importPath == forbidden || strings.HasPrefix(importPath, forbidden+"/") {
+			return true
+		}
+	}
+	return false
 }
 
 func calledName(expression ast.Expr) string {

--- a/cmd/functionalboundarycheck/main.go
+++ b/cmd/functionalboundarycheck/main.go
@@ -20,6 +20,7 @@ const (
 	defaultScenarioPath = "tests/functional/runtime_api/api_request_batch_boundary_smoke_test.go"
 	diagnosticPrefix    = "[agent-factory:functional-boundary]"
 	providerTestRoot    = "tests/functional/providers/"
+	serviceImportPrefix = "github.com/portpowered/infinite-you/pkg/services/"
 )
 
 var forbiddenRequestBatchImports = []string{
@@ -50,6 +51,18 @@ var forbiddenProviderImplementationImports = []string{
 	"github.com/portpowered/infinite-you/pkg/services/workers/provider/kiro",
 	"github.com/portpowered/infinite-you/pkg/services/workers/provider/adapter/opencode",
 	"github.com/portpowered/infinite-you/pkg/services/workers/provider/pi",
+}
+
+// Provider scenarios may import service-root contracts and these exact public
+// external-effect ports to populate edges.Edges. Every other service
+// subpackage is an implementation or composition seam and must stay behind the
+// root-built process harness. Keep this set aligned with the package-boundary
+// policy's publicExternalEffectContractImports.
+var providerPublicEffectContractImports = map[string]struct{}{
+	"github.com/portpowered/infinite-you/pkg/services/workers/agypty":                       {},
+	"github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract":   {},
+	"github.com/portpowered/infinite-you/pkg/services/workers/services/hosted_logic":        {},
+	"github.com/portpowered/infinite-you/pkg/services/workers/services/hosted_logic/linear": {},
 }
 
 var forbiddenCompositionCalls = map[string]struct{}{
@@ -214,6 +227,12 @@ func checkFunctionalCompositionTree(root string) error {
 					diagnosticPrefix, importPath, relative,
 				)
 			}
+			if providerSource && isProviderServiceImplementationImport(importPath) {
+				return fmt.Errorf(
+					"%s prohibited provider service implementation or composition import: %s (%s); exercise provider behavior through tests/functional/internal/support.BuildProcess with exact edges.Edges replacements",
+					diagnosticPrefix, importPath, relative,
+				)
+			}
 			for _, forbidden := range forbiddenCompositionImports {
 				if importPath == forbidden || strings.HasPrefix(importPath, forbidden+"/") {
 					return fmt.Errorf(
@@ -256,6 +275,17 @@ func checkFunctionalCompositionTree(root string) error {
 		}
 		return nil
 	})
+}
+
+func isProviderServiceImplementationImport(importPath string) bool {
+	if !strings.HasPrefix(importPath, serviceImportPrefix) {
+		return false
+	}
+	if _, publicEffectContract := providerPublicEffectContractImports[importPath]; publicEffectContract {
+		return false
+	}
+	remainder := strings.TrimPrefix(importPath, serviceImportPrefix)
+	return strings.Contains(remainder, "/")
 }
 
 func isDedicatedProviderSource(relative string) bool {

--- a/cmd/functionalboundarycheck/main_test.go
+++ b/cmd/functionalboundarycheck/main_test.go
@@ -205,9 +205,7 @@ var fixture = config{ConfigureRuntime: func() {}}
 
 func TestCheckAggregateProviderTestsAcceptsGrandfatheredFiles(t *testing.T) {
 	root := t.TempDir()
-	for name := range grandfatheredAggregateProviderTestFiles {
-		writeFunctionalSourceAtRoot(t, root, providerTestRoot+name, "package providers\n")
-	}
+	writeAggregateProviderTests(t, root, grandfatheredAggregateProviderTestFiles)
 
 	if err := checkAggregateProviderTests(root); err != nil {
 		t.Fatalf("checkAggregateProviderTests() error = %v", err)
@@ -216,6 +214,7 @@ func TestCheckAggregateProviderTestsAcceptsGrandfatheredFiles(t *testing.T) {
 
 func TestCheckAggregateProviderTestsRejectsNewAggregateTest(t *testing.T) {
 	root := t.TempDir()
+	writeAggregateProviderTests(t, root, grandfatheredAggregateProviderTestFiles)
 	writeFunctionalSourceAtRoot(t, root, providerTestRoot+"new_scenario_test.go", "package providers\n")
 
 	err := checkAggregateProviderTests(root)
@@ -227,22 +226,62 @@ func TestCheckAggregateProviderTestsRejectsNewAggregateTest(t *testing.T) {
 	}
 }
 
-func TestCheckAggregateProviderTestsAllowsGrandfatheredRemoval(t *testing.T) {
+func TestCheckAggregateProviderTestsRejectsStaleGrandfatheredEntry(t *testing.T) {
 	root := t.TempDir()
+	for name := range grandfatheredAggregateProviderTestFiles {
+		if name != "helpers_test.go" {
+			writeFunctionalSourceAtRoot(t, root, providerTestRoot+name, "package providers\n")
+		}
+	}
+
+	err := checkAggregateProviderTests(root)
+	if err == nil || !strings.Contains(err.Error(), "stale grandfathered aggregate provider test entry: tests/functional/providers/helpers_test.go") {
+		t.Fatalf("checkAggregateProviderTests() error = %v, want stale grandfathered entry failure", err)
+	}
+	if !strings.Contains(err.Error(), "remove the migrated filename from grandfatheredAggregateProviderTestFiles") {
+		t.Fatalf("checkAggregateProviderTests() error = %v, want allowlist-shrink remediation", err)
+	}
+}
+
+func TestCheckAggregateProviderTestsRejectsReintroducedRemovedException(t *testing.T) {
+	root := t.TempDir()
+	shrunk := copyStringSet(grandfatheredAggregateProviderTestFiles)
+	delete(shrunk, "helpers_test.go")
+	writeAggregateProviderTests(t, root, shrunk)
+
+	if err := checkAggregateProviderTestsAgainst(root, shrunk); err != nil {
+		t.Fatalf("checkAggregateProviderTestsAgainst() after migration error = %v", err)
+	}
 	writeFunctionalSourceAtRoot(t, root, providerTestRoot+"helpers_test.go", "package providers\n")
+	err := checkAggregateProviderTestsAgainst(root, shrunk)
+	if err == nil || !strings.Contains(err.Error(), "new aggregate provider test prohibited: tests/functional/providers/helpers_test.go") {
+		t.Fatalf("checkAggregateProviderTestsAgainst() error = %v, want reintroduced test failure", err)
+	}
+}
+
+func TestCheckAggregateProviderTestsAcceptsDedicatedSubpackageTest(t *testing.T) {
+	root := t.TempDir()
+	writeAggregateProviderTests(t, root, grandfatheredAggregateProviderTestFiles)
+	writeFunctionalSourceAtRoot(t, root, providerTestRoot+"codex/new_scenario_test.go", "package codex\n")
 
 	if err := checkAggregateProviderTests(root); err != nil {
 		t.Fatalf("checkAggregateProviderTests() error = %v", err)
 	}
 }
 
-func TestCheckAggregateProviderTestsAcceptsDedicatedSubpackageTest(t *testing.T) {
-	root := t.TempDir()
-	writeFunctionalSourceAtRoot(t, root, providerTestRoot+"codex/new_scenario_test.go", "package codex\n")
-
-	if err := checkAggregateProviderTests(root); err != nil {
-		t.Fatalf("checkAggregateProviderTests() error = %v", err)
+func writeAggregateProviderTests(t *testing.T, root string, names map[string]struct{}) {
+	t.Helper()
+	for name := range names {
+		writeFunctionalSourceAtRoot(t, root, providerTestRoot+name, "package providers\n")
 	}
+}
+
+func copyStringSet(source map[string]struct{}) map[string]struct{} {
+	result := make(map[string]struct{}, len(source))
+	for value := range source {
+		result[value] = struct{}{}
+	}
+	return result
 }
 
 func writeFunctionalSource(t *testing.T, source string) (string, string) {

--- a/cmd/functionalboundarycheck/main_test.go
+++ b/cmd/functionalboundarycheck/main_test.go
@@ -89,6 +89,69 @@ func scenario() {
 	}
 }
 
+func TestCheckFunctionalCompositionTreeAcceptsProviderSharedProcessHarness(t *testing.T) {
+	root, _ := writeProviderFunctionalSource(t, `package codex
+import (
+  "github.com/portpowered/infinite-you/pkg/services/edges"
+  "github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+func scenario() {
+  process := support.BuildProcess(nil, edges.Edges{})
+  _ = process
+}
+`)
+	if err := checkFunctionalCompositionTree(root); err != nil {
+		t.Fatalf("checkFunctionalCompositionTree() error = %v", err)
+	}
+}
+
+func TestCheckFunctionalCompositionTreeRejectsProviderDirectRootComposition(t *testing.T) {
+	root, _ := writeProviderFunctionalSource(t, `package codex
+import (
+  "github.com/portpowered/infinite-you/pkg/root"
+  "github.com/portpowered/infinite-you/pkg/services/edges"
+)
+func scenario() {
+  process, _ := root.BuildProcess(nil, edges.Edges{})
+  _ = process
+}
+`)
+	err := checkFunctionalCompositionTree(root)
+	if err == nil || !strings.Contains(err.Error(), "prohibited provider functional composition import") {
+		t.Fatalf("checkFunctionalCompositionTree() error = %v, want provider composition failure", err)
+	}
+	if !strings.Contains(err.Error(), "tests/functional/internal/support.BuildProcess with exact edges.Edges replacements") {
+		t.Fatalf("checkFunctionalCompositionTree() error = %v, want shared typed-edge harness remediation", err)
+	}
+}
+
+func TestCheckFunctionalCompositionTreeRejectsConcreteProviderImplementation(t *testing.T) {
+	for _, importPath := range forbiddenProviderImplementationImports {
+		t.Run(importPath, func(t *testing.T) {
+			root, _ := writeProviderFunctionalSource(t, "package codex\nimport _ \""+importPath+"\"\n")
+			err := checkFunctionalCompositionTree(root)
+			if err == nil || !strings.Contains(err.Error(), "prohibited concrete provider implementation import: "+importPath) {
+				t.Fatalf("checkFunctionalCompositionTree() error = %v, want concrete provider failure", err)
+			}
+			if !strings.Contains(err.Error(), "support.BuildProcess with exact edges.Edges replacements") {
+				t.Fatalf("checkFunctionalCompositionTree() error = %v, want shared typed-edge harness remediation", err)
+			}
+		})
+	}
+}
+
+func TestCheckFunctionalCompositionTreeRejectsProviderLocalSharedSupport(t *testing.T) {
+	root, _ := writeFunctionalSourceAt(
+		t,
+		"tests/functional/providers/internal/support/process.go",
+		"package support\n",
+	)
+	err := checkFunctionalCompositionTree(root)
+	if err == nil || !strings.Contains(err.Error(), "keep reusable process composition in tests/functional/internal/support") {
+		t.Fatalf("checkFunctionalCompositionTree() error = %v, want canonical support-root failure", err)
+	}
+}
+
 func TestCheckFunctionalCompositionTreeRejectsLegacyHarnessCall(t *testing.T) {
 	for _, call := range []string{"NewServiceTestHarness", "GetEngineStateSnapshot"} {
 		t.Run(call, func(t *testing.T) {
@@ -142,8 +205,18 @@ var fixture = config{ConfigureRuntime: func() {}}
 
 func writeFunctionalSource(t *testing.T, source string) (string, string) {
 	t.Helper()
+	return writeFunctionalSourceAt(t, "tests/functional/guards_batch/request_batch_test.go", source)
+}
+
+func writeProviderFunctionalSource(t *testing.T, source string) (string, string) {
+	t.Helper()
+	return writeFunctionalSourceAt(t, "tests/functional/providers/codex/process_test.go", source)
+}
+
+func writeFunctionalSourceAt(t *testing.T, relativePath, source string) (string, string) {
+	t.Helper()
 	root := t.TempDir()
-	path := filepath.Join(root, "tests", "functional", "guards_batch", "request_batch_test.go")
+	path := filepath.Join(root, filepath.FromSlash(relativePath))
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("create functional fixture: %v", err)
 	}

--- a/cmd/functionalboundarycheck/main_test.go
+++ b/cmd/functionalboundarycheck/main_test.go
@@ -203,6 +203,48 @@ var fixture = config{ConfigureRuntime: func() {}}
 	}
 }
 
+func TestCheckAggregateProviderTestsAcceptsGrandfatheredFiles(t *testing.T) {
+	root := t.TempDir()
+	for name := range grandfatheredAggregateProviderTestFiles {
+		writeFunctionalSourceAtRoot(t, root, providerTestRoot+name, "package providers\n")
+	}
+
+	if err := checkAggregateProviderTests(root); err != nil {
+		t.Fatalf("checkAggregateProviderTests() error = %v", err)
+	}
+}
+
+func TestCheckAggregateProviderTestsRejectsNewAggregateTest(t *testing.T) {
+	root := t.TempDir()
+	writeFunctionalSourceAtRoot(t, root, providerTestRoot+"new_scenario_test.go", "package providers\n")
+
+	err := checkAggregateProviderTests(root)
+	if err == nil || !strings.Contains(err.Error(), "new aggregate provider test prohibited: tests/functional/providers/new_scenario_test.go") {
+		t.Fatalf("checkAggregateProviderTests() error = %v, want new aggregate test failure", err)
+	}
+	if !strings.Contains(err.Error(), "dedicated provider or domain subpackage") {
+		t.Fatalf("checkAggregateProviderTests() error = %v, want migration destination", err)
+	}
+}
+
+func TestCheckAggregateProviderTestsAllowsGrandfatheredRemoval(t *testing.T) {
+	root := t.TempDir()
+	writeFunctionalSourceAtRoot(t, root, providerTestRoot+"helpers_test.go", "package providers\n")
+
+	if err := checkAggregateProviderTests(root); err != nil {
+		t.Fatalf("checkAggregateProviderTests() error = %v", err)
+	}
+}
+
+func TestCheckAggregateProviderTestsAcceptsDedicatedSubpackageTest(t *testing.T) {
+	root := t.TempDir()
+	writeFunctionalSourceAtRoot(t, root, providerTestRoot+"codex/new_scenario_test.go", "package codex\n")
+
+	if err := checkAggregateProviderTests(root); err != nil {
+		t.Fatalf("checkAggregateProviderTests() error = %v", err)
+	}
+}
+
 func writeFunctionalSource(t *testing.T, source string) (string, string) {
 	t.Helper()
 	return writeFunctionalSourceAt(t, "tests/functional/guards_batch/request_batch_test.go", source)
@@ -216,6 +258,12 @@ func writeProviderFunctionalSource(t *testing.T, source string) (string, string)
 func writeFunctionalSourceAt(t *testing.T, relativePath, source string) (string, string) {
 	t.Helper()
 	root := t.TempDir()
+	path := writeFunctionalSourceAtRoot(t, root, relativePath, source)
+	return root, path
+}
+
+func writeFunctionalSourceAtRoot(t *testing.T, root, relativePath, source string) string {
+	t.Helper()
 	path := filepath.Join(root, filepath.FromSlash(relativePath))
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("create functional fixture: %v", err)
@@ -223,5 +271,5 @@ func writeFunctionalSourceAt(t *testing.T, relativePath, source string) (string,
 	if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
 		t.Fatalf("write functional fixture: %v", err)
 	}
-	return root, path
+	return path
 }

--- a/cmd/functionalboundarycheck/main_test.go
+++ b/cmd/functionalboundarycheck/main_test.go
@@ -105,6 +105,21 @@ func scenario() {
 	}
 }
 
+func TestCheckFunctionalCompositionTreeAcceptsProviderPublicContracts(t *testing.T) {
+	for _, importPath := range []string{
+		"github.com/portpowered/infinite-you/pkg/services/edges",
+		"github.com/portpowered/infinite-you/pkg/services/models",
+		"github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract",
+	} {
+		t.Run(importPath, func(t *testing.T) {
+			root, _ := writeProviderFunctionalSource(t, "package codex\nimport _ \""+importPath+"\"\n")
+			if err := checkFunctionalCompositionTree(root); err != nil {
+				t.Fatalf("checkFunctionalCompositionTree() error = %v, want public contract accepted", err)
+			}
+		})
+	}
+}
+
 func TestCheckFunctionalCompositionTreeRejectsProviderDirectRootComposition(t *testing.T) {
 	root, _ := writeProviderFunctionalSource(t, `package codex
 import (
@@ -132,6 +147,25 @@ func TestCheckFunctionalCompositionTreeRejectsConcreteProviderImplementation(t *
 			err := checkFunctionalCompositionTree(root)
 			if err == nil || !strings.Contains(err.Error(), "prohibited concrete provider implementation import: "+importPath) {
 				t.Fatalf("checkFunctionalCompositionTree() error = %v, want concrete provider failure", err)
+			}
+			if !strings.Contains(err.Error(), "support.BuildProcess with exact edges.Edges replacements") {
+				t.Fatalf("checkFunctionalCompositionTree() error = %v, want shared typed-edge harness remediation", err)
+			}
+		})
+	}
+}
+
+func TestCheckFunctionalCompositionTreeRejectsProviderServiceImplementation(t *testing.T) {
+	for _, importPath := range []string{
+		"github.com/portpowered/infinite-you/pkg/services/models/wire",
+		"github.com/portpowered/infinite-you/pkg/services/models/internal/service",
+		"github.com/portpowered/infinite-you/pkg/services/factory_sessions/execution",
+	} {
+		t.Run(importPath, func(t *testing.T) {
+			root, _ := writeProviderFunctionalSource(t, "package codex\nimport _ \""+importPath+"\"\n")
+			err := checkFunctionalCompositionTree(root)
+			if err == nil || !strings.Contains(err.Error(), "prohibited provider service implementation or composition import: "+importPath) {
+				t.Fatalf("checkFunctionalCompositionTree() error = %v, want service implementation failure", err)
 			}
 			if !strings.Contains(err.Error(), "support.BuildProcess with exact edges.Edges replacements") {
 				t.Fatalf("checkFunctionalCompositionTree() error = %v, want shared typed-edge harness remediation", err)

--- a/cmd/functionallane/main.go
+++ b/cmd/functionallane/main.go
@@ -9,9 +9,9 @@ import (
 	"os/exec"
 	"strings"
 	"time"
-)
 
-const supportPackageSuffix = "/internal/support"
+	"github.com/portpowered/infinite-you/internal/testlanes"
+)
 
 type config struct {
 	count   int
@@ -53,7 +53,7 @@ func parseConfig() config {
 	var cfg config
 	flag.IntVar(&cfg.count, "count", 1, "go test -count value")
 	flag.IntVar(&cfg.jobs, "jobs", 2, "go test -p value")
-	flag.StringVar(&cfg.root, "root", "./tests/functional/...", "go list package pattern for functional test discovery")
+	flag.StringVar(&cfg.root, "root", testlanes.FunctionalPackagePattern, "go list package pattern for functional test discovery")
 	flag.BoolVar(&cfg.short, "short", true, "run with go test -short")
 	flag.DurationVar(&cfg.timeout, "timeout", 5*time.Minute, "go test timeout")
 	flag.Parse()
@@ -79,10 +79,15 @@ func discoverPackages(root string) ([]string, error) {
 	pkgs := make([]string, 0, len(lines))
 	for _, line := range lines {
 		pkg := strings.TrimSpace(line)
-		if pkg == "" || strings.HasSuffix(pkg, supportPackageSuffix) {
+		if pkg == "" || !testlanes.IsRunnableFunctionalPackage(pkg) {
 			continue
 		}
 		pkgs = append(pkgs, pkg)
+	}
+	if root == testlanes.FunctionalPackagePattern {
+		if err := testlanes.ValidateProviderFunctionalPackages(pkgs); err != nil {
+			return nil, err
+		}
 	}
 	return pkgs, nil
 }

--- a/cmd/functionallane/main_test.go
+++ b/cmd/functionallane/main_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/portpowered/infinite-you/internal/testlanes"
 )
 
 func TestMainExecutesFunctionalLane(t *testing.T) {
@@ -155,12 +157,13 @@ func TestDiscoverPackagesKeepsRunnablePackagesAndExcludesSupport(t *testing.T) {
 	}
 
 	t.Setenv("GO_WANT_FUNCTIONALLANE_HELPER", "1")
-	t.Setenv("FUNCTIONALLANE_HELPER_LIST_STDOUT", strings.Join([]string{
+	discovered := append([]string{
 		"github.com/portpowered/infinite-you/tests/functional/runtime_api",
 		"github.com/portpowered/infinite-you/tests/functional/internal/support",
 		"",
 		"github.com/portpowered/infinite-you/tests/functional/bootstrap_portability",
-	}, "\n"))
+	}, testlanes.RequiredProviderFunctionalPackages()...)
+	t.Setenv("FUNCTIONALLANE_HELPER_LIST_STDOUT", strings.Join(discovered, "\n"))
 
 	pkgs, err := discoverPackages("./tests/functional/...")
 	if err != nil {
@@ -178,6 +181,7 @@ func TestDiscoverPackagesKeepsRunnablePackagesAndExcludesSupport(t *testing.T) {
 		"github.com/portpowered/infinite-you/tests/functional/runtime_api",
 		"github.com/portpowered/infinite-you/tests/functional/bootstrap_portability",
 	}
+	want = append(want, testlanes.RequiredProviderFunctionalPackages()...)
 	if !slices.Equal(pkgs, want) {
 		t.Fatalf("discoverPackages() packages = %v, want %v", pkgs, want)
 	}
@@ -188,7 +192,7 @@ func TestRunFailsWhenNoRunnablePackagesRemain(t *testing.T) {
 	restoreArgsAndFlags(t)
 
 	execCommand = fakeFunctionalLaneCommand
-	os.Args = []string{"functionallane"}
+	os.Args = []string{"functionallane", "-root=./tests/functional/internal/..."}
 	flag.CommandLine = flag.NewFlagSet("functionallane", flag.ContinueOnError)
 
 	t.Setenv("GO_WANT_FUNCTIONALLANE_HELPER", "1")
@@ -202,7 +206,7 @@ func TestRunFailsWhenNoRunnablePackagesRemain(t *testing.T) {
 		t.Fatal("run() unexpectedly succeeded")
 	}
 
-	want := "discover functional packages: no test packages found under ./tests/functional/..."
+	want := "discover functional packages: no test packages found under ./tests/functional/internal/..."
 	if err.Error() != want {
 		t.Fatalf("run() error = %q, want %q", err.Error(), want)
 	}
@@ -223,12 +227,13 @@ func TestRunExecutesDiscoveredFunctionalPackagesWithParsedConfig(t *testing.T) {
 
 	testArgsFile := t.TempDir() + "/go-test-args.txt"
 	t.Setenv("GO_WANT_FUNCTIONALLANE_HELPER", "1")
-	t.Setenv("FUNCTIONALLANE_HELPER_LIST_STDOUT", strings.Join([]string{
+	discovered := append([]string{
 		"github.com/portpowered/infinite-you/tests/functional/runtime_api",
 		"github.com/portpowered/infinite-you/tests/functional/internal/support",
 		"",
 		"github.com/portpowered/infinite-you/tests/functional/bootstrap_portability",
-	}, "\n"))
+	}, testlanes.RequiredProviderFunctionalPackages()...)
+	t.Setenv("FUNCTIONALLANE_HELPER_LIST_STDOUT", strings.Join(discovered, "\n"))
 	t.Setenv("FUNCTIONALLANE_HELPER_TEST_ARGS_FILE", testArgsFile)
 
 	if err := run(); err != nil {
@@ -247,9 +252,12 @@ func TestRunExecutesDiscoveredFunctionalPackagesWithParsedConfig(t *testing.T) {
 		"-short",
 		"github.com/portpowered/infinite-you/tests/functional/runtime_api",
 		"github.com/portpowered/infinite-you/tests/functional/bootstrap_portability",
+	}
+	wantArgs = append(wantArgs, testlanes.RequiredProviderFunctionalPackages()...)
+	wantArgs = append(wantArgs,
 		"-count=3",
 		"-timeout=2m0s",
-	}
+	)
 	if !slices.Equal(gotArgs, wantArgs) {
 		t.Fatalf("run() go test args = %v, want %v", gotArgs, wantArgs)
 	}
@@ -287,7 +295,8 @@ func TestRunWrapsFunctionalTestExecutionFailures(t *testing.T) {
 	flag.CommandLine = flag.NewFlagSet("functionallane", flag.ContinueOnError)
 
 	t.Setenv("GO_WANT_FUNCTIONALLANE_HELPER", "1")
-	t.Setenv("FUNCTIONALLANE_HELPER_LIST_STDOUT", "github.com/portpowered/infinite-you/tests/functional/runtime_api")
+	discovered := append([]string{"github.com/portpowered/infinite-you/tests/functional/runtime_api"}, testlanes.RequiredProviderFunctionalPackages()...)
+	t.Setenv("FUNCTIONALLANE_HELPER_LIST_STDOUT", strings.Join(discovered, "\n"))
 	t.Setenv("FUNCTIONALLANE_HELPER_TEST_FAIL", "1")
 	t.Setenv("FUNCTIONALLANE_HELPER_TEST_STDERR", "go test failed")
 
@@ -299,6 +308,24 @@ func TestRunWrapsFunctionalTestExecutionFailures(t *testing.T) {
 	want := "run functional lane: exit status 2"
 	if err.Error() != want {
 		t.Fatalf("run() error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestDiscoverPackagesFailsWhenRequiredProviderPackageIsMissing(t *testing.T) {
+	restoreExecCommand(t)
+
+	execCommand = fakeFunctionalLaneCommand
+	required := testlanes.RequiredProviderFunctionalPackages()
+	missing := required[0]
+	t.Setenv("GO_WANT_FUNCTIONALLANE_HELPER", "1")
+	t.Setenv("FUNCTIONALLANE_HELPER_LIST_STDOUT", strings.Join(required[1:], "\n"))
+
+	_, err := discoverPackages(testlanes.FunctionalPackagePattern)
+	if err == nil {
+		t.Fatal("discoverPackages() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), missing) {
+		t.Fatalf("discoverPackages() error = %q, want missing package %q", err, missing)
 	}
 }
 

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -44,7 +44,7 @@ const defaultCoverageJobs = 2
 var (
 	defaultCoveragePatterns                   = []string{"./pkg/..."}
 	unitTestPatterns                          = []string{"./pkg/..."}
-	functionalTestPatterns                    = []string{"./tests/functional/..."}
+	functionalTestPatterns                    = []string{testlanes.FunctionalPackagePattern}
 	execCommand                               = exec.Command
 	commandRunner           commandRunnerFunc = func(invocation commandInvocation) (string, string, error) {
 		cmd := execCommand(invocation.name, invocation.args...)
@@ -432,7 +432,14 @@ func resolveTestPackages(cfg config) ([]string, error) {
 	case "", "unit":
 		return listGoPackages(unitTestPatterns, isBackendCoveragePackage, false)
 	case "functional":
-		return listGoPackages(functionalTestPatterns, isFunctionalTestPackage, false)
+		packages, err := listGoPackages(functionalTestPatterns, isFunctionalTestPackage, false)
+		if err != nil {
+			return nil, err
+		}
+		if err := testlanes.ValidateProviderFunctionalPackages(packages); err != nil {
+			return nil, fmt.Errorf("resolve go coverage lane: %w", err)
+		}
+		return packages, nil
 	default:
 		return nil, fmt.Errorf("resolve go coverage lane: unsupported suite %q", cfg.suite)
 	}
@@ -531,8 +538,7 @@ func isBackendCoveragePackage(importPath string) bool {
 }
 
 func isFunctionalTestPackage(importPath string) bool {
-	return strings.HasPrefix(importPath, modulePath+"/tests/functional/") &&
-		!strings.HasPrefix(importPath, modulePath+"/tests/functional/internal/")
+	return testlanes.IsRunnableFunctionalPackage(importPath)
 }
 
 func splitList(value string, separator string, filterEmpty bool) []string {

--- a/cmd/gocoveragecheck/main_test.go
+++ b/cmd/gocoveragecheck/main_test.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/portpowered/infinite-you/internal/testlanes"
 )
 
 var emptyCoverageBaseline = map[string]struct{}{}
@@ -118,6 +120,11 @@ func TestResolveCoverageLaneFunctionalSuite(t *testing.T) {
 	} {
 		if !slices.Contains(testPackages, functionalPackage) {
 			t.Fatalf("test packages missing maintained functional package %q: %v", functionalPackage, testPackages)
+		}
+	}
+	for _, providerPackage := range testlanes.RequiredProviderFunctionalPackages() {
+		if !slices.Contains(testPackages, providerPackage) {
+			t.Fatalf("test packages missing required provider package %q: %v", providerPackage, testPackages)
 		}
 	}
 	if slices.Contains(testPackages, modulePath+"/tests/functional/internal/support") {

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -67,6 +67,11 @@
   writers before canonicalizing repeated source blocks into one sorted profile;
   keep that ordering so concurrent packages cannot corrupt the shared profile
   and the uploaded artifact matches the totals enforced by the lane.
+  The default functional and functional-coverage lanes share dynamic package
+  selection through `internal/testlanes`: retain execution of the complete
+  `go list ./tests/functional/...` result, the shared-support exclusion, and
+  required provider-destination validation in both callers. Required package
+  validation protects topology but must not become an execution allowlist.
   When merging `main` into a branch, retain `main`'s reviewed package-minimum
   manifest entries unless the branch has independently regenerated and proven
   a stricter floor. Reintroducing a stale branch floor can turn a passing

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -72,6 +72,10 @@
   `go list ./tests/functional/...` result, the shared-support exclusion, and
   required provider-destination validation in both callers. Required package
   validation protects topology but must not become an execution allowlist.
+  `make functional-boundary-check` also owns the deletion-only inventory of
+  grandfathered `tests/functional/providers/*_test.go` files: existing entries
+  may be removed as they migrate, but new provider scenarios must begin in a
+  dedicated provider or provider-domain subpackage.
   When merging `main` into a branch, retain `main`'s reviewed package-minimum
   manifest entries unless the branch has independently regenerated and proven
   a stricter floor. Reintroducing a stale branch floor can turn a passing

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -76,7 +76,10 @@
   grandfathered `tests/functional/providers/*_test.go` files: existing entries
   must be removed in the same change as their files migrate so stale exceptions
   cannot authorize reintroduction. New provider scenarios must begin in a
-  dedicated provider or provider-domain subpackage.
+  dedicated provider or provider-domain subpackage. The same boundary check
+  rejects all service implementation and composition subpackage imports from
+  dedicated provider packages, while retaining service-root contracts and the
+  exact public external-effect ports used by typed `edges.Edges` replacements.
   When merging `main` into a branch, retain `main`'s reviewed package-minimum
   manifest entries unless the branch has independently regenerated and proven
   a stricter floor. Reintroducing a stale branch floor can turn a passing

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -74,7 +74,8 @@
   validation protects topology but must not become an execution allowlist.
   `make functional-boundary-check` also owns the deletion-only inventory of
   grandfathered `tests/functional/providers/*_test.go` files: existing entries
-  may be removed as they migrate, but new provider scenarios must begin in a
+  must be removed in the same change as their files migrate so stale exceptions
+  cannot authorize reintroduction. New provider scenarios must begin in a
   dedicated provider or provider-domain subpackage.
   When merging `main` into a branch, retain `main`'s reviewed package-minimum
   manifest entries unless the branch has independently regenerated and proven

--- a/internal/testlanes/functional.go
+++ b/internal/testlanes/functional.go
@@ -1,0 +1,61 @@
+package testlanes
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+const (
+	FunctionalPackagePattern = "./tests/functional/..."
+	functionalPackagePrefix  = ModulePath + "/tests/functional/"
+	functionalSupportPackage = functionalPackagePrefix + "internal/support"
+)
+
+var requiredProviderFunctionalPackages = []string{
+	functionalPackagePrefix + "providers/agy",
+	functionalPackagePrefix + "providers/claude",
+	functionalPackagePrefix + "providers/codex",
+	functionalPackagePrefix + "providers/contract",
+	functionalPackagePrefix + "providers/cursor",
+	functionalPackagePrefix + "providers/gemini",
+	functionalPackagePrefix + "providers/kiro",
+	functionalPackagePrefix + "providers/mock_workers",
+	functionalPackagePrefix + "providers/observability",
+	functionalPackagePrefix + "providers/opencode",
+	functionalPackagePrefix + "providers/pi",
+	functionalPackagePrefix + "providers/script",
+}
+
+// IsRunnableFunctionalPackage reports whether a discovered package belongs in
+// the maintained functional lanes. Shared composition support is compiled as a
+// dependency of scenarios rather than executed as its own functional package.
+func IsRunnableFunctionalPackage(importPath string) bool {
+	return strings.HasPrefix(importPath, functionalPackagePrefix) && importPath != functionalSupportPackage
+}
+
+// RequiredProviderFunctionalPackages returns the provider and provider-domain
+// destinations that every maintained functional lane must discover.
+func RequiredProviderFunctionalPackages() []string {
+	return slices.Clone(requiredProviderFunctionalPackages)
+}
+
+// ValidateProviderFunctionalPackages prevents a successful lane from silently
+// omitting one of the repository-owned provider destinations.
+func ValidateProviderFunctionalPackages(packages []string) error {
+	discovered := make(map[string]struct{}, len(packages))
+	for _, pkg := range packages {
+		discovered[pkg] = struct{}{}
+	}
+
+	var missing []string
+	for _, required := range requiredProviderFunctionalPackages {
+		if _, ok := discovered[required]; !ok {
+			missing = append(missing, required)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("required provider functional packages are missing from discovery: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}

--- a/internal/testlanes/lanes_test.go
+++ b/internal/testlanes/lanes_test.go
@@ -1,6 +1,10 @@
 package testlanes
 
-import "testing"
+import (
+	"slices"
+	"strings"
+	"testing"
+)
 
 func TestForImportPathAssignsPrimaryLanes(t *testing.T) {
 	t.Parallel()
@@ -40,5 +44,60 @@ func TestForImportPathAssignsPrimaryLanes(t *testing.T) {
 				t.Fatalf("ForImportPath(%q) = (%q, %t), want (%q, %t)", test.importPath, got, ok, test.want, test.wantOK)
 			}
 		})
+	}
+}
+
+func TestRunnableFunctionalPackagePolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		importPath string
+		want       bool
+	}{
+		{name: "provider package", importPath: ModulePath + "/tests/functional/providers/codex", want: true},
+		{name: "existing package", importPath: ModulePath + "/tests/functional/workflow", want: true},
+		{name: "shared support", importPath: ModulePath + "/tests/functional/internal/support", want: false},
+		{name: "backend package", importPath: ModulePath + "/pkg/root", want: false},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsRunnableFunctionalPackage(test.importPath); got != test.want {
+				t.Fatalf("IsRunnableFunctionalPackage(%q) = %t, want %t", test.importPath, got, test.want)
+			}
+		})
+	}
+}
+
+func TestValidateProviderFunctionalPackages(t *testing.T) {
+	t.Parallel()
+
+	required := RequiredProviderFunctionalPackages()
+	if err := ValidateProviderFunctionalPackages(required); err != nil {
+		t.Fatalf("ValidateProviderFunctionalPackages() error = %v", err)
+	}
+
+	missing := required[2]
+	withoutOne := slices.Delete(slices.Clone(required), 2, 3)
+	err := ValidateProviderFunctionalPackages(withoutOne)
+	if err == nil {
+		t.Fatal("ValidateProviderFunctionalPackages() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), missing) {
+		t.Fatalf("ValidateProviderFunctionalPackages() error = %q, want missing package %q", err, missing)
+	}
+}
+
+func TestRequiredProviderFunctionalPackagesReturnsCopy(t *testing.T) {
+	t.Parallel()
+
+	first := RequiredProviderFunctionalPackages()
+	first[0] = "changed"
+	second := RequiredProviderFunctionalPackages()
+	if second[0] == "changed" {
+		t.Fatal("RequiredProviderFunctionalPackages() exposed mutable policy state")
 	}
 }

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -84,11 +84,16 @@ test results.
 
 - Cross-package functional helpers belong in `tests/functional/internal/support`.
 - `tests/functional/internal/support.StartFunctionalAPIServer` is the
-  canonical Wire-backed HTTP harness for backend transport regressions: it
-  builds the decomposed services through `wire.Build`, so runtime
+  canonical production-composed HTTP harness for backend transport regressions:
+  it builds the customer process through `root.BuildProcess` with exact typed
+  `edges.Edges` replacements, so runtime
   API smoke coverage for `/status`, `/models`, session routes, and factory
   activation should prefer that seam over hand-built HTTP doubles when the
   goal is startup-path parity.
+- Provider functional packages must obtain executable processes through
+  `tests/functional/internal/support.BuildProcess`; they must not import
+  `pkg/root`, `pkg/wire`, initializer or runtime composition internals, or a
+  concrete built-in provider implementation package.
 - Keep package-local helpers next to the tests until a second behavior package
   needs them, then promote them into the support package instead of importing
   or copying another package's `*_test.go` helpers.

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -82,7 +82,7 @@ test results.
 | `workflow` | Core multi-step workflow behavior such as routing, review loops, and ordinary progression across workstations. |
 | `guards_batch` | Guard evaluation, dependency gating, fan-in or batch semantics, and request-batch behavior that should fail in one narrow behavior area. |
 | `runtime_api` | Runtime projections, HTTP API behavior, event or state queries, and other externally observable runtime read models. |
-| `providers` | Legacy aggregate provider coverage that remains runnable while scenarios migrate to the dedicated packages below. Do not add new scenarios here. |
+| `providers` | Legacy aggregate provider coverage that remains runnable while scenarios migrate to the dedicated packages below. `make functional-boundary-check` rejects new root-level Go test files; do not add new scenarios here. |
 | `providers/contract` | Provider-neutral extension behavior shared across provider identities. |
 | `providers/agy`, `providers/claude`, `providers/codex`, `providers/cursor`, `providers/gemini`, `providers/kiro`, `providers/opencode`, `providers/pi` | Behavior owned by the named built-in model provider. |
 | `providers/script` | Script-worker behavior, which is not model-provider behavior. |

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -43,6 +43,13 @@ wildcard `./tests/functional/...` path. The long lane runs the full behavior
 tree plus any `functionallong`-tagged files, so broad or slow scenarios stay
 available without widening the default feedback loop.
 
+The default and functional-coverage lanes share their runnable-package policy
+from `internal/testlanes`. Both lanes still execute every package returned by
+discovery rather than selecting from an allowlist. The same policy verifies
+that the provider contract, all eight built-in providers, script, mock-worker,
+and observability destinations remain present; a missing required destination
+fails discovery with the omitted import path.
+
 The coverage lanes intentionally use separate profiles. The
 `make test-functional-coverage` command executes only the maintained non-long
 functional packages while measuring backend-owned `cmd/factory` and `pkg/...`.
@@ -56,6 +63,10 @@ The lane enforces the current aggregate floor and an 80% target for every new
 backend package. Existing packages below 80% are explicitly grandfathered in
 the functional package baseline and should be removed from that file as their
 functional coverage reaches the target.
+Provider test destinations are test packages rather than measured backend
+packages, so adding an empty destination does not create a package-minimum
+manifest entry. Its scenarios still contribute to the shared backend profile
+as soon as tests are added there.
 
 The `make test-unit-coverage` command executes only backend package tests
 against that same owned code set. Functional coverage therefore remains

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -71,7 +71,12 @@ test results.
 | `workflow` | Core multi-step workflow behavior such as routing, review loops, and ordinary progression across workstations. |
 | `guards_batch` | Guard evaluation, dependency gating, fan-in or batch semantics, and request-batch behavior that should fail in one narrow behavior area. |
 | `runtime_api` | Runtime projections, HTTP API behavior, event or state queries, and other externally observable runtime read models. |
-| `providers` | Provider-backed worker execution behavior, provider retries, provider failures, and command-request shaping that remains user-visible. |
+| `providers` | Legacy aggregate provider coverage that remains runnable while scenarios migrate to the dedicated packages below. Do not add new scenarios here. |
+| `providers/contract` | Provider-neutral extension behavior shared across provider identities. |
+| `providers/agy`, `providers/claude`, `providers/codex`, `providers/cursor`, `providers/gemini`, `providers/kiro`, `providers/opencode`, `providers/pi` | Behavior owned by the named built-in model provider. |
+| `providers/script` | Script-worker behavior, which is not model-provider behavior. |
+| `providers/mock_workers` | Mock-worker behavior, which is not model-provider behavior. |
+| `providers/observability` | Provider-facing logging and diagnostics behavior, which is not model-provider behavior. |
 | `replay_contracts` | Replay, event-history, and artifact reconstruction behavior that must stay stable across recording and playback surfaces. |
 | `bootstrap_portability` | Init, bootstrap, portability, current-factory activation, and checked-in factory portability flows. |
 

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -82,7 +82,7 @@ test results.
 | `workflow` | Core multi-step workflow behavior such as routing, review loops, and ordinary progression across workstations. |
 | `guards_batch` | Guard evaluation, dependency gating, fan-in or batch semantics, and request-batch behavior that should fail in one narrow behavior area. |
 | `runtime_api` | Runtime projections, HTTP API behavior, event or state queries, and other externally observable runtime read models. |
-| `providers` | Legacy aggregate provider coverage that remains runnable while scenarios migrate to the dedicated packages below. `make functional-boundary-check` rejects new root-level Go test files; do not add new scenarios here. |
+| `providers` | Legacy aggregate provider coverage that remains runnable while scenarios migrate to the dedicated packages below. `make functional-boundary-check` requires the grandfathered inventory to match the remaining root-level tests exactly, so remove a migrated file and its exception together; do not add or reintroduce scenarios here. |
 | `providers/contract` | Provider-neutral extension behavior shared across provider identities. |
 | `providers/agy`, `providers/claude`, `providers/codex`, `providers/cursor`, `providers/gemini`, `providers/kiro`, `providers/opencode`, `providers/pi` | Behavior owned by the named built-in model provider. |
 | `providers/script` | Script-worker behavior, which is not model-provider behavior. |

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -103,8 +103,10 @@ test results.
   goal is startup-path parity.
 - Provider functional packages must obtain executable processes through
   `tests/functional/internal/support.BuildProcess`; they must not import
-  `pkg/root`, `pkg/wire`, initializer or runtime composition internals, or a
-  concrete built-in provider implementation package.
+  `pkg/root`, `pkg/wire`, initializer or runtime composition internals, service
+  implementation/composition subpackages, or concrete built-in provider
+  implementations. Service-root contracts and the exact public external-effect
+  ports needed to populate typed `edges.Edges` replacements remain available.
 - Keep package-local helpers next to the tests until a second behavior package
   needs them, then promote them into the support package instead of importing
   or copying another package's `*_test.go` helpers.

--- a/tests/functional/providers/agy/doc.go
+++ b/tests/functional/providers/agy/doc.go
@@ -1,0 +1,2 @@
+// Package agy owns functional behavior specific to the AGY provider.
+package agy

--- a/tests/functional/providers/claude/doc.go
+++ b/tests/functional/providers/claude/doc.go
@@ -1,0 +1,2 @@
+// Package claude owns functional behavior specific to the Claude provider.
+package claude

--- a/tests/functional/providers/codex/doc.go
+++ b/tests/functional/providers/codex/doc.go
@@ -1,0 +1,2 @@
+// Package codex owns functional behavior specific to the Codex provider.
+package codex

--- a/tests/functional/providers/codex/process_harness_test.go
+++ b/tests/functional/providers/codex/process_harness_test.go
@@ -1,0 +1,21 @@
+package codex
+
+import (
+	"strings"
+	"testing"
+
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	"github.com/portpowered/infinite-you/tests/functional/internal/support"
+)
+
+func TestRootBuiltProcessExecutesThroughSharedSupport(t *testing.T) {
+	process := support.BuildProcess(t, serviceedges.Edges{})
+	inputs := support.FakeInputs(t.Context(), []string{"you", "--help"})
+
+	if err := process.Execute(inputs.Input); err != nil {
+		t.Fatalf("Process.Execute(--help) error = %v\nstderr:\n%s", err, inputs.Stderr())
+	}
+	if !strings.Contains(inputs.Stdout(), "Run and manage") {
+		t.Fatalf("Process.Execute(--help) stdout = %q, want root command help", inputs.Stdout())
+	}
+}

--- a/tests/functional/providers/contract/doc.go
+++ b/tests/functional/providers/contract/doc.go
@@ -1,0 +1,3 @@
+// Package contract owns provider-neutral extension contract behavior.
+// Provider-specific behavior belongs in the package named for that provider.
+package contract

--- a/tests/functional/providers/cursor/doc.go
+++ b/tests/functional/providers/cursor/doc.go
@@ -1,0 +1,2 @@
+// Package cursor owns functional behavior specific to the Cursor provider.
+package cursor

--- a/tests/functional/providers/gemini/doc.go
+++ b/tests/functional/providers/gemini/doc.go
@@ -1,0 +1,2 @@
+// Package gemini owns functional behavior specific to the Gemini provider.
+package gemini

--- a/tests/functional/providers/kiro/doc.go
+++ b/tests/functional/providers/kiro/doc.go
@@ -1,0 +1,2 @@
+// Package kiro owns functional behavior specific to the Kiro provider.
+package kiro

--- a/tests/functional/providers/mock_workers/doc.go
+++ b/tests/functional/providers/mock_workers/doc.go
@@ -1,0 +1,3 @@
+// Package mock_workers owns mock-worker functional behavior, separate from
+// model provider behavior.
+package mock_workers

--- a/tests/functional/providers/observability/doc.go
+++ b/tests/functional/providers/observability/doc.go
@@ -1,0 +1,3 @@
+// Package observability owns provider-facing logging and diagnostics behavior,
+// separate from model provider behavior.
+package observability

--- a/tests/functional/providers/opencode/doc.go
+++ b/tests/functional/providers/opencode/doc.go
@@ -1,0 +1,2 @@
+// Package opencode owns functional behavior specific to the OpenCode provider.
+package opencode

--- a/tests/functional/providers/pi/doc.go
+++ b/tests/functional/providers/pi/doc.go
@@ -1,0 +1,2 @@
+// Package pi owns functional behavior specific to the Pi provider.
+package pi

--- a/tests/functional/providers/script/doc.go
+++ b/tests/functional/providers/script/doc.go
@@ -1,0 +1,3 @@
+// Package script owns script-worker functional behavior, separate from model
+// provider behavior.
+package script


### PR DESCRIPTION
{
  "project": "Establish Provider-Specific Functional Test Topology",
  "branchName": "provider-functional-test-topology",
  "description": "Establish the Story 8 foundation for provider functional testing by adding discoverable packages for every built-in provider and provider-related domain, enforcing root-built typed-edge composition, including the packages in functional discovery and coverage policy, and preventing new aggregate provider tests while legacy files remain runnable until later migration waves.",
  "context": {
    "customerAsk": "Create dedicated functional package locations for every built-in provider and providers/contract; keep script and mock-worker targets distinct from model-provider packages; route shared support through root.BuildProcess and exact typed edges; make lane discovery and minimum coverage recognize every package; and add a migration guard that rejects new aggregate tests while existing tests remain operational until moved.",
    "problem": "Provider, script, mock-worker, and observability functional tests currently coexist in one aggregate tests/functional/providers Go package. Future migrations lack stable provider-owned destinations, new tests can deepen the aggregate topology, and functional composition can drift toward direct service construction or concrete provider implementation imports. New empty package destinations could also be omitted from normal short and coverage lanes unless discovery and policy explicitly recognize them.",
    "solution": "Add Go-discoverable packages for providers/contract, all eight built-in providers, script, mock_workers, and observability; keep reusable composition in tests/functional/internal/support through root.BuildProcess and exact edges.Edges; enforce provider test boundaries; align short and coverage discovery plus minimum policy; and use a deletion-only grandfathered guard to block new root-level provider tests without moving existing tests in this wave."
  },
  "acceptanceCriteria": [
    "AC-1: Dedicated, Go-discoverable functional package locations exist for providers/contract and every built-in provider: agy, claude, codex, cursor, gemini, kiro, opencode, and pi.",
    "AC-2: providers/script, providers/mock_workers, and providers/observability are distinct functional packages rather than model-provider packages.",
    "AC-3: Shared provider functional support builds the production-equivalent process through root.BuildProcess with exact typed edges.Edges, and provider functional tests cannot directly compose services or import concrete provider implementations.",
    "AC-4: The default functional lane and functional-coverage lane discover every new package, and reviewed minimum-coverage metadata accounts for the resulting lane shape without silently omitting a package.",
    "AC-5: A migration guard rejects new Go test files directly under tests/functional/providers while allowing the exact existing aggregate files to remain operational until later migration work removes them.",
    "AC-6: Focused topology, boundary, discovery, and migration-guard tests prove accepted and rejected cases, and make functional-boundary-check passes.",
    "AC-7: Quality gates pass (typecheck, lint, tests)."
  ],
  "userStories": [
    {
      "id": "provider-functional-test-topology-001",
      "title": "Expose dedicated provider and domain functional packages",
      "description": "As a maintainer, I want a discoverable functional package for each built-in provider and provider-related domain so I can place and run customer-scale evidence without adding to the aggregate package.",
      "acceptanceCriteria": [
        "Go package discovery exposes dedicated locations for providers/contract, providers/agy, providers/claude, providers/codex, providers/cursor, providers/gemini, providers/kiro, providers/opencode, and providers/pi.",
        "Go package discovery exposes separate providers/script, providers/mock_workers, and providers/observability locations.",
        "Package ownership descriptions make clear that provider-neutral extension behavior belongs in contract, provider behavior belongs under its provider identity, and script, mock-worker, and observability behavior do not belong in model-provider packages.",
        "The existing aggregate provider tests remain runnable and are not moved or rewritten in this story.",
        "No provider integration protocol type or concrete provider implementation package changes are included.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added Go-discoverable packages and ownership documentation; verified discovery, compilation, legacy aggregate tests, typecheck, functional boundaries, package structure, and the short Go suite."
    },
    {
      "id": "provider-functional-test-topology-002",
      "title": "Enforce the public process harness boundary",
      "description": "As a functional-test author, I want one shared public process harness with typed external replacements so my provider scenarios exercise production composition without depending on provider internals.",
      "acceptanceCriteria": [
        "Shared provider functional support constructs the executable process through root.BuildProcess and accepts only exact typed replacements expressed by edges.Edges.",
        "A representative provider-package scenario can obtain and execute the root-built process through shared support without directly constructing a service graph.",
        "Functional boundary enforcement rejects a provider functional source that imports a concrete built-in provider implementation package.",
        "Functional boundary enforcement rejects direct service-graph construction or alternate composition seams within provider functional packages and emits an actionable diagnostic directing authors to the root-built harness and typed edges.",
        "Provider-package-local fixtures may remain local, while reusable process composition remains only under tests/functional/internal/support; no second shared support root is introduced under providers.",
        "The harness does not depend on unfinished standardized provider integration protocol behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Enforced the provider functional composition boundary, added concrete built-in provider import guards and canonical support-root enforcement, and proved a Codex package can execute the root-built process through shared support with exact typed edges. Typecheck, lint, short Go tests, focused tests, and functional-boundary-check pass."
    },
    {
      "id": "provider-functional-test-topology-003",
      "title": "Include every provider package in functional lane policy",
      "description": "As a maintainer, I want the repository-owned short and coverage lanes to recognize every provider functional package so newly placed evidence cannot be skipped by normal verification.",
      "acceptanceCriteria": [
        "Repository functional discovery returns every new provider and provider-domain package while continuing to exclude only the shared internal support package from runnable functional tests.",
        "The default short functional lane attempts every discovered provider and provider-domain package without a hard-coded provider allowlist.",
        "The functional-coverage lane uses the same maintained package topology and its reviewed minimum-coverage metadata accounts for the new packages rather than silently omitting them.",
        "Focused discovery tests fail when any required provider or provider-domain package is absent and prove that all required packages are handed to the applicable lane.",
        "Existing functional packages outside the provider tree retain their current discovery behavior.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Unified default and coverage functional discovery through shared test-lane policy, required all provider/domain destinations without creating an execution allowlist, and passed focused tests, the full short functional lane, functional coverage, typecheck, lint, and short Go tests."
    },
    {
      "id": "provider-functional-test-topology-004",
      "title": "Prevent aggregate provider test growth during migration",
      "description": "As a maintainer, I want new provider functional tests forced into the dedicated packages while legacy aggregate tests continue to run until their scheduled migration.",
      "acceptanceCriteria": [
        "A repository guard accepts the exact grandfathered Go files currently located directly under tests/functional/providers.",
        "The guard fails when a new Go test file is added directly under tests/functional/providers and reports the dedicated provider or domain subpackage as the required destination.",
        "Removing or moving a grandfathered aggregate file does not require retaining a stale exception and cannot expand the grandfathered set implicitly.",
        "Tests for the guard prove an unchanged legacy set passes, a newly added aggregate test fails, and a test placed in a dedicated subpackage passes.",
        "Existing aggregate tests remain operational in the default and applicable long functional lanes until separate migration stories move them.",
        "make functional-boundary-check enforces the migration rule together with the provider composition/import boundary.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Added a deletion-only aggregate provider test allowlist to the functional boundary gate, proved accepted and rejected migration cases, retained default and long-tag aggregate package operation, and passed typecheck, lint, short Go tests, and the full functional lane."
    }
  ]
}
