### PR TITLE
provider-integration-protocol-testkit

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -66,7 +66,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/platform/logging",
-      "minimum": 66.39
+      "minimum": 65.57
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/platform/metrics",

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -70,7 +70,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/platform/metrics",
-      "minimum": 73.33
+      "minimum": 72.00
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/platform/portablefiles",
@@ -474,7 +474,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/state",
-      "minimum": 83.06
+      "minimum": 82.83
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_runtime/state/validation",
@@ -656,7 +656,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/runtime",
-      "minimum": 61.02
+      "minimum": 60.29
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/factory_sessions/runtimebinding",
@@ -848,7 +848,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/work",
-      "minimum": 53.60
+      "minimum": 53.55
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/work/materialize",
@@ -1192,7 +1192,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/http",
-      "minimum": 37.43
+      "minimum": 37.37
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/transports/http/apitypes",

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1007,6 +1007,16 @@
       }
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract/testkit",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/provider/kiro",
       "minimum": 0.00
     },

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -911,6 +911,10 @@
       }
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract/testkit",
+      "minimum": 76.13
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/provider/kiro",
       "minimum": 84.41
     },

--- a/docs/internal/howtos/adding-new-providers.md
+++ b/docs/internal/howtos/adding-new-providers.md
@@ -1,149 +1,149 @@
-# Adding a model provider
+# Implementing a model provider integration
 
-> This guide describes the target workflow in
-> [`provider-integration-convergence.md`](../../temp/standardized-providers/provider-integration-convergence.md).
-> Use it as the implementation checklist while the standardized manifest and
-> inference-contract packages are being introduced.
+The customer-implementable provider inference boundary is
+`pkg/services/workers/provider/inferencecontract`. It is deliberately separate
+from built-in provider registration and Factory Session publication. This
+guide covers implementing and validating that public Go contract; wiring a new
+built-in provider into production is a separate migration.
 
-A provider consists of two deliberately separate pieces:
+Provider-native commands, HTTP or SDK calls, event decoding, session
+extraction, and failure classification stay in the provider package. Shared
+orchestration must not branch on provider identity.
 
-1. A standardized manifest describes identity, technical support level,
-   discovery, and the maximum capability set.
-2. One Go integration implements request-time capability negotiation and
-   invocation through the structured response writer.
+## 1. Implement the public contract
 
-Provider-native commands, HTTP/SDK calls, PTY handling, event decoding, session
-extraction, and failure classification belong in the provider's package. Shared
-orchestration must not switch on the provider ID.
-
-## 1. Author the manifest
-
-For a first-party provider, add
-`packages/model-providers/providers/<provider>/provider.yaml`. External
-integrations use the same published JSON Schema without editing the first-party
-catalog.
-
-An illustrative manifest is:
-
-```yaml
-schemaVersion: you-agent-factory.model-provider.v1
-id: acme
-displayName: Acme Models
-description: Runs Acme models through the Acme CLI.
-aliases: []
-technicalSupportLevel: experimental
-implementation: bundled
-documentation:
-  reference: /providers/acme
-discovery:
-  executables:
-    - acme
-  configurationKeys:
-    - ACME_API_KEY
-capabilities:
-  execution:
-    - prompt_submission
-    - tool_execution
-    - session_resume
-    - working_directory
-  response:
-    - native_streaming
-    - message_snapshots
-    - tool_lifecycle
-    - usage
-    - stable_item_ids
-```
-
-Use `production` only for supported, release-quality integrations;
-`experimental` for runnable integrations whose contract or behavior may still
-change; and `not-supported` only for catalog entries that document a known gap.
-A `not-supported` entry is not runtime-selectable.
-
-The capability lists are maximums, not claims about every request. Do not put
-credentials, live readiness, machine-local paths, pricing, or provider-native
-event payloads in the manifest. Run the provider-manifest generator and drift
-check introduced by the convergence plan, and commit generated artifacts with
-the authored manifest.
-
-## 2. Implement the integration
-
-Create `pkg/services/workers/provider/<provider>`. Implement only the public
-inference contract:
+Implement `inferencecontract.Integration`:
 
 ```go
 type Integration interface {
-	Manifest() inferencecontract.Manifest
-	Capabilities(context.Context, inferencecontract.ProviderInferenceRequest) (inferencecontract.Capabilities, error)
-	Invoke(context.Context, inferencecontract.ProviderInferenceRequest, inferencecontract.ResponseWriter) error
+	Identity() inferencecontract.Identity
+	MaximumCapabilities() inferencecontract.CapabilitySet
+	Discover(context.Context) (inferencecontract.Discovery, error)
+	Capabilities(context.Context, inferencecontract.InvocationRequest) (inferencecontract.CapabilitySet, error)
+	Invoke(context.Context, inferencecontract.InvocationRequest, inferencecontract.ResponseWriter) error
 }
 ```
 
-For a built-in, `Manifest()` returns the typed manifest loaded from the embedded
-`packages/model-providers` catalog; do not repeat aliases, support level,
-discovery data, or maximum capabilities as Go literals. `Capabilities` returns
-the subset available for the specific request and environment. It must never
-return capabilities outside the manifest maximum.
+`Identity` is an opaque, stable identifier. Do not use it to select special
+orchestration behavior. `MaximumCapabilities` declares the integration's
+maximum provider-neutral capability set. `Capabilities` returns the subset
+available for one immutable request and must never escalate beyond that
+maximum.
 
-`Invoke` maps native output to the existing response-event drafts in
-`pkg/services/workers/response_drafts.go` and writes them in observation order.
-Use the documented response-event vocabulary in
-[`response-events.md`](../contract/response-events.md). The runtime owns event
-IDs, Factory Session IDs, timestamps, sequence numbers, retention, and
-`STREAM_GAP`; provider code must not create them.
+`Discover` returns current readiness plus sanitized prerequisites. Report only
+bounded setup guidance and prerequisite names or statuses. Never include
+credentials, raw environment assignments, machine-local paths, prompts, or
+provider-native payloads.
 
-Close the response writer exactly once with either the authoritative inference
-response or a normalized failure. Stop and return the error if writing an event
-fails. Provider failures and diagnostic summaries must be bounded and must not
-expose prompts, credentials, environment values, or unsafe native payloads.
+Use the public validators while developing an integration:
 
-## 3. Register it
-
-Bind the manifest and integration by canonical provider ID through the typed
-provider-registration edge consumed by `root.BuildProcess`. Production
-composition registers a built-in once; customers and tests append named
-registrations without replacing unrelated providers.
-
-Do not add the provider to an OpenAPI enum, central switch, alias map,
-capability map, CLI catalog, or documentation list. The registry and generated
-manifest own those projections. A missing manifest/implementation pair,
-duplicate ID or alias, and a negotiated capability outside the manifest must
-fail during composition or validation.
-
-## 4. Prove conformance and public behavior
-
-Add sanitized native fixtures and run the shared
-`pkg/services/workers/provider/inferencecontract/testkit`. At minimum prove:
-
-- manifest validity and capability-subset enforcement;
-- successful invocation, ordered valid drafts, and one terminal completion;
-- cancellation, timeout, dependency failure, malformed output, and writer
-  failure;
-- stable message/tool correlation and correct final-response selection; and
-- bounded, safe failures and diagnostics.
-
-Add customer-scale tests under `tests/functional/providers/<provider>/`:
-
-```text
-invoke_test.go
-failure_test.go
-stream_test.go       # only when native streaming is declared
-session_test.go      # only when session resume/identity is declared
-transport_test.go    # PTY, Windows prompt, negotiation, or other bespoke IO
+```go
+if err := inferencecontract.ValidateIdentity(integration.Identity()); err != nil {
+	return err
+}
+maximum := integration.MaximumCapabilities()
+if err := inferencecontract.ValidateMaximumCapabilities(maximum); err != nil {
+	return err
+}
+discovery, err := integration.Discover(ctx)
+if err != nil {
+	return err
+}
+if err := inferencecontract.ValidateDiscovery(discovery); err != nil {
+	return err
+}
+negotiated, err := integration.Capabilities(ctx, request)
+if err != nil {
+	return err
+}
+if err := inferencecontract.ValidateNegotiatedCapabilities(maximum, negotiated); err != nil {
+	return err
+}
 ```
 
-Functional tests enter through `root.BuildProcess` and replace only external
-effects through typed edges. They must not import the provider implementation
-or construct an alternate service graph. Verify the provider appears in
-manifest-backed discovery with the expected support level and capability set,
-then prove invocation and failure behavior through the public boundary.
+## 2. Emit drafts and one completion
+
+`Invoke` receives an immutable `InvocationRequest` and a `ResponseWriter`.
+Construct provider-neutral `EventDraft` values with
+`inferencecontract.NewEventDraft`, then write them in observation order. The
+draft vocabulary is owned by `pkg/services/workers`; see
+[`response-events.md`](../contract/response-events.md) for its semantic kinds,
+phases, and payloads.
+
+Provider code supplies semantic correlation and provenance, but never Factory
+Session envelopes, event IDs, timestamps, publication sequence numbers,
+retention metadata, replay gaps, or `STREAM_GAP` drafts. Message and tool
+lifecycles retain stable item or tool correlation. A provider may emit at most
+one authoritative `MESSAGE/COMPLETED` snapshot representing final response
+content.
+
+Close the writer exactly once with either:
+
+- `SuccessfulCompletion(NewResponse(...))`, or
+- `FailedCompletion(NewFailure(...))`.
+
+The response is authoritative. If an authoritative completed message was
+emitted, its content must agree with that response. A completed success message
+cannot be followed by a failure. Stop provider observation and return
+immediately when `WriteEvent` fails; later writes or closes cannot replace the
+first terminal outcome.
+
+Normalize failures into one of the public failure kinds: authentication,
+invalid request, throttling, timeout, cancellation, dependency failure,
+malformed provider output, or unknown failure. Messages and diagnostics must
+be bounded and safe for customers. Optional `ProviderSession` metadata is
+generic and detached; it does not expose transcript history or give the
+integration ownership of Provider Session lifecycle.
+
+Shared orchestration must invoke an implementation through
+`inferencecontract.ExecuteInvocation`. That boundary validates correlation,
+lifecycle order, terminal agreement, sink backpressure, and exactly-once close
+before buffered terminal drafts reach orchestration.
+
+## 3. Run the reusable conformance suites
+
+Use `pkg/services/workers/provider/inferencecontract/testkit` with deterministic,
+sanitized fixtures. `testkit.Run` requires fresh integration factories for
+final-only, streaming, and correlated tool-lifecycle success. Supply at least
+two distinct valid identities to prove behavior is identity-neutral:
+
+```go
+testkit.Run(t, testkit.Suite{
+	Identities: []inferencecontract.Identity{"customer.alpha", "customer-beta"},
+	FinalOnly:  finalOnlyFactory,
+	Streaming:  streamingFactory,
+	Tool:       toolFactory,
+	Fixture: testkit.Fixture{
+		FinalOnlyRequest: finalOnlyRequest,
+		StreamingRequest: streamingRequest,
+		ToolRequest:      toolRequest,
+		ExpectedResponse: expectedResponse,
+	},
+})
+```
+
+Also run `testkit.RunAdverse` with fresh factories for every field in
+`testkit.AdverseSuite`. It proves all normalized failure categories,
+cancellation, timeout, response-sink backpressure, double close, write after
+close, missing close, response/event disagreement, failure after a represented
+success, and conflicting authoritative completed messages. Run the provider
+contract tests with the race detector because cancellation, backpressure, and
+close behavior exercise concurrency.
+
+The conformance suites require no Factory Session store, provider executable,
+credential, worktree, transcript reader, generated API artifact, or process
+composition.
 
 ## Completion checklist
 
-- The authored manifest validates and generated catalog drift checks pass.
-- Website/reference generation sees the provider without a manual inventory
-  edit.
-- The Go integration owns all provider-native behavior.
-- Negotiated capabilities are a subset of the manifest maximum.
-- Response drafts validate and the writer is closed exactly once.
-- Shared conformance and provider-scoped functional tests pass.
-- No central provider switch, enum, alias list, or capability table changed.
+- Identity, maximum capabilities, discovery, and negotiated capabilities pass
+  their public validators.
+- Discovery and normalized failure details are bounded and customer-safe.
+- Draft lifecycles are ordered and correlated, with no Factory-owned fields.
+- The writer closes exactly once and final event content agrees with the
+  authoritative response.
+- Success and adverse conformance suites pass for at least two opaque
+  identities.
+- Focused package tests and race-enabled protocol tests pass.
+- No built-in provider switch, generated API, Factory Session ownership, or
+  production registration migration was added as part of the contract work.

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -34,7 +34,10 @@ primary-result behavior.
   later provider write or close without sending a competing completion. Once
   an authoritative completed message represents success, reject a later
   failure completion and discard the buffered terminal tail so orchestration
-  observes neither side of a contradictory outcome.
+  observes neither side of a contradictory outcome. Reject a second
+  authoritative completed message as `final_result_agreement`, even when it
+  uses a different item correlation, so no earlier represented result can be
+  overwritten before completion validation.
 
 ## CLI run and submit command contracts
 

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -27,7 +27,11 @@ primary-result behavior.
   outside this package. Customer integrations can reuse
   `inferencecontract/testkit.Run` with fresh factories for final-only,
   streaming, and tool-lifecycle modes; pass at least two opaque identities so
-  conformance never depends on a built-in provider name.
+  conformance never depends on a built-in provider name. Reuse
+  `inferencecontract/testkit.RunAdverse` for normalized failure, cancellation,
+  deadline, response-sink backpressure, and terminal-state scenarios. A sink
+  write failure is terminal: preserve it for orchestration and reject every
+  later provider write or close without sending a competing completion.
 
 ## CLI run and submit command contracts
 

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -17,6 +17,14 @@ primary-result behavior.
   package's observed numeric floor and the wrapper package's documented
   measurement exception when it has no executable statements. Verify both with
   `make test-unit-coverage` and `make test-functional-coverage`.
+- The customer-implementable provider inference contract lives in
+  `pkg/services/workers/provider/inferencecontract/`. Invoke implementations
+  through `ExecuteInvocation` so provider-authored drafts are validated for
+  provenance, invocation and item correlation, lifecycle ordering, terminal
+  result agreement, and exactly-once close before they reach orchestration.
+  Keep this boundary provider-neutral and test it with deterministic writers;
+  Factory Session publication identity, sequencing, retention, and replay stay
+  outside this package.
 
 ## CLI run and submit command contracts
 

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -31,7 +31,10 @@ primary-result behavior.
   `inferencecontract/testkit.RunAdverse` for normalized failure, cancellation,
   deadline, response-sink backpressure, and terminal-state scenarios. A sink
   write failure is terminal: preserve it for orchestration and reject every
-  later provider write or close without sending a competing completion.
+  later provider write or close without sending a competing completion. Once
+  an authoritative completed message represents success, reject a later
+  failure completion and discard the buffered terminal tail so orchestration
+  observes neither side of a contradictory outcome.
 
 ## CLI run and submit command contracts
 

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -24,7 +24,10 @@ primary-result behavior.
   result agreement, and exactly-once close before they reach orchestration.
   Keep this boundary provider-neutral and test it with deterministic writers;
   Factory Session publication identity, sequencing, retention, and replay stay
-  outside this package.
+  outside this package. Customer integrations can reuse
+  `inferencecontract/testkit.Run` with fresh factories for final-only,
+  streaming, and tool-lifecycle modes; pass at least two opaque identities so
+  conformance never depends on a built-in provider name.
 
 ## CLI run and submit command contracts
 

--- a/pkg/services/factory_runtime/internal/orchestrators/javascript/runtime/host_pipeline_policy_test.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/javascript/runtime/host_pipeline_policy_test.go
@@ -48,16 +48,6 @@ func peakConcurrentChildRunning(records []factory.JavaScriptRuntimeRecord) int {
 	return peak
 }
 
-func childCompletionOrder(records []factory.JavaScriptRuntimeRecord) []string {
-	var order []string
-	for _, record := range records {
-		if record.Kind == factory.JavaScriptRecordKindChildDispatch && record.ChildDispatch != nil && record.ChildDispatch.Status == factory.JavaScriptChildDispatchStatusCompleted && record.ChildDispatch.Label != "" {
-			order = append(order, record.ChildDispatch.Label)
-		}
-	}
-	return order
-}
-
 func hasChildDispatchStatus(records []factory.JavaScriptRuntimeRecord, status string) bool {
 	for _, record := range records {
 		if record.Kind == factory.JavaScriptRecordKindChildDispatch && record.ChildDispatch != nil && record.ChildDispatch.Status == status {
@@ -548,13 +538,6 @@ func TestRun_ParallelFakeChildren_PreservesInputOrderAndConcurrency(t *testing.T
 	assertParallelResultOrder(t, req.SessionID, first, wantLabels)
 	if peak := peakConcurrentChildRunning(first.Records); peak > policy.Concurrency {
 		t.Fatalf("peak concurrent running children = %d, want <= %d", peak, policy.Concurrency)
-	}
-	completion := childCompletionOrder(first.Records)
-	if len(completion) != len(wantLabels) {
-		t.Fatalf("completion order = %#v, want %d children", completion, len(wantLabels))
-	}
-	if completion[0] == wantLabels[0] && completion[len(completion)-1] == wantLabels[len(wantLabels)-1] {
-		t.Fatalf("completion order %#v matched input order; want differing completion order", completion)
 	}
 
 	if string(first.Value.JSON) != string(second.Value.JSON) {

--- a/pkg/services/workers/provider/inferencecontract/contract.go
+++ b/pkg/services/workers/provider/inferencecontract/contract.go
@@ -10,6 +10,9 @@ import (
 )
 
 // Provider performs one inference request against an external model provider.
+//
+// Deprecated: Provider is the runtime port implemented by the repository's
+// built-in adapters. New provider integrations should implement Integration.
 type Provider interface {
 	Infer(context.Context, workers.ProviderInferenceRequest) (workers.InferenceResponse, error)
 }

--- a/pkg/services/workers/provider/inferencecontract/integration.go
+++ b/pkg/services/workers/provider/inferencecontract/integration.go
@@ -1,0 +1,381 @@
+package inferencecontract
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"slices"
+
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+)
+
+// Identity is an opaque, stable provider integration identity.
+type Identity string
+
+// Capability is one provider-neutral execution or response-fidelity feature.
+type Capability string
+
+const (
+	CapabilityPromptSubmission   Capability = "prompt_submission"
+	CapabilityImageInput         Capability = "image_input"
+	CapabilitySessionResume      Capability = "session_resume"
+	CapabilityStructuredOutput   Capability = "structured_output"
+	CapabilityNativeStreaming    Capability = "native_streaming"
+	CapabilityMessageDeltas      Capability = "message_deltas"
+	CapabilityMessageSnapshots   Capability = "message_snapshots"
+	CapabilityReasoningSummaries Capability = "reasoning_summaries"
+	CapabilityToolLifecycle      Capability = "tool_lifecycle"
+	CapabilityToolOutputDeltas   Capability = "tool_output_deltas"
+	CapabilityFileChanges        Capability = "file_changes"
+	CapabilityPlans              Capability = "plans"
+	CapabilityUsage              Capability = "usage"
+	CapabilityStableItemIDs      Capability = "stable_item_ids"
+	CapabilityProviderReconnect  Capability = "provider_reconnect"
+)
+
+// CapabilitySet is an immutable set of provider-neutral capabilities.
+type CapabilitySet struct {
+	values []Capability
+}
+
+// NewCapabilitySet creates a detached capability set. Duplicate capabilities
+// are collapsed while preserving their first declaration order.
+func NewCapabilitySet(values ...Capability) CapabilitySet {
+	seen := make(map[Capability]struct{}, len(values))
+	detached := make([]Capability, 0, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		detached = append(detached, value)
+	}
+	return CapabilitySet{values: detached}
+}
+
+// Values returns a detached copy of the declared capabilities.
+func (c CapabilitySet) Values() []Capability {
+	return slices.Clone(c.values)
+}
+
+// Has reports whether the set contains capability.
+func (c CapabilitySet) Has(capability Capability) bool {
+	return slices.Contains(c.values, capability)
+}
+
+// Readiness identifies the current provider availability outcome.
+type Readiness string
+
+const (
+	ReadinessReady       Readiness = "ready"
+	ReadinessUnavailable Readiness = "unavailable"
+	ReadinessDegraded    Readiness = "degraded"
+)
+
+// PrerequisiteKind identifies a sanitized requirement for provider readiness.
+type PrerequisiteKind string
+
+const (
+	PrerequisiteConfiguration PrerequisiteKind = "configuration"
+	PrerequisiteCredential    PrerequisiteKind = "credential"
+	PrerequisiteDependency    PrerequisiteKind = "dependency"
+)
+
+// PrerequisiteStatus identifies whether a provider prerequisite is satisfied.
+type PrerequisiteStatus string
+
+const (
+	PrerequisiteSatisfied PrerequisiteStatus = "satisfied"
+	PrerequisiteMissing   PrerequisiteStatus = "missing"
+)
+
+// Prerequisite is a provider-neutral readiness requirement. Description is
+// intended for bounded setup guidance, never raw environment or native output.
+type Prerequisite struct {
+	kind        PrerequisiteKind
+	name        string
+	status      PrerequisiteStatus
+	description string
+}
+
+// NewPrerequisite constructs one immutable readiness requirement.
+func NewPrerequisite(kind PrerequisiteKind, name string, status PrerequisiteStatus, description string) Prerequisite {
+	return Prerequisite{kind: kind, name: name, status: status, description: description}
+}
+
+func (p Prerequisite) Kind() PrerequisiteKind     { return p.kind }
+func (p Prerequisite) Name() string               { return p.name }
+func (p Prerequisite) Status() PrerequisiteStatus { return p.status }
+func (p Prerequisite) Description() string        { return p.description }
+
+// Discovery is an immutable, provider-neutral readiness report.
+type Discovery struct {
+	readiness     Readiness
+	prerequisites []Prerequisite
+}
+
+// NewDiscovery constructs a detached readiness report.
+func NewDiscovery(readiness Readiness, prerequisites ...Prerequisite) Discovery {
+	return Discovery{readiness: readiness, prerequisites: slices.Clone(prerequisites)}
+}
+
+func (d Discovery) Readiness() Readiness { return d.readiness }
+
+// Prerequisites returns a detached copy of the readiness requirements.
+func (d Discovery) Prerequisites() []Prerequisite { return slices.Clone(d.prerequisites) }
+
+// ProviderSession is optional generic provider-owned session metadata.
+type ProviderSession struct {
+	provider string
+	kind     string
+	id       string
+	metadata map[string]string
+}
+
+// NewProviderSession creates detached provider-session metadata.
+func NewProviderSession(provider, kind, id string, metadata map[string]string) ProviderSession {
+	return ProviderSession{provider: provider, kind: kind, id: id, metadata: maps.Clone(metadata)}
+}
+
+func (s ProviderSession) Provider() string { return s.provider }
+func (s ProviderSession) Kind() string     { return s.kind }
+func (s ProviderSession) ID() string       { return s.id }
+
+// Metadata returns a detached copy of generic provider-session metadata.
+func (s ProviderSession) Metadata() map[string]string { return maps.Clone(s.metadata) }
+
+// InvocationInput contains provider-neutral authored inference content.
+type InvocationInput struct {
+	InvocationID    string
+	Model           string
+	SystemPrompt    string
+	UserMessage     string
+	OutputSchema    string
+	Required        CapabilitySet
+	ProviderSession *ProviderSession
+}
+
+// InvocationRequest is an immutable provider invocation request.
+type InvocationRequest struct {
+	invocationID    string
+	model           string
+	systemPrompt    string
+	userMessage     string
+	outputSchema    string
+	required        CapabilitySet
+	providerSession *ProviderSession
+}
+
+// NewInvocationRequest detaches all mutable input from the caller.
+func NewInvocationRequest(input InvocationInput) InvocationRequest {
+	return InvocationRequest{
+		invocationID:    input.InvocationID,
+		model:           input.Model,
+		systemPrompt:    input.SystemPrompt,
+		userMessage:     input.UserMessage,
+		outputSchema:    input.OutputSchema,
+		required:        NewCapabilitySet(input.Required.Values()...),
+		providerSession: cloneProviderSession(input.ProviderSession),
+	}
+}
+
+func (r InvocationRequest) InvocationID() string { return r.invocationID }
+func (r InvocationRequest) Model() string        { return r.model }
+func (r InvocationRequest) SystemPrompt() string { return r.systemPrompt }
+func (r InvocationRequest) UserMessage() string  { return r.userMessage }
+func (r InvocationRequest) OutputSchema() string { return r.outputSchema }
+func (r InvocationRequest) RequiredCapabilities() CapabilitySet {
+	return NewCapabilitySet(r.required.Values()...)
+}
+func (r InvocationRequest) ProviderSession() *ProviderSession {
+	return cloneProviderSession(r.providerSession)
+}
+
+// FailureKind is a provider-neutral invocation failure category.
+type FailureKind string
+
+const (
+	FailureAuthentication  FailureKind = "authentication"
+	FailureInvalidRequest  FailureKind = "invalid_request"
+	FailureThrottled       FailureKind = "throttled"
+	FailureTimeout         FailureKind = "timeout"
+	FailureCanceled        FailureKind = "canceled"
+	FailureDependency      FailureKind = "dependency"
+	FailureMalformedOutput FailureKind = "malformed_output"
+	FailureUnknown         FailureKind = "unknown"
+)
+
+// FailureInput contains normalized, customer-safe failure facts.
+type FailureInput struct {
+	Kind            FailureKind
+	Message         string
+	Retryable       bool
+	ProviderSession *ProviderSession
+	Diagnostics     map[string]string
+}
+
+// Failure is an immutable normalized provider failure.
+type Failure struct {
+	kind            FailureKind
+	message         string
+	retryable       bool
+	providerSession *ProviderSession
+	diagnostics     map[string]string
+}
+
+// NewFailure creates a detached normalized provider failure.
+func NewFailure(input FailureInput) Failure {
+	return Failure{
+		kind:            input.Kind,
+		message:         input.Message,
+		retryable:       input.Retryable,
+		providerSession: cloneProviderSession(input.ProviderSession),
+		diagnostics:     maps.Clone(input.Diagnostics),
+	}
+}
+
+func (f Failure) Kind() FailureKind                 { return f.kind }
+func (f Failure) Message() string                   { return f.message }
+func (f Failure) Retryable() bool                   { return f.retryable }
+func (f Failure) ProviderSession() *ProviderSession { return cloneProviderSession(f.providerSession) }
+func (f Failure) Diagnostics() map[string]string    { return maps.Clone(f.diagnostics) }
+
+// ResponseInput contains the authoritative provider response.
+type ResponseInput struct {
+	Content         string
+	ProviderSession *ProviderSession
+	Metadata        map[string]string
+}
+
+// Response is an immutable authoritative provider response.
+type Response struct {
+	content         string
+	providerSession *ProviderSession
+	metadata        map[string]string
+}
+
+// NewResponse creates a detached authoritative response.
+func NewResponse(input ResponseInput) Response {
+	return Response{
+		content:         input.Content,
+		providerSession: cloneProviderSession(input.ProviderSession),
+		metadata:        maps.Clone(input.Metadata),
+	}
+}
+
+func (r Response) Content() string                   { return r.content }
+func (r Response) ProviderSession() *ProviderSession { return cloneProviderSession(r.providerSession) }
+func (r Response) Metadata() map[string]string       { return maps.Clone(r.metadata) }
+
+// Completion contains one authoritative response or normalized failure.
+// SuccessfulCompletion and FailedCompletion construct the valid outcomes;
+// protocol validation rejects the empty zero value.
+type Completion struct {
+	response *Response
+	failure  *Failure
+}
+
+// SuccessfulCompletion constructs a successful terminal outcome.
+func SuccessfulCompletion(response Response) Completion {
+	clone := NewResponse(ResponseInput{
+		Content:         response.Content(),
+		ProviderSession: response.ProviderSession(),
+		Metadata:        response.Metadata(),
+	})
+	return Completion{response: &clone}
+}
+
+// FailedCompletion constructs a failed terminal outcome.
+func FailedCompletion(failure Failure) Completion {
+	clone := NewFailure(FailureInput{
+		Kind:            failure.Kind(),
+		Message:         failure.Message(),
+		Retryable:       failure.Retryable(),
+		ProviderSession: failure.ProviderSession(),
+		Diagnostics:     failure.Diagnostics(),
+	})
+	return Completion{failure: &clone}
+}
+
+func (c Completion) Response() *Response {
+	if c.response == nil {
+		return nil
+	}
+	clone := SuccessfulCompletion(*c.response)
+	return clone.response
+}
+
+func (c Completion) Failure() *Failure {
+	if c.failure == nil {
+		return nil
+	}
+	clone := FailedCompletion(*c.failure)
+	return clone.failure
+}
+
+// EventDraftInput contains the provider-writable portion of the Workers-owned
+// response-event draft vocabulary. Factory Session identity, dispatch identity,
+// publication sequence, timestamps, and replay gaps are intentionally absent.
+type EventDraftInput struct {
+	RunID              string
+	Kind               workers.Kind
+	Phase              workers.Phase
+	Provenance         workers.Provenance
+	Payload            []byte
+	TurnID             string
+	ItemID             string
+	ParentItemID       string
+	ProviderSessionRef string
+}
+
+// EventDraft is an immutable provider-owned semantic response-event draft.
+type EventDraft struct {
+	draft workers.Draft
+}
+
+// NewEventDraft constructs a detached semantic draft. STREAM_GAP is reserved
+// for Factory Session publication and cannot be authored by a provider.
+func NewEventDraft(input EventDraftInput) (EventDraft, error) {
+	if input.Kind == workers.KindStreamGap {
+		return EventDraft{}, errors.New("STREAM_GAP is reserved for Factory Session publication")
+	}
+	return EventDraft{draft: workers.CloneDraft(workers.Draft{
+		RunID:              input.RunID,
+		Kind:               input.Kind,
+		Phase:              input.Phase,
+		Provenance:         input.Provenance,
+		Payload:            input.Payload,
+		TurnID:             input.TurnID,
+		ItemID:             input.ItemID,
+		ParentItemID:       input.ParentItemID,
+		ProviderSessionRef: input.ProviderSessionRef,
+	})}, nil
+}
+
+// Draft returns a detached Workers-owned semantic draft for orchestration.
+func (e EventDraft) Draft() workers.Draft { return workers.CloneDraft(e.draft) }
+
+// ResponseWriter accepts provider-owned semantic drafts and one authoritative
+// completion. Factory Session envelopes, publication order, and retention are
+// deliberately outside this contract.
+type ResponseWriter interface {
+	WriteEvent(context.Context, EventDraft) error
+	Close(context.Context, Completion) error
+}
+
+// Integration is the single customer-implementable provider protocol.
+type Integration interface {
+	Identity() Identity
+	MaximumCapabilities() CapabilitySet
+	Discover(context.Context) (Discovery, error)
+	Capabilities(context.Context, InvocationRequest) (CapabilitySet, error)
+	Invoke(context.Context, InvocationRequest, ResponseWriter) error
+}
+
+func cloneProviderSession(session *ProviderSession) *ProviderSession {
+	if session == nil {
+		return nil
+	}
+	clone := NewProviderSession(session.Provider(), session.Kind(), session.ID(), session.Metadata())
+	return &clone
+}

--- a/pkg/services/workers/provider/inferencecontract/integration_test.go
+++ b/pkg/services/workers/provider/inferencecontract/integration_test.go
@@ -1,0 +1,244 @@
+package inferencecontract_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	contract "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+)
+
+type deterministicIntegration struct {
+	identity contract.Identity
+}
+
+func (p deterministicIntegration) Identity() contract.Identity { return p.identity }
+
+func (p deterministicIntegration) MaximumCapabilities() contract.CapabilitySet {
+	return contract.NewCapabilitySet(
+		contract.CapabilityPromptSubmission,
+		contract.CapabilityMessageSnapshots,
+	)
+}
+
+func (p deterministicIntegration) Discover(context.Context) (contract.Discovery, error) {
+	return contract.NewDiscovery(
+		contract.ReadinessReady,
+		contract.NewPrerequisite(
+			contract.PrerequisiteConfiguration,
+			"provider configuration",
+			contract.PrerequisiteSatisfied,
+			"provider configuration is available",
+		),
+	), nil
+}
+
+func (p deterministicIntegration) Capabilities(
+	_ context.Context,
+	request contract.InvocationRequest,
+) (contract.CapabilitySet, error) {
+	if request.RequiredCapabilities().Has(contract.CapabilityMessageSnapshots) {
+		return p.MaximumCapabilities(), nil
+	}
+	return contract.NewCapabilitySet(contract.CapabilityPromptSubmission), nil
+}
+
+func (p deterministicIntegration) Invoke(
+	ctx context.Context,
+	request contract.InvocationRequest,
+	writer contract.ResponseWriter,
+) error {
+	payload, err := json.Marshal(workers.MessagePayload{
+		Role: "assistant",
+		ContentBlocks: []workers.ContentBlock{{
+			Kind: workers.ContentBlockText,
+			Text: "response for " + request.UserMessage(),
+		}},
+	})
+	if err != nil {
+		return err
+	}
+	draft, err := contract.NewEventDraft(contract.EventDraftInput{
+		RunID:   request.InvocationID(),
+		Kind:    workers.KindMessage,
+		Phase:   workers.PhaseCompleted,
+		Payload: payload,
+		Provenance: workers.Provenance{
+			Delivery:        workers.DeliveryNativeFinal,
+			Fidelity:        workers.FidelityFinalOnly,
+			NativeEventType: "completion",
+			Provider:        string(p.identity),
+			Representation:  workers.RepresentationSnapshot,
+		},
+		ItemID: "message-1",
+	})
+	if err != nil {
+		return err
+	}
+	if err := writer.WriteEvent(ctx, draft); err != nil {
+		return err
+	}
+	sessionMetadata := map[string]string{"region": "test-region"}
+	responseMetadata := map[string]string{"model": request.Model()}
+	session := contract.NewProviderSession(string(p.identity), "session_id", "session-1", sessionMetadata)
+	response := contract.NewResponse(contract.ResponseInput{
+		Content:         "response for " + request.UserMessage(),
+		ProviderSession: &session,
+		Metadata:        responseMetadata,
+	})
+	sessionMetadata["region"] = "mutated-after-return"
+	responseMetadata["model"] = "mutated-after-return"
+	return writer.Close(ctx, contract.SuccessfulCompletion(response))
+}
+
+type recordingWriter struct {
+	drafts     []contract.EventDraft
+	completion *contract.Completion
+	closes     int
+}
+
+func (w *recordingWriter) WriteEvent(_ context.Context, draft contract.EventDraft) error {
+	w.drafts = append(w.drafts, draft)
+	return nil
+}
+
+func (w *recordingWriter) Close(_ context.Context, completion contract.Completion) error {
+	w.closes++
+	w.completion = &completion
+	return nil
+}
+
+func TestIntegrationContractIsIdentityOpaque(t *testing.T) {
+	t.Parallel()
+
+	for _, identity := range []contract.Identity{"acme.alpha", "customer-provider-42"} {
+		identity := identity
+		t.Run(string(identity), func(t *testing.T) {
+			t.Parallel()
+			assertSuccessfulIntegration(t, deterministicIntegration{identity: identity})
+		})
+	}
+}
+
+func assertSuccessfulIntegration(t *testing.T, integration contract.Integration) {
+	t.Helper()
+	ctx := context.Background()
+	assertDiscovery(t, ctx, integration)
+	request := newFixtureRequest()
+	assertNegotiatedCapabilities(t, ctx, integration, request)
+
+	writer := &recordingWriter{}
+	if err := integration.Invoke(ctx, request, writer); err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	assertDraft(t, writer)
+	assertCompletion(t, integration.Identity(), writer)
+}
+
+func assertDiscovery(t *testing.T, ctx context.Context, integration contract.Integration) {
+	t.Helper()
+	discovery, err := integration.Discover(ctx)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if discovery.Readiness() != contract.ReadinessReady {
+		t.Fatalf("readiness = %q, want %q", discovery.Readiness(), contract.ReadinessReady)
+	}
+	prerequisites := discovery.Prerequisites()
+	if len(prerequisites) != 1 || prerequisites[0].Status() != contract.PrerequisiteSatisfied {
+		t.Fatalf("prerequisites = %#v, want one satisfied prerequisite", prerequisites)
+	}
+}
+
+func newFixtureRequest() contract.InvocationRequest {
+	return contract.NewInvocationRequest(contract.InvocationInput{
+		InvocationID: "invocation-1",
+		Model:        "test-model",
+		UserMessage:  "hello",
+		Required:     contract.NewCapabilitySet(contract.CapabilityMessageSnapshots),
+	})
+}
+
+func assertNegotiatedCapabilities(
+	t *testing.T,
+	ctx context.Context,
+	integration contract.Integration,
+	request contract.InvocationRequest,
+) {
+	t.Helper()
+	capabilities, err := integration.Capabilities(ctx, request)
+	if err != nil {
+		t.Fatalf("negotiate capabilities: %v", err)
+	}
+	if !capabilities.Has(contract.CapabilityMessageSnapshots) {
+		t.Fatalf("capabilities = %v, want message snapshots", capabilities.Values())
+	}
+}
+
+func assertDraft(t *testing.T, writer *recordingWriter) {
+	t.Helper()
+	if writer.closes != 1 || writer.completion == nil {
+		t.Fatalf("close count = %d, want exactly one completion", writer.closes)
+	}
+	if len(writer.drafts) != 1 {
+		t.Fatalf("draft count = %d, want 1", len(writer.drafts))
+	}
+	draft := writer.drafts[0].Draft()
+	if draft.Kind != workers.KindMessage || draft.Phase != workers.PhaseCompleted {
+		t.Fatalf("draft = %#v, want completed message", draft)
+	}
+	if draft.DispatchID != "" {
+		t.Fatalf("dispatch ID = %q, want provider draft without Factory-owned identity", draft.DispatchID)
+	}
+}
+
+func assertCompletion(t *testing.T, identity contract.Identity, writer *recordingWriter) {
+	t.Helper()
+	response := writer.completion.Response()
+	if response == nil || writer.completion.Failure() != nil {
+		t.Fatalf("completion = %#v, want response only", writer.completion)
+	}
+	if response.Content() != "response for hello" {
+		t.Fatalf("response content = %q", response.Content())
+	}
+	session := response.ProviderSession()
+	if session == nil || session.Provider() != string(identity) {
+		t.Fatalf("provider session = %#v, want provider %q", session, identity)
+	}
+	if got := session.Metadata()["region"]; got != "test-region" {
+		t.Fatalf("session region = %q, want detached test-region", got)
+	}
+	if got := response.Metadata()["model"]; got != "test-model" {
+		t.Fatalf("response model = %q, want detached test-model", got)
+	}
+}
+
+func TestEventDraftRejectsFactoryOwnedStreamGap(t *testing.T) {
+	t.Parallel()
+
+	_, err := contract.NewEventDraft(contract.EventDraftInput{Kind: workers.KindStreamGap})
+	if err == nil {
+		t.Fatal("expected STREAM_GAP draft to be rejected")
+	}
+}
+
+func TestImmutableContractValuesReturnDetachedCollections(t *testing.T) {
+	t.Parallel()
+
+	capabilities := contract.NewCapabilitySet(contract.CapabilityPromptSubmission)
+	values := capabilities.Values()
+	values[0] = contract.CapabilityUsage
+	if !capabilities.Has(contract.CapabilityPromptSubmission) {
+		t.Fatalf("capabilities changed through returned values: %v", capabilities.Values())
+	}
+
+	metadata := map[string]string{"scope": "original"}
+	session := contract.NewProviderSession("opaque-provider", "session", "one", metadata)
+	metadata["scope"] = "changed"
+	returned := session.Metadata()
+	returned["scope"] = "changed-again"
+	if got := session.Metadata()["scope"]; got != "original" {
+		t.Fatalf("session metadata = %q, want detached original", got)
+	}
+}

--- a/pkg/services/workers/provider/inferencecontract/protocol.go
+++ b/pkg/services/workers/provider/inferencecontract/protocol.go
@@ -84,6 +84,8 @@ func (w *protocolWriter) WriteEvent(ctx context.Context, event EventDraft) error
 	}
 	draft := event.Draft()
 	if err := w.validateDraft(draft); err != nil {
+		w.closed = true
+		w.terminalErr = err
 		return err
 	}
 	if w.bufferTerminalTail || beginsTerminalTail(draft) {

--- a/pkg/services/workers/provider/inferencecontract/protocol.go
+++ b/pkg/services/workers/provider/inferencecontract/protocol.go
@@ -287,6 +287,9 @@ func (w *protocolWriter) validateCompletion(completion Completion) error {
 		return protocolError("completion_outcome", "completion requires exactly one response or failure")
 	}
 	if failure != nil {
+		if w.hasFinalMessage {
+			return protocolError("final_result_agreement", "completed message content cannot be followed by an authoritative failure")
+		}
 		return ValidateFailure(*failure)
 	}
 	for _, state := range w.lifecycles {

--- a/pkg/services/workers/provider/inferencecontract/protocol.go
+++ b/pkg/services/workers/provider/inferencecontract/protocol.go
@@ -62,6 +62,7 @@ type protocolWriter struct {
 	lifecycles         map[string]lifecycleState
 	finalMessage       string
 	hasFinalMessage    bool
+	terminalErr        error
 }
 
 func newProtocolWriter(invocationID string, provider Identity, destination ResponseWriter) *protocolWriter {
@@ -77,7 +78,9 @@ func (w *protocolWriter) WriteEvent(ctx context.Context, event EventDraft) error
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.closed {
-		return protocolError("write_after_close", "response event cannot be written after completion")
+		err := protocolError("write_after_close", "response event cannot be written after completion")
+		w.terminalErr = errors.Join(w.terminalErr, err)
+		return err
 	}
 	draft := event.Draft()
 	if err := w.validateDraft(draft); err != nil {
@@ -88,7 +91,12 @@ func (w *protocolWriter) WriteEvent(ctx context.Context, event EventDraft) error
 		w.terminalBuffer = append(w.terminalBuffer, event)
 		return nil
 	}
-	return w.destination.WriteEvent(ctx, event)
+	if err := w.destination.WriteEvent(ctx, event); err != nil {
+		w.closed = true
+		w.terminalErr = err
+		return err
+	}
+	return nil
 }
 
 func (w *protocolWriter) Close(ctx context.Context, completion Completion) error {
@@ -99,25 +107,36 @@ func (w *protocolWriter) Close(ctx context.Context, completion Completion) error
 
 func (w *protocolWriter) closeLocked(ctx context.Context, completion Completion) error {
 	if w.closed {
-		return protocolError("duplicate_close", "response completion may be closed exactly once")
+		err := protocolError("duplicate_close", "response completion may be closed exactly once")
+		w.terminalErr = errors.Join(w.terminalErr, err)
+		return err
 	}
 	w.closed = true
 	if err := w.validateCompletion(completion); err != nil {
+		w.terminalErr = err
 		return err
 	}
 	for _, event := range w.terminalBuffer {
 		if err := w.destination.WriteEvent(ctx, event); err != nil {
+			w.terminalErr = err
 			return err
 		}
 	}
-	return w.destination.Close(ctx, completion)
+	if err := w.destination.Close(ctx, completion); err != nil {
+		w.terminalErr = err
+		return err
+	}
+	return nil
 }
 
 func (w *protocolWriter) finish(ctx context.Context, invokeErr error) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.closed {
-		return invokeErr
+		if invokeErr == nil || errors.Is(invokeErr, w.terminalErr) {
+			return w.terminalErr
+		}
+		return errors.Join(invokeErr, w.terminalErr)
 	}
 	if invokeErr != nil {
 		closeErr := w.closeLocked(ctx, FailedCompletion(normalizeInvocationError(ctx, invokeErr)))

--- a/pkg/services/workers/provider/inferencecontract/protocol.go
+++ b/pkg/services/workers/provider/inferencecontract/protocol.go
@@ -1,0 +1,319 @@
+package inferencecontract
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+)
+
+const maxEventPayloadBytes = 64 * 1024
+
+// ProtocolError identifies a provider violation of the invocation lifecycle.
+type ProtocolError struct {
+	Rule    string
+	message string
+}
+
+func (e *ProtocolError) Error() string { return e.message }
+
+func protocolError(rule, message string) error {
+	return &ProtocolError{Rule: rule, message: message}
+}
+
+// ExecuteInvocation invokes an integration through a validating response
+// writer. The destination receives only ordered, correlated drafts followed by
+// at most one authoritative completion.
+func ExecuteInvocation(
+	ctx context.Context,
+	integration Integration,
+	request InvocationRequest,
+	destination ResponseWriter,
+) error {
+	if integration == nil {
+		return protocolError("integration", "provider integration is required")
+	}
+	if destination == nil {
+		return protocolError("destination", "response destination is required")
+	}
+	writer := newProtocolWriter(request.InvocationID(), integration.Identity(), destination)
+	invokeErr := integration.Invoke(ctx, request, writer)
+	return writer.finish(ctx, invokeErr)
+}
+
+type lifecycleState struct {
+	started  bool
+	terminal bool
+	toolName string
+}
+
+type protocolWriter struct {
+	mu                 sync.Mutex
+	destination        ResponseWriter
+	invocationID       string
+	provider           Identity
+	closed             bool
+	terminalBuffer     []EventDraft
+	bufferTerminalTail bool
+	lifecycles         map[string]lifecycleState
+	finalMessage       string
+	hasFinalMessage    bool
+}
+
+func newProtocolWriter(invocationID string, provider Identity, destination ResponseWriter) *protocolWriter {
+	return &protocolWriter{
+		destination:  destination,
+		invocationID: invocationID,
+		provider:     provider,
+		lifecycles:   make(map[string]lifecycleState),
+	}
+}
+
+func (w *protocolWriter) WriteEvent(ctx context.Context, event EventDraft) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return protocolError("write_after_close", "response event cannot be written after completion")
+	}
+	draft := event.Draft()
+	if err := w.validateDraft(draft); err != nil {
+		return err
+	}
+	if w.bufferTerminalTail || beginsTerminalTail(draft) {
+		w.bufferTerminalTail = true
+		w.terminalBuffer = append(w.terminalBuffer, event)
+		return nil
+	}
+	return w.destination.WriteEvent(ctx, event)
+}
+
+func (w *protocolWriter) Close(ctx context.Context, completion Completion) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.closeLocked(ctx, completion)
+}
+
+func (w *protocolWriter) closeLocked(ctx context.Context, completion Completion) error {
+	if w.closed {
+		return protocolError("duplicate_close", "response completion may be closed exactly once")
+	}
+	w.closed = true
+	if err := w.validateCompletion(completion); err != nil {
+		return err
+	}
+	for _, event := range w.terminalBuffer {
+		if err := w.destination.WriteEvent(ctx, event); err != nil {
+			return err
+		}
+	}
+	return w.destination.Close(ctx, completion)
+}
+
+func (w *protocolWriter) finish(ctx context.Context, invokeErr error) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return invokeErr
+	}
+	if invokeErr != nil {
+		closeErr := w.closeLocked(ctx, FailedCompletion(normalizeInvocationError(ctx, invokeErr)))
+		return errors.Join(invokeErr, closeErr)
+	}
+	missingClose := protocolError("missing_close", "provider invocation returned without closing the response")
+	closeErr := w.closeLocked(ctx, FailedCompletion(NewFailure(FailureInput{
+		Kind:    FailureMalformedOutput,
+		Message: "provider invocation completed without a response",
+	})))
+	return errors.Join(missingClose, closeErr)
+}
+
+func (w *protocolWriter) validateDraft(draft workers.Draft) error {
+	if len(draft.Payload) > maxEventPayloadBytes {
+		return protocolError("payload_bound", fmt.Sprintf("response event payload exceeds %d bytes", maxEventPayloadBytes))
+	}
+	if err := workers.ValidateDraft(draft); err != nil {
+		return protocolError("draft", fmt.Sprintf("invalid response event draft: %v", err))
+	}
+	if draft.Kind == workers.KindStreamGap {
+		return protocolError("draft_kind", "STREAM_GAP is reserved for Factory Session publication")
+	}
+	if draft.RunID != w.invocationID {
+		return protocolError("invocation_correlation", "response event run ID must match the invocation ID")
+	}
+	if err := w.validateProvenance(draft.Provenance); err != nil {
+		return err
+	}
+	key, toolName, err := lifecycleKey(draft)
+	if err != nil {
+		return err
+	}
+	if key != "" {
+		if err := w.advanceLifecycle(key, toolName, draft.Kind, draft.Phase); err != nil {
+			return err
+		}
+	}
+	if draft.Kind == workers.KindMessage && draft.Phase == workers.PhaseCompleted {
+		content, represented, err := authoritativeMessageContent(draft.Payload)
+		if err != nil {
+			return err
+		}
+		if represented {
+			w.finalMessage = content
+			w.hasFinalMessage = true
+		}
+	}
+	return nil
+}
+
+func (w *protocolWriter) validateProvenance(provenance workers.Provenance) error {
+	if provenance.Provider != string(w.provider) {
+		return protocolError("provenance_provider", "response event provider must match the integration identity")
+	}
+	if provenance.Delivery != workers.DeliveryNativeStream && provenance.Delivery != workers.DeliveryNativeFinal &&
+		provenance.Delivery != workers.DeliverySynthesized {
+		return protocolError("provenance_delivery", "response event has an invalid provider-writable delivery")
+	}
+	if provenance.Fidelity != workers.FidelityLossless && provenance.Fidelity != workers.FidelityNormalized &&
+		provenance.Fidelity != workers.FidelityLossy && provenance.Fidelity != workers.FidelityFinalOnly &&
+		provenance.Fidelity != workers.FidelityLifecycleOnly {
+		return protocolError("provenance_fidelity", "response event has an invalid fidelity")
+	}
+	if provenance.Representation != workers.RepresentationDelta && provenance.Representation != workers.RepresentationSnapshot &&
+		provenance.Representation != workers.RepresentationNotification {
+		return protocolError("provenance_representation", "response event has an invalid representation")
+	}
+	if err := validatePublicText("event.provenance.nativeEventType", provenance.NativeEventType, maxDiagnosticValueLength); err != nil {
+		return err
+	}
+	return nil
+}
+
+func lifecycleKey(draft workers.Draft) (string, string, error) {
+	switch draft.Kind {
+	case workers.KindSession:
+		return requiredCorrelation("session", draft.ProviderSessionRef)
+	case workers.KindRun:
+		return "run:" + draft.RunID, "", nil
+	case workers.KindTurn:
+		return requiredCorrelation("turn", draft.TurnID)
+	case workers.KindMessage, workers.KindReasoning:
+		return requiredCorrelation(strings.ToLower(string(draft.Kind)), draft.ItemID)
+	case workers.KindTool:
+		return toolCorrelation(draft)
+	default:
+		return "", "", nil
+	}
+}
+
+func requiredCorrelation(kind, value string) (string, string, error) {
+	if strings.TrimSpace(value) == "" {
+		return "", "", protocolError("event_correlation", kind+" lifecycle requires stable correlation")
+	}
+	return kind + ":" + value, "", nil
+}
+
+func toolCorrelation(draft workers.Draft) (string, string, error) {
+	if draft.Phase == workers.PhaseDelta {
+		var payload workers.ToolDeltaPayload
+		if err := json.Unmarshal(draft.Payload, &payload); err != nil {
+			return "", "", protocolError("tool_payload", "tool delta payload could not be decoded")
+		}
+		return "tool:" + payload.ToolCallID, "", nil
+	}
+	var payload workers.ToolPayload
+	if err := json.Unmarshal(draft.Payload, &payload); err != nil {
+		return "", "", protocolError("tool_payload", "tool payload could not be decoded")
+	}
+	return "tool:" + payload.ToolCallID, payload.ToolName, nil
+}
+
+func (w *protocolWriter) advanceLifecycle(key, toolName string, kind workers.Kind, phase workers.Phase) error {
+	state := w.lifecycles[key]
+	switch phase {
+	case workers.PhaseStarted:
+		if state.started || state.terminal {
+			return protocolError("duplicate_start", "response event lifecycle may start only once")
+		}
+		state.started = true
+		state.toolName = toolName
+	case workers.PhaseDelta:
+		if !state.started || state.terminal {
+			return protocolError("update_before_start", "response event update requires an active lifecycle")
+		}
+	case workers.PhaseCompleted, workers.PhaseFailed, workers.PhaseCanceled:
+		if state.terminal {
+			return protocolError("duplicate_terminal", "response event lifecycle may terminate only once")
+		}
+		if !state.started && !(kind == workers.KindMessage && phase == workers.PhaseCompleted) {
+			return protocolError("terminal_before_start", "response event terminal phase requires a start")
+		}
+		if kind == workers.KindTool && state.toolName != toolName {
+			return protocolError("tool_correlation", "tool name must remain stable for one tool correlation")
+		}
+		state.terminal = true
+	}
+	w.lifecycles[key] = state
+	return nil
+}
+
+func (w *protocolWriter) validateCompletion(completion Completion) error {
+	response, failure := completion.Response(), completion.Failure()
+	if (response == nil) == (failure == nil) {
+		return protocolError("completion_outcome", "completion requires exactly one response or failure")
+	}
+	if failure != nil {
+		return ValidateFailure(*failure)
+	}
+	for _, state := range w.lifecycles {
+		if state.started && !state.terminal {
+			return protocolError("incomplete_lifecycle", "completion requires every started event lifecycle to terminate")
+		}
+	}
+	if strings.TrimSpace(response.Content()) == "" {
+		return protocolError("response_content", "authoritative response content is required")
+	}
+	if w.hasFinalMessage && w.finalMessage != response.Content() {
+		return protocolError("final_result_agreement", "completed message content must agree with the authoritative response")
+	}
+	return nil
+}
+
+func authoritativeMessageContent(payload []byte) (string, bool, error) {
+	var message workers.MessagePayload
+	if err := json.Unmarshal(payload, &message); err != nil {
+		return "", false, protocolError("message_payload", "completed message payload could not be decoded")
+	}
+	if !workers.IsAuthoritativeMessageSnapshot(message) {
+		return "", false, nil
+	}
+	var content strings.Builder
+	represented := false
+	for _, block := range message.ContentBlocks {
+		if block.Kind == workers.ContentBlockText {
+			content.WriteString(block.Text)
+			represented = true
+		}
+	}
+	return content.String(), represented, nil
+}
+
+func beginsTerminalTail(draft workers.Draft) bool {
+	return draft.Kind == workers.KindMessage && draft.Phase == workers.PhaseCompleted
+}
+
+func normalizeInvocationError(ctx context.Context, invokeErr error) Failure {
+	kind := FailureUnknown
+	message := "provider invocation failed"
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(invokeErr, context.DeadlineExceeded) {
+		kind = FailureTimeout
+		message = "provider invocation timed out"
+	} else if errors.Is(ctx.Err(), context.Canceled) || errors.Is(invokeErr, context.Canceled) {
+		kind = FailureCanceled
+		message = "provider invocation was canceled"
+	}
+	return NewFailure(FailureInput{Kind: kind, Message: message})
+}

--- a/pkg/services/workers/provider/inferencecontract/protocol.go
+++ b/pkg/services/workers/provider/inferencecontract/protocol.go
@@ -183,6 +183,9 @@ func (w *protocolWriter) validateDraft(draft workers.Draft) error {
 			return err
 		}
 		if represented {
+			if w.hasFinalMessage {
+				return protocolError("final_result_agreement", "only one completed message may represent the authoritative response")
+			}
 			w.finalMessage = content
 			w.hasFinalMessage = true
 		}

--- a/pkg/services/workers/provider/inferencecontract/protocol_test.go
+++ b/pkg/services/workers/provider/inferencecontract/protocol_test.go
@@ -1,0 +1,332 @@
+package inferencecontract_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	contract "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+)
+
+type invocationFunc func(context.Context, contract.InvocationRequest, contract.ResponseWriter) error
+
+type lifecycleIntegration struct {
+	invoke invocationFunc
+}
+
+func (i lifecycleIntegration) Identity() contract.Identity { return "customer.lifecycle" }
+func (i lifecycleIntegration) MaximumCapabilities() contract.CapabilitySet {
+	return contract.NewCapabilitySet(contract.CapabilityPromptSubmission)
+}
+func (i lifecycleIntegration) Discover(context.Context) (contract.Discovery, error) {
+	return contract.NewDiscovery(contract.ReadinessReady), nil
+}
+func (i lifecycleIntegration) Capabilities(context.Context, contract.InvocationRequest) (contract.CapabilitySet, error) {
+	return i.MaximumCapabilities(), nil
+}
+func (i lifecycleIntegration) Invoke(ctx context.Context, request contract.InvocationRequest, writer contract.ResponseWriter) error {
+	return i.invoke(ctx, request, writer)
+}
+
+func TestExecuteInvocationFlushesValidTerminalTailBeforeClose(t *testing.T) {
+	t.Parallel()
+	destination := &orderedWriter{}
+	integration := lifecycleIntegration{invoke: func(ctx context.Context, request contract.InvocationRequest, writer contract.ResponseWriter) error {
+		if err := writer.WriteEvent(ctx, event(t, request.InvocationID(), workers.KindRun, workers.PhaseStarted, "", runPayload(t, "started"))); err != nil {
+			return err
+		}
+		if err := writer.WriteEvent(ctx, event(t, request.InvocationID(), workers.KindMessage, workers.PhaseCompleted, "message-1", messagePayload(t, "answer"))); err != nil {
+			return err
+		}
+		if err := writer.WriteEvent(ctx, event(t, request.InvocationID(), workers.KindRun, workers.PhaseCompleted, "", runPayload(t, "completed"))); err != nil {
+			return err
+		}
+		return writer.Close(ctx, contract.SuccessfulCompletion(contract.NewResponse(contract.ResponseInput{Content: "answer"})))
+	}}
+
+	if err := contract.ExecuteInvocation(context.Background(), integration, request(), destination); err != nil {
+		t.Fatalf("ExecuteInvocation() error = %v", err)
+	}
+	want := []string{"RUN:STARTED", "MESSAGE:COMPLETED", "RUN:COMPLETED", "CLOSE"}
+	if !equalStrings(destination.order, want) {
+		t.Fatalf("destination order = %v, want %v", destination.order, want)
+	}
+}
+
+func TestExecuteInvocationRejectsMalformedEventLifecycles(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		rule   string
+		invoke invocationFunc
+	}{
+		{name: "cross invocation", rule: "invocation_correlation", invoke: writeOne(eventFactory(t, "other", workers.KindRun, workers.PhaseStarted, "", runPayload(t, "started")))},
+		{name: "delta before start", rule: "update_before_start", invoke: writeOne(eventFactory(t, "invocation-1", workers.KindMessage, workers.PhaseDelta, "message-1", messageDeltaPayload(t, "part")))},
+		{name: "duplicate terminal", rule: "duplicate_terminal", invoke: func(ctx context.Context, request contract.InvocationRequest, writer contract.ResponseWriter) error {
+			completed := event(t, request.InvocationID(), workers.KindMessage, workers.PhaseCompleted, "message-1", messagePayload(t, "answer"))
+			if err := writer.WriteEvent(ctx, completed); err != nil {
+				return err
+			}
+			return writer.WriteEvent(ctx, completed)
+		}},
+		{name: "incomplete lifecycle", rule: "incomplete_lifecycle", invoke: func(ctx context.Context, request contract.InvocationRequest, writer contract.ResponseWriter) error {
+			if err := writer.WriteEvent(ctx, event(t, request.InvocationID(), workers.KindRun, workers.PhaseStarted, "", runPayload(t, "started"))); err != nil {
+				return err
+			}
+			return writer.Close(ctx, contract.SuccessfulCompletion(contract.NewResponse(contract.ResponseInput{Content: "answer"})))
+		}},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			err := contract.ExecuteInvocation(context.Background(), lifecycleIntegration{invoke: test.invoke}, request(), &orderedWriter{})
+			assertProtocolRule(t, err, test.rule)
+		})
+	}
+}
+
+func TestExecuteInvocationEnforcesStableToolCorrelation(t *testing.T) {
+	t.Parallel()
+	integration := lifecycleIntegration{invoke: func(ctx context.Context, request contract.InvocationRequest, writer contract.ResponseWriter) error {
+		if err := writer.WriteEvent(ctx, event(t, request.InvocationID(), workers.KindTool, workers.PhaseStarted, "tool-item", toolPayload(t, "tool-1", "lookup", "running"))); err != nil {
+			return err
+		}
+		if err := writer.WriteEvent(ctx, event(t, request.InvocationID(), workers.KindTool, workers.PhaseDelta, "tool-item", toolDeltaPayload(t, "tool-1", "partial"))); err != nil {
+			return err
+		}
+		return writer.WriteEvent(ctx, event(t, request.InvocationID(), workers.KindTool, workers.PhaseCompleted, "tool-item", toolPayload(t, "tool-1", "different", "completed")))
+	}}
+	err := contract.ExecuteInvocation(context.Background(), integration, request(), &orderedWriter{})
+	assertProtocolRule(t, err, "tool_correlation")
+}
+
+func TestExecuteInvocationRejectsInvalidDraftAndCompletionValues(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		rule   string
+		invoke invocationFunc
+	}{
+		{
+			name: "invalid provenance",
+			rule: "provenance_provider",
+			invoke: func(ctx context.Context, request contract.InvocationRequest, writer contract.ResponseWriter) error {
+				draft := event(t, request.InvocationID(), workers.KindRun, workers.PhaseStarted, "", runPayload(t, "started"))
+				input := draft.Draft()
+				input.Provenance.Provider = "different.provider"
+				altered, err := contract.NewEventDraft(contract.EventDraftInput{
+					RunID: input.RunID, Kind: input.Kind, Phase: input.Phase, Payload: input.Payload,
+					ProviderSessionRef: input.ProviderSessionRef, Provenance: input.Provenance,
+				})
+				if err != nil {
+					return err
+				}
+				return writer.WriteEvent(ctx, altered)
+			},
+		},
+		{
+			name: "unbounded payload",
+			rule: "payload_bound",
+			invoke: func(ctx context.Context, request contract.InvocationRequest, writer contract.ResponseWriter) error {
+				return writer.WriteEvent(ctx, event(t, request.InvocationID(), workers.KindTool, workers.PhaseDelta, "tool-1", toolDeltaPayload(t, "tool-1", string(make([]byte, 70*1024)))))
+			},
+		},
+		{
+			name: "empty completion",
+			rule: "completion_outcome",
+			invoke: func(ctx context.Context, _ contract.InvocationRequest, writer contract.ResponseWriter) error {
+				return writer.Close(ctx, contract.Completion{})
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			err := contract.ExecuteInvocation(context.Background(), lifecycleIntegration{invoke: test.invoke}, request(), &orderedWriter{})
+			assertProtocolRule(t, err, test.rule)
+		})
+	}
+}
+
+func TestExecuteInvocationRejectsFinalResultDisagreement(t *testing.T) {
+	t.Parallel()
+	destination := &orderedWriter{}
+	integration := lifecycleIntegration{invoke: func(ctx context.Context, request contract.InvocationRequest, writer contract.ResponseWriter) error {
+		if err := writer.WriteEvent(ctx, event(t, request.InvocationID(), workers.KindMessage, workers.PhaseCompleted, "message-1", messagePayload(t, "streamed"))); err != nil {
+			return err
+		}
+		return writer.Close(ctx, contract.SuccessfulCompletion(contract.NewResponse(contract.ResponseInput{Content: "different"})))
+	}}
+	err := contract.ExecuteInvocation(context.Background(), integration, request(), destination)
+	assertProtocolRule(t, err, "final_result_agreement")
+	if len(destination.order) != 0 {
+		t.Fatalf("destination received contradictory terminal state: %v", destination.order)
+	}
+}
+
+func TestExecuteInvocationNormalizesErrorBeforeClose(t *testing.T) {
+	t.Parallel()
+	destination := &orderedWriter{}
+	providerErr := errors.New("native payload with secret")
+	integration := lifecycleIntegration{invoke: func(ctx context.Context, request contract.InvocationRequest, writer contract.ResponseWriter) error {
+		if err := writer.WriteEvent(ctx, event(t, request.InvocationID(), workers.KindRun, workers.PhaseStarted, "", runPayload(t, "started"))); err != nil {
+			return err
+		}
+		return providerErr
+	}}
+	err := contract.ExecuteInvocation(context.Background(), integration, request(), destination)
+	if !errors.Is(err, providerErr) {
+		t.Fatalf("ExecuteInvocation() error = %v, want provider error", err)
+	}
+	if destination.completion == nil || destination.completion.Failure() == nil {
+		t.Fatal("destination did not receive normalized failure")
+	}
+	failure := destination.completion.Failure()
+	if failure.Kind() != contract.FailureUnknown || failure.Message() != "provider invocation failed" {
+		t.Fatalf("failure = %q %q", failure.Kind(), failure.Message())
+	}
+	if want := []string{"RUN:STARTED", "CLOSE"}; !equalStrings(destination.order, want) {
+		t.Fatalf("destination order = %v, want %v", destination.order, want)
+	}
+}
+
+func TestExecuteInvocationRejectsMissingAndDuplicateClose(t *testing.T) {
+	t.Parallel()
+	t.Run("missing", func(t *testing.T) {
+		destination := &orderedWriter{}
+		err := contract.ExecuteInvocation(context.Background(), lifecycleIntegration{invoke: func(context.Context, contract.InvocationRequest, contract.ResponseWriter) error {
+			return nil
+		}}, request(), destination)
+		assertProtocolRule(t, err, "missing_close")
+		if destination.completion == nil || destination.completion.Failure().Kind() != contract.FailureMalformedOutput {
+			t.Fatalf("completion = %#v, want malformed output failure", destination.completion)
+		}
+	})
+	t.Run("duplicate", func(t *testing.T) {
+		var secondClose error
+		completion := contract.SuccessfulCompletion(contract.NewResponse(contract.ResponseInput{Content: "answer"}))
+		err := contract.ExecuteInvocation(context.Background(), lifecycleIntegration{invoke: func(ctx context.Context, _ contract.InvocationRequest, writer contract.ResponseWriter) error {
+			if err := writer.Close(ctx, completion); err != nil {
+				return err
+			}
+			secondClose = writer.Close(ctx, completion)
+			return secondClose
+		}}, request(), &orderedWriter{})
+		assertProtocolRule(t, secondClose, "duplicate_close")
+		assertProtocolRule(t, err, "duplicate_close")
+	})
+}
+
+func TestProtocolWriterRejectsWriteAfterCloseWithoutReplacingCompletion(t *testing.T) {
+	t.Parallel()
+	destination := &orderedWriter{}
+	var lateWrite error
+	integration := lifecycleIntegration{invoke: func(ctx context.Context, request contract.InvocationRequest, writer contract.ResponseWriter) error {
+		if err := writer.Close(ctx, contract.SuccessfulCompletion(contract.NewResponse(contract.ResponseInput{Content: "answer"}))); err != nil {
+			return err
+		}
+		lateWrite = writer.WriteEvent(ctx, event(t, request.InvocationID(), workers.KindMessage, workers.PhaseCompleted, "message-1", messagePayload(t, "answer")))
+		return lateWrite
+	}}
+	err := contract.ExecuteInvocation(context.Background(), integration, request(), destination)
+	assertProtocolRule(t, lateWrite, "write_after_close")
+	assertProtocolRule(t, err, "write_after_close")
+	if destination.closes != 1 || destination.completion.Response() == nil {
+		t.Fatalf("destination completion = %#v, closes = %d", destination.completion, destination.closes)
+	}
+}
+
+type orderedWriter struct {
+	order      []string
+	completion *contract.Completion
+	closes     int
+}
+
+func (w *orderedWriter) WriteEvent(_ context.Context, event contract.EventDraft) error {
+	draft := event.Draft()
+	w.order = append(w.order, string(draft.Kind)+":"+string(draft.Phase))
+	return nil
+}
+func (w *orderedWriter) Close(_ context.Context, completion contract.Completion) error {
+	w.order = append(w.order, "CLOSE")
+	w.closes++
+	w.completion = &completion
+	return nil
+}
+
+func request() contract.InvocationRequest {
+	return contract.NewInvocationRequest(contract.InvocationInput{InvocationID: "invocation-1", Model: "fixture", UserMessage: "hello"})
+}
+
+func event(t *testing.T, runID string, kind workers.Kind, phase workers.Phase, itemID string, payload []byte) contract.EventDraft {
+	t.Helper()
+	event, err := contract.NewEventDraft(contract.EventDraftInput{
+		RunID: runID, Kind: kind, Phase: phase, ItemID: itemID, Payload: payload,
+		ProviderSessionRef: "session-1", TurnID: "turn-1",
+		Provenance: workers.Provenance{Delivery: workers.DeliveryNativeStream, Fidelity: workers.FidelityNormalized, NativeEventType: "fixture", Provider: "customer.lifecycle", Representation: workers.RepresentationSnapshot},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return event
+}
+
+func eventFactory(t *testing.T, runID string, kind workers.Kind, phase workers.Phase, itemID string, payload []byte) func(contract.InvocationRequest) contract.EventDraft {
+	return func(contract.InvocationRequest) contract.EventDraft {
+		return event(t, runID, kind, phase, itemID, payload)
+	}
+}
+
+func writeOne(factory func(contract.InvocationRequest) contract.EventDraft) invocationFunc {
+	return func(ctx context.Context, request contract.InvocationRequest, writer contract.ResponseWriter) error {
+		return writer.WriteEvent(ctx, factory(request))
+	}
+}
+
+func runPayload(t *testing.T, status string) []byte {
+	return marshal(t, workers.RunPayload{Status: status})
+}
+func messagePayload(t *testing.T, content string) []byte {
+	return marshal(t, workers.MessagePayload{Role: "assistant", ContentBlocks: []workers.ContentBlock{{Kind: workers.ContentBlockText, Text: content}}})
+}
+func messageDeltaPayload(t *testing.T, content string) []byte {
+	return marshal(t, workers.MessageDeltaPayload{ContentBlockIndex: 0, ContentBlockKind: workers.ContentBlockText, TextDelta: content})
+}
+func toolPayload(t *testing.T, id, name, status string) []byte {
+	return marshal(t, workers.ToolPayload{ToolCallID: id, ToolName: name, Status: status})
+}
+func toolDeltaPayload(t *testing.T, id, output string) []byte {
+	return marshal(t, workers.ToolDeltaPayload{ToolCallID: id, OutputDelta: output})
+}
+func marshal(t *testing.T, value any) []byte {
+	t.Helper()
+	payload, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return payload
+}
+
+func assertProtocolRule(t *testing.T, err error, rule string) {
+	t.Helper()
+	var protocolErr *contract.ProtocolError
+	if !errors.As(err, &protocolErr) || protocolErr.Rule != rule {
+		t.Fatalf("error = %v, want protocol rule %q", err, rule)
+	}
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/services/workers/provider/inferencecontract/protocol_test.go
+++ b/pkg/services/workers/provider/inferencecontract/protocol_test.go
@@ -233,6 +233,25 @@ func TestExecuteInvocationPreservesIgnoredDestinationFailure(t *testing.T) {
 	}
 }
 
+func TestExecuteInvocationPreservesIgnoredProtocolValidationFailure(t *testing.T) {
+	t.Parallel()
+	destination := &orderedWriter{}
+	var writeErr, closeErr error
+	integration := lifecycleIntegration{invoke: func(ctx context.Context, request contract.InvocationRequest, writer contract.ResponseWriter) error {
+		writeErr = writer.WriteEvent(ctx, event(t, "other-invocation", workers.KindRun, workers.PhaseStarted, "", runPayload(t, "started")))
+		closeErr = writer.Close(ctx, contract.SuccessfulCompletion(contract.NewResponse(contract.ResponseInput{Content: "answer"})))
+		return nil
+	}}
+
+	err := contract.ExecuteInvocation(context.Background(), integration, request(), destination)
+	assertProtocolRule(t, writeErr, "invocation_correlation")
+	assertProtocolRule(t, closeErr, "duplicate_close")
+	assertProtocolRule(t, err, "invocation_correlation")
+	if len(destination.order) != 0 || destination.closes != 0 {
+		t.Fatalf("destination received output after invalid draft: order = %v, closes = %d", destination.order, destination.closes)
+	}
+}
+
 func TestExecuteInvocationRejectsMissingAndDuplicateClose(t *testing.T) {
 	t.Parallel()
 	t.Run("missing", func(t *testing.T) {

--- a/pkg/services/workers/provider/inferencecontract/protocol_test.go
+++ b/pkg/services/workers/provider/inferencecontract/protocol_test.go
@@ -187,6 +187,25 @@ func TestExecuteInvocationRejectsCompletedMessageBeforeFailure(t *testing.T) {
 	}
 }
 
+func TestExecuteInvocationRejectsMultipleAuthoritativeCompletedMessages(t *testing.T) {
+	t.Parallel()
+	destination := &orderedWriter{}
+	integration := lifecycleIntegration{invoke: func(ctx context.Context, request contract.InvocationRequest, writer contract.ResponseWriter) error {
+		if err := writer.WriteEvent(ctx, event(t, request.InvocationID(), workers.KindMessage, workers.PhaseCompleted, "message-1", messagePayload(t, "first"))); err != nil {
+			return err
+		}
+		_ = writer.WriteEvent(ctx, event(t, request.InvocationID(), workers.KindMessage, workers.PhaseCompleted, "message-2", messagePayload(t, "second")))
+		_ = writer.Close(ctx, contract.SuccessfulCompletion(contract.NewResponse(contract.ResponseInput{Content: "second"})))
+		return nil
+	}}
+
+	err := contract.ExecuteInvocation(context.Background(), integration, request(), destination)
+	assertProtocolRule(t, err, "final_result_agreement")
+	if len(destination.order) != 0 || destination.closes != 0 {
+		t.Fatalf("destination received contradictory terminal state: order = %v, closes = %d", destination.order, destination.closes)
+	}
+}
+
 func TestExecuteInvocationNormalizesErrorBeforeClose(t *testing.T) {
 	t.Parallel()
 	destination := &orderedWriter{}

--- a/pkg/services/workers/provider/inferencecontract/protocol_test.go
+++ b/pkg/services/workers/provider/inferencecontract/protocol_test.go
@@ -194,6 +194,45 @@ func TestExecuteInvocationNormalizesErrorBeforeClose(t *testing.T) {
 	}
 }
 
+func TestExecuteInvocationStopsAfterDestinationWriteFailure(t *testing.T) {
+	t.Parallel()
+	sinkErr := errors.New("response sink failed")
+	destination := &failingWriter{err: sinkErr}
+	var lateWrite, lateClose error
+	integration := lifecycleIntegration{invoke: func(ctx context.Context, request contract.InvocationRequest, writer contract.ResponseWriter) error {
+		writeErr := writer.WriteEvent(ctx, event(t, request.InvocationID(), workers.KindRun, workers.PhaseStarted, "", runPayload(t, "started")))
+		lateWrite = writer.WriteEvent(ctx, event(t, request.InvocationID(), workers.KindRun, workers.PhaseCompleted, "", runPayload(t, "completed")))
+		lateClose = writer.Close(ctx, contract.FailedCompletion(contract.NewFailure(contract.FailureInput{
+			Kind: contract.FailureDependency, Message: "response sink failed",
+		})))
+		return writeErr
+	}}
+
+	err := contract.ExecuteInvocation(context.Background(), integration, request(), destination)
+	if !errors.Is(err, sinkErr) {
+		t.Fatalf("ExecuteInvocation() error = %v, want response sink error", err)
+	}
+	assertProtocolRule(t, lateWrite, "write_after_close")
+	assertProtocolRule(t, lateClose, "duplicate_close")
+	if destination.writes != 1 || destination.closes != 0 {
+		t.Fatalf("destination calls = %d writes, %d closes; want one failed write and no close", destination.writes, destination.closes)
+	}
+}
+
+func TestExecuteInvocationPreservesIgnoredDestinationFailure(t *testing.T) {
+	t.Parallel()
+	sinkErr := errors.New("response sink failed")
+	integration := lifecycleIntegration{invoke: func(ctx context.Context, request contract.InvocationRequest, writer contract.ResponseWriter) error {
+		_ = writer.WriteEvent(ctx, event(t, request.InvocationID(), workers.KindRun, workers.PhaseStarted, "", runPayload(t, "started")))
+		return nil
+	}}
+
+	err := contract.ExecuteInvocation(context.Background(), integration, request(), &failingWriter{err: sinkErr})
+	if !errors.Is(err, sinkErr) {
+		t.Fatalf("ExecuteInvocation() error = %v, want ignored response sink error", err)
+	}
+}
+
 func TestExecuteInvocationRejectsMissingAndDuplicateClose(t *testing.T) {
 	t.Parallel()
 	t.Run("missing", func(t *testing.T) {
@@ -244,6 +283,22 @@ type orderedWriter struct {
 	order      []string
 	completion *contract.Completion
 	closes     int
+}
+
+type failingWriter struct {
+	err    error
+	writes int
+	closes int
+}
+
+func (w *failingWriter) WriteEvent(context.Context, contract.EventDraft) error {
+	w.writes++
+	return w.err
+}
+
+func (w *failingWriter) Close(context.Context, contract.Completion) error {
+	w.closes++
+	return nil
 }
 
 func (w *orderedWriter) WriteEvent(_ context.Context, event contract.EventDraft) error {

--- a/pkg/services/workers/provider/inferencecontract/protocol_test.go
+++ b/pkg/services/workers/provider/inferencecontract/protocol_test.go
@@ -168,6 +168,25 @@ func TestExecuteInvocationRejectsFinalResultDisagreement(t *testing.T) {
 	}
 }
 
+func TestExecuteInvocationRejectsCompletedMessageBeforeFailure(t *testing.T) {
+	t.Parallel()
+	destination := &orderedWriter{}
+	integration := lifecycleIntegration{invoke: func(ctx context.Context, request contract.InvocationRequest, writer contract.ResponseWriter) error {
+		if err := writer.WriteEvent(ctx, event(t, request.InvocationID(), workers.KindMessage, workers.PhaseCompleted, "message-1", messagePayload(t, "answer"))); err != nil {
+			return err
+		}
+		return writer.Close(ctx, contract.FailedCompletion(contract.NewFailure(contract.FailureInput{
+			Kind: contract.FailureDependency, Message: "provider dependency failed",
+		})))
+	}}
+
+	err := contract.ExecuteInvocation(context.Background(), integration, request(), destination)
+	assertProtocolRule(t, err, "final_result_agreement")
+	if len(destination.order) != 0 || destination.closes != 0 {
+		t.Fatalf("destination received contradictory terminal state: order = %v, closes = %d", destination.order, destination.closes)
+	}
+}
+
 func TestExecuteInvocationNormalizesErrorBeforeClose(t *testing.T) {
 	t.Parallel()
 	destination := &orderedWriter{}

--- a/pkg/services/workers/provider/inferencecontract/testkit/adverse.go
+++ b/pkg/services/workers/provider/inferencecontract/testkit/adverse.go
@@ -27,6 +27,7 @@ type AdverseSuite struct {
 	MissingClose        IntegrationFactory
 	Disagreement        IntegrationFactory
 	FailureAfterSuccess IntegrationFactory
+	ConflictingMessages IntegrationFactory
 	Request             contract.InvocationRequest
 }
 
@@ -58,6 +59,7 @@ func RunAdverse(t *testing.T, suite AdverseSuite) {
 			runViolationScenario(t, "missing-close", identity, suite.MissingClose, suite.Request, "missing_close", outcomeMalformedFailure)
 			runViolationScenario(t, "result-event-disagreement", identity, suite.Disagreement, suite.Request, "final_result_agreement", outcomeNone)
 			runViolationScenario(t, "failure-after-success-event", identity, suite.FailureAfterSuccess, suite.Request, "final_result_agreement", outcomeNone)
+			runViolationScenario(t, "conflicting-completed-messages", identity, suite.ConflictingMessages, suite.Request, "final_result_agreement", outcomeNone)
 		})
 	}
 }
@@ -219,6 +221,7 @@ func validateAdverseSuite(suite AdverseSuite) error {
 		suite.MissingClose,
 		suite.Disagreement,
 		suite.FailureAfterSuccess,
+		suite.ConflictingMessages,
 	}
 	for _, factory := range factories {
 		if factory == nil {

--- a/pkg/services/workers/provider/inferencecontract/testkit/adverse.go
+++ b/pkg/services/workers/provider/inferencecontract/testkit/adverse.go
@@ -17,16 +17,17 @@ type FailureIntegrationFactory func(contract.Identity, contract.FailureKind) con
 // failure, and malformed terminal behavior. Each factory must return a fresh
 // integration so scenarios can run independently and under the race detector.
 type AdverseSuite struct {
-	Identities   []contract.Identity
-	Failures     FailureIntegrationFactory
-	Cancellation IntegrationFactory
-	Timeout      IntegrationFactory
-	Backpressure IntegrationFactory
-	DoubleClose  IntegrationFactory
-	WriteAfter   IntegrationFactory
-	MissingClose IntegrationFactory
-	Disagreement IntegrationFactory
-	Request      contract.InvocationRequest
+	Identities          []contract.Identity
+	Failures            FailureIntegrationFactory
+	Cancellation        IntegrationFactory
+	Timeout             IntegrationFactory
+	Backpressure        IntegrationFactory
+	DoubleClose         IntegrationFactory
+	WriteAfter          IntegrationFactory
+	MissingClose        IntegrationFactory
+	Disagreement        IntegrationFactory
+	FailureAfterSuccess IntegrationFactory
+	Request             contract.InvocationRequest
 }
 
 var failureKinds = []contract.FailureKind{
@@ -56,6 +57,7 @@ func RunAdverse(t *testing.T, suite AdverseSuite) {
 			runViolationScenario(t, "write-after-close", identity, suite.WriteAfter, suite.Request, "write_after_close", outcomeSuccess)
 			runViolationScenario(t, "missing-close", identity, suite.MissingClose, suite.Request, "missing_close", outcomeMalformedFailure)
 			runViolationScenario(t, "result-event-disagreement", identity, suite.Disagreement, suite.Request, "final_result_agreement", outcomeNone)
+			runViolationScenario(t, "failure-after-success-event", identity, suite.FailureAfterSuccess, suite.Request, "final_result_agreement", outcomeNone)
 		})
 	}
 }
@@ -163,8 +165,8 @@ func runViolationScenario(t *testing.T, name string, identity contract.Identity,
 		}
 		switch outcome {
 		case outcomeNone:
-			if destination.closes != 0 {
-				t.Fatalf("destination closes = %d, want no contradictory terminal outcome", destination.closes)
+			if len(destination.events) != 0 || destination.closes != 0 {
+				t.Fatalf("destination received %d events and %d closes, want no contradictory terminal outcome", len(destination.events), destination.closes)
 			}
 		case outcomeSuccess:
 			assertSuccessfulClose(t, destination)
@@ -205,9 +207,23 @@ func requireAdverseSuite(t *testing.T, suite AdverseSuite) {
 }
 
 func validateAdverseSuite(suite AdverseSuite) error {
-	if suite.Failures == nil || suite.Cancellation == nil || suite.Timeout == nil || suite.Backpressure == nil ||
-		suite.DoubleClose == nil || suite.WriteAfter == nil || suite.MissingClose == nil || suite.Disagreement == nil {
+	if suite.Failures == nil {
 		return fmt.Errorf("all adverse integration factories are required")
+	}
+	factories := []IntegrationFactory{
+		suite.Cancellation,
+		suite.Timeout,
+		suite.Backpressure,
+		suite.DoubleClose,
+		suite.WriteAfter,
+		suite.MissingClose,
+		suite.Disagreement,
+		suite.FailureAfterSuccess,
+	}
+	for _, factory := range factories {
+		if factory == nil {
+			return fmt.Errorf("all adverse integration factories are required")
+		}
 	}
 	if len(suite.Identities) == 0 {
 		return fmt.Errorf("at least one opaque provider identity is required")

--- a/pkg/services/workers/provider/inferencecontract/testkit/adverse.go
+++ b/pkg/services/workers/provider/inferencecontract/testkit/adverse.go
@@ -1,0 +1,224 @@
+package testkit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	contract "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+)
+
+// FailureIntegrationFactory constructs an integration that completes with the
+// requested normalized failure and no competing successful response.
+type FailureIntegrationFactory func(contract.Identity, contract.FailureKind) contract.Integration
+
+// AdverseSuite supplies deterministic integrations for interruption, sink
+// failure, and malformed terminal behavior. Each factory must return a fresh
+// integration so scenarios can run independently and under the race detector.
+type AdverseSuite struct {
+	Identities   []contract.Identity
+	Failures     FailureIntegrationFactory
+	Cancellation IntegrationFactory
+	Timeout      IntegrationFactory
+	Backpressure IntegrationFactory
+	DoubleClose  IntegrationFactory
+	WriteAfter   IntegrationFactory
+	MissingClose IntegrationFactory
+	Disagreement IntegrationFactory
+	Request      contract.InvocationRequest
+}
+
+var failureKinds = []contract.FailureKind{
+	contract.FailureAuthentication,
+	contract.FailureInvalidRequest,
+	contract.FailureThrottled,
+	contract.FailureTimeout,
+	contract.FailureCanceled,
+	contract.FailureDependency,
+	contract.FailureMalformedOutput,
+	contract.FailureUnknown,
+}
+
+// RunAdverse verifies normalized failures, cancellation, deadlines, response
+// sink backpressure, and deterministic terminal-state contract violations.
+func RunAdverse(t *testing.T, suite AdverseSuite) {
+	t.Helper()
+	requireAdverseSuite(t, suite)
+	for _, identity := range suite.Identities {
+		identity := identity
+		t.Run(string(identity), func(t *testing.T) {
+			runFailureScenarios(t, identity, suite)
+			runInterruptedScenario(t, "cancellation", identity, suite.Cancellation, suite.Request, canceledContext, contract.FailureCanceled)
+			runInterruptedScenario(t, "timeout", identity, suite.Timeout, suite.Request, expiredContext, contract.FailureTimeout)
+			runBackpressureScenario(t, identity, suite)
+			runViolationScenario(t, "double-close", identity, suite.DoubleClose, suite.Request, "duplicate_close", outcomeSuccess)
+			runViolationScenario(t, "write-after-close", identity, suite.WriteAfter, suite.Request, "write_after_close", outcomeSuccess)
+			runViolationScenario(t, "missing-close", identity, suite.MissingClose, suite.Request, "missing_close", outcomeMalformedFailure)
+			runViolationScenario(t, "result-event-disagreement", identity, suite.Disagreement, suite.Request, "final_result_agreement", outcomeNone)
+		})
+	}
+}
+
+func runFailureScenarios(t *testing.T, identity contract.Identity, suite AdverseSuite) {
+	t.Helper()
+	for _, kind := range failureKinds {
+		kind := kind
+		t.Run("failure-"+string(kind), func(t *testing.T) {
+			destination := &recordingWriter{}
+			if err := contract.ExecuteInvocation(context.Background(), suite.Failures(identity, kind), suite.Request, destination); err != nil {
+				t.Fatalf("ExecuteInvocation() error = %v", err)
+			}
+			assertFailureCompletion(t, destination, kind)
+		})
+	}
+}
+
+type contextFactory func() (context.Context, context.CancelFunc)
+
+func canceledContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return ctx, func() {}
+}
+
+func expiredContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), 0)
+}
+
+func runInterruptedScenario(t *testing.T, name string, identity contract.Identity, factory IntegrationFactory, request contract.InvocationRequest, newContext contextFactory, want contract.FailureKind) {
+	t.Helper()
+	t.Run(name, func(t *testing.T) {
+		ctx, cancel := newContext()
+		defer cancel()
+		destination := &recordingWriter{}
+		err := contract.ExecuteInvocation(ctx, factory(identity), request, destination)
+		if err == nil {
+			t.Fatal("ExecuteInvocation() error = nil, want interruption")
+		}
+		assertFailureCompletion(t, destination, want)
+		if len(destination.events) != 0 {
+			t.Fatalf("events after interruption = %#v, want none", drafts(destination.events))
+		}
+	})
+}
+
+var errBackpressure = errors.New("testkit response sink backpressure")
+
+type backpressureWriter struct {
+	recordingWriter
+	writes  int
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (w *backpressureWriter) WriteEvent(context.Context, contract.EventDraft) error {
+	w.writes++
+	close(w.entered)
+	<-w.release
+	return errBackpressure
+}
+
+func runBackpressureScenario(t *testing.T, identity contract.Identity, suite AdverseSuite) {
+	t.Helper()
+	t.Run("backpressure", func(t *testing.T) {
+		destination := &backpressureWriter{entered: make(chan struct{}), release: make(chan struct{})}
+		done := make(chan error, 1)
+		go func() {
+			done <- contract.ExecuteInvocation(context.Background(), suite.Backpressure(identity), suite.Request, destination)
+		}()
+		<-destination.entered
+		select {
+		case err := <-done:
+			t.Fatalf("ExecuteInvocation() returned before response sink released backpressure: %v", err)
+		default:
+		}
+		close(destination.release)
+		err := <-done
+		if !errors.Is(err, errBackpressure) {
+			t.Fatalf("ExecuteInvocation() error = %v, want propagated backpressure error", err)
+		}
+		if destination.writes != 1 || destination.closes != 0 {
+			t.Fatalf("destination calls = %d writes, %d closes; want one failed write and no close", destination.writes, destination.closes)
+		}
+	})
+}
+
+type expectedOutcome int
+
+const (
+	outcomeNone expectedOutcome = iota
+	outcomeSuccess
+	outcomeMalformedFailure
+)
+
+func runViolationScenario(t *testing.T, name string, identity contract.Identity, factory IntegrationFactory, request contract.InvocationRequest, rule string, outcome expectedOutcome) {
+	t.Helper()
+	t.Run(name, func(t *testing.T) {
+		destination := &recordingWriter{}
+		err := contract.ExecuteInvocation(context.Background(), factory(identity), request, destination)
+		var violation *contract.ProtocolError
+		if !errors.As(err, &violation) || violation.Rule != rule {
+			t.Fatalf("ExecuteInvocation() error = %v, want protocol rule %q", err, rule)
+		}
+		switch outcome {
+		case outcomeNone:
+			if destination.closes != 0 {
+				t.Fatalf("destination closes = %d, want no contradictory terminal outcome", destination.closes)
+			}
+		case outcomeSuccess:
+			assertSuccessfulClose(t, destination)
+		case outcomeMalformedFailure:
+			assertFailureCompletion(t, destination, contract.FailureMalformedOutput)
+		default:
+			t.Fatalf("unsupported expected outcome %d", outcome)
+		}
+	})
+}
+
+func assertSuccessfulClose(t *testing.T, destination *recordingWriter) {
+	t.Helper()
+	if destination.closes != 1 || destination.completion == nil || destination.completion.Response() == nil || destination.completion.Failure() != nil {
+		t.Fatalf("completion = %#v after %d closes, want first successful terminal outcome", destination.completion, destination.closes)
+	}
+}
+
+func assertFailureCompletion(t *testing.T, destination *recordingWriter, want contract.FailureKind) {
+	t.Helper()
+	if destination.closes != 1 || destination.completion == nil || destination.completion.Response() != nil {
+		t.Fatalf("completion = %#v after %d closes, want one failure", destination.completion, destination.closes)
+	}
+	failure := destination.completion.Failure()
+	if failure == nil || failure.Kind() != want {
+		t.Fatalf("failure = %#v, want kind %q", failure, want)
+	}
+	if err := contract.ValidateFailure(*failure); err != nil {
+		t.Fatalf("failure is not safe and valid: %v", err)
+	}
+}
+
+func requireAdverseSuite(t *testing.T, suite AdverseSuite) {
+	t.Helper()
+	if err := validateAdverseSuite(suite); err != nil {
+		t.Fatalf("invalid adverse provider conformance suite: %v", err)
+	}
+}
+
+func validateAdverseSuite(suite AdverseSuite) error {
+	if suite.Failures == nil || suite.Cancellation == nil || suite.Timeout == nil || suite.Backpressure == nil ||
+		suite.DoubleClose == nil || suite.WriteAfter == nil || suite.MissingClose == nil || suite.Disagreement == nil {
+		return fmt.Errorf("all adverse integration factories are required")
+	}
+	if len(suite.Identities) == 0 {
+		return fmt.Errorf("at least one opaque provider identity is required")
+	}
+	for _, identity := range suite.Identities {
+		if err := contract.ValidateIdentity(identity); err != nil {
+			return err
+		}
+	}
+	if suite.Request.InvocationID() == "" || suite.Request.Model() == "" || suite.Request.UserMessage() == "" {
+		return fmt.Errorf("request requires invocation ID, model, and user message")
+	}
+	return nil
+}

--- a/pkg/services/workers/provider/inferencecontract/testkit/adverse_test.go
+++ b/pkg/services/workers/provider/inferencecontract/testkit/adverse_test.go
@@ -32,6 +32,7 @@ func TestAdverseConformance(t *testing.T) {
 		MissingClose:        factory(adverseMissingClose),
 		Disagreement:        factory(adverseDisagreement),
 		FailureAfterSuccess: factory(adverseFailureAfterSuccess),
+		ConflictingMessages: factory(adverseConflictingMessages),
 		Request:             request("invocation-adverse", contract.CapabilityPromptSubmission),
 	})
 }
@@ -47,6 +48,7 @@ const (
 	adverseMissingClose
 	adverseDisagreement
 	adverseFailureAfterSuccess
+	adverseConflictingMessages
 )
 
 type adverseIntegration struct {
@@ -102,6 +104,13 @@ func (f *adverseIntegration) Invoke(ctx context.Context, request contract.Invoca
 		return writer.Close(ctx, contract.FailedCompletion(contract.NewFailure(contract.FailureInput{
 			Kind: contract.FailureDependency, Message: "provider dependency failed",
 		})))
+	case adverseConflictingMessages:
+		if err := writer.WriteEvent(ctx, adverseMessageEvent(request.InvocationID(), f.identity)); err != nil {
+			return err
+		}
+		_ = writer.WriteEvent(ctx, adverseConflictingMessageEvent(request.InvocationID(), f.identity))
+		_ = writer.Close(ctx, contract.SuccessfulCompletion(contract.NewResponse(contract.ResponseInput{Content: "contradictory response"})))
+		return nil
 	default:
 		return errors.New("unsupported adverse behavior")
 	}
@@ -143,6 +152,20 @@ func adverseMessageEvent(invocationID string, identity contract.Identity) contra
 	event, err := contract.NewEventDraft(contract.EventDraftInput{
 		RunID: invocationID, Kind: workers.KindMessage, Phase: workers.PhaseCompleted, ItemID: "message-adverse",
 		Payload:    mustJSON(messagePayload()),
+		Provenance: adverseProvenance(identity, workers.RepresentationSnapshot),
+	})
+	if err != nil {
+		panic(err)
+	}
+	return event
+}
+
+func adverseConflictingMessageEvent(invocationID string, identity contract.Identity) contract.EventDraft {
+	event, err := contract.NewEventDraft(contract.EventDraftInput{
+		RunID: invocationID, Kind: workers.KindMessage, Phase: workers.PhaseCompleted, ItemID: "message-conflict",
+		Payload: mustJSON(workers.MessagePayload{
+			Role: "assistant", ContentBlocks: []workers.ContentBlock{{Kind: workers.ContentBlockText, Text: "contradictory response"}},
+		}),
 		Provenance: adverseProvenance(identity, workers.RepresentationSnapshot),
 	})
 	if err != nil {

--- a/pkg/services/workers/provider/inferencecontract/testkit/adverse_test.go
+++ b/pkg/services/workers/provider/inferencecontract/testkit/adverse_test.go
@@ -24,14 +24,15 @@ func TestAdverseConformance(t *testing.T) {
 		Failures: func(identity contract.Identity, kind contract.FailureKind) contract.Integration {
 			return &adverseIntegration{identity: identity, behavior: adverseFailure, failureKind: kind}
 		},
-		Cancellation: factory(adverseInterrupted),
-		Timeout:      factory(adverseInterrupted),
-		Backpressure: factory(adverseBackpressure),
-		DoubleClose:  factory(adverseDoubleClose),
-		WriteAfter:   factory(adverseWriteAfterClose),
-		MissingClose: factory(adverseMissingClose),
-		Disagreement: factory(adverseDisagreement),
-		Request:      request("invocation-adverse", contract.CapabilityPromptSubmission),
+		Cancellation:        factory(adverseInterrupted),
+		Timeout:             factory(adverseInterrupted),
+		Backpressure:        factory(adverseBackpressure),
+		DoubleClose:         factory(adverseDoubleClose),
+		WriteAfter:          factory(adverseWriteAfterClose),
+		MissingClose:        factory(adverseMissingClose),
+		Disagreement:        factory(adverseDisagreement),
+		FailureAfterSuccess: factory(adverseFailureAfterSuccess),
+		Request:             request("invocation-adverse", contract.CapabilityPromptSubmission),
 	})
 }
 
@@ -45,6 +46,7 @@ const (
 	adverseWriteAfterClose
 	adverseMissingClose
 	adverseDisagreement
+	adverseFailureAfterSuccess
 )
 
 type adverseIntegration struct {
@@ -93,6 +95,13 @@ func (f *adverseIntegration) Invoke(ctx context.Context, request contract.Invoca
 			return err
 		}
 		return writer.Close(ctx, contract.SuccessfulCompletion(contract.NewResponse(contract.ResponseInput{Content: "contradictory response"})))
+	case adverseFailureAfterSuccess:
+		if err := writer.WriteEvent(ctx, adverseMessageEvent(request.InvocationID(), f.identity)); err != nil {
+			return err
+		}
+		return writer.Close(ctx, contract.FailedCompletion(contract.NewFailure(contract.FailureInput{
+			Kind: contract.FailureDependency, Message: "provider dependency failed",
+		})))
 	default:
 		return errors.New("unsupported adverse behavior")
 	}

--- a/pkg/services/workers/provider/inferencecontract/testkit/adverse_test.go
+++ b/pkg/services/workers/provider/inferencecontract/testkit/adverse_test.go
@@ -1,0 +1,158 @@
+package testkit_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	contract "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+	"github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract/testkit"
+)
+
+func TestAdverseConformance(t *testing.T) {
+	response := contract.NewResponse(contract.ResponseInput{Content: "fixture response"})
+	factory := func(behavior adverseBehavior) testkit.IntegrationFactory {
+		return func(identity contract.Identity) contract.Integration {
+			return &adverseIntegration{identity: identity, behavior: behavior, response: response}
+		}
+	}
+	testkit.RunAdverse(t, testkit.AdverseSuite{
+		Identities: []contract.Identity{"customer.alpha", "customer-beta"},
+		Failures: func(identity contract.Identity, kind contract.FailureKind) contract.Integration {
+			return &adverseIntegration{identity: identity, behavior: adverseFailure, failureKind: kind}
+		},
+		Cancellation: factory(adverseInterrupted),
+		Timeout:      factory(adverseInterrupted),
+		Backpressure: factory(adverseBackpressure),
+		DoubleClose:  factory(adverseDoubleClose),
+		WriteAfter:   factory(adverseWriteAfterClose),
+		MissingClose: factory(adverseMissingClose),
+		Disagreement: factory(adverseDisagreement),
+		Request:      request("invocation-adverse", contract.CapabilityPromptSubmission),
+	})
+}
+
+type adverseBehavior int
+
+const (
+	adverseFailure adverseBehavior = iota
+	adverseInterrupted
+	adverseBackpressure
+	adverseDoubleClose
+	adverseWriteAfterClose
+	adverseMissingClose
+	adverseDisagreement
+)
+
+type adverseIntegration struct {
+	identity    contract.Identity
+	behavior    adverseBehavior
+	failureKind contract.FailureKind
+	response    contract.Response
+}
+
+func (f *adverseIntegration) Identity() contract.Identity { return f.identity }
+
+func (f *adverseIntegration) MaximumCapabilities() contract.CapabilitySet {
+	return contract.NewCapabilitySet(contract.CapabilityPromptSubmission)
+}
+
+func (f *adverseIntegration) Discover(context.Context) (contract.Discovery, error) {
+	return contract.NewDiscovery(contract.ReadinessReady), nil
+}
+
+func (f *adverseIntegration) Capabilities(_ context.Context, request contract.InvocationRequest) (contract.CapabilitySet, error) {
+	return request.RequiredCapabilities(), nil
+}
+
+func (f *adverseIntegration) Invoke(ctx context.Context, request contract.InvocationRequest, writer contract.ResponseWriter) error {
+	switch f.behavior {
+	case adverseFailure:
+		return writer.Close(ctx, contract.FailedCompletion(contract.NewFailure(contract.FailureInput{
+			Kind: f.failureKind, Message: "safe deterministic provider failure",
+		})))
+	case adverseInterrupted:
+		<-ctx.Done()
+		return ctx.Err()
+	case adverseBackpressure:
+		return writer.WriteEvent(ctx, adverseRunEvent(request.InvocationID(), f.identity, workers.PhaseStarted))
+	case adverseDoubleClose:
+		return closeConcurrently(ctx, writer, contract.SuccessfulCompletion(f.response))
+	case adverseWriteAfterClose:
+		if err := writer.Close(ctx, contract.SuccessfulCompletion(f.response)); err != nil {
+			return err
+		}
+		return writer.WriteEvent(ctx, adverseRunEvent(request.InvocationID(), f.identity, workers.PhaseStarted))
+	case adverseMissingClose:
+		return nil
+	case adverseDisagreement:
+		if err := writer.WriteEvent(ctx, adverseMessageEvent(request.InvocationID(), f.identity)); err != nil {
+			return err
+		}
+		return writer.Close(ctx, contract.SuccessfulCompletion(contract.NewResponse(contract.ResponseInput{Content: "contradictory response"})))
+	default:
+		return errors.New("unsupported adverse behavior")
+	}
+}
+
+func closeConcurrently(ctx context.Context, writer contract.ResponseWriter, completion contract.Completion) error {
+	var wait sync.WaitGroup
+	errorsByAttempt := make([]error, 2)
+	wait.Add(len(errorsByAttempt))
+	for index := range errorsByAttempt {
+		index := index
+		go func() {
+			defer wait.Done()
+			errorsByAttempt[index] = writer.Close(ctx, completion)
+		}()
+	}
+	wait.Wait()
+	for _, err := range errorsByAttempt {
+		if err != nil {
+			return err
+		}
+	}
+	return errors.New("concurrent double close unexpectedly succeeded")
+}
+
+func adverseRunEvent(invocationID string, identity contract.Identity, phase workers.Phase) contract.EventDraft {
+	event, err := contract.NewEventDraft(contract.EventDraftInput{
+		RunID: invocationID, Kind: workers.KindRun, Phase: phase,
+		Payload:    mustJSON(workers.RunPayload{Status: "running"}),
+		Provenance: adverseProvenance(identity, workers.RepresentationSnapshot),
+	})
+	if err != nil {
+		panic(err)
+	}
+	return event
+}
+
+func adverseMessageEvent(invocationID string, identity contract.Identity) contract.EventDraft {
+	event, err := contract.NewEventDraft(contract.EventDraftInput{
+		RunID: invocationID, Kind: workers.KindMessage, Phase: workers.PhaseCompleted, ItemID: "message-adverse",
+		Payload:    mustJSON(messagePayload()),
+		Provenance: adverseProvenance(identity, workers.RepresentationSnapshot),
+	})
+	if err != nil {
+		panic(err)
+	}
+	return event
+}
+
+func adverseProvenance(identity contract.Identity, representation workers.Representation) workers.Provenance {
+	return workers.Provenance{
+		Delivery: workers.DeliveryNativeStream, Fidelity: workers.FidelityNormalized,
+		NativeEventType: "fixture", Provider: string(identity), Representation: representation,
+	}
+}
+
+func mustJSON(value any) []byte {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return payload
+}

--- a/pkg/services/workers/provider/inferencecontract/testkit/conformance.go
+++ b/pkg/services/workers/provider/inferencecontract/testkit/conformance.go
@@ -1,0 +1,345 @@
+// Package testkit provides a reusable black-box conformance suite for
+// customer-implemented provider integrations.
+package testkit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	contract "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+)
+
+// IntegrationFactory constructs a fresh deterministic integration for an
+// opaque identity. Conformance scenarios never branch on the identity value.
+type IntegrationFactory func(contract.Identity) contract.Integration
+
+// Fixture supplies immutable provider-neutral requests and expected responses.
+type Fixture struct {
+	FinalOnlyRequest contract.InvocationRequest
+	StreamingRequest contract.InvocationRequest
+	ToolRequest      contract.InvocationRequest
+	ExpectedResponse contract.Response
+}
+
+// Suite supplies the success-mode integrations exercised by Run.
+type Suite struct {
+	Identities []contract.Identity
+	FinalOnly  IntegrationFactory
+	Streaming  IntegrationFactory
+	Tool       IntegrationFactory
+	Fixture    Fixture
+}
+
+// Run verifies discovery, negotiation, final-only completion, streamed message
+// progress, correlated tool progress, result agreement, and exactly-once close.
+func Run(t *testing.T, suite Suite) {
+	t.Helper()
+	requireSuite(t, suite)
+	for _, identity := range suite.Identities {
+		identity := identity
+		t.Run(string(identity), func(t *testing.T) {
+			runScenario(t, identity, scenario{
+				name: "final-only", factory: suite.FinalOnly,
+				request: suite.Fixture.FinalOnlyRequest, expected: suite.Fixture.ExpectedResponse,
+				assertMaximum: assertFinalOnlyMaximum, assertEvents: assertFinalOnlyEvents,
+			})
+			runScenario(t, identity, scenario{
+				name: "streaming", factory: suite.Streaming,
+				request: suite.Fixture.StreamingRequest, expected: suite.Fixture.ExpectedResponse,
+				assertMaximum: assertStreamingMaximum, assertEvents: assertStreamingEvents,
+			})
+			runScenario(t, identity, scenario{
+				name: "tool-lifecycle", factory: suite.Tool,
+				request: suite.Fixture.ToolRequest, expected: suite.Fixture.ExpectedResponse,
+				assertMaximum: assertToolMaximum, assertEvents: assertToolEvents,
+			})
+		})
+	}
+}
+
+type scenario struct {
+	name          string
+	factory       IntegrationFactory
+	request       contract.InvocationRequest
+	expected      contract.Response
+	assertMaximum func(*testing.T, contract.CapabilitySet)
+	assertEvents  func(*testing.T, []contract.EventDraft)
+}
+
+func runScenario(t *testing.T, identity contract.Identity, test scenario) {
+	t.Helper()
+	t.Run(test.name, func(t *testing.T) {
+		integration := test.factory(identity)
+		if integration == nil {
+			t.Fatal("integration factory returned nil")
+		}
+		maximum := assertIntegrationContract(t, integration, identity, test.request)
+		test.assertMaximum(t, maximum)
+		destination := &recordingWriter{}
+		if err := contract.ExecuteInvocation(context.Background(), integration, test.request, destination); err != nil {
+			t.Fatalf("ExecuteInvocation() error = %v", err)
+		}
+		test.assertEvents(t, destination.events)
+		assertCompletion(t, destination, test.expected)
+	})
+}
+
+func assertIntegrationContract(t *testing.T, integration contract.Integration, identity contract.Identity, request contract.InvocationRequest) contract.CapabilitySet {
+	t.Helper()
+	if integration.Identity() != identity {
+		t.Fatalf("Identity() = %q, want %q", integration.Identity(), identity)
+	}
+	if err := contract.ValidateIdentity(integration.Identity()); err != nil {
+		t.Fatalf("Identity() is invalid: %v", err)
+	}
+	maximum := integration.MaximumCapabilities()
+	if err := contract.ValidateMaximumCapabilities(maximum); err != nil {
+		t.Fatalf("MaximumCapabilities() is invalid: %v", err)
+	}
+	discovery, err := integration.Discover(context.Background())
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if err := contract.ValidateDiscovery(discovery); err != nil {
+		t.Fatalf("Discover() returned invalid readiness: %v", err)
+	}
+	if discovery.Readiness() != contract.ReadinessReady {
+		t.Fatalf("Discover() readiness = %q, want %q", discovery.Readiness(), contract.ReadinessReady)
+	}
+	negotiated, err := integration.Capabilities(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Capabilities() error = %v", err)
+	}
+	if err := contract.ValidateNegotiatedCapabilities(maximum, negotiated); err != nil {
+		t.Fatalf("Capabilities() returned invalid negotiation: %v", err)
+	}
+	for _, required := range request.RequiredCapabilities().Values() {
+		if !negotiated.Has(required) {
+			t.Fatalf("Capabilities() omitted required capability %q", required)
+		}
+	}
+	return maximum
+}
+
+type recordingWriter struct {
+	events     []contract.EventDraft
+	completion *contract.Completion
+	closes     int
+	order      []string
+}
+
+func (w *recordingWriter) WriteEvent(_ context.Context, event contract.EventDraft) error {
+	w.events = append(w.events, event)
+	draft := event.Draft()
+	w.order = append(w.order, string(draft.Kind)+":"+string(draft.Phase))
+	return nil
+}
+
+func (w *recordingWriter) Close(_ context.Context, completion contract.Completion) error {
+	w.closes++
+	w.completion = &completion
+	w.order = append(w.order, "CLOSE")
+	return nil
+}
+
+func assertFinalOnlyEvents(t *testing.T, events []contract.EventDraft) {
+	t.Helper()
+	if len(events) != 0 {
+		t.Fatalf("final-only integration emitted streaming events: %#v", drafts(events))
+	}
+}
+
+func assertFinalOnlyMaximum(t *testing.T, maximum contract.CapabilitySet) {
+	t.Helper()
+	if maximum.Has(contract.CapabilityNativeStreaming) || maximum.Has(contract.CapabilityMessageDeltas) {
+		t.Fatalf("final-only maximum capabilities = %#v, must not advertise streaming or deltas", maximum.Values())
+	}
+}
+
+func assertStreamingMaximum(t *testing.T, maximum contract.CapabilitySet) {
+	t.Helper()
+	assertCapabilities(t, maximum, contract.CapabilityNativeStreaming, contract.CapabilityMessageDeltas, contract.CapabilityMessageSnapshots)
+}
+
+func assertToolMaximum(t *testing.T, maximum contract.CapabilitySet) {
+	t.Helper()
+	assertCapabilities(t, maximum, contract.CapabilityToolLifecycle, contract.CapabilityToolOutputDeltas)
+}
+
+func assertCapabilities(t *testing.T, capabilities contract.CapabilitySet, required ...contract.Capability) {
+	t.Helper()
+	for _, capability := range required {
+		if !capabilities.Has(capability) {
+			t.Fatalf("maximum capabilities = %#v, want %q", capabilities.Values(), capability)
+		}
+	}
+}
+
+func assertStreamingEvents(t *testing.T, events []contract.EventDraft) {
+	t.Helper()
+	want := []eventPhase{
+		{workers.KindRun, workers.PhaseStarted},
+		{workers.KindMessage, workers.PhaseStarted},
+		{workers.KindMessage, workers.PhaseDelta},
+		{workers.KindMessage, workers.PhaseCompleted},
+		{workers.KindRun, workers.PhaseCompleted},
+	}
+	assertEventPhases(t, events, want)
+}
+
+func assertToolEvents(t *testing.T, events []contract.EventDraft) {
+	t.Helper()
+	want := []eventPhase{
+		{workers.KindRun, workers.PhaseStarted},
+		{workers.KindTool, workers.PhaseStarted},
+		{workers.KindTool, workers.PhaseDelta},
+		{workers.KindTool, workers.PhaseCompleted},
+		{workers.KindMessage, workers.PhaseCompleted},
+		{workers.KindRun, workers.PhaseCompleted},
+	}
+	assertEventPhases(t, events, want)
+	assertStableToolCorrelation(t, events[1:4])
+}
+
+type eventPhase struct {
+	kind  workers.Kind
+	phase workers.Phase
+}
+
+func assertEventPhases(t *testing.T, events []contract.EventDraft, want []eventPhase) {
+	t.Helper()
+	if len(events) != len(want) {
+		t.Fatalf("events = %#v, want %d ordered events", drafts(events), len(want))
+	}
+	for index, event := range events {
+		draft := event.Draft()
+		if draft.Kind != want[index].kind || draft.Phase != want[index].phase {
+			t.Fatalf("event[%d] = %s/%s, want %s/%s", index, draft.Kind, draft.Phase, want[index].kind, want[index].phase)
+		}
+	}
+}
+
+func assertStableToolCorrelation(t *testing.T, events []contract.EventDraft) {
+	t.Helper()
+	var toolCallID, toolName string
+	for index, event := range events {
+		draft := event.Draft()
+		if draft.Phase == workers.PhaseDelta {
+			var payload workers.ToolDeltaPayload
+			if err := json.Unmarshal(draft.Payload, &payload); err != nil {
+				t.Fatalf("tool event[%d] payload: %v", index, err)
+			}
+			if payload.ToolCallID != toolCallID || payload.OutputDelta == "" {
+				t.Fatalf("tool delta correlation = %#v, want toolCallID %q and bounded output", payload, toolCallID)
+			}
+			continue
+		}
+		var payload workers.ToolPayload
+		if err := json.Unmarshal(draft.Payload, &payload); err != nil {
+			t.Fatalf("tool event[%d] payload: %v", index, err)
+		}
+		if index == 0 {
+			toolCallID, toolName = payload.ToolCallID, payload.ToolName
+		}
+		if payload.ToolCallID != toolCallID || payload.ToolName != toolName {
+			t.Fatalf("tool event[%d] correlation = %q/%q, want %q/%q", index, payload.ToolCallID, payload.ToolName, toolCallID, toolName)
+		}
+	}
+}
+
+func assertCompletion(t *testing.T, destination *recordingWriter, expected contract.Response) {
+	t.Helper()
+	if destination.closes != 1 || destination.completion == nil {
+		t.Fatalf("destination closes = %d, completion = %#v; want exactly one close", destination.closes, destination.completion)
+	}
+	if destination.order[len(destination.order)-1] != "CLOSE" {
+		t.Fatalf("destination order = %#v, want completion after terminal events", destination.order)
+	}
+	response := destination.completion.Response()
+	if response == nil || destination.completion.Failure() != nil {
+		t.Fatalf("completion = %#v, want one successful response", destination.completion)
+	}
+	if response.Content() != expected.Content() || !maps.Equal(response.Metadata(), expected.Metadata()) ||
+		!sameProviderSession(response.ProviderSession(), expected.ProviderSession()) {
+		t.Fatalf("response = %#v/%#v/%#v, want %q/%#v/%#v", response.Content(), response.Metadata(), response.ProviderSession(), expected.Content(), expected.Metadata(), expected.ProviderSession())
+	}
+	assertDetachedResponse(t, *response)
+}
+
+func assertDetachedResponse(t *testing.T, response contract.Response) {
+	t.Helper()
+	metadata := response.Metadata()
+	metadata["testkit-mutation"] = "must-not-stick"
+	if _, exists := response.Metadata()["testkit-mutation"]; exists {
+		t.Fatal("response metadata aliases caller-owned mutation")
+	}
+	session := response.ProviderSession()
+	if session == nil {
+		return
+	}
+	sessionMetadata := session.Metadata()
+	sessionMetadata["testkit-mutation"] = "must-not-stick"
+	if _, exists := response.ProviderSession().Metadata()["testkit-mutation"]; exists {
+		t.Fatal("Provider Session metadata aliases caller-owned mutation")
+	}
+}
+
+func sameProviderSession(got, want *contract.ProviderSession) bool {
+	if got == nil || want == nil {
+		return got == nil && want == nil
+	}
+	return got.Provider() == want.Provider() && got.Kind() == want.Kind() && got.ID() == want.ID() && maps.Equal(got.Metadata(), want.Metadata())
+}
+
+func requireSuite(t *testing.T, suite Suite) {
+	t.Helper()
+	if err := validateSuite(suite); err != nil {
+		t.Fatalf("invalid provider conformance suite: %v", err)
+	}
+}
+
+func validateSuite(suite Suite) error {
+	if suite.FinalOnly == nil || suite.Streaming == nil || suite.Tool == nil {
+		return fmt.Errorf("final-only, streaming, and tool integration factories are required")
+	}
+	if len(suite.Identities) < 2 {
+		return fmt.Errorf("at least two opaque provider identities are required")
+	}
+	seen := make(map[contract.Identity]struct{}, len(suite.Identities))
+	for _, identity := range suite.Identities {
+		if err := contract.ValidateIdentity(identity); err != nil {
+			return err
+		}
+		if _, exists := seen[identity]; exists {
+			return fmt.Errorf("provider identity %q is duplicated", identity)
+		}
+		seen[identity] = struct{}{}
+	}
+	requests := []contract.InvocationRequest{suite.Fixture.FinalOnlyRequest, suite.Fixture.StreamingRequest, suite.Fixture.ToolRequest}
+	for index, request := range requests {
+		if request.InvocationID() == "" || request.Model() == "" || request.UserMessage() == "" {
+			return fmt.Errorf("request[%d] requires invocation ID, model, and user message", index)
+		}
+	}
+	if suite.Fixture.ExpectedResponse.Content() == "" {
+		return fmt.Errorf("expected response content is required")
+	}
+	if !slices.Contains(suite.Fixture.StreamingRequest.RequiredCapabilities().Values(), contract.CapabilityNativeStreaming) ||
+		!slices.Contains(suite.Fixture.ToolRequest.RequiredCapabilities().Values(), contract.CapabilityToolLifecycle) {
+		return fmt.Errorf("streaming and tool requests require their corresponding capabilities")
+	}
+	return nil
+}
+
+func drafts(events []contract.EventDraft) []workers.Draft {
+	result := make([]workers.Draft, 0, len(events))
+	for _, event := range events {
+		result = append(result, event.Draft())
+	}
+	return result
+}

--- a/pkg/services/workers/provider/inferencecontract/testkit/conformance_test.go
+++ b/pkg/services/workers/provider/inferencecontract/testkit/conformance_test.go
@@ -1,0 +1,161 @@
+package testkit_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	contract "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+	"github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract/testkit"
+)
+
+func TestSuccessConformance(t *testing.T) {
+	expected := contract.NewResponse(contract.ResponseInput{
+		Content:         "fixture response",
+		ProviderSession: providerSession(),
+		Metadata:        map[string]string{"model": "fixture-model"},
+	})
+	testkit.Run(t, testkit.Suite{
+		Identities: []contract.Identity{"customer.alpha", "customer-beta"},
+		FinalOnly:  factory(modeFinalOnly, expected),
+		Streaming:  factory(modeStreaming, expected),
+		Tool:       factory(modeTool, expected),
+		Fixture: testkit.Fixture{
+			FinalOnlyRequest: request("invocation-final", contract.CapabilityPromptSubmission),
+			StreamingRequest: request("invocation-stream", contract.CapabilityPromptSubmission,
+				contract.CapabilityNativeStreaming, contract.CapabilityMessageDeltas, contract.CapabilityMessageSnapshots),
+			ToolRequest: request("invocation-tool", contract.CapabilityPromptSubmission,
+				contract.CapabilityNativeStreaming, contract.CapabilityMessageSnapshots, contract.CapabilityToolLifecycle,
+				contract.CapabilityToolOutputDeltas, contract.CapabilityStableItemIDs),
+			ExpectedResponse: expected,
+		},
+	})
+}
+
+type fakeMode int
+
+const (
+	modeFinalOnly fakeMode = iota
+	modeStreaming
+	modeTool
+)
+
+type fakeIntegration struct {
+	identity contract.Identity
+	mode     fakeMode
+	response contract.Response
+}
+
+func factory(mode fakeMode, response contract.Response) testkit.IntegrationFactory {
+	return func(identity contract.Identity) contract.Integration {
+		return &fakeIntegration{identity: identity, mode: mode, response: response}
+	}
+}
+
+func (f *fakeIntegration) Identity() contract.Identity { return f.identity }
+
+func (f *fakeIntegration) MaximumCapabilities() contract.CapabilitySet {
+	capabilities := []contract.Capability{contract.CapabilityPromptSubmission}
+	if f.mode >= modeStreaming {
+		capabilities = append(capabilities, contract.CapabilityNativeStreaming, contract.CapabilityMessageDeltas,
+			contract.CapabilityMessageSnapshots, contract.CapabilityStableItemIDs)
+	}
+	if f.mode == modeTool {
+		capabilities = append(capabilities, contract.CapabilityToolLifecycle, contract.CapabilityToolOutputDeltas)
+	}
+	return contract.NewCapabilitySet(capabilities...)
+}
+
+func (f *fakeIntegration) Discover(context.Context) (contract.Discovery, error) {
+	return contract.NewDiscovery(contract.ReadinessReady,
+		contract.NewPrerequisite(contract.PrerequisiteDependency, "fixture runtime", contract.PrerequisiteSatisfied, "Fixture runtime is available.")), nil
+}
+
+func (f *fakeIntegration) Capabilities(_ context.Context, request contract.InvocationRequest) (contract.CapabilitySet, error) {
+	return request.RequiredCapabilities(), nil
+}
+
+func (f *fakeIntegration) Invoke(ctx context.Context, request contract.InvocationRequest, writer contract.ResponseWriter) error {
+	switch f.mode {
+	case modeFinalOnly:
+		return writer.Close(ctx, contract.SuccessfulCompletion(f.response))
+	case modeStreaming:
+		if err := f.write(ctx, request, writer, streamingDrafts); err != nil {
+			return err
+		}
+	case modeTool:
+		if err := f.write(ctx, request, writer, toolDrafts); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported fake mode %d", f.mode)
+	}
+	return writer.Close(ctx, contract.SuccessfulCompletion(f.response))
+}
+
+type draftSpec struct {
+	kind    workers.Kind
+	phase   workers.Phase
+	itemID  string
+	payload any
+}
+
+var streamingDrafts = []draftSpec{
+	{workers.KindRun, workers.PhaseStarted, "", workers.RunPayload{Status: "running"}},
+	{workers.KindMessage, workers.PhaseStarted, "message-1", workers.MessagePayload{Role: "assistant", ContentBlocks: []workers.ContentBlock{{Kind: workers.ContentBlockText}}}},
+	{workers.KindMessage, workers.PhaseDelta, "message-1", workers.MessageDeltaPayload{ContentBlockIndex: 0, ContentBlockKind: workers.ContentBlockText, TextDelta: "fixture "}},
+	{workers.KindMessage, workers.PhaseCompleted, "message-1", messagePayload()},
+	{workers.KindRun, workers.PhaseCompleted, "", workers.RunPayload{Status: "completed"}},
+}
+
+var toolDrafts = []draftSpec{
+	{workers.KindRun, workers.PhaseStarted, "", workers.RunPayload{Status: "running"}},
+	{workers.KindTool, workers.PhaseStarted, "tool-item-1", workers.ToolPayload{ToolCallID: "tool-call-1", ToolName: "fixture_lookup", Status: "running"}},
+	{workers.KindTool, workers.PhaseDelta, "tool-item-1", workers.ToolDeltaPayload{ToolCallID: "tool-call-1", OutputDelta: "bounded output"}},
+	{workers.KindTool, workers.PhaseCompleted, "tool-item-1", workers.ToolPayload{ToolCallID: "tool-call-1", ToolName: "fixture_lookup", Status: "completed"}},
+	{workers.KindMessage, workers.PhaseCompleted, "message-1", messagePayload()},
+	{workers.KindRun, workers.PhaseCompleted, "", workers.RunPayload{Status: "completed"}},
+}
+
+func (f *fakeIntegration) write(ctx context.Context, request contract.InvocationRequest, writer contract.ResponseWriter, specs []draftSpec) error {
+	for _, spec := range specs {
+		payload, err := json.Marshal(spec.payload)
+		if err != nil {
+			return err
+		}
+		representation := workers.RepresentationSnapshot
+		if spec.phase == workers.PhaseDelta {
+			representation = workers.RepresentationDelta
+		}
+		event, err := contract.NewEventDraft(contract.EventDraftInput{
+			RunID: request.InvocationID(), Kind: spec.kind, Phase: spec.phase, ItemID: spec.itemID, Payload: payload,
+			Provenance: workers.Provenance{Delivery: workers.DeliveryNativeStream, Fidelity: workers.FidelityNormalized,
+				NativeEventType: "fixture", Provider: string(f.identity), Representation: representation},
+		})
+		if err != nil {
+			return err
+		}
+		if err := writer.WriteEvent(ctx, event); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func request(invocationID string, required ...contract.Capability) contract.InvocationRequest {
+	return contract.NewInvocationRequest(contract.InvocationInput{
+		InvocationID: invocationID, Model: "fixture-model", UserMessage: "deterministic fixture prompt",
+		Required: contract.NewCapabilitySet(required...),
+	})
+}
+
+func providerSession() *contract.ProviderSession {
+	session := contract.NewProviderSession("fixture", "conversation", "session-1", map[string]string{"region": "test"})
+	return &session
+}
+
+func messagePayload() workers.MessagePayload {
+	return workers.MessagePayload{Role: "assistant", ContentBlocks: []workers.ContentBlock{{Kind: workers.ContentBlockText, Text: "fixture response"}}}
+}

--- a/pkg/services/workers/provider/inferencecontract/validation.go
+++ b/pkg/services/workers/provider/inferencecontract/validation.go
@@ -1,0 +1,282 @@
+package inferencecontract
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+const (
+	maxIdentityLength        = 128
+	maxPrerequisiteCount     = 32
+	maxPrerequisiteName      = 80
+	maxPrerequisiteDetail    = 256
+	maxFailureMessage        = 512
+	maxFailureDiagnostics    = 16
+	maxDiagnosticKeyLength   = 64
+	maxDiagnosticValueLength = 256
+)
+
+// ValidationError reports one provider-neutral contract field that is invalid.
+type ValidationError struct {
+	Field   string
+	Message string
+}
+
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("invalid provider integration %s: %s", e.Field, e.Message)
+}
+
+func invalid(field, message string) error {
+	return &ValidationError{Field: field, Message: message}
+}
+
+// ValidateIdentity checks that an opaque identity uses its canonical form.
+func ValidateIdentity(identity Identity) error {
+	value := string(identity)
+	if value == "" {
+		return invalid("identity", "must not be empty")
+	}
+	if len(value) > maxIdentityLength {
+		return invalid("identity", fmt.Sprintf("must not exceed %d bytes", maxIdentityLength))
+	}
+	if !canonicalIdentifier(value) {
+		return invalid("identity", "must start with a lowercase letter and contain only lowercase letters, digits, dots, or hyphens")
+	}
+	return nil
+}
+
+// ValidateMaximumCapabilities checks declared capabilities and their required
+// dependencies before an integration is used.
+func ValidateMaximumCapabilities(capabilities CapabilitySet) error {
+	if !capabilities.Has(CapabilityPromptSubmission) {
+		return invalid("maximumCapabilities", "must include prompt_submission")
+	}
+	return validateCapabilitySet("maximumCapabilities", capabilities)
+}
+
+// ValidateNegotiatedCapabilities checks request-time capabilities against the
+// integration's declared maximum.
+func ValidateNegotiatedCapabilities(maximum, negotiated CapabilitySet) error {
+	if err := ValidateMaximumCapabilities(maximum); err != nil {
+		return err
+	}
+	if err := validateCapabilitySet("capabilities", negotiated); err != nil {
+		return err
+	}
+	for _, capability := range negotiated.Values() {
+		if !maximum.Has(capability) {
+			return invalid("capabilities", fmt.Sprintf("%q exceeds the declared maximum", capability))
+		}
+	}
+	return nil
+}
+
+func validateCapabilitySet(field string, capabilities CapabilitySet) error {
+	for _, capability := range capabilities.Values() {
+		if !knownCapability(capability) {
+			return invalid(field, fmt.Sprintf("contains unknown capability %q", capability))
+		}
+	}
+	dependencies := []struct {
+		capability Capability
+		required   []Capability
+	}{
+		{CapabilityMessageDeltas, []Capability{CapabilityNativeStreaming}},
+		{CapabilityToolOutputDeltas, []Capability{CapabilityToolLifecycle, CapabilityNativeStreaming}},
+		{CapabilityProviderReconnect, []Capability{CapabilitySessionResume}},
+	}
+	for _, dependency := range dependencies {
+		if !capabilities.Has(dependency.capability) {
+			continue
+		}
+		for _, required := range dependency.required {
+			if !capabilities.Has(required) {
+				return invalid(field, fmt.Sprintf("%q requires %q", dependency.capability, required))
+			}
+		}
+	}
+	return nil
+}
+
+func knownCapability(capability Capability) bool {
+	switch capability {
+	case CapabilityPromptSubmission, CapabilityImageInput, CapabilitySessionResume,
+		CapabilityStructuredOutput, CapabilityNativeStreaming, CapabilityMessageDeltas,
+		CapabilityMessageSnapshots, CapabilityReasoningSummaries, CapabilityToolLifecycle,
+		CapabilityToolOutputDeltas, CapabilityFileChanges, CapabilityPlans, CapabilityUsage,
+		CapabilityStableItemIDs, CapabilityProviderReconnect:
+		return true
+	default:
+		return false
+	}
+}
+
+// ValidateDiscovery checks readiness consistency and ensures that discovery
+// guidance is bounded and safe to expose to customers.
+func ValidateDiscovery(discovery Discovery) error {
+	prerequisites := discovery.Prerequisites()
+	if len(prerequisites) > maxPrerequisiteCount {
+		return invalid("discovery.prerequisites", fmt.Sprintf("must not contain more than %d entries", maxPrerequisiteCount))
+	}
+	if err := validatePrerequisites(prerequisites); err != nil {
+		return err
+	}
+	satisfied, missing := prerequisiteOutcomes(prerequisites)
+	switch discovery.Readiness() {
+	case ReadinessReady:
+		if missing > 0 {
+			return invalid("discovery.readiness", "ready cannot include missing prerequisites")
+		}
+	case ReadinessUnavailable:
+		if missing == 0 {
+			return invalid("discovery.readiness", "unavailable requires a missing prerequisite")
+		}
+	case ReadinessDegraded:
+		if satisfied == 0 || missing == 0 {
+			return invalid("discovery.readiness", "degraded requires both satisfied and missing prerequisites")
+		}
+	default:
+		return invalid("discovery.readiness", fmt.Sprintf("contains unknown outcome %q", discovery.Readiness()))
+	}
+	return nil
+}
+
+func validatePrerequisites(prerequisites []Prerequisite) error {
+	seen := make(map[string]struct{}, len(prerequisites))
+	for index, prerequisite := range prerequisites {
+		field := fmt.Sprintf("discovery.prerequisites[%d]", index)
+		if !knownPrerequisiteKind(prerequisite.Kind()) {
+			return invalid(field+".kind", fmt.Sprintf("contains unknown kind %q", prerequisite.Kind()))
+		}
+		if prerequisite.Status() != PrerequisiteSatisfied && prerequisite.Status() != PrerequisiteMissing {
+			return invalid(field+".status", fmt.Sprintf("contains unknown status %q", prerequisite.Status()))
+		}
+		if err := validatePublicText(field+".name", prerequisite.Name(), maxPrerequisiteName); err != nil {
+			return err
+		}
+		if err := validatePublicText(field+".description", prerequisite.Description(), maxPrerequisiteDetail); err != nil {
+			return err
+		}
+		key := string(prerequisite.Kind()) + "\x00" + prerequisite.Name()
+		if _, exists := seen[key]; exists {
+			return invalid(field, "duplicates a prerequisite kind and name")
+		}
+		seen[key] = struct{}{}
+	}
+	return nil
+}
+
+func knownPrerequisiteKind(kind PrerequisiteKind) bool {
+	return kind == PrerequisiteConfiguration || kind == PrerequisiteCredential || kind == PrerequisiteDependency
+}
+
+func prerequisiteOutcomes(prerequisites []Prerequisite) (satisfied, missing int) {
+	for _, prerequisite := range prerequisites {
+		if prerequisite.Status() == PrerequisiteSatisfied {
+			satisfied++
+		} else if prerequisite.Status() == PrerequisiteMissing {
+			missing++
+		}
+	}
+	return satisfied, missing
+}
+
+// ValidateFailure checks that a normalized failure has a known category and
+// only bounded, customer-safe detail.
+func ValidateFailure(failure Failure) error {
+	if !knownFailureKind(failure.Kind()) {
+		return invalid("failure.kind", fmt.Sprintf("contains unknown category %q", failure.Kind()))
+	}
+	if err := validatePublicText("failure.message", failure.Message(), maxFailureMessage); err != nil {
+		return err
+	}
+	diagnostics := failure.Diagnostics()
+	if len(diagnostics) > maxFailureDiagnostics {
+		return invalid("failure.diagnostics", fmt.Sprintf("must not contain more than %d entries", maxFailureDiagnostics))
+	}
+	for key, value := range diagnostics {
+		if len(key) > maxDiagnosticKeyLength || !canonicalIdentifier(key) {
+			return invalid("failure.diagnostics", fmt.Sprintf("contains invalid key %q", key))
+		}
+		if err := validatePublicText("failure.diagnostics."+key, value, maxDiagnosticValueLength); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func knownFailureKind(kind FailureKind) bool {
+	switch kind {
+	case FailureAuthentication, FailureInvalidRequest, FailureThrottled, FailureTimeout,
+		FailureCanceled, FailureDependency, FailureMalformedOutput, FailureUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+func validatePublicText(field, value string, maximum int) error {
+	if value == "" || strings.TrimSpace(value) != value {
+		return invalid(field, "must be non-empty canonical text without surrounding whitespace")
+	}
+	if len(value) > maximum {
+		return invalid(field, fmt.Sprintf("must not exceed %d bytes", maximum))
+	}
+	if strings.ContainsAny(value, "\r\n\x00") || hasUnsafeDetail(value) {
+		return invalid(field, "must not contain credentials, environment values, machine-local paths, or native payloads")
+	}
+	return nil
+}
+
+func hasUnsafeDetail(value string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	markers := []string{
+		"authorization:", "bearer ", "api_key=", "api_key:", "api-key=", "api-key:",
+		"apikey=", "apikey:", "token=", "token:", "secret=", "secret:", "password=",
+		"password:", "credential=", "credential:", "prompt:", "-----begin", "sk-", "ghp_",
+		"aiza", "ya29.", "/home/", "/users/", `c:\users\`, "$home", "${", "%appdata%",
+	}
+	for _, marker := range markers {
+		if strings.Contains(normalized, marker) {
+			return true
+		}
+	}
+	return strings.ContainsAny(normalized, "{}[]") || hasEnvironmentAssignment(value)
+}
+
+func hasEnvironmentAssignment(value string) bool {
+	for _, field := range strings.Fields(value) {
+		name, _, found := strings.Cut(field, "=")
+		if !found || !strings.Contains(name, "_") || name == "" {
+			continue
+		}
+		allEnvironmentName := true
+		for _, character := range name {
+			if character != '_' && !unicode.IsUpper(character) && !unicode.IsDigit(character) {
+				allEnvironmentName = false
+				break
+			}
+		}
+		if allEnvironmentName {
+			return true
+		}
+	}
+	return false
+}
+
+func canonicalIdentifier(value string) bool {
+	for index, character := range value {
+		if character >= 'a' && character <= 'z' {
+			continue
+		}
+		if index > 0 && (character >= '0' && character <= '9' || character == '.' || character == '-') {
+			if character != '.' && character != '-' || index+1 < len(value) {
+				continue
+			}
+		}
+		return false
+	}
+	return !strings.Contains(value, "..") && !strings.Contains(value, "--") &&
+		!strings.Contains(value, ".-") && !strings.Contains(value, "-.")
+}

--- a/pkg/services/workers/provider/inferencecontract/validation_test.go
+++ b/pkg/services/workers/provider/inferencecontract/validation_test.go
@@ -1,0 +1,200 @@
+package inferencecontract_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	contract "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+)
+
+func TestValidateIdentity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		identity contract.Identity
+		wantErr  bool
+	}{
+		{name: "dotted", identity: "acme.alpha"},
+		{name: "hyphenated", identity: "customer-provider-42"},
+		{name: "empty", wantErr: true},
+		{name: "uppercase is non-canonical", identity: "Acme", wantErr: true},
+		{name: "whitespace", identity: "acme provider", wantErr: true},
+		{name: "repeated separator", identity: "acme..provider", wantErr: true},
+		{name: "leading digit", identity: "42-provider", wantErr: true},
+		{name: "too long", identity: contract.Identity("a" + strings.Repeat("b", 128)), wantErr: true},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			err := contract.ValidateIdentity(test.identity)
+			assertValidationOutcome(t, err, test.wantErr)
+		})
+	}
+}
+
+func TestValidateMaximumCapabilities(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		capabilities contract.CapabilitySet
+		wantErr      bool
+	}{
+		{name: "final only", capabilities: contract.NewCapabilitySet(contract.CapabilityPromptSubmission)},
+		{name: "streaming deltas", capabilities: contract.NewCapabilitySet(contract.CapabilityPromptSubmission, contract.CapabilityNativeStreaming, contract.CapabilityMessageDeltas)},
+		{name: "missing prompt submission", capabilities: contract.NewCapabilitySet(contract.CapabilityUsage), wantErr: true},
+		{name: "delta without streaming", capabilities: contract.NewCapabilitySet(contract.CapabilityPromptSubmission, contract.CapabilityMessageDeltas), wantErr: true},
+		{name: "tool output without lifecycle", capabilities: contract.NewCapabilitySet(contract.CapabilityPromptSubmission, contract.CapabilityNativeStreaming, contract.CapabilityToolOutputDeltas), wantErr: true},
+		{name: "reconnect without resume", capabilities: contract.NewCapabilitySet(contract.CapabilityPromptSubmission, contract.CapabilityProviderReconnect), wantErr: true},
+		{name: "unknown", capabilities: contract.NewCapabilitySet(contract.CapabilityPromptSubmission, contract.Capability("native_magic")), wantErr: true},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			assertValidationOutcome(t, contract.ValidateMaximumCapabilities(test.capabilities), test.wantErr)
+		})
+	}
+}
+
+func TestValidateNegotiatedCapabilitiesRejectsEscalation(t *testing.T) {
+	t.Parallel()
+
+	maximum := contract.NewCapabilitySet(contract.CapabilityPromptSubmission, contract.CapabilityMessageSnapshots)
+	if err := contract.ValidateNegotiatedCapabilities(maximum, contract.NewCapabilitySet(contract.CapabilityPromptSubmission)); err != nil {
+		t.Fatalf("valid subset: %v", err)
+	}
+	err := contract.ValidateNegotiatedCapabilities(maximum, contract.NewCapabilitySet(contract.CapabilityPromptSubmission, contract.CapabilityNativeStreaming))
+	assertValidationOutcome(t, err, true)
+}
+
+func TestValidateDiscovery(t *testing.T) {
+	t.Parallel()
+
+	satisfied := prerequisite(contract.PrerequisiteSatisfied, "provider configuration is available")
+	missing := contract.NewPrerequisite(
+		contract.PrerequisiteDependency,
+		"provider endpoint",
+		contract.PrerequisiteMissing,
+		"make the provider endpoint available before use",
+	)
+	tests := []struct {
+		name      string
+		discovery contract.Discovery
+		wantErr   bool
+	}{
+		{name: "ready", discovery: contract.NewDiscovery(contract.ReadinessReady, satisfied)},
+		{name: "ready without prerequisites", discovery: contract.NewDiscovery(contract.ReadinessReady)},
+		{name: "unavailable", discovery: contract.NewDiscovery(contract.ReadinessUnavailable, missing)},
+		{name: "degraded", discovery: contract.NewDiscovery(contract.ReadinessDegraded, satisfied, missing)},
+		{name: "unknown readiness", discovery: contract.NewDiscovery(contract.Readiness("starting")), wantErr: true},
+		{name: "ready contradicts missing", discovery: contract.NewDiscovery(contract.ReadinessReady, missing), wantErr: true},
+		{name: "unavailable lacks missing", discovery: contract.NewDiscovery(contract.ReadinessUnavailable, satisfied), wantErr: true},
+		{name: "degraded lacks mixed outcomes", discovery: contract.NewDiscovery(contract.ReadinessDegraded, missing), wantErr: true},
+		{name: "unknown kind", discovery: contract.NewDiscovery(contract.ReadinessReady, contract.NewPrerequisite("native", "provider", contract.PrerequisiteSatisfied, "available")), wantErr: true},
+		{name: "unknown status", discovery: contract.NewDiscovery(contract.ReadinessReady, contract.NewPrerequisite(contract.PrerequisiteDependency, "provider", "checking", "available")), wantErr: true},
+		{name: "duplicate prerequisite", discovery: contract.NewDiscovery(contract.ReadinessReady, satisfied, satisfied), wantErr: true},
+		{name: "credential detail", discovery: contract.NewDiscovery(contract.ReadinessReady, prerequisite(contract.PrerequisiteSatisfied, "API_KEY=customer-secret")), wantErr: true},
+		{name: "machine local path", discovery: contract.NewDiscovery(contract.ReadinessReady, prerequisite(contract.PrerequisiteSatisfied, `configuration loaded from C:\Users\customer\.provider`)), wantErr: true},
+		{name: "native payload", discovery: contract.NewDiscovery(contract.ReadinessReady, prerequisite(contract.PrerequisiteSatisfied, `{"status":"ok"}`)), wantErr: true},
+		{name: "unbounded detail", discovery: contract.NewDiscovery(contract.ReadinessReady, prerequisite(contract.PrerequisiteSatisfied, strings.Repeat("x", 257))), wantErr: true},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			assertValidationOutcome(t, contract.ValidateDiscovery(test.discovery), test.wantErr)
+		})
+	}
+}
+
+func TestValidateFailure(t *testing.T) {
+	t.Parallel()
+
+	for _, kind := range []contract.FailureKind{
+		contract.FailureAuthentication,
+		contract.FailureInvalidRequest,
+		contract.FailureThrottled,
+		contract.FailureTimeout,
+		contract.FailureCanceled,
+		contract.FailureDependency,
+		contract.FailureMalformedOutput,
+		contract.FailureUnknown,
+	} {
+		kind := kind
+		t.Run(string(kind), func(t *testing.T) {
+			t.Parallel()
+			failure := contract.NewFailure(contract.FailureInput{Kind: kind, Message: "provider request did not complete", Diagnostics: map[string]string{"request.code": "unavailable"}})
+			if err := contract.ValidateFailure(failure); err != nil {
+				t.Fatalf("ValidateFailure: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateFailureRejectsUnsafeOrUnboundedDetail(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input contract.FailureInput
+	}{
+		{name: "unknown kind", input: contract.FailureInput{Kind: "native", Message: "failed"}},
+		{name: "empty message", input: contract.FailureInput{Kind: contract.FailureUnknown}},
+		{name: "long message", input: contract.FailureInput{Kind: contract.FailureUnknown, Message: strings.Repeat("x", 513)}},
+		{name: "credential in message", input: contract.FailureInput{Kind: contract.FailureAuthentication, Message: "authorization: Bearer customer-token"}},
+		{name: "prompt in native payload", input: contract.FailureInput{Kind: contract.FailureMalformedOutput, Message: `{"prompt":"private input"}`}},
+		{name: "raw environment", input: contract.FailureInput{Kind: contract.FailureDependency, Message: "provider failed", Diagnostics: map[string]string{"detail": "OPENAI_API_KEY=private"}}},
+		{name: "invalid diagnostic key", input: contract.FailureInput{Kind: contract.FailureUnknown, Message: "provider failed", Diagnostics: map[string]string{"Native Payload": "failure"}}},
+		{name: "long diagnostic", input: contract.FailureInput{Kind: contract.FailureUnknown, Message: "provider failed", Diagnostics: map[string]string{"detail": strings.Repeat("x", 257)}}},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			failure := contract.NewFailure(test.input)
+			assertValidationOutcome(t, contract.ValidateFailure(failure), true)
+		})
+	}
+}
+
+func TestFailureDetachesDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	diagnostics := map[string]string{"request.code": "unavailable"}
+	failure := contract.NewFailure(contract.FailureInput{
+		Kind:        contract.FailureDependency,
+		Message:     "provider dependency is unavailable",
+		Diagnostics: diagnostics,
+	})
+	diagnostics["request.code"] = "mutated"
+	returned := failure.Diagnostics()
+	returned["request.code"] = "mutated again"
+	if got := failure.Diagnostics()["request.code"]; got != "unavailable" {
+		t.Fatalf("diagnostic = %q, want detached unavailable", got)
+	}
+}
+
+func prerequisite(status contract.PrerequisiteStatus, detail string) contract.Prerequisite {
+	return contract.NewPrerequisite(contract.PrerequisiteConfiguration, "provider configuration", status, detail)
+}
+
+func assertValidationOutcome(t *testing.T, err error, wantErr bool) {
+	t.Helper()
+	if !wantErr && err != nil {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+	if !wantErr {
+		return
+	}
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	var validationErr *contract.ValidationError
+	if !errors.As(err, &validationErr) || validationErr.Field == "" || validationErr.Message == "" {
+		t.Fatalf("error = %#v, want actionable ValidationError", err)
+	}
+}


### PR DESCRIPTION
{
  "project": "Provider Integration Protocol and Conformance Testkit",
  "branchName": "provider-integration-protocol-testkit",
  "description": "Publish a customer-implementable, provider-neutral Go inference contract with explicit identity, capabilities, readiness/discovery, invocation, response-event drafts, normalized completion, validation, and a reusable fake-provider conformance testkit, without migrating built-in providers or taking ownership from Factory Sessions and adjacent services.",
  "context": {
    "customerAsk": "Publish the provider-neutral Go contract that a customer can implement to integrate a model provider. The contract must cover provider identity, maximum and request-time capabilities, readiness and discovery, invocation, provider-neutral response-event drafts, normalized failures, and optional Provider Session metadata. Supply strict validation and a reusable fake-provider conformance protocol, without migrating built-in providers or taking ownership away from Factory Sessions and adjacent services.",
    "problem": "The runtime has useful low-level adapter and response-draft concepts, but it does not yet expose one small, authoritative, customer-implementable provider protocol. Provider behavior is difficult to validate consistently, so capability escalation, malformed event lifecycles, unsafe diagnostic detail, late writes, or disagreement between streamed events and the authoritative result can escape a common contract. Integration authors also lack a reusable black-box suite that proves success and adverse execution behavior before their provider is connected to shared orchestration.",
    "solution": "Define the public provider-neutral Go integration contract and immutable value types under the Workers-owned provider inference boundary. Give integrations explicit operations for identity and maximum capabilities, readiness/discovery, request-sensitive capability negotiation, and one invocation that writes validated semantic drafts before closing with exactly one authoritative response or normalized failure. Permit optional generic Provider Session metadata on completion, add deterministic validation for all contract invariants, and publish a black-box conformance testkit driven by a fake provider and controllable writer. Keep the batch in provider-neutral Go contract and testkit paths, with no generated API work or built-in provider migration."
  },
  "acceptanceCriteria": [
    "AC-1: A customer can implement one public provider-neutral Go integration contract that owns identity, maximum and request-time capabilities, readiness/discovery, invocation, normalized failures, provider-neutral response-event drafts, and optional generic Provider Session metadata.",
    "AC-2: Contract values do not expose or take ownership of Factory Session envelopes, event IDs or sequence allocation, publication, retention or replay, worktree lifecycle, provider transcript history, transport grammars, generated API types, Wire types, or service locators.",
    "AC-3: Validation rejects invalid identity and readiness/discovery values, capability escalation, malformed or uncorrelated event lifecycles, unsafe failure detail, writes or closes after termination, duplicate or missing close, and disagreement between emitted terminal data and the authoritative completion.",
    "AC-4: A reusable black-box testkit using a deterministic fake provider proves final-only and streaming success, normalized failure, cancellation, timeout, response-writer backpressure, correlated tool lifecycle, final-result agreement, and exactly-once close behavior.",
    "AC-5: The protocol and conformance scenarios treat provider identity as opaque; equivalent integrations behave the same under distinct valid identities, and this foundation adds no concrete-provider branch or built-in migration.",
    "AC-6: Focused package and contract tests pass, with race detection or repeated-run evidence for cancellation, backpressure, and terminal-state behavior where concurrency is exercised.",
    "AC-7: Quality checks pass (typecheck, lint, tests)."
  ],
  "userStories": [
    {
      "id": "provider-integration-protocol-testkit-001",
      "title": "Implement the provider-neutral integration boundary",
      "description": "As an integration author, I want one provider-neutral Go contract with immutable request and result values so I can expose provider availability and invoke inference without depending on Factory Session or provider-native runtime types.",
      "acceptanceCriteria": [
        "The public integration boundary exposes stable provider identity, declared maximum capabilities, readiness/discovery, request-sensitive capability negotiation, and one invocation operation using provider-neutral request and response-writer values.",
        "Discovery reports sanitized prerequisites and readiness outcomes without credentials, raw environment values, machine-local secrets, or provider-native payload types.",
        "Invocation completion represents exactly one authoritative response or one normalized failure and may include detached, generic Provider Session identity/metadata that cannot be mutated through caller-owned input after return.",
        "Progress uses the existing Workers-owned provider-neutral response-event draft vocabulary; providers cannot supply Factory Session envelopes, event IDs, sequence numbers, timestamps, replay gaps, or STREAM_GAP drafts.",
        "The contract contains no subprocess/CLI grammar, HTTP or generated API type, Wire type, Factory Session store, worktree lifecycle, transcript-history reader, or service locator.",
        "Two deterministic fake integrations with different valid identities satisfy the same contract behavior without an identity-specific orchestration option.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "provider-integration-protocol-testkit-002",
      "title": "Reject invalid identity, discovery, capabilities, and failures",
      "description": "As a runtime maintainer, I want reusable boundary validation so an invalid or unsafe integration fails deterministically before its output reaches shared orchestration.",
      "acceptanceCriteria": [
        "Identity validation rejects empty, malformed, or non-canonical identities and returns an actionable provider-neutral validation error.",
        "Maximum capability validation rejects impossible combinations, and request-time negotiation rejects every execution or response-fidelity capability not contained in the integration's declared maximum.",
        "Readiness/discovery validation rejects incomplete or contradictory outcomes and details containing credentials, raw environment values, machine-local secret material, or unbounded native output.",
        "Normalized failures distinguish at least authentication, invalid request, throttling, timeout, cancellation, dependency failure, malformed provider output, and unknown failure without exposing prompts, credentials, raw environment values, or unsafe native payloads.",
        "Failure messages and diagnostics are bounded, detached from mutable provider buffers, and safe to carry across the public contract.",
        "Focused table-driven tests prove accepted and rejected cases without requiring a live provider, process, filesystem, or network dependency.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "provider-integration-protocol-testkit-003",
      "title": "Enforce the event and completion lifecycle",
      "description": "As shared orchestration, I want provider output checked as an ordered single-terminal protocol so malformed progress or contradictory results cannot be published as valid inference.",
      "acceptanceCriteria": [
        "The response writer accepts only valid provider-writable draft kinds, phases, payloads, provenance, and invocation correlation, while rejecting Factory Session-owned STREAM_GAP and forged cross-invocation correlation.",
        "Lifecycle validation rejects updates before their corresponding start, duplicate terminal phases, writes after close, a second close, and an invocation that returns successfully without closing.",
        "Tool start, update, bounded output, and completion drafts retain one stable tool correlation; malformed, reordered, or cross-tool sequences fail deterministically.",
        "Close accepts exactly one response or normalized failure, flushes any valid buffered terminal state first, and rejects an empty completion or a completion containing both outcomes.",
        "When final response content is represented in emitted message or terminal drafts, the authoritative response agrees with those drafts; disagreement is a contract violation rather than a silently chosen winner.",
        "An invocation error before close yields one normalized failure completion, while an error or write attempted after a successful close cannot replace or duplicate the established terminal outcome.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "provider-integration-protocol-testkit-004",
      "title": "Prove successful integrations with a reusable conformance testkit",
      "description": "As an integration author, I want a reusable black-box suite for successful provider behavior so I can prove my final-only or streaming implementation conforms without copying repository-specific tests.",
      "acceptanceCriteria": [
        "The testkit accepts an integration factory and sanitized deterministic fixtures through public protocol values, and reports scenario failures with enough provider-neutral context to identify the violated rule.",
        "A final-only fake provider proves readiness/discovery, capability negotiation, invocation, one authoritative response, optional detached Provider Session metadata, and exactly one close without fabricating streaming capability or delta events.",
        "A streaming fake provider proves ordered and correlated run/message progress, valid terminal flushing, final-result agreement, and exactly one close.",
        "A tool-capable fake proves stable correlation across tool start, update, bounded output, and completion before the authoritative final response closes the stream.",
        "The same success scenarios pass for at least two arbitrary valid provider identities, demonstrating that the suite and protocol do not depend on a built-in identity.",
        "Testkit consumers do not need Factory Session stores, process composition, provider executables, credentials, worktrees, transcript readers, or generated API artifacts.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    },
    {
      "id": "provider-integration-protocol-testkit-005",
      "title": "Prove adverse and concurrent protocol behavior",
      "description": "As an integration author, I want deterministic conformance scenarios for failures and interruption so provider work terminates safely under cancellation, deadlines, and a blocked or failed response sink.",
      "acceptanceCriteria": [
        "The fake provider proves each normalized failure category closes once with a safe bounded failure and never returns a competing success response.",
        "Cancellation stops provider observation/work, normalizes to cancellation, emits at most one terminal outcome, and does not permit later writes.",
        "Deadline expiry stops provider observation/work, normalizes to timeout rather than generic cancellation, emits at most one terminal outcome, and does not permit later writes.",
        "A controllable response writer proves backpressure is propagated through WriteEvent; when the sink returns an error, provider observation stops, that error is returned to orchestration, and no later draft or close succeeds.",
        "Double-close, write-after-close, return-without-close, and result/event disagreement fixtures fail with deterministic contract violations while preserving the first terminal outcome.",
        "Cancellation, timeout, backpressure, and close-race scenarios pass focused race detection or repeated runs without hangs, leaks, data races, or intermittent extra terminal outcomes.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": ""
    }
  ]
}
