### PR TITLE
fnd-003-coverage-json

### DIFF
--- a/cmd/gocoveragecheck/coverage_json.go
+++ b/cmd/gocoveragecheck/coverage_json.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"strings"
+)
+
+// coverageSummaryJSON is the machine-readable coverage summary owned by
+// gocoveragecheck. Downstream visualizers consume this artifact instead of
+// re-parsing coverage profiles.
+type coverageSummaryJSON struct {
+	CoveredStatements    int     `json:"coveredStatements"`
+	MeasurableStatements int     `json:"measurableStatements"`
+	CoveragePercent      float64 `json:"coveragePercent"`
+}
+
+func buildCoverageSummaryJSON(result coverageResult) coverageSummaryJSON {
+	covered, measurable := overallStatementTotals(result)
+	return coverageSummaryJSON{
+		CoveredStatements:    covered,
+		MeasurableStatements: measurable,
+		CoveragePercent:      roundCoveragePercent(result.actual),
+	}
+}
+
+func overallStatementTotals(result coverageResult) (covered int, measurable int) {
+	for _, summary := range result.packageSummaries {
+		totals := result.packageTotals[summary.importPath]
+		covered += totals.coveredStatements
+		measurable += totals.totalStatements
+	}
+	return covered, measurable
+}
+
+func roundCoveragePercent(value float64) float64 {
+	return math.Round(value*10) / 10
+}
+
+func renderCoverageSummaryJSON(summary coverageSummaryJSON) ([]byte, error) {
+	data, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("render go coverage summary json: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+func writeCoverageSummaryJSON(path string, result coverageResult) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+	data, err := renderCoverageSummaryJSON(buildCoverageSummaryJSON(result))
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write go coverage summary json: %w", err)
+	}
+	return nil
+}

--- a/cmd/gocoveragecheck/coverage_json.go
+++ b/cmd/gocoveragecheck/coverage_json.go
@@ -12,9 +12,29 @@ import (
 // gocoveragecheck. Downstream visualizers consume this artifact instead of
 // re-parsing coverage profiles.
 type coverageSummaryJSON struct {
-	CoveredStatements    int     `json:"coveredStatements"`
-	MeasurableStatements int     `json:"measurableStatements"`
-	CoveragePercent      float64 `json:"coveragePercent"`
+	CoveredStatements    int                   `json:"coveredStatements"`
+	MeasurableStatements int                   `json:"measurableStatements"`
+	CoveragePercent      float64               `json:"coveragePercent"`
+	Packages             []packageCoverageJSON `json:"packages"`
+}
+
+// packageCoverageJSON reports one measured production package, including the
+// package-gate floor or measurement exception used for that run.
+type packageCoverageJSON struct {
+	Package              string                     `json:"package"`
+	CoveredStatements    int                        `json:"coveredStatements"`
+	MeasurableStatements int                        `json:"measurableStatements"`
+	CoveragePercent      float64                    `json:"coveragePercent"`
+	PackageFloor         *float64                   `json:"packageFloor"`
+	MeasurementException *coverageManifestException `json:"measurementException"`
+}
+
+// packageCoverageGate is the package-local floor or exception policy applied
+// during a coverage run. Exactly one of Floor or Exception is set when a gate
+// applies; both remain nil when the package is ungated for that run.
+type packageCoverageGate struct {
+	Floor     *float64
+	Exception *coverageManifestException
 }
 
 func buildCoverageSummaryJSON(result coverageResult) coverageSummaryJSON {
@@ -23,7 +43,26 @@ func buildCoverageSummaryJSON(result coverageResult) coverageSummaryJSON {
 		CoveredStatements:    covered,
 		MeasurableStatements: measurable,
 		CoveragePercent:      roundCoveragePercent(result.actual),
+		Packages:             buildPackageCoverageJSON(result),
 	}
+}
+
+func buildPackageCoverageJSON(result coverageResult) []packageCoverageJSON {
+	packages := make([]packageCoverageJSON, 0, len(result.packageSummaries))
+	for _, summary := range result.packageSummaries {
+		totals := result.packageTotals[summary.importPath]
+		gate := result.packageGates[summary.importPath]
+		entry := packageCoverageJSON{
+			Package:              summary.importPath,
+			CoveredStatements:    totals.coveredStatements,
+			MeasurableStatements: totals.totalStatements,
+			CoveragePercent:      roundCoveragePercent(summary.coverage),
+			PackageFloor:         gate.Floor,
+			MeasurementException: cloneCoverageManifestException(gate.Exception),
+		}
+		packages = append(packages, entry)
+	}
+	return packages
 }
 
 func overallStatementTotals(result coverageResult) (covered int, measurable int) {
@@ -37,6 +76,47 @@ func overallStatementTotals(result coverageResult) (covered int, measurable int)
 
 func roundCoveragePercent(value float64) float64 {
 	return math.Round(value*10) / 10
+}
+
+func cloneCoverageManifestException(exception *coverageManifestException) *coverageManifestException {
+	if exception == nil {
+		return nil
+	}
+	cloned := *exception
+	return &cloned
+}
+
+func packageGatesFromManifest(manifest coverageManifest) map[string]packageCoverageGate {
+	gates := make(map[string]packageCoverageGate, len(manifest.Packages))
+	for _, entry := range manifest.Packages {
+		if entry.Exception != nil {
+			gates[entry.Package] = packageCoverageGate{
+				Exception: cloneCoverageManifestException(entry.Exception),
+			}
+			continue
+		}
+		floor, err := parseCoverageFloor(entry.Minimum)
+		if err != nil {
+			gates[entry.Package] = packageCoverageGate{}
+			continue
+		}
+		percent := float64(floor) / 100
+		gates[entry.Package] = packageCoverageGate{Floor: &percent}
+	}
+	return gates
+}
+
+func packageGatesFromLegacyMin(summaries []packageCoverageSummary, packageMin float64, baselinePackages map[string]struct{}) map[string]packageCoverageGate {
+	gates := make(map[string]packageCoverageGate, len(summaries))
+	for _, summary := range summaries {
+		if _, exempt := baselinePackages[summary.importPath]; exempt {
+			gates[summary.importPath] = packageCoverageGate{}
+			continue
+		}
+		floor := packageMin
+		gates[summary.importPath] = packageCoverageGate{Floor: &floor}
+	}
+	return gates
 }
 
 func renderCoverageSummaryJSON(summary coverageSummaryJSON) ([]byte, error) {

--- a/cmd/gocoveragecheck/coverage_json_test.go
+++ b/cmd/gocoveragecheck/coverage_json_test.go
@@ -217,36 +217,15 @@ func TestExecuteJSONReportsPackageFloorsFromManifest(t *testing.T) {
 }
 
 func TestExecuteJSONReportsMeasurementExceptionFromManifest(t *testing.T) {
-	originalCommandRunner := commandRunner
-	originalStdout := stdoutWriter
-	originalStderr := stderrWriter
-	defer func() {
-		commandRunner = originalCommandRunner
-		stdoutWriter = originalStdout
-		stderrWriter = originalStderr
-	}()
-
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	commandRunner = fakeGoCoverageCommandPassing
-	stdoutWriter = &stdout
-	stderrWriter = &stderr
+	_, stderr := stubCoverageExecute(t, fakeGoCoverageCommandPassing)
 
 	configPackage := modulePath + "/pkg/config"
 	servicePackage := modulePath + "/pkg/service"
 	initializerPackage := modulePath + "/pkg/initializer"
+	wantException := unitUnmeasurableMeasurementException()
 	manifestPath := writePackageMinimumManifestWithEntries(t, "unit", []manifestPackageSpec{
 		{importPath: configPackage, minimum: "100.00"},
-		{
-			importPath: initializerPackage,
-			exception: &coverageManifestException{
-				Kind:          "measurement",
-				Justification: "The active unit coverage profile contains no measurable statements for this package.",
-				Owner:         "backend-quality",
-				Deadline:      unmeasurablePackageDeadline,
-				RemovalGate:   "The unit coverage profile reports at least one measurable statement for this package.",
-			},
-		},
+		{importPath: initializerPackage, exception: wantException},
 		{importPath: servicePackage, minimum: "100.00"},
 	})
 	jsonPath := filepath.Join(t.TempDir(), "coverage-summary.json")
@@ -267,16 +246,9 @@ func TestExecuteJSONReportsMeasurementExceptionFromManifest(t *testing.T) {
 		t.Fatalf("execute() error = %v", err)
 	}
 
-	data, err := os.ReadFile(jsonPath)
-	if err != nil {
-		t.Fatalf("read coverage summary json: %v", err)
-	}
-	var summary coverageSummaryJSON
-	if err := json.Unmarshal(data, &summary); err != nil {
-		t.Fatalf("decode coverage summary json: %v\n%s", err, data)
-	}
+	summary := readCoverageSummaryJSONFile(t, jsonPath)
 	if len(summary.Packages) != 3 {
-		t.Fatalf("packages len = %d, want 3\n%s", len(summary.Packages), data)
+		t.Fatalf("packages len = %d, want 3", len(summary.Packages))
 	}
 	wantOrder := []string{configPackage, initializerPackage, servicePackage}
 	for index, wantPackage := range wantOrder {
@@ -285,33 +257,7 @@ func TestExecuteJSONReportsMeasurementExceptionFromManifest(t *testing.T) {
 		}
 	}
 
-	exceptionEntry := summary.Packages[1]
-	if exceptionEntry.CoveredStatements != 0 || exceptionEntry.MeasurableStatements != 0 {
-		t.Fatalf("unmeasurable package statements = %d/%d, want 0/0", exceptionEntry.CoveredStatements, exceptionEntry.MeasurableStatements)
-	}
-	if exceptionEntry.PackageFloor != nil {
-		t.Fatalf("unmeasurable packageFloor = %v, want null", *exceptionEntry.PackageFloor)
-	}
-	if exceptionEntry.MeasurementException == nil {
-		t.Fatalf("measurementException is nil, want structured exception\n%s", data)
-	}
-	gotException := exceptionEntry.MeasurementException
-	if gotException.Kind != "measurement" {
-		t.Fatalf("exception kind = %q, want measurement", gotException.Kind)
-	}
-	if gotException.Justification != "The active unit coverage profile contains no measurable statements for this package." {
-		t.Fatalf("exception justification = %q", gotException.Justification)
-	}
-	if gotException.Owner != "backend-quality" {
-		t.Fatalf("exception owner = %q, want backend-quality", gotException.Owner)
-	}
-	if gotException.Deadline != unmeasurablePackageDeadline {
-		t.Fatalf("exception deadline = %q, want %q", gotException.Deadline, unmeasurablePackageDeadline)
-	}
-	if gotException.RemovalGate != "The unit coverage profile reports at least one measurable statement for this package." {
-		t.Fatalf("exception removalGate = %q", gotException.RemovalGate)
-	}
-
+	assertUnmeasurablePackageJSON(t, summary.Packages[1], wantException)
 	if summary.Packages[0].MeasurementException != nil || summary.Packages[2].MeasurementException != nil {
 		t.Fatalf("measurable packages unexpectedly carried measurementException: %+v / %+v", summary.Packages[0].MeasurementException, summary.Packages[2].MeasurementException)
 	}
@@ -619,6 +565,64 @@ type manifestPackageSpec struct {
 	importPath string
 	minimum    string
 	exception  *coverageManifestException
+}
+
+func stubCoverageExecute(t *testing.T, runner commandRunnerFunc) (stdout *bytes.Buffer, stderr *bytes.Buffer) {
+	t.Helper()
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	t.Cleanup(func() {
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	})
+	stdout = &bytes.Buffer{}
+	stderr = &bytes.Buffer{}
+	commandRunner = runner
+	stdoutWriter = stdout
+	stderrWriter = stderr
+	return stdout, stderr
+}
+
+func readCoverageSummaryJSONFile(t *testing.T, path string) coverageSummaryJSON {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read coverage summary json: %v", err)
+	}
+	var summary coverageSummaryJSON
+	if err := json.Unmarshal(data, &summary); err != nil {
+		t.Fatalf("decode coverage summary json: %v\n%s", err, data)
+	}
+	return summary
+}
+
+func unitUnmeasurableMeasurementException() *coverageManifestException {
+	return &coverageManifestException{
+		Kind:          "measurement",
+		Justification: "The active unit coverage profile contains no measurable statements for this package.",
+		Owner:         "backend-quality",
+		Deadline:      unmeasurablePackageDeadline,
+		RemovalGate:   "The unit coverage profile reports at least one measurable statement for this package.",
+	}
+}
+
+func assertUnmeasurablePackageJSON(t *testing.T, entry packageCoverageJSON, want *coverageManifestException) {
+	t.Helper()
+	if entry.CoveredStatements != 0 || entry.MeasurableStatements != 0 {
+		t.Fatalf("unmeasurable package statements = %d/%d, want 0/0", entry.CoveredStatements, entry.MeasurableStatements)
+	}
+	if entry.PackageFloor != nil {
+		t.Fatalf("unmeasurable packageFloor = %v, want null", *entry.PackageFloor)
+	}
+	if entry.MeasurementException == nil {
+		t.Fatal("measurementException is nil, want structured exception")
+	}
+	got := entry.MeasurementException
+	if got.Kind != want.Kind || got.Justification != want.Justification || got.Owner != want.Owner || got.Deadline != want.Deadline || got.RemovalGate != want.RemovalGate {
+		t.Fatalf("measurementException = %+v, want %+v", got, want)
+	}
 }
 
 func writePackageMinimumManifestWithEntries(t *testing.T, lane string, entries []manifestPackageSpec) string {

--- a/cmd/gocoveragecheck/coverage_json_test.go
+++ b/cmd/gocoveragecheck/coverage_json_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -32,8 +33,9 @@ func TestExecuteWritesDeterministicJSONCoverageTotals(t *testing.T) {
 			modulePath + "/pkg/config",
 			modulePath + "/pkg/service",
 		}, ","),
-		packages:   "./pkg/config",
-		jsonOutput: jsonPath,
+		packages:        "./pkg/config",
+		packageBaseline: emptyPackageCoverageBaselinePath(t),
+		jsonOutput:      jsonPath,
 	}
 	if err := execute(cfg); err != nil {
 		t.Fatalf("execute() error = %v", err)
@@ -70,14 +72,8 @@ func TestExecuteWritesDeterministicJSONCoverageTotals(t *testing.T) {
 	if summary.CoveragePercent != 100.0 {
 		t.Fatalf("coveragePercent = %v, want 100.0", summary.CoveragePercent)
 	}
-
-	wantJSON := "{\n" +
-		"  \"coveredStatements\": 8,\n" +
-		"  \"measurableStatements\": 8,\n" +
-		"  \"coveragePercent\": 100\n" +
-		"}\n"
-	if string(first) != wantJSON {
-		t.Fatalf("coverage summary json = %q, want %q", first, wantJSON)
+	if len(summary.Packages) != 2 {
+		t.Fatalf("packages len = %d, want 2", len(summary.Packages))
 	}
 
 	got := stdout.String()
@@ -140,18 +136,220 @@ func TestExecuteOmitsJSONFileWhenJSONOutputOptionAbsent(t *testing.T) {
 	}
 }
 
-func TestBuildCoverageSummaryJSONUsesMeasuredTotals(t *testing.T) {
+func TestExecuteJSONReportsPackageFloorsFromManifest(t *testing.T) {
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	defer func() {
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	}()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	commandRunner = fakeGoCoverageCommandPassing
+	stdoutWriter = &stdout
+	stderrWriter = &stderr
+
+	configPackage := modulePath + "/pkg/config"
+	servicePackage := modulePath + "/pkg/service"
+	manifestPath := writePackageMinimumManifestWithEntries(t, "unit", []manifestPackageSpec{
+		{importPath: configPackage, minimum: "66.66"},
+		{importPath: servicePackage, minimum: "80.00"},
+	})
+	jsonPath := filepath.Join(t.TempDir(), "coverage-summary.json")
+
+	err := execute(config{
+		suite:           "unit",
+		min:             80,
+		coverpkg:        strings.Join([]string{configPackage, servicePackage}, ","),
+		packages:        "./pkg/config",
+		packageManifest: manifestPath,
+		jsonOutput:      jsonPath,
+	})
+	if err != nil {
+		t.Fatalf("execute() error = %v", err)
+	}
+
+	data, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatalf("read coverage summary json: %v", err)
+	}
+	var summary coverageSummaryJSON
+	if err := json.Unmarshal(data, &summary); err != nil {
+		t.Fatalf("decode coverage summary json: %v\n%s", err, data)
+	}
+	if len(summary.Packages) != 2 {
+		t.Fatalf("packages len = %d, want 2\n%s", len(summary.Packages), data)
+	}
+	if summary.Packages[0].Package != configPackage || summary.Packages[1].Package != servicePackage {
+		t.Fatalf("package order = [%s %s], want deterministic [%s %s]", summary.Packages[0].Package, summary.Packages[1].Package, configPackage, servicePackage)
+	}
+
+	configEntry := summary.Packages[0]
+	if configEntry.CoveredStatements != 3 || configEntry.MeasurableStatements != 3 {
+		t.Fatalf("pkg/config statements = %d/%d, want 3/3", configEntry.CoveredStatements, configEntry.MeasurableStatements)
+	}
+	if configEntry.CoveragePercent != 100.0 {
+		t.Fatalf("pkg/config coveragePercent = %v, want 100.0", configEntry.CoveragePercent)
+	}
+	if configEntry.PackageFloor == nil || *configEntry.PackageFloor != 66.66 {
+		t.Fatalf("pkg/config packageFloor = %v, want 66.66", configEntry.PackageFloor)
+	}
+	if configEntry.MeasurementException != nil {
+		t.Fatalf("pkg/config measurementException = %+v, want nil", configEntry.MeasurementException)
+	}
+
+	serviceEntry := summary.Packages[1]
+	if serviceEntry.CoveredStatements != 5 || serviceEntry.MeasurableStatements != 5 {
+		t.Fatalf("pkg/service statements = %d/%d, want 5/5", serviceEntry.CoveredStatements, serviceEntry.MeasurableStatements)
+	}
+	if serviceEntry.PackageFloor == nil || *serviceEntry.PackageFloor != 80.0 {
+		t.Fatalf("pkg/service packageFloor = %v, want 80", serviceEntry.PackageFloor)
+	}
+	if serviceEntry.MeasurementException != nil {
+		t.Fatalf("pkg/service measurementException = %+v, want nil", serviceEntry.MeasurementException)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("execute() stderr = %q, want empty stderr", stderr.String())
+	}
+}
+
+func TestExecuteJSONReportsMeasurementExceptionFromManifest(t *testing.T) {
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	defer func() {
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	}()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	commandRunner = fakeGoCoverageCommandPassing
+	stdoutWriter = &stdout
+	stderrWriter = &stderr
+
+	configPackage := modulePath + "/pkg/config"
+	servicePackage := modulePath + "/pkg/service"
+	initializerPackage := modulePath + "/pkg/initializer"
+	manifestPath := writePackageMinimumManifestWithEntries(t, "unit", []manifestPackageSpec{
+		{importPath: configPackage, minimum: "100.00"},
+		{
+			importPath: initializerPackage,
+			exception: &coverageManifestException{
+				Kind:          "measurement",
+				Justification: "The active unit coverage profile contains no measurable statements for this package.",
+				Owner:         "backend-quality",
+				Deadline:      unmeasurablePackageDeadline,
+				RemovalGate:   "The unit coverage profile reports at least one measurable statement for this package.",
+			},
+		},
+		{importPath: servicePackage, minimum: "100.00"},
+	})
+	jsonPath := filepath.Join(t.TempDir(), "coverage-summary.json")
+
+	err := execute(config{
+		suite: "unit",
+		min:   80,
+		coverpkg: strings.Join([]string{
+			configPackage,
+			initializerPackage,
+			servicePackage,
+		}, ","),
+		packages:        "./pkg/config",
+		packageManifest: manifestPath,
+		jsonOutput:      jsonPath,
+	})
+	if err != nil {
+		t.Fatalf("execute() error = %v", err)
+	}
+
+	data, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatalf("read coverage summary json: %v", err)
+	}
+	var summary coverageSummaryJSON
+	if err := json.Unmarshal(data, &summary); err != nil {
+		t.Fatalf("decode coverage summary json: %v\n%s", err, data)
+	}
+	if len(summary.Packages) != 3 {
+		t.Fatalf("packages len = %d, want 3\n%s", len(summary.Packages), data)
+	}
+	wantOrder := []string{configPackage, initializerPackage, servicePackage}
+	for index, wantPackage := range wantOrder {
+		if summary.Packages[index].Package != wantPackage {
+			t.Fatalf("packages[%d] = %q, want %q", index, summary.Packages[index].Package, wantPackage)
+		}
+	}
+
+	exceptionEntry := summary.Packages[1]
+	if exceptionEntry.CoveredStatements != 0 || exceptionEntry.MeasurableStatements != 0 {
+		t.Fatalf("unmeasurable package statements = %d/%d, want 0/0", exceptionEntry.CoveredStatements, exceptionEntry.MeasurableStatements)
+	}
+	if exceptionEntry.PackageFloor != nil {
+		t.Fatalf("unmeasurable packageFloor = %v, want null", *exceptionEntry.PackageFloor)
+	}
+	if exceptionEntry.MeasurementException == nil {
+		t.Fatalf("measurementException is nil, want structured exception\n%s", data)
+	}
+	gotException := exceptionEntry.MeasurementException
+	if gotException.Kind != "measurement" {
+		t.Fatalf("exception kind = %q, want measurement", gotException.Kind)
+	}
+	if gotException.Justification != "The active unit coverage profile contains no measurable statements for this package." {
+		t.Fatalf("exception justification = %q", gotException.Justification)
+	}
+	if gotException.Owner != "backend-quality" {
+		t.Fatalf("exception owner = %q, want backend-quality", gotException.Owner)
+	}
+	if gotException.Deadline != unmeasurablePackageDeadline {
+		t.Fatalf("exception deadline = %q, want %q", gotException.Deadline, unmeasurablePackageDeadline)
+	}
+	if gotException.RemovalGate != "The unit coverage profile reports at least one measurable statement for this package." {
+		t.Fatalf("exception removalGate = %q", gotException.RemovalGate)
+	}
+
+	if summary.Packages[0].MeasurementException != nil || summary.Packages[2].MeasurementException != nil {
+		t.Fatalf("measurable packages unexpectedly carried measurementException: %+v / %+v", summary.Packages[0].MeasurementException, summary.Packages[2].MeasurementException)
+	}
+	if summary.Packages[0].PackageFloor == nil || *summary.Packages[0].PackageFloor != 100.0 {
+		t.Fatalf("pkg/config packageFloor = %v, want 100", summary.Packages[0].PackageFloor)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("execute() stderr = %q, want empty stderr", stderr.String())
+	}
+}
+
+func TestBuildCoverageSummaryJSONUsesMeasuredTotalsAndPackageGates(t *testing.T) {
 	t.Parallel()
 
+	configPackage := modulePath + "/pkg/config"
+	servicePackage := modulePath + "/pkg/service"
+	floor := 66.66
 	result := coverageResult{
 		actual: 75,
 		packageTotals: map[string]packageCoverageTotals{
-			modulePath + "/pkg/config":  {coveredStatements: 3, totalStatements: 4},
-			modulePath + "/pkg/service": {coveredStatements: 0, totalStatements: 0},
+			configPackage:  {coveredStatements: 3, totalStatements: 4},
+			servicePackage: {coveredStatements: 0, totalStatements: 0},
 		},
 		packageSummaries: []packageCoverageSummary{
-			{importPath: modulePath + "/pkg/config", coverage: 75},
-			{importPath: modulePath + "/pkg/service", coverage: 0},
+			{importPath: configPackage, coverage: 75},
+			{importPath: servicePackage, coverage: 0},
+		},
+		packageGates: map[string]packageCoverageGate{
+			configPackage: {Floor: &floor},
+			servicePackage: {
+				Exception: &coverageManifestException{
+					Kind:          "measurement",
+					Justification: "The active unit coverage profile contains no measurable statements for this package.",
+					Owner:         "backend-quality",
+					Deadline:      unmeasurablePackageDeadline,
+					RemovalGate:   "The unit coverage profile reports at least one measurable statement for this package.",
+				},
+			},
 		},
 	}
 
@@ -165,4 +363,67 @@ func TestBuildCoverageSummaryJSONUsesMeasuredTotals(t *testing.T) {
 	if summary.CoveragePercent != 75.0 {
 		t.Fatalf("coveragePercent = %v, want 75.0", summary.CoveragePercent)
 	}
+	if len(summary.Packages) != 2 {
+		t.Fatalf("packages len = %d, want 2", len(summary.Packages))
+	}
+	if summary.Packages[0].PackageFloor == nil || *summary.Packages[0].PackageFloor != 66.66 {
+		t.Fatalf("packages[0].packageFloor = %v, want 66.66", summary.Packages[0].PackageFloor)
+	}
+	if summary.Packages[0].MeasurementException != nil {
+		t.Fatalf("packages[0].measurementException = %+v, want nil", summary.Packages[0].MeasurementException)
+	}
+	if summary.Packages[1].PackageFloor != nil {
+		t.Fatalf("packages[1].packageFloor = %v, want null", *summary.Packages[1].PackageFloor)
+	}
+	if summary.Packages[1].MeasurementException == nil || summary.Packages[1].MeasurementException.Kind != "measurement" {
+		t.Fatalf("packages[1].measurementException = %+v, want measurement exception", summary.Packages[1].MeasurementException)
+	}
+
+	data, err := renderCoverageSummaryJSON(summary)
+	if err != nil {
+		t.Fatalf("renderCoverageSummaryJSON() error = %v", err)
+	}
+	second, err := renderCoverageSummaryJSON(summary)
+	if err != nil {
+		t.Fatalf("renderCoverageSummaryJSON() second error = %v", err)
+	}
+	if !bytes.Equal(data, second) {
+		t.Fatalf("package coverage json was not deterministic:\nfirst=%s\nsecond=%s", data, second)
+	}
+}
+
+type manifestPackageSpec struct {
+	importPath string
+	minimum    string
+	exception  *coverageManifestException
+}
+
+func writePackageMinimumManifestWithEntries(t *testing.T, lane string, entries []manifestPackageSpec) string {
+	t.Helper()
+	manifestPath := filepath.Join(t.TempDir(), lane+"-minimums.json")
+	var packageBlocks []string
+	for _, entry := range entries {
+		if entry.exception != nil {
+			packageBlocks = append(packageBlocks, fmt.Sprintf(`    {
+      "package": %q,
+      "exception": {
+        "kind": %q,
+        "justification": %q,
+        "owner": %q,
+        "deadline": %q,
+        "removalGate": %q
+      }
+    }`, entry.importPath, entry.exception.Kind, entry.exception.Justification, entry.exception.Owner, entry.exception.Deadline, entry.exception.RemovalGate))
+			continue
+		}
+		packageBlocks = append(packageBlocks, fmt.Sprintf(`    {
+      "package": %q,
+      "minimum": %s
+    }`, entry.importPath, entry.minimum))
+	}
+	data := fmt.Sprintf("{\n  \"version\": 1,\n  \"lane\": %q,\n  \"packages\": [\n%s\n  ]\n}\n", lane, strings.Join(packageBlocks, ",\n"))
+	if err := os.WriteFile(manifestPath, []byte(data), 0o600); err != nil {
+		t.Fatalf("write package minimum manifest: %v", err)
+	}
+	return manifestPath
 }

--- a/cmd/gocoveragecheck/coverage_json_test.go
+++ b/cmd/gocoveragecheck/coverage_json_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExecuteWritesDeterministicJSONCoverageTotals(t *testing.T) {
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	defer func() {
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	}()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	commandRunner = fakeGoCoverageCommandPassing
+	stdoutWriter = &stdout
+	stderrWriter = &stderr
+
+	jsonPath := filepath.Join(t.TempDir(), "coverage-summary.json")
+	cfg := config{
+		min: 80,
+		coverpkg: strings.Join([]string{
+			modulePath + "/pkg/config",
+			modulePath + "/pkg/service",
+		}, ","),
+		packages:   "./pkg/config",
+		jsonOutput: jsonPath,
+	}
+	if err := execute(cfg); err != nil {
+		t.Fatalf("execute() error = %v", err)
+	}
+	if err := execute(cfg); err != nil {
+		t.Fatalf("second execute() error = %v", err)
+	}
+
+	first, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatalf("read coverage summary json: %v", err)
+	}
+	if err := execute(cfg); err != nil {
+		t.Fatalf("third execute() error = %v", err)
+	}
+	second, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatalf("read coverage summary json after rerun: %v", err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatalf("coverage summary json was not deterministic:\nfirst=%s\nsecond=%s", first, second)
+	}
+
+	var summary coverageSummaryJSON
+	if err := json.Unmarshal(first, &summary); err != nil {
+		t.Fatalf("decode coverage summary json: %v\n%s", err, first)
+	}
+	if summary.CoveredStatements != 8 {
+		t.Fatalf("coveredStatements = %d, want 8", summary.CoveredStatements)
+	}
+	if summary.MeasurableStatements != 8 {
+		t.Fatalf("measurableStatements = %d, want 8", summary.MeasurableStatements)
+	}
+	if summary.CoveragePercent != 100.0 {
+		t.Fatalf("coveragePercent = %v, want 100.0", summary.CoveragePercent)
+	}
+
+	wantJSON := "{\n" +
+		"  \"coveredStatements\": 8,\n" +
+		"  \"measurableStatements\": 8,\n" +
+		"  \"coveragePercent\": 100\n" +
+		"}\n"
+	if string(first) != wantJSON {
+		t.Fatalf("coverage summary json = %q, want %q", first, wantJSON)
+	}
+
+	got := stdout.String()
+	if !strings.Contains(got, "Go coverage 100.0% meets minimum 80.0%.") {
+		t.Fatalf("execute() stdout = %q, want success message retained with json output", got)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("execute() stderr = %q, want empty stderr", stderr.String())
+	}
+}
+
+func TestExecuteOmitsJSONFileWhenJSONOutputOptionAbsent(t *testing.T) {
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	defer func() {
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	}()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	commandRunner = fakeGoCoverageCommandPassing
+	stdoutWriter = &stdout
+	stderrWriter = &stderr
+
+	jsonPath := filepath.Join(t.TempDir(), "coverage-summary.json")
+	err := execute(config{
+		min: 80,
+		coverpkg: strings.Join([]string{
+			modulePath + "/pkg/config",
+			modulePath + "/pkg/service",
+		}, ","),
+		packages: "./pkg/config",
+	})
+	if err != nil {
+		t.Fatalf("execute() error = %v", err)
+	}
+	if _, err := os.Stat(jsonPath); !os.IsNotExist(err) {
+		t.Fatalf("unexpected json file at %s with err=%v", jsonPath, err)
+	}
+
+	got := stdout.String()
+	if !strings.Contains(got, "total: (statements) 100.0%") {
+		t.Fatalf("execute() stdout = %q, want total coverage line", got)
+	}
+	if !strings.Contains(got, modulePath+"/pkg/config\tcoverage: 100.0% of statements") {
+		t.Fatalf("execute() stdout = %q, want package summary for pkg/config", got)
+	}
+	if !strings.Contains(got, modulePath+"/pkg/service\tcoverage: 100.0% of statements") {
+		t.Fatalf("execute() stdout = %q, want package summary for pkg/service", got)
+	}
+	wantSuccess := "Go coverage 100.0% meets minimum 80.0%."
+	if !strings.Contains(got, wantSuccess) {
+		t.Fatalf("execute() stdout = %q, want success message %q", got, wantSuccess)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("execute() stderr = %q, want empty stderr", stderr.String())
+	}
+}
+
+func TestBuildCoverageSummaryJSONUsesMeasuredTotals(t *testing.T) {
+	t.Parallel()
+
+	result := coverageResult{
+		actual: 75,
+		packageTotals: map[string]packageCoverageTotals{
+			modulePath + "/pkg/config":  {coveredStatements: 3, totalStatements: 4},
+			modulePath + "/pkg/service": {coveredStatements: 0, totalStatements: 0},
+		},
+		packageSummaries: []packageCoverageSummary{
+			{importPath: modulePath + "/pkg/config", coverage: 75},
+			{importPath: modulePath + "/pkg/service", coverage: 0},
+		},
+	}
+
+	summary := buildCoverageSummaryJSON(result)
+	if summary.CoveredStatements != 3 {
+		t.Fatalf("coveredStatements = %d, want 3", summary.CoveredStatements)
+	}
+	if summary.MeasurableStatements != 4 {
+		t.Fatalf("measurableStatements = %d, want 4", summary.MeasurableStatements)
+	}
+	if summary.CoveragePercent != 75.0 {
+		t.Fatalf("coveragePercent = %v, want 75.0", summary.CoveragePercent)
+	}
+}

--- a/cmd/gocoveragecheck/coverage_json_test.go
+++ b/cmd/gocoveragecheck/coverage_json_test.go
@@ -323,6 +323,229 @@ func TestExecuteJSONReportsMeasurementExceptionFromManifest(t *testing.T) {
 	}
 }
 
+func TestExecuteWritesJSONWhenOverallFloorFails(t *testing.T) {
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	defer func() {
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	}()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	commandRunner = fakeGoCoverageCommandPassing
+	stdoutWriter = &stdout
+	stderrWriter = &stderr
+
+	jsonPath := filepath.Join(t.TempDir(), "coverage-summary.json")
+	err := execute(config{
+		min: 100.1,
+		coverpkg: strings.Join([]string{
+			modulePath + "/pkg/config",
+			modulePath + "/pkg/service",
+		}, ","),
+		packages:        "./pkg/config",
+		packageBaseline: emptyPackageCoverageBaselinePath(t),
+		jsonOutput:      jsonPath,
+	})
+	if err == nil {
+		t.Fatal("execute() unexpectedly succeeded")
+	}
+	wantFailure := "go coverage 100.0% is below minimum 100.1%"
+	if err.Error() != wantFailure {
+		t.Fatalf("execute() error = %q, want %q", err.Error(), wantFailure)
+	}
+
+	data, readErr := os.ReadFile(jsonPath)
+	if readErr != nil {
+		t.Fatalf("read coverage summary json after floor failure: %v", readErr)
+	}
+	var summary coverageSummaryJSON
+	if decodeErr := json.Unmarshal(data, &summary); decodeErr != nil {
+		t.Fatalf("decode coverage summary json: %v\n%s", decodeErr, data)
+	}
+	if summary.CoveredStatements != 8 || summary.MeasurableStatements != 8 {
+		t.Fatalf("overall statements = %d/%d, want 8/8", summary.CoveredStatements, summary.MeasurableStatements)
+	}
+	if summary.CoveragePercent != 100.0 {
+		t.Fatalf("coveragePercent = %v, want 100.0", summary.CoveragePercent)
+	}
+	if len(summary.Packages) != 2 {
+		t.Fatalf("packages len = %d, want 2", len(summary.Packages))
+	}
+
+	got := stdout.String()
+	if !strings.Contains(got, modulePath+"/pkg/config\tcoverage: 100.0% of statements") {
+		t.Fatalf("execute() stdout = %q, want package summary retained on floor failure", got)
+	}
+	if strings.Contains(got, "meets minimum") {
+		t.Fatalf("execute() stdout = %q, did not expect success message", got)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("execute() stderr = %q, want empty stderr", stderr.String())
+	}
+}
+
+func TestExecuteWritesJSONWhenPackageFloorFails(t *testing.T) {
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	defer func() {
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	}()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	commandRunner = fakeGoCoverageCommand
+	stdoutWriter = &stdout
+	stderrWriter = &stderr
+
+	configPackage := modulePath + "/pkg/config"
+	manifestPath := writePackageMinimumManifestWithEntries(t, "unit", []manifestPackageSpec{
+		{importPath: configPackage, minimum: "80.00"},
+	})
+	jsonPath := filepath.Join(t.TempDir(), "coverage-summary.json")
+
+	err := execute(config{
+		suite:           "unit",
+		min:             0,
+		coverpkg:        configPackage,
+		packages:        "./pkg/config",
+		packageManifest: manifestPath,
+		jsonOutput:      jsonPath,
+	})
+	if err == nil {
+		t.Fatal("execute() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "package coverage regression: package="+configPackage+" lane=unit expected-minimum=80.00%") {
+		t.Fatalf("execute() error = %q, want package floor failure", err.Error())
+	}
+
+	data, readErr := os.ReadFile(jsonPath)
+	if readErr != nil {
+		t.Fatalf("read coverage summary json after package floor failure: %v", readErr)
+	}
+	var summary coverageSummaryJSON
+	if decodeErr := json.Unmarshal(data, &summary); decodeErr != nil {
+		t.Fatalf("decode coverage summary json: %v\n%s", decodeErr, data)
+	}
+	if len(summary.Packages) != 1 {
+		t.Fatalf("packages len = %d, want 1\n%s", len(summary.Packages), data)
+	}
+	entry := summary.Packages[0]
+	if entry.Package != configPackage {
+		t.Fatalf("package = %q, want %q", entry.Package, configPackage)
+	}
+	if entry.PackageFloor == nil || *entry.PackageFloor != 80.0 {
+		t.Fatalf("packageFloor = %v, want 80", entry.PackageFloor)
+	}
+	if entry.CoveragePercent != 0.0 {
+		t.Fatalf("coveragePercent = %v, want 0.0", entry.CoveragePercent)
+	}
+	if strings.Contains(stdout.String(), "meets minimum") {
+		t.Fatalf("execute() stdout = %q, did not expect success message", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("execute() stderr = %q, want empty stderr", stderr.String())
+	}
+}
+
+func TestExecuteDoesNotWriteJSONWhenMeasurementIncomplete(t *testing.T) {
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	defer func() {
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	}()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	commandRunner = fakeGoCoverageCommandTestFailsWithoutDetail
+	stdoutWriter = &stdout
+	stderrWriter = &stderr
+
+	jsonPath := filepath.Join(t.TempDir(), "coverage-summary.json")
+	err := execute(config{
+		min: 80,
+		coverpkg: strings.Join([]string{
+			modulePath + "/pkg/config",
+			modulePath + "/pkg/service",
+		}, ","),
+		packages:   "./pkg/config",
+		profile:    filepath.Join(t.TempDir(), "coverage.out"),
+		jsonOutput: jsonPath,
+	})
+	if err == nil {
+		t.Fatal("execute() unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "run go test coverage shard") {
+		t.Fatalf("execute() error = %q, want incomplete measurement failure", err.Error())
+	}
+	if _, statErr := os.Stat(jsonPath); !os.IsNotExist(statErr) {
+		t.Fatalf("unexpected json file at %s after incomplete measurement (stat err=%v)", jsonPath, statErr)
+	}
+}
+
+func TestExecuteFloorFailureWithoutJSONOptionKeepsHumanDiagnostics(t *testing.T) {
+	originalCommandRunner := commandRunner
+	originalStdout := stdoutWriter
+	originalStderr := stderrWriter
+	defer func() {
+		commandRunner = originalCommandRunner
+		stdoutWriter = originalStdout
+		stderrWriter = originalStderr
+	}()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	commandRunner = fakeGoCoverageCommandPassing
+	stdoutWriter = &stdout
+	stderrWriter = &stderr
+
+	jsonPath := filepath.Join(t.TempDir(), "coverage-summary.json")
+	err := execute(config{
+		min: 100.1,
+		coverpkg: strings.Join([]string{
+			modulePath + "/pkg/config",
+			modulePath + "/pkg/service",
+		}, ","),
+		packages: "./pkg/config",
+	})
+	if err == nil {
+		t.Fatal("execute() unexpectedly succeeded")
+	}
+	wantFailure := "go coverage 100.0% is below minimum 100.1%"
+	if err.Error() != wantFailure {
+		t.Fatalf("execute() error = %q, want %q", err.Error(), wantFailure)
+	}
+	if _, statErr := os.Stat(jsonPath); !os.IsNotExist(statErr) {
+		t.Fatalf("unexpected json file at %s when json option absent (stat err=%v)", jsonPath, statErr)
+	}
+
+	got := stdout.String()
+	if !strings.Contains(got, "total: (statements) 100.0%") {
+		t.Fatalf("execute() stdout = %q, want total coverage line", got)
+	}
+	if !strings.Contains(got, modulePath+"/pkg/config\tcoverage: 100.0% of statements") {
+		t.Fatalf("execute() stdout = %q, want package summary for pkg/config", got)
+	}
+	if !strings.Contains(got, modulePath+"/pkg/service\tcoverage: 100.0% of statements") {
+		t.Fatalf("execute() stdout = %q, want package summary for pkg/service", got)
+	}
+	if strings.Contains(got, "meets minimum") {
+		t.Fatalf("execute() stdout = %q, did not expect success message", got)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("execute() stderr = %q, want empty stderr", stderr.String())
+	}
+}
+
 func TestBuildCoverageSummaryJSONUsesMeasuredTotalsAndPackageGates(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -90,6 +90,7 @@ type coverageResult struct {
 	insufficientCoveragePackages []packageCoverageSummary
 	packageTotals                map[string]packageCoverageTotals
 	packageSummaries             []packageCoverageSummary
+	packageGates                 map[string]packageCoverageGate
 	zeroCoveragePackages         []string
 	packageMinimumFailures       []string
 }
@@ -305,6 +306,9 @@ func run(cfg config) (coverageResult, error) {
 			return coverageResult{}, err
 		}
 		result.packageMinimumFailures = checkCoverageManifest(manifest, result.packageTotals, cfg.packageManifest)
+		result.packageGates = packageGatesFromManifest(manifest)
+	} else if legacyPackageGateEnabled {
+		result.packageGates = packageGatesFromLegacyMin(result.packageSummaries, cfg.packageCoverageMin(), baselinePackages)
 	}
 	fmt.Fprintln(stdoutWriter, totalLine)
 	return result, nil

--- a/cmd/gocoveragecheck/main.go
+++ b/cmd/gocoveragecheck/main.go
@@ -73,6 +73,7 @@ type config struct {
 	generateManifest string
 	updateManifest   string
 	packageManifest  string
+	jsonOutput       string
 	min              float64
 	packageBaseline  string
 	packageMin       float64
@@ -154,6 +155,9 @@ func execute(cfg config) error {
 			return err
 		}
 	}
+	if err := writeCoverageSummaryJSON(cfg.jsonOutput, result); err != nil {
+		return err
+	}
 
 	if len(failures) > 0 {
 		return errors.New(strings.Join(failures, "\n"))
@@ -170,6 +174,7 @@ func parseConfig() config {
 	flag.StringVar(&cfg.generateManifest, "generate-manifest", "", "create a deterministic package-minimum manifest from this lane's coverage profile")
 	flag.StringVar(&cfg.updateManifest, "update-manifest", "", "monotonically add or raise floors in an existing package-minimum manifest")
 	flag.StringVar(&cfg.packageManifest, "package-manifest", "", "enforce the active lane's checked-in package-minimum manifest")
+	flag.StringVar(&cfg.jsonOutput, "json-output", "", "optional path for a deterministic machine-readable coverage summary JSON document")
 	flag.Float64Var(&cfg.min, "min", 0, "minimum total statement coverage percentage")
 	flag.StringVar(&cfg.packageBaseline, "package-baseline", "", "newline-delimited list of backend packages temporarily exempt from the per-package minimum coverage gate; defaults by suite")
 	flag.Float64Var(&cfg.packageMin, "package-min", defaultPackageCoverageMin, "minimum statement coverage required for each non-baselined backend package")

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -173,7 +173,10 @@
   The JSON includes overall totals plus per-package covered/measurable counts,
   percentage, package floor, and measurement exception from the same gate
   policy the checker already enforces; do not invent a second coverage-profile
-  parser for those summaries.
+  parser for those summaries. When floors fail after measurement completes, the
+  JSON file is still written before the process returns the floor failure so
+  uploaded artifacts keep diagnostics; incomplete runs that never produce
+  measured results do not invent coverage JSON.
   Windows Go suite coverage is a `windows-go-tests` matrix with independent
   `Unit`, `Functional`, `Stress`, and `Release` jobs. Keep `fail-fast: false`,
   preserve each job's Windows setup, and invoke the matching repository-owned

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -168,9 +168,12 @@
   package-specific minimum to the matching
   `docs/internal/baselines/go-*-coverage-package-minimums.json` manifest in
   the same change; the coverage gate rejects unowned measured packages.
-  Optional machine-readable coverage totals for CI/visualizer consumers come
-  from `gocoveragecheck -json-output <path>` after a completed measurement run;
-  do not invent a second coverage-profile parser for those summaries.
+  Optional machine-readable coverage summaries for CI/visualizer consumers come
+  from `gocoveragecheck -json-output <path>` after a completed measurement run.
+  The JSON includes overall totals plus per-package covered/measurable counts,
+  percentage, package floor, and measurement exception from the same gate
+  policy the checker already enforces; do not invent a second coverage-profile
+  parser for those summaries.
   Windows Go suite coverage is a `windows-go-tests` matrix with independent
   `Unit`, `Functional`, `Stress`, and `Release` jobs. Keep `fail-fast: false`,
   preserve each job's Windows setup, and invoke the matching repository-owned

--- a/docs/internal/processes/ci-relevant-files.md
+++ b/docs/internal/processes/ci-relevant-files.md
@@ -168,6 +168,9 @@
   package-specific minimum to the matching
   `docs/internal/baselines/go-*-coverage-package-minimums.json` manifest in
   the same change; the coverage gate rejects unowned measured packages.
+  Optional machine-readable coverage totals for CI/visualizer consumers come
+  from `gocoveragecheck -json-output <path>` after a completed measurement run;
+  do not invent a second coverage-profile parser for those summaries.
   Windows Go suite coverage is a `windows-go-tests` matrix with independent
   `Unit`, `Functional`, `Stress`, and `Release` jobs. Keep `fail-fast: false`,
   preserve each job's Windows setup, and invoke the matching repository-owned


### PR DESCRIPTION
{
  "project": "infinite-you",
  "branchName": "fnd-003-coverage-json",
  "description": "Expose optional deterministic coverage JSON from cmd/gocoveragecheck that reports covered/measurable statements, percentage, package floor, and measurement exception while preserving existing non-JSON behavior when the option is absent and writing diagnostics after completed runs even when floors fail.",
  "context": {
    "customerAsk": "Add optional JSON output to cmd/gocoveragecheck that reports covered/measurable statements, percentage, package floor, and measurement exception while preserving existing behavior when the option is absent. Write results after a completed run even when a floor fails. Prove the contract with focused tests for totals, package floors, and exception reporting so the visualizer does not invent a second coverage parser.",
    "problem": "gocoveragecheck already enforces statement-coverage floors and prints human-oriented package lines, but the functional-test visualizer needs a stable machine-readable coverage summary. Without optional JSON from the same checker that owns profile parsing and floor policy, later foundation cells would re-parse coverage profiles or invent parallel diagnostics and risk drift—especially when floors fail and CI still needs preserved diagnostics.",
    "solution": "Extend gocoveragecheck with an optional JSON output path that writes one deterministic summary after a completed measurement run, including overall and per-package covered/measurable counts, percentage, package floor, and measurement exception. Keep today's stdout and floor-enforcement behavior unchanged when the option is omitted. When floors fail after measurement completes, still write the JSON file, then fail the process as today."
  },
  "acceptanceCriteria": [
    "Optional JSON output is deterministic and machine-readable, and includes covered/measurable statement counts, coverage percentage, package floor, and measurement exception for reported packages.",
    "Existing non-JSON stdout, stderr, exit, and floor-enforcement behavior remains unchanged when the JSON option is absent.",
    "After a completed measurement run, JSON is written even when overall or package floors fail; the process still reports those floor failures as it does today.",
    "Focused cmd/gocoveragecheck tests cover totals, package floors, and exception reporting through observable JSON contents and run outcomes.",
    "The JSON contract is owned by gocoveragecheck so later visualizer work consumes this artifact instead of inventing a second coverage parser.",
    "Quality gate: typecheck, lint, and tests pass (make test, make verify-fast, and focused cmd/gocoveragecheck tests)."
  ],
  "userStories": [
    {
      "id": "fnd-003-coverage-json-001",
      "title": "Emit optional deterministic JSON coverage totals",
      "description": "As a maintainer running coverage checks, I want an optional JSON output that reports overall covered and measurable statement counts and percentage so downstream tools can consume deterministic totals from the same run that enforces floors.",
      "acceptanceCriteria": [
        "gocoveragecheck accepts an optional JSON output path; when set and a coverage measurement run completes, it writes a single valid JSON document to that path.",
        "The JSON includes overall covered statement count, measurable (total) statement count, and coverage percentage derived from the same measured profile the checker already uses for floors.",
        "Repeated runs against identical measured inputs produce byte-stable or otherwise deterministic JSON (stable field set, stable numeric formatting, and stable ordering of any collections that appear at this stage).",
        "When the JSON option is absent, existing human-oriented package lines, success message, failure message text, and exit behavior remain unchanged.",
        "Focused tests assert overall totals fields and prove non-JSON behavior is unchanged when the option is omitted.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Added -json-output path flag; writes deterministic overall covered/measurable/percentage JSON after completed measurement. Focused tests cover totals and absent-option behavior."
    },
    {
      "id": "fnd-003-coverage-json-002",
      "title": "Report package floors and measurement exceptions in JSON",
      "description": "As a visualizer or CI consumer, I want each measured production package in the JSON to include covered/measurable statements, percentage, package floor, and measurement exception so I can render package coverage without re-parsing profiles or manifests.",
      "acceptanceCriteria": [
        "For each reported measured package, the JSON includes covered statement count, measurable statement count, coverage percentage, and the package floor used by the checker's package gate for that run.",
        "When a package is unmeasurable or otherwise carries a measurement exception in the checker's existing policy model, the JSON reports that measurement exception in a structured field rather than omitting the package silently.",
        "Packages are listed in a deterministic order so consumers can diff summaries across runs.",
        "Package JSON fields remain consistent with the same measured totals and floor policy used for human reporting and gate evaluation in that run.",
        "Focused tests cover package floor values and measurement-exception reporting through observable JSON contents.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "JSON packages[] now includes covered/measurable/percentage plus packageFloor from manifest or legacy package-min, and structured measurementException when the gate uses an exception entry. Deterministic sorted package order; focused execute tests cover floors and exceptions."
    },
    {
      "id": "fnd-003-coverage-json-003",
      "title": "Write JSON diagnostics after completed floor failures",
      "description": "As a CI operator, I want coverage JSON written after a completed measurement even when floors fail so uploaded artifacts still contain diagnostics while the process fails the gate.",
      "acceptanceCriteria": [
        "When the JSON option is set and measurement completes, but overall coverage or package floors fail, the JSON file is still written with the measured totals and package diagnostics before the process returns the floor failure.",
        "Floor-failure exit / error behavior remains non-zero (or otherwise failing) as it does today; JSON emission does not convert a failed floor into a successful run.",
        "Incomplete runs that never produce measured coverage results (for example, test execution failure before a usable profile) do not invent fake coverage JSON; they fail without claiming measured package totals.",
        "Focused tests prove JSON is present after a completed run that fails floors, and that absence of the option still yields today's failure-only human diagnostics.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "JSON write already runs after measurement and before floor-failure return. Focused tests prove JSON is present on overall and package floor failures, absent on incomplete measurement, and omitted when the option is unset while human floor-failure diagnostics stay unchanged."
    }
  ]
}

Made with [Cursor](https://cursor.com)