### PR TITLE
Fix public package releases

### DIFF
--- a/.github/workflows/development-package.yml
+++ b/.github/workflows/development-package.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Prepare the canonical frontend package candidates
         run: >-
           make ui-public-package-publish-prepare
-          PACKAGE_VERSION="0.0.0-dev.${{ github.run_id }}.${{ github.event.pull_request.head.sha }}"
+          PACKAGE_VERSION="0.0.2-dev.${{ github.run_id }}.${{ github.event.pull_request.head.sha }}"
           PACKAGE_OUTPUT=".artifacts/public-development-candidate"
 
       - name: Upload the frontend package candidates and evidence
@@ -199,7 +199,7 @@ jobs:
       - name: Prepare the canonical frontend package candidates
         run: >-
           make ui-public-package-publish-prepare
-          PACKAGE_VERSION="0.0.0-dev.${{ github.run_id }}.${{ github.sha }}"
+          PACKAGE_VERSION="0.0.2-dev.${{ github.run_id }}.${{ github.sha }}"
           PACKAGE_OUTPUT=".artifacts/public-development-candidate"
 
       - name: Upload the frontend package candidates and evidence

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,13 +109,14 @@ jobs:
         working-directory: ui
         run: bun install --frozen-lockfile
 
-      - name: Prepare the canonical frontend package release candidates
+      - name: Prepare all canonical npm package release candidates
         run: >-
           make ui-public-package-publish-prepare
           PACKAGE_VERSION="${{ needs.resolve-release-tag.outputs.release_version }}"
           PACKAGE_OUTPUT=".artifacts/public-release-candidate"
+          PACKAGE_PREPARE_ARGS="--include-release-packages"
 
-      - name: Publish and verify the canonical frontend package family
+      - name: Publish and verify all canonical npm packages
         working-directory: ui
         run: >-
           npm run publish:public-packages --

--- a/Makefile
+++ b/Makefile
@@ -640,7 +640,7 @@ ui-public-package-release:
 	cd ui && $(UI_SCRIPT) verify:public-packages
 
 ui-public-package-publish-prepare:
-	cd ui && $(UI_SCRIPT) publish:public-packages:prepare -- --version "$(PACKAGE_VERSION)" --output-directory "$(abspath $(or $(PACKAGE_OUTPUT),.artifacts/public-packages))"
+	cd ui && $(UI_SCRIPT) publish:public-packages:prepare -- --version "$(PACKAGE_VERSION)" --output-directory "$(abspath $(or $(PACKAGE_OUTPUT),.artifacts/public-packages))" $(PACKAGE_PREPARE_ARGS)
 
 clean:
 	$(GO) clean ./...

--- a/packages/api/generated/manifest.json
+++ b/packages/api/generated/manifest.json
@@ -371,6 +371,6 @@
   },
   "formatVersion": "1.0.0",
   "packageId": "you-agent-factory.api",
-  "packageVersion": "0.0.2",
+  "packageVersion": "0.0.0",
   "sourceCommit": "014042306e999e08a2157e1f7a95fbd291cff646"
 }

--- a/packages/api/generated/manifest.json
+++ b/packages/api/generated/manifest.json
@@ -371,6 +371,6 @@
   },
   "formatVersion": "1.0.0",
   "packageId": "you-agent-factory.api",
-  "packageVersion": "0.0.0",
+  "packageVersion": "0.0.2",
   "sourceCommit": "014042306e999e08a2157e1f7a95fbd291cff646"
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@you-agent-factory/api",
-  "version": "0.0.0",
+  "version": "0.0.2",
   "description": "Raw JSON and YAML contract artifacts for you-agent-factory consumers.",
   "license": "MIT",
   "repository": {

--- a/packages/packaged-factories/package.json
+++ b/packages/packaged-factories/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@you-agent-factory/packaged-factories",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.0.2",
+  "private": false,
   "description": "Human-readable source files for the first-party Factories shipped with You Agent Factory.",
   "license": "MIT",
   "repository": {

--- a/scripts/api-package-candidate.test.mjs
+++ b/scripts/api-package-candidate.test.mjs
@@ -80,7 +80,7 @@ test("preparation packs one attributable candidate without mutating package sour
 	assert.deepEqual(await readFile(contractManifestPath), contractManifestBefore);
 	assert.deepEqual(result.evidence, {
 		packageName: "@you-agent-factory/api",
-		candidateVersion: "0.0.0-dev.9876543210.0123456789ab",
+		candidateVersion: "0.0.2-dev.9876543210.0123456789ab",
 		sourceCommit,
 		contractDigest: digest(contractManifestBefore),
 		artifactDigest: digest(await readFile(result.tarballPath)),

--- a/scripts/api-package-consumer.test.mjs
+++ b/scripts/api-package-consumer.test.mjs
@@ -207,7 +207,7 @@ test("consumer verification rejects semantically substituted manifest and schema
 	const fixture = await temporaryDirectory(t, "you-api-consumer-semantics-");
 	const packageRoot = join(fixture, "package");
 	const substitutions = [
-		["manifest", { name: "@you-agent-factory/api", version: "0.0.2" }],
+		["manifest", { name: "@you-agent-factory/api", version: "0.0.0" }],
 		["schemas/you-config", { formatVersion: "global-config-topology/v1" }],
 		["schemas/factory", { formatVersion: "factory-openapi-parity/v1" }],
 		["schemas/mock-workers", { formatVersion: "mock-workers-topology/v1" }],

--- a/scripts/api-package-consumer.test.mjs
+++ b/scripts/api-package-consumer.test.mjs
@@ -207,7 +207,7 @@ test("consumer verification rejects semantically substituted manifest and schema
 	const fixture = await temporaryDirectory(t, "you-api-consumer-semantics-");
 	const packageRoot = join(fixture, "package");
 	const substitutions = [
-		["manifest", { name: "@you-agent-factory/api", version: "0.0.0" }],
+		["manifest", { name: "@you-agent-factory/api", version: "0.0.2" }],
 		["schemas/you-config", { formatVersion: "global-config-topology/v1" }],
 		["schemas/factory", { formatVersion: "factory-openapi-parity/v1" }],
 		["schemas/mock-workers", { formatVersion: "mock-workers-topology/v1" }],

--- a/scripts/api-package-pr-dry-run.test.mjs
+++ b/scripts/api-package-pr-dry-run.test.mjs
@@ -22,7 +22,7 @@ test("pull request dry run verifies the exact prepared candidate without a regis
 	const tarballPath = join(outputDirectory, "candidate.tgz");
 	const evidence = {
 		packageName: "@you-agent-factory/api",
-		candidateVersion: "0.0.0-dev.42.0123456789ab",
+		candidateVersion: "0.0.2-dev.42.0123456789ab",
 		sourceCommit,
 		contractDigest: `sha256:${"a".repeat(64)}`,
 		artifactDigest: `sha256:${"b".repeat(64)}`,

--- a/scripts/api-package-publish.test.mjs
+++ b/scripts/api-package-publish.test.mjs
@@ -13,7 +13,7 @@ import { RECONCILIATION_OUTCOMES } from "./api-package-registry.mjs";
 
 const evidence = {
 	packageName: "@you-agent-factory/api",
-	candidateVersion: "0.0.0-dev.42.0123456789ab",
+	candidateVersion: "0.0.2-dev.42.0123456789ab",
 	sourceCommit: "0123456789abcdef0123456789abcdef01234567",
 	contractDigest: `sha256:${"a".repeat(64)}`,
 	artifactDigest: `sha256:${"b".repeat(64)}`,

--- a/scripts/api-package-registry.test.mjs
+++ b/scripts/api-package-registry.test.mjs
@@ -29,7 +29,7 @@ async function candidateFixture(t) {
 		tarballPath,
 		evidence: {
 			packageName: "@you-agent-factory/api",
-			candidateVersion: "0.0.0-dev.42.0123456789ab",
+			candidateVersion: "0.0.2-dev.42.0123456789ab",
 			sourceCommit,
 			contractDigest: digest("contract manifest"),
 			artifactDigest: digest(contents),

--- a/ui/packages/README.md
+++ b/ui/packages/README.md
@@ -226,7 +226,7 @@ make ui-public-package-publish-prepare \
 ```
 
 Pull requests run the same candidate preparation as a dry run. Successful
-protected-main builds publish an immutable `0.0.0-dev.<run>.<commit>` family
+protected-main builds publish an immutable `0.0.2-dev.<run>.<commit>` family
 under the npm `dev` tag. A successful `vX.Y.Z` release-candidate workflow lets
 the release workflow publish all five packages at `X.Y.Z` under `latest` using
 npm trusted publishing. Internal package dependency and peer-dependency pins

--- a/ui/packages/client/package.json
+++ b/ui/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@you-agent-factory/client",
-  "version": "0.0.0",
+  "version": "0.0.2",
   "description": "Transport-neutral Factory contracts and recording utilities.",
   "license": "MIT",
   "repository": {
@@ -34,6 +34,7 @@
     "check:pack": "node scripts/verify-package-pack.mjs",
     "check:generated": "node scripts/generate-contracts.mjs --check",
     "generate": "node scripts/generate-contracts.mjs",
+    "prepack": "bun run build",
     "test": "vitest run --config vitest.config.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit --pretty false",
     "verify": "bun run check:generated && bun run typecheck && bun run test && bun run build && bun run check:pack && bun run check:installed-consumer"

--- a/ui/packages/client/scripts/verify-package-pack.mjs
+++ b/ui/packages/client/scripts/verify-package-pack.mjs
@@ -68,7 +68,6 @@ async function runPack(destination) {
       ...npm.args,
       "pack",
       "--json",
-      "--ignore-scripts",
       "--pack-destination",
       destination,
       packageRoot,
@@ -122,11 +121,7 @@ async function verifyRuntimeBoundary(actualFiles, manifest) {
 }
 
 export async function packAndVerify(destination) {
-  await execFileAsync(
-    process.execPath,
-    [path.join(packageRoot, "scripts", "build-package.mjs")],
-    { cwd: packageRoot, maxBuffer: 10 * 1024 * 1024 },
-  );
+  await rm(path.join(packageRoot, "dist"), { force: true, recursive: true });
   await mkdir(destination, { recursive: true });
   const report = await runPack(destination);
   const actualFiles = report.files.map(({ path: file }) => file).sort();

--- a/ui/packages/components/package.json
+++ b/ui/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@you-agent-factory/components",
-  "version": "0.0.0",
+  "version": "0.0.2",
   "description": "Domain-free React components, design tokens, and utilities for public visualizers.",
   "license": "MIT",
   "repository": {
@@ -111,6 +111,7 @@
     "check:pack": "node scripts/verify-package-pack.mjs",
     "check:package-boundary": "node scripts/check-package-boundary.mjs",
     "check:package-dependency-direction": "node scripts/check-package-dependency-direction.mjs",
+    "prepack": "bun run build",
     "storybook": "storybook dev -p 6017",
     "test": "bun run test:unit && bun run check:package-boundary && bun run check:package-dependency-direction",
     "test:build": "bun run build && vitest run --config vitest.build.config.ts",

--- a/ui/packages/components/scripts/verify-package-pack.mjs
+++ b/ui/packages/components/scripts/verify-package-pack.mjs
@@ -171,22 +171,7 @@ export async function validatePackedInventory({
   return actualFiles;
 }
 
-async function runBuild(packageRoot) {
-  try {
-    await execFileAsync(
-      process.execPath,
-      [path.join(packageRoot, "scripts", "build-package.mjs")],
-      { cwd: packageRoot, maxBuffer: 10 * 1024 * 1024 },
-    );
-  } catch (error) {
-    throw new Error(
-      `[components-package-pack] package build failed\n${error.stderr?.trim() ?? error.message}`,
-      { cause: error },
-    );
-  }
-}
-
-async function runNpmPack(packageRoot, packDestination) {
+async function runNpmPack(packageRoot, packDestination, ignoreScripts) {
   let npmExecutable = "npm";
   let npmArguments = [];
   if (process.platform === "win32") {
@@ -211,7 +196,7 @@ async function runNpmPack(packageRoot, packDestination) {
         ...npmArguments,
         "pack",
         "--json",
-        "--ignore-scripts",
+        ...(ignoreScripts ? ["--ignore-scripts"] : []),
         "--pack-destination",
         packDestination,
         packageRoot,
@@ -235,9 +220,11 @@ export async function packAndVerify({
   const packageRoot = path.resolve(packageDirectory);
   const destination = path.resolve(packDestination);
   await mkdir(destination, { recursive: true });
-  if (build) await runBuild(packageRoot);
+  if (build) {
+    await rm(path.join(packageRoot, "dist"), { force: true, recursive: true });
+  }
 
-  const stdout = await runNpmPack(packageRoot, destination);
+  const stdout = await runNpmPack(packageRoot, destination, !build);
   let reports;
   try {
     reports = JSON.parse(stdout);

--- a/ui/packages/factory-emulator/bun.lock
+++ b/ui/packages/factory-emulator/bun.lock
@@ -15,7 +15,7 @@
         "vitest": "4.1.3",
       },
       "peerDependencies": {
-        "@you-agent-factory/client": "0.0.0",
+        "@you-agent-factory/client": "0.0.2",
       },
       "optionalPeers": [
         "@you-agent-factory/client",

--- a/ui/packages/factory-emulator/package.json
+++ b/ui/packages/factory-emulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@you-agent-factory/factory-emulator",
-  "version": "0.0.0",
+  "version": "0.0.2",
   "description": "Deterministic Factory emulator contracts and caller-owned event sinks.",
   "license": "MIT",
   "repository": {
@@ -39,6 +39,7 @@
     "check:runtime-reference-conformance": "node scripts/check-runtime-reference-conformance.mjs",
     "generate": "node scripts/generate-scenario-schema.mjs",
     "lint": "biome check src scripts vitest.config.ts",
+    "prepack": "bun run build",
     "test": "vitest run --config vitest.config.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit --pretty false",
     "verify": "bun run verify:release && bun run check:changed-paths",
@@ -49,7 +50,7 @@
     "ajv-formats": "^3.0.1"
   },
   "peerDependencies": {
-    "@you-agent-factory/client": "0.0.0"
+    "@you-agent-factory/client": "0.0.2"
   },
   "peerDependenciesMeta": {
     "@you-agent-factory/client": {

--- a/ui/packages/factory-emulator/scripts/verify-package-pack.mjs
+++ b/ui/packages/factory-emulator/scripts/verify-package-pack.mjs
@@ -81,7 +81,6 @@ async function runPack(destination) {
       ...npm.args,
       "pack",
       "--json",
-      "--ignore-scripts",
       "--pack-destination",
       destination,
       packageRoot,
@@ -127,11 +126,7 @@ async function verifyRuntimeBoundary(actualFiles, manifest) {
 }
 
 export async function packAndVerify(destination) {
-  await execFileAsync(
-    process.execPath,
-    [path.join(packageRoot, "scripts", "build-package.mjs")],
-    { cwd: packageRoot, maxBuffer: 10 * 1024 * 1024 },
-  );
+  await rm(path.join(packageRoot, "dist"), { force: true, recursive: true });
   await mkdir(destination, { recursive: true });
   const report = await runPack(destination);
   const actualFiles = report.files.map(({ path: file }) => file).sort();
@@ -156,7 +151,7 @@ export async function packAndVerify(destination) {
   }
   if (
     JSON.stringify(manifest.peerDependencies ?? {}) !==
-    JSON.stringify({ "@you-agent-factory/client": "0.0.0" })
+    JSON.stringify({ "@you-agent-factory/client": "0.0.2" })
   ) {
     throw new Error("[factory-emulator-pack] unexpected client peer contract");
   }

--- a/ui/packages/factory-replay/bun.lock
+++ b/ui/packages/factory-replay/bun.lock
@@ -9,7 +9,7 @@
         "vitest": "4.1.3",
       },
       "peerDependencies": {
-        "@you-agent-factory/client": "0.0.0",
+        "@you-agent-factory/client": "0.0.2",
       },
       "optionalPeers": [
         "@you-agent-factory/client",

--- a/ui/packages/factory-replay/package.json
+++ b/ui/packages/factory-replay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@you-agent-factory/factory-replay",
-  "version": "0.0.0",
+  "version": "0.0.2",
   "description": "Deterministic, framework-independent Factory event replay.",
   "license": "MIT",
   "repository": {
@@ -30,13 +30,14 @@
     "check:installed-consumer": "node scripts/verify-installed-consumer.mjs",
     "check:pack": "node scripts/verify-package-pack.mjs",
     "check:package-boundary": "node scripts/check-package-boundary.mjs",
+    "prepack": "bun run build",
     "prepare:client": "bun run --cwd ../client build",
     "test": "bun run prepare:client && vitest run --config vitest.config.ts",
     "typecheck": "bun run prepare:client && tsc -p tsconfig.json --noEmit --pretty false",
     "verify": "bun run typecheck && bun run test && bun run build && bun run check:package-boundary && bun run check:pack && bun run check:installed-consumer"
   },
   "peerDependencies": {
-    "@you-agent-factory/client": "0.0.0"
+    "@you-agent-factory/client": "0.0.2"
   },
   "peerDependenciesMeta": {
     "@you-agent-factory/client": {

--- a/ui/packages/factory-replay/scripts/verify-package-pack.mjs
+++ b/ui/packages/factory-replay/scripts/verify-package-pack.mjs
@@ -59,7 +59,6 @@ async function runPack(destination) {
       ...npm.args,
       "pack",
       "--json",
-      "--ignore-scripts",
       "--pack-destination",
       destination,
       packageRoot,
@@ -74,15 +73,8 @@ async function runPack(destination) {
 }
 
 export async function packAndVerify(destination) {
-  await execFileAsync(
-    process.execPath,
-    [path.join(packageRoot, "scripts", "build-package.mjs")],
-    {
-      cwd: packageRoot,
-      maxBuffer: 10 * 1024 * 1024,
-    },
-  );
   await verifyPackageBoundary();
+  await rm(path.join(packageRoot, "dist"), { force: true, recursive: true });
   const report = await runPack(destination);
   const actualFiles = report.files
     .map(({ path: file }) => file.replaceAll("\\", "/"))

--- a/ui/packages/factory-visualizers/bun.lock
+++ b/ui/packages/factory-visualizers/bun.lock
@@ -6,7 +6,7 @@
       "name": "@you-agent-factory/factory-visualizers",
       "dependencies": {
         "@xyflow/react": "^12.10.2",
-        "@you-agent-factory/components": "0.0.0",
+        "@you-agent-factory/components": "0.0.2",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.4",
@@ -30,8 +30,8 @@
         "vitest": "4.1.3",
       },
       "peerDependencies": {
-        "@you-agent-factory/client": "0.0.0",
-        "@you-agent-factory/factory-replay": "0.0.0",
+        "@you-agent-factory/client": "0.0.2",
+        "@you-agent-factory/factory-replay": "0.0.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
       },
@@ -512,9 +512,9 @@
 
     "@you-agent-factory/client": ["@you-agent-factory/client@file:../client", { "dependencies": { "ajv": "^8.20.0", "ajv-formats": "^3.0.1", "marked": "^14.0.0" }, "devDependencies": { "typescript": "~5.9.3", "vitest": "4.1.3" } }],
 
-    "@you-agent-factory/components": ["@you-agent-factory/components@0.0.0", "", { "dependencies": { "@radix-ui/react-collapsible": "^1.1.12", "@radix-ui/react-dialog": "^1.1.15", "@radix-ui/react-popover": "^1.1.15", "@radix-ui/react-scroll-area": "^1.2.10", "@radix-ui/react-select": "^2.3.0", "@radix-ui/react-slot": "^1.2.3", "@xyflow/react": "^12.10.2", "recharts": "^3.8.1" }, "peerDependencies": { "react": "^19.0.0", "react-dom": "^19.0.0" } }, "sha512-MorN40vb9/kB5Vx5z4ldBj21qcB5mayILUAlWpEQdqULI2PIpZW7cHZPgQyDAOgwCEdXO3vwzwtfBTs6im9T2Q=="],
+    "@you-agent-factory/components": ["@you-agent-factory/components@0.0.2", "", { "dependencies": { "@radix-ui/react-collapsible": "^1.1.12", "@radix-ui/react-dialog": "^1.1.15", "@radix-ui/react-popover": "^1.1.15", "@radix-ui/react-scroll-area": "^1.2.10", "@radix-ui/react-select": "^2.3.0", "@radix-ui/react-slot": "^1.2.3", "@xyflow/react": "^12.10.2", "recharts": "^3.8.1" }, "peerDependencies": { "react": "^19.0.0", "react-dom": "^19.0.0" } }],
 
-    "@you-agent-factory/factory-replay": ["@you-agent-factory/factory-replay@file:../factory-replay", { "devDependencies": { "typescript": "~5.9.3", "vitest": "4.1.3" }, "peerDependencies": { "@you-agent-factory/client": "0.0.0" }, "optionalPeers": ["@you-agent-factory/client"] }],
+    "@you-agent-factory/factory-replay": ["@you-agent-factory/factory-replay@file:../factory-replay", { "devDependencies": { "typescript": "~5.9.3", "vitest": "4.1.3" }, "peerDependencies": { "@you-agent-factory/client": "0.0.2" }, "optionalPeers": ["@you-agent-factory/client"] }],
 
     "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
 

--- a/ui/packages/factory-visualizers/package.json
+++ b/ui/packages/factory-visualizers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@you-agent-factory/factory-visualizers",
-  "version": "0.0.0",
+  "version": "0.0.2",
   "description": "Controlled React visualizers for caller-prepared Factory replay projections.",
   "license": "MIT",
   "repository": {
@@ -38,6 +38,7 @@
     "check:pack": "node scripts/verify-package-pack.mjs",
     "check:package-boundary": "node scripts/check-package-boundary.mjs",
     "lint": "biome check .",
+    "prepack": "bun run build",
     "prepare:dependencies": "bun run --cwd ../client build && bun run --cwd ../components build && bun run --cwd ../factory-replay build",
     "storybook": "storybook dev -p 6027",
     "test": "vitest run --config vitest.config.ts",
@@ -47,12 +48,12 @@
     "verify": "bun run typecheck && bun run lint && bun run test && bun run build && bun run test-storybook && bun run check:package-boundary && bun run check:pack && bun run check:installed-consumer"
   },
   "dependencies": {
-    "@you-agent-factory/components": "0.0.0",
+    "@you-agent-factory/components": "0.0.2",
     "@xyflow/react": "^12.10.2"
   },
   "peerDependencies": {
-    "@you-agent-factory/client": "0.0.0",
-    "@you-agent-factory/factory-replay": "0.0.0",
+    "@you-agent-factory/client": "0.0.2",
+    "@you-agent-factory/factory-replay": "0.0.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/ui/packages/factory-visualizers/scripts/verify-package-pack.mjs
+++ b/ui/packages/factory-visualizers/scripts/verify-package-pack.mjs
@@ -39,15 +39,8 @@ async function npmCommand() {
 }
 
 export async function packAndVerify(destination) {
-  await execFileAsync(
-    process.execPath,
-    [path.join(packageRoot, "scripts", "build-package.mjs")],
-    {
-      cwd: packageRoot,
-      maxBuffer: 20 * 1024 * 1024,
-    },
-  );
   await verifyPackageBoundary();
+  await rm(path.join(packageRoot, "dist"), { force: true, recursive: true });
   const npm = await npmCommand();
   const { stdout } = await execFileAsync(
     npm.executable,
@@ -55,7 +48,6 @@ export async function packAndVerify(destination) {
       ...npm.args,
       "pack",
       "--json",
-      "--ignore-scripts",
       "--pack-destination",
       destination,
       packageRoot,

--- a/ui/scripts/public-package-publish.mjs
+++ b/ui/scripts/public-package-publish.mjs
@@ -12,20 +12,71 @@ const semverPattern =
   /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
 export const PUBLIC_PACKAGES = Object.freeze([
-  { name: "@you-agent-factory/client", directory: "client" },
-  { name: "@you-agent-factory/factory-replay", directory: "factory-replay" },
+  { name: "@you-agent-factory/client", directory: "client", build: true },
+  {
+    name: "@you-agent-factory/factory-replay",
+    directory: "factory-replay",
+    build: true,
+  },
   {
     name: "@you-agent-factory/factory-emulator",
     directory: "factory-emulator",
+    build: true,
   },
-  { name: "@you-agent-factory/components", directory: "components" },
+  {
+    name: "@you-agent-factory/components",
+    directory: "components",
+    build: true,
+  },
   {
     name: "@you-agent-factory/factory-visualizers",
     directory: "factory-visualizers",
+    build: true,
   },
 ]);
 
-const publicPackageNames = new Set(PUBLIC_PACKAGES.map(({ name }) => name));
+export const RELEASE_PUBLIC_PACKAGES = Object.freeze([
+  {
+    name: "@you-agent-factory/api",
+    directory: "api",
+    sourceDirectory: "../packages/api",
+    build: false,
+  },
+  {
+    name: "@you-agent-factory/packaged-factories",
+    directory: "packaged-factories",
+    sourceDirectory: "../packages/packaged-factories",
+    build: false,
+  },
+  ...PUBLIC_PACKAGES,
+]);
+
+const publicPackageNames = new Set(
+  RELEASE_PUBLIC_PACKAGES.map(({ name }) => name),
+);
+
+function collectExportTargets(exports) {
+  if (typeof exports === "string") return [exports.replace(/^\.\//, "")];
+  if (!exports || typeof exports !== "object") return [];
+  return Object.values(exports).flatMap(collectExportTargets);
+}
+
+function matchesExportTarget(file, target) {
+  if (!target.includes("*")) return file === target;
+  const [prefix, suffix] = target.split("*", 2);
+  return file.startsWith(prefix) && file.endsWith(suffix);
+}
+
+export function assertPackedExportTargets(packageName, exports, files) {
+  const packedFiles = new Set(
+    (files ?? []).map(({ path: file }) => file?.replaceAll("\\", "/")),
+  );
+  for (const target of collectExportTargets(exports)) {
+    if (![...packedFiles].some((file) => matchesExportTarget(file, target))) {
+      throw new Error(`${packageName} candidate omits export target ${target}`);
+    }
+  }
+}
 
 export function assertPublishVersion(version) {
   if (typeof version !== "string" || !semverPattern.test(version)) {
@@ -89,9 +140,14 @@ function runNpm(args, options = {}) {
 }
 
 async function stagePackage({ packageSpec, version, stagingRoot }) {
-  const sourceDirectory = path.join(uiRoot, "packages", packageSpec.directory);
+  const sourceDirectory = path.resolve(
+    uiRoot,
+    packageSpec.sourceDirectory ?? `packages/${packageSpec.directory}`,
+  );
   const stagedDirectory = path.join(stagingRoot, packageSpec.directory);
-  await run("bun", ["run", "build"], { cwd: sourceDirectory });
+  if (packageSpec.build) {
+    await run("bun", ["run", "build"], { cwd: sourceDirectory });
+  }
   await cp(sourceDirectory, stagedDirectory, {
     recursive: true,
     filter: (entry) => !entry.split(path.sep).includes("node_modules"),
@@ -105,12 +161,13 @@ async function stagePackage({ packageSpec, version, stagingRoot }) {
     );
   }
   await writeFile(manifestPath, `${JSON.stringify(patched, null, 2)}\n`);
-  return stagedDirectory;
+  return { manifest: patched, stagedDirectory };
 }
 
 export async function preparePublicPackageCandidates({
   version,
   outputDirectory,
+  includeReleasePackages = false,
 }) {
   assertPublishVersion(version);
   const resolvedOutput = path.resolve(outputDirectory);
@@ -121,10 +178,13 @@ export async function preparePublicPackageCandidates({
   await run("bun", ["run", "link:public-package-dependencies"], {
     cwd: uiRoot,
   });
+  const packageSpecs = includeReleasePackages
+    ? RELEASE_PUBLIC_PACKAGES
+    : PUBLIC_PACKAGES;
   const candidates = [];
   try {
-    for (const packageSpec of PUBLIC_PACKAGES) {
-      const stagedDirectory = await stagePackage({
+    for (const packageSpec of packageSpecs) {
+      const { manifest, stagedDirectory } = await stagePackage({
         packageSpec,
         version,
         stagingRoot,
@@ -134,6 +194,7 @@ export async function preparePublicPackageCandidates({
           "pack",
           stagedDirectory,
           "--json",
+          "--ignore-scripts",
           "--pack-destination",
           resolvedOutput,
         ],
@@ -145,6 +206,7 @@ export async function preparePublicPackageCandidates({
           `npm pack returned unexpected identity for ${packageSpec.name}`,
         );
       }
+      assertPackedExportTargets(report.name, manifest.exports, report.files);
       candidates.push({
         name: report.name,
         version: report.version,
@@ -153,7 +215,11 @@ export async function preparePublicPackageCandidates({
         shasum: report.shasum,
       });
     }
-    const evidence = { version, packages: candidates };
+    const evidence = {
+      version,
+      scope: includeReleasePackages ? "release" : "ui",
+      packages: candidates,
+    };
     await writeFile(
       path.join(resolvedOutput, "public-package-candidates.json"),
       `${JSON.stringify(evidence, null, 2)}\n`,
@@ -216,7 +282,13 @@ export async function publishPublicPackageCandidates({
     ),
   );
   assertPublishVersion(evidence.version);
-  if (evidence.packages.length !== PUBLIC_PACKAGES.length) {
+  const packageSpecs =
+    evidence.scope === "release"
+      ? RELEASE_PUBLIC_PACKAGES
+      : evidence.scope === "ui"
+        ? PUBLIC_PACKAGES
+        : null;
+  if (!packageSpecs || evidence.packages.length !== packageSpecs.length) {
     throw new Error("Public package candidate set is incomplete");
   }
   if (
@@ -227,7 +299,7 @@ export async function publishPublicPackageCandidates({
       "Public package candidate set contains duplicate package names",
     );
   }
-  for (const packageSpec of PUBLIC_PACKAGES) {
+  for (const packageSpec of packageSpecs) {
     const candidate = evidence.packages.find(
       ({ name }) => name === packageSpec.name,
     );
@@ -272,6 +344,7 @@ async function main() {
       version: { type: "string" },
       "output-directory": { type: "string" },
       "candidate-directory": { type: "string" },
+      "include-release-packages": { type: "boolean", default: false },
       tag: { type: "string" },
       provenance: { type: "boolean", default: false },
     },
@@ -282,6 +355,7 @@ async function main() {
       ? await preparePublicPackageCandidates({
           version: values.version,
           outputDirectory: values["output-directory"],
+          includeReleasePackages: values["include-release-packages"],
         })
       : values.action === "publish"
         ? await publishPublicPackageCandidates({

--- a/ui/scripts/public-package-publish.mjs
+++ b/ui/scripts/public-package-publish.mjs
@@ -47,6 +47,9 @@ export const RELEASE_PUBLIC_PACKAGES = Object.freeze([
     directory: "packaged-factories",
     sourceDirectory: "../packages/packaged-factories",
     build: false,
+    // Until the package owns an export map, keep its legacy deep-path contract
+    // isolated to this release specification.
+    requiredFiles: ["factories/goal/factory.json"],
   },
   ...PUBLIC_PACKAGES,
 ]);
@@ -74,6 +77,17 @@ export function assertPackedExportTargets(packageName, exports, files) {
   for (const target of collectExportTargets(exports)) {
     if (![...packedFiles].some((file) => matchesExportTarget(file, target))) {
       throw new Error(`${packageName} candidate omits export target ${target}`);
+    }
+  }
+}
+
+export function assertPackedRequiredFiles(packageName, requiredFiles, files) {
+  const packedFiles = new Set(
+    (files ?? []).map(({ path: file }) => file?.replaceAll("\\", "/")),
+  );
+  for (const requiredFile of requiredFiles ?? []) {
+    if (!packedFiles.has(requiredFile)) {
+      throw new Error(`${packageName} candidate omits ${requiredFile}`);
     }
   }
 }
@@ -207,6 +221,11 @@ export async function preparePublicPackageCandidates({
         );
       }
       assertPackedExportTargets(report.name, manifest.exports, report.files);
+      assertPackedRequiredFiles(
+        report.name,
+        packageSpec.requiredFiles,
+        report.files,
+      );
       candidates.push({
         name: report.name,
         version: report.version,

--- a/ui/scripts/public-package-publish.test.mjs
+++ b/ui/scripts/public-package-publish.test.mjs
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import {
   assertPackedExportTargets,
+  assertPackedRequiredFiles,
   assertPublishVersion,
   PUBLIC_PACKAGES,
   patchPublicPackageManifest,
@@ -114,6 +115,25 @@ describe("public package publishing", () => {
       ]),
     ).toThrow(
       "@you-agent-factory/api candidate omits export target generated/joined/*",
+    );
+  });
+
+  test("isolates the packaged factories legacy deep-path contract", () => {
+    expect(() =>
+      assertPackedRequiredFiles(
+        "@you-agent-factory/packaged-factories",
+        ["factories/goal/factory.json"],
+        [{ path: "factories/goal/factory.json" }],
+      ),
+    ).not.toThrow();
+    expect(() =>
+      assertPackedRequiredFiles(
+        "@you-agent-factory/packaged-factories",
+        ["factories/goal/factory.json"],
+        [{ path: "factories/review/factory.json" }],
+      ),
+    ).toThrow(
+      "@you-agent-factory/packaged-factories candidate omits factories/goal/factory.json",
     );
   });
 });

--- a/ui/scripts/public-package-publish.test.mjs
+++ b/ui/scripts/public-package-publish.test.mjs
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "vitest";
 
 import {
+  assertPackedExportTargets,
   assertPublishVersion,
   PUBLIC_PACKAGES,
   patchPublicPackageManifest,
+  RELEASE_PUBLIC_PACKAGES,
 } from "./public-package-publish.mjs";
 
 describe("public package publishing", () => {
@@ -15,12 +17,17 @@ describe("public package publishing", () => {
       "@you-agent-factory/components",
       "@you-agent-factory/factory-visualizers",
     ]);
+    expect(RELEASE_PUBLIC_PACKAGES.map(({ name }) => name)).toEqual([
+      "@you-agent-factory/api",
+      "@you-agent-factory/packaged-factories",
+      ...PUBLIC_PACKAGES.map(({ name }) => name),
+    ]);
   });
 
   test("accepts stable and immutable development versions", () => {
     expect(assertPublishVersion("1.2.3")).toBe("1.2.3");
-    expect(assertPublishVersion("0.0.0-dev.123.abcdef123456")).toBe(
-      "0.0.0-dev.123.abcdef123456",
+    expect(assertPublishVersion("0.0.2-dev.123.abcdef123456")).toBe(
+      "0.0.2-dev.123.abcdef123456",
     );
     expect(() => assertPublishVersion("v1.2.3")).toThrow(
       "Invalid public package version",
@@ -59,5 +66,54 @@ describe("public package publishing", () => {
       },
     });
     expect(manifest.version).toBe("0.0.0");
+  });
+
+  test("rejects release candidates with missing export targets", () => {
+    const exports = {
+      ".": {
+        types: "./dist/index.d.ts",
+        import: "./dist/index.js",
+      },
+      "./styles.css": "./dist/styles.css",
+    };
+    const completeFiles = [
+      { path: "dist/index.d.ts" },
+      { path: "dist/index.js" },
+      { path: "dist/styles.css" },
+    ];
+
+    expect(() =>
+      assertPackedExportTargets(
+        "@you-agent-factory/factory-visualizers",
+        exports,
+        completeFiles,
+      ),
+    ).not.toThrow();
+    expect(() =>
+      assertPackedExportTargets(
+        "@you-agent-factory/factory-visualizers",
+        exports,
+        completeFiles.filter(({ path }) => path !== "dist/index.js"),
+      ),
+    ).toThrow(
+      "@you-agent-factory/factory-visualizers candidate omits export target dist/index.js",
+    );
+  });
+
+  test("accepts populated wildcard export targets", () => {
+    const exports = { "./joined/*": "./generated/joined/*" };
+
+    expect(() =>
+      assertPackedExportTargets("@you-agent-factory/api", exports, [
+        { path: "generated/joined/contracts/manifest.schema.json" },
+      ]),
+    ).not.toThrow();
+    expect(() =>
+      assertPackedExportTargets("@you-agent-factory/api", exports, [
+        { path: "generated/manifest.json" },
+      ]),
+    ).toThrow(
+      "@you-agent-factory/api candidate omits export target generated/joined/*",
+    );
   });
 });


### PR DESCRIPTION
## What changed

- build all executable UI packages during the npm pack/publish lifecycle
- verify clean tarballs contain every declared export target
- align all seven public packages and internal peer dependencies on `0.0.2`
- publish `api` and `packaged-factories` alongside the five UI packages on stable releases
- keep development UI publishing separate from the API development-candidate workflow

## Why

The published `0.0.0` package set included source-only or incomplete artifacts. In particular, `factory-visualizers` omitted `dist` entirely and `components` exported TypeScript source that normal Node consumers cannot load.

## Impact

Stable release CI now prepares, digest-checks, publishes, and registry-verifies all seven public npm packages under one immutable release version. Direct npm packing also performs a clean production build.

## Validation

- all five UI package registry-format pack gates
- isolated installed-consumer gates for client, replay, emulator, components, and visualizers
- `make api-package-pack-smoke`
- seven-package `0.0.2` stable release candidate preparation
- five-package development candidate preparation
- public package release tests (14 passing)
- focused Biome and diff checks
