### PR TITLE
pss-ctr-work-root-contract

### DIFF
--- a/docs/internal/baselines/backend-package-file-count.json
+++ b/docs/internal/baselines/backend-package-file-count.json
@@ -21,7 +21,7 @@
     { "packagePath": "pkg/services/recordings/events", "fileCount": 18, "owner": "recording-maintainers", "removalReason": "Partition recording event contracts by stable concern." },
     { "packagePath": "pkg/services/recordings/projections/projectiontests", "fileCount": 16, "owner": "recording-maintainers", "removalReason": "Consolidate projection fixtures and focused scenarios." },
     { "packagePath": "pkg/services/recordings/replay", "fileCount": 19, "owner": "recording-maintainers", "removalReason": "Split replay ingestion, validation, and execution responsibilities." },
-    { "packagePath": "pkg/services/work", "fileCount": 37, "owner": "work-maintainers", "removalReason": "Continue extracting Work capabilities into focused child packages." },
+    { "packagePath": "pkg/services/work", "fileCount": 42, "owner": "work-maintainers", "removalReason": "Continue extracting Work capabilities into focused child packages." },
     { "packagePath": "pkg/services/workers", "fileCount": 30, "owner": "worker-maintainers", "removalReason": "Continue extracting worker policy and execution capabilities." },
     { "packagePath": "pkg/transports/cli", "fileCount": 20, "owner": "cli-maintainers", "removalReason": "Move command behavior into focused command packages." },
     { "packagePath": "pkg/transports/cli/baseline", "fileCount": 20, "owner": "cli-maintainers", "removalReason": "Consolidate baseline command fixtures and split durable behaviors." },

--- a/docs/internal/baselines/go-functional-coverage-package-minimums.json
+++ b/docs/internal/baselines/go-functional-coverage-package-minimums.json
@@ -922,7 +922,7 @@
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/work/service",
-      "minimum": 35.81
+      "minimum": 30.63
     },
     {
       "package": "github.com/portpowered/infinite-you/pkg/services/workers",

--- a/pkg/services/work/admission_contract.go
+++ b/pkg/services/work/admission_contract.go
@@ -1,0 +1,20 @@
+package work
+
+import "errors"
+
+// Admission typed failures peers can distinguish on the root Service admission
+// slice (SubmitWorkRequestForSession). Implementations may wrap these sentinels
+// with additional context; peers should branch with errors.Is.
+var (
+	// ErrInvalidWorkRequest reports that admission rejected a Work Request
+	// because required identity or payload fields failed Work-owned validation.
+	ErrInvalidWorkRequest = errors.New("invalid Work Request")
+
+	// ErrWorkRequestConflict reports that admission conflicted with an already
+	// applied request identity or incompatible admission state.
+	ErrWorkRequestConflict = errors.New("Work Request admission conflict")
+
+	// ErrWorkRequestRejected reports that admission policy rejected a Work
+	// Request without accepting it into a Factory Session.
+	ErrWorkRequestRejected = errors.New("Work Request rejected")
+)

--- a/pkg/services/work/content_contract.go
+++ b/pkg/services/work/content_contract.go
@@ -42,8 +42,9 @@ type ContentHTTPDoer interface {
 	Do(*http.Request) (*http.Response, error)
 }
 
-// ContentMaterializer resolves a Work content URL to a local path for an
-// invocation.
+// ContentMaterializer is the focused Work materialization role. The published
+// peer root exposes MaterializeContentURL on Service; workers may still inject
+// this narrower role until nested IMP-WORK cuts fold injection onto the root.
 type ContentMaterializer interface {
 	MaterializeContentURL(context.Context, string) (string, ContentCleanup, error)
 }

--- a/pkg/services/work/content_materialize_contract.go
+++ b/pkg/services/work/content_materialize_contract.go
@@ -1,0 +1,17 @@
+package work
+
+import "errors"
+
+// Materialization typed failures peers can distinguish on the root Service
+// content materialization slice (MaterializeContentURL). Implementations may
+// wrap these sentinels with additional context; peers should branch with
+// errors.Is.
+var (
+	// ErrUnsafeContentURL reports that materialization rejected a content URL
+	// that would resolve to a disallowed or private target.
+	ErrUnsafeContentURL = errors.New("unsafe Work content URL")
+
+	// ErrContentURLInaccessible reports that a remote or otherwise resolvable
+	// content URL could not be retrieved.
+	ErrContentURLInaccessible = errors.New("Work content URL inaccessible")
+)

--- a/pkg/services/work/content_staging.go
+++ b/pkg/services/work/content_staging.go
@@ -48,8 +48,9 @@ type ContentStagingClock interface {
 	Now() time.Time
 }
 
-// ContentStagingService is the Work-owned staging boundary consumed by
-// transports. Each operation owns validation and external effects completely.
+// ContentStagingService is the focused Work staging role. The published peer
+// root exposes the same operations on Service; transports may still inject this
+// narrower role until nested IMP-WORK cuts fold injection onto the root.
 type ContentStagingService interface {
 	StageContent(context.Context, StageContentRequest) (StageContentResult, error)
 	PrepareContent(context.Context, []StagedSubmissionItem) ([]WorkContentPart, error)
@@ -57,6 +58,7 @@ type ContentStagingService interface {
 	CleanupContent(context.Context, string) error
 }
 
+// StageContentRequest is the plain Work-owned staging request contract.
 type StageContentRequest struct {
 	ItemType  string
 	FileName  string
@@ -64,6 +66,9 @@ type StageContentRequest struct {
 	Content   []byte
 }
 
+// StageContentResult is the plain Work-owned staging result. StagedFileRef is an
+// opaque reference peers pass back through prepare/resolve/cleanup without
+// observing staging implementation types.
 type StageContentResult struct {
 	StagedFileRef string
 	FileName      string

--- a/pkg/services/work/contracts.go
+++ b/pkg/services/work/contracts.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 )
 
-// ErrMoveWorkRequestAlreadyApplied reports a duplicate operator move requestId.
+// ErrMoveWorkRequestAlreadyApplied is the typed state-access failure returned
+// when an operator move requestId was already applied. Peers branch with
+// errors.Is on MoveWorkForSession / MoveWorkAndRead.
 var ErrMoveWorkRequestAlreadyApplied = errors.New("operator move request was already applied")
 
 // InvocationReturnConfig selects the Work result returned by one Factory
@@ -434,6 +436,9 @@ type WorkStateChangeRecord struct {
 	RequestID, TriggerWorkID, Reason string
 }
 
+// OperatorMoveResult is the existing detached move success shape returned by
+// the root Service state-access slice (MoveWorkForSession). Peers consume Work
+// identity and from/to state facts without importing Factory Runtime types.
 type OperatorMoveResult struct {
 	WorkID, WorkTypeID     string
 	FromState, ToState     string

--- a/pkg/services/work/contracts.go
+++ b/pkg/services/work/contracts.go
@@ -163,7 +163,9 @@ type WorkRequestType string
 
 const WorkRequestTypeFactoryRequestBatch WorkRequestType = "FACTORY_REQUEST_BATCH"
 
-// WorkRequest is the domain representation of the generated WorkRequest schema.
+// WorkRequest is the plain Work-owned admission request contract. Peers pass an
+// already-decoded request (identity, type, works, and relations) through the
+// root Service admission slice; path or protocol decoding stays at adapters.
 type WorkRequest struct {
 	RequestID              string          `json:"requestId"`
 	CurrentChainingTraceID string          `json:"currentChainingTraceId,omitempty"`
@@ -232,7 +234,9 @@ type WorkRequestSubmittedWork struct {
 	WorkID       string
 }
 
-// WorkRequestSubmitResult describes accepted request metadata.
+// WorkRequestSubmitResult is the plain Work-owned admission result. Peers
+// consume detached acceptance facts (request/work identity and Accepted) without
+// importing Work implementation packages.
 type WorkRequestSubmitResult struct {
 	RequestID    string
 	TraceID      string

--- a/pkg/services/work/invocation_input_preparation.go
+++ b/pkg/services/work/invocation_input_preparation.go
@@ -25,8 +25,9 @@ type PreparedInvocationInput struct {
 	NormalizedArguments *NormalizedArguments
 }
 
-// InvocationInputPreparation is the exact Work-owned role used by transports
-// to turn raw invocation-edge values into canonical Work input.
+// InvocationInputPreparation is the focused Work-owned role used by transports
+// that inject preparation alone. Cross-service peers that depend on the
+// singular Work root should call Service.PrepareInvocationInput instead.
 type InvocationInputPreparation interface {
 	PrepareInvocationInput(context.Context, InvocationInputPreparationRequest) (PreparedInvocationInput, error)
 }

--- a/pkg/services/work/invocation_return_policy_contract.go
+++ b/pkg/services/work/invocation_return_policy_contract.go
@@ -1,0 +1,18 @@
+package work
+
+import "errors"
+
+// Invocation/return-policy typed failures peers can distinguish on the root
+// Service slice (PrepareInvocationInput / ResolvePrimaryResult).
+// Implementations may wrap these sentinels with additional context; peers
+// should branch with errors.Is. Structured *InputError and *PrimaryResultError
+// values remain valid typed failures for more specific codes.
+var (
+	// ErrInvalidInvocationInput reports that invocation-input preparation
+	// rejected raw edge values that failed Work-owned validation.
+	ErrInvalidInvocationInput = errors.New("invalid invocation input")
+
+	// ErrUnsupportedReturnPolicy reports that primary-result selection rejected
+	// an unsupported or invalid invocation return-policy configuration.
+	ErrUnsupportedReturnPolicy = errors.New("unsupported invocation return policy")
+)

--- a/pkg/services/work/primary_result.go
+++ b/pkg/services/work/primary_result.go
@@ -80,7 +80,8 @@ func invocationWorldState(input PrimaryResultSelectionInput) InvocationWorldStat
 }
 
 // ResolvePrimaryResult applies the canonical invocation primary-result rules
-// against one selected-tick factory world state.
+// against one selected-tick factory world state. The singular Work root Service
+// publishes this capability as Service.ResolvePrimaryResult.
 func ResolvePrimaryResult(input PrimaryResultSelectionInput) (PrimaryResultSelection, error) {
 	requestID := strings.TrimSpace(input.RequestID)
 	if requestID == "" {
@@ -102,7 +103,7 @@ func ResolvePrimaryResult(input PrimaryResultSelectionInput) (PrimaryResultSelec
 	case invocationReturnPolicyExplicit:
 		return resolveExplicitPrimaryResult(requestID, invocationWorldState(input), request.WorkItems, input.InvocationReturn)
 	default:
-		return PrimaryResultSelection{}, fmt.Errorf("unsupported invocation return policy %q", policy)
+		return PrimaryResultSelection{}, fmt.Errorf("%w: %q", ErrUnsupportedReturnPolicy, policy)
 	}
 }
 

--- a/pkg/services/work/query_list.go
+++ b/pkg/services/work/query_list.go
@@ -18,8 +18,8 @@ const (
 	SortByStateType = "state.type"
 )
 
-// ListOptions contains transport-independent filters, ordering, and pagination
-// controls for a Work list request.
+// ListOptions is the plain Work-owned state-access list request contract used by
+// Service.ListWork. Filters, ordering, and pagination stay transport-independent.
 type ListOptions struct {
 	StateName    string
 	StateType    string

--- a/pkg/services/work/read_contract.go
+++ b/pkg/services/work/read_contract.go
@@ -4,10 +4,14 @@ import "errors"
 
 const DefaultListMaxResults = 50
 
+// ErrWorkNotFound is the typed state-access failure returned when list/get /
+// move-and-read cannot resolve the requested Work. Peers branch with errors.Is.
 var ErrWorkNotFound = errors.New("Work not found")
 
 // ReadModel is the detached customer-facing Work projection returned by the
-// Work owner. It deliberately contains no token, place, marking, or topology.
+// root Service state-access slice (ListWork, GetWork, MoveWorkAndRead). It
+// deliberately contains no token, place, marking, or topology fields and no
+// Factory Runtime or peer implementation types.
 type ReadModel struct {
 	CursorID                 string
 	Name                     string
@@ -32,6 +36,9 @@ type ReadRelation struct {
 	RequiredState  string
 }
 
+// ListResult is the plain Work-owned state-access list contract. Peers consume
+// detached ReadModel projections and pagination facts without importing Work
+// implementation packages.
 type ListResult struct {
 	Results    []ReadModel
 	MaxResults int

--- a/pkg/services/work/service/read_test.go
+++ b/pkg/services/work/service/read_test.go
@@ -28,7 +28,7 @@ func queryReadRuntime() *readRuntime {
 }
 
 func TestListWork_FiltersByWorkTypeNameNameSubstringAndTraceId(t *testing.T) {
-	service := workservice.NewService(workRuntimeResolver{runtime: queryReadRuntime()}, nil)
+	service := workservice.NewService(workRuntimeResolver{runtime: queryReadRuntime()}, nil, nil, nil)
 	for _, tc := range []struct {
 		name    string
 		options work.ListOptions
@@ -49,7 +49,7 @@ func TestListWork_FiltersByWorkTypeNameNameSubstringAndTraceId(t *testing.T) {
 }
 
 func TestListWork_FiltersBeforePagination(t *testing.T) {
-	service := workservice.NewService(workRuntimeResolver{runtime: queryReadRuntime()}, nil)
+	service := workservice.NewService(workRuntimeResolver{runtime: queryReadRuntime()}, nil, nil, nil)
 	got, err := service.ListWork(context.Background(), "session-1", work.ListOptions{WorkTypeName: "story", MaxResults: 2})
 	if err != nil || len(got.Results) != 2 || got.NextToken != "" {
 		t.Fatalf("ListWork = %#v, %v", got, err)
@@ -57,7 +57,7 @@ func TestListWork_FiltersBeforePagination(t *testing.T) {
 }
 
 func TestListWork_FiltersByStateNameAndType(t *testing.T) {
-	service := workservice.NewService(workRuntimeResolver{runtime: queryReadRuntime()}, nil)
+	service := workservice.NewService(workRuntimeResolver{runtime: queryReadRuntime()}, nil, nil, nil)
 	got, err := service.ListWork(context.Background(), "session-1", work.ListOptions{StateName: "review", StateType: work.StateTypeProcessing})
 	if err != nil || len(got.Results) != 1 || got.Results[0].WorkID != "work-story" {
 		t.Fatalf("ListWork = %#v, %v", got, err)
@@ -65,7 +65,7 @@ func TestListWork_FiltersByStateNameAndType(t *testing.T) {
 }
 
 func TestListWork_DefaultOrderingSurfacesActiveWorkBeforeTerminalWork(t *testing.T) {
-	service := workservice.NewService(workRuntimeResolver{runtime: queryReadRuntime()}, nil)
+	service := workservice.NewService(workRuntimeResolver{runtime: queryReadRuntime()}, nil, nil, nil)
 	got, err := service.ListWork(context.Background(), "session-1", work.ListOptions{})
 	if err != nil || len(got.Results) != 3 || got.Results[0].WorkID != "work-bug" || got.Results[1].WorkID != "work-story" || got.Results[2].WorkID != "work-plan" {
 		t.Fatalf("ListWork = %#v, %v", got, err)
@@ -73,7 +73,7 @@ func TestListWork_DefaultOrderingSurfacesActiveWorkBeforeTerminalWork(t *testing
 }
 
 func TestListWork_SortsByStateType(t *testing.T) {
-	service := workservice.NewService(workRuntimeResolver{runtime: queryReadRuntime()}, nil)
+	service := workservice.NewService(workRuntimeResolver{runtime: queryReadRuntime()}, nil, nil, nil)
 	got, err := service.ListWork(context.Background(), "session-1", work.ListOptions{SortBy: "state.type"})
 	if err != nil || len(got.Results) != 3 || got.Results[0].State.Type != work.StateTypeInitial || got.Results[2].State.Type != work.StateTypeTerminal {
 		t.Fatalf("ListWork = %#v, %v", got, err)
@@ -81,7 +81,7 @@ func TestListWork_SortsByStateType(t *testing.T) {
 }
 
 func TestListWork_InvalidStateTypeAndSortReturnValidationErrors(t *testing.T) {
-	service := workservice.NewService(workRuntimeResolver{runtime: queryReadRuntime()}, nil)
+	service := workservice.NewService(workRuntimeResolver{runtime: queryReadRuntime()}, nil, nil, nil)
 	for _, options := range []work.ListOptions{{StateType: "BROKEN"}, {SortBy: "broken"}} {
 		_, err := service.ListWork(context.Background(), "session-1", options)
 		var validation *work.ValidationError
@@ -92,7 +92,7 @@ func TestListWork_InvalidStateTypeAndSortReturnValidationErrors(t *testing.T) {
 }
 
 func TestListWork_NonPositiveMaxResultsDefaultsAndNextTokenContinues(t *testing.T) {
-	service := workservice.NewService(workRuntimeResolver{runtime: queryReadRuntime()}, nil)
+	service := workservice.NewService(workRuntimeResolver{runtime: queryReadRuntime()}, nil, nil, nil)
 	first, err := service.ListWork(context.Background(), "session-1", work.ListOptions{MaxResults: 1})
 	if err != nil || len(first.Results) != 1 || first.NextToken == "" {
 		t.Fatalf("first ListWork = %#v, %v", first, err)
@@ -108,7 +108,7 @@ func TestListWork_NonPositiveMaxResultsDefaultsAndNextTokenContinues(t *testing.
 }
 
 func TestGetWork_ByTokenAndWorkIDAndNotFound(t *testing.T) {
-	service := workservice.NewService(workRuntimeResolver{runtime: queryReadRuntime()}, nil)
+	service := workservice.NewService(workRuntimeResolver{runtime: queryReadRuntime()}, nil, nil, nil)
 	for _, id := range []string{"tok-story", "work-story"} {
 		got, err := service.GetWork(context.Background(), "session-1", id)
 		if err != nil || got.WorkID != "work-story" {
@@ -145,7 +145,7 @@ func TestListWorkOwnsSelectionOrderingPaginationAndDetachesResults(t *testing.T)
 		{CursorID: "tok-active-2", WorkID: "work-active-2", Name: "Alpha second", WorkTypeName: "task", State: &work.State{Name: "review", Type: work.StateTypeProcessing}},
 		{CursorID: "tok-active-1", WorkID: "work-active-1", Name: "Alpha first", WorkTypeName: "task", State: &work.State{Name: "review", Type: work.StateTypeProcessing}},
 	}}}
-	service := workservice.NewService(workRuntimeResolver{runtime: runtime}, nil)
+	service := workservice.NewService(workRuntimeResolver{runtime: runtime}, nil, nil, nil)
 	first, err := service.ListWork(context.Background(), "session-1", work.ListOptions{Name: "alpha", MaxResults: 1})
 	if err != nil {
 		t.Fatalf("ListWork: %v", err)
@@ -165,7 +165,7 @@ func TestListWorkOwnsSelectionOrderingPaginationAndDetachesResults(t *testing.T)
 
 func TestGetWorkAndMoveWorkAndReadOwnDetachedReadSemantics(t *testing.T) {
 	runtime := &readRuntime{snapshot: work.ReadSnapshot{Items: []work.ReadModel{{CursorID: "tok-1", WorkID: "work-1", Name: "one", State: &work.State{Name: "review", Type: work.StateTypeProcessing}}}}}
-	service := workservice.NewService(workRuntimeResolver{runtime: runtime}, nil)
+	service := workservice.NewService(workRuntimeResolver{runtime: runtime}, nil, nil, nil)
 	read, err := service.GetWork(context.Background(), "session-1", "work-1")
 	if err != nil || read.CursorID != "tok-1" {
 		t.Fatalf("GetWork = %#v, %v", read, err)

--- a/pkg/services/work/service/service.go
+++ b/pkg/services/work/service/service.go
@@ -3,6 +3,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -157,6 +158,32 @@ func (s *applicationService) MaterializeContentURL(
 		return "", nil, fmt.Errorf("Work content materializer is required")
 	}
 	return s.contentMaterializer.MaterializeContentURL(ctx, rawURL)
+}
+
+func (s *applicationService) PrepareInvocationInput(
+	ctx context.Context,
+	request work.InvocationInputPreparationRequest,
+) (work.PreparedInvocationInput, error) {
+	prepared, err := work.NewInvocationInputPreparation().PrepareInvocationInput(ctx, request)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return work.PreparedInvocationInput{}, err
+		}
+		return work.PreparedInvocationInput{}, fmt.Errorf("%w: %w", work.ErrInvalidInvocationInput, err)
+	}
+	return prepared, nil
+}
+
+func (s *applicationService) ResolvePrimaryResult(
+	ctx context.Context,
+	input work.PrimaryResultSelectionInput,
+) (work.PrimaryResultSelection, error) {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return work.PrimaryResultSelection{}, err
+		}
+	}
+	return work.ResolvePrimaryResult(input)
 }
 
 // SubmitFile reads and submits one canonical Work Request file. It is used for

--- a/pkg/services/work/service/service.go
+++ b/pkg/services/work/service/service.go
@@ -23,8 +23,10 @@ type RuntimeResolver interface {
 }
 
 type applicationService struct {
-	runtimes          work.RuntimeResolver
-	readSubmittedFile work.SubmittedFileReader
+	runtimes            work.RuntimeResolver
+	readSubmittedFile   work.SubmittedFileReader
+	contentStaging      work.ContentStagingService
+	contentMaterializer work.ContentMaterializer
 }
 
 // New constructs the canonical Work application service.
@@ -32,9 +34,21 @@ func New(sessions RuntimeResolver) *Service {
 	return &Service{sessions: sessions}
 }
 
-// NewService constructs the Work root contract for composition.
-func NewService(runtimes work.RuntimeResolver, readSubmittedFile work.SubmittedFileReader) work.FileSubmissionService {
-	return &applicationService{runtimes: runtimes, readSubmittedFile: readSubmittedFile}
+// NewService constructs the Work root contract for composition. Content staging
+// and materialization may be nil when a caller only needs admission/state-access
+// slices; content methods then return a deterministic configuration error.
+func NewService(
+	runtimes work.RuntimeResolver,
+	readSubmittedFile work.SubmittedFileReader,
+	contentStaging work.ContentStagingService,
+	contentMaterializer work.ContentMaterializer,
+) work.FileSubmissionService {
+	return &applicationService{
+		runtimes:            runtimes,
+		readSubmittedFile:   readSubmittedFile,
+		contentStaging:      contentStaging,
+		contentMaterializer: contentMaterializer,
+	}
 }
 
 func (s *applicationService) SubmitFileForSession(
@@ -96,6 +110,53 @@ func (s *applicationService) MoveWorkForSession(
 		work.WorkStateChangeSourceAPI,
 		requestID,
 	)
+}
+
+func (s *applicationService) StageContent(
+	ctx context.Context,
+	request work.StageContentRequest,
+) (work.StageContentResult, error) {
+	if s == nil || s.contentStaging == nil {
+		return work.StageContentResult{}, fmt.Errorf("Work content staging is required")
+	}
+	return s.contentStaging.StageContent(ctx, request)
+}
+
+func (s *applicationService) PrepareContent(
+	ctx context.Context,
+	items []work.StagedSubmissionItem,
+) ([]work.WorkContentPart, error) {
+	if s == nil || s.contentStaging == nil {
+		return nil, fmt.Errorf("Work content staging is required")
+	}
+	return s.contentStaging.PrepareContent(ctx, items)
+}
+
+func (s *applicationService) ResolveContent(
+	ctx context.Context,
+	ref string,
+) (work.ResolvedStagedContent, error) {
+	if s == nil || s.contentStaging == nil {
+		return work.ResolvedStagedContent{}, fmt.Errorf("Work content staging is required")
+	}
+	return s.contentStaging.ResolveContent(ctx, ref)
+}
+
+func (s *applicationService) CleanupContent(ctx context.Context, ref string) error {
+	if s == nil || s.contentStaging == nil {
+		return fmt.Errorf("Work content staging is required")
+	}
+	return s.contentStaging.CleanupContent(ctx, ref)
+}
+
+func (s *applicationService) MaterializeContentURL(
+	ctx context.Context,
+	rawURL string,
+) (string, work.ContentCleanup, error) {
+	if s == nil || s.contentMaterializer == nil {
+		return "", nil, fmt.Errorf("Work content materializer is required")
+	}
+	return s.contentMaterializer.MaterializeContentURL(ctx, rawURL)
 }
 
 // SubmitFile reads and submits one canonical Work Request file. It is used for

--- a/pkg/services/work/service/service_test.go
+++ b/pkg/services/work/service/service_test.go
@@ -154,3 +154,42 @@ func TestSubmitFileReportsReadParseAndRuntimeFailures(t *testing.T) {
 		}
 	})
 }
+
+func TestNewServiceExposesInvocationAndReturnPolicySlice(t *testing.T) {
+	service := workservice.NewService(workRuntimeResolver{runtime: &recordingFactory{}}, os.ReadFile, nil, nil)
+	ctx := context.Background()
+
+	stdin := "from service root"
+	prepared, err := service.PrepareInvocationInput(ctx, work.InvocationInputPreparationRequest{
+		Arguments: []string{"-"},
+		StdinText: &stdin,
+	})
+	if err != nil {
+		t.Fatalf("PrepareInvocationInput: %v", err)
+	}
+	if prepared.ResolvedInput == nil || prepared.ResolvedInput.Text != stdin {
+		t.Fatalf("prepared = %#v, want stdin text", prepared)
+	}
+
+	_, err = service.PrepareInvocationInput(ctx, work.InvocationInputPreparationRequest{
+		Arguments: []string{""},
+	})
+	if !errors.Is(err, work.ErrInvalidInvocationInput) {
+		t.Fatalf("PrepareInvocationInput error = %v, want ErrInvalidInvocationInput", err)
+	}
+
+	_, err = service.ResolvePrimaryResult(ctx, work.PrimaryResultSelectionInput{
+		RequestID: "request-1",
+		InvocationReturn: &work.InvocationReturnConfig{
+			Policy: "NOT_A_POLICY",
+		},
+		WorldState: work.InvocationWorldState{
+			WorkRequestsByID: map[string]work.InvocationWorkRequest{
+				"request-1": {WorkItems: []work.FactoryWorkItem{{ID: "work-1"}}},
+			},
+		},
+	})
+	if !errors.Is(err, work.ErrUnsupportedReturnPolicy) {
+		t.Fatalf("ResolvePrimaryResult error = %v, want ErrUnsupportedReturnPolicy", err)
+	}
+}

--- a/pkg/services/work/service/service_test.go
+++ b/pkg/services/work/service/service_test.go
@@ -30,7 +30,7 @@ func (r workRuntimeResolver) ResolveWorkRuntime(string) (work.Runtime, error) {
 
 func TestNewServiceRoutesThroughWorkRootRuntimeContract(t *testing.T) {
 	runtime := &recordingFactory{}
-	service := workservice.NewService(workRuntimeResolver{runtime: runtime}, os.ReadFile)
+	service := workservice.NewService(workRuntimeResolver{runtime: runtime}, os.ReadFile, nil, nil)
 
 	request := work.WorkRequest{RequestID: "request-root-contract"}
 	if _, err := service.SubmitWorkRequestForSession(
@@ -76,7 +76,7 @@ func (f *recordingFactory) ReadWorkSnapshot(context.Context) (work.ReadSnapshot,
 }
 
 func TestNewServicePropagatesRuntimeResolverError(t *testing.T) {
-	service := workservice.NewService(workRuntimeResolver{err: factorysessions.ErrSessionNotFound}, os.ReadFile)
+	service := workservice.NewService(workRuntimeResolver{err: factorysessions.ErrSessionNotFound}, os.ReadFile, nil, nil)
 	_, err := service.SubmitWorkRequestForSession(context.Background(), "missing", work.WorkRequest{})
 	if !errors.Is(err, factorysessions.ErrSessionNotFound) {
 		t.Fatalf("error = %v, want ErrSessionNotFound", err)
@@ -108,7 +108,7 @@ func TestSubmitFileForSessionUsesInjectedReaderAndRuntime(t *testing.T) {
 	service := workservice.NewService(workRuntimeResolver{runtime: runtime}, func(path string) ([]byte, error) {
 		readPath = path
 		return []byte(`{"requestId":"request-edge","type":"FACTORY_REQUEST_BATCH","works":[]}`), nil
-	})
+	}, nil, nil)
 
 	result, err := service.SubmitFileForSession(context.Background(), "session-1", "edge.json")
 	if err != nil {

--- a/pkg/services/work/service/service_test.go
+++ b/pkg/services/work/service/service_test.go
@@ -237,18 +237,13 @@ func (s *recordingContentStaging) CleanupContent(_ context.Context, ref string) 
 	return nil
 }
 
-func TestNewServiceDelegatesContentStagingAndMaterializationSlice(t *testing.T) {
+func TestNewServiceDelegatesContentStagingSlice(t *testing.T) {
 	staging := &recordingContentStaging{}
-	materialized := ""
-	materializer := work.ContentMaterializeFunc(func(_ context.Context, rawURL string) (string, work.ContentCleanup, error) {
-		materialized = rawURL
-		return "/tmp/materialized/svc.png", func() {}, nil
-	})
 	service := workservice.NewService(
 		workRuntimeResolver{runtime: &recordingFactory{}},
 		os.ReadFile,
 		staging,
-		materializer,
+		nil,
 	)
 	ctx := context.Background()
 
@@ -277,6 +272,21 @@ func TestNewServiceDelegatesContentStagingAndMaterializationSlice(t *testing.T) 
 	if err := service.CleanupContent(ctx, staged.StagedFileRef); err != nil || staging.cleanupRef != staged.StagedFileRef {
 		t.Fatalf("CleanupContent = (%v, %q)", err, staging.cleanupRef)
 	}
+}
+
+func TestNewServiceDelegatesContentMaterializationSlice(t *testing.T) {
+	materialized := ""
+	materializer := work.ContentMaterializeFunc(func(_ context.Context, rawURL string) (string, work.ContentCleanup, error) {
+		materialized = rawURL
+		return "/tmp/materialized/svc.png", func() {}, nil
+	})
+	service := workservice.NewService(
+		workRuntimeResolver{runtime: &recordingFactory{}},
+		os.ReadFile,
+		nil,
+		materializer,
+	)
+	ctx := context.Background()
 
 	path, cleanup, err := service.MaterializeContentURL(ctx, "file:///fixtures/svc.png")
 	if err != nil || path == "" || cleanup == nil || materialized != "file:///fixtures/svc.png" {

--- a/pkg/services/work/service/service_test.go
+++ b/pkg/services/work/service/service_test.go
@@ -193,3 +193,115 @@ func TestNewServiceExposesInvocationAndReturnPolicySlice(t *testing.T) {
 		t.Fatalf("ResolvePrimaryResult error = %v, want ErrUnsupportedReturnPolicy", err)
 	}
 }
+
+type recordingContentStaging struct {
+	stageReq   work.StageContentRequest
+	prepareIn  []work.StagedSubmissionItem
+	resolveRef string
+	cleanupRef string
+}
+
+func (s *recordingContentStaging) StageContent(
+	_ context.Context,
+	request work.StageContentRequest,
+) (work.StageContentResult, error) {
+	s.stageReq = request
+	return work.StageContentResult{
+		StagedFileRef: "submit-work-stage:v1:svc",
+		FileName:      request.FileName,
+		MediaType:     request.MediaType,
+		URL:           "file:///tmp/svc.png",
+	}, nil
+}
+
+func (s *recordingContentStaging) PrepareContent(
+	_ context.Context,
+	items []work.StagedSubmissionItem,
+) ([]work.WorkContentPart, error) {
+	s.prepareIn = items
+	return []work.WorkContentPart{{
+		Type: work.WorkContentPartTypeImage, URL: "file:///tmp/svc.png", ContentType: "image/png",
+	}}, nil
+}
+
+func (s *recordingContentStaging) ResolveContent(
+	_ context.Context,
+	ref string,
+) (work.ResolvedStagedContent, error) {
+	s.resolveRef = ref
+	return work.ResolvedStagedContent{Path: "/tmp/svc.png", URL: "file:///tmp/svc.png"}, nil
+}
+
+func (s *recordingContentStaging) CleanupContent(_ context.Context, ref string) error {
+	s.cleanupRef = ref
+	return nil
+}
+
+func TestNewServiceDelegatesContentStagingAndMaterializationSlice(t *testing.T) {
+	staging := &recordingContentStaging{}
+	materialized := ""
+	materializer := work.ContentMaterializeFunc(func(_ context.Context, rawURL string) (string, work.ContentCleanup, error) {
+		materialized = rawURL
+		return "/tmp/materialized/svc.png", func() {}, nil
+	})
+	service := workservice.NewService(
+		workRuntimeResolver{runtime: &recordingFactory{}},
+		os.ReadFile,
+		staging,
+		materializer,
+	)
+	ctx := context.Background()
+
+	staged, err := service.StageContent(ctx, work.StageContentRequest{
+		ItemType: "image", FileName: "svc.png", MediaType: "image/png", Content: []byte("png"),
+	})
+	if err != nil {
+		t.Fatalf("StageContent: %v", err)
+	}
+	if staged.StagedFileRef != "submit-work-stage:v1:svc" || staging.stageReq.FileName != "svc.png" {
+		t.Fatalf("stage = (%#v, %#v)", staged, staging.stageReq)
+	}
+
+	parts, err := service.PrepareContent(ctx, []work.StagedSubmissionItem{{
+		ItemType: "image", StagedFileRef: staged.StagedFileRef, FileName: staged.FileName, MediaType: staged.MediaType,
+	}})
+	if err != nil || len(parts) != 1 || staging.prepareIn[0].StagedFileRef != staged.StagedFileRef {
+		t.Fatalf("PrepareContent = (%#v, %v, %#v)", parts, err, staging.prepareIn)
+	}
+
+	resolved, err := service.ResolveContent(ctx, staged.StagedFileRef)
+	if err != nil || resolved.Path == "" || staging.resolveRef != staged.StagedFileRef {
+		t.Fatalf("ResolveContent = (%#v, %v, %q)", resolved, err, staging.resolveRef)
+	}
+
+	if err := service.CleanupContent(ctx, staged.StagedFileRef); err != nil || staging.cleanupRef != staged.StagedFileRef {
+		t.Fatalf("CleanupContent = (%v, %q)", err, staging.cleanupRef)
+	}
+
+	path, cleanup, err := service.MaterializeContentURL(ctx, "file:///fixtures/svc.png")
+	if err != nil || path == "" || cleanup == nil || materialized != "file:///fixtures/svc.png" {
+		t.Fatalf("MaterializeContentURL = (%q, %v, %v, %q)", path, cleanup, err, materialized)
+	}
+	cleanup()
+}
+
+func TestNewServiceContentSliceRequiresInjectedDependencies(t *testing.T) {
+	service := workservice.NewService(workRuntimeResolver{runtime: &recordingFactory{}}, os.ReadFile, nil, nil)
+	ctx := context.Background()
+
+	if _, err := service.StageContent(ctx, work.StageContentRequest{}); err == nil || !strings.Contains(err.Error(), "content staging is required") {
+		t.Fatalf("StageContent error = %v, want staging required", err)
+	}
+	if _, err := service.PrepareContent(ctx, nil); err == nil || !strings.Contains(err.Error(), "content staging is required") {
+		t.Fatalf("PrepareContent error = %v, want staging required", err)
+	}
+	if _, err := service.ResolveContent(ctx, "ref"); err == nil || !strings.Contains(err.Error(), "content staging is required") {
+		t.Fatalf("ResolveContent error = %v, want staging required", err)
+	}
+	if err := service.CleanupContent(ctx, "ref"); err == nil || !strings.Contains(err.Error(), "content staging is required") {
+		t.Fatalf("CleanupContent error = %v, want staging required", err)
+	}
+	if _, _, err := service.MaterializeContentURL(ctx, "file:///x"); err == nil || !strings.Contains(err.Error(), "content materializer is required") {
+		t.Fatalf("MaterializeContentURL error = %v, want materializer required", err)
+	}
+}

--- a/pkg/services/work/service_contract.go
+++ b/pkg/services/work/service_contract.go
@@ -32,8 +32,11 @@ type RequestIDGenerator func() string
 // Filesystem policy is selected at the process edge rather than by Work.
 type SubmittedFileReader func(string) ([]byte, error)
 
-// Service is the public Work submission and movement contract. Runtime state
-// and event queries belong to Factory Runtime and Recordings.
+// Service is the singular Work root contract for cross-service peers.
+// Published slices (admission, content staging/materialization, state access,
+// and invocation/return policy) are additive methods on this interface and use
+// plain Work-owned request, result, value, and typed-error contracts.
+// Runtime state and event queries belong to Factory Runtime and Recordings.
 type Service interface {
 	SubmitWorkRequestForSession(context.Context, string, WorkRequest) (WorkRequestSubmitResult, error)
 	MoveWorkForSession(context.Context, string, string, string, string) (OperatorMoveResult, error)
@@ -43,7 +46,8 @@ type Service interface {
 }
 
 // FileSubmissionService is the exact Work role for path-backed submission.
-// General Work consumers should depend on Service unless they submit files.
+// Path decoding stays adapter-owned; peers that need only the domain root
+// should depend on Service rather than this file-submission role.
 type FileSubmissionService interface {
 	Service
 	SubmitFileForSession(context.Context, string, string) (WorkRequestSubmitResult, error)

--- a/pkg/services/work/service_contract.go
+++ b/pkg/services/work/service_contract.go
@@ -38,6 +38,12 @@ type SubmittedFileReader func(string) ([]byte, error)
 // plain Work-owned request, result, value, and typed-error contracts.
 // Runtime state and event queries belong to Factory Runtime and Recordings.
 type Service interface {
+	// SubmitWorkRequestForSession is the published admission slice. Peers submit
+	// an already-decoded WorkRequest covering request identity and payload, and
+	// receive detached WorkRequestSubmitResult acceptance facts or a typed
+	// admission failure (ErrInvalidWorkRequest, ErrWorkRequestConflict, or
+	// ErrWorkRequestRejected). Path-backed or protocol decoding is not part of
+	// this root domain seam; see FileSubmissionService for file adapters.
 	SubmitWorkRequestForSession(context.Context, string, WorkRequest) (WorkRequestSubmitResult, error)
 	MoveWorkForSession(context.Context, string, string, string, string) (OperatorMoveResult, error)
 	ListWork(context.Context, string, ListOptions) (ListResult, error)

--- a/pkg/services/work/service_contract.go
+++ b/pkg/services/work/service_contract.go
@@ -49,6 +49,27 @@ type Service interface {
 	ListWork(context.Context, string, ListOptions) (ListResult, error)
 	GetWork(context.Context, string, string) (ReadModel, error)
 	MoveWorkAndRead(context.Context, string, string, string, string) (ReadModel, error)
+
+	// StageContent is part of the published content staging slice. Peers stage
+	// already-decoded content bytes through plain StageContentRequest and receive
+	// an opaque StageContentResult reference without supplying filesystem effect
+	// interfaces on the request shape.
+	StageContent(context.Context, StageContentRequest) (StageContentResult, error)
+	// PrepareContent resolves staged submission items into detached Work content
+	// parts peers can attach to admission requests.
+	PrepareContent(context.Context, []StagedSubmissionItem) ([]WorkContentPart, error)
+	// ResolveContent resolves an opaque staged reference to a local path and URL,
+	// or returns a typed staging failure such as ErrInvalidStagedContentRef or
+	// ErrStagedContentExpired.
+	ResolveContent(context.Context, string) (ResolvedStagedContent, error)
+	// CleanupContent releases resources owned by an opaque staged reference.
+	CleanupContent(context.Context, string) error
+	// MaterializeContentURL is the published content materialization slice. Peers
+	// supply a content URL and receive an immutable local path plus ContentCleanup
+	// handle, or a typed materialization failure such as ErrUnsafeContentURL or
+	// ErrContentURLInaccessible. Callers do not supply HTTP or filesystem effect
+	// interfaces on the request shape.
+	MaterializeContentURL(context.Context, string) (string, ContentCleanup, error)
 }
 
 // FileSubmissionService is the exact Work role for path-backed submission.

--- a/pkg/services/work/service_contract.go
+++ b/pkg/services/work/service_contract.go
@@ -36,6 +36,10 @@ type SubmittedFileReader func(string) ([]byte, error)
 // Published slices (admission, content staging/materialization, state access,
 // and invocation/return policy) are additive methods on this interface and use
 // plain Work-owned request, result, value, and typed-error contracts.
+// These published slices are the sealed IMP-WORK unlock surface: peers depend
+// on this one root rather than Work implementation packages. Nested IMP-WORK
+// subservice moves, Wire/CLI-manifest/provider-conductor ownership changes, and
+// OpenAPI package-motion edits remain out of scope for the root-contract packet.
 // Runtime state and event queries belong to Factory Runtime and Recordings.
 type Service interface {
 	// SubmitWorkRequestForSession is the published admission slice. Peers submit

--- a/pkg/services/work/service_contract.go
+++ b/pkg/services/work/service_contract.go
@@ -84,6 +84,20 @@ type Service interface {
 	// ErrContentURLInaccessible. Callers do not supply HTTP or filesystem effect
 	// interfaces on the request shape.
 	MaterializeContentURL(context.Context, string) (string, ContentCleanup, error)
+
+	// PrepareInvocationInput is part of the published invocation/return-policy
+	// slice. Peers supply already-collected edge values through plain
+	// InvocationInputPreparationRequest and receive detached PreparedInvocationInput,
+	// or a typed failure such as ErrInvalidInvocationInput (including structured
+	// *InputError values). Peers are not required to construct a separate
+	// InvocationInputPreparation helper for this published slice.
+	PrepareInvocationInput(context.Context, InvocationInputPreparationRequest) (PreparedInvocationInput, error)
+	// ResolvePrimaryResult is part of the published invocation/return-policy
+	// slice. Peers supply PrimaryResultSelectionInput (request identity, authored
+	// return policy, and Work-owned world-state projection) and receive detached
+	// PrimaryResultSelection for SUBMITTED_WORK_TERMINAL and EXPLICIT policies, or
+	// a typed failure such as ErrUnsupportedReturnPolicy or *PrimaryResultError.
+	ResolvePrimaryResult(context.Context, PrimaryResultSelectionInput) (PrimaryResultSelection, error)
 }
 
 // FileSubmissionService is the exact Work role for path-backed submission.

--- a/pkg/services/work/service_contract.go
+++ b/pkg/services/work/service_contract.go
@@ -45,9 +45,23 @@ type Service interface {
 	// ErrWorkRequestRejected). Path-backed or protocol decoding is not part of
 	// this root domain seam; see FileSubmissionService for file adapters.
 	SubmitWorkRequestForSession(context.Context, string, WorkRequest) (WorkRequestSubmitResult, error)
+
+	// MoveWorkForSession is part of the published state-access slice. Peers apply
+	// an operator move with Work identity, target state name, and requestId, and
+	// receive the detached OperatorMoveResult success shape or a typed failure
+	// such as ErrMoveWorkRequestAlreadyApplied.
 	MoveWorkForSession(context.Context, string, string, string, string) (OperatorMoveResult, error)
+	// ListWork is part of the published state-access slice. Peers supply plain
+	// ListOptions and receive detached ListResult ReadModel projections with no
+	// token, place, marking, or topology fields.
 	ListWork(context.Context, string, ListOptions) (ListResult, error)
+	// GetWork is part of the published state-access slice. Peers look up one Work
+	// by id and receive a detached ReadModel, or ErrWorkNotFound when missing.
 	GetWork(context.Context, string, string) (ReadModel, error)
+	// MoveWorkAndRead is the combined state-access outcome peers already rely on:
+	// apply an operator move, then return the detached post-move ReadModel (or a
+	// typed state-access failure such as ErrWorkNotFound or
+	// ErrMoveWorkRequestAlreadyApplied).
 	MoveWorkAndRead(context.Context, string, string, string, string) (ReadModel, error)
 
 	// StageContent is part of the published content staging slice. Peers stage

--- a/pkg/services/work/service_root_contract_seal_test.go
+++ b/pkg/services/work/service_root_contract_seal_test.go
@@ -1,0 +1,374 @@
+package work_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/work"
+)
+
+// peerWorkRootConsumer is a peer-shaped characterization consumer (Factory
+// Sessions / Workers style) that depends only on the Work root package contract
+// surface. It must not import work/service, work/materialize, Factory Runtime,
+// Petri, or other peer implementation packages to call or assert published
+// slices.
+type peerWorkRootConsumer struct {
+	root work.Service
+}
+
+func (c peerWorkRootConsumer) admit(
+	ctx context.Context,
+	sessionID string,
+	request work.WorkRequest,
+) (work.WorkRequestSubmitResult, error) {
+	return c.root.SubmitWorkRequestForSession(ctx, sessionID, request)
+}
+
+func (c peerWorkRootConsumer) stageAndMaterialize(
+	ctx context.Context,
+	stage work.StageContentRequest,
+	contentURL string,
+) (work.StageContentResult, string, work.ContentCleanup, error) {
+	staged, err := c.root.StageContent(ctx, stage)
+	if err != nil {
+		return work.StageContentResult{}, "", nil, err
+	}
+	if _, err := c.root.PrepareContent(ctx, []work.StagedSubmissionItem{{
+		ItemType:      stage.ItemType,
+		StagedFileRef: staged.StagedFileRef,
+		FileName:      staged.FileName,
+		MediaType:     staged.MediaType,
+	}}); err != nil {
+		return work.StageContentResult{}, "", nil, err
+	}
+	if _, err := c.root.ResolveContent(ctx, staged.StagedFileRef); err != nil {
+		return work.StageContentResult{}, "", nil, err
+	}
+	if err := c.root.CleanupContent(ctx, staged.StagedFileRef); err != nil {
+		return work.StageContentResult{}, "", nil, err
+	}
+	path, cleanup, err := c.root.MaterializeContentURL(ctx, contentURL)
+	return staged, path, cleanup, err
+}
+
+func (c peerWorkRootConsumer) inspectAndMove(
+	ctx context.Context,
+	sessionID string,
+	workID string,
+	listOpts work.ListOptions,
+	toState string,
+	requestID string,
+) (work.ListResult, work.ReadModel, work.OperatorMoveResult, work.ReadModel, error) {
+	listed, err := c.root.ListWork(ctx, sessionID, listOpts)
+	if err != nil {
+		return work.ListResult{}, work.ReadModel{}, work.OperatorMoveResult{}, work.ReadModel{}, err
+	}
+	got, err := c.root.GetWork(ctx, sessionID, workID)
+	if err != nil {
+		return work.ListResult{}, work.ReadModel{}, work.OperatorMoveResult{}, work.ReadModel{}, err
+	}
+	moved, err := c.root.MoveWorkForSession(ctx, sessionID, workID, toState, requestID)
+	if err != nil {
+		return work.ListResult{}, work.ReadModel{}, work.OperatorMoveResult{}, work.ReadModel{}, err
+	}
+	readAfter, err := c.root.MoveWorkAndRead(ctx, sessionID, workID, toState, requestID+"-read")
+	return listed, got, moved, readAfter, err
+}
+
+func (c peerWorkRootConsumer) prepareAndSelectPrimary(
+	ctx context.Context,
+	prepare work.InvocationInputPreparationRequest,
+	selectInput work.PrimaryResultSelectionInput,
+) (work.PreparedInvocationInput, work.PrimaryResultSelection, error) {
+	prepared, err := c.root.PrepareInvocationInput(ctx, prepare)
+	if err != nil {
+		return work.PreparedInvocationInput{}, work.PrimaryResultSelection{}, err
+	}
+	selected, err := c.root.ResolvePrimaryResult(ctx, selectInput)
+	return prepared, selected, err
+}
+
+func TestServiceRootContract_SealAllPublishedSlicesThroughSingularService(t *testing.T) {
+	stdin := "peer seal stdin"
+	fake := &rootServiceFake{
+		submitResult: work.WorkRequestSubmitResult{
+			RequestID: "seal-request-1",
+			TraceID:   "seal-trace-1",
+			Accepted:  true,
+			Works: []work.WorkRequestSubmittedWork{{
+				Name:         "seal-work",
+				WorkTypeName: "story",
+				WorkID:       "seal-work-1",
+			}},
+		},
+		stageResult: work.StageContentResult{
+			StagedFileRef: "submit-work-stage:v1:seal-ref",
+			FileName:      "seal.png",
+			MediaType:     "image/png",
+			URL:           "file:///tmp/seal.png",
+		},
+		prepareResult: []work.WorkContentPart{{
+			Type:        work.WorkContentPartTypeImage,
+			URL:         "file:///tmp/seal.png",
+			ContentType: "image/png",
+		}},
+		resolveResult: work.ResolvedStagedContent{
+			Path: "/tmp/seal.png",
+			URL:  "file:///tmp/seal.png",
+		},
+		materializePath: "/tmp/materialized/seal.png",
+		listResult: work.ListResult{
+			Results: []work.ReadModel{{
+				CursorID:     "seal-work-1",
+				Name:         "seal-work",
+				WorkID:       "seal-work-1",
+				WorkTypeName: "story",
+				State:        &work.State{Name: "review", Type: work.StateTypeProcessing},
+			}},
+			MaxResults: work.DefaultListMaxResults,
+		},
+		getResult: work.ReadModel{
+			CursorID:     "seal-work-1",
+			Name:         "seal-work",
+			WorkID:       "seal-work-1",
+			WorkTypeName: "story",
+			State:        &work.State{Name: "review", Type: work.StateTypeProcessing},
+		},
+		moveResult: work.OperatorMoveResult{
+			WorkID:    "seal-work-1",
+			FromState: "draft",
+			ToState:   "done",
+		},
+		movedRead: work.ReadModel{
+			CursorID:     "seal-work-1",
+			Name:         "seal-work",
+			WorkID:       "seal-work-1",
+			WorkTypeName: "story",
+			State:        &work.State{Name: "done", Type: work.StateTypeTerminal},
+		},
+		prepareInvocationResult: work.PreparedInvocationInput{
+			Source: work.InputSourceStdinText,
+			ResolvedInput: &work.ResolvedInput{
+				Source: work.InputSourceStdinText,
+				Text:   stdin,
+			},
+		},
+		primaryResult: work.PrimaryResultSelection{
+			RequestID:     "seal-request-1",
+			Policy:        work.ReturnPolicySubmittedWorkTerminal,
+			WorkID:        "seal-work-1",
+			WorkTypeName:  "story",
+			WorkName:      "seal-work",
+			TerminalState: "story:done",
+			PrimaryResult: []work.WorkContentPart{{
+				Type: work.WorkContentPartTypeText,
+				Text: "sealed primary",
+			}},
+		},
+	}
+
+	// Singular root seam: one Service value for every published slice.
+	var root work.Service = fake
+	peer := peerWorkRootConsumer{root: root}
+	ctx := context.Background()
+
+	admitted, err := peer.admit(ctx, "session-seal", work.WorkRequest{
+		RequestID: "seal-request-1",
+		Type:      work.WorkRequestTypeFactoryRequestBatch,
+		Works: []work.Work{{
+			Name:       "seal-work",
+			WorkTypeID: "story",
+			State:      "draft",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("admission slice: %v", err)
+	}
+	if !admitted.Accepted || admitted.RequestID != "seal-request-1" {
+		t.Fatalf("admission result = %#v, want accepted seal-request-1", admitted)
+	}
+
+	staged, localPath, cleanup, err := peer.stageAndMaterialize(
+		ctx,
+		work.StageContentRequest{
+			ItemType:  "image",
+			FileName:  "seal.png",
+			MediaType: "image/png",
+			Content:   []byte("png"),
+		},
+		"file:///fixtures/seal.png",
+	)
+	if err != nil {
+		t.Fatalf("content slice: %v", err)
+	}
+	if staged.StagedFileRef == "" || localPath == "" || cleanup == nil {
+		t.Fatalf("content outcomes = (%#v, %q, %v)", staged, localPath, cleanup)
+	}
+	cleanup()
+
+	listed, got, moved, readAfter, err := peer.inspectAndMove(
+		ctx,
+		"session-seal",
+		"seal-work-1",
+		work.ListOptions{WorkTypeName: "story"},
+		"done",
+		"seal-move-1",
+	)
+	if err != nil {
+		t.Fatalf("state-access slice: %v", err)
+	}
+	if len(listed.Results) != 1 || got.WorkID != "seal-work-1" {
+		t.Fatalf("state-access list/get = (%#v, %#v)", listed, got)
+	}
+	if moved.ToState != "done" || readAfter.State == nil || readAfter.State.Type != work.StateTypeTerminal {
+		t.Fatalf("state-access move = (%#v, %#v)", moved, readAfter)
+	}
+
+	prepared, primary, err := peer.prepareAndSelectPrimary(
+		ctx,
+		work.InvocationInputPreparationRequest{
+			Arguments: []string{"-"},
+			StdinText: &stdin,
+		},
+		work.PrimaryResultSelectionInput{
+			RequestID: "seal-request-1",
+			InvocationReturn: &work.InvocationReturnConfig{
+				Policy: work.ReturnPolicySubmittedWorkTerminal,
+			},
+			WorldState: work.InvocationWorldState{},
+		},
+	)
+	if err != nil {
+		t.Fatalf("invocation/return-policy slice: %v", err)
+	}
+	if prepared.ResolvedInput == nil || prepared.ResolvedInput.Text != stdin {
+		t.Fatalf("prepared input = %#v, want sealed stdin", prepared)
+	}
+	if primary.Policy != work.ReturnPolicySubmittedWorkTerminal || len(primary.PrimaryResult) != 1 {
+		t.Fatalf("primary result = %#v, want submitted-terminal content", primary)
+	}
+}
+
+func TestServiceRootContract_SealTypedFailuresPerPublishedSlice(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name string
+		want error
+		call func(peerWorkRootConsumer) error
+	}{
+		{
+			name: "admission invalid",
+			want: work.ErrInvalidWorkRequest,
+			call: func(peer peerWorkRootConsumer) error {
+				_, err := peer.admit(ctx, "session-seal", work.WorkRequest{RequestID: "bad"})
+				return err
+			},
+		},
+		{
+			name: "admission conflict",
+			want: work.ErrWorkRequestConflict,
+			call: func(peer peerWorkRootConsumer) error {
+				_, err := peer.admit(ctx, "session-seal", work.WorkRequest{RequestID: "dup"})
+				return err
+			},
+		},
+		{
+			name: "admission rejected",
+			want: work.ErrWorkRequestRejected,
+			call: func(peer peerWorkRootConsumer) error {
+				_, err := peer.admit(ctx, "session-seal", work.WorkRequest{RequestID: "rejected"})
+				return err
+			},
+		},
+		{
+			name: "content invalid staged ref",
+			want: work.ErrInvalidStagedContentRef,
+			call: func(peer peerWorkRootConsumer) error {
+				_, err := peer.root.ResolveContent(ctx, "not-a-ref")
+				return err
+			},
+		},
+		{
+			name: "content expired staged ref",
+			want: work.ErrStagedContentExpired,
+			call: func(peer peerWorkRootConsumer) error {
+				_, err := peer.root.ResolveContent(ctx, "submit-work-stage:v1:expired")
+				return err
+			},
+		},
+		{
+			name: "content unsafe URL",
+			want: work.ErrUnsafeContentURL,
+			call: func(peer peerWorkRootConsumer) error {
+				_, _, err := peer.root.MaterializeContentURL(ctx, "http://127.0.0.1/secret")
+				return err
+			},
+		},
+		{
+			name: "content inaccessible URL",
+			want: work.ErrContentURLInaccessible,
+			call: func(peer peerWorkRootConsumer) error {
+				_, _, err := peer.root.MaterializeContentURL(ctx, "https://example.invalid/missing")
+				return err
+			},
+		},
+		{
+			name: "state-access missing work",
+			want: work.ErrWorkNotFound,
+			call: func(peer peerWorkRootConsumer) error {
+				_, err := peer.root.GetWork(ctx, "session-seal", "missing")
+				return err
+			},
+		},
+		{
+			name: "state-access already-applied move",
+			want: work.ErrMoveWorkRequestAlreadyApplied,
+			call: func(peer peerWorkRootConsumer) error {
+				_, err := peer.root.MoveWorkForSession(ctx, "session-seal", "work-1", "done", "dup")
+				return err
+			},
+		},
+		{
+			name: "invocation invalid input",
+			want: work.ErrInvalidInvocationInput,
+			call: func(peer peerWorkRootConsumer) error {
+				_, err := peer.root.PrepareInvocationInput(ctx, work.InvocationInputPreparationRequest{
+					Arguments: []string{""},
+				})
+				return err
+			},
+		},
+		{
+			name: "return-policy unsupported",
+			want: work.ErrUnsupportedReturnPolicy,
+			call: func(peer peerWorkRootConsumer) error {
+				_, err := peer.root.ResolvePrimaryResult(ctx, work.PrimaryResultSelectionInput{
+					RequestID: "bad-policy",
+					InvocationReturn: &work.InvocationReturnConfig{
+						Policy: "NOT_A_POLICY",
+					},
+				})
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &rootServiceFake{
+				submitErr:            tc.want,
+				resolveErr:           tc.want,
+				materializeErr:       tc.want,
+				getErr:               tc.want,
+				moveErr:              tc.want,
+				prepareInvocationErr: tc.want,
+				primaryResultErr:     tc.want,
+			}
+			peer := peerWorkRootConsumer{root: fake}
+			if err := tc.call(peer); !errors.Is(err, tc.want) {
+				t.Fatalf("error = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/services/work/service_root_contract_seal_test.go
+++ b/pkg/services/work/service_root_contract_seal_test.go
@@ -89,17 +89,14 @@ func (c peerWorkRootConsumer) prepareAndSelectPrimary(
 	return prepared, selected, err
 }
 
-func TestServiceRootContract_SealAllPublishedSlicesThroughSingularService(t *testing.T) {
-	stdin := "peer seal stdin"
-	fake := &rootServiceFake{
+func newSealRootServiceFake(stdin string) *rootServiceFake {
+	return &rootServiceFake{
 		submitResult: work.WorkRequestSubmitResult{
 			RequestID: "seal-request-1",
 			TraceID:   "seal-trace-1",
 			Accepted:  true,
 			Works: []work.WorkRequestSubmittedWork{{
-				Name:         "seal-work",
-				WorkTypeName: "story",
-				WorkID:       "seal-work-1",
+				Name: "seal-work", WorkTypeName: "story", WorkID: "seal-work-1",
 			}},
 		},
 		stageResult: work.StageContentResult{
@@ -109,78 +106,49 @@ func TestServiceRootContract_SealAllPublishedSlicesThroughSingularService(t *tes
 			URL:           "file:///tmp/seal.png",
 		},
 		prepareResult: []work.WorkContentPart{{
-			Type:        work.WorkContentPartTypeImage,
-			URL:         "file:///tmp/seal.png",
-			ContentType: "image/png",
+			Type: work.WorkContentPartTypeImage, URL: "file:///tmp/seal.png", ContentType: "image/png",
 		}},
-		resolveResult: work.ResolvedStagedContent{
-			Path: "/tmp/seal.png",
-			URL:  "file:///tmp/seal.png",
-		},
+		resolveResult:   work.ResolvedStagedContent{Path: "/tmp/seal.png", URL: "file:///tmp/seal.png"},
 		materializePath: "/tmp/materialized/seal.png",
 		listResult: work.ListResult{
 			Results: []work.ReadModel{{
-				CursorID:     "seal-work-1",
-				Name:         "seal-work",
-				WorkID:       "seal-work-1",
-				WorkTypeName: "story",
-				State:        &work.State{Name: "review", Type: work.StateTypeProcessing},
+				CursorID: "seal-work-1", Name: "seal-work", WorkID: "seal-work-1",
+				WorkTypeName: "story", State: &work.State{Name: "review", Type: work.StateTypeProcessing},
 			}},
 			MaxResults: work.DefaultListMaxResults,
 		},
 		getResult: work.ReadModel{
-			CursorID:     "seal-work-1",
-			Name:         "seal-work",
-			WorkID:       "seal-work-1",
-			WorkTypeName: "story",
-			State:        &work.State{Name: "review", Type: work.StateTypeProcessing},
+			CursorID: "seal-work-1", Name: "seal-work", WorkID: "seal-work-1",
+			WorkTypeName: "story", State: &work.State{Name: "review", Type: work.StateTypeProcessing},
 		},
-		moveResult: work.OperatorMoveResult{
-			WorkID:    "seal-work-1",
-			FromState: "draft",
-			ToState:   "done",
-		},
+		moveResult: work.OperatorMoveResult{WorkID: "seal-work-1", FromState: "draft", ToState: "done"},
 		movedRead: work.ReadModel{
-			CursorID:     "seal-work-1",
-			Name:         "seal-work",
-			WorkID:       "seal-work-1",
-			WorkTypeName: "story",
-			State:        &work.State{Name: "done", Type: work.StateTypeTerminal},
+			CursorID: "seal-work-1", Name: "seal-work", WorkID: "seal-work-1",
+			WorkTypeName: "story", State: &work.State{Name: "done", Type: work.StateTypeTerminal},
 		},
 		prepareInvocationResult: work.PreparedInvocationInput{
-			Source: work.InputSourceStdinText,
-			ResolvedInput: &work.ResolvedInput{
-				Source: work.InputSourceStdinText,
-				Text:   stdin,
-			},
+			Source:        work.InputSourceStdinText,
+			ResolvedInput: &work.ResolvedInput{Source: work.InputSourceStdinText, Text: stdin},
 		},
 		primaryResult: work.PrimaryResultSelection{
-			RequestID:     "seal-request-1",
-			Policy:        work.ReturnPolicySubmittedWorkTerminal,
-			WorkID:        "seal-work-1",
-			WorkTypeName:  "story",
-			WorkName:      "seal-work",
+			RequestID: "seal-request-1", Policy: work.ReturnPolicySubmittedWorkTerminal,
+			WorkID: "seal-work-1", WorkTypeName: "story", WorkName: "seal-work",
 			TerminalState: "story:done",
-			PrimaryResult: []work.WorkContentPart{{
-				Type: work.WorkContentPartTypeText,
-				Text: "sealed primary",
-			}},
+			PrimaryResult: []work.WorkContentPart{{Type: work.WorkContentPartTypeText, Text: "sealed primary"}},
 		},
 	}
+}
 
-	// Singular root seam: one Service value for every published slice.
-	var root work.Service = fake
+func TestServiceRootContract_SealAllPublishedSlicesThroughSingularService(t *testing.T) {
+	stdin := "peer seal stdin"
+	var root work.Service = newSealRootServiceFake(stdin)
 	peer := peerWorkRootConsumer{root: root}
 	ctx := context.Background()
 
 	admitted, err := peer.admit(ctx, "session-seal", work.WorkRequest{
 		RequestID: "seal-request-1",
 		Type:      work.WorkRequestTypeFactoryRequestBatch,
-		Works: []work.Work{{
-			Name:       "seal-work",
-			WorkTypeID: "story",
-			State:      "draft",
-		}},
+		Works:     []work.Work{{Name: "seal-work", WorkTypeID: "story", State: "draft"}},
 	})
 	if err != nil {
 		t.Fatalf("admission slice: %v", err)
@@ -189,13 +157,17 @@ func TestServiceRootContract_SealAllPublishedSlicesThroughSingularService(t *tes
 		t.Fatalf("admission result = %#v, want accepted seal-request-1", admitted)
 	}
 
+	assertSealContentSlice(t, peer, ctx)
+	assertSealStateAccessSlice(t, peer, ctx)
+	assertSealInvocationSlice(t, peer, ctx, stdin)
+}
+
+func assertSealContentSlice(t *testing.T, peer peerWorkRootConsumer, ctx context.Context) {
+	t.Helper()
 	staged, localPath, cleanup, err := peer.stageAndMaterialize(
 		ctx,
 		work.StageContentRequest{
-			ItemType:  "image",
-			FileName:  "seal.png",
-			MediaType: "image/png",
-			Content:   []byte("png"),
+			ItemType: "image", FileName: "seal.png", MediaType: "image/png", Content: []byte("png"),
 		},
 		"file:///fixtures/seal.png",
 	)
@@ -206,14 +178,12 @@ func TestServiceRootContract_SealAllPublishedSlicesThroughSingularService(t *tes
 		t.Fatalf("content outcomes = (%#v, %q, %v)", staged, localPath, cleanup)
 	}
 	cleanup()
+}
 
+func assertSealStateAccessSlice(t *testing.T, peer peerWorkRootConsumer, ctx context.Context) {
+	t.Helper()
 	listed, got, moved, readAfter, err := peer.inspectAndMove(
-		ctx,
-		"session-seal",
-		"seal-work-1",
-		work.ListOptions{WorkTypeName: "story"},
-		"done",
-		"seal-move-1",
+		ctx, "session-seal", "seal-work-1", work.ListOptions{WorkTypeName: "story"}, "done", "seal-move-1",
 	)
 	if err != nil {
 		t.Fatalf("state-access slice: %v", err)
@@ -224,13 +194,13 @@ func TestServiceRootContract_SealAllPublishedSlicesThroughSingularService(t *tes
 	if moved.ToState != "done" || readAfter.State == nil || readAfter.State.Type != work.StateTypeTerminal {
 		t.Fatalf("state-access move = (%#v, %#v)", moved, readAfter)
 	}
+}
 
+func assertSealInvocationSlice(t *testing.T, peer peerWorkRootConsumer, ctx context.Context, stdin string) {
+	t.Helper()
 	prepared, primary, err := peer.prepareAndSelectPrimary(
 		ctx,
-		work.InvocationInputPreparationRequest{
-			Arguments: []string{"-"},
-			StdinText: &stdin,
-		},
+		work.InvocationInputPreparationRequest{Arguments: []string{"-"}, StdinText: &stdin},
 		work.PrimaryResultSelectionInput{
 			RequestID: "seal-request-1",
 			InvocationReturn: &work.InvocationReturnConfig{
@@ -250,13 +220,19 @@ func TestServiceRootContract_SealAllPublishedSlicesThroughSingularService(t *tes
 	}
 }
 
-func TestServiceRootContract_SealTypedFailuresPerPublishedSlice(t *testing.T) {
-	ctx := context.Background()
-	cases := []struct {
-		name string
-		want error
-		call func(peerWorkRootConsumer) error
-	}{
+type sealTypedFailureCase struct {
+	name string
+	want error
+	call func(peerWorkRootConsumer) error
+}
+
+func sealTypedFailureCases(ctx context.Context) []sealTypedFailureCase {
+	cases := sealAdmissionAndContentFailureCases(ctx)
+	return append(cases, sealStateAndInvocationFailureCases(ctx)...)
+}
+
+func sealAdmissionAndContentFailureCases(ctx context.Context) []sealTypedFailureCase {
+	return []sealTypedFailureCase{
 		{
 			name: "admission invalid",
 			want: work.ErrInvalidWorkRequest,
@@ -313,6 +289,11 @@ func TestServiceRootContract_SealTypedFailuresPerPublishedSlice(t *testing.T) {
 				return err
 			},
 		},
+	}
+}
+
+func sealStateAndInvocationFailureCases(ctx context.Context) []sealTypedFailureCase {
+	return []sealTypedFailureCase{
 		{
 			name: "state-access missing work",
 			want: work.ErrWorkNotFound,
@@ -353,8 +334,11 @@ func TestServiceRootContract_SealTypedFailuresPerPublishedSlice(t *testing.T) {
 			},
 		},
 	}
+}
 
-	for _, tc := range cases {
+func TestServiceRootContract_SealTypedFailuresPerPublishedSlice(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range sealTypedFailureCases(ctx) {
 		t.Run(tc.name, func(t *testing.T) {
 			fake := &rootServiceFake{
 				submitErr:            tc.want,

--- a/pkg/services/work/service_root_contract_test.go
+++ b/pkg/services/work/service_root_contract_test.go
@@ -172,50 +172,39 @@ func (f *rootServiceFake) ResolvePrimaryResult(
 
 var _ work.Service = (*rootServiceFake)(nil)
 
-func TestServiceRootContract_FakeImplementsAndExercisesSeam(t *testing.T) {
-	fake := &rootServiceFake{
+func newRootSeamExerciseFake() *rootServiceFake {
+	return &rootServiceFake{
 		submitResult: work.WorkRequestSubmitResult{
 			RequestID: "request-1",
 			TraceID:   "trace-1",
 			Accepted:  true,
 			Works: []work.WorkRequestSubmittedWork{{
-				Name:         "story-1",
-				WorkTypeName: "story",
-				WorkID:       "work-1",
+				Name: "story-1", WorkTypeName: "story", WorkID: "work-1",
 			}},
 		},
 		moveResult: work.OperatorMoveResult{
-			WorkID:     "work-1",
-			WorkTypeID: "story",
-			FromState:  "draft",
-			ToState:    "review",
+			WorkID: "work-1", WorkTypeID: "story", FromState: "draft", ToState: "review",
 		},
 		listResult: work.ListResult{
 			Results: []work.ReadModel{{
-				CursorID:     "work-1",
-				Name:         "story-1",
-				WorkID:       "work-1",
-				WorkTypeName: "story",
-				State:        &work.State{Name: "review", Type: work.StateTypeProcessing},
+				CursorID: "work-1", Name: "story-1", WorkID: "work-1",
+				WorkTypeName: "story", State: &work.State{Name: "review", Type: work.StateTypeProcessing},
 			}},
 			MaxResults: work.DefaultListMaxResults,
 		},
 		getResult: work.ReadModel{
-			CursorID:     "work-1",
-			Name:         "story-1",
-			WorkID:       "work-1",
-			WorkTypeName: "story",
-			State:        &work.State{Name: "review", Type: work.StateTypeProcessing},
+			CursorID: "work-1", Name: "story-1", WorkID: "work-1",
+			WorkTypeName: "story", State: &work.State{Name: "review", Type: work.StateTypeProcessing},
 		},
 		movedRead: work.ReadModel{
-			CursorID:     "work-1",
-			Name:         "story-1",
-			WorkID:       "work-1",
-			WorkTypeName: "story",
-			State:        &work.State{Name: "done", Type: work.StateTypeTerminal},
+			CursorID: "work-1", Name: "story-1", WorkID: "work-1",
+			WorkTypeName: "story", State: &work.State{Name: "done", Type: work.StateTypeTerminal},
 		},
 	}
+}
 
+func TestServiceRootContract_FakeImplementsAndExercisesSeam(t *testing.T) {
+	fake := newRootSeamExerciseFake()
 	// Peers consume only the singular root Service seam.
 	var service work.Service = fake
 	ctx := context.Background()
@@ -223,11 +212,7 @@ func TestServiceRootContract_FakeImplementsAndExercisesSeam(t *testing.T) {
 	submit, err := service.SubmitWorkRequestForSession(ctx, "session-1", work.WorkRequest{
 		RequestID: "request-1",
 		Type:      work.WorkRequestTypeFactoryRequestBatch,
-		Works: []work.Work{{
-			Name:       "story-1",
-			WorkTypeID: "story",
-			State:      "draft",
-		}},
+		Works:     []work.Work{{Name: "story-1", WorkTypeID: "story", State: "draft"}},
 	})
 	if err != nil {
 		t.Fatalf("SubmitWorkRequestForSession: %v", err)

--- a/pkg/services/work/service_root_contract_test.go
+++ b/pkg/services/work/service_root_contract_test.go
@@ -211,3 +211,75 @@ func TestServiceRootContract_TypedFailuresRemainDistinguishable(t *testing.T) {
 		t.Fatalf("MoveWorkForSession error = %v, want ErrMoveWorkRequestAlreadyApplied", err)
 	}
 }
+
+func TestServiceRootContract_AdmissionSliceSuccess(t *testing.T) {
+	fake := &rootServiceFake{
+		submitResult: work.WorkRequestSubmitResult{
+			RequestID: "request-admit-1",
+			TraceID:   "trace-admit-1",
+			Accepted:  true,
+			Works: []work.WorkRequestSubmittedWork{{
+				Name:         "story-admit",
+				WorkTypeName: "story",
+				WorkID:       "work-admit-1",
+			}},
+		},
+	}
+	var service work.Service = fake
+	ctx := context.Background()
+
+	request := work.WorkRequest{
+		RequestID: "request-admit-1",
+		Type:      work.WorkRequestTypeFactoryRequestBatch,
+		Works: []work.Work{{
+			Name:       "story-admit",
+			WorkTypeID: "story",
+			State:      "draft",
+			Payload:    map[string]any{"title": "admit"},
+		}},
+	}
+	result, err := service.SubmitWorkRequestForSession(ctx, "session-admit", request)
+	if err != nil {
+		t.Fatalf("SubmitWorkRequestForSession: %v", err)
+	}
+	if !result.Accepted || result.RequestID != "request-admit-1" {
+		t.Fatalf("admission result = %#v, want accepted request-admit-1", result)
+	}
+	if len(result.Works) != 1 || result.Works[0].WorkID != "work-admit-1" {
+		t.Fatalf("admission works = %#v, want work-admit-1", result.Works)
+	}
+	if fake.lastSessionID != "session-admit" || fake.lastRequest.RequestID != "request-admit-1" {
+		t.Fatalf("admission routed = (%q, %q)", fake.lastSessionID, fake.lastRequest.RequestID)
+	}
+	if len(fake.lastRequest.Works) != 1 || fake.lastRequest.Works[0].Name != "story-admit" {
+		t.Fatalf("admission payload = %#v, want story-admit work", fake.lastRequest.Works)
+	}
+}
+
+func TestServiceRootContract_AdmissionTypedFailures(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{name: "invalid", err: work.ErrInvalidWorkRequest},
+		{name: "conflict", err: work.ErrWorkRequestConflict},
+		{name: "rejected", err: work.ErrWorkRequestRejected},
+	}
+	ctx := context.Background()
+	request := work.WorkRequest{
+		RequestID: "request-bad",
+		Type:      work.WorkRequestTypeFactoryRequestBatch,
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &rootServiceFake{submitErr: tc.err}
+			var service work.Service = fake
+
+			_, err := service.SubmitWorkRequestForSession(ctx, "session-1", request)
+			if !errors.Is(err, tc.err) {
+				t.Fatalf("SubmitWorkRequestForSession error = %v, want %v", err, tc.err)
+			}
+		})
+	}
+}

--- a/pkg/services/work/service_root_contract_test.go
+++ b/pkg/services/work/service_root_contract_test.go
@@ -343,6 +343,169 @@ func TestServiceRootContract_AdmissionTypedFailures(t *testing.T) {
 	}
 }
 
+func TestServiceRootContract_StateAccessSliceSuccess(t *testing.T) {
+	fake := &rootServiceFake{
+		listResult: work.ListResult{
+			Results: []work.ReadModel{{
+				CursorID:     "cursor-work-1",
+				Name:         "story-1",
+				WorkID:       "work-1",
+				WorkTypeName: "story",
+				State:        &work.State{Name: "review", Type: work.StateTypeProcessing},
+				TraceID:      "trace-1",
+			}},
+			MaxResults: 10,
+			NextToken:  "",
+		},
+		getResult: work.ReadModel{
+			CursorID:     "cursor-work-1",
+			Name:         "story-1",
+			WorkID:       "work-1",
+			WorkTypeName: "story",
+			State:        &work.State{Name: "review", Type: work.StateTypeProcessing},
+			TraceID:      "trace-1",
+		},
+		moveResult: work.OperatorMoveResult{
+			WorkID:     "work-1",
+			WorkTypeID: "story",
+			FromState:  "draft",
+			ToState:    "review",
+		},
+		movedRead: work.ReadModel{
+			CursorID:     "cursor-work-1",
+			Name:         "story-1",
+			WorkID:       "work-1",
+			WorkTypeName: "story",
+			State:        &work.State{Name: "done", Type: work.StateTypeTerminal},
+			TraceID:      "trace-1",
+		},
+	}
+	var service work.Service = fake
+	ctx := context.Background()
+
+	listed, err := service.ListWork(ctx, "session-state", work.ListOptions{
+		WorkTypeName: "story",
+		StateName:    "review",
+		MaxResults:   10,
+	})
+	if err != nil {
+		t.Fatalf("ListWork: %v", err)
+	}
+	if len(listed.Results) != 1 {
+		t.Fatalf("list result = %#v, want one detached ReadModel", listed)
+	}
+	assertDetachedReadModel(t, listed.Results[0], "work-1", "review", work.StateTypeProcessing)
+	if fake.lastSessionID != "session-state" || fake.lastListOpts.WorkTypeName != "story" {
+		t.Fatalf("list routed = (%q, %#v)", fake.lastSessionID, fake.lastListOpts)
+	}
+
+	got, err := service.GetWork(ctx, "session-state", "work-1")
+	if err != nil {
+		t.Fatalf("GetWork: %v", err)
+	}
+	assertDetachedReadModel(t, got, "work-1", "review", work.StateTypeProcessing)
+
+	moved, err := service.MoveWorkForSession(ctx, "session-state", "work-1", "review", "move-state-1")
+	if err != nil {
+		t.Fatalf("MoveWorkForSession: %v", err)
+	}
+	if moved.WorkID != "work-1" || moved.FromState != "draft" || moved.ToState != "review" {
+		t.Fatalf("move result = %#v, want detached work-1 draft->review", moved)
+	}
+	if fake.lastRequestID != "move-state-1" {
+		t.Fatalf("move requestID = %q, want move-state-1", fake.lastRequestID)
+	}
+
+	readAfterMove, err := service.MoveWorkAndRead(ctx, "session-state", "work-1", "done", "move-state-2")
+	if err != nil {
+		t.Fatalf("MoveWorkAndRead: %v", err)
+	}
+	assertDetachedReadModel(t, readAfterMove, "work-1", "done", work.StateTypeTerminal)
+	if fake.lastStateName != "done" || fake.lastRequestID != "move-state-2" {
+		t.Fatalf("move-and-read routed = (%q, %q)", fake.lastStateName, fake.lastRequestID)
+	}
+}
+
+func TestServiceRootContract_StateAccessTypedFailures(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name string
+		call func(work.Service) error
+		want error
+	}{
+		{
+			name: "missing work on get",
+			call: func(service work.Service) error {
+				_, err := service.GetWork(ctx, "session-1", "missing")
+				return err
+			},
+			want: work.ErrWorkNotFound,
+		},
+		{
+			name: "missing work on move-and-read",
+			call: func(service work.Service) error {
+				_, err := service.MoveWorkAndRead(ctx, "session-1", "missing", "done", "move-missing")
+				return err
+			},
+			want: work.ErrWorkNotFound,
+		},
+		{
+			name: "already-applied move",
+			call: func(service work.Service) error {
+				_, err := service.MoveWorkForSession(ctx, "session-1", "work-1", "done", "dup-move")
+				return err
+			},
+			want: work.ErrMoveWorkRequestAlreadyApplied,
+		},
+		{
+			name: "already-applied move-and-read",
+			call: func(service work.Service) error {
+				_, err := service.MoveWorkAndRead(ctx, "session-1", "work-1", "done", "dup-move")
+				return err
+			},
+			want: work.ErrMoveWorkRequestAlreadyApplied,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &rootServiceFake{
+				getErr:       work.ErrWorkNotFound,
+				movedReadErr: tc.want,
+				moveErr:      work.ErrMoveWorkRequestAlreadyApplied,
+			}
+			var service work.Service = fake
+			if err := tc.call(service); !errors.Is(err, tc.want) {
+				t.Fatalf("error = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func assertDetachedReadModel(
+	t *testing.T,
+	model work.ReadModel,
+	wantWorkID string,
+	wantStateName string,
+	wantStateType string,
+) {
+	t.Helper()
+	if model.WorkID != wantWorkID {
+		t.Fatalf("ReadModel.WorkID = %q, want %q", model.WorkID, wantWorkID)
+	}
+	if model.Name == "" || model.WorkTypeName == "" {
+		t.Fatalf("ReadModel missing customer identity fields: %#v", model)
+	}
+	if model.State == nil || model.State.Name != wantStateName || model.State.Type != wantStateType {
+		t.Fatalf("ReadModel.State = %#v, want %s/%s", model.State, wantStateName, wantStateType)
+	}
+	// Peers consume customer-facing projection fields only; CursorID is the
+	// Work-owned list cursor, not a Petri token/place/marking/topology handle.
+	if model.CursorID == "" {
+		t.Fatalf("ReadModel.CursorID empty; want opaque Work list cursor")
+	}
+}
+
 func TestServiceRootContract_ContentStagingAndMaterializationSuccess(t *testing.T) {
 	fake := &rootServiceFake{
 		stageResult: work.StageContentResult{

--- a/pkg/services/work/service_root_contract_test.go
+++ b/pkg/services/work/service_root_contract_test.go
@@ -33,17 +33,24 @@ type rootServiceFake struct {
 	materializeClean work.ContentCleanup
 	materializeErr   error
 
-	lastSessionID     string
-	lastRequest       work.WorkRequest
-	lastListOpts      work.ListOptions
-	lastWorkID        string
-	lastStateName     string
-	lastRequestID     string
-	lastStageRequest  work.StageContentRequest
-	lastPrepareItems  []work.StagedSubmissionItem
-	lastStagedRef     string
-	lastContentURL    string
-	cleanupCalled     bool
+	prepareInvocationResult work.PreparedInvocationInput
+	prepareInvocationErr    error
+	primaryResult           work.PrimaryResultSelection
+	primaryResultErr        error
+
+	lastSessionID      string
+	lastRequest        work.WorkRequest
+	lastListOpts       work.ListOptions
+	lastWorkID         string
+	lastStateName      string
+	lastRequestID      string
+	lastStageRequest   work.StageContentRequest
+	lastPrepareItems   []work.StagedSubmissionItem
+	lastStagedRef      string
+	lastContentURL     string
+	lastInvocationReq  work.InvocationInputPreparationRequest
+	lastPrimaryInput   work.PrimaryResultSelectionInput
+	cleanupCalled      bool
 	materializeCleaned bool
 }
 
@@ -145,6 +152,22 @@ func (f *rootServiceFake) MaterializeContentURL(
 		cleanup = func() { f.materializeCleaned = true }
 	}
 	return f.materializePath, cleanup, f.materializeErr
+}
+
+func (f *rootServiceFake) PrepareInvocationInput(
+	_ context.Context,
+	request work.InvocationInputPreparationRequest,
+) (work.PreparedInvocationInput, error) {
+	f.lastInvocationReq = request
+	return f.prepareInvocationResult, f.prepareInvocationErr
+}
+
+func (f *rootServiceFake) ResolvePrimaryResult(
+	_ context.Context,
+	input work.PrimaryResultSelectionInput,
+) (work.PrimaryResultSelection, error) {
+	f.lastPrimaryInput = input
+	return f.primaryResult, f.primaryResultErr
 }
 
 var _ work.Service = (*rootServiceFake)(nil)
@@ -637,6 +660,144 @@ func TestServiceRootContract_ContentTypedFailures(t *testing.T) {
 			fake := &rootServiceFake{
 				resolveErr:     tc.want,
 				materializeErr: tc.want,
+			}
+			var service work.Service = fake
+			if err := tc.call(service); !errors.Is(err, tc.want) {
+				t.Fatalf("error = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestServiceRootContract_InvocationAndReturnPolicySliceSuccess(t *testing.T) {
+	stdin := "ship from pipe"
+	fake := &rootServiceFake{
+		prepareInvocationResult: work.PreparedInvocationInput{
+			Source: work.InputSourceStdinText,
+			ResolvedInput: &work.ResolvedInput{
+				Source: work.InputSourceStdinText,
+				Text:   stdin,
+			},
+		},
+		primaryResult: work.PrimaryResultSelection{
+			RequestID:     "request-inv-1",
+			Policy:        work.ReturnPolicySubmittedWorkTerminal,
+			WorkID:        "work-terminal-1",
+			WorkTypeName:  "task",
+			WorkName:      "root",
+			TerminalState: "task:complete",
+			PrimaryResult: []work.WorkContentPart{{
+				Type: work.WorkContentPartTypeText,
+				Text: "terminal output",
+			}},
+		},
+	}
+	var service work.Service = fake
+	ctx := context.Background()
+
+	prepared, err := service.PrepareInvocationInput(ctx, work.InvocationInputPreparationRequest{
+		Arguments: []string{"-"},
+		StdinText: &stdin,
+	})
+	if err != nil {
+		t.Fatalf("PrepareInvocationInput: %v", err)
+	}
+	if prepared.ResolvedInput == nil || prepared.ResolvedInput.Text != stdin {
+		t.Fatalf("prepared input = %#v, want detached stdin text", prepared)
+	}
+	if len(fake.lastInvocationReq.Arguments) != 1 || fake.lastInvocationReq.Arguments[0] != "-" {
+		t.Fatalf("prepare request = %#v, want dash argv", fake.lastInvocationReq)
+	}
+
+	submittedTerminal, err := service.ResolvePrimaryResult(ctx, work.PrimaryResultSelectionInput{
+		RequestID: "request-inv-1",
+		InvocationReturn: &work.InvocationReturnConfig{
+			Policy: work.ReturnPolicySubmittedWorkTerminal,
+		},
+		WorldState: work.InvocationWorldState{},
+	})
+	if err != nil {
+		t.Fatalf("ResolvePrimaryResult submitted-terminal: %v", err)
+	}
+	if submittedTerminal.Policy != work.ReturnPolicySubmittedWorkTerminal ||
+		submittedTerminal.WorkID != "work-terminal-1" ||
+		len(submittedTerminal.PrimaryResult) != 1 {
+		t.Fatalf("submitted-terminal result = %#v, want detached primary content", submittedTerminal)
+	}
+	if fake.lastPrimaryInput.RequestID != "request-inv-1" {
+		t.Fatalf("primary input requestID = %q, want request-inv-1", fake.lastPrimaryInput.RequestID)
+	}
+
+	fake.primaryResult = work.PrimaryResultSelection{
+		RequestID:     "request-inv-2",
+		Policy:        work.ReturnPolicyExplicit,
+		WorkID:        "work-summary-1",
+		WorkTypeName:  "summary",
+		WorkName:      "summary",
+		TerminalState: "summary:complete",
+		PrimaryResult: []work.WorkContentPart{{
+			Type: work.WorkContentPartTypeText,
+			Text: "explicit summary",
+		}},
+	}
+	explicit, err := service.ResolvePrimaryResult(ctx, work.PrimaryResultSelectionInput{
+		RequestID: "request-inv-2",
+		InvocationReturn: &work.InvocationReturnConfig{
+			Policy:        work.ReturnPolicyExplicit,
+			WorkTypeName:  "summary",
+			TerminalState: "summary:complete",
+		},
+		WorldState: work.InvocationWorldState{},
+	})
+	if err != nil {
+		t.Fatalf("ResolvePrimaryResult explicit: %v", err)
+	}
+	if explicit.Policy != work.ReturnPolicyExplicit ||
+		explicit.WorkID != "work-summary-1" ||
+		len(explicit.PrimaryResult) != 1 ||
+		explicit.PrimaryResult[0].Text != "explicit summary" {
+		t.Fatalf("explicit result = %#v, want configured summary primary content", explicit)
+	}
+}
+
+func TestServiceRootContract_InvocationAndReturnPolicyTypedFailures(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name string
+		call func(work.Service) error
+		want error
+	}{
+		{
+			name: "invalid invocation input",
+			call: func(service work.Service) error {
+				_, err := service.PrepareInvocationInput(ctx, work.InvocationInputPreparationRequest{
+					Arguments: []string{""},
+				})
+				return err
+			},
+			want: work.ErrInvalidInvocationInput,
+		},
+		{
+			name: "unsupported return policy",
+			call: func(service work.Service) error {
+				_, err := service.ResolvePrimaryResult(ctx, work.PrimaryResultSelectionInput{
+					RequestID: "request-bad-policy",
+					InvocationReturn: &work.InvocationReturnConfig{
+						Policy: "NOT_A_POLICY",
+					},
+					WorldState: work.InvocationWorldState{},
+				})
+				return err
+			},
+			want: work.ErrUnsupportedReturnPolicy,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &rootServiceFake{
+				prepareInvocationErr: work.ErrInvalidInvocationInput,
+				primaryResultErr:     work.ErrUnsupportedReturnPolicy,
 			}
 			var service work.Service = fake
 			if err := tc.call(service); !errors.Is(err, tc.want) {

--- a/pkg/services/work/service_root_contract_test.go
+++ b/pkg/services/work/service_root_contract_test.go
@@ -203,7 +203,7 @@ func newRootSeamExerciseFake() *rootServiceFake {
 	}
 }
 
-func TestServiceRootContract_FakeImplementsAndExercisesSeam(t *testing.T) {
+func TestServiceRootContract_FakeImplementsAndExercisesAdmissionAndMove(t *testing.T) {
 	fake := newRootSeamExerciseFake()
 	// Peers consume only the singular root Service seam.
 	var service work.Service = fake
@@ -231,6 +231,12 @@ func TestServiceRootContract_FakeImplementsAndExercisesSeam(t *testing.T) {
 	if move.WorkID != "work-1" || move.ToState != "review" {
 		t.Fatalf("move result = %#v, want work-1 -> review", move)
 	}
+}
+
+func TestServiceRootContract_FakeImplementsAndExercisesListGetAndMoveAndRead(t *testing.T) {
+	fake := newRootSeamExerciseFake()
+	var service work.Service = fake
+	ctx := context.Background()
 
 	listed, err := service.ListWork(ctx, "session-1", work.ListOptions{WorkTypeName: "story"})
 	if err != nil {
@@ -514,8 +520,8 @@ func assertDetachedReadModel(
 	}
 }
 
-func TestServiceRootContract_ContentStagingAndMaterializationSuccess(t *testing.T) {
-	fake := &rootServiceFake{
+func newRootContentSliceSuccessFake() *rootServiceFake {
+	return &rootServiceFake{
 		stageResult: work.StageContentResult{
 			StagedFileRef: "submit-work-stage:v1:opaque-ref",
 			FileName:      "photo.png",
@@ -533,6 +539,10 @@ func TestServiceRootContract_ContentStagingAndMaterializationSuccess(t *testing.
 		},
 		materializePath: "/tmp/materialized/photo.png",
 	}
+}
+
+func TestServiceRootContract_ContentStagingLifecycleSuccess(t *testing.T) {
+	fake := newRootContentSliceSuccessFake()
 	var service work.Service = fake
 	ctx := context.Background()
 
@@ -582,6 +592,12 @@ func TestServiceRootContract_ContentStagingAndMaterializationSuccess(t *testing.
 	if !fake.cleanupCalled {
 		t.Fatal("CleanupContent was not routed through the root Service")
 	}
+}
+
+func TestServiceRootContract_ContentMaterializationSuccess(t *testing.T) {
+	fake := newRootContentSliceSuccessFake()
+	var service work.Service = fake
+	ctx := context.Background()
 
 	localPath, cleanup, err := service.MaterializeContentURL(ctx, "file:///fixtures/photo.png")
 	if err != nil {
@@ -654,7 +670,7 @@ func TestServiceRootContract_ContentTypedFailures(t *testing.T) {
 	}
 }
 
-func TestServiceRootContract_InvocationAndReturnPolicySliceSuccess(t *testing.T) {
+func TestServiceRootContract_PrepareInvocationInputSuccess(t *testing.T) {
 	stdin := "ship from pipe"
 	fake := &rootServiceFake{
 		prepareInvocationResult: work.PreparedInvocationInput{
@@ -663,18 +679,6 @@ func TestServiceRootContract_InvocationAndReturnPolicySliceSuccess(t *testing.T)
 				Source: work.InputSourceStdinText,
 				Text:   stdin,
 			},
-		},
-		primaryResult: work.PrimaryResultSelection{
-			RequestID:     "request-inv-1",
-			Policy:        work.ReturnPolicySubmittedWorkTerminal,
-			WorkID:        "work-terminal-1",
-			WorkTypeName:  "task",
-			WorkName:      "root",
-			TerminalState: "task:complete",
-			PrimaryResult: []work.WorkContentPart{{
-				Type: work.WorkContentPartTypeText,
-				Text: "terminal output",
-			}},
 		},
 	}
 	var service work.Service = fake
@@ -693,6 +697,25 @@ func TestServiceRootContract_InvocationAndReturnPolicySliceSuccess(t *testing.T)
 	if len(fake.lastInvocationReq.Arguments) != 1 || fake.lastInvocationReq.Arguments[0] != "-" {
 		t.Fatalf("prepare request = %#v, want dash argv", fake.lastInvocationReq)
 	}
+}
+
+func TestServiceRootContract_ResolvePrimaryResultSubmittedTerminalSuccess(t *testing.T) {
+	fake := &rootServiceFake{
+		primaryResult: work.PrimaryResultSelection{
+			RequestID:     "request-inv-1",
+			Policy:        work.ReturnPolicySubmittedWorkTerminal,
+			WorkID:        "work-terminal-1",
+			WorkTypeName:  "task",
+			WorkName:      "root",
+			TerminalState: "task:complete",
+			PrimaryResult: []work.WorkContentPart{{
+				Type: work.WorkContentPartTypeText,
+				Text: "terminal output",
+			}},
+		},
+	}
+	var service work.Service = fake
+	ctx := context.Background()
 
 	submittedTerminal, err := service.ResolvePrimaryResult(ctx, work.PrimaryResultSelectionInput{
 		RequestID: "request-inv-1",
@@ -712,19 +735,26 @@ func TestServiceRootContract_InvocationAndReturnPolicySliceSuccess(t *testing.T)
 	if fake.lastPrimaryInput.RequestID != "request-inv-1" {
 		t.Fatalf("primary input requestID = %q, want request-inv-1", fake.lastPrimaryInput.RequestID)
 	}
+}
 
-	fake.primaryResult = work.PrimaryResultSelection{
-		RequestID:     "request-inv-2",
-		Policy:        work.ReturnPolicyExplicit,
-		WorkID:        "work-summary-1",
-		WorkTypeName:  "summary",
-		WorkName:      "summary",
-		TerminalState: "summary:complete",
-		PrimaryResult: []work.WorkContentPart{{
-			Type: work.WorkContentPartTypeText,
-			Text: "explicit summary",
-		}},
+func TestServiceRootContract_ResolvePrimaryResultExplicitSuccess(t *testing.T) {
+	fake := &rootServiceFake{
+		primaryResult: work.PrimaryResultSelection{
+			RequestID:     "request-inv-2",
+			Policy:        work.ReturnPolicyExplicit,
+			WorkID:        "work-summary-1",
+			WorkTypeName:  "summary",
+			WorkName:      "summary",
+			TerminalState: "summary:complete",
+			PrimaryResult: []work.WorkContentPart{{
+				Type: work.WorkContentPartTypeText,
+				Text: "explicit summary",
+			}},
+		},
 	}
+	var service work.Service = fake
+	ctx := context.Background()
+
 	explicit, err := service.ResolvePrimaryResult(ctx, work.PrimaryResultSelectionInput{
 		RequestID: "request-inv-2",
 		InvocationReturn: &work.InvocationReturnConfig{

--- a/pkg/services/work/service_root_contract_test.go
+++ b/pkg/services/work/service_root_contract_test.go
@@ -1,0 +1,213 @@
+package work_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/portpowered/infinite-you/pkg/services/work"
+)
+
+// rootServiceFake is a peer-shaped Work root Service that uses only Work-owned
+// request, result, value, and typed-error contracts.
+type rootServiceFake struct {
+	submitResult work.WorkRequestSubmitResult
+	submitErr    error
+	moveResult   work.OperatorMoveResult
+	moveErr      error
+	listResult   work.ListResult
+	listErr      error
+	getResult    work.ReadModel
+	getErr       error
+	movedRead    work.ReadModel
+	movedReadErr error
+
+	lastSessionID string
+	lastRequest   work.WorkRequest
+	lastListOpts  work.ListOptions
+	lastWorkID    string
+	lastStateName string
+	lastRequestID string
+}
+
+func (f *rootServiceFake) SubmitWorkRequestForSession(
+	_ context.Context,
+	sessionID string,
+	request work.WorkRequest,
+) (work.WorkRequestSubmitResult, error) {
+	f.lastSessionID = sessionID
+	f.lastRequest = request
+	return f.submitResult, f.submitErr
+}
+
+func (f *rootServiceFake) MoveWorkForSession(
+	_ context.Context,
+	sessionID string,
+	workID string,
+	stateName string,
+	requestID string,
+) (work.OperatorMoveResult, error) {
+	f.lastSessionID = sessionID
+	f.lastWorkID = workID
+	f.lastStateName = stateName
+	f.lastRequestID = requestID
+	return f.moveResult, f.moveErr
+}
+
+func (f *rootServiceFake) ListWork(
+	_ context.Context,
+	sessionID string,
+	options work.ListOptions,
+) (work.ListResult, error) {
+	f.lastSessionID = sessionID
+	f.lastListOpts = options
+	return f.listResult, f.listErr
+}
+
+func (f *rootServiceFake) GetWork(
+	_ context.Context,
+	sessionID string,
+	id string,
+) (work.ReadModel, error) {
+	f.lastSessionID = sessionID
+	f.lastWorkID = id
+	return f.getResult, f.getErr
+}
+
+func (f *rootServiceFake) MoveWorkAndRead(
+	_ context.Context,
+	sessionID string,
+	id string,
+	stateName string,
+	requestID string,
+) (work.ReadModel, error) {
+	f.lastSessionID = sessionID
+	f.lastWorkID = id
+	f.lastStateName = stateName
+	f.lastRequestID = requestID
+	return f.movedRead, f.movedReadErr
+}
+
+var _ work.Service = (*rootServiceFake)(nil)
+
+func TestServiceRootContract_FakeImplementsAndExercisesSeam(t *testing.T) {
+	fake := &rootServiceFake{
+		submitResult: work.WorkRequestSubmitResult{
+			RequestID: "request-1",
+			TraceID:   "trace-1",
+			Accepted:  true,
+			Works: []work.WorkRequestSubmittedWork{{
+				Name:         "story-1",
+				WorkTypeName: "story",
+				WorkID:       "work-1",
+			}},
+		},
+		moveResult: work.OperatorMoveResult{
+			WorkID:     "work-1",
+			WorkTypeID: "story",
+			FromState:  "draft",
+			ToState:    "review",
+		},
+		listResult: work.ListResult{
+			Results: []work.ReadModel{{
+				CursorID:     "work-1",
+				Name:         "story-1",
+				WorkID:       "work-1",
+				WorkTypeName: "story",
+				State:        &work.State{Name: "review", Type: work.StateTypeProcessing},
+			}},
+			MaxResults: work.DefaultListMaxResults,
+		},
+		getResult: work.ReadModel{
+			CursorID:     "work-1",
+			Name:         "story-1",
+			WorkID:       "work-1",
+			WorkTypeName: "story",
+			State:        &work.State{Name: "review", Type: work.StateTypeProcessing},
+		},
+		movedRead: work.ReadModel{
+			CursorID:     "work-1",
+			Name:         "story-1",
+			WorkID:       "work-1",
+			WorkTypeName: "story",
+			State:        &work.State{Name: "done", Type: work.StateTypeTerminal},
+		},
+	}
+
+	// Peers consume only the singular root Service seam.
+	var service work.Service = fake
+	ctx := context.Background()
+
+	submit, err := service.SubmitWorkRequestForSession(ctx, "session-1", work.WorkRequest{
+		RequestID: "request-1",
+		Type:      work.WorkRequestTypeFactoryRequestBatch,
+		Works: []work.Work{{
+			Name:       "story-1",
+			WorkTypeID: "story",
+			State:      "draft",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("SubmitWorkRequestForSession: %v", err)
+	}
+	if !submit.Accepted || submit.RequestID != "request-1" || len(submit.Works) != 1 {
+		t.Fatalf("submit result = %#v, want accepted request-1 with one work", submit)
+	}
+	if fake.lastSessionID != "session-1" || fake.lastRequest.RequestID != "request-1" {
+		t.Fatalf("submit routed = (%q, %q)", fake.lastSessionID, fake.lastRequest.RequestID)
+	}
+
+	move, err := service.MoveWorkForSession(ctx, "session-1", "work-1", "review", "move-1")
+	if err != nil {
+		t.Fatalf("MoveWorkForSession: %v", err)
+	}
+	if move.WorkID != "work-1" || move.ToState != "review" {
+		t.Fatalf("move result = %#v, want work-1 -> review", move)
+	}
+
+	listed, err := service.ListWork(ctx, "session-1", work.ListOptions{WorkTypeName: "story"})
+	if err != nil {
+		t.Fatalf("ListWork: %v", err)
+	}
+	if len(listed.Results) != 1 || listed.Results[0].WorkID != "work-1" {
+		t.Fatalf("list result = %#v, want one work-1 entry", listed)
+	}
+	if fake.lastListOpts.WorkTypeName != "story" {
+		t.Fatalf("list options = %#v, want workTypeName=story", fake.lastListOpts)
+	}
+
+	got, err := service.GetWork(ctx, "session-1", "work-1")
+	if err != nil {
+		t.Fatalf("GetWork: %v", err)
+	}
+	if got.WorkID != "work-1" || got.State == nil || got.State.Name != "review" {
+		t.Fatalf("get result = %#v, want work-1 in review", got)
+	}
+
+	moved, err := service.MoveWorkAndRead(ctx, "session-1", "work-1", "done", "move-2")
+	if err != nil {
+		t.Fatalf("MoveWorkAndRead: %v", err)
+	}
+	if moved.WorkID != "work-1" || moved.State == nil || moved.State.Type != work.StateTypeTerminal {
+		t.Fatalf("move-and-read result = %#v, want terminal work-1", moved)
+	}
+}
+
+func TestServiceRootContract_TypedFailuresRemainDistinguishable(t *testing.T) {
+	fake := &rootServiceFake{
+		getErr:  work.ErrWorkNotFound,
+		moveErr: work.ErrMoveWorkRequestAlreadyApplied,
+	}
+	var service work.Service = fake
+	ctx := context.Background()
+
+	_, err := service.GetWork(ctx, "session-1", "missing")
+	if !errors.Is(err, work.ErrWorkNotFound) {
+		t.Fatalf("GetWork error = %v, want ErrWorkNotFound", err)
+	}
+
+	_, err = service.MoveWorkForSession(ctx, "session-1", "work-1", "done", "dup-move")
+	if !errors.Is(err, work.ErrMoveWorkRequestAlreadyApplied) {
+		t.Fatalf("MoveWorkForSession error = %v, want ErrMoveWorkRequestAlreadyApplied", err)
+	}
+}

--- a/pkg/services/work/service_root_contract_test.go
+++ b/pkg/services/work/service_root_contract_test.go
@@ -22,12 +22,29 @@ type rootServiceFake struct {
 	movedRead    work.ReadModel
 	movedReadErr error
 
-	lastSessionID string
-	lastRequest   work.WorkRequest
-	lastListOpts  work.ListOptions
-	lastWorkID    string
-	lastStateName string
-	lastRequestID string
+	stageResult      work.StageContentResult
+	stageErr         error
+	prepareResult    []work.WorkContentPart
+	prepareErr       error
+	resolveResult    work.ResolvedStagedContent
+	resolveErr       error
+	cleanupErr       error
+	materializePath  string
+	materializeClean work.ContentCleanup
+	materializeErr   error
+
+	lastSessionID     string
+	lastRequest       work.WorkRequest
+	lastListOpts      work.ListOptions
+	lastWorkID        string
+	lastStateName     string
+	lastRequestID     string
+	lastStageRequest  work.StageContentRequest
+	lastPrepareItems  []work.StagedSubmissionItem
+	lastStagedRef     string
+	lastContentURL    string
+	cleanupCalled     bool
+	materializeCleaned bool
 }
 
 func (f *rootServiceFake) SubmitWorkRequestForSession(
@@ -86,6 +103,48 @@ func (f *rootServiceFake) MoveWorkAndRead(
 	f.lastStateName = stateName
 	f.lastRequestID = requestID
 	return f.movedRead, f.movedReadErr
+}
+
+func (f *rootServiceFake) StageContent(
+	_ context.Context,
+	request work.StageContentRequest,
+) (work.StageContentResult, error) {
+	f.lastStageRequest = request
+	return f.stageResult, f.stageErr
+}
+
+func (f *rootServiceFake) PrepareContent(
+	_ context.Context,
+	items []work.StagedSubmissionItem,
+) ([]work.WorkContentPart, error) {
+	f.lastPrepareItems = append([]work.StagedSubmissionItem(nil), items...)
+	return f.prepareResult, f.prepareErr
+}
+
+func (f *rootServiceFake) ResolveContent(
+	_ context.Context,
+	ref string,
+) (work.ResolvedStagedContent, error) {
+	f.lastStagedRef = ref
+	return f.resolveResult, f.resolveErr
+}
+
+func (f *rootServiceFake) CleanupContent(_ context.Context, ref string) error {
+	f.lastStagedRef = ref
+	f.cleanupCalled = true
+	return f.cleanupErr
+}
+
+func (f *rootServiceFake) MaterializeContentURL(
+	_ context.Context,
+	rawURL string,
+) (string, work.ContentCleanup, error) {
+	f.lastContentURL = rawURL
+	cleanup := f.materializeClean
+	if cleanup == nil && f.materializeErr == nil {
+		cleanup = func() { f.materializeCleaned = true }
+	}
+	return f.materializePath, cleanup, f.materializeErr
 }
 
 var _ work.Service = (*rootServiceFake)(nil)
@@ -279,6 +338,146 @@ func TestServiceRootContract_AdmissionTypedFailures(t *testing.T) {
 			_, err := service.SubmitWorkRequestForSession(ctx, "session-1", request)
 			if !errors.Is(err, tc.err) {
 				t.Fatalf("SubmitWorkRequestForSession error = %v, want %v", err, tc.err)
+			}
+		})
+	}
+}
+
+func TestServiceRootContract_ContentStagingAndMaterializationSuccess(t *testing.T) {
+	fake := &rootServiceFake{
+		stageResult: work.StageContentResult{
+			StagedFileRef: "submit-work-stage:v1:opaque-ref",
+			FileName:      "photo.png",
+			MediaType:     "image/png",
+			URL:           "file:///tmp/staged/photo.png",
+		},
+		prepareResult: []work.WorkContentPart{{
+			Type:        work.WorkContentPartTypeImage,
+			URL:         "file:///tmp/staged/photo.png",
+			ContentType: "image/png",
+		}},
+		resolveResult: work.ResolvedStagedContent{
+			Path: "/tmp/staged/photo.png",
+			URL:  "file:///tmp/staged/photo.png",
+		},
+		materializePath: "/tmp/materialized/photo.png",
+	}
+	var service work.Service = fake
+	ctx := context.Background()
+
+	staged, err := service.StageContent(ctx, work.StageContentRequest{
+		ItemType:  "image",
+		FileName:  "photo.png",
+		MediaType: "image/png",
+		Content:   []byte("png-bytes"),
+	})
+	if err != nil {
+		t.Fatalf("StageContent: %v", err)
+	}
+	if staged.StagedFileRef == "" || staged.URL == "" {
+		t.Fatalf("stage result = %#v, want opaque staged ref and URL", staged)
+	}
+	if fake.lastStageRequest.FileName != "photo.png" || len(fake.lastStageRequest.Content) == 0 {
+		t.Fatalf("stage request = %#v, want photo.png payload", fake.lastStageRequest)
+	}
+
+	prepared, err := service.PrepareContent(ctx, []work.StagedSubmissionItem{{
+		ItemType:      "image",
+		StagedFileRef: staged.StagedFileRef,
+		FileName:      "photo.png",
+		MediaType:     "image/png",
+	}})
+	if err != nil {
+		t.Fatalf("PrepareContent: %v", err)
+	}
+	if len(prepared) != 1 || prepared[0].URL == "" {
+		t.Fatalf("prepare result = %#v, want one content part with URL", prepared)
+	}
+
+	resolved, err := service.ResolveContent(ctx, staged.StagedFileRef)
+	if err != nil {
+		t.Fatalf("ResolveContent: %v", err)
+	}
+	if resolved.Path == "" || resolved.URL == "" {
+		t.Fatalf("resolve result = %#v, want local path and URL", resolved)
+	}
+	if fake.lastStagedRef != staged.StagedFileRef {
+		t.Fatalf("resolve ref = %q, want staged ref", fake.lastStagedRef)
+	}
+
+	if err := service.CleanupContent(ctx, staged.StagedFileRef); err != nil {
+		t.Fatalf("CleanupContent: %v", err)
+	}
+	if !fake.cleanupCalled {
+		t.Fatal("CleanupContent was not routed through the root Service")
+	}
+
+	localPath, cleanup, err := service.MaterializeContentURL(ctx, "file:///fixtures/photo.png")
+	if err != nil {
+		t.Fatalf("MaterializeContentURL: %v", err)
+	}
+	if localPath == "" || cleanup == nil {
+		t.Fatalf("materialize = (%q, %v), want local path and cleanup handle", localPath, cleanup)
+	}
+	if fake.lastContentURL != "file:///fixtures/photo.png" {
+		t.Fatalf("materialize URL = %q, want file:///fixtures/photo.png", fake.lastContentURL)
+	}
+	cleanup()
+	if !fake.materializeCleaned {
+		t.Fatal("materialize cleanup handle did not run")
+	}
+}
+
+func TestServiceRootContract_ContentTypedFailures(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name string
+		call func(work.Service) error
+		want error
+	}{
+		{
+			name: "invalid staged ref",
+			call: func(service work.Service) error {
+				_, err := service.ResolveContent(ctx, "not-a-staged-ref")
+				return err
+			},
+			want: work.ErrInvalidStagedContentRef,
+		},
+		{
+			name: "expired staged ref",
+			call: func(service work.Service) error {
+				_, err := service.ResolveContent(ctx, "submit-work-stage:v1:expired")
+				return err
+			},
+			want: work.ErrStagedContentExpired,
+		},
+		{
+			name: "unsafe content URL",
+			call: func(service work.Service) error {
+				_, _, err := service.MaterializeContentURL(ctx, "http://127.0.0.1/secret")
+				return err
+			},
+			want: work.ErrUnsafeContentURL,
+		},
+		{
+			name: "remote content inaccessible",
+			call: func(service work.Service) error {
+				_, _, err := service.MaterializeContentURL(ctx, "https://example.invalid/missing.png")
+				return err
+			},
+			want: work.ErrContentURLInaccessible,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &rootServiceFake{
+				resolveErr:     tc.want,
+				materializeErr: tc.want,
+			}
+			var service work.Service = fake
+			if err := tc.call(service); !errors.Is(err, tc.want) {
+				t.Fatalf("error = %v, want %v", err, tc.want)
 			}
 		})
 	}

--- a/pkg/wire/session_runtime_providers.go
+++ b/pkg/wire/session_runtime_providers.go
@@ -915,8 +915,12 @@ func provideWorkSubmittedFileReader(edges serviceedges.Edges) work.SubmittedFile
 	return os.ReadFile
 }
 
-func provideWorkFactory(readFile work.SubmittedFileReader) factorysessionwire.WorkFactory {
+func provideWorkFactory(
+	readFile work.SubmittedFileReader,
+	contentStaging work.ContentStagingService,
+	contentMaterializer work.ContentMaterializer,
+) factorysessionwire.WorkFactory {
 	return func(runtimes work.RuntimeResolver) work.Service {
-		return workservice.NewService(runtimes, readFile)
+		return workservice.NewService(runtimes, readFile, contentStaging, contentMaterializer)
 	}
 }

--- a/pkg/wire/wire_gen.go
+++ b/pkg/wire/wire_gen.go
@@ -107,7 +107,16 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 		return nil, err
 	}
 	submittedFileReader := provideWorkSubmittedFileReader(edges2)
-	v12 := provideWorkFactory(submittedFileReader)
+	contentStagingService, err := provideWorkContentStagingService(edges2)
+	if err != nil {
+		return nil, err
+	}
+	contentHostPlatform := provideWorkContentHostPlatform(edges2)
+	contentMaterializer, err := provideContentMaterializer(contentHostPlatform, edges2)
+	if err != nil {
+		return nil, err
+	}
+	v12 := provideWorkFactory(submittedFileReader, contentStagingService, contentMaterializer)
 	v13 := provideAutomationFactory()
 	sessionResultProjectionOperation := factory.NewSessionResultProjectionOperation()
 	invocationInterpolationService := provideInvocationInterpolationService()
@@ -217,11 +226,6 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	inputDirectoryWalker := provideFactoryRuntimeInputDirectoryWalker(edges2)
 	runtimeFactory := service.NewRuntimeFactory(quorumPolicyService, invocationOutputShapingService, workPropagationPolicyService, decisionEnvelopeService, runtimeLoggerFactory, runtimeLogSinkFactory, runtimeMetricsSinkFactory, idGenerator, requestIDGenerator, runtimeDirectoryFileSystem, inputFileSystem, inputDirectoryWalker)
 	assembly, err := service.NewAssembly(runtimeFactory)
-	if err != nil {
-		return nil, err
-	}
-	contentHostPlatform := provideWorkContentHostPlatform(edges2)
-	contentMaterializer, err := provideContentMaterializer(contentHostPlatform, edges2)
 	if err != nil {
 		return nil, err
 	}
@@ -391,10 +395,6 @@ func InjectBundle(ctx context.Context, edges2 edges.Edges) (*application.Process
 	factoryStatusProjector := factory.NewFactoryStatusProjector()
 	contentPreparation := work.NewContentPreparation()
 	httpBinder, err := composition.NewHTTPBinder(factoryStatusProjector, contentPreparation)
-	if err != nil {
-		return nil, err
-	}
-	contentStagingService, err := provideWorkContentStagingService(edges2)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
{
  "project": "CTR-WORK — Publish Additive Work Root Contract Slices",
  "branchName": "pss-ctr-work-root-contract",
  "description": "Publish additive Work root-contract slices on one named Work Service for admission, content staging/materialization, state access, and peer-needed invocation/return-policy operations, with plain request/result/value/typed-error contracts and characterization tests, without completing nested IMP-WORK cuts or OpenAPI package-motion changes.",
  "context": {
    "customerAsk": "Publish additive Work root-contract slices for the singular Work interface covering admission, content staging/materialization, and state access without exposing implementation types. High-unlock priority: this unblocks IMP-WORK-* and several cross-owner IMP packets. Root contract slices only; do not complete IMP-WORK nested cuts, take Wire/CLI-manifest/provider-conductor leases, or change public OpenAPI solely for package motion.",
    "problem": "pkg/services/work still publishes many loose capabilities instead of one stable root seam. Peers and transports call separate interfaces and package-level operations for admission, staging, materialization, state access, and invocation/return policy, which blocks parallel IMP-WORK-* cuts and forces cross-owner packets to depend on Work implementation shape.",
    "solution": "Freeze and extend one named Work root Service with additive contract slices for admission, content staging/materialization, state access, and peer-needed invocation/return-policy operations; keep the root limited to plain Work-owned contracts; prove each published slice with representative success and typed-failure characterization tests against a fake Service; leave nested subservice moves, Wire, transports, and OpenAPI package-motion changes to later packets."
  },
  "acceptanceCriteria": [
    "AC-1: Work exposes one named root Service interface whose published methods use plain Work-owned request, result, value, and typed-error contracts.",
    "AC-2: Published root methods cover admission, content staging/materialization, state access, and the invocation/return-policy operations peers actually consume.",
    "AC-3: No peer-service implementation types appear in the published Work root contract signatures or published value types.",
    "AC-4: Representative success and typed-failure characterization tests pass for each published slice against a fake Service implementation.",
    "AC-5: Nested IMP-WORK-* subservice cuts, Wire/CLI-manifest/provider-conductor ownership, and OpenAPI package-motion changes are not required for this packet.",
    "AC-6: Quality checks pass (make verify-fast, make lint, and focused Work contract characterization tests)."
  ],
  "userStories": [
    {
      "id": "pss-ctr-work-root-contract-001",
      "title": "Freeze the singular Work root Service seam",
      "description": "As a cross-service maintainer, I want one named Work root Service so peers depend on a single contract seam instead of a mix of Work interfaces and loose operations.",
      "acceptanceCriteria": [
        "pkg/services/work publishes one named root Service interface as the intended cross-service Work seam for the published slices.",
        "A local fake can implement Service using only Work root contracts, and a characterization test compiles and exercises that fake through the interface.",
        "Published method signatures on Service use plain request, result, value, and typed-error contracts rather than returning concrete Work implementation structs from service/, materialize/, or similar implementation packages.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 1,
      "passes": true,
      "notes": "Frozen existing work.Service as singular peer root; added service_root_contract_test.go fake characterization covering success and typed failures."
    },
    {
      "id": "pss-ctr-work-root-contract-002",
      "title": "Publish the admission contract slice",
      "description": "As a Factory Sessions or Automation maintainer, I want a Work root admission command so I can submit Work Requests through one stable contract with typed acceptance and rejection outcomes.",
      "acceptanceCriteria": [
        "The root Service exposes an admission/submit operation whose request and result types are plain Work-owned contracts covering Work Request identity, payload, and acceptance facts needed by peers.",
        "Characterization success: a fake Service accepts a valid admission request and returns a detached success result peers can consume without importing Work implementation packages.",
        "Characterization typed failure: invalid, conflict, or rejection-shaped admission input returns a typed Work error peers can distinguish without parsing free-form implementation details.",
        "Path-backed or protocol-decoding submission is not required on the root domain seam; admission consumes already-decoded Work Request contracts.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 2,
      "passes": true,
      "notes": "Documented SubmitWorkRequestForSession as admission slice; published ErrInvalidWorkRequest/ErrWorkRequestConflict/ErrWorkRequestRejected; added admission success and typed-failure characterization tests."
    },
    {
      "id": "pss-ctr-work-root-contract-003",
      "title": "Publish content staging and materialization contract slices",
      "description": "As a Workers or transport maintainer, I want Work root operations for staging submitted content and materializing content URLs so I can obtain immutable local content through Work without importing staging or materialize implementation types.",
      "acceptanceCriteria": [
        "The root Service exposes content staging and materialization operations with plain request/result/value contracts for stage, prepare/resolve staged refs, cleanup, and materialize-to-local-path outcomes peers need.",
        "Characterization success: staging a valid content payload yields an opaque staged reference, and materializing a valid content reference yields a local path plus cleanup handle represented as Work-owned contract values.",
        "Characterization typed failure: invalid staged refs, expired refs, and unsafe/remote-resolution failures return typed Work errors rather than peer implementation types or untyped string-only failures.",
        "Root contract methods do not require callers to supply peer-service implementation types or public filesystem/HTTP effect interfaces as part of the cross-service request shape.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 3,
      "passes": true,
      "notes": "Published StageContent/PrepareContent/ResolveContent/CleanupContent/MaterializeContentURL on work.Service; added ErrUnsafeContentURL/ErrContentURLInaccessible; root fake characterization covers success and typed failures; applicationService delegates to injected staging/materializer."
    },
    {
      "id": "pss-ctr-work-root-contract-004",
      "title": "Publish the state-access contract slice",
      "description": "As a protocol or Sessions maintainer, I want Work root list/get/move operations that return detached Work read models so operators can inspect and move Work without observing Runtime or Petri implementation types.",
      "acceptanceCriteria": [
        "The root Service exposes state-access operations for list, get, and move (including move-and-read where peers already rely on that combined outcome) using plain Work request/result contracts.",
        "Characterization success: list/get return detached ReadModel projections with no token, place, marking, or topology fields; move returns the existing detached move/read success shape.",
        "Characterization typed failure: missing Work and already-applied move conflicts return typed Work errors (ErrWorkNotFound, ErrMoveWorkRequestAlreadyApplied, or equivalent published typed errors).",
        "Published state-access results remain free of Factory Runtime and peer implementation types.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 4,
      "passes": true,
      "notes": "Documented ListWork/GetWork/MoveWorkForSession/MoveWorkAndRead as state-access slice; clarified ReadModel/ListResult/ListOptions/OperatorMoveResult and ErrWorkNotFound/ErrMoveWorkRequestAlreadyApplied; added dedicated success and typed-failure characterization tests."
    },
    {
      "id": "pss-ctr-work-root-contract-005",
      "title": "Publish invocation and return-policy contract slices",
      "description": "As a Factory Sessions or Workers maintainer, I want Work root operations for invocation-input preparation and primary-result/return-policy selection so peers stop importing Work helper modules for those capabilities.",
      "acceptanceCriteria": [
        "The root Service exposes the invocation-input preparation and primary-result/return-policy operations peers actually consume, using plain Work-owned request/result/value contracts.",
        "Characterization success: valid invocation-input preparation returns detached canonical prepared input; valid return-policy selection returns the configured primary result for representative submitted-terminal and explicit policies.",
        "Characterization typed failure: invalid invocation input and unsupported/invalid return-policy selection return typed Work errors peers can branch on.",
        "These operations are methods on the singular root Service; peers are not required to construct separate exported Work helper services for the published slice.",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 5,
      "passes": true,
      "notes": "Published PrepareInvocationInput/ResolvePrimaryResult on work.Service; added ErrInvalidInvocationInput/ErrUnsupportedReturnPolicy; root fake characterization covers success (stdin prepare + SUBMITTED_WORK_TERMINAL/EXPLICIT) and typed failures; applicationService delegates to NewInvocationInputPreparation/ResolvePrimaryResult."
    },
    {
      "id": "pss-ctr-work-root-contract-006",
      "title": "Seal root-contract invariants for IMP-WORK unlock",
      "description": "As a migration reviewer, I want sealed characterization proof that the published Work root slices are singular, peer-implementation-free, and covered by success/failure tests so IMP-WORK-* can start from a stable contract.",
      "acceptanceCriteria": [
        "All published slices from stories 002-005 are reachable through the one named root Service and covered by representative success and typed-failure characterization tests.",
        "A peer-shaped characterization consumer depends only on the Work root package contract surface for the published slices and does not need peer implementation imports to call or assert those contracts.",
        "The packet does not complete nested IMP-WORK-* subservice moves, Wire/CLI-manifest/provider-conductor edits, or OpenAPI changes made solely for package motion.",
        "Focused Work contract characterization tests pass.",
        "make verify-fast passes",
        "make lint passes",
        "Typecheck passes",
        "Tests pass"
      ],
      "priority": 6,
      "passes": true,
      "notes": "Sealed IMP-WORK unlock surface on work.Service docs; added peerWorkRootConsumer seal tests covering all published slices success + typed failures without peer implementation imports."
    }
  ]
}
