### PR TITLE
standardized-provider-open-configuration

### DIFF
--- a/api/codegen_config/factory-codegen-overlay.yaml
+++ b/api/codegen_config/factory-codegen-overlay.yaml
@@ -164,6 +164,9 @@ actions:
     - target: $.components.schemas.Worker.properties.modelProvider
       update:
         x-go-type: WorkerModelProvider
+    - target: $.components.schemas.ProviderIdentity
+      update:
+        x-go-type: WorkerModelProvider
     - target: $.components.schemas.WorkerProvider
       update:
         x-enum-varnames:

--- a/api/components/schemas/api/GlobalConfigWorkerPresetModelProvider.yaml
+++ b/api/components/schemas/api/GlobalConfigWorkerPresetModelProvider.yaml
@@ -1,3 +1,3 @@
 type: string
-description: Concrete supported model provider or alias; surrounding whitespace is trimmed, and symbolic DEFAULT is not accepted for presets.
-pattern: "^[\t-\r \u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]*(?:AGY|ANTHROPIC|CLAUDE|CODEX|CURSOR|CURSOR_AGENT|GEMINI|KIRO|OPENAI|OPENCODE|PI|agent|agy|anthropic|antigravity|claude|codex|cursor|cursor-agent|gemini|kiro|kiro-cli|openai|opencode|pi)[\t-\r \u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]*$"
+description: Canonical provider identity or built-in compatibility alias; surrounding whitespace is trimmed, and symbolic DEFAULT is not accepted for presets.
+pattern: "^[\t-\r \u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]*(?:[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*|AGY|ANTHROPIC|CLAUDE|CODEX|CURSOR|CURSOR_AGENT|GEMINI|KIRO|OPENAI|OPENCODE|PI)[\t-\r \u0085\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]*$"

--- a/api/components/schemas/data-models/FactoryGuard.yaml
+++ b/api/components/schemas/data-models/FactoryGuard.yaml
@@ -12,7 +12,7 @@ properties:
     description: Factory-level guard condition to evaluate before dispatch-ready transitions can proceed.
   modelProvider:
     allOf:
-      - $ref: './WorkerModelProvider.yaml'
+      - $ref: './ProviderIdentity.yaml'
     description: Provider whose inference-throttle history controls this factory-level guard.
   model:
     type: string

--- a/api/components/schemas/data-models/ProviderIdentity.yaml
+++ b/api/components/schemas/data-models/ProviderIdentity.yaml
@@ -1,0 +1,10 @@
+type: string
+minLength: 1
+maxLength: 128
+pattern: '^(?:[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*|AGY|ANTHROPIC|CLAUDE|CODEX|CURSOR|CURSOR_AGENT|GEMINI|KIRO|OPENAI|OPENCODE|PI)$'
+description: >-
+  Open provider identity used by authored modelProvider fields. Extension
+  identities use lowercase letters and digits separated by dots or hyphens.
+  Built-in identities and documented legacy aliases remain accepted
+  compatibility spellings. For example, `customer.provider` is a valid
+  extension identity.

--- a/api/components/schemas/data-models/Worker.yaml
+++ b/api/components/schemas/data-models/Worker.yaml
@@ -29,10 +29,10 @@ properties:
     description: Model identifier to request from the configured model provider when this worker uses model execution.
   modelProvider:
     oneOf:
-      - $ref: './WorkerModelProvider.yaml'
+      - $ref: './ProviderIdentity.yaml'
       - type: string
         pattern: '^\$\{[A-Za-z0-9_.-]+\}$'
-    description: Canonical model-provider identifier used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Current public built-in values are `CLAUDE` and `CODEX`; the runtime maps them onto the underlying provider command IDs.
+    description: Canonical model-provider identity used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Extension identities use lowercase standardized syntax; built-in values such as `CLAUDE` and `CODEX` remain compatibility conveniences.
   modelLocality:
     allOf:
       - $ref: './WorkerModelLocality.yaml'

--- a/api/components/schemas/data-models/WorkerModelProvider.yaml
+++ b/api/components/schemas/data-models/WorkerModelProvider.yaml
@@ -1,11 +1,14 @@
 type: string
-description: Canonical model-provider identifiers supported by model workers in factory config.
+description: >-
+  Built-in model-provider constants retained as generated-client conveniences.
+  Authored modelProvider fields use the open ProviderIdentity contract, so this
+  list is not an exhaustive provider inventory.
 enum:
-    - CLAUDE
-    - CODEX
-    - CURSOR
-    - GEMINI
-    - KIRO
-    - OPENCODE
-    - PI
-    - AGY
+  - CLAUDE
+  - CODEX
+  - CURSOR
+  - GEMINI
+  - KIRO
+  - OPENCODE
+  - PI
+  - AGY

--- a/api/openapi-main.yaml
+++ b/api/openapi-main.yaml
@@ -2194,6 +2194,8 @@ components:
       $ref: './components/schemas/data-models/WorkerType.yaml'
     WorkerModelProvider:
       $ref: './components/schemas/data-models/WorkerModelProvider.yaml'
+    ProviderIdentity:
+      $ref: './components/schemas/data-models/ProviderIdentity.yaml'
     ProviderCatalog:
       $ref: './components/schemas/model-providers/ProviderCatalog.yaml'
     ProviderManifest:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -8524,7 +8524,7 @@ components:
           description: Factory-level guard condition to evaluate before dispatch-ready transitions can proceed.
         modelProvider:
           allOf:
-            - $ref: '#/components/schemas/WorkerModelProvider'
+            - $ref: '#/components/schemas/ProviderIdentity'
           description: Provider whose inference-throttle history controls this factory-level guard.
         model:
           type: string
@@ -8753,10 +8753,10 @@ components:
           description: Model identifier to request from the configured model provider when this worker uses model execution.
         modelProvider:
           oneOf:
-            - $ref: '#/components/schemas/WorkerModelProvider'
+            - $ref: '#/components/schemas/ProviderIdentity'
             - type: string
               pattern: ^\$\{[A-Za-z0-9_.-]+\}$
-          description: Canonical model-provider identifier used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Current public built-in values are `CLAUDE` and `CODEX`; the runtime maps them onto the underlying provider command IDs.
+          description: Canonical model-provider identity used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Extension identities use lowercase standardized syntax; built-in values such as `CLAUDE` and `CODEX` remain compatibility conveniences.
         modelLocality:
           allOf:
             - $ref: '#/components/schemas/WorkerModelLocality'
@@ -8840,7 +8840,7 @@ components:
         - HOSTED_WORKER
     WorkerModelProvider:
       type: string
-      description: Canonical model-provider identifiers supported by model workers in factory config.
+      description: Built-in model-provider constants retained as generated-client conveniences. Authored modelProvider fields use the open ProviderIdentity contract, so this list is not an exhaustive provider inventory.
       enum:
         - CLAUDE
         - CODEX
@@ -8850,6 +8850,12 @@ components:
         - OPENCODE
         - PI
         - AGY
+    ProviderIdentity:
+      type: string
+      minLength: 1
+      maxLength: 128
+      pattern: ^(?:[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*|AGY|ANTHROPIC|CLAUDE|CODEX|CURSOR|CURSOR_AGENT|GEMINI|KIRO|OPENAI|OPENCODE|PI)$
+      description: Open provider identity used by authored modelProvider fields. Extension identities use lowercase letters and digits separated by dots or hyphens. Built-in identities and documented legacy aliases remain accepted compatibility spellings. For example, `customer.provider` is a valid extension identity.
     ProviderCatalog:
       type: object
       additionalProperties: false
@@ -10048,8 +10054,8 @@ components:
           $ref: '#/components/schemas/GlobalConfigWorkerPresetReasoningEffort'
     GlobalConfigWorkerPresetModelProvider:
       type: string
-      description: Concrete supported model provider or alias; surrounding whitespace is trimmed, and symbolic DEFAULT is not accepted for presets.
-      pattern: "^[\t-\r \N\_  - \L\P  　]*(?:AGY|ANTHROPIC|CLAUDE|CODEX|CURSOR|CURSOR_AGENT|GEMINI|KIRO|OPENAI|OPENCODE|PI|agent|agy|anthropic|antigravity|claude|codex|cursor|cursor-agent|gemini|kiro|kiro-cli|openai|opencode|pi)[\t-\r \N\_  - \L\P  　]*$"
+      description: Canonical provider identity or built-in compatibility alias; surrounding whitespace is trimmed, and symbolic DEFAULT is not accepted for presets.
+      pattern: "^[\t-\r \N\_  - \L\P  　]*(?:[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*|AGY|ANTHROPIC|CLAUDE|CODEX|CURSOR|CURSOR_AGENT|GEMINI|KIRO|OPENAI|OPENCODE|PI)[\t-\r \N\_  - \L\P  　]*$"
     GlobalConfigWorkerPresetReasoningEffort:
       type: string
       description: Optional reasoning effort; surrounding whitespace and letter case are normalized, and an empty value is treated as unspecified.

--- a/contracts/config/factory.schema.json
+++ b/contracts/config/factory.schema.json
@@ -114,7 +114,7 @@
         "modelProvider": {
           "allOf": [
             {
-              "$ref": "#/$defs/WorkerModelProvider"
+              "$ref": "#/$defs/ProviderIdentity"
             }
           ],
           "description": "Provider whose inference-throttle history controls this factory-level guard."
@@ -1451,6 +1451,13 @@
       ],
       "type": "object"
     },
+    "ProviderIdentity": {
+      "description": "Open provider identity used by authored modelProvider fields. Extension identities use lowercase letters and digits separated by dots or hyphens. Built-in identities and documented legacy aliases remain accepted compatibility spellings. For example, `customer.provider` is a valid extension identity.",
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^(?:[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*|AGY|ANTHROPIC|CLAUDE|CODEX|CURSOR|CURSOR_AGENT|GEMINI|KIRO|OPENAI|OPENCODE|PI)$",
+      "type": "string"
+    },
     "RequiredTool": {
       "additionalProperties": false,
       "description": "One declarative external tool dependency for a portable factory.",
@@ -2025,10 +2032,10 @@
           "description": "Provider locality for this model capability declaration. Use `LOCAL` for embedded or host-managed inference and `CLOUD` for remote provider execution."
         },
         "modelProvider": {
-          "description": "Canonical model-provider identifier used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Current public built-in values are `CLAUDE` and `CODEX`; the runtime maps them onto the underlying provider command IDs.",
+          "description": "Canonical model-provider identity used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Extension identities use lowercase standardized syntax; built-in values such as `CLAUDE` and `CODEX` remain compatibility conveniences.",
           "oneOf": [
             {
-              "$ref": "#/$defs/WorkerModelProvider"
+              "$ref": "#/$defs/ProviderIdentity"
             },
             {
               "pattern": "^\\$\\{[A-Za-z0-9_.-]+\\}$",
@@ -2097,20 +2104,6 @@
       "enum": [
         "LOCAL",
         "CLOUD"
-      ],
-      "type": "string"
-    },
-    "WorkerModelProvider": {
-      "description": "Canonical model-provider identifiers supported by model workers in factory config.",
-      "enum": [
-        "CLAUDE",
-        "CODEX",
-        "CURSOR",
-        "GEMINI",
-        "KIRO",
-        "OPENCODE",
-        "PI",
-        "AGY"
       ],
       "type": "string"
     },

--- a/docs/internal/processes/api-relevant-files.md
+++ b/docs/internal/processes/api-relevant-files.md
@@ -326,6 +326,17 @@ Use this map when changing the public REST contract.
 
 ## REST operation identity inventory
 
+- Authored Factory `modelProvider` fields reference the open
+  `api/components/schemas/data-models/ProviderIdentity.yaml` syntax contract.
+  `WorkerModelProvider.yaml` is a generated-client convenience enum for built-in
+  constants only and must not be used to close authored worker or guard fields.
+  Keep the `ProviderIdentity` pattern aligned with
+  `provider/inferencecontract.ValidateIdentity`, preserve exact invocation
+  placeholders through the worker field's one-of, and regenerate bundled Go and
+  TypeScript contracts with `make generate-api`. Then run `npm run generate`
+  from `ui/packages/client` to synchronize its package-local generated copy
+  before dashboard typecheck.
+
 - `internal/contractinventory` owns the pure read-only extractor that turns bundled
   OpenAPI YAML into canonical `rest-operations/v1` JSON (`formatVersion`,
   `operations[]` with `operationId`, `method`, `path`, optional `xDocId`,

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -144,6 +144,15 @@ primary-result behavior.
   default-selection path.
   Other unknown, catalog-only, and not-supported identities fail before
   dispatch instead of falling through to the default Codex runner.
+  After invocation interpolation, the Workers workstation executor resolves
+  the concrete `modelProvider` independently through the registry-backed
+  `ProviderIdentityResolver` before applying runner precedence. Do not rely on
+  `ResolveRunnerSelection` alone for this check: an explicit workstation or
+  Factory runner wins precedence and would otherwise mask a malformed,
+  unknown, or non-selectable interpolated provider value. The identity
+  resolver also carries the registry's canonical identity into the execution
+  request before worktree preparation, capability checks, discovery, or
+  provider invocation.
   Provider-native command construction and `ProviderOverride` execution remain
   unchanged; the manifest-backed capability guard is bypassed for an explicit
   replacement provider because that edge owns its own test/runtime contract.

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -313,12 +313,14 @@ response-stream output.
   owns replay-safe invocation diagnostics such as `InvocationSignatureHash` and
   `InvocationDiagnostic`; execution layers should reuse that summary instead of
   inventing transport- or worker-specific argument telemetry.
-- `pkg/config/openapi_factory.go` must preserve exact `${parameter}` placeholders
-  on authored fields that support invocation interpolation (for example
-  `workers[].modelProvider`) instead of rejecting them as invalid public enum
-  values at the JSON boundary. Keep the exact-placeholder pattern aligned with
-  the accepted OpenAPI one-of, and keep ordinary non-placeholder values on the
-  existing strict enum normalization path.
+- `pkg/transports/mapping/factoryconfig/openapi_factory.go` must preserve exact
+  `${parameter}` placeholders on authored fields that support invocation
+  interpolation (for example `workers[].modelProvider`) instead of forcing them
+  through concrete provider-identity validation at the JSON boundary. Keep the
+  exact-placeholder pattern aligned with the accepted OpenAPI one-of. Concrete
+  provider values use the open `ProviderIdentity` syntax contract; built-in
+  aliases canonicalize through compatibility mapping, while syntactically valid
+  extension identities remain unchanged for registry selection.
 - `pkg/initializer/runtimeconstruction/operatordefaults/operator_defaults_runtime.go`
   is the
   startup-time runtime-validation seam for operator-defaulted model workers.

--- a/docs/internal/processes/invocation-relevant-files.md
+++ b/docs/internal/processes/invocation-relevant-files.md
@@ -121,10 +121,20 @@ primary-result behavior.
   path until provider-native execution migrates to the neutral conductor.
 - Wire supplies that same registry to the Workers runtime for routed provider
   selection, manifest-maximum capability checks, and executable-prerequisite
-  preflight. Preserve the existing selection precedence and native runner IDs;
+  preflight, and to Factory Sessions through the narrow
+  `ProviderIdentityResolver` opening contract. After operator defaults are
+  applied, Factory opening resolves concrete worker and guard selections to
+  canonical registry identities; operator-file defaults and JavaScript worker
+  presets use the same authority. Leave declared invocation interpolation
+  expressions unresolved at this stage. Do not restore built-in membership or
+  alias lists in Factory Runtime or operator-default helpers.
+  Preserve the existing selection precedence and native runner IDs;
   the registry resolves canonical IDs and published aliases first, with the
   legacy `cursor-cli` runner ID mapped only at the native-execution
-  compatibility boundary. Preserve accepted public model-provider aliases
+  compatibility boundary. Externally supplied integrations retain their
+  canonical provider identity during runner selection so opening can validate
+  and carry them without pretending they are a bundled native runner.
+  Preserve accepted public model-provider aliases
   (`openai` and `anthropic`) as collision-validated registry identity claims so
   static lookup and routed selection cannot disagree. Carry the registry's
   canonical legacy-provider selection through the workstation boundary into

--- a/packages/api/generated/manifest.json
+++ b/packages/api/generated/manifest.json
@@ -181,7 +181,7 @@
       "path": "generated/mcp/tools.json"
     },
     "generated.openapi.openapi": {
-      "artifactHash": "12a410b6ad25b8eac90306fa58142f7dfbc152a0d214416c321c49cb01f5217e",
+      "artifactHash": "08a3f0e1fb5aa073d53355557976d52ed54f9f7c38856c13ef4590f4d1b5c7cb",
       "documentation": {
         "documentation": {
           "description": {
@@ -198,7 +198,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.openapi.openapi",
-        "sourceHash": "12a410b6ad25b8eac90306fa58142f7dfbc152a0d214416c321c49cb01f5217e",
+        "sourceHash": "08a3f0e1fb5aa073d53355557976d52ed54f9f7c38856c13ef4590f4d1b5c7cb",
         "visibility": "public"
       },
       "family": "openapi",
@@ -211,7 +211,7 @@
       "path": "generated/openapi/openapi.yaml"
     },
     "generated.schemas.factory": {
-      "artifactHash": "a744184d43d76aaa4d3e8bc5f88ce3024f73c57bc09c3508686046a453eb378e",
+      "artifactHash": "bcbd21b3e40ab308d6e399b26fe89754c51177aa2ea1179048be780a3a4f3a2e",
       "documentation": {
         "documentation": {
           "description": {
@@ -228,7 +228,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.schemas.factory",
-        "sourceHash": "a744184d43d76aaa4d3e8bc5f88ce3024f73c57bc09c3508686046a453eb378e",
+        "sourceHash": "bcbd21b3e40ab308d6e399b26fe89754c51177aa2ea1179048be780a3a4f3a2e",
         "visibility": "public"
       },
       "family": "config",
@@ -241,7 +241,7 @@
       "path": "generated/schemas/factory.schema.json"
     },
     "generated.schemas.factory-event": {
-      "artifactHash": "a1e5ff6b997612478e335c5bdca957fa8356e401297d1bd85a3e923e278bd181",
+      "artifactHash": "dece5a4253e52fe9c1033067ad629584dac47ad6023e4177e921ed50b6836132",
       "documentation": {
         "documentation": {
           "description": {
@@ -258,7 +258,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.schemas.factory-event",
-        "sourceHash": "a1e5ff6b997612478e335c5bdca957fa8356e401297d1bd85a3e923e278bd181",
+        "sourceHash": "dece5a4253e52fe9c1033067ad629584dac47ad6023e4177e921ed50b6836132",
         "visibility": "public"
       },
       "family": "config",
@@ -271,7 +271,7 @@
       "path": "generated/schemas/factory-event.schema.json"
     },
     "generated.schemas.factory-recording": {
-      "artifactHash": "448df498fb99c8b6ef50219c8c86b7d3447b1c7a75c814ced7b2806ff17d00db",
+      "artifactHash": "866145087c8fc059259d7575b93c8c741feff64eabe02403ad8381efe8a1ec05",
       "documentation": {
         "documentation": {
           "description": {
@@ -288,7 +288,7 @@
         ],
         "formatVersion": "1.0.0",
         "itemId": "generated.schemas.factory-recording",
-        "sourceHash": "448df498fb99c8b6ef50219c8c86b7d3447b1c7a75c814ced7b2806ff17d00db",
+        "sourceHash": "866145087c8fc059259d7575b93c8c741feff64eabe02403ad8381efe8a1ec05",
         "visibility": "public"
       },
       "family": "config",

--- a/packages/api/generated/manifest.json
+++ b/packages/api/generated/manifest.json
@@ -372,5 +372,5 @@
   "formatVersion": "1.0.0",
   "packageId": "you-agent-factory.api",
   "packageVersion": "0.0.0",
-  "sourceCommit": "2f87570118a8aa7a0c4f21cf7978fa7de8547b42"
+  "sourceCommit": "d27eee741041069b1edd64681f5f58c9b0224871"
 }

--- a/packages/api/generated/openapi/openapi.yaml
+++ b/packages/api/generated/openapi/openapi.yaml
@@ -8524,7 +8524,7 @@ components:
           description: Factory-level guard condition to evaluate before dispatch-ready transitions can proceed.
         modelProvider:
           allOf:
-            - $ref: '#/components/schemas/WorkerModelProvider'
+            - $ref: '#/components/schemas/ProviderIdentity'
           description: Provider whose inference-throttle history controls this factory-level guard.
         model:
           type: string
@@ -8753,10 +8753,10 @@ components:
           description: Model identifier to request from the configured model provider when this worker uses model execution.
         modelProvider:
           oneOf:
-            - $ref: '#/components/schemas/WorkerModelProvider'
+            - $ref: '#/components/schemas/ProviderIdentity'
             - type: string
               pattern: ^\$\{[A-Za-z0-9_.-]+\}$
-          description: Canonical model-provider identifier used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Current public built-in values are `CLAUDE` and `CODEX`; the runtime maps them onto the underlying provider command IDs.
+          description: Canonical model-provider identity used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Extension identities use lowercase standardized syntax; built-in values such as `CLAUDE` and `CODEX` remain compatibility conveniences.
         modelLocality:
           allOf:
             - $ref: '#/components/schemas/WorkerModelLocality'
@@ -8840,7 +8840,7 @@ components:
         - HOSTED_WORKER
     WorkerModelProvider:
       type: string
-      description: Canonical model-provider identifiers supported by model workers in factory config.
+      description: Built-in model-provider constants retained as generated-client conveniences. Authored modelProvider fields use the open ProviderIdentity contract, so this list is not an exhaustive provider inventory.
       enum:
         - CLAUDE
         - CODEX
@@ -8850,6 +8850,12 @@ components:
         - OPENCODE
         - PI
         - AGY
+    ProviderIdentity:
+      type: string
+      minLength: 1
+      maxLength: 128
+      pattern: ^(?:[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*|AGY|ANTHROPIC|CLAUDE|CODEX|CURSOR|CURSOR_AGENT|GEMINI|KIRO|OPENAI|OPENCODE|PI)$
+      description: Open provider identity used by authored modelProvider fields. Extension identities use lowercase letters and digits separated by dots or hyphens. Built-in identities and documented legacy aliases remain accepted compatibility spellings. For example, `customer.provider` is a valid extension identity.
     ProviderCatalog:
       type: object
       additionalProperties: false
@@ -10048,8 +10054,8 @@ components:
           $ref: '#/components/schemas/GlobalConfigWorkerPresetReasoningEffort'
     GlobalConfigWorkerPresetModelProvider:
       type: string
-      description: Concrete supported model provider or alias; surrounding whitespace is trimmed, and symbolic DEFAULT is not accepted for presets.
-      pattern: "^[\t-\r \N\_  - \L\P  　]*(?:AGY|ANTHROPIC|CLAUDE|CODEX|CURSOR|CURSOR_AGENT|GEMINI|KIRO|OPENAI|OPENCODE|PI|agent|agy|anthropic|antigravity|claude|codex|cursor|cursor-agent|gemini|kiro|kiro-cli|openai|opencode|pi)[\t-\r \N\_  - \L\P  　]*$"
+      description: Canonical provider identity or built-in compatibility alias; surrounding whitespace is trimmed, and symbolic DEFAULT is not accepted for presets.
+      pattern: "^[\t-\r \N\_  - \L\P  　]*(?:[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*|AGY|ANTHROPIC|CLAUDE|CODEX|CURSOR|CURSOR_AGENT|GEMINI|KIRO|OPENAI|OPENCODE|PI)[\t-\r \N\_  - \L\P  　]*$"
     GlobalConfigWorkerPresetReasoningEffort:
       type: string
       description: Optional reasoning effort; surrounding whitespace and letter case are normalized, and an empty value is treated as unspecified.

--- a/packages/api/generated/schemas/factory-event.schema.json
+++ b/packages/api/generated/schemas/factory-event.schema.json
@@ -1056,7 +1056,7 @@
         "modelProvider": {
           "allOf": [
             {
-              "$ref": "#/$defs/WorkerModelProvider"
+              "$ref": "#/$defs/ProviderIdentity"
             }
           ],
           "description": "Provider whose inference-throttle history controls this factory-level guard."
@@ -3203,6 +3203,13 @@
       },
       "type": "object"
     },
+    "ProviderIdentity": {
+      "description": "Open provider identity used by authored modelProvider fields. Extension identities use lowercase letters and digits separated by dots or hyphens. Built-in identities and documented legacy aliases remain accepted compatibility spellings. For example, `customer.provider` is a valid extension identity.",
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^(?:[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*|AGY|ANTHROPIC|CLAUDE|CODEX|CURSOR|CURSOR_AGENT|GEMINI|KIRO|OPENAI|OPENCODE|PI)$",
+      "type": "string"
+    },
     "ProviderSessionMetadata": {
       "additionalProperties": false,
       "properties": {
@@ -4520,10 +4527,10 @@
           "description": "Provider locality for this model capability declaration. Use `LOCAL` for embedded or host-managed inference and `CLOUD` for remote provider execution."
         },
         "modelProvider": {
-          "description": "Canonical model-provider identifier used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Current public built-in values are `CLAUDE` and `CODEX`; the runtime maps them onto the underlying provider command IDs.",
+          "description": "Canonical model-provider identity used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Extension identities use lowercase standardized syntax; built-in values such as `CLAUDE` and `CODEX` remain compatibility conveniences.",
           "oneOf": [
             {
-              "$ref": "#/$defs/WorkerModelProvider"
+              "$ref": "#/$defs/ProviderIdentity"
             },
             {
               "pattern": "^\\$\\{[A-Za-z0-9_.-]+\\}$",
@@ -4592,20 +4599,6 @@
       "enum": [
         "LOCAL",
         "CLOUD"
-      ],
-      "type": "string"
-    },
-    "WorkerModelProvider": {
-      "description": "Canonical model-provider identifiers supported by model workers in factory config.",
-      "enum": [
-        "CLAUDE",
-        "CODEX",
-        "CURSOR",
-        "GEMINI",
-        "KIRO",
-        "OPENCODE",
-        "PI",
-        "AGY"
       ],
       "type": "string"
     },

--- a/packages/api/generated/schemas/factory-recording.schema.json
+++ b/packages/api/generated/schemas/factory-recording.schema.json
@@ -1591,7 +1591,7 @@
         "modelProvider": {
           "allOf": [
             {
-              "$ref": "#/$defs/WorkerModelProvider"
+              "$ref": "#/$defs/ProviderIdentity"
             }
           ],
           "description": "Provider whose inference-throttle history controls this factory-level guard."
@@ -3738,6 +3738,13 @@
       },
       "type": "object"
     },
+    "ProviderIdentity": {
+      "description": "Open provider identity used by authored modelProvider fields. Extension identities use lowercase letters and digits separated by dots or hyphens. Built-in identities and documented legacy aliases remain accepted compatibility spellings. For example, `customer.provider` is a valid extension identity.",
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^(?:[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*|AGY|ANTHROPIC|CLAUDE|CODEX|CURSOR|CURSOR_AGENT|GEMINI|KIRO|OPENAI|OPENCODE|PI)$",
+      "type": "string"
+    },
     "ProviderSessionMetadata": {
       "additionalProperties": false,
       "properties": {
@@ -5055,10 +5062,10 @@
           "description": "Provider locality for this model capability declaration. Use `LOCAL` for embedded or host-managed inference and `CLOUD` for remote provider execution."
         },
         "modelProvider": {
-          "description": "Canonical model-provider identifier used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Current public built-in values are `CLAUDE` and `CODEX`; the runtime maps them onto the underlying provider command IDs.",
+          "description": "Canonical model-provider identity used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Extension identities use lowercase standardized syntax; built-in values such as `CLAUDE` and `CODEX` remain compatibility conveniences.",
           "oneOf": [
             {
-              "$ref": "#/$defs/WorkerModelProvider"
+              "$ref": "#/$defs/ProviderIdentity"
             },
             {
               "pattern": "^\\$\\{[A-Za-z0-9_.-]+\\}$",
@@ -5127,20 +5134,6 @@
       "enum": [
         "LOCAL",
         "CLOUD"
-      ],
-      "type": "string"
-    },
-    "WorkerModelProvider": {
-      "description": "Canonical model-provider identifiers supported by model workers in factory config.",
-      "enum": [
-        "CLAUDE",
-        "CODEX",
-        "CURSOR",
-        "GEMINI",
-        "KIRO",
-        "OPENCODE",
-        "PI",
-        "AGY"
       ],
       "type": "string"
     },

--- a/packages/api/generated/schemas/factory.schema.json
+++ b/packages/api/generated/schemas/factory.schema.json
@@ -114,7 +114,7 @@
         "modelProvider": {
           "allOf": [
             {
-              "$ref": "#/$defs/WorkerModelProvider"
+              "$ref": "#/$defs/ProviderIdentity"
             }
           ],
           "description": "Provider whose inference-throttle history controls this factory-level guard."
@@ -1451,6 +1451,13 @@
       ],
       "type": "object"
     },
+    "ProviderIdentity": {
+      "description": "Open provider identity used by authored modelProvider fields. Extension identities use lowercase letters and digits separated by dots or hyphens. Built-in identities and documented legacy aliases remain accepted compatibility spellings. For example, `customer.provider` is a valid extension identity.",
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^(?:[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*|AGY|ANTHROPIC|CLAUDE|CODEX|CURSOR|CURSOR_AGENT|GEMINI|KIRO|OPENAI|OPENCODE|PI)$",
+      "type": "string"
+    },
     "RequiredTool": {
       "additionalProperties": false,
       "description": "One declarative external tool dependency for a portable factory.",
@@ -2025,10 +2032,10 @@
           "description": "Provider locality for this model capability declaration. Use `LOCAL` for embedded or host-managed inference and `CLOUD` for remote provider execution."
         },
         "modelProvider": {
-          "description": "Canonical model-provider identifier used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Current public built-in values are `CLAUDE` and `CODEX`; the runtime maps them onto the underlying provider command IDs.",
+          "description": "Canonical model-provider identity used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Extension identities use lowercase standardized syntax; built-in values such as `CLAUDE` and `CODEX` remain compatibility conveniences.",
           "oneOf": [
             {
-              "$ref": "#/$defs/WorkerModelProvider"
+              "$ref": "#/$defs/ProviderIdentity"
             },
             {
               "pattern": "^\\$\\{[A-Za-z0-9_.-]+\\}$",
@@ -2097,20 +2104,6 @@
       "enum": [
         "LOCAL",
         "CLOUD"
-      ],
-      "type": "string"
-    },
-    "WorkerModelProvider": {
-      "description": "Canonical model-provider identifiers supported by model workers in factory config.",
-      "enum": [
-        "CLAUDE",
-        "CODEX",
-        "CURSOR",
-        "GEMINI",
-        "KIRO",
-        "OPENCODE",
-        "PI",
-        "AGY"
       ],
       "type": "string"
     },

--- a/packages/model-providers/metadata/manifest.json
+++ b/packages/model-providers/metadata/manifest.json
@@ -2,7 +2,7 @@
   "formatVersion": "1.0.0",
   "packageId": "you-agent-factory.model-providers",
   "packageVersion": "0.0.0",
-  "sourceCommit": "296989741b0696c5bd10e577c9a1320e70f7f5ec",
+  "sourceCommit": "d27eee741041069b1edd64681f5f58c9b0224871",
   "familyFormatVersions": {
     "model-providers": "1.0.0"
   },

--- a/packages/packaged-factories/schemas/factory.schema.json
+++ b/packages/packaged-factories/schemas/factory.schema.json
@@ -114,7 +114,7 @@
         "modelProvider": {
           "allOf": [
             {
-              "$ref": "#/$defs/WorkerModelProvider"
+              "$ref": "#/$defs/ProviderIdentity"
             }
           ],
           "description": "Provider whose inference-throttle history controls this factory-level guard."
@@ -1451,6 +1451,13 @@
       ],
       "type": "object"
     },
+    "ProviderIdentity": {
+      "description": "Open provider identity used by authored modelProvider fields. Extension identities use lowercase letters and digits separated by dots or hyphens. Built-in identities and documented legacy aliases remain accepted compatibility spellings. For example, `customer.provider` is a valid extension identity.",
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^(?:[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*|AGY|ANTHROPIC|CLAUDE|CODEX|CURSOR|CURSOR_AGENT|GEMINI|KIRO|OPENAI|OPENCODE|PI)$",
+      "type": "string"
+    },
     "RequiredTool": {
       "additionalProperties": false,
       "description": "One declarative external tool dependency for a portable factory.",
@@ -2025,10 +2032,10 @@
           "description": "Provider locality for this model capability declaration. Use `LOCAL` for embedded or host-managed inference and `CLOUD` for remote provider execution."
         },
         "modelProvider": {
-          "description": "Canonical model-provider identifier used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Current public built-in values are `CLAUDE` and `CODEX`; the runtime maps them onto the underlying provider command IDs.",
+          "description": "Canonical model-provider identity used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Extension identities use lowercase standardized syntax; built-in values such as `CLAUDE` and `CODEX` remain compatibility conveniences.",
           "oneOf": [
             {
-              "$ref": "#/$defs/WorkerModelProvider"
+              "$ref": "#/$defs/ProviderIdentity"
             },
             {
               "pattern": "^\\$\\{[A-Za-z0-9_.-]+\\}$",
@@ -2097,20 +2104,6 @@
       "enum": [
         "LOCAL",
         "CLOUD"
-      ],
-      "type": "string"
-    },
-    "WorkerModelProvider": {
-      "description": "Canonical model-provider identifiers supported by model workers in factory config.",
-      "enum": [
-        "CLAUDE",
-        "CODEX",
-        "CURSOR",
-        "GEMINI",
-        "KIRO",
-        "OPENCODE",
-        "PI",
-        "AGY"
       ],
       "type": "string"
     },

--- a/packages/packaged-factories/schemas/factory.schema.yaml
+++ b/packages/packaged-factories/schemas/factory.schema.yaml
@@ -82,7 +82,7 @@ $defs:
                 type: string
             modelProvider:
                 allOf:
-                    - $ref: '#/$defs/WorkerModelProvider'
+                    - $ref: '#/$defs/ProviderIdentity'
                 description: Provider whose inference-throttle history controls this factory-level guard.
             refreshWindow:
                 description: Duration string that controls how long the factory should keep re-checking throttle history before allowing the lane again.
@@ -1029,6 +1029,12 @@ $defs:
             - type
             - value
         type: object
+    ProviderIdentity:
+        description: Open provider identity used by authored modelProvider fields. Extension identities use lowercase letters and digits separated by dots or hyphens. Built-in identities and documented legacy aliases remain accepted compatibility spellings. For example, `customer.provider` is a valid extension identity.
+        maxLength: 128
+        minLength: 1
+        pattern: ^(?:[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*|AGY|ANTHROPIC|CLAUDE|CODEX|CURSOR|CURSOR_AGENT|GEMINI|KIRO|OPENAI|OPENCODE|PI)$
+        type: string
     RequiredTool:
         additionalProperties: false
         description: One declarative external tool dependency for a portable factory.
@@ -1399,9 +1405,9 @@ $defs:
                     - $ref: '#/$defs/WorkerModelLocality'
                 description: Provider locality for this model capability declaration. Use `LOCAL` for embedded or host-managed inference and `CLOUD` for remote provider execution.
             modelProvider:
-                description: Canonical model-provider identifier used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Current public built-in values are `CLAUDE` and `CODEX`; the runtime maps them onto the underlying provider command IDs.
+                description: Canonical model-provider identity used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Extension identities use lowercase standardized syntax; built-in values such as `CLAUDE` and `CODEX` remain compatibility conveniences.
                 oneOf:
-                    - $ref: '#/$defs/WorkerModelProvider'
+                    - $ref: '#/$defs/ProviderIdentity'
                     - pattern: ^\$\{[A-Za-z0-9_.-]+\}$
                       type: string
             name:
@@ -1445,18 +1451,6 @@ $defs:
         enum:
             - LOCAL
             - CLOUD
-        type: string
-    WorkerModelProvider:
-        description: Canonical model-provider identifiers supported by model workers in factory config.
-        enum:
-            - CLAUDE
-            - CODEX
-            - CURSOR
-            - GEMINI
-            - KIRO
-            - OPENCODE
-            - PI
-            - AGY
         type: string
     WorkerProvider:
         description: Concrete worker-provider wrappers supported by the public factory-config contract.

--- a/pkg/root/root_test.go
+++ b/pkg/root/root_test.go
@@ -16,6 +16,7 @@ import (
 	modelproviders "github.com/portpowered/infinite-you/packages/model-providers"
 	"github.com/spf13/cobra"
 
+	"github.com/portpowered/infinite-you/internal/testutil"
 	platformhttpserver "github.com/portpowered/infinite-you/pkg/platform/httpserver"
 	serviceedges "github.com/portpowered/infinite-you/pkg/services/edges"
 	inference "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
@@ -132,6 +133,81 @@ func TestBuildProcessReportsCanonicalRegistryValidationFailure(t *testing.T) {
 		!strings.Contains(buildErr.Error(), "provider registry validation failed") ||
 		!strings.Contains(buildErr.Error(), `"claude": identity collision`) {
 		t.Fatalf("BuildProcess() error = %v, want canonical identity-collision diagnostic", buildErr)
+	}
+}
+
+func TestBuildProcessOpensFactoryWithRegisteredExternalProviderWithoutProviderIO(t *testing.T) {
+	t.Parallel()
+
+	manifest := rootExternalManifest(t, "customer.provider", "customer")
+	integration := &rootRecordingIntegration{identity: "customer.provider"}
+	factoryDir := rootFactoryWithProvider(t, "customer")
+
+	process, err := BuildProcess(context.Background(), serviceedges.Edges{
+		ProviderRegistrations: []inference.Registration{{
+			Manifest:    manifest,
+			Integration: integration,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("BuildProcess() error = %v", err)
+	}
+	err = process.Execute(Input{
+		Args: []string{
+			"you", "run", "--dir", factoryDir, "--with-mock-workers", "--quiet", "--no-record",
+		},
+		Env:              homeEnvironment(t.TempDir()),
+		Context:          context.Background(),
+		WorkingDirectory: factoryDir,
+	})
+	if err != nil {
+		t.Fatalf("Process.Execute(run) error = %v", err)
+	}
+	if integration.discoverCalls != 0 ||
+		integration.capabilityCalls != 0 ||
+		integration.invokeCalls != 0 {
+		t.Fatalf(
+			"Factory opening provider I/O = discover:%d capabilities:%d invoke:%d, want zero",
+			integration.discoverCalls,
+			integration.capabilityCalls,
+			integration.invokeCalls,
+		)
+	}
+}
+
+func TestBuildProcessRejectsUnknownAndNonSelectableFactoryProvidersWithoutFallback(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name     string
+		provider string
+		want     string
+	}{
+		{name: "unknown", provider: "unknown.provider", want: `provider "unknown.provider" is unknown`},
+		{name: "not supported", provider: "agy", want: `provider "agy" is not selectable (not-supported)`},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			process, err := BuildProcess(context.Background(), serviceedges.Edges{})
+			if err != nil {
+				t.Fatalf("BuildProcess() error = %v", err)
+			}
+			factoryDir := rootFactoryWithProvider(t, test.provider)
+			err = process.Execute(Input{
+				Args: []string{
+					"you", "run", "--dir", factoryDir, "--with-mock-workers", "--quiet", "--no-record",
+				},
+				Env:              homeEnvironment(t.TempDir()),
+				Context:          context.Background(),
+				WorkingDirectory: factoryDir,
+			})
+			if err == nil ||
+				!strings.Contains(err.Error(), "workers[0].modelProvider") ||
+				!strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Process.Execute(run) error = %v, want field-local %s", err, test.want)
+			}
+		})
 	}
 }
 
@@ -453,6 +529,30 @@ func rootExternalManifest(t *testing.T, identity, alias string) inference.Manife
 	}
 	manifest.MaximumResponseFidelityCapabilities = inference.ResponseFidelityCapabilities{}
 	return manifest
+}
+
+func rootFactoryWithProvider(t *testing.T, provider string) string {
+	t.Helper()
+	factoryDir := testutil.CopyFixtureDir(
+		t,
+		testutil.MustRepoPath(t, filepath.Join("tests", "functional_test", "testdata", "executor_success")),
+	)
+	workerPath := filepath.Join(factoryDir, "workers", "worker", "AGENTS.md")
+	worker := strings.Join([]string{
+		"---",
+		"model: test-model",
+		"modelProvider: " + provider,
+		"stopToken: COMPLETE",
+		"type: MODEL_WORKER",
+		"---",
+		"",
+		"Test worker.",
+		"",
+	}, "\n")
+	if err := os.WriteFile(workerPath, []byte(worker), 0o600); err != nil {
+		t.Fatalf("write provider worker: %v", err)
+	}
+	return factoryDir
 }
 
 func assertProviderLookup(

--- a/pkg/services/factory_definitions/contracts/contracttests/interfaces_contract_enum_normalizer_test.go
+++ b/pkg/services/factory_definitions/contracts/contracttests/interfaces_contract_enum_normalizer_test.go
@@ -1,6 +1,7 @@
 package contracttests
 
 import (
+	"strings"
 	"testing"
 
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions/contracts"
@@ -60,7 +61,7 @@ func publicFactoryEnumNormalizerProviderCases() []publicFactoryEnumNormalizerCas
 		{
 			name:       "worker model provider",
 			alias:      "CODEX",
-			unknown:    "mystery-provider",
+			unknown:    "CUSTOM-PROVIDER",
 			want:       "CODEX",
 			permissive: interfaces.PermissivePublicFactoryWorkerModelProvider,
 			strict:     interfaces.StrictPublicFactoryWorkerModelProvider,
@@ -105,6 +106,23 @@ func publicFactoryEnumNormalizerProviderCases() []publicFactoryEnumNormalizerCas
 			permissive: interfaces.PermissivePublicFactoryResourceType,
 			strict:     interfaces.StrictPublicFactoryResourceType,
 		},
+	}
+}
+
+func TestStrictPublicFactoryWorkerModelProviderAcceptsCanonicalExtensionIdentity(t *testing.T) {
+	t.Parallel()
+
+	const identity = "customer.provider-v2"
+	if got := interfaces.StrictPublicFactoryWorkerModelProvider(identity); got != identity {
+		t.Fatalf("StrictPublicFactoryWorkerModelProvider(%q) = %q, want preserved identity", identity, got)
+	}
+	for _, malformed := range []string{
+		"", " customer.provider", "Customer.provider", "customer_provider",
+		"customer..provider", "customer-", "a" + strings.Repeat("b", 128),
+	} {
+		if got := interfaces.StrictPublicFactoryWorkerModelProvider(malformed); got != "" {
+			t.Errorf("StrictPublicFactoryWorkerModelProvider(%q) = %q, want rejection", malformed, got)
+		}
 	}
 }
 

--- a/pkg/services/factory_definitions/contracts/public_factory_enums.go
+++ b/pkg/services/factory_definitions/contracts/public_factory_enums.go
@@ -6,6 +6,7 @@ import (
 	factoryresource "github.com/portpowered/infinite-you/pkg/services/factory_definitions/resource"
 	workerconfig "github.com/portpowered/infinite-you/pkg/services/factory_definitions/workers"
 	workertaxonomy "github.com/portpowered/infinite-you/pkg/services/factory_definitions/workers/taxonomy"
+	"github.com/portpowered/infinite-you/pkg/services/workers"
 	workerexecution "github.com/portpowered/infinite-you/pkg/services/workers"
 )
 
@@ -427,9 +428,21 @@ func PublicWorkerModelProviderFromInternalRuntime(value string) string {
 	return normalizePublicFactoryEnumValue(value, internalFactoryWorkerModelProviderAliases, true)
 }
 
-// StrictPublicFactoryWorkerModelProvider canonicalizes supported public worker model providers and rejects unknown values.
+// StrictPublicFactoryWorkerModelProvider canonicalizes built-in aliases and
+// preserves extension identities that use the provider contract's canonical
+// syntax. Registry membership is deliberately outside this authored boundary.
 func StrictPublicFactoryWorkerModelProvider(value string) string {
-	return normalizePublicFactoryEnumValue(value, publicFactoryWorkerModelProviderAliases, false)
+	trimmed := strings.TrimSpace(value)
+	if canonical := normalizePublicFactoryEnumValue(trimmed, internalFactoryWorkerModelProviderAliases, false); canonical != "" {
+		return canonical
+	}
+	if trimmed != value {
+		return ""
+	}
+	if err := workers.ProviderIdentity(value).Validate(); err != nil {
+		return ""
+	}
+	return value
 }
 
 // IsSymbolicWorkerModelProviderDefault reports whether value is the symbolic DEFAULT provider.
@@ -446,9 +459,6 @@ func CanonicalizeOperatorWorkerModelProviderInput(value string) (string, bool) {
 	}
 	if IsSymbolicWorkerModelProviderDefault(trimmed) {
 		return WorkerModelProviderDefault, true
-	}
-	if canonical := normalizePublicFactoryEnumValue(trimmed, internalFactoryWorkerModelProviderAliases, false); canonical != "" {
-		return canonical, true
 	}
 	if canonical := StrictPublicFactoryWorkerModelProvider(trimmed); canonical != "" {
 		return canonical, true
@@ -468,11 +478,11 @@ func CanonicalizeReasoningEffort(value string) (string, bool) {
 	}
 }
 
-// AcceptedPublicWorkerModelProviderSummary returns canonical provider names and
-// representative public aliases for operator-facing validation errors.
+// AcceptedPublicWorkerModelProviderSummary describes the open provider identity
+// syntax and representative compatibility aliases for validation errors.
 func AcceptedPublicWorkerModelProviderSummary() string {
-	return "accepted canonical providers: CLAUDE, CODEX, CURSOR, GEMINI, KIRO, OPENCODE, PI, AGY; " +
-		"accepted aliases include codex, claude, gemini, kiro-cli, opencode, pi, agy, agent, cursor, anthropic, and openai"
+	return "use a canonical lowercase provider identity (1-128 bytes; lowercase letters, digits, dots, or hyphens), " +
+		"or a supported built-in identity or legacy alias"
 }
 
 // PermissivePublicFactoryWorkerProvider canonicalizes supported public worker providers and preserves unknown values.

--- a/pkg/services/factory_definitions/loading/runtimetests/runtime_config_model_provider_dispatch_test.go
+++ b/pkg/services/factory_definitions/loading/runtimetests/runtime_config_model_provider_dispatch_test.go
@@ -18,6 +18,13 @@ func TestLoadRuntimeConfig_ResolvesPublicWorkerModelProviderToCLICommand(t *test
 		{name: "GEMINI", public: "GEMINI", internal: modelprovider.ProviderGemini},
 		{name: "KIRO", public: "KIRO", internal: modelprovider.ProviderKiro},
 		{name: "OPENCODE", public: "OPENCODE", internal: modelprovider.ProviderOpenCode},
+		{name: "PI", public: "PI", internal: modelprovider.ProviderPi},
+		{name: "AGY", public: "AGY", internal: modelprovider.ProviderAgy},
+		{name: "anthropic alias", public: "anthropic", internal: modelprovider.ProviderClaude},
+		{name: "openai alias", public: "openai", internal: modelprovider.ProviderCodex},
+		{name: "cursor-agent alias", public: "cursor-agent", internal: modelprovider.ProviderCursor},
+		{name: "kiro-cli alias", public: "kiro-cli", internal: modelprovider.ProviderKiro},
+		{name: "antigravity alias", public: "antigravity", internal: modelprovider.ProviderAgy},
 	}
 
 	for _, tc := range cases {

--- a/pkg/services/factory_definitions/persistence/integrationtests/yaml_persistence_parity_test.go
+++ b/pkg/services/factory_definitions/persistence/integrationtests/yaml_persistence_parity_test.go
@@ -75,6 +75,13 @@ func TestNamedFactoryPersistenceJSONAndYAMLParity(t *testing.T) {
 		if loaded.FactoryConfig().Project != "updated" {
 			t.Fatalf("persisted project = %q, want updated", loaded.FactoryConfig().Project)
 		}
+		worker, ok := loaded.Worker("executor")
+		if !ok {
+			t.Fatal("persisted executor worker is missing")
+		}
+		if worker.ModelProvider != "codex" {
+			t.Fatalf("persisted modelProvider = %q, want codex", worker.ModelProvider)
+		}
 	}
 }
 
@@ -247,6 +254,7 @@ func persistenceParityJSON(project string) string {
   "workers": [{
     "name": "executor",
     "type": "MODEL_WORKER",
+    "modelProvider": "openai",
     "body": "You are the executor."
   }],
   "workstations": [{
@@ -302,6 +310,7 @@ workTypes:
 workers:
   - name: executor
     type: MODEL_WORKER
+    modelProvider: openai
     body: You are the executor.
 workstations:
   - name: execute

--- a/pkg/services/factory_definitions/validation/validate.go
+++ b/pkg/services/factory_definitions/validation/validate.go
@@ -71,13 +71,13 @@ func workerModelProviderTargets(cfg *interfaces.FactoryConfig) []Target {
 		if provider == "" || interfaces.IsSymbolicWorkerModelProviderDefault(provider) || invocationParameterInterpolation(cfg.InvocationSignature, provider) {
 			continue
 		}
-		if _, ok := interfaces.CanonicalizeOperatorWorkerModelProviderInput(provider); ok {
+		if interfaces.StrictPublicFactoryWorkerModelProvider(provider) != "" {
 			continue
 		}
 		targets = append(targets, Target{
 			Code:     CodeWorkerUnsupportedModelProvider,
 			Severity: SeverityError,
-			Message:  fmt.Sprintf("worker modelProvider %q is unsupported; supported values: %s", worker.ModelProvider, interfaces.AcceptedPublicWorkerModelProviderSummary()),
+			Message:  fmt.Sprintf("worker modelProvider %q is malformed; %s", worker.ModelProvider, interfaces.AcceptedPublicWorkerModelProviderSummary()),
 			Subject:  Subject{Type: SubjectTypeWorker, ID: worker.Name, Location: SubjectLocationDefinition},
 			Path:     fmt.Sprintf("%s.workers[%d](%s).modelProvider", validationRoot, workerIndex, worker.Name),
 		})

--- a/pkg/services/factory_definitions/validation/validation_test.go
+++ b/pkg/services/factory_definitions/validation/validation_test.go
@@ -680,6 +680,26 @@ func TestValidate_WorkerModelProviderPreservesExistingOpenAIAlias(t *testing.T) 
 	assertTargetAbsent(t, factoryvalidation.Validate(cfg).Targets, factoryvalidation.CodeWorkerUnsupportedModelProvider, factoryvalidation.SubjectTypeWorker)
 }
 
+func TestValidate_WorkerModelProviderAcceptsExtensionAndRejectsMalformedIdentityAtFieldPath(t *testing.T) {
+	t.Parallel()
+
+	cfg := invocationConfig()
+	cfg.Workers[0].ModelProvider = "customer.provider"
+	assertTargetAbsent(t, factoryvalidation.Validate(cfg).Targets, factoryvalidation.CodeWorkerUnsupportedModelProvider, factoryvalidation.SubjectTypeWorker)
+
+	cfg.Workers[0].ModelProvider = "Customer.Provider"
+	assertTargetDetails(
+		t,
+		factoryvalidation.Validate(cfg).Targets,
+		factoryvalidation.CodeWorkerUnsupportedModelProvider,
+		factoryvalidation.SubjectTypeWorker,
+		"worker-a",
+		factoryvalidation.SubjectLocationDefinition,
+		"malformed",
+		"factory.workers[0](worker-a).modelProvider",
+	)
+}
+
 func TestValidate_OrchestratorCompatibilityAndWorkPropagation(t *testing.T) {
 	t.Run("legacy Petri factory without orchestrator remains valid", func(t *testing.T) {
 		cfg := invocationConfig()

--- a/pkg/services/factory_runtime/build/operator_defaults.go
+++ b/pkg/services/factory_runtime/build/operator_defaults.go
@@ -2,14 +2,10 @@ package runtimebuild
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
-	factorycontracts "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 )
-
-var exactInvocationInterpolationPattern = regexp.MustCompile(`^\$\{([A-Za-z0-9_.-]+)\}$`)
 
 func applyOperatorDefaultsToLoadedConfig(
 	defaultWorkerModelProvider string,
@@ -38,22 +34,6 @@ func applyOperatorDefaultsToLoadedConfig(
 	}); err != nil {
 		return fmt.Errorf("apply operator defaults: %w", err)
 	}
-	return validateModelWorkerRuntimeProviders(loaded)
-}
-
-func validateModelWorkerRuntimeProviders(loaded factorydefinitions.MutableLoadedFactorySource) error {
-	if loaded == nil || loaded.FactoryConfig() == nil {
-		return nil
-	}
-	factoryCfg := loaded.FactoryConfig()
-	for _, worker := range factoryCfg.Workers {
-		if !isModelWorkerType(worker.Type) {
-			continue
-		}
-		if err := validateModelWorkerProvider(factoryCfg.InvocationSignature, worker.Name, worker.ModelProvider); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 
@@ -72,82 +52,15 @@ func operatorDefaultProviderInternal(canonicalPublic string) (string, error) {
 		return "", nil
 	}
 	internal, ok := factorydefinitions.InternalModelProviderFromPublicWorkerModelProvider(trimmed)
-	if !ok {
+	if ok {
+		return string(internal), nil
+	}
+	if factorydefinitions.StrictPublicFactoryWorkerModelProvider(trimmed) == "" {
 		return "", fmt.Errorf(
 			"unsupported worker model provider %q: %s",
 			trimmed,
 			factorydefinitions.AcceptedPublicWorkerModelProviderSummary(),
 		)
 	}
-	return string(internal), nil
-}
-
-func validateModelWorkerProvider(
-	signature *factorydefinitions.InvocationSignatureConfig,
-	workerName string,
-	modelProvider string,
-) error {
-	trimmed := strings.TrimSpace(modelProvider)
-	if trimmed == "" || invocationInterpolationParameterName(signature, trimmed) != "" {
-		return nil
-	}
-	if factorydefinitions.IsSymbolicWorkerModelProviderDefault(trimmed) {
-		return fmt.Errorf(
-			"model worker %q has unresolved DEFAULT model provider; set modelProvider or configure an operator default worker model provider",
-			workerName,
-		)
-	}
-	if isSupportedRuntimeModelProvider(trimmed) {
-		return nil
-	}
-	return fmt.Errorf(
-		"model worker %q has unsupported model provider %q: %s",
-		workerName,
-		trimmed,
-		factorydefinitions.AcceptedPublicWorkerModelProviderSummary(),
-	)
-}
-
-func isSupportedRuntimeModelProvider(value string) bool {
-	trimmed := strings.TrimSpace(value)
-	if trimmed == "" {
-		return true
-	}
-	for _, provider := range factorycontracts.SupportedModelProviders() {
-		if string(provider) == trimmed {
-			return true
-		}
-	}
-	if canonical := factorydefinitions.StrictPublicFactoryWorkerModelProvider(trimmed); canonical != "" {
-		if _, ok := factorydefinitions.InternalModelProviderFromPublicWorkerModelProvider(canonical); ok {
-			return true
-		}
-	}
-	if canonical, ok := factorydefinitions.CanonicalizeOperatorWorkerModelProviderInput(trimmed); ok &&
-		!factorydefinitions.IsSymbolicWorkerModelProviderDefault(canonical) {
-		if _, ok := factorydefinitions.InternalModelProviderFromPublicWorkerModelProvider(canonical); ok {
-			return true
-		}
-	}
-	return false
-}
-
-func invocationInterpolationParameterName(
-	signature *factorydefinitions.InvocationSignatureConfig,
-	value string,
-) string {
-	if signature == nil {
-		return ""
-	}
-	match := exactInvocationInterpolationPattern.FindStringSubmatch(strings.TrimSpace(value))
-	if len(match) != 2 {
-		return ""
-	}
-	name := strings.TrimSpace(match[1])
-	for _, parameter := range signature.Parameters {
-		if strings.TrimSpace(parameter.Name) == name {
-			return name
-		}
-	}
-	return ""
+	return trimmed, nil
 }

--- a/pkg/services/factory_runtime/internal/orchestrators/javascript/runtime/callbehavior_inventory_test.go
+++ b/pkg/services/factory_runtime/internal/orchestrators/javascript/runtime/callbehavior_inventory_test.go
@@ -586,7 +586,7 @@ func agentRunErrorSource(condition string) string {
 	case "unknown-preset":
 		return ""
 	case "unsupported-model-provider":
-		return `return agent.run({ prompt: "review", modelProvider: "not-a-provider" });`
+		return `return agent.run({ prompt: "review", modelProvider: "Not_A_Provider" });`
 	case "unsupported-reasoning-effort":
 		return `return agent.run({ prompt: "review", reasoningEffort: "not-an-effort" });`
 	default:

--- a/pkg/services/factory_sessions/execution_opening_contract.go
+++ b/pkg/services/factory_sessions/execution_opening_contract.go
@@ -2,6 +2,10 @@ package factorysessions
 
 import "io"
 
+// ProviderIdentityResolver resolves one authored provider selection through
+// the immutable process registry without exposing a second service interface.
+type ProviderIdentityResolver func(string) (string, error)
+
 // ExecutionRuntimeOpeningRequest carries invocation-edge roots required to
 // open a runtime-backed durable execution service without ambient discovery.
 type ExecutionRuntimeOpeningRequest struct {

--- a/pkg/services/factory_sessions/internal/runtimeopening/construction.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/construction.go
@@ -12,6 +12,7 @@ import (
 	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/fileeffects"
 	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/logicaltarget"
 	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/roles"
+	operatordefaultsruntime "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/runtimeopening/operatordefaults"
 	"github.com/portpowered/infinite-you/pkg/services/models"
 	operatorconfig "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	"github.com/portpowered/infinite-you/pkg/services/recordings"
@@ -63,6 +64,7 @@ func PrepareRuntime(
 	generateRuntimeInstanceID factorysessions.RuntimeInstanceIDGenerator,
 	resolveHome factorysessions.HomeDirectoryResolver,
 	replayFiles fileeffects.ReplayRecordingReader,
+	providerIdentities factorysessions.ProviderIdentityResolver,
 ) (
 	prepared preparedRuntime,
 	root RuntimeRoot,
@@ -130,6 +132,15 @@ func PrepareRuntime(
 	if err != nil {
 		return preparedRuntime{}, RuntimeRoot{}, RuntimeLoad{}, nil, nil, nil, err
 	}
+	if err := operatordefaultsruntime.ResolveConcreteProviderSelections(
+		load.LoadedFactoryCfg,
+		providerIdentities,
+	); err != nil {
+		return preparedRuntime{}, RuntimeRoot{}, RuntimeLoad{}, nil, nil, nil, fmt.Errorf(
+			"validate Factory provider selections: %w",
+			err,
+		)
+	}
 	if factoryDefinitionValidator == nil {
 		return preparedRuntime{}, RuntimeRoot{}, RuntimeLoad{}, nil, nil, nil, fmt.Errorf(
 			"Factory Definition validator is required",
@@ -175,6 +186,7 @@ func NewDurableExecution(
 	clock factoryruntime.Clock,
 	providerOverride workerprovider.Provider,
 	executionFactory FactorySessionExecutionFactory,
+	providerIdentities factorysessions.ProviderIdentityResolver,
 ) (factorysessions.ExecutionService, error) {
 	if executionFactory == nil {
 		return nil, fmt.Errorf("compose durable session execution: Factory Sessions execution factory is required")
@@ -188,14 +200,35 @@ func NewDurableExecution(
 	if err != nil {
 		return nil, fmt.Errorf("compose durable session worker presets: %w", err)
 	}
+	if providerIdentities == nil {
+		return nil, fmt.Errorf("compose durable session worker presets: provider identity resolver is required")
+	}
 	workerPresetIDs := make(map[string]struct{}, len(operatorConfig.WorkerPresets))
 	workerPresets := make(map[string]factoryruntime.JavaScriptWorkerPreset, len(operatorConfig.WorkerPresets))
-	for _, preset := range operatorConfig.WorkerPresets {
+	for index, preset := range operatorConfig.WorkerPresets {
+		canonicalProvider, err := providerIdentities(preset.ModelProvider)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"compose durable session worker presets: workerPresets[%d].modelProvider: %w",
+				index,
+				err,
+			)
+		}
 		workerPresetIDs[preset.ID] = struct{}{}
 		workerPresets[preset.ID] = factoryruntime.JavaScriptWorkerPreset{
-			ModelProvider:   preset.ModelProvider,
+			ModelProvider:   canonicalProvider,
 			Model:           preset.Model,
 			ReasoningEffort: preset.ReasoningEffort,
+		}
+	}
+	defaultProvider := operatorConfig.Defaults.WorkerModelProvider
+	if strings.TrimSpace(defaultProvider) != "" {
+		defaultProvider, err = providerIdentities(defaultProvider)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"compose durable session worker presets: defaults.workerModelProvider: %w",
+				err,
+			)
 		}
 	}
 	execution, err := executionFactory(
@@ -206,7 +239,7 @@ func NewDurableExecution(
 		workerPresetIDs,
 		factoryruntime.JavaScriptWorkerSettings{
 			Presets:              workerPresets,
-			DefaultModelProvider: operatorConfig.Defaults.WorkerModelProvider,
+			DefaultModelProvider: defaultProvider,
 			DefaultModel:         operatorConfig.Defaults.WorkerModel,
 		},
 	)

--- a/pkg/services/factory_sessions/internal/runtimeopening/factories.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/factories.go
@@ -108,6 +108,7 @@ type DurableExecutionFactory func(
 	factoryruntime.Clock,
 	workerprovider.Provider,
 	FactorySessionExecutionFactory,
+	factorysessions.ProviderIdentityResolver,
 ) (factorysessions.ExecutionService, error)
 
 type WorkerExecutionFactory func(

--- a/pkg/services/factory_sessions/internal/runtimeopening/factory.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/factory.go
@@ -70,6 +70,7 @@ type Factory struct {
 	generateRuntimeInstanceID       factorysessions.RuntimeInstanceIDGenerator
 	resolveHome                     factorysessions.HomeDirectoryResolver
 	replayFiles                     fileeffects.ReplayRecordingReader
+	providerIdentities              factorysessions.ProviderIdentityResolver
 }
 
 // backendsizecheck:ignore-function service-ownership migration preserves this orchestration flow; extract focused helpers and remove this exemption.
@@ -117,6 +118,7 @@ func NewFactory(
 	generateRuntimeInstanceID factorysessions.RuntimeInstanceIDGenerator,
 	resolveHome factorysessions.HomeDirectoryResolver,
 	replayFiles fileeffects.ReplayRecordingReader,
+	providerIdentities factorysessions.ProviderIdentityResolver,
 ) (*Factory, error) {
 	if workflowPreview == nil {
 		return nil, fmt.Errorf("Factory Runtime workflow preview operation is required")
@@ -150,6 +152,9 @@ func NewFactory(
 	}
 	if factorySessionsService == nil {
 		return nil, fmt.Errorf("Factory Sessions service is required")
+	}
+	if providerIdentities == nil {
+		return nil, fmt.Errorf("provider identity resolver is required")
 	}
 	return &Factory{
 		durableExecutionFactory:         durableExecutionFactory,
@@ -194,6 +199,7 @@ func NewFactory(
 		generateRuntimeInstanceID:       generateRuntimeInstanceID,
 		resolveHome:                     resolveHome,
 		replayFiles:                     replayFiles,
+		providerIdentities:              providerIdentities,
 	}, nil
 }
 
@@ -247,6 +253,7 @@ func (f *Factory) openRuntime(
 		f.generateRuntimeInstanceID,
 		f.resolveHome,
 		f.replayFiles,
+		f.providerIdentities,
 	)
 }
 

--- a/pkg/services/factory_sessions/internal/runtimeopening/open.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/open.go
@@ -69,6 +69,7 @@ func openRuntime(
 	generateRuntimeInstanceID factorysessions.RuntimeInstanceIDGenerator,
 	resolveHome factorysessions.HomeDirectoryResolver,
 	replayFiles fileeffects.ReplayRecordingReader,
+	providerIdentities factorysessions.ProviderIdentityResolver,
 ) (runtimeProducts, error) {
 	if request == nil {
 		return runtimeProducts{}, fmt.Errorf("runtime opening request is required")
@@ -108,6 +109,7 @@ func openRuntime(
 		generateRuntimeInstanceID,
 		resolveHome,
 		replayFiles,
+		providerIdentities,
 	)
 	if err != nil {
 		return runtimeProducts{}, err
@@ -142,6 +144,7 @@ func openRuntime(
 		clock,
 		edges.ProviderOverride,
 		factorySessionExecutionFactory,
+		providerIdentities,
 	)
 	if err != nil {
 		return runtimeProducts{}, err

--- a/pkg/services/factory_sessions/internal/runtimeopening/operatordefaults/operator_defaults_runtime.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/operatordefaults/operator_defaults_runtime.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"strings"
 
-	factorycontracts "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	operatorconfig "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 )
 
@@ -31,22 +31,58 @@ func ApplyToLoadedConfig(loaded interfaces.MutableLoadedFactorySource, defaults 
 	})
 }
 
-// ValidateModelWorkerRuntimeProviders rejects unresolved DEFAULT and unsupported
-// model providers on MODEL_WORKER definitions before runtime dispatch.
-func ValidateModelWorkerRuntimeProviders(loaded interfaces.MutableLoadedFactorySource) error {
+// ResolveConcreteProviderSelections resolves every concrete provider selection
+// through the process registry after operator defaults have been applied.
+// Invocation expressions stay unresolved until invocation input is available.
+func ResolveConcreteProviderSelections(
+	loaded interfaces.MutableLoadedFactorySource,
+	providers factorysessions.ProviderIdentityResolver,
+) error {
 	if loaded == nil || loaded.FactoryConfig() == nil {
 		return nil
 	}
+	if providers == nil {
+		return fmt.Errorf("provider identity resolver is required")
+	}
 	factoryCfg := loaded.FactoryConfig()
-	for _, worker := range factoryCfg.Workers {
+	for index := range factoryCfg.Workers {
+		worker := &factoryCfg.Workers[index]
 		if !isModelWorkerType(worker.Type) {
 			continue
 		}
-		if err := validateModelWorkerProvider(factoryCfg.InvocationSignature, worker.Name, worker.ModelProvider); err != nil {
-			return err
+		canonical, err := resolveConcreteProvider(
+			factoryCfg.InvocationSignature,
+			worker.ModelProvider,
+			providers,
+		)
+		if err != nil {
+			return fmt.Errorf("workers[%d].modelProvider: %w", index, err)
 		}
+		worker.ModelProvider = canonical
 	}
-	return nil
+	for index := range factoryCfg.Guards {
+		guard := &factoryCfg.Guards[index]
+		canonical, err := resolveConcreteProvider(nil, guard.ModelProvider, providers)
+		if err != nil {
+			return fmt.Errorf("guards[%d].modelProvider: %w", index, err)
+		}
+		guard.ModelProvider = canonical
+	}
+	return loaded.MutateWorkers(func(worker *interfaces.FactoryWorkerConfig) error {
+		if worker == nil || !isModelWorkerType(worker.Type) {
+			return nil
+		}
+		canonical, err := resolveConcreteProvider(
+			factoryCfg.InvocationSignature,
+			worker.ModelProvider,
+			providers,
+		)
+		if err != nil {
+			return fmt.Errorf("model worker %q modelProvider: %w", worker.Name, err)
+		}
+		worker.ModelProvider = canonical
+		return nil
+	})
 }
 
 func applyOperatorDefaultsToWorker(worker *interfaces.FactoryWorkerConfig, defaultProvider, defaultModel string) error {
@@ -77,62 +113,41 @@ func operatorDefaultProviderInternal(canonicalPublic string) (string, error) {
 		return "", nil
 	}
 	internal, ok := interfaces.InternalModelProviderFromPublicWorkerModelProvider(trimmed)
-	if !ok {
+	if ok {
+		return string(internal), nil
+	}
+	if interfaces.StrictPublicFactoryWorkerModelProvider(trimmed) == "" {
 		return "", fmt.Errorf(
 			"unsupported worker model provider %q: %s",
 			trimmed,
 			interfaces.AcceptedPublicWorkerModelProviderSummary(),
 		)
 	}
-	return string(internal), nil
+	return trimmed, nil
 }
 
-func validateModelWorkerProvider(signature *interfaces.InvocationSignatureConfig, workerName, modelProvider string) error {
+func resolveConcreteProvider(
+	signature *interfaces.InvocationSignatureConfig,
+	modelProvider string,
+	providers factorysessions.ProviderIdentityResolver,
+) (string, error) {
 	trimmed := strings.TrimSpace(modelProvider)
 	if trimmed == "" {
-		return nil
+		return "", nil
 	}
 	if invocationInterpolationParameterName(signature, trimmed) != "" {
-		return nil
+		return modelProvider, nil
 	}
 	if interfaces.IsSymbolicWorkerModelProviderDefault(trimmed) {
-		return fmt.Errorf(
-			"model worker %q has unresolved DEFAULT model provider; set modelProvider or configure an operator default worker model provider",
-			workerName,
+		return "", fmt.Errorf(
+			"unresolved DEFAULT model provider; set modelProvider or configure an operator default worker model provider",
 		)
 	}
-	if isSupportedRuntimeModelProvider(trimmed) {
-		return nil
+	canonical, err := providers(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("select provider %q: %w", trimmed, err)
 	}
-	return fmt.Errorf(
-		"model worker %q has unsupported model provider %q: %s",
-		workerName,
-		trimmed,
-		interfaces.AcceptedPublicWorkerModelProviderSummary(),
-	)
-}
-
-func isSupportedRuntimeModelProvider(value string) bool {
-	trimmed := strings.TrimSpace(value)
-	if trimmed == "" {
-		return true
-	}
-	for _, provider := range factorycontracts.SupportedModelProviders() {
-		if string(provider) == trimmed {
-			return true
-		}
-	}
-	if canonical := interfaces.StrictPublicFactoryWorkerModelProvider(trimmed); canonical != "" {
-		if _, ok := interfaces.InternalModelProviderFromPublicWorkerModelProvider(canonical); ok {
-			return true
-		}
-	}
-	if canonical, ok := interfaces.CanonicalizeOperatorWorkerModelProviderInput(trimmed); ok && !interfaces.IsSymbolicWorkerModelProviderDefault(canonical) {
-		if _, ok := interfaces.InternalModelProviderFromPublicWorkerModelProvider(canonical); ok {
-			return true
-		}
-	}
-	return false
+	return canonical, nil
 }
 
 func invocationInterpolationParameterName(signature *interfaces.InvocationSignatureConfig, value string) string {

--- a/pkg/services/factory_sessions/internal/runtimeopening/operatordefaults/operator_defaults_runtime_test.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/operatordefaults/operator_defaults_runtime_test.go
@@ -2,6 +2,7 @@ package operatordefaults_test
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -106,7 +107,7 @@ func TestApplyOperatorDefaultsToLoadedConfig_SkipsScriptAndHostedWorkers(t *test
 	}
 }
 
-func TestValidateModelWorkerRuntimeProviders_RejectsUnsupportedProvider(t *testing.T) {
+func TestResolveConcreteProviderSelectionsRejectsUnknownProviderAtWorkerField(t *testing.T) {
 	factoryDir := t.TempDir()
 	loaded, err := factorydefinitionfixtures.NewLoadedSource(factoryDir, &interfaces.FactoryConfig{
 		Workers: []interfaces.FactoryWorkerConfig{{
@@ -120,16 +121,84 @@ func TestValidateModelWorkerRuntimeProviders_RejectsUnsupportedProvider(t *testi
 		t.Fatalf("NewLoadedFactoryConfig: %v", err)
 	}
 
-	err = operatordefaultsruntime.ValidateModelWorkerRuntimeProviders(loaded)
+	err = operatordefaultsruntime.ResolveConcreteProviderSelections(
+		loaded,
+		providerResolverStub{errors: map[string]error{
+			"not-a-provider": errors.New(`provider "not-a-provider" is unknown`),
+		}}.CanonicalIdentity,
+	)
 	if err == nil {
-		t.Fatal("expected unsupported provider validation error")
+		t.Fatal("expected unknown provider validation error")
 	}
-	if !strings.Contains(err.Error(), "unsupported model provider") {
-		t.Fatalf("error = %q, want unsupported provider guidance", err.Error())
+	if !strings.Contains(err.Error(), "workers[0].modelProvider") ||
+		!strings.Contains(err.Error(), `provider "not-a-provider" is unknown`) {
+		t.Fatalf("error = %q, want field-local unknown-provider diagnostic", err.Error())
 	}
 }
 
-func TestValidateModelWorkerRuntimeProviders_AllowsInvocationInterpolationProvider(t *testing.T) {
+func TestResolveConcreteProviderSelectionsCanonicalizesWorkersAndGuards(t *testing.T) {
+	factoryDir := t.TempDir()
+	loaded, err := factorydefinitionfixtures.NewLoadedSource(factoryDir, &interfaces.FactoryConfig{
+		Workers: []interfaces.FactoryWorkerConfig{{
+			Name:          "executor",
+			Type:          interfaces.WorkerTypeModel,
+			ModelProvider: "customer",
+			Body:          "You are the executor.",
+		}},
+		Guards: []interfaces.FactoryGuardConfig{{
+			Type:          interfaces.GuardTypeInferenceThrottle,
+			ModelProvider: "agent",
+		}},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("NewLoadedFactoryConfig: %v", err)
+	}
+
+	resolver := providerResolverStub{canonical: map[string]string{
+		"customer": "customer.provider",
+		"agent":    "cursor",
+	}}
+	if err := operatordefaultsruntime.ResolveConcreteProviderSelections(
+		loaded,
+		resolver.CanonicalIdentity,
+	); err != nil {
+		t.Fatalf("ResolveConcreteProviderSelections: %v", err)
+	}
+	worker, ok := loaded.Worker("executor")
+	if !ok || worker.ModelProvider != "customer.provider" {
+		t.Fatalf("worker = %#v, want canonical extension provider", worker)
+	}
+	if got := loaded.FactoryConfig().Guards[0].ModelProvider; got != "cursor" {
+		t.Fatalf("guard modelProvider = %q, want canonical cursor identity", got)
+	}
+}
+
+func TestResolveConcreteProviderSelectionsRejectsNonSelectableGuardAtGuardField(t *testing.T) {
+	factoryDir := t.TempDir()
+	loaded, err := factorydefinitionfixtures.NewLoadedSource(factoryDir, &interfaces.FactoryConfig{
+		Guards: []interfaces.FactoryGuardConfig{{
+			Type:          interfaces.GuardTypeInferenceThrottle,
+			ModelProvider: "agy",
+		}},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("NewLoadedFactoryConfig: %v", err)
+	}
+
+	err = operatordefaultsruntime.ResolveConcreteProviderSelections(
+		loaded,
+		providerResolverStub{errors: map[string]error{
+			"agy": errors.New(`provider "agy" is not selectable (catalog-only)`),
+		}}.CanonicalIdentity,
+	)
+	if err == nil ||
+		!strings.Contains(err.Error(), "guards[0].modelProvider") ||
+		!strings.Contains(err.Error(), `provider "agy" is not selectable (catalog-only)`) {
+		t.Fatalf("error = %v, want field-local catalog-only diagnostic", err)
+	}
+}
+
+func TestResolveConcreteProviderSelectionsAllowsInvocationInterpolationProvider(t *testing.T) {
 	factoryDir := t.TempDir()
 	loaded, err := factorydefinitionfixtures.NewLoadedSource(factoryDir, &interfaces.FactoryConfig{
 		InvocationSignature: &interfaces.InvocationSignatureConfig{
@@ -148,9 +217,60 @@ func TestValidateModelWorkerRuntimeProviders_AllowsInvocationInterpolationProvid
 		t.Fatalf("NewLoadedFactoryConfig: %v", err)
 	}
 
-	if err := operatordefaultsruntime.ValidateModelWorkerRuntimeProviders(loaded); err != nil {
-		t.Fatalf("ValidateModelWorkerRuntimeProviders: %v", err)
+	resolver := &recordingProviderResolver{}
+	if err := operatordefaultsruntime.ResolveConcreteProviderSelections(
+		loaded,
+		resolver.CanonicalIdentity,
+	); err != nil {
+		t.Fatalf("ResolveConcreteProviderSelections: %v", err)
 	}
+	if len(resolver.identities) != 0 {
+		t.Fatalf("registry lookups = %v, want none for unresolved invocation provider", resolver.identities)
+	}
+}
+
+func TestApplyOperatorDefaultsToLoadedConfigPreservesExtensionProvider(t *testing.T) {
+	loaded := newOperatorDefaultsRuntimeFixture(t, map[string]any{
+		"workers": []map[string]any{{
+			"name": "executor",
+			"type": "MODEL_WORKER",
+			"body": "You are the executor.",
+		}},
+	})
+
+	if err := operatordefaultsruntime.ApplyToLoadedConfig(loaded, operatorconfig.ResolvedDefaults{
+		WorkerModelProvider: "customer.provider",
+	}); err != nil {
+		t.Fatalf("ApplyToLoadedConfig: %v", err)
+	}
+	worker, ok := loaded.Worker("executor")
+	if !ok || worker.ModelProvider != "customer.provider" {
+		t.Fatalf("worker = %#v, want preserved extension default", worker)
+	}
+}
+
+type providerResolverStub struct {
+	canonical map[string]string
+	errors    map[string]error
+}
+
+func (r providerResolverStub) CanonicalIdentity(identity string) (string, error) {
+	if err := r.errors[identity]; err != nil {
+		return "", err
+	}
+	if canonical := r.canonical[identity]; canonical != "" {
+		return canonical, nil
+	}
+	return identity, nil
+}
+
+type recordingProviderResolver struct {
+	identities []string
+}
+
+func (r *recordingProviderResolver) CanonicalIdentity(identity string) (string, error) {
+	r.identities = append(r.identities, identity)
+	return identity, nil
 }
 
 func newOperatorDefaultsRuntimeFixture(t *testing.T, factory map[string]any) interfaces.MutableLoadedFactorySource {

--- a/pkg/services/factory_sessions/internal/runtimeopening/runtime_load.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/runtime_load.go
@@ -195,7 +195,7 @@ func applyOperatorDefaults(
 	if err := operatordefaultsruntime.ApplyToLoadedConfig(loaded, operatorDefaults); err != nil {
 		return fmt.Errorf("apply operator defaults: %w", err)
 	}
-	return operatordefaultsruntime.ValidateModelWorkerRuntimeProviders(loaded)
+	return nil
 }
 
 func warnReplayMetadataMismatches(

--- a/pkg/services/factory_sessions/internal/runtimeopening/runtime_load_test.go
+++ b/pkg/services/factory_sessions/internal/runtimeopening/runtime_load_test.go
@@ -10,9 +10,11 @@ import (
 	"github.com/jonboulle/clockwork"
 	factorydefinitions "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	factoryruntime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+	factorysessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
 	"github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/fileeffects"
 	operatorconfig "github.com/portpowered/infinite-you/pkg/services/operator_settings"
 	"github.com/portpowered/infinite-you/pkg/services/recordings"
+	workerprovider "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
 	"go.uber.org/zap"
 )
 
@@ -158,5 +160,55 @@ func TestLoadRuntimeRejectsMissingOrNilSessionLoggerFactory(t *testing.T) {
 		nil,
 	); err == nil {
 		t.Fatal("nil session logger error = nil")
+	}
+}
+
+func TestNewDurableExecutionCanonicalizesOperatorDefaultsAndPresets(t *testing.T) {
+	var got factoryruntime.JavaScriptWorkerSettings
+	executionFactory := func(
+		_ string,
+		_ factorysessions.PersistencePolicy,
+		_ workerprovider.Provider,
+		_ factoryruntime.Clock,
+		_ map[string]struct{},
+		settings factoryruntime.JavaScriptWorkerSettings,
+	) (factorysessions.ExecutionService, error) {
+		got = settings
+		return nil, nil
+	}
+	_, err := NewDurableExecution(
+		func(string) (operatorconfig.Config, error) {
+			return operatorconfig.Config{
+				Defaults: operatorconfig.Defaults{WorkerModelProvider: "customer"},
+				WorkerPresets: []operatorconfig.WorkerPreset{{
+					ID: "review", ModelProvider: "agent",
+				}},
+			}, nil
+		},
+		factorydefinitions.RuntimeOpeningRequest{Directory: t.TempDir()},
+		factorysessions.SessionRuntimeOpeningRequest{SystemConfigHome: t.TempDir()},
+		RuntimeRoot{FactoryRootDir: t.TempDir()},
+		nil,
+		nil,
+		executionFactory,
+		factorysessions.ProviderIdentityResolver(func(identity string) (string, error) {
+			switch identity {
+			case "customer":
+				return "customer.provider", nil
+			case "agent":
+				return "cursor", nil
+			default:
+				return "", errors.New("unexpected provider")
+			}
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewDurableExecution: %v", err)
+	}
+	if got.DefaultModelProvider != "customer.provider" {
+		t.Fatalf("default provider = %q, want canonical extension identity", got.DefaultModelProvider)
+	}
+	if preset := got.Presets["review"]; preset.ModelProvider != "cursor" {
+		t.Fatalf("review preset = %#v, want canonical cursor identity", preset)
 	}
 }

--- a/pkg/services/factory_sessions/wire/application_graph.go
+++ b/pkg/services/factory_sessions/wire/application_graph.go
@@ -171,6 +171,7 @@ type RuntimeOpeningDependencies struct {
 	GenerateRuntimeInstanceID       factorysessions.RuntimeInstanceIDGenerator
 	ResolveHome                     factorysessions.HomeDirectoryResolver
 	ReplayFiles                     ReplayRecordingReader
+	ProviderIdentities              factorysessions.ProviderIdentityResolver
 }
 
 func NewRuntimeOpeningFactory(deps RuntimeOpeningDependencies) (*RuntimeOpeningFactory, error) {
@@ -190,6 +191,7 @@ func NewRuntimeOpeningFactory(deps RuntimeOpeningDependencies) (*RuntimeOpeningF
 		deps.CaptureLoadedFactorySnapshot, deps.ResolveClock, deps.NewSessionLogger,
 		deps.AdaptWorkerCommandRunner, deps.ProcessRuntimeFactory, deps.EnsureOperatorBackendScope,
 		deps.GenerateRuntimeInstanceID, deps.ResolveHome, deps.ReplayFiles,
+		deps.ProviderIdentities,
 	)
 }
 

--- a/pkg/services/operator_settings/input_index_parse_cases.go
+++ b/pkg/services/operator_settings/input_index_parse_cases.go
@@ -167,10 +167,10 @@ func parseInvalidWorkerPresetInputCases() []InputCase {
 			Entrypoint:  entrypointDecodeGlobalConfig,
 			Outcome:     outcomeReject,
 			Fixture:     "invalid/preset-unsupported-provider.json",
-			Description: "unsupported workerPresets[].modelProvider values are rejected",
+			Description: "malformed workerPresets[].modelProvider values are rejected",
 			ErrorFragments: []string{
 				`"build"`,
-				`"other"`,
+				`"Other_Provider"`,
 				"unsupported modelProvider",
 			},
 		},

--- a/pkg/services/operator_settings/input_index_resolve_cases.go
+++ b/pkg/services/operator_settings/input_index_resolve_cases.go
@@ -137,13 +137,13 @@ func resolvePrecedenceSecondaryInputCases() []InputCase {
 			Category:    categoryResolvePrecedence,
 			Entrypoint:  entrypointResolve,
 			Outcome:     outcomeReject,
-			Description: "unsupported provider values fail resolve with accepted provider summary",
+			Description: "malformed provider values fail resolve with provider identity syntax",
 			ResolveLayers: &ResolveLayers{
-				FileDefaults: DefaultsSnapshot{WorkerModelProvider: "not-a-provider"},
+				FileDefaults: DefaultsSnapshot{WorkerModelProvider: "Not_A_Provider"},
 			},
 			ErrorFragments: []string{
 				"unsupported worker model provider",
-				"accepted canonical providers",
+				"canonical lowercase provider identity",
 			},
 		},
 	}

--- a/pkg/services/operator_settings/operator_config_test.go
+++ b/pkg/services/operator_settings/operator_config_test.go
@@ -548,14 +548,29 @@ func TestResolve_EnvOverridesFileWhenFlagsUnset(t *testing.T) {
 }
 
 func TestResolve_CanonicalizesProviderAliases(t *testing.T) {
-	resolved, err := Resolve(ResolveInput{
-		File: Defaults{WorkerModelProvider: "kiro-cli"},
-	}, "/tmp/config.json")
-	if err != nil {
-		t.Fatalf("Resolve() error = %v", err)
-	}
-	if resolved.WorkerModelProvider != "KIRO" {
-		t.Fatalf("provider = %q, want KIRO", resolved.WorkerModelProvider)
+	for _, test := range []struct {
+		alias     string
+		canonical string
+	}{
+		{alias: "anthropic", canonical: "CLAUDE"},
+		{alias: "openai", canonical: "CODEX"},
+		{alias: "agent", canonical: "CURSOR"},
+		{alias: "cursor-agent", canonical: "CURSOR"},
+		{alias: "kiro-cli", canonical: "KIRO"},
+		{alias: "antigravity", canonical: "AGY"},
+	} {
+		test := test
+		t.Run(test.alias, func(t *testing.T) {
+			resolved, err := Resolve(ResolveInput{
+				File: Defaults{WorkerModelProvider: test.alias},
+			}, "/tmp/config.json")
+			if err != nil {
+				t.Fatalf("Resolve() error = %v", err)
+			}
+			if resolved.WorkerModelProvider != test.canonical {
+				t.Fatalf("provider = %q, want %q", resolved.WorkerModelProvider, test.canonical)
+			}
+		})
 	}
 }
 

--- a/pkg/services/operator_settings/operator_config_test.go
+++ b/pkg/services/operator_settings/operator_config_test.go
@@ -449,7 +449,7 @@ func TestParseFileConfig_RejectsInvalidWorkerPresets(t *testing.T) {
 		{name: "duplicate id", json: `{"workerPresets":[{"id":"build","modelProvider":"codex"},{"id":" build ","modelProvider":"claude"}]}`, want: []string{`workerPresets[1].id`, `"build"`, "duplicated"}},
 		{name: "missing provider", json: `{"workerPresets":[{"id":"build"}]}`, want: []string{`workerPresets[0]`, `"build"`, "modelProvider"}},
 		{name: "symbolic provider", json: `{"workerPresets":[{"id":"build","modelProvider":"DEFAULT"}]}`, want: []string{`"build"`, `"DEFAULT"`, "unsupported modelProvider"}},
-		{name: "unsupported provider", json: `{"workerPresets":[{"id":"build","modelProvider":"other"}]}`, want: []string{`"build"`, `"other"`, "unsupported modelProvider"}},
+		{name: "malformed provider", json: `{"workerPresets":[{"id":"build","modelProvider":"Other_Provider"}]}`, want: []string{`"build"`, `"Other_Provider"`, "unsupported modelProvider"}},
 		{name: "unsupported reasoning", json: `{"workerPresets":[{"id":"build","modelProvider":"codex","reasoningEffort":"extreme"}]}`, want: []string{`"build"`, `"extreme"`, "unsupported reasoningEffort"}},
 	}
 	for _, tt := range tests {
@@ -469,7 +469,7 @@ func TestParseFileConfig_RejectsInvalidWorkerPresets(t *testing.T) {
 
 func TestLoadFileDefaults_RejectsMalformedWorkerPresets(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.json")
-	if err := os.WriteFile(path, []byte(`{"workerPresets":[{"id":"bad","modelProvider":"unknown"}]}`), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(`{"workerPresets":[{"id":"bad","modelProvider":"Unknown_Provider"}]}`), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	if _, err := LoadFileDefaults(testFiles, decodeTestConfig, path); err == nil || !strings.Contains(err.Error(), path) {
@@ -605,18 +605,31 @@ func TestResolve_PreservesExplicitConfigPathOverride(t *testing.T) {
 	}
 }
 
-func TestResolve_UnsupportedProviderFailsWithAcceptedProviders(t *testing.T) {
+func TestResolve_MalformedProviderFailsWithIdentitySyntax(t *testing.T) {
 	_, err := Resolve(ResolveInput{
-		File: Defaults{WorkerModelProvider: "not-a-provider"},
+		File: Defaults{WorkerModelProvider: "Not_A_Provider"},
 	}, "/tmp/config.json")
 	if err == nil {
-		t.Fatal("expected unsupported provider error")
+		t.Fatal("expected malformed provider error")
 	}
 	if !strings.Contains(err.Error(), "unsupported worker model provider") {
 		t.Fatalf("error = %q, want unsupported provider message", err.Error())
 	}
-	if !strings.Contains(err.Error(), "accepted canonical providers") {
-		t.Fatalf("error = %q, want accepted provider summary", err.Error())
+	if !strings.Contains(err.Error(), "canonical lowercase provider identity") {
+		t.Fatalf("error = %q, want provider identity syntax", err.Error())
+	}
+}
+
+func TestResolve_PreservesExtensionProviderFromCLIOverride(t *testing.T) {
+	const identity = "customer.provider-v2"
+	resolved, err := Resolve(ResolveInput{
+		Flag: Defaults{WorkerModelProvider: identity},
+	}, "/tmp/config.json")
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if resolved.WorkerModelProvider != identity || resolved.WorkerModelProviderSource != SourceFlag {
+		t.Fatalf("resolved provider = %#v, want CLI identity %q", resolved, identity)
 	}
 }
 

--- a/pkg/services/operator_settings/testdata/baseline/operator-config-input-index.json
+++ b/pkg/services/operator_settings/testdata/baseline/operator-config-input-index.json
@@ -163,10 +163,10 @@
       "entrypoint": "DecodeGlobalConfig",
       "outcome": "reject",
       "fixture": "invalid/preset-unsupported-provider.json",
-      "description": "unsupported workerPresets[].modelProvider values are rejected",
+      "description": "malformed workerPresets[].modelProvider values are rejected",
       "errorFragments": [
         "\"build\"",
-        "\"other\"",
+        "\"Other_Provider\"",
         "unsupported modelProvider"
       ]
     },
@@ -347,16 +347,16 @@
       "category": "resolve-precedence",
       "entrypoint": "Resolve",
       "outcome": "reject",
-      "description": "unsupported provider values fail resolve with accepted provider summary",
+      "description": "malformed provider values fail resolve with provider identity syntax",
       "resolveLayers": {
         "fileDefaults": {
-          "workerModelProvider": "not-a-provider"
+          "workerModelProvider": "Not_A_Provider"
         },
         "flag": {}
       },
       "errorFragments": [
         "unsupported worker model provider",
-        "accepted canonical providers"
+        "canonical lowercase provider identity"
       ]
     },
     {

--- a/pkg/services/operator_settings/testdata/fixtures/invalid/preset-unsupported-provider.json
+++ b/pkg/services/operator_settings/testdata/fixtures/invalid/preset-unsupported-provider.json
@@ -2,7 +2,7 @@
   "workerPresets": [
     {
       "id": "build",
-      "modelProvider": "other"
+      "modelProvider": "Other_Provider"
     }
   ]
 }

--- a/pkg/services/workers/construction/service.go
+++ b/pkg/services/workers/construction/service.go
@@ -76,6 +76,7 @@ type Service struct {
 	retryRandom       platformrandom.Source
 	workstationFiles  platformfilesystem.ReadFileInspector
 	resolveRunner     workers.RunnerSelectionResolver
+	resolveProvider   workers.ProviderIdentityResolver
 }
 
 // New constructs a worker executor service from process-owned factories.
@@ -117,6 +118,17 @@ func (s *Service) WithRunnerSelection(resolve workers.RunnerSelectionResolver) *
 	}
 	clone := *s
 	clone.resolveRunner = resolve
+	return &clone
+}
+
+// WithProviderIdentityResolution returns a service copy that validates
+// invocation-resolved provider values through the process-owned authority.
+func (s *Service) WithProviderIdentityResolution(resolve workers.ProviderIdentityResolver) *Service {
+	if s == nil {
+		return nil
+	}
+	clone := *s
+	clone.resolveProvider = resolve
 	return &clone
 }
 
@@ -193,12 +205,14 @@ func (s *Service) Build(
 			runtimeConfig, factoryRunnerID, workflowContext, logger, direct, s.interpolation,
 			s.executionPolicy, clock, processEnvironment, currentWorkingDirectory, s.factoryDocs, s.worktreePreparer, s.workstationFiles,
 			s.resolveRunner,
+			s.resolveProvider,
 		), nil
 	case interfaces.WorkstationTypeLogical:
 		return workstationResult(
 			runtimeConfig, factoryRunnerID, workflowContext, logger, nil,
 			s.interpolation, s.executionPolicy, clock, processEnvironment, currentWorkingDirectory, s.factoryDocs, s.worktreePreparer, s.workstationFiles,
 			s.resolveRunner,
+			s.resolveProvider,
 		), nil
 	case interfaces.WorkerTypeScript:
 		if s == nil || s.scriptFactory == nil {
@@ -214,6 +228,7 @@ func (s *Service) Build(
 			runtimeConfig, factoryRunnerID, workflowContext, logger, direct, s.interpolation,
 			s.executionPolicy, clock, processEnvironment, currentWorkingDirectory, s.factoryDocs, s.worktreePreparer, s.workstationFiles,
 			s.resolveRunner,
+			s.resolveProvider,
 		), nil
 	default:
 		return Result{}, nil
@@ -249,6 +264,7 @@ func (s *Service) BuildLogical(
 		s.worktreePreparer,
 		s.workstationFiles,
 		s.resolveRunner,
+		s.resolveProvider,
 	)
 }
 
@@ -322,6 +338,7 @@ func workstationResult(
 	worktreePreparer workers.FactoryWorktreePreparer,
 	workstationFiles platformfilesystem.ReadFileInspector,
 	resolveRunner workers.RunnerSelectionResolver,
+	resolveProvider workers.ProviderIdentityResolver,
 ) Result {
 	renderer := &workerprompting.DefaultPromptRenderer{FactoryDocs: factoryDocs}
 	return Result{
@@ -331,8 +348,9 @@ func workstationResult(
 			ProcessEnvironment:      processEnvironment,
 			CurrentWorkingDirectory: currentWorkingDirectory,
 			RuntimeConfig:           runtimeConfig, DefaultRunnerID: factoryRunnerID,
-			ResolveRunnerSelection: resolveRunner,
-			WorkflowContext:        workflowContext, Executor: direct,
+			ResolveRunnerSelection:  resolveRunner,
+			ResolveProviderIdentity: resolveProvider,
+			WorkflowContext:         workflowContext, Executor: direct,
 			Interpolation:   interpolation,
 			ExecutionPolicy: executionPolicy,
 			Renderer:        renderer, Logger: logger,

--- a/pkg/services/workers/execution_requests.go
+++ b/pkg/services/workers/execution_requests.go
@@ -84,6 +84,10 @@ type RunnerSelectionResolver func(
 	workerModelProvider string,
 ) (ResolvedRunnerSelection, error)
 
+// ProviderIdentityResolver validates a concrete provider identity or alias and
+// returns the authoritative canonical identity.
+type ProviderIdentityResolver func(identity string) (string, error)
+
 type ResolvedModelOperationBinding struct {
 	Slot    string                      `json:"slot"`
 	Source  ModelOperationBindingSource `json:"source"`

--- a/pkg/services/workers/executor/agent.go
+++ b/pkg/services/workers/executor/agent.go
@@ -381,6 +381,9 @@ func modelProviderForExecution(workerModelProvider string, selection workerexecu
 		}
 	}
 	if workerModelProvider != "" {
+		if provider := modelProviderForRunnerID(workerModelProvider); provider != "" {
+			return provider
+		}
 		return workerModelProvider
 	}
 	return modelProviderForRunnerID(selection.RunnerID)
@@ -396,7 +399,7 @@ func modelProviderForRunnerID(runnerID string) string {
 		return string(modelprovider.ProviderGemini)
 	case workerexecution.RunnerIDKiro:
 		return string(modelprovider.ProviderKiro)
-	case workerexecution.RunnerIDCursorCLI:
+	case "cursor", workerexecution.RunnerIDCursorCLI:
 		return string(modelprovider.ProviderCursor)
 	case workerexecution.RunnerIDOpenCode:
 		return string(modelprovider.ProviderOpenCode)

--- a/pkg/services/workers/executor/workstation_executor.go
+++ b/pkg/services/workers/executor/workstation_executor.go
@@ -56,6 +56,7 @@ type WorkstationExecutor struct {
 	RuntimeConfig           interfaces.RuntimeConfigLookup
 	DefaultRunnerID         string
 	ResolveRunnerSelection  workerexecution.RunnerSelectionResolver
+	ResolveProviderIdentity workerexecution.ProviderIdentityResolver
 	WorkflowContext         *workerexecution.Context
 	Executor                WorkstationRequestExecutor
 	Interpolation           factorydefinitions.InvocationInterpolationService
@@ -188,6 +189,14 @@ func (we *WorkstationExecutor) executeModelWorkstation(ctx context.Context, disp
 			}, nil
 		}
 		workerDef = &interpolatedWorker
+		if failed := we.resolveInvocationProvider(
+			dispatch,
+			workerDef,
+			invocationDiagnostics,
+			start,
+		); failed != nil {
+			return *failed, nil
+		}
 	}
 
 	resolvedContext, failed := we.resolveWorkstationExecutionContext(dispatch, workstationDef, start, logger)
@@ -213,6 +222,31 @@ func (we *WorkstationExecutor) executeModelWorkstation(ctx context.Context, disp
 		return normalizeClassifierWorkResult(result), nil
 	}
 	return result, nil
+}
+
+func (we *WorkstationExecutor) resolveInvocationProvider(
+	dispatch work.WorkDispatch,
+	worker *factorydefinitions.FactoryWorkerConfig,
+	diagnostics *workerexecution.WorkDiagnostics,
+	start time.Time,
+) *workerexecution.WorkResult {
+	if we.ResolveProviderIdentity == nil || worker == nil ||
+		strings.TrimSpace(worker.ModelProvider) == "" {
+		return nil
+	}
+	canonical, err := we.ResolveProviderIdentity(worker.ModelProvider)
+	if err == nil {
+		worker.ModelProvider = canonical
+		return nil
+	}
+	return &workerexecution.WorkResult{
+		DispatchID:   dispatch.DispatchID,
+		TransitionID: dispatch.TransitionID,
+		Outcome:      workerexecution.OutcomeFailed,
+		Error:        "invocation modelProvider selection failed: " + err.Error(),
+		Diagnostics:  diagnostics,
+		Metrics:      workerexecution.WorkMetrics{Duration: we.Now().Sub(start)},
+	}
 }
 
 func invocationDiagnosticsForDispatch(

--- a/pkg/services/workers/executor/workstation_executor_test.go
+++ b/pkg/services/workers/executor/workstation_executor_test.go
@@ -422,7 +422,10 @@ func TestWorkstationExecutor_ResolvesInterpolatedProviderThroughRegistryBeforeEx
 		canonical string
 	}{
 		{name: "canonical", resolved: "codex", canonical: "codex"},
-		{name: "legacy alias", resolved: "openai", canonical: "codex"},
+		{name: "openai legacy alias", resolved: "openai", canonical: "codex"},
+		{name: "anthropic legacy alias", resolved: "anthropic", canonical: "claude"},
+		{name: "cursor manifest alias", resolved: "agent", canonical: "cursor"},
+		{name: "kiro manifest alias", resolved: "kiro-cli", canonical: "kiro"},
 		{name: "registered extension alias", resolved: "customer", canonical: "customer.provider"},
 	} {
 		test := test

--- a/pkg/services/workers/executor/workstation_executor_test.go
+++ b/pkg/services/workers/executor/workstation_executor_test.go
@@ -17,10 +17,12 @@ import (
 	"time"
 
 	"github.com/portpowered/infinite-you/internal/testutil/factorydefinitionfixtures"
+	modelproviders "github.com/portpowered/infinite-you/packages/model-providers"
 	platformfilesystem "github.com/portpowered/infinite-you/pkg/platform/filesystem"
 	"github.com/portpowered/infinite-you/pkg/platform/logging"
 	interfaces "github.com/portpowered/infinite-you/pkg/services/factory_definitions"
 	"github.com/portpowered/infinite-you/pkg/services/work"
+	inferencecontract "github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract"
 	providerregistry "github.com/portpowered/infinite-you/pkg/services/workers/provider/registry"
 )
 
@@ -407,6 +409,211 @@ func TestWorkstationExecutor_ModelWorkstation_InterpolatesInvocationArguments(t 
 		if parameter.Name == "apiKey" && !parameter.Redacted {
 			t.Fatalf("apiKey diagnostic = %#v, want redacted summary", parameter)
 		}
+	}
+}
+
+func TestWorkstationExecutor_ResolvesInterpolatedProviderThroughRegistryBeforeExecution(t *testing.T) {
+	t.Parallel()
+	providers := providerRegistryWithExternalFixture(t)
+
+	for _, test := range []struct {
+		name      string
+		resolved  string
+		canonical string
+	}{
+		{name: "canonical", resolved: "codex", canonical: "codex"},
+		{name: "legacy alias", resolved: "openai", canonical: "codex"},
+		{name: "registered extension alias", resolved: "customer", canonical: "customer.provider"},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mock := &wsMockExecutor{result: workerexecution.WorkResult{
+				Outcome: workerexecution.OutcomeAccepted,
+				Output:  "done",
+			}}
+			executor := interpolatedProviderExecutor(test.resolved, mock)
+			executor.ResolveProviderIdentity = providers.CanonicalIdentity
+			executor.ResolveRunnerSelection = providers.ResolveRunnerSelection
+
+			result, err := executor.Execute(context.Background(), interpolatedProviderDispatch())
+			if err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			if result.Outcome != workerexecution.OutcomeAccepted {
+				t.Fatalf("Execute() result = %#v", result)
+			}
+			if !mock.called {
+				t.Fatal("provider executor was not called")
+			}
+			if mock.dispatch.ModelProvider != test.canonical {
+				t.Fatalf(
+					"execution modelProvider = %q, want canonical %q",
+					mock.dispatch.ModelProvider,
+					test.canonical,
+				)
+			}
+		})
+	}
+}
+
+func TestWorkstationExecutor_RejectsInterpolatedProviderBeforeExecutionIO(t *testing.T) {
+	t.Parallel()
+	providers := providerRegistryWithExternalFixture(t)
+
+	for _, test := range []struct {
+		name     string
+		resolved string
+		want     string
+	}{
+		{name: "malformed", resolved: "Not_A_Provider", want: "is invalid"},
+		{name: "unknown", resolved: "missing.provider", want: "is unknown"},
+		{name: "non-selectable", resolved: "agy", want: "is not selectable"},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mock := &wsMockExecutor{}
+			executor := interpolatedProviderExecutor(test.resolved, mock)
+			executor.ResolveProviderIdentity = providers.CanonicalIdentity
+			// A concrete workstation runner deliberately wins runner precedence.
+			// The provider field must still be validated independently.
+			executor.ResolveRunnerSelection = providers.ResolveRunnerSelection
+
+			result, err := executor.Execute(context.Background(), interpolatedProviderDispatch())
+			if err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			if result.Outcome != workerexecution.OutcomeFailed ||
+				!strings.Contains(result.Error, "invocation modelProvider selection failed") ||
+				!strings.Contains(result.Error, test.want) {
+				t.Fatalf("Execute() result = %#v, want failure containing %q", result, test.want)
+			}
+			if mock.called {
+				t.Fatal("provider executor was called for a rejected provider")
+			}
+			if result.Diagnostics == nil || result.Diagnostics.Invocation == nil {
+				t.Fatalf("result diagnostics = %#v, want invocation diagnostic", result.Diagnostics)
+			}
+		})
+	}
+}
+
+func providerRegistryWithExternalFixture(t *testing.T) *providerregistry.Registry {
+	t.Helper()
+	registrations, err := providerregistry.BuiltInRegistrations()
+	if err != nil {
+		t.Fatalf("BuiltInRegistrations() error = %v", err)
+	}
+	var catalog struct {
+		Providers []providerregistry.Manifest `json:"providers"`
+	}
+	if err := json.Unmarshal(modelproviders.CatalogJSON(), &catalog); err != nil {
+		t.Fatalf("decode provider catalog: %v", err)
+	}
+	manifest := catalog.Providers[0]
+	manifest.ID = "customer.provider"
+	manifest.Aliases = []string{"customer"}
+	manifest.ImplementationAvailability = providerregistry.ImplementationExternallySupplied
+	manifest.TechnicalSupportLevel = providerregistry.SupportProduction
+	manifest.Deprecation = nil
+	manifest.MaximumExecutionCapabilities = providerregistry.ExecutionCapabilities{
+		PromptSubmission: true,
+	}
+	manifest.MaximumResponseFidelityCapabilities = providerregistry.ResponseFidelityCapabilities{}
+	registrations = append(registrations, providerregistry.ExternalRegistration(
+		manifest,
+		executorTestIntegration{},
+	))
+	providers, err := providerregistry.New(registrations...)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	return providers
+}
+
+type executorTestIntegration struct{}
+
+func (executorTestIntegration) Identity() inferencecontract.Identity {
+	return "customer.provider"
+}
+
+func (executorTestIntegration) MaximumCapabilities() inferencecontract.CapabilitySet {
+	return inferencecontract.NewCapabilitySet(inferencecontract.CapabilityPromptSubmission)
+}
+
+func (executorTestIntegration) Discover(context.Context) (inferencecontract.Discovery, error) {
+	panic("provider discovery must not run during provider selection")
+}
+
+func (executorTestIntegration) Capabilities(
+	context.Context,
+	inferencecontract.InvocationRequest,
+) (inferencecontract.CapabilitySet, error) {
+	panic("provider capability I/O must not run during provider selection")
+}
+
+func (executorTestIntegration) Invoke(
+	context.Context,
+	inferencecontract.InvocationRequest,
+	inferencecontract.ResponseWriter,
+) error {
+	panic("provider invocation must not run during provider selection")
+}
+
+func interpolatedProviderExecutor(
+	resolved string,
+	mock WorkstationRequestExecutor,
+) *WorkstationExecutor {
+	executor := newTestWorkstationExecutor(staticRuntimeConfig{
+		Factory: &interfaces.FactoryConfig{
+			InvocationSignature: &interfaces.InvocationSignatureConfig{
+				Parameters: []interfaces.InvocationParameterConfig{{Name: "provider"}},
+			},
+		},
+		Workers: map[string]*interfaces.FactoryWorkerConfig{
+			"worker-a": {
+				Type:          interfaces.WorkerTypeModel,
+				ModelProvider: "${provider}",
+			},
+		},
+		Workstations: map[string]*interfaces.FactoryWorkstationConfig{
+			"standard": {
+				Type:           interfaces.WorkstationTypeModel,
+				Runner:         "codex",
+				PromptTemplate: "run",
+			},
+		},
+	}, mock)
+	executor.Interpolation = factorydefinitionfixtures.InvocationInterpolation{
+		InterpolateWorker: func(
+			worker interfaces.FactoryWorkerConfig,
+			_ *work.InvocationArguments,
+			_ interfaces.FileReader,
+		) (interfaces.FactoryWorkerConfig, error) {
+			worker.ModelProvider = resolved
+			return worker, nil
+		},
+	}
+	return executor
+}
+
+func interpolatedProviderDispatch() work.WorkDispatch {
+	return work.WorkDispatch{
+		DispatchID:      "dispatch-provider",
+		TransitionID:    "transition-provider",
+		WorkerType:      "worker-a",
+		WorkstationName: "standard",
+		InputTokens: InputTokens(factoryruntime.RuntimeToken{
+			ID: "token-provider",
+			Color: factoryruntime.RuntimeTokenColor{
+				InvocationArguments: &work.InvocationArguments{
+					Arguments: map[string]work.InvocationArgument{
+						"provider": {Values: []string{"unused-by-scripted-interpolator"}},
+					},
+				},
+			},
+		}),
 	}
 }
 

--- a/pkg/services/workers/executor/workstation_executor_test.go
+++ b/pkg/services/workers/executor/workstation_executor_test.go
@@ -143,6 +143,18 @@ func TestWorkstationExecutorCarriesCanonicalLegacyProviderThroughInference(t *te
 	}
 }
 
+func TestModelProviderForExecutionProjectsCanonicalCursorIdentityToNativeCommand(t *testing.T) {
+	t.Parallel()
+
+	got := modelProviderForExecution("cursor", workerexecution.ResolvedRunnerSelection{
+		RunnerID: workerexecution.RunnerIDCodex,
+		Source:   workerexecution.RunnerSelectionSourceDefault,
+	})
+	if got != "agent" {
+		t.Fatalf("modelProviderForExecution(cursor) = %q, want agent", got)
+	}
+}
+
 type wsMockExecutor struct {
 	dispatch workerexecution.WorkstationExecutionRequest
 	called   bool

--- a/pkg/services/workers/interfaces.go
+++ b/pkg/services/workers/interfaces.go
@@ -5,12 +5,50 @@ package workers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/fs"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/portpowered/infinite-you/pkg/services/work"
 )
+
+const maxProviderIdentityLength = 128
+
+// ProviderIdentity is the provider-neutral identity accepted at authored and
+// runtime boundaries.
+type ProviderIdentity string
+
+// Validate checks that the identity uses its canonical authored form.
+func (identity ProviderIdentity) Validate() error {
+	if identity == "" {
+		return fmt.Errorf("must not be empty")
+	}
+	if len(identity) > maxProviderIdentityLength {
+		return fmt.Errorf("must not exceed %d bytes", maxProviderIdentityLength)
+	}
+	if !canonicalProviderIdentifier(string(identity)) {
+		return fmt.Errorf("must start with a lowercase letter and contain only lowercase letters, digits, dots, or hyphens")
+	}
+	return nil
+}
+
+func canonicalProviderIdentifier(value string) bool {
+	for index, character := range value {
+		if character >= 'a' && character <= 'z' {
+			continue
+		}
+		if index > 0 && (character >= '0' && character <= '9' || character == '.' || character == '-') {
+			if character != '.' && character != '-' || index+1 < len(value) {
+				continue
+			}
+		}
+		return false
+	}
+	return !strings.Contains(value, "..") && !strings.Contains(value, "--") &&
+		!strings.Contains(value, ".-") && !strings.Contains(value, "-.")
+}
 
 // HostedPollerClock, HostedPollerHTTPDoer, and HostedPollerSecretResolver are
 // the Workers-owned external-effect contracts used to construct hosted worker

--- a/pkg/services/workers/provider/inferencecontract/validation.go
+++ b/pkg/services/workers/provider/inferencecontract/validation.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"strings"
 	"unicode"
+
+	"github.com/portpowered/infinite-you/pkg/services/workers"
 )
 
 const (
-	maxIdentityLength        = 128
 	maxPrerequisiteCount     = 32
 	maxPrerequisiteName      = 80
 	maxPrerequisiteDetail    = 256
@@ -33,15 +34,8 @@ func invalid(field, message string) error {
 
 // ValidateIdentity checks that an opaque identity uses its canonical form.
 func ValidateIdentity(identity Identity) error {
-	value := string(identity)
-	if value == "" {
-		return invalid("identity", "must not be empty")
-	}
-	if len(value) > maxIdentityLength {
-		return invalid("identity", fmt.Sprintf("must not exceed %d bytes", maxIdentityLength))
-	}
-	if !canonicalIdentifier(value) {
-		return invalid("identity", "must start with a lowercase letter and contain only lowercase letters, digits, dots, or hyphens")
+	if err := workers.ProviderIdentity(identity).Validate(); err != nil {
+		return invalid("identity", err.Error())
 	}
 	return nil
 }

--- a/pkg/services/workers/provider/registry/routing.go
+++ b/pkg/services/workers/provider/registry/routing.go
@@ -47,7 +47,7 @@ func (r *Registry) ResolveRunnerSelection(
 			isUnresolvedProviderTemplate(candidate.identity) {
 			continue
 		}
-		runnerID, err := r.RunnerID(candidate.identity)
+		runnerID, err := r.selectionRunnerID(candidate.identity)
 		if err != nil {
 			return workers.ResolvedRunnerSelection{}, err
 		}
@@ -66,6 +66,18 @@ func (r *Registry) ResolveRunnerSelection(
 func isUnresolvedProviderTemplate(identity string) bool {
 	trimmed := strings.TrimSpace(identity)
 	return strings.HasPrefix(trimmed, "${") && strings.HasSuffix(trimmed, "}")
+}
+
+func (r *Registry) selectionRunnerID(identity string) (string, error) {
+	entry, err := r.Lookup(identity)
+	if err != nil {
+		return "", err
+	}
+	canonical := string(entry.Identity())
+	if canonical == "cursor" {
+		return legacyCursorRunnerID, nil
+	}
+	return canonical, nil
 }
 
 // RunnerID resolves a provider canonical ID or alias to the stable native

--- a/pkg/services/workers/provider/registry/routing_test.go
+++ b/pkg/services/workers/provider/registry/routing_test.go
@@ -149,7 +149,7 @@ func TestResolveRunnerSelectionRejectsUnknownAndNonSelectableWithoutFallback(t *
 	}
 }
 
-func TestResolveRunnerSelectionRejectsExternalIntegrationOnNativeRunnerPath(t *testing.T) {
+func TestResolveRunnerSelectionUsesExternalIntegrationCanonicalIdentity(t *testing.T) {
 	t.Parallel()
 	registrations, err := BuiltInRegistrations()
 	if err != nil {
@@ -162,12 +162,23 @@ func TestResolveRunnerSelectionRejectsExternalIntegrationOnNativeRunnerPath(t *t
 		t.Fatalf("New() error = %v", err)
 	}
 
-	_, err = providers.ResolveRunnerSelection("customer", "", "")
-	if err == nil || !strings.Contains(err.Error(), "not available through the provider-native runner path") {
+	selection, err := providers.ResolveRunnerSelection("customer", "", "")
+	if err != nil {
 		t.Fatalf("ResolveRunnerSelection(external) error = %v", err)
+	}
+	if selection.RunnerID != "customer.provider" ||
+		selection.Source != workers.RunnerSelectionSourceWorkstation {
+		t.Fatalf(
+			"ResolveRunnerSelection(external) = %#v, want canonical registered integration",
+			selection,
+		)
 	}
 	if _, err := providers.Integration("customer"); err != nil {
 		t.Fatalf("Integration(external) error = %v", err)
+	}
+	if _, err := providers.RunnerID("customer"); err == nil ||
+		!strings.Contains(err.Error(), "not available through the provider-native runner path") {
+		t.Fatalf("RunnerID(external) error = %v, want native-path rejection", err)
 	}
 }
 

--- a/pkg/services/workers/provider/registry/routing_test.go
+++ b/pkg/services/workers/provider/registry/routing_test.go
@@ -105,6 +105,7 @@ func TestCompatibilityAliasesUseRegistryIdentityAuthority(t *testing.T) {
 	}{
 		{alias: "anthropic", wantCanonical: "claude", wantRunner: "claude"},
 		{alias: workers.RunnerIDCursorCLI, wantCanonical: "cursor", wantRunner: workers.RunnerIDCursorCLI},
+		{alias: "kiro-cli", wantCanonical: "kiro", wantRunner: workers.RunnerIDKiro},
 		{alias: "openai", wantCanonical: "codex", wantRunner: workers.RunnerIDCodex},
 	}
 	for _, test := range tests {

--- a/pkg/services/workers/service/composition.go
+++ b/pkg/services/workers/service/composition.go
@@ -141,7 +141,9 @@ func NewRuntimeWithSelection(
 	service.providerRegistry = providerRegistry
 	if providerRegistry != nil {
 		if builder, ok := service.executorBuilder.(*workerconstruction.Service); ok {
-			service.executorBuilder = builder.WithRunnerSelection(providerRegistry.ResolveRunnerSelection)
+			service.executorBuilder = builder.
+				WithRunnerSelection(providerRegistry.ResolveRunnerSelection).
+				WithProviderIdentityResolution(providerRegistry.CanonicalIdentity)
 		}
 	}
 	return service, nil

--- a/pkg/transports/http/contracttests/factory_config_enum_contract_test.go
+++ b/pkg/transports/http/contracttests/factory_config_enum_contract_test.go
@@ -39,6 +39,7 @@ func TestGlobalConfigContract_AcceptsSupportedDocumentShapes(t *testing.T) {
 			]
 		}`,
 		`{"workerPresets":[{"id":"research","modelProvider":"\u00a0openai\u00a0","reasoningEffort":"\u00a0HIGH\u00a0"}]}`,
+		`{"workerPresets":[{"id":"extension","modelProvider":" customer.provider-v2 "}]}`,
 	} {
 		assertGlobalConfigValidates(t, schema, payload)
 	}
@@ -57,7 +58,7 @@ func TestGlobalConfigContract_RejectsUnsupportedDocumentShapes(t *testing.T) {
 		{name: "Unicode-whitespace preset id", payload: `{"workerPresets":[{"id":"\u00a0","modelProvider":"codex"}]}`},
 		{name: "missing preset provider", payload: `{"workerPresets":[{"id":"build"}]}`},
 		{name: "symbolic preset provider", payload: `{"workerPresets":[{"id":"build","modelProvider":"DEFAULT"}]}`},
-		{name: "unsupported preset provider", payload: `{"workerPresets":[{"id":"build","modelProvider":"other"}]}`},
+		{name: "malformed preset provider", payload: `{"workerPresets":[{"id":"build","modelProvider":"Customer_Provider"}]}`},
 		{name: "unsupported reasoning effort", payload: `{"workerPresets":[{"id":"build","modelProvider":"codex","reasoningEffort":"extreme"}]}`},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -136,7 +137,7 @@ func TestFactoryConfigContract_OpenAPIEnumBackedFieldsReferenceNamedSchemas(t *t
 	schemas := componentSchemas(t, doc)
 	assertSchemaPropertyRef(t, schemas, "InputType", "type", "#/components/schemas/InputKind")
 	assertSchemaPropertyRef(t, schemas, "FactoryGuard", "type", "#/components/schemas/FactoryGuardType")
-	assertSchemaPropertyRef(t, schemas, "FactoryGuard", "modelProvider", "#/components/schemas/WorkerModelProvider")
+	assertSchemaPropertyRef(t, schemas, "FactoryGuard", "modelProvider", "#/components/schemas/ProviderIdentity")
 	assertSchemaArrayItemRef(t, schemas, "Factory", "guards", "#/components/schemas/FactoryGuard")
 	assertSchemaPropertyRef(t, schemas, "WorkState", "type", "#/components/schemas/WorkStateType")
 	assertSchemaPropertyRef(t, schemas, "Worker", "type", "#/components/schemas/WorkerType")
@@ -145,7 +146,7 @@ func TestFactoryConfigContract_OpenAPIEnumBackedFieldsReferenceNamedSchemas(t *t
 		schemas,
 		"Worker",
 		"modelProvider",
-		"#/components/schemas/WorkerModelProvider",
+		"#/components/schemas/ProviderIdentity",
 		`^\$\{[A-Za-z0-9_.-]+\}$`,
 	)
 	assertSchemaPropertyRef(t, schemas, "Worker", "modelLocality", "#/components/schemas/WorkerModelLocality")

--- a/pkg/transports/http/contracttests/factory_config_smoke_test.go
+++ b/pkg/transports/http/contracttests/factory_config_smoke_test.go
@@ -585,7 +585,7 @@ func assertFactoryConfigSmokeEnumRefs(t *testing.T) {
 		schemas,
 		"Worker",
 		"modelProvider",
-		"#/components/schemas/WorkerModelProvider",
+		"#/components/schemas/ProviderIdentity",
 		`^\$\{[A-Za-z0-9_.-]+\}$`,
 	)
 	assertSchemaPropertyRef(t, schemas, "Worker", "modelLocality", "#/components/schemas/WorkerModelLocality")

--- a/pkg/transports/http/contracttests/legacy_model_guard_test.go
+++ b/pkg/transports/http/contracttests/legacy_model_guard_test.go
@@ -131,12 +131,29 @@ func aliasesGeneratedAPI(expr ast.Expr, generatedImportNames map[string]struct{}
 	_, ok = generatedImportNames[ident.Name]
 	return ok
 }
-func TestOpenAPIContract_WorkerModelProviderEnumMatchesSupportedBackendProviders(t *testing.T) {
+func TestOpenAPIContract_WorkerModelProviderConvenienceConstantsMatchBuiltIns(t *testing.T) {
 	doc := loadBundledOpenAPIDocument(t)
 	schemas := componentSchemas(t, doc)
 	schema := schemaObject(t, schemas, "WorkerModelProvider")
 
 	assertEnumValues(t, schema, "WorkerModelProvider", publicWorkerModelProviderValues())
+}
+
+func TestOpenAPIContract_ProviderIdentityIsOpenAndSyntaxConstrained(t *testing.T) {
+	doc := loadBundledOpenAPIDocument(t)
+	schemas := componentSchemas(t, doc)
+	schema := schemaObject(t, schemas, "ProviderIdentity")
+
+	if _, closed := schema["enum"]; closed {
+		t.Fatal("ProviderIdentity must not define a closed enum")
+	}
+	if schema["minLength"] != 1 || schema["maxLength"] != 128 {
+		t.Fatalf("ProviderIdentity length bounds = %v/%v, want 1/128", schema["minLength"], schema["maxLength"])
+	}
+	pattern, _ := schema["pattern"].(string)
+	if pattern == "" || !strings.Contains(pattern, "[a-z][a-z0-9]*") {
+		t.Fatalf("ProviderIdentity.pattern = %q, want standardized lowercase identity syntax", pattern)
+	}
 }
 
 func TestOpenAPIContract_GeneratedWorkerModelProviderConstantsMatchOpenAPIEnum(t *testing.T) {

--- a/pkg/transports/http/contracttests/openapi_contract_authoring_test.go
+++ b/pkg/transports/http/contracttests/openapi_contract_authoring_test.go
@@ -275,6 +275,7 @@ func TestOpenAPIAuthoring_DataModelSchemasUseDedicatedFragments(t *testing.T) {
 		"Worker":                 "./components/schemas/data-models/Worker.yaml",
 		"WorkerType":             "./components/schemas/data-models/WorkerType.yaml",
 		"WorkerModelProvider":    "./components/schemas/data-models/WorkerModelProvider.yaml",
+		"ProviderIdentity":       "./components/schemas/data-models/ProviderIdentity.yaml",
 		"WorkerProvider":         "./components/schemas/data-models/WorkerProvider.yaml",
 		"Workstation":            "./components/schemas/data-models/Workstation.yaml",
 		"WorkstationLimits":      "./components/schemas/data-models/WorkstationLimits.yaml",

--- a/pkg/transports/http/generated/server.gen.go
+++ b/pkg/transports/http/generated/server.gen.go
@@ -1690,7 +1690,7 @@ type FactoryGuard struct {
 	Model *string `json:"model,omitempty"`
 
 	// ModelProvider Provider whose inference-throttle history controls this factory-level guard.
-	ModelProvider WorkerModelProvider `json:"modelProvider"`
+	ModelProvider ProviderIdentity `json:"modelProvider"`
 
 	// RefreshWindow Duration string that controls how long the factory should keep re-checking throttle history before allowing the lane again.
 	RefreshWindow string `json:"refreshWindow"`
@@ -4115,14 +4115,14 @@ type GlobalConfigWorkerPreset struct {
 	// Model Optional model name, trimmed when present.
 	Model *string `json:"model,omitempty"`
 
-	// ModelProvider Concrete supported model provider or alias; surrounding whitespace is trimmed, and symbolic DEFAULT is not accepted for presets.
+	// ModelProvider Canonical provider identity or built-in compatibility alias; surrounding whitespace is trimmed, and symbolic DEFAULT is not accepted for presets.
 	ModelProvider GlobalConfigWorkerPresetModelProvider `json:"modelProvider"`
 
 	// ReasoningEffort Optional reasoning effort; surrounding whitespace and letter case are normalized, and an empty value is treated as unspecified.
 	ReasoningEffort *GlobalConfigWorkerPresetReasoningEffort `json:"reasoningEffort,omitempty"`
 }
 
-// GlobalConfigWorkerPresetModelProvider Concrete supported model provider or alias; surrounding whitespace is trimmed, and symbolic DEFAULT is not accepted for presets.
+// GlobalConfigWorkerPresetModelProvider Canonical provider identity or built-in compatibility alias; surrounding whitespace is trimmed, and symbolic DEFAULT is not accepted for presets.
 type GlobalConfigWorkerPresetModelProvider = string
 
 // GlobalConfigWorkerPresetReasoningEffort Optional reasoning effort; surrounding whitespace and letter case are normalized, and an empty value is treated as unspecified.
@@ -4561,7 +4561,7 @@ type ManagedRuntimeSourceDiagnostics struct {
 
 // ModelCapability defines model for ModelCapability.
 type ModelCapability struct {
-	// ModelProvider Canonical model-provider identifiers supported by model workers in factory config.
+	// ModelProvider Built-in model-provider constants retained as generated-client conveniences. Authored modelProvider fields use the open ProviderIdentity contract, so this list is not an exhaustive provider inventory.
 	ModelProvider *WorkerModelProvider `json:"modelProvider,omitempty"`
 
 	// Operations Operations declared by this worker for the selected model.
@@ -5163,6 +5163,9 @@ type ProviderFailureMetadata struct {
 	// Type Stable machine-readable failure type used to classify failed work across providers and runtimes.
 	Type *WorkFailureType `json:"type,omitempty"`
 }
+
+// ProviderIdentity Open provider identity used by authored modelProvider fields. Extension identities use lowercase letters and digits separated by dots or hyphens. Built-in identities and documented legacy aliases remain accepted compatibility spellings. For example, `customer.provider` is a valid extension identity.
+type ProviderIdentity = WorkerModelProvider
 
 // ProviderImplementationAvailability How an implementation is supplied. Availability is publication metadata, not a live readiness or installation result.
 type ProviderImplementationAvailability string
@@ -6436,7 +6439,7 @@ type Worker struct {
 	// ModelLocality Provider locality for this model capability declaration. Use `LOCAL` for embedded or host-managed inference and `CLOUD` for remote provider execution.
 	ModelLocality *WorkerModelLocality `json:"modelLocality,omitempty"`
 
-	// ModelProvider Canonical model-provider identifier used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Current public built-in values are `CLAUDE` and `CODEX`; the runtime maps them onto the underlying provider command IDs.
+	// ModelProvider Canonical model-provider identity used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Extension identities use lowercase standardized syntax; built-in values such as `CLAUDE` and `CODEX` remain compatibility conveniences.
 	ModelProvider *WorkerModelProvider `json:"modelProvider,omitempty"`
 
 	// Name Worker name referenced by Workstation.worker.
@@ -6470,7 +6473,7 @@ type Worker struct {
 // WorkerModelLocality Provider locality for a model worker capability declaration.
 type WorkerModelLocality string
 
-// WorkerModelProvider Canonical model-provider identifiers supported by model workers in factory config.
+// WorkerModelProvider Built-in model-provider constants retained as generated-client conveniences. Authored modelProvider fields use the open ProviderIdentity contract, so this list is not an exhaustive provider inventory.
 type WorkerModelProvider string
 
 // WorkerProvider Concrete worker-provider wrappers supported by the public factory-config contract.

--- a/pkg/transports/mapping/factoryconfig/authored/agents_config_test.go
+++ b/pkg/transports/mapping/factoryconfig/authored/agents_config_test.go
@@ -66,6 +66,28 @@ You are a software engineer. Write tests for all new code.
 	}
 }
 
+func TestLoadWorkerConfig_PreservesExtensionModelProviderFromYAMLFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	agentsMD := `---
+type: MODEL_WORKER
+modelProvider: customer.provider-v2
+---
+
+Use the registered extension provider.
+`
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(agentsMD), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadWorkerConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadWorkerConfig: %v", err)
+	}
+	if got := cfg.ModelProvider; got != "customer.provider-v2" {
+		t.Fatalf("modelProvider = %q, want preserved extension identity", got)
+	}
+}
+
 func TestLoadWorkerConfig_ScriptWorker(t *testing.T) {
 	dir := t.TempDir()
 	agentsMD := `---

--- a/pkg/transports/mapping/factoryconfig/openapitests/openapi_factory_model_provider_roundtrip_test.go
+++ b/pkg/transports/mapping/factoryconfig/openapitests/openapi_factory_model_provider_roundtrip_test.go
@@ -48,12 +48,53 @@ func TestGeneratedFactoryFromOpenAPIJSON_ModelProviderRoundTripsAllSupportedPubl
 }
 
 func TestGeneratedFactoryFromOpenAPIJSON_RejectsUnknownWorkerModelProviderAtBoundary(t *testing.T) {
-	assertGeneratedFactoryRejectsMisCasedEnumValue(
-		t,
-		"workers[0].modelProvider",
+	for _, malformed := range []string{
 		"MYSTERY-PROVIDER",
-		string(factoryJSONWithModelProvider("MYSTERY-PROVIDER")),
-	)
+		"customer_provider",
+		"customer..provider",
+		"customer.provider-",
+	} {
+		assertGeneratedFactoryRejectsMisCasedEnumValue(
+			t,
+			"workers[0].modelProvider",
+			malformed,
+			string(factoryJSONWithModelProvider(malformed)),
+		)
+	}
+}
+
+func TestGeneratedFactoryFromOpenAPIJSON_PreservesExtensionWorkerAndGuardProviders(t *testing.T) {
+	const identity = "customer.provider-v2"
+	generated, err := GeneratedFactoryFromOpenAPIJSON(factoryJSONWithModelProviderAndGuard(identity))
+	if err != nil {
+		t.Fatalf("GeneratedFactoryFromOpenAPIJSON: %v", err)
+	}
+	assertGeneratedWorkerModelProvider(t, generated, factoryapi.WorkerModelProvider(identity))
+	if generated.Guards == nil || len(*generated.Guards) != 1 || (*generated.Guards)[0].ModelProvider != factoryapi.WorkerModelProvider(identity) {
+		t.Fatalf("generated guard modelProvider = %#v, want %q", generated.Guards, identity)
+	}
+
+	cfg, err := FactoryConfigFromOpenAPI(generated)
+	if err != nil {
+		t.Fatalf("FactoryConfigFromOpenAPI: %v", err)
+	}
+	if got := cfg.Workers[0].ModelProvider; got != identity {
+		t.Fatalf("runtime worker modelProvider = %q, want %q", got, identity)
+	}
+	if got := cfg.Guards[0].ModelProvider; got != identity {
+		t.Fatalf("runtime guard modelProvider = %q, want %q", got, identity)
+	}
+
+	projected, err := FactoryConfigToOpenAPI(&cfg)
+	if err != nil {
+		t.Fatalf("FactoryConfigToOpenAPI: %v", err)
+	}
+	if projected.Workers == nil || (*projected.Workers)[0].ModelProvider == nil || string(*(*projected.Workers)[0].ModelProvider) != identity {
+		t.Fatalf("projected worker modelProvider = %#v, want %q", projected.Workers, identity)
+	}
+	if projected.Guards == nil || string((*projected.Guards)[0].ModelProvider) != identity {
+		t.Fatalf("projected guard modelProvider = %#v, want %q", projected.Guards, identity)
+	}
 }
 
 func factoryJSONWithModelProvider(provider string) []byte {
@@ -69,6 +110,22 @@ func factoryJSONWithModelProvider(provider string) []byte {
 			"outputs":[{"workType":"story","state":"complete"}]
 		}]
 	}`, provider))
+}
+
+func factoryJSONWithModelProviderAndGuard(provider string) []byte {
+	return []byte(fmt.Sprintf(`{
+		"name":"extension-provider-roundtrip-factory",
+		"guards":[{"type":"INFERENCE_THROTTLE_GUARD","modelProvider":%q,"refreshWindow":"1m"}],
+		"workTypes":[{"name":"story","states":[{"name":"init","type":"INITIAL"},{"name":"complete","type":"TERMINAL"}]}],
+		"workers":[{"name":"executor","type":"MODEL_WORKER","modelProvider":%q}],
+		"workstations":[{
+			"name":"execute-story",
+			"worker":"executor",
+			"type":"MODEL_WORKSTATION",
+			"inputs":[{"workType":"story","state":"init"}],
+			"outputs":[{"workType":"story","state":"complete"}]
+		}]
+	}`, provider, provider))
 }
 
 func assertGeneratedWorkerModelProvider(t *testing.T, generated factoryapi.Factory, want factoryapi.WorkerModelProvider) {

--- a/pkg/transports/mapping/factoryconfig/openapitests/openapi_factory_model_provider_roundtrip_test.go
+++ b/pkg/transports/mapping/factoryconfig/openapitests/openapi_factory_model_provider_roundtrip_test.go
@@ -21,6 +21,7 @@ func TestGeneratedFactoryFromOpenAPIJSON_ModelProviderRoundTripsAllSupportedPubl
 		{factoryapi.WorkerModelProviderKiro, modelprovider.ProviderKiro},
 		{factoryapi.WorkerModelProviderOpenCode, modelprovider.ProviderOpenCode},
 		{factoryapi.WorkerModelProviderPi, modelprovider.ProviderPi},
+		{factoryapi.WorkerModelProviderAgy, modelprovider.ProviderAgy},
 	}
 
 	for _, tc := range cases {
@@ -36,6 +37,47 @@ func TestGeneratedFactoryFromOpenAPIJSON_ModelProviderRoundTripsAllSupportedPubl
 				t.Fatalf("FactoryConfigFromOpenAPI: %v", err)
 			}
 			if got := cfg.Workers[0].ModelProvider; got != string(tc.internal) {
+				t.Fatalf("runtime modelProvider = %q, want %q", got, tc.internal)
+			}
+
+			public := WorkerConfigToOpenAPI(cfg.Workers[0])
+			if public.ModelProvider == nil || *public.ModelProvider != tc.public {
+				t.Fatalf("projected modelProvider = %#v, want %q", public.ModelProvider, tc.public)
+			}
+		})
+	}
+}
+
+func TestGeneratedFactoryFromOpenAPIJSON_ModelProviderAliasesRetainCompatibilityRoundTrip(t *testing.T) {
+	cases := []struct {
+		authored string
+		public   factoryapi.WorkerModelProvider
+		internal modelprovider.Provider
+	}{
+		{authored: "anthropic", public: factoryapi.WorkerModelProviderClaude, internal: modelprovider.ProviderClaude},
+		{authored: "ANTHROPIC", public: factoryapi.WorkerModelProviderClaude, internal: modelprovider.ProviderClaude},
+		{authored: "openai", public: factoryapi.WorkerModelProviderCodex, internal: modelprovider.ProviderCodex},
+		{authored: "OPENAI", public: factoryapi.WorkerModelProviderCodex, internal: modelprovider.ProviderCodex},
+		{authored: "agent", public: factoryapi.WorkerModelProviderCursor, internal: modelprovider.ProviderCursor},
+		{authored: "cursor-agent", public: factoryapi.WorkerModelProviderCursor, internal: modelprovider.ProviderCursor},
+		{authored: "CURSOR_AGENT", public: factoryapi.WorkerModelProviderCursor, internal: modelprovider.ProviderCursor},
+		{authored: "kiro-cli", public: factoryapi.WorkerModelProviderKiro, internal: modelprovider.ProviderKiro},
+		{authored: "antigravity", public: factoryapi.WorkerModelProviderAgy, internal: modelprovider.ProviderAgy},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.authored, func(t *testing.T) {
+			generated, err := GeneratedFactoryFromOpenAPIJSON(factoryJSONWithModelProvider(tc.authored))
+			if err != nil {
+				t.Fatalf("GeneratedFactoryFromOpenAPIJSON: %v", err)
+			}
+			assertGeneratedWorkerModelProvider(t, generated, tc.public)
+
+			cfg, err := FactoryConfigFromOpenAPI(generated)
+			if err != nil {
+				t.Fatalf("FactoryConfigFromOpenAPI: %v", err)
+			}
+			if got := modelprovider.Provider(cfg.Workers[0].ModelProvider); got != tc.internal {
 				t.Fatalf("runtime modelProvider = %q, want %q", got, tc.internal)
 			}
 

--- a/pkg/transports/mapping/globalconfig/decode_test.go
+++ b/pkg/transports/mapping/globalconfig/decode_test.go
@@ -75,6 +75,28 @@ func TestEncode_RoundTripsCanonicalIdentityAndSiblingSettings(t *testing.T) {
 	}
 }
 
+func TestEncode_RoundTripsExtensionProviderDefaultsAndPresets(t *testing.T) {
+	const identity = "customer.provider-v2"
+	want := operatorsettings.Config{
+		Defaults: operatorsettings.Defaults{WorkerModelProvider: identity},
+		WorkerPresets: []operatorsettings.WorkerPreset{{
+			ID: "extension", ModelProvider: identity,
+		}},
+	}
+
+	payload, err := globalconfig.Encode(want)
+	if err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+	got, err := globalconfig.Decode(payload)
+	if err != nil {
+		t.Fatalf("Decode(Encode()) error = %v", err)
+	}
+	if got.Defaults.WorkerModelProvider != identity || len(got.WorkerPresets) != 1 || got.WorkerPresets[0].ModelProvider != identity {
+		t.Fatalf("extension provider round trip = %#v, want %q in defaults and presets", got, identity)
+	}
+}
+
 func TestDecode_EmptyObjectReturnsEmptyConfig(t *testing.T) {
 	config, err := globalconfig.Decode([]byte(`{}`))
 	if err != nil {

--- a/pkg/wire/profiles.go
+++ b/pkg/wire/profiles.go
@@ -332,8 +332,18 @@ func provideDurableExecutionFactory(loadOperatorConfig operatorsettings.ConfigLo
 		clock factoryruntime.Clock,
 		provider workerprovider.Provider,
 		factory factorysessionwire.FactorySessionExecutionFactory,
+		providerIdentities factorysessions.ProviderIdentityResolver,
 	) (factorysessions.ExecutionService, error) {
-		return factorysessionwire.NewDurableExecutionRuntime(loadOperatorConfig, definition, session, root, clock, provider, factory)
+		return factorysessionwire.NewDurableExecutionRuntime(
+			loadOperatorConfig,
+			definition,
+			session,
+			root,
+			clock,
+			provider,
+			factory,
+			providerIdentities,
+		)
 	}
 }
 

--- a/pkg/wire/session_runtime_providers.go
+++ b/pkg/wire/session_runtime_providers.go
@@ -74,6 +74,12 @@ func provideProviderRegistry(edges serviceedges.Edges) (*providerregistry.Regist
 	return providerregistry.New(registrations...)
 }
 
+func provideFactorySessionProviderIdentityResolver(
+	providers *providerregistry.Registry,
+) factorysessions.ProviderIdentityResolver {
+	return providers.CanonicalIdentity
+}
+
 func provideProviderSessions(edges serviceedges.Edges) (providersessions.Service, error) {
 	files := edges.ProviderSessionFileSystem
 	if files == nil {

--- a/pkg/wire/wire.go
+++ b/pkg/wire/wire.go
@@ -48,6 +48,7 @@ var apiSet = wire.NewSet(
 var servicesSet = wire.NewSet(
 	provideProviderRegistry,
 	wire.Bind(new(initializerapplication.ProviderRegistry), new(*providerregistry.Registry)),
+	provideFactorySessionProviderIdentityResolver,
 	factorysessionwire.NewRequestPreparation,
 	provideFactorySessionHTTPRequestPreparation,
 	factoryruntime.NewFactoryStatusProjector,

--- a/pkg/wire/wire_gen.go
+++ b/pkg/wire/wire_gen.go
@@ -247,6 +247,7 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	backendScopeEnsurer := provideOperatorBackendScopeEnsurer(fileSystem, createTemporaryFile, operatorsettingsIDGenerator, configDecoder, configEncoder)
 	runtimeInstanceIDGenerator := provideFactorySessionRuntimeInstanceIDGenerator(edges2)
 	v44 := provideFactorySessionReplayRecordingReader(edges2)
+	providerIdentityResolver := provideFactorySessionProviderIdentityResolver(registry)
 	runtimeOpeningDependencies := wire.RuntimeOpeningDependencies{
 		ProviderSessions:                providersessionsService,
 		FactoryWorkflows:                javaScriptWorkflowDefinitions,
@@ -290,6 +291,7 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 		GenerateRuntimeInstanceID:       runtimeInstanceIDGenerator,
 		ResolveHome:                     homeDirectoryResolver,
 		ReplayFiles:                     v44,
+		ProviderIdentities:              providerIdentityResolver,
 	}
 	v45, err := wire.NewRuntimeOpeningFactory(runtimeOpeningDependencies)
 	if err != nil {
@@ -514,7 +516,7 @@ var platformSet = wire2.NewSet(logging.NewDefaultLogger)
 var apiSet = wire2.NewSet(composition.NewWorkAPI, composition.NewHTTPBinder, apisurface.NewRuntimeAPI, composition.NewLiveSessionAPI, factorydefinition.NewAPI, factorysession.NewDurableAPI, factorysession.NewLiveAPI, factorysession.NewInvocationAPI, stdio.NewOpener, application2.NewHandler)
 
 var servicesSet = wire2.NewSet(
-	provideProviderRegistry, wire2.Bind(new(application.ProviderRegistry), new(*registry.Registry)), wire.NewRequestPreparation, provideFactorySessionHTTPRequestPreparation, factory.NewFactoryStatusProjector, factory.NewSessionResultProjectionOperation, provideOperatorSettingsFileSystem,
+	provideProviderRegistry, wire2.Bind(new(application.ProviderRegistry), new(*registry.Registry)), provideFactorySessionProviderIdentityResolver, wire.NewRequestPreparation, provideFactorySessionHTTPRequestPreparation, factory.NewFactoryStatusProjector, factory.NewSessionResultProjectionOperation, provideOperatorSettingsFileSystem,
 	provideOperatorSettingsCreateTemporaryFile,
 	provideOperatorSettingsIDGenerator,
 	provideOperatorConfigDecoder,

--- a/ui/packages/client/src/generated/factory-event.schema.json
+++ b/ui/packages/client/src/generated/factory-event.schema.json
@@ -1056,7 +1056,7 @@
         "modelProvider": {
           "allOf": [
             {
-              "$ref": "#/$defs/WorkerModelProvider"
+              "$ref": "#/$defs/ProviderIdentity"
             }
           ],
           "description": "Provider whose inference-throttle history controls this factory-level guard."
@@ -3203,6 +3203,13 @@
       },
       "type": "object"
     },
+    "ProviderIdentity": {
+      "description": "Open provider identity used by authored modelProvider fields. Extension identities use lowercase letters and digits separated by dots or hyphens. Built-in identities and documented legacy aliases remain accepted compatibility spellings. For example, `customer.provider` is a valid extension identity.",
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^(?:[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*|AGY|ANTHROPIC|CLAUDE|CODEX|CURSOR|CURSOR_AGENT|GEMINI|KIRO|OPENAI|OPENCODE|PI)$",
+      "type": "string"
+    },
     "ProviderSessionMetadata": {
       "additionalProperties": false,
       "properties": {
@@ -4520,10 +4527,10 @@
           "description": "Provider locality for this model capability declaration. Use `LOCAL` for embedded or host-managed inference and `CLOUD` for remote provider execution."
         },
         "modelProvider": {
-          "description": "Canonical model-provider identifier used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Current public built-in values are `CLAUDE` and `CODEX`; the runtime maps them onto the underlying provider command IDs.",
+          "description": "Canonical model-provider identity used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Extension identities use lowercase standardized syntax; built-in values such as `CLAUDE` and `CODEX` remain compatibility conveniences.",
           "oneOf": [
             {
-              "$ref": "#/$defs/WorkerModelProvider"
+              "$ref": "#/$defs/ProviderIdentity"
             },
             {
               "pattern": "^\\$\\{[A-Za-z0-9_.-]+\\}$",
@@ -4592,20 +4599,6 @@
       "enum": [
         "LOCAL",
         "CLOUD"
-      ],
-      "type": "string"
-    },
-    "WorkerModelProvider": {
-      "description": "Canonical model-provider identifiers supported by model workers in factory config.",
-      "enum": [
-        "CLAUDE",
-        "CODEX",
-        "CURSOR",
-        "GEMINI",
-        "KIRO",
-        "OPENCODE",
-        "PI",
-        "AGY"
       ],
       "type": "string"
     },

--- a/ui/packages/client/src/generated/factory.schema.json
+++ b/ui/packages/client/src/generated/factory.schema.json
@@ -114,7 +114,7 @@
         "modelProvider": {
           "allOf": [
             {
-              "$ref": "#/$defs/WorkerModelProvider"
+              "$ref": "#/$defs/ProviderIdentity"
             }
           ],
           "description": "Provider whose inference-throttle history controls this factory-level guard."
@@ -1451,6 +1451,13 @@
       ],
       "type": "object"
     },
+    "ProviderIdentity": {
+      "description": "Open provider identity used by authored modelProvider fields. Extension identities use lowercase letters and digits separated by dots or hyphens. Built-in identities and documented legacy aliases remain accepted compatibility spellings. For example, `customer.provider` is a valid extension identity.",
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^(?:[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*|AGY|ANTHROPIC|CLAUDE|CODEX|CURSOR|CURSOR_AGENT|GEMINI|KIRO|OPENAI|OPENCODE|PI)$",
+      "type": "string"
+    },
     "RequiredTool": {
       "additionalProperties": false,
       "description": "One declarative external tool dependency for a portable factory.",
@@ -2025,10 +2032,10 @@
           "description": "Provider locality for this model capability declaration. Use `LOCAL` for embedded or host-managed inference and `CLOUD` for remote provider execution."
         },
         "modelProvider": {
-          "description": "Canonical model-provider identifier used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Current public built-in values are `CLAUDE` and `CODEX`; the runtime maps them onto the underlying provider command IDs.",
+          "description": "Canonical model-provider identity used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Extension identities use lowercase standardized syntax; built-in values such as `CLAUDE` and `CODEX` remain compatibility conveniences.",
           "oneOf": [
             {
-              "$ref": "#/$defs/WorkerModelProvider"
+              "$ref": "#/$defs/ProviderIdentity"
             },
             {
               "pattern": "^\\$\\{[A-Za-z0-9_.-]+\\}$",
@@ -2097,20 +2104,6 @@
       "enum": [
         "LOCAL",
         "CLOUD"
-      ],
-      "type": "string"
-    },
-    "WorkerModelProvider": {
-      "description": "Canonical model-provider identifiers supported by model workers in factory config.",
-      "enum": [
-        "CLAUDE",
-        "CODEX",
-        "CURSOR",
-        "GEMINI",
-        "KIRO",
-        "OPENCODE",
-        "PI",
-        "AGY"
       ],
       "type": "string"
     },

--- a/ui/packages/client/src/generated/openapi.ts
+++ b/ui/packages/client/src/generated/openapi.ts
@@ -4219,7 +4219,7 @@ export interface components {
       /** @description Factory-level guard condition to evaluate before dispatch-ready transitions can proceed. */
       type: components["schemas"]["FactoryGuardType"];
       /** @description Provider whose inference-throttle history controls this factory-level guard. */
-      modelProvider: components["schemas"]["WorkerModelProvider"];
+      modelProvider: components["schemas"]["ProviderIdentity"];
       /** @description Optional model name to scope throttling more narrowly than the provider-level window. */
       model?: string;
       /** @description Duration string that controls how long the factory should keep re-checking throttle history before allowing the lane again. */
@@ -4342,8 +4342,8 @@ export interface components {
       provider?: components["schemas"]["HostedWorkerProvider"];
       /** @description Model identifier to request from the configured model provider when this worker uses model execution. */
       model?: string;
-      /** @description Canonical model-provider identifier used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Current public built-in values are `CLAUDE` and `CODEX`; the runtime maps them onto the underlying provider command IDs. */
-      modelProvider?: components["schemas"]["WorkerModelProvider"] | string;
+      /** @description Canonical model-provider identity used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Extension identities use lowercase standardized syntax; built-in values such as `CLAUDE` and `CODEX` remain compatibility conveniences. */
+      modelProvider?: components["schemas"]["ProviderIdentity"] | string;
       /** @description Provider locality for this model capability declaration. Use `LOCAL` for embedded or host-managed inference and `CLOUD` for remote provider execution. */
       modelLocality?: components["schemas"]["WorkerModelLocality"];
       /** @description Canonical executor adapter identifier used to select the worker execution provider or wrapper. The current public built-in value is `SCRIPT_WRAP`. */
@@ -4389,10 +4389,12 @@ export interface components {
      */
     WorkerType: WorkerType;
     /**
-     * @description Canonical model-provider identifiers supported by model workers in factory config.
+     * @description Built-in model-provider constants retained as generated-client conveniences. Authored modelProvider fields use the open ProviderIdentity contract, so this list is not an exhaustive provider inventory.
      * @enum {string}
      */
     WorkerModelProvider: WorkerModelProvider;
+    /** @description Open provider identity used by authored modelProvider fields. Extension identities use lowercase letters and digits separated by dots or hyphens. Built-in identities and documented legacy aliases remain accepted compatibility spellings. For example, `customer.provider` is a valid extension identity. */
+    ProviderIdentity: string;
     /** @description Versioned public collection of provider manifests. */
     ProviderCatalog: {
       /**
@@ -5017,7 +5019,7 @@ export interface components {
       model?: string;
       reasoningEffort?: components["schemas"]["GlobalConfigWorkerPresetReasoningEffort"];
     };
-    /** @description Concrete supported model provider or alias; surrounding whitespace is trimmed, and symbolic DEFAULT is not accepted for presets. */
+    /** @description Canonical provider identity or built-in compatibility alias; surrounding whitespace is trimmed, and symbolic DEFAULT is not accepted for presets. */
     GlobalConfigWorkerPresetModelProvider: string;
     /** @description Optional reasoning effort; surrounding whitespace and letter case are normalized, and an empty value is treated as unspecified. */
     GlobalConfigWorkerPresetReasoningEffort: string;

--- a/ui/src/api/generated/openapi.ts
+++ b/ui/src/api/generated/openapi.ts
@@ -4213,7 +4213,7 @@ export interface components {
       /** @description Factory-level guard condition to evaluate before dispatch-ready transitions can proceed. */
       type: components["schemas"]["FactoryGuardType"];
       /** @description Provider whose inference-throttle history controls this factory-level guard. */
-      modelProvider: components["schemas"]["WorkerModelProvider"];
+      modelProvider: components["schemas"]["ProviderIdentity"];
       /** @description Optional model name to scope throttling more narrowly than the provider-level window. */
       model?: string;
       /** @description Duration string that controls how long the factory should keep re-checking throttle history before allowing the lane again. */
@@ -4336,8 +4336,8 @@ export interface components {
       provider?: components["schemas"]["HostedWorkerProvider"];
       /** @description Model identifier to request from the configured model provider when this worker uses model execution. */
       model?: string;
-      /** @description Canonical model-provider identifier used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Current public built-in values are `CLAUDE` and `CODEX`; the runtime maps them onto the underlying provider command IDs. */
-      modelProvider?: components["schemas"]["WorkerModelProvider"] | string;
+      /** @description Canonical model-provider identity used for model routing and provider diagnostics, or an exact invocation-parameter placeholder such as `${modelProvider}`. Extension identities use lowercase standardized syntax; built-in values such as `CLAUDE` and `CODEX` remain compatibility conveniences. */
+      modelProvider?: components["schemas"]["ProviderIdentity"] | string;
       /** @description Provider locality for this model capability declaration. Use `LOCAL` for embedded or host-managed inference and `CLOUD` for remote provider execution. */
       modelLocality?: components["schemas"]["WorkerModelLocality"];
       /** @description Canonical executor adapter identifier used to select the worker execution provider or wrapper. The current public built-in value is `SCRIPT_WRAP`. */
@@ -4383,10 +4383,12 @@ export interface components {
      */
     WorkerType: WorkerType;
     /**
-     * @description Canonical model-provider identifiers supported by model workers in factory config.
+     * @description Built-in model-provider constants retained as generated-client conveniences. Authored modelProvider fields use the open ProviderIdentity contract, so this list is not an exhaustive provider inventory.
      * @enum {string}
      */
     WorkerModelProvider: WorkerModelProvider;
+    /** @description Open provider identity used by authored modelProvider fields. Extension identities use lowercase letters and digits separated by dots or hyphens. Built-in identities and documented legacy aliases remain accepted compatibility spellings. For example, `customer.provider` is a valid extension identity. */
+    ProviderIdentity: string;
     /** @description Versioned public collection of provider manifests. */
     ProviderCatalog: {
       /**
@@ -5011,7 +5013,7 @@ export interface components {
       model?: string;
       reasoningEffort?: components["schemas"]["GlobalConfigWorkerPresetReasoningEffort"];
     };
-    /** @description Concrete supported model provider or alias; surrounding whitespace is trimmed, and symbolic DEFAULT is not accepted for presets. */
+    /** @description Canonical provider identity or built-in compatibility alias; surrounding whitespace is trimmed, and symbolic DEFAULT is not accepted for presets. */
     GlobalConfigWorkerPresetModelProvider: string;
     /** @description Optional reasoning effort; surrounding whitespace and letter case are normalized, and an empty value is treated as unspecified. */
     GlobalConfigWorkerPresetReasoningEffort: string;


### PR DESCRIPTION
{
  "project": "Open Authored Provider Configuration Through the Authoritative Registry",
  "branchName": "standardized-provider-open-configuration",
  "description": "Replace the closed built-in-only modelProvider configuration contract with an open, syntax-constrained provider identity. Preserve valid extension and invocation-interpolated values through authored and transport boundaries, validate concrete selections against the injected authoritative registry at Factory opening or immediately after invocation resolution, reject malformed, unknown, and non-selectable values deterministically without fallback, and preserve built-in and legacy-alias round-trip compatibility across generated public contracts.",
  "context": {
    "customerAsk": "Allow Factory and worker configuration to reference externally registered provider integrations without adding each identity to an OpenAPI enum or built-in source, while keeping malformed-value diagnostics, runtime registry validation, invocation interpolation, generated contracts, and all accepted built-in aliases correct and compatible.",
    "problem": "The current modelProvider contract and associated normalization paths are built-in-only. Valid extension identities can be rejected before the authoritative registry sees them, provider membership and aliases can be duplicated across boundaries, and invocation-resolved values are not uniformly guaranteed to receive the same registry selection check before provider I/O.",
    "solution": "Make the authored provider contract an open string constrained by standardized identity syntax; keep syntax validation and field-local diagnostics at authored/API mapping boundaries; preserve invocation expressions until the existing input/interpolation path resolves them; and inject the one immutable provider registry into Factory opening and pre-I/O invocation selection. Regenerate every public contract projection from authored OpenAPI and retain registry-authoritative compatibility for built-in canonical identities and aliases."
  },
  "acceptanceCriteria": [
    "AC-1: A syntactically valid extension identity passes JSON/YAML and REST/CLI configuration boundaries, round-trips without loss, and selects an integration registered through the normal root.BuildProcess composition path.",
    "AC-2: Malformed provider identities fail at the authored or API mapping boundary with deterministic diagnostics attached to the exact provider field, while syntactically valid unknown identities are not misreported as malformed.",
    "AC-3: Opening a Factory validates every concrete provider selection against the injected authoritative registry; unknown and catalog-only non-selectable entries fail explicitly and no built-in or default provider is substituted.",
    "AC-4: Invocation-interpolated provider values survive Factory loading unresolved, resolve through the existing invocation-input path, and are checked against the same registry before any provider capability, discovery, or invocation I/O.",
    "AC-5: Every accepted built-in canonical identity and legacy alias retains current JSON/YAML/API/CLI round-trip behavior and selects the registry's canonical integration.",
    "AC-6: Authored OpenAPI components, bundled OpenAPI, generated server/client Go, generated TypeScript, mappings, normalizers, public projections, and contract tests remain synchronized without hand-editing generated files.",
    "AC-7: Quality gates pass (typecheck, lint, tests), including make generate-api, make api-smoke, focused provider/configuration/runtime/interpolation/alias tests, make verify-fast, and make lint."
  ],
  "userStories": [
    {
      "id": "standardized-provider-open-configuration-001",
      "title": "Accept open provider identities at authored and API boundaries",
      "description": "As an integration author, I want Factory configuration to accept my provider's valid identity so that registering an integration does not also require changing the product's OpenAPI enum or built-in source.",
      "acceptanceCriteria": [
        "The authored modelProvider contract is a non-empty, syntax-constrained string compatible with standardized provider identity rules, with built-in identities documented as examples rather than an exhaustive enum.",
        "Factory workers, Factory guards, applicable operator defaults and presets, JSON/YAML loading, REST payloads, CLI configuration paths, and public API projections preserve a syntactically valid extension identity instead of rejecting, clearing, or coercing it.",
        "Empty, over-length, uppercase or otherwise non-canonical extension values, illegal characters, and other malformed identities produce deterministic diagnostics attached to the exact modelProvider field at the authored/API mapping boundary.",
        "A syntactically valid but unregistered identity passes syntax mapping so registry membership can be decided at Factory opening rather than by a duplicate built-in list.",
        "Authored OpenAPI components are the source for regenerated bundled OpenAPI, server/client Go, and TypeScript artifacts; generated files are not hand-edited.",
        "Focused OpenAPI contract, Factory configuration, transport mapping, normalization, and public projection tests prove extension-value round trips and field-local malformed-value failures.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "standardized-provider-open-configuration-002",
      "title": "Validate concrete selections when opening a Factory",
      "description": "As a Factory operator, I want concrete provider selections checked against the integrations available to my process so that invalid Factories fail before dispatch with precise diagnostics and never run a different provider.",
      "acceptanceCriteria": [
        "After authored values and operator defaults are combined, Factory opening resolves each concrete provider identity or alias through the authoritative registry injected into existing Factory/session runtime composition.",
        "A canonical extension identity registered through typed process edges and root.BuildProcess opens successfully and resolves to that registered integration without changes to built-in configuration source.",
        "An unknown but syntactically valid identity fails Factory opening with a deterministic diagnostic that names the requested provider and identifies it as unknown.",
        "A catalog-only or otherwise non-selectable registry entry fails Factory opening with a deterministic diagnostic that distinguishes it from an unknown identity.",
        "Factory opening does not silently replace an unknown or non-selectable identity with an operator default, Claude, Codex, or another integration.",
        "The behavior uses existing immutable-registry and service/root composition boundaries; no service locator, second registry, duplicate supported-provider list, or provider-specific selection switch is introduced.",
        "Focused registry, operator-settings, runtime-opening, and clean-process tests prove successful custom registration and both failure classes before dispatch or provider I/O.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "standardized-provider-open-configuration-003",
      "title": "Validate interpolated provider identities before provider I/O",
      "description": "As a Factory author, I want modelProvider to accept an invocation parameter so that each invocation can select a registered provider without making the Factory invalid while the expression is unresolved.",
      "acceptanceCriteria": [
        "A valid invocation interpolation expression in modelProvider survives authored mapping, Factory loading, operator-default application, and Factory opening without being treated as a concrete or malformed provider identity.",
        "The provider expression resolves through the existing invocation argument and interpolation path, then the resulting concrete value is resolved by the same injected registry used at Factory opening.",
        "A resolved canonical identity or legacy alias selects the registry's canonical integration for that invocation.",
        "A resolved malformed, unknown, or non-selectable value fails with a deterministic provider-field or invocation diagnostic before capability, discovery, subprocess, network, or invocation I/O begins.",
        "Missing or invalid invocation input retains existing invocation-input failure behavior and is not converted into a provider fallback.",
        "No default provider is substituted when the resolved identity cannot be selected.",
        "Focused interpolation and invocation tests use observable provider-I/O spies or fakes to prove accepted selection and zero I/O on each rejected result.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "standardized-provider-open-configuration-004",
      "title": "Preserve built-in identity and alias compatibility",
      "description": "As an existing customer, I want all provider spellings that worked before this change to keep working so that opening the contract to extensions does not break existing Factory definitions, API clients, or CLI configuration.",
      "acceptanceCriteria": [
        "Every accepted built-in canonical identity continues to load and round-trip through JSON, YAML, REST API, CLI configuration, and public Go and TypeScript projections with its current public spelling.",
        "Every accepted legacy alias continues to load and round-trip according to current compatibility behavior and resolves through the authoritative registry to the expected canonical integration.",
        "Alias normalization is registry-authoritative; mapping, operator settings, and runtime opening do not add or retain a separate provider alias table or supported-provider inventory.",
        "Compatibility coverage includes concrete authored selections, operator-provided selections, and invocation-resolved selections where those paths accept aliases today.",
        "OpenAPI generation and API smoke checks prove generated clients retain built-in constants as conveniences while accepting valid extension strings.",
        "Focused alias-compatibility and contract tests fail on changed public round-trip behavior or a mismatch between an alias and its canonical integration.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}
