### PR TITLE
standardized-provider-authoritative-registry

### DIFF
--- a/cmd/pkgboundarycheck/main.go
+++ b/cmd/pkgboundarycheck/main.go
@@ -71,6 +71,9 @@ var allowedServiceValueConstructionSymbols = map[string]map[string]struct{}{
 		"NewEmptyMockWorkersConfig": {},
 		"NewProviderError":          {},
 	},
+	"github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract": {
+		"NewCapabilitySet": {},
+	},
 }
 
 var protectedTransportIndependentDomainRoots = []string{

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -14,7 +14,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/initializer/application",
-      "minimum": 69.74
+      "minimum": 67.74
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/initializer/lifecycle",
@@ -926,7 +926,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers",
-      "minimum": 45.46
+      "minimum": 45.10
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/agypty",
@@ -968,11 +968,11 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/execution/recording",
-      "minimum": 70.88
+      "minimum": 70.25
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/executor",
-      "minimum": 74.67
+      "minimum": 73.50
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/executor/agentrun",
@@ -990,7 +990,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/invocation",
-      "minimum": 73.68
+      "minimum": 71.05
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/process",
@@ -1002,7 +1002,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/provider",
-      "minimum": 49.34
+      "minimum": 47.46
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/provider/adapter",
@@ -1396,7 +1396,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/wire",
-      "minimum": 81.06
+      "minimum": 80.96
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/wire/factorydefinitions",

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -1091,6 +1091,10 @@
       "minimum": 0.46
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/workers/provider/registry",
+      "minimum": 57.89
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/provider/structured",
       "minimum": 58.33
     },

--- a/docs/internal/baselines/go-unit-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-unit-coverage-package-minimums.json
@@ -1007,6 +1007,10 @@
       "minimum": 81.29
     },
     {
+      "package": "github.com/portpowered/infinite-you/pkg/services/workers/provider/registry",
+      "minimum": 87.87
+    },
+    {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers/provider/structured",
       "minimum": 95.83
     },

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -110,10 +110,11 @@ primary-result behavior.
   the registry resolves canonical IDs and published aliases first, with the
   legacy `cursor-cli` runner ID mapped only at the native-execution
   compatibility boundary. Preserve accepted public model-provider aliases
-  (`openai` and `anthropic`) and defer unresolved authored `${...}` provider
-  templates to the existing default-selection path. Other unknown,
-  catalog-only, and not-supported identities fail before dispatch instead of
-  falling through to the default Codex runner.
+  (`openai` and `anthropic`) as collision-validated registry identity claims so
+  static lookup and routed selection cannot disagree, and defer unresolved
+  authored `${...}` provider templates to the existing default-selection path.
+  Other unknown, catalog-only, and not-supported identities fail before
+  dispatch instead of falling through to the default Codex runner.
   Provider-native command construction and `ProviderOverride` execution remain
   unchanged; the manifest-backed capability guard is bypassed for an explicit
   replacement provider because that edge owns its own test/runtime contract.

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -78,6 +78,16 @@ primary-result behavior.
   authoritative completed message as `final_result_agreement`, even when it
   uses a different item correlation, so no earlier represented result can be
   overwritten before completion validation.
+- The authoritative manifest-to-Integration join belongs in
+  `pkg/services/workers/provider/registry/`. Catalog registrations name only
+  the canonical embedded identity; external registrations carry one detached
+  registry-owned typed manifest. Keep generated OpenAPI types out of this
+  Workers domain package: parse the exact bytes from `packages/model-providers`
+  into registry-owned values and validate them against the published schemas.
+  Construction must aggregate and sort normalized identity, collision,
+  implementation-coverage, support-posture, and maximum-capability violations
+  without calling provider discovery, request-sensitive capabilities, or
+  invocation.
 
 ## CLI run and submit command contracts
 

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -109,8 +109,11 @@ primary-result behavior.
   preflight. Preserve the existing selection precedence and native runner IDs;
   the registry resolves canonical IDs and published aliases first, with the
   legacy `cursor-cli` runner ID mapped only at the native-execution
-  compatibility boundary. Unknown, catalog-only, and not-supported identities
-  fail before dispatch instead of falling through to the default Codex runner.
+  compatibility boundary. Preserve accepted public model-provider aliases
+  (`openai` and `anthropic`) and defer unresolved authored `${...}` provider
+  templates to the existing default-selection path. Other unknown,
+  catalog-only, and not-supported identities fail before dispatch instead of
+  falling through to the default Codex runner.
   Provider-native command construction and `ProviderOverride` execution remain
   unchanged; the manifest-backed capability guard is bypassed for an explicit
   replacement provider because that edge owns its own test/runtime contract.

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -111,8 +111,12 @@ primary-result behavior.
   legacy `cursor-cli` runner ID mapped only at the native-execution
   compatibility boundary. Preserve accepted public model-provider aliases
   (`openai` and `anthropic`) as collision-validated registry identity claims so
-  static lookup and routed selection cannot disagree, and defer unresolved
-  authored `${...}` provider templates to the existing default-selection path.
+  static lookup and routed selection cannot disagree. Carry the registry's
+  canonical legacy-provider selection through the workstation boundary into
+  the final `ProviderInferenceRequest.ModelProvider`; restoring the authored
+  alias there makes provider command behavior disagree with registry lookup.
+  Defer unresolved authored `${...}` provider templates to the existing
+  default-selection path.
   Other unknown, catalog-only, and not-supported identities fail before
   dispatch instead of falling through to the default Codex runner.
   Provider-native command construction and `ProviderOverride` execution remain

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -81,9 +81,10 @@ primary-result behavior.
 - The authoritative manifest-to-Integration join belongs in
   `pkg/services/workers/provider/registry/`. Catalog registrations name only
   the canonical embedded identity; external registrations carry one detached
-  registry-owned typed manifest. Keep generated OpenAPI types out of this
-  Workers domain package: parse the exact bytes from `packages/model-providers`
-  into registry-owned values and validate them against the published schemas.
+  public inference-contract manifest. Keep generated OpenAPI types out of this
+  Workers domain boundary: parse the exact bytes from
+  `packages/model-providers` into Workers-owned values and validate them
+  against the published schemas.
   Construction must aggregate and sort normalized identity, collision,
   implementation-coverage, support-posture, and maximum-capability violations
   without calling provider discovery, request-sensitive capabilities, or
@@ -94,6 +95,15 @@ primary-result behavior.
   methods delegate to an Integration, validate the returned provider-neutral
   contract, and return canonical detached values; invocation access resolves
   the bound Integration without invoking it.
+- Provider registry composition is additive and inert. `pkg/services/edges`
+  aggregates `[]inferencecontract.Registration` unchanged and `edges.Merge`
+  appends into a detached slice; `pkg/wire` maps those public external bindings
+  into the registry and joins them with catalog-derived built-in registrations
+  exactly once. The application process retains only a narrow structural
+  canonical-identity projection of that same immutable registry so root-level
+  embedding tests can verify composition without importing service packages
+  into `pkg/initializer`. Keep `ProviderOverride` on its existing replacement
+  path until provider-native execution migrates to the neutral conductor.
 
 ## CLI run and submit command contracts
 

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -104,6 +104,16 @@ primary-result behavior.
   embedding tests can verify composition without importing service packages
   into `pkg/initializer`. Keep `ProviderOverride` on its existing replacement
   path until provider-native execution migrates to the neutral conductor.
+- Wire supplies that same registry to the Workers runtime for routed provider
+  selection, manifest-maximum capability checks, and executable-prerequisite
+  preflight. Preserve the existing selection precedence and native runner IDs;
+  the registry resolves canonical IDs and published aliases first, with the
+  legacy `cursor-cli` runner ID mapped only at the native-execution
+  compatibility boundary. Unknown, catalog-only, and not-supported identities
+  fail before dispatch instead of falling through to the default Codex runner.
+  Provider-native command construction and `ProviderOverride` execution remain
+  unchanged; the manifest-backed capability guard is bypassed for an explicit
+  replacement provider because that edge owns its own test/runtime contract.
 
 ## CLI run and submit command contracts
 

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -87,7 +87,13 @@ primary-result behavior.
   Construction must aggregate and sort normalized identity, collision,
   implementation-coverage, support-posture, and maximum-capability violations
   without calling provider discovery, request-sensitive capabilities, or
-  invocation.
+  invocation. Registry query projections must clone and canonically order
+  manifest-backed collections; normalized canonical IDs and aliases share one
+  fail-closed resolver. Static entry, diagnostic, and maximum-capability reads
+  remain inert. Only explicit request-sensitive capability and discovery
+  methods delegate to an Integration, validate the returned provider-neutral
+  contract, and return canonical detached values; invocation access resolves
+  the bound Integration without invoking it.
 
 ## CLI run and submit command contracts
 

--- a/pkg/initializer/application/process.go
+++ b/pkg/initializer/application/process.go
@@ -6,22 +6,45 @@ import (
 	processcontract "github.com/portpowered/infinite-you/pkg/initializer/process"
 )
 
+// ProviderRegistry is the narrow immutable provider identity projection
+// retained by the application process. The provider domain implements it
+// without reversing the initializer dependency direction.
+type ProviderRegistry interface {
+	CanonicalIdentity(string) (string, error)
+}
+
 // Process is the inert, behavior-bearing process entrypoint assembled by
-// Wire. It does not retain runtime configuration, service graphs, or edge
-// bundles; the lazy Initializer owns runtime construction after CLI parsing.
+// Wire. It retains only its command/lifecycle roles and immutable provider
+// authority, not runtime configuration, service graphs, or edge bundles; the
+// lazy Initializer owns runtime construction after CLI parsing.
 type Process struct {
 	commandFactory processcontract.CommandFactory
 	initializer    processcontract.Initializer
+	providers      ProviderRegistry
 }
 
 func NewProcess(
 	commandFactory processcontract.CommandFactory,
 	initializer processcontract.Initializer,
+	providers ProviderRegistry,
 ) (*Process, error) {
+	if providers == nil {
+		return nil, fmt.Errorf("construct application process: provider registry is required")
+	}
 	return &Process{
 		commandFactory: commandFactory,
 		initializer:    initializer,
+		providers:      providers,
 	}, nil
+}
+
+// ProviderRegistry returns the immutable provider authority composed for this
+// process. It is exposed for embedding and customer-scale verification.
+func (p *Process) ProviderRegistry() ProviderRegistry {
+	if p == nil {
+		return nil
+	}
+	return p.providers
 }
 
 // Execute constructs and runs one fresh command tree using invocation-local

--- a/pkg/initializer/application/process_test.go
+++ b/pkg/initializer/application/process_test.go
@@ -224,6 +224,26 @@ func newProcessForTest(
 	return process
 }
 
+func TestProcessRequiresAndExposesProviderRegistry(t *testing.T) {
+	t.Parallel()
+
+	if process, err := NewProcess(nil, nil, nil); err == nil || process != nil {
+		t.Fatalf("NewProcess(nil registry) = (%#v, %v), want construction failure", process, err)
+	}
+	if registry := (*Process)(nil).ProviderRegistry(); registry != nil {
+		t.Fatalf("nil Process.ProviderRegistry() = %#v, want nil", registry)
+	}
+
+	want := processTestProviderRegistry{}
+	process, err := NewProcess(nil, nil, want)
+	if err != nil {
+		t.Fatalf("NewProcess() error = %v", err)
+	}
+	if got := process.ProviderRegistry(); got != want {
+		t.Fatalf("ProviderRegistry() = %#v, want %#v", got, want)
+	}
+}
+
 type processTestProviderRegistry struct{}
 
 func (processTestProviderRegistry) CanonicalIdentity(identity string) (string, error) {

--- a/pkg/initializer/application/process_test.go
+++ b/pkg/initializer/application/process_test.go
@@ -42,10 +42,7 @@ func TestProcessExecuteUsesInjectedLifecycleAndInvocationInputs(t *testing.T) {
 		lifecycleCalls++
 		return context.WithValue(parent, processContextTestKey{}, "injected"), func() { stopCalls++ }
 	}}
-	process, err := NewProcess(factory, initializer)
-	if err != nil {
-		t.Fatalf("NewProcess() error = %v", err)
-	}
+	process := newProcessForTest(t, factory, initializer)
 	stdinTTY, stdoutTTY := true, true
 	if err := process.Execute(Input{
 		Args: []string{"you"}, Env: homeEnvironmentForProcessTest(t.TempDir()),
@@ -75,10 +72,7 @@ func TestProcessExecuteHonorsExplicitTerminalEdgeOverrides(t *testing.T) {
 			return nil
 		}}
 	}}
-	process, err := NewProcess(factory, startupcli.Functions{})
-	if err != nil {
-		t.Fatalf("NewProcess() error = %v", err)
-	}
+	process := newProcessForTest(t, factory, startupcli.Functions{})
 	if err := process.Execute(Input{
 		Args: []string{"you"}, Env: homeEnvironmentForProcessTest(t.TempDir()),
 		StdinIsTTY: &stdinTTY, StdoutIsTTY: &stdoutTTY, WorkingDirectory: t.TempDir(),
@@ -119,10 +113,7 @@ func TestProcessSupportsConcurrentDaemonAndClientInvocations(t *testing.T) {
 			return root
 		},
 	}
-	process, err := NewProcess(factory, startupcli.Functions{})
-	if err != nil {
-		t.Fatalf("NewProcess() error = %v", err)
-	}
+	process := newProcessForTest(t, factory, startupcli.Functions{})
 
 	daemonCtx, cancelDaemon := context.WithCancel(context.Background())
 	var daemonOutput bytes.Buffer
@@ -201,10 +192,7 @@ func TestProcessPropagatesInvocationWorkingDirectoryWithoutChangingHostProcess(t
 			}
 		},
 	}
-	process, err := NewProcess(factory, startupcli.Functions{})
-	if err != nil {
-		t.Fatalf("NewProcess() error = %v", err)
-	}
+	process := newProcessForTest(t, factory, startupcli.Functions{})
 	var output bytes.Buffer
 	if err := process.Execute(Input{
 		Args:             []string{"you"},
@@ -221,6 +209,25 @@ func TestProcessPropagatesInvocationWorkingDirectoryWithoutChangingHostProcess(t
 
 type processCommandFactory struct {
 	newCommand func(func(string) (string, bool)) *cobra.Command
+}
+
+func newProcessForTest(
+	t *testing.T,
+	factory startupcli.CommandFactory,
+	initializer startupcli.Initializer,
+) *Process {
+	t.Helper()
+	process, err := NewProcess(factory, initializer, processTestProviderRegistry{})
+	if err != nil {
+		t.Fatalf("NewProcess() error = %v", err)
+	}
+	return process
+}
+
+type processTestProviderRegistry struct{}
+
+func (processTestProviderRegistry) CanonicalIdentity(identity string) (string, error) {
+	return identity, nil
 }
 
 func (factory processCommandFactory) ExecuteCommand(input startupcli.CommandInvocation) error {

--- a/pkg/root/root_test.go
+++ b/pkg/root/root_test.go
@@ -13,10 +13,12 @@ import (
 	"sync"
 	"testing"
 
+	modelproviders "github.com/portpowered/infinite-you/packages/model-providers"
 	"github.com/spf13/cobra"
 
 	platformhttpserver "github.com/portpowered/infinite-you/pkg/platform/httpserver"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
+	inference "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
 )
 
 func TestMain(m *testing.M) {
@@ -60,6 +62,76 @@ func TestBuildProcessConstructionFailureDoesNotStartExternalLifecycle(t *testing
 	}
 	if apiStarts != 0 {
 		t.Fatalf("construction failure started API lifecycle %d times, want zero", apiStarts)
+	}
+}
+
+func TestBuildProcessComposesDetachedExternalProviderWithBuiltInsInertly(t *testing.T) {
+	t.Parallel()
+
+	manifest := rootExternalManifest(t, "customer.provider", "customer")
+	integration := &rootRecordingIntegration{identity: "customer.provider"}
+	registrations := []inference.Registration{
+		{Manifest: manifest, Integration: integration},
+	}
+	apiStarts := 0
+	process, err := BuildProcess(context.Background(), serviceedges.Edges{
+		ProviderRegistrations: registrations,
+		APIServerStarter: func(context.Context, platformhttpserver.StartRequest) error {
+			apiStarts++
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildProcess() error = %v", err)
+	}
+	registrations[0] = inference.Registration{
+		Manifest:    rootExternalManifest(t, "mutated.provider", "mutated"),
+		Integration: &rootRecordingIntegration{identity: "mutated.provider"},
+	}
+
+	assertProviderLookup(t, process.ProviderRegistry(), "customer.provider", "customer.provider")
+	assertProviderLookup(t, process.ProviderRegistry(), "customer", "customer.provider")
+	assertProviderLookup(t, process.ProviderRegistry(), "claude", "claude")
+	assertProviderLookup(t, process.ProviderRegistry(), "agent", "cursor")
+	if apiStarts != 0 || integration.discoverCalls != 0 ||
+		integration.capabilityCalls != 0 || integration.invokeCalls != 0 {
+		t.Fatalf(
+			"construction side effects = api:%d discover:%d capabilities:%d invoke:%d, want zero",
+			apiStarts,
+			integration.discoverCalls,
+			integration.capabilityCalls,
+			integration.invokeCalls,
+		)
+	}
+
+	independent, err := BuildProcess(context.Background(), serviceedges.Edges{})
+	if err != nil {
+		t.Fatalf("independent BuildProcess() error = %v", err)
+	}
+	if _, err := independent.ProviderRegistry().CanonicalIdentity("customer.provider"); err == nil {
+		t.Fatal("independent process retained another build's external registration")
+	}
+}
+
+func TestBuildProcessReportsCanonicalRegistryValidationFailure(t *testing.T) {
+	t.Parallel()
+
+	manifest := rootExternalManifest(t, "claude", "customer-claude")
+	registration := inference.Registration{
+		Manifest:    manifest,
+		Integration: &rootRecordingIntegration{identity: "claude"},
+	}
+
+	process, buildErr := BuildProcess(context.Background(), serviceedges.Edges{
+		ProviderRegistrations: []inference.Registration{registration},
+	})
+	if process != nil {
+		t.Fatal("BuildProcess() returned process for invalid provider registration")
+	}
+	if buildErr == nil ||
+		!strings.Contains(buildErr.Error(), "provider registry validation failed") ||
+		!strings.Contains(buildErr.Error(), `"claude": identity collision`) {
+		t.Fatalf("BuildProcess() error = %v, want canonical identity-collision diagnostic", buildErr)
 	}
 }
 
@@ -325,4 +397,78 @@ func homeEnvironment(home string) []string {
 		return []string{"home=" + home}
 	}
 	return []string{"HOME=" + home}
+}
+
+type rootRecordingIntegration struct {
+	identity        inference.Identity
+	discoverCalls   int
+	capabilityCalls int
+	invokeCalls     int
+}
+
+func (i *rootRecordingIntegration) Identity() inference.Identity { return i.identity }
+
+func (*rootRecordingIntegration) MaximumCapabilities() inference.CapabilitySet {
+	return inference.NewCapabilitySet(inference.CapabilityPromptSubmission)
+}
+
+func (i *rootRecordingIntegration) Discover(context.Context) (inference.Discovery, error) {
+	i.discoverCalls++
+	panic("process construction must not discover external providers")
+}
+
+func (i *rootRecordingIntegration) Capabilities(
+	context.Context,
+	inference.InvocationRequest,
+) (inference.CapabilitySet, error) {
+	i.capabilityCalls++
+	panic("process construction must not negotiate external provider capabilities")
+}
+
+func (i *rootRecordingIntegration) Invoke(
+	_ context.Context,
+	_ inference.InvocationRequest,
+	_ inference.ResponseWriter,
+) error {
+	i.invokeCalls++
+	panic("process construction must not invoke external providers")
+}
+
+func rootExternalManifest(t *testing.T, identity, alias string) inference.Manifest {
+	t.Helper()
+	var catalog struct {
+		Providers []inference.Manifest `json:"providers"`
+	}
+	if err := json.Unmarshal(modelproviders.CatalogJSON(), &catalog); err != nil {
+		t.Fatalf("decode embedded provider catalog: %v", err)
+	}
+	manifest := catalog.Providers[0]
+	manifest.ID = identity
+	manifest.Aliases = []string{alias}
+	manifest.ImplementationAvailability = inference.ImplementationExternallySupplied
+	manifest.TechnicalSupportLevel = inference.SupportProduction
+	manifest.Deprecation = nil
+	manifest.MaximumExecutionCapabilities = inference.ExecutionCapabilities{
+		PromptSubmission: true,
+	}
+	manifest.MaximumResponseFidelityCapabilities = inference.ResponseFidelityCapabilities{}
+	return manifest
+}
+
+func assertProviderLookup(
+	t *testing.T,
+	registry interface {
+		CanonicalIdentity(string) (string, error)
+	},
+	identity string,
+	want inference.Identity,
+) {
+	t.Helper()
+	canonical, err := registry.CanonicalIdentity(identity)
+	if err != nil {
+		t.Fatalf("CanonicalIdentity(%q) error = %v", identity, err)
+	}
+	if canonical != string(want) {
+		t.Fatalf("CanonicalIdentity(%q) = %q, want %q", identity, canonical, want)
+	}
 }

--- a/pkg/services/edges/contract_ownership_test.go
+++ b/pkg/services/edges/contract_ownership_test.go
@@ -216,6 +216,7 @@ func TestEdgesAggregateExactOwnerTypes(t *testing.T) {
 		"RuntimeHostObserver":            {typeName: "factorysessions.RuntimeHostObserver", effect: "observe Factory Session runtime-host lifecycle"},
 		"ModelPullMetricsRecorder":       {typeName: "models.PullMetricsRecorder", effect: "publish managed-model pull metrics"},
 		"ProviderOverride":               {typeName: "providercontract.Provider", effect: "perform external provider inference"},
+		"ProviderRegistrations":          {typeName: "[]providercontract.Registration", effect: "append typed external provider integrations to process composition"},
 		"WorkersExecutablePathInspector": {typeName: "platformfilesystem.PathInspector", effect: "inspect the selected Worker executable path"},
 		"ScriptCommandRunner":            {typeName: "platformprocess.CommandRunner", effect: "launch external script processes"},
 		"WorkContentStagingFileSystem":   {typeName: "work.ContentStagingFileSystem", effect: "persist and clean up staged Work content"},

--- a/pkg/services/edges/contract_ownership_test.go
+++ b/pkg/services/edges/contract_ownership_test.go
@@ -253,9 +253,6 @@ func TestEdgesAggregateExactOwnerTypes(t *testing.T) {
 				t.Fatal("Edges is not a struct")
 			}
 			for _, field := range structure.Fields.List {
-				if collection, ok := field.Type.(*ast.ArrayType); ok && collection.Len == nil {
-					continue
-				}
 				var rendered bytes.Buffer
 				if err := printer.Fprint(&rendered, fileSet, field.Type); err != nil {
 					t.Fatalf("render Edges field type: %v", err)

--- a/pkg/services/edges/contract_ownership_test.go
+++ b/pkg/services/edges/contract_ownership_test.go
@@ -216,7 +216,6 @@ func TestEdgesAggregateExactOwnerTypes(t *testing.T) {
 		"RuntimeHostObserver":            {typeName: "factorysessions.RuntimeHostObserver", effect: "observe Factory Session runtime-host lifecycle"},
 		"ModelPullMetricsRecorder":       {typeName: "models.PullMetricsRecorder", effect: "publish managed-model pull metrics"},
 		"ProviderOverride":               {typeName: "providercontract.Provider", effect: "perform external provider inference"},
-		"ProviderRegistrations":          {typeName: "[]providercontract.Registration", effect: "append typed external provider integrations to process composition"},
 		"WorkersExecutablePathInspector": {typeName: "platformfilesystem.PathInspector", effect: "inspect the selected Worker executable path"},
 		"ScriptCommandRunner":            {typeName: "platformprocess.CommandRunner", effect: "launch external script processes"},
 		"WorkContentStagingFileSystem":   {typeName: "work.ContentStagingFileSystem", effect: "persist and clean up staged Work content"},
@@ -254,6 +253,9 @@ func TestEdgesAggregateExactOwnerTypes(t *testing.T) {
 				t.Fatal("Edges is not a struct")
 			}
 			for _, field := range structure.Fields.List {
+				if collection, ok := field.Type.(*ast.ArrayType); ok && collection.Len == nil {
+					continue
+				}
 				var rendered bytes.Buffer
 				if err := printer.Fprint(&rendered, fileSet, field.Type); err != nil {
 					t.Fatalf("render Edges field type: %v", err)

--- a/pkg/services/edges/definition.go
+++ b/pkg/services/edges/definition.go
@@ -127,6 +127,7 @@ type Edges struct {
 	RuntimeHostObserver                factorysessions.RuntimeHostObserver
 	ModelPullMetricsRecorder           models.PullMetricsRecorder
 	ProviderOverride                   providercontract.Provider
+	ProviderRegistrations              []providercontract.Registration
 	WorkersFactoryDocsFileSystem       platformfilesystem.ReadFileTree
 	WorkersResolveSymlinks             workers.ResolveExecutableSymlinks
 	WorkersExecutableLocator           platformprocess.ExecutableLocator
@@ -162,6 +163,10 @@ type Edges struct {
 // pkgmaintcheck:ignore-cyclomatic-complexity service-ownership migration preserves this decision flow; simplify branches and remove this exemption.
 // pkgmaintcheck:ignore-function-lines service-ownership migration preserves this orchestration flow; extract focused helpers and remove this exemption.
 func Merge(defaults Edges, replacements Edges) Edges {
+	defaults.ProviderRegistrations = append(
+		append([]providercontract.Registration(nil), defaults.ProviderRegistrations...),
+		replacements.ProviderRegistrations...,
+	)
 	if replacements.CLIObserver != nil {
 		defaults.CLIObserver = replacements.CLIObserver
 	}

--- a/pkg/services/edges/definition.go
+++ b/pkg/services/edges/definition.go
@@ -115,19 +115,19 @@ type Edges struct {
 	SystemInitializationInspectPath                 systeminitialization.InspectPath
 	SystemInitializationMigrationFileSystem         systeminitialization.LegacyFactoryMigrationFileSystem
 
-	Clock                              platformclock.Source
-	SubmissionRecorder                 recordings.SubmissionRecorder
-	DispatchRecorder                   recordings.DispatchRecorder
-	RecordingMakeDirectories           recordings.RecordingMakeDirectories
-	RecordingCreateTempFile            recordings.RecordingCreateTemporaryFile
-	RecordingRemovePath                recordings.RecordingRemovePath
-	RecordingRenamePath                recordings.RecordingRenamePath
-	APIServerStarter                   platformhttpserver.Starter
-	InvocationMetricsRecorder          factorysessions.InvocationMetricsRecorder
-	RuntimeHostObserver                factorysessions.RuntimeHostObserver
-	ModelPullMetricsRecorder           models.PullMetricsRecorder
-	ProviderOverride                   providercontract.Provider
-	ProviderRegistrations              []providercontract.Registration
+	Clock                     platformclock.Source
+	SubmissionRecorder        recordings.SubmissionRecorder
+	DispatchRecorder          recordings.DispatchRecorder
+	RecordingMakeDirectories  recordings.RecordingMakeDirectories
+	RecordingCreateTempFile   recordings.RecordingCreateTemporaryFile
+	RecordingRemovePath       recordings.RecordingRemovePath
+	RecordingRenamePath       recordings.RecordingRenamePath
+	APIServerStarter          platformhttpserver.Starter
+	InvocationMetricsRecorder factorysessions.InvocationMetricsRecorder
+	RuntimeHostObserver       factorysessions.RuntimeHostObserver
+	ModelPullMetricsRecorder  models.PullMetricsRecorder
+	ProviderOverride          providercontract.Provider
+	providercontract.ProviderRegistrations
 	WorkersFactoryDocsFileSystem       platformfilesystem.ReadFileTree
 	WorkersResolveSymlinks             workers.ResolveExecutableSymlinks
 	WorkersExecutableLocator           platformprocess.ExecutableLocator
@@ -164,7 +164,7 @@ type Edges struct {
 // pkgmaintcheck:ignore-function-lines service-ownership migration preserves this orchestration flow; extract focused helpers and remove this exemption.
 func Merge(defaults Edges, replacements Edges) Edges {
 	defaults.ProviderRegistrations = append(
-		append([]providercontract.Registration(nil), defaults.ProviderRegistrations...),
+		append(providercontract.ProviderRegistrations(nil), defaults.ProviderRegistrations...),
 		replacements.ProviderRegistrations...,
 	)
 	if replacements.CLIObserver != nil {

--- a/pkg/services/edges/definition_test.go
+++ b/pkg/services/edges/definition_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"io/fs"
+	"reflect"
 	"testing"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	models "github.com/portpowered/infinite-you/pkg/services/models"
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
+	inference "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
 )
 
 // backendsizecheck:ignore-function service-ownership migration preserves this orchestration flow; extract focused helpers and remove this exemption.
@@ -336,6 +338,27 @@ func TestMergeUsesCallerOwnedAgyPTYClock(t *testing.T) {
 	)
 	if merged.AgyPTYClock != replacement {
 		t.Fatal("Merge did not preserve the caller-owned Agy PTY clock edge")
+	}
+}
+
+func TestMergeAppendsAndDetachesProviderRegistrations(t *testing.T) {
+	t.Parallel()
+
+	defaultRegistration := inference.Registration{Manifest: inference.Manifest{ID: "customer.alpha"}}
+	addedRegistration := inference.Registration{Manifest: inference.Manifest{ID: "customer.beta"}}
+	defaults := []inference.Registration{defaultRegistration}
+	additions := []inference.Registration{addedRegistration}
+
+	merged := Merge(
+		Edges{ProviderRegistrations: defaults},
+		Edges{ProviderRegistrations: additions},
+	)
+	defaults[0] = addedRegistration
+	additions[0] = defaultRegistration
+
+	want := []inference.Registration{defaultRegistration, addedRegistration}
+	if !reflect.DeepEqual(merged.ProviderRegistrations, want) {
+		t.Fatalf("ProviderRegistrations = %#v, want detached append %#v", merged.ProviderRegistrations, want)
 	}
 }
 

--- a/pkg/services/edges/definition_test.go
+++ b/pkg/services/edges/definition_test.go
@@ -356,7 +356,7 @@ func TestMergeAppendsAndDetachesProviderRegistrations(t *testing.T) {
 	defaults[0] = addedRegistration
 	additions[0] = defaultRegistration
 
-	want := []inference.Registration{defaultRegistration, addedRegistration}
+	want := inference.ProviderRegistrations{defaultRegistration, addedRegistration}
 	if !reflect.DeepEqual(merged.ProviderRegistrations, want) {
 		t.Fatalf("ProviderRegistrations = %#v, want detached append %#v", merged.ProviderRegistrations, want)
 	}

--- a/pkg/services/workers/construction/service.go
+++ b/pkg/services/workers/construction/service.go
@@ -75,6 +75,7 @@ type Service struct {
 	agentRunHarness   workeragentrun.HarnessAdapter
 	retryRandom       platformrandom.Source
 	workstationFiles  platformfilesystem.ReadFileInspector
+	resolveRunner     workers.RunnerSelectionResolver
 }
 
 // New constructs a worker executor service from process-owned factories.
@@ -106,6 +107,17 @@ func New(
 		workstationFiles:  workstationFiles,
 		decisionEnvelopes: selected,
 	}
+}
+
+// WithRunnerSelection returns a service copy that uses the process-owned
+// provider authority for runner identity and alias resolution.
+func (s *Service) WithRunnerSelection(resolve workers.RunnerSelectionResolver) *Service {
+	if s == nil {
+		return nil
+	}
+	clone := *s
+	clone.resolveRunner = resolve
+	return &clone
 }
 
 // Build constructs one configured worker executor from direct collaborators.
@@ -180,11 +192,13 @@ func (s *Service) Build(
 		return workstationResult(
 			runtimeConfig, factoryRunnerID, workflowContext, logger, direct, s.interpolation,
 			s.executionPolicy, clock, processEnvironment, currentWorkingDirectory, s.factoryDocs, s.worktreePreparer, s.workstationFiles,
+			s.resolveRunner,
 		), nil
 	case interfaces.WorkstationTypeLogical:
 		return workstationResult(
 			runtimeConfig, factoryRunnerID, workflowContext, logger, nil,
 			s.interpolation, s.executionPolicy, clock, processEnvironment, currentWorkingDirectory, s.factoryDocs, s.worktreePreparer, s.workstationFiles,
+			s.resolveRunner,
 		), nil
 	case interfaces.WorkerTypeScript:
 		if s == nil || s.scriptFactory == nil {
@@ -199,6 +213,7 @@ func (s *Service) Build(
 		return workstationResult(
 			runtimeConfig, factoryRunnerID, workflowContext, logger, direct, s.interpolation,
 			s.executionPolicy, clock, processEnvironment, currentWorkingDirectory, s.factoryDocs, s.worktreePreparer, s.workstationFiles,
+			s.resolveRunner,
 		), nil
 	default:
 		return Result{}, nil
@@ -233,6 +248,7 @@ func (s *Service) BuildLogical(
 		s.factoryDocs,
 		s.worktreePreparer,
 		s.workstationFiles,
+		s.resolveRunner,
 	)
 }
 
@@ -305,6 +321,7 @@ func workstationResult(
 	factoryDocs workers.FactoryDocsLoader,
 	worktreePreparer workers.FactoryWorktreePreparer,
 	workstationFiles platformfilesystem.ReadFileInspector,
+	resolveRunner workers.RunnerSelectionResolver,
 ) Result {
 	renderer := &workerprompting.DefaultPromptRenderer{FactoryDocs: factoryDocs}
 	return Result{
@@ -314,7 +331,8 @@ func workstationResult(
 			ProcessEnvironment:      processEnvironment,
 			CurrentWorkingDirectory: currentWorkingDirectory,
 			RuntimeConfig:           runtimeConfig, DefaultRunnerID: factoryRunnerID,
-			WorkflowContext: workflowContext, Executor: direct,
+			ResolveRunnerSelection: resolveRunner,
+			WorkflowContext:        workflowContext, Executor: direct,
 			Interpolation:   interpolation,
 			ExecutionPolicy: executionPolicy,
 			Renderer:        renderer, Logger: logger,

--- a/pkg/services/workers/construction/service_test.go
+++ b/pkg/services/workers/construction/service_test.go
@@ -104,6 +104,41 @@ func TestServiceBuildRequiresRuntimeConfig(t *testing.T) {
 	}
 }
 
+func TestServiceWithRunnerSelectionReturnsConfiguredCopy(t *testing.T) {
+	t.Parallel()
+
+	if configured := (*Service)(nil).WithRunnerSelection(nil); configured != nil {
+		t.Fatalf("nil Service.WithRunnerSelection() = %#v, want nil", configured)
+	}
+
+	service := New(
+		nil, nil, nil, nil, testFactoryDocs, nil,
+		workeragentrun.NewLibraryHarnessAdapter(platformfilesystem.Local{}),
+		testRetryRandom,
+		platformfilesystem.Local{},
+	)
+	resolver := func(workstation, factory, worker string) (workers.ResolvedRunnerSelection, error) {
+		return workers.ResolvedRunnerSelection{
+			RunnerID: workstation + factory + worker,
+			Source:   workers.RunnerSelectionSourceWorkstation,
+		}, nil
+	}
+	configured := service.WithRunnerSelection(resolver)
+	if configured == service {
+		t.Fatal("WithRunnerSelection() mutated the original service")
+	}
+	if service.resolveRunner != nil {
+		t.Fatal("WithRunnerSelection() configured the original service")
+	}
+	selection, err := configured.resolveRunner("workstation", "factory", "worker")
+	if err != nil {
+		t.Fatalf("configured resolver error = %v", err)
+	}
+	if selection.RunnerID != "workstationfactoryworker" {
+		t.Fatalf("configured resolver selection = %#v", selection)
+	}
+}
+
 type providerStub struct{}
 
 func testClock() time.Time { return time.Date(2026, time.July, 20, 12, 0, 0, 0, time.UTC) }

--- a/pkg/services/workers/execution_requests.go
+++ b/pkg/services/workers/execution_requests.go
@@ -76,6 +76,14 @@ type ResolvedRunnerSelection struct {
 	Source   RunnerSelectionSource `json:"source,omitempty"`
 }
 
+// RunnerSelectionResolver resolves configured provider precedence into the
+// stable native runner contract.
+type RunnerSelectionResolver func(
+	workstationRunner string,
+	factoryRunner string,
+	workerModelProvider string,
+) (ResolvedRunnerSelection, error)
+
 type ResolvedModelOperationBinding struct {
 	Slot    string                      `json:"slot"`
 	Source  ModelOperationBindingSource `json:"source"`

--- a/pkg/services/workers/executor/agent.go
+++ b/pkg/services/workers/executor/agent.go
@@ -373,7 +373,9 @@ func inferenceRequestForExecutionRequest(request workerexecution.WorkstationExec
 }
 
 func modelProviderForExecution(workerModelProvider string, selection workerexecution.ResolvedRunnerSelection) string {
-	if selection.Source == workerexecution.RunnerSelectionSourceWorkstation || selection.Source == workerexecution.RunnerSelectionSourceFactory {
+	if selection.Source == workerexecution.RunnerSelectionSourceWorkstation ||
+		selection.Source == workerexecution.RunnerSelectionSourceFactory ||
+		selection.Source == workerexecution.RunnerSelectionSourceLegacyProvider {
 		if provider := modelProviderForRunnerID(selection.RunnerID); provider != "" {
 			return provider
 		}
@@ -388,6 +390,8 @@ func modelProviderForRunnerID(runnerID string) string {
 	switch workerrunner.NormalizeRunnerID(runnerID) {
 	case workerexecution.RunnerIDCodex:
 		return string(modelprovider.ProviderCodex)
+	case string(modelprovider.ProviderClaude):
+		return string(modelprovider.ProviderClaude)
 	case workerexecution.RunnerIDGemini:
 		return string(modelprovider.ProviderGemini)
 	case workerexecution.RunnerIDKiro:

--- a/pkg/services/workers/executor/workstation_executor.go
+++ b/pkg/services/workers/executor/workstation_executor.go
@@ -55,6 +55,7 @@ type WorkstationExecutor struct {
 	CurrentWorkingDirectory func() (string, error)
 	RuntimeConfig           interfaces.RuntimeConfigLookup
 	DefaultRunnerID         string
+	ResolveRunnerSelection  workerexecution.RunnerSelectionResolver
 	WorkflowContext         *workerexecution.Context
 	Executor                WorkstationRequestExecutor
 	Interpolation           factorydefinitions.InvocationInterpolationService
@@ -392,7 +393,16 @@ func (we *WorkstationExecutor) applyCodexFactoryWorktreePreparation(
 	requestContext *resolvedWorkstationExecutionContext,
 	start time.Time,
 ) *workerexecution.WorkResult {
-	selection := workerrunner.ResolveRunnerSelection(workstationDef.Runner, we.DefaultRunnerID, workerDef.ModelProvider)
+	selection, err := we.resolveRunnerSelection(workstationDef.Runner, workerDef.ModelProvider)
+	if err != nil {
+		failed := worktree.FailedWorkResultFromPreparation(
+			dispatch.DispatchID,
+			dispatch.TransitionID,
+			we.Now().Sub(start),
+			err,
+		)
+		return &failed
+	}
 	executionProvider := modelProviderForExecution(workerDef.ModelProvider, selection)
 	if !worktree.ShouldPrepareFactoryWorktreeForCodex(executionProvider, workstationDef.WorkingDirectory, requestContext.Worktree) {
 		return nil
@@ -509,7 +519,17 @@ func (we *WorkstationExecutor) buildWorkstationExecutionRequest(dispatch work.Wo
 		return workerexecution.WorkstationExecutionRequest{}, &failed
 	}
 
-	selection := workerrunner.ResolveRunnerSelection(workstationDef.Runner, we.DefaultRunnerID, workerDef.ModelProvider)
+	selection, err := we.resolveRunnerSelection(workstationDef.Runner, workerDef.ModelProvider)
+	if err != nil {
+		failed := workerexecution.WorkResult{
+			DispatchID:   dispatch.DispatchID,
+			TransitionID: dispatch.TransitionID,
+			Outcome:      workerexecution.OutcomeFailed,
+			Error:        "provider selection failed: " + err.Error(),
+			Metrics:      workerexecution.WorkMetrics{Duration: we.Now().Sub(start)},
+		}
+		return workerexecution.WorkstationExecutionRequest{}, &failed
+	}
 	return workerexecution.WorkstationExecutionRequest{
 		Dispatch:                 work.CloneWorkDispatch(dispatch),
 		WorkerType:               workerName,
@@ -532,6 +552,24 @@ func (we *WorkstationExecutor) buildWorkstationExecutionRequest(dispatch work.Wo
 		WorkingDirectory:         requestContext.WorkingDirectory,
 		WorkingDirectoryAuthored: workstationDef.WorkingDirectory != "",
 	}, nil
+}
+
+func (we *WorkstationExecutor) resolveRunnerSelection(
+	workstationRunner string,
+	workerModelProvider string,
+) (workerexecution.ResolvedRunnerSelection, error) {
+	if we.ResolveRunnerSelection != nil {
+		return we.ResolveRunnerSelection(
+			workstationRunner,
+			we.DefaultRunnerID,
+			workerModelProvider,
+		)
+	}
+	return workerrunner.ResolveRunnerSelection(
+		workstationRunner,
+		we.DefaultRunnerID,
+		workerModelProvider,
+	), nil
 }
 
 func processEnvironment(read func() []string) []string {

--- a/pkg/services/workers/executor/workstation_executor_test.go
+++ b/pkg/services/workers/executor/workstation_executor_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/work"
+	providerregistry "github.com/portpowered/infinite-you/pkg/services/workers/provider/registry"
 )
 
 func TestWorkstationExecutorUsesInjectedProviderSelectionAuthority(t *testing.T) {
@@ -55,6 +56,88 @@ func TestWorkstationExecutorUsesInjectedProviderSelectionAuthority(t *testing.T)
 			gotFactory,
 			gotWorker,
 		)
+	}
+}
+
+func TestWorkstationExecutorCarriesCanonicalLegacyProviderThroughInference(t *testing.T) {
+	t.Parallel()
+
+	registrations, err := providerregistry.BuiltInRegistrations()
+	if err != nil {
+		t.Fatalf("BuiltInRegistrations() error = %v", err)
+	}
+	providers, err := providerregistry.New(registrations...)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	for _, tc := range []struct {
+		alias     string
+		canonical string
+	}{
+		{alias: "openai", canonical: "codex"},
+		{alias: "anthropic", canonical: "claude"},
+	} {
+		t.Run(tc.alias, func(t *testing.T) {
+			t.Parallel()
+
+			runtimeConfig := staticRuntimeConfig{
+				Workers: map[string]*interfaces.FactoryWorkerConfig{
+					"worker-a": {
+						Type:          interfaces.WorkerTypeModel,
+						ModelProvider: tc.alias,
+					},
+				},
+				Workstations: map[string]*interfaces.FactoryWorkstationConfig{
+					"standard": {
+						Type:           interfaces.WorkstationTypeModel,
+						PromptTemplate: "run",
+					},
+				},
+			}
+			provider := &agentMockProvider{
+				response: workerexecution.InferenceResponse{Content: "done"},
+			}
+			agent := NewAgentExecutor(
+				runtimeConfig,
+				provider,
+				nil,
+				time.Now,
+				deterministicRetryRandom,
+			)
+			workstation := newTestWorkstationExecutor(runtimeConfig, agent)
+			workstation.ResolveRunnerSelection = providers.ResolveRunnerSelection
+
+			result, executeErr := workstation.Execute(context.Background(), work.WorkDispatch{
+				DispatchID:      "dispatch-" + tc.alias,
+				TransitionID:    "transition-" + tc.alias,
+				WorkerType:      "worker-a",
+				WorkstationName: "standard",
+			})
+			if executeErr != nil {
+				t.Fatalf("Execute() error = %v", executeErr)
+			}
+			if result.Outcome == workerexecution.OutcomeFailed {
+				t.Fatalf("Execute() result = %#v", result)
+			}
+			if provider.callCount != 1 {
+				t.Fatalf("provider calls = %d, want 1", provider.callCount)
+			}
+			if provider.lastReq.ModelProvider != tc.canonical {
+				t.Fatalf(
+					"final provider request ModelProvider = %q, want canonical %q",
+					provider.lastReq.ModelProvider,
+					tc.canonical,
+				)
+			}
+			if provider.lastReq.RunnerID != tc.canonical {
+				t.Fatalf(
+					"final provider request RunnerID = %q, want canonical %q",
+					provider.lastReq.RunnerID,
+					tc.canonical,
+				)
+			}
+		})
 	}
 }
 

--- a/pkg/services/workers/executor/workstation_executor_test.go
+++ b/pkg/services/workers/executor/workstation_executor_test.go
@@ -23,6 +23,41 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/work"
 )
 
+func TestWorkstationExecutorUsesInjectedProviderSelectionAuthority(t *testing.T) {
+	t.Parallel()
+	var gotWorkstation, gotFactory, gotWorker string
+	executor := &WorkstationExecutor{
+		DefaultRunnerID: "factory-provider",
+		ResolveRunnerSelection: func(
+			workstation string,
+			factory string,
+			worker string,
+		) (workerexecution.ResolvedRunnerSelection, error) {
+			gotWorkstation, gotFactory, gotWorker = workstation, factory, worker
+			return workerexecution.ResolvedRunnerSelection{
+				RunnerID: workerexecution.RunnerIDCursorCLI,
+				Source:   workerexecution.RunnerSelectionSourceWorkstation,
+			}, nil
+		},
+	}
+
+	selection, err := executor.resolveRunnerSelection("agent", "codex")
+	if err != nil {
+		t.Fatalf("resolveRunnerSelection() error = %v", err)
+	}
+	if selection.RunnerID != workerexecution.RunnerIDCursorCLI {
+		t.Fatalf("selection = %#v", selection)
+	}
+	if gotWorkstation != "agent" || gotFactory != "factory-provider" || gotWorker != "codex" {
+		t.Fatalf(
+			"resolver inputs = (%q, %q, %q)",
+			gotWorkstation,
+			gotFactory,
+			gotWorker,
+		)
+	}
+}
+
 type wsMockExecutor struct {
 	dispatch workerexecution.WorkstationExecutionRequest
 	called   bool

--- a/pkg/services/workers/provider/inferencecontract/registration.go
+++ b/pkg/services/workers/provider/inferencecontract/registration.go
@@ -89,3 +89,7 @@ type Registration struct {
 	Manifest    Manifest
 	Integration Integration
 }
+
+// ProviderRegistrations is the additive pure configuration collection used to
+// contribute external registrations during process composition.
+type ProviderRegistrations []Registration

--- a/pkg/services/workers/provider/inferencecontract/registration.go
+++ b/pkg/services/workers/provider/inferencecontract/registration.go
@@ -1,0 +1,91 @@
+package inferencecontract
+
+// ImplementationAvailability describes how a manifest's implementation is
+// supplied. It is publication metadata, not live readiness.
+type ImplementationAvailability string
+
+const (
+	ImplementationBundled            ImplementationAvailability = "bundled"
+	ImplementationExternallySupplied ImplementationAvailability = "externally-supplied"
+	ImplementationCatalogOnly        ImplementationAvailability = "catalog-only"
+)
+
+// TechnicalSupportLevel is the catalog's maintainer-verified support posture.
+type TechnicalSupportLevel string
+
+const (
+	SupportProduction   TechnicalSupportLevel = "production"
+	SupportExperimental TechnicalSupportLevel = "experimental"
+	SupportNotSupported TechnicalSupportLevel = "not-supported"
+)
+
+type LocalizedValue struct {
+	ID      *string            `json:"id,omitempty"`
+	Locales *[]string          `json:"locales,omitempty"`
+	Type    string             `json:"type"`
+	Value   string             `json:"value"`
+	Values  *map[string]string `json:"values,omitempty"`
+}
+
+type Deprecation struct {
+	DeprecatedSince       string         `json:"deprecatedSince"`
+	Reason                LocalizedValue `json:"reason"`
+	ReplacementProviderID *string        `json:"replacementProviderId,omitempty"`
+}
+
+type DiscoveryPrerequisites struct {
+	ConfigurationKeys []string `json:"configurationKeys"`
+	EndpointKinds     []string `json:"endpointKinds"`
+	ExecutableNames   []string `json:"executableNames"`
+}
+
+type DocumentationLink struct {
+	Kind string `json:"kind"`
+	URL  string `json:"url"`
+}
+
+type ExecutionCapabilities struct {
+	ImageInput       bool `json:"imageInput"`
+	PromptSubmission bool `json:"promptSubmission"`
+	SessionResume    bool `json:"sessionResume"`
+	StructuredOutput bool `json:"structuredOutput"`
+	ToolExecution    bool `json:"toolExecution"`
+	WorkingDirectory bool `json:"workingDirectory"`
+	Worktree         bool `json:"worktree"`
+}
+
+type ResponseFidelityCapabilities struct {
+	FileChanges        bool `json:"fileChanges"`
+	MessageDeltas      bool `json:"messageDeltas"`
+	MessageSnapshots   bool `json:"messageSnapshots"`
+	NativeStreaming    bool `json:"nativeStreaming"`
+	Plans              bool `json:"plans"`
+	ProviderReconnect  bool `json:"providerReconnect"`
+	ReasoningSummaries bool `json:"reasoningSummaries"`
+	StableItemIDs      bool `json:"stableItemIds"`
+	ToolLifecycle      bool `json:"toolLifecycle"`
+	ToolOutputDeltas   bool `json:"toolOutputDeltas"`
+	Usage              bool `json:"usage"`
+}
+
+// Manifest is the typed public provider-manifest registration contract.
+type Manifest struct {
+	Aliases                             []string                     `json:"aliases"`
+	Deprecation                         *Deprecation                 `json:"deprecation,omitempty"`
+	Description                         LocalizedValue               `json:"description"`
+	Discovery                           DiscoveryPrerequisites       `json:"discovery"`
+	DisplayName                         LocalizedValue               `json:"displayName"`
+	Documentation                       []DocumentationLink          `json:"documentation"`
+	ID                                  string                       `json:"id"`
+	ImplementationAvailability          ImplementationAvailability   `json:"implementationAvailability"`
+	MaximumExecutionCapabilities        ExecutionCapabilities        `json:"maximumExecutionCapabilities"`
+	MaximumResponseFidelityCapabilities ResponseFidelityCapabilities `json:"maximumResponseFidelityCapabilities"`
+	TechnicalSupportLevel               TechnicalSupportLevel        `json:"technicalSupportLevel"`
+}
+
+// Registration contributes one external manifest-to-Integration binding at a
+// process edge. Built-in catalog bindings remain registry-owned.
+type Registration struct {
+	Manifest    Manifest
+	Integration Integration
+}

--- a/pkg/services/workers/provider/recording_provider_test.go
+++ b/pkg/services/workers/provider/recording_provider_test.go
@@ -724,7 +724,8 @@ func recordingProviderStringMapValue(values *factoryapi.StringMap) map[string]st
 }
 
 func TestInferenceProgressPublishingCommandRunner_NormalizesCodexStructuredEvents(t *testing.T) {
-	t.Parallel()
+	// Do not run in parallel: Linux CI can return "text file busy" when executing
+	// the freshly written shell script under heavy parallel package load.
 	scriptPath := writeProviderOutputFixture(t, filepath.Join(t.TempDir(), "codex"), []byte(
 		"{\"event\":\"session.created\",\"session_id\":\"sess-codex-1\"}\n"+
 			"{\"type\":\"response.output_text.delta\",\"delta\":\"hello from delta\"}\n"+
@@ -772,7 +773,8 @@ func TestInferenceProgressPublishingCommandRunner_NormalizesCodexStructuredEvent
 }
 
 func TestInferenceProgressPublishingCommandRunner_MapsUnknownAndMalformedCodexEventsToBoundedDiagnostics(t *testing.T) {
-	t.Parallel()
+	// Do not run in parallel: Linux CI can return "text file busy" when executing
+	// the freshly written shell script under heavy parallel package load.
 	scriptPath := writeProviderOutputFixture(t, filepath.Join(t.TempDir(), "codex"), []byte(
 		"{\"event\":\"session.created\",\"session_id\":\"sess-codex-2\"}\n"+
 			"{\"type\":\"response.mystery\",\"message\":\"secret-token-123 should never be retained\"}\n"+
@@ -819,7 +821,6 @@ func TestInferenceProgressPublishingCommandRunner_MapsUnknownAndMalformedCodexEv
 }
 
 func TestInferenceProgressPublishingCommandRunner_MapsFailureCancelAndTruncation(t *testing.T) {
-	t.Parallel()
 	// Do not run in parallel: Linux CI can return "text file busy" when executing
 	// the freshly written shell script under heavy parallel package load.
 

--- a/pkg/services/workers/provider/registry/builtins.go
+++ b/pkg/services/workers/provider/registry/builtins.go
@@ -1,0 +1,81 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	modelproviders "github.com/portpowered/infinite-you/packages/model-providers"
+	inference "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+)
+
+const nativeRuntimePrerequisite = "provider-native-runtime"
+
+// BuiltInRegistrations returns detached registrations for every selectable
+// bundled manifest. The compatibility integrations describe the accepted
+// built-ins without moving provider-native execution into the neutral
+// Integration conductor.
+func BuiltInRegistrations() ([]Registration, error) {
+	var catalog catalogDocument
+	if err := json.Unmarshal(modelproviders.CatalogJSON(), &catalog); err != nil {
+		return nil, fmt.Errorf("parse embedded provider catalog for built-in registrations: %w", err)
+	}
+	registrations := make([]Registration, 0, len(catalog.Providers))
+	for _, manifest := range catalog.Providers {
+		if !requiresBundledImplementation(manifestCandidate{manifest: manifest, bundled: true}) {
+			continue
+		}
+		integration := nativeRuntimeIntegration{
+			identity: inference.Identity(normalize(manifest.ID)),
+			maximum:  manifestCapabilities(manifest),
+		}
+		registrations = append(registrations, CatalogRegistration(integration.identity, integration))
+	}
+	return registrations, nil
+}
+
+// nativeRuntimeIntegration preserves the accepted Integration shape while the
+// built-in invocation conductor remains on the legacy Provider runtime.
+type nativeRuntimeIntegration struct {
+	identity inference.Identity
+	maximum  inference.CapabilitySet
+}
+
+func (i nativeRuntimeIntegration) Identity() inference.Identity {
+	return i.identity
+}
+
+func (i nativeRuntimeIntegration) MaximumCapabilities() inference.CapabilitySet {
+	return inference.NewCapabilitySet(i.maximum.Values()...)
+}
+
+func (i nativeRuntimeIntegration) Discover(context.Context) (inference.Discovery, error) {
+	return inference.NewDiscovery(
+		inference.ReadinessUnavailable,
+		inference.NewPrerequisite(
+			inference.PrerequisiteDependency,
+			nativeRuntimePrerequisite,
+			inference.PrerequisiteMissing,
+			"Use the provider-native runtime until neutral invocation routing is enabled.",
+		),
+	), nil
+}
+
+func (i nativeRuntimeIntegration) Capabilities(
+	context.Context,
+	inference.InvocationRequest,
+) (inference.CapabilitySet, error) {
+	return i.MaximumCapabilities(), nil
+}
+
+func (i nativeRuntimeIntegration) Invoke(
+	ctx context.Context,
+	_ inference.InvocationRequest,
+	writer inference.ResponseWriter,
+) error {
+	failure := inference.NewFailure(inference.FailureInput{
+		Kind:    inference.FailureDependency,
+		Message: "Neutral invocation routing is not enabled for this built-in provider.",
+	})
+	return writer.Close(ctx, inference.FailedCompletion(failure))
+}

--- a/pkg/services/workers/provider/registry/manifest.go
+++ b/pkg/services/workers/provider/registry/manifest.go
@@ -1,0 +1,95 @@
+package registry
+
+// ImplementationAvailability describes how a manifest's implementation is
+// supplied. It is publication metadata, not live readiness.
+type ImplementationAvailability string
+
+const (
+	ImplementationBundled            ImplementationAvailability = "bundled"
+	ImplementationExternallySupplied ImplementationAvailability = "externally-supplied"
+	ImplementationCatalogOnly        ImplementationAvailability = "catalog-only"
+)
+
+// TechnicalSupportLevel is the catalog's maintainer-verified support posture.
+type TechnicalSupportLevel string
+
+const (
+	SupportProduction   TechnicalSupportLevel = "production"
+	SupportExperimental TechnicalSupportLevel = "experimental"
+	SupportNotSupported TechnicalSupportLevel = "not-supported"
+)
+
+// LocalizedValue is the typed catalog representation of customer-facing copy.
+type LocalizedValue struct {
+	ID      *string            `json:"id,omitempty"`
+	Locales *[]string          `json:"locales,omitempty"`
+	Type    string             `json:"type"`
+	Value   string             `json:"value"`
+	Values  *map[string]string `json:"values,omitempty"`
+}
+
+// Deprecation contains coherent lifecycle metadata for a deprecated provider.
+type Deprecation struct {
+	DeprecatedSince       string         `json:"deprecatedSince"`
+	Reason                LocalizedValue `json:"reason"`
+	ReplacementProviderID *string        `json:"replacementProviderId,omitempty"`
+}
+
+// DiscoveryPrerequisites contains static, credential-free discovery facts.
+type DiscoveryPrerequisites struct {
+	ConfigurationKeys []string `json:"configurationKeys"`
+	EndpointKinds     []string `json:"endpointKinds"`
+	ExecutableNames   []string `json:"executableNames"`
+}
+
+// DocumentationLink identifies one stable public provider resource.
+type DocumentationLink struct {
+	Kind string `json:"kind"`
+	URL  string `json:"url"`
+}
+
+// ExecutionCapabilities is the manifest's maximum execution feature set.
+type ExecutionCapabilities struct {
+	ImageInput       bool `json:"imageInput"`
+	PromptSubmission bool `json:"promptSubmission"`
+	SessionResume    bool `json:"sessionResume"`
+	StructuredOutput bool `json:"structuredOutput"`
+	ToolExecution    bool `json:"toolExecution"`
+	WorkingDirectory bool `json:"workingDirectory"`
+	Worktree         bool `json:"worktree"`
+}
+
+// ResponseFidelityCapabilities is the manifest's maximum response fidelity.
+type ResponseFidelityCapabilities struct {
+	FileChanges        bool `json:"fileChanges"`
+	MessageDeltas      bool `json:"messageDeltas"`
+	MessageSnapshots   bool `json:"messageSnapshots"`
+	NativeStreaming    bool `json:"nativeStreaming"`
+	Plans              bool `json:"plans"`
+	ProviderReconnect  bool `json:"providerReconnect"`
+	ReasoningSummaries bool `json:"reasoningSummaries"`
+	StableItemIDs      bool `json:"stableItemIds"`
+	ToolLifecycle      bool `json:"toolLifecycle"`
+	ToolOutputDeltas   bool `json:"toolOutputDeltas"`
+	Usage              bool `json:"usage"`
+}
+
+// Manifest is the registry-owned typed representation of the published
+// Provider Manifest contract.
+type Manifest struct {
+	Aliases                             []string                     `json:"aliases"`
+	Deprecation                         *Deprecation                 `json:"deprecation,omitempty"`
+	Description                         LocalizedValue               `json:"description"`
+	Discovery                           DiscoveryPrerequisites       `json:"discovery"`
+	DisplayName                         LocalizedValue               `json:"displayName"`
+	Documentation                       []DocumentationLink          `json:"documentation"`
+	ID                                  string                       `json:"id"`
+	ImplementationAvailability          ImplementationAvailability   `json:"implementationAvailability"`
+	MaximumExecutionCapabilities        ExecutionCapabilities        `json:"maximumExecutionCapabilities"`
+	MaximumResponseFidelityCapabilities ResponseFidelityCapabilities `json:"maximumResponseFidelityCapabilities"`
+	TechnicalSupportLevel               TechnicalSupportLevel        `json:"technicalSupportLevel"`
+}
+
+type catalogDocument struct {
+	Providers []Manifest `json:"providers"`
+}

--- a/pkg/services/workers/provider/registry/manifest.go
+++ b/pkg/services/workers/provider/registry/manifest.go
@@ -1,94 +1,47 @@
 package registry
 
+import inference "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+
 // ImplementationAvailability describes how a manifest's implementation is
 // supplied. It is publication metadata, not live readiness.
-type ImplementationAvailability string
+type ImplementationAvailability = inference.ImplementationAvailability
 
 const (
-	ImplementationBundled            ImplementationAvailability = "bundled"
-	ImplementationExternallySupplied ImplementationAvailability = "externally-supplied"
-	ImplementationCatalogOnly        ImplementationAvailability = "catalog-only"
+	ImplementationBundled            = inference.ImplementationBundled
+	ImplementationExternallySupplied = inference.ImplementationExternallySupplied
+	ImplementationCatalogOnly        = inference.ImplementationCatalogOnly
 )
 
 // TechnicalSupportLevel is the catalog's maintainer-verified support posture.
-type TechnicalSupportLevel string
+type TechnicalSupportLevel = inference.TechnicalSupportLevel
 
 const (
-	SupportProduction   TechnicalSupportLevel = "production"
-	SupportExperimental TechnicalSupportLevel = "experimental"
-	SupportNotSupported TechnicalSupportLevel = "not-supported"
+	SupportProduction   = inference.SupportProduction
+	SupportExperimental = inference.SupportExperimental
+	SupportNotSupported = inference.SupportNotSupported
 )
 
 // LocalizedValue is the typed catalog representation of customer-facing copy.
-type LocalizedValue struct {
-	ID      *string            `json:"id,omitempty"`
-	Locales *[]string          `json:"locales,omitempty"`
-	Type    string             `json:"type"`
-	Value   string             `json:"value"`
-	Values  *map[string]string `json:"values,omitempty"`
-}
+type LocalizedValue = inference.LocalizedValue
 
 // Deprecation contains coherent lifecycle metadata for a deprecated provider.
-type Deprecation struct {
-	DeprecatedSince       string         `json:"deprecatedSince"`
-	Reason                LocalizedValue `json:"reason"`
-	ReplacementProviderID *string        `json:"replacementProviderId,omitempty"`
-}
+type Deprecation = inference.Deprecation
 
 // DiscoveryPrerequisites contains static, credential-free discovery facts.
-type DiscoveryPrerequisites struct {
-	ConfigurationKeys []string `json:"configurationKeys"`
-	EndpointKinds     []string `json:"endpointKinds"`
-	ExecutableNames   []string `json:"executableNames"`
-}
+type DiscoveryPrerequisites = inference.DiscoveryPrerequisites
 
 // DocumentationLink identifies one stable public provider resource.
-type DocumentationLink struct {
-	Kind string `json:"kind"`
-	URL  string `json:"url"`
-}
+type DocumentationLink = inference.DocumentationLink
 
 // ExecutionCapabilities is the manifest's maximum execution feature set.
-type ExecutionCapabilities struct {
-	ImageInput       bool `json:"imageInput"`
-	PromptSubmission bool `json:"promptSubmission"`
-	SessionResume    bool `json:"sessionResume"`
-	StructuredOutput bool `json:"structuredOutput"`
-	ToolExecution    bool `json:"toolExecution"`
-	WorkingDirectory bool `json:"workingDirectory"`
-	Worktree         bool `json:"worktree"`
-}
+type ExecutionCapabilities = inference.ExecutionCapabilities
 
 // ResponseFidelityCapabilities is the manifest's maximum response fidelity.
-type ResponseFidelityCapabilities struct {
-	FileChanges        bool `json:"fileChanges"`
-	MessageDeltas      bool `json:"messageDeltas"`
-	MessageSnapshots   bool `json:"messageSnapshots"`
-	NativeStreaming    bool `json:"nativeStreaming"`
-	Plans              bool `json:"plans"`
-	ProviderReconnect  bool `json:"providerReconnect"`
-	ReasoningSummaries bool `json:"reasoningSummaries"`
-	StableItemIDs      bool `json:"stableItemIds"`
-	ToolLifecycle      bool `json:"toolLifecycle"`
-	ToolOutputDeltas   bool `json:"toolOutputDeltas"`
-	Usage              bool `json:"usage"`
-}
+type ResponseFidelityCapabilities = inference.ResponseFidelityCapabilities
 
-// Manifest is the registry-owned typed representation of the published
-// Provider Manifest contract.
-type Manifest struct {
-	Aliases                             []string                     `json:"aliases"`
-	Deprecation                         *Deprecation                 `json:"deprecation,omitempty"`
-	Description                         LocalizedValue               `json:"description"`
-	Discovery                           DiscoveryPrerequisites       `json:"discovery"`
-	DisplayName                         LocalizedValue               `json:"displayName"`
-	Documentation                       []DocumentationLink          `json:"documentation"`
-	ID                                  string                       `json:"id"`
-	ImplementationAvailability          ImplementationAvailability   `json:"implementationAvailability"`
-	MaximumExecutionCapabilities        ExecutionCapabilities        `json:"maximumExecutionCapabilities"`
-	MaximumResponseFidelityCapabilities ResponseFidelityCapabilities `json:"maximumResponseFidelityCapabilities"`
-	TechnicalSupportLevel               TechnicalSupportLevel        `json:"technicalSupportLevel"`
-}
+// Manifest is the registry-facing alias of the public typed Provider Manifest
+// registration contract.
+type Manifest = inference.Manifest
 
 type catalogDocument struct {
 	Providers []Manifest `json:"providers"`

--- a/pkg/services/workers/provider/registry/operations.go
+++ b/pkg/services/workers/provider/registry/operations.go
@@ -112,6 +112,16 @@ func (r *Registry) Lookup(identity string) (Entry, error) {
 	return newEntry(r.manifests[canonical], true), nil
 }
 
+// CanonicalIdentity resolves a selectable canonical ID or alias to its
+// canonical string identity without exposing registry-owned values.
+func (r *Registry) CanonicalIdentity(identity string) (string, error) {
+	entry, err := r.Lookup(identity)
+	if err != nil {
+		return "", err
+	}
+	return string(entry.Identity()), nil
+}
+
 // MaximumCapabilities resolves a selectable provider without calling it and
 // returns the manifest-authoritative maximum capability set.
 func (r *Registry) MaximumCapabilities(identity string) (inference.CapabilitySet, error) {

--- a/pkg/services/workers/provider/registry/operations.go
+++ b/pkg/services/workers/provider/registry/operations.go
@@ -1,0 +1,319 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	inference "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+)
+
+// Availability identifies why a catalog entry is or is not selectable.
+// Support posture is static catalog metadata and does not imply live readiness.
+type Availability string
+
+const (
+	AvailabilityCatalogOnly             Availability = "catalog-only"
+	AvailabilityNotSupported            Availability = "not-supported"
+	AvailabilitySupportedButUnavailable Availability = "supported-but-unavailable"
+	AvailabilitySelectable              Availability = "selectable"
+)
+
+// Entry is an immutable catalog projection. Mutable manifest values are
+// detached when the entry is created and whenever they are returned.
+type Entry struct {
+	manifest   Manifest
+	selectable bool
+}
+
+func newEntry(manifest Manifest, selectable bool) Entry {
+	return Entry{manifest: canonicalManifest(manifest), selectable: selectable}
+}
+
+// Identity returns the canonical manifest identity.
+func (e Entry) Identity() inference.Identity {
+	return inference.Identity(e.manifest.ID)
+}
+
+// Manifest returns a detached manifest projection.
+func (e Entry) Manifest() Manifest {
+	return cloneManifest(e.manifest)
+}
+
+// Aliases returns detached aliases in deterministic normalized order.
+func (e Entry) Aliases() []string {
+	aliases := make([]string, 0, len(e.manifest.Aliases))
+	for _, alias := range e.manifest.Aliases {
+		aliases = append(aliases, normalize(alias))
+	}
+	return sortedUnique(aliases)
+}
+
+// DiscoveryPrerequisites returns detached static discovery metadata.
+func (e Entry) DiscoveryPrerequisites() DiscoveryPrerequisites {
+	return cloneDiscoveryPrerequisites(e.manifest.Discovery)
+}
+
+// MaximumCapabilities returns the manifest-authoritative maximum.
+func (e Entry) MaximumCapabilities() inference.CapabilitySet {
+	return manifestCapabilities(e.manifest)
+}
+
+// Selectable reports whether an Integration is bound to the entry.
+func (e Entry) Selectable() bool {
+	return e.selectable
+}
+
+// ProviderDiagnostic is an immutable static provider-status projection.
+type ProviderDiagnostic struct {
+	entry        Entry
+	availability Availability
+}
+
+func (d ProviderDiagnostic) Entry() Entry {
+	return newEntry(d.entry.manifest, d.entry.selectable)
+}
+
+func (d ProviderDiagnostic) Availability() Availability {
+	return d.availability
+}
+
+// Entries returns every catalog entry in canonical identity order.
+func (r *Registry) Entries() []Entry {
+	identities := sortedManifestIdentities(r.manifests)
+	entries := make([]Entry, 0, len(identities))
+	for _, identity := range identities {
+		_, selectable := r.integrations[identity]
+		entries = append(entries, newEntry(r.manifests[identity], selectable))
+	}
+	return entries
+}
+
+// SupportedProviders returns deterministic diagnostics for all catalog entries.
+func (r *Registry) SupportedProviders() []ProviderDiagnostic {
+	entries := r.Entries()
+	diagnostics := make([]ProviderDiagnostic, 0, len(entries))
+	for _, entry := range entries {
+		diagnostics = append(diagnostics, ProviderDiagnostic{
+			entry:        entry,
+			availability: availabilityFor(entry.manifest, entry.selectable),
+		})
+	}
+	return diagnostics
+}
+
+// Lookup resolves a canonical identity or alias to a selectable entry.
+func (r *Registry) Lookup(identity string) (Entry, error) {
+	canonical, err := r.resolveSelectable(identity)
+	if err != nil {
+		return Entry{}, err
+	}
+	return newEntry(r.manifests[canonical], true), nil
+}
+
+// MaximumCapabilities resolves a selectable provider without calling it and
+// returns the manifest-authoritative maximum capability set.
+func (r *Registry) MaximumCapabilities(identity string) (inference.CapabilitySet, error) {
+	entry, err := r.Lookup(identity)
+	if err != nil {
+		return inference.CapabilitySet{}, err
+	}
+	return entry.MaximumCapabilities(), nil
+}
+
+// Capabilities explicitly delegates request-sensitive capability negotiation,
+// then rejects provider results that violate the manifest or request.
+func (r *Registry) Capabilities(
+	ctx context.Context,
+	identity string,
+	request inference.InvocationRequest,
+) (inference.CapabilitySet, error) {
+	canonical, err := r.resolveSelectable(identity)
+	if err != nil {
+		return inference.CapabilitySet{}, err
+	}
+	maximum := manifestCapabilities(r.manifests[canonical])
+	if err := inference.ValidateNegotiatedCapabilities(maximum, request.RequiredCapabilities()); err != nil {
+		return inference.CapabilitySet{}, integrationContractError(canonical, "request capabilities", err)
+	}
+	negotiated, err := r.integrations[canonical].Capabilities(ctx, request)
+	if err != nil {
+		return inference.CapabilitySet{}, integrationOperationError(canonical, "capability negotiation", err)
+	}
+	if err := inference.ValidateNegotiatedCapabilities(maximum, negotiated); err != nil {
+		return inference.CapabilitySet{}, integrationContractError(canonical, "returned invalid capabilities", err)
+	}
+	for _, required := range request.RequiredCapabilities().Values() {
+		if !negotiated.Has(required) {
+			return inference.CapabilitySet{}, fmt.Errorf(
+				"provider %q capabilities omit required capability %q",
+				canonical,
+				required,
+			)
+		}
+	}
+	return canonicalCapabilities(negotiated), nil
+}
+
+// Discover explicitly delegates live readiness discovery and validates the
+// provider-neutral result before returning it.
+func (r *Registry) Discover(ctx context.Context, identity string) (inference.Discovery, error) {
+	canonical, err := r.resolveSelectable(identity)
+	if err != nil {
+		return inference.Discovery{}, err
+	}
+	discovery, err := r.integrations[canonical].Discover(ctx)
+	if err != nil {
+		return inference.Discovery{}, integrationOperationError(canonical, "discovery", err)
+	}
+	if err := inference.ValidateDiscovery(discovery); err != nil {
+		return inference.Discovery{}, integrationContractError(canonical, "returned invalid discovery", err)
+	}
+	return canonicalDiscovery(discovery), nil
+}
+
+// Integration resolves invocation access without invoking the provider.
+func (r *Registry) Integration(identity string) (inference.Integration, error) {
+	canonical, err := r.resolveSelectable(identity)
+	if err != nil {
+		return nil, err
+	}
+	return r.integrations[canonical], nil
+}
+
+func (r *Registry) resolveSelectable(identity string) (string, error) {
+	normalized := normalize(identity)
+	if err := inference.ValidateIdentity(inference.Identity(normalized)); err != nil {
+		return "", fmt.Errorf("provider lookup %s is invalid: %w", identityLabel(normalized), err)
+	}
+	canonical := normalized
+	if aliasTarget, ok := r.aliases[normalized]; ok {
+		canonical = aliasTarget
+	}
+	manifest, known := r.manifests[canonical]
+	if !known {
+		return "", fmt.Errorf("provider %s is unknown", identityLabel(normalized))
+	}
+	if _, selectable := r.integrations[canonical]; !selectable {
+		return "", fmt.Errorf(
+			"provider %s is not selectable (%s)",
+			identityLabel(canonical),
+			availabilityFor(manifest, false),
+		)
+	}
+	return canonical, nil
+}
+
+func sortedManifestIdentities(manifests map[string]Manifest) []string {
+	identities := make([]string, 0, len(manifests))
+	for identity := range manifests {
+		identities = append(identities, identity)
+	}
+	sort.Strings(identities)
+	return identities
+}
+
+func availabilityFor(manifest Manifest, selectable bool) Availability {
+	switch {
+	case manifest.TechnicalSupportLevel == SupportNotSupported:
+		return AvailabilityNotSupported
+	case manifest.ImplementationAvailability == ImplementationCatalogOnly:
+		return AvailabilityCatalogOnly
+	case selectable:
+		return AvailabilitySelectable
+	default:
+		return AvailabilitySupportedButUnavailable
+	}
+}
+
+type operationError struct {
+	message string
+	cause   error
+}
+
+func (e *operationError) Error() string { return e.message }
+func (e *operationError) Unwrap() error { return e.cause }
+
+func integrationOperationError(identity, operation string, cause error) error {
+	return &operationError{
+		message: fmt.Sprintf("provider %q %s failed", identity, operation),
+		cause:   cause,
+	}
+}
+
+func integrationContractError(identity, violation string, cause error) error {
+	return &operationError{
+		message: fmt.Sprintf("provider %q %s", identity, violation),
+		cause:   cause,
+	}
+}
+
+func canonicalManifest(manifest Manifest) Manifest {
+	canonical := cloneManifest(manifest)
+	canonical.Aliases = make([]string, 0, len(manifest.Aliases))
+	for _, alias := range manifest.Aliases {
+		canonical.Aliases = append(canonical.Aliases, normalize(alias))
+	}
+	canonical.Aliases = sortedUnique(canonical.Aliases)
+	canonical.Discovery = cloneDiscoveryPrerequisites(manifest.Discovery)
+	sort.Strings(canonical.Discovery.ConfigurationKeys)
+	sort.Strings(canonical.Discovery.EndpointKinds)
+	sort.Strings(canonical.Discovery.ExecutableNames)
+	canonical.Description = canonicalLocalizedValue(canonical.Description)
+	canonical.DisplayName = canonicalLocalizedValue(canonical.DisplayName)
+	if canonical.Deprecation != nil {
+		canonical.Deprecation.Reason = canonicalLocalizedValue(canonical.Deprecation.Reason)
+	}
+	sort.Slice(canonical.Documentation, func(i, j int) bool {
+		left := canonical.Documentation[i].Kind + "\x00" + canonical.Documentation[i].URL
+		right := canonical.Documentation[j].Kind + "\x00" + canonical.Documentation[j].URL
+		return left < right
+	})
+	return canonical
+}
+
+func canonicalLocalizedValue(value LocalizedValue) LocalizedValue {
+	canonical := cloneLocalizedValue(value)
+	if canonical.Locales != nil {
+		sort.Strings(*canonical.Locales)
+	}
+	return canonical
+}
+
+func canonicalCapabilities(capabilities inference.CapabilitySet) inference.CapabilitySet {
+	ordered := make([]inference.Capability, 0, len(capabilities.Values()))
+	for _, capability := range allManifestCapabilities() {
+		if capabilities.Has(capability) {
+			ordered = append(ordered, capability)
+		}
+	}
+	return inference.NewCapabilitySet(ordered...)
+}
+
+func canonicalDiscovery(discovery inference.Discovery) inference.Discovery {
+	prerequisites := discovery.Prerequisites()
+	sort.Slice(prerequisites, func(i, j int) bool {
+		left := prerequisiteSortKey(prerequisites[i])
+		right := prerequisiteSortKey(prerequisites[j])
+		return left < right
+	})
+	return inference.NewDiscovery(discovery.Readiness(), prerequisites...)
+}
+
+func prerequisiteSortKey(prerequisite inference.Prerequisite) string {
+	return strings.Join([]string{
+		string(prerequisite.Kind()),
+		prerequisite.Name(),
+		string(prerequisite.Status()),
+		prerequisite.Description(),
+	}, "\x00")
+}
+
+func cloneDiscoveryPrerequisites(prerequisites DiscoveryPrerequisites) DiscoveryPrerequisites {
+	return DiscoveryPrerequisites{
+		ConfigurationKeys: append([]string{}, prerequisites.ConfigurationKeys...),
+		EndpointKinds:     append([]string{}, prerequisites.EndpointKinds...),
+		ExecutableNames:   append([]string{}, prerequisites.ExecutableNames...),
+	}
+}

--- a/pkg/services/workers/provider/registry/operations_test.go
+++ b/pkg/services/workers/provider/registry/operations_test.go
@@ -1,0 +1,398 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	inference "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+)
+
+type recordingIntegration struct {
+	identity        inference.Identity
+	maximum         inference.CapabilitySet
+	negotiated      inference.CapabilitySet
+	discovery       inference.Discovery
+	capabilitiesErr error
+	discoveryErr    error
+	discoveryCalls  int
+	capabilityCalls int
+	invocationCalls int
+}
+
+func (r *recordingIntegration) Identity() inference.Identity { return r.identity }
+func (r *recordingIntegration) MaximumCapabilities() inference.CapabilitySet {
+	return r.maximum
+}
+func (r *recordingIntegration) Discover(context.Context) (inference.Discovery, error) {
+	r.discoveryCalls++
+	return r.discovery, r.discoveryErr
+}
+func (r *recordingIntegration) Capabilities(context.Context, inference.InvocationRequest) (inference.CapabilitySet, error) {
+	r.capabilityCalls++
+	return r.negotiated, r.capabilitiesErr
+}
+func (r *recordingIntegration) Invoke(context.Context, inference.InvocationRequest, inference.ResponseWriter) error {
+	r.invocationCalls++
+	return nil
+}
+
+func TestRegistryStaticQueriesAreNormalizedDeterministicDetachedAndInert(t *testing.T) {
+	t.Parallel()
+
+	registry, recordings := newRecordingRegistry(t)
+	entry, err := registry.Lookup("  AGENT  ")
+	if err != nil {
+		t.Fatalf("Lookup(alias) error = %v", err)
+	}
+	if entry.Identity() != "cursor" {
+		t.Fatalf("Lookup(alias).Identity() = %q, want cursor", entry.Identity())
+	}
+	entries := registry.Entries()
+	identities := entryIdentities(entries)
+	if !slices.IsSorted(identities) {
+		t.Fatalf("Entries() identities = %v, want canonical order", identities)
+	}
+	if len(entries) != 8 {
+		t.Fatalf("Entries() count = %d, want 8", len(entries))
+	}
+
+	cursorEntry := findEntry(t, entries, "cursor")
+	manifest := cursorEntry.Manifest()
+	if !slices.IsSorted(cursorEntry.Aliases()) ||
+		!slices.IsSorted(cursorEntry.DiscoveryPrerequisites().ConfigurationKeys) ||
+		!slices.IsSorted(cursorEntry.DiscoveryPrerequisites().EndpointKinds) ||
+		!slices.IsSorted(cursorEntry.DiscoveryPrerequisites().ExecutableNames) {
+		t.Fatal("entry slice projections are not in canonical order")
+	}
+	manifest.Aliases[0] = "mutated"
+	aliases := entry.Aliases()
+	aliases[0] = "mutated"
+	prerequisites := entry.DiscoveryPrerequisites()
+	prerequisites.ExecutableNames[0] = "mutated"
+	maximum := entry.MaximumCapabilities().Values()
+	maximum[0] = inference.CapabilityUsage
+
+	again, err := registry.Lookup("agent")
+	if err != nil {
+		t.Fatalf("Lookup(alias again) error = %v", err)
+	}
+	if again.Aliases()[0] == "mutated" ||
+		again.DiscoveryPrerequisites().ExecutableNames[0] == "mutated" ||
+		!again.MaximumCapabilities().Has(inference.CapabilityPromptSubmission) {
+		t.Fatal("caller mutation changed later registry results")
+	}
+	assertProviderCalls(t, recordings, 0, 0, 0)
+}
+
+func TestRegistryLookupRejectsInvalidUnknownAndNonSelectableIdentities(t *testing.T) {
+	t.Parallel()
+
+	registry, recordings := newRecordingRegistry(t)
+	tests := []struct {
+		identity string
+		want     string
+	}{
+		{identity: "", want: `provider lookup "<empty>" is invalid`},
+		{identity: "bad identity", want: `provider lookup "bad identity" is invalid`},
+		{identity: "missing", want: `provider "missing" is unknown`},
+		{identity: "agy", want: `provider "agy" is not selectable (not-supported)`},
+	}
+	for _, test := range tests {
+		_, err := registry.Lookup(test.identity)
+		if err == nil || !strings.Contains(err.Error(), test.want) {
+			t.Fatalf("Lookup(%q) error = %v, want containing %q", test.identity, err, test.want)
+		}
+	}
+	assertProviderCalls(t, recordings, 0, 0, 0)
+}
+
+func TestRegistryDiagnosticsDistinguishStaticAvailabilityWithoutDiscovery(t *testing.T) {
+	t.Parallel()
+
+	catalogOnly := externalManifest(t, "catalog.entry", "catalog")
+	catalogOnly.ImplementationAvailability = ImplementationCatalogOnly
+	unavailable := externalManifest(t, "external.entry", "external")
+	registry, err := build([]Manifest{catalogOnly, unavailable}, nil)
+	if err != nil {
+		t.Fatalf("build() error = %v", err)
+	}
+	got := registry.SupportedProviders()
+	if len(got) != 2 ||
+		got[0].Entry().Identity() != "catalog.entry" ||
+		got[0].Availability() != AvailabilityCatalogOnly ||
+		got[1].Entry().Identity() != "external.entry" ||
+		got[1].Availability() != AvailabilitySupportedButUnavailable {
+		t.Fatalf("SupportedProviders() = %#v, want catalog-only then supported-but-unavailable", got)
+	}
+
+	fullRegistry, recordings := newRecordingRegistry(t)
+	availability := make(map[inference.Identity]Availability)
+	for _, diagnostic := range fullRegistry.SupportedProviders() {
+		availability[diagnostic.Entry().Identity()] = diagnostic.Availability()
+	}
+	if availability["agy"] != AvailabilityNotSupported ||
+		availability["claude"] != AvailabilitySelectable {
+		t.Fatalf("availability = %v", availability)
+	}
+	assertProviderCalls(t, recordings, 0, 0, 0)
+}
+
+func TestRegistryExplicitOperationsDelegateOnlyToResolvedIntegration(t *testing.T) {
+	t.Parallel()
+
+	registry, recordings := newRecordingRegistry(t)
+	request := inference.NewInvocationRequest(inference.InvocationInput{
+		Required: inference.NewCapabilitySet(inference.CapabilityPromptSubmission),
+	})
+	assertNegotiatedCapabilityOperation(t, registry, request)
+	assertDiscoveryOperation(t, registry)
+	assertInvocationAccess(t, registry, request)
+	if _, err := registry.MaximumCapabilities("agent"); err != nil {
+		t.Fatalf("MaximumCapabilities() error = %v", err)
+	}
+	assertOnlyCursorReceivedExplicitCalls(t, recordings)
+}
+
+func assertNegotiatedCapabilityOperation(
+	t *testing.T,
+	registry *Registry,
+	request inference.InvocationRequest,
+) {
+	t.Helper()
+	capabilities, err := registry.Capabilities(context.Background(), "agent", request)
+	if err != nil || !capabilities.Has(inference.CapabilityPromptSubmission) {
+		t.Fatalf("Capabilities() = %v, %v", capabilities.Values(), err)
+	}
+	if capabilities.Values()[0] != inference.CapabilityPromptSubmission {
+		t.Fatalf("Capabilities() = %v, want canonical manifest order", capabilities.Values())
+	}
+}
+
+func assertDiscoveryOperation(t *testing.T, registry *Registry) {
+	t.Helper()
+	discovery, err := registry.Discover(context.Background(), "cursor")
+	if err != nil || discovery.Readiness() != inference.ReadinessReady {
+		t.Fatalf("Discover() = %#v, %v", discovery, err)
+	}
+	if discovery.Prerequisites()[0].Kind() != inference.PrerequisiteConfiguration {
+		t.Fatalf("Discover() prerequisites = %#v, want canonical order", discovery.Prerequisites())
+	}
+}
+
+func assertInvocationAccess(t *testing.T, registry *Registry, request inference.InvocationRequest) {
+	t.Helper()
+	integration, err := registry.Integration(" AGENT ")
+	if err != nil || integration.Identity() != "cursor" {
+		t.Fatalf("Integration() identity = %q, %v", integration.Identity(), err)
+	}
+	if err := integration.Invoke(context.Background(), request, nil); err != nil {
+		t.Fatalf("resolved Integration.Invoke() error = %v", err)
+	}
+}
+
+func assertOnlyCursorReceivedExplicitCalls(
+	t *testing.T,
+	recordings map[string]*recordingIntegration,
+) {
+	t.Helper()
+	cursor := recordings["cursor"]
+	if cursor.capabilityCalls != 1 || cursor.discoveryCalls != 1 || cursor.invocationCalls != 1 {
+		t.Fatalf("cursor calls = capabilities %d, discovery %d, invocation %d", cursor.capabilityCalls, cursor.discoveryCalls, cursor.invocationCalls)
+	}
+	for identity, recording := range recordings {
+		if identity != "cursor" && (recording.capabilityCalls != 0 || recording.discoveryCalls != 0 || recording.invocationCalls != 0) {
+			t.Fatalf("%s received unexpected calls", identity)
+		}
+	}
+}
+
+func TestRegistryRejectsInvalidNegotiatedCapabilitiesAndDiscovery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*recordingIntegration)
+		call   func(*Registry) error
+		want   string
+	}{
+		{
+			name: "unknown capability",
+			mutate: func(integration *recordingIntegration) {
+				integration.negotiated = inference.NewCapabilitySet(inference.CapabilityPromptSubmission, "unknown")
+			},
+			call: capabilityCall,
+			want: `returned invalid capabilities`,
+		},
+		{
+			name: "above manifest maximum",
+			mutate: func(integration *recordingIntegration) {
+				integration.negotiated = inference.NewCapabilitySet(
+					inference.CapabilityPromptSubmission,
+					inference.CapabilityProviderReconnect,
+					inference.CapabilitySessionResume,
+				)
+			},
+			call: capabilityCall,
+			want: `returned invalid capabilities`,
+		},
+		{
+			name: "contradictory capability dependencies",
+			mutate: func(integration *recordingIntegration) {
+				integration.negotiated = inference.NewCapabilitySet(
+					inference.CapabilityPromptSubmission,
+					inference.CapabilityMessageDeltas,
+				)
+			},
+			call: capabilityCall,
+			want: `returned invalid capabilities`,
+		},
+		{
+			name: "omits required capability",
+			mutate: func(integration *recordingIntegration) {
+				integration.negotiated = inference.NewCapabilitySet(inference.CapabilityPromptSubmission)
+			},
+			call: func(registry *Registry) error {
+				request := inference.NewInvocationRequest(inference.InvocationInput{
+					Required: inference.NewCapabilitySet(inference.CapabilityMessageSnapshots),
+				})
+				_, err := registry.Capabilities(context.Background(), "cursor", request)
+				return err
+			},
+			want: `omit required capability "message_snapshots"`,
+		},
+		{
+			name: "contradictory discovery",
+			mutate: func(integration *recordingIntegration) {
+				integration.discovery = inference.NewDiscovery(inference.ReadinessUnavailable)
+			},
+			call: func(registry *Registry) error {
+				_, err := registry.Discover(context.Background(), "cursor")
+				return err
+			},
+			want: `returned invalid discovery`,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			registry, recordings := newRecordingRegistry(t)
+			test.mutate(recordings["cursor"])
+			err := test.call(registry)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("operation error = %v, want containing %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestRegistryBoundsProviderOperationErrorsAndPreservesCause(t *testing.T) {
+	t.Parallel()
+
+	registry, recordings := newRecordingRegistry(t)
+	cause := errors.New(strings.Repeat("native provider detail ", 100))
+	recordings["cursor"].discoveryErr = cause
+	_, err := registry.Discover(context.Background(), "cursor")
+	if !errors.Is(err, cause) {
+		t.Fatalf("Discover() error = %v, want wrapped cause", err)
+	}
+	if got := err.Error(); got != `provider "cursor" discovery failed` {
+		t.Fatalf("Discover() error = %q, want bounded provider context", got)
+	}
+}
+
+func newRecordingRegistry(t *testing.T) (*Registry, map[string]*recordingIntegration) {
+	t.Helper()
+	recordings := make(map[string]*recordingIntegration)
+	registrations := supportedCatalogRegistrations(t)
+	for index, registration := range registrations {
+		manifest := findManifest(t, publishedCatalog(t), string(registration.identity))
+		integration := &recordingIntegration{
+			identity:   registration.identity,
+			maximum:    manifestCapabilities(manifest),
+			negotiated: reverseCapabilities(manifestCapabilities(manifest)),
+			discovery: inference.NewDiscovery(
+				inference.ReadinessReady,
+				inference.NewPrerequisite(
+					inference.PrerequisiteDependency,
+					"second dependency",
+					inference.PrerequisiteSatisfied,
+					"second dependency is available",
+				),
+				inference.NewPrerequisite(
+					inference.PrerequisiteConfiguration,
+					"first configuration",
+					inference.PrerequisiteSatisfied,
+					"first configuration is available",
+				),
+			),
+		}
+		registrations[index].integration = integration
+		recordings[string(integration.identity)] = integration
+	}
+	registry, err := New(registrations...)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	return registry, recordings
+}
+
+func reverseCapabilities(capabilities inference.CapabilitySet) inference.CapabilitySet {
+	values := capabilities.Values()
+	slices.Reverse(values)
+	return inference.NewCapabilitySet(values...)
+}
+
+func capabilityCall(registry *Registry) error {
+	request := inference.NewInvocationRequest(inference.InvocationInput{
+		Required: inference.NewCapabilitySet(inference.CapabilityPromptSubmission),
+	})
+	_, err := registry.Capabilities(context.Background(), "cursor", request)
+	return err
+}
+
+func entryIdentities(entries []Entry) []string {
+	identities := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		identities = append(identities, string(entry.Identity()))
+	}
+	return identities
+}
+
+func findEntry(t *testing.T, entries []Entry, identity inference.Identity) Entry {
+	t.Helper()
+	for _, entry := range entries {
+		if entry.Identity() == identity {
+			return entry
+		}
+	}
+	t.Fatalf("entry %q not found", identity)
+	return Entry{}
+}
+
+func assertProviderCalls(
+	t *testing.T,
+	recordings map[string]*recordingIntegration,
+	discoveryCalls, capabilityCalls, invocationCalls int,
+) {
+	t.Helper()
+	for identity, recording := range recordings {
+		if recording.discoveryCalls != discoveryCalls ||
+			recording.capabilityCalls != capabilityCalls ||
+			recording.invocationCalls != invocationCalls {
+			t.Fatalf(
+				"%s calls = discovery %d, capabilities %d, invocation %d; want %d, %d, %d",
+				identity,
+				recording.discoveryCalls,
+				recording.capabilityCalls,
+				recording.invocationCalls,
+				discoveryCalls,
+				capabilityCalls,
+				invocationCalls,
+			)
+		}
+	}
+}

--- a/pkg/services/workers/provider/registry/registry.go
+++ b/pkg/services/workers/provider/registry/registry.go
@@ -54,6 +54,7 @@ func ExternalRegistration(manifest Manifest, integration inference.Integration) 
 type Registry struct {
 	manifests    map[string]Manifest
 	integrations map[string]inference.Integration
+	aliases      map[string]string
 }
 
 // New parses and validates the embedded catalog, then joins all registrations.
@@ -185,9 +186,14 @@ func assembleRegistry(byID map[string][]manifestCandidate, integrations map[stri
 	registry := &Registry{
 		manifests:    make(map[string]Manifest, len(byID)),
 		integrations: make(map[string]inference.Integration, len(integrations)),
+		aliases:      make(map[string]string),
 	}
 	for identity, candidates := range byID {
-		registry.manifests[identity] = cloneManifest(candidates[0].manifest)
+		manifest := cloneManifest(candidates[0].manifest)
+		registry.manifests[identity] = manifest
+		for _, alias := range manifest.Aliases {
+			registry.aliases[normalize(alias)] = identity
+		}
 		if registered := integrations[identity]; len(registered) == 1 {
 			registry.integrations[identity] = registered[0]
 		}

--- a/pkg/services/workers/provider/registry/registry.go
+++ b/pkg/services/workers/provider/registry/registry.go
@@ -1,0 +1,303 @@
+// Package registry joins the published provider manifest catalog to the
+// provider-neutral inference Integration contract.
+package registry
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	modelproviders "github.com/portpowered/infinite-you/packages/model-providers"
+	inference "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+)
+
+type registrationKind uint8
+
+const (
+	catalogRegistration registrationKind = iota + 1
+	externalRegistration
+)
+
+// Registration binds one provider-neutral Integration either to an existing
+// catalog identity or to a typed external manifest. Its fields are private so
+// callers cannot repeat or partially override catalog-owned metadata.
+type Registration struct {
+	kind        registrationKind
+	identity    inference.Identity
+	manifest    Manifest
+	integration inference.Integration
+}
+
+// CatalogRegistration binds an Integration to an embedded catalog identity.
+func CatalogRegistration(identity inference.Identity, integration inference.Integration) Registration {
+	return Registration{
+		kind:        catalogRegistration,
+		identity:    identity,
+		integration: integration,
+	}
+}
+
+// ExternalRegistration contributes a detached typed manifest and binds it to
+// an Integration without mutating the embedded first-party catalog.
+func ExternalRegistration(manifest Manifest, integration inference.Integration) Registration {
+	return Registration{
+		kind:        externalRegistration,
+		manifest:    cloneManifest(manifest),
+		integration: integration,
+	}
+}
+
+// Registry is the immutable result of a validated manifest-to-integration join.
+// Query operations are added at this boundary rather than exposing its maps.
+type Registry struct {
+	manifests    map[string]Manifest
+	integrations map[string]inference.Integration
+}
+
+// New parses and validates the embedded catalog, then joins all registrations.
+// Construction performs no provider discovery, capability negotiation, or
+// invocation.
+func New(registrations ...Registration) (*Registry, error) {
+	payload := modelproviders.CatalogJSON()
+	if err := validateSchema(modelproviders.ProviderCatalogSchemaJSON(), payload); err != nil {
+		return nil, validationFailure([]string{"embedded catalog violates its published schema: " + err.Error()})
+	}
+	var catalog catalogDocument
+	if err := json.Unmarshal(payload, &catalog); err != nil {
+		return nil, fmt.Errorf("parse embedded provider catalog: %w", err)
+	}
+	return build(catalog.Providers, registrations)
+}
+
+func build(catalog []Manifest, registrations []Registration) (*Registry, error) {
+	manifests, violations := collectManifests(catalog, registrations)
+	violations = append(violations, validateIdentityClaims(manifests)...)
+	byID := indexManifests(manifests)
+	integrations, registrationViolations := validateRegistrations(byID, registrations)
+	violations = append(violations, registrationViolations...)
+	violations = append(violations, validateImplementationCoverage(byID, integrations)...)
+	if len(violations) != 0 {
+		return nil, validationFailure(violations)
+	}
+	return assembleRegistry(byID, integrations), nil
+}
+
+func collectManifests(catalog []Manifest, registrations []Registration) ([]manifestCandidate, []string) {
+	manifests := make([]manifestCandidate, 0, len(catalog)+len(registrations))
+	for _, manifest := range catalog {
+		manifests = append(manifests, manifestCandidate{manifest: cloneManifest(manifest), bundled: true})
+	}
+
+	var violations []string
+	for _, registration := range registrations {
+		if registration.kind != externalRegistration {
+			continue
+		}
+		manifest := cloneManifest(registration.manifest)
+		if err := validateManifestSchema(manifest); err != nil {
+			violations = append(violations, identityLabel(manifest.ID)+": external manifest violates the published schema: "+err.Error())
+		}
+		if manifest.ImplementationAvailability != ImplementationExternallySupplied {
+			violations = append(violations, identityLabel(manifest.ID)+": external manifest implementation availability must be externally-supplied")
+		}
+		manifests = append(manifests, manifestCandidate{manifest: manifest})
+	}
+	return manifests, violations
+}
+
+func indexManifests(manifests []manifestCandidate) map[string][]manifestCandidate {
+	byID := make(map[string][]manifestCandidate, len(manifests))
+	for _, candidate := range manifests {
+		identity := normalize(candidate.manifest.ID)
+		byID[identity] = append(byID[identity], candidate)
+	}
+	return byID
+}
+
+func validateRegistrations(byID map[string][]manifestCandidate, registrations []Registration) (map[string][]inference.Integration, []string) {
+	integrations := make(map[string][]inference.Integration, len(registrations))
+	var violations []string
+	for _, registration := range registrations {
+		identity, registered, registrationViolations := validateRegistration(byID, registration)
+		violations = append(violations, registrationViolations...)
+		if registered {
+			integrations[identity] = append(integrations[identity], registration.integration)
+		}
+	}
+	return integrations, violations
+}
+
+func validateRegistration(byID map[string][]manifestCandidate, registration Registration) (string, bool, []string) {
+	identity := registrationIdentity(registration)
+	label := identityLabel(identity)
+	if registration.kind != catalogRegistration && registration.kind != externalRegistration {
+		return identity, false, []string{label + ": registration kind is invalid"}
+	}
+	var violations []string
+	if err := inference.ValidateIdentity(inference.Identity(identity)); err != nil {
+		violations = append(violations, label+": manifest binding identity is invalid: "+err.Error())
+	}
+	if isNilIntegration(registration.integration) {
+		return identity, false, append(violations, label+": integration is nil")
+	}
+	integrationIdentity := normalize(string(registration.integration.Identity()))
+	if err := inference.ValidateIdentity(inference.Identity(integrationIdentity)); err != nil {
+		violations = append(violations, identityLabel(integrationIdentity)+": integration identity is invalid: "+err.Error())
+	}
+	if integrationIdentity != identity {
+		violations = append(violations, label+": integration identity "+identityLabel(integrationIdentity)+" differs from its manifest binding")
+	}
+	candidates := byID[identity]
+	if len(candidates) != 1 {
+		if len(candidates) == 0 {
+			violations = append(violations, label+": implementation has no matching manifest")
+		}
+		return identity, false, violations
+	}
+	manifest := candidates[0].manifest
+	if !selectableManifest(manifest) {
+		violations = append(violations, label+": non-selectable manifest cannot have a runnable integration")
+	}
+	violations = append(violations, validateMaximumCapabilities(identity, manifest, registration.integration)...)
+	return identity, true, violations
+}
+
+func validateImplementationCoverage(byID map[string][]manifestCandidate, integrations map[string][]inference.Integration) []string {
+	var violations []string
+	for identity, candidates := range byID {
+		if len(candidates) != 1 || !requiresBundledImplementation(candidates[0]) {
+			continue
+		}
+		switch len(integrations[identity]) {
+		case 0:
+			violations = append(violations, identityLabel(identity)+": supported bundled manifest has no matching implementation")
+		case 1:
+		default:
+			violations = append(violations, identityLabel(identity)+": multiple implementations bind the same manifest")
+		}
+	}
+	return violations
+}
+
+func assembleRegistry(byID map[string][]manifestCandidate, integrations map[string][]inference.Integration) *Registry {
+	registry := &Registry{
+		manifests:    make(map[string]Manifest, len(byID)),
+		integrations: make(map[string]inference.Integration, len(integrations)),
+	}
+	for identity, candidates := range byID {
+		registry.manifests[identity] = cloneManifest(candidates[0].manifest)
+		if registered := integrations[identity]; len(registered) == 1 {
+			registry.integrations[identity] = registered[0]
+		}
+	}
+	return registry
+}
+
+type manifestCandidate struct {
+	manifest Manifest
+	bundled  bool
+}
+
+func registrationIdentity(registration Registration) string {
+	if registration.kind == externalRegistration {
+		return normalize(registration.manifest.ID)
+	}
+	return normalize(string(registration.identity))
+}
+
+func normalize(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func identityLabel(identity string) string {
+	identity = normalize(identity)
+	if identity == "" {
+		return `"<empty>"`
+	}
+	return `"` + identity + `"`
+}
+
+func selectableManifest(manifest Manifest) bool {
+	return manifest.TechnicalSupportLevel != SupportNotSupported &&
+		manifest.ImplementationAvailability != ImplementationCatalogOnly
+}
+
+func requiresBundledImplementation(candidate manifestCandidate) bool {
+	return candidate.bundled &&
+		candidate.manifest.ImplementationAvailability == ImplementationBundled &&
+		candidate.manifest.TechnicalSupportLevel != SupportNotSupported
+}
+
+func isNilIntegration(integration inference.Integration) bool {
+	if integration == nil {
+		return true
+	}
+	value := reflect.ValueOf(integration)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+func cloneManifest(manifest Manifest) Manifest {
+	clone := manifest
+	clone.Aliases = append([]string{}, manifest.Aliases...)
+	clone.Description = cloneLocalizedValue(manifest.Description)
+	clone.DisplayName = cloneLocalizedValue(manifest.DisplayName)
+	clone.Documentation = append([]DocumentationLink{}, manifest.Documentation...)
+	clone.Discovery.ConfigurationKeys = append([]string{}, manifest.Discovery.ConfigurationKeys...)
+	clone.Discovery.EndpointKinds = append([]string{}, manifest.Discovery.EndpointKinds...)
+	clone.Discovery.ExecutableNames = append([]string{}, manifest.Discovery.ExecutableNames...)
+	if manifest.Deprecation != nil {
+		deprecation := *manifest.Deprecation
+		deprecation.Reason = cloneLocalizedValue(manifest.Deprecation.Reason)
+		if manifest.Deprecation.ReplacementProviderID != nil {
+			replacement := *manifest.Deprecation.ReplacementProviderID
+			deprecation.ReplacementProviderID = &replacement
+		}
+		clone.Deprecation = &deprecation
+	}
+	return clone
+}
+
+func cloneLocalizedValue(value LocalizedValue) LocalizedValue {
+	clone := value
+	if value.ID != nil {
+		id := *value.ID
+		clone.ID = &id
+	}
+	if value.Locales != nil {
+		locales := append([]string{}, (*value.Locales)...)
+		clone.Locales = &locales
+	}
+	if value.Values != nil {
+		values := make(map[string]string, len(*value.Values))
+		for locale, localized := range *value.Values {
+			values[locale] = localized
+		}
+		clone.Values = &values
+	}
+	return clone
+}
+
+func sortedUnique(values []string) []string {
+	sort.Strings(values)
+	return slicesCompact(values)
+}
+
+func slicesCompact(values []string) []string {
+	if len(values) < 2 {
+		return values
+	}
+	output := values[:1]
+	for _, value := range values[1:] {
+		if value != output[len(output)-1] {
+			output = append(output, value)
+		}
+	}
+	return output
+}

--- a/pkg/services/workers/provider/registry/registry.go
+++ b/pkg/services/workers/provider/registry/registry.go
@@ -198,6 +198,11 @@ func assembleRegistry(byID map[string][]manifestCandidate, integrations map[stri
 			registry.integrations[identity] = registered[0]
 		}
 	}
+	for _, compatibility := range providerCompatibilityAliases() {
+		if _, exists := registry.manifests[compatibility.canonical]; exists {
+			registry.aliases[compatibility.alias] = compatibility.canonical
+		}
+	}
 	return registry
 }
 

--- a/pkg/services/workers/provider/registry/registry_test.go
+++ b/pkg/services/workers/provider/registry/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"math/rand"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -43,6 +44,31 @@ func TestNewJoinsSupportedCatalogManifestsWithoutProviderSideEffects(t *testing.
 	}
 	if _, selectable := registry.integrations["agy"]; selectable {
 		t.Fatal("not-supported catalog entry is selectable")
+	}
+}
+
+func TestBuiltInRegistrationsBuildAllSelectableBundledProviders(t *testing.T) {
+	t.Parallel()
+
+	registrations, err := BuiltInRegistrations()
+	if err != nil {
+		t.Fatalf("BuiltInRegistrations() error = %v", err)
+	}
+	registry, err := New(registrations...)
+	if err != nil {
+		t.Fatalf("New(BuiltInRegistrations()) error = %v", err)
+	}
+
+	want := []string{"agy", "claude", "codex", "cursor", "gemini", "kiro", "opencode", "pi"}
+	if got := entryIdentities(registry.Entries()); !reflect.DeepEqual(got, want) {
+		t.Fatalf("built-in manifest identities = %v, want %v", got, want)
+	}
+	cursor, err := registry.Lookup("agent")
+	if err != nil {
+		t.Fatalf("Lookup(cursor alias) error = %v", err)
+	}
+	if cursor.Identity() != "cursor" {
+		t.Fatalf("Lookup(cursor alias) identity = %q, want cursor", cursor.Identity())
 	}
 }
 

--- a/pkg/services/workers/provider/registry/registry_test.go
+++ b/pkg/services/workers/provider/registry/registry_test.go
@@ -1,0 +1,331 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"math/rand"
+	"strings"
+	"testing"
+
+	modelproviders "github.com/portpowered/infinite-you/packages/model-providers"
+	inference "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+)
+
+type fakeIntegration struct {
+	identity inference.Identity
+	maximum  inference.CapabilitySet
+}
+
+func (f *fakeIntegration) Identity() inference.Identity { return f.identity }
+func (f *fakeIntegration) MaximumCapabilities() inference.CapabilitySet {
+	return f.maximum
+}
+func (f *fakeIntegration) Discover(context.Context) (inference.Discovery, error) {
+	panic("registry construction must not discover providers")
+}
+func (f *fakeIntegration) Capabilities(context.Context, inference.InvocationRequest) (inference.CapabilitySet, error) {
+	panic("registry construction must not negotiate capabilities")
+}
+func (f *fakeIntegration) Invoke(context.Context, inference.InvocationRequest, inference.ResponseWriter) error {
+	panic("registry construction must not invoke providers")
+}
+
+func TestNewJoinsSupportedCatalogManifestsWithoutProviderSideEffects(t *testing.T) {
+	t.Parallel()
+
+	registrations := supportedCatalogRegistrations(t)
+	registry, err := New(registrations...)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if len(registry.manifests) != 8 || len(registry.integrations) != 7 {
+		t.Fatalf("joined counts = (%d manifests, %d integrations), want (8, 7)", len(registry.manifests), len(registry.integrations))
+	}
+	if _, selectable := registry.integrations["agy"]; selectable {
+		t.Fatal("not-supported catalog entry is selectable")
+	}
+}
+
+func TestNewAcceptsDetachedSchemaValidExternalManifest(t *testing.T) {
+	t.Parallel()
+
+	registrations := supportedCatalogRegistrations(t)
+	manifest := externalManifest(t, "customer.provider", "customer")
+	localizedNames := map[string]string{"en-US": "Customer Provider"}
+	manifest.DisplayName.Values = &localizedNames
+	registrations = append(registrations, ExternalRegistration(manifest, integrationFor(manifest)))
+	manifest.ID = "mutated"
+	manifest.Aliases[0] = "mutated"
+	localizedNames["en-US"] = "Mutated"
+
+	registry, err := New(registrations...)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if _, ok := registry.manifests["customer.provider"]; !ok {
+		t.Fatal("external manifest was not joined under its detached identity")
+	}
+	if _, ok := registry.manifests["mutated"]; ok {
+		t.Fatal("caller mutation changed the registered external manifest")
+	}
+	storedNames := registry.manifests["customer.provider"].DisplayName.Values
+	if storedNames == nil || (*storedNames)["en-US"] != "Customer Provider" {
+		t.Fatal("caller mutation changed nested external manifest metadata")
+	}
+}
+
+func TestBuildAcceptsCatalogOnlyAndNotSupportedManifestsWithoutImplementations(t *testing.T) {
+	t.Parallel()
+
+	catalogOnly := externalManifest(t, "catalog.entry", "catalog-alias")
+	catalogOnly.ImplementationAvailability = ImplementationCatalogOnly
+	notSupported := externalManifest(t, "unsupported.entry", "unsupported-alias")
+	notSupported.TechnicalSupportLevel = SupportNotSupported
+
+	registry, err := build([]Manifest{catalogOnly, notSupported}, nil)
+	if err != nil {
+		t.Fatalf("build() error = %v", err)
+	}
+	if len(registry.manifests) != 2 || len(registry.integrations) != 0 {
+		t.Fatalf("joined counts = (%d manifests, %d integrations), want (2, 0)", len(registry.manifests), len(registry.integrations))
+	}
+}
+
+func TestNewRejectsInvalidRegistrationInvariants(t *testing.T) {
+	t.Parallel()
+
+	var typedNil *fakeIntegration
+	tests := []struct {
+		name   string
+		mutate func([]Registration) []Registration
+		want   []string
+	}{
+		{
+			name: "nil integration",
+			mutate: func(registrations []Registration) []Registration {
+				registrations[0].integration = typedNil
+				return registrations
+			},
+			want: []string{`"claude": integration is nil`, `"claude": supported bundled manifest has no matching implementation`},
+		},
+		{
+			name: "mismatched integration identity",
+			mutate: func(registrations []Registration) []Registration {
+				registrations[0].integration = &fakeIntegration{
+					identity: "different",
+					maximum:  registrations[0].integration.MaximumCapabilities(),
+				}
+				return registrations
+			},
+			want: []string{`"claude": integration identity "different" differs from its manifest binding`},
+		},
+		{
+			name: "malformed binding",
+			mutate: func(registrations []Registration) []Registration {
+				registrations[0].identity = " Bad Identity "
+				return registrations
+			},
+			want: []string{`"bad identity": manifest binding identity is invalid`, `"bad identity": implementation has no matching manifest`, `"claude": supported bundled manifest has no matching implementation`},
+		},
+		{
+			name: "not supported implementation",
+			mutate: func(registrations []Registration) []Registration {
+				agy := findManifest(t, publishedCatalog(t), "agy")
+				return append(registrations, CatalogRegistration("agy", integrationFor(agy)))
+			},
+			want: []string{`"agy": non-selectable manifest cannot have a runnable integration`},
+		},
+		{
+			name: "external manifest claims bundled availability",
+			mutate: func(registrations []Registration) []Registration {
+				manifest := externalManifest(t, "customer.provider", "customer")
+				manifest.ImplementationAvailability = ImplementationBundled
+				return append(registrations, ExternalRegistration(manifest, integrationFor(manifest)))
+			},
+			want: []string{`"customer.provider": external manifest implementation availability must be externally-supplied`},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := New(test.mutate(supportedCatalogRegistrations(t))...)
+			assertErrorContains(t, err, test.want...)
+		})
+	}
+}
+
+func TestNewRejectsCoverageAndCapabilityContradictions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func([]Registration) []Registration
+		want   string
+	}{
+		{
+			name: "missing bundled implementation",
+			mutate: func(registrations []Registration) []Registration {
+				return registrations[1:]
+			},
+			want: `"claude": supported bundled manifest has no matching implementation`,
+		},
+		{
+			name: "implementation without manifest",
+			mutate: func(registrations []Registration) []Registration {
+				return append(registrations, CatalogRegistration("missing", &fakeIntegration{
+					identity: "missing",
+					maximum:  inference.NewCapabilitySet(inference.CapabilityPromptSubmission),
+				}))
+			},
+			want: `"missing": implementation has no matching manifest`,
+		},
+		{
+			name: "maximum exceeds manifest",
+			mutate: func(registrations []Registration) []Registration {
+				current := registrations[0].integration.MaximumCapabilities().Values()
+				current = append(current, inference.CapabilityProviderReconnect)
+				registrations[0].integration = &fakeIntegration{identity: "claude", maximum: inference.NewCapabilitySet(current...)}
+				return registrations
+			},
+			want: `"claude": integration maximum exceeds manifest maximum: provider_reconnect`,
+		},
+		{
+			name: "maximum contradicts manifest",
+			mutate: func(registrations []Registration) []Registration {
+				registrations[0].integration = &fakeIntegration{
+					identity: "claude",
+					maximum:  inference.NewCapabilitySet(inference.CapabilityPromptSubmission),
+				}
+				return registrations
+			},
+			want: `"claude": integration maximum contradicts manifest maximum by omitting: message_deltas`,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := New(test.mutate(supportedCatalogRegistrations(t))...)
+			assertErrorContains(t, err, test.want)
+		})
+	}
+}
+
+func TestNewRejectsEveryIdentityCollisionIndependentOfInputOrder(t *testing.T) {
+	t.Parallel()
+
+	base := supportedCatalogRegistrations(t)
+	first := externalManifest(t, "customer.one", "customer-alias")
+	second := externalManifest(t, "customer.two", "customer-alias")
+	third := externalManifest(t, "agent", "third-alias")
+	fourth := externalManifest(t, "customer.one", "fourth-alias")
+	additions := []Registration{
+		ExternalRegistration(first, integrationFor(first)),
+		ExternalRegistration(second, integrationFor(second)),
+		ExternalRegistration(third, integrationFor(third)),
+		ExternalRegistration(fourth, integrationFor(fourth)),
+	}
+
+	var want string
+	for seed := int64(0); seed < 20; seed++ {
+		permuted := append([]Registration(nil), additions...)
+		rand.New(rand.NewSource(seed)).Shuffle(len(permuted), func(i, j int) {
+			permuted[i], permuted[j] = permuted[j], permuted[i]
+		})
+		_, err := New(append(append([]Registration(nil), base...), permuted...)...)
+		if err == nil {
+			t.Fatal("New() error = nil")
+		}
+		if seed == 0 {
+			want = err.Error()
+		} else if err.Error() != want {
+			t.Fatalf("seed %d error differs\n got: %s\nwant: %s", seed, err, want)
+		}
+	}
+	assertErrorContains(t, errorString(want),
+		`"agent": identity collision between alias of "cursor", canonical "agent"`,
+		`"customer-alias": identity collision between alias of "customer.one", alias of "customer.two"`,
+		`"customer.one": identity collision between canonical "customer.one", canonical "customer.one"`,
+	)
+}
+
+func TestNewRejectsMalformedExternalManifestWithStableDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	manifest := externalManifest(t, "customer.valid", "customer-alias")
+	manifest.ID = " INVALID "
+	registrations := append(supportedCatalogRegistrations(t), ExternalRegistration(manifest, &fakeIntegration{
+		identity: "invalid",
+		maximum:  inference.NewCapabilitySet(inference.CapabilityPromptSubmission),
+	}))
+	_, err := New(registrations...)
+	assertErrorContains(t, err,
+		`"invalid": external manifest violates the published schema`,
+	)
+}
+
+func supportedCatalogRegistrations(t *testing.T) []Registration {
+	t.Helper()
+	var registrations []Registration
+	for _, manifest := range publishedCatalog(t) {
+		if manifest.TechnicalSupportLevel == SupportNotSupported ||
+			manifest.ImplementationAvailability == ImplementationCatalogOnly {
+			continue
+		}
+		registrations = append(registrations, CatalogRegistration(inference.Identity(manifest.ID), integrationFor(manifest)))
+	}
+	return registrations
+}
+
+func externalManifest(t *testing.T, identity, alias string) Manifest {
+	t.Helper()
+	manifest := cloneManifest(findManifest(t, publishedCatalog(t), "codex"))
+	manifest.ID = identity
+	manifest.Aliases = []string{alias}
+	manifest.ImplementationAvailability = ImplementationExternallySupplied
+	return manifest
+}
+
+func publishedCatalog(t *testing.T) []Manifest {
+	t.Helper()
+	var catalog catalogDocument
+	if err := json.Unmarshal(modelproviders.CatalogJSON(), &catalog); err != nil {
+		t.Fatalf("parse published catalog: %v", err)
+	}
+	return catalog.Providers
+}
+
+func findManifest(t *testing.T, manifests []Manifest, identity string) Manifest {
+	t.Helper()
+	for _, manifest := range manifests {
+		if manifest.ID == identity {
+			return manifest
+		}
+	}
+	t.Fatalf("manifest %q not found", identity)
+	return Manifest{}
+}
+
+func integrationFor(manifest Manifest) inference.Integration {
+	return &fakeIntegration{
+		identity: inference.Identity(manifest.ID),
+		maximum:  manifestCapabilities(manifest),
+	}
+}
+
+func assertErrorContains(t *testing.T, err error, fragments ...string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("error = nil")
+	}
+	for _, fragment := range fragments {
+		if !strings.Contains(err.Error(), fragment) {
+			t.Fatalf("error %q does not contain %q", err, fragment)
+		}
+	}
+}
+
+type errorString string
+
+func (e errorString) Error() string { return string(e) }

--- a/pkg/services/workers/provider/registry/registry_test.go
+++ b/pkg/services/workers/provider/registry/registry_test.go
@@ -276,6 +276,55 @@ func TestNewRejectsEveryIdentityCollisionIndependentOfInputOrder(t *testing.T) {
 	)
 }
 
+func TestNewRejectsCompatibilityAliasCollisions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		identity string
+		alias    string
+		want     string
+	}{
+		{
+			name:     "openai canonical shadows compatibility alias",
+			identity: "openai",
+			alias:    "customer-openai",
+			want:     `"openai": identity collision between canonical "openai", compatibility alias of "codex"`,
+		},
+		{
+			name:     "anthropic canonical shadows compatibility alias",
+			identity: "anthropic",
+			alias:    "customer-anthropic",
+			want:     `"anthropic": identity collision between canonical "anthropic", compatibility alias of "claude"`,
+		},
+		{
+			name:     "external alias shadows openai compatibility alias",
+			identity: "customer.openai",
+			alias:    "openai",
+			want:     `"openai": identity collision between alias of "customer.openai", compatibility alias of "codex"`,
+		},
+		{
+			name:     "external alias shadows anthropic compatibility alias",
+			identity: "customer.anthropic",
+			alias:    "anthropic",
+			want:     `"anthropic": identity collision between alias of "customer.anthropic", compatibility alias of "claude"`,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			manifest := externalManifest(t, test.identity, test.alias)
+			registrations := append(
+				supportedCatalogRegistrations(t),
+				ExternalRegistration(manifest, integrationFor(manifest)),
+			)
+			_, err := New(registrations...)
+			assertErrorContains(t, err, test.want)
+		})
+	}
+}
+
 func TestNewRejectsMalformedExternalManifestWithStableDiagnostics(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/workers/provider/registry/routing.go
+++ b/pkg/services/workers/provider/registry/routing.go
@@ -1,0 +1,172 @@
+package registry
+
+import (
+	"fmt"
+	"strings"
+
+	platformprocess "github.com/portpowered/infinite-you/pkg/platform/process"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+)
+
+const legacyCursorRunnerID = workers.RunnerIDCursorCLI
+
+// ResolveRunnerSelection applies the existing runner precedence while using
+// registry identity and selectability as the authority for every non-empty
+// provider value.
+func (r *Registry) ResolveRunnerSelection(
+	workstationRunner string,
+	factoryRunner string,
+	workerModelProvider string,
+) (workers.ResolvedRunnerSelection, error) {
+	candidates := []struct {
+		identity string
+		source   workers.RunnerSelectionSource
+	}{
+		{workstationRunner, workers.RunnerSelectionSourceWorkstation},
+		{factoryRunner, workers.RunnerSelectionSourceFactory},
+		{workerModelProvider, workers.RunnerSelectionSourceLegacyProvider},
+	}
+	for _, candidate := range candidates {
+		if strings.TrimSpace(candidate.identity) == "" {
+			continue
+		}
+		runnerID, err := r.RunnerID(candidate.identity)
+		if err != nil {
+			return workers.ResolvedRunnerSelection{}, err
+		}
+		return workers.ResolvedRunnerSelection{RunnerID: runnerID, Source: candidate.source}, nil
+	}
+	runnerID, err := r.RunnerID(workers.RunnerIDCodex)
+	if err != nil {
+		return workers.ResolvedRunnerSelection{}, fmt.Errorf("resolve default provider: %w", err)
+	}
+	return workers.ResolvedRunnerSelection{
+		RunnerID: runnerID,
+		Source:   workers.RunnerSelectionSourceDefault,
+	}, nil
+}
+
+// RunnerID resolves a provider canonical ID or alias to the stable native
+// runner ID retained by the current execution path.
+func (r *Registry) RunnerID(identity string) (string, error) {
+	lookup := strings.TrimSpace(identity)
+	if normalize(lookup) == legacyCursorRunnerID {
+		lookup = "cursor"
+	}
+	entry, err := r.Lookup(lookup)
+	if err != nil {
+		return "", err
+	}
+	canonical := string(entry.Identity())
+	if entry.Manifest().ImplementationAvailability != ImplementationBundled {
+		return "", fmt.Errorf(
+			"provider %q is not available through the provider-native runner path",
+			canonical,
+		)
+	}
+	if canonical == "cursor" {
+		return legacyCursorRunnerID, nil
+	}
+	return canonical, nil
+}
+
+// RunnerMetadata projects manifest-authoritative execution capabilities onto
+// the existing runner diagnostic contract.
+func (r *Registry) RunnerMetadata(identity string) (workers.RunnerMetadata, error) {
+	lookup := strings.TrimSpace(identity)
+	if normalize(lookup) == legacyCursorRunnerID {
+		lookup = "cursor"
+	}
+	entry, err := r.Lookup(lookup)
+	if err != nil {
+		return workers.RunnerMetadata{}, err
+	}
+	manifest := entry.Manifest()
+	runnerID := string(entry.Identity())
+	if runnerID == "cursor" {
+		runnerID = legacyCursorRunnerID
+	}
+	execution := manifest.MaximumExecutionCapabilities
+	return workers.RunnerMetadata{
+		ID:          runnerID,
+		DisplayName: manifest.DisplayName.Value,
+		Capabilities: workers.RunnerCapabilities{
+			Baseline: baselineRunnerCapabilities(execution),
+			Optional: optionalRunnerCapabilities(execution, runnerID),
+		},
+	}, nil
+}
+
+// ValidateRunnerPrerequisites checks the manifest-declared executable
+// prerequisites without executing a provider command.
+func (r *Registry) ValidateRunnerPrerequisites(
+	locator platformprocess.ExecutableLocator,
+	identity string,
+) error {
+	lookup := strings.TrimSpace(identity)
+	if normalize(lookup) == legacyCursorRunnerID {
+		lookup = "cursor"
+	}
+	entry, err := r.Lookup(lookup)
+	if err != nil {
+		return err
+	}
+	if locator == nil {
+		return fmt.Errorf("%s runner executable locator is required", entry.Manifest().DisplayName.Value)
+	}
+	for _, command := range entry.DiscoveryPrerequisites().ExecutableNames {
+		if _, err := locator.LookPath(command); err != nil {
+			return fmt.Errorf(
+				"%s runner requires %q on PATH: %w",
+				entry.Manifest().DisplayName.Value,
+				command,
+				err,
+			)
+		}
+	}
+	return nil
+}
+
+func baselineRunnerCapabilities(execution ExecutionCapabilities) []workers.RunnerBaselineCapability {
+	capabilities := make([]workers.RunnerBaselineCapability, 0, 2)
+	if execution.PromptSubmission {
+		capabilities = append(capabilities, workers.RunnerBaselineCapabilityPromptSubmission)
+	}
+	if execution.ToolExecution {
+		capabilities = append(capabilities, workers.RunnerBaselineCapabilityToolExecution)
+	}
+	return capabilities
+}
+
+func optionalRunnerCapabilities(
+	execution ExecutionCapabilities,
+	runnerID string,
+) []workers.RunnerOptionalCapabilitySupport {
+	values := []struct {
+		capability workers.RunnerOptionalCapability
+		supported  bool
+	}{
+		{workers.RunnerOptionalCapabilityImageInput, execution.ImageInput},
+		{workers.RunnerOptionalCapabilitySessionResume, execution.SessionResume},
+		{workers.RunnerOptionalCapabilityStructuredOutput, execution.StructuredOutput},
+		{workers.RunnerOptionalCapabilityWorkingDirectory, execution.WorkingDirectory},
+		{workers.RunnerOptionalCapabilityWorktree, execution.Worktree},
+	}
+	result := make([]workers.RunnerOptionalCapabilitySupport, 0, len(values))
+	for _, value := range values {
+		status := workers.RunnerOptionalCapabilityStatusUnsupported
+		if value.supported {
+			status = workers.RunnerOptionalCapabilityStatusSupported
+		}
+		support := workers.RunnerOptionalCapabilitySupport{
+			Capability: value.capability,
+			Status:     status,
+		}
+		if runnerID == workers.RunnerIDCodex &&
+			value.capability == workers.RunnerOptionalCapabilityWorktree {
+			support.Detail = "factory-managed git worktree preparation under the factory root"
+		}
+		result = append(result, support)
+	}
+	return result
+}

--- a/pkg/services/workers/provider/registry/routing.go
+++ b/pkg/services/workers/provider/registry/routing.go
@@ -10,6 +10,11 @@ import (
 
 const legacyCursorRunnerID = workers.RunnerIDCursorCLI
 
+var legacyNativeProviderAliases = map[string]string{
+	"anthropic": "claude",
+	"openai":    "codex",
+}
+
 // ResolveRunnerSelection applies the existing runner precedence while using
 // registry identity and selectability as the authority for every non-empty
 // provider value.
@@ -30,6 +35,10 @@ func (r *Registry) ResolveRunnerSelection(
 		if strings.TrimSpace(candidate.identity) == "" {
 			continue
 		}
+		if candidate.source == workers.RunnerSelectionSourceLegacyProvider &&
+			isUnresolvedProviderTemplate(candidate.identity) {
+			continue
+		}
 		runnerID, err := r.RunnerID(candidate.identity)
 		if err != nil {
 			return workers.ResolvedRunnerSelection{}, err
@@ -46,12 +55,20 @@ func (r *Registry) ResolveRunnerSelection(
 	}, nil
 }
 
+func isUnresolvedProviderTemplate(identity string) bool {
+	trimmed := strings.TrimSpace(identity)
+	return strings.HasPrefix(trimmed, "${") && strings.HasSuffix(trimmed, "}")
+}
+
 // RunnerID resolves a provider canonical ID or alias to the stable native
 // runner ID retained by the current execution path.
 func (r *Registry) RunnerID(identity string) (string, error) {
 	lookup := strings.TrimSpace(identity)
 	if normalize(lookup) == legacyCursorRunnerID {
 		lookup = "cursor"
+	}
+	if target, ok := legacyNativeProviderAliases[normalize(lookup)]; ok {
+		lookup = target
 	}
 	entry, err := r.Lookup(lookup)
 	if err != nil {

--- a/pkg/services/workers/provider/registry/routing.go
+++ b/pkg/services/workers/provider/registry/routing.go
@@ -10,9 +10,17 @@ import (
 
 const legacyCursorRunnerID = workers.RunnerIDCursorCLI
 
-var legacyNativeProviderAliases = map[string]string{
-	"anthropic": "claude",
-	"openai":    "codex",
+type compatibilityAlias struct {
+	alias     string
+	canonical string
+}
+
+func providerCompatibilityAliases() []compatibilityAlias {
+	return []compatibilityAlias{
+		{alias: "anthropic", canonical: "claude"},
+		{alias: legacyCursorRunnerID, canonical: "cursor"},
+		{alias: "openai", canonical: "codex"},
+	}
 }
 
 // ResolveRunnerSelection applies the existing runner precedence while using
@@ -63,14 +71,7 @@ func isUnresolvedProviderTemplate(identity string) bool {
 // RunnerID resolves a provider canonical ID or alias to the stable native
 // runner ID retained by the current execution path.
 func (r *Registry) RunnerID(identity string) (string, error) {
-	lookup := strings.TrimSpace(identity)
-	if normalize(lookup) == legacyCursorRunnerID {
-		lookup = "cursor"
-	}
-	if target, ok := legacyNativeProviderAliases[normalize(lookup)]; ok {
-		lookup = target
-	}
-	entry, err := r.Lookup(lookup)
+	entry, err := r.Lookup(identity)
 	if err != nil {
 		return "", err
 	}
@@ -90,11 +91,7 @@ func (r *Registry) RunnerID(identity string) (string, error) {
 // RunnerMetadata projects manifest-authoritative execution capabilities onto
 // the existing runner diagnostic contract.
 func (r *Registry) RunnerMetadata(identity string) (workers.RunnerMetadata, error) {
-	lookup := strings.TrimSpace(identity)
-	if normalize(lookup) == legacyCursorRunnerID {
-		lookup = "cursor"
-	}
-	entry, err := r.Lookup(lookup)
+	entry, err := r.Lookup(identity)
 	if err != nil {
 		return workers.RunnerMetadata{}, err
 	}
@@ -120,11 +117,7 @@ func (r *Registry) ValidateRunnerPrerequisites(
 	locator platformprocess.ExecutableLocator,
 	identity string,
 ) error {
-	lookup := strings.TrimSpace(identity)
-	if normalize(lookup) == legacyCursorRunnerID {
-		lookup = "cursor"
-	}
-	entry, err := r.Lookup(lookup)
+	entry, err := r.Lookup(identity)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/workers/provider/registry/routing_test.go
+++ b/pkg/services/workers/provider/registry/routing_test.go
@@ -50,6 +50,18 @@ func TestResolveRunnerSelectionUsesRegistryIdentityAndPrecedence(t *testing.T) {
 			wantSource: workers.RunnerSelectionSourceFactory,
 		},
 		{
+			name:       "legacy public model provider alias",
+			worker:     "openai",
+			wantID:     workers.RunnerIDCodex,
+			wantSource: workers.RunnerSelectionSourceLegacyProvider,
+		},
+		{
+			name:       "legacy anthropic model provider alias",
+			worker:     "anthropic",
+			wantID:     "claude",
+			wantSource: workers.RunnerSelectionSourceLegacyProvider,
+		},
+		{
 			name:       "legacy cursor runner compatibility",
 			worker:     workers.RunnerIDCursorCLI,
 			wantID:     workers.RunnerIDCursorCLI,
@@ -57,6 +69,12 @@ func TestResolveRunnerSelectionUsesRegistryIdentityAndPrecedence(t *testing.T) {
 		},
 		{
 			name:       "default",
+			wantID:     workers.RunnerIDCodex,
+			wantSource: workers.RunnerSelectionSourceDefault,
+		},
+		{
+			name:       "unresolved authored provider template defers to runtime default",
+			worker:     "${branchProvider}",
 			wantID:     workers.RunnerIDCodex,
 			wantSource: workers.RunnerSelectionSourceDefault,
 		},

--- a/pkg/services/workers/provider/registry/routing_test.go
+++ b/pkg/services/workers/provider/registry/routing_test.go
@@ -1,0 +1,202 @@
+package registry
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+)
+
+type recordingExecutableLocator struct {
+	commands []string
+	missing  string
+}
+
+func (l *recordingExecutableLocator) LookPath(command string) (string, error) {
+	l.commands = append(l.commands, command)
+	if command == l.missing {
+		return "", errors.New("not found")
+	}
+	return "/bin/" + command, nil
+}
+
+func TestResolveRunnerSelectionUsesRegistryIdentityAndPrecedence(t *testing.T) {
+	t.Parallel()
+	providers := newBuiltInRegistry(t)
+
+	tests := []struct {
+		name        string
+		workstation string
+		factory     string
+		worker      string
+		wantID      string
+		wantSource  workers.RunnerSelectionSource
+	}{
+		{
+			name:        "manifest alias",
+			workstation: " AGENT ",
+			factory:     "gemini",
+			worker:      "claude",
+			wantID:      workers.RunnerIDCursorCLI,
+			wantSource:  workers.RunnerSelectionSourceWorkstation,
+		},
+		{
+			name:       "published alias",
+			factory:    "kiro-cli",
+			worker:     "claude",
+			wantID:     workers.RunnerIDKiro,
+			wantSource: workers.RunnerSelectionSourceFactory,
+		},
+		{
+			name:       "legacy cursor runner compatibility",
+			worker:     workers.RunnerIDCursorCLI,
+			wantID:     workers.RunnerIDCursorCLI,
+			wantSource: workers.RunnerSelectionSourceLegacyProvider,
+		},
+		{
+			name:       "default",
+			wantID:     workers.RunnerIDCodex,
+			wantSource: workers.RunnerSelectionSourceDefault,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := providers.ResolveRunnerSelection(test.workstation, test.factory, test.worker)
+			if err != nil {
+				t.Fatalf("ResolveRunnerSelection() error = %v", err)
+			}
+			if got.RunnerID != test.wantID || got.Source != test.wantSource {
+				t.Fatalf("ResolveRunnerSelection() = %#v, want id=%q source=%q", got, test.wantID, test.wantSource)
+			}
+		})
+	}
+}
+
+func TestResolveRunnerSelectionRejectsUnknownAndNonSelectableWithoutFallback(t *testing.T) {
+	t.Parallel()
+	providers := newBuiltInRegistry(t)
+
+	for _, identity := range []string{"unknown", "agy"} {
+		identity := identity
+		t.Run(identity, func(t *testing.T) {
+			t.Parallel()
+			_, err := providers.ResolveRunnerSelection("", "", identity)
+			if err == nil || !strings.Contains(err.Error(), `provider "`+identity+`"`) {
+				t.Fatalf("ResolveRunnerSelection(%q) error = %v", identity, err)
+			}
+		})
+	}
+}
+
+func TestResolveRunnerSelectionRejectsExternalIntegrationOnNativeRunnerPath(t *testing.T) {
+	t.Parallel()
+	registrations, err := BuiltInRegistrations()
+	if err != nil {
+		t.Fatalf("BuiltInRegistrations() error = %v", err)
+	}
+	manifest := externalManifest(t, "customer.provider", "customer")
+	registrations = append(registrations, ExternalRegistration(manifest, integrationFor(manifest)))
+	providers, err := New(registrations...)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	_, err = providers.ResolveRunnerSelection("customer", "", "")
+	if err == nil || !strings.Contains(err.Error(), "not available through the provider-native runner path") {
+		t.Fatalf("ResolveRunnerSelection(external) error = %v", err)
+	}
+	if _, err := providers.Integration("customer"); err != nil {
+		t.Fatalf("Integration(external) error = %v", err)
+	}
+}
+
+func TestRunnerMetadataUsesManifestCapabilities(t *testing.T) {
+	t.Parallel()
+	providers := newBuiltInRegistry(t)
+
+	metadata, err := providers.RunnerMetadata("codex")
+	if err != nil {
+		t.Fatalf("RunnerMetadata() error = %v", err)
+	}
+	if metadata.ID != workers.RunnerIDCodex || metadata.DisplayName != "Codex" {
+		t.Fatalf("RunnerMetadata() = %#v", metadata)
+	}
+	wantBaseline := []workers.RunnerBaselineCapability{
+		workers.RunnerBaselineCapabilityPromptSubmission,
+		workers.RunnerBaselineCapabilityToolExecution,
+	}
+	if !reflect.DeepEqual(metadata.Capabilities.Baseline, wantBaseline) {
+		t.Fatalf("baseline = %#v, want %#v", metadata.Capabilities.Baseline, wantBaseline)
+	}
+	assertOptionalCapabilityStatus(
+		t,
+		metadata,
+		workers.RunnerOptionalCapabilityStructuredOutput,
+		workers.RunnerOptionalCapabilityStatusSupported,
+	)
+
+	gemini, err := providers.RunnerMetadata("gemini")
+	if err != nil {
+		t.Fatalf("RunnerMetadata(gemini) error = %v", err)
+	}
+	assertOptionalCapabilityStatus(
+		t,
+		gemini,
+		workers.RunnerOptionalCapabilitySessionResume,
+		workers.RunnerOptionalCapabilityStatusUnsupported,
+	)
+}
+
+func TestValidateRunnerPrerequisitesUsesManifestExecutableAndAlias(t *testing.T) {
+	t.Parallel()
+	providers := newBuiltInRegistry(t)
+	locator := &recordingExecutableLocator{}
+
+	if err := providers.ValidateRunnerPrerequisites(locator, "agent"); err != nil {
+		t.Fatalf("ValidateRunnerPrerequisites() error = %v", err)
+	}
+	if !reflect.DeepEqual(locator.commands, []string{"agent"}) {
+		t.Fatalf("commands = %#v, want manifest executable", locator.commands)
+	}
+
+	locator.missing = "kiro-cli"
+	err := providers.ValidateRunnerPrerequisites(locator, "kiro")
+	if err == nil || !strings.Contains(err.Error(), `requires "kiro-cli" on PATH`) {
+		t.Fatalf("ValidateRunnerPrerequisites(kiro) error = %v", err)
+	}
+}
+
+func assertOptionalCapabilityStatus(
+	t *testing.T,
+	metadata workers.RunnerMetadata,
+	capability workers.RunnerOptionalCapability,
+	want workers.RunnerOptionalCapabilityStatus,
+) {
+	t.Helper()
+	for _, support := range metadata.Capabilities.Optional {
+		if support.Capability == capability {
+			if support.Status != want {
+				t.Fatalf("%s status = %q, want %q", capability, support.Status, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("metadata missing optional capability %q", capability)
+}
+
+func newBuiltInRegistry(t *testing.T) *Registry {
+	t.Helper()
+	registrations, err := BuiltInRegistrations()
+	if err != nil {
+		t.Fatalf("BuiltInRegistrations() error = %v", err)
+	}
+	providers, err := New(registrations...)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	return providers
+}

--- a/pkg/services/workers/provider/registry/routing_test.go
+++ b/pkg/services/workers/provider/registry/routing_test.go
@@ -94,6 +94,45 @@ func TestResolveRunnerSelectionUsesRegistryIdentityAndPrecedence(t *testing.T) {
 	}
 }
 
+func TestCompatibilityAliasesUseRegistryIdentityAuthority(t *testing.T) {
+	t.Parallel()
+	providers := newBuiltInRegistry(t)
+
+	tests := []struct {
+		alias         string
+		wantCanonical string
+		wantRunner    string
+	}{
+		{alias: "anthropic", wantCanonical: "claude", wantRunner: "claude"},
+		{alias: workers.RunnerIDCursorCLI, wantCanonical: "cursor", wantRunner: workers.RunnerIDCursorCLI},
+		{alias: "openai", wantCanonical: "codex", wantRunner: workers.RunnerIDCodex},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.alias, func(t *testing.T) {
+			t.Parallel()
+			canonical, err := providers.CanonicalIdentity(test.alias)
+			if err != nil {
+				t.Fatalf("CanonicalIdentity(%q) error = %v", test.alias, err)
+			}
+			runner, err := providers.RunnerID(test.alias)
+			if err != nil {
+				t.Fatalf("RunnerID(%q) error = %v", test.alias, err)
+			}
+			if canonical != test.wantCanonical || runner != test.wantRunner {
+				t.Fatalf(
+					"compatibility identity %q = (canonical %q, runner %q), want (%q, %q)",
+					test.alias,
+					canonical,
+					runner,
+					test.wantCanonical,
+					test.wantRunner,
+				)
+			}
+		})
+	}
+}
+
 func TestResolveRunnerSelectionRejectsUnknownAndNonSelectableWithoutFallback(t *testing.T) {
 	t.Parallel()
 	providers := newBuiltInRegistry(t)

--- a/pkg/services/workers/provider/registry/validation.go
+++ b/pkg/services/workers/provider/registry/validation.go
@@ -55,9 +55,11 @@ func validateSchema(schemaPayload, document []byte) error {
 
 func validateIdentityClaims(candidates []manifestCandidate) []string {
 	claims := make(map[string][]string)
+	canonicalIdentities := make(map[string]struct{}, len(candidates))
 	var violations []string
 	for _, candidate := range candidates {
 		canonical := normalize(candidate.manifest.ID)
+		canonicalIdentities[canonical] = struct{}{}
 		if err := inference.ValidateIdentity(inference.Identity(canonical)); err != nil {
 			violations = append(violations, identityLabel(canonical)+": manifest identity is invalid: "+err.Error())
 		}
@@ -70,6 +72,7 @@ func validateIdentityClaims(candidates []manifestCandidate) []string {
 			claims[alias] = append(claims[alias], "alias of "+identityLabel(canonical))
 		}
 	}
+	addCompatibilityIdentityClaims(claims, canonicalIdentities)
 	for identity, owners := range claims {
 		if len(owners) < 2 {
 			continue
@@ -79,6 +82,18 @@ func validateIdentityClaims(candidates []manifestCandidate) []string {
 		violations = append(violations, fmt.Sprintf("%s: identity collision between %s", identityLabel(identity), strings.Join(sortedOwners, ", ")))
 	}
 	return violations
+}
+
+func addCompatibilityIdentityClaims(claims map[string][]string, canonicalIdentities map[string]struct{}) {
+	for _, compatibility := range providerCompatibilityAliases() {
+		if _, exists := canonicalIdentities[compatibility.canonical]; !exists {
+			continue
+		}
+		claims[compatibility.alias] = append(
+			claims[compatibility.alias],
+			"compatibility alias of "+identityLabel(compatibility.canonical),
+		)
+	}
 }
 
 func validateMaximumCapabilities(identity string, manifest Manifest, integration inference.Integration) []string {

--- a/pkg/services/workers/provider/registry/validation.go
+++ b/pkg/services/workers/provider/registry/validation.go
@@ -1,0 +1,157 @@
+package registry
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	modelproviders "github.com/portpowered/infinite-you/packages/model-providers"
+	inference "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+func validationFailure(violations []string) error {
+	return fmt.Errorf("provider registry validation failed: %s", strings.Join(sortedUnique(violations), "; "))
+}
+
+func validateManifestSchema(manifest Manifest) error {
+	payload, err := json.Marshal(manifest)
+	if err != nil {
+		return fmt.Errorf("serialize manifest: %w", err)
+	}
+	return validateSchema(modelproviders.ProviderManifestSchemaJSON(), payload)
+}
+
+func validateSchema(schemaPayload, document []byte) error {
+	schemaDocument, err := jsonschema.UnmarshalJSON(bytes.NewReader(schemaPayload))
+	if err != nil {
+		return fmt.Errorf("parse schema: %w", err)
+	}
+	schemaObject, ok := schemaDocument.(map[string]any)
+	if !ok {
+		return fmt.Errorf("parse schema: root must be an object")
+	}
+	schemaID, _ := schemaObject["$id"].(string)
+	compiler := jsonschema.NewCompiler()
+	compiler.DefaultDraft(jsonschema.Draft2020)
+	if err := compiler.AddResource(schemaID, schemaObject); err != nil {
+		return fmt.Errorf("load schema: %w", err)
+	}
+	schema, err := compiler.Compile(schemaID)
+	if err != nil {
+		return fmt.Errorf("compile schema: %w", err)
+	}
+	value, err := jsonschema.UnmarshalJSON(bytes.NewReader(document))
+	if err != nil {
+		return fmt.Errorf("parse document: %w", err)
+	}
+	if err := schema.Validate(value); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateIdentityClaims(candidates []manifestCandidate) []string {
+	claims := make(map[string][]string)
+	var violations []string
+	for _, candidate := range candidates {
+		canonical := normalize(candidate.manifest.ID)
+		if err := inference.ValidateIdentity(inference.Identity(canonical)); err != nil {
+			violations = append(violations, identityLabel(canonical)+": manifest identity is invalid: "+err.Error())
+		}
+		claims[canonical] = append(claims[canonical], "canonical "+identityLabel(canonical))
+		for _, rawAlias := range candidate.manifest.Aliases {
+			alias := normalize(rawAlias)
+			if err := inference.ValidateIdentity(inference.Identity(alias)); err != nil {
+				violations = append(violations, identityLabel(alias)+": manifest alias is invalid: "+err.Error())
+			}
+			claims[alias] = append(claims[alias], "alias of "+identityLabel(canonical))
+		}
+	}
+	for identity, owners := range claims {
+		if len(owners) < 2 {
+			continue
+		}
+		sortedOwners := append([]string(nil), owners...)
+		sort.Strings(sortedOwners)
+		violations = append(violations, fmt.Sprintf("%s: identity collision between %s", identityLabel(identity), strings.Join(sortedOwners, ", ")))
+	}
+	return violations
+}
+
+func validateMaximumCapabilities(identity string, manifest Manifest, integration inference.Integration) []string {
+	maximum := integration.MaximumCapabilities()
+	if err := inference.ValidateMaximumCapabilities(maximum); err != nil {
+		return []string{identityLabel(identity) + ": integration maximum capabilities are invalid: " + err.Error()}
+	}
+	manifestMaximum := manifestCapabilities(manifest)
+	var exceeded []string
+	var omitted []string
+	for _, capability := range allManifestCapabilities() {
+		integrationHas := maximum.Has(capability)
+		manifestHas := manifestMaximum.Has(capability)
+		if integrationHas && !manifestHas {
+			exceeded = append(exceeded, string(capability))
+		}
+		if manifestHas && !integrationHas {
+			omitted = append(omitted, string(capability))
+		}
+	}
+	var violations []string
+	if len(exceeded) > 0 {
+		violations = append(violations, fmt.Sprintf("%s: integration maximum exceeds manifest maximum: %s", identityLabel(identity), strings.Join(sortedUnique(exceeded), ", ")))
+	}
+	if len(omitted) > 0 {
+		violations = append(violations, fmt.Sprintf("%s: integration maximum contradicts manifest maximum by omitting: %s", identityLabel(identity), strings.Join(sortedUnique(omitted), ", ")))
+	}
+	return violations
+}
+
+func manifestCapabilities(manifest Manifest) inference.CapabilitySet {
+	execution := manifest.MaximumExecutionCapabilities
+	response := manifest.MaximumResponseFidelityCapabilities
+	values := make([]inference.Capability, 0, len(allManifestCapabilities()))
+	appendIf := func(enabled bool, capability inference.Capability) {
+		if enabled {
+			values = append(values, capability)
+		}
+	}
+	appendIf(execution.PromptSubmission, inference.CapabilityPromptSubmission)
+	appendIf(execution.ImageInput, inference.CapabilityImageInput)
+	appendIf(execution.SessionResume, inference.CapabilitySessionResume)
+	appendIf(execution.StructuredOutput, inference.CapabilityStructuredOutput)
+	appendIf(response.NativeStreaming, inference.CapabilityNativeStreaming)
+	appendIf(response.MessageDeltas, inference.CapabilityMessageDeltas)
+	appendIf(response.MessageSnapshots, inference.CapabilityMessageSnapshots)
+	appendIf(response.ReasoningSummaries, inference.CapabilityReasoningSummaries)
+	appendIf(response.ToolLifecycle, inference.CapabilityToolLifecycle)
+	appendIf(response.ToolOutputDeltas, inference.CapabilityToolOutputDeltas)
+	appendIf(response.FileChanges, inference.CapabilityFileChanges)
+	appendIf(response.Plans, inference.CapabilityPlans)
+	appendIf(response.Usage, inference.CapabilityUsage)
+	appendIf(response.StableItemIDs, inference.CapabilityStableItemIDs)
+	appendIf(response.ProviderReconnect, inference.CapabilityProviderReconnect)
+	return inference.NewCapabilitySet(values...)
+}
+
+func allManifestCapabilities() []inference.Capability {
+	return []inference.Capability{
+		inference.CapabilityPromptSubmission,
+		inference.CapabilityImageInput,
+		inference.CapabilitySessionResume,
+		inference.CapabilityStructuredOutput,
+		inference.CapabilityNativeStreaming,
+		inference.CapabilityMessageDeltas,
+		inference.CapabilityMessageSnapshots,
+		inference.CapabilityReasoningSummaries,
+		inference.CapabilityToolLifecycle,
+		inference.CapabilityToolOutputDeltas,
+		inference.CapabilityFileChanges,
+		inference.CapabilityPlans,
+		inference.CapabilityUsage,
+		inference.CapabilityStableItemIDs,
+		inference.CapabilityProviderReconnect,
+	}
+}

--- a/pkg/services/workers/service/composition.go
+++ b/pkg/services/workers/service/composition.go
@@ -14,9 +14,11 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
 	"github.com/portpowered/infinite-you/pkg/services/workers/agypty"
+	workerconstruction "github.com/portpowered/infinite-you/pkg/services/workers/construction"
 	modelrecording "github.com/portpowered/infinite-you/pkg/services/workers/execution/recording"
 	workeragentrun "github.com/portpowered/infinite-you/pkg/services/workers/executor/agentrun"
 	workerprovider "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+	providerregistry "github.com/portpowered/infinite-you/pkg/services/workers/provider/registry"
 	hostedworkers "github.com/portpowered/infinite-you/pkg/services/workers/services/hosted_logic"
 	hostedlinear "github.com/portpowered/infinite-you/pkg/services/workers/services/hosted_logic/linear"
 	mockworker "github.com/portpowered/infinite-you/pkg/services/workers/services/testing"
@@ -121,6 +123,7 @@ func NewRuntimeWithSelection(
 	decisionEnvelopes factorydefinitions.DecisionEnvelopeService,
 	providerCommandInjected bool,
 	scriptCommandInjected bool,
+	providerRegistry *providerregistry.Registry,
 ) (workers.RuntimeService, error) {
 	runtimeService, err := NewRuntime(
 		sessions, modelService, providerCommandRunner, scriptCommandRunner,
@@ -135,6 +138,12 @@ func NewRuntimeWithSelection(
 	service := runtimeService.(*Service)
 	service.providerCommandInjected = providerCommandInjected
 	service.scriptCommandInjected = scriptCommandInjected
+	service.providerRegistry = providerRegistry
+	if providerRegistry != nil {
+		if builder, ok := service.executorBuilder.(*workerconstruction.Service); ok {
+			service.executorBuilder = builder.WithRunnerSelection(providerRegistry.ResolveRunnerSelection)
+		}
+	}
 	return service, nil
 }
 

--- a/pkg/services/workers/service/model_invocation.go
+++ b/pkg/services/workers/service/model_invocation.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	workerrunner "github.com/portpowered/infinite-you/pkg/services/workers/runner"
-
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	modelinference "github.com/portpowered/infinite-you/pkg/services/models"
 
@@ -133,7 +131,22 @@ func (s *Service) InvokeModel(
 	if err != nil {
 		return modelinference.Result{}, classifyModelInvocationError(err, failureContext)
 	}
-	workstationRequest := directModelInvocationWorkstationRequest(workerDef, request, inputTokens, resolvedBindings, s.factoryRunnerID)
+	selection, err := resolveRuntimeRunnerSelection(
+		s.providerRegistry,
+		"",
+		s.factoryRunnerID,
+		workerDef.ModelProvider,
+	)
+	if err != nil {
+		return modelinference.Result{}, classifyModelInvocationError(err, failureContext)
+	}
+	workstationRequest := directModelInvocationWorkstationRequest(
+		workerDef,
+		request,
+		inputTokens,
+		resolvedBindings,
+		selection,
+	)
 
 	result, err := executor.Execute(ctx, workstationRequest)
 	if err != nil {
@@ -233,9 +246,8 @@ func directModelInvocationWorkstationRequest(
 	request modelinference.Request,
 	inputTokens []workerexecution.Token,
 	resolvedBindings []workerexecution.ResolvedModelOperationBinding,
-	factoryRunnerID string,
+	selection workerexecution.ResolvedRunnerSelection,
 ) workerexecution.WorkstationExecutionRequest {
-	selection := workerrunner.ResolveRunnerSelection("", factoryRunnerID, workerDef.ModelProvider)
 	inputContent := request.Content
 	return workerexecution.WorkstationExecutionRequest{
 		Dispatch: work.WorkDispatch{

--- a/pkg/services/workers/service/registry_runner.go
+++ b/pkg/services/workers/service/registry_runner.go
@@ -1,0 +1,53 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	providerregistry "github.com/portpowered/infinite-you/pkg/services/workers/provider/registry"
+)
+
+type registryCapabilityRunner struct {
+	next      workers.Runner
+	providers *providerregistry.Registry
+}
+
+func (r registryCapabilityRunner) Execute(
+	ctx context.Context,
+	request workers.RunnerExecutionRequest,
+) (workers.RunnerExecutionResult, error) {
+	if err := validateRequestedRunnerCapabilities(r.providers, request); err != nil {
+		return workers.RunnerExecutionResult{}, err
+	}
+	return r.next.Execute(ctx, request)
+}
+
+func validateRequestedRunnerCapabilities(
+	providers *providerregistry.Registry,
+	request workers.RunnerExecutionRequest,
+) error {
+	if providers == nil {
+		return nil
+	}
+	metadata, err := providers.RunnerMetadata(request.RunnerID)
+	if err != nil {
+		return err
+	}
+	supported := make(map[workers.RunnerOptionalCapability]bool, len(metadata.Capabilities.Optional))
+	for _, capability := range metadata.Capabilities.Optional {
+		supported[capability.Capability] = capability.Status == workers.RunnerOptionalCapabilityStatusSupported
+	}
+	for _, required := range request.RequiredOptionalCapabilities {
+		if supported[required] {
+			continue
+		}
+		return fmt.Errorf(
+			"%s is not supported by the %s runner in v1",
+			strings.ReplaceAll(string(required), "_", " "),
+			metadata.ID,
+		)
+	}
+	return nil
+}

--- a/pkg/services/workers/service/registry_runner_test.go
+++ b/pkg/services/workers/service/registry_runner_test.go
@@ -64,6 +64,59 @@ func TestRegistrySelectionRejectsUnknownInsteadOfDefaulting(t *testing.T) {
 	}
 }
 
+func TestRuntimeSelectionCompatibilityWithoutRegistry(t *testing.T) {
+	t.Parallel()
+
+	selection, err := resolveRuntimeRunnerSelection(nil, "", "", workers.RunnerIDCodex)
+	if err != nil {
+		t.Fatalf("resolveRuntimeRunnerSelection() error = %v", err)
+	}
+	if selection.RunnerID != workers.RunnerIDCodex {
+		t.Fatalf("resolveRuntimeRunnerSelection() = %#v", selection)
+	}
+	if err := validateRuntimeRunnerIdentity(nil, workers.RunnerIDCodex); err != nil {
+		t.Fatalf("validateRuntimeRunnerIdentity(codex) error = %v", err)
+	}
+	if err := validateRuntimeRunnerIdentity(nil, "unknown-provider"); err == nil {
+		t.Fatal("validateRuntimeRunnerIdentity(unknown) succeeded")
+	}
+}
+
+func TestRegistryCapabilityValidationWithoutRegistryPreservesNativeRunner(t *testing.T) {
+	t.Parallel()
+
+	next := &registryRunnerRecorder{}
+	runner := registryCapabilityRunner{next: next}
+	_, err := runner.Execute(context.Background(), workers.RunnerExecutionRequest{
+		RunnerID: workers.RunnerIDCodex,
+		RequiredOptionalCapabilities: []workers.RunnerOptionalCapability{
+			workers.RunnerOptionalCapabilityStructuredOutput,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if next.calls != 1 {
+		t.Fatalf("native runner calls = %d, want 1", next.calls)
+	}
+}
+
+func TestRegistryCapabilityRunnerRejectsUnknownRunnerBeforeNativeExecution(t *testing.T) {
+	t.Parallel()
+
+	next := &registryRunnerRecorder{}
+	runner := registryCapabilityRunner{next: next, providers: builtInProviderRegistry(t)}
+	_, err := runner.Execute(context.Background(), workers.RunnerExecutionRequest{
+		RunnerID: "unknown-provider",
+	})
+	if err == nil || !strings.Contains(err.Error(), `provider "unknown-provider" is unknown`) {
+		t.Fatalf("Execute() error = %v, want unknown-provider diagnostic", err)
+	}
+	if next.calls != 0 {
+		t.Fatalf("native runner calls = %d, want 0", next.calls)
+	}
+}
+
 func builtInProviderRegistry(t *testing.T) *providerregistry.Registry {
 	t.Helper()
 	registrations, err := providerregistry.BuiltInRegistrations()

--- a/pkg/services/workers/service/registry_runner_test.go
+++ b/pkg/services/workers/service/registry_runner_test.go
@@ -1,0 +1,78 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/workers"
+	providerregistry "github.com/portpowered/infinite-you/pkg/services/workers/provider/registry"
+)
+
+type registryRunnerRecorder struct {
+	calls int
+}
+
+func (r *registryRunnerRecorder) Execute(
+	context.Context,
+	workers.RunnerExecutionRequest,
+) (workers.RunnerExecutionResult, error) {
+	r.calls++
+	return workers.RunnerExecutionResult{}, nil
+}
+
+func TestRegistryCapabilityRunnerUsesManifestMaximumBeforeNativeExecution(t *testing.T) {
+	t.Parallel()
+	providers := builtInProviderRegistry(t)
+	next := &registryRunnerRecorder{}
+	runner := registryCapabilityRunner{next: next, providers: providers}
+
+	_, err := runner.Execute(context.Background(), workers.RunnerExecutionRequest{
+		RunnerID: workers.RunnerIDGemini,
+		RequiredOptionalCapabilities: []workers.RunnerOptionalCapability{
+			workers.RunnerOptionalCapabilitySessionResume,
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "session resume is not supported by the gemini runner") {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if next.calls != 0 {
+		t.Fatalf("native runner calls = %d, want 0", next.calls)
+	}
+
+	_, err = runner.Execute(context.Background(), workers.RunnerExecutionRequest{
+		RunnerID: workers.RunnerIDCodex,
+		RequiredOptionalCapabilities: []workers.RunnerOptionalCapability{
+			workers.RunnerOptionalCapabilityStructuredOutput,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute(codex) error = %v", err)
+	}
+	if next.calls != 1 {
+		t.Fatalf("native runner calls = %d, want 1", next.calls)
+	}
+}
+
+func TestRegistrySelectionRejectsUnknownInsteadOfDefaulting(t *testing.T) {
+	t.Parallel()
+	providers := builtInProviderRegistry(t)
+
+	_, err := resolveRuntimeRunnerSelection(providers, "", "", "unknown-provider")
+	if err == nil || !strings.Contains(err.Error(), `provider "unknown-provider" is unknown`) {
+		t.Fatalf("resolveRuntimeRunnerSelection() error = %v", err)
+	}
+}
+
+func builtInProviderRegistry(t *testing.T) *providerregistry.Registry {
+	t.Helper()
+	registrations, err := providerregistry.BuiltInRegistrations()
+	if err != nil {
+		t.Fatalf("BuiltInRegistrations() error = %v", err)
+	}
+	providers, err := providerregistry.New(registrations...)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	return providers
+}

--- a/pkg/services/workers/service/runtime_options.go
+++ b/pkg/services/workers/service/runtime_options.go
@@ -13,6 +13,7 @@ import (
 	modelrecording "github.com/portpowered/infinite-you/pkg/services/workers/execution/recording"
 	workerexecutor "github.com/portpowered/infinite-you/pkg/services/workers/executor"
 	workerprovider "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+	providerregistry "github.com/portpowered/infinite-you/pkg/services/workers/provider/registry"
 	workerrunner "github.com/portpowered/infinite-you/pkg/services/workers/runner"
 	"github.com/portpowered/infinite-you/pkg/services/workers/skippermissions"
 )
@@ -60,11 +61,25 @@ func (s *Service) BuildRuntimeExecutors(
 	}
 	factoryRunnerID = EffectiveFactoryRunnerID(factoryRunnerID, factoryConfig)
 	preflight := runnerSelectionPreflight{skipCommandAvailability: providerOverride != nil || s.providerCommandInjected || skipBuiltInRunnerPrerequisiteValidation}
-	if err := ValidateRuntimeSelections(factoryConfig, factoryRunnerID, runtimeConfig, s.executableLocator, preflight.skipCommandAvailability, invocationSkipPermissionsOverride); err != nil {
+	if err := ValidateRuntimeSelections(
+		factoryConfig,
+		factoryRunnerID,
+		runtimeConfig,
+		s.executableLocator,
+		preflight.skipCommandAvailability,
+		invocationSkipPermissionsOverride,
+		s.providerRegistry,
+	); err != nil {
 		return nil, err
 	}
 
-	decorators := s.runtimeRunnerDecorators(runtimeConfig, factoryConfig, modelRecorder, now)
+	decorators := s.runtimeRunnerDecorators(
+		runtimeConfig,
+		factoryConfig,
+		modelRecorder,
+		now,
+		providerOverride == nil,
+	)
 	executors := make(map[string]workers.WorkerExecutor, len(factoryConfig.Workers)+len(factoryConfig.Workstations))
 	for _, configured := range factoryConfig.Workers {
 		definition, ok := runtimeConfig.Worker(configured.Name)
@@ -98,8 +113,14 @@ func (s *Service) BuildRuntimeExecutors(
 	return executors, nil
 }
 
-func (s *Service) runtimeRunnerDecorators(runtimeCfg interfaces.RuntimeConfigLookup, factoryCfg *interfaces.FactoryConfig, recorder workers.ModelEventRecorder, now func() time.Time) []workerconstruction.RunnerDecorator {
-	return []workerconstruction.RunnerDecorator{
+func (s *Service) runtimeRunnerDecorators(runtimeCfg interfaces.RuntimeConfigLookup, factoryCfg *interfaces.FactoryConfig, recorder workers.ModelEventRecorder, now func() time.Time, useRegistryCapabilities bool) []workerconstruction.RunnerDecorator {
+	decorators := make([]workerconstruction.RunnerDecorator, 0, 3)
+	if useRegistryCapabilities && s.providerRegistry != nil {
+		decorators = append(decorators, func(inner workers.Runner, _ *interfaces.FactoryWorkerConfig) workers.Runner {
+			return registryCapabilityRunner{next: inner, providers: s.providerRegistry}
+		})
+	}
+	return append(decorators,
 		func(inner workers.Runner, definition *interfaces.FactoryWorkerConfig) workers.Runner {
 			return wrapLocalModelRunner(
 				inner, s.models, factoryCfg, definition,
@@ -108,7 +129,7 @@ func (s *Service) runtimeRunnerDecorators(runtimeCfg interfaces.RuntimeConfigLoo
 		func(inner workers.Runner, definition *interfaces.FactoryWorkerConfig) workers.Runner {
 			return modelrecording.NewRunner(inner, factoryCfg, definition, recorder, now)
 		},
-	}
+	)
 }
 
 // EffectiveFactoryRunnerID resolves an explicit runtime runner before the
@@ -132,6 +153,7 @@ func ValidateRuntimeSelections(
 	executableLocator platformprocess.ExecutableLocator,
 	skipCommandAvailability bool,
 	invocationSkipPermissionsOverride *bool,
+	providerRegistries ...*providerregistry.Registry,
 ) error {
 	if cfg == nil {
 		return fmt.Errorf("factory config is required")
@@ -139,19 +161,57 @@ func ValidateRuntimeSelections(
 	if runtimeCfg == nil {
 		return fmt.Errorf("runtime config is required")
 	}
-	return validateWorkerLoadPreflight(cfg, factoryRunnerID, runtimeCfg, executableLocator, runnerSelectionPreflight{skipCommandAvailability: skipCommandAvailability}, invocationSkipPermissionsOverride)
+	var providers *providerregistry.Registry
+	if len(providerRegistries) > 0 {
+		providers = providerRegistries[0]
+	}
+	return validateRuntimeSelectionsWithRegistry(
+		cfg,
+		factoryRunnerID,
+		runtimeCfg,
+		executableLocator,
+		skipCommandAvailability,
+		invocationSkipPermissionsOverride,
+		providers,
+	)
 }
 
 type runnerSelectionPreflight struct{ skipCommandAvailability bool }
 
-func validateWorkerLoadPreflight(cfg *interfaces.FactoryConfig, factoryRunnerID string, runtimeCfg interfaces.RuntimeConfigLookup, executableLocator platformprocess.ExecutableLocator, preflight runnerSelectionPreflight, invocationSkipPermissionsOverride *bool) error {
-	if err := validateConfiguredWorkstationRunners(cfg, factoryRunnerID, runtimeCfg, executableLocator, preflight); err != nil {
+func validateRuntimeSelectionsWithRegistry(
+	cfg *interfaces.FactoryConfig,
+	factoryRunnerID string,
+	runtimeCfg interfaces.RuntimeConfigLookup,
+	executableLocator platformprocess.ExecutableLocator,
+	skipCommandAvailability bool,
+	invocationSkipPermissionsOverride *bool,
+	providers *providerregistry.Registry,
+) error {
+	if cfg == nil {
+		return fmt.Errorf("factory config is required")
+	}
+	if runtimeCfg == nil {
+		return fmt.Errorf("runtime config is required")
+	}
+	return validateWorkerLoadPreflight(
+		cfg,
+		factoryRunnerID,
+		runtimeCfg,
+		executableLocator,
+		runnerSelectionPreflight{skipCommandAvailability: skipCommandAvailability},
+		invocationSkipPermissionsOverride,
+		providers,
+	)
+}
+
+func validateWorkerLoadPreflight(cfg *interfaces.FactoryConfig, factoryRunnerID string, runtimeCfg interfaces.RuntimeConfigLookup, executableLocator platformprocess.ExecutableLocator, preflight runnerSelectionPreflight, invocationSkipPermissionsOverride *bool, providers *providerregistry.Registry) error {
+	if err := validateConfiguredWorkstationRunners(cfg, factoryRunnerID, runtimeCfg, executableLocator, preflight, providers); err != nil {
 		return err
 	}
 	return skippermissions.ValidateInvocationSkipPermissionsWorkers(cfg, runtimeCfg, invocationSkipPermissionsOverride)
 }
 
-func validateConfiguredWorkstationRunners(cfg *interfaces.FactoryConfig, factoryRunnerID string, runtimeCfg interfaces.RuntimeConfigLookup, executableLocator platformprocess.ExecutableLocator, preflight runnerSelectionPreflight) error {
+func validateConfiguredWorkstationRunners(cfg *interfaces.FactoryConfig, factoryRunnerID string, runtimeCfg interfaces.RuntimeConfigLookup, executableLocator platformprocess.ExecutableLocator, preflight runnerSelectionPreflight, providers *providerregistry.Registry) error {
 	for index, workstation := range cfg.Workstations {
 		if configured, ok := runtimeCfg.Workstation(workstation.Name); ok && configured != nil {
 			workstation = *configured
@@ -161,24 +221,66 @@ func validateConfiguredWorkstationRunners(cfg *interfaces.FactoryConfig, factory
 		if worker != nil {
 			modelProvider, openCodeAgent = worker.ModelProvider, worker.OpenCodeAgent
 		}
-		selection := workerrunner.ResolveRunnerSelection(workstation.Runner, factoryRunnerID, modelProvider)
+		selection, selectionErr := resolveRuntimeRunnerSelection(
+			providers,
+			workstation.Runner,
+			factoryRunnerID,
+			modelProvider,
+		)
+		if selectionErr != nil {
+			return fmt.Errorf("workstations[%d](%s).runner: %w", index, workstation.Name, selectionErr)
+		}
 		if err := workerrunner.ValidateOpenCodeAgentForRunnerSelection(workstation.OpenCodeAgent, openCodeAgent, selection); err != nil {
 			return fmt.Errorf("workstations[%d](%s).openCodeAgent: %w", index, workstation.Name, err)
 		}
 		if selection.Source == workerexecution.RunnerSelectionSourceDefault {
 			continue
 		}
-		if _, ok := workerrunner.BuiltInRunnerMetadata(selection.RunnerID); !ok {
-			return fmt.Errorf("workstations[%d](%s).runner: unknown runner %q", index, workstation.Name, selection.RunnerID)
-		}
-		if status, ok := workers.BuiltInRunnerStatus(selection.RunnerID); ok && !status.Available {
-			return fmt.Errorf("workstations[%d](%s).runner: %s", index, workstation.Name, status.UnavailableReason)
+		if err := validateRuntimeRunnerIdentity(providers, selection.RunnerID); err != nil {
+			return fmt.Errorf("workstations[%d](%s).runner: %w", index, workstation.Name, err)
 		}
 		if !preflight.skipCommandAvailability {
-			if err := workers.ValidateBuiltInRunnerPrerequisites(executableLocator, selection.RunnerID); err != nil {
+			if err := validateRuntimeRunnerPrerequisites(providers, executableLocator, selection.RunnerID); err != nil {
 				return fmt.Errorf("workstations[%d](%s).runner: %w", index, workstation.Name, err)
 			}
 		}
 	}
 	return nil
+}
+
+func resolveRuntimeRunnerSelection(
+	providers *providerregistry.Registry,
+	workstationRunner string,
+	factoryRunnerID string,
+	modelProvider string,
+) (workers.ResolvedRunnerSelection, error) {
+	if providers != nil {
+		return providers.ResolveRunnerSelection(workstationRunner, factoryRunnerID, modelProvider)
+	}
+	return workerrunner.ResolveRunnerSelection(workstationRunner, factoryRunnerID, modelProvider), nil
+}
+
+func validateRuntimeRunnerIdentity(providers *providerregistry.Registry, runnerID string) error {
+	if providers != nil {
+		_, err := providers.RunnerMetadata(runnerID)
+		return err
+	}
+	if _, ok := workerrunner.BuiltInRunnerMetadata(runnerID); !ok {
+		return fmt.Errorf("unknown runner %q", runnerID)
+	}
+	if status, ok := workers.BuiltInRunnerStatus(runnerID); ok && !status.Available {
+		return fmt.Errorf("%s", status.UnavailableReason)
+	}
+	return nil
+}
+
+func validateRuntimeRunnerPrerequisites(
+	providers *providerregistry.Registry,
+	executableLocator platformprocess.ExecutableLocator,
+	runnerID string,
+) error {
+	if providers != nil {
+		return providers.ValidateRunnerPrerequisites(executableLocator, runnerID)
+	}
+	return workers.ValidateBuiltInRunnerPrerequisites(executableLocator, runnerID)
 }

--- a/pkg/services/workers/service/service.go
+++ b/pkg/services/workers/service/service.go
@@ -21,6 +21,7 @@ import (
 	workerprocess "github.com/portpowered/infinite-you/pkg/services/workers/process"
 	workerprovider "github.com/portpowered/infinite-you/pkg/services/workers/provider"
 	providercontract "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+	providerregistry "github.com/portpowered/infinite-you/pkg/services/workers/provider/registry"
 	"github.com/portpowered/infinite-you/pkg/services/workers/skippermissions"
 	"go.uber.org/zap"
 
@@ -57,6 +58,7 @@ type Service struct {
 	workstationFiles                  platformfilesystem.ReadFileInspector
 	temporaryFiles                    platformfilesystem.TemporaryFileSystem
 	executableLocator                 platformprocess.ExecutableLocator
+	providerRegistry                  *providerregistry.Registry
 }
 
 type CurrentRuntimeResolver interface {
@@ -254,7 +256,7 @@ func (s *Service) BuildModelInvocationExecutor(runtimeCfg interfaces.RuntimeConf
 		logging.NewZapLogger(s.logger, s.verbose),
 		s.invocationSkipPermissionsOverride, s.providerOverride,
 		nil, nil, nil, nil, s.clock, s.processEnvironment, s.currentWorkingDirectory,
-		s.runtimeRunnerDecorators(runtimeCfg, factoryCfg, nil, s.clock),
+		s.runtimeRunnerDecorators(runtimeCfg, factoryCfg, nil, s.clock, s.providerOverride == nil),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("construct model worker %q: %w", workerName, err)

--- a/pkg/wire/boundary_test.go
+++ b/pkg/wire/boundary_test.go
@@ -14,11 +14,28 @@ import (
 
 	platformclock "github.com/portpowered/infinite-you/pkg/platform/clock"
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
+	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	factorynamedpaths "github.com/portpowered/infinite-you/pkg/services/factory_definitions/namedpaths"
 	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
 	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	factorysessionwire "github.com/portpowered/infinite-you/pkg/services/factory_sessions/wire"
 )
+
+func TestProvideProviderRegistryComposesBuiltIns(t *testing.T) {
+	t.Parallel()
+
+	providers, err := provideProviderRegistry(serviceedges.Edges{})
+	if err != nil {
+		t.Fatalf("provideProviderRegistry() error = %v", err)
+	}
+	canonical, err := providers.CanonicalIdentity("agent")
+	if err != nil {
+		t.Fatalf("CanonicalIdentity(agent) error = %v", err)
+	}
+	if canonical != "cursor" {
+		t.Fatalf("CanonicalIdentity(agent) = %q, want cursor", canonical)
+	}
+}
 
 func TestProvideResponsePresentationReturnsUsableInjectedService(t *testing.T) {
 	t.Parallel()

--- a/pkg/wire/session_runtime_providers.go
+++ b/pkg/wire/session_runtime_providers.go
@@ -576,6 +576,7 @@ func provideWorkersRuntimeFactory(
 	temporaryFiles platformfilesystem.TemporaryFileSystem,
 	defaultAllocator agypty.PTYAllocator,
 	edges serviceedges.Edges,
+	providerRegistry *providerregistry.Registry,
 ) (factorysessionwire.WorkersRuntimeFactory, error) {
 	if defaultAllocator == nil {
 		return nil, agypty.ErrHostRequired
@@ -687,6 +688,7 @@ func provideWorkersRuntimeFactory(
 			decisionEnvelopes,
 			providerInjected,
 			scriptInjected,
+			providerRegistry,
 		)
 	}, nil
 }

--- a/pkg/wire/session_runtime_providers.go
+++ b/pkg/wire/session_runtime_providers.go
@@ -49,6 +49,7 @@ import (
 	workerprocess "github.com/portpowered/infinite-you/pkg/services/workers/process"
 	workerprompting "github.com/portpowered/infinite-you/pkg/services/workers/prompting"
 	workerprovider "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
+	providerregistry "github.com/portpowered/infinite-you/pkg/services/workers/provider/registry"
 	workersservice "github.com/portpowered/infinite-you/pkg/services/workers/service"
 	hostedworkers "github.com/portpowered/infinite-you/pkg/services/workers/services/hosted_logic"
 	hostedlinear "github.com/portpowered/infinite-you/pkg/services/workers/services/hosted_logic/linear"
@@ -57,6 +58,21 @@ import (
 	wirefactorydefinitions "github.com/portpowered/infinite-you/pkg/wire/factorydefinitions"
 	"go.uber.org/zap"
 )
+
+func provideProviderRegistry(edges serviceedges.Edges) (*providerregistry.Registry, error) {
+	builtIns, err := providerregistry.BuiltInRegistrations()
+	if err != nil {
+		return nil, err
+	}
+	registrations := append([]providerregistry.Registration(nil), builtIns...)
+	for _, addition := range edges.ProviderRegistrations {
+		registrations = append(
+			registrations,
+			providerregistry.ExternalRegistration(addition.Manifest, addition.Integration),
+		)
+	}
+	return providerregistry.New(registrations...)
+}
 
 func provideProviderSessions(edges serviceedges.Edges) (providersessions.Service, error) {
 	files := edges.ProviderSessionFileSystem

--- a/pkg/wire/wire.go
+++ b/pkg/wire/wire.go
@@ -16,6 +16,7 @@ import (
 	factorysessionwire "github.com/portpowered/infinite-you/pkg/services/factory_sessions/wire"
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
+	providerregistry "github.com/portpowered/infinite-you/pkg/services/workers/provider/registry"
 	"github.com/portpowered/infinite-you/pkg/transports/cli"
 	configinitcmd "github.com/portpowered/infinite-you/pkg/transports/cli/configinit"
 	httpapplication "github.com/portpowered/infinite-you/pkg/transports/http/application"
@@ -45,6 +46,8 @@ var apiSet = wire.NewSet(
 )
 
 var servicesSet = wire.NewSet(
+	provideProviderRegistry,
+	wire.Bind(new(initializerapplication.ProviderRegistry), new(*providerregistry.Registry)),
 	factorysessionwire.NewRequestPreparation,
 	provideFactorySessionHTTPRequestPreparation,
 	factoryruntime.NewFactoryStatusProjector,

--- a/pkg/wire/wire_gen.go
+++ b/pkg/wire/wire_gen.go
@@ -150,7 +150,11 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	if err != nil {
 		return nil, err
 	}
-	v29, err := provideWorkersRuntimeFactory(invocationInterpolationService, decisionEnvelopeService, v27, v28, source, readFileInspector, temporaryFileSystem, ptyAllocator, edges2)
+	registry, err := provideProviderRegistry(edges2)
+	if err != nil {
+		return nil, err
+	}
+	v29, err := provideWorkersRuntimeFactory(invocationInterpolationService, decisionEnvelopeService, v27, v28, source, readFileInspector, temporaryFileSystem, ptyAllocator, edges2, registry)
 	if err != nil {
 		return nil, err
 	}
@@ -492,10 +496,6 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 		return nil, err
 	}
 	initializer, err := application.NewInitializer(processStdioApplicationOpener)
-	if err != nil {
-		return nil, err
-	}
-	registry, err := provideProviderRegistry(edges2)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/wire/wire_gen.go
+++ b/pkg/wire/wire_gen.go
@@ -19,6 +19,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/wire"
 	"github.com/portpowered/infinite-you/pkg/services/work"
 	"github.com/portpowered/infinite-you/pkg/services/workers"
+	"github.com/portpowered/infinite-you/pkg/services/workers/provider/registry"
 	"github.com/portpowered/infinite-you/pkg/transports/cli"
 	"github.com/portpowered/infinite-you/pkg/transports/cli/configinit"
 	application2 "github.com/portpowered/infinite-you/pkg/transports/http/application"
@@ -494,7 +495,11 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	if err != nil {
 		return nil, err
 	}
-	process, err := application.NewProcess(commandFactory, initializer)
+	registry, err := provideProviderRegistry(edges2)
+	if err != nil {
+		return nil, err
+	}
+	process, err := application.NewProcess(commandFactory, initializer, registry)
 	if err != nil {
 		return nil, err
 	}
@@ -507,7 +512,8 @@ var platformSet = wire2.NewSet(logging.NewDefaultLogger)
 
 var apiSet = wire2.NewSet(composition.NewWorkAPI, composition.NewHTTPBinder, apisurface.NewRuntimeAPI, composition.NewLiveSessionAPI, factorydefinition.NewAPI, factorysession.NewDurableAPI, factorysession.NewLiveAPI, factorysession.NewInvocationAPI, stdio.NewOpener, application2.NewHandler)
 
-var servicesSet = wire2.NewSet(wire.NewRequestPreparation, provideFactorySessionHTTPRequestPreparation, factory.NewFactoryStatusProjector, factory.NewSessionResultProjectionOperation, provideOperatorSettingsFileSystem,
+var servicesSet = wire2.NewSet(
+	provideProviderRegistry, wire2.Bind(new(application.ProviderRegistry), new(*registry.Registry)), wire.NewRequestPreparation, provideFactorySessionHTTPRequestPreparation, factory.NewFactoryStatusProjector, factory.NewSessionResultProjectionOperation, provideOperatorSettingsFileSystem,
 	provideOperatorSettingsCreateTemporaryFile,
 	provideOperatorSettingsIDGenerator,
 	provideOperatorConfigDecoder,


### PR DESCRIPTION
{
  "project": "Make the Manifest-to-Integration Provider Registry Authoritative",
  "branchName": "standardized-provider-authoritative-registry",
  "description": "Deliver Standardized Providers Story 3 as one independently reviewable vertical slice by adding one immutable registry that joins the embedded provider manifest catalog to provider-neutral Integration registrations and becomes authoritative for deterministic identity, alias, capability, discovery, invocation-access, and supported-provider projections without changing provider-native execution or configuration behavior.",
  "context": {
    "customerAsk": "Implement one authoritative manifest-to-integration registry that safely joins the accepted standardized provider catalog to the accepted provider-neutral integration contract. Support deterministic built-in and customer/test registration, normalized lookup and diagnostics, immutable query results, capability validation, discovery and invocation access, and additive root.BuildProcess composition while preserving current execution and configuration behavior.",
    "problem": "The catalog and integration protocol each own the correct half of provider behavior, but the application still answers provider questions from independent runner, CLI-provider, adapter, executor, selection, and process-composition registries. These sources can disagree, replacement-style ProviderOverride composition cannot express additive named integrations safely, invalid joins can survive until late execution, and process construction is not directly proven inert.",
    "solution": "Add a Workers-owned immutable registry that parses the embedded first-party catalog, validates and joins schema-valid manifest identities to provider-neutral Integrations, distinguishes catalog presence from selectability, returns detached deterministic projections, and fails closed on malformed or contradictory composition. Wire constructs it once from built-ins plus a narrowly typed additive edge collection, and required identity, capability, discovery, invocation-access, and supported-provider projections route through it while current execution, configuration, and ProviderOverride behavior remain intact."
  },
  "acceptanceCriteria": [
    "One registry parses the embedded first-party catalog and exposes a deterministic, normalized, immutable view of catalog entries and selectable integrations by canonical ID and alias.",
    "Registry construction fails closed with actionable deterministic errors for every required identity collision, manifest/integration mismatch, implementation-coverage gap, and capability contradiction; catalog-only or not-supported entries remain valid and non-selectable.",
    "Wire constructs the canonical registry once from built-ins plus additive typed customer/test registrations, and root.BuildProcess additions cannot replace or remove unrelated built-ins.",
    "Registry-backed identity, capability, discovery, invocation-access, and supported-provider diagnostic projections preserve current public execution and configuration behavior, with unknown or non-selectable providers failing explicitly rather than falling back to a default.",
    "Construction, lookup, listing, maximum-capability reads, and diagnostic projection perform no provider discovery, invocation, host probing, process startup, or other provider side effects; only an explicit discovery or invocation operation may cross those boundaries.",
    "Typecheck, make pkg-boundary, focused provider/Wire/root tests, make test, make lint, and the narrowest relevant functional verification pass."
  ],
  "userStories": [
    {
      "id": "standardized-provider-authoritative-registry-001",
      "title": "Validate the authoritative manifest-to-integration join",
      "description": "As a Factory operator, I want provider composition to reject invalid or contradictory registrations before the process can use them so that provider selection and diagnostics cannot be based on an ambiguous registry.",
      "acceptanceCriteria": [
        "Registry construction parses and validates the embedded first-party catalog and binds each runnable registration to exactly one canonical manifest identity and one non-nil Integration.",
        "The typed registration boundary does not repeat display metadata, aliases, support posture, discovery prerequisites, or manifest maximum capabilities; those values are read from the bound manifest, and external registrations can contribute a schema-valid typed manifest without mutating the embedded first-party catalog.",
        "Empty or malformed manifest identities, nil integrations, and integration identities that differ from their manifest binding are rejected with errors that name the offending normalized identity and violated invariant.",
        "Duplicate canonical IDs, duplicate aliases, aliases that shadow a canonical ID, and canonical IDs that shadow an alias are rejected regardless of input order.",
        "Construction rejects a supported bundled first-party manifest without a matching implementation, a bundled first-party implementation without a matching manifest, and an implementation whose declared maximum exceeds or contradicts the manifest maximum.",
        "Catalog-only and not-supported manifests remain valid without an implementation and are marked non-selectable; a runnable registration for a not-supported manifest is rejected.",
        "Equivalent invalid inputs produce byte-stable error text and stable offending-identity order across repeated construction and registration input permutations.",
        "Focused registry construction and negative regression tests pass.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "standardized-provider-authoritative-registry-002",
      "title": "Provide deterministic immutable registry operations",
      "description": "As a provider consumer, I want one normalized registry API for lookup, capabilities, discovery, invocation access, and diagnostics so that all callers receive consistent answers without being able to mutate registry state.",
      "acceptanceCriteria": [
        "Canonical IDs and aliases normalize according to the published identity rules and resolve to the same canonical entry; empty, malformed, unknown, and non-selectable lookup requests return explicit errors and never select a default integration.",
        "Entry lists, supported-provider diagnostics, aliases, discovery prerequisites, capability sets, and other slice/map-backed values are returned in deterministic canonical order as detached values; mutating any caller-owned input or returned value cannot alter later registry results.",
        "Diagnostics distinguish at least catalog-only, not-supported, supported-but-unavailable, and selectable integrations without treating support posture as live readiness.",
        "Maximum-capability reads use the manifest as authority, while request-sensitive capability access delegates to the bound Integration and rejects unknown, contradictory, or above-manifest results before returning them.",
        "Explicit discovery delegates to the selected integration, validates the provider-neutral result, and preserves bounded actionable errors; explicit invocation access resolves only the canonical bound Integration.",
        "Construction, normalized lookup, listing, maximum-capability access, and diagnostics do not call Discover, Capabilities, or Invoke; focused recording-integration tests prove calls occur only for the explicitly requested request-sensitive capability, discovery, or invocation operation.",
        "Focused lookup, deterministic-ordering, immutability, capability, discovery, invocation-access, and no-side-effect tests pass.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "standardized-provider-authoritative-registry-003",
      "title": "Compose built-in and additive external registrations once",
      "description": "As an integration author, I want to append my named integration through the normal process edge so that I can test or embed it without replacing built-in providers or constructing a second application graph.",
      "acceptanceCriteria": [
        "pkg/services/edges.Edges exposes one narrowly typed collection of provider registrations owned by the public inference/registry boundary; it does not expose provider implementation packages or a general service locator.",
        "Edge merging appends registrations in a detached collection rather than replacing defaults, and additions cannot remove or replace unrelated built-ins; collisions fail during canonical registry construction rather than silently winning by merge order.",
        "pkg/wire constructs one canonical immutable registry during its single inert process-graph injection from the embedded catalog, built-in registrations, and explicit edge additions, then supplies that same registry-backed authority to its consumers.",
        "root.BuildProcess with a valid fake external registration retains all built-ins and makes the external canonical ID and aliases queryable through the composed registry; invalid external registrations fail with the same deterministic validation outcomes as direct construction.",
        "Reusing or mutating caller-owned registration slices after root.BuildProcess begins cannot alter the composed process, and independent process builds do not share mutable registration state.",
        "Building the root process with built-ins or fake registrations does not call provider discovery or invocation and does not start a subprocess, listener, watcher, model host, or Factory Session.",
        "ProviderOverride remains behaviorally intact for existing callers and is not deleted or repurposed as the additive registry collection in this story.",
        "Focused edge-merge, Wire composition, root external-edge, isolation, and inert-construction tests pass.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "standardized-provider-authoritative-registry-004",
      "title": "Route authoritative provider projections through the registry",
      "description": "As a Factory operator, I want provider identity, aliases, capabilities, discovery, and supported-provider diagnostics to agree so that the system does not report a provider as supported in one path and unknown in another.",
      "acceptanceCriteria": [
        "Registry-owned identity and alias resolution replaces duplicate authority in the required provider selection and diagnostic paths while retaining the current explicit-invocation, configured-default, system-default, and discovery precedence behavior.",
        "Supported-provider diagnostics are projected from manifest support posture plus registry implementation availability in deterministic canonical order and clearly identify catalog-only or non-selectable entries.",
        "Required maximum-capability and request-sensitive capability consumers read through the registry and do not maintain a contradictory provider capability declaration for the routed behavior.",
        "Required provider discovery consumers obtain manifest prerequisites and integration readiness through the registry while preserving current discovery preference and customer-safe unavailable diagnostics.",
        "Unknown canonical IDs and aliases, catalog-only providers, and not-supported providers fail explicitly at routed selection boundaries and never fall through to Claude, Codex, or another default.",
        "Existing provider-native command construction, transport, response parsing, failure handling, session behavior, and runtime invocation path are unchanged; the registry provides invocation access but does not become the neutral invocation conductor in this slice.",
        "Focused provider selection, alias, capability, discovery, supported diagnostic, and negative regression tests pass, plus the narrowest relevant customer-scale functional verification through root.BuildProcess.",
        "Tests pass",
        "Typecheck passes"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}
