### PR TITLE
pss-fnd-03-owner-derived-import-enforcement

### DIFF
--- a/cmd/ownershipboundarycheck/main.go
+++ b/cmd/ownershipboundarycheck/main.go
@@ -35,6 +35,7 @@ const (
 	ruleInitializerTransport             = "initializer-transport-import"
 	ruleInitializerConstruction          = "initializer-product-construction"
 	rulePlatformDomainImport             = "platform-domain-service-import"
+	rulePeerServiceImplementation        = "peer-service-implementation-import"
 	ruleMappingFilesystem                = "mapping-filesystem-behavior"
 	ruleMappingProcess                   = "mapping-process-behavior"
 	ruleMappingTimer                     = "mapping-timer-behavior"
@@ -46,6 +47,7 @@ var deletionGates = map[string]string{
 	ruleInitializerTransport:             "inject an already-constructed transport operation and remove the transport import from Initializer",
 	ruleInitializerConstruction:          "construct the product dependency in pkg/wire and inject its exact operation into Initializer",
 	rulePlatformDomainImport:             "move domain policy to its owning service and leave Platform implementing an exact external-effect port",
+	rulePeerServiceImplementation:        "import only the peer service root contract (pkg/services/<peer>) instead of a peer implementation or nested subservice",
 	ruleMappingFilesystem:                "move filesystem behavior behind an injected service or exact external-effect port",
 	ruleMappingProcess:                   "move process discovery or execution behind an injected service-owned port",
 	ruleMappingTimer:                     "move timer lifecycle behind an injected clock or owning service",
@@ -213,6 +215,11 @@ func scan(repoRoot string) ([]finding, error) {
 			return nil, fmt.Errorf("scan %s: %w", scanRoot, err)
 		}
 	}
+	peerFindings, err := scanPeerServiceImports(repoRoot, inventory)
+	if err != nil {
+		return nil, fmt.Errorf("scan peer service imports: %w", err)
+	}
+	findings = append(findings, peerFindings...)
 	findings = uniqueFindings(findings)
 	sort.Slice(findings, func(i, j int) bool { return findingKey(findings[i]) < findingKey(findings[j]) })
 	return findings, nil

--- a/cmd/ownershipboundarycheck/main.go
+++ b/cmd/ownershipboundarycheck/main.go
@@ -613,6 +613,10 @@ func validateEntry(item baselineEntry) error {
 }
 
 func writeFinding(writer io.Writer, label string, item finding) {
+	remediation := deletionGates[item.Rule]
+	if item.Rule == rulePeerServiceImplementation {
+		remediation = peerViolationMessage(item)
+	}
 	fmt.Fprintf(
 		writer,
 		"[agent-factory:ownership-boundary] %s: %s:%d %s -> %s; %s\n",
@@ -621,6 +625,6 @@ func writeFinding(writer io.Writer, label string, item finding) {
 		item.Line,
 		item.Rule,
 		item.Target,
-		deletionGates[item.Rule],
+		remediation,
 	)
 }

--- a/cmd/ownershipboundarycheck/main.go
+++ b/cmd/ownershipboundarycheck/main.go
@@ -172,6 +172,10 @@ func run(cfg config, stdout, stderr io.Writer) error {
 }
 
 func scan(repoRoot string) ([]finding, error) {
+	inventory, err := loadOwnerInventory(repoRoot)
+	if err != nil {
+		return nil, err
+	}
 	var findings []finding
 	for _, scanRoot := range []string{initializerRoot, platformRoot, mappingRoot} {
 		path := filepath.Join(repoRoot, filepath.FromSlash(scanRoot))
@@ -198,7 +202,7 @@ func scan(repoRoot string) ([]finding, error) {
 				return err
 			}
 			relative = filepath.ToSlash(relative)
-			fileFindings, err := scanFile(path, relative)
+			fileFindings, err := scanFile(path, relative, inventory)
 			if err != nil {
 				return err
 			}
@@ -214,7 +218,7 @@ func scan(repoRoot string) ([]finding, error) {
 	return findings, nil
 }
 
-func scanFile(path, relative string) ([]finding, error) {
+func scanFile(path, relative string, inventory ownerInventory) ([]finding, error) {
 	fileSet := token.NewFileSet()
 	file, err := parser.ParseFile(fileSet, path, nil, parser.ParseComments)
 	if err != nil {
@@ -227,7 +231,7 @@ func scanFile(path, relative string) ([]finding, error) {
 	var findings []finding
 	switch {
 	case within(relative, initializerRoot):
-		findings = append(findings, scanInitializerImports(fileSet, imports, relative)...)
+		findings = append(findings, scanInitializerImports(fileSet, imports, relative, inventory)...)
 		findings = append(findings, scanInitializerCalls(fileSet, file, aliases, relative)...)
 	case within(relative, platformRoot):
 		findings = append(findings, scanPlatformImports(fileSet, imports, relative)...)
@@ -263,14 +267,19 @@ func importInventory(file *ast.File) (map[string]string, []importedPackage) {
 	return aliases, imports
 }
 
-func scanInitializerImports(fileSet *token.FileSet, imports []importedPackage, relative string) []finding {
+func scanInitializerImports(
+	fileSet *token.FileSet,
+	imports []importedPackage,
+	relative string,
+	inventory ownerInventory,
+) []finding {
 	var findings []finding
 	for _, imported := range imports {
 		rule := ""
 		switch {
 		case strings.HasPrefix(imported.Path, transportsImport):
 			rule = ruleInitializerTransport
-		case serviceImplementationImport(imported.Path):
+		case serviceImplementationImport(imported.Path, inventory):
 			rule = ruleInitializerServiceImplementation
 		}
 		if rule != "" {
@@ -292,12 +301,23 @@ func scanInitializerImports(fileSet *token.FileSet, imports []importedPackage, r
 	return findings
 }
 
-func serviceImplementationImport(importPath string) bool {
+func serviceImplementationImport(importPath string, inventory ownerInventory) bool {
 	if !strings.HasPrefix(importPath, servicesImport) {
 		return false
 	}
-	remainder := strings.TrimPrefix(importPath, servicesImport)
-	return strings.Contains(remainder, "/")
+	repositoryPath := "pkg/services/" + strings.TrimPrefix(importPath, servicesImport)
+	_, surface := inventory.classify(repositoryPath)
+	switch surface {
+	case surfaceNonRoot:
+		return true
+	case surfaceRoot:
+		return false
+	default:
+		// Fixtures without a committed service tree keep the path-shape rule so
+		// existing initializer implementation findings remain actionable.
+		remainder := strings.TrimPrefix(importPath, servicesImport)
+		return strings.Contains(remainder, "/")
+	}
 }
 
 func scanInitializerCalls(

--- a/cmd/ownershipboundarycheck/owner_inventory.go
+++ b/cmd/ownershipboundarycheck/owner_inventory.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	servicesRootRelative = "pkg/services"
+	processEdgesOwner    = "edges"
+)
+
+type ownerKind string
+
+const (
+	ownerKindService      ownerKind = "service"
+	ownerKindProcessEdges ownerKind = "process-edges"
+)
+
+type packageSurface string
+
+const (
+	surfaceNone    packageSurface = ""
+	surfaceRoot    packageSurface = "root"
+	surfaceNonRoot packageSurface = "non-root"
+)
+
+// ownerInventory is the committed Packaged Service Structure service-tree
+// identity used for cross-owner import classification. Owners are derived from
+// direct children of pkg/services; Process Edges is classified specially.
+type ownerInventory struct {
+	owners map[string]ownerKind
+}
+
+func loadOwnerInventory(repoRoot string) (ownerInventory, error) {
+	inventory := ownerInventory{owners: map[string]ownerKind{}}
+	servicesRoot := filepath.Join(repoRoot, filepath.FromSlash(servicesRootRelative))
+	entries, err := os.ReadDir(servicesRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return inventory, nil
+		}
+		return ownerInventory{}, fmt.Errorf("read service owner inventory: %w", err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		name := entry.Name()
+		kind := ownerKindService
+		if name == processEdgesOwner {
+			kind = ownerKindProcessEdges
+		}
+		inventory.owners[name] = kind
+	}
+	return inventory, nil
+}
+
+func (inventory ownerInventory) hasOwner(name string) bool {
+	_, ok := inventory.owners[name]
+	return ok
+}
+
+func (inventory ownerInventory) kind(name string) ownerKind {
+	return inventory.owners[name]
+}
+
+// classify reports the owning service and whether repositoryPath is that
+// owner's root contract surface or a deeper non-root path. Paths outside an
+// inventoried owner return surfaceNone.
+func (inventory ownerInventory) classify(repositoryPath string) (string, packageSurface) {
+	repositoryPath = filepath.ToSlash(repositoryPath)
+	prefix := servicesRootRelative + "/"
+	if repositoryPath == servicesRootRelative || !strings.HasPrefix(repositoryPath, prefix) {
+		return "", surfaceNone
+	}
+	remainder := strings.TrimPrefix(repositoryPath, prefix)
+	if remainder == "" {
+		return "", surfaceNone
+	}
+	parts := strings.Split(remainder, "/")
+	owner := parts[0]
+	if owner == "" || !inventory.hasOwner(owner) {
+		return "", surfaceNone
+	}
+	if len(parts) == 1 {
+		return owner, surfaceRoot
+	}
+	return owner, surfaceNonRoot
+}

--- a/cmd/ownershipboundarycheck/owner_inventory_test.go
+++ b/cmd/ownershipboundarycheck/owner_inventory_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestLoadOwnerInventoryCoversCommittedServiceTreeAndProcessEdges(t *testing.T) {
+	root := fixtureRepository(t, map[string]string{
+		"pkg/services/factory_sessions/doc.go": "package factory_sessions\n",
+		"pkg/services/factory_runtime/doc.go":  "package factory_runtime\n",
+		"pkg/services/edges/doc.go":            "package edges\n",
+		"pkg/services/README.md":               "# not an owner\n",
+	})
+
+	inventory, err := loadOwnerInventory(root)
+	if err != nil {
+		t.Fatalf("loadOwnerInventory: %v", err)
+	}
+
+	for _, owner := range []string{"factory_sessions", "factory_runtime", "edges"} {
+		if !inventory.hasOwner(owner) {
+			t.Fatalf("inventory missing owner %q: %#v", owner, inventory.owners)
+		}
+	}
+	if inventory.hasOwner("README.md") {
+		t.Fatalf("inventory unexpectedly includes non-directory entry: %#v", inventory.owners)
+	}
+	if got := inventory.kind("edges"); got != ownerKindProcessEdges {
+		t.Fatalf("edges kind = %q, want %q", got, ownerKindProcessEdges)
+	}
+	if got := inventory.kind("factory_sessions"); got != ownerKindService {
+		t.Fatalf("factory_sessions kind = %q, want %q", got, ownerKindService)
+	}
+}
+
+func TestClassifyServicePackageRootVsNonRootForDistinctOwners(t *testing.T) {
+	root := fixtureRepository(t, map[string]string{
+		"pkg/services/factory_sessions/doc.go": "package factory_sessions\n",
+		"pkg/services/workers/doc.go":          "package workers\n",
+	})
+
+	inventory, err := loadOwnerInventory(root)
+	if err != nil {
+		t.Fatalf("loadOwnerInventory: %v", err)
+	}
+
+	cases := []struct {
+		path    string
+		owner   string
+		surface packageSurface
+	}{
+		{path: "pkg/services/factory_sessions", owner: "factory_sessions", surface: surfaceRoot},
+		{path: "pkg/services/factory_sessions/internal/execution", owner: "factory_sessions", surface: surfaceNonRoot},
+		{path: "pkg/services/workers", owner: "workers", surface: surfaceRoot},
+		{path: "pkg/services/workers/provider", owner: "workers", surface: surfaceNonRoot},
+		{path: "pkg/platform/logging", owner: "", surface: surfaceNone},
+	}
+	for _, tc := range cases {
+		owner, surface := inventory.classify(tc.path)
+		if owner != tc.owner || surface != tc.surface {
+			t.Fatalf(
+				"classify(%q) = (%q, %q), want (%q, %q)",
+				tc.path,
+				owner,
+				surface,
+				tc.owner,
+				tc.surface,
+			)
+		}
+	}
+}
+
+func TestClassifyTreatsNewDeeperPathAsNonRootWithoutPrivateCatalog(t *testing.T) {
+	root := fixtureRepository(t, map[string]string{
+		"pkg/services/factory_definitions/doc.go": "package factory_definitions\n",
+		"pkg/services/recordings/doc.go":          "package recordings\n",
+	})
+
+	inventory, err := loadOwnerInventory(root)
+	if err != nil {
+		t.Fatalf("loadOwnerInventory: %v", err)
+	}
+
+	// Previously unlisted nested implementation path under an inventoried owner.
+	newPath := "pkg/services/factory_definitions/brand_new_adapter/internal"
+	owner, surface := inventory.classify(newPath)
+	if owner != "factory_definitions" || surface != surfaceNonRoot {
+		t.Fatalf(
+			"classify(%q) = (%q, %q), want (factory_definitions, %q)",
+			newPath,
+			owner,
+			surface,
+			surfaceNonRoot,
+		)
+	}
+
+	// Nested subservice under a second inventoried owner is also non-root.
+	nested := "pkg/services/recordings/services/dashboard"
+	owner, surface = inventory.classify(nested)
+	if owner != "recordings" || surface != surfaceNonRoot {
+		t.Fatalf(
+			"classify(%q) = (%q, %q), want (recordings, %q)",
+			nested,
+			owner,
+			surface,
+			surfaceNonRoot,
+		)
+	}
+}
+
+func TestServiceImplementationImportUsesOwnerInventory(t *testing.T) {
+	root := fixtureRepository(t, map[string]string{
+		"pkg/services/factory_sessions/doc.go": "package factory_sessions\n",
+		"pkg/services/workers/doc.go":          "package workers\n",
+		"pkg/initializer/runtime.go": `package initializer
+import (
+  sessions "github.com/portpowered/infinite-you/pkg/services/factory_sessions"
+  provider "github.com/portpowered/infinite-you/pkg/services/workers/provider"
+  novelty "github.com/portpowered/infinite-you/pkg/services/workers/never_listed_before"
+)
+var (
+  _ sessions.ExecutionService
+  _ provider.Service
+  _ novelty.Adapter
+)`,
+	})
+
+	findings := scanFixture(t, root)
+	assertFinding(t, findings, ruleInitializerServiceImplementation, "/workers/provider")
+	assertFinding(t, findings, ruleInitializerServiceImplementation, "/workers/never_listed_before")
+	for _, item := range findings {
+		if item.Rule == ruleInitializerServiceImplementation &&
+			item.Target == modulePath+"/pkg/services/factory_sessions" {
+			t.Fatalf("peer/service root import incorrectly classified as implementation: %#v", item)
+		}
+	}
+}

--- a/cmd/ownershipboundarycheck/peer_import.go
+++ b/cmd/ownershipboundarycheck/peer_import.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"go/parser"
 	"go/token"
 	"os"
@@ -33,6 +34,32 @@ var approvedPeerServiceContractImports = map[string]struct{}{
 func isApprovedPeerServiceContractImport(packagePath, importPath string) bool {
 	_, approved := approvedPeerServiceContractImports[packagePath+"\x00"+importPath]
 	return approved
+}
+
+// peerOwnerFromImport returns the inventoried owner segment for a services import.
+func peerOwnerFromImport(importPath string) string {
+	if !strings.HasPrefix(importPath, servicesImport) {
+		return ""
+	}
+	remainder := strings.TrimPrefix(importPath, servicesImport)
+	owner, _, _ := strings.Cut(remainder, "/")
+	return owner
+}
+
+// peerViolationMessage names the importer and peer owners and directs
+// remediation to the peer root contract.
+func peerViolationMessage(item finding) string {
+	importer := serviceOwnerForFile(item.FilePath)
+	peer := peerOwnerFromImport(item.Target)
+	if importer == "" || peer == "" {
+		return deletionGates[rulePeerServiceImplementation]
+	}
+	return fmt.Sprintf(
+		`importer owner %q must not import peer owner %q non-root path; import only the peer service root contract (pkg/services/%s)`,
+		importer,
+		peer,
+		peer,
+	)
 }
 
 // crossOwnerPeerImplementationImport reports whether importPath is a prohibited

--- a/cmd/ownershipboundarycheck/peer_import.go
+++ b/cmd/ownershipboundarycheck/peer_import.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// Exact documented leaf-effect ports that may be imported across owners.
+// This is not a private-root catalog; each entry is an approved contract path.
+var approvedPeerServiceContractImports = map[string]struct{}{
+	"pkg/services/edges\x00github.com/portpowered/infinite-you/pkg/services/workers/agypty":                                                        {},
+	"pkg/platform/pty\x00github.com/portpowered/infinite-you/pkg/services/workers/agypty":                                                          {},
+	"pkg/services/edges\x00github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract":                                    {},
+	"pkg/services/edges\x00github.com/portpowered/infinite-you/pkg/services/workers/services/hosted_logic":                                         {},
+	"pkg/services/edges\x00github.com/portpowered/infinite-you/pkg/services/workers/services/hosted_logic/linear":                                  {},
+	"pkg/services/factory_runtime\x00github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract":                          {},
+	"pkg/services/factory_runtime/build\x00github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract":                    {},
+	"pkg/services/factory_runtime/service\x00github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract":                  {},
+	"pkg/services/factory_sessions\x00github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract":                         {},
+	"pkg/services/factory_sessions/internal/execution\x00github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract":      {},
+	"pkg/services/factory_sessions/internal/runtimeopening\x00github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract": {},
+	"pkg/services/factory_sessions/internal/executionopening\x00github.com/portpowered/infinite-you/pkg/services/workers/agypty":                   {},
+	"pkg/services/factory_sessions/internal/runtimeopening\x00github.com/portpowered/infinite-you/pkg/services/workers/agypty":                     {},
+	"pkg/services/recordings\x00github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract":                               {},
+	"pkg/services/recordings/replay\x00github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract":                        {},
+	"pkg/services/recordings/service\x00github.com/portpowered/infinite-you/pkg/services/workers/provider/inferencecontract":                       {},
+}
+
+func isApprovedPeerServiceContractImport(packagePath, importPath string) bool {
+	_, approved := approvedPeerServiceContractImports[packagePath+"\x00"+importPath]
+	return approved
+}
+
+// crossOwnerPeerImplementationImport reports whether importPath is a prohibited
+// peer non-root import for importerOwner. Peer roots and same-owner paths are
+// allowed by this cross-owner rule.
+func crossOwnerPeerImplementationImport(
+	importerOwner string,
+	importPath string,
+	inventory ownerInventory,
+) bool {
+	if importerOwner == "" || !strings.HasPrefix(importPath, servicesImport) {
+		return false
+	}
+	repositoryPath := "pkg/services/" + strings.TrimPrefix(importPath, servicesImport)
+	peerOwner, surface := inventory.classify(repositoryPath)
+	if peerOwner == "" || surface == surfaceNone {
+		// Without an inventoried peer, keep the path-shape heuristic so fixtures
+		// and incomplete trees still classify deeper imports as non-root.
+		remainder := strings.TrimPrefix(importPath, servicesImport)
+		parts := strings.Split(remainder, "/")
+		if len(parts) < 2 || parts[0] == "" || parts[0] == importerOwner {
+			return false
+		}
+		return true
+	}
+	if peerOwner == importerOwner {
+		return false
+	}
+	return surface == surfaceNonRoot
+}
+
+func serviceOwnerForFile(relative string) string {
+	relative = filepath.ToSlash(relative)
+	prefix := servicesRootRelative + "/"
+	if !strings.HasPrefix(relative, prefix) {
+		return ""
+	}
+	remainder := strings.TrimPrefix(relative, prefix)
+	owner, _, _ := strings.Cut(remainder, "/")
+	return owner
+}
+
+func scanPeerServiceImports(
+	repoRoot string,
+	inventory ownerInventory,
+) ([]finding, error) {
+	servicesRoot := filepath.Join(repoRoot, filepath.FromSlash(servicesRootRelative))
+	if _, err := os.Stat(servicesRoot); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var findings []finding
+	err := filepath.WalkDir(servicesRoot, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if entry.Name() == "testdata" || entry.Name() == "vendor" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			return nil
+		}
+		relative, err := filepath.Rel(repoRoot, path)
+		if err != nil {
+			return err
+		}
+		relative = filepath.ToSlash(relative)
+		owner := serviceOwnerForFile(relative)
+		if owner == "" || !inventory.hasOwner(owner) {
+			return nil
+		}
+		fileSet := token.NewFileSet()
+		file, err := parser.ParseFile(fileSet, path, nil, parser.ImportsOnly)
+		if err != nil {
+			return err
+		}
+		packagePath := filepath.ToSlash(filepath.Dir(relative))
+		for _, spec := range file.Imports {
+			importPath, err := strconv.Unquote(spec.Path.Value)
+			if err != nil {
+				continue
+			}
+			if isApprovedPeerServiceContractImport(packagePath, importPath) {
+				continue
+			}
+			if !crossOwnerPeerImplementationImport(owner, importPath, inventory) {
+				continue
+			}
+			findings = append(findings, finding{
+				Rule:     rulePeerServiceImplementation,
+				FilePath: relative,
+				Target:   importPath,
+				Line:     fileSet.Position(spec.Pos()).Line,
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return findings, nil
+}

--- a/cmd/ownershipboundarycheck/peer_import_test.go
+++ b/cmd/ownershipboundarycheck/peer_import_test.go
@@ -43,6 +43,130 @@ var _ = engine.Service{}`,
 	t.Fatal("expected peer implementation violation finding")
 }
 
+func TestCrossOwnerPeerRuleRejectsPreviouslyUnlistedPeerImplementationPath(t *testing.T) {
+	// brand_new_adapter is intentionally absent from any allowlist or private-root
+	// catalog. Owner-derived classification alone must reject the peer import.
+	const unlistedPeerPath = "/pkg/services/factory_definitions/brand_new_adapter"
+	root := fixtureRepository(t, map[string]string{
+		"pkg/services/factory_sessions/doc.go":    "package factory_sessions\n",
+		"pkg/services/factory_definitions/doc.go": "package factory_definitions\n",
+		"pkg/services/factory_definitions/brand_new_adapter/doc.go": "package brand_new_adapter\n",
+		"pkg/services/factory_sessions/consume_unlisted.go": `package factory_sessions
+import novelty "github.com/portpowered/infinite-you/pkg/services/factory_definitions/brand_new_adapter"
+var _ = novelty.Adapter{}`,
+	})
+
+	findings := scanFixture(t, root)
+	assertFinding(t, findings, rulePeerServiceImplementation, unlistedPeerPath)
+	for _, item := range findings {
+		if item.Rule != rulePeerServiceImplementation {
+			continue
+		}
+		if !strings.Contains(item.Target, unlistedPeerPath) {
+			continue
+		}
+		message := peerViolationMessage(item)
+		if !strings.Contains(message, `importer owner "factory_sessions"`) ||
+			!strings.Contains(message, `peer owner "factory_definitions"`) ||
+			!strings.Contains(message, "pkg/services/factory_definitions") {
+			t.Fatalf("unlisted peer path diagnostic incomplete: %q", message)
+		}
+		return
+	}
+	t.Fatal("expected previously-unlisted peer implementation path to be rejected")
+}
+
+func TestApprovedPeerExceptionsRemainExactPairwiseNotPrivateRootCatalog(t *testing.T) {
+	approvedImporter := "pkg/services/edges"
+	approvedImport := modulePath + "/pkg/services/workers/agypty"
+	if !isApprovedPeerServiceContractImport(approvedImporter, approvedImport) {
+		t.Fatalf("documented leaf-effect port missing from exact pairwise map")
+	}
+
+	// Sibling unlisted paths under the same peer must not inherit approval.
+	unlistedSibling := modulePath + "/pkg/services/workers/agypty/never_listed_before"
+	if isApprovedPeerServiceContractImport(approvedImporter, unlistedSibling) {
+		t.Fatalf("pairwise exception incorrectly behaves like a private-root prefix allowlist")
+	}
+	unlistedImporter := "pkg/services/factory_sessions"
+	if isApprovedPeerServiceContractImport(unlistedImporter, approvedImport) {
+		t.Fatalf("pairwise exception incorrectly applies to an unlisted importer package")
+	}
+
+	for key := range approvedPeerServiceContractImports {
+		packagePath, importPath, ok := strings.Cut(key, "\x00")
+		if !ok || packagePath == "" || importPath == "" {
+			t.Fatalf("approved peer exception key is not exact pairwise: %q", key)
+		}
+		if strings.ContainsAny(packagePath, "*?") || strings.ContainsAny(importPath, "*?") {
+			t.Fatalf("approved peer exception must be exact, not wildcarded: %q", key)
+		}
+		if !strings.HasPrefix(importPath, modulePath+"/pkg/services/") {
+			t.Fatalf("approved peer exception import is outside pkg/services: %q", key)
+		}
+	}
+}
+
+func TestPeerImportBaselineRemainsDeletionOnlyRatchet(t *testing.T) {
+	const (
+		importerPath = "pkg/services/factory_sessions/consume_peer_impl.go"
+		target       = modulePath + "/pkg/services/factory_runtime/brand_new_adapter"
+	)
+	violatingSource := `package factory_sessions
+import novelty "github.com/portpowered/infinite-you/pkg/services/factory_runtime/brand_new_adapter"
+var _ = novelty.Adapter{}`
+	clearedSource := "package factory_sessions\n"
+
+	t.Run("active recorded peer debt passes without relocating packages", func(t *testing.T) {
+		root := fixtureRepository(t, map[string]string{
+			"pkg/services/factory_sessions/doc.go":                          "package factory_sessions\n",
+			"pkg/services/factory_runtime/doc.go":                           "package factory_runtime\n",
+			"pkg/services/factory_runtime/brand_new_adapter/doc.go":         "package brand_new_adapter\n",
+			importerPath: violatingSource,
+		})
+		writeBaseline(t, root, baselineEntryFor(rulePeerServiceImplementation, importerPath, target))
+		var stdout, stderr bytes.Buffer
+		if err := run(config{root: root}, &stdout, &stderr); err != nil {
+			t.Fatalf("run active peer baseline: %v; stderr=%s", err, stderr.String())
+		}
+		if !strings.Contains(stdout.String(), "1 deletion-only baseline") {
+			t.Fatalf("stdout = %q, want active peer debt count", stdout.String())
+		}
+	})
+
+	t.Run("clearing the import without relocating packages makes baseline stale", func(t *testing.T) {
+		root := fixtureRepository(t, map[string]string{
+			"pkg/services/factory_sessions/doc.go":                  "package factory_sessions\n",
+			"pkg/services/factory_runtime/doc.go":                   "package factory_runtime\n",
+			"pkg/services/factory_runtime/brand_new_adapter/doc.go": "package brand_new_adapter\n",
+			importerPath: clearedSource,
+		})
+		writeBaseline(t, root, baselineEntryFor(rulePeerServiceImplementation, importerPath, target))
+		var stdout, stderr bytes.Buffer
+		err := run(config{root: root}, &stdout, &stderr)
+		if err == nil || !strings.Contains(stderr.String(), "stale baseline") {
+			t.Fatalf("run stale peer baseline err=%v stderr=%q", err, stderr.String())
+		}
+	})
+
+	t.Run("new unlisted peer path is a new violation without allowlist edit", func(t *testing.T) {
+		root := fixtureRepository(t, map[string]string{
+			"pkg/services/factory_sessions/doc.go":                  "package factory_sessions\n",
+			"pkg/services/factory_runtime/doc.go":                   "package factory_runtime\n",
+			"pkg/services/factory_runtime/brand_new_adapter/doc.go": "package brand_new_adapter\n",
+			importerPath: violatingSource,
+		})
+		var stdout, stderr bytes.Buffer
+		err := run(config{root: root}, &stdout, &stderr)
+		if err == nil || !strings.Contains(stderr.String(), "new violation") {
+			t.Fatalf("run new peer violation err=%v stderr=%q", err, stderr.String())
+		}
+		if !strings.Contains(stderr.String(), "brand_new_adapter") {
+			t.Fatalf("stderr missing previously-unlisted path: %q", stderr.String())
+		}
+	})
+}
+
 func TestCrossOwnerPeerRuleRejectsPeerNestedSubserviceImport(t *testing.T) {
 	root := fixtureRepository(t, map[string]string{
 		"pkg/services/factory_sessions/doc.go": "package factory_sessions\n",

--- a/cmd/ownershipboundarycheck/peer_import_test.go
+++ b/cmd/ownershipboundarycheck/peer_import_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestCrossOwnerPeerRuleAllowsPeerRootContractImports(t *testing.T) {
+	root := fixtureRepository(t, map[string]string{
+		"pkg/services/factory_sessions/doc.go": "package factory_sessions\n",
+		"pkg/services/factory_runtime/doc.go":  "package factory_runtime\n",
+		"pkg/services/workers/doc.go":          "package workers\n",
+		"pkg/services/factory_sessions/consume_peer_root.go": `package factory_sessions
+import (
+  runtime "github.com/portpowered/infinite-you/pkg/services/factory_runtime"
+  workers "github.com/portpowered/infinite-you/pkg/services/workers"
+)
+var (
+  _ runtime.Service
+  _ workers.Service
+)`,
+	})
+
+	findings := scanFixture(t, root)
+	for _, item := range findings {
+		if item.Rule == rulePeerServiceImplementation {
+			t.Fatalf("peer root contract import produced cross-owner violation: %#v", item)
+		}
+	}
+}
+
+func TestCrossOwnerPeerRuleAllowsSameOwnerNonRootImports(t *testing.T) {
+	root := fixtureRepository(t, map[string]string{
+		"pkg/services/factory_sessions/doc.go": "package factory_sessions\n",
+		"pkg/services/factory_runtime/doc.go":  "package factory_runtime\n",
+		"pkg/services/factory_sessions/internal/execution/local.go": `package execution
+import local "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/runtime"
+var _ local.Service`,
+		"pkg/services/factory_sessions/wire/wire.go": `package wire
+import execution "github.com/portpowered/infinite-you/pkg/services/factory_sessions/internal/execution"
+func inject() { _ = execution.NewService() }`,
+	})
+
+	findings := scanFixture(t, root)
+	for _, item := range findings {
+		if item.Rule == rulePeerServiceImplementation {
+			t.Fatalf("same-owner non-root import incorrectly fired peer rule: %#v", item)
+		}
+	}
+}
+
+func TestCrossOwnerPeerImportDecisionAllowsPeerRootAndSameOwner(t *testing.T) {
+	root := fixtureRepository(t, map[string]string{
+		"pkg/services/factory_sessions/doc.go": "package factory_sessions\n",
+		"pkg/services/factory_runtime/doc.go":  "package factory_runtime\n",
+	})
+	inventory, err := loadOwnerInventory(root)
+	if err != nil {
+		t.Fatalf("loadOwnerInventory: %v", err)
+	}
+
+	cases := []struct {
+		name          string
+		importerOwner string
+		importPath    string
+		wantViolation bool
+	}{
+		{
+			name:          "peer root allowed",
+			importerOwner: "factory_sessions",
+			importPath:    modulePath + "/pkg/services/factory_runtime",
+			wantViolation: false,
+		},
+		{
+			name:          "same-owner non-root allowed",
+			importerOwner: "factory_sessions",
+			importPath:    modulePath + "/pkg/services/factory_sessions/internal/execution",
+			wantViolation: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := crossOwnerPeerImplementationImport(tc.importerOwner, tc.importPath, inventory)
+			if got != tc.wantViolation {
+				t.Fatalf(
+					"crossOwnerPeerImplementationImport(%q, %q) = %v, want %v",
+					tc.importerOwner,
+					tc.importPath,
+					got,
+					tc.wantViolation,
+				)
+			}
+		})
+	}
+}

--- a/cmd/ownershipboundarycheck/peer_import_test.go
+++ b/cmd/ownershipboundarycheck/peer_import_test.go
@@ -1,8 +1,124 @@
 package main
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 )
+
+func TestCrossOwnerPeerRuleRejectsPeerImplementationImport(t *testing.T) {
+	root := fixtureRepository(t, map[string]string{
+		"pkg/services/factory_sessions/doc.go": "package factory_sessions\n",
+		"pkg/services/factory_runtime/doc.go":  "package factory_runtime\n",
+		"pkg/services/factory_runtime/internal/engine/doc.go": "package engine\n",
+		"pkg/services/factory_sessions/consume_peer_impl.go": `package factory_sessions
+import engine "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/engine"
+var _ = engine.Service{}`,
+	})
+
+	findings := scanFixture(t, root)
+	assertFinding(
+		t,
+		findings,
+		rulePeerServiceImplementation,
+		"/pkg/services/factory_runtime/internal/engine",
+	)
+	for _, item := range findings {
+		if item.Rule != rulePeerServiceImplementation {
+			continue
+		}
+		message := peerViolationMessage(item)
+		if !strings.Contains(message, `importer owner "factory_sessions"`) {
+			t.Fatalf("diagnostic missing importer owner: %q", message)
+		}
+		if !strings.Contains(message, `peer owner "factory_runtime"`) {
+			t.Fatalf("diagnostic missing peer owner: %q", message)
+		}
+		if !strings.Contains(message, "pkg/services/factory_runtime") ||
+			!strings.Contains(message, "root contract") {
+			t.Fatalf("diagnostic missing peer-root remediation: %q", message)
+		}
+		return
+	}
+	t.Fatal("expected peer implementation violation finding")
+}
+
+func TestCrossOwnerPeerRuleRejectsPeerNestedSubserviceImport(t *testing.T) {
+	root := fixtureRepository(t, map[string]string{
+		"pkg/services/factory_sessions/doc.go": "package factory_sessions\n",
+		"pkg/services/workers/doc.go":          "package workers\n",
+		"pkg/services/workers/services/hosted_logic/doc.go": "package hosted_logic\n",
+		"pkg/services/factory_sessions/consume_nested.go": `package factory_sessions
+import hosted "github.com/portpowered/infinite-you/pkg/services/workers/services/hosted_logic"
+var _ = hosted.Service{}`,
+	})
+
+	findings := scanFixture(t, root)
+	assertFinding(
+		t,
+		findings,
+		rulePeerServiceImplementation,
+		"/pkg/services/workers/services/hosted_logic",
+	)
+	for _, item := range findings {
+		if item.Rule != rulePeerServiceImplementation {
+			continue
+		}
+		message := peerViolationMessage(item)
+		if !strings.Contains(message, `importer owner "factory_sessions"`) {
+			t.Fatalf("diagnostic missing importer owner: %q", message)
+		}
+		if !strings.Contains(message, `peer owner "workers"`) {
+			t.Fatalf("diagnostic missing peer owner: %q", message)
+		}
+		if !strings.Contains(message, "pkg/services/workers") ||
+			!strings.Contains(message, "root contract") {
+			t.Fatalf("diagnostic missing peer-root remediation: %q", message)
+		}
+		return
+	}
+	t.Fatal("expected peer nested-subservice violation finding")
+}
+
+func TestCrossOwnerPeerRuleKeepsExactLeafEffectPortExceptions(t *testing.T) {
+	root := fixtureRepository(t, map[string]string{
+		"pkg/services/edges/doc.go":    "package edges\n",
+		"pkg/services/workers/doc.go":  "package workers\n",
+		"pkg/services/workers/agypty/doc.go": "package agypty\n",
+		"pkg/services/edges/leaf.go": `package edges
+import agypty "github.com/portpowered/infinite-you/pkg/services/workers/agypty"
+var _ = agypty.Service{}`,
+	})
+
+	findings := scanFixture(t, root)
+	for _, item := range findings {
+		if item.Rule == rulePeerServiceImplementation {
+			t.Fatalf("approved leaf-effect port incorrectly rejected: %#v", item)
+		}
+	}
+}
+
+func TestPeerViolationMessageAppearsInRunOutput(t *testing.T) {
+	root := fixtureRepository(t, map[string]string{
+		"pkg/services/factory_sessions/doc.go": "package factory_sessions\n",
+		"pkg/services/factory_runtime/doc.go":  "package factory_runtime\n",
+		"pkg/services/factory_runtime/internal/engine/doc.go": "package engine\n",
+		"pkg/services/factory_sessions/consume_peer_impl.go": `package factory_sessions
+import engine "github.com/portpowered/infinite-you/pkg/services/factory_runtime/internal/engine"
+var _ = engine.Service{}`,
+	})
+	var stdout, stderr bytes.Buffer
+	err := run(config{root: root}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("expected peer implementation import to fail run")
+	}
+	out := stderr.String()
+	if !strings.Contains(out, `importer owner "factory_sessions"`) ||
+		!strings.Contains(out, `peer owner "factory_runtime"`) ||
+		!strings.Contains(out, "pkg/services/factory_runtime") {
+		t.Fatalf("run stderr missing owner-named remediation: %q", out)
+	}
+}
 
 func TestCrossOwnerPeerRuleAllowsPeerRootContractImports(t *testing.T) {
 	root := fixtureRepository(t, map[string]string{
@@ -52,6 +168,7 @@ func TestCrossOwnerPeerImportDecisionAllowsPeerRootAndSameOwner(t *testing.T) {
 	root := fixtureRepository(t, map[string]string{
 		"pkg/services/factory_sessions/doc.go": "package factory_sessions\n",
 		"pkg/services/factory_runtime/doc.go":  "package factory_runtime\n",
+		"pkg/services/workers/doc.go":          "package workers\n",
 	})
 	inventory, err := loadOwnerInventory(root)
 	if err != nil {
@@ -75,6 +192,18 @@ func TestCrossOwnerPeerImportDecisionAllowsPeerRootAndSameOwner(t *testing.T) {
 			importerOwner: "factory_sessions",
 			importPath:    modulePath + "/pkg/services/factory_sessions/internal/execution",
 			wantViolation: false,
+		},
+		{
+			name:          "peer implementation rejected",
+			importerOwner: "factory_sessions",
+			importPath:    modulePath + "/pkg/services/factory_runtime/internal/engine",
+			wantViolation: true,
+		},
+		{
+			name:          "peer nested subservice rejected",
+			importerOwner: "factory_sessions",
+			importPath:    modulePath + "/pkg/services/workers/services/hosted_logic",
+			wantViolation: true,
 		},
 	}
 	for _, tc := range cases {

--- a/docs/internal/processes/runtime-cleanup-relevant-files.md
+++ b/docs/internal/processes/runtime-cleanup-relevant-files.md
@@ -272,8 +272,10 @@ cross-owner import decisions. Do not grow a hand-maintained private-subpackage
 catalog for the generic owner-derived rule. The same inventory drives the
 cross-owner peer rule: importing an inventoried peer root
 (`pkg/services/<peer>`) is allowed, and same-owner non-root imports do not fire
-the peer rule. Exact documented leaf-effect ports remain pairwise exceptions,
-not a private-root allowlist.
+the peer rule. Peer implementation and nested-subservice imports fail with a
+diagnostic that names the importer owner and peer owner and directs remediation
+to the peer root contract. Exact documented leaf-effect ports remain pairwise
+exceptions, not a private-root allowlist.
 
 The guard rejects new production imports from `pkg/factory/**`, `pkg/work/**`,
 `pkg/workers/**`, and `pkg/models/**` into `pkg/transports/**`. Generated OpenAPI

--- a/docs/internal/processes/runtime-cleanup-relevant-files.md
+++ b/docs/internal/processes/runtime-cleanup-relevant-files.md
@@ -269,7 +269,11 @@ of `pkg/services` form the owner inventory, `pkg/services/edges` is the Process
 Edges owner, each inventoried `pkg/services/<owner>` path is that owner's root
 contract surface, and any deeper path under that owner is non-root for
 cross-owner import decisions. Do not grow a hand-maintained private-subpackage
-catalog for the generic owner-derived rule.
+catalog for the generic owner-derived rule. The same inventory drives the
+cross-owner peer rule: importing an inventoried peer root
+(`pkg/services/<peer>`) is allowed, and same-owner non-root imports do not fire
+the peer rule. Exact documented leaf-effect ports remain pairwise exceptions,
+not a private-root allowlist.
 
 The guard rejects new production imports from `pkg/factory/**`, `pkg/work/**`,
 `pkg/workers/**`, and `pkg/models/**` into `pkg/transports/**`. Generated OpenAPI

--- a/docs/internal/processes/runtime-cleanup-relevant-files.md
+++ b/docs/internal/processes/runtime-cleanup-relevant-files.md
@@ -263,6 +263,14 @@ finish the named move, not ownership rationale for new product behavior.
 transport packages should own narrow contracts that startup injects instead of
 depending outward on the application graph.
 
+`make ownership-boundary-check` (`cmd/ownershipboundarycheck`) classifies
+`pkg/services/<owner>` surfaces from the committed service tree: direct children
+of `pkg/services` form the owner inventory, `pkg/services/edges` is the Process
+Edges owner, each inventoried `pkg/services/<owner>` path is that owner's root
+contract surface, and any deeper path under that owner is non-root for
+cross-owner import decisions. Do not grow a hand-maintained private-subpackage
+catalog for the generic owner-derived rule.
+
 The guard rejects new production imports from `pkg/factory/**`, `pkg/work/**`,
 `pkg/workers/**`, and `pkg/models/**` into `pkg/transports/**`. Generated OpenAPI
 values must be converted under `pkg/transports/mapping`, while domain packages

--- a/docs/internal/processes/runtime-cleanup-relevant-files.md
+++ b/docs/internal/processes/runtime-cleanup-relevant-files.md
@@ -274,8 +274,13 @@ cross-owner peer rule: importing an inventoried peer root
 (`pkg/services/<peer>`) is allowed, and same-owner non-root imports do not fire
 the peer rule. Peer implementation and nested-subservice imports fail with a
 diagnostic that names the importer owner and peer owner and directs remediation
-to the peer root contract. Exact documented leaf-effect ports remain pairwise
-exceptions, not a private-root allowlist.
+to the peer root contract. Introducing a previously unlisted deeper path under
+an inventoried owner is rejected automatically; do not edit a private-root
+catalog to make that fail. Exact documented leaf-effect ports remain pairwise
+importer→import exceptions, not a private-root allowlist. Peer-import debt in
+`ownership-boundary-baseline.json` stays deletion-only/ratchet: clear the
+import (or delete the exact baseline entry), and do not relocate production
+service packages solely to satisfy the checker.
 
 The guard rejects new production imports from `pkg/factory/**`, `pkg/work/**`,
 `pkg/workers/**`, and `pkg/models/**` into `pkg/transports/**`. Generated OpenAPI

--- a/factory/factory.json
+++ b/factory/factory.json
@@ -76,7 +76,7 @@
         ]
       },
       {
-        "id": "worker-assignment:worker:planner-\u003eworkstation:ideafy",
+        "id": "worker-assignment:worker:ideafier-\u003eworkstation:ideafy",
         "waypoints": [
           {
             "x": -165.4157,
@@ -327,8 +327,8 @@
       {
         "id": "resource:concurrent-planners",
         "position": {
-          "x": -88.58247,
-          "y": 396.74365
+          "x": -79.439995,
+          "y": 376.17307
         }
       },
       {
@@ -369,15 +369,15 @@
     ],
     "schemaVersion": 1,
     "viewport": {
-      "x": 341.12927,
-      "y": 123.05057,
-      "zoom": 0.87503606
+      "x": -286.87537,
+      "y": -542.9691,
+      "zoom": 1.0755962
     }
   },
-  "name": "UNDEFINED",
+  "name": "factory",
   "resources": [
     {
-      "capacity": 8,
+      "capacity": 64,
       "id": "executor-slot",
       "name": "executor-slot"
     },
@@ -416,8 +416,8 @@
     ]
   },
   "version": {
-    "logical": "1780219232503513625",
-    "physical": "2026-06-17T05:42:49.56944Z"
+    "logical": "1780219232503513624",
+    "physical": "2026-06-17T05:43:19.294602Z"
   },
   "workTypes": [
     {
@@ -549,8 +549,7 @@
   "workers": [
     {
       "executorProvider": "SCRIPT_WRAP",
-      "id": "processor",
-      "modelProvider": "CODEX",
+      "modelProvider": "CURSOR",
       "name": "processor",
       "skipPermissions": true,
       "stopToken": "\u003cCOMPLETE\u003e",
@@ -569,10 +568,20 @@
     {
       "executorProvider": "SCRIPT_WRAP",
       "id": "planner",
-      "modelProvider": "CODEX",
+      "modelProvider": "CURSOR",
+      "model": "grok-4.5-high",
       "name": "planner",
       "skipPermissions": true,
       "stopToken": "\u003cCOMPLETE\u003e",
+      "type": "AGENT_WORKER"
+    },
+    {
+      "executorProvider": "SCRIPT_WRAP",
+      "id": "ideafier",
+      "modelProvider": "CURSOR",
+      "model": "grok-4.5-high",
+      "name": "ideafier",
+      "skipPermissions": true,
       "type": "AGENT_WORKER"
     }
   ],
@@ -605,7 +614,7 @@
         }
       ],
       "type": "AGENT_RUN",
-      "worker": "planner"
+      "worker": "ideafier"
     },
     {
       "id": "plan",


### PR DESCRIPTION
{
  "project": "FND-03 Owner-Derived Cross-Owner Import Enforcement",
  "branchName": "pss-fnd-03-owner-derived-import-enforcement",
  "description": "Make cross-owner import enforcement owner-derived from the committed Packaged Service Structure service tree so peer root-contract imports pass ownership-checker fixtures and peer implementation/nested-subservice imports fail, without relocating packages or taking Wire/root/OpenAPI/CLI leases.",
  "context": {
    "customerAsk": "Make cross-owner import enforcement owner-derived from the committed service tree so peer root-contract imports pass and peer implementation/subservice imports fail. Lease ownership checker paths only. Do not relocate service packages, change public API/CLI/MCP contracts solely to satisfy the checker, or take Wire/root/OpenAPI/CLI-manifest leases.",
    "problem": "Cross-owner import guards still depend on hand-maintained inventories of known private subpackage roots and pairwise contract allowlists. New peer implementation or nested-subservice paths are not automatically classified from the committed owner tree, so enforcement can miss new debt and requires manual allowlist edits that drift from the architecture inventory.",
    "solution": "Drive cross-owner import classification from a committed owner inventory of the service tree. Treat each inventoried owner root as the only default cross-owner import surface, classify deeper paths as peer implementation, prove peer roots pass and peer implementation/subservice imports fail with fixtures, and keep only exact documented exceptions."
  },
  "acceptanceCriteria": [
    "AC-1: Ownership-checker fixtures show that importing a peer service root contract succeeds.",
    "AC-2: Ownership-checker fixtures show that importing a peer implementation package or nested subservice fails with an actionable peer-owner diagnostic.",
    "AC-3: Cross-owner import rejection for implementation/subservice paths is derived from the committed owner inventory / service tree, not from a hand-maintained catalog of known private roots where this packet requires owner-derived rules.",
    "AC-4: Introducing a new peer implementation path under an inventoried owner fails the checker in fixtures without editing an ad hoc private-path allowlist.",
    "AC-5: Existing exact deletion-only baselines for still-migrating peer imports remain ratchet-only; this packet does not relocate service packages or widen Wire/root/OpenAPI/CLI leases.",
    "AC-6: Quality checks pass (typecheck, lint, tests), including focused ownership-checker fixture tests, make verify-fast, and make lint."
  ],
  "userStories": [
    {
      "id": "pss-fnd-03-owner-derived-import-enforcement-001",
      "title": "Bind the ownership checker to committed owner inventory",
      "description": "As a maintainer, I want the ownership checker to classify packages from the committed service-owner inventory so cross-owner rules follow the architecture tree instead of a hand-edited private-path list.",
      "acceptanceCriteria": [
        "The ownership checker loads or derives a stable owner inventory covering the committed top-level service owners under pkg/services required by the Packaged Service Structure tree (including the documented Process Edges exception classification where needed for import classification).",
        "For each inventoried owner, the checker classifies pkg/services/<owner> as that owner's root contract surface and classifies deeper paths under that owner as non-root (implementation or nested-subservice) for cross-owner import decisions.",
        "Adding a new deeper path under an inventoried owner in a fixture tree is classified as non-root without updating a hand-maintained private-root catalog.",
        "Focused unit/fixture coverage proves root vs non-root classification for at least two distinct owners.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-fnd-03-owner-derived-import-enforcement-002",
      "title": "Allow peer root-contract imports",
      "description": "As a service implementer, I want importing another service's root contract to pass the ownership checker so legitimate cross-service collaboration stays legal.",
      "acceptanceCriteria": [
        "An ownership-checker fixture where owner A imports exactly pkg/services/<peer> (peer root) reports no cross-owner implementation-import violation.",
        "Same-owner imports of the owner's own non-root packages remain allowed by this cross-owner rule (peer rule does not fire on same-owner paths).",
        "Failure diagnostics for unrelated violations remain unchanged enough that reviewers can still identify owner and peer when a real peer violation exists.",
        "Focused ownership-checker fixture tests cover at least one peer-root success case used by lint/pkg-boundary.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-fnd-03-owner-derived-import-enforcement-003",
      "title": "Reject peer implementation and nested-subservice imports",
      "description": "As a reviewer, I want peer implementation and nested-subservice imports to fail the ownership checker so consumers cannot bypass the peer root contract.",
      "acceptanceCriteria": [
        "An ownership-checker fixture where owner A imports a peer non-root path (for example pkg/services/<peer>/internal/... or another deeper peer package) fails.",
        "An ownership-checker fixture where owner A imports a peer nested subservice path fails.",
        "The failure names the importer owner and peer owner and directs remediation to the peer root contract (import only pkg/services/<peer>).",
        "Exact documented architecture exceptions (Process Edges / approved leaf effect ports) continue to behave as today; this packet does not invent a new general subpackage exception mechanism.",
        "Focused ownership-checker fixture tests cover peer implementation and nested-subservice rejection.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": ""
    },
    {
      "id": "pss-fnd-03-owner-derived-import-enforcement-004",
      "title": "Retire ad hoc private-path allowlists for this rule",
      "description": "As a maintainer, I want cross-owner implementation rejection to stop depending on a hand-maintained private-path allowlist so new owner subpackages are protected automatically.",
      "acceptanceCriteria": [
        "Where the plan requires owner-derived cross-owner import enforcement, the checker no longer requires updating a hand-maintained catalog of known private subpackage roots for a new peer implementation path to be rejected.",
        "A fixture introduces a previously unlisted peer implementation path under an inventoried owner and the checker rejects the cross-owner import without an allowlist edit for that path.",
        "Any remaining pairwise or leaf-port exceptions are exact, documented, and not a substitute private-root inventory for the generic peer rule.",
        "Deletion-only peer-import baselines remain ratchet-only: this packet does not relocate production service packages solely to clear debt.",
        "Focused ownership-checker tests and make verify-fast / make lint (including the ownership/pkg-boundary lane) pass.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": ""
    }
  ]
}
