### PR TITLE
schema-cli-resolved-input-model

### DIFF
--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1143,6 +1143,16 @@
       "minimum": 0.00
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/transports/cli/resolvedinput",
+      "exception": {
+        "kind": "measurement",
+        "justification": "The active functional coverage profile contains no measurable statements for this package.",
+        "owner": "backend-quality",
+        "deadline": "2027-07-15",
+        "removalGate": "The functional coverage profile reports at least one measurable statement for this package."
+      }
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/run",
       "minimum": 14.11
     },

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1041,6 +1041,10 @@
       "minimum": 81.70
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/transports/cli/resolvedinput",
+      "minimum": 86.06
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/transports/cli/run",
       "minimum": 79.19
     },

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -364,6 +364,10 @@ Supported one-shot factory invocations expose three modes; continuous, replay,
   lower tiers, scalar observations from one binding
   use the last value, repeated observations append in order, and multiple
   same-tier bindings for one input are rejected.
+  Resolved runtime CLI values belong in
+  `pkg/transports/cli/resolvedinput`: its collection-based resolver and accessors
+  use stable schema input IDs and canonical typed values, with no Cobra, public
+  spelling, position, environment, filesystem, or process-global dependency.
   Static-plus-Factory composition is owned by
   `pkg/transports/cli/climanifest.ComposeRunInputs`: pass the validated `you.run`
   command and only the selected Factory's `InvocationSignatureConfig`. The pure

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -370,7 +370,9 @@ Supported one-shot factory invocations expose three modes; continuous, replay,
   spelling, position, environment, filesystem, or process-global dependency.
   Definitions supply typed source precedence explicitly; the resolved snapshot
   retains the winning provenance and derives changed/default state from that
-  source instead of asking handlers to infer it.
+  source instead of asking handlers to infer it. Typed, wrap-safe access
+  diagnostics identify missing IDs and value-kind mismatches so handler adapters
+  can translate failures without string parsing.
   Static-plus-Factory composition is owned by
   `pkg/transports/cli/climanifest.ComposeRunInputs`: pass the validated `you.run`
   command and only the selected Factory's `InvocationSignatureConfig`. The pure

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -368,6 +368,9 @@ Supported one-shot factory invocations expose three modes; continuous, replay,
   `pkg/transports/cli/resolvedinput`: its collection-based resolver and accessors
   use stable schema input IDs and canonical typed values, with no Cobra, public
   spelling, position, environment, filesystem, or process-global dependency.
+  Definitions supply typed source precedence explicitly; the resolved snapshot
+  retains the winning provenance and derives changed/default state from that
+  source instead of asking handlers to infer it.
   Static-plus-Factory composition is owned by
   `pkg/transports/cli/climanifest.ComposeRunInputs`: pass the validated `you.run`
   command and only the selected Factory's `InvocationSignatureConfig`. The pure

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -372,7 +372,10 @@ Supported one-shot factory invocations expose three modes; continuous, replay,
   retains the winning provenance and derives changed/default state from that
   source instead of asking handlers to infer it. Typed, wrap-safe access
   diagnostics identify missing IDs and value-kind mismatches so handler adapters
-  can translate failures without string parsing.
+  can translate failures without string parsing. Definitions also carry schema
+  sensitivity into the detached snapshot: diagnostic and observation boundaries
+  expose provenance and changed/default state while replacing sensitive scalar
+  or collection values with `resolvedinput.RedactedValue`.
   Static-plus-Factory composition is owned by
   `pkg/transports/cli/climanifest.ComposeRunInputs`: pass the validated `you.run`
   command and only the selected Factory's `InvocationSignatureConfig`. The pure

--- a/pkg/transports/cli/resolvedinput/access.go
+++ b/pkg/transports/cli/resolvedinput/access.go
@@ -16,15 +16,23 @@ type AccessError struct {
 	InputID      string
 	ExpectedKind ValueKind
 	ActualKind   ValueKind
+	Provenance   Source
+	Changed      bool
+	Default      bool
+	Value        any
 }
 
 func (e *AccessError) Error() string {
 	if e.Failure == AccessFailureKindMismatch {
 		return fmt.Sprintf(
-			"resolved CLI input %q requires accessor kind %q, got %q (%s)",
+			"resolved CLI input %q requires accessor kind %q, got %q from %q (changed=%t, default=%t, value=%v; %s)",
 			e.InputID,
 			e.ExpectedKind,
 			e.ActualKind,
+			e.Provenance,
+			e.Changed,
+			e.Default,
+			e.Value,
 			e.Failure,
 		)
 	}
@@ -44,11 +52,15 @@ func newMissingInputError(inputID string, expected ValueKind) error {
 	}
 }
 
-func newKindMismatchError(inputID string, expected, actual ValueKind) error {
+func newKindMismatchError(inputID string, expected ValueKind, resolved entry) error {
 	return &AccessError{
 		Failure:      AccessFailureKindMismatch,
 		InputID:      inputID,
 		ExpectedKind: expected,
-		ActualKind:   actual,
+		ActualKind:   resolved.value.Kind(),
+		Provenance:   resolved.state.Provenance,
+		Changed:      resolved.state.Changed,
+		Default:      resolved.state.Default,
+		Value:        observableValue(resolved.value, resolved.sensitive),
 	}
 }

--- a/pkg/transports/cli/resolvedinput/access.go
+++ b/pkg/transports/cli/resolvedinput/access.go
@@ -1,0 +1,54 @@
+package resolvedinput
+
+import "fmt"
+
+// AccessFailure classifies a failed typed lookup from a resolved input snapshot.
+type AccessFailure string
+
+const (
+	AccessFailureMissingInput AccessFailure = "missing-input"
+	AccessFailureKindMismatch AccessFailure = "kind-mismatch"
+)
+
+// AccessError is a structured diagnostic for a failed typed lookup.
+type AccessError struct {
+	Failure      AccessFailure
+	InputID      string
+	ExpectedKind ValueKind
+	ActualKind   ValueKind
+}
+
+func (e *AccessError) Error() string {
+	if e.Failure == AccessFailureKindMismatch {
+		return fmt.Sprintf(
+			"resolved CLI input %q requires accessor kind %q, got %q (%s)",
+			e.InputID,
+			e.ExpectedKind,
+			e.ActualKind,
+			e.Failure,
+		)
+	}
+	return fmt.Sprintf(
+		"resolved CLI input %q is missing for accessor kind %q (%s)",
+		e.InputID,
+		e.ExpectedKind,
+		e.Failure,
+	)
+}
+
+func newMissingInputError(inputID string, expected ValueKind) error {
+	return &AccessError{
+		Failure:      AccessFailureMissingInput,
+		InputID:      inputID,
+		ExpectedKind: expected,
+	}
+}
+
+func newKindMismatchError(inputID string, expected, actual ValueKind) error {
+	return &AccessError{
+		Failure:      AccessFailureKindMismatch,
+		InputID:      inputID,
+		ExpectedKind: expected,
+		ActualKind:   actual,
+	}
+}

--- a/pkg/transports/cli/resolvedinput/access_test.go
+++ b/pkg/transports/cli/resolvedinput/access_test.go
@@ -1,0 +1,91 @@
+package resolvedinput_test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/transports/cli/resolvedinput"
+)
+
+func TestTypedAccessorsClassifyMissingInputs(t *testing.T) {
+	inputs, err := resolvedinput.Resolve(
+		[]resolvedinput.Definition{definition("input.unresolved", resolvedinput.ValueKindString)},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		inputID  string
+		expected resolvedinput.ValueKind
+		access   func() error
+	}{
+		{name: "bool", inputID: "input.unknown", expected: resolvedinput.ValueKindBool, access: func() error { _, err := inputs.Bool("input.unknown"); return err }},
+		{name: "string", inputID: "input.unresolved", expected: resolvedinput.ValueKindString, access: func() error { _, err := inputs.String("input.unresolved"); return err }},
+		{name: "int", inputID: "input.unknown", expected: resolvedinput.ValueKindInt, access: func() error { _, err := inputs.Int("input.unknown"); return err }},
+		{name: "int64", inputID: "input.unknown", expected: resolvedinput.ValueKindInt64, access: func() error { _, err := inputs.Int64("input.unknown"); return err }},
+		{name: "string array", inputID: "input.unknown", expected: resolvedinput.ValueKindStringArray, access: func() error { _, err := inputs.StringArray("input.unknown"); return err }},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.access()
+			assertAccessError(t, err, resolvedinput.AccessError{
+				Failure:      resolvedinput.AccessFailureMissingInput,
+				InputID:      test.inputID,
+				ExpectedKind: test.expected,
+			})
+		})
+	}
+}
+
+func TestTypedAccessorsClassifyScalarAndCollectionKindMismatches(t *testing.T) {
+	inputs, err := resolvedinput.Resolve(
+		[]resolvedinput.Definition{
+			definition("input.scalar", resolvedinput.ValueKindBool),
+			definition("input.collection", resolvedinput.ValueKindStringArray),
+		},
+		[]resolvedinput.Candidate{
+			candidate("input.scalar", resolvedinput.BoolValue(true)),
+			candidate("input.collection", resolvedinput.StringArrayValue([]string{"value"})),
+		},
+	)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	_, scalarErr := inputs.String("input.scalar")
+	assertAccessError(t, scalarErr, resolvedinput.AccessError{
+		Failure:      resolvedinput.AccessFailureKindMismatch,
+		InputID:      "input.scalar",
+		ExpectedKind: resolvedinput.ValueKindString,
+		ActualKind:   resolvedinput.ValueKindBool,
+	})
+
+	_, collectionErr := inputs.Int64("input.collection")
+	assertAccessError(t, collectionErr, resolvedinput.AccessError{
+		Failure:      resolvedinput.AccessFailureKindMismatch,
+		InputID:      "input.collection",
+		ExpectedKind: resolvedinput.ValueKindInt64,
+		ActualKind:   resolvedinput.ValueKindStringArray,
+	})
+}
+
+func assertAccessError(t *testing.T, err error, want resolvedinput.AccessError) {
+	t.Helper()
+	wrapped := fmt.Errorf("translate resolved input: %w", err)
+	var diagnostic *resolvedinput.AccessError
+	if !errors.As(wrapped, &diagnostic) {
+		t.Fatalf("wrapped error = %v; want *AccessError", wrapped)
+	}
+	if *diagnostic != want {
+		t.Fatalf("diagnostic = %#v; want %#v", diagnostic, want)
+	}
+	if !strings.Contains(diagnostic.Error(), want.InputID) {
+		t.Fatalf("Error() = %q; want stable input ID %q", diagnostic.Error(), want.InputID)
+	}
+}

--- a/pkg/transports/cli/resolvedinput/access_test.go
+++ b/pkg/transports/cli/resolvedinput/access_test.go
@@ -3,6 +3,7 @@ package resolvedinput_test
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -43,6 +44,56 @@ func TestTypedAccessorsClassifyMissingInputs(t *testing.T) {
 	}
 }
 
+func TestSensitiveMismatchDiagnosticsRedactScalarAndCollectionValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		kind   resolvedinput.ValueKind
+		value  resolvedinput.Value
+		secret []string
+	}{
+		{name: "scalar", kind: resolvedinput.ValueKindString, value: resolvedinput.StringValue("scalar-secret"), secret: []string{"scalar-secret"}},
+		{name: "collection", kind: resolvedinput.ValueKindStringArray, value: resolvedinput.StringArrayValue([]string{"first-secret", "second-secret"}), secret: []string{"first-secret", "second-secret"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			inputs, err := resolvedinput.Resolve(
+				[]resolvedinput.Definition{{
+					ID: "input.secret", Kind: test.kind, Sensitive: true,
+					Precedence: []resolvedinput.Source{resolvedinput.SourceEnvironment},
+				}},
+				[]resolvedinput.Candidate{{
+					InputID: "input.secret", Source: resolvedinput.SourceEnvironment, Value: test.value,
+				}},
+			)
+			if err != nil {
+				t.Fatalf("Resolve() error = %v", err)
+			}
+
+			_, err = inputs.Bool("input.secret")
+			var diagnostic *resolvedinput.AccessError
+			if !errors.As(err, &diagnostic) {
+				t.Fatalf("Bool() error = %v; want *AccessError", err)
+			}
+			if diagnostic.Value != resolvedinput.RedactedValue {
+				t.Fatalf("diagnostic value = %#v; want %q", diagnostic.Value, resolvedinput.RedactedValue)
+			}
+			formatted := diagnostic.Error()
+			if !strings.Contains(formatted, resolvedinput.RedactedValue) {
+				t.Fatalf("Error() = %q; want redaction marker", formatted)
+			}
+			for _, secret := range test.secret {
+				if strings.Contains(formatted, secret) {
+					t.Fatalf("Error() = %q; contains sensitive value %q", formatted, secret)
+				}
+			}
+			if diagnostic.Provenance != resolvedinput.SourceEnvironment || !diagnostic.Changed || diagnostic.Default {
+				t.Fatalf("diagnostic state = %#v; want environment changed non-default", diagnostic)
+			}
+		})
+	}
+}
+
 func TestTypedAccessorsClassifyScalarAndCollectionKindMismatches(t *testing.T) {
 	inputs, err := resolvedinput.Resolve(
 		[]resolvedinput.Definition{
@@ -64,6 +115,9 @@ func TestTypedAccessorsClassifyScalarAndCollectionKindMismatches(t *testing.T) {
 		InputID:      "input.scalar",
 		ExpectedKind: resolvedinput.ValueKindString,
 		ActualKind:   resolvedinput.ValueKindBool,
+		Provenance:   resolvedinput.SourceCLIFlag,
+		Changed:      true,
+		Value:        true,
 	})
 
 	_, collectionErr := inputs.Int64("input.collection")
@@ -72,6 +126,9 @@ func TestTypedAccessorsClassifyScalarAndCollectionKindMismatches(t *testing.T) {
 		InputID:      "input.collection",
 		ExpectedKind: resolvedinput.ValueKindInt64,
 		ActualKind:   resolvedinput.ValueKindStringArray,
+		Provenance:   resolvedinput.SourceCLIFlag,
+		Changed:      true,
+		Value:        []string{"value"},
 	})
 }
 
@@ -82,7 +139,7 @@ func assertAccessError(t *testing.T, err error, want resolvedinput.AccessError) 
 	if !errors.As(wrapped, &diagnostic) {
 		t.Fatalf("wrapped error = %v; want *AccessError", wrapped)
 	}
-	if *diagnostic != want {
+	if !reflect.DeepEqual(*diagnostic, want) {
 		t.Fatalf("diagnostic = %#v; want %#v", diagnostic, want)
 	}
 	if !strings.Contains(diagnostic.Error(), want.InputID) {

--- a/pkg/transports/cli/resolvedinput/inputs.go
+++ b/pkg/transports/cli/resolvedinput/inputs.go
@@ -119,11 +119,11 @@ func (i Inputs) StringArray(inputID string) ([]string, error) {
 func (i Inputs) valueOfKind(inputID string, expected ValueKind) (Value, error) {
 	resolved, ok := i.entries[inputID]
 	if !ok {
-		return Value{}, fmt.Errorf("resolved CLI input %q is missing", inputID)
+		return Value{}, newMissingInputError(inputID, expected)
 	}
 	value := resolved.value
 	if value.Kind() != expected {
-		return Value{}, fmt.Errorf("resolved CLI input %q requires accessor kind %q, got %q", inputID, expected, value.Kind())
+		return Value{}, newKindMismatchError(inputID, expected, value.Kind())
 	}
 	return value, nil
 }

--- a/pkg/transports/cli/resolvedinput/inputs.go
+++ b/pkg/transports/cli/resolvedinput/inputs.go
@@ -1,0 +1,116 @@
+package resolvedinput
+
+import "fmt"
+
+// Definition is the schema-owned identity and value kind of one command input.
+// Public spellings and parser details deliberately do not participate in
+// resolution or lookup.
+type Definition struct {
+	ID   string
+	Kind ValueKind
+}
+
+// Candidate is one already-collected value addressed by stable schema input ID.
+// Source collectors remain outside this pure transport model.
+type Candidate struct {
+	InputID string
+	Value   Value
+}
+
+// Inputs is a resolved CLI input snapshot keyed only by stable schema input ID.
+type Inputs struct {
+	values map[string]Value
+}
+
+// Resolve validates schema definitions and retains at most one candidate for
+// each declared input. Source precedence is added separately when candidates
+// can contain more than one source observation.
+func Resolve(definitions []Definition, candidates []Candidate) (Inputs, error) {
+	kinds := make(map[string]ValueKind, len(definitions))
+	for _, definition := range definitions {
+		if definition.ID == "" {
+			return Inputs{}, fmt.Errorf("resolved CLI input definition has an empty stable ID")
+		}
+		if !definition.Kind.valid() {
+			return Inputs{}, fmt.Errorf("resolved CLI input %q has unsupported value kind %q", definition.ID, definition.Kind)
+		}
+		if _, exists := kinds[definition.ID]; exists {
+			return Inputs{}, fmt.Errorf("resolved CLI input definition repeats stable ID %q", definition.ID)
+		}
+		kinds[definition.ID] = definition.Kind
+	}
+
+	values := make(map[string]Value, len(candidates))
+	for _, candidate := range candidates {
+		kind, declared := kinds[candidate.InputID]
+		if !declared {
+			return Inputs{}, fmt.Errorf("resolved CLI input candidate references undeclared stable ID %q", candidate.InputID)
+		}
+		if _, exists := values[candidate.InputID]; exists {
+			return Inputs{}, fmt.Errorf("resolved CLI input %q has multiple candidates without a source policy", candidate.InputID)
+		}
+		if candidate.Value.Kind() != kind {
+			return Inputs{}, fmt.Errorf(
+				"resolved CLI input %q requires value kind %q, got %q",
+				candidate.InputID,
+				kind,
+				candidate.Value.Kind(),
+			)
+		}
+		values[candidate.InputID] = candidate.Value.clone()
+	}
+	return Inputs{values: values}, nil
+}
+
+// Lookup returns a detached value by stable schema input ID.
+func (i Inputs) Lookup(inputID string) (Value, bool) {
+	value, ok := i.values[inputID]
+	return value.clone(), ok
+}
+
+func (i Inputs) Bool(inputID string) (bool, error) {
+	value, err := i.valueOfKind(inputID, ValueKindBool)
+	return value.boolValue, err
+}
+
+func (i Inputs) String(inputID string) (string, error) {
+	value, err := i.valueOfKind(inputID, ValueKindString)
+	return value.stringValue, err
+}
+
+func (i Inputs) Int(inputID string) (int, error) {
+	value, err := i.valueOfKind(inputID, ValueKindInt)
+	return value.intValue, err
+}
+
+func (i Inputs) Int64(inputID string) (int64, error) {
+	value, err := i.valueOfKind(inputID, ValueKindInt64)
+	return value.int64Value, err
+}
+
+// StringArray returns a detached string collection. Positional collections and
+// repeated string flags share this canonical representation.
+func (i Inputs) StringArray(inputID string) ([]string, error) {
+	value, err := i.valueOfKind(inputID, ValueKindStringArray)
+	return cloneStrings(value.strings), err
+}
+
+func (i Inputs) valueOfKind(inputID string, expected ValueKind) (Value, error) {
+	value, ok := i.values[inputID]
+	if !ok {
+		return Value{}, fmt.Errorf("resolved CLI input %q is missing", inputID)
+	}
+	if value.Kind() != expected {
+		return Value{}, fmt.Errorf("resolved CLI input %q requires accessor kind %q, got %q", inputID, expected, value.Kind())
+	}
+	return value, nil
+}
+
+func (k ValueKind) valid() bool {
+	switch k {
+	case ValueKindBool, ValueKindString, ValueKindInt, ValueKindInt64, ValueKindStringArray:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/transports/cli/resolvedinput/inputs.go
+++ b/pkg/transports/cli/resolvedinput/inputs.go
@@ -9,6 +9,7 @@ type Definition struct {
 	ID         string
 	Kind       ValueKind
 	Precedence []Source
+	Sensitive  bool
 }
 
 // Candidate is one already-collected value and its source provenance, addressed
@@ -25,8 +26,9 @@ type Inputs struct {
 }
 
 type entry struct {
-	value Value
-	state State
+	value     Value
+	state     State
+	sensitive bool
 }
 
 // Resolve validates schema definitions and resolves the first available source
@@ -70,7 +72,11 @@ func Resolve(definitions []Definition, candidates []Candidate) (Inputs, error) {
 			if !found {
 				continue
 			}
-			entries[definition.ID] = entry{value: value.clone(), state: stateFor(source)}
+			entries[definition.ID] = entry{
+				value:     value.clone(),
+				state:     stateFor(source),
+				sensitive: definition.Sensitive,
+			}
 			break
 		}
 	}
@@ -123,7 +129,7 @@ func (i Inputs) valueOfKind(inputID string, expected ValueKind) (Value, error) {
 	}
 	value := resolved.value
 	if value.Kind() != expected {
-		return Value{}, newKindMismatchError(inputID, expected, value.Kind())
+		return Value{}, newKindMismatchError(inputID, expected, resolved)
 	}
 	return value, nil
 }

--- a/pkg/transports/cli/resolvedinput/inputs.go
+++ b/pkg/transports/cli/resolvedinput/inputs.go
@@ -6,66 +6,87 @@ import "fmt"
 // Public spellings and parser details deliberately do not participate in
 // resolution or lookup.
 type Definition struct {
-	ID   string
-	Kind ValueKind
+	ID         string
+	Kind       ValueKind
+	Precedence []Source
 }
 
-// Candidate is one already-collected value addressed by stable schema input ID.
-// Source collectors remain outside this pure transport model.
+// Candidate is one already-collected value and its source provenance, addressed
+// by stable schema input ID. Source collectors remain outside this pure model.
 type Candidate struct {
 	InputID string
+	Source  Source
 	Value   Value
 }
 
 // Inputs is a resolved CLI input snapshot keyed only by stable schema input ID.
 type Inputs struct {
-	values map[string]Value
+	entries map[string]entry
 }
 
-// Resolve validates schema definitions and retains at most one candidate for
-// each declared input. Source precedence is added separately when candidates
-// can contain more than one source observation.
+type entry struct {
+	value Value
+	state State
+}
+
+// Resolve validates schema definitions and resolves the first available source
+// in each definition's precedence order. It performs no IO and does not mutate
+// the supplied definitions or candidates.
 func Resolve(definitions []Definition, candidates []Candidate) (Inputs, error) {
-	kinds := make(map[string]ValueKind, len(definitions))
+	definitionsByID := make(map[string]Definition, len(definitions))
 	for _, definition := range definitions {
-		if definition.ID == "" {
-			return Inputs{}, fmt.Errorf("resolved CLI input definition has an empty stable ID")
+		if err := validateDefinition(definition, definitionsByID); err != nil {
+			return Inputs{}, err
 		}
-		if !definition.Kind.valid() {
-			return Inputs{}, fmt.Errorf("resolved CLI input %q has unsupported value kind %q", definition.ID, definition.Kind)
-		}
-		if _, exists := kinds[definition.ID]; exists {
-			return Inputs{}, fmt.Errorf("resolved CLI input definition repeats stable ID %q", definition.ID)
-		}
-		kinds[definition.ID] = definition.Kind
+		definitionsByID[definition.ID] = definition
 	}
 
-	values := make(map[string]Value, len(candidates))
+	byInput := make(map[string]map[Source]Value, len(candidates))
 	for _, candidate := range candidates {
-		kind, declared := kinds[candidate.InputID]
+		definition, declared := definitionsByID[candidate.InputID]
 		if !declared {
-			return Inputs{}, fmt.Errorf("resolved CLI input candidate references undeclared stable ID %q", candidate.InputID)
+			return Inputs{}, newResolutionError(ResolutionFailureUndeclaredInput, candidate.InputID, candidate.Source, "candidate references an undeclared stable input ID")
 		}
-		if _, exists := values[candidate.InputID]; exists {
-			return Inputs{}, fmt.Errorf("resolved CLI input %q has multiple candidates without a source policy", candidate.InputID)
+		if !containsSource(definition.Precedence, candidate.Source) {
+			return Inputs{}, newResolutionError(ResolutionFailureUndeclaredSource, candidate.InputID, candidate.Source, "candidate source is absent from the input precedence")
 		}
-		if candidate.Value.Kind() != kind {
-			return Inputs{}, fmt.Errorf(
-				"resolved CLI input %q requires value kind %q, got %q",
-				candidate.InputID,
-				kind,
-				candidate.Value.Kind(),
-			)
+		if candidate.Value.Kind() != definition.Kind {
+			return Inputs{}, newResolutionError(ResolutionFailureValueKind, candidate.InputID, candidate.Source,
+				fmt.Sprintf("requires value kind %q, got %q", definition.Kind, candidate.Value.Kind()))
 		}
-		values[candidate.InputID] = candidate.Value.clone()
+		if byInput[candidate.InputID] == nil {
+			byInput[candidate.InputID] = make(map[Source]Value)
+		}
+		if _, exists := byInput[candidate.InputID][candidate.Source]; exists {
+			return Inputs{}, newResolutionError(ResolutionFailureDuplicateSource, candidate.InputID, candidate.Source, "multiple candidates use the same source")
+		}
+		byInput[candidate.InputID][candidate.Source] = candidate.Value
 	}
-	return Inputs{values: values}, nil
+
+	entries := make(map[string]entry, len(byInput))
+	for _, definition := range definitions {
+		for _, source := range definition.Precedence {
+			value, found := byInput[definition.ID][source]
+			if !found {
+				continue
+			}
+			entries[definition.ID] = entry{value: value.clone(), state: stateFor(source)}
+			break
+		}
+	}
+	return Inputs{entries: entries}, nil
 }
 
 // Lookup returns a detached value by stable schema input ID.
 func (i Inputs) Lookup(inputID string) (Value, bool) {
-	value, ok := i.values[inputID]
-	return value.clone(), ok
+	resolved, ok := i.entries[inputID]
+	return resolved.value.clone(), ok
+}
+
+// State reports the winning provenance and its explicit/default classification.
+func (i Inputs) State(inputID string) (State, bool) {
+	resolved, ok := i.entries[inputID]
+	return resolved.state, ok
 }
 
 func (i Inputs) Bool(inputID string) (bool, error) {
@@ -96,14 +117,50 @@ func (i Inputs) StringArray(inputID string) ([]string, error) {
 }
 
 func (i Inputs) valueOfKind(inputID string, expected ValueKind) (Value, error) {
-	value, ok := i.values[inputID]
+	resolved, ok := i.entries[inputID]
 	if !ok {
 		return Value{}, fmt.Errorf("resolved CLI input %q is missing", inputID)
 	}
+	value := resolved.value
 	if value.Kind() != expected {
 		return Value{}, fmt.Errorf("resolved CLI input %q requires accessor kind %q, got %q", inputID, expected, value.Kind())
 	}
 	return value, nil
+}
+
+func validateDefinition(definition Definition, existing map[string]Definition) error {
+	if definition.ID == "" {
+		return newResolutionError(ResolutionFailureInvalidDefinition, "", "", "definition has an empty stable ID")
+	}
+	if !definition.Kind.valid() {
+		return newResolutionError(ResolutionFailureValueKind, definition.ID, "", fmt.Sprintf("has unsupported value kind %q", definition.Kind))
+	}
+	if _, exists := existing[definition.ID]; exists {
+		return newResolutionError(ResolutionFailureInvalidDefinition, definition.ID, "", "definition repeats the stable input ID")
+	}
+	if len(definition.Precedence) == 0 {
+		return newResolutionError(ResolutionFailureInvalidPrecedence, definition.ID, "", "precedence is empty")
+	}
+	seen := make(map[Source]bool, len(definition.Precedence))
+	for _, source := range definition.Precedence {
+		if !source.valid() {
+			return newResolutionError(ResolutionFailureInvalidPrecedence, definition.ID, source, "precedence contains an unsupported source")
+		}
+		if seen[source] {
+			return newResolutionError(ResolutionFailureInvalidPrecedence, definition.ID, source, "precedence repeats a source")
+		}
+		seen[source] = true
+	}
+	return nil
+}
+
+func containsSource(sources []Source, candidate Source) bool {
+	for _, source := range sources {
+		if source == candidate {
+			return true
+		}
+	}
+	return false
 }
 
 func (k ValueKind) valid() bool {

--- a/pkg/transports/cli/resolvedinput/inputs_test.go
+++ b/pkg/transports/cli/resolvedinput/inputs_test.go
@@ -1,0 +1,90 @@
+package resolvedinput_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/transports/cli/resolvedinput"
+)
+
+func TestResolveRetainsEveryCanonicalValueKindByStableInputID(t *testing.T) {
+	definitions := []resolvedinput.Definition{
+		{ID: "command.flag.enabled", Kind: resolvedinput.ValueKindBool},
+		{ID: "command.flag.name", Kind: resolvedinput.ValueKindString},
+		{ID: "command.flag.count", Kind: resolvedinput.ValueKindInt},
+		{ID: "command.flag.limit", Kind: resolvedinput.ValueKindInt64},
+		{ID: "command.flag.labels", Kind: resolvedinput.ValueKindStringArray},
+		{ID: "command.flag.empty-labels", Kind: resolvedinput.ValueKindStringArray},
+		{ID: "command.arg.0", Kind: resolvedinput.ValueKindStringArray},
+	}
+	candidates := []resolvedinput.Candidate{
+		{InputID: "command.flag.enabled", Value: resolvedinput.BoolValue(true)},
+		{InputID: "command.flag.name", Value: resolvedinput.StringValue("factory")},
+		{InputID: "command.flag.count", Value: resolvedinput.IntValue(3)},
+		{InputID: "command.flag.limit", Value: resolvedinput.Int64Value(1 << 40)},
+		{InputID: "command.flag.labels", Value: resolvedinput.StringArrayValue([]string{"one", "two"})},
+		{InputID: "command.flag.empty-labels", Value: resolvedinput.StringArrayValue([]string{})},
+		{InputID: "command.arg.0", Value: resolvedinput.StringArrayValue([]string{"first", "second"})},
+	}
+
+	inputs, err := resolvedinput.Resolve(definitions, candidates)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	gotBool, err := inputs.Bool("command.flag.enabled")
+	assertScalar(t, gotBool, err, true)
+	gotString, err := inputs.String("command.flag.name")
+	assertScalar(t, gotString, err, "factory")
+	gotInt, err := inputs.Int("command.flag.count")
+	assertScalar(t, gotInt, err, 3)
+	gotInt64, err := inputs.Int64("command.flag.limit")
+	assertScalar(t, gotInt64, err, int64(1<<40))
+	assertStrings(t, inputs, "command.flag.labels", []string{"one", "two"})
+	assertStrings(t, inputs, "command.flag.empty-labels", []string{})
+	assertStrings(t, inputs, "command.arg.0", []string{"first", "second"})
+}
+
+func TestResolveUsesOnlyStableIDsForSyntheticInputs(t *testing.T) {
+	const syntheticID = "synthetic.input.customer-defined"
+	inputs, err := resolvedinput.Resolve(
+		[]resolvedinput.Definition{{ID: syntheticID, Kind: resolvedinput.ValueKindString}},
+		[]resolvedinput.Candidate{{InputID: syntheticID, Value: resolvedinput.StringValue("resolved")}},
+	)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	got, err := inputs.String(syntheticID)
+	if err != nil || got != "resolved" {
+		t.Fatalf("String(%q) = %q, %v; want resolved, nil", syntheticID, got, err)
+	}
+	value, ok := inputs.Lookup(syntheticID)
+	if !ok || value.Kind() != resolvedinput.ValueKindString {
+		t.Fatalf("Lookup(%q) = %#v, %t; want string value, true", syntheticID, value, ok)
+	}
+}
+
+func TestResolveRejectsSchemaAndCandidateKindMismatch(t *testing.T) {
+	_, err := resolvedinput.Resolve(
+		[]resolvedinput.Definition{{ID: "command.flag.count", Kind: resolvedinput.ValueKindInt}},
+		[]resolvedinput.Candidate{{InputID: "command.flag.count", Value: resolvedinput.StringValue("3")}},
+	)
+	if err == nil {
+		t.Fatal("Resolve() error = nil, want value-kind rejection")
+	}
+}
+
+func assertScalar[T comparable](t *testing.T, got T, err error, want T) {
+	t.Helper()
+	if err != nil || got != want {
+		t.Fatalf("accessor = %#v, %v; want %#v, nil", got, err, want)
+	}
+}
+
+func assertStrings(t *testing.T, inputs resolvedinput.Inputs, inputID string, want []string) {
+	t.Helper()
+	got, err := inputs.StringArray(inputID)
+	if err != nil || !reflect.DeepEqual(got, want) {
+		t.Fatalf("StringArray(%q) = %#v, %v; want %#v, nil", inputID, got, err, want)
+	}
+}

--- a/pkg/transports/cli/resolvedinput/inputs_test.go
+++ b/pkg/transports/cli/resolvedinput/inputs_test.go
@@ -9,22 +9,22 @@ import (
 
 func TestResolveRetainsEveryCanonicalValueKindByStableInputID(t *testing.T) {
 	definitions := []resolvedinput.Definition{
-		{ID: "command.flag.enabled", Kind: resolvedinput.ValueKindBool},
-		{ID: "command.flag.name", Kind: resolvedinput.ValueKindString},
-		{ID: "command.flag.count", Kind: resolvedinput.ValueKindInt},
-		{ID: "command.flag.limit", Kind: resolvedinput.ValueKindInt64},
-		{ID: "command.flag.labels", Kind: resolvedinput.ValueKindStringArray},
-		{ID: "command.flag.empty-labels", Kind: resolvedinput.ValueKindStringArray},
-		{ID: "command.arg.0", Kind: resolvedinput.ValueKindStringArray},
+		definition("command.flag.enabled", resolvedinput.ValueKindBool),
+		definition("command.flag.name", resolvedinput.ValueKindString),
+		definition("command.flag.count", resolvedinput.ValueKindInt),
+		definition("command.flag.limit", resolvedinput.ValueKindInt64),
+		definition("command.flag.labels", resolvedinput.ValueKindStringArray),
+		definition("command.flag.empty-labels", resolvedinput.ValueKindStringArray),
+		definition("command.arg.0", resolvedinput.ValueKindStringArray),
 	}
 	candidates := []resolvedinput.Candidate{
-		{InputID: "command.flag.enabled", Value: resolvedinput.BoolValue(true)},
-		{InputID: "command.flag.name", Value: resolvedinput.StringValue("factory")},
-		{InputID: "command.flag.count", Value: resolvedinput.IntValue(3)},
-		{InputID: "command.flag.limit", Value: resolvedinput.Int64Value(1 << 40)},
-		{InputID: "command.flag.labels", Value: resolvedinput.StringArrayValue([]string{"one", "two"})},
-		{InputID: "command.flag.empty-labels", Value: resolvedinput.StringArrayValue([]string{})},
-		{InputID: "command.arg.0", Value: resolvedinput.StringArrayValue([]string{"first", "second"})},
+		candidate("command.flag.enabled", resolvedinput.BoolValue(true)),
+		candidate("command.flag.name", resolvedinput.StringValue("factory")),
+		candidate("command.flag.count", resolvedinput.IntValue(3)),
+		candidate("command.flag.limit", resolvedinput.Int64Value(1<<40)),
+		candidate("command.flag.labels", resolvedinput.StringArrayValue([]string{"one", "two"})),
+		candidate("command.flag.empty-labels", resolvedinput.StringArrayValue([]string{})),
+		candidate("command.arg.0", resolvedinput.StringArrayValue([]string{"first", "second"})),
 	}
 
 	inputs, err := resolvedinput.Resolve(definitions, candidates)
@@ -47,8 +47,8 @@ func TestResolveRetainsEveryCanonicalValueKindByStableInputID(t *testing.T) {
 func TestResolveUsesOnlyStableIDsForSyntheticInputs(t *testing.T) {
 	const syntheticID = "synthetic.input.customer-defined"
 	inputs, err := resolvedinput.Resolve(
-		[]resolvedinput.Definition{{ID: syntheticID, Kind: resolvedinput.ValueKindString}},
-		[]resolvedinput.Candidate{{InputID: syntheticID, Value: resolvedinput.StringValue("resolved")}},
+		[]resolvedinput.Definition{definition(syntheticID, resolvedinput.ValueKindString)},
+		[]resolvedinput.Candidate{candidate(syntheticID, resolvedinput.StringValue("resolved"))},
 	)
 	if err != nil {
 		t.Fatalf("Resolve() error = %v", err)
@@ -66,12 +66,20 @@ func TestResolveUsesOnlyStableIDsForSyntheticInputs(t *testing.T) {
 
 func TestResolveRejectsSchemaAndCandidateKindMismatch(t *testing.T) {
 	_, err := resolvedinput.Resolve(
-		[]resolvedinput.Definition{{ID: "command.flag.count", Kind: resolvedinput.ValueKindInt}},
-		[]resolvedinput.Candidate{{InputID: "command.flag.count", Value: resolvedinput.StringValue("3")}},
+		[]resolvedinput.Definition{definition("command.flag.count", resolvedinput.ValueKindInt)},
+		[]resolvedinput.Candidate{candidate("command.flag.count", resolvedinput.StringValue("3"))},
 	)
 	if err == nil {
 		t.Fatal("Resolve() error = nil, want value-kind rejection")
 	}
+}
+
+func definition(id string, kind resolvedinput.ValueKind) resolvedinput.Definition {
+	return resolvedinput.Definition{ID: id, Kind: kind, Precedence: []resolvedinput.Source{resolvedinput.SourceCLIFlag}}
+}
+
+func candidate(id string, value resolvedinput.Value) resolvedinput.Candidate {
+	return resolvedinput.Candidate{InputID: id, Source: resolvedinput.SourceCLIFlag, Value: value}
 }
 
 func assertScalar[T comparable](t *testing.T, got T, err error, want T) {

--- a/pkg/transports/cli/resolvedinput/observation.go
+++ b/pkg/transports/cli/resolvedinput/observation.go
@@ -1,0 +1,74 @@
+package resolvedinput
+
+import "sort"
+
+// RedactedValue is the stable replacement used wherever sensitive resolved
+// values cross a diagnostic or observation boundary.
+const RedactedValue = "<redacted>"
+
+// Observation is a detached, serialization-safe view of one resolved input.
+// Value retains its canonical Go type for non-sensitive inputs and is always
+// RedactedValue for sensitive inputs, including collections.
+type Observation struct {
+	InputID    string    `json:"inputId"`
+	Kind       ValueKind `json:"kind"`
+	Provenance Source    `json:"provenance"`
+	Changed    bool      `json:"changed"`
+	Default    bool      `json:"default"`
+	Value      any       `json:"value"`
+}
+
+// Observe returns a detached observation by stable schema input ID.
+func (i Inputs) Observe(inputID string) (Observation, bool) {
+	resolved, ok := i.entries[inputID]
+	if !ok {
+		return Observation{}, false
+	}
+	return observation(inputID, resolved), true
+}
+
+// Observations returns detached observations ordered by stable input ID.
+func (i Inputs) Observations() []Observation {
+	inputIDs := make([]string, 0, len(i.entries))
+	for inputID := range i.entries {
+		inputIDs = append(inputIDs, inputID)
+	}
+	sort.Strings(inputIDs)
+
+	observations := make([]Observation, 0, len(inputIDs))
+	for _, inputID := range inputIDs {
+		observations = append(observations, observation(inputID, i.entries[inputID]))
+	}
+	return observations
+}
+
+func observation(inputID string, resolved entry) Observation {
+	return Observation{
+		InputID:    inputID,
+		Kind:       resolved.value.Kind(),
+		Provenance: resolved.state.Provenance,
+		Changed:    resolved.state.Changed,
+		Default:    resolved.state.Default,
+		Value:      observableValue(resolved.value, resolved.sensitive),
+	}
+}
+
+func observableValue(value Value, sensitive bool) any {
+	if sensitive {
+		return RedactedValue
+	}
+	switch value.Kind() {
+	case ValueKindBool:
+		return value.boolValue
+	case ValueKindString:
+		return value.stringValue
+	case ValueKindInt:
+		return value.intValue
+	case ValueKindInt64:
+		return value.int64Value
+	case ValueKindStringArray:
+		return cloneStrings(value.strings)
+	default:
+		return nil
+	}
+}

--- a/pkg/transports/cli/resolvedinput/observation_test.go
+++ b/pkg/transports/cli/resolvedinput/observation_test.go
@@ -1,0 +1,140 @@
+package resolvedinput_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/transports/cli/resolvedinput"
+)
+
+func TestResolveDetachesCollectionOnIngressAndEveryEgressBoundary(t *testing.T) {
+	original := []string{"first", "second"}
+	inputs, err := resolvedinput.Resolve(
+		[]resolvedinput.Definition{definition("input.labels", resolvedinput.ValueKindStringArray)},
+		[]resolvedinput.Candidate{candidate("input.labels", resolvedinput.StringArrayValue(original))},
+	)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	original[0] = "mutated ingress"
+
+	accessed, err := inputs.StringArray("input.labels")
+	if err != nil {
+		t.Fatalf("StringArray() error = %v", err)
+	}
+	accessed[0] = "mutated accessor"
+	lookedUp, ok := inputs.Lookup("input.labels")
+	if !ok {
+		t.Fatal("Lookup() found = false; want true")
+	}
+	lookedUpStrings := observedStrings(t, inputs, "input.labels")
+	lookedUpStrings[0] = "mutated observation"
+
+	got, err := inputs.StringArray("input.labels")
+	if err != nil || !reflect.DeepEqual(got, []string{"first", "second"}) {
+		t.Fatalf("StringArray() after mutations = %#v, %v; want detached original", got, err)
+	}
+	if lookedUp.Kind() != resolvedinput.ValueKindStringArray {
+		t.Fatalf("Lookup().Kind() = %q; want stringArray", lookedUp.Kind())
+	}
+	if gotObserved := observedStrings(t, inputs, "input.labels"); !reflect.DeepEqual(gotObserved, []string{"first", "second"}) {
+		t.Fatalf("Observe() after mutation = %#v; want detached original", gotObserved)
+	}
+}
+
+func TestSensitiveObservationsRedactScalarAndCollectionValues(t *testing.T) {
+	const scalarSecret = "scalar-secret"
+	collectionSecrets := []string{"first-secret", "second-secret"}
+	inputs, err := resolvedinput.Resolve(
+		[]resolvedinput.Definition{
+			{ID: "input.token", Kind: resolvedinput.ValueKindString, Sensitive: true, Precedence: []resolvedinput.Source{resolvedinput.SourceEnvironment}},
+			{ID: "input.tokens", Kind: resolvedinput.ValueKindStringArray, Sensitive: true, Precedence: []resolvedinput.Source{resolvedinput.SourceManifestDefault}},
+		},
+		[]resolvedinput.Candidate{
+			{InputID: "input.token", Source: resolvedinput.SourceEnvironment, Value: resolvedinput.StringValue(scalarSecret)},
+			{InputID: "input.tokens", Source: resolvedinput.SourceManifestDefault, Value: resolvedinput.StringArrayValue(collectionSecrets)},
+		},
+	)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	observations := inputs.Observations()
+	if len(observations) != 2 || observations[0].InputID != "input.token" || observations[1].InputID != "input.tokens" {
+		t.Fatalf("Observations() = %#v; want stable-ID order", observations)
+	}
+	for _, observed := range observations {
+		if observed.Value != resolvedinput.RedactedValue {
+			t.Fatalf("observation %q value = %#v; want %q", observed.InputID, observed.Value, resolvedinput.RedactedValue)
+		}
+	}
+	encoded, err := json.Marshal(observations)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	formatted := string(encoded)
+	humanReadable := fmt.Sprint(observations)
+	var decoded []resolvedinput.Observation
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	for _, observed := range decoded {
+		if observed.Value != resolvedinput.RedactedValue {
+			t.Fatalf("serialized observation %q value = %#v; want redaction marker", observed.InputID, observed.Value)
+		}
+	}
+	for _, secret := range append([]string{scalarSecret}, collectionSecrets...) {
+		if strings.Contains(formatted, secret) || strings.Contains(humanReadable, secret) {
+			t.Fatalf("observation output contains sensitive value %q: JSON=%s human=%v", secret, formatted, observations)
+		}
+	}
+}
+
+func TestNonSensitiveObservationExposesDetachedValueAndWinningState(t *testing.T) {
+	inputs, err := resolvedinput.Resolve(
+		[]resolvedinput.Definition{{
+			ID: "input.labels", Kind: resolvedinput.ValueKindStringArray,
+			Precedence: []resolvedinput.Source{resolvedinput.SourceCLIFlag, resolvedinput.SourceManifestDefault},
+		}},
+		[]resolvedinput.Candidate{{
+			InputID: "input.labels", Source: resolvedinput.SourceManifestDefault,
+			Value: resolvedinput.StringArrayValue([]string{"one", "two"}),
+		}},
+	)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	observed, ok := inputs.Observe("input.labels")
+	if !ok {
+		t.Fatal("Observe() found = false; want true")
+	}
+	want := resolvedinput.Observation{
+		InputID: "input.labels", Kind: resolvedinput.ValueKindStringArray,
+		Provenance: resolvedinput.SourceManifestDefault, Default: true,
+		Value: []string{"one", "two"},
+	}
+	if !reflect.DeepEqual(observed, want) {
+		t.Fatalf("Observe() = %#v; want %#v", observed, want)
+	}
+	observed.Value.([]string)[0] = "mutated"
+	if got := observedStrings(t, inputs, "input.labels"); !reflect.DeepEqual(got, []string{"one", "two"}) {
+		t.Fatalf("Observe() after egress mutation = %#v; want detached value", got)
+	}
+}
+
+func observedStrings(t *testing.T, inputs resolvedinput.Inputs, inputID string) []string {
+	t.Helper()
+	observed, ok := inputs.Observe(inputID)
+	if !ok {
+		t.Fatalf("Observe(%q) found = false; want true", inputID)
+	}
+	values, ok := observed.Value.([]string)
+	if !ok {
+		t.Fatalf("Observe(%q).Value = %#v; want []string", inputID, observed.Value)
+	}
+	return values
+}

--- a/pkg/transports/cli/resolvedinput/resolution_test.go
+++ b/pkg/transports/cli/resolvedinput/resolution_test.go
@@ -1,0 +1,145 @@
+package resolvedinput_test
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/transports/cli/resolvedinput"
+)
+
+func TestResolveUsesEveryPrecedencePositionAndExposesWinningState(t *testing.T) {
+	precedence := allSources()
+	for position, wantSource := range precedence {
+		t.Run(string(wantSource), func(t *testing.T) {
+			candidates := make([]resolvedinput.Candidate, 0, len(precedence)-position)
+			for _, source := range precedence[position:] {
+				candidates = append(candidates, resolvedinput.Candidate{
+					InputID: "command.input", Source: source, Value: resolvedinput.StringValue(string(source)),
+				})
+			}
+
+			inputs, err := resolvedinput.Resolve(
+				[]resolvedinput.Definition{{ID: "command.input", Kind: resolvedinput.ValueKindString, Precedence: precedence}},
+				candidates,
+			)
+			if err != nil {
+				t.Fatalf("Resolve() error = %v", err)
+			}
+			got, err := inputs.String("command.input")
+			if err != nil || got != string(wantSource) {
+				t.Fatalf("String() = %q, %v; want %q, nil", got, err, wantSource)
+			}
+			state, ok := inputs.State("command.input")
+			wantDefault := position >= len(precedence)-2
+			wantState := resolvedinput.State{Provenance: wantSource, Changed: !wantDefault, Default: wantDefault}
+			if !ok || state != wantState {
+				t.Fatalf("State() = %#v, %t; want %#v, true", state, ok, wantState)
+			}
+		})
+	}
+}
+
+func TestResolveIsDeterministicAcrossDefinitionAndCandidateOrder(t *testing.T) {
+	definitions := []resolvedinput.Definition{
+		{ID: "input.alpha", Kind: resolvedinput.ValueKindString, Precedence: []resolvedinput.Source{resolvedinput.SourceCLIFlag, resolvedinput.SourceEnvironment}},
+		{ID: "input.beta", Kind: resolvedinput.ValueKindInt, Precedence: []resolvedinput.Source{resolvedinput.SourceOperatorConfig, resolvedinput.SourceManifestDefault}},
+	}
+	candidates := []resolvedinput.Candidate{
+		{InputID: "input.alpha", Source: resolvedinput.SourceEnvironment, Value: resolvedinput.StringValue("environment")},
+		{InputID: "input.beta", Source: resolvedinput.SourceManifestDefault, Value: resolvedinput.IntValue(2)},
+		{InputID: "input.alpha", Source: resolvedinput.SourceCLIFlag, Value: resolvedinput.StringValue("cli")},
+		{InputID: "input.beta", Source: resolvedinput.SourceOperatorConfig, Value: resolvedinput.IntValue(4)},
+	}
+
+	first, err := resolvedinput.Resolve(definitions, candidates)
+	if err != nil {
+		t.Fatalf("first Resolve() error = %v", err)
+	}
+	second, err := resolvedinput.Resolve(reverse(definitions), reverse(candidates))
+	if err != nil {
+		t.Fatalf("second Resolve() error = %v", err)
+	}
+	assertEquivalentInput(t, first, second, "input.alpha", resolvedinput.ValueKindString)
+	assertEquivalentInput(t, first, second, "input.beta", resolvedinput.ValueKindInt)
+}
+
+func TestResolveRejectsInvalidResolutionInputWithTypedDiagnostic(t *testing.T) {
+	tests := []struct {
+		name       string
+		definition resolvedinput.Definition
+		candidate  resolvedinput.Candidate
+		failure    resolvedinput.ResolutionFailure
+		source     resolvedinput.Source
+	}{
+		{
+			name: "empty precedence", definition: resolvedinput.Definition{ID: "input", Kind: resolvedinput.ValueKindString},
+			failure: resolvedinput.ResolutionFailureInvalidPrecedence,
+		},
+		{
+			name:       "unsupported precedence source",
+			definition: resolvedinput.Definition{ID: "input", Kind: resolvedinput.ValueKindString, Precedence: []resolvedinput.Source{"unknown"}},
+			failure:    resolvedinput.ResolutionFailureInvalidPrecedence, source: "unknown",
+		},
+		{
+			name:       "duplicate precedence source",
+			definition: resolvedinput.Definition{ID: "input", Kind: resolvedinput.ValueKindString, Precedence: []resolvedinput.Source{resolvedinput.SourceCLIFlag, resolvedinput.SourceCLIFlag}},
+			failure:    resolvedinput.ResolutionFailureInvalidPrecedence, source: resolvedinput.SourceCLIFlag,
+		},
+		{
+			name:       "undeclared candidate source",
+			definition: resolvedinput.Definition{ID: "input", Kind: resolvedinput.ValueKindString, Precedence: []resolvedinput.Source{resolvedinput.SourceCLIFlag}},
+			candidate:  resolvedinput.Candidate{InputID: "input", Source: resolvedinput.SourceEnvironment, Value: resolvedinput.StringValue("value")},
+			failure:    resolvedinput.ResolutionFailureUndeclaredSource, source: resolvedinput.SourceEnvironment,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			candidates := []resolvedinput.Candidate(nil)
+			if test.candidate.InputID != "" {
+				candidates = append(candidates, test.candidate)
+			}
+			_, err := resolvedinput.Resolve([]resolvedinput.Definition{test.definition}, candidates)
+			var diagnostic *resolvedinput.ResolutionError
+			if !errors.As(err, &diagnostic) {
+				t.Fatalf("Resolve() error = %v; want *ResolutionError", err)
+			}
+			if diagnostic.Failure != test.failure || diagnostic.InputID != "input" || diagnostic.Source != test.source {
+				t.Fatalf("diagnostic = %#v; want failure=%q input=input source=%q", diagnostic, test.failure, test.source)
+			}
+		})
+	}
+}
+
+func allSources() []resolvedinput.Source {
+	return []resolvedinput.Source{
+		resolvedinput.SourceCLIFlag,
+		resolvedinput.SourcePositionalArgument,
+		resolvedinput.SourceEnvironment,
+		resolvedinput.SourceOperatorConfig,
+		resolvedinput.SourceStdin,
+		resolvedinput.SourceManifestDefault,
+		resolvedinput.SourceFactorySignatureDefault,
+	}
+}
+
+func reverse[T any](values []T) []T {
+	reversed := append([]T(nil), values...)
+	for left, right := 0, len(reversed)-1; left < right; left, right = left+1, right-1 {
+		reversed[left], reversed[right] = reversed[right], reversed[left]
+	}
+	return reversed
+}
+
+func assertEquivalentInput(t *testing.T, first, second resolvedinput.Inputs, inputID string, kind resolvedinput.ValueKind) {
+	t.Helper()
+	firstValue, firstOK := first.Lookup(inputID)
+	secondValue, secondOK := second.Lookup(inputID)
+	firstState, firstStateOK := first.State(inputID)
+	secondState, secondStateOK := second.State(inputID)
+	if !firstOK || !secondOK || !firstStateOK || !secondStateOK || kind != firstValue.Kind() ||
+		!reflect.DeepEqual(firstValue, secondValue) || firstState != secondState {
+		t.Fatalf("resolved input %q differs: values=(%#v, %#v), states=(%#v, %#v)", inputID, firstValue, secondValue, firstState, secondState)
+	}
+}

--- a/pkg/transports/cli/resolvedinput/source.go
+++ b/pkg/transports/cli/resolvedinput/source.go
@@ -1,0 +1,73 @@
+package resolvedinput
+
+import "fmt"
+
+// Source identifies the channel that supplied a resolved CLI input value.
+type Source string
+
+const (
+	SourceCLIFlag                 Source = "cli-flag"
+	SourcePositionalArgument      Source = "positional-argument"
+	SourceEnvironment             Source = "environment"
+	SourceOperatorConfig          Source = "operator-config"
+	SourceStdin                   Source = "stdin"
+	SourceManifestDefault         Source = "manifest-default"
+	SourceFactorySignatureDefault Source = "factory-signature-default"
+)
+
+// State describes how the winning value entered the resolved snapshot.
+type State struct {
+	Provenance Source
+	Changed    bool
+	Default    bool
+}
+
+// ResolutionFailure classifies invalid schema or candidate data.
+type ResolutionFailure string
+
+const (
+	ResolutionFailureInvalidDefinition ResolutionFailure = "invalid-definition"
+	ResolutionFailureInvalidPrecedence ResolutionFailure = "invalid-precedence"
+	ResolutionFailureUndeclaredInput   ResolutionFailure = "undeclared-input"
+	ResolutionFailureUndeclaredSource  ResolutionFailure = "undeclared-source"
+	ResolutionFailureDuplicateSource   ResolutionFailure = "duplicate-source"
+	ResolutionFailureValueKind         ResolutionFailure = "value-kind"
+)
+
+// ResolutionError is a structured diagnostic for invalid resolver input.
+type ResolutionError struct {
+	Failure ResolutionFailure
+	InputID string
+	Source  Source
+	Detail  string
+}
+
+func (e *ResolutionError) Error() string {
+	context := "resolved CLI input"
+	if e.InputID != "" {
+		context += fmt.Sprintf(" %q", e.InputID)
+	}
+	if e.Source != "" {
+		context += fmt.Sprintf(" source %q", e.Source)
+	}
+	return fmt.Sprintf("%s: %s (%s)", context, e.Detail, e.Failure)
+}
+
+func newResolutionError(failure ResolutionFailure, inputID string, source Source, detail string) error {
+	return &ResolutionError{Failure: failure, InputID: inputID, Source: source, Detail: detail}
+}
+
+func (s Source) valid() bool {
+	switch s {
+	case SourceCLIFlag, SourcePositionalArgument, SourceEnvironment, SourceOperatorConfig,
+		SourceStdin, SourceManifestDefault, SourceFactorySignatureDefault:
+		return true
+	default:
+		return false
+	}
+}
+
+func stateFor(source Source) State {
+	isDefault := source == SourceManifestDefault || source == SourceFactorySignatureDefault
+	return State{Provenance: source, Changed: !isDefault, Default: isDefault}
+}

--- a/pkg/transports/cli/resolvedinput/value.go
+++ b/pkg/transports/cli/resolvedinput/value.go
@@ -1,0 +1,60 @@
+package resolvedinput
+
+// ValueKind is one canonical CLI input value kind.
+type ValueKind string
+
+const (
+	ValueKindBool        ValueKind = "bool"
+	ValueKindString      ValueKind = "string"
+	ValueKindInt         ValueKind = "int"
+	ValueKindInt64       ValueKind = "int64"
+	ValueKindStringArray ValueKind = "stringArray"
+)
+
+// Value retains one canonical CLI value without serializing it through text.
+// Collection data is detached when the value enters or leaves this package.
+type Value struct {
+	kind        ValueKind
+	boolValue   bool
+	stringValue string
+	intValue    int
+	int64Value  int64
+	strings     []string
+}
+
+func BoolValue(value bool) Value {
+	return Value{kind: ValueKindBool, boolValue: value}
+}
+
+func StringValue(value string) Value {
+	return Value{kind: ValueKindString, stringValue: value}
+}
+
+func IntValue(value int) Value {
+	return Value{kind: ValueKindInt, intValue: value}
+}
+
+func Int64Value(value int64) Value {
+	return Value{kind: ValueKindInt64, int64Value: value}
+}
+
+func StringArrayValue(value []string) Value {
+	return Value{kind: ValueKindStringArray, strings: cloneStrings(value)}
+}
+
+// Kind reports the canonical kind retained by the value.
+func (v Value) Kind() ValueKind {
+	return v.kind
+}
+
+func (v Value) clone() Value {
+	v.strings = cloneStrings(v.strings)
+	return v
+}
+
+func cloneStrings(value []string) []string {
+	if value == nil {
+		return nil
+	}
+	return append([]string{}, value...)
+}


### PR DESCRIPTION
{
  "project": "Schema-Neutral Resolved CLI Input Model",
  "branchName": "schema-cli-resolved-input-model",
  "description": "Create the schema-driven CLI's transport-owned resolved-input foundation: one schema-neutral, typed, detached value bag keyed by stable input IDs, with deterministic source resolution, provenance, changed/default state, actionable typed access diagnostics, and redaction for sensitive diagnostics and observations. The intent is to remove per-global-flag constructor coupling and give later generic Cobra construction and handler migration one safe runtime input contract.",
  "context": {
    "customerAsk": "Generate one typed resolved CLI input model with typed accessors, provenance, changed/default state, redaction, deterministic resolution, and stable input ID lookup. It must support every canonical CLI value kind, return actionable typed diagnostics for missing or mismatched access, independently prove resolution order and detached ownership, and eliminate constructor signatures that require one field per public global flag.",
    "problem": "The canonical CLI manifest describes inputs and their precedence, but runtime value ownership remains coupled to command-specific and global-flag-shaped storage. That coupling makes generic command construction difficult, allows mutation aliases to cross the resolution boundary, and gives handlers and observation code no uniform contract for typed lookup, provenance, default state, or safe failure reporting. Missing values, type mismatches, and sensitive inputs therefore cannot be handled consistently across later schema-driven CLI work.",
    "solution": "Introduce one immutable-by-contract resolved-input bag at the CLI transport boundary. A pure resolver consumes schema-described input definitions, ordered source candidates, and sensitivity metadata, then stores detached canonical values under stable IDs. Consumers use typed accessors and state inspection rather than concrete flag-name fields. Structured diagnostics identify the input and failure kind while their rendered and observed forms replace sensitive values with a fixed redaction marker."
  },
  "acceptanceCriteria": [
    "AC-1: The resolved-input model accepts and returns every scalar or collection kind admitted by the canonical CLI input contract, including `bool`, `string`, `int`, `int64`, `stringArray`, and positional string collections where cardinality produces multiple values.",
    "AC-2: Values are keyed and retrieved by stable schema input ID, and constructors consume collections of schema-described inputs/candidates rather than requiring one field for each public global flag.",
    "AC-3: Resolution follows the command's declared source order deterministically and exposes the winning provenance and changed/default state for each resolved input.",
    "AC-4: Missing IDs and incompatible typed access return actionable typed diagnostics that distinguish failure kind and identify expected and actual value kinds where applicable.",
    "AC-5: Sensitive scalar and collection values are replaced by a stable redaction marker in diagnostics and observation; no original sensitive value is present in formatted output.",
    "AC-6: Focused unit tests independently prove source resolution order, stable-ID lookup, every supported value kind, typed failure behavior, redaction, and detached ownership on both ingress and egress.",
    "AC-7: Quality checks pass (typecheck, lint, tests)."
  ],
  "userStories": [
    {
      "id": "schema-cli-resolved-input-model-001",
      "title": "Resolve and retain all canonical value kinds by stable input ID",
      "description": "As a CLI transport maintainer, I want one schema-neutral resolved-input bag so any schema-defined command input can be retained and retrieved without adding a constructor field for its public flag name.",
      "acceptanceCriteria": [
        "A resolver accepts collections of schema-described input definitions and candidate values keyed by stable input ID; its public constructor signature does not enumerate individual global flags.",
        "Stable-ID lookup succeeds independently of a flag's public long name, shorthand, alias, argument position, or source channel.",
        "Typed retrieval succeeds for canonical `bool`, `string`, `int`, `int64`, `stringArray`, and positional string-collection values without lossy string round-trips.",
        "Adding a synthetic schema input with a new stable ID and an already-supported value kind requires data supplied to the generic constructor, not a new constructor parameter or name-based binding branch.",
        "Unit tests cover every admitted value kind and stable-ID lookup.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "schema-cli-resolved-input-model-002",
      "title": "Resolve source precedence and expose value state deterministically",
      "description": "As a handler adapter, I want each effective value to report its winning source and explicit/default state so behavior is repeatable and I can distinguish customer input from fallback values.",
      "acceptanceCriteria": [
        "When multiple allowed sources provide one input, the candidate from the first available source in the command's declared precedence order wins.",
        "Repeating the same resolution with identical definitions, candidates, and precedence produces equivalent values, provenance, and changed/default state regardless of map iteration order.",
        "Each resolved entry exposes typed provenance for the winning channel, including CLI flags, positional arguments, environment, operator config, stdin, manifest default, and Factory-signature default when supplied by the resolved schema.",
        "Each entry unambiguously reports whether it was explicitly changed and whether its winning value is a default; the two states are derived from the winning source rather than inferred later by a handler.",
        "Invalid resolution inputs, including an undeclared source or an unusable precedence definition, fail deterministically with a typed diagnostic instead of silently selecting a value.",
        "Focused unit tests independently exercise each precedence position, fallback to defaults, state metadata, invalid resolution input, and repeat-run determinism.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "schema-cli-resolved-input-model-003",
      "title": "Return actionable typed access diagnostics",
      "description": "As a CLI handler author, I want typed accessors to distinguish an absent input from a value-kind mismatch so I can report or translate failures without parsing error strings.",
      "acceptanceCriteria": [
        "Looking up an unknown or unresolved stable input ID returns a typed missing-input diagnostic that includes the requested stable ID.",
        "Requesting a value through an incompatible typed accessor returns a typed mismatch diagnostic that includes the stable ID, expected kind, and actual kind.",
        "Successful accessors return the requested typed value together with no failure and do not require consumers to inspect untyped maps or parse serialized defaults.",
        "Diagnostic classification and structured metadata remain available through error wrapping or translation so callers do not need string matching.",
        "Focused unit tests prove successful access, missing-input classification, mismatch classification, and expected/actual kind metadata for scalar and collection accessors.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "schema-cli-resolved-input-model-004",
      "title": "Preserve detached ownership and redact sensitive values",
      "description": "As an operator, I want resolved inputs to be stable snapshots whose diagnostics and observations never reveal sensitive values so debugging cannot mutate invocation state or leak secrets.",
      "acceptanceCriteria": [
        "Mutating caller-owned collection data after resolution does not alter the stored resolved value.",
        "Mutating a collection returned by an accessor or observation does not alter later reads from the resolved-input model.",
        "Diagnostics and observation output replace sensitive scalar and collection values with one stable redaction marker while retaining safe context such as stable input ID, value kind, provenance, and state.",
        "The original sensitive value, including each element of a sensitive collection, is absent from formatted diagnostics and serialized or human-readable observation output.",
        "Non-sensitive observations expose detached values and the same provenance and changed/default state available through lookup.",
        "Focused unit tests independently prove ingress detachment, egress detachment, scalar redaction, collection redaction, and safe non-sensitive observation.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}
